### PR TITLE
fix: replace panic with fallback in ID generation

### DIFF
--- a/internal/mail/types.go
+++ b/internal/mail/types.go
@@ -4,6 +4,7 @@ package mail
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"strings"
 	"time"
 )
@@ -142,19 +143,23 @@ func NewReplyMessage(from, to, subject, body string, original *Message) *Message
 }
 
 // generateID creates a random message ID.
+// Falls back to time-based ID if crypto/rand fails (extremely rare).
 func generateID() string {
 	b := make([]byte, 8)
 	if _, err := rand.Read(b); err != nil {
-		panic("crypto/rand.Read failed: " + err.Error())
+		// Fallback to time-based ID instead of panicking
+		return fmt.Sprintf("msg-%x", time.Now().UnixNano())
 	}
 	return "msg-" + hex.EncodeToString(b)
 }
 
 // generateThreadID creates a random thread ID.
+// Falls back to time-based ID if crypto/rand fails (extremely rare).
 func generateThreadID() string {
 	b := make([]byte, 6)
 	if _, err := rand.Read(b); err != nil {
-		panic("crypto/rand.Read failed: " + err.Error())
+		// Fallback to time-based ID instead of panicking
+		return fmt.Sprintf("thread-%x", time.Now().UnixNano())
 	}
 	return "thread-" + hex.EncodeToString(b)
 }


### PR DESCRIPTION
## Summary
- Replace panic calls in `generateID()` and `generateThreadID()` with time-based fallback
- When `crypto/rand.Read` fails (extremely rare), use `time.Now().UnixNano()` as fallback instead of crashing

## Changes
- `internal/mail/types.go`: Modified ID generation functions to gracefully handle random number generation failures

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/mail/...` passes

🤖 Generated with [Claude Code](https://claude.ai/code)