### PR TITLE
fix(deacon): prevent duplicate patrol molecules on restart

### DIFF
--- a/internal/cmd/patrol_helpers.go
+++ b/internal/cmd/patrol_helpers.go
@@ -27,7 +27,30 @@ type PatrolConfig struct {
 // findActivePatrol finds an active patrol molecule for the role.
 // Returns the patrol ID, display line, and whether one was found.
 func findActivePatrol(cfg PatrolConfig) (patrolID, patrolLine string, found bool) {
-	// Check for in-progress patrol first (if configured)
+	// Check for hooked patrol first (highest priority - resume it)
+	cmdHooked := exec.Command("bd", "--no-daemon", "list", "--status=hooked", "--type=epic")
+	cmdHooked.Dir = cfg.BeadsDir
+	var stdoutHooked, stderrHooked bytes.Buffer
+	cmdHooked.Stdout = &stdoutHooked
+	cmdHooked.Stderr = &stderrHooked
+
+	if err := cmdHooked.Run(); err != nil {
+		if errMsg := strings.TrimSpace(stderrHooked.String()); errMsg != "" {
+			fmt.Fprintf(os.Stderr, "bd list: %s\n", errMsg)
+		}
+	} else {
+		lines := strings.Split(stdoutHooked.String(), "\n")
+		for _, line := range lines {
+			if strings.Contains(line, cfg.PatrolMolName) && !strings.Contains(line, "[template]") {
+				parts := strings.Fields(line)
+				if len(parts) > 0 {
+					return parts[0], line, true
+				}
+			}
+		}
+	}
+
+	// Check for in-progress patrol (if configured)
 	if cfg.CheckInProgress {
 		cmdList := exec.Command("bd", "--no-daemon", "list", "--status=in_progress", "--type=epic")
 		cmdList.Dir = cfg.BeadsDir
@@ -97,6 +120,78 @@ func findActivePatrol(cfg PatrolConfig) (patrolID, patrolLine string, found bool
 	}
 
 	return "", "", false
+}
+
+// findStalePatrols finds patrol molecules that should be closed before creating a new one.
+// Returns a list of patrol IDs that are stale (open but with no active children).
+func findStalePatrols(cfg PatrolConfig) []string {
+	var stalePatrols []string
+
+	// Find open patrols without active children
+	cmdOpen := exec.Command("bd", "--no-daemon", "list", "--status=open", "--type=epic")
+	cmdOpen.Dir = cfg.BeadsDir
+	var stdoutOpen, stderrOpen bytes.Buffer
+	cmdOpen.Stdout = &stdoutOpen
+	cmdOpen.Stderr = &stderrOpen
+
+	if err := cmdOpen.Run(); err != nil {
+		return stalePatrols
+	}
+
+	lines := strings.Split(stdoutOpen.String(), "\n")
+	for _, line := range lines {
+		if strings.Contains(line, cfg.PatrolMolName) && !strings.Contains(line, "[template]") {
+			parts := strings.Fields(line)
+			if len(parts) > 0 {
+				molID := parts[0]
+				// Check if this molecule has active children
+				cmdShow := exec.Command("bd", "--no-daemon", "show", molID)
+				cmdShow.Dir = cfg.BeadsDir
+				var stdoutShow, stderrShow bytes.Buffer
+				cmdShow.Stdout = &stdoutShow
+				cmdShow.Stderr = &stderrShow
+				if err := cmdShow.Run(); err == nil {
+					showOutput := stdoutShow.String()
+					hasOpenChildren := strings.Contains(showOutput, "- open]")
+					hasHookedChildren := strings.Contains(showOutput, "- hooked]")
+					hasInProgressChildren := strings.Contains(showOutput, "- in_progress]")
+					if !hasOpenChildren && !hasHookedChildren && !hasInProgressChildren {
+						stalePatrols = append(stalePatrols, molID)
+					}
+				}
+			}
+		}
+	}
+
+	return stalePatrols
+}
+
+// closeStalePatrols closes stale patrol molecules and their children.
+func closeStalePatrols(cfg PatrolConfig) {
+	stalePatrols := findStalePatrols(cfg)
+	for _, molID := range stalePatrols {
+		// Close all children first
+		cmdChildren := exec.Command("bd", "--no-daemon", "list", "--parent", molID)
+		cmdChildren.Dir = cfg.BeadsDir
+		var stdoutChildren bytes.Buffer
+		cmdChildren.Stdout = &stdoutChildren
+		if err := cmdChildren.Run(); err == nil {
+			childLines := strings.Split(stdoutChildren.String(), "\n")
+			for _, childLine := range childLines {
+				childParts := strings.Fields(childLine)
+				if len(childParts) > 0 {
+					childID := childParts[0]
+					cmdClose := exec.Command("bd", "--no-daemon", "close", childID)
+					cmdClose.Dir = cfg.BeadsDir
+					cmdClose.Run() // Ignore errors - child may already be closed
+				}
+			}
+		}
+		// Close the patrol molecule itself
+		cmdClose := exec.Command("bd", "--no-daemon", "close", molID)
+		cmdClose.Dir = cfg.BeadsDir
+		cmdClose.Run() // Ignore errors
+	}
 }
 
 // autoSpawnPatrol creates and pins a new patrol wisp.
@@ -185,7 +280,10 @@ func outputPatrolContext(cfg PatrolConfig) {
 	patrolID, patrolLine, hasPatrol := findActivePatrol(cfg)
 
 	if !hasPatrol {
-		// No active patrol - auto-spawn one
+		// No active patrol - close any stale patrols before creating new one
+		closeStalePatrols(cfg)
+
+		// Auto-spawn a new patrol
 		fmt.Printf("Status: **No active patrol** - creating %s...\n", cfg.PatrolMolName)
 		fmt.Println()
 


### PR DESCRIPTION
## Summary
- Check for hooked patrol molecules first on restart (resume existing work)
- Close stale patrols and their children before creating new ones
- Prevents duplicate mol-deacon-patrol molecules from accumulating

## Changes
- `findActivePatrol()` now checks for "hooked" status patrols first (highest priority)
- Added `findStalePatrols()` to identify open patrols without active children
- Added `closeStalePatrols()` to clean up stale patrols before spawning new
- `outputPatrolContext()` calls `closeStalePatrols()` before auto-spawn

## Test plan
- [ ] Verify tests pass: `go test ./...`
- [ ] Manual test: Stop deacon mid-patrol, restart, verify it resumes existing patrol
- [ ] Manual test: Stop deacon after patrol complete, restart, verify old patrol is closed and new one created

Fixes #997.