### PR TITLE
fix: update convoy_manager integration tests for API changes

### DIFF
--- a/internal/daemon/convoy_manager_integration_test.go
+++ b/internal/daemon/convoy_manager_integration_test.go
@@ -278,11 +278,12 @@ exit 0
 	}
 
 	// Start manager with short scan interval; event poll is 5s (fixed).
-	m := NewConvoyManager(townRoot, logger, gtPath, 1*time.Hour, map[string]beadsdk.Storage{"hq": store}, nil, nil)
-	// Skip seeding so pollAllStores processes events immediately.
-	m.seeded = true
+	stores := map[string]beadsdk.Storage{"hq": store}
+	m := NewConvoyManager(townRoot, logger, gtPath, 1*time.Hour, stores, nil, nil)
+	// Skip seeding so pollStoresSnapshot processes events immediately.
+	m.seeded.Store(true)
 	// Drive one poll manually instead of waiting for the 5s ticker.
-	m.pollAllStores()
+	m.pollStoresSnapshot(stores)
 
 	mu.Lock()
 	snapshot := make([]string, len(logged))
@@ -392,10 +393,11 @@ exit 0
 		logged = append(logged, fmt.Sprintf(format, args...))
 	}
 
-	m := NewConvoyManager(townRoot, logger, gtPath, 1*time.Hour, map[string]beadsdk.Storage{"hq": store}, nil, nil)
-	// Skip seeding so pollAllStores processes events immediately.
-	m.seeded = true
-	m.pollAllStores()
+	stores := map[string]beadsdk.Storage{"hq": store}
+	m := NewConvoyManager(townRoot, logger, gtPath, 1*time.Hour, stores, nil, nil)
+	// Skip seeding so pollStoresSnapshot processes events immediately.
+	m.seeded.Store(true)
+	m.pollStoresSnapshot(stores)
 
 	mu.Lock()
 	snapshot := make([]string, len(logged))
@@ -506,10 +508,11 @@ exit 0
 		logged = append(logged, fmt.Sprintf(format, args...))
 	}
 
-	m := NewConvoyManager(townRoot, logger, gtPath, 1*time.Hour, map[string]beadsdk.Storage{"hq": store}, nil, nil)
-	// Skip seeding so pollAllStores processes events immediately.
-	m.seeded = true
-	m.pollAllStores()
+	stores := map[string]beadsdk.Storage{"hq": store}
+	m := NewConvoyManager(townRoot, logger, gtPath, 1*time.Hour, stores, nil, nil)
+	// Skip seeding so pollStoresSnapshot processes events immediately.
+	m.seeded.Store(true)
+	m.pollStoresSnapshot(stores)
 
 	mu.Lock()
 	snapshot := make([]string, len(logged))
@@ -631,10 +634,11 @@ exit 0
 
 	// isRigParked returns true for "gt" rig
 	parked := func(rig string) bool { return rig == "gt" }
-	m := NewConvoyManager(townRoot, logger, gtPath, 1*time.Hour, map[string]beadsdk.Storage{"hq": store}, nil, parked)
-	// Skip seeding so pollAllStores processes events immediately.
-	m.seeded = true
-	m.pollAllStores()
+	stores := map[string]beadsdk.Storage{"hq": store}
+	m := NewConvoyManager(townRoot, logger, gtPath, 1*time.Hour, stores, nil, parked)
+	// Skip seeding so pollStoresSnapshot processes events immediately.
+	m.seeded.Store(true)
+	m.pollStoresSnapshot(stores)
 
 	mu.Lock()
 	snapshot := make([]string, len(logged))


### PR DESCRIPTION
## Summary

Fixes build failures in the Integration Tests CI job caused by two API changes
in `ConvoyManager` that weren't propagated to the integration test file:

1. `seeded` field changed from `bool` to `atomic.Bool` — updated 4 call sites
   from `m.seeded = true` to `m.seeded.Store(true)`
2. `pollAllStores()` renamed to `pollStoresSnapshot(stores)` with a new
   parameter — updated 4 call sites to extract the stores map to a variable
   and pass it to the new method

## Related Issue

CI failure on main: https://github.com/steveyegge/gastown/actions/runs/22265292299

## Changes

- `internal/daemon/convoy_manager_integration_test.go`: Update all 4 test
  functions to use the new `atomic.Bool` API and renamed `pollStoresSnapshot`
  method

## Testing

- [x] `go build -tags integration ./internal/daemon/...` passes
- [x] No other files affected

## Checklist
- [x] Code follows project style
- [x] No breaking changes
- [x] Tests updated to match current API