### PR TITLE
feat(dashboard): show convoy titles alongside IDs

### DIFF
--- a/internal/web/templates/convoy.html
+++ b/internal/web/templates/convoy.html
@@ -153,6 +153,7 @@
                                 </td>
                                 <td>
                                     <span class="convoy-id">{{.ID}}</span>
+                                    {{if .Title}}<div class="convoy-title">{{.Title}}</div>{{end}}
                                 </td>
                                 <td>
                                     {{.Progress}}


### PR DESCRIPTION
## Summary

Adds convoy title display to the dashboard convoy list. Titles now appear below the convoy ID when available, making it easier to identify convoys at a glance.

## Changes

- `internal/web/templates/convoy.html`: Added convoy title display with `.convoy-title` class

## Testing

- All web package tests pass

---
🤖 [Tackled](https://github.com/aleiby/claude-skills/tree/main/tackle) with [Claude Code](https://claude.com/claude-code)