### PR TITLE
[DO NOT MERGE] fix: ensure integration test repos use 'main' branch

### DIFF
--- a/internal/cmd/rig_integration_test.go
+++ b/internal/cmd/rig_integration_test.go
@@ -53,6 +53,7 @@ func createTestGitRepo(t *testing.T, name string) string {
 	commitCmds := [][]string{
 		{"git", "add", "."},
 		{"git", "commit", "-m", "Initial commit"},
+		{"git", "branch", "-M", "main"}, // Ensure branch is named 'main' regardless of git config
 	}
 	for _, args := range commitCmds {
 		cmd := exec.Command(args[0], args[1:]...)


### PR DESCRIPTION
## Summary
- Fixes CI integration test failures affecting all PRs
- The test repos were created with git's system default branch (could be 'master'), but `AddRig` tries to checkout `main`
- Fix by explicitly using `git branch -M main` after initial commit

## Root cause
CI environment uses `main` as the default branch, but some git configs default to `master`. The test was not explicitly setting the branch name.

## Test plan
- [x] Ran integration tests locally - all 7 tests pass
- Wait for CI to go green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)