### PR TITLE
feat(dashboard): enhanced command palette with autocomplete and context

### DIFF
--- a/internal/web/static/dashboard.css
+++ b/internal/web/static/dashboard.css
@@ -1664,6 +1664,38 @@
             margin-right: 4px;
         }
 
+        /* Command palette section headers */
+        .command-section-header {
+            padding: 6px 16px 4px;
+            font-size: 0.7rem;
+            font-weight: 600;
+            color: var(--text-muted);
+            text-transform: uppercase;
+            letter-spacing: 0.05em;
+            border-top: 1px solid var(--border);
+            margin-top: 4px;
+        }
+
+        .command-section-header:first-child {
+            border-top: none;
+            margin-top: 0;
+        }
+
+        /* Recent command icon */
+        .command-recent-icon {
+            color: var(--text-muted);
+            font-size: 0.85rem;
+            flex-shrink: 0;
+        }
+
+        /* Search match highlight */
+        .command-name mark {
+            background: rgba(255, 196, 0, 0.25);
+            color: var(--text-primary);
+            border-radius: 2px;
+            padding: 0 1px;
+        }
+
         /* Command args hint in list */
         .command-args {
             color: var(--text-muted);

--- a/internal/web/templates/convoy.html
+++ b/internal/web/templates/convoy.html
@@ -832,7 +832,7 @@
     <!-- Command Palette (outside HTMX-refreshed area) -->
     <div id="command-palette-overlay" class="command-palette-overlay">
         <div class="command-palette">
-            <input type="text" id="command-palette-input" class="command-palette-input" placeholder="Search commands..." autocomplete="off">
+            <input type="text" id="command-palette-input" class="command-palette-input" placeholder="Type to search commands..." autocomplete="off">
             <div id="command-palette-results" class="command-palette-results"></div>
             <div class="command-palette-footer">
                 <span><kbd>↑↓</kbd> navigate</span>


### PR DESCRIPTION
## Summary
- Autocomplete with fuzzy matching and better scoring
- Recent commands history (persisted, shown as a section)
- Contextual suggestions based on active panel (mail, crew, work, merge queue)
- Section headers in command list (Recent, Contextual, All)

## Bead
gt-ggl

## Test plan
- [ ] Open command palette (Cmd+K), verify recent commands section appears
- [ ] Type partial command, verify autocomplete/fuzzy matching works
- [ ] Navigate to Mail panel, open palette, verify mail-related commands prioritized
- [ ] Run a command, reopen palette, verify it appears in Recent section
- [ ] Navigate to Work panel, verify contextual suggestions change

🤖 Generated with [Claude Code](https://claude.com/claude-code)