### PR TITLE
feat(dashboard): add Sling buttons to work panel and ready items (gt-5d8)

### DIFF
--- a/internal/web/static/dashboard.css
+++ b/internal/web/static/dashboard.css
@@ -389,6 +389,67 @@
             color: var(--bg-primary);
         }
 
+        .sling-btn {
+            background: var(--bg-tertiary);
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            color: var(--orange);
+            cursor: pointer;
+            font-size: 0.75rem;
+            padding: 4px 8px;
+            transition: all 0.15s ease;
+            white-space: nowrap;
+        }
+
+        .sling-btn:hover {
+            background: var(--orange);
+            border-color: var(--orange);
+            color: var(--bg-primary);
+        }
+
+        .sling-dropdown {
+            background: var(--bg-card);
+            border: 1px solid var(--border-accent);
+            border-radius: 6px;
+            box-shadow: 0 8px 24px rgba(0, 0, 0, 0.4);
+            min-width: 180px;
+            overflow: hidden;
+        }
+
+        .sling-dropdown-header {
+            padding: 8px 12px;
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            border-bottom: 1px solid var(--border);
+        }
+
+        .sling-dropdown-loading,
+        .sling-dropdown-empty {
+            padding: 12px;
+            font-size: 0.8rem;
+            color: var(--text-muted);
+            text-align: center;
+        }
+
+        .sling-dropdown-item {
+            display: block;
+            width: 100%;
+            background: none;
+            border: none;
+            padding: 8px 12px;
+            font-size: 0.85rem;
+            color: var(--text-primary);
+            cursor: pointer;
+            text-align: left;
+            font-family: inherit;
+            transition: background 0.1s ease;
+        }
+
+        .sling-dropdown-item:hover {
+            background: var(--bg-tertiary);
+            color: var(--orange);
+        }
+
         /* Toast notifications */
         #toast-container {
             position: fixed;

--- a/internal/web/templates/convoy.html
+++ b/internal/web/templates/convoy.html
@@ -724,6 +724,7 @@
                                     <th>Title</th>
                                     <th>Status</th>
                                     <th>Age</th>
+                                    <th>Actions</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -741,6 +742,7 @@
                                         {{if .Assignee}}<span class="badge badge-blue" title="{{.Assignee}}">{{.Assignee}}</span>{{else}}<span class="badge badge-green">Ready</span>{{end}}
                                     </td>
                                     <td>{{.Age}}</td>
+                                    <td>{{if not .Assignee}}<button class="sling-btn" data-bead-id="{{.ID}}" title="Sling to rig">🏹 Sling</button>{{end}}</td>
                                 </tr>
                                 {{end}}
                             </tbody>


### PR DESCRIPTION
## Summary
- Add "Sling" action buttons on ready work items and issue rows in the dashboard
- Target picker dropdown for rig selection
- Executes `gt sling` via `/api/run` endpoint

## Test plan
- [ ] Verify Sling buttons appear on ready work items
- [ ] Verify rig picker dropdown shows available rigs
- [ ] Verify sling executes successfully from dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)