### PR TITLE
fix(stale): exclude beads-only changes from uncommitted work detection

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -953,6 +953,32 @@ func (s *UncommittedWorkStatus) Clean() bool {
 	return !s.HasUncommittedChanges && s.StashCount == 0 && s.UnpushedCommits == 0
 }
 
+// CleanExcludingBeads returns true if the only uncommitted changes are in .beads/ paths.
+// This is used by stale detection to allow cleanup of polecats that only have beads sync changes.
+func (s *UncommittedWorkStatus) CleanExcludingBeads() bool {
+	if s.StashCount > 0 || s.UnpushedCommits > 0 {
+		return false
+	}
+
+	// Check if all modified files are beads files
+	for _, f := range s.ModifiedFiles {
+		if !isBeadsPath(f) {
+			return false
+		}
+	}
+	for _, f := range s.UntrackedFiles {
+		if !isBeadsPath(f) {
+			return false
+		}
+	}
+	return true
+}
+
+// isBeadsPath returns true if the path is a beads database file.
+func isBeadsPath(path string) bool {
+	return strings.Contains(path, ".beads/") || strings.Contains(path, ".beads\\")
+}
+
 // String returns a human-readable summary of uncommitted work.
 func (s *UncommittedWorkStatus) String() string {
 	var issues []string

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -892,9 +892,9 @@ func (m *Manager) DetectStalePolecats(threshold int) ([]*StalenessInfo, error) {
 		polecatGit := git.NewGit(p.ClonePath)
 		info.CommitsBehind = countCommitsBehind(polecatGit, defaultBranch)
 
-		// Check for uncommitted work
+		// Check for uncommitted work (excluding beads-only changes)
 		status, err := polecatGit.CheckUncommittedWork()
-		if err == nil && !status.Clean() {
+		if err == nil && !status.CleanExcludingBeads() {
 			info.HasUncommittedWork = true
 		}
 


### PR DESCRIPTION
## Summary

Fixes #516 - `gt polecat stale` reports polecats as having "uncommitted work" when the only changes are `.beads/` files, preventing automatic cleanup.

## Changes

- Add `CleanExcludingBeads()` method to `UncommittedWorkStatus` that returns true when the only uncommitted changes are in `.beads/` paths
- Add `isBeadsPath()` helper function to identify beads database files
- Update `DetectStalePolecats()` to use `CleanExcludingBeads()` instead of `Clean()`
- Add comprehensive unit tests

## Files Changed

- `internal/git/git.go` - Add CleanExcludingBeads() and isBeadsPath()
- `internal/git/git_test.go` - Add unit tests (6 test cases)
- `internal/polecat/manager.go` - Use CleanExcludingBeads() in DetectStalePolecats

## Test Plan

- [x] Unit tests for `isBeadsPath()` with various path formats
- [x] Unit tests for `CleanExcludingBeads()` covering:
  - Only beads files changed → returns true
  - Real code files changed → returns false
  - Untracked non-beads files → returns false
  - With stashes → returns false
  - With unpushed commits → returns false
  - Truly clean state → returns true

## Note

This is a draft PR pending investigation of whether filtering at stale detection is the correct layer vs. gitignoring .beads/ files.

🤖 Generated with [Claude Code](https://claude.ai/code)