### PR TITLE
fix(guard): block Task tool for Mayor to enforce polecat dispatch

### DIFF
--- a/internal/cmd/tap_guard.go
+++ b/internal/cmd/tap_guard.go
@@ -18,7 +18,8 @@ is violated. They're called before the tool runs, preventing the
 forbidden operation entirely.
 
 Available guards:
-  pr-workflow   - Block PR creation and feature branches
+  pr-workflow      - Block PR creation and feature branches
+  task-dispatch    - Block Task tool for Mayor (use gt sling instead)
 
 Example hook configuration:
   {
@@ -51,9 +52,33 @@ witness, etc.). Humans running outside Gas Town can still use PRs.`,
 	RunE: runTapGuardPRWorkflow,
 }
 
+var tapGuardTaskDispatchCmd = &cobra.Command{
+	Use:   "task-dispatch",
+	Short: "Block Task tool for Mayor (use gt sling instead)",
+	Long: `Block the Claude Code Task tool when running as Mayor.
+
+The Mayor should dispatch work via gt sling, not by spawning Claude Code
+subagents. Subagents block the Mayor's context until they finish, breaking
+GUPP (the propulsion principle) and preventing parallel polecat execution.
+
+This guard blocks:
+  - Task tool invocations (Claude Code subagent spawning)
+
+Exit codes:
+  0 - Operation allowed (not Mayor, or --force override)
+  2 - Operation BLOCKED (Mayor context detected)
+
+The guard only blocks when GT_MAYOR is set. Crew members and polecats
+can still use the Task tool for parallel research.
+
+See: https://github.com/steveyegge/gastown/issues/904`,
+	RunE: runTapGuardTaskDispatch,
+}
+
 func init() {
 	tapCmd.AddCommand(tapGuardCmd)
 	tapGuardCmd.AddCommand(tapGuardPRWorkflowCmd)
+	tapGuardCmd.AddCommand(tapGuardTaskDispatchCmd)
 }
 
 func runTapGuardPRWorkflow(cmd *cobra.Command, args []string) error {
@@ -75,6 +100,28 @@ func runTapGuardPRWorkflow(cmd *cobra.Command, args []string) error {
 	fmt.Fprintln(os.Stderr, "║                                                                  ║")
 	fmt.Fprintln(os.Stderr, "║  Why? PRs add friction that breaks autonomous execution.        ║")
 	fmt.Fprintln(os.Stderr, "║  See: ~/gt/docs/PRIMING.md (GUPP principle)                     ║")
+	fmt.Fprintln(os.Stderr, "╚══════════════════════════════════════════════════════════════════╝")
+	fmt.Fprintln(os.Stderr, "")
+	return NewSilentExit(2) // Exit 2 = BLOCK in Claude Code hooks
+}
+
+func runTapGuardTaskDispatch(cmd *cobra.Command, args []string) error {
+	// Only block when running as Mayor
+	if os.Getenv("GT_MAYOR") == "" {
+		return nil
+	}
+
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintln(os.Stderr, "╔══════════════════════════════════════════════════════════════════╗")
+	fmt.Fprintln(os.Stderr, "║  ❌ TASK TOOL BLOCKED — Mayor cannot spawn subagents             ║")
+	fmt.Fprintln(os.Stderr, "╠══════════════════════════════════════════════════════════════════╣")
+	fmt.Fprintln(os.Stderr, "║  Subagents block your context and prevent parallel execution.    ║")
+	fmt.Fprintln(os.Stderr, "║                                                                  ║")
+	fmt.Fprintln(os.Stderr, "║  Instead of:  Task tool (spawning a subagent)                   ║")
+	fmt.Fprintln(os.Stderr, "║  Do this:     bd create \"...\" && gt sling <bead-id> <rig>       ║")
+	fmt.Fprintln(os.Stderr, "║                                                                  ║")
+	fmt.Fprintln(os.Stderr, "║  Why? Polecats execute in parallel without blocking the Mayor.  ║")
+	fmt.Fprintln(os.Stderr, "║  See: https://github.com/steveyegge/gastown/issues/904          ║")
 	fmt.Fprintln(os.Stderr, "╚══════════════════════════════════════════════════════════════════╝")
 	fmt.Fprintln(os.Stderr, "")
 	return NewSilentExit(2) // Exit 2 = BLOCK in Claude Code hooks

--- a/internal/cmd/tap_guard_test.go
+++ b/internal/cmd/tap_guard_test.go
@@ -1,0 +1,53 @@
+package cmd
+
+import (
+	"os"
+	"testing"
+)
+
+func TestTapGuardTaskDispatch_BlocksWhenMayor(t *testing.T) {
+	t.Setenv("GT_MAYOR", "true")
+
+	err := runTapGuardTaskDispatch(nil, nil)
+	if err == nil {
+		t.Fatal("expected error (exit 2) when GT_MAYOR is set")
+	}
+
+	se, ok := err.(*SilentExitError)
+	if !ok {
+		t.Fatalf("expected SilentExitError, got %T: %v", err, err)
+	}
+	if se.Code != 2 {
+		t.Errorf("expected exit code 2, got %d", se.Code)
+	}
+}
+
+func TestTapGuardTaskDispatch_AllowsWhenNotMayor(t *testing.T) {
+	// Ensure GT_MAYOR is not set
+	os.Unsetenv("GT_MAYOR")
+
+	err := runTapGuardTaskDispatch(nil, nil)
+	if err != nil {
+		t.Errorf("expected nil error when GT_MAYOR is not set, got %v", err)
+	}
+}
+
+func TestTapGuardTaskDispatch_AllowsForCrew(t *testing.T) {
+	t.Setenv("GT_CREW", "rhett")
+	os.Unsetenv("GT_MAYOR")
+
+	err := runTapGuardTaskDispatch(nil, nil)
+	if err != nil {
+		t.Errorf("expected nil error for crew member, got %v", err)
+	}
+}
+
+func TestTapGuardTaskDispatch_AllowsForPolecat(t *testing.T) {
+	t.Setenv("GT_POLECAT", "alpha")
+	os.Unsetenv("GT_MAYOR")
+
+	err := runTapGuardTaskDispatch(nil, nil)
+	if err != nil {
+		t.Errorf("expected nil error for polecat, got %v", err)
+	}
+}

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -424,14 +424,26 @@ func TestComputeExpectedNoBase(t *testing.T) {
 	tmpDir := t.TempDir()
 	setTestHome(t, tmpDir)
 
+	// Mayor target: DefaultBase + built-in mayor override (task-dispatch guard)
 	expected, err := ComputeExpected("mayor")
 	if err != nil {
 		t.Fatalf("ComputeExpected failed: %v", err)
 	}
 
 	defaultBase := DefaultBase()
-	if !HooksEqual(expected, defaultBase) {
-		t.Error("expected DefaultBase when no configs exist")
+	mayorDefaults := DefaultOverrides()["mayor"]
+	merged := Merge(defaultBase, mayorDefaults)
+	if !HooksEqual(expected, merged) {
+		t.Error("expected DefaultBase + mayor default override when no configs exist")
+	}
+
+	// Non-mayor target with no built-in override: should equal DefaultBase
+	crew, err := ComputeExpected("crew")
+	if err != nil {
+		t.Fatalf("ComputeExpected(crew) failed: %v", err)
+	}
+	if !HooksEqual(crew, defaultBase) {
+		t.Error("expected DefaultBase for crew when no configs exist")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Adds `gt tap guard task-dispatch` PreToolUse guard that blocks the Claude Code Task tool when `GT_MAYOR` is set, directing the Mayor to use `bd create` + `gt sling` instead
- Wires the guard into `DefaultOverrides()` so `gt hooks sync` auto-deploys it to mayor sessions — no manual configuration needed
- Prevents Mayor from spawning subagents that block its context and break parallel polecat execution (GUPP violation)

Fixes #904

## How it works

The guard leverages the existing `gt tap guard` infrastructure (same pattern as `pr-workflow`):

1. **Guard command** (`gt tap guard task-dispatch`): Checks `GT_MAYOR` env var. If set, exits code 2 (BLOCK). Otherwise returns 0 (ALLOW).
2. **Built-in hook override** (`DefaultOverrides()`): Registers a PreToolUse hook matching `"Task"` that runs the guard. Applied automatically when no on-disk mayor override exists.
3. **Auto-deployment**: `gt hooks sync` picks up the default override and writes it to the mayor's `.claude/settings.json`.

## Test plan

- [x] `TestTapGuardTaskDispatch_BlocksWhenMayor` — GT_MAYOR set → SilentExitError code 2
- [x] `TestTapGuardTaskDispatch_AllowsWhenNotMayor` — no env → nil (allowed)
- [x] `TestTapGuardTaskDispatch_AllowsForCrew` — GT_CREW set, no GT_MAYOR → nil
- [x] `TestTapGuardTaskDispatch_AllowsForPolecat` — GT_POLECAT set, no GT_MAYOR → nil
- [x] `TestComputeExpectedNoBase` — mayor gets DefaultBase + mayor override; crew gets DefaultBase only
- [x] `go test ./internal/cmd/... ./internal/hooks/...` — all pass
- [x] `golangci-lint run ./internal/cmd/... ./internal/hooks/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)