### PR TITLE
fix(rig): return rig root from BeadsPath() to respect redirect system

### DIFF
--- a/internal/rig/types.go
+++ b/internal/rig/types.go
@@ -70,13 +70,16 @@ func (r *Rig) Summary() RigSummary {
 }
 
 // BeadsPath returns the path to use for beads operations.
-// Returns the mayor/rig clone path if available (has proper sync-branch config),
-// otherwise falls back to the rig root path.
-// This ensures beads commands read from a location with git-synced beads data.
+// Always returns the rig root path where .beads/ contains either:
+//   - A local beads database (when repo doesn't track .beads/)
+//   - A redirect file pointing to mayor/rig/.beads (when repo tracks .beads/)
+//
+// The redirect is set up by initBeads() during rig creation and followed
+// automatically by the bd CLI and beads.ResolveBeadsDir().
+//
+// This ensures we never write to the user's repo clone (mayor/rig/) and
+// all beads operations go through the redirect system.
 func (r *Rig) BeadsPath() string {
-	if r.HasMayor {
-		return r.Path + "/mayor/rig"
-	}
 	return r.Path
 }
 

--- a/internal/rig/types_test.go
+++ b/internal/rig/types_test.go
@@ -1,0 +1,146 @@
+package rig
+
+import (
+	"testing"
+)
+
+func TestBeadsPath_AlwaysReturnsRigRoot(t *testing.T) {
+	t.Parallel()
+
+	// BeadsPath should always return the rig root path, regardless of HasMayor.
+	// The redirect system at <rig>/.beads/redirect handles finding the actual
+	// beads location (either local at <rig>/.beads/ or tracked at mayor/rig/.beads/).
+	//
+	// This ensures:
+	// 1. We don't write files to the user's repo clone (mayor/rig/)
+	// 2. The redirect architecture is respected
+	// 3. All code paths use the same beads resolution logic
+
+	tests := []struct {
+		name     string
+		rig      Rig
+		wantPath string
+	}{
+		{
+			name: "rig with mayor only",
+			rig: Rig{
+				Name:     "testrig",
+				Path:     "/home/user/gt/testrig",
+				HasMayor: true,
+			},
+			wantPath: "/home/user/gt/testrig",
+		},
+		{
+			name: "rig with witness only",
+			rig: Rig{
+				Name:       "testrig",
+				Path:       "/home/user/gt/testrig",
+				HasWitness: true,
+			},
+			wantPath: "/home/user/gt/testrig",
+		},
+		{
+			name: "rig with refinery only",
+			rig: Rig{
+				Name:        "testrig",
+				Path:        "/home/user/gt/testrig",
+				HasRefinery: true,
+			},
+			wantPath: "/home/user/gt/testrig",
+		},
+		{
+			name: "rig with no agents",
+			rig: Rig{
+				Name: "testrig",
+				Path: "/home/user/gt/testrig",
+			},
+			wantPath: "/home/user/gt/testrig",
+		},
+		{
+			name: "rig with mayor and witness",
+			rig: Rig{
+				Name:       "testrig",
+				Path:       "/home/user/gt/testrig",
+				HasMayor:   true,
+				HasWitness: true,
+			},
+			wantPath: "/home/user/gt/testrig",
+		},
+		{
+			name: "rig with mayor and refinery",
+			rig: Rig{
+				Name:        "testrig",
+				Path:        "/home/user/gt/testrig",
+				HasMayor:    true,
+				HasRefinery: true,
+			},
+			wantPath: "/home/user/gt/testrig",
+		},
+		{
+			name: "rig with witness and refinery",
+			rig: Rig{
+				Name:        "testrig",
+				Path:        "/home/user/gt/testrig",
+				HasWitness:  true,
+				HasRefinery: true,
+			},
+			wantPath: "/home/user/gt/testrig",
+		},
+		{
+			name: "rig with all agents",
+			rig: Rig{
+				Name:        "fullrig",
+				Path:        "/tmp/gt/fullrig",
+				HasMayor:    true,
+				HasWitness:  true,
+				HasRefinery: true,
+			},
+			wantPath: "/tmp/gt/fullrig",
+		},
+		{
+			name: "rig with polecats",
+			rig: Rig{
+				Name:     "testrig",
+				Path:     "/home/user/gt/testrig",
+				HasMayor: true,
+				Polecats: []string{"polecat1", "polecat2"},
+			},
+			wantPath: "/home/user/gt/testrig",
+		},
+		{
+			name: "rig with crew",
+			rig: Rig{
+				Name:     "testrig",
+				Path:     "/home/user/gt/testrig",
+				HasMayor: true,
+				Crew:     []string{"crew1", "crew2"},
+			},
+			wantPath: "/home/user/gt/testrig",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := tt.rig.BeadsPath()
+			if got != tt.wantPath {
+				t.Errorf("BeadsPath() = %q, want %q", got, tt.wantPath)
+			}
+		})
+	}
+}
+
+func TestDefaultBranch_FallsBackToMain(t *testing.T) {
+	t.Parallel()
+
+	// DefaultBranch should return "main" when config cannot be loaded
+	rig := Rig{
+		Name: "testrig",
+		Path: "/nonexistent/path",
+	}
+
+	got := rig.DefaultBranch()
+	if got != "main" {
+		t.Errorf("DefaultBranch() = %q, want %q", got, "main")
+	}
+}


