### PR TITLE
fix(prime): add boot role detection for proper context injection

### DIFF
--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -29,6 +29,7 @@ type Role string
 const (
 	RoleMayor    Role = "mayor"
 	RoleDeacon   Role = "deacon"
+	RoleBoot     Role = "boot"
 	RoleWitness  Role = "witness"
 	RoleRefinery Role = "refinery"
 	RolePolecat  Role = "polecat"
@@ -276,6 +277,13 @@ func detectRole(cwd, townRoot string) RoleInfo {
 		return ctx
 	}
 
+	// Check for boot role: deacon/dogs/boot/
+	// Must check before deacon since boot is under deacon directory
+	if len(parts) >= 3 && parts[0] == "deacon" && parts[1] == "dogs" && parts[2] == "boot" {
+		ctx.Role = RoleBoot
+		return ctx
+	}
+
 	// Check for deacon role: deacon/
 	if len(parts) >= 1 && parts[0] == "deacon" {
 		ctx.Role = RoleDeacon
@@ -496,6 +504,8 @@ func buildRoleAnnouncement(ctx RoleContext) string {
 		return "Mayor, checking in."
 	case RoleDeacon:
 		return "Deacon, checking in."
+	case RoleBoot:
+		return "Boot, checking in."
 	case RoleWitness:
 		return fmt.Sprintf("%s Witness, checking in.", ctx.Rig)
 	case RoleRefinery:
@@ -530,6 +540,8 @@ func getAgentIdentity(ctx RoleContext) string {
 		return "mayor"
 	case RoleDeacon:
 		return "deacon"
+	case RoleBoot:
+		return "boot"
 	case RoleWitness:
 		return fmt.Sprintf("%s/witness", ctx.Rig)
 	case RoleRefinery:
@@ -598,6 +610,9 @@ func getAgentBeadID(ctx RoleContext) string {
 	case RoleMayor:
 		return beads.MayorBeadIDTown()
 	case RoleDeacon:
+		return beads.DeaconBeadIDTown()
+	case RoleBoot:
+		// Boot uses deacon's bead since it's a deacon subprocess
 		return beads.DeaconBeadIDTown()
 	case RoleWitness:
 		if ctx.Rig != "" {


### PR DESCRIPTION
## Summary

Boot sessions were incorrectly detected as `deacon` role because the deacon path check matched first. This caused Boot to receive Deacon's context instead of Boot-specific context from `boot.md.tmpl`.

## Changes

- Add `RoleBoot` constant to role enum
- Add boot path detection (`deacon/dogs/boot/`) before deacon check in `detectRole()`
- Add `case RoleBoot:` in `buildRoleAnnouncement()` 
- Add `case RoleBoot:` in `getAgentIdentity()` (returns "boot")
- Add `case RoleBoot:` in `getAgentBeadID()` (uses deacon's bead as subprocess)

The `boot.md.tmpl` template already exists and will now be correctly selected.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/cmd/...` passes
- [x] `go test -race ./internal/cmd/...` passes
- [x] `golangci-lint` passes

Fixes #318