### PR TITLE
feat: allow local repo reference clones to save disk

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -251,6 +251,7 @@ Examples:
 // Flags
 var (
 	rigAddPrefix       string
+	rigAddLocalRepo    string
 	rigResetHandoff    bool
 	rigResetMail       bool
 	rigResetStale      bool
@@ -279,6 +280,7 @@ func init() {
 	rigCmd.AddCommand(rigStopCmd)
 
 	rigAddCmd.Flags().StringVar(&rigAddPrefix, "prefix", "", "Beads issue prefix (default: derived from name)")
+	rigAddCmd.Flags().StringVar(&rigAddLocalRepo, "local-repo", "", "Local repo path to share git objects (optional)")
 
 	rigResetCmd.Flags().BoolVar(&rigResetHandoff, "handoff", false, "Clear handoff content")
 	rigResetCmd.Flags().BoolVar(&rigResetMail, "mail", false, "Clear stale mail messages")
@@ -330,6 +332,9 @@ func runRigAdd(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("Creating rig %s...\n", style.Bold.Render(name))
 	fmt.Printf("  Repository: %s\n", gitURL)
+	if rigAddLocalRepo != "" {
+		fmt.Printf("  Local repo: %s\n", rigAddLocalRepo)
+	}
 
 	startTime := time.Now()
 
@@ -338,6 +343,7 @@ func runRigAdd(cmd *cobra.Command, args []string) error {
 		Name:        name,
 		GitURL:      gitURL,
 		BeadsPrefix: rigAddPrefix,
+		LocalRepo:   rigAddLocalRepo,
 	})
 	if err != nil {
 		return fmt.Errorf("adding rig: %w", err)

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -44,8 +44,9 @@ func TestRigsConfigRoundTrip(t *testing.T) {
 		Version: 1,
 		Rigs: map[string]RigEntry{
 			"gastown": {
-				GitURL:  "git@github.com:steveyegge/gastown.git",
-				AddedAt: time.Now().Truncate(time.Second),
+				GitURL:    "git@github.com:steveyegge/gastown.git",
+				LocalRepo: "/tmp/local-repo",
+				AddedAt:   time.Now().Truncate(time.Second),
 				BeadsConfig: &BeadsConfig{
 					Repo:   "local",
 					Prefix: "gt-",
@@ -73,6 +74,9 @@ func TestRigsConfigRoundTrip(t *testing.T) {
 	}
 	if rig.BeadsConfig == nil || rig.BeadsConfig.Prefix != "gt-" {
 		t.Errorf("BeadsConfig.Prefix = %v, want 'gt-'", rig.BeadsConfig)
+	}
+	if rig.LocalRepo != "/tmp/local-repo" {
+		t.Errorf("LocalRepo = %q, want %q", rig.LocalRepo, "/tmp/local-repo")
 	}
 }
 
@@ -140,6 +144,7 @@ func TestRigConfigRoundTrip(t *testing.T) {
 	original := NewRigConfig("gastown", "git@github.com:test/gastown.git")
 	original.CreatedAt = time.Now().Truncate(time.Second)
 	original.Beads = &BeadsConfig{Prefix: "gt-"}
+	original.LocalRepo = "/tmp/local-repo"
 
 	if err := SaveRigConfig(path, original); err != nil {
 		t.Fatalf("SaveRigConfig: %v", err)
@@ -161,6 +166,9 @@ func TestRigConfigRoundTrip(t *testing.T) {
 	}
 	if loaded.GitURL != "git@github.com:test/gastown.git" {
 		t.Errorf("GitURL = %q, want expected URL", loaded.GitURL)
+	}
+	if loaded.LocalRepo != "/tmp/local-repo" {
+		t.Errorf("LocalRepo = %q, want %q", loaded.LocalRepo, "/tmp/local-repo")
 	}
 	if loaded.Beads == nil || loaded.Beads.Prefix != "gt-" {
 		t.Error("Beads.Prefix not preserved")

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -54,6 +54,7 @@ type RigsConfig struct {
 // RigEntry represents a single rig in the registry.
 type RigEntry struct {
 	GitURL      string       `json:"git_url"`
+	LocalRepo   string       `json:"local_repo,omitempty"`
 	AddedAt     time.Time    `json:"added_at"`
 	BeadsConfig *BeadsConfig `json:"beads,omitempty"`
 }
@@ -92,6 +93,7 @@ type RigConfig struct {
 	Version   int          `json:"version"`    // schema version
 	Name      string       `json:"name"`       // rig name
 	GitURL    string       `json:"git_url"`    // git repository URL
+	LocalRepo string       `json:"local_repo,omitempty"`
 	CreatedAt time.Time    `json:"created_at"` // when the rig was created
 	Beads     *BeadsConfig `json:"beads,omitempty"`
 }

--- a/internal/crew/manager.go
+++ b/internal/crew/manager.go
@@ -72,8 +72,17 @@ func (m *Manager) Add(name string, createBranch bool) (*CrewWorker, error) {
 	}
 
 	// Clone the rig repo
-	if err := m.git.Clone(m.rig.GitURL, crewPath); err != nil {
-		return nil, fmt.Errorf("cloning rig: %w", err)
+	if m.rig.LocalRepo != "" {
+		if err := m.git.CloneWithReference(m.rig.GitURL, crewPath, m.rig.LocalRepo); err != nil {
+			fmt.Printf("Warning: could not clone with local repo reference: %v\n", err)
+			if err := m.git.Clone(m.rig.GitURL, crewPath); err != nil {
+				return nil, fmt.Errorf("cloning rig: %w", err)
+			}
+		}
+	} else {
+		if err := m.git.Clone(m.rig.GitURL, crewPath); err != nil {
+			return nil, fmt.Errorf("cloning rig: %w", err)
+		}
 	}
 
 	crewGit := git.NewGit(crewPath)

--- a/internal/rig/types.go
+++ b/internal/rig/types.go
@@ -16,6 +16,9 @@ type Rig struct {
 	// GitURL is the remote repository URL.
 	GitURL string `json:"git_url"`
 
+	// LocalRepo is an optional local repository used for reference clones.
+	LocalRepo string `json:"local_repo,omitempty"`
+
 	// Config is the rig-level configuration.
 	Config *config.BeadsConfig `json:"config,omitempty"`
 


### PR DESCRIPTION
## Summary
- add `--local-repo` to `gt rig add` and persist it in rig config
- use git reference clones for rigs and crew when a local repo is provided
- add tests covering reference clone behavior and config round-trips

## Test plan
- [x] go test -v -race -short ./...

🤖 Generated with [Claude Code](https://claude.com/claude-code)