### PR TITLE
fix(config): update mayor.toml work_dir to match actual session directory

### DIFF
--- a/internal/config/roles/mayor.toml
+++ b/internal/config/roles/mayor.toml
@@ -8,7 +8,7 @@ prompt_template = "mayor.md.tmpl"
 
 [session]
 pattern = "hq-mayor"
-work_dir = "{town}"
+work_dir = "{town}/mayor"
 needs_pre_sync = false
 start_command = "exec claude --dangerously-skip-permissions"
 


### PR DESCRIPTION
## Summary

The `mayor.toml` role definition declared `work_dir = "{town}"` but the Mayor manager (`manager.go`) starts sessions from `{town}/mayor`. This updates the TOML to reflect the actual session directory.

## Related Issue

Closes #1142

## Changes

- Update `internal/config/roles/mayor.toml` `work_dir` from `"{town}"` to `"{town}/mayor"` to match `manager.go:mayorDir()`

## Context

Investigation of #1142 found:

1. The bug report's claimed impact (Mayor can't find rig beads) is **not reproducible** — `gt ready` uses explicit path construction via `beads.New(r.BeadsPath())` for each rig, not cwd-based discovery. Cross-rig coordination uses the mail/routing system operating on town-level beads regardless of Mayor cwd.

2. The real issue is a **config-vs-code inconsistency**: `mayor.toml` says `{town}`, but `manager.go:mayorDir()` returns `{town}/mayor`. The TOML isn't consumed by the Mayor's startup path (`mayor.Manager.Start()` hardcodes `mayorDir`), but it should be accurate.

3. The daemon's `getWorkDir()` in `lifecycle.go` does read the TOML via `LoadRoleDefinition()`, but the Mayor is never started through the daemon code path — it uses `mayor.Manager.Start()` directly from `gt mayor start`, `gt start`, and `gt up`.

## Testing

- [x] Code follows project style
- [x] No breaking changes — the TOML field is not consumed by the Mayor's startup path
- [x] Config value now matches actual runtime behavior