### PR TITLE
Properly place 'Getting Started' section in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,18 @@ gt mayor attach
 
 ## Quick Start Guide
 
+### Getting Started
+Run 
+```shell
+gt install ~/gt --git && 
+cd ~/gt && 
+gt config agent list && 
+gt mayor attach
+```
+and tell the Mayor what you want to build!
+
+---
+
 ### Basic Workflow
 
 ```mermaid
@@ -475,7 +487,3 @@ gt mayor attach
 ## License
 
 MIT License - see LICENSE file for details
-
----
-
-**Getting Started:** Run `gt install ~/gt --git && cd ~/gt && gt config agent list && gt mayor attach` (or `gt mayor attach --agent codex`) and tell the Mayor what you want to build!


### PR DESCRIPTION
The "Getting Started" section got jammed at the bottom, apparently by accident. Here's a better place for it.

<img width="1359" height="946" alt="image" src="https://github.com/user-attachments/assets/2a06c400-601d-4ba5-a153-7beb0fad5e1c" />