### PR TITLE
feat(config): add agent-specific environment variables and mayor persistence

### DIFF
--- a/internal/cmd/mayor.go
+++ b/internal/cmd/mayor.go
@@ -153,6 +153,11 @@ func runMayorAttach(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// If no explicit --agent flag, use the persisted override from start
+	if mayorAgentOverride == "" {
+		mayorAgentOverride = mgr.LoadAgentOverride()
+	}
+
 	townRoot, err := workspace.FindFromCwdOrError()
 	if err != nil {
 		return fmt.Errorf("finding workspace: %w", err)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -394,6 +394,11 @@ type RuntimeConfig struct {
 
 	// Instructions controls the per-workspace instruction file name.
 	Instructions *RuntimeInstructionsConfig `json:"instructions,omitempty"`
+
+	// Env contains environment variables to export when starting the agent.
+	// These are merged with standard Gas Town env vars (GT_ROLE, BD_ACTOR, etc).
+	// Useful for agent-specific API endpoints, auth tokens, or model overrides.
+	Env map[string]string `json:"env,omitempty"`
 }
 
 // RuntimeSessionConfig configures how Gas Town discovers runtime session IDs.


### PR DESCRIPTION
## Summary

Adds support for per-agent environment variables in runtime config and fixes Mayor agent override persistence across attach/respawn cycles.

## Problem

1. **No per-agent env vars**: All agents share the same environment, making it impossible to configure agent-specific settings (API keys, feature flags, etc.)

2. **Mayor agent override not persisted**: Running `gt mayor start --agent claude-org` works initially, but `gt mayor attach` resets to the default agent because the override isn't saved.

3. **False respawn detection**: ExpectedPaneCommands returns wrong values for claude-* wrapper scripts, causing unnecessary respawns.

## Solution

### Agent-specific environment variables
- Add `Env` field to `RuntimeConfig` for per-agent environment variables
- Update `fillRuntimeDefaults` to preserve Env field
- Export agent env vars in startup command builders

### Mayor agent persistence
- Add `PersistAgentOverride`/`LoadAgentOverride` to mayor manager
- Persist agent override on start, load on attach
- Override survives attach/respawn cycles

### ExpectedPaneCommands fix
- Return `["node", "claude"]` for claude-* wrapper scripts
- Fixes false "runtime exited" detection

## Changes

- `internal/config/runtime.go`: Add Env field and preserve in defaults
- `internal/config/startup.go`: Export env vars in startup commands
- `internal/mayor/manager.go`: Add override persistence

## Test Plan

- [x] Build passes
- [x] `gt mayor start --agent claude-org` persists across attach
- [x] Agent-specific env vars exported correctly

Fixes #692