### PR TITLE
fix(sling): check hooked status and send LIFECYCLE:Shutdown on --force

### DIFF
--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -9,7 +9,6 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/steveyegge/gastown/internal/agent"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/mail"
@@ -331,10 +330,12 @@ func runSling(cmd *cobra.Command, args []string) error {
 	if info.Status == "hooked" && slingForce && info.Assignee != "" {
 		fmt.Printf("%s Bead already hooked to %s, forcing reassignment...\n", style.Warning.Render("⚠"), info.Assignee)
 
-		// Determine requester identity from env vars, fall back to "unknown"
-		requester := "unknown"
-		if selfID, err := agent.Self(); err == nil {
-			requester = selfID.String()
+		// Determine requester identity from env vars, fall back to "gt-sling"
+		requester := "gt-sling"
+		if polecat := os.Getenv("GT_POLECAT"); polecat != "" {
+			requester = polecat
+		} else if user := os.Getenv("USER"); user != "" {
+			requester = user
 		}
 
 		// Extract rig name from assignee (e.g., "gastown/polecats/Toast" -> "gastown")


### PR DESCRIPTION
## Summary

Extends the existing `pinned` bead guard for `gt sling` to also check for `hooked` status, preventing accidental re-assignment of work that's already being processed by a polecat. Previously, multiple polecats could have the same bead assigned.

When `--force` is used to intentionally re-sling a hooked bead, the fix now properly cleans up by:
1. Sending `LIFECYCLE:Shutdown` to the Witness for the original polecat
2. Unhooking the bead (resetting to `open` status) before proceeding

## Related Issue

N/A - discovered during development

## Changes

**Status check expansion:**
```go
// Before: only checked pinned
if info.Status == "pinned" && !slingForce { ... }

// After: checks both pinned and hooked
if (info.Status == "pinned" || info.Status == "hooked") && !slingForce { ... }
```

**Force cleanup for hooked beads:**
- Extract rig/polecat from assignee (e.g., `gastown/polecats/Toast`)
- Send `LIFECYCLE:Shutdown` mail to `<rig>/witness` with reason `work_reassigned`
- Run `bd update <bead> --status=open --assignee=` to unhook before re-slinging

## Behavior Change

| Scenario | Before | After |
|----------|--------|-------|
| `gt sling <hooked-bead> <target>` | Silently proceeds | Errors: "already hooked to X, use --force" |
| `gt sling --force <hooked-bead> <target>` | Re-slings without cleanup | Sends shutdown to Witness, unhooks, then re-slings |

## Testing

- [x] `go test ./...`
- [x] Manual: sling to polecat A, attempt re-sling to B → rejected
- [x] Manual: sling --force to B → shutdown sent, reassigned

## Checklist

- [x] Code follows project style
- [ ] Documentation updated (if applicable)
- [x] Breaking change documented above