### PR TITLE
fix(ready): filter mol infrastructure and events from gt ready / dashboard Work panel

### DIFF
--- a/internal/cmd/ready.go
+++ b/internal/cmd/ready.go
@@ -138,7 +138,9 @@ func runReady(cmd *cobra.Command, args []string) error {
 				wispIDs := getWispIDs(townBeadsPath)
 				filtered = filterWisps(filtered, wispIDs)
 				// Filter identity beads (agents, roles, rigs) - not actionable work
-				src.Issues = filterIdentityBeads(filtered)
+				filtered = filterIdentityBeads(filtered)
+				// Filter molecule infrastructure (mol instances, mol steps, events)
+				src.Issues = filterMoleculeBeads(filtered)
 			}
 			sources = append(sources, src)
 		}()
@@ -167,7 +169,9 @@ func runReady(cmd *cobra.Command, args []string) error {
 				wispIDs := getWispIDs(r.BeadsPath())
 				filtered = filterWisps(filtered, wispIDs)
 				// Filter identity beads (agents, roles, rigs) - not actionable work
-				src.Issues = filterIdentityBeads(filtered)
+				filtered = filterIdentityBeads(filtered)
+				// Filter molecule infrastructure (mol instances, mol steps, events)
+				src.Issues = filterMoleculeBeads(filtered)
 			}
 			sources = append(sources, src)
 		}(r)
@@ -464,18 +468,54 @@ func filterIdentityBeads(issues []*beads.Issue) []*beads.Issue {
 	return filtered
 }
 
-// filterWisps removes wisp issues from the list.
-// Wisps are ephemeral operational work that shouldn't appear in ready work.
-func filterWisps(issues []*beads.Issue, wispIDs map[string]bool) []*beads.Issue {
-	if wispIDs == nil || len(wispIDs) == 0 {
-		return issues
-	}
-
+// filterMoleculeBeads removes molecule infrastructure beads from the list.
+// Molecule instances and their step sub-issues are operational infrastructure
+// managed by agents — not dispatchable user work. The dashboard Work panel
+// should only show issues that a human or agent can actually sling to a polecat.
+//
+// Molecule beads follow the naming convention: <prefix>-mol-<id>
+// Both mol instance epics and their step sub-issues share this pattern.
+//
+// Also filters event-type issues (compaction reports, convoy events, etc.)
+// that are informational records, not actionable work items.
+func filterMoleculeBeads(issues []*beads.Issue) []*beads.Issue {
 	filtered := make([]*beads.Issue, 0, len(issues))
 	for _, issue := range issues {
-		if !wispIDs[issue.ID] {
-			filtered = append(filtered, issue)
+		// Filter event-type issues (compaction reports, convoy events, etc.)
+		if issue.Type == "event" {
+			continue
 		}
+
+		// Filter molecule infrastructure beads.
+		// ID convention: <rig-prefix>mol-<random-id> for both mol instances and steps.
+		// We detect this by checking whether "-mol-" appears in the ID.
+		if strings.Contains(issue.ID, "-mol-") {
+			continue
+		}
+
+		filtered = append(filtered, issue)
+	}
+	return filtered
+}
+
+// filterWisps removes wisp issues from the list.
+// Wisps are ephemeral operational work that shouldn't appear in ready work.
+// Primary filtering is done by bd ready (which excludes ephemeral issues by default).
+// This function provides defense-in-depth using two strategies:
+//  1. ID-based: any issue whose ID contains "-wisp-" is a wisp by naming convention
+//  2. DB-based: fallback lookup of explicit wisp flags from issues.jsonl (flat-file stores only)
+func filterWisps(issues []*beads.Issue, wispIDs map[string]bool) []*beads.Issue {
+	filtered := make([]*beads.Issue, 0, len(issues))
+	for _, issue := range issues {
+		// Filter by ID pattern: wisp IDs follow the convention <prefix>-wisp-<id>
+		if strings.Contains(issue.ID, "-wisp-") {
+			continue
+		}
+		// Filter by explicit wisp flag from DB lookup (when available)
+		if wispIDs != nil && wispIDs[issue.ID] {
+			continue
+		}
+		filtered = append(filtered, issue)
 	}
 	return filtered
 }


### PR DESCRIPTION
## Problem

The dashboard Work panel was showing infrastructure noise alongside legitimate dispatchable work. After cleanup, only 2 of 9 'ready' items in the Work panel were actual user issues a polecat could work on. The rest were:

- **Molecule instances** (`asm-mol-*` with `issue_type=epic`, title like `mol-witness-patrol`) — operational infrastructure managed by agents
- **Molecule step sub-issues** (`asm-mol-*` child steps of mol instances) — individual steps in a running molecule
- **Event-type issues** (`hq-f29k`, `issue_type=event`) — compaction reports, convoy events, informational records

These items each had a 'Sling' button in the dashboard, which would be incorrect to use on them.

Additionally, `filterWisps` was effectively a no-op on Dolt-backed stores because it tried to read from `issues.jsonl` which doesn't exist in that storage format — meaning the defense-in-depth wisp filter was silently doing nothing.

## Solution

**`filterMoleculeBeads`** (new function): Removes issues where:
- `issue_type == "event"` — compaction reports, convoy events, etc.
- ID contains `-mol-` — both mol instance epics (`asm-mol-4lj`) and their step sub-issues (`asm-mol-fje`) follow this naming convention

**`filterWisps`** (fixed): Now uses ID pattern matching (`-wisp-` in ID) as the primary strategy, with the existing DB lookup as a fallback for flat-file stores. This means it correctly filters wisps in both Dolt-backed and flat-file beads stores.

Both filters are applied in the ready pipeline for town beads and per-rig beads, after the existing formula-scaffold and identity-bead filters.

## Test plan

- [x] `TestFilterMoleculeBeads` — verifies mol instances, mol steps, and events are filtered; legitimate work passes through
- [x] `TestFilterMoleculeBeads_EmptyInput` — empty list handled
- [x] `TestFilterMoleculeBeads_AllLegitimate` — no false positives on real issues
- [x] `TestFilterWisps_IDPatternFallback` — filters wisps by ID pattern even when wispIDs DB lookup is nil
- [x] `TestFilterWisps_DBLookupFallback` — DB-lookup still works for edge cases where ID doesn't contain `-wisp-`
- [x] All existing tests pass

Fixes: hq-0onx

🤖 Generated with [Claude Code](https://claude.com/claude-code)