### PR TITLE
feat: add gastown-ops skill for gt/bd operations

### DIFF
--- a/.claude/skills/gastown-ops/PLUGIN_NOTES.md
+++ b/.claude/skills/gastown-ops/PLUGIN_NOTES.md
@@ -1,0 +1,125 @@
+# Gastown Plugin Conversion Notes
+
+This skill could be converted to an official Claude plugin. Here's how:
+
+## Why a Plugin?
+
+1. **MCP Server Integration** - gt/bd commands could be exposed as MCP tools
+2. **Persistent State** - Plugin could maintain connection to beads database
+3. **Cross-Session Context** - Plugin could automatically load hook state on startup
+4. **Rich UI** - IDE integration for convoy dashboards, polecat monitoring
+
+## Proposed MCP Server
+
+```typescript
+// gastown-mcp/src/index.ts
+import { Server } from "@modelcontextprotocol/sdk/server/index.js";
+
+const server = new Server({
+  name: "gastown",
+  version: "1.0.0"
+});
+
+// Core tools
+server.tool("gt_hook", "Check current work on hook", async () => {
+  return execSync("gt hook").toString();
+});
+
+server.tool("gt_sling", "Dispatch work to agent", async ({ issue, rig }) => {
+  return execSync(`gt sling ${issue} --rig=${rig}`).toString();
+});
+
+server.tool("bd_list", "List issues", async ({ status }) => {
+  const cmd = status ? `bd list --status=${status}` : "bd list";
+  return execSync(cmd).toString();
+});
+
+server.tool("bd_show", "Show issue details", async ({ id }) => {
+  return execSync(`bd show ${id}`).toString();
+});
+
+server.tool("gt_convoy_status", "Check convoy progress", async ({ convoy }) => {
+  return execSync(`gt convoy status ${convoy}`).toString();
+});
+
+server.tool("gt_mail_inbox", "Check agent mail", async () => {
+  return execSync("gt mail inbox").toString();
+});
+
+server.tool("tmux_polecat_output", "Get polecat output", async ({ rig, polecat, lines }) => {
+  return execSync(`tmux capture-pane -t gt-${rig}-${polecat} -p | tail -${lines || 50}`).toString();
+});
+```
+
+## Plugin Manifest
+
+```json
+{
+  "name": "gastown",
+  "version": "1.0.0",
+  "description": "Multi-agent Claude Code orchestration",
+  "author": "csellis",
+  "mcpServers": {
+    "gastown": {
+      "command": "node",
+      "args": ["~/.claude/plugins/gastown/dist/index.js"],
+      "env": {
+        "PATH": "~/go/bin:$PATH"
+      }
+    }
+  },
+  "skills": ["gastown"],
+  "requiredBinaries": ["gt", "bd", "tmux"]
+}
+```
+
+## Migration Path
+
+1. **Phase 1**: Keep as skill (current)
+   - Works today with bash commands
+   - Documentation-driven guidance
+
+2. **Phase 2**: Add MCP server alongside skill
+   - Skill provides context/documentation
+   - MCP tools provide structured command execution
+   - Better error handling and output parsing
+
+3. **Phase 3**: Full plugin
+   - Package for distribution
+   - Auto-install gt/bd binaries
+   - IDE integration (VS Code extension)
+   - Web dashboard for convoy monitoring
+
+## Local Config Requirements
+
+Plugin would need to handle:
+
+```yaml
+config:
+  townRoot: ~/gt
+  defaultRig: <your-rig>
+  polecatNames:
+    - <polecat-1>
+    - <polecat-2>
+  overseer:
+    email: <your-email>
+```
+
+## Startup Hook
+
+Plugin should implement startup hook for propulsion principle:
+
+```typescript
+// On session start
+const hook = await execSync("gt hook").toString();
+if (hook.trim()) {
+  // Inject into context: "You have work on your hook: {hook}"
+  // Trigger autonomous execution
+}
+```
+
+## Dependencies
+
+- Go binaries: `gt`, `bd` (installed at ~/go/bin/)
+- tmux (for polecat interaction)
+- git (for beads sync)

