### PR TITLE
fix(beads): add CreateOrReopenAgentBead for polecat re-spawn

### DIFF
--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -307,11 +307,12 @@ func (m *Manager) AddWithOptions(name string, opts AddOptions) (*Polecat, error)
 	// NOTE: Slash commands (.claude/commands/) are provisioned at town level by gt install.
 	// All agents inherit them via Claude's directory traversal - no per-workspace copies needed.
 
-	// Create agent bead for ZFC compliance (self-report state).
+	// Create or reopen agent bead for ZFC compliance (self-report state).
 	// State starts as "spawning" - will be updated to "working" when Claude starts.
 	// HookBead is set atomically at creation time if provided (avoids cross-beads routing issues).
+	// Uses CreateOrReopenAgentBead to handle re-spawning with same name (GH #332).
 	agentID := m.agentBeadID(name)
-	_, err = m.beads.CreateAgentBead(agentID, agentID, &beads.AgentFields{
+	_, err = m.beads.CreateOrReopenAgentBead(agentID, agentID, &beads.AgentFields{
 		RoleType:   "polecat",
 		Rig:        m.rig.Name,
 		AgentState: "spawning",
@@ -562,9 +563,10 @@ func (m *Manager) RepairWorktreeWithOptions(name string, force bool, opts AddOpt
 
 	// NOTE: Slash commands inherited from town level - no per-workspace copies needed.
 
-	// Create fresh agent bead for ZFC compliance
+	// Create or reopen agent bead for ZFC compliance
 	// HookBead is set atomically at recreation time if provided.
-	_, err = m.beads.CreateAgentBead(agentID, agentID, &beads.AgentFields{
+	// Uses CreateOrReopenAgentBead to handle re-spawning with same name (GH #332).
+	_, err = m.beads.CreateOrReopenAgentBead(agentID, agentID, &beads.AgentFields{
 		RoleType:   "polecat",
 		Rig:        m.rig.Name,
 		AgentState: "spawning",


### PR DESCRIPTION
## Summary

Fixes UNIQUE constraint error when re-spawning polecats with the same name. When a polecat is nuked and later re-allocated from the pool with the same name, `CreateAgentBead` failed because the old agent bead (closed but not deleted) still existed.

## Related Issue

Fixes #332

## Changes

- Added `CreateOrReopenAgentBead` function in `internal/beads/beads_agent.go` that:
  - First attempts normal bead creation
  - If UNIQUE constraint fails, reopens the existing closed bead and updates its fields
  - Properly sets role and hook slots on the reopened bead
- Updated both spawn paths in `internal/polecat/manager.go` to use the new function

## Testing

- [x] Unit tests pass (`go test ./...`) - note: pre-existing failures in TestPrimeFlagCombinations unrelated to this change
- [x] Manual testing: verified UNIQUE constraint error is now handled gracefully

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable) - inline comments explain the upsert logic
- [x] No breaking changes