### PR TITLE
fix(formula): add missing variable declarations to formulas (#1133)

### DIFF
--- a/internal/formula/convoy_feed_integration_test.go
+++ b/internal/formula/convoy_feed_integration_test.go
@@ -1,0 +1,228 @@
+package formula
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestConvoyFeedWorkflow_Integration is a high-level integration test that verifies
+// the complete convoy feed workflow can be parsed and validated.
+//
+// This is a regression test for GitHub issue #1133:
+// - mol-convoy-feed formula was committed with undefined template variables
+// - This caused "bd mol wisp" to fail with "missing required variables" error
+// - The fix adds computed variables to [vars] with default=""
+//
+// The test ensures:
+// 1. The formula can be parsed
+// 2. All template variables are defined in [vars]
+// 3. The convoy input variable is marked as required
+// 4. Computed variables have empty defaults (not required as inputs)
+func TestConvoyFeedWorkflow_Integration(t *testing.T) {
+	formulaPath := filepath.Join("formulas", "mol-convoy-feed.formula.toml")
+	data, err := os.ReadFile(formulaPath)
+	if err != nil {
+		t.Skipf("Formula file not found: %v", err)
+	}
+
+	// Step 1: Parse the formula
+	f, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Failed to parse mol-convoy-feed formula: %v", err)
+	}
+
+	// Step 2: Verify it's a workflow formula
+	if f.Type != TypeWorkflow {
+		t.Errorf("Expected workflow type, got %s", f.Type)
+	}
+
+	// Step 3: Verify the convoy variable is required (this is the input)
+	convoyVar, ok := f.Vars["convoy"]
+	if !ok {
+		t.Fatal("Missing required 'convoy' variable definition")
+	}
+	if !convoyVar.Required {
+		t.Error("'convoy' variable should be marked as required")
+	}
+
+	// Step 4: Verify template variables are all defined
+	if err := f.ValidateTemplateVariables(); err != nil {
+		t.Errorf("Template variable validation failed: %v", err)
+	}
+
+	// Step 5: Verify computed variables have defaults (not required as inputs)
+	computedVars := []string{
+		"ready_count", "available_count", "dispatch_count",
+		"issue_id", "title", "rig", "polecat",
+		"error", "error_count", "report_summary",
+	}
+	for _, name := range computedVars {
+		v, ok := f.Vars[name]
+		if !ok {
+			t.Errorf("Missing computed variable %q in [vars]", name)
+			continue
+		}
+		// Computed variables should have default="" so they're not required as inputs
+		// They get filled in by the dog during execution
+		if v.Required {
+			t.Errorf("Computed variable %q should not be marked required", name)
+		}
+	}
+
+	// Step 6: Verify the formula has the expected steps
+	expectedSteps := []string{
+		"load-convoy",
+		"check-capacity",
+		"dispatch-work",
+		"report-results",
+		"return-to-kennel",
+	}
+	if len(f.Steps) != len(expectedSteps) {
+		t.Errorf("Expected %d steps, got %d", len(expectedSteps), len(f.Steps))
+	}
+	for i, expected := range expectedSteps {
+		if i >= len(f.Steps) {
+			break
+		}
+		if f.Steps[i].ID != expected {
+			t.Errorf("Step %d: expected %q, got %q", i, expected, f.Steps[i].ID)
+		}
+	}
+}
+
+// TestAllDogFormulas_CanBeWisped verifies that all dog formulas (those used by
+// Deacon's dogs) can pass variable validation for wisp creation.
+//
+// Dog formulas are special because they're invoked via:
+//   gt sling mol-<name> deacon/dogs/<dog> --var convoy=<id>
+//
+// The wisp creation validates that all template variables are either:
+// - Provided via --var flags, OR
+// - Defined in [vars] with a default value
+func TestAllDogFormulas_CanBeWisped(t *testing.T) {
+	dogFormulas := []string{
+		"mol-convoy-feed",
+		"mol-convoy-cleanup",
+		"mol-dep-propagate",
+		"mol-digest-generate",
+		"mol-orphan-scan",
+		"mol-session-gc",
+	}
+
+	formulasDir := "formulas"
+	for _, name := range dogFormulas {
+		t.Run(name, func(t *testing.T) {
+			path := filepath.Join(formulasDir, name+".formula.toml")
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Skipf("Formula not found: %v", err)
+			}
+
+			f, err := Parse(data)
+			if err != nil {
+				t.Fatalf("Parse failed: %v", err)
+			}
+
+			// All template variables must be defined
+			if err := f.ValidateTemplateVariables(); err != nil {
+				t.Errorf("Would fail wisp creation: %v", err)
+			}
+
+			// Must have at least one required input variable
+			hasRequired := false
+			for _, v := range f.Vars {
+				if v.Required {
+					hasRequired = true
+					break
+				}
+			}
+			if !hasRequired {
+				t.Log("Warning: formula has no required input variables")
+			}
+		})
+	}
+}
+
+// TestPolecatFormulas_CanBeWisped verifies that polecat formulas pass variable validation.
+// These formulas are used when spawning polecats for code review and PR review tasks.
+func TestPolecatFormulas_CanBeWisped(t *testing.T) {
+	polecatFormulas := []struct {
+		name         string
+		requiredVars []string
+	}{
+		{
+			name:         "mol-polecat-code-review",
+			requiredVars: []string{"scope", "issue", "rig"},
+		},
+		{
+			name:         "mol-polecat-review-pr",
+			requiredVars: []string{"pr_url", "issue", "rig"},
+		},
+	}
+
+	formulasDir := "formulas"
+	for _, tc := range polecatFormulas {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(formulasDir, tc.name+".formula.toml")
+			data, err := os.ReadFile(path)
+			if err != nil {
+				t.Skipf("Formula not found: %v", err)
+			}
+
+			f, err := Parse(data)
+			if err != nil {
+				t.Fatalf("Parse failed: %v", err)
+			}
+
+			// All template variables must be defined
+			if err := f.ValidateTemplateVariables(); err != nil {
+				t.Errorf("Would fail wisp creation: %v", err)
+			}
+
+			// Verify expected required variables exist
+			for _, varName := range tc.requiredVars {
+				v, ok := f.Vars[varName]
+				if !ok {
+					t.Errorf("Missing required variable %q", varName)
+					continue
+				}
+				if !v.Required {
+					t.Errorf("Variable %q should be marked required", varName)
+				}
+			}
+		})
+	}
+}
+
+// TestTownShutdownFormula_CanBeWisped verifies the town shutdown formula passes validation.
+// This formula is used by Mayor to orchestrate full Gas Town shutdown/restart.
+func TestTownShutdownFormula_CanBeWisped(t *testing.T) {
+	formulaPath := filepath.Join("formulas", "mol-town-shutdown.formula.toml")
+	data, err := os.ReadFile(formulaPath)
+	if err != nil {
+		t.Skipf("Formula file not found: %v", err)
+	}
+
+	f, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Failed to parse mol-town-shutdown formula: %v", err)
+	}
+
+	// Verify it's a workflow formula
+	if f.Type != TypeWorkflow {
+		t.Errorf("Expected workflow type, got %s", f.Type)
+	}
+
+	// All template variables must be defined
+	if err := f.ValidateTemplateVariables(); err != nil {
+		t.Errorf("Would fail wisp creation: %v", err)
+	}
+
+	// shutdown_reason should be defined but not required (has a use case without it)
+	if v, ok := f.Vars["shutdown_reason"]; !ok {
+		t.Error("Missing 'shutdown_reason' variable")
+	} else if v.Required {
+		t.Error("'shutdown_reason' should not be required (optional parameter)")
+	}
+}

