### PR TITLE
fix(cmd): replace IsAgentRunning with IsAgentAlive in crew and start

### DIFF
--- a/internal/cmd/crew_at.go
+++ b/internal/cmd/crew_at.go
@@ -238,14 +238,11 @@ func runCrewAt(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%s Created session for %s/%s\n",
 			style.Bold.Render("✓"), r.Name, name)
 	} else {
-		// Session exists - check if runtime is still running
-		// Uses both pane command check and UI marker detection to avoid
-		// restarting when user is in a subshell spawned from the runtime
-		agentCfg, _, err := config.ResolveAgentConfigWithOverride(townRoot, r.Path, crewAgentOverride)
-		if err != nil {
-			return fmt.Errorf("resolving agent: %w", err)
-		}
-		if !t.IsAgentRunning(sessionID, config.ExpectedPaneCommands(agentCfg)...) {
+		// Session exists - check if agent is still alive
+		// Uses descendant process check instead of pane command check,
+		// since crew members launch via bash -c wrappers that cause
+		// false-negative detection with IsAgentRunning (see #1315, #1330).
+		if !t.IsAgentAlive(sessionID) {
 			// Runtime has exited, restart it using respawn-pane
 			fmt.Printf("Runtime exited, restarting...\n")
 
@@ -301,15 +298,18 @@ func runCrewAt(cmd *cobra.Command, args []string) error {
 
 	// Check if we're already in the target session
 	if isInTmuxSession(sessionID) {
-		// Check if agent is already running - don't restart if so
+		// Check if agent is already alive - don't restart if so
+		// Uses descendant process check (see #1315, #1330).
+		if t.IsAgentAlive(sessionID) {
+			// Agent is already running, nothing to do
+			fmt.Printf("Already in %s session with agent running.\n", name)
+			return nil
+		}
+
+		// Agent not alive — resolve config to start it
 		agentCfg, _, err := config.ResolveAgentConfigWithOverride(townRoot, r.Path, crewAgentOverride)
 		if err != nil {
 			return fmt.Errorf("resolving agent: %w", err)
-		}
-		if t.IsAgentRunning(sessionID, config.ExpectedPaneCommands(agentCfg)...) {
-			// Agent is already running, nothing to do
-			fmt.Printf("Already in %s session with %s running.\n", name, agentCfg.Command)
-			return nil
 		}
 
 		// We're in the session at a shell prompt - start the agent

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -409,9 +409,10 @@ func startConfiguredCrew(t *tmux.Tmux, rigs []*rig.Rig, townRoot string, mu *syn
 func startOrRestartCrewMember(t *tmux.Tmux, r *rig.Rig, crewName, townRoot string) (msg string, started bool) {
 	sessionID := crewSessionName(r.Name, crewName)
 	if running, _ := t.HasSession(sessionID); running {
-		// Session exists - check if agent is still running
-		agentCfg := config.ResolveRoleAgentConfig(constants.RoleCrew, townRoot, r.Path)
-		if !t.IsAgentRunning(sessionID, config.ExpectedPaneCommands(agentCfg)...) {
+		// Session exists - check if agent is still alive
+		// Uses descendant process check instead of pane command check,
+		// since crew members launch via bash -c wrappers (see #1315, #1330).
+		if !t.IsAgentAlive(sessionID) {
 			// Agent has exited, restart it
 			// Build startup beacon for predecessor discovery via /resume
 			address := fmt.Sprintf("%s/crew/%s", r.Name, crewName)


### PR DESCRIPTION
## Summary

- Replace `IsAgentRunning` (pane command check) with `IsAgentAlive` (descendant process check) at three call sites in crew attach and start flows
- Crew members launch via `bash -c` wrappers, causing false-negative detection that leads to unnecessary restarts
- Mirrors the fix applied to mayor in PR #1315

**Call sites fixed:**
- `crew_at.go`: attach restart decision (session exists, agent exited)
- `crew_at.go`: attach already-running check (in target session)
- `start.go`: `startOrRestartCrewMember` restart decision

Closes #1330

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/cmd/...` clean
- [x] `go test -short ./internal/cmd/...` passes
- [ ] Manual: `gt crew at <name>` when agent is running via bash wrapper — should not restart
- [ ] Manual: `gt start <rig>` when crew agent exited — should detect and restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)