### PR TITLE
fix(beads): don't override BEADS_DIR to preserve prefix routing

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -219,10 +219,20 @@ func (b *Beads) run(args ...string) ([]byte, error) {
 	var env []string
 	if b.isolated {
 		env = filterBeadsEnv(os.Environ())
+		// In isolated mode, always set BEADS_DIR to the resolved directory
+		cmd.Env = append(env, "BEADS_DIR="+beadsDir)
 	} else {
 		env = os.Environ()
+		// Only set BEADS_DIR if explicitly provided via NewWithBeadsDir().
+		// Otherwise, let bd use its native prefix-based routing to find the correct
+		// database for each bead ID. Setting BEADS_DIR forces bd to use only that
+		// database, bypassing routing for beads with different prefixes.
+		if b.beadsDir != "" {
+			cmd.Env = append(env, "BEADS_DIR="+b.beadsDir)
+		} else {
+			cmd.Env = env
+		}
 	}
-	cmd.Env = append(env, "BEADS_DIR="+beadsDir)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout


### PR DESCRIPTION
## Summary
Fix `gt hook` returning "Nothing on hook" even when beads are properly hooked to agents.

## Problem
`beads.run()` was setting `BEADS_DIR` to the resolved beads directory, which bypassed prefix-based routing. Beads with prefixes like `gt-` route to different databases, but the forced `BEADS_DIR` made `bd` search only one database.

## Fix
Only set `BEADS_DIR` when explicitly provided via `NewWithBeadsDir()`, allowing `bd`'s native prefix routing to work.

## Test plan
- [x] Build passes
- [x] Unit tests pass  
- [x] Manual test: `gt hook` from polecat worktree now finds hooked beads

Fixes #663