### PR TITLE
fix(rig): detect empty repos early in gt rig add

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -768,6 +768,20 @@ func (g *Git) RefExists(ref string) (bool, error) {
 	return true, nil
 }
 
+// IsEmpty returns true if the repository has no refs (an empty/unborn repo).
+// This is the case for newly-created repos with no commits.
+func (g *Git) IsEmpty() (bool, error) {
+	out, err := g.run("show-ref")
+	if err != nil {
+		// git show-ref exits 1 when there are no refs — that means empty
+		if strings.Contains(err.Error(), "exit status 1") {
+			return true, nil
+		}
+		return false, err
+	}
+	return strings.TrimSpace(out) == "", nil
+}
+
 // RemoteBranchExists checks if a branch exists on the remote.
 func (g *Git) RemoteBranchExists(remote, branch string) (bool, error) {
 	out, err := g.run("ls-remote", "--heads", remote, branch)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -535,6 +535,37 @@ func TestCloneBareHasOriginRefs(t *testing.T) {
 	}
 }
 
+func TestIsEmpty_EmptyRepo(t *testing.T) {
+	dir := t.TempDir()
+	cmd := exec.Command("git", "init")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	g := NewGit(dir)
+	empty, err := g.IsEmpty()
+	if err != nil {
+		t.Fatalf("IsEmpty: %v", err)
+	}
+	if !empty {
+		t.Error("expected newly-initialized repo to be empty")
+	}
+}
+
+func TestIsEmpty_RepoWithCommit(t *testing.T) {
+	dir := initTestRepo(t)
+	g := NewGit(dir)
+
+	empty, err := g.IsEmpty()
+	if err != nil {
+		t.Fatalf("IsEmpty: %v", err)
+	}
+	if empty {
+		t.Error("expected repo with commits to not be empty")
+	}
+}
+
 func TestRefExists_ValidRef(t *testing.T) {
 	dir := initTestRepo(t)
 	g := NewGit(dir)


### PR DESCRIPTION
## Summary
- `AddRig()` now checks if the cloned bare repo has any refs before attempting branch detection and checkout.
- Empty repos (no commits) previously caused an opaque git checkout error because the fallback default branch `"main"` didn't exist.
- Now returns a clear error: `"repository <url> is empty (no commits). Push at least one commit before adding it as a rig"`.
- Added `Git.IsEmpty()` method using `show-ref` to detect repos with no refs, with 2 tests.

Closes #1055

## Test plan
- [x] `go test ./internal/git/ -run TestIsEmpty` — both tests pass
- [x] `go test ./internal/rig/` — all rig manager tests pass
- [x] `go build ./...` — clean compilation

🤖 Generated with [Claude Code](https://claude.com/claude-code)