### PR TITLE
Add convoy dashboard HTML template with Last Activity (hq-fq1g)

### DIFF
--- a/internal/activity/activity.go
+++ b/internal/activity/activity.go
@@ -1,0 +1,133 @@
+// Package activity provides last-activity tracking and color-coding for the dashboard.
+package activity
+
+import (
+	"time"
+)
+
+// Color class constants for activity status.
+const (
+	ColorGreen   = "green"   // Active: <2 minutes
+	ColorYellow  = "yellow"  // Stale: 2-5 minutes
+	ColorRed     = "red"     // Stuck: >5 minutes
+	ColorUnknown = "unknown" // No activity data
+)
+
+// Thresholds for activity color coding.
+const (
+	ThresholdActive = 2 * time.Minute  // Green threshold
+	ThresholdStale  = 5 * time.Minute  // Yellow threshold (beyond this is red)
+)
+
+// Info holds activity information for display.
+type Info struct {
+	LastActivity time.Time // Raw timestamp of last activity
+	Duration     time.Duration // Time since last activity
+	FormattedAge string    // Human-readable age (e.g., "2m", "1h")
+	ColorClass   string    // CSS class for coloring (green, yellow, red, unknown)
+}
+
+// Calculate computes activity info from a last-activity timestamp.
+// Returns color-coded info based on thresholds:
+//   - Green:   <2 minutes (active)
+//   - Yellow:  2-5 minutes (stale)
+//   - Red:     >5 minutes (stuck)
+//   - Unknown: zero time value
+func Calculate(lastActivity time.Time) Info {
+	info := Info{
+		LastActivity: lastActivity,
+	}
+
+	// Handle zero time (no activity data)
+	if lastActivity.IsZero() {
+		info.FormattedAge = "unknown"
+		info.ColorClass = ColorUnknown
+		return info
+	}
+
+	// Calculate duration since last activity
+	info.Duration = time.Since(lastActivity)
+
+	// Handle future time (clock skew) - treat as just now
+	if info.Duration < 0 {
+		info.Duration = 0
+	}
+
+	// Format age string
+	info.FormattedAge = formatAge(info.Duration)
+
+	// Determine color class
+	info.ColorClass = colorForDuration(info.Duration)
+
+	return info
+}
+
+// formatAge formats a duration as a short human-readable string.
+// Examples: "<1m", "5m", "2h", "1d"
+func formatAge(d time.Duration) string {
+	if d < time.Minute {
+		return "<1m"
+	}
+	if d < time.Hour {
+		return formatMinutes(d)
+	}
+	if d < 24*time.Hour {
+		return formatHours(d)
+	}
+	return formatDays(d)
+}
+
+func formatMinutes(d time.Duration) string {
+	mins := int(d.Minutes())
+	return formatInt(mins) + "m"
+}
+
+func formatHours(d time.Duration) string {
+	hours := int(d.Hours())
+	return formatInt(hours) + "h"
+}
+
+func formatDays(d time.Duration) string {
+	days := int(d.Hours() / 24)
+	return formatInt(days) + "d"
+}
+
+func formatInt(n int) string {
+	if n < 10 {
+		return string(rune('0'+n))
+	}
+	// For larger numbers, use standard conversion
+	result := ""
+	for n > 0 {
+		result = string(rune('0'+n%10)) + result
+		n /= 10
+	}
+	return result
+}
+
+// colorForDuration returns the color class for a given duration.
+func colorForDuration(d time.Duration) string {
+	switch {
+	case d < ThresholdActive:
+		return ColorGreen
+	case d < ThresholdStale:
+		return ColorYellow
+	default:
+		return ColorRed
+	}
+}
+
+// IsActive returns true if the activity is within the active threshold (green).
+func (i Info) IsActive() bool {
+	return i.ColorClass == ColorGreen
+}
+
+// IsStale returns true if the activity is in the stale range (yellow).
+func (i Info) IsStale() bool {
+	return i.ColorClass == ColorYellow
+}
+
+// IsStuck returns true if the activity is beyond the stale threshold (red).
+func (i Info) IsStuck() bool {
+	return i.ColorClass == ColorRed
+}

