### PR TITLE
fix(mail): resolve cross-rig agent addresses when description is missing

### DIFF
--- a/internal/mail/router_test.go
+++ b/internal/mail/router_test.go
@@ -794,6 +794,21 @@ func TestAgentBeadToAddress(t *testing.T) {
 			want: "pyspark_pipeline_framework/Toast",
 		},
 		{
+			name: "malformed singleton witness with name segment",
+			bead: &agentBead{ID: "bd-beads-witness-extra"},
+			want: "",
+		},
+		{
+			name: "malformed singleton refinery with name segment",
+			bead: &agentBead{ID: "bd-beads-refinery-extra"},
+			want: "",
+		},
+		{
+			name: "hyphenated agent name via fallback",
+			bead: &agentBead{ID: "bd-beads-crew-my-agent"},
+			want: "beads/my-agent",
+		},
+		{
 			name: "empty ID",
 			bead: &agentBead{ID: ""},
 			want: "",


### PR DESCRIPTION
## Summary
- `agentBeadToAddress()` returns empty string for non-`gt-` prefixed agent beads when their description metadata is missing (`role_type:`, `rig:` fields)
- Adds `parseRigAgentAddressFromID()` fallback that extracts rig/role/name from the bead ID by scanning for known role markers (`crew`, `polecat`, `witness`, `refinery`)
- Makes cross-rig mail resilient to agent beads created without proper description fields (e.g. via manual `bd create` instead of `gt crew add`)

## Test plan
- [x] Updated `TestAgentBeadToAddress` with 6 new cases covering non-gt prefixes with and without descriptions
- [x] All existing tests pass unchanged
- [x] `go test ./internal/mail/` passes
- [x] `go build ./...` clean
- [x] Verified end-to-end: `gt mail send beads/beavis` resolves correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)