### PR TITLE
fix(sling): allow polecat/crew shorthand and validate before dispatch fork

### DIFF
--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -217,6 +217,14 @@ func runSling(cmd *cobra.Command, args []string) error {
 		args[i] = strings.TrimRight(args[i], "/")
 	}
 
+	// Validate target format early, before any dispatch path (bead, formula, batch)
+	// can trigger resolveTarget side-effects like polecat spawning.
+	if len(args) > 1 {
+		if err := ValidateTarget(args[len(args)-1]); err != nil {
+			return err
+		}
+	}
+
 	// Batch mode detection: multiple beads with rig target
 	// Pattern: gt sling gt-abc gt-def gt-ghi gastown
 	// When len(args) > 2 and last arg is a rig, sling each bead to its own polecat
@@ -299,12 +307,6 @@ func runSling(cmd *cobra.Command, args []string) error {
 	var target string
 	if len(args) > 1 {
 		target = args[1]
-
-		// Validate target format before resolveTarget, which can have
-		// side-effects like polecat spawning.
-		if err := ValidateTarget(target); err != nil {
-			return err
-		}
 	}
 	resolved, err := resolveTarget(target, ResolveTargetOptions{
 		DryRun:     slingDryRun,

--- a/internal/cmd/sling_validate_test.go
+++ b/internal/cmd/sling_validate_test.go
@@ -24,20 +24,25 @@ func TestValidateTarget(t *testing.T) {
 		{name: "rig/refinery", target: "gastown/refinery", wantErr: false},
 		{name: "deacon/dogs", target: "deacon/dogs", wantErr: false},
 		{name: "deacon/dogs/name", target: "deacon/dogs/rex", wantErr: false},
+		{name: "polecat shorthand", target: "gastown/nux", wantErr: false},
+		{name: "crew shorthand", target: "gastown/max", wantErr: false},
 
 		// Invalid targets — empty segments
 		{name: "trailing slash", target: "gastown/", wantErr: true, errMsg: "empty path segment"},
 		{name: "double slash", target: "gastown//polecats", wantErr: true, errMsg: "empty path segment"},
 		{name: "leading slash", target: "/polecats", wantErr: true, errMsg: "empty path segment"},
 
-		// Invalid targets — unknown role
-		{name: "unknown role", target: "gastown/badrole", wantErr: true, errMsg: "unknown role"},
-		{name: "typo in role", target: "gastown/polecat", wantErr: true, errMsg: "unknown role"},
-		{name: "plural witness", target: "gastown/witnesses", wantErr: true, errMsg: "unknown role"},
+		// Invalid targets — unknown role (only rejected with 3+ segments)
+		{name: "unknown role 3-seg", target: "gastown/badrole/name", wantErr: true, errMsg: "unknown role"},
+		{name: "typo in role 3-seg", target: "gastown/polecat/name", wantErr: true, errMsg: "unknown role"},
 
 		// Invalid targets — missing name
 		{name: "crew no name", target: "gastown/crew", wantErr: true, errMsg: "requires a worker name"},
 		{name: "polecats no name", target: "gastown/polecats", wantErr: true, errMsg: "requires a polecat name"},
+
+		// Invalid targets — witness/refinery with sub-agents
+		{name: "witness with name", target: "gastown/witness/extra", wantErr: true, errMsg: "does not have named sub-agents"},
+		{name: "refinery with name", target: "gastown/refinery/extra", wantErr: true, errMsg: "does not have named sub-agents"},
 
 		// Invalid targets — too many segments
 		{name: "too many segments", target: "gastown/crew/burke/extra", wantErr: true, errMsg: "too many path segments"},


### PR DESCRIPTION
## Summary

Fix three issues in `ValidateTarget()` introduced by #1481:
1. **Blocker:** Polecat shorthand `<rig>/<name>` (e.g., `gastown/nux`) was rejected as "unknown role" — a regression on a core, documented sling workflow
2. **Major:** Formula sling path bypassed `ValidateTarget` entirely (the call was placed after the formula dispatch fork)
3. **Minor:** `witness/<name>` and `refinery/<name>` passed validation but fail in the resolver (singleton roles have no sub-agents)

## Related Issue

Follow-up fixes for #1481 (merged). Part of #907.

## Changes

- Allow 2-segment `<rig>/<name>` paths through validation (polecat/crew shorthand handled by `resolvePathToSession`)
- Only reject unknown roles when 3+ segments are present
- Reject `witness/<name>` and `refinery/<name>` (singleton roles with no sub-agents)
- Move `ValidateTarget` call before the bead/formula/batch dispatch fork so all paths are validated
- Add test cases for polecat shorthand, crew shorthand, and witness/refinery sub-agent rejection (24 total)
- Add comment on deacon early-return re: downstream validation

## Testing

- [x] Unit tests pass (`go test ./internal/cmd/ -run TestValidateTarget` — 24 cases)
- [x] All existing sling/convoy tests pass (`go test ./internal/cmd/ -run "TestSling|TestConvoy"`)
- [x] `go build ./...` passes

## Checklist
- [x] Code follows project style
- [x] No breaking changes
- [x] Tests added for new behavior