--- a/internal/activity/activity_test.go
+++ b/internal/activity/activity_test.go
@@ -1,0 +1,178 @@
+package activity
+
+import (
+	"testing"
+	"time"
+)
+
+func TestCalculateActivity_Green(t *testing.T) {
+	tests := []struct {
+		name     string
+		age      time.Duration
+		wantAge  string
+		wantColor string
+	}{
+		{"just now", 0, "<1m", ColorGreen},
+		{"30 seconds", 30 * time.Second, "<1m", ColorGreen},
+		{"1 minute", 1 * time.Minute, "1m", ColorGreen},
+		{"1m30s", 90 * time.Second, "1m", ColorGreen},
+		{"1m59s", 119 * time.Second, "1m", ColorGreen},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lastActivity := time.Now().Add(-tt.age)
+			info := Calculate(lastActivity)
+
+			if info.FormattedAge != tt.wantAge {
+				t.Errorf("FormattedAge = %q, want %q", info.FormattedAge, tt.wantAge)
+			}
+			if info.ColorClass != tt.wantColor {
+				t.Errorf("ColorClass = %q, want %q", info.ColorClass, tt.wantColor)
+			}
+		})
+	}
+}
+
+func TestCalculateActivity_Yellow(t *testing.T) {
+	tests := []struct {
+		name     string
+		age      time.Duration
+		wantAge  string
+		wantColor string
+	}{
+		{"2 minutes", 2 * time.Minute, "2m", ColorYellow},
+		{"3 minutes", 3 * time.Minute, "3m", ColorYellow},
+		{"4 minutes", 4 * time.Minute, "4m", ColorYellow},
+		{"4m59s", 299 * time.Second, "4m", ColorYellow},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lastActivity := time.Now().Add(-tt.age)
+			info := Calculate(lastActivity)
+
+			if info.FormattedAge != tt.wantAge {
+				t.Errorf("FormattedAge = %q, want %q", info.FormattedAge, tt.wantAge)
+			}
+			if info.ColorClass != tt.wantColor {
+				t.Errorf("ColorClass = %q, want %q", info.ColorClass, tt.wantColor)
+			}
+		})
+	}
+}
+
+func TestCalculateActivity_Red(t *testing.T) {
+	tests := []struct {
+		name     string
+		age      time.Duration
+		wantAge  string
+		wantColor string
+	}{
+		{"5 minutes", 5 * time.Minute, "5m", ColorRed},
+		{"10 minutes", 10 * time.Minute, "10m", ColorRed},
+		{"30 minutes", 30 * time.Minute, "30m", ColorRed},
+		{"1 hour", 1 * time.Hour, "1h", ColorRed},
+		{"2 hours", 2 * time.Hour, "2h", ColorRed},
+		{"1 day", 24 * time.Hour, "1d", ColorRed},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			lastActivity := time.Now().Add(-tt.age)
+			info := Calculate(lastActivity)
+
+			if info.FormattedAge != tt.wantAge {
+				t.Errorf("FormattedAge = %q, want %q", info.FormattedAge, tt.wantAge)
+			}
+			if info.ColorClass != tt.wantColor {
+				t.Errorf("ColorClass = %q, want %q", info.ColorClass, tt.wantColor)
+			}
+		})
+	}
+}
+
+func TestCalculateActivity_ZeroTime(t *testing.T) {
+	// Zero time should return unknown state
+	info := Calculate(time.Time{})
+
+	if info.ColorClass != ColorUnknown {
+		t.Errorf("ColorClass = %q, want %q for zero time", info.ColorClass, ColorUnknown)
+	}
+	if info.FormattedAge != "unknown" {
+		t.Errorf("FormattedAge = %q, want %q for zero time", info.FormattedAge, "unknown")
+	}
+}
+
+func TestCalculateActivity_FutureTime(t *testing.T) {
+	// Future time (clock skew) should be treated as "just now"
+	futureTime := time.Now().Add(5 * time.Second)
+	info := Calculate(futureTime)
+
+	if info.ColorClass != ColorGreen {
+		t.Errorf("ColorClass = %q, want %q for future time", info.ColorClass, ColorGreen)
+	}
+}
+
+func TestInfo_IsActive(t *testing.T) {
+	tests := []struct {
+		color    string
+		isActive bool
+	}{
+		{ColorGreen, true},
+		{ColorYellow, false},
+		{ColorRed, false},
+		{ColorUnknown, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.color, func(t *testing.T) {
+			info := Info{ColorClass: tt.color}
+			if info.IsActive() != tt.isActive {
+				t.Errorf("IsActive() = %v, want %v for color %q", info.IsActive(), tt.isActive, tt.color)
+			}
+		})
+	}
+}
+
+func TestInfo_IsStale(t *testing.T) {
+	tests := []struct {
+		color   string
+		isStale bool
+	}{
+		{ColorGreen, false},
+		{ColorYellow, true},
+		{ColorRed, false},
+		{ColorUnknown, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.color, func(t *testing.T) {
+			info := Info{ColorClass: tt.color}
+			if info.IsStale() != tt.isStale {
+				t.Errorf("IsStale() = %v, want %v for color %q", info.IsStale(), tt.isStale, tt.color)
+			}
+		})
+	}
+}
+
+func TestInfo_IsStuck(t *testing.T) {
+	tests := []struct {
+		color   string
+		isStuck bool
+	}{
+		{ColorGreen, false},
+		{ColorYellow, false},
+		{ColorRed, true},
+		{ColorUnknown, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.color, func(t *testing.T) {
+			info := Info{ColorClass: tt.color}
+			if info.IsStuck() != tt.isStuck {
+				t.Errorf("IsStuck() = %v, want %v for color %q", info.IsStuck(), tt.isStuck, tt.color)
+			}
+		})
+	}
+}

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -1,0 +1,96 @@
+// Package web provides HTTP server and templates for the Gas Town dashboard.
+package web
+
+import (
+	"embed"
+	"html/template"
+	"io/fs"
+
+	"github.com/steveyegge/gastown/internal/activity"
+)
+
+//go:embed templates/*.html
+var templateFS embed.FS
+
+// ConvoyData represents data passed to the convoy template.
+type ConvoyData struct {
+	Convoys []ConvoyRow
+}
+
+// ConvoyRow represents a single convoy in the dashboard.
+type ConvoyRow struct {
+	ID            string
+	Title         string
+	Status        string // "open" or "closed"
+	Progress      string // e.g., "2/5"
+	Completed     int
+	Total         int
+	LastActivity  activity.Info
+	TrackedIssues []TrackedIssue
+}
+
+// TrackedIssue represents an issue tracked by a convoy.
+type TrackedIssue struct {
+	ID       string
+	Title    string
+	Status   string
+	Assignee string
+}
+
+// LoadTemplates loads and parses all HTML templates.
+func LoadTemplates() (*template.Template, error) {
+	// Define template functions
+	funcMap := template.FuncMap{
+		"activityClass":   activityClass,
+		"statusClass":     statusClass,
+		"progressPercent": progressPercent,
+	}
+
+	// Get the templates subdirectory
+	subFS, err := fs.Sub(templateFS, "templates")
+	if err != nil {
+		return nil, err
+	}
+
+	// Parse all templates
+	tmpl, err := template.New("").Funcs(funcMap).ParseFS(subFS, "*.html")
+	if err != nil {
+		return nil, err
+	}
+
+	return tmpl, nil
+}
+
+// activityClass returns the CSS class for an activity color.
+func activityClass(info activity.Info) string {
+	switch info.ColorClass {
+	case activity.ColorGreen:
+		return "activity-green"
+	case activity.ColorYellow:
+		return "activity-yellow"
+	case activity.ColorRed:
+		return "activity-red"
+	default:
+		return "activity-unknown"
+	}
+}
+
+// statusClass returns the CSS class for a convoy status.
+func statusClass(status string) string {
+	switch status {
+	case "open":
+		return "status-open"
+	case "closed":
+		return "status-closed"
+	default:
+		return "status-unknown"
+	}
+}
+
+// progressPercent calculates percentage as an integer for progress bars.
+func progressPercent(completed, total int) int {
+	if total == 0 {
+		return 0
+	}
+	return (completed * 100) / total
+}