--- a/internal/formula/formulas/mol-convoy-cleanup.formula.toml
+++ b/internal/formula/formulas/mol-convoy-cleanup.formula.toml
@@ -207,3 +207,24 @@ or retire the dog if pool is oversized.
 [vars.convoy]
 description = "The convoy ID to archive"
 required = true
+
+# Computed variables (issue #1133)
+[vars.contributor_list]
+description = "Computed: list of contributors"
+default = ""
+
+[vars.duration]
+description = "Computed: convoy duration"
+default = ""
+
+[vars.generated_summary]
+description = "Computed: generated summary text"
+default = ""
+
+[vars.issue_count]
+description = "Computed: number of issues in convoy"
+default = ""
+
+[vars.work_duration]
+description = "Computed: total work duration"
+default = ""

--- a/internal/formula/formulas/mol-convoy-feed.formula.toml
+++ b/internal/formula/formulas/mol-convoy-feed.formula.toml
@@ -268,3 +268,45 @@ mail is optional but useful for visibility.
 [vars.convoy]
 description = "The convoy ID to feed"
 required = true
+
+# Computed variables - filled in by the dog during execution
+# These need default="" to pass variable validation (issue #1133)
+[vars.ready_count]
+description = "Computed: number of ready issues found in convoy"
+default = ""
+
+[vars.available_count]
+description = "Computed: number of available polecats"
+default = ""
+
+[vars.dispatch_count]
+description = "Computed: number of issues dispatched"
+default = ""
+
+[vars.issue_id]
+description = "Computed: current issue ID in dispatch loop"
+default = ""
+
+[vars.title]
+description = "Computed: current issue title in dispatch loop"
+default = ""
+
+[vars.rig]
+description = "Computed: target rig for dispatch"
+default = ""
+
+[vars.polecat]
+description = "Computed: target polecat name"
+default = ""
+
+[vars.error]
+description = "Computed: error message if dispatch fails"
+default = ""
+
+[vars.error_count]
+description = "Computed: number of dispatch errors"
+default = ""
+
+[vars.report_summary]
+description = "Computed: summary for completion report"
+default = ""

