### PR TITLE
fix: add bounds checks for string indexing panic points (issue #1228)

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -387,7 +387,7 @@ func parseMailInboxText(output string) []MailMessage {
 			rest := strings.TrimSpace(trimmed[2:])
 			if strings.HasPrefix(rest, "●") {
 				current.Read = false
-				current.Subject = strings.TrimSpace(rest[len("●"):])
+				current.Subject = strings.TrimSpace(strings.TrimPrefix(rest, "●"))
 			} else {
 				current.Read = true
 				current.Subject = rest
@@ -777,14 +777,23 @@ func (h *APIHandler) handleIssueShow(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Run bd show to get issue details
-	output, err := h.runBdCommand(r.Context(), 10*time.Second, []string{"show", issueID})
+	// Try structured JSON output first (preferred — no text parsing needed)
+	output, err := h.runBdCommand(r.Context(), 10*time.Second, []string{"show", issueID, "--json"})
+	if err == nil {
+		if resp, ok := parseIssueShowJSON(output, issueID); ok {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(resp)
+			return
+		}
+	}
+
+	// Fall back to text parsing
+	output, err = h.runBdCommand(r.Context(), 10*time.Second, []string{"show", issueID})
 	if err != nil {
 		h.sendError(w, "Failed to fetch issue: "+err.Error(), http.StatusInternalServerError)
 		return
 	}
 
-	// Parse the output
 	resp := parseIssueShowOutput(output, issueID)
 
 	w.Header().Set("Content-Type", "application/json")
@@ -913,7 +922,48 @@ func (h *APIHandler) runBdCommand(ctx context.Context, timeout time.Duration, ar
 	return output, nil
 }
 
-// parseIssueShowOutput parses the output from "bd show <id>".
+// parseIssueShowJSON parses the JSON output from "bd show <id> --json".
+// Returns (response, true) on success, or (zero, false) if parsing fails.
+func parseIssueShowJSON(output string, issueID string) (IssueShowResponse, bool) {
+	var items []struct {
+		ID          string   `json:"id"`
+		Title       string   `json:"title"`
+		Description string   `json:"description"`
+		Status      string   `json:"status"`
+		Priority    int      `json:"priority"`
+		Type        string   `json:"issue_type"`
+		CreatedAt   string   `json:"created_at"`
+		UpdatedAt   string   `json:"updated_at"`
+		DependsOn   []string `json:"depends_on,omitempty"`
+		Blocks      []string `json:"blocks,omitempty"`
+	}
+	if err := json.Unmarshal([]byte(output), &items); err != nil || len(items) == 0 {
+		return IssueShowResponse{}, false
+	}
+	item := items[0]
+
+	priority := ""
+	if item.Priority > 0 {
+		priority = fmt.Sprintf("P%d", item.Priority)
+	}
+
+	return IssueShowResponse{
+		ID:          item.ID,
+		Title:       item.Title,
+		Type:        item.Type,
+		Status:      item.Status,
+		Priority:    priority,
+		Description: item.Description,
+		Created:     item.CreatedAt,
+		Updated:     item.UpdatedAt,
+		DependsOn:   item.DependsOn,
+		Blocks:      item.Blocks,
+		RawOutput:   output,
+	}, true
+}
+
+// parseIssueShowOutput parses the text output from "bd show <id>".
+// This is the fallback path when --json is unavailable.
 func parseIssueShowOutput(output string, issueID string) IssueShowResponse {
 	resp := IssueShowResponse{
 		ID:        issueID,
@@ -950,14 +1000,13 @@ func parseIssueShowOutput(output string, issueID string) IssueShowResponse {
 
 				// Now parse the title from before the bracket
 				// Format: "○ id · title"
-				// Find the second · which separates id from title
-				if firstDot := strings.Index(beforeBracket, "·"); firstDot > 0 {
-					afterFirstDot := beforeBracket[firstDot+len("·"):]
-					if secondDot := strings.Index(afterFirstDot, "·"); secondDot > 0 {
-						resp.Title = strings.TrimSpace(afterFirstDot[secondDot+len("·"):])
+				// Use strings.Cut for safe splitting on multi-byte "·" separator
+				if _, afterFirst, ok := strings.Cut(beforeBracket, "·"); ok {
+					if _, afterSecond, ok := strings.Cut(afterFirst, "·"); ok {
+						resp.Title = strings.TrimSpace(afterSecond)
 					} else {
 						// Only one dot - id is embedded in icon part
-						resp.Title = strings.TrimSpace(afterFirstDot)
+						resp.Title = strings.TrimSpace(afterFirst)
 					}
 				}
 			}
@@ -967,9 +1016,10 @@ func parseIssueShowOutput(output string, issueID string) IssueShowResponse {
 		if strings.HasPrefix(line, "Type:") {
 			resp.Type = strings.TrimSpace(strings.TrimPrefix(line, "Type:"))
 		} else if strings.HasPrefix(line, "Created:") {
+			// Split always returns >= 1 element; parts[0] is safe unconditionally
 			parts := strings.Split(line, "·")
 			resp.Created = strings.TrimSpace(strings.TrimPrefix(parts[0], "Created:"))
-			if len(parts) > 1 {
+			if len(parts) >= 2 {
 				resp.Updated = strings.TrimSpace(strings.TrimPrefix(parts[1], "Updated:"))
 			}
 		} else if line == "DESCRIPTION" {

--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -1331,6 +1331,7 @@ func (f *LiveConvoyFetcher) FetchSessions() ([]SessionRow, error) {
 			continue
 		}
 
+		// SplitN always returns >= 1 element; parts[0] is safe unconditionally
 		parts := strings.SplitN(line, ":", 2)
 		name := parts[0]
 


### PR DESCRIPTION
## Summary

Several text-parsing functions in the dashboard API and witness subsystem use manual byte-offset slicing on strings containing multi-byte Unicode characters ("$(●)", "$(·)"). If "$(bd)" output is ever truncated, malformed, or changes format, these "$(str[idx+N:])" expressions can panic at runtime.

This PR takes two approaches:

### 1. Eliminate the text parser where possible
"$(handleIssueShow)" was shelling out to "$(bd show <id>)" (text format) and feeding the output into a ~100-line text parser that splits on Unicode middle dots. But "$(bd show)" supports "$(--json)", which the rest of the codebase already uses. The handler now tries "$(bd show <id> --json)" first with a new "$(parseIssueShowJSON)" function that directly unmarshals into the response struct. The text parser is retained as a fallback.

### 2. Harden the remaining text parsers
For code paths where text parsing is unavoidable (mail inbox fallback, session list):
- "$(parseMailInboxText)" — "$(rest[len("●"):])" replaced with "$(strings.TrimPrefix)"
- "$(parseIssueShowOutput)" — chained "$(strings.Index)" + "$([idx+len("·"):])" replaced with "$(strings.Cut)"
- "$(UpdateCleanupWispState)" — manual "$(strings.Index("polecat:") + [idx+8:])" on JSON replaced with "$(json.Unmarshal)" via new "$(extractPolecatFromJSON)" helper

Removed two dead-code guards ("$(len(parts) >= 1)" after "$(Split)", "$(len(parts) == 0)" after "$(SplitN)") that could never trigger — replaced with comments explaining why direct access is safe.

## Changes
- **"$(internal/web/api.go)"**: Add "$(parseIssueShowJSON)" + JSON-first path in "$(handleIssueShow)"; harden text fallback with "$(TrimPrefix)" and "$(strings.Cut)"
- **"$(internal/web/fetcher.go)"**: Replace dead guard with explanatory comment
- **"$(internal/witness/handlers.go)"**: Replace string slicing on JSON with "$(json.Unmarshal)" via "$(extractPolecatFromJSON)"
- **Tests**: 17 new test cases (JSON parser, text parser edge cases, extractPolecatFromJSON)

## Test plan
- [x] "$(go build ./...)"
- [x] "$(go test -race -short ./internal/web/ ./internal/witness/)"
- [x] "$(go vet ./...)"
- [x] Verified clean merge with sibling PRs (#1269, #1270)

Fixes #1228

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>