### PR TITLE
fix(handoff): normalize identity in sendHandoffMail

### DIFF
--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -11,6 +11,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/events"
+	"github.com/steveyegge/gastown/internal/mail"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/tmux"
@@ -576,6 +577,9 @@ func sendHandoffMail(subject, message string) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("detecting agent identity: %w", err)
 	}
+
+	// Normalize identity to match mailbox query format
+	agentID = mail.AddressToIdentity(agentID)
 
 	// Detect town root for beads location
 	townRoot := detectTownRootFromCwd()

--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -56,7 +56,7 @@ func NewMailboxBeads(identity, workDir string) *Mailbox {
 func NewMailboxFromAddress(address, workDir string) *Mailbox {
 	beadsDir := beads.ResolveBeadsDir(workDir)
 	return &Mailbox{
-		identity: addressToIdentity(address),
+		identity: AddressToIdentity(address),
 		workDir:  workDir,
 		beadsDir: beadsDir,
 		legacy:   false,
@@ -66,7 +66,7 @@ func NewMailboxFromAddress(address, workDir string) *Mailbox {
 // NewMailboxWithBeadsDir creates a mailbox with an explicit beads directory.
 func NewMailboxWithBeadsDir(address, workDir, beadsDir string) *Mailbox {
 	return &Mailbox{
-		identity: addressToIdentity(address),
+		identity: AddressToIdentity(address),
 		workDir:  workDir,
 		beadsDir: beadsDir,
 		legacy:   false,

--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -569,7 +569,7 @@ func (r *Router) sendToGroup(msg *Message) error {
 // sendToSingle sends a message to a single recipient.
 func (r *Router) sendToSingle(msg *Message) error {
 	// Convert addresses to beads identities
-	toIdentity := addressToIdentity(msg.To)
+	toIdentity := AddressToIdentity(msg.To)
 
 	// Build labels for from/thread/reply-to/cc
 	var labels []string
@@ -582,7 +582,7 @@ func (r *Router) sendToSingle(msg *Message) error {
 	}
 	// Add CC labels (one per recipient)
 	for _, cc := range msg.CC {
-		ccIdentity := addressToIdentity(cc)
+		ccIdentity := AddressToIdentity(cc)
 		labels = append(labels, "cc:"+ccIdentity)
 	}
 
@@ -692,7 +692,7 @@ func (r *Router) sendToQueue(msg *Message) error {
 		labels = append(labels, "reply-to:"+msg.ReplyTo)
 	}
 	for _, cc := range msg.CC {
-		ccIdentity := addressToIdentity(cc)
+		ccIdentity := AddressToIdentity(cc)
 		labels = append(labels, "cc:"+ccIdentity)
 	}
 
@@ -763,7 +763,7 @@ func (r *Router) sendToAnnounce(msg *Message) error {
 		labels = append(labels, "reply-to:"+msg.ReplyTo)
 	}
 	for _, cc := range msg.CC {
-		ccIdentity := addressToIdentity(cc)
+		ccIdentity := AddressToIdentity(cc)
 		labels = append(labels, "cc:"+ccIdentity)
 	}
 
@@ -836,7 +836,7 @@ func (r *Router) sendToChannel(msg *Message) error {
 		labels = append(labels, "reply-to:"+msg.ReplyTo)
 	}
 	for _, cc := range msg.CC {
-		ccIdentity := addressToIdentity(cc)
+		ccIdentity := AddressToIdentity(cc)
 		labels = append(labels, "cc:"+ccIdentity)
 	}
 

--- a/internal/mail/types.go
+++ b/internal/mail/types.go
@@ -488,7 +488,7 @@ func ParseMessageType(s string) MessageType {
 	}
 }
 
-// addressToIdentity converts a GGT address to a beads identity.
+// AddressToIdentity converts a GGT address to a beads identity.
 //
 // Liberal normalization: accepts multiple address formats and normalizes
 // to canonical form (Postel's Law - be liberal in what you accept).
@@ -504,7 +504,7 @@ func ParseMessageType(s string) MessageType {
 //   - "gastown/Toast" → "gastown/Toast" (already canonical)
 //   - "gastown/refinery" → "gastown/refinery"
 //   - "gastown/" → "gastown" (rig broadcast)
-func addressToIdentity(address string) string {
+func AddressToIdentity(address string) string {
 	// Overseer (human operator) - no trailing slash, distinct from agents
 	if address == "overseer" {
 		return "overseer"

--- a/internal/mail/types_test.go
+++ b/internal/mail/types_test.go
@@ -30,9 +30,9 @@ func TestAddressToIdentity(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.address, func(t *testing.T) {
-			got := addressToIdentity(tt.address)
+			got := AddressToIdentity(tt.address)
 			if got != tt.expected {
-				t.Errorf("addressToIdentity(%q) = %q, want %q", tt.address, got, tt.expected)
+				t.Errorf("AddressToIdentity(%q) = %q, want %q", tt.address, got, tt.expected)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fix bug where `gt handoff -c` self-mail is invisible to the target inbox.

The handoff mail bead was created with un-normalized assignee (e.g., `gastown/crew/holden`) but mailbox queries use normalized identity (`gastown/holden`), causing the mismatch.

## Changes

- Export `addressToIdentity` as `AddressToIdentity` in `internal/mail/types.go`
- Call `mail.AddressToIdentity(agentID)` in `sendHandoffMail()` to normalize identity before storing
- Update internal callers to use the exported function name

## Testing

- All existing tests pass (`go test ./...`)
- Build passes (`go build ./...`)
- No lint warnings (`go vet ./...`)

## Related

Fixes hq-snp8

---
🤖 Generated with [Claude Code](https://claude.ai/code)