### PR TITLE
fix(rig): handle tracked beads repos correctly during rig add (#1426)

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1122,11 +1122,15 @@ func EnsureMetadata(townRoot, rigName string) error {
 		_ = json.Unmarshal(data, &existing) // best effort
 	}
 
-	// Set/update the dolt server fields
+	// Patch dolt server fields. Only set fields that are gastown's responsibility
+	// (ensuring server mode). dolt_database is owned by bd init — only set it as
+	// a fallback when bd init hasn't run yet (no existing value).
 	existing["database"] = "dolt"
 	existing["backend"] = "dolt"
 	existing["dolt_mode"] = "server"
-	existing["dolt_database"] = rigName
+	if existing["dolt_database"] == nil || existing["dolt_database"] == "" {
+		existing["dolt_database"] = rigName
+	}
 
 	// Always set jsonl_export to the canonical filename.
 	// Historical migrations may have left stale values (e.g., "beads.jsonl").


### PR DESCRIPTION
## Summary

- **`bdDatabaseExists`**: Now verifies the Dolt server actually has the referenced database in `.dolt-data/`, not just that `metadata.json` exists (it may be tracked in git from another workspace)
- **`EnsureMetadata`**: Only sets `dolt_database` as a fallback when `bd init` hasn't set it yet — respects `bd init`'s `beads_<prefix>` naming
- **`SetupRedirect`**: Suppresses "rig .beads not found" warning when `rig/.beads/redirect` exists (intentional tracked-beads configuration)
- **`issue_prefix` / `types.custom`**: Always configured, even when `metadata.json` was tracked in git

Fixes #1426

## Test plan

- [x] `go test ./internal/doltserver/ ./internal/rig/ ./internal/beads/ ./internal/cmd/` — all pass (no test changes)
- [x] `rm -rf ~/gt && gt install ~/gt --git` — clean output, no errors
- [x] `gt rig add btap <url> --branch feature/nats --prefix ap` — no routing warnings, no beads warnings
- [x] `gt doctor` — passes (only pre-existing `priming` issue)

🤖 Generated with [Claude Code](https://claude.com/claude-code)