### PR TITLE
Revert erroneous addition of .beads to agent .gitignore template

### DIFF
--- a/internal/rig/overlay.go
+++ b/internal/rig/overlay.go
@@ -65,7 +65,6 @@ func EnsureGitignorePatterns(worktreePath string) error {
 	requiredPatterns := []string{
 		".runtime/",
 		".claude/",
-		".beads/",
 		".logs/",
 	}
 


### PR DESCRIPTION
I believe the fix applied in https://github.com/steveyegge/gastown/pull/753 to be incorrect, as it results in polecats attempting to merge a `.beads` line into `.gitignore` in all project repositories they work with. See a related commit to the gastown source here, presumptively caused by Steve's furiosa polecat after the introduction of this bug: https://github.com/steveyegge/gastown/commit/535647cefc6463ba2fb0c548bd3f6c5da9870265

```
  ⎿  commit 535647cefc6463ba2fb0c548bd3f6c5da9870265
     Author: furiosa <steve.yegge@gmail.com>
     Date:   Wed Jan 21 10:30:45 2026 -0800

         chore: ignore Gas Town working directories

         Co-Authored-By: Claude Opus 4.5 <noreply@anthropic.com>

     diff --git a/.gitignore b/.gitignore
     index 9d99ed3a..537d2b52 100644
     --- a/.gitignore
     +++ b/.gitignore
     @@ -51,3 +51,7 @@ CLAUDE.md

      # Embedded formulas are committed so `go install @latest` works
      # Run `go generate ./...` after modifying .beads/formulas/
     +
     +# Gas Town (added by gt)
     +.beads/
     +.logs/
```

## Summary

Gas town agents need to ignore working-file directories like .logs, .runtime, and .claude, but Beads provides its own .gitignore handling in `bd init`, creating a .beads/.gitignore file which ignores the relevant Beads working files while allowing .beads/issues.jsonl to be tracked correctly. PR #753 broke this, causing new polecats to attempt to merge their changed .gitignore into the project repo, ultimately breaking bd sync and causing issues to become untracked.

## Related Issue

Resolves regression introduced by https://github.com/steveyegge/gastown/pull/753

## Changes

- Remove the erroneous `.beads` line from .gitignore enforcement

## Testing
<!-- How did you test these changes? -->
- [ ] Unit tests pass (`go test ./...`)
- [x] Manual testing performed

## Checklist
- [ ] Code follows project style
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or documented in summary)
