### PR TITLE
fix(ci,tests): pin bd to v0.47.1 and fix hash-like test suffixes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,7 +235,8 @@ jobs:
           git config --global user.email "ci@gastown.test"
 
       - name: Install beads (bd)
-        run: go install github.com/steveyegge/beads/cmd/bd@latest
+        # Pin to v0.47.1 - v0.47.2 has routing defaults that cause prefix mismatch errors
+        run: go install github.com/steveyegge/beads/cmd/bd@v0.47.1
 
       - name: Build gt
         run: go build -v -o gt ./cmd/gt

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,7 +30,8 @@ jobs:
           git config --global user.email "ci@gastown.test"
 
       - name: Install beads (bd)
-        run: go install github.com/steveyegge/beads/cmd/bd@latest
+        # Pin to v0.47.1 - v0.47.2 has routing defaults that cause prefix mismatch errors
+        run: go install github.com/steveyegge/beads/cmd/bd@v0.47.1
 
       - name: Add to PATH
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -2131,10 +2131,11 @@ func TestCloseAndClearAgentBead_FieldClearing(t *testing.T) {
 		},
 	}
 
-	for i, tc := range tests {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			// Create unique agent ID for each test case
-			agentID := fmt.Sprintf("test-testrig-%s-%d", tc.fields.RoleType, i)
+			// Use tc.name for suffix to avoid hash-like patterns (e.g., single digits)
+			// that trigger bd's isLikelyHash() prefix extraction in v0.47.1+
+			agentID := fmt.Sprintf("test-testrig-%s-%s", tc.fields.RoleType, tc.name)
 
 			// Step 1: Create agent bead with specified fields
 			_, err := bd.CreateAgentBead(agentID, "Test agent", tc.fields)
@@ -2369,9 +2370,11 @@ func TestCloseAndClearAgentBead_ReasonVariations(t *testing.T) {
 		{"long_reason", "This is a very long reason that explains in detail why the agent bead was closed including multiple sentences and detailed context about the situation."},
 	}
 
-	for i, tc := range tests {
+	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			agentID := fmt.Sprintf("test-testrig-polecat-reason%d", i)
+			// Use tc.name for suffix to avoid hash-like patterns (e.g., "reason0")
+			// that trigger bd's isLikelyHash() prefix extraction in v0.47.1+
+			agentID := fmt.Sprintf("test-testrig-polecat-%s", tc.name)
 
 			// Create agent bead
 			_, err := bd.CreateAgentBead(agentID, "Test agent", &AgentFields{


### PR DESCRIPTION
## Summary

Pin bd (beads CLI) to v0.47.1 in CI workflows and fix test agent IDs that were triggering bd's `isLikelyHash()` prefix extraction logic, causing test failures.

## Related Issue

Fixes CI test failures across all PRs caused by bd version incompatibilities.

Supersedes: #556

## Changes

- Pin `go install github.com/steveyegge/beads/cmd/bd@latest` to `@v0.47.1` in `.github/workflows/ci.yml`
- Pin `go install github.com/steveyegge/beads/cmd/bd@latest` to `@v0.47.1` in `.github/workflows/integration.yml`
- Fix `TestCloseAndClearAgentBead_FieldClearing`: change agent IDs from `test-testrig-polecat-0` to `test-testrig-polecat-all_fields_populated` (using `tc.name`)
- Fix `TestCloseAndClearAgentBead_ReasonVariations`: change agent IDs from `test-testrig-polecat-reason0` to `test-testrig-polecat-empty_reason` (using `tc.name`)

## Root Cause Analysis

### bd Version Issues

| Version | Issue |
|---------|-------|
| v0.47.1 | `isLikelyHash()` treats 3-8 char suffixes (with digits for 4+ chars) as hash suffixes |
| v0.47.2 | Adds `routing.mode=auto` default that routes creates to `~/.beads-planning` |

### How Tests Were Breaking

The bd v0.47.1 `ExtractIssuePrefix()` function uses `isLikelyHash()` to determine if a suffix looks like a git hash:
- Suffixes of 3-8 characters
- For 4+ char suffixes, must contain at least one digit

Test agent IDs were triggering this:
- `test-testrig-polecat-0` → suffix `0` (1 char, but still treated as hash-like)
- `test-testrig-polecat-reason0` → suffix `reason0` (7 chars with digit)

This caused bd to extract `test-testrig-polecat` as the prefix instead of `test`, resulting in:
```
Error: prefix mismatch: database uses 'test' but you specified 'test-testrig-polecat'
```

### Why v0.47.1 Instead of v0.47.0

v0.47.1 is preferred because:
1. It includes bug fixes and improvements over v0.47.0
2. The prefix extraction behavior is correct for properly-formatted IDs
3. Only requires fixing test IDs that use hash-like suffixes

### The Fix

Using test names as suffixes avoids the issue because they're all >8 characters:
- `all_fields_populated` (20 chars)
- `empty_reason` (12 chars)
- `simple_reason` (13 chars)
- etc.

Suffixes >8 chars are never considered hash-like by `isLikelyHash()`.

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Verified all beads tests pass with bd v0.47.1
- [x] Manual testing performed

## Checklist

- [x] Code follows project style
- [x] Documentation updated (comments explaining why suffixes were changed)
- [x] No breaking changes