### PR TITLE
fix(prime): use agent bead hook_bead field as primary hook source

### DIFF
--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -403,6 +403,8 @@ func checkSlungWork(ctx RoleContext) bool {
 }
 
 // findAgentWork looks up hooked or in-progress beads assigned to this agent.
+// Primary: reads hook_bead from the agent bead (same strategy as detectSessionState/gt hook).
+// Fallback: queries by assignee for agents without an agent bead.
 // Returns nil if no work is found.
 func findAgentWork(ctx RoleContext) *beads.Issue {
 	agentID := getAgentIdentity(ctx)
@@ -411,6 +413,23 @@ func findAgentWork(ctx RoleContext) *beads.Issue {
 	}
 
 	b := beads.New(ctx.WorkDir)
+
+	// Primary: agent bead's hook_bead field (authoritative, set by bd slot set during sling)
+	agentBeadID := buildAgentBeadID(agentID, ctx.Role, ctx.TownRoot)
+	if agentBeadID != "" {
+		agentBeadDir := beads.ResolveHookDir(ctx.TownRoot, agentBeadID, ctx.WorkDir)
+		ab := beads.New(agentBeadDir)
+		if agentBead, err := ab.Show(agentBeadID); err == nil && agentBead != nil && agentBead.HookBead != "" {
+			hookBeadDir := beads.ResolveHookDir(ctx.TownRoot, agentBead.HookBead, ctx.WorkDir)
+			hb := beads.New(hookBeadDir)
+			if hookBead, err := hb.Show(agentBead.HookBead); err == nil && hookBead != nil &&
+				(hookBead.Status == beads.StatusHooked || hookBead.Status == "in_progress") {
+				return hookBead
+			}
+		}
+	}
+
+	// Fallback: query by assignee
 	hookedBeads, err := b.List(beads.ListOptions{
 		Status:   beads.StatusHooked,
 		Assignee: agentID,


### PR DESCRIPTION
## Summary

- Use agent bead's `hook_bead` DB column as primary source for detecting hooked work
- Falls back to querying by assignee if `hook_bead` is not set

## Problem

`detectSessionState()` was querying beads by assignee to find hooked work, which could be slow or return stale results. The authoritative hook information is already stored in the agent bead's `hook_bead` field (set by `bd slot` during sling).

## Solution

Read `hook_bead` from the agent bead first (same strategy as `gt hook` uses). Only fall back to the assignee query if the agent bead doesn't have a `hook_bead` set.

This aligns `gt prime` with `gt hook` for consistent hook detection.