### PR TITLE
fix: resolve Mac hang when running in iTerm

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -44,6 +44,12 @@ func AgentEnv(cfg AgentEnvConfig) map[string]string {
 
 	env["GT_ROLE"] = cfg.Role
 
+	// CI=0 prevents Ink (Claude Code's terminal UI framework) from detecting CI mode.
+	// Some terminal emulators like iTerm may set or inherit CI=1, which causes Ink to
+	// fall into a non-interactive mode that can cause hangs and excessive resource usage.
+	// See: https://github.com/steveyegge/gastown/issues/322
+	env["CI"] = "0"
+
 	// Set role-specific variables
 	switch cfg.Role {
 	case "mayor":

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -19,6 +19,29 @@ func TestAgentEnv_Mayor(t *testing.T) {
 	assertNotSet(t, env, "BEADS_NO_DAEMON")
 }
 
+// TestAgentEnv_CI verifies that CI=0 is set for all roles.
+// This prevents Ink (Claude Code's terminal UI) from detecting CI mode,
+// which can cause hangs in terminals like iTerm.
+// See: https://github.com/steveyegge/gastown/issues/322
+func TestAgentEnv_CI(t *testing.T) {
+	t.Parallel()
+	roles := []string{"mayor", "deacon", "witness", "refinery", "polecat", "crew", "boot"}
+
+	for _, role := range roles {
+		t.Run(role, func(t *testing.T) {
+			env := AgentEnv(AgentEnvConfig{
+				Role:      role,
+				Rig:       "testrig",
+				AgentName: "testagent",
+				TownRoot:  "/town",
+			})
+
+			// CI=0 must be set to prevent Ink from detecting CI mode
+			assertEnv(t, env, "CI", "0")
+		})
+	}
+}
+
 func TestAgentEnv_Witness(t *testing.T) {
 	t.Parallel()
 	env := AgentEnv(AgentEnvConfig{


### PR DESCRIPTION
## Summary
- Set `CI=0` in agent environment variables to prevent Ink (Claude Code's terminal UI framework) from detecting CI mode
- Some terminal emulators like iTerm may set or inherit `CI=1`, which causes Ink to fall into a non-interactive mode that can cause hangs and excessive resource usage
- The fix adds `CI=0` to the centralized `AgentEnv()` function which sets environment variables for all agent roles

## Related Issue
Fixes #322

## Changes
- Added `CI=0` environment variable in `internal/config/env.go` to the `AgentEnv()` function
- Added test case in `internal/config/env_test.go` to verify `CI=0` is set for all agent roles

## Testing
- [x] Unit tests added (`TestAgentEnv_CI`)
- [x] Unit tests pass (`go test ./...`) - verified locally
- [x] Build passes (`go build -o gt ./cmd/gt`)
- [x] go vet clean

## Checklist
- [x] Code follows project style
- [x] No breaking changes