### PR TITLE
fix: resolve CI lint and test failures on main

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,8 +35,18 @@ jobs:
           git clone --depth 1 https://github.com/steveyegge/beads /tmp/beads
           cd /tmp/beads && go install ./cmd/bd
 
+      - name: Install Dolt
+        run: |
+          git clone --depth 1 https://github.com/dolthub/dolt /tmp/dolt
+          cd /tmp/dolt/go && go install ./cmd/dolt
+
       - name: Add to PATH
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
+
+      - name: Configure Dolt
+        run: |
+          dolt config --global --add user.name "CI Bot"
+          dolt config --global --add user.email "ci@gastown.test"
 
       - name: Generate embedded files
         run: go generate ./internal/formula/...

--- a/internal/cmd/beads_db_init_test.go
+++ b/internal/cmd/beads_db_init_test.go
@@ -120,6 +120,9 @@ func TestBeadsDbInitAfterClone(t *testing.T) {
 	if _, err := exec.LookPath("bd"); err != nil {
 		t.Skip("bd not installed, skipping test")
 	}
+	// Dolt server required: bd init --backend dolt (auto-detects server on 3307),
+	// and gt rig add --adopt uses --server mode for re-initialization.
+	requireDoltServer(t)
 
 	tmpDir := t.TempDir()
 	gtBinary := buildGT(t)
@@ -465,11 +468,11 @@ func createTrackedBeadsRepoWithNoIssues(t *testing.T, path, prefix string) {
 
 // removeDBFiles removes gitignored database files from a beads directory to simulate a clone.
 // Only removes files that match patterns in .beads/.gitignore. Files NOT in .gitignore
-// (metadata.json, dolt/, config.yaml, issues.jsonl, etc.) are tracked by git and survive clones.
+// (metadata.json, config.yaml, issues.jsonl, etc.) are tracked by git and survive clones.
 //
 // Anchored to .beads/.gitignore patterns as of 2026-02: *.db, *.db-*, daemon.*, bd.sock,
-// sync-state.json, redirect, db.sqlite, bd.db, export-state/, etc.
-// metadata.json and dolt/ are NOT gitignored — they are tracked and present after clone.
+// sync-state.json, redirect, db.sqlite, bd.db, export-state/, dolt/, dolt-access.lock.
+// metadata.json is NOT gitignored — it is tracked and present after clone.
 func removeDBFiles(t *testing.T, beadsDir string) {
 	t.Helper()
 
@@ -482,16 +485,18 @@ func removeDBFiles(t *testing.T, beadsDir string) {
 		}
 	}
 	// Remove gitignored runtime state files
-	for _, name := range []string{"sync-state.json", "redirect", ".local_version"} {
+	for _, name := range []string{"sync-state.json", "redirect", ".local_version", "dolt-access.lock"} {
 		os.Remove(filepath.Join(beadsDir, name))
 	}
 	os.RemoveAll(filepath.Join(beadsDir, "export-state"))
+	// Remove Dolt database directory (gitignored since bd v0.50+; managed by Dolt remotes, not git)
+	os.RemoveAll(filepath.Join(beadsDir, "dolt"))
 
-	// Verify our assumptions: metadata.json and dolt/ must NOT be removed.
-	// If .beads/.gitignore ever starts ignoring these, this assertion catches drift.
+	// Verify our assumptions: metadata.json must NOT be removed.
+	// If .beads/.gitignore ever starts ignoring it, this assertion catches drift.
 	gitignorePath := filepath.Join(beadsDir, ".gitignore")
 	if content, err := os.ReadFile(gitignorePath); err == nil {
-		for _, tracked := range []string{"metadata.json", "dolt"} {
+		for _, tracked := range []string{"metadata.json"} {
 			if strings.Contains(string(content), tracked) {
 				t.Fatalf("clone simulation assumption violated: %s found in .beads/.gitignore — "+
 					"removeDBFiles must be updated if tracked file set changes", tracked)

--- a/internal/cmd/dolt_test_helpers_test.go
+++ b/internal/cmd/dolt_test_helpers_test.go
@@ -1,0 +1,262 @@
+//go:build integration
+
+package cmd
+
+import (
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"strconv"
+	"strings"
+	"sync"
+	"syscall"
+	"testing"
+	"time"
+)
+
+const doltTestPort = "3307"
+
+// doltServer tracks the singleton dolt sql-server process for integration tests.
+// Started once per test binary invocation via sync.Once; cleaned up at process exit.
+var (
+	doltServerOnce sync.Once
+	doltServerErr  error
+	// doltLockFile is held with LOCK_SH for the lifetime of the test binary.
+	// This prevents other test processes from killing the server while we're
+	// still using it. See cleanupDoltServer for the shutdown protocol.
+	doltLockFile *os.File
+	// doltWeStarted tracks whether this process started the server (vs reusing).
+	doltWeStarted bool
+)
+
+// requireDoltServer ensures a dolt sql-server is running on port 3307 for
+// integration tests that need it. The server is shared across all tests in
+// the same test binary invocation.
+//
+// Port contention strategy:
+//
+//  1. In-process: sync.Once ensures only one goroutine attempts startup.
+//
+//  2. Cross-process: a file lock (/tmp/dolt-test-server.lock) serializes
+//     startup across concurrent test binaries. The first process to acquire
+//     LOCK_EX starts the server and writes its PID + data dir to
+//     /tmp/dolt-test-server.pid. After startup, the lock is downgraded to
+//     LOCK_SH (shared) and held for the lifetime of the test binary.
+//
+//  3. Safe shutdown: cleanupDoltServer tries to upgrade from LOCK_SH to
+//     LOCK_EX (non-blocking). If it succeeds, no other test processes hold
+//     the shared lock, so it's safe to kill the server. The server PID is
+//     read from the PID file, so ANY last-exiting process can clean up —
+//     not just the one that started the server.
+//
+//  4. External server: if port 3307 is already listening before any test
+//     process acquires the lock, we reuse it. No PID file is written, and
+//     cleanup never kills an external server.
+//
+// Why port 3307 is fixed: the entire gt/bd stack (doltserver.DefaultPort,
+// gt install, gt dolt start, bd init --backend dolt) assumes port 3307.
+// A random port would require threading an override through all layers.
+func requireDoltServer(t *testing.T) {
+	t.Helper()
+
+	if _, err := exec.LookPath("dolt"); err != nil {
+		t.Skip("dolt not installed, skipping test")
+	}
+
+	doltServerOnce.Do(func() {
+		doltServerErr = startDoltServer()
+	})
+
+	if doltServerErr != nil {
+		t.Fatalf("dolt server setup failed: %v", doltServerErr)
+	}
+}
+
+func doltTestAddr() string {
+	return "127.0.0.1:" + doltTestPort
+}
+
+const (
+	// lockFilePath serializes server startup/shutdown across test processes.
+	lockFilePath = "/tmp/dolt-test-server.lock"
+	// pidFilePath stores the server PID and data dir for cross-process cleanup.
+	pidFilePath = "/tmp/dolt-test-server.pid"
+)
+
+func startDoltServer() error {
+	// Open the lock file (kept open for the lifetime of the test binary).
+	lockFile, err := os.OpenFile(lockFilePath, os.O_CREATE|os.O_RDWR, 0666)
+	if err != nil {
+		return fmt.Errorf("opening lock file %s: %w", lockFilePath, err)
+	}
+
+	// Acquire exclusive lock for the startup phase.
+	if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_EX); err != nil {
+		lockFile.Close()
+		return fmt.Errorf("acquiring startup lock: %w", err)
+	}
+
+	// Under the exclusive lock: check if a server is already running
+	// (started by another process that held the lock before us, or external).
+	if portReady(2 * time.Second) {
+		// Downgrade to shared lock — signals "I'm using the server".
+		if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_SH); err != nil {
+			lockFile.Close()
+			return fmt.Errorf("downgrading to shared lock: %w", err)
+		}
+		doltLockFile = lockFile
+		return nil
+	}
+
+	// No server running — start one.
+	dataDir, err := os.MkdirTemp("", "dolt-test-server-*")
+	if err != nil {
+		syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+		lockFile.Close()
+		return fmt.Errorf("creating dolt data dir: %w", err)
+	}
+
+	cmd := exec.Command("dolt", "sql-server",
+		"--port", doltTestPort,
+		"--data-dir", dataDir,
+	)
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	if err := cmd.Start(); err != nil {
+		os.RemoveAll(dataDir)
+		syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+		lockFile.Close()
+		return fmt.Errorf("starting dolt sql-server: %w", err)
+	}
+
+	// Write PID file so any last-exiting process can clean up.
+	// Format: "PID\nDATA_DIR\n"
+	pidContent := fmt.Sprintf("%d\n%s\n", cmd.Process.Pid, dataDir)
+	if err := os.WriteFile(pidFilePath, []byte(pidContent), 0666); err != nil {
+		cmd.Process.Kill()
+		os.RemoveAll(dataDir)
+		syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+		lockFile.Close()
+		return fmt.Errorf("writing PID file: %w", err)
+	}
+
+	// Reap the process in the background so ProcessState is populated on exit.
+	exited := make(chan struct{})
+	go func() {
+		cmd.Wait()
+		close(exited)
+	}()
+
+	// Wait for server to accept connections (up to 30 seconds).
+	deadline := time.Now().Add(30 * time.Second)
+	for time.Now().Before(deadline) {
+		if portReady(time.Second) {
+			// Server is ready. Downgrade to shared lock.
+			if err := syscall.Flock(int(lockFile.Fd()), syscall.LOCK_SH); err != nil {
+				lockFile.Close()
+				return fmt.Errorf("downgrading to shared lock: %w", err)
+			}
+			doltLockFile = lockFile
+			doltWeStarted = true
+			return nil
+		}
+		// Check if process exited (port bind failure, etc).
+		select {
+		case <-exited:
+			os.RemoveAll(dataDir)
+			os.Remove(pidFilePath)
+			syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+			lockFile.Close()
+			return fmt.Errorf("dolt sql-server exited prematurely")
+		default:
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+
+	// Timed out — kill and clean up.
+	cmd.Process.Kill()
+	<-exited
+	os.RemoveAll(dataDir)
+	os.Remove(pidFilePath)
+	syscall.Flock(int(lockFile.Fd()), syscall.LOCK_UN)
+	lockFile.Close()
+	return fmt.Errorf("dolt sql-server did not become ready within 30s")
+}
+
+// portReady returns true if the dolt test port is accepting TCP connections.
+func portReady(timeout time.Duration) bool {
+	conn, err := net.DialTimeout("tcp", doltTestAddr(), timeout)
+	if err != nil {
+		return false
+	}
+	conn.Close()
+	return true
+}
+
+// cleanupDoltServer conditionally kills the test dolt server. Called from TestMain.
+//
+// Shutdown protocol: try to upgrade from LOCK_SH to LOCK_EX (non-blocking).
+//   - If we get LOCK_EX: no other test processes hold the shared lock, so we're
+//     the last user. Read the PID file to find and kill the server.
+//   - If LOCK_EX fails (EWOULDBLOCK): another process still holds LOCK_SH,
+//     meaning it's actively using the server. Skip cleanup — the last process
+//     to exit will handle it.
+//
+// The PID file enables any last-exiting process to clean up, not just the
+// process that originally started the server. This prevents leaked servers
+// when the starter exits before other consumers.
+func cleanupDoltServer() {
+	// Release our shared lock regardless.
+	defer func() {
+		if doltLockFile != nil {
+			syscall.Flock(int(doltLockFile.Fd()), syscall.LOCK_UN)
+			doltLockFile.Close()
+			doltLockFile = nil
+		}
+	}()
+
+	if doltLockFile == nil {
+		return
+	}
+
+	// Try to acquire exclusive lock (non-blocking). If another process
+	// holds LOCK_SH, this fails with EWOULDBLOCK — the server is still in use.
+	err := syscall.Flock(int(doltLockFile.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+	if err != nil {
+		// Another process is using the server. Don't kill it.
+		return
+	}
+	// We got LOCK_EX — we're the last process. Kill from PID file.
+
+	data, err := os.ReadFile(pidFilePath)
+	if err != nil {
+		// No PID file — either external server or already cleaned up.
+		return
+	}
+
+	lines := strings.SplitN(string(data), "\n", 3)
+	if len(lines) < 2 {
+		return
+	}
+
+	pid, err := strconv.Atoi(strings.TrimSpace(lines[0]))
+	if err != nil || pid <= 0 {
+		return
+	}
+	dataDir := strings.TrimSpace(lines[1])
+
+	// Kill the server process.
+	proc, err := os.FindProcess(pid)
+	if err == nil {
+		proc.Kill()
+		proc.Wait()
+	}
+
+	// Clean up data dir and PID file.
+	if dataDir != "" {
+		os.RemoveAll(dataDir)
+	}
+	os.Remove(pidFilePath)
+}

--- a/internal/cmd/integration_testmain_test.go
+++ b/internal/cmd/integration_testmain_test.go
@@ -12,5 +12,8 @@ func TestMain(m *testing.M) {
 	// Force sequential test execution to avoid bd file locks on Windows.
 	_ = flag.Set("test.parallel", "1")
 	flag.Parse()
-	os.Exit(m.Run())
+	code := m.Run()
+	// Clean up the shared dolt test server if one was started.
+	cleanupDoltServer()
+	os.Exit(code)
 }

--- a/internal/cmd/rig_integration_test.go
+++ b/internal/cmd/rig_integration_test.go
@@ -993,6 +993,7 @@ func TestAgentWorktreesStayClean(t *testing.T) {
 	if _, err := exec.LookPath("bd"); err != nil {
 		t.Skip("bd not installed, skipping integration test")
 	}
+	requireDoltServer(t)
 
 	testCases := []struct {
 		name            string

--- a/internal/cmd/routes_jsonl_corruption_test.go
+++ b/internal/cmd/routes_jsonl_corruption_test.go
@@ -22,6 +22,7 @@ func TestRoutesJSONLCorruption(t *testing.T) {
 	if _, err := exec.LookPath("bd"); err != nil {
 		t.Skip("bd not installed, skipping test")
 	}
+	requireDoltServer(t)
 
 	t.Run("TownLevelRoutesNotCorrupted", func(t *testing.T) {
 		// Test that gt install creates issues.jsonl before routes.jsonl

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -461,10 +461,7 @@ func runShutdown(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("listing sessions: %w", err)
 	}
 
-	// Get session names for categorization
-	mayorSession := getMayorSessionName()
-	deaconSession := getDeaconSessionName()
-	toStop, preserved := categorizeSessions(sessions, mayorSession, deaconSession)
+	toStop, preserved := categorizeSessions(sessions)
 
 	if len(toStop) == 0 {
 		fmt.Printf("%s Gas Town was not running\n", style.Dim.Render("○"))
@@ -512,8 +509,7 @@ func runShutdown(cmd *cobra.Command, args []string) error {
 }
 
 // categorizeSessions splits sessions into those to stop and those to preserve.
-// mayorSession and deaconSession are the dynamic session names for the current town.
-func categorizeSessions(sessions []string, mayorSession, deaconSession string) (toStop, preserved []string) {
+func categorizeSessions(sessions []string) (toStop, preserved []string) {
 	for _, sess := range sessions {
 		// Gas Town sessions use gt- (rig-level) or hq- (town-level) prefix
 		if !strings.HasPrefix(sess, "gt-") && !strings.HasPrefix(sess, "hq-") {


### PR DESCRIPTION
## Summary

Fix two pre-existing CI failures on main: a lint error (`unparam`) and five failing integration test subtests (`TestBeadsDbInitAfterClone`).

## Related Issue

Partial fix for CI stability. The test failures were caused by an upstream beads change where `dolt/` is now gitignored (previously tracked).

## Changes

### Lint fix (`start.go`)
- Remove unused `mayorSession`/`deaconSession` parameters from `categorizeSessions()` and its sole caller in `runShutdown()`

### Test fix (`beads_db_init_test.go`)
- Update `removeDBFiles()` to also remove `dolt/` directory and `dolt-access.lock` (now gitignored by beads)
- Update drift-detection assertion to only guard `metadata.json` (no longer checking `dolt`)

### Bug fix (`rig.go` — `runRigAdopt`)
- **Prefix detection fallback**: When `bd config get issue_prefix` fails (no `dolt/` dir after clone), extract the prefix from `metadata.json`'s `dolt_database` field (format: `beads_<prefix>`)
- **Re-init condition**: Trigger database re-initialization when `metadata.json` exists with `backend: "dolt"` but `dolt/` directory is missing (not just when `metadata.json` is absent)
- **Prefix persistence**: Explicitly run `bd config set issue_prefix` after `bd init` (matching the pattern in `initBeads`/`initTownBeads`, since `bd init --prefix` may not persist it)

## Testing

- [x] Unit tests pass (`go test ./...` — only pre-existing `refinery` tmux test fails, unrelated)
- [x] Lint passes (`golangci-lint run ./internal/cmd/...` — 0 issues)
- [x] All 5 `TestBeadsDbInitAfterClone` subtests pass:
  - `TrackedRepoWithExistingPrefix` ✓
  - `TrackedRepoWithNoIssuesRequiresPrefix` ✓
  - `TrackedRepoWithPrefixMismatchErrors` ✓
  - `TrackedRepoWithNoIssuesFallsBackToDerivedPrefix` ✓
  - `MissingMetadataTriggersReInit` ✓
- [x] Dual-model code review (Claude + Codex) — decision: approve

## Checklist

- [x] Code follows project style
- [x] No breaking changes
- [x] `bd config set issue_prefix` failure is fatal (matches `initBeads`/`install.go` pattern)