### PR TITLE
fix(startup): use WaitForRuntimeReady before sending propulsion nudges

### DIFF
--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/steveyegge/gastown/internal/claude"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
@@ -108,15 +109,19 @@ func (m *Manager) Start(agentOverride string) error {
 	theme := tmux.DeaconTheme()
 	_ = t.ConfigureGasTownSession(sessionID, theme, "", "Deacon", "health-check")
 
-	// Wait for Claude to start (non-fatal)
-	if err := t.WaitForCommand(sessionID, constants.SupportedShells, constants.ClaudeStartTimeout); err != nil {
+	// Wait for Claude to start and show its prompt (non-fatal)
+	// WaitForRuntimeReady polls for the "> " prompt, ensuring Claude is ready for input
+	runtimeConfig := config.LoadRuntimeConfig("")
+	if err := t.WaitForRuntimeReady(sessionID, runtimeConfig, constants.ClaudeStartTimeout); err != nil {
 		// Non-fatal - try to continue anyway
 	}
 
 	// Accept bypass permissions warning dialog if it appears.
 	_ = t.AcceptBypassPermissionsWarning(sessionID)
 
-	time.Sleep(constants.ShutdownNotifyDelay)
+	// Wait for runtime to be fully ready
+	runtime.SleepForReadyDelay(runtimeConfig)
+	_ = runtime.RunStartupFallback(t, sessionID, "deacon", runtimeConfig)
 
 	// Inject startup nudge for predecessor discovery via /resume
 	_ = session.StartupNudge(t, sessionID, session.StartupNudgeConfig{

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/rig"
+	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/workspace"
@@ -223,15 +224,19 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 		return fmt.Errorf("starting Claude agent: %w", err)
 	}
 
-	// Wait for Claude to start (non-fatal).
-	if err := t.WaitForCommand(sessionID, constants.SupportedShells, constants.ClaudeStartTimeout); err != nil {
+	// Wait for Claude to start and show its prompt (non-fatal)
+	// WaitForRuntimeReady polls for the "> " prompt, ensuring Claude is ready for input
+	runtimeConfig := config.LoadRuntimeConfig(m.rig.Path)
+	if err := t.WaitForRuntimeReady(sessionID, runtimeConfig, constants.ClaudeStartTimeout); err != nil {
 		// Non-fatal - try to continue anyway
 	}
 
 	// Accept bypass permissions warning dialog if it appears.
 	_ = t.AcceptBypassPermissionsWarning(sessionID)
 
-	time.Sleep(constants.ShutdownNotifyDelay)
+	// Wait for runtime to be fully ready
+	runtime.SleepForReadyDelay(runtimeConfig)
+	_ = runtime.RunStartupFallback(t, sessionID, "witness", runtimeConfig)
 
 	// Inject startup nudge for predecessor discovery via /resume
 	address := fmt.Sprintf("%s/witness", m.rig.Name)


### PR DESCRIPTION
## Summary

Fixes a timing issue where propulsion nudges were being sent before Claude's input prompt was ready to receive input. This caused agents (especially the deacon) to start but hang waiting for an Enter key, as the nudges were lost during Claude's initialization.

## Related Issue

Fixes agent startup reliability issue where deacon and other agents would not auto-start properly.

## Changes

- Replace `WaitForCommand` with `WaitForRuntimeReady` in agent startup flows
- Add `runtime.SleepForReadyDelay` and `runtime.RunStartupFallback` calls after prompt detection
- Add `runtime` package import to affected files
- Rename `config` variable to `roleConfig` in `daemon/lifecycle.go` to avoid shadowing the config package

### Root Cause

`WaitForCommand` only checks that the pane command is not a shell (bash/zsh/sh). It returns as soon as the `node` process starts, but Claude's TUI may not be fully initialized and ready to accept input yet.

`WaitForRuntimeReady` polls for Claude's `"> "` prompt prefix in the captured pane content, which is the reliable indicator that Claude is actually ready to receive input.

### Files Modified

| File | Change |
|------|--------|
| `internal/deacon/manager.go` | Replace `WaitForCommand` with `WaitForRuntimeReady` pattern |
| `internal/mayor/manager.go` | Replace `WaitForCommand` with `WaitForRuntimeReady` pattern |
| `internal/witness/manager.go` | Replace `WaitForCommand` with `WaitForRuntimeReady` pattern |
| `internal/daemon/lifecycle.go` | Replace `WaitForCommand` with `WaitForRuntimeReady` pattern in `restartSession()` |

### Reference Implementation

The `refinery/manager.go` already had the correct pattern and served as the reference:

```go
// Wait for Claude to start and show its prompt (non-fatal)
// WaitForRuntimeReady waits for the runtime to be ready
if err := t.WaitForRuntimeReady(sessionID, runtimeConfig, constants.ClaudeStartTimeout); err != nil {
    // Non-fatal - try to continue anyway
}

// Accept bypass permissions warning dialog if it appears.
_ = t.AcceptBypassPermissionsWarning(sessionID)

// Wait for runtime to be fully ready
runtime.SleepForReadyDelay(runtimeConfig)
_ = runtime.RunStartupFallback(t, sessionID, "refinery", runtimeConfig)
```

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed (build successful, all existing tests pass)
- [ ] Integration testing with actual tmux sessions (requires manual verification)

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable) - N/A, internal fix
- [x] No breaking changes (or documented in summary)
