### PR TITLE
fix: Prevent startup race condition and isolate polecat settings

### DIFF
--- a/internal/cmd/polecat_spawn.go
+++ b/internal/cmd/polecat_spawn.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
@@ -144,6 +145,18 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 		}
 		if err := polecatSessMgr.Start(polecatName, startOpts); err != nil {
 			return nil, fmt.Errorf("starting session: %w", err)
+		}
+
+		// Wait for runtime to be fully ready before returning.
+		// This prevents callers from sending nudges during Claude's initialization
+		// phase, which would interrupt the agent and cause "Interrupted" prompts.
+		// Fixes: https://github.com/steveyegge/gastown/issues/470
+		runtimeConfig := config.LoadRuntimeConfig(r.Path)
+		sessionName := polecatSessMgr.SessionName(polecatName)
+		if err := t.WaitForRuntimeReady(sessionName, runtimeConfig, 30*time.Second); err != nil {
+			// Non-fatal: session started, just not fully initialized yet.
+			// Caller should handle this gracefully.
+			fmt.Printf("Warning: runtime may not be fully ready: %v\n", err)
 		}
 	}
 

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -173,10 +173,12 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 
 	runtimeConfig := config.LoadRuntimeConfig(m.rig.Path)
 
-	// Ensure runtime settings exist in polecats/ (not polecats/<name>/) so we don't
-	// write into the source repo. Runtime walks up the tree to find settings.
-	polecatsDir := filepath.Join(m.rig.Path, "polecats")
-	if err := runtime.EnsureSettingsForRole(polecatsDir, "polecat", runtimeConfig); err != nil {
+	// Ensure runtime settings exist in polecat's home directory (polecats/<name>/).
+	// This keeps settings out of the git worktree while allowing runtime to find them
+	// when walking up the tree from workDir (polecats/<name>/<rigname>/).
+	// Each polecat gets isolated settings rather than sharing a single settings file.
+	polecatHomeDir := m.polecatDir(polecat)
+	if err := runtime.EnsureSettingsForRole(polecatHomeDir, "polecat", runtimeConfig); err != nil {
 		return fmt.Errorf("ensuring runtime settings: %w", err)
 	}
 


### PR DESCRIPTION
## Summary
Two related fixes for polecat lifecycle stability:

- **Startup race condition (#470)**: Wait for runtime readiness (prompt detection) before returning from `SpawnPolecatForSling`. Uses 30s timeout to prevent callers from sending nudges during Claude's initialization phase.
- **Settings isolation (#742)**: Write polecat settings to individual home directories (`polecats/<name>/`) instead of shared `polecats/` directory. Each polecat gets isolated settings.

## Test plan
- [ ] Spawn multiple polecats via `gt sling` and verify no "Interrupted" prompts
- [ ] Verify each polecat has its own settings.json in `polecats/<name>/`
- [ ] Verify settings.json is not written into git worktree

Fixes #470, #742