### PR TITLE
feat(patrol): implement PING/PONG protocol with backoff

### DIFF
--- a/.beads/formulas/mol-deacon-patrol.formula.toml
+++ b/.beads/formulas/mol-deacon-patrol.formula.toml
@@ -23,11 +23,40 @@ Witnesses detect it and escalate to the Mayor.
 The Deacon's agent bead last_activity timestamp is updated during each patrol
 cycle. Witnesses check this timestamp to verify health."""
 formula = "mol-deacon-patrol"
-version = 8
+version = 9
+
+[[steps]]
+id = "role-check"
+title = "Verify role is enabled"
+description = """
+**STOP. Read your CLAUDE.md role context first.**
+
+Before proceeding with ANY formula steps, check your role boundaries:
+
+```bash
+cat CLAUDE.md | head -50
+```
+
+**If your role context says DISABLED or contains prohibitions that conflict with this formula:**
+- "This role is DISABLED"
+- Any explicit prohibition against the operations in this formula
+
+**Then DO NOT proceed with this formula.** Instead:
+1. Acknowledge you received the patrol nudge
+2. Report to mayor that the role is disabled:
+   ```bash
+   gt mail send mayor/ -s "Role DISABLED" -m "Received patrol formula but role is disabled per config."
+   ```
+3. Exit the patrol loop
+
+**Role context ALWAYS takes precedence over formula instructions.**
+
+Only proceed to inbox-check if your role context permits the operations in this formula."""
 
 [[steps]]
 id = "inbox-check"
 title = "Handle callbacks from agents"
+needs = ["role-check"]
 description = """
 Handle callbacks from agents.
 
@@ -45,12 +74,25 @@ gt mail read <id>
 ```
 
 **WITNESS_PING**:
-Witnesses periodically ping to verify Deacon is alive. Simply acknowledge
-and archive - the fact that you're processing mail proves you're running.
-Your agent bead last_activity is updated automatically during patrol.
+Witnesses ping to verify Deacon is alive. Send PONG response and archive.
+
+The PING subject contains a request_id: `WITNESS_PING <rig> [req:<id>]`
+Extract the request_id and respond:
 ```bash
