### PR TITLE
feat(theme): add dark mode CLI theme support

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -39,6 +39,12 @@ type TownSettings struct {
 	Type    string `json:"type"`    // "town-settings"
 	Version int    `json:"version"` // schema version
 
+	// CLITheme controls CLI output color scheme.
+	// Values: "dark", "light", "auto" (default).
+	// "auto" lets the terminal emulator's background color guide the choice.
+	// Can be overridden by GT_THEME environment variable.
+	CLITheme string `json:"cli_theme,omitempty"`
+
 	// DefaultAgent is the name of the agent preset to use by default.
 	// Can be a built-in preset ("claude", "gemini", "codex", "cursor", "auggie", "amp")
 	// or a custom agent name defined in settings/agents.json.

--- a/internal/ui/styles.go
+++ b/internal/ui/styles.go
@@ -22,6 +22,16 @@ func init() {
 	}
 }
 
+// ApplyThemeMode applies the theme mode settings to lipgloss.
+// This should be called after InitTheme() has been called.
+func ApplyThemeMode() {
+	if !ShouldUseColor() {
+		return
+	}
+	// Set lipgloss dark background flag based on theme mode
+	lipgloss.SetHasDarkBackground(HasDarkBackground())
+}
+
 // Ayu theme color palette
 // Dark: https://terminalcolors.com/themes/ayu/dark/
 // Light: https://terminalcolors.com/themes/ayu/light/

--- a/internal/ui/terminal_test.go
+++ b/internal/ui/terminal_test.go
@@ -245,3 +245,90 @@ func TestIsAgentMode_CLAUDE_CODE_AnyValue(t *testing.T) {
 		t.Error("IsAgentMode() should return true when CLAUDE_CODE is set to any value")
 	}
 }
+
+func TestInitTheme_EnvOverridesConfig(t *testing.T) {
+	oldGTTheme := os.Getenv("GT_THEME")
+	defer func() {
+		if oldGTTheme != "" {
+			os.Setenv("GT_THEME", oldGTTheme)
+		} else {
+			os.Unsetenv("GT_THEME")
+		}
+	}()
+
+	// Test: env var overrides config
+	os.Setenv("GT_THEME", "dark")
+	InitTheme("light") // config says light
+	if GetThemeMode() != ThemeModeDark {
+		t.Errorf("Expected dark mode from env var, got %s", GetThemeMode())
+	}
+
+	os.Setenv("GT_THEME", "light")
+	InitTheme("dark") // config says dark
+	if GetThemeMode() != ThemeModeLight {
+		t.Errorf("Expected light mode from env var, got %s", GetThemeMode())
+	}
+}
+
+func TestInitTheme_ConfigUsedWhenNoEnv(t *testing.T) {
+	oldGTTheme := os.Getenv("GT_THEME")
+	defer func() {
+		if oldGTTheme != "" {
+			os.Setenv("GT_THEME", oldGTTheme)
+		} else {
+			os.Unsetenv("GT_THEME")
+		}
+	}()
+
+	os.Unsetenv("GT_THEME")
+
+	InitTheme("dark")
+	if GetThemeMode() != ThemeModeDark {
+		t.Errorf("Expected dark mode from config, got %s", GetThemeMode())
+	}
+
+	InitTheme("light")
+	if GetThemeMode() != ThemeModeLight {
+		t.Errorf("Expected light mode from config, got %s", GetThemeMode())
+	}
+}
+
+func TestInitTheme_DefaultsToAuto(t *testing.T) {
+	oldGTTheme := os.Getenv("GT_THEME")
+	defer func() {
+		if oldGTTheme != "" {
+			os.Setenv("GT_THEME", oldGTTheme)
+		} else {
+			os.Unsetenv("GT_THEME")
+		}
+	}()
+
+	os.Unsetenv("GT_THEME")
+	InitTheme("") // no config
+	if GetThemeMode() != ThemeModeAuto {
+		t.Errorf("Expected auto mode as default, got %s", GetThemeMode())
+	}
+}
+
+func TestHasDarkBackground_ForcedModes(t *testing.T) {
+	oldGTTheme := os.Getenv("GT_THEME")
+	defer func() {
+		if oldGTTheme != "" {
+			os.Setenv("GT_THEME", oldGTTheme)
+		} else {
+			os.Unsetenv("GT_THEME")
+		}
+	}()
+
+	os.Setenv("GT_THEME", "dark")
+	InitTheme("")
+	if !HasDarkBackground() {
+		t.Error("Expected HasDarkBackground() to return true when mode is dark")
+	}
+
+	os.Setenv("GT_THEME", "light")
+	InitTheme("")
+	if HasDarkBackground() {
+		t.Error("Expected HasDarkBackground() to return false when mode is light")
+	}
+}


### PR DESCRIPTION
## Summary
- Add dark mode theme support for the CLI

## Bead
gt-lnz (Add dark mode theme support)

🤖 Generated with [Claude Code](https://claude.com/claude-code)