### PR TITLE
fix: update Claude Code prompt prefix for v2.1+

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -552,7 +552,8 @@ func defaultProcessNames(provider, command string) []string {
 
 func defaultReadyPromptPrefix(provider string) string {
 	if provider == "claude" {
-		return "> "
+		// Claude Code v2.1+ uses "❯" as prompt character (was "> " in earlier versions)
+		return "❯"
 	}
 	return ""
 }


### PR DESCRIPTION
## Summary
- Update default `ready_prompt_prefix` for Claude provider from `"> "` to `"❯"`
- Claude Code v2.1+ changed the input prompt character in the UI refresh

## Problem
Agents (refinery, witness, polecats) were timing out during startup with:
```
Error: starting refinery: waiting for refinery to start: timeout waiting for runtime prompt
```

The gastown startup detection was looking for `"> "` but Claude Code now displays `"❯"` as its prompt indicator.

## Solution
Simple one-line fix to update the default prompt prefix. Users on older Claude Code versions can override via `settings/config.json` if needed.

## Test plan
- [x] Existing config tests pass
- [x] Manually verified refinery startup succeeds with this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)