### PR TITLE
session: make startup env application deterministic

### DIFF
--- a/internal/session/lifecycle.go
+++ b/internal/session/lifecycle.go
@@ -3,6 +3,7 @@ package session
 
 import (
 	"fmt"
+	"sort"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/config"
@@ -192,11 +193,11 @@ func StartSession(t *tmux.Tmux, cfg SessionConfig) (*StartResult, error) {
 		TownRoot:         cfg.TownRoot,
 		RuntimeConfigDir: cfg.RuntimeConfigDir,
 	})
-	for k, v := range envVars {
-		_ = t.SetEnvironment(cfg.SessionID, k, v)
+	for _, k := range mapKeysSorted(envVars) {
+		_ = t.SetEnvironment(cfg.SessionID, k, envVars[k])
 	}
-	for k, v := range cfg.ExtraEnv {
-		_ = t.SetEnvironment(cfg.SessionID, k, v)
+	for _, k := range mapKeysSorted(cfg.ExtraEnv) {
+		_ = t.SetEnvironment(cfg.SessionID, k, cfg.ExtraEnv[k])
 	}
 
 	// 7. Apply theme.
@@ -275,6 +276,18 @@ func StopSession(t *tmux.Tmux, sessionID string, graceful bool) error {
 	}
 
 	return nil
+}
+
+func mapKeysSorted(m map[string]string) []string {
+	if len(m) == 0 {
+		return nil
+	}
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 // KillExistingSession kills an existing session if one is found.

--- a/internal/session/lifecycle_test.go
+++ b/internal/session/lifecycle_test.go
@@ -114,6 +114,24 @@ func TestKillExistingSession_NoSession(t *testing.T) {
 	t.Skip("requires tmux for integration testing")
 }
 
+func TestMapKeysSorted(t *testing.T) {
+	got := mapKeysSorted(map[string]string{
+		"GT_SESSION": "1",
+		"GT_ROLE":    "polecat",
+		"GT_RIG":     "alpha",
+	})
+
+	want := []string{"GT_RIG", "GT_ROLE", "GT_SESSION"}
+	if len(got) != len(want) {
+		t.Fatalf("mapKeysSorted() length = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("mapKeysSorted()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
 }


### PR DESCRIPTION
## Problem
Startup initialization used map iteration for environment application, introducing non-deterministic side-effect ordering.

## Why now
Deterministic startup/recovery behavior is core for reliable orchestration trails and reproducibility.

## What changed
- Added deterministic key sorting helper `mapKeysSorted`.
- Applied sorted ordering when setting startup environment variables in `StartSession`.
- Added unit regression test `TestMapKeysSorted`.

## Validation
- `go test ./internal/session -run 'TestMapKeysSorted|TestBuildPrompt_WithInstructions'` (pass)

Refs #1754
