### PR TITLE
Fix spurious 'go build' warning for Homebrew installs

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -83,7 +83,9 @@ func persistentPreRun(cmd *cobra.Command, args []string) error {
 	// Check if binary was built properly (via make build, not raw go build).
 	// Raw go build produces unsigned binaries that macOS may kill.
 	// Warning only - doesn't block execution.
-	if BuiltProperly == "" {
+	// Skip warning when Build was set by a package manager (e.g. Homebrew sets
+	// Build to "Homebrew" via ldflags but doesn't set BuiltProperly).
+	if BuiltProperly == "" && Build == "dev" {
 		fmt.Fprintln(os.Stderr, "WARNING: This binary was built with 'go build' directly.")
 		fmt.Fprintln(os.Stderr, "         Use 'make build' to create a properly signed binary.")
 		if gtRoot := os.Getenv("GT_ROOT"); gtRoot != "" {


### PR DESCRIPTION
## Summary

- Fixes the `BuiltProperly` check to also consider the `Build` ldflag, so package manager installs (e.g. Homebrew) don't trigger the unsigned-binary warning

## Problem

Every `gt` command prints this warning when installed via `brew install gastown`:

```
WARNING: This binary was built with 'go build' directly.
         Use 'make build' to create a properly signed binary.
```

The Homebrew formula sets `Build` to `"Homebrew"` via ldflags but doesn't set `BuiltProperly`. The check at `internal/cmd/root.go:86` only tested `BuiltProperly == ""`, so it fired for every Homebrew user.

## Fix

Changed the condition from:

```go
if BuiltProperly == "" {
```

to:

```go
if BuiltProperly == "" && Build == "dev" {
```

The `Build` variable defaults to `"dev"`. A plain `go build` leaves it at `"dev"`, but any proper build system (Makefile, Homebrew, goreleaser) overrides it via ldflags. This makes the warning fire only when the binary was genuinely built with a raw `go build`.

## Test plan

- [x] `go build ./cmd/gt` compiles without errors
- [x] `go test ./internal/cmd/` passes
- [x] `make build` produces no warning — outputs `gt version v0.6.0-116-g62261111 (dev: ...)` with no stderr
- [x] Raw `go build ./cmd/gt` still shows the warning — `WARNING: This binary was built with 'go build' directly.`
- [x] Homebrew-equivalent ldflags (`-X ...Build=Homebrew`) produce no warning — outputs `gt version 0.6.0 (Homebrew: v0.6.0@Homebrew)` with no stderr

Fixes #1531

🤖 Generated with [Claude Code](https://claude.com/claude-code)