### PR TITLE
feat: add gt diagnose command and new doctor checks

### DIFF
--- a/internal/cmd/diagnose.go
+++ b/internal/cmd/diagnose.go
@@ -1,0 +1,104 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/doctor"
+	"github.com/steveyegge/gastown/internal/workspace"
+)
+
+var (
+	diagnoseFix     bool
+	diagnoseVerbose bool
+	diagnoseRig     string
+)
+
+var diagnoseCmd = &cobra.Command{
+	Use:     "diagnose",
+	GroupID: GroupDiag,
+	Short:   "Run focused diagnostics on key system components",
+	Long: `Run focused diagnostic checks on key Gas Town components.
+
+This is a lighter-weight alternative to 'gt doctor' that focuses on
+common issues that affect day-to-day operation:
+
+Runtime checks:
+  - runtime-state      Verify .runtime/*.json files are valid
+  - namepool-health    Detect stale namepool entries
+  - sync-parity        Check if clones are in sync with remote
+
+With --rig flag:
+  - sparse-checkout    Verify sparse checkout configuration
+  - rig-structure      Verify rig directory structure
+  - crew-state         Validate crew worker state
+
+Use --fix to attempt automatic fixes:
+  - Reset corrupted runtime state files
+  - Prune stale namepool entries
+
+For comprehensive diagnostics, use 'gt doctor' instead.
+
+Examples:
+  gt diagnose              # Quick health check
+  gt diagnose --fix        # Auto-fix common issues
+  gt diagnose --rig pai    # Check specific rig
+  gt diagnose -v           # Verbose output`,
+	RunE: runDiagnose,
+}
+
+func init() {
+	diagnoseCmd.Flags().BoolVar(&diagnoseFix, "fix", false, "Attempt to automatically fix issues")
+	diagnoseCmd.Flags().BoolVarP(&diagnoseVerbose, "verbose", "v", false, "Show detailed output")
+	diagnoseCmd.Flags().StringVar(&diagnoseRig, "rig", "", "Check specific rig")
+	rootCmd.AddCommand(diagnoseCmd)
+}
+
+func runDiagnose(cmd *cobra.Command, args []string) error {
+	// Find town root
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("not in a Gas Town workspace: %w", err)
+	}
+
+	// Create check context
+	ctx := &doctor.CheckContext{
+		TownRoot: townRoot,
+		RigName:  diagnoseRig,
+		Verbose:  diagnoseVerbose,
+	}
+
+	// Create doctor and register focused checks
+	d := doctor.NewDoctor()
+
+	// Always run these core checks
+	d.Register(doctor.NewRuntimeStateCheck())
+	d.Register(doctor.NewNamepoolHealthCheck())
+	d.Register(doctor.NewCloneDivergenceCheck())
+	d.Register(doctor.NewDaemonCheck())
+
+	// Rig-specific checks (lighter than full rig checks)
+	if diagnoseRig != "" {
+		d.Register(doctor.NewSparseCheckoutCheck())
+		d.Register(doctor.NewCrewStateCheck())
+	}
+
+	// Run checks
+	var report *doctor.Report
+	if diagnoseFix {
+		report = d.Fix(ctx)
+	} else {
+		report = d.Run(ctx)
+	}
+
+	// Print report
+	report.Print(os.Stdout, diagnoseVerbose)
+
+	// Exit with error code if there are errors
+	if report.HasErrors() {
+		return fmt.Errorf("diagnose found %d error(s)", report.Summary.Errors)
+	}
+
+	return nil
+}

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -40,6 +40,8 @@ Town root protection:
 Infrastructure checks:
   - stale-binary             Check if gt binary is up to date with repo
   - daemon                   Check if daemon is running (fixable)
