### PR TITLE
fix(rig): validate git URL in gt rig add to reject local paths

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -331,6 +331,10 @@ func runRigAdd(cmd *cobra.Command, args []string) error {
 	}
 	gitURL := args[1]
 
+	if !isGitRemoteURL(gitURL) {
+		return fmt.Errorf("invalid git URL %q: expected a remote URL (https://, git@, ssh://, git://)\n\nTo register a local directory, use:\n  gt rig add %s --adopt", gitURL, name)
+	}
+
 	// Ensure beads (bd) is available before proceeding
 	if err := deps.EnsureBeads(true); err != nil {
 		return fmt.Errorf("beads dependency check failed: %w", err)
@@ -585,6 +589,11 @@ func runRigAdopt(_ *cobra.Command, args []string) error {
 	mgr := rig.NewManager(townRoot, rigsConfig, g)
 
 	fmt.Printf("Adopting existing rig %s...\n", style.Bold.Render(name))
+
+	// Validate --url if provided
+	if rigAddAdoptURL != "" && !isGitRemoteURL(rigAddAdoptURL) {
+		return fmt.Errorf("invalid git URL %q: expected a remote URL (https://, git@, ssh://, git://)", rigAddAdoptURL)
+	}
 
 	// Register the existing rig
 	result, err := mgr.RegisterRig(rig.RegisterRigOptions{
@@ -1625,4 +1634,48 @@ func getRigOperationalState(townRoot, rigName string) (state string, source stri
 
 	// Default: operational
 	return "OPERATIONAL", "default"
+}
+
+// isGitRemoteURL returns true if s looks like a remote git URL
+// (https, http, ssh, git protocol, or SCP-style) rather than a local path.
+func isGitRemoteURL(s string) bool {
+	// Reject flag-like strings (defense-in-depth against argument injection)
+	if strings.HasPrefix(s, "-") {
+		return false
+	}
+	// Reject absolute paths
+	if strings.HasPrefix(s, "/") {
+		return false
+	}
+	// Reject Windows-style paths (C:\...)
+	if len(s) >= 3 && s[1] == ':' && (s[2] == '/' || s[2] == '\\') {
+		return false
+	}
+	// Reject relative paths
+	if strings.HasPrefix(s, "./") || strings.HasPrefix(s, "../") {
+		return false
+	}
+	// Reject home-relative paths
+	if strings.HasPrefix(s, "~/") {
+		return false
+	}
+	// Reject file:// URIs (local filesystem access)
+	if strings.HasPrefix(s, "file://") {
+		return false
+	}
+	// Accept known remote URL schemes
+	if strings.HasPrefix(s, "https://") ||
+		strings.HasPrefix(s, "http://") ||
+		strings.HasPrefix(s, "ssh://") ||
+		strings.HasPrefix(s, "git://") {
+		return true
+	}
+	// Accept SCP-style SSH URLs (user@host:path) where user and host are non-empty
+	// and host contains no slashes (distinguishes from file:// or path-like strings)
+	atIdx := strings.Index(s, "@")
+	colonIdx := strings.Index(s, ":")
+	if atIdx > 0 && colonIdx > atIdx+1 && !strings.Contains(s[:colonIdx], "/") {
+		return true
+	}
+	return false
 }

--- a/internal/cmd/rig_test.go
+++ b/internal/cmd/rig_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import "testing"
+
+func TestIsGitRemoteURL(t *testing.T) {
+	tests := []struct {
+		input string
+		want  bool
+	}{
+		// Remote URLs — should return true
+		{"https://github.com/org/repo.git", true},
+		{"http://github.com/org/repo.git", true},
+		{"git@github.com:org/repo.git", true},
+		{"ssh://git@github.com/org/repo.git", true},
+		{"git://github.com/org/repo.git", true},
+		{"deploy@private-host.internal:repos/app.git", true},
+
+		// Local paths — should return false
+		{"/Users/scott/projects/foo", false},
+		{"/tmp/repo", false},
+		{"./foo", false},
+		{"../foo", false},
+		{"~/projects/foo", false},
+		{"C:\\Users\\scott\\projects\\foo", false},
+		{"C:/Users/scott/projects/foo", false},
+
+		// Bare directory name — should return false
+		{"foo", false},
+
+		// file:// URIs — should return false (local filesystem)
+		{"file:///tmp/evil-repo", false},
+		{"file:///Users/scott/projects/foo", false},
+		{"file://user@localhost:/tmp/evil-repo", false},
+
+		// Argument injection — should return false
+		{"-oProxyCommand=evil", false},
+		{"--upload-pack=touch /tmp/pwned", false},
+		{"-c", false},
+
+		// Malformed SCP-style — should return false
+		{"@host:path", false},    // empty user
+		{"user@:/path", false},   // empty host
+		{"localhost:path", false}, // no user (not SCP-style)
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := isGitRemoteURL(tt.input)
+			if got != tt.want {
+				t.Errorf("isGitRemoteURL(%q) = %v, want %v", tt.input, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `gt rig add name /local/path` silently succeeded because `git clone` accepts local paths. This adds `isGitRemoteURL()` validation in `runRigAdd()` that rejects local paths and suggests `--adopt` instead.
- Rejects absolute paths, relative paths, `~/` paths, Windows paths, `file://` URIs, and flag-like strings (defense-in-depth against argument injection).
- Accepts remote URL schemes (`https://`, `http://`, `ssh://`, `git://`) and SCP-style SSH URLs (`git@host:path`).
- Also validates `--url` in the `--adopt` code path to prevent unvalidated URLs from being stored in config.

## Test plan

- [x] `go test ./internal/cmd/ -run TestIsGitRemoteURL -v` — 24 test cases pass
- [x] `make test` — `internal/cmd` package passes (pre-existing failures in unrelated packages)
- [x] Manual: `gt rig add foo /tmp/some-dir` returns error with `--adopt` suggestion
- [x] Manual: `gt rig add foo https://github.com/org/repo.git` works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)