### PR TITLE
fix: fail fast on config errors in polecat spawn retry loop (gt-2ra)

### DIFF
--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -555,6 +555,7 @@ func isHookedAgentDead(assignee string) bool {
 
 // hookBeadWithRetry hooks a bead to a target agent with exponential backoff retry
 // and post-hook verification. This ensures the hook sticks even under Dolt concurrency.
+// Fails fast on configuration/initialization errors (gt-2ra).
 // See: https://github.com/steveyegge/gastown/issues/148
 func hookBeadWithRetry(beadID, targetAgent, hookDir string) error {
 	const maxRetries = 10
@@ -569,6 +570,10 @@ func hookBeadWithRetry(beadID, targetAgent, hookDir string) error {
 		hookCmd.Stderr = os.Stderr
 		if err := hookCmd.Run(); err != nil {
 			lastErr = err
+			// Fail fast on config/init errors — retrying won't help (gt-2ra)
+			if isSlingConfigError(err) {
+				return fmt.Errorf("hooking bead failed (DB not initialized — not retrying): %w", err)
+			}
 			if attempt < maxRetries {
 				backoff := slingBackoff(attempt, baseBackoff, maxBackoff)
 				fmt.Printf("%s Hook attempt %d failed, retrying in %v...\n", style.Warning.Render("⚠"), attempt, backoff)
@@ -630,4 +635,21 @@ func slingBackoff(attempt int, base, max time.Duration) time.Duration { //nolint
 		result = max
 	}
 	return result
+}
+
+// isSlingConfigError returns true if the error indicates a configuration or
+// initialization problem rather than a transient failure. Config errors should
+// NOT be retried because they will fail identically on every attempt (gt-2ra).
+func isSlingConfigError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "not initialized") ||
+		strings.Contains(msg, "no such table") ||
+		strings.Contains(msg, "table not found") ||
+		strings.Contains(msg, "issue_prefix") ||
+		strings.Contains(msg, "no database") ||
+		strings.Contains(msg, "database not found") ||
+		strings.Contains(msg, "connection refused")
 }

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -67,6 +67,25 @@ func isDoltOptimisticLockError(err error) bool {
 		strings.Contains(msg, "cannot update manifest")
 }
 
+// isDoltConfigError returns true if the error indicates a configuration or initialization
+// problem rather than a transient failure. Config errors should NOT be retried because
+// they will fail identically on every attempt, wasting ~3 minutes in the retry loop.
+// See gt-2ra: polecat spawn hang when Dolt DB not initialized.
+func isDoltConfigError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "not initialized") ||
+		strings.Contains(msg, "no such table") ||
+		strings.Contains(msg, "table not found") ||
+		strings.Contains(msg, "issue_prefix") ||
+		strings.Contains(msg, "no database") ||
+		strings.Contains(msg, "database not found") ||
+		strings.Contains(msg, "connection refused") ||
+		strings.Contains(msg, "configure custom types")
+}
+
 // Common errors
 var (
 	ErrPolecatExists      = errors.New("polecat already exists")
@@ -175,6 +194,7 @@ func (m *Manager) lockPool() (*flock.Flock, error) {
 // Returns an error if Dolt exists but is unhealthy after retries.
 // Returns nil if beads is not configured (test/setup environments).
 // If read-only errors persist after retries, attempts server recovery (gt-chx92).
+// Fails fast on configuration/initialization errors (gt-2ra).
 func (m *Manager) CheckDoltHealth() error {
 	var lastErr error
 	for attempt := 1; attempt <= doltMaxRetries; attempt++ {
@@ -191,6 +211,10 @@ func (m *Manager) CheckDoltHealth() error {
 		// If beads isn't configured at all, skip the health check
 		if strings.Contains(err.Error(), "does not exist") || errors.Is(err, beads.ErrNotInstalled) {
 			return nil
+		}
+		// Fail fast on config/init errors — retrying won't help (gt-2ra)
+		if isDoltConfigError(err) {
+			return fmt.Errorf("%w: DB not initialized (not retrying): %v", ErrDoltUnhealthy, err)
 		}
 		lastErr = err
 		if attempt < doltMaxRetries {
@@ -249,6 +273,8 @@ func (m *Manager) CheckDoltServerCapacity() error {
 // and fails hard — a polecat without an agent bead is untrackable.
 // If beads is not configured (no .beads directory), warns and returns nil
 // since this indicates a test/setup environment, not a Dolt failure.
+// Fails fast on configuration/initialization errors (gt-2ra) — these are not
+// transient and retrying them wastes ~3 minutes for identical failures.
 func (m *Manager) createAgentBeadWithRetry(agentID string, fields *beads.AgentFields) error {
 	var lastErr error
 	for attempt := 1; attempt <= doltMaxRetries; attempt++ {
@@ -261,6 +287,10 @@ func (m *Manager) createAgentBeadWithRetry(agentID string, fields *beads.AgentFi
 		if strings.Contains(err.Error(), "does not exist") || errors.Is(err, beads.ErrNotInstalled) {
 			fmt.Printf("Warning: could not create agent bead (beads not configured): %v\n", err)
 			return nil
+		}
+		// Fail fast on config/init errors — retrying won't help (gt-2ra)
+		if isDoltConfigError(err) {
+			return fmt.Errorf("agent bead creation failed (DB not initialized — not retrying): %w", err)
 		}
 		if attempt < doltMaxRetries {
 			backoff := doltBackoff(attempt)
@@ -276,6 +306,7 @@ func (m *Manager) createAgentBeadWithRetry(agentID string, fields *beads.AgentFi
 // rather than fail — e.g., in StartSession where the tmux session is already
 // running and failing hard would orphan it. Agent state is a monitoring
 // concern, not a correctness requirement.
+// Fails fast on configuration/initialization errors (gt-2ra).
 func (m *Manager) SetAgentStateWithRetry(name string, state string) error {
 	var lastErr error
 	for attempt := 1; attempt <= doltMaxRetries; attempt++ {
@@ -284,6 +315,10 @@ func (m *Manager) SetAgentStateWithRetry(name string, state string) error {
 			return nil
 		}
 		lastErr = err
+		// Fail fast on config/init errors — retrying won't help (gt-2ra)
+		if isDoltConfigError(err) {
+			return fmt.Errorf("setting agent state failed (DB not initialized — not retrying): %w", err)
+		}
 		if attempt < doltMaxRetries {
 			backoff := doltBackoff(attempt)
 			fmt.Printf("Warning: SetAgentState attempt %d failed, retrying in %v: %v\n", attempt, backoff, err)

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -1,6 +1,7 @@
 package polecat
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -691,6 +692,62 @@ func TestReconcilePoolWith_OrphanDoesNotBlockAllocation(t *testing.T) {
 
 	if name != "furiosa" {
 		t.Errorf("expected furiosa (orphan freed), got %q", name)
+	}
+}
+
+func TestIsDoltConfigError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"transient optimistic lock", fmt.Errorf("optimistic lock failed"), false},
+		{"transient serialization", fmt.Errorf("serialization failure"), false},
+		{"not initialized", fmt.Errorf("database not initialized"), true},
+		{"no such table", fmt.Errorf("no such table: issues"), true},
+		{"table not found", fmt.Errorf("table not found: issues"), true},
+		{"issue_prefix missing", fmt.Errorf("issue_prefix not configured"), true},
+		{"no database", fmt.Errorf("no database found at path"), true},
+		{"database not found", fmt.Errorf("database not found"), true},
+		{"connection refused", fmt.Errorf("dial tcp: connection refused"), true},
+		{"configure custom types", fmt.Errorf("configure custom types in /path: exit 1"), true},
+		{"generic error", fmt.Errorf("something else failed"), false},
+		{"wrapped not initialized", fmt.Errorf("bd create failed: %w", fmt.Errorf("database not initialized")), true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDoltConfigError(tt.err); got != tt.want {
+				t.Errorf("isDoltConfigError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIsDoltOptimisticLockError(t *testing.T) {
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil error", nil, false},
+		{"optimistic lock", fmt.Errorf("optimistic lock failed"), true},
+		{"serialization failure", fmt.Errorf("serialization failure"), true},
+		{"lock wait timeout", fmt.Errorf("lock wait timeout exceeded"), true},
+		{"try restarting transaction", fmt.Errorf("try restarting transaction"), true},
+		{"database is read only", fmt.Errorf("database is read only"), true},
+		{"cannot update manifest", fmt.Errorf("cannot update manifest"), true},
+		{"config error", fmt.Errorf("not initialized"), false},
+		{"generic error", fmt.Errorf("something else"), false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isDoltOptimisticLockError(tt.err); got != tt.want {
+				t.Errorf("isDoltOptimisticLockError(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary
- When `gt sling` fails due to missing `issue_prefix` config (not a transient error), fail immediately instead of retrying 10 times with exponential backoff up to 30s
- Distinguishes config/initialization errors from transient errors in the retry loop
- Prevents Mayor session from being blocked for ~3 minutes on unrecoverable errors

## Test plan
- [ ] Verify `gt sling` fails fast when rig Dolt DB has no `issue_prefix` config
- [ ] Verify transient errors still retry with backoff
- [ ] Verify normal sling flow is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)