### PR TITLE
fix(rig): check parked/docked status before starting agents

### DIFF
--- a/internal/cmd/refinery.go
+++ b/internal/cmd/refinery.go
@@ -294,6 +294,10 @@ func runRefineryStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	if err := checkRigNotParkedOrDocked(rigName); err != nil {
+		return err
+	}
+
 	fmt.Printf("Starting refinery for %s...\n", rigName)
 
 	if err := mgr.Start(refineryForeground, refineryAgentOverride); err != nil {
@@ -519,6 +523,10 @@ func runRefineryRestart(cmd *cobra.Command, args []string) error {
 
 	mgr, _, rigName, err := getRefineryManager(rigName)
 	if err != nil {
+		return err
+	}
+
+	if err := checkRigNotParkedOrDocked(rigName); err != nil {
 		return err
 	}
 

--- a/internal/cmd/rig_helpers.go
+++ b/internal/cmd/rig_helpers.go
@@ -10,6 +10,31 @@ import (
 	"github.com/steveyegge/gastown/internal/workspace"
 )
 
+// checkRigNotParkedOrDocked checks if a rig is parked or docked and returns
+// an error if so. This prevents starting agents on rigs that have been
+// intentionally taken offline.
+func checkRigNotParkedOrDocked(rigName string) error {
+	townRoot, r, err := getRig(rigName)
+	if err != nil {
+		return err
+	}
+
+	if IsRigParked(townRoot, rigName) {
+		return fmt.Errorf("rig '%s' is parked - use 'gt rig unpark %s' first", rigName, rigName)
+	}
+
+	prefix := "gt"
+	if r.Config != nil && r.Config.Prefix != "" {
+		prefix = r.Config.Prefix
+	}
+
+	if IsRigDocked(townRoot, rigName, prefix) {
+		return fmt.Errorf("rig '%s' is docked - use 'gt rig undock %s' first", rigName, rigName)
+	}
+
+	return nil
+}
+
 // getRig finds the town root and retrieves the specified rig.
 // This is the common boilerplate extracted from get*Manager functions.
 // Returns the town root path and rig instance.

--- a/internal/cmd/rig_park_enforcement_test.go
+++ b/internal/cmd/rig_park_enforcement_test.go
@@ -1,0 +1,105 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/wisp"
+)
+
+func TestIsRigParked_WhenParked(t *testing.T) {
+	townRoot := t.TempDir()
+	rigName := "testrig"
+
+	// Set up wisp config with parked status
+	configDir := filepath.Join(townRoot, wisp.WispConfigDir, wisp.ConfigSubdir)
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("failed to create wisp config dir: %v", err)
+	}
+
+	configFile := filepath.Join(configDir, rigName+".json")
+	data, _ := json.Marshal(wisp.ConfigFile{
+		Rig:    rigName,
+		Values: map[string]interface{}{"status": "parked"},
+	})
+	if err := os.WriteFile(configFile, data, 0o644); err != nil {
+		t.Fatalf("failed to write wisp config: %v", err)
+	}
+
+	if !IsRigParked(townRoot, rigName) {
+		t.Error("expected IsRigParked to return true for parked rig")
+	}
+}
+
+func TestIsRigParked_WhenNotParked(t *testing.T) {
+	townRoot := t.TempDir()
+	rigName := "testrig"
+
+	// No wisp config at all — should not be parked
+	if IsRigParked(townRoot, rigName) {
+		t.Error("expected IsRigParked to return false when no wisp config exists")
+	}
+}
+
+func TestIsRigParked_WhenUnparked(t *testing.T) {
+	townRoot := t.TempDir()
+	rigName := "testrig"
+
+	// Set up wisp config with empty status (unparked)
+	configDir := filepath.Join(townRoot, wisp.WispConfigDir, wisp.ConfigSubdir)
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("failed to create wisp config dir: %v", err)
+	}
+
+	configFile := filepath.Join(configDir, rigName+".json")
+	data, _ := json.Marshal(wisp.ConfigFile{
+		Rig:    rigName,
+		Values: map[string]interface{}{},
+	})
+	if err := os.WriteFile(configFile, data, 0o644); err != nil {
+		t.Fatalf("failed to write wisp config: %v", err)
+	}
+
+	if IsRigParked(townRoot, rigName) {
+		t.Error("expected IsRigParked to return false for unparked rig")
+	}
+}
+
+func TestIsRigParked_WhenDocked(t *testing.T) {
+	townRoot := t.TempDir()
+	rigName := "testrig"
+
+	// Wisp config with docked status — IsRigParked should return false
+	// (docked is a separate check via IsRigDocked)
+	configDir := filepath.Join(townRoot, wisp.WispConfigDir, wisp.ConfigSubdir)
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("failed to create wisp config dir: %v", err)
+	}
+
+	configFile := filepath.Join(configDir, rigName+".json")
+	data, _ := json.Marshal(wisp.ConfigFile{
+		Rig:    rigName,
+		Values: map[string]interface{}{"status": "docked"},
+	})
+	if err := os.WriteFile(configFile, data, 0o644); err != nil {
+		t.Fatalf("failed to write wisp config: %v", err)
+	}
+
+	if IsRigParked(townRoot, rigName) {
+		t.Error("expected IsRigParked to return false for docked rig (not parked)")
+	}
+}
+
+func TestRigStatusConstants(t *testing.T) {
+	if RigStatusKey != "status" {
+		t.Errorf("expected RigStatusKey to be 'status', got %q", RigStatusKey)
+	}
+	if RigStatusParked != "parked" {
+		t.Errorf("expected RigStatusParked to be 'parked', got %q", RigStatusParked)
+	}
+	if RigDockedLabel != "status:docked" {
+		t.Errorf("expected RigDockedLabel to be 'status:docked', got %q", RigDockedLabel)
+	}
+}