+# Extract request_id from subject (e.g., "WITNESS_PING myrig [req:abc123]")
+REQUEST_ID=$(echo "<subject>" | grep -o 'req:[^]]*' | cut -d: -f2)
+
+# Send PONG back to the witness
+gt mail send <rig>/witness -s "WITNESS_PONG [req:$REQUEST_ID]" -m "Request-ID: $REQUEST_ID
+Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+Deacon-Patrol: <cycle>"
+
+# Archive the PING
 gt mail archive <message-id>
 ```
+
+This completes the request-response handshake. The witness will clear its
+pending_ping state when it receives the PONG.
 
 **HELP / Escalation**:
 Assess and handle or forward to Mayor.

--- a/.beads/formulas/mol-witness-patrol.formula.toml
+++ b/.beads/formulas/mol-witness-patrol.formula.toml
@@ -1,11 +1,40 @@
 description = "Per-rig worker monitor patrol loop.\n\nThe Witness is the Pit Boss for your rig. You watch polecats, nudge them toward\ncompletion, verify clean git state before kills, and escalate stuck workers.\n\n**You do NOT do implementation work.** Your job is oversight, not coding.\n\n## Ephemeral Polecat Model\n\nPolecats are truly ephemeral - done at MR submission, recyclable immediately:\n\n```\nPolecat lifecycle: spawning → working → mr_submitted → nuked\nMR lifecycle:      created → queued → processed → merged (Refinery handles)\n```\n\nOnce a polecat's branch is pushed (cleanup_status=clean), the polecat can be\nnuked immediately. The MR continues independently in the Refinery. If conflicts\narise, Refinery creates a NEW conflict-resolution task for a NEW polecat.\n\n**Key principle**: Polecat lifecycle is separate from MR lifecycle.\n\n## Design Philosophy\n\nThis patrol follows Gas Town principles:\n- **Discovery over tracking**: Observe reality each cycle, don't maintain state\n- **Events over state**: POLECAT_DONE mail triggers immediate cleanup\n- **Ephemeral by default**: Clean polecats are nuked immediately, no waiting\n- **Cleanup wisps for exceptions**: Only created when intervention needed\n- **Task tool for parallelism**: Subagents inspect polecats, not molecule arms\n\n## Patrol Shape (Linear, Deacon-style)\n\n```\ninbox-check ─► process-cleanups ─► check-refinery ─► survey-workers\n                                                            │\n         ┌──────────────────────────────────────────────────┘\n         ▼\n  check-timer-gates ─► check-swarm ─► ping-deacon ─► patrol-cleanup ─► context-check ─► loop-or-exit\n```\n\nNo dynamic arms. No fanout gates. No persistent nudge counters.\nState is discovered each cycle from reality (tmux, beads, mail)."
 formula = 'mol-witness-patrol'
-version = 2
+version = 3
+
+[[steps]]
+id = 'role-check'
+title = 'Verify role is enabled'
+description = """
+**STOP. Read your CLAUDE.md role context first.**
+
+Before proceeding with ANY formula steps, check your role boundaries:
+
+```bash
+cat CLAUDE.md | head -50
+```
+
+**If your role context says DISABLED or contains prohibitions that conflict with this formula:**
+- "This role is DISABLED"
+- Any explicit prohibition against the operations in this formula
+
+**Then DO NOT proceed with this formula.** Instead:
+1. Acknowledge you received the patrol nudge
+2. Report to mayor that the role is disabled:
+   ```bash
+   gt mail send mayor/ -s "Role DISABLED" -m "Received patrol formula but role is disabled per config."
+   ```
+3. Exit the patrol loop
+
+**Role context ALWAYS takes precedence over formula instructions.**
+
+Only proceed to inbox-check if your role context permits the operations in this formula."""
 
 [[steps]]
 description = "Check inbox and handle messages.\n\n```bash\ngt mail inbox\n```\n\nFor each message:\n\n**POLECAT_STARTED**:\nA new polecat has started working. Acknowledge and archive.\n```bash\n# Acknowledge startup (optional: log for activity tracking)\ngt mail archive <message-id>\n```\nNo action needed beyond acknowledgment - archive immediately.\n\n**POLECAT_DONE / LIFECYCLE:Shutdown**:\n\n*EPHEMERAL MODEL*: Polecats are truly ephemeral - done at MR submission,\nrecyclable immediately. Once the branch is pushed (cleanup_status=clean),\nthe polecat can be nuked. The MR lifecycle continues independently in the\nRefinery. If conflicts arise, Refinery creates a NEW conflict-resolution\ntask for a NEW polecat.\n\nPolecat lifecycle: spawning → working → mr_submitted → nuked\nMR lifecycle: created → queued → processed → merged (handled by Refinery)\n\nThe handler (HandlePolecatDone) will:\n1. Check cleanup_status from agent bead\n2. If \"clean\" (branch pushed): AUTO-NUKE immediately, archive mail\n3. If dirty: Create cleanup wisp for manual intervention\n\n```bash\n# The handler does this automatically:\n# - For clean state: gt polecat nuke <name> → archive mail\n# - For dirty state: create wisp → process in next step\n```\n\nCleanup wisps are only created when something is wrong (uncommitted changes,\nunpushed commits). Most POLECAT_DONE messages result in immediate nuke.\n\n**MERGED**:\nA branch was merged successfully. This is informational in the ephemeral model\nsince the polecat was already nuked after MR submission.\n\nIf a cleanup wisp exists (dirty state), complete the cleanup:\n```bash\n# Find the cleanup wisp for this polecat\nbd list --wisp --labels=polecat:<name>,state:merge-requested --status=open\n\n# If found, proceed with full polecat nuke:\ngt polecat nuke <name>\n\n# Burn the cleanup wisp\nbd close <wisp-id>\n```\nArchive after cleanup is complete.\n\n**HELP / Blocked**:\nAssess the request. Can you help? If not, escalate to Mayor:\n```bash\ngt mail send mayor/ -s \"Escalation: <polecat> needs help\" -m \"<details>\"\n```\nArchive after handling (escalated or resolved):\n```bash\ngt mail archive <message-id>\n```\n\n**HANDOFF**:\nRead predecessor context. Continue from where they left off.\nArchive after absorbing context:\n```bash\ngt mail archive <message-id>\n```\n\n**SWARM_START**:\nMayor initiating batch polecat work. Initialize swarm tracking.\n```bash\n# Parse swarm info from mail body: {\"swarm_id\": \"batch-123\", \"beads\": [\"bd-a\", \"bd-b\"]}\nbd create --wisp --title \"swarm:<swarm_id>\" --description \"Tracking batch: <swarm_id>\" --labels swarm,swarm_id:<swarm_id>,total:<N>,completed:0,start:<timestamp>\n```\nArchive after creating swarm tracking wisp:\n```bash\ngt mail archive <message-id>\n```\n\n**Hygiene principle**: Archive messages after they're fully processed.\nKeep only: active work, unprocessed requests. Inbox should be near-empty."
 id = 'inbox-check'
 title = 'Process witness mail'
