### PR TITLE
fix: detect actual rig layout instead of hardcoding mayor/rig path

### DIFF
--- a/internal/doctor/beads_check_test.go
+++ b/internal/doctor/beads_check_test.go
@@ -204,10 +204,23 @@ func TestPrefixMismatchCheck_Mismatch(t *testing.T) {
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")
 	mayorDir := filepath.Join(tmpDir, "mayor")
+	// Create rig's mayor/rig/.beads directory and redirect so ResolveBeadsDir returns the mayor/rig path
+	rigBeadsDir := filepath.Join(tmpDir, "gastown", "mayor", "rig", ".beads")
+	rigRootBeadsDir := filepath.Join(tmpDir, "gastown", ".beads")
 	if err := os.MkdirAll(beadsDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigRootBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Create redirect file so ResolveBeadsDir follows it
+	if err := os.WriteFile(filepath.Join(rigRootBeadsDir, "redirect"), []byte("mayor/rig/.beads\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -253,10 +266,23 @@ func TestPrefixMismatchCheck_Fix(t *testing.T) {
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")
 	mayorDir := filepath.Join(tmpDir, "mayor")
+	// Create rig's mayor/rig/.beads directory and redirect so ResolveBeadsDir returns the mayor/rig path
+	rigBeadsDir := filepath.Join(tmpDir, "gastown", "mayor", "rig", ".beads")
+	rigRootBeadsDir := filepath.Join(tmpDir, "gastown", ".beads")
 	if err := os.MkdirAll(beadsDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(rigRootBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Create redirect file so ResolveBeadsDir follows it
+	if err := os.WriteFile(filepath.Join(rigRootBeadsDir, "redirect"), []byte("mayor/rig/.beads\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 

--- a/internal/doctor/routes_check.go
+++ b/internal/doctor/routes_check.go
@@ -10,6 +10,15 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 )
 
+// determineRigBeadsPath returns the correct route path for a rig based on its actual layout.
+// Uses ResolveBeadsDir to follow any redirects (e.g., rig/.beads/redirect -> mayor/rig/.beads).
+func determineRigBeadsPath(townRoot, rigName string) string {
+	rigPath := filepath.Join(townRoot, rigName)
+	resolved := beads.ResolveBeadsDir(rigPath)
+	rel, _ := filepath.Rel(townRoot, resolved)
+	return strings.TrimSuffix(rel, "/.beads")
+}
+
 // RoutesCheck verifies that beads routing is properly configured.
 // It checks that routes.jsonl exists, all rigs have routing entries,
 // and all routes point to valid locations.
@@ -111,7 +120,8 @@ func (c *RoutesCheck) Run(ctx *CheckContext) *CheckResult {
 
 	// Check each rig has a route (by path, not just prefix from rigs.json)
 	for rigName, rigEntry := range rigsConfig.Rigs {
-		expectedPath := rigName + "/mayor/rig"
+		// Determine the correct path based on actual rig layout
+		expectedPath := determineRigBeadsPath(ctx.TownRoot, rigName)
 
 		// Check if there's already a route for this rig (by path)
 		if _, hasRoute := routeByPath[expectedPath]; hasRoute {
@@ -286,12 +296,13 @@ func (c *RoutesCheck) Fix(ctx *CheckContext) error {
 		}
 
 		if prefix != "" && !routeMap[prefix] {
-			// Verify the rig path exists before adding
-			rigPath := filepath.Join(ctx.TownRoot, rigName, "mayor", "rig")
+			// Determine the correct path based on actual rig layout
+			rigRoutePath := determineRigBeadsPath(ctx.TownRoot, rigName)
+			rigPath := filepath.Join(ctx.TownRoot, rigRoutePath)
 			if _, err := os.Stat(rigPath); err == nil {
 				route := beads.Route{
 					Prefix: prefix,
-					Path:   rigName + "/mayor/rig",
+					Path:   rigRoutePath,
 				}
 				routes = append(routes, route)
 				routeMap[prefix] = true


### PR DESCRIPTION
## Summary
- Routes and beads doctor checks were hardcoding `mayor/rig` as the route path for all rigs
- Some rigs have `.beads` directly at the rig root (direct layout) rather than at `mayor/rig/.beads` (mayor clone layout)
- Adds `determineRigBeadsPath()` helper that checks the actual rig layout, matching the logic in `rig.go`'s `rigInit()`

## Testing
All doctor tests pass.