### PR TITLE
fix: resolve Windows CI feed test failures

### DIFF
--- a/internal/feed/curator.go
+++ b/internal/feed/curator.go
@@ -407,6 +407,9 @@ func (c *Curator) truncateFeedFile(feedPath string, currentSize int64) {
 	}
 	tmp.Close()
 
+	// Close the read handle before rename — Windows cannot rename over open files.
+	f.Close()
+
 	// Atomic replace
 	os.Rename(tmpPath, feedPath) //nolint:errcheck // best-effort truncation
 }

--- a/internal/feed/curator_test.go
+++ b/internal/feed/curator_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -483,6 +484,9 @@ func TestCurator_ReadRecentFeedEventsLargeFile(t *testing.T) {
 }
 
 func TestCurator_FeedFilePermissions(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Unix file permissions are not supported on Windows")
+	}
 	tmpDir := t.TempDir()
 	feedPath := filepath.Join(tmpDir, FeedFile)
 


### PR DESCRIPTION
## Summary

Fix 2 Windows CI test failures in `internal/feed` introduced by 423cd780 (PR #1280: prevent feed curator OOM and unbounded file growth).

## Related Issue

Regression from 423cd780 — no standalone issue.

## Changes

- `curator.go`: close read handle explicitly before `os.Rename` in `truncateFeedFile` — Windows cannot rename over a file with an open handle (the `defer f.Close()` runs too late)
- `curator_test.go`: skip `TestCurator_FeedFilePermissions` on Windows where Unix file permissions are not supported (`os.Stat().Mode().Perm()` always returns `0666`)

## Testing

- [x] Unit tests pass (`go test ./internal/feed/...`)
- [x] `TestCurator_TruncatesAtMaxSize` passes
- [x] `TestCurator_FeedFilePermissions` passes
- [x] Windows CI pipeline passes (this PR)

## Checklist

- [x] Code follows project style
- [x] No breaking changes
- [x] Production code fix: `truncateFeedFile` was silently failing on Windows due to open file handle during rename