### PR TITLE
fix(daemon): spawn Deacon immediately after killing stuck session

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -435,7 +435,9 @@ func (d *Daemon) checkDeaconHeartbeat() {
 		if err := d.tmux.KillSession(sessionName); err != nil {
 			d.logger.Printf("Error killing stuck Deacon: %v", err)
 		}
-		// ensureDeaconRunning will restart on next heartbeat
+		// Spawn new Deacon immediately instead of waiting for next heartbeat
+		// (kill may fail if session disappeared between check and kill)
+		d.ensureDeaconRunning()
 	} else {
 		// Stuck but not critically - nudge to wake up
 		d.logger.Printf("Deacon stuck for %s - nudging session", age.Round(time.Minute))


### PR DESCRIPTION
## Summary

- Fixes bug where Deacon never restarts after daemon kills a stuck session
- Calls `ensureDeaconRunning()` immediately after kill attempt instead of waiting for next heartbeat

## Problem

When `checkDeaconHeartbeat()` detects a stuck Deacon (heartbeat >30 min stale), it kills the session but relies on `ensureDeaconRunning()` being called on the next heartbeat cycle.

However, on the next heartbeat:
1. `ensureDeaconRunning()` runs first but session doesn't exist, so `deacon.Manager.Start()` tries to create one
2. `checkDeaconHeartbeat()` runs next, sees no session, and exits early at line 425-428 assuming "ensureDeaconRunning already ran earlier"

The race condition: if the kill fails (e.g., "session not found" because session disappeared between HasSession check and KillSession call), the Deacon is never restarted.

**Evidence from logs:**
```
15:57:01 Deacon heartbeat is stale (3h54m0s old), checking session...
15:57:01 Deacon stuck for 3h54m0s - restarting session
15:57:01 Error killing stuck Deacon: session not found
```
(No "Deacon started successfully" follows)

## Solution

Call `d.ensureDeaconRunning()` immediately after the kill attempt in `checkDeaconHeartbeat()`, regardless of whether the kill succeeded or failed.

## Test plan

- [x] Build passes
- [x] Unit tests pass (`go test ./internal/daemon/...`)
- [ ] Manual testing: kill deacon session, verify daemon restarts it immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)