### PR TITLE
fix(beads): use town beads for agent bead creation

### DIFF
--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -451,8 +451,8 @@ func (m *Manager) initBeads(rigPath, prefix string) error {
 		return err
 	}
 
-	// Run bd init if available, with --no-agents to skip AGENTS.md creation
-	cmd := exec.Command("bd", "init", "--prefix", prefix, "--no-agents")
+	// Run bd init if available
+	cmd := exec.Command("bd", "init", "--prefix", prefix)
 	cmd.Dir = rigPath
 	_, err := cmd.CombinedOutput()
 	if err != nil {
@@ -477,33 +477,19 @@ func (m *Manager) initBeads(rigPath, prefix string) error {
 }
 
 // initAgentBeads creates agent beads for this rig and optionally global agents.
-// - Always creates: <prefix>-witness-<rig>, <prefix>-refinery-<rig>
-// - First rig only: <prefix>-deacon, <prefix>-mayor
+// - Always creates: gt-<rig>-witness, gt-<rig>-refinery
+// - First rig only: gt-deacon, gt-mayor
+//
+// Agent beads are stored in TOWN beads (not rig beads) because they use the
+// canonical gt-* prefix for cross-rig coordination. The town beads must be
+// initialized with 'gt' prefix for this to work.
 //
 // Agent beads track lifecycle state for ZFC compliance (gt-h3hak, gt-pinkq).
 func (m *Manager) initAgentBeads(rigPath, rigName, prefix string, isFirstRig bool) error {
-	// Run bd commands from the canonical beads location.
-	// - If source repo has .beads/ tracked (mayor/rig/.beads exists), use that
-	// - Otherwise use rig root .beads/ (created by initBeads during rig add)
-	mayorRigBeads := filepath.Join(rigPath, "mayor", "rig", ".beads")
-	var beadsDir string
-	if _, err := os.Stat(mayorRigBeads); err == nil {
-		beadsDir = mayorRigBeads
-	} else {
-		beadsDir = filepath.Join(rigPath, ".beads")
-	}
-	prevBeadsDir, hadBeadsDir := os.LookupEnv("BEADS_DIR")
-	if err := os.Setenv("BEADS_DIR", beadsDir); err != nil {
-		return fmt.Errorf("setting BEADS_DIR: %w", err)
-	}
-	defer func() {
-		if hadBeadsDir {
-			_ = os.Setenv("BEADS_DIR", prevBeadsDir)
-		} else {
-			_ = os.Unsetenv("BEADS_DIR")
-		}
-	}()
-	bd := beads.New(rigPath)
+	// Agent beads go in town beads (gt-* prefix), not rig beads.
+	// This enables cross-rig agent coordination via canonical IDs.
+	townBeadsDir := filepath.Join(m.townRoot, ".beads")
+	bd := beads.NewWithBeadsDir(m.townRoot, townBeadsDir)
 
 	// Define agents to create
 	type agentDef struct {
@@ -515,16 +501,18 @@ func (m *Manager) initAgentBeads(rigPath, rigName, prefix string, isFirstRig boo
 
 	var agents []agentDef
 
-	// Always create rig-specific agents (using canonical naming: prefix-rig-role-name)
+	// Always create rig-specific agents using canonical gt-* prefix.
+	// Agent bead IDs use the gastown namespace (gt-) regardless of the rig's
+	// beads prefix. Format: gt-<rig>-<role> (e.g., gt-tribal-witness)
 	agents = append(agents,
 		agentDef{
-			id:       beads.WitnessBeadIDWithPrefix(prefix, rigName),
+			id:       beads.WitnessBeadID(rigName),
 			roleType: "witness",
 			rig:      rigName,
 			desc:     fmt.Sprintf("Witness for %s - monitors polecat health and progress.", rigName),
 		},
 		agentDef{
-			id:       beads.RefineryBeadIDWithPrefix(prefix, rigName),
+			id:       beads.RefineryBeadID(rigName),
 			roleType: "refinery",
 			rig:      rigName,
 			desc:     fmt.Sprintf("Refinery for %s - processes merge queue.", rigName),

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -329,13 +329,16 @@ exit 1
 	}
 }
 
-func TestInitAgentBeadsUsesRigBeadsDir(t *testing.T) {
-	rigPath := t.TempDir()
-	beadsDir := filepath.Join(rigPath, ".beads")
+func TestInitAgentBeadsUsesTownBeadsDir(t *testing.T) {
+	// Agent beads use town beads (gt-* prefix) for cross-rig coordination.
+	// The Manager.townRoot determines where agent beads are created.
+	townRoot := t.TempDir()
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	rigPath := filepath.Join(townRoot, "testrip")
 	mayorRigPath := filepath.Join(rigPath, "mayor", "rig")
 
-	if err := os.MkdirAll(beadsDir, 0755); err != nil {
-		t.Fatalf("mkdir beads dir: %v", err)
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir town beads dir: %v", err)
 	}
 	if err := os.MkdirAll(mayorRigPath, 0755); err != nil {
 		t.Fatalf("mkdir mayor rig: %v", err)
@@ -386,10 +389,10 @@ esac
 
 	binDir := writeFakeBD(t, script)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	t.Setenv("EXPECT_BEADS_DIR", beadsDir)
+	t.Setenv("EXPECT_BEADS_DIR", townBeadsDir)
 	t.Setenv("BEADS_DIR", "")
 
-	manager := &Manager{}
+	manager := &Manager{townRoot: townRoot}
 	if err := manager.initAgentBeads(rigPath, "demo", "gt", false); err != nil {
 		t.Fatalf("initAgentBeads: %v", err)
 	}


### PR DESCRIPTION
## Summary

Agent beads should use the canonical gt-* prefix for cross-rig coordination. This fix ensures `gt rig add` creates agent beads in **town beads** instead of rig beads, preventing prefix mismatch errors when the rig uses a different prefix (e.g., tr-).

This incorporates the remaining valid fixes from PR #32 (by @PepijnSenders) after PR #34 was merged.

### Issues Fixed

1. **Invalid --no-agents flag** - Removed from bd init call (flag doesn't exist)

2. **Agent beads in wrong location** - Agent beads were created in rig beads with rig-specific prefix, but agent IDs use canonical gt-* prefix. Now uses `beads.NewWithBeadsDir()` to explicitly target town beads.

3. **Wrong agent ID prefix functions** - Was using `WitnessBeadIDWithPrefix(prefix, rig)` which passed the rig's prefix. Now uses `WitnessBeadID(rig)` and `RefineryBeadID(rig)` which hardcode the gt- prefix.

### Changes

- `internal/rig/manager.go`:
  - Removed --no-agents flag from bd init
  - Use `beads.NewWithBeadsDir(m.townRoot, townBeadsDir)` for agent bead creation
  - Use canonical `WitnessBeadID()` and `RefineryBeadID()` functions
  - Updated comments to reflect town beads usage

- `internal/rig/manager_test.go`:
  - Updated test to verify agent beads are created in town beads
  - Renamed test to `TestInitAgentBeadsUsesTownBeadsDir`

## Test plan

- [x] `go build ./...` succeeds
- [x] `go test ./...` passes (including updated test)
- [x] Agent beads will be created with gt-* prefix in town beads

🤖 Generated with [Claude Code](https://claude.com/claude-code)