### PR TITLE
fix(role): remove incorrect /rig suffix from crew/polecat paths

### DIFF
--- a/internal/cmd/role.go
+++ b/internal/cmd/role.go
@@ -326,12 +326,12 @@ func getRoleHome(role Role, rig, polecat, townRoot string) string {
 		if rig == "" || polecat == "" {
 			return ""
 		}
-		return filepath.Join(townRoot, rig, "polecats", polecat, "rig")
+		return filepath.Join(townRoot, rig, "polecats", polecat)
 	case RoleCrew:
 		if rig == "" || polecat == "" {
 			return ""
 		}
-		return filepath.Join(townRoot, rig, "crew", polecat, "rig")
+		return filepath.Join(townRoot, rig, "crew", polecat)
 	default:
 		return ""
 	}

--- a/internal/cmd/role_e2e_test.go
+++ b/internal/cmd/role_e2e_test.go
@@ -65,12 +65,12 @@ func TestRoleHomeE2E(t *testing.T) {
 		{
 			name:     "polecat",
 			args:     []string{"role", "home", "polecat", "--rig", rigName, "--polecat", "Toast"},
-			expected: filepath.Join(hqPath, rigName, "polecats", "Toast", "rig"),
+			expected: filepath.Join(hqPath, rigName, "polecats", "Toast"),
 		},
 		{
 			name:     "crew",
 			args:     []string{"role", "home", "crew", "--rig", rigName, "--polecat", "worker1"},
-			expected: filepath.Join(hqPath, rigName, "crew", "worker1", "rig"),
+			expected: filepath.Join(hqPath, rigName, "crew", "worker1"),
 		},
 	}
 
@@ -170,8 +170,8 @@ func TestRoleHomeCwdDetection(t *testing.T) {
 	dirs := []string{
 		filepath.Join(hqPath, rigName, "witness"),
 		filepath.Join(hqPath, rigName, "refinery", "rig"),
-		filepath.Join(hqPath, rigName, "polecats", "Toast", "rig"),
-		filepath.Join(hqPath, rigName, "crew", "worker1", "rig"),
+		filepath.Join(hqPath, rigName, "polecats", "Toast"),
+		filepath.Join(hqPath, rigName, "crew", "worker1"),
 	}
 	for _, dir := range dirs {
 		if err := os.MkdirAll(dir, 0755); err != nil {
@@ -205,14 +205,14 @@ func TestRoleHomeCwdDetection(t *testing.T) {
 			expected: filepath.Join(hqPath, rigName, "refinery", "rig"),
 		},
 		{
-			name:     "polecat from polecats/Toast/rig dir",
-			cwd:      filepath.Join(hqPath, rigName, "polecats", "Toast", "rig"),
-			expected: filepath.Join(hqPath, rigName, "polecats", "Toast", "rig"),
+			name:     "polecat from polecats/Toast dir",
+			cwd:      filepath.Join(hqPath, rigName, "polecats", "Toast"),
+			expected: filepath.Join(hqPath, rigName, "polecats", "Toast"),
 		},
 		{
-			name:     "crew from crew/worker1/rig dir",
-			cwd:      filepath.Join(hqPath, rigName, "crew", "worker1", "rig"),
-			expected: filepath.Join(hqPath, rigName, "crew", "worker1", "rig"),
+			name:     "crew from crew/worker1 dir",
+			cwd:      filepath.Join(hqPath, rigName, "crew", "worker1"),
+			expected: filepath.Join(hqPath, rigName, "crew", "worker1"),
 		},
 	}
 
@@ -253,8 +253,8 @@ func TestRoleEnvCwdDetection(t *testing.T) {
 	dirs := []string{
 		filepath.Join(hqPath, rigName, "witness"),
 		filepath.Join(hqPath, rigName, "refinery", "rig"),
-		filepath.Join(hqPath, rigName, "polecats", "Toast", "rig"),
-		filepath.Join(hqPath, rigName, "crew", "worker1", "rig"),
+		filepath.Join(hqPath, rigName, "polecats", "Toast"),
+		filepath.Join(hqPath, rigName, "crew", "worker1"),
 	}
 	for _, dir := range dirs {
 		if err := os.MkdirAll(dir, 0755); err != nil {
@@ -304,25 +304,25 @@ func TestRoleEnvCwdDetection(t *testing.T) {
 			},
 		},
 		{
-			name: "polecat from polecats/Toast/rig dir",
-			cwd:  filepath.Join(hqPath, rigName, "polecats", "Toast", "rig"),
+			name: "polecat from polecats/Toast dir",
+			cwd:  filepath.Join(hqPath, rigName, "polecats", "Toast"),
 			want: []string{
 				"export GT_ROLE=polecat",
 				"export GT_RIG=" + rigName,
 				"export GT_POLECAT=Toast",
 				"export BD_ACTOR=" + rigName + "/polecats/Toast",
-				"export GT_ROLE_HOME=" + filepath.Join(hqPath, rigName, "polecats", "Toast", "rig"),
+				"export GT_ROLE_HOME=" + filepath.Join(hqPath, rigName, "polecats", "Toast"),
 			},
 		},
 		{
-			name: "crew from crew/worker1/rig dir",
-			cwd:  filepath.Join(hqPath, rigName, "crew", "worker1", "rig"),
+			name: "crew from crew/worker1 dir",
+			cwd:  filepath.Join(hqPath, rigName, "crew", "worker1"),
 			want: []string{
 				"export GT_ROLE=crew",
 				"export GT_RIG=" + rigName,
 				"export GT_CREW=worker1",
 				"export BD_ACTOR=" + rigName + "/crew/worker1",
-				"export GT_ROLE_HOME=" + filepath.Join(hqPath, rigName, "crew", "worker1", "rig"),
+				"export GT_ROLE_HOME=" + filepath.Join(hqPath, rigName, "crew", "worker1"),
 			},
 		},
 	}


### PR DESCRIPTION
## Summary
- Fix `getRoleHome()` returning incorrect paths for crew and polecat roles
- The function incorrectly appended `/rig` suffix to paths, but workspace creation never creates that subdirectory
- This caused `gt sling tackle --on <issue>` to fail for crew workers

## Root Cause

Commit 2343e6b0 (Jan 7, 2026) introduced this bug with the commit message:
> "Fix getRoleHome paths (witness has no /rig suffix, polecat/crew do)"

However, this was **backwards** - the reality is:
- **Witness/Refinery**: HAVE `/rig` subdirectory (`<rig>/refinery/rig/`)
- **Crew/Polecat**: Do NOT have `/rig` subdirectory (`<rig>/crew/<name>/`)

The **original** `getRoleHome` implementation (commit 2f4a3539, Dec 18, 2025) was correct:
- Crew: `filepath.Join(townRoot, rig, "crew", polecat)` - no `/rig`
- Polecat: `filepath.Join(townRoot, rig, "polecats", polecat)` - no `/rig`

The workspace creation code in `internal/crew/manager.go` (commit 887c0f19, Dec 16, 2025) always created paths without `/rig`:
```go
crewBaseDir := filepath.Join(m.rig.Path, "crew")
// Creates: <rig>/crew/<name> (NO /rig suffix)
```

This fix restores the original correct behavior.

## Test plan
- [x] Updated `role_e2e_test.go` to expect correct paths (without `/rig` suffix)
- [x] Manual test: `gt role home crew --rig gastown --polecat holden` returns correct path
- [x] Code compiles successfully

---
🤖 [Tackled](https://github.com/aleiby/claude-skills/tree/main/tackle) with [Claude Code](https://claude.com/claude-code)