### PR TITLE
Add gt doctor check for stale JSONL-sync hooks with Dolt backend

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -195,6 +195,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewHookAttachmentValidCheck())
 	d.Register(doctor.NewHookSingletonCheck())
 	d.Register(doctor.NewOrphanedAttachmentsCheck())
+	d.Register(doctor.NewDoltHooksCheck())
 
 	// Hooks sync check
 	d.Register(doctor.NewHooksSyncCheck())

--- a/internal/doctor/dolt_hooks_check.go
+++ b/internal/doctor/dolt_hooks_check.go
@@ -1,0 +1,158 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+// DoltHooksCheck detects stale JSONL-sync git hooks when the Dolt backend is active.
+// After migrating to Dolt via "bd migrate --to-dolt", old inline hooks that call
+// "bd sync --flush-only" (pre-commit) or "bd import -i" (post-merge) are pointless
+// and cause confusing errors. Shim hooks (containing "# bd-shim") are fine because
+// they delegate to "bd hooks run" which handles Dolt internally.
+//
+// Mirrors bd doctor's CheckGitHooksDoltCompatibility but covers both the town root
+// and all registered rigs.
+type DoltHooksCheck struct {
+	FixableCheck
+	stalePaths []string // directories with stale hooks, cached for Fix
+}
+
+// NewDoltHooksCheck creates a new Dolt hooks compatibility check.
+func NewDoltHooksCheck() *DoltHooksCheck {
+	return &DoltHooksCheck{
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "dolt-hooks-compat",
+				CheckDescription: "Detect stale JSONL-sync hooks when Dolt backend is active",
+				CheckCategory:    CategoryHooks,
+			},
+		},
+	}
+}
+
+// Markers matching beads/cmd/bd/doctor/git.go and beads/cmd/bd/init_git_hooks.go
+const (
+	bdShimMarker       = "# bd-shim"
+	bdInlineHookMarker = "# bd (beads)"
+)
+
+// beadsMetadata is a minimal struct for reading the backend field from metadata.json.
+type beadsMetadata struct {
+	Backend string `json:"backend"`
+}
+
+// readBeadsBackend reads metadata.json from beadsDir and returns the backend field.
+// Returns "" on any error (missing file, bad JSON, etc.).
+func readBeadsBackend(beadsDir string) string {
+	data, err := os.ReadFile(filepath.Join(beadsDir, "metadata.json")) //nolint:gosec // G304: path is constructed internally
+	if err != nil {
+		return ""
+	}
+	var meta beadsMetadata
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return ""
+	}
+	return meta.Backend
+}
+
+// isHookStaleDolt checks whether the post-merge hook in hooksDir is a stale
+// JSONL-sync hook that predates Dolt migration. Returns true if the hook should
+// be upgraded.
+//
+// Decision tree (mirrors bd doctor logic):
+//  1. No hook file → not stale
+//  2. Contains "# bd-shim" → OK (shim delegates to bd hooks run)
+//  3. Does NOT contain "# bd (beads)" AND does NOT contain "bd" → OK (not a bd hook)
+//  4. Contains both "backend" and "dolt" → OK (already has Dolt skip logic)
+//  5. Otherwise → stale
+func isHookStaleDolt(hooksDir string) bool {
+	content, err := os.ReadFile(filepath.Join(hooksDir, "post-merge")) //nolint:gosec // G304: path is constructed internally
+	if err != nil {
+		return false // no hook file
+	}
+	s := string(content)
+
+	if strings.Contains(s, bdShimMarker) {
+		return false // shim hooks handle Dolt internally
+	}
+	if !strings.Contains(s, bdInlineHookMarker) && !strings.Contains(s, "bd") {
+		return false // not a bd hook at all
+	}
+	if strings.Contains(s, "backend") && strings.Contains(s, "dolt") {
+		return false // already has Dolt-aware logic
+	}
+	return true
+}
+
+// Run checks the town root and all registered rigs for stale JSONL-sync hooks.
+func (c *DoltHooksCheck) Run(ctx *CheckContext) *CheckResult {
+	c.stalePaths = nil
+	var details []string
+
+	// 1. Check town root
+	townBeadsDir := beads.ResolveBeadsDir(ctx.TownRoot)
+	if readBeadsBackend(townBeadsDir) == "dolt" {
+		hooksDir := filepath.Join(ctx.TownRoot, ".git", "hooks")
+		if isHookStaleDolt(hooksDir) {
+			c.stalePaths = append(c.stalePaths, ctx.TownRoot)
+			details = append(details, "Town root has stale JSONL-sync hooks")
+		}
+	}
+
+	// 2. Check each registered rig
+	rigsPath := filepath.Join(ctx.TownRoot, "mayor", "rigs.json")
+	rigsCfg, err := loadRigsConfig(rigsPath)
+	if err == nil {
+		for rigName := range rigsCfg.Rigs {
+			rigPath := filepath.Join(ctx.TownRoot, rigName)
+			rigBeadsDir := beads.ResolveBeadsDir(rigPath)
+			if readBeadsBackend(rigBeadsDir) != "dolt" {
+				continue
+			}
+			hooksDir := filepath.Join(rigPath, ".git", "hooks")
+			if isHookStaleDolt(hooksDir) {
+				c.stalePaths = append(c.stalePaths, rigPath)
+				details = append(details, fmt.Sprintf("Rig %q has stale JSONL-sync hooks", rigName))
+			}
+		}
+	}
+
+	if len(c.stalePaths) == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "No stale JSONL-sync hooks found",
+		}
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusWarning,
+		Message: fmt.Sprintf("%d location(s) have stale JSONL-sync hooks with Dolt backend", len(c.stalePaths)),
+		Details: details,
+		FixHint: "Run 'gt doctor --fix' or 'bd hooks install --force' in each affected directory",
+	}
+}
+
+// Fix runs "bd hooks install --force" in each directory that was flagged during Run.
+func (c *DoltHooksCheck) Fix(ctx *CheckContext) error {
+	var errors []string
+	for _, dir := range c.stalePaths {
+		cmd := exec.Command("bd", "hooks", "install", "--force") // #nosec G204 - fixed command
+		cmd.Dir = dir
+		if output, err := cmd.CombinedOutput(); err != nil {
+			errors = append(errors, fmt.Sprintf("%s: %s (%v)", dir, strings.TrimSpace(string(output)), err))
+		}
+	}
+	if len(errors) > 0 {
+		return fmt.Errorf("failed to fix hooks: %s", strings.Join(errors, "; "))
+	}
+	return nil
+}