### PR DESCRIPTION
  ## Summary

  `BeadsPath()` was incorrectly returning `<rig>/mayor/rig` when `HasMayor` was true, bypassing the redirect system at `<rig>/.beads/redirect`. This caused beads operations to fail when the user's repo doesn't have tracked `.beads/`.

  The fix changes `BeadsPath()` to always return the rig root path, allowing the redirect system (set up by `initBeads()` during rig creation) to handle finding the actual beads location.

  ## Related Issue

 #317

  ## Changes

  - **`internal/rig/types.go`**: Changed `BeadsPath()` to always return `r.Path` instead of conditionally returning `r.Path + "/mayor/rig"` when `HasMayor` is true
  - **`internal/rig/types_test.go`**: Added comprehensive unit tests for `BeadsPath()` covering all agent combinations (10 test cases)
  - **`internal/rig/manager_test.go`**: Added integration tests for `initBeads()` redirect logic:
    - `TestInitBeads_TrackedBeads_CreatesRedirect` - verifies redirect is created when repo has tracked beads
    - `TestInitBeads_LocalBeads_CreatesDatabase` - verifies local database is created when repo doesn't track beads

  ### Impact Analysis

  The following callers of `BeadsPath()` were affected by the bug and now work correctly:

  | File | Usage | Impact |
  |------|-------|--------|
  | `internal/refinery/manager.go:284` | `beads.New(m.rig.BeadsPath())` in `Queue()` | Merge queue queries failed without redirect |
  | `internal/swarm/manager.go:35` | `beadsDir: r.BeadsPath()` | Swarm operations failed |
  | `internal/cmd/swarm.go` (15+ locations) | Various `bd` command executions | All swarm CLI commands affected |
  | `internal/cmd/status.go:1141` | `beads.New(r.BeadsPath())` | Rig status display failed |
  | `internal/cmd/mq_next.go:59` | `beads.New(r.BeadsPath())` | Merge queue next failed |
  | `internal/cmd/mq_list.go:26` | `beads.New(r.BeadsPath())` | Merge queue listing failed |
  | `internal/cmd/rig_dock.go` (4 locations) | Dock/undock operations | Dock commands failed |

  ### Redirect Architecture

  The beads redirect system works as follows:

  /.beads/
  ├── redirect → "mayor/rig/.beads"  (when repo tracks .beads/)
  └── [local database files]          (when repo doesn't track .beads/)

  By returning `<rig>/` from `BeadsPath()`, all callers now go through this redirect system, which is followed automatically by the `bd` CLI and `beads.ResolveBeadsDir()`.

  ## Testing

  - [x] Unit tests pass (`go test ./internal/rig/...`)
  - [x] Full test suite passes (`go test ./...` - beads integration test skipped, requires `bd` CLI)
  - [x] Manual testing: N/A (code path analysis)

  ## Checklist

  - [x] Code follows project style
  - [x] Documentation updated (updated BeadsPath() docstring)
  - [x] No breaking changes (callers now work correctly instead of failing)

  ---
