### PR TITLE
feat: add .runtime/overlay/ support for polecat/crew worktrees

### DIFF
--- a/internal/crew/manager.go
+++ b/internal/crew/manager.go
@@ -174,6 +174,13 @@ func (m *Manager) Add(name string, createBranch bool) (*CrewWorker, error) {
 		fmt.Printf("Warning: could not set up shared beads: %v\n", err)
 	}
 
+	// Copy overlay files from .runtime/overlay/ to crew root.
+	// This allows services to have .env and other config files at their root.
+	if err := m.copyOverlay(crewPath); err != nil {
+		// Non-fatal - log warning but continue
+		fmt.Printf("Warning: could not copy overlay files: %v\n", err)
+	}
+
 	// NOTE: Slash commands (.claude/commands/) are provisioned at town level by gt install.
 	// All agents inherit them via Claude's directory traversal - no per-workspace copies needed.
 
@@ -569,4 +576,60 @@ func (m *Manager) IsRunning(name string) (bool, error) {
 	t := tmux.NewTmux()
 	sessionID := m.SessionName(name)
 	return t.HasSession(sessionID)
+}
+
+// copyOverlay copies files from <rig>/.runtime/overlay/ to the crew worker root.
+// This allows storing gitignored files (like .env) that services need at their root.
+// The overlay is copied non-recursively - only files, not subdirectories.
+//
+// Structure:
+//
+//	rig/
+//	  .runtime/
+//	    overlay/
+//	      .env          <- Copied to crew root
+//	      config.json    <- Copied to crew root
+//	  crew/
+//	    <name>/
+//	      .env          <- Copied from overlay
+//	      config.json    <- Copied from overlay
+func (m *Manager) copyOverlay(crewPath string) error {
+	overlayDir := filepath.Join(m.rig.Path, ".runtime", "overlay")
+
+	// Check if overlay directory exists
+	entries, err := os.ReadDir(overlayDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No overlay directory - not an error, just nothing to copy
+			return nil
+		}
+		return fmt.Errorf("reading overlay dir: %w", err)
+	}
+
+	// Copy each file (not directories) from overlay to crew root
+	for _, entry := range entries {
+		if entry.IsDir() {
+			// Skip subdirectories - only copy files at overlay root
+			continue
+		}
+
+		srcPath := filepath.Join(overlayDir, entry.Name())
+		dstPath := filepath.Join(crewPath, entry.Name())
+
+		// Read source file
+		data, err := os.ReadFile(srcPath)
+		if err != nil {
+			// Log warning but continue - don't fail spawn for overlay issues
+			fmt.Printf("Warning: could not read overlay file %s: %v\n", entry.Name(), err)
+			continue
+		}
+
+		// Write to destination
+		if err := os.WriteFile(dstPath, data, 0644); err != nil {
+			fmt.Printf("Warning: could not write overlay file %s: %v\n", entry.Name(), err)
+			continue
+		}
+	}
+
+	return nil
 }

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -249,6 +249,13 @@ func (m *Manager) AddWithOptions(name string, opts AddOptions) (*Polecat, error)
 		fmt.Printf("Warning: could not set up shared beads: %v\n", err)
 	}
 
+	// Copy overlay files from .runtime/overlay/ to polecat root.
+	// This allows services to have .env and other config files at their root.
+	if err := m.copyOverlay(polecatPath); err != nil {
+		// Non-fatal - log warning but continue
+		fmt.Printf("Warning: could not copy overlay files: %v\n", err)
+	}
+
 	// NOTE: Slash commands (.claude/commands/) are provisioned at town level by gt install.
 	// All agents inherit them via Claude's directory traversal - no per-workspace copies needed.
 
