### PR TITLE
fix(lint): remove unused param from parseIssueShowJSON

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -756,7 +756,7 @@ func (h *APIHandler) handleIssueShow(w http.ResponseWriter, r *http.Request) {
 	// Try structured JSON output first (preferred — no text parsing needed)
 	output, err := h.runBdCommand(r.Context(), 10*time.Second, []string{"show", issueID, "--json"})
 	if err == nil {
-		if resp, ok := parseIssueShowJSON(output, issueID); ok {
+		if resp, ok := parseIssueShowJSON(output); ok {
 			w.Header().Set("Content-Type", "application/json")
 			_ = json.NewEncoder(w).Encode(resp)
 			return
@@ -900,7 +900,7 @@ func (h *APIHandler) runBdCommand(ctx context.Context, timeout time.Duration, ar
 
 // parseIssueShowJSON parses the JSON output from "bd show <id> --json".
 // Returns (response, true) on success, or (zero, false) if parsing fails.
-func parseIssueShowJSON(output string, issueID string) (IssueShowResponse, bool) {
+func parseIssueShowJSON(output string) (IssueShowResponse, bool) {
 	var items []struct {
 		ID          string   `json:"id"`
 		Title       string   `json:"title"`

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -613,7 +613,7 @@ func TestParseIssueShowJSON_ValidOutput(t *testing.T) {
 		"depends_on": ["gt-dep1"],
 		"blocks": ["gt-blk1", "gt-blk2"]
 	}]`
-	resp, ok := parseIssueShowJSON(input, "gt-abc")
+	resp, ok := parseIssueShowJSON(input)
 	if !ok {
 		t.Fatal("parseIssueShowJSON returned ok=false for valid input")
 	}
@@ -645,7 +645,7 @@ func TestParseIssueShowJSON_ValidOutput(t *testing.T) {
 
 func TestParseIssueShowJSON_ZeroPriority(t *testing.T) {
 	input := `[{"id": "gt-abc", "title": "No priority", "priority": 0}]`
-	resp, ok := parseIssueShowJSON(input, "gt-abc")
+	resp, ok := parseIssueShowJSON(input)
 	if !ok {
 		t.Fatal("parseIssueShowJSON returned ok=false")
 	}
@@ -665,7 +665,7 @@ func TestParseIssueShowJSON_InvalidInputs(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			_, ok := parseIssueShowJSON(tt.input, "gt-abc")
+			_, ok := parseIssueShowJSON(tt.input)
 			if ok {
 				t.Errorf("parseIssueShowJSON(%q) returned ok=true, want false", tt.input)
 			}


### PR DESCRIPTION
## Summary
- Remove unused `issueID` parameter from `parseIssueShowJSON` in `internal/web/api.go`
- Fixes `unparam` lint failure on main

## Test plan
- [x] `go build ./cmd/gt` compiles
- CI lint job should pass