### PR TITLE
Add Windows stub for orphan cleanup

### DIFF
--- a/internal/util/orphan_windows.go
+++ b/internal/util/orphan_windows.go
@@ -1,0 +1,29 @@
+//go:build windows
+
+package util
+
+// OrphanedProcess represents a claude process running without a controlling terminal.
+// On Windows, orphan cleanup is not supported, so this is a stub definition.
+type OrphanedProcess struct {
+	PID int
+	Cmd string
+	Age int // Age in seconds
+}
+
+// CleanupResult describes what happened to an orphaned process.
+// On Windows, cleanup is a no-op.
+type CleanupResult struct {
+	Process OrphanedProcess
+	Signal  string // "SIGTERM", "SIGKILL", or "UNKILLABLE"
+	Error   error
+}
+
+// FindOrphanedClaudeProcesses is a Windows stub.
+func FindOrphanedClaudeProcesses() ([]OrphanedProcess, error) {
+	return nil, nil
+}
+
+// CleanupOrphanedClaudeProcesses is a Windows stub.
+func CleanupOrphanedClaudeProcesses() ([]CleanupResult, error) {
+	return nil, nil
+}


### PR DESCRIPTION
## Summary
- Fixes build on Windows

## Related Issue
- #807

## Changes
- Stub for orphaned claude process

## Testing
manual build started using 
```sh
go build ./...
```

- ⚠️ Unit tests pass (`go test ./...`) timed out after ~14s
- ✅ Manual testing performed

## Checklist
- ✅ Code follows project style
- ☑️ Documentation updated (not applicable)
- ✅ No breaking changes (or documented in summary)
