### PR TITLE
fix(polecat): prevent orphaned hooked work during concurrent sling

### DIFF
--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -530,6 +530,19 @@ func (m *Manager) RemoveWithOptions(name string, force, nuclear, selfNuke bool) 
 		}
 	}
 
+// Close agent bead FIRST, before any filesystem operations.
+	// This prevents a race where a concurrent sling allocates the same name,
+	// sets hook_bead, and then has it cleared by this cleanup. By closing
+	// the agent bead first, concurrent slings see a CLOSED bead and
+	// CreateOrReopenAgentBead safely reopens it with fresh state.
+	agentID := m.agentBeadID(name)
+	if err := m.beads.CloseAndClearAgentBead(agentID, "polecat removed"); err != nil {
+		// Only log if not "not found" - it's ok if it doesn't exist
+		if !errors.Is(err, beads.ErrNotFound) {
+			fmt.Printf("Warning: could not close agent bead %s: %v\n", agentID, err)
+		}
+	}
+
 	// Check if user's shell is cd'd into the worktree (prevents broken shell)
 	// This check runs unless selfNuke=true (polecat deleting its own worktree).
 	// When a polecat calls `gt done`, it's inside its worktree by design - the session
@@ -604,17 +617,6 @@ func (m *Manager) RemoveWithOptions(name string, force, nuclear, selfNuke bool) 
 	// Release name back to pool if it's a pooled name (non-fatal: state file update)
 	m.namePool.Release(name)
 	_ = m.namePool.Save()
-
-	// Close agent bead (non-fatal: may not exist or beads may not be available)
-	// NOTE: We use CloseAndClearAgentBead instead of DeleteAgentBead because bd delete --hard
-	// creates tombstones that cannot be reopened.
-	agentID := m.agentBeadID(name)
-	if err := m.beads.CloseAndClearAgentBead(agentID, "polecat removed"); err != nil {
-		// Only log if not "not found" - it's ok if it doesn't exist
-		if !errors.Is(err, beads.ErrNotFound) {
-			fmt.Printf("Warning: could not close agent bead %s: %v\n", agentID, err)
-		}
-	}
 
 	return nil
 }


### PR DESCRIPTION
## Summary

Reorders operations in `RemoveWithOptions` to close the agent bead BEFORE deleting the worktree and releasing the name. This prevents a race condition where concurrent slings can have their hooked work orphaned.

## Problem

When polecats are cleaned up, work that was HOOKED to them can become orphaned due to a race condition:

1. Old polecat deletes worktree, releases name
2. New sling allocates same name, sets hook_bead = B
3. Old polecat's CloseAndClearAgentBead clears hook_bead → B orphaned

## Solution

By closing the agent bead first, concurrent slings see a CLOSED bead and `CreateOrReopenAgentBead` safely reopens it with fresh state.

## Changes

- `internal/polecat/manager.go` - Move `CloseAndClearAgentBead` call to before filesystem operations (~5 lines moved)

## Testing

- Build passes
- Existing polecat removal tests pass

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)