### PR TITLE
[DO NOT MERGE] fix: Use --initial-branch=main in rig integration tests

### DIFF
--- a/internal/cmd/rig_integration_test.go
+++ b/internal/cmd/rig_integration_test.go
@@ -30,9 +30,10 @@ func createTestGitRepo(t *testing.T, name string) string {
 		t.Fatalf("mkdir repo: %v", err)
 	}
 
-	// Initialize git repo
+	// Initialize git repo with explicit main branch
+	// (system default may vary, causing checkout failures)
 	cmds := [][]string{
-		{"git", "init"},
+		{"git", "init", "--initial-branch=main"},
 		{"git", "config", "user.email", "test@test.com"},
 		{"git", "config", "user.name", "Test User"},
 	}


### PR DESCRIPTION
## Summary
- Fixes CI failure in rig integration tests
- Changes `git init` to `git init --initial-branch=main` in test helper

## Problem
The test helper `createTestGitRepo` used plain `git init` which creates a branch based on system default (often `master`). When `AddRig` falls back to "main" for checkout, it fails with:
```
error: pathspec 'main' did not match any file(s) known to git
```

## Fix
Use `git init --initial-branch=main` to explicitly create the main branch.

## Tests Fixed
- TestRigAddCreatesCorrectStructure
- TestRigAddInitializesBeads
- TestRigAddUpdatesRoutes
- TestRigAddUpdatesRigsJson
- TestRigAddDerivesPrefix
- TestRigAddCreatesRigConfig
- TestRigAddCreatesAgentDirs

🤖 Generated with [Claude Code](https://claude.com/claude-code)