### PR TITLE
fix(beads): fix findTownRoot and absolute path handling in rig scanning

### DIFF
--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -434,10 +433,5 @@ func runHookShow(cmd *cobra.Command, args []string) error {
 
 // findTownRoot finds the Gas Town root directory.
 func findTownRoot() (string, error) {
-	cmd := exec.Command("gt", "root")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
+	return workspace.FindFromCwd()
 }

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -1012,7 +1012,14 @@ func scanAllRigsForHookedBeads(townRoot, target string) []*beads.Issue {
 
 	// Scan each rig's beads directory
 	for _, route := range routes {
-		rigBeadsDir := filepath.Join(townRoot, route.Path)
+		// Handle both absolute and relative paths in routes.jsonl
+		// Go's filepath.Join doesn't replace with absolute paths like Python
+		var rigBeadsDir string
+		if filepath.IsAbs(route.Path) {
+			rigBeadsDir = route.Path
+		} else {
+			rigBeadsDir = filepath.Join(townRoot, route.Path)
+		}
 		if _, err := os.Stat(rigBeadsDir); os.IsNotExist(err) {
 			continue
 		}


### PR DESCRIPTION
## Summary

Cherry-pick of 2 of 3 fixes from PR #421 by @timyarm, rebased onto current main with conflicts resolved. Fixes two bugs in beads database routing that cause `gt hook show` to fail when querying hooked beads across rigs.

## Related Issue

Closes #421 (cherry-pick of relevant fixes)

## Changes

- **`findTownRoot` (hook.go):** Replace `exec.Command("gt", "root")` with `workspace.FindFromCwd()`. The `gt root` command does not exist, so `findTownRoot()` always failed, breaking `gt hook show`'s fallback scan of town beads for non-polecat agents.
- **`scanAllRigsForHookedBeads` (molecule_status.go):** Check `filepath.IsAbs(route.Path)` before joining with `townRoot`. When `routes.jsonl` contains absolute paths, `filepath.Join` produces invalid doubled paths like `/home/user/gt/home/user/gt/...`.
- The third fix from #421 (`ResolveBeadsDir` double `.beads` prevention) was already addressed differently in the current codebase and is not included.
- Original authorship by @timyarm preserved in the commit.

## Testing

- [x] Unit tests pass (`go test ./internal/cmd/...`)
- [x] Build passes (`go build ./internal/cmd/...`)
- [x] Verified `strings` import correctly removed (only used by old `findTownRoot`)

## Checklist

- [x] Code follows project style
- [x] No breaking changes
- [x] Original author attribution preserved