### PR TITLE
fix(doltserver): create rig-root .beads instead of mayor path for new rigs

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1352,7 +1352,8 @@ func RepairWorkspace(townRoot string, ws BrokenWorkspace) (string, error) {
 // centralized Dolt server.
 //
 // For the "hq" rig, it writes to <townRoot>/.beads/metadata.json.
-// For other rigs, it writes to <townRoot>/<rigName>/mayor/rig/.beads/metadata.json.
+// For other rigs, it writes to mayor/rig/.beads/metadata.json if that path exists,
+// otherwise to <townRoot>/<rigName>/.beads/metadata.json.
 func EnsureMetadata(townRoot, rigName string) error {
 	// Use FindOrCreateRigBeadsDir to atomically resolve and create the directory,
 	// avoiding the TOCTOU race where the directory state changes between
@@ -1453,8 +1454,8 @@ func FindRigBeadsDir(townRoot, rigName string) string {
 		return rigBeads
 	}
 
-	// Neither exists; return mayor path (caller will create it)
-	return mayorBeads
+	// Neither exists; return rig-root path (consistent with FindOrCreateRigBeadsDir)
+	return rigBeads
 }
 
 // FindOrCreateRigBeadsDir atomically resolves and ensures the .beads directory

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -503,11 +503,11 @@ func TestFindRigBeadsDir(t *testing.T) {
 		t.Errorf("otherrig beads dir = %q, want %q", dir, rigBeads)
 	}
 
-	// Test rig with neither directory existing — should return mayor path for creation
+	// Test rig with neither directory existing — should return rig-root path
 	neitherRig := "newrig"
-	expectedMayor := filepath.Join(townRoot, neitherRig, "mayor", "rig", ".beads")
-	if dir := FindRigBeadsDir(townRoot, neitherRig); dir != expectedMayor {
-		t.Errorf("newrig (neither exists) beads dir = %q, want %q (mayor path for creation)", dir, expectedMayor)
+	expectedRigRoot := filepath.Join(townRoot, neitherRig, ".beads")
+	if dir := FindRigBeadsDir(townRoot, neitherRig); dir != expectedRigRoot {
+		t.Errorf("newrig (neither exists) beads dir = %q, want %q (rig-root path)", dir, expectedRigRoot)
 	}
 }
 


### PR DESCRIPTION
## Summary

When adding a new rig for an untracked repo while the dolt server is running, `FindOrCreateRigBeadsDir` created `mayor/rig/.beads/` instead of the rig-root `.beads/`. This caused `InitBeads` to misdetect the repo as having tracked beads, take the redirect early-return, and skip creating `config.yaml` and `issues.jsonl`. The result: a degraded rig where all `bd` commands fail until `gt doctor --fix` repairs it.

## Changes

- **`FindOrCreateRigBeadsDir`**: Changed fallback (when neither beads path exists) to create rig-root `.beads/` instead of `mayor/rig/.beads/`. The mayor path should only be used when it already exists (i.e., the source repo has tracked beads checked out via git clone).
- **`FindRigBeadsDir`**: Aligned read-only fallback to also return rig-root path, for consistency.
- **`EnsureMetadata` docstring**: Updated to reflect actual resolution order (mayor if present, else rig-root).
- **Tests**: Updated existing tests to expect rig-root path; added regression test verifying mayor path is NOT created for untracked repos.

### Why this happens

`AddRig` calls `InitRig` before `InitBeads`. Inside `InitRig`, when the dolt server `IsRunning()`, `EnsureMetadata` calls `FindOrCreateRigBeadsDir` — which was eagerly creating `mayor/rig/.beads/`. Then when `InitBeads` runs, it sees that directory, assumes the repo has tracked beads, and takes the redirect path instead of initializing the local beads database.

The mayor/rig/.beads path is only correct when the source repo actually has tracked beads (checked out via git clone). For new rigs with untracked repos, the rig-root `.beads/` is the right location.

## Testing

- [x] Unit tests pass (`go test ./internal/doltserver/ -v`)
- [x] All 8 `TestFindOrCreateRigBeadsDir` subtests pass including new regression test
- [x] `TestFindRigBeadsDir` passes with updated assertion
- [x] All rig, doctor, and cmd tests pass
- [x] Dual-model review (Claude + Codex) passed with `approve` decision

## Checklist

- [x] Code follows project style
- [x] Documentation updated (docstring corrections)
- [x] No breaking changes