### PR TITLE
fix(doctor): add allowed_prefixes check for convoy beads

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -134,6 +134,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewBootHealthCheck())
 	d.Register(doctor.NewBeadsDatabaseCheck())
 	d.Register(doctor.NewCustomTypesCheck())
+	d.Register(doctor.NewAllowedPrefixesCheck())
 	d.Register(doctor.NewRoleLabelCheck())
 	d.Register(doctor.NewFormulaCheck())
 	d.Register(doctor.NewPrefixConflictCheck())

--- a/internal/doctor/config_check.go
+++ b/internal/doctor/config_check.go
@@ -775,3 +775,116 @@ func (c *CustomTypesCheck) Fix(ctx *CheckContext) error {
 	}
 	return nil
 }
+
+// AllowedPrefixesCheck verifies allowed_prefixes config includes convoy prefix.
+// Convoy beads use hq-cv-* IDs, which requires allowed_prefixes to include "hq-cv".
+type AllowedPrefixesCheck struct {
+	FixableCheck
+	townRoot string // Cached during Run for use in Fix
+}
+
+// NewAllowedPrefixesCheck creates a new allowed prefixes check.
+func NewAllowedPrefixesCheck() *AllowedPrefixesCheck {
+	return &AllowedPrefixesCheck{
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "beads-allowed-prefixes",
+				CheckDescription: "Check that allowed_prefixes includes convoy prefix (hq-cv)",
+				CheckCategory:    CategoryConfig,
+			},
+		},
+	}
+}
+
+// requiredPrefixes are the prefixes that must be in allowed_prefixes for Gas Town.
+var requiredPrefixes = []string{"hq", "hq-cv"}
+
+// Run checks if allowed_prefixes is properly configured.
+func (c *AllowedPrefixesCheck) Run(ctx *CheckContext) *CheckResult {
+	// Check if bd command is available
+	if _, err := exec.LookPath("bd"); err != nil {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "beads not installed (skipped)",
+		}
+	}
+
+	// Check if .beads directory exists at town level
+	townBeadsDir := filepath.Join(ctx.TownRoot, ".beads")
+	if _, err := os.Stat(townBeadsDir); os.IsNotExist(err) {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "No beads database (skipped)",
+		}
+	}
+
+	// Get current allowed_prefixes configuration
+	cmd := exec.Command("bd", "config", "get", "allowed_prefixes")
+	cmd.Dir = ctx.TownRoot
+	output, err := cmd.Output()
+	if err != nil {
+		// If config key doesn't exist, prefixes are not configured
+		c.townRoot = ctx.TownRoot
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: "allowed_prefixes not configured",
+			Details: []string{
+				"Convoy beads require allowed_prefixes to include 'hq' and 'hq-cv'",
+				"Without this, bd create --id=hq-cv-xxx will fail prefix validation",
+			},
+			FixHint: "Run 'gt doctor --fix' or 'bd config set allowed_prefixes \"hq,hq-cv\"'",
+		}
+	}
+
+	// Parse configured prefixes
+	configuredPrefixes := parseConfigOutput(output)
+	configuredSet := make(map[string]bool)
+	for _, p := range strings.Split(configuredPrefixes, ",") {
+		configuredSet[strings.TrimSpace(p)] = true
+	}
+
+	// Check for missing required prefixes
+	var missing []string
+	for _, required := range requiredPrefixes {
+		if !configuredSet[required] {
+			missing = append(missing, required)
+		}
+	}
+
+	if len(missing) == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "allowed_prefixes configured correctly",
+		}
+	}
+
+	// Cache for Fix
+	c.townRoot = ctx.TownRoot
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusWarning,
+		Message: fmt.Sprintf("%d required prefix(es) missing from allowed_prefixes", len(missing)),
+		Details: []string{
+			fmt.Sprintf("Missing: %s", strings.Join(missing, ", ")),
+			fmt.Sprintf("Configured: %s", configuredPrefixes),
+			fmt.Sprintf("Required: %s", strings.Join(requiredPrefixes, ", ")),
+		},
+		FixHint: "Run 'gt doctor --fix' to add missing prefixes",
+	}
+}
+
+// Fix sets allowed_prefixes to the required value.
+func (c *AllowedPrefixesCheck) Fix(ctx *CheckContext) error {
+	cmd := exec.Command("bd", "config", "set", "allowed_prefixes", strings.Join(requiredPrefixes, ","))
+	cmd.Dir = c.townRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("bd config set allowed_prefixes: %s", strings.TrimSpace(string(output)))
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Add `beads-allowed-prefixes` doctor check to verify and fix `allowed_prefixes` config
- Convoy beads use `hq-cv-*` IDs which require `allowed_prefixes` to include both `hq` and `hq-cv`
- Without this config, `bd create --id=hq-cv-xxx` fails prefix validation

## Related
- Companion to #601 which sets `allowed_prefixes` during `gt install`
- This check catches cases where the config is missing (e.g., database recreated without running `gt install`)

## The check
- Detects missing required prefixes and reports them
- Can be auto-fixed with `gt doctor --fix`
- Follows the same pattern as `CustomTypesCheck`

## Test plan
- [x] Verified check detects missing `hq-cv` prefix
- [x] Verified `--fix` restores the correct config
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)