### PR TITLE
fix: prevent nuke --force from deleting remote branches with unmerged work

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -854,6 +854,22 @@ func (g *Git) Rev(ref string) (string, error) {
 	return g.run("rev-parse", ref)
 }
 
+// HasDiff checks if two refs have different tree content.
+// Returns true if there is a diff, false if they are identical.
+// This is useful for detecting squash merges where commit SHAs differ but content matches.
+func (g *Git) HasDiff(ref1, ref2 string) (bool, error) {
+	_, err := g.run("diff", "--quiet", ref1, ref2)
+	if err != nil {
+		// Exit code 1 means there IS a diff
+		if strings.Contains(err.Error(), "exit status 1") {
+			return true, nil
+		}
+		return false, err
+	}
+	// Exit code 0 means no diff
+	return false, nil
+}
+
 // IsAncestor checks if ancestor is an ancestor of descendant.
 func (g *Git) IsAncestor(ancestor, descendant string) (bool, error) {
 	_, err := g.run("merge-base", "--is-ancestor", ancestor, descendant)


### PR DESCRIPTION
## Summary
- `gt polecat nuke --force` now checks if a remote branch has unmerged commits before deleting it
- Adds `branchHasUnmergedWork()` helper that checks both ancestry and content diff (handles squash merges)
- Preserves remote branches with unmerged work so refinery can create MRs

Fixes gt-3xal — three incidents of completed work being lost when nuke deleted remote branches before refinery could process them.

## Test plan
- [x] Unit tests added for `branchHasUnmergedWork` via `git_test.go`
- [ ] Verify nuke preserves remote branch when commits exist ahead of main
- [ ] Verify nuke still deletes remote branch when fully merged

🤖 Generated with [Claude Code](https://claude.com/claude-code)