--- a/internal/cmd/witness.go
+++ b/internal/cmd/witness.go
@@ -156,6 +156,10 @@ func getWitnessManager(rigName string) (*witness.Manager, error) {
 func runWitnessStart(cmd *cobra.Command, args []string) error {
 	rigName := args[0]
 
+	if err := checkRigNotParkedOrDocked(rigName); err != nil {
+		return err
+	}
+
 	mgr, err := getWitnessManager(rigName)
 	if err != nil {
 		return err
@@ -338,6 +342,10 @@ func runWitnessAttach(cmd *cobra.Command, args []string) error {
 
 func runWitnessRestart(cmd *cobra.Command, args []string) error {
 	rigName := args[0]
+
+	if err := checkRigNotParkedOrDocked(rigName); err != nil {
+		return err
+	}
 
 	mgr, err := getWitnessManager(rigName)
 	if err != nil {


### PR DESCRIPTION
## Summary
- `gt witness start`, `gt witness restart`, `gt refinery start`, and `gt refinery restart` now check rig operational status before spawning agents
- Returns a clear error if the rig is parked or docked, with instructions to unpark/undock

## Problem
The daemon correctly checks `isRigOperational()` before auto-starting agents, but the manual CLI commands bypass this check entirely. This means parked/docked rigs can have agents started on them by users or Claude agents (e.g., the Deacon), defeating the purpose of parking/docking.

## Changes
- Add `checkRigNotParkedOrDocked()` helper in `rig_helpers.go` that calls the existing `IsRigParked()` and `IsRigDocked()` functions
- Add the check to `runWitnessStart()`, `runWitnessRestart()`, `runRefineryStart()`, and `runRefineryRestart()`
- Add unit tests for `IsRigParked` covering parked, unparked, no-config, and docked-not-parked cases

## Testing
- Unit tests pass: `go test -vet=off -run "TestIsRigParked|TestRigStatusConstants" ./internal/cmd/`
- Manual testing: `gt rig park <rig> && gt witness start <rig>` → error
- Manual testing: docked rig label → all four commands return error
- Manual testing: unpark/remove label → commands work normally

**Note:** Tests require `-vet=off` due to a pre-existing issue: `mail_check_test.go` references symbols (`mailCheckCacheDir`, `loadMailCheckCache`, etc.) that don't exist in any source file, preventing the `internal/cmd` package from compiling tests without `-vet=off`.

Closes #1152