### PR TITLE
fix(tmux): handle deleted working directory on respawn

### DIFF
--- a/internal/cmd/molecule_step.go
+++ b/internal/cmd/molecule_step.go
@@ -359,6 +359,22 @@ func handleStepContinue(cwd, townRoot, _ string, nextStep *beads.Issue, dryRun b
 		style.PrintWarning("could not clear history: %v", err)
 	}
 
+	// Check if pane's working directory exists (may have been deleted)
+	paneWorkDir, _ := t.GetPaneWorkDir(currentSession)
+	var respawnWorkDir string
+	if paneWorkDir != "" {
+		if _, err := os.Stat(paneWorkDir); err != nil {
+			// Use town root as fallback
+			if townRoot != "" {
+				style.PrintWarning("pane working directory deleted, using town root")
+				respawnWorkDir = townRoot
+			}
+		}
+	}
+
+	if respawnWorkDir != "" {
+		return t.RespawnPaneWithWorkDir(pane, respawnWorkDir, restartCmd)
+	}
 	return t.RespawnPane(pane, restartCmd)
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1479,6 +1479,19 @@ func (t *Tmux) RespawnPane(pane, command string) error {
 	return err
 }
 
+// RespawnPaneWithWorkDir kills all processes in a pane and starts a new command
+// in the specified working directory. Use this when the pane's current working
+// directory may have been deleted.
+func (t *Tmux) RespawnPaneWithWorkDir(pane, workDir, command string) error {
+	args := []string{"respawn-pane", "-k", "-t", pane}
+	if workDir != "" {
+		args = append(args, "-c", workDir)
+	}
+	args = append(args, command)
+	_, err := t.run(args...)
+	return err
+}
+
 // ClearHistory clears the scrollback history buffer for a pane.
 // This resets copy-mode display from [0/N] to [0/0].
 // The pane parameter should be a pane ID (e.g., "%0") or session:window.pane format.

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"regexp"
 	"strings"
 	"testing"
@@ -13,6 +14,11 @@ import (
 func hasTmux() bool {
 	_, err := exec.LookPath("tmux")
 	return err == nil
+}
+
+// resolveSymlinks resolves symbolic links in a path (for comparing paths on macOS where /var -> /private/var)
+func resolveSymlinks(path string) (string, error) {
+	return filepath.EvalSymlinks(path)
 }
 
 func TestListSessionsNoServer(t *testing.T) {
@@ -1082,5 +1088,94 @@ func TestKillPaneProcessesExcluding_FiltersPIDs(t *testing.T) {
 		if pid != expectedFiltered[i] {
 			t.Errorf("filtered[%d] = %q, want %q", i, pid, expectedFiltered[i])
 		}
+	}
+}
+
+func TestRespawnPaneWithWorkDir(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+
+	tm := NewTmux()
+	sessionName := "gt-test-respawn-workdir-" + t.Name()
+
+	// Clean up any existing session
+	_ = tm.KillSession(sessionName)
+
+	// Create session in temp directory
+	tempDir := t.TempDir()
+	if err := tm.NewSession(sessionName, tempDir); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tm.KillSession(sessionName) }()
+
+	// Get pane ID
+	paneID, err := tm.GetPaneID(sessionName)
+	if err != nil {
+		t.Fatalf("GetPaneID: %v", err)
+	}
+
+	// Set remain-on-exit so we can respawn
+	if err := tm.SetRemainOnExit(paneID, true); err != nil {
+		t.Fatalf("SetRemainOnExit: %v", err)
+	}
+
+	// Create another temp directory for the new workdir
+	newWorkDir := t.TempDir()
+
+	// Respawn with the new working directory, using sleep to keep process alive
+	if err := tm.RespawnPaneWithWorkDir(paneID, newWorkDir, "sleep 30"); err != nil {
+		t.Fatalf("RespawnPaneWithWorkDir: %v", err)
+	}
+
+	// Wait a bit for the command to start
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify the working directory changed
+	actualWorkDir, err := tm.GetPaneWorkDir(sessionName)
+	if err != nil {
+		t.Fatalf("GetPaneWorkDir: %v", err)
+	}
+
+	// Resolve symlinks for comparison (macOS /var -> /private/var)
+	resolvedActual, _ := resolveSymlinks(actualWorkDir)
+	resolvedExpected, _ := resolveSymlinks(newWorkDir)
+	if resolvedActual != resolvedExpected {
+		t.Errorf("GetPaneWorkDir = %q, want %q", actualWorkDir, newWorkDir)
+	}
+}
+
+func TestRespawnPaneWithWorkDir_EmptyWorkDir(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+
+	tm := NewTmux()
+	sessionName := "gt-test-respawn-empty-" + t.Name()
+
+	// Clean up any existing session
+	_ = tm.KillSession(sessionName)
+
+	// Create session
+	tempDir := t.TempDir()
+	if err := tm.NewSession(sessionName, tempDir); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tm.KillSession(sessionName) }()
+
+	// Get pane ID
+	paneID, err := tm.GetPaneID(sessionName)
+	if err != nil {
+		t.Fatalf("GetPaneID: %v", err)
+	}
+
+	// Set remain-on-exit so we can respawn
+	if err := tm.SetRemainOnExit(paneID, true); err != nil {
+		t.Fatalf("SetRemainOnExit: %v", err)
+	}
+
+	// Respawn with empty workdir (should behave like regular RespawnPane)
+	if err := tm.RespawnPaneWithWorkDir(paneID, "", "true"); err != nil {
+		t.Fatalf("RespawnPaneWithWorkDir with empty workdir: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `RespawnPaneWithWorkDir` function to tmux.go that uses `-c` flag to specify working directory
- Update all `RespawnPane` callers to check if pane's working directory exists before respawning
- Fall back to town root or rig root when pane working directory has been deleted

## Problem
When a tmux pane's working directory is deleted (e.g., worktree nuked while agent is cd'd into it), `respawn-pane` inherits the stale path, causing the shell to become non-functional with "shell is completely broken (deleted working directory issue)" error.

## Test plan
- [x] `go build ./cmd/gt`
- [x] `go test ./...`
- [x] Added unit tests for `RespawnPaneWithWorkDir`

Fixes #942