### PR TITLE
fix(boot): improve Boot and Deacon startup behavior

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -9,10 +9,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/templates"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
@@ -62,6 +64,27 @@ func New(townRoot string) *Boot {
 // EnsureDir ensures the Boot directory exists.
 func (b *Boot) EnsureDir() error {
 	return os.MkdirAll(b.bootDir, 0755)
+}
+
+// EnsureCLAUDEmd ensures Boot's CLAUDE.md exists with proper context.
+// Creates it from the boot role template if missing.
+func (b *Boot) EnsureCLAUDEmd() error {
+	claudePath := filepath.Join(b.bootDir, "CLAUDE.md")
+
+	// Check if CLAUDE.md already exists
+	if _, err := os.Stat(claudePath); err == nil {
+		// File exists, nothing to do
+		return nil
+	}
+
+	// Create CLAUDE.md from template
+	townName := filepath.Base(b.townRoot)
+	// Deacon session name is "hq-{townname}" or just "hq-deacon" for town root
+	deaconSession := "hq-deacon"
+	if townName != "" && strings.ToLower(townName) != "gt" {
+		deaconSession = fmt.Sprintf("hq-%s", strings.ToLower(townName))
+	}
+	return templates.CreateBootCLAUDEmd(b.bootDir, b.townRoot, townName, deaconSession)
 }
 
 // markerPath returns the path to the marker file.
@@ -168,6 +191,11 @@ func (b *Boot) spawnTmux() error {
 	// Ensure boot directory exists (it should have CLAUDE.md with Boot context)
 	if err := b.EnsureDir(); err != nil {
 		return fmt.Errorf("ensuring boot dir: %w", err)
+	}
+
+	// Ensure CLAUDE.md exists with proper Boot context
+	if err := b.EnsureCLAUDEmd(); err != nil {
+		return fmt.Errorf("ensuring boot CLAUDE.md: %w", err)
 	}
 
 	// Create new session in boot directory (not deacon dir) so Claude reads Boot's CLAUDE.md

--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -394,18 +394,21 @@ func startDeaconSession(t *tmux.Tmux, sessionName, agentOverride string) error {
 	runtimeConfig := config.LoadRuntimeConfig("")
 	_ = runtime.RunStartupFallback(t, sessionName, "deacon", runtimeConfig)
 
+	// GUPP: Gas Town Universal Propulsion Principle
+	// Directly execute gt prime to trigger autonomous patrol execution.
+	// This bypasses the prompt area - the command runs immediately.
+	// Wait for Claude to be ready before sending command.
+	time.Sleep(2 * time.Second)
+	_ = t.SendKeys(sessionName, "gt prime") // Non-fatal
+
 	// Inject startup nudge for predecessor discovery via /resume
+	// Send AFTER gt prime so the beacon appears in session history, not prompt area
+	time.Sleep(1 * time.Second)
 	_ = session.StartupNudge(t, sessionName, session.StartupNudgeConfig{
 		Recipient: "deacon",
 		Sender:    "daemon",
 		Topic:     "patrol",
 	}) // Non-fatal
-
-	// GUPP: Gas Town Universal Propulsion Principle
-	// Send the propulsion nudge to trigger autonomous patrol execution.
-	// Wait for beacon to be fully processed (needs to be separate prompt)
-	time.Sleep(2 * time.Second)
-	_ = t.NudgeSession(sessionName, session.PropulsionNudgeForRole("deacon", deaconDir)) // Non-fatal
 
 	return nil
 }

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -128,7 +128,7 @@ func (t *Templates) RenderMessage(name string, data interface{}) (string, error)
 
 // RoleNames returns the list of available role templates.
 func (t *Templates) RoleNames() []string {
-	return []string{"mayor", "witness", "refinery", "polecat", "crew", "deacon"}
+	return []string{"mayor", "witness", "refinery", "polecat", "crew", "deacon", "boot"}
 }
 
 // MessageNames returns the list of available message templates.
@@ -159,6 +159,31 @@ func CreateMayorCLAUDEmd(mayorDir, townRoot, townName, mayorSession, deaconSessi
 	}
 
 	claudePath := filepath.Join(mayorDir, "CLAUDE.md")
+	return os.WriteFile(claudePath, []byte(content), 0644)
+}
+
+// CreateBootCLAUDEmd creates the Boot watchdog's CLAUDE.md file at the specified directory.
+// This ensures Boot has proper context when spawned by the daemon.
+func CreateBootCLAUDEmd(bootDir, townRoot, townName, deaconSession string) error {
+	tmpl, err := New()
+	if err != nil {
+		return err
+	}
+
+	data := RoleData{
+		Role:          "boot",
+		TownRoot:      townRoot,
+		TownName:      townName,
+		WorkDir:       bootDir,
+		DeaconSession: deaconSession,
+	}
+
+	content, err := tmpl.RenderRole("boot", data)
+	if err != nil {
+		return err
+	}
+
+	claudePath := filepath.Join(bootDir, "CLAUDE.md")
 	return os.WriteFile(claudePath, []byte(content), 0644)
 }
 


### PR DESCRIPTION
## Summary
Two fixes for daemon-managed agent startup.

## Changes

1. **Boot watchdog CLAUDE.md creation**
   - Add `CreateBootCLAUDEmd` function to templates package
   - Add `EnsureCLAUDEmd` method to create context before session spawn
   - Enables Boot to perform intelligent triage decisions

2. **Deacon startup auto-execution**
   - Execute `gt prime` directly via SendKeys instead of nudge message
   - Prevents text appearing in prompt area without execution
   - Fixes endless restart loop in Claude Code v2.1.4+

## Test Plan
- [x] Build passes
- [ ] Boot session starts with proper CLAUDE.md context
- [ ] Deacon starts and runs gt prime automatically