### PR TITLE
feat(doctor): add stale-agent-beads check for removed crew

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -155,6 +155,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewPatrolPluginsAccessibleCheck())
 	d.Register(doctor.NewPatrolRolesHavePromptsCheck())
 	d.Register(doctor.NewAgentBeadsCheck())
+	d.Register(doctor.NewStaleAgentBeadsCheck())
 	d.Register(doctor.NewRigBeadsCheck())
 	d.Register(doctor.NewRoleBeadsCheck())
 

--- a/internal/doctor/stale_agent_beads_check.go
+++ b/internal/doctor/stale_agent_beads_check.go
@@ -1,0 +1,174 @@
+package doctor
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+// StaleAgentBeadsCheck detects agent beads that exist in the database but have
+// no corresponding agent on disk. This catches beads inherited from upstream or
+// left over after crew members are removed.
+//
+// Only checks crew worker beads (not polecats, which are transient by design).
+// The fix closes stale beads so they no longer pollute bd ready output.
+type StaleAgentBeadsCheck struct {
+	FixableCheck
+}
+
+// NewStaleAgentBeadsCheck creates a new stale agent beads check.
+func NewStaleAgentBeadsCheck() *StaleAgentBeadsCheck {
+	return &StaleAgentBeadsCheck{
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "stale-agent-beads",
+				CheckDescription: "Detect agent beads for removed crew members",
+				CheckCategory:    CategoryRig,
+			},
+		},
+	}
+}
+
+// Run checks for agent beads that have no matching agent on disk.
+func (c *StaleAgentBeadsCheck) Run(ctx *CheckContext) *CheckResult {
+	// Load routes to get prefixes
+	beadsDir := filepath.Join(ctx.TownRoot, ".beads")
+	routes, err := beads.LoadRoutes(beadsDir)
+	if err != nil {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: "Could not load routes.jsonl",
+		}
+	}
+
+	// Build prefix -> rigInfo map from routes
+	prefixToRig := make(map[string]rigInfo)
+	for _, r := range routes {
+		parts := strings.Split(r.Path, "/")
+		if len(parts) >= 1 && parts[0] != "." {
+			rigName := parts[0]
+			prefix := strings.TrimSuffix(r.Prefix, "-")
+			prefixToRig[prefix] = rigInfo{
+				name:      rigName,
+				beadsPath: r.Path,
+			}
+		}
+	}
+
+	if len(prefixToRig) == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "No rigs to check",
+		}
+	}
+
+	var stale []string
+
+	for prefix, info := range prefixToRig {
+		rigBeadsPath := filepath.Join(ctx.TownRoot, info.beadsPath)
+		bd := beads.New(rigBeadsPath)
+		rigName := info.name
+
+		// Get actual crew workers on disk
+		diskWorkers := listCrewWorkers(ctx.TownRoot, rigName)
+		diskSet := make(map[string]bool, len(diskWorkers))
+		for _, w := range diskWorkers {
+			diskSet[w] = true
+		}
+
+		// List all beads and find crew agent beads
+		// Crew bead IDs follow the pattern: prefix-rig-crew-name
+		crewPrefix := fmt.Sprintf("%s-%s-crew-", prefix, rigName)
+		allBeads, err := bd.List(beads.ListOptions{
+			Status:   "all",
+			Priority: -1,
+		})
+		if err != nil {
+			continue
+		}
+
+		for _, issue := range allBeads {
+			if !strings.HasPrefix(issue.ID, crewPrefix) {
+				continue
+			}
+			// Extract worker name from bead ID
+			workerName := strings.TrimPrefix(issue.ID, crewPrefix)
+			if workerName == "" {
+				continue
+			}
+			if !diskSet[workerName] {
+				stale = append(stale, issue.ID)
+			}
+		}
+	}
+
+	if len(stale) == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "No stale agent beads found",
+		}
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusWarning,
+		Message: fmt.Sprintf("%d stale agent bead(s) for removed crew", len(stale)),
+		Details: stale,
+		FixHint: "Run 'gt doctor --fix' to close stale agent beads",
+	}
+}
+
+// Fix closes stale agent beads for crew members that no longer exist on disk.
+func (c *StaleAgentBeadsCheck) Fix(ctx *CheckContext) error {
+	// Re-run detection to get current stale list
+	result := c.Run(ctx)
+	if result.Status == StatusOK {
+		return nil
+	}
+
+	// Load routes to get beads paths
+	beadsDir := filepath.Join(ctx.TownRoot, ".beads")
+	routes, err := beads.LoadRoutes(beadsDir)
+	if err != nil {
+		return fmt.Errorf("loading routes.jsonl: %w", err)
+	}
+
+	// Build prefix -> beads path map
+	prefixToPath := make(map[string]string)
+	for _, r := range routes {
+		parts := strings.Split(r.Path, "/")
+		if len(parts) >= 1 && parts[0] != "." {
+			prefix := strings.TrimSuffix(r.Prefix, "-")
+			prefixToPath[prefix] = filepath.Join(ctx.TownRoot, r.Path)
+		}
+	}
+
+	// Close each stale bead
+	closedStatus := "closed"
+	for _, beadID := range result.Details {
+		// Determine which rig's beads client to use based on bead ID prefix
+		var bd *beads.Beads
+		for prefix, path := range prefixToPath {
+			if strings.HasPrefix(beadID, prefix+"-") {
+				bd = beads.New(path)
+				break
+			}
+		}
+		if bd == nil {
+			continue
+		}
+
+		if err := bd.Update(beadID, beads.UpdateOptions{
+			Status: &closedStatus,
+		}); err != nil {
+			return fmt.Errorf("closing stale bead %s: %w", beadID, err)
+		}
+	}
+
+	return nil
+}

