### PR TITLE
refactor: extract ExecWithOutput utility for command execution (gt-vurfr)

### DIFF
--- a/internal/util/exec.go
+++ b/internal/util/exec.go
@@ -1,0 +1,49 @@
+package util
+
+import (
+	"bytes"
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// ExecWithOutput runs a command in the specified directory and returns stdout.
+// If the command fails, stderr content is included in the error message.
+func ExecWithOutput(workDir, cmd string, args ...string) (string, error) {
+	c := exec.Command(cmd, args...) //nolint:gosec // G204: callers validate args
+	c.Dir = workDir
+
+	var stdout, stderr bytes.Buffer
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+
+	if err := c.Run(); err != nil {
+		errMsg := strings.TrimSpace(stderr.String())
+		if errMsg != "" {
+			return "", fmt.Errorf("%s", errMsg)
+		}
+		return "", err
+	}
+
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+// ExecRun runs a command in the specified directory.
+// If the command fails, stderr content is included in the error message.
+func ExecRun(workDir, cmd string, args ...string) error {
+	c := exec.Command(cmd, args...) //nolint:gosec // G204: callers validate args
+	c.Dir = workDir
+
+	var stderr bytes.Buffer
+	c.Stderr = &stderr
+
+	if err := c.Run(); err != nil {
+		errMsg := strings.TrimSpace(stderr.String())
+		if errMsg != "" {
+			return fmt.Errorf("%s", errMsg)
+		}
+		return err
+	}
+
+	return nil
+}

--- a/internal/util/exec_test.go
+++ b/internal/util/exec_test.go
@@ -1,0 +1,67 @@
+package util
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestExecWithOutput(t *testing.T) {
+	// Test successful command
+	output, err := ExecWithOutput(".", "echo", "hello")
+	if err != nil {
+		t.Fatalf("ExecWithOutput failed: %v", err)
+	}
+	if output != "hello" {
+		t.Errorf("expected 'hello', got %q", output)
+	}
+
+	// Test command that fails
+	_, err = ExecWithOutput(".", "false")
+	if err == nil {
+		t.Error("expected error for failing command")
+	}
+}
+
+func TestExecRun(t *testing.T) {
+	// Test successful command
+	err := ExecRun(".", "true")
+	if err != nil {
+		t.Fatalf("ExecRun failed: %v", err)
+	}
+
+	// Test command that fails
+	err = ExecRun(".", "false")
+	if err == nil {
+		t.Error("expected error for failing command")
+	}
+}
+
+func TestExecWithOutput_WorkDir(t *testing.T) {
+	// Create a temp directory
+	tmpDir, err := os.MkdirTemp("", "exec-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Test that workDir is respected
+	output, err := ExecWithOutput(tmpDir, "pwd")
+	if err != nil {
+		t.Fatalf("ExecWithOutput failed: %v", err)
+	}
+	if !strings.Contains(output, tmpDir) && !strings.Contains(tmpDir, output) {
+		t.Errorf("expected output to contain %q, got %q", tmpDir, output)
+	}
+}
+
+func TestExecWithOutput_StderrInError(t *testing.T) {
+	// Test that stderr is captured in error
+	_, err := ExecWithOutput(".", "sh", "-c", "echo 'error message' >&2; exit 1")
+	if err == nil {
+		t.Error("expected error")
+	}
+	if !strings.Contains(err.Error(), "error message") {
+		t.Errorf("expected error to contain stderr, got %q", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary
- Extracts ExecWithOutput utility function for command execution
- Provides consistent pattern for running commands and capturing output

## Test plan
- [x] All tests pass (`go test ./...`)
- Rebased on current main

🤖 Generated with [Claude Code](https://claude.com/claude-code)