### PR TITLE
fix(sling): set attached_molecule field when bonding formula to bead

### DIFF
--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -434,6 +434,13 @@ func runSling(cmd *cobra.Command, args []string) error {
 
 		fmt.Printf("%s Formula bonded to %s\n", style.Bold.Render("✓"), beadID)
 
+		// Record the attached molecule in the wisp's description.
+		// This is required for gt hook to recognize the molecule attachment.
+		if err := storeAttachedMoleculeInBead(wispRootID, wispRootID); err != nil {
+			// Warn but don't fail - polecat can still work through steps
+			fmt.Printf("%s Could not store attached_molecule: %v\n", style.Dim.Render("Warning:"), err)
+		}
+
 		// Update beadID to hook the compound root instead of bare bead
 		beadID = wispRootID
 	}

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -210,6 +210,13 @@ func runSlingFormula(args []string) error {
 
 	fmt.Printf("%s Wisp created: %s\n", style.Bold.Render("✓"), wispRootID)
 
+	// Record the attached molecule in the wisp's description.
+	// This is required for gt hook to recognize the molecule attachment.
+	if err := storeAttachedMoleculeInBead(wispRootID, wispRootID); err != nil {
+		// Warn but don't fail - polecat can still work through steps
+		fmt.Printf("%s Could not store attached_molecule: %v\n", style.Dim.Render("Warning:"), err)
+	}
+
 	// Step 3: Hook the wisp bead using bd update.
 	// See: https://github.com/steveyegge/gastown/issues/148
 	hookCmd := exec.Command("bd", "--no-daemon", "update", wispRootID, "--status=hooked", "--assignee="+targetAgent)

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -703,3 +703,159 @@ func TestLooksLikeBeadID(t *testing.T) {
 		})
 	}
 }
