### PR TITLE
fix: set GT_PROCESS_NAMES for Deacon and unified session lifecycle

### DIFF
--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -132,7 +132,7 @@ func (m *Manager) Start(agentOverride string) error {
 	// FIX: GT_PROCESS_NAMES must be set for correct IsAgentAlive detection
 	// when using non-Claude agents (opencode, codex, etc.)
 	// See: https://github.com/steveyegge/gastown/issues/1808
-	processNames := config.GetProcessNames(runtimeConfig.ResolvedAgent)
+	processNames := config.ResolveProcessNames(runtimeConfig.ResolvedAgent, runtimeConfig.Command)
 	envVars["GT_PROCESS_NAMES"] = strings.Join(processNames, ",")
 	for k, v := range envVars {
 		_ = t.SetEnvironment(sessionID, k, v)

--- a/internal/session/lifecycle.go
+++ b/internal/session/lifecycle.go
@@ -199,7 +199,7 @@ func StartSession(t *tmux.Tmux, cfg SessionConfig) (*StartResult, error) {
 	// FIX: GT_PROCESS_NAMES must be set for correct IsAgentAlive detection
 	// when using non-Claude agents (opencode, codex, etc.)
 	// See: https://github.com/steveyegge/gastown/issues/1808
-	processNames := config.GetProcessNames(runtimeConfig.ResolvedAgent)
+	processNames := config.ResolveProcessNames(runtimeConfig.ResolvedAgent, runtimeConfig.Command)
 	envVars["GT_PROCESS_NAMES"] = strings.Join(processNames, ",")
 	for _, k := range mapKeysSorted(envVars) {
 		_ = t.SetEnvironment(cfg.SessionID, k, envVars[k])


### PR DESCRIPTION
## Summary

Supersedes #1817 by @DerrickBarra. This PR includes the original fix plus a maintainer fixup that came out of the adoption review.

Credit: Original fix by @DerrickBarra (commit preserved with original authorship).

The fix from #1785 added GT_PROCESS_NAMES to daemon and polecat session managers, but missed:
1. **Deacon manager** — explicit Deacon startup path
2. **Unified session lifecycle** — `StartSession()` used by Mayor, Boot, Dog, etc.

This caused `IsAgentAlive` to fail for non-Claude agents (opencode, codex, etc.) running as Mayor or Deacon, because `resolveSessionProcessNames` reads GT_PROCESS_NAMES from the tmux session table, which was never set for these paths.

**Maintainer fixup:** Changed `GetProcessNames` → `ResolveProcessNames` to cross-reference both agent name and command binary, matching the pattern used by all other GT_PROCESS_NAMES callsites (daemon.go, polecat/session_manager.go, loader.go, handoff.go).

## Related Issue

Fixes #1808
Supersedes #1817
Related to #1785

## Changes

- Add GT_PROCESS_NAMES to `internal/deacon/manager.go` using `config.ResolveProcessNames()`
- Add GT_PROCESS_NAMES to `internal/session/lifecycle.go` using `config.ResolveProcessNames()`

## Testing

- Existing tests pass (build failure in `config/agents.go:338` is pre-existing on main — duplicate struct fields unrelated to this PR)
- Pattern matches established usage in daemon.go and polecat/session_manager.go
- Fix confirmed working in live Gastown deployment (per original PR)

## Checklist
- [x] Code follows project style
- [x] No breaking changes
- [x] Matches established GT_PROCESS_NAMES pattern across codebase