### PR TITLE
fix(costs): read token usage from Claude Code transcripts instead of tmux

### DIFF
--- a/internal/cmd/costs.go
+++ b/internal/cmd/costs.go
@@ -338,8 +338,15 @@ func runCostsFromLedger() error {
 		// Also include today's wisps (not yet digested)
 		todayEntries, _ := querySessionCostEntries(now)
 		entries = append(entries, todayEntries...)
+	} else if costsByRole || costsByRig {
+		// When using --by-role or --by-rig without time filter, default to today
+		// (querying all historical events would be expensive and likely empty)
+		entries, err = querySessionCostEntries(now)
+		if err != nil {
+			return fmt.Errorf("querying session cost entries: %w", err)
+		}
 	} else {
-		// No time filter: query both digests and legacy session.ended events
+		// No time filter and no breakdown flags: query both digests and legacy session.ended events
 		// (for backwards compatibility during migration)
 		entries = querySessionEvents()
 	}


### PR DESCRIPTION
## Summary

Enables `gt costs` by reading token usage directly from Claude Code transcript files instead of screen-scraping tmux panes.

**Key changes:**
- Add transcript parsing types (`TranscriptMessage`, `TranscriptUsage`)
- Add model pricing table (Opus 4.5, Sonnet 4, Haiku 3.5)
- Replace `extractCost()` with `extractCostFromWorkDir()` that reads `~/.claude/projects/*/session.jsonl`
- Remove the "DISABLED" warning from command help

**Fixes:** #24

## Test plan

- [x] Run `gt costs` with active Claude sessions - should show token counts and USD costs
- [x] Verify costs update as sessions continue
- [x] Test with different models (Opus, Sonnet, Haiku)
- [x] Verify `gt costs --by-role` and `--by-rig` breakdowns work

🤖 Generated with [Claude Code](https://claude.ai/code)