### PR TITLE
fix(daemon): prevent runaway refinery session spawning

### DIFF
--- a/internal/daemon/patrol_config_test.go
+++ b/internal/daemon/patrol_config_test.go
@@ -1,0 +1,53 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadPatrolConfig(t *testing.T) {
+	// Create a temp dir with test config
+	tmpDir := t.TempDir()
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write test config
+	configJSON := `{
+		"type": "daemon-patrol-config",
+		"version": 1,
+		"patrols": {
+			"refinery": {"enabled": false},
+			"witness": {"enabled": true}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "daemon.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Load config
+	config := LoadPatrolConfig(tmpDir)
+	if config == nil {
+		t.Fatal("expected config to be loaded")
+	}
+
+	// Test enabled flags
+	if IsPatrolEnabled(config, "refinery") {
+		t.Error("expected refinery to be disabled")
+	}
+	if !IsPatrolEnabled(config, "witness") {
+		t.Error("expected witness to be enabled")
+	}
+	if !IsPatrolEnabled(config, "deacon") {
+		t.Error("expected deacon to be enabled (default)")
+	}
+}
+
+func TestIsPatrolEnabled_NilConfig(t *testing.T) {
+	// Should default to enabled when config is nil
+	if !IsPatrolEnabled(nil, "refinery") {
+		t.Error("expected default to be enabled")
+	}
+}

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -115,9 +115,8 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 
 	if foreground {
 		// In foreground mode, check tmux session (no PID inference per ZFC)
-		townRoot := filepath.Dir(m.rig.Path)
-		agentCfg := config.ResolveRoleAgentConfig(constants.RoleRefinery, townRoot, m.rig.Path)
-		if running, _ := t.HasSession(sessionID); running && t.IsAgentRunning(sessionID, config.ExpectedPaneCommands(agentCfg)...) {
+		// Use IsClaudeRunning for robust detection (see gastown#566)
+		if running, _ := t.HasSession(sessionID); running && t.IsClaudeRunning(sessionID) {
 			return ErrAlreadyRunning
 		}
 
@@ -138,14 +137,15 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 	// Background mode: check if session already exists
 	running, _ := t.HasSession(sessionID)
 	if running {
-		// Session exists - check if agent is actually running (healthy vs zombie)
-		townRoot := filepath.Dir(m.rig.Path)
-		agentCfg := config.ResolveRoleAgentConfig(constants.RoleRefinery, townRoot, m.rig.Path)
-		if t.IsAgentRunning(sessionID, config.ExpectedPaneCommands(agentCfg)...) {
-			// Healthy - agent is running
+		// Session exists - check if Claude is actually running (healthy vs zombie)
+		// Use IsClaudeRunning for robust detection: Claude can report as "node", "claude",
+		// or version number like "2.0.76". IsAgentRunning with just "node" was too strict
+		// and caused healthy sessions to be killed. See: gastown#566
+		if t.IsClaudeRunning(sessionID) {
+			// Healthy - Claude is running
 			return ErrAlreadyRunning
 		}
-		// Zombie - tmux alive but agent dead. Kill and recreate.
+		// Zombie - tmux alive but Claude dead. Kill and recreate.
 		_, _ = fmt.Fprintln(m.output, "⚠ Detected zombie session (tmux alive, agent dead). Recreating...")
 		if err := t.KillSession(sessionID); err != nil {
 			return fmt.Errorf("killing zombie session: %w", err)


### PR DESCRIPTION
## Summary

Fixes #566 - Daemon spawns refinery sessions without checking if one already exists, causing runaway session accumulation (812 sessions over 4 days, 29+ concurrent Claude instances).

## Root Cause

**Bug 1: Zombie detection too strict**
- `refinery/manager.go` used `IsAgentRunning(session, "node")` to detect running Claude
- But Claude reports pane command as version number (e.g., `"2.1.7"`), not `"node"`
- Healthy sessions were incorrectly killed as "zombies" and recreated every heartbeat

**Bug 2: daemon.json config ignored**
- The daemon never loaded `mayor/daemon.json`
- Setting `refinery.enabled: false` had no effect

## Changes

| File | Change |
|------|--------|
| `internal/refinery/manager.go` | Use `IsClaudeRunning()` instead of `IsAgentRunning("node")` |
| `internal/daemon/types.go` | Add `PatrolConfig` types and `LoadPatrolConfig()` |
| `internal/daemon/daemon.go` | Load patrol config, check enabled flags, add diagnostic logging |
| `internal/daemon/patrol_config_test.go` | Unit tests for patrol config |

## Testing

Verified over multiple heartbeats:
```
20:47:08 Refinery session for Inspection_app started successfully
20:48:54 Refinery for Inspection_app already running, skipping spawn  ← FIX WORKING
20:52:00 Refinery for Inspection_app already running, skipping spawn
20:57:36 Refinery for Inspection_app already running, skipping spawn
```

- Process count stable (no accumulation)
- Session count stable
- Genuine zombie detection still works (tested by checking IsClaudeRunning returns false when Claude not running)

## Test plan

- [ ] Run `go test ./internal/daemon/... ./internal/refinery/...`
- [ ] Start daemon with refinery enabled
- [ ] Verify "already running, skipping spawn" appears on subsequent heartbeats
- [ ] Verify process count remains stable over multiple heartbeats