### PR TITLE
feat(doctor): add timing display for slow checks

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/doctor"
@@ -14,6 +15,7 @@ var (
 	doctorVerbose         bool
 	doctorRig             string
 	doctorRestartSessions bool
+	doctorSlow            string
 )
 
 var doctorCmd = &cobra.Command{
@@ -81,7 +83,8 @@ Patrol checks:
   - patrol-roles-have-prompts Verify role prompts exist
 
 Use --fix to attempt automatic fixes for issues that support it.
-Use --rig to check a specific rig instead of the entire workspace.`,
+Use --rig to check a specific rig instead of the entire workspace.
+Use --slow to highlight slow checks (default threshold: 1s, e.g. --slow=500ms).`,
 	RunE: runDoctor,
 }
 
@@ -90,6 +93,9 @@ func init() {
 	doctorCmd.Flags().BoolVarP(&doctorVerbose, "verbose", "v", false, "Show detailed output")
 	doctorCmd.Flags().StringVar(&doctorRig, "rig", "", "Check specific rig only")
 	doctorCmd.Flags().BoolVar(&doctorRestartSessions, "restart-sessions", false, "Restart patrol sessions when fixing stale settings (use with --fix)")
+	doctorCmd.Flags().StringVar(&doctorSlow, "slow", "", "Highlight slow checks (optional threshold, default 1s)")
+	// Allow --slow without a value (uses default 1s)
+	doctorCmd.Flags().Lookup("slow").NoOptDefVal = "1s"
 	rootCmd.AddCommand(doctorCmd)
 }
 
@@ -188,17 +194,27 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		d.RegisterAll(doctor.RigChecks()...)
 	}
 
+	// Parse slow threshold (0 = disabled)
+	var slowThreshold time.Duration
+	if doctorSlow != "" {
+		var err error
+		slowThreshold, err = time.ParseDuration(doctorSlow)
+		if err != nil {
+			return fmt.Errorf("invalid --slow duration %q: %w", doctorSlow, err)
+		}
+	}
+
 	// Run checks with streaming output
 	fmt.Println() // Initial blank line
 	var report *doctor.Report
 	if doctorFix {
-		report = d.FixStreaming(ctx, os.Stdout)
+		report = d.FixStreaming(ctx, os.Stdout, slowThreshold)
 	} else {
-		report = d.RunStreaming(ctx, os.Stdout)
+		report = d.RunStreaming(ctx, os.Stdout, slowThreshold)
 	}
 
 	// Print summary (checks were already printed during streaming)
-	report.PrintSummaryOnly(os.Stdout, doctorVerbose)
+	report.PrintSummaryOnly(os.Stdout, doctorVerbose, slowThreshold)
 
 	// Exit with error code if there are errors
 	if report.HasErrors() {

--- a/internal/doctor/doctor_test.go
+++ b/internal/doctor/doctor_test.go
@@ -209,7 +209,7 @@ func TestReport_Print(t *testing.T) {
 	})
 
 	var buf bytes.Buffer
-	r.Print(&buf, false)
+	r.Print(&buf, false, 0)
 
 	output := buf.String()
 	if output == "" {


### PR DESCRIPTION
## Summary

Add `--slow` flag to highlight checks that exceed a time threshold, helping identify performance bottlenecks.

## Features

- Default threshold is 1s, configurable via `--slow=500ms` or `--slow=2s`
- Shows hourglass icon (⏳) for slow checks with elapsed time
- Summary line shows slow count and slowest check

## Example output

```
  ✓  daemon Daemon is running (PID 756)
  ✓⏳role-bead-labels All role beads have gt:role label (2.0s)
  ✓⏳agent-beads-exist All 9 agent beads exist (3.5s)

✓ 53 passed  ⚠ 4 warnings  ✖ 0 failed  ⏳ 5 slow (slowest: agent-beads-exist 3.5s)
```

## Usage

```bash
gt doctor --slow           # Default 1s threshold
gt doctor --slow=500ms     # Custom threshold  
gt doctor --slow=2s        # Any Go duration
```

## Dependencies

This PR includes two commits:
1. `eec8b91f` - streaming output (same as #1010 / cf9ea8da)
2. `8f88e309` - `--slow` flag feature

Options:
- If #1010 is merged first, cherry-pick only `8f88e309` to add the `--slow` feature
- If streaming output is not desired, this can be rebased on upstream/main to include only the `--slow` feature

## Test plan

- [x] All existing doctor tests pass
- [x] Manual testing with various thresholds
- [x] Hourglass alignment verified (replaces 2 spaces to maintain column alignment)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)