### PR TITLE
fix(errors): use errors.As for wrapped error handling

### DIFF
--- a/internal/cmd/errors.go
+++ b/internal/cmd/errors.go
@@ -1,6 +1,9 @@
 package cmd
 
-import "fmt"
+import (
+	"errors"
+	"fmt"
+)
 
 // SilentExitError signals that the command should exit with a specific code
 // without printing an error message. This is used for scripting purposes
@@ -19,12 +22,14 @@ func NewSilentExit(code int) *SilentExitError {
 }
 
 // IsSilentExit checks if an error is a SilentExitError and returns its code.
+// Uses errors.As to properly handle wrapped errors.
 // Returns 0 and false if err is nil or not a SilentExitError.
 func IsSilentExit(err error) (int, bool) {
 	if err == nil {
 		return 0, false
 	}
-	if se, ok := err.(*SilentExitError); ok {
+	var se *SilentExitError
+	if errors.As(err, &se) {
 		return se.Code, true
 	}
 	return 0, false

--- a/internal/cmd/errors_test.go
+++ b/internal/cmd/errors_test.go
@@ -54,9 +54,9 @@ func TestNewSilentExit(t *testing.T) {
 
 func TestIsSilentExit(t *testing.T) {
 	tests := []struct {
-		name        string
-		err         error
-		wantCode    int
+		name         string
+		err          error
+		wantCode     int
 		wantIsSilent bool
 	}{
 		{"nil error", nil, 0, false},
@@ -64,7 +64,7 @@ func TestIsSilentExit(t *testing.T) {
 		{"silent exit code 1", NewSilentExit(1), 1, true},
 		{"silent exit code 2", NewSilentExit(2), 2, true},
 		{"other error", errors.New("some error"), 0, false},
-		// Note: wrapped errors require errors.As fix - see PR #462
+		{"wrapped silent exit", fmt.Errorf("wrapped: %w", NewSilentExit(5)), 5, true},
 	}
 
 	for _, tt := range tests {
@@ -81,7 +81,6 @@ func TestIsSilentExit(t *testing.T) {
 }
 
 func TestSilentExitError_Is(t *testing.T) {
-	// Test that SilentExitError works with errors.Is
 	err := NewSilentExit(1)
 	var target *SilentExitError
 	if !errors.As(err, &target) {


### PR DESCRIPTION
## Summary

`IsSilentExit()` uses a type assertion to detect `SilentExitError`, which fails when the error is wrapped (e.g., via `fmt.Errorf("%w", err)`).

## Problem

```go
// This works:
err := NewSilentExit(1)
IsSilentExit(err) // returns 1, true

// This fails (returns 0, false):
wrapped := fmt.Errorf("context: %w", NewSilentExit(1))
IsSilentExit(wrapped) // returns 0, false ← BUG
```

## Solution

Use `errors.As()` instead of type assertion to properly unwrap error chains.

## Changes

- `internal/cmd/errors.go` - Use `errors.As()` in `IsSilentExit()`

## Test Plan

- [x] Build passes
- [x] `go test ./internal/cmd/...` passes