### PR TITLE
fix: Register custom beads types during install

### DIFF
--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -321,6 +321,14 @@ func initTownBeads(townPath string) error {
 		fmt.Printf("   %s Could not verify repo fingerprint: %v\n", style.Dim.Render("⚠"), err)
 	}
 
+	// Register Gas Town custom types (agent, role, rig, convoy, slot).
+	// These types are not built into beads core - they must be registered
+	// before creating agent/role beads. See GH #gt-xyz for context.
+	if err := ensureCustomTypes(townPath); err != nil {
+		// Non-fatal but will cause agent bead creation to fail
+		fmt.Printf("   %s Could not register custom types: %v\n", style.Dim.Render("⚠"), err)
+	}
+
 	return nil
 }
 
@@ -333,6 +341,20 @@ func ensureRepoFingerprint(beadsPath string) error {
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("bd migrate --update-repo-id: %s", strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+// ensureCustomTypes registers Gas Town custom issue types with beads.
+// Beads core only supports built-in types (bug, feature, task, etc.).
+// Gas Town needs custom types: agent, role, rig, convoy, slot.
+// This is idempotent - safe to call multiple times.
+func ensureCustomTypes(beadsPath string) error {
+	cmd := exec.Command("bd", "config", "set", "types.custom", "agent,role,rig,convoy,slot")
+	cmd.Dir = beadsPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("bd config set types.custom: %s", strings.TrimSpace(string(output)))
 	}
 	return nil
 }


### PR DESCRIPTION
## Summary
- Fixes installation failing to create agent/role beads with "invalid issue type: agent" error
- Adds `ensureCustomTypes()` function that runs `bd config set types.custom "agent,role,rig,convoy,slot"` after `bd init`
- The fix is idempotent - safe to run multiple times

## Problem
During `gt install`, the beads database is initialized with `bd init --prefix hq`, but Gas Town's custom issue types (agent, role, rig, convoy, slot) were not being registered. This caused subsequent `bd create --type=agent` calls to fail.

## Solution
Added `ensureCustomTypes()` function in `internal/cmd/install.go` that registers Gas Town's custom types with beads right after database initialization.

## Test plan
- [x] Fresh install with `gt install ~/test-workspace --git` completes successfully
- [x] All role beads (hq-mayor-role, hq-deacon-role, etc.) are created
- [x] All agent beads (hq-mayor, hq-deacon) are created  
- [x] `bd config get types.custom` returns `agent,role,rig,convoy,slot`
- [x] `gt doctor` shows no errors for agent-beads-exist check

🤖 Generated with [Claude Code](https://claude.com/claude-code)