### PR TITLE
fix(dashboard): close expanded panels with Escape key

### DIFF
--- a/internal/web/static/dashboard.js
+++ b/internal/web/static/dashboard.js
@@ -761,6 +761,19 @@
             return;
         }
 
+        // Escape closes expanded panels when palette is not open
+        if (!isPaletteOpen && e.key === 'Escape') {
+            var expanded = document.querySelector('.panel.expanded');
+            if (expanded) {
+                e.preventDefault();
+                expanded.classList.remove('expanded');
+                var expandBtn = expanded.querySelector('.expand-btn');
+                if (expandBtn) expandBtn.textContent = 'Expand';
+                window.pauseRefresh = false;
+                return;
+            }
+        }
+
         // Rest only when palette is open
         if (!isPaletteOpen) return;
 


### PR DESCRIPTION
## Summary

- Add Escape key handler to close expanded dashboard panels, returning to the normal grid layout
- Handler is gated behind `!isPaletteOpen` so Escape still closes the command palette when it's open
- Resets expand button text and resumes auto-refresh on close

Fixes #1536

## Test plan

- [ ] Run `gt dashboard`, expand a tile, press Escape — panel collapses back to grid
- [ ] Expand a tile, open command palette (Cmd+K), press Escape — palette closes, panel stays expanded
- [ ] Press Escape again — panel collapses
- [ ] Press Escape with no panel expanded and no palette open — nothing happens

🤖 Generated with [Claude Code](https://claude.com/claude-code)