### PR TITLE
WIP: feat(daemon): add configurable socket locations for bd daemon (hq-q9n)

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -73,6 +73,16 @@ func NewTownSettings() *TownSettings {
 type DaemonConfig struct {
 	HeartbeatInterval string `json:"heartbeat_interval,omitempty"` // e.g., "30s"
 	PollInterval      string `json:"poll_interval,omitempty"`      // e.g., "10s"
+
+	// BdSocket is an explicit socket path for the beads daemon (hq-q9n).
+	// If set, overrides the auto-computed socket path.
+	// Useful for containers or environments with restricted /tmp access.
+	BdSocket string `json:"bd_socket,omitempty"`
+
+	// BdSocketDir is a custom base directory for bd daemon sockets (hq-q9n).
+	// Used when the workspace path is too long for Unix socket limits.
+	// Defaults to /tmp if not set.
+	BdSocketDir string `json:"bd_socket_dir,omitempty"`
 }
 
 // DaemonPatrolConfig represents the daemon patrol configuration (mayor/daemon.json).


### PR DESCRIPTION
## Summary
When running in a sandboxed container, you may need to pass specific socket paths to allow gas town to start the bd daemon. My understanding was this was configurable in bd but not gt so I added it.

Add BdSocket and BdSocketDir config fields to DaemonConfig, allowing gastown to pass socket configuration to bd daemon commands via BD_SOCKET and BD_SOCKET_DIR environment variables.

This enables:
- Explicit socket path override for containers/restricted environments
- Custom temp directory for socket files when workspace paths are long

Includes SocketConfig type, applySocketConfig helper, and StartBdDaemonWithConfig function variant.

## Related Issue
https://github.com/steveyegge/beads/pull/1064/files

## Changes
* Added socket path configuration to gt

## Testing
<!-- How did you test these changes? -->
- [ ] Unit tests pass (`go test ./...`)
- [ ] Manual testing performed

## Checklist
- [ ] Code follows project style
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)
