### PR TITLE
fix(rig): abort remove on kill failures, propagate session check errors

### DIFF
--- a/internal/cmd/rig_test.go
+++ b/internal/cmd/rig_test.go
@@ -86,7 +86,10 @@ func TestFindRigSessions(t *testing.T) {
 		}
 	}()
 
-	got := findRigSessions(tm, "testrig1223")
+	got, err := findRigSessions(tm, "testrig1223")
+	if err != nil {
+		t.Fatalf("findRigSessions: %v", err)
+	}
 
 	// Verify all matching sessions are returned
 	gotSet := make(map[string]bool, len(got))
@@ -117,7 +120,10 @@ func TestFindRigSessions_NoSessions(t *testing.T) {
 	}
 
 	tm := tmux.NewTmux()
-	got := findRigSessions(tm, "nonexistentrig999")
+	got, err := findRigSessions(tm, "nonexistentrig999")
+	if err != nil {
+		t.Fatalf("findRigSessions: %v", err)
+	}
 	if len(got) != 0 {
 		t.Errorf("expected 0 sessions, got %d: %v", len(got), got)
 	}


### PR DESCRIPTION
## Summary

Safety improvements for `gt rig remove --force` to prevent invisible orphaned sessions and silent safety-guard failures.

## Related Issue

Post-merge review findings from PR #1493 (fix(rig): kill tmux sessions on rig remove).

## Changes

- **`findRigSessions` returns error**: Now returns `([]string, error)` instead of silently returning `nil` on `ListSessions` failure. In non-force mode, a tmux error aborts removal instead of proceeding as if no sessions exist.
- **Abort on partial kill failure**: The `--force` path now accumulates kill errors. If any session survives the kill attempt, removal is aborted and the rig stays registered — preventing orphaned sessions that become invisible to `gt rig` commands.
- **Data loss warning**: Updated `--force` flag description to note it may lose uncommitted work (unlike `gt rig shutdown --force` which checks for uncommitted polecat work).

## Testing

- [x] `go build ./internal/cmd/...` compiles cleanly
- [x] `TestFindRigSessions` passes (updated for new error return)
- [x] `TestFindRigSessions_NoSessions` passes
- [x] `TestIsGitRemoteURL` passes (existing tests unaffected)

## Checklist

- [x] Tests updated for changed function signature
- [x] No breaking changes to CLI interface
- [x] Error messages provide actionable guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)