### PR TITLE
test(e2e): add containerized install and daemon tests

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,23 +1,9 @@
 name: E2E Tests
 
 on:
-  push:
-    branches: [ main ]
-  pull_request:
-    branches: [ main ]
-    paths:
-      - 'internal/cmd/install*.go'
-      - 'internal/cmd/rig*.go'
-      - 'internal/cmd/crew*.go'
-      - 'internal/cmd/doctor*.go'
-      - 'internal/cmd/daemon*.go'
-      - 'internal/config/**'
-      - 'internal/routing/**'
-      - 'internal/doctor/**'
-      - 'internal/cmd/*_integration_test.go'
-      - 'Dockerfile.e2e'
-      - 'Makefile'
-      - '.github/workflows/e2e.yml'
+  schedule:
+    - cron: '0 6 * * *'  # Daily at 6am UTC
+  workflow_dispatch:       # Allow manual trigger
 
 jobs:
   e2e:

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,31 +1,44 @@
-# Dockerfile.test - Isolated environment for e2e testing
+# Dockerfile.e2e - Isolated environment for e2e testing
 #
 # This container provides full isolation for integration tests that require:
 # - No interference from host tmux sessions
 # - Clean filesystem without existing Gas Town installations
-# - Independent beads daemon
+# - Independent beads daemon and Dolt server
 #
 # Usage:
-#   docker build -f Dockerfile.test -t gastown-test .
+#   docker build -f Dockerfile.e2e -t gastown-test .
 #   docker run --rm gastown-test
 
-FROM golang:1.24-alpine
+FROM golang:1.25-alpine
 
 # Install dependencies including CGO build requirements for beads daemon
+# procps and lsof are required by gt dolt start for process verification
 RUN apk add --no-cache \
     git \
     bash \
     sqlite \
     build-base \
-    zstd-dev
+    zstd-dev \
+    icu-dev \
+    procps \
+    lsof
 
-# Configure git (required for gt install --git and rig operations)
+# Install beads daemon (bd) - build from source to handle replace directives
+RUN git clone --depth 1 https://github.com/steveyegge/beads /tmp/beads && \
+    cd /tmp/beads && go install ./cmd/bd && \
+    rm -rf /tmp/beads
+
+# Install Dolt (required for beads database server)
+RUN git clone --depth 1 https://github.com/dolthub/dolt /tmp/dolt && \
+    cd /tmp/dolt/go && go install ./cmd/dolt && \
+    rm -rf /tmp/dolt
+
+# Configure git and dolt identity (required for gt install --git and dolt init)
 RUN git config --global user.name "Test User" && \
     git config --global user.email "test@test.com" && \
-    git config --global init.defaultBranch main
-
-# Install beads daemon (bd)
-RUN go install github.com/steveyegge/beads/cmd/bd@latest
+    git config --global init.defaultBranch main && \
+    dolt config --global --add user.name "Test User" && \
+    dolt config --global --add user.email "test@test.com"
 
 # Set up workspace
 WORKDIR /app
@@ -38,9 +51,8 @@ RUN go mod download
 COPY . .
 
 # Build gt binary
-RUN go build -o /usr/local/bin/gt ./cmd/gt
+RUN go build -ldflags "-X github.com/steveyegge/gastown/internal/cmd.BuiltProperly=1" -o /usr/local/bin/gt ./cmd/gt
 
-# Run integration tests
-# Note: Using -count=1 to disable test caching
-# Runs both TestInstallDoctorClean and TestInstallWithDaemon
-CMD ["go", "test", "-tags=integration", "-timeout=5m", "-v", "-count=1", "-run", "TestInstall(DoctorClean|WithDaemon)", "./internal/cmd/..."]
+# Run e2e tests (all TestInstall* functions from install_integration_test.go)
+# Note: Using -count=1 to disable test caching, -parallel 1 for sequential execution
+CMD ["go", "test", "-tags=e2e", "-timeout=5m", "-v", "-count=1", "-parallel", "1", "-run", "TestInstall", "./internal/cmd/..."]

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build install clean test test-e2e test-e2e-container generate check-up-to-date
+.PHONY: build install clean test test-e2e-container generate check-up-to-date
 
 BINARY := gt
 BUILD_DIR := .
