### PR TITLE
fix(feed): auto-disable follow when stdout is not a TTY

### DIFF
--- a/internal/cmd/feed.go
+++ b/internal/cmd/feed.go
@@ -154,6 +154,13 @@ func buildFeedArgs() []string {
 		shouldFollow = true
 	}
 
+	// Auto-disable follow when stdout is not a TTY (e.g. agents, pipes),
+	// unless the user explicitly passed --follow. This prevents agents
+	// from blocking on a streaming feed that never terminates.
+	if !term.IsTerminal(int(os.Stdout.Fd())) && !feedFollow {
+		shouldFollow = false
+	}
+
 	if shouldFollow {
 		args = append(args, "--follow")
 	}


### PR DESCRIPTION
## Summary

- Auto-disable `--follow` when stdout is not a TTY (agents, pipes, scripts), so `gt feed` defaults to snapshot mode in non-interactive contexts
- Explicit `--follow` still overrides this behavior
- Adds `--plain` to two formulas (`mol-convoy-cleanup`, `mol-digest-generate`) that called `gt feed` without safe flags

Uses the same `term.IsTerminal` check that already gates the TUI, applied to the follow-mode default in `buildFeedArgs()`.

Closes #391

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/cmd/...` clean
- [x] `go test ./internal/formula/...` passes (embedded formula validation)
- [ ] Manual: `gt feed --since 5m` in terminal → still follows (TTY detected)
- [ ] Manual: `gt feed --since 5m | cat` → exits after snapshot (non-TTY)
- [ ] Manual: `gt feed --since 5m --follow | cat` → follows (explicit flag)

🤖 Generated with [Claude Code](https://claude.com/claude-code)