### PR TITLE
Add .repo.git/ to gitignore during rig setup

### DIFF
--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -987,7 +987,10 @@ See docs/deacon-plugins.md for full documentation.
 		return fmt.Errorf("creating rig plugins directory: %w", err)
 	}
 
-	// Add plugins/ to rig .gitignore
+	// Add plugins/ and .repo.git/ to rig .gitignore
 	gitignorePath := filepath.Join(rigPath, ".gitignore")
-	return m.ensureGitignoreEntry(gitignorePath, "plugins/")
+	if err := m.ensureGitignoreEntry(gitignorePath, "plugins/"); err != nil {
+		return err
+	}
+	return m.ensureGitignoreEntry(gitignorePath, ".repo.git/")
 }


### PR DESCRIPTION
## Summary

When running `git install --git` and then adding rigs, the bare repos are not ignored.

Adds .rego.git in the rig directories to the right .gitignore. This prevents .repo.git/ directories from showing up as untracked files in town git status.

## Changes
- manager.go: Add .repo.git/ to rig .gitignore during setup

## Testing
- [X] Unit tests pass (`go test ./...`)
- [X] Manual testing performed (`.gitignore` generates with `.repo.git` which works correctly)

## Checklist
- [X] Code follows project style
- [ ] Documentation updated (if applicable)
- [X] No breaking changes (or documented in summary)
