### PR TITLE
fix(dolthub): harden CreateDoltHubRepo test mocks

### DIFF
--- a/internal/doltserver/dolthub.go
+++ b/internal/doltserver/dolthub.go
@@ -13,6 +13,7 @@ import (
 
 // dolthubAPIBase is the DoltHub REST API base URL.
 // It is a var (not const) so tests can override it with httptest servers.
+// Not safe for parallel tests — tests that mutate this must not use t.Parallel().
 var dolthubAPIBase = "https://www.dolthub.com/api/v1alpha1"
 
 const (

--- a/internal/doltserver/dolthub_test.go
+++ b/internal/doltserver/dolthub_test.go
@@ -74,6 +74,9 @@ func TestCreateDoltHubRepo_Success(t *testing.T) {
 		if r.Method != "POST" {
 			t.Errorf("expected POST, got %s", r.Method)
 		}
+		if r.URL.Path != "/database" {
+			t.Errorf("expected path /database, got %s", r.URL.Path)
+		}
 		if r.Header.Get("authorization") != "token test-token" {
 			t.Errorf("expected auth header, got %q", r.Header.Get("authorization"))
 		}
@@ -113,6 +116,9 @@ func TestCreateDoltHubRepo_Success(t *testing.T) {
 
 func TestCreateDoltHubRepo_AlreadyExists(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/database" {
+			t.Errorf("expected path /database, got %s", r.URL.Path)
+		}
 		w.WriteHeader(409)
 		json.NewEncoder(w).Encode(map[string]string{
 			"status":  "Error",


### PR DESCRIPTION
## Summary
- Assert mock handlers verify the request hits `/database` endpoint path, catching accidental endpoint changes
- Add parallel-safety comment on `dolthubAPIBase` var since tests mutate it

Addresses optional review feedback from PR #1448 ([comment](https://github.com/steveyegge/gastown/pull/1448#issuecomment-3905000961)).

## Test plan
- [x] `go test -race ./internal/doltserver/...` passes
- [x] `go vet ./internal/doltserver/...` clean
- [x] Path assertion verified: changing `/database` to anything else fails the test

🤖 Generated with [Claude Code](https://claude.com/claude-code)