### PR TITLE
fix(boot): use flock instead of session check in AcquireLock

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -11,6 +11,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/gofrs/flock"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
@@ -34,11 +35,12 @@ type Status struct {
 
 // Boot manages the Boot watchdog lifecycle.
 type Boot struct {
-	townRoot  string
-	bootDir   string // ~/gt/deacon/dogs/boot/
-	deaconDir string // ~/gt/deacon/
-	tmux      *tmux.Tmux
-	degraded  bool
+	townRoot   string
+	bootDir    string // ~/gt/deacon/dogs/boot/
+	deaconDir  string // ~/gt/deacon/
+	tmux       *tmux.Tmux
+	degraded   bool
+	lockHandle *flock.Flock // held during triage execution
 }
 
 // New creates a new Boot manager.
@@ -79,28 +81,39 @@ func (b *Boot) IsSessionAlive() bool {
 	return err == nil && has
 }
 
-// AcquireLock creates the marker file to indicate Boot is starting.
-// Returns error if Boot is already running.
+// AcquireLock acquires an exclusive flock on the marker file.
+// Returns error if another triage is already running.
+// Uses flock instead of session existence check because triage runs inside
+// the Boot session - checking session existence would always fail.
 func (b *Boot) AcquireLock() error {
-	if b.IsRunning() {
-		return fmt.Errorf("boot is already running (session exists)")
-	}
-
 	if err := b.EnsureDir(); err != nil {
 		return fmt.Errorf("ensuring boot dir: %w", err)
 	}
 
-	// Create marker file
-	f, err := os.Create(b.markerPath())
+	// Use flock for actual mutual exclusion
+	b.lockHandle = flock.New(b.markerPath())
+	locked, err := b.lockHandle.TryLock()
 	if err != nil {
-		return fmt.Errorf("creating marker: %w", err)
+		return fmt.Errorf("acquiring lock: %w", err)
 	}
-	return f.Close()
+	if !locked {
+		return fmt.Errorf("boot triage is already running (lock held)")
+	}
+
+	return nil
 }
 
-// ReleaseLock removes the marker file.
+// ReleaseLock releases the flock and removes the marker file.
 func (b *Boot) ReleaseLock() error {
-	return os.Remove(b.markerPath())
+	if b.lockHandle != nil {
+		if err := b.lockHandle.Unlock(); err != nil {
+			return fmt.Errorf("releasing lock: %w", err)
+		}
+		b.lockHandle = nil
+	}
+	// Remove marker file (ignore error if already gone)
+	_ = os.Remove(b.markerPath())
+	return nil
 }
 
 // SaveStatus saves Boot's execution status.

--- a/internal/boot/boot_test.go
+++ b/internal/boot/boot_test.go
@@ -1,0 +1,118 @@
+package boot
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gofrs/flock"
+)
+
+func TestAcquireLock(t *testing.T) {
+	// Create temp directory for test
+	tmpDir := t.TempDir()
+
+	b := &Boot{
+		townRoot: tmpDir,
+		bootDir:  filepath.Join(tmpDir, "deacon", "dogs", "boot"),
+	}
+
+	// First acquire should succeed
+	if err := b.AcquireLock(); err != nil {
+		t.Fatalf("First AcquireLock failed: %v", err)
+	}
+
+	// Verify marker file exists
+	markerPath := filepath.Join(b.bootDir, MarkerFileName)
+	if _, err := os.Stat(markerPath); os.IsNotExist(err) {
+		t.Error("Marker file was not created")
+	}
+
+	// Verify lock is held by trying to acquire from another flock instance
+	otherLock := flock.New(markerPath)
+	locked, err := otherLock.TryLock()
+	if err != nil {
+		t.Fatalf("TryLock failed: %v", err)
+	}
+	if locked {
+		t.Error("Should not be able to acquire lock while first lock is held")
+		_ = otherLock.Unlock()
+	}
+
+	// Release should succeed
+	if err := b.ReleaseLock(); err != nil {
+		t.Fatalf("ReleaseLock failed: %v", err)
+	}
+
+	// After release, another instance should be able to acquire
+	locked, err = otherLock.TryLock()
+	if err != nil {
+		t.Fatalf("TryLock after release failed: %v", err)
+	}
+	if !locked {
+		t.Error("Should be able to acquire lock after release")
+	}
+	_ = otherLock.Unlock()
+}
+
+func TestAcquireLockConcurrent(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	b1 := &Boot{
+		townRoot: tmpDir,
+		bootDir:  filepath.Join(tmpDir, "deacon", "dogs", "boot"),
+	}
+	b2 := &Boot{
+		townRoot: tmpDir,
+		bootDir:  filepath.Join(tmpDir, "deacon", "dogs", "boot"),
+	}
+
+	// First boot acquires lock
+	if err := b1.AcquireLock(); err != nil {
+		t.Fatalf("First boot AcquireLock failed: %v", err)
+	}
+
+	// Second boot should fail to acquire
+	err := b2.AcquireLock()
+	if err == nil {
+		t.Error("Second boot should have failed to acquire lock")
+		_ = b2.ReleaseLock()
+	}
+
+	// Release first lock
+	if err := b1.ReleaseLock(); err != nil {
+		t.Fatalf("First boot ReleaseLock failed: %v", err)
+	}
+
+	// Now second boot should succeed
+	if err := b2.AcquireLock(); err != nil {
+		t.Fatalf("Second boot AcquireLock after release failed: %v", err)
+	}
+
+	_ = b2.ReleaseLock()
+}
+
+func TestReleaseLockIdempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	b := &Boot{
+		townRoot: tmpDir,
+		bootDir:  filepath.Join(tmpDir, "deacon", "dogs", "boot"),
+	}
+
+	// Release without acquire should not error (lockHandle is nil)
+	if err := b.ReleaseLock(); err != nil {
+		t.Errorf("ReleaseLock without acquire should not error: %v", err)
+	}
+
+	// Acquire then release twice should not error
+	if err := b.AcquireLock(); err != nil {
+		t.Fatalf("AcquireLock failed: %v", err)
+	}
+	if err := b.ReleaseLock(); err != nil {
+		t.Fatalf("First ReleaseLock failed: %v", err)
+	}
+	if err := b.ReleaseLock(); err != nil {
+		t.Errorf("Second ReleaseLock should not error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`AcquireLock()` was checking if the `gt-boot` tmux session exists before allowing triage to run. But `gt boot triage` runs inside the Boot session, so the session always exists and triage always fails with "boot is already running".

- Changed `AcquireLock()` to use flock-based locking (like `isShutdownInProgress`) instead of session existence check
- This properly prevents concurrent triage while allowing triage to run inside its own session
- Added `lockHandle *flock.Flock` field to Boot struct for lock management

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/...` passes (1 pre-existing failure in formula package)
- [x] `golangci-lint run ./internal/boot/...` passes
- [ ] Manual verification: `gt boot triage` succeeds when run inside Boot session

---
🤖 [Tackled](https://github.com/aleiby/claude-config/tree/master/skills/tackle) with [Claude Code](https://claude.com/claude-code)