### PR TITLE
fix(install): bootstrap Dolt server during fresh install

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -352,17 +352,8 @@ func Start(townRoot string) error {
 		return fmt.Errorf("creating data directory: %w", err)
 	}
 
-	// List available databases
-	databases, err := ListDatabases(townRoot)
-	if err != nil {
-		return fmt.Errorf("listing databases: %w", err)
-	}
-
-	if len(databases) == 0 {
-		return fmt.Errorf("no databases found in %s\nInitialize with: gt dolt init-rig <name>", config.DataDir)
-	}
-
 	// Clean up stale Dolt LOCK files in all database directories
+	databases, _ := ListDatabases(townRoot)
 	for _, db := range databases {
 		dbDir := filepath.Join(config.DataDir, db)
 		if err := cleanupStaleDoltLock(dbDir); err != nil {


### PR DESCRIPTION
## Summary

Fresh `gt install --git` hits a chicken-and-egg problem with Dolt:

1. `bd init --backend dolt --server` needs a running Dolt server
2. `doltserver.Start()` refuses to start with an empty `.dolt-data/` directory
3. The database is created by `bd init`, but `bd init` needs the server running first

This results in confusing warnings about falling back to embedded mode and database lock errors.

**Fix:** Move the empty-database guard from `doltserver.Start()` (library) to `runDoltStart()` (CLI handler), so internal callers like install can start an empty server and let `bd init` create the database. Also bootstrap `routing.mode` and hook targets during install to eliminate post-install `gt doctor --fix` items.

### Changes

- **`internal/doltserver/doltserver.go`** — Remove empty-database guard from `Start()`. Internal callers (install, migrate) may legitimately start with an empty data dir.
- **`internal/cmd/dolt.go`** — Add the guard to `runDoltStart()` instead, so `gt dolt start` still gives a helpful error when no databases exist.
- **`internal/cmd/install.go`** — Start Dolt server before `bd init`; set `routing.mode` to explicit; sync hook targets; show post-install note about Dolt server.

### Before

```
$ gt install ~/gt --git
   ⚠ Dolt server at 127.0.0.1:3307 is not reachable, falling back to embedded mode
   ⚠ failed to open database: the database is locked by another dolt process

$ gt doctor
   5 fixable items found
```

### After

```
$ gt install ~/gt --git
   ✓ Town beads initialized (hq- prefix)
   ✓ Synced 4 hook target(s)
   Note: Dolt server is running (stop with gt dolt stop)

$ gt doctor
   68 passed, 2 warnings (global-state, daemon — both intentionally inactive after install)
```

## Test plan

- [ ] `rm -rf ~/gt && go build ./cmd/gt && ./gt install ~/gt --git` — clean install with no Dolt warnings
- [ ] `cd ~/gt && gt doctor` — only global-state and daemon warnings (both expected)
- [ ] `gt dolt status` — server running
- [ ] `bd list` — works without errors
- [ ] `gt dolt start` with empty `.dolt-data/` still shows helpful error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)