### PR TITLE
fix(sling): verify session survives startup before returning success

### DIFF
--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -250,6 +250,16 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 	time.Sleep(2 * time.Second)
 	debugSession("NudgeSession PropulsionNudge", m.tmux.NudgeSession(sessionID, session.PropulsionNudge()))
 
+	// Verify session survived startup - if the command crashed, the session may have died.
+	// Without this check, Start() would return success even if the pane died during initialization.
+	running, err = m.tmux.HasSession(sessionID)
+	if err != nil {
+		return fmt.Errorf("verifying session: %w", err)
+	}
+	if !running {
+		return fmt.Errorf("session %s died during startup (agent command may have failed)", sessionID)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Fix `gt sling` failing with "getting pane" error when the Claude session dies during startup
- The `Start()` function now verifies the session is still running before returning success
- Returns a clear error message "session died during startup (agent command may have failed)" instead of the confusing "getting pane" error

## Test plan
- [x] Build passes
- [x] `internal/polecat` tests pass
- [x] `internal/tmux` tests pass

Fixes: gt-0cif0s

🤖 Generated with [Claude Code](https://claude.com/claude-code)