### PR TITLE
fix(feed): prevent concurrent Start() and guard feed file access

### DIFF
--- a/internal/feed/curator.go
+++ b/internal/feed/curator.go
@@ -47,7 +47,8 @@ type Curator struct {
 	ctx             context.Context
 	cancel          context.CancelFunc
 	wg              sync.WaitGroup
-	startOnce       sync.Once // prevents concurrent Start() calls from spawning multiple goroutines
+	startOnce sync.Once // prevents concurrent Start() calls from spawning multiple goroutines
+	startErr  error     // result of the one-shot Start; visible to all callers via sync.Once happens-before
 
 	// feedMu guards in-process access to the feed file. The flock in
 	// readRecentFeedEvents/writeFeedEvent coordinates across processes;
@@ -94,28 +95,27 @@ func NewCurator(townRoot string) *Curator {
 // Start begins the curator goroutine. It is safe to call concurrently;
 // only the first call starts the goroutine — subsequent calls are no-ops.
 func (c *Curator) Start() error {
-	var startErr error
 	c.startOnce.Do(func() {
 		eventsPath := filepath.Join(c.townRoot, events.EventsFile)
 
 		// Open events file, creating if needed
 		file, err := os.OpenFile(eventsPath, os.O_RDONLY|os.O_CREATE, 0600)
 		if err != nil {
-			startErr = fmt.Errorf("opening events file: %w", err)
+			c.startErr = fmt.Errorf("opening events file: %w", err)
 			return
 		}
 
 		// Seek to end to only process new events
 		if _, err := file.Seek(0, io.SeekEnd); err != nil {
 			_ = file.Close() //nolint:gosec // G104: best effort cleanup on error
-			startErr = fmt.Errorf("seeking to end: %w", err)
+			c.startErr = fmt.Errorf("seeking to end: %w", err)
 			return
 		}
 
 		c.wg.Add(1)
 		go c.run(file)
 	})
-	return startErr
+	return c.startErr
 }
 
 // Stop gracefully stops the curator.


### PR DESCRIPTION
## Summary
- Wrap `Start()` in `sync.Once` so concurrent callers don't spawn multiple `run()` goroutines that would produce duplicate feed events (race 6)
- Add in-process `sync.Mutex` (`feedMu`) to coordinate `readRecentFeedEvents` and `writeFeedEvent` across goroutines within the same process — the existing `flock` only coordinates across processes (race 7)

Part of #1230 (items 6-7)

## Test plan
- [x] `go build ./...` passes
- [x] `TestCurator_ConcurrentStartIsIdempotent` — 10 concurrent Start() → exactly 1 feed event
- [x] `TestCurator_ConcurrentFeedReadWrite` — 20 concurrent reader/writer goroutines → valid JSONL, no data races
- [x] All existing `curator_test.go` tests pass with `-race` (16/16)

🤖 Generated with [Claude Code](https://claude.com/claude-code)