### PR TITLE
fix: use IsAgentAlive in mayor attach to check descendant processes

### DIFF
--- a/internal/cmd/mayor.go
+++ b/internal/cmd/mayor.go
@@ -172,13 +172,11 @@ func runMayorAttach(cmd *cobra.Command, args []string) error {
 			return err
 		}
 	} else {
-		// Session exists - check if runtime is still running (hq-95xfq)
-		// If runtime exited or sitting at shell, restart with proper context
-		agentCfg, _, err := config.ResolveAgentConfigWithOverride(townRoot, townRoot, mayorAgentOverride)
-		if err != nil {
-			return fmt.Errorf("resolving agent: %w", err)
-		}
-		if !t.IsAgentRunning(sessionID, config.ExpectedPaneCommands(agentCfg)...) {
+		// Session exists - check if runtime is still running (hq-95xfq, gt-7zl)
+		// If runtime exited or sitting at shell, restart with proper context.
+		// Use IsAgentAlive (checks descendant processes) instead of IsAgentRunning
+		// (pane command only), since mayor launches via bash wrapper.
+		if !t.IsAgentAlive(sessionID) {
 			// Runtime has exited, restart it with proper context
 			fmt.Println("Runtime exited, restarting with context...")
 


### PR DESCRIPTION
## Summary

- Replace `IsAgentRunning` with `IsAgentAlive` in `runMayorAttach()` so mayor attach correctly detects a running mayor session
- Remove unused `agentCfg` resolution that was only needed for `IsAgentRunning`

`IsAgentRunning` only checks the pane command, but mayor launches via `bash -c '... && claude ...'`, so the pane command is always `bash`. This causes `gt may at` to kill+restart a healthy session. `IsAgentAlive` checks descendant processes, matching what `Manager.Start()` already uses.

Closes #1314

## Test plan

- [ ] Start mayor session: `gt may up`
- [ ] Verify `gt may at` attaches without restarting
- [ ] Verify `gt may at` still restarts if mayor runtime has actually exited (kill claude process, then attach)

🤖 Generated with [Claude Code](https://claude.com/claude-code)