### PR TITLE
fix(ci): install ICU4C for Windows build via MSYS2

### DIFF
--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -26,25 +26,36 @@ jobs:
           key: gomod-windows-${{ hashFiles('go.sum') }}
           restore-keys: gomod-windows-
 
-      - name: Configure Git
-        run: |
-          git config --global user.name "CI Bot"
-          git config --global user.email "ci@gastown.test"
-
       - name: Add to PATH
         run: |
           echo "$(go env GOPATH)/bin" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+
+      - name: Install ICU4C (MSYS2)
+        uses: msys2/setup-msys2@4f806de0a5a7294ffabaff804b38a9b435a73bda # v2.30.0
+        with:
+          path-type: inherit
+          msystem: UCRT64
+          pacboy: icu:p toolchain:p pkg-config:p
+
+      - name: Configure Git
+        shell: msys2 {0}
+        run: |
+          git config --global user.name "CI Bot"
+          git config --global user.email "ci@gastown.test"
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
       - name: Generate embedded files
+        shell: msys2 {0}
         run: go generate ./internal/formula/...
 
       - name: Build
+        shell: msys2 {0}
         run: go build -v ./cmd/gt
 
       - name: Unit Tests
+        shell: msys2 {0}
         run: gotestsum --format testname --junitfile junit.xml -- -short ./...
 
       - name: Test Report


### PR DESCRIPTION
## Summary
Install ICU4C on Windows CI via MSYS2 to fix the build failure caused by the `go-icu-regex` transitive dependency requiring `unicode/uregex.h`.

## Related Issue
Windows CI has been failing on every push to main with `fatal error: unicode/uregex.h: No such file or directory` since the `go-icu-regex` dependency was introduced through `beads → go-mysql-server`.

## Changes
- Add `msys2/setup-msys2` action step to install ICU4C, toolchain, and pkg-config via UCRT64
- Run `go generate`, `go build`, and `gotestsum` steps under `shell: msys2 {0}` so CGo can find ICU headers and libraries
- Matches the approach used by dolthub/dolt's own [Windows CI workflow](https://github.com/dolthub/dolt/blob/main/.github/workflows/ci-bats-windows.yaml)

## Testing
- [x] Verified `go build -v ./cmd/gt` and `go test -short ./...` pass locally
- [ ] CI run on this PR will validate the fix on actual Windows runners

## Checklist
- [x] Code follows project style
- [x] No breaking changes
- [x] Action SHA pinned (`msys2/setup-msys2@4f806de...` = v2.30.0)