### PR TITLE
[DO NOT MERGE] fix: use ResolveBeadsDir for redirect support in more commands

### DIFF
--- a/internal/cmd/callbacks.go
+++ b/internal/cmd/callbacks.go
@@ -340,7 +340,7 @@ func handleMergeCompleted(townRoot string, msg *mail.Message, dryRun bool) (stri
 	// Close the source issue if we have it
 	if sourceIssue != "" {
 		cwd, _ := os.Getwd()
-		bd := beads.New(cwd)
+		bd := beads.New(beads.ResolveBeadsDir(cwd))
 		reason := fmt.Sprintf("Merged in %s", mergeCommit)
 		if err := bd.Close(sourceIssue, reason); err != nil {
 			// Non-fatal: issue might already be closed or not exist

--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -115,8 +115,8 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("cannot determine source issue from branch '%s'; use --issue to specify", branch)
 	}
 
-	// Initialize beads for looking up source issue
-	bd := beads.New(cwd)
+	// Initialize beads for looking up source issue (resolve redirect for polecat worktrees)
+	bd := beads.New(beads.ResolveBeadsDir(cwd))
 
 	// Determine target branch
 	target := defaultBranch

--- a/internal/cmd/release.go
+++ b/internal/cmd/release.go
@@ -44,7 +44,7 @@ func runRelease(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting working directory: %w", err)
 	}
 
-	bd := beads.New(cwd)
+	bd := beads.New(beads.ResolveBeadsDir(cwd))
 
 	// Release each issue
 	var released, failed int

--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -535,8 +535,8 @@ func runRigReset(cmd *cobra.Command, args []string) error {
 
 	// Town beads for handoff/mail operations
 	townBd := beads.New(townRoot)
-	// Rig beads for issue operations (uses cwd to find .beads/)
-	rigBd := beads.New(cwd)
+	// Rig beads for issue operations (resolve redirect for polecat worktrees)
+	rigBd := beads.New(beads.ResolveBeadsDir(cwd))
 
 	// Reset handoff content
 	if resetAll || rigResetHandoff {


### PR DESCRIPTION
## Summary
- `gt mq submit`, `gt release`, `gt rig reset`, and merge callbacks now use `beads.ResolveBeadsDir(cwd)` to properly follow `.beads/redirect` files in polecat worktrees
- Cherry-picked from stale branch `polecat/furiosa-mk18qjeg`

## Files changed
- `internal/cmd/callbacks.go` - handleMergeCompleted uses ResolveBeadsDir
- `internal/cmd/mq_submit.go` - submit uses ResolveBeadsDir
- `internal/cmd/release.go` - release uses ResolveBeadsDir
- `internal/cmd/rig.go` - rig reset uses ResolveBeadsDir

## Test plan
- Run commands from within a polecat worktree that has a `.beads/redirect` file
- Verify beads operations correctly resolve to the rig's beads directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)