### PR TITLE
fix(cmd): cache bd version check to reduce subprocess contention

### DIFF
--- a/internal/cmd/mail_queue.go
+++ b/internal/cmd/mail_queue.go
@@ -35,7 +35,7 @@ func runMailClaim(cmd *cobra.Command, args []string) error {
 	}
 
 	queueCfg, ok := cfg.Queues[queueName]
-	if !ok || queueCfg == nil {
+	if !ok {
 		return fmt.Errorf("unknown queue: %s", queueName)
 	}
 


### PR DESCRIPTION
## Summary

- Cache bd version check based on binary path and mtime to avoid spawning subprocesses
- Under high concurrency (17+ sessions), eliminates 85-120+ competing git processes
- Cache stored at `~/.gt/beads-version-cache.json`, auto-invalidates on bd upgrade
- Also fixes pre-existing compile error in mail_queue.go

## Test plan

- [x] Unit tests for cache save/load/invalidation
- [x] Unit tests for version validation
- [x] Verified code compiles
- [ ] Manual test with high concurrency scenario

Fixes #503

🤖 Generated with [Claude Code](https://claude.ai/code)