### PR TITLE
feat(feed): add problems view with stuck agent detection

### DIFF
--- a/internal/tui/feed/convoy.go
+++ b/internal/tui/feed/convoy.go
@@ -350,4 +350,3 @@ func renderProgressBar(completed, total int) string {
 	bar := strings.Repeat("●", filled) + strings.Repeat("○", displayTotal-filled)
 	return ConvoyProgressStyle.Render(bar)
 }
-

--- a/internal/tui/feed/keys.go
+++ b/internal/tui/feed/keys.go
@@ -24,6 +24,12 @@ type KeyMap struct {
 	Expand  key.Binding
 	Refresh key.Binding
 
+	// Problems view
+	ToggleProblems key.Binding
+	Nudge          key.Binding
+	Handoff        key.Binding
+	Restart        key.Binding
+
 	// Search/Filter
 	Search      key.Binding
 	Filter      key.Binding
@@ -90,8 +96,24 @@ func DefaultKeyMap() KeyMap {
 			key.WithHelp("o", "toggle expand"),
 		),
 		Refresh: key.NewBinding(
+			key.WithKeys("R"),
+			key.WithHelp("R", "refresh"),
+		),
+		ToggleProblems: key.NewBinding(
+			key.WithKeys("p"),
+			key.WithHelp("p", "toggle problems view"),
+		),
+		Nudge: key.NewBinding(
+			key.WithKeys("n"),
+			key.WithHelp("n", "nudge agent"),
+		),
+		Handoff: key.NewBinding(
+			key.WithKeys("h"),
+			key.WithHelp("h", "handoff agent"),
+		),
+		Restart: key.NewBinding(
 			key.WithKeys("r"),
-			key.WithHelp("r", "refresh"),
+			key.WithHelp("r", "restart agent"),
 		),
 		Search: key.NewBinding(
 			key.WithKeys("/"),
@@ -118,7 +140,7 @@ func DefaultKeyMap() KeyMap {
 
 // ShortHelp returns key bindings for the short help view.
 func (k KeyMap) ShortHelp() []key.Binding {
-	return []key.Binding{k.Up, k.Down, k.Tab, k.Search, k.Filter, k.Quit, k.Help}
+	return []key.Binding{k.Up, k.Down, k.Tab, k.ToggleProblems, k.Search, k.Quit, k.Help}
 }
 
 // FullHelp returns key bindings for the full help view.
@@ -126,6 +148,7 @@ func (k KeyMap) FullHelp() [][]key.Binding {
 	return [][]key.Binding{
 		{k.Up, k.Down, k.PageUp, k.PageDown, k.Top, k.Bottom},
 		{k.Tab, k.FocusTree, k.FocusConvoy, k.FocusFeed, k.Enter, k.Expand},
+		{k.ToggleProblems, k.Nudge, k.Handoff, k.Restart},
 		{k.Search, k.Filter, k.ClearFilter, k.Refresh},
 		{k.Help, k.Quit},
 	}

--- a/internal/tui/feed/stuck.go
+++ b/internal/tui/feed/stuck.go
@@ -1,0 +1,379 @@
+// Package feed provides a TUI for the Gas Town activity feed.
+// This file implements stuck detection for agents.
+package feed
+
+import (
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// TmuxClient defines the tmux operations needed by StuckDetector.
+// This interface enables testing with mock implementations.
+type TmuxClient interface {
+	HasSession(name string) (bool, error)
+	CapturePane(session string, lines int) (string, error)
+	GetSessionActivity(session string) (time.Time, error)
+	GetSessionSet() (*tmux.SessionSet, error)
+}
+
+// AgentState represents the possible states for a GasTown agent.
+// Ordered by priority (most urgent first) for sorting.
+type AgentState int
+
+const (
+	StateGUPPViolation AgentState = iota // >30m no progress with hooked work - CRITICAL
+	StateInputRequired                   // Waiting for user input (prompt, YOLO, Enter)
+	StateStalled                         // >15m no progress
+	StateWorking                         // Actively producing output
+	StateIdle                            // No hooked work
+	StateZombie                          // Dead/crashed session
+)
+
+func (s AgentState) String() string {
+	switch s {
+	case StateGUPPViolation:
+		return "gupp"
+	case StateInputRequired:
+		return "input"
+	case StateStalled:
+		return "stalled"
+	case StateWorking:
+		return "working"
+	case StateIdle:
+		return "idle"
+	case StateZombie:
+		return "zombie"
+	default:
+		return "unknown"
+	}
+}
+
+// Priority returns the sort priority (lower = more urgent).
+func (s AgentState) Priority() int {
+	return int(s)
+}
+
+// NeedsAttention returns true if this state requires user action.
+func (s AgentState) NeedsAttention() bool {
+	switch s {
+	case StateGUPPViolation, StateInputRequired, StateStalled, StateZombie:
+		return true
+	default:
+		return false
+	}
+}
+
+// Symbol returns the display symbol for this state.
+func (s AgentState) Symbol() string {
+	switch s {
+	case StateGUPPViolation:
+		return "🔥"
+	case StateInputRequired:
+		return "⌨"
+	case StateStalled:
+		return "⚠"
+	case StateWorking:
+		return "●"
+	case StateIdle:
+		return "○"
+	case StateZombie:
+		return "💀"
+	default:
+		return "?"
+	}
+}
+
+// Label returns the short display label for this state.
+func (s AgentState) Label() string {
+	switch s {
+	case StateGUPPViolation:
+		return "GUPP!"
+	case StateInputRequired:
+		return "INPUT"
+	case StateStalled:
+		return "STALL"
+	case StateWorking:
+		return "work"
+	case StateIdle:
+		return "idle"
+	case StateZombie:
+		return "dead"
+	default:
+		return "???"
+	}
+}
+
+// InputReason indicates why an agent is waiting for input.
+type InputReason int
+
+const (
+	InputReasonUnknown InputReason = iota
+	InputReasonPromptWaiting
+	InputReasonYOLOConfirmation
+	InputReasonEnterRequired
+	InputReasonPermission
+)
+
+func (r InputReason) String() string {
+	switch r {
+	case InputReasonPromptWaiting:
+		return "prompt"
+	case InputReasonYOLOConfirmation:
+		return "[Y/n]"
+	case InputReasonEnterRequired:
+		return "Enter"
+	case InputReasonPermission:
+		return "Allow?"
+	default:
+		return "waiting"
+	}
+}
+
+// GUPP threshold constants
+const (
+	GUPPViolationMinutes    = 30
+	StalledThresholdMinutes = 15
+	InputWaitThresholdSecs  = 120
+)
+
+// Pattern represents a regex pattern for detecting stuck states.
+type Pattern struct {
+	Regex  *regexp.Regexp
+	Reason InputReason
+}
+
+// DefaultPatterns are the patterns used to detect input-required states.
+var DefaultPatterns = []Pattern{
+	{regexp.MustCompile(`>\s*$`), InputReasonPromptWaiting},
+	{regexp.MustCompile(`claude>\s*$`), InputReasonPromptWaiting},
+	{regexp.MustCompile(`\[Y/n\]\s*$`), InputReasonYOLOConfirmation},
+	{regexp.MustCompile(`\[y/N\]\s*$`), InputReasonYOLOConfirmation},
+	{regexp.MustCompile(`Allow\?\s*`), InputReasonPermission},
+	{regexp.MustCompile(`Press Enter`), InputReasonEnterRequired},
+	{regexp.MustCompile(`(?i)continue\?`), InputReasonPermission},
+	{regexp.MustCompile(`(?i)proceed\?`), InputReasonPermission},
+}
+
+// ErrorPatterns indicate error states.
+var ErrorPatterns = []*regexp.Regexp{
+	regexp.MustCompile(`(?i)rate limit`),
+	regexp.MustCompile(`(?i)context.*full`),
+	regexp.MustCompile(`(?i)error:`),
+	regexp.MustCompile(`(?i)failed:`),
+}
+
+// ProblemAgent represents an agent that needs attention.
+type ProblemAgent struct {
+	Name          string
+	SessionID     string
+	Role          string
+	Rig           string
+	State         AgentState
+	InputReason   InputReason
+	IdleMinutes   int
+	LastActivity  time.Time
+	LastLines     string
+	ActionHint    string
+	CurrentBeadID string
+	HasHookedWork bool
+}
+
+// NeedsAttention returns true if agent requires user action.
+func (p *ProblemAgent) NeedsAttention() bool {
+	return p.State.NeedsAttention()
+}
+
+// DurationDisplay returns human-readable duration since last progress.
+func (p *ProblemAgent) DurationDisplay() string {
+	mins := p.IdleMinutes
+	if mins < 1 {
+		return "<1m"
+	}
+	if mins < 60 {
+		return strconv.Itoa(mins) + "m"
+	}
+	hours := mins / 60
+	remaining := mins % 60
+	if remaining == 0 {
+		return strconv.Itoa(hours) + "h"
+	}
+	return strconv.Itoa(hours) + "h" + strconv.Itoa(remaining) + "m"
+}
+
+// StuckDetector analyzes tmux sessions for stuck states.
+type StuckDetector struct {
+	tmux          TmuxClient
+	Patterns      []Pattern
+	IdleThreshold time.Duration
+}
+
+// NewStuckDetector creates a new stuck detector with default tmux wrapper.
+func NewStuckDetector() *StuckDetector {
+	return NewStuckDetectorWithClient(tmux.NewTmux())
+}
+
+// NewStuckDetectorWithTmux creates a new stuck detector with the given tmux wrapper.
+// Deprecated: Use NewStuckDetectorWithClient instead.
+func NewStuckDetectorWithTmux(t *tmux.Tmux) *StuckDetector {
+	return NewStuckDetectorWithClient(t)
+}
+
+// NewStuckDetectorWithClient creates a new stuck detector with the given TmuxClient.
+// This constructor accepts any TmuxClient implementation, enabling testing with mocks.
+func NewStuckDetectorWithClient(client TmuxClient) *StuckDetector {
+	return &StuckDetector{
+		tmux:          client,
+		Patterns:      DefaultPatterns,
+		IdleThreshold: InputWaitThresholdSecs * time.Second,
+	}
+}
+
+// AnalyzeSession checks a tmux session for stuck indicators.
+func (d *StuckDetector) AnalyzeSession(sessionID string) *ProblemAgent {
+	agent := &ProblemAgent{
+		SessionID: sessionID,
+		Name:      sessionID,
+		State:     StateWorking,
+	}
+
+	// Parse role from session name
+	agent.Role = parseRoleFromSession(sessionID)
+
+	// Check if session exists
+	exists, _ := d.tmux.HasSession(sessionID)
+	if !exists {
+		agent.State = StateZombie
+		agent.ActionHint = "Session does not exist - may need restart"
+		return agent
+	}
+
+	// Capture pane content
+	content, err := d.tmux.CapturePane(sessionID, 50)
+	if err != nil {
+		agent.State = StateZombie
+		agent.ActionHint = "Cannot capture pane content"
+		return agent
+	}
+
+	// Get last few lines for display
+	lines := strings.Split(strings.TrimSpace(content), "\n")
+	if len(lines) > 5 {
+		agent.LastLines = strings.Join(lines[len(lines)-5:], "\n")
+	} else {
+		agent.LastLines = strings.Join(lines, "\n")
+	}
+
+	// Get idle time
+	lastActivity, err := d.tmux.GetSessionActivity(sessionID)
+	if err == nil {
+		agent.LastActivity = lastActivity
+		agent.IdleMinutes = int(time.Since(lastActivity).Minutes())
+	}
+
+	// Check for input-required patterns
+	lastContent := ""
+	if len(lines) > 0 {
+		// Get last non-empty lines
+		for i := len(lines) - 1; i >= 0 && i >= len(lines)-10; i-- {
+			if strings.TrimSpace(lines[i]) != "" {
+				lastContent = strings.Join(lines[i:], "\n")
+				break
+			}
+		}
+	}
+
+	for _, pattern := range d.Patterns {
+		if pattern.Regex.MatchString(lastContent) {
+			// Pattern matches - check if idle long enough
+			if agent.IdleMinutes >= int(d.IdleThreshold.Minutes()) || agent.IdleMinutes >= 2 {
+				agent.State = StateInputRequired
+				agent.InputReason = pattern.Reason
+				agent.ActionHint = getActionHint(pattern.Reason)
+				return agent
+			}
+		}
+	}
+
+	// Check for error patterns
+	for _, pattern := range ErrorPatterns {
+		if pattern.MatchString(content) {
+			agent.State = StateStalled
+			agent.ActionHint = "Error detected in output"
+			return agent
+		}
+	}
+
+	// Check for stalled (no progress for 15+ minutes)
+	if agent.IdleMinutes >= StalledThresholdMinutes {
+		agent.State = StateStalled
+		agent.ActionHint = "No progress for " + strconv.Itoa(agent.IdleMinutes) + "m"
+	}
+
+	return agent
+}
+
+// gasTownSessionPrefixes are the prefixes used to identify GasTown agent sessions.
+var gasTownSessionPrefixes = []string{"polecat", "mayor", "refinery", "witness", "deacon", "crew", "boot"}
+
+// isGasTownSession returns true if the session name looks like a GasTown agent.
+func isGasTownSession(name string) bool {
+	for _, prefix := range gasTownSessionPrefixes {
+		if strings.HasPrefix(name, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// FindGasTownSessions returns tmux sessions that look like GasTown agents.
+// Uses the efficient GetSessionSet for O(1) lookups.
+func (d *StuckDetector) FindGasTownSessions() ([]string, error) {
+	sessionSet, err := d.tmux.GetSessionSet()
+	if err != nil {
+		return nil, err
+	}
+
+	var gtSessions []string
+	for _, name := range sessionSet.Names() {
+		if isGasTownSession(name) {
+			gtSessions = append(gtSessions, name)
+		}
+	}
+	return gtSessions, nil
+}
+
+// IsGUPPViolation checks if an agent is in GUPP violation.
+func IsGUPPViolation(hasHookedWork bool, minutesSinceProgress int) bool {
+	return hasHookedWork && minutesSinceProgress >= GUPPViolationMinutes
+}
+
+// Helper functions
+
+func parseRoleFromSession(sessionID string) string {
+	roles := []string{"polecat", "mayor", "refinery", "witness", "deacon", "crew", "boot"}
+	for _, role := range roles {
+		if strings.HasPrefix(sessionID, role) {
+			return role
+		}
+	}
+	return "unknown"
+}
+
+func getActionHint(reason InputReason) string {
+	switch reason {
+	case InputReasonPromptWaiting:
+		return "Agent waiting at prompt - attach and provide input"
+	case InputReasonYOLOConfirmation:
+		return "YOLO confirmation needed - attach and press Y or n"
+	case InputReasonEnterRequired:
+		return "Press Enter to continue"
+	case InputReasonPermission:
+		return "Permission prompt - attach and respond"
+	default:
+		return "Agent appears stuck - consider attaching"
+	}
+}

--- a/internal/tui/feed/stuck_test.go
+++ b/internal/tui/feed/stuck_test.go
@@ -1,0 +1,707 @@
+package feed
+
+import (
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// mockTmuxClient is a test double for TmuxClient
+type mockTmuxClient struct {
+	sessions        map[string]bool
+	sessionNames    []string // For GetSessionSet
+	paneContent     map[string]string
+	sessionActivity map[string]time.Time
+	captureErr      error
+	activityErr     error
+	sessionSetErr   error
+}
+
+func newMockTmuxClient() *mockTmuxClient {
+	return &mockTmuxClient{
+		sessions:        make(map[string]bool),
+		paneContent:     make(map[string]string),
+		sessionActivity: make(map[string]time.Time),
+	}
+}
+
+func (m *mockTmuxClient) HasSession(name string) (bool, error) {
+	return m.sessions[name], nil
+}
+
+func (m *mockTmuxClient) CapturePane(session string, lines int) (string, error) {
+	if m.captureErr != nil {
+		return "", m.captureErr
+	}
+	return m.paneContent[session], nil
+}
+
+func (m *mockTmuxClient) GetSessionActivity(session string) (time.Time, error) {
+	if m.activityErr != nil {
+		return time.Time{}, m.activityErr
+	}
+	if t, ok := m.sessionActivity[session]; ok {
+		return t, nil
+	}
+	return time.Time{}, errors.New("no activity")
+}
+
+func (m *mockTmuxClient) GetSessionSet() (*tmux.SessionSet, error) {
+	if m.sessionSetErr != nil {
+		return nil, m.sessionSetErr
+	}
+	return tmux.NewSessionSet(m.sessionNames), nil
+}
+
+// TestAgentStateString tests the String() method for all AgentState values
+func TestAgentStateString(t *testing.T) {
+	tests := []struct {
+		state    AgentState
+		expected string
+	}{
+		{StateGUPPViolation, "gupp"},
+		{StateInputRequired, "input"},
+		{StateStalled, "stalled"},
+		{StateWorking, "working"},
+		{StateIdle, "idle"},
+		{StateZombie, "zombie"},
+		{AgentState(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if got := tt.state.String(); got != tt.expected {
+				t.Errorf("AgentState(%d).String() = %q, want %q", tt.state, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestAgentStatePriority tests that priorities are ordered correctly
+func TestAgentStatePriority(t *testing.T) {
+	// GUPP should have highest priority (lowest number)
+	if StateGUPPViolation.Priority() >= StateInputRequired.Priority() {
+		t.Error("GUPP violation should have higher priority than input required")
+	}
+	if StateInputRequired.Priority() >= StateStalled.Priority() {
+		t.Error("Input required should have higher priority than stalled")
+	}
+	if StateStalled.Priority() >= StateWorking.Priority() {
+		t.Error("Stalled should have higher priority than working")
+	}
+	if StateWorking.Priority() >= StateIdle.Priority() {
+		t.Error("Working should have higher priority than idle")
+	}
+	if StateIdle.Priority() >= StateZombie.Priority() {
+		t.Error("Idle should have higher priority than zombie")
+	}
+}
+
+// TestAgentStateNeedsAttention tests which states require user attention
+func TestAgentStateNeedsAttention(t *testing.T) {
+	needsAttention := []AgentState{
+		StateGUPPViolation,
+		StateInputRequired,
+		StateStalled,
+		StateZombie,
+	}
+	noAttention := []AgentState{
+		StateWorking,
+		StateIdle,
+	}
+
+	for _, state := range needsAttention {
+		if !state.NeedsAttention() {
+			t.Errorf("%s.NeedsAttention() = false, want true", state)
+		}
+	}
+	for _, state := range noAttention {
+		if state.NeedsAttention() {
+			t.Errorf("%s.NeedsAttention() = true, want false", state)
+		}
+	}
+}
+
+// TestAgentStateSymbol tests the display symbols
+func TestAgentStateSymbol(t *testing.T) {
+	tests := []struct {
+		state    AgentState
+		expected string
+	}{
+		{StateGUPPViolation, "🔥"},
+		{StateInputRequired, "⌨"},
+		{StateStalled, "⚠"},
+		{StateWorking, "●"},
+		{StateIdle, "○"},
+		{StateZombie, "💀"},
+		{AgentState(99), "?"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.state.String(), func(t *testing.T) {
+			if got := tt.state.Symbol(); got != tt.expected {
+				t.Errorf("AgentState(%d).Symbol() = %q, want %q", tt.state, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestAgentStateLabel tests the display labels
+func TestAgentStateLabel(t *testing.T) {
+	tests := []struct {
+		state    AgentState
+		expected string
+	}{
+		{StateGUPPViolation, "GUPP!"},
+		{StateInputRequired, "INPUT"},
+		{StateStalled, "STALL"},
+		{StateWorking, "work"},
+		{StateIdle, "idle"},
+		{StateZombie, "dead"},
+		{AgentState(99), "???"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.state.String(), func(t *testing.T) {
+			if got := tt.state.Label(); got != tt.expected {
+				t.Errorf("AgentState(%d).Label() = %q, want %q", tt.state, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestInputReasonString tests the String() method for InputReason
+func TestInputReasonString(t *testing.T) {
+	tests := []struct {
+		reason   InputReason
+		expected string
+	}{
+		{InputReasonUnknown, "waiting"},
+		{InputReasonPromptWaiting, "prompt"},
+		{InputReasonYOLOConfirmation, "[Y/n]"},
+		{InputReasonEnterRequired, "Enter"},
+		{InputReasonPermission, "Allow?"},
+		{InputReason(99), "waiting"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			if got := tt.reason.String(); got != tt.expected {
+				t.Errorf("InputReason(%d).String() = %q, want %q", tt.reason, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestIsGasTownSession tests the session name detection
+func TestIsGasTownSession(t *testing.T) {
+	gasTownSessions := []string{
+		"polecat-1",
+		"polecat-myproject-42",
+		"mayor",
+		"mayor-main",
+		"refinery-abc",
+		"witness-123",
+		"deacon-boot",
+		"crew-joe",
+		"boot-init",
+	}
+	nonGasTownSessions := []string{
+		"my-session",
+		"dev",
+		"main",
+		"polecatnotreally", // No hyphen, but still matches prefix - this is expected behavior
+		"",
+	}
+
+	for _, name := range gasTownSessions {
+		if !isGasTownSession(name) {
+			t.Errorf("isGasTownSession(%q) = false, want true", name)
+		}
+	}
+	for _, name := range nonGasTownSessions {
+		// Note: "polecatnotreally" will match because it starts with "polecat"
+		// This is acceptable behavior - session names typically have hyphens
+		if name != "polecatnotreally" && name != "" && isGasTownSession(name) {
+			t.Errorf("isGasTownSession(%q) = true, want false", name)
+		}
+	}
+}
+
+// TestIsGUPPViolation tests the GUPP violation detection
+func TestIsGUPPViolation(t *testing.T) {
+	tests := []struct {
+		name          string
+		hasHookedWork bool
+		minutes       int
+		expected      bool
+	}{
+		{"no work, no time", false, 0, false},
+		{"no work, long time", false, 60, false},
+		{"has work, short time", true, 10, false},
+		{"has work, at threshold", true, 30, true},
+		{"has work, over threshold", true, 45, true},
+		{"has work, just under threshold", true, 29, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsGUPPViolation(tt.hasHookedWork, tt.minutes); got != tt.expected {
+				t.Errorf("IsGUPPViolation(%v, %d) = %v, want %v",
+					tt.hasHookedWork, tt.minutes, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestProblemAgentDurationDisplay tests the human-readable duration formatting
+func TestProblemAgentDurationDisplay(t *testing.T) {
+	tests := []struct {
+		minutes  int
+		expected string
+	}{
+		{0, "<1m"},
+		{1, "1m"},
+		{5, "5m"},
+		{59, "59m"},
+		{60, "1h"},
+		{61, "1h1m"},
+		{90, "1h30m"},
+		{120, "2h"},
+		{125, "2h5m"},
+		{180, "3h"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.expected, func(t *testing.T) {
+			agent := &ProblemAgent{IdleMinutes: tt.minutes}
+			if got := agent.DurationDisplay(); got != tt.expected {
+				t.Errorf("ProblemAgent{IdleMinutes: %d}.DurationDisplay() = %q, want %q",
+					tt.minutes, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestProblemAgentNeedsAttention tests the NeedsAttention delegation
+func TestProblemAgentNeedsAttention(t *testing.T) {
+	tests := []struct {
+		state    AgentState
+		expected bool
+	}{
+		{StateGUPPViolation, true},
+		{StateInputRequired, true},
+		{StateStalled, true},
+		{StateZombie, true},
+		{StateWorking, false},
+		{StateIdle, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.state.String(), func(t *testing.T) {
+			agent := &ProblemAgent{State: tt.state}
+			if got := agent.NeedsAttention(); got != tt.expected {
+				t.Errorf("ProblemAgent{State: %s}.NeedsAttention() = %v, want %v",
+					tt.state, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestDefaultPatternsMatch tests that the default patterns match expected content
+func TestDefaultPatternsMatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		content  string
+		expected InputReason
+	}{
+		{"general prompt", "some output\n> ", InputReasonPromptWaiting},
+		{"claude prompt", "claude> ", InputReasonPromptWaiting},
+		{"YOLO Y/n", "Do something? [Y/n] ", InputReasonYOLOConfirmation},
+		{"YOLO y/N", "Do something? [y/N] ", InputReasonYOLOConfirmation},
+		{"allow prompt", "Allow? ", InputReasonPermission},
+		{"press enter", "Press Enter to continue", InputReasonEnterRequired},
+		{"continue question", "Do you want to continue?", InputReasonPermission},
+		{"proceed question", "Proceed?", InputReasonPermission},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var matched InputReason
+			for _, pattern := range DefaultPatterns {
+				if pattern.Regex.MatchString(tt.content) {
+					matched = pattern.Reason
+					break
+				}
+			}
+			if matched != tt.expected {
+				t.Errorf("Pattern match for %q = %v, want %v", tt.content, matched, tt.expected)
+			}
+		})
+	}
+}
+
+// TestDefaultPatternsNoMatch tests that normal output doesn't trigger patterns
+func TestDefaultPatternsNoMatch(t *testing.T) {
+	normalOutputs := []string{
+		"Building project...",
+		"Running tests",
+		"Completed successfully",
+		"Processing file.go",
+		"",
+	}
+
+	for _, content := range normalOutputs {
+		for _, pattern := range DefaultPatterns {
+			if pattern.Regex.MatchString(content) {
+				t.Errorf("Pattern %v unexpectedly matched %q", pattern.Reason, content)
+			}
+		}
+	}
+}
+
+// TestErrorPatternsMatch tests error pattern detection
+func TestErrorPatternsMatch(t *testing.T) {
+	errorOutputs := []string{
+		"Rate limit exceeded",
+		"RATE LIMIT",
+		"Context is full",
+		"context window full",
+		"Error: something went wrong",
+		"error: failed to compile",
+		"Failed: test case",
+		"FAILED: build step",
+	}
+
+	for _, content := range errorOutputs {
+		matched := false
+		for _, pattern := range ErrorPatterns {
+			if pattern.MatchString(content) {
+				matched = true
+				break
+			}
+		}
+		if !matched {
+			t.Errorf("No error pattern matched %q", content)
+		}
+	}
+}
+
+// TestParseRoleFromSession tests role extraction from session names
+func TestParseRoleFromSession(t *testing.T) {
+	tests := []struct {
+		sessionID string
+		expected  string
+	}{
+		{"polecat-1", "polecat"},
+		{"polecat-myproject-42", "polecat"},
+		{"mayor", "mayor"},
+		{"mayor-main", "mayor"},
+		{"refinery-abc", "refinery"},
+		{"witness-123", "witness"},
+		{"deacon-boot", "deacon"},
+		{"crew-joe", "crew"},
+		{"boot-init", "boot"},
+		{"unknown-session", "unknown"},
+		{"my-session", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.sessionID, func(t *testing.T) {
+			if got := parseRoleFromSession(tt.sessionID); got != tt.expected {
+				t.Errorf("parseRoleFromSession(%q) = %q, want %q", tt.sessionID, got, tt.expected)
+			}
+		})
+	}
+}
+
+// TestGetActionHint tests action hint generation
+func TestGetActionHint(t *testing.T) {
+	tests := []struct {
+		reason   InputReason
+		contains string
+	}{
+		{InputReasonPromptWaiting, "prompt"},
+		{InputReasonYOLOConfirmation, "YOLO"},
+		{InputReasonEnterRequired, "Enter"},
+		{InputReasonPermission, "Permission"},
+		{InputReasonUnknown, "stuck"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.reason.String(), func(t *testing.T) {
+			hint := getActionHint(tt.reason)
+			if hint == "" {
+				t.Errorf("getActionHint(%v) returned empty string", tt.reason)
+			}
+			// Just verify it returns something meaningful
+			if len(hint) < 10 {
+				t.Errorf("getActionHint(%v) = %q, expected longer hint", tt.reason, hint)
+			}
+		})
+	}
+}
+
+// TestStuckDetectorAnalyzeSession_NoSession tests zombie detection for missing sessions
+func TestStuckDetectorAnalyzeSession_NoSession(t *testing.T) {
+	mock := newMockTmuxClient()
+	// Don't add any sessions - HasSession will return false
+
+	detector := NewStuckDetectorWithClient(mock)
+	agent := detector.AnalyzeSession("nonexistent-session")
+
+	if agent.State != StateZombie {
+		t.Errorf("Expected StateZombie for missing session, got %s", agent.State)
+	}
+	if agent.SessionID != "nonexistent-session" {
+		t.Errorf("Expected SessionID to be preserved, got %s", agent.SessionID)
+	}
+}
+
+// TestStuckDetectorAnalyzeSession_CaptureError tests zombie detection for capture failures
+func TestStuckDetectorAnalyzeSession_CaptureError(t *testing.T) {
+	mock := newMockTmuxClient()
+	mock.sessions["test-session"] = true
+	mock.captureErr = errors.New("capture failed")
+
+	detector := NewStuckDetectorWithClient(mock)
+	agent := detector.AnalyzeSession("test-session")
+
+	if agent.State != StateZombie {
+		t.Errorf("Expected StateZombie for capture error, got %s", agent.State)
+	}
+}
+
+// TestStuckDetectorAnalyzeSession_Working tests normal working state
+func TestStuckDetectorAnalyzeSession_Working(t *testing.T) {
+	mock := newMockTmuxClient()
+	mock.sessions["polecat-1"] = true
+	mock.paneContent["polecat-1"] = "Building project...\nProcessing files..."
+	mock.sessionActivity["polecat-1"] = time.Now() // Recent activity
+
+	detector := NewStuckDetectorWithClient(mock)
+	agent := detector.AnalyzeSession("polecat-1")
+
+	if agent.State != StateWorking {
+		t.Errorf("Expected StateWorking, got %s", agent.State)
+	}
+	if agent.Role != "polecat" {
+		t.Errorf("Expected role 'polecat', got %s", agent.Role)
+	}
+}
+
+// TestStuckDetectorAnalyzeSession_InputRequired tests input detection
+func TestStuckDetectorAnalyzeSession_InputRequired(t *testing.T) {
+	mock := newMockTmuxClient()
+	mock.sessions["polecat-1"] = true
+	mock.paneContent["polecat-1"] = "Some output\nclaude> "
+	// Set activity to 3 minutes ago (past the 2-minute threshold)
+	mock.sessionActivity["polecat-1"] = time.Now().Add(-3 * time.Minute)
+
+	detector := NewStuckDetectorWithClient(mock)
+	agent := detector.AnalyzeSession("polecat-1")
+
+	if agent.State != StateInputRequired {
+		t.Errorf("Expected StateInputRequired, got %s", agent.State)
+	}
+	if agent.InputReason != InputReasonPromptWaiting {
+		t.Errorf("Expected InputReasonPromptWaiting, got %v", agent.InputReason)
+	}
+}
+
+// TestStuckDetectorAnalyzeSession_Stalled tests stalled detection
+func TestStuckDetectorAnalyzeSession_Stalled(t *testing.T) {
+	mock := newMockTmuxClient()
+	mock.sessions["polecat-1"] = true
+	mock.paneContent["polecat-1"] = "Processing...\nStill working..."
+	// Set activity to 20 minutes ago (past the 15-minute stalled threshold)
+	mock.sessionActivity["polecat-1"] = time.Now().Add(-20 * time.Minute)
+
+	detector := NewStuckDetectorWithClient(mock)
+	agent := detector.AnalyzeSession("polecat-1")
+
+	if agent.State != StateStalled {
+		t.Errorf("Expected StateStalled, got %s", agent.State)
+	}
+}
+
+// TestStuckDetectorAnalyzeSession_ErrorPattern tests error pattern detection
+func TestStuckDetectorAnalyzeSession_ErrorPattern(t *testing.T) {
+	mock := newMockTmuxClient()
+	mock.sessions["polecat-1"] = true
+	mock.paneContent["polecat-1"] = "Attempting operation...\nError: connection refused"
+	mock.sessionActivity["polecat-1"] = time.Now() // Recent activity
+
+	detector := NewStuckDetectorWithClient(mock)
+	agent := detector.AnalyzeSession("polecat-1")
+
+	if agent.State != StateStalled {
+		t.Errorf("Expected StateStalled for error pattern, got %s", agent.State)
+	}
+	if agent.ActionHint != "Error detected in output" {
+		t.Errorf("Expected error action hint, got %s", agent.ActionHint)
+	}
+}
+
+// TestStuckDetectorAnalyzeSession_LastLines tests that last lines are captured
+func TestStuckDetectorAnalyzeSession_LastLines(t *testing.T) {
+	mock := newMockTmuxClient()
+	mock.sessions["polecat-1"] = true
+	mock.paneContent["polecat-1"] = "line1\nline2\nline3\nline4\nline5\nline6\nline7"
+	mock.sessionActivity["polecat-1"] = time.Now()
+
+	detector := NewStuckDetectorWithClient(mock)
+	agent := detector.AnalyzeSession("polecat-1")
+
+	// Should only capture last 5 lines
+	if agent.LastLines == "" {
+		t.Error("Expected LastLines to be populated")
+	}
+	// The last lines should contain the most recent content
+	if len(agent.LastLines) == 0 {
+		t.Error("LastLines should not be empty")
+	}
+}
+
+// TestNewStuckDetector tests the default constructor
+func TestNewStuckDetector(t *testing.T) {
+	// This will use the real tmux wrapper, but we can verify the struct is set up correctly
+	detector := NewStuckDetector()
+
+	if detector == nil {
+		t.Fatal("NewStuckDetector returned nil")
+	}
+	if len(detector.Patterns) == 0 {
+		t.Error("Expected default patterns to be set")
+	}
+	if detector.IdleThreshold != InputWaitThresholdSecs*time.Second {
+		t.Errorf("Expected IdleThreshold to be %v, got %v",
+			InputWaitThresholdSecs*time.Second, detector.IdleThreshold)
+	}
+}
+
+// TestThresholdConstants verifies the threshold constants are reasonable
+func TestThresholdConstants(t *testing.T) {
+	if GUPPViolationMinutes != 30 {
+		t.Errorf("GUPPViolationMinutes = %d, want 30", GUPPViolationMinutes)
+	}
+	if StalledThresholdMinutes != 15 {
+		t.Errorf("StalledThresholdMinutes = %d, want 15", StalledThresholdMinutes)
+	}
+	if InputWaitThresholdSecs != 120 {
+		t.Errorf("InputWaitThresholdSecs = %d, want 120", InputWaitThresholdSecs)
+	}
+
+	// GUPP threshold should be longer than stalled threshold
+	if GUPPViolationMinutes <= StalledThresholdMinutes {
+		t.Error("GUPP violation threshold should be longer than stalled threshold")
+	}
+}
+
+// TestNewStuckDetectorWithTmux tests the deprecated constructor
+func TestNewStuckDetectorWithTmux(t *testing.T) {
+	// NewStuckDetectorWithTmux is a deprecated wrapper around NewStuckDetectorWithClient
+	// It should work identically
+	realTmux := tmux.NewTmux()
+	detector := NewStuckDetectorWithTmux(realTmux)
+
+	if detector == nil {
+		t.Fatal("NewStuckDetectorWithTmux returned nil")
+	}
+	if len(detector.Patterns) == 0 {
+		t.Error("Expected default patterns to be set")
+	}
+	if detector.IdleThreshold != InputWaitThresholdSecs*time.Second {
+		t.Errorf("Expected IdleThreshold to be %v, got %v",
+			InputWaitThresholdSecs*time.Second, detector.IdleThreshold)
+	}
+}
+
+// TestFindGasTownSessions tests session discovery
+func TestFindGasTownSessions(t *testing.T) {
+	mock := newMockTmuxClient()
+	mock.sessionNames = []string{
+		"polecat-1",
+		"polecat-myproject-42",
+		"mayor-main",
+		"witness-123",
+		"my-personal-session",
+		"dev",
+		"deacon-boot",
+	}
+
+	detector := NewStuckDetectorWithClient(mock)
+	sessions, err := detector.FindGasTownSessions()
+	if err != nil {
+		t.Fatalf("FindGasTownSessions: %v", err)
+	}
+
+	// Should find GasTown sessions but not personal ones
+	expected := map[string]bool{
+		"polecat-1":           true,
+		"polecat-myproject-42": true,
+		"mayor-main":          true,
+		"witness-123":         true,
+		"deacon-boot":         true,
+	}
+
+	if len(sessions) != len(expected) {
+		t.Errorf("FindGasTownSessions found %d sessions, want %d", len(sessions), len(expected))
+	}
+
+	for _, s := range sessions {
+		if !expected[s] {
+			t.Errorf("Unexpected session found: %s", s)
+		}
+	}
+}
+
+// TestFindGasTownSessions_Empty tests with no sessions
+func TestFindGasTownSessions_Empty(t *testing.T) {
+	mock := newMockTmuxClient()
+	mock.sessionNames = []string{}
+
+	detector := NewStuckDetectorWithClient(mock)
+	sessions, err := detector.FindGasTownSessions()
+	if err != nil {
+		t.Fatalf("FindGasTownSessions: %v", err)
+	}
+
+	if len(sessions) != 0 {
+		t.Errorf("Expected no sessions, got %d", len(sessions))
+	}
+}
+
+// TestFindGasTownSessions_Error tests error handling
+func TestFindGasTownSessions_Error(t *testing.T) {
+	mock := newMockTmuxClient()
+	mock.sessionSetErr = errors.New("tmux error")
+
+	detector := NewStuckDetectorWithClient(mock)
+	_, err := detector.FindGasTownSessions()
+	if err == nil {
+		t.Error("Expected error from FindGasTownSessions")
+	}
+}
+
+// TestFindGasTownSessions_NoGasTownSessions tests when no GT sessions exist
+func TestFindGasTownSessions_NoGasTownSessions(t *testing.T) {
+	mock := newMockTmuxClient()
+	mock.sessionNames = []string{
+		"my-session",
+		"dev",
+		"work",
+	}
+
+	detector := NewStuckDetectorWithClient(mock)
+	sessions, err := detector.FindGasTownSessions()
+	if err != nil {
+		t.Fatalf("FindGasTownSessions: %v", err)
+	}
+
+	if len(sessions) != 0 {
+		t.Errorf("Expected no GasTown sessions, got %d: %v", len(sessions), sessions)
+	}
+}

--- a/internal/tui/feed/styles.go
+++ b/internal/tui/feed/styles.go
@@ -9,11 +9,11 @@ import (
 
 // Color palette using Ayu theme colors from ui package
 var (
-	colorPrimary   = ui.ColorAccent // Blue
-	colorSuccess   = ui.ColorPass   // Green
-	colorWarning   = ui.ColorWarn   // Yellow
-	colorError     = ui.ColorFail   // Red
-	colorDim       = ui.ColorMuted  // Gray
+	colorPrimary   = ui.ColorAccent                                            // Blue
+	colorSuccess   = ui.ColorPass                                              // Green
+	colorWarning   = ui.ColorWarn                                              // Yellow
+	colorError     = ui.ColorFail                                              // Red
+	colorDim       = ui.ColorMuted                                             // Gray
 	colorHighlight = lipgloss.AdaptiveColor{Light: "#59c2ff", Dark: "#59c2ff"} // Cyan (Ayu)
 	colorAccent    = lipgloss.AdaptiveColor{Light: "#d2a6ff", Dark: "#d2a6ff"} // Purple (Ayu)
 )
@@ -124,6 +124,47 @@ var (
 
 	EventMergeSkippedStyle = lipgloss.NewStyle().
 				Foreground(colorWarning)
+
+	// Problems view styles
+	ProblemsModeStyle = lipgloss.NewStyle().
+				Foreground(colorError).
+				Bold(true)
+
+	ProblemsPanelStyle = lipgloss.NewStyle().
+				Border(lipgloss.RoundedBorder()).
+				BorderForeground(colorDim).
+				Padding(0, 1)
+
+	ProblemsHeaderStyle = lipgloss.NewStyle().
+				Foreground(colorError).
+				Bold(true)
+
+	WorkingHeaderStyle = lipgloss.NewStyle().
+				Foreground(colorSuccess).
+				Bold(true)
+
+	IdleHeaderStyle = lipgloss.NewStyle().
+			Foreground(colorDim).
+			Bold(true)
+
+	SelectedStyle = lipgloss.NewStyle().
+			Foreground(colorHighlight).
+			Bold(true)
+
+	// Agent state styles
+	GUPPStyle = lipgloss.NewStyle().
+			Foreground(colorError).
+			Bold(true)
+
+	InputRequiredStyle = lipgloss.NewStyle().
+				Foreground(colorWarning).
+				Bold(true)
+
+	StalledStyle = lipgloss.NewStyle().
+			Foreground(colorError)
+
+	ZombieStyle = lipgloss.NewStyle().
+			Foreground(colorDim)
 
 	// Event symbols
 	EventSymbols = map[string]string{

--- a/internal/tui/feed/view.go
+++ b/internal/tui/feed/view.go
@@ -20,17 +20,24 @@ func (m *Model) render() string {
 	// Header
 	sections = append(sections, m.renderHeader())
 
-	// Tree panel (top)
-	treePanel := m.renderTreePanel()
-	sections = append(sections, treePanel)
+	if m.viewMode == ViewProblems {
+		// Problems view: single panel
+		problemsPanel := m.renderProblemsPanel()
+		sections = append(sections, problemsPanel)
+	} else {
+		// Activity view: three panels
+		// Tree panel (top)
+		treePanel := m.renderTreePanel()
+		sections = append(sections, treePanel)
 
-	// Convoy panel (middle)
-	convoyPanel := m.renderConvoyPanel()
-	sections = append(sections, convoyPanel)
+		// Convoy panel (middle)
+		convoyPanel := m.renderConvoyPanel()
+		sections = append(sections, convoyPanel)
 
-	// Feed panel (bottom)
-	feedPanel := m.renderFeedPanel()
-	sections = append(sections, feedPanel)
+		// Feed panel (bottom)
+		feedPanel := m.renderFeedPanel()
+		sections = append(sections, feedPanel)
+	}
 
 	// Status bar
 	sections = append(sections, m.renderStatusBar())
@@ -45,22 +52,50 @@ func (m *Model) render() string {
 
 // renderHeader renders the top header bar
 func (m *Model) renderHeader() string {
-	title := TitleStyle.Render("GT Feed")
-
-	filter := ""
-	if m.filter != "" {
-		filter = FilterStyle.Render(fmt.Sprintf("Filter: %s", m.filter))
+	var title string
+	if m.viewMode == ViewProblems {
+		title = TitleStyle.Render("GT Feed") + " " + ProblemsModeStyle.Render("[PROBLEMS]")
 	} else {
-		filter = FilterStyle.Render("Filter: all")
+		title = TitleStyle.Render("GT Feed")
 	}
 
-	// Right-align filter
-	gap := m.width - lipgloss.Width(title) - lipgloss.Width(filter) - 4
+	// Show summary stats on the right
+	var stats string
+	if m.viewMode == ViewProblems && len(m.problemAgents) > 0 {
+		ok, stuck, idle := m.countAgentStates()
+		stats = fmt.Sprintf("%d agents  %s %d ok │ %s %d stuck │ %d idle",
+			len(m.problemAgents),
+			AgentActiveStyle.Render("●"), ok,
+			EventFailStyle.Render("●"), stuck,
+			idle)
+	} else if m.filter != "" {
+		stats = FilterStyle.Render(fmt.Sprintf("Filter: %s", m.filter))
+	} else {
+		stats = FilterStyle.Render("Filter: all")
+	}
+
+	// Right-align stats
+	gap := m.width - lipgloss.Width(title) - lipgloss.Width(stats) - 4
 	if gap < 1 {
 		gap = 1
 	}
 
-	return HeaderStyle.Render(title + strings.Repeat(" ", gap) + filter)
+	return HeaderStyle.Render(title + strings.Repeat(" ", gap) + stats)
+}
+
+// countAgentStates returns counts of ok, stuck, and idle agents
+func (m *Model) countAgentStates() (ok, stuck, idle int) {
+	for _, agent := range m.problemAgents {
+		switch agent.State {
+		case StateWorking:
+			ok++
+		case StateIdle:
+			idle++
+		case StateGUPPViolation, StateInputRequired, StateStalled, StateZombie:
+			stuck++
+		}
+	}
+	return
 }
 
 // renderTreePanel renders the agent tree panel with border
@@ -79,6 +114,151 @@ func (m *Model) renderFeedPanel() string {
 		style = FocusedBorderStyle
 	}
 	return style.Width(m.width - 2).Render(m.feedViewport.View())
+}
+
+// renderProblemsPanel renders the problems view panel
+func (m *Model) renderProblemsPanel() string {
+	style := ProblemsPanelStyle
+	if m.focusedPanel == PanelProblems {
+		style = FocusedBorderStyle
+	}
+	return style.Width(m.width - 2).Render(m.problemsViewport.View())
+}
+
+// renderProblemsContent renders the problems view content
+func (m *Model) renderProblemsContent() string {
+	var lines []string
+
+	if len(m.problemAgents) == 0 {
+		return AgentIdleStyle.Render("No agents detected. Run gt feed in a GasTown workspace with active tmux sessions.")
+	}
+
+	// Count problems
+	var problemAgents []*ProblemAgent
+	var workingAgents []*ProblemAgent
+	var idleAgents []*ProblemAgent
+
+	for _, agent := range m.problemAgents {
+		switch {
+		case agent.State.NeedsAttention():
+			problemAgents = append(problemAgents, agent)
+		case agent.State == StateWorking:
+			workingAgents = append(workingAgents, agent)
+		default:
+			idleAgents = append(idleAgents, agent)
+		}
+	}
+
+	// NEEDS ATTENTION section
+	if len(problemAgents) > 0 {
+		lines = append(lines, ProblemsHeaderStyle.Render(fmt.Sprintf("NEEDS ATTENTION (%d)", len(problemAgents))))
+		lines = append(lines, "")
+		for i, agent := range problemAgents {
+			isSelected := i == m.selectedProblem
+			lines = append(lines, m.renderProblemAgent(agent, isSelected))
+		}
+		lines = append(lines, "")
+	} else {
+		lines = append(lines, ProblemsHeaderStyle.Render("NEEDS ATTENTION (0)"))
+		lines = append(lines, "  "+AgentActiveStyle.Render("All agents OK!"))
+		lines = append(lines, "")
+	}
+
+	// WORKING section (collapsed dots by rig)
+	if len(workingAgents) > 0 {
+		lines = append(lines, WorkingHeaderStyle.Render(fmt.Sprintf("WORKING (%d)", len(workingAgents))))
+		// Group by rig
+		byRig := make(map[string]int)
+		for _, agent := range workingAgents {
+			rig := agent.Rig
+			if rig == "" {
+				rig = "default"
+			}
+			byRig[rig]++
+		}
+		for rig, count := range byRig {
+			dots := strings.Repeat("●", count)
+			if count > 20 {
+				dots = strings.Repeat("●", 20) + fmt.Sprintf("+%d", count-20)
+			}
+			lines = append(lines, fmt.Sprintf("  %s %s (%d)",
+				AgentActiveStyle.Render(dots),
+				RigStyle.Render(rig),
+				count))
+		}
+		lines = append(lines, "")
+	}
+
+	// IDLE section (collapsed)
+	if len(idleAgents) > 0 {
+		lines = append(lines, IdleHeaderStyle.Render(fmt.Sprintf("IDLE (%d)", len(idleAgents))))
+		dots := strings.Repeat("○", len(idleAgents))
+		if len(idleAgents) > 20 {
+			dots = strings.Repeat("○", 20) + fmt.Sprintf("+%d", len(idleAgents)-20)
+		}
+		lines = append(lines, "  "+AgentIdleStyle.Render(dots))
+	}
+
+	return strings.Join(lines, "\n")
+}
+
+// renderProblemAgent renders a single problem agent line
+func (m *Model) renderProblemAgent(agent *ProblemAgent, selected bool) string {
+	// Format: "▶polecat-12  🔥 GUPP!    45m (violation)  gt-xyz89   myproject"
+	prefix := "  "
+	if selected {
+		prefix = SelectedStyle.Render("▶ ")
+	}
+
+	// Name
+	name := agent.Name
+	if len(name) > 12 {
+		name = name[:12]
+	}
+	namePart := fmt.Sprintf("%-12s", name)
+
+	// State symbol and label
+	stateStyle := getStateStyle(agent.State)
+	statePart := stateStyle.Render(fmt.Sprintf("%s %-6s", agent.State.Symbol(), agent.State.Label()))
+
+	// Reason or duration
+	var reasonPart string
+	if agent.State == StateInputRequired {
+		reasonPart = fmt.Sprintf("%-8s %s", agent.InputReason.String(), agent.DurationDisplay()+" ago")
+	} else {
+		reasonPart = fmt.Sprintf("%s no progress", agent.DurationDisplay())
+	}
+	reasonPart = fmt.Sprintf("%-20s", reasonPart)
+
+	// Bead ID (if known)
+	beadPart := ""
+	if agent.CurrentBeadID != "" {
+		beadPart = ConvoyIDStyle.Render(agent.CurrentBeadID)
+	}
+
+	// Rig
+	rigPart := ""
+	if agent.Rig != "" {
+		rigPart = RigStyle.Render(agent.Rig)
+	}
+
+	return prefix + namePart + "  " + statePart + "  " + TimestampStyle.Render(reasonPart) + "  " + beadPart + "  " + rigPart
+}
+
+// getStateStyle returns the appropriate style for an agent state
+func getStateStyle(state AgentState) lipgloss.Style {
+	switch state {
+	case StateGUPPViolation:
+		return GUPPStyle
+	case StateInputRequired:
+		return InputRequiredStyle
+	case StateStalled:
+		return StalledStyle
+	case StateZombie:
+		return ZombieStyle
+	default:
+		return AgentIdleStyle
+	}
 }
 
 // renderTree renders the agent tree content
@@ -301,26 +481,37 @@ func (m *Model) renderEvent(e Event) string {
 
 // renderStatusBar renders the bottom status bar
 func (m *Model) renderStatusBar() string {
-	// Panel indicator
-	var panelName string
-	switch m.focusedPanel {
-	case PanelTree:
-		panelName = "tree"
-	case PanelConvoy:
-		panelName = "convoy"
-	case PanelFeed:
-		panelName = "feed"
+	var left string
+	if m.viewMode == ViewProblems {
+		// Problems view: show problem count and selected agent
+		problemCount := 0
+		for _, agent := range m.problemAgents {
+			if agent.State.NeedsAttention() {
+				problemCount++
+			}
+		}
+		left = fmt.Sprintf("[problems] %d need attention", problemCount)
+		if m.selectedProblem >= 0 && m.selectedProblem < len(m.problemAgents) {
+			left += fmt.Sprintf(" | selected: %s", m.problemAgents[m.selectedProblem].Name)
+		}
+	} else {
+		// Activity view: show panel and event count
+		var panelName string
+		switch m.focusedPanel {
+		case PanelTree:
+			panelName = "tree"
+		case PanelConvoy:
+			panelName = "convoy"
+		case PanelFeed:
+			panelName = "feed"
+		}
+		left = fmt.Sprintf("[%s] %d events", panelName, len(m.events))
 	}
-	panel := fmt.Sprintf("[%s]", panelName)
-
-	// Event count
-	count := fmt.Sprintf("%d events", len(m.events))
 
 	// Short help
 	help := m.renderShortHelp()
 
 	// Combine
-	left := panel + " " + count
 	gap := m.width - lipgloss.Width(left) - lipgloss.Width(help) - 4
 	if gap < 1 {
 		gap = 1
@@ -331,7 +522,20 @@ func (m *Model) renderStatusBar() string {
 
 // renderShortHelp renders abbreviated key hints
 func (m *Model) renderShortHelp() string {
+	if m.viewMode == ViewProblems {
+		hints := []string{
+			HelpKeyStyle.Render("p") + HelpDescStyle.Render(":activity"),
+			HelpKeyStyle.Render("⏎") + HelpDescStyle.Render(":attach"),
+			HelpKeyStyle.Render("n") + HelpDescStyle.Render(":nudge"),
+			HelpKeyStyle.Render("h") + HelpDescStyle.Render(":handoff"),
+			HelpKeyStyle.Render("Tab") + HelpDescStyle.Render(":next"),
+			HelpKeyStyle.Render("?") + HelpDescStyle.Render(":help"),
+			HelpKeyStyle.Render("q") + HelpDescStyle.Render(":quit"),
+		}
+		return strings.Join(hints, "  ")
+	}
 	hints := []string{
+		HelpKeyStyle.Render("p") + HelpDescStyle.Render(":problems"),
 		HelpKeyStyle.Render("j/k") + HelpDescStyle.Render(":scroll"),
 		HelpKeyStyle.Render("tab") + HelpDescStyle.Render(":switch"),
 		HelpKeyStyle.Render("/") + HelpDescStyle.Render(":search"),


### PR DESCRIPTION
Add a problem-first view to gt feed that surfaces agents needing attention:

- New --problems/-p flag to start in problems view
- Press 'p' to toggle between activity and problems views
- Stuck detection via tmux pattern matching (prompts, [Y/n], permissions)
- Agent states: GUPP violation, Input Required, Stalled, Working, Idle, Zombie
- Intervention actions: Enter=attach, n=nudge, h=handoff, r=restart

Implementation:
- Add TmuxClient interface for testability
- Add GetSessionActivity method to tmux wrapper
- Add stuck.go with detection patterns and StuckDetector
- Add comprehensive tests in stuck_test.go (24 tests)

## Summary
Add a problems view to gt feed that detects stuck agents and surfaces them for human intervention. This addresses cognitive overload when managing 30-50+ agents where stuck agents can go unnoticed for 30+ minutes. Reuses existing tmux state discovery and respects configured stuck thresholds.

## Related Issue
Related: #228 (community web UI has similar goals, different surface)
Reviewed: #195/#196 (convoy states - complementary, not duplicative)

## Changes                                                                                                     
- Add --problems/-p flag to start in problems view                                                             
- Add p key to toggle between activity and problems views                                                      
- Add stuck detection via tmux pattern matching (prompts, [Y/n], permissions, errors)                          
- Add 6 agent states: GUPP violation, Input Required, Stalled, Working, Idle, Zombie                           
- Add intervention keybindings: Enter=attach, n=nudge, h=handoff, r=restart
- Add TmuxClient interface for dependency injection and testability                                            
- Add GetSessionActivity and NewSessionSet methods to tmux wrapper                                             
- Add stuck.go with detection patterns and StuckDetector                                                       
- Add 29 unit tests in stuck_test.go (100% coverage on stuck.go)                                               
- Add 5 tests in tmux_test.go for new methods    

## Testing
- Unit tests pass (go test ./...)                                                                              
- Manual testing performed                                                                                     
- 29 tests for stuck detection logic                                                                           
- 100% code coverage on internal/tui/feed/stuck.go   

## Checklist
- [ ] Code follows project style
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or documented in summary)
