### PR TITLE
feat(doctor): add rig-name-mismatch check

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -137,6 +137,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewRoleLabelCheck())
 	d.Register(doctor.NewFormulaCheck())
 	d.Register(doctor.NewPrefixConflictCheck())
+	d.Register(doctor.NewRigNameMismatchCheck())
 	d.Register(doctor.NewPrefixMismatchCheck())
 	d.Register(doctor.NewDatabasePrefixCheck())
 	d.Register(doctor.NewRoutesCheck())

--- a/internal/doctor/rig_name_check.go
+++ b/internal/doctor/rig_name_check.go
@@ -1,0 +1,169 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// RigNameMismatchCheck detects when a rig's config.json has a name or beads
+// prefix that doesn't match the authoritative sources (directory name and
+// rigs.json registry respectively).
+type RigNameMismatchCheck struct {
+	FixableCheck
+}
+
+// NewRigNameMismatchCheck creates a new rig name mismatch check.
+func NewRigNameMismatchCheck() *RigNameMismatchCheck {
+	return &RigNameMismatchCheck{
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "rig-name-mismatch",
+				CheckDescription: "Check rig config.json name and prefix match directory and registry",
+				CheckCategory:    CategoryConfig,
+			},
+		},
+	}
+}
+
+// rigConfigLocal is a local type for reading/writing rig config.json without
+// importing the rig package (avoids circular dependency).
+type rigConfigLocal struct {
+	Type      string               `json:"type"`
+	Version   int                  `json:"version"`
+	Name      string               `json:"name"`
+	GitURL    string               `json:"git_url"`
+	LocalRepo string               `json:"local_repo,omitempty"`
+	CreatedAt json.RawMessage      `json:"created_at"`
+	Beads     *rigConfigBeadsLocal `json:"beads,omitempty"`
+
+	// Preserve unknown fields for round-trip fidelity
+	DefaultBranch string `json:"default_branch,omitempty"`
+}
+
+type rigConfigBeadsLocal struct {
+	Prefix     string `json:"prefix"`
+	SyncRemote string `json:"sync_remote,omitempty"`
+}
+
+func loadRigConfigLocal(rigPath string) (*rigConfigLocal, error) {
+	configPath := filepath.Join(rigPath, "config.json")
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, err
+	}
+	var cfg rigConfigLocal
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+func saveRigConfigLocal(rigPath string, cfg *rigConfigLocal) error {
+	configPath := filepath.Join(rigPath, "config.json")
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(configPath, data, 0644)
+}
+
+// Run checks for name/prefix mismatches between config.json and the
+// authoritative sources (directory name and rigs.json).
+func (c *RigNameMismatchCheck) Run(ctx *CheckContext) *CheckResult {
+	if ctx.RigName == "" {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "No rig specified (skipped)",
+		}
+	}
+
+	rigPath := ctx.RigPath()
+	cfg, err := loadRigConfigLocal(rigPath)
+	if err != nil {
+		// Missing or unreadable config.json — skip gracefully
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "No config.json found (skipped)",
+		}
+	}
+
+	var details []string
+
+	// Check 1: config.Name vs directory name
+	if cfg.Name != ctx.RigName {
+		details = append(details, fmt.Sprintf(
+			"config.json name is %q but directory is %q", cfg.Name, ctx.RigName))
+	}
+
+	// Check 2: config beads prefix vs rigs.json prefix
+	rigsPath := filepath.Join(ctx.TownRoot, "mayor", "rigs.json")
+	rigsConfig, rigsErr := loadRigsConfig(rigsPath)
+	if rigsErr == nil && cfg.Beads != nil && cfg.Beads.Prefix != "" {
+		if entry, ok := rigsConfig.Rigs[ctx.RigName]; ok && entry.BeadsConfig != nil && entry.BeadsConfig.Prefix != "" {
+			if cfg.Beads.Prefix != entry.BeadsConfig.Prefix {
+				details = append(details, fmt.Sprintf(
+					"config.json beads prefix is %q but rigs.json says %q",
+					cfg.Beads.Prefix, entry.BeadsConfig.Prefix))
+			}
+		}
+	}
+
+	if len(details) == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "Rig config name and prefix match directory and registry",
+		}
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusWarning,
+		Message: fmt.Sprintf("%d rig config mismatch(es) found", len(details)),
+		Details: details,
+		FixHint: "Run 'gt doctor --fix' to update config.json to match directory name and registry prefix",
+	}
+}
+
+// Fix updates config.json to match the directory name and rigs.json prefix.
+func (c *RigNameMismatchCheck) Fix(ctx *CheckContext) error {
+	if ctx.RigName == "" {
+		return nil
+	}
+
+	rigPath := ctx.RigPath()
+	cfg, err := loadRigConfigLocal(rigPath)
+	if err != nil {
+		return nil // Nothing to fix
+	}
+
+	modified := false
+
+	// Fix name to match directory
+	if cfg.Name != ctx.RigName {
+		cfg.Name = ctx.RigName
+		modified = true
+	}
+
+	// Fix prefix to match rigs.json
+	rigsPath := filepath.Join(ctx.TownRoot, "mayor", "rigs.json")
+	rigsConfig, rigsErr := loadRigsConfig(rigsPath)
+	if rigsErr == nil && cfg.Beads != nil && cfg.Beads.Prefix != "" {
+		if entry, ok := rigsConfig.Rigs[ctx.RigName]; ok && entry.BeadsConfig != nil && entry.BeadsConfig.Prefix != "" {
+			if cfg.Beads.Prefix != entry.BeadsConfig.Prefix {
+				cfg.Beads.Prefix = entry.BeadsConfig.Prefix
+				modified = true
+			}
+		}
+	}
+
+	if modified {
+		return saveRigConfigLocal(rigPath, cfg)
+	}
+
+	return nil
+}

