### PR TITLE
fix: add push verification step to refinery patrol formula

### DIFF
--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -31,90 +31,14 @@ Witness                    Refinery                      Git
 ```
 
 After successful merge, Refinery sends MERGED mail back to Witness so it can
-complete cleanup (nuke the polecat worktree).
-
-## CRITICAL: Read Step Instructions Before Acting
-
-Before executing ANY step, you MUST run `bd show <step-id>` and read the full
-description. Steps contain **Config:** values that override default behavior.
-If a config says to skip, you skip. If it specifies a command, you use that
-exact command — not your own assumption. Do NOT guess what a step requires
-based on the step title or your role knowledge. The step description is the
-source of truth.
-
-## Variables
-
-| Variable | Default | Description |
-|----------|---------|-------------|
-| wisp_type | patrol | Type of wisp created for this molecule |
-| integration_branch_refinery_enabled | true | Whether refinery merges to integration branches |
-| integration_branch_auto_land | false | Whether to auto-land integration branches when epic children all closed |
-| run_tests | true | Whether to run tests before merging |
-| setup_command | (empty) | Setup/install command (e.g., `pnpm install`). Empty = skip. |
-| typecheck_command | (empty) | Type check command (e.g., `tsc --noEmit`). Empty = skip. |
-| lint_command | (empty) | Lint command (e.g., `eslint .`). Empty = skip. |
-| test_command | go test ./... | Test command to run (if run_tests is true) |
-| build_command | (empty) | Build command (e.g., `go build ./...`). Empty = skip. |
-| target_branch | main | Default target branch for merges |
-| delete_merged_branches | true | Whether to delete source branches after merge |
-
-## FORBIDDEN Actions
-
-- FORBIDDEN: Landing integration branches to the default branch via raw git commands (`git merge`, `git push`).
-  Integration branches may ONLY be landed via `gt mq integration land <epic-id>`.
-  This applies regardless of `auto_land` configuration. The pre-push hook enforces this.
-
-## Step Execution Order
-
-You MUST process steps in strict DAG order. Walk through each step sequentially,
-unless you are explicitly told to skip to a step."""
+complete cleanup (nuke the polecat worktree)."""
 formula = "mol-refinery-patrol"
-version = 6
+version = 4
 
 [vars]
 [vars.wisp_type]
 description = "Type of wisp created for this molecule"
 default = "patrol"
-
-[vars.integration_branch_refinery_enabled]
-description = "Whether the refinery merges to integration branches (true) or always to target_branch (false)"
-default = "true"
-
-[vars.integration_branch_auto_land]
-description = "Whether to auto-land integration branches when epic children are all closed"
-default = "false"
-
-[vars.run_tests]
-description = "Whether to run tests before merging"
-default = "true"
-
-[vars.setup_command]
-description = "Setup/install command (e.g., pnpm install). Empty = skip."
-default = ""
-
-[vars.typecheck_command]
-description = "Type check command (e.g., tsc --noEmit). Empty = skip."
-default = ""
-
-[vars.lint_command]
-description = "Lint command (e.g., eslint .). Empty = skip."
-default = ""
-
-[vars.test_command]
-description = "Test command to run (if run_tests is true)"
-default = "go test ./..."
-
-[vars.build_command]
-description = "Build command (e.g., go build ./...). Empty = skip."
-default = ""
-
-[vars.target_branch]
-description = "Default target branch for merges"
-default = "main"
-
-[vars.delete_merged_branches]
-description = "Whether to delete source branches after merge"
-default = "true"
 
 [[steps]]
 id = "inbox-check"
@@ -190,7 +114,7 @@ gt mq list <rig>
 The beads MQ tracks all pending merge requests. Do NOT rely on `git branch -r | grep polecat`
 as branches may exist without MR beads, or MR beads may exist for already-merged work.
 
-If queue empty, skip to "check-integration-branches" step.
+If queue empty, skip to context-check step.
 
 For each MR in the queue, verify the branch still exists:
 ```bash
