### PR TITLE
fix: add --allow-stale to --no-daemon reads for resilience

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -129,8 +129,10 @@ func NewWithBeadsDir(workDir, beadsDir string) *Beads {
 // run executes a bd command and returns stdout.
 func (b *Beads) run(args ...string) ([]byte, error) {
 	// Use --no-daemon for faster read operations (avoids daemon IPC overhead)
-	// The daemon is primarily useful for write coalescing, not reads
-	fullArgs := append([]string{"--no-daemon"}, args...)
+	// The daemon is primarily useful for write coalescing, not reads.
+	// Use --allow-stale to prevent failures when db is out of sync with JSONL
+	// (e.g., after daemon is killed during shutdown before syncing).
+	fullArgs := append([]string{"--no-daemon", "--allow-stale"}, args...)
 	cmd := exec.Command("bd", fullArgs...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Dir = b.workDir
 


### PR DESCRIPTION
## Summary
Add `--allow-stale` flag to `--no-daemon` reads in beads.go to prevent failures when database is out of sync with JSONL.

## Related Issue
Related to shutdown reliability improvements (complements PR #457, #460)

## Changes
- Added `--allow-stale` to the `run()` function in `internal/beads/beads.go`

## Testing
- [x] Unit tests pass (`go test ./internal/beads/...`)
- [x] Manual testing: witnesses now start successfully after `gt down --all` without needing `bd sync`

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)