### PR TITLE
fix(role): don't infer RoleMayor from town root cwd

### DIFF
--- a/internal/cmd/role.go
+++ b/internal/cmd/role.go
@@ -257,12 +257,13 @@ func detectRole(cwd, townRoot string) RoleInfo {
 	relPath = filepath.ToSlash(relPath)
 	parts := strings.Split(relPath, "/")
 
-	// Check for mayor role
-	// At town root, or in mayor/ or mayor/rig/
+	// Town root is a neutral location — don't infer any role from it.
+	// The mayor's actual home is mayor/ (matched below).
 	if relPath == "." || relPath == "" {
-		ctx.Role = RoleMayor
 		return ctx
 	}
+
+	// Check for mayor role: mayor/ or mayor/rig/
 	if len(parts) >= 1 && parts[0] == "mayor" {
 		ctx.Role = RoleMayor
 		return ctx


### PR DESCRIPTION
## Summary
- `detectRole()` treated cwd at town root (`~/gt/`) as `RoleMayor`, causing false `ROLE/LOCATION MISMATCH` warnings for any non-mayor agent running `gt prime` from `~/gt/`
- Returns `RoleUnknown` for town root instead — the mayor match at `parts[0] == "mayor"` already handles `~/gt/mayor/` correctly
- `RoleUnknown` is already excluded from mismatch detection (line 223), so this silently skips the warning as intended

Fixes #1496

## Test plan
- [x] `go build ./cmd/gt/` compiles cleanly
- [x] `go test ./internal/cmd/ -run "Role|role|Prime|prime"` passes
- [ ] Manual: `cd ~/gt && gt prime` as a non-mayor agent no longer shows mismatch warning
- [ ] Manual: `cd ~/gt/mayor && gt prime` still correctly detects mayor role

🤖 Generated with [Claude Code](https://claude.com/claude-code)