### PR TITLE
fix(witness): use correct bd list/update flags in handler functions

### DIFF
--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -749,10 +749,14 @@ func UpdateCleanupWispState(workDir, wispID, newState string) error {
 		polecatName = "unknown"
 	}
 
-	// Update with new state
-	newLabels := strings.Join(CleanupWispLabels(polecatName, newState), ",")
-
-	return util.ExecRun(workDir, "bd", "update", wispID, "--set-labels", newLabels)
+	// Update with new state — pass one --set-labels=<label> per label,
+	// matching the pattern used in agent_state.go and molecule_await_signal.go.
+	labels := CleanupWispLabels(polecatName, newState)
+	args := []string{"update", wispID}
+	for _, l := range labels {
+		args = append(args, "--set-labels="+l)
+	}
+	return util.ExecRun(workDir, "bd", args...)
 }
 
 // extractPolecatFromJSON extracts the polecat name from bd show --json output.


### PR DESCRIPTION
## Summary

Fixes #1368 — witness handler code uses invalid `bd list` and `bd update` flags.

**3 call sites fixed:**
- `findCleanupWisp` (line 519): `--ephemeral` removed, `--labels` → `--label`
- `findAnyCleanupWisp` (line 1415): `--ephemeral` removed, `--labels` → `--label`
- `UpdateCleanupWispState` (line 765): `--labels` → `--set-labels`

Note: The `bd create` calls at lines 466 and 500 are correct — both `--ephemeral` and `--labels` are valid flags on `bd create`. Only the `bd list` and `bd update` calls were broken.

## Test plan

- [x] `go test -race ./internal/witness/...` passes
- [x] `go vet ./internal/witness/...` clean
- [x] `TestFindCleanupWisp_UsesCorrectBdListFlags` — verifies `--label` (not `--labels`), no `--ephemeral`
- [x] `TestFindAnyCleanupWisp_UsesCorrectBdListFlags` — verifies `--label` (not `--labels`), no `--ephemeral`
- [x] `TestUpdateCleanupWispState_UsesCorrectBdUpdateFlags` — verifies `--set-labels` (not `--labels`)
- [x] Tests use a fake `bd` script via `PATH` override to capture and verify actual flag construction
- [x] Verified no other `bd list --ephemeral` or `bd list --labels` calls remain in codebase

🤖 Generated with [Claude Code](https://claude.com/claude-code)