### PR TITLE
fix(startup): unify agent startup with beacon + instructions in CLI prompt

### DIFF
--- a/internal/cmd/boot.go
+++ b/internal/cmd/boot.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/boot"
 	"github.com/steveyegge/gastown/internal/deacon"
+	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
@@ -141,7 +142,7 @@ func runBootStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	if sessionAlive {
-		fmt.Printf("  Session: %s (alive)\n", boot.SessionName)
+		fmt.Printf("  Session: %s (alive)\n", session.BootSessionName())
 	} else {
 		fmt.Printf("  Session: %s\n", style.Dim.Render("not running"))
 	}
@@ -219,7 +220,7 @@ func runBootSpawn(cmd *cobra.Command, args []string) error {
 	if b.IsDegraded() {
 		fmt.Println("Boot spawned in degraded mode (subprocess)")
 	} else {
-		fmt.Printf("Boot spawned in session: %s\n", boot.SessionName)
+		fmt.Printf("Boot spawned in session: %s\n", session.BootSessionName())
 	}
 
 	return nil

--- a/internal/cmd/crew_at.go
+++ b/internal/cmd/crew_at.go
@@ -193,10 +193,10 @@ func runCrewAt(cmd *cobra.Command, args []string) error {
 		}
 
 		// Build startup beacon for predecessor discovery via /resume
-		// Use FormatStartupNudge instead of bare "gt prime" which confuses agents
+		// Use FormatStartupBeacon instead of bare "gt prime" which confuses agents
 		// The SessionStart hook handles context injection (gt prime --hook)
 		address := fmt.Sprintf("%s/crew/%s", r.Name, name)
-		beacon := session.FormatStartupNudge(session.StartupNudgeConfig{
+		beacon := session.FormatStartupBeacon(session.BeaconConfig{
 			Recipient: address,
 			Sender:    "human",
 			Topic:     "start",
@@ -242,9 +242,9 @@ func runCrewAt(cmd *cobra.Command, args []string) error {
 			}
 
 			// Build startup beacon for predecessor discovery via /resume
-			// Use FormatStartupNudge instead of bare "gt prime" which confuses agents
+			// Use FormatStartupBeacon instead of bare "gt prime" which confuses agents
 			address := fmt.Sprintf("%s/crew/%s", r.Name, name)
-			beacon := session.FormatStartupNudge(session.StartupNudgeConfig{
+			beacon := session.FormatStartupBeacon(session.BeaconConfig{
 				Recipient: address,
 				Sender:    "human",
 				Topic:     "restart",
@@ -301,7 +301,7 @@ func runCrewAt(cmd *cobra.Command, args []string) error {
 		// We're in the session at a shell prompt - start the agent
 		// Build startup beacon for predecessor discovery via /resume
 		address := fmt.Sprintf("%s/crew/%s", r.Name, name)
-		beacon := session.FormatStartupNudge(session.StartupNudgeConfig{
+		beacon := session.FormatStartupBeacon(session.BeaconConfig{
 			Recipient: address,
 			Sender:    "human",
 			Topic:     "start",

--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -385,9 +385,9 @@ func buildRestartCommand(sessionName string) (string, error) {
 	gtRole := identity.GTRole()
 
 	// Build startup beacon for predecessor discovery via /resume
-	// Use FormatStartupNudge instead of bare "gt prime" which confuses agents
+	// Use FormatStartupBeacon instead of bare "gt prime" which confuses agents
 	// The SessionStart hook handles context injection (gt prime --hook)
-	beacon := session.FormatStartupNudge(session.StartupNudgeConfig{
+	beacon := session.FormatStartupBeacon(session.BeaconConfig{
 		Recipient: identity.Address(),
 		Sender:    "self",
 		Topic:     "handoff",

--- a/internal/cmd/mayor.go
+++ b/internal/cmd/mayor.go
@@ -188,7 +188,7 @@ func runMayorAttach(cmd *cobra.Command, args []string) error {
 			}
 
 			// Build startup beacon for context (like gt handoff does)
-			beacon := session.FormatStartupNudge(session.StartupNudgeConfig{
+			beacon := session.FormatStartupBeacon(session.BeaconConfig{
 				Recipient: "mayor",
 				Sender:    "human",
 				Topic:     "attach",

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -404,7 +404,7 @@ func startOrRestartCrewMember(t *tmux.Tmux, r *rig.Rig, crewName, townRoot strin
 			// Agent has exited, restart it
 			// Build startup beacon for predecessor discovery via /resume
 			address := fmt.Sprintf("%s/crew/%s", r.Name, crewName)
-			beacon := session.FormatStartupNudge(session.StartupNudgeConfig{
+			beacon := session.FormatStartupBeacon(session.BeaconConfig{
 				Recipient: address,
 				Sender:    "human",
 				Topic:     "restart",

--- a/internal/crew/manager.go
+++ b/internal/crew/manager.go
@@ -503,7 +503,7 @@ func (m *Manager) Start(name string, opts StartOptions) error {
 	if topic == "" {
 		topic = "start"
 	}
-	beacon := session.FormatStartupNudge(session.StartupNudgeConfig{
+	beacon := session.FormatStartupBeacon(session.BeaconConfig{
 		Recipient: address,
 		Sender:    "human",
 		Topic:     topic,

--- a/internal/doctor/boot_check.go
+++ b/internal/doctor/boot_check.go
@@ -6,6 +6,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/boot"
+	"github.com/steveyegge/gastown/internal/session"
 )
 
 // BootHealthCheck verifies Boot watchdog health.
@@ -63,9 +64,9 @@ func (c *BootHealthCheck) Run(ctx *CheckContext) *CheckResult {
 	// Check 2: Session alive
 	sessionAlive := b.IsSessionAlive()
 	if sessionAlive {
-		details = append(details, fmt.Sprintf("Session: %s (alive)", boot.SessionName))
+		details = append(details, fmt.Sprintf("Session: %s (alive)", session.BootSessionName()))
 	} else {
-		details = append(details, fmt.Sprintf("Session: %s (not running)", boot.SessionName))
+		details = append(details, fmt.Sprintf("Session: %s (not running)", session.BootSessionName()))
 	}
 
 	// Check 3: Last execution status

--- a/internal/mayor/manager.go
+++ b/internal/mayor/manager.go
@@ -80,7 +80,7 @@ func (m *Manager) Start(agentOverride string) error {
 
 	// Build startup beacon with explicit instructions (matches gt handoff behavior)
 	// This ensures the agent has clear context immediately, not after nudges arrive
-	beacon := session.FormatStartupNudge(session.StartupNudgeConfig{
+	beacon := session.FormatStartupBeacon(session.BeaconConfig{
 		Recipient: "mayor",
 		Sender:    "human",
 		Topic:     "cold-start",

--- a/internal/session/names_test.go
+++ b/internal/session/names_test.go
@@ -1,9 +1,6 @@
 package session
 
 import (
-	"os"
-	"path/filepath"
-	"strings"
 	"testing"
 )
 
@@ -107,65 +104,5 @@ func TestPrefix(t *testing.T) {
 	want := "gt-"
 	if Prefix != want {
 		t.Errorf("Prefix = %q, want %q", Prefix, want)
-	}
-}
-
-func TestPropulsionNudgeForRole_WithSessionID(t *testing.T) {
-	// Create temp directory with session_id file
-	tmpDir := t.TempDir()
-	runtimeDir := filepath.Join(tmpDir, ".runtime")
-	if err := os.MkdirAll(runtimeDir, 0755); err != nil {
-		t.Fatalf("creating runtime dir: %v", err)
-	}
-
-	sessionID := "test-session-abc123"
-	if err := os.WriteFile(filepath.Join(runtimeDir, "session_id"), []byte(sessionID), 0644); err != nil {
-		t.Fatalf("writing session_id: %v", err)
-	}
-
-	// Test that session ID is appended
-	msg := PropulsionNudgeForRole("mayor", tmpDir)
-	if !strings.Contains(msg, "[session:test-session-abc123]") {
-		t.Errorf("PropulsionNudgeForRole(mayor, tmpDir) = %q, should contain [session:test-session-abc123]", msg)
-	}
-}
-
-func TestPropulsionNudgeForRole_WithoutSessionID(t *testing.T) {
-	// Use nonexistent directory
-	msg := PropulsionNudgeForRole("mayor", "/nonexistent-dir-12345")
-	if strings.Contains(msg, "[session:") {
-		t.Errorf("PropulsionNudgeForRole(mayor, /nonexistent) = %q, should NOT contain session ID", msg)
-	}
-}
-
-func TestPropulsionNudgeForRole_EmptyWorkDir(t *testing.T) {
-	// Empty workDir should not crash and should not include session ID
-	msg := PropulsionNudgeForRole("mayor", "")
-	if strings.Contains(msg, "[session:") {
-		t.Errorf("PropulsionNudgeForRole(mayor, \"\") = %q, should NOT contain session ID", msg)
-	}
-}
-
-func TestPropulsionNudgeForRole_AllRoles(t *testing.T) {
-	tests := []struct {
-		role     string
-		contains string
-	}{
-		{"polecat", "gt hook"},
-		{"crew", "gt hook"},
-		{"witness", "gt prime"},
-		{"refinery", "gt prime"},
-		{"deacon", "gt prime"},
-		{"mayor", "gt prime"},
-		{"unknown", "gt hook"},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.role, func(t *testing.T) {
-			msg := PropulsionNudgeForRole(tt.role, "")
-			if !strings.Contains(msg, tt.contains) {
-				t.Errorf("PropulsionNudgeForRole(%q, \"\") = %q, should contain %q", tt.role, msg, tt.contains)
-			}
-		})
 	}
 }

--- a/internal/session/town.go
+++ b/internal/session/town.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/steveyegge/gastown/internal/boot"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
@@ -22,7 +21,7 @@ type TownSession struct {
 func TownSessions() []TownSession {
 	return []TownSession{
 		{"Mayor", MayorSessionName()},
-		{"Boot", boot.SessionName},
+		{"Boot", BootSessionName()},
 		{"Deacon", DeaconSessionName()},
 	}
 }


### PR DESCRIPTION
## Summary

All agents now receive their startup beacon + role-specific instructions via the CLI prompt, making sessions identifiable in /resume picker while removing unreliable post-startup nudges.

**Key changes:**
- Rename `FormatStartupNudge` → `FormatStartupBeacon`, `StartupNudgeConfig` → `BeaconConfig`
- Remove `StartupNudge()`, `PropulsionNudge()`, and `PropulsionNudgeForRole()` functions
- Update all role managers (deacon, witness, refinery, polecat, boot) to include beacon in CLI prompt
- Update daemon/lifecycle.go and cmd/deacon.go to include beacon
- Remove redundant post-startup nudge calls from all startup paths

## GUPP Preservation

**This change does NOT remove GUPP (Gas Town Universal Propulsion Principle).** It changes the mechanism:

**Before (post-startup nudge):**
1. Start session
2. Send beacon via `StartupNudge()` (tmux send-keys)
3. Wait 2 seconds for Claude to process
4. Send `PropulsionNudge()` to trigger autonomous execution

**After (pre-startup injection via CLI prompt + SessionStart hook):**
1. CLI prompt includes beacon + instructions (queued before Claude starts)
2. SessionStart hook runs `gt prime --hook` synchronously
3. `gt prime` injects full context including "AUTONOMOUS WORK MODE" instructions
4. Claude sees everything in first turn and executes immediately

The old two-step nudge was a workaround for unreliable context injection. SessionStart hooks now handle propulsion reliably via `gt prime`, making the separate PropulsionNudge redundant.

GUPP is still enforced by:
- `gt prime` injecting "Work is on your hook... Begin IMMEDIATELY" when work is hooked
- Daemon's `checkGUPPViolations()` detecting agents with hooked work that aren't progressing
- Witness remediation of stuck agents

## Test plan
- [x] Unit tests pass for all affected packages
- [x] Build compiles without errors
- [ ] Manual test: Start deacon and verify beacon appears in prompt
- [ ] Manual test: Verify agents with hooked work start immediately

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)