### PR TITLE
Fix: Use correct .opencode/plugins directory for OpenCode hooks

### DIFF
--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -98,7 +98,7 @@ type AgentPresetInfo struct {
 	// Empty or "none" means no hooks support.
 	HooksProvider string `json:"hooks_provider,omitempty"`
 
-	// HooksDir is the directory for hooks/settings (e.g., ".claude", ".opencode/plugin").
+	// HooksDir is the directory for hooks/settings (e.g., ".claude", ".opencode/plugins").
 	HooksDir string `json:"hooks_dir,omitempty"`
 
 	// HooksSettingsFile is the settings/plugin filename (e.g., "settings.json", "gastown.js").
@@ -275,7 +275,7 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		SessionIDEnv:        "",                                   // OpenCode manages sessions internally
 		ResumeFlag:          "",                                   // No resume support yet
 		ResumeStyle:         "",
-		SupportsHooks:       true, // Uses .opencode/plugin/gastown.js
+		SupportsHooks:       true, // Uses .opencode/plugins/gastown.js
 		SupportsForkSession: false,
 		NonInteractive: &NonInteractiveConfig{
 			Subcommand: "run",
@@ -285,7 +285,7 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		PromptMode:        "none",
 		ConfigDir:         ".opencode",
 		HooksProvider:     "opencode",
-		HooksDir:          ".opencode/plugin",
+		HooksDir:          ".opencode/plugins",
 		HooksSettingsFile: "gastown.js",
 		ReadyDelayMs:      8000,
 		InstructionsFile:  "AGENTS.md",


### PR DESCRIPTION
## Summary
Fixes OpenCode plugin loading by correcting hooks directory from singular to plural.

## Changes
- `internal/config/agents.go`: Update `HooksDir` from `.opencode/plugin` to `.opencode/plugins`
- Update related comments to reflect correct path

## Problem
OpenCode CLI expects plugins in `.opencode/plugins/` (per [official docs](https://opencode.ai/docs/plugins/)), but Gastown was installing to `.opencode/plugin/`. This caused:
- Hooks to never load
- `session.created` event to never fire
- Persistent agents (mayor) to exit immediately (~10s)

## Verification
- Built and tested locally with OpenCode
- Mayor now stays running (5+ minutes vs. 10 seconds before)
- All tests pass: `go test ./...`

## Regression Note
Bug introduced in commit `0ae16ec3` during agent preset registry refactor.

## Testing
- [x] `go test ./...` passes
- [x] Manual testing with OpenCode runtime
- [x] Verified mayor stays running

 Closes Issue [#1614](https://github.com/steveyegge/gastown/issues/1614)