### PR TITLE
feat(dashboard): add sling buttons to work panel and ready items

### DIFF
--- a/internal/web/static/dashboard.css
+++ b/internal/web/static/dashboard.css
@@ -2259,3 +2259,71 @@
             from { transform: translateX(100%); opacity: 0; }
             to { transform: translateX(0); opacity: 1; }
         }
+
+        /* Sling button */
+        .sling-btn {
+            background: transparent;
+            border: 1px solid var(--purple);
+            border-radius: 4px;
+            color: var(--purple);
+            cursor: pointer;
+            font-family: inherit;
+            font-size: 0.7rem;
+            font-weight: 600;
+            padding: 3px 8px;
+            transition: all 0.15s ease;
+            white-space: nowrap;
+        }
+
+        .sling-btn:hover {
+            background: var(--purple);
+            color: var(--bg-dark);
+        }
+
+        /* Sling dropdown */
+        .sling-dropdown {
+            background: var(--bg-card);
+            border: 1px solid var(--purple);
+            border-radius: 6px;
+            box-shadow: 0 4px 16px rgba(0, 0, 0, 0.4);
+            min-width: 160px;
+            overflow: hidden;
+        }
+
+        .sling-dropdown-header {
+            padding: 8px 12px;
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            border-bottom: 1px solid var(--border);
+        }
+
+        .sling-dropdown-loading,
+        .sling-dropdown-empty {
+            padding: 12px;
+            font-size: 0.8rem;
+            color: var(--text-muted);
+            text-align: center;
+        }
+
+        .sling-dropdown-item {
+            display: block;
+            width: 100%;
+            background: transparent;
+            border: none;
+            color: var(--text-primary);
+            cursor: pointer;
+            font-family: inherit;
+            font-size: 0.85rem;
+            padding: 8px 12px;
+            text-align: left;
+            transition: background 0.1s ease;
+        }
+
+        .sling-dropdown-item:hover {
+            background: var(--purple);
+            color: var(--bg-dark);
+        }
+
+        .sling-dropdown-item + .sling-dropdown-item {
+            border-top: 1px solid var(--border);
+        }

--- a/internal/web/static/dashboard.js
+++ b/internal/web/static/dashboard.js
@@ -1003,7 +1003,8 @@
                             '<td>' + priBadge + '</td>' +
                             '<td><span class="ready-id">' + escapeHtml(item.id) + '</span></td>' +
                             '<td><span class="ready-title">' + escapeHtml(item.title || '') + '</span></td>' +
-                            '<td><span class="' + sourceClass + '">' + escapeHtml(item.source) + '</span></td>';
+                            '<td><span class="' + sourceClass + '">' + escapeHtml(item.source) + '</span></td>' +
+                            '<td><button class="sling-btn" data-bead-id="' + escapeHtml(item.id) + '" title="Sling to rig">Sling</button></td>';
                         tbody.appendChild(tr);
                     });
 
@@ -1524,5 +1525,108 @@
             window.pauseRefresh = false;
         });
     }
