### PR TITLE
fix(deacon): improve session stability with startup consistency

### DIFF
--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -385,6 +385,11 @@ func startDeaconSession(t *tmux.Tmux, sessionName, agentOverride string) error {
 	if err := t.WaitForCommand(sessionName, constants.SupportedShells, constants.ClaudeStartTimeout); err != nil {
 		return fmt.Errorf("waiting for deacon to start: %w", err)
 	}
+
+	// Accept bypass permissions warning dialog if it appears.
+	// This prevents hangs on systems where Claude prompts for permissions.
+	_ = t.AcceptBypassPermissionsWarning(sessionName)
+
 	time.Sleep(constants.ShutdownNotifyDelay)
 
 	runtimeConfig := config.LoadRuntimeConfig("")
@@ -685,19 +690,24 @@ func runDeaconHealthCheck(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Get current bead update time
-	baselineTime, err := getAgentBeadUpdateTime(townRoot, beadID)
-	if err != nil {
-		// Bead might not exist yet - that's okay
-		baselineTime = time.Time{}
-	}
-
 	// Record ping
 	agentState.RecordPing()
 
 	// Send health check nudge
 	if err := t.NudgeSession(sessionName, "HEALTH_CHECK: respond with any action to confirm responsiveness"); err != nil {
 		return fmt.Errorf("sending nudge: %w", err)
+	}
+
+	// Get baseline time AFTER sending nudge to avoid false positives.
+	// If we get the time before the nudge and the bead doesn't exist (time.Time{}),
+	// any subsequent update would incorrectly appear as a response.
+	// By getting the baseline after the nudge, we ensure we're only detecting
+	// activity that happens in response to our health check.
+	baselineTime, err := getAgentBeadUpdateTime(townRoot, beadID)
+	if err != nil {
+		// Bead might not exist yet - use current time as baseline
+		// This way only updates AFTER this point count as responses
+		baselineTime = time.Now()
 	}
 
 	fmt.Printf("%s Sent HEALTH_CHECK to %s, waiting %s...\n",

--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -10,6 +10,7 @@ import (
 	"github.com/steveyegge/gastown/internal/claude"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
@@ -115,6 +116,11 @@ func (m *Manager) Start(agentOverride string) error {
 	_ = t.AcceptBypassPermissionsWarning(sessionID)
 
 	time.Sleep(constants.ShutdownNotifyDelay)
+
+	// Run startup fallback if Claude failed to start correctly on the first attempt.
+	// This matches the cmd/deacon.go behavior for consistency.
+	runtimeConfig := config.LoadRuntimeConfig("")
+	_ = runtime.RunStartupFallback(t, sessionID, "deacon", runtimeConfig)
 
 	// Inject startup nudge for predecessor discovery via /resume
 	_ = session.StartupNudge(t, sessionID, session.StartupNudgeConfig{


### PR DESCRIPTION
## Summary
- Add AcceptBypassPermissionsWarning to cmd/deacon.go startup path to prevent hangs on systems with permission dialogs
- Add RunStartupFallback to Manager.Start() for consistency with CLI startup path, enabling recovery if Claude fails to start correctly
- Fix health check false positives by getting baseline time AFTER sending the HEALTH_CHECK nudge (zero time baseline would incorrectly detect any bead update as a response)

## Test plan
- [x] Build passes (`go build ./...`)
- [x] Tests pass (`go test ./internal/deacon/...`)
- [ ] Manual testing of deacon startup via CLI (`gt deacon start`)
- [ ] Manual testing of deacon startup via daemon
- [ ] Verify health checks correctly detect stuck agents