+needs = ['role-check']
 
 [[steps]]
 description = "Process cleanup wisps (exception handling for dirty polecats).\n\nIn the ephemeral model, cleanup wisps are only created when a polecat has\ndirty state (uncommitted changes, unpushed commits) that prevented immediate\nnuke. Most polecats are nuked immediately on POLECAT_DONE and never create wisps.\n\n```bash\n# Find all cleanup wisps\nbd list --wisp --labels=cleanup --status=open\n```\n\nIf no wisps, skip this step (most common case in ephemeral model).\n\nFor each cleanup wisp, investigate and resolve the dirty state:\n\n## State: pending (needs investigation)\n\n1. **Extract polecat name** from wisp title/labels\n\n2. **Diagnose the problem**:\n```bash\ncd polecats/<name>\ngit status                    # What's uncommitted?\ngit stash list                # Any stashed work?\ngit log origin/main..HEAD     # Any unpushed commits?\n```\n\n3. **Resolution options**:\n   - **Uncommitted changes**: Commit and push, then nuke\n   - **Stashed work**: Pop and commit, or discard if not valuable\n   - **Unpushed commits**: Push to origin, then nuke\n   - **All valuable work lost**: Escalate to Mayor for recovery\n\n4. **If resolvable locally**: Fix and nuke\n```bash\n# Example: push unpushed commits\ngit push origin HEAD\n\n# Then nuke\ngt polecat nuke <name>\n\n# Close the wisp\nbd close <wisp-id> --reason \"Resolved: pushed commits, nuked\"\n```\n\n5. **If needs escalation**: Send RECOVERY_NEEDED to Mayor\n```bash\ngt mail send mayor/ -s \"RECOVERY_NEEDED <rig>/<polecat>\" \\\n  -m \"Cleanup Status: <status>\nBranch: <branch>\nIssue: <issue-id>\n\nCannot auto-resolve. Please advise.\"\n```\nLeave wisp open until Mayor resolves.\n\n## State: merge-requested (legacy, rare)\n\nThis state was used before the ephemeral model. If found, the polecat is\nwaiting for a MERGED signal. The inbox-check step handles these.\n\n**Parallelism**: Use Task tool subagents to process multiple cleanups concurrently.\nEach cleanup is independent - perfect for parallel execution."
@@ -38,7 +67,74 @@ needs = ['check-timer-gates']
 title = 'Check if active swarm is complete'
 
 [[steps]]
