### PR TITLE
fix: allow polecat to delete its own worktree on gt done

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -765,7 +765,8 @@ func selfNukePolecat(roleInfo RoleInfo, _ string) error {
 
 	// Use nuclear=true since we know we just pushed our work
 	// The branch is pushed, MR is created, we're clean
-	if err := mgr.RemoveWithOptions(roleInfo.Polecat, true, true); err != nil {
+	// selfNuke=true because polecat is deleting its own worktree from inside it
+	if err := mgr.RemoveWithOptions(roleInfo.Polecat, true, true, true); err != nil {
 		return fmt.Errorf("removing worktree: %w", err)
 	}
 

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1127,7 +1127,8 @@ func runPolecatNuke(cmd *cobra.Command, args []string) error {
 		}
 
 		// Step 3: Delete worktree (nuclear mode - bypass all safety checks)
-		if err := p.mgr.RemoveWithOptions(p.polecatName, true, true); err != nil {
+		// selfNuke=false because this is an external nuke command, not polecat self-deleting
+		if err := p.mgr.RemoveWithOptions(p.polecatName, true, true, false); err != nil {
 			if errors.Is(err, polecat.ErrPolecatNotFound) {
 				fmt.Printf("  %s worktree already gone\n", style.Dim.Render("○"))
 			} else {
@@ -1336,7 +1337,7 @@ func runPolecatStale(cmd *cobra.Command, args []string) error {
 					continue
 				}
 				fmt.Printf("  Nuking %s...", info.Name)
-				if err := mgr.RemoveWithOptions(info.Name, true, false); err != nil {
+				if err := mgr.RemoveWithOptions(info.Name, true, false, false); err != nil {
 					fmt.Printf(" %s (%v)\n", style.Error.Render("failed"), err)
 				} else {
 					fmt.Printf(" %s\n", style.Success.Render("done"))

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -775,7 +775,8 @@ func cleanupPolecats(townRoot string) {
 			}
 
 			// Clean: remove worktree and branch
-			if err := polecatMgr.RemoveWithOptions(p.Name, true, shutdownNuclear); err != nil {
+			// selfNuke=false because this is gt start --shutdown cleanup, not polecat self-deleting
+			if err := polecatMgr.RemoveWithOptions(p.Name, true, shutdownNuclear, false); err != nil {
 				fmt.Printf("  %s %s/%s: cleanup failed: %v\n",
 					style.Dim.Render("○"), r.Name, p.Name, err)
 				totalSkipped++


### PR DESCRIPTION
## Problem

When a polecat completes work and calls `gt done`, the worktree is not deleted. The polecat session exits but the worktree remains on disk, accumulating stale worktrees over time.

## Root Cause

In `internal/polecat/manager.go:532-547`, `RemoveWithOptions()` has a safety check that prevents deleting a worktree when the shell's current working directory is inside it:

```go
cwd, cwdErr := os.Getwd()
if cwdErr == nil {
    cwdAbs, _ := filepath.Abs(cwd)
    cloneAbs, _ := filepath.Abs(clonePath)
    polecatAbs, _ := filepath.Abs(polecatDir)

    if strings.HasPrefix(cwdAbs, cloneAbs) || strings.HasPrefix(cwdAbs, polecatAbs) {
        return fmt.Errorf("%w: your shell is in %s\n\nPlease cd elsewhere first...",
            ErrShellInWorktree, cwd, m.rig.Name, name)
    }
}
```

This check exists to protect interactive user shells — deleting a directory that is the shell's cwd causes all subsequent commands to fail with exit code 1.

**The bug:** When a polecat calls `gt done`, it's running *inside* its own worktree by design. The polecat **wants** to delete its worktree, and the session will be killed immediately after, so "breaking" the shell is expected and harmless. However, the safety check runs unconditionally (even with `force=true` and `nuclear=true`), blocking the self-nuke operation.

## Solution

Add a `selfNuke bool` parameter to `RemoveWithOptions()`:

```go
func (m *Manager) RemoveWithOptions(name string, force, nuclear, selfNuke bool) error
```

When `selfNuke=true`, the cwd-in-worktree check is bypassed. This allows polecats to delete their own worktrees while preserving the safety check for external operations.

## Changes

| File | Change |
|------|--------|
| `internal/polecat/manager.go` | Add `selfNuke` parameter, wrap cwd check in `if !selfNuke` |
| `internal/cmd/done.go` | Pass `selfNuke=true` for polecat self-deletion |
| `internal/cmd/polecat.go` | Pass `selfNuke=false` for `gt polecat nuke` and stale cleanup |
| `internal/cmd/start.go` | Pass `selfNuke=false` for `gt start --shutdown` cleanup |

Fixes #1022

🤖 Generated with [Claude Code](https://claude.com/claude-code)