### PR TITLE
fix(done): prevent stale polecat from force-closing reassigned beads

### DIFF
--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -1482,14 +1482,19 @@ func TestDoneMRFailedEventType(t *testing.T) {
 	}
 }
 
-// TestIsStalePolecatDoneLogic verifies the guard logic that prevents respawned
+
+// TestIsStalePolecatDoneCheck verifies the guard logic that prevents respawned
 // polecats from force-closing beads assigned to other polecats (gt-frf61).
 //
 // Root cause: polecat furiosa was respawned for a different bead but retained
 // stale branch state from a prior assignment. Its gt done found 0 commits ahead
 // and the G15 force-close path closed gt-frf61, which was assigned to polecat
-// cheedo. The isStalePolecatDone guard checks hook_bead and assignee to prevent this.
-func TestIsStalePolecatDoneLogic(t *testing.T) {
+// cheedo. The isStalePolecatDoneCheck guard checks hook_bead and assignee to prevent this.
+//
+// This tests the actual isStalePolecatDoneCheck function (pure logic, no bd dependency).
+// The bd.Show error paths (fail-closed behavior) are handled by isStalePolecatDone,
+// which returns stale=true on any read error — see TestIsStalePolecatDoneFailClosed.
+func TestIsStalePolecatDoneCheck(t *testing.T) {
 	tests := []struct {
 		name          string
 		agentHookBead string // agent's current hook_bead
@@ -1562,30 +1567,55 @@ func TestIsStalePolecatDoneLogic(t *testing.T) {
 			polecatName:   "",
 			wantStale:     false,
 		},
+		{
+			name:          "substring polecat name does not false-match (gastown in path)",
+			agentHookBead: "",
+			issueID:       "gt-abc",
+			beadAssignee:  "gastown/polecats/cheedo",
+			polecatName:   "gastown",
+			wantStale:     true,
+		},
+		{
+			name:          "prefix polecat name does not false-match",
+			agentHookBead: "",
+			issueID:       "gt-abc",
+			beadAssignee:  "gastown/polecats/maximum",
+			polecatName:   "max",
+			wantStale:     true,
+		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			// Replicate the isStalePolecatDone logic without bd dependency.
-			// This validates the boolean guard conditions match the function's behavior.
-			stale := false
-
-			// Check 1: Hook mismatch
-			if tt.agentHookBead != "" && tt.agentHookBead != tt.issueID {
-				stale = true
-			}
-
-			// Check 2: Assignee mismatch (only if hook didn't catch it)
-			if !stale && tt.polecatName != "" && tt.issueID != "" {
-				if tt.beadAssignee != "" && !strings.Contains(tt.beadAssignee, tt.polecatName) {
-					stale = true
-				}
-			}
-
+			stale, reason := isStalePolecatDoneCheck(tt.agentHookBead, tt.issueID, tt.beadAssignee, tt.polecatName)
 			if stale != tt.wantStale {
-				t.Errorf("stale = %v, want %v (hook=%q, issue=%q, assignee=%q, polecat=%q)",
-					stale, tt.wantStale, tt.agentHookBead, tt.issueID, tt.beadAssignee, tt.polecatName)
+				t.Errorf("stale = %v (reason: %s), want %v (hook=%q, issue=%q, assignee=%q, polecat=%q)",
+					stale, reason, tt.wantStale, tt.agentHookBead, tt.issueID, tt.beadAssignee, tt.polecatName)
 			}
 		})
+	}
+}
+
+// TestIsStalePolecatDoneFailClosed verifies that isStalePolecatDone returns stale=true
+// when bd.Show fails, rather than proceeding to force-close (fail-closed behavior).
+// This is tested indirectly: isStalePolecatDone with a nil/invalid beads instance
+// will fail on bd.Show and should return stale=true.
+func TestIsStalePolecatDoneFailClosed(t *testing.T) {
+	// A beads instance pointing at a nonexistent directory will fail on Show.
+	bd := beads.New("/nonexistent/beads/dir")
+
+	// With a non-empty agentBeadID, the first bd.Show should fail → stale.
+	stale, reason := isStalePolecatDone(bd, "agent-bead-123", "gt-test", "furiosa")
+	if !stale {
+		t.Errorf("expected stale=true when bd.Show fails, got false (reason: %s)", reason)
+	}
+	if reason == "" {
+		t.Error("expected non-empty reason when bd.Show fails")
+	}
+
+	// With empty agentBeadID but valid polecatName/issueID, second bd.Show should fail → stale.
+	stale, reason = isStalePolecatDone(bd, "", "gt-test", "furiosa")
+	if !stale {
+		t.Errorf("expected stale=true when bd.Show fails on issue lookup, got false (reason: %s)", reason)
 	}
 }


### PR DESCRIPTION
## Summary
- Add `isStalePolecatDone` ownership guard before the G15 force-close path in `gt done`
- Prevents respawned polecats with stale branch state from closing beads assigned to other polecats
- Two independent checks: agent hook mismatch (primary) and assignee mismatch (backup)

## Related Issue
Fixes gt-frf61: polecat furiosa was respawned for gt-pjox2 but retained stale branch `polecat/furiosa/gt-frf61@mlurugd2`. Its `gt done` found 0 commits ahead, hit the G15 force-close path, and closed gt-frf61 with "Completed with no code changes" — while cheedo was actively working on it. The branch with 2 real review-fix commits (`polecat/furiosa/gt-frf61@mlupw65o`) was never merged.

### Root cause timeline
1. Furiosa completed gt-frf61 review fixes at 10:18 (branch `@mlupw65o` pushed to origin)
2. Furiosa respawned for gt-pjox2, completed it at 10:37/10:51
3. Witness recovered orphaned gt-frf61 at 10:52, mayor dispatched to **cheedo** at 10:55
4. Furiosa respawned at 10:53 — worktree created with stale frf61 branch `@mlurugd2`
5. Furiosa's session started at 10:57 (for MERGED mail about pjox2)
6. **Bug**: Within 41s, furiosa ran `gt done` on the stale branch → 0 commits ahead → G15 `ForceCloseWithReason` closed gt-frf61 at 10:58
7. Auto-flush captured closed state; cheedo's later merge lost to conflict resolution

### Why the guard works
`isStalePolecatDone` runs two checks before `ForceCloseWithReason`:
1. **Hook mismatch**: Agent's `hook_bead` (authoritative current work) ≠ `issueID` from branch name → stale
2. **Assignee mismatch**: Bead's assignee doesn't contain this polecat's name → stale

In the gt-frf61 case: furiosa's hook was empty/pointed to pjox2, and the bead was assigned to cheedo. Either check catches it.

## Changes
- `internal/cmd/done.go`: Add `isStalePolecatDone` guard before G15 force-close, add helper function
- `internal/cmd/done_test.go`: Add `TestIsStalePolecatDoneLogic` with 8 test cases covering hook match/mismatch, assignee formats, and edge cases

## Testing
- [x] Unit tests pass (`go test ./internal/cmd/`)
- [x] `go vet ./internal/cmd/` clean
- [x] All 8 regression test cases pass

## Checklist
- [x] Code follows project style
- [x] No breaking changes — guard only skips force-close for stale polecats, legitimate done paths unaffected