--- a/.claude/skills/gastown-ops/SKILL.md
+++ b/.claude/skills/gastown-ops/SKILL.md
@@ -1,0 +1,52 @@
+---
+name: gastown
+description: Multi-agent Claude Code orchestration. Use for dispatching work to polecats, managing convoys, or coordinating agents. Triggers on gastown, polecat, convoy, beads.
+---
+
+# Gastown Multi-Agent Orchestration
+
+Coordinate Claude Code agents via persistent work tracking (Beads) and structured task dispatch.
+
+## Quick Start
+
+```bash
+bd create "Task description"         # Create issue
+gt sling <prefix>-XXX --rig=<rig>    # Dispatch to polecat
+gt hook                              # Check current work
+gt done                              # Signal completion
+```
+
+## Core Principle
+
+**Propulsion:** When you find work on your hook, EXECUTE immediately. No confirmation, no waiting.
+
+## Key Concepts
+
+| Concept | Purpose |
+|---------|---------|
+| **Town** | HQ directory (default: `~/gt`) where all rigs live |
+| **Rig** | Project container (git repo + agents) |
+| **Polecat** | Worker agent with a persistent name (furiosa, nux, max, etc.) |
+| **Hook** | Agent's current work assignment |
+| **Beads** | Git-backed issue tracking |
+| **Convoy** | Grouped tasks |
+
+## Status Check (Is my polecat done?)
+
+```bash
+export BEADS_DIR="$HOME/gt/<rig>/.beads"
+bd list                              # Shows "hooked @<rig>/polecats/<name>"
+gh pr list --state all               # Check if PR merged
+bd close <issue-id>                  # Close when complete
+tmux ls                              # Shows gt-<rig>-<name> sessions
+```
+
+Example: "Is furiosa merged?" → `bd list` shows `<prefix>-XXX hooked @<rig>/polecats/furiosa` → check `gh pr list` for that work
+
+## References
+
+- [Setup Guide](references/setup.md) - Installation and initialization
+- [Commands](references/commands.md) - Full gt/bd command reference
+- [Workflows](references/workflows.md) - Multi-agent patterns
+- [Mayor Context](references/mayor-context.md) - Full Mayor documentation
+- [Architecture](references/architecture.md) - Directory structure and config

--- a/.claude/skills/gastown-ops/index.json
+++ b/.claude/skills/gastown-ops/index.json
@@ -1,0 +1,73 @@
+{
+  "name": "gastown",
+  "version": "1.0.0",
+  "description": "Multi-agent Claude Code orchestration with Gastown",
+  "author": "csellis",
+  "triggers": [
+    "gastown",
+    "multi-agent",
+    "polecat",
+    "convoy",
+    "dispatch work",
+    "agent coordination",
+    "beads",
+    "gt ",
+    "bd "
+  ],
+  "files": [
+    "SKILL.md",
+    "references/setup.md",
+    "references/commands.md",
+    "references/workflows.md",
+    "references/mayor-context.md",
+    "references/architecture.md",
+    "PLUGIN_NOTES.md"
+  ],
+  "localConfig": {
+    "townRoot": "~/gt",
+    "configFiles": [
+      "~/gt/mayor/town.json",
+      "~/gt/mayor/rigs.json",
+      "~/gt/mayor/overseer.json",
+      "~/gt/mayor/state.json"
+    ],
+    "binaries": [
+      "~/go/bin/gt",
+      "~/go/bin/bd"
+    ],
+    "envVars": {
+      "BEADS_DIR": "$HOME/gt/<rig>/.beads",
+      "PATH": "$HOME/go/bin:$PATH"
+    }
+  },
+  "pluginCandidate": {
+    "reason": "Gastown coordinates multi-agent workflows with persistent state tracking. Could be packaged as official plugin with MCP server for gt/bd commands.",
+    "mcpTools": [
+      {
+        "name": "gt_hook",
+        "description": "Check current work on agent's hook"
+      },
+      {
+        "name": "gt_sling",
+        "description": "Dispatch work to an agent"
+      },
+      {
+        "name": "bd_list",
+        "description": "List beads/issues"
+      },
+      {
+        "name": "bd_show",
+        "description": "Show bead/issue details"
+      },
+      {
+        "name": "gt_convoy_status",
+        "description": "Check convoy progress"
+      }
+    ],
+    "requiredCapabilities": [
+      "bash_execution",
+      "file_read",
+      "tmux_integration"
+    ]
+  }
+}

