### PR TITLE
fix: improve integration test reliability

### DIFF
--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -88,9 +88,9 @@ func TestWrapError(t *testing.T) {
 	b := New("/test")
 
 	tests := []struct {
-		stderr   string
-		wantErr  error
-		wantNil  bool
+		stderr  string
+		wantErr error
+		wantNil bool
 	}{
 		{"not a beads repository", ErrNotARepo, false},
 		{"No .beads directory found", ErrNotARepo, false},
@@ -127,7 +127,6 @@ func TestIntegration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Walk up to find .beads
 	dir := cwd
 	for {
 		if _, err := os.Stat(filepath.Join(dir, ".beads")); err == nil {
@@ -138,6 +137,11 @@ func TestIntegration(t *testing.T) {
 			t.Skip("no .beads directory found in path")
 		}
 		dir = parent
+	}
+
+	dbPath := filepath.Join(dir, ".beads", "beads.db")
+	if _, err := os.Stat(dbPath); os.IsNotExist(err) {
+		t.Skip("no beads.db found (JSONL-only repo)")
 	}
 
 	b := New(dir)
@@ -201,10 +205,10 @@ func TestIntegration(t *testing.T) {
 // TestParseMRFields tests parsing MR fields from issue descriptions.
 func TestParseMRFields(t *testing.T) {
 	tests := []struct {
-		name        string
-		issue       *Issue
-		wantNil     bool
-		wantFields  *MRFields
+		name       string
+		issue      *Issue
+		wantNil    bool
+		wantFields *MRFields
 	}{
 		{
 			name:    "nil issue",
@@ -521,8 +525,8 @@ author: someone
 target: main`,
 			},
 			fields: &MRFields{
-				Branch:     "polecat/Capable/gt-ghi",
-				Target:     "integration/epic",
+				Branch:      "polecat/Capable/gt-ghi",
+				Target:      "integration/epic",
 				CloseReason: "merged",
 			},
 			want: `branch: polecat/Capable/gt-ghi
@@ -1032,10 +1036,10 @@ func TestParseAgentBeadID(t *testing.T) {
 		// Parseable but not valid agent roles (IsAgentSessionBead will reject)
 		{"gt-abc123", "", "abc123", "", true}, // Parses as town-level but not valid role
 		// Other prefixes (bd-, hq-)
-		{"bd-mayor", "", "mayor", "", true},                               // bd prefix town-level
-		{"bd-beads-witness", "beads", "witness", "", true},                // bd prefix rig-level singleton
-		{"bd-beads-polecat-pearl", "beads", "polecat", "pearl", true},     // bd prefix rig-level named
-		{"hq-mayor", "", "mayor", "", true},                               // hq prefix town-level
+		{"bd-mayor", "", "mayor", "", true},                           // bd prefix town-level
+		{"bd-beads-witness", "beads", "witness", "", true},            // bd prefix rig-level singleton
+		{"bd-beads-polecat-pearl", "beads", "polecat", "pearl", true}, // bd prefix rig-level named
+		{"hq-mayor", "", "mayor", "", true},                           // hq prefix town-level
 		// Truly invalid patterns
 		{"x-mayor", "", "", "", false},    // Prefix too short (1 char)
 		{"abcd-mayor", "", "", "", false}, // Prefix too long (4 chars)

--- a/internal/config/integration_test.go
+++ b/internal/config/integration_test.go
@@ -259,25 +259,36 @@ func writeTownJSON(t *testing.T, path string, data interface{}) {
 	}
 }
 
-// testTmuxSessionWithStubAgent tests that a tmux session runs the stub agent.
+func pollForOutput(t *testing.T, sessionName, expected string, timeout time.Duration) (string, bool) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		output := captureTmuxPane(t, sessionName, 50)
+		if strings.Contains(output, expected) {
+			return output, true
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+	return captureTmuxPane(t, sessionName, 50), false
+}
+
 func testTmuxSessionWithStubAgent(t *testing.T, tmpDir, stubAgentPath, rigName string) {
 	t.Helper()
 
-	sessionName := fmt.Sprintf("gt-test-%d", time.Now().UnixNano())
+	sessionName := fmt.Sprintf("gt-test-pid%d-%d", os.Getpid(), time.Now().UnixNano())
 	workDir := tmpDir
 
-	// Cleanup session on exit
+	exec.Command("tmux", "kill-session", "-t", sessionName).Run()
+
 	defer func() {
 		exec.Command("tmux", "kill-session", "-t", sessionName).Run()
 	}()
 
-	// Create tmux session
 	cmd := exec.Command("tmux", "new-session", "-d", "-s", sessionName, "-c", workDir)
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Failed to create tmux session: %v", err)
 	}
 
-	// Set environment variables
 	envVars := map[string]string{
 		"GT_ROLE":    "polecat",
 		"GT_POLECAT": "test-polecat",
@@ -291,53 +302,39 @@ func testTmuxSessionWithStubAgent(t *testing.T, tmpDir, stubAgentPath, rigName s
 		}
 	}
 
-	// Send the stub agent command
 	agentCmd := fmt.Sprintf("%s --test-mode --stub", stubAgentPath)
 	cmd = exec.Command("tmux", "send-keys", "-t", sessionName, agentCmd, "Enter")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Failed to send keys: %v", err)
 	}
 
-	// Wait for agent to start
-	time.Sleep(2 * time.Second)
-
-	// Capture pane output
-	output := captureTmuxPane(t, sessionName, 50)
-
-	// Verify stub agent started
-	if !strings.Contains(output, "STUB_AGENT_STARTED") {
+	output, found := pollForOutput(t, sessionName, "STUB_AGENT_STARTED", 5*time.Second)
+	if !found {
 		t.Errorf("Expected STUB_AGENT_STARTED in output, got:\n%s", output)
+		return
 	}
 
-	// Verify environment variables were visible to agent
 	if !strings.Contains(output, "GT_ROLE: polecat") {
 		t.Logf("Warning: GT_ROLE not visible in agent output (tmux env may not propagate to subshell)")
 	}
 
-	// Send a question and verify response
 	cmd = exec.Command("tmux", "send-keys", "-t", sessionName, "ping", "Enter")
 	if err := cmd.Run(); err != nil {
 		t.Fatalf("Failed to send ping: %v", err)
 	}
 
-	time.Sleep(1 * time.Second)
-
-	output = captureTmuxPane(t, sessionName, 50)
-	if !strings.Contains(output, "STUB_AGENT_ANSWER: pong") {
+	output, found = pollForOutput(t, sessionName, "STUB_AGENT_ANSWER: pong", 3*time.Second)
+	if !found {
 		t.Errorf("Expected 'pong' response, got:\n%s", output)
 	}
 
-	// Send exit command
 	cmd = exec.Command("tmux", "send-keys", "-t", sessionName, "exit", "Enter")
 	if err := cmd.Run(); err != nil {
 		t.Logf("Warning: failed to send exit: %v", err)
 	}
 
-	time.Sleep(500 * time.Millisecond)
-
-	// Final capture to verify clean exit
-	output = captureTmuxPane(t, sessionName, 50)
-	if !strings.Contains(output, "STUB_AGENT_EXITING") {
+	output, found = pollForOutput(t, sessionName, "STUB_AGENT_EXITING", 2*time.Second)
+	if !found {
 		t.Logf("Note: Agent may have exited before capture. Output:\n%s", output)
 	}
 

--- a/internal/daemon/role_config_integration_test.go
+++ b/internal/daemon/role_config_integration_test.go
@@ -28,6 +28,7 @@ func TestGetRoleConfigForIdentity_PrefersTownRoleBead(t *testing.T) {
 
 	townRoot := t.TempDir()
 	runBd(t, townRoot, "init", "--quiet", "--prefix", "hq")
+	runBd(t, townRoot, "config", "set", "types.custom", "agent,role,rig,convoy,event")
 
 	// Create canonical role bead.
 	runBd(t, townRoot, "create",
@@ -61,6 +62,7 @@ func TestGetRoleConfigForIdentity_FallsBackToLegacyRoleBead(t *testing.T) {
 
 	townRoot := t.TempDir()
 	runBd(t, townRoot, "init", "--quiet", "--prefix", "gt")
+	runBd(t, townRoot, "config", "set", "types.custom", "agent,role,rig,convoy,event")
 
 	// Only legacy role bead exists.
 	runBd(t, townRoot, "create",


### PR DESCRIPTION
## Summary

- Add custom types config after `bd init` in daemon tests
- Replace fixed `time.Sleep()` with poll-based waiting in tmux tests
- Skip beads integration test for JSONL-only repos

## Problem

Integration tests were failing intermittently due to:
1. Missing custom types configuration after `bd init` (daemon tests)
2. Race conditions from fixed sleeps in tmux tests
3. Test failures in repos without SQLite database

## Solution

### Daemon tests
Added `runBd(t, townRoot, "config", "set", "types.custom", "agent,role,rig,convoy,event")` after `bd init` to register custom types before creating role beads.

### Tmux tests
Replaced fixed `time.Sleep()` calls with a poll-based helper that polls every 100ms until the expected output appears or timeout expires.

### Beads integration test
Added check to skip if no `beads.db` exists (JSONL-only repos).

## Testing

All 34 packages pass with `go test -tags=integration ./...`