### PR TITLE
fix: make gt agents default to list output

### DIFF
--- a/internal/cmd/agents.go
+++ b/internal/cmd/agents.go
@@ -62,14 +62,14 @@ var agentsCmd = &cobra.Command{
 	Use:     "agents",
 	Aliases: []string{"ag"},
 	GroupID: GroupAgents,
-	Short:   "Switch between Gas Town agent sessions",
-	Long: `Display a popup menu of core Gas Town agent sessions.
+	Short:   "List Gas Town agent sessions",
+	Long: `List core Gas Town agent sessions.
 
 Shows Mayor, Deacon, Witnesses, Refineries, and Crew workers.
 Polecats are hidden (use 'gt polecat list' to see them).
 
-The menu appears as a tmux popup for quick session switching.`,
-	RunE: runAgents,
+Use 'gt agents menu' for an interactive popup menu.`,
+	RunE: runAgentsList,
 }
 
 var agentsListCmd = &cobra.Command{
@@ -77,6 +77,18 @@ var agentsListCmd = &cobra.Command{
 	Short: "List agent sessions (no popup)",
 	Long:  `List all agent sessions to stdout without the popup menu.`,
 	RunE:  runAgentsList,
+}
+
+var agentsMenuCmd = &cobra.Command{
+	Use:   "menu",
+	Short: "Show interactive agent switcher menu",
+	Long: `Display a popup menu of core Gas Town agent sessions.
+
+Shows Mayor, Deacon, Witnesses, Refineries, and Crew workers.
+Polecats are hidden unless --all is specified.
+
+The menu appears as a tmux popup for quick session switching.`,
+	RunE: runAgentsMenu,
 }
 
 var agentsCheckCmd = &cobra.Command{
@@ -120,6 +132,7 @@ func init() {
 	agentsCheckCmd.Flags().BoolVar(&agentsCheckJSON, "json", false, "Output as JSON")
 
 	agentsCmd.AddCommand(agentsListCmd)
+	agentsCmd.AddCommand(agentsMenuCmd)
 	agentsCmd.AddCommand(agentsCheckCmd)
 	agentsCmd.AddCommand(agentsFixCmd)
 	rootCmd.AddCommand(agentsCmd)
@@ -284,7 +297,7 @@ func shortcutKey(index int) string {
 	return ""
 }
 
-func runAgents(cmd *cobra.Command, args []string) error {
+func runAgentsMenu(cmd *cobra.Command, args []string) error {
 	agents, err := getAgentSessions(agentsAllFlag)
 	if err != nil {
 		return fmt.Errorf("listing sessions: %w", err)


### PR DESCRIPTION
## Summary

- Change `gt agents` to show a non-blocking list by default instead of the tmux popup menu
- The popup menu is now available via `gt agents menu`

This improves UX for scripting and non-interactive use cases where the popup would block.

Fixes #658

## Test plan

- [x] `gt agents` shows list output (non-blocking)
- [x] `gt agents menu` shows the popup menu  
- [x] `gt agents list` unchanged
- [x] Tests pass