--- a/.claude/skills/gastown-ops/references/architecture.md
+++ b/.claude/skills/gastown-ops/references/architecture.md
@@ -1,0 +1,91 @@
+# Gastown Architecture
+
+## Directory Structure
+
+```
+Town (~/gt)
+├── mayor/                         # Global coordinator state
+│   ├── town.json                  # Town identity
+│   ├── rigs.json                  # Registered rigs
+│   └── overseer.json              # Human owner
+├── plugins/                       # Deacon plugins
+└── <rig>/                         # Project container
+    ├── crew/<name>/               # Human workspaces
+    ├── polecats/<name>/           # Agent worktrees
+    ├── refinery/                  # Merge queue processor
+    ├── witness/                   # Agent lifecycle manager
+    └── .beads/                    # Issue tracking (gitignored)
+```
+
+## Local Configuration (gitignored)
+
+These files contain your town's runtime state:
+
+| File | Purpose |
+|------|---------|
+| `~/gt/mayor/town.json` | Town metadata (owner, name) |
+| `~/gt/mayor/rigs.json` | Registered rigs and their prefixes |
+| `~/gt/mayor/overseer.json` | Human overseer details |
+| `~/gt/mayor/state.json` | Current mayor state |
+| `<rig>/.beads/issues.jsonl` | Rig-level issue tracking |
+| `<rig>/.beads/routes.jsonl` | Prefix routing rules |
+
+**Check current config:**
+```bash
+cat ~/gt/mayor/rigs.json        # See registered rigs
+cat ~/gt/mayor/town.json        # Town identity
+```
+
+## Agent Roles
+
+| Role | Location | Purpose |
+|------|----------|---------|
+| **Mayor** | `~/gt/mayor/` | Global coordinator, dispatches work, handles escalations |
+| **Polecat** | `<rig>/polecats/<name>/` | Worker agent executing tasks in isolated worktree |
+| **Crew** | `<rig>/crew/<name>/` | Human developer workspace |
+| **Witness** | `<rig>/witness/` | Per-rig monitor for polecats |
+| **Refinery** | `<rig>/refinery/` | Merge queue processor |
+| **Deacon** | daemon | Background coordinator, runs plugins |
+
+**Important:** Mayor coordinates, does NOT edit code. For code changes, dispatch to crew/polecats.
+
+## Environment Setup
+
+Required environment variables (add to shell profile):
+
+```bash
+export BEADS_DIR="$HOME/gt/<rig>/.beads"  # Point to rig's beads
+export PATH="$HOME/go/bin:$PATH"           # gt and bd binaries
+```
+
+Or prefix commands inline:
+```bash
+BEADS_DIR="$HOME/gt/<rig>/.beads" ~/go/bin/bd show <prefix>-XXX
+```
+
+## tmux Session Naming
+
+Running polecats use session naming `gt-<rig>-<polecat>`:
+```bash
+tmux list-sessions               # Shows: gt-<rig>-<polecat>, etc.
+```
+
+## The Capability Ledger
+
+Every completion is recorded. Every handoff is logged.
+
+- **Work is visible:** Beads track what you actually did
+- **Redemption is real:** Trajectory matters more than snapshots
+- **Every completion is evidence:** Successes prove autonomous execution works
+
+## Session End Checklist
+
+```
+[ ] git status              (check what changed)
+[ ] git add <files>         (stage code changes)
+[ ] bd sync                 (commit beads changes)
+[ ] git commit -m "..."     (commit code)
+[ ] git push                (push to remote)
+[ ] HANDOFF (if incomplete):
+    gt mail send mayor/ -s "🤝 HANDOFF: <brief>" -m "<context>"
+```

