### PR TITLE
feat(config): add Env field to RuntimeConfig and AgentPresetInfo

### DIFF
--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -102,6 +102,21 @@ func TestRuntimeConfigFromPreset(t *testing.T) {
 	}
 }
 
+func TestRuntimeConfigFromPresetReturnsNilEnvForPresetsWithoutEnv(t *testing.T) {
+	t.Parallel()
+	// Built-in presets like Claude don't have Env set
+	// This verifies nil Env handling in RuntimeConfigFromPreset
+	rc := RuntimeConfigFromPreset(AgentClaude)
+	if rc == nil {
+		t.Fatal("RuntimeConfigFromPreset returned nil")
+	}
+
+	// Claude preset doesn't have Env, so it should be nil
+	if rc.Env != nil && len(rc.Env) > 0 {
+		t.Errorf("Expected nil/empty Env for Claude preset, got %v", rc.Env)
+	}
+}
+
 func TestIsKnownPreset(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1085,6 +1085,13 @@ func fillRuntimeDefaults(rc *RuntimeConfig) *RuntimeConfig {
 		Args:          rc.Args,
 		InitialPrompt: rc.InitialPrompt,
 	}
+	// Copy Env map to avoid mutation and preserve agent-specific env vars
+	if len(rc.Env) > 0 {
+		result.Env = make(map[string]string, len(rc.Env))
+		for k, v := range rc.Env {
+			result.Env[k] = v
+		}
+	}
 	if result.Command == "" {
 		result.Command = "claude"
 	}
@@ -1252,6 +1259,10 @@ func BuildStartupCommand(envVars map[string]string, rigPath, prompt string) stri
 	if rc.Session != nil && rc.Session.SessionIDEnv != "" {
 		resolvedEnv["GT_SESSION_ID_ENV"] = rc.Session.SessionIDEnv
 	}
+	// Merge agent-specific env vars (e.g., OPENCODE_PERMISSION for yolo mode)
+	for k, v := range rc.Env {
+		resolvedEnv[k] = v
+	}
 
 	// Build environment export prefix
 	var exports []string
@@ -1361,6 +1372,10 @@ func BuildStartupCommandWithAgentOverride(envVars map[string]string, rigPath, pr
 	// Record agent override so handoff can preserve it
 	if agentOverride != "" {
 		resolvedEnv["GT_AGENT"] = agentOverride
+	}
+	// Merge agent-specific env vars (e.g., OPENCODE_PERMISSION for yolo mode)
+	for k, v := range rc.Env {
+		resolvedEnv[k] = v
 	}
 
 	// Build environment export prefix

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -263,6 +263,11 @@ type RuntimeConfig struct {
 	// Empty array [] means no args (not "use defaults").
 	Args []string `json:"args"`
 
+	// Env are environment variables to set when starting the agent.
+	// These are merged with the standard GT_* variables.
+	// Used for agent-specific configuration like OPENCODE_PERMISSION.
+	Env map[string]string `json:"env,omitempty"`
+
 	// InitialPrompt is an optional first message to send after startup.
 	// For claude, this is passed as the prompt argument.
 	// Empty by default (hooks handle context).


### PR DESCRIPTION
Rebased version of #832 by @Avyukth onto current main (after #830 merged).

## Summary
Add `Env` field to `RuntimeConfig` and `AgentPresetInfo` structs, enabling agent presets to specify environment variables that get exported when starting sessions.

## Changes
- Add `Env` field to `RuntimeConfig` (types.go)
- Add `Env` field to `AgentPresetInfo` (agents.go)
- Update `RuntimeConfigFromPreset()` with copy semantics
- Update `fillRuntimeDefaults()` to preserve Env
- Merge `rc.Env` in `BuildStartupCommand()` functions
- Tests for Env preservation and copy semantics

Closes #832

Co-authored-by: Avyukth <subhrajit.makur@hotmail.com>