+
+    // ============================================
+    // SLING BUTTONS
+    // ============================================
+    var activeSlingDropdown = null;
+
+    function closeSlingDropdown() {
+        if (activeSlingDropdown) {
+            activeSlingDropdown.remove();
+            activeSlingDropdown = null;
+        }
+    }
+
+    function openSlingDropdown(btn) {
+        closeSlingDropdown();
+
+        var beadId = btn.getAttribute('data-bead-id');
+        if (!beadId) return;
+
+        var dropdown = document.createElement('div');
+        dropdown.className = 'sling-dropdown';
+        dropdown.innerHTML = '<div class="sling-dropdown-loading">Loading rigs...</div>';
+
+        // Position dropdown below the button
+        var rect = btn.getBoundingClientRect();
+        dropdown.style.position = 'fixed';
+        dropdown.style.top = (rect.bottom + 4) + 'px';
+        dropdown.style.left = rect.left + 'px';
+        dropdown.style.zIndex = '10001';
+        document.body.appendChild(dropdown);
+        activeSlingDropdown = dropdown;
+
+        // Fetch rig options
+        fetch('/api/options?type=rigs')
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                var rigs = data.rigs || [];
+                if (rigs.length === 0) {
+                    dropdown.innerHTML = '<div class="sling-dropdown-empty">No rigs available</div>';
+                    return;
+                }
+                var html = '<div class="sling-dropdown-header">Sling ' + escapeHtml(beadId) + ' to:</div>';
+                for (var i = 0; i < rigs.length; i++) {
+                    html += '<button class="sling-dropdown-item" data-rig="' + escapeHtml(rigs[i]) + '">' + escapeHtml(rigs[i]) + '</button>';
+                }
+                dropdown.innerHTML = html;
+
+                // Handle rig selection
+                dropdown.addEventListener('click', function(e) {
+                    var item = e.target.closest('.sling-dropdown-item');
+                    if (!item) return;
+                    var rig = item.getAttribute('data-rig');
+                    closeSlingDropdown();
+                    executeSling(beadId, rig);
+                });
+            })
+            .catch(function() {
+                dropdown.innerHTML = '<div class="sling-dropdown-empty">Failed to load rigs</div>';
+            });
+    }
+
+    function executeSling(beadId, rig) {
+        var cmd = 'sling ' + beadId + ' ' + rig;
+        showToast('info', 'Slinging...', beadId + ' → ' + rig);
+
+        fetch('/api/run', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ command: cmd })
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (data.success) {
+                showToast('success', 'Slung', beadId + ' → ' + rig);
+                if (data.output && data.output.trim()) {
+                    showOutput(cmd, data.output);
+                }
+            } else {
+                showToast('error', 'Sling failed', data.error || 'Unknown error');
+                if (data.output) {
+                    showOutput(cmd, data.output);
+                }
+            }
+        })
+        .catch(function(err) {
+            showToast('error', 'Error', err.message || 'Request failed');
+        });
+    }
+
+    // Click handler for sling buttons
+    document.addEventListener('click', function(e) {
+        var slingBtn = e.target.closest('.sling-btn');
+        if (slingBtn) {
+            e.preventDefault();
+            e.stopPropagation();
+            openSlingDropdown(slingBtn);
+            return;
+        }
+        // Close dropdown when clicking outside
+        if (activeSlingDropdown && !e.target.closest('.sling-dropdown')) {
+            closeSlingDropdown();
+        }
+    });
 
 })();

--- a/internal/web/templates/convoy.html
+++ b/internal/web/templates/convoy.html
@@ -724,6 +724,7 @@
                                     <th>Title</th>
                                     <th>Status</th>
                                     <th>Age</th>
+                                    <th>Actions</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -741,6 +742,7 @@
                                         {{if .Assignee}}<span class="badge badge-blue" title="{{.Assignee}}">{{.Assignee}}</span>{{else}}<span class="badge badge-green">Ready</span>{{end}}
                                     </td>
                                     <td>{{.Age}}</td>
+                                    <td><button class="sling-btn" data-bead-id="{{.ID}}" title="Sling to rig">Sling</button></td>
                                 </tr>
                                 {{end}}
                             </tbody>


### PR DESCRIPTION
## Summary
- Adds "Sling" action buttons to issue rows in the Work panel and ready work items
- Clicking opens a rig picker dropdown (fetched from /api/options) to select target rig
- Executes `gt sling <bead-id> <rig>` via POST /api/run with toast notifications for success/error
- New CSS styles for sling button and rig picker dropdown

## Bead
gt-kb1

## Test plan
- [ ] Open dashboard, navigate to Work panel
- [ ] Verify Sling buttons appear on issue rows
- [ ] Click Sling, verify rig dropdown appears with available rigs
- [ ] Select a rig, verify sling command executes and shows toast
- [ ] Check ready work items also have sling buttons

🤖 Generated with [Claude Code](https://claude.com/claude-code)