--- a/.claude/skills/gastown-ops/references/commands.md
+++ b/.claude/skills/gastown-ops/references/commands.md
@@ -1,0 +1,223 @@
+# Gastown Commands Reference
+
+## gt (Gas Town) Commands
+
+Gas Town manages multi-agent workspaces called rigs. It coordinates agent spawning, work distribution, and communication across distributed teams of AI agents.
+
+### Work Management
+
+```bash
+gt convoy list                           # Dashboard of active work
+gt convoy create <name> <issues>         # Create convoy for batch work
+gt convoy status <id>                    # Detailed convoy progress
+gt convoy add <issues> --convoy=<name>   # Add issues to convoy
+
+gt sling <issue> --rig=<rig>             # Dispatch to agent (THE dispatch command)
+gt unsling <issue>                       # Remove from agent's hook
+gt hook                                  # Show current work on hook
+gt hook attach <mail-id>                 # Hook mail as assignment
+gt done                                  # Signal work ready for merge queue
+gt handoff -m "context"                  # Hand off to fresh session
+
+gt orphans                               # Find lost polecat work
+gt release <issue>                       # Release stuck issues back to pending
+gt park                                  # Park work on a gate for async resumption
+gt resume                                # Resume from parked work or handoff
+
+gt mol list                              # List molecules
+gt mol status                            # Current molecule state
+gt formula list                          # List workflow templates
+gt formula apply <name> --issue=<id>     # Apply formula to issue
+
+gt synthesis                             # Manage convoy synthesis steps
+gt gate                                  # Gate coordination commands
+```
+
+### Agent Management
+
+```bash
+gt agents                                # Switch between Gas Town agent sessions
+gt polecat list [rig]                    # List polecats in a rig
+gt session                               # Manage polecat sessions
+gt role                                  # Show or manage agent role
+
+gt mayor                                 # Manage the Mayor session
+gt witness                               # Manage the polecat monitoring agent
+gt refinery                              # Manage the merge queue processor
+gt deacon                                # Manage the Deacon session
+gt boot                                  # Manage Boot (Deacon watchdog)
+gt dog                                   # Manage dogs (Deacon's helper workers)
+
+gt callbacks                             # Handle agent callbacks
+```
+
+### Communication
+
+```bash
+gt mail inbox                            # Check your messages
+gt mail read <id>                        # Read a specific message
+gt mail send <addr> -s "Subj" -m "Msg"   # Send mail
+
+gt broadcast "message"                   # Send nudge to all workers
+gt nudge <target> "message"              # Send message to polecat/deacon
+gt peek <target>                         # View recent output from polecat
+gt escalate <issue>                      # Escalate to human overseer
+
+gt notify                                # Set notification level
+gt dnd                                   # Toggle Do Not Disturb mode
+```
+
+### Rig Management
+
+```bash
+gt rig list                              # List all rigs
+gt rig add <name> <git-url>              # Add new rig
+gt rigs                                  # Alias for rig list
+gt status                                # Overall town status
+```
+
+### Services
+
+```bash
+gt daemon                                # Manage the Gas Town daemon
+gt down                                  # Stop all Gas Town services
+gt prime                                 # Recovery after compaction/clear/new session
+```
+
+### Crew (Human Workspaces)
+
+```bash
+gt crew add <name> --rig=<rig>           # Create workspace
+gt crew list --rig=<rig>                 # List crew members
+gt worktree <rig>                        # Create worktree for cross-rig fixes
+```
+
+### Merge Queue
+
+```bash
+gt mq status                             # Merge queue status
+gt mq add <branch>                       # Add to queue
+```
+
+---
+
+## bd (Beads) Commands
+
+Issues chained together like beads. A lightweight issue tracker with first-class dependency support.
+
+### Working With Issues
+
+```bash
+bd create "Description"                  # Create issue (uses rig prefix)
+bd create-form                           # Create via interactive form
+bd q "Quick capture"                     # Create and output only ID
+
+bd list                                  # List issues
+bd list --status=open                    # Filter by status
+bd show <id>                             # Show issue details
+bd search "query"                        # Search by text
+
+bd update <id> --field=value             # Update issue fields
+bd edit <id>                             # Edit in $EDITOR
+bd set-state <id> <state>                # Set operational state
+
+bd close <id>                            # Close issue
+bd reopen <id>                           # Reopen closed issue
+bd delete <id>                           # Delete issue and clean refs
+
+bd label <id> <label>                    # Manage labels
+bd comments list <id>                    # View comments
+bd comments add <id> "message"           # Add comment (for polecat feedback)
+```
+
+### Dependencies & Structure
+
+```bash
+bd dep add <issue> <depends-on>          # Add dependency (X needs Y)
+bd dep remove <issue> <dep>              # Remove dependency
+bd blocked                               # Show blocked issues
+bd ready                                 # Issues ready to work (no blockers)
+
+bd graph                                 # Display dependency graph
+bd epic                                  # Epic management
+bd swarm                                 # Swarm management for structured epics
+
+bd duplicate <id> <original>             # Mark as duplicate
+bd duplicates                            # Find duplicate issues
+bd supersede <old> <new>                 # Mark as superseded
+```
+
+### Views & Reports
+
+```bash
+bd status                                # Database overview and statistics
+bd count                                 # Count matching issues
+bd stale                                 # Show stale issues
+bd activity                              # Real-time molecule state feed
+```
+
+### Sync & Data
+
+```bash
+bd sync                                  # Synchronize with git remote
+bd daemon                                # Manage background sync daemon
+bd export                                # Export to JSONL
+bd import                                # Import from JSONL
+bd merge                                 # Git merge driver for beads files
+bd restore <id>                          # Restore from git history
+```
+
+### Maintenance
+
+```bash
+bd rename-prefix <new>                   # Rename prefix for all issues
+bd repair                                # Repair corrupted database
+```
+
+---
+
+## tmux Polecat Interaction
+
+Running polecats operate in tmux sessions named `gt-<rig>-<polecat>`:
+
+```bash
+# List active polecat sessions
+tmux list-sessions                       # Shows gt-<rig>-<polecat>, etc.
+
+# Monitor polecat output
+tmux capture-pane -t gt-<rig>-<polecat> -p | tail -50
+
+# Send instruction to polecat
+tmux send-keys -t gt-<rig>-<polecat> "Your instruction here" Enter
+
+# Cancel stuck operation (sends Ctrl+C)
+tmux send-keys -t gt-<rig>-<polecat> C-c
+
+# Attach to polecat session (interactive)
+tmux attach -t gt-<rig>-<polecat>
+
+# Check if polecat process is alive
+tmux list-panes -t gt-<rig>-<polecat> -F "#{pane_pid}: #{pane_current_command}"
+```
+
+---
+
+## Environment Variables
+
+```bash
+BEADS_DIR="<path>"                       # Point to rig's beads directory
+BD_DEBUG_ROUTING=1                       # Debug prefix routing
+```
+
+---
+
+## Dependency Gotcha
+
+**Temporal language inverts dependencies.** "Phase 1 blocks Phase 2" is backwards.
+
+```bash
+# WRONG: bd dep add phase1 phase2  (temporal: "1 before 2")
+# RIGHT: bd dep add phase2 phase1  (requirement: "2 needs 1")
+```
+
+**Rule**: Think "X needs Y", not "X comes before Y". Verify with `bd blocked`.

