### PR TITLE
fix(config): use GT_ROOT from envVars before cwd detection in startup commands

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1500,7 +1500,8 @@ func ExtractSimpleRole(gtRole string) string {
 
 // BuildStartupCommand builds a full startup command with environment exports.
 // envVars is a map of environment variable names to values.
-// rigPath is optional - if empty, tries to detect town root from cwd.
+// rigPath is optional - if empty, uses envVars["GT_ROOT"] to find town root,
+// falling back to cwd detection if GT_ROOT is not set.
 // prompt is optional - if provided, appended as the initial prompt.
 //
 // If envVars contains GT_ROLE, the function uses role-based agent resolution
@@ -1525,14 +1526,19 @@ func BuildStartupCommand(envVars map[string]string, rigPath, prompt string) stri
 			rc = ResolveAgentConfig(townRoot, rigPath)
 		}
 	} else {
-		// Try to detect town root from cwd for town-level agents (mayor, deacon)
-		var err error
-		townRoot, err = findTownRootFromCwd()
-		if err != nil {
-			rc = DefaultRuntimeConfig()
-		} else {
+		// For town-level agents (mayor, deacon), prefer GT_ROOT from envVars
+		// (set by AgentEnv) over cwd detection. This ensures role_agents config
+		// is respected even when the daemon runs outside the town hierarchy.
+		townRoot = envVars["GT_ROOT"]
+		if townRoot == "" {
+			var err error
+			townRoot, err = findTownRootFromCwd()
+			if err != nil {
+				rc = DefaultRuntimeConfig()
+			}
+		}
+		if rc == nil {
 			if role != "" {
-				// Use role-based agent resolution for per-role model selection
 				rc = ResolveRoleAgentConfig(role, townRoot, "")
 			} else {
 				rc = ResolveAgentConfig(townRoot, "")
@@ -1657,22 +1663,29 @@ func BuildStartupCommandWithAgentOverride(envVars map[string]string, rigPath, pr
 			rc = ResolveAgentConfig(townRoot, rigPath)
 		}
 	} else {
-		var err error
-		townRoot, err = findTownRootFromCwd()
-		if err != nil {
-			// Can't find town root from cwd - but if agentOverride is specified,
-			// try to use the preset directly. This allows `gt deacon start --agent codex`
-			// to work even when run from outside the town directory.
-			if agentOverride != "" {
-				if preset := GetAgentPresetByName(agentOverride); preset != nil {
-					rc = RuntimeConfigFromPreset(AgentPreset(agentOverride))
+		// For town-level agents (mayor, deacon), prefer GT_ROOT from envVars
+		// (set by AgentEnv) over cwd detection. This ensures role_agents config
+		// is respected even when the daemon runs outside the town hierarchy.
+		townRoot = envVars["GT_ROOT"]
+		if townRoot == "" {
+			var err error
+			townRoot, err = findTownRootFromCwd()
+			if err != nil {
+				// Can't find town root from cwd - but if agentOverride is specified,
+				// try to use the preset directly. This allows `gt deacon start --agent codex`
+				// to work even when run from outside the town directory.
+				if agentOverride != "" {
+					if preset := GetAgentPresetByName(agentOverride); preset != nil {
+						rc = RuntimeConfigFromPreset(AgentPreset(agentOverride))
+					} else {
+						return "", fmt.Errorf("agent '%s' not found", agentOverride)
+					}
 				} else {
-					return "", fmt.Errorf("agent '%s' not found", agentOverride)
+					rc = DefaultRuntimeConfig()
 				}
-			} else {
-				rc = DefaultRuntimeConfig()
 			}
-		} else {
+		}
+		if rc == nil {
 			if agentOverride != "" {
 				var resolveErr error
 				rc, _, resolveErr = ResolveAgentConfigWithOverride(townRoot, "", agentOverride)
@@ -1680,7 +1693,6 @@ func BuildStartupCommandWithAgentOverride(envVars map[string]string, rigPath, pr
 					return "", resolveErr
 				}
 			} else if role != "" {
-				// No override, use role-based agent resolution
 				rc = ResolveRoleAgentConfig(role, townRoot, "")
 			} else {
 				rc = ResolveAgentConfig(townRoot, "")


### PR DESCRIPTION
## Summary

When spawning town-level agents (deacon, mayor) where `rigPath` is empty, `BuildStartupCommand` and `BuildStartupCommandWithAgentOverride` fall back to `findTownRootFromCwd()`. If the daemon's cwd is outside the town hierarchy, this fails silently and returns `DefaultRuntimeConfig()`, ignoring `role_agents` configuration.

`AgentEnv` already sets `GT_ROOT` in envVars from the known `townRoot`. This fix checks `envVars["GT_ROOT"]` before falling back to cwd detection, ensuring `role_agents` config is always respected.

## Related Issue

Fixes #433

## Changes

- `internal/config/loader.go`: In both `BuildStartupCommand` and `BuildStartupCommandWithAgentOverride`, check `envVars["GT_ROOT"]` before calling `findTownRootFromCwd()` when `rigPath` is empty
- `internal/config/loader_test.go`: Add tests verifying both functions use `GT_ROOT` from envVars to resolve `role_agents` config

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] New tests verify `role_agents[deacon]` is respected when GT_ROOT is provided in envVars

## Checklist
- [x] Code follows project style
- [x] No breaking changes