### PR TITLE
fix(process): Additional KillSessionWithProcesses

### DIFF
--- a/internal/cmd/boot.go
+++ b/internal/cmd/boot.go
@@ -301,9 +301,9 @@ func runDegradedTriage(b *boot.Boot) (action, target string, err error) {
 			// Nudge the session to try to wake it up
 			age := hb.Age()
 			if age > 30*time.Minute {
-				// Very stuck - restart the session
+				// Very stuck - restart the session (kill all child processes too)
 				fmt.Printf("Deacon heartbeat is %s old - restarting session\n", age.Round(time.Minute))
-				if err := tm.KillSession(deaconSession); err == nil {
+				if err := tm.KillSessionWithProcesses(deaconSession); err == nil {
 					return "restart", "deacon-stuck", nil
 				}
 			} else {

--- a/internal/cmd/crew_maintenance.go
+++ b/internal/cmd/crew_maintenance.go
@@ -28,11 +28,11 @@ func runCrewRename(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Kill any running session for the old name
+	// Kill any running session for the old name (including child processes)
 	t := tmux.NewTmux()
 	oldSessionID := crewSessionName(r.Name, oldName)
 	if hasSession, _ := t.HasSession(oldSessionID); hasSession {
-		if err := t.KillSession(oldSessionID); err != nil {
+		if err := t.KillSessionWithProcesses(oldSessionID); err != nil {
 			return fmt.Errorf("killing old session: %w", err)
 		}
 		fmt.Printf("Killed session %s\n", oldSessionID)

--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -459,8 +459,8 @@ func runDeaconStop(cmd *cobra.Command, args []string) error {
 	_ = t.SendKeysRaw(sessionName, "C-c")
 	time.Sleep(100 * time.Millisecond)
 
-	// Kill the session
-	if err := t.KillSession(sessionName); err != nil {
+	// Kill the session and all child processes
+	if err := t.KillSessionWithProcesses(sessionName); err != nil {
 		return fmt.Errorf("killing session: %w", err)
 	}
 
@@ -560,8 +560,8 @@ func runDeaconRestart(cmd *cobra.Command, args []string) error {
 	fmt.Println("Restarting Deacon...")
 
 	if running {
-		// Kill existing session
-		if err := t.KillSession(sessionName); err != nil {
+		// Kill existing session and all child processes
+		if err := t.KillSessionWithProcesses(sessionName); err != nil {
 			style.PrintWarning("failed to kill session: %v", err)
 		}
 	}
@@ -844,9 +844,9 @@ func runDeaconForceKill(cmd *cobra.Command, args []string) error {
 	mailBody := fmt.Sprintf("Deacon detected %s as unresponsive.\nReason: %s\nAction: force-killing session", agent, reason)
 	sendMail(townRoot, agent, "FORCE_KILL: unresponsive", mailBody)
 
-	// Step 2: Kill the tmux session
+	// Step 2: Kill the tmux session and all child processes
 	fmt.Printf("%s Killing tmux session %s...\n", style.Dim.Render("2."), sessionName)
-	if err := t.KillSession(sessionName); err != nil {
+	if err := t.KillSessionWithProcesses(sessionName); err != nil {
 		return fmt.Errorf("killing session: %w", err)
 	}
 

--- a/internal/cmd/witness.go
+++ b/internal/cmd/witness.go
@@ -192,12 +192,12 @@ func runWitnessStop(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Kill tmux session if it exists
+	// Kill tmux session and child processes if it exists
 	t := tmux.NewTmux()
 	sessionName := witnessSessionName(rigName)
 	running, _ := t.HasSession(sessionName)
 	if running {
-		if err := t.KillSession(sessionName); err != nil {
+		if err := t.KillSessionWithProcesses(sessionName); err != nil {
 			style.PrintWarning("failed to kill session: %v", err)
 		}
 	}

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -289,7 +289,8 @@ func (m *SessionManager) Stop(polecat string, force bool) error {
 		time.Sleep(100 * time.Millisecond)
 	}
 
-	if err := m.tmux.KillSession(sessionID); err != nil {
+	// Use KillSessionWithProcesses to ensure Claude and its children are terminated
+	if err := m.tmux.KillSessionWithProcesses(sessionID); err != nil {
 		return fmt.Errorf("killing session: %w", err)
 	}
 

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -661,8 +661,9 @@ func NukePolecat(workDir, rigName, polecatName string) error {
 		_ = t.SendKeysRaw(sessionName, "C-c")
 		// Brief delay for graceful handling
 		time.Sleep(100 * time.Millisecond)
-		// Force kill the session
-		if err := t.KillSession(sessionName); err != nil {
+		// Force kill the session and all child processes
+		// Use KillSessionWithProcesses to ensure Claude and its children are terminated
+		if err := t.KillSessionWithProcesses(sessionName); err != nil {
 			// Log but continue - session might already be dead
 			// The important thing is we tried
 		}

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -136,7 +136,8 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 			return ErrAlreadyRunning
 		}
 		// Zombie - tmux alive but Claude dead. Kill and recreate.
-		if err := t.KillSession(sessionID); err != nil {
+		// Use KillSessionWithProcesses to ensure any lingering child processes are terminated
+		if err := t.KillSessionWithProcesses(sessionID); err != nil {
 			return fmt.Errorf("killing zombie session: %w", err)
 		}
 	}
@@ -207,7 +208,7 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	w.PID = 0 // Claude agent doesn't have a PID we track
 	w.MonitoredPolecats = m.rig.Polecats
 	if err := m.saveState(w); err != nil {
-		_ = t.KillSession(sessionID) // best-effort cleanup on state save failure
+		_ = t.KillSessionWithProcesses(sessionID) // best-effort cleanup on state save failure
 		return fmt.Errorf("saving state: %w", err)
 	}
 
@@ -301,9 +302,9 @@ func (m *Manager) Stop() error {
 		return ErrNotRunning
 	}
 
-	// Kill tmux session if it exists (best-effort: may already be dead)
+	// Kill tmux session and child processes if it exists (best-effort: may already be dead)
 	if sessionRunning {
-		_ = t.KillSession(sessionID)
+		_ = t.KillSessionWithProcesses(sessionID)
 	}
 
 	// Note: No PID-based stop per ZFC - tmux session kill is sufficient


### PR DESCRIPTION
## Summary
Replace all remaining KillSession() calls with KillSessionWithProcesses() to ensure Claude and its child processes are properly terminated when sessions are killed.

This follows pattern started started in 2feefd17 which fixed done.go and crew_lifecycle.go but missed several other code paths.

Without this fix, nuked polecats would leave orphaned Claude processes that accumulated over time and consumed resources.


## Related Issue
None

## Changes
- witness/handlers.go: NukePolecat() - the main auto-nuke path
- polecat/session_manager.go: SessionManager.Stop()
- cmd/deacon.go: stop, restart, and force-kill commands
- witness/manager.go: zombie cleanup, state save failure, and Stop()
- cmd/witness.go: gt witness stop
- cmd/crew_maintenance.go: crew rename cleanup
- cmd/boot.go: stuck deacon restart

## Testing
<!-- How did you test these changes? -->
- [X] Unit tests pass (`go test ./...`)
- [ ] Manual testing performed

## Checklist
- [X] Code follows project style
- [ ] Documentation updated (if applicable)
- [X] No breaking changes (or documented in summary)
