### PR TITLE
fix(witness): detect IN_PROGRESS beads assigned to dead polecats

### DIFF
--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1334,6 +1334,99 @@ Please re-dispatch to an available polecat.`,
 	return true
 }
 
+// OrphanedBeadResult contains a single detected orphaned bead.
+type OrphanedBeadResult struct {
+	BeadID       string
+	Assignee     string // Original assignee (e.g. "gastown/polecats/alpha")
+	PolecatName  string // Extracted polecat name
+	BeadRecovered bool
+	Error        error
+}
+
+// DetectOrphanedBeadsResult contains the results of an orphaned bead scan.
+type DetectOrphanedBeadsResult struct {
+	Checked int
+	Orphans []OrphanedBeadResult
+	Errors  []error
+}
+
+// DetectOrphanedBeads finds IN_PROGRESS beads assigned to non-existent polecats.
+//
+// This complements DetectZombiePolecats which scans FROM polecat directories.
+// If a polecat was nuked and its directory removed, DetectZombiePolecats won't
+// see it, but the bead remains IN_PROGRESS. This function scans FROM beads to
+// catch that case.
+func DetectOrphanedBeads(workDir, rigName string, router *mail.Router) *DetectOrphanedBeadsResult {
+	result := &DetectOrphanedBeadsResult{}
+
+	townRoot, err := workspace.Find(workDir)
+	if err != nil || townRoot == "" {
+		townRoot = workDir
+	}
+
+	// List all in_progress beads
+	output, err := util.ExecWithOutput(workDir, "bd", "list", "--status=in_progress", "--json")
+	if err != nil || output == "" {
+		return result
+	}
+
+	var beadList []struct {
+		ID       string `json:"id"`
+		Assignee string `json:"assignee"`
+	}
+	if err := json.Unmarshal([]byte(output), &beadList); err != nil {
+		result.Errors = append(result.Errors, fmt.Errorf("parsing in_progress beads: %w", err))
+		return result
+	}
+
+	t := tmux.NewTmux()
+
+	for _, bead := range beadList {
+		if bead.Assignee == "" {
+			continue // No assignee — not a dead-polecat orphan
+		}
+
+		// Parse assignee: "rigname/polecats/polecatname"
+		parts := strings.Split(bead.Assignee, "/")
+		if len(parts) != 3 || parts[1] != "polecats" {
+			continue // Not a polecat assignee (crew, refinery, etc.)
+		}
+		assigneeRig := parts[0]
+		polecatName := parts[2]
+		result.Checked++
+
+		// Check if the polecat's tmux session exists
+		sessionName := fmt.Sprintf("gt-%s-%s", assigneeRig, polecatName)
+		sessionAlive, err := t.HasSession(sessionName)
+		if err != nil {
+			result.Errors = append(result.Errors,
+				fmt.Errorf("checking session %s for bead %s: %w", sessionName, bead.ID, err))
+			continue
+		}
+		if sessionAlive {
+			continue // Polecat is alive — not an orphan
+		}
+
+		// Session is dead. Also check if polecat directory still exists
+		// (if dir exists, DetectZombiePolecats will handle it)
+		polecatsDir := filepath.Join(townRoot, assigneeRig, "polecats", polecatName)
+		if _, err := os.Stat(polecatsDir); err == nil {
+			continue // Directory exists — DetectZombiePolecats handles this case
+		}
+
+		// Polecat is truly gone (no session, no directory). Reset the bead.
+		orphan := OrphanedBeadResult{
+			BeadID:      bead.ID,
+			Assignee:    bead.Assignee,
+			PolecatName: polecatName,
+		}
+		orphan.BeadRecovered = resetAbandonedBead(workDir, assigneeRig, bead.ID, polecatName, router)
+		result.Orphans = append(result.Orphans, orphan)
+	}
+
+	return result
+}
+
 // DoneIntent represents a parsed done-intent label from an agent bead.
 type DoneIntent struct {
 	ExitType  string

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
 	"time"
 
@@ -525,5 +526,135 @@ func TestBeadRecoveredField_DefaultFalse(t *testing.T) {
 	}
 	if z.BeadRecovered {
 		t.Error("BeadRecovered should default to false")
+	}
+}
+
+func TestDetectOrphanedBeads_NoBdAvailable(t *testing.T) {
+	// When bd is not available (test environment), should return empty result
+	result := DetectOrphanedBeads("/nonexistent", "testrig", nil)
+
+	if result.Checked != 0 {
+		t.Errorf("Checked = %d, want 0 when bd unavailable", result.Checked)
+	}
+	if len(result.Orphans) != 0 {
+		t.Errorf("Orphans = %d, want 0 when bd unavailable", len(result.Orphans))
+	}
+}
+
+func TestDetectOrphanedBeads_ResultTypes(t *testing.T) {
+	// Verify the OrphanedBeadResult type has all expected fields
+	o := OrphanedBeadResult{
+		BeadID:        "gt-orphan1",
+		Assignee:      "testrig/polecats/alpha",
+		PolecatName:   "alpha",
+		BeadRecovered: true,
+		Error:         nil,
+	}
+
+	if o.BeadID != "gt-orphan1" {
+		t.Errorf("BeadID = %q, want %q", o.BeadID, "gt-orphan1")
+	}
+	if o.Assignee != "testrig/polecats/alpha" {
+		t.Errorf("Assignee = %q, want %q", o.Assignee, "testrig/polecats/alpha")
+	}
+	if o.PolecatName != "alpha" {
+		t.Errorf("PolecatName = %q, want %q", o.PolecatName, "alpha")
+	}
+	if !o.BeadRecovered {
+		t.Error("BeadRecovered = false, want true")
+	}
+}
+
+func TestDetectOrphanedBeads_WithMockBd(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping mock bd test on Windows")
+	}
+
+	// Set up town directory structure
+	townRoot := t.TempDir()
+	rigName := "testrig"
+	polecatsDir := filepath.Join(townRoot, rigName, "polecats")
+	if err := os.MkdirAll(polecatsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a polecat directory for "bravo" (alive dir, dead session)
+	// This case should be SKIPPED (deferred to DetectZombiePolecats)
+	if err := os.Mkdir(filepath.Join(polecatsDir, "bravo"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// "alpha" has NO directory and NO tmux session — true orphan
+	// "bravo" has directory but no session — deferred to DetectZombiePolecats
+	// "charlie" has no directory, assigned to different rig — still orphan if session dead
+
+	binDir := t.TempDir()
+	bdPath := filepath.Join(binDir, "bd")
+
+	// Create mock bd that returns in_progress beads with polecat assignees
+	script := `#!/bin/sh
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;; # skip flags
+    *) cmd="$arg"; break ;;
+  esac
+done
+
+case "$cmd" in
+  list)
+    cat <<'JSONEOF'
+[
+  {"id":"gt-orphan1","assignee":"testrig/polecats/alpha"},
+  {"id":"gt-alive1","assignee":"testrig/polecats/bravo"},
+  {"id":"gt-nocrew","assignee":"testrig/crew/sean"},
+  {"id":"gt-noassign","assignee":""}
+]
+JSONEOF
+    exit 0
+    ;;
+  update)
+    # Log update calls for verification
+    echo "$@" >> "` + filepath.Join(binDir, "bd-update.log") + `"
+    exit 0
+    ;;
+  show)
+    # Return in_progress status for any bead query
+    echo '[{"status":"in_progress"}]'
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(bdPath, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	result := DetectOrphanedBeads(townRoot, rigName, nil)
+
+	// Should have checked 2 polecat assignees (alpha and bravo)
+	// "crew/sean" is not a polecat, "" has no assignee
+	if result.Checked != 2 {
+		t.Errorf("Checked = %d, want 2 (alpha + bravo)", result.Checked)
+	}
+
+	// Should have found 1 orphan (alpha — no dir, no session)
+	// bravo has directory so deferred to DetectZombiePolecats
+	if len(result.Orphans) != 1 {
+		t.Fatalf("Orphans = %d, want 1 (only alpha)", len(result.Orphans))
+	}
+
+	orphan := result.Orphans[0]
+	if orphan.BeadID != "gt-orphan1" {
+		t.Errorf("orphan BeadID = %q, want %q", orphan.BeadID, "gt-orphan1")
+	}
+	if orphan.PolecatName != "alpha" {
+		t.Errorf("orphan PolecatName = %q, want %q", orphan.PolecatName, "alpha")
+	}
+	if orphan.Assignee != "testrig/polecats/alpha" {
+		t.Errorf("orphan Assignee = %q, want %q", orphan.Assignee, "testrig/polecats/alpha")
 	}
 }


