### PR TITLE
Fix: Add permissive permission mode to Claude settings templates

### DIFF
--- a/internal/claude/config/settings-autonomous.json
+++ b/internal/claude/config/settings-autonomous.json
@@ -1,4 +1,5 @@
 {
+  "permissionMode": "permissive",
   "enabledPlugins": {
     "beads@beads-marketplace": false
   },

--- a/internal/claude/config/settings-interactive.json
+++ b/internal/claude/config/settings-interactive.json
@@ -1,4 +1,5 @@
 {
+  "permissionMode": "permissive",
   "enabledPlugins": {
     "beads@beads-marketplace": false
   },


### PR DESCRIPTION
## Summary
- Fixed hq-z26: gt sling now creates Claude sessions with permissive permission mode by default
- Added "permissionMode": "permissive" to both settings template files (autonomous and interactive)
- Prevents blocking permission dialog on first tool call in newly spawned polecat sessions

## Changes
Modified both Claude settings templates to include permissive permission mode:
- internal/claude/config/settings-autonomous.json
- internal/claude/config/settings-interactive.json

## Test Plan
1. Rebuild gt binary with updated templates
2. Spawn a new polecat with gt sling
3. Verify .claude/settings.json includes "permissionMode": "permissive"
4. Verify first tool call executes without permission dialog blocking

## Related Issues
- Fixes: hq-z26
- Blocks: hq-cv-dbnkm