### PR TITLE
Update installation and workspace setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,13 +26,13 @@ Multi-agent orchestrator for Claude Code. Track work with convoys; sling to agen
 go install github.com/steveyegge/gastown/cmd/gt@latest
 
 # Create workspace
-gt install ~/gt
+gt install ~/gt && cd ~/gt
 
 # Add a project
 gt rig add myproject https://github.com/you/repo.git
 
 # Enter the Mayor's office (recommended)
-cd ~/gt && gt prime
+gt prime
 ```
 
 Once inside the Mayor session, you're talking to Claude with full town context. Just tell it what you want:


### PR DESCRIPTION
```
~ ❯ gt rig add tallstuffnearme https://github.com/jakehemmerle/tallstuffnearme
Error: not in a Gas Town workspace: not in a Gas Town workspace
Usage:
  gt rig add <name> <git-url> [flags]

Flags:
  -h, --help            help for add
      --prefix string   Beads issue prefix (default: derived from name)

~ ❯ cd ~/gt
~/gt main* ❯ gt rig add tallstuffnearme https://github.com/jakehemmerle/tallstuffnearme
Creating rig tallstuffnearme...
  Repository: https://github.com/jakehemmerle/tallstuffnearme
  Warning: Could not create agent beads: creating ta-tallstuffnearme-witness: bd create --json --id=ta-tallstuffnearme-witness --type=agent --title=Witness for tallstuffnearme - monitors polecat health and progress. --description=Witness for tallstuffnearme - monitors polecat health and progress.

role_type: witness
rig: tallstuffnearme
agent_state: idle
hook_bead: null
role_bead: gt-witness-role
cleanup_status: null
active_mr: null
notification_level: null: Error: prefix mismatch: database uses 'gm' but you specified 'ta' (use --force to override)
```

Second error is unrelated to these changes, but first command demonstrates that `gt rig add` must be run in `~/gt`
