### PR TITLE
fix: create town role beads before agents

### DIFF
--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -424,12 +424,22 @@ func initTownAgentBeads(townPath string) error {
 		},
 	}
 
+	existingAgents, err := bd.List(beads.ListOptions{
+		Status:   "all",
+		Type:     "agent",
+		Priority: -1,
+	})
+	if err != nil {
+		return fmt.Errorf("listing existing agent beads: %w", err)
+	}
+	existingAgentIDs := make(map[string]struct{}, len(existingAgents))
+	for _, issue := range existingAgents {
+		existingAgentIDs[issue.ID] = struct{}{}
+	}
+
 	for _, agent := range agentDefs {
-		// Check if already exists (exact ID + agent type).
-		if issue, err := bd.Show(agent.id); err == nil {
-			if issue.ID == agent.id && issue.Type == "agent" {
-				continue
-			}
+		if _, ok := existingAgentIDs[agent.id]; ok {
+			continue
 		}
 
 		fields := &beads.AgentFields{

--- a/internal/cmd/install_integration_test.go
+++ b/internal/cmd/install_integration_test.go
@@ -342,9 +342,12 @@ func assertSlotValue(t *testing.T, townRoot, issueID, slot, want string) {
 	t.Helper()
 	cmd := exec.Command("bd", "--no-daemon", "--json", "slot", "show", issueID)
 	cmd.Dir = townRoot
-	output, err := cmd.CombinedOutput()
+	output, err := cmd.Output()
 	if err != nil {
-		t.Fatalf("bd slot show %s failed: %v\nOutput: %s", issueID, err, output)
+		debugCmd := exec.Command("bd", "--no-daemon", "--json", "slot", "show", issueID)
+		debugCmd.Dir = townRoot
+		combined, _ := debugCmd.CombinedOutput()
+		t.Fatalf("bd slot show %s failed: %v\nOutput: %s", issueID, err, combined)
 	}
 
 	var parsed struct {


### PR DESCRIPTION
## Summary
- Create town-level role beads before agent beads so role slots can be set on first install.
- Avoid bd show prefix matching by listing existing town agents before creating them.
- Add an integration test that asserts the mayor/deacon role slot is populated after install.

## Test plan
- [x] `go generate ./...`
- [x] `go test ./internal/cmd -tags=integration -run TestInstallTownRoleSlots`
- [x] `go test ./...` (after `bd sync --import-only`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)