### PR TITLE
fix: Add retry logic for Enter key send in NudgeSession/NudgePane

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -272,12 +272,19 @@ func (t *Tmux) NudgeSession(session, message string) error {
 	// 2. Wait 500ms for paste to complete (tested, required)
 	time.Sleep(500 * time.Millisecond)
 
-	// 3. Send Enter as separate command (key to reliability)
-	if _, err := t.run("send-keys", "-t", session, "Enter"); err != nil {
-		return err
+	// 3. Send Enter with retry (critical for message submission)
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			time.Sleep(200 * time.Millisecond)
+		}
+		if _, err := t.run("send-keys", "-t", session, "Enter"); err != nil {
+			lastErr = err
+			continue
+		}
+		return nil
 	}
-
-	return nil
+	return fmt.Errorf("failed to send Enter after 3 attempts: %w", lastErr)
 }
 
 // NudgePane sends a message to a specific pane reliably.
@@ -291,12 +298,19 @@ func (t *Tmux) NudgePane(pane, message string) error {
 	// 2. Wait 500ms for paste to complete (tested, required)
 	time.Sleep(500 * time.Millisecond)
 
-	// 3. Send Enter as separate command (key to reliability)
-	if _, err := t.run("send-keys", "-t", pane, "Enter"); err != nil {
-		return err
+	// 3. Send Enter with retry (critical for message submission)
+	var lastErr error
+	for attempt := 0; attempt < 3; attempt++ {
+		if attempt > 0 {
+			time.Sleep(200 * time.Millisecond)
+		}
+		if _, err := t.run("send-keys", "-t", pane, "Enter"); err != nil {
+			lastErr = err
+			continue
+		}
+		return nil
 	}
-
-	return nil
+	return fmt.Errorf("failed to send Enter after 3 attempts: %w", lastErr)
 }
 
 // AcceptBypassPermissionsWarning dismisses the Claude Code bypass permissions warning dialog.


### PR DESCRIPTION
## Summary
- Add retry logic (up to 3 attempts with 200ms delays) for Enter key send in `NudgeSession()` and `NudgePane()`
- Fixes issue where polecats receive their initial prompt but it's never submitted
- The Enter key send could fail silently, leaving messages in Claude's input area without submission

## Root Cause
When sending messages to Claude sessions via tmux, the sequence is:
1. Send text in literal mode
2. Wait 500ms for paste to complete
3. Send Enter

Step 3 could fail, but all call sites silently ignored the error. Adding retry logic makes message submission more reliable.

## Test Plan
- [x] All existing tests pass
- [x] Manual verification that retry logic executes correctly

Fixes #41