--- a/internal/doctor/stale_agent_beads_check_test.go
+++ b/internal/doctor/stale_agent_beads_check_test.go
@@ -1,0 +1,100 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestNewStaleAgentBeadsCheck(t *testing.T) {
+	check := NewStaleAgentBeadsCheck()
+
+	if check.Name() != "stale-agent-beads" {
+		t.Errorf("expected name 'stale-agent-beads', got %q", check.Name())
+	}
+
+	if !check.CanFix() {
+		t.Error("expected CanFix to return true")
+	}
+
+	if check.Description() != "Detect agent beads for removed crew members" {
+		t.Errorf("unexpected description: %q", check.Description())
+	}
+
+	if check.Category() != CategoryRig {
+		t.Errorf("expected category %q, got %q", CategoryRig, check.Category())
+	}
+}
+
+func TestStaleAgentBeadsCheck_NoRoutes(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// No .beads dir at all — LoadRoutes returns empty, so check returns OK (no rigs)
+	check := NewStaleAgentBeadsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	// With no routes, there are no rigs to check, so result is OK or Warning
+	if result.Status != StatusOK && result.Status != StatusWarning {
+		t.Errorf("expected StatusOK or StatusWarning, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestStaleAgentBeadsCheck_NoRigs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create .beads dir with empty routes.jsonl
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewStaleAgentBeadsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK for no rigs, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestStaleAgentBeadsCheck_CrewOnDisk(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Set up routes pointing to a rig
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	routesContent := `{"prefix":"gt-","path":"myrig/mayor/rig"}` + "\n"
+	if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), []byte(routesContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create rig beads directory
+	rigBeadsDir := filepath.Join(tmpDir, "myrig", "mayor", "rig", ".beads")
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create crew on disk
+	crewDir := filepath.Join(tmpDir, "myrig", "crew")
+	for _, name := range []string{"alice", "bob"} {
+		if err := os.MkdirAll(filepath.Join(crewDir, name), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	check := NewStaleAgentBeadsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	// Without a running bd daemon, List() will fail gracefully
+	// The check should handle this and not crash
+	result := check.Run(ctx)
+	t.Logf("Stale agent beads check: status=%v, message=%s", result.Status, result.Message)
+}


### PR DESCRIPTION
## Summary

- Add new doctor check `stale-agent-beads` that detects agent beads for crew members no longer on disk
- These beads pollute `bd ready` output when inherited from upstream or left after crew removal
- `gt doctor --fix` closes stale beads automatically

## Context

It appears the maintainer's beads database was checked in at some point, and now multiple contributors have stale agent beads (e.g. `gt-gastown-crew-jack`, `gt-gastown-crew-joe`) for crew members that don't exist in their local installations. These show up in `bd ready` and `gt ready` output, creating noise. This check detects and cleans up that stale data.

## How it works

For each rig, the check:
1. Lists all beads matching the crew bead ID pattern (`prefix-rig-crew-*`)
2. Compares against actual crew workers on disk (`listCrewWorkers`)
3. Reports any beads with no matching worker as stale

Only checks crew worker beads (not polecats, which are transient by design).

## Test plan

- [x] Unit tests for check properties (name, category, fixable)
- [x] Test with no routes (graceful handling)
- [x] Test with no rigs (OK status)
- [x] Test with crew on disk (no crash when bd daemon not running)
- [x] Full test suite passes (`go test ./... -short`)

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)