### PR TITLE
fix: Make WaitForCommand/WaitForRuntimeReady fatal in manager Start()

### DIFF
--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -106,9 +106,11 @@ func (m *Manager) Start(agentOverride string) error {
 	theme := tmux.DeaconTheme()
 	_ = t.ConfigureGasTownSession(sessionID, theme, "", "Deacon", "health-check")
 
-	// Wait for Claude to start (non-fatal)
+	// Wait for Claude to start - fatal if Claude fails to launch
 	if err := t.WaitForCommand(sessionID, constants.SupportedShells, constants.ClaudeStartTimeout); err != nil {
-		// Non-fatal - try to continue anyway
+		// Kill the zombie session before returning error
+		_ = t.KillSessionWithProcesses(sessionID)
+		return fmt.Errorf("waiting for deacon to start: %w", err)
 	}
 
 	// Accept bypass permissions warning dialog if it appears.

--- a/internal/mayor/manager.go
+++ b/internal/mayor/manager.go
@@ -114,9 +114,11 @@ func (m *Manager) Start(agentOverride string) error {
 	theme := tmux.MayorTheme()
 	_ = t.ConfigureGasTownSession(sessionID, theme, "", "Mayor", "coordinator")
 
-	// Wait for Claude to start (non-fatal)
+	// Wait for Claude to start - fatal if Claude fails to launch
 	if err := t.WaitForCommand(sessionID, constants.SupportedShells, constants.ClaudeStartTimeout); err != nil {
-		// Non-fatal - try to continue anyway
+		// Kill the zombie session before returning error
+		_ = t.KillSessionWithProcesses(sessionID)
+		return fmt.Errorf("waiting for mayor to start: %w", err)
 	}
 
 	// Accept bypass permissions warning dialog if it appears.

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -223,10 +223,12 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 		return fmt.Errorf("saving state: %w", err)
 	}
 
-	// Wait for Claude to start and show its prompt (non-fatal)
+	// Wait for Claude to start and show its prompt - fatal if Claude fails to launch
 	// WaitForRuntimeReady waits for the runtime to be ready
 	if err := t.WaitForRuntimeReady(sessionID, runtimeConfig, constants.ClaudeStartTimeout); err != nil {
-		// Non-fatal - try to continue anyway
+		// Kill the zombie session before returning error
+		_ = t.KillSessionWithProcesses(sessionID)
+		return fmt.Errorf("waiting for refinery to start: %w", err)
 	}
 
 	// Accept bypass permissions warning dialog if it appears.

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -211,9 +211,11 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 		return fmt.Errorf("saving state: %w", err)
 	}
 
-	// Wait for Claude to start (non-fatal).
+	// Wait for Claude to start - fatal if Claude fails to launch
 	if err := t.WaitForCommand(sessionID, constants.SupportedShells, constants.ClaudeStartTimeout); err != nil {
-		// Non-fatal - try to continue anyway
+		// Kill the zombie session before returning error
+		_ = t.KillSessionWithProcesses(sessionID)
+		return fmt.Errorf("waiting for witness to start: %w", err)
 	}
 
 	// Accept bypass permissions warning dialog if it appears.


### PR DESCRIPTION
## Summary

Fixes #525: `gt up` reports deacon success but session doesn't actually start.

### Root Cause

There was a **code path divergence** between `gt up` and `gt deacon start`:

**`gt deacon start` (worked):** Uses `cmd/deacon.go:startDeaconSession()` where `WaitForCommand` failure is **fatal**.

**`gt up` (broken):** Uses `internal/deacon/manager.go:Start()` where `WaitForCommand` failure was **non-fatal** - errors were silently ignored.

### What Happened

1. `gt up` calls `deaconMgr.Start()` which creates the tmux session
2. The session is created but Claude fails to start (or exits immediately)
3. `WaitForCommand` fails but the error was ignored
4. `Start()` returns nil (success)
5. `gt up` reports "✓ Deacon: hq-deacon"
6. But the actual tmux session is already dead

### The Fix

Made `WaitForCommand` and `WaitForRuntimeReady` failures **fatal** in all manager `Start()` methods:

- `internal/deacon/manager.go`
- `internal/mayor/manager.go`
- `internal/witness/manager.go`
- `internal/refinery/manager.go`

When Claude fails to start:
1. Zombie tmux session is killed
2. Error is returned: `waiting for <role> to start: <error>`
3. `gt up` properly reports failure instead of false success

This aligns manager `Start()` behavior with cmd start functions which already had fatal error handling.

## Test plan
- [x] `gt up` now properly reports failure when Claude fails to start
- [x] No false "success" messages for dead sessions
- [x] Build succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)