### PR TITLE
Fix GT_ROOT export for beads formula search compatibility

### DIFF
--- a/internal/cmd/rig_detect.go
+++ b/internal/cmd/rig_detect.go
@@ -30,10 +30,11 @@ for fast lookups by the shell hook.
 
 Output format (to stdout):
   export GT_TOWN_ROOT=/path/to/town
+  export GT_ROOT=/path/to/town
   export GT_RIG=rigname
 
 Or if not in a rig:
-  unset GT_TOWN_ROOT GT_RIG`,
+  unset GT_TOWN_ROOT GT_ROOT GT_RIG`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runRigDetect,
 }
@@ -63,9 +64,11 @@ func runRigDetect(cmd *cobra.Command, args []string) error {
 
 	if rigName != "" {
 		fmt.Printf("export GT_TOWN_ROOT=%q\n", townRoot)
+		fmt.Printf("export GT_ROOT=%q\n", townRoot)
 		fmt.Printf("export GT_RIG=%q\n", rigName)
 	} else {
 		fmt.Printf("export GT_TOWN_ROOT=%q\n", townRoot)
+		fmt.Printf("export GT_ROOT=%q\n", townRoot)
 		fmt.Println("unset GT_RIG")
 	}
 
@@ -105,7 +108,7 @@ func detectRigFromPath(townRoot, absPath string) string {
 }
 
 func outputNotInRig() error {
-	fmt.Println("unset GT_TOWN_ROOT GT_RIG")
+	fmt.Println("unset GT_TOWN_ROOT GT_ROOT GT_RIG")
 	return nil
 }
 
@@ -129,11 +132,11 @@ func updateRigCache(repoRoot, townRoot, rigName string) error {
 
 	var value string
 	if rigName != "" {
-		value = fmt.Sprintf("export GT_TOWN_ROOT=%q; export GT_RIG=%q", townRoot, rigName)
+		value = fmt.Sprintf("export GT_TOWN_ROOT=%q; export GT_ROOT=%q; export GT_RIG=%q", townRoot, townRoot, rigName)
 	} else if townRoot != "" {
-		value = fmt.Sprintf("export GT_TOWN_ROOT=%q; unset GT_RIG", townRoot)
+		value = fmt.Sprintf("export GT_TOWN_ROOT=%q; export GT_ROOT=%q; unset GT_RIG", townRoot, townRoot)
 	} else {
-		value = "unset GT_TOWN_ROOT GT_RIG"
+		value = "unset GT_TOWN_ROOT GT_ROOT GT_RIG"
 	}
 
 	existing[repoRoot] = value


### PR DESCRIPTION
## Problem

Gas Town and Beads use different environment variable names for the same purpose:
- **Gas Town** sets `GT_TOWN_ROOT` via `gt rig detect`
- **Beads** looks for `GT_ROOT` when searching for formulas

This naming inconsistency causes beads to not find town-level formulas, resulting in:
- `bd mol seed --patrol` fails in rig directories
- `gt doctor` shows false warnings about missing patrol formulas
- Formula search only works at project and user levels, not orchestrator level

## Solution

Export **both** `GT_TOWN_ROOT` and `GT_ROOT` from `gt rig detect` command. Both variables point to the same town root path.

**Changes:**
1. Updated stdout output to export `GT_ROOT` alongside `GT_TOWN_ROOT` (lines 66, 70)
2. Updated cache storage format to include `GT_ROOT` (lines 134, 136, 138)
3. Updated unset statement for both variables (line 110)
4. Updated command documentation (lines 33, 37)

## Benefits

- **Backward compatible**: Existing Gas Town code using `GT_TOWN_ROOT` continues to work
- **Forward compatible**: Beads formula search using `GT_ROOT` now works correctly
- **Fixes integration issue**: Three-tier formula search path now fully functional:
  1. `.beads/formulas/` (project level)
  2. `~/.beads/formulas/` (user level)
  3. `$GT_ROOT/.beads/formulas/` (orchestrator level) ← this now works

## Testing

```bash
# Test from town root
$ gt rig detect /home/yoda/Development/Work/ailtir-town
export GT_TOWN_ROOT="/home/yoda/Development/Work/ailtir-town"
export GT_ROOT="/home/yoda/Development/Work/ailtir-town"
unset GT_RIG

# Test from rig directory
$ gt rig detect /home/yoda/Development/Work/ailtir-town/pgqueue
export GT_TOWN_ROOT="/home/yoda/Development/Work/ailtir-town"
export GT_ROOT="/home/yoda/Development/Work/ailtir-town"
export GT_RIG="pgqueue"

# Test beads formula search
$ cd /home/yoda/Development/Work/ailtir-town/pgqueue
$ eval "$(gt rig detect .)"
$ bd mol seed --patrol
✓ All patrol formulas accessible
```

## Related PRs

This PR completes a three-part fix for the patrol formula system:

1. **steveyegge/gastown#715** - Fix doctor check to verify formulas instead of placeholder beads
2. **steveyegge/beads#1149** - Implement `bd mol seed --patrol` command
3. **This PR** - Export `GT_ROOT` for beads formula search

All three PRs work together to fix the Gas Town + Beads integration.

## Notes

The naming inconsistency (`GT_TOWN_ROOT` vs `GT_ROOT`) likely arose from:
- Gas Town using "town" terminology consistently
- Beads using more generic "root" terminology

Rather than breaking existing code by renaming `GT_TOWN_ROOT`, this PR adds `GT_ROOT` as an alias. Future Gas Town code can use either variable name, and both will be maintained for compatibility.