### PR TITLE
fix: make beads version check non-blocking with 2s timeout

### DIFF
--- a/internal/cmd/beads_version.go
+++ b/internal/cmd/beads_version.go
@@ -91,7 +91,7 @@ func (v beadsVersion) compare(other beadsVersion) int {
 var beadsVersionRe = regexp.MustCompile(`bd version (\d+\.\d+(?:\.\d+)?(?:-\w+)?)`)
 
 func getBeadsVersion() (string, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
 	// Use --no-daemon to avoid contention when multiple agents start simultaneously.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -101,8 +101,12 @@ func persistentPreRun(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Check beads version
-	return CheckBeadsVersion()
+	// Check beads version (non-blocking - warn only)
+	if err := CheckBeadsVersion(); err != nil {
+		// Just warn, don't block - beads issues shouldn't prevent gt from running
+		fmt.Fprintf(os.Stderr, "⚠ beads check: %v\n", err)
+	}
+	return nil
 }
 
 // initCLITheme initializes the CLI color theme based on settings and environment.


### PR DESCRIPTION
## Summary
Make CheckBeadsVersion() non-blocking to prevent gt from hanging when beads daemon is stuck.

## Related Issue
Fixes #1139

## Changes
- Changed beads version check from blocking error to warning-only
- Reduced timeout from 5s to 2s
- Commands continue running even if beads check fails/times out

## Testing
- [x] Manual testing: gt dashboard now starts even with stuck beads daemon
- [x] Verified warning is printed when check fails

## Checklist
- [x] Code follows project style
- [x] No breaking changes