### PR TITLE
fix(handoff): kill old processes before respawning to prevent duplicates

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -783,7 +783,7 @@ func (d *Daemon) ensureWitnessRunning(rigName string) {
 	if status := mgr.IsHealthy(hungSessionThreshold); status == tmux.AgentHung {
 		d.logger.Printf("Witness for %s is hung (no activity for %v), killing for restart", rigName, hungSessionThreshold)
 		t := tmux.NewTmux()
-		_ = t.KillSession(mgr.SessionName())
+		_ = t.KillSessionWithProcesses(mgr.SessionName())
 	}
 
 	if err := mgr.Start(false, "", nil); err != nil {
@@ -833,7 +833,7 @@ func (d *Daemon) ensureRefineryRunning(rigName string) {
 	if status := mgr.IsHealthy(hungSessionThreshold); status == tmux.AgentHung {
 		d.logger.Printf("Refinery for %s is hung (no activity for %v), killing for restart", rigName, hungSessionThreshold)
 		t := tmux.NewTmux()
-		_ = t.KillSession(mgr.SessionName())
+		_ = t.KillSessionWithProcesses(mgr.SessionName())
 	}
 
 	if err := mgr.Start(false, ""); err != nil {

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -118,7 +118,7 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 		}
 		// Zombie - tmux alive but agent dead. Kill and recreate.
 		_, _ = fmt.Fprintln(m.output, "⚠ Detected zombie session (tmux alive, agent dead). Recreating...")
-		if err := t.KillSession(sessionID); err != nil {
+		if err := t.KillSessionWithProcesses(sessionID); err != nil {
 			return fmt.Errorf("killing zombie session: %w", err)
 		}
 	}
@@ -225,8 +225,8 @@ func (m *Manager) Stop() error {
 		return ErrNotRunning
 	}
 
-	// Kill the tmux session
-	return t.KillSession(sessionID)
+	// Kill the tmux session and all descendant processes
+	return t.KillSessionWithProcesses(sessionID)
 }
 
 // Queue returns the current merge queue.

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -775,8 +775,8 @@ func NukePolecat(workDir, rigName, polecatName string) error {
 		_ = t.SendKeysRaw(sessionName, "C-c")
 		// Brief delay for graceful handling
 		time.Sleep(100 * time.Millisecond)
-		// Force kill the session
-		if err := t.KillSession(sessionName); err != nil {
+		// Force kill the session and all descendant processes
+		if err := t.KillSessionWithProcesses(sessionName); err != nil {
 			// Log but continue - session might already be dead
 			// The important thing is we tried
 		}

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -122,7 +122,7 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 			return ErrAlreadyRunning
 		}
 		// Zombie - tmux alive but Claude dead. Kill and recreate.
-		if err := t.KillSession(sessionID); err != nil {
+		if err := t.KillSessionWithProcesses(sessionID); err != nil {
 			return fmt.Errorf("killing zombie session: %w", err)
 		}
 	}
@@ -278,6 +278,6 @@ func (m *Manager) Stop() error {
 		return ErrNotRunning
 	}
 
-	// Kill the tmux session
-	return t.KillSession(sessionID)
+	// Kill the tmux session and all descendant processes
+	return t.KillSessionWithProcesses(sessionID)
 }


### PR DESCRIPTION
## Summary
- Fix duplicate agent processes caused by self-handoff not killing old processes properly

## Problem
Self-handoff relied on `respawn-pane -k` to kill the old process, but respawn-pane only sends SIGHUP which opencode/Node.js ignores. This caused the old process to survive while a new one spawned, creating duplicate agent processes.

## Solution
1. **handoff.go**: Call `KillPaneProcessesExcluding()` before `RespawnPane()` to explicitly kill all pane processes (except gt handoff itself) using SIGTERM/SIGKILL.

2. **daemon.go**: Change hung session handling from `KillSession()` to `KillSessionWithProcesses()` for witness and refinery.

3. **witness/manager.go**: Change `Stop()` and zombie detection to use `KillSessionWithProcesses()`.

4. **witness/handlers.go**: Change polecat nuke to use `KillSessionWithProcesses()`.

5. **refinery/manager.go**: Change `Stop()` and zombie detection to use `KillSessionWithProcesses()`.

`KillSession()` only sends SIGHUP which agents ignore, leaving orphan processes. `KillSessionWithProcesses()` sends SIGTERM/SIGKILL to ensure all descendant processes are terminated.

## Changes
- `internal/cmd/handoff.go`: +15/-10 lines
- `internal/daemon/daemon.go`: +2/-2 lines
- `internal/refinery/manager.go`: +3/-3 lines
- `internal/witness/manager.go`: +3/-3 lines
- `internal/witness/handlers.go`: +2/-2 lines

## Testing
- Build passes
- Existing tests pass