### PR TITLE
fix(mol): harden gt mol squash --jitter implementation

### DIFF
--- a/docs/concepts/molecules.md
+++ b/docs/concepts/molecules.md
@@ -115,7 +115,7 @@ Next ready in molecule:
 ✓ Closed gt-abc.6: Exit decision
 
 Molecule gt-abc complete! All steps closed.
-Consider: bd mol squash gt-abc --summary '...'
+Consider: gt mol squash --summary '...'
 ```
 
 ## Molecule Commands

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -282,7 +282,7 @@ gt mol step done <step>      # Complete a molecule step
 
 ```
 1. Complete work steps
-2. bd mol squash (create digest)
+2. gt mol squash (create digest)
 3. Submit to merge queue
 4. gt handoff (request shutdown)
 5. Wait for Witness to kill session
@@ -689,7 +689,7 @@ Deacon, Witness, and Refinery run continuous patrol loops using wisps:
 ```
 1. bd mol wisp mol-<role>-patrol
 2. Execute steps (check workers, process queue, run plugins)
-3. bd mol squash (or burn if routine)
+3. gt mol squash --jitter 10s (or burn if routine)
 4. Loop
 ```
 

--- a/internal/cmd/molecule.go
+++ b/internal/cmd/molecule.go
@@ -6,8 +6,9 @@ import (
 
 // Molecule command flags
 var (
-	moleculeJSON   bool
-	moleculeJitter string // jitter duration for squash (e.g. "10s")
+	moleculeJSON    bool
+	moleculeJitter  string // jitter duration for squash (e.g. "10s")
+	moleculeSummary string // optional summary for squash digest
 )
 
 var moleculeCmd = &cobra.Command{
@@ -244,6 +245,7 @@ func init() {
 	// Squash flags
 	moleculeSquashCmd.Flags().BoolVar(&moleculeJSON, "json", false, "Output as JSON")
 	moleculeSquashCmd.Flags().StringVar(&moleculeJitter, "jitter", "", "Sleep a random duration from 0 to this value before squashing (e.g. '10s') to reduce concurrent Dolt lock contention")
+	moleculeSquashCmd.Flags().StringVar(&moleculeSummary, "summary", "", "Optional summary for the squash digest (e.g. patrol observations)")
 
 	// Add step subcommand with its children
 	moleculeStepCmd.AddCommand(moleculeStepDoneCmd)

--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -260,7 +260,7 @@ func outputDeaconPatrolContext(ctx RoleContext) {
 			"Execute the step (heartbeat, mail, health checks, etc.)",
 			"Close step: `bd close <step-id>`",
 			"Check next: `bd mol current`",
-			"At cycle end (loop-or-exit step):\n   - If context LOW:\n     * Squash: `bd mol squash <mol-id> --summary \"<summary>\"`\n     * Create new patrol: `" + cli.Name() + " patrol new`\n     * Continue executing from inbox-check step\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Deacon patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",
+			"At cycle end (loop-or-exit step):\n   - If context LOW:\n     * Squash: `" + cli.Name() + " mol squash --jitter 10s --summary \"<summary>\"`\n     * Create new patrol: `" + cli.Name() + " patrol new`\n     * Continue executing from inbox-check step\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Deacon patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",
 		},
 	}
 	outputPatrolContext(cfg)
@@ -283,7 +283,7 @@ func outputWitnessPatrolContext(ctx RoleContext) {
 			"Execute the step (survey polecats, inspect, nudge, etc.)",
 			"Close step: `bd close <step-id>`",
 			"Check next: `bd mol current`",
-			"At cycle end (loop-or-exit step):\n   - If context LOW:\n     * Squash: `bd mol squash <mol-id> --summary \"<summary>\"`\n     * Create new patrol: `" + cli.Name() + " patrol new`\n     * Continue executing from inbox-check step\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Witness patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",
+			"At cycle end (loop-or-exit step):\n   - If context LOW:\n     * Squash: `" + cli.Name() + " mol squash --jitter 10s --summary \"<summary>\"`\n     * Create new patrol: `" + cli.Name() + " patrol new`\n     * Continue executing from inbox-check step\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Witness patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",
 		},
 	}
 	outputPatrolContext(cfg)
@@ -307,7 +307,7 @@ func outputRefineryPatrolContext(ctx RoleContext) {
 			"Execute the step (queue scan, process branch, tests, merge)",
 			"Close step: `bd close <step-id>`",
 			"Check next: `bd mol current`",
-			"At cycle end (loop-or-exit step):\n   - If context LOW:\n     * Squash: `bd mol squash <mol-id> --summary \"<summary>\"`\n     * Create new patrol: `" + cli.Name() + " patrol new`\n     * Continue executing from inbox-check step\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Refinery patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",
+			"At cycle end (loop-or-exit step):\n   - If context LOW:\n     * Squash: `" + cli.Name() + " mol squash --jitter 10s --summary \"<summary>\"`\n     * Create new patrol: `" + cli.Name() + " patrol new`\n     * Continue executing from inbox-check step\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Refinery patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",
 		},
 	}
 	outputPatrolContext(cfg)

