### PR TITLE
fix(config): inject --settings flag for roles with mismatched session directories

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1054,6 +1054,62 @@ func lookupAgentConfigIfExists(name string, townSettings *TownSettings, rigSetti
 // townRoot is the path to the town directory (e.g., ~/gt).
 // rigPath is the path to the rig directory (e.g., ~/gt/gastown), or empty for town-level roles.
 func ResolveRoleAgentConfig(role, townRoot, rigPath string) *RuntimeConfig {
+	rc := resolveRoleAgentConfigCore(role, townRoot, rigPath)
+	return withRoleSettingsFlag(rc, role, rigPath)
+}
+
+// withRoleSettingsFlag appends --settings to the Args for Claude agents whose
+// settings directory differs from the session working directory. Claude Code
+// resolves project-level settings from its working directory only; the --settings
+// flag tells it where to find them when they live in a parent directory.
+func withRoleSettingsFlag(rc *RuntimeConfig, role, rigPath string) *RuntimeConfig {
+	if rc == nil || rigPath == "" {
+		return rc
+	}
+
+	provider := rc.Provider
+	if provider == "" {
+		provider = "claude"
+	}
+	if provider != "claude" {
+		return rc
+	}
+
+	settingsDir := roleSettingsDir(role, rigPath)
+	if settingsDir == "" {
+		return rc
+	}
+
+	hooksDir := ".claude"
+	settingsFile := "settings.json"
+	if rc.Hooks != nil {
+		if rc.Hooks.Dir != "" {
+			hooksDir = rc.Hooks.Dir
+		}
+		if rc.Hooks.SettingsFile != "" {
+			settingsFile = rc.Hooks.SettingsFile
+		}
+	}
+
+	rc.Args = append(rc.Args, "--settings", filepath.Join(settingsDir, hooksDir, settingsFile))
+	return rc
+}
+
+// roleSettingsDir returns the shared settings directory for roles whose session
+// working directory differs from their settings location. Returns empty for
+// roles where settings and session directory are the same (mayor, deacon).
+func roleSettingsDir(role, rigPath string) string {
+	switch role {
+	case "crew", "witness", "refinery":
+		return filepath.Join(rigPath, role)
+	case "polecat":
+		return filepath.Join(rigPath, "polecats")
+	default:
+		return ""
+	}
+}
+
+func resolveRoleAgentConfigCore(role, townRoot, rigPath string) *RuntimeConfig {
 	// Load rig settings (may be nil for town-level roles like mayor/deacon)
 	var rigSettings *RigSettings
 	if rigPath != "" {


### PR DESCRIPTION
## Issue

Claude Code resolves project-level settings (`settings.json`) from its working directory. Roles like crew, witness, refinery, and polecat run in subdirectories (e.g., `polecats/<name>/`, `gastown/crew/`) that differ from where their settings are located. This means these roles fail to pick up the correct project settings.

## Fix

Add `withRoleSettingsFlag()` to `ResolveRoleAgentConfig()` in `internal/config/loader.go`. For roles whose session working directory differs from their settings location, it appends `--settings <path>` to the Claude args, pointing at the correct `settings.json`.

This approach is chosen so that we don't update the `.claude/settings.json` file in a project that may already have `.claude/` checked in. In such projects, even with sparse-checkout it avoids any problems. Also avoids the need to rely on using `*.local.json` files.

This could be potential allow the ability to actually keep the original `.claude/` directory that may already be checked into projects.

Role-to-settings mapping:
- `crew`, `witness`, `refinery` → `<rigPath>/<role>/.claude/settings.json`
- `polecat` → `<rigPath>/polecats/.claude/settings.json`
- `mayor`, `deacon` → no flag needed (settings and session dir are the same)

## Test plan

- [x] Build compiles clean
- [x] Verified role settings resolution logic matches directory structure

🤖 Generated with [Claude Code](https://claude.com/claude-code)