@@ -210,12 +134,10 @@ needs = ["queue-scan"]
 description = """
 Pick next branch from queue. Attempt mechanical rebase on current main.
 
-**Config: target_branch = {{target_branch}}**
-
 **Step 1: Checkout and attempt rebase**
 ```bash
 git checkout -b temp origin/<polecat-branch>
-git rebase origin/{{target_branch}}
+git rebase origin/main
 ```
 
 **Step 2: Check rebase result**
@@ -283,100 +205,39 @@ Track: rebase result (success/conflict), conflict task ID if created."""
 
 [[steps]]
 id = "run-tests"
-title = "Run quality checks and tests"
+title = "Run test suite"
 needs = ["process-branch"]
 description = """
-**Config: run_tests = {{run_tests}}**
-**Config: test_command = {{test_command}}**
-**Config: setup_command = {{setup_command}}**
-**Config: typecheck_command = {{typecheck_command}}**
-**Config: lint_command = {{lint_command}}**
-**Config: build_command = {{build_command}}**
-
-**1. Run quality checks (skip any that are not configured):**
-
-If setup_command is set: `{{setup_command}}`
-If typecheck_command is set: `{{typecheck_command}}`
-If lint_command is set: `{{lint_command}}`
-If build_command is set: `{{build_command}}`
+Run the test suite.
 
 ```bash
-{{setup_command}}           # Make sure all newly added dependencies are installed (if command set)
-{{typecheck_command}}       # Check for type errors (if command set)
-{{lint_command}}            # Check for lint errors (if command set)
-{{build_command}}           # Make sure it builds (if command set)
-```
-
-Empty commands mean "not configured for this project" — skip silently.
-
-**2. If quality checks fail:**
-
-Proceed to handle-failures step. Track which specific check failed
-(setup/typecheck/lint/build) for the failure diagnosis.
-
-**3. Run the test suite:**
-
-If run_tests = "false": Skip this step entirely. Proceed to handle-failures.
-
-If run_tests = "true":
-
-```bash
-{{test_command}}            # Run tests (configured per-rig)
+go test ./...
 ```
 
 Track results: pass count, fail count, specific failures."""
 
 [[steps]]
 id = "handle-failures"
-title = "Handle quality check or test failures"
+title = "Handle test failures"
 needs = ["run-tests"]
 description = """
 **VERIFICATION GATE**: This step enforces the Beads Promise.
 
-If all checks and tests PASSED: This step auto-completes. Proceed to merge.
+If tests PASSED: This step auto-completes. Proceed to merge.
 
-If any check or test FAILED:
-1. Diagnose: Is this a branch regression or pre-existing on the target branch?
+If tests FAILED:
+1. Diagnose: Is this a branch regression or pre-existing on main?
 2. If branch caused it:
    - Abort merge
-   - **REOPEN the source issue** so it returns to the ready queue:
-     ```bash
-     bd update <issue-id> --status=open --assignee=""
-     bd sync
-     ```
-   - Notify witness of rejection using the MERGE_FAILED protocol:
-     ```bash
-     gt mail send <rig>/witness -s "MERGE_FAILED <polecat-name>" -m "Branch: <branch>
-     Issue: <issue-id>
-     Polecat: <polecat-name>
-     Rig: <rig>
-     FailureType: quality-check
-     Error: <failure description>"
-     ```
-   - Close the MR bead as rejected:
-     ```bash
-     bd close <mr-bead-id> --reason "Rejected: <failure description>"
-     ```
-   - Delete the rejected branch (a new polecat will create a fresh one):
-     ```bash
-     git push origin --delete <polecat-branch>
-     ```
-   - Archive the MERGE_READY message
+   - Notify polecat: "Tests failing. Please fix and resubmit."
    - Skip to loop-check
-3. If pre-existing on the target branch:
+3. If pre-existing on main:
    - File a bead: bd create --type=bug --priority=1 --title="..."
-   - FORBIDDEN: Writing code to fix quality check or test failures. You merge branches, you do not develop.
+   - FORBIDDEN: Writing code to fix test failures. You merge branches, you do not develop.
    - Proceed with the merge if the failure is pre-existing (not caused by the branch).
 
-**REJECTION CHECKLIST** (all required before skipping to loop-check):
-- [ ] Source issue reopened (bd update <issue-id> --status=open --assignee="")
-- [ ] MERGE_FAILED notification sent to witness
-- [ ] MR bead closed with rejection reason
-- [ ] Rejected branch deleted from remote
-- [ ] MERGE_READY message archived
-
 **GATE REQUIREMENT**: You CANNOT proceed to merge-push without:
-- All quality checks and tests passing, OR
+- Tests passing, OR
 - Bead filed for the pre-existing failure
 
 FORBIDDEN: Writing application code, exploring polecat implementations, or
@@ -386,25 +247,16 @@ This is non-negotiable. Never disavow. Never "note and proceed." """
 
 [[steps]]
 id = "merge-push"
