### PR TITLE
fix(config): harden cost-tier ephemeral resolution and test isolation

### DIFF
--- a/internal/config/cost_tier.go
+++ b/internal/config/cost_tier.go
@@ -35,6 +35,9 @@ func IsValidTier(tier string) bool {
 // TierManagedRoles is the set of roles whose model selection is managed by cost tiers.
 // These are the only roles that ApplyCostTier modifies — any other custom RoleAgents
 // entries (e.g., user-defined roles or non-Claude agents for non-tier roles) are preserved.
+//
+// Excluded roles: "dog" (watchdog/monitoring utility — always uses default agent)
+// and "boot" (deacon bootstrap sub-role — transient, always uses default agent).
 var TierManagedRoles = []string{"mayor", "deacon", "witness", "refinery", "polecat", "crew"}
 
 // CostTierRoleAgents returns the role_agents mapping for a given tier.

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1269,10 +1269,16 @@ func resolveRoleAgentConfigCore(role, townRoot, rigPath string) *RuntimeConfig {
 				return tierRC
 			}
 		} else {
-			// Tier says "use default" for this role — skip persisted RoleAgents
-			// to prevent stale config from leaking through, go straight to
-			// default resolution (rig's Agent → town's DefaultAgent → "claude").
-			return resolveAgentConfigInternal(townRoot, rigPath)
+			// Tier says "use default" for this role — but if there's an explicit
+			// non-Claude override, respect it (cost tiers only manage Claude models).
+			if hasExplicitNonClaudeOverride(role, townSettings, rigSettings) {
+				// Fall through to normal resolution below
+			} else {
+				// Skip persisted RoleAgents to prevent stale config from leaking
+				// through, go straight to default resolution
+				// (rig's Agent → town's DefaultAgent → "claude").
+				return resolveAgentConfigInternal(townRoot, rigPath)
+			}
 		}
 	}
 
@@ -1312,6 +1318,10 @@ func resolveRoleAgentConfigCore(role, townRoot, rigPath string) *RuntimeConfig {
 // ResolveRoleAgentName returns the agent name that would be used for a specific role.
 // This is useful for logging and diagnostics.
 // Returns the agent name and whether it came from role-specific configuration.
+//
+// NOTE: This function does not account for ephemeral cost tier overrides
+// (GT_COST_TIER env var). It reflects persisted config only. For the actual
+// runtime agent config, use ResolveRoleAgentConfig.
 func ResolveRoleAgentName(role, townRoot, rigPath string) (agentName string, isRoleSpecific bool) {
 	// Load rig settings
 	var rigSettings *RigSettings


### PR DESCRIPTION
## Summary

Post-merge hardening for #1564 (cost-tier presets by @seanbearden). Fixes a bug in the ephemeral tier nil-rc path and improves test isolation.

## Related Issue

Follow-up to #1564

## Changes

- **Fix ephemeral tier nil-rc path dropping non-Claude overrides:** When a tier maps a role to `""` (use default), the resolver now checks `hasExplicitNonClaudeOverride` before skipping persisted RoleAgents. Example: economy tier maps `polecat=""` but a rig override sets `polecat=gemini` — previously the gemini assignment was silently dropped.
- **Replace `os.Setenv`/`os.Unsetenv` with `t.Setenv` in ephemeral tier tests:** The test file uses `t.Parallel()` extensively (100+ occurrences). Process-global env mutation via `os.Setenv` risks data races with concurrent tests that read `GT_COST_TIER` through the agent resolution chain. `t.Setenv` is test-scoped and automatically prevents parallel execution conflicts.
- **Document `TierManagedRoles` exclusion of `dog` and `boot` roles** — explains why these roles are intentionally omitted from tier management.
- **Document `ResolveRoleAgentName`'s lack of ephemeral tier awareness** — notes that this diagnostic function reflects persisted config only, not `GT_COST_TIER` overrides.

## Testing

- [x] Unit tests pass (`go test ./internal/config/...`)
- [x] New test `TestResolveRoleAgentConfig_EphemeralDefaultPreservesNonClaudeOverride` validates the nil-rc fix
- [x] All 11 ephemeral tier tests pass with `t.Setenv` migration

## Checklist
- [x] Code follows project style
- [x] No breaking changes
- [x] Tests added for bug fix