### PR TITLE
fix(beads): fix agent bead creation during rig add

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -225,6 +225,21 @@ func (b *Beads) run(args ...string) ([]byte, error) {
 	cmd := exec.Command("bd", fullArgs...)
 	cmd.Dir = b.workDir
 
+	// Explicitly set BEADS_DIR for child process to ensure bd uses the correct
+	// database. Without this, bd may search parent directories and find a different
+	// .beads/ directory with a different prefix, causing "prefix mismatch" errors.
+	beadsDir := filepath.Join(b.workDir, ".beads")
+	env := os.Environ()
+	// Filter out any existing BEADS_DIR to avoid conflicts
+	filteredEnv := make([]string, 0, len(env)+1)
+	for _, e := range env {
+		if !strings.HasPrefix(e, "BEADS_DIR=") {
+			filteredEnv = append(filteredEnv, e)
+		}
+	}
+	filteredEnv = append(filteredEnv, "BEADS_DIR="+beadsDir)
+	cmd.Env = filteredEnv
+
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr


### PR DESCRIPTION
## Summary

Fixes multiple issues causing errors when running `gt rig add`.

### Issues Fixed

#### 1. bd init flag error
The `--no-agents` flag doesn't exist in `bd init`, causing silent failures and the beads database not being properly initialized.

**Fix:** Removed the invalid flag.

#### 2. BEADS_DIR not set for init commands
`bd init` and `bd migrate` were searching parent directories and finding wrong databases.

**Fix:** Explicitly set `BEADS_DIR` in the child process environment.

#### 3. Agent beads in wrong location
Agent beads were being created in rig beads (with rig-specific prefix like `tr-`) but agent IDs use the canonical `gt-*` prefix. bd strictly validates ID prefix against database prefix.

**Error:**
```
Error: prefix mismatch: database uses 'tr' but you specified 'gt'
```

**Fix:** Agent beads now go in **town beads** (which uses `gt` prefix) instead of rig beads. This matches the design where agent beads enable cross-rig coordination.

#### 4. beads.run() not passing BEADS_DIR
Child processes could find wrong databases through parent directory traversal.

**Fix:** Modified `beads.run()` to explicitly pass `BEADS_DIR=<workDir>/.beads` to child processes.

#### 5. Wrong agent ID prefix function
Code was using `WitnessBeadIDWithPrefix(prefix, rig)` instead of `WitnessBeadID(rig)`, generating IDs like `tr-tribal-witness` instead of `gt-tribal-witness`.

**Fix:** Use canonical `WitnessBeadID()` and `RefineryBeadID()` functions.

### Changes

- `internal/rig/manager.go`:
  - Removed `--no-agents` flag from bd init
  - Added BEADS_DIR to bd init/migrate environment
  - Agent beads now created in town beads (m.townRoot)
  - Use canonical gt-* agent ID functions
- `internal/beads/beads.go`:
  - Modified `run()` to explicitly set BEADS_DIR for child processes

### Prerequisites

Town beads must be initialized with `gt` prefix:
```bash
cd ~/gt && bd init --prefix gt
```

## Test plan

- [x] Verified code compiles with `go build ./...`
- [x] `gt rig add tribal` creates agent beads successfully
- [x] Agent beads visible in town beads: `bd list --type=agent`
- [x] Works without `--force` flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)