### PR TITLE
fix(sling): pass HookBead atomically when spawning polecat

### DIFF
--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -70,7 +70,12 @@ func verifyFormulaExists(formulaName string) error {
 }
 
 // runSlingFormula handles standalone formula slinging.
-// Flow: cook → wisp → attach to hook → nudge
+// Flow: cook → wisp → spawn (if rig target) → attach to hook → nudge
+//
+// When target is a rig, we create the wisp BEFORE spawning the polecat so we can
+// pass HookBead atomically at spawn time. This ensures the polecat's agent bead
+// always has a valid hook_bead from the start, avoiding race conditions where
+// gt prime might run before the hook is set.
 func runSlingFormula(args []string) error {
 	formulaName := args[0]
 
@@ -87,88 +92,54 @@ func runSlingFormula(args []string) error {
 		target = args[1]
 	}
 
+	// Check if target is a rig early - we need to know this to reorder operations
+	var targetIsRig bool
+	var rigName string
+	if target != "" && target != "." {
+		if _, isDog := IsDogTarget(target); !isDog {
+			rigName, targetIsRig = IsRigName(target)
+		}
+	}
+
 	// Resolve target agent and pane
 	var targetAgent string
 	var targetPane string
+	var wispRootID string
 
-	if target != "" {
-		// Resolve "." to current agent identity (like git's "." meaning current directory)
-		if target == "." {
+	// For dry run, handle all target types and return early
+	if slingDryRun {
+		if target == "" {
+			targetAgent, targetPane, _, err = resolveSelfTarget()
+			if err != nil {
+				return err
+			}
+		} else if target == "." {
 			targetAgent, targetPane, _, err = resolveSelfTarget()
 			if err != nil {
 				return fmt.Errorf("resolving self for '.' target: %w", err)
 			}
 		} else if dogName, isDog := IsDogTarget(target); isDog {
-			if slingDryRun {
-				if dogName == "" {
-					fmt.Printf("Would dispatch to idle dog in kennel\n")
-				} else {
-					fmt.Printf("Would dispatch to dog '%s'\n", dogName)
-				}
-				targetAgent = fmt.Sprintf("deacon/dogs/%s", dogName)
-				if dogName == "" {
-					targetAgent = "deacon/dogs/<idle>"
-				}
-				targetPane = "<dog-pane>"
+			if dogName == "" {
+				fmt.Printf("Would dispatch to idle dog in kennel\n")
 			} else {
-				// Dispatch to dog
-				dispatchInfo, dispatchErr := DispatchToDog(dogName, slingCreate)
-				if dispatchErr != nil {
-					return fmt.Errorf("dispatching to dog: %w", dispatchErr)
-				}
-				targetAgent = dispatchInfo.AgentID
-				targetPane = dispatchInfo.Pane
-				fmt.Printf("Dispatched to dog %s\n", dispatchInfo.DogName)
+				fmt.Printf("Would dispatch to dog '%s'\n", dogName)
 			}
-		} else if rigName, isRig := IsRigName(target); isRig {
-			// Check if target is a rig name (auto-spawn polecat)
-			if slingDryRun {
-				// Dry run - just indicate what would happen
-				fmt.Printf("Would spawn fresh polecat in rig '%s'\n", rigName)
-				targetAgent = fmt.Sprintf("%s/polecats/<new>", rigName)
-				targetPane = "<new-pane>"
-			} else {
-				// Spawn a fresh polecat in the rig
-				fmt.Printf("Target is rig '%s', spawning fresh polecat...\n", rigName)
-				spawnOpts := SlingSpawnOptions{
-					Force:   slingForce,
-					Account: slingAccount,
-					Create:  slingCreate,
-					Agent:   slingAgent,
-				}
-				spawnInfo, spawnErr := SpawnPolecatForSling(rigName, spawnOpts)
-				if spawnErr != nil {
-					return fmt.Errorf("spawning polecat: %w", spawnErr)
-				}
-				targetAgent = spawnInfo.AgentID()
-				targetPane = spawnInfo.Pane
-
-				// Wake witness and refinery to monitor the new polecat
-				wakeRigAgents(rigName)
+			targetAgent = fmt.Sprintf("deacon/dogs/%s", dogName)
+			if dogName == "" {
+				targetAgent = "deacon/dogs/<idle>"
 			}
+			targetPane = "<dog-pane>"
+		} else if targetIsRig {
+			fmt.Printf("Would spawn fresh polecat in rig '%s'\n", rigName)
+			targetAgent = fmt.Sprintf("%s/polecats/<new>", rigName)
+			targetPane = "<new-pane>"
 		} else {
-			// Slinging to an existing agent
-			var targetWorkDir string
-			targetAgent, targetPane, targetWorkDir, err = resolveTargetAgent(target)
+			targetAgent, targetPane, _, err = resolveTargetAgent(target)
 			if err != nil {
 				return fmt.Errorf("resolving target: %w", err)
 			}
-			// Use target's working directory for bd commands (needed for redirect-based routing)
-			_ = targetWorkDir // Formula sling doesn't need hookWorkDir
 		}
-	} else {
-		// Slinging to self
-		var selfWorkDir string
-		targetAgent, targetPane, selfWorkDir, err = resolveSelfTarget()
-		if err != nil {
-			return err
-		}
-		_ = selfWorkDir // Formula sling doesn't need hookWorkDir
-	}
-
-	fmt.Printf("%s Slinging formula %s to %s...\n", style.Bold.Render("🎯"), formulaName, targetAgent)
-
-	if slingDryRun {
+		fmt.Printf("%s Slinging formula %s to %s...\n", style.Bold.Render("🎯"), formulaName, targetAgent)
 		fmt.Printf("Would cook formula: %s\n", formulaName)
 		fmt.Printf("Would create wisp and pin to: %s\n", targetAgent)
 		for _, v := range slingVars {
@@ -178,37 +149,118 @@ func runSlingFormula(args []string) error {
 		return nil
 	}
 
-	// Step 1: Cook the formula (ensures proto exists)
-	fmt.Printf("  Cooking formula...\n")
-	cookArgs := []string{"--no-daemon", "cook", formulaName}
-	cookCmd := exec.Command("bd", cookArgs...)
-	cookCmd.Stderr = os.Stderr
-	if err := cookCmd.Run(); err != nil {
-		return fmt.Errorf("cooking formula: %w", err)
-	}
+	// For rig targets, create wisp BEFORE spawning polecat so we can pass HookBead
+	if targetIsRig {
+		fmt.Printf("%s Slinging formula %s to %s...\n", style.Bold.Render("🎯"), formulaName, rigName)
 
-	// Step 2: Create wisp instance (ephemeral)
-	fmt.Printf("  Creating wisp...\n")
-	wispArgs := []string{"--no-daemon", "mol", "wisp", formulaName}
-	for _, v := range slingVars {
-		wispArgs = append(wispArgs, "--var", v)
-	}
-	wispArgs = append(wispArgs, "--json")
+		// Step 1: Cook the formula (ensures proto exists)
+		fmt.Printf("  Cooking formula...\n")
+		cookArgs := []string{"--no-daemon", "cook", formulaName}
+		cookCmd := exec.Command("bd", cookArgs...)
+		cookCmd.Stderr = os.Stderr
+		if err := cookCmd.Run(); err != nil {
+			return fmt.Errorf("cooking formula: %w", err)
+		}
 
-	wispCmd := exec.Command("bd", wispArgs...)
-	wispCmd.Stderr = os.Stderr // Show wisp errors to user
-	wispOut, err := wispCmd.Output()
-	if err != nil {
-		return fmt.Errorf("creating wisp: %w", err)
-	}
+		// Step 2: Create wisp instance BEFORE spawning polecat
+		fmt.Printf("  Creating wisp...\n")
+		wispArgs := []string{"--no-daemon", "mol", "wisp", formulaName}
+		for _, v := range slingVars {
+			wispArgs = append(wispArgs, "--var", v)
+		}
+		wispArgs = append(wispArgs, "--json")
 
-	// Parse wisp output to get the root ID
-	wispRootID, err := parseWispIDFromJSON(wispOut)
-	if err != nil {
-		return fmt.Errorf("parsing wisp output: %w", err)
-	}
+		wispCmd := exec.Command("bd", wispArgs...)
+		wispCmd.Stderr = os.Stderr
+		wispOut, err := wispCmd.Output()
+		if err != nil {
+			return fmt.Errorf("creating wisp: %w", err)
+		}
 
-	fmt.Printf("%s Wisp created: %s\n", style.Bold.Render("✓"), wispRootID)
+		wispRootID, err = parseWispIDFromJSON(wispOut)
+		if err != nil {
+			return fmt.Errorf("parsing wisp output: %w", err)
+		}
+		fmt.Printf("%s Wisp created: %s\n", style.Bold.Render("✓"), wispRootID)
+
+		// Step 3: Spawn polecat WITH HookBead set atomically
+		fmt.Printf("Target is rig '%s', spawning fresh polecat...\n", rigName)
+		spawnOpts := SlingSpawnOptions{
+			Force:    slingForce,
+			Account:  slingAccount,
+			Create:   slingCreate,
+			Agent:    slingAgent,
+			HookBead: wispRootID, // Set atomically at spawn time
+		}
+		spawnInfo, spawnErr := SpawnPolecatForSling(rigName, spawnOpts)
+		if spawnErr != nil {
+			return fmt.Errorf("spawning polecat: %w", spawnErr)
+		}
+		targetAgent = spawnInfo.AgentID()
+		targetPane = spawnInfo.Pane
+
+		// Wake witness and refinery to monitor the new polecat
+		wakeRigAgents(rigName)
+	} else {
+		// Non-rig targets: resolve target first, then cook/wisp
+		if target == "" {
+			targetAgent, targetPane, _, err = resolveSelfTarget()
+			if err != nil {
+				return err
+			}
+		} else if target == "." {
+			targetAgent, targetPane, _, err = resolveSelfTarget()
+			if err != nil {
+				return fmt.Errorf("resolving self for '.' target: %w", err)
+			}
+		} else if dogName, isDog := IsDogTarget(target); isDog {
+			dispatchInfo, dispatchErr := DispatchToDog(dogName, slingCreate)
+			if dispatchErr != nil {
+				return fmt.Errorf("dispatching to dog: %w", dispatchErr)
+			}
+			targetAgent = dispatchInfo.AgentID
+			targetPane = dispatchInfo.Pane
+			fmt.Printf("Dispatched to dog %s\n", dispatchInfo.DogName)
+		} else {
+			// Slinging to an existing agent
+			targetAgent, targetPane, _, err = resolveTargetAgent(target)
+			if err != nil {
+				return fmt.Errorf("resolving target: %w", err)
+			}
+		}
+
+		fmt.Printf("%s Slinging formula %s to %s...\n", style.Bold.Render("🎯"), formulaName, targetAgent)
+
+		// Step 1: Cook the formula (ensures proto exists)
+		fmt.Printf("  Cooking formula...\n")
+		cookArgs := []string{"--no-daemon", "cook", formulaName}
+		cookCmd := exec.Command("bd", cookArgs...)
+		cookCmd.Stderr = os.Stderr
+		if err := cookCmd.Run(); err != nil {
+			return fmt.Errorf("cooking formula: %w", err)
+		}
+
+		// Step 2: Create wisp instance (ephemeral)
+		fmt.Printf("  Creating wisp...\n")
+		wispArgs := []string{"--no-daemon", "mol", "wisp", formulaName}
+		for _, v := range slingVars {
+			wispArgs = append(wispArgs, "--var", v)
+		}
+		wispArgs = append(wispArgs, "--json")
+
+		wispCmd := exec.Command("bd", wispArgs...)
+		wispCmd.Stderr = os.Stderr
+		wispOut, err := wispCmd.Output()
+		if err != nil {
+			return fmt.Errorf("creating wisp: %w", err)
+		}
+
+		wispRootID, err = parseWispIDFromJSON(wispOut)
+		if err != nil {
+			return fmt.Errorf("parsing wisp output: %w", err)
+		}
+		fmt.Printf("%s Wisp created: %s\n", style.Bold.Render("✓"), wispRootID)
+	}
 
 	// Step 3: Hook the wisp bead using bd update.
 	// See: https://github.com/steveyegge/gastown/issues/148


### PR DESCRIPTION
## Summary

Fix race condition in standalone formula slinging to rig targets where polecat spawns without `hook_bead` set.

When slinging a formula to a rig target (`gt sling <formula> <rig>`), the polecat was being spawned WITHOUT `HookBead` set atomically, creating a race condition where `gt prime` could run before the hook was attached. This caused issues where the polecat might not see its assigned work.

## Related Issue

N/A - Related to commit e159489e which added HookBead support for --on bead mode but missed the standalone formula mode path.

## Root Cause Analysis

In commit e159489e ("Set hook_bead atomically at polecat spawn time"), HookBead was correctly added for the `--on` bead mode (slinging a formula ON an existing bead to a rig). However, the standalone formula mode (`gt sling <formula> <rig>`) was missed.

The bug existed in the original `sling.go` before the refactor (cd2de6ec):
- Line 275 (--on mode): `HookBead: beadID` ✓
- Line 910 (standalone formula mode): `HookBead` missing ✗

## Bug Scenario (Before Fix)

```
1. gt sling formula gastown
2. SpawnPolecatForSling called WITHOUT HookBead
3. Polecat spawns with empty hook_bead in agent bead
4. gt prime runs before hook was attached
5. Race condition: polecat doesn't see its work
```

## Fixed Behavior

```
1. gt sling formula gastown
2. Cook formula (ensures proto exists)
3. Create wisp (get wispRootID)
4. SpawnPolecatForSling called WITH HookBead=wispRootID
5. Polecat spawns with hook_bead already set
6. No race: polecat always sees its work from first gt prime
```

## Changes

- Reorder operations for rig targets: cook → wisp → spawn polecat with HookBead (atomic)
- Add documentation comment explaining the atomic HookBead assignment
- Add tests verifying HookBead is passed through SlingSpawnOptions

### Key diff in `sling_formula.go`

```go
// For rig targets, create wisp BEFORE spawning polecat so we can pass HookBead
if targetIsRig {
    // Step 1: Cook formula
    // Step 2: Create wisp (get wispRootID)
    // Step 3: Spawn polecat WITH HookBead set atomically
    spawnOpts := SlingSpawnOptions{
        Force:    slingForce,
        Account:  slingAccount,
        Create:   slingCreate,
        Agent:    slingAgent,
        HookBead: wispRootID, // Set atomically at spawn time
    }
    spawnInfo, spawnErr := SpawnPolecatForSling(rigName, spawnOpts)
    // ...
}
```

## Testing

- [x] Unit tests pass (`go test ./internal/cmd/...`)
- [x] Added tests:
  - `TestSlingFormulaToRigPassesHookBead` - documents the bug and fix
  - `TestSlingSpawnOptionsHookBeadField` - verifies HookBead field handling

## Checklist

- [x] Code follows project style
- [x] Documentation updated (function comments explain the atomic assignment)
- [x] No breaking changes
- [x] Tests added for new behavior