### PR TITLE
fix(rig): zero struct before unmarshaling in unsetNestedValue

### DIFF
--- a/internal/cmd/rig_settings.go
+++ b/internal/cmd/rig_settings.go
@@ -1,0 +1,410 @@
+// Package cmd provides CLI commands for the gt tool.
+// This file implements the gt rig settings commands for viewing and manipulating
+// rig settings/config.json files.
+package cmd
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"reflect"
+	"strconv"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/style"
+)
+
+var rigSettingsCmd = &cobra.Command{
+	Use:   "settings",
+	Short: "View and manage rig settings",
+	Long: `View and manage rig settings (settings/config.json).
+
+Rig settings control behavioral configuration for a rig:
+- Agent selection and overrides
+- Merge queue settings
+- Theme configuration
+- Namepool settings
+- Crew startup settings
+- Workflow settings
+
+Settings are stored in settings/config.json within each rig directory.
+Use dot notation to access nested keys (e.g., role_agents.witness).`,
+	RunE: requireSubcommand,
+}
+
+var rigSettingsShowCmd = &cobra.Command{
+	Use:   "show <rig>",
+	Short: "Display all settings",
+	Long: `Display all settings for a rig.
+
+Shows the complete settings/config.json file as formatted JSON.
+
+Example:
+  gt rig settings show gastown`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRigSettingsShow,
+}
+
+var rigSettingsSetCmd = &cobra.Command{
+	Use:   "set <rig> <key-path> <value>",
+	Short: "Set a settings value",
+	Long: `Set a settings value using dot notation for nested keys.
+
+The value type is automatically inferred:
+- "true"/"false" → boolean
+- Numbers → number
+- Valid JSON → parsed as JSON
+- Otherwise → string
+
+If the settings file doesn't exist, it will be created with a valid scaffold.
+
+Examples:
+  gt rig settings set gastown agent claude
+  gt rig settings set gastown role_agents.witness gemini
+  gt rig settings set gastown merge_queue.max_concurrent 5
+  gt rig settings set gastown theme.background_color "#000000"`,
+	Args: cobra.ExactArgs(3),
+	RunE: runRigSettingsSet,
+}
+
+var rigSettingsUnsetCmd = &cobra.Command{
+	Use:   "unset <rig> <key-path>",
+	Short: "Remove a settings value",
+	Long: `Remove a settings value using dot notation for nested keys.
+
+This removes the key from the settings file. For nested keys, only the
+specified key is removed (parent objects remain if they have other keys).
+
+Examples:
+  gt rig settings unset gastown agent
+  gt rig settings unset gastown role_agents.witness`,
+	Args: cobra.ExactArgs(2),
+	RunE: runRigSettingsUnset,
+}
+
+func init() {
+	rigCmd.AddCommand(rigSettingsCmd)
+	rigSettingsCmd.AddCommand(rigSettingsShowCmd)
+	rigSettingsCmd.AddCommand(rigSettingsSetCmd)
+	rigSettingsCmd.AddCommand(rigSettingsUnsetCmd)
+}
+
+func runRigSettingsShow(cmd *cobra.Command, args []string) error {
+	rigName := args[0]
+
+	_, r, err := getRig(rigName)
+	if err != nil {
+		return err
+	}
+
+	settingsPath := filepath.Join(r.Path, "settings", "config.json")
+	settings, err := config.LoadRigSettings(settingsPath)
+	if err != nil {
+		if errors.Is(err, config.ErrNotFound) {
+			fmt.Printf("No settings file found at %s\n", settingsPath)
+			fmt.Printf("Use 'gt rig settings set' to create one.\n")
+			return nil
+		}
+		return fmt.Errorf("loading settings: %w", err)
+	}
+
+	// Format as JSON
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		return fmt.Errorf("formatting settings: %w", err)
+	}
+
+	fmt.Println(string(data))
+	return nil
+}
+
+func runRigSettingsSet(cmd *cobra.Command, args []string) error {
+	rigName := args[0]
+	keyPath := args[1]
+	valueStr := args[2]
+
+	_, r, err := getRig(rigName)
+	if err != nil {
+		return err
+	}
+
+	settingsPath := filepath.Join(r.Path, "settings", "config.json")
+
+	// Load existing settings or create new
+	settings, err := config.LoadRigSettings(settingsPath)
+	if err != nil {
+		if errors.Is(err, config.ErrNotFound) {
+			// Create new settings with scaffold
+			settings = config.NewRigSettings()
+		} else {
+			return fmt.Errorf("loading settings: %w", err)
+		}
+	}
+
+	// Parse the value
+	value, err := parseValue(valueStr)
+	if err != nil {
+		return fmt.Errorf("parsing value: %w", err)
+	}
+
+	// Set the value using dot notation
+	if err := setNestedValue(settings, keyPath, value); err != nil {
+		return fmt.Errorf("setting %s: %w", keyPath, err)
+	}
+
+	// Save the settings
+	if err := config.SaveRigSettings(settingsPath, settings); err != nil {
+		return fmt.Errorf("saving settings: %w", err)
+	}
+
+	fmt.Printf("%s Set %s=%v in settings for rig %s\n",
+		style.Success.Render("✓"), keyPath, formatValueForDisplay(value), rigName)
+	return nil
+}
+
+func runRigSettingsUnset(cmd *cobra.Command, args []string) error {
+	rigName := args[0]
+	keyPath := args[1]
+
+	_, r, err := getRig(rigName)
+	if err != nil {
+		return err
+	}
+
+	settingsPath := filepath.Join(r.Path, "settings", "config.json")
+
+	// Load existing settings
+	settings, err := config.LoadRigSettings(settingsPath)
+	if err != nil {
+		if errors.Is(err, config.ErrNotFound) {
+			return fmt.Errorf("settings file not found at %s", settingsPath)
+		}
+		return fmt.Errorf("loading settings: %w", err)
+	}
+
+	// Unset the value using dot notation
+	if err := unsetNestedValue(settings, keyPath); err != nil {
+		return fmt.Errorf("unsetting %s: %w", keyPath, err)
+	}
+
+	// Save the settings
+	if err := config.SaveRigSettings(settingsPath, settings); err != nil {
+		return fmt.Errorf("saving settings: %w", err)
+	}
+
+	fmt.Printf("%s Unset %s from settings for rig %s\n",
+		style.Success.Render("✓"), keyPath, rigName)
+	return nil
+}
+
+// parseValue attempts to parse a string value into the appropriate type.
+// Tries: bool → number → JSON → string
+func parseValue(s string) (interface{}, error) {
+	// Try boolean
+	if s == "true" {
+		return true, nil
+	}
+	if s == "false" {
+		return false, nil
+	}
+
+	// Try integer
+	if i, err := strconv.Atoi(s); err == nil {
+		return i, nil
+	}
+
+	// Try float
+	if f, err := strconv.ParseFloat(s, 64); err == nil {
+		return f, nil
+	}
+
+	// Try JSON
+	var jsonValue interface{}
+	if err := json.Unmarshal([]byte(s), &jsonValue); err == nil {
+		return jsonValue, nil
+	}
+
+	// Default to string
+	return s, nil
+}
+
+// setNestedValue sets a value in a nested structure using dot notation.
+// For example, "role_agents.witness" sets settings.RoleAgents["witness"].
+func setNestedValue(obj interface{}, keyPath string, value interface{}) error {
+	keys := strings.Split(keyPath, ".")
+	if len(keys) == 0 || (len(keys) == 1 && keys[0] == "") {
+		return fmt.Errorf("empty key path")
+	}
+
+	// Convert to map for manipulation
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("marshaling object: %w", err)
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return fmt.Errorf("unmarshaling object: %w", err)
+	}
+
+	// Navigate to the parent of the target key
+	current := m
+	for i := 0; i < len(keys)-1; i++ {
+		key := keys[i]
+		if val, ok := current[key]; ok {
+			// Check if it's a map
+			if nestedMap, ok := val.(map[string]interface{}); ok {
+				current = nestedMap
+			} else {
+				// Convert to map if it's not already
+				valData, err := json.Marshal(val)
+				if err != nil {
+					return fmt.Errorf("marshaling nested value: %w", err)
+				}
+				var newMap map[string]interface{}
+				if err := json.Unmarshal(valData, &newMap); err != nil {
+					return fmt.Errorf("cannot set nested key %s: parent is not an object", key)
+				}
+				current[key] = newMap
+				current = newMap
+			}
+		} else {
+			// Create new nested map
+			newMap := make(map[string]interface{})
+			current[key] = newMap
+			current = newMap
+		}
+	}
+
+	// Set the final value
+	finalKey := keys[len(keys)-1]
+	current[finalKey] = value
+
+	// Convert back to the original type
+	data, err = json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshaling result: %w", err)
+	}
+
+	// Unmarshal back into the original struct
+	if err := json.Unmarshal(data, obj); err != nil {
+		return fmt.Errorf("unmarshaling result: %w", err)
+	}
+
+	// Verify the value was actually set by marshaling back and checking.
+	// Unknown fields are silently dropped by json.Unmarshal, so we need to
+	// confirm the key exists in the output.
+	var verifyMap map[string]interface{}
+	checkData, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("marshaling for verification: %w", err)
+	}
+	if err := json.Unmarshal(checkData, &verifyMap); err != nil {
+		return fmt.Errorf("unmarshaling for verification: %w", err)
+	}
+
+	// Navigate to the key in the verified output
+	verifyCurrent := verifyMap
+	for i, key := range keys {
+		if i == len(keys)-1 {
+			// This is the final key - check if it exists
+			if _, exists := verifyCurrent[key]; !exists {
+				// The field doesn't exist in the struct definition
+				// List all valid top-level keys from RigSettings
+				validKeys := []string{
+					"type", "version",
+					"merge_queue", "theme", "namepool", "crew", "workflow",
+					"runtime", "agent", "agents", "role_agents",
+				}
+				return fmt.Errorf("unknown key %q (valid top-level keys: %s)", keyPath, strings.Join(validKeys, ", "))
+			}
+			break
+		}
+		// Navigate deeper
+		next, ok := verifyCurrent[key].(map[string]interface{})
+		if !ok {
+			return fmt.Errorf("invalid key path %q: %s is not an object", keyPath, key)
+		}
+		verifyCurrent = next
+	}
+
+	return nil
+}
+
+// unsetNestedValue removes a value from a nested structure using dot notation.
+func unsetNestedValue(obj interface{}, keyPath string) error {
+	keys := strings.Split(keyPath, ".")
+	if len(keys) == 0 {
+		return fmt.Errorf("empty key path")
+	}
+
+	// Convert to map for manipulation
+	data, err := json.Marshal(obj)
+	if err != nil {
+		return fmt.Errorf("marshaling object: %w", err)
+	}
+
+	var m map[string]interface{}
+	if err := json.Unmarshal(data, &m); err != nil {
+		return fmt.Errorf("unmarshaling object: %w", err)
+	}
+
+	// Navigate to the parent of the target key
+	current := m
+	for i := 0; i < len(keys)-1; i++ {
+		key := keys[i]
+		if val, ok := current[key]; ok {
+			if nestedMap, ok := val.(map[string]interface{}); ok {
+				current = nestedMap
+			} else {
+				return fmt.Errorf("cannot unset nested key %s: parent is not an object", key)
+			}
+		} else {
+			return fmt.Errorf("key path %s not found", keyPath)
+		}
+	}
+
+	// Remove the final key
+	finalKey := keys[len(keys)-1]
+	if _, ok := current[finalKey]; !ok {
+		return fmt.Errorf("key %s not found", keyPath)
+	}
+	delete(current, finalKey)
+
+	// Convert back to the original type
+	data, err = json.Marshal(m)
+	if err != nil {
+		return fmt.Errorf("marshaling result: %w", err)
+	}
+
+	// Zero out the struct before unmarshaling so deleted keys don't persist.
+	// json.Unmarshal only updates fields present in JSON, so we need to
+	// reset the struct first to ensure deleted keys are actually removed.
+	objVal := reflect.ValueOf(obj).Elem()
+	objVal.Set(reflect.Zero(objVal.Type()))
+
+	// Unmarshal back into the zeroed struct
+	if err := json.Unmarshal(data, obj); err != nil {
+		return fmt.Errorf("unmarshaling result: %w", err)
+	}
+
+	return nil
+}
+
+// formatValueForDisplay formats a value for display in success messages.
+func formatValueForDisplay(v interface{}) string {
+	switch val := v.(type) {
+	case string:
+		return fmt.Sprintf("%q", val)
+	case bool:
+		if val {
+			return "true"
+		}
+		return "false"
+	default:
+		return fmt.Sprintf("%v", v)
+	}
+}

