### PR TITLE
fix: add description to dog agent beads for mail routing

### DIFF
--- a/internal/beads/beads_dog.go
+++ b/internal/beads/beads_dog.go
@@ -20,12 +20,15 @@ func (b *Beads) CreateDogAgentBead(name, location string) (*Issue, error) {
 		"location:" + location,
 	}
 
+	description := formatDogDescription(name, location)
+
 	args := []string{
 		"create", "--json",
 		"--id=" + beadID,
 		"--type=agent",
 		"--role-type=dog",
 		"--title=" + title,
+		"--description=" + description,
 		"--labels=" + strings.Join(labels, ","),
 	}
 
@@ -96,5 +99,18 @@ func (b *Beads) ResetDogAgentBead(name string) error {
 		return fmt.Errorf("resetting bead %s: %w", issue.ID, err)
 	}
 	return nil
+}
+
+// formatDogDescription creates a description for a dog agent bead.
+// Includes role_type, rig, and location metadata so the mail router
+// can resolve the agent address from the description.
+func formatDogDescription(name, location string) string {
+	return strings.Join([]string{
+		fmt.Sprintf("Dog: %s", name),
+		"",
+		"role_type: dog",
+		"rig: town",
+		fmt.Sprintf("location: %s", location),
+	}, "\n")
 }
 


### PR DESCRIPTION
## Summary

- `CreateDogAgentBead()` was creating beads without a description field, causing `gt dog dispatch --plugin` to fail with "invalid recipient deacon/dogs/alpha: no agent found"
- Added `location:` field to dog bead descriptions so the mail router can resolve dog addresses
- Added `location:` field parsing in `parseAgentAddressFromDescription()`, taking priority over `role_type`+`rig` derivation

## Test plan

- [x] Existing `TestAgentBeadToAddress` tests pass (no regressions)
- [x] New tests for hq-dog beads with location in description
- [x] New `TestParseAgentAddressFromDescription` unit tests including location field
- [x] `go vet` clean on both packages
- [ ] Manual: `gt dog dispatch --plugin sheriff` succeeds after binary rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)