### PR TITLE
feat(dashboard): add interactive hook management

### DIFF
--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -88,6 +88,35 @@ Output format (one line):
 	RunE: runHookShow,
 }
 
+// hookAttachCmd attaches a bead to your hook (alias for 'gt hook <bead-id>')
+var hookAttachCmd = &cobra.Command{
+	Use:   "attach <bead-id>",
+	Short: "Attach work to your hook",
+	Long: `Attach a bead to your hook (same as 'gt hook <bead-id>').
+
+Examples:
+  gt hook attach gt-abc               # Attach issue gt-abc to your hook`,
+	Args: cobra.ExactArgs(1),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runHook(cmd, args)
+	},
+}
+
+// hookDetachCmd detaches a bead from a hook (alias for 'gt hook clear')
+var hookDetachCmd = &cobra.Command{
+	Use:   "detach <bead-id> [target]",
+	Short: "Detach work from a hook",
+	Long: `Remove a specific bead from a hook (same as 'gt hook clear <bead-id>').
+
+Examples:
+  gt hook detach gt-abc               # Detach gt-abc from my hook
+  gt hook detach gt-abc gastown/nux   # Detach gt-abc from nux's hook`,
+	Args: cobra.RangeArgs(1, 2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		return runUnslingWith(cmd, args, hookDryRun, hookForce)
+	},
+}
+
 // hookClearCmd clears the hook (alias for 'gt unhook')
 var hookClearCmd = &cobra.Command{
 	Use:   "clear [bead-id] [target]",
@@ -131,12 +160,20 @@ func init() {
 	hookStatusCmd.Flags().BoolVar(&moleculeJSON, "json", false, "Output as JSON")
 	hookShowCmd.Flags().BoolVar(&moleculeJSON, "json", false, "Output as JSON")
 
+	// Flags for attach subcommand
+	hookAttachCmd.Flags().BoolVarP(&hookForce, "force", "f", false, "Replace existing incomplete hooked bead")
+
+	// Flags for detach subcommand (mirror unsling flags)
+	hookDetachCmd.Flags().BoolVarP(&hookForce, "force", "f", false, "Detach even if work is incomplete")
+
 	// Flags for clear subcommand (mirror unsling flags)
 	hookClearCmd.Flags().BoolVarP(&hookDryRun, "dry-run", "n", false, "Show what would be done")
 	hookClearCmd.Flags().BoolVarP(&hookForce, "force", "f", false, "Clear even if work is incomplete")
 
 	hookCmd.AddCommand(hookStatusCmd)
 	hookCmd.AddCommand(hookShowCmd)
+	hookCmd.AddCommand(hookAttachCmd)
+	hookCmd.AddCommand(hookDetachCmd)
 	hookCmd.AddCommand(hookClearCmd)
 
 	rootCmd.AddCommand(hookCmd)

--- a/internal/web/static/dashboard.css
+++ b/internal/web/static/dashboard.css
@@ -867,6 +867,128 @@
             color: var(--orange);
         }
 
+        .hook-detach-btn {
+            background: transparent;
+            border: 1px solid var(--red);
+            border-radius: 3px;
+            color: var(--red);
+            cursor: pointer;
+            font-size: 0.7rem;
+            padding: 2px 8px;
+            transition: all 0.15s ease;
+        }
+
+        .hook-detach-btn:hover {
+            background: rgba(240, 113, 120, 0.15);
+        }
+
+        .hook-detach-btn:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+
+        .hook-attach-btn {
+            background: var(--cyan);
+            border: none;
+            border-radius: 4px;
+            color: #000;
+            cursor: pointer;
+            font-size: 0.75rem;
+            font-weight: 600;
+            padding: 4px 10px;
+            margin-right: 4px;
+            transition: all 0.15s ease;
+        }
+
+        .hook-attach-btn:hover {
+            background: var(--green);
+            transform: scale(1.05);
+        }
+
+        .hook-clear-all-btn {
+            background: transparent;
+            border: 1px solid var(--text-muted);
+            border-radius: 4px;
+            color: var(--text-muted);
+            cursor: pointer;
+            font-size: 0.7rem;
+            padding: 3px 8px;
+            margin-right: 4px;
+            transition: all 0.15s ease;
+        }
+
+        .hook-clear-all-btn:hover {
+            border-color: var(--red);
+            color: var(--red);
+        }
+
+        .hook-attach-form {
+            padding: 8px;
+            margin-bottom: 8px;
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            background: var(--bg-secondary);
+        }
+
+        .hook-attach-form-row {
+            display: flex;
+            gap: 6px;
+            align-items: center;
+        }
+
+        .hook-attach-input {
+            flex: 1;
+            background: var(--bg-primary);
+            border: 1px solid var(--border);
+            border-radius: 3px;
+            color: var(--text-primary);
+            font-family: inherit;
+            font-size: 0.8rem;
+            padding: 5px 8px;
+        }
+
+        .hook-attach-input:focus {
+            outline: none;
+            border-color: var(--cyan);
+        }
+
+        .hook-attach-submit {
+            background: var(--cyan);
+            border: none;
+            border-radius: 3px;
+            color: #000;
+            cursor: pointer;
+            font-size: 0.75rem;
+            font-weight: 600;
+            padding: 5px 12px;
+            transition: all 0.15s ease;
+        }
+
+        .hook-attach-submit:hover {
+            background: var(--green);
+        }
+
+        .hook-attach-submit:disabled {
+            opacity: 0.4;
+            cursor: not-allowed;
+        }
+
+        .hook-attach-cancel {
+            background: transparent;
+            border: 1px solid var(--text-muted);
+            border-radius: 3px;
+            color: var(--text-muted);
+            cursor: pointer;
+            font-size: 0.75rem;
+            padding: 5px 10px;
+            transition: all 0.15s ease;
+        }
+
+        .hook-attach-cancel:hover {
+            border-color: var(--text-primary);
+            color: var(--text-primary);
+        }
+
         /* Issue styles */
         .issue-id {
             font-weight: 600;

--- a/internal/web/static/dashboard.js
+++ b/internal/web/static/dashboard.js
@@ -829,6 +829,174 @@
 
 
     // ============================================
+    // HOOK MANAGEMENT
+    // ============================================
+
+    function detachHook(btn) {
+        var beadId = btn.getAttribute('data-hook-id');
+        if (!beadId) return;
+
+        if (!confirm('Detach hook ' + beadId + '?')) return;
+
+        btn.disabled = true;
+        btn.textContent = '...';
+
+        fetch('/api/run', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ command: 'hook detach ' + beadId })
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (data.success) {
+                showToast('success', 'Detached', beadId + ' detached from hook');
+                // Refresh the page to update the hooks panel
+                if (typeof htmx !== 'undefined') {
+                    htmx.trigger(document.body, 'htmx:load');
+                }
+            } else {
+                showToast('error', 'Failed', data.error || 'Failed to detach hook');
+                btn.disabled = false;
+                btn.textContent = 'Detach';
+            }
+        })
+        .catch(function(err) {
+            showToast('error', 'Error', err.message);
+            btn.disabled = false;
+            btn.textContent = 'Detach';
+        });
+    }
+    window.detachHook = detachHook;
+
+    function openHookAttachForm() {
+        var form = document.getElementById('hook-attach-form');
+        if (form) {
+            form.style.display = 'block';
+            var input = document.getElementById('hook-attach-bead');
+            if (input) {
+                input.value = '';
+                setTimeout(function() { input.focus(); }, 50);
+            }
+        }
+    }
+    window.openHookAttachForm = openHookAttachForm;
+
+    function closeHookAttachForm() {
+        var form = document.getElementById('hook-attach-form');
+        if (form) {
+            form.style.display = 'none';
+        }
+    }
+    window.closeHookAttachForm = closeHookAttachForm;
+
+    function submitHookAttach() {
+        var input = document.getElementById('hook-attach-bead');
+        var beadId = input ? input.value.trim() : '';
+
+        if (!beadId) {
+            showToast('error', 'Missing', 'Bead ID is required');
+            return;
+        }
+
+        var submitBtn = document.querySelector('.hook-attach-submit');
+        if (submitBtn) {
+            submitBtn.disabled = true;
+            submitBtn.textContent = '...';
+        }
+
+        fetch('/api/run', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ command: 'hook attach ' + beadId })
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (data.success) {
+                showToast('success', 'Attached', beadId + ' attached to hook');
+                closeHookAttachForm();
+                if (typeof htmx !== 'undefined') {
+                    htmx.trigger(document.body, 'htmx:load');
+                }
+            } else {
+                showToast('error', 'Failed', data.error || 'Failed to attach hook');
+            }
+        })
+        .catch(function(err) {
+            showToast('error', 'Error', err.message);
+        })
+        .finally(function() {
+            if (submitBtn) {
+                submitBtn.disabled = false;
+                submitBtn.textContent = 'Attach';
+            }
+        });
+    }
+    window.submitHookAttach = submitHookAttach;
+
+    function clearAllHooks() {
+        if (!confirm('Clear ALL hooks? This will detach all hooked work.')) return;
+
+        var rows = document.querySelectorAll('.hook-detach-btn');
+        if (rows.length === 0) {
+            showToast('info', 'Nothing', 'No hooks to clear');
+            return;
+        }
+
+        var beadIds = [];
+        for (var i = 0; i < rows.length; i++) {
+            var id = rows[i].getAttribute('data-hook-id');
+            if (id) beadIds.push(id);
+        }
+
+        var completed = 0;
+        var errors = 0;
+
+        beadIds.forEach(function(beadId) {
+            fetch('/api/run', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ command: 'hook detach ' + beadId })
+            })
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                if (data.success) {
+                    completed++;
+                } else {
+                    errors++;
+                }
+            })
+            .catch(function() {
+                errors++;
+            })
+            .finally(function() {
+                if (completed + errors === beadIds.length) {
+                    if (errors > 0) {
+                        showToast('error', 'Partial', completed + ' detached, ' + errors + ' failed');
+                    } else {
+                        showToast('success', 'Cleared', completed + ' hook(s) cleared');
+                    }
+                    if (typeof htmx !== 'undefined') {
+                        htmx.trigger(document.body, 'htmx:load');
+                    }
+                }
+            });
+        });
+    }
+    window.clearAllHooks = clearAllHooks;
+
+    // Handle Enter key in hook attach input
+    document.addEventListener('keydown', function(e) {
+        if (e.key === 'Enter' && e.target.id === 'hook-attach-bead') {
+            e.preventDefault();
+            submitHookAttach();
+        }
+        if (e.key === 'Escape' && e.target.id === 'hook-attach-bead') {
+            e.preventDefault();
+            closeHookAttachForm();
+        }
+    });
+
+    // ============================================
     // ISSUE CREATION MODAL
     // ============================================
     function openIssueModal() {

--- a/internal/web/templates/convoy.html
+++ b/internal/web/templates/convoy.html
@@ -789,9 +789,19 @@
                 <div class="panel-header">
                     <h2>🪝 Hooks</h2>
                     <span class="count{{if .Hooks}} {{end}}">{{len .Hooks}}</span>
+                    <button class="hook-attach-btn" onclick="openHookAttachForm()">+ Attach</button>
+                    {{if .Hooks}}<button class="hook-clear-all-btn" onclick="clearAllHooks()">Clear All</button>{{end}}
                     <button class="expand-btn">Expand</button>
                 </div>
                 <div class="panel-body">
+                    <!-- Attach Hook Form (hidden by default) -->
+                    <div id="hook-attach-form" class="hook-attach-form" style="display:none;">
+                        <div class="hook-attach-form-row">
+                            <input type="text" id="hook-attach-bead" class="hook-attach-input" placeholder="Bead ID (e.g. gt-abc)">
+                            <button class="hook-attach-submit" onclick="submitHookAttach()">Attach</button>
+                            <button class="hook-attach-cancel" onclick="closeHookAttachForm()">Cancel</button>
+                        </div>
+                    </div>
                     {{if .Hooks}}
                     <table>
                         <thead>
@@ -800,6 +810,7 @@
                                 <th>Title</th>
                                 <th>Agent</th>
                                 <th>Hooked</th>
+                                <th></th>
                             </tr>
                         </thead>
                         <tbody>
@@ -815,6 +826,7 @@
                                     {{.Age}}
                                     {{end}}
                                 </td>
+                                <td><button class="hook-detach-btn" data-hook-id="{{.ID}}" onclick="detachHook(this)">Detach</button></td>
                             </tr>
                             {{end}}
                         </tbody>


### PR DESCRIPTION
## Summary
- Adds "Detach" button on each hook row to detach hooked work
- Adds "Attach" button with inline bead ID input form for attaching work to hooks
- Adds "Clear All" button with confirmation dialog
- Adds `hook attach` and `hook detach` CLI subcommands to support the whitelist

## Bead
gt-a68

## Test plan
- [ ] Open dashboard, navigate to Hooks panel
- [ ] Verify Detach button appears on hooked items
- [ ] Click Detach, verify hook is removed and toast shown
- [ ] Click Attach, enter bead ID, verify hook is attached
- [ ] Click Clear All, confirm dialog, verify all hooks cleared

🤖 Generated with [Claude Code](https://claude.com/claude-code)