### PR TITLE
docs: add PR instruction to use origin remote

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -7,3 +7,11 @@ This file exists for compatibility with tools that look for AGENTS.md.
 > **Recovery**: Run `gt prime` after compaction, clear, or new session
 
 Full context is injected by `gt prime` at session start.
+
+## Pull Requests
+
+When creating PRs, always use `--repo` with the origin remote (gh CLI defaults to upstream for forks):
+
+```bash
+gh pr create --repo $(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\.git/\1/')
+```


### PR DESCRIPTION
## Summary
- Adds instruction to AGENTS.md to use `--repo` with origin remote when creating PRs
- gh CLI defaults to upstream for forks, which can cause PRs to go to the wrong repo

## Test plan
- [x] Instruction is clear and includes the shell command

🤖 Generated with [Claude Code](https://claude.com/claude-code)