### PR TITLE
fix: correct liveness detection for custom agents shadowing built-in presets

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1591,6 +1591,10 @@ func (d *Daemon) restartPolecatSession(rigName, polecatName, sessionName string)
 		_ = d.tmux.SetEnvironment(sessionName, "GT_AGENT", rc.ResolvedAgent)
 	}
 
+	// Set GT_PROCESS_NAMES for accurate liveness detection of custom agents.
+	processNames := config.ResolveProcessNames(rc.ResolvedAgent, rc.Command)
+	_ = d.tmux.SetEnvironment(sessionName, "GT_PROCESS_NAMES", strings.Join(processNames, ","))
+
 	// Apply theme
 	theme := tmux.AssignTheme(rigName)
 	_ = d.tmux.ConfigureGasTownSession(sessionName, theme, rigName, polecatName, "polecat")

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -337,6 +337,11 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 	// This ensures respawned processes also inherit the setting.
 	debugSession("SetEnvironment BD_DOLT_AUTO_COMMIT", m.tmux.SetEnvironment(sessionID, "BD_DOLT_AUTO_COMMIT", "off"))
 
+	// Set GT_PROCESS_NAMES for accurate liveness detection. Custom agents may
+	// shadow built-in preset names (e.g., custom "codex" running "opencode"),
+	// so we resolve process names from both agent name and actual command.
+	processNames := config.ResolveProcessNames(runtimeConfig.ResolvedAgent, runtimeConfig.Command)
+	debugSession("SetEnvironment GT_PROCESS_NAMES", m.tmux.SetEnvironment(sessionID, "GT_PROCESS_NAMES", strings.Join(processNames, ",")))
 	// Hook the issue to the polecat if provided via --issue flag
 	if opts.Issue != "" {
 		agentID := fmt.Sprintf("%s/polecats/%s", m.rig.Name, polecat)


### PR DESCRIPTION
## Summary

Re-applies #1768 (by @abambalov) which was reverted as part of the PR #1776 revert.

Custom agents defined in town settings can shadow built-in preset names. For example, a custom "codex" agent using "opencode" as the command shadows the built-in AgentCodex preset. When `IsAgentAlive` reads `GT_AGENT=codex`, `GetProcessNames` resolves to the built-in preset's ProcessNames (`["codex"]`), but the actual process is "opencode", so the liveness check fails — causing actively working polecats to appear dead.

## Related Issue

Re-applies #1768 (reverted in #1780)

## Changes

- Add `ResolveProcessNames(agentName, command)` function that cross-references agent name with actual command binary to determine correct process names
- Store resolved process names in `GT_PROCESS_NAMES` tmux env var at session startup
- `IsAgentAlive` and `FindAgentPane` prefer `GT_PROCESS_NAMES`, falling back to `GT_AGENT`-based lookup for legacy sessions
- Add `SetProcessNamesEnv` in daemon heartbeat for sessions started before this change

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] `TestResolveProcessNames` — covers built-in presets, shadowed agents, path-resolved commands, unknown agents

## Checklist

- [x] Code follows project style
- [x] No breaking changes
- [x] Original author attribution preserved

---

Original author: @abambalov
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>