### PR TITLE
fix(test): use t.Setenv in tap guard test, add MergeHooks doc comment

### DIFF
--- a/internal/cmd/tap_guard_test.go
+++ b/internal/cmd/tap_guard_test.go
@@ -1,7 +1,6 @@
 package cmd
 
 import (
-	"os"
 	"testing"
 )
 
@@ -23,7 +22,7 @@ func TestTapGuardTaskDispatch_BlocksWhenMayor(t *testing.T) {
 }
 
 func TestTapGuardTaskDispatch_AllowsWhenNotMayor(t *testing.T) {
-	os.Unsetenv("GT_ROLE")
+	t.Setenv("GT_ROLE", "")
 
 	err := runTapGuardTaskDispatch(nil, nil)
 	if err != nil {

--- a/internal/hooks/merge.go
+++ b/internal/hooks/merge.go
@@ -9,6 +9,8 @@ import (
 )
 
 // MergeHooks merges a base config with applicable overrides for a target.
+// It does NOT incorporate built-in defaults from DefaultOverrides(); callers
+// that need the full production merge should use ComputeExpected() instead.
 //
 // Merge rules:
 //  1. Start with base hooks


### PR DESCRIPTION
## Summary

Addresses review feedback from #1529 (comment https://github.com/steveyegge/gastown/pull/1529#issuecomment-3906549080):

- Replace `os.Unsetenv("GT_ROLE")` with `t.Setenv("GT_ROLE", "")` in `TestTapGuardTaskDispatch_AllowsWhenNotMayor` to avoid mutating process-global state without cleanup (prevents flaky tests if CI has `GT_ROLE` set or `t.Parallel()` is added later)
- Add doc comment to `MergeHooks()` noting it excludes built-in defaults from `DefaultOverrides()` and pointing callers to `ComputeExpected()` for the full production merge path

## Test plan

- [x] `go test ./internal/cmd/... ./internal/hooks/...` — all pass
- [x] `golangci-lint run ./internal/cmd/... ./internal/hooks/...` — 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)