### PR TITLE
fix(polecat): prevent orphaned hooked work during concurrent sling

### DIFF
--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -546,6 +546,22 @@ func (m *Manager) RemoveWithOptions(name string, force, nuclear bool) error {
 		}
 	}
 
+	// FIX (gt-x7uaih): Close agent bead FIRST, before any filesystem operations.
+	// This prevents a race condition where:
+	// 1. Old polecat deletes worktree, releases name
+	// 2. New sling allocates same name, sets hook_bead = B
+	// 3. Old polecat's CloseAndClearAgentBead clears hook_bead → B orphaned!
+	//
+	// By closing the agent bead first, any concurrent sling sees a CLOSED bead
+	// and CreateOrReopenAgentBead safely reopens it with fresh state.
+	agentID := m.agentBeadID(name)
+	if err := m.beads.CloseAndClearAgentBead(agentID, "polecat removed"); err != nil {
+		// Only log if not "not found" - it's ok if it doesn't exist
+		if !errors.Is(err, beads.ErrNotFound) {
+			fmt.Printf("Warning: could not close agent bead %s: %v\n", agentID, err)
+		}
+	}
+
 	// Get repo base to remove the worktree properly
 	repoGit, err := m.repoBase()
 	if err != nil {
@@ -593,17 +609,6 @@ func (m *Manager) RemoveWithOptions(name string, force, nuclear bool) error {
 	// Release name back to pool if it's a pooled name (non-fatal: state file update)
 	m.namePool.Release(name)
 	_ = m.namePool.Save()
-
-	// Close agent bead (non-fatal: may not exist or beads may not be available)
-	// NOTE: We use CloseAndClearAgentBead instead of DeleteAgentBead because bd delete --hard
-	// creates tombstones that cannot be reopened.
-	agentID := m.agentBeadID(name)
-	if err := m.beads.CloseAndClearAgentBead(agentID, "polecat removed"); err != nil {
-		// Only log if not "not found" - it's ok if it doesn't exist
-		if !errors.Is(err, beads.ErrNotFound) {
-			fmt.Printf("Warning: could not close agent bead %s: %v\n", agentID, err)
-		}
-	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Reorders operations in `RemoveWithOptions` to close the agent bead BEFORE deleting the worktree and releasing the name. This prevents a race condition where concurrent slings can have their hooked work orphaned.

## Problem

When a polecat runs `gt done`, it calls `RemoveWithOptions` which previously:
1. Deleted the worktree
2. Released the name to the pool
3. Closed the agent bead

A concurrent `gt sling` could allocate the same name between steps 2 and 3, set `hook_bead = B` on the agent bead, and then have it cleared by step 3 of the old polecat's cleanup.

## Fix

Close the agent bead FIRST, before any filesystem operations:
1. Close the agent bead (clears hook, sets state=closed)
2. Delete the worktree  
3. Release the name to the pool

This ensures any concurrent sling sees a CLOSED bead and `CreateOrReopenAgentBead` safely reopens it with fresh state.

## Race Trace

<details>
<summary>Full race condition trace (before and after)</summary>

### Before Fix (Race)

```
TIME    gt done (polecat "rust")              gt sling (work B)
────    ────────────────────────              ─────────────────
T1      selfNukePolecat → RemoveWithOptions:
        ┌─────────────────────────────────┐
        │ 1. os.RemoveAll(polecatDir)     │  ← Directory gone
        │ 2. m.namePool.Release("rust")   │  ← Name available
        └─────────────────────────────────┘
                                              AllocateName():
T2                                            - Returns "rust"

T3                                            AddWithOptions("rust", {HookBead: B}):
                                              - CreateOrReopenAgentBead:
                                                - Sees OPEN agent bead
                                                - Updates hook_bead = B

        ┌─────────────────────────────────┐
T4      │ 3. CloseAndClearAgentBead       │  ← RACE: Clears B's hook!
        └─────────────────────────────────┘

RESULT: Work B orphaned (hook_bead cleared by old polecat's cleanup)
```

### After Fix

```
TIME    gt done (polecat "rust")              gt sling (work B)
────    ────────────────────────              ─────────────────
T1      selfNukePolecat → RemoveWithOptions:
        ┌─────────────────────────────────┐
        │ 1. CloseAndClearAgentBead       │  ← Agent bead CLOSED FIRST
        └─────────────────────────────────┘

T2      ┌─────────────────────────────────┐
        │ 2. os.RemoveAll(polecatDir)     │
        │ 3. m.namePool.Release("rust")   │
        └─────────────────────────────────┘
                                              AllocateName():
T3                                            - Returns "rust"

T4                                            AddWithOptions("rust", {HookBead: B}):
                                              - CreateOrReopenAgentBead:
                                                - Sees CLOSED agent bead
                                                - Reopens with fresh state
                                                - Sets hook_bead = B

RESULT: Work B safely hooked to fresh agent bead
```

</details>

## Test Plan

- [x] All existing tests pass
- [ ] Manual test: concurrent sling during gt done

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)