### PR TITLE
fix(skill): Update handoff skill to always collect state

### DIFF
--- a/.claude/skills/handoff/SKILL.md
+++ b/.claude/skills/handoff/SKILL.md
@@ -27,15 +27,16 @@ Hand off your current session to a fresh Claude instance while preserving work c
 
 ## How It Works
 
-1. If you provide a message, it's sent as handoff mail to yourself
-2. `gt handoff` respawns your session with a fresh Claude
-3. New session auto-primes via SessionStart hook
-4. Work continues from your hook (pinned molecule persists)
+1. State is collected (your message, or auto-collected inbox/beads/hook status)
+2. Handoff mail is sent to yourself with context
+3. `gt handoff` respawns your session with a fresh Claude
+4. New session auto-primes via SessionStart hook
+5. Work continues from your hook (pinned molecule persists)
 
 ## Examples
 
 ```bash
-# Simple handoff (molecule persists, fresh context)
+# Simple handoff - auto-collects state (inbox, ready beads, hooked work)
 /handoff
 
 # Handoff with context notes
@@ -58,14 +59,14 @@ Hand off your current session to a fresh Claude instance while preserving work c
 
 When invoked, execute:
 
-1. If user provided a message, send handoff mail:
+1. If user provided a message:
    ```bash
-   gt mail send <your-address> -s "HANDOFF: Session cycling" -m "<message>"
+   gt handoff -m "<message>"
    ```
 
-2. Run the handoff command:
+2. If NO message provided, use `-c` to auto-collect state:
    ```bash
-   gt handoff
+   gt handoff -c
    ```
 
-The new session will find your handoff mail and hooked work automatically.
+**IMPORTANT**: Never run bare `gt handoff` - it sends no mail and the next session loses context. Always use `-c` or `-m`.


### PR DESCRIPTION
## Summary

The `/handoff` skill currently tells agents to run bare `gt handoff` when no message is provided. This silently drops all session context — the next session starts with no handoff mail and has to reconstruct state from scratch.

The `gt handoff -c` (collect) flag already exists in the Go code and gathers hooked work, inbox, and ready beads into a handoff mail automatically. But the skill file doesn't use it, so agents using `/handoff` without a message lose context on every session cycle.

This updates the handoff skill to:
- Use `gt handoff -c` when no message is provided (auto-collects state)
- Use `gt handoff -m "<message>"` when a message is given
- Add a warning that bare `gt handoff` should never be used
- Update the "How It Works" section to reflect the state collection step

## Related Issue

No existing issue — discovered through repeated context loss during agent session cycling in production.

## Changes

- Update `.claude/skills/handoff/SKILL.md`:
  - `/handoff` (no args) → `gt handoff -c` instead of bare `gt handoff`
  - `/handoff "message"` → `gt handoff -m "message"` instead of separate mail + handoff
  - Add warning against bare `gt handoff`
  - Update documentation to describe state collection flow

## Testing

- [x] Skill file change only — no Go code changes
- [x] Verified `gt handoff -c` flag exists in upstream `internal/cmd/handoff.go`
- [x] Manual testing confirmed `-c` collects inbox, hooked work, and ready beads

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)