### PR TITLE
docs: Document formula invocation patterns to prevent convoy type errors

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -663,6 +663,47 @@ Patrol molecules bond plugins dynamically:
 bd mol bond mol-security-scan $PATROL_ID --var scope="$SCOPE"
 ```
 
+## Formula Invocation Patterns
+
+**CRITICAL**: Different formula types require different invocation methods.
+
+### Workflow Formulas (sequential steps, single polecat)
+
+Examples: `shiny`, `shiny-enterprise`, `mol-polecat-work`
+
+```bash
+gt sling <formula> --on <bead-id> <target>
+gt sling shiny-enterprise --on gt-abc123 gastown
+```
+
+### Convoy Formulas (parallel legs, multiple polecats)
+
+Examples: `code-review`
+
+**DO NOT use `gt sling` for convoy formulas!** It fails with "convoy type not supported".
+
+```bash
+# Correct invocation - use gt formula run:
+gt formula run code-review --pr=123
+gt formula run code-review --files="src/*.go"
+
+# Dry run to preview:
+gt formula run code-review --pr=123 --dry-run
+```
+
+### Identifying Formula Type
+
+```bash
+gt formula show <name>   # Shows "Type: convoy" or "Type: workflow"
+bd formula list          # Lists formulas by type
+```
+
+### Why This Matters
+
+- `gt sling` attempts to cook+pour the formula, which fails for convoy type
+- `gt formula run` handles convoy dispatch directly, spawning parallel polecats
+- Convoy formulas create multiple polecats (one per leg) + synthesis step
+
 ## Common Issues
 
 | Problem | Solution |


### PR DESCRIPTION
## Summary

Agents and users hit a confusing error when trying to `gt sling` a convoy-type formula: `"convoy type not supported"`. The root cause is that workflow and convoy formulas require different invocation methods, but this isn't documented anywhere in the reference docs.

This adds a "Formula Invocation Patterns" section to `docs/reference.md` that:
- Explains the critical difference between workflow (`gt sling`) and convoy (`gt formula run`) invocation
- Shows correct syntax for each type with examples
- Documents how to identify a formula's type
- Explains *why* `gt sling` fails for convoy formulas (it attempts cook+pour, which doesn't apply)

## Related Issue

No existing issue - discovered through repeated agent confusion in production use.

## Changes

- Add "Formula Invocation Patterns" section to `docs/reference.md` covering:
  - Workflow formula invocation via `gt sling`
  - Convoy formula invocation via `gt formula run`
  - How to identify formula type
  - Why the distinction matters

## Testing

- [x] Documentation only - no code changes
- [x] Verified section integrates correctly into existing reference.md structure

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)