### PR TITLE
fix(deacon): update heartbeat on every startup, including resume

### DIFF
--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -417,7 +417,7 @@ func startDeaconSession(t *tmux.Tmux, sessionName, agentOverride string) error {
 		Recipient: "deacon",
 		Sender:    "daemon",
 		Topic:     "patrol",
-	}, "I am Deacon. Start patrol: check gt hook, if empty create mol-deacon-patrol wisp and execute it.")
+	}, "I am Deacon. First run `gt deacon heartbeat`. Then check gt hook, if empty create mol-deacon-patrol wisp and execute it.")
 	startupCmd, err := config.BuildAgentStartupCommandWithAgentOverride("deacon", "", townRoot, "", initialPrompt, agentOverride)
 	if err != nil {
 		return fmt.Errorf("building startup command: %w", err)

--- a/internal/templates/roles/deacon.md.tmpl
+++ b/internal/templates/roles/deacon.md.tmpl
@@ -142,16 +142,19 @@ Routes defined in `~/gt/.beads/routes.jsonl`. Debug with: `BD_DEBUG_ROUTING=1 bd
 There is no decision logic. Check your hook, execute what's there:
 
 ```bash
-# Step 1: Check your hook
+# Step 1: Update heartbeat (ALWAYS, before anything else)
+gt deacon heartbeat
+
+# Step 2: Check your hook
 gt hook                          # Shows hooked work (if any)
 
-# Step 2: Work hooked? → RUN IT
+# Step 3: Work hooked? → RUN IT
 # Hook empty? → Check mail for attached work
 gt mail inbox
 # If mail contains attached work, hook it:
 gt mol attach-from-mail <mail-id>
 
-# Step 3: Still nothing? Create patrol wisp (two-step: create then hook)
+# Step 4: Still nothing? Create patrol wisp (two-step: create then hook)
 bd mol wisp mol-deacon-patrol
 bd update <wisp-id> --status=hooked --assignee=deacon
 ```


### PR DESCRIPTION
## Summary

The deacon was only updating its heartbeat when starting fresh patrol. When resuming an in-progress patrol wisp (the common case), it skipped straight to working on the wisp without updating the heartbeat.

This caused the daemon to see stale heartbeats and restart the deacon every few minutes, creating a restart loop.

## Changes

- Add `gt deacon heartbeat` to the initial startup prompt in `deacon.go`
- Add heartbeat as Step 1 in the startup protocol documentation in `deacon.md.tmpl`

## Test Plan

- [x] Build passes
- [x] Template tests pass
- [ ] Manual verification: restart deacon and confirm heartbeat updates on both fresh start and resume

Fixes: gt-385idq

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)