### PR TITLE
refactor: rename bdCmd.StripBdBranch() to OnMain() for API alignment

### DIFF
--- a/internal/cmd/bd_branch_arch_test.go
+++ b/internal/cmd/bd_branch_arch_test.go
@@ -24,7 +24,7 @@ import (
 // When a callsite is added or removed, this test fails — forcing the
 // developer to classify it for BD_BRANCH safety.
 //
-// For polecat read paths:  add .OnMain() or StripBdBranch()
+// For polecat read paths:  add .OnMain() (bdCmd) or beads.StripBdBranch() (raw exec)
 // For write/non-polecat:   update the expected count in the registry
 // ===================================================================
 
@@ -594,14 +594,12 @@ func checkRegistry(t *testing.T, label string, actual map[string]*bdCallsiteCoun
 // Architecture test: protection coverage
 //
 // Verifies that polecat-context files maintain their BD_BRANCH
-// protection patterns. If OnMain or StripBdBranch counts decrease,
-// protection was removed.
+// protection patterns. If OnMain counts decrease, protection was removed.
 //
 // Scope: Only monitors files that were identified in W-006 (#1796) as
 // needing BD_BRANCH protection. The registry test above catches NEW
 // callsites in any file; this test ensures EXISTING protections are
-// not removed. Files are added here when they receive OnMain/StripBdBranch
-// fixes.
+// not removed. Files are added here when they receive OnMain fixes.
 // ===================================================================
 
 func TestBdBranchProtectionCoverage(t *testing.T) {
@@ -631,8 +629,8 @@ func TestBdBranchProtectionCoverage(t *testing.T) {
 		{"hook.go", 2, 0},
 		{"statusline.go", 1, 0},
 		{"molecule_status.go", 1, 0},
-		{"sling_helpers.go", 0, 8},
-		{"sling_formula.go", 0, 2},
+		{"sling_helpers.go", 8, 0},
+		{"sling_formula.go", 2, 0},
 		{"show.go", 0, 1},
 	}
 
@@ -651,5 +649,60 @@ func TestBdBranchProtectionCoverage(t *testing.T) {
 					counts.StripBdBranch, tt.wantStripBd)
 			}
 		})
+	}
+}
+
+// ===================================================================
+// Architecture test: OnMain naming convention
+//
+// bdCmd users must call .OnMain() instead of the removed .StripBdBranch().
+// This aligns with the beads.Beads.OnMain() API for the same operation.
+// Only beads.StripBdBranch(env) is allowed for raw exec.Command calls
+// that cannot use bdCmd (e.g., syscall.Exec in show.go, prime.go).
+//
+// The scanner counts .StripBdBranch() 0-arg method calls (bdCmd fluent
+// API) separately from beads.StripBdBranch(env) 1-arg function calls.
+// This test enforces that only prime.go, show.go, and bd_helpers.go
+// retain the 1-arg form (for raw exec.Command/syscall.Exec or the
+// OnMain() implementation), and NO file uses the 0-arg bdCmd form.
+// ===================================================================
+
+func TestBdBranchOnMainNamingConvention(t *testing.T) {
+	dir := bdArchTestDir(t)
+	fset := token.NewFileSet()
+	pkgs, err := parser.ParseDir(fset, dir, func(fi os.FileInfo) bool {
+		return !strings.HasSuffix(fi.Name(), "_test.go")
+	}, 0)
+	if err != nil {
+		t.Fatalf("failed to parse directory: %v", err)
+	}
+
+	for _, pkg := range pkgs {
+		for filename, file := range pkg.Files {
+			basename := filepath.Base(filename)
+			counts := countBdCallsites(file)
+
+			// The scanner counts both bdCmd .StripBdBranch() (0-arg) and
+			// beads.StripBdBranch(env) (1-arg) in the same counter.
+			// We use an allow-list heuristic: files in the list may have
+			// StripBdBranch calls (they use the beads.StripBdBranch(env)
+			// function). All other files must have zero. If a new file
+			// needs beads.StripBdBranch(env), add it to the allow list.
+			switch basename {
+			case "prime.go", "show.go":
+				// These use beads.StripBdBranch(env) for raw exec.Command / syscall.Exec.
+				// That's the correct pattern for non-bdCmd invocations.
+				continue
+			case "bd_helpers.go":
+				// Uses beads.StripBdBranch(env) internally in buildEnv() — this is
+				// the implementation of .OnMain(), not a direct callsite.
+				continue
+			default:
+				if counts.StripBdBranch > 0 {
+					t.Errorf("%s: has %d StripBdBranch() calls — use .OnMain() on bdCmd instead (#1897)",
+						basename, counts.StripBdBranch)
+				}
+			}
+		}
 	}
 }

