### PR TITLE
fix(ci): pin beads to v0.47.0 to fix CI test failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,9 @@ jobs:
           git config --global user.email "ci@gastown.test"
 
       - name: Install beads (bd)
-        run: go install github.com/steveyegge/beads/cmd/bd@latest
+        # Pin to v0.47.0 - v0.47.1 has prefix extraction changes that break agent ID format,
+        # v0.47.2 has routing defaults that cause prefix mismatch errors
+        run: go install github.com/steveyegge/beads/cmd/bd@v0.47.0
 
       - name: Build gt
         run: go build -v -o gt ./cmd/gt

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,9 @@ jobs:
           git config --global user.email "ci@gastown.test"
 
       - name: Install beads (bd)
-        run: go install github.com/steveyegge/beads/cmd/bd@latest
+        # Pin to v0.47.0 - v0.47.1 has prefix extraction changes that break agent ID format,
+        # v0.47.2 has routing defaults that cause prefix mismatch errors
+        run: go install github.com/steveyegge/beads/cmd/bd@v0.47.0
 
       - name: Add to PATH
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH


### PR DESCRIPTION
## Summary

Pin bd (beads CLI) to v0.47.0 in CI workflows to fix test failures caused by breaking changes in v0.47.1 and v0.47.2.

## Related Issue

Fixes CI test failures across all PRs since Jan 15 20:07 UTC.

## Changes

- Pin `go install github.com/steveyegge/beads/cmd/bd@latest` to `@v0.47.0` in `.github/workflows/ci.yml`
- Pin `go install github.com/steveyegge/beads/cmd/bd@latest` to `@v0.47.0` in `.github/workflows/integration.yml`
- Added comments explaining why version is pinned

## Root Cause Analysis

### Breaking Changes in bd

| Version | Release Date | Breaking Change |
|---------|--------------|-----------------|
| v0.47.0 | Jan 11 00:25 UTC | Working version |
| v0.47.1 | Jan 12 03:21 UTC | `ExtractIssuePrefix()` changed to treat 3-8 char suffixes with digits as hash suffixes |
| v0.47.2 | Jan 14 21:57 UTC | Added `routing.mode=auto` default, routing creates to `~/.beads-planning` |

### How Tests Break

**v0.47.1 prefix extraction issue:**
- Agent IDs like `test-testrig-polecat-reason0` have suffix `reason0` (7 chars with digit)
- `isLikelyHash()` returns true for this suffix
- bd extracts `test-testrig-polecat` as the prefix instead of `test`
- Error: `prefix mismatch: database uses 'test' but you specified 'test-testrig-polecat'`

**v0.47.2 routing issue:**
- Default `routing.mode=auto` routes contributor creates to `~/.beads-planning`
- CI doesn't have `~/.beads-planning` or it has different prefix
- Error: `prefix mismatch: database uses 'hq' but you specified 'test'`

### Timeline Mystery Solved

Tests passed at 06:00 UTC Jan 15 but failed at 20:07 UTC because:

1. Tests with agent ID short suffixes were added in commit `6becab4a` (Jan 13 10:44 UTC)
2. v0.47.1 was released Jan 12 (before tests were written)
3. Tests were developed against local v0.47.0 installation
4. CI runs at 06:00 UTC were on branches **without** the new tests (branched before merge)
5. CI runs at 20:07 UTC were on branches **with** the new tests, using `@latest` → v0.47.2

The tests were essentially written against old bd behavior but never validated against v0.47.1+ before merge.

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Verified v0.47.0 passes all beads tests locally
- [x] Verified v0.47.1 fails with prefix extraction error
- [x] Verified v0.47.2 fails with routing error

## Checklist

- [x] Code follows project style
- [x] Documentation updated (comments in workflow files)
- [x] No breaking changes