### PR TITLE
fix(sling): check GT_ROLE before GT_POLECAT to allow coordinators

### DIFF
--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -141,9 +141,15 @@ func init() {
 }
 
 func runSling(cmd *cobra.Command, args []string) error {
-	// Polecats cannot sling - check early before writing anything
-	if polecatName := os.Getenv("GT_POLECAT"); polecatName != "" {
-		return fmt.Errorf("polecats cannot sling (use gt done for handoff)")
+	// Polecats cannot sling - check early before writing anything.
+	// However, coordinator roles (mayor, deacon, witness, refinery) CAN sling,
+	// even if GT_POLECAT is set from a stale environment.
+	role := os.Getenv("GT_ROLE")
+	isCoordinator := role == "mayor" || role == "deacon" || role == "witness" || role == "refinery"
+	if !isCoordinator {
+		if polecatName := os.Getenv("GT_POLECAT"); polecatName != "" {
+			return fmt.Errorf("polecats cannot sling (use gt done for handoff)")
+		}
 	}
 
 	// Disable Dolt auto-commit for all bd commands run during sling (gt-u6n6a).


### PR DESCRIPTION
## Summary

Fixes sling incorrectly blocking coordinator roles when a stale `GT_POLECAT` environment variable is inherited.

## Problem

When Mayor (or other coordinator) inherits `GT_POLECAT` from a previous shell session:

```
GT_POLECAT=furiosa  # stale from previous session
GT_ROLE=mayor       # current role
```

Running `gt sling` fails with: `"polecats cannot sling (use gt done for handoff)"`

## Fix

Check `GT_ROLE` first. If the role is a coordinator (mayor, deacon, witness, refinery), allow sling regardless of `GT_POLECAT` value.

## Changes

- `internal/cmd/sling.go`: Add role check before polecat check

## Test Plan

- [x] `go build ./...` passes
- [x] Manual test: Mayor with stale GT_POLECAT can now sling

Fixes #664