### PR TITLE
feat(session): add GIT_CEILING_DIRECTORIES to prevent umbrella commits

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -92,6 +92,10 @@ func AgentEnv(cfg AgentEnvConfig) map[string]string {
 	// Empty values would override tmux session environment
 	if cfg.TownRoot != "" {
 		env["GT_ROOT"] = cfg.TownRoot
+		// Prevent git from walking up to umbrella repo when running in rig worktrees.
+		// This stops accidental commits to the umbrella when running git commands from
+		// intermediate directories (e.g., polecats/) that don't have their own .git.
+		env["GIT_CEILING_DIRECTORIES"] = cfg.TownRoot
 	}
 
 	// Set BEADS_AGENT_NAME for polecat/crew (uses same format as BD_ACTOR)

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -15,6 +15,7 @@ func TestAgentEnv_Mayor(t *testing.T) {
 	assertEnv(t, env, "BD_ACTOR", "mayor")
 	assertEnv(t, env, "GIT_AUTHOR_NAME", "mayor")
 	assertEnv(t, env, "GT_ROOT", "/town")
+	assertEnv(t, env, "GIT_CEILING_DIRECTORIES", "/town") // prevents git walking to umbrella
 	assertNotSet(t, env, "GT_RIG")
 	assertNotSet(t, env, "BEADS_NO_DAEMON")
 }
@@ -169,6 +170,7 @@ func TestAgentEnv_EmptyTownRootOmitted(t *testing.T) {
 
 	// Key should be absent, not empty string
 	assertNotSet(t, env, "GT_ROOT")
+	assertNotSet(t, env, "GIT_CEILING_DIRECTORIES") // also not set when TownRoot empty
 
 	// Other keys should still be set
 	assertEnv(t, env, "GT_ROLE", "myrig/polecats/Toast") // compound format


### PR DESCRIPTION
## Summary

Implement git context protection in agent sessions by setting `GIT_CEILING_DIRECTORIES` to the town root. This prevents git from walking up the directory tree and finding an umbrella repo when running git commands from intermediate directories.

**Changes:**
- Add `GIT_CEILING_DIRECTORIES` environment variable to `AgentEnv()` in `internal/config/env.go`
- Add tests verifying the env var is set when TownRoot is configured, and not set when empty

## Problem

When agents spawn in rig worktrees or subdirectories (e.g., `polecats/`), git commands like `git status` or `git commit` could accidentally find and operate on a parent umbrella repository instead of the intended rig repo.

## Solution

Setting `GIT_CEILING_DIRECTORIES` to the town root stops gits upward directory traversal at the town boundary, ensuring git operations stay within their intended scope.

## Test plan

- [x] Tests pass: `go test ./internal/config/...`
- [x] Existing tests updated for the new env var behavior