### PR TITLE
feat(dog): add session management and delayed dispatch

### DIFF
--- a/internal/beads/beads_dog.go
+++ b/internal/beads/beads_dog.go
@@ -12,6 +12,7 @@ import (
 // Returns the created issue or an error.
 func (b *Beads) CreateDogAgentBead(name, location string) (*Issue, error) {
 	title := fmt.Sprintf("Dog: %s", name)
+	beadID := DogBeadIDTown(name) // Use canonical ID: hq-dog-<name>
 	labels := []string{
 		"gt:agent",
 		"role_type:dog",
@@ -21,6 +22,8 @@ func (b *Beads) CreateDogAgentBead(name, location string) (*Issue, error) {
 
 	args := []string{
 		"create", "--json",
+		"--id=" + beadID,
+		"--type=agent",
 		"--role-type=dog",
 		"--title=" + title,
 		"--labels=" + strings.Join(labels, ","),

--- a/internal/cmd/sling_dog.go
+++ b/internal/cmd/sling_dog.go
@@ -16,12 +16,23 @@ import (
 // Patterns:
 //   - "deacon/dogs" -> ("", true) - dispatch to any idle dog
 //   - "deacon/dogs/alpha" -> ("alpha", true) - dispatch to specific dog
+//   - "dog:" -> ("", true) - dispatch to any idle dog (shorthand)
+//   - "dog:alpha" -> ("alpha", true) - dispatch to specific dog (shorthand)
 func IsDogTarget(target string) (dogName string, isDog bool) {
 	target = strings.ToLower(target)
 
 	// Check for exact "deacon/dogs" (pool dispatch)
-	if target == "deacon/dogs" {
+	if target == "deacon/dogs" || target == "dog:" {
 		return "", true
+	}
+
+	// Check for "dog:<name>" shorthand (like rig:polecat syntax)
+	if strings.HasPrefix(target, "dog:") {
+		name := strings.TrimPrefix(target, "dog:")
+		if name != "" && !strings.Contains(name, "/") {
+			return name, true
+		}
+		return "", true // "dog:" without name = pool dispatch
 	}
 
 	// Check for "deacon/dogs/<name>" (specific dog)
@@ -35,18 +46,32 @@ func IsDogTarget(target string) (dogName string, isDog bool) {
 	return "", false
 }
 
+// DogDispatchOptions contains options for dispatching work to a dog.
+type DogDispatchOptions struct {
+	Create            bool   // Create dog if it doesn't exist
+	WorkDesc          string // Work description (formula or bead ID)
+	DelaySessionStart bool   // If true, don't start session (caller will start later)
+}
+
 // DogDispatchInfo contains information about a dog dispatch.
 type DogDispatchInfo struct {
 	DogName string // Name of the dog
 	AgentID string // Agent ID format (deacon/dogs/<name>)
-	Pane    string // Tmux pane (empty if no session)
+	Pane    string // Tmux pane (empty if session start was delayed)
 	Spawned bool   // True if dog was spawned (new)
+
+	// Internal fields for delayed session start
+	sessionDelayed bool
+	townRoot       string
+	workDesc       string
 }
 
 // DispatchToDog finds or spawns a dog for work dispatch.
 // If dogName is empty, finds an idle dog from the pool.
-// If create is true and no dogs exist, creates one.
-func DispatchToDog(dogName string, create bool) (*DogDispatchInfo, error) {
+// If opts.Create is true and no dogs exist, creates one.
+// opts.WorkDesc is recorded in the dog's state so we know what it's working on.
+// If opts.DelaySessionStart is true, the session is not started (caller must call StartDelayedSession).
+func DispatchToDog(dogName string, opts DogDispatchOptions) (*DogDispatchInfo, error) {
 	townRoot, err := workspace.FindFromCwd()
 	if err != nil {
 		return nil, fmt.Errorf("finding town root: %w", err)
@@ -67,7 +92,7 @@ func DispatchToDog(dogName string, create bool) (*DogDispatchInfo, error) {
 		// Specific dog requested
 		targetDog, err = mgr.Get(dogName)
 		if err != nil {
-			if create {
+			if opts.Create {
 				// Create the dog if it doesn't exist
 				targetDog, err = mgr.Add(dogName)
 				if err != nil {
@@ -87,7 +112,7 @@ func DispatchToDog(dogName string, create bool) (*DogDispatchInfo, error) {
 		}
 
 		if targetDog == nil {
-			if create {
+			if opts.Create {
 				// No idle dogs - create one
 				newName := generateDogName(mgr)
 				targetDog, err = mgr.Add(newName)
@@ -102,23 +127,40 @@ func DispatchToDog(dogName string, create bool) (*DogDispatchInfo, error) {
 		}
 	}
 
-	// Mark dog as working
-	if err := mgr.SetState(targetDog.Name, dog.StateWorking); err != nil {
-		return nil, fmt.Errorf("setting dog state: %w", err)
+	// Mark dog as working with the assigned work
+	if err := mgr.AssignWork(targetDog.Name, opts.WorkDesc); err != nil {
+		return nil, fmt.Errorf("assigning work to dog: %w", err)
 	}
 
 	// Build agent ID
 	agentID := fmt.Sprintf("deacon/dogs/%s", targetDog.Name)
 
-	// Try to find tmux session for the dog (dogs may run in tmux like polecats)
-	// Dogs use the pattern gt-{town}-deacon-{name}
-	townName, _ := workspace.GetTownName(townRoot)
-	sessionName := fmt.Sprintf("gt-%s-deacon-%s", townName, targetDog.Name)
+	// If delayed start, return info for later session start
+	if opts.DelaySessionStart {
+		fmt.Printf("Dog %s assigned (session start delayed)\n", targetDog.Name)
+		return &DogDispatchInfo{
+			DogName:        targetDog.Name,
+			AgentID:        agentID,
+			Pane:           "", // No pane yet
+			Spawned:        spawned,
+			sessionDelayed: true,
+			townRoot:       townRoot,
+			workDesc:       opts.WorkDesc,
+		}, nil
+	}
+
+	// Ensure dog session is running (start if needed)
 	t := tmux.NewTmux()
-	var pane string
-	if has, _ := t.HasSession(sessionName); has {
-		// Get the pane from the session
-		pane, _ = getSessionPane(sessionName)
+	sessMgr := dog.NewSessionManager(t, townRoot)
+
+	sessOpts := dog.SessionStartOptions{
+		WorkDesc: opts.WorkDesc,
+	}
+	pane, err := sessMgr.EnsureRunning(targetDog.Name, sessOpts)
+	if err != nil {
+		// Log but don't fail - dog state is set, session may start later
+		fmt.Printf("Warning: could not start dog session: %v\n", err)
+		pane = ""
 	}
 
 	return &DogDispatchInfo{
@@ -127,6 +169,29 @@ func DispatchToDog(dogName string, create bool) (*DogDispatchInfo, error) {
 		Pane:    pane,
 		Spawned: spawned,
 	}, nil
+}
+
+// StartDelayedSession starts the dog session after bead setup is complete.
+// This should only be called when DelaySessionStart was true during dispatch.
+func (d *DogDispatchInfo) StartDelayedSession() (string, error) {
+	if !d.sessionDelayed {
+		return d.Pane, nil // Session was already started
+	}
+
+	t := tmux.NewTmux()
+	sessMgr := dog.NewSessionManager(t, d.townRoot)
+
+	opts := dog.SessionStartOptions{
+		WorkDesc: d.workDesc,
+	}
+	pane, err := sessMgr.EnsureRunning(d.DogName, opts)
+	if err != nil {
+		return "", fmt.Errorf("starting dog session: %w", err)
+	}
+
+	d.Pane = pane
+	d.sessionDelayed = false
+	return pane, nil
 }
 
 // generateDogName creates a unique dog name for pool expansion.

--- a/internal/cmd/sling_dog_test.go
+++ b/internal/cmd/sling_dog_test.go
@@ -1,0 +1,102 @@
+package cmd
+
+import "testing"
+
+// TestIsDogTarget verifies the dog target pattern matching.
+// Dogs can be targeted via:
+//   - "deacon/dogs" -> pool dispatch (any idle dog)
+//   - "deacon/dogs/alpha" -> specific dog
+//   - "dog:" -> pool dispatch (shorthand)
+//   - "dog:alpha" -> specific dog (shorthand)
+func TestIsDogTarget(t *testing.T) {
+	tests := []struct {
+		target  string
+		wantDog string
+		wantIs  bool
+	}{
+		// Pool dispatch patterns
+		{"deacon/dogs", "", true},
+		{"dog:", "", true},
+		{"DEACON/DOGS", "", true}, // case insensitive
+		{"DOG:", "", true},
+
+		// Specific dog patterns
+		{"deacon/dogs/alpha", "alpha", true},
+		{"deacon/dogs/bravo", "bravo", true},
+		{"dog:alpha", "alpha", true},
+		{"dog:bravo", "bravo", true},
+		{"DOG:ALPHA", "alpha", true}, // case insensitive, name lowercased
+
+		// Invalid patterns - not dog targets
+		{"deacon", "", false},
+		{"deacon/", "", false},
+		{"deacon/dogs/", "", false},      // trailing slash, empty name
+		{"deacon/dogs/alpha/extra", "", false}, // too many segments
+		{"dog", "", false},               // missing colon
+		{"dogs:alpha", "", false},        // wrong prefix
+		{"polecat:alpha", "", false},
+		{"gastown/polecats/alpha", "", false},
+		{"mayor", "", false},
+		{"", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.target, func(t *testing.T) {
+			gotDog, gotIs := IsDogTarget(tt.target)
+			if gotIs != tt.wantIs {
+				t.Errorf("IsDogTarget(%q) isDog = %v, want %v", tt.target, gotIs, tt.wantIs)
+			}
+			if gotDog != tt.wantDog {
+				t.Errorf("IsDogTarget(%q) dogName = %q, want %q", tt.target, gotDog, tt.wantDog)
+			}
+		})
+	}
+}
+
+// TestDogDispatchInfoDelayedSession verifies the delayed session start pattern.
+// When DelaySessionStart is true:
+//   - DispatchToDog returns with Pane="" and sessionDelayed=true
+//   - StartDelayedSession() must be called to actually start the session
+// This prevents the race condition where dogs start before their hook is set.
+func TestDogDispatchInfoDelayedSession(t *testing.T) {
+	// Test that DogDispatchInfo correctly tracks delayed state
+	info := &DogDispatchInfo{
+		DogName:        "alpha",
+		AgentID:        "deacon/dogs/alpha",
+		Pane:           "",    // Empty when delayed
+		Spawned:        false,
+		sessionDelayed: true,
+		townRoot:       "/tmp/test",
+		workDesc:       "test-work",
+	}
+
+	// Verify initial state
+	if info.Pane != "" {
+		t.Errorf("delayed dispatch should have empty Pane, got %q", info.Pane)
+	}
+	if !info.sessionDelayed {
+		t.Error("sessionDelayed should be true for delayed dispatch")
+	}
+
+	// Note: We can't test StartDelayedSession without mocking tmux,
+	// but we verify the struct correctly holds the delayed state.
+}
+
+// TestDogDispatchOptionsStruct verifies the DogDispatchOptions fields.
+func TestDogDispatchOptionsStruct(t *testing.T) {
+	opts := DogDispatchOptions{
+		Create:            true,
+		WorkDesc:          "mol-convoy-feed",
+		DelaySessionStart: true,
+	}
+
+	if !opts.Create {
+		t.Error("Create should be true")
+	}
+	if opts.WorkDesc != "mol-convoy-feed" {
+		t.Errorf("WorkDesc = %q, want %q", opts.WorkDesc, "mol-convoy-feed")
+	}
+	if !opts.DelaySessionStart {
+		t.Error("DelaySessionStart should be true")
+	}
+}

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -419,6 +419,9 @@ func agentIDToBeadID(agentID, townRoot string) string {
 		return beads.CrewBeadIDWithPrefix(prefix, rig, parts[2])
 	case len(parts) == 3 && parts[1] == "polecats":
 		return beads.PolecatBeadIDWithPrefix(prefix, rig, parts[2])
+	case len(parts) == 3 && parts[0] == "deacon" && parts[1] == "dogs":
+		// Dogs are town-level agents with hq- prefix
+		return beads.DogBeadIDTown(parts[2])
 	default:
 		return ""
 	}
@@ -476,6 +479,10 @@ func updateAgentHookBead(agentID, beadID, workDir, townBeadsDir string) {
 	if err := bd.SetHookBead(agentBeadID, beadID); err != nil {
 		// Log warning instead of silent ignore - helps debug cross-beads issues
 		fmt.Fprintf(os.Stderr, "Warning: couldn't set agent %s hook: %v\n", agentBeadID, err)
+		// Dogs created before canonical IDs need recreation: gt dog rm <name> && gt dog add <name>
+		if strings.Contains(agentBeadID, "-dog-") {
+			fmt.Fprintf(os.Stderr, "  (Old dog? Recreate with: gt dog rm <name> && gt dog add <name>)\n")
+		}
 		return
 	}
 }

--- a/internal/dog/session_manager.go
+++ b/internal/dog/session_manager.go
@@ -1,0 +1,267 @@
+// Package dog provides dog session management for Deacon's helper workers.
+package dog
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/claude"
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/tmux"
+	"github.com/steveyegge/gastown/internal/workspace"
+)
+
+// Session errors
+var (
+	ErrSessionRunning  = errors.New("session already running")
+	ErrSessionNotFound = errors.New("session not found")
+)
+
+// SessionManager handles dog session lifecycle.
+type SessionManager struct {
+	tmux     *tmux.Tmux
+	townRoot string
+	townName string
+}
+
+// NewSessionManager creates a new dog session manager.
+func NewSessionManager(t *tmux.Tmux, townRoot string) *SessionManager {
+	townName, _ := workspace.GetTownName(townRoot)
+	return &SessionManager{
+		tmux:     t,
+		townRoot: townRoot,
+		townName: townName,
+	}
+}
+
+// SessionStartOptions configures dog session startup.
+type SessionStartOptions struct {
+	// WorkDesc is the work description (formula or bead ID) for the startup prompt.
+	WorkDesc string
+
+	// AgentOverride specifies an alternate agent (e.g., "gemini", "claude-haiku").
+	AgentOverride string
+}
+
+// SessionInfo contains information about a running dog session.
+type SessionInfo struct {
+	// DogName is the dog name.
+	DogName string `json:"dog_name"`
+
+	// SessionID is the tmux session identifier.
+	SessionID string `json:"session_id"`
+
+	// Running indicates if the session is currently active.
+	Running bool `json:"running"`
+
+	// Attached indicates if someone is attached to the session.
+	Attached bool `json:"attached,omitempty"`
+
+	// Created is when the session was created.
+	Created time.Time `json:"created,omitempty"`
+}
+
+// SessionName generates the tmux session name for a dog.
+// Pattern: gt-{town}-deacon-{name}
+func (m *SessionManager) SessionName(dogName string) string {
+	return fmt.Sprintf("gt-%s-deacon-%s", m.townName, dogName)
+}
+
+// kennelPath returns the path to the dog's kennel directory.
+func (m *SessionManager) kennelPath(dogName string) string {
+	return filepath.Join(m.townRoot, "deacon", "dogs", dogName)
+}
+
+// Start creates and starts a new session for a dog.
+// Dogs run Claude sessions that check mail for work and execute formulas.
+func (m *SessionManager) Start(dogName string, opts SessionStartOptions) error {
+	kennelDir := m.kennelPath(dogName)
+	if _, err := os.Stat(kennelDir); os.IsNotExist(err) {
+		return fmt.Errorf("%w: %s", ErrDogNotFound, dogName)
+	}
+
+	sessionID := m.SessionName(dogName)
+
+	// Check if session already exists
+	running, err := m.tmux.HasSession(sessionID)
+	if err != nil {
+		return fmt.Errorf("checking session: %w", err)
+	}
+	if running {
+		// Session exists - check if Claude is actually running
+		if m.tmux.IsClaudeRunning(sessionID) {
+			return fmt.Errorf("%w: %s", ErrSessionRunning, sessionID)
+		}
+		// Zombie session - kill and recreate
+		if err := m.tmux.KillSessionWithProcesses(sessionID); err != nil {
+			return fmt.Errorf("killing zombie session: %w", err)
+		}
+	}
+
+	// Ensure Claude settings exist for dogs
+	if err := claude.EnsureSettingsForRole(kennelDir, "dog"); err != nil {
+		return fmt.Errorf("ensuring Claude settings: %w", err)
+	}
+
+	// Build startup prompt - dogs check mail for work
+	address := fmt.Sprintf("deacon/dogs/%s", dogName)
+	workInfo := ""
+	if opts.WorkDesc != "" {
+		workInfo = fmt.Sprintf(" Work assigned: %s.", opts.WorkDesc)
+	}
+	beacon := session.FormatStartupBeacon(session.BeaconConfig{
+		Recipient: address,
+		Sender:    "deacon",
+		Topic:     "assigned",
+	})
+	initialPrompt := fmt.Sprintf("I am Dog %s.%s Check mail for work: `gt mail inbox`. Execute assigned formula/bead. When done, send DOG_DONE mail to deacon/ and return to idle.", dogName, workInfo)
+
+	// Build startup command
+	startupCmd, err := config.BuildAgentStartupCommandWithAgentOverride("dog", "", m.townRoot, "", beacon+"\n"+initialPrompt, opts.AgentOverride)
+	if err != nil {
+		return fmt.Errorf("building startup command: %w", err)
+	}
+
+	// Create session with command
+	if err := m.tmux.NewSessionWithCommand(sessionID, kennelDir, startupCmd); err != nil {
+		return fmt.Errorf("creating tmux session: %w", err)
+	}
+
+	// Set environment variables
+	envVars := config.AgentEnv(config.AgentEnvConfig{
+		Role:     "dog",
+		TownRoot: m.townRoot,
+	})
+	for k, v := range envVars {
+		_ = m.tmux.SetEnvironment(sessionID, k, v)
+	}
+
+	// Apply dog theming
+	theme := tmux.DogTheme()
+	_ = m.tmux.ConfigureGasTownSession(sessionID, theme, "", dogName, "dog")
+
+	// Wait for Claude to start
+	if err := m.tmux.WaitForCommand(sessionID, constants.SupportedShells, constants.ClaudeStartTimeout); err != nil {
+		_ = m.tmux.KillSessionWithProcesses(sessionID)
+		return fmt.Errorf("waiting for dog to start: %w", err)
+	}
+
+	// Accept bypass permissions warning if it appears
+	_ = m.tmux.AcceptBypassPermissionsWarning(sessionID)
+
+	time.Sleep(constants.ShutdownNotifyDelay)
+
+	// Verify session survived startup
+	running, err = m.tmux.HasSession(sessionID)
+	if err != nil {
+		return fmt.Errorf("verifying session: %w", err)
+	}
+	if !running {
+		return fmt.Errorf("session %s died during startup", sessionID)
+	}
+
+	return nil
+}
+
+// Stop terminates a dog session.
+func (m *SessionManager) Stop(dogName string, force bool) error {
+	sessionID := m.SessionName(dogName)
+
+	running, err := m.tmux.HasSession(sessionID)
+	if err != nil {
+		return fmt.Errorf("checking session: %w", err)
+	}
+	if !running {
+		return ErrSessionNotFound
+	}
+
+	// Try graceful shutdown first
+	if !force {
+		_ = m.tmux.SendKeysRaw(sessionID, "C-c")
+		time.Sleep(100 * time.Millisecond)
+	}
+
+	if err := m.tmux.KillSessionWithProcesses(sessionID); err != nil {
+		return fmt.Errorf("killing session: %w", err)
+	}
+
+	return nil
+}
+
+// IsRunning checks if a dog session is active.
+func (m *SessionManager) IsRunning(dogName string) (bool, error) {
+	sessionID := m.SessionName(dogName)
+	return m.tmux.HasSession(sessionID)
+}
+
+// Status returns detailed status for a dog session.
+func (m *SessionManager) Status(dogName string) (*SessionInfo, error) {
+	sessionID := m.SessionName(dogName)
+
+	running, err := m.tmux.HasSession(sessionID)
+	if err != nil {
+		return nil, fmt.Errorf("checking session: %w", err)
+	}
+
+	info := &SessionInfo{
+		DogName:   dogName,
+		SessionID: sessionID,
+		Running:   running,
+	}
+
+	if !running {
+		return info, nil
+	}
+
+	tmuxInfo, err := m.tmux.GetSessionInfo(sessionID)
+	if err != nil {
+		return info, nil
+	}
+
+	info.Attached = tmuxInfo.Attached
+
+	return info, nil
+}
+
+// GetPane returns the pane ID for a dog session.
+func (m *SessionManager) GetPane(dogName string) (string, error) {
+	sessionID := m.SessionName(dogName)
+
+	running, err := m.tmux.HasSession(sessionID)
+	if err != nil {
+		return "", fmt.Errorf("checking session: %w", err)
+	}
+	if !running {
+		return "", ErrSessionNotFound
+	}
+
+	// Get pane ID from session
+	pane, err := m.tmux.GetPaneID(sessionID)
+	if err != nil {
+		return "", fmt.Errorf("getting pane: %w", err)
+	}
+
+	return pane, nil
+}
+
+// EnsureRunning ensures a dog session is running, starting it if needed.
+// Returns the pane ID.
+func (m *SessionManager) EnsureRunning(dogName string, opts SessionStartOptions) (string, error) {
+	running, err := m.IsRunning(dogName)
+	if err != nil {
+		return "", err
+	}
+
+	if !running {
+		if err := m.Start(dogName, opts); err != nil {
+			return "", err
+		}
+	}
+
+	return m.GetPane(dogName)
+}

--- a/internal/tmux/theme.go
+++ b/internal/tmux/theme.go
@@ -40,6 +40,12 @@ func DeaconTheme() Theme {
 	return Theme{Name: "deacon", BG: "#2d1f3d", FG: "#c0b0d0"}
 }
 
+// DogTheme returns the theme for Dog sessions.
+// Brown/tan - earthy, loyal worker aesthetic.
+func DogTheme() Theme {
+	return Theme{Name: "dog", BG: "#3d2f1f", FG: "#d0c0a0"}
+}
+
 // GetThemeByName finds a theme by name from the default palette.
 // Returns nil if not found.
 func GetThemeByName(name string) *Theme {


### PR DESCRIPTION
## Summary

- **Dog Session Manager** - New `session_manager.go` for dog session lifecycle (start/stop/status)
- **Delayed Session Start** - Fixes race condition: session starts AFTER hook is set, not before
- **Canonical Bead IDs** - Dogs get proper `hq-dog-<name>` agent beads with `--type=agent`
- **`dog:name` Shorthand** - New syntax: `dog:alpha` instead of `deacon/dogs/alpha`

## Problem

As similar issue to one for polecats, when dispatching work to dogs, the session started before the hook was set. Dogs would run `gt prime` on startup and pick up deacon patrol tasks instead of their assigned work (e.g., `mol-convoy-feed`).

## Solution

Delay session start until after the hook is set:
```
1. Dog assigned (session NOT started yet)
2. Wisp created, hook attached to dog
3. Session started (dog sees hook via gt prime)
```

## Files Changed

| File | Change |
|------|--------|
| `internal/dog/session_manager.go` | **NEW** - Dog session lifecycle (267 lines) |
| `internal/cmd/sling_dog.go` | `DogDispatchOptions`, `StartDelayedSession()` |
| `internal/cmd/sling.go` | Use delayed start for dog dispatch |
| `internal/cmd/sling_formula.go` | Use delayed start for formula dispatch to dogs |
| `internal/cmd/sling_helpers.go` | `agentIDToBeadID()` for dogs, old dog warning |
| `internal/beads/beads_dog.go` | Canonical `--id=hq-dog-<name>`, `--type=agent` |
| `internal/tmux/theme.go` | Add `DogTheme()` |
| `internal/cmd/sling_dog_test.go` | **NEW** - Tests for dog dispatch |

## Backwards Compatibility

Old dogs (with non-canonical bead IDs) show warning:
```
Warning: couldn't set agent hq-dog-alpha hook: ...
  (Old dog? Recreate with: gt dog rm <name> && gt dog add <name>)
```
Work dispatch still functions - only agent bead tracking affected.

## Test Plan

- [x] `go test ./internal/cmd/... -run TestIsDogTarget` - all pass
- [x] `go test ./internal/cmd/... -run TestDogDispatch` - all pass  
- [x] Manual: `gt sling mol-boot-triage dog:charlie` - session starts after hook set

🤖 Generated with [Claude Code](https://claude.com/claude-code)