### PR TITLE
Agent-agnostic zombie detection

### DIFF
--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -352,7 +352,8 @@ func ensureAgentReady(sessionName string) error {
 	}
 
 	// Claude-only: accept bypass permissions warning if present
-	if t.IsClaudeRunning(sessionName) {
+	agentName, _ := t.GetEnvironment(sessionName, "GT_AGENT")
+	if agentName == "" || agentName == "claude" {
 		_ = t.AcceptBypassPermissionsWarning(sessionName)
 
 		// PRAGMATIC APPROACH: fixed delay rather than prompt detection.

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -109,7 +109,7 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		Name:                AgentClaude,
 		Command:             "claude",
 		Args:                []string{"--dangerously-skip-permissions"},
-		ProcessNames:        []string{"node"}, // Claude runs as Node.js
+		ProcessNames:        []string{"node", "claude"}, // Claude runs as Node.js
 		SessionIDEnv:        "CLAUDE_SESSION_ID",
 		ResumeFlag:          "--resume",
 		ResumeStyle:         "flag",
@@ -192,7 +192,7 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 			// Auto-approve all tool calls (equivalent to --dangerously-skip-permissions)
 			"OPENCODE_PERMISSION": `{"*":"allow"}`,
 		},
-		ProcessNames:        []string{"opencode", "node"}, // Runs as Node.js
+		ProcessNames:        []string{"opencode", "node", "bun"}, // Runs as Node.js or Bun
 		SessionIDEnv:        "",                           // OpenCode manages sessions internally
 		ResumeFlag:          "",                           // No resume support yet
 		ResumeStyle:         "",
@@ -429,8 +429,8 @@ func GetSessionIDEnvVar(agentName string) string {
 func GetProcessNames(agentName string) []string {
 	info := GetAgentPresetByName(agentName)
 	if info == nil || len(info.ProcessNames) == 0 {
-		// Default to Claude's process name for backwards compatibility
-		return []string{"node"}
+		// Default to Claude's process names for backwards compatibility
+		return []string{"node", "claude"}
 	}
 	return info.ProcessNames
 }

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -384,13 +384,14 @@ func TestGetProcessNames(t *testing.T) {
 		agentName string
 		want      []string
 	}{
-		{"claude", []string{"node"}},
+		{"claude", []string{"node", "claude"}},
 		{"gemini", []string{"gemini"}},
 		{"codex", []string{"codex"}},
 		{"cursor", []string{"cursor-agent"}},
 		{"auggie", []string{"auggie"}},
 		{"amp", []string{"amp"}},
-		{"unknown", []string{"node"}}, // Falls back to Claude's process
+		{"opencode", []string{"opencode", "node", "bun"}},
+		{"unknown", []string{"node", "claude"}}, // Falls back to Claude's process
 	}
 
 	for _, tt := range tests {
@@ -692,15 +693,15 @@ func TestOpenCodeAgentPreset(t *testing.T) {
 		t.Errorf("OPENCODE_PERMISSION = %q, want {\"*\":\"allow\"}", permission)
 	}
 
-	// Check ProcessNames for detection
-	if len(info.ProcessNames) != 2 {
-		t.Errorf("opencode ProcessNames length = %d, want 2", len(info.ProcessNames))
+	// Check ProcessNames for detection (opencode, node, bun)
+	if len(info.ProcessNames) != 3 {
+		t.Errorf("opencode ProcessNames length = %d, want 3", len(info.ProcessNames))
 	}
-	if info.ProcessNames[0] != "opencode" {
-		t.Errorf("opencode ProcessNames[0] = %q, want opencode", info.ProcessNames[0])
-	}
-	if info.ProcessNames[1] != "node" {
-		t.Errorf("opencode ProcessNames[1] = %q, want node", info.ProcessNames[1])
+	expectedNames := []string{"opencode", "node", "bun"}
+	for i, want := range expectedNames {
+		if i < len(info.ProcessNames) && info.ProcessNames[i] != want {
+			t.Errorf("opencode ProcessNames[%d] = %q, want %q", i, info.ProcessNames[i], want)
+		}
 	}
 
 	// Check hooks support

--- a/internal/crew/manager.go
+++ b/internal/crew/manager.go
@@ -464,8 +464,8 @@ func (m *Manager) Start(name string, opts StartOptions) error {
 				return fmt.Errorf("killing existing session: %w", err)
 			}
 		} else {
-			// Normal start - session exists, check if Claude is actually running
-			if t.IsClaudeRunning(sessionID) {
+			// Normal start - session exists, check if agent is actually running
+			if t.IsAgentAlive(sessionID) {
 				return fmt.Errorf("%w: %s", ErrSessionRunning, sessionID)
 			}
 			// Zombie session - kill and recreate.
@@ -537,10 +537,10 @@ func (m *Manager) Start(name string, opts StartOptions) error {
 	// Set up C-b n/p keybindings for crew session cycling (non-fatal)
 	_ = t.SetCrewCycleBindings(sessionID)
 
-	// Note: We intentionally don't wait for Claude to start here.
+	// Note: We intentionally don't wait for the agent to start here.
 	// The session is created in detached mode, and blocking for 60 seconds
-	// serves no purpose. If the caller needs to know when Claude is ready,
-	// they can check with IsClaudeRunning().
+	// serves no purpose. If the caller needs to know when the agent is ready,
+	// they can check with IsAgentAlive().
 
 	return nil
 }

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -833,8 +833,8 @@ func (d *Daemon) checkRigGUPPViolations(rigName string) {
 		polecatName := strings.TrimPrefix(agent.ID, prefix)
 		sessionName := fmt.Sprintf("gt-%s-%s", rigName, polecatName)
 
-		// Check if tmux session exists and Claude is running
-		if d.tmux.IsClaudeRunning(sessionName) {
+		// Check if tmux session exists and agent is running
+		if d.tmux.IsAgentAlive(sessionName) {
 			// Session is alive - check if it's been stuck too long
 			updatedAt, err := time.Parse(time.RFC3339, agent.UpdatedAt)
 			if err != nil {
@@ -928,7 +928,7 @@ func (d *Daemon) checkRigOrphanedWork(rigName string) {
 		sessionName := fmt.Sprintf("gt-%s-%s", rigName, polecatName)
 
 		// Session running = not orphaned (work is being processed)
-		if d.tmux.IsClaudeRunning(sessionName) {
+		if d.tmux.IsAgentAlive(sessionName) {
 			continue
 		}
 

--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -58,11 +58,11 @@ func (m *Manager) Start(agentOverride string) error {
 	// Check if session already exists
 	running, _ := t.HasSession(sessionID)
 	if running {
-		// Session exists - check if Claude is actually running (healthy vs zombie)
-		if t.IsClaudeRunning(sessionID) {
+		// Session exists - check if agent is actually running (healthy vs zombie)
+		if t.IsAgentAlive(sessionID) {
 			return ErrAlreadyRunning
 		}
-		// Zombie - tmux alive but Claude dead. Kill and recreate.
+		// Zombie - tmux alive but agent dead. Kill and recreate.
 		// Use KillSessionWithProcesses to ensure all descendant processes are killed.
 		if err := t.KillSessionWithProcesses(sessionID); err != nil {
 			return fmt.Errorf("killing zombie session: %w", err)

--- a/internal/doctor/zombie_check.go
+++ b/internal/doctor/zombie_check.go
@@ -72,7 +72,7 @@ func (c *ZombieSessionCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 
 		// Check if Claude is running in this session
-		if t.IsClaudeRunning(sess) {
+		if t.IsAgentAlive(sess) {
 			healthyCount++
 		} else {
 			zombies = append(zombies, sess)

--- a/internal/mayor/manager.go
+++ b/internal/mayor/manager.go
@@ -57,11 +57,11 @@ func (m *Manager) Start(agentOverride string) error {
 	// Check if session already exists
 	running, _ := t.HasSession(sessionID)
 	if running {
-		// Session exists - check if Claude is actually running (healthy vs zombie)
-		if t.IsClaudeRunning(sessionID) {
+		// Session exists - check if agent is actually running (healthy vs zombie)
+		if t.IsAgentAlive(sessionID) {
 			return ErrAlreadyRunning
 		}
-		// Zombie - tmux alive but Claude dead. Kill and recreate.
+		// Zombie - tmux alive but agent dead. Kill and recreate.
 		if err := t.KillSession(sessionID); err != nil {
 			return fmt.Errorf("killing zombie session: %w", err)
 		}

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -97,15 +97,11 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 	// Check if session already exists
 	running, _ := t.HasSession(sessionID)
 	if running {
-		// Session exists - check if Claude is actually running (healthy vs zombie)
-		// Use IsClaudeRunning for robust detection: Claude can report as "node", "claude",
-		// or version number like "2.0.76". IsAgentRunning with just "node" was too strict
-		// and caused healthy sessions to be killed. See: gastown#566
-		if t.IsClaudeRunning(sessionID) {
-			// Healthy - Claude is running
+		// Session exists - check if agent is actually running (healthy vs zombie)
+		if t.IsAgentAlive(sessionID) {
 			return ErrAlreadyRunning
 		}
-		// Zombie - tmux alive but Claude dead. Kill and recreate.
+		// Zombie - tmux alive but agent dead. Kill and recreate.
 		_, _ = fmt.Fprintln(m.output, "⚠ Detected zombie session (tmux alive, agent dead). Recreating...")
 		if err := t.KillSession(sessionID); err != nil {
 			return fmt.Errorf("killing zombie session: %w", err)

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -101,7 +101,7 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	running, _ := t.HasSession(sessionID)
 	if running {
 		// Session exists - check if Claude is actually running (healthy vs zombie)
-		if t.IsClaudeRunning(sessionID) {
+		if t.IsAgentAlive(sessionID) {
 			// Healthy - Claude is running
 			return ErrAlreadyRunning
 		}


### PR DESCRIPTION
## Summary

Fixes #1025 - Daemon kills non-Claude agent sessions as zombies

Replace Claude-specific `IsClaudeRunning()` with unified `IsAgentAlive()` that works for all agent types.

## Changes

### Core Detection (`internal/tmux/tmux.go`)

**Removed:**
- `IsClaudeRunning()` - hardcoded Claude detection
- `hasClaudeChild()` - hardcoded child process check
- `versionPattern` regex - no longer needed

**Added:**
- `IsAgentAlive(session)` - reads `GT_AGENT` env, calls `IsRuntimeRunning` with appropriate process names
- `hasChildWithNames(pid, names)` - parameterized child process detection
- `IsRuntimeRunning` now checks both direct pane command AND child processes for shell-launched agents

```go
func (t *Tmux) IsAgentAlive(session string) bool {
    agentName, _ := t.GetEnvironment(session, "GT_AGENT")
    processNames := config.GetProcessNames(agentName)
    return t.IsRuntimeRunning(session, processNames)
}
```

### Agent Configuration (`internal/config/agents.go`)

Updated ProcessNames for proper detection:

| Agent | Before | After |
|-------|--------|-------|
| Claude | `["node"]` | `["node", "claude"]` |
| OpenCode | `["opencode", "node"]` | `["opencode", "node", "bun"]` |

### Callers Updated (8 files)

All `IsClaudeRunning(session)` calls replaced with `IsAgentAlive(session)`:

- `internal/daemon/lifecycle.go` - patrol zombie checks
- `internal/witness/manager.go` - polecat health monitoring
- `internal/crew/manager.go` - session startup validation
- `internal/refinery/manager.go` - merge queue processor
- `internal/deacon/manager.go` - deacon health
- `internal/mayor/manager.go` - mayor health
- `internal/doctor/zombie_check.go` - diagnostic checks

### Tests Updated (`internal/tmux/tmux_test.go`, `internal/config/agents_test.go`)

- `TestHasClaudeChild` → `TestHasChildWithNames`
- `TestGetProcessNames` - updated expected values
- `TestOpenCodeAgentPreset` - expects 3 ProcessNames now

## How It Works

1. Agent starts in tmux session with `GT_AGENT=opencode` (or claude, gemini, etc.) in session environment
2. Zombie detection calls `IsAgentAlive(session)`
3. `IsAgentAlive` reads `GT_AGENT` from session env
4. Looks up ProcessNames from agent config (e.g., `["opencode", "node", "bun"]`)
5. `IsRuntimeRunning` checks pane command OR child processes against ProcessNames
6. Returns true if any match found → session is alive, not a zombie

🤖 Generated with [Claude Code](https://claude.ai/code)