### PR TITLE
witness: add JSON patrol receipts for stale/orphan verdicts

### DIFF
--- a/internal/witness/patrol_receipts.go
+++ b/internal/witness/patrol_receipts.go
@@ -1,0 +1,76 @@
+package witness
+
+import "strings"
+
+// PatrolVerdict classifies witness patrol outcomes for machine consumers.
+type PatrolVerdict string
+
+const (
+	PatrolVerdictStale  PatrolVerdict = "stale"
+	PatrolVerdictOrphan PatrolVerdict = "orphan"
+)
+
+// PatrolReceiptEvidence captures the primary evidence fields for a verdict.
+type PatrolReceiptEvidence struct {
+	AgentState    string `json:"agent_state,omitempty"`
+	HookBead      string `json:"hook_bead,omitempty"`
+	BeadRecovered bool   `json:"bead_recovered"`
+	Error         string `json:"error,omitempty"`
+}
+
+// PatrolReceipt is a machine-readable witness patrol verdict with recommended action.
+type PatrolReceipt struct {
+	Rig               string                `json:"rig"`
+	Polecat           string                `json:"polecat"`
+	Verdict           PatrolVerdict         `json:"verdict"`
+	RecommendedAction string                `json:"recommended_action"`
+	Evidence          PatrolReceiptEvidence `json:"evidence"`
+}
+
+func receiptVerdictForZombie(z ZombieResult) PatrolVerdict {
+	if strings.TrimSpace(z.HookBead) != "" {
+		return PatrolVerdictStale
+	}
+	if z.AgentState == "working" || z.AgentState == "running" || z.AgentState == "spawning" {
+		return PatrolVerdictStale
+	}
+	return PatrolVerdictOrphan
+}
+
+// BuildPatrolReceipt projects a zombie patrol result into a stable JSON-ready receipt.
+func BuildPatrolReceipt(rigName string, z ZombieResult) PatrolReceipt {
+	action := strings.TrimSpace(z.Action)
+	if action == "" {
+		action = "investigate"
+	}
+
+	receipt := PatrolReceipt{
+		Rig:               rigName,
+		Polecat:           z.PolecatName,
+		Verdict:           receiptVerdictForZombie(z),
+		RecommendedAction: action,
+		Evidence: PatrolReceiptEvidence{
+			AgentState:    z.AgentState,
+			HookBead:      z.HookBead,
+			BeadRecovered: z.BeadRecovered,
+		},
+	}
+
+	if z.Error != nil {
+		receipt.Evidence.Error = z.Error.Error()
+	}
+
+	return receipt
+}
+
+// BuildPatrolReceipts returns machine-readable patrol verdicts for all detected zombies.
+func BuildPatrolReceipts(rigName string, result *DetectZombiePolecatsResult) []PatrolReceipt {
+	if result == nil || len(result.Zombies) == 0 {
+		return nil
+	}
+	receipts := make([]PatrolReceipt, 0, len(result.Zombies))
+	for _, zombie := range result.Zombies {
+		receipts = append(receipts, BuildPatrolReceipt(rigName, zombie))
+	}
+	return receipts
+}

--- a/internal/witness/patrol_receipts_test.go
+++ b/internal/witness/patrol_receipts_test.go
@@ -1,0 +1,87 @@
+package witness
+
+import (
+	"encoding/json"
+	"errors"
+	"testing"
+)
+
+func TestBuildPatrolReceipt_StaleVerdictFromHookBead(t *testing.T) {
+	receipt := BuildPatrolReceipt("gastown", ZombieResult{
+		PolecatName: "atlas",
+		AgentState:  "idle",
+		HookBead:    "gt-abc123",
+		Action:      "auto-nuked",
+	})
+
+	if receipt.Verdict != PatrolVerdictStale {
+		t.Fatalf("Verdict = %q, want %q", receipt.Verdict, PatrolVerdictStale)
+	}
+	if receipt.RecommendedAction != "auto-nuked" {
+		t.Fatalf("RecommendedAction = %q, want %q", receipt.RecommendedAction, "auto-nuked")
+	}
+}
+
+func TestBuildPatrolReceipt_OrphanVerdictWithoutHookedWork(t *testing.T) {
+	receipt := BuildPatrolReceipt("gastown", ZombieResult{
+		PolecatName: "echo",
+		AgentState:  "idle",
+		Action:      "cleanup-wisp-created",
+	})
+
+	if receipt.Verdict != PatrolVerdictOrphan {
+		t.Fatalf("Verdict = %q, want %q", receipt.Verdict, PatrolVerdictOrphan)
+	}
+}
+
+func TestBuildPatrolReceipt_ErrorIncludedInEvidence(t *testing.T) {
+	receipt := BuildPatrolReceipt("gastown", ZombieResult{
+		PolecatName: "nux",
+		AgentState:  "running",
+		Error:       errors.New("nuke failed"),
+	})
+
+	if receipt.Evidence.Error != "nuke failed" {
+		t.Fatalf("Evidence.Error = %q, want %q", receipt.Evidence.Error, "nuke failed")
+	}
+}
+
+func TestBuildPatrolReceipts_JSONShape(t *testing.T) {
+	receipts := BuildPatrolReceipts("gastown", &DetectZombiePolecatsResult{
+		Zombies: []ZombieResult{
+			{
+				PolecatName: "atlas",
+				AgentState:  "working",
+				HookBead:    "gt-123",
+				Action:      "auto-nuked",
+			},
+		},
+	})
+	if len(receipts) != 1 {
+		t.Fatalf("len(receipts) = %d, want 1", len(receipts))
+	}
+
+	data, err := json.Marshal(receipts[0])
+	if err != nil {
+		t.Fatalf("json.Marshal() error = %v", err)
+	}
+
+	var decoded map[string]any
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("json.Unmarshal() error = %v", err)
+	}
+
+	if decoded["verdict"] != string(PatrolVerdictStale) {
+		t.Fatalf("decoded verdict = %v, want %q", decoded["verdict"], PatrolVerdictStale)
+	}
+	if decoded["recommended_action"] != "auto-nuked" {
+		t.Fatalf("decoded recommended_action = %v, want %q", decoded["recommended_action"], "auto-nuked")
+	}
+	evidence, ok := decoded["evidence"].(map[string]any)
+	if !ok {
+		t.Fatalf("decoded evidence missing or wrong type: %#v", decoded["evidence"])
+	}
+	if evidence["hook_bead"] != "gt-123" {
+		t.Fatalf("decoded evidence.hook_bead = %v, want %q", evidence["hook_bead"], "gt-123")
+	}
+}


### PR DESCRIPTION
## Problem
Witness patrol stale/orphan outcomes were harder to consume programmatically without a stable machine-readable receipt contract.

## What changed
- Added JSON-ready witness patrol receipt types in `/Users/davidahmann/Projects/agent-ecosystem/gastown/internal/witness/patrol_receipts.go`.
- Added deterministic verdict mapping (`stale` vs `orphan`) with evidence fields and recommended action.
- Added focused tests in `/Users/davidahmann/Projects/agent-ecosystem/gastown/internal/witness/patrol_receipts_test.go` for verdict mapping and JSON shape.

## Validation
- `go test ./internal/witness -run 'BuildPatrol|PatrolReceipt' -count=1` (pass)

Fixes #1464
