### PR TITLE
fix(beads): handle .beads paths and absolute routes correctly

### DIFF
--- a/internal/beads/beads_redirect.go
+++ b/internal/beads/beads_redirect.go
@@ -23,7 +23,14 @@ import (
 // this indicates an errant redirect file that should be removed. The function logs a
 // warning and returns the original beads directory.
 func ResolveBeadsDir(workDir string) string {
-	beadsDir := filepath.Join(workDir, ".beads")
+	// If workDir is already a .beads directory, use it directly
+	// (prevents double .beads paths like /path/.beads/.beads)
+	var beadsDir string
+	if strings.HasSuffix(workDir, ".beads") {
+		beadsDir = workDir
+	} else {
+		beadsDir = filepath.Join(workDir, ".beads")
+	}
 	redirectPath := filepath.Join(beadsDir, "redirect")
 
 	// Check for redirect file

--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/style"
+	"github.com/steveyegge/gastown/internal/workspace"
 )
 
 var hookCmd = &cobra.Command{
@@ -326,10 +326,5 @@ func runHookShow(cmd *cobra.Command, args []string) error {
 
 // findTownRoot finds the Gas Town root directory.
 func findTownRoot() (string, error) {
-	cmd := exec.Command("gt", "root")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
+	return workspace.FindFromCwd()
 }

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -915,7 +915,14 @@ func scanAllRigsForHookedBeads(townRoot, target string) []*beads.Issue {
 
 	// Scan each rig's beads directory
 	for _, route := range routes {
-		rigBeadsDir := filepath.Join(townRoot, route.Path)
+		// Handle both absolute and relative paths in routes.jsonl
+		// Go's filepath.Join doesn't replace with absolute paths like Python
+		var rigBeadsDir string
+		if filepath.IsAbs(route.Path) {
+			rigBeadsDir = route.Path
+		} else {
+			rigBeadsDir = filepath.Join(townRoot, route.Path)
+		}
 		if _, err := os.Stat(rigBeadsDir); os.IsNotExist(err) {
 			continue
 		}


### PR DESCRIPTION
## Summary

Three related fixes for beads database routing that caused `gt hook show` to fail when querying hooked beads across rigs:

1. **ResolveBeadsDir**: Detect if `workDir` already ends with `.beads` to prevent double paths like `/path/.beads/.beads` when called with a beads directory directly

2. **findTownRoot**: Use `workspace.FindFromCwd()` instead of nonexistent `gt root` command (currently returns "unknown command")

3. **scanAllRigsForHookedBeads**: Check `filepath.IsAbs()` before joining paths since Go's `filepath.Join` doesn't handle absolute paths like Python - it concatenates instead of replacing

## Problem

When `routes.jsonl` contains absolute paths (e.g., `/home/user/gt/rig/mayor/rig/.beads`), the scan would produce invalid doubled paths like `/home/user/gt/home/user/gt/...` causing beads lookups to fail.

## Test plan

- [ ] `gt hook show <polecat>` correctly finds hooked beads
- [ ] `gt sling <bead> <rig>` updates bead status to hooked
- [ ] Works with both absolute and relative paths in routes.jsonl

🤖 Generated with [Claude Code](https://claude.ai/code)