### PR TITLE
feat(install): fold Dolt identity, HQ database, and server start into gt install

### DIFF
--- a/internal/cmd/beads_db_init_test.go
+++ b/internal/cmd/beads_db_init_test.go
@@ -125,6 +125,7 @@ func TestBeadsDbInitAfterClone(t *testing.T) {
 	requireDoltServer(t)
 
 	tmpDir := t.TempDir()
+	configureTestGitIdentity(t, tmpDir)
 	gtBinary := buildGT(t)
 
 	t.Run("TrackedRepoWithExistingPrefix", func(t *testing.T) {

--- a/internal/cmd/dolt.go
+++ b/internal/cmd/dolt.go
@@ -523,13 +523,19 @@ func runDoltInitRig(cmd *cobra.Command, args []string) error {
 
 	rigName := args[0]
 
-	serverWasRunning, err := doltserver.InitRig(townRoot, rigName)
+	serverWasRunning, created, err := doltserver.InitRig(townRoot, rigName)
 	if err != nil {
 		return err
 	}
 
 	config := doltserver.DefaultConfig(townRoot)
 	rigDir := doltserver.RigDatabaseDir(townRoot, rigName)
+
+	if !created {
+		fmt.Printf("%s Rig database %q already exists (no-op)\n", style.Bold.Render("✓"), rigName)
+		fmt.Printf("  Location: %s\n", rigDir)
+		return nil
+	}
 
 	fmt.Printf("%s Initialized rig database %q\n", style.Bold.Render("✓"), rigName)
 	fmt.Printf("  Location: %s\n", rigDir)

--- a/internal/cmd/dolt_test_helpers_test.go
+++ b/internal/cmd/dolt_test_helpers_test.go
@@ -17,6 +17,24 @@ import (
 
 const doltTestPort = "3307"
 
+// configureTestGitIdentity sets git global config in an isolated HOME directory
+// so that EnsureDoltIdentity (called during gt install preflight) can copy
+// identity from git to dolt.
+func configureTestGitIdentity(t *testing.T, homeDir string) {
+	t.Helper()
+	env := append(os.Environ(), "HOME="+homeDir)
+	for _, args := range [][]string{
+		{"config", "--global", "user.name", "Test User"},
+		{"config", "--global", "user.email", "test@test.com"},
+	} {
+		cmd := exec.Command("git", args...)
+		cmd.Env = env
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+}
+
 // doltServer tracks the singleton dolt sql-server process for integration tests.
 // Started once per test binary invocation via sync.Once; cleaned up at process exit.
 var (

--- a/internal/cmd/rig_integration_test.go
+++ b/internal/cmd/rig_integration_test.go
@@ -1024,6 +1024,7 @@ func runAgentCleanTest(t *testing.T, hasTrackedBeads bool) {
 	t.Helper()
 
 	tmpDir := t.TempDir()
+	configureTestGitIdentity(t, tmpDir)
 	hqPath := filepath.Join(tmpDir, "test-hq")
 
 	// Build gt binary for testing

--- a/internal/cmd/routes_jsonl_corruption_test.go
+++ b/internal/cmd/routes_jsonl_corruption_test.go
@@ -28,6 +28,7 @@ func TestRoutesJSONLCorruption(t *testing.T) {
 		// Test that gt install creates issues.jsonl before routes.jsonl
 		// so that bd auto-export doesn't corrupt routes.jsonl
 		tmpDir := t.TempDir()
+		configureTestGitIdentity(t, tmpDir)
 		townRoot := filepath.Join(tmpDir, "test-town")
 
 		gtBinary := buildGT(t)
@@ -85,6 +86,7 @@ func TestRoutesJSONLCorruption(t *testing.T) {
 		// Test that gt rig add does NOT create routes.jsonl in rig beads
 		// (rig-level routes.jsonl breaks bd's walk-up routing to town routes)
 		tmpDir := t.TempDir()
+		configureTestGitIdentity(t, tmpDir)
 		townRoot := filepath.Join(tmpDir, "test-town")
 
 		gtBinary := buildGT(t)

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -1867,7 +1867,7 @@ func TestEnsureMetadata_SetsDefaultJSONLExport(t *testing.T) {
 
 func TestInitRig_EmptyName(t *testing.T) {
 	townRoot := t.TempDir()
-	_, err := InitRig(townRoot, "")
+	_, _, err := InitRig(townRoot, "")
 	if err == nil {
 		t.Fatal("expected error for empty rig name")
 	}
@@ -1876,12 +1876,13 @@ func TestInitRig_EmptyName(t *testing.T) {
 func TestInitRig_InvalidCharacters(t *testing.T) {
 	townRoot := t.TempDir()
 	for _, name := range []string{"my rig", "rig/name", "rig.name", "rig@name"} {
-		_, err := InitRig(townRoot, name)
+		_, _, err := InitRig(townRoot, name)
 		if err == nil {
 			t.Errorf("expected error for invalid rig name %q", name)
 		}
 	}
 }
+
 
 // =============================================================================
 // ListDatabases edge cases


### PR DESCRIPTION
## Summary

Fold three manual post-install steps into `gt install` so new users get a working Dolt-backed beads system out of the box.

Previously, users had to manually run `dolt config --global`, `gt dolt init-rig hq`, and `gt dolt start` after `gt install`. Now these steps happen automatically.

## Related Issue

N/A — UX improvement identified during onboarding.

## Changes

- Add `EnsureDoltIdentity()` to `internal/doltserver/doltserver.go` that copies git global user.name/email to dolt config (with `--unset` + `--add` for idempotency)
- Add `doltConfigMissing()` helper that distinguishes "key not found" (exit 1) from unexpected dolt failures
- Add `setDoltGlobalConfig()` helper that prevents duplicate config entries
- Make `InitRig()` idempotent — returns `(serverWasRunning, created, err)` instead of erroring on existing databases; still runs `EnsureMetadata` to self-heal corrupt metadata.json
- Update `RepairWorkspace` to use the new `created` return value for accurate status messaging
- Move `EnsureDoltIdentity` to preflight in install flow (before workspace mutations) to prevent non-retryable partial installs
- Call `InitRig("hq")` before server start in the install flow
- Restructure e2e integration tests: replace manual `configureDoltIdentity`/`dolt init-rig`/`dolt start` steps with post-install assertions
- Add `configureGitIdentity()` test helper (sets git config so `EnsureDoltIdentity` can copy it)
- Add `verify-dolt-bootstrap` subtest: asserts HQ database exists, dolt identity was copied, server is running, and `init-rig hq` is idempotent

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed
- [x] 6 rounds of dual-model code review (Claude + Codex) with all major findings resolved

## Checklist

- [x] Code follows project style
- [x] No breaking changes (InitRig signature change is internal; all callers updated)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>