### PR TITLE
fix: remove conflicting required+default in mol-session-gc formula

### DIFF
--- a/.beads/formulas/mol-session-gc.formula.toml
+++ b/.beads/formulas/mol-session-gc.formula.toml
@@ -246,5 +246,4 @@ Dog returns to available state in the pool.
 [vars]
 [vars.mode]
 description = "GC mode: 'conservative' or 'aggressive'"
-required = true
 default = "conservative"

--- a/internal/formula/formulas/mol-session-gc.formula.toml
+++ b/internal/formula/formulas/mol-session-gc.formula.toml
@@ -246,5 +246,4 @@ Dog returns to available state in the pool.
 [vars]
 [vars.mode]
 description = "GC mode: 'conservative' or 'aggressive'"
-required = true
 default = "conservative"


### PR DESCRIPTION
## Summary

`vars.mode` in `mol-session-gc.formula.toml` has both `required=true` and `default="conservative"`, which causes formula validation to fail:

```
vars.mode: cannot have both required:true and default
```

This prevents `gt doctor` from dispatching cleanup work to dogs.

## Fix

Remove `required=true` since the default value ensures the variable is always populated.

## Before
```toml
[vars.mode]
description = "GC mode: 'conservative' or 'aggressive'"
required = true
default = "conservative"
```

## After
```toml
[vars.mode]
description = "GC mode: 'conservative' or 'aggressive'"
default = "conservative"
```

## Testing

After this fix, `gt doctor` no longer reports the formula validation error and can successfully dispatch mol-session-gc work.