### PR TITLE
fix: remove .beads/ from gitignore required patterns (regression from #966)

### DIFF
--- a/internal/rig/overlay.go
+++ b/internal/rig/overlay.go
@@ -61,12 +61,16 @@ func CopyOverlay(rigPath, destPath string) error {
 func EnsureGitignorePatterns(worktreePath string) error {
 	gitignorePath := filepath.Join(worktreePath, ".gitignore")
 
-	// Required patterns for Gas Town worktrees
+	// Required patterns for Gas Town worktrees.
+	// DO NOT add ".beads/" here. Beads manages its own .beads/.gitignore
+	// (created by bd init) which selectively ignores runtime files while
+	// tracking issues.jsonl. Adding .beads/ here overrides that and breaks
+	// bd sync. This has regressed twice (PR #753 added it, #891 removed it,
+	// #966 re-added it). See overlay_test.go for a regression guard.
 	requiredPatterns := []string{
 		".runtime/",
 		".claude/",
 		".logs/",
-		".beads/",
 	}
 
 	// Read existing gitignore content

--- a/internal/rig/overlay_test.go
+++ b/internal/rig/overlay_test.go
@@ -263,8 +263,8 @@ func TestEnsureGitignorePatterns_CreatesNewFile(t *testing.T) {
 		t.Fatalf("Failed to read .gitignore: %v", err)
 	}
 
-	// Check all required patterns are present
-	patterns := []string{".runtime/", ".claude/", ".beads/", ".logs/"}
+	// Check all required patterns are present (.beads/ intentionally excluded — see overlay.go)
+	patterns := []string{".runtime/", ".claude/", ".logs/"}
 	for _, pattern := range patterns {
 		if !containsLine(string(content), pattern) {
 			t.Errorf(".gitignore missing pattern %q", pattern)
@@ -301,8 +301,8 @@ func TestEnsureGitignorePatterns_AppendsToExisting(t *testing.T) {
 		t.Error("Missing Gas Town header comment")
 	}
 
-	// Should add required patterns
-	patterns := []string{".runtime/", ".claude/", ".beads/", ".logs/"}
+	// Should add required patterns (.beads/ intentionally excluded — see overlay.go)
+	patterns := []string{".runtime/", ".claude/", ".logs/"}
 	for _, pattern := range patterns {
 		if !containsLine(string(content), pattern) {
 			t.Errorf(".gitignore missing pattern %q", pattern)
@@ -336,11 +336,16 @@ func TestEnsureGitignorePatterns_SkipsExistingPatterns(t *testing.T) {
 	}
 
 	// Should add missing patterns
-	if !containsLine(string(content), ".beads/") {
-		t.Error(".gitignore missing pattern .beads/")
-	}
 	if !containsLine(string(content), ".logs/") {
 		t.Error(".gitignore missing pattern .logs/")
+	}
+
+	// Regression guard: .beads/ must NOT be in required patterns.
+	// Beads manages its own .beads/.gitignore via bd init.
+	// Adding .beads/ here breaks bd sync. This has regressed twice
+	// (PR #753, #966). If this test fails, you're about to break polecats.
+	if containsLine(string(content), ".beads/") {
+		t.Error(".gitignore must NOT contain .beads/ - beads manages its own .gitignore (see overlay.go comment)")
 	}
 }
 


### PR DESCRIPTION
## Summary

- PR #891 correctly removed `.beads/` from `EnsureGitignorePatterns` required patterns
- PR #966 accidentally re-added it two days later — **this is the second regression**
- Beads manages its own `.beads/.gitignore` via `bd init`, which selectively ignores runtime files while tracking `issues.jsonl`
- Adding `.beads/` to the top-level gitignore breaks `bd sync` — polecat work silently vanishes

## Changes

- Remove `.beads/` from `requiredPatterns` in `overlay.go`
- Add detailed comment explaining why it must not be re-added (with PR history)
- Add **regression guard test** that explicitly fails if `.beads/` is re-added
- Update existing tests to not expect `.beads/` in required patterns

## Request to maintainers

This has regressed twice now (#753 added it, #891 removed it, #966 re-added it). Please consider adding a CI grep guard or similar protection to prevent a third regression.

## Test plan

- [x] All `TestEnsureGitignore*` tests pass
- [x] New regression guard test verifies `.beads/` is NOT in required patterns
- [ ] Verify new polecat worktrees do not gitignore `.beads/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)