### PR TITLE
fix: prevent nil pointer panic in mq_submit when FindMRForBranch errors

### DIFF
--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -215,8 +215,10 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 	existingMR, err := bd.FindMRForBranch(branch)
 	if err != nil {
 		style.PrintWarning("could not check for existing MR: %v", err)
-		// Continue with creation attempt - Create will fail if duplicate
-	} else if existingMR != nil {
+		// FindMRForBranch failed — fall through to create a new MR
+	}
+
+	if existingMR != nil {
 		mrIssue = existingMR
 		fmt.Printf("%s MR already exists (idempotent)\n", style.Bold.Render("✓"))
 	} else {


### PR DESCRIPTION
## Summary
- Fixes nil pointer panic at `mq_submit.go:241` when `FindMRForBranch` returns an error
- Previously, the else-if chain skipped MR creation on error, leaving `mrIssue` nil
- Now falls through to creation on error, preventing stranded MR beads and ensuring MERGE_READY signals are sent

## Test plan
- [ ] Submit to MQ when FindMRForBranch encounters a transient error — should create new MR instead of panicking
- [ ] Verify idempotent case still works (existing MR found → reuse)
- [ ] Verify new MR creation path still sends MERGE_READY nudge to refinery

🤖 Generated with [Claude Code](https://claude.com/claude-code)