### PR TITLE
feat(crew): add --reset flag to gt crew at, make branch switch opt-in

### DIFF
--- a/internal/cmd/crew.go
+++ b/internal/cmd/crew.go
@@ -22,6 +22,7 @@ var (
 	crewListAll       bool
 	crewDryRun        bool
 	crewDebug         bool
+	crewReset         bool
 )
 
 var crewCmd = &cobra.Command{
@@ -108,6 +109,10 @@ current pane. Use C-b s to switch to the new session.
 When run from outside tmux, you are attached to the session (unless
 --detached is specified).
 
+Branch Handling:
+  By default, the workspace stays on its current branch. Use --reset to
+  switch to the default branch and pull latest changes.
+
 Role Discovery:
   If no name is provided, attempts to detect the crew workspace from the
   current directory. If you're in <rig>/crew/<name>/, it will attach to
@@ -116,6 +121,7 @@ Role Discovery:
 Examples:
   gt crew at dave                 # Attach to dave's session
   gt crew at                      # Auto-detect from cwd
+  gt crew at dave --reset         # Reset to default branch first
   gt crew at dave --detached      # Start session without attaching
   gt crew at dave --no-tmux       # Just print path`,
 	Args: cobra.MaximumNArgs(1),
@@ -351,6 +357,7 @@ func init() {
 	crewAtCmd.Flags().StringVar(&crewAccount, "account", "", "Claude Code account handle to use (overrides default)")
 	crewAtCmd.Flags().StringVar(&crewAgentOverride, "agent", "", "Agent alias to run crew worker with (overrides rig/town default)")
 	crewAtCmd.Flags().BoolVar(&crewDebug, "debug", false, "Show debug output for troubleshooting")
+	crewAtCmd.Flags().BoolVar(&crewReset, "reset", false, "Reset workspace to default branch (checkout and pull)")
 
 	crewRemoveCmd.Flags().StringVar(&crewRig, "rig", "", "Rig to use")
 	crewRemoveCmd.Flags().BoolVar(&crewForce, "force", false, "Force remove (skip safety checks)")

--- a/internal/cmd/crew_at.go
+++ b/internal/cmd/crew_at.go
@@ -82,8 +82,10 @@ func runCrewAt(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting crew worker: %w", err)
 	}
 
-	// Ensure crew workspace is on default branch (persistent roles should not use feature branches)
-	ensureDefaultBranch(worker.ClonePath, fmt.Sprintf("Crew workspace %s/%s", r.Name, name), r.Path)
+	// Only reset to default branch if --reset flag is passed
+	if crewReset {
+		ensureDefaultBranch(worker.ClonePath, fmt.Sprintf("Crew workspace %s/%s", r.Name, name), r.Path)
+	}
 
 	// If --no-tmux, just print the path
 	if crewNoTmux {


### PR DESCRIPTION
## Summary
- `gt crew at` no longer auto-switches to the default branch
- Added `--reset` flag to explicitly reset workspace to default branch
- Branch switching is now opt-in instead of automatic

## Problem
`gt crew at <crew>` was automatically resetting the crew's branch to main every time it ran, which was disruptive and unexpected for users working on feature branches.

## Changes
- Added `crewReset` flag variable in `crew.go`
- Registered `--reset` flag on `crewAtCmd`
- Made `ensureDefaultBranch()` call conditional on `--reset` flag
- Updated command help with Branch Handling section

## Test plan
- [ ] `gt crew at dave` stays on current branch (no auto-switch)
- [ ] `gt crew at dave --reset` switches to default branch and pulls
- [ ] `gt crew at --help` shows the new --reset flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)