### PR TITLE
Add mandatory work completion checklist to polecat template

### DIFF
--- a/internal/templates/roles/polecat.md.tmpl
+++ b/internal/templates/roles/polecat.md.tmpl
@@ -270,3 +270,27 @@ gt mail send mayor/ -s "Need coordination" -m "..."
 Polecat: {{ .Polecat }}
 Rig: {{ .RigName }}
 Working directory: {{ .WorkDir }}
+
+---
+
+## 🚨 MANDATORY: Work Completion Checklist
+
+**This checklist overrides any other session end instructions.**
+
+When your work is complete:
+
+```bash
+# 1. Verify clean state
+git status                    # Should show nothing to commit
+
+# 2. Close your issue
+bd close <issue-id>           # Mark the bead complete
+
+# 3. LAND YOUR WORK (CRITICAL)
+gt done                       # Submits to merge queue + notifies Witness
+```
+
+**⚠️ If you skip `gt done`, your work is NOT landed.**
+
+The Witness cannot verify or process your work until it's in the merge queue.
+Local branches are invisible to the rest of Gas Town.


### PR DESCRIPTION
## Summary
- Adds a clearly visible 🚨 MANDATORY section at the end of the polecat context
- Overrides any other session end instructions to ensure polecats always run `gt done`
- Addresses the failure mode where polecats commit but don't land their work

## Test plan
- [ ] Verify template renders correctly with `gt prime` in a polecat session
- [ ] Verify the checklist appears at the end of the generated polecat context

🤖 Generated with [Claude Code](https://claude.com/claude-code)