### PR TITLE
daemon-role-agent-fix

### DIFF
--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -1184,7 +1184,7 @@ func TestBuildStartupCommand_UsesRigAgentWhenRigPathProvided(t *testing.T) {
 		t.Fatalf("SaveRigSettings: %v", err)
 	}
 
-	cmd := BuildStartupCommand(map[string]string{"GT_ROLE": "witness"}, rigPath, "")
+	cmd := BuildStartupCommand(map[string]string{"GT_ROLE": "witness"}, rigPath, "", "witness")
 	if !strings.Contains(cmd, "codex") {
 		t.Fatalf("expected rig agent (codex) in command: %q", cmd)
 	}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -875,7 +875,7 @@ func (d *Daemon) restartPolecatSession(rigName, polecatName, sessionName string)
 
 	// Launch Claude with environment exported inline
 	// Pass rigPath so rig agent settings are honored (not town-level defaults)
-	startCmd := config.BuildStartupCommand(envVars, rigPath, "")
+	startCmd := config.BuildStartupCommand(envVars, rigPath, "", "polecat")
 	if err := d.tmux.SendKeys(sessionName, startCmd); err != nil {
 		return fmt.Errorf("sending startup command: %w", err)
 	}


### PR DESCRIPTION
## Summary

The role_agents configuration, previously ignored when daemon spawned agent sessions, is now correctly utilized. The fix involved updating internal/config/loader.go functions to ensure proper agent resolution based on the provided role.

## Related Issue
#433 

## Changes
- Core Startup Functions: BuildStartupCommand and BuildStartupCommandWithAgentOverride now accept a role parameter for role-specific agent resolution.
- Agent-Specific Startup Functions: All agent startup functions (e.g., BuildAgentStartupCommand, BuildPolecatStartupCommand) were updated to correctly pass the agent's role.
- Internal Daemon Logic: Polecat session restarts now properly pass the "polecat" role.
- Test Updates: Existing unit tests were adjusted for the new role parameter.

## Testing
<!-- How did you test these changes? -->
- [x] Unit tests pass (`go test ./...`)
- [ ] Manual testing performed

## Checklist
- [ ] Code follows project style
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or documented in summary)
