### PR TITLE
fix(doctor): allow identity anchor CLAUDE.md at town root

### DIFF
--- a/internal/doctor/claude_settings_check.go
+++ b/internal/doctor/claude_settings_check.go
@@ -142,11 +142,11 @@ func (c *ClaudeSettingsCheck) findSettingsFiles(townRoot string) []staleSettings
 	}
 
 	// Check for STALE CLAUDE.md at town root (~/gt/CLAUDE.md)
-	// This is WRONG - CLAUDE.md here is inherited by ALL agents via directory traversal,
-	// causing crew/polecat/etc to receive Mayor-specific instructions.
-	// Mayor's CLAUDE.md should be at ~/gt/mayor/CLAUDE.md instead.
+	// This is WRONG if it contains Mayor-specific instructions that would be inherited
+	// by ALL agents via directory traversal. However, a short identity anchor file
+	// (created by priming) that just says "run gt prime" is intentional and safe.
 	staleTownRootCLAUDEmd := filepath.Join(townRoot, "CLAUDE.md")
-	if fileExists(staleTownRootCLAUDEmd) {
+	if fileExists(staleTownRootCLAUDEmd) && !isIdentityAnchor(staleTownRootCLAUDEmd) {
 		files = append(files, staleSettingsInfo{
 			path:          staleTownRootCLAUDEmd,
 			agentType:     "mayor",
@@ -541,4 +541,23 @@ func fileExists(path string) bool {
 		return false
 	}
 	return !info.IsDir()
+}
+
+// isIdentityAnchor checks if a CLAUDE.md file is the short identity anchor
+// created by the priming system. These files are intentional - they contain
+// a brief message telling agents to run "gt prime" for their role-specific context.
+// They should NOT be flagged as "wrong location" since they don't contain
+// Mayor-specific instructions that would pollute other agents.
+//
+// An identity anchor is identified by:
+// - Being small (<20 lines)
+// - Containing "gt prime" (the recovery instruction)
+func isIdentityAnchor(path string) bool {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false
+	}
+	content := string(data)
+	lines := strings.Count(content, "\n") + 1
+	return lines < 20 && strings.Contains(content, "gt prime")
 }


### PR DESCRIPTION
## Summary

The `claude-settings` check and `priming` check have conflicting expectations about `~/gt/CLAUDE.md`:

- **claude-settings** (added in PR #239) flags ANY `~/gt/CLAUDE.md` as "wrong location" because Mayor-specific content there would be inherited by all agents via Claude Code's directory traversal
- **priming** expects a short identity anchor at `~/gt/CLAUDE.md` that tells agents to run `gt prime` for their role-specific context

This creates an infinite loop when running `gt doctor --fix`:
1. `claude-settings` deletes `~/gt/CLAUDE.md` and regenerates `~/gt/mayor/CLAUDE.md` from template (317 lines)
2. `priming` then fails because the identity anchor is missing AND `mayor/CLAUDE.md` exceeds 30 lines
3. Running `--fix` again repeats the cycle

## Root Cause

The checks have valid but different concerns:
- `claude-settings` correctly worries about Mayor-specific content polluting other agents
- `priming` correctly wants a generic identity anchor that works for ALL agents

The identity anchor created by priming is NOT Mayor-specific - it's a short (~8 line) file that says "run `gt prime` for your role". This is safe to inherit because it doesn't give any agent the wrong identity.

## Solution

Add `isIdentityAnchor()` helper that identifies the short priming anchor:
- File is small (<20 lines)
- Contains "gt prime" (the recovery instruction)

Update `claude-settings` to skip these files - they're intentional, not stale.

## Changes

- Add `isIdentityAnchor()` helper function
- Update town-root CLAUDE.md check to allow identity anchors
- Update comment to explain the distinction

## Test Plan

- [x] All existing `claude_settings_check` tests pass (23 tests)
- [x] Manual verification: `gt doctor` no longer flags the identity anchor
- [x] Verified both checks now pass simultaneously

## Related

- PR #239 added the `claude-settings` check
- PR #1082 attempted a larger fix but is stale
- Issue #205 documents related doctor check confusion

---
🤖 [Tackled](https://github.com/aleiby/claude-skills/tree/main/tackle) with [Claude Code](https://claude.com/claude-code)