### PR TITLE
feat: add zombie auto-cleanup and gt deploy helper

### DIFF
--- a/internal/cmd/config_zombie.go
+++ b/internal/cmd/config_zombie.go
@@ -1,0 +1,185 @@
+// Package cmd provides CLI commands for the gt tool.
+package cmd
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/style"
+	"github.com/steveyegge/gastown/internal/workspace"
+)
+
+var configZombieCmd = &cobra.Command{
+	Use:   "zombie",
+	Short: "Manage zombie polecat auto-cleanup settings",
+	Long: `Manage zombie polecat auto-cleanup settings.
+
+When enabled, the deacon will automatically nuke polecats that have been
+idle for longer than the threshold with no hooked work.
+
+Examples:
+  gt config zombie                     # Show current settings
+  gt config zombie --enable            # Enable auto-cleanup
+  gt config zombie --disable           # Disable auto-cleanup
+  gt config zombie --threshold=2h      # Set idle threshold
+  gt config zombie --protect=max,dev   # Set protected polecats`,
+	RunE: runConfigZombie,
+}
+
+var (
+	zombieEnable    bool
+	zombieDisable   bool
+	zombieThreshold string
+	zombieProtect   string
+)
+
+func init() {
+	configZombieCmd.Flags().BoolVar(&zombieEnable, "enable", false, "Enable zombie auto-cleanup")
+	configZombieCmd.Flags().BoolVar(&zombieDisable, "disable", false, "Disable zombie auto-cleanup")
+	configZombieCmd.Flags().StringVar(&zombieThreshold, "threshold", "", "Idle threshold (e.g., 2h, 30m)")
+	configZombieCmd.Flags().StringVar(&zombieProtect, "protect", "", "Comma-separated list of protected polecat names")
+
+	configCmd.AddCommand(configZombieCmd)
+}
+
+func runConfigZombie(cmd *cobra.Command, args []string) error {
+	townRoot, err := workspace.FindFromCwd()
+	if err != nil {
+		return fmt.Errorf("finding town root: %w", err)
+	}
+
+	// Load mayor config
+	mayorConfigPath := config.MayorConfigPath(townRoot)
+	mayorConfig, err := config.LoadOrCreateMayorConfig(mayorConfigPath)
+	if err != nil {
+		return fmt.Errorf("loading mayor config: %w", err)
+	}
+
+	// Ensure deacon config exists
+	if mayorConfig.Deacon == nil {
+		mayorConfig.Deacon = &config.DeaconConfig{}
+	}
+	if mayorConfig.Deacon.Zombie == nil {
+		mayorConfig.Deacon.Zombie = &config.ZombieConfig{}
+	}
+
+	zombie := mayorConfig.Deacon.Zombie
+	modified := false
+
+	// Handle flags
+	if zombieEnable && zombieDisable {
+		return fmt.Errorf("cannot use both --enable and --disable")
+	}
+
+	if zombieEnable {
+		zombie.AutoCleanup = true
+		modified = true
+		fmt.Printf("%s Zombie auto-cleanup enabled\n", style.Green.Render("✓"))
+	}
+
+	if zombieDisable {
+		zombie.AutoCleanup = false
+		modified = true
+		fmt.Printf("%s Zombie auto-cleanup disabled\n", style.Yellow.Render("•"))
+	}
+
+	if zombieThreshold != "" {
+		// Validate threshold
+		if _, err := time.ParseDuration(zombieThreshold); err != nil {
+			return fmt.Errorf("invalid threshold duration: %w", err)
+		}
+		zombie.IdleThreshold = zombieThreshold
+		modified = true
+		fmt.Printf("%s Idle threshold set to %s\n", style.Green.Render("✓"), zombieThreshold)
+	}
+
+	if zombieProtect != "" {
+		if zombieProtect == "-" || zombieProtect == "none" {
+			zombie.Protected = nil
+		} else {
+			zombie.Protected = splitAndTrim(zombieProtect)
+		}
+		modified = true
+		if len(zombie.Protected) > 0 {
+			fmt.Printf("%s Protected polecats: %v\n", style.Green.Render("✓"), zombie.Protected)
+		} else {
+			fmt.Printf("%s Cleared protected polecats list\n", style.Yellow.Render("•"))
+		}
+	}
+
+	// Save if modified
+	if modified {
+		if err := config.SaveMayorConfig(mayorConfigPath, mayorConfig); err != nil {
+			return fmt.Errorf("saving mayor config: %w", err)
+		}
+	}
+
+	// Show current settings if no flags or after modification
+	if !modified || cmd.Flags().NFlag() > 0 {
+		fmt.Printf("\n%s\n\n", style.Bold.Render("Zombie Auto-Cleanup Settings"))
+
+		enabled := "disabled"
+		if zombie.AutoCleanup {
+			enabled = style.Green.Render("enabled")
+		} else {
+			enabled = style.Dim.Render("disabled")
+		}
+		fmt.Printf("  Auto-cleanup: %s\n", enabled)
+
+		threshold := zombie.IdleThreshold
+		if threshold == "" {
+			threshold = "2h (default)"
+		}
+		fmt.Printf("  Idle threshold: %s\n", threshold)
+
+		if len(zombie.Protected) > 0 {
+			fmt.Printf("  Protected: %v\n", zombie.Protected)
+		} else {
+			fmt.Printf("  Protected: %s\n", style.Dim.Render("none"))
+		}
+	}
+
+	return nil
+}
+
+func splitAndTrim(s string) []string {
+	var result []string
+	for _, part := range splitComma(s) {
+		trimmed := trimSpace(part)
+		if trimmed != "" {
+			result = append(result, trimmed)
+		}
+	}
+	return result
+}
+
+func splitComma(s string) []string {
+	var result []string
+	current := ""
+	for _, c := range s {
+		if c == ',' {
+			result = append(result, current)
+			current = ""
+		} else {
+			current += string(c)
+		}
+	}
+	if current != "" {
+		result = append(result, current)
+	}
+	return result
+}
+
+func trimSpace(s string) string {
+	start := 0
+	end := len(s)
+	for start < end && (s[start] == ' ' || s[start] == '\t') {
+		start++
+	}
+	for end > start && (s[end-1] == ' ' || s[end-1] == '\t') {
+		end--
+	}
+	return s[start:end]
+}

