### PR TITLE
fix: init session registry in handoff for custom-prefix resolution

### DIFF
--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -338,6 +338,12 @@ func getCurrentTmuxSession() (string, error) {
 //
 // For role shortcuts that need context (crew, witness, refinery), it auto-detects from environment.
 func resolveRoleToSession(role string) (string, error) {
+	// Ensure prefix registry is initialized for correct PrefixFor resolution.
+	// persistentPreRun may have failed (broken cwd), but env fallback may work.
+	if townRoot := detectTownRootFromCwd(); townRoot != "" {
+		_ = session.InitRegistry(townRoot)
+	}
+
 	// First, check if it's a path format (contains /)
 	if strings.Contains(role, "/") {
 		return resolvePathToSession(role)
@@ -468,6 +474,10 @@ func buildRestartCommand(sessionName string) (string, error) {
 	if townRoot == "" {
 		return "", fmt.Errorf("cannot detect town root - run from within a Gas Town workspace")
 	}
+
+	// Ensure prefix registry is initialized for correct session name parsing.
+	// persistentPreRun may have failed (broken cwd), but we have townRoot via env fallback.
+	_ = session.InitRegistry(townRoot)
 
 	// Determine the working directory for this session type
 	workDir, err := sessionWorkDir(sessionName, townRoot)

--- a/internal/cmd/handoff_test.go
+++ b/internal/cmd/handoff_test.go
@@ -212,3 +212,48 @@ func TestDetectTownRootFromCwd_EnvFallback(t *testing.T) {
 		}
 	})
 }
+
+func TestSessionWorkDirWithCustomPrefix(t *testing.T) {
+	// Register "tr" → "testrig" to simulate a custom-prefix rig
+	reg := session.NewPrefixRegistry()
+	reg.Register("tr", "testrig")
+	old := session.DefaultRegistry()
+	session.SetDefaultRegistry(reg)
+	t.Cleanup(func() { session.SetDefaultRegistry(old) })
+
+	townRoot := "/home/test/gt"
+
+	tests := []struct {
+		name        string
+		sessionName string
+		wantDir     string
+	}{
+		{
+			name:        "custom prefix witness",
+			sessionName: "tr-witness",
+			wantDir:     townRoot + "/testrig/witness",
+		},
+		{
+			name:        "custom prefix refinery",
+			sessionName: "tr-refinery",
+			wantDir:     townRoot + "/testrig/refinery/rig",
+		},
+		{
+			name:        "custom prefix polecat",
+			sessionName: "tr-rust",
+			wantDir:     townRoot + "/testrig/polecats/rust",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotDir, err := sessionWorkDir(tt.sessionName, townRoot)
+			if err != nil {
+				t.Fatalf("sessionWorkDir(%q) error: %v", tt.sessionName, err)
+			}
+			if gotDir != tt.wantDir {
+				t.Errorf("sessionWorkDir(%q) = %q, want %q", tt.sessionName, gotDir, tt.wantDir)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- `buildRestartCommand()` calls `session.ParseSessionName()` and `resolveRoleToSession()` calls `session.PrefixFor()` — both use the default registry
- When `persistentPreRun` couldn't init the registry (cwd detection failed), custom-prefix sessions like `tr-witness` parse as `rig="tr"` instead of `rig="testrig"`
- `sessionWorkDir` then returns `<townRoot>/tr/witness` (wrong) instead of `<townRoot>/testrig/witness`
- Add defensive `session.InitRegistry(townRoot)` calls in both `buildRestartCommand()` and `resolveRoleToSession()`

## Test plan
- [x] `TestSessionWorkDirWithCustomPrefix` — registers `"tr"→"testrig"`, verifies `sessionWorkDir("tr-witness")` → `testrig/witness`, `sessionWorkDir("tr-refinery")` → `testrig/refinery/rig`, `sessionWorkDir("tr-rust")` → `testrig/polecats/rust`
- [x] Existing `TestSessionWorkDir` still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)