### PR TITLE
fix: give overseer its own RoleOverseer instead of misusing RolePolecat

### DIFF
--- a/internal/session/identity.go
+++ b/internal/session/identity.go
@@ -12,6 +12,7 @@ type Role string
 const (
 	RoleMayor    Role = "mayor"
 	RoleDeacon   Role = "deacon"
+	RoleOverseer Role = "overseer"
 	RoleWitness  Role = "witness"
 	RoleRefinery Role = "refinery"
 	RoleCrew     Role = "crew"
@@ -117,7 +118,7 @@ func ParseSessionNameWithRegistry(session string, registry *PrefixRegistry) (*Ag
 		case "boot":
 			return &AgentIdentity{Role: RoleDeacon, Name: "boot"}, nil
 		case "overseer":
-			return &AgentIdentity{Role: RolePolecat, Name: "overseer"}, nil
+			return &AgentIdentity{Role: RoleOverseer}, nil
 		default:
 			return nil, fmt.Errorf("invalid session name %q: unknown hq- role", session)
 		}
@@ -169,6 +170,8 @@ func (a *AgentIdentity) SessionName() string {
 			return BootSessionName()
 		}
 		return DeaconSessionName()
+	case RoleOverseer:
+		return OverseerSessionName()
 	case RoleWitness:
 		return WitnessSessionName(a.prefix())
 	case RoleRefinery:
@@ -208,6 +211,8 @@ func (a *AgentIdentity) BeaconAddress() string {
 		return "mayor"
 	case RoleDeacon:
 		return "deacon"
+	case RoleOverseer:
+		return "overseer"
 	case RoleWitness:
 		return BeaconRecipient("witness", "", a.Rig)
 	case RoleRefinery:
@@ -235,6 +240,8 @@ func (a *AgentIdentity) Address() string {
 		return "mayor"
 	case RoleDeacon:
 		return "deacon"
+	case RoleOverseer:
+		return "overseer"
 	case RoleWitness:
 		return fmt.Sprintf("%s/witness", a.Rig)
 	case RoleRefinery:


### PR DESCRIPTION
## Summary
- `ParseSessionNameWithRegistry("hq-overseer")` was returning `{Role: RolePolecat, Name: "overseer"}`, which broke round-trip identity resolution
- `SessionName()` produced `"gt-overseer"` instead of `"hq-overseer"`
- `Address()` produced `"/polecats/overseer"` instead of `"overseer"`

## Related Issue
N/A — discovered during code audit of overseer vs mayor identity separation.

## Changes
- Add `RoleOverseer Role = "overseer"` constant alongside the other role constants
- Update `ParseSessionNameWithRegistry` to return `RoleOverseer` for `"hq-overseer"` sessions (was `RolePolecat`)
- Add `RoleOverseer` case to `SessionName()` → returns `OverseerSessionName()` (`"hq-overseer"`)
- Add `RoleOverseer` case to `Address()` → returns `"overseer"`
- Add `RoleOverseer` case to `BeaconAddress()` → returns `"overseer"`

## Testing
- [x] Unit tests pass (`go test ./internal/session/... ./internal/mail/...`)
- [x] All existing round-trip, parse, and address tests continue to pass
- [x] External switch sites reviewed — all use `default` cases that handle unknown roles gracefully

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)