### PR TITLE
fix: init session registry before resolving polecat session name

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -1346,6 +1346,16 @@ func isPolecatActor(actor string) bool {
 	return len(parts) >= 2 && parts[1] == "polecats"
 }
 
+// resolvePolecatSessionName resolves the tmux session name for a polecat,
+// ensuring the prefix registry is initialized for correct prefix resolution.
+// persistentPreRun may have failed to init it (e.g., deleted worktree).
+func resolvePolecatSessionName(townRoot, rigName, polecatName string) string {
+	if townRoot != "" {
+		_ = session.InitRegistry(townRoot)
+	}
+	return session.PolecatSessionName(session.PrefixFor(rigName), polecatName)
+}
+
 // selfKillSession terminates the polecat's own tmux session after logging the event.
 // This completes the self-cleaning model: "done means gone" - both worktree and session.
 //
@@ -1370,7 +1380,7 @@ func selfKillSession(townRoot string, roleInfo RoleInfo) error {
 		return fmt.Errorf("cannot determine session: rig=%q, polecat=%q", rigName, polecatName)
 	}
 
-	sessionName := session.PolecatSessionName(session.PrefixFor(rigName), polecatName)
+	sessionName := resolvePolecatSessionName(townRoot, rigName, polecatName)
 	agentID := fmt.Sprintf("%s/polecats/%s", rigName, polecatName)
 
 	// Log to townlog (human-readable audit log)

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -10,6 +11,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/session"
 )
 
 // TestDoneUsesResolveBeadsDir verifies that the done command correctly uses
@@ -1044,5 +1046,63 @@ func TestCheckpointNilMapSafe(t *testing.T) {
 	emptyMap := map[DoneCheckpoint]string{}
 	if emptyMap[CheckpointPushed] != "" {
 		t.Error("empty map should return zero value")
+	}
+}
+
+// createTestTownWithPrefix creates a minimal town directory structure with
+// a rigs.json that maps the given prefix to the given rig name.
+// Returns the town root path.
+func createTestTownWithPrefix(t *testing.T, prefix, rigName string) string {
+	t.Helper()
+	townRoot := t.TempDir()
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+
+	rigsData := map[string]interface{}{
+		"rigs": map[string]interface{}{
+			rigName: map[string]interface{}{
+				"beads": map[string]interface{}{
+					"prefix": prefix,
+				},
+			},
+		},
+	}
+	data, err := json.Marshal(rigsData)
+	if err != nil {
+		t.Fatalf("marshal rigs.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), data, 0644); err != nil {
+		t.Fatalf("write rigs.json: %v", err)
+	}
+	return townRoot
+}
+
+func TestResolvePolecatSessionName_CustomPrefix(t *testing.T) {
+	// Save and restore the default registry
+	old := session.DefaultRegistry()
+	t.Cleanup(func() { session.SetDefaultRegistry(old) })
+
+	townRoot := createTestTownWithPrefix(t, "tr", "testrig")
+
+	got := resolvePolecatSessionName(townRoot, "testrig", "rust")
+	if got != "tr-rust" {
+		t.Errorf("resolvePolecatSessionName() = %q, want %q", got, "tr-rust")
+	}
+}
+
+func TestResolvePolecatSessionName_DefaultPrefix(t *testing.T) {
+	// Save and restore the default registry
+	old := session.DefaultRegistry()
+	t.Cleanup(func() { session.SetDefaultRegistry(old) })
+
+	// Use empty temp dir as town root (no rigs.json → falls back to default prefix)
+	townRoot := t.TempDir()
+	os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755)
+
+	got := resolvePolecatSessionName(townRoot, "testrig", "rust")
+	if got != "gt-rust" {
+		t.Errorf("resolvePolecatSessionName() = %q, want %q", got, "gt-rust")
 	}
 }


### PR DESCRIPTION
## Summary
- `selfKillSession()` calls `session.PrefixFor(rigName)` which uses the default registry
- When `persistentPreRun` can't find cwd (deleted polecat worktree), the registry stays empty and `PrefixFor("testrig")` returns `"gt"` instead of `"tr"`
- The kill targets `gt-rust` instead of `tr-rust` — the session survives as a zombie
- Extract `resolvePolecatSessionName()` helper that initializes the prefix registry from `townRoot` before resolving the session name

## Test plan
- [x] `TestResolvePolecatSessionName_CustomPrefix` — creates temp town with `"tr" → "testrig"` mapping, verifies `resolvePolecatSessionName` returns `"tr-rust"` not `"gt-rust"`
- [x] `TestResolvePolecatSessionName_DefaultPrefix` — no rigs.json mapping, verifies fallback to `"gt-rust"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)