### PR TITLE
feat(refinery): add batch merge mode to reduce CPU load

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -661,12 +661,43 @@ type MergeQueueConfig struct {
 
 	// MaxConcurrent is the maximum number of concurrent merges.
 	MaxConcurrent int `json:"max_concurrent"`
+
+	// BatchMerge enables batch mode where multiple MRs are merged together
+	// before running tests once. This reduces CPU load when processing many MRs.
+	BatchMerge bool `json:"batch_merge,omitempty"`
+
+	// BatchSize is the maximum number of MRs to include in a single batch.
+	// Only used when BatchMerge is enabled. Default: 5
+	BatchSize int `json:"batch_size,omitempty"`
+
+	// BatchWindow is the time window to wait for collecting MRs into a batch.
+	// Format: Go duration string (e.g., "5m", "2m30s").
+	// Only used when BatchMerge is enabled. Default: "5m"
+	BatchWindow string `json:"batch_window,omitempty"`
+
+	// BatchStrategy controls how to handle test failures in batch mode.
+	// "all-or-nothing": Reject entire batch on failure (fast, simple).
+	// "bisect-on-fail": Binary search to find failing MR(s) on failure.
+	// Only used when BatchMerge is enabled. Default: "all-or-nothing"
+	BatchStrategy string `json:"batch_strategy,omitempty"`
 }
 
 // OnConflict strategy constants.
 const (
 	OnConflictAssignBack = "assign_back"
 	OnConflictAutoRebase = "auto_rebase"
+)
+
+// BatchStrategy constants for batch merge mode.
+const (
+	BatchStrategyAllOrNothing = "all-or-nothing"
+	BatchStrategyBisectOnFail = "bisect-on-fail"
+)
+
+// Default batch merge settings.
+const (
+	DefaultBatchSize   = 5
+	DefaultBatchWindow = "5m"
 )
 
 // DefaultMergeQueueConfig returns a MergeQueueConfig with sensible defaults.


### PR DESCRIPTION
## Summary

Add configurable batch merge support for the refinery merge queue. When enabled, multiple MRs are merged to a staging branch, tests run once, then main is fast-forwarded.

**Problem**: Sequential PR processing causes high CPU load. Each PR triggers a full build+test cycle.

**Solution**: Batch mode collects N MRs, merges all to staging, runs tests ONCE, then fast-forwards main.

```
BEFORE: PR1→test→merge → PR2→test→merge → PR3→test→merge  (3x CPU)
AFTER:  PR1+PR2+PR3 → staging → test ONCE → fast-forward   (1x CPU)
```

Closes #545

## Changes

### `internal/config/types.go`
- Add `BatchMerge`, `BatchSize`, `BatchWindow`, `BatchStrategy` fields to `MergeQueueConfig`
- Add constants: `BatchStrategyAllOrNothing`, `BatchStrategyBisectOnFail`
- Add defaults: `DefaultBatchSize` (5), `DefaultBatchWindow` ("5m")

### `internal/refinery/engineer.go`
- Add batch fields to local `MergeQueueConfig` struct
- Update `LoadConfig()` to parse batch settings from JSON
- Add `BatchResult` type for batch processing results
- Add `ProcessBatch()` method implementing batch merge workflow

## Config Example

```json
{
  "merge_queue": {
    "batch_merge": true,
    "batch_size": 5,
    "batch_window": "5m",
    "batch_strategy": "all-or-nothing"
  }
}
```

## Test Plan

- [x] `go build ./...` passes
- [x] `go test ./internal/refinery/...` passes
- [ ] Manual testing with batch mode enabled

## Notes

- Feature is opt-in (`batch_merge: false` by default)
- Backward compatible - existing configs work unchanged
- `bisect-on-fail` strategy logged as "not yet implemented" (follow-up PR)
- Conflicting MRs are automatically ejected and can be processed individually