### PR TITLE
feat(dashboard): add issue management actions to Work panel

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -97,6 +97,10 @@ func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handleIssueShow(w, r)
 	case path == "/issues/create" && r.Method == http.MethodPost:
 		h.handleIssueCreate(w, r)
+	case path == "/issues/close" && r.Method == http.MethodPost:
+		h.handleIssueClose(w, r)
+	case path == "/issues/update" && r.Method == http.MethodPost:
+		h.handleIssueUpdate(w, r)
 	case path == "/pr/show" && r.Method == http.MethodGet:
 		h.handlePRShow(w, r)
 	case path == "/crew" && r.Method == http.MethodGet:
@@ -768,6 +772,7 @@ type IssueShowResponse struct {
 	Type        string   `json:"type,omitempty"`
 	Status      string   `json:"status,omitempty"`
 	Priority    string   `json:"priority,omitempty"`
+	Owner       string   `json:"owner,omitempty"`
 	Description string   `json:"description,omitempty"`
 	Created     string   `json:"created,omitempty"`
 	Updated     string   `json:"updated,omitempty"`
@@ -933,6 +938,124 @@ func (h *APIHandler) handleIssueCreate(w http.ResponseWriter, r *http.Request) {
 	_ = json.NewEncoder(w).Encode(resp)
 }
 
+// IssueCloseRequest is the request body for closing an issue.
+type IssueCloseRequest struct {
+	ID string `json:"id"`
+}
+
+// handleIssueClose closes an issue via bd close.
+func (h *APIHandler) handleIssueClose(w http.ResponseWriter, r *http.Request) {
+	var req IssueCloseRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.sendError(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.ID == "" {
+		h.sendError(w, "Issue ID is required", http.StatusBadRequest)
+		return
+	}
+	if !isValidID(req.ID) {
+		h.sendError(w, "Invalid issue ID format", http.StatusBadRequest)
+		return
+	}
+
+	output, err := h.runBdCommand(r.Context(), 12*time.Second, []string{"close", req.ID})
+
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   "Failed to close issue: " + err.Error(),
+			"output":  output,
+		})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"success": true,
+		"message": "Issue closed",
+		"output":  output,
+	})
+}
+
+// IssueUpdateRequest is the request body for updating an issue.
+type IssueUpdateRequest struct {
+	ID       string `json:"id"`
+	Status   string `json:"status,omitempty"`   // "open", "in_progress"
+	Priority int    `json:"priority,omitempty"` // 1-4
+	Assignee string `json:"assignee,omitempty"`
+}
+
+// handleIssueUpdate updates issue fields via bd update.
+func (h *APIHandler) handleIssueUpdate(w http.ResponseWriter, r *http.Request) {
+	var req IssueUpdateRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		h.sendError(w, "Invalid request body", http.StatusBadRequest)
+		return
+	}
+
+	if req.ID == "" {
+		h.sendError(w, "Issue ID is required", http.StatusBadRequest)
+		return
+	}
+	if !isValidID(req.ID) {
+		h.sendError(w, "Invalid issue ID format", http.StatusBadRequest)
+		return
+	}
+
+	// Build bd update args
+	args := []string{"update", req.ID}
+	hasUpdate := false
+
+	if req.Status != "" {
+		// Validate allowed status values
+		switch req.Status {
+		case "open", "in_progress":
+			args = append(args, "--status="+req.Status)
+			hasUpdate = true
+		default:
+			h.sendError(w, "Invalid status (allowed: open, in_progress)", http.StatusBadRequest)
+			return
+		}
+	}
+
+	if req.Priority >= 1 && req.Priority <= 4 {
+		args = append(args, fmt.Sprintf("--priority=%d", req.Priority))
+		hasUpdate = true
+	}
+
+	if req.Assignee != "" {
+		if !isValidID(req.Assignee) {
+			h.sendError(w, "Invalid assignee format", http.StatusBadRequest)
+			return
+		}
+		args = append(args, "--assignee="+req.Assignee)
+		hasUpdate = true
+	}
+
+	if !hasUpdate {
+		h.sendError(w, "No update fields provided", http.StatusBadRequest)
+		return
+	}
+
+	output, err := h.runBdCommand(r.Context(), 12*time.Second, args)
+
+	w.Header().Set("Content-Type", "application/json")
+	if err != nil {
+		_ = json.NewEncoder(w).Encode(map[string]interface{}{
+			"success": false,
+			"error":   "Failed to update issue: " + err.Error(),
+			"output":  output,
+		})
+		return
+	}
+	_ = json.NewEncoder(w).Encode(map[string]interface{}{
+		"success": true,
+		"message": "Issue updated",
+		"output":  output,
+	})
+}
+
 // runBdCommand executes a bd command with the given args.
 func (h *APIHandler) runBdCommand(ctx context.Context, timeout time.Duration, args []string) (string, error) {
 	ctx, cancel := context.WithTimeout(ctx, timeout)
@@ -979,6 +1102,7 @@ func parseIssueShowJSON(output string) (IssueShowResponse, bool) {
 		Status      string   `json:"status"`
 		Priority    int      `json:"priority"`
 		Type        string   `json:"issue_type"`
+		Owner       string   `json:"owner"`
 		CreatedAt   string   `json:"created_at"`
 		UpdatedAt   string   `json:"updated_at"`
 		DependsOn   []string `json:"depends_on,omitempty"`
@@ -1000,6 +1124,7 @@ func parseIssueShowJSON(output string) (IssueShowResponse, bool) {
 		Type:        item.Type,
 		Status:      item.Status,
 		Priority:    priority,
+		Owner:       item.Owner,
 		Description: item.Description,
 		Created:     item.CreatedAt,
 		Updated:     item.UpdatedAt,
@@ -1060,7 +1185,16 @@ func parseIssueShowOutput(output string, issueID string) IssueShowResponse {
 			continue
 		}
 
-		if strings.HasPrefix(line, "Type:") {
+		if strings.HasPrefix(line, "Owner:") {
+			// Format: "Owner: mayor · Type: task"
+			ownerLine := strings.TrimPrefix(line, "Owner:")
+			ownerParts := strings.Split(ownerLine, "·")
+			resp.Owner = strings.TrimSpace(ownerParts[0])
+			if len(ownerParts) >= 2 {
+				typePart := strings.TrimSpace(ownerParts[1])
+				resp.Type = strings.TrimSpace(strings.TrimPrefix(typePart, "Type:"))
+			}
+		} else if strings.HasPrefix(line, "Type:") {
 			resp.Type = strings.TrimSpace(strings.TrimPrefix(line, "Type:"))
 		} else if strings.HasPrefix(line, "Created:") {
 			// Split always returns >= 1 element; parts[0] is safe unconditionally

--- a/internal/web/static/dashboard.css
+++ b/internal/web/static/dashboard.css
@@ -990,6 +990,90 @@
             overflow-y: auto;
         }
 
+        /* Issue action buttons */
+        .issue-detail-actions {
+            margin: 12px 0;
+        }
+
+        .issue-actions-bar {
+            display: flex;
+            align-items: center;
+            gap: 12px;
+            padding: 10px 12px;
+            background: rgba(0, 0, 0, 0.2);
+            border-radius: 6px;
+            flex-wrap: wrap;
+        }
+
+        .issue-action-btn {
+            border: 1px solid var(--border);
+            border-radius: 4px;
+            cursor: pointer;
+            font-size: 0.8rem;
+            font-family: inherit;
+            padding: 6px 14px;
+            transition: all 0.15s ease;
+        }
+
+        .issue-action-btn.close {
+            background: var(--green);
+            color: var(--bg-dark);
+            border-color: var(--green);
+        }
+
+        .issue-action-btn.close:hover {
+            opacity: 0.85;
+        }
+
+        .issue-action-btn.reopen {
+            background: transparent;
+            color: var(--blue);
+            border-color: var(--blue);
+        }
+
+        .issue-action-btn.reopen:hover {
+            background: var(--blue);
+            color: var(--bg-dark);
+        }
+
+        .issue-action-group {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .issue-action-label {
+            font-size: 0.7rem;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.5px;
+        }
+
+        .issue-action-select {
+            background: var(--bg-dark);
+            border: 1px solid var(--border);
+            color: var(--text-primary);
+            padding: 5px 28px 5px 8px;
+            border-radius: 4px;
+            font-size: 0.8rem;
+            font-family: inherit;
+            cursor: pointer;
+            appearance: none;
+            background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='12' height='12' viewBox='0 0 12 12'%3E%3Cpath fill='%236c7680' d='M6 8L1 3h10z'/%3E%3C/svg%3E");
+            background-repeat: no-repeat;
+            background-position: right 8px center;
+        }
+
+        .issue-action-select:focus {
+            outline: none;
+            border-color: var(--blue);
+        }
+
+        .issue-action-select option {
+            background: var(--bg-card);
+            color: var(--text-primary);
+        }
+
         .issue-dep-item {
             display: inline-block;
             padding: 2px 8px;

--- a/internal/web/static/dashboard.js
+++ b/internal/web/static/dashboard.js
@@ -1310,6 +1310,8 @@
         document.getElementById('issue-detail-status').textContent = '';
         document.getElementById('issue-detail-type').textContent = '';
         document.getElementById('issue-detail-created').textContent = '';
+        document.getElementById('issue-detail-owner').textContent = '';
+        document.getElementById('issue-detail-actions').innerHTML = '';
         document.getElementById('issue-detail-depends-on').innerHTML = '';
         document.getElementById('issue-detail-blocks').innerHTML = '';
         document.getElementById('issue-detail-deps').style.display = 'none';
@@ -1355,9 +1357,15 @@
                 if (data.type) {
                     document.getElementById('issue-detail-type').textContent = 'Type: ' + data.type;
                 }
+                if (data.owner) {
+                    document.getElementById('issue-detail-owner').textContent = 'Owner: ' + data.owner;
+                }
                 if (data.created) {
                     document.getElementById('issue-detail-created').textContent = 'Created: ' + data.created;
                 }
+
+                // Render action buttons
+                renderIssueActions(issueId, data);
 
                 // Dependencies
                 if (data.depends_on && data.depends_on.length > 0) {
@@ -1394,6 +1402,206 @@
             window.pauseRefresh = false;
         });
     }
+
+    // ============================================
+    // ISSUE ACTION BUTTONS
+    // ============================================
+
+    // Render action buttons based on current issue state
+    function renderIssueActions(issueId, data) {
+        var actionsEl = document.getElementById('issue-detail-actions');
+        if (!actionsEl) return;
+
+        var status = (data.status || '').toUpperCase();
+        var isClosed = status === 'CLOSED';
+        var currentPriority = data.priority || 'P2';
+        // Extract numeric priority (P1 -> 1, P2 -> 2, etc.)
+        var priNum = currentPriority.length === 2 ? parseInt(currentPriority[1], 10) : 2;
+
+        var html = '<div class="issue-actions-bar">';
+
+        // Close / Reopen button
+        if (isClosed) {
+            html += '<button class="issue-action-btn reopen" onclick="reopenIssue(\'' + escapeHtml(issueId) + '\')">↺ Reopen</button>';
+        } else {
+            html += '<button class="issue-action-btn close" onclick="closeIssue(\'' + escapeHtml(issueId) + '\')">✓ Close</button>';
+        }
+
+        // Priority dropdown
+        html += '<div class="issue-action-group">';
+        html += '<label class="issue-action-label">Priority</label>';
+        html += '<select class="issue-action-select" id="issue-action-priority" onchange="updateIssuePriority(\'' + escapeHtml(issueId) + '\', this.value)">';
+        for (var p = 1; p <= 4; p++) {
+            var sel = p === priNum ? ' selected' : '';
+            var pLabel = p === 1 ? 'P1 - Critical' : p === 2 ? 'P2 - High' : p === 3 ? 'P3 - Medium' : 'P4 - Low';
+            html += '<option value="' + p + '"' + sel + '>' + pLabel + '</option>';
+        }
+        html += '</select>';
+        html += '</div>';
+
+        // Assignee dropdown
+        html += '<div class="issue-action-group">';
+        html += '<label class="issue-action-label">Assign</label>';
+        html += '<select class="issue-action-select" id="issue-action-assignee" onchange="assignIssue(\'' + escapeHtml(issueId) + '\', this.value)">';
+        html += '<option value="">Unassigned</option>';
+        html += '<option value="" disabled>Loading agents...</option>';
+        html += '</select>';
+        html += '</div>';
+
+        html += '</div>';
+        actionsEl.innerHTML = html;
+
+        // Load agents for assignee dropdown
+        loadAssigneeOptions(data.owner || '');
+    }
+
+    // Load agent options into the assignee dropdown
+    function loadAssigneeOptions(currentOwner) {
+        var select = document.getElementById('issue-action-assignee');
+        if (!select) return;
+
+        fetch('/api/options')
+            .then(function(r) { return r.json(); })
+            .then(function(data) {
+                // Rebuild dropdown
+                var html = '<option value="">Unassigned</option>';
+                var agents = data.agents || [];
+                var polecats = data.polecats || [];
+
+                // Combine agents and polecats for assignee options
+                var seen = {};
+                var allOptions = [];
+
+                agents.forEach(function(agent) {
+                    var name = typeof agent === 'string' ? agent : agent.name;
+                    if (!seen[name]) {
+                        seen[name] = true;
+                        allOptions.push(name);
+                    }
+                });
+
+                polecats.forEach(function(polecat) {
+                    if (!seen[polecat]) {
+                        seen[polecat] = true;
+                        allOptions.push(polecat);
+                    }
+                });
+
+                allOptions.forEach(function(name) {
+                    var sel = name === currentOwner ? ' selected' : '';
+                    html += '<option value="' + escapeHtml(name) + '"' + sel + '>' + escapeHtml(name) + '</option>';
+                });
+
+                select.innerHTML = html;
+            })
+            .catch(function() {
+                select.innerHTML = '<option value="">Unassigned</option>';
+            });
+    }
+
+    // Close an issue
+    function closeIssue(issueId) {
+        if (!confirm('Close issue ' + issueId + '?')) return;
+
+        showToast('info', 'Closing...', issueId);
+
+        fetch('/api/issues/close', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: issueId })
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (data.success) {
+                showToast('success', 'Closed', issueId + ' closed');
+                // Re-fetch to update the detail view
+                openIssueDetail(issueId);
+            } else {
+                showToast('error', 'Failed', data.error || 'Unknown error');
+            }
+        })
+        .catch(function(err) {
+            showToast('error', 'Error', err.message);
+        });
+    }
+    window.closeIssue = closeIssue;
+
+    // Reopen an issue
+    function reopenIssue(issueId) {
+        showToast('info', 'Reopening...', issueId);
+
+        fetch('/api/issues/update', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: issueId, status: 'open' })
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (data.success) {
+                showToast('success', 'Reopened', issueId + ' reopened');
+                openIssueDetail(issueId);
+            } else {
+                showToast('error', 'Failed', data.error || 'Unknown error');
+            }
+        })
+        .catch(function(err) {
+            showToast('error', 'Error', err.message);
+        });
+    }
+    window.reopenIssue = reopenIssue;
+
+    // Update issue priority
+    function updateIssuePriority(issueId, priority) {
+        var priNum = parseInt(priority, 10);
+        if (priNum < 1 || priNum > 4) return;
+
+        showToast('info', 'Updating...', 'Setting priority to P' + priNum);
+
+        fetch('/api/issues/update', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: issueId, priority: priNum })
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (data.success) {
+                showToast('success', 'Updated', 'Priority set to P' + priNum);
+                openIssueDetail(issueId);
+            } else {
+                showToast('error', 'Failed', data.error || 'Unknown error');
+            }
+        })
+        .catch(function(err) {
+            showToast('error', 'Error', err.message);
+        });
+    }
+    window.updateIssuePriority = updateIssuePriority;
+
+    // Assign issue to agent
+    function assignIssue(issueId, assignee) {
+        if (!assignee) return; // Unassigned selected, no-op for now
+
+        showToast('info', 'Assigning...', 'Assigning to ' + assignee);
+
+        fetch('/api/issues/update', {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ id: issueId, assignee: assignee })
+        })
+        .then(function(r) { return r.json(); })
+        .then(function(data) {
+            if (data.success) {
+                showToast('success', 'Assigned', 'Assigned to ' + assignee);
+                openIssueDetail(issueId);
+            } else {
+                showToast('error', 'Failed', data.error || 'Unknown error');
+            }
+        })
+        .catch(function(err) {
+            showToast('error', 'Error', err.message);
+        });
+    }
+    window.assignIssue = assignIssue;
 
     // ============================================
     // PR/MERGE QUEUE PANEL INTERACTIONS

