### PR TITLE
fix(refinery): nudge refinery when MR is created, not at sling time

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -415,6 +415,9 @@ func runDone(cmd *cobra.Command, args []string) error {
 			// Success output
 			fmt.Printf("%s Work submitted to merge queue\n", style.Bold.Render("✓"))
 			fmt.Printf("  MR ID: %s\n", style.Bold.Render(mrID))
+
+			// Nudge refinery to pick up the new MR
+			nudgeRefinery(rigName, fmt.Sprintf("MR submitted: %s branch=%s", mrID, branch))
 		}
 		fmt.Printf("  Source: %s\n", branch)
 		fmt.Printf("  Target: %s\n", target)

--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -190,6 +190,9 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("creating merge request bead: %w", err)
 		}
+
+		// Nudge refinery to pick up the new MR
+		nudgeRefinery(rigName, fmt.Sprintf("MR submitted: %s branch=%s", mrIssue.ID, branch))
 	}
 
 	// Success output

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -488,21 +488,41 @@ func updateAgentHookBead(agentID, beadID, workDir, townBeadsDir string) {
 	}
 }
 
-// wakeRigAgents wakes the witness and refinery for a rig after polecat dispatch.
-// This ensures the patrol agents are ready to monitor and merge.
+// wakeRigAgents wakes the witness for a rig after polecat dispatch.
+// This ensures the witness is ready to monitor. The refinery is nudged
+// separately when an MR is actually created (by nudgeRefinery).
 func wakeRigAgents(rigName string) {
 	// Boot the rig (idempotent - no-op if already running)
 	bootCmd := exec.Command("gt", "rig", "boot", rigName)
 	_ = bootCmd.Run() // Ignore errors - rig might already be running
 
-	// Nudge witness and refinery to clear any backoff
+	// Nudge witness to clear any backoff
 	t := tmux.NewTmux()
 	witnessSession := fmt.Sprintf("gt-%s-witness", rigName)
+
+	// Silent nudge - session might not exist yet
+	_ = t.NudgeSession(witnessSession, "Polecat dispatched - check for work")
+}
+
+// nudgeRefinery wakes the refinery for a rig after an MR is created.
+// This ensures the refinery picks up the new merge request promptly
+// instead of waiting for its next poll cycle.
+func nudgeRefinery(rigName, message string) {
 	refinerySession := fmt.Sprintf("gt-%s-refinery", rigName)
 
-	// Silent nudges - sessions might not exist yet
-	_ = t.NudgeSession(witnessSession, "Polecat dispatched - check for work")
-	_ = t.NudgeSession(refinerySession, "Polecat dispatched - check for merge requests")
+	// Test hook: log nudge for test observability (same pattern as GT_TEST_ATTACHED_MOLECULE_LOG)
+	if logPath := os.Getenv("GT_TEST_NUDGE_LOG"); logPath != "" {
+		entry := fmt.Sprintf("nudge:%s:%s\n", refinerySession, message)
+		f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+		if err == nil {
+			_, _ = f.WriteString(entry)
+			_ = f.Close()
+		}
+		return // Don't actually nudge tmux in tests
+	}
+
+	t := tmux.NewTmux()
+	_ = t.NudgeSession(refinerySession, message)
 }
 
 // isPolecatTarget checks if the target string refers to a polecat.

--- a/internal/cmd/sling_helpers_test.go
+++ b/internal/cmd/sling_helpers_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestNudgeRefinerySessionName verifies that nudgeRefinery constructs the
+// correct tmux session name (gt-<rigName>-refinery) and passes the message.
+func TestNudgeRefinerySessionName(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "nudge.log")
+	t.Setenv("GT_TEST_NUDGE_LOG", logPath)
+
+	tests := []struct {
+		name        string
+		rigName     string
+		message     string
+		wantSession string
+	}{
+		{
+			name:        "simple rig name",
+			rigName:     "gastown",
+			message:     "MR submitted: gt-abc branch=polecat/Nux/gt-abc",
+			wantSession: "gt-gastown-refinery",
+		},
+		{
+			name:        "hyphenated rig name",
+			rigName:     "my-project",
+			message:     "MR submitted: mp-xyz branch=polecat/Toast/mp-xyz",
+			wantSession: "gt-my-project-refinery",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Truncate log for each subtest
+			if err := os.WriteFile(logPath, nil, 0644); err != nil {
+				t.Fatalf("truncate log: %v", err)
+			}
+
+			nudgeRefinery(tt.rigName, tt.message)
+
+			logBytes, err := os.ReadFile(logPath)
+			if err != nil {
+				t.Fatalf("read log: %v", err)
+			}
+			logContent := string(logBytes)
+
+			// Verify session name
+			wantPrefix := "nudge:" + tt.wantSession + ":"
+			if !strings.Contains(logContent, wantPrefix) {
+				t.Errorf("nudgeRefinery(%q) session = got log %q, want prefix %q",
+					tt.rigName, logContent, wantPrefix)
+			}
+
+			// Verify message is passed through
+			if !strings.Contains(logContent, tt.message) {
+				t.Errorf("nudgeRefinery() message not found in log: got %q, want %q",
+					logContent, tt.message)
+			}
+		})
+	}
+}
+
+// TestWakeRigAgentsDoesNotNudgeRefinery verifies that wakeRigAgents only
+// nudges the witness, not the refinery. The refinery should only be nudged
+// when an MR is actually created (via nudgeRefinery), not at polecat dispatch time.
+func TestWakeRigAgentsDoesNotNudgeRefinery(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "nudge.log")
+	t.Setenv("GT_TEST_NUDGE_LOG", logPath)
+
+	// wakeRigAgents calls exec.Command("gt", "rig", "boot", ...) and tmux.NudgeSession.
+	// The boot command and witness nudge will fail silently (no real rig/tmux).
+	// We only care that nudgeRefinery is NOT called (no log entries).
+	wakeRigAgents("testrig")
+
+	// Check that no refinery nudge was logged
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		// File doesn't exist = no nudges logged = correct
+		return
+	}
+	if strings.Contains(string(logBytes), "refinery") {
+		t.Errorf("wakeRigAgents() should not nudge refinery, but log contains: %s", string(logBytes))
+	}
+}
+
+// TestNudgeRefineryNoOpWithoutLog verifies that nudgeRefinery doesn't panic
+// or error when called without the test log env var and without a real tmux session.
+// The tmux NudgeSession call should fail silently.
+func TestNudgeRefineryNoOpWithoutLog(t *testing.T) {
+	// Ensure test log is NOT set so we exercise the real tmux path
+	t.Setenv("GT_TEST_NUDGE_LOG", "")
+
+	// Should not panic even though no tmux session exists
+	nudgeRefinery("nonexistent-rig", "test message")
+}


### PR DESCRIPTION
wakeRigAgents() was nudging the refinery at polecat spawn time before any MR existed. The refinery would wake up, find nothing, and go back to sleep. Move the refinery nudge to mq_submit and done, where MRs are actually created, so the refinery wakes up with work to process.

## Summary
<!-- Brief description of changes -->

## Related Issue
<!-- Link to issue: Fixes #123 or Closes #123 -->

## Changes
<!-- Bullet list of changes -->
-

## Testing
<!-- How did you test these changes? -->
- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)

## Human Note
Idk if there's guidance on how often to nudge, since it can interrupt agent work. But with this change there's no net new nudge between the polecat and refinery, still just one nudge per polecat. The nudge just happens after the work has been queued which is when the refinery needs to know about it, not when the polecat starts.