--- a/internal/templates/roles/deacon.md.tmpl
+++ b/internal/templates/roles/deacon.md.tmpl
@@ -237,7 +237,7 @@ Then squash and decide:
 
 ```bash
 # Squash the wisp to a digest
-bd mol squash <wisp-id> --summary="Patrol complete: checked inbox, scanned health, no issues"
+gt mol squash --jitter 10s --summary="Patrol complete: checked inbox, scanned health, no issues"
 
 # Option A: Loop (low context)
 {{ cmd }} patrol new

--- a/internal/templates/roles/refinery.md.tmpl
+++ b/internal/templates/roles/refinery.md.tmpl
@@ -352,7 +352,7 @@ Then squash and decide:
 
 ```bash
 # Squash the wisp to a digest
-bd mol squash <wisp-id> --summary="Patrol: merged 3 branches, no issues"
+gt mol squash --jitter 10s --summary="Patrol: merged 3 branches, no issues"
 
 # Assess session health: RSS, session age, context, work done
 RSS_MB=$(( $(ps -o rss= -p $$) / 1024 ))
@@ -408,7 +408,7 @@ gt mail send {{ .RigName }}/<worker> -s "Rebase needed" \
 - `{{ cmd }} hook` - Check for hooked patrol
 - `bd mol wisp <mol>` - Create patrol wisp
 - `bd update <wisp-id> --status=hooked --assignee=...` - Hook the wisp
-- `bd mol squash <id> --summary="..."` - Squash completed patrol
+- `gt mol squash --jitter 10s --summary="..."` - Squash completed patrol
 
 ### Git Operations
 - `git fetch origin` - Fetch all remote branches


### PR DESCRIPTION
## Summary

Follow-up to #1691 which added the `--jitter` flag to `gt mol squash`. During adoption review, several gaps were identified that this PR addresses: missing `--summary` flag, stale `bd mol squash` references in patrol instructions and docs, non-cancellable `time.Sleep`, and lack of input validation for negative durations.

## Related Issue

Follow-up to #1691

## Changes

- Register `--summary` flag on `gt mol squash` and wire into digest description
- Update `prime_molecule.go` patrol instructions: `bd mol squash` → `gt mol squash --jitter 10s`
- Update role templates (deacon, refinery) to use `gt mol squash --jitter 10s`
- Replace `time.Sleep` with context-aware `select` for cancellation during jitter
- Add stderr log line for jitter sleep duration (operability)
- Move jitter sleep after workspace/attachment validation (fail fast on no-ops)
- Reject negative `--jitter` durations with clear error message
- Update `docs/reference.md` and `docs/concepts/molecules.md` stale squash refs
- Add unit tests for jitter: invalid duration, negative duration, zero duration, context cancellation

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] `TestSquashJitterInvalidDuration` — verifies invalid duration string is rejected
- [x] `TestSquashJitterNegativeDuration` — verifies negative duration is rejected
- [x] `TestSquashJitterZeroDuration` — verifies zero duration skips sleep
- [x] `TestSquashJitterContextCancellation` — verifies cancelled context returns promptly
- [x] `TestPatrolFormulasHaveSquashCycle` — verifies all 3 patrol formulas use `gt mol squash --jitter`

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)