### PR TITLE
fix: add doctor check for stale task-dispatch hooks

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -83,6 +83,7 @@ Session hook checks:
   - session-hooks            Check settings.json use session-start.sh
   - claude-settings          Check Claude settings.json match templates (fixable)
   - deprecated-merge-queue-keys  Detect stale deprecated keys in merge_queue config (fixable)
+  - stale-task-dispatch      Detect stale task-dispatch guard in settings.json (fixable)
 
 Dolt checks:
   - dolt-binary              Check that dolt is installed and in PATH
@@ -212,6 +213,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewOrphanedAttachmentsCheck())
 
 	// Hooks sync check
+	d.Register(doctor.NewStaleTaskDispatchCheck())
 	d.Register(doctor.NewHooksSyncCheck())
 
 	// Dolt health checks

--- a/internal/doctor/stale_task_dispatch_check.go
+++ b/internal/doctor/stale_task_dispatch_check.go
@@ -1,0 +1,176 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/hooks"
+)
+
+// StaleTaskDispatchCheck detects settings.json files that still reference
+// the removed "gt tap guard task-dispatch" command. After the task-dispatch
+// guard was removed, existing Mayor settings.json files may retain stale
+// hook entries that invoke the deleted subcommand.
+type StaleTaskDispatchCheck struct {
+	FixableCheck
+	staleTargets []hooks.Target
+}
+
+// NewStaleTaskDispatchCheck creates a check for stale task-dispatch hook references.
+func NewStaleTaskDispatchCheck() *StaleTaskDispatchCheck {
+	return &StaleTaskDispatchCheck{
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "stale-task-dispatch",
+				CheckDescription: "Detect stale task-dispatch guard in settings.json",
+				CheckCategory:    CategoryHooks,
+			},
+		},
+	}
+}
+
+// containsTaskDispatch checks if a HooksConfig has any hook commands
+// referencing the removed task-dispatch guard.
+func containsTaskDispatch(cfg *hooks.HooksConfig) bool {
+	for _, entry := range cfg.PreToolUse {
+		for _, h := range entry.Hooks {
+			if strings.Contains(h.Command, "task-dispatch") {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// Run checks all managed settings.json files for stale task-dispatch references.
+func (c *StaleTaskDispatchCheck) Run(ctx *CheckContext) *CheckResult {
+	c.staleTargets = nil
+
+	targets, err := hooks.DiscoverTargets(ctx.TownRoot)
+	if err != nil {
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusWarning,
+			Message:  fmt.Sprintf("Failed to discover targets: %v", err),
+			Category: c.Category(),
+		}
+	}
+
+	var details []string
+	for _, target := range targets {
+		// Only check targets that have an existing settings.json
+		if _, statErr := os.Stat(target.Path); statErr != nil {
+			continue
+		}
+
+		current, err := hooks.LoadSettings(target.Path)
+		if err != nil {
+			details = append(details, fmt.Sprintf("%s: error loading: %v", target.DisplayKey(), err))
+			continue
+		}
+
+		if containsTaskDispatch(&current.Hooks) {
+			c.staleTargets = append(c.staleTargets, target)
+			details = append(details, fmt.Sprintf("%s: contains stale task-dispatch guard", target.DisplayKey()))
+		}
+	}
+
+	if len(c.staleTargets) == 0 {
+		return &CheckResult{
+			Name:     c.Name(),
+			Status:   StatusOK,
+			Message:  "No stale task-dispatch hooks found",
+			Category: c.Category(),
+		}
+	}
+
+	return &CheckResult{
+		Name:     c.Name(),
+		Status:   StatusWarning,
+		Message:  fmt.Sprintf("%d target(s) have stale task-dispatch guard", len(c.staleTargets)),
+		Details:  details,
+		FixHint:  "Run 'gt doctor --fix' or 'gt hooks sync' to regenerate settings.json files",
+		Category: c.Category(),
+	}
+}
+
+// stripTaskDispatch removes any PreToolUse entries whose hooks reference
+// the removed task-dispatch guard. This handles the case where an on-disk
+// hooks-override still contains the stale command — ComputeExpected would
+// re-inject it, so we strip it from the computed result before writing.
+func stripTaskDispatch(cfg *hooks.HooksConfig) *hooks.HooksConfig {
+	var cleaned []hooks.HookEntry
+	for _, entry := range cfg.PreToolUse {
+		var cleanedHooks []hooks.Hook
+		for _, h := range entry.Hooks {
+			if !strings.Contains(h.Command, "task-dispatch") {
+				cleanedHooks = append(cleanedHooks, h)
+			}
+		}
+		if len(cleanedHooks) > 0 {
+			entry.Hooks = cleanedHooks
+			cleaned = append(cleaned, entry)
+		}
+	}
+	cfg.PreToolUse = cleaned
+	return cfg
+}
+
+// Fix regenerates settings.json files that contain the stale task-dispatch guard.
+// After computing expected hooks, it strips any task-dispatch references that may
+// originate from on-disk hooks-overrides to ensure the fix converges.
+func (c *StaleTaskDispatchCheck) Fix(ctx *CheckContext) error {
+	if len(c.staleTargets) == 0 {
+		return nil
+	}
+
+	var errs []string
+	for _, target := range c.staleTargets {
+		expected, err := hooks.ComputeExpected(target.Key)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", target.DisplayKey(), err))
+			continue
+		}
+
+		// Strip task-dispatch from expected in case on-disk overrides re-inject it.
+		expected = stripTaskDispatch(expected)
+
+		current, err := hooks.LoadSettings(target.Path)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", target.DisplayKey(), err))
+			continue
+		}
+
+		current.Hooks = *expected
+
+		if current.EnabledPlugins == nil {
+			current.EnabledPlugins = make(map[string]bool)
+		}
+		current.EnabledPlugins["beads@beads-marketplace"] = false
+
+		claudeDir := filepath.Dir(target.Path)
+		if err := os.MkdirAll(claudeDir, 0755); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: creating dir: %v", target.DisplayKey(), err))
+			continue
+		}
+
+		data, err := hooks.MarshalSettings(current)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: marshal: %v", target.DisplayKey(), err))
+			continue
+		}
+		data = append(data, '\n')
+
+		if err := os.WriteFile(target.Path, data, 0644); err != nil {
+			errs = append(errs, fmt.Sprintf("%s: write: %v", target.DisplayKey(), err))
+			continue
+		}
+	}
+
+	if len(errs) > 0 {
+		return fmt.Errorf("%s", strings.Join(errs, "; "))
+	}
+	return nil
+}