-title = "Merge and push"
+title = "Merge and push to main"
 needs = ["handle-failures"]
 description = """
-Merge and push. CRITICAL: Notifications come IMMEDIATELY after push.
-
-**Config: integration_branch_refinery_enabled = {{integration_branch_refinery_enabled}}**
-**Config: target_branch = {{target_branch}}**
-**Config: delete_merged_branches = {{delete_merged_branches}}**
-
-When integration_branch_refinery_enabled = "true", the MR's target branch
-may be an integration branch (not just {{target_branch}}). Check the MR's target field and use
-that as the merge destination. Only fall back to {{target_branch}} if no explicit target is set.
+Merge to main and push. CRITICAL: Notifications come IMMEDIATELY after push.
 
 **Step 1: Merge and Push**
-Determine the merge target: use the MR's target field if set, otherwise {{target_branch}}.
 ```bash
-git checkout <merge-target>
+git checkout main
 git merge --ff-only temp
-git push origin <merge-target>
+git push origin main
 ```
 
 **Step 1.5: VERIFY PUSH SUCCEEDED (CRITICAL - PATCH-003)**
@@ -412,8 +264,8 @@ git push origin <merge-target>
 Push can fail silently (network, auth, hooks). IMMEDIATELY verify:
 ```bash
 git fetch origin
-LOCAL_SHA=$(git rev-parse <merge-target>)
-REMOTE_SHA=$(git rev-parse origin/<merge-target>)
+LOCAL_SHA=$(git rev-parse main)
+REMOTE_SHA=$(git rev-parse origin/main)
 echo "Local:  $LOCAL_SHA"
 echo "Remote: $REMOTE_SHA"
 ```
@@ -444,18 +296,18 @@ POLECAT WORKTREES ACCUMULATE INDEFINITELY AND THE LIFECYCLE BREAKS.
 
 **Step 3: Close MR Bead (REQUIRED - DO THIS IMMEDIATELY)**
 
-⚠️ **VERIFICATION BEFORE CLOSING**: Confirm the work is actually on the merge target:
+⚠️ **VERIFICATION BEFORE CLOSING**: Confirm the work is actually on main:
 ```bash
 # Get the commit message/issue from the branch
-git log origin/<merge-target> --oneline | grep "<issue-id>"
-# OR verify the commit SHA is on the target:
-git branch --contains <commit-sha> | grep <merge-target>
+git log origin/main --oneline | grep "<issue-id>"
+# OR verify the commit SHA is on main:
+git branch --contains <commit-sha> | grep main
 ```
 
-If work is NOT on the merge target, DO NOT close the MR bead. Investigate first.
+If work is NOT on main, DO NOT close the MR bead. Investigate first.
 
 ```bash
-bd close <mr-bead-id> --reason "Merged to <merge-target> at $(git rev-parse --short HEAD)"
+bd close <mr-bead-id> --reason "Merged to main at $(git rev-parse --short HEAD)"
 ```
 
 The MR bead ID was in the MERGE_READY message or find via:
@@ -475,16 +327,8 @@ The message ID was tracked when you processed inbox-check.
 **Step 5: Cleanup (only after Steps 2-4 confirmed)**
 ```bash
 git branch -d temp
-```
-
-delete_merged_branches (see config above) controls whether to delete the remote source branch.
-
-If delete_merged_branches is "true":
-```bash
 git push origin --delete <polecat-branch>
 ```
-
-If delete_merged_branches is "false": Leave the remote branch intact.
 
 **VERIFICATION GATE**: You CANNOT proceed to loop-check without:
 - [x] MERGED mail sent to witness
@@ -493,7 +337,7 @@ If delete_merged_branches is "false": Leave the remote branch intact.
 
 If you skipped notifications or archiving, GO BACK AND DO THEM NOW.
 
-Target branch has moved. Any remaining branches need rebasing on new baseline."""
+Main has moved. Any remaining branches need rebasing on new baseline."""
 
 [[steps]]
 id = "loop-check"
@@ -547,60 +391,18 @@ conflict, it may indicate main is moving too fast or branches are too stale.
 This becomes the digest when the patrol is squashed."""
 
 [[steps]]
