### PR TITLE
feat: Add semantic conflict detection as plugin molecule (#88)

### DIFF
--- a/docs/plugins/semantic-conflicts.md
+++ b/docs/plugins/semantic-conflicts.md
@@ -1,0 +1,249 @@
+# Semantic Conflict Detection Plugin
+
+## Overview
+
+The semantic conflict detector is a **plugin molecule** that extends Refinery to detect and escalate semantic conflicts - situations where multiple Polecats modify the same bead field with different professional judgments.
+
+## Problem
+
+Current conflict resolution (Last-Write-Wins) works for technical conflicts but silently discards important expert disagreements:
+
+| Agent | Field | Value | Reasoning |
+|-------|-------|-------|-----------|
+| security-agent | priority | 0 | CVE-2024-1234 with public exploit |
+| product-agent | priority | 2 | Low user impact edge case |
+
+With LWW, whichever Polecat's commit is processed last wins, potentially ignoring critical security judgment.
+
+## Solution
+
+This plugin:
+1. **Detects** conflicting bead modifications in MR commits
+2. **Escalates** to Mayor with confidence scores and reasoning
+3. **Awaits** Mayor's decision
+4. **Applies** the resolution to affected beads
+
+## Architecture
+
+```
+Refinery Patrol
+    │
+    ├─> Bond mol-semantic-conflict-detector plugin
+    │
+    ├─> Step: detect-conflicts
+    │       └─> gt semantic-conflict detect --branch $BRANCH
+    │
+    ├─> Step: escalate-to-mayor (if conflicts)
+    │       └─> gt semantic-conflict escalate --conflicts conflicts.json
+    │
+    ├─> Step: await-mayor-decision
+    │       └─> gt semantic-conflict await --mr $MR_ID --timeout 1h
+    │
+    └─> Step: apply-resolution
+            └─> gt semantic-conflict apply --resolution resolution.json
+```
+
+## Configuration
+
+### Enable in Rig Config
+
+Add to your rig's `config.json`:
+
+```json
+{
+  "refinery": {
+    "plugins": {
+      "semantic-conflict-detector": {
+        "enabled": true,
+        "escalate_fields": ["priority", "assignee", "estimated_minutes"],
+        "timeout": "1h"
+      }
+    }
+  }
+}
+```
+
+### Configuration Options
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `enabled` | bool | `false` | Enable the plugin |
+| `escalate_fields` | []string | `["priority", "assignee"]` | Fields requiring Mayor decision |
+| `timeout` | duration | `"1h"` | Max wait for Mayor decision |
+
+## Commands
+
+### gt semantic-conflict detect
+
+Analyze commits for conflicting bead modifications.
+
+```bash
+gt semantic-conflict detect \
+  --branch polecat/toast/gt-abc123 \
+  --target main \
+  --fields priority,assignee \
+  --output conflicts.json
+```
+
+**Output:**
+```json
+{
+  "mr": "gt-abc123",
+  "branch": "polecat/toast/gt-abc123",
+  "target": "main",
+  "conflicts": [
+    {
+      "bead_id": "gt-abc123",
+      "field": "priority",
+      "changes": [
+        {"polecat": "security-agent", "new_value": "0", "confidence": 0.95},
+        {"polecat": "product-agent", "new_value": "2", "confidence": 0.60}
+      ]
+    }
+  ],
+  "detected": "2026-01-04T12:00:00Z"
+}
+```
+
+### gt semantic-conflict escalate
+
+Send escalation mail to Mayor.
+
+```bash
+gt semantic-conflict escalate --conflicts conflicts.json --mr gt-abc123
+```
+
+### gt semantic-conflict await
+
+Wait for Mayor's resolution.
+
+```bash
+gt semantic-conflict await --mr gt-abc123 --timeout 1h
+```
+
+### gt semantic-conflict apply
+
+Apply resolved values to beads.
+
+```bash
+gt semantic-conflict apply --resolution resolution.json
+```
+
+## Polecat Integration
+
+For detection to work, Polecats must include `BEAD_CHANGES` metadata in commits:
+
+```bash
+git commit -m "Update priority due to security analysis
+
+BEAD_CHANGES:
+{
+  \"bead_id\": \"gt-abc123\",
+  \"polecat\": \"security-agent\",
+  \"changes\": [
+    {
+      \"field\": \"priority\",
+      \"old_value\": \"2\",
+      \"new_value\": \"0\",
+      \"confidence\": 0.95,
+      \"reasoning\": \"CVE-2024-1234 detected with public exploit available\"
+    }
+  ]
+}
+"
+```
+
+### BEAD_CHANGES Format
+
+```json
+{
+  "bead_id": "gt-abc123",
+  "polecat": "agent-name",
+  "changes": [
+    {
+      "field": "priority",
+      "old_value": "2",
+      "new_value": "0",
+      "confidence": 0.95,
+      "reasoning": "Explanation for this change"
+    }
+  ]
+}
+```
+
+| Field | Required | Description |
+|-------|----------|-------------|
+| `bead_id` | Yes | The bead being modified |
+| `polecat` | Yes | Agent making the change |
+| `changes[].field` | Yes | Field being modified |
+| `changes[].old_value` | Yes | Previous value |
+| `changes[].new_value` | Yes | New value |
+| `changes[].confidence` | No | 0.0-1.0 confidence score |
+| `changes[].reasoning` | No | Why this change was made |
+
+## Mayor Resolution
+
+### Escalation Mail Format
+
+```
+Subject: SEMANTIC_CONFLICT_ESCALATED gt-abc123
+
+Semantic conflicts detected in MR: gt-abc123
+
+## Conflict 1: gt-abc123.priority
+
+**Change 1** (by security-agent):
+- Value: 2 -> 0
+- Confidence: 0.95
+- Reasoning: CVE-2024-1234 detected with public exploit available
+
+**Change 2** (by product-agent):
+- Value: 0 -> 2
+- Confidence: 0.60
+- Reasoning: Edge case only affects <1% of users
+
+---
+Please review and provide a resolution.
+```
+
+### Resolution Format
+
+Mayor replies with:
+
+```json
+{
+  "resolutions": {
+    "gt-abc123:priority": "0"
+  },
+  "reasoning": "Security vulnerabilities with public exploits take precedence over user impact concerns."
+}
+```
+
+## Plugin vs Core
+
+This feature is implemented as a **plugin** rather than core code because:
+
+1. **Workflow-specific** - Not all teams need semantic conflict detection
+2. **Configurable** - Teams choose which fields to escalate
+3. **Optional** - Can be enabled/disabled per rig
+4. **Extensible** - Can be modified without touching core
+
+## Files
+
+```
+molecules/plugins/semantic-conflict-detector/
+├── mol-semantic-conflict-detector.formula.json  # Plugin molecule
+└── README.md                                     # Plugin docs
+
+internal/cmd/
+└── semantic_conflict.go                          # gt semantic-conflict command
+
+docs/plugins/
+└── semantic-conflicts.md                         # This file
+```
+
+## Related
+
+- Issue #88: Feature request
+- `docs/reference.md`: Plugin molecules documentation
+- `gt escalate`: General escalation command

--- a/docs/proposals/semantic-conflict-plugin.md
+++ b/docs/proposals/semantic-conflict-plugin.md
@@ -1,0 +1,339 @@
+# Proposal: Semantic Conflict Detection as Plugin Molecule
+
+**Issue:** #88
+**Status:** Draft
+**Author:** TimpiaAI
+**Date:** 2026-01-04
+
+## Summary
+
+Refactor semantic conflict detection from core Refinery code to a **plugin molecule** that can be optionally bonded during Refinery patrol. This follows the Gas Town pattern where workflow-specific logic lives in molecules, not core code.
+
+## Background
+
+The original PR #96 added semantic conflict detection directly to `internal/refinery/engineer.go`. The maintainer feedback was:
+
+> This kind of bespoke application-level/workflow-level routing logic needs to be implemented in the plugin layer rather than in core.
+
+This proposal redesigns the feature as a plugin molecule following Gas Town's extensibility patterns.
+
+## Plugin Architecture
+
+### What is a Plugin Molecule?
+
+From `docs/reference.md`:
+
+```json
+{
+  "id": "mol-security-scan",
+  "labels": ["template", "plugin", "witness", "tier:haiku"]
+}
+```
+
+Plugins are:
+1. **Molecules** - Workflow definitions with steps
+2. **Labeled** - With `template`, `plugin`, and target agent
+3. **Bonded dynamically** - Patrol molecules attach them when needed
+4. **Optional** - Can be enabled/disabled per rig
+
+### Semantic Conflict Plugin Design
+
+```json
+{
+  "id": "mol-semantic-conflict-detector",
+  "title": "Semantic Conflict Detection Plugin",
+  "type": "molecule",
+  "labels": ["template", "plugin", "refinery", "tier:sonnet"],
+  "description": "Detects semantic conflicts in MR bead modifications and escalates to Mayor for decision",
+  "steps": [
+    {
+      "id": "detect",
+      "title": "Detect semantic conflicts in MR",
+      "type": "task"
+    },
+    {
+      "id": "escalate",
+      "title": "Escalate conflicts to Mayor",
+      "type": "task",
+      "depends_on": ["detect"]
+    },
+    {
+      "id": "await-decision",
+      "title": "Wait for Mayor decision",
+      "type": "task",
+      "depends_on": ["escalate"]
+    },
+    {
+      "id": "apply-resolution",
+      "title": "Apply Mayor's resolution to beads",
+      "type": "task",
+      "depends_on": ["await-decision"]
+    }
+  ]
+}
+```
+
+## Integration with Refinery Patrol
+
+### Current Flow (without plugin)
+
+```
+Refinery Patrol:
+1. Check merge queue
+2. For each ready MR:
+   a. Fetch branch
+   b. Check git conflicts
+   c. Run tests
+   d. Merge or fail
+```
+
+### New Flow (with plugin bonded)
+
+```
+Refinery Patrol:
+1. Check merge queue
+2. For each ready MR:
+   a. Fetch branch
+   b. **Bond semantic-conflict-detector plugin**
+   c. Execute plugin steps:
+      - detect: Analyze commits for bead field changes
+      - escalate: If conflicts found, mail Mayor
+      - await-decision: Block until Mayor responds
+      - apply-resolution: Update beads with decision
+   d. Check git conflicts
+   e. Run tests
+   f. Merge or fail
+```
+
+### Bonding the Plugin
+
+In the Refinery patrol molecule or via config:
+
+```bash
+# Bond plugin for current MR processing
+bd mol bond mol-semantic-conflict-detector $MR_ID --var mr_branch="$BRANCH"
+```
+
+Or in rig config (`config.json`):
+
+```json
+{
+  "refinery": {
+    "plugins": ["mol-semantic-conflict-detector"],
+    "semantic_conflicts": {
+      "enabled": true,
+      "escalate_fields": ["priority", "assignee"],
+      "timeout": "1h"
+    }
+  }
+}
+```
+
+## What Stays in Core
+
+### Protocol Types (Minimal Core Addition)
+
+The protocol message types can stay in core since they're part of the inter-agent communication contract:
+
+**File: `internal/protocol/types.go`**
+
+```go
+const (
+    TypeSemanticConflictEscalated MessageType = "SEMANTIC_CONFLICT_ESCALATED"
+    TypeSemanticConflictResolved  MessageType = "SEMANTIC_CONFLICT_RESOLVED"
+)
+
+type SemanticConflictEscalatedPayload struct {
+    MRID      string
+    Conflicts []ConflictData
+}
+
+type SemanticConflictResolvedPayload struct {
+    MRID        string
+    Resolutions map[string]string
+}
+```
+
+These are just message type definitions - no business logic.
+
+### What Moves to Plugin
+
+Everything else moves out of core:
+
+| Component | Old Location (Core) | New Location (Plugin) |
+|-----------|--------------------|-----------------------|
+| Detection logic | `internal/refinery/semantic_conflict.go` | Plugin molecule step |
+| Config parsing | `internal/refinery/engineer.go` | Rig config + plugin vars |
+| Escalation mail | `internal/refinery/semantic_conflict.go` | Plugin molecule step |
+| ProcessMR hook | `internal/refinery/engineer.go` | Plugin bonding |
+
+## Plugin Implementation
+
+### Step 1: Detect Conflicts
+
+The plugin molecule's "detect" step runs a command that:
+
+1. Parses commits in the MR branch
+2. Looks for `BEAD_CHANGES:` blocks
+3. Groups changes by bead:field
+4. Identifies conflicts (same field, different values, different polecats)
+
+```bash
+# Detection command (could be gt subcommand or script)
+gt semantic-conflict detect --branch $MR_BRANCH --target main
+```
+
+Output format:
+```json
+{
+  "conflicts": [
+    {
+      "bead_id": "gt-abc123",
+      "field": "priority",
+      "changes": [
+        {"polecat": "security-agent", "value": "0", "confidence": 0.95},
+        {"polecat": "product-agent", "value": "2", "confidence": 0.60}
+      ]
+    }
+  ]
+}
+```
+
+### Step 2: Escalate to Mayor
+
+If conflicts detected, send escalation mail:
+
+```bash
+gt mail send mayor/ \
+  -s "SEMANTIC_CONFLICT_ESCALATED $MR_ID" \
+  -m "$(gt semantic-conflict format-escalation --input conflicts.json)"
+```
+
+### Step 3: Await Decision
+
+Block until Mayor responds:
+
+```bash
+# Poll for resolution mail
+gt mail wait --subject "SEMANTIC_CONFLICT_RESOLVED $MR_ID" --timeout 1h
+```
+
+Or use the molecule's built-in blocking (step stays open until Mayor closes it).
+
+### Step 4: Apply Resolution
+
+Apply Mayor's decision:
+
+```bash
+gt semantic-conflict apply --resolution resolution.json
+```
+
+## Directory Structure
+
+```
+/Users/ovipi/gastown/
+├── molecules/
+│   └── plugins/
+│       └── semantic-conflict-detector/
+│           ├── mol-semantic-conflict-detector.json  # Molecule definition
+│           ├── detect.sh                            # Detection script
+│           ├── escalate.sh                          # Escalation script
+│           └── apply.sh                             # Resolution application
+├── internal/
+│   └── cmd/
+│       └── semantic_conflict.go                     # gt semantic-conflict subcommand
+└── docs/
+    └── plugins/
+        └── semantic-conflicts.md                    # Plugin documentation
+```
+
+## Configuration
+
+### Enabling the Plugin
+
+Per-rig in `config.json`:
+
+```json
+{
+  "refinery": {
+    "plugins": {
+      "semantic-conflict-detector": {
+        "enabled": true,
+        "escalate_fields": ["priority", "assignee", "estimated_minutes"],
+        "auto_resolve_fields": ["labels", "title"],
+        "escalation_timeout": "1h"
+      }
+    }
+  }
+}
+```
+
+### Disabling the Plugin
+
+Simply don't include it in the plugins list, or set `enabled: false`.
+
+## Benefits of Plugin Approach
+
+1. **No core changes** - Refinery code stays clean
+2. **Optional** - Teams choose whether to enable
+3. **Configurable** - Per-rig settings
+4. **Testable** - Plugin can be tested independently
+5. **Upgradeable** - Update plugin without touching core
+6. **Composable** - Can combine with other plugins
+
+## Migration from PR #96
+
+### Files to Remove from Core
+
+```bash
+# Remove from internal/refinery/
+rm internal/refinery/semantic_conflict.go
+
+# Revert changes to engineer.go
+git checkout origin/main -- internal/refinery/engineer.go
+```
+
+### Files to Keep
+
+Protocol types can stay if maintainer approves minimal additions:
+- `internal/protocol/types.go` (message type constants only)
+
+### New Files to Create
+
+```bash
+# Plugin molecule
+molecules/plugins/semantic-conflict-detector/mol-semantic-conflict-detector.json
+
+# Detection command
+internal/cmd/semantic_conflict.go
+
+# Documentation
+docs/plugins/semantic-conflicts.md
+```
+
+## Open Questions for Maintainer
+
+1. **Protocol types in core?** Should `SEMANTIC_CONFLICT_ESCALATED/RESOLVED` message types live in core, or should they be entirely plugin-defined?
+
+2. **Plugin discovery mechanism?** How should Refinery discover and bond available plugins? Currently `bd mol bond` is explicit.
+
+3. **gt subcommand vs scripts?** Should detection logic be a `gt semantic-conflict` subcommand, or shell scripts in the plugin directory?
+
+4. **Plugin molecule location?** Should plugin molecules live in `molecules/plugins/` or elsewhere?
+
+5. **Mayor handling?** Should Mayor's conflict resolution be a separate plugin, or just mail-based responses?
+
+## Next Steps
+
+1. Get maintainer feedback on this proposal
+2. Implement plugin molecule structure
+3. Create `gt semantic-conflict` subcommand (if approved)
+4. Write plugin documentation
+5. Submit new PR with plugin-based implementation
+
+## References
+
+- Issue #88: Original feature request
+- PR #96: Original implementation (closed)
+- `docs/reference.md`: Plugin molecule documentation
+- `docs/molecules.md`: Molecule architecture

--- a/internal/cmd/semantic_conflict.go
+++ b/internal/cmd/semantic_conflict.go
@@ -1,0 +1,559 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/mail"
+	"github.com/steveyegge/gastown/internal/workspace"
+)
+
+// SemanticConflict represents a detected conflict between Polecat modifications.
+type SemanticConflict struct {
+	BeadID  string                `json:"bead_id"`
+	Field   string                `json:"field"`
+	Changes []SemanticFieldChange `json:"changes"`
+}
+
+// SemanticFieldChange represents a single modification to a bead field.
+type SemanticFieldChange struct {
+	Polecat    string  `json:"polecat"`
+	OldValue   string  `json:"old_value"`
+	NewValue   string  `json:"new_value"`
+	Confidence float64 `json:"confidence,omitempty"`
+	Reasoning  string  `json:"reasoning,omitempty"`
+	CommitSHA  string  `json:"commit_sha,omitempty"`
+}
+
+// ConflictDetectionResult is the output of the detect command.
+type ConflictDetectionResult struct {
+	MR        string             `json:"mr"`
+	Branch    string             `json:"branch"`
+	Target    string             `json:"target"`
+	Conflicts []SemanticConflict `json:"conflicts"`
+	Detected  time.Time          `json:"detected"`
+}
+
+var semanticConflictCmd = &cobra.Command{
+	Use:     "semantic-conflict",
+	GroupID: GroupWork,
+	Short:   "Detect and handle semantic conflicts in MR bead modifications",
+	Long: `Semantic conflict detection plugin for Gas Town Refinery.
+
+Detects when multiple Polecats modify the same bead field with different values
+(semantic conflicts) and escalates to Mayor for decision rather than using
+automatic resolution (LWW).
+
+This command is typically invoked by the mol-semantic-conflict-detector plugin
+molecule during Refinery MR processing.
+
+Subcommands:
+  detect    - Analyze commits for conflicting bead modifications
+  escalate  - Send conflict details to Mayor for decision
+  await     - Wait for Mayor's resolution
+  apply     - Apply resolved values to beads`,
+}
+
+var detectCmd = &cobra.Command{
+	Use:   "detect",
+	Short: "Detect semantic conflicts in MR branch",
+	Long: `Analyze commits in an MR branch to detect semantic conflicts.
+
+Looks for BEAD_CHANGES metadata blocks in commit messages and identifies
+conflicts where:
+  - Same bead field modified by different Polecats
+  - Different values set for the field
+  - Field is in the escalate-fields list
+
+Output is JSON with detected conflicts.
+
+Example:
+  gt semantic-conflict detect --branch polecat/toast/gt-abc --target main`,
+	RunE: runSemanticConflictDetect,
+}
+
+var escalateCmd2 = &cobra.Command{
+	Use:   "escalate",
+	Short: "Escalate conflicts to Mayor for decision",
+	Long: `Send escalation mail to Mayor with conflict details.
+
+Reads conflicts from stdin or --conflicts file and sends formatted
+escalation mail to Mayor with confidence scores and reasoning.
+
+Example:
+  gt semantic-conflict escalate --conflicts conflicts.json --mr gt-abc123`,
+	RunE: runSemanticConflictEscalate,
+}
+
+var awaitCmd = &cobra.Command{
+	Use:   "await",
+	Short: "Wait for Mayor's resolution",
+	Long: `Block until Mayor responds with conflict resolution.
+
+Polls for mail with subject "SEMANTIC_CONFLICT_RESOLVED <mr-id>" and
+outputs the resolution when received.
+
+Example:
+  gt semantic-conflict await --mr gt-abc123 --timeout 1h`,
+	RunE: runSemanticConflictAwait,
+}
+
+var applyCmd = &cobra.Command{
+	Use:   "apply",
+	Short: "Apply Mayor's resolution to beads",
+	Long: `Apply resolved values to affected beads.
+
+Reads resolution from stdin or --resolution file and updates each
+bead field with the resolved value.
+
+Example:
+  gt semantic-conflict apply --resolution resolution.json`,
+	RunE: runSemanticConflictApply,
+}
+
+var (
+	scBranch        string
+	scTarget        string
+	scFields        string
+	scConflictsFile string
+	scMRID          string
+	scTimeout       string
+	scResolutionFile string
+	scOutput        string
+)
+
+func init() {
+	// detect flags
+	detectCmd.Flags().StringVar(&scBranch, "branch", "", "MR branch to analyze (required)")
+	detectCmd.Flags().StringVar(&scTarget, "target", "main", "Target branch")
+	detectCmd.Flags().StringVar(&scFields, "fields", "priority,assignee", "Comma-separated fields to check")
+	detectCmd.Flags().StringVarP(&scOutput, "output", "o", "", "Output file (default: stdout)")
+	_ = detectCmd.MarkFlagRequired("branch")
+
+	// escalate flags
+	escalateCmd2.Flags().StringVar(&scConflictsFile, "conflicts", "", "Conflicts JSON file (default: stdin)")
+	escalateCmd2.Flags().StringVar(&scMRID, "mr", "", "MR ID (required)")
+	_ = escalateCmd2.MarkFlagRequired("mr")
+
+	// await flags
+	awaitCmd.Flags().StringVar(&scMRID, "mr", "", "MR ID (required)")
+	awaitCmd.Flags().StringVar(&scTimeout, "timeout", "1h", "Timeout waiting for response")
+	_ = awaitCmd.MarkFlagRequired("mr")
+
+	// apply flags
+	applyCmd.Flags().StringVar(&scResolutionFile, "resolution", "", "Resolution JSON file (default: stdin)")
+	applyCmd.Flags().StringVar(&scMRID, "mr", "", "MR ID")
+
+	// Add subcommands
+	semanticConflictCmd.AddCommand(detectCmd)
+	semanticConflictCmd.AddCommand(escalateCmd2)
+	semanticConflictCmd.AddCommand(awaitCmd)
+	semanticConflictCmd.AddCommand(applyCmd)
+
+	rootCmd.AddCommand(semanticConflictCmd)
+}
+
+func runSemanticConflictDetect(cmd *cobra.Command, args []string) error {
+	// Parse fields to check
+	fieldsToCheck := strings.Split(scFields, ",")
+	for i := range fieldsToCheck {
+		fieldsToCheck[i] = strings.TrimSpace(fieldsToCheck[i])
+	}
+
+	// Get commits in branch range
+	commits, err := getCommitsInRange(scTarget, scBranch)
+	if err != nil {
+		return fmt.Errorf("getting commits: %w", err)
+	}
+
+	// Extract bead changes from commits
+	allChanges := []beadChangeWithMeta{}
+	for _, commit := range commits {
+		changes := parseBeadChangesFromCommit(commit)
+		allChanges = append(allChanges, changes...)
+	}
+
+	// Group by bead:field
+	grouped := groupChangesByBeadField(allChanges)
+
+	// Detect conflicts
+	conflicts := []SemanticConflict{}
+	for key, changes := range grouped {
+		parts := strings.SplitN(key, ":", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		beadID, field := parts[0], parts[1]
+
+		// Check if field should be escalated
+		shouldCheck := false
+		for _, f := range fieldsToCheck {
+			if f == field {
+				shouldCheck = true
+				break
+			}
+		}
+		if !shouldCheck {
+			continue
+		}
+
+		// Check for conflict
+		if isConflict(changes) {
+			scChanges := []SemanticFieldChange{}
+			for _, ch := range changes {
+				scChanges = append(scChanges, SemanticFieldChange{
+					Polecat:    ch.Polecat,
+					OldValue:   ch.OldValue,
+					NewValue:   ch.NewValue,
+					Confidence: ch.Confidence,
+					Reasoning:  ch.Reasoning,
+					CommitSHA:  ch.CommitSHA,
+				})
+			}
+			conflicts = append(conflicts, SemanticConflict{
+				BeadID:  beadID,
+				Field:   field,
+				Changes: scChanges,
+			})
+		}
+	}
+
+	// Build result
+	result := ConflictDetectionResult{
+		MR:        scMRID,
+		Branch:    scBranch,
+		Target:    scTarget,
+		Conflicts: conflicts,
+		Detected:  time.Now(),
+	}
+
+	// Output
+	jsonData, err := json.MarshalIndent(result, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling result: %w", err)
+	}
+
+	if scOutput != "" {
+		if err := os.WriteFile(scOutput, jsonData, 0644); err != nil {
+			return fmt.Errorf("writing output: %w", err)
+		}
+		fmt.Printf("Wrote %d conflict(s) to %s\n", len(conflicts), scOutput)
+	} else {
+		fmt.Println(string(jsonData))
+	}
+
+	// Exit with code 1 if conflicts found (for scripting)
+	if len(conflicts) > 0 {
+		return fmt.Errorf("detected %d semantic conflict(s)", len(conflicts))
+	}
+
+	return nil
+}
+
+func runSemanticConflictEscalate(cmd *cobra.Command, args []string) error {
+	// Read conflicts
+	var data []byte
+	var err error
+	if scConflictsFile != "" {
+		data, err = os.ReadFile(scConflictsFile)
+	} else {
+		data, err = readStdin()
+	}
+	if err != nil {
+		return fmt.Errorf("reading conflicts: %w", err)
+	}
+
+	var result ConflictDetectionResult
+	if err := json.Unmarshal(data, &result); err != nil {
+		return fmt.Errorf("parsing conflicts: %w", err)
+	}
+
+	if len(result.Conflicts) == 0 {
+		fmt.Println("No conflicts to escalate")
+		return nil
+	}
+
+	// Find workspace
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("not in a Gas Town workspace: %w", err)
+	}
+
+	// Build escalation mail
+	subject := fmt.Sprintf("SEMANTIC_CONFLICT_ESCALATED %s", scMRID)
+	body := buildEscalationMailBody(scMRID, result.Conflicts)
+
+	// Send to Mayor
+	router := mail.NewRouter(townRoot)
+	msg := mail.NewMessage("refinery", "mayor/", subject, body)
+	msg.Priority = mail.PriorityHigh
+	msg.Type = mail.TypeTask
+	msg.ThreadID = "semantic-conflict-" + scMRID
+
+	if err := router.Send(msg); err != nil {
+		return fmt.Errorf("sending escalation mail: %w", err)
+	}
+
+	fmt.Printf("Escalated %d conflict(s) to Mayor\n", len(result.Conflicts))
+	fmt.Printf("Mail ID: %s\n", msg.ID)
+	fmt.Printf("Thread: %s\n", msg.ThreadID)
+
+	return nil
+}
+
+func runSemanticConflictAwait(cmd *cobra.Command, args []string) error {
+	timeout, err := time.ParseDuration(scTimeout)
+	if err != nil {
+		return fmt.Errorf("invalid timeout: %w", err)
+	}
+
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("not in a Gas Town workspace: %w", err)
+	}
+
+	expectedSubject := fmt.Sprintf("SEMANTIC_CONFLICT_RESOLVED %s", scMRID)
+	deadline := time.Now().Add(timeout)
+
+	fmt.Printf("Waiting for resolution (timeout: %s)...\n", scTimeout)
+
+	// Poll for resolution mail
+	for time.Now().Before(deadline) {
+		// Get mailbox for refinery
+		router := mail.NewRouter(townRoot)
+		mailbox, err := router.GetMailbox("refinery")
+		if err != nil {
+			time.Sleep(30 * time.Second)
+			continue
+		}
+
+		// Check unread messages
+		messages, err := mailbox.ListUnread()
+		if err != nil {
+			time.Sleep(30 * time.Second)
+			continue
+		}
+
+		for _, msg := range messages {
+			if strings.Contains(msg.Subject, expectedSubject) {
+				fmt.Printf("Resolution received from: %s\n", msg.From)
+				fmt.Println(msg.Body)
+				return nil
+			}
+		}
+
+		time.Sleep(30 * time.Second)
+	}
+
+	return fmt.Errorf("timeout waiting for Mayor resolution after %s", scTimeout)
+}
+
+func runSemanticConflictApply(cmd *cobra.Command, args []string) error {
+	// Read resolution
+	var data []byte
+	var err error
+	if scResolutionFile != "" {
+		data, err = os.ReadFile(scResolutionFile)
+	} else {
+		data, err = readStdin()
+	}
+	if err != nil {
+		return fmt.Errorf("reading resolution: %w", err)
+	}
+
+	var resolution struct {
+		Resolutions map[string]string `json:"resolutions"`
+		Reasoning   string            `json:"reasoning"`
+	}
+	if err := json.Unmarshal(data, &resolution); err != nil {
+		return fmt.Errorf("parsing resolution: %w", err)
+	}
+
+	// Apply each resolution
+	for key, value := range resolution.Resolutions {
+		parts := strings.SplitN(key, ":", 2)
+		if len(parts) != 2 {
+			fmt.Printf("Warning: invalid key format: %s\n", key)
+			continue
+		}
+		beadID, field := parts[0], parts[1]
+
+		// Use bd to update the bead
+		cmd := exec.Command("bd", "update", beadID, fmt.Sprintf("--%s=%s", field, value))
+		if out, err := cmd.CombinedOutput(); err != nil {
+			fmt.Printf("Warning: failed to update %s.%s: %v\n%s\n", beadID, field, err, out)
+		} else {
+			fmt.Printf("Applied: %s.%s = %s\n", beadID, field, value)
+		}
+	}
+
+	if resolution.Reasoning != "" {
+		fmt.Printf("\nMayor's reasoning: %s\n", resolution.Reasoning)
+	}
+
+	return nil
+}
+
+// Helper types and functions
+
+type beadChangeWithMeta struct {
+	BeadID     string
+	Field      string
+	Polecat    string
+	OldValue   string
+	NewValue   string
+	Confidence float64
+	Reasoning  string
+	CommitSHA  string
+}
+
+type commitInfo struct {
+	SHA     string
+	Message string
+}
+
+func getCommitsInRange(target, branch string) ([]commitInfo, error) {
+	// Use git log to get commits
+	cmd := exec.Command("git", "log", "--format=%H|||%B|||END|||",
+		fmt.Sprintf("origin/%s..origin/%s", target, branch))
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	commits := []commitInfo{}
+	entries := strings.Split(string(out), "|||END|||")
+	for _, entry := range entries {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			continue
+		}
+		parts := strings.SplitN(entry, "|||", 2)
+		if len(parts) == 2 {
+			commits = append(commits, commitInfo{
+				SHA:     strings.TrimSpace(parts[0]),
+				Message: strings.TrimSpace(parts[1]),
+			})
+		}
+	}
+	return commits, nil
+}
+
+func parseBeadChangesFromCommit(commit commitInfo) []beadChangeWithMeta {
+	changes := []beadChangeWithMeta{}
+
+	// Look for BEAD_CHANGES: block in commit message
+	idx := strings.Index(commit.Message, "BEAD_CHANGES:")
+	if idx == -1 {
+		return changes
+	}
+
+	jsonStart := idx + len("BEAD_CHANGES:")
+	jsonStr := strings.TrimSpace(commit.Message[jsonStart:])
+
+	// Try to parse JSON
+	var changeData struct {
+		BeadID  string `json:"bead_id"`
+		Polecat string `json:"polecat"`
+		Changes []struct {
+			Field      string  `json:"field"`
+			OldValue   string  `json:"old_value"`
+			NewValue   string  `json:"new_value"`
+			Confidence float64 `json:"confidence"`
+			Reasoning  string  `json:"reasoning"`
+		} `json:"changes"`
+	}
+
+	if err := json.Unmarshal([]byte(jsonStr), &changeData); err == nil {
+		for _, ch := range changeData.Changes {
+			changes = append(changes, beadChangeWithMeta{
+				BeadID:     changeData.BeadID,
+				Field:      ch.Field,
+				Polecat:    changeData.Polecat,
+				OldValue:   ch.OldValue,
+				NewValue:   ch.NewValue,
+				Confidence: ch.Confidence,
+				Reasoning:  ch.Reasoning,
+				CommitSHA:  commit.SHA,
+			})
+		}
+	}
+
+	return changes
+}
+
+func groupChangesByBeadField(changes []beadChangeWithMeta) map[string][]beadChangeWithMeta {
+	grouped := make(map[string][]beadChangeWithMeta)
+	for _, ch := range changes {
+		key := ch.BeadID + ":" + ch.Field
+		grouped[key] = append(grouped[key], ch)
+	}
+	return grouped
+}
+
+func isConflict(changes []beadChangeWithMeta) bool {
+	if len(changes) < 2 {
+		return false
+	}
+
+	// Check for different values from different polecats
+	uniqueValues := make(map[string]bool)
+	uniquePolecats := make(map[string]bool)
+
+	for _, ch := range changes {
+		uniqueValues[ch.NewValue] = true
+		uniquePolecats[ch.Polecat] = true
+	}
+
+	return len(uniqueValues) > 1 && len(uniquePolecats) > 1
+}
+
+func buildEscalationMailBody(mrID string, conflicts []SemanticConflict) string {
+	var body strings.Builder
+
+	body.WriteString(fmt.Sprintf("Semantic conflicts detected in MR: %s\n\n", mrID))
+
+	for i, conflict := range conflicts {
+		body.WriteString(fmt.Sprintf("## Conflict %d: %s.%s\n\n", i+1, conflict.BeadID, conflict.Field))
+
+		for j, change := range conflict.Changes {
+			body.WriteString(fmt.Sprintf("**Change %d** (by %s):\n", j+1, change.Polecat))
+			body.WriteString(fmt.Sprintf("- Value: %s -> %s\n", change.OldValue, change.NewValue))
+			if change.Confidence > 0 {
+				body.WriteString(fmt.Sprintf("- Confidence: %.2f\n", change.Confidence))
+			}
+			if change.Reasoning != "" {
+				body.WriteString(fmt.Sprintf("- Reasoning: %s\n", change.Reasoning))
+			}
+			if change.CommitSHA != "" {
+				body.WriteString(fmt.Sprintf("- Commit: %s\n", change.CommitSHA[:8]))
+			}
+			body.WriteString("\n")
+		}
+	}
+
+	body.WriteString("---\n")
+	body.WriteString("Please review and provide a resolution.\n\n")
+	body.WriteString("Reply with JSON:\n```json\n")
+	body.WriteString("{\n")
+	body.WriteString("  \"resolutions\": {\n")
+	body.WriteString("    \"<bead_id>:<field>\": \"<resolved_value>\"\n")
+	body.WriteString("  },\n")
+	body.WriteString("  \"reasoning\": \"<your decision reasoning>\"\n")
+	body.WriteString("}\n```\n")
+
+	return body.String()
+}
+
+func readStdin() ([]byte, error) {
+	stat, _ := os.Stdin.Stat()
+	if (stat.Mode() & os.ModeCharDevice) != 0 {
+		return nil, fmt.Errorf("no input provided (use --file or pipe to stdin)")
+	}
+	return os.ReadFile("/dev/stdin")
+}

