### PR TITLE
fix(role): update stale prime help text and add town root regression tests

### DIFF
--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -49,7 +49,8 @@ var primeCmd = &cobra.Command{
 	Long: `Detect the agent role from the current directory and output context.
 
 Role detection:
-  - Town root, mayor/, or <rig>/mayor/ → Mayor context
+  - Town root → Neutral (no role inferred; use GT_ROLE)
+  - mayor/ or <rig>/mayor/ → Mayor context
   - <rig>/witness/rig/ → Witness context
   - <rig>/refinery/rig/ → Refinery context
   - <rig>/polecats/<name>/ → Polecat context

--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -250,7 +250,8 @@ func outputUnknownContext(ctx RoleContext) {
 	fmt.Println("- `<rig>/polecats/<name>/` - Polecat role")
 	fmt.Println("- `<rig>/witness/rig/` - Witness role")
 	fmt.Println("- `<rig>/refinery/rig/` - Refinery role")
-	fmt.Println("- Town root or `mayor/` - Mayor role")
+	fmt.Println("- `mayor/` or `<rig>/mayor/` - Mayor role")
+	fmt.Println("- Town root is neutral (set GT_ROLE or cd into a role directory)")
 	fmt.Println()
 	fmt.Printf("Town root: %s\n", style.Dim.Render(ctx.TownRoot))
 }


### PR DESCRIPTION
## Summary

Follow-up to PR #1497 (fix(role): don't infer RoleMayor from town root cwd). Updates stale documentation and adds regression tests that were identified during post-merge review.

## Related Issue

Closes #1496

## Changes

- Update `gt prime` help text to reflect that town root is neutral (no role inferred), not mayor
- Update `prime_output.go` role guidance (`outputUnknownContext`) to list `mayor/` and `<rig>/mayor/` consistently with help text, and note town root is neutral
- Add `TestRoleShowNoMismatchAtTownRoot`: validates no ROLE MISMATCH warning at town root with `GT_ROLE=mayor` set (direct regression test for #1496)
- Add "town root returns unknown" case to `TestRoleDetectE2E` table

## Testing

- [x] Integration tests pass (`go test -tags integration ./internal/cmd -run 'TestRoleShowMismatch$|TestRoleShowNoMismatchAtTownRoot|TestRoleDetectE2E|TestRoleDetectInvalidPaths' -count=1`)
- [x] All 4 role detection test suites pass
- [x] Dual-model review (Claude + Codex) — both approve with no blockers

## Checklist
- [x] Code follows project style
- [x] Documentation updated
- [x] No breaking changes