### PR TITLE
feat(config): add Env field to RuntimeConfig and AgentPresetInfo

### DIFF
--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -102,6 +102,21 @@ func TestRuntimeConfigFromPreset(t *testing.T) {
 	}
 }
 
+func TestRuntimeConfigFromPresetReturnsNilEnvForPresetsWithoutEnv(t *testing.T) {
+	t.Parallel()
+	// Built-in presets like Claude don't have Env set
+	// This verifies nil Env handling in RuntimeConfigFromPreset
+	rc := RuntimeConfigFromPreset(AgentClaude)
+	if rc == nil {
+		t.Fatal("RuntimeConfigFromPreset returned nil")
+	}
+
+	// Claude preset doesn't have Env, so it should be nil
+	if rc.Env != nil && len(rc.Env) > 0 {
+		t.Errorf("Expected nil/empty Env for Claude preset, got %v", rc.Env)
+	}
+}
+
 func TestIsKnownPreset(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1085,6 +1085,13 @@ func fillRuntimeDefaults(rc *RuntimeConfig) *RuntimeConfig {
 		Args:          rc.Args,
 		InitialPrompt: rc.InitialPrompt,
 	}
+	// Copy Env map to avoid mutation and preserve agent-specific env vars
+	if len(rc.Env) > 0 {
+		result.Env = make(map[string]string, len(rc.Env))
+		for k, v := range rc.Env {
+			result.Env[k] = v
+		}
+	}
 	if result.Command == "" {
 		result.Command = "claude"
 	}
@@ -1252,6 +1259,10 @@ func BuildStartupCommand(envVars map[string]string, rigPath, prompt string) stri
 	if rc.Session != nil && rc.Session.SessionIDEnv != "" {
 		resolvedEnv["GT_SESSION_ID_ENV"] = rc.Session.SessionIDEnv
 	}
+	// Merge agent-specific env vars (e.g., OPENCODE_PERMISSION for yolo mode)
+	for k, v := range rc.Env {
+		resolvedEnv[k] = v
+	}
 
 	// Build environment export prefix
 	var exports []string
@@ -1361,6 +1372,10 @@ func BuildStartupCommandWithAgentOverride(envVars map[string]string, rigPath, pr
 	// Record agent override so handoff can preserve it
 	if agentOverride != "" {
 		resolvedEnv["GT_AGENT"] = agentOverride
+	}
+	// Merge agent-specific env vars (e.g., OPENCODE_PERMISSION for yolo mode)
+	for k, v := range rc.Env {
+		resolvedEnv[k] = v
 	}
 
 	// Build environment export prefix

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -263,6 +263,11 @@ type RuntimeConfig struct {
 	// Empty array [] means no args (not "use defaults").
 	Args []string `json:"args"`
 
+	// Env are environment variables to set when starting the agent.
+	// These are merged with the standard GT_* variables.
+	// Used for agent-specific configuration like OPENCODE_PERMISSION.
+	Env map[string]string `json:"env,omitempty"`
+
 	// InitialPrompt is an optional first message to send after startup.
 	// For claude, this is passed as the prompt argument.
 	// Empty by default (hooks handle context).


### PR DESCRIPTION
## Summary
Add "$(Env)" field to "$(RuntimeConfig)" and "$(AgentPresetInfo)" structs, enabling agent presets to specify environment variables that get exported when starting sessions.

## Problem
Some agents require environment-based configuration that cannot be passed via CLI flags. For example, OpenCode uses "$(OPENCODE_PERMISSION)" environment variable for auto-approve mode instead of a CLI flag.

Without this feature, users would need to manually configure environment variables in their shell or use wrapper scripts.

## Solution

### New Env Field
```go
// In RuntimeConfig (types.go)
type RuntimeConfig struct {
    Command string            "$(json:"command,omitempty")"
    Args    []string          "$(json:"args")"
    Env     map[string]string "$(json:"env,omitempty")"  // NEW
    // ...
}

// In AgentPresetInfo (agents.go)
type AgentPresetInfo struct {
    Name    AgentPreset       "$(json:"name")"
    Command string            "$(json:"command")"
    Args    []string          "$(json:"args")"
    Env     map[string]string "$(json:"env,omitempty")"  // NEW
    // ...
}
```

### Env Merging in BuildStartupCommand
```go
// In BuildStartupCommand (loader.go)
// Merge agent-specific env vars (e.g., OPENCODE_PERMISSION for yolo mode)
for k, v := range rc.Env {
    resolvedEnv[k] = v
}
```

### Copy Semantics
All Env map operations use copy semantics to prevent mutation:

```go
// In RuntimeConfigFromPreset (agents.go)
var envCopy map[string]string
if len(info.Env) > 0 {
    envCopy = make(map[string]string, len(info.Env))
    for k, v := range info.Env {
        envCopy[k] = v
    }
}

// In fillRuntimeDefaults (loader.go)
if len(rc.Env) > 0 {
    result.Env = make(map[string]string, len(rc.Env))
    for k, v := range rc.Env {
        result.Env[k] = v
    }
}
```

## Changes

| File | Changes |
|------|---------|
| "$(internal/config/types.go)" | Add "$(Env)" field to "$(RuntimeConfig)" struct |
| "$(internal/config/agents.go)" | Add "$(Env)" field to "$(AgentPresetInfo)", update "$(RuntimeConfigFromPreset())" to copy Env |
| "$(internal/config/loader.go)" | Update "$(fillRuntimeDefaults())" to preserve Env, merge "$(rc.Env)" in "$(BuildStartupCommand())" and "$(BuildStartupCommandWithAgentOverride())" |
| "$(internal/config/agents_test.go)" | Add "$(TestRuntimeConfigFromPresetReturnsNilEnvForPresetsWithoutEnv)" |
| "$(internal/config/loader_test.go)" | Add "$(TestFillRuntimeDefaultsPreservesEnv)" (4 sub-tests), "$(TestFillRuntimeDefaultsEnvIsCopy)" |

## Use Case
Enables agents like OpenCode to use environment-based configuration:
```go
AgentOpenCode: {
    Name:    AgentOpenCode,
    Command: "opencode",
    Args:    []string{},  // No CLI flags needed
    Env: map[string]string{
        "OPENCODE_PERMISSION": "$({"*":"allow"})",  // Auto-approve mode
    },
}
```

The Env values are properly shell-quoted using "$(ShellQuote())" from PR #830.

## Test Coverage
- "$(TestRuntimeConfigFromPresetReturnsNilEnvForPresetsWithoutEnv)": Verifies nil Env handling
- "$(TestFillRuntimeDefaultsPreservesEnv)": 4 sub-tests for Env preservation
  - nil input returns default
  - preserves Env map
  - nil Env stays nil
  - empty Env stays empty
- "$(TestFillRuntimeDefaultsEnvIsCopy)": Verifies copy semantics (mutation doesn't affect original)

## Dependency Chain
This is PR 2 of 3 for the OpenCode agent preset feature:
1. #830: ShellQuote helper ← **required for proper Env value escaping**
2. **This PR**: Add Env field to RuntimeConfig
3. #829: Add OpenCode agent preset

🤖 Generated with [Claude Code](https://claude.com/claude-code)