### PR TITLE
fix(install): allow --wrappers in existing town without recreating HQ

### DIFF
--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -109,6 +109,14 @@ func runInstall(cmd *cobra.Command, args []string) error {
 
 	// Check if already a workspace
 	if isWS, _ := workspace.IsWorkspace(absPath); isWS && !installForce {
+		// If only --wrappers is requested in existing town, just install wrappers and exit
+		if installWrappers {
+			if err := wrappers.Install(); err != nil {
+				return fmt.Errorf("installing wrapper scripts: %w", err)
+			}
+			fmt.Printf("✓ Installed gt-codex and gt-opencode to %s\n", wrappers.BinDir())
+			return nil
+		}
 		return fmt.Errorf("directory is already a Gas Town HQ (use --force to reinitialize)")
 	}
 


### PR DESCRIPTION
## Summary

- Allow `gt install --wrappers` to work in an existing Gas Town installation
- Previously, `--wrappers` required recreating the entire HQ which was destructive
- Now wrapper installation can be done independently

## Test plan

- [x] Verify `go build ./...` passes
- [ ] Manual test: run `gt install --wrappers` in existing town

🤖 Generated with [Claude Code](https://claude.com/claude-code)