### PR TITLE
fix(doctor): prevent killing non-gastown tmux sessions

### DIFF
--- a/internal/doctor/orphan_check_test.go
+++ b/internal/doctor/orphan_check_test.go
@@ -105,12 +105,12 @@ func TestIsCrewSession(t *testing.T) {
 		session string
 		want    bool
 	}{
-		{"gt-crew-joe", true},   // gastown crew (prefix: gt)
-		{"bd-crew-max", true},   // beads crew (prefix: bd)
-		{"nif-crew-a", true},    // niflheim crew (prefix: nif)
-		{"gt-witness", false},   // witness, not crew
-		{"gt-refinery", false},  // refinery, not crew
-		{"gt-polecat1", false},  // polecat, not crew
+		{"gt-crew-joe", true},  // gastown crew (prefix: gt)
+		{"bd-crew-max", true},  // beads crew (prefix: bd)
+		{"nif-crew-a", true},   // niflheim crew (prefix: nif)
+		{"gt-witness", false},  // witness, not crew
+		{"gt-refinery", false}, // refinery, not crew
+		{"gt-polecat1", false}, // polecat, not crew
 		{"hq-deacon", false},
 		{"hq-mayor", false},
 		{"other-session", false},
@@ -146,16 +146,16 @@ func TestOrphanSessionCheck_IsValidSession(t *testing.T) {
 		{"hq-boot", true},
 
 		// Valid rig sessions (using rig prefixes)
-		{"gt-witness", true},    // gastown witness (prefix: gt)
-		{"gt-refinery", true},   // gastown refinery
-		{"gt-polecat1", true},   // gastown polecat
-		{"bd-witness", true},    // beads witness (prefix: bd)
-		{"bd-refinery", true},   // beads refinery
-		{"bd-crew-max", true},   // beads crew
+		{"gt-witness", true},  // gastown witness (prefix: gt)
+		{"gt-refinery", true}, // gastown refinery
+		{"gt-polecat1", true}, // gastown polecat
+		{"bd-witness", true},  // beads witness (prefix: bd)
+		{"bd-refinery", true}, // beads refinery
+		{"bd-crew-max", true}, // beads crew
 
 		// Invalid rig sessions (unknown prefix/rig)
-		{"zz-witness", false},   // unknown prefix
-		{"xx-refinery", false},  // unknown prefix
+		{"zz-witness", false},  // unknown prefix
+		{"xx-refinery", false}, // unknown prefix
 
 		// Non-GT sessions fail format validation
 		{"other-session", false},
@@ -319,9 +319,9 @@ func TestOrphanSessionCheck_FixProtectsCrewSessions(t *testing.T) {
 
 	// Simulate cached orphan sessions including a crew session
 	check.orphanSessions = []string{
-		"gt-crew-max",      // Crew - should be protected
-		"zz-witness",       // Not crew - would be killed
-		"nif-crew-codex1",  // Crew - should be protected
+		"gt-crew-max",     // Crew - should be protected
+		"zz-witness",      // Not crew - would be killed
+		"nif-crew-codex1", // Crew - should be protected
 	}
 
 	// Verify isCrewSession correctly identifies crew sessions
@@ -387,8 +387,8 @@ func TestOrphanSessionCheck_HQSessions(t *testing.T) {
 
 	lister := &mockSessionLister{
 		sessions: []string{
-			"hq-mayor",   // valid: headquarters mayor session
-			"hq-deacon",  // valid: headquarters deacon session
+			"hq-mayor",  // valid: headquarters mayor session
+			"hq-deacon", // valid: headquarters deacon session
 		},
 	}
 	check := NewOrphanSessionCheckWithSessionLister(lister)
@@ -429,25 +429,24 @@ func TestOrphanSessionCheck_Run_Deterministic(t *testing.T) {
 
 	lister := &mockSessionLister{
 		sessions: []string{
-			"gt-witness",          // valid: gastown rig exists (prefix "gt")
-			"gt-polecat1",         // valid: gastown rig exists
-			"bd-refinery",         // valid: beads rig exists (prefix "bd")
-			"hq-mayor",            // valid: hq-mayor is recognized
-			"hq-deacon",           // valid: hq-deacon is recognized
-			"zz-witness",          // orphan: unknown prefix/rig
-			"xx-crew-joe",         // orphan: unknown prefix/rig
-			"random-session",      // parsed as polecat with unknown prefix, orphan
+			"gt-witness",     // valid: gastown rig exists (prefix "gt")
+			"gt-polecat1",    // valid: gastown rig exists
+			"bd-refinery",    // valid: beads rig exists (prefix "bd")
+			"hq-mayor",       // valid: hq-mayor is recognized
+			"hq-deacon",      // valid: hq-deacon is recognized
+			"zz-witness",     // ignored: unknown prefix, not a gastown session
+			"xx-crew-joe",    // ignored: unknown prefix, not a gastown session
+			"random-session", // ignored: unknown prefix, not a gastown session
 		},
 	}
 	check := NewOrphanSessionCheckWithSessionLister(lister)
 	result := check.Run(&CheckContext{TownRoot: townRoot})
 
-	if result.Status != StatusWarning {
-		t.Fatalf("expected StatusWarning, got %v: %s", result.Status, result.Message)
+	if result.Status != StatusOK {
+		t.Fatalf("expected StatusOK, got %v: %s", result.Status, result.Message)
 	}
 
-	// Expect 3 orphans: zz-witness, xx-crew-joe, random-session (all have unknown rigs)
-	if len(check.orphanSessions) != 3 {
-		t.Fatalf("expected 3 orphans, got %d: %v", len(check.orphanSessions), check.orphanSessions)
+	if len(check.orphanSessions) != 0 {
+		t.Fatalf("expected 0 orphans (unknown prefixes are ignored), got %d: %v", len(check.orphanSessions), check.orphanSessions)
 	}
 }

--- a/internal/session/identity_test.go
+++ b/internal/session/identity_test.go
@@ -148,25 +148,17 @@ func TestParseSessionName(t *testing.T) {
 			wantPrefix: "sky",
 		},
 
-		// Unknown prefix (fallback: prefix = first segment, rig = prefix)
+		// Error cases: unknown prefixes should fail (not fall back to splitting on dash)
 		{
-			name:       "unknown prefix polecat",
-			session:    "zz-alpha",
-			wantRole:   RolePolecat,
-			wantRig:    "zz",
-			wantName:   "alpha",
-			wantPrefix: "zz",
+			name:    "unknown prefix polecat",
+			session: "zz-alpha",
+			wantErr: true,
 		},
 		{
-			name:       "unknown prefix witness",
-			session:    "foo-witness",
-			wantRole:   RoleWitness,
-			wantRig:    "foo",
-			wantName:   "",
-			wantPrefix: "foo",
+			name:    "unknown prefix witness",
+			session: "foo-witness",
+			wantErr: true,
 		},
-
-		// Error cases
 		{
 			name:    "empty string",
 			session: "",

--- a/internal/session/registry.go
+++ b/internal/session/registry.go
@@ -171,7 +171,9 @@ func IsKnownSession(sess string) bool {
 // matchPrefix finds the prefix in a session name suffix using the registry.
 // Returns the prefix and the remaining string after the prefix dash.
 // Tries longest prefix match first.
-// Falls back to splitting on the first dash if no registry match.
+// Only matches sessions with registered prefixes - does NOT fall back to
+// splitting on dashes, as that would incorrectly match non-gastown sessions
+// (e.g., "gs-1923" or "dotfiles-main" would be parsed as gastown sessions).
 func (r *PrefixRegistry) matchPrefix(session string) (prefix, rest string, matched bool) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
@@ -182,12 +184,6 @@ func (r *PrefixRegistry) matchPrefix(session string) (prefix, rest string, match
 		if strings.HasPrefix(session, candidate) {
 			return p, session[len(candidate):], true
 		}
-	}
-
-	// Fallback: split on first dash
-	idx := strings.Index(session, "-")
-	if idx > 0 && idx < len(session)-1 {
-		return session[:idx], session[idx+1:], false
 	}
 
 	return "", "", false


### PR DESCRIPTION
## Summary

- Remove fallback in `matchPrefix()` that incorrectly matched any session with a dash as a gastown session
- Sessions like `gs-1923` or `dotfiles-main` were being parsed as polecats and killed by `gt doctor --fix`
- Now only sessions with registered prefixes (gt-, bd-, hq-, etc.) are recognized as gastown sessions

## Problem

The `matchPrefix()` function in `registry.go` had a fallback that split ANY session name on the first dash. This meant personal tmux sessions like `gs-1923`, `dotfiles-main`, or any `<name>-<suffix>` pattern would be:

1. Parsed as a gastown session (prefix = first segment)
2. Flagged as "orphan" (since the prefix wasn't a registered rig)
3. **Killed** by `gt doctor --fix`

## Solution

Remove the fallback logic so only sessions with registered prefixes or `hq-*` patterns are recognized as gastown sessions. Unknown sessions are now ignored entirely.

## Testing

- Updated existing tests to expect unknown prefixes to fail parsing
- Verified `gt doctor` no longer flags personal sessions
- All `./internal/session/...` and `./internal/doctor/...` tests pass