### PR TITLE
feat(rig): add push_url config for read-only upstream repos

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -240,6 +240,14 @@ func (g *Git) Pull(remote, branch string) error {
 	return err
 }
 
+// ConfigurePushURL sets the push URL for a remote while keeping the fetch URL.
+// This is useful for read-only upstream repos where you want to push to a fork.
+// Example: ConfigurePushURL("origin", "https://github.com/user/fork.git")
+func (g *Git) ConfigurePushURL(remote, pushURL string) error {
+	_, err := g.run("remote", "set-url", remote, "--push", pushURL)
+	return err
+}
+
 // Push pushes to the remote branch.
 func (g *Git) Push(remote, branch string, force bool) error {
 	args := []string{"push", remote, branch}

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -29,7 +29,8 @@ type RigConfig struct {
 	Type          string       `json:"type"`                     // "rig"
 	Version       int          `json:"version"`                  // schema version
 	Name          string       `json:"name"`                     // rig name
-	GitURL        string       `json:"git_url"`                  // repository URL
+	GitURL        string       `json:"git_url"`                  // repository URL (fetch/pull)
+	PushURL       string       `json:"push_url,omitempty"`       // optional push URL (fork for read-only upstreams)
 	LocalRepo     string       `json:"local_repo,omitempty"`     // optional local reference repo
 	DefaultBranch string       `json:"default_branch,omitempty"` // main, master, etc.
 	CreatedAt     time.Time    `json:"created_at"`               // when rig was created
@@ -115,6 +116,11 @@ func (m *Manager) loadRig(name string, entry config.RigEntry) (*Rig, error) {
 		Config:    entry.BeadsConfig,
 	}
 
+	// Read PushURL from rig config if available
+	if rigCfg, err := LoadRigConfig(rigPath); err == nil {
+		rig.PushURL = rigCfg.PushURL
+	}
+
 	// Scan for polecats
 	polecatsDir := filepath.Join(rigPath, "polecats")
 	if entries, err := os.ReadDir(polecatsDir); err == nil {
@@ -164,7 +170,8 @@ func (m *Manager) loadRig(name string, entry config.RigEntry) (*Rig, error) {
 // AddRigOptions configures rig creation.
 type AddRigOptions struct {
 	Name          string // Rig name (directory name)
-	GitURL        string // Repository URL
+	GitURL        string // Repository URL (fetch/pull)
+	PushURL       string // Optional push URL (fork for read-only upstreams)
 	BeadsPrefix   string // Beads issue prefix (defaults to derived from name)
 	LocalRepo     string // Optional local repo for reference clones
 	DefaultBranch string // Default branch (defaults to auto-detected from remote)
@@ -265,6 +272,7 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 		Version:   CurrentRigConfigVersion,
 		Name:      opts.Name,
 		GitURL:    opts.GitURL,
+		PushURL:   opts.PushURL,
 		LocalRepo: localRepo,
 		CreatedAt: time.Now(),
 		Beads: &BeadsConfig{
@@ -295,6 +303,15 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 	}
 	fmt.Printf("   ✓ Created shared bare repo\n")
 	bareGit := git.NewGitWithDir(bareRepoPath, "")
+
+	// Configure push URL if provided (for read-only upstream repos)
+	// This sets origin's push URL to the fork while keeping fetch URL as upstream
+	if opts.PushURL != "" {
+		if err := bareGit.ConfigurePushURL("origin", opts.PushURL); err != nil {
+			return nil, fmt.Errorf("configuring push URL: %w", err)
+		}
+		fmt.Printf("   ✓ Configured push URL (fork: %s)\n", opts.PushURL)
+	}
 
 	// Determine default branch: use provided value or auto-detect from remote
 	var defaultBranch string

--- a/internal/rig/types.go
+++ b/internal/rig/types.go
@@ -13,8 +13,12 @@ type Rig struct {
 	// Path is the absolute path to the rig directory.
 	Path string `json:"path"`
 
-	// GitURL is the remote repository URL.
+	// GitURL is the remote repository URL (fetch/pull).
 	GitURL string `json:"git_url"`
+
+	// PushURL is an optional push URL for read-only upstreams.
+	// When set, polecats push here instead of to GitURL (e.g., personal fork).
+	PushURL string `json:"push_url,omitempty"`
 
 	// LocalRepo is an optional local repository used for reference clones.
 	LocalRepo string `json:"local_repo,omitempty"`


### PR DESCRIPTION
## Summary
Adds support for configuring a separate push URL (fork) when the upstream repository is read-only. This allows polecats to push to a personal fork while still pulling from the upstream repository.

## Changes
- Added `PushURL` field to `RigConfig` and `Rig` struct
- Added `PushURL` to `AddRigOptions`
- Added `ConfigurePushURL` function to git package
- Configure push URL in bare repo when `PushURL` is set

## Usage
```bash
gt rig add --git-url=https://github.com/upstream/repo \
           --push-url=https://github.com/user/fork \
           myrig
```

## Test Plan
- [x] Build passes
- [ ] Rig with push_url pushes to fork, pulls from upstream