### PR TITLE
fix(patrol): use gt convoy commands instead of bd list for town-aware convoy detection

### DIFF
--- a/.beads/formulas/mol-deacon-patrol.formula.toml
+++ b/.beads/formulas/mol-deacon-patrol.formula.toml
@@ -236,30 +236,31 @@ Check convoy completion status.
 
 Convoys are coordination beads that track multiple issues across rigs. When all tracked issues close, the convoy auto-closes.
 
+**IMPORTANT**: Use `gt convoy` commands (not `bd list`) because convoys are stored in
+town-level HQ beads and the Deacon runs from ~/gt/deacon/. The `gt` commands are
+town-aware and will find convoys regardless of current directory.
+
 **Step 1: Find open convoys**
 ```bash
-bd list --type=convoy --status=open
+gt convoy list
 ```
 
-**Step 2: For each open convoy, check tracked issues**
+**Step 2: Check and auto-close completed convoys**
 ```bash
-bd show <convoy-id>
-# Look for 'tracks' or 'dependencies' field listing tracked issues
+gt convoy check
 ```
 
-**Step 3: If all tracked issues are closed, close the convoy**
-```bash
-# Check each tracked issue
-for issue in tracked_issues:
-    bd show <issue-id>
-    # If status is open/in_progress, convoy stays open
-    # If all are closed (completed, wontfix, etc.), convoy is complete
+This command:
+- Finds all open convoys
+- Checks if all tracked issues are closed (handles cross-rig resolution)
+- Auto-closes convoys where all tracked work is complete
+- Sends notifications to convoy owners
 
-# Close convoy when all tracked issues are done
-bd close <convoy-id> --reason "All tracked issues completed"
-```
+**Note**: Convoys support cross-prefix tracking (e.g., hq-* convoy can track gt-*, bd-* issues).
+The `gt convoy` commands handle cross-rig issue resolution automatically.
 
-**Note**: Convoys support cross-prefix tracking (e.g., hq-* convoy can track gt-*, bd-* issues). Use full IDs when checking."""
+Stranded convoy detection (ready work, no workers) is handled by the separate
+`feed-stranded-convoys` step."""
 
 [[steps]]
 id = "resolve-external-deps"

--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -236,30 +236,31 @@ Check convoy completion status.
 
 Convoys are coordination beads that track multiple issues across rigs. When all tracked issues close, the convoy auto-closes.
 
+**IMPORTANT**: Use `gt convoy` commands (not `bd list`) because convoys are stored in
+town-level HQ beads and the Deacon runs from ~/gt/deacon/. The `gt` commands are
+town-aware and will find convoys regardless of current directory.
+
 **Step 1: Find open convoys**
 ```bash
-bd list --type=convoy --status=open
+gt convoy list
 ```
 
-**Step 2: For each open convoy, check tracked issues**
+**Step 2: Check and auto-close completed convoys**
 ```bash
-bd show <convoy-id>
-# Look for 'tracks' or 'dependencies' field listing tracked issues
+gt convoy check
 ```
 
-**Step 3: If all tracked issues are closed, close the convoy**
-```bash
-# Check each tracked issue
-for issue in tracked_issues:
-    bd show <issue-id>
-    # If status is open/in_progress, convoy stays open
-    # If all are closed (completed, wontfix, etc.), convoy is complete
+This command:
+- Finds all open convoys
+- Checks if all tracked issues are closed (handles cross-rig resolution)
+- Auto-closes convoys where all tracked work is complete
+- Sends notifications to convoy owners
 
-# Close convoy when all tracked issues are done
-bd close <convoy-id> --reason "All tracked issues completed"
-```
+**Note**: Convoys support cross-prefix tracking (e.g., hq-* convoy can track gt-*, bd-* issues).
+The `gt convoy` commands handle cross-rig issue resolution automatically.
 
-**Note**: Convoys support cross-prefix tracking (e.g., hq-* convoy can track gt-*, bd-* issues). Use full IDs when checking."""
+Stranded convoy detection (ready work, no workers) is handled by the separate
+`feed-stranded-convoys` step."""
 
 [[steps]]
 id = "resolve-external-deps"


### PR DESCRIPTION
## Summary

The Deacon runs from `~/gt/deacon/` which doesn't have a `.beads/` directory.
When the patrol formula used `bd list --type=convoy`, it couldn't find
convoys stored in town-level HQ beads (`~/gt/.beads/`).

Changed `check-convoy-completion` step to use:
- `gt convoy list` - finds convoys from any directory
- `gt convoy check` - auto-closes completed convoys with cross-rig resolution

The `gt` commands are town-aware and properly resolve town beads regardless
of current working directory.

**Note**: Stranded convoy detection is handled by the separate `feed-stranded-convoys` step added in #1092.

## Test plan

- [x] Start Deacon patrol with `gt nudge deacon "Run patrol"`
- [x] Verify convoy check step executes without "no convoys found" when convoys exist in HQ
- [x] Verify `gt convoy list` returns results from any directory

Fixes: gt-jnqxax

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)