### PR TITLE
fix(git): fetch origin after configuring refspec for bare clones

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -194,6 +194,12 @@ func configureRefspec(repoPath string) error {
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("configuring refspec: %s", strings.TrimSpace(stderr.String()))
 	}
+	// Fetch to populate refs/remotes/origin/* so worktrees can use origin/main
+	fetchCmd := exec.Command("git", "-C", repoPath, "fetch", "origin")
+	fetchCmd.Stderr = &stderr
+	if err := fetchCmd.Run(); err != nil {
+		return fmt.Errorf("fetching origin: %s", strings.TrimSpace(stderr.String()))
+	}
 	return nil
 }
 

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -261,6 +261,12 @@ func (m *Manager) AddWithOptions(name string, opts AddOptions) (*Polecat, error)
 		return nil, fmt.Errorf("finding repo base: %w", err)
 	}
 
+	// Fetch latest from origin to ensure worktree starts from up-to-date code
+	if err := repoGit.Fetch("origin"); err != nil {
+		// Non-fatal - proceed with potentially stale code
+		fmt.Printf("Warning: could not fetch origin: %v\n", err)
+	}
+
 	// Determine the start point for the new worktree
 	// Use origin/<default-branch> to ensure we start from the rig's configured branch
 	defaultBranch := "main"


### PR DESCRIPTION
## Summary

Bare clones don't have `refs/remotes/origin/*` populated by default. The `configureRefspec` fix (a91e6cd6) set up the fetch config but didn't actually run a fetch, leaving `origin/main` unavailable.

This caused polecat worktree creation to fail with:
```
fatal: invalid reference: origin/main
```

## Related Issue

Related: #286

## Changes

- Add `git fetch origin` after configuring refspec in `CloneBare()` to populate remote refs
- Add `git fetch origin` before polecat worktree creation in `AddWithOptions()` to ensure latest code
- Add `TestCloneBareHasOriginRefs` integration test that verifies:
  - `origin/main` exists after `CloneBare()`
  - `WorktreeAddFromRef("origin/main")` succeeds

The second fix (fetch before worktree) matches `RepairWorktreeWithOptions` which already had a fetch.

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed
- [x] Test fails without fix, passes with fix

### Test output without fix:
```
=== RUN   TestCloneBareHasOriginRefs
    git_test.go:466: expected "origin/main" in remote branches, got:
    git_test.go:473: WorktreeAddFromRef("origin/main") failed: git worktree: fatal: invalid reference: origin/main
--- FAIL: TestCloneBareHasOriginRefs (0.36s)
```

### Test output with fix:
```
=== RUN   TestCloneBareHasOriginRefs
--- PASS: TestCloneBareHasOriginRefs (0.36s)
```

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)

## Additional Context

The root cause was a gap between two fixes:
- **Jan 8** (`a91e6cd6`): Added `configureRefspec` - sets up config but no fetch
- **Jan 11** (`6e01ecfc`): Changed polecats to use `origin/branch` - assumes `origin/*` refs exist

Users didn't hit this often because:
1. Most don't immediately sling after `gt rig add`
2. Any other git operation would trigger a fetch
3. `RepairWorktreeWithOptions` (respawn) already had a fetch