### PR TITLE
Fix witness LIFECYCLE:Shutdown to parse polecat name from message

### DIFF
--- a/internal/formula/formulas/mol-witness-patrol.formula.toml
+++ b/internal/formula/formulas/mol-witness-patrol.formula.toml
@@ -3,7 +3,39 @@ formula = 'mol-witness-patrol'
 version = 2
 
 [[steps]]
-description = "Check inbox and handle messages.\n\n```bash\ngt mail inbox\n```\n\nFor each message:\n\n**POLECAT_STARTED**:\nA new polecat has started working. Acknowledge and archive.\n```bash\n# Acknowledge startup (optional: log for activity tracking)\ngt mail archive <message-id>\n```\nNo action needed beyond acknowledgment - archive immediately.\n\n**POLECAT_DONE / LIFECYCLE:Shutdown**:\n\n*EPHEMERAL MODEL*: Polecats are truly ephemeral - done at MR submission,\nrecyclable immediately. Once the branch is pushed (cleanup_status=clean),\nthe polecat can be nuked. The MR lifecycle continues independently in the\nRefinery. If conflicts arise, Refinery creates a NEW conflict-resolution\ntask for a NEW polecat.\n\nPolecat lifecycle: spawning → working → mr_submitted → nuked\nMR lifecycle: created → queued → processed → merged (handled by Refinery)\n\nThe handler (HandlePolecatDone) will:\n1. Check cleanup_status from agent bead\n2. If \"clean\" (branch pushed): AUTO-NUKE immediately, archive mail\n3. If dirty: Create cleanup wisp for manual intervention\n\n```bash\n# The handler does this automatically:\n# - For clean state: gt polecat nuke <name> → archive mail\n# - For dirty state: create wisp → process in next step\n```\n\nCleanup wisps are only created when something is wrong (uncommitted changes,\nunpushed commits). Most POLECAT_DONE messages result in immediate nuke.\n\n**MERGED**:\nA branch was merged successfully. This is informational in the ephemeral model\nsince the polecat was already nuked after MR submission.\n\nIf a cleanup wisp exists (dirty state), complete the cleanup:\n```bash\n# Find the cleanup wisp for this polecat\nbd list --wisp --labels=polecat:<name>,state:merge-requested --status=open\n\n# If found, proceed with full polecat nuke:\ngt polecat nuke <name>\n\n# Burn the cleanup wisp\nbd close <wisp-id>\n```\nArchive after cleanup is complete.\n\n**HELP / Blocked**:\nAssess the request. Can you help? If not, escalate to Mayor:\n```bash\ngt mail send mayor/ -s \"Escalation: <polecat> needs help\" -m \"<details>\"\n```\nArchive after handling (escalated or resolved):\n```bash\ngt mail archive <message-id>\n```\n\n**HANDOFF**:\nRead predecessor context. Continue from where they left off.\nArchive after absorbing context:\n```bash\ngt mail archive <message-id>\n```\n\n**SWARM_START**:\nMayor initiating batch polecat work. Initialize swarm tracking.\n```bash\n# Parse swarm info from mail body: {\"swarm_id\": \"batch-123\", \"beads\": [\"bd-a\", \"bd-b\"]}\nbd create --wisp --title \"swarm:<swarm_id>\" --description \"Tracking batch: <swarm_id>\" --labels swarm,swarm_id:<swarm_id>,total:<N>,completed:0,start:<timestamp>\n```\nArchive after creating swarm tracking wisp:\n```bash\ngt mail archive <message-id>\n```\n\n**Hygiene principle**: Archive messages after they're fully processed.\nKeep only: active work, unprocessed requests. Inbox should be near-empty."
+description = "Check inbox and handle messages.\n\n```bash\ngt mail inbox\n```\n\nFor each message:\n\n**POLECAT_STARTED**:\nA new polecat has started working. Acknowledge and archive.\n```bash\n# Acknowledge startup (optional: log for activity tracking)\ngt mail archive <message-id>\n```\nNo action needed beyond acknowledgment - archive immediately.\n\n**POLECAT_DONE / LIFECYCLE:Shutdown**:
+
+**CRITICAL: Parse the polecat name from the message subject.**
+The subject format is `POLECAT_DONE <polecat-name>` or `LIFECYCLE:Shutdown <polecat-name>`.
+For example, if subject is \"LIFECYCLE:Shutdown alpha\", the polecat name is \"alpha\".
+
+**DO NOT** run `gt polecat list` and nuke whatever polecat you find.
+**ONLY** nuke the specific polecat named in the message subject.
+
+*EPHEMERAL MODEL*: Polecats are truly ephemeral - done at MR submission,
+recyclable immediately. Once the branch is pushed (cleanup_status=clean),
+the polecat can be nuked. The MR lifecycle continues independently in the
+Refinery. If conflicts arise, Refinery creates a NEW conflict-resolution
+task for a NEW polecat.
+
+Polecat lifecycle: spawning → working → mr_submitted → nuked
+MR lifecycle: created → queued → processed → merged (handled by Refinery)
+
+Steps to handle:
+1. Extract `<polecat-name>` from the message subject
+2. Check if that specific polecat exists:
+   ```bash
+   gt polecat list <rig> | grep \"<polecat-name>\"
+   ```
+3. If polecat doesn't exist, it's already gone - just archive the message
+4. If polecat exists, check cleanup_status and nuke ONLY that polecat:
+   ```bash
+   gt polecat nuke <rig>/<polecat-name>
+   ```
+5. Archive the message after handling
+
+Cleanup wisps are only created when something is wrong (uncommitted changes,
+unpushed commits). Most POLECAT_DONE messages result in immediate nuke.\n\n**MERGED**:\nA branch was merged successfully. This is informational in the ephemeral model\nsince the polecat was already nuked after MR submission.\n\nIf a cleanup wisp exists (dirty state), complete the cleanup:\n```bash\n# Find the cleanup wisp for this polecat\nbd list --wisp --labels=polecat:<name>,state:merge-requested --status=open\n\n# If found, proceed with full polecat nuke:\ngt polecat nuke <name>\n\n# Burn the cleanup wisp\nbd close <wisp-id>\n```\nArchive after cleanup is complete.\n\n**HELP / Blocked**:\nAssess the request. Can you help? If not, escalate to Mayor:\n```bash\ngt mail send mayor/ -s \"Escalation: <polecat> needs help\" -m \"<details>\"\n```\nArchive after handling (escalated or resolved):\n```bash\ngt mail archive <message-id>\n```\n\n**HANDOFF**:\nRead predecessor context. Continue from where they left off.\nArchive after absorbing context:\n```bash\ngt mail archive <message-id>\n```\n\n**SWARM_START**:\nMayor initiating batch polecat work. Initialize swarm tracking.\n```bash\n# Parse swarm info from mail body: {\"swarm_id\": \"batch-123\", \"beads\": [\"bd-a\", \"bd-b\"]}\nbd create --wisp --title \"swarm:<swarm_id>\" --description \"Tracking batch: <swarm_id>\" --labels swarm,swarm_id:<swarm_id>,total:<N>,completed:0,start:<timestamp>\n```\nArchive after creating swarm tracking wisp:\n```bash\ngt mail archive <message-id>\n```\n\n**Hygiene principle**: Archive messages after they're fully processed.\nKeep only: active work, unprocessed requests. Inbox should be near-empty."
 id = 'inbox-check'
 title = 'Process witness mail'
 


### PR DESCRIPTION
## Summary

The witness formula's `inbox-check` step didn't explicitly instruct the Claude agent to extract the polecat name from the `LIFECYCLE:Shutdown` message subject. This caused the agent to improvise by running `gt polecat list` and nuking whatever polecat was currently active - even if it was a DIFFERENT polecat than the one named in the shutdown message.

## The Bug

When witness receives `LIFECYCLE:Shutdown alpha`:
1. Agent runs `gt polecat list` and sees `rust` is active
2. Agent nukes `rust` (wrong!) instead of `alpha`
3. New polecat `rust` is destroyed, work is lost

## The Fix

Updated `mol-witness-patrol.formula.toml` to add explicit instructions:
1. Parse `<polecat-name>` from the message subject
2. Check if that specific polecat exists
3. **ONLY** nuke the named polecat, not whatever is currently active
4. Skip if the polecat doesn't exist (already gone)

## Test Plan

- [ ] Verify witness correctly parses polecat name from `LIFECYCLE:Shutdown <name>`
- [ ] Verify witness only nukes the named polecat
- [ ] Verify witness archives message if named polecat doesn't exist

Fixes #1071