### PR TITLE
docs: Fix Quick Start to use gt mayor attach

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ gt install ~/gt
 gt rig add myproject https://github.com/you/repo.git
 
 # Enter the Mayor's office (recommended)
-cd ~/gt && gt prime
+gt mayor attach
 ```
 
 Once inside the Mayor session, you're talking to Claude with full town context. Just tell it what you want:


### PR DESCRIPTION
The quick Start section says that `cd ~/gt && gt prime` enters the Mayor's office. It only prints the mayoral context.
I changed it to `gt mayor attach` which properly attaches to the Mayor tmux session.
Please re-change it if it should be a different command. 