### PR TITLE
fix(rig): --force prompts instead of blocking on uncommitted work

### DIFF
--- a/internal/cmd/rig_uncommitted_work_test.go
+++ b/internal/cmd/rig_uncommitted_work_test.go
@@ -1,0 +1,200 @@
+package cmd
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/polecat"
+	"github.com/steveyegge/gastown/internal/rig"
+)
+
+func stubUncommittedWorkCheckDeps(
+	t *testing.T,
+	listFn func(*rig.Rig) ([]*polecat.Polecat, error),
+	checkFn func(string) (*git.UncommittedWorkStatus, error),
+	isTTYFn func() bool,
+	promptFn func(string) bool,
+) {
+	t.Helper()
+
+	oldList := listPolecatsForWorkCheck
+	oldCheck := checkPolecatWorkStatus
+	oldIsTTY := isStdinTerminal
+	oldPrompt := promptYesNoUnsafeProceed
+
+	listPolecatsForWorkCheck = listFn
+	checkPolecatWorkStatus = checkFn
+	isStdinTerminal = isTTYFn
+	promptYesNoUnsafeProceed = promptFn
+
+	t.Cleanup(func() {
+		listPolecatsForWorkCheck = oldList
+		checkPolecatWorkStatus = oldCheck
+		isStdinTerminal = oldIsTTY
+		promptYesNoUnsafeProceed = oldPrompt
+	})
+}
+
+func testRig() *rig.Rig {
+	return &rig.Rig{
+		Name: "testrig",
+		Path: "/tmp/testrig",
+	}
+}
+
+func TestCheckUncommittedWork_ListErrorBlocksWithoutForce(t *testing.T) {
+	stubUncommittedWorkCheckDeps(
+		t,
+		func(*rig.Rig) ([]*polecat.Polecat, error) {
+			return nil, errors.New("list failed")
+		},
+		func(string) (*git.UncommittedWorkStatus, error) {
+			t.Fatalf("check should not be called when list fails")
+			return nil, nil
+		},
+		func() bool { return false },
+		func(string) bool {
+			t.Fatalf("prompt should not be called without --force")
+			return false
+		},
+	)
+
+	var proceed bool
+	output := captureStdout(t, func() {
+		proceed = checkUncommittedWork(testRig(), "testrig", "stop", false)
+	})
+
+	if proceed {
+		t.Fatal("expected proceed=false when polecat listing fails without --force")
+	}
+	if !strings.Contains(output, "Could not check polecats for uncommitted work") {
+		t.Fatalf("expected list-error warning, got: %q", output)
+	}
+	if !strings.Contains(output, "--force") || !strings.Contains(output, "--nuclear") {
+		t.Fatalf("expected override hint, got: %q", output)
+	}
+}
+
+func TestCheckUncommittedWork_ListErrorForceTTYPrompts(t *testing.T) {
+	stubUncommittedWorkCheckDeps(
+		t,
+		func(*rig.Rig) ([]*polecat.Polecat, error) {
+			return nil, errors.New("list failed")
+		},
+		func(string) (*git.UncommittedWorkStatus, error) {
+			t.Fatalf("check should not be called when list fails")
+			return nil, nil
+		},
+		func() bool { return true },
+		func(question string) bool {
+			if question != "Proceed anyway?" {
+				t.Fatalf("unexpected prompt question: %q", question)
+			}
+			return true
+		},
+	)
+
+	proceed := checkUncommittedWork(testRig(), "testrig", "shutdown", true)
+	if !proceed {
+		t.Fatal("expected proceed=true after force+TTY confirmation")
+	}
+}
+
+func TestCheckUncommittedWork_PolecatStatusErrorBlocks(t *testing.T) {
+	stubUncommittedWorkCheckDeps(
+		t,
+		func(*rig.Rig) ([]*polecat.Polecat, error) {
+			return []*polecat.Polecat{
+				{Name: "alpha", ClonePath: "/tmp/alpha"},
+			}, nil
+		},
+		func(string) (*git.UncommittedWorkStatus, error) {
+			return nil, errors.New("git status failed")
+		},
+		func() bool { return false },
+		func(string) bool {
+			t.Fatalf("prompt should not be called without --force")
+			return false
+		},
+	)
+
+	var proceed bool
+	output := captureStdout(t, func() {
+		proceed = checkUncommittedWork(testRig(), "testrig", "restart", false)
+	})
+
+	if proceed {
+		t.Fatal("expected proceed=false when polecat status check fails")
+	}
+	if !strings.Contains(output, "Could not verify uncommitted work for") {
+		t.Fatalf("expected status-check error warning, got: %q", output)
+	}
+	if !strings.Contains(output, "alpha") {
+		t.Fatalf("expected polecat name in warning, got: %q", output)
+	}
+}
+
+func TestCheckUncommittedWork_DirtyForceNonTTYBlocks(t *testing.T) {
+	stubUncommittedWorkCheckDeps(
+		t,
+		func(*rig.Rig) ([]*polecat.Polecat, error) {
+			return []*polecat.Polecat{
+				{Name: "alpha", ClonePath: "/tmp/alpha"},
+			}, nil
+		},
+		func(string) (*git.UncommittedWorkStatus, error) {
+			return &git.UncommittedWorkStatus{
+				HasUncommittedChanges: true,
+				ModifiedFiles:         []string{"README.md"},
+			}, nil
+		},
+		func() bool { return false },
+		func(string) bool {
+			t.Fatalf("prompt should not be called in non-TTY mode")
+			return false
+		},
+	)
+
+	var proceed bool
+	output := captureStdout(t, func() {
+		proceed = checkUncommittedWork(testRig(), "testrig", "stop", true)
+	})
+
+	if proceed {
+		t.Fatal("expected proceed=false for force in non-TTY mode")
+	}
+	if !strings.Contains(output, "--force") || !strings.Contains(output, "interactive terminal") {
+		t.Fatalf("expected non-TTY force hint, got: %q", output)
+	}
+}
+
+func TestCheckUncommittedWork_DirtyForceTTYPrompts(t *testing.T) {
+	stubUncommittedWorkCheckDeps(
+		t,
+		func(*rig.Rig) ([]*polecat.Polecat, error) {
+			return []*polecat.Polecat{
+				{Name: "alpha", ClonePath: "/tmp/alpha"},
+			}, nil
+		},
+		func(string) (*git.UncommittedWorkStatus, error) {
+			return &git.UncommittedWorkStatus{
+				HasUncommittedChanges: true,
+				ModifiedFiles:         []string{"README.md"},
+			}, nil
+		},
+		func() bool { return true },
+		func(question string) bool {
+			if question != "Proceed anyway?" {
+				t.Fatalf("unexpected prompt question: %q", question)
+			}
+			return true
+		},
+	)
+
+	proceed := checkUncommittedWork(testRig(), "testrig", "stop", true)
+	if !proceed {
+		t.Fatal("expected proceed=true after force+TTY confirmation")
+	}
+}


