### PR TITLE
fix(tmux): serialize nudges to prevent interleaving

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -9,11 +9,17 @@ import (
 	"os/exec"
 	"regexp"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 )
+
+// sessionNudgeLocks serializes nudges to the same session.
+// This prevents interleaving when multiple nudges arrive concurrently,
+// which can cause garbled input and missed Enter keys.
+var sessionNudgeLocks sync.Map // map[string]*sync.Mutex
 
 // versionPattern matches Claude Code version numbers like "2.0.76"
 var versionPattern = regexp.MustCompile(`^\d+\.\d+\.\d+$`)
@@ -420,11 +426,28 @@ func (t *Tmux) SendKeysDelayedDebounced(session, keys string, preDelayMs, deboun
 	return t.SendKeysDebounced(session, keys, debounceMs)
 }
 
+// getSessionNudgeLock returns the mutex for serializing nudges to a session.
+// Creates a new mutex if one doesn't exist for this session.
+func getSessionNudgeLock(session string) *sync.Mutex {
+	actual, _ := sessionNudgeLocks.LoadOrStore(session, &sync.Mutex{})
+	return actual.(*sync.Mutex)
+}
+
 // NudgeSession sends a message to a Claude Code session reliably.
 // This is the canonical way to send messages to Claude sessions.
 // Uses: literal mode + 500ms debounce + ESC (for vim mode) + separate Enter.
 // Verification is the Witness's job (AI), not this function.
+//
+// IMPORTANT: Nudges to the same session are serialized to prevent interleaving.
+// If multiple goroutines try to nudge the same session concurrently, they will
+// queue up and execute one at a time. This prevents garbled input when
+// SessionStart hooks and nudges arrive simultaneously.
 func (t *Tmux) NudgeSession(session, message string) error {
+	// Serialize nudges to this session to prevent interleaving
+	lock := getSessionNudgeLock(session)
+	lock.Lock()
+	defer lock.Unlock()
+
 	// 1. Send text in literal mode (handles special characters)
 	if _, err := t.run("send-keys", "-t", session, "-l", message); err != nil {
 		return err
@@ -455,7 +478,13 @@ func (t *Tmux) NudgeSession(session, message string) error {
 
 // NudgePane sends a message to a specific pane reliably.
 // Same pattern as NudgeSession but targets a pane ID (e.g., "%9") instead of session name.
+// Nudges to the same pane are serialized to prevent interleaving.
 func (t *Tmux) NudgePane(pane, message string) error {
+	// Serialize nudges to this pane to prevent interleaving
+	lock := getSessionNudgeLock(pane)
+	lock.Lock()
+	defer lock.Unlock()
+
 	// 1. Send text in literal mode (handles special characters)
 	if _, err := t.run("send-keys", "-t", pane, "-l", message); err != nil {
 		return err


### PR DESCRIPTION
## Summary

Adds per-session mutex serialization to `NudgeSession()` and `NudgePane()` to prevent concurrent nudges from interleaving and corrupting tmux input.

## Problem

When multiple agents start simultaneously (e.g., `gt up`), each runs `gt nudge deacon session-started` in their SessionStart hook. These nudges arrive concurrently and interleave in the tmux input buffer, causing:

1. Text from one nudge mixing with another
2. Enter keys not properly submitting messages  
3. Garbled input requiring manual intervention to unstick
4. **Agent crashes or unexpected exits** - corrupted input can cause Claude to misinterpret commands or enter bad states

**Symptoms observed:**
- Deacon stuck waiting for input (nudges queued but not submitted)
- Deacon crashes or exits unexpectedly after concurrent nudges
- Polecats exiting early without completing work
- Manual Enter key required to unstick queued nudges

**Example corruption from [#280](https://github.com/steveyegge/gastown/issues/280):**
```
zsh: bad pattern: [GAS
zsh: command not found: Run
```
Where `[GAS TOWN] mayor <- human...` and `Run gt prime...` were fed to the shell instead of Claude due to interleaved input.

Example from logs - 4 nudges arriving within 8 seconds:
```
21:26:35 [nudge] deacon nudged with "[from deacon] session-started"
21:26:42 [nudge] deacon nudged with "[from beads/witness] session-started"
21:26:42 [nudge] deacon nudged with "[from da/witness] session-started"
21:26:43 [nudge] deacon nudged with "[from gastown/witness] session-started"
```

## Why Corruption Occurs

Claude Code is designed to allow typing messages while it's processing, which should queue and either steer Claude or add context. However, this functionality has known reliability issues:

- [Messages queued while working get "lost"](https://github.com/anthropics/claude-code/issues/12047) - "Claude keeps ignoring the messages I queue up while it's working"
- [Messages not processed between queries](https://github.com/anthropics/claude-code/issues/10892) - "Previous query still processing" error, typed message disappears
- [Queued prompts no longer steering](https://github.com/anthropics/claude-code/issues/11543) - Feature "no longer seems to be working"

We would like to take advantage of Claude's message queuing to handle concurrent nudges gracefully, but this functionality is currently unreliable. Until it stabilizes upstream, we need to serialize nudges ourselves to ensure robustness.

## Solution

Add a `sync.Map` of per-session mutexes. Before sending a nudge, acquire the lock for that session. This ensures concurrent nudges queue and execute one at a time.

## Alternatives Considered

| Alternative | Pros | Cons |
|-------------|------|------|
| **Delay nudges** - Add sleep in SessionStart | Simplest (one line) | Doesn't prevent concurrent nudges from multiple agents |
| **Debounce session-started** | Medium complexity | Only helps one nudge type |
| **File-based signaling** | Avoids tmux entirely | Major architectural change |
| **Rely on Claude queuing** | No code changes | Currently unreliable (see above) |

## Tradeoffs

- ✅ Prevents all nudge interleaving
- ⚠️ Adds latency when nudges queue (but prevents corruption)
- ⚠️ Memory: one mutex per session name (bounded, acceptable)
- ❌ Does not fix Claude Code's underlying queuing issues

## Future Work

- Revisit this fix if Claude Code's message queuing becomes reliable
- Consider deduplicating redundant session-started nudges (tracked in hq-u8l3)

## Testing

- [x] Build passes
- [x] All tmux package tests pass
- [x] Manual testing: started deacon + multiple witnesses concurrently, nudges processed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)