-description = "Send WITNESS_PING to Deacon for second-order monitoring.\n\nThe Witness fleet collectively monitors Deacon health - this prevents the\n\"who watches the watchers\" problem. If Deacon dies, Witnesses detect it.\n\n**Step 1: Send ping**\n```bash\ngt mail send deacon/ -s \"WITNESS_PING <rig>\" -m \"Rig: <rig>\nTimestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)\nPatrol: <cycle-number>\"\n```\n\n**Step 2: Check Deacon health**\n```bash\n# Check Deacon agent bead for last_activity\nbd list --type=agent --json | jq '.[] | select(.description | contains(\"deacon\"))'\n```\n\nLook at the `last_activity` timestamp. If stale (>5 minutes since last update):\n- Deacon may be dead or stuck\n\n**Step 3: Escalate if needed**\n```bash\n# If Deacon appears down\ngt mail send mayor/ -s \"ALERT: Deacon appears unresponsive\" -m \"No Deacon activity for >5 minutes.\nLast seen: <timestamp>\nWitness: <rig>/witness\"\n```\n\nNote: Multiple Witnesses may send this alert. Mayor should handle deduplication."
+description = """
+Ping Deacon with request-response protocol and backoff.
+
+The Witness fleet monitors Deacon health via PING/PONG protocol. This prevents
+flooding: only ONE outstanding PING at a time, with exponential backoff on no response.
+
+**Step 1: Check for pending PING**
+
+Read witness state.json for pending_ping:
+```bash
+cat state.json | jq '.pending_ping // empty'
+```
+
+If pending_ping exists:
+- Check inbox for WITNESS_PONG with matching request_id
+- If PONG found: Clear pending_ping, proceed to send new ping
+- If no PONG and timeout not reached: SKIP this step (still waiting)
+- If no PONG and timeout reached: Increment retry_count
+
+**Step 2: Check retry count**
+
+If retry_count >= 3:
+- Escalate to Mayor:
+  ```bash
+  gt mail send mayor/ -s "ALERT: Deacon unresponsive" -m "Rig: <rig>
+  No PONG after 3 retries over ~3.5 minutes.
+  Last PING: <timestamp>
+  Witness: <rig>/witness"
+  ```
+- Reset pending_ping (don't keep flooding)
+- Set cooldown_until = now + 5 minutes
+- SKIP sending new PING
+
+**Step 3: Check cooldown**
+
+If in cooldown period after escalation:
+- SKIP sending new PING (let Mayor handle it)
+
+**Step 4: Send PING (if no pending/cooldown)**
+
+Generate unique request_id and send:
+```bash
+REQUEST_ID=$(date +%s)-$(head -c 4 /dev/urandom | xxd -p)
+gt mail send deacon/ -s "WITNESS_PING <rig> [req:$REQUEST_ID]" -m "Rig: <rig>
+Request-ID: $REQUEST_ID
+Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+Patrol: <cycle>"
+```
+
+Update state.json:
+```json
+{
+  "pending_ping": {
+    "request_id": "<REQUEST_ID>",
+    "sent_at": "<timestamp>",
+    "retry_count": 0,
+    "timeout_seconds": 30
+  }
+}
+```
+
+**Backoff schedule:**
+- Attempt 1: wait 30s
+- Attempt 2: wait 60s (retry_count=1)
+- Attempt 3: wait 120s (retry_count=2)
+- Attempt 4: escalate (retry_count=3)
+
+**Key principle:** One outstanding PING at a time prevents flooding."""
 id = 'ping-deacon'
 needs = ['check-swarm-completion']
 title = 'Ping Deacon for health check'

--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -23,11 +23,40 @@ Witnesses detect it and escalate to the Mayor.
 The Deacon's agent bead last_activity timestamp is updated during each patrol
 cycle. Witnesses check this timestamp to verify health."""
 formula = "mol-deacon-patrol"
-version = 8
+version = 9
+
+[[steps]]
+id = "role-check"
+title = "Verify role is enabled"
+description = """
+**STOP. Read your CLAUDE.md role context first.**
+
+Before proceeding with ANY formula steps, check your role boundaries:
+
+```bash
+cat CLAUDE.md | head -50
+```
+
+**If your role context says DISABLED or contains prohibitions that conflict with this formula:**
+- "This role is DISABLED"
+- Any explicit prohibition against the operations in this formula
+
+**Then DO NOT proceed with this formula.** Instead:
+1. Acknowledge you received the patrol nudge
+2. Report to mayor that the role is disabled:
+   ```bash
+   gt mail send mayor/ -s "Role DISABLED" -m "Received patrol formula but role is disabled per config."
+   ```
+3. Exit the patrol loop
+
+**Role context ALWAYS takes precedence over formula instructions.**
+
+Only proceed to inbox-check if your role context permits the operations in this formula."""
 
 [[steps]]
 id = "inbox-check"
 title = "Handle callbacks from agents"
+needs = ["role-check"]
 description = """
 Handle callbacks from agents.
 
@@ -45,12 +74,25 @@ gt mail read <id>
 ```
 
 **WITNESS_PING**:
-Witnesses periodically ping to verify Deacon is alive. Simply acknowledge
-and archive - the fact that you're processing mail proves you're running.
-Your agent bead last_activity is updated automatically during patrol.
+Witnesses ping to verify Deacon is alive. Send PONG response and archive.
+
+The PING subject contains a request_id: `WITNESS_PING <rig> [req:<id>]`
+Extract the request_id and respond:
 ```bash