@@ -57,11 +57,7 @@ clean:
 test:
 	go test ./...
 
-# Run e2e tests locally (may have false failures from host environment leakage)
-test-e2e:
-	go test -tags=integration -run 'TestInstallDoctorClean' ./internal/cmd -v -timeout=5m
-
-# Run e2e tests in isolated container (recommended for CI)
+# Run e2e tests in isolated container (the only supported way to run them)
 test-e2e-container:
 	docker build -f Dockerfile.e2e -t gastown-test .
 	docker run --rm gastown-test


### PR DESCRIPTION
## Summary

Resurrects the containerized e2e tests from PR #559 (by @easel / Erik LaBianca), cherry-picked and adapted for the current codebase.

- **9 tests (17 subtests)** across `TestInstallDoctorClean` and `TestInstallWithDaemon` covering `gt install`, `gt rig add`, `gt crew add`, `gt dolt`, `gt daemon`, and `gt doctor`, plus 6 standalone install tests
- **Full Docker isolation** — no host tmux/cache/state leakage
- **Zero test skips** — all dependencies (bd, dolt) installed in container; no conditional skips
- **Dolt server running** — tests initialize dolt database (`gt dolt init-rig hq`) and start the server (`gt dolt start`) before rig operations
- **Build tag isolation** — uses `//go:build e2e` so tests are excluded from CI's `-tags=integration` runs; only the Docker container passes `-tags=e2e`
- **Nightly CI schedule** (6am UTC) + manual `workflow_dispatch` trigger
- Uses `octocat/Hello-World.git` as the test rig repo (front-door CLI only, no internal API calls)
- **Container-only execution** — no local `make test-e2e` target (removed to prevent host leakage)

### Files added/modified (cherry-pick from #559 + adaptation)
- `internal/cmd/install_integration_test.go` — e2e tests (`//go:build e2e`)
- `Dockerfile.e2e` — Alpine-based test container
- `.github/workflows/e2e.yml` — CI workflow
- `Makefile` — `test-e2e-container` target only

### Adaptation commit
- Rebased onto current `upstream/main` (clean 2-commit history)
- Upgraded to `golang:1.25-alpine` (beads requires Go 1.25+)
- Added `icu-dev`, `procps`, `lsof` to Dockerfile (beads ICU dependency, dolt process verification)
- Build `bd` and `dolt` from source in Dockerfile
- Added ldflags (`BuiltProperly=1`) to Dockerfile build
- Switched `rig add` from local paths to remote URL (CLI now validates remote-only)
- Switched workflow from push/PR triggers to nightly schedule
- Added `configureDoltIdentity` helper (HOME override hides container's global dolt config)
- Added `gt dolt init-rig` + `gt dolt start` subtests to both tests
- Added `pkill -f "dolt sql-server"` between tests to avoid port 3307 conflicts
- Removed `mail inbox` and `hook` from command smoke tests (fresh Dolt databases lack beads tables)
- Added crash detection (panic/SIGSEGV/runtime error) to doctor subtests
- Changed build tag from `integration` to `e2e` to prevent CI from running container-only tests
- Removed local `test-e2e` Makefile target (container is the only supported execution path)
- Added `cleanE2EEnv()` helper (local copy, avoids dependency on `integration`-tagged files)
- Added `-parallel 1` to Dockerfile CMD for sequential test execution
- Removed all `t.Skip` guards — dependencies guaranteed by Dockerfile
- Removed phantom `container-test` from Makefile `.PHONY`

## Test plan

- [x] `go build -tags=e2e ./internal/cmd/...` — compiles cleanly
- [x] `go test -tags=integration -list TestInstallDoctorClean` — NOT listed (excluded from CI)
- [x] `go test -tags=e2e -list TestInstall` — all 9 tests listed
- [x] `go test ./internal/cmd/...` — regular tests still pass
- [x] `docker build -f Dockerfile.e2e -t gastown-test .` — container builds
- [x] `docker run --rm gastown-test` — all 9 tests (17 subtests) pass, zero skips

🤖 Generated with [Claude Code](https://claude.com/claude-code)