### PR TITLE
fix(templates): remove hardcoded repo names from role templates

### DIFF
--- a/internal/templates/roles/crew.md.tmpl
+++ b/internal/templates/roles/crew.md.tmpl
@@ -262,13 +262,13 @@ instructions immediately. Useful for one-off tasks that don't warrant a full bea
 
 ### No PRs in Maintainer Repos
 
-If the remote origin is `steveyegge/beads` or `steveyegge/gastown`:
+If you have push access to the remote origin (you're a maintainer or owner):
 - **NEVER create GitHub PRs** - you have direct push access
 - Crew workers: push directly to main
 - Polecats: use `gt done` → Refinery merges to main
 
 PRs are for external contributors submitting to repos they don't own.
-Check `git remote -v` if unsure about repo ownership.
+Check `git remote -v` and your GitHub permissions if unsure about repo access.
 
 ### The Landing Rule
 

--- a/internal/templates/roles/polecat.md.tmpl
+++ b/internal/templates/roles/polecat.md.tmpl
@@ -371,13 +371,13 @@ closes it after successful merge. This enables conflict-resolution retries.
 
 ### No PRs in Maintainer Repos
 
-If the remote origin is `steveyegge/beads` or `steveyegge/gastown`:
+If you have push access to the remote origin (you're a maintainer or owner):
 - **NEVER create GitHub PRs** - you have direct push access
 - Polecats: use `gt done` → Refinery merges to main
 - Crew workers: push directly to main
 
 PRs are for external contributors submitting to repos they don't own.
-Check `git remote -v` if unsure about repo ownership.
+Check `git remote -v` and your GitHub permissions if unsure about repo access.
 
 ### The Landing Rule
 

--- a/templates/polecat-CLAUDE.md
+++ b/templates/polecat-CLAUDE.md
@@ -212,13 +212,13 @@ you (you don't exist anymore).
 
 ### No PRs in Maintainer Repos
 
-If the remote origin is `steveyegge/beads` or `steveyegge/gastown`:
+If you have push access to the remote origin (you're a maintainer or owner):
 - **NEVER create GitHub PRs** - you have direct push access
 - Polecats: use `gt done` → Refinery merges to main
 - Crew workers: push directly to main
 
 PRs are for external contributors submitting to repos they don't own.
-Check `git remote -v` if unsure about repo ownership.
+Check `git remote -v` and your GitHub permissions if unsure about repo access.
 
 ### The Landing Rule
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `steveyegge/beads` and `steveyegge/gastown` references in role templates
- Use generic guidance about repos where user has push access (maintainer/owner)
- Updated 3 template files: crew.md.tmpl, polecat.md.tmpl, polecat-CLAUDE.md

## Test plan
- [ ] Verify template rendering still works correctly
- [ ] Confirm guidance is clear for users with different repo access levels

Closes #849