### PR TITLE
fix: ExpectedPaneCommands returns both node and claude for Claude Code

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1461,13 +1461,14 @@ func BuildCrewStartupCommandWithAgentOverride(rigName, crewName, rigPath, prompt
 }
 
 // ExpectedPaneCommands returns tmux pane command names that indicate the runtime is running.
-// For example, Claude runs as "node", while most other runtimes report their executable name.
+// Claude can report as "node" (older versions) or "claude" (newer versions).
+// Other runtimes typically report their executable name.
 func ExpectedPaneCommands(rc *RuntimeConfig) []string {
 	if rc == nil || rc.Command == "" {
 		return nil
 	}
 	if filepath.Base(rc.Command) == "claude" {
-		return []string{"node"}
+		return []string{"node", "claude"}
 	}
 	return []string{filepath.Base(rc.Command)}
 }

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -1429,10 +1429,11 @@ func TestGetRuntimeCommand_UsesRigAgentWhenRigPathProvided(t *testing.T) {
 
 func TestExpectedPaneCommands(t *testing.T) {
 	t.Parallel()
-	t.Run("claude maps to node", func(t *testing.T) {
+	t.Run("claude maps to node and claude", func(t *testing.T) {
 		got := ExpectedPaneCommands(&RuntimeConfig{Command: "claude"})
-		if len(got) != 1 || got[0] != "node" {
-			t.Fatalf("ExpectedPaneCommands(claude) = %v, want %v", got, []string{"node"})
+		want := []string{"node", "claude"}
+		if len(got) != 2 || got[0] != "node" || got[1] != "claude" {
+			t.Fatalf("ExpectedPaneCommands(claude) = %v, want %v", got, want)
 		}
 	})
 


### PR DESCRIPTION

## Summary
Newer versions of Claude Code report the tmux pane command as "claude" instead of "node". This caused gt mayor attach (and similar commands) to incorrectly detect that the runtime had exited and restart the session.

The fix adds "claude" to the expected pane commands alongside "node", matching the behavior of IsClaudeRunning() which already handles both.


## Changes

- add “claude” to the list of `ExpectedPaneCommands`

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed
-

## Checklist
- [x] Code follows project style
- [x[ No breaking changes
