### PR TITLE
feat(synthesis): record output location metadata on completed leg beads

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -1115,11 +1115,12 @@ func getTrackedIssues(townBeads, convoyID string) []trackedIssueInfo {
 
 // issueDetails holds basic issue info.
 type issueDetails struct {
-	ID        string
-	Title     string
-	Status    string
-	IssueType string
-	Assignee  string
+	ID          string
+	Title       string
+	Status      string
+	IssueType   string
+	Assignee    string
+	Description string
 }
 
 // getIssueDetailsBatch fetches details for multiple issues in a single bd show call.
@@ -1151,11 +1152,12 @@ func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 	}
 
 	var issues []struct {
-		ID        string `json:"id"`
-		Title     string `json:"title"`
-		Status    string `json:"status"`
-		IssueType string `json:"issue_type"`
-		Assignee  string `json:"assignee"`
+		ID          string `json:"id"`
+		Title       string `json:"title"`
+		Status      string `json:"status"`
+		IssueType   string `json:"issue_type"`
+		Assignee    string `json:"assignee"`
+		Description string `json:"description"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil {
 		return result
@@ -1163,11 +1165,12 @@ func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 
 	for _, issue := range issues {
 		result[issue.ID] = &issueDetails{
-			ID:        issue.ID,
-			Title:     issue.Title,
-			Status:    issue.Status,
-			IssueType: issue.IssueType,
-			Assignee:  issue.Assignee,
+			ID:          issue.ID,
+			Title:       issue.Title,
+			Status:      issue.Status,
+			IssueType:   issue.IssueType,
+			Assignee:    issue.Assignee,
+			Description: issue.Description,
 		}
 	}
 
@@ -1192,22 +1195,24 @@ func getIssueDetails(issueID string) *issueDetails {
 	}
 
 	var issues []struct {
-		ID        string `json:"id"`
-		Title     string `json:"title"`
-		Status    string `json:"status"`
-		IssueType string `json:"issue_type"`
-		Assignee  string `json:"assignee"`
+		ID          string `json:"id"`
+		Title       string `json:"title"`
+		Status      string `json:"status"`
+		IssueType   string `json:"issue_type"`
+		Assignee    string `json:"assignee"`
+		Description string `json:"description"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil || len(issues) == 0 {
 		return nil
 	}
 
 	return &issueDetails{
-		ID:        issues[0].ID,
-		Title:     issues[0].Title,
-		Status:    issues[0].Status,
-		IssueType: issues[0].IssueType,
-		Assignee:  issues[0].Assignee,
+		ID:          issues[0].ID,
+		Title:       issues[0].Title,
+		Status:      issues[0].Status,
+		IssueType:   issues[0].IssueType,
+		Assignee:    issues[0].Assignee,
+		Description: issues[0].Description,
 	}
 }
 


### PR DESCRIPTION
## Summary
When convoy leg beads complete, they now record `output_path` metadata so synthesis workflows can discover and aggregate outputs without hunting through worktrees or guessing branch names.

## Changes
- `formula.go`: parse output section, include output_path in leg descriptions
- `convoy.go`: add Description field to issueDetails for metadata parsing
- `synthesis.go`: parse output_path from leg descriptions with template fallback

## Test Plan
- [x] Build passes
- [ ] Manual test: complete a convoy leg and verify output_path is recorded in bead

Fixes #303