### PR TITLE
fix(lint): mark unused mr parameter in postMergeConvoyCheck

### DIFF
--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -1439,7 +1439,7 @@ func (e *Engineer) ReleaseMR(mrID string) error {
 //  3. Cleans up stale polecat branches from completed work
 //
 // All operations are best-effort: failures are logged but don't affect merge success.
-func (e *Engineer) postMergeConvoyCheck(mr *MRInfo) {
+func (e *Engineer) postMergeConvoyCheck(_ *MRInfo) {
 	// Find town root from rig path (rig is at ~/gt/<rigname>, town is ~/gt)
 	townRoot := filepath.Dir(e.rig.Path)
 	townBeads := filepath.Join(townRoot, ".beads")


### PR DESCRIPTION
## Summary

Fix `unparam` lint failure on main — `mr *MRInfo` parameter is unused in `postMergeConvoyCheck`.

## Changes

- Mark unused `mr` parameter with `_` in `internal/refinery/engineer.go:1442`

## Testing
- [x] `go build ./...` passes
- [x] `go vet ./internal/refinery/...` passes

## Checklist
- [x] Code follows project style
- [x] No breaking changes