### PR TITLE
fix: remove deprecated --no-daemon flag from all bd command invocations

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -190,11 +190,9 @@ func (b *Beads) Init(prefix string) error {
 
 // run executes a bd command and returns stdout.
 func (b *Beads) run(args ...string) ([]byte, error) {
-	// Use --no-daemon for faster read operations (avoids daemon IPC overhead)
-	// The daemon is primarily useful for write coalescing, not reads.
 	// Use --allow-stale to prevent failures when db is out of sync with JSONL
 	// (e.g., after daemon is killed during shutdown before syncing).
-	fullArgs := append([]string{"--no-daemon", "--allow-stale"}, args...)
+	fullArgs := append([]string{"--allow-stale"}, args...)
 
 	// Always explicitly set BEADS_DIR to prevent inherited env vars from
 	// causing prefix mismatches. Use explicit beadsDir if set, otherwise
@@ -235,8 +233,8 @@ func (b *Beads) run(args ...string) ([]byte, error) {
 		return nil, b.wrapError(err, stderr.String(), args)
 	}
 
-	// Handle bd --no-daemon exit code 0 bug: when issue not found,
-	// --no-daemon exits 0 but writes error to stderr with empty stdout.
+	// Handle bd exit code 0 bug: when issue not found,
+	// bd may exit 0 but write error to stderr with empty stdout.
 	// Detect this case and treat as error to avoid JSON parse failures.
 	if stdout.Len() == 0 && stderr.Len() > 0 {
 		return nil, b.wrapError(fmt.Errorf("command produced no output"), stderr.String(), args)

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -154,7 +154,7 @@ func TestIntegration(t *testing.T) {
 	// consistent data and prevents flaky test failures.
 	// We use --allow-stale to handle cases where the daemon is actively writing and
 	// the staleness check would otherwise fail spuriously.
-	syncCmd := exec.Command("bd", "--no-daemon", "--allow-stale", "sync", "--import-only")
+	syncCmd := exec.Command("bd", "--allow-stale", "sync", "--import-only")
 	syncCmd.Dir = dir
 	if err := syncCmd.Run(); err != nil {
 		// If sync fails (e.g., no database exists), just log and continue

--- a/internal/cmd/beads_db_init_test.go
+++ b/internal/cmd/beads_db_init_test.go
@@ -79,7 +79,7 @@ func createTrackedBeadsRepoWithIssues(t *testing.T, path, prefix string, numIssu
 	}
 
 	// Run bd init
-	cmd := exec.Command("bd", "--no-daemon", "init", "--prefix", prefix)
+	cmd := exec.Command("bd", "init", "--prefix", prefix)
 	cmd.Dir = path
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("bd init failed: %v\nOutput: %s", err, output)
@@ -87,7 +87,7 @@ func createTrackedBeadsRepoWithIssues(t *testing.T, path, prefix string, numIssu
 
 	// Create issues
 	for i := 1; i <= numIssues; i++ {
-		cmd = exec.Command("bd", "--no-daemon", "-q", "create",
+		cmd = exec.Command("bd", "-q", "create",
 			"--type", "task", "--title", fmt.Sprintf("Test issue %d", i))
 		cmd.Dir = path
 		if output, err := cmd.CombinedOutput(); err != nil {
@@ -163,7 +163,7 @@ func TestBeadsDbInitAfterClone(t *testing.T) {
 
 		// NOW TRY TO USE bd - this is the key test for the bug
 		// Without the fix, the database doesn't exist and bd operations fail
-		cmd = exec.Command("bd", "--no-daemon", "--json", "-q", "create",
+		cmd = exec.Command("bd", "--json", "-q", "create",
 			"--type", "task", "--title", "test-from-rig")
 		cmd.Dir = rigDir
 		output, err := cmd.CombinedOutput()
@@ -219,7 +219,7 @@ func TestBeadsDbInitAfterClone(t *testing.T) {
 		}
 
 		// Verify bd operations work with the configured prefix
-		cmd = exec.Command("bd", "--no-daemon", "--json", "-q", "create",
+		cmd = exec.Command("bd", "--json", "-q", "create",
 			"--type", "task", "--title", "test-from-empty-repo")
 		cmd.Dir = rigDir
 		output, err := cmd.CombinedOutput()
@@ -307,7 +307,7 @@ func TestBeadsDbInitAfterClone(t *testing.T) {
 		}
 
 		// Verify bd operations work - the key test is that the database was initialized
-		cmd = exec.Command("bd", "--no-daemon", "--json", "-q", "create",
+		cmd = exec.Command("bd", "--json", "-q", "create",
 			"--type", "task", "--title", "test-derived-prefix")
 		cmd.Dir = rigDir
 		output, err = cmd.CombinedOutput()
@@ -380,7 +380,7 @@ func createTrackedBeadsRepoWithNoIssues(t *testing.T, path, prefix string) {
 	}
 
 	// Run bd init (creates database but no issues)
-	cmd := exec.Command("bd", "--no-daemon", "init", "--prefix", prefix)
+	cmd := exec.Command("bd", "init", "--prefix", prefix)
 	cmd.Dir = path
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("bd init failed: %v\nOutput: %s", err, output)

--- a/internal/cmd/beads_routing_integration_test.go
+++ b/internal/cmd/beads_routing_integration_test.go
@@ -110,7 +110,7 @@ func setupRoutingTestTown(t *testing.T) string {
 func initBeadsDBWithPrefix(t *testing.T, dir, prefix string) {
 	t.Helper()
 
-	cmd := exec.Command("bd", "--no-daemon", "init", "--quiet", "--prefix", prefix)
+	cmd := exec.Command("bd", "init", "--quiet", "--prefix", prefix)
 	cmd.Dir = dir
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("bd init failed in %s: %v\n%s", dir, err, output)
@@ -128,7 +128,7 @@ func initBeadsDBWithPrefix(t *testing.T, dir, prefix string) {
 func createTestIssue(t *testing.T, dir, title string) *beads.Issue {
 	t.Helper()
 
-	args := []string{"--no-daemon", "create", "--json", "--title", title, "--type", "task",
+	args := []string{"create", "--json", "--title", title, "--type", "task",
 		"--description", "Integration test issue"}
 	cmd := exec.Command("bd", args...)
 	cmd.Dir = dir

--- a/internal/cmd/beads_version.go
+++ b/internal/cmd/beads_version.go
@@ -94,9 +94,8 @@ func getBeadsVersion() (string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
 	defer cancel()
 
-	// Use --no-daemon to avoid contention when multiple agents start simultaneously.
-	// Version check doesn't need database access, so direct mode is faster and more reliable.
-	cmd := exec.CommandContext(ctx, "bd", "version", "--no-daemon")
+	// Version check doesn't need database access.
+	cmd := exec.CommandContext(ctx, "bd", "version")
 	output, err := cmd.Output()
 	if err != nil {
 		if ctx.Err() == context.DeadlineExceeded {

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -1459,7 +1459,7 @@ func getTrackedIssues(townBeads, convoyID string) ([]trackedIssueInfo, error) {
 	// Use bd dep list to get tracked dependencies
 	// Run from town root (parent of .beads) so bd routes correctly
 	townRoot := filepath.Dir(townBeads)
-	depCmd := exec.Command("bd", "--no-daemon", "dep", "list", convoyID, "--direction=down", "--type=tracks", "--json")
+	depCmd := exec.Command("bd", "dep", "list", convoyID, "--direction=down", "--type=tracks", "--json")
 	depCmd.Dir = townRoot
 
 	var stdout bytes.Buffer
@@ -1559,7 +1559,7 @@ func getExternalIssueDetails(townBeads, rigName, issueID string) *issueDetails {
 
 	// Query the rig database by running bd show from the rig directory
 	// Use --allow-stale to handle cases where JSONL and DB are out of sync
-	showCmd := exec.Command("bd", "--no-daemon", "show", issueID, "--json", "--allow-stale")
+	showCmd := exec.Command("bd", "show", issueID, "--json", "--allow-stale")
 	showCmd.Dir = rigDir // Set working directory to rig directory
 	var stdout bytes.Buffer
 	showCmd.Stdout = &stdout
@@ -1612,9 +1612,8 @@ func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 		return result
 	}
 
-	// Build args: bd --no-daemon show id1 id2 id3 ... --json
-	// Use --no-daemon to ensure fresh data (avoid stale cache from daemon)
-	args := append([]string{"--no-daemon", "show"}, issueIDs...)
+	// Build args: bd show id1 id2 id3 ... --json
+	args := append([]string{"show"}, issueIDs...)
 	args = append(args, "--json")
 
 	showCmd := exec.Command("bd", args...)
@@ -1660,15 +1659,14 @@ func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 // Prefer getIssueDetailsBatch for multiple issues to avoid N+1 subprocess calls.
 func getIssueDetails(issueID string) *issueDetails {
 	// Use bd show with routing - it should find the issue in the right rig
-	// Use --no-daemon to ensure fresh data (avoid stale cache)
-	showCmd := exec.Command("bd", "--no-daemon", "show", issueID, "--json")
+	showCmd := exec.Command("bd", "show", issueID, "--json")
 	var stdout bytes.Buffer
 	showCmd.Stdout = &stdout
 
 	if err := showCmd.Run(); err != nil {
 		return nil
 	}
-	// Handle bd --no-daemon exit 0 bug: empty stdout means not found
+	// Handle bd exit 0 bug: empty stdout means not found
 	if stdout.Len() == 0 {
 		return nil
 	}

--- a/internal/cmd/crew_at.go
+++ b/internal/cmd/crew_at.go
@@ -106,6 +106,9 @@ func runCrewAt(cmd *cobra.Command, args []string) error {
 	}
 
 	runtimeConfig := config.ResolveRoleAgentConfig("crew", townRoot, r.Path)
+	if runtimeConfig == nil {
+		runtimeConfig = config.DefaultRuntimeConfig()
+	}
 	if err := runtime.EnsureSettingsForRole(worker.ClonePath, "crew", runtimeConfig); err != nil {
 		// Non-fatal but log warning - missing settings can cause agents to start without hooks
 		style.PrintWarning("could not ensure settings for %s: %v", name, err)
@@ -128,7 +131,7 @@ func runCrewAt(cmd *cobra.Command, args []string) error {
 	// Before creating a new session, check if there's already a runtime session
 	// running in this crew's directory (might have been started manually or via
 	// a different mechanism)
-	if !hasSession {
+	if !hasSession && runtimeConfig.Tmux != nil {
 		existingSessions, err := t.FindSessionByWorkDir(worker.ClonePath, runtimeConfig.Tmux.ProcessNames)
 		if err == nil && len(existingSessions) > 0 {
 			// Found an existing session with runtime running in this directory

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -325,7 +325,7 @@ func TestGetIssueFromAgentHook(t *testing.T) {
 			tmpDir := t.TempDir()
 
 			// Initialize the beads database
-			cmd := exec.Command("bd", "--no-daemon", "init", "--prefix", "test", "--quiet")
+			cmd := exec.Command("bd", "init", "--prefix", "test", "--quiet")
 			cmd.Dir = tmpDir
 			if output, err := cmd.CombinedOutput(); err != nil {
 				t.Fatalf("bd init: %v\n%s", err, output)

--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -288,7 +288,7 @@ func runHook(_ *cobra.Command, args []string) error {
 	const hookBackoffMax = 10 * time.Second
 	var lastHookErr error
 	for attempt := 1; attempt <= hookMaxRetries; attempt++ {
-		hookBdCmd := exec.Command("bd", "--no-daemon", "update", beadID, "--status=hooked", "--assignee="+agentID)
+		hookBdCmd := exec.Command("bd", "update", beadID, "--status=hooked", "--assignee="+agentID)
 		hookBdCmd.Dir = townRoot
 		hookBdCmd.Stderr = os.Stderr
 		if err := hookBdCmd.Run(); err != nil {

--- a/internal/cmd/hook_slot_integration_test.go
+++ b/internal/cmd/hook_slot_integration_test.go
@@ -74,7 +74,7 @@ func setupHookTestTown(t *testing.T) (townRoot, polecatDir string) {
 func initBeadsDB(t *testing.T, dir string) {
 	t.Helper()
 
-	cmd := exec.Command("bd", "--no-daemon", "init")
+	cmd := exec.Command("bd", "init")
 	cmd.Dir = dir
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("bd init failed: %v\n%s", err, output)

--- a/internal/cmd/install_integration_test.go
+++ b/internal/cmd/install_integration_test.go
@@ -106,13 +106,12 @@ func TestInstallBeadsHasCorrectPrefix(t *testing.T) {
 	assertFileExists(t, metadataPath, ".beads/metadata.json")
 
 	// Verify prefix by running bd config get issue_prefix
-	// Use --no-daemon to avoid daemon startup issues in test environment
-	bdCmd := exec.Command("bd", "--no-daemon", "config", "get", "issue_prefix")
+	bdCmd := exec.Command("bd", "config", "get", "issue_prefix")
 	bdCmd.Dir = hqPath
 	prefixOutput, err := bdCmd.Output() // Use Output() to get only stdout
 	if err != nil {
 		// If Output() fails, try CombinedOutput for better error info
-		combinedOut, _ := exec.Command("bd", "--no-daemon", "config", "get", "issue_prefix").CombinedOutput()
+		combinedOut, _ := exec.Command("bd", "config", "get", "issue_prefix").CombinedOutput()
 		t.Fatalf("bd config get issue_prefix failed: %v\nOutput: %s", err, combinedOut)
 	}
 
@@ -315,11 +314,11 @@ func assertFileExists(t *testing.T, path, name string) {
 
 func assertSlotValue(t *testing.T, townRoot, issueID, slot, want string) {
 	t.Helper()
-	cmd := exec.Command("bd", "--no-daemon", "--json", "slot", "show", issueID)
+	cmd := exec.Command("bd", "--json", "slot", "show", issueID)
 	cmd.Dir = townRoot
 	output, err := cmd.Output()
 	if err != nil {
-		debugCmd := exec.Command("bd", "--no-daemon", "--json", "slot", "show", issueID)
+		debugCmd := exec.Command("bd", "--json", "slot", "show", issueID)
 		debugCmd.Dir = townRoot
 		combined, _ := debugCmd.CombinedOutput()
 		t.Fatalf("bd slot show %s failed: %v\nOutput: %s", issueID, err, combined)

--- a/internal/cmd/molecule_lifecycle_test.go
+++ b/internal/cmd/molecule_lifecycle_test.go
@@ -54,9 +54,6 @@ func TestSlingFormulaOnBeadHooksBaseBead(t *testing.T) {
 	bdScript := `#!/bin/sh
 set -e
 echo "$*" >> "${BD_LOG}"
-if [ "$1" = "--no-daemon" ]; then
-  shift
-fi
 if [ "$1" = "--allow-stale" ]; then
   shift
 fi
@@ -97,10 +94,6 @@ setlocal enableextensions
 echo %*>>"%BD_LOG%"
 set "cmd=%1"
 set "sub=%2"
-if "%cmd%"=="--no-daemon" (
-  set "cmd=%2"
-  set "sub=%3"
-)
 if "%cmd%"=="--allow-stale" (
   set "cmd=%2"
   set "sub=%3"
@@ -255,9 +248,6 @@ func TestSlingFormulaOnBeadSetsAttachedMoleculeInBaseBead(t *testing.T) {
 	bdScript := `#!/bin/sh
 set -e
 echo "$*" >> "${BD_LOG}"
-if [ "$1" = "--no-daemon" ]; then
-  shift
-fi
 if [ "$1" = "--allow-stale" ]; then
   shift
 fi
@@ -298,10 +288,6 @@ setlocal enableextensions
 echo %*>>"%BD_LOG%"
 set "cmd=%1"
 set "sub=%2"
-if "%cmd%"=="--no-daemon" (
-  set "cmd=%2"
-  set "sub=%3"
-)
 if "%cmd%"=="--allow-stale" (
   set "cmd=%2"
   set "sub=%3"
@@ -452,8 +438,8 @@ func TestDoneClosesAttachedMolecule(t *testing.T) {
 	// - Wisp gt-wisp-xyz (the attached molecule)
 	bdScript := fmt.Sprintf(`#!/bin/sh
 echo "$*" >> "%s/bd.log"
-# Strip --no-daemon and --allow-stale
-while [ "$1" = "--no-daemon" ] || [ "$1" = "--allow-stale" ]; do
+# Strip --allow-stale
+while [ "$1" = "--allow-stale" ]; do
   shift
 done
 cmd="$1"
@@ -492,12 +478,6 @@ echo %%*>>"%s\bd.log"
 set "cmd=%%1"
 set "beadID=%%2"
 :strip_flags
-if "%%cmd%%"=="--no-daemon" (
-  set "cmd=%%2"
-  set "beadID=%%3"
-  shift
-  goto strip_flags
-)
 if "%%cmd%%"=="--allow-stale" (
   set "cmd=%%2"
   set "beadID=%%3"

--- a/internal/cmd/patrol_helpers.go
+++ b/internal/cmd/patrol_helpers.go
@@ -30,7 +30,7 @@ type PatrolConfig struct {
 func findActivePatrol(cfg PatrolConfig) (patrolID, patrolLine string, found bool) {
 	// Check for in-progress patrol first (if configured)
 	if cfg.CheckInProgress {
-		cmdList := exec.Command("bd", "--no-daemon", "list", "--status=in_progress", "--type=epic")
+		cmdList := exec.Command("bd", "list", "--status=in_progress", "--type=epic")
 		cmdList.Dir = cfg.BeadsDir
 		var stdoutList, stderrList bytes.Buffer
 		cmdList.Stdout = &stdoutList
@@ -69,7 +69,7 @@ func findActivePatrol(cfg PatrolConfig) (patrolID, patrolLine string, found bool
 
 // findPatrolByStatus searches for a patrol molecule with the given status.
 func findPatrolByStatus(cfg PatrolConfig, status string) (patrolID, patrolLine string, found bool) {
-	cmdList := exec.Command("bd", "--no-daemon", "list", "--status="+status, "--type=epic")
+	cmdList := exec.Command("bd", "list", "--status="+status, "--type=epic")
 	cmdList.Dir = cfg.BeadsDir
 	var stdoutList, stderrList bytes.Buffer
 	cmdList.Stdout = &stdoutList
@@ -131,7 +131,7 @@ func autoSpawnPatrol(cfg PatrolConfig) (string, error) {
 	}
 
 	// Create the patrol wisp
-	cmdSpawn := exec.Command("bd", "--no-daemon", "mol", "wisp", "create", protoID, "--actor", cfg.RoleName)
+	cmdSpawn := exec.Command("bd", "mol", "wisp", "create", protoID, "--actor", cfg.RoleName)
 	cmdSpawn.Dir = cfg.BeadsDir
 	var stdoutSpawn, stderrSpawn bytes.Buffer
 	cmdSpawn.Stdout = &stdoutSpawn
@@ -161,7 +161,7 @@ func autoSpawnPatrol(cfg PatrolConfig) (string, error) {
 	}
 
 	// Hook the wisp to the agent so gt mol status sees it
-	cmdPin := exec.Command("bd", "--no-daemon", "update", patrolID, "--status=hooked", "--assignee="+cfg.Assignee)
+	cmdPin := exec.Command("bd", "update", patrolID, "--status=hooked", "--assignee="+cfg.Assignee)
 	cmdPin.Dir = cfg.BeadsDir
 	if err := cmdPin.Run(); err != nil {
 		return patrolID, fmt.Errorf("created wisp %s but failed to hook", patrolID)

--- a/internal/cmd/polecat_dotdir_test.go
+++ b/internal/cmd/polecat_dotdir_test.go
@@ -52,9 +52,6 @@ func TestStartPolecatsWithWorkSkipsDotDirs(t *testing.T) {
 
 	binDir := t.TempDir()
 	bdScript := `#!/bin/sh
-if [ "$1" = "--no-daemon" ]; then
-  shift
-fi
 cmd="$1"
 case "$cmd" in
   list)

--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -32,7 +32,7 @@ type MoleculeCurrentOutput struct {
 // with execution instructions. This is the core of the Propulsion Principle.
 func showMoleculeExecutionPrompt(workDir, moleculeID string) {
 	// Call bd mol current with JSON output
-	cmd := exec.Command("bd", "--no-daemon", "mol", "current", moleculeID, "--json")
+	cmd := exec.Command("bd", "mol", "current", moleculeID, "--json")
 	cmd.Dir = workDir
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -45,7 +45,7 @@ func showMoleculeExecutionPrompt(workDir, moleculeID string) {
 		fmt.Printf("  Check status with: bd mol current %s\n", moleculeID)
 		return
 	}
-	// Handle bd --no-daemon exit 0 bug: empty stdout means not found
+	// Handle bd exit 0 bug: empty stdout means not found
 	if stdout.Len() == 0 {
 		fmt.Println(style.Bold.Render("→ PROPULSION PRINCIPLE: Work is on your hook. RUN IT."))
 		fmt.Println("  Begin working on this molecule immediately.")

--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -698,7 +698,7 @@ func runRigAdopt(_ *cobra.Command, args []string) error {
 			workDir := filepath.Dir(beadsDir) // directory containing .beads/
 			// IMPORTANT: Use --backend dolt --server to prevent SQLite creation.
 			// Gas Town rigs use Dolt server mode via the shared town Dolt sql-server.
-			initCmd := exec.Command("bd", "--no-daemon", "init", "--prefix", prefix, "--backend", "dolt", "--server")
+			initCmd := exec.Command("bd", "init", "--prefix", prefix, "--backend", "dolt", "--server")
 			initCmd.Dir = workDir
 			if output, initErr := initCmd.CombinedOutput(); initErr != nil {
 				fmt.Printf("  %s Could not init bd database: %v (%s)\n", style.Warning.Render("!"), initErr, strings.TrimSpace(string(output)))

--- a/internal/cmd/rig_integration_test.go
+++ b/internal/cmd/rig_integration_test.go
@@ -209,13 +209,13 @@ pwsh -NoProfile -NoLogo -File "` + psPath + `" %*
 	} else {
 		// Create a script that simulates bd init and other commands
 		// Also logs all create commands for verification.
-		// Note: beads.run() prepends --no-daemon --allow-stale to all commands,
+		// Note: beads.run() prepends --allow-stale to all commands,
 		// so we need to find the actual command in the argument list.
 		script := `#!/bin/sh
 # Mock bd for testing
 LOG_FILE="` + logPath + `"
 
-# Find the actual command (skip global flags like --no-daemon, --allow-stale)
+# Find the actual command (skip global flags like --allow-stale)
 cmd=""
 for arg in "$@"; do
   case "$arg" in

--- a/internal/cmd/routes_jsonl_corruption_test.go
+++ b/internal/cmd/routes_jsonl_corruption_test.go
@@ -60,7 +60,7 @@ func TestRoutesJSONLCorruption(t *testing.T) {
 		}
 
 		// Create an issue and verify routes.jsonl is still valid
-		cmd = exec.Command("bd", "--no-daemon", "-q", "create", "--type", "task", "--title", "test issue")
+		cmd = exec.Command("bd", "-q", "create", "--type", "task", "--title", "test issue")
 		cmd.Dir = townRoot
 		if output, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("bd create failed: %v\nOutput: %s", err, output)
@@ -129,7 +129,7 @@ func TestRoutesJSONLCorruption(t *testing.T) {
 		os.MkdirAll(beadsDir, 0755)
 
 		// Initialize beads
-		cmd := exec.Command("bd", "--no-daemon", "init", "--prefix", "test", "--quiet")
+		cmd := exec.Command("bd", "init", "--prefix", "test", "--quiet")
 		cmd.Dir = tmpDir
 		if output, err := cmd.CombinedOutput(); err != nil {
 			t.Fatalf("bd init failed: %v\nOutput: %s", err, output)
@@ -147,7 +147,7 @@ func TestRoutesJSONLCorruption(t *testing.T) {
 		}
 
 		// Create an issue - this triggers auto-export
-		cmd = exec.Command("bd", "--no-daemon", "-q", "create", "--type", "task", "--title", "bug reproduction")
+		cmd = exec.Command("bd", "-q", "create", "--type", "task", "--title", "bug reproduction")
 		cmd.Dir = tmpDir
 		cmd.CombinedOutput() // Ignore error - we're testing the corruption
 

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -455,7 +455,7 @@ func runSling(cmd *cobra.Command, args []string) error {
 		}
 
 		// Unhook the bead from old owner (set status back to open)
-		unhookCmd := exec.Command("bd", "--no-daemon", "update", beadID, "--status=open", "--assignee=")
+		unhookCmd := exec.Command("bd", "update", beadID, "--status=open", "--assignee=")
 		unhookCmd.Dir = beads.ResolveHookDir(townRoot, beadID, "")
 		if err := unhookCmd.Run(); err != nil {
 			fmt.Printf("%s Could not unhook bead from old owner: %v\n", style.Dim.Render("Warning:"), err)
@@ -557,7 +557,7 @@ func runSling(cmd *cobra.Command, args []string) error {
 	skipVerify := os.Getenv("GT_TEST_SKIP_HOOK_VERIFY") != "" // For tests with stub bd
 	var lastErr error
 	for attempt := 1; attempt <= maxRetries; attempt++ {
-		hookCmd := exec.Command("bd", "--no-daemon", "update", beadID, "--status=hooked", "--assignee="+targetAgent)
+		hookCmd := exec.Command("bd", "update", beadID, "--status=hooked", "--assignee="+targetAgent)
 		hookCmd.Dir = hookDir
 		hookCmd.Stderr = os.Stderr
 		if err := hookCmd.Run(); err != nil {
@@ -759,7 +759,7 @@ func rollbackSlingArtifacts(spawnInfo *SpawnedPolecatInfo, beadID, hookWorkDir s
 		fmt.Printf("  %s Could not find workspace to unhook bead %s: %v\n", style.Dim.Render("Warning:"), beadID, err)
 	} else {
 		unhookDir := beads.ResolveHookDir(townRoot, beadID, hookWorkDir)
-		unhookCmd := exec.Command("bd", "--no-daemon", "update", beadID, "--status=open", "--assignee=")
+		unhookCmd := exec.Command("bd", "update", beadID, "--status=open", "--assignee=")
 		unhookCmd.Dir = unhookDir
 		if err := unhookCmd.Run(); err != nil {
 			fmt.Printf("  %s Could not unhook bead %s: %v\n", style.Dim.Render("Warning:"), beadID, err)

--- a/internal/cmd/sling_288_test.go
+++ b/internal/cmd/sling_288_test.go
@@ -43,9 +43,6 @@ func TestInstantiateFormulaOnBead(t *testing.T) {
 	bdScript := `#!/bin/sh
 set -e
 echo "CMD:$*" >> "${BD_LOG}"
-if [ "$1" = "--no-daemon" ]; then
-  shift
-fi
 cmd="$1"
 shift || true
 case "$cmd" in
@@ -79,10 +76,6 @@ setlocal enableextensions
 echo CMD:%*>>"%BD_LOG%"
 set "cmd=%1"
 set "sub=%2"
-if "%cmd%"=="--no-daemon" (
-  set "cmd=%2"
-  set "sub=%3"
-)
 if "%cmd%"=="show" (
   echo [{^"title^":^"Fix bug ABC^",^"status^":^"open^",^"assignee^":^"^",^"description^":^"^"}]
   exit /b 0
@@ -180,7 +173,6 @@ func TestInstantiateFormulaOnBeadSkipCook(t *testing.T) {
 	logPath := filepath.Join(townRoot, "bd.log")
 	bdScript := `#!/bin/sh
 echo "CMD:$*" >> "${BD_LOG}"
-if [ "$1" = "--no-daemon" ]; then shift; fi
 cmd="$1"; shift || true
 case "$cmd" in
   mol)
@@ -197,10 +189,6 @@ setlocal enableextensions
 echo CMD:%*>>"%BD_LOG%"
 set "cmd=%1"
 set "sub=%2"
-if "%cmd%"=="--no-daemon" (
-  set "cmd=%2"
-  set "sub=%3"
-)
 if "%cmd%"=="mol" (
   if "%sub%"=="wisp" (
     echo {^"new_epic_id^":^"gt-wisp-skip^"}
@@ -376,7 +364,6 @@ func TestFormulaOnBeadPassesVariables(t *testing.T) {
 	logPath := filepath.Join(townRoot, "bd.log")
 	bdScript := `#!/bin/sh
 echo "CMD:$*" >> "${BD_LOG}"
-if [ "$1" = "--no-daemon" ]; then shift; fi
 cmd="$1"; shift || true
 case "$cmd" in
   cook) exit 0;;
@@ -394,10 +381,6 @@ setlocal enableextensions
 echo CMD:%*>>"%BD_LOG%"
 set "cmd=%1"
 set "sub=%2"
-if "%cmd%"=="--no-daemon" (
-  set "cmd=%2"
-  set "sub=%3"
-)
 if "%cmd%"=="cook" exit /b 0
 if "%cmd%"=="mol" (
   if "%sub%"=="wisp" (

--- a/internal/cmd/sling_batch.go
+++ b/internal/cmd/sling_batch.go
@@ -161,7 +161,7 @@ func runBatchSling(beadIDs []string, rigName string, townBeadsDir string) error 
 		}
 
 		// Hook the bead (or wisp compound if formula was applied)
-		hookCmd := exec.Command("bd", "--no-daemon", "update", beadToHook, "--status=hooked", "--assignee="+targetAgent)
+		hookCmd := exec.Command("bd", "update", beadToHook, "--status=hooked", "--assignee="+targetAgent)
 		hookCmd.Dir = beads.ResolveHookDir(townRoot, beadToHook, hookWorkDir)
 		hookCmd.Stderr = os.Stderr
 		if err := hookCmd.Run(); err != nil {

--- a/internal/cmd/sling_convoy.go
+++ b/internal/cmd/sling_convoy.go
@@ -31,7 +31,7 @@ func isTrackedByConvoy(beadID string) string {
 
 	// Primary: Use bd dep list to find what tracks this issue (direction=up)
 	// This is authoritative when cross-rig routing works
-	depCmd := exec.Command("bd", "--no-daemon", "dep", "list", beadID, "--direction=up", "--type=tracks", "--json")
+	depCmd := exec.Command("bd", "dep", "list", beadID, "--direction=up", "--type=tracks", "--json")
 	depCmd.Dir = townRoot
 
 	out, err := depCmd.Output()
@@ -64,7 +64,7 @@ func findConvoyByDescription(townRoot, beadID string) string {
 	townBeads := filepath.Join(townRoot, ".beads")
 
 	// Query all open convoys from HQ
-	listCmd := exec.Command("bd", "--no-daemon", "list", "--type=convoy", "--status=open", "--json")
+	listCmd := exec.Command("bd", "list", "--type=convoy", "--status=open", "--json")
 	listCmd.Dir = townBeads
 
 	out, err := listCmd.Output()
@@ -104,7 +104,7 @@ func findConvoyByDescription(townRoot, beadID string) string {
 // convoyTracksBead checks if a convoy has a tracks dependency on the given beadID.
 // Handles both raw bead IDs and external-formatted references (e.g., "external:gt-mol:gt-mol-xyz").
 func convoyTracksBead(beadsDir, convoyID, beadID string) bool {
-	depCmd := exec.Command("bd", "--no-daemon", "dep", "list", convoyID, "--direction=down", "--type=tracks", "--json")
+	depCmd := exec.Command("bd", "dep", "list", convoyID, "--direction=down", "--type=tracks", "--json")
 	depCmd.Dir = beadsDir
 
 	out, err := depCmd.Output()
@@ -165,7 +165,7 @@ func createAutoConvoy(beadID, beadTitle string) (string, error) {
 		createArgs = append(createArgs, "--force")
 	}
 
-	createCmd := exec.Command("bd", append([]string{"--no-daemon"}, createArgs...)...)
+	createCmd := exec.Command("bd", createArgs...)
 	createCmd.Dir = townBeads
 	createCmd.Stderr = os.Stderr
 
@@ -176,14 +176,14 @@ func createAutoConvoy(beadID, beadTitle string) (string, error) {
 	// Add tracking relation: convoy tracks the issue.
 	// Pass the raw beadID and let bd handle cross-rig resolution via routes.jsonl,
 	// matching what gt convoy create/add already do (convoy.go:368, convoy.go:464).
-	depArgs := []string{"--no-daemon", "dep", "add", convoyID, beadID, "--type=tracks"}
+	depArgs := []string{"dep", "add", convoyID, beadID, "--type=tracks"}
 	depCmd := exec.Command("bd", depArgs...)
 	depCmd.Dir = townRoot
 	depCmd.Stderr = os.Stderr
 
 	if err := depCmd.Run(); err != nil {
 		// Tracking failed — delete the orphan convoy to prevent accumulation
-		delCmd := exec.Command("bd", "--no-daemon", "close", convoyID, "-r", "tracking dep failed")
+		delCmd := exec.Command("bd", "close", convoyID, "-r", "tracking dep failed")
 		delCmd.Dir = townRoot
 		_ = delCmd.Run()
 		return "", fmt.Errorf("adding tracking relation for %s: %w", beadID, err)

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -51,18 +51,18 @@ func trimJSONForError(jsonOutput []byte) string {
 
 // verifyFormulaExists checks that the formula exists using bd formula show.
 // Formulas are TOML files (.formula.toml).
-// Uses --no-daemon with --allow-stale for consistency with verifyBeadExists.
+// Uses --allow-stale for consistency with verifyBeadExists.
 func verifyFormulaExists(formulaName string) error {
 	// Try bd formula show (handles all formula file formats)
-	// Use Output() instead of Run() to detect bd --no-daemon exit 0 bug:
-	// when formula not found, --no-daemon may exit 0 but produce empty stdout.
-	cmd := exec.Command("bd", "--no-daemon", "formula", "show", formulaName, "--allow-stale")
+	// Use Output() instead of Run() to detect bd exit 0 bug:
+	// when formula not found, bd may exit 0 but produce empty stdout.
+	cmd := exec.Command("bd", "formula", "show", formulaName, "--allow-stale")
 	if out, err := cmd.Output(); err == nil && len(out) > 0 {
 		return nil
 	}
 
 	// Try with mol- prefix
-	cmd = exec.Command("bd", "--no-daemon", "formula", "show", "mol-"+formulaName, "--allow-stale")
+	cmd = exec.Command("bd", "formula", "show", "mol-"+formulaName, "--allow-stale")
 	if out, err := cmd.Output(); err == nil && len(out) > 0 {
 		return nil
 	}
@@ -195,7 +195,7 @@ func runSlingFormula(args []string) error {
 
 	// Step 1: Cook the formula (ensures proto exists)
 	fmt.Printf("  Cooking formula...\n")
-	cookArgs := []string{"--no-daemon", "cook", formulaName}
+	cookArgs := []string{"cook", formulaName}
 	cookCmd := exec.Command("bd", cookArgs...)
 	cookCmd.Dir = formulaWorkDir
 	cookCmd.Stderr = os.Stderr
@@ -205,7 +205,7 @@ func runSlingFormula(args []string) error {
 
 	// Step 2: Create wisp instance (ephemeral)
 	fmt.Printf("  Creating wisp...\n")
-	wispArgs := []string{"--no-daemon", "mol", "wisp", formulaName}
+	wispArgs := []string{"mol", "wisp", formulaName}
 	for _, v := range slingVars {
 		wispArgs = append(wispArgs, "--var", v)
 	}
@@ -229,7 +229,7 @@ func runSlingFormula(args []string) error {
 
 	// Step 3: Hook the wisp bead using bd update.
 	// See: https://github.com/steveyegge/gastown/issues/148
-	hookCmd := exec.Command("bd", "--no-daemon", "update", wispRootID, "--status=hooked", "--assignee="+targetAgent)
+	hookCmd := exec.Command("bd", "update", wispRootID, "--status=hooked", "--assignee="+targetAgent)
 	hookCmd.Dir = beads.ResolveHookDir(townRoot, wispRootID, "")
 	hookCmd.Stderr = os.Stderr
 	if err := hookCmd.Run(); err != nil {

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -76,7 +76,7 @@ type beadInfo struct {
 // Checks bead existence using bd show.
 // Resolves the rig directory from the bead's prefix for correct dolt access.
 func verifyBeadExists(beadID string) error {
-	cmd := exec.Command("bd", "--no-daemon", "show", beadID, "--json", "--allow-stale")
+	cmd := exec.Command("bd", "show", beadID, "--json", "--allow-stale")
 	cmd.Dir = resolveBeadDir(beadID)
 	out, err := cmd.Output()
 	if err != nil {
@@ -91,7 +91,7 @@ func verifyBeadExists(beadID string) error {
 // getBeadInfo returns status and assignee for a bead.
 // Resolves the rig directory from the bead's prefix for correct dolt access.
 func getBeadInfo(beadID string) (*beadInfo, error) {
-	cmd := exec.Command("bd", "--no-daemon", "show", beadID, "--json", "--allow-stale")
+	cmd := exec.Command("bd", "show", beadID, "--json", "--allow-stale")
 	cmd.Dir = resolveBeadDir(beadID)
 	out, err := cmd.Output()
 	if err != nil {
@@ -131,7 +131,7 @@ func storeFieldsInBead(beadID string, updates beadFieldUpdates) error {
 	issue := &beads.Issue{}
 	if logPath == "" {
 		// Read the bead once
-		showCmd := exec.Command("bd", "--no-daemon", "show", beadID, "--json", "--allow-stale")
+		showCmd := exec.Command("bd", "show", beadID, "--json", "--allow-stale")
 		showCmd.Dir = resolveBeadDir(beadID)
 		out, err := showCmd.Output()
 		if err != nil {
@@ -181,7 +181,7 @@ func storeFieldsInBead(beadID string, updates beadFieldUpdates) error {
 		return nil
 	}
 
-	updateCmd := exec.Command("bd", "--no-daemon", "update", beadID, "--description="+newDesc)
+	updateCmd := exec.Command("bd", "update", beadID, "--description="+newDesc)
 	updateCmd.Stderr = os.Stderr
 	if err := updateCmd.Run(); err != nil {
 		return fmt.Errorf("updating bead description: %w", err)
@@ -467,7 +467,7 @@ func InstantiateFormulaOnBead(formulaName, beadID, title, hookWorkDir, townRoot 
 
 	// Step 1: Cook the formula (ensures proto exists)
 	if !skipCook {
-		cookCmd := exec.Command("bd", "--no-daemon", "cook", formulaName)
+		cookCmd := exec.Command("bd", "cook", formulaName)
 		cookCmd.Dir = formulaWorkDir
 		cookCmd.Env = append(os.Environ(), "GT_ROOT="+townRoot)
 		cookCmd.Stderr = os.Stderr
@@ -527,7 +527,7 @@ func InstantiateFormulaOnBead(formulaName, beadID, title, hookWorkDir, townRoot 
 // This is useful for batch mode where we cook once before processing multiple beads.
 // townRoot is required for GT_ROOT so bd can find town-level formulas.
 func CookFormula(formulaName, workDir, townRoot string) error {
-	cookCmd := exec.Command("bd", "--no-daemon", "cook", formulaName)
+	cookCmd := exec.Command("bd", "cook", formulaName)
 	cookCmd.Dir = workDir
 	cookCmd.Env = append(os.Environ(), "GT_ROOT="+townRoot)
 	cookCmd.Stderr = os.Stderr

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -145,9 +145,6 @@ func TestSlingFormulaOnBeadRoutesBDCommandsToTargetRig(t *testing.T) {
 	bdScript := `#!/bin/sh
 set -e
 echo "$(pwd)|$*" >> "${BD_LOG}"
-if [ "$1" = "--no-daemon" ]; then
-  shift
-fi
 cmd="$1"
 shift || true
 case "$cmd" in
@@ -182,10 +179,6 @@ setlocal enableextensions
 echo %CD%^|%*>>"%BD_LOG%"
 set "cmd=%1"
 set "sub=%2"
-if "%cmd%"=="--no-daemon" (
-  set "cmd=%2"
-  set "sub=%3"
-)
 if "%cmd%"=="show" (
   echo [{"title":"Test issue","status":"open","assignee":"","description":""}]
   exit /b 0
@@ -337,9 +330,6 @@ func TestSlingFormulaOnBeadPassesFeatureAndIssueVars(t *testing.T) {
 	bdScript := `#!/bin/sh
 set -e
 echo "ARGS:$*" >> "${BD_LOG}"
-if [ "$1" = "--no-daemon" ]; then
-  shift
-fi
 cmd="$1"
 shift || true
 case "$cmd" in
@@ -374,10 +364,6 @@ setlocal enableextensions
 echo ARGS:%*>>"%BD_LOG%"
 set "cmd=%1"
 set "sub=%2"
-if "%cmd%"=="--no-daemon" (
-  set "cmd=%2"
-  set "sub=%3"
-)
 if "%cmd%"=="show" (
   echo [{^"title^":^"My Test Feature^",^"status^":^"open^",^"assignee^":^"^",^"description^":^"^"}]
   exit /b 0
@@ -475,7 +461,7 @@ exit /b 0
 }
 
 // TestVerifyBeadExistsAllowStale reproduces the bug in gtl-ncq where beads
-// visible via regular bd show fail with --no-daemon due to database sync issues.
+// visible via regular bd show fail due to database sync issues.
 // The fix uses --allow-stale to skip the sync check for existence verification.
 func TestVerifyBeadExistsAllowStale(t *testing.T) {
 	townRoot := t.TempDir()
@@ -486,8 +472,8 @@ func TestVerifyBeadExistsAllowStale(t *testing.T) {
 	}
 
 	// Create a stub bd that simulates the sync issue:
-	// - --no-daemon without --allow-stale fails (database out of sync)
-	// - --no-daemon with --allow-stale succeeds (skips sync check)
+	// - without --allow-stale fails (database out of sync)
+	// - with --allow-stale succeeds (skips sync check)
 	binDir := filepath.Join(townRoot, "bin")
 	if err := os.MkdirAll(binDir, 0755); err != nil {
 		t.Fatalf("mkdir binDir: %v", err)
@@ -501,20 +487,15 @@ for arg in "$@"; do
   fi
 done
 
-if [ "$1" = "--no-daemon" ]; then
-  if [ "$allow_stale" = "true" ]; then
-    # --allow-stale skips sync check, succeeds
-    echo '[{"title":"Test bead","status":"open","assignee":""}]'
-    exit 0
-  else
-    # Without --allow-stale, fails with sync error
-    echo '{"error":"Database out of sync with JSONL."}'
-    exit 1
-  fi
+if [ "$allow_stale" = "true" ]; then
+  # --allow-stale skips sync check, succeeds
+  echo '[{"title":"Test bead","status":"open","assignee":""}]'
+  exit 0
+else
+  # Without --allow-stale, fails with sync error
+  echo '{"error":"Database out of sync with JSONL."}'
+  exit 1
 fi
-# Daemon mode works
-echo '[{"title":"Test bead","status":"open","assignee":""}]'
-exit 0
 `
 	bdScriptWindows := `@echo off
 setlocal enableextensions
@@ -522,16 +503,12 @@ set "allow=false"
 for %%A in (%*) do (
   if "%%~A"=="--allow-stale" set "allow=true"
 )
-if "%1"=="--no-daemon" (
-  if "%allow%"=="true" (
-    echo [{"title":"Test bead","status":"open","assignee":""}]
-    exit /b 0
-  )
-  echo {"error":"Database out of sync with JSONL."}
-  exit /b 1
+if "%allow%"=="true" (
+  echo [{"title":"Test bead","status":"open","assignee":""}]
+  exit /b 0
 )
-echo [{"title":"Test bead","status":"open","assignee":""}]
-exit /b 0
+echo {"error":"Database out of sync with JSONL."}
+exit /b 1
 `
 	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
 
@@ -546,7 +523,7 @@ exit /b 0
 		t.Fatalf("chdir: %v", err)
 	}
 
-	// EXPECTED: verifyBeadExists should use --no-daemon --allow-stale and succeed
+	// EXPECTED: verifyBeadExists should use --allow-stale and succeed
 	beadID := "jv-v599"
 	err = verifyBeadExists(beadID)
 	if err != nil {
@@ -578,24 +555,16 @@ for arg in "$@"; do
   fi
 done
 
-if [ "$1" = "--no-daemon" ]; then
-  shift
-  cmd="$1"
-  if [ "$cmd" = "show" ]; then
+cmd="$1"
+shift || true
+case "$cmd" in
+  show)
     if [ "$allow_stale" = "true" ]; then
       echo '[{"title":"Synced bead","status":"open","assignee":""}]'
       exit 0
     fi
     echo '{"error":"Database out of sync"}'
     exit 1
-  fi
-  exit 0
-fi
-cmd="$1"
-shift || true
-case "$cmd" in
-  show)
-    echo '[{"title":"Synced bead","status":"open","assignee":""}]'
     ;;
   update)
     exit 0
@@ -610,22 +579,13 @@ for %%A in (%*) do (
   if "%%~A"=="--allow-stale" set "allow=true"
 )
 set "cmd=%1"
-if "%cmd%"=="--no-daemon" (
-  set "cmd=%2"
-  if "%cmd%"=="show" (
-    if "%allow%"=="true" (
-      echo [{"title":"Synced bead","status":"open","assignee":""}]
-      exit /b 0
-    )
-    echo {"error":"Database out of sync"}
-    exit /b 1
-  )
-  exit /b 0
-)
-set "cmd=%1"
 if "%cmd%"=="show" (
-  echo [{"title":"Synced bead","status":"open","assignee":""}]
-  exit /b 0
+  if "%allow%"=="true" (
+    echo [{"title":"Synced bead","status":"open","assignee":""}]
+    exit /b 0
+  )
+  echo {"error":"Database out of sync"}
+  exit /b 1
 )
 if "%cmd%"=="update" exit /b 0
 exit /b 0
@@ -661,14 +621,13 @@ exit /b 0
 	// Prevent real tmux nudge from firing during tests (causes agent self-interruption)
 	t.Setenv("GT_TEST_NO_NUDGE", "1")
 
-	// EXPECTED: gt sling should use daemon mode and succeed
-	// ACTUAL: verifyBeadExists uses --no-daemon and fails with sync error
+	// EXPECTED: gt sling should use --allow-stale and succeed
 	beadID := "jv-v599"
 	err = runSling(nil, []string{beadID})
 	if err != nil {
 		// Check if it's the specific error we're testing for
 		if strings.Contains(err.Error(), "is not a valid bead or formula") {
-			t.Errorf("gt sling failed to recognize bead %q: %v\nExpected to use daemon mode, but used --no-daemon which fails when DB out of sync", beadID, err)
+			t.Errorf("gt sling failed to recognize bead %q: %v\nExpected --allow-stale to skip sync check", beadID, err)
 		} else {
 			// Some other error - might be expected in dry-run mode
 			t.Logf("gt sling returned error (may be expected in test): %v", err)
@@ -771,9 +730,6 @@ func TestSlingFormulaOnBeadSetsAttachedMolecule(t *testing.T) {
 	bdScript := `#!/bin/sh
 set -e
 echo "$PWD|$*" >> "${BD_LOG}"
-if [ "$1" = "--no-daemon" ]; then
-  shift
-fi
 cmd="$1"
 shift || true
 case "$cmd" in
@@ -811,10 +767,6 @@ setlocal enableextensions
 echo %CD%^|%*>>"%BD_LOG%"
 set "cmd=%1"
 set "sub=%2"
-if "%cmd%"=="--no-daemon" (
-  set "cmd=%2"
-  set "sub=%3"
-)
 if "%cmd%"=="show" (
   echo [{^"title^":^"Bug to fix^",^"status^":^"open^",^"assignee^":^"^",^"description^":^"^"}]
   exit /b 0
@@ -951,9 +903,6 @@ func TestSlingNoMergeFlag(t *testing.T) {
 	bdScript := `#!/bin/sh
 set -e
 echo "ARGS:$*" >> "${BD_LOG}"
-if [ "$1" = "--no-daemon" ]; then
-  shift
-fi
 cmd="$1"
 shift || true
 case "$cmd" in
@@ -970,7 +919,6 @@ exit 0
 setlocal enableextensions
 echo ARGS:%*>>"%BD_LOG%"
 set "cmd=%1"
-if "%cmd%"=="--no-daemon" set "cmd=%2"
 if not "%cmd%"=="show" goto :notshow
 echo [{"title":"Test issue","status":"open","assignee":"","description":""}]
 exit /b 0
@@ -1145,9 +1093,6 @@ func TestSlingSetsDoltAutoCommitOff(t *testing.T) {
 	bdScript := `#!/bin/sh
 set -e
 echo "ENV:BD_DOLT_AUTO_COMMIT=${BD_DOLT_AUTO_COMMIT}|$*" >> "${BD_LOG}"
-if [ "$1" = "--no-daemon" ]; then
-  shift
-fi
 cmd="$1"
 shift || true
 case "$cmd" in
@@ -1164,7 +1109,6 @@ exit 0
 setlocal enableextensions
 echo ENV:BD_DOLT_AUTO_COMMIT=%BD_DOLT_AUTO_COMMIT%^|%*>>"%BD_LOG%"
 set "cmd=%1"
-if "%cmd%"=="--no-daemon" set "cmd=%2"
 if not "%cmd%"=="show" goto :notshow
 echo [{"title":"Test issue","status":"open","assignee":"","description":""}]
 exit /b 0

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1009,12 +1009,12 @@ func (d *Daemon) migrateBeadsToTown(srcBeadsDir, dstBeadsDir string) error {
 	d.killBeadsDaemon(srcBeadsDir)
 
 	// Set up export command (reads from source)
-	exportCmd := exec.Command(d.bdPath, "export", "--no-daemon")
+	exportCmd := exec.Command(d.bdPath, "export")
 	exportCmd.Env = append(os.Environ(), "BEADS_DIR="+srcBeadsDir)
 	exportCmd.Dir = filepath.Dir(srcBeadsDir)
 
 	// Set up import command (writes to destination)
-	importCmd := exec.Command(d.bdPath, "import", "--no-daemon")
+	importCmd := exec.Command(d.bdPath, "import")
 	importCmd.Env = append(os.Environ(), "BEADS_DIR="+dstBeadsDir)
 	importCmd.Dir = filepath.Dir(dstBeadsDir)
 

--- a/internal/doctor/config_check.go
+++ b/internal/doctor/config_check.go
@@ -694,7 +694,7 @@ func (c *CustomTypesCheck) Run(ctx *CheckContext) *CheckResult {
 
 	// Get current custom types configuration
 	// Use Output() not CombinedOutput() to avoid capturing bd's stderr messages
-	cmd := exec.Command("bd", "--no-daemon", "config", "get", "types.custom")
+	cmd := exec.Command("bd", "config", "get", "types.custom")
 	cmd.Dir = ctx.TownRoot
 	output, err := cmd.Output()
 	if err != nil {
@@ -767,7 +767,7 @@ func parseConfigOutput(output []byte) string {
 
 // Fix registers the missing custom types.
 func (c *CustomTypesCheck) Fix(ctx *CheckContext) error {
-	cmd := exec.Command("bd", "--no-daemon", "config", "set", "types.custom", constants.BeadsCustomTypes)
+	cmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
 	cmd.Dir = c.townRoot
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/doctor/routing_mode_check.go
+++ b/internal/doctor/routing_mode_check.go
@@ -59,7 +59,7 @@ func (c *RoutingModeCheck) Run(ctx *CheckContext) *CheckResult {
 // checkRoutingMode checks the routing mode in a specific beads directory.
 func (c *RoutingModeCheck) checkRoutingMode(beadsDir, location string) *CheckResult {
 	// Run bd config get routing.mode
-	cmd := exec.Command("bd", "--no-daemon", "config", "get", "routing.mode")
+	cmd := exec.Command("bd", "config", "get", "routing.mode")
 	cmd.Dir = filepath.Dir(beadsDir)
 	cmd.Env = append(cmd.Environ(), "BEADS_DIR="+beadsDir)
 
@@ -135,7 +135,7 @@ func (c *RoutingModeCheck) Fix(ctx *CheckContext) error {
 
 // setRoutingMode sets routing.mode to "explicit" in the specified beads directory.
 func (c *RoutingModeCheck) setRoutingMode(beadsDir string) error {
-	cmd := exec.Command("bd", "--no-daemon", "config", "set", "routing.mode", "explicit")
+	cmd := exec.Command("bd", "config", "set", "routing.mode", "explicit")
 	cmd.Dir = filepath.Dir(beadsDir)
 	cmd.Env = append(cmd.Environ(), "BEADS_DIR="+beadsDir)
 

--- a/internal/doctor/wisp_check.go
+++ b/internal/doctor/wisp_check.go
@@ -135,8 +135,8 @@ func (c *WispGCCheck) Fix(ctx *CheckContext) error {
 	for rigName := range c.abandonedRigs {
 		rigPath := filepath.Join(ctx.TownRoot, rigName)
 
-		// Run bd --no-daemon mol wisp gc
-		cmd := exec.Command("bd", "--no-daemon", "mol", "wisp", "gc")
+		// Run bd mol wisp gc
+		cmd := exec.Command("bd", "mol", "wisp", "gc")
 		cmd.Dir = rigPath
 		if output, err := cmd.CombinedOutput(); err != nil {
 			lastErr = fmt.Errorf("%s: %v (%s)", rigName, err, string(output))

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -424,13 +424,13 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 		// DB files are gitignored so they won't exist after clone — bd init creates them.
 		// bd init --prefix will create the database and auto-import from issues.jsonl.
 		if !bdDatabaseExists(sourceBeadsDir) {
-			cmd := exec.Command("bd", "--no-daemon", "init", "--prefix", opts.BeadsPrefix, "--backend", "dolt") // opts.BeadsPrefix validated earlier
+			cmd := exec.Command("bd", "init", "--prefix", opts.BeadsPrefix, "--backend", "dolt") // opts.BeadsPrefix validated earlier
 			cmd.Dir = mayorRigPath
 			if output, err := cmd.CombinedOutput(); err != nil {
 				fmt.Printf("  Warning: Could not init bd database: %v (%s)\n", err, strings.TrimSpace(string(output)))
 			}
 			// Configure custom types for Gas Town (beads v0.46.0+)
-			configCmd := exec.Command("bd", "--no-daemon", "config", "set", "types.custom", constants.BeadsCustomTypes)
+			configCmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
 			configCmd.Dir = mayorRigPath
 			_, _ = configCmd.CombinedOutput() // Ignore errors - older beads don't need this
 		}
@@ -661,7 +661,7 @@ func (m *Manager) initBeads(rigPath, prefix string) error {
 	filteredEnv = append(filteredEnv, "BEADS_DIR="+beadsDir)
 
 	// Run bd init if available (default to Dolt backend)
-	cmd := exec.Command("bd", "--no-daemon", "init", "--prefix", prefix, "--backend", "dolt")
+	cmd := exec.Command("bd", "init", "--prefix", prefix, "--backend", "dolt")
 	cmd.Dir = rigPath
 	cmd.Env = filteredEnv
 	_, err := cmd.CombinedOutput()
@@ -677,7 +677,7 @@ func (m *Manager) initBeads(rigPath, prefix string) error {
 
 	// Configure custom types for Gas Town (agent, role, rig, convoy).
 	// These were extracted from beads core in v0.46.0 and now require explicit config.
-	configCmd := exec.Command("bd", "--no-daemon", "config", "set", "types.custom", constants.BeadsCustomTypes)
+	configCmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
 	configCmd.Dir = rigPath
 	configCmd.Env = filteredEnv
 	// Ignore errors - older beads versions don't need this
@@ -686,7 +686,7 @@ func (m *Manager) initBeads(rigPath, prefix string) error {
 	// Ensure database has repository fingerprint (GH #25).
 	// This is idempotent - safe on both new and legacy (pre-0.17.5) databases.
 	// Without fingerprint, the bd daemon fails to start silently.
-	migrateCmd := exec.Command("bd", "--no-daemon", "migrate", "--update-repo-id")
+	migrateCmd := exec.Command("bd", "migrate", "--update-repo-id")
 	migrateCmd.Dir = rigPath
 	migrateCmd.Env = filteredEnv
 	// Ignore errors - fingerprint is optional for functionality
@@ -1229,7 +1229,7 @@ func (m *Manager) createPatrolHooks(workspacePath string, runtimeConfig *config.
 // These molecules define the work loops for Deacon, Witness, and Refinery roles.
 func (m *Manager) seedPatrolMolecules(rigPath string) error {
 	// Use bd command to seed molecules (more reliable than internal API)
-	cmd := exec.Command("bd", "--no-daemon", "mol", "seed", "--patrol")
+	cmd := exec.Command("bd", "mol", "seed", "--patrol")
 	cmd.Dir = rigPath
 	if err := cmd.Run(); err != nil {
 		// Fallback: bd mol seed might not support --patrol yet
@@ -1262,7 +1262,7 @@ func (m *Manager) seedPatrolMoleculesManually(rigPath string) error {
 
 	for _, mol := range patrolMols {
 		// Check if already exists by title
-		checkCmd := exec.Command("bd", "--no-daemon", "list", "--type=molecule", "--format=json")
+		checkCmd := exec.Command("bd", "list", "--type=molecule", "--format=json")
 		checkCmd.Dir = rigPath
 		output, _ := checkCmd.Output()
 		if strings.Contains(string(output), mol.title) {
@@ -1270,7 +1270,7 @@ func (m *Manager) seedPatrolMoleculesManually(rigPath string) error {
 		}
 
 		// Create the molecule
-		cmd := exec.Command("bd", "--no-daemon", "create", //nolint:gosec // G204: bd is a trusted internal tool
+		cmd := exec.Command("bd", "create", //nolint:gosec // G204: bd is a trusted internal tool
 			"--type=molecule",
 			"--title="+mol.title,
 			"--description="+mol.desc,

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -477,9 +477,6 @@ set -e
 if [[ -n "$BEADS_DIR_LOG" ]]; then
   echo "${BEADS_DIR:-<unset>}" >> "$BEADS_DIR_LOG"
 fi
-if [[ "$1" == "--no-daemon" ]]; then
-  shift
-fi
 if [[ "$1" == "--allow-stale" ]]; then
   shift
 fi
@@ -515,7 +512,7 @@ case "$cmd" in
     ;;
 esac
 `
-	windowsScript := "@echo off\r\nsetlocal enabledelayedexpansion\r\nif defined BEADS_DIR_LOG (\r\n  if defined BEADS_DIR (\r\n    echo %BEADS_DIR%>>\"%BEADS_DIR_LOG%\"\r\n  ) else (\r\n    echo ^<unset^> >>\"%BEADS_DIR_LOG%\"\r\n  )\r\n)\r\nset \"cmd=%1\"\r\nset \"arg2=%2\"\r\nset \"arg3=%3\"\r\nif \"%cmd%\"==\"--no-daemon\" (\r\n  set \"cmd=%2\"\r\n  set \"arg2=%3\"\r\n  set \"arg3=%4\"\r\n)\r\nif \"%cmd%\"==\"--allow-stale\" (\r\n  set \"cmd=%2\"\r\n  set \"arg2=%3\"\r\n  set \"arg3=%4\"\r\n)\r\nif \"%cmd%\"==\"show\" (\r\n  echo []\r\n  exit /b 0\r\n)\r\nif \"%cmd%\"==\"create\" (\r\n  set \"id=\"\r\n  set \"title=\"\r\n  for %%A in (%*) do (\r\n    set \"arg=%%~A\"\r\n    if /i \"!arg:~0,5!\"==\"--id=\" set \"id=!arg:~5!\"\r\n    if /i \"!arg:~0,8!\"==\"--title=\" set \"title=!arg:~8!\"\r\n  )\r\n  if defined AGENT_LOG (\r\n    echo !id!>>\"%AGENT_LOG%\"\r\n  )\r\n  echo {\"id\":\"!id!\",\"title\":\"!title!\",\"description\":\"\",\"issue_type\":\"agent\"}\r\n  exit /b 0\r\n)\r\nif \"%cmd%\"==\"slot\" exit /b 0\r\nif \"%cmd%\"==\"config\" exit /b 0\r\nexit /b 1\r\n"
+	windowsScript := "@echo off\r\nsetlocal enabledelayedexpansion\r\nif defined BEADS_DIR_LOG (\r\n  if defined BEADS_DIR (\r\n    echo %BEADS_DIR%>>\"%BEADS_DIR_LOG%\"\r\n  ) else (\r\n    echo ^<unset^> >>\"%BEADS_DIR_LOG%\"\r\n  )\r\n)\r\nset \"cmd=%1\"\r\nset \"arg2=%2\"\r\nset \"arg3=%3\"\r\nif \"%cmd%\"==\"--allow-stale\" (\r\n  set \"cmd=%2\"\r\n  set \"arg2=%3\"\r\n  set \"arg3=%4\"\r\n)\r\nif \"%cmd%\"==\"show\" (\r\n  echo []\r\n  exit /b 0\r\n)\r\nif \"%cmd%\"==\"create\" (\r\n  set \"id=\"\r\n  set \"title=\"\r\n  for %%A in (%*) do (\r\n    set \"arg=%%~A\"\r\n    if /i \"!arg:~0,5!\"==\"--id=\" set \"id=!arg:~5!\"\r\n    if /i \"!arg:~0,8!\"==\"--title=\" set \"title=!arg:~8!\"\r\n  )\r\n  if defined AGENT_LOG (\r\n    echo !id!>>\"%AGENT_LOG%\"\r\n  )\r\n  echo {\"id\":\"!id!\",\"title\":\"!title!\",\"description\":\"\",\"issue_type\":\"agent\"}\r\n  exit /b 0\r\n)\r\nif \"%cmd%\"==\"slot\" exit /b 0\r\nif \"%cmd%\"==\"config\" exit /b 0\r\nexit /b 1\r\n"
 
 	binDir := writeFakeBD(t, script, windowsScript)
 	agentLog := filepath.Join(t.TempDir(), "agents.log")

--- a/internal/tui/convoy/model.go
+++ b/internal/tui/convoy/model.go
@@ -211,7 +211,7 @@ func refreshIssueStatus(ctx context.Context, tracked []struct {
 		return nil
 	}
 
-	args := []string{"--no-daemon", "show"}
+	args := []string{"show"}
 	for _, t := range tracked {
 		args = append(args, t.ID)
 	}

--- a/internal/tui/feed/convoy.go
+++ b/internal/tui/feed/convoy.go
@@ -225,7 +225,7 @@ func refreshTrackedStatus(ctx context.Context, deps []struct {
 		return nil
 	}
 
-	args := []string{"--no-daemon", "show"}
+	args := []string{"show"}
 	for _, d := range deps {
 		args = append(args, d.ID)
 	}


### PR DESCRIPTION
## Summary

- Removes all `--no-daemon` flag references from production code (19 files) and test code (13 files) after bd daemon mode was removed upstream
- Adds nil guard for `runtimeConfig` and `runtimeConfig.Tmux` in `crew_at.go` to prevent panic when config resolution returns nil

The `--no-daemon` flag was removed from the `bd` CLI but gt still passed it in ~50 call sites, causing `bd version` checks to fail and a nil pointer dereference in `crew_at.go` when attaching to crew members.

## Test plan

- [x] `go build ./...` passes cleanly
- [x] Zero remaining `--no-daemon` references in codebase (verified via grep)
- [x] `bd version` no longer errors on unknown flag
- [x] `gt crew at <name>` attaches without panic

🤖 Generated with [Claude Code](https://claude.com/claude-code)