--- a/internal/formula/formulas/mol-dep-propagate.formula.toml
+++ b/internal/formula/formulas/mol-dep-propagate.formula.toml
@@ -206,3 +206,16 @@ Dog returns to available state in the pool.
 [vars.resolved_issue]
 description = "The issue ID that just closed and needs propagation"
 required = true
+
+# Computed variables (issue #1133)
+[vars.dependent_count]
+description = "Computed: number of dependent issues"
+default = ""
+
+[vars.end]
+description = "Computed: end timestamp"
+default = ""
+
+[vars.witness_list]
+description = "Computed: list of witnesses"
+default = ""

--- a/internal/formula/formulas/mol-digest-generate.formula.toml
+++ b/internal/formula/formulas/mol-digest-generate.formula.toml
@@ -225,3 +225,24 @@ Dog returns to available state in the pool.
 description = "The digest period type (daily, weekly, custom)"
 required = true
 default = "daily"
+
+# Computed variables (issue #1133)
+[vars.date]
+description = "Computed: digest date"
+default = ""
+
+[vars.formatted_digest]
+description = "Computed: formatted digest content"
+default = ""
+
+[vars.polecat]
+description = "Computed: polecat name"
+default = ""
+
+[vars.since]
+description = "Computed: start time of digest period"
+default = ""
+
+[vars.until]
+description = "Computed: end time of digest period"
+default = ""

--- a/internal/formula/formulas/mol-orphan-scan.formula.toml
+++ b/internal/formula/formulas/mol-orphan-scan.formula.toml
@@ -310,3 +310,72 @@ Dog returns to available state in the pool.
 description = "Scan scope: 'town' or specific rig name"
 required = true
 default = "town"
