### PR TITLE
fix: replace blind sleeps with prompt-based readiness polling

### DIFF
--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -207,8 +207,6 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 		return fmt.Errorf("waiting for refinery to start: %w", err)
 	}
 
-	// Wait for runtime to be fully ready
-	runtime.SleepForReadyDelay(runtimeConfig)
 	_ = runtime.RunStartupFallback(t, sessionID, "refinery", runtimeConfig)
 
 	return nil


### PR DESCRIPTION
## Summary

Replace blind `time.Sleep` calls during agent startup with smart prompt-based readiness polling via `WaitForRuntimeReady`. This eliminates the race condition where work instructions could arrive before agents finish processing the startup beacon and `gt prime`.

## Related Issue

Fixes #1829

## Changes

- **Replace `SleepForReadyDelay` with `WaitForRuntimeReady` in polecat startup** (`session_manager.go`): Uses prompt-based polling for agents with `ReadyPromptPrefix` (Claude, Copilot), falls back to `ReadyDelayMs` sleep for others (Codex, OpenCode).
- **Replace fixed 2000ms prime-wait with smart polling** (`session_manager.go`): After beacon delivery, uses `RuntimeConfigWithMinDelay` to wait for gt prime completion with a guaranteed minimum delay floor, instead of a fixed `DefaultPrimeWaitMs` sleep.
- **Replace `SleepForReadyDelay` with `WaitForRuntimeReady` in session lifecycle** (`lifecycle.go`): Brings dogs/boot/mayor/witness startup in line with the prompt-based pattern. Adds warning on timeout instead of silently discarding errors.
- **Remove redundant double-wait in refinery** (`manager.go`): `WaitForRuntimeReady` was already called at line 204; the subsequent `SleepForReadyDelay` at line 211 was a redundant second wait.
- **Add `RuntimeConfigWithMinDelay` helper** (`runtime.go`): Creates a shallow config copy with minimum `ReadyDelayMs` floor and clears `ReadyPromptPrefix` to force the delay-based path (prevents prompt detection from short-circuiting the intended prime-wait delay).
- **Remove dead code**: Delete `SleepForReadyDelay` and `session.ReadyDelay` (zero remaining callers after migration). Add tests for `RuntimeConfigWithMinDelay`.

## Testing

- [x] Unit tests pass (`go test ./internal/runtime/... ./internal/polecat/... ./internal/session/... ./internal/refinery/...`)
- [x] Full test suite passes (`go test ./...`)
- [x] Triple-model automated review (Claude + Codex + Gemini) — approved with no blockers
- [ ] Manual testing: spawn non-hook polecat (e.g., `gt sling <bead> <rig> --agent codex`) and verify work arrives after agent is ready

## Checklist

- [x] Code follows project style
- [x] No breaking changes — `SessionConfig.ReadyDelay` bool field preserved; only the unused function wrappers were removed
- [x] Tests updated — deleted 4 obsolete `TestSleepForReadyDelay_*` tests, added 5 new `TestRuntimeConfigWithMinDelay_*` tests