--- a/internal/doctor/rig_name_check_test.go
+++ b/internal/doctor/rig_name_check_test.go
@@ -1,0 +1,269 @@
+package doctor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func setupRigNameTestDir(t *testing.T, rigName string, rigConfig *rigConfigLocal, rigsJSON *rigsConfigFile) string {
+	t.Helper()
+	townRoot := t.TempDir()
+
+	// Create rig directory with config.json
+	rigDir := filepath.Join(townRoot, rigName)
+	if err := os.MkdirAll(rigDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if rigConfig != nil {
+		data, err := json.MarshalIndent(rigConfig, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(rigDir, "config.json"), data, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create mayor/rigs.json if provided
+	if rigsJSON != nil {
+		mayorDir := filepath.Join(townRoot, "mayor")
+		if err := os.MkdirAll(mayorDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		data, err := json.MarshalIndent(rigsJSON, "", "  ")
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), data, 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	return townRoot
+}
+
+func TestRigNameMismatchCheck_AllMatch(t *testing.T) {
+	rigCfg := &rigConfigLocal{
+		Type:    "rig",
+		Version: 1,
+		Name:    "myrig",
+		Beads:   &rigConfigBeadsLocal{Prefix: "mr"},
+	}
+	rigsJSON := &rigsConfigFile{
+		Version: 1,
+		Rigs: map[string]rigsConfigEntry{
+			"myrig": {
+				BeadsConfig: &rigsConfigBeadsConfig{Prefix: "mr"},
+			},
+		},
+	}
+
+	townRoot := setupRigNameTestDir(t, "myrig", rigCfg, rigsJSON)
+
+	check := NewRigNameMismatchCheck()
+	ctx := &CheckContext{TownRoot: townRoot, RigName: "myrig"}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK, got %v: %v", result.Status, result.Details)
+	}
+}
+
+func TestRigNameMismatchCheck_NameMismatch(t *testing.T) {
+	rigCfg := &rigConfigLocal{
+		Type:    "rig",
+		Version: 1,
+		Name:    "oldname",
+		Beads:   &rigConfigBeadsLocal{Prefix: "mr"},
+	}
+	rigsJSON := &rigsConfigFile{
+		Version: 1,
+		Rigs: map[string]rigsConfigEntry{
+			"newname": {
+				BeadsConfig: &rigsConfigBeadsConfig{Prefix: "mr"},
+			},
+		},
+	}
+
+	townRoot := setupRigNameTestDir(t, "newname", rigCfg, rigsJSON)
+
+	check := NewRigNameMismatchCheck()
+	ctx := &CheckContext{TownRoot: townRoot, RigName: "newname"}
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning, got %v", result.Status)
+	}
+	if len(result.Details) != 1 {
+		t.Errorf("expected 1 detail, got %d: %v", len(result.Details), result.Details)
+	}
+}
+
+func TestRigNameMismatchCheck_PrefixMismatch(t *testing.T) {
+	rigCfg := &rigConfigLocal{
+		Type:    "rig",
+		Version: 1,
+		Name:    "myrig",
+		Beads:   &rigConfigBeadsLocal{Prefix: "ab"},
+	}
+	rigsJSON := &rigsConfigFile{
+		Version: 1,
+		Rigs: map[string]rigsConfigEntry{
+			"myrig": {
+				BeadsConfig: &rigsConfigBeadsConfig{Prefix: "xy"},
+			},
+		},
+	}
+
+	townRoot := setupRigNameTestDir(t, "myrig", rigCfg, rigsJSON)
+
+	check := NewRigNameMismatchCheck()
+	ctx := &CheckContext{TownRoot: townRoot, RigName: "myrig"}
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning, got %v", result.Status)
+	}
+	if len(result.Details) != 1 {
+		t.Errorf("expected 1 detail, got %d: %v", len(result.Details), result.Details)
+	}
+}
+
+func TestRigNameMismatchCheck_BothMismatch(t *testing.T) {
+	rigCfg := &rigConfigLocal{
+		Type:    "rig",
+		Version: 1,
+		Name:    "wrongname",
+		Beads:   &rigConfigBeadsLocal{Prefix: "ab"},
+	}
+	rigsJSON := &rigsConfigFile{
+		Version: 1,
+		Rigs: map[string]rigsConfigEntry{
+			"myrig": {
+				BeadsConfig: &rigsConfigBeadsConfig{Prefix: "xy"},
+			},
+		},
+	}
+
+	townRoot := setupRigNameTestDir(t, "myrig", rigCfg, rigsJSON)
+
+	check := NewRigNameMismatchCheck()
+	ctx := &CheckContext{TownRoot: townRoot, RigName: "myrig"}
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning, got %v", result.Status)
+	}
+	if len(result.Details) != 2 {
+		t.Errorf("expected 2 details, got %d: %v", len(result.Details), result.Details)
+	}
+}
+
+func TestRigNameMismatchCheck_NoConfigJson(t *testing.T) {
+	townRoot := t.TempDir()
+
+	// Create rig directory but no config.json
+	rigDir := filepath.Join(townRoot, "myrig")
+	if err := os.MkdirAll(rigDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewRigNameMismatchCheck()
+	ctx := &CheckContext{TownRoot: townRoot, RigName: "myrig"}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK for missing config.json, got %v", result.Status)
+	}
+}
+
+func TestRigNameMismatchCheck_Fix(t *testing.T) {
+	rigCfg := &rigConfigLocal{
+		Type:      "rig",
+		Version:   1,
+		Name:      "wrongname",
+		GitURL:    "https://example.com/repo.git",
+		CreatedAt: json.RawMessage(`"2025-01-01T00:00:00Z"`),
+		Beads:     &rigConfigBeadsLocal{Prefix: "ab"},
+	}
+	rigsJSON := &rigsConfigFile{
+		Version: 1,
+		Rigs: map[string]rigsConfigEntry{
+			"myrig": {
+				BeadsConfig: &rigsConfigBeadsConfig{Prefix: "xy"},
+			},
+		},
+	}
+
+	townRoot := setupRigNameTestDir(t, "myrig", rigCfg, rigsJSON)
+
+	check := NewRigNameMismatchCheck()
+	ctx := &CheckContext{TownRoot: townRoot, RigName: "myrig"}
+
+	// Verify mismatch is detected
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning before fix, got %v", result.Status)
+	}
+
+	// Apply fix
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+
+	// Re-read config.json and verify both fields are corrected
+	fixed, err := loadRigConfigLocal(filepath.Join(townRoot, "myrig"))
+	if err != nil {
+		t.Fatalf("failed to load fixed config: %v", err)
+	}
+
+	if fixed.Name != "myrig" {
+		t.Errorf("expected Name=%q after fix, got %q", "myrig", fixed.Name)
+	}
+	if fixed.Beads == nil || fixed.Beads.Prefix != "xy" {
+		prefix := ""
+		if fixed.Beads != nil {
+			prefix = fixed.Beads.Prefix
+		}
+		t.Errorf("expected Beads.Prefix=%q after fix, got %q", "xy", prefix)
+	}
+
+	// Re-run check to confirm clean
+	result = check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK after fix, got %v: %v", result.Status, result.Details)
+	}
+}
+
+func TestRigNameMismatchCheck_NoRig(t *testing.T) {
+	check := NewRigNameMismatchCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir(), RigName: ""}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when no rig specified, got %v", result.Status)
+	}
+}
+
+func TestRigNameMismatchCheck_NoRigsJson(t *testing.T) {
+	// Config name matches directory, but no rigs.json — should only check name
+	rigCfg := &rigConfigLocal{
+		Type:    "rig",
+		Version: 1,
+		Name:    "myrig",
+		Beads:   &rigConfigBeadsLocal{Prefix: "mr"},
+	}
+
+	townRoot := setupRigNameTestDir(t, "myrig", rigCfg, nil)
+
+	check := NewRigNameMismatchCheck()
+	ctx := &CheckContext{TownRoot: townRoot, RigName: "myrig"}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when name matches and no rigs.json, got %v: %v", result.Status, result.Details)
+	}
+}


### PR DESCRIPTION
## Summary

Prevents this issue: #1135 fixed by #1136 

- Add `RigNameMismatchCheck` to the doctor framework that detects when a rig's `config.json` has a `name` or `beads.prefix` that diverges from the authoritative sources (directory name and `rigs.json` registry)
- The fix updates `config.json` to match the directory name and registry prefix
- Uses local config structs to avoid circular dependency on the `rig` package; reuses the existing `loadRigsConfig()` helper from `beads_check.go`

## Test plan

- [x] `go test ./internal/doctor/ -run TestRigNameMismatch -v` — 8 new tests pass (all match, name mismatch, prefix mismatch, both, no config.json, fix, no rig, no rigs.json)
- [x] `make test` — all existing tests still pass (pre-existing `TestParallelReadySteps` TOML failure is unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)