### PR TITLE
fix(dashboard): distinguish crew from polecats in Workers panel

### DIFF
--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -19,7 +19,7 @@ var errFetchFailed = errors.New("fetch failed")
 type MockConvoyFetcher struct {
 	Convoys     []ConvoyRow
 	MergeQueue  []MergeQueueRow
-	Polecats    []PolecatRow
+	Workers     []WorkerRow
 	Mail        []MailRow
 	Rigs        []RigRow
 	Dogs        []DogRow
@@ -42,8 +42,8 @@ func (m *MockConvoyFetcher) FetchMergeQueue() ([]MergeQueueRow, error) {
 	return m.MergeQueue, nil
 }
 
-func (m *MockConvoyFetcher) FetchPolecats() ([]PolecatRow, error) {
-	return m.Polecats, nil
+func (m *MockConvoyFetcher) FetchWorkers() ([]WorkerRow, error) {
+	return m.Workers, nil
 }
 
 func (m *MockConvoyFetcher) FetchMail() ([]MailRow, error) {
@@ -378,7 +378,7 @@ func TestConvoyHandler_EmptyMergeQueue(t *testing.T) {
 func TestConvoyHandler_PolecatWorkersRendering(t *testing.T) {
 	mock := &MockConvoyFetcher{
 		Convoys: []ConvoyRow{},
-		Polecats: []PolecatRow{
+		Workers: []WorkerRow{
 			{
 				Name:         "dag",
 				Rig:          "roxas",
@@ -602,7 +602,7 @@ func TestConvoyHandler_FullDashboard(t *testing.T) {
 				ColorClass: "mq-green",
 			},
 		},
-		Polecats: []PolecatRow{
+		Workers: []WorkerRow{
 			{
 				Name:         "worker1",
 				Rig:          "testrig",
@@ -680,7 +680,7 @@ func TestE2E_Server_FullDashboard(t *testing.T) {
 				ColorClass: "mq-green",
 			},
 		},
-		Polecats: []PolecatRow{
+		Workers: []WorkerRow{
 			{
 				Name:         "furiosa",
 				Rig:          "roxas",
@@ -763,7 +763,7 @@ func TestE2E_Server_ActivityColors(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			mock := &MockConvoyFetcher{
-				Polecats: []PolecatRow{
+				Workers: []WorkerRow{
 					{
 						Name:         "test-worker",
 						Rig:          "test-rig",
@@ -803,7 +803,7 @@ func TestE2E_Server_MergeQueueEmpty(t *testing.T) {
 	mock := &MockConvoyFetcher{
 		Convoys:    []ConvoyRow{},
 		MergeQueue: []MergeQueueRow{},
-		Polecats:   []PolecatRow{},
+		Workers:   []WorkerRow{},
 	}
 
 	handler, err := NewConvoyHandler(mock)
@@ -947,7 +947,7 @@ func TestE2E_Server_HTMLStructure(t *testing.T) {
 // TestE2E_Server_RefineryInPolecats tests that refinery appears in polecat workers.
 func TestE2E_Server_RefineryInPolecats(t *testing.T) {
 	mock := &MockConvoyFetcher{
-		Polecats: []PolecatRow{
+		Workers: []WorkerRow{
 			{
 				Name:         "refinery",
 				Rig:          "roxas",
@@ -999,7 +999,7 @@ func TestE2E_Server_RefineryInPolecats(t *testing.T) {
 type MockConvoyFetcherWithErrors struct {
 	Convoys         []ConvoyRow
 	MergeQueueError error
-	PolecatsError   error
+	WorkersError    error
 }
 
 func (m *MockConvoyFetcherWithErrors) FetchConvoys() ([]ConvoyRow, error) {
@@ -1010,8 +1010,8 @@ func (m *MockConvoyFetcherWithErrors) FetchMergeQueue() ([]MergeQueueRow, error)
 	return nil, m.MergeQueueError
 }
 
-func (m *MockConvoyFetcherWithErrors) FetchPolecats() ([]PolecatRow, error) {
-	return nil, m.PolecatsError
+func (m *MockConvoyFetcherWithErrors) FetchWorkers() ([]WorkerRow, error) {
+	return nil, m.WorkersError
 }
 
 func (m *MockConvoyFetcherWithErrors) FetchMail() ([]MailRow, error) {
@@ -1064,7 +1064,7 @@ func TestConvoyHandler_NonFatalErrors(t *testing.T) {
 			{ID: "hq-cv-test", Title: "Test", Status: "open", WorkStatus: "active"},
 		},
 		MergeQueueError: errFetchFailed,
-		PolecatsError:   errFetchFailed,
+		WorkersError:    errFetchFailed,
 	}
 
 	handler, err := NewConvoyHandler(mock)

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -16,7 +16,7 @@ var templateFS embed.FS
 type ConvoyData struct {
 	Convoys     []ConvoyRow
 	MergeQueue  []MergeQueueRow
-	Polecats    []PolecatRow
+	Workers     []WorkerRow
 	Mail        []MailRow
 	Rigs        []RigRow
 	Dogs        []DogRow
@@ -165,8 +165,8 @@ type MailRow struct {
 	SortKey     int64  // Unix timestamp for sorting
 }
 
-// PolecatRow represents a worker (polecat or crew) in the dashboard.
-type PolecatRow struct {
+// WorkerRow represents a worker (polecat or refinery) in the dashboard.
+type WorkerRow struct {
 	Name         string        // e.g., "dag", "nux", "refinery"
 	Rig          string        // e.g., "roxas", "gastown"
 	SessionID    string        // e.g., "gt-roxas-dag"
@@ -175,7 +175,7 @@ type PolecatRow struct {
 	IssueID      string        // Currently assigned issue ID (e.g., "hq-1234")
 	IssueTitle   string        // Issue title (truncated)
 	WorkStatus   string        // working, stale, stuck, idle
-	AgentType    string        // "polecat" (ephemeral) or "crew" (permanent)
+	AgentType    string        // "polecat" (ephemeral) or "refinery" (permanent)
 }
 
 // MergeQueueRow represents a PR in the merge queue.

--- a/internal/web/templates/convoy.html
+++ b/internal/web/templates/convoy.html
@@ -1045,15 +1045,15 @@
                 </div>
             </div>
 
-            <!-- Workers Panel (Polecats + Crew) -->
+            <!-- Workers Panel (Polecats + Refinery) -->
             <div class="panel">
                 <div class="panel-header">
                     <h2>👷 Workers</h2>
-                    <span class="count">{{len .Polecats}}</span>
+                    <span class="count">{{len .Workers}}</span>
                     <button class="expand-btn">Expand</button>
                 </div>
                 <div class="panel-body">
-                    {{if .Polecats}}
+                    {{if .Workers}}
                     <table>
                         <thead>
                             <tr>
@@ -1066,7 +1066,7 @@
                             </tr>
                         </thead>
                         <tbody>
-                            {{range .Polecats}}
+                            {{range .Workers}}
                             <tr class="{{polecatStatusClass .WorkStatus}}">
                                 <td><span class="polecat-name">{{.Name}}</span></td>
                                 <td>


### PR DESCRIPTION
## Summary

Fixes #1006

- Renamed "Polecats" panel to "Workers" to reflect that it shows both polecats and refinery
- Added Type column with badges to distinguish agent types:
  - `polecat` (muted) - Ephemeral workers spawned per task, nuked when done
  - `refinery` (blue) - Permanent rig-level role that manages the merge queue

## Problem

The UI showed refinery sessions in the Polecats panel with no visual distinction, causing confusion during cleanup operations where the refinery could be mistaken for a polecat.

## Terminology (per glossary)

- **Polecat**: Ephemeral worker agents that produce Merge Requests
- **Refinery**: Manages the Merge Queue for a Rig (permanent rig-level role)
- **Crew**: Human workspaces for persistent collaboration (NOT refinery)

## Test plan

- [ ] Verify Workers panel displays with new header
- [ ] Verify Type column shows correct badges for polecats vs refinery
- [ ] Verify existing functionality (activity, status, working on) still works