### PR TITLE
Fix doctor env-vars false positive for boot session

### DIFF
--- a/internal/doctor/env_check.go
+++ b/internal/doctor/env_check.go
@@ -97,9 +97,17 @@ func (c *EnvVarsCheck) Run(ctx *CheckContext) *CheckResult {
 			continue
 		}
 
+		// Determine role for AgentEnv lookup.
+		// Boot watchdog is parsed as deacon with name "boot", but AgentEnv
+		// uses "boot" as a distinct role for env var generation.
+		role := string(identity.Role)
+		if identity.Role == session.RoleDeacon && identity.Name == "boot" {
+			role = "boot"
+		}
+
 		// Get expected env vars based on role
 		expected := config.AgentEnv(config.AgentEnvConfig{
-			Role:      string(identity.Role),
+			Role:      role,
 			Rig:       identity.Rig,
 			AgentName: identity.Name,
 			TownRoot:  ctx.TownRoot,

--- a/internal/doctor/env_check_test.go
+++ b/internal/doctor/env_check_test.go
@@ -341,6 +341,24 @@ func TestEnvVarsCheck_HyphenatedRig(t *testing.T) {
 	}
 }
 
+func TestEnvVarsCheck_BootCorrect(t *testing.T) {
+	// Boot watchdog session (gt-boot) uses "boot" role in AgentEnv,
+	// even though ParseSessionName returns Role=deacon, Name="boot".
+	expected := expectedEnv("boot", "", "boot")
+	reader := &mockEnvReader{
+		sessions: []string{"gt-boot"},
+		sessionEnvs: map[string]map[string]string{
+			"gt-boot": expected,
+		},
+	}
+	check := NewEnvVarsCheckWithReader(reader)
+	result := check.Run(testCtx())
+
+	if result.Status != StatusOK {
+		t.Errorf("Status = %v, want StatusOK", result.Status)
+	}
+}
+
 func TestEnvVarsCheck_BeadsDirWarning(t *testing.T) {
 	// BEADS_DIR being set breaks prefix-based routing
 	expected := expectedEnv("witness", "myrig", "")


### PR DESCRIPTION
## Summary
- `gt doctor` env-vars check reports 3 mismatches on `gt-boot` session that persist through restarts
- Root cause: `ParseSessionName("gt-boot")` returns `Role: "deacon"`, but `boot.go` spawns with `AgentEnv(Role: "boot")` which generates different env vars (`deacon/boot` vs `deacon`)
- Added special-case detection in `env_check.go` to use `Role: "boot"` for the boot identity

## Test plan
- [x] Added `TestEnvVarsCheck_BootCorrect` test case
- [x] All 22 env-vars tests pass
- [x] Rebuilt `gt` binary — `gt doctor` now shows 66 passed, 0 warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)