### PR TITLE
Fix deacon patrol process leak

### DIFF
--- a/internal/cmd/molecule_step.go
+++ b/internal/cmd/molecule_step.go
@@ -322,6 +322,12 @@ func handleStepContinue(cwd, townRoot, _ string, nextStep *beads.Issue, dryRun b
 
 	t := tmux.NewTmux()
 
+	// Kill all processes in the pane before respawning to prevent process leaks
+	if err := t.KillPaneProcesses(pane); err != nil {
+		// Non-fatal but log the warning
+		style.PrintWarning("could not kill pane processes: %v", err)
+	}
+
 	// Clear history before respawn
 	if err := t.ClearHistory(pane); err != nil {
 		// Non-fatal


### PR DESCRIPTION
## Problem
The deacon patrol was leaking claude processes. Every patrol cycle (1-3 minutes), a new claude process was spawned under the hq-deacon tmux session, but old processes were never terminated. This resulted in 12+ accumulated claude processes consuming resources.

## Root Cause
In `molecule_step.go:331`, the `handleStepContinue()` function uses `tmux respawn-pane -k` to restart the pane between patrol steps. The `-k` flag sends SIGHUP to the shell but **does not kill all descendant processes** (claude and its node children).

## Solution
Added `KillPaneProcesses()` function in `tmux.go` that explicitly kills all descendant processes before respawning the pane. This function:
- Gets all descendant PIDs recursively
- Sends SIGTERM to all (deepest first)
- Waits 100ms for graceful shutdown
- Sends SIGKILL to survivors

Updated `handleStepContinue()` to call `KillPaneProcesses()` before `RespawnPane()`.

## Testing
Before the fix, `ps -C claude` showed 12+ accumulated processes under the deacon's PPID. After the fix, only the current process should remain after each patrol cycle.

## Files Changed
- `internal/tmux/tmux.go`: Added `KillPaneProcesses()` method
- `internal/cmd/molecule_step.go`: Updated `handleStepContinue()` to kill processes before respawn