### PR TITLE
fix(compact): stop treating molecule deps as proven value

### DIFF
--- a/internal/cmd/compact.go
+++ b/internal/cmd/compact.go
@@ -55,7 +55,7 @@ var compactCmd = &cobra.Command{
 
 For non-closed wisps past TTL: promotes to permanent beads (something is stuck).
 For closed wisps past TTL: deletes them (Dolt AS OF preserves history).
-Wisps with comments, references, or keep labels are always promoted.
+Wisps with comments or keep labels are always promoted.
 
 TTLs by wisp type:
   heartbeat, ping:              6h
@@ -238,7 +238,7 @@ func runCompact(cmd *cobra.Command, args []string) error {
 		}
 
 		ttl := getTTL(ttls, w.WispType)
-		shouldPromote := hasComments(w) || isReferenced(w) || hasKeepLabel(w)
+		shouldPromote := hasComments(w) || hasKeepLabel(w)
 
 		if w.Status != "closed" {
 			// Non-closed wisps


### PR DESCRIPTION
## Summary

- Remove `isReferenced(w)` from the `shouldPromote` check in `gt compact`
- Molecule step wisps have structural dependencies (parent-child + blocks from `Needs:` declarations) that are workflow DAG edges, not semantic references
- This was preventing compaction of **all** molecule step wisps — 773+ accumulated per rig

## The Bug

Every patrol cycle creates ~8-10 step wisps. Each step (except the first) has `dependency_count >= 1` from formula `Needs:` declarations. `isReferenced()` treats any dep as "proven value", so compact promotes instead of deleting. Wisps pile up indefinitely even though compact runs every deacon patrol cycle.

## The Fix

```go
// Before:
shouldPromote := hasComments(w) || isReferenced(w) || hasKeepLabel(w)

// After:
shouldPromote := hasComments(w) || hasKeepLabel(w)
```

`hasComments()` and `hasKeepLabel()` still protect genuinely referenced wisps. Dolt `AS OF` preserves history after deletion — nothing is truly lost.

## Test plan

- [x] Existing unit tests pass (`TestIsReferenced`, `TestHasComments`, `TestHasKeepLabel`, `TestCompactTruncate`)
- [ ] `gt compact --dry-run` shows "delete" instead of "promote" for expired wisps
- [ ] `gt compact` actually reduces wisp count
- [ ] `bd stats` shows reduced open issue count after compaction

Fixes #1843

🤖 Generated with [Claude Code](https://claude.com/claude-code)