### PR TITLE
feat(witness): detect and auto-dismiss stalled polecat permission prompts

### DIFF
--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1252,6 +1252,101 @@ func DetectZombiePolecats(workDir, rigName string, router *mail.Router) *DetectZ
 	return result
 }
 
+// StalledResult represents a single stalled polecat detection.
+type StalledResult struct {
+	PolecatName string // e.g., "alpha"
+	StallType   string // "bypass-permissions", "unknown-prompt"
+	Action      string // "auto-dismissed", "escalated"
+	Error       error
+}
+
+// DetectStalledPolecatsResult holds aggregate results.
+type DetectStalledPolecatsResult struct {
+	Checked int             // Number of live polecats inspected
+	Stalled []StalledResult // Stalled polecats found and processed
+	Errors  []error         // Transient errors
+}
+
+// DetectStalledPolecats checks live polecat sessions for agents stuck on
+// interactive prompts (e.g., the "Bypass Permissions mode" startup warning).
+// Unlike zombie detection which looks for dead sessions/agents, this targets
+// alive-but-stuck agents that will never make progress without intervention.
+//
+// For each qualifying polecat (live session + alive agent):
+//   - Captures pane content (last 30 lines)
+//   - Checks for known stall patterns
+//   - Auto-dismisses known prompts (bypass-permissions) or escalates
+//
+// This is idempotent: calling AcceptBypassPermissionsWarning on a non-stalled
+// session is harmless, so no dedup or TOCTOU guards are needed.
+func DetectStalledPolecats(workDir, rigName string) *DetectStalledPolecatsResult {
+	result := &DetectStalledPolecatsResult{}
+
+	// Find town root for path resolution
+	townRoot, err := workspace.Find(workDir)
+	if err != nil || townRoot == "" {
+		townRoot = workDir
+	}
+
+	// List all polecat directories
+	polecatsDir := filepath.Join(townRoot, rigName, "polecats")
+	entries, err := os.ReadDir(polecatsDir)
+	if err != nil {
+		return result // No polecats directory
+	}
+
+	t := tmux.NewTmux()
+
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
+		polecatName := entry.Name()
+		sessionName := fmt.Sprintf("gt-%s-%s", rigName, polecatName)
+		result.Checked++
+
+		// Only check live sessions with alive agents (the opposite of zombie detection)
+		sessionAlive, err := t.HasSession(sessionName)
+		if err != nil {
+			result.Errors = append(result.Errors,
+				fmt.Errorf("checking session %s: %w", sessionName, err))
+			continue
+		}
+		if !sessionAlive {
+			continue // Dead session — zombie detection handles this
+		}
+		if !t.IsAgentAlive(sessionName) {
+			continue // Dead agent — zombie detection handles this
+		}
+
+		// Agent is alive. Capture pane to check for known stall patterns.
+		content, err := t.CapturePane(sessionName, 30)
+		if err != nil {
+			result.Errors = append(result.Errors,
+				fmt.Errorf("capturing pane for %s: %w", sessionName, err))
+			continue
+		}
+
+		// Check for bypass-permissions prompt
+		if strings.Contains(content, "Bypass Permissions mode") {
+			stalled := StalledResult{
+				PolecatName: polecatName,
+				StallType:   "bypass-permissions",
+			}
+			if err := t.AcceptBypassPermissionsWarning(sessionName); err != nil {
+				stalled.Action = "escalated"
+				stalled.Error = fmt.Errorf("auto-dismiss failed: %w", err)
+			} else {
+				stalled.Action = "auto-dismissed"
+			}
+			result.Stalled = append(result.Stalled, stalled)
+		}
+	}
+
+	return result
+}
+
 // getAgentBeadState reads agent_state and hook_bead from an agent bead.
 // Returns the agent_state string and hook_bead ID.
 func getAgentBeadState(workDir, agentBeadID string) (agentState, hookBead string) {

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -527,3 +527,121 @@ func TestBeadRecoveredField_DefaultFalse(t *testing.T) {
 		t.Error("BeadRecovered should default to false")
 	}
 }
