### PR TITLE
fix(boot): detect stale molecule progress for idle Deacon

### DIFF
--- a/internal/cmd/boot.go
+++ b/internal/cmd/boot.go
@@ -320,11 +320,21 @@ func runDegradedTriage(b *boot.Boot) (action, target string, err error) {
 			}
 		} else {
 			// Heartbeat is fresh - but is Deacon actually working?
-			// Check for idle state (no work on hook)
-			if !hasDeaconWork() {
+			// Check for idle state (no work on hook, or work not progressing)
+			hookBead := getDeaconHookBead()
+			if hookBead == "" {
 				fmt.Println("Deacon heartbeat fresh but no work on hook - nudging to restart patrol")
 				_ = tm.NudgeSession(deaconSession, "IDLE_CHECK: No active work on hook. If idle, start patrol: gt deacon patrol")
 				return "nudge", "deacon-idle", nil
+			}
+
+			// Has work on hook - check if it's actually progressing
+			// by looking at when the last molecule step was closed.
+			lastActivity, err := getMoleculeLastActivity(hookBead)
+			if err == nil && !lastActivity.IsZero() && time.Since(lastActivity) > 15*time.Minute {
+				fmt.Printf("Deacon has hooked work but no progress in %s - nudging\n", time.Since(lastActivity).Round(time.Minute))
+				_ = tm.NudgeSession(deaconSession, "IDLE_CHECK: Hooked work not progressing. Continue work or restart patrol: gt deacon patrol")
+				return "nudge", "deacon-stale-work", nil
 			}
 		}
 	}
@@ -332,28 +342,71 @@ func runDegradedTriage(b *boot.Boot) (action, target string, err error) {
 	return "nothing", "", nil
 }
 
-// hasDeaconWork checks if the Deacon has work on its hook.
+// getDeaconHookBead returns the bead ID hooked to Deacon, or "" if none.
 // Uses bd slot show to check the hook slot on the deacon agent bead.
