### PR TITLE
feat(rig): copy overlay files to refinery during rig creation

### DIFF
--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -471,6 +471,12 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 	if err := m.createRoleCLAUDEmd(refineryRigPath, "refinery", opts.Name, ""); err != nil {
 		return nil, fmt.Errorf("creating refinery CLAUDE.md: %w", err)
 	}
+	// Copy overlay files from .runtime/overlay/ to refinery root.
+	// This allows services to have .env and other config files at their root.
+	if err := CopyOverlay(rigPath, refineryRigPath); err != nil {
+		// Non-fatal - log warning but continue
+		fmt.Printf("  Warning: Could not copy overlay files to refinery: %v\n", err)
+	}
 	// Create refinery hooks for patrol triggering (at refinery/ level, not rig/)
 	refineryPath := filepath.Dir(refineryRigPath)
 	runtimeConfig := config.LoadRuntimeConfig(rigPath)


### PR DESCRIPTION
## Summary

Extends the overlay file pattern to refinery for feature parity with crew and polecat.

## Changes

- Call `CopyOverlay()` when creating refinery during `gt rig add`
- Copies files from `.runtime/overlay/` to refinery root (e.g., .env files)
- Non-fatal operation (warns but continues on failure)

## Background

Crew and polecat managers already use `CopyOverlay()` (added in commit e124402b, Jan 8). This extends the same pattern to refinery.

## Use Case

Refinery services often need configuration files at their root:
- `.env` files for environment variables
- `config.json` for service configuration
- Other service-specific config files

## Implementation

The overlay directory structure:
```
rig/
  .runtime/
    overlay/
      .env          <- Copied to refinery root
      config.json   <- Copied to refinery root
```

Called in `AddRig()` after creating refinery CLAUDE.md:
```go
if err := CopyOverlay(rigPath, refineryRigPath); err != nil {
    // Non-fatal - log warning but continue
    fmt.Printf("  Warning: Could not copy overlay files to refinery: %v\n", err)
}
```

## Safety

- Uses existing `rig.CopyOverlay()` utility (well-tested)
- Non-fatal operation - warns on failure but doesn't block rig creation
- No impact on existing rigs
- Only copies files (not directories) from overlay root

🤖 Generated with Claude Code