### PR TITLE
fix: Enable gt doctor --fix to remediate missing patrol role templates

### DIFF
--- a/internal/doctor/patrol_check.go
+++ b/internal/doctor/patrol_check.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/templates"
 )
 
 // PatrolMoleculesExistCheck verifies that patrol molecules exist for each rig.
@@ -392,30 +393,36 @@ func (c *PatrolPluginsAccessibleCheck) Fix(ctx *CheckContext) error {
 	return nil
 }
 
-// PatrolRolesHavePromptsCheck verifies that internal/templates/roles/*.md.tmpl exist for each role.
+// PatrolRolesHavePromptsCheck verifies that internal/templates/roles/*.md.tmpl exist for each rig.
+// Checks at <town>/<rig>/mayor/rig/internal/templates/roles/*.md.tmpl
+// Fix copies embedded templates to missing locations.
 type PatrolRolesHavePromptsCheck struct {
-	BaseCheck
+	FixableCheck
+	// missingByRig tracks missing templates per rig: rigName -> []missingFiles
+	missingByRig map[string][]string
 }
 
 // NewPatrolRolesHavePromptsCheck creates a new patrol roles have prompts check.
 func NewPatrolRolesHavePromptsCheck() *PatrolRolesHavePromptsCheck {
 	return &PatrolRolesHavePromptsCheck{
-		BaseCheck: BaseCheck{
-			CheckName:        "patrol-roles-have-prompts",
-			CheckDescription: "Check if internal/templates/roles/*.md.tmpl exist for each patrol role",
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "patrol-roles-have-prompts",
+				CheckDescription: "Check if internal/templates/roles/*.md.tmpl exist for each patrol role",
+			},
 		},
 	}
 }
 
-// requiredRolePrompts are the required role prompt template files.
 var requiredRolePrompts = []string{
 	"deacon.md.tmpl",
 	"witness.md.tmpl",
 	"refinery.md.tmpl",
 }
 
