### PR TITLE
fix(beads): Fix test isolation and env override for TestCloseAndClearAgentBead

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -143,7 +143,16 @@ func (b *Beads) run(args ...string) ([]byte, error) {
 	if beadsDir == "" {
 		beadsDir = ResolveBeadsDir(b.workDir)
 	}
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
+	// Filter out existing BEADS_DIR to ensure our override takes effect
+	// (append would just add a duplicate, and most programs use the first)
+	env := os.Environ()
+	filteredEnv := make([]string, 0, len(env)+1)
+	for _, e := range env {
+		if !strings.HasPrefix(e, "BEADS_DIR=") {
+			filteredEnv = append(filteredEnv, e)
+		}
+	}
+	cmd.Env = append(filteredEnv, "BEADS_DIR="+beadsDir)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -1821,8 +1821,7 @@ func TestAgentBeadTombstoneBug(t *testing.T) {
 		t.Fatalf("bd init: %v\n%s", err, output)
 	}
 
-	beadsDir := filepath.Join(tmpDir, ".beads")
-	bd := New(beadsDir)
+	bd := New(tmpDir)
 
 	agentID := "test-testrig-polecat-tombstone"
 
@@ -1905,8 +1904,7 @@ func TestAgentBeadCloseReopenWorkaround(t *testing.T) {
 		t.Fatalf("bd init: %v\n%s", err, output)
 	}
 
-	beadsDir := filepath.Join(tmpDir, ".beads")
-	bd := New(beadsDir)
+	bd := New(tmpDir)
 
 	agentID := "test-testrig-polecat-closereopen"
 
@@ -1966,8 +1964,7 @@ func TestCreateOrReopenAgentBead_ClosedBead(t *testing.T) {
 		t.Fatalf("bd init: %v\n%s", err, output)
 	}
 
-	beadsDir := filepath.Join(tmpDir, ".beads")
-	bd := New(beadsDir)
+	bd := New(tmpDir)
 
 	agentID := "test-testrig-polecat-lifecycle"
 
@@ -2054,8 +2051,7 @@ func TestCloseAndClearAgentBead_FieldClearing(t *testing.T) {
 		t.Fatalf("bd init: %v\n%s", err, output)
 	}
 
-	beadsDir := filepath.Join(tmpDir, ".beads")
-	bd := New(beadsDir)
+	bd := New(tmpDir)
 
 	// Test cases for field clearing permutations
 	tests := []struct {
@@ -2131,10 +2127,11 @@ func TestCloseAndClearAgentBead_FieldClearing(t *testing.T) {
 		},
 	}
 
-	for i, tc := range tests {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
 			// Create unique agent ID for each test case
-			agentID := fmt.Sprintf("test-testrig-%s-%d", tc.fields.RoleType, i)
+			// Use tc.name (alphabetic) instead of numeric index to avoid bd prefix parsing issue
+			agentID := fmt.Sprintf("test-testrig-%s-%s", tc.fields.RoleType, tc.name)
 
 			// Step 1: Create agent bead with specified fields
 			_, err := bd.CreateAgentBead(agentID, "Test agent", tc.fields)
@@ -2211,8 +2208,7 @@ func TestCloseAndClearAgentBead_NonExistent(t *testing.T) {
 		t.Fatalf("bd init: %v\n%s", err, output)
 	}
 
-	beadsDir := filepath.Join(tmpDir, ".beads")
-	bd := New(beadsDir)
+	bd := New(tmpDir)
 
 	// Attempt to close non-existent bead
 	err := bd.CloseAndClearAgentBead("test-nonexistent-polecat-xyz", "should fail")
@@ -2233,8 +2229,7 @@ func TestCloseAndClearAgentBead_AlreadyClosed(t *testing.T) {
 		t.Fatalf("bd init: %v\n%s", err, output)
 	}
 
-	beadsDir := filepath.Join(tmpDir, ".beads")
-	bd := New(beadsDir)
+	bd := New(tmpDir)
 
 	agentID := "test-testrig-polecat-doubleclosed"
 
@@ -2287,8 +2282,7 @@ func TestCloseAndClearAgentBead_ReopenHasCleanState(t *testing.T) {
 		t.Fatalf("bd init: %v\n%s", err, output)
 	}
 
-	beadsDir := filepath.Join(tmpDir, ".beads")
-	bd := New(beadsDir)
+	bd := New(tmpDir)
 
 	agentID := "test-testrig-polecat-cleanreopen"
 
@@ -2355,8 +2349,7 @@ func TestCloseAndClearAgentBead_ReasonVariations(t *testing.T) {
 		t.Fatalf("bd init: %v\n%s", err, output)
 	}
 
-	beadsDir := filepath.Join(tmpDir, ".beads")
-	bd := New(beadsDir)
+	bd := New(tmpDir)
 
 	tests := []struct {
 		name   string
@@ -2369,9 +2362,10 @@ func TestCloseAndClearAgentBead_ReasonVariations(t *testing.T) {
 		{"long_reason", "This is a very long reason that explains in detail why the agent bead was closed including multiple sentences and detailed context about the situation."},
 	}
 
-	for i, tc := range tests {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			agentID := fmt.Sprintf("test-testrig-polecat-reason%d", i)
+			// Use tc.name (alphabetic) instead of numeric index to avoid bd prefix parsing issue
+			agentID := fmt.Sprintf("test-testrig-polecat-%s", tc.name)
 
 			// Create agent bead
 			_, err := bd.CreateAgentBead(agentID, "Test agent", &AgentFields{


### PR DESCRIPTION
## Summary
- Fix `New(beadsDir)` → `New(tmpDir)` in 8 test locations (New() expects working directory, not .beads path)
- Filter out existing `BEADS_DIR` from environment before appending override (prevents duplicate env vars where first occurrence wins)
- Use alphabetic test suffixes instead of numeric to avoid bd prefix parsing issues

## Test plan
- [x] Run `go test ./internal/beads/...` - all tests pass
- [x] Verify BEADS_DIR override works correctly in subprocess calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)