### PR TITLE
test(coverage): cover fetcher command helpers + session registry edge cases

### DIFF
--- a/internal/session/registry_atomic_test.go
+++ b/internal/session/registry_atomic_test.go
@@ -1,0 +1,41 @@
+package session
+
+import "testing"
+
+func TestDefaultRegistrySwapAndPrefixFor(t *testing.T) {
+	old := DefaultRegistry()
+	defer SetDefaultRegistry(old)
+
+	r := NewPrefixRegistry()
+	r.Register("xy", "xrig")
+	SetDefaultRegistry(r)
+
+	if got := DefaultRegistry(); got != r {
+		t.Fatalf("DefaultRegistry() did not return swapped registry")
+	}
+	if got := PrefixFor("xrig"); got != "xy" {
+		t.Fatalf("PrefixFor(xrig) = %q, want %q", got, "xy")
+	}
+	if got := PrefixFor("unknown-rig"); got != DefaultPrefix {
+		t.Fatalf("PrefixFor(unknown-rig) = %q, want %q", got, DefaultPrefix)
+	}
+}
+
+func TestIsKnownSession_UsesDefaultRegistryAndHQPrefix(t *testing.T) {
+	old := DefaultRegistry()
+	defer SetDefaultRegistry(old)
+
+	r := NewPrefixRegistry()
+	r.Register("xy", "xrig")
+	SetDefaultRegistry(r)
+
+	if !IsKnownSession("hq-mayor") {
+		t.Fatal("expected hq-mayor to always be known")
+	}
+	if !IsKnownSession("xy-worker") {
+		t.Fatal("expected xy-worker to be known via registry prefix")
+	}
+	if IsKnownSession("zz-worker") {
+		t.Fatal("expected zz-worker to be unknown")
+	}
+}

--- a/internal/web/fetcher_test.go
+++ b/internal/web/fetcher_test.go
@@ -1,6 +1,10 @@
 package web
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
 
@@ -478,5 +482,78 @@ func TestNewDashboardMux_NilConfig(t *testing.T) {
 	}
 	if mux == nil {
 		t.Fatal("NewDashboardMux returned nil handler")
+	}
+}
+
+func TestRunCmd_SuccessAndTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-based command test")
+	}
+
+	out, err := runCmd(500*time.Millisecond, "sh", "-c", "printf 'ok'")
+	if err != nil {
+		t.Fatalf("runCmd success case failed: %v", err)
+	}
+	if got := strings.TrimSpace(out.String()); got != "ok" {
+		t.Fatalf("runCmd output = %q, want %q", got, "ok")
+	}
+
+	_, err = runCmd(30*time.Millisecond, "sh", "-c", "sleep 1")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout error, got: %v", err)
+	}
+}
+
+func TestRunBdCmd_ReturnsStdoutOnNonZeroAndTimeout(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-based command test")
+	}
+
+	binDir := t.TempDir()
+	bdPath := filepath.Join(binDir, "bd")
+	script := `#!/bin/sh
+case "$1" in
+  warn)
+    echo "partial output"
+    exit 1
+    ;;
+  sleep)
+    sleep 1
+    exit 0
+    ;;
+  *)
+    echo "ok"
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(bdPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	f := &LiveConvoyFetcher{cmdTimeout: 200 * time.Millisecond}
+
+	// Non-zero exit with stdout should return stdout and nil error.
+	stdout, err := f.runBdCmd(t.TempDir(), "warn")
+	if err != nil {
+		t.Fatalf("runBdCmd warn returned error: %v", err)
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "partial output" {
+		t.Fatalf("runBdCmd warn output = %q, want %q", got, "partial output")
+	}
+
+	// Timeout path should return explicit timeout error.
+	f.cmdTimeout = 20 * time.Millisecond
+	_, err = f.runBdCmd(t.TempDir(), "sleep")
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("expected timeout error, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary
Follow-up test-only PR to address Codecov patch feedback from recently merged reliability fixes:
- #1805 (`fix/dashboard-bd-process-flood`)
- #1807 (`fix/session-registry-race`)

This adds coverage for important edge paths without changing production behavior.

## What this adds

### `internal/web/fetcher_test.go`
- `TestRunCmd_SuccessAndTimeout`
  - verifies normal output path
  - verifies timeout path returns explicit timeout error
- `TestRunBdCmd_ReturnsStdoutOnNonZeroAndTimeout`
  - verifies non-zero `bd` exit with stdout still returns output (intentional behavior)
  - verifies timeout handling for `runBdCmd`

### `internal/session/registry_atomic_test.go`
- `TestDefaultRegistrySwapAndPrefixFor`
  - verifies atomic default-registry swap and `PrefixFor` behavior
- `TestIsKnownSession_UsesDefaultRegistryAndHQPrefix`
  - verifies `IsKnownSession` respects HQ prefix and registry-backed prefixes

## Why
These are exactly the branches Codecov flagged as missing in the merged PRs, and they are high-value reliability/error-handling paths.

## Validation
- `GOTOOLCHAIN=auto GOSUMDB=sum.golang.org gofmt -w internal/web/fetcher_test.go internal/session/registry_atomic_test.go`
- `GOTOOLCHAIN=auto GOSUMDB=sum.golang.org go test ./internal/web ./internal/session`
- `GOTOOLCHAIN=auto GOSUMDB=sum.golang.org go vet ./internal/web ./internal/session`
- `GOTOOLCHAIN=auto GOSUMDB=sum.golang.org go test -race ./internal/session`
