### PR TITLE
refactor: consolidate duplicate atomic write and slice utilities

### DIFF
--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/util"
 	"github.com/google/uuid"
 )
 
@@ -96,6 +97,7 @@ func Load() (*State, error) {
 }
 
 // Save writes the state to disk atomically.
+// Uses util.EnsureDirAndWriteJSONWithPerm with 0600 permissions for security.
 func Save(s *State) error {
 	dir := StateDir()
 	if err := os.MkdirAll(dir, 0755); err != nil {
@@ -104,17 +106,7 @@ func Save(s *State) error {
 
 	s.UpdatedAt = time.Now()
 
-	data, err := json.MarshalIndent(s, "", "  ")
-	if err != nil {
-		return err
-	}
-
-	// Atomic write via temp file
-	tmp := StatePath() + ".tmp"
-	if err := os.WriteFile(tmp, data, 0600); err != nil {
-		return err
-	}
-	return os.Rename(tmp, StatePath())
+	return util.AtomicWriteJSONWithPerm(StatePath(), s, 0600)
 }
 
 // Enable enables Gas Town globally.

--- a/internal/util/atomic.go
+++ b/internal/util/atomic.go
@@ -4,6 +4,7 @@ package util
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 )
 
 // AtomicWriteJSON writes JSON data to a file atomically.
@@ -16,6 +17,38 @@ func AtomicWriteJSON(path string, v interface{}) error {
 		return err
 	}
 	return AtomicWriteFile(path, data, 0644)
+}
+
+// AtomicWriteJSONWithPerm writes JSON data to a file atomically with custom permissions.
+// It first writes to a temporary file, then renames it to the target path.
+// This prevents data corruption if the process crashes during write.
+// The rename operation is atomic on POSIX systems.
+func AtomicWriteJSONWithPerm(path string, v interface{}, perm os.FileMode) error {
+	data, err := json.MarshalIndent(v, "", "  ")
+	if err != nil {
+		return err
+	}
+	return AtomicWriteFile(path, data, perm)
+}
+
+// EnsureDirAndWriteJSON creates parent directories if needed, then atomically writes JSON.
+// This is a convenience function for the common pattern of:
+//
+//	os.MkdirAll(filepath.Dir(path), 0755)
+//	util.AtomicWriteJSON(path, data)
+func EnsureDirAndWriteJSON(path string, v interface{}) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return AtomicWriteJSON(path, v)
+}
+
+// EnsureDirAndWriteJSONWithPerm creates directories and writes JSON with custom permissions.
+func EnsureDirAndWriteJSONWithPerm(path string, v interface{}, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	return AtomicWriteJSONWithPerm(path, v, perm)
 }
 
 // AtomicWriteFile writes data to a file atomically.

--- a/internal/util/slice.go
+++ b/internal/util/slice.go
@@ -1,0 +1,24 @@
+// Package util provides common utilities for Gas Town.
+package util
+
+// RemoveFromSlice removes all occurrences of an item from a string slice.
+// Returns a new slice without modifying the original.
+func RemoveFromSlice(slice []string, item string) []string {
+	result := make([]string, 0, len(slice))
+	for _, s := range slice {
+		if s != item {
+			result = append(result, s)
+		}
+	}
+	return result
+}
+
+// ContainsString checks if a string slice contains the given item.
+func ContainsString(slice []string, item string) bool {
+	for _, s := range slice {
+		if s == item {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/util/slice_test.go
+++ b/internal/util/slice_test.go
@@ -1,0 +1,128 @@
+package util
+
+import (
+	"testing"
+)
+
+func TestRemoveFromSlice(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    []string
+		item     string
+		expected []string
+	}{
+		{
+			name:     "remove single occurrence",
+			slice:    []string{"a", "b", "c"},
+			item:     "b",
+			expected: []string{"a", "c"},
+		},
+		{
+			name:     "remove multiple occurrences",
+			slice:    []string{"a", "b", "b", "c"},
+			item:     "b",
+			expected: []string{"a", "c"},
+		},
+		{
+			name:     "remove first element",
+			slice:    []string{"a", "b", "c"},
+			item:     "a",
+			expected: []string{"b", "c"},
+		},
+		{
+			name:     "remove last element",
+			slice:    []string{"a", "b", "c"},
+			item:     "c",
+			expected: []string{"a", "b"},
+		},
+		{
+			name:     "item not found",
+			slice:    []string{"a", "b", "c"},
+			item:     "d",
+			expected: []string{"a", "b", "c"},
+		},
+		{
+			name:     "empty slice",
+			slice:    []string{},
+			item:     "a",
+			expected: []string{},
+		},
+		{
+			name:     "nil slice",
+			slice:    nil,
+			item:     "a",
+			expected: []string{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := RemoveFromSlice(tt.slice, tt.item)
+			if len(result) != len(tt.expected) {
+				t.Errorf("RemoveFromSlice() = %v, want %v", result, tt.expected)
+				return
+			}
+			for i, v := range result {
+				if v != tt.expected[i] {
+					t.Errorf("RemoveFromSlice() = %v, want %v", result, tt.expected)
+					return
+				}
+			}
+		})
+	}
+}
+
+func TestContainsString(t *testing.T) {
+	tests := []struct {
+		name     string
+		slice    []string
+		item     string
+		expected bool
+	}{
+		{
+			name:     "contains item",
+			slice:    []string{"a", "b", "c"},
+			item:     "b",
+			expected: true,
+		},
+		{
+			name:     "does not contain item",
+			slice:    []string{"a", "b", "c"},
+			item:     "d",
+			expected: false,
+		},
+		{
+			name:     "empty slice",
+			slice:    []string{},
+			item:     "a",
+			expected: false,
+		},
+		{
+			name:     "nil slice",
+			slice:    nil,
+			item:     "a",
+			expected: false,
+		},
+		{
+			name:     "first element",
+			slice:    []string{"a", "b", "c"},
+			item:     "a",
+			expected: true,
+		},
+		{
+			name:     "last element",
+			slice:    []string{"a", "b", "c"},
+			item:     "c",
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := ContainsString(tt.slice, tt.item)
+			if result != tt.expected {
+				t.Errorf("ContainsString() = %v, want %v", result, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add `RemoveFromSlice` and `ContainsString` to `internal/util/slice.go`
- Add `EnsureDirAndWriteJSON`, `AtomicWriteJSONWithPerm` to `internal/util/atomic.go`
- Refactor `internal/wisp/io.go`, `internal/wisp/config.go`, `internal/state/state.go` to use shared utilities
- Add comprehensive tests for new slice utilities

## Test plan
- [x] All existing tests pass (`go test ./internal/util/... ./internal/wisp/... ./internal/state/...`)
- [x] New slice utility tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)