### PR TITLE
fix: remove StripBdBranch from sling bond to fix split-brain

### DIFF
--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -694,7 +694,6 @@ func InstantiateFormulaOnBead(formulaName, beadID, title, hookWorkDir, townRoot 
 		Dir(formulaWorkDir).
 		WithAutoCommit().
 		WithGTRoot(townRoot).
-		StripBdBranch().
 		Output()
 	if err != nil {
 		return nil, fmt.Errorf("bonding formula to bead: %w", err)


### PR DESCRIPTION
## Summary

- Removes `StripBdBranch()` from the bond call in `InstantiateFormulaOnBead()` (`sling_helpers.go:697`)
- When `BD_BRANCH` is set for polecat write-isolation, wisp creation writes to Dolt but the bond call was stripping `BD_BRANCH`, causing it to look up the wisp in SQLite where it doesn't exist
- This resulted in `"not found"` errors during formula instantiation, making `gt sling` completely non-functional for rigs with dolt_mode=server

## Root Cause

In `InstantiateFormulaOnBead()`:
1. **Wisp creation** (line 676) preserves `BD_BRANCH` → writes to Dolt ✓
2. **Bond call** (line 697) called `.StripBdBranch()` → reads from SQLite ✗
3. SQLite has no record of the wisp → `"not found"` error

## Verification

Tested on seif_core rig (dolt_mode=server). After the fix, formula instantiation succeeds — `mol-polecat-work` epic and all 10 child step wisps are created and bonded correctly.

## Test plan

- [x] Verify `InstantiateFormulaOnBead` creates wisp in Dolt and bonds in same backend
- [x] Verify polecat work molecule is fully instantiated with all step beads
- [ ] Full E2E: `gt sling <bead> <rig>` → polecat completes work cycle

Fixes: hq-r688

🤖 Generated with [Claude Code](https://claude.com/claude-code)