### PR TITLE
fix(witness): use town-level beads for role config lookup

### DIFF
--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -251,9 +251,9 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 }
 
 func (m *Manager) roleConfig() (*beads.RoleConfig, error) {
-	beadsPath := m.rig.BeadsPath()
-	beadsDir := beads.ResolveBeadsDir(beadsPath)
-	bd := beads.NewWithBeadsDir(beadsPath, beadsDir)
+	// Role beads use hq- prefix and live in town-level beads, not rig beads
+	townRoot := m.townRoot()
+	bd := beads.NewWithBeadsDir(townRoot, beads.ResolveBeadsDir(townRoot))
 	roleConfig, err := bd.GetRoleConfig(beads.RoleBeadIDTown("witness"))
 	if err != nil {
 		return nil, fmt.Errorf("loading witness role config: %w", err)


### PR DESCRIPTION
## Summary
- Fixed witness manager using wrong beads path for role config lookup
- Role beads use `hq-` prefix and live in town-level beads, not rig beads
- This caused "unexpected end of JSON input" errors when starting witnesses

## Problem
The `roleConfig()` function was using `m.rig.BeadsPath()` which returns the rig-level beads path (e.g., `gastown/mayor/rig/.beads` with `gt-` prefix). However, role beads like `hq-witness-role` use the `hq-` prefix and live in town-level beads (`~/gt/.beads`).

When using `--no-daemon` mode, the prefix-based routing is bypassed, so the rig database couldn't find the town-level role bead.

## Fix
Changed `roleConfig()` to use `m.townRoot()` instead of `m.rig.BeadsPath()`, matching the pattern used by deacon's `LoadStuckConfig()`.

## Test plan
- [x] Rebuilt gt binary
- [x] Ran `gt start --all` - all witnesses now start successfully
- [x] Ran `gt doctor` - 50 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)