### PR TITLE
Detect and clean stale POLECAT_DONE messages

### DIFF
--- a/internal/cmd/mail.go
+++ b/internal/cmd/mail.go
@@ -42,6 +42,10 @@ var (
 
 	// Clear flags
 	mailClearAll bool
+
+	// Archive flags
+	mailArchiveStale  bool
+	mailArchiveDryRun bool
 )
 
 var mailCmd = &cobra.Command{
@@ -196,16 +200,22 @@ Examples:
 }
 
 var mailArchiveCmd = &cobra.Command{
-	Use:   "archive <message-id> [message-id...]",
+	Use:   "archive [message-id...]",
 	Short: "Archive messages",
 	Long: `Archive one or more messages.
 
 Removes the messages from your inbox by closing them in beads.
 
+Use --stale to archive messages sent before your current session started.
+
 Examples:
-  gt mail archive hq-abc123
-  gt mail archive hq-abc123 hq-def456 hq-ghi789`,
-	Args: cobra.MinimumNArgs(1),
+	gt mail archive hq-abc123
+	gt mail archive hq-abc123 hq-def456 hq-ghi789
+	gt mail archive --stale
+	gt mail archive --stale --dry-run`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		return nil
+	},
 	RunE: runMailArchive,
 }
 
@@ -486,6 +496,10 @@ func init() {
 
 	// Clear flags
 	mailClearCmd.Flags().BoolVar(&mailClearAll, "all", false, "Clear all messages (default behavior)")
+
+	// Archive flags
+	mailArchiveCmd.Flags().BoolVar(&mailArchiveStale, "stale", false, "Archive messages sent before session start")
+	mailArchiveCmd.Flags().BoolVarP(&mailArchiveDryRun, "dry-run", "n", false, "Show what would be archived without archiving")
 
 	// Add subcommands
 	mailCmd.AddCommand(mailSendCmd)

--- a/internal/cmd/mail_archive_test.go
+++ b/internal/cmd/mail_archive_test.go
@@ -1,0 +1,25 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/mail"
+)
+
+func TestStaleMessagesForSession(t *testing.T) {
+	sessionStart := time.Date(2026, 1, 24, 2, 0, 0, 0, time.UTC)
+	messages := []*mail.Message{
+		{ID: "msg-1", Subject: "Older", Timestamp: sessionStart.Add(-2 * time.Minute)},
+		{ID: "msg-2", Subject: "Newer", Timestamp: sessionStart.Add(2 * time.Minute)},
+		{ID: "msg-3", Subject: "Equal", Timestamp: sessionStart},
+	}
+
+	stale := staleMessagesForSession(messages, sessionStart)
+	if len(stale) != 1 {
+		t.Fatalf("expected 1 stale message, got %d", len(stale))
+	}
+	if stale[0].Message.ID != "msg-1" {
+		t.Fatalf("expected msg-1 stale, got %s", stale[0].Message.ID)
+	}
+}

--- a/internal/session/identity_test.go
+++ b/internal/session/identity_test.go
@@ -250,3 +250,71 @@ func TestParseSessionName_RoundTrip(t *testing.T) {
 		})
 	}
 }
+
+func TestParseAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		address string
+		want    AgentIdentity
+		wantErr bool
+	}{
+		{
+			name:    "mayor",
+			address: "mayor/",
+			want:    AgentIdentity{Role: RoleMayor},
+		},
+		{
+			name:    "deacon",
+			address: "deacon",
+			want:    AgentIdentity{Role: RoleDeacon},
+		},
+		{
+			name:    "witness",
+			address: "gastown/witness",
+			want:    AgentIdentity{Role: RoleWitness, Rig: "gastown"},
+		},
+		{
+			name:    "refinery",
+			address: "rig-a/refinery",
+			want:    AgentIdentity{Role: RoleRefinery, Rig: "rig-a"},
+		},
+		{
+			name:    "crew",
+			address: "gastown/crew/max",
+			want:    AgentIdentity{Role: RoleCrew, Rig: "gastown", Name: "max"},
+		},
+		{
+			name:    "polecat explicit",
+			address: "gastown/polecats/nux",
+			want:    AgentIdentity{Role: RolePolecat, Rig: "gastown", Name: "nux"},
+		},
+		{
+			name:    "polecat canonical",
+			address: "gastown/nux",
+			want:    AgentIdentity{Role: RolePolecat, Rig: "gastown", Name: "nux"},
+		},
+		{
+			name:    "invalid",
+			address: "gastown/crew",
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := ParseAddress(tt.address)
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("expected error")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ParseAddress(%q) error = %v", tt.address, err)
+			}
+			if *got != tt.want {
+				t.Fatalf("ParseAddress(%q) = %#v, want %#v", tt.address, *got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/session/stale.go
+++ b/internal/session/stale.go
@@ -1,0 +1,46 @@
+package session
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// SessionCreatedAt returns the time a tmux session was created.
+func SessionCreatedAt(sessionName string) (time.Time, error) {
+	t := tmux.NewTmux()
+	info, err := t.GetSessionInfo(sessionName)
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	return ParseTmuxSessionCreated(info.Created)
+}
+
+// ParseTmuxSessionCreated parses the tmux session created timestamp.
+func ParseTmuxSessionCreated(created string) (time.Time, error) {
+	created = strings.TrimSpace(created)
+	if created == "" {
+		return time.Time{}, fmt.Errorf("empty session created time")
+	}
+	return time.ParseInLocation("2006-01-02 15:04:05", created, time.Local)
+}
+
+// StaleReasonForTimes compares message time to session creation and returns staleness info.
+func StaleReasonForTimes(messageTime, sessionCreated time.Time) (bool, string) {
+	if messageTime.IsZero() || sessionCreated.IsZero() {
+		return false, ""
+	}
+
+	if messageTime.Before(sessionCreated) {
+		reason := fmt.Sprintf("message=%s session_started=%s",
+			messageTime.Format(time.RFC3339),
+			sessionCreated.Format(time.RFC3339),
+		)
+		return true, reason
+	}
+
+	return false, ""
+}

--- a/internal/session/stale_test.go
+++ b/internal/session/stale_test.go
@@ -1,4 +1,4 @@
-package witness
+package session
 
 import (
 	"strings"
@@ -13,9 +13,9 @@ func TestParseTmuxSessionCreated(t *testing.T) {
 		t.Fatalf("parse expected: %v", err)
 	}
 
-	parsed, err := parseTmuxSessionCreated(input)
+	parsed, err := ParseTmuxSessionCreated(input)
 	if err != nil {
-		t.Fatalf("parseTmuxSessionCreated: %v", err)
+		t.Fatalf("ParseTmuxSessionCreated: %v", err)
 	}
 	if !parsed.Equal(expected) {
 		t.Fatalf("parsed time mismatch: got %v want %v", parsed, expected)
@@ -28,7 +28,7 @@ func TestStaleReasonForTimes(t *testing.T) {
 	older := now.Add(-2 * time.Minute)
 
 	t.Run("message before session", func(t *testing.T) {
-		stale, reason := staleReasonForTimes(older, newer)
+		stale, reason := StaleReasonForTimes(older, newer)
 		if !stale {
 			t.Fatalf("expected stale")
 		}
@@ -38,21 +38,21 @@ func TestStaleReasonForTimes(t *testing.T) {
 	})
 
 	t.Run("message after session", func(t *testing.T) {
-		stale, reason := staleReasonForTimes(newer, older)
+		stale, reason := StaleReasonForTimes(newer, older)
 		if stale || reason != "" {
 			t.Fatalf("expected not stale, got %v %q", stale, reason)
 		}
 	})
 
 	t.Run("zero message time", func(t *testing.T) {
-		stale, reason := staleReasonForTimes(time.Time{}, now)
+		stale, reason := StaleReasonForTimes(time.Time{}, now)
 		if stale || reason != "" {
 			t.Fatalf("expected not stale for zero message time, got %v %q", stale, reason)
 		}
 	})
 
 	t.Run("zero session time", func(t *testing.T) {
-		stale, reason := staleReasonForTimes(now, time.Time{})
+		stale, reason := StaleReasonForTimes(now, time.Time{})
 		if stale || reason != "" {
 			t.Fatalf("expected not stale for zero session time, got %v %q", stale, reason)
 		}


### PR DESCRIPTION
## Summary

Add timestamp validation to prevent Witness from nuking newly spawned polecat sessions when processing stale POLECAT_DONE messages from previous sessions.

Also adds `gt mail archive --stale` command to clean up stale messages in patrol cycles.

Fixes #909

## Changes

### Stale POLECAT_DONE Detection (Witness)
- Add `isStalePolecatDone()` to compare message timestamp vs tmux session created time
- If message timestamp < session created time → message is stale → ignore
- Refactor stale detection helpers to `internal/session/stale.go` for reuse

### Stale Mail Archival (New)
- Add `--stale` flag to `gt mail archive` command
- Add `--dry-run` flag to preview what would be archived
- Add `ParseAddress()` to parse mail addresses into AgentIdentity
- Add `SessionCreatedAt()` to get tmux session start time

## How it works

### Witness stale detection
1. When POLECAT_DONE message arrives, get tmux session creation time via `GetSessionInfo()`
2. Compare with `msg.Timestamp` from the message
3. If message predates current session → stale → safely ignore

### Mail archive --stale
1. Get current session start time
2. List all inbox messages
3. Archive messages with timestamp before session start

## Usage

```bash
# Archive stale messages before processing inbox
gt mail archive --stale

# Preview what would be archived
gt mail archive --stale --dry-run
```

## Testing

```bash
go test ./internal/session/...
go test ./internal/witness/...
go test ./internal/cmd/...
```

## Files Changed
- `internal/session/stale.go` - Stale detection helpers (new)
- `internal/session/stale_test.go` - Tests for stale detection
- `internal/session/identity.go` - Add ParseAddress, SessionName
- `internal/cmd/mail.go` - Add --stale, --dry-run flags
- `internal/cmd/mail_inbox.go` - Implement stale archival logic
- `internal/witness/handlers.go` - Use session package for stale detection