### PR TITLE
feat(agents): add GitHub Copilot CLI as built-in agent preset

### DIFF
--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -27,6 +27,8 @@ const (
 	AgentAuggie AgentPreset = "auggie"
 	// AgentAmp is Sourcegraph AMP.
 	AgentAmp AgentPreset = "amp"
+	// AgentCopilot is GitHub Copilot CLI.
+	AgentCopilot AgentPreset = "copilot"
 )
 
 // AgentPresetInfo contains the configuration details for an agent preset.
@@ -176,6 +178,17 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		ResumeStyle:         "subcommand", // 'amp threads continue <threadId>'
 		SupportsHooks:       false,
 		SupportsForkSession: false,
+	},
+	AgentCopilot: {
+		Name:         AgentCopilot,
+		Command:      "copilot",
+		Args:         []string{"--allow-all-tools", "--allow-all-paths"},
+		ProcessNames: []string{"node"},
+		ResumeFlag:   "--resume",
+		ResumeStyle:  "flag",
+		NonInteractive: &NonInteractiveConfig{
+			PromptFlag: "-p",
+		},
 	},
 }
 

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -11,7 +11,7 @@ import (
 func TestBuiltinPresets(t *testing.T) {
 	t.Parallel()
 	// Ensure all built-in presets are accessible
-	presets := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentCursor, AgentAuggie, AgentAmp}
+	presets := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentCursor, AgentAuggie, AgentAmp, AgentCopilot}
 
 	for _, preset := range presets {
 		info := GetAgentPreset(preset)
@@ -44,6 +44,7 @@ func TestGetAgentPresetByName(t *testing.T) {
 		{"cursor", AgentCursor, false},
 		{"auggie", AgentAuggie, false},
 		{"amp", AgentAmp, false},
+		{"copilot", AgentCopilot, false},
 		{"aider", "", true},    // Not built-in, can be added via config
 		{"opencode", "", true}, // Not built-in, can be added via config
 		{"unknown", "", true},
@@ -77,6 +78,7 @@ func TestRuntimeConfigFromPreset(t *testing.T) {
 		{AgentCursor, "cursor-agent"},
 		{AgentAuggie, "auggie"},
 		{AgentAmp, "amp"},
+		{AgentCopilot, "copilot"},
 	}
 
 	for _, tt := range tests {
@@ -102,6 +104,7 @@ func TestIsKnownPreset(t *testing.T) {
 		{"cursor", true},
 		{"auggie", true},
 		{"amp", true},
+		{"copilot", true},
 		{"aider", false},    // Not built-in, can be added via config
 		{"opencode", false}, // Not built-in, can be added via config
 		{"unknown", false},
@@ -315,6 +318,7 @@ func TestSupportsSessionResume(t *testing.T) {
 		{"cursor", true},
 		{"auggie", true},
 		{"amp", true},
+		{"copilot", true},
 		{"unknown", false},
 	}
 
@@ -363,6 +367,7 @@ func TestGetProcessNames(t *testing.T) {
 		{"cursor", []string{"cursor-agent"}},
 		{"auggie", []string{"auggie"}},
 		{"amp", []string{"amp"}},
+		{"copilot", []string{"node"}},
 		{"unknown", []string{"node"}}, // Falls back to Claude's process
 	}
 
@@ -385,7 +390,7 @@ func TestGetProcessNames(t *testing.T) {
 func TestListAgentPresetsMatchesConstants(t *testing.T) {
 	t.Parallel()
 	// Ensure all AgentPreset constants are returned by ListAgentPresets
-	allConstants := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentCursor, AgentAuggie, AgentAmp}
+	allConstants := []AgentPreset{AgentClaude, AgentGemini, AgentCodex, AgentCursor, AgentAuggie, AgentAmp, AgentCopilot}
 	presets := ListAgentPresets()
 
 	// Convert to map for quick lookup
@@ -446,6 +451,11 @@ func TestAgentCommandGeneration(t *testing.T) {
 			preset:       AgentAmp,
 			wantCommand:  "amp",
 			wantContains: []string{"--dangerously-allow-all", "--no-ide"},
+		},
+		{
+			preset:       AgentCopilot,
+			wantCommand:  "copilot",
+			wantContains: []string{"--allow-all-tools", "--allow-all-paths"},
 		},
 	}
 


### PR DESCRIPTION
## Summary
Add GitHub Copilot CLI as a built-in agent preset to Gas Town.

## Changes
1. Added `AgentCopilot` constant to `internal/config/agents.go`
2. Added preset to `builtinPresets` map with:
   - Command: `copilot`
   - Args: `--allow-all-tools`, `--allow-all-paths`
   - ProcessNames: `node`
   - Resume support via `--resume` flag
   - Non-interactive mode via `-p` flag
3. Updated all relevant tests to include Copilot

## Testing
All tests pass:
- `TestBuiltinPresets` - verifies Copilot preset is accessible
- `TestGetAgentPresetByName` - validates name lookup
- `TestRuntimeConfigFromPreset` - confirms command generation
- `TestIsKnownPreset` - checks preset registration
- `TestSupportsSessionResume` - validates resume capability
- `TestGetProcessNames` - confirms process detection
- `TestAgentCommandGeneration` - validates full command line

## Prerequisites Verified
- [x] Thoroughly tested copilot + Gas Town locally
- [x] Session resume works correctly
- [x] Non-interactive mode (-p flag) supported
- [x] Cloud delegation compatible (RemoteSession SDK)
