### PR TITLE
fix(nudge): use unique claim suffix to prevent Windows race in concurrent Drain

### DIFF
--- a/internal/nudge/queue_test.go
+++ b/internal/nudge/queue_test.go
@@ -385,7 +385,8 @@ func TestDrainSweepsOrphanedClaims(t *testing.T) {
 	}
 
 	// Create an orphaned .claimed file with old mod time
-	orphanPath := filepath.Join(dir, "100.json.claimed")
+	// Claim files now use the format: <original>.json.claimed.<suffix>
+	orphanPath := filepath.Join(dir, "100.json.claimed.deadbeef")
 	if err := os.WriteFile(orphanPath, []byte(`{"sender":"ghost"}`), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -396,7 +397,7 @@ func TestDrainSweepsOrphanedClaims(t *testing.T) {
 	}
 
 	// Create a fresh .claimed file (should NOT be swept)
-	freshClaimPath := filepath.Join(dir, "200.json.claimed")
+	freshClaimPath := filepath.Join(dir, "200.json.claimed.cafebabe")
 	if err := os.WriteFile(freshClaimPath, []byte(`{"sender":"active"}`), 0644); err != nil {
 		t.Fatal(err)
 	}
@@ -426,7 +427,8 @@ func TestDrainSweepsOrphanedClaims(t *testing.T) {
 	if _, err := os.Stat(orphanPath); !os.IsNotExist(err) {
 		t.Error("orphaned .claimed file should no longer exist (requeued to .json)")
 	}
-	restoredPath := strings.TrimSuffix(orphanPath, ".claimed")
+	// Restored path strips everything from ".claimed" onward
+	restoredPath := filepath.Join(dir, "100.json")
 	if _, err := os.Stat(restoredPath); os.IsNotExist(err) {
 		t.Error("restored .json file should exist after requeue")
 	}


### PR DESCRIPTION
## Summary

Fix Windows CI failure in `TestConcurrentDrainNoDoubleDeli` caused by non-atomic `os.Rename` behavior on Windows during concurrent queue draining.

**CI failure:** https://github.com/steveyegge/gastown/actions/runs/22047416384/job/63698708716

## Related Issue

Fixes Windows build break on main — `TestConcurrentDrainNoDoubleDeli` delivers 5/10 nudges (nudge loss).

## Changes

- Use unique random suffix per claim (`.claimed.<suffix>` instead of shared `.claimed` destination) to prevent two concurrent drainers from both "succeeding" at renaming the same source file via `MOVEFILE_REPLACE_EXISTING` on Windows
- Treat post-rename read failures as lost races (file-not-found = another drainer won) instead of logging noisy warnings
- Update orphan sweep to detect new claim format using `strings.Contains` + `strings.Index` instead of `strings.HasSuffix` + `strings.TrimSuffix`
- Update `TestDrainSweepsOrphanedClaims` to use the new `.claimed.<suffix>` format

## Testing

- [x] Unit tests pass (`go test ./internal/nudge/ -v`)
- [x] `TestConcurrentDrainNoDoubleDeli` passes (the previously failing test)
- [x] `TestDrainSweepsOrphanedClaims` passes (orphan requeue still works)
- [x] Full build succeeds (`go build ./...`)

## Checklist

- [x] Code follows project style
- [x] No breaking changes — backward compatible (existing `.claimed` files without suffix are still detected by `strings.Contains`)