### PR TITLE
Fix #289: Add feed-stranded-convoys to Deacon patrol

### DIFF
--- a/.beads/formulas/mol-deacon-patrol.formula.toml
+++ b/.beads/formulas/mol-deacon-patrol.formula.toml
@@ -23,7 +23,7 @@ Witnesses detect it and escalate to the Mayor.
 The Deacon's agent bead last_activity timestamp is updated during each patrol
 cycle. Witnesses check this timestamp to verify health."""
 formula = "mol-deacon-patrol"
-version = 8
+version = 9
 
 [[steps]]
 id = "inbox-check"
@@ -226,9 +226,51 @@ bd close <convoy-id> --reason "All tracked issues completed"
 **Note**: Convoys support cross-prefix tracking (e.g., hq-* convoy can track gt-*, bd-* issues). Use full IDs when checking."""
 
 [[steps]]
+id = "feed-stranded-convoys"
+title = "Feed stranded convoys"
+needs = ["check-convoy-completion"]
+description = """
+Detect and feed stranded convoys to resume progress.
+
+A convoy becomes stranded when its current batch of issues completes but the
+next batch is never dispatched. This causes the convoy to stall indefinitely.
+
+**Step 1: Detect stranded convoys**
+```bash
+gt convoy stranded --json
+```
+
+This returns convoys where:
+- The convoy is open (in progress)
+- All currently assigned issues are closed
+- No polecats are actively working on convoy issues
+- The next batch has not been dispatched
+
+**Step 2: For each stranded convoy, dispatch a feeder dog**
+```bash
+# Dispatch mol-convoy-feed to an idle dog
+gt sling mol-convoy-feed deacon/dogs --var convoy=<convoy-id>
+```
+
+The mol-convoy-feed formula handles:
+- Finding the next batch of issues in the convoy synthesis
+- Dispatching those issues to the appropriate rig/polecats
+- Updating the convoy's current batch tracker
+
+**Step 3: If no stranded convoys**
+Skip - all convoys are progressing normally.
+
+**Why this exists:**
+When Mayor creates a convoy, it dispatches the first batch immediately. However,
+subsequent batches require explicit feeding. Without this step, convoys stall
+after the first batch completes.
+
+**Exit criteria:** All stranded convoys have feeder dogs dispatched."""
+
+[[steps]]
 id = "resolve-external-deps"
 title = "Resolve external dependencies"
-needs = ["check-convoy-completion"]
+needs = ["feed-stranded-convoys"]
 description = """
 Resolve external dependencies across rigs.
 

--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -23,7 +23,7 @@ Witnesses detect it and escalate to the Mayor.
 The Deacon's agent bead last_activity timestamp is updated during each patrol
 cycle. Witnesses check this timestamp to verify health."""
 formula = "mol-deacon-patrol"
-version = 8
+version = 9
 
 [[steps]]
 id = "inbox-check"
@@ -226,9 +226,51 @@ bd close <convoy-id> --reason "All tracked issues completed"
 **Note**: Convoys support cross-prefix tracking (e.g., hq-* convoy can track gt-*, bd-* issues). Use full IDs when checking."""
 
 [[steps]]
+id = "feed-stranded-convoys"
+title = "Feed stranded convoys"
+needs = ["check-convoy-completion"]
+description = """
+Detect and feed stranded convoys to resume progress.
+
+A convoy becomes stranded when its current batch of issues completes but the
+next batch is never dispatched. This causes the convoy to stall indefinitely.
+
+**Step 1: Detect stranded convoys**
+```bash
+gt convoy stranded --json
+```
+
+This returns convoys where:
+- The convoy is open (in progress)
+- All currently assigned issues are closed
+- No polecats are actively working on convoy issues
+- The next batch has not been dispatched
+
+**Step 2: For each stranded convoy, dispatch a feeder dog**
+```bash
+# Dispatch mol-convoy-feed to an idle dog
+gt sling mol-convoy-feed deacon/dogs --var convoy=<convoy-id>
+```
+
+The mol-convoy-feed formula handles:
+- Finding the next batch of issues in the convoy synthesis
+- Dispatching those issues to the appropriate rig/polecats
+- Updating the convoy's current batch tracker
+
+**Step 3: If no stranded convoys**
+Skip - all convoys are progressing normally.
+
+**Why this exists:**
+When Mayor creates a convoy, it dispatches the first batch immediately. However,
+subsequent batches require explicit feeding. Without this step, convoys stall
+after the first batch completes.
+
+**Exit criteria:** All stranded convoys have feeder dogs dispatched."""
+
+[[steps]]
 id = "resolve-external-deps"
 title = "Resolve external dependencies"
-needs = ["check-convoy-completion"]
+needs = ["feed-stranded-convoys"]
 description = """
 Resolve external dependencies across rigs.
 


### PR DESCRIPTION
Fixes #289

## Problem
When Mayor creates a convoy (multi-issue work pipeline), it correctly creates issues, sets up dependencies, creates the convoy, and slings the first batch of work to polecats. It then says "Monitoring convoy progress" but **stops dead**. When polecats complete their work, the next issues in the convoy are never dispatched automatically.

## Root Cause
The problem is NOT in Mayor - it's in **Deacon's patrol loop**. Gas Town already had the complete infrastructure for autonomous convoy progression (`gt convoy stranded`, `mol-convoy-feed`), but **Deacon's patrol formula never called them**.

## Solution
Added a new step `feed-stranded-convoys` to `mol-deacon-patrol.formula.toml`:

- Detects stranded convoys using `gt convoy stranded --json`
- Dispatches `mol-convoy-feed` to deacon/dogs for each stranded convoy
- Runs asynchronously during each Deacon patrol cycle

## Changes
- Added `feed-stranded-convoys` step to `internal/formula/formulas/mol-deacon-patrol.formula.toml`
- Added `feed-stranded-convoys` step to `.beads/formulas/mol-deacon-patrol.formula.toml`
- Updated `resolve-external-deps` to depend on `feed-stranded-convoys`
- Bumped formula version from 8 to 9