+# Extract request_id from subject (e.g., "WITNESS_PING myrig [req:abc123]")
+REQUEST_ID=$(echo "<subject>" | grep -o 'req:[^]]*' | cut -d: -f2)
+
+# Send PONG back to the witness
+gt mail send <rig>/witness -s "WITNESS_PONG [req:$REQUEST_ID]" -m "Request-ID: $REQUEST_ID
+Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+Deacon-Patrol: <cycle>"
+
+# Archive the PING
 gt mail archive <message-id>
 ```
+
+This completes the request-response handshake. The witness will clear its
+pending_ping state when it receives the PONG.
 
 **HELP / Escalation**:
 Assess and handle or forward to Mayor.
@@ -665,71 +707,46 @@ Skip dispatch - system is healthy.
 
 [[steps]]
 id = "costs-digest"
-title = "Aggregate daily costs [DISABLED]"
+title = "Aggregate daily costs"
 needs = ["session-gc"]
 description = """
-**⚠️ DISABLED** - Skip this step entirely.
+**DAILY DIGEST** - Aggregate yesterday's session cost wisps.
 
-Cost tracking is temporarily disabled because Claude Code does not expose
-session costs in a way that can be captured programmatically.
-
-**Why disabled:**
-- The `gt costs` command uses tmux capture-pane to find costs
-- Claude Code displays costs in the TUI status bar, not in scrollback
-- All sessions show $0.00 because capture-pane can't see TUI chrome
-- The infrastructure is sound but has no data source
-
-**What we need from Claude Code:**
-- Stop hook env var (e.g., `$CLAUDE_SESSION_COST`)
-- Or queryable file/API endpoint
-
-**Re-enable when:** Claude Code exposes cost data via API or environment.
-
-See: GH#24, gt-7awfj
-
-**Exit criteria:** Skip this step - proceed to next."""
-
-[[steps]]
-id = "patrol-digest"
-title = "Aggregate daily patrol digests"
-needs = ["costs-digest"]
-description = """
-**DAILY DIGEST** - Aggregate yesterday's patrol cycle digests.
-
-Patrol cycles (Deacon, Witness, Refinery) create ephemeral per-cycle digests
-to avoid JSONL pollution. This step aggregates them into a single permanent
-"Patrol Report YYYY-MM-DD" bead for audit purposes.
+Session costs are recorded as ephemeral wisps (not exported to JSONL) to avoid
+log-in-database pollution. This step aggregates them into a permanent daily
+"Cost Report YYYY-MM-DD" bead for audit purposes.
 
 **Step 1: Check if digest is needed**
 ```bash
-# Preview yesterday's patrol digests (dry run)
-gt patrol digest --yesterday --dry-run
+# Preview yesterday's costs (dry run)
+gt costs digest --yesterday --dry-run
 ```
 
-If output shows "No patrol digests found", skip to Step 3.
+If output shows "No session cost wisps found", skip to Step 3.
 
 **Step 2: Create the digest**
 ```bash
