### PR TITLE
refinery: detect stale claims and orphaned MR branches

### DIFF
--- a/.beads/formulas/mol-witness-patrol.formula.toml
+++ b/.beads/formulas/mol-witness-patrol.formula.toml
@@ -20,6 +20,7 @@ title = 'Process pending cleanup wisps'
 
 [[steps]]
 description = "Ensure the refinery is alive and processing merge requests.\n\n```bash\n# Check if refinery session exists\ngt session status <rig>/refinery\n\n# Check for pending merge requests\nbd list --type=merge-request --status=open\n```\n\nIf MRs waiting AND refinery not running:\n```bash\ngt session start <rig>/refinery\ngt mail send <rig>/refinery -s \"PATROL: Wake up\" -m \"Merge requests in queue. Please process.\"\n```\n\nIf refinery running but queue stale (>30 min), send nudge."
+description = "Ensure the refinery is alive and processing merge requests.\n\n```bash\n# Check if refinery session exists\ngt session status <rig>/refinery\n\n# Check for pending merge requests\nbd list --type=merge-request --status=open\n\n# Check for stale claims / orphaned MR branches\ngt refinery ready <rig> --json\n```\n\nIf MRs waiting AND refinery not running:\n```bash\ngt session start <rig>/refinery\ngt mail send <rig>/refinery -s \"PATROL: Wake up\" -m \"Merge requests in queue. Please process.\"\n```\n\nIf `gt refinery ready --json` reports anomalies:\n- `stale-claim`: claimed MR not progressing for 2h+ (critical at 6h+)\n- `orphaned-branch`: MR branch missing locally and in `origin/*`\n\nEscalate anomalies to Deacon with MR IDs and branch names. If refinery is running but queue is stale (>30 min), send a nudge."
 id = 'check-refinery'
 needs = ['process-cleanups']
 title = 'Ensure refinery is alive'

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -704,6 +704,20 @@ func (g *Git) RemoteBranchExists(remote, branch string) (bool, error) {
 	return out != "", nil
 }
 
+// RemoteTrackingBranchExists checks if a remote-tracking branch ref exists locally
+// (e.g. refs/remotes/origin/main), without hitting the network.
+func (g *Git) RemoteTrackingBranchExists(remote, branch string) (bool, error) {
+	ref := fmt.Sprintf("refs/remotes/%s/%s", remote, branch)
+	_, err := g.run("show-ref", "--verify", "--quiet", ref)
+	if err != nil {
+		if strings.Contains(err.Error(), "exit status 1") {
+			return false, nil
+		}
+		return false, err
+	}
+	return true, nil
+}
+
 // DeleteBranch deletes a local branch.
 func (g *Git) DeleteBranch(name string, force bool) error {
 	flag := "-d"

--- a/internal/refinery/engineer_anomalies_test.go
+++ b/internal/refinery/engineer_anomalies_test.go
@@ -1,0 +1,96 @@
+package refinery
+
+import (
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func TestDetectQueueAnomalies_StaleClaimSeverity(t *testing.T) {
+	now := time.Date(2026, 2, 10, 12, 0, 0, 0, time.UTC)
+	issues := []*beads.Issue{
+		{
+			ID:        "gt-warn",
+			Status:    "open",
+			Assignee:  "rig/refinery-1",
+			UpdatedAt: now.Add(-3 * time.Hour).Format(time.RFC3339),
+			Description: `branch: polecat/warn
+target: main
+worker: nux`,
+		},
+		{
+			ID:        "gt-critical",
+			Status:    "open",
+			Assignee:  "rig/refinery-2",
+			UpdatedAt: now.Add(-7 * time.Hour).Format(time.RFC3339),
+			Description: `branch: polecat/critical
+target: main
+worker: nux`,
+		},
+	}
+
+	anomalies := detectQueueAnomalies(issues, now, func(branch string) (bool, bool, error) {
+		return true, false, nil
+	})
+
+	if len(anomalies) != 2 {
+		t.Fatalf("expected 2 anomalies, got %d", len(anomalies))
+	}
+	if anomalies[0].Type != "stale-claim" || anomalies[1].Type != "stale-claim" {
+		t.Fatalf("expected stale-claim anomalies, got %+v", anomalies)
+	}
+
+	got := map[string]string{}
+	for _, a := range anomalies {
+		got[a.ID] = a.Severity
+	}
+	if got["gt-warn"] != "warning" {
+		t.Fatalf("gt-warn severity = %q, want warning", got["gt-warn"])
+	}
+	if got["gt-critical"] != "critical" {
+		t.Fatalf("gt-critical severity = %q, want critical", got["gt-critical"])
+	}
+}
+
+func TestDetectQueueAnomalies_OrphanedBranch(t *testing.T) {
+	now := time.Date(2026, 2, 10, 12, 0, 0, 0, time.UTC)
+	issues := []*beads.Issue{
+		{
+			ID:        "gt-orphan",
+			Status:    "open",
+			UpdatedAt: now.Add(-30 * time.Minute).Format(time.RFC3339),
+			Description: `branch: polecat/orphan
+target: main
+worker: nux`,
+		},
+		{
+			ID:        "gt-ok",
+			Status:    "open",
+			UpdatedAt: now.Add(-30 * time.Minute).Format(time.RFC3339),
+			Description: `branch: polecat/ok
+target: main
+worker: nux`,
+		},
+	}
+
+	anomalies := detectQueueAnomalies(issues, now, func(branch string) (bool, bool, error) {
+		if branch == "polecat/orphan" {
+			return false, false, nil
+		}
+		return false, true, nil
+	})
+
+	if len(anomalies) != 1 {
+		t.Fatalf("expected 1 anomaly, got %d (%+v)", len(anomalies), anomalies)
+	}
+	if anomalies[0].Type != "orphaned-branch" {
+		t.Fatalf("anomaly type = %q, want orphaned-branch", anomalies[0].Type)
+	}
+	if anomalies[0].Severity != "critical" {
+		t.Fatalf("anomaly severity = %q, want critical", anomalies[0].Severity)
+	}
+	if anomalies[0].ID != "gt-orphan" {
+		t.Fatalf("anomaly ID = %q, want gt-orphan", anomalies[0].ID)
+	}
+}


### PR DESCRIPTION
## Summary
- add queue anomaly detection for open merge requests in refinery:
  - stale claims (warning at 2h, critical at 6h)
  - orphaned branches (missing local + missing `origin/*` tracking ref)
- surface anomaly outputs in `gt refinery ready` (human + JSON)
- add unit tests for anomaly classification

## Why
Issue #691 calls out deadlock risk from stale/orphaned merge requests. This adds deterministic patrol-visible outputs so Witness/Refinery workflows can escalate before the queue stalls.

## Validation
- `go test ./internal/refinery ./internal/git ./internal/cmd -run 'TestDetectQueueAnomalies|TestDefaultMergeQueueConfig|TestEngineer|TestParse'`

Closes #691.
