### PR TITLE
feat(agents): add claude-haiku and claude-opus presets

### DIFF
--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -15,8 +15,12 @@ type AgentPreset string
 
 // Supported agent presets (built-in, E2E tested).
 const (
-	// AgentClaude is Claude Code (default).
+	// AgentClaude is Claude Code with Sonnet (default).
 	AgentClaude AgentPreset = "claude"
+	// AgentClaudeHaiku is Claude Code with Haiku model (fast, low-cost).
+	AgentClaudeHaiku AgentPreset = "claude-haiku"
+	// AgentClaudeOpus is Claude Code with Opus model (high reasoning).
+	AgentClaudeOpus AgentPreset = "claude-opus"
 	// AgentGemini is Gemini CLI.
 	AgentGemini AgentPreset = "gemini"
 	// AgentCodex is OpenAI Codex.
@@ -109,6 +113,30 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		SupportsHooks:       true,
 		SupportsForkSession: true,
 		NonInteractive:      nil, // Claude is native non-interactive
+	},
+	AgentClaudeHaiku: {
+		Name:                AgentClaudeHaiku,
+		Command:             "claude",
+		Args:                []string{"--model", "haiku", "--dangerously-skip-permissions"},
+		ProcessNames:        []string{"node"},
+		SessionIDEnv:        "CLAUDE_SESSION_ID",
+		ResumeFlag:          "--resume",
+		ResumeStyle:         "flag",
+		SupportsHooks:       true,
+		SupportsForkSession: true,
+		NonInteractive:      nil,
+	},
+	AgentClaudeOpus: {
+		Name:                AgentClaudeOpus,
+		Command:             "claude",
+		Args:                []string{"--model", "opus", "--dangerously-skip-permissions"},
+		ProcessNames:        []string{"node"},
+		SessionIDEnv:        "CLAUDE_SESSION_ID",
+		ResumeFlag:          "--resume",
+		ResumeStyle:         "flag",
+		SupportsHooks:       true,
+		SupportsForkSession: true,
+		NonInteractive:      nil,
 	},
 	AgentGemini: {
 		Name:                AgentGemini,


### PR DESCRIPTION
## Summary

Adds built-in agent presets for Claude Haiku and Opus models:

- `claude-haiku`: Fast, low-cost model (`--model haiku`)
- `claude-opus`: High-reasoning model (`--model opus`)

## Motivation

The `role_agents` feature enables cost optimization by assigning different models to different roles. However, users currently must define custom agents first.

With this PR, it works out of the box:

```bash
gt config role-agents set witness claude-haiku
gt config role-agents set refinery claude-haiku
```

## Related

- Complements #539 (cost optimization docs)
- Complements #540 (role-agents CLI)

## Test plan

- [x] `TestClaudeModelPresets` - all 3 subtests pass
- [x] `TestBuiltinPresets` includes new presets
- [x] `TestIsKnownPreset` recognizes new presets