### PR TITLE
feat(doctor): add streaming output for real-time check progress

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -188,16 +188,17 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		d.RegisterAll(doctor.RigChecks()...)
 	}
 
-	// Run checks
+	// Run checks with streaming output
+	fmt.Println() // Initial blank line
 	var report *doctor.Report
 	if doctorFix {
-		report = d.Fix(ctx)
+		report = d.FixStreaming(ctx, os.Stdout)
 	} else {
-		report = d.Run(ctx)
+		report = d.RunStreaming(ctx, os.Stdout)
 	}
 
-	// Print report
-	report.Print(os.Stdout, doctorVerbose)
+	// Print summary (checks were already printed during streaming)
+	report.PrintSummaryOnly(os.Stdout, doctorVerbose)
 
 	// Exit with error code if there are errors
 	if report.HasErrors() {


### PR DESCRIPTION
## Summary

- Shows each check name as it starts (with ○ icon), then overwrites the line with the result (✓/⚠/✖) when complete
- Provides real-time feedback so users can see which check is currently running
- Helps identify slow checks without needing special timing flags

## Changes

- Add `RunStreaming()` and `FixStreaming()` methods to Doctor
- Add `PrintSummaryOnly()` method to Report for post-streaming summary  
- Update `runDoctor` command to use streaming by default

## Example output

```
  ○  town-config-exists...  ✓  town-config-exists mayor/town.json exists
  ○  daemon...  ✓  daemon Daemon is running (PID 756)
```

Each check shows "○ name..." while running, then overwrites to "✓ name message" when complete.

## Test plan

- [x] All existing doctor tests pass
- [x] Manual testing shows streaming output works correctly
- [x] Carriage return properly overwrites running line

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)