--- a/internal/doctor/stale_task_dispatch_check_test.go
+++ b/internal/doctor/stale_task_dispatch_check_test.go
@@ -1,0 +1,291 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/hooks"
+)
+
+func TestStaleTaskDispatchCheck_Clean(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Create a mayor settings.json without task-dispatch
+	mayorDir := filepath.Join(tmpDir, "mayor", ".claude")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	settings := `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Bash(gh pr create*)",
+        "hooks": [{"type": "command", "command": "gt tap guard pr-workflow"}]
+      }
+    ]
+  }
+}
+`
+	if err := os.WriteFile(filepath.Join(mayorDir, "settings.json"), []byte(settings), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewStaleTaskDispatchCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK for clean settings, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestStaleTaskDispatchCheck_Stale(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Create a mayor settings.json WITH stale task-dispatch
+	mayorDir := filepath.Join(tmpDir, "mayor", ".claude")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	settings := `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [{"type": "command", "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard task-dispatch"}]
+      },
+      {
+        "matcher": "Bash(gh pr create*)",
+        "hooks": [{"type": "command", "command": "gt tap guard pr-workflow"}]
+      }
+    ]
+  }
+}
+`
+	if err := os.WriteFile(filepath.Join(mayorDir, "settings.json"), []byte(settings), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewStaleTaskDispatchCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning for stale settings, got %v: %s", result.Status, result.Message)
+	}
+	if len(check.staleTargets) != 1 {
+		t.Errorf("expected 1 stale target, got %d", len(check.staleTargets))
+	}
+}
+
+func TestStaleTaskDispatchCheck_Fix(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Create a mayor settings.json WITH stale task-dispatch
+	mayorDir := filepath.Join(tmpDir, "mayor", ".claude")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	settings := `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [{"type": "command", "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard task-dispatch"}]
+      }
+    ]
+  }
+}
+`
+	settingsPath := filepath.Join(mayorDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(settings), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewStaleTaskDispatchCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	// Run to detect
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning, got %v", result.Status)
+	}
+
+	// Fix
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+
+	// Verify the fix removed the stale entry
+	fixed, err := hooks.LoadSettings(settingsPath)
+	if err != nil {
+		t.Fatalf("failed to load fixed settings: %v", err)
+	}
+
+	if containsTaskDispatch(&fixed.Hooks) {
+		t.Error("fixed settings still contain task-dispatch")
+	}
+
+	// Re-run check should pass
+	result = check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK after fix, got %v: %s", result.Status, result.Message)
+	}
+}
+
+// TestStaleTaskDispatchCheck_FixConvergesWithOverride verifies that Fix()
+// converges even when an on-disk hooks-override re-injects the task-dispatch
+// command via ComputeExpected.
+func TestStaleTaskDispatchCheck_FixConvergesWithOverride(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Create an on-disk mayor override that contains task-dispatch
+	overrideDir := filepath.Join(tmpDir, ".gt", "hooks-overrides")
+	if err := os.MkdirAll(overrideDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	override := `{
+  "PreToolUse": [
+    {
+      "matcher": "Task",
+      "hooks": [{"type": "command", "command": "gt tap guard task-dispatch"}]
+    }
+  ]
+}
+`
+	if err := os.WriteFile(filepath.Join(overrideDir, "mayor.json"), []byte(override), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a mayor settings.json WITH stale task-dispatch
+	mayorDir := filepath.Join(tmpDir, "mayor", ".claude")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	settings := `{
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Task",
+        "hooks": [{"type": "command", "command": "gt tap guard task-dispatch"}]
+      }
+    ]
+  }
+}
+`
+	settingsPath := filepath.Join(mayorDir, "settings.json")
+	if err := os.WriteFile(settingsPath, []byte(settings), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewStaleTaskDispatchCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	// Run to detect
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning, got %v", result.Status)
+	}
+
+	// Fix should converge even though override re-injects task-dispatch
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+
+	// Verify the fix stripped the stale entry despite the override
+	fixed, err := hooks.LoadSettings(settingsPath)
+	if err != nil {
+		t.Fatalf("failed to load fixed settings: %v", err)
+	}
+
+	if containsTaskDispatch(&fixed.Hooks) {
+		t.Error("fixed settings still contain task-dispatch despite stripTaskDispatch")
+	}
+
+	// Re-run check should pass
+	result = check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK after fix, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestContainsTaskDispatch(t *testing.T) {
+	tests := []struct {
+		name     string
+		config   hooks.HooksConfig
+		expected bool
+	}{
+		{
+			name:     "empty config",
+			config:   hooks.HooksConfig{},
+			expected: false,
+		},
+		{
+			name: "no task-dispatch",
+			config: hooks.HooksConfig{
+				PreToolUse: []hooks.HookEntry{
+					{Matcher: "Bash(gh pr create*)", Hooks: []hooks.Hook{{Type: "command", Command: "gt tap guard pr-workflow"}}},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "has task-dispatch",
+			config: hooks.HooksConfig{
+				PreToolUse: []hooks.HookEntry{
+					{Matcher: "Task", Hooks: []hooks.Hook{{Type: "command", Command: "gt tap guard task-dispatch"}}},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "has task-dispatch with path setup",
+			config: hooks.HooksConfig{
+				PreToolUse: []hooks.HookEntry{
+					{Matcher: "Task", Hooks: []hooks.Hook{{Type: "command", Command: "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard task-dispatch"}}},
+				},
+			},
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containsTaskDispatch(&tt.config); got != tt.expected {
+				t.Errorf("containsTaskDispatch() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestStripTaskDispatch(t *testing.T) {
+	cfg := &hooks.HooksConfig{
+		PreToolUse: []hooks.HookEntry{
+			{Matcher: "Task", Hooks: []hooks.Hook{{Type: "command", Command: "gt tap guard task-dispatch"}}},
+			{Matcher: "Bash(gh pr create*)", Hooks: []hooks.Hook{{Type: "command", Command: "gt tap guard pr-workflow"}}},
+		},
+	}
+
+	stripped := stripTaskDispatch(cfg)
+
+	if containsTaskDispatch(stripped) {
+		t.Error("stripTaskDispatch did not remove task-dispatch entry")
+	}
+
+	// Should preserve the pr-workflow entry
+	if len(stripped.PreToolUse) != 1 {
+		t.Errorf("expected 1 PreToolUse entry after strip, got %d", len(stripped.PreToolUse))
+	}
+	if stripped.PreToolUse[0].Matcher != "Bash(gh pr create*)" {
+		t.Errorf("wrong remaining entry: %s", stripped.PreToolUse[0].Matcher)
+	}
+}

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -165,7 +165,8 @@ func Merge(base, override *HooksConfig) *HooksConfig {
 }
 
 // DefaultOverrides returns built-in role-specific hook overrides.
-// These are always applied as a baseline layer; on-disk overrides merge on top.
+// Currently empty — the merge mechanism is retained for future use.
+// On-disk overrides (in ~/.gt/hooks-overrides/) layer on top of DefaultBase().
 func DefaultOverrides() map[string]*HooksConfig {
 	return map[string]*HooksConfig{}
 }
@@ -174,9 +175,9 @@ func DefaultOverrides() map[string]*HooksConfig {
 // the base config and applying all applicable overrides in order of specificity.
 // If no base config exists, uses DefaultBase().
 //
-// For each override key, built-in defaults (from DefaultOverrides) are merged
-// first, then on-disk overrides layer on top. On-disk overrides can replace
-// or disable built-in guards by providing a matching PreToolUse entry.
+// For each override key, built-in defaults (from DefaultOverrides, currently empty)
+// are merged first, then on-disk overrides layer on top. On-disk overrides can
+// replace or extend base hooks by providing matching PreToolUse entries.
 func ComputeExpected(target string) (*HooksConfig, error) {
 	base, err := LoadBase()
 	if err != nil {


### PR DESCRIPTION
## Summary

Follow-up to #1624 (remove Task tool block for Mayor). Addresses review findings:

- Add `StaleTaskDispatchCheck` to `gt doctor` — detects settings.json files still referencing the removed `gt tap guard task-dispatch` command
- Auto-fixable via `gt doctor --fix` — regenerates affected settings.json via `ComputeExpected()` with `stripTaskDispatch()` to handle stale on-disk overrides
- Update doc comments on `DefaultOverrides()` and `ComputeExpected()` to reflect empty defaults
- Register check before `HooksSyncCheck` for correct ordering (strip stale entries before sync verification)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/doctor/...` passes (7 new tests)
- [x] `go test ./internal/hooks/...` passes
- [x] `TestStaleTaskDispatchCheck_Clean` — no false positives on clean settings
- [x] `TestStaleTaskDispatchCheck_Stale` — detects stale task-dispatch guard
- [x] `TestStaleTaskDispatchCheck_Fix` — fix converges, re-check passes
- [x] `TestStaleTaskDispatchCheck_FixConvergesWithOverride` — fix converges even when on-disk hooks-override re-injects task-dispatch
- [x] `TestStripTaskDispatch` — strips task-dispatch entries while preserving others
- [x] `TestContainsTaskDispatch` — 4 cases (empty, no match, exact, prefixed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)