--- a/internal/web/templates/convoy.html
+++ b/internal/web/templates/convoy.html
@@ -1,0 +1,245 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Gas Town Dashboard</title>
+    <script src="https://unpkg.com/htmx.org@1.9.10"></script>
+    <style>
+        :root {
+            --bg-dark: #1a1a2e;
+            --bg-card: #16213e;
+            --text-primary: #eee;
+            --text-secondary: #aaa;
+            --border: #0f3460;
+            --green: #4ade80;
+            --yellow: #facc15;
+            --red: #f87171;
+        }
+
+        * {
+            box-sizing: border-box;
+            margin: 0;
+            padding: 0;
+        }
+
+        body {
+            font-family: 'SF Mono', 'Menlo', 'Monaco', monospace;
+            background: var(--bg-dark);
+            color: var(--text-primary);
+            padding: 20px;
+            min-height: 100vh;
+        }
+
+        .dashboard {
+            max-width: 1200px;
+            margin: 0 auto;
+        }
+
+        header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+            margin-bottom: 24px;
+            padding-bottom: 16px;
+            border-bottom: 1px solid var(--border);
+        }
+
+        h1 {
+            font-size: 1.5rem;
+            font-weight: 600;
+        }
+
+        .refresh-info {
+            color: var(--text-secondary);
+            font-size: 0.875rem;
+        }
+
+        .convoy-table {
+            width: 100%;
+            border-collapse: collapse;
+            background: var(--bg-card);
+            border-radius: 8px;
+            overflow: hidden;
+        }
+
+        .convoy-table th,
+        .convoy-table td {
+            padding: 12px 16px;
+            text-align: left;
+            border-bottom: 1px solid var(--border);
+        }
+
+        .convoy-table th {
+            background: var(--bg-dark);
+            font-weight: 500;
+            color: var(--text-secondary);
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+        }
+
+        .convoy-table tr:last-child td {
+            border-bottom: none;
+        }
+
+        .convoy-table tr:hover {
+            background: rgba(255, 255, 255, 0.02);
+        }
+
+        /* Status indicators */
+        .status-indicator {
+            display: inline-block;
+            width: 8px;
+            height: 8px;
+            border-radius: 50%;
+            margin-right: 8px;
+        }
+
+        .status-open .status-indicator {
+            background: var(--yellow);
+        }
+
+        .status-closed .status-indicator {
+            background: var(--green);
+        }
+
+        /* Activity colors */
+        .activity-dot {
+            display: inline-block;
+            width: 10px;
+            height: 10px;
+            border-radius: 50%;
+            margin-right: 8px;
+        }
+
+        .activity-green .activity-dot {
+            background: var(--green);
+            box-shadow: 0 0 8px var(--green);
+        }
+
+        .activity-yellow .activity-dot {
+            background: var(--yellow);
+            box-shadow: 0 0 8px var(--yellow);
+        }
+
+        .activity-red .activity-dot {
+            background: var(--red);
+            box-shadow: 0 0 8px var(--red);
+        }
+
+        .activity-unknown .activity-dot {
+            background: var(--text-secondary);
+        }
+
+        .convoy-id {
+            font-weight: 500;
+            color: var(--text-primary);
+        }
+
+        .convoy-title {
+            color: var(--text-secondary);
+            margin-left: 8px;
+        }
+
+        .progress {
+            font-variant-numeric: tabular-nums;
+        }
+
+        .progress-bar {
+            width: 60px;
+            height: 4px;
+            background: var(--border);
+            border-radius: 2px;
+            overflow: hidden;
+            margin-top: 4px;
+        }
+
+        .progress-fill {
+            height: 100%;
+            background: var(--green);
+            border-radius: 2px;
+        }
+
+        .empty-state {
+            text-align: center;
+            padding: 48px;
+            color: var(--text-secondary);
+        }
+
+        .empty-state h2 {
+            font-size: 1.25rem;
+            margin-bottom: 8px;
+        }
+
+        .empty-state p {
+            font-size: 0.875rem;
+        }
+
+        /* htmx loading indicator */
+        .htmx-request .htmx-indicator {
+            opacity: 1;
+        }
+
+        .htmx-indicator {
+            opacity: 0;
+            transition: opacity 200ms ease-in;
+        }
+    </style>
+</head>
+<body>
+    <div class="dashboard" hx-get="/" hx-trigger="every 30s" hx-swap="outerHTML">
+        <header>
+            <h1>🚚 Gas Town Convoys</h1>
+            <span class="refresh-info">
+                Auto-refresh: every 30s
+                <span class="htmx-indicator">⟳</span>
+            </span>
+        </header>
+
+        {{if .Convoys}}
+        <table class="convoy-table">
+            <thead>
+                <tr>
+                    <th>Status</th>
+                    <th>Convoy</th>
+                    <th>Progress</th>
+                    <th>Last Activity</th>
+                </tr>
+            </thead>
+            <tbody>
+                {{range .Convoys}}
+                <tr class="{{statusClass .Status}}">
+                    <td>
+                        <span class="status-indicator"></span>
+                        {{if eq .Status "open"}}●{{else}}✓{{end}}
+                    </td>
+                    <td>
+                        <span class="convoy-id">{{.ID}}</span>
+                        <span class="convoy-title">{{.Title}}</span>
+                    </td>
+                    <td class="progress">
+                        {{.Progress}}
+                        {{if .Total}}
+                        <div class="progress-bar">
+                            <div class="progress-fill" style="width: {{progressPercent .Completed .Total}}%;"></div>
+                        </div>
+                        {{end}}
+                    </td>
+                    <td class="{{activityClass .LastActivity}}">
+                        <span class="activity-dot"></span>
+                        {{.LastActivity.FormattedAge}}
+                    </td>
+                </tr>
+                {{end}}
+            </tbody>
+        </table>
+        {{else}}
+        <div class="empty-state">
+            <h2>No convoys found</h2>
+            <p>Create a convoy with: gt convoy create &lt;name&gt; [issues...]</p>
+        </div>
+        {{end}}
+    </div>
+</body>
+</html>

