### PR TITLE
fix: Add route from rig beads to town beads

### DIFF
--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/templates"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
@@ -545,6 +546,15 @@ func (m *Manager) initBeads(rigPath, prefix string) error {
 	migrateCmd.Env = filteredEnv
 	// Ignore errors - fingerprint is optional for functionality
 	_, _ = migrateCmd.CombinedOutput()
+
+	// Add route from rig beads to town beads for cross-database resolution.
+	// This allows rig beads to resolve hq-* prefixed beads (role beads, etc.)
+	// that are stored in town beads.
+	townRoute := beads.Route{Prefix: "hq-", Path: ".."}
+	if err := beads.WriteRoutes(beadsDir, []beads.Route{townRoute}); err != nil {
+		// Non-fatal: role slot set will fail but agent beads still work
+		fmt.Printf("   %s Could not add route to town beads: %v\n", style.Dim.Render("⚠"), err)
+	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- Add route entry during rig beads initialization to resolve town beads
- Enables rig agents to reference role beads stored in town beads

## Problem

After fixing agent beads to use rig prefix (#48), the role slot setting fails because rig beads can't resolve `hq-*` prefixed beads from town beads:

```
⚠ Could not set role slot for pi-pixelforge-witness: 
   no issue found matching hq-witness-role
```

## Solution

Add a route entry in `initBeads()` in `internal/rig/manager.go`:

```go
townRoute := beads.Route{Prefix: "hq-", Path: ".."}
beads.WriteRoutes(beadsDir, []beads.Route{townRoute})
```

This creates `routes.jsonl` in rig beads:
```json
{"prefix":"hq-","path":".."}
```

Now rig beads can resolve `hq-*` prefixed beads (role beads, town agents) from the parent town beads directory.

Fixes #48