### PR TITLE
fix(formula): add missing template vars to mol-wisp-compact

### DIFF
--- a/.beads/formulas/mol-wisp-compact.formula.toml
+++ b/.beads/formulas/mol-wisp-compact.formula.toml
@@ -36,6 +36,46 @@ include_metrics = true
 [vars]
 wisp_type = "gc_report"
 
+[vars.timestamp]
+description = "Compaction run timestamp"
+default = ""
+
+[vars.promoted_count]
+description = "Number of wisps promoted to permanent beads"
+default = ""
+
+[vars.deleted_count]
+description = "Number of expired wisps deleted"
+default = ""
+
+[vars.skipped_count]
+description = "Number of wisps still within TTL"
+default = ""
+
+[vars.error_count]
+description = "Number of errors during compaction"
+default = ""
+
+[vars.id]
+description = "Bead/wisp ID in report iteration"
+default = ""
+
+[vars.title]
+description = "Bead/wisp title in report iteration"
+default = ""
+
+[vars.reason]
+description = "Promotion or deletion reason"
+default = ""
+
+[vars.error]
+description = "Error message from failed compaction operation"
+default = ""
+
+[vars.report]
+description = "Full compaction report body for mail"
+default = ""
+
 [[steps]]
 id = "preview-compaction"
 title = "Preview compaction scope"

--- a/internal/formula/formulas/mol-wisp-compact.formula.toml
+++ b/internal/formula/formulas/mol-wisp-compact.formula.toml
@@ -36,6 +36,46 @@ include_metrics = true
 [vars]
 wisp_type = "gc_report"
 
+[vars.timestamp]
+description = "Compaction run timestamp"
+default = ""
+
+[vars.promoted_count]
+description = "Number of wisps promoted to permanent beads"
+default = ""
+
+[vars.deleted_count]
+description = "Number of expired wisps deleted"
+default = ""
+
+[vars.skipped_count]
+description = "Number of wisps still within TTL"
+default = ""
+
+[vars.error_count]
+description = "Number of errors during compaction"
+default = ""
+
+[vars.id]
+description = "Bead/wisp ID in report iteration"
+default = ""
+
+[vars.title]
+description = "Bead/wisp title in report iteration"
+default = ""
+
+[vars.reason]
+description = "Promotion or deletion reason"
+default = ""
+
+[vars.error]
+description = "Error message from failed compaction operation"
+default = ""
+
+[vars.report]
+description = "Full compaction report body for mail"
+default = ""
+
 [[steps]]
 id = "preview-compaction"
 title = "Preview compaction scope"


### PR DESCRIPTION
## Summary
- Add 10 missing computed template variable declarations to `mol-wisp-compact.formula.toml`
- Fixes `TestAllEmbeddedFormulas_VariableValidation` failure on Windows CI

## Why
The formula uses `{{timestamp}}`, `{{promoted_count}}`, `{{deleted_count}}`, `{{skipped_count}}`, `{{error_count}}`, `{{id}}`, `{{title}}`, `{{reason}}`, `{{error}}`, and `{{report}}` in step descriptions without declaring them in `[vars]`. The variable validation test catches this and fails.

## Changes
- `.beads/formulas/mol-wisp-compact.formula.toml` — add 10 `[vars.*]` entries with `default = ""`
- `internal/formula/formulas/mol-wisp-compact.formula.toml` — synced via `go generate`

## Test plan
- [x] `go test github.com/steveyegge/gastown/internal/formula -count=1` — all 48 tests pass
- [x] `go build ./...` compiles cleanly
- [ ] Windows CI passes