--- a/internal/web/templates_test.go
+++ b/internal/web/templates_test.go
@@ -1,0 +1,238 @@
+package web
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/activity"
+)
+
+func TestConvoyTemplate_RendersConvoyList(t *testing.T) {
+	tmpl, err := LoadTemplates()
+	if err != nil {
+		t.Fatalf("LoadTemplates() error = %v", err)
+	}
+
+	data := ConvoyData{
+		Convoys: []ConvoyRow{
+			{
+				ID:       "hq-cv-abc",
+				Title:    "Feature X",
+				Status:   "open",
+				Progress: "2/5",
+				Completed: 2,
+				Total:    5,
+				LastActivity: activity.Calculate(time.Now().Add(-1 * time.Minute)),
+			},
+			{
+				ID:       "hq-cv-def",
+				Title:    "Bugfix Y",
+				Status:   "open",
+				Progress: "1/3",
+				Completed: 1,
+				Total:    3,
+				LastActivity: activity.Calculate(time.Now().Add(-3 * time.Minute)),
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.ExecuteTemplate(&buf, "convoy.html", data)
+	if err != nil {
+		t.Fatalf("ExecuteTemplate() error = %v", err)
+	}
+
+	output := buf.String()
+
+	// Check convoy IDs are rendered
+	if !strings.Contains(output, "hq-cv-abc") {
+		t.Error("Template should contain convoy ID hq-cv-abc")
+	}
+	if !strings.Contains(output, "hq-cv-def") {
+		t.Error("Template should contain convoy ID hq-cv-def")
+	}
+
+	// Check titles are rendered
+	if !strings.Contains(output, "Feature X") {
+		t.Error("Template should contain title 'Feature X'")
+	}
+	if !strings.Contains(output, "Bugfix Y") {
+		t.Error("Template should contain title 'Bugfix Y'")
+	}
+}
+
+func TestConvoyTemplate_LastActivityColors(t *testing.T) {
+	tmpl, err := LoadTemplates()
+	if err != nil {
+		t.Fatalf("LoadTemplates() error = %v", err)
+	}
+
+	tests := []struct {
+		name       string
+		age        time.Duration
+		wantClass  string
+	}{
+		{"green for 1 minute", 1 * time.Minute, "activity-green"},
+		{"yellow for 3 minutes", 3 * time.Minute, "activity-yellow"},
+		{"red for 10 minutes", 10 * time.Minute, "activity-red"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			data := ConvoyData{
+				Convoys: []ConvoyRow{
+					{
+						ID:           "hq-cv-test",
+						Title:        "Test",
+						Status:       "open",
+						LastActivity: activity.Calculate(time.Now().Add(-tt.age)),
+					},
+				},
+			}
+
+			var buf bytes.Buffer
+			err = tmpl.ExecuteTemplate(&buf, "convoy.html", data)
+			if err != nil {
+				t.Fatalf("ExecuteTemplate() error = %v", err)
+			}
+
+			output := buf.String()
+			if !strings.Contains(output, tt.wantClass) {
+				t.Errorf("Template should contain class %q for %v age", tt.wantClass, tt.age)
+			}
+		})
+	}
+}
+
+func TestConvoyTemplate_HtmxAutoRefresh(t *testing.T) {
+	tmpl, err := LoadTemplates()
+	if err != nil {
+		t.Fatalf("LoadTemplates() error = %v", err)
+	}
+
+	data := ConvoyData{
+		Convoys: []ConvoyRow{
+			{
+				ID:     "hq-cv-test",
+				Title:  "Test",
+				Status: "open",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.ExecuteTemplate(&buf, "convoy.html", data)
+	if err != nil {
+		t.Fatalf("ExecuteTemplate() error = %v", err)
+	}
+
+	output := buf.String()
+
+	// Check for htmx attributes
+	if !strings.Contains(output, "hx-get") {
+		t.Error("Template should contain hx-get for auto-refresh")
+	}
+	if !strings.Contains(output, "hx-trigger") {
+		t.Error("Template should contain hx-trigger for auto-refresh")
+	}
+	if !strings.Contains(output, "every 30s") {
+		t.Error("Template should refresh every 30 seconds")
+	}
+}
+
+func TestConvoyTemplate_ProgressDisplay(t *testing.T) {
+	tmpl, err := LoadTemplates()
+	if err != nil {
+		t.Fatalf("LoadTemplates() error = %v", err)
+	}
+
+	data := ConvoyData{
+		Convoys: []ConvoyRow{
+			{
+				ID:        "hq-cv-test",
+				Title:     "Test",
+				Status:    "open",
+				Progress:  "3/7",
+				Completed: 3,
+				Total:     7,
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.ExecuteTemplate(&buf, "convoy.html", data)
+	if err != nil {
+		t.Fatalf("ExecuteTemplate() error = %v", err)
+	}
+
+	output := buf.String()
+
+	// Check progress is displayed
+	if !strings.Contains(output, "3/7") {
+		t.Error("Template should display progress '3/7'")
+	}
+}
+
+func TestConvoyTemplate_StatusIndicators(t *testing.T) {
+	tmpl, err := LoadTemplates()
+	if err != nil {
+		t.Fatalf("LoadTemplates() error = %v", err)
+	}
+
+	data := ConvoyData{
+		Convoys: []ConvoyRow{
+			{
+				ID:     "hq-cv-open",
+				Title:  "Open Convoy",
+				Status: "open",
+			},
+			{
+				ID:     "hq-cv-closed",
+				Title:  "Closed Convoy",
+				Status: "closed",
+			},
+		},
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.ExecuteTemplate(&buf, "convoy.html", data)
+	if err != nil {
+		t.Fatalf("ExecuteTemplate() error = %v", err)
+	}
+
+	output := buf.String()
+
+	// Check status indicators
+	if !strings.Contains(output, "status-open") {
+		t.Error("Template should contain status-open class")
+	}
+	if !strings.Contains(output, "status-closed") {
+		t.Error("Template should contain status-closed class")
+	}
+}
+
+func TestConvoyTemplate_EmptyState(t *testing.T) {
+	tmpl, err := LoadTemplates()
+	if err != nil {
+		t.Fatalf("LoadTemplates() error = %v", err)
+	}
+
+	data := ConvoyData{
+		Convoys: []ConvoyRow{},
+	}
+
+	var buf bytes.Buffer
+	err = tmpl.ExecuteTemplate(&buf, "convoy.html", data)
+	if err != nil {
+		t.Fatalf("ExecuteTemplate() error = %v", err)
+	}
+
+	output := buf.String()
+
+	// Check for empty state message
+	if !strings.Contains(output, "No convoys") {
+		t.Error("Template should show empty state message when no convoys")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `internal/web` package with convoy dashboard template
- Last Activity column with color-coded indicators
- htmx auto-refresh every 30 seconds

## Features
- **Color coding**: Green (<2min), Yellow (2-5min), Red (>5min)
- **htmx auto-refresh**: Updates every 30s without full page reload
- **Progress bars**: Visual convoy completion indicator
- **Status indicators**: Open/closed convoy states
- **Empty state**: Message when no convoys exist

## Files Added
- `internal/web/templates.go` - Template loading and helper functions
- `internal/web/templates/convoy.html` - Dashboard HTML with htmx
- `internal/web/templates_test.go` - 6 unit tests
- `internal/activity/` - Dependency from hq-x2xy (included)

## Test plan
- [x] 6 template tests covering rendering, colors, htmx, progress, status, empty state
- [x] 8 activity tests (from hq-x2xy dependency)
- [x] `go test ./internal/web/... ./internal/activity/...` passes

Closes hq-fq1g

🤖 Generated with [Claude Code](https://claude.com/claude-code)