### PR TITLE
fix(config): use role-based agent resolution in daemon restart path

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1044,7 +1044,9 @@ func resolveAgentConfigWithOverrideInternal(townRoot, rigPath, agentOverride str
 	}
 
 	// Normal lookup path (no override)
-	return lookupAgentConfig(agentName, townSettings, rigSettings), agentName, nil
+	rc := lookupAgentConfig(agentName, townSettings, rigSettings)
+	rc.ResolvedAgent = agentName
+	return rc, agentName, nil
 }
 
 // ValidateAgentConfig checks if an agent configuration is valid and the binary exists.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1506,7 +1506,7 @@ func (d *Daemon) restartPolecatSession(rigName, polecatName, sessionName string)
 	// (e.g., witness patrol) can detect non-Claude agents.
 	// BuildStartupCommand sets GT_AGENT in process env via exec env, but that
 	// isn't visible to tmux show-environment.
-	rc := config.ResolveAgentConfig(d.config.TownRoot, rigPath)
+	rc := config.ResolveRoleAgentConfig("polecat", d.config.TownRoot, rigPath)
 	if rc.ResolvedAgent != "" {
 		_ = d.tmux.SetEnvironment(sessionName, "GT_AGENT", rc.ResolvedAgent)
 	}


### PR DESCRIPTION
## Summary

Fixes two issues identified during review of #1714 (GT_AGENT for role_agents):

1. **Daemon restart path uses wrong resolution function** — `restartPolecatSession` called `ResolveAgentConfig` (default agent) instead of `ResolveRoleAgentConfig("polecat", ...)`, causing restarted polecats to get `GT_AGENT=claude` in tmux env while running a different agent (e.g. opencode via `role_agents.polecat = "codex"`). Witness patrol would then false-kill the restarted polecat — the exact same bug #1714 fixed, but on the crash-restart path.

2. **`resolveAgentConfigWithOverrideInternal` skips `ResolvedAgent`** — The normal lookup path (no override) returned without setting `rc.ResolvedAgent = agentName`, inconsistent with the contract established by `resolveAgentConfigInternal`. Currently mitigated since `BuildStartupCommandWithAgentOverride` uses the override directly, but violates the invariant that all resolution functions populate `ResolvedAgent`.

## Related Issue

Follow-up to #1714

## Changes

- `internal/daemon/daemon.go`: Replace `config.ResolveAgentConfig(...)` with `config.ResolveRoleAgentConfig("polecat", ...)` in `restartPolecatSession`, matching the pattern at `lifecycle.go:469`
- `internal/config/loader.go`: Set `rc.ResolvedAgent = agentName` in `resolveAgentConfigWithOverrideInternal`'s normal lookup path

## Testing

- [x] Unit tests pass (`go test ./internal/config/ ./internal/daemon/ ./internal/polecat/`)
- [x] Manual review: verified `restartPolecatSession` now uses role-based resolution matching `lifecycle.go:469`

## Checklist

- [x] Code follows project style
- [x] No breaking changes
- [x] Minimal, focused fix (2 files, 4 insertions, 2 deletions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)