### PR TITLE
fix(tmux): wait for shell ready before sending keys

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -197,6 +197,11 @@ func (b *Boot) spawnTmux() error {
 	// Launch Claude with environment exported inline and initial triage prompt
 	// The "gt boot triage" prompt tells Boot to immediately start triage (GUPP principle)
 	startCmd := config.BuildAgentStartupCommand("boot", "deacon-boot", "", "gt boot triage")
+	// Wait for shell to be ready before sending keys (prevents "can't find pane" under load)
+	if err := b.tmux.WaitForShellReady(SessionName, 5*time.Second); err != nil {
+		_ = b.tmux.KillSession(SessionName)
+		return fmt.Errorf("waiting for shell: %w", err)
+	}
 	if err := b.tmux.SendKeys(SessionName, startCmd); err != nil {
 		return fmt.Errorf("sending startup command: %w", err)
 	}

--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -99,6 +99,11 @@ func (m *Manager) Start() error {
 		runtimeCmd,
 	)
 
+	// Wait for shell to be ready before sending keys (prevents "can't find pane" under load)
+	if err := t.WaitForShellReady(sessionID, 5*time.Second); err != nil {
+		_ = t.KillSession(sessionID)
+		return fmt.Errorf("waiting for shell: %w", err)
+	}
 	if err := t.SendKeysDelayed(sessionID, respawnCmd, 200); err != nil {
 		_ = t.KillSession(sessionID) // best-effort cleanup
 		return fmt.Errorf("starting Claude agent: %w", err)

--- a/internal/mayor/manager.go
+++ b/internal/mayor/manager.go
@@ -98,6 +98,11 @@ func (m *Manager) Start(agentOverride string) error {
 		_ = t.KillSession(sessionID) // best-effort cleanup
 		return fmt.Errorf("building startup command: %w", err)
 	}
+	// Wait for shell to be ready before sending keys (prevents "can't find pane" under load)
+	if err := t.WaitForShellReady(sessionID, 5*time.Second); err != nil {
+		_ = t.KillSession(sessionID)
+		return fmt.Errorf("waiting for shell: %w", err)
+	}
 	if err := t.SendKeysDelayed(sessionID, startupCmd, 200); err != nil {
 		_ = t.KillSession(sessionID) // best-effort cleanup
 		return fmt.Errorf("starting Claude agent: %w", err)

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -183,6 +183,11 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 	if command == "" {
 		command = config.BuildPolecatStartupCommand(m.rig.Name, polecat, m.rig.Path, "")
 	}
+	// Wait for shell to be ready before sending keys (prevents "can't find pane" under load)
+	if err := m.tmux.WaitForShellReady(sessionID, 5*time.Second); err != nil {
+		_ = m.tmux.KillSession(sessionID)
+		return fmt.Errorf("waiting for shell: %w", err)
+	}
 	if err := m.tmux.SendKeys(sessionID, command); err != nil {
 		return fmt.Errorf("sending command: %w", err)
 	}


### PR DESCRIPTION
## Summary

  Add `WaitForShellReady` call before `SendKeys` in all agent managers to prevent intermittent "can't find pane" errors during startup.

  ## Related Issue

  None (race condition fix)

  ## Testing

  - [x] Unit tests pass (`go test ./...`)
  - [x] Manual testing performed
    - [x] `gt up` starts all agents without "can't find pane" errors
    - [x] `gt start --all` starts agents reliably under load

  ## Checklist

  - [x] Code follows project style
  - [x] Documentation updated (if applicable)
  - [x] No breaking changes (or documented in summary)

  🤖 Generated with [Claude Code](https://claude.com/claude-code)