### PR TITLE
fix(sling): add --no-daemon flag to mol bond command

### DIFF
--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -403,7 +403,8 @@ func runSling(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%s Formula wisp created: %s\n", style.Bold.Render("✓"), wispRootID)
 
 		// Step 3: Bond wisp to original bead (creates compound)
-		bondArgs := []string{"mol", "bond", wispRootID, beadID, "--json"}
+		// Use --no-daemon for mol bond (requires direct database access)
+		bondArgs := []string{"--no-daemon", "mol", "bond", wispRootID, beadID, "--json"}
 		bondCmd := exec.Command("bd", bondArgs...)
 		bondCmd.Stderr = os.Stderr
 		bondOut, err := bondCmd.Output()


### PR DESCRIPTION
the bigger question is whats up w the deacon, i cant seem to get it to boot up reliably

## Summary
Fixes `gt sling` failures when using `--quality=shiny` by adding `--no-daemon` flag to the `bd mol bond` command.

## Problem
When using `gt sling <convoy> <rig> --quality=shiny`, the command was failing with:
```
Error: mol bond requires direct database access
Hint: use --no-daemon flag: bd --no-daemon mol bond ...
Error: bonding formula to bead: exit status 1
```

This blocked all polecat dispatch with workflow molecules, breaking the convoy system.

## Root Cause
The `bd mol bond` command in `internal/cmd/sling.go:407` wasn't passing the `--no-daemon` flag. When the beads daemon is slow to start (>5s) or unavailable, mol bond operations require direct database access.

## Solution
Added `--no-daemon` to the bond command invocation at `sling.go:407`:

```go
bondArgs := []string{"--no-daemon", "mol", "bond", wispRootID, beadID, "--json"}
```

This pattern is already used elsewhere in the codebase for operations requiring direct DB access (see `patrol_helpers.go`, `doctor/wisp_check.go`).

## Testing
- Built and installed locally (`make install`)
- All tests pass except pre-existing `internal/beads` test failure (unrelated DB sync issue)
- Fix follows established pattern used in other mol operations

## Impact
- Unblocks polecat dispatch with quality levels (basic/shiny/chrome)
- Fixes convoy workflow for all rigs
- Resolves tsunesaburo's 3 stuck convoys (gm-5f5i, gm-4cbn, gm-csx2)

Fixes gt--4hz

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>