### PR TITLE
fix(gitinit): add missing directories to HQ .gitignore

### DIFF
--- a/internal/cmd/gitinit.go
+++ b/internal/cmd/gitinit.go
@@ -62,9 +62,10 @@ const HQGitignore = `# Gas Town HQ .gitignore
 **/state.json
 **/*.lock
 **/registry.json
+**/.events.jsonl
 
 # =============================================================================
-# Rig git worktrees (recreate with 'gt sling' or 'gt rig add')
+# Rig git worktrees and clones (recreate with 'gt sling' or 'gt rig add')
 # =============================================================================
 
 # Polecats - worker worktrees
@@ -73,15 +74,23 @@ const HQGitignore = `# Gas Town HQ .gitignore
 # Mayor rig clones
 **/mayor/rig/
 
-# Refinery working clones
-**/refinery/rig/
+# Refinery agent directories (both the clone and state)
+**/refinery/
+
+# Witness agent directories
+**/witness/
 
 # Crew workspaces (user-managed)
 **/crew/
 
 # =============================================================================
-# Runtime state directories (gitignored ephemeral data)
+# Town-level runtime directories (recreated on gt start)
 # =============================================================================
+**/daemon/
+**/deacon/
+**/logs/
+**/settings/
+**/plugins/
 **/.runtime/
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Add missing runtime and agent directories to HQGitignore template to prevent untracked files from confusing agents.

## Problem

After setting up Gas Town, agents encounter many untracked files in the HQ directory which confuse them and cause them to run wild with commits (issue #613).

The existing `.gitignore` template was missing several standard Gas Town directories:
- `witness/` - witness agent state
- `refinery/` - the entire refinery directory (not just `rig/`)
- `daemon/` - daemon runtime files
- `deacon/` - deacon agent state
- `logs/` - log files
- `settings/` - user settings
- `plugins/` - installed plugins
- `.events.jsonl` - event logs

## Solution

Update `HQGitignore` constant in `internal/cmd/gitinit.go` to include all standard Gas Town directories that should be ignored.

## Files Changed

- `internal/cmd/gitinit.go`: Added 13 lines, removed 4 lines

## Test plan

- [x] `go build ./cmd/gt` passes
- [ ] New Gas Town installations will have complete `.gitignore`
- [ ] Existing installations can run `gt gitinit` to update

Fixes #613