### PR TITLE
fix(tmux): make KillSession always terminate child processes

### DIFF
--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -389,8 +389,8 @@ func stopSession(t *tmux.Tmux, sessionName string) (bool, error) {
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	// Kill the session (with explicit process termination to prevent orphans)
-	return true, t.KillSessionWithProcesses(sessionName)
+	// Kill the session (KillSession now always terminates child processes)
+	return true, t.KillSession(sessionName)
 }
 
 // stopSessionWithCache is like stopSession but uses a pre-fetched SessionSet
@@ -406,8 +406,8 @@ func stopSessionWithCache(t *tmux.Tmux, sessionName string, cache *tmux.SessionS
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	// Kill the session (with explicit process termination to prevent orphans)
-	return true, t.KillSessionWithProcesses(sessionName)
+	// Kill the session (KillSession now always terminates child processes)
+	return true, t.KillSession(sessionName)
 }
 
 // acquireShutdownLock prevents concurrent shutdowns.

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -627,7 +627,7 @@ func killSessionsInOrder(t *tmux.Tmux, sessions []string, mayorSession, deaconSe
 
 	// 1. Stop Deacon first
 	if inList(deaconSession) {
-		if err := t.KillSessionWithProcesses(deaconSession); err == nil {
+		if err := t.KillSession(deaconSession); err == nil {
 			fmt.Printf("  %s %s stopped\n", style.Bold.Render("✓"), deaconSession)
 			stopped++
 		}
@@ -638,7 +638,7 @@ func killSessionsInOrder(t *tmux.Tmux, sessions []string, mayorSession, deaconSe
 		if sess == deaconSession || sess == mayorSession {
 			continue
 		}
-		if err := t.KillSessionWithProcesses(sess); err == nil {
+		if err := t.KillSession(sess); err == nil {
 			fmt.Printf("  %s %s stopped\n", style.Bold.Render("✓"), sess)
 			stopped++
 		}
@@ -646,7 +646,7 @@ func killSessionsInOrder(t *tmux.Tmux, sessions []string, mayorSession, deaconSe
 
 	// 3. Stop Mayor last
 	if inList(mayorSession) {
-		if err := t.KillSessionWithProcesses(mayorSession); err == nil {
+		if err := t.KillSession(mayorSession); err == nil {
 			fmt.Printf("  %s %s stopped\n", style.Bold.Render("✓"), mayorSession)
 			stopped++
 		}


### PR DESCRIPTION
## Summary
- **KillSession** now kills all descendant processes before terminating the tmux session, preventing orphaned Claude processes that survive SIGHUP
- **KillSessionWithProcesses** is now a deprecated alias - all callers automatically get correct behavior
- ~35 call sites across the codebase now properly clean up child processes

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/tmux/...` passes (all 28 tests)
- [ ] Manual test: start a polecat, nuke it, verify no orphaned processes with `ps aux | grep claude`

Fixes #536

🤖 Generated with [Claude Code](https://claude.com/claude-code)