### PR TITLE
feat(dashboard): replace polling with SSE for real-time updates

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -3,6 +3,7 @@ package web
 import (
 	"bytes"
 	"context"
+	"crypto/sha256"
 	"encoding/json"
 	"fmt"
 	"log"
@@ -104,6 +105,8 @@ func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		h.handleCrew(w, r)
 	case path == "/ready" && r.Method == http.MethodGet:
 		h.handleReady(w, r)
+	case path == "/events" && r.Method == http.MethodGet:
+		h.handleSSE(w, r)
 	default:
 		http.Error(w, "Not found", http.StatusNotFound)
 	}
@@ -1667,4 +1670,105 @@ func parseCommandArgs(command string) []string {
 	}
 
 	return args
+}
+
+// handleSSE streams Server-Sent Events to the dashboard client.
+// It polls key dashboard state every 2 seconds and sends an event when
+// changes are detected, allowing the client to trigger a re-render.
+// Falls through gracefully if the client disconnects.
+func (h *APIHandler) handleSSE(w http.ResponseWriter, r *http.Request) {
+	flusher, ok := w.(http.Flusher)
+	if !ok {
+		http.Error(w, "SSE not supported", http.StatusInternalServerError)
+		return
+	}
+
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.Header().Set("Connection", "keep-alive")
+	w.Header().Set("Access-Control-Allow-Origin", "*")
+	w.Header().Set("X-Accel-Buffering", "no")
+
+	ctx := r.Context()
+
+	// Send initial connection event
+	fmt.Fprintf(w, "event: connected\ndata: ok\n\n")
+	flusher.Flush()
+
+	var lastHash string
+	ticker := time.NewTicker(2 * time.Second)
+	defer ticker.Stop()
+
+	// Send keepalive comment every 15 seconds to prevent connection timeouts
+	keepalive := time.NewTicker(15 * time.Second)
+	defer keepalive.Stop()
+
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-keepalive.C:
+			fmt.Fprintf(w, ": keepalive\n\n")
+			flusher.Flush()
+		case <-ticker.C:
+			hash := h.computeDashboardHash(ctx)
+			if hash != "" && hash != lastHash {
+				lastHash = hash
+				fmt.Fprintf(w, "event: dashboard-update\ndata: %s\n\n", hash)
+				flusher.Flush()
+			}
+		}
+	}
+}
+
+// computeDashboardHash generates a lightweight hash of key dashboard state.
+// It runs quick commands in parallel and hashes their output to detect changes.
+func (h *APIHandler) computeDashboardHash(ctx context.Context) string {
+	ctx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	defer cancel()
+
+	var mu sync.Mutex
+	var parts []string
+
+	var wg sync.WaitGroup
+	wg.Add(3)
+
+	// Check worker/polecat state
+	go func() {
+		defer wg.Done()
+		if out, err := h.runGtCommand(ctx, 3*time.Second, []string{"status", "--json"}); err == nil {
+			mu.Lock()
+			parts = append(parts, "status:"+out)
+			mu.Unlock()
+		}
+	}()
+
+	// Check hooks state
+	go func() {
+		defer wg.Done()
+		if out, err := h.runGtCommand(ctx, 3*time.Second, []string{"hooks", "list"}); err == nil {
+			mu.Lock()
+			parts = append(parts, "hooks:"+out)
+			mu.Unlock()
+		}
+	}()
+
+	// Check mail count
+	go func() {
+		defer wg.Done()
+		if out, err := h.runGtCommand(ctx, 3*time.Second, []string{"mail", "inbox"}); err == nil {
+			mu.Lock()
+			parts = append(parts, "mail:"+out)
+			mu.Unlock()
+		}
+	}()
+
+	wg.Wait()
+
+	if len(parts) == 0 {
+		return ""
+	}
+
+	h256 := sha256.Sum256([]byte(strings.Join(parts, "|")))
+	return fmt.Sprintf("%x", h256[:8])
 }

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -571,8 +571,11 @@ func TestConvoyHandler_HTMXAutoRefresh(t *testing.T) {
 	if !strings.Contains(body, "hx-trigger") {
 		t.Error("Response should contain hx-trigger attribute for HTMX")
 	}
-	if !strings.Contains(body, "every 10s") {
-		t.Error("Response should contain 'every 10s' trigger interval")
+	if !strings.Contains(body, "sse:dashboard-update") {
+		t.Error("Response should contain 'sse:dashboard-update' trigger for SSE")
+	}
+	if !strings.Contains(body, "every 30s") {
+		t.Error("Response should contain 'every 30s' polling fallback")
 	}
 }
 
@@ -738,7 +741,7 @@ func TestE2E_Server_FullDashboard(t *testing.T) {
 		{"PR repo", "roxas"},
 		{"Workers section", "Workers"},
 		{"Polecat name", "furiosa"},
-		{"HTMX auto-refresh", `hx-trigger="every 10s`}, // trigger has conditional suffix
+		{"HTMX SSE trigger", `hx-trigger="sse:dashboard-update`},
 	}
 
 	for _, check := range checks {

--- a/internal/web/static/dashboard.css
+++ b/internal/web/static/dashboard.css
@@ -68,6 +68,19 @@
             font-size: 0.75rem;
         }
 
+        .connection-live {
+            color: var(--green);
+        }
+        .connection-live::before {
+            content: "● ";
+        }
+        .connection-reconnecting {
+            color: var(--yellow);
+        }
+        .connection-reconnecting::before {
+            content: "○ ";
+        }
+
         /* Grid layout for panels - auto-fit responsive */
         .panels {
             display: grid;

--- a/internal/web/templates/convoy.html
+++ b/internal/web/templates/convoy.html
@@ -9,7 +9,7 @@
     <link rel="stylesheet" href="/static/dashboard.css">
 </head>
 <body>
-    <div class="dashboard" id="dashboard-main" hx-get="/" hx-trigger="every 10s [!window.pauseRefresh]" hx-swap="morph:outerHTML" hx-ext="morph">
+    <div class="dashboard" id="dashboard-main" hx-get="/" hx-trigger="sse:dashboard-update, every 30s [!window.pauseRefresh && !window.sseConnected]" hx-swap="morph:outerHTML" hx-ext="morph">
         <header>
             <pre class="ascii-title">  __  __    __   _____ __  _   _  __  _    ___ __  __  _ _____ ___  __  _      ______ __  _ _____ ___ ___ 
  / _]/  \ /' _| |_   _/__\| | | ||  \| |  / _//__\|  \| |_   _| _ \/__\| |    / _/ __|  \| |_   _| __| _ \
@@ -19,8 +19,8 @@
                 <button class="cmd-btn" id="open-palette-btn">
                     <span>⌘</span> Commands <kbd>⌘K</kbd>
                 </button>
-                <span class="refresh-info">
-                    Auto-refresh: 10s
+                <span class="refresh-info" id="refresh-info">
+                    <span id="connection-status">Connecting...</span>
                     <span class="htmx-indicator">⟳</span>
                 </span>
             </div>
@@ -894,6 +894,6 @@
         <div id="output-panel-content" class="output-panel-content"></div>
     </div>
 
-    <script src="/static/dashboard.js?v=2"></script>
+    <script src="/static/dashboard.js?v=3"></script>
 </body>
 </html>

--- a/internal/web/templates_test.go
+++ b/internal/web/templates_test.go
@@ -132,8 +132,11 @@ func TestConvoyTemplate_HtmxAutoRefresh(t *testing.T) {
 	if !strings.Contains(output, "hx-trigger") {
 		t.Error("Template should contain hx-trigger for auto-refresh")
 	}
-	if !strings.Contains(output, "every 10s") {
-		t.Error("Template should refresh every 10 seconds")
+	if !strings.Contains(output, "sse:dashboard-update") {
+		t.Error("Template should contain SSE dashboard-update trigger")
+	}
+	if !strings.Contains(output, "every 30s") {
+		t.Error("Template should contain polling fallback trigger")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `/api/events` SSE endpoint streaming dashboard state changes
- Replaces 10-second HTMX polling with EventSource for instant updates
- Falls back to polling if SSE connection drops
- Reduces server load and improves responsiveness

## Bead
gt-tjy

## Test plan
- [ ] Open dashboard, verify real-time updates without visible polling delay
- [ ] Check Network tab for SSE connection to /api/events
- [ ] Kill SSE connection, verify polling fallback activates
- [ ] Verify all panels still update correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)