### PR TITLE
fix(ci): exempt renovate[bot] from internal PR blocker

### DIFF
--- a/.github/workflows/block-internal-prs.yml
+++ b/.github/workflows/block-internal-prs.yml
@@ -8,7 +8,7 @@ jobs:
   block-internal-prs:
     name: Block Internal PRs
     # Only run if PR is from the same repo (not a fork)
-    if: github.event.pull_request.head.repo.full_name == github.repository
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Close PR and comment


### PR DESCRIPTION
## Summary

The `block-internal-prs` workflow blocks all same-repo PRs, but Renovate creates branches in the same repo, so its dependency update PRs get incorrectly blocked (see PR #1733). This adds an actor check to skip the blocker for `renovate[bot]`.

## Related Issue

Fixes the CI failure on #1733

## Changes

- Add `&& github.actor != 'renovate[bot]'` condition to the `block-internal-prs` job so Renovate PRs are allowed through

## Testing

- [ ] Unit tests pass (`go test ./...`)
- [x] Manual testing performed — verified the workflow condition logic

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)