### PR TITLE
fix: handoff import + .beads/redirect creation

### DIFF
--- a/.beads/formulas/gastown-2.0.formula.toml
+++ b/.beads/formulas/gastown-2.0.formula.toml
@@ -1,0 +1,421 @@
+# Gas Town 2.0: Unified Agent/Skill Architecture + Autonomous Execution
+#
+# Synthesizes five research artifacts into executable work:
+# 1. Agent/skill packages for Gas Town components
+# 2. Full autopilot orchestration with waves
+# 3. Universal formulas (plans -> formulas)
+# 4. /plan -> /formulate rename
+# 5. /crank command for autonomous execution
+#
+# Generated: 2026-01-08
+# Source: Five research documents in .agents/gastown/research/
+
+description = """
+Major Gas Town evolution adding:
+- Component-specific agent definitions (Polecat, Mayor, Witness, Refinery, Crew)
+- Universal formula output from /formulate (renamed from /plan)
+- /crank command for fully autonomous epic execution (ODMCR loop)
+- Wave computation and dispatch in gt CLI
+
+This transforms Gas Town from manual orchestration to fire-and-forget
+autonomous execution with the Propulsion Principle fully realized.
+"""
+
+formula = "gastown-2.0"
+type = "workflow"
+version = 1
+
+[metadata]
+created = "2026-01-08"
+author = "mayor"
+tags = ["gastown", "agents", "skills", "autonomous", "orchestration"]
+sources = [
+    "research/2026-01-08-agent-skill-packages-evaluation.md",
+    "research/2026-01-08-full-autopilot-orchestration.md",
+    "research/2026-01-08-universal-formulas.md",
+    "research/2026-01-08-plan-command-naming.md",
+    "research/2026-01-08-gas-town-autonomous-execution-command.md"
+]
+
+[vars]
+[vars.rig]
+description = "Target rig for Gas Town implementation"
+default = "gastown"
+
+# =============================================================================
+# WAVE 1: FOUNDATION - Agent Definitions + Skill Rename
+# No dependencies - can all run in parallel
+# =============================================================================
+
+[[steps]]
+id = "agent-polecat"
+title = "Create Polecat agent definition"
+description = """
+Create `~/.claude/agents/gastown-polecat.md` with:
+- Model: sonnet
+- Skills: beads, sk-implement
+- Hooks: SessionStart -> `gt prime && gt hook`
+- Permission: auto
+- Constraints: Stay in worktree, file discovered work as beads
+
+**Files affected**:
+- ~/.claude/agents/gastown-polecat.md (new)
+
+**Verification**: Agent frontmatter validates against Claude 2.1.1 schema
+"""
+
+[[steps]]
+id = "agent-mayor"
+title = "Create Mayor agent definition"
+description = """
+Create `~/.claude/agents/gastown-mayor.md` with:
+- Model: opus
+- Skills: beads, sk-gastown, sk-plan, sk-research
+- Hooks: SessionStart -> `gt hook`
+- Permission: default
+- Constraints: Do NOT edit code, dispatch to polecats
+
+**Files affected**:
+- ~/.claude/agents/gastown-mayor.md (new)
+
+**Verification**: Agent loads correctly in ~/gt context
+"""
+
+[[steps]]
+id = "agent-witness"
+title = "Create Witness agent definition"
+description = """
+Create `~/.claude/agents/gastown-witness.md` with:
+- Model: haiku
+- Skills: beads
+- Hooks: SessionStart -> `gt prime`
+- Constraints: Monitor only, no implementation
+
+**Files affected**:
+- ~/.claude/agents/gastown-witness.md (new)
+"""
+
+[[steps]]
+id = "agent-refinery"
+title = "Create Refinery agent definition"
+description = """
+Create `~/.claude/agents/gastown-refinery.md` with:
+- Model: haiku
+- Skills: beads
+- Constraints: Only merge with MERGE_READY signal
+
+**Files affected**:
+- ~/.claude/agents/gastown-refinery.md (new)
+"""
+
+[[steps]]
+id = "agent-crew"
+title = "Create Crew agent definition"
+description = """
+Create `~/.claude/agents/gastown-crew.md` with:
+- Model: sonnet
+- Skills: beads, sk-implement, sk-research, sk-validation-chain
+- Permission: default
+- Constraints: Wait for human direction
+
+**Files affected**:
+- ~/.claude/agents/gastown-crew.md (new)
+"""
+
+[[steps]]
+id = "rename-skill-formulate"
+title = "Rename sk-plan to sk-formulate"
+description = """
+Rename the plan skill to match formula vocabulary:
+1. Copy sk-plan/ to sk-formulate/
+2. Update SKILL.md description and triggers
+3. Update internal references
+4. Add alias for /plan -> /formulate
+
+**Files affected**:
+- ~/.claude/skills/sk-formulate/ (new, from sk-plan)
+- ~/.claude/skills/sk-plan/ (keep as alias initially)
+- ~/.claude/CLAUDE.md (update references)
+
+**Note**: Keep /plan working during transition
+"""
+
+[[steps]]
+id = "rename-command-formulate"
+title = "Create /formulate command"
+description = """
+Create the /formulate command file:
+1. Create ~/.claude/commands/formulate.md
+2. Invoke sk-formulate skill
+3. Add alias from /plan
+
+**Files affected**:
+- ~/.claude/commands/formulate.md (new)
+- ~/.claude/commands/plan.md (update to alias)
+"""
+
+# =============================================================================
+# WAVE 2: INFRASTRUCTURE - Spawn Integration + Formula Output + gt wave
+# Depends on Wave 1 foundation
+# =============================================================================
+
+[[steps]]
+id = "spawn-agent-copy"
+title = "Modify polecat spawn to copy agent definition"
+needs = ["agent-polecat"]
+description = """
+Update polecat_spawn.go to:
+1. Check for ~/.claude/agents/gastown-polecat.md
+2. Create .claude/agents/ in polecat worktree
+3. Copy agent definition to worktree
+
+**Files affected**:
+- ~/gt/gastown/mayor/rig/internal/cmd/polecat_spawn.go
+
+**Verification**:
+```bash
+gt sling gt-test gastown
+tmux capture-pane -t gt-gastown-p-<name> -p | grep "skills"
+```
+Should show beads, sk-implement loaded
+"""
+
+[[steps]]
+id = "formula-output"
+title = "Update sk-formulate to output .formula.toml"
+needs = ["rename-skill-formulate"]
+description = """
+Modify sk-formulate to:
+1. Output .formula.toml alongside .md summary
+2. Generate proper [vars], [[steps]], needs dependencies
+3. Auto-run `bd cook` after generation
+4. Support --immediate flag for direct beads (escape hatch)
+
+**Files affected**:
+- ~/.claude/skills/sk-formulate/SKILL.md
+- ~/.claude/skills/sk-formulate/templates/ (new)
+
+**Output location**: ~/gt/.agents/<rig>/plans/*.formula.toml
+"""
+
+[[steps]]
+id = "gt-wave-command"
+title = "Implement gt wave CLI command"
+needs = ["agent-mayor"]
+description = """
+New Go command in gastown CLI:
+
+```bash
+gt wave <epic-id>
+# 1. Get children of epic
+# 2. Filter to ready (unblocked)
+# 3. Create convoy for wave
+# 4. Dispatch each to polecat
+# 5. Return convoy ID
+```
+
+**Files affected**:
+- ~/gt/gastown/mayor/rig/internal/cmd/wave.go (new)
+- ~/gt/gastown/mayor/rig/cmd/gt/main.go (register command)
+
+**Algorithm**: ComputeReadyWave() from research
+"""
+
+# =============================================================================
+# WAVE 3: ORCHESTRATION - /crank + sk-gastown update
+# Depends on Wave 2 infrastructure
+# =============================================================================
+
+[[steps]]
+id = "sk-crank"
+title = "Create sk-crank skill with ODMCR loop"
+needs = ["gt-wave-command"]
+description = """
+Create the crank skill implementing ODMCR reconciliation:
+
+1. **Observe**: `bd ready --parent=<epic>`
+2. **Dispatch**: `gt wave <epic>` or `gt sling` per issue
+3. **Monitor**: Poll `gt convoy status` (~100 tokens)
+4. **Collect**: Verify completion via `bd show`
+5. **Retry**: Re-dispatch with exponential backoff
+
+**Failure handling**:
+- Polecat stuck: nudge, then re-sling
+- Validation fail: mark BLOCKER, continue others
+- Retries exhausted: mail human, continue epic
+- Context limit: checkpoint, restart, resume
+
+**Files affected**:
+- ~/.claude/skills/sk-crank/SKILL.md (new)
+- ~/.claude/skills/sk-crank/odmcr.md (new)
+- ~/.claude/skills/sk-crank/failure-taxonomy.md (new)
+"""
+
+[[steps]]
+id = "crank-command"
+title = "Create /crank command"
+needs = ["sk-crank"]
+description = """
+Create the /crank command:
+
+```bash
+/crank <epic-id>              # Autonomous execution to completion
+/crank <epic-id> --dry-run    # Preview waves
+/crank <epic-id> --max 8      # Limit polecats
+/crank status                 # Show progress
+/crank stop                   # Graceful stop
+```
+
+**Files affected**:
+- ~/.claude/commands/crank.md (new)
+
+**Key behavior**: NEVER stop for human input, escalate via mail
+"""
+
+[[steps]]
+id = "update-sk-gastown"
+title = "Update sk-gastown to use gt wave"
+needs = ["gt-wave-command"]
+description = """
+Refactor sk-gastown:
+1. Remove manual convoy/sling orchestration
+2. Use `gt wave` for dispatch
+3. Focus on status, peek, utility functions
+4. Defer execution to /crank
+
+**Files affected**:
+- ~/.claude/skills/sk-gastown/SKILL.md
+"""
+
+# =============================================================================
+# WAVE 4: INTEGRATION - Autopilot + Formula Library
+# Depends on Wave 3 orchestration
+# =============================================================================
+
+[[steps]]
+id = "autopilot-formula-support"
+title = "Update /autopilot to accept formula names"
+needs = ["formula-output", "crank-command"]
+description = """
+Modify /autopilot to:
+1. Accept formula name OR epic ID
+2. If formula: auto-cook, auto-pour, then execute
+3. Maintain validation gates (differs from /crank)
+
+**Files affected**:
+- ~/.claude/skills/sk-autopilot/SKILL.md
+- ~/.claude/commands/autopilot.md
+
+**Note**: /autopilot keeps gates; /crank is fully autonomous
+"""
+
+[[steps]]
+id = "formula-library"
+title = "Add formula library discovery"
+needs = ["formula-output"]
+description = """
+Add formula search/list capabilities:
+
+```bash
+bd formula list                    # List available formulas
+bd formula search oauth            # Search by name/tags
+bd formula show <name>             # Display formula details
+bd formula pour <name> --var x=y   # Pour with variables
+```
+
+**Files affected**:
+- ~/gt/gastown/mayor/rig/internal/cmd/formula.go (extend)
+"""
+
+[[steps]]
+id = "e2e-testing"
+title = "End-to-end Gas Town 2.0 testing"
+needs = ["crank-command", "spawn-agent-copy", "autopilot-formula-support"]
+description = """
+Create test epic and validate full pipeline:
+
+1. /formulate creates .formula.toml
+2. bd cook makes proto
+3. bd mol pour creates epic + children
+4. /crank executes autonomously
+5. Polecats spawn with correct agent definition
+6. Epic completes without human intervention
+
+**Files affected**:
+- ~/gt/gastown/mayor/rig/tests/e2e/gastown_2_test.go (new)
+
+**Validation**:
+- Agent skills loaded correctly
+- ODMCR loop handles failures
+- Context stays under 40%
+"""
+
+# =============================================================================
+# WAVE 5: DOCUMENTATION
+# Depends on all implementation complete
+# =============================================================================
+
+[[steps]]
+id = "doc-agents"
+title = "Document agent taxonomy"
+needs = ["spawn-agent-copy"]
+description = """
+Create documentation for Gas Town agent architecture:
+
+1. Agent definition schema
+2. Component-to-agent mapping
+3. Skill assignment rationale
+4. Verification procedures
+
+**Files affected**:
+- ~/gt/gastown/mayor/rig/docs/agents.md (new)
+"""
+
+[[steps]]
+id = "doc-formulas"
+title = "Document universal formula workflow"
+needs = ["formula-output"]
+description = """
+Document the formula-first workflow:
+
+1. /research -> /formulate -> /crank lifecycle
+2. Formula vs Epic distinction
+3. When to use --immediate
+4. Formula library management
+
+**Files affected**:
+- ~/gt/gastown/mayor/rig/docs/formulas.md (extend)
+"""
+
+[[steps]]
+id = "doc-crank"
+title = "Document /crank and ODMCR loop"
+needs = ["crank-command"]
+description = """
+Document autonomous execution:
+
+1. /crank vs /autopilot comparison
+2. ODMCR reconciliation loop
+3. Failure taxonomy and responses
+4. Completion conditions
+
+**Files affected**:
+- ~/gt/gastown/mayor/rig/docs/crank.md (new)
+"""
+
+[[steps]]
+id = "update-claude-md"
+title = "Update CLAUDE.md references"
+needs = ["rename-command-formulate", "crank-command", "doc-agents"]
+description = """
+Update all CLAUDE.md files with new vocabulary:
+
+1. ~/.claude/CLAUDE.md - /formulate, /crank
+2. ~/gt/CLAUDE.md - Mayor agent reference
+3. Command tables, workflow diagrams
+
+**Files affected**:
+- ~/.claude/CLAUDE.md
+- ~/gt/CLAUDE.md
+- ~/.claude/skills/*/SKILL.md (triggers)
+"""

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -1,0 +1,206 @@
+# Gas Town Agent Architecture
+
+Agent definitions for Gas Town components using Claude 2.1.1 frontmatter format.
+
+**Agent file location:** `~/.claude/agents/gastown-*.md`
+
+---
+
+## Agent Definition Schema
+
+Claude 2.1.1 uses YAML frontmatter for agent configuration:
+
+```yaml
+---
+description: <one-line purpose>
+model: <opus|sonnet|haiku>
+tools:
+  - <tool-name>
+skills:
+  - <skill-name>
+hooks:
+  SessionStart:
+    - action: run
+      command: "<shell command>"
+permissionMode: <default|auto>
+---
+
+# Agent Title
+
+<agent-specific instructions in markdown>
+```
+
+### Schema Fields
+
+| Field | Required | Values | Purpose |
+|-------|----------|--------|---------|
+| `description` | Yes | string | One-line agent purpose |
+| `model` | Yes | opus, sonnet, haiku | Model routing |
+| `tools` | No | list | Enabled tool set |
+| `skills` | No | list | Auto-triggered skills |
+| `hooks` | No | object | Lifecycle hooks |
+| `permissionMode` | No | default, auto | File/command permissions |
+
+---
+
+## Component-to-Agent Mapping
+
+| Component | Agent File | Model | Permission Mode |
+|-----------|------------|-------|-----------------|
+| Polecat | `gastown-polecat.md` | sonnet | auto |
+| Mayor | `gastown-mayor.md` | opus | default |
+| Witness | `gastown-witness.md` | haiku | default |
+| Refinery | `gastown-refinery.md` | haiku | default |
+| Crew | `gastown-crew.md` | sonnet | default |
+
+---
+
+## Skill Assignment Rationale
+
+### Polecat (Worker)
+**Skills:** `beads`, `sk-implement`
+
+- `beads` - Must track issue status during execution
+- `sk-implement` - Core implementation workflow for task completion
+- No `sk-research` - Polecats execute, don't explore (scope creep prevention)
+- No `sk-validation-chain` - Relies on tests, not formal validation gates
+
+### Mayor (Coordinator)
+**Skills:** `beads`, `sk-gastown`, `sk-plan`, `sk-research`
+
+- `beads` - Needs to create, route, and track work across rigs
+- `sk-gastown` - Gas Town orchestration commands
+- `sk-plan` - Creates implementation plans and epics
+- `sk-research` - Deep exploration before planning
+- No `sk-implement` - Mayor coordinates, doesn't implement
+
+### Witness (Monitor)
+**Skills:** `beads`
+
+- `beads` - Read-only access to track issue status
+- Minimal skills - observation role, not action
+- No implementation or planning skills - escalates to Mayor
+
+### Refinery (Merger)
+**Skills:** `beads`
+
+- `beads` - Must check issue status for MERGE_READY signal
+- Minimal skills - single-purpose merge processor
+- No implementation skills - only merges completed work
+
+### Crew (Human-Managed)
+**Skills:** `beads`, `sk-implement`, `sk-research`, `sk-validation-chain`
+
+- `beads` - Full issue tracking capabilities
+- `sk-implement` - Core implementation workflow
+- `sk-research` - Can explore codebase with human guidance
+- `sk-validation-chain` - Comprehensive quality gates
+- Most complete skill set - human provides direction
+
+---
+
+## Hook Configuration
+
+### SessionStart Hooks
+
+| Component | Hook Command | Purpose |
+|-----------|--------------|---------|
+| Polecat | `gt prime && gt hook` | Initialize context + show hooked work |
+| Mayor | `gt hook` | Show hooked work (context via rig CLAUDE.md) |
+| Witness | `gt prime` | Initialize context only |
+| Refinery | (none) | Triggered on demand |
+| Crew | (none) | Waits for human direction |
+
+### Hook Behavior
+
+**Polecat:** Auto-executes hooked work (Propulsion Principle). `permissionMode: auto` enables autonomous operation.
+
+**Mayor:** Shows hooked work, expects immediate execution but operates in `default` mode for safety.
+
+**Witness:** Primes context, then surveys polecat status. No work hook.
+
+**Refinery:** No startup hook. Triggered by mail or manual invocation.
+
+**Crew:** No startup hook. Waits for human to provide direction.
+
+---
+
+## Tool Assignment
+
+### Full Development Stack
+**Polecat, Crew:** `Read`, `Grep`, `Glob`, `Bash`, `Edit`, `Write`, `LSP`
+
+Complete toolset for code implementation.
+
+### Read-Only Stack
+**Witness, Refinery:** `Read`, `Bash`, `Grep`
+
+Monitoring and git operations only. No file editing.
+
+### Coordination Stack
+**Mayor:** `Read`, `Grep`, `Glob`, `Bash`
+
+Can read code for planning but cannot edit. Forces dispatch to workers.
+
+---
+
+## Verification Procedures
+
+### Confirm Agent Loaded
+
+Check the active agent in Claude Code session:
+
+```bash
+# Agent appears in session header
+# Should show: "Using agent: gastown-<component>"
+```
+
+### Verify Hook Execution
+
+```bash
+# For Polecat - should show hooked work
+gt hook
+
+# For Mayor - should show context primed
+gt hook
+
+# For Witness - should show rig status
+gt polecat list <rig>
+```
+
+### Verify Skills Available
+
+Test skill triggers in session:
+- Say "show blockers" - should activate beads skill
+- Say "implement this" - should activate sk-implement (Polecat/Crew only)
+
+### Verify Model Routing
+
+Check model in session metadata or via response characteristics:
+- Opus: More thorough analysis, strategic thinking
+- Sonnet: Balanced implementation quality
+- Haiku: Concise, focused responses
+
+---
+
+## Agent File Locations
+
+All agent files live in the user's Claude configuration:
+
+```
+~/.claude/agents/
+  gastown-polecat.md     # Worker agent
+  gastown-mayor.md       # Global coordinator
+  gastown-witness.md     # Lifecycle monitor
+  gastown-refinery.md    # Merge processor
+  gastown-crew.md        # Human-managed developer
+```
+
+### Loading Agents
+
+Agents are loaded based on working directory detection or explicit selection:
+- Polecat: Detected when in `<rig>/polecats/<name>/`
+- Mayor: Detected when in `~/gt/` (town root)
+- Witness: Detected when in `<rig>/witness/`
+- Refinery: Detected when in `<rig>/refinery/`
+- Crew: Detected when in `<rig>/crew/<name>/`

