### PR TITLE
fix(polecat): improve lifecycle handling and prevent premature cleanup

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -378,6 +378,20 @@ func runDone(cmd *cobra.Command, args []string) error {
 	selfNukeAttempted := false
 	if exitType == ExitCompleted {
 		if roleInfo, err := GetRoleWithContext(cwd, townRoot); err == nil && roleInfo.Role == RolePolecat {
+			// CRITICAL: Push branch to origin before self-nuking
+			// The Refinery needs the branch to be accessible after the polecat's
+			// worktree is deleted. Without this push, the branch only exists locally
+			// in the polecat's worktree and will be lost when self-nuke removes it.
+			fmt.Printf("\nPushing branch to origin before self-nuke...\n")
+			if err := g.Push("origin", branch, false); err != nil {
+				// Push failure is fatal - we cannot self-nuke without pushing
+				// The work must be preserved for the Refinery to process
+				fmt.Fprintf(os.Stderr, "Error: failed to push branch to origin: %v\n", err)
+				fmt.Fprintf(os.Stderr, "Error: cannot self-nuke without pushing - worktree preserved for manual intervention\n")
+				return fmt.Errorf("push to origin failed (self-nuke aborted): %w", err)
+			}
+			fmt.Printf("%s Branch pushed to origin\n", style.Bold.Render("✓"))
+
 			selfNukeAttempted = true
 			if err := selfNukePolecat(roleInfo, townRoot); err != nil {
 				// Non-fatal: Witness will clean up if we fail
@@ -550,9 +564,10 @@ func selfNukePolecat(roleInfo RoleInfo, _ string) error {
 		return fmt.Errorf("getting polecat manager: %w", err)
 	}
 
-	// Use nuclear=true since we know we just pushed our work
-	// The branch is pushed, MR is created, we're clean
-	if err := mgr.RemoveWithOptions(roleInfo.Polecat, true, true); err != nil {
+	// Use nuclear=false to respect cleanup_status safety checks (ZFC #10)
+	// The agent's self-reported cleanup_status will be validated before removal
+	// This prevents accidental work loss if git state doesn't match expectations
+	if err := mgr.RemoveWithOptions(roleInfo.Polecat, true, false); err != nil {
 		return fmt.Errorf("removing worktree: %w", err)
 	}
 

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -785,8 +785,10 @@ func (m *Manager) ClearIssue(name string) error {
 	return nil
 }
 
-// loadFromBeads gets polecat info from beads assignee field.
-// State is simple: issue assigned → working, no issue → done (ready for cleanup).
+// loadFromBeads gets polecat info from beads assignee field and agent bead hook_bead.
+// State is determined by: has assigned issue OR has hook_bead → working, neither → done.
+// This fixes the bug where polecats with newly hooked work show as "done" because
+// the issue assignee hasn't been updated yet.
 // Transient polecats should always have work; no work means ready for Witness cleanup.
 // We don't interpret issue status (ZFC: Go is transport, not decision-maker).
 func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
@@ -824,6 +826,23 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 	if issue != nil {
 		issueID = issue.ID
 		state = StateWorking
+	}
+
+	// FIX (hq-50u3h): Also check agent bead's hook_bead field.
+	// If hook_bead is set, the polecat has work waiting and should be "working".
+	// This prevents polecats from showing as "done" when new work is hooked via gt sling.
+	// gt sling sets hook_bead atomically, so this is the reliable signal for pending work.
+	agentBeadID := m.agentBeadID(name)
+	if _, fields, err := m.beads.GetAgentBead(agentBeadID); err == nil && fields != nil {
+		if fields.HookBead != "" {
+			// Polecat has hooked work - should be working, not done
+			state = StateWorking
+			// If issueID is empty, use the hook_bead as the issue reference
+			// This ensures the hooked work is visible in listings
+			if issueID == "" {
+				issueID = fields.HookBead
+			}
+		}
 	}
 
 	return &Polecat{

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -11,6 +11,7 @@ import (
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/mail"
+	"github.com/steveyegge/gastown/internal/polecat"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/util"
@@ -810,4 +811,154 @@ func verifyCommitOnMain(workDir, rigName, polecatName string) (bool, error) {
 
 	// Commit is not on any remote's default branch
 	return false, nil
+}
+
+// PolecatsWithHookedWork contains info about polecats that have hooked work but no active session.
+type PolecatsWithHookedWork struct {
+	PolecatName string
+	HookBead    string
+	RigName     string
+}
+
+// FindPolecatsWithHookedWork finds polecats that have hooked work but no active tmux session.
+// These are polecats that completed work (gt done) but then had new work slung to them via gt sling.
+// They need to be respawned to process the hooked work.
+// Returns a list of such polecats that should be respawned.
+//
+// FIX (hq-50u3h): This function addresses the bug where done polecats don't process hooked work.
+// The fix checks each polecat's agent bead for hook_bead and verifies no active tmux session.
+func FindPolecatsWithHookedWork(workDir, rigName string) ([]*PolecatsWithHookedWork, error) {
+	townRoot, err := workspace.Find(workDir)
+	if err != nil || townRoot == "" {
+		return nil, fmt.Errorf("finding town root: %w", err)
+	}
+
+	// Get beads directory
+	rigPath := filepath.Join(townRoot, rigName)
+	bd := beads.New(rigPath)
+	t := tmux.NewTmux()
+
+	var result []*PolecatsWithHookedWork
+
+	// Get all polecat agent beads (returns map of bead ID to Issue)
+	agentBeads, err := bd.ListAgentBeads()
+	if err != nil {
+		return nil, fmt.Errorf("listing agent beads: %w", err)
+	}
+
+	// Filter for polecat agents in this rig
+	// Format: <prefix>-<rig>-polecat-<name>
+	polecatSuffix := fmt.Sprintf("%s-polecat-", rigName)
+	for agentID := range agentBeads {
+		// Check if this is a polecat agent bead for this rig
+		if !strings.Contains(agentID, polecatSuffix) {
+			continue
+		}
+
+		// Extract polecat name from agent ID
+		parts := strings.Split(agentID, "-polecat-")
+		if len(parts) < 2 {
+			continue
+		}
+		polecatName := parts[len(parts)-1]
+
+		// Get agent bead fields to check hook_bead
+		_, fields, err := bd.GetAgentBead(agentID)
+		if err != nil || fields == nil {
+			// Skip if we can't get agent bead info
+			continue
+		}
+
+		// Check if hook_bead is set (indicating work is waiting)
+		if fields.HookBead == "" {
+			continue
+		}
+
+		// Check if polecat has an active tmux session
+		sessionName := fmt.Sprintf("gt-%s-%s", rigName, polecatName)
+		hasSession, _ := t.HasSession(sessionName)
+
+		if hasSession {
+			// Session is active - polecat is already working
+			continue
+		}
+
+		// Polecat has hooked work but no active session - needs respawn
+		result = append(result, &PolecatsWithHookedWork{
+			PolecatName: polecatName,
+			HookBead:    fields.HookBead,
+			RigName:     rigName,
+		})
+	}
+
+	return result, nil
+}
+
+// RespawnPolecatWithHookedWork respawns a polecat to process its hooked work.
+// This is used when a polecat has completed work (gt done) but new work was slung to it.
+// The polecat's session is restarted to process the hooked work.
+//
+// FIX (hq-50u3h): This function respawns polecats with hooked work but no active session.
+func RespawnPolecatWithHookedWork(workDir, rigName, polecatName string) error {
+	townRoot, err := workspace.Find(workDir)
+	if err != nil || townRoot == "" {
+		return fmt.Errorf("finding town root: %w", err)
+	}
+
+	rigPath := filepath.Join(townRoot, rigName)
+	// Create rig struct directly (no LoadRig function exists)
+	r := &rig.Rig{
+		Name: rigName,
+		Path: rigPath,
+	}
+
+	// Get the polecat manager
+	g := git.NewGit(rigPath)
+	mgr := polecat.NewManager(r, g)
+
+	// Get the hook_bead from the agent bead
+	prefix := beads.GetPrefixForRig(townRoot, rigName)
+	agentBeadID := beads.PolecatBeadIDWithPrefix(prefix, rigName, polecatName)
+	bd := beads.New(rigPath)
+	_, fields, err := bd.GetAgentBead(agentBeadID)
+	if err != nil || fields == nil {
+		return fmt.Errorf("getting agent bead: %w", err)
+	}
+
+	if fields.HookBead == "" {
+		return fmt.Errorf("no hooked work found for polecat %s", polecatName)
+	}
+
+	// Check if polecat directory exists (using Get to check if polecat exists)
+	_, err = mgr.Get(polecatName)
+	if err != nil {
+		// Polecat doesn't exist - need to create it fresh
+		_, err := mgr.AddWithOptions(polecatName, polecat.AddOptions{
+			HookBead: fields.HookBead,
+		})
+		if err != nil {
+			return fmt.Errorf("creating polecat: %w", err)
+		}
+	} else {
+		// Polecat exists - repair it to get a fresh worktree
+		_, err := mgr.RepairWorktreeWithOptions(polecatName, true, polecat.AddOptions{
+			HookBead: fields.HookBead,
+		})
+		if err != nil {
+			return fmt.Errorf("repairing polecat worktree: %w", err)
+		}
+	}
+
+	// Start a new tmux session for the polecat
+	t := tmux.NewTmux()
+	sessionMgr := polecat.NewSessionManager(t, r)
+
+	err = sessionMgr.Start(polecatName, polecat.SessionStartOptions{
+		Issue: fields.HookBead,
+	})
+	if err != nil {
+		return fmt.Errorf("starting polecat session: %w", err)
+	}
+
+	return nil
 }


### PR DESCRIPTION
## Summary
Three related fixes for polecat lifecycle management that together address the full scope of #360.

## Changes

1. **Push branch to origin before self-nuke**
   - Ensures work is preserved on remote before worktree cleanup
   - Prevents orphaned local-only branches

2. **Respect cleanup_status in selfNukePolecat**
   - Changed `nuclear=true` to `nuclear=false`
   - Validates cleanup_status before removal
   - Prevents destruction with uncommitted/unpushed work

3. **Respawn done polecats with hooked work**
   - `loadFromBeads` now checks `hook_bead` field
   - Added `FindPolecatsWithHookedWork()` and `RespawnPolecatWithHookedWork()`
   - Witness can auto-respawn polecats that have pending work

## Test Plan
- [x] Build passes
- [ ] Polecat with uncommitted changes should not be removed on `gt done`
- [ ] Work slung to done polecat triggers respawn

Fixes #360