### PR TITLE
feat(dashboard): add mail threading to inbox

### DIFF
--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -599,6 +599,93 @@ func TestParseMailInboxText_UnreadMarker(t *testing.T) {
 	}
 }
 
+// --- groupIntoThreads tests ---
+
+func TestGroupIntoThreads_SingleMessages(t *testing.T) {
+	msgs := []MailMessage{
+		{ID: "msg-1", From: "alice", Subject: "Hello", Timestamp: "2026-01-01T10:00:00Z"},
+		{ID: "msg-2", From: "bob", Subject: "World", Timestamp: "2026-01-01T11:00:00Z"},
+	}
+	threads := groupIntoThreads(msgs)
+	if len(threads) != 2 {
+		t.Fatalf("got %d threads, want 2", len(threads))
+	}
+	if threads[0].Count != 1 {
+		t.Errorf("thread 0 count = %d, want 1", threads[0].Count)
+	}
+	if threads[1].Subject != "World" {
+		t.Errorf("thread 1 subject = %q, want %q", threads[1].Subject, "World")
+	}
+}
+
+func TestGroupIntoThreads_ByThreadID(t *testing.T) {
+	msgs := []MailMessage{
+		{ID: "msg-1", From: "alice", Subject: "Status update", ThreadID: "t-001", Timestamp: "2026-01-01T10:00:00Z"},
+		{ID: "msg-2", From: "bob", Subject: "Re: Status update", ThreadID: "t-001", Timestamp: "2026-01-01T11:00:00Z"},
+		{ID: "msg-3", From: "carol", Subject: "Other topic", Timestamp: "2026-01-01T12:00:00Z"},
+	}
+	threads := groupIntoThreads(msgs)
+	if len(threads) != 2 {
+		t.Fatalf("got %d threads, want 2", len(threads))
+	}
+	// First thread should have 2 messages grouped by ThreadID
+	if threads[0].Count != 2 {
+		t.Errorf("thread 0 count = %d, want 2", threads[0].Count)
+	}
+	if threads[0].Subject != "Status update" {
+		t.Errorf("thread 0 subject = %q, want %q", threads[0].Subject, "Status update")
+	}
+	if threads[0].LastMessage.ID != "msg-2" {
+		t.Errorf("thread 0 last message ID = %q, want %q", threads[0].LastMessage.ID, "msg-2")
+	}
+	// Second thread is standalone
+	if threads[1].Count != 1 {
+		t.Errorf("thread 1 count = %d, want 1", threads[1].Count)
+	}
+}
+
+func TestGroupIntoThreads_ByReplyTo(t *testing.T) {
+	msgs := []MailMessage{
+		{ID: "msg-1", From: "alice", Subject: "Question", Timestamp: "2026-01-01T10:00:00Z"},
+		{ID: "msg-2", From: "bob", Subject: "Re: Question", ReplyTo: "msg-1", Timestamp: "2026-01-01T11:00:00Z"},
+	}
+	threads := groupIntoThreads(msgs)
+	if len(threads) != 1 {
+		t.Fatalf("got %d threads, want 1", len(threads))
+	}
+	if threads[0].Count != 2 {
+		t.Errorf("thread count = %d, want 2", threads[0].Count)
+	}
+	if threads[0].Subject != "Question" {
+		t.Errorf("thread subject = %q, want %q", threads[0].Subject, "Question")
+	}
+}
+
+func TestGroupIntoThreads_UnreadCount(t *testing.T) {
+	msgs := []MailMessage{
+		{ID: "msg-1", From: "alice", Subject: "Update", ThreadID: "t-001", Read: true},
+		{ID: "msg-2", From: "bob", Subject: "Re: Update", ThreadID: "t-001", Read: false},
+		{ID: "msg-3", From: "carol", Subject: "Re: Update", ThreadID: "t-001", Read: false},
+	}
+	threads := groupIntoThreads(msgs)
+	if len(threads) != 1 {
+		t.Fatalf("got %d threads, want 1", len(threads))
+	}
+	if threads[0].UnreadCount != 2 {
+		t.Errorf("unread count = %d, want 2", threads[0].UnreadCount)
+	}
+}
+
+func TestGroupIntoThreads_ReSubjectStrip(t *testing.T) {
+	msgs := []MailMessage{
+		{ID: "msg-1", From: "alice", Subject: "Re: Original topic", ThreadID: "t-001"},
+	}
+	threads := groupIntoThreads(msgs)
+	if threads[0].Subject != "Original topic" {
+		t.Errorf("subject = %q, want %q", threads[0].Subject, "Original topic")
+	}
+}
+
 // --- parseIssueShowJSON tests (issue #1228: prefer structured JSON over text parsing) ---
 
 func TestParseIssueShowJSON_ValidOutput(t *testing.T) {

--- a/internal/web/static/dashboard.css
+++ b/internal/web/static/dashboard.css
@@ -1464,6 +1464,8 @@
         .panel.expanded .issue-title,
         .panel.expanded .hook-title,
         .panel.expanded .mail-subject,
+        .panel.expanded .mail-thread-preview,
+        .panel.expanded .mail-thread-left .mail-from,
         .panel.expanded .feed-summary,
         .panel.expanded td {
             max-width: none;
@@ -1869,6 +1871,176 @@
         .command-field-select option {
             background: var(--bg-card);
             color: var(--text-primary);
+        }
+
+        /* Mail thread styles */
+        .mail-thread {
+            border-bottom: 1px solid var(--border);
+            transition: background 0.15s ease;
+        }
+
+        .mail-thread:last-child {
+            border-bottom: none;
+        }
+
+        .mail-thread-header {
+            display: flex;
+            align-items: center;
+            gap: 8px;
+            padding: 8px 12px;
+            cursor: pointer;
+            transition: background 0.15s ease;
+        }
+
+        .mail-thread-header:hover {
+            background: var(--bg-card-hover);
+        }
+
+        .mail-thread-unread .mail-thread-header {
+            background: rgba(89, 194, 255, 0.06);
+        }
+
+        .mail-thread-unread .mail-thread-header:hover {
+            background: rgba(89, 194, 255, 0.12);
+        }
+
+        .mail-thread-left {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+            min-width: 120px;
+            flex-shrink: 0;
+        }
+
+        .mail-thread-left .mail-from {
+            font-size: 0.8rem;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+            max-width: 110px;
+        }
+
+        .mail-thread-unread .mail-thread-left .mail-from {
+            font-weight: 600;
+        }
+
+        .thread-count {
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            min-width: 18px;
+            height: 18px;
+            padding: 0 5px;
+            background: var(--border-accent);
+            border-radius: 9px;
+            font-size: 0.65rem;
+            font-weight: 600;
+            color: var(--text-secondary);
+            flex-shrink: 0;
+        }
+
+        .mail-thread-unread .thread-count {
+            background: var(--blue);
+            color: var(--bg-dark);
+        }
+
+        .thread-unread-dot {
+            display: inline-block;
+            width: 6px;
+            height: 6px;
+            border-radius: 50%;
+            background: var(--blue);
+            flex-shrink: 0;
+        }
+
+        .mail-thread-center {
+            flex: 1;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
+        }
+
+        .mail-thread-center .mail-subject {
+            font-size: 0.85rem;
+        }
+
+        .mail-thread-unread .mail-thread-center .mail-subject {
+            font-weight: 600;
+        }
+
+        .mail-thread-preview {
+            color: var(--text-muted);
+            font-size: 0.8rem;
+        }
+
+        .mail-thread-right {
+            flex-shrink: 0;
+        }
+
+        .mail-thread-right .mail-time {
+            font-size: 0.75rem;
+        }
+
+        /* Expanded thread */
+        .mail-thread-expanded {
+            background: rgba(0, 0, 0, 0.1);
+        }
+
+        .mail-thread-expanded .mail-thread-header {
+            border-bottom: 1px solid var(--border);
+        }
+
+        .mail-thread-messages {
+            padding-left: 20px;
+            border-left: 2px solid var(--border-accent);
+            margin-left: 18px;
+        }
+
+        .mail-thread-msg {
+            padding: 6px 12px;
+            border-bottom: 1px solid rgba(45, 54, 63, 0.5);
+            cursor: pointer;
+            transition: background 0.15s ease;
+        }
+
+        .mail-thread-msg:last-child {
+            border-bottom: none;
+        }
+
+        .mail-thread-msg:hover {
+            background: rgba(255, 255, 255, 0.03);
+        }
+
+        .mail-thread-msg.mail-unread {
+            background: rgba(89, 194, 255, 0.05);
+        }
+
+        .mail-thread-msg-header {
+            display: flex;
+            justify-content: space-between;
+            align-items: center;
+        }
+
+        .mail-thread-msg-header .mail-from {
+            font-size: 0.8rem;
+            color: var(--text-secondary);
+        }
+
+        .mail-thread-msg.mail-unread .mail-from {
+            font-weight: 600;
+            color: var(--text-primary);
+        }
+
+        .mail-thread-msg-header .mail-time {
+            font-size: 0.7rem;
+        }
+
+        .mail-thread-msg-subject {
+            font-size: 0.75rem;
+            color: var(--text-muted);
+            overflow: hidden;
+            text-overflow: ellipsis;
+            white-space: nowrap;
         }
 
         /* Mail panel interactions */

--- a/internal/web/templates/convoy.html
+++ b/internal/web/templates/convoy.html
@@ -350,20 +350,10 @@
                     <button class="expand-btn">Expand</button>
                 </div>
                 <div class="panel-body">
-                    <!-- Inbox view (overseer inbox via API) -->
+                    <!-- Inbox view (threaded conversations via API) -->
                     <div id="mail-list">
                         <div class="loading-state" id="mail-loading">Loading inbox...</div>
-                        <table id="mail-table" style="display: none;">
-                            <thead>
-                                <tr>
-                                    <th>From</th>
-                                    <th>Subject</th>
-                                    <th>Time</th>
-                                </tr>
-                            </thead>
-                            <tbody id="mail-tbody">
-                            </tbody>
-                        </table>
+                        <div id="mail-threads" style="display: none;"></div>
                         <div class="empty-state" id="mail-empty" style="display: none;">
                             <p>No mail in inbox</p>
                         </div>


### PR DESCRIPTION
## Summary
- Groups mail messages by thread/reply-to chain in inbox view
- Thread previews in inbox list, expand to see full conversation
- Uses existing reply-to fields for thread grouping
- Threaded indentation styling for conversation flow

## Bead
gt-fru

## Test plan
- [ ] Open dashboard, navigate to Mail panel inbox tab
- [ ] Verify messages are grouped by thread
- [ ] Click a thread to expand and see full conversation
- [ ] Verify reply-to chains display correctly with indentation

🤖 Generated with [Claude Code](https://claude.com/claude-code)