### PR TITLE
fix(mail): remove invalid nil check for value type QueueConfig

### DIFF
--- a/internal/cmd/mail_queue.go
+++ b/internal/cmd/mail_queue.go
@@ -35,7 +35,7 @@ func runMailClaim(cmd *cobra.Command, args []string) error {
 	}
 
 	queueCfg, ok := cfg.Queues[queueName]
-	if !ok || queueCfg == nil {
+	if !ok {
 		return fmt.Errorf("unknown queue: %s", queueName)
 	}
 


### PR DESCRIPTION
## Summary
Fixes #507

`cfg.Queues` is `map[string]QueueConfig` (value type, not pointer). Comparing a struct value to `nil` is invalid in Go, causing build failures:

```
internal/cmd/mail_queue.go:38:24: invalid operation: queueCfg == nil (mismatched types config.QueueConfig and untyped nil)
```

The `!ok` check already handles missing keys, so the nil check is both invalid and redundant.

## Test plan
- [x] `go build ./cmd/gt` succeeds

---
Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>