### PR TITLE
fix: Initialize git before beads to enable repo fingerprint

### DIFF
--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -188,6 +188,15 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		fmt.Printf("   ✓ Created .claude/settings.json\n")
 	}
 
+	// Initialize git BEFORE beads so that bd can compute repository fingerprint.
+	// The fingerprint is required for the daemon to start properly.
+	if installGit || installGitHub != "" {
+		fmt.Println()
+		if err := InitGitForHarness(absPath, installGitHub, !installPublic); err != nil {
+			return fmt.Errorf("git initialization failed: %w", err)
+		}
+	}
+
 	// Initialize town-level beads database (optional)
 	// Town beads (hq- prefix) stores mayor mail, cross-rig coordination, and handoffs.
 	// Rig beads are separate and have their own prefixes.
@@ -232,14 +241,6 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		fmt.Printf("   %s Could not provision slash commands: %v\n", style.Dim.Render("⚠"), err)
 	} else {
 		fmt.Printf("   ✓ Created .claude/commands/ (slash commands for all agents)\n")
-	}
-
-	// Initialize git if requested (--git or --github implies --git)
-	if installGit || installGitHub != "" {
-		fmt.Println()
-		if err := InitGitForHarness(absPath, installGitHub, !installPublic); err != nil {
-			return fmt.Errorf("git initialization failed: %w", err)
-		}
 	}
 
 	fmt.Printf("\n%s HQ created successfully!\n", style.Bold.Render("✓"))


### PR DESCRIPTION
## Summary
- Move git initialization before beads initialization when `--git` flag is used
- Fixes fingerprint warning during fresh installs with `--git`

## Problem

When using `gt install --git`, beads initialization tries to compute the repository fingerprint **before** git is initialized:

```
⚠ Could not verify repo fingerprint: bd migrate --update-repo-id: 
   Note: No git repository initialized - running without background sync
   Error: failed to compute repository ID: not a git repository
```

## Solution

Simple reorder in `internal/cmd/install.go`:

**Before:**
1. `initTownBeads()` → tries to compute fingerprint → fails (no .git)
2. `InitGitForHarness()` → creates .git

**After:**
1. `InitGitForHarness()` → creates .git
2. `initTownBeads()` → computes fingerprint → succeeds

Fixes #25