### PR TITLE
docs: add PR branch naming guidance to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,6 +18,31 @@ We use a direct-to-main workflow for trusted contributors. For external contribu
 3. Ensure tests pass: `go test ./...`
 4. Submit a pull request
 
+### PR Branch Naming
+
+**Never create PRs from your fork's `main` branch.** Always create a dedicated branch for each PR:
+
+```bash
+# Good - dedicated branch per PR
+git checkout -b fix/deacon-startup upstream/main
+git checkout -b feat/auto-seance upstream/main
+
+# Bad - PR from main accumulates unrelated commits
+git checkout main  # Don't PR from here!
+```
+
+Why this matters:
+- PRs from `main` accumulate ALL commits pushed to your fork
+- Multiple contributors pushing to the same fork's `main` creates chaos
+- Reviewers can't tell which commits belong to which PR
+- You can't have multiple PRs open simultaneously
+
+Branch naming conventions:
+- `fix/*` - Bug fixes
+- `feat/*` - New features
+- `refactor/*` - Code restructuring
+- `docs/*` - Documentation only
+
 ## Code Style
 
 - Follow standard Go conventions (`gofmt`, `go vet`)


### PR DESCRIPTION
## Summary
- Add explicit guidance about PR branching to prevent the anti-pattern of creating PRs from fork main branch

## Problem
When PRs are created from `aleiby:main` instead of a dedicated feature branch:
- PRs accumulate ALL commits pushed to the fork
- Multiple contributors pushing to the same fork's `main` creates chaos
- Reviewers can't tell which commits belong to which PR
- Contributors can't have multiple PRs open simultaneously

## Changes
- Add "PR Branch Naming" section to CONTRIBUTING.md after "Development Workflow"
- Include examples of good vs bad branch practices
- List branch naming conventions (fix/*, feat/*, refactor/*, docs/*)

---
🤖 [Tackled](https://github.com/aleiby/claude-skills/tree/main/tackle) with [Claude Code](https://claude.com/claude-code)