### PR TITLE
fix(web): remove os.Executable() to prevent test fork bomb

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -59,15 +59,11 @@ const optionsCacheTTL = 30 * time.Second
 
 // NewAPIHandler creates a new API handler.
 func NewAPIHandler() *APIHandler {
-	// Use the current executable as the gt binary (we ARE gt)
-	gtPath := "gt"
-	if exe, err := os.Executable(); err == nil {
-		gtPath = exe
-	}
-	// Capture the current working directory for command execution
+	// Use PATH lookup for gt binary. Do NOT use os.Executable() here - during
+	// tests it returns the test binary, causing fork bombs when executed.
 	workDir, _ := os.Getwd()
 	return &APIHandler{
-		gtPath:  gtPath,
+		gtPath:  "gt",
 		workDir: workDir,
 	}
 }

--- a/internal/web/setup.go
+++ b/internal/web/setup.go
@@ -203,18 +203,14 @@ func (h *SetupAPIHandler) handleLaunch(w http.ResponseWriter, r *http.Request) {
 		port = 8080
 	}
 
-	// Find the gt binary (use the one that's currently running)
-	gtBin, err := os.Executable()
-	if err != nil {
-		h.sendError(w, "Cannot find gt binary: "+err.Error(), http.StatusInternalServerError)
-		return
-	}
+	// Use PATH lookup for gt binary. Do NOT use os.Executable() here - during
+	// tests it returns the test binary, causing fork bombs when executed.
 
 	// Start new dashboard on a DIFFERENT port first, then we'll tell the browser to go there
 	newPort := port + 1
 
 	// Start new dashboard process from the workspace directory
-	cmd := exec.Command(gtBin, "dashboard", "--port", fmt.Sprintf("%d", newPort))
+	cmd := exec.Command("gt", "dashboard", "--port", fmt.Sprintf("%d", newPort))
 	cmd.Dir = path
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr


### PR DESCRIPTION
## Summary

Removes `os.Executable()` usage that can cause fork bombs during test execution.

### The Issue

`NewAPIHandler()` and `handleEnterWorkspace()` use `os.Executable()` to find the gt binary. The intent was to use the currently running binary rather than PATH lookup.

However, during tests `os.Executable()` returns the test binary (e.g., `web.test`). If a test calls an endpoint that executes commands (like `/api/crew`), it runs `web.test crew list --json`, which re-runs all tests, recursively.

This was a latent bug from PR #1018 - the original tests only covered blocked commands that don't execute. It became a problem when tests for `/api/crew` and `/api/ready` were added.

### The Fix

Use PATH lookup (`"gt"`) instead of `os.Executable()`. Simpler and safer - if gt isn't in PATH, commands fail with a clear error.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)