### PR TITLE
fix(npm): use NPM_TOKEN for npm publish authentication

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,15 +60,15 @@ jobs:
           node-version: '22'
           registry-url: 'https://registry.npmjs.org'
 
-      - name: Update npm for OIDC trusted publishing
-        run: npm install -g npm@latest  # Requires npm >= 11.5.1 for trusted publishing
+      - name: Update npm for provenance support
+        run: npm install -g npm@latest
 
       - name: Publish to npm
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: |
           cd npm-package
-          npm publish --access public
-          # Uses OIDC trusted publishing - no token needed
-          # Provenance attestations are automatic with trusted publishing
+          npm publish --access public --provenance
 
   update-homebrew:
     runs-on: ubuntu-latest

--- a/README.md
+++ b/README.md
@@ -97,7 +97,8 @@ Git-backed issue tracking system that stores work state as structured data.
 
 ```bash
 # Install Gas Town
-$ brew install gastown                                    # Homebrew
+$ brew tap steveyegge/gastown && brew install gt         # Homebrew (recommended)
+$ npm install -g @gastown/gt                              # npm
 $ go install github.com/steveyegge/gastown/cmd/gt@latest  # From source
 
 # If using go install, add Go binaries to PATH (add to ~/.zshrc or ~/.bashrc)


### PR DESCRIPTION
## Summary
- Fixed npm publish workflow to use `NPM_TOKEN` secret instead of OIDC trusted publishing
- Added npm installation option to README

## Problem
The npm package `@gastown/gt` was never published because the release workflow used OIDC trusted publishing, which requires initial manual setup on npm.org that was never completed. Users got 404 errors when trying `npm install -g @gastown/gt`.

## Solution
Changed the workflow to use the standard `NPM_TOKEN` secret for authentication. Once the secret is configured in the repository, the next release will publish the npm package.

## Test plan
- [ ] Add `NPM_TOKEN` secret to repository settings with an npm automation token for the `@gastown` scope
- [ ] Tag a new release and verify the npm package is published
- [ ] Test `npm install -g @gastown/gt` works

Fixes #867

🤖 Generated with [Claude Code](https://claude.com/claude-code)