### PR TITLE
fix: ensure rig beads init targets rig DB

### DIFF
--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -418,7 +418,7 @@ func (m *Manager) initBeads(rigPath, prefix string) error {
 	// Run bd init if available, with --no-agents to skip AGENTS.md creation
 	cmd := exec.Command("bd", "init", "--prefix", prefix, "--no-agents")
 	cmd.Dir = rigPath
-	output, err := cmd.CombinedOutput()
+	_, err := cmd.CombinedOutput()
 	if err != nil {
 		// bd might not be installed or failed, create minimal structure
 		// Note: beads currently expects YAML format for config


### PR DESCRIPTION
## Summary
- Ensure rig agent bead creation targets the rig `.beads` via `BEADS_DIR`
- Remove legacy fallback for older `bd` flag handling in rig beads init
- Keep rig beads bootstrap writing `config.yaml` on `bd init` failure

## Test plan
- [x] `go -C /home/user/code/extern/gastown test ./internal/rig -run 'TestInitBeadsWritesConfigOnFailure|TestInitAgentBeadsUsesRigBeadsDir'`
- [x] `BEADS_DIR="/tmp/gastown-beads-test/.beads" go -C /tmp/gastown-pr9-clean test ./...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)