### PR TITLE
chore: remove deprecated addressToSessionID function

### DIFF
--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -1561,13 +1561,3 @@ func AddressToSessionIDs(address string) []string {
 	}
 }
 
-// addressToSessionID converts a mail address to a tmux session ID.
-// Returns empty string if address format is not recognized.
-// Deprecated: Use AddressToSessionIDs for proper crew/polecat handling.
-func addressToSessionID(address string) string {
-	ids := AddressToSessionIDs(address)
-	if len(ids) == 0 {
-		return ""
-	}
-	return ids[0]
-}

--- a/internal/mail/router_test.go
+++ b/internal/mail/router_test.go
@@ -146,42 +146,6 @@ func TestAddressToSessionIDs(t *testing.T) {
 	}
 }
 
-func TestAddressToSessionID(t *testing.T) {
-	// Set up prefix registry for test
-	reg := session.NewPrefixRegistry()
-	reg.Register("gt", "gastown")
-	reg.Register("bd", "beads")
-	old := session.DefaultRegistry()
-	session.SetDefaultRegistry(reg)
-	defer session.SetDefaultRegistry(old)
-
-	// Deprecated wrapper - returns first candidate from AddressToSessionIDs
-	tests := []struct {
-		address string
-		want    string
-	}{
-		{"overseer", "hq-overseer"},
-		{"mayor", "hq-mayor"},
-		{"mayor/", "hq-mayor"},
-		{"deacon", "hq-deacon"},
-		{"gastown/refinery", "gt-refinery"},
-		{"gastown/Toast", "gt-crew-Toast"}, // First candidate is crew
-		{"beads/witness", "bd-witness"},
-		{"gastown/", ""},   // Empty target
-		{"gastown", ""},    // No slash
-		{"", ""},           // Empty address
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.address, func(t *testing.T) {
-			got := addressToSessionID(tt.address)
-			if got != tt.want {
-				t.Errorf("addressToSessionID(%q) = %q, want %q", tt.address, got, tt.want)
-			}
-		})
-	}
-}
-
 func TestIsSelfMail(t *testing.T) {
 	tests := []struct {
 		from string


### PR DESCRIPTION
## Summary

- Remove the deprecated `addressToSessionID` wrapper function from `internal/mail/router.go` which simply called `AddressToSessionIDs` and returned the first result
- Remove its redundant test — the comprehensive `TestAddressToSessionIDs` already exercises the replacement function with more thorough coverage (including crew/polecat ambiguity cases)

## Test plan

- [x] `go test ./internal/mail/...` passes
- [x] No other callers of `addressToSessionID` exist in the codebase