### PR TITLE
feat(refinery): add --agent flag for runtime override

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -779,7 +779,7 @@ func runRigBoot(cmd *cobra.Command, args []string) error {
 	} else {
 		fmt.Printf("  Starting refinery...\n")
 		refMgr := refinery.NewManager(r)
-		if err := refMgr.Start(false); err != nil { // false = background mode
+		if err := refMgr.Start(false, "", nil); err != nil { // false = background mode
 			return fmt.Errorf("starting refinery: %w", err)
 		}
 		started = append(started, "refinery")
@@ -859,7 +859,7 @@ func runRigStart(cmd *cobra.Command, args []string) error {
 		} else {
 			fmt.Printf("  Starting refinery...\n")
 			refMgr := refinery.NewManager(r)
-			if err := refMgr.Start(false); err != nil {
+			if err := refMgr.Start(false, "", nil); err != nil {
 				fmt.Printf("  %s Failed to start refinery: %v\n", style.Warning.Render("⚠"), err)
 				hasError = true
 			} else {
@@ -1437,7 +1437,7 @@ func runRigRestart(cmd *cobra.Command, args []string) error {
 			skipped = append(skipped, "refinery")
 		} else {
 			fmt.Printf("    Starting refinery...\n")
-			if err := refMgr.Start(false); err != nil {
+			if err := refMgr.Start(false, "", nil); err != nil {
 				fmt.Printf("    %s Failed to start refinery: %v\n", style.Warning.Render("⚠"), err)
 				startErrors = append(startErrors, fmt.Sprintf("refinery: %v", err))
 			} else {

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -340,7 +340,7 @@ func startWitnessForRig(t *tmux.Tmux, r *rig.Rig) string {
 // startRefineryForRig starts the refinery for a single rig and returns a status message.
 func startRefineryForRig(r *rig.Rig) string {
 	refineryMgr := refinery.NewManager(r)
-	if err := refineryMgr.Start(false); err != nil {
+	if err := refineryMgr.Start(false, "", nil); err != nil {
 		if errors.Is(err, refinery.ErrAlreadyRunning) {
 			return fmt.Sprintf("  %s %s refinery already running\n", style.Dim.Render("○"), r.Name)
 		}

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -140,7 +140,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 		}
 
 		mgr := refinery.NewManager(r)
-		if err := mgr.Start(false); err != nil {
+		if err := mgr.Start(false, "", nil); err != nil {
 			if err == refinery.ErrAlreadyRunning {
 				printStatus(fmt.Sprintf("Refinery (%s)", rigName), true, mgr.SessionName())
 			} else {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -443,7 +443,7 @@ func (d *Daemon) ensureRefineryRunning(rigName string) {
 	}
 	mgr := refinery.NewManager(r)
 
-	if err := mgr.Start(false); err != nil {
+	if err := mgr.Start(false, "", nil); err != nil {
 		if err == refinery.ErrAlreadyRunning {
 			// Already running - nothing to do
 			return


### PR DESCRIPTION
## Summary

Adds `--agent` and `--env` flags to `gt refinery start` and `gt refinery restart` commands, matching the existing witness command flags.

This allows overriding the default agent alias when starting refinery, useful when:
- The default model has API issues
- Testing with different runtime configurations
- Switching between agent providers

## Changes

- Add `refineryAgentOverride` and `refineryEnvOverrides` flag variables
- Add flags to `refineryStartCmd` and `refineryRestartCmd`
- Update `refinery.Manager.Start()` signature to accept agent override and env overrides
- Update all callers to pass the new parameters

## Test plan

- [x] Build passes
- [x] `gt refinery start --help` shows new flags
- [x] Manual test: `gt refinery start gastown --agent new-agent`