### PR TITLE
fix(ci): pin golangci-lint to v2.9.0 to unblock PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,7 +233,7 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@v9
         with:
-          version: latest
+          version: v2.9.0
           args: --timeout=5m
 
   integration:


### PR DESCRIPTION
## Summary
Pin golangci-lint to v2.9.0 to unblock contributor PRs that are failing lint on files they didn't touch.

## Related Issue
Unblocks PR #1613 (and any other open PRs hitting the same failure).

## Changes
- Pin `golangci/golangci-lint-action` from `version: latest` to `version: v2.9.0` in `ci.yml`

## Root Cause
`golangci-lint v2.10.1` was released between the last green main run and PR #1613's CI run. The new version adds stricter `gosec` rules (G115, G117, G702, G703, G704, G705) that flag 16 pre-existing issues across `internal/activity`, `internal/daemon`, `internal/doctor`, `internal/doltserver`, `internal/git`, `internal/util`, `internal/version`, `internal/wasteland`, and `internal/web`. None of these files are touched by PR #1613.

The lint fixes for v2.10.1 will be done as a separate PR to bump the pinned version.

## Testing
- [ ] Unit tests pass (`go test ./...`) — N/A (CI config change only)
- [x] Manual testing performed — verified main last passed with v2.9.0 and PR #1613 failed with v2.10.1

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)