### PR TITLE
fix(role): add RoleBoot case to ActorString and fix isTownLevelRole

### DIFF
--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -993,7 +993,7 @@ func outputMoleculeCurrent(info MoleculeCurrentInfo) error {
 func isTownLevelRole(agentID string) bool {
 	return agentID == "mayor" || agentID == "mayor/" ||
 		agentID == "deacon" || agentID == "deacon/" ||
-		agentID == "boot" || agentID == "deacon/boot"
+		agentID == "deacon/boot" || agentID == "deacon-boot"
 }
 
 // extractMailSender extracts the sender from mail bead labels.

--- a/internal/cmd/role.go
+++ b/internal/cmd/role.go
@@ -405,6 +405,8 @@ func (info RoleInfo) ActorString() string {
 			return fmt.Sprintf("%s/crew/%s", info.Rig, info.Polecat)
 		}
 		return "crew"
+	case RoleBoot:
+		return "deacon-boot"
 	default:
 		return string(info.Role)
 	}

--- a/internal/cmd/role_boot_test.go
+++ b/internal/cmd/role_boot_test.go
@@ -50,14 +50,15 @@ func TestIsTownLevelRoleBoot(t *testing.T) {
 		agentID string
 		want    bool
 	}{
-		{"boot", true},
 		{"deacon/boot", true},
+		{"deacon-boot", true},
 		{"mayor", true},
 		{"mayor/", true},
 		{"deacon", true},
 		{"deacon/", true},
 		{"gastown/witness", false},
 		{"west/boot", false},
+		{"boot", false}, // bare "boot" is not a valid agentID
 	}
 
 	for _, tt := range tests {
@@ -65,5 +66,25 @@ func TestIsTownLevelRoleBoot(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("isTownLevelRole(%q) = %v, want %v", tt.agentID, got, tt.want)
 		}
+	}
+}
+
+func TestActorStringBoot(t *testing.T) {
+	info := RoleInfo{Role: RoleBoot}
+	got := info.ActorString()
+	want := "deacon-boot"
+	if got != want {
+		t.Errorf("ActorString() for RoleBoot = %q, want %q", got, want)
+	}
+}
+
+func TestActorStringConsistentWithBDActorBoot(t *testing.T) {
+	// ActorString() must match what BD_ACTOR is set to in config/env.go.
+	// BD_ACTOR for boot is "deacon-boot".
+	info := RoleInfo{Role: RoleBoot}
+	actorString := info.ActorString()
+	bdActor := "deacon-boot" // from internal/config/env.go:57
+	if actorString != bdActor {
+		t.Errorf("ActorString() = %q does not match BD_ACTOR = %q", actorString, bdActor)
 	}
 }


### PR DESCRIPTION
## Summary
- Add explicit `case RoleBoot` to `ActorString()` returning `"deacon-boot"` to match `BD_ACTOR` convention set in `config/env.go`
- Fix `isTownLevelRole`: replace unreachable bare `"boot"` match with `"deacon-boot"` (matching `ActorString` output); `buildAgentIdentity` only produces `"deacon/boot"`, never bare `"boot"`
- Add test coverage for `ActorString()` with `RoleBoot` and consistency check against `BD_ACTOR`

Closes #1383

## Test plan
- [x] `go build ./...` passes
- [x] All boot-related tests pass (`TestActorStringBoot`, `TestActorStringConsistentWithBDActorBoot`, `TestIsTownLevelRoleBoot`, `TestParseRoleStringBoot`, `TestGetRoleHomeBoot`)
- [x] Full `go test ./internal/cmd/` passes with no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)