### PR TITLE
fix: set GT_PROCESS_NAMES in tmux env for all session types

### DIFF
--- a/internal/crew/manager.go
+++ b/internal/crew/manager.go
@@ -696,6 +696,7 @@ func (m *Manager) Start(name string, opts StartOptions) error {
 		RuntimeConfigDir: opts.ClaudeConfigDir,
 		Agent:            opts.AgentOverride,
 	})
+	envVars = session.MergeRuntimeLivenessEnv(envVars, runtimeConfig)
 
 	// Build startup command (also includes env vars via 'exec env' for
 	// WaitForCommand detection — belt and suspenders with -e flags)

--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -133,6 +133,7 @@ func (m *Manager) Start(agentOverride string) error {
 		TownRoot: m.townRoot,
 		Agent:    agentOverride,
 	})
+	envVars = session.MergeRuntimeLivenessEnv(envVars, runtimeConfig)
 	for k, v := range envVars {
 		_ = t.SetEnvironment(sessionID, k, v)
 	}

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -182,6 +182,7 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 		TownRoot: townRoot,
 		Agent:    agentOverride,
 	})
+	envVars = session.MergeRuntimeLivenessEnv(envVars, runtimeConfig)
 
 	// Add refinery-specific flag
 	envVars["GT_REFINERY"] = "1"

--- a/internal/session/lifecycle.go
+++ b/internal/session/lifecycle.go
@@ -199,7 +199,7 @@ func StartSession(t *tmux.Tmux, cfg SessionConfig) (_ *StartResult, retErr error
 		RuntimeConfigDir: cfg.RuntimeConfigDir,
 		Agent:            cfg.AgentOverride,
 	})
-	envVars = mergeRuntimeLivenessEnv(envVars, runtimeConfig)
+	envVars = MergeRuntimeLivenessEnv(envVars, runtimeConfig)
 	for _, k := range mapKeysSorted(envVars) {
 		_ = t.SetEnvironment(cfg.SessionID, k, envVars[k])
 	}
@@ -301,10 +301,13 @@ func mapKeysSorted(m map[string]string) []string {
 	return keys
 }
 
-// mergeRuntimeLivenessEnv ensures liveness-critical env vars are present in the
+// MergeRuntimeLivenessEnv ensures liveness-critical env vars are present in the
 // tmux session environment table, even when agent resolution came from
 // workspace/default settings rather than an explicit --agent override.
-func mergeRuntimeLivenessEnv(envVars map[string]string, runtimeConfig *config.RuntimeConfig) map[string]string {
+//
+// Call this after config.AgentEnv() to add GT_AGENT and GT_PROCESS_NAMES
+// before writing env vars to the tmux session via SetEnvironment.
+func MergeRuntimeLivenessEnv(envVars map[string]string, runtimeConfig *config.RuntimeConfig) map[string]string {
 	if envVars == nil {
 		envVars = make(map[string]string)
 	}

--- a/internal/session/lifecycle_test.go
+++ b/internal/session/lifecycle_test.go
@@ -143,7 +143,7 @@ func TestMergeRuntimeLivenessEnv_SetsResolvedAgentAndProcessNames(t *testing.T) 
 		ResolvedAgent: "claude",
 	}
 
-	got := mergeRuntimeLivenessEnv(env, rc)
+	got := MergeRuntimeLivenessEnv(env, rc)
 
 	if got["GT_AGENT"] != "claude" {
 		t.Fatalf("GT_AGENT = %q, want %q", got["GT_AGENT"], "claude")
@@ -163,7 +163,7 @@ func TestMergeRuntimeLivenessEnv_RespectsExistingValues(t *testing.T) {
 		ResolvedAgent: "wen",
 	}
 
-	got := mergeRuntimeLivenessEnv(env, rc)
+	got := MergeRuntimeLivenessEnv(env, rc)
 
 	if got["GT_AGENT"] != "explicit-agent" {
 		t.Fatalf("GT_AGENT = %q, want %q", got["GT_AGENT"], "explicit-agent")
@@ -185,7 +185,7 @@ func TestMergeRuntimeLivenessEnv_UsesEffectiveAgentForProcessNames(t *testing.T)
 		ResolvedAgent: "claude", // workspace default, NOT the override
 	}
 
-	got := mergeRuntimeLivenessEnv(env, rc)
+	got := MergeRuntimeLivenessEnv(env, rc)
 
 	if got["GT_AGENT"] != "codex" {
 		t.Fatalf("GT_AGENT = %q, want %q", got["GT_AGENT"], "codex")

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -177,6 +177,7 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 		TownRoot: townRoot,
 		Agent:    agentOverride,
 	})
+	envVars = session.MergeRuntimeLivenessEnv(envVars, runtimeConfig)
 	for k, v := range envVars {
 		_ = t.SetEnvironment(sessionID, k, v)
 	}


### PR DESCRIPTION
## Problem

When the agent binary name differs from the defaults (e.g., Nix wraps `claude` as `.claude-unwrapped`), `gt doctor --fix` misclassifies all witness, deacon, refinery, and crew sessions as zombies and kills them.

After `gt up` starts 7 sessions, `gt doctor` reports "Found 7 zombie session(s)" and `--fix` kills 6 of them (the 7th — a polecat started by the daemon — survives because it has `GT_PROCESS_NAMES` set).

### Root cause

The zombie check calls `IsAgentAlive(session)` → `resolveSessionProcessNames(session)` → `IsRuntimeRunning(session, names)`. Process name resolution reads `GT_PROCESS_NAMES` from the **tmux session environment** (via `tmux show-environment`).

There are two session startup paths, and only one sets `GT_PROCESS_NAMES`:

| Startup path | Used by | Sets GT_PROCESS_NAMES? |
|---|---|---|
| `session.StartSession()` | mayor, boot, dog | ✅ calls `mergeRuntimeLivenessEnv()` |
| Manual `AgentEnv()` + `SetEnvironment` loop | **witness, deacon, refinery, crew** | ❌ |
| `daemon.go` explicit `SetEnvironment` | polecats | ✅ |

When `GT_PROCESS_NAMES` is missing, `resolveSessionProcessNames` falls back to `["node", "claude"]`. If the actual binary name doesn't match those defaults, every affected session fails the liveness check and is classified as a zombie.

## Fix

Export the existing `mergeRuntimeLivenessEnv()` from the `session` package and call it from the four managers that use the older manual startup path. This is the same function that already keeps mayor/boot/dog sessions alive — it resolves `GT_AGENT` and `GT_PROCESS_NAMES` from the `RuntimeConfig` and merges them into the env map before `SetEnvironment`.

One-line addition in each manager, between `AgentEnv()` and the `SetEnvironment` loop:
```go
envVars = session.MergeRuntimeLivenessEnv(envVars, runtimeConfig)
```

## Test plan

- [x] `go build ./...` compiles
- [x] `go test ./internal/session/ -run TestMergeRuntimeLivenessEnv` — 3/3 pass
- [x] `go test ./internal/doctor/ -run TestZombie` — 3/3 pass
- [x] Manual: `gt up` (7 sessions) → `gt doctor` reports "All 7 Gas Town sessions have running Claude processes"