### PR TITLE
fix(rig): create settings dir and fix priming check for tracked beads (#1428)

### DIFF
--- a/internal/doctor/priming_check.go
+++ b/internal/doctor/priming_check.go
@@ -213,8 +213,9 @@ func (c *PrimingCheck) checkRigPriming(townRoot string) []primingIssue {
 			continue
 		}
 
-		// Check PRIME.md exists at rig level
-		primeMdPath := filepath.Join(rigPath, ".beads", "PRIME.md")
+		// Check PRIME.md exists at rig level (follow redirects for tracked beads)
+		resolvedBeadsDir := beads.ResolveBeadsDir(rigPath)
+		primeMdPath := filepath.Join(resolvedBeadsDir, "PRIME.md")
 		if !fileExists(primeMdPath) {
 			issues = append(issues, primingIssue{
 				location:    rigName,

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -582,6 +582,12 @@ Use crew for your own workspace. Polecats are for batch work dispatch.
 		fmt.Printf("  %s Could not scaffold polecat commands: %v\n", "!", err)
 	}
 
+	// Create rig-level settings directory (used by gt config for rig overrides)
+	rigSettingsPath := filepath.Join(rigPath, constants.DirSettings)
+	if err := os.MkdirAll(rigSettingsPath, 0755); err != nil {
+		return nil, fmt.Errorf("creating settings dir: %w", err)
+	}
+
 	// Create rig-level agent beads (witness, refinery) in rig beads.
 	// Town-level agents (mayor, deacon) are created by gt install in town beads.
 	if err := m.initAgentBeads(rigPath, opts.Name, opts.BeadsPrefix); err != nil {


### PR DESCRIPTION
## Summary

- **`rig add`**: Create `settings/` directory during rig scaffolding (fixes `rig-settings` doctor warning)
- **priming check**: Use `beads.ResolveBeadsDir()` to follow redirects when looking for `PRIME.md` (fixes false `priming` failure for tracked beads repos)

Fixes #1428

## Test plan

- [x] `go test ./internal/doctor/ ./internal/rig/` — all pass
- [x] `gt install ~/gt --git && gt rig add btap <url> --prefix ap && gt doctor` — no priming failure, no rig-settings warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)