### PR TITLE
fix(convoy): extend lifecycle guards to batch auto-close and synthesis paths

### DIFF
--- a/.beads/formulas/mol-convoy-cleanup.formula.toml
+++ b/.beads/formulas/mol-convoy-cleanup.formula.toml
@@ -113,34 +113,28 @@ bd show <tracked-id>
 
 [[steps]]
 id = "archive-convoy"
-title = "Archive convoy to cold storage"
+title = "Close convoy and prepare for archival"
 needs = ["generate-summary"]
 description = """
-Move convoy from active to archived state.
+Close the convoy to mark it complete. Beads retention handles archival.
 
-**1. Update convoy status:**
+**1. Close convoy:**
 ```bash
-bd update {{convoy}} --status=archived
-# Or close if not already closed
-bd close {{convoy}} --reason="Convoy complete, archived"
+bd close {{convoy}} --reason="Convoy complete"
 ```
 
-**2. Generate archive record:**
-The convoy bead with all metadata is the archive record. Beads retention
-handles moving it to `.beads/archive/` after the retention period.
-
-**3. Verify archive:**
+**2. Verify closure:**
 ```bash
 bd show {{convoy}}
-# Status should reflect archived state
+# Status should be "closed"
 ```
 
-**4. Sync to persist:**
+**3. Sync to persist:**
 ```bash
 bd sync
 ```
 
-**Exit criteria:** Convoy archived, changes synced."""
+**Exit criteria:** Convoy closed, changes synced."""
 
 [[steps]]
 id = "notify-overseer"
@@ -152,7 +146,7 @@ Notify the Mayor (overseer) of convoy completion.
 **1. Send completion mail:**
 ```bash
 gt mail send mayor/ -s "Convoy complete: {{convoy.title}}" -m "$(cat <<EOF
-Convoy {{convoy}} has completed and been archived.
+Convoy {{convoy}} has completed and been closed.
 
 ## Summary
 {{generated_summary}}
@@ -162,7 +156,7 @@ Convoy {{convoy}} has completed and been archived.
 - Issues: {{issue_count}}
 - Contributors: {{contributor_list}}
 
-This convoy has been archived. View details: bd show {{convoy}}
+This convoy has been closed. View details: bd show {{convoy}}
 EOF
 )"
 ```

--- a/internal/formula/formulas/mol-convoy-cleanup.formula.toml
+++ b/internal/formula/formulas/mol-convoy-cleanup.formula.toml
@@ -113,34 +113,28 @@ bd show <tracked-id>
 
 [[steps]]
 id = "archive-convoy"
-title = "Archive convoy to cold storage"
+title = "Close convoy and prepare for archival"
 needs = ["generate-summary"]
 description = """
-Move convoy from active to archived state.
+Close the convoy to mark it complete. Beads retention handles archival.
 
-**1. Update convoy status:**
+**1. Close convoy:**
 ```bash
-bd update {{convoy}} --status=archived
-# Or close if not already closed
-bd close {{convoy}} --reason="Convoy complete, archived"
+bd close {{convoy}} --reason="Convoy complete"
 ```
 
-**2. Generate archive record:**
-The convoy bead with all metadata is the archive record. Beads retention
-handles moving it to `.beads/archive/` after the retention period.
-
-**3. Verify archive:**
+**2. Verify closure:**
 ```bash
 bd show {{convoy}}
-# Status should reflect archived state
+# Status should be "closed"
 ```
 
-**4. Sync to persist:**
+**3. Sync to persist:**
 ```bash
 bd sync
 ```
 
-**Exit criteria:** Convoy archived, changes synced."""
+**Exit criteria:** Convoy closed, changes synced."""
 
 [[steps]]
 id = "notify-overseer"
@@ -152,7 +146,7 @@ Notify the Mayor (overseer) of convoy completion.
 **1. Send completion mail:**
 ```bash
 gt mail send mayor/ -s "Convoy complete: {{convoy.title}}" -m "$(cat <<EOF
-Convoy {{convoy}} has completed and been archived.
+Convoy {{convoy}} has completed and been closed.
 
 ## Summary
 {{generated_summary}}
@@ -162,7 +156,7 @@ Convoy {{convoy}} has completed and been archived.
 - Issues: {{issue_count}}
 - Contributors: {{contributor_list}}
 
-This convoy has been archived. View details: bd show {{convoy}}
+This convoy has been closed. View details: bd show {{convoy}}
 EOF
 )"
 ```


### PR DESCRIPTION
## Summary
Extends the convoy lifecycle transition guards from PR #1462 to two mutation paths that were missed, and resolves a contract mismatch with formula guidance.

## Related Issue
Follow-up to #1462 (convoy: formalize lifecycle transition guards). Closes gaps identified during post-merge review.

## Changes
- **`checkAndCloseCompletedConvoys`**: Added `ensureKnownConvoyStatus` validation inside the convoy iteration loop. Added `Status` field to the JSON decode struct. This is the batch auto-close path used by deacon patrol via `gt convoy check`.
- **`runSynthesisClose`**: Added status read, `ensureKnownConvoyStatus` validation, and idempotent already-closed check before calling `bd close`. Previously bypassed all lifecycle guards entirely.
- **`mol-convoy-cleanup.formula.toml`**: Replaced `--status=archived` references with `bd close` workflow. The `archived` status is not a valid convoy lifecycle state (`open`/`closed` only), so formula guidance directing agents to set it would cause hard failures at the new guards.
- **`validateConvoyStatusTransition`**: Added comment documenting the unreachable final error return (all valid 2-state combinations are exhaustively covered above it).
- **`runConvoyAdd` reopen flow**: Removed redundant `validateConvoyStatusTransition` call inside the `if closed` branch (the transition is algebraically guaranteed valid at that point), replaced with explanatory comment.

## Testing
- `go build ./...` — compiles clean
- `go test ./internal/cmd/ -run 'TestEnsureKnownConvoyStatus|TestValidateConvoyStatusTransition'` — passes
- `go generate ./internal/formula/...` + `git diff --exit-code` — formula source and embedded copies in sync

## Checklist
- [x] Code compiles without errors
- [x] Existing tests pass
- [x] Embedded formulas regenerated and in sync