### PR TITLE
fix(mayor): create settings at town root, not mayor subdir

### DIFF
--- a/internal/mayor/manager.go
+++ b/internal/mayor/manager.go
@@ -73,8 +73,11 @@ func (m *Manager) Start(agentOverride string) error {
 		return fmt.Errorf("creating mayor directory: %w", err)
 	}
 
-	// Ensure Claude settings exist
-	if err := claude.EnsureSettingsForRole(mayorDir, "mayor"); err != nil {
+	// Ensure Claude settings exist at town root (not mayorDir)
+	// Mayor session runs from townRoot (line 99), so Claude looks for
+	// .claude/settings.json relative to townRoot, not mayorDir.
+	// See: https://github.com/steveyegge/gastown/issues/943
+	if err := claude.EnsureSettingsForRole(m.townRoot, "mayor"); err != nil {
 		return fmt.Errorf("ensuring Claude settings: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

Mayor's SessionStart hook never fires because `settings.json` is created in the wrong directory.

## Root Cause

| Component | Location | Problem |
|-----------|----------|---------|
| Settings created at | `~/gt/mayor/.claude/settings.json` | Line 77 uses `mayorDir` |
| Session runs from | `~/gt/` (town root) | Line 99 uses `townRoot` |
| Claude looks for | `.claude/settings.json` relative to cwd | Doesn't find settings |

Claude Code looks for `.claude/settings.json` relative to the working directory. Since Mayor's session runs from `townRoot` but settings are created in `mayorDir`, the hook never fires.

## Fix

One-line change - create settings at `townRoot` instead of `mayorDir`:

```go
// Line 80 - BEFORE:
if err := claude.EnsureSettingsForRole(mayorDir, "mayor"); err != nil {

// AFTER:
if err := claude.EnsureSettingsForRole(m.townRoot, "mayor"); err != nil {
```

## Verification

```bash
# Before fix: settings at wrong location
ls ~/gt/mayor/.claude/settings.json  # exists
ls ~/gt/.claude/settings.json        # missing

# After fix: settings at correct location  
ls ~/gt/.claude/settings.json        # exists
# SessionStart hook fires, gt prime outputs Mayor context
```

## Impact

- Mayor receives full role context (Propulsion Principle, responsibilities)
- SessionStart hook (`gt prime`) runs on Mayor startup
- No behavioral changes to other agents

Fixes #943