### PR TITLE
fix(rig): suggest SSH URL when HTTPS auth fails

### DIFF
--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -690,3 +690,56 @@ func TestSplitCompoundWord(t *testing.T) {
 		})
 	}
 }
+
+func TestConvertToSSH(t *testing.T) {
+	tests := []struct {
+		name     string
+		https    string
+		wantSSH  string
+	}{
+		{
+			name:    "GitHub with .git suffix",
+			https:   "https://github.com/owner/repo.git",
+			wantSSH: "git@github.com:owner/repo.git",
+		},
+		{
+			name:    "GitHub without .git suffix",
+			https:   "https://github.com/owner/repo",
+			wantSSH: "git@github.com:owner/repo.git",
+		},
+		{
+			name:    "GitHub with org/subpath",
+			https:   "https://github.com/myorg/myproject.git",
+			wantSSH: "git@github.com:myorg/myproject.git",
+		},
+		{
+			name:    "GitLab with .git suffix",
+			https:   "https://gitlab.com/owner/repo.git",
+			wantSSH: "git@gitlab.com:owner/repo.git",
+		},
+		{
+			name:    "GitLab without .git suffix",
+			https:   "https://gitlab.com/owner/repo",
+			wantSSH: "git@gitlab.com:owner/repo.git",
+		},
+		{
+			name:    "Unknown host returns empty",
+			https:   "https://bitbucket.org/owner/repo.git",
+			wantSSH: "",
+		},
+		{
+			name:    "Non-HTTPS URL returns empty",
+			https:   "git@github.com:owner/repo.git",
+			wantSSH: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := convertToSSH(tt.https)
+			if got != tt.wantSSH {
+				t.Errorf("convertToSSH(%q) = %q, want %q", tt.https, got, tt.wantSSH)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When `gt rig add` fails because GitHub no longer supports password authentication via HTTPS, provide a helpful error message suggesting the SSH alternative.

## What Changed

**internal/rig/manager.go**:
- Added `wrapCloneError()` function that detects authentication failures
- Added `convertToSSH()` function that converts HTTPS URLs to SSH format for GitHub/GitLab
- When clone fails with auth error, the error message now includes:
  - Explanation that GitHub doesn't support password auth
  - The equivalent SSH URL to use (if detectable)

**internal/rig/manager_test.go**:
- Added tests for `convertToSSH()` covering GitHub, GitLab, and unknown hosts

## Example Error Output

Before:
```
Error: adding rig: creating bare repo: git clone: ...
remote: Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/org/private.git/'
```

After:
```
Error: adding rig: creating bare repo: git clone: ...
remote: Password authentication is not supported for Git operations.
fatal: Authentication failed for 'https://github.com/org/private.git/'

Hint: GitHub no longer supports password authentication.
Try using SSH instead:
  gt rig add <name> git@github.com:org/private.git
```

## Test plan

- [x] `go build ./cmd/gt` succeeds
- [x] `go test ./internal/rig/...` passes
- [x] `TestConvertToSSH` covers GitHub, GitLab, and unknown hosts

Note: The pre-existing beads test failures are unrelated to this change.

Fixes #548

---
Generated with [Claude Code](https://claude.ai/code)