### PR TITLE
fix(hooks): add PreToolUse guards to match EnsureSettingsAt templates

### DIFF
--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -468,6 +468,29 @@ func DefaultBase() *HooksConfig {
 	pathSetup := `export PATH="$HOME/go/bin:$HOME/.local/bin:$PATH"`
 
 	return &HooksConfig{
+		PreToolUse: []HookEntry{
+			{
+				Matcher: "Bash(gh pr create*)",
+				Hooks: []Hook{{
+					Type:    "command",
+					Command: fmt.Sprintf("%s && gt tap guard pr-workflow", pathSetup),
+				}},
+			},
+			{
+				Matcher: "Bash(git checkout -b*)",
+				Hooks: []Hook{{
+					Type:    "command",
+					Command: fmt.Sprintf("%s && gt tap guard pr-workflow", pathSetup),
+				}},
+			},
+			{
+				Matcher: "Bash(git switch -c*)",
+				Hooks: []Hook{{
+					Type:    "command",
+					Command: fmt.Sprintf("%s && gt tap guard pr-workflow", pathSetup),
+				}},
+			},
+		},
 		SessionStart: []HookEntry{
 			{
 				Matcher: "",


### PR DESCRIPTION
## Issue

The settings templates written by `EnsureSettingsAt` (`internal/claude/config/settings-autonomous.json` and `settings-interactive.json`) include `PreToolUse` hooks that guard PR workflow commands (`gh pr create`, `git checkout -b`, `git switch -c`) through `gt tap guard pr-workflow`.

However, the default hooks config generated by `DefaultBase()` in `internal/hooks/config.go` was missing these `PreToolUse` entries. This means agents that rely on the programmatic hooks config rather than the JSON templates would not have the PR workflow guards enforced.

## Fix

Add the matching `PreToolUse` hook entries to `DefaultBase()` in `internal/hooks/config.go`, guarding the same three commands with the same `gt tap guard pr-workflow` call that the JSON templates already specify.

## Test plan

- [x] Build compiles clean
- [x] Verified `PreToolUse` entries match the templates in `internal/claude/config/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)