### PR TITLE
Fix gt shutdown to stop daemon

### DIFF
--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/crew"
+	"github.com/steveyegge/gastown/internal/daemon"
 	"github.com/steveyegge/gastown/internal/deacon"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/mayor"
@@ -465,6 +466,12 @@ func runGracefulShutdown(t *tmux.Tmux, gtSessions []string, townRoot string) err
 		cleanupPolecats(townRoot)
 	}
 
+	// Phase 6: Stop the daemon
+	fmt.Printf("\nPhase 6: Stopping daemon...\n")
+	if townRoot != "" {
+		stopDaemonIfRunning(townRoot)
+	}
+
 	fmt.Println()
 	fmt.Printf("%s Graceful shutdown complete (%d sessions stopped)\n", style.Bold.Render("✓"), stopped)
 	return nil
@@ -482,6 +489,13 @@ func runImmediateShutdown(t *tmux.Tmux, gtSessions []string, townRoot string) er
 		fmt.Println()
 		fmt.Println("Cleaning up polecats...")
 		cleanupPolecats(townRoot)
+	}
+
+	// Stop the daemon
+	if townRoot != "" {
+		fmt.Println()
+		fmt.Println("Stopping daemon...")
+		stopDaemonIfRunning(townRoot)
 	}
 
 	fmt.Println()
@@ -630,6 +644,21 @@ func cleanupPolecats(townRoot string) {
 		fmt.Printf("  Cleaned: %d, Skipped: %d\n", totalCleaned, totalSkipped)
 	} else {
 		fmt.Printf("  %s No polecats to clean up\n", style.Dim.Render("○"))
+	}
+}
+
+// stopDaemonIfRunning stops the daemon if it is running.
+// This prevents the daemon from restarting agents after shutdown.
+func stopDaemonIfRunning(townRoot string) {
+	running, _, _ := daemon.IsRunning(townRoot)
+	if running {
+		if err := daemon.StopDaemon(townRoot); err != nil {
+			fmt.Printf("  %s Daemon: %s\n", style.Dim.Render("○"), err.Error())
+		} else {
+			fmt.Printf("  %s Daemon stopped\n", style.Bold.Render("✓"))
+		}
+	} else {
+		fmt.Printf("  %s Daemon not running\n", style.Dim.Render("○"))
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes #299

`gt shutdown` was not stopping the daemon, which caused it to restart agents (witnesses, refineries) after shutdown completed.

## Problem

The daemon heartbeats every 3 minutes and calls `ensureWitnessesRunning()` and `ensureRefineriesRunning()`. After `gt shutdown`:
1. Sessions are killed
2. Polecat cleanup runs
3. **Daemon continues running**
4. ~3 minutes later, daemon wakes up and restarts the agents

Meanwhile, `gt down` correctly stops the daemon.

## Solution

Add daemon stop logic to both `runGracefulShutdown` (as Phase 6) and `runImmediateShutdown` (after polecat cleanup), matching the behavior that `gt down` already has.

## Changes

- Added `daemon` import to `internal/cmd/start.go`
- Added `stopDaemonIfRunning()` helper function
- Called it from both `runGracefulShutdown` and `runImmediateShutdown`

## Test plan

- [ ] Run `gt shutdown` and verify daemon is stopped
- [ ] Run `gt shutdown --graceful` and verify daemon is stopped
- [ ] Verify agents don't restart after shutdown

🤖 Generated with [Claude Code](https://claude.com/claude-code)