### PR TITLE
fix(rig): normalize trailing dash in beads prefix

### DIFF
--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -280,6 +280,7 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 
 	// Track whether user explicitly provided --prefix (before deriving)
 	userProvidedPrefix := opts.BeadsPrefix != ""
+	opts.BeadsPrefix = strings.TrimSuffix(opts.BeadsPrefix, "-")
 
 	// Derive defaults
 	if opts.BeadsPrefix == "" {
@@ -398,7 +399,7 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 		if sourcePrefix := detectBeadsPrefixFromConfig(sourceBeadsConfig); sourcePrefix != "" {
 			fmt.Printf("  Detected existing beads prefix '%s' from source repo\n", sourcePrefix)
 			// Only error on mismatch if user explicitly provided --prefix
-			if userProvidedPrefix && opts.BeadsPrefix != sourcePrefix {
+			if userProvidedPrefix && strings.TrimSuffix(opts.BeadsPrefix, "-") != strings.TrimSuffix(sourcePrefix, "-") {
 				return nil, fmt.Errorf("prefix mismatch: source repo uses '%s' but --prefix '%s' was provided; use --prefix %s to match existing issues", sourcePrefix, opts.BeadsPrefix, sourcePrefix)
 			}
 			// Use detected prefix (overrides derived prefix)
@@ -905,7 +906,7 @@ func detectBeadsPrefixFromConfig(configPath string) string {
 				// Remove quotes if present
 				value = strings.Trim(value, `"'`)
 				if value != "" && isValidBeadsPrefix(value) {
-					return value
+					return strings.TrimSuffix(value, "-")
 				}
 			}
 		}

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -767,3 +767,46 @@ func TestConvertToSSH(t *testing.T) {
 		})
 	}
 }
+
+func TestDetectBeadsPrefixFromConfig_TrailingDash(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		want       string
+	}{
+		{
+			name:       "prefix without trailing dash is unchanged",
+			configYAML: "prefix: baseball-v3\n",
+			want:       "baseball-v3",
+		},
+		{
+			name:       "prefix with trailing dash is stripped",
+			configYAML: "prefix: baseball-v3-\n",
+			want:       "baseball-v3",
+		},
+		{
+			name:       "issue-prefix with trailing dash is stripped",
+			configYAML: "issue-prefix: baseball-v3-\n",
+			want:       "baseball-v3",
+		},
+		{
+			name:       "quoted prefix with trailing dash is stripped",
+			configYAML: "prefix: \"baseball-v3-\"\n",
+			want:       "baseball-v3",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			configPath := filepath.Join(dir, "config.yaml")
+			if err := os.WriteFile(configPath, []byte(tt.configYAML), 0644); err != nil {
+				t.Fatalf("writing config: %v", err)
+			}
+			got := detectBeadsPrefixFromConfig(configPath)
+			if got != tt.want {
+				t.Errorf("detectBeadsPrefixFromConfig() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes: #1135

- Strip trailing dashes from beads prefixes at the two intake boundaries (`detectBeadsPrefixFromConfig` and user-provided `--prefix` flag) so that a source config with `"baseball-v3-"` is stored as `"baseball-v3"`, preventing double-dashes in routes and bead IDs
- Normalize both sides of the prefix mismatch comparison so `baseball-v3` and `baseball-v3-` are treated as equivalent
- Add tests for trailing-dash normalization in `detectBeadsPrefixFromConfig`

## Test plan

- [x] `go test ./internal/rig/ -run TestDetectBeads -v` — new tests pass
- [x] `make test` — all existing rig tests pass (two pre-existing failures in unrelated packages: `TestCrossPlatformBuild` windows cross-compile, `TestParallelReadySteps` TOML parse)
- [ ] Manual: `gt rig add` with `--prefix baseball-v3-` produces single-dash routes and agent bead IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)