### PR TITLE
fix(test): skip warrant execution test on Windows

### DIFF
--- a/internal/cmd/boot_test.go
+++ b/internal/cmd/boot_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -246,6 +247,9 @@ func readTestWarrant(t *testing.T, dir string, target string) Warrant {
 // This covers the normal case during degraded triage: sessions have been killed
 // by other means, or the warrant fires in the same cycle that restarts everything.
 func TestExecuteWarrants_MarksPendingAsExecuted(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping warrant execution test on Windows (no tmux)")
+	}
 	// Register prefixes so targetToSessionName can resolve "gastown" → "gt"
 	setupWarrantTestRegistry(t)
 


### PR DESCRIPTION
## Summary

Skip `TestExecuteWarrants_MarksPendingAsExecuted` on Windows where tmux is not available.

## Related Issue

Fixes Windows CI failure introduced by #1686.

## Changes

- Add `runtime.GOOS == "windows"` skip guard to `TestExecuteWarrants_MarksPendingAsExecuted` in `internal/cmd/boot_test.go`
- This test exercises `executeWarrants` → `executeOneWarrant` → `tmux.HasSession`, which requires tmux to be installed

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Verified existing Windows skip pattern matches codebase convention (e.g., `internal/witness/handlers_test.go`)

## Checklist

- [x] Code follows project style
- [x] No breaking changes