### PR TITLE
fix(sling): parse bd mol wisp --json new_epic_id

### DIFF
--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -2,6 +2,58 @@ package cmd
 
 import "testing"
 
+func TestParseWispIDFromJSON(t *testing.T) {
+	tests := []struct {
+		name    string
+		json    string
+		wantID  string
+		wantErr bool
+	}{
+		{
+			name:   "new_epic_id",
+			json:   `{"new_epic_id":"gt-wisp-abc","created":7,"phase":"vapor"}`,
+			wantID: "gt-wisp-abc",
+		},
+		{
+			name:   "root_id legacy",
+			json:   `{"root_id":"gt-wisp-legacy"}`,
+			wantID: "gt-wisp-legacy",
+		},
+		{
+			name:   "result_id forward compat",
+			json:   `{"result_id":"gt-wisp-result"}`,
+			wantID: "gt-wisp-result",
+		},
+		{
+			name:   "precedence prefers new_epic_id",
+			json:   `{"root_id":"gt-wisp-legacy","new_epic_id":"gt-wisp-new"}`,
+			wantID: "gt-wisp-new",
+		},
+		{
+			name:    "missing id keys",
+			json:    `{"created":7,"phase":"vapor"}`,
+			wantErr: true,
+		},
+		{
+			name:    "invalid JSON",
+			json:    `{"new_epic_id":`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotID, err := parseWispIDFromJSON([]byte(tt.json))
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseWispIDFromJSON() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if gotID != tt.wantID {
+				t.Fatalf("parseWispIDFromJSON() id = %q, want %q", gotID, tt.wantID)
+			}
+		})
+	}
+}
+
 func TestFormatTrackBeadID(t *testing.T) {
 	tests := []struct {
 		name     string


### PR DESCRIPTION
Fix formula-on-bead mode (gt sling <formula> --on <bead> ...) and standalone formula slinging to parse the wisp id from bd mol wisp --json.

bd mol wisp --json returns {"new_epic_id": ...} (not root_id), which previously caused an empty id and then bd mol bond "" <bead>.

Changes:
- Add parseWispIDFromJSON helper supporting new_epic_id (current), root_id (legacy), result_id (forward compat).
- Use helper in both wisp creation call sites.
- Add unit tests for the helper.

Note: cross-rig routing for --on is a separate issue (see #148/#149 / upstream bead gt-myeym).