### PR TITLE
fix: anchor stash branch match and fix inline stash counting

### DIFF
--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1391,3 +1391,124 @@ func TestStashCount_FiltersByBranch(t *testing.T) {
 		t.Errorf("StashCount from main after worktree stash = %d, want 1", mainCount)
 	}
 }
+
+// TestStashCount_DetachedHEAD verifies that StashCount counts all stashes
+// when in detached HEAD state (cannot determine branch, falls back to counting all).
+func TestStashCount_DetachedHEAD(t *testing.T) {
+	t.Parallel()
+	dir := initTestRepo(t)
+	g := NewGit(dir)
+
+	// Create a stash on main
+	if err := os.WriteFile(filepath.Join(dir, "dirty.txt"), []byte("dirty"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "add", ".")
+	cmd.Dir = dir
+	_ = cmd.Run()
+	cmd = exec.Command("git", "stash", "push", "-m", "some-stash")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git stash: %v", err)
+	}
+
+	// Detach HEAD
+	cmd = exec.Command("git", "checkout", "--detach")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git checkout --detach: %v", err)
+	}
+
+	// In detached HEAD, StashCount should count all stashes (safe fallback)
+	count, err := g.StashCount()
+	if err != nil {
+		t.Fatalf("StashCount: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("StashCount in detached HEAD = %d, want 1 (should count all stashes)", count)
+	}
+}
+
+// TestStashCount_CustomMessage verifies that StashCount handles both
+// "WIP on <branch>:" (auto-stash) and "On <branch>:" (custom message) formats.
+func TestStashCount_CustomMessage(t *testing.T) {
+	t.Parallel()
+	dir := initTestRepo(t)
+	g := NewGit(dir)
+
+	// Create a stash with custom message (produces "On <branch>: <message>" format)
+	if err := os.WriteFile(filepath.Join(dir, "dirty.txt"), []byte("dirty"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "add", ".")
+	cmd.Dir = dir
+	_ = cmd.Run()
+	cmd = exec.Command("git", "stash", "push", "-m", "my custom message")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git stash: %v", err)
+	}
+
+	// Should count the custom-message stash on current branch
+	count, err := g.StashCount()
+	if err != nil {
+		t.Fatalf("StashCount: %v", err)
+	}
+	if count != 1 {
+		t.Errorf("StashCount with custom message stash = %d, want 1", count)
+	}
+}
+
+// TestStashCount_NoFalsePositiveFromCommitMessage verifies that a stash
+// from branch "develop" with commit message containing "on fix:" does NOT
+// match when the current branch is "fix".
+func TestStashCount_NoFalsePositiveFromCommitMessage(t *testing.T) {
+	t.Parallel()
+	dir := initTestRepo(t)
+
+	// Create branch "develop" and make a commit with message containing "on fix:"
+	cmd := exec.Command("git", "checkout", "-b", "develop")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git checkout -b develop: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "work.txt"), []byte("work on fix: edge case"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = dir
+	_ = cmd.Run()
+	cmd = exec.Command("git", "commit", "-m", "work on fix: edge case")
+	cmd.Dir = dir
+	_ = cmd.Run()
+
+	// Create a stash on "develop" — its reflog line will contain "on fix:" in the
+	// commit message, but the branch prefix is "WIP on develop:"
+	if err := os.WriteFile(filepath.Join(dir, "dirty.txt"), []byte("dirty"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cmd = exec.Command("git", "add", ".")
+	cmd.Dir = dir
+	_ = cmd.Run()
+	cmd = exec.Command("git", "stash")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git stash: %v", err)
+	}
+
+	// Switch to branch "fix" — should NOT see the "develop" stash
+	cmd = exec.Command("git", "checkout", "-b", "fix")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git checkout -b fix: %v", err)
+	}
+
+	fixGit := NewGit(dir)
+	count, err := fixGit.StashCount()
+	if err != nil {
+		t.Fatalf("StashCount: %v", err)
+	}
+	if count != 0 {
+		t.Errorf("StashCount on 'fix' branch = %d, want 0 (stash belongs to 'develop', commit msg has 'on fix:')", count)
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #1718 (merged), addressing all three review findings from the automated dual-model review.

## Changes

### 1. Anchor substring match to reflog prefix (Major)

**Problem:** `strings.Contains(line, "on "+branch+":")` searches the entire stash line including the trailing commit message. A stash from branch `develop` with commit message `"work on fix: edge case"` would falsely match when current branch is `fix`.

**Fix:** Changed to `": WIP on "+branch+":"` and `": On "+branch+":"` which anchors the match to the reflog prefix position that always precedes the branch name. Git stash list format:
```
stash@{0}: WIP on develop: abc1234 work on fix: edge case
           ^^^^^^^^^^^^^^^^^^^^^^^
           reflog prefix (anchored match)
                                   ^^^^^^^^^^^^^^^^^^^^^^^^
                                   commit message (no longer matched)
```

### 2. Replace inline stash counting in `getGitState()` (Major)

**Problem:** `getGitState()` in `internal/cmd/polecat.go` had its own inline `git stash list` counting that counted ALL stashes without branch filtering — the exact same bug #1718 fixed in `StashCount()`. This feeds into `NEEDS_RECOVERY` verdicts and `gt polecat git-state` display.

**Fix:** Replaced 16 lines of inline stash counting with `git.NewGit(worktreePath).StashCount()`.

### 3. Add edge case tests (Minor)

Three new tests:
- **`TestStashCount_DetachedHEAD`** — verifies fallback to counting all stashes in detached HEAD state
- **`TestStashCount_CustomMessage`** — verifies `"On <branch>:"` format (custom stash message) is counted correctly
- **`TestStashCount_NoFalsePositiveFromCommitMessage`** — creates a stash on `develop` with commit message containing `"on fix:"`, verifies branch `fix` sees 0 stashes

## Test Plan

- [x] All 4 StashCount tests pass (original + 3 new)
- [x] `go build ./internal/cmd/` compiles cleanly
- [x] `go build ./internal/git/` compiles cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)