### PR TITLE
feat(down): comprehensive shutdown with bd process management and verification

### DIFF
--- a/internal/beads/daemon_test.go
+++ b/internal/beads/daemon_test.go
@@ -1,0 +1,73 @@
+package beads
+
+import (
+	"os/exec"
+	"testing"
+)
+
+func TestParseBdDaemonCount_Array(t *testing.T) {
+	input := []byte(`[{"pid":1234},{"pid":5678}]`)
+	count := parseBdDaemonCount(input)
+	if count != 2 {
+		t.Errorf("expected 2, got %d", count)
+	}
+}
+
+func TestParseBdDaemonCount_ObjectWithCount(t *testing.T) {
+	input := []byte(`{"count":3,"daemons":[{},{},{}]}`)
+	count := parseBdDaemonCount(input)
+	if count != 3 {
+		t.Errorf("expected 3, got %d", count)
+	}
+}
+
+func TestParseBdDaemonCount_ObjectWithDaemons(t *testing.T) {
+	input := []byte(`{"daemons":[{},{}]}`)
+	count := parseBdDaemonCount(input)
+	if count != 2 {
+		t.Errorf("expected 2, got %d", count)
+	}
+}
+
+func TestParseBdDaemonCount_Empty(t *testing.T) {
+	input := []byte(``)
+	count := parseBdDaemonCount(input)
+	if count != 0 {
+		t.Errorf("expected 0, got %d", count)
+	}
+}
+
+func TestParseBdDaemonCount_Invalid(t *testing.T) {
+	input := []byte(`not json`)
+	count := parseBdDaemonCount(input)
+	if count != 0 {
+		t.Errorf("expected 0 for invalid JSON, got %d", count)
+	}
+}
+
+func TestCountBdActivityProcesses(t *testing.T) {
+	count := CountBdActivityProcesses()
+	if count < 0 {
+		t.Errorf("count should be non-negative, got %d", count)
+	}
+}
+
+func TestCountBdDaemons(t *testing.T) {
+	if _, err := exec.LookPath("bd"); err != nil {
+		t.Skip("bd not installed")
+	}
+	count := CountBdDaemons()
+	if count < 0 {
+		t.Errorf("count should be non-negative, got %d", count)
+	}
+}
+
+func TestStopAllBdProcesses_DryRun(t *testing.T) {
+	daemonsKilled, activityKilled, err := StopAllBdProcesses(true, false)
+	if err != nil {
+		t.Errorf("unexpected error: %v", err)
+	}
+	if daemonsKilled < 0 || activityKilled < 0 {
+		t.Errorf("counts should be non-negative: daemons=%d, activity=%d", daemonsKilled, activityKilled)
+	}
+}

--- a/internal/cmd/down_test.go
+++ b/internal/cmd/down_test.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestIsProcessRunning_CurrentProcess(t *testing.T) {
+	if !isProcessRunning(os.Getpid()) {
+		t.Error("current process should be detected as running")
+	}
+}
+
+func TestIsProcessRunning_InvalidPID(t *testing.T) {
+	if isProcessRunning(99999999) {
+		t.Error("invalid PID should not be detected as running")
+	}
+}
+
+func TestIsProcessRunning_MaxPID(t *testing.T) {
+	if isProcessRunning(2147483647) {
+		t.Error("max PID should not be running")
+	}
+}


### PR DESCRIPTION
## Problem Statement

### The Core Problem
```
User runs: gt down
Expects:   Everything stops
Reality:   bd daemon respawns everything in 3 minutes
```

**Root cause**: `gt down` doesn't stop `bd daemon` or `bd activity`.

### All Problems Identified

| # | Problem | Root Cause | Impact | Status |
|---|---------|------------|--------|--------|
| 1 | Sessions respawn after kill | `bd daemon` not stopped | High | ✅ Fixed |
| 2 | Instant wakeups on feed | `bd activity` not stopped | High | ✅ Fixed |
| 3 | Refineries keep running | Missing from `gt down` | Medium | ✅ Fixed |
| 4 | Old `--all` too destructive | Killed ALL tmux sessions | High | ✅ Fixed (renamed to `--nuke`) |
| 5 | No verification | Can't detect respawns | Medium | ✅ Fixed |
| 6 | Concurrent shutdowns race | No lock mechanism | Medium | ✅ Fixed |
| 7 | No dry-run mode | Can't preview actions | Low | ✅ Fixed |

