### PR TITLE
chore: normalize beads version to 0.52.0 across all configs

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -24,7 +24,7 @@ RUN apk add --no-cache \
     lsof
 
 # Install beads daemon (bd)
-RUN go install github.com/steveyegge/beads/cmd/bd@v0.50.2
+RUN go install github.com/steveyegge/beads/cmd/bd@v0.52.0
 
 # Install Dolt (required for beads database server)
 RUN git clone --depth 1 https://github.com/dolthub/dolt /tmp/dolt && \

--- a/flake.nix
+++ b/flake.nix
@@ -5,7 +5,7 @@
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
     beads = {
-      url = "github:steveyegge/beads/v0.47.1";
+      url = "github:steveyegge/beads/v0.52.0";
       inputs.nixpkgs.follows = "nixpkgs";
     };
   };


### PR DESCRIPTION
## Summary
- Update `Dockerfile.e2e` beads pin from v0.50.2 to v0.52.0
- Update `flake.nix` beads pin from v0.47.1 to v0.52.0

## Related Issue
N/A — housekeeping alignment

## Changes
- `Dockerfile.e2e`: `bd@v0.50.2` → `bd@v0.52.0`
- `flake.nix`: `beads/v0.47.1` → `beads/v0.52.0`

These two files were lagging behind the rest of the codebase, which already enforces `MinBeadsVersion = "0.52.0"` in Go code, CI workflows (`ci.yml`, `integration.yml`), README, and docs.

## Testing
- [ ] Unit tests pass (`go test ./...`)
- [ ] CI workflows already install `bd@v0.52.0` — no behavioral change there
- [ ] Docker e2e image will now build with the same version the rest of the project requires

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable) — docs already reference 0.52.0
- [x] No breaking changes (or documented in summary)