### PR TITLE
add the ability to configure the branch naming convention at the rig level

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -182,13 +182,14 @@ type RigConfig struct {
 
 // RigSettings represents per-rig behavioral configuration (settings/config.json).
 type RigSettings struct {
-	Type       string            `json:"type"`                  // "rig-settings"
-	Version    int               `json:"version"`               // schema version
-	MergeQueue *MergeQueueConfig `json:"merge_queue,omitempty"` // merge queue settings
-	Theme      *ThemeConfig      `json:"theme,omitempty"`       // tmux theme settings
-	Namepool   *NamepoolConfig   `json:"namepool,omitempty"`    // polecat name pool settings
-	Crew       *CrewConfig       `json:"crew,omitempty"`        // crew startup settings
-	Runtime    *RuntimeConfig    `json:"runtime,omitempty"`     // LLM runtime settings (deprecated: use Agent)
+	Type         string               `json:"type"`                   // "rig-settings"
+	Version      int                  `json:"version"`                // schema version
+	MergeQueue   *MergeQueueConfig    `json:"merge_queue,omitempty"`  // merge queue settings
+	Theme        *ThemeConfig         `json:"theme,omitempty"`        // tmux theme settings
+	Namepool     *NamepoolConfig      `json:"namepool,omitempty"`     // polecat name pool settings
+	BranchNaming *BranchNamingConfig  `json:"branch_naming,omitempty"` // branch naming settings
+	Crew         *CrewConfig          `json:"crew,omitempty"`         // crew startup settings
+	Runtime      *RuntimeConfig       `json:"runtime,omitempty"`      // LLM runtime settings (deprecated: use Agent)
 
 	// Agent selects which agent preset to use for this rig.
 	// Can be a built-in preset ("claude", "gemini", "codex", "cursor", "auggie", "amp")
@@ -677,6 +678,27 @@ func DefaultNamepoolConfig() *NamepoolConfig {
 	return &NamepoolConfig{
 		Style:              "mad-max",
 		MaxBeforeNumbering: 50,
+	}
+}
+
+// BranchNamingConfig represents branch naming settings for a rig.
+type BranchNamingConfig struct {
+	// PolecatBranchTemplate is the pattern for polecat work branch names.
+	// Supports variables: {name}, {timestamp}, {rig}
+	// - {name}: Polecat name (e.g., "Toast")
+	// - {timestamp}: Base36 Unix milliseconds (e.g., "1gvp7k5")
+	// - {rig}: Rig name (e.g., "gastown")
+	// Default: "polecat/{name}-{timestamp}"
+	PolecatBranchTemplate string `json:"polecat_branch_template,omitempty"`
+}
+
+// DefaultPolecatBranchTemplate is the default pattern for polecat branch names.
+const DefaultPolecatBranchTemplate = "polecat/{name}-{timestamp}"
+
+// DefaultBranchNamingConfig returns a BranchNamingConfig with sensible defaults.
+func DefaultBranchNamingConfig() *BranchNamingConfig {
+	return &BranchNamingConfig{
+		PolecatBranchTemplate: DefaultPolecatBranchTemplate,
 	}
 }
 

--- a/internal/polecat/branch.go
+++ b/internal/polecat/branch.go
@@ -1,0 +1,88 @@
+package polecat
+
+import (
+	"fmt"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/config"
+)
+
+// invalidBranchCharsRegex matches characters that are invalid in git branch names.
+// Git branch names cannot contain: ~ ^ : \ space, .., @{, or end with .lock
+var invalidBranchCharsRegex = regexp.MustCompile(`[~^:\s\\]|\.\.|\.\.|@\{`)
+
+// BuildPolecatBranchName expands a polecat branch template with variables.
+// Variables supported:
+//   - {name}: Polecat name (e.g., "Toast")
+//   - {timestamp}: Base36 Unix milliseconds (e.g., "1gvp7k5")
+//   - {rig}: Rig name (e.g., "gastown")
+//
+// If template is empty, uses DefaultPolecatBranchTemplate.
+func BuildPolecatBranchName(template, name, rigName string) string {
+	if template == "" {
+		template = config.DefaultPolecatBranchTemplate
+	}
+
+	// Generate timestamp in base36 for shorter branch names
+	timestamp := strconv.FormatInt(time.Now().UnixMilli(), 36)
+
+	result := template
+	result = strings.ReplaceAll(result, "{name}", name)
+	result = strings.ReplaceAll(result, "{timestamp}", timestamp)
+	result = strings.ReplaceAll(result, "{rig}", rigName)
+
+	return result
+}
+
+// GetPolecatBranchTemplate returns the polecat branch template from rig settings.
+// Falls back to DefaultPolecatBranchTemplate if settings don't exist or don't specify a template.
+func GetPolecatBranchTemplate(rigPath string) string {
+	settingsPath := filepath.Join(rigPath, "settings", "config.json")
+	settings, err := config.LoadRigSettings(settingsPath)
+	if err != nil {
+		return config.DefaultPolecatBranchTemplate
+	}
+
+	if settings.BranchNaming != nil && settings.BranchNaming.PolecatBranchTemplate != "" {
+		return settings.BranchNaming.PolecatBranchTemplate
+	}
+
+	return config.DefaultPolecatBranchTemplate
+}
+
+// ValidateBranchName checks if a branch name is valid for git.
+// Returns an error if the branch name contains invalid characters.
+func ValidateBranchName(branchName string) error {
+	if branchName == "" {
+		return fmt.Errorf("branch name cannot be empty")
+	}
+
+	// Check for invalid characters
+	if invalidBranchCharsRegex.MatchString(branchName) {
+		return fmt.Errorf("branch name %q contains invalid characters (~ ^ : \\ space, .., or @{)", branchName)
+	}
+
+	// Check for .lock suffix
+	if strings.HasSuffix(branchName, ".lock") {
+		return fmt.Errorf("branch name %q cannot end with .lock", branchName)
+	}
+
+	// Check for leading/trailing slashes or dots
+	if strings.HasPrefix(branchName, "/") || strings.HasSuffix(branchName, "/") {
+		return fmt.Errorf("branch name %q cannot start or end with /", branchName)
+	}
+	if strings.HasPrefix(branchName, ".") || strings.HasSuffix(branchName, ".") {
+		return fmt.Errorf("branch name %q cannot start or end with .", branchName)
+	}
+
+	// Check for consecutive slashes
+	if strings.Contains(branchName, "//") {
+		return fmt.Errorf("branch name %q cannot contain consecutive slashes", branchName)
+	}
+
+	return nil
+}

--- a/internal/polecat/branch_test.go
+++ b/internal/polecat/branch_test.go
@@ -1,0 +1,190 @@
+package polecat
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/config"
+)
+
+func TestBuildPolecatBranchName(t *testing.T) {
+	tests := []struct {
+		name        string
+		template    string
+		polecatName string
+		rigName     string
+		wantPrefix  string // We can't test exact match due to timestamp
+		wantSuffix  string
+	}{
+		{
+			name:        "default template",
+			template:    "",
+			polecatName: "Toast",
+			rigName:     "gastown",
+			wantPrefix:  "polecat/Toast-",
+			wantSuffix:  "",
+		},
+		{
+			name:        "explicit default template",
+			template:    config.DefaultPolecatBranchTemplate,
+			polecatName: "Nux",
+			rigName:     "gastown",
+			wantPrefix:  "polecat/Nux-",
+			wantSuffix:  "",
+		},
+		{
+			name:        "custom template with rig",
+			template:    "work/{rig}/{name}-{timestamp}",
+			polecatName: "Toast",
+			rigName:     "gastown",
+			wantPrefix:  "work/gastown/Toast-",
+			wantSuffix:  "",
+		},
+		{
+			name:        "template without timestamp",
+			template:    "feature/{name}",
+			polecatName: "Toast",
+			rigName:     "gastown",
+			wantPrefix:  "feature/Toast",
+			wantSuffix:  "",
+		},
+		{
+			name:        "template with all variables",
+			template:    "{rig}/polecats/{name}/{timestamp}",
+			polecatName: "Nux",
+			rigName:     "beads",
+			wantPrefix:  "beads/polecats/Nux/",
+			wantSuffix:  "",
+		},
+		{
+			name:        "template with only timestamp",
+			template:    "work/{timestamp}",
+			polecatName: "Toast",
+			rigName:     "gastown",
+			wantPrefix:  "work/",
+			wantSuffix:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BuildPolecatBranchName(tt.template, tt.polecatName, tt.rigName)
+
+			if tt.wantPrefix != "" && !strings.HasPrefix(got, tt.wantPrefix) {
+				t.Errorf("BuildPolecatBranchName() = %q, want prefix %q", got, tt.wantPrefix)
+			}
+
+			if tt.wantSuffix != "" && !strings.HasSuffix(got, tt.wantSuffix) {
+				t.Errorf("BuildPolecatBranchName() = %q, want suffix %q", got, tt.wantSuffix)
+			}
+
+			// Branch name should not be empty
+			if got == "" {
+				t.Error("BuildPolecatBranchName() returned empty string")
+			}
+		})
+	}
+}
+
+func TestValidateBranchName(t *testing.T) {
+	tests := []struct {
+		name       string
+		branchName string
+		wantErr    bool
+	}{
+		{
+			name:       "valid simple branch",
+			branchName: "feature/toast",
+			wantErr:    false,
+		},
+		{
+			name:       "valid polecat branch",
+			branchName: "polecat/Toast-1abc2de",
+			wantErr:    false,
+		},
+		{
+			name:       "valid nested branch",
+			branchName: "work/gastown/Toast-1abc2de",
+			wantErr:    false,
+		},
+		{
+			name:       "empty branch name",
+			branchName: "",
+			wantErr:    true,
+		},
+		{
+			name:       "branch with tilde",
+			branchName: "feature~toast",
+			wantErr:    true,
+		},
+		{
+			name:       "branch with caret",
+			branchName: "feature^toast",
+			wantErr:    true,
+		},
+		{
+			name:       "branch with colon",
+			branchName: "feature:toast",
+			wantErr:    true,
+		},
+		{
+			name:       "branch with space",
+			branchName: "feature toast",
+			wantErr:    true,
+		},
+		{
+			name:       "branch with backslash",
+			branchName: "feature\\toast",
+			wantErr:    true,
+		},
+		{
+			name:       "branch with double dot",
+			branchName: "feature..toast",
+			wantErr:    true,
+		},
+		{
+			name:       "branch ending with .lock",
+			branchName: "feature.lock",
+			wantErr:    true,
+		},
+		{
+			name:       "branch starting with slash",
+			branchName: "/feature/toast",
+			wantErr:    true,
+		},
+		{
+			name:       "branch ending with slash",
+			branchName: "feature/toast/",
+			wantErr:    true,
+		},
+		{
+			name:       "branch starting with dot",
+			branchName: ".feature/toast",
+			wantErr:    true,
+		},
+		{
+			name:       "branch ending with dot",
+			branchName: "feature/toast.",
+			wantErr:    true,
+		},
+		{
+			name:       "branch with consecutive slashes",
+			branchName: "feature//toast",
+			wantErr:    true,
+		},
+		{
+			name:       "branch with @{",
+			branchName: "feature@{toast}",
+			wantErr:    true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := ValidateBranchName(tt.branchName)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("ValidateBranchName(%q) error = %v, wantErr %v", tt.branchName, err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
Some organizations have standards around how branches need to be formatted. To suit those branch naming standards, I suggest adding a rig-level configuration option that allows a user to set the branch naming format.

## Related Issue
none

## Changes
- Add branch_naming configuration to rig settings with a polecat_branch_template option
- Support template variables: {name} (polecat name), {timestamp} (base36 milliseconds), {rig} (rig name)
- Default template remains polecat/{name}-{timestamp} for backwards compatibility
- Add branch name validation to catch invalid git branch characters
- Include comprehensive tests for branch name building and validation

##  Example Configuration

```
  {
    "type": "rig-settings",
    "version": 1,
    "branch_naming": {
      "polecat_branch_template": "work/{rig}/{name}-{timestamp}"
    }
  }
```

## Testing
- Unit tests for BuildPolecatBranchName with various template patterns
- Unit tests for ValidateBranchName covering invalid git branch characters
- Manual test: Create polecat with default template
- Manual test: Create polecat with custom template in rig settings

## Checklist
- [ ] Code follows project style
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or documented in summary)
