### PR TITLE
fix(done): terminate polecat session for all exit types

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -462,27 +462,28 @@ func runDone(cmd *cobra.Command, args []string) error {
 	// This is the self-cleaning model - polecats clean up after themselves
 	// "done means gone" - both worktree and session are terminated
 	selfCleanAttempted := false
-	if exitType == ExitCompleted {
-		if roleInfo, err := GetRoleWithContext(cwd, townRoot); err == nil && roleInfo.Role == RolePolecat {
-			selfCleanAttempted = true
+	if roleInfo, err := GetRoleWithContext(cwd, townRoot); err == nil && roleInfo.Role == RolePolecat {
+		selfCleanAttempted = true
 
-			// Step 1: Nuke the worktree
+		// Step 1: Nuke the worktree (only for COMPLETED - other statuses preserve work)
+		if exitType == ExitCompleted {
 			if err := selfNukePolecat(roleInfo, townRoot); err != nil {
 				// Non-fatal: Witness will clean up if we fail
 				style.PrintWarning("worktree nuke failed: %v (Witness will clean up)", err)
 			} else {
 				fmt.Printf("%s Worktree nuked\n", style.Bold.Render("✓"))
 			}
-
-			// Step 2: Kill our own session (this terminates Claude and the shell)
-			// This is the last thing we do - the process will be killed when tmux session dies
-			fmt.Printf("%s Terminating session (done means gone)\n", style.Bold.Render("→"))
-			if err := selfKillSession(townRoot, roleInfo); err != nil {
-				// If session kill fails, fall through to os.Exit
-				style.PrintWarning("session kill failed: %v", err)
-			}
-			// If selfKillSession succeeds, we won't reach here (process killed by tmux)
 		}
+
+		// Step 2: Kill our own session (this terminates Claude and the shell)
+		// This is the last thing we do - the process will be killed when tmux session dies
+		// All exit types kill the session - "done means gone"
+		fmt.Printf("%s Terminating session (done means gone)\n", style.Bold.Render("→"))
+		if err := selfKillSession(townRoot, roleInfo); err != nil {
+			// If session kill fails, fall through to os.Exit
+			style.PrintWarning("session kill failed: %v", err)
+		}
+		// If selfKillSession succeeds, we won't reach here (process killed by tmux)
 	}
 
 	// Fallback exit for non-polecats or if self-clean failed


### PR DESCRIPTION
## Summary

Fix `gt done` to terminate the polecat session for all exit types (DEFERRED, ESCALATED, PHASE_COMPLETE), not just COMPLETED.

Previously, when a polecat ran `gt done --status DEFERRED`, the command would call `os.Exit(0)` which only exits the gt process. Since Claude invokes `gt done` as a Bash tool call, control returns to Claude after gt exits, leaving the polecat session running indefinitely.

## Related Issue

None filed yet - discovered during testing of batch polecat dispatch.

## Changes

- Move the `exitType == ExitCompleted` check inside the self-clean block instead of wrapping it
- Worktree nuke still only happens for COMPLETED (other statuses preserve work for potential resume)
- Session kill now happens for ALL exit types - "done means gone"

**Before:**
```go
if exitType == ExitCompleted {
    if roleInfo.Role == RolePolecat {
        selfNukePolecat(...)  // nuke worktree
        selfKillSession(...)  // kill session
    }
}
os.Exit(0)  // Only exits gt process, not Claude!
```

**After:**
```go
if roleInfo.Role == RolePolecat {
    if exitType == ExitCompleted {
        selfNukePolecat(...)  // nuke worktree (COMPLETED only)
    }
    selfKillSession(...)  // kill session (ALL exit types)
}
```

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed
  - Ran `gt sling` with batch beads
  - Polecats completed work and ran `gt done --status DEFERRED`
  - Verified sessions now terminate properly via `selfKillSession`
  - Confirmed `KillSessionWithProcesses` kills all descendant processes

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable) - N/A, behavior change matches documented intent
- [x] No breaking changes (or documented in summary) - This is a bug fix; the documented behavior was "done means gone" but DEFERRED wasn't actually exiting