-func hasDeaconWork() bool {
+func getDeaconHookBead() string {
 	// The deacon agent bead is hq-deacon (town-level)
 	cmd := exec.Command("bd", "slot", "show", "hq-deacon", "--json")
 	output, err := cmd.Output()
 	if err != nil {
-		// If we can't check, assume it has work (don't false-positive nudge)
-		return true
+		// If we can't check, assume no hook (conservative - may false-positive nudge)
+		return ""
 	}
 
-	// Parse JSON to check if hook slot is set
+	// Parse JSON to get hook slot value
 	var result struct {
 		Slots struct {
 			Hook *string `json:"hook"`
 		} `json:"slots"`
 	}
 	if err := json.Unmarshal(output, &result); err != nil {
-		return true // Parse error - assume has work
+		return "" // Parse error - assume no hook
 	}
 
-	return result.Slots.Hook != nil
+	if result.Slots.Hook == nil {
+		return ""
+	}
+	return *result.Slots.Hook
+}
+
+// getMoleculeLastActivity returns the most recent closed_at timestamp among
+// a molecule's steps. This indicates when the molecule last made progress.
+// Returns zero time if unable to determine (caller should assume working).
+//
+// TODO(steveyegge/beads#1456): Replace with `bd mol last-activity` when available.
+func getMoleculeLastActivity(molID string) (time.Time, error) {
+	cmd := exec.Command("bd", "mol", "current", molID, "--json")
+	output, err := cmd.Output()
+	if err != nil {
+		return time.Time{}, err
+	}
+
+	// bd mol current returns an array of molecules (usually one)
+	// Each has a steps array with issue details including closed_at
+	var molecules []struct {
+		Steps []struct {
+			Status string `json:"status"`
+			Issue  struct {
+				ClosedAt *time.Time `json:"closed_at"`
+			} `json:"issue"`
+		} `json:"steps"`
+	}
+	if err := json.Unmarshal(output, &molecules); err != nil {
+		return time.Time{}, err
+	}
+
+	// Find the most recent closed_at among all done steps
+	var latest time.Time
+	for _, mol := range molecules {
+		for _, step := range mol.Steps {
+			if step.Status == "done" && step.Issue.ClosedAt != nil {
+				if step.Issue.ClosedAt.After(latest) {
+					latest = *step.Issue.ClosedAt
+				}
+			}
+		}
+	}
+	return latest, nil
 }
 
 // formatDurationAgo formats a duration for human display.

--- a/internal/cmd/boot_test.go
+++ b/internal/cmd/boot_test.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"encoding/json"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBootSpawnAgentFlag(t *testing.T) {
@@ -15,5 +17,129 @@ func TestBootSpawnAgentFlag(t *testing.T) {
 	}
 	if !strings.Contains(flag.Usage, "overrides town default") {
 		t.Errorf("expected --agent usage to mention overrides town default, got %q", flag.Usage)
+	}
+}
+
+// TestSlotShowJSONParsing verifies the JSON schema for bd slot show output.
+// This catches schema changes that would break getDeaconHookBead().
+func TestSlotShowJSONParsing(t *testing.T) {
+	// Sample output from: bd slot show hq-deacon --json
+	sampleJSON := `{
+		"agent": "hq-deacon",
+		"slots": {
+			"hook": "hq-wisp-0laki",
+			"role": null
+		}
+	}`
+
+	var result struct {
+		Slots struct {
+			Hook *string `json:"hook"`
+		} `json:"slots"`
+	}
+
+	if err := json.Unmarshal([]byte(sampleJSON), &result); err != nil {
+		t.Fatalf("failed to parse slot show JSON: %v", err)
+	}
+
+	if result.Slots.Hook == nil {
+		t.Fatal("expected hook to be non-nil")
+	}
+	if *result.Slots.Hook != "hq-wisp-0laki" {
+		t.Errorf("expected hook to be 'hq-wisp-0laki', got %q", *result.Slots.Hook)
+	}
+}
+
+// TestSlotShowJSONParsingNoHook verifies parsing when no hook is set.
+func TestSlotShowJSONParsingNoHook(t *testing.T) {
+	sampleJSON := `{
+		"agent": "hq-deacon",
+		"slots": {
+			"hook": null,
+			"role": null
+		}
+	}`
+
+	var result struct {
+		Slots struct {
+			Hook *string `json:"hook"`
+		} `json:"slots"`
+	}
+
+	if err := json.Unmarshal([]byte(sampleJSON), &result); err != nil {
+		t.Fatalf("failed to parse slot show JSON: %v", err)
+	}
+
+	if result.Slots.Hook != nil {
+		t.Errorf("expected hook to be nil, got %q", *result.Slots.Hook)
+	}
+}
+
+// TestMolCurrentJSONParsing verifies the JSON schema for bd mol current output.
+// This catches schema changes that would break getMoleculeLastActivity().
+func TestMolCurrentJSONParsing(t *testing.T) {
+	// Sample output from: bd mol current hq-wisp-0laki --json (simplified)
+	sampleJSON := `[
+		{
+			"molecule_id": "hq-wisp-0laki",
+			"steps": [
+				{
+					"status": "done",
+					"issue": {
+						"id": "hq-step1",
+						"closed_at": "2026-02-02T05:50:55Z"
+					}
+				},
+				{
+					"status": "done",
+					"issue": {
+						"id": "hq-step2",
+						"closed_at": "2026-02-03T05:29:21Z"
+					}
+				},
+				{
+					"status": "pending",
+					"issue": {
+						"id": "hq-step3",
+						"closed_at": null
+					}
+				}
+			]
+		}
+	]`
+
+	var molecules []struct {
+		Steps []struct {
+			Status string `json:"status"`
+			Issue  struct {
+				ClosedAt *time.Time `json:"closed_at"`
+			} `json:"issue"`
+		} `json:"steps"`
+	}
+
+	if err := json.Unmarshal([]byte(sampleJSON), &molecules); err != nil {
+		t.Fatalf("failed to parse mol current JSON: %v", err)
+	}
+
+	if len(molecules) != 1 {
+		t.Fatalf("expected 1 molecule, got %d", len(molecules))
+	}
+	if len(molecules[0].Steps) != 3 {
+		t.Fatalf("expected 3 steps, got %d", len(molecules[0].Steps))
+	}
+
+	// Find latest closed_at among done steps
+	var latest time.Time
+	for _, step := range molecules[0].Steps {
+		if step.Status == "done" && step.Issue.ClosedAt != nil {
+			if step.Issue.ClosedAt.After(latest) {
+				latest = *step.Issue.ClosedAt
+			}
+		}
+	}
+
+	expected, _ := time.Parse(time.RFC3339, "2026-02-03T05:29:21Z")
+	if !latest.Equal(expected) {
+		t.Errorf("expected latest closed_at to be %v, got %v", expected, latest)
 	}
 }


### PR DESCRIPTION
## Summary

- Boot's IDLE_CHECK only fired when Deacon had no work on hook
- But Deacon can have work hooked (patrol molecule) while sitting idle at the prompt
- This adds molecule progress tracking to detect that case

## Changes

- Refactor `hasDeaconWork()` → `getDeaconHookBead()` (returns bead ID instead of bool)
- Add `getMoleculeLastActivity()` to check most recent step `closed_at`
- Update triage logic: if hooked work hasn't progressed in >15 min → IDLE_CHECK

## Test plan

- [x] `go build` compiles
- [x] `go test ./internal/cmd/...` passes
- [ ] Manual test with idle Deacon (has patrol molecule hooked but at prompt)

## Related

- #1177 - upstream issue for `bd mol last-activity` command (TODO in code to switch when available)

---
🤖 [Tackled](https://github.com/aleiby/claude-skills/tree/main/tackle) with [Claude Code](https://claude.com/claude-code)