### PR TITLE
fix(lint): remove unused error return from buildCVSummary

### DIFF
--- a/internal/cmd/polecat_identity.go
+++ b/internal/cmd/polecat_identity.go
@@ -407,11 +407,7 @@ func runPolecatIdentityShow(cmd *cobra.Command, args []string) error {
 	sessionRunning, _ := polecatMgr.IsRunning(polecatName)
 
 	// Build CV summary with enhanced analytics
-	cv, err := buildCVSummary(r.Path, rigName, polecatName, beadID, clonePath)
-	if err != nil {
-		// Continue without CV if there's an error
-		cv = &CVSummary{Identity: beadID}
-	}
+	cv := buildCVSummary(r.Path, rigName, polecatName, beadID, clonePath)
 
 	// JSON output - include both identity details and CV
 	if polecatIdentityShowJSON {
@@ -707,7 +703,8 @@ func runPolecatIdentityRemove(cmd *cobra.Command, args []string) error {
 }
 
 // buildCVSummary constructs the CV summary for a polecat.
-func buildCVSummary(rigPath, rigName, polecatName, identityBeadID, clonePath string) (*CVSummary, error) {
+// Returns a partial CV on errors rather than failing - CV data is best-effort.
+func buildCVSummary(rigPath, rigName, polecatName, identityBeadID, clonePath string) *CVSummary {
 	cv := &CVSummary{
 		Identity:   identityBeadID,
 		Languages:  make(map[string]int),
@@ -787,7 +784,7 @@ func buildCVSummary(rigPath, rigName, polecatName, identityBeadID, clonePath str
 		cv.FirstPassRate = float64(cv.IssuesCompleted) / float64(total)
 	}
 
-	return cv, nil
+	return cv
 }
 
 // IssueInfo holds basic issue information for CV queries.


### PR DESCRIPTION
## Summary

The `buildCVSummary` function declares it returns `(*CVSummary, error)` but always returns `nil` for the error, causing golangci-lint to fail on every PR with:

```
buildCVSummary - result 1 (error) is always nil (unparam)
```

This blocks CI for all incoming PRs.

## Problem

The function handles all errors internally by returning partial data rather than propagating failures. This is intentional - CV data is best-effort and shouldn't block identity display. However, the error return signature was misleading and created dead code at the call site.

## Solution

Remove the unused error return:
- Change signature from `(*CVSummary, error)` to `*CVSummary`
- Remove dead error-handling code at caller
- Add comment clarifying the partial-data-on-error behavior

## Changes

- `internal/cmd/polecat_identity.go` - Remove error return, simplify caller

## Test Plan

- [x] Build passes
- [x] `go test ./internal/cmd/... -run Polecat` passes
- [x] golangci-lint should now pass (no longer reports unparam error)