### PR TITLE
web: stop swallowing bd show failures in convoy fetcher

### DIFF
--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -19,7 +19,6 @@ import (
 	"github.com/steveyegge/gastown/internal/workspace"
 )
 
-
 // runCmd executes a command with a timeout and returns stdout.
 // Returns empty buffer on timeout or error.
 // Security: errors from this function are logged server-side only (via log.Printf
@@ -41,6 +40,8 @@ func runCmd(timeout time.Duration, name string, args ...string) (*bytes.Buffer, 
 	}
 	return &stdout, nil
 }
+
+var fetcherRunCmd = runCmd
 
 // runBdCmd executes a bd command with the configured cmdTimeout in the specified beads directory.
 func (f *LiveConvoyFetcher) runBdCmd(beadsDir string, args ...string) (*bytes.Buffer, error) {
@@ -105,11 +106,11 @@ func NewLiveConvoyFetcher() (*LiveConvoyFetcher, error) {
 	}
 
 	return &LiveConvoyFetcher{
-		townRoot:       townRoot,
-		townBeads:      filepath.Join(townRoot, ".beads"),
-		cmdTimeout:     config.ParseDurationOrDefault(webCfg.CmdTimeout, 15*time.Second),
-		ghCmdTimeout:   config.ParseDurationOrDefault(webCfg.GhCmdTimeout, 10*time.Second),
-		tmuxCmdTimeout: config.ParseDurationOrDefault(webCfg.TmuxCmdTimeout, 2*time.Second),
+		townRoot:                townRoot,
+		townBeads:               filepath.Join(townRoot, ".beads"),
+		cmdTimeout:              config.ParseDurationOrDefault(webCfg.CmdTimeout, 15*time.Second),
+		ghCmdTimeout:            config.ParseDurationOrDefault(webCfg.GhCmdTimeout, 10*time.Second),
+		tmuxCmdTimeout:          config.ParseDurationOrDefault(webCfg.TmuxCmdTimeout, 2*time.Second),
 		staleThreshold:          config.ParseDurationOrDefault(workerCfg.StaleThreshold, 5*time.Minute),
 		stuckThreshold:          config.ParseDurationOrDefault(workerCfg.StuckThreshold, 30*time.Minute),
 		heartbeatFreshThreshold: config.ParseDurationOrDefault(workerCfg.HeartbeatFreshThreshold, 5*time.Minute),
@@ -269,7 +270,10 @@ func (f *LiveConvoyFetcher) getTrackedIssues(convoyID string) ([]trackedIssueInf
 	}
 
 	// Batch fetch issue details
-	details := f.getIssueDetailsBatch(issueIDs)
+	details, err := f.getIssueDetailsBatch(issueIDs)
+	if err != nil {
+		return nil, fmt.Errorf("fetching tracked issue details for %s: %w", convoyID, err)
+	}
 
 	// Get worker activity from tmux sessions based on assignees
 	workers := f.getWorkersFromAssignees(details)
@@ -309,18 +313,18 @@ type issueDetail struct {
 }
 
 // getIssueDetailsBatch fetches details for multiple issues.
-func (f *LiveConvoyFetcher) getIssueDetailsBatch(issueIDs []string) map[string]*issueDetail {
+func (f *LiveConvoyFetcher) getIssueDetailsBatch(issueIDs []string) (map[string]*issueDetail, error) {
 	result := make(map[string]*issueDetail)
 	if len(issueIDs) == 0 {
-		return result
+		return result, nil
 	}
 
 	args := append([]string{"show"}, issueIDs...)
 	args = append(args, "--json")
 
-	stdout, err := runCmd(f.cmdTimeout, "bd", args...)
+	stdout, err := fetcherRunCmd(f.cmdTimeout, "bd", args...)
 	if err != nil {
-		return result
+		return nil, fmt.Errorf("bd show failed (issue_count=%d): %w", len(issueIDs), err)
 	}
 
 	var issues []struct {
@@ -331,7 +335,7 @@ func (f *LiveConvoyFetcher) getIssueDetailsBatch(issueIDs []string) map[string]*
 		UpdatedAt string `json:"updated_at"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil {
-		return result
+		return nil, fmt.Errorf("bd show returned invalid JSON (issue_count=%d): %w", len(issueIDs), err)
 	}
 
 	for _, issue := range issues {
@@ -350,7 +354,7 @@ func (f *LiveConvoyFetcher) getIssueDetailsBatch(issueIDs []string) map[string]*
 		result[issue.ID] = detail
 	}
 
-	return result
+	return result, nil
 }
 
 // workerDetail holds worker info including last activity.

--- a/internal/web/fetcher_error_reporting_test.go
+++ b/internal/web/fetcher_error_reporting_test.go
@@ -1,0 +1,84 @@
+package web
+
+import (
+	"bytes"
+	"errors"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGetIssueDetailsBatch_ReturnsStructuredErrorOnCommandFailure(t *testing.T) {
+	original := fetcherRunCmd
+	t.Cleanup(func() {
+		fetcherRunCmd = original
+	})
+
+	fetcherRunCmd = func(_ time.Duration, _ string, _ ...string) (*bytes.Buffer, error) {
+		return nil, errors.New("boom")
+	}
+
+	f := &LiveConvoyFetcher{cmdTimeout: 100 * time.Millisecond}
+	_, err := f.getIssueDetailsBatch([]string{"gt-1", "gt-2"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "bd show failed") {
+		t.Fatalf("expected structured failure context, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "issue_count=2") {
+		t.Fatalf("expected issue count in error, got: %v", err)
+	}
+}
+
+func TestGetIssueDetailsBatch_ReturnsStructuredErrorOnInvalidJSON(t *testing.T) {
+	original := fetcherRunCmd
+	t.Cleanup(func() {
+		fetcherRunCmd = original
+	})
+
+	fetcherRunCmd = func(_ time.Duration, _ string, _ ...string) (*bytes.Buffer, error) {
+		return bytes.NewBufferString("{invalid"), nil
+	}
+
+	f := &LiveConvoyFetcher{cmdTimeout: 100 * time.Millisecond}
+	_, err := f.getIssueDetailsBatch([]string{"gt-9"})
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !strings.Contains(err.Error(), "invalid JSON") {
+		t.Fatalf("expected parse context, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "issue_count=1") {
+		t.Fatalf("expected issue count in error, got: %v", err)
+	}
+}
+
+func TestGetIssueDetailsBatch_ParsesIssueDetails(t *testing.T) {
+	original := fetcherRunCmd
+	t.Cleanup(func() {
+		fetcherRunCmd = original
+	})
+
+	fetcherRunCmd = func(_ time.Duration, _ string, _ ...string) (*bytes.Buffer, error) {
+		return bytes.NewBufferString(`[
+			{"id":"gt-1","title":"One","status":"open","assignee":"rig/polecats/a","updated_at":"2026-02-01T12:00:00Z"},
+			{"id":"gt-2","title":"Two","status":"closed","assignee":"","updated_at":"2026-02-01T12:01:00Z"}
+		]`), nil
+	}
+
+	f := &LiveConvoyFetcher{cmdTimeout: 100 * time.Millisecond}
+	details, err := f.getIssueDetailsBatch([]string{"gt-1", "gt-2"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(details) != 2 {
+		t.Fatalf("expected 2 details, got %d", len(details))
+	}
+	if details["gt-1"] == nil || details["gt-1"].Title != "One" {
+		t.Fatalf("unexpected parsed details for gt-1: %#v", details["gt-1"])
+	}
+	if details["gt-2"] == nil || details["gt-2"].Status != "closed" {
+		t.Fatalf("unexpected parsed details for gt-2: %#v", details["gt-2"])
+	}
+}


### PR DESCRIPTION
## Problem
Fixes #1231. `internal/web/fetcher.go` silently dropped critical `bd show` failures by returning empty issue details, hiding failure states in dashboard data.

## What Changed
- Changed `getIssueDetailsBatch` to return `(map[string]*issueDetail, error)`.
- Added structured error context (`bd show failed` / `invalid JSON`, `issue_count=<n>`).
- Propagated batch-fetch failures through `getTrackedIssues` instead of silently continuing.
- Added focused tests for command failure, invalid JSON, and successful parsing.

## Validation
- `go test ./internal/web -run 'TestGetIssueDetailsBatch'`
  - Passed