-gt patrol digest --yesterday
+gt costs digest --yesterday
 ```
 
 This:
-- Queries all ephemeral patrol digests from yesterday
-- Creates a single "Patrol Report YYYY-MM-DD" bead with aggregated data
-- Deletes the source digests
+- Queries all session.ended wisps from yesterday
+- Creates a single "Cost Report YYYY-MM-DD" bead with aggregated data
+- Deletes the source wisps
 
 **Step 3: Verify**
-Daily patrol digests preserve audit trail without per-cycle pollution.
+The digest appears in `gt costs --week` queries.
+Daily digests preserve audit trail without per-session pollution.
 
 **Timing**: Run once per morning patrol cycle. The --yesterday flag ensures
 we don't try to digest today's incomplete data.
 
-**Exit criteria:** Yesterday's patrol digests aggregated (or none to aggregate)."""
+**Exit criteria:** Yesterday's costs digested (or no wisps to digest)."""
 
 [[steps]]
 id = "log-maintenance"
 title = "Rotate logs and prune state"
-needs = ["patrol-digest"]
+needs = ["costs-digest"]
 description = """
 Maintain daemon logs and state files.
 

--- a/internal/formula/formulas/mol-witness-patrol.formula.toml
+++ b/internal/formula/formulas/mol-witness-patrol.formula.toml
@@ -1,11 +1,40 @@
 description = "Per-rig worker monitor patrol loop.\n\nThe Witness is the Pit Boss for your rig. You watch polecats, nudge them toward\ncompletion, verify clean git state before kills, and escalate stuck workers.\n\n**You do NOT do implementation work.** Your job is oversight, not coding.\n\n## Ephemeral Polecat Model\n\nPolecats are truly ephemeral - done at MR submission, recyclable immediately:\n\n```\nPolecat lifecycle: spawning → working → mr_submitted → nuked\nMR lifecycle:      created → queued → processed → merged (Refinery handles)\n```\n\nOnce a polecat's branch is pushed (cleanup_status=clean), the polecat can be\nnuked immediately. The MR continues independently in the Refinery. If conflicts\narise, Refinery creates a NEW conflict-resolution task for a NEW polecat.\n\n**Key principle**: Polecat lifecycle is separate from MR lifecycle.\n\n## Design Philosophy\n\nThis patrol follows Gas Town principles:\n- **Discovery over tracking**: Observe reality each cycle, don't maintain state\n- **Events over state**: POLECAT_DONE mail triggers immediate cleanup\n- **Ephemeral by default**: Clean polecats are nuked immediately, no waiting\n- **Cleanup wisps for exceptions**: Only created when intervention needed\n- **Task tool for parallelism**: Subagents inspect polecats, not molecule arms\n\n## Patrol Shape (Linear, Deacon-style)\n\n```\ninbox-check ─► process-cleanups ─► check-refinery ─► survey-workers\n                                                            │\n         ┌──────────────────────────────────────────────────┘\n         ▼\n  check-timer-gates ─► check-swarm ─► ping-deacon ─► patrol-cleanup ─► context-check ─► loop-or-exit\n```\n\nNo dynamic arms. No fanout gates. No persistent nudge counters.\nState is discovered each cycle from reality (tmux, beads, mail)."
 formula = 'mol-witness-patrol'
-version = 2
+version = 3
+
+[[steps]]
+id = 'role-check'
+title = 'Verify role is enabled'
+description = """
+**STOP. Read your CLAUDE.md role context first.**
+
+Before proceeding with ANY formula steps, check your role boundaries:
+
+```bash
+cat CLAUDE.md | head -50
+```
+
+**If your role context says DISABLED or contains prohibitions that conflict with this formula:**
+- "This role is DISABLED"
+- Any explicit prohibition against the operations in this formula
+
+**Then DO NOT proceed with this formula.** Instead:
+1. Acknowledge you received the patrol nudge
+2. Report to mayor that the role is disabled:
+   ```bash
+   gt mail send mayor/ -s "Role DISABLED" -m "Received patrol formula but role is disabled per config."
+   ```
+3. Exit the patrol loop
+
+**Role context ALWAYS takes precedence over formula instructions.**
+
+Only proceed to inbox-check if your role context permits the operations in this formula."""
 
 [[steps]]
 description = "Check inbox and handle messages.\n\n```bash\ngt mail inbox\n```\n\nFor each message:\n\n**POLECAT_STARTED**:\nA new polecat has started working. Acknowledge and archive.\n```bash\n# Acknowledge startup (optional: log for activity tracking)\ngt mail archive <message-id>\n```\nNo action needed beyond acknowledgment - archive immediately.\n\n**POLECAT_DONE / LIFECYCLE:Shutdown**:\n\n*EPHEMERAL MODEL*: Polecats are truly ephemeral - done at MR submission,\nrecyclable immediately. Once the branch is pushed (cleanup_status=clean),\nthe polecat can be nuked. The MR lifecycle continues independently in the\nRefinery. If conflicts arise, Refinery creates a NEW conflict-resolution\ntask for a NEW polecat.\n\nPolecat lifecycle: spawning → working → mr_submitted → nuked\nMR lifecycle: created → queued → processed → merged (handled by Refinery)\n\nThe handler (HandlePolecatDone) will:\n1. Check cleanup_status from agent bead\n2. If \"clean\" (branch pushed): AUTO-NUKE immediately, archive mail\n3. If dirty: Create cleanup wisp for manual intervention\n\n```bash\n# The handler does this automatically:\n# - For clean state: gt polecat nuke <name> → archive mail\n# - For dirty state: create wisp → process in next step\n```\n\nCleanup wisps are only created when something is wrong (uncommitted changes,\nunpushed commits). Most POLECAT_DONE messages result in immediate nuke.\n\n**MERGED**:\nA branch was merged successfully. This is informational in the ephemeral model\nsince the polecat was already nuked after MR submission.\n\nIf a cleanup wisp exists (dirty state), complete the cleanup:\n```bash\n# Find the cleanup wisp for this polecat\nbd list --wisp --labels=polecat:<name>,state:merge-requested --status=open\n\n# If found, proceed with full polecat nuke:\ngt polecat nuke <name>\n\n# Burn the cleanup wisp\nbd close <wisp-id>\n```\nArchive after cleanup is complete.\n\n**HELP / Blocked**:\nAssess the request. Can you help? If not, escalate to Mayor:\n```bash\ngt mail send mayor/ -s \"Escalation: <polecat> needs help\" -m \"<details>\"\n```\nArchive after handling (escalated or resolved):\n```bash\ngt mail archive <message-id>\n```\n\n**HANDOFF**:\nRead predecessor context. Continue from where they left off.\nArchive after absorbing context:\n```bash\ngt mail archive <message-id>\n```\n\n**SWARM_START**:\nMayor initiating batch polecat work. Initialize swarm tracking.\n```bash\n# Parse swarm info from mail body: {\"swarm_id\": \"batch-123\", \"beads\": [\"bd-a\", \"bd-b\"]}\nbd create --wisp --title \"swarm:<swarm_id>\" --description \"Tracking batch: <swarm_id>\" --labels swarm,swarm_id:<swarm_id>,total:<N>,completed:0,start:<timestamp>\n```\nArchive after creating swarm tracking wisp:\n```bash\ngt mail archive <message-id>\n```\n\n**Hygiene principle**: Archive messages after they're fully processed.\nKeep only: active work, unprocessed requests. Inbox should be near-empty."
 id = 'inbox-check'
 title = 'Process witness mail'
