### PR TITLE
fix(config): remove --settings flag for polecat role

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1098,7 +1098,11 @@ func roleSettingsDir(role, rigPath string) string {
 	case "crew", "witness", "refinery":
 		return filepath.Join(rigPath, role)
 	case "polecat":
-		return filepath.Join(rigPath, "polecats")
+		// Polecats get settings via EnsureSettingsForRole into their worktree
+		// (polecats/<name>/<rig>/). Claude Code resolves settings from its cwd,
+		// so no --settings flag is needed. The parent polecats/ directory is not
+		// a valid settings location.
+		return ""
 	default:
 		return ""
 	}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -1594,7 +1594,7 @@ func TestWithRoleSettingsFlag_SkipsNonClaude(t *testing.T) {
 	}
 }
 
-func TestWithRoleSettingsFlag_InjectsForClaude(t *testing.T) {
+func TestWithRoleSettingsFlag_NoSettingsForPolecat(t *testing.T) {
 	t.Parallel()
 	townRoot := t.TempDir()
 	rigPath := filepath.Join(townRoot, "myrig")
@@ -1610,16 +1610,13 @@ func TestWithRoleSettingsFlag_InjectsForClaude(t *testing.T) {
 	}
 
 	rc := ResolveRoleAgentConfig("polecat", townRoot, rigPath)
-	// Should contain --settings since default agent is Claude
-	found := false
+	// Polecats should NOT get --settings since EnsureSettingsForRole writes
+	// settings into the worktree and Claude resolves from cwd.
 	for _, arg := range rc.Args {
 		if arg == "--settings" {
-			found = true
+			t.Errorf("polecat should not get --settings flag (settings are in worktree cwd), but Args = %v", rc.Args)
 			break
 		}
-	}
-	if !found {
-		t.Errorf("default Claude agent should get --settings flag for polecat role, but Args = %v", rc.Args)
 	}
 }
 


### PR DESCRIPTION
## Bug

Polecat sessions crash immediately on startup because Claude Code receives a `--settings` flag pointing to a non-existent file:

```
--settings /Users/.../gt/gastown/polecats/.claude/settings.local.json
```

This path (`<rig>/polecats/.claude/settings.local.json`) is never created by any current code path:

- `gt hooks sync` writes settings to individual polecat worktrees (`polecats/<name>/<rig>/.claude/settings.local.json`), not the parent `polecats/` directory
- `EnsureSettingsForRole` writes settings into the polecat's worktree (cwd), not the parent
- `gt doctor` explicitly marks `polecats/.claude/settings.{json,local.json}` as **stale** and flags them as `wrongLocation`

The file only existed previously as a legacy artifact. After recent cleanup (stale settings removal, hooks sync improvements), the file no longer exists, causing the crash.

## Root Cause

`roleSettingsDir()` in `internal/config/loader.go` returns `filepath.Join(rigPath, "polecats")` for the polecat role. This causes `withRoleSettingsFlag()` to inject `--settings <rig>/polecats/.claude/settings.local.json` into the startup command. This path is inconsistent with the actual settings layout used by `gt hooks sync`, `EnsureSettingsForRole`, and `gt doctor`.

## Fix

Return `""` from `roleSettingsDir()` for the polecat role, so no `--settings` flag is injected. Polecats already get settings via `EnsureSettingsForRole` written directly into their worktree, and Claude Code resolves settings from its working directory.

Updated the corresponding test to verify `--settings` is **not** present for polecats.

## Test plan

- [x] `go test ./internal/config/ -run "TestWithRoleSettingsFlag|TestBuildPolecatStartupCommand"` — all pass
- [x] `make install` — clean build
- [x] `gt sling` spawns polecat successfully (manually verified)