### PR TITLE
fix(doctor): continue on error in agent/rig bead fix methods

### DIFF
--- a/internal/doctor/rig_beads_check.go
+++ b/internal/doctor/rig_beads_check.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
@@ -141,7 +142,9 @@ func (c *RigBeadsCheck) Fix(ctx *CheckContext) error {
 		return nil // No rigs to process
 	}
 
-	// Create missing rig identity beads
+	// Create missing rig identity beads — collect errors instead of failing
+	// on first so one broken rig doesn't block fixes for others.
+	var errs []error
 	for rigName, info := range rigSet {
 		rigBeadsPath := filepath.Join(ctx.TownRoot, info.beadsPath)
 		bd := beads.New(rigBeadsPath)
@@ -163,10 +166,10 @@ func (c *RigBeadsCheck) Fix(ctx *CheckContext) error {
 			}
 
 			if _, err := bd.CreateRigBead(rigName, fields); err != nil {
-				return fmt.Errorf("creating %s: %w", rigBeadID, err)
+				errs = append(errs, fmt.Errorf("creating %s: %w", rigBeadID, err))
 			}
 		}
 	}
 
-	return nil
+	return errors.Join(errs...)
 }


### PR DESCRIPTION
## Summary
- `AgentBeadsCheck.Fix()` and `RigBeadsCheck.Fix()` now collect errors using `errors.Join()` instead of returning on first failure
- One broken rig (locked DB, missing types) no longer blocks fixes for all other rigs

## Problem
In a multi-rig environment, `gt doctor --fix` for agent-beads-exist and rig-beads-exist would stop at the first rig that errored (e.g., locked Dolt database). All subsequent rigs were silently skipped.

## Test plan
- [ ] Run `gt doctor --fix` in a multi-rig town with one rig's DB locked
- [ ] Verify other rigs' beads are still created successfully
- [ ] Verify all errors are reported at the end

Fixes #1317