### PR TITLE
fix(docs): remove non-existent gt patrol from CLAUDE.md template

### DIFF
--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -338,7 +338,6 @@ Full context is injected by ` + "`gt prime`" + ` at session start.
 
 - Check mail: ` + "`gt mail inbox`" + `
 - Check rigs: ` + "`gt rig list`" + `
-- Start patrol: ` + "`gt patrol start`" + `
 `
 	claudePath := filepath.Join(mayorDir, "CLAUDE.md")
 	return os.WriteFile(claudePath, []byte(bootstrap), 0644)


### PR DESCRIPTION
## Summary

Remove non-existent `gt patrol start` command from Mayor's CLAUDE.md bootstrap template.

## Related Issue

None - discovered during mayor session startup.

## Changes

- The `gt patrol` command does not exist; the Deacon runs patrol on the Mayor's behalf

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed
  - Verified `gt patrol` returns "unknown command"

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)
