### PR TITLE
fix(hooks): allow feature branches in contributor workflow

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -15,17 +15,22 @@ while read local_ref local_sha remote_ref remote_sha; do
       # Allowed branches
       ;;
     *)
-      echo "ERROR: Invalid branch for Gas Town agents."
-      echo ""
-      echo "Blocked push to: $branch"
-      echo ""
-      echo "Allowed branches:"
-      echo "  main        - Crew workers push here directly"
-      echo "  polecat/*   - Polecat working branches"
-      echo "  beads-sync  - Beads synchronization"
-      echo ""
-      echo "Do NOT create PRs. Push to main or let Refinery merge polecat work."
-      exit 1
+      # Allow feature branches when contributing to upstream (fork workflow).
+      # If an 'upstream' remote exists, this is a contribution setup where
+      # feature branches are needed for PRs. See: #848
+      if ! git remote get-url upstream &>/dev/null; then
+        echo "ERROR: Invalid branch for Gas Town agents."
+        echo ""
+        echo "Blocked push to: $branch"
+        echo ""
+        echo "Allowed branches:"
+        echo "  main        - Crew workers push here directly"
+        echo "  polecat/*   - Polecat working branches"
+        echo "  beads-sync  - Beads synchronization"
+        echo ""
+        echo "Do NOT create PRs. Push to main or let Refinery merge polecat work."
+        exit 1
+      fi
       ;;
   esac
 done


### PR DESCRIPTION
## Summary

Fixes #848 - The pre-push hook now detects when an `upstream` remote is configured and allows feature branches for the contributor workflow.

## Changes

- Added upstream remote detection to `.githooks/pre-push`
- If `git remote get-url upstream` succeeds, the hook exits early (allowing any branch)
- This enables pushing PR branches to forks while maintaining the internal branch restrictions

## Test plan

- [x] Verified push works with upstream remote configured (this PR's branch push succeeded)
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.ai/code)