--- a/internal/cmd/deacon_zombie.go
+++ b/internal/cmd/deacon_zombie.go
@@ -1,0 +1,225 @@
+// Package cmd provides CLI commands for the gt tool.
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/polecat"
+	"github.com/steveyegge/gastown/internal/style"
+	"github.com/steveyegge/gastown/internal/workspace"
+)
+
+var deaconCleanupZombiesCmd = &cobra.Command{
+	Use:   "cleanup-zombies",
+	Short: "Auto-cleanup zombie polecats based on config",
+	Long: `Automatically cleanup zombie polecats based on configured thresholds.
+
+This command checks all polecats across all rigs and nukes those that:
+1. Have been idle longer than the configured threshold
+2. Have no hooked work (no active bead assignment)
+3. Are not in the protected list
+
+Configure settings with: gt config zombie --enable --threshold=2h
+
+Examples:
+  gt deacon cleanup-zombies           # Run cleanup
+  gt deacon cleanup-zombies --dry-run # Show what would be cleaned`,
+	RunE: runDeaconCleanupZombies,
+}
+
+var cleanupZombiesDryRun bool
+
+func init() {
+	deaconCleanupZombiesCmd.Flags().BoolVar(&cleanupZombiesDryRun, "dry-run", false, "Show what would be cleaned without actually cleaning")
+	deaconCmd.AddCommand(deaconCleanupZombiesCmd)
+}
+
+func runDeaconCleanupZombies(cmd *cobra.Command, args []string) error {
+	townRoot, err := workspace.FindFromCwd()
+	if err != nil {
+		return fmt.Errorf("finding town root: %w", err)
+	}
+
+	// Load mayor config
+	mayorConfigPath := config.MayorConfigPath(townRoot)
+	mayorConfig, err := config.LoadOrCreateMayorConfig(mayorConfigPath)
+	if err != nil {
+		return fmt.Errorf("loading mayor config: %w", err)
+	}
+
+	// Check if auto-cleanup is enabled
+	if mayorConfig.Deacon == nil || mayorConfig.Deacon.Zombie == nil || !mayorConfig.Deacon.Zombie.AutoCleanup {
+		fmt.Printf("%s Zombie auto-cleanup is disabled\n", style.Dim.Render("•"))
+		fmt.Println("Enable with: gt config zombie --enable")
+		return nil
+	}
+
+	zombie := mayorConfig.Deacon.Zombie
+
+	// Parse threshold
+	threshold := 2 * time.Hour // default
+	if zombie.IdleThreshold != "" {
+		parsed, err := time.ParseDuration(zombie.IdleThreshold)
+		if err != nil {
+			return fmt.Errorf("invalid idle threshold: %w", err)
+		}
+		threshold = parsed
+	}
+
+	// Build protected map
+	protected := make(map[string]bool)
+	for _, name := range zombie.Protected {
+		protected[name] = true
+	}
+
+	fmt.Printf("%s Scanning for zombie polecats (threshold: %s)\n\n",
+		style.Bold.Render("🧟"),
+		threshold)
+
+	// Find all rigs
+	rigEntries, err := findRigs(townRoot)
+	if err != nil {
+		return fmt.Errorf("finding rigs: %w", err)
+	}
+
+	cleaned := 0
+	skipped := 0
+
+	for _, rigPath := range rigEntries {
+		rigName := filepath.Base(rigPath)
+		polecatsDir := filepath.Join(rigPath, "polecats")
+
+		entries, err := os.ReadDir(polecatsDir)
+		if err != nil {
+			continue // No polecats directory
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() {
+				continue
+			}
+
+			polecatName := entry.Name()
+			polecatPath := filepath.Join(polecatsDir, polecatName)
+
+			// Check if protected
+			if protected[polecatName] {
+				fmt.Printf("  %s %s/%s (protected)\n",
+					style.Dim.Render("•"),
+					rigName,
+					polecatName)
+				skipped++
+				continue
+			}
+
+			// Check if has hooked work
+			hookFile := filepath.Join(polecatPath, ".beads", "hook.json")
+			if _, err := os.Stat(hookFile); err == nil {
+				// Has hooked work, skip
+				skipped++
+				continue
+			}
+
+			// Check idle time (using activity file or directory mtime)
+			activityFile := filepath.Join(polecatPath, ".beads", "activity.json")
+			var lastActivity time.Time
+
+			if info, err := os.Stat(activityFile); err == nil {
+				lastActivity = info.ModTime()
+			} else if info, err := os.Stat(polecatPath); err == nil {
+				lastActivity = info.ModTime()
+			} else {
+				continue
+			}
+
+			idleTime := time.Since(lastActivity)
+			if idleTime < threshold {
+				skipped++
+				continue
+			}
+
+			// This is a zombie - cleanup
+			fmt.Printf("  %s %s/%s (idle %s)\n",
+				style.Yellow.Render("→"),
+				rigName,
+				polecatName,
+				formatDuration(idleTime))
+
+			if !cleanupZombiesDryRun {
+				// Nuke the polecat
+				pm := polecat.NewManager(rigPath)
+				if err := pm.Nuke(polecatName, true); err != nil {
+					fmt.Printf("    %s Failed to nuke: %v\n", style.Red.Render("✗"), err)
+				} else {
+					fmt.Printf("    %s Nuked\n", style.Green.Render("✓"))
+					cleaned++
+				}
+			} else {
+				fmt.Printf("    %s Would nuke (dry-run)\n", style.Dim.Render("•"))
+				cleaned++
+			}
+		}
+	}
+
+	fmt.Println()
+	if cleanupZombiesDryRun {
+		fmt.Printf("%s Dry run: %d zombies found, %d skipped\n",
+			style.Yellow.Render("⚠"),
+			cleaned,
+			skipped)
+	} else if cleaned > 0 {
+		fmt.Printf("%s Cleaned %d zombies, %d skipped\n",
+			style.Green.Render("✓"),
+			cleaned,
+			skipped)
+	} else {
+		fmt.Printf("%s No zombies found (%d polecats checked)\n",
+			style.Green.Render("✓"),
+			skipped)
+	}
+
+	return nil
+}
+
+func findRigs(townRoot string) ([]string, error) {
+	var rigs []string
+
+	entries, err := os.ReadDir(townRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+
+		// Check if it looks like a rig (has polecats or refinery dir)
+		rigPath := filepath.Join(townRoot, entry.Name())
+		if _, err := os.Stat(filepath.Join(rigPath, "polecats")); err == nil {
+			rigs = append(rigs, rigPath)
+		} else if _, err := os.Stat(filepath.Join(rigPath, "refinery")); err == nil {
+			rigs = append(rigs, rigPath)
+		}
+	}
+
+	return rigs, nil
+}
+
+func formatDuration(d time.Duration) string {
+	if d < time.Minute {
+		return fmt.Sprintf("%ds", int(d.Seconds()))
+	}
+	if d < time.Hour {
+		return fmt.Sprintf("%dm", int(d.Minutes()))
+	}
+	if d < 24*time.Hour {
+		return fmt.Sprintf("%.1fh", d.Hours())
+	}
+	return fmt.Sprintf("%.1fd", d.Hours()/24)
+}

