### PR TITLE
fix(witness): cover all synthetic zombie states in patrol receipt verdict mapping

### DIFF
--- a/internal/witness/patrol_receipts.go
+++ b/internal/witness/patrol_receipts.go
@@ -31,10 +31,17 @@ func receiptVerdictForZombie(z ZombieResult) PatrolVerdict {
 	if strings.TrimSpace(z.HookBead) != "" {
 		return PatrolVerdictStale
 	}
-	if z.AgentState == "working" || z.AgentState == "running" || z.AgentState == "spawning" {
+	// All states from DetectZombiePolecats that indicate a polecat was recently
+	// active are classified as stale. States without evidence of recent work
+	// (e.g. "idle") fall through to orphan.
+	switch z.AgentState {
+	case "working", "running", "spawning",
+		"stuck-in-done", "agent-dead-in-session",
+		"bead-closed-still-running", "done-intent-dead":
 		return PatrolVerdictStale
+	default:
+		return PatrolVerdictOrphan
 	}
-	return PatrolVerdictOrphan
 }
 
 // BuildPatrolReceipt projects a zombie patrol result into a stable JSON-ready receipt.


### PR DESCRIPTION
## Summary

Fixes verdict mapping gap in patrol receipt generation where synthetic zombie states from `DetectZombiePolecats` were misclassified as `orphan` instead of `stale`.

Relates to #1464, follow-up to #1465.

## Related Issue

Post-merge review of PR #1465 identified that `receiptVerdictForZombie` only checked `working`/`running`/`spawning` for stale verdicts, but `DetectZombiePolecats` produces four additional synthetic states (`stuck-in-done`, `agent-dead-in-session`, `bead-closed-still-running`, `done-intent-dead`) that fell through to `orphan`. These states all represent recently-active polecats and should be classified as stale.

## Changes

- **`patrol_receipts.go`**: Replaced if-chain with explicit `switch` covering all seven known `AgentState` values. Added comment documenting the classification logic.
- **`patrol_receipts_test.go`**: Added `TestReceiptVerdictForZombie_AllStates` table-driven test covering all 7 states × {empty, non-empty} HookBead (19 cases). Added `TestBuildPatrolReceipts_NilAndEmpty` for nil/empty edge cases.

## Testing

- [x] `go test ./internal/witness/ -run "TestReceiptVerdict|TestBuildPatrolReceipt"` — all pass
- [x] All 19 verdict test cases pass including synthetic states
- [x] Nil/empty edge case tests pass

## Checklist

- [x] Tests added for new behavior
- [x] No breaking changes
- [x] Follows existing code patterns

🤖 Generated with [Claude Code](https://claude.com/claude-code)