### PR TITLE
fix: use exec env for startup command to fix WaitForCommand detection

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1264,7 +1264,11 @@ func BuildStartupCommand(envVars map[string]string, rigPath, prompt string) stri
 
 	var cmd string
 	if len(exports) > 0 {
-		cmd = "export " + strings.Join(exports, " ") + " && "
+		// Use 'exec env' instead of 'export ... &&' so the agent process
+		// replaces the shell. This allows WaitForCommand to detect the
+		// running agent via pane_current_command (which shows the direct
+		// process, not child processes).
+		cmd = "exec env " + strings.Join(exports, " ") + " "
 	}
 
 	// Add runtime command
@@ -1367,7 +1371,11 @@ func BuildStartupCommandWithAgentOverride(envVars map[string]string, rigPath, pr
 
 	var cmd string
 	if len(exports) > 0 {
-		cmd = "export " + strings.Join(exports, " ") + " && "
+		// Use 'exec env' instead of 'export ... &&' so the agent process
+		// replaces the shell. This allows WaitForCommand to detect the
+		// running agent via pane_current_command (which shows the direct
+		// process, not child processes).
+		cmd = "exec env " + strings.Join(exports, " ") + " "
 	}
 
 	if prompt != "" {


### PR DESCRIPTION
## Problem

`gt start` times out with:
```
Error: starting Deacon: waiting for deacon to start: timeout waiting for command (still running excluded command)
```

## Root Cause

When starting agents with environment variables, `BuildStartupCommand` generates:
```bash
export GT_ROLE=mayor GT_ROOT=~/gt && claude --dangerously-skip-permissions
```

This keeps **bash** as the pane command with claude/node as a child process. `WaitForCommand()` polls `pane_current_command` which returns `bash`, not `node`, causing the 60-second timeout.

The existing `IsClaudeRunning()` correctly checks child processes, but `WaitForCommand()` only looks at the direct pane command.

## Solution

Changed from:
```go
cmd = "export " + strings.Join(exports, " ") + " && "
```

To:
```go
cmd = "exec env " + strings.Join(exports, " ") + " "
```

This generates:
```bash
exec env GT_ROLE=mayor GT_ROOT=~/gt claude --dangerously-skip-permissions
```

The `exec` replaces the shell process with `env`, which then execs the agent. This makes the agent the direct pane command, detectable by `WaitForCommand()`.

## Testing

- All existing tests pass
- Verified `gt start` now succeeds on macOS
- Verified Mayor and Deacon start correctly
- Verified pane_current_command now shows `node` instead of `bash`

## Environment

- macOS Sequoia 15.2
- Gas Town v0.4.0
- tmux 3.5a
- Claude Code v2.1.14