+
+# Computed variables (issue #1133)
+[vars.action]
+description = "Computed: action taken on orphan"
+default = ""
+
+[vars.action_summary]
+description = "Computed: summary of actions"
+default = ""
+
+[vars.burn_count]
+description = "Computed: number of wisps burned"
+default = ""
+
+[vars.escalate_count]
+description = "Computed: number of escalations"
+default = ""
+
+[vars.escalations_section]
+description = "Computed: escalations report section"
+default = ""
+
+[vars.id]
+description = "Computed: current item ID"
+default = ""
+
+[vars.issue_count]
+description = "Computed: number of orphaned issues"
+default = ""
+
+[vars.mol_count]
+description = "Computed: number of orphaned molecules"
+default = ""
+
+[vars.reason]
+description = "Computed: reason for action"
+default = ""
+
+[vars.reassign_count]
+description = "Computed: number of reassignments"
+default = ""
+
+[vars.recover_count]
+description = "Computed: number of recoveries"
+default = ""
+
+[vars.report]
+description = "Computed: full report"
+default = ""
+
+[vars.reset_count]
+description = "Computed: number of resets"
+default = ""
+
+[vars.timestamp]
+description = "Computed: current timestamp"
+default = ""
+
+[vars.total_count]
+description = "Computed: total orphan count"
+default = ""
+
+[vars.type]
+description = "Computed: orphan type"
+default = ""
+
+[vars.wisp_count]
+description = "Computed: number of orphaned wisps"
+default = ""

--- a/internal/formula/formulas/mol-polecat-code-review.formula.toml
+++ b/internal/formula/formulas/mol-polecat-code-review.formula.toml
@@ -316,3 +316,7 @@ required = true
 [vars.focus]
 description = "Optional focus area (security, performance, correctness, etc.)"
 required = false
+
+[vars.rig]
+description = "The rig name where the polecat is running"
+required = true

--- a/internal/formula/formulas/mol-polecat-review-pr.formula.toml
+++ b/internal/formula/formulas/mol-polecat-review-pr.formula.toml
@@ -281,3 +281,7 @@ required = true
 [vars.issue]
 description = "The tracking issue for this review task"
 required = true
+
+[vars.rig]
+description = "The rig name where the polecat is running"
+required = true

--- a/internal/formula/formulas/mol-session-gc.formula.toml
+++ b/internal/formula/formulas/mol-session-gc.formula.toml
@@ -247,3 +247,44 @@ Dog returns to available state in the pool.
 [vars.mode]
 description = "GC mode: 'conservative' or 'aggressive'"
 default = "conservative"
+
+# Computed variables (issue #1133)
+[vars.age]
+description = "Computed: age of item"
+default = ""
+
+[vars.bytes_freed]
+description = "Computed: bytes freed by GC"
+default = ""
+
+[vars.error]
+description = "Computed: error message"
+default = ""
+
+[vars.identifier]
+description = "Computed: item identifier"
+default = ""
+
+[vars.item]
+description = "Computed: current item"
+default = ""
+
+[vars.reason]
+description = "Computed: reason for GC"
+default = ""
+
+[vars.report]
+description = "Computed: GC report"
+default = ""
+
+[vars.timestamp]
+description = "Computed: timestamp"
+default = ""
+
+[vars.total_cleaned]
+description = "Computed: total items cleaned"
+default = ""
+
+[vars.type]
+description = "Computed: item type"
+default = ""

