### PR TITLE
feat(config): add ShellQuote helper for safe env var escaping

### DIFF
--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -175,6 +175,101 @@ func TestAgentEnv_EmptyTownRootOmitted(t *testing.T) {
 	assertEnv(t, env, "GT_RIG", "myrig")
 }
 
+func TestShellQuote(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "simple value no quoting",
+			input:    "foobar",
+			expected: "foobar",
+		},
+		{
+			name:     "alphanumeric and underscore",
+			input:    "FOO_BAR_123",
+			expected: "FOO_BAR_123",
+		},
+		// CRITICAL: These values are used by existing agents and must NOT be quoted
+		{
+			name:     "path with slashes (GT_ROOT, CLAUDE_CONFIG_DIR)",
+			input:    "/home/user/.config/claude",
+			expected: "/home/user/.config/claude", // NOT quoted
+		},
+		{
+			name:     "BD_ACTOR with slashes",
+			input:    "myrig/polecats/Toast",
+			expected: "myrig/polecats/Toast", // NOT quoted
+		},
+		{
+			name:     "value with hyphen",
+			input:    "deacon-boot",
+			expected: "deacon-boot", // NOT quoted
+		},
+		{
+			name:     "value with dots",
+			input:    "user.name",
+			expected: "user.name", // NOT quoted
+		},
+		{
+			name:     "value with spaces",
+			input:    "hello world",
+			expected: "'hello world'",
+		},
+		{
+			name:     "value with double quotes",
+			input:    `say "hello"`,
+			expected: `'say "hello"'`,
+		},
+		{
+			name:     "JSON object",
+			input:    `{"*":"allow"}`,
+			expected: `'{"*":"allow"}'`,
+		},
+		{
+			name:     "OPENCODE_PERMISSION value",
+			input:    `{"*":"allow"}`,
+			expected: `'{"*":"allow"}'`,
+		},
+		{
+			name:     "value with single quote",
+			input:    "it's a test",
+			expected: `'it'\''s a test'`,
+		},
+		{
+			name:     "value with dollar sign",
+			input:    "$HOME",
+			expected: "'$HOME'",
+		},
+		{
+			name:     "value with backticks",
+			input:    "`whoami`",
+			expected: "'`whoami`'",
+		},
+		{
+			name:     "value with asterisk",
+			input:    "*.txt",
+			expected: "'*.txt'",
+		},
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ShellQuote(tt.input)
+			if result != tt.expected {
+				t.Errorf("ShellQuote(%q) = %q, want %q", tt.input, result, tt.expected)
+			}
+		})
+	}
+}
+
 func TestExportPrefix(t *testing.T) {
 	t.Parallel()
 	tests := []struct {
@@ -200,6 +295,22 @@ func TestExportPrefix(t *testing.T) {
 				"MMM": "middle",
 			},
 			expected: "export AAA=first MMM=middle ZZZ=last && ",
+		},
+		{
+			name: "JSON value is quoted",
+			env: map[string]string{
+				"OPENCODE_PERMISSION": `{"*":"allow"}`,
+			},
+			expected: `export OPENCODE_PERMISSION='{"*":"allow"}' && `,
+		},
+		{
+			name: "mixed simple and complex values",
+			env: map[string]string{
+				"SIMPLE":  "value",
+				"COMPLEX": `{"key":"val"}`,
+				"GT_ROLE": "polecat",
+			},
+			expected: `export COMPLEX='{"key":"val"}' GT_ROLE=polecat SIMPLE=value && `,
 		},
 	}
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1256,7 +1256,7 @@ func BuildStartupCommand(envVars map[string]string, rigPath, prompt string) stri
 	// Build environment export prefix
 	var exports []string
 	for k, v := range resolvedEnv {
-		exports = append(exports, fmt.Sprintf("%s=%s", k, v))
+		exports = append(exports, fmt.Sprintf("%s=%s", k, ShellQuote(v)))
 	}
 
 	// Sort for deterministic output
@@ -1278,6 +1278,7 @@ func BuildStartupCommand(envVars map[string]string, rigPath, prompt string) stri
 }
 
 // PrependEnv prepends export statements to a command string.
