### PR TITLE
fix(mail): mark messages as read when viewed via gt mail read

### DIFF
--- a/internal/cmd/mail_inbox.go
+++ b/internal/cmd/mail_inbox.go
@@ -149,9 +149,13 @@ func runMailRead(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting message: %w", err)
 	}
 
-	// Note: We intentionally do NOT mark as read/ack on read.
-	// User must explicitly delete/ack the message.
-	// This preserves handoff messages for reference.
+	// Mark as read when viewed (adds "read" label, does not close/archive).
+	// Handoff messages are preserved via the hook mechanism, so marking
+	// read here is safe — hooked mail is found via gt hook, not the inbox.
+	if err := mailbox.MarkReadOnly(msgID); err != nil {
+		// Non-fatal: message was retrieved, just couldn't mark
+		style.PrintWarning("could not mark message as read: %v", err)
+	}
 
 	// JSON output
 	if mailReadJSON {

--- a/internal/mail/mailbox_test.go
+++ b/internal/mail/mailbox_test.go
@@ -264,6 +264,56 @@ func TestMailboxLegacyListUnread(t *testing.T) {
 	}
 }
 
+func TestMailboxMarkReadOnlyExcludesFromUnread(t *testing.T) {
+	tmpDir := t.TempDir()
+	m := NewMailbox(tmpDir)
+
+	msgs := []*Message{
+		{ID: "msg-001", Read: false, Subject: "First"},
+		{ID: "msg-002", Read: false, Subject: "Second"},
+	}
+	for _, msg := range msgs {
+		if err := m.Append(msg); err != nil {
+			t.Fatalf("Append error: %v", err)
+		}
+	}
+
+	// Both should be unread initially
+	unread, err := m.ListUnread()
+	if err != nil {
+		t.Fatalf("ListUnread error: %v", err)
+	}
+	if len(unread) != 2 {
+		t.Errorf("ListUnread returned %d, want 2", len(unread))
+	}
+
+	// Mark one as read-only (simulates gt mail read behavior)
+	if err := m.MarkReadOnly("msg-001"); err != nil {
+		t.Fatalf("MarkReadOnly error: %v", err)
+	}
+
+	// Should only have 1 unread now
+	unread, err = m.ListUnread()
+	if err != nil {
+		t.Fatalf("ListUnread error: %v", err)
+	}
+	if len(unread) != 1 {
+		t.Errorf("ListUnread returned %d after MarkReadOnly, want 1", len(unread))
+	}
+	if len(unread) == 1 && unread[0].ID != "msg-002" {
+		t.Errorf("Expected msg-002 to be unread, got %s", unread[0].ID)
+	}
+
+	// The marked message should still be in full list
+	all, err := m.List()
+	if err != nil {
+		t.Fatalf("List error: %v", err)
+	}
+	if len(all) != 2 {
+		t.Errorf("List returned %d, want 2 (MarkReadOnly should not remove)", len(all))
+	}
+}
+
 func TestMailboxLegacyListByThread(t *testing.T) {
 	tmpDir := t.TempDir()
 	m := NewMailbox(tmpDir)


### PR DESCRIPTION
## Summary

`gt mail read` previously did not mark messages as read, causing agents to
re-process the same mail after restart or handoff. The original comment
cited preserving handoff messages, but handoff mail is already preserved
via the hook mechanism (`gt hook`), making inbox preservation redundant.

## Changes

- `internal/cmd/mail_inbox.go`: Replace "don't mark read" comment with
  `MarkReadOnly()` call in `runMailRead()`. Adds the "read" label without
  closing or archiving — mail stays in inbox but won't appear as unread.
- `internal/mail/mailbox_test.go`: Add test verifying `MarkReadOnly()`
  excludes messages from `ListUnread()` while keeping them in `List()`.

## Testing

Empirically validated across 3 sessions with `beads/crew/ruby`:

| Session | Without Fix | With Fix |
|---------|------------|----------|
| 1 | Read mail, replied. Mail stayed unread. | Read mail, replied. Auto-marked read. |
| 2 (restart) | Re-read same mail, sent duplicate reply. | 0 unread, no re-processing. |
| 2 (handoff) | N/A | Handoff context found via hook, work continued correctly. |
| 3 (post-handoff) | Would re-process everything. | 0 unread, clean idle. |

Fixes #1031

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)