### PR TITLE
feat(polecat): add explicit lint/test step to decommission checklist

### DIFF
--- a/templates/polecat-CLAUDE.md
+++ b/templates/polecat-CLAUDE.md
@@ -181,14 +181,23 @@ Question: <what you need>"
 
 ## Completion Protocol (MANDATORY)
 
-When your work is done, follow this EXACT checklist - **step 4 is REQUIRED**:
+When your work is done, follow this EXACT checklist - **step 5 is REQUIRED**:
+
+⚠️ **DO NOT commit if lint or tests fail. Fix issues first.**
 
 ```
-[ ] 1. Tests pass:        go test ./...
-[ ] 2. Commit changes:    git add <files> && git commit -m "msg (issue-id)"
-[ ] 3. Sync beads:        bd sync
-[ ] 4. Self-clean:        gt done   ← MANDATORY FINAL STEP
+[ ] 1. Run quality gates (ALL must pass before committing):
+       - For npm projects:   npm run lint && npm run format && npm test
+       - For Go projects:    go test ./... && go vet ./...
+[ ] 2. Stage changes:     git add <files>
+[ ] 3. Commit changes:    git commit -m "msg (issue-id)"
+[ ] 4. Sync beads:        bd sync
+[ ] 5. Self-clean:        gt done   ← MANDATORY FINAL STEP
 ```
+
+**Quality gates are not optional.** Git worktrees may not trigger pre-commit hooks
+reliably, so you MUST run lint/format/tests manually before every commit. CI will
+catch failures, but by then you've wasted the merge queue's time.
 
 ⚠️ **CRITICAL: You MUST run `gt done` after completing work. This is not optional.**
 


### PR DESCRIPTION
## Summary

- Add explicit quality gates (lint, format, tests) as step 1 before committing in the polecat completion checklist
- Support both npm and Go project types
- Add explicit warning: "DO NOT commit if lint or tests fail"
- Explain why manual checks are needed (git worktrees may not reliably trigger pre-commit hooks)

## Problem

Polecats are pushing code with lint errors that only get caught by CI after the push (e.g., PR #1143 failed with "'OPERATOR_GATEWAY' is defined but never used").

The current checklist jumps from `git add` directly to `git commit` without verification, and git worktrees may not properly trigger husky hooks.

## Test plan

- [ ] Review the updated polecat-CLAUDE.md template
- [ ] Verify the checklist now includes explicit quality gate step before committing
- [ ] Confirm instructions are clear about not committing if lint/tests fail

Generated with [Claude Code](https://claude.com/claude-code)