### PR TITLE
fix: dashboard shows 0 convoys (#1698)

### DIFF
--- a/internal/tui/convoy/model.go
+++ b/internal/tui/convoy/model.go
@@ -91,7 +91,7 @@ func loadConvoys(townBeads string) ([]ConvoyItem, error) {
 	defer cancel()
 
 	// Get list of open convoys
-	listArgs := []string{"list", "--label=gt:convoy", "--json"}
+	listArgs := []string{"list", "--type=convoy", "--json"}
 	listCmd := exec.CommandContext(ctx, "bd", listArgs...)
 	listCmd.Dir = townBeads
 	var stdout bytes.Buffer

--- a/internal/tui/feed/convoy.go
+++ b/internal/tui/feed/convoy.go
@@ -86,7 +86,7 @@ func FetchConvoys(townRoot string) (*ConvoyState, error) {
 
 // listConvoys returns convoys with the given status
 func listConvoys(beadsDir, status string) ([]convoyListItem, error) {
-	listArgs := []string{"list", "--label=gt:convoy", "--status=" + status, "--json"}
+	listArgs := []string{"list", "--type=convoy", "--status=" + status, "--json"}
 
 	ctx, cancel := context.WithTimeout(context.Background(), constants.BdSubprocessTimeout)
 	defer cancel()

--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -121,7 +121,7 @@ func NewLiveConvoyFetcher() (*LiveConvoyFetcher, error) {
 // FetchConvoys fetches all open convoys with their activity data.
 func (f *LiveConvoyFetcher) FetchConvoys() ([]ConvoyRow, error) {
 	// List all open convoy issues
-	stdout, err := f.runBdCmd(f.townRoot, "list", "--label=gt:convoy", "--status=open", "--json")
+	stdout, err := f.runBdCmd(f.townRoot, "list", "--type=convoy", "--status=open", "--json")
 	if err != nil {
 		return nil, fmt.Errorf("listing convoys: %w", err)
 	}


### PR DESCRIPTION
Closes #1698

## Summary
- **Bug 1**: Dashboard, TUI feed, and TUI convoy view all queried convoys with `--label=gt:convoy`, but convoy creation uses `--type=convoy` and never sets a `gt:convoy` label — so the query always returned zero results. Fixed all three call sites to use `--type=convoy`.
- **Bug 2**: `/api/options` endpoint parsed `gt convoy list` text output by splitting on whitespace and taking `parts[0]`, which produced `["1.", "2.", "Use"]` instead of convoy IDs. Switched to `--json` output with a proper JSON parser (`parseConvoyListJSON`).

## Test plan
- [x] Added `TestParseConvoyListJSON` covering: valid JSON, empty array, invalid JSON, empty string, empty ID filtering
- [x] `go test ./internal/web/... ./internal/tui/feed/... ./internal/tui/convoy/...` all pass
- [x] `go vet` clean on all changed packages