### PR TITLE
fix(refinery): auto-sync crew workspaces after merge

### DIFF
--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/convoy"
+	"github.com/steveyegge/gastown/internal/crew"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/mail"
 	"github.com/steveyegge/gastown/internal/protocol"
@@ -490,8 +491,43 @@ func (e *Engineer) handleSuccess(mr *beads.Issue, result ProcessResult) {
 		}
 	}
 
-	// 5. Log success
+	// 5. Sync crew workspaces with the newly pushed changes
+	e.syncCrewWorkspaces()
+
+	// 6. Log success
 	_, _ = fmt.Fprintf(e.output, "[Engineer] ✓ Merged: %s (commit: %s)\n", mr.ID, result.MergeCommit)
+}
+
+// syncCrewWorkspaces pulls latest changes to all crew workspaces.
+// This ensures crew members have access to newly merged code without manual sync.
+func (e *Engineer) syncCrewWorkspaces() {
+	crewGit := git.NewGit(e.rig.Path)
+	crewMgr := crew.NewManager(e.rig, crewGit)
+
+	workers, err := crewMgr.List()
+	if err != nil {
+		_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to list crew workspaces: %v\n", err)
+		return
+	}
+
+	if len(workers) == 0 {
+		return
+	}
+
+	_, _ = fmt.Fprintf(e.output, "[Engineer] Syncing %d crew workspace(s)...\n", len(workers))
+
+	for _, worker := range workers {
+		result, err := crewMgr.Pristine(worker.Name)
+		if err != nil {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to sync crew/%s: %v\n", worker.Name, err)
+			continue
+		}
+		if result.Pulled {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] ✓ Synced crew/%s\n", worker.Name)
+		} else if result.PullError != "" {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: crew/%s pull failed: %s\n", worker.Name, result.PullError)
+		}
+	}
 }
 
 // handleFailure handles a failed merge request.


### PR DESCRIPTION
## Summary

- When the refinery successfully merges and pushes code to origin, it now automatically syncs all crew workspaces by running `git pull`
- This fixes the issue where crew workspaces would become stale after polecats completed work
- Previously, users had to manually run `gt crew pristine` to sync their workspaces with the latest code

## Problem

When a rig is created pointing to a remote git repo:
1. Polecats do work and push to origin
2. Refinery merges the work to main and pushes
3. Crew workspaces (human developer workspaces) remain stale
4. Users had to manually run `gt crew pristine` to get the latest code

## Solution

Added `syncCrewWorkspaces()` to `Engineer.handleSuccess()` which:
1. Lists all crew workspaces in the rig
2. Runs `Pristine()` (git pull) on each workspace
3. Logs success/failure for each sync

## Test plan

- [x] `go build ./internal/refinery/...` compiles
- [x] `go test ./internal/refinery/...` passes
- [ ] Manual test: create rig, add crew, run polecat work, verify crew auto-syncs after merge