### PR TITLE
Fix zombie tmux session detection across all startup paths

### DIFF
--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -948,7 +948,7 @@ func startCrewMember(rigName, crewName, townRoot string) error {
 	t := tmux.NewTmux()
 	sessionID := crewSessionName(rigName, crewName)
 
-	healthy, err := t.EnsureSessionClear(sessionID)
+	healthy, _, err := t.EnsureSessionClear(sessionID)
 	if err != nil {
 		return err
 	}

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -250,7 +250,7 @@ func ensureDaemon(townRoot string) error {
 // ensureSession starts a Claude session if not running.
 // Handles zombie sessions (tmux alive but Claude dead) by killing and recreating.
 func ensureSession(t *tmux.Tmux, sessionName, workDir, role string) error {
-	healthy, err := t.EnsureSessionClear(sessionName)
+	healthy, _, err := t.EnsureSessionClear(sessionName)
 	if err != nil {
 		return err
 	}
@@ -421,7 +421,7 @@ func startCrewFromSettings(t *tmux.Tmux, townRoot, rigName string) ([]string, ma
 		sessionName := fmt.Sprintf("gt-%s-crew-%s", rigName, crewName)
 
 		// Check for existing session, handle zombies
-		healthy, err := t.EnsureSessionClear(sessionName)
+		healthy, _, err := t.EnsureSessionClear(sessionName)
 		if err != nil {
 			errors[crewName] = err
 			continue

--- a/internal/session/manager.go
+++ b/internal/session/manager.go
@@ -123,7 +123,7 @@ func (m *Manager) Start(polecat string, opts StartOptions) error {
 	sessionID := m.SessionName(polecat)
 
 	// Check if session already exists, handle zombies
-	healthy, err := m.tmux.EnsureSessionClear(sessionID)
+	healthy, _, err := m.tmux.EnsureSessionClear(sessionID)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
## Summary

  Fix zombie session detection across all session creation paths. A "zombie" session is one where tmux is alive but Claude has exited (pane shows `bash` instead of `claude`). Previously, `gt up` and other commands would report these sessions as healthy and skip recreation.

  ## Related Issue

  Fixes #102 - IsClaudeRunning detection failures
  Based on PR #200 (rebased onto main)

  ## Changes

  - Add `EnsureSessionClear()` helper for consistent zombie detection across all session creation paths
  - Fix `IsClaudeRunning()` to detect "claude" binary (was only checking for "node")
  - Add version pattern detection for Claude (e.g., "2.0.76") from PR #200
  - Add mock-based unit tests for zombie detection logic

  ## Testing

  - [x] Unit tests pass (`go test ./...`)
  - [x] Manual testing performed

  ### Manual Test: Zombie Detection

  ```bash
  # Verify healthy session
  $ tmux display -t hq-mayor -p '#{pane_current_command}'
  claude

  # Create zombie by killing Claude process
  $ kill $(pstree -p $(tmux list-panes -t hq-mayor -F '#{pane_pid}') | grep -oP 'claude\(\K[0-9]+' | head -1)
  $ tmux display -t hq-mayor -p '#{pane_current_command}'
  bash   # ZOMBIE: tmux alive, Claude dead

  # Run gt up (with fix)
  $ gt up
  ✓ Mayor: hq-mayor
  ✓ All services running

  # Verify fix
  $ tmux display -t hq-mayor -p '#{pane_current_command}'
  claude   # FIXED: Session recreated with Claude running

  Results

  | State                    | Before Fix                        | After Fix                            |
  |--------------------------|-----------------------------------|--------------------------------------|
  | Zombie detected          | ❌ Reports healthy, leaves zombie | ✅ Detects zombie, kills & recreates |
  | Pane command after gt up | bash (zombie persists)            | claude (healthy)                     |
```
  

### Checklist

  [X] Code follows project style
  [X] Documentation updated (if applicable)
  [X] No breaking changes