### PR TITLE
chore: increase timeout for `bd version` check

### DIFF
--- a/internal/cmd/beads_version.go
+++ b/internal/cmd/beads_version.go
@@ -91,7 +91,7 @@ func (v beadsVersion) compare(other beadsVersion) int {
 var beadsVersionRe = regexp.MustCompile(`bd version (\d+\.\d+(?:\.\d+)?(?:-\w+)?)`)
 
 func getBeadsVersion() (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "bd", "version")


### PR DESCRIPTION
👋 seeing some Homebrew CI performance issue with `bd version` check, thus bumping timeout from 2s to 5s

- https://github.com/Homebrew/homebrew-core/pull/263964