### PR TITLE
fix(formula): restore deacon patrol changes overwritten by go generate

### DIFF
--- a/.beads/formulas/mol-deacon-patrol.formula.toml
+++ b/.beads/formulas/mol-deacon-patrol.formula.toml
@@ -16,14 +16,15 @@ This prevents flooding idle agents with health checks every few seconds.
 
 ## Second-Order Monitoring
 
-Witnesses send WITNESS_PING messages to verify the Deacon is alive. This
-prevents the "who watches the watchers" problem - if the Deacon dies,
-Witnesses detect it and escalate to the Mayor.
+Witnesses passively monitor Deacon health by checking the Deacon's agent bead
+last_activity timestamp. This prevents the "who watches the watchers" problem —
+if the Deacon dies, Witnesses detect it and escalate to the Mayor.
 
-The Deacon's agent bead last_activity timestamp is updated during each patrol
-cycle. Witnesses check this timestamp to verify health."""
+No WITNESS_PING mail is sent. Witnesses observe the Deacon's last_activity
+timestamp instead, and only send an alert to the Mayor if the Deacon appears
+unresponsive (>5 minutes stale). This avoids heartbeat mail spam."""
 formula = "mol-deacon-patrol"
-version = 10
+version = 11
 
 [vars]
 [vars.wisp_type]
@@ -47,14 +48,6 @@ gt mail inbox
 # For each message:
 gt mail read <id>
 # Handle based on message type
-```
-
-**WITNESS_PING**:
-Witnesses periodically ping to verify Deacon is alive. Simply acknowledge
-and archive - the fact that you're processing mail proves you're running.
-Your agent bead last_activity is updated automatically during patrol.
-```bash
-gt mail archive <message-id>
 ```
 
 **HELP / Escalation**:
@@ -760,9 +753,38 @@ If performance becomes an issue, add a cooldown gate (e.g., run once per hour).
 **Exit criteria:** Wisps compacted (or nothing to compact)."""
 
 [[steps]]
+id = "compact-report"
+title = "Send compaction digest report"
+needs = ["wisp-compact"]
+description = """
+Generate and send the daily compaction digest.
+
+**Step 1: Send daily digest**
+```bash
+gt compact report
+```
+
+This runs compaction (capturing JSON results), queries active wisps,
+builds a per-category breakdown (Heartbeats, Patrols, Errors, Untyped),
+detects anomalies, and sends the digest to deacon/ (cc mayor/).
+
+A permanent event bead (wisp.compaction) is created for audit trail.
+
+**Step 2: Weekly rollup (Mondays only)**
+If today is Monday, also send the weekly rollup:
+```bash
+gt compact report --weekly
+```
+
+This aggregates the past 7 days of compaction event beads and sends
+trend data (totals, promotion rate, avg deleted/day) to mayor/.
+
+**Exit criteria:** Compaction digest sent (or nothing to report)."""
+
+[[steps]]
 id = "costs-digest"
 title = "Aggregate daily costs [DISABLED]"
-needs = ["wisp-compact"]
+needs = ["compact-report"]
 description = """
 **⚠️ DISABLED** - Skip this step entirely.
 
@@ -885,7 +907,6 @@ Inbox should be EMPTY or contain only just-arrived unprocessed messages.
 **Step 2: Archive any remaining processed messages**
 
 All message types should have been archived during inbox-check processing:
-- WITNESS_PING → archived after acknowledging
 - HELP/Escalation → archived after handling
 - LIFECYCLE → archived after processing
 

--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -16,14 +16,15 @@ This prevents flooding idle agents with health checks every few seconds.
 
 ## Second-Order Monitoring
 
-Witnesses send WITNESS_PING messages to verify the Deacon is alive. This
-prevents the "who watches the watchers" problem - if the Deacon dies,
-Witnesses detect it and escalate to the Mayor.
+Witnesses passively monitor Deacon health by checking the Deacon's agent bead
+last_activity timestamp. This prevents the "who watches the watchers" problem —
+if the Deacon dies, Witnesses detect it and escalate to the Mayor.
 
-The Deacon's agent bead last_activity timestamp is updated during each patrol
-cycle. Witnesses check this timestamp to verify health."""
+No WITNESS_PING mail is sent. Witnesses observe the Deacon's last_activity
+timestamp instead, and only send an alert to the Mayor if the Deacon appears
+unresponsive (>5 minutes stale). This avoids heartbeat mail spam."""
 formula = "mol-deacon-patrol"
-version = 10
+version = 11
 
 [vars]
 [vars.wisp_type]
@@ -47,14 +48,6 @@ gt mail inbox
 # For each message:
 gt mail read <id>
 # Handle based on message type
-```
-
-**WITNESS_PING**:
-Witnesses periodically ping to verify Deacon is alive. Simply acknowledge
-and archive - the fact that you're processing mail proves you're running.
-Your agent bead last_activity is updated automatically during patrol.
-```bash
-gt mail archive <message-id>
 ```
 
 **HELP / Escalation**:
