### PR TITLE
feat(startup): add nudge fallback for non-hook agents

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -99,3 +99,79 @@ func isAutonomousRole(role string) bool {
 		return false
 	}
 }
+
+// DefaultPrimeWaitMs is the default wait time in milliseconds for non-hook agents
+// to run gt prime before sending work instructions.
+const DefaultPrimeWaitMs = 2000
+
+// StartupFallbackInfo describes what fallback actions are needed for agent startup
+// based on the agent's hook and prompt capabilities.
+//
+// Fallback matrix based on agent capabilities:
+//
+//	| Hooks | Prompt | Beacon Content           | Context Source      | Work Instructions   |
+//	|-------|--------|--------------------------|---------------------|---------------------|
+//	| ✓     | ✓      | Standard                 | Hook runs gt prime  | In beacon           |
+//	| ✓     | ✗      | Standard (via nudge)     | Hook runs gt prime  | Same nudge          |
+//	| ✗     | ✓      | "Run gt prime" (prompt)  | Agent runs manually | Delayed nudge       |
+//	| ✗     | ✗      | "Run gt prime" (nudge)   | Agent runs manually | Delayed nudge       |
+type StartupFallbackInfo struct {
+	// IncludePrimeInBeacon indicates the beacon should include "Run gt prime" instruction.
+	// True for non-hook agents where gt prime doesn't run automatically.
+	IncludePrimeInBeacon bool
+
+	// SendBeaconNudge indicates the beacon must be sent via nudge (agent has no prompt support).
+	// True for agents with PromptMode "none".
+	SendBeaconNudge bool
+
+	// SendStartupNudge indicates work instructions need to be sent via nudge.
+	// True when beacon doesn't include work instructions (non-hook agents, or hook agents without prompt).
+	SendStartupNudge bool
+
+	// StartupNudgeDelayMs is milliseconds to wait before sending work instructions nudge.
+	// Allows gt prime to complete for non-hook agents (where it's not automatic).
+	StartupNudgeDelayMs int
+}
+
+// GetStartupFallbackInfo returns the fallback actions needed based on agent capabilities.
+func GetStartupFallbackInfo(rc *config.RuntimeConfig) *StartupFallbackInfo {
+	if rc == nil {
+		rc = config.DefaultRuntimeConfig()
+	}
+
+	hasHooks := rc.Hooks != nil && rc.Hooks.Provider != "" && rc.Hooks.Provider != "none"
+	hasPrompt := rc.PromptMode != "none"
+
+	info := &StartupFallbackInfo{}
+
+	if !hasHooks {
+		// Non-hook agents need to be told to run gt prime
+		info.IncludePrimeInBeacon = true
+		info.SendStartupNudge = true
+		info.StartupNudgeDelayMs = DefaultPrimeWaitMs
+
+		if !hasPrompt {
+			// No prompt support - beacon must be sent via nudge
+			info.SendBeaconNudge = true
+		}
+	} else if !hasPrompt {
+		// Has hooks but no prompt - need to nudge beacon + work instructions together
+		// Hook runs gt prime synchronously, so no wait needed
+		info.SendBeaconNudge = true
+		info.SendStartupNudge = true
+		info.StartupNudgeDelayMs = 0
+	}
+	// else: hooks + prompt - nothing needed, all in CLI prompt + hook
+
+	return info
+}
+
+// StartupNudgeContent returns the work instructions to send as a startup nudge.
+func StartupNudgeContent() string {
+	return "Check your hook with `gt hook`. If work is present, begin immediately."
+}
+
+// BeaconPrimeInstruction returns the instruction to add to beacon for non-hook agents.
+func BeaconPrimeInstruction() string {
+	return "\n\nRun `gt prime` to initialize your context."
+}


### PR DESCRIPTION
## Summary

Implements fallback support for agents that don't support SessionStart hooks (Codex, Cursor, Auggie, AMP). These agents need alternative mechanisms to receive startup context since they can't automatically run `gt prime` via hooks.

### Fallback Matrix

| Hooks | Prompt | Beacon Content | Context Source | Work Instructions |
|-------|--------|----------------|----------------|-------------------|
| ✓ | ✓ | Standard | Hook runs gt prime | In beacon |
| ✓ | ✗ | Standard (nudge) | Hook runs gt prime | Same nudge |
| ✗ | ✓ | "Run gt prime" | Agent runs manually | Delayed nudge |
| ✗ | ✗ | "Run gt prime" (nudge) | Agent runs manually | Delayed nudge |

### Changes

**runtime.go:**
- Add `StartupFallbackInfo` struct with fallback matrix documentation
- Add `GetStartupFallbackInfo()` to determine fallback actions based on agent config
- Add `StartupNudgeContent()` for work instructions nudge content
- Add `DefaultPrimeWaitMs` constant (2 seconds)

**startup.go:**
- Add `IncludePrimeInstruction` field to `BeaconConfig` for non-hook agents
- Add `ExcludeWorkInstructions` field to control whether beacon includes work instructions
- Update `FormatStartupBeacon()` to handle non-hook agent beacons

**session_manager.go:**
- Integrate `GetStartupFallbackInfo()` to configure beacon based on agent capabilities
- Handle combined nudge for hooks+no-prompt case (single nudge, no delay)
- Handle separate nudges with delay for non-hook agents

**runtime_test.go:**
- Add tests for all four fallback matrix cases
- Add test for `StartupNudgeContent()`

Closes #978

## Test plan

- [x] New unit tests pass for fallback matrix logic
- [x] All existing tests pass (including backward compatibility)
- [x] Linter passes on modified files
- [ ] Manual test with non-hook agent (e.g., Codex)

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)