### PR TITLE
fix(mail): crew addresses now resolve to correct tmux session for notifications

### DIFF
--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -1004,6 +1004,7 @@ func addressToSessionID(address string) string {
 	target := parts[1]
 
 	// Polecat: gt-rig-polecat
+	// Crew: gt-rig-crew-name (crew/name → crew-name)
 	// Refinery: gt-rig-refinery (if refinery has its own session)
-	return fmt.Sprintf("gt-%s-%s", rig, target)
+	return fmt.Sprintf("gt-%s-%s", rig, strings.ReplaceAll(target, "/", "-"))
 }

--- a/internal/mail/router_test.go
+++ b/internal/mail/router_test.go
@@ -97,6 +97,9 @@ func TestAddressToSessionID(t *testing.T) {
 		{"gastown/refinery", "gt-gastown-refinery"},
 		{"gastown/Toast", "gt-gastown-Toast"},
 		{"beads/witness", "gt-beads-witness"},
+		{"gastown/crew/max", "gt-gastown-crew-max"},         // Crew address
+		{"beads/crew/wolf", "gt-beads-crew-wolf"},           // Crew with different rig
+		{"gastown/polecats/jade", "gt-gastown-polecats-jade"}, // Polecats long form
 		{"gastown/", ""},   // Empty target
 		{"gastown", ""},    // No slash
 		{"", ""},           // Empty address


### PR DESCRIPTION
## Summary
- Fix `addressToSessionID()` to handle nested address formats like `rig/crew/name`
- Previously only split on first `/`, leaving subsequent slashes intact
- Resulted in invalid session IDs like `gt-rig-crew/name` instead of `gt-rig-crew-name`
- Caused mail notifications to silently fail for crew members

## Test plan
- [x] Added test cases for crew and polecats long-form addresses
- [x] All existing mail tests pass
- [x] Manually verified crew-to-crew notifications now work

🤖 Generated with [Claude Code](https://claude.ai/code)