### PR TITLE
fix: repair CI build failures in witness tests and prime_output lint

### DIFF
--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -25,7 +25,8 @@ func outputPrimeContext(ctx RoleContext) (string, error) {
 	tmpl, err := templates.New()
 	if err != nil {
 		// Fall back to hardcoded output if templates fail
-		return "", outputPrimeContextFallback(ctx)
+		outputPrimeContextFallback(ctx)
+		return "", nil
 	}
 
 	// Map role to template name
@@ -47,7 +48,8 @@ func outputPrimeContext(ctx RoleContext) (string, error) {
 		roleName = "boot"
 	default:
 		// Unknown role - use fallback
-		return "", outputPrimeContextFallback(ctx)
+		outputPrimeContextFallback(ctx)
+		return "", nil
 	}
 
 	// Build template data
@@ -85,7 +87,7 @@ func outputPrimeContext(ctx RoleContext) (string, error) {
 	return output, nil
 }
 
-func outputPrimeContextFallback(ctx RoleContext) error {
+func outputPrimeContextFallback(ctx RoleContext) {
 	switch ctx.Role {
 	case RoleMayor:
 		outputMayorContext(ctx)
@@ -102,7 +104,6 @@ func outputPrimeContextFallback(ctx RoleContext) error {
 	default:
 		outputUnknownContext(ctx)
 	}
-	return nil
 }
 
 func outputMayorContext(ctx RoleContext) {

--- a/internal/witness/manager_test.go
+++ b/internal/witness/manager_test.go
@@ -12,7 +12,7 @@ func TestBuildWitnessStartCommand_UsesRoleConfig(t *testing.T) {
 		StartCommand: "exec run --town {town} --rig {rig} --role {role}",
 	}
 
-	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "", roleConfig)
+	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "", "", roleConfig)
 	if err != nil {
 		t.Fatalf("buildWitnessStartCommand: %v", err)
 	}
@@ -24,7 +24,7 @@ func TestBuildWitnessStartCommand_UsesRoleConfig(t *testing.T) {
 }
 
 func TestBuildWitnessStartCommand_DefaultsToRuntime(t *testing.T) {
-	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "", nil)
+	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "", "", nil)
 	if err != nil {
 		t.Fatalf("buildWitnessStartCommand: %v", err)
 	}
@@ -42,7 +42,7 @@ func TestBuildWitnessStartCommand_AgentOverrideWins(t *testing.T) {
 		StartCommand: "exec run --role {role}",
 	}
 
-	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "codex", roleConfig)
+	got, err := buildWitnessStartCommand("/town/rig", "gastown", "/town", "", "codex", roleConfig)
 	if err != nil {
 		t.Fatalf("buildWitnessStartCommand: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Fix `buildWitnessStartCommand` test calls missing the `sessionName` parameter added in the telemetry commit
- Fix `unparam` lint violation on `outputPrimeContextFallback` which always returned nil

## Related Issue
CI has been failing on main since the telemetry merge (`4f3d6a78`).

## Changes
- `internal/witness/manager_test.go`: Add missing `sessionName` (empty string) argument to all 3 test call sites
- `internal/cmd/prime_output.go`: Remove always-nil error return from `outputPrimeContextFallback`, adjust callers

## Testing
- [x] Unit tests pass (`go test ./internal/witness/ ./internal/cmd/`)
- [x] Full build passes (`go build ./...`)
- [x] `go vet` clean

## Checklist
- [x] Code follows project style
- [x] No breaking changes