### PR TITLE
Fix: Enable startup prompts for OpenCode runtime

### DIFF
--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -282,7 +282,7 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 			OutputFlag: "--format json",
 		},
 		// Runtime defaults
-		PromptMode:        "none",
+		PromptMode:        "arg",
 		ConfigDir:         ".opencode",
 		HooksProvider:     "opencode",
 		HooksDir:          ".opencode/plugin",


### PR DESCRIPTION
## Problem

OpenCode was configured with `PromptMode: 'none'`, which caused startup prompts (like 'Run gt prime --hook and begin patrol') to be completely ignored. This broke autonomous agents like refinery that rely on initial instructions.

## Solution

Change `PromptMode` from `'none'` to `'arg'` for the OpenCode preset. This enables `--prompt` flag usage for OpenCode CLI, matching the behavior of other agents like Claude.

## Changes

- `internal/config/agents.go`: Change `PromptMode: "none"` → `PromptMode: "arg"`

## Testing

- [x] Verified refinery receives patrol instructions on startup
- [x] Verified OpenCode behaves like other agents for prompt handling
- [x] All unit tests pass (`go test ./...`)

## Related

- This fix is independent of the HooksDir fix (PR #1613)
- Both fixes are needed for full OpenCode support
- Together with the HooksDir fix, OpenCode now works for all Gastown roles (mayor, refinery, etc.)
