### PR TITLE
feat(dashboard): add issue management to Work panel (gt-hsn)

### DIFF
--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -510,6 +510,180 @@ func TestAPIHandler_IssueCreate_InvalidJSON(t *testing.T) {
 	}
 }
 
+// --- Issue management endpoint tests ---
+
+func TestAPIHandler_IssueClose_MissingID(t *testing.T) {
+	handler := NewAPIHandler(30*time.Second, 60*time.Second)
+
+	body := `{"id": ""}`
+	req := httptest.NewRequest(http.MethodPost, "/api/issues/close", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/issues/close empty ID status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAPIHandler_IssueClose_InvalidID(t *testing.T) {
+	handler := NewAPIHandler(30*time.Second, 60*time.Second)
+
+	body := `{"id": "--flag-injection"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/issues/close", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/issues/close invalid ID status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAPIHandler_IssueClose_InvalidJSON(t *testing.T) {
+	handler := NewAPIHandler(30*time.Second, 60*time.Second)
+
+	body := `{not valid json}`
+	req := httptest.NewRequest(http.MethodPost, "/api/issues/close", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/issues/close invalid JSON status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAPIHandler_IssueReopen_MissingID(t *testing.T) {
+	handler := NewAPIHandler(30*time.Second, 60*time.Second)
+
+	body := `{"id": ""}`
+	req := httptest.NewRequest(http.MethodPost, "/api/issues/reopen", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/issues/reopen empty ID status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAPIHandler_IssueReopen_InvalidID(t *testing.T) {
+	handler := NewAPIHandler(30*time.Second, 60*time.Second)
+
+	body := `{"id": "--flag-injection"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/issues/reopen", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/issues/reopen invalid ID status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAPIHandler_IssueUpdate_MissingID(t *testing.T) {
+	handler := NewAPIHandler(30*time.Second, 60*time.Second)
+
+	body := `{"id": "", "priority": 2}`
+	req := httptest.NewRequest(http.MethodPost, "/api/issues/update", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/issues/update empty ID status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAPIHandler_IssueUpdate_InvalidID(t *testing.T) {
+	handler := NewAPIHandler(30*time.Second, 60*time.Second)
+
+	body := `{"id": "--flag-injection", "priority": 2}`
+	req := httptest.NewRequest(http.MethodPost, "/api/issues/update", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/issues/update invalid ID status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAPIHandler_IssueUpdate_NoFields(t *testing.T) {
+	handler := NewAPIHandler(30*time.Second, 60*time.Second)
+
+	body := `{"id": "gt-abc"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/issues/update", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/issues/update no fields status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAPIHandler_IssueUpdate_InvalidAssignee(t *testing.T) {
+	handler := NewAPIHandler(30*time.Second, 60*time.Second)
+
+	body := `{"id": "gt-abc", "assignee": "-flag"}`
+	req := httptest.NewRequest(http.MethodPost, "/api/issues/update", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/issues/update invalid assignee status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestAPIHandler_IssueUpdate_InvalidJSON(t *testing.T) {
+	handler := NewAPIHandler(30*time.Second, 60*time.Second)
+
+	body := `{not valid}`
+	req := httptest.NewRequest(http.MethodPost, "/api/issues/update", bytes.NewBufferString(body))
+	req.Header.Set("Content-Type", "application/json")
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("POST /api/issues/update invalid JSON status = %d, want %d", w.Code, http.StatusBadRequest)
+	}
+}
+
+func TestParseIssueShowJSON_WithAssignee(t *testing.T) {
+	input := `[{
+		"id": "gt-abc",
+		"title": "Test issue",
+		"status": "hooked",
+		"priority": 2,
+		"issue_type": "feature",
+		"assignee": "gastown/polecats/nux",
+		"owner": "user@example.com"
+	}]`
+	resp, ok := parseIssueShowJSON(input)
+	if !ok {
+		t.Fatal("parseIssueShowJSON returned ok=false for valid input with assignee")
+	}
+	if resp.Assignee != "gastown/polecats/nux" {
+		t.Errorf("Assignee = %q, want %q", resp.Assignee, "gastown/polecats/nux")
+	}
+	if resp.Owner != "user@example.com" {
+		t.Errorf("Owner = %q, want %q", resp.Owner, "user@example.com")
+	}
+}
+
 // --- parseIssueShowOutput edge-case tests (issue #1228: panic-safe string indexing) ---
 
 func TestParseIssueShowOutput_EmptyOutput(t *testing.T) {

--- a/internal/web/static/dashboard.css
+++ b/internal/web/static/dashboard.css
@@ -1005,6 +1005,109 @@
             background: rgba(138, 180, 248, 0.2);
         }
 
+        /* Issue detail actions */
+        .issue-detail-actions {
+            display: flex;
+            gap: 8px;
+            margin-bottom: 16px;
+        }
+
+        .btn-action {
+            border: none;
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 0.8rem;
+            font-weight: 600;
+            padding: 6px 14px;
+            transition: all 0.15s ease;
+        }
+
+        .btn-close-issue {
+            background: rgba(237, 135, 150, 0.2);
+            color: var(--red);
+        }
+
+        .btn-close-issue:hover {
+            background: rgba(237, 135, 150, 0.35);
+        }
+
+        .btn-close-issue:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        .btn-reopen-issue {
+            background: rgba(166, 218, 149, 0.2);
+            color: var(--green);
+        }
+
+        .btn-reopen-issue:hover {
+            background: rgba(166, 218, 149, 0.35);
+        }
+
+        .btn-reopen-issue:disabled {
+            opacity: 0.5;
+            cursor: not-allowed;
+        }
+
+        .btn-edit-issue {
+            background: rgba(138, 180, 248, 0.2);
+            color: var(--blue);
+        }
+
+        .btn-edit-issue:hover {
+            background: rgba(138, 180, 248, 0.35);
+        }
+
+        /* Issue edit form */
+        .issue-edit-form {
+            background: var(--bg-tertiary);
+            border: 1px solid var(--border);
+            border-radius: 6px;
+            padding: 12px;
+            margin-bottom: 16px;
+        }
+
+        .form-group-inline {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            margin-bottom: 8px;
+        }
+
+        .form-group-inline label {
+            font-size: 0.8rem;
+            color: var(--text-muted);
+            min-width: 70px;
+        }
+
+        .form-group-inline select,
+        .form-group-inline input {
+            flex: 1;
+            padding: 4px 8px;
+            background: var(--bg-primary);
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            color: var(--text-primary);
+            font-size: 0.85rem;
+        }
+
+        .issue-edit-actions {
+            display: flex;
+            gap: 8px;
+            margin-top: 8px;
+        }
+
+        .btn-sm {
+            padding: 4px 12px;
+            font-size: 0.8rem;
+        }
+
+        .issue-status.hooked {
+            background: rgba(245, 169, 127, 0.2);
+            color: var(--orange);
+        }
+
         /* Clickable PR rows */
         .pr-row {
             cursor: pointer;

--- a/internal/web/templates/convoy.html
+++ b/internal/web/templates/convoy.html
@@ -766,6 +766,33 @@
                             <div class="issue-detail-meta">
                                 <span id="issue-detail-type"></span>
                                 <span id="issue-detail-created"></span>
+                                <span id="issue-detail-assignee"></span>
+                            </div>
+                            <!-- Action buttons -->
+                            <div class="issue-detail-actions" id="issue-detail-actions">
+                                <button id="issue-close-btn" class="btn-action btn-close-issue" onclick="closeIssue()">Close Issue</button>
+                                <button id="issue-reopen-btn" class="btn-action btn-reopen-issue" onclick="reopenIssue()" style="display: none;">Reopen Issue</button>
+                                <button id="issue-edit-btn" class="btn-action btn-edit-issue" onclick="toggleIssueEdit()">Edit</button>
+                            </div>
+                            <!-- Inline edit form (hidden by default) -->
+                            <div id="issue-edit-form" class="issue-edit-form" style="display: none;">
+                                <div class="form-group-inline">
+                                    <label for="issue-edit-priority">Priority:</label>
+                                    <select id="issue-edit-priority">
+                                        <option value="1">P1 - Critical</option>
+                                        <option value="2">P2 - High</option>
+                                        <option value="3">P3 - Medium</option>
+                                        <option value="4">P4 - Low</option>
+                                    </select>
+                                </div>
+                                <div class="form-group-inline">
+                                    <label for="issue-edit-assignee">Assignee:</label>
+                                    <input type="text" id="issue-edit-assignee" placeholder="e.g. gastown/polecats/nux">
+                                </div>
+                                <div class="issue-edit-actions">
+                                    <button class="btn-primary btn-sm" onclick="saveIssueEdit()">Save</button>
+                                    <button class="btn-secondary btn-sm" onclick="toggleIssueEdit()">Cancel</button>
+                                </div>
                             </div>
                             <div class="issue-detail-section">
                                 <h4>Description</h4>


### PR DESCRIPTION
## Summary
- Add close, reopen, edit priority, and assign actions to issues in the Work panel
- Show full issue details in expandable rows
- Uses `bd close`, `bd update`, `bd show` via `/api/run` endpoint

## Test plan
- [ ] Verify issue close/reopen buttons work
- [ ] Verify priority edit and assignee update
- [ ] Verify issue detail expansion shows full info

🤖 Generated with [Claude Code](https://claude.com/claude-code)