### PR TITLE
fix: add polecats/ prefix to nudge address resolution

### DIFF
--- a/internal/cmd/dnd_test.go
+++ b/internal/cmd/dnd_test.go
@@ -29,6 +29,8 @@ func TestAddressToAgentBeadID(t *testing.T) {
 		{"gastown/refinery", "gt-refinery"},
 		{"gastown/alpha", "gt-alpha"},
 		{"gastown/crew/max", "gt-crew-max"},
+		{"gastown/polecats/alpha", "gt-alpha"},
+		{"beads/polecats/beta", "bd-beta"},
 		{"beads/witness", "bd-witness"},
 		{"beads/beta", "bd-beta"},
 		// Invalid addresses should return empty string

--- a/internal/cmd/nudge.go
+++ b/internal/cmd/nudge.go
@@ -706,6 +706,10 @@ func addressToAgentBeadID(address string) string {
 			crewName := strings.TrimPrefix(role, "crew/")
 			return session.CrewSessionName(session.PrefixFor(rig), crewName)
 		}
+		if strings.HasPrefix(role, "polecats/") {
+			pcName := strings.TrimPrefix(role, "polecats/")
+			return session.PolecatSessionName(session.PrefixFor(rig), pcName)
+		}
 		return session.PolecatSessionName(session.PrefixFor(rig), role)
 	}
 }

--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -1491,6 +1491,9 @@ func addressToAgentBeadID(address string) string {
 	case strings.HasPrefix(target, "crew/"):
 		crewName := strings.TrimPrefix(target, "crew/")
 		return session.CrewSessionName(rigPrefix, crewName)
+	case strings.HasPrefix(target, "polecats/"):
+		pcName := strings.TrimPrefix(target, "polecats/")
+		return session.PolecatSessionName(rigPrefix, pcName)
 	default:
 		return session.PolecatSessionName(rigPrefix, target)
 	}

--- a/internal/mail/router_test.go
+++ b/internal/mail/router_test.go
@@ -1129,6 +1129,11 @@ func TestAddressToAgentBeadID(t *testing.T) {
 			expected: "gt-alpha",
 		},
 		{
+			name:     "explicit polecat with polecats/ prefix",
+			address:  "gastown/polecats/alpha",
+			expected: "gt-alpha",
+		},
+		{
 			name:     "empty address",
 			address:  "",
 			expected: "",


### PR DESCRIPTION
## Summary

Supersedes #1826 by @timyarm, which correctly identified that short addresses like `rig/name` resolve crew-first in `gt nudge`, causing nudges intended for polecats to land in crew sessions when both share the same name. This PR includes that fix plus maintainer fixups for DND bypass and test coverage.

Credit: Original fix by @timyarm (commit preserved with original authorship).

## Related Issue

Supersedes #1826

## Changes

- Add explicit `polecats/` prefix handling in nudge address resolution (`internal/cmd/nudge.go`) — original fix by @timyarm
- Add `polecats/` prefix handling to `addressToAgentBeadID` in both `internal/cmd/nudge.go` and `internal/mail/router.go` to prevent DND bypass for explicit polecat addresses
- Add test coverage for `polecats/` prefix in `TestAddressToAgentBeadID` (both `dnd_test.go` and `router_test.go`)

## Testing

- [x] `go test ./internal/cmd/ -run TestAddressToAgentBeadID` passes (including new `polecats/` cases)
- [x] `go test ./internal/mail/ -run TestAddressToAgentBeadID` passes (including new `polecats/` case)
- [x] Existing `TestNudge*` and `TestResolveNudgePattern` tests pass (no regressions)

## Checklist
- [x] Code follows project style
- [x] No breaking changes — backward compatible (`rig/name` still resolves crew-first)