### PR TITLE
fix: stop bd daemons on shutdown

### DIFF
--- a/internal/cmd/rig_lifecycle.go
+++ b/internal/cmd/rig_lifecycle.go
@@ -1,0 +1,55 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/steveyegge/gastown/internal/polecat"
+	"github.com/steveyegge/gastown/internal/refinery"
+	"github.com/steveyegge/gastown/internal/rig"
+	"github.com/steveyegge/gastown/internal/tmux"
+	"github.com/steveyegge/gastown/internal/witness"
+)
+
+// StopRigOptions defines which agents to stop for a rig.
+type StopRigOptions struct {
+	StopPolecats bool
+	StopWitness  bool
+	StopRefinery bool
+	Force        bool
+}
+
+// StopRigAgents stops the specified rig agents and returns any errors encountered.
+func StopRigAgents(r *rig.Rig, opts StopRigOptions) []error {
+	var errs []error
+
+	if opts.StopPolecats {
+		t := tmux.NewTmux()
+		polecatMgr := polecat.NewSessionManager(t, r)
+		infos, err := polecatMgr.List()
+		if err == nil && len(infos) > 0 {
+			if err := polecatMgr.StopAll(opts.Force); err != nil {
+				errs = append(errs, fmt.Errorf("polecat sessions: %w", err))
+			}
+		}
+	}
+
+	if opts.StopRefinery {
+		refMgr := refinery.NewManager(r)
+		if running, _ := refMgr.IsRunning(); running {
+			if err := refMgr.Stop(); err != nil {
+				errs = append(errs, fmt.Errorf("refinery: %w", err))
+			}
+		}
+	}
+
+	if opts.StopWitness {
+		witMgr := witness.NewManager(r)
+		if running, _ := witMgr.IsRunning(); running {
+			if err := witMgr.Stop(); err != nil {
+				errs = append(errs, fmt.Errorf("witness: %w", err))
+			}
+		}
+	}
+
+	return errs
+}


### PR DESCRIPTION
## Summary

Refactors duplicated rig agent stopping logic into a centralized `StopRigAgents()` function.

**Note:** The original PR included bd daemon stopping, but bd daemon functionality was removed from beads in commit b178d056. This updated PR removes all bd daemon related code.

Closes #968

## Changes

### New `internal/cmd/rig_lifecycle.go`
Centralized rig agent shutdown logic:
```go
type StopRigOptions struct {
    StopPolecats  bool
    StopWitness   bool
    StopRefinery  bool
    Force         bool
}

func StopRigAgents(r *rig.Rig, opts StopRigOptions) []error
```

### Refactored commands
- `rig_dock.go` — now uses `StopRigAgents()` (-28 lines)
- `rig_park.go` — now uses `StopRigAgents()` (-28 lines)

## What was removed from original PR
- `internal/beads/daemon.go` changes — file deleted in main (b178d056)
- `StopBdDaemon` option — bd daemon no longer exists
- `start.go` changes — bd daemon stopping not needed

## Testing
- `go build ./...` ✓
- Manual testing of park/dock commands

---
🤖 Generated with [Claude Code](https://claude.ai/code)