### PR TITLE
chore: deduplicate bd timeout constants into shared constants package

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -43,6 +43,14 @@ const (
 	// NudgeRetryInterval is the base interval between send-keys retry attempts
 	// when a transient tmux error is encountered during nudge delivery.
 	NudgeRetryInterval = 500 * time.Millisecond
+
+	// BdCommandTimeout is the default timeout for bd (beads CLI) command
+	// execution. Used across polecat session management and plugin recording.
+	BdCommandTimeout = 30 * time.Second
+
+	// BdSubprocessTimeout is the timeout for bd subprocess calls in TUI panels.
+	// Prevents the TUI from freezing if these commands hang.
+	BdSubprocessTimeout = 5 * time.Second
 )
 
 // Directory names within a Gas Town workspace.

--- a/internal/plugin/recording.go
+++ b/internal/plugin/recording.go
@@ -11,9 +11,8 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/constants"
 )
-
-const bdCommandTimeout = 30 * time.Second
 
 // RunResult represents the outcome of a plugin execution.
 type RunResult string
@@ -80,7 +79,7 @@ func (r *Recorder) RecordRun(record PluginRunRecord) (string, error) {
 		args = append(args, "--description="+record.Body)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), bdCommandTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), constants.BdCommandTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Dir = r.townRoot
@@ -148,7 +147,7 @@ func (r *Recorder) queryRuns(pluginName string, limit int, since string) ([]*Plu
 		args = append(args, "--created-after="+sinceArg)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), bdCommandTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), constants.BdCommandTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Dir = r.townRoot

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -29,7 +29,6 @@ func debugSession(context string, err error) {
 	}
 }
 
-const bdCommandTimeout = 30 * time.Second
 
 // Session errors
 var (
@@ -636,7 +635,7 @@ func (m *SessionManager) resolveBeadsDir(issueID, fallbackDir string) string {
 func (m *SessionManager) validateIssue(issueID, workDir string) error {
 	bdWorkDir := m.resolveBeadsDir(issueID, workDir)
 
-	ctx, cancel := context.WithTimeout(context.Background(), bdCommandTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), constants.BdCommandTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "bd", "show", issueID, "--json") //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Dir = bdWorkDir
@@ -664,7 +663,7 @@ func (m *SessionManager) validateIssue(issueID, workDir string) error {
 func (m *SessionManager) hookIssue(issueID, agentID, workDir string) error {
 	bdWorkDir := m.resolveBeadsDir(issueID, workDir)
 
-	ctx, cancel := context.WithTimeout(context.Background(), bdCommandTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), constants.BdCommandTimeout)
 	defer cancel()
 	cmd := exec.CommandContext(ctx, "bd", "update", issueID, "--status=hooked", "--assignee="+agentID) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Dir = bdWorkDir

--- a/internal/tui/convoy/model.go
+++ b/internal/tui/convoy/model.go
@@ -10,18 +10,16 @@ import (
 	"sort"
 	"strings"
 	"sync"
-	"time"
 
 	"github.com/charmbracelet/bubbles/help"
 	"github.com/charmbracelet/bubbles/key"
 	tea "github.com/charmbracelet/bubbletea"
+
+	"github.com/steveyegge/gastown/internal/constants"
 )
 
 // convoyIDPattern validates convoy IDs.
 var convoyIDPattern = regexp.MustCompile(`^hq-[a-zA-Z0-9-]+$`)
-
-// subprocessTimeout is the timeout for bd subprocess calls.
-const subprocessTimeout = 5 * time.Second
 
 // IssueItem represents a tracked issue within a convoy.
 type IssueItem struct {
@@ -89,7 +87,7 @@ func (m *Model) fetchConvoys() tea.Msg {
 
 // loadConvoys loads convoy data from the beads directory.
 func loadConvoys(townBeads string) ([]ConvoyItem, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), subprocessTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), constants.BdSubprocessTimeout)
 	defer cancel()
 
 	// Get list of open convoys
@@ -148,7 +146,7 @@ func loadTrackedIssues(townBeads, convoyID string) ([]IssueItem, int, int) {
 		return nil, 0, 0
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), subprocessTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), constants.BdSubprocessTimeout)
 	defer cancel()
 
 	// Query tracked issues using bd dep list (returns full issue details)

--- a/internal/tui/feed/convoy.go
+++ b/internal/tui/feed/convoy.go
@@ -13,14 +13,12 @@ import (
 	"time"
 
 	"github.com/charmbracelet/lipgloss"
+
+	"github.com/steveyegge/gastown/internal/constants"
 )
 
 // convoyIDPattern validates convoy IDs.
 var convoyIDPattern = regexp.MustCompile(`^hq-[a-zA-Z0-9-]+$`)
-
-// convoySubprocessTimeout is the timeout for bd subprocess calls in the convoy panel.
-// Prevents TUI freezing if these commands hang.
-const convoySubprocessTimeout = 5 * time.Second
 
 // Convoy represents a convoy's status for the dashboard
 type Convoy struct {
@@ -90,7 +88,7 @@ func FetchConvoys(townRoot string) (*ConvoyState, error) {
 func listConvoys(beadsDir, status string) ([]convoyListItem, error) {
 	listArgs := []string{"list", "--label=gt:convoy", "--status=" + status, "--json"}
 
-	ctx, cancel := context.WithTimeout(context.Background(), convoySubprocessTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), constants.BdSubprocessTimeout)
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "bd", listArgs...) //nolint:gosec // G204: args are constructed internally
@@ -174,7 +172,7 @@ func getTrackedIssueStatus(beadsDir, convoyID string) []trackedStatus {
 		return nil
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), convoySubprocessTimeout)
+	ctx, cancel := context.WithTimeout(context.Background(), constants.BdSubprocessTimeout)
 	defer cancel()
 
 	// Query tracked issues using bd dep list (returns full issue details)


### PR DESCRIPTION
## Summary

Extract two independently duplicated timeout constants into the existing `internal/constants` package:

- **`BdCommandTimeout` (30s)**: was defined as `bdCommandTimeout` in both `polecat/session_manager.go` and `plugin/recording.go`
- **`BdSubprocessTimeout` (5s)**: was defined as `subprocessTimeout` in `tui/convoy/model.go` and `convoySubprocessTimeout` in `tui/feed/convoy.go`

Only true semantic duplicates were consolidated — other 30s constants (cache TTL, lock timeout, health check interval) were intentionally left local since they serve different purposes.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/polecat/...` passes
- [x] `go test ./internal/plugin/...` passes
- [x] `go test ./internal/tui/...` passes