### PR TITLE
fix(doctor): update claude_settings_check to delete old/misplaced settings

### DIFF
--- a/internal/doctor/claude_settings_check_test.go
+++ b/internal/doctor/claude_settings_check_test.go
@@ -1,7 +1,6 @@
 package doctor
 
 import (
-	"encoding/json"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -34,155 +33,28 @@ func TestClaudeSettingsCheck_NoSettingsFiles(t *testing.T) {
 	}
 }
 
-// createValidSettings creates a valid settings.json with all required elements.
-func createValidSettings(t *testing.T, path string) {
+// createSettingsFile creates a settings file at the given path.
+func createSettingsFile(t *testing.T, path string) {
 	t.Helper()
-
-	settings := map[string]any{
-		"enabledPlugins": []string{"plugin1"},
-		"hooks": map[string]any{
-			"SessionStart": []any{
-				map[string]any{
-					"matcher": "**",
-					"hooks": []any{
-						map[string]any{
-							"type":    "command",
-							"command": "export PATH=/usr/local/bin:$PATH",
-						},
-						map[string]any{
-							"type":    "command",
-							"command": "gt nudge deacon session-started",
-						},
-					},
-				},
-			},
-			"Stop": []any{
-				map[string]any{
-					"matcher": "**",
-					"hooks": []any{
-						map[string]any{
-							"type":    "command",
-							"command": "gt costs record --session $CLAUDE_SESSION_ID",
-						},
-					},
-				},
-			},
-		},
-	}
 
 	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
 		t.Fatal(err)
 	}
 
-	data, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.WriteFile(path, data, 0644); err != nil {
+	content := `{"enabledPlugins": ["plugin1"]}`
+	if err := os.WriteFile(path, []byte(content), 0644); err != nil {
 		t.Fatal(err)
 	}
 }
 
-// createStaleSettings creates a settings.json missing required elements.
-func createStaleSettings(t *testing.T, path string, missingElements ...string) {
-	t.Helper()
-
-	settings := map[string]any{
-		"enabledPlugins": []string{"plugin1"},
-		"hooks": map[string]any{
-			"SessionStart": []any{
-				map[string]any{
-					"matcher": "**",
-					"hooks": []any{
-						map[string]any{
-							"type":    "command",
-							"command": "export PATH=/usr/local/bin:$PATH",
-						},
-						map[string]any{
-							"type":    "command",
-							"command": "gt nudge deacon session-started",
-						},
-					},
-				},
-			},
-			"Stop": []any{
-				map[string]any{
-					"matcher": "**",
-					"hooks": []any{
-						map[string]any{
-							"type":    "command",
-							"command": "gt costs record --session $CLAUDE_SESSION_ID",
-						},
-					},
-				},
-			},
-		},
-	}
-
-	for _, missing := range missingElements {
-		switch missing {
-		case "enabledPlugins":
-			delete(settings, "enabledPlugins")
-		case "hooks":
-			delete(settings, "hooks")
-		case "PATH":
-			// Remove PATH from SessionStart hooks
-			hooks := settings["hooks"].(map[string]any)
-			sessionStart := hooks["SessionStart"].([]any)
-			hookObj := sessionStart[0].(map[string]any)
-			innerHooks := hookObj["hooks"].([]any)
-			// Filter out PATH command
-			var filtered []any
-			for _, h := range innerHooks {
-				hMap := h.(map[string]any)
-				if cmd, ok := hMap["command"].(string); ok && !strings.Contains(cmd, "PATH=") {
-					filtered = append(filtered, h)
-				}
-			}
-			hookObj["hooks"] = filtered
-		case "deacon-nudge":
-			// Remove deacon nudge from SessionStart hooks
-			hooks := settings["hooks"].(map[string]any)
-			sessionStart := hooks["SessionStart"].([]any)
-			hookObj := sessionStart[0].(map[string]any)
-			innerHooks := hookObj["hooks"].([]any)
-			// Filter out deacon nudge
-			var filtered []any
-			for _, h := range innerHooks {
-				hMap := h.(map[string]any)
-				if cmd, ok := hMap["command"].(string); ok && !strings.Contains(cmd, "gt nudge deacon") {
-					filtered = append(filtered, h)
-				}
-			}
-			hookObj["hooks"] = filtered
-		case "Stop":
-			hooks := settings["hooks"].(map[string]any)
-			delete(hooks, "Stop")
-		}
-	}
-
-	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	data, err := json.MarshalIndent(settings, "", "  ")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	if err := os.WriteFile(path, data, 0644); err != nil {
-		t.Fatal(err)
-	}
-}
+// Tests for valid settings.local.json in correct working directories
 
 func TestClaudeSettingsCheck_ValidMayorSettings(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create valid mayor settings at correct location (mayor/.claude/settings.json)
-	// NOT at town root (.claude/settings.json) which is wrong location
-	mayorSettings := filepath.Join(tmpDir, "mayor", ".claude", "settings.json")
-	createValidSettings(t, mayorSettings)
+	// Create valid mayor settings at correct location with correct filename
+	mayorSettings := filepath.Join(tmpDir, "mayor", ".claude", "settings.local.json")
+	createSettingsFile(t, mayorSettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -197,9 +69,9 @@ func TestClaudeSettingsCheck_ValidMayorSettings(t *testing.T) {
 func TestClaudeSettingsCheck_ValidDeaconSettings(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create valid deacon settings
-	deaconSettings := filepath.Join(tmpDir, "deacon", ".claude", "settings.json")
-	createValidSettings(t, deaconSettings)
+	// Create valid deacon settings at correct location with correct filename
+	deaconSettings := filepath.Join(tmpDir, "deacon", ".claude", "settings.local.json")
+	createSettingsFile(t, deaconSettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -211,13 +83,14 @@ func TestClaudeSettingsCheck_ValidDeaconSettings(t *testing.T) {
 	}
 }
 
-func TestClaudeSettingsCheck_ValidWitnessSettings(t *testing.T) {
+func TestClaudeSettingsCheck_ValidWitnessSettingsInWitnessDir(t *testing.T) {
 	tmpDir := t.TempDir()
 	rigName := "testrig"
 
-	// Create valid witness settings in correct location (witness/.claude/, outside git repo)
-	witnessSettings := filepath.Join(tmpDir, rigName, "witness", ".claude", "settings.json")
-	createValidSettings(t, witnessSettings)
+	// Working dir is witness/ when witness/rig/ doesn't exist
+	// settings.local.json in witness/ is correct
+	witnessSettings := filepath.Join(tmpDir, rigName, "witness", ".claude", "settings.local.json")
+	createSettingsFile(t, witnessSettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -229,13 +102,37 @@ func TestClaudeSettingsCheck_ValidWitnessSettings(t *testing.T) {
 	}
 }
 
+func TestClaudeSettingsCheck_ValidWitnessSettingsInWitnessRigDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+
+	// When witness/rig/ exists, working dir is witness/rig/
+	// settings.local.json in witness/rig/ is correct
+	witnessRigDir := filepath.Join(tmpDir, rigName, "witness", "rig")
+	if err := os.MkdirAll(witnessRigDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	witnessSettings := filepath.Join(witnessRigDir, ".claude", "settings.local.json")
+	createSettingsFile(t, witnessSettings)
+
+	check := NewClaudeSettingsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK for valid witness settings in rig dir, got %v: %s", result.Status, result.Message)
+	}
+}
+
 func TestClaudeSettingsCheck_ValidRefinerySettings(t *testing.T) {
 	tmpDir := t.TempDir()
 	rigName := "testrig"
 
-	// Create valid refinery settings in correct location (refinery/.claude/, outside git repo)
-	refinerySettings := filepath.Join(tmpDir, rigName, "refinery", ".claude", "settings.json")
-	createValidSettings(t, refinerySettings)
+	// Working dir is refinery/rig/ (always)
+	// settings.local.json in refinery/rig/ is correct
+	refinerySettings := filepath.Join(tmpDir, rigName, "refinery", "rig", ".claude", "settings.local.json")
+	createSettingsFile(t, refinerySettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -251,9 +148,10 @@ func TestClaudeSettingsCheck_ValidCrewSettings(t *testing.T) {
 	tmpDir := t.TempDir()
 	rigName := "testrig"
 
-	// Create valid crew settings in correct location (crew/.claude/, shared by all crew)
-	crewSettings := filepath.Join(tmpDir, rigName, "crew", ".claude", "settings.json")
-	createValidSettings(t, crewSettings)
+	// Working dir is crew/<name>/ (always)
+	// settings.local.json in crew/<name>/ is correct
+	crewSettings := filepath.Join(tmpDir, rigName, "crew", "agent1", ".claude", "settings.local.json")
+	createSettingsFile(t, crewSettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -269,9 +167,10 @@ func TestClaudeSettingsCheck_ValidPolecatSettings(t *testing.T) {
 	tmpDir := t.TempDir()
 	rigName := "testrig"
 
-	// Create valid polecat settings in correct location (polecats/.claude/, shared by all polecats)
-	pcSettings := filepath.Join(tmpDir, rigName, "polecats", ".claude", "settings.json")
-	createValidSettings(t, pcSettings)
+	// Working dir is polecats/<name>/<rig>/ (always)
+	// settings.local.json in polecats/<name>/<rig>/ is correct
+	pcSettings := filepath.Join(tmpDir, rigName, "polecats", "pc1", rigName, ".claude", "settings.local.json")
+	createSettingsFile(t, pcSettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -283,12 +182,14 @@ func TestClaudeSettingsCheck_ValidPolecatSettings(t *testing.T) {
 	}
 }
 
-func TestClaudeSettingsCheck_MissingEnabledPlugins(t *testing.T) {
+// Tests for stale settings.json (old filename)
+
+func TestClaudeSettingsCheck_OldFilenameInMayor(t *testing.T) {
 	tmpDir := t.TempDir()
 
-	// Create stale mayor settings missing enabledPlugins (at correct location)
+	// settings.json is the OLD filename - should be marked stale
 	mayorSettings := filepath.Join(tmpDir, "mayor", ".claude", "settings.json")
-	createStaleSettings(t, mayorSettings, "enabledPlugins")
+	createSettingsFile(t, mayorSettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -296,63 +197,27 @@ func TestClaudeSettingsCheck_MissingEnabledPlugins(t *testing.T) {
 	result := check.Run(ctx)
 
 	if result.Status != StatusError {
-		t.Errorf("expected StatusError for missing enabledPlugins, got %v", result.Status)
-	}
-	if !strings.Contains(result.Message, "1 stale") {
-		t.Errorf("expected message about stale settings, got %q", result.Message)
-	}
-}
-
-func TestClaudeSettingsCheck_MissingHooks(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Create stale settings missing hooks entirely (at correct location)
-	mayorSettings := filepath.Join(tmpDir, "mayor", ".claude", "settings.json")
-	createStaleSettings(t, mayorSettings, "hooks")
-
-	check := NewClaudeSettingsCheck()
-	ctx := &CheckContext{TownRoot: tmpDir}
-
-	result := check.Run(ctx)
-
-	if result.Status != StatusError {
-		t.Errorf("expected StatusError for missing hooks, got %v", result.Status)
-	}
-}
-
-func TestClaudeSettingsCheck_MissingPATH(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Create stale settings missing PATH export (at correct location)
-	mayorSettings := filepath.Join(tmpDir, "mayor", ".claude", "settings.json")
-	createStaleSettings(t, mayorSettings, "PATH")
-
-	check := NewClaudeSettingsCheck()
-	ctx := &CheckContext{TownRoot: tmpDir}
-
-	result := check.Run(ctx)
-
-	if result.Status != StatusError {
-		t.Errorf("expected StatusError for missing PATH, got %v", result.Status)
+		t.Errorf("expected StatusError for old filename, got %v", result.Status)
 	}
 	found := false
 	for _, d := range result.Details {
-		if strings.Contains(d, "PATH export") {
+		if strings.Contains(d, "old filename") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected details to mention PATH export, got %v", result.Details)
+		t.Errorf("expected details to mention old filename, got %v", result.Details)
 	}
 }
 
-func TestClaudeSettingsCheck_MissingDeaconNudge(t *testing.T) {
+func TestClaudeSettingsCheck_OldFilenameInWorkingDir(t *testing.T) {
 	tmpDir := t.TempDir()
+	rigName := "testrig"
 
-	// Create stale settings missing deacon nudge (at correct location)
-	mayorSettings := filepath.Join(tmpDir, "mayor", ".claude", "settings.json")
-	createStaleSettings(t, mayorSettings, "deacon-nudge")
+	// settings.json in working dir (crew/<name>/) is stale - should use settings.local.json
+	crewSettings := filepath.Join(tmpDir, rigName, "crew", "agent1", ".claude", "settings.json")
+	createSettingsFile(t, crewSettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -360,26 +225,29 @@ func TestClaudeSettingsCheck_MissingDeaconNudge(t *testing.T) {
 	result := check.Run(ctx)
 
 	if result.Status != StatusError {
-		t.Errorf("expected StatusError for missing deacon nudge, got %v", result.Status)
+		t.Errorf("expected StatusError for old filename, got %v", result.Status)
 	}
 	found := false
 	for _, d := range result.Details {
-		if strings.Contains(d, "deacon nudge") {
+		if strings.Contains(d, "old filename") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected details to mention deacon nudge, got %v", result.Details)
+		t.Errorf("expected details to mention old filename, got %v", result.Details)
 	}
 }
 
-func TestClaudeSettingsCheck_MissingStopHook(t *testing.T) {
-	tmpDir := t.TempDir()
+// Tests for wrong location (parent directory instead of working directory)
 
-	// Create stale settings missing Stop hook (at correct location)
-	mayorSettings := filepath.Join(tmpDir, "mayor", ".claude", "settings.json")
-	createStaleSettings(t, mayorSettings, "Stop")
+func TestClaudeSettingsCheck_WrongLocationRefinery(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+
+	// Settings in refinery/ parent dir is WRONG - should be in refinery/rig/
+	wrongSettings := filepath.Join(tmpDir, rigName, "refinery", ".claude", "settings.local.json")
+	createSettingsFile(t, wrongSettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -387,17 +255,17 @@ func TestClaudeSettingsCheck_MissingStopHook(t *testing.T) {
 	result := check.Run(ctx)
 
 	if result.Status != StatusError {
-		t.Errorf("expected StatusError for missing Stop hook, got %v", result.Status)
+		t.Errorf("expected StatusError for wrong location, got %v", result.Status)
 	}
 	found := false
 	for _, d := range result.Details {
-		if strings.Contains(d, "Stop hook") {
+		if strings.Contains(d, "wrong location") {
 			found = true
 			break
 		}
 	}
 	if !found {
-		t.Errorf("expected details to mention Stop hook, got %v", result.Details)
+		t.Errorf("expected details to mention wrong location, got %v", result.Details)
 	}
 }
 
@@ -405,10 +273,13 @@ func TestClaudeSettingsCheck_WrongLocationWitness(t *testing.T) {
 	tmpDir := t.TempDir()
 	rigName := "testrig"
 
-	// Create settings in wrong location (witness/rig/.claude/ instead of witness/.claude/)
-	// Settings inside git repos should be flagged as wrong location
-	wrongSettings := filepath.Join(tmpDir, rigName, "witness", "rig", ".claude", "settings.json")
-	createValidSettings(t, wrongSettings)
+	// When witness/rig/ exists, settings in witness/ are WRONG
+	witnessRigDir := filepath.Join(tmpDir, rigName, "witness", "rig")
+	if err := os.MkdirAll(witnessRigDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	wrongSettings := filepath.Join(tmpDir, rigName, "witness", ".claude", "settings.local.json")
+	createSettingsFile(t, wrongSettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -427,193 +298,6 @@ func TestClaudeSettingsCheck_WrongLocationWitness(t *testing.T) {
 	}
 	if !found {
 		t.Errorf("expected details to mention wrong location, got %v", result.Details)
-	}
-}
-
-func TestClaudeSettingsCheck_WrongLocationRefinery(t *testing.T) {
-	tmpDir := t.TempDir()
-	rigName := "testrig"
-
-	// Create settings in wrong location (refinery/rig/.claude/ instead of refinery/.claude/)
-	// Settings inside git repos should be flagged as wrong location
-	wrongSettings := filepath.Join(tmpDir, rigName, "refinery", "rig", ".claude", "settings.json")
-	createValidSettings(t, wrongSettings)
-
-	check := NewClaudeSettingsCheck()
-	ctx := &CheckContext{TownRoot: tmpDir}
-
-	result := check.Run(ctx)
-
-	if result.Status != StatusError {
-		t.Errorf("expected StatusError for wrong location, got %v", result.Status)
-	}
-	found := false
-	for _, d := range result.Details {
-		if strings.Contains(d, "wrong location") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("expected details to mention wrong location, got %v", result.Details)
-	}
-}
-
-func TestClaudeSettingsCheck_MultipleStaleFiles(t *testing.T) {
-	tmpDir := t.TempDir()
-	rigName := "testrig"
-
-	// Create multiple stale settings files (all at correct locations)
-	mayorSettings := filepath.Join(tmpDir, "mayor", ".claude", "settings.json")
-	createStaleSettings(t, mayorSettings, "PATH")
-
-	deaconSettings := filepath.Join(tmpDir, "deacon", ".claude", "settings.json")
-	createStaleSettings(t, deaconSettings, "Stop")
-
-	// Settings inside git repo (witness/rig/.claude/) are wrong location
-	witnessWrong := filepath.Join(tmpDir, rigName, "witness", "rig", ".claude", "settings.json")
-	createValidSettings(t, witnessWrong) // Valid content but wrong location
-
-	check := NewClaudeSettingsCheck()
-	ctx := &CheckContext{TownRoot: tmpDir}
-
-	result := check.Run(ctx)
-
-	if result.Status != StatusError {
-		t.Errorf("expected StatusError for multiple stale files, got %v", result.Status)
-	}
-	if !strings.Contains(result.Message, "3 stale") {
-		t.Errorf("expected message about 3 stale files, got %q", result.Message)
-	}
-}
-
-func TestClaudeSettingsCheck_InvalidJSON(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Create invalid JSON file (at correct location)
-	mayorSettings := filepath.Join(tmpDir, "mayor", ".claude", "settings.json")
-	if err := os.MkdirAll(filepath.Dir(mayorSettings), 0755); err != nil {
-		t.Fatal(err)
-	}
-	if err := os.WriteFile(mayorSettings, []byte("not valid json {"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	check := NewClaudeSettingsCheck()
-	ctx := &CheckContext{TownRoot: tmpDir}
-
-	result := check.Run(ctx)
-
-	if result.Status != StatusError {
-		t.Errorf("expected StatusError for invalid JSON, got %v", result.Status)
-	}
-	found := false
-	for _, d := range result.Details {
-		if strings.Contains(d, "invalid JSON") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("expected details to mention invalid JSON, got %v", result.Details)
-	}
-}
-
-func TestClaudeSettingsCheck_FixDeletesStaleFile(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Create stale settings in wrong location (inside git repo - easy to test - just delete, no recreate)
-	rigName := "testrig"
-	wrongSettings := filepath.Join(tmpDir, rigName, "witness", "rig", ".claude", "settings.json")
-	createValidSettings(t, wrongSettings)
-
-	check := NewClaudeSettingsCheck()
-	ctx := &CheckContext{TownRoot: tmpDir}
-
-	// Run to detect
-	result := check.Run(ctx)
-	if result.Status != StatusError {
-		t.Fatalf("expected StatusError before fix, got %v", result.Status)
-	}
-
-	// Apply fix
-	if err := check.Fix(ctx); err != nil {
-		t.Fatalf("Fix failed: %v", err)
-	}
-
-	// Verify file was deleted
-	if _, err := os.Stat(wrongSettings); !os.IsNotExist(err) {
-		t.Error("expected wrong location settings to be deleted")
-	}
-
-	// Verify check passes (no settings files means OK)
-	result = check.Run(ctx)
-	if result.Status != StatusOK {
-		t.Errorf("expected StatusOK after fix, got %v", result.Status)
-	}
-}
-
-func TestClaudeSettingsCheck_SkipsNonRigDirectories(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Create directories that should be skipped
-	for _, skipDir := range []string{"mayor", "deacon", "daemon", ".git", "docs", ".hidden"} {
-		dir := filepath.Join(tmpDir, skipDir, "witness", "rig", ".claude")
-		if err := os.MkdirAll(dir, 0755); err != nil {
-			t.Fatal(err)
-		}
-		// These should NOT be detected as rig witness settings
-		settingsPath := filepath.Join(dir, "settings.json")
-		createStaleSettings(t, settingsPath, "PATH")
-	}
-
-	check := NewClaudeSettingsCheck()
-	ctx := &CheckContext{TownRoot: tmpDir}
-
-	_ = check.Run(ctx)
-
-	// Should only find mayor and deacon settings in their specific locations
-	// The witness settings in these dirs should be ignored
-	// Since we didn't create valid mayor/deacon settings, those will be stale
-	// But the ones in "mayor/witness/rig/.claude" should be ignored
-
-	// Count how many stale files were found - should be 0 since none of the
-	// skipped directories have their settings detected
-	if len(check.staleSettings) != 0 {
-		t.Errorf("expected 0 stale files (skipped dirs), got %d", len(check.staleSettings))
-	}
-}
-
-func TestClaudeSettingsCheck_MixedValidAndStale(t *testing.T) {
-	tmpDir := t.TempDir()
-	rigName := "testrig"
-
-	// Create valid mayor settings (at correct location)
-	mayorSettings := filepath.Join(tmpDir, "mayor", ".claude", "settings.json")
-	createValidSettings(t, mayorSettings)
-
-	// Create stale witness settings in correct location (missing PATH)
-	witnessSettings := filepath.Join(tmpDir, rigName, "witness", ".claude", "settings.json")
-	createStaleSettings(t, witnessSettings, "PATH")
-
-	// Create valid refinery settings in correct location
-	refinerySettings := filepath.Join(tmpDir, rigName, "refinery", ".claude", "settings.json")
-	createValidSettings(t, refinerySettings)
-
-	check := NewClaudeSettingsCheck()
-	ctx := &CheckContext{TownRoot: tmpDir}
-
-	result := check.Run(ctx)
-
-	if result.Status != StatusError {
-		t.Errorf("expected StatusError for mixed valid/stale, got %v", result.Status)
-	}
-	if !strings.Contains(result.Message, "1 stale") {
-		t.Errorf("expected message about 1 stale file, got %q", result.Message)
-	}
-	// Should only report the witness settings as stale
-	if len(result.Details) != 1 {
-		t.Errorf("expected 1 detail, got %d: %v", len(result.Details), result.Details)
 	}
 }
 
@@ -621,10 +305,9 @@ func TestClaudeSettingsCheck_WrongLocationCrew(t *testing.T) {
 	tmpDir := t.TempDir()
 	rigName := "testrig"
 
-	// Create settings in wrong location (crew/<name>/.claude/ instead of crew/.claude/)
-	// Settings inside git repos should be flagged as wrong location
-	wrongSettings := filepath.Join(tmpDir, rigName, "crew", "agent1", ".claude", "settings.json")
-	createValidSettings(t, wrongSettings)
+	// Settings in crew/ parent dir is WRONG - should be in crew/<name>/
+	wrongSettings := filepath.Join(tmpDir, rigName, "crew", ".claude", "settings.local.json")
+	createSettingsFile(t, wrongSettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -650,10 +333,9 @@ func TestClaudeSettingsCheck_WrongLocationPolecat(t *testing.T) {
 	tmpDir := t.TempDir()
 	rigName := "testrig"
 
-	// Create settings in wrong location (polecats/<name>/.claude/ instead of polecats/.claude/)
-	// Settings inside git repos should be flagged as wrong location
-	wrongSettings := filepath.Join(tmpDir, rigName, "polecats", "pc1", ".claude", "settings.json")
-	createValidSettings(t, wrongSettings)
+	// Settings in polecats/ parent dir is WRONG - should be in polecats/<name>/<rig>/
+	wrongSettings := filepath.Join(tmpDir, rigName, "polecats", ".claude", "settings.local.json")
+	createSettingsFile(t, wrongSettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -674,6 +356,221 @@ func TestClaudeSettingsCheck_WrongLocationPolecat(t *testing.T) {
 		t.Errorf("expected details to mention wrong location, got %v", result.Details)
 	}
 }
+
+func TestClaudeSettingsCheck_WrongLocationPolecatIntermediate(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+
+	// Settings in polecats/<name>/ is also WRONG - should be in polecats/<name>/<rig>/
+	wrongSettings := filepath.Join(tmpDir, rigName, "polecats", "pc1", ".claude", "settings.local.json")
+	createSettingsFile(t, wrongSettings)
+
+	check := NewClaudeSettingsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusError {
+		t.Errorf("expected StatusError for wrong location, got %v", result.Status)
+	}
+	found := false
+	for _, d := range result.Details {
+		if strings.Contains(d, "wrong location") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected details to mention wrong location, got %v", result.Details)
+	}
+}
+
+// Tests for town root settings (always wrong)
+
+func TestClaudeSettingsCheck_TownRootSettings(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Settings at town root is ALWAYS wrong (pollutes all agents)
+	wrongSettings := filepath.Join(tmpDir, ".claude", "settings.json")
+	createSettingsFile(t, wrongSettings)
+
+	check := NewClaudeSettingsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusError {
+		t.Errorf("expected StatusError for town root settings, got %v", result.Status)
+	}
+	found := false
+	for _, d := range result.Details {
+		if strings.Contains(d, "wrong location") && strings.Contains(d, "mayor") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected details to mention wrong location for mayor, got %v", result.Details)
+	}
+}
+
+func TestClaudeSettingsCheck_TownRootCLAUDEmd(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// CLAUDE.md at town root is WRONG (pollutes all agents)
+	wrongCLAUDEmd := filepath.Join(tmpDir, "CLAUDE.md")
+	if err := os.WriteFile(wrongCLAUDEmd, []byte("# Mayor Context\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewClaudeSettingsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusError {
+		t.Errorf("expected StatusError for town root CLAUDE.md, got %v", result.Status)
+	}
+	found := false
+	for _, d := range result.Details {
+		if strings.Contains(d, "CLAUDE.md") && strings.Contains(d, "wrong location") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected details to mention CLAUDE.md wrong location, got %v", result.Details)
+	}
+}
+
+// Tests for multiple stale files
+
+func TestClaudeSettingsCheck_MultipleStaleFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+
+	// Create multiple stale files
+	// 1. Old filename in mayor
+	createSettingsFile(t, filepath.Join(tmpDir, "mayor", ".claude", "settings.json"))
+	// 2. Wrong location for refinery (parent dir instead of refinery/rig/)
+	createSettingsFile(t, filepath.Join(tmpDir, rigName, "refinery", ".claude", "settings.local.json"))
+	// 3. Old filename in crew working dir
+	createSettingsFile(t, filepath.Join(tmpDir, rigName, "crew", "agent1", ".claude", "settings.json"))
+
+	check := NewClaudeSettingsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusError {
+		t.Errorf("expected StatusError for multiple stale files, got %v", result.Status)
+	}
+	if !strings.Contains(result.Message, "3 stale") {
+		t.Errorf("expected message about 3 stale files, got %q", result.Message)
+	}
+}
+
+// Tests for Fix behavior
+
+func TestClaudeSettingsCheck_FixDeletesStaleFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+
+	// Create stale settings in wrong location (parent dir)
+	wrongSettings := filepath.Join(tmpDir, rigName, "refinery", ".claude", "settings.local.json")
+	createSettingsFile(t, wrongSettings)
+
+	check := NewClaudeSettingsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	// Run to detect
+	result := check.Run(ctx)
+	if result.Status != StatusError {
+		t.Fatalf("expected StatusError before fix, got %v", result.Status)
+	}
+
+	// Apply fix
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+
+	// Verify file was deleted
+	if _, err := os.Stat(wrongSettings); !os.IsNotExist(err) {
+		t.Error("expected stale settings to be deleted")
+	}
+
+	// Verify check passes after fix
+	result = check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK after fix, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestClaudeSettingsCheck_FixDeletesTownRootFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create stale files at town root
+	staleTownRootSettings := filepath.Join(tmpDir, ".claude", "settings.json")
+	createSettingsFile(t, staleTownRootSettings)
+
+	staleCLAUDEmd := filepath.Join(tmpDir, "CLAUDE.md")
+	if err := os.WriteFile(staleCLAUDEmd, []byte("# Mayor Context\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewClaudeSettingsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	// Run to detect
+	result := check.Run(ctx)
+	if result.Status != StatusError {
+		t.Fatalf("expected StatusError before fix, got %v", result.Status)
+	}
+
+	// Apply fix
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+
+	// Verify settings.json was deleted
+	if _, err := os.Stat(staleTownRootSettings); !os.IsNotExist(err) {
+		t.Error("expected town root settings.json to be deleted")
+	}
+
+	// Verify CLAUDE.md was deleted
+	if _, err := os.Stat(staleCLAUDEmd); !os.IsNotExist(err) {
+		t.Error("expected town root CLAUDE.md to be deleted")
+	}
+}
+
+func TestClaudeSettingsCheck_SkipsNonRigDirectories(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create directories that should be skipped
+	for _, skipDir := range []string{"mayor", "deacon", "daemon", ".git", "docs", ".hidden"} {
+		dir := filepath.Join(tmpDir, skipDir, "witness", "rig", ".claude")
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		// These should NOT be detected as rig witness settings
+		settingsPath := filepath.Join(dir, "settings.json")
+		createSettingsFile(t, settingsPath)
+	}
+
+	check := NewClaudeSettingsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	_ = check.Run(ctx)
+
+	// Should only find mayor and deacon settings (if any) - not nested witness dirs
+	// In this case, we're putting settings in mayor/witness/rig/.claude/ which is invalid
+	// The skip logic should prevent these from being found as "rig" witness settings
+	if len(check.staleSettings) != 0 {
+		t.Errorf("expected 0 stale files from skipped dirs, got %d", len(check.staleSettings))
+	}
+}
+
+// Git status tests
 
 // initTestGitRepo initializes a git repo in the given directory for settings tests.
 func initTestGitRepo(t *testing.T, dir string) {
@@ -719,15 +616,15 @@ func TestClaudeSettingsCheck_GitStatusUntracked(t *testing.T) {
 	rigName := "testrig"
 
 	// Create a git repo to simulate a source repo
-	rigDir := filepath.Join(tmpDir, rigName, "witness", "rig")
+	rigDir := filepath.Join(tmpDir, rigName, "refinery", "rig")
 	if err := os.MkdirAll(rigDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 	initTestGitRepo(t, rigDir)
 
-	// Create an untracked settings file (not git added)
-	wrongSettings := filepath.Join(rigDir, ".claude", "settings.json")
-	createValidSettings(t, wrongSettings)
+	// Create an untracked stale settings file (old filename)
+	staleSettings := filepath.Join(rigDir, ".claude", "settings.json")
+	createSettingsFile(t, staleSettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -735,7 +632,7 @@ func TestClaudeSettingsCheck_GitStatusUntracked(t *testing.T) {
 	result := check.Run(ctx)
 
 	if result.Status != StatusError {
-		t.Errorf("expected StatusError for wrong location, got %v", result.Status)
+		t.Errorf("expected StatusError for stale file, got %v", result.Status)
 	}
 	// Should mention "untracked"
 	found := false
@@ -755,16 +652,16 @@ func TestClaudeSettingsCheck_GitStatusTrackedClean(t *testing.T) {
 	rigName := "testrig"
 
 	// Create a git repo to simulate a source repo
-	rigDir := filepath.Join(tmpDir, rigName, "witness", "rig")
+	rigDir := filepath.Join(tmpDir, rigName, "refinery", "rig")
 	if err := os.MkdirAll(rigDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 	initTestGitRepo(t, rigDir)
 
 	// Create settings and commit it (tracked, clean)
-	wrongSettings := filepath.Join(rigDir, ".claude", "settings.json")
-	createValidSettings(t, wrongSettings)
-	gitAddAndCommit(t, rigDir, wrongSettings)
+	staleSettings := filepath.Join(rigDir, ".claude", "settings.json")
+	createSettingsFile(t, staleSettings)
+	gitAddAndCommit(t, rigDir, staleSettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -772,7 +669,7 @@ func TestClaudeSettingsCheck_GitStatusTrackedClean(t *testing.T) {
 	result := check.Run(ctx)
 
 	if result.Status != StatusError {
-		t.Errorf("expected StatusError for wrong location, got %v", result.Status)
+		t.Errorf("expected StatusError for stale file, got %v", result.Status)
 	}
 	// Should mention "tracked but unmodified"
 	found := false
@@ -792,19 +689,19 @@ func TestClaudeSettingsCheck_GitStatusTrackedModified(t *testing.T) {
 	rigName := "testrig"
 
 	// Create a git repo to simulate a source repo
-	rigDir := filepath.Join(tmpDir, rigName, "witness", "rig")
+	rigDir := filepath.Join(tmpDir, rigName, "refinery", "rig")
 	if err := os.MkdirAll(rigDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 	initTestGitRepo(t, rigDir)
 
 	// Create settings and commit it
-	wrongSettings := filepath.Join(rigDir, ".claude", "settings.json")
-	createValidSettings(t, wrongSettings)
-	gitAddAndCommit(t, rigDir, wrongSettings)
+	staleSettings := filepath.Join(rigDir, ".claude", "settings.json")
+	createSettingsFile(t, staleSettings)
+	gitAddAndCommit(t, rigDir, staleSettings)
 
 	// Modify the file after commit
-	if err := os.WriteFile(wrongSettings, []byte(`{"modified": true}`), 0644); err != nil {
+	if err := os.WriteFile(staleSettings, []byte(`{"modified": true}`), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -814,7 +711,7 @@ func TestClaudeSettingsCheck_GitStatusTrackedModified(t *testing.T) {
 	result := check.Run(ctx)
 
 	if result.Status != StatusError {
-		t.Errorf("expected StatusError for wrong location, got %v", result.Status)
+		t.Errorf("expected StatusError for stale file, got %v", result.Status)
 	}
 	// Should mention "local modifications"
 	found := false
@@ -838,19 +735,19 @@ func TestClaudeSettingsCheck_FixSkipsModifiedFiles(t *testing.T) {
 	rigName := "testrig"
 
 	// Create a git repo to simulate a source repo
-	rigDir := filepath.Join(tmpDir, rigName, "witness", "rig")
+	rigDir := filepath.Join(tmpDir, rigName, "refinery", "rig")
 	if err := os.MkdirAll(rigDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 	initTestGitRepo(t, rigDir)
 
 	// Create settings and commit it
-	wrongSettings := filepath.Join(rigDir, ".claude", "settings.json")
-	createValidSettings(t, wrongSettings)
-	gitAddAndCommit(t, rigDir, wrongSettings)
+	staleSettings := filepath.Join(rigDir, ".claude", "settings.json")
+	createSettingsFile(t, staleSettings)
+	gitAddAndCommit(t, rigDir, staleSettings)
 
 	// Modify the file after commit
-	if err := os.WriteFile(wrongSettings, []byte(`{"modified": true}`), 0644); err != nil {
+	if err := os.WriteFile(staleSettings, []byte(`{"modified": true}`), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -869,7 +766,7 @@ func TestClaudeSettingsCheck_FixSkipsModifiedFiles(t *testing.T) {
 	}
 
 	// Verify file still exists (was skipped)
-	if _, err := os.Stat(wrongSettings); os.IsNotExist(err) {
+	if _, err := os.Stat(staleSettings); os.IsNotExist(err) {
 		t.Error("expected modified file to be preserved, but it was deleted")
 	}
 }
@@ -879,15 +776,15 @@ func TestClaudeSettingsCheck_FixDeletesUntrackedFiles(t *testing.T) {
 	rigName := "testrig"
 
 	// Create a git repo to simulate a source repo
-	rigDir := filepath.Join(tmpDir, rigName, "witness", "rig")
+	rigDir := filepath.Join(tmpDir, rigName, "refinery", "rig")
 	if err := os.MkdirAll(rigDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 	initTestGitRepo(t, rigDir)
 
-	// Create an untracked settings file (not git added)
-	wrongSettings := filepath.Join(rigDir, ".claude", "settings.json")
-	createValidSettings(t, wrongSettings)
+	// Create an untracked stale settings file (not git added)
+	staleSettings := filepath.Join(rigDir, ".claude", "settings.json")
+	createSettingsFile(t, staleSettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -904,7 +801,7 @@ func TestClaudeSettingsCheck_FixDeletesUntrackedFiles(t *testing.T) {
 	}
 
 	// Verify file was deleted
-	if _, err := os.Stat(wrongSettings); !os.IsNotExist(err) {
+	if _, err := os.Stat(staleSettings); !os.IsNotExist(err) {
 		t.Error("expected untracked file to be deleted")
 	}
 }
@@ -914,16 +811,16 @@ func TestClaudeSettingsCheck_FixDeletesTrackedCleanFiles(t *testing.T) {
 	rigName := "testrig"
 
 	// Create a git repo to simulate a source repo
-	rigDir := filepath.Join(tmpDir, rigName, "witness", "rig")
+	rigDir := filepath.Join(tmpDir, rigName, "refinery", "rig")
 	if err := os.MkdirAll(rigDir, 0755); err != nil {
 		t.Fatal(err)
 	}
 	initTestGitRepo(t, rigDir)
 
 	// Create settings and commit it (tracked, clean)
-	wrongSettings := filepath.Join(rigDir, ".claude", "settings.json")
-	createValidSettings(t, wrongSettings)
-	gitAddAndCommit(t, rigDir, wrongSettings)
+	staleSettings := filepath.Join(rigDir, ".claude", "settings.json")
+	createSettingsFile(t, staleSettings)
+	gitAddAndCommit(t, rigDir, staleSettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -940,145 +837,7 @@ func TestClaudeSettingsCheck_FixDeletesTrackedCleanFiles(t *testing.T) {
 	}
 
 	// Verify file was deleted
-	if _, err := os.Stat(wrongSettings); !os.IsNotExist(err) {
+	if _, err := os.Stat(staleSettings); !os.IsNotExist(err) {
 		t.Error("expected tracked clean file to be deleted")
-	}
-}
-
-func TestClaudeSettingsCheck_DetectsStaleCLAUDEmdAtTownRoot(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Create CLAUDE.md at town root (wrong location)
-	staleCLAUDEmd := filepath.Join(tmpDir, "CLAUDE.md")
-	if err := os.WriteFile(staleCLAUDEmd, []byte("# Mayor Context\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	check := NewClaudeSettingsCheck()
-	ctx := &CheckContext{TownRoot: tmpDir}
-
-	result := check.Run(ctx)
-
-	if result.Status != StatusError {
-		t.Errorf("expected StatusError for stale CLAUDE.md at town root, got %v", result.Status)
-	}
-
-	// Should mention wrong location
-	found := false
-	for _, d := range result.Details {
-		if strings.Contains(d, "CLAUDE.md") && strings.Contains(d, "wrong location") {
-			found = true
-			break
-		}
-	}
-	if !found {
-		t.Errorf("expected details to mention CLAUDE.md wrong location, got %v", result.Details)
-	}
-}
-
-func TestClaudeSettingsCheck_FixMovesCLAUDEmdToMayor(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Create mayor directory (needed for fix to create CLAUDE.md there)
-	mayorDir := filepath.Join(tmpDir, "mayor")
-	if err := os.MkdirAll(mayorDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create CLAUDE.md at town root (wrong location)
-	staleCLAUDEmd := filepath.Join(tmpDir, "CLAUDE.md")
-	if err := os.WriteFile(staleCLAUDEmd, []byte("# Mayor Context\n"), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	check := NewClaudeSettingsCheck()
-	ctx := &CheckContext{TownRoot: tmpDir}
-
-	// Run to detect
-	result := check.Run(ctx)
-	if result.Status != StatusError {
-		t.Fatalf("expected StatusError before fix, got %v", result.Status)
-	}
-
-	// Apply fix
-	if err := check.Fix(ctx); err != nil {
-		t.Fatalf("Fix failed: %v", err)
-	}
-
-	// Verify old file was deleted
-	if _, err := os.Stat(staleCLAUDEmd); !os.IsNotExist(err) {
-		t.Error("expected CLAUDE.md at town root to be deleted")
-	}
-
-	// Verify new file was created at mayor/
-	correctCLAUDEmd := filepath.Join(mayorDir, "CLAUDE.md")
-	if _, err := os.Stat(correctCLAUDEmd); os.IsNotExist(err) {
-		t.Error("expected CLAUDE.md to be created at mayor/")
-	}
-}
-
-func TestClaudeSettingsCheck_TownRootSettingsWarnsInsteadOfKilling(t *testing.T) {
-	tmpDir := t.TempDir()
-
-	// Create mayor directory (needed for fix to recreate settings there)
-	mayorDir := filepath.Join(tmpDir, "mayor")
-	if err := os.MkdirAll(mayorDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create settings.json at town root (wrong location - pollutes all agents)
-	staleTownRootDir := filepath.Join(tmpDir, ".claude")
-	if err := os.MkdirAll(staleTownRootDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-	staleTownRootSettings := filepath.Join(staleTownRootDir, "settings.json")
-	// Create valid settings content
-	settingsContent := `{
-		"env": {"PATH": "/usr/bin"},
-		"enabledPlugins": ["claude-code-expert"],
-		"hooks": {
-			"SessionStart": [{"matcher": "", "hooks": [{"type": "command", "command": "gt prime"}]}],
-			"Stop": [{"matcher": "", "hooks": [{"type": "command", "command": "gt handoff"}]}]
-		}
-	}`
-	if err := os.WriteFile(staleTownRootSettings, []byte(settingsContent), 0644); err != nil {
-		t.Fatal(err)
-	}
-
-	check := NewClaudeSettingsCheck()
-	ctx := &CheckContext{TownRoot: tmpDir}
-
-	// Run to detect
-	result := check.Run(ctx)
-	if result.Status != StatusError {
-		t.Fatalf("expected StatusError for town root settings, got %v", result.Status)
-	}
-
-	// Verify it's flagged as wrong location
-	foundWrongLocation := false
-	for _, d := range result.Details {
-		if strings.Contains(d, "wrong location") {
-			foundWrongLocation = true
-			break
-		}
-	}
-	if !foundWrongLocation {
-		t.Errorf("expected details to mention wrong location, got %v", result.Details)
-	}
-
-	// Apply fix - should NOT return error and should NOT kill sessions
-	// (session killing would require tmux which isn't available in tests)
-	if err := check.Fix(ctx); err != nil {
-		t.Fatalf("Fix failed: %v", err)
-	}
-
-	// Verify stale file was deleted
-	if _, err := os.Stat(staleTownRootSettings); !os.IsNotExist(err) {
-		t.Error("expected settings.json at town root to be deleted")
-	}
-
-	// Verify .claude directory was cleaned up (best-effort)
-	if _, err := os.Stat(staleTownRootDir); !os.IsNotExist(err) {
-		t.Error("expected .claude directory at town root to be deleted")
 	}
 }


### PR DESCRIPTION
## Summary

The claude_settings_check doctor check had backwards logic - it considered parent directories as CORRECT locations for settings when Claude Code actually requires settings in the working directory.

Changes:
- Detect settings in both old (settings.json) and new (settings.local.json) filenames
- Mark parent-directory settings as stale (should be deleted)
- Mark old settings.json files as stale (should be settings.local.json)
- Simplify Fix() to only delete - agent startup handles recreation
- Remove content validation (we only care about location/filename now)
- Update tests to match new behavior

### Why delete-only (no recreation)?

We considered having doctor recreate correct settings after deletion, but Claude Code only reads settings at startup - it doesn't hot-reload them during a session (see [anthropics/claude-code#5513](https://github.com/anthropics/claude-code/issues/5513) for a feature request to add `/reloadSettings`).

Recreating files would give a false sense of security since running agents wouldn't pick up the changes anyway. Instead, we:
1. Delete stale files
2. Warn that agents need restart
3. Let agent startup (EnsureSettingsForRole) create correct settings when they restart

This keeps the creation logic in one authoritative place.

## Test plan

- [x] All existing tests pass
- [x] New tests verify correct behavior for working directories vs parent directories
- [x] Manual: run `gt doctor` and verify it correctly identifies stale settings

## Related

- #993 (bootstrap files fix - this PR adds the doctor check portion)
- anthropics/claude-code#12962 (Claude Code doesn't traverse parent directories for settings)
- anthropics/claude-code#5513 (no hot-reload for settings - why we don't recreate)

---
🤖 Tackled with [Claude Code](https://claude.com/claude-code)