### PR TITLE
Fix missing deacon nudge in DefaultBase SessionStart hook

### DIFF
--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -523,7 +523,7 @@ func DefaultBase() *HooksConfig {
 				Hooks: []Hook{
 					{
 						Type:    "command",
-						Command: fmt.Sprintf("%s && gt prime --hook", pathSetup),
+						Command: fmt.Sprintf("%s && gt prime --hook && gt nudge deacon session-started", pathSetup),
 					},
 				},
 			},


### PR DESCRIPTION
## Summary

- `DefaultBase()` in `internal/hooks/config.go` lacked `gt nudge deacon session-started` in the SessionStart command
- During `gt doctor --fix`, the `hooks-sync` check runs after `claude-settings` and overwrites the template-generated settings.json with content computed from `DefaultBase()`, causing the "missing deacon nudge" error to persist
- Add the deacon nudge to `DefaultBase()` so all settings.json files include it

## Test plan

- [ ] Run `gt doctor --fix` on a town with stale settings — verify deacon nudge errors resolve
- [ ] Run `gt doctor` again — verify no "missing deacon nudge" errors return
- [ ] Verify `go test ./internal/hooks/ ./internal/doctor/` pass