### PR TITLE
fix(doctor): exclude closed beads from stale-agent-beads detection

### DIFF
--- a/internal/doctor/stale_agent_beads_check.go
+++ b/internal/doctor/stale_agent_beads_check.go
@@ -94,7 +94,7 @@ func (c *StaleAgentBeadsCheck) Run(ctx *CheckContext) *CheckResult {
 		crewPrefix := fmt.Sprintf("%s-%s-crew-", prefix, rigName)
 		polecatPrefix := fmt.Sprintf("%s-%s-polecat-", prefix, rigName)
 		allBeads, err := bd.List(beads.ListOptions{
-			Status:   "all",
+			Status:   "open",
 			Priority: -1,
 			Label:    "gt:agent",
 		})


### PR DESCRIPTION
## Summary

The `stale-agent-beads` doctor check queries beads with `Status: "all"`, which includes closed beads. Since `gt doctor --fix` closes stale beads, they are immediately re-detected on the next run — causing `gt doctor` to perpetually report the same warnings.

## Related Issue

Introduced in #1036 — the fix method correctly closes stale beads, but the detection query includes closed beads, so closing never clears the warning.

## Changes

- Change `ListOptions.Status` from `"all"` to `"open"` in `StaleAgentBeadsCheck.Run()` so closed beads are excluded from detection

## Testing

- [x] Unit tests pass (`go test ./internal/doctor/ -run StaleAgent -v`)
- [x] Manual testing performed — `gt doctor` no longer re-reports beads that were already closed by `--fix`

## Checklist

- [x] Code follows the project's style guidelines
- [x] No documentation updates needed (behavior matches original intent)
- [x] No breaking changes

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)