### PR TITLE
fix: propagate CLAUDE_CONFIG_DIR to witness and refinery

### DIFF
--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -123,6 +123,9 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 	// Ensure runtime settings exist in the shared refinery parent directory.
 	// Settings are passed to Claude Code via --settings flag.
 	townRoot := filepath.Dir(m.rig.Path)
+	accountsPath := constants.MayorAccountsPath(townRoot)
+	claudeConfigDir, _, _ := config.ResolveAccountConfigDir(accountsPath, "")
+
 	runtimeConfig := config.ResolveRoleAgentConfig("refinery", townRoot, m.rig.Path)
 	refinerySettingsDir := config.RoleSettingsDir("refinery", m.rig.Path)
 	if err := runtime.EnsureSettingsForRole(refinerySettingsDir, refineryRigDir, "refinery", runtimeConfig); err != nil {
@@ -140,15 +143,21 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 		Topic:     "patrol",
 	}, "Run `gt prime --hook` and begin patrol.")
 
+	startEnvVars := config.AgentEnv(config.AgentEnvConfig{
+		Role:             "refinery",
+		Rig:              m.rig.Name,
+		TownRoot:         townRoot,
+		RuntimeConfigDir: claudeConfigDir,
+	})
 	var command string
 	if agentOverride != "" {
 		var err error
-		command, err = config.BuildAgentStartupCommandWithAgentOverride("refinery", m.rig.Name, townRoot, m.rig.Path, initialPrompt, agentOverride)
+		command, err = config.BuildStartupCommandWithAgentOverride(startEnvVars, m.rig.Path, initialPrompt, agentOverride)
 		if err != nil {
 			return fmt.Errorf("building startup command with agent override: %w", err)
 		}
 	} else {
-		command = config.BuildAgentStartupCommand("refinery", m.rig.Name, townRoot, m.rig.Path, initialPrompt)
+		command = config.BuildStartupCommand(startEnvVars, m.rig.Path, initialPrompt)
 	}
 
 	// Create session with command directly to avoid send-keys race condition.
@@ -160,9 +169,10 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 	// Set environment variables (non-fatal: session works without these)
 	// Use centralized AgentEnv for consistency across all role startup paths
 	envVars := config.AgentEnv(config.AgentEnvConfig{
-		Role:     "refinery",
-		Rig:      m.rig.Name,
-		TownRoot: townRoot,
+		Role:             "refinery",
+		Rig:              m.rig.Name,
+		TownRoot:         townRoot,
+		RuntimeConfigDir: claudeConfigDir,
 	})
 
 	// Add refinery-specific flag

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -123,6 +123,9 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	// package config) to prevent concurrent rig starts from corrupting the
 	// global agent registry.
 	townRoot := m.townRoot()
+	accountsPath := constants.MayorAccountsPath(townRoot)
+	claudeConfigDir, _, _ := config.ResolveAccountConfigDir(accountsPath, "")
+
 	runtimeConfig := config.ResolveRoleAgentConfig("witness", townRoot, m.rig.Path)
 	witnessSettingsDir := config.RoleSettingsDir("witness", m.rig.Path)
 	if err := runtime.EnsureSettingsForRole(witnessSettingsDir, witnessDir, "witness", runtimeConfig); err != nil {
@@ -143,7 +146,7 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	// NOTE: No gt prime injection needed - SessionStart hook handles it automatically
 	// Export GT_ROLE and BD_ACTOR in the command since tmux SetEnvironment only affects new panes
 	// Pass m.rig.Path so rig agent settings are honored (not town-level defaults)
-	command, err := buildWitnessStartCommand(m.rig.Path, m.rig.Name, townRoot, agentOverride, roleConfig)
+	command, err := buildWitnessStartCommand(m.rig.Path, m.rig.Name, townRoot, agentOverride, claudeConfigDir, roleConfig)
 	if err != nil {
 		return err
 	}
@@ -157,9 +160,10 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	// Set environment variables (non-fatal: session works without these)
 	// Use centralized AgentEnv for consistency across all role startup paths
 	envVars := config.AgentEnv(config.AgentEnvConfig{
-		Role:     "witness",
-		Rig:      m.rig.Name,
-		TownRoot: townRoot,
+		Role:             "witness",
+		Rig:              m.rig.Name,
+		TownRoot:         townRoot,
+		RuntimeConfigDir: claudeConfigDir,
 	})
 	for k, v := range envVars {
 		_ = t.SetEnvironment(sessionID, k, v)
@@ -231,7 +235,7 @@ func roleConfigEnvVars(roleConfig *beads.RoleConfig, townRoot, rigName string) m
 	return expanded
 }
 
-func buildWitnessStartCommand(rigPath, rigName, townRoot, agentOverride string, roleConfig *beads.RoleConfig) (string, error) {
+func buildWitnessStartCommand(rigPath, rigName, townRoot, agentOverride, claudeConfigDir string, roleConfig *beads.RoleConfig) (string, error) {
 	if agentOverride != "" {
 		roleConfig = nil
 	}
@@ -243,11 +247,16 @@ func buildWitnessStartCommand(rigPath, rigName, townRoot, agentOverride string, 
 		Sender:    "deacon",
 		Topic:     "patrol",
 	}, "Run `gt prime --hook` and begin patrol.")
-	command, err := config.BuildAgentStartupCommandWithAgentOverride("witness", rigName, townRoot, rigPath, initialPrompt, agentOverride)
-	if err != nil {
-		return "", fmt.Errorf("building startup command: %w", err)
+	envVars := config.AgentEnv(config.AgentEnvConfig{
+		Role:             "witness",
+		Rig:              rigName,
+		TownRoot:         townRoot,
+		RuntimeConfigDir: claudeConfigDir,
+	})
+	if agentOverride != "" {
+		return config.BuildStartupCommandWithAgentOverride(envVars, rigPath, initialPrompt, agentOverride)
 	}
-	return command, nil
+	return config.BuildStartupCommand(envVars, rigPath, initialPrompt), nil
 }
 
 // Stop stops the witness.

--- a/internal/witness/manager_test.go
+++ b/internal/witness/manager_test.go
@@ -12,7 +12,7 @@ func TestBuildWitnessStartCommand_UsesRoleConfig(t *testing.T) {
 		StartCommand: "exec run --town {town} --rig {rig} --role {role}",
 	}
 
-	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "", roleConfig)
+	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "", "", roleConfig)
 	if err != nil {
 		t.Fatalf("buildWitnessStartCommand: %v", err)
 	}
