### PR TITLE
fix(doltserver): clean up dolt_branch_control on RemoveDatabase

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1404,11 +1404,17 @@ func RemoveDatabase(townRoot, dbName string) error {
 		return fmt.Errorf("database %q not found at %s", dbName, dbPath)
 	}
 
-	// If server is running, DROP the database first
+	// If server is running, DROP the database first and clean up branch control entries.
+	// In Dolt 1.81.x, DROP DATABASE does not automatically remove dolt_branch_control
+	// entries for the dropped database. These stale entries cause the database directory
+	// to be recreated when connections reference the database name (gt-zlv7l).
 	running, _, _ := IsRunning(townRoot)
 	if running {
 		// Try to DROP — ignore errors (database might not be loaded)
 		_ = serverExecSQL(townRoot, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", dbName))
+		// Explicitly clean up branch control entries to prevent the database from being
+		// recreated on subsequent connections. `database` is a reserved word, so backtick-quote it.
+		_ = serverExecSQL(townRoot, fmt.Sprintf("DELETE FROM dolt_branch_control WHERE `database` = '%s'", dbName))
 	}
 
 	// Remove the directory


### PR DESCRIPTION
## Summary

- `RemoveDatabase()` calls `DROP DATABASE IF EXISTS` but in Dolt 1.81.x, this does not remove the corresponding `dolt_branch_control` entries for the dropped database
- These stale entries cause the database directory to be recreated when any connection references the database name, resulting in a phantom orphan that resurfaces after every `gt dolt cleanup`
- Root cause discovered while investigating gt-zlv7l (gastown db routing), where `beads_tr` kept reappearing after cleanup

**Fix**: add explicit `DELETE FROM dolt_branch_control WHERE database = '<dbName>'` after `DROP DATABASE IF EXISTS` in `RemoveDatabase()`.

## Reproduction

1. Create an orphaned database with polecat branch control entries
2. Run `gt dolt cleanup` to remove it
3. Within minutes, the database reappears (Dolt recreates it from `branch_control.db`)

## Test plan

- [ ] Existing `TestRemoveDatabase_RemovesDirectory` still passes (directory removal)
- [ ] All `go test ./internal/doltserver/...` pass
- [ ] After deploying, `gt dolt cleanup` removes orphaned databases permanently (no resurrection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)