### PR TITLE
fix: replace hardcoded gt-/hq- prefix checks with dynamic registry lookups

### DIFF
--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -189,7 +189,7 @@ func runStart(cmd *cobra.Command, args []string) error {
 	// Clean up orphaned tmux sessions before starting new agents.
 	// This prevents session name conflicts and resource accumulation from
 	// zombie sessions (tmux alive but Claude dead).
-	if cleaned, err := t.CleanupOrphanedSessions(); err != nil {
+	if cleaned, err := t.CleanupOrphanedSessions(session.IsKnownSession); err != nil {
 		fmt.Printf("  %s Could not clean orphaned sessions: %v\n", style.Dim.Render("○"), err)
 	} else if cleaned > 0 {
 		fmt.Printf("  %s Cleaned up %d orphaned session(s)\n", style.Bold.Render("✓"), cleaned)

--- a/internal/doctor/theme_check.go
+++ b/internal/doctor/theme_check.go
@@ -5,6 +5,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
@@ -44,7 +45,7 @@ func (c *ThemeCheck) Run(ctx *CheckContext) *CheckResult {
 	// Check for Gas Town sessions
 	var gtSessions []string
 	for _, s := range sessions {
-		if strings.HasPrefix(s, "gt-") {
+		if session.IsKnownSession(s) {
 			gtSessions = append(gtSessions, s)
 		}
 	}

--- a/internal/doctor/tmux_check.go
+++ b/internal/doctor/tmux_check.go
@@ -43,11 +43,11 @@ func (c *LinkedPaneCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
-	// Filter to gt-* sessions only
+	// Filter to Gas Town sessions only
 	var gtSessions []string
-	for _, session := range sessions {
-		if strings.HasPrefix(session, "gt-") {
-			gtSessions = append(gtSessions, session)
+	for _, s := range sessions {
+		if session.IsKnownSession(s) {
+			gtSessions = append(gtSessions, s)
 		}
 	}
 

--- a/internal/doctor/zombie_check.go
+++ b/internal/doctor/zombie_check.go
@@ -2,9 +2,9 @@ package doctor
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/steveyegge/gastown/internal/events"
+	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
@@ -60,8 +60,8 @@ func (c *ZombieSessionCheck) Run(ctx *CheckContext) *CheckResult {
 			continue
 		}
 
-		// Only check Gas Town sessions (gt-* and hq-*)
-		if !strings.HasPrefix(sess, "gt-") && !strings.HasPrefix(sess, "hq-") {
+		// Only check Gas Town sessions
+		if !session.IsKnownSession(sess) {
 			continue
 		}
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2096,18 +2096,21 @@ func CurrentSessionName() string {
 // A zombie session is one where tmux is alive but the Claude process has died.
 // This runs at `gt start` time to prevent session name conflicts and resource accumulation.
 //
+// The isGTSession predicate identifies Gas Town sessions (e.g. session.IsKnownSession).
+// It is passed as a parameter to avoid a circular import from tmux → session.
+//
 // Returns:
 //   - cleaned: number of zombie sessions that were killed
 //   - err: error if session listing failed (individual kill errors are logged but not returned)
-func (t *Tmux) CleanupOrphanedSessions() (cleaned int, err error) {
+func (t *Tmux) CleanupOrphanedSessions(isGTSession func(string) bool) (cleaned int, err error) {
 	sessions, err := t.ListSessions()
 	if err != nil {
 		return 0, fmt.Errorf("listing sessions: %w", err)
 	}
 
 	for _, sess := range sessions {
-		// Only process Gas Town sessions (gt-* for rigs, hq-* for town-level)
-		if !strings.HasPrefix(sess, "gt-") && !strings.HasPrefix(sess, "hq-") {
+		// Only process Gas Town sessions
+		if !isGTSession(sess) {
 			continue
 		}
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -920,12 +920,18 @@ func TestCleanupOrphanedSessions(t *testing.T) {
 		t.Skip("tmux not installed")
 	}
 
+	// Local predicate matching gt-/hq- prefixes (sufficient for test fixtures;
+	// avoids circular import of session package).
+	isTestGTSession := func(s string) bool {
+		return strings.HasPrefix(s, "gt-") || strings.HasPrefix(s, "hq-")
+	}
+
 	tm := NewTmux()
 
 	// Additional safety check: Skip if production GT sessions exist.
 	sessions, _ := tm.ListSessions()
 	for _, sess := range sessions {
-		if (strings.HasPrefix(sess, "gt-") || strings.HasPrefix(sess, "hq-")) &&
+		if isTestGTSession(sess) &&
 			sess != "gt-test-cleanup-rig" && sess != "hq-test-cleanup" {
 			t.Skip("Skipping: production GT sessions exist (would be killed by CleanupOrphanedSessions)")
 		}
@@ -970,7 +976,7 @@ func TestCleanupOrphanedSessions(t *testing.T) {
 	}
 
 	// Run cleanup
-	cleaned, err := tm.CleanupOrphanedSessions()
+	cleaned, err := tm.CleanupOrphanedSessions(isTestGTSession)
 	if err != nil {
 		t.Fatalf("CleanupOrphanedSessions: %v", err)
 	}
@@ -1012,18 +1018,23 @@ func TestCleanupOrphanedSessions_NoSessions(t *testing.T) {
 		t.Skip("tmux not installed")
 	}
 
+	// Local predicate matching gt-/hq- prefixes (avoids circular import).
+	isTestGTSession := func(s string) bool {
+		return strings.HasPrefix(s, "gt-") || strings.HasPrefix(s, "hq-")
+	}
+
 	tm := NewTmux()
 
 	// Additional safety check: Skip if production GT sessions exist.
 	sessions, _ := tm.ListSessions()
 	for _, sess := range sessions {
-		if strings.HasPrefix(sess, "gt-") || strings.HasPrefix(sess, "hq-") {
+		if isTestGTSession(sess) {
 			t.Skip("Skipping: GT sessions exist (CleanupOrphanedSessions would kill them)")
 		}
 	}
 
 	// Running cleanup with no orphaned GT sessions should return 0, no error
-	cleaned, err := tm.CleanupOrphanedSessions()
+	cleaned, err := tm.CleanupOrphanedSessions(isTestGTSession)
 	if err != nil {
 		t.Fatalf("CleanupOrphanedSessions: %v", err)
 	}

--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -1334,8 +1334,8 @@ func (f *LiveConvoyFetcher) FetchSessions() ([]SessionRow, error) {
 		parts := strings.SplitN(line, ":", 2)
 		name := parts[0]
 
-		// Only include gt-* sessions
-		if !strings.HasPrefix(name, "gt-") {
+		// Only include Gas Town sessions
+		if !session.IsKnownSession(name) {
 			continue
 		}
 


### PR DESCRIPTION
## Summary
- Replace hardcoded `"gt-"` / `"hq-"` prefix strings in doctor checks and `CleanupOrphanedSessions` with `session.IsKnownSession()` so sessions from non-gastown rigs (e.g. `bd-witness`) are no longer silently skipped
- `CleanupOrphanedSessions` now accepts an `isGTSession` predicate parameter to avoid circular `tmux → session` import
- Follows the pattern established in PR #1655 for keybinding functions

## Changes
- **`internal/doctor/tmux_check.go`** — `session.IsKnownSession(s)` replaces `strings.HasPrefix(session, "gt-")`
- **`internal/doctor/zombie_check.go`** — `session.IsKnownSession(sess)` replaces dual prefix check
- **`internal/doctor/theme_check.go`** — `session.IsKnownSession(s)` replaces `strings.HasPrefix(s, "gt-")`
- **`internal/web/fetcher.go`** — `session.IsKnownSession(name)` replaces `strings.HasPrefix(name, "gt-")`
- **`internal/tmux/tmux.go`** — `CleanupOrphanedSessions` takes `isGTSession func(string) bool` predicate
- **`internal/cmd/start.go`** — passes `session.IsKnownSession` to `CleanupOrphanedSessions`
- **`internal/tmux/tmux_test.go`** — tests use local predicate to avoid circular import

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./internal/tmux/ ./internal/doctor/ ./internal/web/ ./internal/cmd/` clean
- [x] `go test ./internal/tmux/ ./internal/doctor/ ./internal/web/ ./internal/cmd/` all pass

Closes #1662

🤖 Generated with [Claude Code](https://claude.com/claude-code)