-// Run checks if role prompts exist.
 func (c *PatrolRolesHavePromptsCheck) Run(ctx *CheckContext) *CheckResult {
+	c.missingByRig = make(map[string][]string)
+
 	rigs, err := discoverRigs(ctx.TownRoot)
 	if err != nil {
 		return &CheckResult{
@@ -440,11 +447,16 @@ func (c *PatrolRolesHavePromptsCheck) Run(ctx *CheckContext) *CheckResult {
 		mayorRig := filepath.Join(ctx.TownRoot, rigName, "mayor", "rig")
 		templatesDir := filepath.Join(mayorRig, "internal", "templates", "roles")
 
+		var rigMissing []string
 		for _, roleFile := range requiredRolePrompts {
 			promptPath := filepath.Join(templatesDir, roleFile)
 			if _, err := os.Stat(promptPath); os.IsNotExist(err) {
 				missingPrompts = append(missingPrompts, fmt.Sprintf("%s: %s", rigName, roleFile))
+				rigMissing = append(rigMissing, roleFile)
 			}
+		}
+		if len(rigMissing) > 0 {
+			c.missingByRig[rigName] = rigMissing
 		}
 	}
 
@@ -454,7 +466,7 @@ func (c *PatrolRolesHavePromptsCheck) Run(ctx *CheckContext) *CheckResult {
 			Status:  StatusWarning,
 			Message: fmt.Sprintf("%d role prompt template(s) missing", len(missingPrompts)),
 			Details: missingPrompts,
-			FixHint: "Role prompt templates should be in the project repository under internal/templates/roles/",
+			FixHint: "Run 'gt doctor --fix' to copy embedded templates to rig repos",
 		}
 	}
 
@@ -463,6 +475,36 @@ func (c *PatrolRolesHavePromptsCheck) Run(ctx *CheckContext) *CheckResult {
 		Status:  StatusOK,
 		Message: "All patrol role prompt templates found",
 	}
+}
+
+func (c *PatrolRolesHavePromptsCheck) Fix(ctx *CheckContext) error {
+	allTemplates, err := templates.GetAllRoleTemplates()
+	if err != nil {
+		return fmt.Errorf("getting embedded templates: %w", err)
+	}
+
+	for rigName, missingFiles := range c.missingByRig {
+		mayorRig := filepath.Join(ctx.TownRoot, rigName, "mayor", "rig")
+		templatesDir := filepath.Join(mayorRig, "internal", "templates", "roles")
+
+		if err := os.MkdirAll(templatesDir, 0755); err != nil {
+			return fmt.Errorf("creating %s: %w", templatesDir, err)
+		}
+
+		for _, roleFile := range missingFiles {
+			content, ok := allTemplates[roleFile]
+			if !ok {
+				continue
+			}
+
+			destPath := filepath.Join(templatesDir, roleFile)
+			if err := os.WriteFile(destPath, content, 0644); err != nil {
+				return fmt.Errorf("writing %s in %s: %w", roleFile, rigName, err)
+			}
+		}
+	}
+
+	return nil
 }
 
 // discoverRigs finds all registered rigs.

--- a/internal/doctor/patrol_check_test.go
+++ b/internal/doctor/patrol_check_test.go
@@ -1,0 +1,361 @@
+package doctor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/config"
+)
+
+func TestNewPatrolRolesHavePromptsCheck(t *testing.T) {
+	check := NewPatrolRolesHavePromptsCheck()
+	if check == nil {
+		t.Fatal("NewPatrolRolesHavePromptsCheck() returned nil")
+	}
+	if check.Name() != "patrol-roles-have-prompts" {
+		t.Errorf("Name() = %q, want %q", check.Name(), "patrol-roles-have-prompts")
+	}
+	if !check.CanFix() {
+		t.Error("CanFix() should return true")
+	}
+}
+
+func setupRigConfig(t *testing.T, tmpDir string, rigNames []string) {
+	t.Helper()
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+
+	rigsConfig := config.RigsConfig{Rigs: make(map[string]config.RigEntry)}
+	for _, name := range rigNames {
+		rigsConfig.Rigs[name] = config.RigEntry{}
+	}
+
+	data, err := json.Marshal(rigsConfig)
+	if err != nil {
+		t.Fatalf("marshal rigs.json: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), data, 0644); err != nil {
+		t.Fatalf("write rigs.json: %v", err)
+	}
+}
+
+func setupRigTemplatesDir(t *testing.T, tmpDir, rigName string) string {
+	t.Helper()
+	templatesDir := filepath.Join(tmpDir, rigName, "mayor", "rig", "internal", "templates", "roles")
+	if err := os.MkdirAll(templatesDir, 0755); err != nil {
+		t.Fatalf("mkdir templates: %v", err)
+	}
+	return templatesDir
+}
+
+func TestPatrolRolesHavePromptsCheck_NoRigs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	check := NewPatrolRolesHavePromptsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("Status = %v, want OK (no rigs configured)", result.Status)
+	}
+}
+
+func TestPatrolRolesHavePromptsCheck_NoTemplatesDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupRigConfig(t, tmpDir, []string{"myproject"})
+
+	check := NewPatrolRolesHavePromptsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("Status = %v, want Warning", result.Status)
+	}
+	if len(check.missingByRig) != 1 {
+		t.Errorf("missingByRig count = %d, want 1", len(check.missingByRig))
+	}
+	if len(check.missingByRig["myproject"]) != 3 {
+		t.Errorf("missing templates for myproject = %d, want 3", len(check.missingByRig["myproject"]))
+	}
+}
+
+func TestPatrolRolesHavePromptsCheck_SomeTemplatesMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupRigConfig(t, tmpDir, []string{"myproject"})
+	templatesDir := setupRigTemplatesDir(t, tmpDir, "myproject")
+
+	if err := os.WriteFile(filepath.Join(templatesDir, "deacon.md.tmpl"), []byte("test"), 0644); err != nil {
+		t.Fatalf("write deacon.md.tmpl: %v", err)
+	}
+
+	check := NewPatrolRolesHavePromptsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("Status = %v, want Warning", result.Status)
+	}
+	if len(check.missingByRig["myproject"]) != 2 {
+		t.Errorf("missing templates = %d, want 2 (witness, refinery)", len(check.missingByRig["myproject"]))
+	}
+}
+
+func TestPatrolRolesHavePromptsCheck_AllTemplatesExist(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupRigConfig(t, tmpDir, []string{"myproject"})
+	templatesDir := setupRigTemplatesDir(t, tmpDir, "myproject")
+
+	for _, tmpl := range requiredRolePrompts {
+		if err := os.WriteFile(filepath.Join(templatesDir, tmpl), []byte("test content"), 0644); err != nil {
+			t.Fatalf("write %s: %v", tmpl, err)
+		}
+	}
+
+	check := NewPatrolRolesHavePromptsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("Status = %v, want OK", result.Status)
+	}
+	if len(check.missingByRig) != 0 {
+		t.Errorf("missingByRig count = %d, want 0", len(check.missingByRig))
+	}
+}
+
+func TestPatrolRolesHavePromptsCheck_Fix(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupRigConfig(t, tmpDir, []string{"myproject"})
+
+	check := NewPatrolRolesHavePromptsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("Initial Status = %v, want Warning", result.Status)
+	}
+
+	err := check.Fix(ctx)
+	if err != nil {
+		t.Fatalf("Fix() error = %v", err)
+	}
+
+	templatesDir := filepath.Join(tmpDir, "myproject", "mayor", "rig", "internal", "templates", "roles")
+	for _, tmpl := range requiredRolePrompts {
+		path := filepath.Join(templatesDir, tmpl)
+		info, err := os.Stat(path)
+		if err != nil {
+			t.Errorf("Fix() did not create %s: %v", tmpl, err)
+			continue
+		}
+		if info.Size() == 0 {
+			t.Errorf("Fix() created empty file %s", tmpl)
+		}
+	}
+
+	result = check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("After Fix(), Status = %v, want OK", result.Status)
+	}
+}
+
+func TestPatrolRolesHavePromptsCheck_FixPartial(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupRigConfig(t, tmpDir, []string{"myproject"})
+	templatesDir := setupRigTemplatesDir(t, tmpDir, "myproject")
+
+	existingContent := []byte("existing custom content")
+	if err := os.WriteFile(filepath.Join(templatesDir, "deacon.md.tmpl"), existingContent, 0644); err != nil {
+		t.Fatalf("write deacon.md.tmpl: %v", err)
+	}
+
+	check := NewPatrolRolesHavePromptsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("Initial Status = %v, want Warning", result.Status)
+	}
+	if len(check.missingByRig["myproject"]) != 2 {
+		t.Fatalf("missing = %d, want 2", len(check.missingByRig["myproject"]))
+	}
+
+	err := check.Fix(ctx)
+	if err != nil {
+		t.Fatalf("Fix() error = %v", err)
+	}
+
+	deaconContent, err := os.ReadFile(filepath.Join(templatesDir, "deacon.md.tmpl"))
+	if err != nil {
+		t.Fatalf("read deacon.md.tmpl: %v", err)
+	}
+	if string(deaconContent) != string(existingContent) {
+		t.Error("Fix() should not overwrite existing deacon.md.tmpl")
+	}
+
+	for _, tmpl := range []string{"witness.md.tmpl", "refinery.md.tmpl"} {
+		path := filepath.Join(templatesDir, tmpl)
+		if _, err := os.Stat(path); err != nil {
+			t.Errorf("Fix() did not create %s: %v", tmpl, err)
+		}
+	}
+}
+
+func TestPatrolRolesHavePromptsCheck_MultipleRigs(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupRigConfig(t, tmpDir, []string{"project1", "project2"})
+
+	templatesDir1 := setupRigTemplatesDir(t, tmpDir, "project1")
+	for _, tmpl := range requiredRolePrompts {
+		if err := os.WriteFile(filepath.Join(templatesDir1, tmpl), []byte("test"), 0644); err != nil {
+			t.Fatalf("write %s: %v", tmpl, err)
+		}
+	}
+
+	check := NewPatrolRolesHavePromptsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("Status = %v, want Warning (project2 missing)", result.Status)
+	}
+	if _, ok := check.missingByRig["project1"]; ok {
+		t.Error("project1 should not be in missingByRig")
+	}
+	if len(check.missingByRig["project2"]) != 3 {
+		t.Errorf("project2 missing = %d, want 3", len(check.missingByRig["project2"]))
+	}
+}
+
+func TestPatrolRolesHavePromptsCheck_FixHint(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupRigConfig(t, tmpDir, []string{"myproject"})
+
+	check := NewPatrolRolesHavePromptsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.FixHint == "" {
+		t.Error("FixHint should not be empty for warning status")
+	}
+	if result.FixHint != "Run 'gt doctor --fix' to copy embedded templates to rig repos" {
+		t.Errorf("FixHint = %q, unexpected value", result.FixHint)
+	}
+}
+
+func TestPatrolRolesHavePromptsCheck_FixMultipleRigs(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupRigConfig(t, tmpDir, []string{"project1", "project2", "project3"})
+
+	templatesDir1 := setupRigTemplatesDir(t, tmpDir, "project1")
+	for _, tmpl := range requiredRolePrompts {
+		if err := os.WriteFile(filepath.Join(templatesDir1, tmpl), []byte("existing"), 0644); err != nil {
+			t.Fatalf("write %s: %v", tmpl, err)
+		}
+	}
+
+	check := NewPatrolRolesHavePromptsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("Initial Status = %v, want Warning", result.Status)
+	}
+	if len(check.missingByRig) != 2 {
+		t.Fatalf("missingByRig count = %d, want 2 (project2, project3)", len(check.missingByRig))
+	}
+
+	err := check.Fix(ctx)
+	if err != nil {
+		t.Fatalf("Fix() error = %v", err)
+	}
+
+	for _, rig := range []string{"project2", "project3"} {
+		templatesDir := filepath.Join(tmpDir, rig, "mayor", "rig", "internal", "templates", "roles")
+		for _, tmpl := range requiredRolePrompts {
+			path := filepath.Join(templatesDir, tmpl)
+			if _, err := os.Stat(path); err != nil {
+				t.Errorf("Fix() did not create %s for %s: %v", tmpl, rig, err)
+			}
+		}
+	}
+
+	result = check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("After Fix(), Status = %v, want OK", result.Status)
+	}
+}
+
+func TestPatrolRolesHavePromptsCheck_DetailsFormat(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupRigConfig(t, tmpDir, []string{"myproject"})
+
+	check := NewPatrolRolesHavePromptsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if len(result.Details) != 3 {
+		t.Fatalf("Details count = %d, want 3", len(result.Details))
+	}
+
+	for _, detail := range result.Details {
+		if detail[:10] != "myproject:" {
+			t.Errorf("Detail %q should be prefixed with 'myproject:'", detail)
+		}
+	}
+}
+
+func TestPatrolRolesHavePromptsCheck_MalformedRigsJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte("not valid json"), 0644); err != nil {
+		t.Fatalf("write rigs.json: %v", err)
+	}
+
+	check := NewPatrolRolesHavePromptsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusError {
+		t.Errorf("Status = %v, want Error for malformed rigs.json", result.Status)
+	}
+}
+
+func TestPatrolRolesHavePromptsCheck_EmptyRigsConfig(t *testing.T) {
+	tmpDir := t.TempDir()
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(`{"rigs":{}}`), 0644); err != nil {
+		t.Fatalf("write rigs.json: %v", err)
+	}
+
+	check := NewPatrolRolesHavePromptsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("Status = %v, want OK for empty rigs config", result.Status)
+	}
+	if result.Message != "No rigs configured" {
+		t.Errorf("Message = %q, want 'No rigs configured'", result.Message)
+	}
+}

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -62,14 +62,14 @@ type EscalationData struct {
 
 // HandoffData contains information for session handoff messages.
 type HandoffData struct {
-	Role         string
-	CurrentWork  string
-	Status       string
-	NextSteps    []string
-	Notes        string
-	PendingMail  int
-	GitBranch    string
-	GitDirty     bool
+	Role        string
+	CurrentWork string
+	Status      string
+	NextSteps   []string
+	Notes       string
+	PendingMail int
+	GitBranch   string
+	GitDirty    bool
 }
 
 // New creates a new Templates instance.
@@ -125,4 +125,26 @@ func (t *Templates) RoleNames() []string {
 // MessageNames returns the list of available message templates.
 func (t *Templates) MessageNames() []string {
 	return []string{"spawn", "nudge", "escalation", "handoff"}
+}
+
+// GetAllRoleTemplates returns all role templates as a map of filename to content.
+func GetAllRoleTemplates() (map[string][]byte, error) {
+	entries, err := templateFS.ReadDir("roles")
+	if err != nil {
+		return nil, fmt.Errorf("reading roles directory: %w", err)
+	}
+
+	result := make(map[string][]byte)
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+		content, err := templateFS.ReadFile("roles/" + entry.Name())
+		if err != nil {
+			return nil, fmt.Errorf("reading %s: %w", entry.Name(), err)
+		}
+		result[entry.Name()] = content
+	}
+
+	return result, nil
 }

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -188,3 +188,51 @@ func TestRoleNames(t *testing.T) {
 		}
 	}
 }
