### PR TITLE
fix(config): Respect --agent override when town root not found

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1453,7 +1453,18 @@ func BuildStartupCommandWithAgentOverride(envVars map[string]string, rigPath, pr
 		var err error
 		townRoot, err = findTownRootFromCwd()
 		if err != nil {
-			rc = DefaultRuntimeConfig()
+			// Can't find town root from cwd - but if agentOverride is specified,
+			// try to use the preset directly. This allows `gt deacon start --agent codex`
+			// to work even when run from outside the town directory.
+			if agentOverride != "" {
+				if preset := GetAgentPresetByName(agentOverride); preset != nil {
+					rc = RuntimeConfigFromPreset(AgentPreset(agentOverride))
+				} else {
+					return "", fmt.Errorf("agent '%s' not found", agentOverride)
+				}
+			} else {
+				rc = DefaultRuntimeConfig()
+			}
 		} else {
 			if agentOverride != "" {
 				var resolveErr error


### PR DESCRIPTION
## Summary

Fixes a bug where `gt deacon start --agent codex` (and similar commands for mayor/town-level roles) would ignore the `--agent` flag and always use Claude when the current working directory is outside the Gas Town workspace.

## Problem

When `BuildStartupCommandWithAgentOverride` is called with `rigPath=""` (as done by deacon/mayor), it tries to find `townRoot` via `findTownRootFromCwd()`. If this fails (e.g., user runs the command from outside the town directory), the code fell back to `DefaultRuntimeConfig()` (Claude) and completely ignored the `agentOverride` parameter.

This caused:
- Deacon sessions to run Claude instead of Codex even when `--agent codex` was specified
- Wasted Anthropic API credits when users intended to use OpenAI/Codex

## Solution

When `findTownRootFromCwd()` fails but `agentOverride` is specified, look up the agent preset directly via `GetAgentPresetByName()` and use it instead of falling back to Claude.

## Changes

- `internal/config/loader.go`: Modified error handling in `BuildStartupCommandWithAgentOverride` to check `agentOverride` before falling back to default
- `internal/config/loader_test.go`: Added regression test `TestBuildStartupCommandWithAgentOverride_UsesOverrideWhenNoTownRoot`

## Test Plan

- [x] Added unit test that verifies `--agent codex` works even when CWD is not in a Gas Town workspace
- [x] All existing tests pass (`go test ./internal/config/...`)
- [x] Manual verification: `gt deacon start --agent codex` now correctly launches Codex

## Related

This bug was discovered during a credit burn investigation where 7 rogue Claude processes were found running instead of Codex.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)