### PR TITLE
fix: complete type-to-label migration for mail queries

### DIFF
--- a/internal/beads/beads_channel.go
+++ b/internal/beads/beads_channel.go
@@ -400,7 +400,7 @@ func (b *Beads) EnforceChannelRetention(name string) error {
 
 	// Query messages in this channel (oldest first)
 	out, err := b.run("list",
-		"--type=message",
+		"--label=gt:message",
 		"--label=channel:"+name,
 		"--json",
 		"--limit=0",
@@ -471,7 +471,7 @@ func (b *Beads) PruneAllChannels() (int, error) {
 
 		// Get messages with timestamps
 		out, err := b.run("list",
-			"--type=message",
+			"--label=gt:message",
 			"--label=channel:"+name,
 			"--json",
 			"--limit=0",

--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -714,11 +714,10 @@ func sendHandoffMail(subject, message string) (string, error) {
 	// Mail goes to town-level beads (hq- prefix)
 	args := []string{
 		"create", subject,
-		"--type", "message",
 		"--assignee", agentID,
 		"-d", message,
 		"--priority", "2",
-		"--labels", labels,
+		"--labels", labels + ",gt:message",
 		"--actor", agentID,
 		"--ephemeral", // Handoff mail is ephemeral
 		"--silent",    // Output only the bead ID

--- a/internal/cmd/mail_announce.go
+++ b/internal/cmd/mail_announce.go
@@ -181,7 +181,7 @@ func listAnnounceMessages(townRoot, channelName string) ([]announceMessage, erro
 	// Query for messages with label announce_channel:<channel>
 	// Messages are stored with this label when sent via sendToAnnounce()
 	args := []string{"list",
-		"--type", "message",
+		"--label", "gt:message",
 		"--label", "announce_channel:" + channelName,
 		"--sort", "-created", // Newest first
 		"--limit", "0",       // No limit

--- a/internal/cmd/mail_channel.go
+++ b/internal/cmd/mail_channel.go
@@ -478,7 +478,7 @@ func listChannelMessages(townRoot, channelName string) ([]channelMessage, error)
 
 	// Query for messages with label channel:<name>
 	args := []string{"list",
-		"--type", "message",
+		"--label", "gt:message",
 		"--label", "channel:" + channelName,
 		"--sort", "-created",
 		"--limit", "0",

--- a/internal/cmd/mail_queue.go
+++ b/internal/cmd/mail_queue.go
@@ -168,7 +168,7 @@ func listUnclaimedQueueMessages(beadsDir, queueName string) ([]queueMessage, err
 	args := []string{"list",
 		"--label", "queue:" + queueName,
 		"--status", "open",
-		"--type", "message",
+		"--label", "gt:message",
 		"--json",
 		"--limit", "0",
 	}

--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -131,11 +131,12 @@ func (m *Mailbox) listFromDir(beadsDir string) ([]*Message, error) {
 		return nil, fmt.Errorf("ensuring custom types: %w", err)
 	}
 
-	// Single bd query: fetch all non-closed messages of type "message",
+	// Single bd query: fetch all messages with gt:message label,
 	// then filter client-side for assignee/CC match. Process-spawn overhead
 	// dominates query time, so 1 broad call beats N narrow calls.
+	// NOTE: Uses --label instead of --type per migration in 221ff022.
 	args := []string{"list",
-		"--type", "message",
+		"--label", "gt:message",
 		"--json",
 		"--limit", "0",
 	}


### PR DESCRIPTION
## Summary

- Completes the migration started in 221ff022 (type-based → label-based bead queries)
- The original commit migrated the **send side** but missed the **read side** in 6 files
- Messages were created as `type: task` (default) with `gt:message` label, but inbox/channel/queue queries filtered on `type: message` — finding nothing

## Changes

**Read side** — replace `--type message` with `--label gt:message`:
- `internal/mail/mailbox.go` — main inbox query (most critical)
- `internal/beads/beads_channel.go` — 2 channel message queries
- `internal/cmd/mail_channel.go` — channel listing
- `internal/cmd/mail_announce.go` — announce listing
- `internal/cmd/mail_queue.go` — queue listing

**Write side** — remove `--type message`, add `gt:message` to labels:
- `internal/cmd/handoff.go` — handoff mail creation

## Test plan

- [x] Sent mail to gleam/frank → verified message stored in HQ Dolt with correct assignee and gt:message label
- [x] Ran `gt mail check --json` as frank → confirmed `unread: 4` (was 0 before fix)
- [x] Ran `gt mail check --inject` as frank → confirmed all messages listed in notification
- [x] Verified cross-rig mail delivery (laser ↔ gleam)

Closes #1287

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>