### PR TITLE
fix: handle bd --no-daemon exit code 0 bug on not-found

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -147,6 +147,13 @@ func (b *Beads) run(args ...string) ([]byte, error) {
 		return nil, b.wrapError(err, stderr.String(), args)
 	}
 
+	// Handle bd --no-daemon exit code 0 bug: when issue not found,
+	// --no-daemon exits 0 but writes error to stderr with empty stdout.
+	// Detect this case and treat as error to avoid JSON parse failures.
+	if stdout.Len() == 0 && stderr.Len() > 0 {
+		return nil, b.wrapError(fmt.Errorf("command produced no output"), stderr.String(), args)
+	}
+
 	return stdout.Bytes(), nil
 }
 
@@ -170,7 +177,9 @@ func (b *Beads) wrapError(err error, stderr string, args []string) error {
 	}
 
 	// ErrNotFound is widely used for issue lookups - acceptable exception
-	if strings.Contains(stderr, "not found") || strings.Contains(stderr, "Issue not found") {
+	// Match various "not found" error patterns from bd
+	if strings.Contains(stderr, "not found") || strings.Contains(stderr, "Issue not found") ||
+		strings.Contains(stderr, "no issue found") {
 		return ErrNotFound
 	}
 

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -1186,6 +1186,10 @@ func getIssueDetails(issueID string) *issueDetails {
 	if err := showCmd.Run(); err != nil {
 		return nil
 	}
+	// Handle bd --no-daemon exit 0 bug: empty stdout means not found
+	if stdout.Len() == 0 {
+		return nil
+	}
 
 	var issues []struct {
 		ID        string `json:"id"`

--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -44,6 +44,12 @@ func showMoleculeExecutionPrompt(workDir, moleculeID string) {
 		fmt.Printf("  Check status with: bd mol current %s\n", moleculeID)
 		return
 	}
+	// Handle bd --no-daemon exit 0 bug: empty stdout means not found
+	if stdout.Len() == 0 {
+		fmt.Println(style.Bold.Render("→ PROPULSION PRINCIPLE: Work is on your hook. RUN IT."))
+		fmt.Println("  Begin working on this molecule immediately.")
+		return
+	}
 
 	// Parse JSON output - it's an array with one element
 	var outputs []MoleculeCurrentOutput


### PR DESCRIPTION
## Summary

When `bd --no-daemon show <id>` doesn't find an issue, it incorrectly exits with code 0 (success) but writes the error to stderr and leaves stdout empty. This causes JSON parse failures throughout gt when code tries to unmarshal the empty stdout.

**Symptoms:**
- `gt rig boot` fails with: `parsing bd show output: unexpected end of JSON input`
- `gt sling <nonexistent>` fails with: `parsing bead info: unexpected end of JSON input`

## Root Cause

```
bd show hq-witness-role --json           → exit 1, JSON error in stdout
bd --no-daemon show hq-witness-role --json → exit 0, error in stderr, stdout EMPTY
```

The `--no-daemon` flag causes bd to exit 0 even when the issue is not found.

## Fix

This PR handles the bug defensively in all affected code paths:

| File | Function | Fix |
|------|----------|-----|
| `internal/beads/beads.go` | `run()` | Detect empty stdout + non-empty stderr → error |
| `internal/beads/beads.go` | `wrapError()` | Add "no issue found" to ErrNotFound patterns |
| `internal/cmd/sling.go` | `storeArgsInBead()` | Check `len(out) == 0` |
| `internal/cmd/sling.go` | `verifyBeadExists()` | Use `Output()` + check empty |
| `internal/cmd/sling.go` | `getBeadInfo()` | Check `len(out) == 0` |
| `internal/cmd/sling.go` | `verifyFormulaExists()` | Use `Output()` + check content |
| `internal/cmd/convoy.go` | `getIssueDetails()` | Check `stdout.Len() == 0` |
| `internal/cmd/prime_molecule.go` | `showMoleculeExecutionPrompt()` | Check `stdout.Len() == 0` |

## Test Results

```
✅ TEST 1: gt rig boot global_opt      → "✓ Started: witness"
✅ TEST 2: gt sling go-nonexistent     → "bead 'go-nonexistent' not found" (clean error)
✅ TEST 3: gt sling go-ury (existing)  → Works (no regression)
```

## Notes

The root cause is in bd itself (should exit non-zero on not-found with `--no-daemon`), but this fix makes gt resilient to the bug. A separate fix to bd would also be appropriate.