### PR TITLE
Fix orphan detection to recognize hq-* sessions

### DIFF
--- a/internal/doctor/orphan_check_test.go
+++ b/internal/doctor/orphan_check_test.go
@@ -353,6 +353,37 @@ func TestIsCrewSession_ComprehensivePatterns(t *testing.T) {
 	}
 }
 
+// TestOrphanSessionCheck_HQSessions tests that hq-* sessions are properly recognized as valid.
+func TestOrphanSessionCheck_HQSessions(t *testing.T) {
+	townRoot := t.TempDir()
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0o755); err != nil {
+		t.Fatalf("create mayor dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte("{}"), 0o644); err != nil {
+		t.Fatalf("create rigs.json: %v", err)
+	}
+
+	lister := &mockSessionLister{
+		sessions: []string{
+			"hq-mayor",   // valid: headquarters mayor session
+			"hq-deacon",  // valid: headquarters deacon session
+		},
+	}
+	check := NewOrphanSessionCheckWithSessionLister(lister)
+	result := check.Run(&CheckContext{TownRoot: townRoot})
+
+	if result.Status != StatusOK {
+		t.Fatalf("expected StatusOK for valid hq sessions, got %v: %s", result.Status, result.Message)
+	}
+	if result.Message != "All 2 Gas Town sessions are valid" {
+		t.Fatalf("unexpected message: %q", result.Message)
+	}
+	if len(check.orphanSessions) != 0 {
+		t.Fatalf("expected no orphan sessions, got %v", check.orphanSessions)
+	}
+}
+
 // TestOrphanSessionCheck_Run_Deterministic tests the full Run path with a mock session
 // lister, ensuring deterministic behavior without depending on real tmux state.
 func TestOrphanSessionCheck_Run_Deterministic(t *testing.T) {
@@ -378,9 +409,11 @@ func TestOrphanSessionCheck_Run_Deterministic(t *testing.T) {
 			"gt-gastown-witness",      // valid: gastown rig exists
 			"gt-gastown-polecat1",     // valid: gastown rig exists
 			"gt-beads-refinery",       // valid: beads rig exists
+			"hq-mayor",                // valid: hq-mayor is recognized
+			"hq-deacon",               // valid: hq-deacon is recognized
 			"gt-unknown-witness",      // orphan: unknown rig doesn't exist
 			"gt-missing-crew-joe",     // orphan: missing rig doesn't exist
-			"random-session",          // ignored: doesn't match gt-* pattern
+			"random-session",          // ignored: doesn't match gt-*/hq-* pattern
 		},
 	}
 	check := NewOrphanSessionCheckWithSessionLister(lister)


### PR DESCRIPTION
## Summary

The daemon creates `hq-deacon` and `hq-mayor` sessions (headquarters sessions) that were incorrectly flagged as orphaned by `gt doctor`.

This PR fixes the false positive warnings where:
- `hq-deacon` session was reported as an orphaned session
- Child processes under `hq-deacon` were reported as orphaned processes

## Root Cause

The orphan detection logic only recognized `gt-*` prefixed sessions as valid Gas Town sessions, but the daemon also creates `hq-*` prefixed sessions for headquarters roles (mayor, deacon).

## Changes

1. **Session Detection**: Updated orphan session check to recognize both `gt-*` and `hq-*` prefixes
2. **Process Detection**: Fixed tmux server PID detection on Linux where tmux shows as "tmux: server" in the process comm field
3. **Test Coverage**: Added test for `hq-*` session validation
4. **Documentation**: Updated code comments to reflect `hq-*` patterns

## Testing

Tested on Linux system with active `hq-deacon` session:
- Before: 5+ orphaned processes flagged (false positives)
- After: Only 1 legitimate orphan process flagged (user terminal session)

All existing tests pass, new test added for `hq-*` sessions.

## Verification

```bash
# Build and install
make build
cp ./gt ~/.local/bin/

# Test
gt doctor  # Should no longer flag hq-deacon as orphan
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)