### PR TITLE
fix(refinery): use role-specific runtime config for startup

### DIFF
--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -168,13 +168,16 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 	// Ensure runtime settings exist in refinery/ (not refinery/rig/) so we don't
 	// write into the source repo. Runtime walks up the tree to find settings.
 	refineryParentDir := filepath.Join(m.rig.Path, "refinery")
-	runtimeConfig := config.LoadRuntimeConfig(m.rig.Path)
+	townRoot := filepath.Dir(m.rig.Path)
+	// Use ResolveRoleAgentConfig to get role-specific runtime settings (e.g., ready_prompt_prefix)
+	// instead of LoadRuntimeConfig which only loads from rig settings.
+	// See: https://github.com/steveyegge/gastown/issues/756
+	runtimeConfig := config.ResolveRoleAgentConfig("refinery", townRoot, m.rig.Path)
 	if err := runtime.EnsureSettingsForRole(refineryParentDir, "refinery", runtimeConfig); err != nil {
 		return fmt.Errorf("ensuring runtime settings: %w", err)
 	}
 
-	// Build startup command first
-	townRoot := filepath.Dir(m.rig.Path)
+	// Build startup command
 	var command string
 	if agentOverride != "" {
 		var err error


### PR DESCRIPTION
## Summary
Fix refinery startup timeout by using role-specific runtime configuration instead of rig-only settings.

## Related Issue
Fixes #756

## Changes
- Replace `config.LoadRuntimeConfig(m.rig.Path)` with `config.ResolveRoleAgentConfig("refinery", townRoot, m.rig.Path)`
- Move `townRoot` declaration earlier so it's available for config resolution
- Add comment referencing the issue

`LoadRuntimeConfig` only loads from rig settings, ignoring role-specific agent configuration (e.g., `role_agents.refinery`). This caused `WaitForRuntimeReady` to look for the wrong `ready_prompt_prefix` when a custom agent was configured for the refinery role, resulting in timeout.

`ResolveRoleAgentConfig` properly resolves:
1. Rig's `RoleAgents[refinery]` setting
2. Town's `RoleAgents[refinery]` setting  
3. Falls back to default agent config

## Testing
- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed
  - `go build ./...` passes
  - Refinery-specific tests pass

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)