### PR TITLE
fix: Resolve CI lint and build errors

### DIFF
--- a/internal/cmd/info.go
+++ b/internal/cmd/info.go
@@ -48,7 +48,7 @@ Examples:
 		if jsonFlag {
 			enc := json.NewEncoder(os.Stdout)
 			enc.SetIndent("", "  ")
-			enc.Encode(info)
+			_ = enc.Encode(info)
 			return
 		}
 
@@ -148,7 +148,7 @@ func showWhatsNew(jsonOutput bool) {
 	if jsonOutput {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
-		enc.Encode(map[string]interface{}{
+		_ = enc.Encode(map[string]interface{}{
 			"current_version": Version,
 			"recent_changes":  versionChanges,
 		})

--- a/internal/cmd/install_integration_test.go
+++ b/internal/cmd/install_integration_test.go
@@ -3,6 +3,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"


### PR DESCRIPTION
## Summary
- Add error suppression for `enc.Encode()` calls in info.go (errcheck lint)
- Add missing `encoding/json` import in install_integration_test.go

These are pre-existing issues blocking all PRs from passing CI.

## Test plan
- CI should pass after this merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)