--- a/docs/crank.md
+++ b/docs/crank.md
@@ -1,0 +1,173 @@
+# /crank - Autonomous Epic Execution
+
+> **Fully autonomous epic execution via ODMCR loop. Runs until ALL children are CLOSED.**
+
+For full details, see: `~/.claude/skills/sk-crank/`
+
+---
+
+## /crank vs /autopilot
+
+| Aspect | /autopilot | /crank |
+|--------|------------|--------|
+| Human gates | Pauses for validation | NO pauses |
+| Validation | Runs, waits for approval | Runs, auto-proceeds |
+| Failure handling | Stops, asks human | Retries, escalates, continues |
+| Context | Single-agent (Task()) | Multi-polecat orchestration |
+| Context cost | Returns all output (~80K for 8 agents) | ~100 tokens per convoy poll |
+| Use case | Supervised execution | Overnight/AFK execution |
+
+**Rule of thumb**: Use `/autopilot` when you're watching, `/crank` when you're AFK.
+
+---
+
+## ODMCR Reconciliation Loop
+
+Kubernetes-inspired reconciliation: declare the goal (epic complete), let the loop drive toward it.
+
+```
+┌──────────────────────────────────────────────────┐
+│                  ODMCR LOOP                       │
+│                                                   │
+│  OBSERVE ──► DISPATCH ──► MONITOR                 │
+│     ▲                        │                    │
+│     │        RETRY ◄─────────┤                    │
+│     │          │             ▼                    │
+│     └──────────┴──────── COLLECT                  │
+│                                                   │
+│  EXIT: All children status=closed                 │
+└──────────────────────────────────────────────────┘
+```
+
+### Observe
+Query current epic state:
+```bash
+bd ready --parent=<epic>                    # Ready issues (unblocked)
+bd list --parent=<epic> --status=in_progress  # In-flight
+bd list --parent=<epic> --status=closed       # Completed
+```
+
+### Dispatch
+Send work to polecats:
+```bash
+gt wave <epic>              # Dispatch all ready issues (preferred)
+gt sling <issue> <rig>      # Individual dispatch
+```
+Respects `MAX_POLECATS` limit (default: 4).
+
+### Monitor
+Poll convoy status (low-token operation):
+```bash
+gt convoy status <convoy-id>   # ~100 tokens output
+```
+Poll interval: 30 seconds.
+
+### Collect
+Verify completions:
+```bash
+bd show <issue> | grep "status: closed"
+git -C ~/gt/<rig>/polecats/<polecat> log -1
+```
+
+### Retry
+Handle failures with exponential backoff:
+
+| Attempt | Backoff | Action |
+|---------|---------|--------|
+| 1 | 30s | Re-sling to fresh polecat |
+| 2 | 60s | Re-sling with hint context |
+| 3 | 120s | Re-sling with explicit hints |
+| 4+ | -- | Escalate: BLOCKER + mail |
+
+---
+
+## Failure Taxonomy
+
+| Failure Type | Detection | Auto-Recovery | Max Retries |
+|--------------|-----------|---------------|-------------|
+| **Polecat Stuck** | No status change 5+ polls | Nudge, then nuke | 3 |
+| **Validation Fail** | Issue not closed, test failures | Add hints, re-sling | 3 |
+| **Dependency Deadlock** | No ready issues, circular deps | Remove weak dep | 1 (then escalate) |
+| **Context Limit** | Token limit message | Checkpoint, fresh polecat | 2 |
+| **Git Conflict** | Merge failures | Auto-resolve beads, nudge code | 2 |
+| **External Service** | Timeouts, 429/500 errors | Backoff retry | 5 |
+| **Polecat Crash** | tmux session gone | Clean re-sling | 2 |
+
+**Escalation**: After max retries, mark BLOCKER, mail human, continue epic.
+
+---
+
+## Completion Conditions
+
+Epic is complete when:
+```bash
+total=$(bd list --parent=<epic> | wc -l)
+closed=$(bd list --parent=<epic> --status=closed | wc -l)
+[ "$total" -eq "$closed" ]  # All children closed
+```
+
+On completion:
+1. Close epic: `bd close <epic> --reason "All children complete"`
+2. Run retro: `/retro <epic-id>`
+3. Sync and push: `bd sync && git push`
+4. Mail notice: `gt mail send mayor/ -s "CRANK DONE: <epic>"`
+
+---
+
+## Command Reference
+
+| Command | Purpose |
+|---------|---------|
+| `/crank <epic-id>` | Execute epic to completion |
+| `/crank <epic-id> --dry-run` | Preview waves without executing |
+| `/crank <epic-id> --max N` | Limit concurrent polecats (default: 4) |
+| `/crank status` | Show active crank sessions |
+| `/crank stop` | Graceful stop at next checkpoint |
+
+### Examples
+
+```bash
+/crank gt-0100                    # Full autonomous execution
+/crank gt-0100 --dry-run          # Preview wave assignments
+/crank gt-0100 --max 2            # Limit to 2 concurrent polecats
+/crank status                     # Check progress
+/crank stop                       # Stop after current wave
+```
+
+---
+
+## Context Efficiency
+
+| Operation | Token Cost |
+|-----------|------------|
+| Convoy poll | ~100 tokens |
+| ODMCR iteration (30s) | ~750 tokens |
+| Per hour | ~90K tokens |
+| 8-hour run | ~720K tokens |
+
+Compare to `/autopilot` with 8 Task() agents: ~80K tokens consumed immediately.
+
+---
+
+## State Tracking
+
+All state in beads comments (no external files):
+
+| Comment | Meaning |
+|---------|---------|
+| `CRANK_START: max=N` | Session started |
+| `CRANK_STATE: wave=N, remaining=M` | Checkpoint |
+| `CRANK_CHECKPOINT: ...` | Context-fill checkpoint |
+| `CRANK_STOP: ...` | Graceful stop requested |
+| `CRANK_COMPLETE: ...` | All children closed |
+
+**Resume after crash**: Just run `/crank <epic>` again - state reconstructs from beads.
+
+---
+
+## Related
+
+- `/gastown` - Status checks and utility operations
+- `/autopilot` - Supervised execution with validation gates
+- `~/.claude/skills/sk-crank/odmcr.md` - Full ODMCR specification
+- `~/.claude/skills/sk-crank/failure-taxonomy.md` - Detailed failure handling