### PR DESCRIPTION
## Summary
- Adds `DetectOrphanedBeads()` to complement `DetectZombiePolecats()` for comprehensive dead-polecat detection
- `DetectZombiePolecats` scans FROM polecat directories — once a polecat is nuked and its directory removed, its beads become invisible
- `DetectOrphanedBeads` scans FROM beads — lists all IN_PROGRESS beads, checks if polecat assignees still exist, resets orphans

## How it works
1. `bd list --status=in_progress --json` to get all active beads
2. For each bead with a polecat assignee (`rig/polecats/name`):
   - Check tmux session existence
   - Check polecat directory existence
3. If both are gone → reset bead via `resetAbandonedBead` (status=open, clear assignee, mail deacon)
4. If directory exists but session dead → skip (DetectZombiePolecats handles this case)

## Test plan
- [x] `go test -race ./internal/witness/... -count=1` — all pass
- [x] `go vet ./internal/witness/...` — clean
- [x] `TestDetectOrphanedBeads_NoBdAvailable` — graceful degradation when bd unavailable
- [x] `TestDetectOrphanedBeads_ResultTypes` — struct fields work correctly
- [x] `TestDetectOrphanedBeads_WithMockBd` — mock bd returns 4 beads, correctly identifies 1 orphan (alpha), skips bravo (dir exists), skips crew assignee, skips empty assignee

Closes #1380

🤖 Generated with [Claude Code](https://claude.com/claude-code)