### PR TITLE
fix(dashboard): limit concurrent bd processes and slow SSE polling

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -2061,11 +2061,11 @@ func (h *APIHandler) handleSSE(w http.ResponseWriter, r *http.Request) {
 	flusher.Flush()
 
 	var lastHash string
-	ticker := time.NewTicker(2 * time.Second)
+	ticker := time.NewTicker(10 * time.Second)
 	defer ticker.Stop()
 
-	// Send keepalive comment every 15 seconds to prevent connection timeouts
-	keepalive := time.NewTicker(15 * time.Second)
+	// Send keepalive comment every 30 seconds to prevent connection timeouts
+	keepalive := time.NewTicker(30 * time.Second)
 	defer keepalive.Stop()
 
 	for {


### PR DESCRIPTION
## Problem

`gt dashboard` spawns 50+ concurrent `bd` processes within seconds of starting, pegging all CPUs (#1760). On an 8-core Apple Silicon, load average goes from 7 → 27 in 30 seconds.

### Root cause

Three factors compound:

1. **14 parallel Fetch\* goroutines** per page load — each can cascade into multiple `bd` subprocess calls (list → dep list → show per issue)
2. **SSE hash-check every 2 seconds** — spawns 3 more `gt`/`bd` commands per tick
3. **No concurrency limit** on the fetcher's command execution paths (`runCmd` and `runBdCmd`)

The API handler had a 12-slot semaphore (`cmdSem`), but the fetcher's `runCmd`/`runBdCmd` bypassed it entirely.

## Fix

- **Fetcher semaphore** — adds a package-level 6-slot buffered channel (`fetcherSem`) gating all `runCmd` and `runBdCmd` calls. When all slots are taken, goroutines block until one frees up or their context expires.
- **SSE interval 2s → 10s** — dashboard state doesn't change fast enough to justify 2-second polling. 10 seconds is responsive enough for a monitoring dashboard.
- **SSE keepalive 15s → 30s** — aligned with the slower poll interval.

### Before / After (expected)

| Metric | Before | After |
|--------|--------|-------|
| Peak concurrent bd processes | 55+ | ≤6 |
| SSE commands/minute | ~90 | ~18 |
| CPU impact | All cores pegged | Minimal |

## Testing

- `go build ./...` — passes
- `go vet ./internal/web/` — clean
- `go test ./internal/web/ -count=1` — all pass (includes new `TestFetcherSemaphoreLimits`)

## AI-Assisted

This PR was developed with AI assistance (Claude).

Fixes #1760