@@ -24,7 +24,7 @@ func TestBuildWitnessStartCommand_UsesRoleConfig(t *testing.T) {
 }
 
 func TestBuildWitnessStartCommand_DefaultsToRuntime(t *testing.T) {
-	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "", nil)
+	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "", "", nil)
 	if err != nil {
 		t.Fatalf("buildWitnessStartCommand: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestBuildWitnessStartCommand_AgentOverrideWins(t *testing.T) {
 		StartCommand: "exec run --role {role}",
 	}
 
-	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "codex", roleConfig)
+	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "codex", "", roleConfig)
 	if err != nil {
 		t.Fatalf("buildWitnessStartCommand: %v", err)
 	}
@@ -51,5 +51,27 @@ func TestBuildWitnessStartCommand_AgentOverrideWins(t *testing.T) {
 	}
 	if !strings.Contains(got, "GT_ROLE=gastown/witness") {
 		t.Errorf("expected GT_ROLE=gastown/witness in command, got %q", got)
+	}
+}
+
+func TestBuildWitnessStartCommand_IncludesClaudeConfigDir(t *testing.T) {
+	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "", "/custom/config", nil)
+	if err != nil {
+		t.Fatalf("buildWitnessStartCommand: %v", err)
+	}
+
+	if !strings.Contains(got, "CLAUDE_CONFIG_DIR=/custom/config") {
+		t.Errorf("expected CLAUDE_CONFIG_DIR=/custom/config in command, got %q", got)
+	}
+}
+
+func TestBuildWitnessStartCommand_OmitsClaudeConfigDirWhenEmpty(t *testing.T) {
+	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "", "", nil)
+	if err != nil {
+		t.Fatalf("buildWitnessStartCommand: %v", err)
+	}
+
+	if strings.Contains(got, "CLAUDE_CONFIG_DIR") {
+		t.Errorf("expected no CLAUDE_CONFIG_DIR when empty, got %q", got)
 	}
 }


### PR DESCRIPTION
## Summary
- Witness (`manager.go:159`) and refinery (`manager.go:162`) create `AgentEnvConfig` without `RuntimeConfigDir`
- Without `CLAUDE_CONFIG_DIR`, they fall back to default credentials and get 401 errors in multi-account setups
- The polecat path (`polecat_spawn.go`) already calls `ResolveAccountConfigDir()` — witness and refinery were missing it
- Resolve credentials via `config.ResolveAccountConfigDir()` in `Start()`, pass `RuntimeConfigDir` to both the startup command env vars and the tmux session `AgentEnvConfig`
- Witness `buildWitnessStartCommand` now uses lower-level `config.BuildStartupCommand` / `config.BuildStartupCommandWithAgentOverride` to pass custom env vars including `CLAUDE_CONFIG_DIR`

## Test plan
- [x] `TestBuildWitnessStartCommand_IncludesClaudeConfigDir` — pass non-empty `claudeConfigDir`, assert `CLAUDE_CONFIG_DIR=/custom/config` in command
- [x] `TestBuildWitnessStartCommand_OmitsClaudeConfigDirWhenEmpty` — pass empty `claudeConfigDir`, assert no `CLAUDE_CONFIG_DIR` in command
- [x] Existing `TestBuildWitnessStartCommand_*` tests updated and passing
- [x] All refinery tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)