### PR TITLE
fix(formula): sync .beads/ canonical formulas with internal/ embedded copies

### DIFF
--- a/.beads/formulas/mol-polecat-work.formula.toml
+++ b/.beads/formulas/mol-polecat-work.formula.toml
@@ -34,7 +34,7 @@ for step details — do NOT read this file directly.
 | base_branch | sling vars | The base branch to rebase on (default: main) |
 | setup_command | rig config | Setup/install command (e.g., `pnpm install`). Empty = skip. |
 | typecheck_command | rig config | Type check command (e.g., `tsc --noEmit`). Empty = skip. |
-| test_command | rig config | Test command (default: `go test ./...`) |
+| test_command | rig config | Test command. Empty = skip. Rig must configure for its language. |
 | lint_command | rig config | Lint command (e.g., `eslint .`). Empty = skip. |
 | build_command | rig config | Build command (e.g., `go build ./...`). Empty = skip. |
 
@@ -531,7 +531,7 @@ default = ""
 
 [vars.test_command]
 description = "Command to run tests (auto-detected from rig settings)"
-default = "go test ./..."
+default = ""
 
 [vars.lint_command]
 description = "Command to run linting. Empty = skip."

--- a/.beads/formulas/mol-sync-workspace.formula.toml
+++ b/.beads/formulas/mol-sync-workspace.formula.toml
@@ -32,7 +32,7 @@ Polecats can file a bead and delegate. Refinery must resolve inline.
 | setup_command | config | Setup/install command (empty = skip) |
 | typecheck_command | config | Type check command (empty = skip) |
 | lint_command | config | Lint command (empty = skip) |
-| test_command | config or default | Test command (default: `go test ./...`) |
+| test_command | rig config | Test command. Empty = skip. Rig must configure for its language. |
 | build_command | config | Build command (empty = skip) |
 
 ## Failure Modes
@@ -515,7 +515,7 @@ default = ""
 
 [vars.test_command]
 description = "Command to run tests (auto-detected from rig settings)"
-default = "go test ./..."
+default = ""
 
 [vars.build_command]
 description = "Command to run build. Empty = skip."


### PR DESCRIPTION
## Summary
Commit 85810249 changed `test_command` default from `go test ./...` to empty string in `internal/formula/formulas/` without updating the canonical `.beads/formulas/` sources. This broke the CI "Check embedded formulas" gate.

## Related Issue
Fixes CI failure on main (run 22239700933).

## Changes
- Update `.beads/formulas/mol-polecat-work.formula.toml`: set `test_command` default to `""` and update description to match `internal/` version
- Update `.beads/formulas/mol-sync-workspace.formula.toml`: same changes
- Add missing `internal/formula/formulas/mol-polecat-adopt-pr.formula.toml` (existed in `.beads/` but was not embedded)

## Testing
- [x] Unit tests pass (`go test ./internal/formula/...`)
- [x] `go generate ./internal/formula/...` produces no diff (formulas in sync)
- [x] `go build ./...` succeeds

## Checklist
- [x] Code follows project style
- [x] No breaking changes