### PR TITLE
fix(rig): register route before agent bead creation (#1424)

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -399,30 +399,15 @@ func runRigAdd(cmd *cobra.Command, args []string) error {
 		fmt.Printf("  %s Could not update daemon.json patrols: %v\n", style.Warning.Render("!"), err)
 	}
 
-	// Add route to town-level routes.jsonl for prefix-based routing.
-	// Route points to the canonical beads location:
-	// - If source repo has .beads/ tracked in git, route to mayor/rig
-	// - Otherwise route to rig root (where initBeads creates the database)
-	// The conditional routing is necessary because initBeads creates the database at
-	// "<rig>/.beads", while repos with tracked beads have their database at mayor/rig/.beads.
+	// Route registration is now handled inside AddRig (before agent bead creation)
+	// to avoid "no route found" warnings (#1424). Determine beadsWorkDir for rig identity bead.
 	var beadsWorkDir string
 	if newRig.Config.Prefix != "" {
-		routePath := name
 		mayorRigBeads := filepath.Join(townRoot, name, "mayor", "rig", ".beads")
 		if _, err := os.Stat(mayorRigBeads); err == nil {
-			// Source repo has .beads/ tracked - route to mayor/rig
-			routePath = name + "/mayor/rig"
 			beadsWorkDir = filepath.Join(townRoot, name, "mayor", "rig")
 		} else {
 			beadsWorkDir = filepath.Join(townRoot, name)
-		}
-		route := beads.Route{
-			Prefix: newRig.Config.Prefix + "-",
-			Path:   routePath,
-		}
-		if err := beads.AppendRoute(townRoot, route); err != nil {
-			// Non-fatal: routing will still work, just not from town root
-			fmt.Printf("  %s Could not update routes.jsonl: %v\n", style.Warning.Render("!"), err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Fixes #1424 — `gt rig add` logs noisy "no route found" warnings because the route is registered in `routes.jsonl` *after* agent beads (witness, refinery) are created, but `CreateAgentBead` needs the route to resolve the target database.

```
Warning: no route found for prefix "bt-" (bead bt-btap-witness), falling back to /home/user/gt/btap/.beads
Warning: no route found for prefix "bt-" (bead bt-btap-refinery), falling back to /home/user/gt/btap/.beads
```

**Fix:** Move route registration from the CLI handler (`rig.go`) into `AddRig()` (`manager.go`), placing it right before `initAgentBeads`. The route is now present when `ResolveRoutingTarget` looks it up.

### Changes

- **`internal/rig/manager.go`** — Register route in `AddRig()` after beads init, before `initAgentBeads`
- **`internal/cmd/rig.go`** — Remove duplicate route registration from CLI handler (keep only `beadsWorkDir` logic for rig identity bead)

## Test plan

- [ ] `gt rig add <name> <url>` — no "no route found" warnings
- [ ] `cat ~/gt/.beads/routes.jsonl` — route present for new rig
- [ ] Agent beads created successfully (witness, refinery)
- [ ] `gt rig add --adopt` path unaffected (doesn't call `initAgentBeads`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)