### PR TITLE
fix(prime): add gt done to Session Close Protocol in PRIME.md

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -656,15 +656,16 @@ This is physics, not politeness. Gas Town is a steam engine - you are a piston.
 
 ## Session Close Protocol
 
-Before saying "done":
+Before signaling completion:
 1. git status (check what changed)
 2. git add <files> (stage code changes)
 3. bd sync (commit beads changes)
 4. git commit -m "..." (commit code)
 5. bd sync (commit any new beads changes)
 6. git push (push to remote)
+7. ` + "`gt done`" + ` (submit to merge queue and exit)
 
-**Work is not done until pushed.**
+**Polecats MUST call ` + "`gt done`" + ` - this submits work and exits the session.**
 `
 
 // ProvisionPrimeMD writes the Gas Town PRIME.md file to the specified beads directory.


### PR DESCRIPTION
## Summary
- Added `gt done` as step 7 in the Session Close Protocol in PRIME.md
- Changed "Before saying done" to "Before signaling completion" for clarity
- Added explicit note: "Polecats MUST call `gt done` - this submits work and exits the session."

## Problem
Polecats were not calling `gt done` after completing work because the compact PRIME.md context (used after context compaction or when the SessionStart hook is the only context) was missing this critical step.

The Session Close Protocol listed steps 1-6 (git status, add, bd sync, commit, bd sync, push) but omitted step 7 (`gt done`), which:
- Submits work to the merge queue
- Exits the polecat session
- Allows the witness to spawn new polecats for remaining work

Without `gt done`, polecats would push code and announce "done" verbally but remain idle in their sessions, blocking the workflow cascade.

## Test plan
- [ ] Spawn a polecat with work
- [ ] Verify polecat receives the updated PRIME.md content via `bd prime`
- [ ] Verify polecat calls `gt done` when completing work
- [ ] Verify witness spawns new polecats for subsequent phases

🤖 Generated with [Claude Code](https://claude.com/claude-code)