### PR TITLE
fix(beads): explicitly pass BEADS_DIR to bd child processes

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -225,6 +225,21 @@ func (b *Beads) run(args ...string) ([]byte, error) {
 	cmd := exec.Command("bd", fullArgs...)
 	cmd.Dir = b.workDir
 
+	// Explicitly set BEADS_DIR for child process to ensure bd uses the correct
+	// database. Without this, bd may search parent directories and find a different
+	// .beads/ directory with a different prefix, causing "prefix mismatch" errors.
+	beadsDir := filepath.Join(b.workDir, ".beads")
+	env := os.Environ()
+	// Filter out any existing BEADS_DIR to avoid conflicts
+	filteredEnv := make([]string, 0, len(env)+1)
+	for _, e := range env {
+		if !strings.HasPrefix(e, "BEADS_DIR=") {
+			filteredEnv = append(filteredEnv, e)
+		}
+	}
+	filteredEnv = append(filteredEnv, "BEADS_DIR="+beadsDir)
+	cmd.Env = filteredEnv
+
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -479,16 +479,18 @@ func (m *Manager) initAgentBeads(rigPath, rigName, prefix string, isFirstRig boo
 
 	var agents []agentDef
 
-	// Always create rig-specific agents (using canonical naming: prefix-rig-role-name)
+	// Always create rig-specific agents using canonical gt- prefix.
+	// Agent bead IDs use the gastown namespace (gt-) regardless of the rig's
+	// beads prefix. Format: gt-<rig>-<role> (e.g., gt-tribal-witness)
 	agents = append(agents,
 		agentDef{
-			id:       beads.WitnessBeadIDWithPrefix(prefix, rigName),
+			id:       beads.WitnessBeadID(rigName),
 			roleType: "witness",
 			rig:      rigName,
 			desc:     fmt.Sprintf("Witness for %s - monitors polecat health and progress.", rigName),
 		},
 		agentDef{
-			id:       beads.RefineryBeadIDWithPrefix(prefix, rigName),
+			id:       beads.RefineryBeadID(rigName),
 			roleType: "refinery",
 			rig:      rigName,
 			desc:     fmt.Sprintf("Refinery for %s - processes merge queue.", rigName),


### PR DESCRIPTION
## Summary

Fixes two issues causing errors when running `gt rig add` with a rig that has a different beads prefix than the town-level beads database.

### Issue 1: Wrong database (prefix mismatch)

**Error:**
```
Error: prefix mismatch: database uses 'gm' but you specified 'tr'
```

**Cause:** `beads.run()` relied on `os.Setenv("BEADS_DIR", ...)` to set the beads directory, but child processes could still resolve a different database through parent directory traversal.

**Fix:** Explicitly pass `BEADS_DIR` in the child process's environment when executing `bd` commands.

### Issue 2: Wrong agent ID prefix

**Error:**
```
Error: invalid agent ID: agent ID must start with 'gt-' (got "tr-tribal-witness")
```

**Cause:** Agent bead IDs were using the rig's beads prefix (e.g., `tr-tribal-witness`) instead of the canonical `gt-` gastown namespace prefix.

**Fix:** Use `WitnessBeadID(rigName)` and `RefineryBeadID(rigName)` instead of the `WithPrefix` variants, which always use `gt-`.

### Changes

- `internal/beads/beads.go`: Modified `run()` to explicitly set `cmd.Env` with `BEADS_DIR`
- `internal/rig/manager.go`: Use canonical `gt-` prefix for agent bead IDs

## Test plan

- [x] Verified code compiles with `go build ./...`
- [x] Unit tests pass
- [ ] Manual test: `gt rig add <name> <url>` creates agent beads without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)