### PR TITLE
fix(mail): filter by read status in ListUnread for beads mode

### DIFF
--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -281,22 +281,19 @@ func (m *Mailbox) listLegacy() ([]*Message, error) {
 }
 
 // ListUnread returns unread (open) messages.
+// Filters out messages marked as read (via "read" label in beads mode).
 func (m *Mailbox) ListUnread() ([]*Message, error) {
-	if m.legacy {
-		all, err := m.List()
-		if err != nil {
-			return nil, err
-		}
-		var unread []*Message
-		for _, msg := range all {
-			if !msg.Read {
-				unread = append(unread, msg)
-			}
-		}
-		return unread, nil
+	all, err := m.List()
+	if err != nil {
+		return nil, err
 	}
-	// For beads, inbox only returns open (unread) messages
-	return m.List()
+	var unread []*Message
+	for _, msg := range all {
+		if !msg.Read {
+			unread = append(unread, msg)
+		}
+	}
+	return unread, nil
 }
 
 // Get returns a message by ID.


### PR DESCRIPTION
## Summary

`ListUnread()` was returning all open messages in beads mode instead of
filtering out messages marked as read. This caused `gt mail inbox --unread`
to show all messages even when they had the "read" label.

The fix unifies the code path for legacy and beads modes - both now
filter by the `msg.Read` field, which is correctly populated from the
"read" label via `ToMessage()`.

## Testing

- `gt mail inbox --unread` now correctly returns empty when all messages are read
- All existing mail package tests pass

## Notes

`gt mail read` intentionally does NOT mark messages as read (to preserve
handoff messages for reference). This is documented behavior. Users should
use `gt mail mark-read` to explicitly mark messages as read.

Fixes gt-izcp85

---
🤖 Generated with [Claude Code](https://claude.ai/code)