### PR TITLE
feat(tmux): add C-b g keybinding for agent switcher menu

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1429,6 +1429,9 @@ func (t *Tmux) ConfigureGasTownSession(session string, theme Theme, rig, worker,
 	if err := t.SetFeedBinding(session); err != nil {
 		return fmt.Errorf("setting feed binding: %w", err)
 	}
+	if err := t.SetAgentsBinding(session); err != nil {
+		return fmt.Errorf("setting agents binding: %w", err)
+	}
 	if err := t.SetCycleBindings(session); err != nil {
 		return fmt.Errorf("setting cycle bindings: %w", err)
 	}
@@ -1581,6 +1584,20 @@ func (t *Tmux) SetFeedBinding(session string) error {
 		"if-shell", "echo '#{session_name}' | grep -Eq '^(gt|hq)-'",
 		"run-shell 'gt feed --window'",
 		"display-message 'C-b a is for Gas Town sessions only'")
+	return err
+}
+
+// SetAgentsBinding configures C-b g to open the agent switcher popup menu.
+// This runs `gt agents` which displays a tmux popup with all Gas Town agents.
+//
+// IMPORTANT: This binding is conditional - it only runs for Gas Town sessions
+// (those starting with "gt-" or "hq-"). For non-GT sessions, a help message is shown.
+func (t *Tmux) SetAgentsBinding(session string) error {
+	// C-b g → gt agents for GT sessions, help message otherwise
+	_, err := t.run("bind-key", "-T", "prefix", "g",
+		"if-shell", "echo '#{session_name}' | grep -Eq '^(gt|hq)-'",
+		"run-shell 'gt agents'",
+		"display-message 'C-b g is for Gas Town sessions only'")
 	return err
 }
 


### PR DESCRIPTION
## Summary
- Adds `C-b g` keybinding to open the `gt agents` popup menu
- Quick keyboard access to switch between Gas Town agents without typing the command

## Changes
- Added `SetAgentsBinding()` function in `internal/tmux/tmux.go`
- Binding is conditional: only works in Gas Town sessions (gt-* or hq-*)
- Follows same pattern as existing bindings (C-b a for feed, C-b n/p for cycling)

## Test plan
- [x] Press C-b g in any Gas Town tmux session
- [x] Verify popup menu appears with agent list
- [x] Select an agent to switch to it

🤖 Generated with [Claude Code](https://claude.ai/code)