### PR TITLE
fix: add warning logs for silently swallowed errors (fixes #1231)

### DIFF
--- a/internal/feed/curator.go
+++ b/internal/feed/curator.go
@@ -14,6 +14,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -311,6 +312,7 @@ func (c *Curator) writeFeedEvent(event *events.Event) {
 
 	data, err := json.Marshal(feedEvent)
 	if err != nil {
+		log.Printf("warning: marshaling feed event: %v", err)
 		return
 	}
 	data = append(data, '\n')
@@ -320,17 +322,19 @@ func (c *Curator) writeFeedEvent(event *events.Event) {
 	// Acquire cross-process file lock to prevent interleaved writes
 	fl := flock.New(feedPath + ".lock")
 	if err := fl.Lock(); err != nil {
+		log.Printf("warning: acquiring feed file lock: %v", err)
 		return
 	}
 	defer fl.Unlock() //nolint:errcheck // best-effort unlock
 
 	f, err := os.OpenFile(feedPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644) //nolint:gosec // G302: feed file is non-sensitive operational data
 	if err != nil {
+		log.Printf("warning: opening feed file: %v", err)
 		return
 	}
 	defer f.Close()
 
-	_, _ = f.Write(data)
+	_, _ = f.Write(data) //nolint:errcheck // best-effort append under flock
 }
 
 // generateSummary creates a human-readable summary of an event.

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"log"
 	"os"
 	"path/filepath"
 	"sort"
@@ -463,7 +464,9 @@ Please review the feedback and address the issues before resubmitting.`,
 			mr.Branch, mr.IssueID, reason),
 		Priority: mail.PriorityNormal,
 	}
-	_ = router.Send(msg) // best-effort notification
+	if err := router.Send(msg); err != nil {
+		log.Printf("warning: notifying worker of rejection for %s: %v", mr.IssueID, err)
+	}
 }
 
 // findTownRoot walks up directories to find the town root.

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log"
 	"net/http"
 	"os"
 	"os/exec"
@@ -488,6 +489,8 @@ func (h *APIHandler) handleOptions(w http.ResponseWriter, r *http.Request) {
 			mu.Lock()
 			resp.Rigs = parseRigListOutput(output)
 			mu.Unlock()
+		} else {
+			log.Printf("warning: handleOptions: rig list: %v", err)
 		}
 	}()
 
@@ -498,6 +501,8 @@ func (h *APIHandler) handleOptions(w http.ResponseWriter, r *http.Request) {
 			mu.Lock()
 			resp.Polecats = parseJSONPaths(output)
 			mu.Unlock()
+		} else {
+			log.Printf("warning: handleOptions: polecat list: %v", err)
 		}
 	}()
 
@@ -508,6 +513,8 @@ func (h *APIHandler) handleOptions(w http.ResponseWriter, r *http.Request) {
 			mu.Lock()
 			resp.Convoys = parseConvoyListOutput(output)
 			mu.Unlock()
+		} else {
+			log.Printf("warning: handleOptions: convoy list: %v", err)
 		}
 	}()
 
@@ -518,6 +525,8 @@ func (h *APIHandler) handleOptions(w http.ResponseWriter, r *http.Request) {
 			mu.Lock()
 			resp.Hooks = parseHooksListOutput(output)
 			mu.Unlock()
+		} else {
+			log.Printf("warning: handleOptions: hooks list: %v", err)
 		}
 	}()
 
@@ -528,6 +537,8 @@ func (h *APIHandler) handleOptions(w http.ResponseWriter, r *http.Request) {
 			mu.Lock()
 			resp.Messages = parseMailInboxOutput(output)
 			mu.Unlock()
+		} else {
+			log.Printf("warning: handleOptions: mail inbox: %v", err)
 		}
 	}()
 
@@ -538,6 +549,8 @@ func (h *APIHandler) handleOptions(w http.ResponseWriter, r *http.Request) {
 			mu.Lock()
 			resp.Crew = parseCrewListOutput(output)
 			mu.Unlock()
+		} else {
+			log.Printf("warning: handleOptions: crew list: %v", err)
 		}
 	}()
 
@@ -548,6 +561,8 @@ func (h *APIHandler) handleOptions(w http.ResponseWriter, r *http.Request) {
 			mu.Lock()
 			resp.Agents = parseAgentsFromStatus(output)
 			mu.Unlock()
+		} else {
+			log.Printf("warning: handleOptions: status: %v", err)
 		}
 	}()
 

--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -320,6 +320,7 @@ func (f *LiveConvoyFetcher) getIssueDetailsBatch(issueIDs []string) map[string]*
 
 	stdout, err := runCmd(f.cmdTimeout, "bd", args...)
 	if err != nil {
+		log.Printf("warning: bd show failed for %d issues: %v", len(issueIDs), err)
 		return result
 	}
 
@@ -331,6 +332,7 @@ func (f *LiveConvoyFetcher) getIssueDetailsBatch(issueIDs []string) map[string]*
 		UpdatedAt string `json:"updated_at"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil {
+		log.Printf("warning: parsing bd show output: %v", err)
 		return result
 	}
 
@@ -817,7 +819,8 @@ func (f *LiveConvoyFetcher) getAssignedIssuesMap() map[string]assignedIssue {
 	// Query all in_progress issues (these are the ones being worked on)
 	stdout, err := f.runBdCmd(f.townRoot, "list", "--status=in_progress", "--json")
 	if err != nil {
-		return result // Return empty map on error
+		log.Printf("warning: bd list in_progress failed: %v", err)
+		return result
 	}
 
 	var issues []struct {
@@ -826,6 +829,7 @@ func (f *LiveConvoyFetcher) getAssignedIssuesMap() map[string]assignedIssue {
 		Assignee string `json:"assignee"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil {
+		log.Printf("warning: parsing bd list output: %v", err)
 		return result
 	}
 

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -3,6 +3,7 @@ package witness
 import (
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -178,10 +179,14 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	}
 
 	// Accept bypass permissions warning dialog if it appears.
-	_ = t.AcceptBypassPermissionsWarning(sessionID)
+	if err := t.AcceptBypassPermissionsWarning(sessionID); err != nil {
+		log.Printf("warning: accepting bypass permissions for %s: %v", sessionID, err)
+	}
 
 	// Track PID for defense-in-depth orphan cleanup (non-fatal)
-	_ = session.TrackSessionPID(townRoot, sessionID, t)
+	if err := session.TrackSessionPID(townRoot, sessionID, t); err != nil {
+		log.Printf("warning: tracking session PID for %s: %v", sessionID, err)
+	}
 
 	time.Sleep(constants.ShutdownNotifyDelay)
 


### PR DESCRIPTION
## Summary

Fixes #1231 — Adds "$(log.Printf("warning: ..."))" calls at **18 sites across 5 files** where errors were silently discarded, making failures invisible during debugging.

All sites are **recoverable errors** — behavior is unchanged, logging is purely additive. No new dependencies.

## Error Policy

| Category | Action | Example |
|----------|--------|---------|
| Fatal | Return/propagate error | Already done at all sites |
| Recoverable | "$(log.Printf("warning: ..."))" + continue | Dashboard fetches, notifications |
| Intentionally ignored | "$(//nolint:errcheck)" with reason | Lock unlocks, cleanup |

## Changes by file

### `internal/web/api.go` — 7 sites (+1 import)

All 7 goroutines in "$(handleOptions)" silently discarded "$(gt)" command errors. Added "$(else)" clause with logging to each:

```go
// Before: success-only, errors invisible
if output, err := h.runGtCommand(r.Context(), 3*time.Second, ...); err == nil {
    // parse output
}

// After: errors now visible in logs
if output, err := h.runGtCommand(r.Context(), 3*time.Second, ...); err == nil {
    // parse output
} else {
    log.Printf("warning: handleOptions: rig list: %v", err)
}
```

Labels: "$(rig list)", "$(polecat list)", "$(convoy list)", "$(hooks list)", "$(mail inbox)", "$(crew list)", "$(status)"

### `internal/web/fetcher.go` — 4 sites (import already present)

Two functions had silent returns on command failures and JSON parse errors:

```go
// getIssueDetailsBatch — bd show command failure
stdout, err := runCmd(f.cmdTimeout, "bd", args...)
if err != nil {
    log.Printf("warning: bd show failed for %d issues: %v", len(issueIDs), err)
    return result
}

// getIssueDetailsBatch — JSON unmarshal failure
if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil {
    log.Printf("warning: parsing bd show output: %v", err)
    return result
}
```

**Bonus finds** (not in original issue): Same pattern in "$(getAssignedIssuesMap)" — "$(bd list)" command failure and JSON unmarshal.

### `internal/feed/curator.go` — 4 sites (+1 import)

"$(writeFeedEvent)" had 3 silent "$(return)" paths and 1 unannotated discard:

```go
// JSON marshal failure — was silent return
data, err := json.Marshal(feedEvent)
if err != nil {
    log.Printf("warning: marshaling feed event: %v", err)
    return
}

// File lock acquisition — was silent return
fl := flock.New(feedPath + ".lock")
if err := fl.Lock(); err != nil {
    log.Printf("warning: acquiring feed file lock: %v", err)
    return
}

// File open — was silent return
f, err := os.OpenFile(feedPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
if err != nil {
    log.Printf("warning: opening feed file: %v", err)
    return
}

// Best-effort write — annotated rather than logged (redundant under flock)
_, _ = f.Write(data) //nolint:errcheck // best-effort append under flock
```

### `internal/witness/manager.go` — 2 sites (+1 import)

Non-fatal startup helpers used "$(_ =)" discard pattern:

```go
// Before
_ = t.AcceptBypassPermissionsWarning(sessionID)
_ = session.TrackSessionPID(townRoot, sessionID, t)

// After
if err := t.AcceptBypassPermissionsWarning(sessionID); err != nil {
    log.Printf("warning: accepting bypass permissions for %s: %v", sessionID, err)
}
if err := session.TrackSessionPID(townRoot, sessionID, t); err != nil {
    log.Printf("warning: tracking session PID for %s: %v", sessionID, err)
}
```

### `internal/refinery/manager.go` — 1 site (+1 import)

Worker rejection notification used "$(_ =)" discard:

```go
// Before
_ = router.Send(msg) // best-effort notification

// After
if err := router.Send(msg); err != nil {
    log.Printf("warning: notifying worker of rejection for %s: %v", mr.IssueID, err)
}
```

## Out of Scope (already handled in codebase)

- "$(witness/manager.go:124-126)" — "$(EnsureSettingsForRole)" already returns "$(fmt.Errorf)"
- "$(refinery/manager.go:309-312)" — "$(closeWithReason)" already has "$(fmt.Fprintf)" logging
- "$(refinery/manager.go:507-510)" — "$(crewMgr.List)" already has proper error handling in all callers

## Stats

- **5 files changed**, **+36 insertions**, **-5 deletions**
- **4 new "$("log")" imports** (fetcher.go already had it)
- **0 behavioral changes** — all logging is additive

## Test plan

- [x] "$(go build ./...)" clean
- [x] "$(go vet ./...)" clean
- [x] "$(go test -race -short ./internal/web/ ./internal/feed/ ./internal/witness/ ./internal/refinery/)" — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>