### PR TITLE
fix(startup): replace fixed sleeps with prompt-detection polling

### DIFF
--- a/internal/cmd/swarm.go
+++ b/internal/cmd/swarm.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
+
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/git"
@@ -527,6 +529,11 @@ func spawnSwarmWorkersFromBeads(r *rig.Rig, townRoot string, swarmID string, wor
 				style.PrintWarning("  couldn't start %s: %v", worker, err)
 				continue
 			}
+			// Minimum readiness guard before injection. Start() handles
+			// runtime-config-aware delays internally, but presets with
+			// ReadyDelayMs=0 (e.g. gemini, cursor) skip the delay entirely.
+			// This floor prevents early-input races on those agents.
+			time.Sleep(1 * time.Second)
 		}
 
 		// Inject work assignment


### PR DESCRIPTION
## Summary

- Replace the hard-coded `time.Sleep(8 * time.Second)` in `ensureAgentReady()` with `WaitForRuntimeReady()` polling, which detects the agent's prompt prefix (e.g. `❯ ` for Claude) every 200ms instead of blindly sleeping
- Remove redundant 5-second sleep in `swarm.go` after `polecatSessMgr.Start()`, which already handles readiness internally via `WaitForCommand()`, `AcceptBypassPermissionsWarning()`, and `runtime.SleepForReadyDelay()` (fixed delay)
- For known agent presets: uses the preset's `ReadyPromptPrefix` and `ReadyDelayMs` for prompt-detection polling
- For unknown/custom agents: falls back to a 1-second fixed delay with no prompt detection (mirrors old behavior)
- Empty `GT_AGENT` normalized to "claude" before preset lookup (default sessions are Claude)
- Minimum 1s readiness delay floor for presets without prompt detection (prevents early-input races on gemini, cursor, auggie, amp)

Cherry-picked from #431 by @ekoziol and adapted to use existing `WaitForRuntimeReady()` infrastructure.

Supersedes #1395 (closed — was pushed directly to upstream instead of from fork).

## Test plan

- [x] `go build ./...` — clean build
- [x] `go vet ./...` — no warnings
- [x] `go test ./internal/cmd/... -count=1` — all cmd tests pass
- [x] `go test ./internal/config/... -count=1` — config tests pass
- [ ] Manual: `gt start` on fast machine — agent ready in <1s instead of 8s
- [ ] Manual: `gt start` on slow machine — agent waits up to 60s timeout, then proceeds gracefully
- [ ] Manual: `gt swarm create` — workers start with minimum 1s readiness guard
- [ ] Manual: custom/unknown GT_AGENT — falls back to 1s delay (no 60s regression)
- [ ] Manual: zero-delay preset (e.g. gemini) — gets 1s minimum floor, not 0s