### PR TITLE
fix: use gt handoff flags for mail

### DIFF
--- a/internal/templates/commands/handoff.md
+++ b/internal/templates/commands/handoff.md
@@ -1,6 +1,6 @@
 ---
 description: Hand off to fresh session, work continues from hook
-allowed-tools: Bash(gt mail send:*),Bash(gt handoff:*)
+allowed-tools: Bash(gt handoff:*)
 argument-hint: [message]
 ---
 
@@ -10,11 +10,10 @@ User's handoff message (if any): $ARGUMENTS
 
 Execute these steps in order:
 
-1. If user provided a message, send handoff mail to yourself first.
-   Construct your mail address from your identity (e.g., gastown/crew/max for crew, mayor/ for mayor).
-   Example: `gt mail send gastown/crew/max -s "HANDOFF: Session cycling" -m "USER_MESSAGE_HERE"`
+1. If user provided a message, run the handoff command with a subject and message.
+   Example: `gt handoff -s "HANDOFF: Session cycling" -m "USER_MESSAGE_HERE"`
 
-2. Run the handoff command (this will respawn your session with a fresh Claude):
+2. If no message was provided, run the handoff command:
    `gt handoff`
 
 Note: The new session will auto-prime via the SessionStart hook and find your handoff mail.


### PR DESCRIPTION
## Summary

Fixes #958

The `/handoff` skill was incorrectly instructing agents to use `gt mail send` followed by `gt handoff`, which created handoff mail but did not hook it. This broke the handoff workflow because new sessions couldn't find the mail on their hook.

## Changes

- Updated `/handoff` skill template to call `gt handoff -s/-m` directly
- Removed separate `gt mail send` step from instructions
- The `-s/-m` flags activate the built-in auto-hook logic in `sendHandoffMail()`

## Testing

- [x] `go build ./...` passes
- [ ] `go test ./...` - some unrelated tests fail (`internal/rig TestEnsureGitignorePatterns_*`)

## Files Changed

- `internal/templates/commands/handoff.md`