### PR TITLE
docs: fix incorrect mail command in documentation

### DIFF
--- a/docs/design/mail-protocol.md
+++ b/docs/design/mail-protocol.md
@@ -330,7 +330,7 @@ gt mail inbox
 gt mail read <msg-id>
 
 # Mark as read
-gt mail ack <msg-id>
+gt mail mark-read <msg-id>
 ```
 
 ### In Patrol Formulas


### PR DESCRIPTION
## Summary
Fix documentation that references a non-existent `gt mail ack` command. The correct command is `gt mail mark-read`.

## Related Issue
Fixes gt-lzf3.6
Agents read docs to understand expected behavior

## Changes
- Replace `gt mail ack <msg-id>` with `gt mail mark-read <msg-id>` in docs/design/mail-protocol.md

## Testing
- [x] Build passes (`go build ./...`)
- [x] Documentation change only - no code affected

## Checklist
- [x] Code follows project style
- [x] Documentation updated (this PR)
- [x] No breaking changes
