### PR TITLE
Different roles to different models

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -49,6 +49,13 @@ type TownSettings struct {
 	// Values override or extend the built-in presets.
 	// Example: {"gemini": {"command": "/custom/path/to/gemini"}}
 	Agents map[string]*RuntimeConfig `json:"agents,omitempty"`
+
+	// RoleAgents maps role names to agent aliases for per-role model selection.
+	// Keys are role names: "mayor", "deacon", "witness", "refinery", "polecat", "crew".
+	// Values are agent names (built-in presets or custom agents defined in Agents).
+	// This allows cost optimization by using different models for different roles.
+	// Example: {"mayor": "claude-opus", "witness": "claude-haiku", "polecat": "claude-sonnet"}
+	RoleAgents map[string]string `json:"role_agents,omitempty"`
 }
 
 // NewTownSettings creates a new TownSettings with defaults.
@@ -58,6 +65,7 @@ func NewTownSettings() *TownSettings {
 		Version:      CurrentTownSettingsVersion,
 		DefaultAgent: "claude",
 		Agents:       make(map[string]*RuntimeConfig),
+		RoleAgents:   make(map[string]string),
 	}
 }
 
@@ -209,6 +217,13 @@ type RigSettings struct {
 	// Similar to TownSettings.Agents but applies to this rig only.
 	// Allows per-rig custom agents for polecats and crew members.
 	Agents map[string]*RuntimeConfig `json:"agents,omitempty"`
+
+	// RoleAgents maps role names to agent aliases for per-role model selection.
+	// Keys are role names: "witness", "refinery", "polecat", "crew".
+	// Values are agent names (built-in presets or custom agents).
+	// Overrides TownSettings.RoleAgents for this specific rig.
+	// Example: {"witness": "claude-haiku", "polecat": "claude-sonnet"}
+	RoleAgents map[string]string `json:"role_agents,omitempty"`
 }
 
 // CrewConfig represents crew workspace settings for a rig.


### PR DESCRIPTION
## Summary
This implementation allows assigning different LLM agents/models to different roles (Mayor, Deacon, Witness, Refinery, Polecat, Crew) for cost optimization.

## Related Issue
#335 

## Changes
  internal/config/types.go
  - Added RoleAgents map[string]string field to TownSettings
  - Added RoleAgents map[string]string field to RigSettings
  - Updated NewTownSettings() to initialize RoleAgents map

  internal/config/loader.go
  - Added ResolveRoleAgentConfig(role, townRoot, rigPath) - resolves agent config for a role
  - Added ResolveRoleAgentName(role, townRoot, rigPath) - returns agent name and whether role-specific
  - Resolution order: rig's RoleAgents → town's RoleAgents → default agent

  internal/daemon/lifecycle.go
  - Modified getStartCommand() to use ResolveRoleAgentConfig() for role-based agent selection

  internal/config/loader_test.go
  - Added TestResolveRoleAgentConfig
  - Added TestResolveRoleAgentName
  - Added TestRoleAgentsRoundTripzation

  ---

## Testing
- [x] Unit tests pass (`go test ./...`)
- [ ] Manual testing performed

## Checklist
- [ ] Code follows project style
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or documented in summary)
