### PR TITLE
fix: Allow .mcp.json in worktree sparse checkout

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -382,18 +382,19 @@ persisting it to disk.
 ### Sparse Checkout (Source Repo Isolation)
 
 When agents work on source repositories that have their own Claude Code configuration,
-Gas Town uses git sparse checkout to exclude all context files:
+Gas Town uses git sparse checkout to exclude Claude Code context files:
 
 ```bash
 # Automatically configured for worktrees - excludes:
 # - .claude/       : settings, rules, agents, commands
 # - CLAUDE.md      : primary context file
 # - CLAUDE.local.md: personal context file
-# - .mcp.json      : MCP server configuration
-git sparse-checkout set --no-cone '/*' '!/.claude/' '!/CLAUDE.md' '!/CLAUDE.local.md' '!/.mcp.json'
+# Note: .mcp.json is NOT excluded so worktrees inherit MCP server config
+git sparse-checkout set --no-cone '/*' '!/.claude/' '!/CLAUDE.md' '!/CLAUDE.local.md'
 ```
 
 This ensures agents use Gas Town's context, not the source repo's instructions.
+MCP servers defined in `.mcp.json` are inherited by all worktrees for tool access.
 
 **Doctor check**: `gt doctor` verifies sparse checkout is configured correctly.
 Run `gt doctor --fix` to update legacy configurations missing the newer patterns.

