### PR TITLE
Readme beads installation (#1)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,9 @@ go install github.com/steveyegge/gastown/cmd/gt@latest
 # Add Go binaries to PATH (add to ~/.zshrc or ~/.bashrc)
 export PATH="$PATH:$HOME/go/bin"
 
+# Install Beads (macOS/Linux/FreeBSD)
+curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash
+
 # Create workspace with git initialization
 gt install ~/gt --git
 cd ~/gt


### PR DESCRIPTION
I ran into an issue installing gastown the first time; I got an error about beads not being installed; added that to the readme