### PR TITLE
fix(daemon): skip restart for polecats in agent_state=spawning (#1752)

### DIFF
--- a/internal/daemon/polecat_health_test.go
+++ b/internal/daemon/polecat_health_test.go
@@ -1,0 +1,103 @@
+package daemon
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// writeFakeTestTmux creates a shell script in dir named "tmux" that simulates
+// "session not found" for has-session calls and fails on anything else.
+func writeFakeTestTmux(t *testing.T, dir string) {
+	t.Helper()
+	script := "#!/bin/sh\n" +
+		"case \"$*\" in\n" +
+		"  *has-session*) echo \"can't find session\" >&2; exit 1;;\n" +
+		"  *) echo 'unexpected tmux command' >&2; exit 1;;\n" +
+		"esac\n"
+	if err := os.WriteFile(filepath.Join(dir, "tmux"), []byte(script), 0755); err != nil {
+		t.Fatalf("writing fake tmux: %v", err)
+	}
+}
+
+// writeFakeTestBD creates a shell script in dir named "bd" that outputs a
+// polecat agent bead JSON with the given agentState and hookBead values.
+// The description field contains "agent_state: <agentState>" which is parsed
+// by ParseAgentFieldsFromDescription to populate AgentBeadInfo.State.
+func writeFakeTestBD(t *testing.T, dir, agentState, hookBead string) string {
+	t.Helper()
+	// description parsed by ParseAgentFieldsFromDescription for State field
+	desc := "agent_state: " + agentState
+	// JSON matches the structure that getAgentBeadInfo expects from bd show --json
+	bdJSON := `[{"id":"gt-myr-polecat-mycat","issue_type":"agent","labels":["gt:agent"],"description":"` +
+		desc + `","hook_bead":"` + hookBead + `","agent_state":"` + agentState + `","updated_at":"2024-01-01T00:00:00Z"}]`
+	script := "#!/bin/sh\necho '" + bdJSON + "'\n"
+	path := filepath.Join(dir, "bd")
+	if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+		t.Fatalf("writing fake bd: %v", err)
+	}
+	return path
+}
+
+// TestCheckPolecatHealth_SkipsSpawning verifies that checkPolecatHealth does NOT
+// attempt to restart a polecat in agent_state=spawning. This is the regression
+// test for the double-spawn bug (issue #1752): the daemon heartbeat fires during
+// the window between bead creation (hook_bead set atomically by gt sling) and the
+// actual tmux session launch, causing a second Claude process to start.
+func TestCheckPolecatHealth_SkipsSpawning(t *testing.T) {
+	binDir := t.TempDir()
+	writeFakeTestTmux(t, binDir)
+	bdPath := writeFakeTestBD(t, binDir, "spawning", "gt-xyz")
+
+	// Prepend binDir to PATH so exec.Command("tmux",...) finds our fake binary.
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	var logBuf strings.Builder
+	d := &Daemon{
+		config: &Config{TownRoot: t.TempDir()},
+		logger: log.New(&logBuf, "", 0),
+		tmux:   tmux.NewTmux(),
+		bdPath: bdPath,
+	}
+
+	d.checkPolecatHealth("myr", "mycat")
+
+	got := logBuf.String()
+	if !strings.Contains(got, "spawning") {
+		t.Errorf("expected log to mention 'spawning', got: %q", got)
+	}
+	if strings.Contains(got, "CRASH DETECTED") {
+		t.Errorf("spawning polecat must not trigger CRASH DETECTED, got: %q", got)
+	}
+}
+
+// TestCheckPolecatHealth_DetectsCrashedPolecat verifies that checkPolecatHealth
+// does detect a crash for a polecat in agent_state=working with a dead session.
+// This ensures the spawning guard in issue #1752 does not accidentally suppress
+// legitimate crash detection for polecats that were running normally.
+func TestCheckPolecatHealth_DetectsCrashedPolecat(t *testing.T) {
+	binDir := t.TempDir()
+	writeFakeTestTmux(t, binDir)
+	bdPath := writeFakeTestBD(t, binDir, "working", "gt-xyz")
+
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	var logBuf strings.Builder
+	d := &Daemon{
+		config: &Config{TownRoot: t.TempDir()},
+		logger: log.New(&logBuf, "", 0),
+		tmux:   tmux.NewTmux(),
+		bdPath: bdPath,
+	}
+
+	d.checkPolecatHealth("myr", "mycat")
+
+	got := logBuf.String()
+	if !strings.Contains(got, "CRASH DETECTED") {
+		t.Errorf("expected CRASH DETECTED for working polecat with dead session, got: %q", got)
+	}
+}


### PR DESCRIPTION
## Problem

Every polecat spawn produces two `session_start` events ~4-8s apart. 13/13 spawns were affected.

**Root cause**: `checkPolecatHealth` in the daemon fires during the race window between:
1. `AddWithOptions` (sets `hook_bead` + `agent_state=spawning` atomically)
2. The actual tmux session launch by `gt sling`

During this window the tmux session doesn't exist yet, so the daemon sees:
- session dead ✓
- hook_bead set ✓
→ "CRASH DETECTED" → `restartPolecatSession` → second Claude process starts alongside the one gt sling is about to launch

Both processes share the same session file and fight, causing premature `done` events and process death.

## Fix

Add a spawning guard in `checkPolecatHealth` that returns early when `agent_state == "spawning"`:

```go
if info.State == "spawning" {
    d.logger.Printf("Skipping restart for %s/%s: agent_state=spawning (gt sling in progress)",
        rigName, polecatName)
    return
}
```

This is placed after the `hook_bead == ""` check, so polecats with no work are still handled by the existing orphan detection path.

**Safety**: Polecats stuck in `spawning` due to a `gt sling` crash are still caught by the existing GUPP violation mechanism after 30 minutes.

## Test Plan

- [x] Added `TestCheckPolecatHealth_SkipsSpawning`: verifies spawning polecats are not restarted (no CRASH DETECTED)
- [x] Added `TestCheckPolecatHealth_DetectsCrashedPolecat`: verifies non-spawning polecats with dead sessions still trigger crash detection (guard doesn't regress normal behaviour)
- [x] All daemon package tests pass
- [x] Build passes: `go build ./...`

Fixes #1752

🤖 Generated with [Claude Code](https://claude.com/claude-code)