### PR TITLE
chore: add Renovate config for automated dependency management

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,53 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "config:recommended",
+    "helpers:pinGitHubActionDigests",
+    ":pinDevDependencies"
+  ],
+  "labels": ["dependencies"],
+  "schedule": ["before 9am on Monday"],
+  "timezone": "America/Los_Angeles",
+  "gomod": {
+    "enabled": true,
+    "postUpdateOptions": ["gomodTidy"]
+  },
+  "dockerfile": {
+    "enabled": true
+  },
+  "github-actions": {
+    "enabled": true
+  },
+  "npm": {
+    "enabled": true,
+    "fileMatch": ["npm-package/package.json"]
+  },
+  "packageRules": [
+    {
+      "description": "Automerge patch and minor updates for stable deps",
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "matchCurrentVersion": "!/^0/",
+      "automerge": true
+    },
+    {
+      "description": "Group Go x/ stdlib packages",
+      "matchPackagePrefixes": ["golang.org/x/"],
+      "groupName": "Go x/ packages"
+    },
+    {
+      "description": "Group Charm ecosystem packages",
+      "matchPackagePrefixes": ["github.com/charmbracelet/"],
+      "groupName": "Charm TUI packages"
+    },
+    {
+      "description": "Group GitHub Actions updates",
+      "matchManagers": ["github-actions"],
+      "groupName": "GitHub Actions"
+    },
+    {
+      "description": "Do not automerge major updates",
+      "matchUpdateTypes": ["major"],
+      "automerge": false
+    }
+  ]
+}


### PR DESCRIPTION
## ⚙️ Required Setup (Repo Owner)

This PR adds the config file, but Renovate won't activate until the GitHub App is installed. After merging:

### 1. Install the Renovate GitHub App
1. Go to **https://github.com/apps/renovate**
2. Click **Install**
3. Select the **steveyegge** account (or org)
4. Choose **"Only select repositories"** → select **gastown**
5. Click **Install**
6. Renovate will create an onboarding PR within minutes confirming it detected all dependencies

### 2. Enable Dependabot Security Alerts (complementary)
1. Go to **https://github.com/steveyegge/gastown/settings/security_analysis**
2. Enable **Dependency graph** (if not already on)
3. Enable **Dependabot alerts**
4. Optionally enable **Dependabot security updates** for automated CVE fix PRs

This gives a hybrid approach: Renovate handles version updates on a weekly schedule, Dependabot handles urgent CVE alerts in real-time.

---

## Summary

Gastown has no automated dependency management. Dependencies are updated manually, which has led to version drift:

- `actions/checkout` pinned to **v4** in `release.yml` but **v6** everywhere else
- Go version: **1.23** (release.yml) vs **1.24** (CI) vs **1.24.2** (go.mod) vs **1.25** (Dockerfile.e2e)
- `golangci-lint`: uses `latest` (unpinned)
- Dolt: cloned from main branch (no version pin)

This PR adds a `renovate.json` config to enable [Renovate](https://github.com/apps/renovate) for automated dependency update PRs.

## Related Issue

N/A — proactive infrastructure improvement.

## Changes

- Add `renovate.json` with config covering all dependency types:
  - **Go modules** — with `gomodTidy` post-update
  - **GitHub Actions** — pinned to SHA digests via `helpers:pinGitHubActionDigests`
  - **Docker base images** (e.g., `golang:1.25-alpine` in `Dockerfile.e2e`)
  - **npm** (`npm-package/package.json`)
- **Weekly Monday schedule** (before 9am PT) to batch updates and reduce noise
- **Automerge** enabled for minor/patch/pin/digest updates on stable (≥1.0) deps
- **Dependency grouping** to reduce PR count:
  - Charm TUI packages (`github.com/charmbracelet/*`)
  - Go x/ stdlib packages (`golang.org/x/*`)
  - GitHub Actions (all grouped into one PR)
- **Major version updates** require manual review (no automerge)

## Testing

- [x] JSON validated (schema-compliant)
- [ ] Renovate onboarding PR appears after app install (post-merge verification)
- [ ] Dependency Dashboard issue created by Renovate

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)