### PR TITLE
fix(handoff): recognize polecat session pattern gt-<rig>-<name>

### DIFF
--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -444,7 +444,16 @@ func sessionWorkDir(sessionName, townRoot string) (string, error) {
 		return fmt.Sprintf("%s/%s/refinery/rig", townRoot, rig), nil
 
 	default:
-		return "", fmt.Errorf("unknown session type: %s (try specifying role explicitly)", sessionName)
+		// Assume polecat: gt-<rig>-<name> -> <townRoot>/<rig>/polecats/<name>
+		// Use session.ParseSessionName to determine rig and name
+		identity, err := session.ParseSessionName(sessionName)
+		if err != nil {
+			return "", fmt.Errorf("unknown session type: %s (%w)", sessionName, err)
+		}
+		if identity.Role != session.RolePolecat {
+			return "", fmt.Errorf("unknown session type: %s (role %s, try specifying role explicitly)", sessionName, identity.Role)
+		}
+		return fmt.Sprintf("%s/%s/polecats/%s", townRoot, identity.Rig, identity.Name), nil
 	}
 }
 


### PR DESCRIPTION
## Summary
- Fix `gt handoff` failing with "unknown session type" for polecat sessions
- `sessionWorkDir()` now handles polecat pattern `gt-<rig>-<name>` by using `session.ParseSessionName`

## Problem
When running `gt handoff` from a polecat session like `gt-tanwa_info-slit`, it failed with:
```
Error: unknown session type: gt-tanwa_info-slit (try specifying role explicitly)
```

## Root Cause
`sessionWorkDir()` in `internal/cmd/handoff.go` had explicit cases for mayor, deacon, crew, witness, and refinery sessions, but polecats fell through to the catch-all error case.

## Fix
Added a default case that uses `session.ParseSessionName()` to parse polecat session names and map them to `<townRoot>/<rig>/polecats/<name>`.

## Test plan
- [x] `gt handoff --dry-run` from polecat directory shows correct workdir
- [x] All existing session identity tests pass
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)