--- a/internal/cmd/deploy.go
+++ b/internal/cmd/deploy.go
@@ -1,0 +1,139 @@
+// Package cmd provides CLI commands for the gt tool.
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/style"
+)
+
+var deployCmd = &cobra.Command{
+	Use:   "deploy <file> <ct>:<path>",
+	Short: "Deploy a file to a Proxmox container",
+	Long: `Deploy a file to a Proxmox container via SSH and pct push.
+
+This command simplifies the common pattern of copying files to containers:
+  1. scp file to PVE host
+  2. pct push into container
+  3. optionally restart a service
+
+Examples:
+  gt deploy portal.html 103:/var/www/html/index.html
+  gt deploy app.py 109:/opt/app/app.py --restart myapp
+  gt deploy config.yml 112:/etc/caddy/Caddyfile --restart caddy
+  gt deploy --dry-run script.sh 107:/opt/scripts/
+
+The command assumes 'pve' is configured as an SSH host in your ~/.ssh/config.`,
+	Args: cobra.ExactArgs(2),
+	RunE: runDeploy,
+}
+
+var (
+	deployRestart string
+	deployDryRun  bool
+	deployPVEHost string
+)
+
+func init() {
+	deployCmd.Flags().StringVar(&deployRestart, "restart", "", "Systemd service to restart after deploy")
+	deployCmd.Flags().BoolVar(&deployDryRun, "dry-run", false, "Show commands without executing")
+	deployCmd.Flags().StringVar(&deployPVEHost, "pve", "pve", "SSH host for Proxmox (default: pve)")
+
+	rootCmd.AddCommand(deployCmd)
+}
+
+func runDeploy(cmd *cobra.Command, args []string) error {
+	localFile := args[0]
+	target := args[1]
+
+	// Parse target: CT:path
+	parts := strings.SplitN(target, ":", 2)
+	if len(parts) != 2 {
+		return fmt.Errorf("invalid target format, expected CT:path (e.g., 103:/var/www/html/index.html)")
+	}
+	ct := parts[0]
+	remotePath := parts[1]
+
+	// Verify local file exists
+	if _, err := os.Stat(localFile); os.IsNotExist(err) {
+		return fmt.Errorf("local file not found: %s", localFile)
+	}
+
+	// Get absolute path for local file
+	absLocalFile, err := filepath.Abs(localFile)
+	if err != nil {
+		return fmt.Errorf("getting absolute path: %w", err)
+	}
+
+	// Generate temp path on PVE
+	tmpFile := fmt.Sprintf("/tmp/%s", filepath.Base(localFile))
+
+	fmt.Printf("%s Deploying %s → CT %s:%s\n",
+		style.Bold.Render("→"),
+		style.Cyan.Render(filepath.Base(localFile)),
+		style.Yellow.Render(ct),
+		style.Dim.Render(remotePath))
+
+	// Step 1: scp to PVE
+	scpCmd := fmt.Sprintf("scp %s %s:%s", absLocalFile, deployPVEHost, tmpFile)
+	if deployDryRun {
+		fmt.Printf("  [dry-run] %s\n", scpCmd)
+	} else {
+		fmt.Printf("  %s Copying to PVE...\n", style.Dim.Render("•"))
+		if err := runShellCmd(scpCmd); err != nil {
+			return fmt.Errorf("scp failed: %w", err)
+		}
+	}
+
+	// Step 2: pct push into container
+	pushCmd := fmt.Sprintf("ssh %s \"pct push %s %s %s\"", deployPVEHost, ct, tmpFile, remotePath)
+	if deployDryRun {
+		fmt.Printf("  [dry-run] %s\n", pushCmd)
+	} else {
+		fmt.Printf("  %s Pushing to container...\n", style.Dim.Render("•"))
+		if err := runShellCmd(pushCmd); err != nil {
+			return fmt.Errorf("pct push failed: %w", err)
+		}
+	}
+
+	// Step 3: Cleanup temp file on PVE
+	cleanupCmd := fmt.Sprintf("ssh %s \"rm -f %s\"", deployPVEHost, tmpFile)
+	if deployDryRun {
+		fmt.Printf("  [dry-run] %s\n", cleanupCmd)
+	} else {
+		_ = runShellCmd(cleanupCmd) // Best effort cleanup
+	}
+
+	// Step 4: Optional service restart
+	if deployRestart != "" {
+		restartCmd := fmt.Sprintf("ssh %s \"pct exec %s -- systemctl restart %s\"", deployPVEHost, ct, deployRestart)
+		if deployDryRun {
+			fmt.Printf("  [dry-run] %s\n", restartCmd)
+		} else {
+			fmt.Printf("  %s Restarting %s...\n", style.Dim.Render("•"), deployRestart)
+			if err := runShellCmd(restartCmd); err != nil {
+				return fmt.Errorf("service restart failed: %w", err)
+			}
+		}
+	}
+
+	if deployDryRun {
+		fmt.Printf("\n%s Dry run complete\n", style.Yellow.Render("⚠"))
+	} else {
+		fmt.Printf("%s Deployed successfully\n", style.Green.Render("✓"))
+	}
+
+	return nil
+}
+
+func runShellCmd(command string) error {
+	cmd := exec.Command("sh", "-c", command)
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -146,7 +146,25 @@ func NewDaemonPatrolConfig() *DaemonPatrolConfig {
 
 // DeaconConfig represents deacon process settings.
 type DeaconConfig struct {
-	PatrolInterval string `json:"patrol_interval,omitempty"` // e.g., "5m"
+	PatrolInterval string        `json:"patrol_interval,omitempty"` // e.g., "5m"
+	Zombie         *ZombieConfig `json:"zombie,omitempty"`          // zombie auto-cleanup settings
+}
+
+// ZombieConfig represents zombie polecat auto-cleanup settings.
+type ZombieConfig struct {
+	// AutoCleanup enables automatic cleanup of zombie polecats.
+	// When true, the deacon will nuke polecats that have been idle
+	// past the IdleThreshold with no hooked work.
+	AutoCleanup bool `json:"auto_cleanup,omitempty"`
+
+	// IdleThreshold is the duration after which an idle polecat
+	// with no hooked work is considered a zombie and eligible for cleanup.
+	// Default: "2h" (2 hours)
+	IdleThreshold string `json:"idle_threshold,omitempty"`
+
+	// Protected is a list of polecat names that should never be auto-cleaned.
+	// Example: ["max", "dev"]
+	Protected []string `json:"protected,omitempty"`
 }
 
 // CurrentMayorConfigVersion is the current schema version for MayorConfig.


### PR DESCRIPTION
## Summary
- Add `gt deploy` command for simplified container file deployment (scp + pct push in one command)
- Add `gt config zombie` command to manage zombie polecat auto-cleanup settings
- Add `gt deacon cleanup-zombies` command to automatically clean up idle polecats

## Features

### gt deploy
Simplifies the common pattern of deploying files to Proxmox containers:
```bash
gt deploy portal.html 103:/var/www/html/index.html
gt deploy app.py 109:/opt/app/app.py --restart myapp
```

### Zombie Auto-Cleanup
Automatically nukes polecats that have been idle past a threshold with no hooked work:
```bash
gt config zombie --enable --threshold=2h --protect=max,dev
gt deacon cleanup-zombies           # Run cleanup
gt deacon cleanup-zombies --dry-run # Preview what would be cleaned
```

## Test plan
- [ ] Test `gt deploy` with various file types and containers
- [ ] Test `gt config zombie` enable/disable/threshold/protect flags
- [ ] Test `gt deacon cleanup-zombies` with --dry-run and actual cleanup
- [ ] Verify protected polecats are not nuked
- [ ] Verify polecats with hooked work are not nuked

🤖 Generated with [Claude Code](https://claude.com/claude-code)