### PR TITLE
fix(test): stabilize flaky TestIsAgentRunning with WaitForShellReady

### DIFF
--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -333,6 +333,13 @@ func TestIsAgentRunning(t *testing.T) {
 	}
 	defer func() { _ = tm.KillSession(sessionName) }()
 
+	// Wait for the shell to be fully initialized before querying pane command.
+	// Without this, GetPaneCommand can return a transient value during shell
+	// startup (e.g., login or profile-sourced commands), causing flaky matches.
+	if err := tm.WaitForShellReady(sessionName, 2*time.Second); err != nil {
+		t.Fatalf("WaitForShellReady: %v", err)
+	}
+
 	// Get the current pane command (should be bash/zsh/etc)
 	cmd, err := tm.GetPaneCommand(sessionName)
 	if err != nil {


### PR DESCRIPTION
## Summary
Fix TOCTOU race in `TestIsAgentRunning` that causes intermittent failures by adding `WaitForShellReady` after session creation.

## Related Issue
Flaky test report for `TestIsAgentRunning` in `internal/tmux/tmux_test.go`.

## Changes
- Add `WaitForShellReady(sessionName, 2*time.Second)` call after `NewSession` and before the first `GetPaneCommand` in `TestIsAgentRunning`

## Root Cause
The test captures the pane command immediately after `NewSession`, then `IsAgentRunning` queries it again internally via `GetPaneCommand`. If the shell hasn't fully initialized (e.g., still running login/profile scripts), the two calls can return different values, causing the "matching shell process" and "multiple process names with match" subtests to fail intermittently.

## Testing
- [x] Unit tests pass (`go test ./...`)
- [x] `TestIsAgentRunning` passes reliably with `-count=5`
- [x] Manual testing performed

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)