### PR TITLE
fix: use rig prefixes for agent bead IDs

### DIFF
--- a/internal/cmd/crew_add.go
+++ b/internal/cmd/crew_add.go
@@ -100,7 +100,8 @@ func runCrewAdd(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  Branch: %s\n", worker.Branch)
 
 		// Create agent bead for the crew worker
-		crewID := beads.CrewBeadID(rigName, name)
+		prefix := beads.GetPrefixForRig(townRoot, rigName)
+		crewID := beads.CrewBeadIDWithPrefix(prefix, rigName, name)
 		if _, err := bd.Show(crewID); err != nil {
 			// Agent bead doesn't exist, create it
 			fields := &beads.AgentFields{

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -1195,9 +1195,7 @@ func getAgentFields(ctx RoleContext, state string) *beads.AgentFields {
 }
 
 // getAgentBeadID returns the agent bead ID for the current role.
-// Uses canonical naming: gt-rig-role-name
-// Agent beads always use "gt-" prefix (required by beads validation).
-// Only issue beads use rig-specific prefixes.
+// Rig-scoped agents use the rig's configured prefix; town agents remain gt-.
 // Returns empty string for unknown roles.
 func getAgentBeadID(ctx RoleContext) string {
 	switch ctx.Role {
@@ -1207,22 +1205,26 @@ func getAgentBeadID(ctx RoleContext) string {
 		return beads.DeaconBeadID()
 	case RoleWitness:
 		if ctx.Rig != "" {
-			return beads.WitnessBeadID(ctx.Rig)
+			prefix := beads.GetPrefixForRig(ctx.TownRoot, ctx.Rig)
+			return beads.WitnessBeadIDWithPrefix(prefix, ctx.Rig)
 		}
 		return ""
 	case RoleRefinery:
 		if ctx.Rig != "" {
-			return beads.RefineryBeadID(ctx.Rig)
+			prefix := beads.GetPrefixForRig(ctx.TownRoot, ctx.Rig)
+			return beads.RefineryBeadIDWithPrefix(prefix, ctx.Rig)
 		}
 		return ""
 	case RolePolecat:
 		if ctx.Rig != "" && ctx.Polecat != "" {
-			return beads.PolecatBeadID(ctx.Rig, ctx.Polecat)
+			prefix := beads.GetPrefixForRig(ctx.TownRoot, ctx.Rig)
+			return beads.PolecatBeadIDWithPrefix(prefix, ctx.Rig, ctx.Polecat)
 		}
 		return ""
 	case RoleCrew:
 		if ctx.Rig != "" && ctx.Polecat != "" {
-			return beads.CrewBeadID(ctx.Rig, ctx.Polecat)
+			prefix := beads.GetPrefixForRig(ctx.TownRoot, ctx.Rig)
+			return beads.CrewBeadIDWithPrefix(prefix, ctx.Rig, ctx.Polecat)
 		}
 		return ""
 	default:

--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func writeTestRoutes(t *testing.T, townRoot string, routes []beads.Route) {
+	t.Helper()
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("create beads dir: %v", err)
+	}
+	if err := beads.WriteRoutes(beadsDir, routes); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+}
+
+func TestGetAgentBeadID_UsesRigPrefix(t *testing.T) {
+	townRoot := t.TempDir()
+	writeTestRoutes(t, townRoot, []beads.Route{
+		{Prefix: "bd-", Path: "beads/mayor/rig"},
+	})
+
+	cases := []struct {
+		name string
+		ctx  RoleContext
+		want string
+	}{
+		{
+			name: "mayor",
+			ctx: RoleContext{
+				Role:     RoleMayor,
+				TownRoot: townRoot,
+			},
+			want: "gt-mayor",
+		},
+		{
+			name: "deacon",
+			ctx: RoleContext{
+				Role:     RoleDeacon,
+				TownRoot: townRoot,
+			},
+			want: "gt-deacon",
+		},
+		{
+			name: "witness",
+			ctx: RoleContext{
+				Role:     RoleWitness,
+				Rig:      "beads",
+				TownRoot: townRoot,
+			},
+			want: "bd-beads-witness",
+		},
+		{
+			name: "refinery",
+			ctx: RoleContext{
+				Role:     RoleRefinery,
+				Rig:      "beads",
+				TownRoot: townRoot,
+			},
+			want: "bd-beads-refinery",
+		},
+		{
+			name: "polecat",
+			ctx: RoleContext{
+				Role:     RolePolecat,
+				Rig:      "beads",
+				Polecat:  "lex",
+				TownRoot: townRoot,
+			},
+			want: "bd-beads-polecat-lex",
+		},
+		{
+			name: "crew",
+			ctx: RoleContext{
+				Role:     RoleCrew,
+				Rig:      "beads",
+				Polecat:  "lex",
+				TownRoot: townRoot,
+			},
+			want: "bd-beads-crew-lex",
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := getAgentBeadID(tc.ctx)
+			if got != tc.want {
+				t.Fatalf("getAgentBeadID() = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/status_test.go
+++ b/internal/cmd/status_test.go
@@ -1,0 +1,97 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/rig"
+)
+
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+	os.Stdout = w
+
+	fn()
+
+	_ = w.Close()
+	os.Stdout = old
+
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read stdout: %v", err)
+	}
+	_ = r.Close()
+
+	return buf.String()
+}
+
+func TestDiscoverRigAgents_UsesRigPrefix(t *testing.T) {
+	townRoot := t.TempDir()
+	writeTestRoutes(t, townRoot, []beads.Route{
+		{Prefix: "bd-", Path: "beads/mayor/rig"},
+	})
+
+	r := &rig.Rig{
+		Name:       "beads",
+		Path:       filepath.Join(townRoot, "beads"),
+		HasWitness: true,
+	}
+
+	allAgentBeads := map[string]*beads.Issue{
+		"bd-beads-witness": {
+			ID:         "bd-beads-witness",
+			AgentState: "running",
+			HookBead:   "bd-hook",
+		},
+	}
+	allHookBeads := map[string]*beads.Issue{
+		"bd-hook": {ID: "bd-hook", Title: "Pinned"},
+	}
+
+	agents := discoverRigAgents(map[string]bool{}, r, nil, allAgentBeads, allHookBeads, nil, true)
+	if len(agents) != 1 {
+		t.Fatalf("discoverRigAgents() returned %d agents, want 1", len(agents))
+	}
+
+	if agents[0].State != "running" {
+		t.Fatalf("agent state = %q, want %q", agents[0].State, "running")
+	}
+	if !agents[0].HasWork {
+		t.Fatalf("agent HasWork = false, want true")
+	}
+	if agents[0].WorkTitle != "Pinned" {
+		t.Fatalf("agent WorkTitle = %q, want %q", agents[0].WorkTitle, "Pinned")
+	}
+}
+
+func TestRenderAgentDetails_UsesRigPrefix(t *testing.T) {
+	townRoot := t.TempDir()
+	writeTestRoutes(t, townRoot, []beads.Route{
+		{Prefix: "bd-", Path: "beads/mayor/rig"},
+	})
+
+	agent := AgentRuntime{
+		Name:    "witness",
+		Address: "beads/witness",
+		Role:    "witness",
+		Running: true,
+	}
+
+	output := captureStdout(t, func() {
+		renderAgentDetails(agent, "", nil, townRoot)
+	})
+
+	if !strings.Contains(output, "bd-beads-witness") {
+		t.Fatalf("output %q does not contain rig-prefixed bead ID", output)
+	}
+}


### PR DESCRIPTION
## Summary
- Resolve rig-scoped agent bead IDs via town routes in crew add, prime, and status
- Aggregate agent beads per rig to avoid assuming a single gastown DB
- Add tests covering prefix selection in prime and status

## Test plan
- [x] `go test ./internal/cmd -run 'TestGetAgentBeadID_UsesRigPrefix|TestDiscoverRigAgents_UsesRigPrefix|TestRenderAgentDetails_UsesRigPrefix'`
- [x] `BEADS_DIR=/tmp/gastown-beads-test/.beads go test ./...`
- [x] `cd /tmp/gt-acceptance-town-0dbUFc && /tmp/gt-bin rig add beads /tmp/gt-acceptance-repo-glo9zo --prefix bd`
- [x] `cd /tmp/gt-acceptance-town-0dbUFc && BEADS_DIR=/tmp/gt-acceptance-town-0dbUFc/beads/.beads /tmp/gt-bin crew add carol --rig beads` (agent bead: `bd-beads-crew-carol`)
- [x] `cd /tmp/gt-acceptance-town-0dbUFc/beads/crew/carol && BEADS_DIR=/tmp/gt-acceptance-town-0dbUFc/beads/.beads /tmp/gt-bin prime` (verified `bd show bd-beads-crew-carol`)
- [x] `cd /tmp/gt-acceptance-town-0dbUFc && /tmp/gt-bin status` (verified `bd-beads-crew-carol` present)

🤖 Generated with [Claude Code](https://claude.com/claude-code)