### PR TITLE
feat(deacon): add feed-stranded-convoys step to patrol

### DIFF
--- a/.beads/formulas/mol-deacon-patrol.formula.toml
+++ b/.beads/formulas/mol-deacon-patrol.formula.toml
@@ -23,7 +23,7 @@ Witnesses detect it and escalate to the Mayor.
 The Deacon's agent bead last_activity timestamp is updated during each patrol
 cycle. Witnesses check this timestamp to verify health."""
 formula = "mol-deacon-patrol"
-version = 8
+version = 9
 
 [[steps]]
 id = "inbox-check"
@@ -262,9 +262,50 @@ bd close <convoy-id> --reason "All tracked issues completed"
 **Note**: Convoys support cross-prefix tracking (e.g., hq-* convoy can track gt-*, bd-* issues). Use full IDs when checking."""
 
 [[steps]]
+id = "feed-stranded-convoys"
+title = "Feed stranded convoys"
+needs = ["check-convoy-completion"]
+description = """
+Detect stranded convoys and dispatch dogs to feed them.
+
+A convoy is "stranded" when it has ready issues (open, unblocked, no assignee)
+but no workers are processing them. This step ensures work doesn't stall.
+
+**Step 1: Check for stranded convoys**
+```bash
+gt convoy stranded --json
+```
+
+If no stranded convoys, skip to exit criteria.
+
+**Step 2: For each stranded convoy, dispatch a dog**
+```bash
+# For each convoy in the stranded list:
+gt sling mol-convoy-feed deacon/dogs --var convoy=<convoy-id>
+```
+
+The dog will:
+1. Load the convoy and find ready issues
+2. Check polecat capacity across rigs
+3. Dispatch ready issues using `gt sling`
+4. Return to kennel
+
+**Step 3: Log dispatches**
+Note which convoys were fed for observability:
+```bash
+# Convoy <convoy-id> dispatched to dog for feeding (<N> ready issues)
+```
+
+**If no idle dogs available:**
+Log warning and continue - the convoy will be detected again next cycle.
+Dog pool maintenance step ensures dogs are available.
+
+**Exit criteria:** All stranded convoys have feeding dogs dispatched (or logged if no dogs available)."""
+
+[[steps]]
 id = "resolve-external-deps"
 title = "Resolve external dependencies"
-needs = ["check-convoy-completion"]
+needs = ["feed-stranded-convoys"]
 description = """
 Resolve external dependencies across rigs.
 

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -759,7 +759,7 @@ func runConvoyStranded(cmd *cobra.Command, args []string) error {
 
 // findStrandedConvoys finds convoys with ready work but no workers.
 func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
-	var stranded []strandedConvoyInfo
+	stranded := []strandedConvoyInfo{} // Initialize as empty slice for proper JSON encoding
 
 	// Get blocked issues (we need this to filter out blocked issues)
 	blockedIssues := getBlockedIssueIDs()

--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -23,7 +23,7 @@ Witnesses detect it and escalate to the Mayor.
 The Deacon's agent bead last_activity timestamp is updated during each patrol
 cycle. Witnesses check this timestamp to verify health."""
 formula = "mol-deacon-patrol"
-version = 8
+version = 9
 
 [[steps]]
 id = "inbox-check"
@@ -262,9 +262,50 @@ bd close <convoy-id> --reason "All tracked issues completed"
 **Note**: Convoys support cross-prefix tracking (e.g., hq-* convoy can track gt-*, bd-* issues). Use full IDs when checking."""
 
 [[steps]]
+id = "feed-stranded-convoys"
+title = "Feed stranded convoys"
+needs = ["check-convoy-completion"]
+description = """
+Detect stranded convoys and dispatch dogs to feed them.
+
+A convoy is "stranded" when it has ready issues (open, unblocked, no assignee)
+but no workers are processing them. This step ensures work doesn't stall.
+
+**Step 1: Check for stranded convoys**
+```bash
+gt convoy stranded --json
+```
+
+If no stranded convoys, skip to exit criteria.
+
+**Step 2: For each stranded convoy, dispatch a dog**
+```bash
+# For each convoy in the stranded list:
+gt sling mol-convoy-feed deacon/dogs --var convoy=<convoy-id>
+```
+
+The dog will:
+1. Load the convoy and find ready issues
+2. Check polecat capacity across rigs
+3. Dispatch ready issues using `gt sling`
+4. Return to kennel
+
+**Step 3: Log dispatches**
+Note which convoys were fed for observability:
+```bash
+# Convoy <convoy-id> dispatched to dog for feeding (<N> ready issues)
+```
+
+**If no idle dogs available:**
+Log warning and continue - the convoy will be detected again next cycle.
+Dog pool maintenance step ensures dogs are available.
+
+**Exit criteria:** All stranded convoys have feeding dogs dispatched (or logged if no dogs available)."""
+
+[[steps]]
 id = "resolve-external-deps"
 title = "Resolve external dependencies"
-needs = ["check-convoy-completion"]
+needs = ["feed-stranded-convoys"]
 description = """
 Resolve external dependencies across rigs.
 


### PR DESCRIPTION
## Summary

Adds a `feed-stranded-convoys` step to the Deacon patrol formula that automatically detects and feeds stranded convoys.

A convoy is "stranded" when it has ready issues (open, unblocked, no assignee) but no workers are processing them. This step uses `gt convoy stranded` to detect these and dispatches dogs with `mol-convoy-feed` to sling the ready issues to polecats.

## Why this is needed

The existing Deacon patrol steps don't handle the case where a convoy has ready work that was never picked up:

| Existing Step | What it handles |
|---------------|-----------------|
| `check-convoy-completion` | Checks if convoy is DONE (all issues closed) |
| `orphan-check` | Issues **in_progress** but assignee session is dead |

Neither handles **open** issues that are unblocked but have no assignee. This gap means convoys could sit idle indefinitely waiting for someone to manually sling the issues.

## Changes

- **New patrol step**: `feed-stranded-convoys` inserted between `check-convoy-completion` and `resolve-external-deps`
- **JSON fix**: `gt convoy stranded --json` now returns `[]` instead of `null` for empty results
- Bumps formula version to 9

## How it works

1. Deacon patrol runs `gt convoy stranded --json`
2. For each stranded convoy, dispatches: `gt sling mol-convoy-feed deacon/dogs --var convoy=<id>`
3. Dog executes mol-convoy-feed formula, which slings ready issues to available polecats
4. Dog returns to kennel, convoy is no longer stranded

## Testing

Manually verified in local Gas Town setup:
- ✅ `gt convoy stranded` correctly detects convoys with ready unassigned issues
- ✅ `gt convoy stranded --json` returns proper array (empty `[]` or populated)
- ✅ `gt sling mol-convoy-feed deacon/dogs --var convoy=X` dispatches to idle dog
- ✅ Dog gets assigned and wisp is created/hooked

🤖 Generated with [Claude Code](https://claude.com/claude-code)