### PR TITLE
fix: log rig discovery errors instead of silently swallowing (gt-rsnj9)

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -871,7 +871,8 @@ func (g *Git) BranchPushedToRemote(localBranch, remote string) (bool, int, error
 	// See: gt-cehl8 (gt done fails in worktrees due to missing origin tracking ref)
 	remoteRef := "refs/remotes/" + remoteBranch
 	if _, err := g.run("rev-parse", "--verify", remoteRef); err != nil {
-		// Remote ref doesn't exist locally - update it from FETCH_HEAD if fetch succeeded
+		// Remote ref doesn't exist locally - update it from FETCH_HEAD if fetch succeeded.
+		// Best-effort: if this fails, the code below falls back to ls-remote.
 		if fetchErr == nil {
 			_, _ = g.run("update-ref", remoteRef, "FETCH_HEAD")
 		}

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -62,13 +62,14 @@ func NewManager(townRoot string, rigsConfig *config.RigsConfig, g *git.Git) *Man
 }
 
 // DiscoverRigs returns all rigs registered in the workspace.
+// Rigs that fail to load are logged to stderr and skipped; partial results are returned.
 func (m *Manager) DiscoverRigs() ([]*Rig, error) {
 	var rigs []*Rig
 
 	for name, entry := range m.config.Rigs {
 		rig, err := m.loadRig(name, entry)
 		if err != nil {
-			// Log error but continue with other rigs
+			fmt.Fprintf(os.Stderr, "Warning: failed to load rig %q: %v\n", name, err)
 			continue
 		}
 		rigs = append(rigs, rig)
@@ -443,19 +444,19 @@ Use crew for your own workspace. Polecats are for batch work dispatch.
 	// Town-level agents (mayor, deacon) are created by gt install in town beads.
 	if err := m.initAgentBeads(rigPath, opts.Name, opts.BeadsPrefix); err != nil {
 		// Non-fatal: log warning but continue
-		fmt.Printf("  Warning: Could not create agent beads: %v\n", err)
+		fmt.Fprintf(os.Stderr, "  Warning: Could not create agent beads: %v\n", err)
 	}
 
 	// Seed patrol molecules for this rig
 	if err := m.seedPatrolMolecules(rigPath); err != nil {
 		// Non-fatal: log warning but continue
-		fmt.Printf("  Warning: Could not seed patrol molecules: %v\n", err)
+		fmt.Fprintf(os.Stderr, "  Warning: Could not seed patrol molecules: %v\n", err)
 	}
 
 	// Create plugin directories
 	if err := m.createPluginDirectories(rigPath); err != nil {
 		// Non-fatal: log warning but continue
-		fmt.Printf("  Warning: Could not create plugin directories: %v\n", err)
+		fmt.Fprintf(os.Stderr, "  Warning: Could not create plugin directories: %v\n", err)
 	}
 
 	// Register in town config


### PR DESCRIPTION
## Summary
- Logs rig discovery errors instead of silently swallowing them
- Improves debugging by making error conditions visible

## Test plan
- [x] All tests pass (`go test ./...`)
- Rebased on current main

🤖 Generated with [Claude Code](https://claude.com/claude-code)