### PR TITLE
fix: add input validation for path traversal and argument injection (fixes #1229)

### DIFF
--- a/internal/web/validate.go
+++ b/internal/web/validate.go
@@ -1,0 +1,72 @@
+package web
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Validation patterns for user input.
+var (
+	// idPattern matches typical IDs: alphanumeric, hyphens, underscores, dots.
+	idPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+	// repoRefPattern matches GitHub-style owner/repo references.
+	repoRefPattern = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9._-]*/[a-zA-Z0-9][a-zA-Z0-9._-]*$`)
+)
+
+// isValidID checks if a string is a safe identifier (issue IDs, message IDs, rig names).
+func isValidID(s string) bool {
+	return len(s) > 0 && len(s) <= 200 && idPattern.MatchString(s)
+}
+
+// isValidRepoRef checks if a string matches the owner/repo format.
+func isValidRepoRef(s string) bool {
+	return repoRefPattern.MatchString(s)
+}
+
+// isNumeric checks if a string contains only ASCII digits.
+func isNumeric(s string) bool {
+	if len(s) == 0 || len(s) > 20 {
+		return false
+	}
+	for _, r := range s {
+		if r < '0' || r > '9' {
+			return false
+		}
+	}
+	return true
+}
+
+// isValidGitURL checks if a string looks like a valid git remote reference.
+// Accepts HTTPS URLs, SSH URLs (git@), and owner/repo shorthand.
+func isValidGitURL(s string) bool {
+	return strings.HasPrefix(s, "https://") ||
+		strings.HasPrefix(s, "git@") ||
+		isValidRepoRef(s)
+}
+
+// expandHomePath safely expands ~ prefix, cleans the result, and ensures
+// ~-expanded paths stay within the home directory.
+// Returns error if home directory cannot be determined or path escapes home.
+func expandHomePath(path string) (string, error) {
+	if path != "~" && !strings.HasPrefix(path, "~/") {
+		// Non-~ paths: normalize to remove . / .. segments for consistency.
+		// Callers that need traversal checks should validate separately.
+		return filepath.Clean(path), nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	if path == "~" {
+		return home, nil
+	}
+	cleaned := filepath.Clean(filepath.Join(home, path[2:]))
+	// Ensure ~ expansion doesn't escape the home directory
+	if cleaned != home && !strings.HasPrefix(cleaned, home+string(filepath.Separator)) {
+		return "", fmt.Errorf("path escapes home directory")
+	}
+	return cleaned, nil
+}


### PR DESCRIPTION
## Summary

Closes #1229 — Adds defense-in-depth input validation at the HTTP request boundary across the localhost dashboard's web handlers.

The dashboard shells out to "$(gt)", "$(bd)", and "$(gh)" via "$(exec.Command)" (no shell involved), so the original issue's "shell injection" framing is incorrect — but **argument injection** (e.g., "$(--flag)" as an ID) is real. All fixes are additive guardrails that reject malformed input before it reaches external commands. **Zero behavioral change for valid inputs.**

---

## Changes by file

### `internal/web/validate.go` — New file (73 lines)

Shared validation helpers extracted to keep "$(api.go)" and "$(setup.go)" clean:

```go
// Compiled regex patterns — safe identifiers and owner/repo format
var idPattern      = regexp.MustCompile("$(^[a-zA-Z0-9][a-zA-Z0-9._-]*$)")
var repoRefPattern = regexp.MustCompile("$(^[a-zA-Z0-9][a-zA-Z0-9._-]*/[a-zA-Z0-9][a-zA-Z0-9._-]*$)")

func isValidID(s string) bool       // alphanumeric start, max 200 bytes
func isValidRepoRef(s string) bool   // owner/repo format
func isNumeric(s string) bool        // digits only, max 20 chars (for PR numbers)
func isValidGitURL(s string) bool    // https://, git@, or owner/repo shorthand
func expandHomePath(path string) (string, error) // safe ~ expansion + containment
```

Key design decisions:
- "$(idPattern)" requires **alphanumeric first character** — rejects "$(--flag)", "$(-evil)", "$(.hidden)"
- "$(repoRefPattern)" requires alphanumeric start on **both** owner and repo segments
- "$(isNumeric)" is intentionally not "$(strconv.Atoi)" — no sign prefix, no overflow, no whitespace
- "$(isValidGitURL)" accepts the three standard git remote formats: "$(https://...)", "$(git@...)", "$(owner/repo)"

### `internal/web/setup.go` — 4 fixes across 3 handlers

#### Fix 1: Path traversal via `~` expansion (3 sites)

"$(handleInstall)", "$(handleLaunch)", "$(handleCheckWorkspace)" all had identical vulnerable code:

```go
// BEFORE: ignores UserHomeDir error, no path cleaning, no traversal check
if strings.HasPrefix(req.Path, "~/") {
    home, _ := os.UserHomeDir()
    req.Path = filepath.Join(home, req.Path[2:])
}
// ~/../../etc/passwd → /etc/passwd ← traversal succeeds
```

```go
// AFTER: expandHomePath cleans, checks containment, propagates errors
expanded, err := expandHomePath(req.Path)
if err != nil {
    h.sendError(w, err.Error(), http.StatusBadRequest)
    return
}
req.Path = expanded
// ~/../../etc/passwd → error "path escapes home directory"
```

The containment check inside "$(expandHomePath)":
```go
cleaned := filepath.Clean(filepath.Join(home, path[2:]))
if cleaned != home && !strings.HasPrefix(cleaned, home+string(filepath.Separator)) {
    return "", fmt.Errorf("path escapes home directory")
}
```

Note: "$(handleCheckWorkspace)" uses "$(CheckWorkspaceResponse{Valid: false, ...})" instead of "$(h.sendError())" to match its existing response contract.

#### Fix 2: Port range validation

```go
// BEFORE: any int accepted, newPort = port + 1 could overflow valid range
port := req.Port
if port == 0 { port = 8080 }

// AFTER: bounds check before newPort = port + 1
if port < 1 || port > 65534 {
    h.sendError(w, "Port must be between 1 and 65534", http.StatusBadRequest)
    return
}
// Upper bound 65534 ensures newPort (port+1) ≤ 65535
```

#### Fix 3: Rig name and git URL validation

```go
// BEFORE: no format validation — Name and GitURL passed directly to exec.Command
args := []string{"rig", "add", req.Name, req.GitURL}

// AFTER: validate before use
if !isValidID(req.Name) {
    h.sendError(w, "Invalid rig name format", http.StatusBadRequest)
    return
}
if !isValidGitURL(req.GitURL) {
    h.sendError(w, "Git URL must be https://, git@, or owner/repo format", http.StatusBadRequest)
    return
}
```

### `internal/web/api.go` — 4 fixes across 4 handlers

#### Fix 4: Issue ID injection

```go
// BEFORE: issueID passed directly to bd show <issueID> --json
// --evil-flag would be interpreted as a flag by bd

// AFTER: reject non-identifier characters
if !isValidID(issueID) {
    h.sendError(w, "Invalid issue ID format", http.StatusBadRequest)
    return
}
```

#### Fix 5: Mail message ID injection

Same pattern as issue ID — "$(handleMailRead)" now validates "$(msgID)":

```go
if !isValidID(msgID) {
    h.sendError(w, "Invalid message ID format", http.StatusBadRequest)
    return
}
```

#### Fix 6: PR URL, number, and repo injection

```go
// BEFORE: prURL, number, repo passed directly to gh pr view
// number="--help" or repo="--repo=evil" would be interpreted as flags

// AFTER: type-appropriate validation for each parameter
if prURL != "" && !strings.HasPrefix(prURL, "https://") {
    h.sendError(w, "PR URL must start with https://", http.StatusBadRequest)
    return
}
if number != "" && !isNumeric(number) {
    h.sendError(w, "Invalid PR number format", http.StatusBadRequest)
    return
}
if repo != "" && !isValidRepoRef(repo) {
    h.sendError(w, "Invalid repo format (expected owner/repo)", http.StatusBadRequest)
    return
}
```

Note: PR number uses "$(isNumeric)" (digits-only) rather than "$(isValidID)" since PR numbers are strictly numeric.

#### Fix 7: Issue title/description length limits

```go
// BEFORE: no size limit — arbitrarily large payloads accepted
// AFTER: cap at reasonable sizes
const maxTitleLen = 500
const maxDescriptionLen = 100_000 // 100KB
if len(req.Title) > maxTitleLen {
    h.sendError(w, fmt.Sprintf("Title too long (max %d bytes)", maxTitleLen), http.StatusBadRequest)
    return
}
if len(req.Description) > maxDescriptionLen {
    h.sendError(w, fmt.Sprintf("Description too long (max %d bytes)", maxDescriptionLen), http.StatusBadRequest)
    return
}
```

Error messages say "bytes" (not "characters") because "$(len())" in Go measures bytes.

---

## False positive (not fixed)

**#4 "$(SanitizeArgs)" in "$(commands.go)"** — "$(strings.Map)" operates on runes (not bytes), so multi-byte UTF-8 is handled correctly. "$($)", "$(()", "$())" are all in the removal list so "$($())" is stripped. "$(exec.Command)" doesn't invoke a shell. No change needed.

---

## Out of scope

| Concern | Why deferred |
|---------|-------------|
| HTTP request body size limit | Needs "$(http.MaxBytesReader)" at middleware level — larger change |
| Other unvalidated handlers | This PR covers the 6 gaps from #1229 plus handleMailRead and handleRigAdd found during review |
| Non-"$(~/)" path traversal | "$(expandHomePath)" documents that non-"$(~)" paths get "$(filepath.Clean)" only; callers validate separately |

---

## Stats

- **3 files changed** (1 new), **+135 insertions**, **-14 deletions**
- **0 behavioral changes** for valid inputs
- **0 new dependencies**

## Test plan

All tests verified against a live temp-town dashboard instance (both workspace-mode and setup-mode).

### Rejection tests (malformed input → 400)

| # | Endpoint | Input | Expected | Result |
|---|----------|-------|----------|--------|
| 1 | POST /api/install | "$(~/../../etc/passwd)" | path escapes home directory | ✅ |
| 2 | GET /api/issues/show | "$(--malicious)" | Invalid issue ID format | ✅ |
| 3 | GET /api/pr/show | number="$(abc)" | Invalid PR number format | ✅ |
| 3b | GET /api/pr/show | number="$(1.2)" | Invalid PR number format | ✅ |
| 4 | POST /api/launch | port="$(99999)" | Port must be between 1 and 65534 | ✅ |
| 4b | POST /api/launch | port="$(-1)" | Port must be between 1 and 65534 | ✅ |
| 5 | GET /api/mail/read | "$(--help)" | Invalid message ID format | ✅ |
| 6 | GET /api/pr/show | repo="$(--evil/repo)" | Invalid repo format | ✅ |
| 7 | GET /api/pr/show | url="$(http://evil.com)" | PR URL must start with https:// | ✅ |
| 8 | POST /api/rig/add | name="$(--evil)" | Invalid rig name format | ✅ |
| 8b | POST /api/rig/add | gitUrl="$(ftp://evil.com)" | Git URL must be https://, git@, or owner/repo | ✅ |
| 9 | POST /api/check-workspace | "$(~/../../etc)" | path escapes home directory | ✅ |

### Acceptance tests (valid input → passes validation layer)

| # | Endpoint | Input | Result |
|---|----------|-------|--------|
| P1 | GET /api/issues/show | "$(ISSUE-123)" | ✅ Passed validation (failed downstream — no beads, expected) |
| P2 | GET /api/pr/show | number="$(42)", repo="$(steveyegge/gastown)" | ✅ Passed validation (failed downstream — no gh, expected) |
| P3 | GET /api/mail/read | "$(msg.001)" | ✅ Passed validation (failed downstream — no mail, expected) |
| P4 | POST /api/check-workspace | valid temp-town path | ✅ "$("Valid workspace with 0 rigs")" |
| P5 | POST /api/launch | port="$(3000)" | ✅ Passed validation (failed downstream — no dir, expected) |
| P6 | POST /api/check-workspace | "$(~)" | ✅ Expanded to home dir, checked workspace correctly |

### Automated tests

- [x] "$(go build ./...)" — compiles cleanly
- [x] "$(go vet ./...)" — no warnings
- [x] "$(go test -race -short ./internal/web/...)" — all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
