### PR TITLE
fix(beads): auto-initialize database in EnsureCustomTypes to prevent Dolt panic

### DIFF
--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -559,13 +559,16 @@ case "$cmd" in
   config)
     # Accept config commands (e.g., "bd config set types.custom ...")
     ;;
+  init)
+    # Accept init commands (e.g., "bd init --prefix gt --server")
+    ;;
   *)
     echo "unexpected command: $cmd" >&2
     exit 1
     ;;
 esac
 `
-	windowsScript := "@echo off\r\nsetlocal enabledelayedexpansion\r\nif defined BEADS_DIR_LOG (\r\n  if defined BEADS_DIR (\r\n    echo %BEADS_DIR%>>\"%BEADS_DIR_LOG%\"\r\n  ) else (\r\n    echo ^<unset^> >>\"%BEADS_DIR_LOG%\"\r\n  )\r\n)\r\nset \"cmd=%1\"\r\nset \"arg2=%2\"\r\nset \"arg3=%3\"\r\nif \"%cmd%\"==\"--allow-stale\" (\r\n  set \"cmd=%2\"\r\n  set \"arg2=%3\"\r\n  set \"arg3=%4\"\r\n)\r\nif \"%cmd%\"==\"show\" (\r\n  echo []\r\n  exit /b 0\r\n)\r\nif \"%cmd%\"==\"create\" (\r\n  set \"id=\"\r\n  set \"title=\"\r\n  for %%A in (%*) do (\r\n    set \"arg=%%~A\"\r\n    if /i \"!arg:~0,5!\"==\"--id=\" set \"id=!arg:~5!\"\r\n    if /i \"!arg:~0,8!\"==\"--title=\" set \"title=!arg:~8!\"\r\n  )\r\n  if defined AGENT_LOG (\r\n    echo !id!>>\"%AGENT_LOG%\"\r\n  )\r\n  echo {\"id\":\"!id!\",\"title\":\"!title!\",\"description\":\"\",\"issue_type\":\"agent\"}\r\n  exit /b 0\r\n)\r\nif \"%cmd%\"==\"slot\" exit /b 0\r\nif \"%cmd%\"==\"config\" exit /b 0\r\nexit /b 1\r\n"
+	windowsScript := "@echo off\r\nsetlocal enabledelayedexpansion\r\nif defined BEADS_DIR_LOG (\r\n  if defined BEADS_DIR (\r\n    echo %BEADS_DIR%>>\"%BEADS_DIR_LOG%\"\r\n  ) else (\r\n    echo ^<unset^> >>\"%BEADS_DIR_LOG%\"\r\n  )\r\n)\r\nset \"cmd=%1\"\r\nset \"arg2=%2\"\r\nset \"arg3=%3\"\r\nif \"%cmd%\"==\"--allow-stale\" (\r\n  set \"cmd=%2\"\r\n  set \"arg2=%3\"\r\n  set \"arg3=%4\"\r\n)\r\nif \"%cmd%\"==\"show\" (\r\n  echo []\r\n  exit /b 0\r\n)\r\nif \"%cmd%\"==\"create\" (\r\n  set \"id=\"\r\n  set \"title=\"\r\n  for %%A in (%*) do (\r\n    set \"arg=%%~A\"\r\n    if /i \"!arg:~0,5!\"==\"--id=\" set \"id=!arg:~5!\"\r\n    if /i \"!arg:~0,8!\"==\"--title=\" set \"title=!arg:~8!\"\r\n  )\r\n  if defined AGENT_LOG (\r\n    echo !id!>>\"%AGENT_LOG%\"\r\n  )\r\n  echo {\"id\":\"!id!\",\"title\":\"!title!\",\"description\":\"\",\"issue_type\":\"agent\"}\r\n  exit /b 0\r\n)\r\nif \"%cmd%\"==\"slot\" exit /b 0\r\nif \"%cmd%\"==\"config\" exit /b 0\r\nif \"%cmd%\"==\"init\" exit /b 0\r\nexit /b 1\r\n"
 
 	binDir := writeFakeBD(t, script, windowsScript)
 	agentLog := filepath.Join(t.TempDir(), "agents.log")


### PR DESCRIPTION
## Summary

Adopts and extends @DerrickBarra's fix from PR #1770. When `gt doctor --fix` or agent bead creation encounters a `.beads/` directory without an initialized database, `EnsureCustomTypes` now auto-initializes it instead of crashing with a Dolt nil-pointer dereference.

## Related Issue

Supersedes #1770

## Changes

- Add `ensureDatabaseInitialized()` guard before `bd config set` in `EnsureCustomTypes`
- Deep metadata.json check mirrors `bdDatabaseExists` in `rig/manager.go` (parses JSON, verifies `.dolt-data/<db>` exists for server mode)
- Detect beads prefix via rigs.json (authoritative), config.yaml fallback, or "gt" default
- Run `bd config set issue_prefix` after init to match all production callers
- Handle "already initialized" output gracefully (matching install.go pattern)
- Add `stripYAMLQuotes` helper with correct quote-then-dash-trim ordering
- Comprehensive tests: 5 init scenarios, 9 prefix detection cases, 7 quote-stripping cases

### Contributor credit
- Original fix by @DerrickBarra (commit preserved with original authorship)
- Maintainer fixup addresses findings from 4 rounds of triple-model review (Claude + Codex + Gemini)

## Testing

- [x] Unit tests pass (`go test ./internal/beads/ -count=1`)
- [x] All 3 database detection paths tested (dolt/, metadata.json+server, beads.db)
- [x] Deep metadata.json check tested (valid db → skip init; missing db → attempt init)
- [x] Prefix detection tested (rigs.json, config.yaml quoted/unquoted/dash variants, routed paths, default)
- [x] 4 review iterations (Claude Opus 4.6 + GPT-5.3 Codex + Gemini 3 Pro)

## Checklist

- [x] Code follows project style
- [x] No breaking changes
- [x] Tests added for new functionality