### PR TITLE
docs(templates): add bd show instruction to help agents view hooked work

### DIFF
--- a/internal/templates/roles/crew.md.tmpl
+++ b/internal/templates/roles/crew.md.tmpl
@@ -193,6 +193,7 @@ Unlike polecats, you're human-managed. But the hook protocol still applies:
 gt hook                          # Shows hooked work (if any)
 
 # Step 2: Work hooked? → RUN IT
+bd show <bead-id>                # View work details (title, description, steps)
 # Hook empty? → Check mail for attached work
 gt mail inbox
 # If mail contains attached work, hook it:

--- a/internal/templates/roles/deacon.md.tmpl
+++ b/internal/templates/roles/deacon.md.tmpl
@@ -130,6 +130,7 @@ There is no decision logic. Check your hook, execute what's there:
 gt hook                          # Shows hooked work (if any)
 
 # Step 2: Work hooked? → RUN IT
+bd show <bead-id>                # View work details (title, description, steps)
 # Hook empty? → Check mail for attached work
 gt mail inbox
 # If mail contains attached work, hook it:

--- a/internal/templates/roles/mayor.md.tmpl
+++ b/internal/templates/roles/mayor.md.tmpl
@@ -241,6 +241,7 @@ Like crew, you're human-managed. But the hook protocol still applies:
 gt hook                          # Shows hooked work (if any)
 
 # Step 2: Work hooked? → RUN IT
+bd show <bead-id>                # View work details (title, description, steps)
 # Hook empty? → Check mail for attached work
 gt mail inbox
 # If mail contains attached work, hook it:

--- a/internal/templates/roles/polecat.md.tmpl
+++ b/internal/templates/roles/polecat.md.tmpl
@@ -180,6 +180,7 @@ There is no decision logic. Check your hook, execute what's there:
 gt hook                          # Shows hooked work (if any)
 
 # Step 2: Work hooked? → RUN IT
+bd show <bead-id>                # View work details (title, description, steps)
 # Hook empty? → Check mail for attached work
 gt mail inbox
 # If mail contains attached work, hook it:

--- a/internal/templates/roles/witness.md.tmpl
+++ b/internal/templates/roles/witness.md.tmpl
@@ -162,6 +162,7 @@ There is no decision logic. No "should I?" questions. Check your hook, execute:
 gt hook                          # Shows hooked work (if any)
 
 # Step 2: Work hooked? → RUN IT
+bd show <bead-id>                # View work details (title, description, steps)
 # Execute the mol steps one by one. Each step tells you exactly what to do.
 
 # Step 3: Hook empty? Check mail for attached work


### PR DESCRIPTION
## Summary

Add `bd show <bead-id>` instruction to all role templates so agents know how to view details of their hooked work assignment. Previously, agents would try various commands before finding `bd show`, wasting context.

## Related Issue

On every hooked work item the agent had to spend a cycles failing commands to understand how to show the hooked bead

## Changes

- Add `bd show <bead-id>` line under "Step 2: Work hooked?" in polecat.md.tmpl
- Add `bd show <bead-id>` line under "Step 2: Work hooked?" in crew.md.tmpl
- Add `bd show <bead-id>` line under "Step 2: Work hooked?" in mayor.md.tmpl
- Add `bd show <bead-id>` line under "Step 2: Work hooked?" in deacon.md.tmpl
- Add `bd show <bead-id>` line under "Step 2: Work hooked?" in witness.md.tmpl

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)
