### PR TITLE
fix(session): synchronize defaultRegistry access with atomic.Pointer

### DIFF
--- a/internal/session/identity.go
+++ b/internal/session/identity.go
@@ -97,7 +97,7 @@ func ParseAddress(address string) (*AgentIdentity, error) {
 // The rig name is resolved from the default PrefixRegistry. If the prefix is
 // not in the registry, the prefix itself is used as the rig name.
 func ParseSessionName(session string) (*AgentIdentity, error) {
-	return ParseSessionNameWithRegistry(session, defaultRegistry)
+	return ParseSessionNameWithRegistry(session, defaultRegistry.Load())
 }
 
 // ParseSessionNameWithRegistry parses a tmux session name using a specific registry.

--- a/internal/session/identity_test.go
+++ b/internal/session/identity_test.go
@@ -18,9 +18,9 @@ func testRegistry() *PrefixRegistry {
 func TestParseSessionName(t *testing.T) {
 	reg := testRegistry()
 	// Also set as default for ParseSessionName (no-registry variant)
-	old := defaultRegistry
-	defaultRegistry = reg
-	defer func() { defaultRegistry = old }()
+	old := defaultRegistry.Load()
+	defaultRegistry.Store(reg)
+	defer func() { defaultRegistry.Store(old) }()
 
 	tests := []struct {
 		name       string
@@ -303,9 +303,9 @@ func TestAgentIdentity_Address(t *testing.T) {
 
 func TestParseSessionName_RoundTrip(t *testing.T) {
 	reg := testRegistry()
-	old := defaultRegistry
-	defaultRegistry = reg
-	defer func() { defaultRegistry = old }()
+	old := defaultRegistry.Load()
+	defaultRegistry.Store(reg)
+	defer func() { defaultRegistry.Store(old) }()
 
 	// Test that parsing then reconstructing gives the same result
 	sessions := []string{


### PR DESCRIPTION
## Problem

`session.SetDefaultRegistry` performs an unsynchronized write to the package-level `defaultRegistry` pointer (#1661). While the write is effectively atomic on all Go platforms (single machine word), `go test -race` correctly flags this as a data race.

The race window is widening: PR #1659 increased `InitRegistry` call sites from ~2 to ~9, with concurrent reads from patrol goroutines and mail handlers.

## Fix

Replace the bare `*PrefixRegistry` variable with `atomic.Pointer[PrefixRegistry]`:

```go
// Before
var defaultRegistry = NewPrefixRegistry()

func SetDefaultRegistry(r *PrefixRegistry) {
    defaultRegistry = r  // unsynchronized write
}

// After
var defaultRegistry atomic.Pointer[PrefixRegistry]

func SetDefaultRegistry(r *PrefixRegistry) {
    defaultRegistry.Store(r)  // atomic store
}
```

All read sites (`DefaultRegistry`, `PrefixFor`, `IsKnownSession`, `ParseSessionName`) now go through `.Load()`.

## Testing

- `go test ./internal/session/ -race -count=1` — passes
- `go vet ./internal/session/` — clean
- `go build ./...` — passes

## AI-Assisted

This PR was developed with AI assistance (Claude).

Fixes #1661