### PR TITLE
fix(tmux): kill pane process explicitly to prevent setsid orphans

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -176,6 +176,11 @@ func (t *Tmux) KillSessionWithProcesses(name string) error {
 		for _, dpid := range descendants {
 			_ = exec.Command("kill", "-KILL", dpid).Run()
 		}
+
+		// Kill the pane process itself (may have called setsid() and detached)
+		_ = exec.Command("kill", "-TERM", pid).Run()
+		time.Sleep(100 * time.Millisecond)
+		_ = exec.Command("kill", "-KILL", pid).Run()
 	}
 
 	// Kill the tmux session


### PR DESCRIPTION
## Summary

- Fixes orphaned Claude processes that survive `gt done` by escaping via `setsid()`
- Adds explicit kill of the pane PID itself after killing descendants
- Completes the fix started in #501, which only killed descendant processes

## Root Cause

`KillSessionWithProcesses` was only killing descendant processes (found via `pgrep -P`), assuming the tmux session kill would terminate the pane process itself. However, Claude CLI spawns processes that call `setsid()`, which:
- Creates a new session ID and process group
- Detaches from the controlling terminal (TTY shows as `?`)
- Breaks the parent-child relationship that `pgrep -P` relies on

When the session was killed, these detached processes survived.

## Fix

After killing descendants, explicitly send SIGTERM/SIGKILL to the pane PID itself before killing the tmux session. This catches processes that have escaped the process tree.

## Testing

1. Spawned polecat, ran `gt done` - orphan process remained (before fix)
2. Applied fix, nuked polecat - no orphan processes (after fix)

Fixes #513

🤖 Generated with [Claude Code](https://claude.com/claude-code)