### PR TITLE
Draft: Fix SessionManager treating witness/refinery as polecats

### DIFF
--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -343,7 +343,7 @@ func stopAllPolecats(t *tmux.Tmux, townRoot string, rigNames []string, force boo
 		}
 
 		polecatMgr := polecat.NewSessionManager(t, r)
-		infos, err := polecatMgr.List()
+		infos, err := polecatMgr.ListPolecats()
 		if err != nil {
 			continue
 		}

--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -967,7 +967,7 @@ func runRigShutdown(cmd *cobra.Command, args []string) error {
 	// 1. Stop all polecat sessions
 	t := tmux.NewTmux()
 	polecatMgr := polecat.NewSessionManager(t, r)
-	infos, err := polecatMgr.List()
+	infos, err := polecatMgr.ListPolecats()
 	if err == nil && len(infos) > 0 {
 		fmt.Printf("  Stopping %d polecat session(s)...\n", len(infos))
 		if err := polecatMgr.StopAll(rigShutdownForce); err != nil {
@@ -1230,7 +1230,7 @@ func runRigStop(cmd *cobra.Command, args []string) error {
 		// 1. Stop all polecat sessions
 		t := tmux.NewTmux()
 		polecatMgr := polecat.NewSessionManager(t, r)
-		infos, err := polecatMgr.List()
+		infos, err := polecatMgr.ListPolecats()
 		if err == nil && len(infos) > 0 {
 			fmt.Printf("  Stopping %d polecat session(s)...\n", len(infos))
 			if err := polecatMgr.StopAll(rigStopForce); err != nil {
@@ -1361,7 +1361,7 @@ func runRigRestart(cmd *cobra.Command, args []string) error {
 
 		// 1. Stop all polecat sessions
 		polecatMgr := polecat.NewSessionManager(t, r)
-		infos, err := polecatMgr.List()
+		infos, err := polecatMgr.ListPolecats()
 		if err == nil && len(infos) > 0 {
 			fmt.Printf("    Stopping %d polecat session(s)...\n", len(infos))
 			if err := polecatMgr.StopAll(rigRestartForce); err != nil {

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -364,7 +364,9 @@ func (m *SessionManager) Status(polecat string) (*SessionInfo, error) {
 	return info, nil
 }
 
-// List returns information about all polecat sessions for this rig.
+// List returns information about all sessions for this rig.
+// This includes polecats, witness, refinery, and crew sessions.
+// Use ListPolecats() to get only polecat sessions.
 func (m *SessionManager) List() ([]SessionInfo, error) {
 	sessions, err := m.tmux.ListSessions()
 	if err != nil {
@@ -389,6 +391,26 @@ func (m *SessionManager) List() ([]SessionInfo, error) {
 	}
 
 	return infos, nil
+}
+
+// ListPolecats returns information only about polecat sessions for this rig.
+// Filters out witness, refinery, and crew sessions.
+func (m *SessionManager) ListPolecats() ([]SessionInfo, error) {
+	infos, err := m.List()
+	if err != nil {
+		return nil, err
+	}
+
+	var filtered []SessionInfo
+	for _, info := range infos {
+		// Skip non-polecat sessions
+		if info.Polecat == "witness" || info.Polecat == "refinery" || strings.HasPrefix(info.Polecat, "crew-") {
+			continue
+		}
+		filtered = append(filtered, info)
+	}
+
+	return filtered, nil
 }
 
 // Attach attaches to a polecat session.
@@ -456,7 +478,7 @@ func (m *SessionManager) Inject(polecat, message string) error {
 
 // StopAll terminates all polecat sessions for this rig.
 func (m *SessionManager) StopAll(force bool) error {
-	infos, err := m.List()
+	infos, err := m.ListPolecats()
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Marking this PR as draft because I'm not sure if this is the right/even-a-good fix or if it reflects a larger incoherency/separation-of-concerns issue with SessionManager.

## Summary

The bug: SessionManager.List() returned ALL sessions matching gt-<rig>-*, including witness, refinery, and crew sessions. Commands like gt rig shutdown would try to sync beads in non-existent directories like <prefix>/polecats/refinery, causing "beads sync failed" warnings.

The fix: Add ListPolecats() method that filters out witness, refinery, and crew-* sessions. Update call sites that should only see polecats (rig shutdown/stop/restart, gt down) to use ListPolecats() instead of List().

Leave List() unchanged so gt session list continues to show all sessions.

## Testing
<!-- How did you test these changes? -->
- [ ] Unit tests pass (`go test ./...`)
- [x] Manual testing performed

## Checklist
- [ ] Code follows project style
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or documented in summary)