--- a/internal/doctor/sparse_checkout_check.go
+++ b/internal/doctor/sparse_checkout_check.go
@@ -12,7 +12,8 @@ import (
 // SparseCheckoutCheck verifies that git clones/worktrees have sparse checkout configured
 // to exclude Claude Code context files from source repos. This ensures source repo settings
 // and instructions don't override Gas Town agent configuration.
-// Excluded files: .claude/, CLAUDE.md, CLAUDE.local.md, .mcp.json
+// Excluded files: .claude/, CLAUDE.md, CLAUDE.local.md
+// Note: .mcp.json is NOT excluded so worktrees inherit MCP server config.
 type SparseCheckoutCheck struct {
 	FixableCheck
 	rigPath       string

--- a/internal/doctor/sparse_checkout_check_test.go
+++ b/internal/doctor/sparse_checkout_check_test.go
@@ -370,11 +370,11 @@ func TestSparseCheckoutCheck_VerifiesAllPatterns(t *testing.T) {
 	contentStr := string(content)
 
 	// Verify all required patterns are present
+	// Note: .mcp.json is NOT excluded so worktrees inherit MCP server config
 	requiredPatterns := []string{
 		"!/.claude/",        // Settings, rules, agents, commands
 		"!/CLAUDE.md",       // Primary context file
 		"!/CLAUDE.local.md", // Personal context file
-		"!/.mcp.json",       // MCP server configuration
 	}
 
 	for _, pattern := range requiredPatterns {
@@ -464,7 +464,7 @@ func TestSparseCheckoutCheck_FixUpgradesLegacyPatterns(t *testing.T) {
 	}
 
 	contentStr := string(content)
-	requiredPatterns := []string{"!/.claude/", "!/CLAUDE.md", "!/CLAUDE.local.md", "!/.mcp.json"}
+	requiredPatterns := []string{"!/.claude/", "!/CLAUDE.md", "!/CLAUDE.local.md"}
 	for _, pattern := range requiredPatterns {
 		if !strings.Contains(contentStr, pattern) {
 			t.Errorf("after fix, sparse-checkout file missing pattern %q", pattern)
@@ -620,10 +620,11 @@ func TestSparseCheckoutCheck_FixFailsWithMultipleProblems(t *testing.T) {
 	initGitRepo(t, mayorRig)
 
 	// Create multiple untracked context files
+	// Note: .mcp.json is NOT excluded (worktrees inherit MCP config), so we test with CLAUDE.md and CLAUDE.local.md
 	if err := os.WriteFile(filepath.Join(mayorRig, "CLAUDE.md"), []byte("# Context\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(mayorRig, ".mcp.json"), []byte("{}"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(mayorRig, "CLAUDE.local.md"), []byte("# Local context\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -647,7 +648,7 @@ func TestSparseCheckoutCheck_FixFailsWithMultipleProblems(t *testing.T) {
 	if !strings.Contains(errStr, "CLAUDE.md") {
 		t.Errorf("expected error to mention CLAUDE.md, got: %v", err)
 	}
-	if !strings.Contains(errStr, ".mcp.json") {
-		t.Errorf("expected error to mention .mcp.json, got: %v", err)
+	if !strings.Contains(errStr, "CLAUDE.local.md") {
+		t.Errorf("expected error to mention CLAUDE.local.md, got: %v", err)
 	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -875,18 +875,18 @@ func ConfigureSparseCheckout(repoPath string) error {
 
 	// Write patterns directly to sparse-checkout file
 	// (git sparse-checkout set --stdin escapes the ! character incorrectly)
-	// Exclude all Claude Code context files to prevent source repo instructions
+	// Exclude Claude Code context files to prevent source repo instructions
 	// from interfering with Gas Town agent context:
 	// - .claude/      : settings, rules, agents, commands
 	// - CLAUDE.md     : primary context file
 	// - CLAUDE.local.md : personal context file
-	// - .mcp.json     : MCP server configuration
+	// Note: .mcp.json is NOT excluded so worktrees can inherit MCP server config
 	infoDir := filepath.Join(gitDir, "info")
 	if err := os.MkdirAll(infoDir, 0755); err != nil {
 		return fmt.Errorf("creating info dir: %w", err)
 	}
 	sparseFile := filepath.Join(infoDir, "sparse-checkout")
-	sparsePatterns := "/*\n!/.claude/\n!/CLAUDE.md\n!/CLAUDE.local.md\n!/.mcp.json\n"
+	sparsePatterns := "/*\n!/.claude/\n!/CLAUDE.md\n!/CLAUDE.local.md\n"
 	if err := os.WriteFile(sparseFile, []byte(sparsePatterns), 0644); err != nil {
 		return fmt.Errorf("writing sparse-checkout: %w", err)
 	}
@@ -910,11 +910,11 @@ func ConfigureSparseCheckout(repoPath string) error {
 }
 
 // ExcludedContextFiles lists all Claude context files that should be excluded by sparse checkout.
+// Note: .mcp.json is NOT excluded so worktrees can inherit MCP server config (e.g., Puppeteer).
 var ExcludedContextFiles = []string{
 	".claude",
 	"CLAUDE.md",
 	"CLAUDE.local.md",
-	".mcp.json",
 }
 
 // CheckExcludedFilesExist checks if any Claude context files still exist in the repo


### PR DESCRIPTION
## Summary

- Remove `.mcp.json` from the list of excluded files in sparse checkout configuration
- This allows worktrees (including polecat sandboxes) to inherit MCP server configuration from the project root
- Agents can now use MCP servers like Puppeteer that are defined in `.mcp.json`

## Background

Previously, `.mcp.json` was excluded along with other Claude context files (`.claude/`, `CLAUDE.md`, `CLAUDE.local.md`) to prevent source repo settings from overriding Gas Town agent configuration.

However, MCP server config is different from Claude context - agents need access to `.mcp.json` to use tools like Puppeteer for UI automation and visual inspection.

## Changes

- `internal/git/git.go`: Remove `!/.mcp.json` from sparse checkout patterns
- `internal/doctor/sparse_checkout_check.go`: Update comments
- `internal/doctor/sparse_checkout_check_test.go`: Update tests to not expect `.mcp.json` exclusion
- `docs/reference.md`: Update documentation

## Test plan

- [x] All existing tests pass
- [x] New polecat worktrees will include `.mcp.json` from source repo
- [x] Combined with `enableAllProjectMcpServers: true` in `polecats/.claude/settings.json`, polecats can use project MCP servers
