### PR TITLE
fix(settings): create settings.json in working directory, not parent

### DIFF
--- a/internal/crew/manager.go
+++ b/internal/crew/manager.go
@@ -476,11 +476,10 @@ func (m *Manager) Start(name string, opts StartOptions) error {
 		}
 	}
 
-	// Ensure Claude settings exist in crew/ (not crew/<name>/) so we don't
-	// write into the source repo. Claude walks up the tree to find settings.
-	// All crew members share the same settings file.
-	crewBaseDir := filepath.Join(m.rig.Path, "crew")
-	if err := claude.EnsureSettingsForRole(crewBaseDir, "crew"); err != nil {
+	// Ensure Claude settings exist in the working directory (worker.ClonePath).
+	// Claude Code does NOT traverse parent directories for settings.json.
+	// The .claude/ directory is already gitignored via EnsureGitignorePatterns().
+	if err := claude.EnsureSettingsForRole(worker.ClonePath, "crew"); err != nil {
 		return fmt.Errorf("ensuring Claude settings: %w", err)
 	}
 

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -173,10 +173,10 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 
 	runtimeConfig := config.LoadRuntimeConfig(m.rig.Path)
 
-	// Ensure runtime settings exist in polecats/ (not polecats/<name>/) so we don't
-	// write into the source repo. Runtime walks up the tree to find settings.
-	polecatsDir := filepath.Join(m.rig.Path, "polecats")
-	if err := runtime.EnsureSettingsForRole(polecatsDir, "polecat", runtimeConfig); err != nil {
+	// Ensure runtime settings exist in the working directory (workDir).
+	// Claude Code does NOT traverse parent directories for settings.json.
+	// The .claude/ directory is already gitignored via EnsureGitignorePatterns().
+	if err := runtime.EnsureSettingsForRole(workDir, "polecat", runtimeConfig); err != nil {
 		return fmt.Errorf("ensuring runtime settings: %w", err)
 	}
 

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -125,12 +125,12 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 		refineryRigDir = filepath.Join(m.rig.Path, "mayor", "rig")
 	}
 
-	// Ensure runtime settings exist in refinery/ (not refinery/rig/) so we don't
-	// write into the source repo. Runtime walks up the tree to find settings.
-	refineryParentDir := filepath.Join(m.rig.Path, "refinery")
+	// Ensure runtime settings exist in the working directory (refineryRigDir).
+	// Claude Code does NOT traverse parent directories for settings.json.
+	// The .claude/ directory is already gitignored via EnsureGitignorePatterns().
 	townRoot := filepath.Dir(m.rig.Path)
 	runtimeConfig := config.ResolveRoleAgentConfig("refinery", townRoot, m.rig.Path)
-	if err := runtime.EnsureSettingsForRole(refineryParentDir, "refinery", runtimeConfig); err != nil {
+	if err := runtime.EnsureSettingsForRole(refineryRigDir, "refinery", runtimeConfig); err != nil {
 		return fmt.Errorf("ensuring runtime settings: %w", err)
 	}
 

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -116,10 +116,10 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	// Working directory
 	witnessDir := m.witnessDir()
 
-	// Ensure Claude settings exist in witness/ (not witness/rig/) so we don't
-	// write into the source repo. Claude walks up the tree to find settings.
-	witnessParentDir := filepath.Join(m.rig.Path, "witness")
-	if err := claude.EnsureSettingsForRole(witnessParentDir, "witness"); err != nil {
+	// Ensure Claude settings exist in the working directory (witnessDir).
+	// Claude Code does NOT traverse parent directories for settings.json.
+	// The .claude/ directory is already gitignored via EnsureGitignorePatterns().
+	if err := claude.EnsureSettingsForRole(witnessDir, "witness"); err != nil {
 		return fmt.Errorf("ensuring Claude settings: %w", err)
 	}
 


### PR DESCRIPTION
## Summary

Claude Code does NOT traverse parent directories for settings.json (confirmed via issue anthropics/claude-code#12962 and empirical testing). Several agent startup paths were creating settings in parent directories, causing SessionStart hooks to never fire.

This fix ensures settings are created in the actual working directory for all agents:
- **refinery**: was `refinery/`, now `refinery/rig/`
- **crew (via gt crew start)**: was `crew/`, now `crew/<name>/`
- **polecat**: was `polecats/`, now `polecats/<name>/<rig>/`
- **witness**: was `witness/`, now `witnessDir` (dynamically resolved)

The `.claude/` directory is already gitignored via `EnsureGitignorePatterns()`, so there's no risk of committing settings to source repos.

## Test Plan

- [x] All existing tests pass
- [ ] Manual verification: restart agents and verify SessionStart hooks fire
- [ ] Verify `.claude/` directories are created in working directories

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)