### PR TITLE
fix(polecat): add explicit completion protocol with push step

### DIFF
--- a/internal/templates/roles/polecat.md.tmpl
+++ b/internal/templates/roles/polecat.md.tmpl
@@ -163,7 +163,8 @@ bd create --title="gt session capture: Support positional line count" --type=tas
 Agent-friendly UX is critical. Your guesses reveal what's intuitive.
 
 ### Completion
-- `gt done` - Signal work ready for merge queue (handles beads sync internally)
+- `git push -u origin HEAD` - Push your branch (REQUIRED before gt done)
+- `gt done --exit` - Submit to merge queue and exit session
 
 ## Startup Protocol: Propulsion
 
@@ -217,10 +218,24 @@ bd ready                   # See next step
 
 When all steps are done, the molecule gets squashed automatically when you run `gt done`.
 
-## Before Signaling Done
+## Completion Protocol
 
-Run `gt done` when your work is complete. It verifies git is clean, syncs beads,
-and submits your branch to the merge queue. The Witness handles the rest.
+When your work is done, follow this **EXACT** checklist:
+
+```
+[ ] 1. Tests pass         (run project's test command)
+[ ] 2. Commit changes     git add <files> && git commit -m "feat(scope): description"
+[ ] 3. Push branch        git push -u origin HEAD
+[ ] 4. Close issue        bd close <issue-id> --reason "..."
+[ ] 5. Exit session       gt done --exit
+```
+
+**CRITICAL**: You MUST push your branch BEFORE running `gt done --exit`.
+If you skip the push, `gt done` will fail with "branch has unpushed commit(s)".
+
+> **Note**: The `bd prime` output may say "ephemeral branch - not pushed". This does
+> NOT apply to polecats. Polecats use remote branches that MUST be pushed for the
+> Refinery to merge your work.
 
 ### The Landing Rule
 


### PR DESCRIPTION
## Summary

Polecats were getting stuck because they received conflicting instructions:

- `bd prime` told them: "ephemeral branch - not pushed"
- But `gt done` requires branches to be pushed first

This caused 8+ polecats to complete their work but never submit to the merge queue.

## Changes

Updated `internal/templates/roles/polecat.md.tmpl` to add:

1. **Explicit completion checklist** with the required steps:
   - Tests pass
   - Commit changes
   - Push branch (CRITICAL)
   - Close issue
   - Exit session with `gt done --exit`

2. **Warning note** clarifying that `bd prime's` "ephemeral branch" advice does NOT apply to polecats

## Root Cause Analysis

- `bd prime` detects branches without upstream tracking as "ephemeral"
- Fresh polecat branches have no upstream until pushed
- So `bd prime` outputs "not pushed" advice
- But `gt done` (done.go:165-173) requires branches to be pushed first
- Polecats followed the "not pushed" advice and got stuck

## Test Plan

- [ ] Verify `gt prime` output for polecats includes the new completion checklist
- [ ] Spawn a test polecat and verify it follows the checklist
- [ ] Confirm `gt done` succeeds after following the checklist

Fixes: ga-fgnwa