### PR TITLE
fixup: use bd list directly for convoy options (#1699)

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -726,7 +726,7 @@ func (h *APIHandler) handleOptions(w http.ResponseWriter, r *http.Request) {
 	// Fetch convoys
 	go func() {
 		defer wg.Done()
-		if output, err := h.runGtCommand(r.Context(), 3*time.Second, []string{"convoy", "list", "--json"}); err == nil {
+		if output, err := h.runBdCommand(r.Context(), 3*time.Second, []string{"list", "--type=convoy", "--json"}); err == nil {
 			mu.Lock()
 			resp.Convoys = parseConvoyListJSON(output)
 			mu.Unlock()
@@ -821,12 +821,13 @@ func parseRigListOutput(output string) []string {
 	return rigs
 }
 
-// parseConvoyListJSON extracts convoy IDs from JSON output of "gt convoy list --json".
+// parseConvoyListJSON extracts convoy IDs from JSON output of "bd list --type=convoy --json".
 func parseConvoyListJSON(jsonStr string) []string {
 	var convoys []struct {
 		ID string `json:"id"`
 	}
 	if err := json.Unmarshal([]byte(jsonStr), &convoys); err != nil {
+		log.Printf("warning: parseConvoyListJSON: %v", err)
 		return nil
 	}
 	ids := make([]string, 0, len(convoys))


### PR DESCRIPTION
## Summary
Follow-up to #1699. The triple-model review (Claude + Codex + Gemini) found that using `gt convoy list --json` via `runGtCommand` in `/api/options` had two issues:

- **Stdout corruption risk:** `gt convoy list --json` runs Go enrichment code that calls `style.PrintWarning()` (writes to stdout). If any convoy fails enrichment, warning text is interleaved before the JSON array, corrupting `json.Unmarshal`.
- **N² subprocess overhead:** The JSON mode enriches every convoy via multiple subprocesses (tracked issues, completion counts, workers) — all discarded since only IDs are needed.

This fixup switches to `runBdCommand` with `bd list --type=convoy --json` directly, and adds `log.Printf` for parse errors.

## Changes
- Switch `/api/options` convoy fetch from `runGtCommand("convoy","list","--json")` to `runBdCommand(ctx, ..., []string{"list","--type=convoy","--json"})`
- Add warning log in `parseConvoyListJSON` when `json.Unmarshal` fails

## Test plan
- [x] `go test ./internal/web/...` passes
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)