### PR TITLE
fix: cross-rig routing in Beads.Show() and dolt prefix detection on adopt

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -423,6 +423,14 @@ func (b *Beads) ReadyWithType(issueType string) ([]*Issue, error) {
 
 // Show returns detailed information about an issue.
 func (b *Beads) Show(id string) (*Issue, error) {
+	// Route cross-rig queries via routes.jsonl so that rig-level bead IDs
+	// (e.g., "gt-abc123") resolve to the correct rig database.
+	targetDir := ResolveRoutingTarget(b.getTownRoot(), id, b.getResolvedBeadsDir())
+	if targetDir != b.getResolvedBeadsDir() {
+		target := NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
+		return target.Show(id)
+	}
+
 	out, err := b.run("show", id, "--json")
 	if err != nil {
 		return nil, err

--- a/internal/cmd/beads_db_init_test.go
+++ b/internal/cmd/beads_db_init_test.go
@@ -241,12 +241,7 @@ func TestBeadsDbInitAfterClone(t *testing.T) {
 
 	t.Run("TrackedRepoWithPrefixMismatchErrors", func(t *testing.T) {
 		// Test that when --prefix is explicitly provided but doesn't match
-		// the prefix detected from config.yaml, gt rig add fails with an error.
-		// Skip: gt rig add --adopt doesn't detect prefix mismatch with dolt backend.
-		// With dolt, metadata.json and dolt/ survive clone, but adopt ignores the
-		// existing prefix in the database. Fix in rig.go adopt logic.
-		// Tracked: https://github.com/steveyegge/gastown/issues/1306
-		t.Skip("gt rig add --adopt prefix mismatch detection not yet implemented for dolt backend (#1306)")
+		// the prefix detected from the database, gt rig add fails with an error.
 
 		townRoot := filepath.Join(tmpDir, "town-mismatch")
 

--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -661,35 +661,65 @@ func runRigAdopt(_ *cobra.Command, args []string) error {
 			continue
 		}
 
-		// Detect prefix from issues.jsonl (prefix is stored in DB, not config.yaml)
-		jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
-		if f, readErr := os.Open(jsonlPath); readErr == nil {
-			scanner := bufio.NewScanner(f)
-			if scanner.Scan() {
-				var issue struct {
-					ID string `json:"id"`
-				}
-				if json.Unmarshal(scanner.Bytes(), &issue) == nil && issue.ID != "" {
-					// Extract prefix: everything before the last "-" segment
-					if lastDash := strings.LastIndex(issue.ID, "-"); lastDash > 0 {
-						detected := issue.ID[:lastDash]
-						if detected != "" && rigAddPrefix != "" {
-							if strings.TrimSuffix(rigAddPrefix, "-") != detected {
-								f.Close()
-								return fmt.Errorf("prefix mismatch: source repo uses '%s' but --prefix '%s' was provided", detected, rigAddPrefix)
-							}
+		// Detect prefix: try dolt backend first, fall back to issues.jsonl.
+		// With dolt, metadata.json and the database survive clone, so we can
+		// query the prefix directly via "bd config get issue_prefix".
+		prefixDetected := false
+		metadataPath := filepath.Join(beadsDir, "metadata.json")
+		if metaBytes, readErr := os.ReadFile(metadataPath); readErr == nil {
+			var meta struct {
+				Backend string `json:"backend"`
+			}
+			if json.Unmarshal(metaBytes, &meta) == nil && meta.Backend == "dolt" {
+				workDir := filepath.Dir(beadsDir)
+				bdCmd := exec.Command("bd", "config", "get", "issue_prefix")
+				bdCmd.Dir = workDir
+				if out, bdErr := bdCmd.Output(); bdErr == nil {
+					detected := strings.TrimSpace(string(out))
+					if detected != "" {
+						if rigAddPrefix != "" && strings.TrimSuffix(rigAddPrefix, "-") != detected {
+							return fmt.Errorf("prefix mismatch: source repo uses '%s' but --prefix '%s' was provided", detected, rigAddPrefix)
 						}
-						if detected != "" && result.BeadsPrefix == "" {
+						if result.BeadsPrefix == "" {
 							result.BeadsPrefix = detected
 						}
+						prefixDetected = true
 					}
 				}
 			}
-			f.Close()
+		}
+
+		// Fall back to issues.jsonl for non-dolt backends or if dolt detection failed
+		if !prefixDetected {
+			jsonlPath := filepath.Join(beadsDir, "issues.jsonl")
+			if f, readErr := os.Open(jsonlPath); readErr == nil {
+				scanner := bufio.NewScanner(f)
+				if scanner.Scan() {
+					var issue struct {
+						ID string `json:"id"`
+					}
+					if json.Unmarshal(scanner.Bytes(), &issue) == nil && issue.ID != "" {
+						// Extract prefix: everything before the last "-" segment
+						if lastDash := strings.LastIndex(issue.ID, "-"); lastDash > 0 {
+							detected := issue.ID[:lastDash]
+							if detected != "" && rigAddPrefix != "" {
+								if strings.TrimSuffix(rigAddPrefix, "-") != detected {
+									f.Close()
+									return fmt.Errorf("prefix mismatch: source repo uses '%s' but --prefix '%s' was provided", detected, rigAddPrefix)
+								}
+							}
+							if detected != "" && result.BeadsPrefix == "" {
+								result.BeadsPrefix = detected
+							}
+						}
+					}
+				}
+				f.Close()
+			}
 		}
 
 		// Init database if metadata.json is missing (DB files are gitignored)
-		metadataPath := filepath.Join(beadsDir, "metadata.json")
+		metadataPath = filepath.Join(beadsDir, "metadata.json")
 		if _, err := os.Stat(metadataPath); os.IsNotExist(err) {
 			prefix := result.BeadsPrefix
 			if prefix == "" {


### PR DESCRIPTION
## Summary
Fix two gaps in gastown's dolt backend support that were exposed by the integration test migration (PR #1304). Both were straightforward wiring — the infrastructure already existed, it just needed to be connected.

## Related Issue
Fixes #1305, Fixes #1306

## Changes
- **`internal/beads/beads.go`**: Wire `ResolveRoutingTarget` into `Beads.Show()` so cross-rig bead IDs (e.g., `gt-abc` queried from town root) route to the correct rig database via `routes.jsonl`, matching the pattern already used 4 times in `beads_agent.go`
- **`internal/cmd/rig.go`**: Add dolt backend detection to rig adopt logic — when `metadata.json` indicates `backend: "dolt"`, query prefix directly via `bd config get issue_prefix` instead of relying on `issues.jsonl` (which doesn't exist with dolt). Falls through to `issues.jsonl` for non-dolt backends
- **`internal/cmd/beads_routing_integration_test.go`**: Remove `crossRig` skip/field, add `mayor/town.json` to test setup so `FindTownRoot()` works
- **`internal/cmd/beads_db_init_test.go`**: Remove `t.Skip` from `TrackedRepoWithPrefixMismatchErrors`

## Testing
- [x] Unit tests pass (`go test -short ./internal/beads/... ./internal/cmd/...`)
- [x] Both previously-skipped integration tests pass:
  - `TestBeadsRoutingFromTownRoot` — all 3 subtests (hq, gt, tr) pass
  - `TestBeadsDbInitAfterClone/TrackedRepoWithPrefixMismatchErrors` — passes
- [x] Full integration suite passes with no regressions (`go test -tags=integration -timeout=5m ./internal/cmd/...`)

## Checklist
- [x] Code follows project style
- [x] No breaking changes
- [x] No new documentation needed (code-only fix)