### PR TITLE
fix(formula): add mol-wisp-compact to canonical .beads/formulas/

### DIFF
--- a/.beads/formulas/mol-wisp-compact.formula.toml
+++ b/.beads/formulas/mol-wisp-compact.formula.toml
@@ -1,0 +1,189 @@
+description = """
+Compact expired wisps across rigs using TTL-based policy.
+
+Dogs work through molecules (poured from this formula) to apply TTL-based compaction
+to ephemeral wisps. This keeps storage manageable while preserving forensic value
+through Dolt's AS OF history.
+
+Wisp categories and default TTLs:
+- Heartbeats/pings: 6h
+- Patrols/GC reports: 24h
+- Errors/recovery/escalations: 7d
+- Proven value (comments, referenced, keep label): never auto-delete
+
+## Dog Contract
+
+This is infrastructure work. You:
+1. Preview compaction scope via dry run
+2. Execute compaction per rig
+3. Verify results
+4. Report what was compacted
+5. Return to kennel
+
+## Key Principle
+
+Closed wisps past TTL are deleted (Dolt AS OF preserves history).
+Non-closed wisps past TTL are promoted to permanent beads (something is stuck).
+Wisps with comments, references, or keep labels are always promoted."""
+formula = "mol-wisp-compact"
+version = 1
+
+[squash]
+trigger = "on_complete"
+template_type = "work"
+include_metrics = true
+
+[vars]
+wisp_type = "gc_report"
+
+[[steps]]
+id = "preview-compaction"
+title = "Preview compaction scope"
+description = """
+Dry-run compaction to assess what will happen.
+
+**1. Run compaction preview:**
+```bash
+gt compact --dry-run --verbose
+```
+
+**2. If targeting a specific rig:**
+```bash
+gt compact --dry-run --verbose --rig <rig-name>
+```
+
+**3. Review the output:**
+- How many wisps will be promoted (stuck/proven value)
+- How many wisps will be deleted (TTL expired)
+- How many will be skipped (still within TTL)
+
+**4. Check for anomalies:**
+- Unusually high promotion count may indicate stuck work
+- Zero deletions when wisps exist may indicate clock/TTL misconfiguration
+
+**Exit criteria:** Dry-run complete, compaction scope understood."""
+
+[[steps]]
+id = "execute-compaction"
+title = "Execute wisp compaction"
+needs = ["preview-compaction"]
+description = """
+Run compaction for real.
+
+**1. Execute compaction:**
+```bash
+gt compact --verbose --json
+```
+
+**2. Capture JSON output for reporting:**
+The --json flag produces structured output:
+```json
+{
+  "promoted": [{"id": "...", "title": "...", "reason": "..."}],
+  "deleted": [{"id": "...", "title": "...", "reason": "..."}],
+  "skipped": 42,
+  "errors": []
+}
+```
+
+**3. Check for errors:**
+- Promotion failures: wisp may have been deleted between dry-run and execution
+- Deletion failures: wisp may have been promoted by another process
+- These are expected in concurrent environments; log and continue
+
+**Exit criteria:** Compaction executed, results captured."""
+
+[[steps]]
+id = "verify-compaction"
+title = "Verify compaction results"
+needs = ["execute-compaction"]
+description = """
+Confirm compaction was clean.
+
+**1. Run a second dry-run to verify:**
+```bash
+gt compact --dry-run
+```
+Should show zero or near-zero pending compactions (new wisps may have
+arrived during execution).
+
+**2. Spot-check promoted beads:**
+```bash
+# Verify promoted wisps are now permanent
+bd show <promoted-id>
+# Should show ephemeral=false
+```
+
+**3. Verify deleted wisps are gone but recoverable:**
+```bash
+# Dolt AS OF preserves history
+# This is informational only - no action needed
+```
+
+**Exit criteria:** Compaction verified clean."""
+
+[[steps]]
+id = "report-compaction"
+title = "Generate compaction report"
+needs = ["verify-compaction"]
+description = """
+Create summary report of compaction results.
+
+**1. Generate report from JSON output:**
+```markdown
+## Wisp Compaction: {{timestamp}}
+
+### Summary
+| Action | Count |
+|--------|-------|
+| Promoted | {{promoted_count}} |
+| Deleted | {{deleted_count}} |
+| Skipped | {{skipped_count}} |
+| Errors | {{error_count}} |
+
+### Promotions
+{{#each promoted}}
+- {{id}}: {{title}} ({{reason}})
+{{/each}}
+
+### Errors
+{{#if errors}}
+{{#each errors}}
+- {{error}}
+{{/each}}
+{{else}}
+None
+{{/if}}
+```
+
+**2. Send report to Deacon:**
+```bash
+gt mail send deacon/ -s "Wisp compaction: {{promoted_count}} promoted, {{deleted_count}} deleted" \
+  -m "{{report}}"
+```
+
+**Exit criteria:** Report sent."""
+
+[[steps]]
+id = "return-to-kennel"
+title = "Signal completion and return to kennel"
+needs = ["report-compaction"]
+description = """
+Signal work complete and return to available pool.
+
+**1. Signal completion to Deacon:**
+```bash
+gt mail send deacon/ -s "DOG_DONE $(hostname)" -m "Task: wisp-compact
+Promoted: {{promoted_count}}
+Deleted: {{deleted_count}}
+Skipped: {{skipped_count}}
+Errors: {{error_count}}
+Status: COMPLETE
+
+Ready for next assignment."
+```
+
+**2. Return to kennel:**
+Dog returns to available state in the pool.
+
+**Exit criteria:** Deacon notified, dog ready for next work."""


### PR DESCRIPTION
## Summary

Commit `b755831a` added `mol-wisp-compact.formula.toml` to the embedded/generated directory (`internal/formula/formulas/`) but not to the canonical source directory (`.beads/formulas/`). This means `go generate` would delete the embedded copy and the CI "Check embedded formulas" job would fail.

## Related Issue

Regression from `b755831a` (feat(formula): add wisp compaction formula for Dogs).

## Changes

- Add `mol-wisp-compact.formula.toml` to `.beads/formulas/` (canonical location)

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] `go generate ./internal/formula/...` produces no diff (canonical and embedded are in sync)
- [x] Manual testing performed

## Checklist

- [x] Code follows project style
- [x] No breaking changes (or documented in summary)