### PR TITLE
Update .gitignore

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -10,6 +10,7 @@ daemon.lock
 daemon.log
 daemon.pid
 bd.sock
+bd.sock.startlock
 sync-state.json
 last-touched
 


### PR DESCRIPTION
bd.sock.startlock which captures pid appears and disappears frequently.

## Summary
Add bd.sock.startlock in .gitignore

## Related Issue
N/A

## Changes
<!-- Bullet list of changes -->

-Adding `bd.sock.startlock` to `.gitignore` in `.beads/` folder


## Testing
<!-- How did you test these changes? -->
Manual Testing

## Checklist
- [ x] Code follows project style
- [ x] Documentation updated (if applicable)
- [ x] No breaking changes (or documented in summary)
