### PR TITLE
fix: correct liveness detection for custom agents shadowing built-in presets

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1591,6 +1591,10 @@ func (d *Daemon) restartPolecatSession(rigName, polecatName, sessionName string)
 		_ = d.tmux.SetEnvironment(sessionName, "GT_AGENT", rc.ResolvedAgent)
 	}
 
+	// Set GT_PROCESS_NAMES for accurate liveness detection of custom agents.
+	processNames := config.ResolveProcessNames(rc.ResolvedAgent, rc.Command)
+	_ = d.tmux.SetEnvironment(sessionName, "GT_PROCESS_NAMES", strings.Join(processNames, ","))
+
 	// Apply theme
 	theme := tmux.AssignTheme(rigName)
 	_ = d.tmux.ConfigureGasTownSession(sessionName, theme, rigName, polecatName, "polecat")

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -338,6 +338,12 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 		debugSession("SetEnvironment GT_AGENT", m.tmux.SetEnvironment(sessionID, "GT_AGENT", runtimeConfig.ResolvedAgent))
 	}
 
+	// Set GT_PROCESS_NAMES for accurate liveness detection. Custom agents may
+	// shadow built-in preset names (e.g., custom "codex" running "opencode"),
+	// so we resolve process names from both agent name and actual command.
+	processNames := config.ResolveProcessNames(runtimeConfig.ResolvedAgent, runtimeConfig.Command)
+	debugSession("SetEnvironment GT_PROCESS_NAMES", m.tmux.SetEnvironment(sessionID, "GT_PROCESS_NAMES", strings.Join(processNames, ",")))
+
 	// Hook the issue to the polecat if provided via --issue flag
 	if opts.Issue != "" {
 		agentID := fmt.Sprintf("%s/polecats/%s", m.rig.Name, polecat)


### PR DESCRIPTION
## Problem

`gt polecat list` shows `○ done` and `gt status` shows `running: false` for actively working polecats, while `gt polecat status` correctly reports `State: working`.

## Root Cause

Custom agents defined in `settings/config.json` can shadow built-in preset names. In this case, a custom `"codex"` agent uses `opencode` as the command:

```json
"codex": { "command": "opencode", "args": ["-m", "openai/gpt-5.3-codex"] }
```

But the built-in `AgentCodex` preset has `Command: "codex"` and `ProcessNames: ["codex"]`.

The chain of failure:

1. `session_manager.Start()` sets `GT_AGENT=codex` in tmux session env
2. `IsAgentAlive()` reads `GT_AGENT=codex`
3. `GetProcessNames("codex")` finds the **built-in** `AgentCodex` preset → returns `["codex"]`
4. `IsRuntimeRunning()` looks for a process named `codex` in the session's process tree
5. The actual process is `opencode` → **not found** → returns `false`
6. `CheckSessionHealth()` → `AgentDead` → `IsRunning()` → `false`

The reconciliation logic in `gt polecat list` then overrides the beads state: "session dead + beads says working → must be done". Correct logic, but wrong liveness input.

`gt polecat status` works because it uses `HasSession()` (simple tmux existence check), not `IsAgentAlive()`/`CheckSessionHealth()`.

### Blast radius

`IsAgentAlive()` is called in 20+ places: witness zombie patrol, daemon lifecycle, doctor checks, refinery/witness managers, crew management, status display. All affected when a custom agent name collides with a built-in preset.

## Fix

### New: `ResolveProcessNames(agentName, command)` in `config/agents.go`

Cross-references the agent name with the actual command binary:

1. If agent name matches a built-in preset AND the preset's Command matches → use preset's ProcessNames (no mismatch)
2. If command differs → find a built-in preset whose Command matches the actual binary → use its ProcessNames
3. Fallback: `[command]` for fully custom binaries

### New: `GT_PROCESS_NAMES` tmux env var

Set at session startup alongside `GT_AGENT`. Contains the comma-separated resolved process names (e.g., `opencode,node,bun`).

### New: `resolveSessionProcessNames()` helper in `tmux/tmux.go`

Shared by both `IsAgentAlive()` and `FindAgentPane()`. Prefers `GT_PROCESS_NAMES` if set, falls back to `GT_AGENT`-based lookup for legacy sessions.

## Why not alternative approaches

- **Fix `GetProcessNames` to be config-aware**: Would need `townRoot`/`rigPath` context that it doesn't have, and the function is called from tmux package which shouldn't depend on full config resolution.
- **Change `GT_AGENT` to the command name**: Breaks `handoff.go` and `sling_helpers.go` which use `GT_AGENT` as agent config name (not process name).
- **Register custom agents in global registry**: Timing issues (registry must be populated before any liveness check) and shared state conflicts between rigs with different custom configs.
- **Resolve from pane command at runtime**: Unreliable — pane command can be `bash` (shell wrapper), not the agent binary.

## Files changed

| File | Change |
|------|--------|
| `config/agents.go` | Add `ResolveProcessNames()` |
| `config/agents_test.go` | 8 test cases for `ResolveProcessNames` |
| `tmux/tmux.go` | Add `resolveSessionProcessNames()` helper, update `IsAgentAlive()` and `FindAgentPane()` |
| `polecat/session_manager.go` | Set `GT_PROCESS_NAMES` at polecat startup |
| `daemon/daemon.go` | Set `GT_PROCESS_NAMES` at daemon polecat restart |

## Test plan

- [x] `go vet ./...` passes
- [x] `TestResolveProcessNames` — 8 cases including the key scenario (`codex` + `opencode` → `["opencode", "node", "bun"]`)
- [x] All existing `config` tests pass
- [ ] Manual: sling a polecat with custom `codex` agent, verify `gt polecat list` and `gt status` show correct running state</body>
</invoke>