### PR TITLE
fix(dashboard): resolve cross-rig issue details for convoy progress

### DIFF
--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -90,7 +90,7 @@ func NewLiveConvoyFetcher() (*LiveConvoyFetcher, error) {
 // FetchConvoys fetches all open convoys with their activity data.
 func (f *LiveConvoyFetcher) FetchConvoys() ([]ConvoyRow, error) {
 	// List all open convoy-type issues
-	stdout, err := runBdCmd(f.townBeads, "list", "--type=convoy", "--status=open", "--json")
+	stdout, err := runBdCmd(f.townRoot, "list", "--type=convoy", "--status=open", "--json")
 	if err != nil {
 		return nil, fmt.Errorf("listing convoys: %w", err)
 	}
@@ -203,7 +203,7 @@ type trackedIssueInfo struct {
 // getTrackedIssues fetches tracked issues for a convoy.
 func (f *LiveConvoyFetcher) getTrackedIssues(convoyID string) []trackedIssueInfo {
 	// Query tracked dependencies using bd dep list
-	stdout, err := runBdCmd(f.townBeads, "dep", "list", convoyID, "-t", "tracks", "--json")
+	stdout, err := runBdCmd(f.townRoot, "dep", "list", convoyID, "-t", "tracks", "--json")
 	if err != nil {
 		return nil
 	}
@@ -768,7 +768,7 @@ func (f *LiveConvoyFetcher) getAssignedIssuesMap() map[string]assignedIssue {
 	result := make(map[string]assignedIssue)
 
 	// Query all in_progress issues (these are the ones being worked on)
-	stdout, err := runBdCmd(f.townBeads, "list", "--status=in_progress", "--json")
+	stdout, err := runBdCmd(f.townRoot, "list", "--status=in_progress", "--json")
 	if err != nil {
 		return result // Return empty map on error
 	}
@@ -906,7 +906,7 @@ func parseActivityTimestamp(s string) (int64, bool) {
 // FetchMail fetches recent mail messages from the beads database.
 func (f *LiveConvoyFetcher) FetchMail() ([]MailRow, error) {
 	// List all message-type issues (mail)
-	stdout, err := runBdCmd(f.townBeads, "list", "--type=message", "--json", "--limit=50")
+	stdout, err := runBdCmd(f.townRoot, "list", "--type=message", "--json", "--limit=50")
 	if err != nil {
 		return nil, fmt.Errorf("listing mail: %w", err)
 	}
@@ -1147,7 +1147,7 @@ func (f *LiveConvoyFetcher) FetchDogs() ([]DogRow, error) {
 // FetchEscalations returns open escalations needing attention.
 func (f *LiveConvoyFetcher) FetchEscalations() ([]EscalationRow, error) {
 	// List open escalations
-	stdout, err := runBdCmd(f.townBeads, "list", "--label=gt:escalation", "--status=open", "--json")
+	stdout, err := runBdCmd(f.townRoot, "list", "--label=gt:escalation", "--status=open", "--json")
 	if err != nil {
 		return nil, nil // No escalations or bd not available
 	}
@@ -1251,7 +1251,7 @@ func (f *LiveConvoyFetcher) FetchHealth() (*HealthRow, error) {
 // FetchQueues returns work queues and their status.
 func (f *LiveConvoyFetcher) FetchQueues() ([]QueueRow, error) {
 	// List queue-type beads
-	stdout, err := runBdCmd(f.townBeads, "list", "--type=queue", "--json")
+	stdout, err := runBdCmd(f.townRoot, "list", "--type=queue", "--json")
 	if err != nil {
 		return nil, nil // No queues or bd not available
 	}
@@ -1385,7 +1385,7 @@ func (f *LiveConvoyFetcher) FetchSessions() ([]SessionRow, error) {
 // FetchHooks returns all hooked beads (work pinned to agents).
 func (f *LiveConvoyFetcher) FetchHooks() ([]HookRow, error) {
 	// Query all beads with status=hooked
-	stdout, err := runBdCmd(f.townBeads, "list", "--status=hooked", "--json", "--limit=0")
+	stdout, err := runBdCmd(f.townRoot, "list", "--status=hooked", "--json", "--limit=0")
 	if err != nil {
 		return nil, nil // No hooked beads or bd not available
 	}
@@ -1480,7 +1480,7 @@ func (f *LiveConvoyFetcher) FetchMayor() (*MayorStatus, error) {
 // FetchIssues returns open issues (the backlog).
 func (f *LiveConvoyFetcher) FetchIssues() ([]IssueRow, error) {
 	// Query open issues (excluding internal types like messages, convoys, queues)
-	stdout, err := runBdCmd(f.townBeads, "list", "--status=open", "--json", "--limit=50")
+	stdout, err := runBdCmd(f.townRoot, "list", "--status=open", "--json", "--limit=50")
 	if err != nil {
 		return nil, nil // No issues or bd not available
 	}


### PR DESCRIPTION
## Summary

Fixes #992

The dashboard was showing 0/0 progress for convoys that track issues from external rigs. The root cause was that all `bd` commands in `fetcher.go` were running from the `.beads/` directory instead of the town root, which breaks cross-rig routing.

**Fix:**
- Changed all `runBdCmd(f.townBeads, ...)` calls to `runBdCmd(f.townRoot, ...)`
- The `bd` CLI needs to run from the town root for cross-rig issue routing to work properly
- `bd dep list --json` already handles cross-rig resolution and returns full issue details

This is simpler than the original approach (SQLite queries + external rig lookups) because it relies on existing `bd` infrastructure rather than duplicating that logic.

## Test plan

- [x] Code builds successfully
- [x] Manual verification: `gt dashboard` shows correct counts (0/7) for cross-rig convoys

---
🤖 [Tackled](https://github.com/aleiby/claude-skills/tree/main/tackle) with [Claude Code](https://claude.com/claude-code)