### PR TITLE
fix(config): add --hook flag to gt prime in SessionStart templates

### DIFF
--- a/internal/claude/config/settings-autonomous.json
+++ b/internal/claude/config/settings-autonomous.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime && gt mail check --inject && gt nudge deacon session-started"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime --hook && gt mail check --inject && gt nudge deacon session-started"
           }
         ]
       }

--- a/internal/claude/config/settings-interactive.json
+++ b/internal/claude/config/settings-interactive.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime && gt nudge deacon session-started"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime --hook && gt nudge deacon session-started"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Add `--hook` flag to `gt prime` commands in SessionStart hook templates
- The flag was added in v0.2.0 (commit e7994d98) but templates were never updated
- This broke `gt seance` which relies on session ID persistence for transcript lookup

## Related
- **See also #510** - Fixes seance to run `claude --resume` from the session's original cwd (both fixes needed for seance to work)

## Test plan
- [x] Verify new sessions persist session ID via `gt prime --hook`
- [x] Verify `gt seance` can find transcripts for recent sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)