### PR TITLE
fix(convoy): auto-close empty convoys and flag in stranded detection

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -615,12 +615,8 @@ func checkSingleConvoy(townBeads, convoyID string, dryRun bool) error {
 	if err != nil {
 		return fmt.Errorf("checking convoy %s: %w", convoyID, err)
 	}
-	if len(tracked) == 0 {
-		fmt.Printf("%s Convoy %s has no tracked issues\n", style.Dim.Render("○"), convoyID)
-		return nil
-	}
-
-	// Check if all tracked issues are closed
+	// A convoy with 0 tracked issues is definitionally complete
+	// (tracking deps were likely lost). Treat as all-closed.
 	allClosed := true
 	openCount := 0
 	for _, t := range tracked {
@@ -635,14 +631,18 @@ func checkSingleConvoy(townBeads, convoyID string, dryRun bool) error {
 		return nil
 	}
 
-	// All tracked issues are complete - close the convoy
+	// All tracked issues are complete (or convoy is empty) - close the convoy
 	if dryRun {
 		fmt.Printf("%s Would auto-close convoy 🚚 %s: %s\n", style.Warning.Render("⚠"), convoyID, convoy.Title)
 		return nil
 	}
 
 	// Actually close the convoy
-	closeArgs := []string{"close", convoyID, "-r", "All tracked issues completed"}
+	reason := "All tracked issues completed"
+	if len(tracked) == 0 {
+		reason = "Empty convoy (0 tracked issues) — auto-closed as definitionally complete"
+	}
+	closeArgs := []string{"close", convoyID, "-r", reason}
 	closeCmd := exec.Command("bd", closeArgs...)
 	closeCmd.Dir = townBeads
 
@@ -869,7 +869,8 @@ func runConvoyStranded(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// findStrandedConvoys finds convoys with ready work but no workers.
+// findStrandedConvoys finds convoys with ready work but no workers,
+// or empty convoys (0 tracked issues) that need cleanup.
 func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
 	stranded := []strandedConvoyInfo{} // Initialize as empty slice for proper JSON encoding
 
@@ -899,7 +900,15 @@ func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
 			style.PrintWarning("skipping convoy %s: %v", convoy.ID, err)
 			continue
 		}
+		// Empty convoys (0 tracked issues) are stranded — they need
+		// attention (auto-close via convoy check or manual cleanup).
 		if len(tracked) == 0 {
+			stranded = append(stranded, strandedConvoyInfo{
+				ID:          convoy.ID,
+				Title:       convoy.Title,
+				ReadyCount:  0,
+				ReadyIssues: []string{},
+			})
 			continue
 		}
 

--- a/internal/cmd/convoy_empty_test.go
+++ b/internal/cmd/convoy_empty_test.go
@@ -1,0 +1,142 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// mockBdForConvoyTest creates a fake bd binary tailored for convoy empty-check
+// tests. The script handles show, dep, close, and list subcommands.
+// closeLogPath is the file where close commands are logged for verification.
+func mockBdForConvoyTest(t *testing.T, convoyID, convoyTitle string) (binDir, townBeads, closeLogPath string) {
+	t.Helper()
+
+	binDir = t.TempDir()
+	townRoot := t.TempDir()
+	townBeads = filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(townBeads, 0755); err != nil {
+		t.Fatalf("mkdir townBeads: %v", err)
+	}
+
+	closeLogPath = filepath.Join(binDir, "bd-close.log")
+
+	bdPath := filepath.Join(binDir, "bd")
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping convoy empty test on Windows")
+	}
+
+	// Shell script that handles the bd subcommands needed by
+	// checkSingleConvoy and findStrandedConvoys.
+	script := `#!/bin/sh
+CLOSE_LOG="` + closeLogPath + `"
+CONVOY_ID="` + convoyID + `"
+CONVOY_TITLE="` + convoyTitle + `"
+
+# Find the actual subcommand (skip global flags like --allow-stale)
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;; # skip flags
+    *) cmd="$arg"; break ;;
+  esac
+done
+
+case "$cmd" in
+  show)
+    # Return convoy JSON
+    echo '[{"id":"'"$CONVOY_ID"'","title":"'"$CONVOY_TITLE"'","status":"open","issue_type":"convoy"}]'
+    exit 0
+    ;;
+  dep)
+    # Return empty tracked issues
+    echo '[]'
+    exit 0
+    ;;
+  close)
+    # Log the close command for verification
+    echo "$@" >> "$CLOSE_LOG"
+    exit 0
+    ;;
+  list)
+    # Return one open convoy
+    echo '[{"id":"'"$CONVOY_ID"'","title":"'"$CONVOY_TITLE"'"}]'
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(bdPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write mock bd: %v", err)
+	}
+
+	// Prepend mock bd to PATH
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	return binDir, townBeads, closeLogPath
+}
+
+func TestCheckSingleConvoy_EmptyConvoyAutoCloses(t *testing.T) {
+	_, townBeads, closeLogPath := mockBdForConvoyTest(t, "hq-empty1", "Empty test convoy")
+
+	err := checkSingleConvoy(townBeads, "hq-empty1", false)
+	if err != nil {
+		t.Fatalf("checkSingleConvoy() error: %v", err)
+	}
+
+	// Verify bd close was called with the empty-convoy reason
+	data, err := os.ReadFile(closeLogPath)
+	if err != nil {
+		t.Fatalf("reading close log: %v", err)
+	}
+	log := string(data)
+	if !strings.Contains(log, "hq-empty1") {
+		t.Errorf("close log should contain convoy ID, got: %q", log)
+	}
+	if !strings.Contains(log, "Empty convoy") {
+		t.Errorf("close log should contain empty-convoy reason, got: %q", log)
+	}
+}
+
+func TestCheckSingleConvoy_EmptyConvoyDryRun(t *testing.T) {
+	_, townBeads, closeLogPath := mockBdForConvoyTest(t, "hq-empty2", "Dry run convoy")
+
+	err := checkSingleConvoy(townBeads, "hq-empty2", true)
+	if err != nil {
+		t.Fatalf("checkSingleConvoy() dry-run error: %v", err)
+	}
+
+	// In dry-run mode, bd close should NOT be called
+	_, err = os.ReadFile(closeLogPath)
+	if err == nil {
+		t.Error("dry-run should not call bd close, but close log exists")
+	}
+}
+
+func TestFindStrandedConvoys_EmptyConvoyFlagged(t *testing.T) {
+	_, townBeads, _ := mockBdForConvoyTest(t, "hq-empty3", "Stranded empty convoy")
+
+	stranded, err := findStrandedConvoys(townBeads)
+	if err != nil {
+		t.Fatalf("findStrandedConvoys() error: %v", err)
+	}
+
+	if len(stranded) != 1 {
+		t.Fatalf("expected 1 stranded convoy, got %d", len(stranded))
+	}
+
+	s := stranded[0]
+	if s.ID != "hq-empty3" {
+		t.Errorf("stranded convoy ID = %q, want %q", s.ID, "hq-empty3")
+	}
+	if s.ReadyCount != 0 {
+		t.Errorf("stranded ReadyCount = %d, want 0", s.ReadyCount)
+	}
+	if len(s.ReadyIssues) != 0 {
+		t.Errorf("stranded ReadyIssues = %v, want empty", s.ReadyIssues)
+	}
+}


### PR DESCRIPTION
## Summary
- `checkSingleConvoy` returned nil for convoys with 0 tracked issues, silently ignoring them instead of closing them
- `findStrandedConvoys` skipped empty convoys entirely, making them invisible to stranded detection
- Both are now consistent with `checkAndCloseCompletedConvoys` which already treats empty convoys as definitionally complete

## Changes
- **checkSingleConvoy**: Remove early return on 0 tracked issues; let the `allClosed` logic handle it (0/0 = all closed). Uses descriptive close reason for empty convoys.
- **findStrandedConvoys**: Include empty convoys in stranded results with `ReadyCount=0` so they're visible and can be cleaned up.
- **Tests**: 3 new tests with mock `bd` binary covering auto-close, dry-run, and stranded detection for empty convoys.

## Test plan
- [x] `go test -race -run "TestCheckSingleConvoy_Empty|TestFindStrandedConvoys_Empty" ./internal/cmd/`
- [x] `go vet ./internal/cmd/...`
- [x] Existing convoy stranded tests still pass

Closes #1377

🤖 Generated with [Claude Code](https://claude.com/claude-code)