### PR TITLE
fix(refinery): use role-specific runtime config for startup

### DIFF
--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -128,13 +128,13 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 	// Ensure runtime settings exist in refinery/ (not refinery/rig/) so we don't
 	// write into the source repo. Runtime walks up the tree to find settings.
 	refineryParentDir := filepath.Join(m.rig.Path, "refinery")
-	runtimeConfig := config.LoadRuntimeConfig(m.rig.Path)
+	townRoot := filepath.Dir(m.rig.Path)
+	runtimeConfig := config.ResolveRoleAgentConfig("refinery", townRoot, m.rig.Path)
 	if err := runtime.EnsureSettingsForRole(refineryParentDir, "refinery", runtimeConfig); err != nil {
 		return fmt.Errorf("ensuring runtime settings: %w", err)
 	}
 
 	// Build startup command first
-	townRoot := filepath.Dir(m.rig.Path)
 	var command string
 	if agentOverride != "" {
 		var err error
@@ -173,6 +173,10 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 	theme := tmux.AssignTheme(m.rig.Name)
 	_ = t.ConfigureGasTownSession(sessionID, theme, m.rig.Name, "refinery", "refinery")
 
+	// Accept bypass permissions warning dialog if it appears.
+	// Must be before WaitForRuntimeReady to avoid race where dialog blocks prompt detection.
+	_ = t.AcceptBypassPermissionsWarning(sessionID)
+
 	// Wait for Claude to start and show its prompt - fatal if Claude fails to launch
 	// WaitForRuntimeReady waits for the runtime to be ready
 	if err := t.WaitForRuntimeReady(sessionID, runtimeConfig, constants.ClaudeStartTimeout); err != nil {
@@ -180,9 +184,6 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 		_ = t.KillSessionWithProcesses(sessionID)
 		return fmt.Errorf("waiting for refinery to start: %w", err)
 	}
-
-	// Accept bypass permissions warning dialog if it appears.
-	_ = t.AcceptBypassPermissionsWarning(sessionID)
 
 	// Wait for runtime to be fully ready
 	runtime.SleepForReadyDelay(runtimeConfig)


### PR DESCRIPTION
## Summary
- Use `ResolveRoleAgentConfig` instead of `LoadRuntimeConfig` to properly resolve role-specific agent settings (like `ready_prompt_prefix`) when starting the refinery
- Move `AcceptBypassPermissionsWarning` before `WaitForRuntimeReady` to avoid race condition where bypass dialog blocks prompt detection

Fixes #756

## Test plan
- [x] Build passes (`go build ./...`)
- [x] Refinery tests pass (`go test ./internal/refinery/...`)
- [x] Config tests pass (`go test ./internal/config/... -run ResolveRoleAgentConfig`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)