### PR TITLE
fix(install): add gt:role label to role beads during creation

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -126,6 +126,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewBootHealthCheck())
 	d.Register(doctor.NewBeadsDatabaseCheck())
 	d.Register(doctor.NewCustomTypesCheck())
+	d.Register(doctor.NewRoleLabelCheck())
 	d.Register(doctor.NewFormulaCheck())
 	d.Register(doctor.NewBdDaemonCheck())
 	d.Register(doctor.NewPrefixConflictCheck())

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -492,18 +492,18 @@ func initTownAgentBeads(townPath string) error {
 			continue // Already exists
 		}
 
-		// Create role bead using bd create --type=role
-		cmd := exec.Command("bd", "create",
-			"--type=role",
-			"--id="+role.id,
-			"--title="+role.title,
-			"--description="+role.desc,
-		)
-		cmd.Dir = townPath
-		if output, err := cmd.CombinedOutput(); err != nil {
+		// Create role bead using the beads API
+		// CreateWithID with Type: "role" automatically adds gt:role label
+		_, err := bd.CreateWithID(role.id, beads.CreateOptions{
+			Title:       role.title,
+			Type:        "role",
+			Description: role.desc,
+			Priority:    -1, // No priority
+		})
+		if err != nil {
 			// Log but continue - role beads are optional
-			fmt.Printf("   %s Could not create role bead %s: %s\n",
-				style.Dim.Render("⚠"), role.id, strings.TrimSpace(string(output)))
+			fmt.Printf("   %s Could not create role bead %s: %v\n",
+				style.Dim.Render("⚠"), role.id, err)
 			continue
 		}
 		fmt.Printf("   ✓ Created role bead: %s\n", role.id)

--- a/internal/doctor/beads_check_test.go
+++ b/internal/doctor/beads_check_test.go
@@ -4,6 +4,8 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 func TestNewBeadsDatabaseCheck(t *testing.T) {
@@ -313,5 +315,295 @@ func TestPrefixMismatchCheck_Fix(t *testing.T) {
 	}
 	if cfg.Rigs["gastown"].BeadsConfig.Prefix != "gt" {
 		t.Errorf("expected prefix 'gt' after fix, got %q", cfg.Rigs["gastown"].BeadsConfig.Prefix)
+	}
+}
+
+func TestNewRoleLabelCheck(t *testing.T) {
+	check := NewRoleLabelCheck()
+
+	if check.Name() != "role-bead-labels" {
+		t.Errorf("expected name 'role-bead-labels', got %q", check.Name())
+	}
+
+	if !check.CanFix() {
+		t.Error("expected CanFix to return true")
+	}
+}
+
+func TestRoleLabelCheck_NoBeadsDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	check := NewRoleLabelCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when no .beads dir, got %v", result.Status)
+	}
+	if result.Message != "No beads database (skipped)" {
+		t.Errorf("unexpected message: %s", result.Message)
+	}
+}
+
+// mockBeadShower implements beadShower for testing
+type mockBeadShower struct {
+	beads map[string]*beads.Issue
+}
+
+func (m *mockBeadShower) Show(id string) (*beads.Issue, error) {
+	if issue, ok := m.beads[id]; ok {
+		return issue, nil
+	}
+	return nil, beads.ErrNotFound
+}
+
+// mockLabelAdder implements labelAdder for testing
+type mockLabelAdder struct {
+	calls []labelAddCall
+}
+
+type labelAddCall struct {
+	townRoot string
+	id       string
+	label    string
+}
+
+func (m *mockLabelAdder) AddLabel(townRoot, id, label string) error {
+	m.calls = append(m.calls, labelAddCall{townRoot, id, label})
+	return nil
+}
+
+func TestRoleLabelCheck_AllBeadsHaveLabel(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create mock with all role beads having gt:role label
+	mock := &mockBeadShower{
+		beads: map[string]*beads.Issue{
+			"hq-mayor-role":    {ID: "hq-mayor-role", Labels: []string{"gt:role"}},
+			"hq-deacon-role":   {ID: "hq-deacon-role", Labels: []string{"gt:role"}},
+			"hq-dog-role":      {ID: "hq-dog-role", Labels: []string{"gt:role"}},
+			"hq-witness-role":  {ID: "hq-witness-role", Labels: []string{"gt:role"}},
+			"hq-refinery-role": {ID: "hq-refinery-role", Labels: []string{"gt:role"}},
+			"hq-polecat-role":  {ID: "hq-polecat-role", Labels: []string{"gt:role"}},
+			"hq-crew-role":     {ID: "hq-crew-role", Labels: []string{"gt:role"}},
+		},
+	}
+
+	check := NewRoleLabelCheck()
+	check.beadShower = mock
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when all beads have label, got %v: %s", result.Status, result.Message)
+	}
+	if result.Message != "All role beads have gt:role label" {
+		t.Errorf("unexpected message: %s", result.Message)
+	}
+}
+
+func TestRoleLabelCheck_MissingLabel(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create mock with witness-role missing the gt:role label (the regression case)
+	mock := &mockBeadShower{
+		beads: map[string]*beads.Issue{
+			"hq-mayor-role":    {ID: "hq-mayor-role", Labels: []string{"gt:role"}},
+			"hq-deacon-role":   {ID: "hq-deacon-role", Labels: []string{"gt:role"}},
+			"hq-dog-role":      {ID: "hq-dog-role", Labels: []string{"gt:role"}},
+			"hq-witness-role":  {ID: "hq-witness-role", Labels: []string{}}, // Missing gt:role!
+			"hq-refinery-role": {ID: "hq-refinery-role", Labels: []string{"gt:role"}},
+			"hq-polecat-role":  {ID: "hq-polecat-role", Labels: []string{"gt:role"}},
+			"hq-crew-role":     {ID: "hq-crew-role", Labels: []string{"gt:role"}},
+		},
+	}
+
+	check := NewRoleLabelCheck()
+	check.beadShower = mock
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning when label missing, got %v", result.Status)
+	}
+	if result.Message != "1 role bead(s) missing gt:role label" {
+		t.Errorf("unexpected message: %s", result.Message)
+	}
+	if len(result.Details) != 1 || result.Details[0] != "hq-witness-role" {
+		t.Errorf("expected details to contain hq-witness-role, got %v", result.Details)
+	}
+}
+
+func TestRoleLabelCheck_MultipleMissingLabels(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create mock with multiple beads missing the gt:role label
+	mock := &mockBeadShower{
+		beads: map[string]*beads.Issue{
+			"hq-mayor-role":    {ID: "hq-mayor-role", Labels: []string{}},    // Missing
+			"hq-deacon-role":   {ID: "hq-deacon-role", Labels: []string{}},   // Missing
+			"hq-dog-role":      {ID: "hq-dog-role", Labels: []string{"gt:role"}},
+			"hq-witness-role":  {ID: "hq-witness-role", Labels: []string{}},  // Missing
+			"hq-refinery-role": {ID: "hq-refinery-role", Labels: []string{}}, // Missing
+			"hq-polecat-role":  {ID: "hq-polecat-role", Labels: []string{"gt:role"}},
+			"hq-crew-role":     {ID: "hq-crew-role", Labels: []string{"gt:role"}},
+		},
+	}
+
+	check := NewRoleLabelCheck()
+	check.beadShower = mock
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning, got %v", result.Status)
+	}
+	if result.Message != "4 role bead(s) missing gt:role label" {
+		t.Errorf("unexpected message: %s", result.Message)
+	}
+	if len(result.Details) != 4 {
+		t.Errorf("expected 4 details, got %d: %v", len(result.Details), result.Details)
+	}
+}
+
+func TestRoleLabelCheck_BeadNotFound(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create mock with only some beads existing (others return ErrNotFound)
+	mock := &mockBeadShower{
+		beads: map[string]*beads.Issue{
+			"hq-mayor-role":  {ID: "hq-mayor-role", Labels: []string{"gt:role"}},
+			"hq-deacon-role": {ID: "hq-deacon-role", Labels: []string{"gt:role"}},
+			// Other beads don't exist - should be skipped, not reported as errors
+		},
+	}
+
+	check := NewRoleLabelCheck()
+	check.beadShower = mock
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	// Should be OK - missing beads are not an error (install will create them)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when beads don't exist, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestRoleLabelCheck_Fix(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create mock with witness-role missing the label
+	mockShower := &mockBeadShower{
+		beads: map[string]*beads.Issue{
+			"hq-mayor-role":   {ID: "hq-mayor-role", Labels: []string{"gt:role"}},
+			"hq-witness-role": {ID: "hq-witness-role", Labels: []string{}}, // Missing gt:role
+		},
+	}
+	mockAdder := &mockLabelAdder{}
+
+	check := NewRoleLabelCheck()
+	check.beadShower = mockShower
+	check.labelAdder = mockAdder
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	// First run to detect the issue
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning, got %v", result.Status)
+	}
+
+	// Now fix
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix() failed: %v", err)
+	}
+
+	// Verify the correct bd label add command was called
+	if len(mockAdder.calls) != 1 {
+		t.Fatalf("expected 1 AddLabel call, got %d", len(mockAdder.calls))
+	}
+	call := mockAdder.calls[0]
+	if call.townRoot != tmpDir {
+		t.Errorf("expected townRoot %q, got %q", tmpDir, call.townRoot)
+	}
+	if call.id != "hq-witness-role" {
+		t.Errorf("expected id 'hq-witness-role', got %q", call.id)
+	}
+	if call.label != "gt:role" {
+		t.Errorf("expected label 'gt:role', got %q", call.label)
+	}
+}
+
+func TestRoleLabelCheck_FixMultiple(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create mock with multiple beads missing the label
+	mockShower := &mockBeadShower{
+		beads: map[string]*beads.Issue{
+			"hq-mayor-role":    {ID: "hq-mayor-role", Labels: []string{}},    // Missing
+			"hq-deacon-role":   {ID: "hq-deacon-role", Labels: []string{"gt:role"}},
+			"hq-witness-role":  {ID: "hq-witness-role", Labels: []string{}},  // Missing
+			"hq-refinery-role": {ID: "hq-refinery-role", Labels: []string{}}, // Missing
+		},
+	}
+	mockAdder := &mockLabelAdder{}
+
+	check := NewRoleLabelCheck()
+	check.beadShower = mockShower
+	check.labelAdder = mockAdder
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	// First run to detect the issues
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning, got %v", result.Status)
+	}
+	if len(result.Details) != 3 {
+		t.Fatalf("expected 3 missing, got %d", len(result.Details))
+	}
+
+	// Now fix
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix() failed: %v", err)
+	}
+
+	// Verify all 3 beads got the label added
+	if len(mockAdder.calls) != 3 {
+		t.Fatalf("expected 3 AddLabel calls, got %d", len(mockAdder.calls))
+	}
+
+	// Verify each call has the correct label
+	for _, call := range mockAdder.calls {
+		if call.label != "gt:role" {
+			t.Errorf("expected label 'gt:role', got %q", call.label)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Fix witness startup failure caused by role beads missing the `gt:role` label. After a fresh install, `gt up` would fail with:
```
loading witness role config: bead hq-witness-role is not a role bead (missing gt:role label)
```

## Related Issue

Regression introduced in commit 96970071 ("feat(beads): migrate from types to labels for bead classification")

## Changes

- Use `bd.CreateWithID()` API in `install.go` instead of raw `exec.Command`
  - The API automatically converts `Type: "role"` to `--labels=gt:role`
- Add `RoleLabelCheck` doctor check to detect and fix existing installations
  - Checks all 7 role beads: mayor, deacon, dog, witness, refinery, polecat, crew
  - Fixable with `gt doctor --fix` which runs `bd label add <id> gt:role`
- Add comprehensive unit tests with mocked `beadShower` and `labelAdder` interfaces

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed
- [x] Tests verify:
  - Detection of missing `gt:role` label on role beads
  - Correct `bd label add` command called during fix
  - Graceful handling of non-existent beads

```bash
# Run the new tests
go test -v ./internal/doctor/... -run "RoleLabel"
```

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)