--- a/molecules/plugins/semantic-conflict-detector/README.md
+++ b/molecules/plugins/semantic-conflict-detector/README.md
@@ -1,0 +1,120 @@
+# Semantic Conflict Detector Plugin
+
+Detects semantic conflicts in MR bead modifications and escalates to Mayor for decision.
+
+## What is a Semantic Conflict?
+
+When multiple Polecats modify the same bead field with different values, that's a **semantic conflict** - different professional judgments that need discussion, not arbitrary resolution.
+
+**Example:**
+- Polecat A (security): `priority = 0` (critical vulnerability)
+- Polecat B (product): `priority = 2` (low user impact)
+
+Auto-resolve (LWW) would silently discard one expert's judgment. This plugin escalates to Mayor instead.
+
+## Installation
+
+This plugin is included in Gas Town. Enable it in your rig's `config.json`:
+
+```json
+{
+  "refinery": {
+    "plugins": {
+      "semantic-conflict-detector": {
+        "enabled": true,
+        "escalate_fields": ["priority", "assignee", "estimated_minutes"],
+        "timeout": "1h"
+      }
+    }
+  }
+}
+```
+
+## Usage
+
+### Automatic (via Refinery Patrol)
+
+When enabled, the Refinery patrol molecule bonds this plugin for each MR:
+
+```bash
+bd mol bond mol-semantic-conflict-detector $MR_ID --var branch="$BRANCH"
+```
+
+### Manual
+
+You can also run the detection manually:
+
+```bash
+# Detect conflicts
+gt semantic-conflict detect --branch polecat/toast/gt-abc --target main
+
+# Escalate to Mayor
+gt semantic-conflict escalate --conflicts conflicts.json --mr gt-abc123
+
+# Wait for resolution
+gt semantic-conflict await --mr gt-abc123 --timeout 1h
+
+# Apply resolution
+gt semantic-conflict apply --resolution resolution.json
+```
+
+## Polecat Integration
+
+For conflicts to be detected, Polecats must include structured metadata in commits:
+
+```bash
+git commit -m "Update priority based on security analysis
+
+BEAD_CHANGES:
+{
+  \"bead_id\": \"gt-abc123\",
+  \"polecat\": \"security-agent\",
+  \"changes\": [{
+    \"field\": \"priority\",
+    \"old_value\": \"2\",
+    \"new_value\": \"0\",
+    \"confidence\": 0.95,
+    \"reasoning\": \"CVE-2024-1234 with public exploit\"
+  }]
+}
+"
+```
+
+## Mayor Resolution
+
+When Mayor receives an escalation, they reply with a resolution:
+
+```json
+{
+  "resolutions": {
+    "gt-abc123:priority": "0"
+  },
+  "reasoning": "Security vulnerabilities with public exploits take precedence"
+}
+```
+
+## Plugin Steps
+
+1. **detect-conflicts** - Analyze commits for bead field changes
+2. **escalate-to-mayor** - Send mail to Mayor with conflict details
+3. **await-mayor-decision** - Block until Mayor responds
+4. **apply-resolution** - Update beads with resolved values
+
+## Configuration Options
+
+| Option | Default | Description |
+|--------|---------|-------------|
+| `enabled` | `false` | Enable/disable the plugin |
+| `escalate_fields` | `["priority", "assignee"]` | Fields requiring Mayor decision |
+| `timeout` | `"1h"` | Timeout waiting for Mayor |
+
+## Files
+
+- `mol-semantic-conflict-detector.formula.json` - Plugin molecule definition
+- `README.md` - This file
+
+## Related
+
+- Issue #88: Original feature request
+- `gt escalate` - General escalation command
+- `gt mail` - Mail system commands