--- a/internal/cmd/rig_settings_test.go
+++ b/internal/cmd/rig_settings_test.go
@@ -1,0 +1,813 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/config"
+)
+
+// setupTestRigForSettings creates a test rig for settings testing.
+// Returns townRoot, rigName, and a cleanup function.
+func setupTestRigForSettings(t *testing.T) (string, string) {
+	t.Helper()
+
+	townRoot := t.TempDir()
+
+	// Create mayor directory and town.json (required for workspace detection)
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+
+	// Create town.json (primary marker for workspace detection)
+	townConfig := &config.TownConfig{
+		Type:      "town",
+		Version:    config.CurrentTownVersion,
+		Name:       "test-town",
+		CreatedAt:  time.Now().Truncate(time.Second),
+	}
+	townConfigPath := filepath.Join(mayorDir, "town.json")
+	if err := config.SaveTownConfig(townConfigPath, townConfig); err != nil {
+		t.Fatalf("save town.json: %v", err)
+	}
+
+	// Create rigs.json
+	rigsPath := filepath.Join(mayorDir, "rigs.json")
+	rigsConfig := &config.RigsConfig{
+		Version: 1,
+		Rigs: map[string]config.RigEntry{
+			"testrig": {
+				GitURL:  "git@github.com:test/testrig.git",
+				AddedAt: time.Now().Truncate(time.Second),
+			},
+		},
+	}
+	if err := config.SaveRigsConfig(rigsPath, rigsConfig); err != nil {
+		t.Fatalf("save rigs.json: %v", err)
+	}
+
+	// Create rig directory structure
+	rigPath := filepath.Join(townRoot, "testrig")
+	if err := os.MkdirAll(rigPath, 0755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+
+	// Create rig config.json
+	rigConfig := config.NewRigConfig("testrig", "git@github.com:test/testrig.git")
+	rigConfigPath := filepath.Join(rigPath, "config.json")
+	if err := config.SaveRigConfig(rigConfigPath, rigConfig); err != nil {
+		t.Fatalf("save rig config: %v", err)
+	}
+
+	// Change to town root so workspace.FindFromCwdOrError works
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get current directory: %v", err)
+	}
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("chdir to town root: %v", err)
+	}
+	t.Cleanup(func() {
+		os.Chdir(oldCwd)
+	})
+
+	return townRoot, "testrig"
+}
+
+func TestRigSettingsShow(t *testing.T) {
+	t.Run("shows existing settings file", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Create settings file with some data
+		settingsPath := filepath.Join(rigPath, "settings", "config.json")
+		settings := config.NewRigSettings()
+		settings.Agent = "claude"
+		settings.RoleAgents = map[string]string{
+			"witness": "gemini",
+		}
+		if err := config.SaveRigSettings(settingsPath, settings); err != nil {
+			t.Fatalf("save settings: %v", err)
+		}
+
+		// Run show command
+		cmd := rigSettingsShowCmd
+		err := runRigSettingsShow(cmd, []string{rigName})
+		if err != nil {
+			t.Fatalf("runRigSettingsShow error: %v", err)
+		}
+
+		// Verify settings were loaded correctly by checking the file still exists
+		loaded, err := config.LoadRigSettings(settingsPath)
+		if err != nil {
+			t.Fatalf("reload settings: %v", err)
+		}
+		if loaded.Agent != "claude" {
+			t.Errorf("Agent = %q, want %q", loaded.Agent, "claude")
+		}
+	})
+
+	t.Run("shows helpful message when file doesn't exist", func(t *testing.T) {
+		_, rigName := setupTestRigForSettings(t)
+
+		// Run show command (no settings file created)
+		cmd := rigSettingsShowCmd
+		err := runRigSettingsShow(cmd, []string{rigName})
+		if err != nil {
+			t.Fatalf("runRigSettingsShow error: %v", err)
+		}
+		// Should not error, just show message
+	})
+
+	t.Run("shows various settings configurations", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Create settings with various configurations
+		settingsPath := filepath.Join(rigPath, "settings", "config.json")
+		settings := config.NewRigSettings()
+		settings.Agent = "claude"
+		settings.RoleAgents = map[string]string{
+			"witness":  "gemini",
+			"refinery": "claude-sonnet",
+			"polecat":  "claude-haiku",
+		}
+		if settings.MergeQueue == nil {
+			settings.MergeQueue = config.DefaultMergeQueueConfig()
+		}
+		if settings.MergeQueue != nil {
+			settings.MergeQueue.MaxConcurrent = 5
+		}
+		if err := config.SaveRigSettings(settingsPath, settings); err != nil {
+			t.Fatalf("save settings: %v", err)
+		}
+
+		// Run show command
+		cmd := rigSettingsShowCmd
+		err := runRigSettingsShow(cmd, []string{rigName})
+		if err != nil {
+			t.Fatalf("runRigSettingsShow error: %v", err)
+		}
+
+		// Verify by reloading
+		loaded, err := config.LoadRigSettings(settingsPath)
+		if err != nil {
+			t.Fatalf("reload settings: %v", err)
+		}
+		if loaded.Agent != "claude" {
+			t.Errorf("Agent = %q, want %q", loaded.Agent, "claude")
+		}
+		if len(loaded.RoleAgents) != 3 {
+			t.Errorf("RoleAgents length = %d, want 3", len(loaded.RoleAgents))
+		}
+	})
+}
+
+func TestRigSettingsSet(t *testing.T) {
+	t.Run("sets top-level keys", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Set agent
+		cmd := rigSettingsSetCmd
+		err := runRigSettingsSet(cmd, []string{rigName, "agent", "claude"})
+		if err != nil {
+			t.Fatalf("runRigSettingsSet error: %v", err)
+		}
+
+		// Verify
+		settingsPath := filepath.Join(rigPath, "settings", "config.json")
+		settings, err := config.LoadRigSettings(settingsPath)
+		if err != nil {
+			t.Fatalf("load settings: %v", err)
+		}
+		if settings.Agent != "claude" {
+			t.Errorf("Agent = %q, want %q", settings.Agent, "claude")
+		}
+	})
+
+	t.Run("sets nested keys with dot notation", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Set role_agents.witness
+		cmd := rigSettingsSetCmd
+		err := runRigSettingsSet(cmd, []string{rigName, "role_agents.witness", "gemini"})
+		if err != nil {
+			t.Fatalf("runRigSettingsSet error: %v", err)
+		}
+
+		// Verify
+		settingsPath := filepath.Join(rigPath, "settings", "config.json")
+		settings, err := config.LoadRigSettings(settingsPath)
+		if err != nil {
+			t.Fatalf("load settings: %v", err)
+		}
+		if settings.RoleAgents == nil {
+			t.Fatal("RoleAgents is nil")
+		}
+		if settings.RoleAgents["witness"] != "gemini" {
+			t.Errorf("RoleAgents[witness] = %q, want %q", settings.RoleAgents["witness"], "gemini")
+		}
+	})
+
+	t.Run("sets deeply nested keys", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Set merge_queue.max_concurrent
+		cmd := rigSettingsSetCmd
+		err := runRigSettingsSet(cmd, []string{rigName, "merge_queue.max_concurrent", "5"})
+		if err != nil {
+			t.Fatalf("runRigSettingsSet error: %v", err)
+		}
+
+		// Verify
+		settingsPath := filepath.Join(rigPath, "settings", "config.json")
+		settings, err := config.LoadRigSettings(settingsPath)
+		if err != nil {
+			t.Fatalf("load settings: %v", err)
+		}
+		if settings.MergeQueue == nil {
+			t.Fatal("MergeQueue is nil")
+		}
+		if settings.MergeQueue.MaxConcurrent != 5 {
+			t.Errorf("MergeQueue.MaxConcurrent = %d, want 5", settings.MergeQueue.MaxConcurrent)
+		}
+	})
+
+	t.Run("type inference for bool", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Test bool parsing with a field that can accept bool
+		// Since Agent is a string field, we can't test bool directly on it
+		// Instead, test that parseValue correctly identifies "true" and "false" as bools
+		// by checking the parseValue function behavior
+		// Note: The actual setting will fail because Agent field is string, not bool
+		// This tests that type inference works, but struct validation prevents invalid types
+		cmd := rigSettingsSetCmd
+		err := runRigSettingsSet(cmd, []string{rigName, "agent", "true"})
+		// This should fail because we can't set a bool to a string field
+		// The error is expected and shows that type inference works but struct validation prevents it
+		if err != nil {
+			// Expected: type inference parses "true" as bool, but struct field is string
+			if !strings.Contains(err.Error(), "cannot unmarshal bool") {
+				t.Logf("Expected error about bool/string mismatch, got: %v", err)
+			}
+		} else {
+			// If it succeeded, "true" was stored as string (valid agent name)
+			settingsPath := filepath.Join(rigPath, "settings", "config.json")
+			settings, err := config.LoadRigSettings(settingsPath)
+			if err != nil {
+				t.Fatalf("load settings: %v", err)
+			}
+			if settings.Agent != "true" {
+				t.Errorf("Agent = %q, want %q", settings.Agent, "true")
+			}
+		}
+	})
+
+	t.Run("type inference for number", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Set merge_queue.max_concurrent as number
+		cmd := rigSettingsSetCmd
+		err := runRigSettingsSet(cmd, []string{rigName, "merge_queue.max_concurrent", "10"})
+		if err != nil {
+			t.Fatalf("runRigSettingsSet error: %v", err)
+		}
+
+		// Verify it's stored as number
+		settingsPath := filepath.Join(rigPath, "settings", "config.json")
+		settings, err := config.LoadRigSettings(settingsPath)
+		if err != nil {
+			t.Fatalf("load settings: %v", err)
+		}
+		if settings.MergeQueue.MaxConcurrent != 10 {
+			t.Errorf("MergeQueue.MaxConcurrent = %d, want 10", settings.MergeQueue.MaxConcurrent)
+		}
+	})
+
+	t.Run("type inference for JSON", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Set a JSON array value
+		// Note: role_agents expects string values, not arrays, so this will fail validation
+		// This tests that JSON parsing works, but struct validation prevents invalid types
+		cmd := rigSettingsSetCmd
+		err := runRigSettingsSet(cmd, []string{rigName, "role_agents.witness", `["gemini", "claude"]`})
+		// This should fail because we can't set an array to a string field
+		// The error is expected and shows that JSON parsing works but struct validation prevents it
+		if err != nil {
+			// Expected: JSON parsing works, but struct field is string, not array
+			if !strings.Contains(err.Error(), "cannot unmarshal array") {
+				t.Logf("Expected error about array/string mismatch, got: %v", err)
+			}
+		} else {
+			// If it succeeded somehow, verify the file is valid JSON
+			settingsPath := filepath.Join(rigPath, "settings", "config.json")
+			data, err := os.ReadFile(settingsPath)
+			if err != nil {
+				t.Fatalf("read settings: %v", err)
+			}
+			var m map[string]interface{}
+			if err := json.Unmarshal(data, &m); err != nil {
+				t.Fatalf("parse JSON: %v", err)
+			}
+			t.Logf("JSON after setting array: %v", m)
+		}
+	})
+
+	t.Run("creates file if missing", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Verify file doesn't exist
+		settingsPath := filepath.Join(rigPath, "settings", "config.json")
+		if _, err := os.Stat(settingsPath); err == nil {
+			t.Fatal("settings file should not exist yet")
+		}
+
+		// Set a value (should create file)
+		cmd := rigSettingsSetCmd
+		err := runRigSettingsSet(cmd, []string{rigName, "agent", "claude"})
+		if err != nil {
+			t.Fatalf("runRigSettingsSet error: %v", err)
+		}
+
+		// Verify file was created
+		if _, err := os.Stat(settingsPath); err != nil {
+			t.Fatalf("settings file should exist: %v", err)
+		}
+
+		// Verify it's valid JSON
+		settings, err := config.LoadRigSettings(settingsPath)
+		if err != nil {
+			t.Fatalf("load settings: %v", err)
+		}
+		if settings.Agent != "claude" {
+			t.Errorf("Agent = %q, want %q", settings.Agent, "claude")
+		}
+	})
+
+	t.Run("merge behavior for nested objects", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Create initial settings with merge_queue
+		settingsPath := filepath.Join(rigPath, "settings", "config.json")
+		settings := config.NewRigSettings()
+		if settings.MergeQueue == nil {
+			settings.MergeQueue = config.DefaultMergeQueueConfig()
+		}
+		if err := config.SaveRigSettings(settingsPath, settings); err != nil {
+			t.Fatalf("save initial settings: %v", err)
+		}
+
+		// Set a nested value (should merge, not replace)
+		cmd := rigSettingsSetCmd
+		err := runRigSettingsSet(cmd, []string{rigName, "merge_queue.max_concurrent", "7"})
+		if err != nil {
+			t.Fatalf("runRigSettingsSet error: %v", err)
+		}
+
+		// Verify merge_queue still exists and has the new value
+		loaded, err := config.LoadRigSettings(settingsPath)
+		if err != nil {
+			t.Fatalf("load settings: %v", err)
+		}
+		if loaded.MergeQueue == nil {
+			t.Fatal("MergeQueue should still exist")
+		}
+		if loaded.MergeQueue.MaxConcurrent != 7 {
+			t.Errorf("MergeQueue.MaxConcurrent = %d, want 7", loaded.MergeQueue.MaxConcurrent)
+		}
+	})
+
+	t.Run("error case: invalid rig", func(t *testing.T) {
+		_, _ = setupTestRigForSettings(t)
+
+		cmd := rigSettingsSetCmd
+		err := runRigSettingsSet(cmd, []string{"nonexistent", "agent", "claude"})
+		if err == nil {
+			t.Fatal("expected error for invalid rig")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("error message should mention 'not found', got: %v", err)
+		}
+	})
+
+	t.Run("error case: invalid key path", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Create settings file
+		settingsPath := filepath.Join(rigPath, "settings", "config.json")
+		settings := config.NewRigSettings()
+		if err := config.SaveRigSettings(settingsPath, settings); err != nil {
+			t.Fatalf("save settings: %v", err)
+		}
+
+		// Try to set a deeply nested path that doesn't make sense
+		// This should fail during unmarshaling back to struct
+		cmd := rigSettingsSetCmd
+		err := runRigSettingsSet(cmd, []string{rigName, "invalid.deeply.nested.path", "value"})
+		// This might succeed (creates the path) but fail validation, or might fail earlier
+		// The behavior depends on how setNestedValue handles invalid paths
+		if err != nil {
+			t.Logf("Setting invalid path returned error (expected): %v", err)
+		}
+	})
+
+	t.Run("error case: unknown top-level key", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Create settings file
+		settingsPath := filepath.Join(rigPath, "settings", "config.json")
+		settings := config.NewRigSettings()
+		if err := config.SaveRigSettings(settingsPath, settings); err != nil {
+			t.Fatalf("save settings: %v", err)
+		}
+
+		// Try to set an unknown top-level key (regression test for false success bug)
+		cmd := rigSettingsSetCmd
+		err := runRigSettingsSet(cmd, []string{rigName, "something_else", "blah"})
+		if err == nil {
+			t.Fatal("expected error for unknown top-level key 'something_else'")
+		}
+		if !strings.Contains(err.Error(), "unknown key") {
+			t.Errorf("error message should mention 'unknown key', got: %v", err)
+		}
+
+		// Verify the file wasn't modified
+		loaded, err := config.LoadRigSettings(settingsPath)
+		if err != nil {
+			t.Fatalf("load settings: %v", err)
+		}
+		if loaded.Agent != "" {
+			t.Errorf("Agent should be empty, got %q", loaded.Agent)
+		}
+	})
+}
+
+func TestRigSettingsUnset(t *testing.T) {
+	t.Run("unsets top-level keys", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Create settings file with a value
+		settingsPath := filepath.Join(rigPath, "settings", "config.json")
+		settings := config.NewRigSettings()
+		settings.Agent = "claude"
+		if err := config.SaveRigSettings(settingsPath, settings); err != nil {
+			t.Fatalf("save settings: %v", err)
+		}
+
+		// Verify the value is set
+		loaded, err := config.LoadRigSettings(settingsPath)
+		if err != nil {
+			t.Fatalf("load settings: %v", err)
+		}
+		if loaded.Agent != "claude" {
+			t.Fatalf("Agent should be 'claude' before unset, got %q", loaded.Agent)
+		}
+
+		// Unset the value
+		cmd := rigSettingsUnsetCmd
+		err = runRigSettingsUnset(cmd, []string{rigName, "agent"})
+		if err != nil {
+			t.Fatalf("runRigSettingsUnset error: %v", err)
+		}
+
+		// Verify the value is gone
+		loaded, err = config.LoadRigSettings(settingsPath)
+		if err != nil {
+			t.Fatalf("reload settings: %v", err)
+		}
+		if loaded.Agent != "" {
+			t.Errorf("Agent should be empty after unset, got %q", loaded.Agent)
+		}
+
+		// Also verify by reading raw JSON to ensure key is not present
+		data, err := os.ReadFile(settingsPath)
+		if err != nil {
+			t.Fatalf("read settings file: %v", err)
+		}
+		var rawMap map[string]interface{}
+		if err := json.Unmarshal(data, &rawMap); err != nil {
+			t.Fatalf("unmarshal raw JSON: %v", err)
+		}
+		if _, exists := rawMap["agent"]; exists {
+			t.Errorf("agent key should not exist in JSON after unset, but it does")
+		}
+	})
+
+	t.Run("unsets nested keys", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Create settings file with nested values
+		settingsPath := filepath.Join(rigPath, "settings", "config.json")
+		settings := config.NewRigSettings()
+		settings.RoleAgents = map[string]string{
+			"witness":  "gemini",
+			"refinery": "claude-sonnet",
+		}
+		if err := config.SaveRigSettings(settingsPath, settings); err != nil {
+			t.Fatalf("save settings: %v", err)
+		}
+
+		// Verify the values are set
+		loaded, err := config.LoadRigSettings(settingsPath)
+		if err != nil {
+			t.Fatalf("load settings: %v", err)
+		}
+		if loaded.RoleAgents["witness"] != "gemini" {
+			t.Fatalf("RoleAgents[witness] should be 'gemini' before unset, got %q", loaded.RoleAgents["witness"])
+		}
+
+		// Unset the nested value
+		cmd := rigSettingsUnsetCmd
+		err = runRigSettingsUnset(cmd, []string{rigName, "role_agents.witness"})
+		if err != nil {
+			t.Fatalf("runRigSettingsUnset error: %v", err)
+		}
+
+		// Verify the nested value is gone but sibling is preserved
+		loaded, err = config.LoadRigSettings(settingsPath)
+		if err != nil {
+			t.Fatalf("reload settings: %v", err)
+		}
+		if _, exists := loaded.RoleAgents["witness"]; exists {
+			t.Errorf("RoleAgents[witness] should not exist after unset")
+		}
+		if loaded.RoleAgents["refinery"] != "claude-sonnet" {
+			t.Errorf("RoleAgents[refinery] should still be 'claude-sonnet', got %q", loaded.RoleAgents["refinery"])
+		}
+	})
+
+	t.Run("error case: key not found", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Create settings file
+		settingsPath := filepath.Join(rigPath, "settings", "config.json")
+		settings := config.NewRigSettings()
+		if err := config.SaveRigSettings(settingsPath, settings); err != nil {
+			t.Fatalf("save settings: %v", err)
+		}
+
+		// Try to unset non-existent key
+		cmd := rigSettingsUnsetCmd
+		err := runRigSettingsUnset(cmd, []string{rigName, "nonexistent"})
+		if err == nil {
+			t.Fatal("expected error for non-existent key")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("error message should mention 'not found', got: %v", err)
+		}
+	})
+
+	t.Run("error case: invalid rig", func(t *testing.T) {
+		_, _ = setupTestRigForSettings(t)
+
+		cmd := rigSettingsUnsetCmd
+		err := runRigSettingsUnset(cmd, []string{"nonexistent", "agent"})
+		if err == nil {
+			t.Fatal("expected error for invalid rig")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("error message should mention 'not found', got: %v", err)
+		}
+	})
+
+	t.Run("error case: settings file not found", func(t *testing.T) {
+		_, rigName := setupTestRigForSettings(t)
+
+		// Don't create settings file
+		cmd := rigSettingsUnsetCmd
+		err := runRigSettingsUnset(cmd, []string{rigName, "agent"})
+		if err == nil {
+			t.Fatal("expected error when settings file doesn't exist")
+		}
+		if !strings.Contains(err.Error(), "not found") {
+			t.Errorf("error message should mention 'not found', got: %v", err)
+		}
+	})
+}
+
+func TestRigSettingsEdgeCases(t *testing.T) {
+	t.Run("empty key path", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Create settings file
+		settingsPath := filepath.Join(rigPath, "settings", "config.json")
+		settings := config.NewRigSettings()
+		if err := config.SaveRigSettings(settingsPath, settings); err != nil {
+			t.Fatalf("save settings: %v", err)
+		}
+
+		// Try to set with empty key path
+		cmd := rigSettingsSetCmd
+		err := runRigSettingsSet(cmd, []string{rigName, "", "value"})
+		if err == nil {
+			t.Fatal("expected error for empty key path")
+		}
+		if !strings.Contains(err.Error(), "empty") {
+			t.Errorf("error message should mention 'empty', got: %v", err)
+		}
+	})
+
+	t.Run("deeply nested paths", func(t *testing.T) {
+		_, rigName := setupTestRigForSettings(t)
+
+		// Set a deeply nested path (though this might not map to actual struct fields)
+		// We'll test that the path creation works
+		cmd := rigSettingsSetCmd
+		err := runRigSettingsSet(cmd, []string{rigName, "a.b.c.d.e", "deepvalue"})
+		// This might succeed in creating the path, but fail validation
+		// The important thing is it doesn't crash
+		if err != nil {
+			t.Logf("Deeply nested path returned error (may be expected): %v", err)
+		}
+	})
+
+	t.Run("special characters in values", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Set value with special characters
+		cmd := rigSettingsSetCmd
+		specialValue := `test"value'with\special/chars`
+		err := runRigSettingsSet(cmd, []string{rigName, "agent", specialValue})
+		if err != nil {
+			t.Fatalf("runRigSettingsSet error: %v", err)
+		}
+
+		// Verify it's stored correctly
+		settingsPath := filepath.Join(rigPath, "settings", "config.json")
+		settings, err := config.LoadRigSettings(settingsPath)
+		if err != nil {
+			t.Fatalf("load settings: %v", err)
+		}
+		if settings.Agent != specialValue {
+			t.Errorf("Agent = %q, want %q", settings.Agent, specialValue)
+		}
+	})
+
+	t.Run("JSON array values", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Set a JSON array value
+		// Note: This might not map to actual RigSettings fields, but tests JSON parsing
+		cmd := rigSettingsSetCmd
+		jsonArray := `["item1", "item2", "item3"]`
+		err := runRigSettingsSet(cmd, []string{rigName, "test_array", jsonArray})
+		// This might succeed but the field won't be in the struct
+		// We're testing that JSON parsing works
+		if err != nil {
+			t.Logf("JSON array set returned error (may be expected): %v", err)
+		} else {
+			// If it succeeded, verify the file is valid JSON
+			settingsPath := filepath.Join(rigPath, "settings", "config.json")
+			data, err := os.ReadFile(settingsPath)
+			if err != nil {
+				t.Fatalf("read settings: %v", err)
+			}
+			var m map[string]interface{}
+			if err := json.Unmarshal(data, &m); err != nil {
+				t.Fatalf("parse JSON: %v", err)
+			}
+			// The test_array might be in the raw JSON even if not in the struct
+			t.Logf("JSON contains: %v", m)
+		}
+	})
+
+	t.Run("JSON object values", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Set a JSON object value
+		cmd := rigSettingsSetCmd
+		jsonObject := `{"key1": "value1", "key2": 42}`
+		err := runRigSettingsSet(cmd, []string{rigName, "test_object", jsonObject})
+		// Similar to array test - might succeed but not map to struct
+		if err != nil {
+			t.Logf("JSON object set returned error (may be expected): %v", err)
+		} else {
+			// Verify file is valid JSON
+			settingsPath := filepath.Join(rigPath, "settings", "config.json")
+			data, err := os.ReadFile(settingsPath)
+			if err != nil {
+				t.Fatalf("read settings: %v", err)
+			}
+			var m map[string]interface{}
+			if err := json.Unmarshal(data, &m); err != nil {
+				t.Fatalf("parse JSON: %v", err)
+			}
+			t.Logf("JSON contains: %v", m)
+		}
+	})
+
+	t.Run("multiple set operations preserve other values", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForSettings(t)
+		rigPath := filepath.Join(townRoot, rigName)
+
+		// Set multiple values
+		cmd := rigSettingsSetCmd
+		if err := runRigSettingsSet(cmd, []string{rigName, "agent", "claude"}); err != nil {
+			t.Fatalf("set agent: %v", err)
+		}
+		if err := runRigSettingsSet(cmd, []string{rigName, "role_agents.witness", "gemini"}); err != nil {
+			t.Fatalf("set witness: %v", err)
+		}
+		if err := runRigSettingsSet(cmd, []string{rigName, "role_agents.refinery", "claude-sonnet"}); err != nil {
+			t.Fatalf("set refinery: %v", err)
+		}
+
+		// Verify all values are preserved
+		settingsPath := filepath.Join(rigPath, "settings", "config.json")
+		settings, err := config.LoadRigSettings(settingsPath)
+		if err != nil {
+			t.Fatalf("load settings: %v", err)
+		}
+		if settings.Agent != "claude" {
+			t.Errorf("Agent = %q, want %q", settings.Agent, "claude")
+		}
+		if settings.RoleAgents == nil {
+			t.Fatal("RoleAgents is nil")
+		}
+		if settings.RoleAgents["witness"] != "gemini" {
+			t.Errorf("RoleAgents[witness] = %q, want %q", settings.RoleAgents["witness"], "gemini")
+		}
+		if settings.RoleAgents["refinery"] != "claude-sonnet" {
+			t.Errorf("RoleAgents[refinery] = %q, want %q", settings.RoleAgents["refinery"], "claude-sonnet")
+		}
+	})
+}
+
+// Test helper functions
+func TestParseValue(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		wantType string
+		wantVal  interface{}
+	}{
+		{"boolean true", "true", "bool", true},
+		{"boolean false", "false", "bool", false},
+		{"integer", "42", "int", 42},
+		{"float", "3.14", "float64", 3.14},
+		{"JSON array", `["a", "b"]`, "[]interface {}", []interface{}{"a", "b"}},
+		{"JSON object", `{"key": "value"}`, "map[string]interface {}", map[string]interface{}{"key": "value"}},
+		{"string", "hello", "string", "hello"},
+		{"number as string", "123abc", "string", "123abc"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseValue(tt.input)
+			if err != nil {
+				t.Fatalf("parseValue(%q) error: %v", tt.input, err)
+			}
+
+			// Type check
+			switch tt.wantType {
+			case "bool":
+				if _, ok := got.(bool); !ok {
+					t.Errorf("parseValue(%q) = %T, want bool", tt.input, got)
+				}
+			case "int":
+				if _, ok := got.(int); !ok {
+					t.Errorf("parseValue(%q) = %T, want int", tt.input, got)
+				}
+			case "float64":
+				if _, ok := got.(float64); !ok {
+					t.Errorf("parseValue(%q) = %T, want float64", tt.input, got)
+				}
+			case "string":
+				if _, ok := got.(string); !ok {
+					t.Errorf("parseValue(%q) = %T, want string", tt.input, got)
+				}
+			}
+
+			// Value check for simple types
+			if tt.wantType == "bool" || tt.wantType == "int" || tt.wantType == "string" {
+				if got != tt.wantVal {
+					t.Errorf("parseValue(%q) = %v, want %v", tt.input, got, tt.wantVal)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Fixes bug in `unsetNestedValue` where deleted keys persist after unsetting
- Uses `reflect.Zero()` to clear the struct before `json.Unmarshal`, ensuring deleted keys are removed
- Re-enables previously skipped unset tests with full coverage

## Details
The bug occurred because Go's `json.Unmarshal` only updates struct fields that are present in the JSON data - it doesn't clear fields that are missing. When `unsetNestedValue` deleted a key from the intermediate map and marshaled back to JSON, the subsequent unmarshal into the original struct would preserve the old field value.

The fix adds a reflection-based reset of the struct to its zero value before unmarshaling, ensuring the struct accurately reflects the modified JSON data.

## Test plan
- [x] Run `go test ./internal/cmd/... -run TestRigSettingsUnset` - all tests pass
- [x] Run `go test ./internal/cmd/... -run TestRigSettings` - full test suite passes
- [x] Verify `TestRigSettingsUnset/unsets_top-level_keys` passes (previously skipped)
- [x] Verify `TestRigSettingsUnset/unsets_nested_keys` passes (previously skipped)

Fixes #1007