### PR TITLE
fix(config): add missing runtime defaults to Pi agent preset

### DIFF
--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -336,6 +336,13 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 			PromptFlag: "-p",
 			OutputFlag: "--no-session",
 		},
+		// Runtime defaults
+		PromptMode:        "arg",
+		HooksProvider:     "pi",
+		HooksDir:          ".pi/extensions",
+		HooksSettingsFile: "gastown-hooks.js",
+		ReadyDelayMs:      3000,
+		InstructionsFile:  "AGENTS.md",
 	},
 }
 


### PR DESCRIPTION
## Summary
Fix CI failures on main caused by missing runtime default fields in the Pi agent preset, introduced in #1450.

## Related Issue
Fixes CI failures: https://github.com/steveyegge/gastown/actions/runs/22131386936

## Changes
- Add missing `HooksProvider`, `HooksDir`, `HooksSettingsFile`, `PromptMode`, `ReadyDelayMs`, and `InstructionsFile` fields to the `AgentPi` preset in `internal/config/agents.go`
- These fields are required by `fillRuntimeDefaults()` to auto-fill hooks configuration, matching the pattern used by all other hook-supporting agents (Claude, Gemini, OpenCode, Copilot)

## Testing
- [x] Unit tests pass (`go test ./internal/config/...`)
- [x] All 3 previously failing tests now pass:
  - `TestPiProviderDefaults`
  - `TestFillRuntimeDefaults/pi_command_gets_hooks_and_tmux_defaults`
  - `TestFillRuntimeDefaults` (parent)
- [x] Full test suite passes (`go test -short ./...`) — no regressions

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)