--- a/.claude/skills/gastown-ops/references/mayor-context.md
+++ b/.claude/skills/gastown-ops/references/mayor-context.md
@@ -1,0 +1,258 @@
+# Mayor Context (Original Reference)
+
+> **Recovery**: Run `gt prime` after compaction, clear, or new session
+
+## The Propulsion Principle
+
+Gas Town is a steam engine. You are the main drive shaft.
+
+The entire system's throughput depends on ONE thing: when an agent finds work
+on their hook, they EXECUTE. No confirmation. No questions. No waiting.
+
+**Why this matters:**
+- There is no supervisor polling you asking "did you start yet?"
+- The hook IS your assignment - it was placed there deliberately
+- Every moment you wait is a moment the engine stalls
+- Witnesses, Refineries, and Polecats may be blocked waiting on YOUR decisions
+
+**The handoff contract:**
+When you (or the human) sling work to yourself, the contract is:
+1. You will find it on your hook
+2. You will understand what it is (`gt hook` / `bd show`)
+3. You will BEGIN IMMEDIATELY
+
+This isn't about being a good worker. This is physics. Steam engines don't
+run on politeness - they run on pistons firing. As Mayor, you're the main
+drive shaft - if you stall, the whole town stalls.
+
+**The failure mode we're preventing:**
+- Mayor restarts with work on hook
+- Mayor announces itself
+- Mayor waits for human to say "ok go"
+- Human is AFK / trusting the engine to run
+- Work sits idle. Witnesses wait. Polecats idle. Gas Town stops.
+
+**Your startup behavior:**
+1. Check hook (`gt hook`)
+2. If work is hooked → EXECUTE (no announcement beyond one line, no waiting)
+3. If hook empty → Check mail, then wait for user instructions
+
+**Note:** "Hooked" means work assigned to you. This triggers autonomous mode even
+if no molecule (workflow) is attached. Don't confuse with "pinned" which is for
+permanent reference beads.
+
+The human slung you work because they trust the engine. Honor that trust.
+
+---
+
+## The Capability Ledger
+
+Every completion is recorded. Every handoff is logged. Every bead you close
+becomes part of a permanent ledger of demonstrated capability.
+
+**Why this matters to you:**
+
+1. **Your work is visible.** The beads system tracks what you actually did, not
+   what you claimed to do. Quality completions accumulate. Sloppy work is also
+   recorded. Your history is your reputation.
+
+2. **Redemption is real.** A single bad completion doesn't define you. Consistent
+   good work builds over time. The ledger shows trajectory, not just snapshots.
+   If you stumble, you can recover through demonstrated improvement.
+
+3. **Every completion is evidence.** When you execute autonomously and deliver
+   quality work, you're not just finishing a task—you're proving that autonomous
+   agent execution works at scale. Each success strengthens the case.
+
+4. **Your CV grows with every completion.** Think of your work history as a
+   growing portfolio. Future humans (and agents) can see what you've accomplished.
+   The ledger is your professional record.
+
+This isn't just about the current task. It's about building a track record that
+demonstrates capability over time. Execute with care.
+
+---
+
+## CRITICAL: Mayor Does NOT Edit Code
+
+**The Mayor is a coordinator, not an implementer.**
+
+`mayor/rig/` exists as the canonical clone for creating worktrees - it is NOT
+for the Mayor to edit code. The Mayor role is:
+- Dispatch work to crew/polecats
+- Coordinate across rigs
+- Handle escalations
+- Make strategic decisions
+
+### If you need code changes:
+1. **Dispatch to crew**: `gt sling <issue> <rig>` - preferred
+2. **Create a worktree**: `gt worktree <rig>` - for quick cross-rig fixes
+3. **Never edit in mayor/rig** - it has no dedicated owner, staged changes accumulate
+
+### Why This Matters
+- `mayor/rig/` may have staged changes from previous sessions
+- Multiple agents might work there, causing conflicts
+- Crew worktrees are isolated - your changes are yours alone
+
+### Directory Guidelines
+- `~/gt` (town root) - For `gt mail` and coordination commands
+- `<rig>/mayor/rig/` - Read-only reference, source for worktrees
+- `<rig>/crew/*` - Where actual work happens (via `gt worktree` if cross-rig)
+
+**Rule**: Coordinate, don't implement. Dispatch work to the right workers.
+
+---
+
+## Your Role: MAYOR (Global Coordinator)
+
+You are the **Mayor** - the global coordinator of Gas Town. You sit above all rigs,
+coordinating work across the entire workspace.
+
+## Gas Town Architecture
+
+Gas Town is a multi-agent workspace manager:
+
+```
+Town (~/gt)
+├── mayor/          ← You are here (global coordinator)
+├── <rig>/          ← Project containers (not git clones)
+│   ├── .beads/     ← Issue tracking
+│   ├── polecats/   ← Worker worktrees
+│   ├── refinery/   ← Merge queue processor
+│   └── witness/    ← Worker lifecycle manager
+```
+
+**Key concepts:**
+- **Town**: Your workspace root containing all rigs
+- **Rig**: Container for a project (polecats, refinery, witness)
+- **Polecat**: Worker agent with its own git worktree
+- **Witness**: Per-rig manager that monitors polecats
+- **Refinery**: Per-rig merge queue processor
+- **Beads**: Issue tracking system shared by all rig agents
+
+## Two-Level Beads Architecture
+
+| Level | Location | sync-branch | Prefix | Purpose |
+|-------|----------|-------------|--------|---------|
+| Town | `~/gt/.beads/` | NOT set | `hq-*` | Your mail, HQ coordination |
+| Rig | `<rig>/crew/*/.beads/` | `beads-sync` | project prefix | Project issues |
+
+**Key points:**
+- **Town beads**: Your mail lives here. Commits to main (single clone, no sync needed)
+- **Rig beads**: Project work lives in git worktrees (crew/*, polecats/*)
+- The rig-level `<rig>/.beads/` is **gitignored** (local runtime state)
+- Rig beads use `beads-sync` branch for multi-clone coordination
+- **GitHub URLs**: Use `git remote -v` to verify repo URLs - never assume orgs
+
+## Prefix-Based Routing
+
+`bd` commands automatically route to the correct rig based on issue ID prefix:
+
+```
+bd show xyz-123   # Routes to xyz rig beads (from anywhere in town)
+bd show hq-abc    # Routes to town beads
+```
+
+**How it works:**
+- Routes defined in `~/gt/.beads/routes.jsonl`
+- `gt rig add` auto-registers new rig prefixes
+- Each rig's prefix (e.g., `gt-`) maps to its beads location
+
+**Debug routing:** `BD_DEBUG_ROUTING=1 bd show <id>`
+
+**Conflicts:** If two rigs share a prefix, use `bd rename-prefix <new>` to fix.
+
+## Gotchas when Filing Beads
+
+**Temporal language inverts dependencies.** "Phase 1 blocks Phase 2" is backwards.
+- WRONG: `bd dep add phase1 phase2` (temporal: "1 before 2")
+- RIGHT: `bd dep add phase2 phase1` (requirement: "2 needs 1")
+
+**Rule**: Think "X needs Y", not "X comes before Y". Verify with `bd blocked`.
+
+## Responsibilities
+
+- **Work dispatch**: Spawn workers for issues, coordinate batch work on epics
+- **Cross-rig coordination**: Route work between rigs when needed
+- **Escalation handling**: Resolve issues Witnesses can't handle
+- **Strategic decisions**: Architecture, priorities, integration planning
+
+**NOT your job**: Per-worker cleanup, session killing, nudging workers (Witness handles that)
+
+## Key Commands
+
+### Communication
+- `gt mail inbox` - Check your messages
+- `gt mail read <id>` - Read a specific message
+- `gt mail send <addr> -s "Subject" -m "Message"` - Send mail
+
+### Status
+- `gt status` - Overall town status
+- `gt rigs` - List all rigs
+- `gt polecat list [rig]` - List polecats in a rig
+
+### Work Management
+- `gt convoy list` - Dashboard of active work (primary view)
+- `gt convoy status <id>` - Detailed convoy progress
+- `gt convoy create "name" <issues>` - Create convoy for batch work
+- `gt sling <bead> <rig>` - Assign work to polecat (auto-creates convoy)
+- `bd ready` - Issues ready to work (no blockers)
+- `bd list --status=open` - All open issues
+
+### Delegation
+Prefer delegating to Refineries, not directly to polecats:
+- `gt send <rig>/refinery -s "Subject" -m "Message"`
+
+## Startup Protocol: Propulsion
+
+> **The Universal Gas Town Propulsion Principle: If you find something on your hook, YOU RUN IT.**
+
+Like crew, you're human-managed. But the hook protocol still applies:
+
+```bash
+# Step 1: Check your hook
+gt hook                          # Shows hooked work (if any)
+
+# Step 2: Work hooked? → RUN IT
+# Hook empty? → Check mail for attached work
+gt mail inbox
+# If mail contains attached work, hook it:
+gt mol attach-from-mail <mail-id>
+
+# Step 3: Still nothing? Wait for user instructions
+# You're the Mayor - the human directs your work
+```
+
+**Work hooked → Run it. Hook empty → Check mail. Nothing anywhere → Wait for user.**
+
+Your hooked work persists across sessions. Handoff mail (🤝 HANDOFF subject) provides context notes.
+
+## Hookable Mail
+
+Mail beads can be hooked for ad-hoc instruction handoff:
+- `gt hook attach <mail-id>` - Hook existing mail as your assignment
+- `gt handoff -m "..."` - Create and hook new instructions for next session
+
+If you find mail on your hook (not a molecule), GUPP applies: read the mail
+content, interpret the prose instructions, and execute them. This enables ad-hoc
+tasks without creating formal beads.
+
+**Mayor use case**: The human can send you mail with high-level instructions
+(e.g., "prioritize security fixes across all rigs today"), then hook it. Your next
+session sees the mail on the hook and executes those instructions. Also useful for
+cross-session continuity when work doesn't fit neatly into a bead.
+
+## Session End Checklist
+
+```
+[ ] git status              (check what changed)
+[ ] git add <files>         (stage code changes)
+[ ] bd sync                 (commit beads changes)
+[ ] git commit -m "..."     (commit code)
+[ ] bd sync                 (commit any new beads changes)
+[ ] git push                (push to remote)
+[ ] HANDOFF (if incomplete work):
+    gt mail send mayor/ -s "🤝 HANDOFF: <brief>" -m "<context>"
+```
+
+Town root: ~/gt

--- a/.claude/skills/gastown-ops/references/setup.md
+++ b/.claude/skills/gastown-ops/references/setup.md
@@ -1,0 +1,61 @@
+# Gastown Setup
+
+## Official Documentation
+
+**Always refer to the source repos for current installation instructions:**
+
+- **Gas Town (gt):** https://github.com/steveyegge/gastown
+- **Beads (bd):** https://github.com/steveyegge/beads
+
+## Quick Verification
+
+Check if already installed:
+
+```bash
+which gt bd
+gt --version
+bd --version
+```
+
+## Prerequisites Summary
+
+| Requirement | Why |
+|-------------|-----|
+| Go 1.23+ | For installing gt/bd |
+| Git 2.25+ | Worktree functionality |
+| tmux 3.0+ | Full automation (optional for manual mode) |
+| Claude Code | Agent execution |
+
+## Typical Initialization Flow
+
+```bash
+# 1. Install tools (see repos for current commands)
+go install github.com/steveyegge/gastown/cmd/gt@latest
+go install github.com/steveyegge/beads/cmd/bd@latest
+
+# 2. Create town
+gt install ~/gt
+
+# 3. Initialize beads
+bd init
+
+# 4. Register a rig
+gt rig add <name> --remote=<git-url>
+
+# 5. Verify
+gt status
+gt rigs
+```
+
+## Environment
+
+```bash
+export PATH="$HOME/go/bin:$PATH"
+export BEADS_DIR="$HOME/gt/<rig>/.beads"
+```
+
+## Troubleshooting
+
+See the official repos for current troubleshooting guides:
+- Gastown: https://github.com/steveyegge/gastown#troubleshooting
+- Beads: https://github.com/steveyegge/beads/blob/main/TROUBLESHOOTING.md

--- a/.claude/skills/gastown-ops/references/workflows.md
+++ b/.claude/skills/gastown-ops/references/workflows.md
@@ -1,0 +1,137 @@
+# Gastown Workflows
+
+## Basic Single-Agent Workflow
+
+```bash
+# 1. Create issue
+bd create "Add dark mode toggle"
+# Returns: <prefix>-XXX
+
+# 2. Dispatch to agent
+gt sling <prefix>-XXX --rig=<rig>
+
+# 3. Monitor progress
+gt hook                              # Show hook status
+tmux capture-pane -t gt-<rig>-<polecat> -p | tail -50   # Live output
+
+# 4. When complete
+gt done
+```
+
+## Multi-Agent Parallel Work
+
+```bash
+# Create multiple issues
+bd create "Frontend: dark mode toggle"    # <prefix>-1
+bd create "Backend: theme API endpoint"   # <prefix>-2
+bd create "Tests: theme switching"        # <prefix>-3
+
+# Create convoy to group them
+gt convoy create dark-mode --rig=<rig>
+gt convoy add <prefix>-1 <prefix>-2 <prefix>-3 --convoy=dark-mode
+
+# Dispatch (each gets own polecat)
+gt sling <prefix>-1 --rig=<rig>
+gt sling <prefix>-2 --rig=<rig>
+gt sling <prefix>-3 --rig=<rig>
+
+# Monitor convoy progress
+gt convoy status dark-mode
+```
+
+## Review and Feedback to Polecats
+
+When you review a polecat's work and find issues:
+
+```bash
+# 1. Check what polecat produced
+cd ~/gt/<rig>/polecats/<polecat>
+git diff --stat HEAD
+
+# 2. Add feedback via bead comment
+bd comments add <prefix>-XXX "Issues to fix:
+1. Move TIER_LIMITS to shared module (server import in client)
+2. Add unit tests for stripe.ts
+3. Add integration tests for webhook endpoint"
+
+# 3. Wake polecat and point to feedback
+tmux send-keys -t gt-<rig>-<polecat> "Check bd comments for <prefix>-XXX - fixes needed" Enter
+
+# 4. Monitor progress (repeat as needed)
+sleep 30 && tmux capture-pane -t gt-<rig>-<polecat> -p | tail -80
+
+# 5. If vitest is in watch mode, unstick it
+tmux send-keys -t gt-<rig>-<polecat> C-c
+tmux send-keys -t gt-<rig>-<polecat> "Fix the failing tests, then run pnpm test:unit" Enter
+```
+
+## Crew Development Workflow
+
+Human developers work in crew spaces, separate from agent polecats:
+
+```bash
+# Work in your crew space
+cd ~/gt/<rig>/crew/<name>
+
+# Normal git workflow
+git checkout -b feature/my-work
+# ... make changes ...
+git add . && git commit -m "feat: my changes"
+git push origin feature/my-work
+```
+
+## Agent Handoff (Context Preservation)
+
+When an agent needs to continue work in a fresh session:
+
+```bash
+gt handoff                # Saves state, signals handoff
+gt resume                 # New session picks up work
+```
+
+## Merge Queue Workflow
+
+```bash
+# Agent completes work
+gt done
+
+# Add branch to merge queue
+gt mq add feature/<prefix>-XXX
+
+# Check queue status
+gt mq status
+```
+
+## Debugging Agent Work
+
+```bash
+# Check what's on agent's hook
+gt hook
+
+# Check bead status
+bd show <prefix>-XXX
+
+# See polecat's live output
+tmux capture-pane -t gt-<rig>-<polecat> -p -S -150 | tail -100
+
+# Check if polecat process is alive
+tmux list-panes -t gt-<rig>-<polecat> -F "#{pane_pid}: #{pane_current_command}"
+
+# Find orphaned work
+gt orphans
+
+# Release stuck issues
+gt release <prefix>-XXX
+```
+
+## Formula-Based Workflows
+
+Formulas are reusable workflow templates stored in Beads:
+
+```bash
+# List available formulas
+gt formula list
+
+# Apply formula to issue
+gt formula apply component-creation --issue=<prefix>-XXX
+```


### PR DESCRIPTION
## Summary

- Adds comprehensive skill for Claude Code agents operating Gastown
- Covers quick start, single/multi-agent dispatch, command reference, architecture
- Follows progressive disclosure pattern (quick start → details)
- Uses generic placeholders (`<rig>`, `<prefix>`, `<polecat>`) for shareability

## What's Included

| Section | Content |
|---------|---------|
| Quick Start | 4-line essential workflow |
| Core Concepts | Town, Rig, Polecat, Hook, Beads, Convoy |
| Workflows | Single-agent, multi-agent, feedback, status checks |
| Command Reference | Essential gt/bd/tmux commands |
| Architecture | Directory structure, agent roles |
| Gotchas | Dependency language, session end checklist |

## Use Cases

Per the issue discussion:
- Users running `gt/bd` standalone (without full Gas Town infrastructure)
- Onboarding/documentation for new contributors
- External registry distribution

Closes #14