+needs = ['role-check']
 
 [[steps]]
 description = "Process cleanup wisps (exception handling for dirty polecats).\n\nIn the ephemeral model, cleanup wisps are only created when a polecat has\ndirty state (uncommitted changes, unpushed commits) that prevented immediate\nnuke. Most polecats are nuked immediately on POLECAT_DONE and never create wisps.\n\n```bash\n# Find all cleanup wisps\nbd list --wisp --labels=cleanup --status=open\n```\n\nIf no wisps, skip this step (most common case in ephemeral model).\n\nFor each cleanup wisp, investigate and resolve the dirty state:\n\n## State: pending (needs investigation)\n\n1. **Extract polecat name** from wisp title/labels\n\n2. **Diagnose the problem**:\n```bash\ncd polecats/<name>\ngit status                    # What's uncommitted?\ngit stash list                # Any stashed work?\ngit log origin/main..HEAD     # Any unpushed commits?\n```\n\n3. **Resolution options**:\n   - **Uncommitted changes**: Commit and push, then nuke\n   - **Stashed work**: Pop and commit, or discard if not valuable\n   - **Unpushed commits**: Push to origin, then nuke\n   - **All valuable work lost**: Escalate to Mayor for recovery\n\n4. **If resolvable locally**: Fix and nuke\n```bash\n# Example: push unpushed commits\ngit push origin HEAD\n\n# Then nuke\ngt polecat nuke <name>\n\n# Close the wisp\nbd close <wisp-id> --reason \"Resolved: pushed commits, nuked\"\n```\n\n5. **If needs escalation**: Send RECOVERY_NEEDED to Mayor\n```bash\ngt mail send mayor/ -s \"RECOVERY_NEEDED <rig>/<polecat>\" \\\n  -m \"Cleanup Status: <status>\nBranch: <branch>\nIssue: <issue-id>\n\nCannot auto-resolve. Please advise.\"\n```\nLeave wisp open until Mayor resolves.\n\n## State: merge-requested (legacy, rare)\n\nThis state was used before the ephemeral model. If found, the polecat is\nwaiting for a MERGED signal. The inbox-check step handles these.\n\n**Parallelism**: Use Task tool subagents to process multiple cleanups concurrently.\nEach cleanup is independent - perfect for parallel execution."
@@ -38,7 +67,74 @@ needs = ['check-timer-gates']
 title = 'Check if active swarm is complete'
 
 [[steps]]
