### PR TITLE
fix(test): stabilize flaky TestIsAgentRunning and brittle refinery tests

### DIFF
--- a/internal/refinery/manager_test.go
+++ b/internal/refinery/manager_test.go
@@ -12,8 +12,12 @@ import (
 
 func setupTestRegistry(t *testing.T) {
 	t.Helper()
+	// Use a prefix that won't collide with real gastown sessions.
+	// The "tr" prefix conflicts with actual rigs running on the host
+	// (e.g., tr-refinery, tr-witness), causing tests that assert
+	// "no session exists" to fail in gastown workspaces.
 	reg := session.NewPrefixRegistry()
-	reg.Register("tr", "testrig")
+	reg.Register("xut", "testrig")
 	old := session.DefaultRegistry()
 	session.SetDefaultRegistry(reg)
 	t.Cleanup(func() { session.SetDefaultRegistry(old) })
@@ -41,7 +45,7 @@ func setupTestManager(t *testing.T) (*Manager, string) {
 func TestManager_SessionName(t *testing.T) {
 	mgr, _ := setupTestManager(t)
 
-	want := "tr-refinery"
+	want := "xut-refinery"
 	got := mgr.SessionName()
 	if got != want {
 		t.Errorf("SessionName() = %s, want %s", got, want)


### PR DESCRIPTION
## Summary

- **Refinery tests**: Change session prefix from `tr` to `xut` so `TestManager_IsRunning_NoSession` and `TestManager_Status_NotRunning` don't collide with real `tr-refinery`/`tr-witness` sessions on development hosts.
- **TestIsAgentRunning**: Add retry loop (5 attempts, 200ms spacing) to tolerate transient pane command changes during shell initialization, fixing intermittent failures in the `matching_shell_process` subtest.

## Test plan

- [x] `go test ./internal/refinery/ -run 'TestManager_SessionName|TestManager_IsRunning|TestManager_Status' -count=1 -v` — all pass
- [x] `go test ./internal/tmux/ -run TestIsAgentRunning -count=3 -v` — all pass (3/3 runs)
- [x] `go build ./...` — passes

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>