### PR TITLE
fix(start): restore early return for alive crew agents

### DIFF
--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -466,8 +466,8 @@ func startOrRestartCrewMember(t *tmux.Tmux, r *rig.Rig, crewName, townRoot strin
 			}
 			return fmt.Sprintf("  %s %s/%s agent restarted\n", style.Bold.Render("✓"), r.Name, crewName), true
 		}
-		// Agent is dead (zombie session) - fall through to startCrewMember
-		// which calls crewMgr.Start() to kill zombie and recreate cleanly
+		// Agent is alive — nothing to do
+		return fmt.Sprintf("  %s %s/%s already running\n", style.Dim.Render("○"), r.Name, crewName), false
 	}
 
 	if err := startCrewMember(r.Name, crewName, townRoot); err != nil {


### PR DESCRIPTION
## Summary

Restore the missing "already running" early return in `startOrRestartCrewMember`. Commit 03d47f3b (post-merge follow-up to #1485) accidentally removed this return, causing alive crew agents to fall through to `startCrewMember` on every `gt start`.

**Symptoms:**
- Misleading "started" output for agents that were already running
- `startedAny` flag set incorrectly, masking the "No crew configured or all already running" message
- Unnecessary work on every start cycle (creating crew managers, hitting `ErrSessionRunning`)

## Related Issue

Follow-up fix for #1485 (merged). Found during post-merge dual-model review (Claude + Codex).

## Changes

- Restore early return with `"already running"` / `started=false` when `IsAgentAlive` returns true
- Fix inverted comment ("Agent is dead" → "Agent is alive")

## Testing

- [x] `go build ./...` passes
- [x] `go test ./internal/cmd/` passes

## Checklist
- [x] Code follows project style
- [x] No breaking changes