### PR TITLE
fix(session): remove redundant gt prime instruction from start/restart beacons

### DIFF
--- a/internal/session/startup.go
+++ b/internal/session/startup.go
@@ -70,14 +70,6 @@ func FormatStartupBeacon(cfg BeaconConfig) string {
 		beacon += "\n\nWork is on your hook. Run `gt hook` now and begin immediately."
 	}
 
-	// For start/restart, add fallback instructions in case SessionStart hook fails
-	// to inject context via gt prime. This prevents the "No recent activity" state
-	// where agents sit idle because they received only metadata, no instructions.
-	// See: gt-uoc64 (crew workers starting without proper context injection)
-	if cfg.Topic == "start" || cfg.Topic == "restart" {
-		beacon += "\n\nRun `gt prime` now for full context, then check your hook and mail."
-	}
-
 	return beacon
 }
 

--- a/internal/session/startup_test.go
+++ b/internal/session/startup_test.go
@@ -90,7 +90,7 @@ func TestFormatStartupBeacon(t *testing.T) {
 			},
 		},
 		{
-			name: "start includes fallback instructions",
+			name: "start beacon has no prime instruction",
 			cfg: BeaconConfig{
 				Recipient: "beads/crew/fang",
 				Sender:    "human",
@@ -101,11 +101,13 @@ func TestFormatStartupBeacon(t *testing.T) {
 				"beads/crew/fang",
 				"<- human",
 				"start",
-				"gt prime", // fallback instruction for when SessionStart hook fails
+			},
+			wantNot: []string{
+				"gt prime",
 			},
 		},
 		{
-			name: "restart includes fallback instructions",
+			name: "restart beacon has no prime instruction",
 			cfg: BeaconConfig{
 				Recipient: "gastown/crew/george",
 				Sender:    "human",
@@ -115,7 +117,9 @@ func TestFormatStartupBeacon(t *testing.T) {
 				"[GAS TOWN]",
 				"gastown/crew/george",
 				"restart",
-				"gt prime", // fallback instruction for when SessionStart hook fails
+			},
+			wantNot: []string{
+				"gt prime",
 			},
 		},
 	}


### PR DESCRIPTION
## Summary

- Remove the fallback "Run `gt prime`" instruction from start/restart beacons
- The SessionStart hook now reliably injects context via `gt prime --hook`, making this instruction redundant
- When the hook works (normal case), the beacon text causes agents to run `gt prime` a second time, wasting context window

## Historical context

This fallback was added in 605eeec8 (Jan 12) as a safety net for when the SessionStart hook failed to inject context, causing agents to sit idle. Since then, hook infrastructure has stabilized.

For non-hook agents (Codex, Cursor) that genuinely need "Run gt prime", PR #1029 introduces a capability-aware fallback matrix (`IncludePrimeInstruction` field) that only targets agents without hooks. This change removes the blunt fallback; #1029 adds the surgical replacement. The two are complementary and merge-order independent.

## Test plan

- [x] Updated startup_test.go with negative assertions (start/restart beacons must NOT contain "gt prime")
- [x] All session package tests pass
- [x] Change isolated to 2 files (startup.go, startup_test.go)

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)