### PR TITLE
fix: repair Windows test failures in emit event and mayor dir

### DIFF
--- a/internal/cmd/molecule_emit_event_test.go
+++ b/internal/cmd/molecule_emit_event_test.go
@@ -161,14 +161,14 @@ func TestEmitEventPIDInFilename(t *testing.T) {
 		t.Fatalf("emit failed: %v", err)
 	}
 
-	// Filename should contain PID for uniqueness: <nanoseconds>-<pid>.event
+	// Filename should contain PID for uniqueness: <nanoseconds>-<seq>-<pid>.event
 	base := filepath.Base(path)
 	if !strings.Contains(base, "-") {
-		t.Errorf("filename %q should contain PID separator '-'", base)
+		t.Errorf("filename %q should contain separator '-'", base)
 	}
-	parts := strings.SplitN(strings.TrimSuffix(base, ".event"), "-", 2)
-	if len(parts) != 2 {
-		t.Errorf("filename %q should be <nanos>-<pid>.event, got %d parts", base, len(parts))
+	parts := strings.Split(strings.TrimSuffix(base, ".event"), "-")
+	if len(parts) != 3 {
+		t.Errorf("filename %q should be <nanos>-<seq>-<pid>.event, got %d parts", base, len(parts))
 	}
 }
 

--- a/internal/mayor/manager_test.go
+++ b/internal/mayor/manager_test.go
@@ -1,6 +1,7 @@
 package mayor
 
 import (
+	"path/filepath"
 	"testing"
 )
 
@@ -17,7 +18,7 @@ func TestNewManager(t *testing.T) {
 func TestManager_mayorDir(t *testing.T) {
 	m := NewManager("/tmp/test-town")
 	got := m.mayorDir()
-	want := "/tmp/test-town/mayor"
+	want := filepath.Join("/tmp/test-town", "mayor")
 	if got != want {
 		t.Errorf("mayorDir() = %q, want %q", got, want)
 	}


### PR DESCRIPTION
## Summary

Fixes two Windows-specific test failures that have been causing the Windows
Build and Unit Tests CI job to fail on main.

## Related Issue

Pre-existing CI failures visible on every recent main CI run (e.g.,
https://github.com/steveyegge/gastown/actions/runs/22265712731)

## Changes

### 1. `TestEmitEvent/multiple_events_unique_paths` — duplicate event filenames

`time.Now().UnixNano()` has low resolution on Windows (~100ns or 1ms
granularity). In a tight loop, multiple calls return the same nanosecond
value. Since PID is constant, the event filename (`<nanos>-<pid>.event`)
is identical across iterations.

**Fix:** Add an atomic sequence counter to the filename format:
`<nanos>-<seq>-<pid>.event`. This guarantees uniqueness regardless of
timer resolution.

### 2. `TestManager_mayorDir` — path separator mismatch

The test hardcodes `/tmp/test-town/mayor` as expected output, but
`filepath.Join` on Windows produces `\tmp\test-town\mayor`.

**Fix:** Use `filepath.Join` to construct the expected path.

### 3. `TestBdBranchCallsiteRegistry` — stale registry entry

The `migrate-bead-labels` command was removed but its entry in the
bd_branch architecture test registry was not cleaned up.

**Fix:** Remove the stale `migrate_bead_labels.go` entry.

## Testing

- [x] `go test -run TestEmitEvent ./internal/cmd/` passes
- [x] `go test -run TestManager_mayorDir ./internal/mayor/` passes
- [x] `go test -run TestBdBranchCallsiteRegistry ./internal/cmd/` passes

## Checklist
- [x] Code follows project style
- [x] No breaking changes
- [x] Tests updated for cross-platform compatibility