### PR TITLE
feat(doctor): add database-prefix check for rig config mismatch

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -68,6 +68,7 @@ Rig checks (with --rig flag):
 Routing checks (fixable):
   - routes-config            Check beads routing configuration
   - prefix-mismatch          Detect rigs.json vs routes.jsonl prefix mismatches (fixable)
+  - database-prefix          Detect database vs routes.jsonl prefix mismatches (fixable)
 
 Session hook checks:
   - session-hooks            Check settings.json use session-start.sh
@@ -131,6 +132,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewFormulaCheck())
 	d.Register(doctor.NewPrefixConflictCheck())
 	d.Register(doctor.NewPrefixMismatchCheck())
+	d.Register(doctor.NewDatabasePrefixCheck())
 	d.Register(doctor.NewRoutesCheck())
 	d.Register(doctor.NewRigRoutesJSONLCheck())
 	d.Register(doctor.NewRoutingModeCheck())

--- a/internal/doctor/beads_check.go
+++ b/internal/doctor/beads_check.go
@@ -576,3 +576,160 @@ func (c *RoleLabelCheck) Fix(ctx *CheckContext) error {
 	}
 	return nil
 }
+
+// DatabasePrefixCheck detects when a rig's database has a different issue_prefix
+// than what routes.jsonl specifies. This can happen when:
+// - The database was initialized with a different prefix
+// - Manual database edits changed the prefix
+// - A bug in prefix derivation caused a mismatch
+//
+// Unlike PrefixMismatchCheck (rigs.json ↔ routes.jsonl), this check verifies
+// the actual database configuration matches the routing table.
+type DatabasePrefixCheck struct {
+	FixableCheck
+	mismatches []databasePrefixMismatch
+}
+
+type databasePrefixMismatch struct {
+	rigPath      string
+	beadsDir     string
+	routesPrefix string // From routes.jsonl (without trailing hyphen)
+	dbPrefix     string // From database config
+}
+
+// NewDatabasePrefixCheck creates a new database prefix check.
+func NewDatabasePrefixCheck() *DatabasePrefixCheck {
+	return &DatabasePrefixCheck{
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "database-prefix",
+				CheckDescription: "Check rig database issue_prefix matches routes.jsonl",
+				CheckCategory:    CategoryConfig,
+			},
+		},
+	}
+}
+
+// Run checks if each rig's database issue_prefix matches routes.jsonl.
+func (c *DatabasePrefixCheck) Run(ctx *CheckContext) *CheckResult {
+	c.mismatches = nil // Reset
+
+	beadsDir := filepath.Join(ctx.TownRoot, ".beads")
+
+	// Load routes.jsonl
+	routes, err := beads.LoadRoutes(beadsDir)
+	if err != nil {
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusOK,
+			Message:  "No routes.jsonl found (nothing to check)",
+			Category: c.Category(),
+		}
+	}
+	if len(routes) == 0 {
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusOK,
+			Message:  "No routes configured (nothing to check)",
+			Category: c.Category(),
+		}
+	}
+
+	// Check if bd command is available
+	if _, err := exec.LookPath("bd"); err != nil {
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusOK,
+			Message:  "beads not installed (skipped)",
+			Category: c.Category(),
+		}
+	}
+
+	var problems []string
+
+	for _, route := range routes {
+		// Skip town root route
+		if route.Path == "." || route.Path == "" {
+			continue
+		}
+
+		// Resolve the rig's beads directory (follows redirects)
+		rigPath := filepath.Join(ctx.TownRoot, route.Path)
+		rigBeadsDir := beads.ResolveBeadsDir(rigPath)
+
+		// Check if beads directory exists
+		if _, err := os.Stat(rigBeadsDir); os.IsNotExist(err) {
+			continue // No beads dir for this rig
+		}
+
+		// Query database for issue_prefix using bd config get
+		dbPrefix, err := c.getDBPrefix(rigBeadsDir)
+		if err != nil {
+			// No issue_prefix configured - that's OK
+			continue
+		}
+
+		// Normalize routes prefix (strip trailing hyphen)
+		routesPrefix := strings.TrimSuffix(route.Prefix, "-")
+
+		// Compare prefixes
+		if dbPrefix != routesPrefix {
+			problems = append(problems, fmt.Sprintf("Route '%s': routes.jsonl says '%s', database has '%s'",
+				route.Path, routesPrefix, dbPrefix))
+			c.mismatches = append(c.mismatches, databasePrefixMismatch{
+				rigPath:      route.Path,
+				beadsDir:     rigBeadsDir,
+				routesPrefix: routesPrefix,
+				dbPrefix:     dbPrefix,
+			})
+		}
+	}
+
+	if len(c.mismatches) == 0 {
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusOK,
+			Message:  "All database prefixes match routes.jsonl",
+			Category: c.Category(),
+		}
+	}
+
+	return &CheckResult{
+		Name:     c.Name(),
+		Status:   StatusWarning,
+		Message:  fmt.Sprintf("%d database prefix mismatch(es) with routes.jsonl", len(c.mismatches)),
+		Details:  problems,
+		FixHint:  "Run 'gt doctor --fix' to update database configs to match routes.jsonl",
+		Category: c.Category(),
+	}
+}
+
+// getDBPrefix queries the database for issue_prefix config value.
+func (c *DatabasePrefixCheck) getDBPrefix(beadsDir string) (string, error) {
+	cmd := exec.Command("bd", "config", "get", "issue_prefix", "--db", beadsDir)
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
+// Fix updates database configs to match routes.jsonl prefixes.
+func (c *DatabasePrefixCheck) Fix(ctx *CheckContext) error {
+	// Re-run check to populate mismatches if needed
+	if len(c.mismatches) == 0 {
+		result := c.Run(ctx)
+		if result.Status == StatusOK {
+			return nil // Nothing to fix
+		}
+	}
+
+	for _, m := range c.mismatches {
+		cmd := exec.Command("bd", "config", "set", "issue_prefix", m.routesPrefix, "--db", m.beadsDir)
+		if output, err := cmd.CombinedOutput(); err != nil {
+			return fmt.Errorf("updating %s: %s", m.rigPath, strings.TrimSpace(string(output)))
+		}
+	}
+
+	return nil
+}


### PR DESCRIPTION
## Summary

Add `DatabasePrefixCheck` that verifies each rig's database `issue_prefix` config matches routes.jsonl. This catches misconfigurations where:
- rigs.json ↔ routes.jsonl pass (PrefixMismatchCheck)
- But the actual database has a different prefix

Uses `bd config get issue_prefix --db <dir>` for backend-agnostic checking (works with both SQLite and Dolt).

**Gap found:** gastown's beads.db had `issue_prefix=hq` while routes.jsonl said `gt-` → gastown. The existing prefix-mismatch check passed because rigs.json also said 'gt', but the actual database was misconfigured.

## Changes

- `internal/doctor/beads_check.go`: Add `DatabasePrefixCheck` struct with Run/Fix methods
- `internal/doctor/beads_check_test.go`: Add tests for the new check
- `internal/cmd/doctor.go`: Register the new check and update help text

## Test Plan

- [x] `go test ./internal/doctor/...` passes
- [x] New tests cover: no routes, empty routes, no beads dir cases
- [ ] Manual test with misconfigured database

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)