### PR TITLE
fix(deacon): update startup prompt to use correct wisp creation command

### DIFF
--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -103,7 +103,7 @@ func (m *Manager) Start(agentOverride string) error {
 		Recipient: "deacon",
 		Sender:    "daemon",
 		Topic:     "patrol",
-	}, "I am Deacon. Start patrol: run gt deacon heartbeat, then check gt hook. If no hook, create mol-deacon-patrol wisp and execute it.")
+	}, "I am Deacon. Start patrol: run gt deacon heartbeat, then check gt hook. If no hook, create patrol molecule via 'bd mol wisp mol-deacon-patrol --json', hook it with 'bd update <id> --status=hooked --assignee=deacon', then execute.")
 	startupCmd, err := config.BuildAgentStartupCommandWithAgentOverride("deacon", "", m.townRoot, "", initialPrompt, agentOverride)
 	if err != nil {
 		return fmt.Errorf("building startup command: %w", err)


### PR DESCRIPTION
## Summary

Fixes the Deacon startup failure caused by referencing the removed `gt wisp` command.

## Problem

The deacon's startup prompt in `internal/deacon/manager.go` instructed the agent to run `gt wisp create mol-deacon-patrol`, which no longer exists. This caused immediate failure on deacon start:

Error: unknown command "wisp" for "gt"

## Solution
Updated the startup prompt (line 103) to reference the correct beads CLI command:

**Before:**
"I am Deacon. Start patrol: run gt deacon heartbeat, then check gt hook. If no hook, create mol-deacon-patrol wisp and execute it."

**After:**
"I am Deacon. Start patrol: run gt deacon heartbeat, then check gt hook. If no hook, create patrol molecule via 'bd mol wisp mol-deacon-patrol --json', hook it with 'bd update <id> --status=hooked --assignee=deacon', then execute."

## Verification
- Built from fork and tested locally: `gt deacon start` now succeeds

- No "unknown command wisp" errors in deacon tmux session
- Aligns with existing formula behavior in `mol-deacon-patrol.formula.toml`

## Related
Closes Issue #1757