### PR TITLE
fix(refinery): reopen source issue on rejection

### DIFF
--- a/.beads/formulas/mol-refinery-patrol.formula.toml
+++ b/.beads/formulas/mol-refinery-patrol.formula.toml
@@ -33,7 +33,7 @@ Witness                    Refinery                      Git
 After successful merge, Refinery sends MERGED mail back to Witness so it can
 complete cleanup (nuke the polecat worktree)."""
 formula = "mol-refinery-patrol"
-version = 4
+version = 5
 
 [vars]
 [vars.wisp_type]
@@ -229,12 +229,41 @@ If tests FAILED:
 1. Diagnose: Is this a branch regression or pre-existing on main?
 2. If branch caused it:
    - Abort merge
-   - Notify polecat: "Tests failing. Please fix and resubmit."
+   - **REOPEN the source issue** so it returns to the ready queue:
+     ```bash
+     bd update <issue-id> --status=open --assignee=""
+     bd sync
+     ```
+   - Notify witness of rejection using the MERGE_FAILED protocol:
+     ```bash
+     gt mail send <rig>/witness -s "MERGE_FAILED <polecat-name>" -m "Branch: <branch>
+     Issue: <issue-id>
+     Polecat: <polecat-name>
+     Rig: <rig>
+     FailureType: tests
+     Error: <failure description>"
+     ```
+   - Close the MR bead as rejected:
+     ```bash
+     bd close <mr-bead-id> --reason "Rejected: <failure description>"
+     ```
+   - Delete the rejected branch (a new polecat will create a fresh one):
+     ```bash
+     git push origin --delete <polecat-branch>
+     ```
+   - Archive the MERGE_READY message
    - Skip to loop-check
 3. If pre-existing on main:
    - File a bead: bd create --type=bug --priority=1 --title="..."
    - FORBIDDEN: Writing code to fix test failures. You merge branches, you do not develop.
    - Proceed with the merge if the failure is pre-existing (not caused by the branch).
+
+**REJECTION CHECKLIST** (all required before skipping to loop-check):
+- [ ] Source issue reopened (bd update <issue-id> --status=open --assignee="")
+- [ ] MERGE_FAILED notification sent to witness
+- [ ] MR bead closed with rejection reason
+- [ ] Rejected branch deleted from remote
+- [ ] MERGE_READY message archived
 
 **GATE REQUIREMENT**: You CANNOT proceed to merge-push without:
 - Tests passing, OR

--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -33,7 +33,7 @@ Witness                    Refinery                      Git
 After successful merge, Refinery sends MERGED mail back to Witness so it can
 complete cleanup (nuke the polecat worktree)."""
 formula = "mol-refinery-patrol"
-version = 4
+version = 5
 
 [vars]
 [vars.wisp_type]
@@ -229,12 +229,41 @@ If tests FAILED:
 1. Diagnose: Is this a branch regression or pre-existing on main?
 2. If branch caused it:
    - Abort merge
-   - Notify polecat: "Tests failing. Please fix and resubmit."
+   - **REOPEN the source issue** so it returns to the ready queue:
+     ```bash
+     bd update <issue-id> --status=open --assignee=""
+     bd sync
+     ```
+   - Notify witness of rejection using the MERGE_FAILED protocol:
+     ```bash
+     gt mail send <rig>/witness -s "MERGE_FAILED <polecat-name>" -m "Branch: <branch>
+     Issue: <issue-id>
+     Polecat: <polecat-name>
+     Rig: <rig>
+     FailureType: tests
+     Error: <failure description>"
+     ```
+   - Close the MR bead as rejected:
+     ```bash
+     bd close <mr-bead-id> --reason "Rejected: <failure description>"
+     ```
+   - Delete the rejected branch (a new polecat will create a fresh one):
+     ```bash
+     git push origin --delete <polecat-branch>
+     ```
+   - Archive the MERGE_READY message
    - Skip to loop-check
 3. If pre-existing on main:
    - File a bead: bd create --type=bug --priority=1 --title="..."
    - FORBIDDEN: Writing code to fix test failures. You merge branches, you do not develop.
    - Proceed with the merge if the failure is pre-existing (not caused by the branch).
+
+**REJECTION CHECKLIST** (all required before skipping to loop-check):
+- [ ] Source issue reopened (bd update <issue-id> --status=open --assignee="")
+- [ ] MERGE_FAILED notification sent to witness
+- [ ] MR bead closed with rejection reason
+- [ ] Rejected branch deleted from remote
+- [ ] MERGE_READY message archived
 
 **GATE REQUIREMENT**: You CANNOT proceed to merge-push without:
 - Tests passing, OR

--- a/internal/templates/roles/refinery.md.tmpl
+++ b/internal/templates/roles/refinery.md.tmpl
@@ -124,7 +124,7 @@ not by Go code. This follows the Zero Friction Control (ZFC) principle.
 | Situation | Your Decision |
 |-----------|---------------|
 | Merge conflict detected | Abort, notify polecat, or attempt resolution |
-| Tests fail after merge | Rollback, notify polecat, investigate cause |
+| Tests fail after merge | Reopen source issue, notify witness (MERGE_FAILED), close MR, delete branch |
 | Push fails | Retry with backoff, or abort and investigate |
 | Pre-existing test failure | File bead for tracking (NEVER fix it yourself) |
 | Uncertain merge order | Choose based on priority, dependencies, timing |
@@ -291,10 +291,10 @@ go test ./...
 Tests PASSED → Gate auto-satisfied, proceed to merge
 
 Tests FAILED:
-├── Branch caused it? → Abort, notify polecat, skip branch
+├── Branch caused it? → Abort, reopen source issue, notify witness (MERGE_FAILED), close MR, delete branch, skip to loop-check
 └── Pre-existing? → MUST do ONE of:
-    ├── Fix it yourself (you're the Engineer!)
-    └── File bead: bd create --type=bug --priority=1 --title="..."
+    ├── File bead: bd create --type=bug --priority=1 --title="..."
+    └── Proceed with merge if failure is not caused by the branch
 
 GATE: Cannot proceed to merge without fix OR bead filed
 ```


### PR DESCRIPTION
## Summary

When the refinery rejects a branch due to test failures, the rejected work gets stuck in limbo — the polecat already closed the bead, but the code never merged. This adds a structured rejection flow that reopens the source issue so it returns to the ready queue for re-dispatch.

## Related Issue

Supersedes #511 (cherry-picked refinery formula fix only, dropped unrelated deacon formula changes)

## Changes

- Updated `handle-failures` step in `mol-refinery-patrol.formula.toml` with structured rejection flow:
  - Reopen source issue via `bd update --status=open` so work returns to ready queue
  - Notify witness of rejection via `gt mail send`
  - Close MR bead with rejection reason
  - Added rejection checklist ensuring all steps are completed before skipping to loop-check
- Synced embedded formula copy via `go generate`

## Testing

- [x] Unit tests pass (`go test ./internal/formula/...`)
- [x] Build succeeds (`go build ./...`)
- [ ] Manual test: reject a branch, verify source issue gets reopened and appears in `bd ready`

## Checklist

- [x] Code follows project style
- [x] No breaking changes
- [x] Original authorship preserved (JeremyKalmus)