### PR TITLE
fix(done): retry molecule close with exponential backoff

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -677,9 +677,27 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, _ string) { // issueID unus
 			// Order matters: wisp closes -> unblocks base bead -> base bead closes.
 			attachment := beads.ParseAttachmentFields(hookedBead)
 			if attachment != nil && attachment.AttachedMolecule != "" {
-				if err := bd.Close(attachment.AttachedMolecule); err != nil {
-					// Non-fatal: warn but continue
-					fmt.Fprintf(os.Stderr, "Warning: couldn't close attached molecule %s: %v\n", attachment.AttachedMolecule, err)
+				// Retry molecule close with exponential backoff. Transient failures
+				// can leave wisps orphaned, blocking the work bead from closing.
+				var moleculeClosed bool
+				var lastErr error
+				for attempt := 0; attempt < 3; attempt++ {
+					if err := bd.Close(attachment.AttachedMolecule); err == nil {
+						moleculeClosed = true
+						break
+					} else {
+						lastErr = err
+						if attempt < 2 {
+							time.Sleep(time.Duration(100<<attempt) * time.Millisecond) // 100ms, 200ms
+						}
+					}
+				}
+				if !moleculeClosed {
+					// All retries failed - skip closing hooked bead (it's blocked by the molecule)
+					fmt.Fprintf(os.Stderr, "Warning: couldn't close attached molecule %s after 3 attempts: %v\n", attachment.AttachedMolecule, lastErr)
+					// Don't try to close hookedBeadID - it will fail because it's still blocked
+					// The Witness will clean up orphaned state
+					return
 				}
 			}
 


### PR DESCRIPTION
## Summary

When `bd.Close(moleculeID)` fails transiently during `gt done`, the code previously warned and continued, then tried to close the hooked bead. But the hooked bead was still blocked by the open molecule, causing that close to also fail. This left both the wisp EPIC and work bead orphaned.

## Changes

- Add retry logic with exponential backoff (100ms, 200ms) for molecule close
- If all 3 attempts fail, skip trying to close the hooked bead (since it would fail anyway)
- Let the Witness handle cleanup of orphaned state

## Testing

- [x] Unit tests pass (`go test ./internal/cmd/...`)
- [x] Manual review of code changes

---
🤖 [Tackled](https://github.com/aleiby/claude-skills/tree/main/tackle) with [Claude Code](https://claude.com/claude-code)