@@ -760,9 +753,38 @@ If performance becomes an issue, add a cooldown gate (e.g., run once per hour).
 **Exit criteria:** Wisps compacted (or nothing to compact)."""
 
 [[steps]]
+id = "compact-report"
+title = "Send compaction digest report"
+needs = ["wisp-compact"]
+description = """
+Generate and send the daily compaction digest.
+
+**Step 1: Send daily digest**
+```bash
+gt compact report
+```
+
+This runs compaction (capturing JSON results), queries active wisps,
+builds a per-category breakdown (Heartbeats, Patrols, Errors, Untyped),
+detects anomalies, and sends the digest to deacon/ (cc mayor/).
+
+A permanent event bead (wisp.compaction) is created for audit trail.
+
+**Step 2: Weekly rollup (Mondays only)**
+If today is Monday, also send the weekly rollup:
+```bash
+gt compact report --weekly
+```
+
+This aggregates the past 7 days of compaction event beads and sends
+trend data (totals, promotion rate, avg deleted/day) to mayor/.
+
+**Exit criteria:** Compaction digest sent (or nothing to report)."""
+
+[[steps]]
 id = "costs-digest"
 title = "Aggregate daily costs [DISABLED]"
-needs = ["wisp-compact"]
+needs = ["compact-report"]
 description = """
 **⚠️ DISABLED** - Skip this step entirely.
 
@@ -885,7 +907,6 @@ Inbox should be EMPTY or contain only just-arrived unprocessed messages.
 **Step 2: Archive any remaining processed messages**
 
 All message types should have been archived during inbox-check processing:
-- WITNESS_PING → archived after acknowledging
 - HELP/Escalation → archived after handling
 - LIFECYCLE → archived after processing
 


### PR DESCRIPTION
## Summary

Two deacon patrol formula improvements were silently reverted when a later `go generate` copied stale `.beads/formulas/` over `internal/formula/formulas/`:

- **WITNESS_PING removal** (original: `fc77e86b`) — replaced mail-based heartbeat with passive `last_activity` timestamp checking, reducing inbox spam
- **compact-report step** (original: `346ddaa3`) — daily compaction digest via `gt compact report`, with weekly rollups on Mondays

Both original commits only updated `internal/formula/formulas/` (the generated/embedded copy) without updating `.beads/formulas/` (the canonical source). When `4aadf656` ran `go generate ./internal/formula/...`, it copied the stale canonical source over the patched embedded copy, reverting both changes.

This fix applies both changes to the canonical `.beads/formulas/` source first, then regenerates the embedded copy via `go generate`.

### Root cause

The `go:generate` directive in `internal/formula/embed.go:14` copies `.beads/formulas/ → internal/formula/formulas/`. Commits that only edit `internal/` will be silently overwritten by the next `go generate`.

## Test plan

- [x] `go build ./cmd/gt` passes
- [x] `go test ./internal/formula/...` passes
- [x] `.beads/` and `internal/` copies are identical after `go generate`
- [x] No WITNESS_PING handling remains in inbox-check step
- [x] compact-report step present between wisp-compact and costs-digest
- [x] Formula version bumped 10 → 11