### PR TITLE
fix(checkpoint): Use >= instead of > for IsStale boundary condition

### DIFF
--- a/internal/checkpoint/checkpoint.go
+++ b/internal/checkpoint/checkpoint.go
@@ -181,9 +181,9 @@ func (cp *Checkpoint) Age() time.Duration {
 	return time.Since(cp.Timestamp)
 }
 
-// IsStale returns true if the checkpoint is older than the threshold.
+// IsStale returns true if the checkpoint is at least as old as the threshold.
 func (cp *Checkpoint) IsStale(threshold time.Duration) bool {
-	return cp.Age() > threshold
+	return cp.Age() >= threshold
 }
 
 // Summary returns a concise summary of the checkpoint.


### PR DESCRIPTION
## Summary
- Change `IsStale()` comparison from `>` to `>=` so checkpoints exactly at the threshold are considered stale
- Updates comment to reflect semantic: "at least as old as" vs "older than"

## Rationale
The test `TestIsStale/exactly_threshold` expects that a checkpoint exactly 1 hour old should be considered stale when the threshold is 1 hour. The previous code used strict inequality:

```go
return cp.Age() > threshold  // 1h > 1h = false
```

This is a semantic question: does "stale" mean "older than X" or "at least X old"? 

The latter makes more sense - if you set a 1-hour threshold, you're saying "anything 1 hour or older is stale." A boundary exactly at the threshold should be included, not excluded. This matches common expectations (e.g., "items older than 30 days" typically includes day 30).

## Test plan
- [x] Run `go test ./internal/checkpoint/...` - all tests pass including `TestIsStale/exactly_threshold`

🤖 Generated with [Claude Code](https://claude.com/claude-code)