### PR TITLE
docs: fix misleading help text for gt mail read

### DIFF
--- a/internal/cmd/mail.go
+++ b/internal/cmd/mail.go
@@ -150,9 +150,10 @@ Examples:
 var mailReadCmd = &cobra.Command{
 	Use:   "read <message-id>",
 	Short: "Read a message",
-	Long: `Read a specific message and mark it as read.
+	Long: `Read a specific message (does not mark as read).
 
-The message ID can be found from 'gt mail inbox'.`,
+The message ID can be found from 'gt mail inbox'.
+Use 'gt mail mark-read' to mark messages as read.`,
 	Aliases: []string{"show"},
 	Args: cobra.ExactArgs(1),
 	RunE: runMailRead,


### PR DESCRIPTION
## Summary
Fix the `gt mail read` help text which incorrectly claims the command marks messages as read.

## Problem
The help text says:
> Read a specific message and mark it as read.

But the code intentionally does NOT mark as read (see comment at `mail_inbox.go:124`):
```go
// Note: We intentionally do NOT mark as read/ack on read.
```

This was changed in 71d313ed to preserve handoff messages.

## Fix
Update help text to accurately describe behavior and point users to `gt mail mark-read`.

## Testing
- [x] `go build ./...` passes
- [x] Documentation-only change