### PR TITLE
fix: spawn polecats from rig's configured default_branch

### DIFF
--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -315,6 +315,13 @@ func TestAddWithOptions_HasAgentsMD(t *testing.T) {
 		t.Fatalf("git commit: %v", err)
 	}
 
+	// Rename branch to main (git init may create master by default)
+	cmd = exec.Command("git", "branch", "-m", "main")
+	cmd.Dir = mayorRig
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git branch -m main: %v\n%s", err, out)
+	}
+
 	// AddWithOptions needs origin/main to exist. Add self as origin and fetch.
 	cmd = exec.Command("git", "remote", "add", "origin", mayorRig)
 	cmd.Dir = mayorRig
@@ -384,6 +391,13 @@ func TestAddWithOptions_AgentsMDFallback(t *testing.T) {
 	}
 	if err := mayorGit.Commit("Initial commit"); err != nil {
 		t.Fatalf("git commit: %v", err)
+	}
+
+	// Rename branch to main (git init may create master by default)
+	cmd = exec.Command("git", "branch", "-m", "main")
+	cmd.Dir = mayorRig
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git branch -m main: %v\n%s", err, out)
 	}
 
 	// AddWithOptions needs origin/main to exist. Add self as origin and fetch.


### PR DESCRIPTION
## Problem

When `gt sling` spawns a new polecat, `AddWithOptions()` uses inline branch resolution. This PR adds a centralized `resolveDefaultBranch()` helper for consistency across all branch resolution points.

## Changes

1. **Add `resolveDefaultBranch()` helper** - Centralizes the pattern used in `AddWithOptions()`, `RepairWorktreeWithOptions()`, and `DetectStalePolecats()`

2. **Use helper in all three functions** - DRY principle, single source of truth for default branch resolution

3. **Fix test setup** - Added `git branch -m main` after `git init` in tests to ensure `origin/main` exists (git may default to `master` depending on configuration)

## Testing

```bash
go build ./...     # ✅ Passes
go test ./internal/polecat/...   # ✅ Passes (with test fix)
```

## Context

This is a refactoring to improve maintainability. The helper consolidates the default branch lookup pattern that was duplicated across multiple functions.