### PR TITLE
fix(dashboard): use registered rigs for merge queue instead of hardcoded repos

### DIFF
--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -10,11 +10,13 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/activity"
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
 
 // LiveConvoyFetcher fetches convoy data from beads.
 type LiveConvoyFetcher struct {
+	townRoot  string
 	townBeads string
 }
 
@@ -26,6 +28,7 @@ func NewLiveConvoyFetcher() (*LiveConvoyFetcher, error) {
 	}
 
 	return &LiveConvoyFetcher{
+		townRoot:  townRoot,
 		townBeads: filepath.Join(townRoot, ".beads"),
 	}, nil
 }
@@ -439,21 +442,25 @@ func calculateWorkStatus(completed, total int, activityColor string) string {
 	}
 }
 
-// FetchMergeQueue fetches open PRs from configured repos.
+// FetchMergeQueue fetches open PRs from registered rigs.
 func (f *LiveConvoyFetcher) FetchMergeQueue() ([]MergeQueueRow, error) {
-	// Repos to query for PRs
-	repos := []struct {
-		Full  string // Full repo path for gh CLI
-		Short string // Short name for display
-	}{
-		{"michaellady/roxas", "roxas"},
-		{"michaellady/gastown", "gastown"},
+	// Load registered rigs from config
+	rigsConfigPath := filepath.Join(f.townRoot, "mayor", "rigs.json")
+	rigsConfig, err := config.LoadRigsConfig(rigsConfigPath)
+	if err != nil {
+		return nil, fmt.Errorf("loading rigs config: %w", err)
 	}
 
 	var result []MergeQueueRow
 
-	for _, repo := range repos {
-		prs, err := f.fetchPRsForRepo(repo.Full, repo.Short)
+	for rigName, entry := range rigsConfig.Rigs {
+		// Convert git URL to owner/repo format for gh CLI
+		repoPath := gitURLToRepoPath(entry.GitURL)
+		if repoPath == "" {
+			continue
+		}
+
+		prs, err := f.fetchPRsForRepo(repoPath, rigName)
 		if err != nil {
 			// Non-fatal: continue with other repos
 			continue
@@ -462,6 +469,28 @@ func (f *LiveConvoyFetcher) FetchMergeQueue() ([]MergeQueueRow, error) {
 	}
 
 	return result, nil
+}
+
+// gitURLToRepoPath converts a git URL to owner/repo format.
+// Supports HTTPS (https://github.com/owner/repo.git) and
+// SSH (git@github.com:owner/repo.git) formats.
+func gitURLToRepoPath(gitURL string) string {
+	// Handle HTTPS format: https://github.com/owner/repo.git
+	if strings.HasPrefix(gitURL, "https://github.com/") {
+		path := strings.TrimPrefix(gitURL, "https://github.com/")
+		path = strings.TrimSuffix(path, ".git")
+		return path
+	}
+
+	// Handle SSH format: git@github.com:owner/repo.git
+	if strings.HasPrefix(gitURL, "git@github.com:") {
+		path := strings.TrimPrefix(gitURL, "git@github.com:")
+		path = strings.TrimSuffix(path, ".git")
+		return path
+	}
+
+	// Unsupported format
+	return ""
 }
 
 // prResponse represents the JSON response from gh pr list.
@@ -479,7 +508,7 @@ type prResponse struct {
 
 // fetchPRsForRepo fetches open PRs for a single repo.
 func (f *LiveConvoyFetcher) fetchPRsForRepo(repoFull, repoShort string) ([]MergeQueueRow, error) {
-	// #nosec G204 -- gh is a trusted CLI, repo is from hardcoded list
+	// #nosec G204 -- gh is a trusted CLI, repo is from registered rigs config
 	cmd := exec.Command("gh", "pr", "list",
 		"--repo", repoFull,
 		"--state", "open",


### PR DESCRIPTION
## Summary
- Fixes dashboard merge queue showing unrelated PRs (roxas/gastown hardcoded)
- Dynamically loads registered rigs from `mayor/rigs.json`
- Adds `gitURLToRepoPath` helper to convert git URLs to `owner/repo` format

## Problem
The `FetchMergeQueue` function was hardcoded to query PRs from `michaellady/roxas` and `michaellady/gastown`, causing every Gas Town installation to show the same unrelated PRs regardless of which rigs were actually registered.

## Solution
Instead of hardcoded repos, the function now:
1. Reads `mayor/rigs.json` to get registered rigs
2. Extracts GitHub `owner/repo` from each rig's `git_url` (supports both HTTPS and SSH formats)
3. Queries PRs only for the registered rigs

## Test plan
- [ ] Verify dashboard shows PRs only from registered rigs
- [ ] Test with HTTPS git URLs (`https://github.com/owner/repo.git`)
- [ ] Test with SSH git URLs (`git@github.com:owner/repo.git`)
- [ ] Verify graceful handling when no rigs are registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)