### PR TITLE
fix(dog): migrate from claude.EnsureSettingsForRole to runtime.EnsureSettingsForRole

### DIFF
--- a/internal/dog/session_manager.go
+++ b/internal/dog/session_manager.go
@@ -8,8 +8,8 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/steveyegge/gastown/internal/claude"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
@@ -103,9 +103,10 @@ func (m *SessionManager) Start(dogName string, opts SessionStartOptions) error {
 		}
 	}
 
-	// Ensure Claude settings exist for dogs
-	if err := claude.EnsureSettingsForRole(kennelDir, "dog"); err != nil {
-		return fmt.Errorf("ensuring Claude settings: %w", err)
+	// Ensure runtime settings exist for dogs
+	runtimeConfig := config.ResolveRoleAgentConfig("dog", m.townRoot, kennelDir)
+	if err := runtime.EnsureSettingsForRole(kennelDir, "dog", runtimeConfig); err != nil {
+		return fmt.Errorf("ensuring runtime settings: %w", err)
 	}
 
 	// Build startup prompt - dogs check mail for work


### PR DESCRIPTION
## Summary

- Migrate dog session manager to use `runtime.EnsureSettingsForRole` instead of `claude.EnsureSettingsForRole`
- This enables configurable agent runtimes for dog role via `role_agents` config

## Context

PR #1020 migrated all roles to the new agent-agnostic `runtime.EnsureSettingsForRole` pattern, but missed the `internal/dog/session_manager.go` file.

This caused an inconsistency where dog was the only role still using the Claude-specific `claude.EnsureSettingsForRole`, meaning it wouldn't respect `role_agents` configuration for alternative runtimes.

## Changes

- Replace `claude.EnsureSettingsForRole` with `runtime.EnsureSettingsForRole`
- Add `config.ResolveRoleAgentConfig` call to get runtime config
- Update import from `claude` to `runtime`

## Pattern

```go
// Before:
claude.EnsureSettingsForRole(kennelDir, "dog")

// After:
runtimeConfig := config.ResolveRoleAgentConfig("dog", m.townRoot, kennelDir)
runtime.EnsureSettingsForRole(kennelDir, "dog", runtimeConfig)
```

🤖 Generated with [Claude Code](https://claude.ai/code)