### PR TITLE
fix(shell): use detected shell RC path in activation message

### DIFF
--- a/internal/cmd/shell.go
+++ b/internal/cmd/shell.go
@@ -60,9 +60,10 @@ func runShellInstall(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%s Could not enable Gas Town: %v\n", style.Dim.Render("⚠"), err)
 	}
 
-	fmt.Printf("%s Shell integration installed (%s)\n", style.Success.Render("✓"), shell.RCFilePath(shell.DetectShell()))
+	rcPath := shell.RCFilePath(shell.DetectShell())
+	fmt.Printf("%s Shell integration installed (%s)\n", style.Success.Render("✓"), rcPath)
 	fmt.Println()
-	fmt.Println("Run 'source ~/.zshrc' or open a new terminal to activate.")
+	fmt.Printf("Run 'source %s' or open a new terminal to activate.\n", rcPath)
 	return nil
 }
 


### PR DESCRIPTION
## Summary
- Fix hardcoded `~/.zshrc` in shell install success message
- Now correctly shows `~/.bashrc` on bash or `~/.zshrc` on zsh

Before (on bash system):
```
✓ Shell integration installed (/home/user/.bashrc)

Run 'source ~/.zshrc' or open a new terminal to activate.
```

After:
```
✓ Shell integration installed (/home/user/.bashrc)

Run 'source /home/user/.bashrc' or open a new terminal to activate.
```

## Test plan
- [x] Run `gt shell install` on bash - verify message shows bashrc
- [x] Run `gt shell install` on zsh - verify message shows zshrc

🤖 Generated with [Claude Code](https://claude.com/claude-code)