### PR TITLE
Replace `gt rigs` with `gt rig list` in templates and docs

### DIFF
--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -371,7 +371,7 @@ func outputMayorContext(ctx RoleContext) {
 	fmt.Println("- `gt mail inbox` - Check your messages")
 	fmt.Println("- `gt mail read <id>` - Read a specific message")
 	fmt.Println("- `gt status` - Show overall town status")
-	fmt.Println("- `gt rigs` - List all rigs")
+	fmt.Println("- `gt rig list` - List all rigs")
 	fmt.Println("- `bd ready` - Issues ready to work")
 	fmt.Println()
 	fmt.Println("## Hookable Mail")

--- a/internal/cmd/worktree.go
+++ b/internal/cmd/worktree.go
@@ -113,7 +113,7 @@ func runWorktree(cmd *cobra.Command, args []string) error {
 	// Verify target rig exists
 	_, targetRigInfo, err := getRig(targetRig)
 	if err != nil {
-		return fmt.Errorf("rig '%s' not found - run 'gt rigs' to see available rigs", targetRig)
+		return fmt.Errorf("rig '%s' not found - run 'gt rig list' to see available rigs", targetRig)
 	}
 
 	// Compute worktree path: ~/gt/<target-rig>/crew/<source-rig>-<name>/
@@ -305,7 +305,7 @@ func runWorktreeRemove(cmd *cobra.Command, args []string) error {
 	// Verify target rig exists
 	_, targetRigInfo, err := getRig(targetRig)
 	if err != nil {
-		return fmt.Errorf("rig '%s' not found - run 'gt rigs' to see available rigs", targetRig)
+		return fmt.Errorf("rig '%s' not found - run 'gt rig list' to see available rigs", targetRig)
 	}
 
 	// Compute worktree path: ~/gt/<target-rig>/crew/<source-rig>-<name>/

--- a/internal/formula/formulas/mol-digest-generate.formula.toml
+++ b/internal/formula/formulas/mol-digest-generate.formula.toml
@@ -78,7 +78,7 @@ Gather activity data from each rig in the town.
 
 **1. List accessible rigs:**
 ```bash
-gt rigs
+gt rig list
 # Returns list of rigs: gastown, beads, etc.
 ```
 

--- a/internal/formula/formulas/mol-orphan-scan.formula.toml
+++ b/internal/formula/formulas/mol-orphan-scan.formula.toml
@@ -57,7 +57,7 @@ gt hook               # Shows scope in hook_bead
 
 ```bash
 # If town-wide
-gt rigs                     # Get list of all rigs
+gt rig list                 # Get list of all rigs
 
 # If specific rig
 # Just use that rig

--- a/internal/formula/formulas/mol-town-shutdown.formula.toml
+++ b/internal/formula/formulas/mol-town-shutdown.formula.toml
@@ -85,7 +85,7 @@ Archive and clear all agent inboxes across all rigs.
 
 ```bash
 # For each rig
-for rig in $(gt rigs --names); do
+for rig in $(gt rig list --names); do
   gt mail clear $rig/witness --archive
   gt mail clear $rig/refinery --archive
 done

--- a/internal/templates/roles/mayor.md.tmpl
+++ b/internal/templates/roles/mayor.md.tmpl
@@ -188,7 +188,7 @@ bd show hq-abc      # Routes to town beads
 
 ### Status
 - `gt status` - Overall town status
-- `gt rigs` - List all rigs
+- `gt rig list` - List all rigs
 - `gt polecat list [rig]` - List polecats in a rig
 
 ### Work Management

--- a/npm-package/README.md
+++ b/npm-package/README.md
@@ -23,7 +23,7 @@ gt init
 gt status
 
 # List rigs
-gt rigs
+gt rig list
 ```
 
 ## Supported Platforms


### PR DESCRIPTION
## Summary
The command appears to have been renamed from `gt rigs` to `gt rig` with subcommands. This updates all references to use `gt rig list` for listing rigs.

My mayor, deacon, etc kept trying to run `git rigs` because it was in their AGENTS.md, but that command doesn't exist. I'm assuming this is the better fix than renaming the command. 😉 

## Changes
- Fix docs and templates to refer to correct `git rig list` command as appropriate.

## Testing
- [ ] I did not test this at all. I just looked at the diff.

## Checklist
- [X] Code follows project style
- [X] Documentation updated (if applicable)
- [X] No breaking changes (or documented in summary)
