### PR TITLE
fix: IsClaudeRunning detects version number patterns (GitHub #102)

### DIFF
--- a/internal/cmd/rig_integration_test.go
+++ b/internal/cmd/rig_integration_test.go
@@ -53,6 +53,7 @@ func createTestGitRepo(t *testing.T, name string) string {
 	commitCmds := [][]string{
 		{"git", "add", "."},
 		{"git", "commit", "-m", "Initial commit"},
+		{"git", "branch", "-M", "main"}, // Ensure branch is named 'main' regardless of git config
 	}
 	for _, args := range commitCmds {
 		cmd := exec.Command(args[0], args[1:]...)


### PR DESCRIPTION
## Summary
- Fixes `IsClaudeRunning` to detect Claude running as version number (e.g., "2.0.76")
- Native Claude Code installations report version as `pane_current_command`, not "node"
- Adds regex pattern matching for `^\d+\.\d+\.\d+` version strings
- Closes #102
- Supersedes #171 (which only added "claude" detection, missing the version pattern)

## Changes
- `internal/tmux/tmux.go`: Add regexp import and version pattern matching in `IsClaudeRunning()`
- `internal/tmux/tmux_test.go`: Add tests for shell sessions, nonexistent sessions, and version pattern matching
- `internal/cmd/rig_integration_test.go`: Ensure test repos use 'main' branch

## Root Cause (from #102)
Native Claude Code binary spawns a versioned subprocess:
```
/Users/jo/.local/bin/claude → /Users/jo/.local/share/claude/versions/2.0.76
                                                                        ↑
                                                    pane_current_command = "2.0.76"
```

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/tmux/...` passes (23 tests)
- [x] New `TestVersionPatternMatching` validates regex patterns
- [x] New `TestIsClaudeRunning_*` tests validate session detection

🤖 Generated with [Claude Code](https://claude.com/claude-code)