### PR TITLE
fix(costs): query all beads locations for session events

### DIFF
--- a/internal/cmd/costs_workdir_test.go
+++ b/internal/cmd/costs_workdir_test.go
@@ -188,10 +188,7 @@ func TestQuerySessionEvents_FindsEventsFromAllLocations(t *testing.T) {
 	}
 
 	// Call querySessionEvents - this should find events from ALL locations
-	entries, err := querySessionEvents()
-	if err != nil {
-		t.Fatalf("querySessionEvents failed: %v", err)
-	}
+	entries := querySessionEvents()
 
 	t.Logf("querySessionEvents returned %d entries", len(entries))
 


### PR DESCRIPTION
## Summary

Fix `gt costs` to find session.ended events from all beads databases (town-level and rig-level).

Previously, `querySessionEvents()` used the process's current working directory to find the beads database. This meant it only queried whichever single beads database `bd` discovered from cwd - missing events stored in other locations. Session cost events are created by different agents in different beads databases:
- Town-level agents (mayor, deacon) → town's `.beads`
- Rig-level agents (polecats, witness, refinery, crew) → each rig's `.beads`

## Related Issue

N/A - Bug discovered during costs workDir fix investigation.

## Changes

- Add `querySessionEventsFromLocation()` helper to query a single beads location
- Update `querySessionEvents()` to:
  - Discover town root using `workspace.FindFromCwdOrError()`
  - Load rigs from `mayor/rigs.json`
  - Query town-level beads AND each rig's beads location
  - Merge and deduplicate results by session ID + timestamp
- Add comprehensive integration test that:
  - Creates a town with a rig (separate beads DBs)
  - Creates session.ended events in both locations
  - Verifies `querySessionEvents()` finds events from all locations

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed
- [x] New integration test `TestQuerySessionEvents_FindsEventsFromAllLocations` covers the fix

Test output confirms fix works:
```
Town beads has 1 events
Rig beads has 1 events
querySessionEvents returned 2 entries
  Entry: session=hq-mayor role=mayor cost=$1.50
  Entry: session=gt-testrig-toast role=polecat cost=$2.50
--- PASS: TestQuerySessionEvents_FindsEventsFromAllLocations
```

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)