### PR TITLE
  test(polecat): skip beads-unavailable test when bd is installed

### DIFF
--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -2,6 +2,7 @@ package polecat
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"testing"
 
@@ -144,6 +145,13 @@ func TestAssigneeID(t *testing.T) {
 func TestGetReturnsWorkingWithoutBeads(t *testing.T) {
 	// When beads is not available, Get should return StateWorking
 	// (assume the polecat is doing something if it exists)
+	//
+	// Skip if bd is installed - the test assumes bd is unavailable, but when bd
+	// is present it queries beads and returns actual state instead of defaulting.
+	if _, err := exec.LookPath("bd"); err == nil {
+		t.Skip("skipping: bd is installed, test requires bd to be unavailable")
+	}
+
 	root := t.TempDir()
 	polecatDir := filepath.Join(root, "polecats", "Test")
 	if err := os.MkdirAll(polecatDir, 0755); err != nil {


### PR DESCRIPTION
## Summary

  `TestGetReturnsWorkingWithoutBeads` assumes bd is not available and expects polecat state to default to `StateWorking`. When bd is installed locally, it actually queries beads and returns the real state, causing the test to fail.

  Skip the test when bd is detected to avoid environment-dependent failures.

  ## Related Issue

  N/A - flaky test fix

  ## Testing

  - [x] Unit tests pass (`go test ./...`)
  - [x] Lint passes

  ## Checklist

  - [x] Code follows project style
  - [x] Documentation updated (if applicable)
  - [x] No breaking changes (or documented in summary)