### PR TITLE
fix(config): remove incorrect --settings flag for crew/polecat roles

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1092,14 +1092,16 @@ func withRoleSettingsFlag(rc *RuntimeConfig, role, rigPath string) *RuntimeConfi
 
 // roleSettingsDir returns the shared settings directory for roles whose session
 // working directory differs from their settings location. Returns empty for
-// roles where settings and session directory are the same (mayor, deacon).
+// roles where settings and session directory are the same (mayor, deacon), or
+// where each agent has its own settings in its working directory (crew, polecat).
 func roleSettingsDir(role, rigPath string) string {
 	switch role {
-	case "crew", "witness", "refinery":
+	case "witness", "refinery":
+		// Single-instance roles: settings live at <rig>/<role>/.claude/
 		return filepath.Join(rigPath, role)
-	case "polecat":
-		return filepath.Join(rigPath, "polecats")
 	default:
+		// crew/polecat: per-agent settings in <rig>/<role>/<name>/.claude/ (CWD)
+		// mayor/deacon/boot: settings in working directory
 		return ""
 	}
 }

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -1603,14 +1603,14 @@ func TestWithRoleSettingsFlag_InjectsForClaude(t *testing.T) {
 		t.Fatalf("creating settings dir: %v", err)
 	}
 
-	// Default config (Claude agent) for polecat role
+	// Default config (Claude agent) for witness role (single-instance, gets --settings)
 	settings := NewRigSettings()
 	if err := SaveRigSettings(filepath.Join(settingsDir, "config.json"), settings); err != nil {
 		t.Fatalf("saving settings: %v", err)
 	}
 
-	rc := ResolveRoleAgentConfig("polecat", townRoot, rigPath)
-	// Should contain --settings since default agent is Claude
+	rc := ResolveRoleAgentConfig("witness", townRoot, rigPath)
+	// Should contain --settings since witness is a single-instance role
 	found := false
 	for _, arg := range rc.Args {
 		if arg == "--settings" {
@@ -1619,7 +1619,18 @@ func TestWithRoleSettingsFlag_InjectsForClaude(t *testing.T) {
 		}
 	}
 	if !found {
-		t.Errorf("default Claude agent should get --settings flag for polecat role, but Args = %v", rc.Args)
+		t.Errorf("default Claude agent should get --settings flag for witness role, but Args = %v", rc.Args)
+	}
+
+	// Polecat and crew should NOT get --settings (per-agent settings in CWD)
+	for _, role := range []string{"polecat", "crew"} {
+		rc = ResolveRoleAgentConfig(role, townRoot, rigPath)
+		for _, arg := range rc.Args {
+			if arg == "--settings" {
+				t.Errorf("%s role should NOT get --settings flag (per-agent CWD settings), but Args = %v", role, rc.Args)
+				break
+			}
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- `roleSettingsDir()` incorrectly returns the parent directory (`<rig>/crew/` or `<rig>/polecats/`) for crew and polecat roles, causing `--settings` to point to a non-existent `settings.local.json`
- Crew and polecat agents each have per-agent settings in their own working directory (`<rig>/crew/<name>/.claude/` and `<rig>/polecats/<name>/.claude/`), so Claude discovers them from CWD naturally — no `--settings` override is needed
- Only single-instance roles (`witness`, `refinery`) need the `--settings` flag since their session directory differs from their settings location

**Symptom**: `gt crew at <name>` sessions crash immediately with `[exited]` because Claude treats a missing `--settings` path as fatal.

**Root cause**: Introduced in #1261 which added `roleSettingsDir` — the mapping assumed crew/polecat settings live at the role directory level, but they live at the per-agent level.

## Changes

- `internal/config/loader.go` — Remove `"crew"` and `"polecat"` cases from `roleSettingsDir()` switch, so they fall through to the default (empty string = no `--settings` flag)
- `internal/config/loader_test.go` — Update test to use `witness` as the positive case; add negative assertions that `crew` and `polecat` do NOT receive `--settings`

## Test plan

- [x] `go build ./internal/config/` compiles clean
- [x] `go test ./internal/config/ -run "TestRoleSettingsDir|TestWithRoleSettingsFlag"` passes
- [x] Cherry-picked cleanly onto latest `upstream/main` (1112c906)

🤖 Generated with [Claude Code](https://claude.com/claude-code)