### PR TITLE
fix(web): data race in ConvoyHandler when fetch timeout fires

### DIFF
--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -211,6 +211,9 @@ func (h *ConvoyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		// All fetches completed
 	case <-ctx.Done():
 		log.Printf("dashboard: fetch timeout after %v", h.fetchTimeout)
+		// Goroutines may still be writing to shared result variables.
+		// Wait for them to finish to avoid a data race on read below.
+		<-done
 	}
 
 	// Compute summary from already-fetched data

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -1074,8 +1074,9 @@ func TestConvoyHandler_TemplateErrorReturns500(t *testing.T) {
 
 	// Create handler with the failing template
 	handler := &ConvoyHandler{
-		fetcher:  &MockConvoyFetcher{Convoys: []ConvoyRow{}},
-		template: tmpl,
+		fetcher:      &MockConvoyFetcher{Convoys: []ConvoyRow{}},
+		template:     tmpl,
+		fetchTimeout: 5 * time.Second,
 	}
 
 	req := httptest.NewRequest("GET", "/", nil)


### PR DESCRIPTION
## Summary

Fix a data race in `ConvoyHandler.ServeHTTP` detected by `-race` in CI. When the
fetch timeout fires, goroutines may still be writing to shared result variables
while the main goroutine reads them in `computeSummary`.

## Related Issue

Pre-existing flaky failure in CI: `TestConvoyHandler_TemplateErrorReturns500`

## Changes

- **`internal/web/handler.go`**: After the timeout `select` case, wait for all
  fetch goroutines to finish (`<-done`) before reading their results. This ensures
  no concurrent writes when `computeSummary` and `ConvoyData` read the variables.
- **`internal/web/handler_test.go`**: Set `fetchTimeout: 5 * time.Second` in
  `TestConvoyHandler_TemplateErrorReturns500` so it doesn't use a zero timeout
  (which creates an already-expired context and always takes the timeout path —
  this test is about template errors, not timeouts).

## Testing

- [x] Unit tests pass (`go test ./internal/web/...`)
- [x] Race detector clean (`go test -race -count=5 -run TestConvoyHandler_TemplateErrorReturns500 ./internal/web/...`)
- [x] Full web package race-clean (`go test -race -count=3 ./internal/web/...`)

## Checklist

- [x] Code follows project style
- [x] No breaking changes
- [x] Minimal fix — 3 lines of production code, 2 lines in test