### PR TITLE
fix: preserve --agent override across handoff

### DIFF
--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -414,7 +414,15 @@ func buildRestartCommand(sessionName string) (string, error) {
 	//
 	// Check if current session is using a non-default agent (GT_AGENT env var).
 	// If so, preserve it across handoff by using the override variant.
+	// Fall back to tmux session environment if process env doesn't have it,
+	// since exec env vars may not propagate through all agent runtimes.
 	currentAgent := os.Getenv("GT_AGENT")
+	if currentAgent == "" {
+		t := tmux.NewTmux()
+		if val, err := t.GetEnvironment(sessionName, "GT_AGENT"); err == nil && val != "" {
+			currentAgent = val
+		}
+	}
 	var runtimeCmd string
 	if currentAgent != "" {
 		var err error

--- a/internal/crew/manager.go
+++ b/internal/crew/manager.go
@@ -531,6 +531,13 @@ func (m *Manager) Start(name string, opts StartOptions) error {
 		_ = t.SetEnvironment(sessionID, k, v)
 	}
 
+	// Persist agent override in tmux session env so handoff can read it back.
+	// The startup command sets GT_AGENT via exec env, but that only lives in the
+	// process tree. The tmux session env survives respawn-pane and is queryable.
+	if opts.AgentOverride != "" {
+		_ = t.SetEnvironment(sessionID, "GT_AGENT", opts.AgentOverride)
+	}
+
 	// Apply rig-based theming (non-fatal: theming failure doesn't affect operation)
 	theme := tmux.AssignTheme(m.rig.Name)
 	_ = t.ConfigureGasTownSession(sessionID, theme, m.rig.Name, name, "crew")


### PR DESCRIPTION
## Summary
- When a crew session is started with `--agent codex` (or any override), `gt handoff` was losing the agent override and restarting with the default agent
- Root cause: `GT_AGENT` was set via `exec env` in the process tree but not persisted in the tmux session environment, so `buildRestartCommand` couldn't read it back via `os.Getenv()`
- Fix: crew manager now sets `GT_AGENT` in tmux session env on startup, and `buildRestartCommand` falls back to reading from tmux session env when process env is empty

## Test plan
- [x] `go vet ./...` clean
- [x] `go test ./...` all passing
- [x] `golangci-lint` — only pre-existing errcheck warnings (same 6 as upstream main)
- [x] `gt handoff -n` dry-run confirms correct behavior
- [x] Manual: `gt start crew octane --agent codex` → `GT_AGENT=codex` in tmux session env → `gt handoff -n` restarts with `exec codex --yolo` + `GT_AGENT=codex` in exports. Fallback also verified: unsetting GT_AGENT from both process and tmux env correctly falls back to default `claude`.