### PR TITLE
fix(hook): warn when hooked bead is already closed

### DIFF
--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -602,6 +602,14 @@ func outputMoleculeStatus(status MoleculeStatusInfo) error {
 	fmt.Println(style.Bold.Render("🚀 AUTONOMOUS MODE - Work on hook triggers immediate execution"))
 	fmt.Println()
 
+	// Check if the hooked bead is already closed (someone closed it externally)
+	if status.PinnedBead.Status == "closed" {
+		fmt.Printf("%s Hooked bead %s is already closed!\n", style.Bold.Render("⚠"), status.PinnedBead.ID)
+		fmt.Printf("   Title: %s\n", status.PinnedBead.Title)
+		fmt.Printf("   This work was completed elsewhere. Clear your hook with: gt unsling\n")
+		return nil
+	}
+
 	// Check if this is a mail bead - display mail-specific format
 	if status.PinnedBead.Type == "message" {
 		sender := extractMailSender(status.PinnedBead.Labels)


### PR DESCRIPTION
## Summary
- Added warning in `gt hook` when the hooked bead is already closed
- Displays clear message with instructions to clear the hook using `gt unsling`

## Test plan
- [x] Build passes
- [x] Unit tests pass
- Run `gt hook` when a hooked bead is closed - should show warning

Closes: gt-8w0r6

🤖 Generated with [Claude Code](https://claude.com/claude-code)