### PR TITLE
fix(test): use unique prefixes in TestFindRigSessions

### DIFF
--- a/internal/cmd/rig_test.go
+++ b/internal/cmd/rig_test.go
@@ -62,8 +62,10 @@ func TestIsGitRemoteURL(t *testing.T) {
 func setupRigTestRegistry(t *testing.T) {
 	t.Helper()
 	reg := session.NewPrefixRegistry()
-	reg.Register("tr", "testrig1223")
-	reg.Register("or", "otherrig")
+	// Use zz-prefixed names to avoid collisions with real rig sessions
+	// (e.g. "tr" collides with production rigs that use that prefix).
+	reg.Register("zztr", "testrig1223")
+	reg.Register("zzor", "otherrig")
 	old := session.DefaultRegistry()
 	session.SetDefaultRegistry(reg)
 	t.Cleanup(func() { session.SetDefaultRegistry(old) })
@@ -77,14 +79,14 @@ func TestFindRigSessions(t *testing.T) {
 
 	tm := tmux.NewTmux()
 
-	// Create sessions that match our test rig prefix (tr- for testrig1223)
+	// Create sessions that match our test rig prefix (zztr- for testrig1223)
 	matching := []string{
-		"tr-witness",
-		"tr-refinery",
-		"tr-alpha",
+		"zztr-witness",
+		"zztr-refinery",
+		"zztr-alpha",
 	}
-	// Create a non-matching session (or- for otherrig)
-	nonMatching := "or-witness"
+	// Create a non-matching session (zzor- for otherrig)
+	nonMatching := "zzor-witness"
 
 	for _, name := range append(matching, nonMatching) {
 		_ = tm.KillSession(name) // clean up any leftovers


### PR DESCRIPTION
## Summary
Fix flaky `TestFindRigSessions` caused by session prefix collisions with real rigs.

## Related Issue
<!-- No existing issue -->

## Changes
- Change test session prefixes from `"tr"`/`"or"` to `"zztr"`/`"zzor"` in `setupRigTestRegistry` and `TestFindRigSessions`
- Follows the `zz`-prefix convention already used by `TestFindRigSessions_NoSessions`

## Testing
- [x] Unit tests pass (`go test ./internal/cmd/ -run TestFindRigSessions -v`)
- [x] Manual testing performed

### Root Cause
`TestFindRigSessions` registered `"tr"` as the test rig prefix and created sessions `tr-witness`, `tr-refinery`, `tr-alpha`. It then asserted exactly 3 sessions matched. However, real rig sessions with the same `tr-` prefix (e.g. `tr-rust`) exist on the host, causing the count assertion to fail:

```
rig_test.go:125: expected 3 sessions, got 4: [tr-alpha tr-refinery tr-rust tr-witness]
```

### Fix
Switch to `"zztr"`/`"zzor"` prefixes that won't collide with production rigs, following the `zz`-prefix convention already established in `TestFindRigSessions_NoSessions`.

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)