### PR TITLE
fix(done): use KillSessionWithProcesses to prevent orphaned Claude processes

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -15,6 +14,7 @@ import (
 	"github.com/steveyegge/gastown/internal/polecat"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/style"
+	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/townlog"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
@@ -718,11 +718,12 @@ func selfKillSession(townRoot string, roleInfo RoleInfo) error {
 	_ = events.LogFeed(events.TypeSessionDeath, agentID,
 		events.SessionDeathPayload(sessionName, agentID, "self-clean: done means gone", "gt done"))
 
-	// Kill our own tmux session
-	// This will terminate Claude and the shell, completing the self-cleaning cycle.
-	// We use exec.Command instead of the tmux package to avoid import cycles.
-	cmd := exec.Command("tmux", "kill-session", "-t", sessionName) //nolint:gosec // G204: sessionName is derived from env vars, not user input
-	if err := cmd.Run(); err != nil {
+	// Kill our own tmux session with proper process cleanup
+	// This will terminate Claude and all child processes, then kill the session.
+	// KillSessionWithProcesses recursively kills all descendants (deepest first)
+	// to prevent orphaned processes that ignore SIGHUP.
+	t := tmux.NewTmux()
+	if err := t.KillSessionWithProcesses(sessionName); err != nil {
 		return fmt.Errorf("killing session %s: %w", sessionName, err)
 	}
 


### PR DESCRIPTION
## Summary
Fix orphaned Claude processes after `gt done` by using proper process tree cleanup.

## Related Issue
Follow-up to f32a63e (feat: complete self-cleaning by killing tmux session) and 1043f00d (fix: kill entire process tree)

## Changes
- Replace `exec.Command("tmux", "kill-session")` with `tmux.KillSessionWithProcesses()`
- The original code only sent SIGHUP, which Claude ignores, causing orphaned processes
- `KillSessionWithProcesses` properly:
  1. Recursively finds all descendant processes via `pgrep -P`
  2. Sends SIGTERM (deepest first to avoid orphaning grandchildren)
  3. Waits 100ms for graceful shutdown  
  4. Sends SIGKILL to survivors
  5. Then kills the tmux session
- The original comment about "import cycles" was incorrect - many cmd files already import tmux

## Testing
- [x] Build passes (`go build -o gt ./cmd/gt`)
- [x] Unit tests pass for done command (`go test ./internal/cmd/... -run Done`)
- [ ] Manual testing: verify no orphaned claude processes after `gt done`

## Checklist
- [x] Code follows project style
- [ ] Documentation updated (if applicable) - no documentation changes needed
- [x] No breaking changes (or documented in summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)