### PR TITLE
fix(daemon): check flock status instead of file existence in isShutdownInProgress

### DIFF
--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -94,7 +94,11 @@ func runDown(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("cannot proceed: %w", err)
 		}
-		defer func() { _ = lock.Unlock() }()
+		defer func() {
+			_ = lock.Unlock()
+			// Clean up lock file after releasing (defense in depth)
+			_ = os.Remove(filepath.Join(townRoot, shutdownLockFile))
+		}()
 
 		// Prevent tmux server from exiting when all sessions are killed.
 		// By default, tmux exits when there are no sessions (exit-empty on).

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -758,10 +758,36 @@ func (d *Daemon) Stop() {
 // isShutdownInProgress checks if a shutdown is currently in progress.
 // The shutdown.lock file is created by gt down before terminating sessions.
 // This prevents the daemon from fighting shutdown by auto-restarting killed agents.
+//
+// Uses flock to check actual lock status rather than file existence, since
+// the lock file may persist after shutdown completes. If the file exists but
+// is not locked, it is removed as self-healing cleanup.
 func (d *Daemon) isShutdownInProgress() bool {
 	lockPath := filepath.Join(d.config.TownRoot, "daemon", "shutdown.lock")
-	_, err := os.Stat(lockPath)
-	return err == nil
+
+	// If file doesn't exist, no shutdown in progress
+	if _, err := os.Stat(lockPath); os.IsNotExist(err) {
+		return false
+	}
+
+	// Try non-blocking lock acquisition to check if shutdown holds the lock
+	lock := flock.New(lockPath)
+	locked, err := lock.TryLock()
+	if err != nil {
+		// Error acquiring lock - assume shutdown in progress to be safe
+		return true
+	}
+
+	if locked {
+		// We acquired the lock, so no shutdown is holding it
+		// Release immediately and clean up stale file
+		_ = lock.Unlock()
+		_ = os.Remove(lockPath) // Self-healing: remove orphaned lock file
+		return false
+	}
+
+	// Could not acquire lock - shutdown is in progress
+	return true
 }
 
 // IsRunning checks if a daemon is running for the given town.


### PR DESCRIPTION
## Summary

The daemon's `isShutdownInProgress()` was checking if shutdown.lock FILE EXISTS rather than whether the flock is actually held. A stale shutdown.lock from a previous shutdown would block all heartbeats forever.

**Changes:**
- `daemon.go`: Use `flock.TryLock()` to check actual lock status instead of `os.Stat()`
  - Self-healing: delete stale lock files when lock is not held
- `down.go`: Delete shutdown.lock after releasing flock (defense in depth)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/daemon/... ./internal/cmd/...` passes
- [x] `golangci-lint run` clean

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)