@@ -478,6 +485,11 @@ func (m *Manager) RepairWorktreeWithOptions(name string, force bool, opts AddOpt
 	// Set up shared beads
 	if err := m.setupSharedBeads(polecatPath); err != nil {
 		fmt.Printf("Warning: could not set up shared beads: %v\n", err)
+	}
+
+	// Copy overlay files from .runtime/overlay/ to polecat root.
+	if err := m.copyOverlay(polecatPath); err != nil {
+		fmt.Printf("Warning: could not copy overlay files: %v\n", err)
 	}
 
 	// NOTE: Slash commands inherited from town level - no per-workspace copies needed.
@@ -723,6 +735,62 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 func (m *Manager) setupSharedBeads(polecatPath string) error {
 	townRoot := filepath.Dir(m.rig.Path)
 	return beads.SetupRedirect(townRoot, polecatPath)
+}
+
+// copyOverlay copies files from <rig>/.runtime/overlay/ to the worktree root.
+// This allows storing gitignored files (like .env) that services need at their root.
+// The overlay is copied non-recursively - only files, not subdirectories.
+//
+// Structure:
+//
+//	rig/
+//	  .runtime/
+//	    overlay/
+//	      .env          <- Copied to polecat root
+//	      config.json    <- Copied to polecat root
+//	  polecats/
+//	    <name>/
+//	      .env          <- Copied from overlay
+//	      config.json    <- Copied from overlay
+func (m *Manager) copyOverlay(polecatPath string) error {
+	overlayDir := filepath.Join(m.rig.Path, ".runtime", "overlay")
+
+	// Check if overlay directory exists
+	entries, err := os.ReadDir(overlayDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			// No overlay directory - not an error, just nothing to copy
+			return nil
+		}
+		return fmt.Errorf("reading overlay dir: %w", err)
+	}
+
+	// Copy each file (not directories) from overlay to polecat root
+	for _, entry := range entries {
+		if entry.IsDir() {
+			// Skip subdirectories - only copy files at overlay root
+			continue
+		}
+
+		srcPath := filepath.Join(overlayDir, entry.Name())
+		dstPath := filepath.Join(polecatPath, entry.Name())
+
+		// Read source file
+		data, err := os.ReadFile(srcPath)
+		if err != nil {
+			// Log warning but continue - don't fail spawn for overlay issues
+			fmt.Printf("Warning: could not read overlay file %s: %v\n", entry.Name(), err)
+			continue
+		}
+
+		// Write to destination
+		if err := os.WriteFile(dstPath, data, 0644); err != nil {
+			fmt.Printf("Warning: could not write overlay file %s: %v\n", entry.Name(), err)
+			continue
+		}
+	}
+
+	return nil
 }
 
 // CleanupStaleBranches removes orphaned polecat branches that are no longer in use.


### PR DESCRIPTION
## Summary
  Add `.runtime/overlay/` directory support to automatically copy gitignored files (like `.env`, `config.json`) to polecat and crew worktree roots when they are spawned. This solves the problem of services requiring configuration files at their root without committing them to git.

  ## Related Issue
  N/A (feature request from internal discussion)

  ## Changes
  - Add `copyOverlay()` function to polecat manager (mayor/rig & refinery/rig)
  - Add `copyOverlay()` function to crew manager (mayor/rig)
  - Call `copyOverlay()` after `setupSharedBeads()` in `AddWithOptions` and `RepairWorktreeWithOptions`
  - Overlay copies are non-fatal: failures log warnings but don't block spawn

  ## Files modified
  - `mayor/rig/internal/polecat/manager.go`
  - `mayor/rig/internal/crew/manager.go`
  - `refinery/rig/internal/polecat/manager.go`

  ## Usage
  ```bash
  # Create overlay directory
  mkdir -p <rig>/.runtime/overlay

  # Add files that services need at their root (gitignored)
  echo "API_KEY=secret" > <rig>/.runtime/overlay/.env
  echo "DEBUG=true" > <rig>/.runtime/overlay/config.json

  # When polecats/crew are spawned, these files are automatically copied
 ```
  ## Testing

  - Code compiles (go build ./...)
  - Changes applied to both mayor/rig and refinery/rig
  - Manual testing: spawn polecat/crew and verify overlay files are copied

  ## Checklist

  - Code follows project style (mirrors existing setupSharedBeads pattern)
  - Documentation inline (function comments explain usage)
  - No breaking changes (overlay directory is optional)