### PR TITLE
fix: Remove stale .beads-wisp/ references (gt-d0h4e)

### DIFF
--- a/.beads/formulas/mol-boot-triage.formula.toml
+++ b/.beads/formulas/mol-boot-triage.formula.toml
@@ -46,8 +46,8 @@ bd show hq-deacon 2>/dev/null
 # Recent feed events
 gt feed --since 10m --plain | head -20
 
-# Recent wisps (operational state)
-ls -lt ~/gt/.beads-wisp/*.wisp.json 2>/dev/null | head -5
+# Recent wisps (operational state, now in main beads)
+bd list --type=wisp --sort=updated 2>/dev/null | head -5
 ```
 
 **Step 4: Check Deacon mail**

--- a/.beads/formulas/mol-orphan-scan.formula.toml
+++ b/.beads/formulas/mol-orphan-scan.formula.toml
@@ -139,9 +139,9 @@ needs = ["determine-scope"]
 description = """
 Find wisps from terminated sessions.
 
-**1. List wisps in ephemeral storage:**
+**1. List wisps in beads:**
 ```bash
-ls .beads-wisp/             # Or equivalent location
+bd list --type=wisp         # Wisps now stored in main .beads/
 ```
 
 **2. For each wisp, check spawner session:**
@@ -229,8 +229,8 @@ Recommended action: ..."
 
 **5. BURN orphans:**
 ```bash
-# For empty wisps, etc.
-rm .beads-wisp/<wisp-file>
+# For empty wisps, etc. (wisps now in main beads)
+bd mol burn <wisp-id>
 ```
 
 **Exit criteria:** All orphans handled."""

--- a/.beads/formulas/mol-session-gc.formula.toml
+++ b/.beads/formulas/mol-session-gc.formula.toml
@@ -161,8 +161,8 @@ tmux list-sessions 2>/dev/null
 # Claude processes
 pgrep -f claude
 
-# Wisps
-ls .beads-wisp/ 2>/dev/null | wc -l
+# Wisps (type=wisp in .beads/)
+bd list --type=wisp 2>/dev/null | wc -l
 ```
 
 **3. Compare before/after:**

--- a/docs/polecat-wisp-architecture.md
+++ b/docs/polecat-wisp-architecture.md
@@ -12,7 +12,7 @@ They execute molecule steps sequentially, closing each step as they complete it.
 | Type | Storage | Use Case |
 |------|---------|----------|
 | **Regular Molecule** | `.beads/` (synced) | Discrete deliverables, audit trail |
-| **Wisp** | `.beads-wisp/` (ephemeral) | Patrol cycles, operational loops |
+| **Wisp** | `.beads/` (ephemeral, squashed to digests) | Patrol cycles, operational loops |
 
 Polecats typically use **regular molecules** because each assignment has audit value.
 Patrol agents (Witness, Refinery, Deacon) use **wisps** to prevent accumulation.


### PR DESCRIPTION
## Summary
- Remove stale .beads-wisp/ references from docs and formulas
- The .beads-wisp/ approach was eradicated - wisps now live in main beads

## Changes
- docs/polecat-wisp-architecture.md: Update storage table
- mol-session-gc.formula.toml: Use bd list --type=wisp  
- mol-boot-triage.formula.toml: Use bd list --type=wisp
- mol-orphan-scan.formula.toml: Use bd commands instead of filesystem

## Test plan
- [x] Verify no remaining .beads-wisp references in changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)