### PR TITLE
feat(github): add github-sheriff Deacon plugin for CI failure monitoring

### DIFF
--- a/internal/plugin/scanner_test.go
+++ b/internal/plugin/scanner_test.go
@@ -354,6 +354,51 @@ version = 1
 	}
 }
 
+func TestParsePluginMD_GitHubSheriff(t *testing.T) {
+	// Verify the actual github-sheriff plugin.md parses correctly.
+	// This catches frontmatter regressions in the shipped plugin.
+	content, err := os.ReadFile(filepath.Join("..", "..", "plugins", "github-sheriff", "plugin.md"))
+	if err != nil {
+		t.Skipf("github-sheriff plugin not found (expected in plugins/): %v", err)
+	}
+
+	plugin, err := parsePluginMD(content, "/test/github-sheriff", LocationRig, "gastown")
+	if err != nil {
+		t.Fatalf("parsePluginMD failed: %v", err)
+	}
+
+	if plugin.Name != "github-sheriff" {
+		t.Errorf("expected name 'github-sheriff', got %q", plugin.Name)
+	}
+	if plugin.Gate == nil {
+		t.Fatal("expected gate to be non-nil")
+	}
+	if plugin.Gate.Type != GateCooldown {
+		t.Errorf("expected gate type 'cooldown', got %q", plugin.Gate.Type)
+	}
+	if plugin.Gate.Duration != "5m" {
+		t.Errorf("expected gate duration '5m', got %q", plugin.Gate.Duration)
+	}
+	if plugin.Tracking == nil {
+		t.Fatal("expected tracking to be non-nil")
+	}
+	if !plugin.Tracking.Digest {
+		t.Error("expected digest to be true")
+	}
+	if plugin.Execution == nil {
+		t.Fatal("expected execution to be non-nil")
+	}
+	if plugin.Execution.Timeout != "2m" {
+		t.Errorf("expected timeout '2m', got %q", plugin.Execution.Timeout)
+	}
+	if !plugin.Execution.NotifyOnFailure {
+		t.Error("expected notify_on_failure to be true")
+	}
+	if plugin.Instructions == "" {
+		t.Error("expected non-empty instructions")
+	}
+}
+
 func TestScanner_RigOverridesTown(t *testing.T) {
 	// Create temp directory structure
 	tmpDir, err := os.MkdirTemp("", "plugin-test")

--- a/plugins/github-sheriff/plugin.md
+++ b/plugins/github-sheriff/plugin.md
@@ -1,0 +1,164 @@
++++
+name = "github-sheriff"
+description = "Monitor GitHub CI checks on open PRs and create beads for failures"
+version = 1
+
+[gate]
+type = "cooldown"
+duration = "5m"
+
+[tracking]
+labels = ["plugin:github-sheriff", "category:ci-monitoring"]
+digest = true
+
+[execution]
+timeout = "2m"
+notify_on_failure = true
+severity = "low"
++++
+
+# GitHub Sheriff
+
+Polls GitHub for failed CI checks on open pull requests and creates `ci-failure`
+beads for each new failure. Implements the PR Sheriff pattern from the
+[Gas Town User Manual](https://steve-yegge.medium.com/gas-town-emergency-user-manual-cf0e4556d74b)
+as a Deacon plugin.
+
+Requires: `gh` CLI installed and authenticated (`gh auth status`).
+
+## Detection
+
+Verify `gh` is available and authenticated:
+
+```bash
+gh auth status 2>/dev/null
+if [ $? -ne 0 ]; then
+  echo "SKIP: gh CLI not authenticated"
+  exit 0
+fi
+```
+
+Detect the repo from the rig's git remote. Fall back to explicit config if
+detection fails:
+
+```bash
+REPO=$(git -C "$GT_RIG_ROOT" remote get-url origin 2>/dev/null \
+  | sed -E 's|.*github\.com[:/]||; s|\.git$||')
+
+if [ -z "$REPO" ]; then
+  echo "SKIP: could not detect GitHub repo from rig remote"
+  exit 0
+fi
+```
+
+## Action
+
+### Step 1: List open PRs
+
+```bash
+PRS=$(gh pr list --repo "$REPO" --state open \
+  --json number,title,author,headRefName,url --limit 100)
+
+PR_COUNT=$(echo "$PRS" | jq length)
+if [ "$PR_COUNT" -eq 0 ]; then
+  echo "No open PRs found for $REPO"
+  exit 0
+fi
+```
+
+### Step 2: Check each PR for failures
+
+For each open PR, fetch check runs and identify failures:
+
+```bash
+FAILURES=()
+for PR_NUM in $(echo "$PRS" | jq -r '.[].number'); do
+  PR_TITLE=$(echo "$PRS" | jq -r ".[] | select(.number == $PR_NUM) | .title")
+
+  CHECKS=$(gh pr checks "$PR_NUM" --repo "$REPO" \
+    --json name,state,conclusion,link 2>/dev/null || echo "[]")
+
+  for ROW in $(echo "$CHECKS" | jq -c '.[] | select(.conclusion == "failure" or .conclusion == "timed_out" or .conclusion == "cancelled" or .conclusion == "action_required")'); do
+    CHECK_NAME=$(echo "$ROW" | jq -r '.name')
+    CHECK_URL=$(echo "$ROW" | jq -r '.link')
+    CONCLUSION=$(echo "$ROW" | jq -r '.conclusion')
+    FAILURES+=("$PR_NUM|$PR_TITLE|$CHECK_NAME|$CHECK_URL|$CONCLUSION")
+  done
+done
+```
+
+### Step 3: Deduplicate against existing beads
+
+For each failure, check if a bead already exists:
+
+```bash
+EXISTING=$(bd list --label ci-failure --status open --json 2>/dev/null || echo "[]")
+
+CREATED=0
+SKIPPED=0
+
+for F in "${FAILURES[@]}"; do
+  IFS='|' read -r PR_NUM PR_TITLE CHECK_NAME CHECK_URL CONCLUSION <<< "$F"
+  BEAD_TITLE="CI failure: $CHECK_NAME on PR #$PR_NUM"
+
+  # Check for duplicate
+  if echo "$EXISTING" | jq -e ".[] | select(.title == \"$BEAD_TITLE\")" > /dev/null 2>&1; then
+    SKIPPED=$((SKIPPED + 1))
+    continue
+  fi
+
+  # Create bead
+  DESCRIPTION="CI check \`$CHECK_NAME\` failed on PR #$PR_NUM ($PR_TITLE)
+
+PR: https://github.com/$REPO/pull/$PR_NUM
+Check: $CHECK_URL
+Conclusion: $CONCLUSION"
+
+  BEAD_ID=$(bd create "$BEAD_TITLE" -t task -p 2 \
+    --description "$DESCRIPTION" \
+    --label ci-failure \
+    --json 2>/dev/null | jq -r '.id // empty')
+
+  if [ -n "$BEAD_ID" ]; then
+    CREATED=$((CREATED + 1))
+
+    # Log to activity feed
+    gt activity emit github_check_failed \
+      --repo "$REPO" \
+      --pr "$PR_NUM" \
+      --check "$CHECK_NAME" \
+      --conclusion "$CONCLUSION" \
+      --bead "$BEAD_ID" 2>/dev/null || true
+  fi
+done
+```
+
+## Record Result
+
+```bash
+SUMMARY="$REPO: checked $PR_COUNT PRs, ${#FAILURES[@]} failure(s), $CREATED bead(s) created, $SKIPPED already tracked"
+echo "$SUMMARY"
+```
+
+On success:
+```bash
+bd wisp create \
+  --label type:plugin-run \
+  --label plugin:github-sheriff \
+  --label result:success \
+  --body "$SUMMARY"
+```
+
+On failure:
+```bash
+bd wisp create \
+  --label type:plugin-run \
+  --label plugin:github-sheriff \
+  --label result:failure \
+  --body "GitHub sheriff failed: $ERROR"
+
+gt escalate --severity=low \
+  --subject="Plugin FAILED: github-sheriff" \
+  --body="$ERROR" \
+  --source="plugin:github-sheriff"
+```


### PR DESCRIPTION
## Summary

Add `github-sheriff` Deacon plugin that polls GitHub for failed CI checks on open PRs and auto-creates beads. Implements the PR Sheriff pattern (from the [Gas Town User Manual](https://steve-yegge.medium.com/gas-town-emergency-user-manual-cf0e4556d74b)) as a plugin rather than core Go code.

Closes #1516

## Changes

- **`plugins/github-sheriff/plugin.md`**: Deacon plugin with TOML frontmatter and shell-based instructions

### What the plugin does
- Detects GitHub repo from rig's git remote
- Lists open PRs via `gh pr list --json`
- Checks each PR for failed CI via `gh pr checks --json`
- Deduplicates against existing `ci-failure` labeled beads via `bd list`
- Creates beads for new failures via `bd create`
- Logs to activity feed via `gt activity emit`
- Runs on a 5-minute cooldown gate during Deacon patrol

### Design decisions (addressing [architectural feedback](https://github.com/steveyegge/gastown/pull/1518#issuecomment-3906345649))

1. **Plugin, not core command**: CI monitoring is a patrol pattern, not a primitive. The Deacon's existing `plugin-run` step handles scheduling, dispatch, and lifecycle.
2. **Zero new Go code**: All logic uses existing CLI tools (`gh`, `bd`, `gt activity emit`). Dedup is `bd list --label ci-failure | jq` instead of 28 lines of Go.
3. **VCS-agnostic core preserved**: GitHub-specific logic lives in a plugin, not `internal/`. Swapping for GitLab CI means creating a different plugin, not modifying core.
4. **164 lines vs 806**: One markdown file replaces 7 Go files. The plugin follows the established format from `docs/design/plugin-system.md`.

## Test Plan

- [ ] Manual: Place plugin in `$GT_ROOT/plugins/github-sheriff/` or `<rig>/plugins/github-sheriff/`
- [ ] Manual: Verify Deacon's `plugin-run` step discovers and evaluates the gate
- [ ] Manual: Verify `gh pr list` + `gh pr checks` + `bd create` flow against a repo with failing CI
- [ ] Manual: Verify deduplication (run twice, second run should skip existing beads)