### PR TITLE
fix(agents): use FormatStartupNudge beacon instead of bare gt prime

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -171,17 +171,21 @@ func (b *Boot) spawnTmux(agentOverride string) error {
 		return fmt.Errorf("ensuring boot dir: %w", err)
 	}
 
-	// Build startup command with optional agent override
-	// The "gt boot triage" prompt tells Boot to immediately start triage (GUPP principle)
+	// Build startup command with beacon for triage.
+	// Using beacon format provides sender/recipient context for /resume and agent discovery.
+	// NOTE: Can't import session package due to import cycle (session imports boot.SessionName),
+	// so we inline the beacon format here.
+	timestamp := time.Now().Format("2006-01-02T15:04")
+	beacon := fmt.Sprintf("[GAS TOWN] boot <- daemon • %s • triage", timestamp)
 	var startCmd string
 	if agentOverride != "" {
 		var err error
-		startCmd, err = config.BuildAgentStartupCommandWithAgentOverride("boot", "", b.townRoot, "", "gt boot triage", agentOverride)
+		startCmd, err = config.BuildAgentStartupCommandWithAgentOverride("boot", "", b.townRoot, "", beacon, agentOverride)
 		if err != nil {
 			return fmt.Errorf("building startup command with agent override: %w", err)
 		}
 	} else {
-		startCmd = config.BuildAgentStartupCommand("boot", "", b.townRoot, "", "gt boot triage")
+		startCmd = config.BuildAgentStartupCommand("boot", "", b.townRoot, "", beacon)
 	}
 
 	// Create session with command directly to avoid send-keys race condition.

--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -80,11 +80,15 @@ func (m *Manager) Start(agentOverride string) error {
 		return fmt.Errorf("ensuring Claude settings: %w", err)
 	}
 
-	// Build startup command with initial prompt for autonomous patrol.
-	// The prompt triggers GUPP: deacon starts patrol immediately without waiting for input.
-	// This prevents the agent from sitting idle at the prompt after SessionStart hooks run.
-	initialPrompt := "I am Deacon. Start patrol: check gt hook, if empty create mol-deacon-patrol wisp and execute it."
-	startupCmd, err := config.BuildAgentStartupCommandWithAgentOverride("deacon", "", m.townRoot, "", initialPrompt, agentOverride)
+	// Build startup command with beacon for autonomous patrol.
+	// The beacon triggers GUPP: deacon starts patrol immediately without waiting for input.
+	// Using FormatStartupNudge provides sender/recipient context for /resume and agent discovery.
+	beacon := session.FormatStartupNudge(session.StartupNudgeConfig{
+		Recipient: "deacon",
+		Sender:    "daemon",
+		Topic:     "patrol",
+	})
+	startupCmd, err := config.BuildAgentStartupCommandWithAgentOverride("deacon", "", m.townRoot, "", beacon, agentOverride)
 	if err != nil {
 		return fmt.Errorf("building startup command: %w", err)
 	}

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -180,10 +180,20 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 		return fmt.Errorf("ensuring runtime settings: %w", err)
 	}
 
-	// Build startup command first
+	// Build startup command with beacon.
+	// Using FormatStartupNudge provides sender/recipient context for /resume and agent discovery.
 	command := opts.Command
 	if command == "" {
-		command = config.BuildPolecatStartupCommand(m.rig.Name, polecat, m.rig.Path, "")
+		topic := "ready"
+		if opts.Issue != "" {
+			topic = "assigned"
+		}
+		beacon := session.FormatStartupNudge(session.StartupNudgeConfig{
+			Recipient: m.rig.Name + "/polecats/" + polecat,
+			Sender:    "witness",
+			Topic:     topic,
+		})
+		command = config.BuildPolecatStartupCommand(m.rig.Name, polecat, m.rig.Path, beacon)
 	}
 	// Prepend runtime config dir env if needed
 	if runtimeConfig.Session != nil && runtimeConfig.Session.ConfigDirEnv != "" && opts.RuntimeConfigDir != "" {

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -134,16 +134,22 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 		return fmt.Errorf("ensuring runtime settings: %w", err)
 	}
 
