### PR TITLE
chore(brew): add tmux as recommended Homebrew dependency

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,6 +109,8 @@ jobs:
             version "${{ steps.release.outputs.version }}"
             license "MIT"
 
+            depends_on "tmux" => :recommended
+
             on_macos do
               if Hardware::CPU.arm?
                 url "https://github.com/steveyegge/gastown/releases/download/v#{version}/gastown_#{version}_darwin_arm64.tar.gz"


### PR DESCRIPTION
## Summary
- Adds `depends_on "tmux" => :recommended` to the Homebrew formula generated in the release workflow
- Gas Town uses tmux for multi-agent session management but has explicit degraded-mode support without it (`IsAvailable()` checks, degraded daemon mode, optional crew sessions)
- Using `:recommended` means `brew install gt` pulls in tmux by default, but users can opt out with `--without-tmux`

## Test plan
- [ ] Verify the generated formula is valid Ruby by inspecting the heredoc output in a dry-run
- [ ] Confirm `brew install gt` on a clean system installs tmux alongside gt
- [ ] Confirm `brew install gt --without-tmux` skips tmux and gt still runs in degraded mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)