### PR TITLE
fix: Updated setup brew command to use correct formula

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ Git-backed issue tracking system that stores work state as structured data.
 
 ```bash
 # Install Gas Town
-$ brew tap steveyegge/gastown && brew install gt         # Homebrew (recommended)
+$ brew install gastown                                    # Homebrew (recommended)
 $ npm install -g @gastown/gt                              # npm
 $ go install github.com/steveyegge/gastown/cmd/gt@latest  # From source
 


### PR DESCRIPTION
## Summary
The setup instructions refer to a Homebrew tap which no longer exists, `steveyegge/gastown`. The tap points to a repo that no longer exists or is private ([link](https://github.com/steveyegge/homebrew-gastown)):

```bash
==> Tapping steveyegge/gastown
Cloning into '/opt/homebrew/Library/Taps/steveyegge/homebrew-gastown'...
remote: Repository not found.
fatal: repository 'https://github.com/steveyegge/homebrew-gastown/' not found
```

I assume this has been deprecated in favor of the much simpler `brew install gastown`, whose formula is pinned to latest release: [`gastown` Homebrew formula](https://formulae.brew.sh/formula/gastown).

## Changes
- Updated setup command to `brew install gastown`.

## Testing
- Manual tests performed (first install of gastown/gt)
- Verified that the prior Homebrew release pipeline is dead trees (see `update-homebrew` job in `.github/workflows/release.yml`)
