### PR TITLE
fix(web): buffer template output to prevent superfluous WriteHeader

### DIFF
--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"html/template"
 	"net/http"
 )
@@ -57,10 +58,12 @@ func (h *ConvoyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Polecats:   polecats,
 	}
 
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-
-	if err := h.template.ExecuteTemplate(w, "convoy.html", data); err != nil {
+	var buf bytes.Buffer
+	if err := h.template.ExecuteTemplate(&buf, "convoy.html", data); err != nil {
 		http.Error(w, "Failed to render template", http.StatusInternalServerError)
 		return
 	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	buf.WriteTo(w)
 }

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"errors"
+	"html/template"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -962,6 +963,48 @@ func (m *MockConvoyFetcherWithErrors) FetchMergeQueue() ([]MergeQueueRow, error)
 
 func (m *MockConvoyFetcherWithErrors) FetchPolecats() ([]PolecatRow, error) {
 	return nil, m.PolecatsError
+}
+
+// TestConvoyHandler_TemplateErrorReturns500 verifies that template execution errors
+// return a proper 500 status code, not 200 (which would happen if we wrote directly
+// to the ResponseWriter and it failed mid-execution).
+func TestConvoyHandler_TemplateErrorReturns500(t *testing.T) {
+	// Create a template that writes some output, then fails
+	failingFuncCalled := false
+	tmpl := template.Must(template.New("convoy.html").Funcs(template.FuncMap{
+		"failAfterOutput": func() (string, error) {
+			failingFuncCalled = true
+			return "", errors.New("intentional template error")
+		},
+	}).Parse(`<!DOCTYPE html><html>{{failAfterOutput}}</html>`))
+
+	// Create handler with the failing template
+	handler := &ConvoyHandler{
+		fetcher:  &MockConvoyFetcher{Convoys: []ConvoyRow{}},
+		template: tmpl,
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if !failingFuncCalled {
+		t.Fatal("Template function was not called")
+	}
+
+	// The key assertion: status should be 500, not 200
+	// If we write directly to ResponseWriter and it fails mid-execution,
+	// headers (with 200) are already sent, so http.Error can't change it
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Status = %d, want %d (template error should return 500, not 200)", w.Code, http.StatusInternalServerError)
+	}
+
+	// Error message should be in the body
+	body := w.Body.String()
+	if !strings.Contains(body, "Failed to render template") {
+		t.Errorf("Response should contain error message, got: %q", body)
+	}
 }
 
 func TestConvoyHandler_NonFatalErrors(t *testing.T) {


### PR DESCRIPTION
## Summary

- Buffer template output to `bytes.Buffer` before writing to ResponseWriter
- Ensures proper 500 status on template errors (instead of 200 with partial content)
- Add test verifying template errors return correct status code

## Problem

When `template.ExecuteTemplate` writes directly to `http.ResponseWriter` and fails mid-execution, the implicit `WriteHeader(200)` has already been sent. Calling `http.Error` then triggers:

```
http: superfluous response.WriteHeader call from github.com/steveyegge/gastown/internal/web.(*ConvoyHandler).ServeHTTP (handler.go:63)
```

## Solution

Buffer template output first, only writing to ResponseWriter on success. This is the standard Go pattern for this problem.

## Test plan

- [x] Added `TestConvoyHandler_TemplateErrorReturns500` that verifies template errors return 500
- [x] All existing tests pass: `go test ./internal/web/...`