### PR TITLE
fix(mayor): run session from mayorDir instead of townRoot

### DIFF
--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -458,7 +458,9 @@ func sessionWorkDir(sessionName, townRoot string) (string, error) {
 
 	switch {
 	case sessionName == mayorSession:
-		return townRoot, nil
+		// Mayor runs from ~/gt/mayor/, not town root.
+		// Tools use workspace.FindFromCwd() which walks UP to find town root.
+		return townRoot + "/mayor", nil
 
 	case sessionName == deaconSession:
 		return townRoot + "/deacon", nil

--- a/internal/cmd/handoff_test.go
+++ b/internal/cmd/handoff_test.go
@@ -8,6 +8,61 @@ import (
 	"github.com/steveyegge/gastown/internal/workspace"
 )
 
+func TestSessionWorkDir(t *testing.T) {
+	townRoot := "/home/test/gt"
+
+	tests := []struct {
+		name        string
+		sessionName string
+		wantDir     string
+		wantErr     bool
+	}{
+		{
+			name:        "mayor runs from mayor subdirectory",
+			sessionName: "hq-mayor",
+			wantDir:     townRoot + "/mayor",
+			wantErr:     false,
+		},
+		{
+			name:        "deacon runs from deacon subdirectory",
+			sessionName: "hq-deacon",
+			wantDir:     townRoot + "/deacon",
+			wantErr:     false,
+		},
+		{
+			name:        "crew runs from crew subdirectory",
+			sessionName: "gt-gastown-crew-holden",
+			wantDir:     townRoot + "/gastown/crew/holden",
+			wantErr:     false,
+		},
+		{
+			name:        "witness runs from witness directory",
+			sessionName: "gt-gastown-witness",
+			wantDir:     townRoot + "/gastown/witness",
+			wantErr:     false,
+		},
+		{
+			name:        "refinery runs from refinery/rig directory",
+			sessionName: "gt-gastown-refinery",
+			wantDir:     townRoot + "/gastown/refinery/rig",
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotDir, err := sessionWorkDir(tt.sessionName, townRoot)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("sessionWorkDir() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if gotDir != tt.wantDir {
+				t.Errorf("sessionWorkDir() = %q, want %q", gotDir, tt.wantDir)
+			}
+		})
+	}
+}
+
 func TestDetectTownRootFromCwd_EnvFallback(t *testing.T) {
 	// Save original env vars and restore after test
 	origTownRoot := os.Getenv("GT_TOWN_ROOT")

--- a/internal/doctor/config_check.go
+++ b/internal/doctor/config_check.go
@@ -517,6 +517,14 @@ func (c *SessionHookCheck) findSettingsFiles(townRoot string) []string {
 		files = append(files, townSettings)
 	}
 
+	// Town-level agents (mayor, deacon) - these are not rigs but have their own settings
+	for _, agent := range []string{"mayor", "deacon"} {
+		agentSettings := filepath.Join(townRoot, agent, ".claude", "settings.json")
+		if _, err := os.Stat(agentSettings); err == nil {
+			files = append(files, agentSettings)
+		}
+	}
+
 	// Find all rigs
 	rigs := findAllRigs(townRoot)
 	for _, rig := range rigs {

--- a/internal/mayor/manager.go
+++ b/internal/mayor/manager.go
@@ -67,13 +67,13 @@ func (m *Manager) Start(agentOverride string) error {
 		}
 	}
 
-	// Ensure mayor directory exists (for Claude settings)
+	// Ensure mayor directory exists
 	mayorDir := m.mayorDir()
 	if err := os.MkdirAll(mayorDir, 0755); err != nil {
 		return fmt.Errorf("creating mayor directory: %w", err)
 	}
 
-	// Ensure Claude settings exist
+	// Ensure Claude settings exist in mayorDir (where session runs from).
 	if err := claude.EnsureSettingsForRole(mayorDir, "mayor"); err != nil {
 		return fmt.Errorf("ensuring Claude settings: %w", err)
 	}
@@ -93,10 +93,10 @@ func (m *Manager) Start(agentOverride string) error {
 		return fmt.Errorf("building startup command: %w", err)
 	}
 
-	// Create session in townRoot (not mayorDir) to match gt handoff behavior
-	// This ensures Mayor works from the town root where all tools work correctly
-	// See: https://github.com/anthropics/gastown/issues/280
-	if err := t.NewSessionWithCommand(sessionID, m.townRoot, startupCmd); err != nil {
+	// Create session in mayorDir - Mayor's home directory within the town.
+	// Tools like gt prime use workspace.FindFromCwd() which walks UP to find
+	// town root, so running from ~/gt/mayor/ still finds ~/gt/ correctly.
+	if err := t.NewSessionWithCommand(sessionID, mayorDir, startupCmd); err != nil {
 		return fmt.Errorf("creating tmux session: %w", err)
 	}
 

--- a/internal/workspace/find_test.go
+++ b/internal/workspace/find_test.go
@@ -251,6 +251,29 @@ func TestFindSkipsNestedWorkspaceInWorktree(t *testing.T) {
 	}
 }
 
+func TestFindFromMayorDir(t *testing.T) {
+	// This test verifies that Mayor running from ~/gt/mayor/ can find ~/gt/ as town root.
+	// This is critical for the Mayor working directory change (issue #943).
+	root := realPath(t, t.TempDir())
+	mayorDir := filepath.Join(root, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	townFile := filepath.Join(mayorDir, "town.json")
+	if err := os.WriteFile(townFile, []byte(`{"type":"town"}`), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	// Find from mayorDir should return root (the parent)
+	found, err := Find(mayorDir)
+	if err != nil {
+		t.Fatalf("Find: %v", err)
+	}
+	if found != root {
+		t.Errorf("Find(%q) = %q, want %q", mayorDir, found, root)
+	}
+}
+
 func TestFindSkipsNestedWorkspaceInCrew(t *testing.T) {
 	root := realPath(t, t.TempDir())
 


### PR DESCRIPTION
## Summary

Mayor's session was running from `~/gt/` (townRoot) but settings were created in `~/gt/mayor/`. Claude Code only looks in the exact working directory, so Mayor never found its settings.

**Fix**: Revert Mayor to run from `~/gt/mayor/` where its settings already exist.

## Background Investigation

### How did Mayor end up running from townRoot?

1. **Dec 22, 2025** (`e3500543f`): `sessionWorkDir()` added to handoff.go, setting Mayor to `townRoot` without explanation
2. **Jan 13, 2026** (`278b2f2d`): Mayor manager changed to "match gt handoff behavior"

The commit `278b2f2d` bundled the working directory change with unrelated fixes (startup beacon, removing redundant nudges). The commit message claimed it was to match handoff, but didn't explain WHY handoff used townRoot in the first place.

### Why is running from mayorDir safe?

All Gas Town commands use `workspace.FindFromCwd()` which **walks UP** to find the town root:

| Command | Location | Behavior |
|---------|----------|----------|
| `gt hook` | `internal/cmd/hook.go:241` | Uses `workspace.FindFromCwd()` |
| `gt prime` | `internal/cmd/prime.go:102` | Uses `workspace.FindFromCwd()` |
| `gt mail inbox` | `internal/mail/router.go:168` | Uses `workspace.Find(startDir)` |

Running from `~/gt/mayor/` will correctly find `~/gt/` as town root.

### Why is this safer than moving settings to townRoot?

Moving settings to `~/gt/.claude/settings.json` could cause settings pollution:
- If Claude Code traverses parent directories, other agents (crew, polecats) running from subdirectories of `~/gt/` might inherit Mayor's settings
- We have conflicting evidence about parent traversal (see bead gt-um09ny)
- Keeping settings in `~/gt/mayor/` avoids this risk entirely

### Test added: `TestFindFromMayorDir`

Explicitly verifies that `workspace.Find()` returns the correct town root when called from the mayor directory.

## Changes

| File | Change |
|------|--------|
| `internal/mayor/manager.go` | Create session in `mayorDir`, not `townRoot` |
| `internal/cmd/handoff.go` | Return `townRoot/mayor` for Mayor session working directory |
| `internal/doctor/config_check.go` | Add scanning for town-level agent settings (mayor, deacon) |
| `internal/cmd/handoff_test.go` | Add `TestSessionWorkDir` - verifies all role working directories |
| `internal/workspace/find_test.go` | Add `TestFindFromMayorDir` - verifies town root discovery |

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/mayor/... ./internal/cmd/... ./internal/workspace/...` passes
- [x] New tests verify Mayor working directory behavior
- [x] Verified `gt hook`, `gt prime`, `gt mail` all use `workspace.Find*` for town root discovery
- [x] Manual: Restart mayor, verify SessionStart hook fires

Fixes #943

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)
