### PR TITLE
DO NOT MERGE feat: add GT_ROOT environment variable to all agent session starts

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -192,6 +192,7 @@ func (b *Boot) spawnTmux() error {
 
 	// Set environment
 	_ = b.tmux.SetEnvironment(SessionName, "GT_ROLE", "boot")
+	_ = b.tmux.SetEnvironment(SessionName, "GT_ROOT", b.townRoot)
 	_ = b.tmux.SetEnvironment(SessionName, "BD_ACTOR", "deacon-boot")
 
 	// Launch Claude with environment exported inline and initial triage prompt
@@ -218,6 +219,7 @@ func (b *Boot) spawnDegraded() error {
 	cmd.Dir = b.deaconDir
 	cmd.Env = append(os.Environ(),
 		"GT_ROLE=boot",
+		"GT_ROOT="+b.townRoot,
 		"BD_ACTOR=deacon-boot",
 		"GT_DEGRADED=true",
 	)

--- a/internal/cmd/crew_at.go
+++ b/internal/cmd/crew_at.go
@@ -136,6 +136,7 @@ func runCrewAt(cmd *cobra.Command, args []string) error {
 		_ = t.SetEnvironment(sessionID, "GT_ROLE", "crew")
 		_ = t.SetEnvironment(sessionID, "GT_RIG", r.Name)
 		_ = t.SetEnvironment(sessionID, "GT_CREW", name)
+		_ = t.SetEnvironment(sessionID, "GT_ROOT", townRoot)
 
 		// Set CLAUDE_CONFIG_DIR for account selection (non-fatal)
 		if claudeConfigDir != "" {

--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -359,6 +359,7 @@ func startDeaconSession(t *tmux.Tmux, sessionName, agentOverride string) error {
 	// Set environment (non-fatal: session works without these)
 	_ = t.SetEnvironment(sessionName, "GT_ROLE", "deacon")
 	_ = t.SetEnvironment(sessionName, "BD_ACTOR", "deacon")
+	_ = t.SetEnvironment(sessionName, "GT_ROOT", townRoot)
 
 	// Apply Deacon theme (non-fatal: theming failure doesn't affect operation)
 	// Note: ConfigureGasTownSession includes cycle bindings

--- a/internal/crew/manager.go
+++ b/internal/crew/manager.go
@@ -484,6 +484,7 @@ func (m *Manager) Start(name string, opts StartOptions) error {
 	_ = t.SetEnvironment(sessionID, "GT_RIG", m.rig.Name)
 	_ = t.SetEnvironment(sessionID, "GT_CREW", name)
 	_ = t.SetEnvironment(sessionID, "GT_ROLE", "crew")
+	_ = t.SetEnvironment(sessionID, "GT_ROOT", filepath.Dir(m.rig.Path))
 
 	// Set CLAUDE_CONFIG_DIR for account selection (non-fatal)
 	if opts.ClaudeConfigDir != "" {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -325,6 +325,7 @@ func (d *Daemon) ensureDeaconRunning() {
 
 	// Set environment (non-fatal: session works without these)
 	_ = d.tmux.SetEnvironment(sessionName, "GT_ROLE", "deacon")
+	_ = d.tmux.SetEnvironment(sessionName, "GT_ROOT", d.config.TownRoot)
 	_ = d.tmux.SetEnvironment(sessionName, "BD_ACTOR", "deacon")
 
 	// Launch Claude directly (no shell respawn loop)
@@ -801,6 +802,7 @@ func (d *Daemon) restartPolecatSession(rigName, polecatName, sessionName string)
 
 	// Set environment variables
 	_ = d.tmux.SetEnvironment(sessionName, "GT_ROLE", "polecat")
+	_ = d.tmux.SetEnvironment(sessionName, "GT_ROOT", d.config.TownRoot)
 	_ = d.tmux.SetEnvironment(sessionName, "GT_RIG", rigName)
 	_ = d.tmux.SetEnvironment(sessionName, "GT_POLECAT", polecatName)
 

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -478,8 +478,9 @@ func (d *Daemon) getStartCommand(roleConfig *beads.RoleConfig, parsed *ParsedIde
 // setSessionEnvironment sets environment variables for the tmux session.
 // Uses role bead config if available, falls back to hardcoded defaults.
 func (d *Daemon) setSessionEnvironment(sessionName, identity string, config *beads.RoleConfig, parsed *ParsedIdentity) {
-	// Always set GT_ROLE
+	// Always set GT_ROLE and GT_ROOT
 	_ = d.tmux.SetEnvironment(sessionName, "GT_ROLE", identity)
+	_ = d.tmux.SetEnvironment(sessionName, "GT_ROOT", d.config.TownRoot)
 
 	// BD_ACTOR uses slashes instead of dashes for path-like identity
 	bdActor := identityToBDActor(identity)

--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -87,6 +87,7 @@ func (m *Manager) Start(agentOverride string) error {
 	// Set environment variables (non-fatal: session works without these)
 	_ = t.SetEnvironment(sessionID, "GT_ROLE", "deacon")
 	_ = t.SetEnvironment(sessionID, "BD_ACTOR", "deacon")
+	_ = t.SetEnvironment(sessionID, "GT_ROOT", m.townRoot)
 
 	// Apply Deacon theming (non-fatal: theming failure doesn't affect operation)
 	theme := tmux.DeaconTheme()

--- a/internal/mayor/manager.go
+++ b/internal/mayor/manager.go
@@ -85,6 +85,7 @@ func (m *Manager) Start(agentOverride string) error {
 
 	// Set environment variables (non-fatal: session works without these)
 	_ = t.SetEnvironment(sessionID, "GT_ROLE", "mayor")
+	_ = t.SetEnvironment(sessionID, "GT_ROOT", m.townRoot)
 	_ = t.SetEnvironment(sessionID, "BD_ACTOR", "mayor")
 
 	// Apply Mayor theming (non-fatal: theming failure doesn't affect operation)

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -179,7 +179,9 @@ func (m *Manager) Start(foreground bool) error {
 
 	// Set environment variables (non-fatal: session works without these)
 	bdActor := fmt.Sprintf("%s/refinery", m.rig.Name)
+	townRoot := filepath.Dir(m.rig.Path)
 	_ = t.SetEnvironment(sessionID, "GT_RIG", m.rig.Name)
+	_ = t.SetEnvironment(sessionID, "GT_ROOT", townRoot)
 	_ = t.SetEnvironment(sessionID, "GT_REFINERY", "1")
 	_ = t.SetEnvironment(sessionID, "GT_ROLE", "refinery")
 	_ = t.SetEnvironment(sessionID, "BD_ACTOR", bdActor)

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -158,8 +158,10 @@ func (m *Manager) Start(foreground bool) error {
 
 	// Set environment variables (non-fatal: session works without these)
 	bdActor := fmt.Sprintf("%s/witness", m.rig.Name)
+	townRoot := filepath.Dir(m.rig.Path)
 	_ = t.SetEnvironment(sessionID, "GT_ROLE", "witness")
 	_ = t.SetEnvironment(sessionID, "GT_RIG", m.rig.Name)
+	_ = t.SetEnvironment(sessionID, "GT_ROOT", townRoot)
 	_ = t.SetEnvironment(sessionID, "BD_ACTOR", bdActor)
 
 	// Apply Gas Town theming (non-fatal: theming failure doesn't affect operation)


### PR DESCRIPTION
## Summary

- Adds `GT_ROOT` environment variable to all agent session starts
- Fixes formula lookup from deacon and other agents that run from town-level directories
- The `bd formula` command uses `$GT_ROOT` to find town-level formulas in search path 3

## Problem

Agents like the deacon couldn't find formulas because `bd formula list` only searched:
1. Current directory's `.beads/formulas/`
2. User home's `~/.beads/formulas/`

Missing: `$GT_ROOT/.beads/formulas/` (town root) because GT_ROOT wasn't set.

## Solution

Add `GT_ROOT=townRoot` to all 10 session start locations:
- `boot/boot.go` - boot sessions
- `cmd/crew_at.go` - crew sessions  
- `cmd/deacon.go` - deacon sessions
- `crew/manager.go` - crew manager
- `daemon/daemon.go` - daemon-spawned sessions
- `daemon/lifecycle.go` - lifecycle-spawned sessions
- `deacon/manager.go` - deacon manager
- `mayor/manager.go` - mayor sessions
- `refinery/manager.go` - refinery sessions
- `witness/manager.go` - witness sessions

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/...` passes
- [ ] Manual: restart deacon, verify `bd formula list` shows town formulas

🤖 Generated with [Claude Code](https://claude.com/claude-code)