### PR TITLE
feat: add initial prompt for autonomous patrol startup (deacon & witness)

### DIFF
--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -79,9 +79,11 @@ func (m *Manager) Start(agentOverride string) error {
 		return fmt.Errorf("ensuring Claude settings: %w", err)
 	}
 
-	// Build startup command first
-	// Restarts are handled by daemon via ensureDeaconRunning on each heartbeat
-	startupCmd, err := config.BuildAgentStartupCommandWithAgentOverride("deacon", "", m.townRoot, "", "", agentOverride)
+	// Build startup command with initial prompt for autonomous patrol.
+	// The prompt triggers GUPP: deacon starts patrol immediately without waiting for input.
+	// This prevents the agent from sitting idle at the prompt after SessionStart hooks run.
+	initialPrompt := "I am Deacon. Start patrol: check gt hook, if empty create mol-deacon-patrol wisp and execute it."
+	startupCmd, err := config.BuildAgentStartupCommandWithAgentOverride("deacon", "", m.townRoot, "", initialPrompt, agentOverride)
 	if err != nil {
 		return fmt.Errorf("building startup command: %w", err)
 	}

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -277,7 +277,10 @@ func buildWitnessStartCommand(rigPath, rigName, townRoot, agentOverride string, 
 	if roleConfig != nil && roleConfig.StartCommand != "" {
 		return beads.ExpandRolePattern(roleConfig.StartCommand, townRoot, rigName, "", "witness"), nil
 	}
-	command, err := config.BuildAgentStartupCommandWithAgentOverride("witness", rigName, townRoot, rigPath, "", agentOverride)
+	// Add initial prompt for autonomous patrol startup.
+	// The prompt triggers GUPP: witness starts patrol immediately without waiting for input.
+	initialPrompt := "I am Witness for " + rigName + ". Start patrol: check gt hook, if empty create mol-witness-patrol wisp and execute it."
+	command, err := config.BuildAgentStartupCommandWithAgentOverride("witness", rigName, townRoot, rigPath, initialPrompt, agentOverride)
 	if err != nil {
 		return "", fmt.Errorf("building startup command: %w", err)
 	}


### PR DESCRIPTION
## Summary
- Add initial prompt to deacon and witness startup commands to trigger autonomous patrol
- Without this, agents sit idle at the prompt after SessionStart hooks run
- Implements GUPP (Gas Town Universal Propulsion Principle): agents start patrol immediately

## Problem
After session start, deacon and witness would be idle at the prompt waiting for user input. The daemon heartbeat would see them as "running" (tmux session exists, Claude is running) but they weren't actually patrolling.

## Solution
Pass an initial prompt to `BuildAgentStartupCommandWithAgentOverride`:
```
"I am Deacon. Start patrol: check gt hook, if empty create mol-deacon-patrol wisp and execute it."
```

This triggers the agent to immediately start patrol when Claude launches.

## Test plan
- [x] Rebuild gt
- [x] Stop and start deacon - verify it auto-patrols
- [x] Stop and start witness - verify it auto-patrols
- [x] Daemon correctly sees them as running