### PR TITLE
fix(formula): sync source formula with embedded changes

### DIFF
--- a/.beads/formulas/mol-deacon-patrol.formula.toml
+++ b/.beads/formulas/mol-deacon-patrol.formula.toml
@@ -665,46 +665,71 @@ Skip dispatch - system is healthy.
 
 [[steps]]
 id = "costs-digest"
-title = "Aggregate daily costs"
+title = "Aggregate daily costs [DISABLED]"
 needs = ["session-gc"]
 description = """
-**DAILY DIGEST** - Aggregate yesterday's session cost wisps.
+**⚠️ DISABLED** - Skip this step entirely.
 
-Session costs are recorded as ephemeral wisps (not exported to JSONL) to avoid
-log-in-database pollution. This step aggregates them into a permanent daily
-"Cost Report YYYY-MM-DD" bead for audit purposes.
+Cost tracking is temporarily disabled because Claude Code does not expose
+session costs in a way that can be captured programmatically.
+
+**Why disabled:**
+- The `gt costs` command uses tmux capture-pane to find costs
+- Claude Code displays costs in the TUI status bar, not in scrollback
+- All sessions show $0.00 because capture-pane can't see TUI chrome
+- The infrastructure is sound but has no data source
+
+**What we need from Claude Code:**
+- Stop hook env var (e.g., `$CLAUDE_SESSION_COST`)
+- Or queryable file/API endpoint
+
+**Re-enable when:** Claude Code exposes cost data via API or environment.
+
+See: GH#24, gt-7awfj
+
+**Exit criteria:** Skip this step - proceed to next."""
+
+[[steps]]
+id = "patrol-digest"
+title = "Aggregate daily patrol digests"
+needs = ["costs-digest"]
+description = """
+**DAILY DIGEST** - Aggregate yesterday's patrol cycle digests.
+
+Patrol cycles (Deacon, Witness, Refinery) create ephemeral per-cycle digests
+to avoid JSONL pollution. This step aggregates them into a single permanent
+"Patrol Report YYYY-MM-DD" bead for audit purposes.
 
 **Step 1: Check if digest is needed**
 ```bash
-# Preview yesterday's costs (dry run)
-gt costs digest --yesterday --dry-run
+# Preview yesterday's patrol digests (dry run)
+gt patrol digest --yesterday --dry-run
 ```
 
-If output shows "No session cost wisps found", skip to Step 3.
+If output shows "No patrol digests found", skip to Step 3.
 
 **Step 2: Create the digest**
 ```bash
-gt costs digest --yesterday
+gt patrol digest --yesterday
 ```
 
 This:
-- Queries all session.ended wisps from yesterday
-- Creates a single "Cost Report YYYY-MM-DD" bead with aggregated data
-- Deletes the source wisps
+- Queries all ephemeral patrol digests from yesterday
+- Creates a single "Patrol Report YYYY-MM-DD" bead with aggregated data
+- Deletes the source digests
 
 **Step 3: Verify**
-The digest appears in `gt costs --week` queries.
-Daily digests preserve audit trail without per-session pollution.
+Daily patrol digests preserve audit trail without per-cycle pollution.
 
 **Timing**: Run once per morning patrol cycle. The --yesterday flag ensures
 we don't try to digest today's incomplete data.
 
-**Exit criteria:** Yesterday's costs digested (or no wisps to digest)."""
+**Exit criteria:** Yesterday's patrol digests aggregated (or none to aggregate)."""
 
 [[steps]]
 id = "log-maintenance"
 title = "Rotate logs and prune state"
-needs = ["costs-digest"]
+needs = ["patrol-digest"]
 description = """
 Maintain daemon logs and state files.
 


### PR DESCRIPTION
## Summary
Sync .beads/formulas/mol-deacon-patrol.formula.toml with changes that were only applied to internal/formula/formulas/.

## Related Issue
N/A - discovered when `go generate` kept modifying internal/formula/formulas/mol-deacon-patrol.formula.toml

## Changes
- Add disabled costs-digest step (from bd655f58)
- Add patrol-digest step (from d6a4bc22)

Two commits modified the embedded formula directly without updating the source:
- `d6a4bc22` - added patrol-digest step
- `bd655f58` - disabled cost tracking

This caused `go generate` to overwrite embedded changes on every build.

## Testing
- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed
  - `go generate ./...` no longer modifies internal/formula/formulas/
  - `go build ./...` passes

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)