--- a/internal/doctor/dolt_hooks_check_test.go
+++ b/internal/doctor/dolt_hooks_check_test.go
@@ -1,0 +1,324 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// setupBeadsDir creates a .beads/metadata.json with the given backend.
+func setupBeadsDir(t *testing.T, dir, backend string) {
+	t.Helper()
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"backend":"` + backend + `"}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// setupHook creates a .git/hooks/post-merge file with the given content.
+func setupHook(t *testing.T, dir, content string) {
+	t.Helper()
+	hooksDir := filepath.Join(dir, ".git", "hooks")
+	if err := os.MkdirAll(hooksDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hooksDir, "post-merge"), []byte(content), 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// setupRigsJSON creates a mayor/rigs.json with the given rig names.
+func setupRigsJSON(t *testing.T, townRoot string, rigNames []string) {
+	t.Helper()
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	rigs := "{"
+	for i, name := range rigNames {
+		if i > 0 {
+			rigs += ","
+		}
+		rigs += `"` + name + `":{"git_url":"https://example.com/` + name + `.git","added_at":"2025-01-01T00:00:00Z"}`
+	}
+	rigs += "}"
+	content := `{"version":1,"rigs":` + rigs + `}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestDoltHooksCheck_NoBeadsDir(t *testing.T) {
+	townRoot := t.TempDir()
+	check := NewDoltHooksCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+
+	result := check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestDoltHooksCheck_BackendSqlite(t *testing.T) {
+	townRoot := t.TempDir()
+	setupBeadsDir(t, townRoot, "sqlite")
+	setupHook(t, townRoot, "#!/bin/sh\n# bd (beads) post-merge hook\nbd sync --import-only\n")
+
+	check := NewDoltHooksCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+
+	result := check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK for sqlite backend, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestDoltHooksCheck_DoltNoHooks(t *testing.T) {
+	townRoot := t.TempDir()
+	setupBeadsDir(t, townRoot, "dolt")
+	// No .git/hooks directory at all
+
+	check := NewDoltHooksCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+
+	result := check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when no hooks exist, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestDoltHooksCheck_DoltShimHook(t *testing.T) {
+	townRoot := t.TempDir()
+	setupBeadsDir(t, townRoot, "dolt")
+	setupHook(t, townRoot, "#!/bin/sh\n# bd-shim v1\nexec bd hooks run post-merge \"$@\"\n")
+
+	check := NewDoltHooksCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+
+	result := check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK for shim hook, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestDoltHooksCheck_DoltNonBdHook(t *testing.T) {
+	townRoot := t.TempDir()
+	setupBeadsDir(t, townRoot, "dolt")
+	setupHook(t, townRoot, "#!/bin/sh\n# Custom post-merge hook\necho 'merged'\n")
+
+	check := NewDoltHooksCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+
+	result := check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK for non-bd hook, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestDoltHooksCheck_DoltHookWithDoltSkipLogic(t *testing.T) {
+	townRoot := t.TempDir()
+	setupBeadsDir(t, townRoot, "dolt")
+	setupHook(t, townRoot, "#!/bin/sh\n# bd (beads) post-merge hook\n# Check backend\nif [ \"$backend\" = \"dolt\" ]; then exit 0; fi\nbd sync --import-only\n")
+
+	check := NewDoltHooksCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+
+	result := check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK for hook with Dolt skip logic, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestDoltHooksCheck_DoltStaleInlineHook(t *testing.T) {
+	townRoot := t.TempDir()
+	setupBeadsDir(t, townRoot, "dolt")
+	setupHook(t, townRoot, "#!/bin/sh\n# bd (beads) post-merge hook\nbd sync --import-only\n")
+
+	check := NewDoltHooksCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning for stale inline hook, got %v: %s", result.Status, result.Message)
+	}
+	if len(result.Details) == 0 {
+		t.Error("expected details about stale hooks")
+	}
+	if result.FixHint == "" {
+		t.Error("expected a fix hint")
+	}
+}
+
+func TestDoltHooksCheck_TownOKButRigStale(t *testing.T) {
+	townRoot := t.TempDir()
+
+	// Town root: sqlite backend (OK)
+	setupBeadsDir(t, townRoot, "sqlite")
+
+	// Set up a rig with dolt backend and stale hook
+	rigDir := filepath.Join(townRoot, "myrig")
+	setupBeadsDir(t, rigDir, "dolt")
+	setupHook(t, rigDir, "#!/bin/sh\n# bd (beads) post-merge hook\nbd sync --import-only\n")
+	setupRigsJSON(t, townRoot, []string{"myrig"})
+
+	check := NewDoltHooksCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning for stale rig hook, got %v: %s", result.Status, result.Message)
+	}
+	found := false
+	for _, d := range result.Details {
+		if d == `Rig "myrig" has stale JSONL-sync hooks` {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected detail mentioning rig 'myrig', got %v", result.Details)
+	}
+}
+
+func TestDoltHooksCheck_BothTownAndRigStale(t *testing.T) {
+	townRoot := t.TempDir()
+
+	// Town root: dolt + stale
+	setupBeadsDir(t, townRoot, "dolt")
+	setupHook(t, townRoot, "#!/bin/sh\n# bd (beads) post-merge hook\nbd sync --import-only\n")
+
+	// Rig: dolt + stale
+	rigDir := filepath.Join(townRoot, "rigA")
+	setupBeadsDir(t, rigDir, "dolt")
+	setupHook(t, rigDir, "#!/bin/sh\n# bd (beads) post-merge hook\nbd sync --import-only\n")
+	setupRigsJSON(t, townRoot, []string{"rigA"})
+
+	check := NewDoltHooksCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning, got %v: %s", result.Status, result.Message)
+	}
+	if len(result.Details) != 2 {
+		t.Errorf("expected 2 details (town + rig), got %d: %v", len(result.Details), result.Details)
+	}
+}
+
+func TestDoltHooksCheck_FixCachesStalePathsFromRun(t *testing.T) {
+	townRoot := t.TempDir()
+	setupBeadsDir(t, townRoot, "dolt")
+	setupHook(t, townRoot, "#!/bin/sh\n# bd (beads) post-merge hook\nbd sync --import-only\n")
+
+	check := NewDoltHooksCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+
+	// Run populates stalePaths
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning, got %v", result.Status)
+	}
+	if len(check.stalePaths) != 1 {
+		t.Fatalf("expected 1 stale path, got %d", len(check.stalePaths))
+	}
+	if check.stalePaths[0] != townRoot {
+		t.Errorf("expected stale path %q, got %q", townRoot, check.stalePaths[0])
+	}
+}
+
+func TestDoltHooksCheck_MultipleRigs(t *testing.T) {
+	townRoot := t.TempDir()
+
+	// No town-level beads
+	// Two rigs: one dolt+stale, one dolt+shim (OK)
+	rig1 := filepath.Join(townRoot, "rig1")
+	setupBeadsDir(t, rig1, "dolt")
+	setupHook(t, rig1, "#!/bin/sh\n# bd (beads) post-merge hook\nbd sync --import-only\n")
+
+	rig2 := filepath.Join(townRoot, "rig2")
+	setupBeadsDir(t, rig2, "dolt")
+	setupHook(t, rig2, "#!/bin/sh\n# bd-shim v1\nexec bd hooks run post-merge\n")
+
+	setupRigsJSON(t, townRoot, []string{"rig1", "rig2"})
+
+	check := NewDoltHooksCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning, got %v: %s", result.Status, result.Message)
+	}
+	if len(result.Details) != 1 {
+		t.Errorf("expected 1 detail (only rig1), got %d: %v", len(result.Details), result.Details)
+	}
+}
+
+// Test helpers
+
+func TestReadBeadsBackend(t *testing.T) {
+	t.Run("missing dir", func(t *testing.T) {
+		got := readBeadsBackend("/nonexistent/path/.beads")
+		if got != "" {
+			t.Errorf("expected empty, got %q", got)
+		}
+	})
+
+	t.Run("bad json", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "metadata.json"), []byte("not json"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		got := readBeadsBackend(dir)
+		if got != "" {
+			t.Errorf("expected empty for bad json, got %q", got)
+		}
+	})
+
+	t.Run("dolt", func(t *testing.T) {
+		dir := t.TempDir()
+		if err := os.WriteFile(filepath.Join(dir, "metadata.json"), []byte(`{"backend":"dolt"}`), 0644); err != nil {
+			t.Fatal(err)
+		}
+		got := readBeadsBackend(dir)
+		if got != "dolt" {
+			t.Errorf("expected 'dolt', got %q", got)
+		}
+	})
+}
+
+func TestIsHookStaleDolt(t *testing.T) {
+	tests := []struct {
+		name    string
+		content string
+		want    bool
+	}{
+		{"no hook", "", false},
+		{"shim hook", "#!/bin/sh\n# bd-shim v1\nexec bd hooks run post-merge\n", false},
+		{"non-bd hook", "#!/bin/sh\necho merged\n", false},
+		{"hook with dolt skip", "#!/bin/sh\n# bd (beads) post-merge\nif backend == dolt; then skip; fi\n", false},
+		{"stale inline hook", "#!/bin/sh\n# bd (beads) post-merge hook\nbd sync --import-only\n", true},
+		{"stale hook with bd but no marker", "#!/bin/sh\nbd import -i\n", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if tt.content != "" {
+				if err := os.MkdirAll(dir, 0755); err != nil {
+					t.Fatal(err)
+				}
+				if err := os.WriteFile(filepath.Join(dir, "post-merge"), []byte(tt.content), 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+			got := isHookStaleDolt(dir)
+			if got != tt.want {
+				t.Errorf("isHookStaleDolt() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

When users migrate to Dolt via `bd migrate --to-dolt`, the old inline git hooks installed by `bd init` still perform JSONL sync operations (`bd sync --flush-only` in pre-commit, `bd import -i` in post-merge). These are pointless with the Dolt backend and produce confusing errors. The existing `bd doctor` has `CheckGitHooksDoltCompatibility` for this, but users in a Gas Town workspace run `gt doctor`, not `bd doctor` — so the problem goes undetected. This is a common stumbling block during Dolt upgrades since people aren't used to running `bd doctor` directly.

This PR adds a new `dolt-hooks-compat` check to `gt doctor` that mirrors the bd logic, covering both the town root and all registered rigs.

## Changes

- Add `internal/doctor/dolt_hooks_check.go` — new `DoltHooksCheck` (fixable) that:
  - Reads `.beads/metadata.json` to detect Dolt backend
  - Inspects `.git/hooks/post-merge` for stale JSONL-sync patterns
  - Skips shim hooks (`# bd-shim`), non-bd hooks, and hooks with existing Dolt skip logic
  - Scans town root + all rigs from `mayor/rigs.json`, follows beads redirects
  - Auto-fix runs `bd hooks install --force` in each affected directory
- Add `internal/doctor/dolt_hooks_check_test.go` — 17 test cases covering all detection branches, multi-rig scenarios, and helper functions
- Register `NewDoltHooksCheck()` in `internal/cmd/doctor.go` alongside existing hook checks

## Testing

- [x] Unit tests pass (`go test ./internal/doctor/ -run TestDoltHooks -v` — 17/17 pass)
- [x] Full build succeeds (`go build ./...`)
- [x] `go vet ./internal/doctor/` clean

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)