### PR TITLE
fix(polecat): verify and force removal of worktree directories during nuke

### DIFF
--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -590,6 +590,13 @@ func (m *Manager) RemoveWithOptions(name string, force, nuclear bool) error {
 	// Prune any stale worktree entries (non-fatal: cleanup only)
 	_ = repoGit.WorktreePrune()
 
+	// Verify removal succeeded (fixes #618)
+	// The above removal attempts may fail silently on permissions, symlinks, or busy files
+	if err := verifyRemovalComplete(polecatDir, clonePath); err != nil {
+		// Log warning but don't fail - the polecat is effectively "removed" from Gas Town's perspective
+		fmt.Printf("Warning: incomplete removal for %s: %v\n", name, err)
+	}
+
 	// Release name back to pool if it's a pooled name (non-fatal: state file update)
 	m.namePool.Release(name)
 	_ = m.namePool.Save()
@@ -606,6 +613,61 @@ func (m *Manager) RemoveWithOptions(name string, force, nuclear bool) error {
 	}
 
 	return nil
+}
+
+// verifyRemovalComplete checks that polecat directories were actually removed.
+// If they still exist, it attempts more aggressive cleanup and returns an error
+// describing what couldn't be removed.
+func verifyRemovalComplete(polecatDir, clonePath string) error {
+	var remaining []string
+
+	// Check if clone path still exists
+	if _, err := os.Stat(clonePath); err == nil {
+		// Try one more aggressive removal
+		if removeErr := forceRemoveDir(clonePath); removeErr != nil {
+			remaining = append(remaining, clonePath)
+		}
+	}
+
+	// Check if polecat dir still exists (and is different from clone path)
+	if polecatDir != clonePath {
+		if _, err := os.Stat(polecatDir); err == nil {
+			if removeErr := forceRemoveDir(polecatDir); removeErr != nil {
+				remaining = append(remaining, polecatDir)
+			}
+		}
+	}
+
+	if len(remaining) > 0 {
+		return fmt.Errorf("directories still exist after removal: %v", remaining)
+	}
+	return nil
+}
+
+// forceRemoveDir attempts aggressive removal of a directory.
+// It handles permission issues by making files writable before removal.
+func forceRemoveDir(dir string) error {
+	// First try normal removal
+	if err := os.RemoveAll(dir); err == nil {
+		return nil
+	}
+
+	// Walk the directory and make everything writable, then try again
+	_ = filepath.WalkDir(dir, func(path string, d os.DirEntry, err error) error {
+		if err != nil {
+			return nil // Continue on error
+		}
+		// Make writable (0755 for dirs, 0644 for files)
+		if d.IsDir() {
+			_ = os.Chmod(path, 0755)
+		} else {
+			_ = os.Chmod(path, 0644)
+		}
+		return nil
+	})
+
+	// Try removal again after fixing permissions
+	return os.RemoveAll(dir)
 }
 
 // AllocateName allocates a name from the name pool.


### PR DESCRIPTION
## Summary
Fixes #618

The existing removal logic has multiple fallbacks but doesn't verify that directories were actually removed.

## Problem
Directories can remain after nuke due to:
- Permission issues on files
- Busy files/directories  
- Symlinks pointing outside the worktree

## Changes
- Added `verifyRemovalComplete()` to check directories are actually gone after removal
- Added `forceRemoveDir()` for aggressive cleanup (chmod files writable, then retry)
- Log warning if complete removal fails (non-fatal)

## Test plan
- [x] Code compiles
- [ ] Test nuke on polecat with permission-locked files
- [ ] Test nuke on polecat with symlinks
- [ ] Verify warning appears when cleanup incomplete

## Related issues
- #698 - Orphan polecat state cleanup (fixed in #1073)
- #1070 - Worktree verification during spawn (fixed in #1072)