### PR TITLE
fix(handoff): use correct witness working directory

### DIFF
--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -442,10 +442,11 @@ func sessionWorkDir(sessionName, townRoot string) (string, error) {
 		return "", fmt.Errorf("cannot parse crew session name: %s", sessionName)
 
 	case strings.HasSuffix(sessionName, "-witness"):
-		// gt-<rig>-witness -> <townRoot>/<rig>/witness/rig
+		// gt-<rig>-witness -> <townRoot>/<rig>/witness
+		// Note: witness doesn't have a /rig worktree like refinery does
 		rig := strings.TrimPrefix(sessionName, "gt-")
 		rig = strings.TrimSuffix(rig, "-witness")
-		return fmt.Sprintf("%s/%s/witness/rig", townRoot, rig), nil
+		return fmt.Sprintf("%s/%s/witness", townRoot, rig), nil
 
 	case strings.HasSuffix(sessionName, "-refinery"):
 		// gt-<rig>-refinery -> <townRoot>/<rig>/refinery/rig


### PR DESCRIPTION
## Summary

Fix witness handoff failure caused by incorrect working directory path. The handoff command was generating `cd <rig>/witness/rig` but witness doesn't have a `/rig` worktree like refinery does, causing the respawn to fail and the session to die.

## Related Issue

N/A (discovered during testing)

## Impact

**Before:** When a witness ran `gt handoff` (either manually or due to context exhaustion), the session would die completely. The respawn command failed because it tried to `cd` to a non-existent directory, causing:
- Witness session to disappear without restart
- Polecats to go unmonitored until manual intervention
- Handoff state file left behind indicating "running" when session was dead

**After:** Witness handoff works correctly - session respawns with fresh Claude instance in the correct working directory (`<rig>/witness`).


## Changes

- Change witness working directory from `<rig>/witness/rig` to `<rig>/witness` in `sessionWorkDir()`
- Add clarifying comment explaining witness doesn't have a /rig worktree

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed
  - Started witness with `gt witness start gastown`
  - Ran `gt handoff` from witness session
  - Verified session respawns correctly instead of dying

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable) - added clarifying comment
- [x] No breaking changes (or documented in summary)

---

## Diff

```go
// Before:
case strings.HasSuffix(sessionName, "-witness"):
    // gt-<rig>-witness -> <townRoot>/<rig>/witness/rig
    rig := strings.TrimPrefix(sessionName, "gt-")
    rig = strings.TrimSuffix(rig, "-witness")
    return fmt.Sprintf("%s/%s/witness/rig", townRoot, rig), nil

// After:
case strings.HasSuffix(sessionName, "-witness"):
    // gt-<rig>-witness -> <townRoot>/<rig>/witness
    // Note: witness doesn't have a /rig worktree like refinery does
    rig := strings.TrimPrefix(sessionName, "gt-")
    rig = strings.TrimSuffix(rig, "-witness")
    return fmt.Sprintf("%s/%s/witness", townRoot, rig), nil
```
