### PR TITLE
fix(web): buffer template output to prevent superfluous WriteHeader

### DIFF
--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"context"
 	"embed"
 	"html/template"
@@ -234,15 +235,19 @@ func (h *ConvoyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		Expand:      expandPanel,
 	}
 
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-
-	if err := h.template.ExecuteTemplate(w, "convoy.html", data); err != nil {
+	var buf bytes.Buffer
+	if err := h.template.ExecuteTemplate(&buf, "convoy.html", data); err != nil {
 		// Security: intentionally returns a generic error message to the client.
 		// Internal error details (err) are not exposed in the HTTP response to
 		// prevent information leakage. The error is logged server-side only.
 		log.Printf("dashboard: template execution failed: %v", err)
 		http.Error(w, "Failed to render template", http.StatusInternalServerError)
 		return
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if _, err := buf.WriteTo(w); err != nil {
+		log.Printf("dashboard: response write failed: %v", err)
 	}
 }
 

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"errors"
+	"html/template"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1053,6 +1054,51 @@ func (m *MockConvoyFetcherWithErrors) FetchIssues() ([]IssueRow, error) {
 
 func (m *MockConvoyFetcherWithErrors) FetchActivity() ([]ActivityRow, error) {
 	return nil, nil
+}
+
+// TestConvoyHandler_TemplateErrorReturns500 verifies that template execution errors
+// return a proper 500 status code, not 200 (which would happen if we wrote directly
+// to the ResponseWriter and it failed mid-execution).
+func TestConvoyHandler_TemplateErrorReturns500(t *testing.T) {
+	// Create a template that writes some output, then fails
+	failingFuncCalled := false
+	tmpl := template.Must(template.New("convoy.html").Funcs(template.FuncMap{
+		"failAfterOutput": func() (string, error) {
+			failingFuncCalled = true
+			return "", errors.New("intentional template error")
+		},
+	}).Parse(`<!DOCTYPE html><html>{{failAfterOutput}}</html>`))
+
+	// Create handler with the failing template
+	handler := &ConvoyHandler{
+		fetcher:  &MockConvoyFetcher{Convoys: []ConvoyRow{}},
+		template: tmpl,
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	handler.ServeHTTP(w, req)
+
+	if !failingFuncCalled {
+		t.Fatal("Template function was not called")
+	}
+
+	// The key assertion: status should be 500, not 200
+	// If we write directly to ResponseWriter and it fails mid-execution,
+	// headers (with 200) are already sent, so http.Error can't change it
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("Status = %d, want %d (template error should return 500, not 200)", w.Code, http.StatusInternalServerError)
+	}
+
+	// Error message should be in the body, not partial template content
+	body := w.Body.String()
+	if !strings.Contains(body, "Failed to render template") {
+		t.Errorf("Response should contain error message, got: %q", body)
+	}
+	if strings.Contains(body, "<!DOCTYPE") {
+		t.Error("Error response should not contain partial template output")
+	}
 }
 
 func TestConvoyHandler_NonFatalErrors(t *testing.T) {


### PR DESCRIPTION
## Summary

Buffer template output to `bytes.Buffer` before writing to `ResponseWriter`, ensuring proper 500 status on template errors instead of 200 with partial content.

## Related Issue

Supersedes #627 (rebased onto current main, resolved conflicts with upstream security/logging improvements)

## Changes

- Buffer `ExecuteTemplate` output to `bytes.Buffer` instead of writing directly to `ResponseWriter`
- Only write to `ResponseWriter` on success — prevents implicit `WriteHeader(200)` on partial template execution
- Preserve upstream's server-side error logging and security comment on the error path
- Add `TestConvoyHandler_TemplateErrorReturns500` verifying template errors return 500

## Testing

- [x] Unit tests pass (`go test ./internal/web/...`)
- [x] Build succeeds (`go build ./...`)

## Checklist

- [x] Code follows project style
- [x] No breaking changes
- [x] Original authorship preserved (Graeme Foster)