### PR TITLE
fix(nudge): resolve short addresses by trying crew then polecat

### DIFF
--- a/internal/cmd/nudge.go
+++ b/internal/cmd/nudge.go
@@ -189,12 +189,19 @@ func runNudge(cmd *cobra.Command, args []string) error {
 			crewName := strings.TrimPrefix(polecatName, "crew/")
 			sessionName = crewSessionName(rigName, crewName)
 		} else {
-			// Regular polecat - use session manager
-			mgr, _, err := getSessionManager(rigName)
-			if err != nil {
-				return err
+			// Short address (e.g., "gastown/holden") - could be crew or polecat.
+			// Try crew first (matches mail system's addressToSessionIDs pattern),
+			// then fall back to polecat.
+			crewSession := crewSessionName(rigName, polecatName)
+			if exists, _ := t.HasSession(crewSession); exists {
+				sessionName = crewSession
+			} else {
+				mgr, _, err := getSessionManager(rigName)
+				if err != nil {
+					return err
+				}
+				sessionName = mgr.SessionName(polecatName)
 			}
-			sessionName = mgr.SessionName(polecatName)
 		}
 
 		// Send nudge using the reliable NudgeSession


### PR DESCRIPTION
## Summary

`gt nudge gastown/holden` now works the same as `gt mail send gastown/holden`.

When given a short address without explicit `crew/` prefix, nudge tries the crew
session name first, then falls back to polecat — matching the pattern already used
by the mail system's `addressToSessionIDs`.

Fixes the inconsistency where `gt mail send gastown/holden` worked but
`gt nudge gastown/holden` failed with "can't find pane".

## Test plan

- [x] Existing `TestResolveNudgePattern` tests pass
- [x] Build succeeds
- [x] Single file changed, focused on the fix

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)