### PR TITLE
Fix agent bead ID parsing for hyphenated rig names

### DIFF
--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -1017,6 +1017,16 @@ func TestParseAgentBeadID(t *testing.T) {
 		{"gt-gastown-polecat-capable", "gastown", "polecat", "capable", true},
 		// Names with hyphens
 		{"gt-gastown-polecat-my-agent", "gastown", "polecat", "my-agent", true},
+		// Hyphenated rig names (GitHub issue #90)
+		{"ge-gastown-example-polecat-worker1", "gastown-example", "polecat", "worker1", true},
+		{"ge-gastown-example-witness", "gastown-example", "witness", "", true},
+		{"ge-gastown-example-refinery", "gastown-example", "refinery", "", true},
+		{"ge-gastown-example-crew-steve", "gastown-example", "crew", "steve", true},
+		{"mp-my-project-polecat-nux", "my-project", "polecat", "nux", true},
+		// Hyphenated rig AND hyphenated name
+		{"ge-my-cool-rig-polecat-my-agent-name", "my-cool-rig", "polecat", "my-agent-name", true},
+		// Multiple hyphens in rig name
+		{"xx-a-b-c-witness", "a-b-c", "witness", "", true},
 		// Parseable but not valid agent roles (IsAgentSessionBead will reject)
 		{"gt-abc123", "", "abc123", "", true}, // Parses as town-level but not valid role
 		// Other prefixes (bd-, hq-)


### PR DESCRIPTION
## Summary

Fixes #90

- Implements role-based parsing that scans from right to find known roles
- Supports hyphenated rig names like `gastown-example`
- Maintains backward compatibility with existing non-hyphenated rigs

## Problem

Agent bead IDs use hyphen-delimited format: `<prefix>-<rig>-<role>-<name>`

When a rig name contains hyphens (e.g., `gastown-example`), the previous parser couldn't determine where the rig name ends:

```
ge-gastown-example-polecat-worker1
```

Previous parser saw:
- prefix: `ge`
- rig: `gastown` (stopped at first hyphen)
- role: `example` (invalid!)

## Solution

Since roles are a known finite set (`polecat`, `crew`, `witness`, `refinery`, `mayor`, `deacon`, `dog`), scan from right to find the role:

1. `prefix` = first segment (before first hyphen)
2. Scan segments from right until a known role is found
3. `rig` = all segments between prefix and role, rejoined with hyphens
4. `name` = all segments after role, rejoined with hyphens

## Test plan

- [x] Added test cases for hyphenated rig names
- [x] All existing tests pass
- [x] Tested with `gastown-example`, `my-project`, multi-hyphen rigs

🤖 Generated with [Claude Code](https://claude.com/claude-code)