### PR TITLE
feat(agents): add OpenCode built-in preset

### DIFF
--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -27,6 +27,8 @@ const (
 	AgentAuggie AgentPreset = "auggie"
 	// AgentAmp is Sourcegraph AMP.
 	AgentAmp AgentPreset = "amp"
+	// AgentOpenCode is OpenCode CLI.
+	AgentOpenCode AgentPreset = "opencode"
 )
 
 // AgentPresetInfo contains the configuration details for an agent preset.
@@ -176,6 +178,21 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		ResumeStyle:         "subcommand", // 'amp threads continue <threadId>'
 		SupportsHooks:       false,
 		SupportsForkSession: false,
+	},
+	AgentOpenCode: {
+		Name:                AgentOpenCode,
+		Command:             "opencode",
+		Args:                []string{}, // OpenCode handles permissions internally
+		ProcessNames:        []string{"opencode", "bun"}, // Runs via Bun runtime
+		SessionIDEnv:        "OPENCODE_SESSION_ID",
+		ResumeFlag:          "-c", // --continue flag
+		ResumeStyle:         "flag",
+		SupportsHooks:       true, // Uses gastown.js plugin
+		SupportsForkSession: false,
+		NonInteractive: &NonInteractiveConfig{
+			Subcommand: "run", // opencode run "prompt"
+			OutputFlag: "--format json",
+		},
 	},
 }
 


### PR DESCRIPTION
## Summary

**New Feature: Open Source Agent Support**

Gas Town now supports open source AI coding agents. This PR adds OpenCode as a built-in agent preset, enabling `--agent opencode` without manual configuration.

### What This Enables

Users can now run Gas Town polecats with OpenCode instead of Claude. OpenCode connects to any OpenAI-compatible API, which means:

- **Self-hosted models** via LiteLLM + vLLM/Ollama/etc.
- **Alternative cloud providers** (Together, Fireworks, Groq, etc.)
- **Any model you want** - configure OpenCode, Gas Town just orchestrates

Gas Town doesn't care what model OpenCode talks to. That's the point.

### Proof of Concept

We validated the full flow with a self-hosted stack:

| Layer | Component | Status |
|-------|-----------|--------|
| Orchestration | Gas Town | AgentOpenCode preset spawns OpenCode in tmux |
| Agent | OpenCode | Runs in polecat session, detectable via ProcessNames |
| Gateway | LiteLLM | Routes to backend model |
| Inference | vLLM | Serves model |
| Model | gpt-oss-120b | Responded correctly |

**OpenCode in Tmux Polecat:**
```
Tmux pane_current_command: opencode
GT_ROLE=polecat
GT_RIG=daedalus
OPENCODE_SESSION_ID=test-session-001
```

**Model Response:**
```json
{
  "model": "gpt-oss-120b",
  "content": "4",
  "reasoning": "Need to reply with just \"4\".",
  "tokens": { "prompt": 81, "completion": 19 }
}
```

The model name is whatever you configure in LiteLLM. We tested with `gpt-oss-120b` - you can use anything.

## Changes

- Add `AgentOpenCode` constant to `internal/config/agents.go`
- Add preset info with process detection (`opencode`, `bun`)
- Enable session resume via `-c` flag
- Support non-interactive mode via `run` subcommand
- Add comprehensive test coverage in `agents_test.go`

## Test Plan

- [x] `go test ./internal/config/...` passes
- [x] Manual test: `gt sling <issue> <rig> --agent opencode` spawns OpenCode
- [x] OpenCode detectable via ProcessNames in tmux
- [x] Full stack responds correctly