### PR TITLE
fix(doctor): correct shell integration install hint

### DIFF
--- a/internal/doctor/global_state_check.go
+++ b/internal/doctor/global_state_check.go
@@ -86,14 +86,14 @@ func (c *GlobalStateCheck) Run(ctx *CheckContext) *CheckResult {
 	if len(errors) > 0 {
 		result.Status = StatusError
 		result.Message = errors[0]
-		result.FixHint = "Run: gt install --shell"
+		result.FixHint = "Run: gt shell install"
 	} else if len(warnings) > 0 {
 		result.Status = StatusWarning
 		result.Message = warnings[0]
 		if !s.Enabled {
 			result.FixHint = "Run: gt enable"
 		} else {
-			result.FixHint = "Run: gt install --shell"
+			result.FixHint = "Run: gt shell install"
 		}
 	} else {
 		result.Message = "Global state healthy"


### PR DESCRIPTION
## Summary
- Fix `gt doctor` global-state check to recommend `gt shell install` instead of `gt install --shell`
- The latter fails on existing HQ setups without `--force`, while the standalone command works correctly

## Test plan
- [x] Run `gt doctor` on existing HQ setup - verify hint shows `gt shell install`
- [x] Run `gt shell install` - verify it works without requiring `--force`

🤖 Generated with [Claude Code](https://claude.com/claude-code)