--- a/internal/web/templates/convoy.html
+++ b/internal/web/templates/convoy.html
@@ -765,8 +765,10 @@
                             <h3 id="issue-detail-title-text"></h3>
                             <div class="issue-detail-meta">
                                 <span id="issue-detail-type"></span>
+                                <span id="issue-detail-owner"></span>
                                 <span id="issue-detail-created"></span>
                             </div>
+                            <div id="issue-detail-actions" class="issue-detail-actions"></div>
                             <div class="issue-detail-section">
                                 <h4>Description</h4>
                                 <pre id="issue-detail-description"></pre>


### PR DESCRIPTION
## Summary
- Adds Close, Reopen, Edit Priority, and Assign actions to issue detail view
- Close calls `bd close <id>`, Reopen calls `bd update --status=open`
- Priority edit with P0-P4 dropdown, Assign with agent picker dropdown
- New API endpoints for issue operations with toast notifications and panel refresh

## Bead
gt-spw

## Test plan
- [ ] Open dashboard, click an issue to see detail view
- [ ] Click Close, verify issue closes and toast shows
- [ ] Click Reopen on a closed issue, verify it reopens
- [ ] Change priority via dropdown, verify update
- [ ] Assign to an agent via dropdown, verify assignment

🤖 Generated with [Claude Code](https://claude.com/claude-code)