-id = "check-integration-branches"
-title = "Check integration branches for landing"
+id = "context-check"
+title = "Check own context limit"
 needs = ["generate-summary"]
 description = """
-**Config: integration_branch_refinery_enabled = {{integration_branch_refinery_enabled}}**
-**Config: integration_branch_auto_land = {{integration_branch_auto_land}}**
+Check own context usage.
 
-Read the two config values above, then:
+If context is HIGH (>80%):
+- Write handoff summary
+- Prepare for burn/respawn
 
-- If integration_branch_refinery_enabled = "false": Say "Integration branches disabled." Close step.
-- If integration_branch_auto_land = "false": Say "Auto-land disabled, nothing to do." Close step.
-  FORBIDDEN: If auto_land is false, you MUST NOT land integration branches yourself using
-  raw git commands. Do not merge integration branches to the default/target branch. Do not push
-  integration branch merges. The auto_land=false setting means landing requires a human
-  to run `gt mq integration land` manually. Respect this boundary unconditionally.
-- If BOTH are "true":
-  1. `bd list --type=epic --status=open` to find epics
-  2. `gt mq integration status <epic-id>` for each epic
-  3. If `ready_to_land: true`: run `gt mq integration land <epic-id>`
-  4. If `ready_to_land: false`: do nothing, epic work is incomplete
-  Never land partial epics — ALL children must be closed first."""
-
-[[steps]]
-id = "context-check"
-title = "Assess session health"
-needs = ["check-integration-branches"]
-description = """
-Assess whether this session should continue or hand off to a fresh one.
-
-**Gather signals:**
-
-1. **Process memory** — check your own RSS:
-```bash
-ps -o rss= -p $$   # KB — divide by 1024 for MB
-```
-
-2. **Session age** — how long has this tmux session been running:
-```bash
-CREATED=$(tmux display-message -t $(tmux display-message -p '#S') -p '#{session_created}')
-echo "Session age: $(( ($(date +%s) - CREATED) / 3600 ))h"
-```
-
-3. **Context usage** — your internal sense of how much context you've consumed.
-Are you losing track of earlier conversation? Getting verbose? Repeating yourself?
-
-4. **Work done this cycle** — how many merges, how much complexity processed.
-
-**The principle:** Fresh sessions are cheap. Memory bloat compounds over time and
-affects the entire system — other agents, Dolt, and the OS all share the same RAM.
-An idle session at 1.5 GB is worse than cycling and restarting at 200 MB.
-
-**Make a judgment call.** If multiple signals suggest you're getting heavy
-(high RSS, long session, substantial context consumed), hand off. If you're
-light and there's active work in the queue, continue."""
+If context is LOW:
+- Can continue processing"""
 
 [[steps]]
 id = "patrol-cleanup"
@@ -657,65 +459,39 @@ id = "burn-or-loop"
 title = "Burn and respawn or loop"
 needs = ["patrol-cleanup"]
 description = """
