### PR TITLE
fix(doctor): add dolt binary check and list dolt as prerequisite

### DIFF
--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -10,6 +10,7 @@ Complete setup guide for Gas Town multi-agent orchestrator.
 |------|---------|-------|---------|
 | **Go** | 1.24+ | `go version` | See [golang.org](https://go.dev/doc/install) |
 | **Git** | 2.20+ | `git --version` | See below |
+| **Dolt** | latest | `dolt version` | See [dolthub/dolt](https://github.com/dolthub/dolt?tab=readme-ov-file#installation) |
 | **Beads** | latest | `bd version` | `go install github.com/steveyegge/beads/cmd/bd@latest` |
 
 ### Optional (for Full Stack Mode)
@@ -31,6 +32,7 @@ Complete setup guide for Gas Town multi-agent orchestrator.
 
 # Required
 brew install go git
+# Install Dolt: see https://github.com/dolthub/dolt?tab=readme-ov-file#installation
 
 # Optional (for full stack mode)
 brew install tmux
@@ -49,6 +51,8 @@ sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.24.12.linux-amd64.t
 echo 'export PATH=$PATH:/usr/local/go/bin:$HOME/go/bin' >> ~/.bashrc
 source ~/.bashrc
 
+# Install Dolt: see https://github.com/dolthub/dolt?tab=readme-ov-file#installation
+
 # Optional (for full stack mode)
 sudo apt install -y tmux
 ```
@@ -58,6 +62,7 @@ sudo apt install -y tmux
 ```bash
 # Required
 sudo dnf install -y git golang
+# Install Dolt: see https://github.com/dolthub/dolt?tab=readme-ov-file#installation
 
 # Optional
 sudo dnf install -y tmux
@@ -69,6 +74,7 @@ sudo dnf install -y tmux
 # Check all prerequisites
 go version        # Should show go1.24 or higher
 git --version     # Should show 2.20 or higher
+dolt version      # Should show dolt version string
 tmux -V           # (Optional) Should show 3.0 or higher
 ```
 

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -84,6 +84,12 @@ Session hook checks:
   - claude-settings          Check Claude settings.json match templates (fixable)
   - deprecated-merge-queue-keys  Detect stale deprecated keys in merge_queue config (fixable)
 
+Dolt checks:
+  - dolt-binary              Check that dolt is installed and in PATH
+  - dolt-metadata            Check dolt metadata tables exist
+  - dolt-server-reachable    Check dolt sql-server is reachable
+  - dolt-orphaned-databases  Detect orphaned dolt databases
+
 Patrol checks:
   - patrol-molecules-exist   Verify patrol molecules exist
   - patrol-hooks-wired       Verify daemon triggers patrols
@@ -215,6 +221,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewHooksSyncCheck())
 
 	// Dolt health checks
+	d.Register(doctor.NewDoltBinaryCheck())
 	d.Register(doctor.NewDoltMetadataCheck())
 	d.Register(doctor.NewDoltServerReachableCheck())
 	d.Register(doctor.NewDoltOrphanedDatabaseCheck())

--- a/internal/doctor/dolt_binary_check.go
+++ b/internal/doctor/dolt_binary_check.go
@@ -1,0 +1,64 @@
+package doctor
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// DoltBinaryCheck verifies that the dolt binary is installed and accessible in PATH.
+// Dolt is required for the beads storage backend (dolt sql-server).
+type DoltBinaryCheck struct {
+	BaseCheck
+}
+
+// NewDoltBinaryCheck creates a new dolt binary availability check.
+func NewDoltBinaryCheck() *DoltBinaryCheck {
+	return &DoltBinaryCheck{
+		BaseCheck: BaseCheck{
+			CheckName:        "dolt-binary",
+			CheckDescription: "Check that dolt is installed and in PATH",
+			CheckCategory:    CategoryInfrastructure,
+		},
+	}
+}
+
+// Run checks if dolt is available in PATH and reports its version.
+func (c *DoltBinaryCheck) Run(ctx *CheckContext) *CheckResult {
+	doltPath, err := exec.LookPath("dolt")
+	if err != nil {
+		return &CheckResult{
+			Name:   c.Name(),
+			Status: StatusError,
+			Message: "dolt not found in PATH",
+			Details: []string{
+				"Dolt is required for the beads storage backend",
+				"Install from: https://github.com/dolthub/dolt#installation",
+			},
+			FixHint: "Install dolt: https://github.com/dolthub/dolt#installation",
+		}
+	}
+
+	// Get version for the OK message
+	cmd := exec.Command(doltPath, "version")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return &CheckResult{
+			Name:   c.Name(),
+			Status: StatusError,
+			Message: fmt.Sprintf("dolt found at %s but 'dolt version' failed: %v", doltPath, err),
+			Details: []string{
+				strings.TrimSpace(string(output)),
+			},
+			FixHint: "Reinstall dolt: https://github.com/dolthub/dolt#installation",
+		}
+	}
+
+	ver := strings.TrimSpace(string(output))
+	// dolt version outputs "dolt version X.Y.Z"
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusOK,
+		Message: ver,
+	}
+}

--- a/internal/doctor/dolt_binary_check_test.go
+++ b/internal/doctor/dolt_binary_check_test.go
@@ -1,0 +1,118 @@
+package doctor
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDoltBinaryCheck_Metadata(t *testing.T) {
+	check := NewDoltBinaryCheck()
+
+	if check.Name() != "dolt-binary" {
+		t.Errorf("Name() = %q, want %q", check.Name(), "dolt-binary")
+	}
+	if check.Description() != "Check that dolt is installed and in PATH" {
+		t.Errorf("Description() = %q", check.Description())
+	}
+	if check.Category() != CategoryInfrastructure {
+		t.Errorf("Category() = %q, want %q", check.Category(), CategoryInfrastructure)
+	}
+	if check.CanFix() {
+		t.Error("CanFix() should return false (user must install dolt manually)")
+	}
+}
+
+func TestDoltBinaryCheck_DoltInstalled(t *testing.T) {
+	// Skip if dolt is not actually installed in the test environment
+	if _, err := exec.LookPath("dolt"); err != nil {
+		t.Skip("dolt not installed, skipping installed-path test")
+	}
+
+	check := NewDoltBinaryCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+
+	result := check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when dolt is installed, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "dolt version") {
+		t.Errorf("expected version string in message, got %q", result.Message)
+	}
+}
+
+func TestDoltBinaryCheck_HermeticSuccess(t *testing.T) {
+	// Create a fake "dolt" binary that prints a version string
+	fakeDir := t.TempDir()
+	fakeDolt := filepath.Join(fakeDir, "dolt")
+	if err := os.WriteFile(fakeDolt, []byte("#!/bin/sh\necho 'dolt version 1.0.0'\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", fakeDir)
+
+	check := NewDoltBinaryCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+
+	result := check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK with fake dolt, got %v: %s", result.Status, result.Message)
+	}
+	if result.Message != "dolt version 1.0.0" {
+		t.Errorf("expected 'dolt version 1.0.0', got %q", result.Message)
+	}
+}
+
+func TestDoltBinaryCheck_DoltNotInPath(t *testing.T) {
+	// Create an empty directory and set PATH to only that directory,
+	// ensuring dolt (and nothing else) is findable.
+	emptyDir := t.TempDir()
+	t.Setenv("PATH", emptyDir)
+
+	check := NewDoltBinaryCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+
+	result := check.Run(ctx)
+	if result.Status != StatusError {
+		t.Errorf("expected StatusError when dolt is not in PATH, got %v: %s", result.Status, result.Message)
+	}
+	if result.Message != "dolt not found in PATH" {
+		t.Errorf("unexpected message: %q", result.Message)
+	}
+	if len(result.Details) != 2 {
+		t.Errorf("expected 2 detail lines, got %d", len(result.Details))
+	}
+	if result.FixHint == "" {
+		t.Error("expected a fix hint with install instructions")
+	}
+	if !strings.Contains(result.FixHint, "dolthub/dolt") {
+		t.Errorf("fix hint should reference dolthub/dolt, got %q", result.FixHint)
+	}
+}
+
+func TestDoltBinaryCheck_DoltVersionFails(t *testing.T) {
+	// Create a fake "dolt" binary that exits with an error
+	fakeDir := t.TempDir()
+	fakeDolt := filepath.Join(fakeDir, "dolt")
+	if err := os.WriteFile(fakeDolt, []byte("#!/bin/sh\nexit 1\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	t.Setenv("PATH", fakeDir)
+
+	check := NewDoltBinaryCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+
+	result := check.Run(ctx)
+	if result.Status != StatusError {
+		t.Errorf("expected StatusError when dolt version fails, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "dolt version") {
+		t.Errorf("expected message to mention 'dolt version', got %q", result.Message)
+	}
+	if result.FixHint == "" {
+		t.Error("expected a fix hint for broken dolt")
+	}
+}


### PR DESCRIPTION
## Summary

Dolt is required for the beads storage backend but was missing from both the installation docs and `gt doctor` checks. Users following `INSTALLING.md` would never install dolt, then hit a runtime error when the daemon tried to start the dolt server.

- Add `DoltBinaryCheck` to `gt doctor` (errors if dolt not in PATH or `dolt version` fails)
- Add Dolt to the Required prerequisites table in `INSTALLING.md`
- Add install instructions for macOS, Debian/Ubuntu, and Fedora/RHEL (pointing to upstream GitHub docs rather than raw `curl|bash`)
- Add "Dolt checks" section to `gt doctor --help` listing all four dolt checks

## Test plan

- [x] All 5 `TestDoltBinaryCheck_*` tests pass (`go test ./internal/doctor/ -run TestDoltBinaryCheck -v`)
- [x] Full doctor test suite passes (`go test ./internal/doctor/`)
- [ ] Run `gt doctor` on a workspace with dolt installed — verify `dolt-binary` shows OK with version
- [ ] Run `gt doctor` on a workspace without dolt — verify `dolt-binary` shows error with install link
- [ ] Verify `gt doctor --help` shows the new "Dolt checks" section

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>