### PR TITLE
fix(install): set allowed_prefixes for convoy beads during gt install

### DIFF
--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -378,6 +378,14 @@ func initTownBeads(townPath string) error {
 		fmt.Printf("   %s Could not set custom types: %s\n", style.Dim.Render("⚠"), strings.TrimSpace(string(configOutput)))
 	}
 
+	// Configure allowed_prefixes for convoy beads (hq-cv-* IDs).
+	// This allows bd create --id=hq-cv-xxx to pass prefix validation.
+	prefixCmd := exec.Command("bd", "config", "set", "allowed_prefixes", "hq,hq-cv")
+	prefixCmd.Dir = townPath
+	if prefixOutput, prefixErr := prefixCmd.CombinedOutput(); prefixErr != nil {
+		fmt.Printf("   %s Could not set allowed_prefixes: %s\n", style.Dim.Render("⚠"), strings.TrimSpace(string(prefixOutput)))
+	}
+
 	// Ensure database has repository fingerprint (GH #25).
 	// This is idempotent - safe on both new and legacy (pre-0.17.5) databases.
 	// Without fingerprint, the bd daemon fails to start silently.


### PR DESCRIPTION
## Summary
- Convoy beads use `hq-cv-*` IDs for visual distinction from other town beads
- `gt install` was adding `hq-cv-` to `routes.jsonl` but not setting `allowed_prefixes` config
- This caused `bd create --id=hq-cv-xxx` to fail prefix validation after fresh install

## Fix
Add `allowed_prefixes` config (hq,hq-cv) during `initTownBeads()` so convoy creation works out of the box.

## Test plan
- [x] Verified convoy creation works after applying config fix
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)