-description = "Send WITNESS_PING to Deacon for second-order monitoring.\n\nThe Witness fleet collectively monitors Deacon health - this prevents the\n\"who watches the watchers\" problem. If Deacon dies, Witnesses detect it.\n\n**Step 1: Send ping**\n```bash\ngt mail send deacon/ -s \"WITNESS_PING <rig>\" -m \"Rig: <rig>\nTimestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)\nPatrol: <cycle-number>\"\n```\n\n**Step 2: Check Deacon health**\n```bash\n# Check Deacon agent bead for last_activity\nbd list --type=agent --json | jq '.[] | select(.description | contains(\"deacon\"))'\n```\n\nLook at the `last_activity` timestamp. If stale (>5 minutes since last update):\n- Deacon may be dead or stuck\n\n**Step 3: Escalate if needed**\n```bash\n# If Deacon appears down\ngt mail send mayor/ -s \"ALERT: Deacon appears unresponsive\" -m \"No Deacon activity for >5 minutes.\nLast seen: <timestamp>\nWitness: <rig>/witness\"\n```\n\nNote: Multiple Witnesses may send this alert. Mayor should handle deduplication."
+description = """
+Ping Deacon with request-response protocol and backoff.
+
+The Witness fleet monitors Deacon health via PING/PONG protocol. This prevents
+flooding: only ONE outstanding PING at a time, with exponential backoff on no response.
+
+**Step 1: Check for pending PING**
+
+Read witness state.json for pending_ping:
+```bash
+cat state.json | jq '.pending_ping // empty'
+```
+
+If pending_ping exists:
+- Check inbox for WITNESS_PONG with matching request_id
+- If PONG found: Clear pending_ping, proceed to send new ping
+- If no PONG and timeout not reached: SKIP this step (still waiting)
+- If no PONG and timeout reached: Increment retry_count
+
+**Step 2: Check retry count**
+
+If retry_count >= 3:
+- Escalate to Mayor:
+  ```bash
+  gt mail send mayor/ -s "ALERT: Deacon unresponsive" -m "Rig: <rig>
+  No PONG after 3 retries over ~3.5 minutes.
+  Last PING: <timestamp>
+  Witness: <rig>/witness"
+  ```
+- Reset pending_ping (don't keep flooding)
+- Set cooldown_until = now + 5 minutes
+- SKIP sending new PING
+
+**Step 3: Check cooldown**
+
+If in cooldown period after escalation:
+- SKIP sending new PING (let Mayor handle it)
+
+**Step 4: Send PING (if no pending/cooldown)**
+
+Generate unique request_id and send:
+```bash
+REQUEST_ID=$(date +%s)-$(head -c 4 /dev/urandom | xxd -p)
+gt mail send deacon/ -s "WITNESS_PING <rig> [req:$REQUEST_ID]" -m "Rig: <rig>
+Request-ID: $REQUEST_ID
+Timestamp: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+Patrol: <cycle>"
+```
+
+Update state.json:
+```json
+{
+  "pending_ping": {
+    "request_id": "<REQUEST_ID>",
+    "sent_at": "<timestamp>",
+    "retry_count": 0,
+    "timeout_seconds": 30
+  }
+}
+```
+
+**Backoff schedule:**
+- Attempt 1: wait 30s
+- Attempt 2: wait 60s (retry_count=1)
+- Attempt 3: wait 120s (retry_count=2)
+- Attempt 4: escalate (retry_count=3)
+
+**Key principle:** One outstanding PING at a time prevents flooding."""
 id = 'ping-deacon'
 needs = ['check-swarm-completion']
 title = 'Ping Deacon for health check'


### PR DESCRIPTION
## Summary
- Implement request-response PING/PONG protocol between witness and deacon
- Add exponential backoff to prevent mail flood from bricking deacon
- Escalate to Mayor after repeated failures

## Problem
Previously, witnesses would flood the deacon with WITNESS_PING messages. If the deacon was slow to respond (e.g., processing a large patrol cycle), the accumulated pings would interrupt the deacon mid-thought via UserPromptSubmit hook, causing it to get stuck.

## Solution
**PING/PONG Protocol v2:**
1. Request-response model with unique `request_id`
2. One outstanding PING at a time - wait for PONG before sending next
3. Exponential backoff: 30s → 60s → 120s between retries
4. Escalate to Mayor after 3 consecutive failures
5. 5-minute cooldown after escalation

**Witness (mol-witness-patrol.formula.toml):**
- Check for PONG response before sending new PING
- Track pending_ping state with timestamps
- Implement backoff logic

**Deacon (mol-deacon-patrol.formula.toml):**
- Extract request_id from PING subject
- Send PONG response with matching request_id
- Archive processed PING messages

## Test plan
- [x] Witness sends PING with request_id
- [x] Deacon responds with PONG containing request_id
- [x] Witness waits for PONG before next PING
- [x] No mail flood observed during testing