### PR TITLE
fix(mail): handle hq- prefix in agentBeadIDToAddress

### DIFF
--- a/internal/mail/resolve.go
+++ b/internal/mail/resolve.go
@@ -341,13 +341,22 @@ func (r *Resolver) resolveChannel(name string) ([]Recipient, error) {
 }
 
 // agentBeadIDToAddress converts an agent bead ID to a mail address.
-// E.g., "gt-gastown-crew-max" → "gastown/crew/max"
+// Handles both gt- (rig agents) and hq- (town agents) prefixes:
+//   - hq-mayor → mayor/
+//   - hq-deacon → deacon/
+//   - gt-gastown-crew-max → gastown/crew/max
 func agentBeadIDToAddress(id string) string {
-	if !strings.HasPrefix(id, "gt-") {
+	var rest string
+
+	// Handle both gt- (rig agents) and hq- (town agents) prefixes
+	if strings.HasPrefix(id, "gt-") {
+		rest = strings.TrimPrefix(id, "gt-")
+	} else if strings.HasPrefix(id, "hq-") {
+		rest = strings.TrimPrefix(id, "hq-")
+	} else {
 		return ""
 	}
 
-	rest := strings.TrimPrefix(id, "gt-")
 	parts := strings.Split(rest, "-")
 
 	switch len(parts) {

--- a/internal/mail/resolve_test.go
+++ b/internal/mail/resolve_test.go
@@ -48,9 +48,13 @@ func TestAgentBeadIDToAddress(t *testing.T) {
 		id   string
 		want string
 	}{
-		// Town-level agents
+		// Town-level agents (gt- prefix)
 		{"gt-mayor", "mayor/"},
 		{"gt-deacon", "deacon/"},
+
+		// Town-level agents (hq- prefix)
+		{"hq-mayor", "mayor/"},
+		{"hq-deacon", "deacon/"},
 
 		// Rig singletons
 		{"gt-gastown-witness", "gastown/witness"},


### PR DESCRIPTION
## Summary
Fix "no agent found" error when sending mail to `mayor/` from rigs.

## Related Issue
N/A (discovered during testing)

## Changes
- Add `hq-` prefix support to `agentBeadIDToAddress` in `resolve.go`
- Add test cases for `hq-mayor` and `hq-deacon`

## Testing
- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)