### PR TITLE
fix(config): use > prompt symbol on Windows for better compatibility

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -4,6 +4,7 @@ package config
 import (
 	"path/filepath"
 	"os"
+	"runtime"
 	"strings"
 	"time"
 )
@@ -552,7 +553,11 @@ func defaultProcessNames(provider, command string) []string {
 
 func defaultReadyPromptPrefix(provider string) string {
 	if provider == "claude" {
-		// Claude Code uses ❯ (U+276F) as the prompt character
+		// Claude Code uses ❯ (U+276F) as the prompt character on Unix,
+		// but > on Windows for better terminal compatibility
+		if runtime.GOOS == "windows" {
+			return "> "
+		}
 		return "❯ "
 	}
 	return ""


### PR DESCRIPTION
## Summary
- Use `>` as the ready prompt prefix on Windows instead of `❯` (U+276F)
- The Unicode character `❯` may not render correctly in all Windows terminals
- Unix (macOS/Linux) continues to use `❯`

## Test plan
- [x] Verify build works on both platforms
- [ ] Test on Windows to confirm `>` is detected correctly