### PR TITLE
fix: filter getCurrentWork by assignee to prevent shared rig beads leaking across crew sessions

### DIFF
--- a/internal/cmd/statusline.go
+++ b/internal/cmd/statusline.go
@@ -121,7 +121,7 @@ func runWorkerStatusLine(t *tmux.Tmux, session, rigName, polecat, crew, issue st
 	// Priority 2: Fall back to GT_ISSUE env var or in_progress beads
 	currentWork := issue
 	if currentWork == "" && hookedWork == "" && session != "" {
-		currentWork = getCurrentWork(t, session, 40)
+		currentWork = getCurrentWork(t, session, identity, 40)
 	}
 
 	// Show hooked work (takes precedence)
@@ -688,9 +688,9 @@ func getHookedWork(identity string, maxLen int, beadsDir string) string {
 	return display
 }
 
-// getCurrentWork returns a truncated title of the first in_progress issue.
+// getCurrentWork returns a truncated title of the first in_progress issue assigned to identity.
 // Uses the pane's working directory to find the beads.
-func getCurrentWork(t *tmux.Tmux, session string, maxLen int) string {
+func getCurrentWork(t *tmux.Tmux, session string, identity string, maxLen int) string {
 	// Get the pane's working directory
 	workDir, err := t.GetPaneWorkDir(session)
 	if err != nil || workDir == "" {
@@ -703,10 +703,11 @@ func getCurrentWork(t *tmux.Tmux, session string, maxLen int) string {
 		return ""
 	}
 
-	// Query beads for in_progress issues
+	// Query beads for in_progress issues assigned to this agent
 	b := beads.New(workDir)
 	issues, err := b.List(beads.ListOptions{
 		Status:   "in_progress",
+		Assignee: identity,
 		Priority: -1,
 	})
 	if err != nil || len(issues) == 0 {


### PR DESCRIPTION
## Problem

When cycling through tmux sessions for different crew members in the same rig, the status line showed the same bead for every crew member regardless of who it was assigned to.

**Root cause**: All crew member `.beads` directories redirect to the shared rig beads database (e.g. `~/gt/xenota/mayor/rig/.beads`). The `getCurrentWork` fallback in `runWorkerStatusLine` queried for `in_progress` beads **without filtering by assignee**, so the first `in_progress` bead in the shared database was returned for every crew session.

`getHookedWork` already filtered by assignee correctly. The bug was only in the `getCurrentWork` fallback path, used when no bead is actively hooked.

## Fix

Pass the agent identity into `getCurrentWork` and add `Assignee: identity` to the beads list query, so each crew member only sees their own in-progress work.

## Test plan

- [x] `go test -race -short ./internal/cmd/...` passes
- [x] `golangci-lint run ./internal/cmd/...` clean
- [x] Verified manually: `gt status-line --session=xc-crew-earthshot` now shows earthshot's bead only; other crew sessions show their own work or nothing