### PR TITLE
fix(doctor): fix --add-labels flag (bd renamed to --add-label)

### DIFF
--- a/internal/doctor/agent_beads_check.go
+++ b/internal/doctor/agent_beads_check.go
@@ -274,7 +274,7 @@ func (c *AgentBeadsCheck) Fix(ctx *CheckContext) error {
 
 // addLabelToBead adds a label to an existing bead via bd update.
 func addLabelToBead(townRoot, id, label string) error {
-	cmd := exec.Command("bd", "update", id, "--add-labels="+label)
+	cmd := exec.Command("bd", "update", id, "--add-label="+label)
 	cmd.Dir = townRoot
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("%s: %s", err, strings.TrimSpace(string(output)))


### PR DESCRIPTION
## Summary
- The `bd` CLI renamed `--add-labels` to `--add-label` (singular) in a recent update
- `addLabelToBead` in `agent_beads_check.go` was using the old flag name, causing `gt doctor --fix` to fail when adding `gt:agent` labels to existing beads
- One-line fix: `--add-labels` → `--add-label`

## Test plan
- [ ] Run `gt doctor --fix` on a workspace with beads missing the `gt:agent` label
- [ ] Verify `bd update <id> --add-label=gt:agent` succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)