### PR DESCRIPTION
## Problem

Fixes #1374

"$(gt rig stop/shutdown/restart --force)" misleads users. The flag name implies it bypasses everything, but it only controls *how* sessions are killed (immediate vs graceful) — the uncommitted-work safety check still hard-blocks with an error. Users hit "$(--force)", get the same error, and haread -r helpd help to discover "$(--nuclear)". The "$(Long)" help text and hint messages also only mention "$(--nuclear)", making "$(--force)" behavior unclear.

## Solution

### 1. `--force` now prompts instead of blocking

When "$(--force)" is used and polecats have uncommitted work, the user sees the warning and gets a "$([y/N])" prompt instead of a hard error. They can make an informed choice without re-running with a different flag. "$(--nuclear)" remains unchanged — it skips all checks silently.

### 2. TTY-safe: no hanging in scripts

The prompt only fires when stdin is an interactive terminal ("$(term.IsTerminal)"). In non-interactive contexts (pipes, CI, scripts), "$(--force)" falls back to blocking behavior with a context-aware hint:
- If "$(--force)" was already passed: explains it requires an interactive terminal and only suggests "$(--nuclear)"
- If no flags: suggests both "$(--force)" and "$(--nuclear)"

This ensures commands never hang waiting for input that won't come.

### 3. Consistent help text everywhere

