### PR TITLE
fix(nudge): use immediate delivery with consistent MQ-oriented messages

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -843,7 +843,7 @@ afterDoltMerge:
 	// on the polecat branch and refinery won't find it on main.
 	// If no branch existed (crew worker), MR bead is already on main.
 	if mrID != "" && !mergeFailed {
-		nudgeRefinery(rigName, fmt.Sprintf("MR submitted: %s branch=%s", mrID, branch))
+		nudgeRefinery(rigName, "MERGE_READY received - check inbox for pending work")
 	}
 
 	// Notify Witness about completion

--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -233,7 +233,7 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 		}
 
 		// Nudge refinery to pick up the new MR
-		nudgeRefinery(rigName, fmt.Sprintf("MR submitted: %s branch=%s", mrIssue.ID, branch))
+		nudgeRefinery(rigName, "MERGE_READY received - check inbox for pending work")
 	}
 
 	// Success output


### PR DESCRIPTION
## Summary

Fixes #1763 — refinery not waking up after `gt done`.

Two problems fixed:

### 1. Wait-idle delivery causes stuck nudges

The original wait-idle approach (`WaitForIdle` → direct if idle, `Enqueue` if busy) has a fatal flaw: nudges queued while the agent is busy are **never drained**. `Drain()` only runs at `UserPromptSubmit` hook boundaries, and an idle agent never submits prompts. This causes queued nudges to be stuck forever — visible as `N queued` in `gt status` while the refinery sits idle.

**Fix**: Replace with immediate delivery via `NudgeSession()`. Sends text directly to the tmux pane. If idle — agent wakes up immediately. If busy — text buffers in tmux input and is processed at next prompt. No `Drain()` dependency.

### 2. Nudge message leads refinery to bypass merge queue

`done.go` and `mq_submit.go` sent messages like `"MR submitted: te-1615 branch=polecat/furiosa/te-r1qt@mlu360ha"`, which led the refinery to operate on the git branch directly instead of following the `mol-refinery-patrol` workflow (`gt mail inbox` → `gt mq list` → process).

**Fix**: All refinery nudge messages now use `"MERGE_READY received - check inbox for pending work"` — consistent with the witness nudge — directing the refinery through its merge queue patrol loop.

## Files changed

- **`internal/cmd/sling_helpers.go`** — `wakeRigAgents()` and `nudgeRefinery()`: removed wait-idle + queue logic, replaced with direct `NudgeSession()`
- **`internal/witness/handlers.go`** — `nudgeRefinery()`: same simplification
- **`internal/cmd/done.go`** — nudge message changed from `"MR submitted: ..."` to `"MERGE_READY received - check inbox for pending work"`
- **`internal/cmd/mq_submit.go`** — same message change

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./internal/cmd/... ./internal/witness/...` passes
- [x] Manual: `gt done` multiple times → refinery wakes up each time, no stuck `queued`
- [x] Manual: refinery follows inbox → mq list workflow, not direct git branch operations