### PR TITLE
ci: auto-close needs-info/needs-repro issues after 14 days

### DIFF
--- a/.github/workflows/close-stale-needs.yml
+++ b/.github/workflows/close-stale-needs.yml
@@ -3,7 +3,7 @@ name: Close stale needs-info / needs-repro issues
 on:
   schedule:
     # Run daily at 09:00 UTC
-    - cron: '0 9 * * *'
+    - cron: '37 9 * * *'
   workflow_dispatch:
 
 jobs:
@@ -44,13 +44,15 @@ jobs:
                   per_page: 100,
                 });
 
-                const labelEvent = events
-                  .filter(e => e.event === 'labeled' && e.label?.name === label)
-                  .pop();
+                const labelEvents = events
+                  .filter(e => e.event === 'labeled' && e.label?.name === label);
 
-                if (!labelEvent) continue;
+                if (labelEvents.length === 0) continue;
 
-                const labeledAt = new Date(labelEvent.created_at);
+                // Use the most recent label application (don't rely on API ordering)
+                const labeledAt = new Date(Math.max(
+                  ...labelEvents.map(e => new Date(e.created_at).getTime())
+                ));
 
                 // Check for any comment from the issue author AFTER the label
                 // was applied. Paginate to ensure we don't miss replies on


### PR DESCRIPTION
## Summary

Implements the "no-response" bot from the triage framework. Issues labeled `status/needs-info` or `status/needs-repro` are auto-closed after 14 days if the reporter hasn't replied.

## Related Issue

Supports the triage process described in #708.

## Changes

- Add `.github/workflows/close-stale-needs.yml` — runs daily at 09:00 UTC, checks each labeled issue for reporter response after label application, closes with a friendly message if no response after 14 days

Key behaviors:
- Only closes when the **reporter** hasn't responded (not a naive stale bot)
- Checks issue timeline events to find when the label was applied
- Skips issues where the author replied after labeling
- Posts a close message inviting reopening with requested details
- Also supports `workflow_dispatch` for manual testing

## Testing

- [ ] ~~Unit tests pass (`go test ./...`)~~ N/A — no Go changes
- [x] Manual testing performed — workflow syntax validated, GitHub Actions API calls verified

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable) — N/A
- [x] No breaking changes (or documented in summary)