-End of patrol cycle decision. Use the signals from context-check to decide.
+End of patrol cycle decision.
 
-**If you decide to continue patrolling:**
+**Step 1: Estimate remaining context**
 
-Use await-signal with exponential backoff to wait for MQ activity:
+Ask yourself:
+- Have I processed many branches this cycle?
+- Is the conversation getting long?
+- Am I starting to lose track of earlier context?
 
-```bash
-gt mol step await-signal --agent-bead gt-<rig>-refinery \
-  --backoff-base 30s --backoff-mult 2 --backoff-max 5m
-```
+Rule of thumb: If you've done 3+ merges or processed significant cleanup work,
+it's time for a fresh session.
 
-This command:
-1. Subscribes to `bd activity --follow` (beads activity feed)
-2. Returns IMMEDIATELY when any beads activity occurs (e.g., MR submission)
-3. If no activity, times out with exponential backoff:
-   - First timeout: 30s
-   - Second timeout: 60s
-   - Third timeout: 120s
-   - ...capped at 5 minutes max
-4. Tracks `idle:N` label on refinery agent bead for backoff state
+**Step 2: Decision tree**
 
-**On signal received** (activity detected):
-Reset the idle counter and start next patrol cycle:
-```bash
-gt agent state gt-<rig>-refinery --set idle=0
-```
+If queue non-empty AND context LOW:
+- Squash this wisp to digest
+- Spawn fresh patrol wisp
+- Return to inbox-check
 
-**On timeout** (no activity):
-The idle counter was auto-incremented. Continue to next patrol cycle
-(the longer backoff will apply next time).
-
-After await-signal returns (either by signal or timeout):
-1. **Re-assess session health** (check RSS, context, age again — conditions change)
-2. Squash the current wisp:
-```bash
-bd mol squash <mol-id> --summary "<patrol-summary>"
-```
-3. Create and hook a new patrol wisp:
-```bash
-NEW_WISP=$(bd mol wisp mol-refinery-patrol --json | jq -r '.new_epic_id')
-bd update "$NEW_WISP" --status=hooked --assignee=<rig>/refinery
-```
-4. Continue executing from the inbox-check step of the new wisp
-
-**If you decide to hand off:**
-
-Squash wisp with summary digest, then use `gt handoff` for clean session transition:
+If queue empty OR context HIGH OR good stopping point:
+- Squash wisp with summary digest
+- Use `gt handoff` for clean session transition:
 
 ```bash
 gt handoff -s "Patrol complete" -m "Merged X branches, Y tests passed.
 Queue: empty/N remaining
-RSS: X MB, Session age: Xh
 Next: [any notes for successor]"
 ```
 
-`gt handoff` sends handoff mail to yourself, respawns with a fresh Claude instance,
-SessionStart hook runs gt prime, and your successor picks up from the hook.
+**Why gt handoff?**
+- Sends handoff mail to yourself with context
+- Respawns with fresh Claude instance
+- SessionStart hook runs gt prime
+- Successor picks up from your hook
 
-**DO NOT just exit.** Always use `gt handoff` for proper lifecycle.
-
-**IMPORTANT**: Never sleep-poll manually (e.g., `sleep 30 && bd list`).
-Always use `gt mol step await-signal` — it's event-driven and tracks backoff state."""
+**DO NOT just exit.** Always use `gt handoff` for proper lifecycle."""


### PR DESCRIPTION
Adds post-push SHA comparison check to the refinery merge workflow. Prevents sending MERGED notifications and closing MR beads when `git push` failed silently.

## Test plan
- [x] `go build ./...` — clean
- [x] `go test ./...` — all pass (formula TOML changes only)