### PR TITLE
fix(dashboard): use internal merge queue instead of GitHub PRs

### DIFF
--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -28,15 +28,17 @@ type PolecatRow struct {
 	StatusHint   string        // Last line from pane (optional)
 }
 
-// MergeQueueRow represents a PR in the merge queue.
+// MergeQueueRow represents a merge request in the internal queue.
 type MergeQueueRow struct {
-	Number     int
-	Repo       string // Short repo name (e.g., "roxas", "gastown")
-	Title      string
-	URL        string
-	CIStatus   string // "pass", "fail", "pending"
-	Mergeable  string // "ready", "conflict", "pending"
-	ColorClass string // "mq-green", "mq-yellow", "mq-red"
+	ID          string // Bead ID (e.g., "gt-abc12")
+	Repo        string // Short rig name (e.g., "myrig")
+	Title       string // MR title (e.g., "Merge: gt-xyz99")
+	Branch      string // Source branch name
+	SourceIssue string // Original issue ID
+	Worker      string // Polecat that created the MR
+	Priority    int    // Priority level (0=highest)
+	Status      string // "ready", "blocked", "conflict"
+	ColorClass  string // "mq-green", "mq-yellow", "mq-red"
 }
 
 // ConvoyRow represents a single convoy in the dashboard.

--- a/internal/web/templates/convoy.html
+++ b/internal/web/templates/convoy.html
@@ -380,37 +380,31 @@
         <table class="convoy-table">
             <thead>
                 <tr>
-                    <th>PR #</th>
-                    <th>Repo</th>
-                    <th>Title</th>
-                    <th>CI Status</th>
-                    <th>Mergeable</th>
+                    <th>MR ID</th>
+                    <th>Rig</th>
+                    <th>Source Issue</th>
+                    <th>Worker</th>
+                    <th>Status</th>
                 </tr>
             </thead>
             <tbody>
                 {{range .MergeQueue}}
                 <tr class="{{.ColorClass}}">
                     <td>
-                        <a href="{{.URL}}" target="_blank" class="pr-link">#{{.Number}}</a>
+                        <span class="convoy-id">{{.ID}}</span>
                     </td>
                     <td>{{.Repo}}</td>
                     <td>
-                        <span class="pr-title">{{.Title}}</span>
+                        <span class="pr-title">{{.SourceIssue}}</span>
                     </td>
+                    <td>{{.Worker}}</td>
                     <td>
-                        {{if eq .CIStatus "pass"}}
-                        <span class="ci-status ci-pass">✓ Pass</span>
-                        {{else if eq .CIStatus "fail"}}
-                        <span class="ci-status ci-fail">✗ Fail</span>
-                        {{else}}
-                        <span class="ci-status ci-pending">⏳ Pending</span>
-                        {{end}}
-                    </td>
-                    <td>
-                        {{if eq .Mergeable "ready"}}
+                        {{if eq .Status "ready"}}
                         <span class="merge-status merge-ready">Ready</span>
-                        {{else if eq .Mergeable "conflict"}}
+                        {{else if eq .Status "conflict"}}
                         <span class="merge-status merge-conflict">Conflict</span>
+                        {{else if eq .Status "blocked"}}
+                        <span class="merge-status merge-pending">Blocked</span>
                         {{else}}
                         <span class="merge-status merge-pending">Pending</span>
                         {{end}}
@@ -421,7 +415,7 @@
         </table>
         {{else}}
         <div class="empty-state-inline">
-            <p>No PRs in queue</p>
+            <p>No MRs in queue</p>
         </div>
         {{end}}
 


### PR DESCRIPTION
## Summary
- Dashboard now displays internal merge queue (beads) instead of GitHub PRs
- Fixes "No PRs in queue" showing when internal MQ has pending merge requests
- Updates terminology from "PRs" to "MRs" throughout dashboard

## Problem
The `FetchMergeQueue` function was querying GitHub PRs via `gh pr list`, but Gas Town uses an internal merge queue based on beads (merge-request type). This caused a mismatch where the dashboard showed "No PRs in queue" / "Waiting for PRs" even when the internal MQ had 50+ pending merge requests.

## Solution
Changed `FetchMergeQueue` to query the internal merge queue using `gt mq list <rig> --json` for each registered rig. The MR bead data (ID, branch, source_issue, worker, priority) is now displayed instead of GitHub PR data.

## Changes
- `FetchMergeQueue` now uses `gt mq list <rig> --json` instead of `gh pr list`
- `MergeQueueRow` struct updated for bead-based data
- Dashboard template displays MR fields (ID, Rig, Source Issue, Worker, Status)
- Status hints updated: "Waiting for PRs" → "Waiting for MRs"
- Removed unused GitHub PR code (gitURLToRepoPath, prResponse, fetchPRsForRepo, determineCIStatus, etc.)

## Test plan
- [ ] Verify dashboard displays MRs from internal queue
- [ ] Verify MR status (ready/blocked/conflict) displays correctly
- [ ] Verify refinery status hint shows correct MR count
- [ ] Verify empty state shows "No MRs in queue"

🤖 Generated with [Claude Code](https://claude.com/claude-code)