### PR TITLE
fix(boot): improve Boot and Deacon startup behavior

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -10,11 +10,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strings"
 	"time"
 
 	"github.com/gofrs/flock"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/templates"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
@@ -58,6 +60,27 @@ func New(townRoot string) *Boot {
 // EnsureDir ensures the Boot directory exists.
 func (b *Boot) EnsureDir() error {
 	return os.MkdirAll(b.bootDir, 0755)
+}
+
+// EnsureCLAUDEmd ensures Boot's CLAUDE.md exists with proper context.
+// Creates it from the boot role template if missing.
+func (b *Boot) EnsureCLAUDEmd() error {
+	claudePath := filepath.Join(b.bootDir, "CLAUDE.md")
+
+	// Check if CLAUDE.md already exists
+	if _, err := os.Stat(claudePath); err == nil {
+		// File exists, nothing to do
+		return nil
+	}
+
+	// Create CLAUDE.md from template
+	townName := filepath.Base(b.townRoot)
+	// Deacon session name is "hq-{townname}" or just "hq-deacon" for town root
+	deaconSession := "hq-deacon"
+	if townName != "" && strings.ToLower(townName) != "gt" {
+		deaconSession = fmt.Sprintf("hq-%s", strings.ToLower(townName))
+	}
+	return templates.CreateBootCLAUDEmd(b.bootDir, b.townRoot, townName, deaconSession)
 }
 
 // markerPath returns the path to the marker file.
@@ -185,6 +208,13 @@ func (b *Boot) spawnTmux(agentOverride string) error {
 		Topic:     "triage",
 	}, "Run `" + cli.Name() + " boot triage` now.")
 
+	// Ensure CLAUDE.md exists with proper Boot context
+	if err := b.EnsureCLAUDEmd(); err != nil {
+		return fmt.Errorf("ensuring boot CLAUDE.md: %w", err)
+	}
+
+	// Build startup command with optional agent override
+	// The "gt boot triage" prompt tells Boot to immediately start triage (GUPP principle)
 	var startCmd string
 	if agentOverride != "" {
 		var err error

--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -460,6 +460,27 @@ func startDeaconSession(t *tmux.Tmux, sessionName, agentOverride string) error {
 	runtimeCfg := config.ResolveRoleAgentConfig("deacon", deaconTownRoot, "")
 	_ = runtime.RunStartupFallback(t, sessionName, "deacon", runtimeCfg)
 
+	// GUPP: Gas Town Universal Propulsion Principle
+	// Directly execute gt prime to trigger autonomous patrol execution.
+	time.Sleep(2 * time.Second)
+	_ = t.SendKeys(sessionName, "gt prime") // Non-fatal
+
+	// Inject startup nudge for predecessor discovery via /resume
+	time.Sleep(1 * time.Second)
+	if err := session.StartupNudge(t, sessionName, session.StartupNudgeConfig{
+		Recipient: "deacon",
+		Sender:    "daemon",
+		Topic:     "patrol",
+	}); err != nil {
+		style.PrintWarning("failed to send startup nudge: %v", err)
+	}
+
+	// Send propulsion nudge for autonomous patrol execution
+	time.Sleep(2 * time.Second)
+	if err := t.NudgeSession(sessionName, session.PropulsionNudgeForRole("deacon", deaconDir)); err != nil {
+		return fmt.Errorf("sending propulsion nudge: %w", err)
+	}
+
 	return nil
 }
 

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -151,7 +151,7 @@ func (t *Templates) RenderMessage(name string, data interface{}) (string, error)
 
 // RoleNames returns the list of available role templates.
 func (t *Templates) RoleNames() []string {
-	return []string{"mayor", "witness", "refinery", "polecat", "crew", "deacon"}
+	return []string{"mayor", "witness", "refinery", "polecat", "crew", "deacon", "boot"}
 }
 
 // MessageNames returns the list of available message templates.
@@ -194,6 +194,31 @@ func CreateMayorCLAUDEmd(mayorDir, townRoot, townName, mayorSession, deaconSessi
 	}
 
 	return true, os.WriteFile(claudePath, []byte(content), 0644)
+}
+
+// CreateBootCLAUDEmd creates the Boot watchdog's CLAUDE.md file at the specified directory.
+// This ensures Boot has proper context when spawned by the daemon.
+func CreateBootCLAUDEmd(bootDir, townRoot, townName, deaconSession string) error {
+	tmpl, err := New()
+	if err != nil {
+		return err
+	}
+
+	data := RoleData{
+		Role:          "boot",
+		TownRoot:      townRoot,
+		TownName:      townName,
+		WorkDir:       bootDir,
+		DeaconSession: deaconSession,
+	}
+
+	content, err := tmpl.RenderRole("boot", data)
+	if err != nil {
+		return err
+	}
+
+	claudePath := filepath.Join(bootDir, "CLAUDE.md")
+	return os.WriteFile(claudePath, []byte(content), 0644)
 }
 
 // GetAllRoleTemplates returns all role templates as a map of filename to content.


### PR DESCRIPTION
## Summary
Two fixes for daemon-managed agent startup.

## Changes

1. **Boot watchdog CLAUDE.md creation**
   - Add `CreateBootCLAUDEmd` function to templates package
   - Add `EnsureCLAUDEmd` method to create context before session spawn
   - Enables Boot to perform intelligent triage decisions

2. **Deacon startup auto-execution**
   - Execute `gt prime` directly via SendKeys instead of nudge message
   - Prevents text appearing in prompt area without execution
   - Fixes endless restart loop in Claude Code v2.1.4+

## Test Plan
- [x] Build passes
- [x] Boot session starts with proper CLAUDE.md context (verified: /gt/deacon/dogs/boot/CLAUDE.md created on spawn)
- [x] Deacon starts and runs gt prime automatically (verified: session output shows `❯ gt prime` auto-executed)

Fixes #667