### PR TITLE
fix(polecat): validate issue exists before starting session

### DIFF
--- a/internal/polecat/session_manager_test.go
+++ b/internal/polecat/session_manager_test.go
@@ -190,3 +190,38 @@ func TestPolecatCommandFormat(t *testing.T) {
 		t.Error("GT_ROLE must be 'polecat', not 'mayor' or 'crew'")
 	}
 }
+
+func TestValidateIssue(t *testing.T) {
+	// Create a temp directory with a minimal beads setup
+	tmpDir := t.TempDir()
+
+	r := &rig.Rig{
+		Name:     "test-rig",
+		Path:     tmpDir,
+		Polecats: []string{"test-polecat"},
+	}
+	m := NewSessionManager(tmux.NewTmux(), r)
+
+	// Test with nonexistent issue - should fail
+	// This requires bd to be installed, so skip if not available
+	if _, err := os.Stat("/opt/homebrew/bin/bd"); os.IsNotExist(err) {
+		if _, err := os.Stat("/usr/local/bin/bd"); os.IsNotExist(err) {
+			t.Skip("bd not installed, skipping integration test")
+		}
+	}
+
+	// Create minimal .beads directory so bd can run
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Validate nonexistent issue should fail
+	err := m.validateIssue("nonexistent-issue-xyz123", tmpDir)
+	if err == nil {
+		t.Error("expected error for nonexistent issue")
+	}
+	if !strings.Contains(err.Error(), "not found") {
+		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Add `validateIssue()` to check issue exists and isn't tombstoned before starting session
- Add HookBead validation in `AddWithOptions()` and `RepairWorktreeWithOptions()` before creating polecat
- Fail fast with clear error instead of creating polecat with invalid work

## Problem

When `gt sling` is called with a tombstoned or nonexistent issue, the polecat gets created and the agent enters retry loops, causing CPU spin (observed load average 26+ with fork failures).

**Root cause:** No validation that the assigned issue exists before creating the polecat or starting its session.

## Solution

Add validation in two places:

1. **`session_manager.go`**: `validateIssue()` checks issue exists before creating tmux session (when `opts.Issue` is provided in `Start()`)

2. **`manager.go`**: HookBead validation in `AddWithOptions()` and `RepairWorktreeWithOptions()` before creating/repairing the polecat worktree

The validation calls `bd show` to verify the issue exists and checks that `status != "tombstone"` before proceeding.

## Changes

- `internal/polecat/session_manager.go`: Add `validateIssue()` function, call in `Start()` before session creation
- `internal/polecat/manager.go`: Add HookBead validation in `AddWithOptions()` and `RepairWorktreeWithOptions()`
- `internal/polecat/session_manager_test.go`: Add `TestValidateIssue` test

## Test plan

- [x] `go test ./internal/polecat/...` passes
- [x] `go vet ./...` clean  
- [x] `gofmt` applied
- [x] `go build ./cmd/gt` succeeds
- [x] Manual test: `gt sling <tombstoned-issue> <rig>` now fails fast with "invalid hook_bead: issue not found"

Fixes #569