### PR TITLE
fix(refinery): use default Claude account and resolve config dir

### DIFF
--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -173,9 +173,25 @@ func (m *Manager) Start(foreground bool) error {
 		return fmt.Errorf("ensuring runtime settings: %w", err)
 	}
 
+	// Resolve account for runtime config (use default account if configured)
+	townRoot := filepath.Dir(m.rig.Path)
+	accountsPath := constants.MayorAccountsPath(townRoot)
+	claudeConfigDir, accountHandle, err := config.ResolveAccountConfigDir(accountsPath, "")
+	if err != nil {
+		// Non-fatal: continue without account config
+		_, _ = fmt.Fprintf(m.output, "Warning: could not resolve account: %v\n", err)
+	}
+	if accountHandle != "" {
+		_, _ = fmt.Fprintf(m.output, "Using account: %s\n", accountHandle)
+	}
+
 	// Build startup command first
 	bdActor := fmt.Sprintf("%s/refinery", m.rig.Name)
 	command := config.BuildAgentStartupCommand("refinery", bdActor, m.rig.Path, "")
+	// Prepend runtime config dir env if needed (for account selection)
+	if runtimeConfig.Session != nil && runtimeConfig.Session.ConfigDirEnv != "" && claudeConfigDir != "" {
+		command = config.PrependEnv(command, map[string]string{runtimeConfig.Session.ConfigDirEnv: claudeConfigDir})
+	}
 
 	// Create session with command directly to avoid send-keys race condition.
 	// See: https://github.com/anthropics/gastown/issues/280
@@ -185,13 +201,13 @@ func (m *Manager) Start(foreground bool) error {
 
 	// Set environment variables (non-fatal: session works without these)
 	// Use centralized AgentEnv for consistency across all role startup paths
-	townRoot := filepath.Dir(m.rig.Path)
 	envVars := config.AgentEnv(config.AgentEnvConfig{
-		Role:          "refinery",
-		Rig:           m.rig.Name,
-		TownRoot:      townRoot,
-		BeadsDir:      beads.ResolveBeadsDir(m.rig.Path),
-		BeadsNoDaemon: true,
+		Role:             "refinery",
+		Rig:              m.rig.Name,
+		TownRoot:         townRoot,
+		BeadsDir:         beads.ResolveBeadsDir(m.rig.Path),
+		RuntimeConfigDir: claudeConfigDir,
+		BeadsNoDaemon:    true,
 	})
 
 	// Add refinery-specific flag


### PR DESCRIPTION
## Summary

- Fix refinery initialization to use the default Claude account configured via `gt account default`
- Set `RuntimeConfigDir` in `AgentEnv` so `CLAUDE_CONFIG_DIR` is correctly propagated
- Aligns refinery spawn behavior with polecats and crew workers

**Root cause**: Refineries were spawning without account context, ignoring the configured default account.

## Changes

1. **internal/refinery/manager.go**: 
   - Resolve account using `config.ResolveAccountConfigDir`
   - Pass `RuntimeConfigDir` to `AgentEnv`
   - Prepend config dir env to startup command if needed

## Test plan

- [x] Verify `go build ./...` passes
- [ ] Manual test: configure a default account with `gt account default`, start refinery, verify it uses correct account

🤖 Generated with [Claude Code](https://claude.com/claude-code)