Updated "$(--force)" descriptions in three places per command to match the new behavior:
- "$(Long)" help text (shown by "$(--help)")
- Flag description (shown in flag listing)
- Error hint messages (shown when blocked)

All now say: *"Force immediate shutdown (prompts if uncommitted work)"* and mention both "$(--force)" and "$(--nuclear)" as options.

### 4. Extracted shared helper (net reduction)

The identical ~30-line uncommitted-work check was copy-pasted across "$(runRigStop)", "$(runRigShutdown)", and "$(runRigRestart)". Extracted into:
- **"$(checkUncommittedWork())"** — lists polecats, checks git status, prints warnings, defers to "$(confirmUnsafeProceed)"
- **"$(confirmUnsafeProceed())"** — handles TTY detection, prompting, and context-aware hint messages

Each call site is now 3 lines. "$(runRigReboot)" delegates to "$(runRigShutdown)" so it gets the fix automatically.

### 5. Improved error handling

The original code silently skipped errors from "$(polecatMgr.List())" and "$(CheckUncommittedWork())". Now:
- "$(List())" errors: warn and defer to "$(confirmUnsafeProceed)" (block without "$(--force)", prompt with "$(--force)"+TTY)
- Per-polecat check errors: collected and reported, then defer to "$(confirmUnsafeProceed)"

### 6. Test seams and unit tests

Added package-level "$(var)" functions ("$(listPolecatsForWorkCheck)", "$(checkPolecatWorkStatus)", "$(isStdinTerminal)", "$(promptYesNoUnsafeProceed)") as test seams. New test file "$(rig_uncommitted_work_test.go)" covers:
- List error without "$(--force)" → blocks
- List error with "$(--force)"+TTY → prompts
- Polecat status error → blocks
- Dirty + "$(--force)" + non-TTY → blocks with "requires interactive terminal" hint
- Dirty + "$(--force)" + TTY → prompts

## Behavior matrix

| Flag | Uncommitted work | TTY | Result |
|------|-----------------|-----|--------|
| _(none)_ | dirty polecats | any | Hard-block + hint about "$(--force)" and "$(--nuclear)" |
| "$(--force)" | dirty polecats | yes | Show warning + prompt "$([y/N])" |
| "$(--force)" | dirty polecats | no | Hard-block + hint that "$(--force)" requires interactive terminal, suggests "$(--nuclear)" |
| "$(--nuclear)" | dirty polecats | any | Skip check entirely |
| "$(--force --nuclear)" | dirty polecats | any | Skip check entirely ("$(--nuclear)" wins) |

## Test plan

- [x] "$(go build ./...)" passes
- [x] "$(go vet ./...)" passes
- [x] "$(go test ./internal/cmd/...)" passes (5 new unit tests)
- [x] Manual: "$(gt rig stop <rig>)" with dirty polecat → hard-block with updated hint
- [x] Manual: "$(gt rig stop <rig> --force)" with dirty polecat → prompt "$([y/N])" (y proceeds, n aborts)
- [x] Manual: "$(echo n | gt rig stop <rig> --force)" → blocks cleanly with "requires interactive terminal" hint (non-TTY detection, no hang)
- [x] Manual: "$(gt rig stop <rig> --nuclear)" with dirty polecat → skips check entirely

🤖 Generated with [Claude Code](https://claude.com/claude-code)