### PR TITLE
feat(rig): add --adopt flag to register existing directories

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -60,10 +60,16 @@ The command also:
   - Creates ~/gt/plugins/ (town-level) if it doesn't exist
   - Creates <rig>/plugins/ (rig-level)
 
+Use --adopt to register an existing directory instead of creating new:
+  - Reads existing config.json if present
+  - Auto-detects git URL from origin remote (git-url argument not required)
+  - Adds entry to mayor/rigs.json
+
 Example:
   gt rig add gastown https://github.com/steveyegge/gastown
-  gt rig add my-project git@github.com:user/repo.git --prefix mp`,
-	Args: cobra.ExactArgs(2),
+  gt rig add my-project git@github.com:user/repo.git --prefix mp
+  gt rig add existing-rig --adopt`,
+	Args: cobra.RangeArgs(1, 2),
 	RunE: runRigAdd,
 }
 
@@ -256,6 +262,9 @@ var (
 	rigAddPrefix       string
 	rigAddLocalRepo    string
 	rigAddBranch       string
+	rigAddAdopt        bool
+	rigAddAdoptURL     string
+	rigAddAdoptForce   bool
 	rigResetHandoff    bool
 	rigResetMail       bool
 	rigResetStale      bool
@@ -286,6 +295,9 @@ func init() {
 	rigAddCmd.Flags().StringVar(&rigAddPrefix, "prefix", "", "Beads issue prefix (default: derived from name)")
 	rigAddCmd.Flags().StringVar(&rigAddLocalRepo, "local-repo", "", "Local repo path to share git objects (optional)")
 	rigAddCmd.Flags().StringVar(&rigAddBranch, "branch", "", "Default branch name (default: auto-detected from remote)")
+	rigAddCmd.Flags().BoolVar(&rigAddAdopt, "adopt", false, "Adopt an existing directory instead of creating new")
+	rigAddCmd.Flags().StringVar(&rigAddAdoptURL, "url", "", "Git remote URL for --adopt (default: auto-detected from origin)")
+	rigAddCmd.Flags().BoolVar(&rigAddAdoptForce, "force", false, "With --adopt, register even if git remote cannot be detected")
 
 	rigResetCmd.Flags().BoolVar(&rigResetHandoff, "handoff", false, "Clear handoff content")
 	rigResetCmd.Flags().BoolVar(&rigResetMail, "mail", false, "Clear stale mail messages")
@@ -307,6 +319,16 @@ func init() {
 
 func runRigAdd(cmd *cobra.Command, args []string) error {
 	name := args[0]
+
+	// Handle --adopt mode: register existing directory
+	if rigAddAdopt {
+		return runRigAdopt(cmd, args)
+	}
+
+	// Normal add mode requires git URL
+	if len(args) < 2 {
+		return fmt.Errorf("git-url is required (or use --adopt to register an existing directory)")
+	}
 	gitURL := args[1]
 
 	// Ensure beads (bd) is available before proceeding
@@ -521,6 +543,78 @@ func runRigRemove(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%s Rig %s removed from registry\n", style.Success.Render("✓"), name)
 	fmt.Printf("\nNote: Files at %s were NOT deleted.\n", filepath.Join(townRoot, name))
 	fmt.Printf("To delete: %s\n", style.Dim.Render(fmt.Sprintf("rm -rf %s", filepath.Join(townRoot, name))))
+
+	return nil
+}
+
+func runRigAdopt(_ *cobra.Command, args []string) error {
+	name := args[0]
+
+	// Find workspace
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("not in a Gas Town workspace: %w", err)
+	}
+
+	// Load rigs config
+	rigsPath := filepath.Join(townRoot, "mayor", "rigs.json")
+	rigsConfig, err := config.LoadRigsConfig(rigsPath)
+	if err != nil {
+		// Create new if doesn't exist
+		rigsConfig = &config.RigsConfig{
+			Version: 1,
+			Rigs:    make(map[string]config.RigEntry),
+		}
+	}
+
+	// Create rig manager
+	g := git.NewGit(townRoot)
+	mgr := rig.NewManager(townRoot, rigsConfig, g)
+
+	fmt.Printf("Adopting existing rig %s...\n", style.Bold.Render(name))
+
+	// Register the existing rig
+	result, err := mgr.RegisterRig(rig.RegisterRigOptions{
+		Name:        name,
+		GitURL:      rigAddAdoptURL,
+		BeadsPrefix: rigAddPrefix,
+		Force:       rigAddAdoptForce,
+	})
+	if err != nil {
+		return fmt.Errorf("adopting rig: %w", err)
+	}
+
+	// Save updated config
+	if err := config.SaveRigsConfig(rigsPath, rigsConfig); err != nil {
+		return fmt.Errorf("saving rigs config: %w", err)
+	}
+
+	// Add route to town-level routes.jsonl for prefix-based routing
+	if result.BeadsPrefix != "" {
+		routePath := name
+		mayorRigBeads := filepath.Join(townRoot, name, "mayor", "rig", ".beads")
+		if _, err := os.Stat(mayorRigBeads); err == nil {
+			routePath = name + "/mayor/rig"
+		}
+		route := beads.Route{
+			Prefix: result.BeadsPrefix + "-",
+			Path:   routePath,
+		}
+		if err := beads.AppendRoute(townRoot, route); err != nil {
+			fmt.Printf("  %s Could not update routes.jsonl: %v\n", style.Warning.Render("!"), err)
+		}
+	}
+
+	// Print results
+	fmt.Printf("\n%s Rig %s adopted\n", style.Success.Render("✓"), name)
+	if result.FromConfig {
+		fmt.Printf("  %s Read configuration from existing config.json\n", style.Dim.Render("ℹ"))
+	}
+	fmt.Printf("  Repository: %s\n", result.GitURL)
+	fmt.Printf("  Prefix: %s\n", result.BeadsPrefix)
+	if result.DefaultBranch != "" {
+		fmt.Printf("  Default branch: %s\n", result.DefaultBranch)
+	}
 
 	return nil
 }

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -13,8 +13,8 @@ import (
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/claude"
-	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/git"
 )
 
@@ -275,7 +275,7 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 
 	// Check if directory already exists
 	if _, err := os.Stat(rigPath); err == nil {
-		return nil, fmt.Errorf("directory already exists: %s", rigPath)
+		return nil, fmt.Errorf("directory already exists: %s\n\nTo adopt an existing directory, use --adopt:\n  gt rig add %s --adopt", rigPath, opts.Name)
 	}
 
 	// Track whether user explicitly provided --prefix (before deriving)
@@ -947,6 +947,124 @@ func (m *Manager) RemoveRig(name string) error {
 
 	delete(m.config.Rigs, name)
 	return nil
+}
+
+// RegisterRigOptions contains options for registering an existing rig directory.
+type RegisterRigOptions struct {
+	Name        string // Rig name (directory name)
+	GitURL      string // Override git URL (auto-detected from origin if empty)
+	BeadsPrefix string // Beads issue prefix (defaults to derived from name or existing config)
+	Force       bool   // Register even if directory structure looks incomplete
+}
+
+// RegisterRigResult contains the result of registering a rig.
+type RegisterRigResult struct {
+	Name          string // Rig name
+	GitURL        string // Detected or provided git URL
+	BeadsPrefix   string // Detected or derived beads prefix
+	FromConfig    bool   // True if values were read from existing config.json
+	DefaultBranch string // Default branch from existing config (if any)
+}
+
+// RegisterRig registers an existing rig directory with the town.
+// Complementary to AddRig: while AddRig creates a new rig from scratch,
+// RegisterRig adopts an existing directory structure.
+func (m *Manager) RegisterRig(opts RegisterRigOptions) (*RegisterRigResult, error) {
+	// Check if already registered
+	if m.RigExists(opts.Name) {
+		return nil, ErrRigExists
+	}
+
+	// Validate rig name (same rules as AddRig)
+	if strings.ContainsAny(opts.Name, "-. ") {
+		sanitized := strings.NewReplacer("-", "_", ".", "_", " ", "_").Replace(opts.Name)
+		sanitized = strings.ToLower(sanitized)
+		return nil, fmt.Errorf("rig name %q contains invalid characters; hyphens, dots, and spaces are reserved for agent ID parsing. Try %q instead (underscores are allowed)", opts.Name, sanitized)
+	}
+
+	rigPath := filepath.Join(m.townRoot, opts.Name)
+
+	// Check if directory exists
+	info, err := os.Stat(rigPath)
+	if os.IsNotExist(err) {
+		return nil, fmt.Errorf("directory does not exist: %s", rigPath)
+	}
+	if err != nil {
+		return nil, fmt.Errorf("checking directory: %w", err)
+	}
+	if !info.IsDir() {
+		return nil, fmt.Errorf("not a directory: %s", rigPath)
+	}
+
+	result := &RegisterRigResult{
+		Name: opts.Name,
+	}
+
+	// Try to load existing config.json
+	existingConfig, err := LoadRigConfig(rigPath)
+	if err == nil && existingConfig != nil {
+		result.FromConfig = true
+		if opts.GitURL == "" {
+			result.GitURL = existingConfig.GitURL
+		}
+		if opts.BeadsPrefix == "" && existingConfig.Beads != nil {
+			result.BeadsPrefix = existingConfig.Beads.Prefix
+		}
+		result.DefaultBranch = existingConfig.DefaultBranch
+	}
+
+	// If no git URL from config or override, try to detect from git remote
+	if result.GitURL == "" && opts.GitURL == "" {
+		detectedURL, detectErr := m.detectGitURL(rigPath)
+		if detectErr != nil && !opts.Force {
+			return nil, fmt.Errorf("could not detect git URL (use --url to specify, or --force to skip): %w", detectErr)
+		}
+		result.GitURL = detectedURL
+	}
+
+	// Apply override if provided
+	if opts.GitURL != "" {
+		result.GitURL = opts.GitURL
+	}
+
+	// Derive beads prefix if not set
+	if result.BeadsPrefix == "" && opts.BeadsPrefix == "" {
+		result.BeadsPrefix = deriveBeadsPrefix(opts.Name)
+	}
+	if opts.BeadsPrefix != "" {
+		result.BeadsPrefix = opts.BeadsPrefix
+	}
+
+	// Register in town config
+	m.config.Rigs[opts.Name] = config.RigEntry{
+		GitURL:  result.GitURL,
+		AddedAt: time.Now(),
+		BeadsConfig: &config.BeadsConfig{
+			Prefix: result.BeadsPrefix,
+		},
+	}
+
+	return result, nil
+}
+
+// detectGitURL attempts to detect the git remote URL from an existing repository.
+func (m *Manager) detectGitURL(rigPath string) (string, error) {
+	// Check for git repo in common locations
+	possiblePaths := []string{
+		rigPath,                                // Direct git repo
+		filepath.Join(rigPath, "mayor", "rig"), // Mayor clone
+		filepath.Join(rigPath, "refinery", "rig"), // Refinery worktree
+	}
+
+	for _, p := range possiblePaths {
+		g := git.NewGitWithDir(p, "")
+		url, err := g.RemoteURL("origin")
+		if err == nil && url != "" {
+			return strings.TrimSpace(url), nil
+		}
+	}
+
+	return "", fmt.Errorf("no git repository with origin remote found in %s", rigPath)
 }
 
 // ListRigNames returns the names of all registered rigs.


### PR DESCRIPTION
## Summary

Adds `--adopt` flag to `gt rig add` for registering existing rig directories that aren't in rigs.json.

The `--adopt` flag lets `gt rig add` register an existing directory instead of cloning a new one. Useful for recovery, manual setup, or migration.

**Use cases:**
- Recovery from corrupted `rigs.json`
- Manual rig setup (cloned repos into town structure)
- Migration between towns

**Behavior with --adopt:**
1. Reads existing `config.json` if present (preserves prefix/URL)
2. Auto-detects git URL from origin remote
3. Adds entry to `mayor/rigs.json`
4. Updates `routes.jsonl` for prefix routing

**Additional flags for --adopt:**
- `--prefix`: override beads prefix
- `--url`: override detected git URL
- `--force`: adopt even without git remote

**Improved error message:**
```
$ gt rig add myrig git@github.com:user/repo.git
Error: directory already exists: /path/to/town/myrig

To adopt an existing directory, use --adopt:
  gt rig add myrig --adopt
```

Closes #762

## Test plan

- [x] `go test ./...` passes
- [x] `go vet ./...` passes
- [x] `gofmt` clean
- [ ] Manual testing: `gt rig add myrig --adopt` on an unregistered directory
- [ ] Verify existing `config.json` values are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)