--- a/internal/formula/formulas/mol-town-shutdown.formula.toml
+++ b/internal/formula/formulas/mol-town-shutdown.formula.toml
@@ -177,6 +177,11 @@ Shutdown reason: {{shutdown_reason}}
 ```
 """
 
+[vars]
+[vars.shutdown_reason]
+description = "Reason for the shutdown (maintenance, upgrade, reset, etc.)"
+required = false
+
 [[steps]]
 id = "restart-daemon"
 title = "Restart daemon"

--- a/internal/formula/variable_validation.go
+++ b/internal/formula/variable_validation.go
@@ -1,0 +1,149 @@
+package formula
+
+import (
+	"fmt"
+	"regexp"
+	"sort"
+	"strings"
+)
+
+// variablePattern matches {{variable}} template placeholders.
+// It captures the variable name (alphanumeric + underscore, starting with letter/underscore).
+var variablePattern = regexp.MustCompile(`\{\{([a-zA-Z_][a-zA-Z0-9_]*)\}\}`)
+
+// ExtractTemplateVariables finds all {{variable}} patterns in text.
+// Returns a deduplicated, sorted list of variable names.
+// Handlebars helpers like {{#if}}, {{/each}}, {{else}} are excluded.
+func ExtractTemplateVariables(text string) []string {
+	matches := variablePattern.FindAllStringSubmatch(text, -1)
+	seen := make(map[string]bool)
+	var vars []string
+
+	for _, match := range matches {
+		if len(match) < 2 {
+			continue
+		}
+		name := match[1]
+
+		// Skip Handlebars helpers and keywords
+		if isHandlebarsKeyword(name) {
+			continue
+		}
+
+		if !seen[name] {
+			seen[name] = true
+			vars = append(vars, name)
+		}
+	}
+
+	sort.Strings(vars)
+	return vars
+}
+
+// isHandlebarsKeyword returns true for Handlebars control keywords
+// that look like variables but aren't (e.g., "else", "this").
+func isHandlebarsKeyword(name string) bool {
+	switch name {
+	case "else", "this", "root", "index", "key", "first", "last":
+		return true
+	default:
+		return false
+	}
+}
+
+// ValidateTemplateVariables checks that all {{variable}} placeholders used
+// in the formula are defined in the [vars] section.
+//
+// This catches the bug where formulas use computed variables like {{ready_count}}
+// in their text but don't define them in [vars], causing bd mol wisp to fail
+// with "missing required variables" error.
+//
+// Variables with any definition in [vars] (even with default="") are considered valid.
+func (f *Formula) ValidateTemplateVariables() error {
+	// Collect all text that might contain variables
+	var allText strings.Builder
+
+	// Description
+	allText.WriteString(f.Description)
+	allText.WriteString("\n")
+
+	// Steps (workflow)
+	for _, step := range f.Steps {
+		allText.WriteString(step.Title)
+		allText.WriteString("\n")
+		allText.WriteString(step.Description)
+		allText.WriteString("\n")
+	}
+
+	// Legs (convoy)
+	for _, leg := range f.Legs {
+		allText.WriteString(leg.Title)
+		allText.WriteString("\n")
+		allText.WriteString(leg.Description)
+		allText.WriteString("\n")
+		allText.WriteString(leg.Focus)
+		allText.WriteString("\n")
+	}
+
+	// Synthesis
+	if f.Synthesis != nil {
+		allText.WriteString(f.Synthesis.Title)
+		allText.WriteString("\n")
+		allText.WriteString(f.Synthesis.Description)
+		allText.WriteString("\n")
+	}
+
+	// Template (expansion)
+	for _, tmpl := range f.Template {
+		allText.WriteString(tmpl.Title)
+		allText.WriteString("\n")
+		allText.WriteString(tmpl.Description)
+		allText.WriteString("\n")
+	}
+
+	// Aspects
+	for _, aspect := range f.Aspects {
+		allText.WriteString(aspect.Title)
+		allText.WriteString("\n")
+		allText.WriteString(aspect.Description)
+		allText.WriteString("\n")
+		allText.WriteString(aspect.Focus)
+		allText.WriteString("\n")
+	}
+
+	// Extract all variables used
+	usedVars := ExtractTemplateVariables(allText.String())
+
+	// Check each against defined vars
+	var undefined []string
+	for _, v := range usedVars {
+		if _, defined := f.Vars[v]; !defined {
+			undefined = append(undefined, v)
+		}
+	}
+
+	if len(undefined) > 0 {
+		return fmt.Errorf("undefined template variables: %s (add to [vars] section with default=\"\" for computed values)",
+			strings.Join(undefined, ", "))
+	}
+
+	return nil
+}
+
+// GetUndefinedVariables returns a list of template variables used in the formula
+// that are not defined in the [vars] section. Useful for tooling and diagnostics.
+func (f *Formula) GetUndefinedVariables() []string {
+	if err := f.ValidateTemplateVariables(); err != nil {
+		// Parse the error to extract variable names
+		// This is a bit hacky but works for now
+		errStr := err.Error()
+		if idx := strings.Index(errStr, ": "); idx > 0 {
+			varsStr := errStr[idx+2:]
+			if endIdx := strings.Index(varsStr, " ("); endIdx > 0 {
+				varsStr = varsStr[:endIdx]
+			}
+			return strings.Split(varsStr, ", ")
+		}
+	}
+	return nil
+}

--- a/internal/formula/variable_validation_test.go
+++ b/internal/formula/variable_validation_test.go
@@ -1,0 +1,230 @@
+package formula
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestExtractTemplateVariables verifies we can find all {{variable}} patterns.
+func TestExtractTemplateVariables(t *testing.T) {
+	tests := []struct {
+		name     string
+		text     string
+		expected []string
+	}{
+		{
+			name:     "single variable",
+			text:     "Hello {{name}}!",
+			expected: []string{"name"},
+		},
+		{
+			name:     "multiple variables",
+			text:     "{{greeting}} {{name}}, you have {{count}} messages",
+			expected: []string{"count", "greeting", "name"}, // sorted alphabetically
+		},
+		{
+			name:     "no variables",
+			text:     "Hello world!",
+			expected: []string{},
+		},
+		{
+			name:     "duplicate variables",
+			text:     "{{name}} and {{name}} again",
+			expected: []string{"name"}, // should dedupe
+		},
+		{
+			name:     "handlebars helpers ignored",
+			text:     "{{#if condition}}{{value}}{{/if}}",
+			expected: []string{"value"}, // #if, /if are helpers, not variables
+		},
+		{
+			name:     "each helper ignored",
+			text:     "{{#each items}}{{item}}{{/each}}",
+			expected: []string{"item"}, // #each, /each are helpers
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got := ExtractTemplateVariables(tc.text)
+			if len(got) != len(tc.expected) {
+				t.Errorf("ExtractTemplateVariables(%q) = %v, want %v", tc.text, got, tc.expected)
+				return
+			}
+			for i, v := range tc.expected {
+				if got[i] != v {
+					t.Errorf("ExtractTemplateVariables(%q)[%d] = %q, want %q", tc.text, i, got[i], v)
+				}
+			}
+		})
+	}
+}
+
+// TestValidateTemplateVariables verifies that undefined variables are caught.
+func TestValidateTemplateVariables(t *testing.T) {
+	tests := []struct {
+		name      string
+		formula   string
+		wantError bool
+		errorMsg  string
+	}{
+		{
+			name: "all variables defined",
+			formula: `
+formula = "test"
+type = "workflow"
+version = 1
+
+[[steps]]
+id = "step1"
+title = "Work on {{issue}}"
+description = "Process {{issue}}"
+
+[vars.issue]
+description = "The issue ID"
+required = true
+`,
+			wantError: false,
+		},
+		{
+			name: "undefined variable",
+			formula: `
+formula = "test"
+type = "workflow"
+version = 1
+
+[[steps]]
+id = "step1"
+title = "Count: {{ready_count}}"
+description = "Process {{issue}}"
+
+[vars.issue]
+description = "The issue ID"
+required = true
+`,
+			wantError: true,
+			errorMsg:  "ready_count",
+		},
+		{
+			name: "variable with default is ok",
+			formula: `
+formula = "test"
+type = "workflow"
+version = 1
+
+[[steps]]
+id = "step1"
+title = "Count: {{ready_count}}"
+
+[vars.ready_count]
+description = "Computed count"
+default = ""
+`,
+			wantError: false,
+		},
+		{
+			name: "multiple undefined variables",
+			formula: `
+formula = "test"
+type = "workflow"
+version = 1
+
+[[steps]]
+id = "step1"
+title = "{{a}} {{b}} {{c}}"
+
+[vars.a]
+description = "Defined"
+required = true
+`,
+			wantError: true,
+			errorMsg:  "b", // Should mention at least one undefined
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			f, err := Parse([]byte(tc.formula))
+			if err != nil {
+				t.Fatalf("Parse failed: %v", err)
+			}
+
+			err = f.ValidateTemplateVariables()
+			if tc.wantError {
+				if err == nil {
+					t.Errorf("ValidateTemplateVariables() = nil, want error containing %q", tc.errorMsg)
+				} else if !strings.Contains(err.Error(), tc.errorMsg) {
+					t.Errorf("ValidateTemplateVariables() = %v, want error containing %q", err, tc.errorMsg)
+				}
+			} else {
+				if err != nil {
+					t.Errorf("ValidateTemplateVariables() = %v, want nil", err)
+				}
+			}
+		})
+	}
+}
+
+// TestMolConvoyFeedFormula_VariableValidation is a regression test for issue #1133.
+// The mol-convoy-feed formula uses template variables like {{ready_count}} that
+// aren't defined in [vars], causing wisp creation to fail.
+func TestMolConvoyFeedFormula_VariableValidation(t *testing.T) {
+	// Find the formula file
+	formulaPath := filepath.Join("formulas", "mol-convoy-feed.formula.toml")
+	data, err := os.ReadFile(formulaPath)
+	if err != nil {
+		t.Skipf("Formula file not found: %v", err)
+	}
+
+	f, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Failed to parse mol-convoy-feed formula: %v", err)
+	}
+
+	// This test will FAIL until the formula is fixed
+	err = f.ValidateTemplateVariables()
+	if err != nil {
+		t.Errorf("mol-convoy-feed formula has undefined template variables: %v", err)
+		t.Log("Fix: Add all computed variables to [vars] with default = \"\"")
+	}
+}
+
+// TestAllEmbeddedFormulas_VariableValidation ensures no embedded formula
+// has undefined template variables. This prevents future regressions.
+func TestAllEmbeddedFormulas_VariableValidation(t *testing.T) {
+	formulasDir := "formulas"
+	entries, err := os.ReadDir(formulasDir)
+	if err != nil {
+		t.Skipf("Formulas directory not found: %v", err)
+	}
+
+	var failures []string
+	for _, entry := range entries {
+		if !strings.HasSuffix(entry.Name(), ".formula.toml") {
+			continue
+		}
+
+		path := filepath.Join(formulasDir, entry.Name())
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Errorf("Failed to read %s: %v", entry.Name(), err)
+			continue
+		}
+
+		f, err := Parse(data)
+		if err != nil {
+			// Skip formulas that don't parse (may have other issues)
+			continue
+		}
+
+		if err := f.ValidateTemplateVariables(); err != nil {
+			failures = append(failures, entry.Name()+": "+err.Error())
+		}
+	}
+
+	if len(failures) > 0 {
+		t.Errorf("Formulas with undefined template variables:\n%s", strings.Join(failures, "\n"))
+	}
+}


### PR DESCRIPTION
## Summary

Add missing `[vars]` declarations to formula files and introduce validation to catch undefined template variables. All 9 affected formulas now have explicit test coverage.

## Related Issue

Fixes #1133

## Changes

- Add `variable_validation.go` with `ExtractTemplateVariables()` and `ValidateTemplateVariables()` functions
- Add `[vars]` sections to 9 formulas:
  - Dog formulas: mol-convoy-feed, mol-convoy-cleanup, mol-dep-propagate, mol-digest-generate, mol-orphan-scan, mol-session-gc
  - Polecat formulas: mol-polecat-code-review, mol-polecat-review-pr
  - Workflow formula: mol-town-shutdown
- Add unit tests for variable extraction/validation
- Add explicit integration tests for all 9 affected formulas:
  - `TestAllDogFormulas_CanBeWisped` - tests 6 dog formulas
  - `TestPolecatFormulas_CanBeWisped` - tests 2 polecat formulas
  - `TestTownShutdownFormula_CanBeWisped` - tests shutdown formula
  - `TestAllEmbeddedFormulas_VariableValidation` - catch-all for regressions

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed
- [x] Verified tests fail without formula fixes (red→green)
- [x] All 9 formulas have explicit test coverage
- Note: Pre-existing failures unrelated to this PR (TestParallelReadySteps filed as gt-olfq)

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)