+
+func TestStalledResult_Types(t *testing.T) {
+	// Verify the StalledResult type has all expected fields
+	s := StalledResult{
+		PolecatName: "alpha",
+		StallType:   "bypass-permissions",
+		Action:      "auto-dismissed",
+		Error:       nil,
+	}
+
+	if s.PolecatName != "alpha" {
+		t.Errorf("PolecatName = %q, want %q", s.PolecatName, "alpha")
+	}
+	if s.StallType != "bypass-permissions" {
+		t.Errorf("StallType = %q, want %q", s.StallType, "bypass-permissions")
+	}
+	if s.Action != "auto-dismissed" {
+		t.Errorf("Action = %q, want %q", s.Action, "auto-dismissed")
+	}
+	if s.Error != nil {
+		t.Errorf("Error = %v, want nil", s.Error)
+	}
+
+	// Verify error field works
+	s2 := StalledResult{
+		PolecatName: "bravo",
+		StallType:   "unknown-prompt",
+		Action:      "escalated",
+		Error:       fmt.Errorf("auto-dismiss failed"),
+	}
+	if s2.Error == nil {
+		t.Error("Error = nil, want non-nil")
+	}
+}
+
+func TestDetectStalledPolecatsResult_Empty(t *testing.T) {
+	result := &DetectStalledPolecatsResult{}
+
+	if result.Checked != 0 {
+		t.Errorf("Checked = %d, want 0", result.Checked)
+	}
+	if len(result.Stalled) != 0 {
+		t.Errorf("Stalled length = %d, want 0", len(result.Stalled))
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("Errors length = %d, want 0", len(result.Errors))
+	}
+}
+
+func TestDetectStalledPolecats_NoPolecats(t *testing.T) {
+	// Should handle missing polecats directory gracefully
+	result := DetectStalledPolecats("/nonexistent/path", "testrig")
+
+	if result.Checked != 0 {
+		t.Errorf("Checked = %d, want 0 for nonexistent dir", result.Checked)
+	}
+	if len(result.Stalled) != 0 {
+		t.Errorf("Stalled = %d, want 0 for nonexistent dir", len(result.Stalled))
+	}
+	if len(result.Errors) != 0 {
+		t.Errorf("Errors = %d, want 0 for nonexistent dir", len(result.Errors))
+	}
+}
+
+func TestDetectStalledPolecats_EmptyPolecatsDir(t *testing.T) {
+	// Empty polecats directory should return 0 checked
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+	polecatsDir := filepath.Join(tmpDir, rigName, "polecats")
+	if err := os.MkdirAll(polecatsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	result := DetectStalledPolecats(tmpDir, rigName)
+
+	if result.Checked != 0 {
+		t.Errorf("Checked = %d, want 0 for empty polecats dir", result.Checked)
+	}
+	if len(result.Stalled) != 0 {
+		t.Errorf("Stalled = %d, want 0 for empty polecats dir", len(result.Stalled))
+	}
+}
+
+func TestDetectStalledPolecats_NoPaneCapture(t *testing.T) {
+	// When tmux sessions don't exist (no real tmux in test),
+	// HasSession returns false so polecats are skipped (not errors).
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+	polecatsDir := filepath.Join(tmpDir, rigName, "polecats")
+	if err := os.MkdirAll(polecatsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create polecat directories
+	for _, name := range []string{"alpha", "bravo"} {
+		if err := os.Mkdir(filepath.Join(polecatsDir, name), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Create hidden dir (should be skipped)
+	if err := os.Mkdir(filepath.Join(polecatsDir, ".hidden"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	result := DetectStalledPolecats(tmpDir, rigName)
+
+	// Should count 2 polecats (skip hidden)
+	if result.Checked != 2 {
+		t.Errorf("Checked = %d, want 2 (should skip hidden dirs)", result.Checked)
+	}
+
+	// No stalled because HasSession returns false (no real tmux in test),
+	// so polecats are skipped before pane capture is attempted.
+	if len(result.Stalled) != 0 {
+		t.Errorf("Stalled = %d, want 0 (no tmux sessions in test)", len(result.Stalled))
+	}
+}


### PR DESCRIPTION
## Summary

- Add `DetectStalledPolecats` function to witness patrol that detects polecats stuck on interactive prompts (e.g., "Bypass Permissions mode" startup warning)
- Auto-dismisses known prompts via existing `AcceptBypassPermissionsWarning` infrastructure
- Adds `StalledResult` and `DetectStalledPolecatsResult` types following the `DetectZombiePolecats` pattern
- 5 new unit tests, all passing with race detector

Closes #1378

## Test plan

- [x] `go vet ./internal/witness/...` passes
- [x] `go test -race -v ./internal/witness/... -count=1` — all tests pass (5 new + existing)
- [x] No regressions in existing zombie detection tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)