### PR TITLE
fix(boot): ensure Boot exits after triage (ephemeral design)

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -139,10 +139,10 @@ func (b *Boot) LoadStatus() (*Status, error) {
 // Boot runs the mol-boot-triage molecule and exits when done.
 // In degraded mode (no tmux), it runs in a subprocess.
 // The agentOverride parameter allows specifying an agent alias to use instead of the town default.
+// Boot is ephemeral - each spawn kills any existing session and starts fresh.
 func (b *Boot) Spawn(agentOverride string) error {
-	if b.IsRunning() {
-		return fmt.Errorf("boot is already running")
-	}
+	// No IsRunning() guard here - Boot is ephemeral by design.
+	// spawnTmux() kills any existing session before spawning fresh.
 
 	// Check for degraded mode
 	if b.degraded {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -348,11 +348,9 @@ func (d *Daemon) getDeaconSessionName() string {
 func (d *Daemon) ensureBootRunning() {
 	b := boot.New(d.config.TownRoot)
 
-	// Check if Boot is already running (recent marker)
-	if b.IsRunning() {
-		d.logger.Println("Boot already running, skipping spawn")
-		return
-	}
+	// Boot is ephemeral - always spawn fresh each tick.
+	// spawnTmux() kills any existing session before spawning, ensuring
+	// Boot never accumulates context across triage cycles.
 
 	// Check for degraded mode
 	degraded := os.Getenv("GT_DEGRADED") == "true"


### PR DESCRIPTION
## Summary

Boot sessions were staying alive across daemon ticks, accumulating context instead of being fresh each tick as designed.

The fix removes `IsRunning()` guards that prevented respawning:

1. **boot.go `Spawn()`**: Remove guard - `spawnTmux()` already kills any existing session before spawning
2. **daemon.go `ensureBootRunning()`**: Remove guard for same reason

## What We Tried and Abandoned

We initially attempted a "belt and suspenders" approach where the agent would also self-exit:

1. **Exit instructions**: Added "exit with /exit" to the startup prompt
   - Agents interpreted "exit" as outputting text, not running the command

2. **More explicit instructions**: "you MUST run the /exit command"
   - Agent correctly identified `/exit` is a built-in CLI command but could not invoke it

3. **Framework-agnostic wording**: "output just `/exit` on its own line"
   - Agent tried `/handoff` instead (following Gas Town conventions)

**Why agent self-exit does not work:**
- Agents can only output text and use tools - they cannot invoke CLI commands like `/exit`
- Different agent frameworks have different exit mechanisms (not portable)
- The daemon killing Boot is reliable and framework-agnostic

The "belt" (daemon kills Boot each tick) is the real mechanism.

## Test Plan

- [x] Build and install `gt`
- [x] Restart daemon
- [x] Verify daemon logs show "Boot spawned successfully" (not "boot is already running")
- [x] Verify Boot session gets killed and respawned on subsequent ticks

---
Tackled with Claude Code