### PR TITLE
fix(done): get issue ID from agent hook and detect integration branches

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -215,6 +215,16 @@ func runDone(cmd *cobra.Command, args []string) error {
 		agentBeadID = getAgentBeadID(ctx)
 	}
 
+	// If issue ID not set by flag or branch name, try agent's hook_bead.
+	// This handles cases where branch name doesn't contain issue ID
+	// (e.g., "polecat/furiosa-mkb0vq9f" doesn't have the actual issue).
+	if issueID == "" && agentBeadID != "" {
+		bd := beads.New(beads.ResolveBeadsDir(cwd))
+		if hookIssue := getIssueFromAgentHook(bd, agentBeadID); hookIssue != "" {
+			issueID = hookIssue
+		}
+	}
+
 	// Get configured default branch for this rig
 	defaultBranch := "main" // fallback
 	if rigCfg, err := rig.LoadRigConfig(filepath.Join(townRoot, rigName)); err == nil && rigCfg.DefaultBranch != "" {
@@ -615,6 +625,21 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, _ string) { // issueID unus
 			}
 		}
 	}
+}
+
+// getIssueFromAgentHook retrieves the issue ID from an agent's hook_bead field.
+// This is the authoritative source for what work a polecat is doing, since branch
+// names may not contain the issue ID (e.g., "polecat/furiosa-mkb0vq9f").
+// Returns empty string if agent doesn't exist or has no hook.
+func getIssueFromAgentHook(bd *beads.Beads, agentBeadID string) string {
+	if agentBeadID == "" {
+		return ""
+	}
+	agentBead, err := bd.Show(agentBeadID)
+	if err != nil {
+		return ""
+	}
+	return agentBead.HookBead
 }
 
 // getDispatcherFromBead retrieves the dispatcher agent ID from the bead's attachment fields.

--- a/internal/cmd/mq_test.go
+++ b/internal/cmd/mq_test.go
@@ -69,6 +69,24 @@ func TestParseBranchName(t *testing.T) {
 			wantWorker: "Worker",
 		},
 		{
+			name:       "polecat branch with issue and timestamp",
+			branch:     "polecat/furiosa/gt-jns7.1@mk123456",
+			wantIssue:  "gt-jns7.1",
+			wantWorker: "furiosa",
+		},
+		{
+			name:       "modern polecat branch (timestamp format)",
+			branch:     "polecat/furiosa-mkc36bb9",
+			wantIssue:  "", // Should NOT extract fake issue from worker-timestamp
+			wantWorker: "furiosa",
+		},
+		{
+			name:       "modern polecat branch with longer name",
+			branch:     "polecat/citadel-mk0vro62",
+			wantIssue:  "",
+			wantWorker: "citadel",
+		},
+		{
 			name:       "simple issue branch",
 			branch:     "gt-xyz",
 			wantIssue:  "gt-xyz",


### PR DESCRIPTION
## Summary

Modern polecat branch names like `polecat/furiosa-mkb0vq9f` don't contain the actual issue ID, causing `gt done` to incorrectly parse `furiosa-mkb0vq9f` as the issue. This broke:
1. Integration branch auto-detection (wrong issue used for epic lookup)
2. MR targeting (couldn't find the parent epic's integration branch)

This PR fixes the issue by using the agent's `hook_bead` field as the authoritative source for what work a polecat is doing.

## Impact

### What Was Broken

| Command/Feature | Before | After |
|-----------------|--------|-------|
| `gt done` | Failed to find issue, couldn't submit MR | Correctly identifies issue from hook_bead |
| `gt mq submit` | Targeted `main` instead of integration branch | Auto-detects epic's integration branch |
| Integration branch workflow | Only worked if bug was direct child of epic | Works for any depth (molecule → bug → epic) |
| Branch traceability | `polecat/furiosa-mk123` - no issue context | `polecat/furiosa/gt-abc@mk123` - issue in name |
| Convoy tracking | Wrong issue ID reported in done events | Correct issue ID in all audit logs |

### Workflows Now Unlocked

1. **Epic-based development** - Create an epic, spawn an integration branch, and have all child work (bugs, tasks, molecules) automatically target that integration branch when polecats run `gt done`

2. **Deep work hierarchies** - Formulas that create molecules containing tasks can now correctly detect their grandparent epic's integration branch:
   ```
   epic (gt-epic-123)           ← integration/gt-epic-123
       └── bug (gt-bug-456)
               └── molecule (gt-wisp-789)
                       └── task (gt-task-abc)  ← MR targets integration/gt-epic-123 ✓
   ```

3. **Formula-driven work** - When `gt sling mol-polecat-work --on gt-bug` creates a wisp, the polecat's `gt done` now correctly:
   - Finds the wisp ID from hook_bead
   - Traverses wisp → bug → epic
   - Targets the epic's integration branch

4. **Reliable merge queue** - MRs land on the correct branch, enabling:
   - Parallel polecat work on same epic
   - Integration testing before main merge
   - Clean epic-level squash merges

## Related Issue

Fixes #411

## Changes

### 1. Use agent hook as issue ID fallback

When branch name doesn't contain a valid issue ID, query the agent's `hook_bead` field:

```go
// done.go
if issueID == "" && agentBeadID != "" {
    if hookIssue := getIssueFromAgentHook(bd, agentBeadID); hookIssue != "" {
        issueID = hookIssue
    }
}
```

### 2. Fix parseBranchName for modern polecat branches

Don't extract fake issue IDs from `polecat/<worker>-<timestamp>` format:

```go
// Before: "polecat/furiosa-mkb0vq9f" → Issue: "furiosa-mkb0vq9f" ❌
// After:  "polecat/furiosa-mkb0vq9f" → Issue: "" (let hook fallback handle it) ✓
```

Also strip `@timestamp` suffix from `polecat/<worker>/<issue>@<timestamp>` format.

### 3. Fix detectIntegrationBranch parent traversal

The old code only checked immediate parent. Now traverses full chain:

```
molecule (gt-wisp-xyz)
    └── bug (gt-abc)
            └── epic (gt-epic-123) ← has integration/gt-epic-123 branch
```

Before: Only found integration branch if issue's direct parent was the epic
After: Traverses up to 10 levels to find any ancestor epic with integration branch

### 4. Include issue ID in polecat branch names

When `HookBead` is set, include it in the branch name for better traceability:

```
polecat/<name>/<issue>@<timestamp>
```

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] New tests added

### New Tests

- `TestGetIssueFromAgentHook` - Verifies hook_bead lookup
- `TestParseBranchName_ModernPolecatFormat` - Verifies modern branch format handling
- `TestDetectIntegrationBranch_ParentChain` - Verifies multi-level traversal

## Example Flow

```
1. Polecat spawned with branch: polecat/furiosa/gt-wisp-abc@mk123
2. gt done runs:
   - parseBranchName extracts issue="gt-wisp-abc" (strips @timestamp)
   - If branch was "polecat/furiosa-mk123", falls back to hook_bead
3. detectIntegrationBranch:
   - gt-wisp-abc (molecule) → parent: gt-bug-xyz
   - gt-bug-xyz (bug) → parent: gt-epic-123
   - gt-epic-123 (epic) → integration/gt-epic-123 exists ✓
4. MR targets integration/gt-epic-123 instead of main
```

## Checklist

- [x] Code follows project style
- [x] Tests added for new functionality
- [x] No breaking changes
