### PR TITLE
fix(mq): use label instead of issue_type for merge-request filtering

### DIFF
--- a/internal/cmd/mq_list.go
+++ b/internal/cmd/mq_list.go
@@ -48,9 +48,9 @@ func runMQList(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("querying ready MRs: %w", err)
 		}
-		// Filter to only merge-request type
+		// Filter to only merge-request label (issue_type field is deprecated)
 		for _, issue := range allReady {
-			if issue.Type == "merge-request" {
+			if beads.HasLabel(issue, "gt:merge-request") {
 				issues = append(issues, issue)
 			}
 		}


### PR DESCRIPTION
## Summary

- Changed `mq list --ready` to filter by `gt:merge-request` label instead of `issue.Type == "merge-request"`
- The `issue_type` field is deprecated in favor of labels, but some code paths still checked the field directly
- MRs created by `gt done` have `issue_type='task'` (default) with a `gt:merge-request` label, causing them to be filtered out

## Test plan

- [x] Build passes (`go build ./...`)
- [x] Tests pass (`go test ./internal/cmd/...`)
- [x] Verified `beads.HasLabel()` helper exists and is used elsewhere

Fixes #816

🤖 Generated with [Claude Code](https://claude.ai/code)