+
+// TestSlingFormulaOnBeadSetsAttachedMolecule verifies that when using
+// gt sling <formula> --on <bead>, the attached_molecule field is set in the
+// hooked bead's description after bonding. This is required for gt hook to
+// recognize the molecule attachment.
+//
+// Bug: The original code bonds the wisp to the bead and sets status=hooked,
+// but doesn't record attached_molecule in the description. This causes
+// gt hook to report "No molecule attached".
+func TestSlingFormulaOnBeadSetsAttachedMolecule(t *testing.T) {
+	townRoot := t.TempDir()
+
+	// Minimal workspace marker so workspace.FindFromCwd() succeeds.
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir mayor/rig: %v", err)
+	}
+
+	// Create a rig path that owns gt-* beads, and a routes.jsonl pointing to it.
+	rigDir := filepath.Join(townRoot, "gastown", "mayor", "rig")
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.MkdirAll(rigDir, 0755); err != nil {
+		t.Fatalf("mkdir rigDir: %v", err)
+	}
+	routes := strings.Join([]string{
+		`{"prefix":"gt-","path":"gastown/mayor/rig"}`,
+		`{"prefix":"hq-","path":"."}`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	// Stub bd so we can observe the arguments passed to update commands.
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	logPath := filepath.Join(townRoot, "bd.log")
+	bdPath := filepath.Join(binDir, "bd")
+	// The stub logs all commands to a file for verification
+	bdScript := `#!/bin/sh
+set -e
+echo "$PWD|$*" >> "${BD_LOG}"
+if [ "$1" = "--no-daemon" ]; then
+  shift
+fi
+cmd="$1"
+shift || true
+case "$cmd" in
+  show)
+    echo '[{"title":"Bug to fix","status":"open","assignee":"","description":""}]'
+    ;;
+  formula)
+    echo '{"name":"mol-polecat-work"}'
+    exit 0
+    ;;
+  cook)
+    exit 0
+    ;;
+  mol)
+    sub="$1"
+    shift || true
+    case "$sub" in
+      wisp)
+        echo '{"new_epic_id":"gt-wisp-xyz"}'
+        ;;
+      bond)
+        echo '{"root_id":"gt-wisp-xyz"}'
+        ;;
+    esac
+    ;;
+  update)
+    # Just succeed
+    exit 0
+    ;;
+esac
+exit 0
+`
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv(EnvGTRole, "mayor")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("GT_CREW", "")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	// Ensure we don't leak global flag state across tests.
+	prevOn := slingOnTarget
+	prevVars := slingVars
+	prevDryRun := slingDryRun
+	prevNoConvoy := slingNoConvoy
+	t.Cleanup(func() {
+		slingOnTarget = prevOn
+		slingVars = prevVars
+		slingDryRun = prevDryRun
+		slingNoConvoy = prevNoConvoy
+	})
+
+	slingDryRun = false
+	slingNoConvoy = true
+	slingVars = nil
+	slingOnTarget = "gt-abc123" // The bug bead we're applying formula to
+
+	if err := runSling(nil, []string{"mol-polecat-work"}); err != nil {
+		t.Fatalf("runSling: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+
+	// After bonding (mol bond), there should be an update call that includes
+	// --description with attached_molecule field. This is what gt hook looks for.
+	logLines := strings.Split(string(logBytes), "\n")
+
+	// Find all update commands after the bond
+	sawBond := false
+	foundAttachedMolecule := false
+	for _, line := range logLines {
+		if strings.Contains(line, "mol bond") {
+			sawBond = true
+			continue
+		}
+		if sawBond && strings.Contains(line, "update") {
+			// Check if this update sets attached_molecule in description
+			if strings.Contains(line, "attached_molecule") {
+				foundAttachedMolecule = true
+				break
+			}
+		}
+	}
+
+	if !sawBond {
+		t.Fatalf("mol bond command not found in log:\n%s", string(logBytes))
+	}
+
+	if !foundAttachedMolecule {
+		t.Errorf("after mol bond, expected update with attached_molecule in description\n"+
+			"This is required for gt hook to recognize the molecule attachment.\n"+
+			"Log output:\n%s", string(logBytes))
+	}
+}


### PR DESCRIPTION
## Summary

When using `gt sling <formula> --on <bead>` to apply a formula to an existing bead, the wisp was correctly bonded but the `attached_molecule` field wasn't being set in the bead's description. This caused `gt hook` to report "No molecule attached" even though the formula was correctly bonded and the polecat could work through the steps.

This PR ensures both sling paths (standalone formula and `--on` mode) call `storeAttachedMoleculeInBead()` after wisp creation.

## Related Issue

Fixes `gt hook` reporting "No molecule attached" when formula is bonded via `--on` flag.

## Changes

- **Add `storeAttachedMoleculeInBead()` helper** - New function in `sling_helpers.go` that:
  - Fetches the bead's current description
  - Parses attachment fields
  - Sets `attached_molecule` and `attached_at` fields
  - Updates the bead description

- **Call helper in both sling paths**:
  - `sling.go`: After `mol bond` in `--on` mode
  - `sling_formula.go`: After `mol wisp` in standalone mode

- **Add comprehensive test** - `TestSlingFormulaOnBeadSetsAttachedMolecule` verifies the update command includes `attached_molecule` in the description after bonding

### Code Flow

```
gt sling mol-polecat-work --on gt-abc123
    │
    ├── bd cook mol-polecat-work          # Validate formula
    ├── bd mol wisp mol-polecat-work      # Create wisp
    ├── bd mol bond gt-wisp-xyz gt-abc123 # Bond to target
    │
    ├── storeAttachedMoleculeInBead()     # NEW: Set attached_molecule
    │   ├── bd show gt-wisp-xyz --json
    │   └── bd update gt-wisp-xyz --description="...attached_molecule: gt-wisp-xyz..."
    │
    └── bd update gt-wisp-xyz --status=hooked --assignee=<target>
```

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] New test added: `TestSlingFormulaOnBeadSetsAttachedMolecule`

### Test Coverage

The new test:
1. Stubs `bd` commands to log all invocations
2. Runs `runSling()` with `--on` flag set
3. Verifies that after `mol bond`, an `update` command includes `attached_molecule` in the description

### Manual Verification

After fix:
```
$ gt sling mol-polecat-work --on gt-abc123 gastown
✓ Formula wisp created: gt-wisp-xyz
✓ Formula bonded to gt-abc123

$ gt hook
🪝 Hook Status: gastown/polecats/nux
  Molecule: gt-wisp-xyz (mol-polecat-work)   # Now shows correctly
  Progress: 2/5 steps complete
```

## Checklist

- [x] Code follows project style
- [x] Tests added for new functionality
- [x] No breaking changes
