### PR TITLE
fix(beads): add --type=rig to CreateRigBead

### DIFF
--- a/internal/beads/beads_rig.go
+++ b/internal/beads/beads_rig.go
@@ -82,6 +82,7 @@ func (b *Beads) CreateRigBead(id, title string, fields *RigFields) (*Issue, erro
 		"--id=" + id,
 		"--title=" + title,
 		"--description=" + description,
+		"--type=rig",
 		"--labels=gt:rig",
 	}
 	if NeedsForceForID(id) {


### PR DESCRIPTION
## Summary
- `CreateRigBead()` now passes `--type=rig` to `bd create`

## Problem
Rig identity beads were being created with `issue_type: task` instead of `issue_type: rig` because the function didn't pass `--type=rig` to `bd create`.

This caused rig beads (like `bd-rig-beads`) to show up in `bd ready` output, since the filtering in `ready.go` excludes by `issue_type NOT IN ('rig', ...)` - which doesn't catch beads that have `issue_type: task`.

## Fix
Add `"--type=rig"` to the args slice in `CreateRigBead()`.

## Test plan
- [ ] Run `gt rig add` and verify the created rig bead has `issue_type: rig`
- [ ] Verify rig beads no longer appear in `bd ready`

## Note
Existing rig beads will need to be updated manually: `bd update <id> --type=rig`

🤖 Generated with [Claude Code](https://claude.ai/code)