### PR TITLE
fix(agents): use CLI prompt for propulsion instead of unreliable nudges

### DIFF
--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -79,9 +79,10 @@ func (m *Manager) Start(agentOverride string) error {
 		return fmt.Errorf("ensuring Claude settings: %w", err)
 	}
 
-	// Build startup command first
+	// Build startup command with initial prompt for propulsion.
+	// The CLI prompt is more reliable than post-startup nudges (which arrive before input is ready).
 	// Restarts are handled by daemon via ensureDeaconRunning on each heartbeat
-	startupCmd, err := config.BuildAgentStartupCommandWithAgentOverride("deacon", "", m.townRoot, "", "", agentOverride)
+	startupCmd, err := config.BuildAgentStartupCommandWithAgentOverride("deacon", "", m.townRoot, "", "gt prime", agentOverride)
 	if err != nil {
 		return fmt.Errorf("building startup command: %w", err)
 	}
@@ -116,20 +117,9 @@ func (m *Manager) Start(agentOverride string) error {
 	// Accept bypass permissions warning dialog if it appears.
 	_ = t.AcceptBypassPermissionsWarning(sessionID)
 
-	time.Sleep(constants.ShutdownNotifyDelay)
-
-	// Inject startup nudge for predecessor discovery via /resume
-	_ = session.StartupNudge(t, sessionID, session.StartupNudgeConfig{
-		Recipient: "deacon",
-		Sender:    "daemon",
-		Topic:     "patrol",
-	}) // Non-fatal
-
-	// GUPP: Gas Town Universal Propulsion Principle
-	// Send the propulsion nudge to trigger autonomous patrol execution.
-	// Wait for beacon to be fully processed (needs to be separate prompt)
-	time.Sleep(2 * time.Second)
-	_ = t.NudgeSession(sessionID, session.PropulsionNudgeForRole("deacon", deaconDir)) // Non-fatal
+	// Propulsion is handled by the CLI prompt ("gt prime") passed at startup.
+	// No need for post-startup nudges which are unreliable (text arrives before input is ready).
+	// The SessionStart hook also runs "gt prime" as a backup.
 
 	return nil
 }

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -18,7 +18,6 @@ import (
 	"github.com/steveyegge/gastown/internal/mail"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/runtime"
-	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/util"
 )
@@ -173,17 +172,18 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 		return fmt.Errorf("ensuring runtime settings: %w", err)
 	}
 
-	// Build startup command first
+	// Build startup command with initial prompt for propulsion.
+	// The CLI prompt is more reliable than post-startup nudges (which arrive before input is ready).
 	townRoot := filepath.Dir(m.rig.Path)
 	var command string
 	if agentOverride != "" {
 		var err error
-		command, err = config.BuildAgentStartupCommandWithAgentOverride("refinery", m.rig.Name, townRoot, m.rig.Path, "", agentOverride)
+		command, err = config.BuildAgentStartupCommandWithAgentOverride("refinery", m.rig.Name, townRoot, m.rig.Path, "gt prime", agentOverride)
 		if err != nil {
 			return fmt.Errorf("building startup command with agent override: %w", err)
 		}
 	} else {
-		command = config.BuildAgentStartupCommand("refinery", m.rig.Name, townRoot, m.rig.Path, "")
+		command = config.BuildAgentStartupCommand("refinery", m.rig.Name, townRoot, m.rig.Path, "gt prime")
 	}
 
 	// Create session with command directly to avoid send-keys race condition.
@@ -238,19 +238,9 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 	runtime.SleepForReadyDelay(runtimeConfig)
 	_ = runtime.RunStartupFallback(t, sessionID, "refinery", runtimeConfig)
 
-	// Inject startup nudge for predecessor discovery via /resume
-	address := fmt.Sprintf("%s/refinery", m.rig.Name)
-	_ = session.StartupNudge(t, sessionID, session.StartupNudgeConfig{
-		Recipient: address,
-		Sender:    "deacon",
-		Topic:     "patrol",
-	}) // Non-fatal
-
-	// GUPP: Gas Town Universal Propulsion Principle
-	// Send the propulsion nudge to trigger autonomous patrol execution.
-	// Wait for beacon to be fully processed (needs to be separate prompt)
-	time.Sleep(2 * time.Second)
-	_ = t.NudgeSession(sessionID, session.PropulsionNudgeForRole("refinery", refineryRigDir)) // Non-fatal
+	// Propulsion is handled by the CLI prompt ("gt prime") passed at startup.
+	// No need for post-startup nudges which are unreliable (text arrives before input is ready).
+	// The SessionStart hook also runs "gt prime" as a backup.
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Fixes agent startup reliability by passing `gt prime` as a CLI argument to Claude instead of using post-startup nudges.

## Problem

Post-startup nudges are unreliable in Claude Code v2.1.4+:
- Text arrives before input is ready
- Only Enter key makes it through (empty input)
- Agents hang or enter restart cycles

This affects all agent types: Deacon, Witness, Refinery, and Polecat.

## Solution

Pass `gt prime` as a CLI prompt parameter to `BuildAgentStartupCommand*`:
- CLI prompt is queued before Claude starts
- No race condition with input readiness
- Simpler than polling + sleep workarounds

| Approach | Timing Issue? | Complexity |
|----------|---------------|------------|
| Post-startup nudges | Yes | Polling + sleeps |
| **CLI prompt** (this PR) | No | Simple |

## Changes

For each agent (Deacon, Witness, Refinery, Polecat):
1. Pass `"gt prime"` as CLI prompt parameter
2. Remove post-startup nudges
3. Remove timing sleeps
4. Keep SessionStart hook as backup

## Test Plan

- [x] Build passes
- [x] Unit tests pass
- [x] Agents start and execute gt prime immediately

Fixes #661