### PR TITLE
fix(beads): use runWithRouting for agent state updates

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -370,7 +370,9 @@ func (b *Beads) ResetAgentBeadForReuse(id, reason string) error {
 // which caused inconsistencies with bd slot commands (see GH #gt-9v52).
 func (b *Beads) UpdateAgentState(id string, state string, hookBead *string) error {
 	// Update agent state using bd agent state command
-	_, err := b.run("agent", "state", id, state)
+	// Use runWithRouting so bd can resolve cross-prefix agent beads (e.g., wa-*
+	// agent beads from hq context) via routes.jsonl instead of BEADS_DIR.
+	_, err := b.runWithRouting("agent", "state", id, state)
 	if err != nil {
 		return fmt.Errorf("updating agent state: %w", err)
 	}


### PR DESCRIPTION
Fixes #gt-wk46l

## Problem

`bd agent state` fails when agent bead ID doesn't match configured prefix:

```
Error: failed to auto-create agent bead wa-whatsapp_automation-polecat-rust: validate issue ID prefix: issue ID 'wa-whatsapp_automation-polecat-rust' does not match configured prefix 'hq'
```

## Solution

Changed `UpdateAgentState` to use `runWithRouting` instead of `run` for bd agent state calls. This allows bd to resolve agent beads with rig-specific prefixes (e.g., `wa-whatsapp_automation-polecat-rust`) when run from a different prefix context (e.g., `hq-`).

The fix follows the same pattern already used for slot operations in the same function, which already use `runWithRouting` for cross-prefix operations.

## Testing

- ✅ Code compiles successfully
- ✅ Follows existing pattern for cross-prefix operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)