### PR TITLE
fix(rig): map rig/polecats assignees to tmux sessions

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -921,7 +921,8 @@ func runResetStale(bd *beads.Beads, dryRun bool) error {
 	return nil
 }
 
-// assigneeToSessionName converts an assignee (rig/name or rig/crew/name) to tmux session name.
+// assigneeToSessionName converts an assignee (rig/name, rig/crew/name, or rig/polecats/name)
+// to tmux session name.
 // Returns the session name and whether this is a persistent identity (crew).
 func assigneeToSessionName(assignee string) (sessionName string, isPersistent bool) {
 	parts := strings.Split(assignee, "/")
@@ -934,6 +935,10 @@ func assigneeToSessionName(assignee string) (sessionName string, isPersistent bo
 		// rig/crew/name -> gt-rig-crew-name
 		if parts[1] == "crew" {
 			return fmt.Sprintf("gt-%s-crew-%s", parts[0], parts[2]), true
+		}
+		// rig/polecats/name -> gt-rig-name
+		if parts[1] == "polecats" {
+			return fmt.Sprintf("gt-%s-%s", parts[0], parts[2]), false
 		}
 		// Other 3-part formats not recognized
 		return "", false

--- a/internal/cmd/rig_assignee_test.go
+++ b/internal/cmd/rig_assignee_test.go
@@ -1,0 +1,49 @@
+package cmd
+
+import "testing"
+
+func TestAssigneeToSessionName(t *testing.T) {
+	tests := []struct {
+		name           string
+		assignee       string
+		wantSession    string
+		wantPersistent bool
+	}{
+		{
+			name:           "two part polecat",
+			assignee:       "schema_tools/nux",
+			wantSession:    "gt-schema_tools-nux",
+			wantPersistent: false,
+		},
+		{
+			name:           "three part crew",
+			assignee:       "schema_tools/crew/fiddler",
+			wantSession:    "gt-schema_tools-crew-fiddler",
+			wantPersistent: true,
+		},
+		{
+			name:           "three part polecats",
+			assignee:       "schema_tools/polecats/nux",
+			wantSession:    "gt-schema_tools-nux",
+			wantPersistent: false,
+		},
+		{
+			name:           "unknown three part role",
+			assignee:       "schema_tools/refinery/rig",
+			wantSession:    "",
+			wantPersistent: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gotSession, gotPersistent := assigneeToSessionName(tc.assignee)
+			if gotSession != tc.wantSession {
+				t.Fatalf("session = %q, want %q", gotSession, tc.wantSession)
+			}
+			if gotPersistent != tc.wantPersistent {
+				t.Fatalf("persistent = %v, want %v", gotPersistent, tc.wantPersistent)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Motivation

Some stale-session/reset flows need to map assignee identities to tmux session names. `rig/polecats/name` assignee format was not recognized, which could prevent correct stale-session targeting for polecat identities.

## What this changes

- Extends `assigneeToSessionName` to support:
  - `rig/polecats/name` -> `gt-rig-name`
- Preserves existing mappings:
  - `rig/name` -> `gt-rig-name`
  - `rig/crew/name` -> `gt-rig-crew-name`

## Why this is safe

- Narrow change to assignee parsing logic.
- No behavior change for existing recognized formats.
- Unknown 3-part roles remain explicitly unsupported.

## Tests

- Adds `internal/cmd/rig_assignee_test.go` cases for:
  - two-part polecat identity
  - three-part crew identity
  - three-part polecats identity
  - unknown three-part role fallback