### PR TITLE
fix(polecat): use math/rand/v2 for thread-safe jitter in doltBackoff

### DIFF
--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -5,7 +5,7 @@ package polecat
 import (
 	"errors"
 	"fmt"
-	"math/rand"
+	"math/rand/v2"
 	"os"
 	"os/exec"
 	"path/filepath"


### PR DESCRIPTION
## Summary
- Switch `doltBackoff()` from `math/rand` to `math/rand/v2` for thread-safe global RNG
- `rand.Float64()` in `math/rand` v1 is not safe for concurrent goroutine access
- `math/rand/v2` (Go 1.22+) provides a thread-safe global RNG as a drop-in replacement
- Called concurrently from `CheckDoltHealth`, `CreateAgentBeadWithRetry`, and `SetAgentStateWithRetry`

## Test plan
- [x] `go build ./internal/polecat/...` passes
- [x] `go test -race ./internal/polecat/...` passes with race detector enabled

Closes #1316

🤖 Generated with [Claude Code](https://claude.com/claude-code)