### PR TITLE
feat(polecat): add GT_POLECAT_INDEX env var for test isolation

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -35,6 +35,11 @@ type AgentEnvConfig struct {
 	// BeadsNoDaemon sets BEADS_NO_DAEMON=1 if true
 	// Used for polecats that should bypass the beads daemon
 	BeadsNoDaemon bool
+
+	// PolecatIndex is a unique index for this polecat within the rig (0, 1, 2...).
+	// Used for port offsetting in parallel E2E tests to avoid port conflicts.
+	// Only applicable when Role is "polecat". -1 means not set.
+	PolecatIndex int
 }
 
 // AgentEnv returns all environment variables for an agent based on the config.
@@ -79,6 +84,10 @@ func AgentEnv(cfg AgentEnvConfig) map[string]string {
 		env["GT_POLECAT"] = cfg.AgentName
 		env["BD_ACTOR"] = fmt.Sprintf("%s/polecats/%s", cfg.Rig, cfg.AgentName)
 		env["GIT_AUTHOR_NAME"] = cfg.AgentName
+		// GT_POLECAT_INDEX enables port offsetting for parallel E2E tests
+		if cfg.PolecatIndex >= 0 {
+			env["GT_POLECAT_INDEX"] = fmt.Sprintf("%d", cfg.PolecatIndex)
+		}
 
 	case "crew":
 		env["GT_ROLE"] = fmt.Sprintf("%s/crew/%s", cfg.Rig, cfg.AgentName)

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -42,6 +42,7 @@ func TestAgentEnv_Polecat(t *testing.T) {
 		AgentName:     "Toast",
 		TownRoot:      "/town",
 		BeadsNoDaemon: true,
+		PolecatIndex:  0, // First polecat gets index 0
 	})
 
 	assertEnv(t, env, "GT_ROLE", "myrig/polecats/Toast") // compound format
@@ -51,6 +52,36 @@ func TestAgentEnv_Polecat(t *testing.T) {
 	assertEnv(t, env, "GIT_AUTHOR_NAME", "Toast")
 	assertEnv(t, env, "BEADS_AGENT_NAME", "myrig/Toast")
 	assertEnv(t, env, "BEADS_NO_DAEMON", "1")
+	assertEnv(t, env, "GT_POLECAT_INDEX", "0") // First polecat
+}
+
+func TestAgentEnv_PolecatWithIndex(t *testing.T) {
+	t.Parallel()
+	env := AgentEnv(AgentEnvConfig{
+		Role:          "polecat",
+		Rig:           "myrig",
+		AgentName:     "Toast",
+		TownRoot:      "/town",
+		BeadsNoDaemon: true,
+		PolecatIndex:  3,
+	})
+
+	assertEnv(t, env, "GT_POLECAT_INDEX", "3")
+}
+
+func TestAgentEnv_PolecatIndexNegativeNotSet(t *testing.T) {
+	t.Parallel()
+	// Negative index means "not set" - GT_POLECAT_INDEX should not be in env
+	env := AgentEnv(AgentEnvConfig{
+		Role:          "polecat",
+		Rig:           "myrig",
+		AgentName:     "Toast",
+		TownRoot:      "/town",
+		BeadsNoDaemon: true,
+		PolecatIndex:  -1,
+	})
+
+	assertNotSet(t, env, "GT_POLECAT_INDEX")
 }
 
 func TestAgentEnv_Crew(t *testing.T) {


### PR DESCRIPTION
## Summary
- Add `GT_POLECAT_INDEX` environment variable when spawning polecats
- Index is computed from count of active polecat sessions (0, 1, 2...)
- Enables port offsetting in parallel E2E tests to avoid port conflicts

## Usage
Projects can use the index to offset port numbers:
```bash
PORT=$((8080 + ${GT_POLECAT_INDEX:-0}))
```

## Test plan
- [x] Added unit tests for `AgentEnv` with polecat index
- [x] All existing tests pass
- [x] Build succeeds

Closes #954