### PR TITLE
fix: scan for dolt databases instead of hardcoding 'beads' subdir

### DIFF
--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -267,7 +267,7 @@ func TestFindLocalDoltDB(t *testing.T) {
 		}
 	})
 
-	t.Run("multiple databases returns first alphabetically with warning", func(t *testing.T) {
+	t.Run("multiple databases returns empty with warning", func(t *testing.T) {
 		beadsDir := t.TempDir()
 		doltParent := filepath.Join(beadsDir, "dolt")
 		// Create two valid dolt databases
@@ -292,10 +292,9 @@ func TestFindLocalDoltDB(t *testing.T) {
 		io.Copy(&buf, r)
 		os.Stderr = origStderr
 
-		// Should return the first alphabetically (beads_gt < beads_old)
-		expected := filepath.Join(doltParent, "beads_gt")
-		if result != expected {
-			t.Errorf("got %q, want %q", result, expected)
+		// Should fail closed on ambiguity — return empty string
+		if result != "" {
+			t.Errorf("expected empty string for ambiguous multi-candidate, got %q", result)
 		}
 		// Verify warning was emitted
 		if !strings.Contains(buf.String(), "multiple dolt databases found") {


### PR DESCRIPTION
## Summary

`FindMigratableDatabases` and `checkWorkspace` hardcoded `"beads"` as the subdirectory name under `.beads/dolt/`, but `bd migrate dolt` names it based on the beads prefix (e.g., `beads_hq`, `beads_gt`, `beads_bd`). This caused `gt dolt migrate` to miss real databases while picking up spurious empty directories from an earlier bd bug (fixed in beads PR #1670).

## Related Issue

Fixes #1296

## Changes

- Add `findLocalDoltDB(beadsDir string) string` helper that scans `.beads/dolt/*/` for any subdirectory containing `.dolt`, returning the full path
- Replace 3 hardcoded `filepath.Join(..., "dolt", "beads")` path constructions with `findLocalDoltDB` calls:
  - `FindMigratableDatabases` town-level check
  - `FindMigratableDatabases` per-rig check
  - `checkWorkspace` local data check (used by `gt doctor`)
- Update all test directory names from `dolt/beads` to realistic names (`beads_hq`, `beads_gt`, `beads_testrig`, etc.)
- Add `TestFindLocalDoltDB` with 4 subtests (no dolt dir, empty dolt dir, single database, non-.dolt files ignored)

## Testing

- [x] Unit tests pass (`go test ./internal/doltserver/ -v` — all 57 pass)
- [x] Manual testing performed
  - `gt dolt migrate` found and migrated all 3 databases (`beads_hq`, `beads_gt`, `beads_bd`)
  - `gt dolt status` shows all 3 databases with real data (17.1 MB after server compaction)
  - `gt doctor` — `dolt-metadata` and `dolt-server-reachable` both pass for all 3 rigs

## Checklist

- [x] Code follows project style
- [x] No breaking changes
- [x] Branch created per CONTRIBUTING.md (`fix/*` naming)