--- a/molecules/plugins/semantic-conflict-detector/mol-semantic-conflict-detector.formula.json
+++ b/molecules/plugins/semantic-conflict-detector/mol-semantic-conflict-detector.formula.json
@@ -1,0 +1,49 @@
+{
+  "formula": "mol-semantic-conflict-detector",
+  "description": "Detects semantic conflicts in MR bead modifications and escalates to Mayor for decision.\n\n## Purpose\nWhen multiple Polecats modify the same bead field with different values, this plugin detects the conflict and escalates to Mayor for a decision rather than using automatic resolution (LWW).\n\n## Labels\n- template: Can be instantiated as wisp\n- plugin: Optional workflow extension\n- refinery: Bonds during refinery MR processing\n- tier:sonnet: Requires Sonnet-level reasoning\n\n## Configuration\nEnable in rig config.json:\n```json\n{\n  \"refinery\": {\n    \"plugins\": {\n      \"semantic-conflict-detector\": {\n        \"enabled\": true,\n        \"escalate_fields\": [\"priority\", \"assignee\"]\n      }\n    }\n  }\n}\n```\n\n## Execution\n```bash\nbd mol bond mol-semantic-conflict-detector $MR_ID --var branch=\"$BRANCH\"\n```",
+  "version": 1,
+  "labels": ["template", "plugin", "refinery", "tier:sonnet"],
+  "vars": {
+    "branch": {
+      "description": "MR branch to analyze",
+      "required": true
+    },
+    "target": {
+      "description": "Target branch (default: main)",
+      "default": "main"
+    },
+    "escalate_fields": {
+      "description": "Comma-separated list of fields requiring Mayor decision",
+      "default": "priority,assignee"
+    },
+    "timeout": {
+      "description": "Timeout waiting for Mayor decision",
+      "default": "1h"
+    }
+  },
+  "steps": [
+    {
+      "id": "detect-conflicts",
+      "title": "Detect semantic conflicts",
+      "description": "Analyze commits in the MR branch for conflicting bead field modifications.\n\n## Action\n```bash\ngt semantic-conflict detect --branch $branch --target $target --fields $escalate_fields\n```\n\n## Output\nCreates `conflicts.json` with detected conflicts:\n```json\n{\n  \"conflicts\": [\n    {\n      \"bead_id\": \"gt-abc123\",\n      \"field\": \"priority\",\n      \"changes\": [\n        {\"polecat\": \"security-agent\", \"value\": \"0\", \"confidence\": 0.95},\n        {\"polecat\": \"product-agent\", \"value\": \"2\", \"confidence\": 0.60}\n      ]\n    }\n  ]\n}\n```\n\n## Verify\n1. Detection completed without error\n2. If no conflicts: Close this step AND skip remaining steps (burn molecule)\n3. If conflicts found: Continue to escalation"
+    },
+    {
+      "id": "escalate-to-mayor",
+      "title": "Escalate conflicts to Mayor",
+      "needs": ["detect-conflicts"],
+      "description": "Send escalation mail to Mayor with conflict details.\n\n## Action\n```bash\ngt semantic-conflict escalate --conflicts conflicts.json --mr $MR_ID\n```\n\n## What It Does\n1. Acquires merge slot (serializes conflict resolution)\n2. Formats conflict details with confidence scores and reasoning\n3. Sends mail to mayor/ with subject: \"SEMANTIC_CONFLICT_ESCALATED $MR_ID\"\n4. Records escalation mail ID for tracking\n\n## Verify\n1. Merge slot acquired (or queued)\n2. Mail sent successfully\n3. Mail ID recorded in step metadata"
+    },
+    {
+      "id": "await-mayor-decision",
+      "title": "Await Mayor decision",
+      "needs": ["escalate-to-mayor"],
+      "description": "Wait for Mayor to respond with resolution.\n\n## Action\n```bash\ngt semantic-conflict await --mr $MR_ID --timeout $timeout\n```\n\n## What It Does\n1. Polls for mail with subject: \"SEMANTIC_CONFLICT_RESOLVED $MR_ID\"\n2. Blocks until resolution received or timeout\n3. On timeout: Falls back to LWW resolution\n\n## Verify\n1. Resolution mail received OR timeout triggered\n2. Resolution parsed successfully\n3. Resolutions recorded in step metadata"
+    },
+    {
+      "id": "apply-resolution",
+      "title": "Apply Mayor's resolution",
+      "needs": ["await-mayor-decision"],
+      "description": "Apply the resolved values to affected beads.\n\n## Action\n```bash\ngt semantic-conflict apply --resolution resolution.json --mr $MR_ID\n```\n\n## What It Does\n1. Parses resolution (map of \"bead:field\" -> value)\n2. Updates each bead field with resolved value\n3. Releases merge slot\n4. Notifies polecats of decision\n\n## Verify\n1. All resolutions applied successfully\n2. Merge slot released\n3. Polecats notified"
+    }
+  ]
+}


### PR DESCRIPTION
Following feedback on PR #96, this reimplements semantic conflict detection as a **plugin molecule** rather than core code changes.

  ## Changes

  - **No core code modifications** - All logic is in the plugin
  - **Plugin molecule**: `mol-semantic-conflict-detector.formula.json`
  - **New command**: `gt semantic-conflict` with subcommands
  - **Documentation**: `docs/plugins/semantic-conflicts.md`

  ## How It Works

  1. Refinery patrol bonds the plugin molecule for each MR
  2. Plugin detects conflicts in commits (looks for BEAD_CHANGES metadata)
  3. Escalates to Mayor if conflicts found
  4. Awaits Mayor's decision
  5. Applies resolution to beads

  ## Configuration

  Enable per-rig in config.json:
  ```json
  {
    "refinery": {
      "plugins": {
        "semantic-conflict-detector": {
          "enabled": true,
          "escalate_fields": ["priority", "assignee"]
        }
      }
    }
  }
  ```

  Fixes #88