### PR TITLE
fix: remove call to undefined RefreshKeyBindings method

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -260,12 +260,6 @@ func (d *Daemon) Run() error {
 
 	d.logger.Printf("Daemon running, recovery heartbeat interval %v", recoveryHeartbeatInterval)
 
-	// Ensure tmux keybindings have the current rig-prefix pattern.
-	// This auto-corrects stale bindings when new rigs are registered.
-	if err := d.tmux.RefreshKeyBindings(); err != nil {
-		d.logger.Printf("Warning: failed to refresh key bindings: %v", err)
-	}
-
 	// Start feed curator goroutine
 	d.curator = feed.NewCurator(d.config.TownRoot)
 	if err := d.curator.Start(); err != nil {


### PR DESCRIPTION
## Summary

- Remove call to `d.tmux.RefreshKeyBindings()` in daemon startup — the method was never implemented on `*tmux.Tmux`, breaking the build on main since ba629275.

## Test plan

- [x] `go build ./...` passes (was failing with `d.tmux.RefreshKeyBindings undefined`)
- [x] `go test ./internal/daemon/...` passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>