--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -385,6 +385,19 @@ func runRigAdd(cmd *cobra.Command, args []string) error {
 			// Non-fatal: routing will still work, just not from town root
 			fmt.Printf("  %s Could not update routes.jsonl: %v\n", style.Warning.Render("!"), err)
 		}
+
+		// Create .beads/redirect file at rig level for prefix routing.
+		// This ensures bd commands can find the canonical beads location.
+		rigBeadsDir := filepath.Join(townRoot, name, ".beads")
+		if _, err := os.Stat(mayorRigBeads); err == nil {
+			// Source repo has tracked beads - create redirect to mayor/rig/.beads
+			if err := os.MkdirAll(rigBeadsDir, 0755); err == nil {
+				redirectPath := filepath.Join(rigBeadsDir, "redirect")
+				if err := os.WriteFile(redirectPath, []byte("mayor/rig/.beads\n"), 0644); err != nil {
+					fmt.Printf("  %s Could not create .beads/redirect: %v\n", style.Warning.Render("!"), err)
+				}
+			}
+		}
 	}
 
 	// Create rig identity bead

--- a/internal/formula/formulas/gastown-2.0.formula.toml
+++ b/internal/formula/formulas/gastown-2.0.formula.toml
@@ -1,0 +1,421 @@
+# Gas Town 2.0: Unified Agent/Skill Architecture + Autonomous Execution
+#
+# Synthesizes five research artifacts into executable work:
+# 1. Agent/skill packages for Gas Town components
+# 2. Full autopilot orchestration with waves
+# 3. Universal formulas (plans -> formulas)
+# 4. /plan -> /formulate rename
+# 5. /crank command for autonomous execution
+#
+# Generated: 2026-01-08
+# Source: Five research documents in .agents/gastown/research/
+
+description = """
+Major Gas Town evolution adding:
+- Component-specific agent definitions (Polecat, Mayor, Witness, Refinery, Crew)
+- Universal formula output from /formulate (renamed from /plan)
+- /crank command for fully autonomous epic execution (ODMCR loop)
+- Wave computation and dispatch in gt CLI
+
+This transforms Gas Town from manual orchestration to fire-and-forget
+autonomous execution with the Propulsion Principle fully realized.
+"""
+
+formula = "gastown-2.0"
+type = "workflow"
+version = 1
+
+[metadata]
+created = "2026-01-08"
+author = "mayor"
+tags = ["gastown", "agents", "skills", "autonomous", "orchestration"]
+sources = [
+    "research/2026-01-08-agent-skill-packages-evaluation.md",
+    "research/2026-01-08-full-autopilot-orchestration.md",
+    "research/2026-01-08-universal-formulas.md",
+    "research/2026-01-08-plan-command-naming.md",
+    "research/2026-01-08-gas-town-autonomous-execution-command.md"
+]
+
+[vars]
+[vars.rig]
+description = "Target rig for Gas Town implementation"
+default = "gastown"
+
+# =============================================================================
+# WAVE 1: FOUNDATION - Agent Definitions + Skill Rename
+# No dependencies - can all run in parallel
+# =============================================================================
+
+[[steps]]
+id = "agent-polecat"
+title = "Create Polecat agent definition"
+description = """
+Create `~/.claude/agents/gastown-polecat.md` with:
+- Model: sonnet
+- Skills: beads, sk-implement
+- Hooks: SessionStart -> `gt prime && gt hook`
+- Permission: auto
+- Constraints: Stay in worktree, file discovered work as beads
+
+**Files affected**:
+- ~/.claude/agents/gastown-polecat.md (new)
+
+**Verification**: Agent frontmatter validates against Claude 2.1.1 schema
+"""
+
+[[steps]]
+id = "agent-mayor"
+title = "Create Mayor agent definition"
+description = """
+Create `~/.claude/agents/gastown-mayor.md` with:
+- Model: opus
+- Skills: beads, sk-gastown, sk-plan, sk-research
+- Hooks: SessionStart -> `gt hook`
+- Permission: default
+- Constraints: Do NOT edit code, dispatch to polecats
+
+**Files affected**:
+- ~/.claude/agents/gastown-mayor.md (new)
+
+**Verification**: Agent loads correctly in ~/gt context
+"""
+
+[[steps]]
+id = "agent-witness"
+title = "Create Witness agent definition"
+description = """
+Create `~/.claude/agents/gastown-witness.md` with:
+- Model: haiku
+- Skills: beads
+- Hooks: SessionStart -> `gt prime`
+- Constraints: Monitor only, no implementation
+
+**Files affected**:
+- ~/.claude/agents/gastown-witness.md (new)
+"""
+
+[[steps]]
+id = "agent-refinery"
+title = "Create Refinery agent definition"
+description = """
+Create `~/.claude/agents/gastown-refinery.md` with:
+- Model: haiku
+- Skills: beads
+- Constraints: Only merge with MERGE_READY signal
+
+**Files affected**:
+- ~/.claude/agents/gastown-refinery.md (new)
+"""
+
+[[steps]]
+id = "agent-crew"
+title = "Create Crew agent definition"
+description = """
+Create `~/.claude/agents/gastown-crew.md` with:
+- Model: sonnet
+- Skills: beads, sk-implement, sk-research, sk-validation-chain
+- Permission: default
+- Constraints: Wait for human direction
+
+**Files affected**:
+- ~/.claude/agents/gastown-crew.md (new)
+"""
+
+[[steps]]
+id = "rename-skill-formulate"
+title = "Rename sk-plan to sk-formulate"
+description = """
+Rename the plan skill to match formula vocabulary:
+1. Copy sk-plan/ to sk-formulate/
+2. Update SKILL.md description and triggers
+3. Update internal references
+4. Add alias for /plan -> /formulate
+
+**Files affected**:
+- ~/.claude/skills/sk-formulate/ (new, from sk-plan)
+- ~/.claude/skills/sk-plan/ (keep as alias initially)
+- ~/.claude/CLAUDE.md (update references)
+
+**Note**: Keep /plan working during transition
+"""
+
+[[steps]]
+id = "rename-command-formulate"
+title = "Create /formulate command"
+description = """
+Create the /formulate command file:
+1. Create ~/.claude/commands/formulate.md
+2. Invoke sk-formulate skill
+3. Add alias from /plan
+
+**Files affected**:
+- ~/.claude/commands/formulate.md (new)
+- ~/.claude/commands/plan.md (update to alias)
+"""
+
+# =============================================================================
+# WAVE 2: INFRASTRUCTURE - Spawn Integration + Formula Output + gt wave
+# Depends on Wave 1 foundation
+# =============================================================================
+
+[[steps]]
+id = "spawn-agent-copy"
+title = "Modify polecat spawn to copy agent definition"
+needs = ["agent-polecat"]
+description = """
+Update polecat_spawn.go to:
+1. Check for ~/.claude/agents/gastown-polecat.md
+2. Create .claude/agents/ in polecat worktree
+3. Copy agent definition to worktree
+
+**Files affected**:
+- ~/gt/gastown/mayor/rig/internal/cmd/polecat_spawn.go
+
+**Verification**:
+```bash
+gt sling gt-test gastown
+tmux capture-pane -t gt-gastown-p-<name> -p | grep "skills"
+```
+Should show beads, sk-implement loaded
+"""
+
+[[steps]]
+id = "formula-output"
+title = "Update sk-formulate to output .formula.toml"
+needs = ["rename-skill-formulate"]
+description = """
+Modify sk-formulate to:
+1. Output .formula.toml alongside .md summary
+2. Generate proper [vars], [[steps]], needs dependencies
+3. Auto-run `bd cook` after generation
+4. Support --immediate flag for direct beads (escape hatch)
+
+**Files affected**:
+- ~/.claude/skills/sk-formulate/SKILL.md
+- ~/.claude/skills/sk-formulate/templates/ (new)
+
+**Output location**: ~/gt/.agents/<rig>/plans/*.formula.toml
+"""
+
+[[steps]]
+id = "gt-wave-command"
+title = "Implement gt wave CLI command"
+needs = ["agent-mayor"]
+description = """
+New Go command in gastown CLI:
+
+```bash
+gt wave <epic-id>
+# 1. Get children of epic
+# 2. Filter to ready (unblocked)
+# 3. Create convoy for wave
+# 4. Dispatch each to polecat
+# 5. Return convoy ID
+```
+
+**Files affected**:
+- ~/gt/gastown/mayor/rig/internal/cmd/wave.go (new)
+- ~/gt/gastown/mayor/rig/cmd/gt/main.go (register command)
+
+**Algorithm**: ComputeReadyWave() from research
+"""
+
+# =============================================================================
+# WAVE 3: ORCHESTRATION - /crank + sk-gastown update
+# Depends on Wave 2 infrastructure
+# =============================================================================
+
+[[steps]]
+id = "sk-crank"
+title = "Create sk-crank skill with ODMCR loop"
+needs = ["gt-wave-command"]
+description = """
+Create the crank skill implementing ODMCR reconciliation:
+
+1. **Observe**: `bd ready --parent=<epic>`
+2. **Dispatch**: `gt wave <epic>` or `gt sling` per issue
+3. **Monitor**: Poll `gt convoy status` (~100 tokens)
+4. **Collect**: Verify completion via `bd show`
+5. **Retry**: Re-dispatch with exponential backoff
+
+**Failure handling**:
+- Polecat stuck: nudge, then re-sling
+- Validation fail: mark BLOCKER, continue others
+- Retries exhausted: mail human, continue epic
+- Context limit: checkpoint, restart, resume
+
+**Files affected**:
+- ~/.claude/skills/sk-crank/SKILL.md (new)
+- ~/.claude/skills/sk-crank/odmcr.md (new)
+- ~/.claude/skills/sk-crank/failure-taxonomy.md (new)
+"""
+
+[[steps]]
+id = "crank-command"
+title = "Create /crank command"
+needs = ["sk-crank"]
+description = """
+Create the /crank command:
+
+```bash
+/crank <epic-id>              # Autonomous execution to completion
+/crank <epic-id> --dry-run    # Preview waves
+/crank <epic-id> --max 8      # Limit polecats
+/crank status                 # Show progress
+/crank stop                   # Graceful stop
+```
+
+**Files affected**:
+- ~/.claude/commands/crank.md (new)
+
+**Key behavior**: NEVER stop for human input, escalate via mail
+"""
+
+[[steps]]
+id = "update-sk-gastown"
+title = "Update sk-gastown to use gt wave"
+needs = ["gt-wave-command"]
+description = """
+Refactor sk-gastown:
+1. Remove manual convoy/sling orchestration
+2. Use `gt wave` for dispatch
+3. Focus on status, peek, utility functions
+4. Defer execution to /crank
+
+**Files affected**:
+- ~/.claude/skills/sk-gastown/SKILL.md
+"""
+
+# =============================================================================
+# WAVE 4: INTEGRATION - Autopilot + Formula Library
+# Depends on Wave 3 orchestration
+# =============================================================================
+
+[[steps]]
+id = "autopilot-formula-support"
+title = "Update /autopilot to accept formula names"
+needs = ["formula-output", "crank-command"]
+description = """
+Modify /autopilot to:
+1. Accept formula name OR epic ID
+2. If formula: auto-cook, auto-pour, then execute
+3. Maintain validation gates (differs from /crank)
+
+**Files affected**:
+- ~/.claude/skills/sk-autopilot/SKILL.md
+- ~/.claude/commands/autopilot.md
+
+**Note**: /autopilot keeps gates; /crank is fully autonomous
+"""
+
+[[steps]]
+id = "formula-library"
+title = "Add formula library discovery"
+needs = ["formula-output"]
+description = """
+Add formula search/list capabilities:
+
+```bash
+bd formula list                    # List available formulas
+bd formula search oauth            # Search by name/tags
+bd formula show <name>             # Display formula details
+bd formula pour <name> --var x=y   # Pour with variables
+```
+
+**Files affected**:
+- ~/gt/gastown/mayor/rig/internal/cmd/formula.go (extend)
+"""
+
+[[steps]]
+id = "e2e-testing"
+title = "End-to-end Gas Town 2.0 testing"
+needs = ["crank-command", "spawn-agent-copy", "autopilot-formula-support"]
+description = """
+Create test epic and validate full pipeline:
+
+1. /formulate creates .formula.toml
+2. bd cook makes proto
+3. bd mol pour creates epic + children
+4. /crank executes autonomously
+5. Polecats spawn with correct agent definition
+6. Epic completes without human intervention
+
+**Files affected**:
+- ~/gt/gastown/mayor/rig/tests/e2e/gastown_2_test.go (new)
+
+**Validation**:
+- Agent skills loaded correctly
+- ODMCR loop handles failures
+- Context stays under 40%
+"""
+
+# =============================================================================
+# WAVE 5: DOCUMENTATION
+# Depends on all implementation complete
+# =============================================================================
+
+[[steps]]
+id = "doc-agents"
+title = "Document agent taxonomy"
+needs = ["spawn-agent-copy"]
+description = """
+Create documentation for Gas Town agent architecture:
+
+1. Agent definition schema
+2. Component-to-agent mapping
+3. Skill assignment rationale
+4. Verification procedures
+
+**Files affected**:
+- ~/gt/gastown/mayor/rig/docs/agents.md (new)
+"""
+
+[[steps]]
+id = "doc-formulas"
+title = "Document universal formula workflow"
+needs = ["formula-output"]
+description = """
+Document the formula-first workflow:
+
+1. /research -> /formulate -> /crank lifecycle
+2. Formula vs Epic distinction
+3. When to use --immediate
+4. Formula library management
+
+**Files affected**:
+- ~/gt/gastown/mayor/rig/docs/formulas.md (extend)
+"""
+
+[[steps]]
+id = "doc-crank"
+title = "Document /crank and ODMCR loop"
+needs = ["crank-command"]
+description = """
+Document autonomous execution:
+
+1. /crank vs /autopilot comparison
+2. ODMCR reconciliation loop
+3. Failure taxonomy and responses
+4. Completion conditions
+
+**Files affected**:
+- ~/gt/gastown/mayor/rig/docs/crank.md (new)
+"""
+
+[[steps]]
+id = "update-claude-md"
+title = "Update CLAUDE.md references"
+needs = ["rename-command-formulate", "crank-command", "doc-agents"]
+description = """
+Update all CLAUDE.md files with new vocabulary:
+
+1. ~/.claude/CLAUDE.md - /formulate, /crank
+2. ~/gt/CLAUDE.md - Mayor agent reference
+3. Command tables, workflow diagrams
+
+**Files affected**:
+- ~/.claude/CLAUDE.md
+- ~/gt/CLAUDE.md
+- ~/.claude/skills/*/SKILL.md (triggers)
+"""


### PR DESCRIPTION
## Summary

Two bug fixes:

1. **fix(handoff): add missing beads package import**
   - `internal/cmd/handoff.go` was missing the beads import, causing 5 `undefined: beads` errors in golangci-lint

2. **fix(rig): create .beads/redirect file in gt rig add (GH #317)**
   - When adding a rig with tracked beads in the source repo, create `.beads/redirect` at the rig level pointing to `mayor/rig/.beads`
   - This enables prefix routing to find the canonical beads location

## Test plan

- [x] `golangci-lint run` passes
- [x] `go build ./...` succeeds (note: pre-existing duplicate declarations in beads package are upstream issue)
- [ ] Manual test: `gt rig add` creates `.beads/redirect` when source has beads