### PR TITLE
Revert: Unset BD_BRANCH when reading hooked work (#1797)

### DIFF
--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -278,11 +278,6 @@ func runHook(_ *cobra.Command, args []string) error {
 		}
 	}
 
-	// Unset BD_BRANCH to read from main rig branch for hooked work visibility
-	if bdBranch := os.Getenv("BD_BRANCH"); bdBranch != "" {
-		os.Unsetenv("BD_BRANCH")
-	}
-
 	b := beads.New(workDir)
 
 	// Check for existing hooked bead for this agent

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -155,11 +155,6 @@ func runMoleculeProgress(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a beads workspace: %w", err)
 	}
 
-	// Unset BD_BRANCH to read from main rig branch for hooked work visibility
-	if bdBranch := os.Getenv("BD_BRANCH"); bdBranch != "" {
-		os.Unsetenv("BD_BRANCH")
-	}
-
 	b := beads.New(workDir)
 
 	// Get the root issue
@@ -361,14 +356,6 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 	workDir, err := findLocalBeadsDir()
 	if err != nil {
 		return fmt.Errorf("not in a beads workspace: %w", err)
-	}
-
-	// Unset BD_BRANCH so we read from the main rig branch where work is assigned,
-	// not the polecat's isolated branch. Polecats have BD_BRANCH set for write isolation,
-	// but they need to read hooked work from the main branch.
-	// See: https://github.com/steveyegge/gastown/issues/gt-nnnnnn
-	if bdBranch := os.Getenv("BD_BRANCH"); bdBranch != "" {
-		os.Unsetenv("BD_BRANCH")
 	}
 
 	b := beads.New(workDir)

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -412,13 +412,6 @@ func findAgentWork(ctx RoleContext) *beads.Issue {
 		return nil
 	}
 
-	// Unset BD_BRANCH so we read from the main rig branch where work is assigned,
-	// not the polecat's isolated branch. Polecats have BD_BRANCH set for write isolation,
-	// but they need to read hooked work from the main branch.
-	if bdBranch := os.Getenv("BD_BRANCH"); bdBranch != "" {
-		os.Unsetenv("BD_BRANCH")
-	}
-
 	b := beads.New(ctx.WorkDir)
 
 	// Primary: agent bead's hook_bead field (authoritative, set by bd slot set during sling)


### PR DESCRIPTION
## Summary

Reverts PR #1797 (merge commit 9cf387cf). The original change used `os.Unsetenv("BD_BRANCH")` in three call sites to force reads from the main Dolt branch. This breaks write isolation and masks the real root cause.

## Related Issue

Reverts #1797

## Changes

- Remove `os.Unsetenv("BD_BRANCH")` from `runHook()` in `hook.go`
- Remove `os.Unsetenv("BD_BRANCH")` from `runMoleculeProgress()` and `runMoleculeStatus()` in `molecule_status.go`
- Remove `os.Unsetenv("BD_BRANCH")` from `findAgentWork()` in `prime.go`

### Why revert

1. **`os.Unsetenv` is permanent** — BD_BRANCH is never restored after the unset. Any subsequent `bd` writes in the same process go to main instead of the polecat's isolated branch, silently breaking write isolation.

2. **Data should already be on the polecat branch.** The sling sequence explicitly flushes the working set to HEAD (`CommitServerWorkingSet`) and then forks the branch from that HEAD (`CreatePolecatBranch`). The comments in `sling_formula.go:215-217`, `sling_batch.go:229-231`, and `polecat_spawn.go:321-324` all document this guarantee. If hooked work isn't visible on the polecat branch, the root cause is upstream in the flush/fork sequence or in `bd`'s branch-read behavior.

3. **Fix was copy-pasted across 3 call sites** rather than handled once at the `beads.run()` transport layer where `BD_BRANCH` is propagated to the `bd` CLI via `os.Environ()`.

### If there is a real visibility gap

The proper investigation should check:
- Whether `CommitServerWorkingSet` is actually committing before `CreatePolecatBranch` runs
- Whether the `bd` CLI properly reads from a non-main branch via `BD_BRANCH`
- Whether `gt hook <bead> <target>` from outside a running polecat creates a scenario where new hook data lands on main after the branch fork (legitimate, but needs a different fix)

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Verified revert matches exact inverse of PR #1797 diff

## Checklist
- [x] Code follows project style
- [x] No breaking changes (restores pre-#1797 behavior)