### PR TITLE
fix(sling): pass both feature and issue vars in formula-on-bead mode

### DIFF
--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -371,7 +371,7 @@ func runSling(cmd *cobra.Command, args []string) error {
 		if formulaName != "" {
 			fmt.Printf("Would instantiate formula %s:\n", formulaName)
 			fmt.Printf("  1. bd cook %s\n", formulaName)
-			fmt.Printf("  2. bd mol wisp %s --var feature=\"%s\"\n", formulaName, info.Title)
+			fmt.Printf("  2. bd mol wisp %s --var feature=\"%s\" --var issue=\"%s\"\n", formulaName, info.Title, beadID)
 			fmt.Printf("  3. bd mol bond <wisp-root> %s\n", beadID)
 			fmt.Printf("  4. bd update <compound-root> --status=hooked --assignee=%s\n", targetAgent)
 		} else {
@@ -407,9 +407,10 @@ func runSling(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("cooking formula %s: %w", formulaName, err)
 		}
 
-		// Step 2: Create wisp with feature variable from bead title
+		// Step 2: Create wisp with feature and issue variables from bead
 		featureVar := fmt.Sprintf("feature=%s", info.Title)
-		wispArgs := []string{"--no-daemon", "mol", "wisp", formulaName, "--var", featureVar, "--json"}
+		issueVar := fmt.Sprintf("issue=%s", beadID)
+		wispArgs := []string{"--no-daemon", "mol", "wisp", formulaName, "--var", featureVar, "--var", issueVar, "--json"}
 		wispCmd := exec.Command("bd", wispArgs...)
 		wispCmd.Dir = formulaWorkDir
 		wispCmd.Stderr = os.Stderr


### PR DESCRIPTION
## Summary

When using `gt sling <formula> --on <bead>`, the code was only passing the `feature` variable (set to bead title) to `bd mol wisp`. This broke formulas that expect the `issue` variable (set to bead ID), like `mol-polecat-work`.

Now passes both common variables:
- `feature`: bead title (for shiny-style formulas)
- `issue`: bead ID (for mol-polecat-work-style formulas)

## Related Issue

Fixes #355

## Changes

- Pass `--var issue=<beadID>` in addition to `--var feature=<title>` when creating wisps in formula-on-bead mode
- Update dry-run output to show both variables for consistency
- Add unit test `TestSlingFormulaOnBeadPassesFeatureAndIssueVars` to verify both variables are passed

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed

### Test output
```
=== RUN   TestSlingFormulaOnBeadPassesFeatureAndIssueVars
--- PASS: TestSlingFormulaOnBeadPassesFeatureAndIssueVars (0.01s)
```

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)