### PR TITLE
fix(sling): Set hook slot when creating agent beads

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -975,6 +975,16 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 		}
 	}
 
+	// Set the hook slot if specified (this is the authoritative storage)
+	// This fixes the slot inconsistency bug where bead status is 'hooked' but
+	// agent's hook slot is empty. See mi-619.
+	if fields != nil && fields.HookBead != "" {
+		if _, err := b.run("slot", "set", id, "hook", fields.HookBead); err != nil {
+			// Non-fatal: warn but continue - description text has the backup
+			fmt.Printf("Warning: could not set hook slot: %v\n", err)
+		}
+	}
+
 	return &issue, nil
 }
 


### PR DESCRIPTION
## Summary
Fixes the hook attachment bug where bead status shows 'hooked' but agent's hook slot remains empty.

**Problem**: `CreateAgentBead` embedded `hook_bead` in description text but never called `bd slot set` to update the SQLite column. When `bd slot show` queried the hook, it read the empty column.

**Solution**: 
- Added `bd slot set` for `hook_bead` in `CreateAgentBead`, matching the existing pattern for `role_bead`
- Updated `updateAgentHookBead` in sling.go to pass the `beadID` to `UpdateAgentState` so existing agents get their hook slot updated when work is slung

## Changes
- `internal/beads/beads.go`: Set hook slot atomically at agent spawn time
- `internal/cmd/sling.go`: Pass beadID to UpdateAgentState when slinging work

## Testing
- Unit tests pass (`go test ./internal/beads/...`)
- Manual verification: hook slot now populated when work is slung

## Related
- Supersedes PR #119 (closed, less complete fix)
- Fixes: mi-619

🤖 Generated with [Claude Code](https://claude.ai/code)