### PR TITLE
Fix tmux error handling for "no current target"

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -63,7 +63,8 @@ func (t *Tmux) wrapError(err error, stderr string, args []string) error {
 
 	// Detect specific error types
 	if strings.Contains(stderr, "no server running") ||
-		strings.Contains(stderr, "error connecting to") {
+		strings.Contains(stderr, "error connecting to") ||
+		strings.Contains(stderr, "no current target") {
 		return ErrNoServer
 	}
 	if strings.Contains(stderr, "duplicate session") {

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -198,6 +198,7 @@ func TestWrapError(t *testing.T) {
 	}{
 		{"no server running on /tmp/tmux-...", ErrNoServer},
 		{"error connecting to /tmp/tmux-...", ErrNoServer},
+		{"no current target", ErrNoServer},
 		{"duplicate session: test", ErrSessionExists},
 		{"session not found: test", ErrSessionNotFound},
 		{"can't find session: test", ErrSessionNotFound},


### PR DESCRIPTION
## Summary
- Handle "no current target" tmux error as ErrNoServer
- Allows agents to bootstrap tmux server on first session creation
- Adds test coverage for the new error case

## Problem
When no tmux server is running, `gt crew start` fails with:
```
Error: checking session: tmux has-session: no current target
```

Observed on Ubuntu (tmux 3.4-1ubuntu0.1). The error "no current target" 
wasn't being mapped to `ErrNoServer`, so `HasSession()` returned an 
error instead of `(false, nil)`.

## Solution
Add "no current target" to the error detection in `wrapError()`.
This lets `HasSession()` treat "no server" the same as "session not found",
allowing `NewSession()` to run and implicitly start the tmux server.

## Test plan
- [x] Unit test added for "no current target" → ErrNoServer mapping
- [x] Full test suite passes (`go test ./...`)

Manual verification:
```bash
tmux kill-server
gt crew start <rig>/<name>
# Before fix: Error: checking session: tmux has-session: no current target
# After fix: Crew session starts successfully
```