### PR TITLE
feat: notify dispatcher when polecat work completes

### DIFF
--- a/internal/beads/fields.go
+++ b/internal/beads/fields.go
@@ -20,6 +20,7 @@ type AttachmentFields struct {
 	AttachedMolecule string // Root issue ID of the attached molecule
 	AttachedAt       string // ISO 8601 timestamp when attached
 	AttachedArgs     string // Natural language args passed via gt sling --args (no-tmux mode)
+	DispatchedBy     string // Agent ID that dispatched this work (for completion notification)
 }
 
 // ParseAttachmentFields extracts attachment fields from an issue's description.
@@ -61,6 +62,9 @@ func ParseAttachmentFields(issue *Issue) *AttachmentFields {
 		case "attached_args", "attached-args", "attachedargs":
 			fields.AttachedArgs = value
 			hasFields = true
+		case "dispatched_by", "dispatched-by", "dispatchedby":
+			fields.DispatchedBy = value
+			hasFields = true
 		}
 	}
 
@@ -88,6 +92,9 @@ func FormatAttachmentFields(fields *AttachmentFields) string {
 	if fields.AttachedArgs != "" {
 		lines = append(lines, "attached_args: "+fields.AttachedArgs)
 	}
+	if fields.DispatchedBy != "" {
+		lines = append(lines, "dispatched_by: "+fields.DispatchedBy)
+	}
 
 	return strings.Join(lines, "\n")
 }
@@ -107,6 +114,9 @@ func SetAttachmentFields(issue *Issue, fields *AttachmentFields) string {
 		"attached_args":     true,
 		"attached-args":     true,
 		"attachedargs":      true,
+		"dispatched_by":     true,
+		"dispatched-by":     true,
+		"dispatchedby":      true,
 	}
 
 	// Collect non-attachment lines from existing description

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -322,6 +322,23 @@ func runDone(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%s Witness notified of %s\n", style.Bold.Render("✓"), exitType)
 	}
 
+	// Notify dispatcher if work was dispatched by another agent
+	if issueID != "" {
+		if dispatcher := getDispatcherFromBead(cwd, issueID); dispatcher != "" && dispatcher != sender {
+			dispatcherNotification := &mail.Message{
+				To:      dispatcher,
+				From:    sender,
+				Subject: fmt.Sprintf("WORK_DONE: %s", issueID),
+				Body:    strings.Join(bodyLines, "\n"),
+			}
+			if err := townRouter.Send(dispatcherNotification); err != nil {
+				style.PrintWarning("could not notify dispatcher %s: %v", dispatcher, err)
+			} else {
+				fmt.Printf("%s Dispatcher %s notified of %s\n", style.Bold.Render("✓"), dispatcher, exitType)
+			}
+		}
+	}
+
 	// Log done event (townlog and activity feed)
 	LogDone(townRoot, sender, issueID)
 	_ = events.LogFeed(events.TypeDone, sender, events.DonePayload(issueID, branch))
@@ -404,6 +421,27 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) {
 			return
 		}
 	}
+}
+
+// getDispatcherFromBead retrieves the dispatcher agent ID from the bead's attachment fields.
+// Returns empty string if no dispatcher is recorded.
+func getDispatcherFromBead(cwd, issueID string) string {
+	if issueID == "" {
+		return ""
+	}
+
+	bd := beads.New(cwd)
+	issue, err := bd.Show(issueID)
+	if err != nil {
+		return ""
+	}
+
+	fields := beads.ParseAttachmentFields(issue)
+	if fields == nil {
+		return ""
+	}
+
+	return fields.DispatchedBy
 }
 
 // computeCleanupStatus checks git state and returns the cleanup status.


### PR DESCRIPTION
## Summary

When a crew dispatches work to a polecat via `gt sling`, the polecat now notifies the dispatcher when the work is complete.

**The Problem:**
Crews would dispatch work to polecats and then wait indefinitely with no notification when the work completed. The polecat only reported to the mayor, leaving the dispatcher in the dark.

**The Fix:**
- Track who dispatched the work in the bead's `dispatched_by` field
- When polecat runs `gt done`, check for dispatcher and send WORK_DONE notification

## Changes
- `internal/beads/fields.go`: Added `DispatchedBy` field to `AttachmentFields`
- `internal/cmd/sling.go`: Store dispatcher when slinging
- `internal/cmd/done.go`: Send notification to dispatcher on completion

## Test plan
- [ ] `gt sling <bead> <rig>` stores dispatcher in bead
- [ ] `gt done` sends notification to dispatcher
- [ ] Dispatcher receives WORK_DONE mail when polecat completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)