### PR TITLE
docs(readme): add Discord server link

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,10 @@ Git-backed issue tracking system that stores work state as structured data.
 
 > **New to Gas Town?** See the [Glossary](docs/glossary.md) for a complete guide to terminology and concepts.
 
+## Community
+
+Join the [Gas Town Discord server](https://discord.gg/ZbEFb2Yg) for real-time discussion, troubleshooting, and collaboration with other Gas Town users.
+
 ## Installation
 
 ### Prerequisites


### PR DESCRIPTION
## Summary
Add link to community Discord server for real-time support and discussion.

## Changes
- Add Community section to README with Discord invite link

Fixes #305