### PR TITLE
fix(test): add --adopt flag to integration tests using local paths

### DIFF
--- a/internal/cmd/beads_db_init_test.go
+++ b/internal/cmd/beads_db_init_test.go
@@ -141,7 +141,8 @@ func TestBeadsDbInitAfterClone(t *testing.T) {
 		}
 
 		// Add rig WITHOUT specifying --prefix - should detect "existing-prefix" from issues.jsonl
-		cmd = exec.Command(gtBinary, "rig", "add", "myrig", existingRepo)
+		// Use --adopt since we're adding a local directory (not a remote URL)
+		cmd = exec.Command(gtBinary, "rig", "add", "myrig", existingRepo, "--adopt")
 		cmd.Dir = townRoot
 		cmd.Env = append(os.Environ(), "HOME="+tmpDir)
 		if output, err := cmd.CombinedOutput(); err != nil {
@@ -201,7 +202,8 @@ func TestBeadsDbInitAfterClone(t *testing.T) {
 		}
 
 		// Add rig WITH --prefix since we can't detect from empty issues.jsonl
-		cmd = exec.Command(gtBinary, "rig", "add", "emptyrig", emptyRepo, "--prefix", "empty-prefix")
+		// Use --adopt since we're adding a local directory (not a remote URL)
+		cmd = exec.Command(gtBinary, "rig", "add", "emptyrig", emptyRepo, "--adopt", "--prefix", "empty-prefix")
 		cmd.Dir = townRoot
 		cmd.Env = append(os.Environ(), "HOME="+tmpDir)
 		if output, err := cmd.CombinedOutput(); err != nil {
@@ -260,7 +262,8 @@ func TestBeadsDbInitAfterClone(t *testing.T) {
 		}
 
 		// Add rig with WRONG --prefix - should fail
-		cmd = exec.Command(gtBinary, "rig", "add", "mismatchrig", mismatchRepo, "--prefix", "wrong-prefix")
+		// Use --adopt since we're adding a local directory (not a remote URL)
+		cmd = exec.Command(gtBinary, "rig", "add", "mismatchrig", mismatchRepo, "--adopt", "--prefix", "wrong-prefix")
 		cmd.Dir = townRoot
 		cmd.Env = append(os.Environ(), "HOME="+tmpDir)
 		output, err := cmd.CombinedOutput()
@@ -304,7 +307,8 @@ func TestBeadsDbInitAfterClone(t *testing.T) {
 
 		// Add rig WITHOUT --prefix - should derive from rig name "testrig"
 		// deriveBeadsPrefix("testrig") should produce some abbreviation
-		cmd = exec.Command(gtBinary, "rig", "add", "testrig", derivedRepo)
+		// Use --adopt since we're adding a local directory (not a remote URL)
+		cmd = exec.Command(gtBinary, "rig", "add", "testrig", derivedRepo, "--adopt")
 		cmd.Dir = townRoot
 		cmd.Env = append(os.Environ(), "HOME="+tmpDir)
 		output, err := cmd.CombinedOutput()


### PR DESCRIPTION
## Summary

PR #1138 added validation to reject local paths in `gt rig add`, requiring `--adopt` for local directories. The integration tests in `beads_db_init_test.go` use local temp directories and need this flag.

## Problem

`TestBeadsDbInitAfterClone` fails with:
```
Error: invalid git URL "/tmp/...": expected a remote URL (https://, git@, ssh://, git://)

To register a local directory, use:
  gt rig add myrig --adopt
```

## Fix

Add `--adopt` flag to all `gt rig add` commands in the integration tests that use local paths.

## Test plan

- [x] Build passes
- [x] Integration tests should pass (tested concept matches error message suggestion)

## Related

- #1138 - PR that added local path validation