### PR TITLE
Fix gt costs record auto-detection for Mayor/Deacon sessions

### DIFF
--- a/internal/cmd/costs.go
+++ b/internal/cmd/costs.go
@@ -650,9 +650,13 @@ func deriveSessionName() string {
 		return fmt.Sprintf("gt-%s-crew-%s", rig, crew)
 	}
 
-	// Town-level roles (mayor, deacon): gt-{town}-{role}
-	if (role == "mayor" || role == "deacon") && town != "" {
-		return fmt.Sprintf("gt-%s-%s", town, role)
+	// Town-level roles (mayor, deacon): gt-{town}-{role} or gt-{role}
+	if role == "mayor" || role == "deacon" {
+		if town != "" {
+			return fmt.Sprintf("gt-%s-%s", town, role)
+		}
+		// No town set - use simple gt-{role} pattern
+		return fmt.Sprintf("gt-%s", role)
 	}
 
 	// Rig-based roles (witness, refinery): gt-{rig}-{role}

--- a/internal/cmd/costs_test.go
+++ b/internal/cmd/costs_test.go
@@ -62,6 +62,20 @@ func TestDeriveSessionName(t *testing.T) {
 			expected: "gt-ai-deacon",
 		},
 		{
+			name: "mayor session without GT_TOWN",
+			envVars: map[string]string{
+				"GT_ROLE": "mayor",
+			},
+			expected: "gt-mayor",
+		},
+		{
+			name: "deacon session without GT_TOWN",
+			envVars: map[string]string{
+				"GT_ROLE": "deacon",
+			},
+			expected: "gt-deacon",
+		},
+		{
 			name:     "no env vars",
 			envVars:  map[string]string{},
 			expected: "",


### PR DESCRIPTION
## Summary
Error: Ran 1 stop hook
  ⎿  Stop hook error: Failed with non-blocking status code: Error: --session flag required (or set GT_SESSION env var, or GT_RIG/GT_ROLE)
  Usage:
    gt costs record [flags]

## Related Issue
<!-- Link to issue: Fixes #123 or Closes #123 -->

## Changes
- deriveSessionName() now falls back to gt-{role} when GT_ROLE is mayor or deacon but GT_TOWN is not set. Previously this case returned empty string, causing the Stop hook to fail.

## Testing
<!-- How did you test these changes? -->
- [X] Unblocks hooks that fail with the above error. Shown with manual testing.

## Checklist
- [X] Code follows project style
- [ ] Documentation updated (if applicable)
- [X] No breaking changes (or documented in summary)
