### PR TITLE
fix: Set hook slot atomically when creating agent beads (gt-mol-6xg5o)

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -975,6 +975,17 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 		}
 	}
 
+	// Set the hook slot if specified (atomic at spawn time)
+	// This uses bd slot set to update the SQLite column directly, ensuring
+	// consistency with bd slot show and other commands that read from SQLite.
+	// Previously, hook_bead was only in description text which caused #gt-mol-6xg5o.
+	if fields != nil && fields.HookBead != "" {
+		if _, err := b.run("slot", "set", id, "hook", fields.HookBead); err != nil {
+			// Non-fatal: warn but continue
+			fmt.Printf("Warning: could not set hook slot: %v\n", err)
+		}
+	}
+
 	return &issue, nil
 }
 


### PR DESCRIPTION
CreateAgentBead embedded hook_bead in description text but never called bd slot set to update the SQLite column. When bd slot show queried the hook, it read the empty column.

Added bd slot set for hook_bead at spawn time, matching the pattern for role.

---
🐍 Gas Town fixed itself in ~9 minutes.
New instance, first real dispatch → hit hook bug → pointed Gas Town at its own repo → polecat diagnosed and patched it. Cool stuff! Very meta (lowercase 'm')

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary
Hook attachment fails silently - bead status shows "hooked" but agent slot remains empty.

## Related Issue
Fixes internal issue gt-mol-6xg5o (first-time user, no upstream issue filed)

## Changes
- Added `bd slot set` call for `hook_bead` in `CreateAgentBead` (internal/beads/beads.go)
- Matches existing pattern used for `role_bead`
- Hook is now set atomically in SQLite at spawn time

## Testing
- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)