+
+func TestGetAllRoleTemplates(t *testing.T) {
+	templates, err := GetAllRoleTemplates()
+	if err != nil {
+		t.Fatalf("GetAllRoleTemplates() error = %v", err)
+	}
+
+	if len(templates) == 0 {
+		t.Fatal("GetAllRoleTemplates() returned empty map")
+	}
+
+	expectedFiles := []string{
+		"deacon.md.tmpl",
+		"witness.md.tmpl",
+		"refinery.md.tmpl",
+		"mayor.md.tmpl",
+		"polecat.md.tmpl",
+		"crew.md.tmpl",
+	}
+
+	for _, file := range expectedFiles {
+		content, ok := templates[file]
+		if !ok {
+			t.Errorf("GetAllRoleTemplates() missing %s", file)
+			continue
+		}
+		if len(content) == 0 {
+			t.Errorf("GetAllRoleTemplates()[%s] has empty content", file)
+		}
+	}
+}
+
+func TestGetAllRoleTemplates_ContentValidity(t *testing.T) {
+	templates, err := GetAllRoleTemplates()
+	if err != nil {
+		t.Fatalf("GetAllRoleTemplates() error = %v", err)
+	}
+
+	for name, content := range templates {
+		if !strings.HasSuffix(name, ".md.tmpl") {
+			t.Errorf("unexpected file %s (should end with .md.tmpl)", name)
+		}
+		contentStr := string(content)
+		if !strings.Contains(contentStr, "Context") {
+			t.Errorf("%s doesn't contain 'Context' - may not be a valid role template", name)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Enable `gt doctor --fix` to auto-remediate missing patrol role templates by making `PatrolRolesHavePromptsCheck` fixable.

## Problem

Running `gt doctor` shows this warning that `--fix` cannot remediate:

```
⚠ patrol-roles-have-prompts: 3 role prompt template(s) missing
    myrig: deacon.md.tmpl
    myrig: witness.md.tmpl
    myrig: refinery.md.tmpl
    → Role prompt templates should be in the project repository under internal/templates/roles/
```

The check detects missing templates but provides no auto-fix capability.

## Changes

### `internal/doctor/patrol_check.go`

**Struct changes:**
- Changed `BaseCheck` → `FixableCheck` to enable auto-fix
- Added `missingByRig map[string][]string` to track missing templates per rig

**Run() changes:**
- Now populates `missingByRig` during detection for use by `Fix()`

**New Fix() method:**
```go
func (c *PatrolRolesHavePromptsCheck) Fix(ctx *CheckContext) error {
    allTemplates, err := templates.GetAllRoleTemplates()
    // For each rig with missing templates:
    //   - Create directory at <rig>/mayor/rig/internal/templates/roles/
    //   - Copy embedded templates to disk
}
```

**FixHint change:**
- Before: `"Role prompt templates should be in the project repository under internal/templates/roles/"`
- After: `"Run 'gt doctor --fix' to copy embedded templates to rig repos"`

### `internal/templates/templates.go`

**New function:**
```go
func GetAllRoleTemplates() (map[string][]byte, error)
```
Reads all role templates from embedded FS and returns as filename → content map.

### `internal/doctor/patrol_check_test.go` (new file)

13 test cases covering:
- `TestNewPatrolRolesHavePromptsCheck` - Constructor and `CanFix()` returns true
- `TestPatrolRolesHavePromptsCheck_NoRigs` - Returns OK when no rigs
- `TestPatrolRolesHavePromptsCheck_NoTemplatesDir` - Detects missing dir
- `TestPatrolRolesHavePromptsCheck_SomeTemplatesMissing` - Detects partial
- `TestPatrolRolesHavePromptsCheck_AllTemplatesExist` - Returns OK
- `TestPatrolRolesHavePromptsCheck_Fix` - Creates all templates
- `TestPatrolRolesHavePromptsCheck_FixPartial` - Preserves existing files
- `TestPatrolRolesHavePromptsCheck_MultipleRigs` - Handles multiple rigs
- `TestPatrolRolesHavePromptsCheck_FixHint` - Correct hint message
- `TestPatrolRolesHavePromptsCheck_FixMultipleRigs` - Fix across rigs
- `TestPatrolRolesHavePromptsCheck_DetailsFormat` - Output format `rig:template`
- `TestPatrolRolesHavePromptsCheck_MalformedRigsJSON` - Error handling
- `TestPatrolRolesHavePromptsCheck_EmptyRigsConfig` - Edge case

### `internal/templates/templates_test.go`

2 new tests:
- `TestGetAllRoleTemplates` - Returns all expected template files with content
- `TestGetAllRoleTemplates_ContentValidity` - Templates have `.md.tmpl` suffix and contain "Context"

## Behavior

**Before:**
```
gt doctor --fix
  ⚠ patrol-roles-have-prompts: 3 role prompt template(s) missing
      → Role prompt templates should be in the project repository...
  (no fix applied)
```

**After:**
```
gt doctor --fix
  ✓ patrol-roles-have-prompts: All patrol role prompt templates found
  (templates copied to <rig>/mayor/rig/internal/templates/roles/)
```

## Stats

- 4 files changed
- 489 insertions, 16 deletions
- 15 new tests