### PR TITLE
fix(config): correct Claude prompt prefix from > to ❯

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -552,7 +552,8 @@ func defaultProcessNames(provider, command string) []string {
 
 func defaultReadyPromptPrefix(provider string) string {
 	if provider == "claude" {
-		return "> "
+		// Claude Code uses ❯ (U+276F) as the prompt character
+		return "❯ "
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary

Fixes refinery startup timeout by correcting the Claude prompt detection character.

## Problem

When running `gt up`, refineries fail to start with:
```
✖ Refinery (rig_name): waiting for refinery to start: timeout waiting for runtime prompt
```

The `WaitForRuntimeReady()` function looks for `"> "` in the tmux pane to detect when Claude is ready, but Claude Code uses `"❯ "` (U+276F) as its prompt character.

## Solution

Update `defaultReadyPromptPrefix()` to return `"❯ "` instead of `"> "` for the Claude provider.

## Testing

Verified locally:
- With `"> "`: Refinery times out after 60 seconds
- With `"❯ "`: Refinery starts successfully

Fixes #763