### PR TITLE
refactor: use ForceCloseWithReason for wisp root close in gt done

### DIFF
--- a/internal/cmd/done_closeDescendants_test.go
+++ b/internal/cmd/done_closeDescendants_test.go
@@ -81,8 +81,9 @@ case "$cmd" in
     fi
     ;;
   close)
-    # Log all arguments (closeDescendants batches IDs via b.Close(idsToClose...))
+    # Log bead IDs only, skip flags (--reason, --force, --session)
     for arg in "$@"; do
+      case "$arg" in --*) continue ;; esac
       echo "$arg" >> "%s"
     done
     ;;
@@ -253,8 +254,9 @@ case "$cmd" in
     echo '[]'
     ;;
   close)
-    # Log all arguments (closeDescendants batches IDs via b.Close(idsToClose...))
+    # Log bead IDs only, skip flags (--reason, --force, --session)
     for arg in "$@"; do
+      case "$arg" in --*) continue ;; esac
       echo "$arg" >> "%s"
     done
     ;;
@@ -386,8 +388,9 @@ case "$cmd" in
     fi
     ;;
   close)
-    # Log all arguments (closeDescendants batches IDs via b.Close(idsToClose...))
+    # Log bead IDs only, skip flags (--reason, --force, --session)
     for arg in "$@"; do
+      case "$arg" in --*) continue ;; esac
       echo "$arg" >> "%s"
     done
     ;;
@@ -537,8 +540,9 @@ case "$cmd" in
     fi
     ;;
   close)
-    # Log all arguments (closeDescendants batches IDs via b.Close(idsToClose...))
+    # Log bead IDs only, skip flags (--reason, --force, --session)
     for arg in "$@"; do
+      case "$arg" in --*) continue ;; esac
       echo "$arg" >> "%s"
     done
     ;;
@@ -703,8 +707,9 @@ case "$cmd" in
     echo '[]'
     ;;
   close)
-    # Log all arguments (closeDescendants batches IDs via b.Close(idsToClose...))
+    # Log bead IDs only, skip flags (--reason, --force, --session)
     for arg in "$@"; do
+      case "$arg" in --*) continue ;; esac
       echo "$arg" >> "%s"
     done
     ;;
@@ -826,8 +831,9 @@ case "$cmd" in
     exit 1
     ;;
   close)
-    # Log all arguments (closeDescendants batches IDs via b.Close(idsToClose...))
+    # Log bead IDs only, skip flags (--reason, --force, --session)
     for arg in "$@"; do
+      case "$arg" in --*) continue ;; esac
       echo "$arg" >> "%s"
     done
     ;;


### PR DESCRIPTION
## Context

Follow-up to #1882 (merged) and #1879.

PR #1879 introduced `ForceCloseWithReason` for closing wisp roots in `gt mol burn` and `gt mol squash` — single call with `--force`, audit reason, and session attribution. PR #1882 added `closeDescendants()` to `gt done` but kept the old retry loop with `bd.Close()` for the wisp root itself.

This PR aligns `gt done` with the pattern established by #1879.

## Problem

The wisp root close in `gt done` used a 3-attempt retry loop with exponential backoff (100ms, 200ms) and `bd.Close()`. This was a workaround for status mismatches — `bd.Close()` can fail on beads in `hooked` status. Meanwhile, `gt mol burn` and `gt mol squash` already use `ForceCloseWithReason` which handles any status via `--force`.

Three issues with the retry approach:
1. **Inconsistency** — different close pattern than burn/squash for the same operation
2. **No audit trail** — `bd.Close()` doesn't record why the bead was closed or which session did it
3. **Unnecessary complexity** — `--force` handles the status mismatch that retries were working around

## Fix

Replace the retry loop with a single `ForceCloseWithReason("done", moleculeID)` call:

- `--force` handles any bead status (hooked, open, in_progress)
- `--reason=done` records audit trail
- `--session=<id>` records session attribution
- `ErrNotFound` still handled (already burned/deleted by another path)

Test bd stubs updated to filter `--` flags from close call logs.

## Changes

| File | Change |
|------|--------|
| `internal/cmd/done.go` | Replace 30-line retry loop with 13-line ForceCloseWithReason call |
| `internal/cmd/done_closeDescendants_test.go` | Filter `--reason`/`--force`/`--session` flags in bd stub close handler |

## Tests

All 7 edge case tests pass. Full suite: `go test ./internal/cmd/...` (47s, ok).

🤖 Generated with [Claude Code](https://claude.com/claude-code)