### PR TITLE
fix(polecat): fix TestAddWithOptions_RollbackReleasesName flaky test

### DIFF
--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -1361,9 +1361,10 @@ func TestAddWithOptions_RollbackReleasesName(t *testing.T) {
 		t.Fatalf("git commit: %v", err)
 	}
 
-	// Add origin remote but deliberately DON'T create origin/main ref.
-	// This will cause AddWithOptions to fail at ref validation, testing rollback.
-	cmd = exec.Command("git", "remote", "add", "origin", mayorRig)
+	// Add origin remote pointing to a nonexistent path so that fetch fails
+	// and origin/main is never created. This causes AddWithOptions to fail at
+	// ref validation, testing rollback.
+	cmd = exec.Command("git", "remote", "add", "origin", "/nonexistent/repo")
 	cmd.Dir = mayorRig
 	if out, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("git remote add: %v\n%s", err, out)


### PR DESCRIPTION
## Summary
- **gt-05r**: `TestAddWithOptions_RollbackReleasesName` was failing because the test's `origin` remote pointed to itself (`mayorRig`), so `AddWithOptions`' `Fetch("origin")` succeeded and created `origin/main` — preventing the expected ref-validation failure
- Changed the origin remote to `/nonexistent/repo` so fetch fails and `origin/main` never materializes, correctly triggering the rollback path

## Test plan
- [x] `go test ./internal/polecat/ -run TestAddWithOptions_RollbackReleasesName` passes
- [x] Full `go test ./internal/polecat/` suite passes (all tests green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)