### PR TITLE
chore(ci): pin beads (bd) to v0.50.2

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -235,10 +235,7 @@ jobs:
           git config --global user.email "ci@gastown.test"
 
       - name: Install beads (bd)
-        # Clone and build to handle replace directives that break go install @version
-        run: |
-          git clone --depth 1 https://github.com/steveyegge/beads /tmp/beads
-          cd /tmp/beads && go install ./cmd/bd
+        run: go install github.com/steveyegge/beads/cmd/bd@v0.50.2
 
       - name: Build gt
         run: |

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -30,10 +30,7 @@ jobs:
           git config --global user.email "ci@gastown.test"
 
       - name: Install beads (bd)
-        # Clone and build to handle replace directives that break go install @version
-        run: |
-          git clone --depth 1 https://github.com/steveyegge/beads /tmp/beads
-          cd /tmp/beads && go install ./cmd/bd
+        run: go install github.com/steveyegge/beads/cmd/bd@v0.50.2
 
       - name: Install Dolt
         run: |

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -31,15 +31,13 @@ jobs:
         run: C:\msys64\usr\bin\pacman.exe -Sy --noconfirm mingw-w64-x86_64-gcc mingw-w64-x86_64-icu
 
       - name: Install beads (bd)
-        # Clone and build to handle replace directives that break go install @version
         env:
           CC: C:/msys64/mingw64/bin/gcc.exe
           CGO_CFLAGS: -IC:/msys64/mingw64/include
           CGO_LDFLAGS: -LC:/msys64/mingw64/lib
         run: |
           $env:PATH = "C:\msys64\mingw64\bin;$env:PATH"
-          git clone --depth 1 https://github.com/steveyegge/beads $env:TEMP\beads
-          cd $env:TEMP\beads; go install ./cmd/bd
+          go install github.com/steveyegge/beads/cmd/bd@v0.50.2
 
       - name: Add to PATH
         run: |

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -23,10 +23,8 @@ RUN apk add --no-cache \
     procps \
     lsof
 
-# Install beads daemon (bd) - build from source to handle replace directives
-RUN git clone --depth 1 https://github.com/steveyegge/beads /tmp/beads && \
-    cd /tmp/beads && go install ./cmd/bd && \
-    rm -rf /tmp/beads
+# Install beads daemon (bd)
+RUN go install github.com/steveyegge/beads/cmd/bd@v0.50.2
 
 # Install Dolt (required for beads database server)
 RUN git clone --depth 1 https://github.com/dolthub/dolt /tmp/dolt && \


### PR DESCRIPTION
## Summary

Pin the beads (bd) dependency to v0.50.2 across all CI workflows and the e2e Dockerfile. The beads repo HEAD currently has a breaking build (`cmd/bd/test_wait_helper.go` references undefined symbols), causing all CI runs on main to fail.

## Related Issue

Fixes CI failures on main (all recent commits failing at "Install beads (bd)" step).

## Changes

- Pin `bd` install to `v0.50.2` in `ci.yml`, `windows-ci.yml`, `integration.yml`, and `Dockerfile.e2e`
- Replace `git clone --depth 1 && go install ./cmd/bd` workaround with `go install @v0.50.2` — the clone approach was needed because older beads versions had `replace` directives that break `go install @version`, but v0.50.2 has none
- Remove stale comments about the replace-directive workaround

## Testing

- [x] Verified `v0.50.2` tag exists in beads repo
- [x] Verified `v0.50.2` has no `replace` directives in `go.mod` (so `go install @version` works)
- [x] Unit tests pass (`go test ./...`)

## Checklist

- [x] Code follows project style
- [x] No breaking changes