### PR TITLE
fix(mail): resolve identity from .gt-agent for nested agent dirs

### DIFF
--- a/internal/cmd/mail_identity_test.go
+++ b/internal/cmd/mail_identity_test.go
@@ -1,0 +1,75 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDetectSenderFromCwdUsesAgentFileWitnessIdentity(t *testing.T) {
+	t.Setenv("GT_ROLE", "")
+	t.Setenv("GT_RIG", "")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("GT_CREW", "")
+
+	tmp := t.TempDir()
+	witnessDir := filepath.Join(tmp, "x267", "witness")
+	if err := os.MkdirAll(filepath.Join(witnessDir, "rig"), 0o755); err != nil {
+		t.Fatalf("mkdir witness dir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(witnessDir, ".gt-agent"),
+		[]byte(`{"role":"witness","rig":"x267"}`),
+		0o644,
+	); err != nil {
+		t.Fatalf("write .gt-agent: %v", err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(filepath.Join(witnessDir, "rig")); err != nil {
+		t.Fatalf("chdir witness rig dir: %v", err)
+	}
+
+	got := detectSender()
+	if got != "x267/witness" {
+		t.Fatalf("detectSender() = %q, want %q", got, "x267/witness")
+	}
+}
+
+func TestDetectSenderFromCwdUsesAgentFileRefineryIdentity(t *testing.T) {
+	t.Setenv("GT_ROLE", "")
+	t.Setenv("GT_RIG", "")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("GT_CREW", "")
+
+	tmp := t.TempDir()
+	refineryDir := filepath.Join(tmp, "x267", "refinery")
+	if err := os.MkdirAll(filepath.Join(refineryDir, "rig"), 0o755); err != nil {
+		t.Fatalf("mkdir refinery dir: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(refineryDir, ".gt-agent"),
+		[]byte(`{"role":"refinery","rig":"x267"}`),
+		0o644,
+	); err != nil {
+		t.Fatalf("write .gt-agent: %v", err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	defer func() { _ = os.Chdir(oldWd) }()
+	if err := os.Chdir(filepath.Join(refineryDir, "rig")); err != nil {
+		t.Fatalf("chdir refinery rig dir: %v", err)
+	}
+
+	got := detectSender()
+	if got != "x267/refinery" {
+		t.Fatalf("detectSender() = %q, want %q", got, "x267/refinery")
+	}
+}


### PR DESCRIPTION
## Problem
`gt mail inbox` identity auto-detection could miss witness/refinery identities from nested working directories, leading to empty inbox reads even when unread mail exists.

## What Changed
- Added `.gt-agent`-based identity detection with parent-directory lookup.
- Prioritized `.gt-agent` metadata before path heuristics in cwd-based identity detection.
- Added tests for witness/refinery detection from nested `.../witness/rig` and `.../refinery/rig` directories.

## Validation
- `go test ./internal/cmd -run 'TestDetectSenderFromCwdUsesAgentFile'`
- Result: passed.

## Issue
- Closes #1208