+  - runtime-state            Verify .runtime/*.json files are valid (fixable)
+  - namepool-health          Detect stale namepool entries (fixable)
   - repo-fingerprint         Check database has valid repo fingerprint (fixable)
   - boot-health              Check Boot watchdog health (vet mode)
 
@@ -122,6 +124,8 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewTownRootBranchCheck())
 	d.Register(doctor.NewPreCheckoutHookCheck())
 	d.Register(doctor.NewDaemonCheck())
+	d.Register(doctor.NewRuntimeStateCheck())
+	d.Register(doctor.NewNamepoolHealthCheck())
 	d.Register(doctor.NewRepoFingerprintCheck())
 	d.Register(doctor.NewBootHealthCheck())
 	d.Register(doctor.NewBeadsDatabaseCheck())

--- a/internal/cmd/mail_queue.go
+++ b/internal/cmd/mail_queue.go
@@ -35,7 +35,7 @@ func runMailClaim(cmd *cobra.Command, args []string) error {
 	}
 
 	queueCfg, ok := cfg.Queues[queueName]
-	if !ok || queueCfg == nil {
+	if !ok {
 		return fmt.Errorf("unknown queue: %s", queueName)
 	}
 

--- a/internal/doctor/namepool_health_check.go
+++ b/internal/doctor/namepool_health_check.go
@@ -1,0 +1,181 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+// NamepoolHealthCheck verifies namepool state consistency and detects stale entries.
+// The namepool tracks which polecat names are in use, but can become inconsistent
+// if polecats are terminated abnormally (crashes, manual kills).
+type NamepoolHealthCheck struct {
+	FixableCheck
+	staleEntries map[string][]string // rigPath -> stale polecat names
+	townRoot     string
+}
+
+// NewNamepoolHealthCheck creates a new namepool health check.
+func NewNamepoolHealthCheck() *NamepoolHealthCheck {
+	return &NamepoolHealthCheck{
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "namepool-health",
+				CheckDescription: "Verify namepool consistency and detect stale entries",
+				CheckCategory:    CategoryInfrastructure,
+			},
+		},
+	}
+}
+
+// namepoolState represents the structure of namepool-state.json
+type namepoolState struct {
+	RigName      string          `json:"rig_name"`
+	Theme        string          `json:"theme"`
+	InUse        map[string]bool `json:"in_use"`
+	OverflowNext int             `json:"overflow_next"`
+	MaxSize      int             `json:"max_size"`
+}
+
+// Run checks namepool consistency across all rigs.
+func (c *NamepoolHealthCheck) Run(ctx *CheckContext) *CheckResult {
+	c.townRoot = ctx.TownRoot
+	c.staleEntries = make(map[string][]string)
+
+	// Load rigs from registry
+	rigsPath := filepath.Join(ctx.TownRoot, "mayor", "rigs.json")
+	rigsData, err := os.ReadFile(rigsPath)
+	if err != nil {
+		// No rigs registered, nothing to check
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "No rigs registered",
+		}
+	}
+
+	var rigs map[string]interface{}
+	if err := json.Unmarshal(rigsData, &rigs); err != nil {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: "Failed to parse rigs registry",
+			Details: []string{err.Error()},
+		}
+	}
+
+	for rigName := range rigs {
+		rigPath := filepath.Join(ctx.TownRoot, rigName)
+		c.checkRigNamepool(rigPath, rigName)
+	}
+
+	if len(c.staleEntries) == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "All namepool entries are valid",
+		}
+	}
+
+	// Build summary
+	var details []string
+	totalStale := 0
+	for rigPath, names := range c.staleEntries {
+		rel, _ := filepath.Rel(ctx.TownRoot, rigPath)
+		if rel == "" {
+			rel = rigPath
+		}
+		details = append(details, fmt.Sprintf("%s: %s", rel, strings.Join(names, ", ")))
+		totalStale += len(names)
+	}
+	sort.Strings(details)
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusWarning,
+		Message: fmt.Sprintf("%d stale namepool entry(s) found (polecats that no longer exist)", totalStale),
+		Details: details,
+		FixHint: "Run 'gt doctor --fix' to prune stale entries",
+	}
+}
+
+// checkRigNamepool checks a single rig's namepool for stale entries.
+func (c *NamepoolHealthCheck) checkRigNamepool(rigPath, rigName string) {
+	statePath := filepath.Join(rigPath, ".runtime", "namepool-state.json")
+	data, err := os.ReadFile(statePath)
+	if err != nil {
+		return // No namepool state, nothing to check
+	}
+
+	var state namepoolState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return // Invalid JSON, handled by runtime_state_check
+	}
+
+	if len(state.InUse) == 0 {
+		return // Nothing in use
+	}
+
+	// Get actual polecat directories
+	polecatsDir := filepath.Join(rigPath, "polecats")
+	actualPolecats := make(map[string]bool)
+
+	entries, err := os.ReadDir(polecatsDir)
+	if err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() {
+				actualPolecats[entry.Name()] = true
+			}
+		}
+	}
+
+	// Find entries marked as in-use but no matching polecat directory exists
+	var stale []string
+	for name, inUse := range state.InUse {
+		if inUse && !actualPolecats[name] {
+			stale = append(stale, name)
+		}
+	}
+
+	if len(stale) > 0 {
+		sort.Strings(stale)
+		c.staleEntries[rigPath] = stale
+	}
+}
+
+// Fix prunes stale entries from namepool state files.
+func (c *NamepoolHealthCheck) Fix(ctx *CheckContext) error {
+	for rigPath, staleNames := range c.staleEntries {
+		statePath := filepath.Join(rigPath, ".runtime", "namepool-state.json")
+		data, err := os.ReadFile(statePath)
+		if err != nil {
+			continue
+		}
+
+		var state namepoolState
+		if err := json.Unmarshal(data, &state); err != nil {
+			continue
+		}
+
+		// Remove stale entries
+		for _, name := range staleNames {
+			delete(state.InUse, name)
+		}
+
+		// Write back
+		newData, err := json.MarshalIndent(state, "", "  ")
+		if err != nil {
+			rel, _ := filepath.Rel(ctx.TownRoot, rigPath)
+			return fmt.Errorf("failed to marshal namepool state for %s: %w", rel, err)
+		}
+
+		if err := os.WriteFile(statePath, newData, 0644); err != nil {
+			rel, _ := filepath.Rel(ctx.TownRoot, rigPath)
+			return fmt.Errorf("failed to write namepool state for %s: %w", rel, err)
+		}
+	}
+	return nil
+}

--- a/internal/doctor/namepool_health_check_test.go
+++ b/internal/doctor/namepool_health_check_test.go
@@ -1,0 +1,207 @@
+package doctor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNamepoolHealthCheck_NoRigs(t *testing.T) {
+	t.Parallel()
+
+	// Create temp workspace without rigs.json
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewNamepoolHealthCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK with no rigs, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestNamepoolHealthCheck_NoNamepool(t *testing.T) {
+	t.Parallel()
+
+	townRoot := setupTestWorkspace(t, "test-rig")
+
+	check := NewNamepoolHealthCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK with no namepool, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestNamepoolHealthCheck_ConsistentNamepool(t *testing.T) {
+	t.Parallel()
+
+	townRoot := setupTestWorkspace(t, "test-rig")
+
+	// Create a polecat directory
+	polecatsDir := filepath.Join(townRoot, "test-rig", "polecats")
+	if err := os.MkdirAll(filepath.Join(polecatsDir, "furiosa"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create namepool state with furiosa in use
+	runtimeDir := filepath.Join(townRoot, "test-rig", ".runtime")
+	if err := os.MkdirAll(runtimeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	state := namepoolState{
+		RigName:      "test-rig",
+		Theme:        "mad-max",
+		InUse:        map[string]bool{"furiosa": true},
+		OverflowNext: 51,
+		MaxSize:      50,
+	}
+	data, _ := json.MarshalIndent(state, "", "  ")
+	if err := os.WriteFile(filepath.Join(runtimeDir, "namepool-state.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewNamepoolHealthCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK for consistent namepool, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestNamepoolHealthCheck_StaleEntry(t *testing.T) {
+	t.Parallel()
+
+	townRoot := setupTestWorkspace(t, "test-rig")
+
+	// Create polecats directory (no polecat inside)
+	polecatsDir := filepath.Join(townRoot, "test-rig", "polecats")
+	if err := os.MkdirAll(polecatsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create namepool state with ghost entry
+	runtimeDir := filepath.Join(townRoot, "test-rig", ".runtime")
+	if err := os.MkdirAll(runtimeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	state := namepoolState{
+		RigName:      "test-rig",
+		Theme:        "mad-max",
+		InUse:        map[string]bool{"ghost": true}, // No matching directory
+		OverflowNext: 51,
+		MaxSize:      50,
+	}
+	data, _ := json.MarshalIndent(state, "", "  ")
+	if err := os.WriteFile(filepath.Join(runtimeDir, "namepool-state.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewNamepoolHealthCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+	result := check.Run(ctx)
+
+	if result.Status == StatusOK {
+		t.Error("expected non-OK status for stale namepool entry")
+	}
+	if len(check.staleEntries) != 1 {
+		t.Errorf("expected 1 rig with stale entries, got %d", len(check.staleEntries))
+	}
+}
+
+func TestNamepoolHealthCheck_Fix(t *testing.T) {
+	t.Parallel()
+
+	townRoot := setupTestWorkspace(t, "test-rig")
+	rigPath := filepath.Join(townRoot, "test-rig")
+
+	// Create polecats directory
+	if err := os.MkdirAll(filepath.Join(rigPath, "polecats"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create namepool state with stale entry
+	runtimeDir := filepath.Join(rigPath, ".runtime")
+	if err := os.MkdirAll(runtimeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	statePath := filepath.Join(runtimeDir, "namepool-state.json")
+	state := namepoolState{
+		RigName:      "test-rig",
+		Theme:        "mad-max",
+		InUse:        map[string]bool{"ghost": true, "furiosa": true}, // ghost is stale
+		OverflowNext: 51,
+		MaxSize:      50,
+	}
+	data, _ := json.MarshalIndent(state, "", "  ")
+	if err := os.WriteFile(statePath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Only create furiosa polecat
+	if err := os.MkdirAll(filepath.Join(rigPath, "polecats", "furiosa"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewNamepoolHealthCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+
+	// Run to detect
+	_ = check.Run(ctx)
+
+	// Fix
+	if err := check.Fix(ctx); err != nil {
+		t.Errorf("Fix failed: %v", err)
+	}
+
+	// Read back and verify ghost is gone
+	data, _ = os.ReadFile(statePath)
+	var newState namepoolState
+	_ = json.Unmarshal(data, &newState)
+
+	if newState.InUse["ghost"] {
+		t.Error("Fix did not remove ghost entry")
+	}
+	if !newState.InUse["furiosa"] {
+		t.Error("Fix incorrectly removed valid furiosa entry")
+	}
+}
+
+// setupTestWorkspace creates a minimal workspace with a rig
+func setupTestWorkspace(t *testing.T, rigName string) string {
+	t.Helper()
+
+	townRoot := t.TempDir()
+
+	// Create mayor directory with rigs.json
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	rigs := map[string]interface{}{
+		rigName: map[string]interface{}{},
+	}
+	data, _ := json.MarshalIndent(rigs, "", "  ")
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create rig directory
+	rigPath := filepath.Join(townRoot, rigName)
+	if err := os.MkdirAll(rigPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	return townRoot
+}

--- a/internal/doctor/runtime_state_check.go
+++ b/internal/doctor/runtime_state_check.go
@@ -1,0 +1,151 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RuntimeStateCheck verifies the validity of .runtime/*.json files.
+// These files contain transient state for agents (witness, refinery, namepool, etc.)
+// and can become corrupted or stale after crashes.
+type RuntimeStateCheck struct {
+	FixableCheck
+	invalidFiles []string // files that failed validation
+	townRoot     string
+}
+
+// NewRuntimeStateCheck creates a new runtime state check.
+func NewRuntimeStateCheck() *RuntimeStateCheck {
+	return &RuntimeStateCheck{
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "runtime-state",
+				CheckDescription: "Verify .runtime/*.json files are valid and not corrupted",
+				CheckCategory:    CategoryInfrastructure,
+			},
+		},
+	}
+}
+
+// Run checks if all runtime state files are valid JSON.
+func (c *RuntimeStateCheck) Run(ctx *CheckContext) *CheckResult {
+	c.townRoot = ctx.TownRoot
+	c.invalidFiles = nil
+
+	// Check town-level runtime
+	c.checkRuntimeDir(ctx.TownRoot)
+
+	// Check each rig's runtime directories
+	rigsPath := filepath.Join(ctx.TownRoot, "mayor", "rigs.json")
+	rigsData, err := os.ReadFile(rigsPath)
+	if err == nil {
+		var rigs map[string]interface{}
+		if json.Unmarshal(rigsData, &rigs) == nil {
+			for rigName := range rigs {
+				rigPath := filepath.Join(ctx.TownRoot, rigName)
+				c.checkRuntimeDir(rigPath)
+
+				// Check witness runtime
+				witnessRuntimePath := filepath.Join(rigPath, "witness", ".runtime")
+				c.checkRuntimeDir(witnessRuntimePath)
+
+				// Check refinery runtime
+				refineryRuntimePath := filepath.Join(rigPath, "refinery", "rig", ".runtime")
+				c.checkRuntimeDir(refineryRuntimePath)
+
+				// Check crew runtimes
+				crewDir := filepath.Join(rigPath, "crew")
+				if entries, err := os.ReadDir(crewDir); err == nil {
+					for _, entry := range entries {
+						if entry.IsDir() {
+							c.checkRuntimeDir(filepath.Join(crewDir, entry.Name(), ".runtime"))
+						}
+					}
+				}
+			}
+		}
+	}
+
+	if len(c.invalidFiles) == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "All runtime state files are valid",
+		}
+	}
+
+	// Build relative paths for display
+	var details []string
+	for _, f := range c.invalidFiles {
+		rel, _ := filepath.Rel(ctx.TownRoot, f)
+		if rel == "" {
+			rel = f
+		}
+		details = append(details, rel)
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusWarning,
+		Message: fmt.Sprintf("%d runtime state file(s) are invalid or corrupted", len(c.invalidFiles)),
+		Details: details,
+		FixHint: "Run 'gt doctor --fix' to reset invalid runtime state files",
+	}
+}
+
+// checkRuntimeDir checks all JSON files in a .runtime directory.
+func (c *RuntimeStateCheck) checkRuntimeDir(basePath string) {
+	runtimePath := basePath
+	if !strings.HasSuffix(basePath, ".runtime") {
+		runtimePath = filepath.Join(basePath, ".runtime")
+	}
+
+	entries, err := os.ReadDir(runtimePath)
+	if err != nil {
+		return // Directory doesn't exist or not accessible
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".json") {
+			continue
+		}
+
+		filePath := filepath.Join(runtimePath, entry.Name())
+		if !c.isValidJSONFile(filePath) {
+			c.invalidFiles = append(c.invalidFiles, filePath)
+		}
+	}
+}
+
+// isValidJSONFile checks if a file contains valid JSON.
+func (c *RuntimeStateCheck) isValidJSONFile(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+
+	// Empty file is invalid
+	if len(data) == 0 {
+		return false
+	}
+
+	// Try to parse as JSON
+	var obj interface{}
+	return json.Unmarshal(data, &obj) == nil
+}
+
+// Fix removes invalid runtime state files.
+// This is safe because runtime state is transient and will be regenerated
+// when the relevant service starts.
+func (c *RuntimeStateCheck) Fix(ctx *CheckContext) error {
+	for _, f := range c.invalidFiles {
+		if err := os.Remove(f); err != nil && !os.IsNotExist(err) {
+			rel, _ := filepath.Rel(ctx.TownRoot, f)
+			return fmt.Errorf("failed to remove %s: %w", rel, err)
+		}
+	}
+	return nil
+}

--- a/internal/doctor/runtime_state_check_test.go
+++ b/internal/doctor/runtime_state_check_test.go
@@ -1,0 +1,133 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRuntimeStateCheck_ValidJSON(t *testing.T) {
+	t.Parallel()
+
+	// Create temp workspace
+	townRoot := t.TempDir()
+	runtimeDir := filepath.Join(townRoot, ".runtime")
+	if err := os.MkdirAll(runtimeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create valid JSON file
+	validJSON := `{"state": "running", "pid": 12345}`
+	if err := os.WriteFile(filepath.Join(runtimeDir, "daemon.json"), []byte(validJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewRuntimeStateCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK for valid JSON, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestRuntimeStateCheck_InvalidJSON(t *testing.T) {
+	t.Parallel()
+
+	// Create temp workspace
+	townRoot := t.TempDir()
+	runtimeDir := filepath.Join(townRoot, ".runtime")
+	if err := os.MkdirAll(runtimeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create invalid JSON file
+	invalidJSON := `{invalid json`
+	if err := os.WriteFile(filepath.Join(runtimeDir, "broken.json"), []byte(invalidJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewRuntimeStateCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+	result := check.Run(ctx)
+
+	if result.Status == StatusOK {
+		t.Error("expected non-OK status for invalid JSON")
+	}
+	if len(check.invalidFiles) != 1 {
+		t.Errorf("expected 1 invalid file, got %d", len(check.invalidFiles))
+	}
+}
+
+func TestRuntimeStateCheck_EmptyFile(t *testing.T) {
+	t.Parallel()
+
+	// Create temp workspace
+	townRoot := t.TempDir()
+	runtimeDir := filepath.Join(townRoot, ".runtime")
+	if err := os.MkdirAll(runtimeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create empty JSON file
+	if err := os.WriteFile(filepath.Join(runtimeDir, "empty.json"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewRuntimeStateCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+	result := check.Run(ctx)
+
+	if result.Status == StatusOK {
+		t.Error("expected non-OK status for empty JSON file")
+	}
+}
+
+func TestRuntimeStateCheck_Fix(t *testing.T) {
+	t.Parallel()
+
+	// Create temp workspace
+	townRoot := t.TempDir()
+	runtimeDir := filepath.Join(townRoot, ".runtime")
+	if err := os.MkdirAll(runtimeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create invalid JSON file
+	brokenFile := filepath.Join(runtimeDir, "broken.json")
+	if err := os.WriteFile(brokenFile, []byte(`{invalid`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewRuntimeStateCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+
+	// Run first to detect the issue
+	_ = check.Run(ctx)
+
+	// Fix should remove the file
+	if err := check.Fix(ctx); err != nil {
+		t.Errorf("Fix failed: %v", err)
+	}
+
+	// File should be gone
+	if _, err := os.Stat(brokenFile); !os.IsNotExist(err) {
+		t.Error("Fix did not remove invalid file")
+	}
+}
+
+func TestRuntimeStateCheck_NoRuntimeDir(t *testing.T) {
+	t.Parallel()
+
+	// Create temp workspace without .runtime
+	townRoot := t.TempDir()
+
+	check := NewRuntimeStateCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+	result := check.Run(ctx)
+
+	// Should pass when no .runtime directory exists
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when no .runtime dir, got %v", result.Status)
+	}
+}


### PR DESCRIPTION
## Summary

- Add focused `gt diagnose` command for common issues (lighter-weight alternative to `gt doctor`)
- Add new doctor checks: `runtime-state` and `namepool-health` (both fixable)
- Fix compile error in mail_queue.go (QueueConfig nil check on struct type)

## New Command: `gt diagnose`

```bash
gt diagnose              # Quick health check
gt diagnose --fix        # Auto-fix common issues
gt diagnose --rig pai    # Check specific rig
gt diagnose -v           # Verbose output
```

Checks:
- `runtime-state`: Verify .runtime/*.json files are valid JSON
- `namepool-health`: Detect stale namepool entries (polecats that no longer exist)
- `clone-divergence`: Check if clones are in sync with remote
- `daemon`: Check if daemon is running

## New Doctor Checks

### runtime-state (fixable)
Verifies that all `.runtime/*.json` files contain valid JSON. These files can become corrupted after crashes. Fix: removes corrupted files (they regenerate on next service start).

### namepool-health (fixable)
Detects stale namepool entries - names marked as "in use" but no corresponding polecat directory exists. This can happen when polecats are terminated abnormally. Fix: prunes stale entries from namepool state.

## Test plan
- [x] Build succeeds: `go build ./cmd/gt`
- [x] All new tests pass: `go test ./internal/doctor/... -run "RuntimeState|NamepoolHealth"`
- [x] `gt diagnose` runs successfully
- [x] `gt doctor` runs with new checks

🤖 Generated with [Claude Code](https://claude.com/claude-code)