### PR TITLE
perf(doctor): bypass bd daemon for town-root subprocess calls

### DIFF
--- a/internal/doctor/config_check.go
+++ b/internal/doctor/config_check.go
@@ -686,7 +686,7 @@ func (c *CustomTypesCheck) Run(ctx *CheckContext) *CheckResult {
 
 	// Get current custom types configuration
 	// Use Output() not CombinedOutput() to avoid capturing bd's stderr messages
-	cmd := exec.Command("bd", "config", "get", "types.custom")
+	cmd := exec.Command("bd", "--no-daemon", "config", "get", "types.custom")
 	cmd.Dir = ctx.TownRoot
 	output, err := cmd.Output()
 	if err != nil {
@@ -759,7 +759,7 @@ func parseConfigOutput(output []byte) string {
 
 // Fix registers the missing custom types.
 func (c *CustomTypesCheck) Fix(ctx *CheckContext) error {
-	cmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
+	cmd := exec.Command("bd", "--no-daemon", "config", "set", "types.custom", constants.BeadsCustomTypes)
 	cmd.Dir = c.townRoot
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/doctor/lifecycle_check.go
+++ b/internal/doctor/lifecycle_check.go
@@ -60,6 +60,7 @@ func (c *LifecycleHygieneCheck) checkDeaconInbox(ctx *CheckContext) int {
 	// Get deacon inbox via gt mail
 	cmd := exec.Command("gt", "mail", "inbox", "--identity", "deacon/", "--json")
 	cmd.Dir = ctx.TownRoot
+	cmd.Env = append(cmd.Environ(), "BEADS_NO_DAEMON=1")
 
 	output, err := cmd.Output()
 	if err != nil {
@@ -101,6 +102,7 @@ func (c *LifecycleHygieneCheck) Fix(ctx *CheckContext) error {
 	for _, msg := range c.staleMessages {
 		cmd := exec.Command("gt", "mail", "delete", msg.ID) //nolint:gosec // G204: msg.ID is from internal state, not user input
 		cmd.Dir = ctx.TownRoot
+		cmd.Env = append(cmd.Environ(), "BEADS_NO_DAEMON=1")
 		if err := cmd.Run(); err != nil {
 			errors = append(errors, fmt.Sprintf("failed to delete message %s: %v", msg.ID, err))
 		}

--- a/internal/doctor/routing_mode_check.go
+++ b/internal/doctor/routing_mode_check.go
@@ -59,7 +59,7 @@ func (c *RoutingModeCheck) Run(ctx *CheckContext) *CheckResult {
 // checkRoutingMode checks the routing mode in a specific beads directory.
 func (c *RoutingModeCheck) checkRoutingMode(beadsDir, location string) *CheckResult {
 	// Run bd config get routing.mode
-	cmd := exec.Command("bd", "config", "get", "routing.mode")
+	cmd := exec.Command("bd", "--no-daemon", "config", "get", "routing.mode")
 	cmd.Dir = filepath.Dir(beadsDir)
 	cmd.Env = append(cmd.Environ(), "BEADS_DIR="+beadsDir)
 
@@ -135,7 +135,7 @@ func (c *RoutingModeCheck) Fix(ctx *CheckContext) error {
 
 // setRoutingMode sets routing.mode to "explicit" in the specified beads directory.
 func (c *RoutingModeCheck) setRoutingMode(beadsDir string) error {
-	cmd := exec.Command("bd", "config", "set", "routing.mode", "explicit")
+	cmd := exec.Command("bd", "--no-daemon", "config", "set", "routing.mode", "explicit")
 	cmd.Dir = filepath.Dir(beadsDir)
 	cmd.Env = append(cmd.Environ(), "BEADS_DIR="+beadsDir)
 


### PR DESCRIPTION
## Summary

- Add `--no-daemon` flag to `bd config get/set` subprocess calls in doctor checks that run from town root
- Add `BEADS_NO_DAEMON=1` env var to `gt mail` subprocess calls in lifecycle check
- Reduces ~5s per affected check to <1s

## Root Cause

The bd daemon runs per-clone, not per-town. Doctor checks that shell out to `bd` with `cmd.Dir = ctx.TownRoot` wait for a daemon connection that will never succeed, timing out after ~5 seconds before falling back to direct mode. This pattern already appears in the Go beads library (`beads.go:185`) and `wisp_check.go`, which both use `--no-daemon`.

## Affected checks

| Check | Before | After | Fix |
|-------|--------|-------|-----|
| beads-custom-types | ~5.4s | <1s | `--no-daemon` on `bd config get/set` |
| routing-mode | ~5.4s | <1s | `--no-daemon` on `bd config get/set` |
| lifecycle-hygiene | ~5.8s | <1s | `BEADS_NO_DAEMON=1` on `gt mail` |

## Test plan

- [x] `go build ./...` succeeds
- [x] Doctor tests pass
- [x] Manual verification: `gt doctor --slow` shows reduced times

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)