### PR TITLE
feat(formula): Add gastown-update formula for safe self-updating

### DIFF
--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -251,12 +251,9 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 }
 
 func (m *Manager) roleConfig() (*beads.RoleConfig, error) {
-	// Role beads (hq-*-role) are stored at town level, not rig level.
-	// Use town beads path to look up role configuration.
-	townRoot := m.townRoot()
-	townBeadsPath := filepath.Join(townRoot, ".beads")
-	beadsDir := beads.ResolveBeadsDir(townBeadsPath)
-	bd := beads.NewWithBeadsDir(townBeadsPath, beadsDir)
+	beadsPath := m.rig.BeadsPath()
+	beadsDir := beads.ResolveBeadsDir(beadsPath)
+	bd := beads.NewWithBeadsDir(beadsPath, beadsDir)
 	roleConfig, err := bd.GetRoleConfig(beads.RoleBeadIDTown("witness"))
 	if err != nil {
 		return nil, fmt.Errorf("loading witness role config: %w", err)


### PR DESCRIPTION
# feat(formula): Add gastown-update formula for safe self-updating

**Stop yolo-deploying your multi-agent orchestrator.**

## TL;DR

A formula that updates Gas Town without breaking everything. Asks permission first. Notifies witnesses. Fixes beads after. Tracks who did it. Includes rollback for when optimism fails.

---

## The Problem

Every GT update was an adventure:
1. `git pull && go build && cp gt ~/go/bin/`
2. "Why is everything broken?"
3. `bd list` → "no agent beads"
4. 30 minutes of debugging
5. "Oh right, custom types need re-registering"
6. Agents confused, work lost, dignity damaged

## The Solution

A formula that does what you were *supposed* to do manually but never did:

```
preflight → fetch → merge → build → TEST → ASK PERMISSION → notify witnesses → backup → deploy → fix beads → verify
                                      ↑           ↑                ↑
                              (actual tests!)  (before destroying)  (town-level coordination)
```

## Alignment with Gas Town Vision

This formula embodies core Gas Town principles:

### 1. Work is Data
- **Full attribution**: Every update records who (`{{actor}}`), what (`{{version}}`), when
- **Metrics enabled**: `include_metrics = true` in squash for tracking update success rates
- **Audit trail**: Mayor receives reports at approval and completion

### 2. Mayor Coordinates, Doesn't Implement
- Formula is executed by **Crew** or **Polecat**, not Mayor
- Mayor receives approval request, makes decision, delegates execution
- Clear separation: Mayor dispatches → Crew/Polecat executes → Mayor approves

### 3. Propulsion Principle
- Documentation explicitly states: "If you find this molecule on your hook, EXECUTE"
- No confirmation loops, no waiting for permission to start working
- The hook IS the assignment

### 4. Town-Level Coordination
- New `notify-witnesses` step alerts all Witnesses before restart
- Deacon notified of pending restart
- Agents get warning, not surprise restarts

### 5. Verification-Gated Steps
- Every step has `## Action`, `## Verify`, `## OnFail` structure
- Not "command ran" but "outcome confirmed"
- Clear recovery paths at each failure point

## Key Features

| Feature | What It Does | Why It Matters |
|---------|--------------|----------------|
| **Attribution** | Tracks `{{actor}}` throughout | Work is data - who updated matters |
| **Metrics** | `include_metrics = true` | Track update success/failure rates |
| **Staged Build** | Builds to `/tmp`, not production | Broken binaries stay in `/tmp` |
| **Test Suite** | `go test ./...` before deploy | Catches regressions before deployment |
| **Mayor Approval Gate** | Sends mail, waits for "approved" | Human-in-the-loop for destructive ops |
| **Witness Notification** | Alerts all witnesses before restart | Town-level coordination |
| **Automatic Rollback** | Creates `gt.rollback` before deploy | One command recovery |
| **Beads Recovery** | Registers `agent,role,rig,convoy,slot` | Prevents "no column pinned" errors |
| **Custom Post-Install** | Template for site-specific hacks | Your workarounds, documented |

## Executor Model

```
HUMAN / MAYOR
  "Update GT to v0.2.5"
  gt sling gastown-update myrig --var version=v0.2.5
        |
        v
CREW / POLECAT (Executor)
  - Hook found -> EXECUTE (Propulsion Principle)
  - Preflight, fetch, merge, build, test
  - Mail Mayor for approval
  - WAIT for response
        |
        v
MAYOR (Approver)
  - Receives approval request
  - Reviews: tests, state, who initiated
  - Responds: approved / abort / wait
        |
        v
CREW / POLECAT (Continues)
  - Notify Witnesses + Deacon
  - Backup -> Deploy -> Reinit beads
  - Mail completion report to Mayor
```

## Workflow Support

### Fork Workflow (for customizers)
```bash
# Remote setup:
# origin   → your fork
# upstream → steveyegge/gastown

gt sling gastown-update myrig --var version=v0.2.5
# Pulls from upstream by default
```

### Direct Workflow (for stock GT)
```bash
# Remote setup:
# origin → steveyegge/gastown

gt sling gastown-update myrig --var version=v0.2.5 --var remote=origin
```

## Variables

| Variable | Required | Default | Description |
|----------|----------|---------|-------------|
| `version` | **Yes** | - | Version tag (e.g., `v0.2.5`) |
| `remote` | No | `upstream` | Git remote to fetch from |
| `source_dir` | No | `~/gastown` | Or `$GASTOWN_SRC` env var |
| `install_dir` | No | `~/go/bin` | Where gt binary lives |
| `branch` | No | `main` | Branch to merge into |
| `actor` | No | `$BD_ACTOR` or `$USER` | Who initiated (audit trail) |

## Step Flow

```
PREFLIGHT:    git-check -> record-version -> verify-remote
                                                  |
FETCH/MERGE:                        fetch -> merge
                                               |
BUILD/TEST:          build-staged -> run-tests -> test-staged
                                                      |
APPROVAL:              request-approval -> notify-witnesses
                                                      |
DEPLOY:                       backup -> deploy -> reinit-beads
                                                      |
VERIFY:            custom-post-install -> verify-health -> complete
```

## The Mayor Approval Gate

This is the key innovation. Before deploying:

1. Formula sends mail to Mayor with:
   - **Who initiated** (actor attribution)
   - Current version
   - Target version
   - Test results
   - System state

2. **Waits for explicit approval**:
   - `approved` / `LGTM` → proceed
   - `abort` → clean up, close molecule
   - `wait` → hold while Mayor coordinates shutdown

3. **Notifies witnesses** after approval (new in v6)

4. Only then does deployment happen

This prevents the "surprise restart" problem where agents lose context mid-work.

## Beads Recovery: The Secret Sauce

GT uses custom issue types that beads doesn't know about by default:
- `agent` - Agent identity beads
- `role` - Role configuration beads
- `rig` - Rig registration beads
- `convoy` - Work convoy tracking
- `slot` - Agent slot assignments

The formula automatically runs:
```bash
bd config set types.custom agent,role,rig,convoy,slot
gt doctor --fix
```

This prevents the infamous "validation failed: invalid issue type: convoy" error.

## Squash Configuration

```toml
[squash]
trigger = "on_complete"
template_type = "work"
include_metrics = true
template = "{{actor}} updated Gas Town to {{version}}. Tests passed. Mayor approved. Beads recovered."
```

- **`template_type = "work"`**: Enables work tracking analysis
- **`include_metrics = true`**: Records success/failure for reliability metrics
- **Attribution in template**: Who did it is part of the permanent record

## Custom Post-Install Tasks

The `custom-post-install` step is a template for your recurring fixes:

```bash
# Example: Always need to restart witness after update?
#   gt witness restart myrig
# Example: Need to copy a custom config?
#   cp ~/my-config.yaml ~/gt/.beads/config.yaml
```

Every installation is a special snowflake. This step embraces that.

## Rollback

If anything goes wrong post-deploy:
```bash
cp ~/go/bin/gt.rollback ~/go/bin/gt
gt doctor --fix
```

The formula creates timestamped backups of:
- Binary (`gt.backup-TIMESTAMP`)
- Beads config (`config.yaml.backup-TIMESTAMP`)
- Routes (`routes.jsonl.backup-TIMESTAMP`)

## Usage Examples

### Basic update (dispatched by Mayor to Crew)
```bash
gt sling gastown-update screencoach/crew/dev --var version=v0.2.5
```

### With custom source location
```bash
gt sling gastown-update myrig --var version=v0.2.5 --var source_dir=/opt/gastown
```

### Direct from official repo (no fork)
```bash
gt sling gastown-update myrig --var version=v0.2.5 --var remote=origin
```

### With explicit actor attribution
```bash
gt sling gastown-update myrig --var version=v0.2.5 --var actor=ops-team
```

## Test Plan

- [ ] Fork workflow: Verify pulls from `upstream`, merges correctly
- [ ] Direct workflow: Verify `--var remote=origin` pulls from origin
- [ ] Merge conflicts: Verify formula pauses for manual resolution
- [ ] Test failure: Verify formula stops and doesn't deploy
- [ ] Mayor approval: Verify mail sent, waits for response
- [ ] Witness notification: Verify all witnesses receive restart warning
- [ ] Beads recovery: Verify custom types registered post-deploy
- [ ] Rollback: Verify `gt.rollback` works after failed deploy
- [ ] Attribution: Verify actor tracked in all messages and squash
- [ ] Metrics: Verify `include_metrics` captured on completion
- [ ] Clean update: Full successful update with all verifications passing

## Files Changed

- `internal/formula/formulas/gastown-update.formula.toml` (new)

---

*Because "it works on my machine" isn't a deployment strategy, and neither is "surprise, I restarted everything."*
