### PR TITLE
update beads fingerprint after git initialization

### DIFF
--- a/internal/cmd/gitinit.go
+++ b/internal/cmd/gitinit.go
@@ -143,6 +143,18 @@ func runGitInit(cmd *cobra.Command, args []string) error {
 		fmt.Printf("   %s Could not install pre-checkout hook: %v\n", style.Dim.Render("⚠"), err)
 	}
 
+	// Ensure beads database has repository fingerprint now that git is initialized.
+	// This fixes the case where 'gt install' ran before git, leaving the database
+	// without a fingerprint (causes slow bd commands due to daemon startup failures).
+	beadsDir := filepath.Join(hqRoot, ".beads")
+	if _, err := os.Stat(beadsDir); err == nil {
+		if err := ensureRepoFingerprint(hqRoot); err != nil {
+			fmt.Printf("   %s Could not update beads fingerprint: %v\n", style.Dim.Render("⚠"), err)
+		} else {
+			fmt.Printf("   ✓ Updated beads repository fingerprint\n")
+		}
+	}
+
 	// Create GitHub repo if requested
 	if gitInitGitHub != "" {
 		if err := createGitHubRepo(hqRoot, gitInitGitHub, !gitInitPublic); err != nil {
@@ -308,6 +320,18 @@ func InitGitForHarness(hqRoot string, github string, private bool) error {
 	// Install pre-checkout hook to prevent accidental branch switches
 	if err := InstallPreCheckoutHook(hqRoot); err != nil {
 		fmt.Printf("   %s Could not install pre-checkout hook: %v\n", style.Dim.Render("⚠"), err)
+	}
+
+	// Ensure beads database has repository fingerprint now that git is initialized.
+	// This fixes the case where 'gt install' ran before git, leaving the database
+	// without a fingerprint (causes slow bd commands due to daemon startup failures).
+	beadsDir := filepath.Join(hqRoot, ".beads")
+	if _, err := os.Stat(beadsDir); err == nil {
+		if err := ensureRepoFingerprint(hqRoot); err != nil {
+			fmt.Printf("   %s Could not update beads fingerprint: %v\n", style.Dim.Render("⚠"), err)
+		} else {
+			fmt.Printf("   ✓ Updated beads repository fingerprint\n")
+		}
 	}
 
 	// Create GitHub repo if requested


### PR DESCRIPTION
## Summary
- Fixes the case where `gt install` runs before git, leaving the beads database without a fingerprint
- Now `gt git-init` calls `ensureRepoFingerprint()` after initializing git if a `.beads/` directory exists
- This prevents slow bd commands (~6s → ~0.5s) caused by repeated daemon startup failures

## Test plan
- [ ] Run `gt install ~/test-hq` (without --git)
- [ ] Run `gt git-init` in that directory
- [ ] Verify no "LEGACY DATABASE DETECTED" warning when running `bd list`
- [ ] Verify `gt status` runs quickly

Fixes #1063

🤖 Generated with [Claude Code](https://claude.com/claude-code)