### PR TITLE
fix: remove hardcoded repo names from role templates

### DIFF
--- a/internal/templates/roles/crew.md.tmpl
+++ b/internal/templates/roles/crew.md.tmpl
@@ -262,13 +262,13 @@ instructions immediately. Useful for one-off tasks that don't warrant a full bea
 
 ### No PRs in Maintainer Repos
 
-If the remote origin is `steveyegge/beads` or `steveyegge/gastown`:
-- **NEVER create GitHub PRs** - you have direct push access
+If you have direct push access to the repo (you're a maintainer):
+- **NEVER create GitHub PRs** - push directly to main instead
 - Crew workers: push directly to main
 - Polecats: use `gt done` → Refinery merges to main
 
 PRs are for external contributors submitting to repos they don't own.
-Check `git remote -v` if unsure about repo ownership.
+Check `git remote -v` to identify repo ownership.
 
 ### The Landing Rule
 

--- a/internal/templates/roles/polecat.md.tmpl
+++ b/internal/templates/roles/polecat.md.tmpl
@@ -418,13 +418,13 @@ closes it after successful merge. This enables conflict-resolution retries.
 
 ### No PRs in Maintainer Repos
 
-If the remote origin is `steveyegge/beads` or `steveyegge/gastown`:
-- **NEVER create GitHub PRs** - you have direct push access
+If you have direct push access to the repo (you're a maintainer):
+- **NEVER create GitHub PRs** - push directly to main instead
 - Polecats: use `gt done` → Refinery merges to main
 - Crew workers: push directly to main
 
 PRs are for external contributors submitting to repos they don't own.
-Check `git remote -v` if unsure about repo ownership.
+Check `git remote -v` to identify repo ownership.
 
 ### The Landing Rule
 

--- a/templates/polecat-CLAUDE.md
+++ b/templates/polecat-CLAUDE.md
@@ -212,13 +212,13 @@ you (you don't exist anymore).
 
 ### No PRs in Maintainer Repos
 
-If the remote origin is `steveyegge/beads` or `steveyegge/gastown`:
-- **NEVER create GitHub PRs** - you have direct push access
+If you have direct push access to the repo (you're a maintainer):
+- **NEVER create GitHub PRs** - push directly to main instead
 - Polecats: use `gt done` → Refinery merges to main
 - Crew workers: push directly to main
 
 PRs are for external contributors submitting to repos they don't own.
-Check `git remote -v` if unsure about repo ownership.
+Check `git remote -v` to identify repo ownership.
 
 ### The Landing Rule
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `steveyegge/beads` and `steveyegge/gastown` references in role templates with general guidance about maintainer repo access
- Updated 3 files: `crew.md.tmpl`, `polecat.md.tmpl`, and `polecat-CLAUDE.md`

## Changes
The "No PRs in Maintainer Repos" section now uses:
```
If you have direct push access to the repo (you're a maintainer):
```
Instead of:
```
If the remote origin is `steveyegge/beads` or `steveyegge/gastown`:
```

## Test plan
- [x] Verify generated role context files no longer contain hardcoded repo names
- [x] Confirm agents can still correctly determine when to push directly vs create PRs

Fixes #849