### PR TITLE
fix(refinery): implement stale claim timeout to prevent stuck MRs

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -233,6 +233,17 @@ func validateMergeQueueConfig(c *MergeQueueConfig) error {
 		}
 	}
 
+	// Validate stale_claim_timeout if specified
+	if c.StaleClaimTimeout != "" {
+		dur, err := time.ParseDuration(c.StaleClaimTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid stale_claim_timeout: %w", err)
+		}
+		if dur <= 0 {
+			return fmt.Errorf("stale_claim_timeout must be positive, got %v", dur)
+		}
+	}
+
 	// Validate non-negative values
 	if c.RetryFlakyTests < 0 {
 		return fmt.Errorf("%w: retry_flaky_tests must be non-negative", ErrMissingField)

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -339,6 +339,39 @@ func TestRigSettingsValidation(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "invalid stale_claim_timeout",
+			settings: &RigSettings{
+				Type:    "rig-settings",
+				Version: 1,
+				MergeQueue: &MergeQueueConfig{
+					StaleClaimTimeout: "not-a-duration",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "zero stale_claim_timeout",
+			settings: &RigSettings{
+				Type:    "rig-settings",
+				Version: 1,
+				MergeQueue: &MergeQueueConfig{
+					StaleClaimTimeout: "0s",
+				},
+			},
+			wantErr: true,
+		},
+		{
+			name: "negative stale_claim_timeout",
+			settings: &RigSettings{
+				Type:    "rig-settings",
+				Version: 1,
+				MergeQueue: &MergeQueueConfig{
+					StaleClaimTimeout: "-5m",
+				},
+			},
+			wantErr: true,
+		},
 	}
 
 	for _, tt := range tests {
@@ -384,6 +417,9 @@ func TestDefaultMergeQueueConfig(t *testing.T) {
 	}
 	if cfg.MaxConcurrent != 1 {
 		t.Errorf("MaxConcurrent = %d, want 1", cfg.MaxConcurrent)
+	}
+	if cfg.StaleClaimTimeout != "30m" {
+		t.Errorf("StaleClaimTimeout = %q, want '30m'", cfg.StaleClaimTimeout)
 	}
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -869,6 +869,10 @@ type MergeQueueConfig struct {
 
 	// MaxConcurrent is the maximum number of concurrent merges.
 	MaxConcurrent int `json:"max_concurrent"`
+
+	// StaleClaimTimeout is how long a claimed MR can go without updates before
+	// being considered abandoned and eligible for re-claim (e.g., "30m").
+	StaleClaimTimeout string `json:"stale_claim_timeout,omitempty"`
 }
 
 // OnConflict strategy constants.
@@ -941,6 +945,7 @@ func DefaultMergeQueueConfig() *MergeQueueConfig {
 		RetryFlakyTests:                  1,
 		PollInterval:                     "30s",
 		MaxConcurrent:                    1,
+		StaleClaimTimeout:               "30m",
 	}
 }
 

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -24,22 +24,25 @@ import (
 	"github.com/steveyegge/gastown/internal/rig"
 )
 
-// StaleClaimTimeout is how long a claimed MR can sit without updates before
-// being considered abandoned and eligible for re-claim.
-const StaleClaimTimeout = 10 * time.Minute
+// DefaultStaleClaimTimeout is the default duration after which a claimed MR
+// is considered abandoned and eligible for re-claim. This is conservative
+// to avoid re-claiming MRs that are legitimately processing long test suites.
+// Can be overridden per-rig via MergeQueueConfig.StaleClaimTimeout.
+const DefaultStaleClaimTimeout = 30 * time.Minute
 
 // isClaimStale checks if a claimed MR should be considered abandoned based on
-// its UpdatedAt timestamp. Returns true if the claim is stale (eligible for
-// re-claim), false if the claim is recent or the timestamp is invalid/missing.
-func isClaimStale(updatedAt string) bool {
+// its UpdatedAt timestamp and configured timeout. Returns true if the claim
+// is stale (eligible for re-claim), false if the claim is recent or the
+// timestamp is invalid/missing.
+func isClaimStale(updatedAt string, timeout time.Duration) (stale bool, parseErr error) {
 	if updatedAt == "" {
-		return false // No timestamp - assume claim is valid
+		return false, nil // No timestamp - assume claim is valid
 	}
 	t, err := time.Parse(time.RFC3339, updatedAt)
 	if err != nil {
-		return false // Invalid timestamp - assume claim is valid
+		return false, err // Caller should log the parse error
 	}
-	return time.Since(t) >= StaleClaimTimeout
+	return time.Since(t) >= timeout, nil
 }
 
 // MergeQueueConfig holds configuration for the merge queue processor.
@@ -72,6 +75,14 @@ type MergeQueueConfig struct {
 
 	// MaxConcurrent is the maximum number of MRs to process concurrently.
 	MaxConcurrent int `json:"max_concurrent"`
+
+	// StaleClaimTimeout is how long a claimed MR can go without updates before
+	// being considered abandoned and eligible for re-claim. This handles the
+	// case where a refinery crashes mid-merge, leaving an MR permanently claimed.
+	// Set conservatively to avoid re-claiming MRs with long-running test suites.
+	// NOTE: Only one refinery instance runs per rig (enforced by ErrAlreadyRunning
+	// in manager.go), so concurrent re-claim is not a concern in practice.
+	StaleClaimTimeout time.Duration `json:"stale_claim_timeout"`
 }
 
 // DefaultMergeQueueConfig returns sensible defaults for merge queue configuration.
@@ -85,6 +96,7 @@ func DefaultMergeQueueConfig() *MergeQueueConfig {
 		RetryFlakyTests:                  1,
 		PollInterval:                     30 * time.Second,
 		MaxConcurrent:                    1,
+		StaleClaimTimeout:               DefaultStaleClaimTimeout,
 	}
 }
 
@@ -234,6 +246,7 @@ func (e *Engineer) LoadConfig() error {
 		RetryFlakyTests                  *int    `json:"retry_flaky_tests"`
 		PollInterval                     *string `json:"poll_interval"`
 		MaxConcurrent                    *int    `json:"max_concurrent"`
+		StaleClaimTimeout                *string `json:"stale_claim_timeout"`
 	}
 
 	if err := json.Unmarshal(rawConfig.MergeQueue, &mqRaw); err != nil {
@@ -268,6 +281,16 @@ func (e *Engineer) LoadConfig() error {
 			return fmt.Errorf("invalid poll_interval %q: %w", *mqRaw.PollInterval, err)
 		}
 		e.config.PollInterval = dur
+	}
+	if mqRaw.StaleClaimTimeout != nil {
+		dur, err := time.ParseDuration(*mqRaw.StaleClaimTimeout)
+		if err != nil {
+			return fmt.Errorf("invalid stale_claim_timeout %q: %w", *mqRaw.StaleClaimTimeout, err)
+		}
+		if dur <= 0 {
+			return fmt.Errorf("stale_claim_timeout must be positive, got %v", dur)
+		}
+		e.config.StaleClaimTimeout = dur
 	}
 
 	return nil
@@ -951,9 +974,20 @@ func (e *Engineer) ListReadyMRs() ([]*MRInfo, error) {
 			continue // Skip issues without MR fields
 		}
 
-		// Skip if already assigned, unless claim is stale (allows re-claim after crash)
-		if issue.Assignee != "" && !isClaimStale(issue.UpdatedAt) {
-			continue
+		// Skip if already assigned, unless claim is stale (allows re-claim after crash).
+		// NOTE: Only one refinery runs per rig (enforced by ErrAlreadyRunning in
+		// manager.go), so concurrent re-claim race conditions are not a concern.
+		if issue.Assignee != "" {
+			stale, parseErr := isClaimStale(issue.UpdatedAt, e.config.StaleClaimTimeout)
+			if parseErr != nil {
+				_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: could not parse UpdatedAt for %s: %v (treating claim as valid)\n",
+					issue.ID, parseErr)
+			}
+			if !stale {
+				continue
+			}
+			_, _ = fmt.Fprintf(e.output, "[Engineer] Stale claim detected: %s (assignee: %s, updated: %s) — eligible for re-claim\n",
+				issue.ID, issue.Assignee, issue.UpdatedAt)
 		}
 
 		mrs = append(mrs, issueToMRInfo(issue, fields))

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -25,6 +25,9 @@ func TestDefaultMergeQueueConfig(t *testing.T) {
 	if cfg.OnConflict != "assign_back" {
 		t.Errorf("expected OnConflict to be 'assign_back', got %q", cfg.OnConflict)
 	}
+	if cfg.StaleClaimTimeout != DefaultStaleClaimTimeout {
+		t.Errorf("expected StaleClaimTimeout to be %v, got %v", DefaultStaleClaimTimeout, cfg.StaleClaimTimeout)
+	}
 }
 
 func TestEngineer_LoadConfig_NoFile(t *testing.T) {
@@ -67,11 +70,12 @@ func TestEngineer_LoadConfig_WithMergeQueue(t *testing.T) {
 		"version": 1,
 		"name":    "test-rig",
 		"merge_queue": map[string]interface{}{
-			"enabled":        true,
-			"poll_interval":  "10s",
-			"max_concurrent": 2,
-			"run_tests":      false,
-			"test_command":   "make test",
+			"enabled":             true,
+			"poll_interval":       "10s",
+			"max_concurrent":      2,
+			"run_tests":           false,
+			"test_command":        "make test",
+			"stale_claim_timeout": "1h",
 		},
 	}
 
@@ -103,6 +107,9 @@ func TestEngineer_LoadConfig_WithMergeQueue(t *testing.T) {
 	}
 	if e.config.TestCommand != "make test" {
 		t.Errorf("expected TestCommand 'make test', got %q", e.config.TestCommand)
+	}
+	if e.config.StaleClaimTimeout != 1*time.Hour {
+		t.Errorf("expected StaleClaimTimeout 1h, got %v", e.config.StaleClaimTimeout)
 	}
 
 	// Check that defaults are preserved for unspecified fields
@@ -179,6 +186,50 @@ func TestEngineer_LoadConfig_InvalidPollInterval(t *testing.T) {
 	}
 }
 
+func TestEngineer_LoadConfig_InvalidStaleClaimTimeout(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "engineer-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tests := []struct {
+		name    string
+		timeout string
+	}{
+		{"not a duration", "not-a-duration"},
+		{"zero", "0s"},
+		{"negative", "-5m"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := map[string]interface{}{
+				"merge_queue": map[string]interface{}{
+					"stale_claim_timeout": tt.timeout,
+				},
+			}
+
+			data, _ := json.MarshalIndent(config, "", "  ")
+			if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			r := &rig.Rig{
+				Name: "test-rig",
+				Path: tmpDir,
+			}
+
+			e := NewEngineer(r)
+
+			err := e.LoadConfig()
+			if err == nil {
+				t.Errorf("expected error for stale_claim_timeout %q", tt.timeout)
+			}
+		})
+	}
+}
+
 func TestNewEngineer(t *testing.T) {
 	r := &rig.Rig{
 		Name: "test-rig",
@@ -210,29 +261,32 @@ func TestEngineer_DeleteMergedBranchesConfig(t *testing.T) {
 }
 
 func TestIsClaimStale(t *testing.T) {
+	timeout := DefaultStaleClaimTimeout
+
 	tests := []struct {
 		name      string
 		updatedAt string
 		want      bool
+		wantErr   bool
 	}{
 		{
-			name:      "stale claim (> 10 min old)",
-			updatedAt: time.Now().Add(-15 * time.Minute).Format(time.RFC3339),
+			name:      "stale claim (> threshold)",
+			updatedAt: time.Now().Add(-timeout - 5*time.Minute).Format(time.RFC3339),
 			want:      true,
 		},
 		{
-			name:      "recent claim (< 10 min old)",
+			name:      "recent claim (< threshold)",
 			updatedAt: time.Now().Add(-5 * time.Minute).Format(time.RFC3339),
 			want:      false,
 		},
 		{
 			name:      "exactly at threshold",
-			updatedAt: time.Now().Add(-StaleClaimTimeout).Format(time.RFC3339),
+			updatedAt: time.Now().Add(-timeout).Format(time.RFC3339),
 			want:      true,
 		},
 		{
 			name:      "just under threshold",
-			updatedAt: time.Now().Add(-StaleClaimTimeout + time.Second).Format(time.RFC3339),
+			updatedAt: time.Now().Add(-timeout + time.Second).Format(time.RFC3339),
 			want:      false,
 		},
 		{
@@ -244,17 +298,31 @@ func TestIsClaimStale(t *testing.T) {
 			name:      "invalid timestamp format",
 			updatedAt: "not-a-timestamp",
 			want:      false,
+			wantErr:   true,
 		},
 		{
 			name:      "wrong date format",
 			updatedAt: "2026-01-14 12:00:00",
 			want:      false,
+			wantErr:   true,
+		},
+		{
+			name:      "custom short timeout",
+			updatedAt: time.Now().Add(-2 * time.Minute).Format(time.RFC3339),
+			want:      true,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := isClaimStale(tt.updatedAt)
+			to := timeout
+			if tt.name == "custom short timeout" {
+				to = 1 * time.Minute // Test configurable timeout
+			}
+			got, err := isClaimStale(tt.updatedAt, to)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("isClaimStale(%q) error = %v, wantErr %v", tt.updatedAt, err, tt.wantErr)
+			}
 			if got != tt.want {
 				t.Errorf("isClaimStale(%q) = %v, want %v", tt.updatedAt, got, tt.want)
 			}


### PR DESCRIPTION
## Summary

- Adds `StaleClaimTimeout` constant (10 minutes) to detect abandoned MR claims
- Adds `isClaimStale()` helper function for testability
- Updates `ListReadyMRs()` to allow re-claiming stale MRs

## Problem

When a refinery crashes mid-merge, the MR it was processing stays claimed indefinitely. A new refinery instance sees the claimed MR and skips it, assuming another worker is handling it. But that worker crashed - the MR is orphaned.

## Solution

Check `issue.UpdatedAt` timestamp before skipping claimed MRs:

```go
const StaleClaimTimeout = 10 * time.Minute

func isClaimStale(updatedAt string) bool {
    if updatedAt == "" {
        return false // No timestamp - assume claim is valid
    }
    t, err := time.Parse(time.RFC3339, updatedAt)
    if err != nil {
        return false // Invalid timestamp - assume claim is valid
    }
    return time.Since(t) >= StaleClaimTimeout
}
```

## Test plan

- [x] All refinery tests pass
- [x] Build succeeds
- [x] Unit tests for `isClaimStale()`:
  - Stale claim (> 10 min old) → re-claimable
  - Recent claim (< 10 min old) → skipped
  - Exactly at threshold → re-claimable
  - Just under threshold → skipped
  - Empty timestamp → skipped (safe default)
  - Invalid timestamp format → skipped (safe default)
  - Wrong date format → skipped (safe default)

🤖 Generated with [Claude Code](https://claude.com/claude-code)