+// Values containing special characters are properly shell-quoted.
 func PrependEnv(command string, envVars map[string]string) string {
 	if len(envVars) == 0 {
 		return command
@@ -1285,7 +1286,7 @@ func PrependEnv(command string, envVars map[string]string) string {
 
 	var exports []string
 	for k, v := range envVars {
-		exports = append(exports, fmt.Sprintf("%s=%s", k, v))
+		exports = append(exports, fmt.Sprintf("%s=%s", k, ShellQuote(v)))
 	}
 
 	sort.Strings(exports)
@@ -1361,7 +1362,7 @@ func BuildStartupCommandWithAgentOverride(envVars map[string]string, rigPath, pr
 	// Build environment export prefix
 	var exports []string
 	for k, v := range resolvedEnv {
-		exports = append(exports, fmt.Sprintf("%s=%s", k, v))
+		exports = append(exports, fmt.Sprintf("%s=%s", k, ShellQuote(v)))
 	}
 	sort.Strings(exports)
 


### PR DESCRIPTION
## Summary
Add "$(ShellQuote)" function to properly escape environment variable values containing shell special characters.

## Problem
Environment variable values containing shell special characters like "$({)", "$(})", "$(*)", "$($)", "$(")" get mangled by shell expansion when exported in tmux sessions.

**Before (broken):**
```bash
export OPENCODE_PERMISSION={"*":"allow"}
# Shell expands to: OPENCODE_PERMISSION={*:allow}  # Corrupted!
```

**After (fixed):**
```bash
export OPENCODE_PERMISSION='{"*":"allow"}'
# Preserved correctly as JSON
```

## Solution

### ShellQuote Function
```go
func ShellQuote(s string) string {
    // Check if quoting is needed (contains shell special chars)
    needsQuoting := false
    for _, c := range s {
        switch c {
        case ' ', '\t', '\n', '"', '\'', '`', '$', '\\', '!', '*', '?',
            '[', ']', '{', '}', '(', ')', '<', '>', '|', '&', ';', '#':
            needsQuoting = true
        }
    }
    if !needsQuoting {
        return s
    }
    // Use single quotes, escaping embedded single quotes
    return "'" + strings.ReplaceAll(s, "'", "'\\''") + "'"
}
```

### Integration Points
- "$(ExportPrefix())" in "$(env.go)" - uses ShellQuote for all values
- "$(BuildStartupCommand())" in "$(loader.go)" - uses ShellQuote when building exports
- "$(PrependEnv())" in "$(loader.go)" - uses ShellQuote when prepending env vars

## Backwards Compatibility
**Critical**: The following values are NOT quoted to preserve existing agent behavior:
- Paths with slashes: "$(/home/user/.config/claude)" (GT_ROOT, CLAUDE_CONFIG_DIR)
- BD_ACTOR values: "$(myrig/polecats/Toast)"
- Values with hyphens: "$(deacon-boot)"
- Values with dots: "$(user.name)"

Only values with shell special characters ("$({)", "$(})", "$(*)", "$($)", etc.) get quoted.

## Changes

| File | Changes |
|------|---------|
| "$(internal/config/env.go)" | Add "$(ShellQuote())" function, update "$(ExportPrefix())" to use it |
| "$(internal/config/env_test.go)" | Add "$(TestShellQuote)" (14 test cases), update "$(TestExportPrefix)" with JSON value tests |
| "$(internal/config/loader.go)" | Update "$(BuildStartupCommand())", "$(PrependEnv())", "$(BuildStartupCommandWithAgentOverride())" to use ShellQuote |

## Test Coverage
- "$(TestShellQuote)": 14 test cases covering simple values, JSON, quotes, special chars, paths, backwards compatibility
- "$(TestExportPrefix)": Updated with JSON value tests and mixed value tests

## Why This Matters
This fix is required for OpenCode agent integration, which uses:
```go
Env: map[string]string{
    "OPENCODE_PERMISSION": "$({"*":"allow"})",
}
```

Without proper shell quoting, this JSON value would be corrupted by shell expansion.

## Dependency Chain
This is PR 1 of 3 for the OpenCode agent preset feature:
1. **This PR**: ShellQuote helper
2. #832: Add Env field to RuntimeConfig
3. #829: Add OpenCode agent preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)