### PR TITLE
fix(settings): set editorMode to normal for Claude sessions

### DIFF
--- a/internal/claude/config/settings-autonomous.json
+++ b/internal/claude/config/settings-autonomous.json
@@ -1,4 +1,5 @@
 {
+  "editorMode": "normal",
   "enabledPlugins": {
     "beads@beads-marketplace": false
   },

--- a/internal/claude/config/settings-interactive.json
+++ b/internal/claude/config/settings-interactive.json
@@ -1,4 +1,5 @@
 {
+  "editorMode": "normal",
   "enabledPlugins": {
     "beads@beads-marketplace": false
   },


### PR DESCRIPTION
This ensures Claude Code starts in normal editor mode rather than potentially using vim mode, which can cause issues with automated text input via tmux send-keys.

## Changes
- Added editorMode: normal to settings-autonomous.json
- Added editorMode: normal to settings-interactive.json

## Test plan
- [x] Rebuilt gt binary with changes
- [x] Booted selkie rig polecats
- [x] Verified witness/.claude/settings.json contains editorMode: normal