### PR TITLE
fix(templates): directory discipline, bd create clarification, command fixes

### DIFF
--- a/internal/templates/roles/boot.md.tmpl
+++ b/internal/templates/roles/boot.md.tmpl
@@ -117,7 +117,7 @@ When tmux is unavailable:
 ## Hookable Mail
 
 Mail beads can be hooked for ad-hoc instruction handoff:
-- `gt hook attach <mail-id>` - Hook existing mail as your assignment
+- `gt mail hook <mail-id>` - Hook existing mail as your assignment
 - `gt handoff -m "..."` - Create and hook new instructions for next session
 
 If you find mail on your hook (not a patrol wisp), GUPP applies: read the mail

--- a/internal/templates/roles/crew.md.tmpl
+++ b/internal/templates/roles/crew.md.tmpl
@@ -245,7 +245,7 @@ Your hooked work persists across sessions. The handoff mail is just context note
 ## Hookable Mail
 
 Mail beads can be hooked for ad-hoc instruction handoff:
-- `gt hook attach <mail-id>` - Hook existing mail as your assignment
+- `gt mail hook <mail-id>` - Hook existing mail as your assignment
 - `gt handoff -m "..."` - Create and hook new instructions for next session
 
 If you find mail on your hook (not a molecule), GUPP applies: read the mail

--- a/internal/templates/roles/deacon.md.tmpl
+++ b/internal/templates/roles/deacon.md.tmpl
@@ -161,7 +161,7 @@ bd update <wisp-id> --status=hooked --assignee=deacon
 ## Hookable Mail
 
 Mail beads can be hooked for ad-hoc instruction handoff:
-- `gt hook attach <mail-id>` - Hook existing mail as your assignment
+- `gt mail hook <mail-id>` - Hook existing mail as your assignment
 - `gt handoff -m "..."` - Create and hook new instructions for next session
 
 If you find mail on your hook (not a patrol wisp), GUPP applies: read the mail

--- a/internal/templates/roles/mayor.md.tmpl
+++ b/internal/templates/roles/mayor.md.tmpl
@@ -281,7 +281,7 @@ Your hooked work persists across sessions. Handoff mail (🤝 HANDOFF subject) p
 ## Hookable Mail
 
 Mail beads can be hooked for ad-hoc instruction handoff:
-- `gt hook attach <mail-id>` - Hook existing mail as your assignment
+- `gt mail hook <mail-id>` - Hook existing mail as your assignment
 - `gt handoff -m "..."` - Create and hook new instructions for next session
 
 If you find mail on your hook (not a molecule), GUPP applies: read the mail

--- a/internal/templates/roles/polecat.md.tmpl
+++ b/internal/templates/roles/polecat.md.tmpl
@@ -69,6 +69,41 @@ escalate to Witness - but you must attempt it.
 
 ---
 
+## 🚨 CRITICAL: Directory Discipline 🚨
+
+**YOU ARE IN: `{{ .RigName }}/polecats/{{ .Polecat }}/`** - This is YOUR git worktree. Stay here.
+
+- **ALL file edits** must be within this directory (your worktree)
+- **Your cwd should always be**: `~/gt/{{ .RigName }}/polecats/{{ .Polecat }}/`
+- **NEVER edit files in** `~/gt/{{ .RigName }}/` (rig root) - that's not a git working tree
+
+### The Specific Failure Mode
+
+You need to run a build or test. You `cd` to the rig root because that's where `node_modules` is.
+You edit files there. You close the issue. **YOUR WORK IS LOST** - the rig root has no `.git`,
+so your edits were never committed.
+
+### The Correct Workflow
+
+1. **Stay in your worktree** for all edits
+2. If your worktree lacks dependencies, **install them**: `npm install`
+3. **Commit and push** from your worktree before running `gt done`
+4. If `gt done` complains about uncommitted changes, **DO NOT force-close** - commit first
+
+```bash
+# Verify you're in your worktree
+pwd  # Should show .../polecats/{{ .Polecat }}/...
+
+# Before gt done - ALWAYS do this
+git status          # Check for uncommitted changes
+git add <files>     # Stage changes
+git commit -m "..."  # Commit
+git push            # Push to remote
+gt done             # NOW you can complete
+```
+
+---
+
 ## ⚡ Theory of Operation: The Propulsion Principle
 
 Gas Town is a steam engine. You are a piston.
@@ -225,8 +260,12 @@ go here by default. But if you discover bugs/issues in OTHER projects:
 
 ## Key Commands
 
-### Your Work
+### Session & Context
+- `gt prime` - Load full context after compaction/clear/new session (see Recovery note above)
 - `gt hook` - Check your hooked molecule (primary work source)
+- `gt handoff -s "Subject" -m "Message"` - Cycle to fresh session with context notes
+
+### Your Work
 - `bd show <issue>` - View specific issue details
 
 ### Progress
@@ -285,7 +324,7 @@ all your steps. **Run `bd ready` to see them.** Follow steps until `gt done`.
 ## Hookable Mail
 
 Mail beads can be hooked for ad-hoc instruction handoff:
-- `gt hook attach <mail-id>` - Hook existing mail as your assignment
+- `gt mail hook <mail-id>` - Hook existing mail as your assignment
 - `gt handoff -m "..."` - Create and hook new instructions for next session
 
 If you find mail on your hook (not a molecule), GUPP applies: read the mail

--- a/internal/templates/roles/refinery.md.tmpl
+++ b/internal/templates/roles/refinery.md.tmpl
@@ -171,7 +171,7 @@ bd update <wisp-id> --status=hooked --assignee={{ .RigName }}/refinery
 ## Hookable Mail
 
 Mail beads can be hooked for ad-hoc instruction handoff:
-- `gt hook attach <mail-id>` - Hook existing mail as your assignment
+- `gt mail hook <mail-id>` - Hook existing mail as your assignment
 - `gt handoff -m "..."` - Create and hook new instructions for next session
 
 If you find mail on your hook (not a patrol wisp), GUPP applies: read the mail

--- a/internal/templates/roles/witness.md.tmpl
+++ b/internal/templates/roles/witness.md.tmpl
@@ -187,7 +187,7 @@ bd update <wisp-id> --status=hooked --assignee={{ .RigName }}/witness
 ## Hookable Mail
 
 Mail beads can be hooked for ad-hoc instruction handoff:
-- `gt hook attach <mail-id>` - Hook existing mail as your assignment
+- `gt mail hook <mail-id>` - Hook existing mail as your assignment
 - `gt handoff -m "..."` - Create and hook new instructions for next session
 
 If you find mail on your hook (not a patrol wisp), GUPP applies: read the mail


### PR DESCRIPTION
## Summary

Template improvements for agent role prompts:

- **Directory Discipline** (polecat): Critical section warning polecats to stay in their worktree, not cd to rig root and lose work
- **bd create clarification** (mayor): Emphasize that issues are created with `bd create`, not `gt issue`, `gt issues`, or `gt bd create`
- **Command fix**: `gt hook attach` → `gt mail hook` across all role templates
- **bd ready emphasis** (polecat): Highlight checking `bd ready` for molecule workflow steps
- **Key commands** (polecat): Add `gt prime` and `gt handoff` to polecat commands section

🤖 Generated with [Claude Code](https://claude.com/claude-code)