### PR TITLE
fix: use filepath.Join in TestFeedStrandedStateFile for Windows compat

### DIFF
--- a/internal/deacon/feed_stranded_test.go
+++ b/internal/deacon/feed_stranded_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestFeedStrandedStateFile(t *testing.T) {
 	got := FeedStrandedStateFile("/tmp/town")
-	want := "/tmp/town/deacon/feed-stranded-state.json"
+	want := filepath.Join("/tmp/town", "deacon", "feed-stranded-state.json")
 	if got != want {
 		t.Errorf("FeedStrandedStateFile = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary
- Fix Windows CI test failure in `TestFeedStrandedStateFile` by using `filepath.Join` for the expected path instead of a hardcoded Unix-style string

## Related Issue
N/A — CI failure on Windows

## Changes
- `internal/deacon/feed_stranded_test.go`: Replace hardcoded `"/tmp/town/deacon/feed-stranded-state.json"` with `filepath.Join("/tmp/town", "deacon", "feed-stranded-state.json")` so the expected value uses OS-appropriate path separators

## Testing
- [ ] Unit tests pass (`go test ./...`)
- [ ] Manual testing performed

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)