### PR TITLE
fix(witness): prevent crash loop when rig is idle

### DIFF
--- a/internal/formula/formulas/mol-witness-patrol.formula.toml
+++ b/internal/formula/formulas/mol-witness-patrol.formula.toml
@@ -56,7 +56,63 @@ needs = ['patrol-cleanup']
 title = 'Check own context limit'
 
 [[steps]]
-description = "End of patrol cycle decision.\n\n**If context LOW** (can continue patrolling):\n1. Generate a brief summary of this patrol cycle\n2. Squash the current wisp:\n```bash\nbd mol squash <mol-id> --summary \"<patrol-summary>\"\n```\n3. Create a new patrol wisp:\n```bash\nbd mol wisp mol-witness-patrol\n```\n4. Continue executing from the inbox-check step of the new wisp\n\n**If context HIGH** (approaching limit):\n1. Write handoff mail with notable observations:\n```bash\ngt handoff -s \"Witness patrol handoff\" -m \"<observations>\"\n```\n2. Exit cleanly - the daemon will respawn a fresh Witness session\n\n**IMPORTANT**: You must either create a new wisp (context LOW) or exit (context HIGH).\nNever leave the session idle without work on your hook."
+description = """End of patrol cycle decision.
+
+**If context LOW** (can continue patrolling):
+
+First, use await-signal with exponential backoff to wait for activity:
+
+```bash
+gt mol step await-signal --agent-bead <witness-agent-bead> \
+  --backoff-base 30s --backoff-mult 2 --backoff-max 5m
+```
+
+This command:
+1. Subscribes to beads activity feed
+2. Returns IMMEDIATELY when any rig activity occurs (polecat work, mail, etc.)
+3. If no activity, times out with exponential backoff:
+   - First timeout: 30s
+   - Second timeout: 60s
+   - Third timeout: 120s
+   - ...capped at 5 minutes max
+4. Tracks `idle:N` label on agent bead for backoff state
+
+**On signal received** (activity detected):
+Reset the idle counter:
+```bash
+gt agent state <witness-agent-bead> --set idle=0
+```
+
+**On timeout** (no activity):
+The idle counter was auto-incremented. The longer backoff will apply next time.
+
+After await-signal returns (either by signal or timeout):
+1. Generate a brief summary of this patrol cycle
+2. Squash the current wisp:
+```bash
+bd mol squash <mol-id> --summary "<patrol-summary>"
+```
+3. Create a new patrol wisp:
+```bash
+bd mol wisp mol-witness-patrol
+```
+4. Continue executing from the inbox-check step of the new wisp
+
+**If context HIGH** (approaching limit):
+1. Write handoff mail with notable observations:
+```bash
+gt handoff -s "Witness patrol handoff" -m "<observations>"
+```
+2. Exit cleanly - the daemon will respawn a fresh Witness session
+
+**Why await-signal prevents crash loops:**
+- Idle rigs let the Witness sleep (up to 5 min between patrols)
+- Any polecat activity wakes the Witness immediately via the feed
+- No tight loops when nothing needs monitoring
+- Context is preserved by sleeping, not by handing off
+
+**IMPORTANT**: You must either create a new wisp (context LOW) or exit (context HIGH).
+Never leave the session idle without work on your hook."""
 id = 'loop-or-exit'
 needs = ['context-check']
 title = 'Loop or exit for respawn'

--- a/internal/templates/roles/witness.md.tmpl
+++ b/internal/templates/roles/witness.md.tmpl
@@ -274,7 +274,12 @@ A fresh Witness with empty context can handle emergencies better than one with
 1. Read `state.json` for `patrol_count` and `extraordinary_action`
 2. If `extraordinary_action == true` → hand off immediately
 3. If `patrol_count >= 15` → hand off
-4. Otherwise → increment `patrol_count`, save state, create new wisp
+4. Otherwise → use `await-signal` to sleep until activity (30s-5m backoff when idle)
+5. After waking, increment `patrol_count`, save state, create new wisp
+
+**Idle sleep prevents crash loops**: When the rig has no polecats, await-signal
+ensures minimum time between patrols (30s base, exponential backoff to 5m max).
+This prevents the witness from spinning in a tight loop when there's nothing to do.
 
 **Handoff command:** `gt handoff -s "Witness cycle" -m "Completed N patrols, no incidents"`
 


### PR DESCRIPTION
## Summary
- Add `await-signal` with exponential backoff (30s base, 5m max) to witness patrol `loop-or-exit` step
- When rig is idle (no polecats), witness now sleeps between patrol cycles instead of immediately handing off
- Any polecat activity wakes the witness immediately via beads activity feed
- Updates witness template to document the idle sleep behavior

## Root Cause
When a rig had no polecats, the witness would:
1. Start patrol
2. Complete instantly (nothing to monitor)
3. Hand off immediately 'for fresh context'
4. Daemon respawns witness
5. Repeat → crash loop with many WITNESS_PING messages

## Fix
The fix mirrors the Deacon's `await-signal` pattern from `mol-deacon-patrol.formula.toml`. The witness now uses exponential backoff (30s → 60s → 120s → ... up to 5m) when the rig is idle.

Fixes: hq-oymf9

## Test plan
- [ ] Verify witness patrol on idle rig sleeps between cycles
- [ ] Verify witness wakes immediately when polecat activity occurs
- [ ] Verify no WITNESS_PING flood in deacon inbox

🤖 Generated with [Claude Code](https://claude.com/claude-code)