### PR TITLE
fix(sling): fix formula lookup in --on mode (#422)

### DIFF
--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -343,25 +343,27 @@ func runSling(cmd *cobra.Command, args []string) error {
 	if formulaName != "" {
 		fmt.Printf("  Instantiating formula %s...\n", formulaName)
 
-		// Route bd mutations (cook/wisp/bond) to the correct beads context for the target bead.
+		// Route bd mutations (wisp/bond) to the correct beads context for the target bead.
 		// Some bd mol commands don't support prefix routing, so we must run them from the
 		// rig directory that owns the bead's database.
 		formulaWorkDir := beads.ResolveHookDir(townRoot, beadID, hookWorkDir)
 
 		// Step 1: Cook the formula (ensures proto exists)
+		// Cook doesn't need database context - runs from cwd like gt formula show
 		cookCmd := exec.Command("bd", "--no-daemon", "cook", formulaName)
-		cookCmd.Dir = formulaWorkDir
 		cookCmd.Stderr = os.Stderr
 		if err := cookCmd.Run(); err != nil {
 			return fmt.Errorf("cooking formula %s: %w", formulaName, err)
 		}
 
 		// Step 2: Create wisp with feature and issue variables from bead
+		// Run from rig directory so wisp is created in correct database
 		featureVar := fmt.Sprintf("feature=%s", info.Title)
 		issueVar := fmt.Sprintf("issue=%s", beadID)
 		wispArgs := []string{"--no-daemon", "mol", "wisp", formulaName, "--var", featureVar, "--var", issueVar, "--json"}
 		wispCmd := exec.Command("bd", wispArgs...)
 		wispCmd.Dir = formulaWorkDir
+		wispCmd.Env = append(os.Environ(), "GT_ROOT="+townRoot)
 		wispCmd.Stderr = os.Stderr
 		wispOut, err := wispCmd.Output()
 		if err != nil {


### PR DESCRIPTION
## Summary

Fixes formula lookup failure when using `gt sling <formula> --on <bead>`. The formula instantiation was failing because `bd cook` and `bd mol wisp` couldn't find formulas in the expected locations.

## Related Issue

Fixes #422

## Changes

- Remove `cookCmd.Dir` assignment so `bd cook` runs from cwd (like `gt formula show`)
- Add `GT_ROOT` environment variable to `wispCmd` so `bd mol wisp` can find formulas in the orchestrator path

### Root Cause

When running `gt sling <formula> --on <bead>`:

1. `bd cook` was running from the rig directory where formulas might not exist locally
2. `bd mol wisp` couldn't find formulas because it didn't have access to `$GT_ROOT/.beads/formulas/`

### Fix Details

| Command | Before | After |
|---------|--------|-------|
| `bd cook` | Ran from `formulaWorkDir` (rig dir) | Runs from cwd (formulas exist) |
| `bd mol wisp` | No GT_ROOT in env | GT_ROOT passed for formula lookup |

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed
  - Verified `gt sling <formula> --on <bead>` works from orchestrator context
  - Confirmed formula instantiation creates wisp correctly

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable) - N/A, internal fix
- [x] No breaking changes (or documented in summary)
