### PR TITLE
Fix: Add missing deacon/dogs/ pattern to .gitignore template

### DIFF
--- a/internal/cmd/gitinit.go
+++ b/internal/cmd/gitinit.go
@@ -81,6 +81,9 @@ logs/
 # Polecats - worker worktrees
 **/polecats/
 
+# Deacon dogs - patrol worker worktrees
+**/deacon/dogs/
+
 # Mayor rig clones
 **/mayor/rig/
 


### PR DESCRIPTION
## Summary

Adds the missing `**/deacon/dogs/` pattern to the HQ .gitignore template.

The template included patterns for other worker directories (polecats, mayor/rig, refinery/rig, crew) but was missing deacon/dogs/, causing these ephemeral worker directories to appear as untracked files.

## Changes

Adds `**/deacon/dogs/` pattern to `internal/cmd/gitinit.go` to match the existing `**/polecats/` pattern.

## Note

This PR was originally bundled with several other fixes. Those changes have already been merged to main via commit 2499d26d:
- Runtime state gitignore patterns
- Ephemeral field in Issue struct
- gt-boot session recognition in orphan check

This PR now contains only the deacon/dogs gitignore pattern, which was the remaining unmerged change.

Fixes: gt-1ka

🤖 Generated with [Claude Code](https://claude.com/claude-code)