### PR TITLE
fix(config): implement role_agents support in BuildStartupCommand

### DIFF
--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -381,10 +381,10 @@ func startConfiguredCrew(t *tmux.Tmux, rigs []*rig.Rig, townRoot string, mu *syn
 func startOrRestartCrewMember(t *tmux.Tmux, r *rig.Rig, crewName, townRoot string) (msg string, started bool) {
 	sessionID := crewSessionName(r.Name, crewName)
 	if running, _ := t.HasSession(sessionID); running {
-		// Session exists - check if Claude is still running
-		agentCfg := config.ResolveAgentConfig(townRoot, r.Path)
+		// Session exists - check if agent is still running
+		agentCfg := config.ResolveRoleAgentConfig("crew", townRoot, r.Path)
 		if !t.IsAgentRunning(sessionID, config.ExpectedPaneCommands(agentCfg)...) {
-			// Claude has exited, restart it
+			// Agent has exited, restart it
 			// Build startup beacon for predecessor discovery via /resume
 			address := fmt.Sprintf("%s/crew/%s", r.Name, crewName)
 			beacon := session.FormatStartupNudge(session.StartupNudgeConfig{
@@ -392,11 +392,11 @@ func startOrRestartCrewMember(t *tmux.Tmux, r *rig.Rig, crewName, townRoot strin
 				Sender:    "human",
 				Topic:     "restart",
 			})
-			claudeCmd := config.BuildCrewStartupCommand(r.Name, crewName, r.Path, beacon)
-			if err := t.SendKeys(sessionID, claudeCmd); err != nil {
+			agentCmd := config.BuildCrewStartupCommand(r.Name, crewName, r.Path, beacon)
+			if err := t.SendKeys(sessionID, agentCmd); err != nil {
 				return fmt.Sprintf("  %s %s/%s restart failed: %v\n", style.Dim.Render("○"), r.Name, crewName, err), false
 			}
-			return fmt.Sprintf("  %s %s/%s Claude restarted\n", style.Bold.Render("✓"), r.Name, crewName), true
+			return fmt.Sprintf("  %s %s/%s agent restarted\n", style.Bold.Render("✓"), r.Name, crewName), true
 		}
 		return fmt.Sprintf("  %s %s/%s already running\n", style.Dim.Render("○"), r.Name, crewName), false
 	}

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -115,7 +115,7 @@ func (m *Manager) Start(foreground bool) error {
 	if foreground {
 		// In foreground mode, check tmux session (no PID inference per ZFC)
 		townRoot := filepath.Dir(m.rig.Path)
-		agentCfg := config.ResolveAgentConfig(townRoot, m.rig.Path)
+		agentCfg := config.ResolveRoleAgentConfig("refinery", townRoot, m.rig.Path)
 		if running, _ := t.HasSession(sessionID); running && t.IsAgentRunning(sessionID, config.ExpectedPaneCommands(agentCfg)...) {
 			return ErrAlreadyRunning
 		}
@@ -137,15 +137,15 @@ func (m *Manager) Start(foreground bool) error {
 	// Background mode: check if session already exists
 	running, _ := t.HasSession(sessionID)
 	if running {
-		// Session exists - check if Claude is actually running (healthy vs zombie)
+		// Session exists - check if agent is actually running (healthy vs zombie)
 		townRoot := filepath.Dir(m.rig.Path)
-		agentCfg := config.ResolveAgentConfig(townRoot, m.rig.Path)
+		agentCfg := config.ResolveRoleAgentConfig("refinery", townRoot, m.rig.Path)
 		if t.IsAgentRunning(sessionID, config.ExpectedPaneCommands(agentCfg)...) {
-			// Healthy - Claude is running
+			// Healthy - agent is running
 			return ErrAlreadyRunning
 		}
-		// Zombie - tmux alive but Claude dead. Kill and recreate.
-		_, _ = fmt.Fprintln(m.output, "⚠ Detected zombie session (tmux alive, Claude dead). Recreating...")
+		// Zombie - tmux alive but agent dead. Kill and recreate.
+		_, _ = fmt.Fprintln(m.output, "⚠ Detected zombie session (tmux alive, agent dead). Recreating...")
 		if err := t.KillSession(sessionID); err != nil {
 			return fmt.Errorf("killing zombie session: %w", err)
 		}


### PR DESCRIPTION
## Summary

- Implements role-based agent resolution in `BuildStartupCommand` and related functions
- Fixes the issue where `role_agents` configuration was defined but never used
- Services now correctly use per-role agent assignments from `settings/config.json`

## Problem

The `role_agents` field in `TownSettings` existed but was not being used. All services (refinery, witness, crew, etc.) fell back to the default agent instead of respecting role-specific agent assignments.

## Solution

Modified the startup command builders to:
1. Extract `GT_ROLE` from environment variables
2. Use `ResolveRoleAgentConfig(role, townRoot, rigPath)` for role-based agent selection
3. Fall back to existing resolution when no role is specified

## Files Changed

| File | Change |
|------|--------|
| `internal/config/loader.go` | Added role-based resolution in `BuildStartupCommand` and `BuildStartupCommandWithAgentOverride` |
| `internal/refinery/manager.go` | Use `ResolveRoleAgentConfig("refinery", ...)` for agent checks |
| `internal/cmd/start.go` | Use `ResolveRoleAgentConfig("crew", ...)` for crew agent checks |
| `internal/config/loader_test.go` | Added 3 new test cases for role-based resolution |

## Resolution Priority (Now Working)

1. Explicit `--agent` override
2. Rig's `role_agents[role]`
3. Town's `role_agents[role]`
4. Rig's `agent` setting
5. Town's `default_agent`
6. Hardcoded default fallback

## Test Plan

- [x] `TestBuildStartupCommand_UsesRoleAgentsFromTownSettings` - verifies town-level role_agents
- [x] `TestBuildStartupCommand_RigRoleAgentsOverridesTownRoleAgents` - verifies rig overrides town
- [x] `TestBuildAgentStartupCommand_UsesRoleAgents` - verifies BuildAgentStartupCommand works
- [x] All existing tests pass
- [x] Build succeeds

## Usage Example

\`\`\`json
{
  "type": "town-settings",
  "version": 1,
  "default_agent": "default-agent",
  "role_agents": {
    "deacon": "codex",
    "refinery": "gemini",
    "witness": "gemini",
    "mayor": "default-agent"
  }
}
\`\`\`

Running \`gt up\` will now start each service with its configured agent.