### PR TITLE
fix(done): defer no-commits-ahead close to after BD_BRANCH unset

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -814,6 +814,11 @@ notifyWitness:
 	}
 
 afterDoltMerge:
+	// Ensure BD_BRANCH is unset before any post-merge bead operations.
+	// The normal path unsets it above after MergePolecatBranch, but the
+	// checkpoint-resume path (goto afterDoltMerge) bypasses that code.
+	os.Unsetenv("BD_BRANCH")
+
 	// Deferred close for no-commits-ahead path (G15 fix).
 	// The close is deferred to here because BD_BRANCH has now been unset,
 	// so ForceCloseWithReason writes directly to Dolt main. Closing earlier


### PR DESCRIPTION
## Summary

When a polecat completes with zero commits ahead (`aheadCount == 0`), the G15 fix calls `ForceCloseWithReason` to close the bead so it doesn't get stuck as HOOKED. However, at that point `BD_BRANCH` is still set in the environment, so the close writes `status=closed` to the **polecat's Dolt branch** instead of main.

The subsequent `MergePolecatBranch` at the `notifyWitness` label can then hit merge conflicts — main has `status=hooked` while the polecat branch has `status=closed` from different base states. When this happens, the bead is left permanently stuck as HOOKED with no recovery path.

**Fix:** Defer the close to after the `afterDoltMerge` label, where `BD_BRANCH` has already been unset. The polecat branch merges cleanly (no meaningful writes on it), then the close writes directly to Dolt main.

## Reproduction

1. Sling a bead to a polecat (creates Dolt branch with `BD_BRANCH` set)
2. The bug is already fixed or work was pushed directly to main
3. Polecat runs `gt done --cleanup-status clean`
4. `aheadCount == 0` path triggers, `ForceCloseWithReason` writes close to polecat branch
5. `MergePolecatBranch` hits conflict → bead stuck as HOOKED

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `go test ./internal/cmd/ -run Done` — all tests pass
- [ ] Manual: sling a bead, push fix directly to main, run `gt done --cleanup-status clean` — bead should close successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)