### PR TITLE
feat(ci): add gotestsum + JUnit reporting for readable test failures

### DIFF
--- a/.github/scripts/junit-report.py
+++ b/.github/scripts/junit-report.py
@@ -1,0 +1,128 @@
+#!/usr/bin/env python3
+"""Parse JUnit XML and report test failures.
+
+Outputs:
+  1. Formatted table to stdout (visible in the step's log)
+  2. ::error annotations (visible in the check run annotations)
+  3. Markdown table to $GITHUB_STEP_SUMMARY
+  4. PR comment via gh CLI (best-effort, skips on permission errors)
+
+Usage: python3 junit-report.py <junit-xml-path> <heading>
+"""
+import os
+import subprocess
+import sys
+import xml.etree.ElementTree as ET
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: junit-report.py <junit.xml> [heading]", file=sys.stderr)
+        sys.exit(1)
+
+    xml_path = sys.argv[1]
+    heading = sys.argv[2] if len(sys.argv) > 2 else "Test Failures"
+
+    if not os.path.exists(xml_path):
+        return
+
+    tree = ET.parse(xml_path)
+    failures = []
+    for tc in tree.iter("testcase"):
+        f = tc.find("failure")
+        if f is not None:
+            pkg = tc.get("classname", "")
+            name = tc.get("name", "")
+            # Prefer the failure body for detail, fall back to message attr
+            detail = (f.text or f.get("message") or "").strip()
+            # Find the first meaningful line (skip === RUN, blank lines, timestamps)
+            short = ""
+            for line in detail.split("\n"):
+                line = line.strip()
+                if line and not line.startswith("=== RUN") and not line.startswith("--- FAIL"):
+                    short = line[:200]
+                    break
+            if not short:
+                short = f.get("message", "failed")
+            failures.append((pkg, name, short, detail))
+
+    if not failures:
+        return
+
+    # 1. Formatted output to stdout (visible in step log)
+    print(f"\n{'=' * 60}")
+    print(f"  {heading}: {len(failures)} failed")
+    print(f"{'=' * 60}\n")
+    for pkg, name, short, detail in failures:
+        print(f"  FAIL  {pkg}.{name}")
+        # Indent the detail for readability
+        for line in detail.split("\n")[:15]:
+            print(f"        {line}")
+        print()
+    print(f"{'=' * 60}\n")
+
+    # 2. ::error annotations
+    for pkg, name, short, _ in failures:
+        print(f"::error title=FAIL {pkg}.{name}::{short}")
+
+    # 3. $GITHUB_STEP_SUMMARY
+    summary_path = os.environ.get("GITHUB_STEP_SUMMARY", "")
+    if summary_path:
+        with open(summary_path, "a") as out:
+            out.write(f"## {heading}\n\n")
+            out.write("| Package | Test | Error |\n")
+            out.write("|---------|------|-------|\n")
+            for pkg, name, short, _ in failures:
+                # Escape pipes in the message for markdown tables
+                safe = short.replace("|", "\\|")
+                out.write(f"| `{pkg}` | `{name}` | {safe} |\n")
+
+    # 4. PR comment (best-effort)
+    pr_number = os.environ.get("PR_NUMBER", "")
+    if not pr_number:
+        return
+
+    comment_marker = f"<!-- junit-report: {heading} -->"
+    body_lines = [
+        comment_marker,
+        f"## {heading}",
+        "",
+        "| Package | Test | Error |",
+        "|---------|------|-------|",
+    ]
+    for pkg, name, short, _ in failures:
+        safe = short.replace("|", "\\|")
+        body_lines.append(f"| `{pkg}` | `{name}` | {safe} |")
+    body_lines.append("")
+    body_lines.append("_Updated by CI — this comment is replaced on each push._")
+    body = "\n".join(body_lines)
+
+    try:
+        # Check for existing comment to update
+        result = subprocess.run(
+            ["gh", "pr", "view", pr_number, "--json", "comments",
+             "--jq", f'.comments[] | select(.body | startswith("{comment_marker}")) | .url'],
+            capture_output=True, text=True, timeout=15,
+        )
+        existing_url = result.stdout.strip().split("\n")[0] if result.stdout.strip() else ""
+
+        if existing_url:
+            # Extract comment ID from URL and update
+            comment_id = existing_url.rstrip("/").split("/")[-1]
+            subprocess.run(
+                ["gh", "api", f"repos/{{owner}}/{{repo}}/issues/comments/{comment_id}",
+                 "-X", "PATCH", "-f", f"body={body}"],
+                capture_output=True, timeout=15,
+            )
+        else:
+            subprocess.run(
+                ["gh", "pr", "comment", pr_number, "--body", body],
+                capture_output=True, timeout=15,
+            )
+    except Exception:
+        pass  # Best-effort — don't fail the step
+
+    # Exit non-zero so the step shows as failed (red X) in the UI
+    sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,13 +83,24 @@ jobs:
           git config --global user.name "CI Bot"
           git config --global user.email "ci@gastown.test"
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
       - name: Build
         run: go build -v ./cmd/gt
 
       - name: Test with Coverage
         run: |
           set -o pipefail
-          go test -race -short -coverprofile=coverage.out ./... 2>&1 | tee test-output.txt
+          gotestsum --format testname --junitfile junit.xml -- -race -short -coverprofile=coverage.out ./... 2>&1 | tee test-output.txt
+
+      - name: Test Report
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          python3 .github/scripts/junit-report.py junit.xml "Unit Test Failures"
 
       - name: Upload Coverage Data
         if: github.event_name == 'pull_request'
