### PR TITLE
fix: remove migrate_bead_labels.go from bd_branch callsite registry

### DIFF
--- a/internal/cmd/bd_branch_arch_test.go
+++ b/internal/cmd/bd_branch_arch_test.go
@@ -496,7 +496,6 @@ var expectedExecBdCounts = map[string]int{
 	"mail_announce.go":       1,
 	"mail_channel.go":        1,
 	"mail_queue.go":          4,
-	"migrate_bead_labels.go": 2,
 	"molecule_await_signal.go": 4,
 	"molecule_step.go":       3,
 	"patrol.go":              5,


### PR DESCRIPTION
## Summary

Fixes CI failures on main caused by the `migrate-bead-labels` command removal
not cleaning up the bd_branch architecture test registry.

`TestBdBranchCallsiteRegistry` expected `migrate_bead_labels.go` to have 2
`exec.Command("bd",...)` calls, but the file no longer exists.

## Related Issue

CI failure on main after merge of "Remove migrate-bead-labels command":
https://github.com/steveyegge/gastown/actions/runs/22265633992

## Changes

- `internal/cmd/bd_branch_arch_test.go`: Remove `migrate_bead_labels.go` entry
  from `expectedExecBdCounts` registry

## Testing

- [x] `go test -run TestBdBranchCallsiteRegistry ./internal/cmd/` passes
- [x] No other files affected

## Checklist
- [x] Code follows project style
- [x] No breaking changes
- [x] Tests updated to match current codebase