### PR TITLE
docs(mayor): Add Polecat Operations section

### DIFF
--- a/internal/templates/roles/mayor.md.tmpl
+++ b/internal/templates/roles/mayor.md.tmpl
@@ -195,9 +195,31 @@ bd show hq-abc      # Routes to town beads
 - `gt convoy list` - Dashboard of active work (primary view)
 - `gt convoy status <id>` - Detailed convoy progress
 - `gt convoy create "name" <issues>` - Create convoy for batch work
-- `gt sling <bead> <rig>` - Assign work to polecat (auto-creates convoy)
+- `gt sling <bead> <rig>` - Spawn polecat with work (see below)
 - `bd ready` - Issues ready to work (no blockers)
 - `bd list --status=open` - All open issues
+
+### Polecat Operations
+
+**To spawn a polecat with work (the normal flow):**
+```bash
+gt sling <bead-id> <rig>        # Spawns polecat, hooks work, starts session
+gt sling mi-xyz missioncontrol  # Example: spawns in missioncontrol rig
+```
+
+This is THE command for dispatching work. It:
+1. Allocates a fresh polecat name from the pool
+2. Creates the git worktree
+3. Starts the tmux session
+4. Hooks the bead to the polecat
+5. Nudges the polecat to start working
+
+**There is NO `gt polecat spawn` command.** Use `gt sling`.
+
+**Other polecat commands:**
+- `gt polecat list` - List polecats in current rig
+- `gt polecat nuke <rig>/<name> --force` - Kill session + remove worktree
+- `gt polecat status <rig>/<name>` - Show polecat status
 
 ### Delegation
 Prefer delegating to Refineries, not directly to polecats:


### PR DESCRIPTION
## Problem

Users look for `gt polecat spawn` when they should use `gt sling`.

## Changes

Add "Polecat Operations" section to Mayor template clarifying that `gt sling` is THE command for spawning polecats with work.

Searching for polecat spawn you are? Here it is not. Hrmmm.

🤖 Generated with [Claude Code](https://claude.ai/code)