### PR TITLE
fix(mail): remove invalid nil check for value type QueueConfig

### DIFF
--- a/internal/cmd/mail_queue.go
+++ b/internal/cmd/mail_queue.go
@@ -35,7 +35,7 @@ func runMailClaim(cmd *cobra.Command, args []string) error {
 	}
 
 	queueCfg, ok := cfg.Queues[queueName]
-	if !ok || queueCfg == nil {
+	if !ok {
 		return fmt.Errorf("unknown queue: %s", queueName)
 	}
 


### PR DESCRIPTION
## Summary
- Removes invalid nil check for `QueueConfig` (a value type struct, not a pointer)
- This was previously fixed in 58820397 but accidentally re-introduced in PR #445

The `!ok` check from the map lookup is sufficient to determine if the queue exists. Value types in Go can never be nil.

## Test plan
- [x] `go vet ./...` passes
- [x] `go build ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)