### PR TITLE
fix(up): gate witness/refinery startup on Dolt server readiness (gt-zou1n)

### DIFF
--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -274,7 +274,11 @@ func runUp(cmd *cobra.Command, args []string) error {
 	// Witnesses and refineries run bd commands on startup (via gt prime → patrol_helpers)
 	// that connect to the Dolt SQL server. Without this gate, they race the server
 	// and get "connection refused" errors. (gt-zou1n)
-	waitForDoltReady(townRoot)
+	// Only wait if Dolt was actually started (or detected running). If it failed or
+	// was skipped, polling the port would just burn the full timeout. (review finding #1)
+	if !doltSkipped && doltOK {
+		waitForDoltReady(townRoot)
+	}
 
 	// 5 & 6. Witnesses and Refineries (using prefetched rigs)
 	witnessResults, refineryResults := startRigAgentsWithPrefetch(rigs, prefetchedRigs, rigErrors)


### PR DESCRIPTION
## Summary

Add a readiness gate to `gt up` that waits for the Dolt SQL server to accept TCP connections before starting witnesses and refineries. Witnesses and refineries run `bd` commands on startup (via `gt prime` → patrol helpers) that connect to the Dolt server. Without this gate, they race the server startup and get "connection refused" errors.

## Related Issue

Fixes gt-zou1n

## Changes

- Add `doltserver.WaitForReady()` — polls for TCP connectivity with exponential backoff (100ms → 500ms cap), configurable timeout
- Add `waitForDoltReady()` wrapper in `gt up` that calls `WaitForReady` with a 10s timeout after Dolt startup succeeds
- Gate is skipped when Dolt was skipped or failed (no point polling a port that won't come up)
- Gate is a no-op when no rig has server-mode metadata configured
- Graceful degradation: if timeout expires, logs a warning and continues (doesn't block startup)
- Unit tests for all paths: no server configured, server already listening, timeout on unreachable server, server becomes ready mid-wait

## Testing

- [x] Unit tests pass (`go test ./internal/cmd/ -run TestWaitForDolt -v`)
- [x] Unit tests pass (`go test ./internal/doltserver/ -run TestWaitForReady -v`)
- [x] Manual testing performed

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)
