### PR TITLE
ci: auto-remove status labels on author response and triage

### DIFF
--- a/.github/workflows/remove-needs-info.yml
+++ b/.github/workflows/remove-needs-info.yml
@@ -1,0 +1,57 @@
+name: Remove needs-info on author response
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_target:
+    types: [synchronize]
+
+jobs:
+  remove-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Remove needs-info / needs-repro on author response
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const labels = ['status/needs-info', 'status/needs-repro'];
+
+            // Determine issue/PR number and author
+            let number, author;
+            if (context.eventName === 'issue_comment') {
+              number = context.payload.issue.number;
+              author = context.payload.issue.user.login;
+
+              // Only act when the original author comments
+              if (context.payload.comment.user.login !== author) return;
+            } else {
+              // pull_request_target / synchronize
+              number = context.payload.pull_request.number;
+              author = context.payload.pull_request.user.login;
+
+              // Only act when the PR author pushes
+              if (context.payload.sender.login !== author) return;
+            }
+
+            // Get current labels on the issue/PR
+            const current = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+            });
+            const currentNames = current.data.map(l => l.name);
+
+            for (const label of labels) {
+              if (!currentNames.includes(label)) continue;
+
+              await github.rest.issues.removeLabel({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: number,
+                name: label,
+              });
+              console.log(`Removed '${label}' from #${number}`);
+            }

--- a/.github/workflows/remove-needs-triage.yml
+++ b/.github/workflows/remove-needs-triage.yml
@@ -1,0 +1,44 @@
+name: Remove needs-triage when triaged
+
+on:
+  issues:
+    types: [labeled]
+  pull_request_target:
+    types: [labeled]
+
+jobs:
+  remove-triage-label:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+      pull-requests: write
+    steps:
+      - name: Remove needs-triage when a non-status label is added
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const added = context.payload.label.name;
+
+            // Don't trigger on status/ labels themselves (needs-triage,
+            // needs-info, needs-repro, etc.)
+            if (added.startsWith('status/')) return;
+
+            const number = context.issue?.number || context.payload.pull_request?.number;
+            const target = 'status/needs-triage';
+
+            // Check if needs-triage is present
+            const current = await github.rest.issues.listLabelsOnIssue({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+            });
+
+            if (!current.data.some(l => l.name === target)) return;
+
+            await github.rest.issues.removeLabel({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              name: target,
+            });
+            console.log(`Removed '${target}' from #${number} (triaged with '${added}')`);


### PR DESCRIPTION
## Summary
Add two GitHub Actions workflows that automate status label cleanup, reducing manual label management for maintainers.

## Related Issue
N/A — quality-of-life improvement for issue/PR triage workflow.

## Changes
- **`remove-needs-info.yml`**: Removes `status/needs-info` and `status/needs-repro` when the issue/PR author comments or pushes new commits to their PR. Complements the existing `close-stale-needs.yml` that auto-closes after 14 days of no response.
- **`remove-needs-triage.yml`**: Removes `status/needs-triage` when a maintainer adds any non-`status/` label (e.g., `bug`, `enhancement`, `area/*`), indicating the issue has been triaged. Complements the existing `triage-label.yml` that auto-adds `status/needs-triage` on open.

## Testing
- [ ] Unit tests pass (`go test ./...`) — N/A (workflow-only change, no Go code)
- [x] Manual testing performed — workflow logic reviewed against GitHub Actions event schemas

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)