-	// Build startup command first
+	// Build startup command with beacon for autonomous patrol.
+	// Using FormatStartupNudge provides sender/recipient context for /resume and agent discovery.
+	beacon := session.FormatStartupNudge(session.StartupNudgeConfig{
+		Recipient: m.rig.Name + "/refinery",
+		Sender:    "daemon",
+		Topic:     "patrol",
+	})
 	var command string
 	if agentOverride != "" {
 		var err error
-		command, err = config.BuildAgentStartupCommandWithAgentOverride("refinery", m.rig.Name, townRoot, m.rig.Path, "", agentOverride)
+		command, err = config.BuildAgentStartupCommandWithAgentOverride("refinery", m.rig.Name, townRoot, m.rig.Path, beacon, agentOverride)
 		if err != nil {
 			return fmt.Errorf("building startup command with agent override: %w", err)
 		}
 	} else {
-		command = config.BuildAgentStartupCommand("refinery", m.rig.Name, townRoot, m.rig.Path, "")
+		command = config.BuildAgentStartupCommand("refinery", m.rig.Name, townRoot, m.rig.Path, beacon)
 	}
 
 	// Create session with command directly to avoid send-keys race condition.

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -236,10 +236,15 @@ func buildWitnessStartCommand(rigPath, rigName, townRoot, agentOverride string, 
 	if roleConfig != nil && roleConfig.StartCommand != "" {
 		return beads.ExpandRolePattern(roleConfig.StartCommand, townRoot, rigName, "", "witness"), nil
 	}
-	// Add initial prompt for autonomous patrol startup.
-	// The prompt triggers GUPP: witness starts patrol immediately without waiting for input.
-	initialPrompt := "I am Witness for " + rigName + ". Start patrol: check gt hook, if empty create mol-witness-patrol wisp and execute it."
-	command, err := config.BuildAgentStartupCommandWithAgentOverride("witness", rigName, townRoot, rigPath, initialPrompt, agentOverride)
+	// Build beacon for autonomous patrol startup.
+	// The beacon triggers GUPP: witness starts patrol immediately without waiting for input.
+	// Using FormatStartupNudge provides sender/recipient context for /resume and agent discovery.
+	beacon := session.FormatStartupNudge(session.StartupNudgeConfig{
+		Recipient: rigName + "/witness",
+		Sender:    "daemon",
+		Topic:     "patrol",
+	})
+	command, err := config.BuildAgentStartupCommandWithAgentOverride("witness", rigName, townRoot, rigPath, beacon, agentOverride)
 	if err != nil {
 		return "", fmt.Errorf("building startup command: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Extends the FormatStartupNudge pattern from commit 86739556 to manager startup files
- Fixes agents receiving bare `gt prime` instead of structured `[GAS TOWN]` beacon format
- **Now includes boot** - fixes boot sitting idle after `gt up`

## Changes
- `internal/deacon/manager.go` - Use beacon for deacon startup
- `internal/witness/manager.go` - Use beacon for witness startup
- `internal/refinery/manager.go` - Use beacon for refinery startup
- `internal/polecat/session_manager.go` - Use beacon for polecat startup
- `internal/boot/boot.go` - Use beacon for boot startup (inlined due to import cycle)

## Why
Bare CLI prompts like `gt prime` or `gt boot triage` confuse agents - they see a raw command without sender/recipient context and don't execute it. The beacon format provides:
- Sender/recipient context for agent discovery and `/resume`
- Structured topic for propulsion (patrol, work, triage)
- Consistent format across all startup paths

## Test plan
- [x] Build compiles
- [x] Restarted gastown rig - witness and refinery start with proper beacon prompts
- [x] Agents begin patrol without hanging
- [ ] Test boot spawns with beacon and runs triage

## Related
- Supersedes PR #418 (which used bare `gt prime`)
- Extends commit 86739556 pattern

🤖 Generated with [Claude Code](https://claude.ai/code)