### PR TITLE
Add Nix flake and integrate with bump-version script

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,6 @@ CLAUDE.md
 
 # Embedded formulas are committed so `go install @latest` works
 # Run `go generate ./...` after modifying .beads/formulas/
+
+# Nix build
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,117 @@
+{
+  "nodes": {
+    "beads": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1768216872,
+        "narHash": "sha256-DwIR/r1TJnpVd/CT1E2OTkAjU7k9/KHbcVwg5zziFVg=",
+        "owner": "steveyegge",
+        "repo": "beads",
+        "rev": "279192c5fbf851d0e47feaa7a5b5a9a6df325866",
+        "type": "github"
+      },
+      "original": {
+        "owner": "steveyegge",
+        "ref": "v0.47.1",
+        "repo": "beads",
+        "type": "github"
+      }
+    },
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "flake-utils_2": {
+      "inputs": {
+        "systems": "systems_2"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1768305791,
+        "narHash": "sha256-AIdl6WAn9aymeaH/NvBj0H9qM+XuAuYbGMZaP0zcXAQ=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "1412caf7bf9e660f2f962917c14b1ea1c3bc695e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "beads": "beads",
+        "flake-utils": "flake-utils_2",
+        "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "systems_2": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,57 @@
+{
+  description = "Multi-agent orchestration system for Claude Code with persistent work tracking";
+
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    flake-utils.url = "github:numtide/flake-utils";
+    beads = {
+      url = "github:steveyegge/beads/v0.47.1";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+
+  outputs = { self, nixpkgs, flake-utils, beads }:
+    flake-utils.lib.eachDefaultSystem (system:
+      let
+        pkgs = nixpkgs.legacyPackages.${system};
+        beads = self.inputs.beads.packages.${system};
+      in
+      {
+        packages = {
+          gt = pkgs.buildGoModule {
+            pname = "gt";
+            version = "0.4.0";
+            src = ./.;
+            vendorHash = "sha256-ripY9vrYgVW8bngAyMLh0LkU/Xx1UUaLgmAA7/EmWQU=";
+
+            subPackages = [ "cmd/gt" ];
+
+            meta = with pkgs.lib; {
+              description = "Multi-agent orchestration system for Claude Code with persistent work tracking";
+              homepage = "https://github.com/steveyegge/gastown";
+              license = licenses.mit;
+              mainProgram = "gt";
+            };
+          };
+          default = self.packages.${system}.gt;
+        };
+
+        apps = {
+          gt = flake-utils.lib.mkApp {
+            drv = self.packages.${system}.gt;
+          };
+          default = self.apps.${system}.gt;
+        };
+
+        devShells.default = pkgs.mkShell {
+          buildInputs = with pkgs; [
+            beads
+            go
+            gopls
+            gotools
+            go-tools
+          ];
+        };
+      }
+    );
+}

--- a/scripts/bump-version.sh
+++ b/scripts/bump-version.sh
@@ -14,15 +14,14 @@ set -e
 # WHAT IT UPDATES:
 #   - internal/cmd/version.go   - CLI version constant
 #   - npm-package/package.json  - npm package version
+#   - flake.nix                 - Nix flake package version and vendorHash (if nix available)
 #   - CHANGELOG.md              - Creates release entry from [Unreleased]
 #
 # =============================================================================
 
-# Colors for output
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-YELLOW='\033[1;33m'
-NC='\033[0m' # No Color
+# Source common functions
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/common.sh"
 
 # Usage message
 usage() {
@@ -36,6 +35,8 @@ usage() {
     echo "  --tag            Create annotated git tag (requires --commit)"
     echo "  --push           Push commit and tag to origin (requires --tag)"
     echo "  --install        Rebuild and install gt binary to GOPATH/bin"
+    echo ""
+    echo "Note: flake.nix version and vendorHash are updated automatically if nix is available."
     echo ""
     echo "Examples:"
     echo "  $0 0.2.0                        # Update versions and show diff"
@@ -64,19 +65,6 @@ get_current_version() {
     grep 'Version = ' internal/cmd/version.go | sed 's/.*"\(.*\)".*/\1/'
 }
 
-# Update a file with sed (cross-platform compatible)
-update_file() {
-    local file=$1
-    local old_pattern=$2
-    local new_text=$3
-
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        sed -i '' "s|$old_pattern|$new_text|g" "$file"
-    else
-        sed -i "s|$old_pattern|$new_text|g" "$file"
-    fi
-}
-
 # Update CHANGELOG.md: move [Unreleased] to [version]
 update_changelog() {
     local version=$1
@@ -94,11 +82,7 @@ update_changelog() {
         return
     fi
 
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        sed -i '' "s/## \[Unreleased\]/## [Unreleased]\n\n## [$version] - $date/" CHANGELOG.md
-    else
-        sed -i "s/## \[Unreleased\]/## [Unreleased]\n\n## [$version] - $date/" CHANGELOG.md
-    fi
+    sed_i "s/## \[Unreleased\]/## [Unreleased]\n\n## [$version] - $date/" CHANGELOG.md
 }
 
 # Main script
@@ -190,7 +174,24 @@ main() {
         "\"version\": \"$CURRENT_VERSION\"" \
         "\"version\": \"$NEW_VERSION\""
 
-    # 3. Update CHANGELOG.md
+    # 3. Update flake.nix (if nix is available)
+    if command -v nix &> /dev/null; then
+        echo "  • flake.nix (version)"
+        update_file "flake.nix" \
+            "version = \"$CURRENT_VERSION\"" \
+            "version = \"$NEW_VERSION\""
+
+        echo "  • flake.nix (vendorHash)"
+        SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+        if ! "$SCRIPT_DIR/update-nix-flake.sh"; then
+            echo -e "${RED}Error: Failed to update vendorHash${NC}"
+            exit 1
+        fi
+    else
+        echo -e "  ${YELLOW}• flake.nix (skipped - nix not in PATH)${NC}"
+    fi
+
+    # 4. Update CHANGELOG.md
     echo "  • CHANGELOG.md"
     update_changelog "$NEW_VERSION"
 
@@ -208,13 +209,26 @@ main() {
     VERSION_GO=$(grep 'Version = ' internal/cmd/version.go | sed 's/.*"\(.*\)".*/\1/')
     VERSION_NPM=$(grep '"version"' npm-package/package.json | head -1 | sed 's/.*"\([0-9.]*\)".*/\1/')
 
-    if [ "$VERSION_GO" = "$NEW_VERSION" ] && [ "$VERSION_NPM" = "$NEW_VERSION" ]; then
-        echo -e "${GREEN}✓ All versions match: $NEW_VERSION${NC}"
+    if command -v nix &> /dev/null; then
+        VERSION_NIX=$(grep 'version = ' flake.nix | head -1 | sed 's/.*"\(.*\)".*/\1/')
+        if [ "$VERSION_GO" = "$NEW_VERSION" ] && [ "$VERSION_NPM" = "$NEW_VERSION" ] && [ "$VERSION_NIX" = "$NEW_VERSION" ]; then
+            echo -e "${GREEN}✓ All versions match: $NEW_VERSION${NC}"
+        else
+            echo -e "${RED}✗ Version mismatch detected!${NC}"
+            echo "  version.go: $VERSION_GO"
+            echo "  package.json: $VERSION_NPM"
+            echo "  flake.nix: $VERSION_NIX"
+            exit 1
+        fi
     else
-        echo -e "${RED}✗ Version mismatch detected!${NC}"
-        echo "  version.go: $VERSION_GO"
-        echo "  package.json: $VERSION_NPM"
-        exit 1
+        if [ "$VERSION_GO" = "$NEW_VERSION" ] && [ "$VERSION_NPM" = "$NEW_VERSION" ]; then
+            echo -e "${GREEN}✓ All versions match: $NEW_VERSION${NC}"
+        else
+            echo -e "${RED}✗ Version mismatch detected!${NC}"
+            echo "  version.go: $VERSION_GO"
+            echo "  package.json: $VERSION_NPM"
+            exit 1
+        fi
     fi
 
     echo ""
@@ -259,7 +273,8 @@ main() {
         echo "Creating git commit..."
 
         git add internal/cmd/version.go \
-                npm-package/package.json
+                npm-package/package.json \
+                flake.nix
 
         if [ -f "CHANGELOG.md" ]; then
             git add CHANGELOG.md
@@ -270,6 +285,7 @@ main() {
 Updated all component versions:
 - gt CLI: $CURRENT_VERSION → $NEW_VERSION
 - npm package: $CURRENT_VERSION → $NEW_VERSION
+- flake.nix: $CURRENT_VERSION → $NEW_VERSION
 
 Generated by scripts/bump-version.sh"
 

--- a/scripts/lib/common.sh
+++ b/scripts/lib/common.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+# =============================================================================
+# COMMON SHELL FUNCTIONS FOR GAS TOWN SCRIPTS
+# =============================================================================
+#
+# Source this file in other scripts:
+#   SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+#   source "$SCRIPT_DIR/lib/common.sh"
+#
+# =============================================================================
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Detect darwin system sed; darwin may still be using GNU sed.
+is_darwin_sed() {
+    [[ "$OSTYPE" == "darwin"* && "$(which sed)" == "/usr/bin/sed" ]]
+}
+
+# Cross-platform sed -i wrapper that handles macOS BSD sed vs GNU sed differences
+# Automatically adds '' after -i on macOS BSD sed
+# Usage: sed_i <sed expression> <file>
+sed_i() {
+    if is_darwin_sed; then
+        sed -i '' "$@"
+    else
+        sed -i "$@"
+    fi
+}
+
+# Update a file with sed (cross-platform compatible)
+# Usage: update_file <file> <old_pattern> <new_text>
+update_file() {
+    local file=$1
+    local old_pattern=$2
+    local new_text=$3
+
+    sed_i "s|$old_pattern|$new_text|g" "$file"
+}

--- a/scripts/update-nix-flake.sh
+++ b/scripts/update-nix-flake.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+set -e
+
+# =============================================================================
+# UPDATE FLAKE VENDOR HASH SCRIPT FOR GAS TOWN
+# =============================================================================
+#
+# This script computes and updates the vendorHash in flake.nix for the Go module.
+# It uses nix to build a vendor directory and compute the hash.
+#
+# USAGE:
+#   ./scripts/update-nix-flake.sh
+#
+# =============================================================================
+
+# Source common functions
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/lib/common.sh"
+
+# Main function
+main() {
+    # Check if we're in the repo root
+    if [ ! -f "flake.nix" ]; then
+        echo -e "${RED}Error: Must run from repository root (flake.nix not found)${NC}"
+        exit 1
+    fi
+
+    if ! command -v nix &> /dev/null; then
+        echo -e "${RED}Error: nix not found${NC}"
+        exit 1
+    fi
+
+    echo "Computing vendorHash..."
+
+    # Get current vendor hash
+    local current_hash
+    current_hash=$(grep 'vendorHash = ' flake.nix | sed 's/.*"\(.*\)".*/\1/')
+    echo "  Current: $current_hash"
+
+    # Create a temporary directory for the vendor output
+    local tmp_dir
+    tmp_dir=$(mktemp -d)
+    trap "rm -rf $tmp_dir" EXIT
+
+    # Use go mod vendor to create a vendor directory
+    echo "  Downloading Go modules..."
+    GOFLAGS="-mod=readonly" go mod vendor -o "$tmp_dir/vendor" 2>/dev/null || go mod vendor -o "$tmp_dir/vendor"
+
+    # Compute the hash using nix hash path
+    echo "  Computing hash..."
+    local new_hash
+    new_hash=$(nix hash path "$tmp_dir/vendor" 2>/dev/null)
+
+    if [ -z "$new_hash" ]; then
+        echo -e "${RED}Error: Could not compute vendorHash${NC}"
+        exit 1
+    fi
+
+    # Update flake.nix with the new hash
+    update_file "flake.nix" \
+        "vendorHash = \"$current_hash\"" \
+        "vendorHash = \"$new_hash\""
+
+    if [ "$current_hash" = "$new_hash" ]; then
+        echo -e "${GREEN}✓ vendorHash unchanged: $new_hash${NC}"
+    else
+        echo -e "${GREEN}✓ vendorHash updated${NC}"
+        echo "  Old: $current_hash"
+        echo "  New: $new_hash"
+    fi
+}
+
+main "$@"


### PR DESCRIPTION
## Summary
Saw that `beads` already had a Flake setup - no worries if this is too much maintenance overhead for `gt` and I'll just keep using the fork's flake instead.

- Add Nix flake support for Gas Town with automatic vendorHash updates during version bumps.
- Moves shared bash to a library, including a darwin-agnostic `sed -i` wrapper (existing behaviour was broken for me on Darwin due to using nixpkgs' GNU sed, but still  hitting the "darwin*" guard)

## Changes
### New Files
- `flake.nix` - Nix flake for building gt with buildGoModule
- `flake.lock` - Pinned dependencies (beads v0.47.1)
- `scripts/lib/common.sh` - Shared shell utilities (colors, sed_i, update_file)
- `scripts/update-nix-flake.sh` - Computes vendorHash using go mod vendor + nix hash

### Updated Files
- `scripts/bump-version.sh` - Now auto-updates flake.nix version and vendorHash when nix is available
- `.gitignore` - Added result symlink

## Testing
<!-- How did you test these changes? -->
- [x] `nix build .#gt` / `nix run` builds/runs gt correctly (I'm daily driving this Flake version)
- [x] Test-bump worked:
```
  $ ./scripts/bump-version.sh 0.5.0

  Bumping version: 0.4.0 → 0.5.0

  Updating version files...
    • internal/cmd/version.go
    • npm-package/package.json
    • flake.nix (version)
    • flake.nix (vendorHash)
  Computing vendorHash...
    Current: sha256-ripY9vrYgVW8bngAyMLh0LkU/Xx1UUaLgmAA7/EmWQU=
    Downloading Go modules...
    Computing hash...
  ✓ vendorHash unchanged: sha256-ripY9vrYgVW8bngAyMLh0LkU/Xx1UUaLgmAA7/EmWQU=
    • CHANGELOG.md

  ✓ Version updated to 0.5.0

  Changed files:
   CHANGELOG.md             | 2 ++
   flake.nix                | 2 +-
   internal/cmd/version.go  | 2 +-
   npm-package/package.json | 2 +-
   4 files changed, 5 insertions(+), 3 deletions(-)

  Verifying version consistency...
  ✓ All versions match: 0.5.0
```

and without Nix in path:

```
export PATH=/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin; ./scripts/bump-version.sh 0.5.0
Bumping version: 0.4.0 → 0.5.0

Warning: You have uncommitted changes
Continue anyway? (y/N) y
Updating version files...
  • internal/cmd/version.go
  • npm-package/package.json
  • flake.nix (skipped - nix not in PATH)
  • CHANGELOG.md


✓ Version updated to 0.5.0

Changed files:

Verifying version consistency...
✓ All versions match: 0.5.0

Review the changes above.

To commit and release:
  ./scripts/bump-version.sh 0.5.0 --commit --tag --push --install
```

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)
