### PR TITLE
fix: resolve polecat Dolt branch isolation gaps (sling + done)

### DIFF
--- a/internal/cmd/polecat_spawn.go
+++ b/internal/cmd/polecat_spawn.go
@@ -163,21 +163,11 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 			polecatName, err, rigName, polecatName)
 	}
 
-	// Branch-per-polecat: create a Dolt branch for write isolation.
-	// Each polecat writes to its own branch (zero contention).
-	// Merge to main happens at gt done time.
-	// This is a hard error: falling back to main causes all polecats to
-	// write to the same branch, triggering optimistic lock storms and
-	// potentially read-only mode under load (gt-lfc0d).
-	var doltBranch string
-	doltBranchName := doltserver.PolecatBranchName(polecatName)
-	if err := doltserver.CreatePolecatBranch(townRoot, rigName, doltBranchName); err != nil {
-		// Clean up the polecat since it can't safely operate without branch isolation
-		_ = polecatMgr.Remove(polecatName, true)
-		return nil, fmt.Errorf("creating Dolt branch for %s: %w\nHint: Dolt server may be overloaded — check 'gt dolt health'", polecatName, err)
-	}
-	doltBranch = doltBranchName
-	fmt.Printf("%s Dolt branch: %s\n", style.Bold.Render("✓"), doltBranch)
+	// Branch-per-polecat: generate name but DEFER creation to after sling writes.
+	// DOLT_BRANCH forks from HEAD, but BD_DOLT_AUTO_COMMIT=off means writes
+	// stay in working set. Caller must call CreateDoltBranch() after all writes
+	// are complete to flush the working set and create the branch.
+	doltBranch := doltserver.PolecatBranchName(polecatName)
 
 	// Get session manager for session name (session start is deferred)
 	polecatSessMgr := polecat.NewSessionManager(t, r)
@@ -291,6 +281,34 @@ func (s *SpawnedPolecatInfo) StartSession() (string, error) {
 
 	s.Pane = pane
 	return pane, nil
+}
+
+// CreateDoltBranch flushes the main working set to HEAD and creates the polecat's
+// Dolt branch. Must be called AFTER all sling writes (hook, formula, fields) so the
+// branch fork includes everything. This fixes the visibility gap where DOLT_BRANCH
+// forks from HEAD but BD_DOLT_AUTO_COMMIT=off leaves writes in working set only.
+//
+// On error, callers are responsible for cleaning up the spawned polecat (worktree,
+// agent bead) and unhooking any attached beads. See rollbackSlingArtifacts for the
+// standard cleanup pattern.
+func (s *SpawnedPolecatInfo) CreateDoltBranch() error {
+	if s.DoltBranch == "" {
+		return nil
+	}
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("not in a Gas Town workspace: %w", err)
+	}
+	// Flush main working set to HEAD so DOLT_BRANCH includes all sling writes
+	if err := doltserver.CommitServerWorkingSet(townRoot, s.RigName, "sling: flush for "+s.PolecatName); err != nil {
+		return fmt.Errorf("flushing working set for %s: %w", s.PolecatName, err)
+	}
+	// Create branch from now-committed HEAD (includes all writes)
+	if err := doltserver.CreatePolecatBranch(townRoot, s.RigName, s.DoltBranch); err != nil {
+		return fmt.Errorf("creating Dolt branch %s: %w", s.DoltBranch, err)
+	}
+	fmt.Printf("%s Dolt branch: %s\n", style.Bold.Render("✓"), s.DoltBranch)
+	return nil
 }
 
 // IsRigName checks if a target string is a rig name (not a role or path).

--- a/internal/cmd/sling_batch.go
+++ b/internal/cmd/sling_batch.go
@@ -191,12 +191,24 @@ func runBatchSling(beadIDs []string, rigName string, townBeadsDir string) error 
 			fmt.Printf("  %s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)
 		}
 
