### PR TITLE
fix(role): add RoleBoot case to buildAgentBeadID

### DIFF
--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -44,6 +44,8 @@ func buildAgentBeadID(identity string, role Role, townRoot string) string {
 			return beads.MayorBeadIDTown()
 		case identity == "deacon":
 			return beads.DeaconBeadIDTown()
+		case identity == "deacon-boot":
+			return beads.DogBeadIDTown("boot")
 		case len(parts) == 2 && parts[1] == "witness":
 			return beads.WitnessBeadIDWithPrefix(getPrefix(parts[0]), parts[0])
 		case len(parts) == 2 && parts[1] == "refinery":
@@ -91,6 +93,9 @@ func buildAgentBeadID(identity string, role Role, townRoot string) string {
 			return beads.CrewBeadIDWithPrefix(getPrefix(parts[0]), parts[0], parts[2])
 		}
 		return ""
+	case RoleBoot:
+		// Boot is a deacon dog — uses town-level dog bead ID
+		return beads.DogBeadIDTown("boot")
 	default:
 		return ""
 	}

--- a/internal/cmd/role.go
+++ b/internal/cmd/role.go
@@ -377,6 +377,7 @@ func parseRoleString(s string) (Role, string, string) {
 // ActorString returns the actor identity string for beads attribution.
 // Format matches beads created_by convention:
 //   - Simple roles: "mayor", "deacon"
+//   - Dog roles: "deacon-boot" (hyphenated, matching BD_ACTOR)
 //   - Rig-specific: "gastown/witness", "gastown/refinery"
 //   - Workers: "gastown/crew/max", "gastown/polecats/Toast"
 func (info RoleInfo) ActorString() string {

--- a/internal/cmd/role_boot_test.go
+++ b/internal/cmd/role_boot_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"path/filepath"
 	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 func TestParseRoleStringBoot(t *testing.T) {
@@ -79,12 +81,31 @@ func TestActorStringBoot(t *testing.T) {
 }
 
 func TestActorStringConsistentWithBDActorBoot(t *testing.T) {
-	// ActorString() must match what BD_ACTOR is set to in config/env.go.
-	// BD_ACTOR for boot is "deacon-boot".
+	// ActorString() must match what BD_ACTOR is set to in config/env.go:57.
+	// This is a snapshot value — if BD_ACTOR for boot changes in config/env.go,
+	// update it here too.
 	info := RoleInfo{Role: RoleBoot}
 	actorString := info.ActorString()
-	bdActor := "deacon-boot" // from internal/config/env.go:57
+	bdActor := "deacon-boot" // snapshot from internal/config/env.go:57
 	if actorString != bdActor {
 		t.Errorf("ActorString() = %q does not match BD_ACTOR = %q", actorString, bdActor)
+	}
+}
+
+func TestBuildAgentBeadIDBoot(t *testing.T) {
+	// RoleBoot should produce the town-level dog bead ID "hq-dog-boot"
+	// via both the explicit role path and the identity-inference path.
+	want := beads.DogBeadIDTown("boot")
+
+	// Explicit role path
+	got := buildAgentBeadID("deacon-boot", RoleBoot, "/tmp/gt")
+	if got != want {
+		t.Errorf("buildAgentBeadID(RoleBoot) = %q, want %q", got, want)
+	}
+
+	// Identity inference path (RoleUnknown + "deacon-boot" identity)
+	got = buildAgentBeadID("deacon-boot", RoleUnknown, "/tmp/gt")
+	if got != want {
+		t.Errorf("buildAgentBeadID(RoleUnknown, \"deacon-boot\") = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
## Summary

- Add `case RoleBoot` to `buildAgentBeadID` returning `beads.DogBeadIDTown("boot")` — fixes slung-work detection silently skipping boot sessions
- Add `"deacon-boot"` to the identity-inference path (when role is unknown)
- Update `ActorString()` docstring to mention the `"deacon-boot"` convention
- Add `TestBuildAgentBeadIDBoot` covering both the explicit role and inference paths

Follow-up to PR #1467 review comment: https://github.com/steveyegge/gastown/pull/1467#issuecomment-3905000249

Closes #1488

## Test plan

- [x] `TestBuildAgentBeadIDBoot` — explicit RoleBoot and RoleUnknown inference paths
- [x] Existing `TestActorStringBoot` and `TestActorStringConsistentWithBDActorBoot` still pass
- [x] `go test -short ./...` clean (except pre-existing flaky tmux test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)