### PR TITLE
fix(test): provide Windows bd stub in TestSlingRejectsDeferredBead

### DIFF
--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -2178,7 +2178,8 @@ func TestSlingRejectsDeferredBead(t *testing.T) {
 
 			// Create bd stub that returns the test bead info
 			bdScript := "#!/bin/sh\necho '" + tt.bdOutput + "'\n"
-			writeBDStub(t, binDir, bdScript, "")
+			bdScriptWindows := "@echo off\r\necho " + tt.bdOutput + "\r\n"
+			writeBDStub(t, binDir, bdScript, bdScriptWindows)
 
 			t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 			t.Setenv(EnvGTRole, "crew")


### PR DESCRIPTION
Fixes #1781

## Summary

`TestSlingRejectsDeferredBead` passed an empty string as the Windows batch script to `writeBDStub`, so on Windows `bd.cmd` was created empty. When `runSling` called `bd show gt-test123`, the stub returned no output, producing a "bead not found" error before the deferred-status check could run.

One-line fix: generate the equivalent `@echo off` + `echo <json>` batch script alongside the existing Unix shell script, matching the pattern used by all other tests in `sling_test.go`.

## Test plan

- [x] `TestSlingRejectsDeferredBead` passes (all 5 subtests) on macOS
- [x] No other tests broken