### PR TITLE
fix(tmux): use KillSessionWithProcesses to prevent orphaned Claude processes

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -162,7 +162,7 @@ func (b *Boot) Spawn(agentOverride string) error {
 func (b *Boot) spawnTmux(agentOverride string) error {
 	// Kill any stale session first
 	if b.IsSessionAlive() {
-		_ = b.tmux.KillSession(SessionName)
+		_ = b.tmux.KillSessionWithProcesses(SessionName)
 	}
 
 	// Ensure boot directory exists (it should have CLAUDE.md with Boot context)

--- a/internal/cmd/boot.go
+++ b/internal/cmd/boot.go
@@ -303,7 +303,7 @@ func runDegradedTriage(b *boot.Boot) (action, target string, err error) {
 			if age > 30*time.Minute {
 				// Very stuck - restart the session
 				fmt.Printf("Deacon heartbeat is %s old - restarting session\n", age.Round(time.Minute))
-				if err := tm.KillSession(deaconSession); err == nil {
+				if err := tm.KillSessionWithProcesses(deaconSession); err == nil {
 					return "restart", "deacon-stuck", nil
 				}
 			} else {

--- a/internal/cmd/crew_maintenance.go
+++ b/internal/cmd/crew_maintenance.go
@@ -32,7 +32,7 @@ func runCrewRename(cmd *cobra.Command, args []string) error {
 	t := tmux.NewTmux()
 	oldSessionID := crewSessionName(r.Name, oldName)
 	if hasSession, _ := t.HasSession(oldSessionID); hasSession {
-		if err := t.KillSession(oldSessionID); err != nil {
+		if err := t.KillSessionWithProcesses(oldSessionID); err != nil {
 			return fmt.Errorf("killing old session: %w", err)
 		}
 		fmt.Printf("Killed session %s\n", oldSessionID)

--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -460,7 +460,7 @@ func runDeaconStop(cmd *cobra.Command, args []string) error {
 	time.Sleep(100 * time.Millisecond)
 
 	// Kill the session
-	if err := t.KillSession(sessionName); err != nil {
+	if err := t.KillSessionWithProcesses(sessionName); err != nil {
 		return fmt.Errorf("killing session: %w", err)
 	}
 
@@ -561,7 +561,7 @@ func runDeaconRestart(cmd *cobra.Command, args []string) error {
 
 	if running {
 		// Kill existing session
-		if err := t.KillSession(sessionName); err != nil {
+		if err := t.KillSessionWithProcesses(sessionName); err != nil {
 			style.PrintWarning("failed to kill session: %v", err)
 		}
 	}
@@ -846,7 +846,7 @@ func runDeaconForceKill(cmd *cobra.Command, args []string) error {
 
 	// Step 2: Kill the tmux session
 	fmt.Printf("%s Killing tmux session %s...\n", style.Dim.Render("2."), sessionName)
-	if err := t.KillSession(sessionName); err != nil {
+	if err := t.KillSessionWithProcesses(sessionName); err != nil {
 		return fmt.Errorf("killing session: %w", err)
 	}
 

--- a/internal/cmd/witness.go
+++ b/internal/cmd/witness.go
@@ -197,7 +197,7 @@ func runWitnessStop(cmd *cobra.Command, args []string) error {
 	sessionName := witnessSessionName(rigName)
 	running, _ := t.HasSession(sessionName)
 	if running {
-		if err := t.KillSession(sessionName); err != nil {
+		if err := t.KillSessionWithProcesses(sessionName); err != nil {
 			style.PrintWarning("failed to kill session: %v", err)
 		}
 	}

--- a/internal/connection/local.go
+++ b/internal/connection/local.go
@@ -162,7 +162,7 @@ func (c *LocalConnection) TmuxNewSession(name, dir string) error {
 
 // TmuxKillSession terminates a tmux session.
 func (c *LocalConnection) TmuxKillSession(name string) error {
-	return c.tmux.KillSession(name)
+	return c.tmux.KillSessionWithProcesses(name)
 }
 
 // TmuxSendKeys sends keys to a tmux session.

--- a/internal/crew/manager.go
+++ b/internal/crew/manager.go
@@ -466,7 +466,7 @@ func (m *Manager) Start(name string, opts StartOptions) error {
 	if running {
 		if opts.KillExisting {
 			// Restart mode - kill existing session
-			if err := t.KillSession(sessionID); err != nil {
+			if err := t.KillSessionWithProcesses(sessionID); err != nil {
 				return fmt.Errorf("killing existing session: %w", err)
 			}
 		} else {
@@ -475,7 +475,7 @@ func (m *Manager) Start(name string, opts StartOptions) error {
 				return fmt.Errorf("%w: %s", ErrSessionRunning, sessionID)
 			}
 			// Zombie session - kill and recreate
-			if err := t.KillSession(sessionID); err != nil {
+			if err := t.KillSessionWithProcesses(sessionID); err != nil {
 				return fmt.Errorf("killing zombie session: %w", err)
 			}
 		}
@@ -569,7 +569,7 @@ func (m *Manager) Stop(name string) error {
 	}
 
 	// Kill the session
-	if err := t.KillSession(sessionID); err != nil {
+	if err := t.KillSessionWithProcesses(sessionID); err != nil {
 		return fmt.Errorf("killing session: %w", err)
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -432,7 +432,7 @@ func (d *Daemon) checkDeaconHeartbeat() {
 	if age > 30*time.Minute {
 		// Very stuck - restart the session
 		d.logger.Printf("Deacon stuck for %s - restarting session", age.Round(time.Minute))
-		if err := d.tmux.KillSession(sessionName); err != nil {
+		if err := d.tmux.KillSessionWithProcesses(sessionName); err != nil {
 			d.logger.Printf("Error killing stuck Deacon: %v", err)
 		}
 		// ensureDeaconRunning will restart on next heartbeat

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -179,7 +179,7 @@ func (d *Daemon) executeLifecycleAction(request *LifecycleRequest) error {
 	switch request.Action {
 	case ActionShutdown:
 		if running {
-			if err := d.tmux.KillSession(sessionName); err != nil {
+			if err := d.tmux.KillSessionWithProcesses(sessionName); err != nil {
 				return fmt.Errorf("killing session: %w", err)
 			}
 			d.logger.Printf("Killed session %s", sessionName)
@@ -189,7 +189,7 @@ func (d *Daemon) executeLifecycleAction(request *LifecycleRequest) error {
 	case ActionCycle, ActionRestart:
 		if running {
 			// Kill the session first
-			if err := d.tmux.KillSession(sessionName); err != nil {
+			if err := d.tmux.KillSessionWithProcesses(sessionName); err != nil {
 				return fmt.Errorf("killing session: %w", err)
 			}
 			d.logger.Printf("Killed session %s for restart", sessionName)

--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -63,7 +63,7 @@ func (m *Manager) Start(agentOverride string) error {
 			return ErrAlreadyRunning
 		}
 		// Zombie - tmux alive but Claude dead. Kill and recreate.
-		if err := t.KillSession(sessionID); err != nil {
+		if err := t.KillSessionWithProcesses(sessionID); err != nil {
 			return fmt.Errorf("killing zombie session: %w", err)
 		}
 	}
@@ -153,7 +153,7 @@ func (m *Manager) Stop() error {
 	time.Sleep(100 * time.Millisecond)
 
 	// Kill the session
-	if err := t.KillSession(sessionID); err != nil {
+	if err := t.KillSessionWithProcesses(sessionID); err != nil {
 		return fmt.Errorf("killing session: %w", err)
 	}
 

--- a/internal/doctor/claude_settings_check.go
+++ b/internal/doctor/claude_settings_check.go
@@ -511,7 +511,7 @@ func (c *ClaudeSettingsCheck) Fix(ctx *CheckContext) error {
 				running, _ := t.HasSession(sf.sessionName)
 				if running {
 					// Cycle the agent by killing and letting gt up restart it
-					_ = t.KillSession(sf.sessionName)
+					_ = t.KillSessionWithProcesses(sf.sessionName)
 				}
 			}
 		}

--- a/internal/doctor/orphan_check.go
+++ b/internal/doctor/orphan_check.go
@@ -150,7 +150,7 @@ func (c *OrphanSessionCheck) Fix(ctx *CheckContext) error {
 		// Log pre-death event for crash investigation (before killing)
 		_ = events.LogFeed(events.TypeSessionDeath, sess,
 			events.SessionDeathPayload(sess, "unknown", "orphan cleanup", "gt doctor"))
-		if err := t.KillSession(sess); err != nil {
+		if err := t.KillSessionWithProcesses(sess); err != nil {
 			lastErr = err
 		}
 	}

--- a/internal/doctor/tmux_check.go
+++ b/internal/doctor/tmux_check.go
@@ -123,7 +123,7 @@ func (c *LinkedPaneCheck) Fix(ctx *CheckContext) error {
 	var lastErr error
 
 	for _, session := range c.linkedSessions {
-		if err := t.KillSession(session); err != nil {
+		if err := t.KillSessionWithProcesses(session); err != nil {
 			lastErr = err
 		}
 	}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -726,7 +726,7 @@ func (m *Manager) ReconcilePoolWith(namesWithDirs, namesWithSessions []string) {
 		for _, name := range namesWithSessions {
 			if !dirSet[name] {
 				sessionName := fmt.Sprintf("gt-%s-%s", m.rig.Name, name)
-				_ = m.tmux.KillSession(sessionName)
+				_ = m.tmux.KillSessionWithProcesses(sessionName)
 			}
 		}
 	}

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -289,7 +289,7 @@ func (m *SessionManager) Stop(polecat string, force bool) error {
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	if err := m.tmux.KillSession(sessionID); err != nil {
+	if err := m.tmux.KillSessionWithProcesses(sessionID); err != nil {
 		return fmt.Errorf("killing session: %w", err)
 	}
 

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -147,7 +147,7 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 		}
 		// Zombie - tmux alive but Claude dead. Kill and recreate.
 		_, _ = fmt.Fprintln(m.output, "⚠ Detected zombie session (tmux alive, agent dead). Recreating...")
-		if err := t.KillSession(sessionID); err != nil {
+		if err := t.KillSessionWithProcesses(sessionID); err != nil {
 			return fmt.Errorf("killing zombie session: %w", err)
 		}
 	}
@@ -219,7 +219,7 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 	ref.StartedAt = &now
 	ref.PID = 0 // Claude agent doesn't have a PID we track
 	if err := m.saveState(ref); err != nil {
-		_ = t.KillSession(sessionID) // best-effort cleanup on state save failure
+		_ = t.KillSessionWithProcesses(sessionID) // best-effort cleanup on state save failure
 		return fmt.Errorf("saving state: %w", err)
 	}
 
@@ -274,7 +274,7 @@ func (m *Manager) Stop() error {
 
 	// Kill tmux session if it exists (best-effort: may already be dead)
 	if sessionRunning {
-		_ = t.KillSession(sessionID)
+		_ = t.KillSessionWithProcesses(sessionID)
 	}
 
 	// Note: No PID-based stop per ZFC - tmux session kill is sufficient

--- a/internal/session/town.go
+++ b/internal/session/town.go
@@ -69,7 +69,7 @@ func stopTownSessionInternal(t *tmux.Tmux, ts TownSession, force bool) (bool, er
 		events.SessionDeathPayload(ts.SessionID, ts.Name, reason, "gt down"))
 
 	// Kill the session
-	if err := t.KillSession(ts.SessionID); err != nil {
+	if err := t.KillSessionWithProcesses(ts.SessionID); err != nil {
 		return false, fmt.Errorf("killing %s session: %w", ts.Name, err)
 	}
 

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -662,7 +662,7 @@ func NukePolecat(workDir, rigName, polecatName string) error {
 		// Brief delay for graceful handling
 		time.Sleep(100 * time.Millisecond)
 		// Force kill the session
-		if err := t.KillSession(sessionName); err != nil {
+		if err := t.KillSessionWithProcesses(sessionName); err != nil {
 			// Log but continue - session might already be dead
 			// The important thing is we tried
 		}

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -136,7 +136,7 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 			return ErrAlreadyRunning
 		}
 		// Zombie - tmux alive but Claude dead. Kill and recreate.
-		if err := t.KillSession(sessionID); err != nil {
+		if err := t.KillSessionWithProcesses(sessionID); err != nil {
 			return fmt.Errorf("killing zombie session: %w", err)
 		}
 	}
@@ -207,7 +207,7 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	w.PID = 0 // Claude agent doesn't have a PID we track
 	w.MonitoredPolecats = m.rig.Polecats
 	if err := m.saveState(w); err != nil {
-		_ = t.KillSession(sessionID) // best-effort cleanup on state save failure
+		_ = t.KillSessionWithProcesses(sessionID) // best-effort cleanup on state save failure
 		return fmt.Errorf("saving state: %w", err)
 	}
 
@@ -303,7 +303,7 @@ func (m *Manager) Stop() error {
 
 	// Kill tmux session if it exists (best-effort: may already be dead)
 	if sessionRunning {
-		_ = t.KillSession(sessionID)
+		_ = t.KillSessionWithProcesses(sessionID)
 	}
 
 	// Note: No PID-based stop per ZFC - tmux session kill is sufficient


### PR DESCRIPTION
## Summary

Replaces all `KillSession()` calls with `KillSessionWithProcesses()` to ensure proper cleanup of child processes when terminating tmux sessions.

## Problem

Standard `tmux kill-session` leaves child processes (Claude, node) running as orphans when the session is terminated. These orphaned processes:
- Consume CPU and memory
- Hold file locks
- Cause resource leaks over time

## Solution

`KillSessionWithProcesses()` performs thorough cleanup:
1. Recursive process discovery via `pgrep -P`
2. SIGTERM to deepest processes first (bottom-up)
3. 100ms wait for graceful shutdown
4. SIGKILL to remaining processes
5. Then kills the tmux session

## Changes

Updated all session termination paths to use `KillSessionWithProcesses()`:
- Agent shutdown (deacon, witness, refinery, polecat)
- Session restart/repair
- Orphan cleanup
- `gt down` shutdown

## Test Plan

- [x] Build passes
- [x] No orphaned Claude/node processes after session kill
- [x] CPU usage returns to baseline after shutdown

Based on discussion from upstream PR #524

Fixes #699