### PR TITLE
feat(crew): add --reset flag to gt crew at, make branch switch opt-in

### DIFF
--- a/internal/cmd/crew.go
+++ b/internal/cmd/crew.go
@@ -110,8 +110,9 @@ When run from outside tmux, you are attached to the session (unless
 --detached is specified).
 
 Branch Handling:
-  By default, the workspace stays on its current branch. Use --reset to
-  switch to the default branch and pull latest changes.
+  By default, the workspace stays on its current branch (a warning is
+  shown if not on the default branch). Use --reset to switch to the
+  default branch and pull latest changes.
 
 Role Discovery:
   If no name is provided, attempts to detect the crew workspace from the

--- a/internal/cmd/crew_at.go
+++ b/internal/cmd/crew_at.go
@@ -82,9 +82,13 @@ func runCrewAt(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting crew worker: %w", err)
 	}
 
-	// Only reset to default branch if --reset flag is passed
+	// Reset to default branch if --reset flag is passed; otherwise warn if off-branch
 	if crewReset {
-		ensureDefaultBranch(worker.ClonePath, fmt.Sprintf("Crew workspace %s/%s", r.Name, name), r.Path)
+		if err := ensureDefaultBranch(worker.ClonePath, fmt.Sprintf("Crew workspace %s/%s", r.Name, name), r.Path); err != nil {
+			return fmt.Errorf("resetting to default branch: %w", err)
+		}
+	} else {
+		warnIfNotDefaultBranch(worker.ClonePath, fmt.Sprintf("Crew workspace %s/%s", r.Name, name), r.Path)
 	}
 
 	// If --no-tmux, just print the path


### PR DESCRIPTION
## Summary
- `gt crew at` no longer auto-switches to the default branch
- Added `--reset` flag to explicitly reset workspace to default branch
- Branch switching is now opt-in instead of automatic

## Problem
`gt crew at <crew>` was automatically resetting the crew's branch to main every time it ran, which was disruptive and unexpected for users working on feature branches.

## Changes
- Added `crewReset` flag variable in `crew.go`
- Registered `--reset` flag on `crewAtCmd`
- Made `ensureDefaultBranch()` call conditional on `--reset` flag
- Updated command help with Branch Handling section

## Test plan
- [ ] `gt crew at dave` stays on current branch (no auto-switch)
- [ ] `gt crew at dave --reset` switches to default branch and pulls
- [ ] `gt crew at --help` shows the new --reset flag

🤖 Generated with [Claude Code](https://claude.com/claude-code)