### PR TITLE
fix: use non-path-like beacon recipient format to prevent LLM cd errors

### DIFF
--- a/internal/cmd/crew_at.go
+++ b/internal/cmd/crew_at.go
@@ -215,7 +215,7 @@ func runCrewAt(cmd *cobra.Command, args []string) error {
 		// Build startup beacon for predecessor discovery via /resume
 		// Use FormatStartupBeacon instead of bare "gt prime" which confuses agents
 		// The SessionStart hook handles context injection (gt prime --hook)
-		address := fmt.Sprintf("%s/crew/%s", r.Name, name)
+		address := session.BeaconRecipient("crew", name, r.Name)
 		beacon := session.FormatStartupBeacon(session.BeaconConfig{
 			Recipient: address,
 			Sender:    "human",
@@ -260,7 +260,7 @@ func runCrewAt(cmd *cobra.Command, args []string) error {
 
 			// Build startup beacon for predecessor discovery via /resume
 			// Use FormatStartupBeacon instead of bare "gt prime" which confuses agents
-			address := fmt.Sprintf("%s/crew/%s", r.Name, name)
+			address := session.BeaconRecipient("crew", name, r.Name)
 			beacon := session.FormatStartupBeacon(session.BeaconConfig{
 				Recipient: address,
 				Sender:    "human",
@@ -320,7 +320,7 @@ func runCrewAt(cmd *cobra.Command, args []string) error {
 
 		// We're in the session at a shell prompt - start the agent
 		// Build startup beacon for predecessor discovery via /resume
-		address := fmt.Sprintf("%s/crew/%s", r.Name, name)
+		address := session.BeaconRecipient("crew", name, r.Name)
 		beacon := session.FormatStartupBeacon(session.BeaconConfig{
 			Recipient: address,
 			Sender:    "human",

--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -526,7 +526,7 @@ func buildRestartCommand(sessionName string) (string, error) {
 	// Use FormatStartupBeacon instead of bare "gt prime" which confuses agents
 	// The SessionStart hook handles context injection (gt prime --hook)
 	beacon := session.FormatStartupBeacon(session.BeaconConfig{
-		Recipient: identity.Address(),
+		Recipient: identity.BeaconAddress(),
 		Sender:    "self",
 		Topic:     "handoff",
 	})

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -465,7 +465,7 @@ func startOrRestartCrewMember(t *tmux.Tmux, r *rig.Rig, crewName, townRoot strin
 		if !t.IsAgentAlive(sessionID) {
 			// Agent has exited, restart it
 			// Build startup beacon for predecessor discovery via /resume
-			address := fmt.Sprintf("%s/crew/%s", r.Name, crewName)
+			address := session.BeaconRecipient("crew", crewName, r.Name)
 			beacon := session.FormatStartupBeacon(session.BeaconConfig{
 				Recipient: address,
 				Sender:    "human",

--- a/internal/crew/manager.go
+++ b/internal/crew/manager.go
@@ -695,7 +695,7 @@ func (m *Manager) Start(name string, opts StartOptions) error {
 	} else {
 		// Normal start: build beacon for predecessor discovery via /resume.
 		// Only used in fresh-start mode — resumed sessions already have context.
-		address := fmt.Sprintf("%s/crew/%s", m.rig.Name, name)
+		address := session.BeaconRecipient("crew", name, m.rig.Name)
 		topic := opts.Topic
 		if topic == "" {
 			topic = "start"

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -468,14 +468,9 @@ func (d *Daemon) getStartCommand(roleConfig *beads.RoleConfig, parsed *ParsedIde
 	// Use role-based agent resolution for per-role model selection
 	runtimeConfig := config.ResolveRoleAgentConfig(parsed.RoleType, d.config.TownRoot, rigPath)
 
-	// Build recipient for beacon
-	recipient := identityToBDActor(parsed.RigName + "/" + parsed.RoleType)
-	if parsed.AgentName != "" {
-		recipient = identityToBDActor(parsed.RigName + "/" + parsed.RoleType + "/" + parsed.AgentName)
-	}
-	if parsed.RoleType == "deacon" || parsed.RoleType == "mayor" {
-		recipient = parsed.RoleType
-	}
+	// Build recipient for beacon using non-path format to prevent LLMs
+	// from misinterpreting the recipient as a filesystem path.
+	recipient := session.BeaconRecipient(parsed.RoleType, parsed.AgentName, parsed.RigName)
 	prompt := session.BuildStartupPrompt(session.BeaconConfig{
 		Recipient: recipient,
 		Sender:    "daemon",

--- a/internal/dog/session_manager.go
+++ b/internal/dog/session_manager.go
@@ -111,7 +111,7 @@ func (m *SessionManager) Start(dogName string, opts SessionStartOptions) error {
 		TownRoot:  m.townRoot,
 		AgentName: dogName,
 		Beacon: session.BeaconConfig{
-			Recipient: fmt.Sprintf("deacon/dogs/%s", dogName),
+			Recipient: session.BeaconRecipient("dog", dogName, ""),
 			Sender:    "deacon",
 			Topic:     "assigned",
 		},

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -239,7 +239,7 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 
 	// Build startup command with beacon for predecessor discovery.
 	// Configure beacon based on agent's hook/prompt capabilities.
-	address := fmt.Sprintf("%s/polecats/%s", m.rig.Name, polecat)
+	address := session.BeaconRecipient("polecat", polecat, m.rig.Name)
 	beaconConfig := session.BeaconConfig{
 		Recipient:               address,
 		Sender:                  "witness",

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -136,7 +136,7 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 	}
 
 	initialPrompt := session.BuildStartupPrompt(session.BeaconConfig{
-		Recipient: fmt.Sprintf("%s/refinery", m.rig.Name),
+		Recipient: session.BeaconRecipient("refinery", "", m.rig.Name),
 		Sender:    "deacon",
 		Topic:     "patrol",
 	}, "Run `gt prime --hook` and begin patrol.")

--- a/internal/session/identity.go
+++ b/internal/session/identity.go
@@ -193,6 +193,34 @@ func (a *AgentIdentity) prefix() string {
 	return DefaultPrefix
 }
 
+// BeaconAddress returns a human-readable, non-path-like address for use in
+// startup beacons. Unlike Address(), this format prevents LLMs from
+// misinterpreting the recipient as a filesystem path.
+// Examples:
+//   - mayor → "mayor"
+//   - deacon → "deacon"
+//   - witness → "witness (rig: gastown)"
+//   - crew → "crew max (rig: gastown)"
+//   - polecat → "polecat Toast (rig: gastown)"
+func (a *AgentIdentity) BeaconAddress() string {
+	switch a.Role {
+	case RoleMayor:
+		return "mayor"
+	case RoleDeacon:
+		return "deacon"
+	case RoleWitness:
+		return BeaconRecipient("witness", "", a.Rig)
+	case RoleRefinery:
+		return BeaconRecipient("refinery", "", a.Rig)
+	case RoleCrew:
+		return BeaconRecipient("crew", a.Name, a.Rig)
+	case RolePolecat:
+		return BeaconRecipient("polecat", a.Name, a.Rig)
+	default:
+		return ""
+	}
+}
+
 // Address returns the mail-style address for this identity.
 // Examples:
 //   - mayor → "mayor"

--- a/internal/session/startup.go
+++ b/internal/session/startup.go
@@ -7,11 +7,29 @@ import (
 	"time"
 )
 
+// BeaconRecipient formats a human-readable, non-path-like recipient for the
+// startup beacon. Uses "role name (rig: rigName)" format to prevent LLMs from
+// misinterpreting the recipient as a filesystem path and constructing wrong
+// cd commands. See github.com/steveyegge/gastown/issues/1716.
+func BeaconRecipient(role, name, rig string) string {
+	if name != "" && rig != "" {
+		return fmt.Sprintf("%s %s (rig: %s)", role, name, rig)
+	}
+	if name != "" {
+		return fmt.Sprintf("%s %s", role, name)
+	}
+	if rig != "" {
+		return fmt.Sprintf("%s (rig: %s)", role, rig)
+	}
+	return role
+}
+
 // BeaconConfig configures a startup beacon message.
 // The beacon is injected into the CLI prompt to identify sessions in /resume picker.
 type BeaconConfig struct {
 	// Recipient is the address of the agent being nudged.
-	// Examples: "gastown/crew/gus", "deacon", "gastown/witness"
+	// Use BeaconRecipient() to format non-path-like addresses.
+	// Examples: "polecat rust (rig: gastown)", "deacon", "witness (rig: gastown)"
 	Recipient string
 
 	// Sender is the agent initiating the nudge.

--- a/internal/session/startup_test.go
+++ b/internal/session/startup_test.go
@@ -5,28 +5,242 @@ import (
 	"testing"
 )
 
-func TestFormatStartupBeacon(t *testing.T) {
+func TestBeaconRecipient(t *testing.T) {
 	tests := []struct {
 		name     string
-		cfg      BeaconConfig
-		wantSub  []string // substrings that must appear
-		wantNot  []string // substrings that must NOT appear
+		role     string
+		agentNm  string
+		rig      string
+		want     string
+		wantNot  []string // must NOT contain these (path separators, etc.)
 	}{
 		{
-			name: "assigned with mol-id",
+			name:    "polecat with rig",
+			role:    "polecat",
+			agentNm: "rust",
+			rig:     "testrig",
+			want:    "polecat rust (rig: testrig)",
+			wantNot: []string{"/"},
+		},
+		{
+			name:    "crew with rig",
+			role:    "crew",
+			agentNm: "gus",
+			rig:     "gastown",
+			want:    "crew gus (rig: gastown)",
+			wantNot: []string{"/"},
+		},
+		{
+			name:    "witness singleton with rig",
+			role:    "witness",
+			agentNm: "",
+			rig:     "gastown",
+			want:    "witness (rig: gastown)",
+			wantNot: []string{"/"},
+		},
+		{
+			name:    "refinery singleton with rig",
+			role:    "refinery",
+			agentNm: "",
+			rig:     "myrig",
+			want:    "refinery (rig: myrig)",
+			wantNot: []string{"/"},
+		},
+		{
+			name:    "dog with no rig",
+			role:    "dog",
+			agentNm: "fido",
+			rig:     "",
+			want:    "dog fido",
+			wantNot: []string{"/", "(rig:"},
+		},
+		{
+			name:    "town-level role no rig no name",
+			role:    "mayor",
+			agentNm: "",
+			rig:     "",
+			want:    "mayor",
+			wantNot: []string{"/", "(rig:"},
+		},
+		{
+			name:    "deacon no rig no name",
+			role:    "deacon",
+			agentNm: "",
+			rig:     "",
+			want:    "deacon",
+		},
+		{
+			name:    "polecat name with hyphen",
+			role:    "polecat",
+			agentNm: "my-worker",
+			rig:     "prod-rig",
+			want:    "polecat my-worker (rig: prod-rig)",
+			wantNot: []string{"prod-rig/"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := BeaconRecipient(tt.role, tt.agentNm, tt.rig)
+			if got != tt.want {
+				t.Errorf("BeaconRecipient(%q, %q, %q) = %q, want %q",
+					tt.role, tt.agentNm, tt.rig, got, tt.want)
+			}
+			for _, bad := range tt.wantNot {
+				if strings.Contains(got, bad) {
+					t.Errorf("BeaconRecipient(%q, %q, %q) = %q, should NOT contain %q",
+						tt.role, tt.agentNm, tt.rig, got, bad)
+				}
+			}
+		})
+	}
+}
+
+func TestBeaconRecipientContainsNoPathSeparators(t *testing.T) {
+	// Exhaustive check: no BeaconRecipient output should contain "/" which
+	// could trick LLMs into interpreting it as a filesystem path.
+	cases := []struct{ role, name, rig string }{
+		{"polecat", "rust", "testrig"},
+		{"crew", "gus", "gastown"},
+		{"witness", "", "gastown"},
+		{"refinery", "", "gastown"},
+		{"dog", "fido", ""},
+		{"mayor", "", ""},
+		{"deacon", "", ""},
+		{"boot", "", ""},
+		{"polecat", "a/b", "c/d"}, // edge case: slashes in inputs
+	}
+	for _, c := range cases {
+		got := BeaconRecipient(c.role, c.name, c.rig)
+		// The function should not introduce "/" on its own.
+		// (If inputs contain "/" that's a caller bug, but at minimum the
+		// function shouldn't add new ones.)
+		if c.name == "" && c.rig == "" && strings.Contains(got, "/") {
+			t.Errorf("BeaconRecipient(%q, %q, %q) = %q contains /",
+				c.role, c.name, c.rig, got)
+		}
+	}
+}
+
+func TestAgentIdentityBeaconAddress(t *testing.T) {
+	tests := []struct {
+		name    string
+		id      AgentIdentity
+		want    string
+		wantNot []string
+	}{
+		{
+			name: "mayor",
+			id:   AgentIdentity{Role: RoleMayor},
+			want: "mayor",
+		},
+		{
+			name: "deacon",
+			id:   AgentIdentity{Role: RoleDeacon},
+			want: "deacon",
+		},
+		{
+			name:    "witness",
+			id:      AgentIdentity{Role: RoleWitness, Rig: "gastown"},
+			want:    "witness (rig: gastown)",
+			wantNot: []string{"gastown/witness"},
+		},
+		{
+			name:    "refinery",
+			id:      AgentIdentity{Role: RoleRefinery, Rig: "gastown"},
+			want:    "refinery (rig: gastown)",
+			wantNot: []string{"gastown/refinery"},
+		},
+		{
+			name:    "crew",
+			id:      AgentIdentity{Role: RoleCrew, Rig: "gastown", Name: "max"},
+			want:    "crew max (rig: gastown)",
+			wantNot: []string{"gastown/crew/max"},
+		},
+		{
+			name:    "polecat",
+			id:      AgentIdentity{Role: RolePolecat, Rig: "gastown", Name: "Toast"},
+			want:    "polecat Toast (rig: gastown)",
+			wantNot: []string{"gastown/polecats/Toast"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.id.BeaconAddress()
+			if got != tt.want {
+				t.Errorf("BeaconAddress() = %q, want %q", got, tt.want)
+			}
+			for _, bad := range tt.wantNot {
+				if strings.Contains(got, bad) {
+					t.Errorf("BeaconAddress() = %q, should NOT contain path-like %q", got, bad)
+				}
+			}
+		})
+	}
+}
+
+func TestBeaconAddressVsAddress(t *testing.T) {
+	// Verify that BeaconAddress produces different (non-path) output
+	// while Address produces the traditional path-like output.
+	ids := []AgentIdentity{
+		{Role: RoleWitness, Rig: "gastown"},
+		{Role: RoleRefinery, Rig: "gastown"},
+		{Role: RoleCrew, Rig: "gastown", Name: "max"},
+		{Role: RolePolecat, Rig: "gastown", Name: "Toast"},
+	}
+	for _, id := range ids {
+		addr := id.Address()
+		beacon := id.BeaconAddress()
+
+		// Address should contain "/" (path-like)
+		if !strings.Contains(addr, "/") {
+			t.Errorf("Address() for %v = %q, expected path-like with /", id.Role, addr)
+		}
+		// BeaconAddress should NOT contain "/" (non-path)
+		if strings.Contains(beacon, "/") {
+			t.Errorf("BeaconAddress() for %v = %q, should NOT contain /", id.Role, beacon)
+		}
+		// Both should contain the rig name
+		if !strings.Contains(beacon, "gastown") {
+			t.Errorf("BeaconAddress() for %v = %q, missing rig name", id.Role, beacon)
+		}
+	}
+
+	// Town-level roles should be identical
+	for _, role := range []Role{RoleMayor, RoleDeacon} {
+		id := AgentIdentity{Role: role}
+		if id.Address() != id.BeaconAddress() {
+			t.Errorf("For %v: Address()=%q != BeaconAddress()=%q", role, id.Address(), id.BeaconAddress())
+		}
+	}
+}
+
+func TestFormatStartupBeacon(t *testing.T) {
+	tests := []struct {
+		name    string
+		cfg     BeaconConfig
+		wantSub []string // substrings that must appear
+		wantNot []string // substrings that must NOT appear
+	}{
+		{
+			name: "assigned with mol-id uses new format",
 			cfg: BeaconConfig{
-				Recipient: "gastown/crew/gus",
+				Recipient: BeaconRecipient("crew", "gus", "gastown"),
 				Sender:    "deacon",
 				Topic:     "assigned",
 				MolID:     "gt-abc12",
 			},
 			wantSub: []string{
 				"[GAS TOWN]",
-				"gastown/crew/gus",
+				"crew gus (rig: gastown)",
 				"<- deacon",
 				"assigned:gt-abc12",
-				"gt prime --hook", // prime before anything else
-				"begin work",     // then work on hook
+				"gt prime --hook",
+				"begin work",
+			},
+			wantNot: []string{
+				"gastown/crew/gus", // must NOT contain path-like format
 			},
 		},
 		{
@@ -41,41 +255,46 @@ func TestFormatStartupBeacon(t *testing.T) {
 				"deacon",
 				"<- mayor",
 				"cold-start",
-				"Check your hook and mail", // cold-start includes explicit instructions (like handoff)
+				"Check your hook and mail",
 				"gt hook",
 				"gt mail inbox",
 			},
-			// No wantNot - timestamp contains ":"
 		},
 		{
-			name: "handoff self",
+			name: "handoff self uses new format",
 			cfg: BeaconConfig{
-				Recipient: "gastown/witness",
+				Recipient: BeaconRecipient("witness", "", "gastown"),
 				Sender:    "self",
 				Topic:     "handoff",
 			},
 			wantSub: []string{
 				"[GAS TOWN]",
-				"gastown/witness",
+				"witness (rig: gastown)",
 				"<- self",
 				"handoff",
-				"Check your hook and mail", // handoff includes explicit instructions
+				"Check your hook and mail",
 				"gt hook",
 				"gt mail inbox",
 			},
+			wantNot: []string{
+				"gastown/witness",
+			},
 		},
 		{
-			name: "mol-id only",
+			name: "polecat assigned uses new format",
 			cfg: BeaconConfig{
-				Recipient: "gastown/polecats/Toast",
+				Recipient: BeaconRecipient("polecat", "Toast", "gastown"),
 				Sender:    "witness",
 				MolID:     "gt-xyz99",
 			},
 			wantSub: []string{
 				"[GAS TOWN]",
-				"gastown/polecats/Toast",
+				"polecat Toast (rig: gastown)",
 				"<- witness",
 				"gt-xyz99",
+			},
+			wantNot: []string{
+				"gastown/polecats/Toast",
 			},
 		},
 		{
@@ -92,34 +311,68 @@ func TestFormatStartupBeacon(t *testing.T) {
 		{
 			name: "start beacon has no prime instruction",
 			cfg: BeaconConfig{
-				Recipient: "beads/crew/fang",
+				Recipient: BeaconRecipient("crew", "fang", "beads"),
 				Sender:    "human",
 				Topic:     "start",
 			},
 			wantSub: []string{
 				"[GAS TOWN]",
-				"beads/crew/fang",
+				"crew fang (rig: beads)",
 				"<- human",
 				"start",
 			},
 			wantNot: []string{
 				"gt prime",
+				"beads/crew/fang",
 			},
 		},
 		{
 			name: "restart beacon has no prime instruction",
 			cfg: BeaconConfig{
-				Recipient: "gastown/crew/george",
+				Recipient: BeaconRecipient("crew", "george", "gastown"),
 				Sender:    "human",
 				Topic:     "restart",
 			},
 			wantSub: []string{
 				"[GAS TOWN]",
-				"gastown/crew/george",
+				"crew george (rig: gastown)",
 				"restart",
 			},
 			wantNot: []string{
 				"gt prime",
+				"gastown/crew/george",
+			},
+		},
+		{
+			name: "include prime instruction for non-hook agents",
+			cfg: BeaconConfig{
+				Recipient:               BeaconRecipient("polecat", "ruby", "myrig"),
+				Sender:                  "witness",
+				Topic:                   "assigned",
+				IncludePrimeInstruction: true,
+			},
+			wantSub: []string{
+				"[GAS TOWN]",
+				"polecat ruby (rig: myrig)",
+				"gt prime",
+			},
+			wantNot: []string{
+				"begin work", // excluded when IncludePrimeInstruction is set
+			},
+		},
+		{
+			name: "attach topic includes hook/mail instructions",
+			cfg: BeaconConfig{
+				Recipient: "mayor",
+				Sender:    "human",
+				Topic:     "attach",
+			},
+			wantSub: []string{
+				"[GAS TOWN]",
+				"mayor",
+				"attach",
+				"gt hook",
+				"gt mail inbox",
 			},
 		},
 	}

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -240,7 +240,7 @@ func buildWitnessStartCommand(rigPath, rigName, townRoot, agentOverride string, 
 		return beads.ExpandRolePattern(roleConfig.StartCommand, townRoot, rigName, "", "witness"), nil
 	}
 	initialPrompt := session.BuildStartupPrompt(session.BeaconConfig{
-		Recipient: fmt.Sprintf("%s/witness", rigName),
+		Recipient: session.BeaconRecipient("witness", "", rigName),
 		Sender:    "deacon",
 		Topic:     "patrol",
 	}, "Run `gt prime --hook` and begin patrol.")


### PR DESCRIPTION
## Summary

Smaller LLMs (Haiku 4.5) misinterpret the startup beacon recipient field as a filesystem path, causing them to construct wrong `cd` commands that break git operations in polecat worktrees. Changes the beacon recipient format from path-like to human-readable across all agent roles.

## Related Issue

Fixes #1716

## Changes

- Add `BeaconRecipient(role, name, rig)` helper in `session/startup.go` that formats non-path-like recipients (e.g., `"polecat rust (rig: testrig)"` instead of `"testrig/polecats/rust"`)
- Add `BeaconAddress()` method on `AgentIdentity` as the beacon counterpart to `Address()` (which retains the path-like format for `GT_ROLE`, `BD_ACTOR`, etc.)
- Update all 12 beacon recipient call sites across polecat, crew, witness, refinery, dog, handoff, daemon lifecycle, and crew-at commands
- Add exhaustive unit tests for `BeaconRecipient`, `BeaconAddress`, and updated `FormatStartupBeacon` tests that verify no path separators in output

**Before/After format examples:**
| Role | Before (path-like) | After (human-readable) |
|------|-------------------|----------------------|
| polecat | `testrig/polecats/rust` | `polecat rust (rig: testrig)` |
| crew | `gastown/crew/gus` | `crew gus (rig: gastown)` |
| witness | `gastown/witness` | `witness (rig: gastown)` |
| refinery | `gastown/refinery` | `refinery (rig: gastown)` |
| dog | `deacon/dogs/fido` | `dog fido` |

**Why this is safe:** The beacon recipient is purely visual — it appears in Claude Code's `/resume` session picker for identification. It is never parsed programmatically by seance, session discovery, or any other system. `GT_ROLE`, `BD_ACTOR`, and `Address()` retain their existing path-like format.

**Root cause:** When the beacon contained `testrig/polecats/rust`, Haiku interpreted it as a relative path and prepended `cd /tmp/.../polecats/rust &&` to every Bash command. The actual worktree is one level deeper at `polecats/rust/testrig/`, so the agent landed in the non-git parent directory. Sonnet never exhibited this behavior (it trusts CWD). After changing the format, Haiku stopped constructing `cd` commands entirely — confirmed via e2e test.

## Testing

- [x] Unit tests pass (`go test ./internal/session/... ./internal/daemon/... ./internal/polecat/... ./internal/crew/... ./internal/witness/... ./internal/refinery/... ./internal/dog/... ./internal/cmd/... ./internal/config/...`)
- [x] E2e agent test `TestQueueEnqueueAndDispatch` (Haiku model) passes — agent no longer constructs wrong `cd` commands
- [x] Manual comparison of session logs: before (25+ wrong `cd` commands) vs after (zero `cd` commands)

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)