### PR TITLE
fix(formula): boot triage checks wrong session name, causing deacon restarts

### DIFF
--- a/.beads/formulas/mol-boot-triage.formula.toml
+++ b/.beads/formulas/mol-boot-triage.formula.toml
@@ -27,7 +27,7 @@ Observe the current system state to inform triage decisions.
 **Step 1: Check Deacon state**
 ```bash
 # Is Deacon session alive?
-tmux has-session -t gt-deacon 2>/dev/null && echo "alive" || echo "dead"
+tmux has-session -t hq-deacon 2>/dev/null && echo "alive" || echo "dead"
 
 # If alive, what's the pane output showing?
 gt peek deacon --lines 20
@@ -125,7 +125,7 @@ gt nudge deacon "Boot check-in: you have pending work"
 **WAKE**
 ```bash
 # Send escape to break any tool waiting
-tmux send-keys -t gt-deacon Escape
+tmux send-keys -t hq-deacon Escape
 
 # Brief pause
 sleep 1

--- a/.beads/formulas/mol-gastown-boot.formula.toml
+++ b/.beads/formulas/mol-gastown-boot.formula.toml
@@ -48,7 +48,7 @@ gt deacon start
 ```
 
 ## Verify
-1. Session exists: `tmux has-session -t gt-deacon 2>/dev/null`
+1. Session exists: `tmux has-session -t hq-deacon 2>/dev/null`
 2. Not stalled: `gt peek deacon/` does NOT show \"> Try\" prompt
 3. Heartbeat fresh: `deacon/heartbeat.json` modified < 2 min ago
 

--- a/internal/formula/formulas/mol-boot-triage.formula.toml
+++ b/internal/formula/formulas/mol-boot-triage.formula.toml
@@ -27,7 +27,7 @@ Observe the current system state to inform triage decisions.
 **Step 1: Check Deacon state**
 ```bash
 # Is Deacon session alive?
-tmux has-session -t gt-deacon 2>/dev/null && echo "alive" || echo "dead"
+tmux has-session -t hq-deacon 2>/dev/null && echo "alive" || echo "dead"
 
 # If alive, what's the pane output showing?
 gt peek deacon --lines 20
@@ -125,7 +125,7 @@ gt nudge deacon "Boot check-in: you have pending work"
 **WAKE**
 ```bash
 # Send escape to break any tool waiting
-tmux send-keys -t gt-deacon Escape
+tmux send-keys -t hq-deacon Escape
 
 # Brief pause
 sleep 1

--- a/internal/formula/formulas/mol-gastown-boot.formula.toml
+++ b/internal/formula/formulas/mol-gastown-boot.formula.toml
@@ -48,7 +48,7 @@ gt deacon start
 ```
 
 ## Verify
-1. Session exists: `tmux has-session -t gt-deacon 2>/dev/null`
+1. Session exists: `tmux has-session -t hq-deacon 2>/dev/null`
 2. Not stalled: `gt peek deacon/` does NOT show \"> Try\" prompt
 3. Heartbeat fresh: `deacon/heartbeat.json` modified < 2 min ago
 


### PR DESCRIPTION
## Summary

  Boot triage incorrectly checks for a `gt-deacon` tmux session, but the actual session is named `hq-deacon`. This causes boot triage to think deacon is dead on every tick, triggering unnecessary session terminations that disrupt ongoing work.

  ## Related Issue

  None

  ## Changes

  - Fix `gt-deacon` → `hq-deacon` in mol-boot-triage.formula.toml (2 occurrences)
  - Fix `gt-deacon` → `hq-deacon` in mol-gastown-boot.formula.toml (1 occurrence)
  - Update both canonical (`.beads/formulas/`) and embedded (`internal/formula/formulas/`) copies

  ## Testing

  - [x] Unit tests pass (`go test ./...`)
  - [x] Manual testing performed

  ## Checklist

  - [x] Code follows project style
  - [x] Documentation updated (if applicable)
  - [x] No breaking changes (or documented in summary)