### PR TITLE
fix(polecat): resolve cross-rig beads in session manager (#1056)

### DIFF
--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/rig"
@@ -486,12 +487,22 @@ func (m *SessionManager) StopAll(force bool) error {
 	return lastErr
 }
 
+// resolveBeadsDir determines the correct working directory for bd commands
+// on a given issue. This enables cross-rig beads resolution via routes.jsonl.
+// This is the core fix for GitHub issue #1056.
+func (m *SessionManager) resolveBeadsDir(issueID, fallbackDir string) string {
+	townRoot := filepath.Dir(m.rig.Path)
+	return beads.ResolveHookDir(townRoot, issueID, fallbackDir)
+}
+
 // validateIssue checks that an issue exists and is not tombstoned.
 // This must be called before starting a session to avoid CPU spin loops
 // from agents retrying work on invalid issues.
 func (m *SessionManager) validateIssue(issueID, workDir string) error {
+	bdWorkDir := m.resolveBeadsDir(issueID, workDir)
+
 	cmd := exec.Command("bd", "show", issueID, "--json") //nolint:gosec
-	cmd.Dir = workDir
+	cmd.Dir = bdWorkDir
 	output, err := cmd.Output()
 	if err != nil {
 		return fmt.Errorf("%w: %s", ErrIssueInvalid, issueID)
@@ -514,8 +525,10 @@ func (m *SessionManager) validateIssue(issueID, workDir string) error {
 
 // hookIssue pins an issue to a polecat's hook using bd update.
 func (m *SessionManager) hookIssue(issueID, agentID, workDir string) error {
+	bdWorkDir := m.resolveBeadsDir(issueID, workDir)
+
 	cmd := exec.Command("bd", "update", issueID, "--status=hooked", "--assignee="+agentID) //nolint:gosec
-	cmd.Dir = workDir
+	cmd.Dir = bdWorkDir
 	cmd.Stderr = os.Stderr
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("bd update failed: %w", err)


### PR DESCRIPTION
## Summary

Complete the fix for cross-rig bead resolution. The formula instantiation path (`bd cook`, `bd mol wisp`, `bd mol bond`) was fixed in #859; this fixes the remaining session manager path so polecats can validate and hook beads from any rig.

## Related Issue

Fixes #1056

## Changes

- Add `resolveBeadsDir()` helper that resolves beads directory via `routes.jsonl`
- Update `validateIssue` to use resolved directory for `bd show` commands
- Update `hookIssue` to use resolved directory for `bd update` commands
- Add regression test covering same-rig, cross-rig, town-level, and fallback scenarios

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)