### PR TITLE
fix(molecule): update agent heartbeat on idle cycle timeout

### DIFF
--- a/internal/cmd/molecule_await_signal.go
+++ b/internal/cmd/molecule_await_signal.go
@@ -209,6 +209,13 @@ func runMoleculeAwaitSignal(cmd *cobra.Command, args []string) error {
 		} else {
 			result.IdleCycles = newIdleCycles
 		}
+		// Update last_activity so watchers know agent is still alive
+		if err := updateAgentHeartbeat(awaitSignalAgentBead, beadsDir); err != nil {
+			if !awaitSignalQuiet {
+				fmt.Printf("%s Failed to update agent heartbeat: %v\n",
+					style.Dim.Render("⚠"), err)
+			}
+		}
 		// Clear the backoff window — timeout completed normally
 		_ = clearAgentBackoffUntil(awaitSignalAgentBead, beadsDir)
 	} else if result.Reason == "signal" && awaitSignalAgentBead != "" {


### PR DESCRIPTION
## Summary

- Update `last_activity` timestamp when `await-signal` times out due to idle cycles
- Keeps watchers informed that the agent is still alive even when idle

## Problem

When an agent is idle (no signals arriving), `await-signal` would time out but not update the agent's `last_activity` timestamp. Watchers monitoring agent health could incorrectly assume the agent was dead/stuck.

## Solution

Call `updateAgentHeartbeat()` on idle cycle timeout to refresh the `last_activity` timestamp, signaling to watchers that the agent is still responsive.