### PR TITLE
feat: update to use core tap for gastown installation

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -164,7 +164,7 @@ release:
 
     **Homebrew (macOS/Linux):**
     ```bash
-    brew install steveyegge/gastown/gt
+    brew install gastown
     ```
 
     **npm (Node.js):**

--- a/README.md
+++ b/README.md
@@ -97,9 +97,10 @@ Git-backed issue tracking system that stores work state as structured data.
 
 ```bash
 # Install Gas Town
-go install github.com/steveyegge/gastown/cmd/gt@latest
+$ brew install gastown                                    # Homebrew
+$ go install github.com/steveyegge/gastown/cmd/gt@latest  # From source
 
-# Add Go binaries to PATH (add to ~/.zshrc or ~/.bashrc)
+# If using go install, add Go binaries to PATH (add to ~/.zshrc or ~/.bashrc)
 export PATH="$PATH:$HOME/go/bin"
 
 # Create workspace with git initialization
@@ -120,11 +121,11 @@ gt mayor attach
 ## Quick Start Guide
 
 ### Getting Started
-Run 
+Run
 ```shell
-gt install ~/gt --git && 
-cd ~/gt && 
-gt config agent list && 
+gt install ~/gt --git &&
+cd ~/gt &&
+gt config agent list &&
 gt mayor attach
 ```
 and tell the Mayor what you want to build!


### PR DESCRIPTION
feat: update to use core tap for gastown installation

- formula page, https://formulae.brew.sh/formula/gastown
- https://github.com/Homebrew/homebrew-core/pull/261248
- https://github.com/Homebrew/homebrew-core/pull/264068

similar to https://github.com/steveyegge/beads/pull/1261