### PR TITLE
chore: remove deprecated hasChildWithNames function

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1298,12 +1298,6 @@ func hasDescendantWithNames(pid string, names []string, depth int) bool {
 	return false
 }
 
-// hasChildWithNames checks if a process has a child matching any of the given names.
-// Deprecated: Use hasDescendantWithNames for more robust detection.
-func hasChildWithNames(pid string, names []string) bool {
-	return hasDescendantWithNames(pid, names, 0)
-}
-
 // FindSessionByWorkDir finds tmux sessions where the pane's current working directory
 // matches or is under the target directory. Returns session names that match.
 // If processNames is provided, only returns sessions that match those processes.

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -553,31 +553,31 @@ func TestGetPaneCommand_MultiPane(t *testing.T) {
 	}
 }
 
-func TestHasChildWithNames(t *testing.T) {
-	// Test the hasChildWithNames helper function directly
+func TestHasDescendantWithNames(t *testing.T) {
+	// Test the hasDescendantWithNames helper function directly
 
 	// Test with a definitely nonexistent PID
-	got := hasChildWithNames("999999999", []string{"node", "claude"})
+	got := hasDescendantWithNames("999999999", []string{"node", "claude"}, 0)
 	if got {
-		t.Error("hasChildWithNames should return false for nonexistent PID")
+		t.Error("hasDescendantWithNames should return false for nonexistent PID")
 	}
 
 	// Test with empty names slice - should always return false
-	got = hasChildWithNames("1", []string{})
+	got = hasDescendantWithNames("1", []string{}, 0)
 	if got {
-		t.Error("hasChildWithNames should return false for empty names slice")
+		t.Error("hasDescendantWithNames should return false for empty names slice")
 	}
 
 	// Test with nil names slice - should always return false
-	got = hasChildWithNames("1", nil)
+	got = hasDescendantWithNames("1", nil, 0)
 	if got {
-		t.Error("hasChildWithNames should return false for nil names slice")
+		t.Error("hasDescendantWithNames should return false for nil names slice")
 	}
 
 	// Test with PID 1 (init/launchd) - should have children but not specific agent processes
-	got = hasChildWithNames("1", []string{"node", "claude"})
+	got = hasDescendantWithNames("1", []string{"node", "claude"}, 0)
 	if got {
-		t.Logf("hasChildWithNames(\"1\", [node,claude]) = true - init has matching child?")
+		t.Logf("hasDescendantWithNames(\"1\", [node,claude]) = true - init has matching child?")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove the deprecated `hasChildWithNames` wrapper from `internal/tmux/tmux.go` which simply delegated to `hasDescendantWithNames(pid, names, 0)`
- Update 4 test call sites to use `hasDescendantWithNames` directly with `depth=0`
- Rename test from `TestHasChildWithNames` to `TestHasDescendantWithNames`

## Test plan

- [x] `go test ./internal/tmux/... -run TestHasDescendantWithNames` passes
- [x] No other callers of `hasChildWithNames` exist in the codebase