### User-Reported Scenarios

1. **"I ran `gt down` but agents keep coming back"** → bd daemon not stopped
2. **"Sessions wake up immediately when I check status"** → bd activity triggers on events
3. **"Refineries are still running after shutdown"** → Missing refinery loop
4. **"`gt down --all` killed my vim session!"** → --all killed entire tmux server

---

## Solution

Enhanced `gt down` with comprehensive, phased shutdown and safety features.

### New Command Interface
```bash
gt down                    # Current behavior + refineries (bug fix)
gt down --all              # + bd processes, verification
gt down --all --force      # Use SIGKILL, skip graceful waits
gt down --all --dry-run    # Preview without action
gt down --nuke             # Kill entire tmux server (requires GT_NUKE_ACKNOWLEDGED=1)
```

### Shutdown Phases

| Phase | Action | Flag Required |
|-------|--------|---------------|
| 0 | Acquire shutdown lock | Always |
| 1 | Stop bd daemon/activity | `--all` |
| 2 | Stop refineries + witnesses | Always |
| 3 | Stop town sessions (Mayor, Boot, Deacon) | Always |
| 4 | Stop Go daemon | Always |
| 5 | Verify complete shutdown | `--all` |
| 6 | Nuke tmux server | `--nuke` |

---

## Changes by File

| File | Changes | Description |
|------|---------|-------------|
| `internal/cmd/down.go` | +303 -49 | Extended shutdown with phases, flags, verification |
| `internal/beads/daemon.go` | +158 -8 | Added bd process management (stop, count, health) |
| `internal/beads/daemon_test.go` | +73 new | Unit tests for daemon functions |
| `internal/cmd/down_test.go` | +24 new | Unit tests for isProcessRunning |
| `internal/cmd/prime.go` | +5 | Validation for --state flag |

**Total: 5 files changed, +514 -49 lines**

---

## Key Fixes Applied

| Issue | Fix |
|-------|-----|
| macOS `pgrep -c` not available | Use `sh -c "pgrep \| wc -l"` for cross-platform |
| Misleading "stopped" vs "not running" | `stopSession` returns `(wasRunning, error)` |
| `daemon.IsRunning` error ignored | Now surfaces errors properly |
| `--nuke` proceeded without confirmation | Now **blocks** unless `GT_NUKE_ACKNOWLEDGED=1` |
| Negative killed counts on race | Clamped to minimum 0 |
| pkill pattern too broad | Documented limitation (anchoring would break functionality) |

---

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all 36 packages)
- [x] `golangci-lint` - no new issues
- [x] Manual test: `gt down --dry-run`
- [x] Manual test: `gt down --all`
- [x] Manual test: `GT_NUKE_ACKNOWLEDGED=1 gt down --nuke`
- [x] Manual test: `gt down --nuke` blocks without acknowledgement

---

## Acceptance Criteria Met

- [x] **AC1**: Tmux check before lock, lock prevents concurrent shutdowns
- [x] **AC2**: `bd daemon killall` + pkill fallback for bd processes
- [x] **AC3**: Refineries now stopped (bug fix)
- [x] **AC4**: Witnesses stopped per-rig with graceful Ctrl-C
- [x] **AC5**: Town sessions stopped (Mayor, Boot, Deacon)
- [x] **AC6**: Daemon stopped with PID reporting
- [x] **AC7**: Verification detects respawns, suggests systemd/launchd check
- [x] **AC8**: All flags work (`--all`, `--nuke`, `--dry-run`, `--force`, `--quiet`)
- [x] **AC9**: Backwards compatible, `--nuke` replaces old `--all`
- [x] **AC10**: Clear status output (✓/✗) with counts
- [x] **AC11**: Exit 0 on success, Exit 1 on failure