+		// Create Dolt branch AFTER all sling writes are complete.
+		// CommitWorkingSet flushes working set to HEAD, then CreatePolecatBranch
+		// forks from HEAD — ensuring the polecat's branch includes all writes.
+		if spawnInfo.DoltBranch != "" {
+			if err := spawnInfo.CreateDoltBranch(); err != nil {
+				fmt.Printf("  %s Could not create Dolt branch: %v, cleaning up...\n", style.Dim.Render("✗"), err)
+				rollbackSlingArtifacts(spawnInfo, beadToHook, hookWorkDir)
+				results = append(results, slingResult{beadID: beadID, polecat: spawnInfo.PolecatName, success: false})
+				continue
+			}
+		}
+
 		// Start polecat session now that molecule/bead is attached.
 		// This ensures polecat sees its work when gt prime runs on session start.
 		pane, err := spawnInfo.StartSession()
 		if err != nil {
 			fmt.Printf("  %s Could not start session: %v, cleaning up partial state...\n", style.Dim.Render("✗"), err)
-			cleanupSpawnedPolecat(spawnInfo, rigName)
+			rollbackSlingArtifacts(spawnInfo, beadToHook, hookWorkDir)
 			results = append(results, slingResult{beadID: beadID, polecat: spawnInfo.PolecatName, success: false})
 			continue
 		} else {

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1534,27 +1534,152 @@ func CreatePolecatBranch(townRoot, rigDB, branchName string) error {
 	return nil
 }
 
+// CommitServerWorkingSet stages all pending changes and commits them on the current branch via SQL.
+// This flushes the Dolt working set to HEAD so that DOLT_BRANCH (which forks from
+// HEAD, not the working set) will include all recent writes. Critical for the sling
+// flow where BD_DOLT_AUTO_COMMIT=off leaves writes in working set only.
+//
+// NOTE: This flushes ALL pending working set changes on the target branch, not just
+// those from a specific polecat. In batch sling, polecat B's flush may capture
+// polecat A's writes. This is benign because beads are keyed by unique ID, so
+// duplicate data across branches merges cleanly.
+func CommitServerWorkingSet(townRoot, rigDB, message string) error {
+	if err := doltSQLWithRecovery(townRoot, rigDB, "CALL DOLT_ADD('-A')"); err != nil {
+		return fmt.Errorf("staging working set in %s: %w", rigDB, err)
+	}
+	escaped := strings.ReplaceAll(message, "'", "''")
+	query := fmt.Sprintf("CALL DOLT_COMMIT('--allow-empty', '-m', '%s')", escaped)
+	if err := doltSQLWithRecovery(townRoot, rigDB, query); err != nil {
+		return fmt.Errorf("committing working set in %s: %w", rigDB, err)
+	}
+	return nil
+}
+
 // MergePolecatBranch merges a polecat's Dolt branch into main and deletes it.
 // Called at gt done time to make the polecat's beads changes visible.
-// Retries each step with exponential backoff on transient errors.
-// If read-only errors persist after retries, attempts server recovery (gt-chx92).
+//
+// CRITICAL: The entire operation runs as a single SQL script (one connection).
+// In Dolt server mode, each `dolt sql -q` call opens a new connection, and
+// DOLT_CHECKOUT only affects the current connection. Separate calls would
+// checkout the polecat branch on connection 1, then ADD/COMMIT on connection 2
+// (which defaults back to main), silently losing all polecat working set data.
+//
+// The script handles two scenarios:
+//  1. Fast-forward merge (no conflict): commit polecat working set, merge to main
+//  2. Conflict: disable autocommit, merge, resolve with --theirs (polecat wins), commit
+//
+// On conflict, a second script runs with autocommit disabled so conflicts can
+// be resolved rather than triggering an automatic rollback.
 func MergePolecatBranch(townRoot, rigDB, branchName string) error {
 	if err := validateBranchName(branchName); err != nil {
 		return fmt.Errorf("merging Dolt branch in %s: %w", rigDB, err)
 	}
-	// Checkout main, merge, delete branch — each as separate commands
-	// to avoid multi-statement parsing issues with dolt sql CLI.
-	if err := doltSQLWithRecovery(townRoot, rigDB, "CALL DOLT_CHECKOUT('main')"); err != nil {
-		return fmt.Errorf("checkout main in %s: %w", rigDB, err)
+
+	// Phase 1: Commit polecat working set and attempt merge.
+	// All in one connection so DOLT_CHECKOUT persists across statements.
+	// NOTE: DOLT_BRANCH('-D') is deliberately NOT in the merge scripts.
+	// If the merge fails (conflict), the branch must still exist for Phase 2.
+	// Branch deletion happens separately after successful merge.
+	escaped := strings.ReplaceAll(branchName, "'", "''")
+	script := fmt.Sprintf(`USE %s;
+CALL DOLT_CHECKOUT('%s');
+CALL DOLT_ADD('-A');
+CALL DOLT_COMMIT('--allow-empty', '-m', 'polecat %s final state');
+CALL DOLT_CHECKOUT('main');
+CALL DOLT_MERGE('%s');
+`, rigDB, escaped, escaped, escaped)
+
+	if err := doltSQLScriptWithRetry(townRoot, script); err != nil {
+		if !strings.Contains(err.Error(), "Merge conflict") {
+			return fmt.Errorf("merging %s to main in %s: %w", branchName, rigDB, err)
+		}
+
+		// Phase 2: Conflict detected. Re-run merge with autocommit disabled
+		// so conflicts are staged (not rolled back) and can be resolved.
+		// --theirs: polecat state wins (latest mutations, always authoritative).
+		fmt.Printf("Dolt merge conflict on %s, auto-resolving (--theirs)...\n", branchName)
+		conflictScript := fmt.Sprintf(`USE %s;
+SET @@autocommit = 0;
+CALL DOLT_CHECKOUT('main');
+CALL DOLT_MERGE('%s');
+CALL DOLT_CONFLICTS_RESOLVE('--theirs', '.');
+CALL DOLT_COMMIT('-m', 'merge %s (conflicts auto-resolved)');
+SET @@autocommit = 1;
+`, rigDB, escaped, escaped)
+
+		if err := doltSQLScriptWithRetry(townRoot, conflictScript); err != nil {
+			return fmt.Errorf("conflict-resolving merge of %s in %s: %w", branchName, rigDB, err)
+		}
 	}
-	if err := doltSQLWithRecovery(townRoot, rigDB, fmt.Sprintf("CALL DOLT_MERGE('%s')", branchName)); err != nil {
-		return fmt.Errorf("merging %s to main in %s: %w", branchName, rigDB, err)
+
+	// Delete branch only after successful merge (either phase).
+	// This prevents branch loss if the merge script fails partway through.
+	DeletePolecatBranch(townRoot, rigDB, branchName)
+	return nil
+}
+
+// doltSQLScript executes a multi-statement SQL script via a temp file.
+// Uses `dolt sql --file` for reliable multi-statement execution within a
+// single connection, preserving DOLT_CHECKOUT state across statements.
+func doltSQLScript(townRoot, script string) error {
+	config := DefaultConfig(townRoot)
+
+	tmpFile, err := os.CreateTemp("", "dolt-script-*.sql")
+	if err != nil {
+		return fmt.Errorf("creating temp SQL file: %w", err)
 	}
-	if err := doltSQLWithRecovery(townRoot, rigDB, fmt.Sprintf("CALL DOLT_BRANCH('-D', '%s')", branchName)); err != nil {
-		// Non-fatal: branch deletion failure doesn't lose data
-		fmt.Printf("Warning: could not delete Dolt branch %s: %v\n", branchName, err)
+	defer os.Remove(tmpFile.Name())
+
+	if _, err := tmpFile.WriteString(script); err != nil {
+		tmpFile.Close()
+		return fmt.Errorf("writing SQL script: %w", err)
+	}
+	tmpFile.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "dolt", "sql", "--file", tmpFile.Name())
+	cmd.Dir = config.DataDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%w (output: %s)", err, strings.TrimSpace(string(output)))
 	}
 	return nil
+}
+
+// doltSQLScriptWithRetry executes a SQL script with exponential backoff on transient errors.
+// Callers must ensure scripts are idempotent, as partial execution may have occurred
+// before the retry. Uses the same retry classification as doltSQLWithRetry but with
+// fewer retries and shorter backoff since multi-statement scripts are more expensive.
+func doltSQLScriptWithRetry(townRoot, script string) error {
+	const maxRetries = 3
+	const baseBackoff = 500 * time.Millisecond
+	const maxBackoff = 8 * time.Second
+
+	var lastErr error
+	for attempt := 1; attempt <= maxRetries; attempt++ {
+		if err := doltSQLScript(townRoot, script); err != nil {
+			lastErr = err
+			if !isDoltRetryableError(err) {
+				return err
+			}
+			if attempt < maxRetries {
+				backoff := baseBackoff
+				for i := 1; i < attempt; i++ {
+					backoff *= 2
+					if backoff > maxBackoff {
+						backoff = maxBackoff
+						break
+					}
+				}
+				time.Sleep(backoff)
+			}
+			continue
+		}
+		return nil
+	}
+	return fmt.Errorf("after %d retries: %w", maxRetries, lastErr)
 }
 
 // DeletePolecatBranch deletes a polecat's Dolt branch (cleanup/nuke).


### PR DESCRIPTION
## Summary

Fixes two related bugs where polecats lose beads data due to Dolt branch-per-polecat architecture interacting with `BD_DOLT_AUTO_COMMIT=off`:

- **Sling side**: `DOLT_BRANCH` forks from HEAD (committed state), but sling writes stay in working set with auto-commit off. Branch was created *before* writes, so polecats couldn't find their hooked work on startup. Fix: defer branch creation to after all writes, flush working set to HEAD first via new `CommitServerWorkingSet()`.

- **Done side**: `MergePolecatBranch` used separate `dolt sql -q` calls per step. In server mode, each call is a new connection and `DOLT_CHECKOUT` does not persist. The polecat branch working set was never committed (ADD/COMMIT ran on main instead). All MR beads were silently lost. Fix: rewrite as single SQL script via `dolt sql --file`. Adds two-phase merge: try ff first, fall back to `DOLT_CONFLICTS_RESOLVE('--theirs')` on conflict.

- **Race fix**: Refinery nudge deferred to after Dolt merge completes (was firing before, causing refinery to query main before MR bead was merged).

## Hardening (from review)

All 7 findings from the automated review plus 2 additional gaps from @ztbrown's review have been addressed:

- **Finding 1 (blocker)**: Added `CreateDoltBranch()` call to `runSlingFormula` path, which was missing. Formula-slung polecats would have written to main.
- **Finding 2 (blocker)**: Moved `DOLT_BRANCH('-D')` out of both Phase 1 and Phase 2 merge scripts. Branch deletion now happens as a separate step only after a successful merge.
- **Finding 3 (major)**: Added `doltSQLScriptWithRetry` (3 retries, exponential backoff, same error classification as existing `doltSQLWithRetry`). Merge scripts use this instead of raw `doltSQLScript`.
- **Finding 4 (major)**: Gated refinery nudge on merge success. If no polecat branch existed (crew worker), nudge still fires since MR bead is already on main.
- **Finding 5 (minor)**: Documented `CommitServerWorkingSet` flush-all behavior.
- **Finding 6 (minor)**: Replaced `cleanupSpawnedPolecat` with `rollbackSlingArtifacts` in all three inconsistent failure paths (see Finding 8 below for full scope).
- **Finding 7 (minor)**: Documented caller cleanup responsibilities on `CreateDoltBranch` error.
- **Finding 8 (@ztbrown review)**: Aligned all sling rollback paths to use `rollbackSlingArtifacts` — fixing 3 gaps where `cleanupSpawnedPolecat` (or missing rollback) left hooked beads orphaned on failure:
  - `sling_formula.go` `CreateDoltBranch` failure: `cleanupSpawnedPolecat` → `rollbackSlingArtifacts`
  - `sling_formula.go` `StartSession` failure: no rollback → `rollbackSlingArtifacts`
  - `sling_batch.go` `StartSession` failure: `cleanupSpawnedPolecat` → `rollbackSlingArtifacts`

## Files changed

| File | Change |
|------|--------|
| `internal/doltserver/doltserver.go` | Add `CommitServerWorkingSet()`, `doltSQLScript()`, `doltSQLScriptWithRetry()`, rewrite `MergePolecatBranch()` |
| `internal/doltserver/doltserver_test.go` | Tests for retry logic, error classification, merge script validation |
| `internal/cmd/polecat_spawn.go` | Defer branch creation, add `CreateDoltBranch()` method with cleanup docs |
| `internal/cmd/sling.go` | Insert branch creation after writes, add Dolt cleanup to rollback |
| `internal/cmd/sling_formula.go` | Add `CreateDoltBranch()` call with rollback on failure, add StartSession rollback |
| `internal/cmd/sling_batch.go` | Same fix for batch sling path, use full `rollbackSlingArtifacts` on all failures |
| `internal/cmd/done.go` | Defer refinery nudge to after successful Dolt merge |

## Test plan

- [x] `make build` compiles clean
- [x] `go vet ./...` no warnings
- [x] `go test ./internal/cmd/...` passes
- [x] `go test ./internal/doltserver/...` passes (includes new retry/merge tests)
- [x] Manual: `gt sling <bead> <rig>` polecat finds hooked work on startup
- [x] Manual: polecat `gt done` MR bead visible to refinery
- [x] Manual: merge conflict auto-resolved with --theirs
- [x] Manual: refinery processes MR, runs tests, merges to main