@@ -136,7 +147,9 @@ jobs:
           echo "|---------|----------|" >> coverage-report.md
 
           # Extract package coverage from all test output lines
+          # tr -d '()' handles both raw go test and gotestsum output formats
           grep -E "github.com/steveyegge/gastown.*coverage:" test-output.txt | \
+            tr -d '()' | \
             sed 's/.*github.com\/steveyegge\/gastown\///' | \
             awk '{
               pkg = $1
@@ -251,6 +264,9 @@ jobs:
         if: steps.cache-beads-int.outputs.cache-hit != 'true'
         run: go install github.com/steveyegge/beads/cmd/bd@v0.52.0
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
       - name: Build gt
         run: |
           make build
@@ -260,4 +276,12 @@ jobs:
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Integration Tests
-        run: go test -tags=integration -timeout=5m -v ./internal/cmd/...
+        run: gotestsum --format testname --junitfile junit-integration.xml -- -tags=integration -timeout=5m -v ./internal/cmd/...
+
+      - name: Test Report
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          python3 .github/scripts/junit-report.py junit-integration.xml "Integration Test Failures"

--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -53,6 +53,9 @@ jobs:
           dolt config --global --add user.name "CI Bot"
           dolt config --global --add user.email "ci@gastown.test"
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
       - name: Generate embedded files
         run: go generate ./internal/formula/...
 
@@ -60,5 +63,13 @@ jobs:
         run: go build -v ./cmd/gt
 
       - name: Run integration tests
-        run: go test -v -tags=integration -timeout=8m ./internal/cmd/...
+        run: gotestsum --format testname --junitfile junit.xml -- -v -tags=integration -timeout=8m ./internal/cmd/...
+
+      - name: Test Report
+        if: always()
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          python3 .github/scripts/junit-report.py junit.xml "Integration Test Failures"
 

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -35,6 +35,9 @@ jobs:
         run: |
           echo "$(go env GOPATH)/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
       - name: Generate embedded files
         run: go generate ./internal/formula/...
 
@@ -42,4 +45,13 @@ jobs:
         run: go build -v ./cmd/gt
 
       - name: Unit Tests
-        run: go test -short ./...
+        run: gotestsum --format testname --junitfile junit.xml -- -short ./...
+
+      - name: Test Report
+        if: always()
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          python3 .github/scripts/junit-report.py junit.xml "Windows Test Failures"


### PR DESCRIPTION
## Summary

Replace raw `go test` with `gotestsum` across all CI workflows and add a shared
Python script that parses JUnit XML to surface test failures in multiple places:
step logs, `::error` annotations, job summary, and PR comments.

## Why

Debugging CI failures previously required scrolling through verbose logs looking
for `FAIL`. Now, failed tests are:

1. **Formatted in the step log** — a clear table in the "Test Report" step
2. **Shown as `::error` annotations** — visible in the PR checks tab
3. **Written to `$GITHUB_STEP_SUMMARY`** — visible in the job summary
4. **Posted as a PR comment** — best-effort via `gh` CLI (skips silently on permission errors for fork PRs)

The "Test Report" step exits non-zero when failures are found, so it shows a
red X — making it obvious which step to click for failure details.

## Changes

### New file: `.github/scripts/junit-report.py`

Shared script used by all CI workflows. Parses JUnit XML and:
- Prints a formatted failure table to stdout (visible in step log)
- Emits `::error` annotations with the first meaningful error line (skips `=== RUN` / `--- FAIL` noise)
- Appends a markdown table to `$GITHUB_STEP_SUMMARY`
- Attempts to post/update a PR comment via `gh` CLI (best-effort)
- Exits non-zero when failures exist (red X on the step)

### Workflow updates

All 4 test jobs across 3 workflows updated:

| Workflow | Job | JUnit file |
|----------|-----|------------|
| `ci.yml` | Test | `junit.xml` |
| `ci.yml` | Integration Tests | `junit-integration.xml` |
| `integration.yml` | Integration Tests | `junit.xml` |
| `windows-ci.yml` | Unit Tests | `junit.xml` |

Each job now:
1. Installs `gotestsum` via `go install gotest.tools/gotestsum@latest`
2. Runs tests with `gotestsum --format testname --junitfile <file> -- <original flags>`
3. Runs `junit-report.py` in an `if: always()` "Test Report" step

### Additional fixes
- `ci.yml` test step: adds `set -o pipefail` (supersedes #1598)
- `ci.yml` coverage parsing: adds `tr -d '()'` to handle gotestsum output format

## Design decisions

- **No third-party actions** — `mikepenz/action-junit-report` was tried first but
  requires `checks: write` permission, which GitHub restricts for fork PR tokens.
  Native `::error` annotations and `$GITHUB_STEP_SUMMARY` need no special permissions.
- **Shared Python script** — avoids duplicating JUnit parsing logic across workflows.
  Python is available on all GitHub Actions runners (Ubuntu, Windows with `shell: bash`).
- **Best-effort PR comments** — uses `gh` CLI which works for same-repo PRs but
  silently skips on fork PRs where the token lacks write access.

## Test plan

- [x] Test Report step shows red X when tests fail
- [x] Formatted failure table visible in step log
- [x] `::error` annotation shows meaningful error message
- [x] Integration Tests, Windows CI, and dedicated Integration workflow all use the shared script
- [ ] PR comment posted on same-repo PRs (untested — current PR is from a fork)

_The only failing test (`TestConvoyHandler_TemplateErrorReturns500`) is a pre-existing
data race in `internal/web/handler.go`, unrelated to this PR._