### PR TITLE
fix: use mayor/rig path for beads to prevent prefix mismatch

### DIFF
--- a/internal/cmd/crew_add.go
+++ b/internal/cmd/crew_add.go
@@ -56,8 +56,9 @@ func runCrewAdd(cmd *cobra.Command, args []string) error {
 	crewGit := git.NewGit(r.Path)
 	crewMgr := crew.NewManager(r, crewGit)
 
-	// Beads for agent bead creation (use rig root where .beads/ lives)
-	bd := beads.New(r.Path)
+	// Beads for agent bead creation (use mayor/rig where beads.db lives)
+	// The rig root .beads/ only has config.yaml, no database.
+	bd := beads.New(filepath.Join(r.Path, "mayor", "rig"))
 
 	// Track results
 	var created []string

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -48,16 +48,12 @@ type Manager struct {
 
 // NewManager creates a new polecat manager.
 func NewManager(r *rig.Rig, g *git.Git) *Manager {
-	// Determine the canonical beads location:
-	// - If mayor/rig/.beads exists (source repo has beads tracked), use that
-	// - Otherwise use rig root .beads/ (created by initBeads during gt rig add)
-	// This matches the conditional logic in setupSharedBeads and route registration.
-	// For repos that have .beads/ tracked in git, the canonical database lives in mayor/rig/.
-	mayorRigBeads := filepath.Join(r.Path, "mayor", "rig", ".beads")
-	beadsPath := r.Path
-	if _, err := os.Stat(mayorRigBeads); err == nil {
-		beadsPath = filepath.Join(r.Path, "mayor", "rig")
-	}
+	// Always use mayor/rig as the beads path.
+	// This matches routes.jsonl which maps prefixes to <rig>/mayor/rig.
+	// The rig root .beads/ only contains config.yaml (no database),
+	// so running bd from there causes it to walk up and find town beads
+	// with the wrong prefix (e.g., 'gm' instead of the rig's prefix).
+	beadsPath := filepath.Join(r.Path, "mayor", "rig")
 
 	// Try to load rig settings for namepool config
 	settingsPath := filepath.Join(r.Path, "settings", "config.json")


### PR DESCRIPTION
## Summary

Fixes prefix mismatch errors when creating agent beads for polecats or crew workers.

**The Problem:**
When spawning polecats or adding crew workers, the code was using the rig root path instead of `mayor/rig`. The rig root `.beads/` only contains `config.yaml` (no database), so `bd` walks up and finds the town-level beads with the wrong prefix:

```
Error: prefix mismatch: database uses 'gm' but you specified 'id'
```

**The Fix:**
Always use `mayor/rig` as the beads path, which matches how `routes.jsonl` maps prefixes.

## Changes
- `internal/polecat/manager.go`: Always use `mayor/rig` path, remove conditional fallback
- `internal/cmd/crew_add.go`: Use `mayor/rig` path instead of rig root

## Test plan
- [x] Build passes
- [ ] `gt polecat add <rig> <name>` no longer shows prefix mismatch warning
- [ ] `gt crew add <name> --rig <rig>` creates agent bead correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)