### PR TITLE
fix(doctor): filter bd "Note:" messages from custom types check

### DIFF
--- a/internal/doctor/config_check.go
+++ b/internal/doctor/config_check.go
@@ -602,14 +602,7 @@ func (c *CustomTypesCheck) Run(ctx *CheckContext) *CheckResult {
 	}
 
 	// Parse configured types, filtering out bd "Note:" messages that may appear in stdout
-	var configuredTypes string
-	for _, line := range strings.Split(string(output), "\n") {
-		line = strings.TrimSpace(line)
-		if line != "" && !strings.HasPrefix(line, "Note:") {
-			configuredTypes = line
-			break
-		}
-	}
+	configuredTypes := parseConfigOutput(output)
 	configuredSet := make(map[string]bool)
 	for _, t := range strings.Split(configuredTypes, ",") {
 		configuredSet[strings.TrimSpace(t)] = true
@@ -646,6 +639,18 @@ func (c *CustomTypesCheck) Run(ctx *CheckContext) *CheckResult {
 		},
 		FixHint: "Run 'gt doctor --fix' to register missing types",
 	}
+}
+
+// parseConfigOutput extracts the config value from bd output, filtering out
+// informational messages like "Note: ..." that bd may emit to stdout.
+func parseConfigOutput(output []byte) string {
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" && !strings.HasPrefix(line, "Note:") {
+			return line
+		}
+	}
+	return ""
 }
 
 // Fix registers the missing custom types.


### PR DESCRIPTION
## Summary

Fix false warning in `gt doctor` where the `beads-custom-types` check incorrectly reports missing custom types when `bd` outputs informational "Note:" messages to stdout.

When running `gt install` on a fresh installation, users would see:
```
Warning: beads-custom-types 1 custom type(s) missing...
```

This occurred because `bd config get types.custom` can output messages like `Note: No git repository initialized - running without background sync` before the actual config value, and the check was treating the "Note:" line as the config value.

## Related Issue

N/A - discovered during fresh install testing

## Changes

- Extract `parseConfigOutput` helper function to filter bd output
- Filter lines starting with "Note:" from bd config output
- Use `cmd.Output()` instead of `cmd.CombinedOutput()` to avoid stderr contamination
- Add comprehensive unit tests for the parsing logic:
  - `TestParseConfigOutput` - table-driven tests covering 7 cases
  - `TestCustomTypesCheck_ParsesOutputWithNotePrefix` - integration test for the full scenario

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed
- [x] Verified tests fail without the fix and pass with it

```bash
# Run the new tests
go test -v ./internal/doctor/... -run "TestParseConfigOutput|TestCustomTypesCheck_ParsesOutput"
```

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)