### PR TITLE
fix(ci): add pipefail so test failures aren't masked by tee

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,7 @@ jobs:
 
       - name: Test with Coverage
         run: |
+          set -o pipefail
           go test -race -short -coverprofile=coverage.out ./... 2>&1 | tee test-output.txt
 
       - name: Upload Coverage Data


### PR DESCRIPTION
## Summary
Add `set -o pipefail` to the "Test with Coverage" step in `ci.yml`.

## Why
The `go test ... 2>&1 | tee test-output.txt` pipeline reports `tee`'s exit code (always 0), not `go test`'s. This silently masks test failures on Linux CI — the `mol-wisp-compact` template variable validation failure went undetected on Linux while Windows CI (which doesn't pipe through `tee`) correctly caught it.

## Changes
- `.github/workflows/ci.yml` — add `set -o pipefail` before the piped `go test` command

## Test plan
- [ ] CI "Test" job now correctly fails when any `go test` package fails

**Note:** This PR will fail CI until #1597 merges (it exposes the same formula validation failure that Windows already catches).
