### PR TITLE
fix(done): handle already-deleted molecules gracefully

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -1186,13 +1187,21 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, _ string) { // issueID unus
 						break
 					} else {
 						lastErr = err
+						// If the molecule doesn't exist (already burned/deleted),
+						// treat it as already closed and stop retrying.
+						if errors.Is(err, beads.ErrNotFound) {
+							moleculeClosed = true
+							fmt.Fprintf(os.Stderr, "Warning: attached molecule %s not found (already burned/deleted), treating as closed\n", attachment.AttachedMolecule)
+							break
+						}
 						if attempt < 2 {
 							time.Sleep(time.Duration(100<<attempt) * time.Millisecond) // 100ms, 200ms
 						}
 					}
 				}
 				if !moleculeClosed {
-					// All retries failed - skip closing hooked bead (it's blocked by the molecule)
+					// All retries failed with non-"not found" errors - skip closing
+					// hooked bead (it's blocked by the molecule)
 					fmt.Fprintf(os.Stderr, "Warning: couldn't close attached molecule %s after 3 attempts: %v\n", attachment.AttachedMolecule, lastErr)
 					// Don't try to close hookedBeadID - it will fail because it's still blocked
 					// The Witness will clean up orphaned state


### PR DESCRIPTION
## Summary

- Handle `ErrNotFound` when closing attached molecules in `gt done`
- Treat already-deleted/burned molecules as successfully closed instead of retrying

## Problem

When a molecule is burned or deleted before `gt done` runs, the close attempt fails with `ErrNotFound`. The code would:

1. Retry 3 times unnecessarily
2. Print a warning suggesting the close failed
3. Skip closing the hooked bead (treating it as blocked)

## Solution

Check for `ErrNotFound` in the retry loop and treat it as success - if the molecule doesn't exist, it's effectively already closed. This avoids unnecessary retries and misleading warnings.