### PR TITLE
feat(witness): send POLECAT_AVAILABLE signal after nuke

### DIFF
--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -128,6 +128,9 @@ func HandlePolecatDone(workDir, rigName string, msg *mail.Message, router *mail.
 	// No pending MR - try to auto-nuke immediately
 	nukeResult := AutoNukeIfClean(workDir, rigName, payload.PolecatName)
 	if nukeResult.Nuked {
+		// Notify Mayor that capacity is available for new work
+		NotifyMayorCapacityAvailable(workDir, rigName, payload.PolecatName)
+
 		result.Handled = true
 		result.Action = fmt.Sprintf("auto-nuked %s (exit=%s, no MR): %s", payload.PolecatName, payload.Exit, nukeResult.Reason)
 		return result
@@ -321,6 +324,9 @@ func HandleMerged(workDir, rigName string, msg *mail.Message) *HandlerResult {
 			result.Error = fmt.Errorf("nuke failed for %s: %w", payload.PolecatName, err)
 			result.Action = fmt.Sprintf("cleanup wisp %s for %s: nuke FAILED", wispID, payload.PolecatName)
 		} else {
+			// Notify Mayor that capacity is available for new work
+			NotifyMayorCapacityAvailable(workDir, rigName, payload.PolecatName)
+
 			result.Handled = true
 			result.WispCreated = wispID
 			result.Action = fmt.Sprintf("auto-nuked %s (cleanup_status=clean, wisp=%s)", payload.PolecatName, wispID)
@@ -356,6 +362,9 @@ func HandleMerged(workDir, rigName string, msg *mail.Message) *HandlerResult {
 			result.Error = fmt.Errorf("nuke failed for %s: %w", payload.PolecatName, err)
 			result.Action = fmt.Sprintf("cleanup wisp %s for %s: nuke FAILED", wispID, payload.PolecatName)
 		} else {
+			// Notify Mayor that capacity is available for new work
+			NotifyMayorCapacityAvailable(workDir, rigName, payload.PolecatName)
+
 			result.Handled = true
 			result.WispCreated = wispID
 			result.Action = fmt.Sprintf("auto-nuked %s (commit on main, cleanup_status=%s, wisp=%s)", payload.PolecatName, cleanupStatus, wispID)
@@ -829,6 +838,8 @@ func AutoNukeIfClean(workDir, rigName, polecatName string) *NukePolecatResult {
 			result.Error = err
 			result.Reason = fmt.Sprintf("nuke failed: %v", err)
 		} else {
+			// Notify Mayor that capacity is available
+			NotifyMayorCapacityAvailable(workDir, rigName, polecatName)
 			result.Nuked = true
 			result.Reason = "auto-nuked (cleanup_status=clean, no MR)"
 		}
@@ -851,6 +862,8 @@ func AutoNukeIfClean(workDir, rigName, polecatName string) *NukePolecatResult {
 				result.Error = err
 				result.Reason = fmt.Sprintf("nuke failed: %v", err)
 			} else {
+				// Notify Mayor that capacity is available
+				NotifyMayorCapacityAvailable(workDir, rigName, polecatName)
 				result.Nuked = true
 				result.Reason = "auto-nuked (commit on main, no cleanup_status)"
 			}
@@ -862,6 +875,27 @@ func AutoNukeIfClean(workDir, rigName, polecatName string) *NukePolecatResult {
 	}
 
 	return result
+}
+
+// NotifyMayorCapacityAvailable sends POLECAT_AVAILABLE signal to Mayor after a successful nuke.
+// This enables Mayor to immediately check for ready work and dispatch to the freed slot.
+// Without this signal, Mayor sleeps and work piles up until human intervention.
+func NotifyMayorCapacityAvailable(workDir, rigName, polecatName string) {
+	subject := fmt.Sprintf("POLECAT_AVAILABLE %s", rigName)
+	body := fmt.Sprintf(`Rig: %s
+Polecat: %s
+Freed-At: %s
+Status: Ready for new work assignment
+
+A polecat slot has been freed. Check for ready work and dispatch if available.`,
+		rigName,
+		polecatName,
+		time.Now().Format(time.RFC3339),
+	)
+
+	// Send mail to Mayor (fire-and-forget, non-blocking)
+	// The mail will be processed in Mayor's next patrol cycle
+	_ = util.ExecRun(workDir, "gt", "mail", "send", "mayor/", "-s", subject, "-m", body)
 }
 
 // verifyCommitOnMain checks if the polecat's current commit is on the default branch.


### PR DESCRIPTION
## Summary

Adds `NotifyMayorCapacityAvailable()` function that signals Mayor when polecat capacity becomes available, enabling autonomous work dispatch.

## Problem

After Mayor dispatches work to all available polecats, it has no way to know when capacity becomes available again. Without a signal, Mayor sleeps indefinitely while completed polecats sit idle.

This breaks the autonomous dispatch loop:
1. Mayor dispatches work → all polecats busy
2. Polecats complete work → get nuked
3. Mayor doesn't know → stays asleep
4. Work piles up despite available capacity

## Solution

Send `POLECAT_AVAILABLE` signal to Mayor whenever a polecat is successfully nuked:
- `HandlePolecatDone`: Auto-nuke path for ESCALATED/DEFERRED exits
- `HandleMerged`: Post-merge cleanup path
- `AutoNukeIfClean`: Orphan cleanup fallback

Mayor's dispatch loop can then wake and assign new work.

## Changes

- `internal/witness/handlers.go`: Add `NotifyMayorCapacityAvailable()` calls after successful nuke

## Test Plan

- [x] Build passes
- [x] Signal sent after polecat nuke
- [x] Mayor wakes and dispatches new work

Fixes #693