### PR TITLE
fix: prevent gt down --all from respawning bd daemon

### DIFF
--- a/internal/beads/daemon_test.go
+++ b/internal/beads/daemon_test.go
@@ -5,46 +5,6 @@ import (
 	"testing"
 )
 
-func TestParseBdDaemonCount_Array(t *testing.T) {
-	input := []byte(`[{"pid":1234},{"pid":5678}]`)
-	count := parseBdDaemonCount(input)
-	if count != 2 {
-		t.Errorf("expected 2, got %d", count)
-	}
-}
-
-func TestParseBdDaemonCount_ObjectWithCount(t *testing.T) {
-	input := []byte(`{"count":3,"daemons":[{},{},{}]}`)
-	count := parseBdDaemonCount(input)
-	if count != 3 {
-		t.Errorf("expected 3, got %d", count)
-	}
-}
-
-func TestParseBdDaemonCount_ObjectWithDaemons(t *testing.T) {
-	input := []byte(`{"daemons":[{},{}]}`)
-	count := parseBdDaemonCount(input)
-	if count != 2 {
-		t.Errorf("expected 2, got %d", count)
-	}
-}
-
-func TestParseBdDaemonCount_Empty(t *testing.T) {
-	input := []byte(``)
-	count := parseBdDaemonCount(input)
-	if count != 0 {
-		t.Errorf("expected 0, got %d", count)
-	}
-}
-
-func TestParseBdDaemonCount_Invalid(t *testing.T) {
-	input := []byte(`not json`)
-	count := parseBdDaemonCount(input)
-	if count != 0 {
-		t.Errorf("expected 0 for invalid JSON, got %d", count)
-	}
-}
-
 func TestCountBdActivityProcesses(t *testing.T) {
 	count := CountBdActivityProcesses()
 	if count < 0 {


### PR DESCRIPTION
## Summary
Prevent `gt down --all` from respawning bd daemon during shutdown verification.

## Related Issue
N/A (bug discovered during debugging)

## Changes
- Changed `CountBdDaemons()` to use pgrep instead of `bd daemon list --json`
- Removed unused `parseBdDaemonCount` helper function and its tests

## Testing
- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed (`gt down --all` no longer respawns daemon)

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)