### PR TITLE
fix(nudge): retry on transient send-keys errors during agent startup

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -36,7 +36,9 @@ const (
 	// NudgeReadyTimeout is how long NudgeSession waits for the target pane to
 	// accept input before giving up. Covers cold startup where Claude's TUI
 	// hasn't initialized yet (tmux returns "not in a mode").
-	NudgeReadyTimeout = 30 * time.Second
+	// Kept well under nudgeLockTimeout (30s) so concurrent nudges don't
+	// starve waiting for the lock while a retry loop holds it.
+	NudgeReadyTimeout = 10 * time.Second
 
 	// NudgeRetryInterval is the base interval between send-keys retry attempts
 	// when a transient tmux error is encountered during nudge delivery.


### PR DESCRIPTION
## Summary

- `NudgeSession` / `NudgePane` now retry with backoff when `tmux send-keys` fails with "not in a mode" during cold startup
- Non-transient errors (session not found, no server) still fail immediately — no wasted retries
- Backoff starts at 500ms, increases by 1.5x each attempt, capped at 2s, bounded by 30s total timeout (`NudgeReadyTimeout`)

**Root cause**: When `gt crew at` or `gt sling` creates a session, the agent TUI (Claude Code) takes a few seconds to initialize input handling. During this window, `tmux send-keys` returns "not in a mode" and the nudge is lost. Any nudge sent in this window (startup hooks, coordinator messages, work assignments) fails silently or with a wall of repeated errors.

## Scope — what this fixes and what it doesn't

| Problem | Issue | Fixed? |
|---------|-------|--------|
| Nudge during startup → "not in a mode" | This PR | Yes |
| Nudge during user typing → garbled input | #1216 | No — needs Claude Code side-channel API |
| Nudge during tool call → kills in-flight work | #1275 | No — needs nudge priority/queueing layer |

This is a pragmatic partial fix for the startup race. The deeper nudge reliability problems (#1216, #1275) require changes to how agents receive input (side-channel vs shared input field).

## Changes

- `internal/constants/constants.go` — Add `NudgeReadyTimeout` (30s) and `NudgeRetryInterval` (500ms)
- `internal/tmux/tmux.go` — Add `isTransientSendKeysError()`, `sendKeysLiteralWithRetry()`, update `NudgeSession`/`NudgePane` to use retry
- `internal/tmux/tmux_test.go` — Tests for transient error detection, immediate success, non-transient fast-fail, and end-to-end nudge with retry

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/tmux/ -run "TestIsTransient|TestSendKeysLiteral|TestNudgeSession_WithRetry|TestNudgeLock"` — all pass
- [x] New tests verify: transient vs non-transient classification, fast-fail on permanent errors, successful delivery on ready sessions
- [ ] Manual: `gt crew at sean --rig gastown --detached && gt nudge gastown/crew/sean "test"` — nudge waits for readiness instead of failing

Relates to #1216, #1275

🤖 Generated with [Claude Code](https://claude.com/claude-code)