### PR TITLE
fix: cache last good status in watch mode to prevent empty bubbles

### DIFF
--- a/internal/cmd/status_test.go
+++ b/internal/cmd/status_test.go
@@ -417,6 +417,95 @@ func TestIsAgentCmdline(t *testing.T) {
 	}
 }
 
+func TestCountRunningAgents(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		status TownStatus
+		want   int
+	}{
+		{
+			name:   "empty status",
+			status: TownStatus{},
+			want:   0,
+		},
+		{
+			name: "global agents only",
+			status: TownStatus{
+				Agents: []AgentRuntime{
+					{Name: "mayor", Running: true},
+					{Name: "deacon", Running: false},
+				},
+			},
+			want: 1,
+		},
+		{
+			name: "rig agents only",
+			status: TownStatus{
+				Rigs: []RigStatus{
+					{
+						Agents: []AgentRuntime{
+							{Name: "polecat-1", Running: true},
+							{Name: "witness", Running: true},
+						},
+					},
+				},
+			},
+			want: 2,
+		},
+		{
+			name: "mixed global and rig agents",
+			status: TownStatus{
+				Agents: []AgentRuntime{
+					{Name: "mayor", Running: true},
+				},
+				Rigs: []RigStatus{
+					{
+						Agents: []AgentRuntime{
+							{Name: "polecat-1", Running: true},
+							{Name: "witness", Running: false},
+						},
+					},
+					{
+						Agents: []AgentRuntime{
+							{Name: "polecat-2", Running: true},
+						},
+					},
+				},
+			},
+			want: 3,
+		},
+		{
+			name: "all not running",
+			status: TownStatus{
+				Agents: []AgentRuntime{
+					{Name: "mayor", Running: false},
+				},
+				Rigs: []RigStatus{
+					{
+						Agents: []AgentRuntime{
+							{Name: "polecat-1", Running: false},
+						},
+					},
+				},
+			},
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := countRunningAgents(tt.status)
+			if got != tt.want {
+				t.Errorf(
+					"countRunningAgents() = %d, want %d",
+					got, tt.want,
+				)
+			}
+		})
+	}
+}
+
 func TestExtractBaseName(t *testing.T) {
 	t.Parallel()
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Add retry-on-failure and cache-based fallback to `runStatusWatch()` to prevent transient tmux failures from showing empty agent bubbles
- When `gatherStatus()` returns zero running agents after previously having some, retry once then fall back to cached data (up to 5 missed cycles)
- Display a staleness note when using cached data so the user knows the display may be slightly behind
- Add `countRunningAgents()` helper with table-driven tests

Closes #1701

## Test plan

- [x] `TestCountRunningAgents` covers: empty status, global-only, rig-only, mixed, all-not-running
- [x] All existing status tests pass (`TestRunStatusWatch_*`, `TestDiscoverRigAgents_*`, `TestBuildStatusIndicator_*`)
- [x] Full build passes (`go build ./...`)
- [ ] Manual: run `gt status --watch` with active agents and verify stable display

🤖 Generated with [Claude Code](https://claude.com/claude-code)