--- a/internal/cmd/bd_helpers.go
+++ b/internal/cmd/bd_helpers.go
@@ -13,13 +13,13 @@ import (
 // It provides a fluent API for configuring environment variables,
 // working directory, and I/O settings common to bd CLI invocations.
 type bdCmd struct {
-	args          []string
-	dir           string
-	env           []string
-	stderr        io.Writer
-	stripBdBranch bool
-	autoCommit    bool
-	gtRoot        string
+	args       []string
+	dir        string
+	env        []string
+	stderr     io.Writer
+	onMain     bool
+	autoCommit bool
+	gtRoot     string
 }
 
 // BdCmd creates a new bd command builder with the given arguments.
@@ -28,7 +28,7 @@ type bdCmd struct {
 // Example:
 //
 //	err := cmd.BdCmd("show", beadID, "--json").
-//	    StripBdBranch().
+//	    OnMain().
 //	    Dir(workDir).
 //	    Run()
 func BdCmd(args ...string) *bdCmd {
@@ -47,11 +47,11 @@ func (b *bdCmd) WithAutoCommit() *bdCmd {
 	return b
 }
 
-// StripBdBranch removes BD_BRANCH from the environment.
-// This is used for read operations that need to access the main branch
-// instead of a polecat's write-isolation branch.
-func (b *bdCmd) StripBdBranch() *bdCmd {
-	b.stripBdBranch = true
+// OnMain removes BD_BRANCH from the environment so the command
+// targets the main branch instead of a polecat's write-isolation branch.
+// This aligns with the beads.Beads.OnMain() API for the same operation.
+func (b *bdCmd) OnMain() *bdCmd {
+	b.onMain = true
 	return b
 }
 
@@ -94,7 +94,7 @@ func (b *bdCmd) buildEnv() []string {
 	env := b.env
 
 	// Strip BD_BRANCH if requested (for reading from main branch)
-	if b.stripBdBranch {
+	if b.onMain {
 		env = beads.StripBdBranch(env)
 	}
 

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -138,7 +138,7 @@ func runSlingFormula(args []string) error {
 	if err := BdCmd("cook", formulaName).
 		Dir(formulaWorkDir).
 		WithGTRoot(townRoot).
-		StripBdBranch().
+		OnMain().
 		Run(); err != nil {
 		rollbackSpawned("")
 		return fmt.Errorf("cooking formula: %w", err)
@@ -156,7 +156,7 @@ func runSlingFormula(args []string) error {
 		Dir(formulaWorkDir).
 		WithAutoCommit().
 		WithGTRoot(townRoot).
-		StripBdBranch().
+		OnMain().
 		Output()
 	if err != nil {
 		rollbackSpawned("")

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -171,7 +171,7 @@ func burnExistingMolecules(molecules []string, beadID, townRoot string) error {
 func verifyBeadExists(beadID string) error {
 	out, err := BdCmd("show", beadID, "--json", "--allow-stale").
 		Dir(resolveBeadDir(beadID)).
-		StripBdBranch().
+		OnMain().
 		Stderr(io.Discard).
 		Output()
 	if err != nil {
@@ -188,7 +188,7 @@ func verifyBeadExists(beadID string) error {
 func getBeadInfo(beadID string) (*beadInfo, error) {
 	out, err := BdCmd("show", beadID, "--json", "--allow-stale").
 		Dir(resolveBeadDir(beadID)).
-		StripBdBranch().
+		OnMain().
 		Stderr(io.Discard).
 		Output()
 	if err != nil {
@@ -234,7 +234,7 @@ func storeFieldsInBead(beadID string, updates beadFieldUpdates) error {
 		// Read the bead once (strip BD_BRANCH so we read from main)
 		out, err := BdCmd("show", beadID, "--json", "--allow-stale").
 			Dir(resolveBeadDir(beadID)).
-			StripBdBranch().
+			OnMain().
 			Stderr(io.Discard).
 			Output()
 		if err != nil {
@@ -656,12 +656,12 @@ func InstantiateFormulaOnBead(formulaName, beadID, title, hookWorkDir, townRoot 
 	formulaWorkDir := beads.ResolveHookDir(townRoot, beadID, hookWorkDir)
 
 	// Step 1: Cook the formula (ensures proto exists)
-	// StripBdBranch: cook reads from main (proto lives there, not on polecat branches).
+	// OnMain: cook reads from main (proto lives there, not on polecat branches).
 	if !skipCook {
 		if err := BdCmd("cook", formulaName).
 			Dir(formulaWorkDir).
 			WithGTRoot(townRoot).
-			StripBdBranch().
+			OnMain().
 			Run(); err != nil {
 			return nil, fmt.Errorf("cooking formula %s: %w", formulaName, err)
 		}
@@ -676,9 +676,9 @@ func InstantiateFormulaOnBead(formulaName, beadID, title, hookWorkDir, townRoot 
 	formulaVars = ensureFormulaRequiredVars(formulaName, formulaVars)
 
 	// Step 2: Create wisp with feature and issue variables from bead
-	// StripBdBranch: wisp is operational scaffolding that must be written to main,
+	// OnMain: wisp is operational scaffolding that must be written to main,
 	// not a polecat's isolated branch. Without this, step 3 (bond) reads from main
-	// via StripBdBranch but can't find the wisp that was written to a different branch,
+	// via OnMain but can't find the wisp that was written to a different branch,
 	// causing "not found" errors. Both steps must target the same branch.
 	wispArgs := []string{"mol", "wisp", formulaName, "--var", featureVar, "--var", issueVar}
 	for _, variable := range extraVars {
@@ -689,7 +689,7 @@ func InstantiateFormulaOnBead(formulaName, beadID, title, hookWorkDir, townRoot 
 		Dir(formulaWorkDir).
 		WithAutoCommit().
 		WithGTRoot(townRoot).
-		StripBdBranch().
+		OnMain().
 		Output()
 	if err != nil {
 		return nil, fmt.Errorf("creating wisp for formula %s: %w", formulaName, err)
@@ -712,7 +712,7 @@ func InstantiateFormulaOnBead(formulaName, beadID, title, hookWorkDir, townRoot 
 		Dir(formulaWorkDir).
 		WithAutoCommit().
 		WithGTRoot(townRoot).
-		StripBdBranch().
+		OnMain().
 		Output()
 	if err != nil {
 		fallbackRootID, fallbackErr := bondFormulaDirect(formulaName, beadID, formulaWorkDir, townRoot, formulaVars)
@@ -761,7 +761,7 @@ func bondFormulaDirect(formulaName, beadID, formulaWorkDir, townRoot string, var
 		Dir(formulaWorkDir).
 		WithAutoCommit().
 		WithGTRoot(townRoot).
-		StripBdBranch().
+		OnMain().
 		Output()
 	if err != nil {
 		return "", fmt.Errorf("%w (args: %s)", err, strings.Join(bondArgs, " "))
@@ -852,7 +852,7 @@ func CookFormula(formulaName, workDir, townRoot string) error {
 	return BdCmd("cook", formulaName).
 		Dir(workDir).
 		WithGTRoot(townRoot).
-		StripBdBranch().
+		OnMain().
 		Run()
 }
 


### PR DESCRIPTION
## Summary

Aligns the `bdCmd` fluent API with `beads.Beads.OnMain()` — both now use `.OnMain()` to express "target main branch, not a polecat write-isolation branch." Removes the old `StripBdBranch()` method entirely (no deprecation shim needed since `bdCmd` is unexported).

## Related Issue

Follows from #1897 — standardizes the naming convention introduced there across the `bdCmd` builder API.

## Changes

- **`bd_helpers.go`**: Renamed struct field `stripBdBranch` → `onMain`, renamed method `StripBdBranch()` → `OnMain()` with updated doc comment and example
- **`sling_helpers.go`**: Migrated all 8 `.StripBdBranch()` bdCmd call sites to `.OnMain()`, updated comments
- **`sling_formula.go`**: Migrated 2 `.StripBdBranch()` bdCmd call sites to `.OnMain()`
- **`bd_helpers_test.go`**: Updated all test names, assertions, field references, and comments to use `OnMain`
- **`bd_branch_arch_test.go`**: Updated protection coverage counts (`sling_helpers.go`: 0,8 → 8,0; added `sling_formula.go`: 2,0). Added new `TestBdBranchOnMainNamingConvention` arch test that scans all production files and fails if any file (other than the allow-listed `prime.go`, `show.go`, `bd_helpers.go`) uses `.StripBdBranch()` — preventing future bdCmd callers from using the old name.

## Testing

- [x] Unit tests pass (`go test ./internal/cmd/ -run 'TestBdBranch|TestBdCmd'` — 27 tests)
- [x] Build passes (`go build ./internal/cmd/...`)
- [x] Dual-model code review (Claude + Codex) — decision: approve, 0 blockers, 0 majors

## Checklist

- [x] Code follows project style
- [x] No breaking changes — pure rename of unexported type method
- [x] `beads.StripBdBranch(env)` package-level function is intentionally preserved for raw `exec.Command`/`syscall.Exec` call sites