### PR TITLE
fix(formula): add missing skipped_count variable declaration

### DIFF
--- a/internal/formula/formulas/mol-convoy-feed.formula.toml
+++ b/internal/formula/formulas/mol-convoy-feed.formula.toml
@@ -275,6 +275,10 @@ default = ""
 description = "Computed: number of issues dispatched"
 default = ""
 
+[vars.skipped_count]
+description = "Computed: number of issues skipped (unmapped prefix)"
+default = ""
+
 [vars.issue_id]
 description = "Computed: current issue ID in dispatch loop"
 default = ""


### PR DESCRIPTION
## Summary

PR #1134 added variable validation tests but missed declaring `skipped_count` in `mol-convoy-feed.formula.toml`. The variable is used in the report template but was not declared in `[vars]`.

## Problem

`TestAllEmbeddedFormulas_VariableValidation` fails with:
```
mol-convoy-feed.formula.toml: undefined template variables: skipped_count
```

## Fix

Add the missing variable declaration:
```toml
[vars.skipped_count]
description = "Computed: number of issues skipped (unmapped prefix)"
default = ""
```

## Test plan

- [x] `TestAllEmbeddedFormulas_VariableValidation` passes
- [x] `TestMolConvoyFeedFormula_VariableValidation` passes
- [x] `TestAllDogFormulas_CanBeWisped` passes

## Related

- #1134 - PR that added variable validation (missed this variable)