### PR TITLE
cleanup: remove dead sling flags (--quality, --molecule)

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -242,7 +242,7 @@ Note: "Swarm" is ephemeral (workers on a convoy's issues). See [Convoys](convoy.
 # Standard workflow: convoy first, then sling
 gt convoy create "Feature X" gt-abc gt-def
 gt sling gt-abc <rig>                    # Assign to polecat
-gt sling gt-def <rig> --molecule=<proto> # With workflow template
+gt sling <proto> --on gt-def <rig>       # With workflow template
 
 # Quick sling (auto-creates convoy)
 gt sling <bead> <rig>                    # Auto-convoy for dashboard visibility

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -53,7 +53,6 @@ Target Resolution:
   gt sling gt-abc deacon/dogs/alpha     # Specific dog
 
 Spawning Options (when target is a rig):
-  gt sling gp-abc greenplace --molecule mol-review  # Use specific workflow
   gt sling gp-abc greenplace --create               # Create polecat if missing
   gt sling gp-abc greenplace --naked                # No-tmux (manual start)
   gt sling gp-abc greenplace --force                # Ignore unread mail
@@ -101,7 +100,6 @@ var (
 	// Flags migrated for polecat spawning (used by sling for work assignment
 	slingNaked    bool   // --naked: no-tmux mode (skip session creation)
 	slingCreate   bool   // --create: create polecat if it doesn't exist
-	slingMolecule string // --molecule: workflow to instantiate on the bead
 	slingForce    bool   // --force: force spawn even if polecat has unread mail
 	slingAccount  string // --account: Claude Code account handle to use
 	slingNoConvoy bool   // --no-convoy: skip auto-convoy creation
@@ -118,7 +116,6 @@ func init() {
 	// Flags for polecat spawning (when target is a rig)
 	slingCmd.Flags().BoolVar(&slingNaked, "naked", false, "No-tmux mode: assign work but skip session creation (manual start)")
 	slingCmd.Flags().BoolVar(&slingCreate, "create", false, "Create polecat if it doesn't exist")
-	slingCmd.Flags().StringVar(&slingMolecule, "molecule", "", "Molecule workflow to instantiate on the bead")
 	slingCmd.Flags().BoolVar(&slingForce, "force", false, "Force spawn even if polecat has unread mail")
 	slingCmd.Flags().StringVar(&slingAccount, "account", "", "Claude Code account handle to use")
 	slingCmd.Flags().BoolVar(&slingNoConvoy, "no-convoy", false, "Skip auto-convoy creation for single-issue sling")


### PR DESCRIPTION
## Summary
  Removes two dead flags from gt sling that were either broken or never wired up:
  - --quality/-q: Referenced mol-polecat-* formulas that were removed in c47a746 but the flag code was left behind, causing errors when used
  - --molecule: Was defined but never actually wired up - the flag was parsed but the value was never read

Both flags are superseded by the fully-functional --on flag:
  - `gt sling <formula> --on <bead> <target>`

## Related Issue
N/A - Cleanup of dead code discovered during development

## Changes
  - Remove --quality/-q flag definition and help text
  - Remove qualityToFormula() function (37 lines)
  - Remove --molecule flag definition
  - Remove slingMolecule variable (never read)
  - Update reference.md to remove --molecule from docs

## Testing
- Unit tests pass (go test ./...)
- Manual testing performed
  - Verified `gt sling --help` no longer shows removed flags

## Checklist
- [X] Code follows project style
- [X] Documentation updated (if applicable)
- [X] No breaking changes (or documented in summary)
