### PR TITLE
Fix settings templates to use 'gt prime --hook' for session ID tracking

### DIFF
--- a/internal/claude/config/settings-autonomous.json
+++ b/internal/claude/config/settings-autonomous.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime && gt mail check --inject && gt nudge deacon session-started"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime --hook && gt mail check --inject && gt nudge deacon session-started"
           }
         ]
       }
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime --hook"
           }
         ]
       }

--- a/internal/claude/config/settings-interactive.json
+++ b/internal/claude/config/settings-interactive.json
@@ -9,7 +9,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime && gt nudge deacon session-started"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime --hook && gt nudge deacon session-started"
           }
         ]
       }
@@ -20,7 +20,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime --hook"
           }
         ]
       }


### PR DESCRIPTION
## Summary

Both `settings-autonomous.json` and `settings-interactive.json` templates were using bare `gt prime` in SessionStart and PreCompact hooks, causing `gt doctor` to report warnings about missing `--hook` flag.

## Problem

The templates generate settings files with:
```bash
gt prime && gt mail check --inject
```

But `gt doctor` expects:
```bash
gt prime --hook && gt mail check --inject
```

The `--hook` flag is required for proper session ID passthrough from Claude Code. When called as a hook, `gt prime --hook` reads session metadata (session_id, transcript_path, source) from stdin JSON that Claude Code provides.

Without `--hook`, session tracking breaks and `gt doctor` correctly warns:
> SessionStart uses bare 'gt prime' - add --hook flag or use session-start.sh

## Solution

Updated both template files to use `gt prime --hook` in:
- SessionStart hooks (line 12)
- PreCompact hooks (line 23)

## Impact

New installations will now generate settings.json files with the correct format that passes `gt doctor` validation.

Existing installations will still show the warning until they manually update their settings files or run `gt doctor --fix` (if that feature is implemented).

## Testing

- Verified the templates now match the format expected by `gt doctor`
- Changes are minimal and localized to the two template files

🤖 Generated with [Claude Code](https://claude.com/claude-code)