### PR TITLE
docs: Add Go PATH setup to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,9 @@ Multi-agent orchestrator for Claude Code. Track work with convoys; sling to agen
 # Install
 go install github.com/steveyegge/gastown/cmd/gt@latest
 
+# Ensure Go binaries are in your PATH (add to ~/.zshrc or ~/.bashrc)
+export PATH="$PATH:$HOME/go/bin"
+
 # Create workspace (--git auto-initializes git repository)
 gt install ~/gt --git
 cd ~/gt


### PR DESCRIPTION
## Summary
- Adds a note in Quick Start about adding Go's bin directory to PATH
- Helps users who haven't configured Go's PATH avoid getting stuck after `go install`


