### PR TITLE
fix(beads): try reopen on any create failure instead of parsing errors

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -220,7 +220,8 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 //
 // The function:
 // 1. Tries to create the agent bead
-// 2. If UNIQUE constraint fails, reopens the existing bead and updates its fields
+// 2. If create fails, tries to reopen existing bead and update its fields
+// 3. If reopen also fails, returns the original create error
 func (b *Beads) CreateOrReopenAgentBead(id, title string, fields *AgentFields) (*Issue, error) {
 	// First try to create the bead
 	issue, err := b.CreateAgentBead(id, title, fields)
@@ -228,20 +229,19 @@ func (b *Beads) CreateOrReopenAgentBead(id, title string, fields *AgentFields) (
 		return issue, nil
 	}
 
-	// Check if it's a UNIQUE constraint error
-	if !strings.Contains(err.Error(), "UNIQUE constraint failed") {
-		return nil, err
-	}
+	// Create failed - try to reopen existing bead instead of parsing error messages
+	// (error formats differ between SQLite and Dolt backends)
+	createErr := err
 
 	// Resolve where this bead lives (for slot operations)
 	targetDir := ResolveRoutingTarget(b.getTownRoot(), id, b.getResolvedBeadsDir())
 
-	// The bead already exists (should be closed from previous polecat lifecycle)
-	// Reopen it and update its fields
+	// Try to reopen - if bead doesn't exist, this will fail and we return createErr
 	if _, reopenErr := b.run("reopen", id, "--reason=re-spawning agent"); reopenErr != nil {
 		// If reopen fails, the bead might already be open - continue with update
+		// Otherwise return the original create error (more informative than reopen error)
 		if !strings.Contains(reopenErr.Error(), "already open") {
-			return nil, fmt.Errorf("reopening existing agent bead: %w (original error: %v)", reopenErr, err)
+			return nil, createErr
 		}
 	}
 


### PR DESCRIPTION
## Problem

When slinging work to a rig (e.g., `gt sling gt-wtc6c gastown`), the polecat's hook appears empty even though the sling command reports success. The bead gets updated with assignee but the polecat can't find its hooked work.

**Root cause:** `CreateOrReopenAgentBead` checks for `"UNIQUE constraint failed"` (SQLite format) to detect existing beads and trigger the reopen path. However, Dolt returns `"Error 1062 (HY000): duplicate primary key"` (MySQL format), causing the reopen path to be skipped entirely.

## Background

The original UNIQUE check was introduced for GH #332 to handle re-spawning polecats with the same name. When a polecat is re-spawned (e.g., after a crash or restart), `CreateOrReopenAgentBead` needs to:
1. Try to create a new agent bead
2. If the bead already exists (duplicate key), reopen it instead
3. Update the bead with the new hook assignment

The SQLite-specific error check worked in development but fails in production with Dolt.

## Solution

Instead of parsing error messages (fragile, violates ZFC principles), simply try reopen after any create failure:

1. Attempt to create the agent bead
2. If create fails for any reason, attempt to reopen the existing bead
3. If reopen also fails (and it's not "already open"), return the original create error

This approach is more robust because:
- Works with both SQLite and Dolt backends
- Handles any duplicate key error format
- Returns the original (more informative) create error if both operations fail
- The "already open" check handles the edge case where the bead exists and is already open

## Edge Cases Analyzed

| Scenario | Create | Reopen | Result |
|----------|--------|--------|--------|
| New bead | Success | - | Works |
| Existing closed bead | Duplicate key | Success | Works |
| Existing open bead | Duplicate key | "already open" | Works (continues to update) |
| Invalid bead ID | Fails | Fails | Returns create error |
| DB connection error | Fails | Fails | Returns create error |

## Test plan
- [x] Build passes
- [x] Unit tests pass
- [ ] Manual test: sling to rig with existing agent bead, verify hook_bead is set

---
🤖 [Tackled](https://github.com/aleiby/claude-skills/tree/main/tackle) with [Claude Code](https://claude.com/claude-code)