### PR TITLE
fix(done): respect cleanup_status in selfNukePolecat

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -550,9 +550,10 @@ func selfNukePolecat(roleInfo RoleInfo, _ string) error {
 		return fmt.Errorf("getting polecat manager: %w", err)
 	}
 
-	// Use nuclear=true since we know we just pushed our work
-	// The branch is pushed, MR is created, we're clean
-	if err := mgr.RemoveWithOptions(roleInfo.Polecat, true, true); err != nil {
+	// Use nuclear=false to respect cleanup_status safety checks (ZFC #10)
+	// The agent's self-reported cleanup_status will be validated before removal
+	// This prevents accidental work loss if git state doesn't match expectations
+	if err := mgr.RemoveWithOptions(roleInfo.Polecat, true, false); err != nil {
 		return fmt.Errorf("removing worktree: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
When polecats self-destruct via `gt done`, they were using `nuclear=true` which bypasses all safety checks including cleanup_status validation. This caused work loss when polecats called `gt done` prematurely (e.g., before CI passed).

## Changes
- Changed `nuclear=true` to `nuclear=false` in `selfNukePolecat()`
- Polecats now validate their cleanup_status before removal
- Prevents accidental destruction with uncommitted or unpushed work

## Test Plan
- [x] Build passes
- [ ] Manual test: polecat with uncommitted changes should not be removed on `gt done`

Fixes #360