### PR TITLE
fix(tmux): add defer cleanup to kill tests to prevent session leaks

### DIFF
--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -548,6 +548,7 @@ func TestKillSessionWithProcesses(t *testing.T) {
 	if err := tm.NewSessionWithCommand(sessionName, "", cmd); err != nil {
 		t.Fatalf("NewSessionWithCommand: %v", err)
 	}
+	defer func() { _ = tm.KillSession(sessionName) }()
 
 	// Verify session exists
 	has, err := tm.HasSession(sessionName)
@@ -603,6 +604,7 @@ func TestKillSessionWithProcessesExcluding(t *testing.T) {
 	if err := tm.NewSessionWithCommand(sessionName, "", cmd); err != nil {
 		t.Fatalf("NewSessionWithCommand: %v", err)
 	}
+	defer func() { _ = tm.KillSession(sessionName) }()
 
 	// Verify session exists
 	has, err := tm.HasSession(sessionName)
@@ -745,6 +747,7 @@ func TestKillSessionWithProcesses_KillsProcessGroup(t *testing.T) {
 	if err := tm.NewSessionWithCommand(sessionName, "", cmd); err != nil {
 		t.Fatalf("NewSessionWithCommand: %v", err)
 	}
+	defer func() { _ = tm.KillSession(sessionName) }()
 
 	// Give processes time to start
 	time.Sleep(200 * time.Millisecond)


### PR DESCRIPTION
## Summary
- Add defer cleanup to 3 tests that create tmux sessions without proper cleanup
- Prevents orphaned sessions if assertions fail before reaching the kill call

## Tests fixed
- `TestKillSessionWithProcesses`
- `TestKillSessionWithProcessesExcluding`  
- `TestKillSessionWithProcesses_KillsProcessGroup`

## Test plan
- [x] All tmux tests pass locally
- [x] Build passes