### PR TITLE
fix: silently skip costs record for non-GT sessions

### DIFF
--- a/internal/cmd/costs.go
+++ b/internal/cmd/costs.go
@@ -973,6 +973,9 @@ func runCostsRecord(cmd *cobra.Command, args []string) error {
 	if session == "" {
 		// Not a Gas Town session (e.g., Claude Code launched outside gt agent system).
 		// Exit silently — no costs to record.
+		if costsVerbose {
+			fmt.Fprintf(os.Stderr, "[costs] no session context found, skipping costs record\n")
+		}
 		return nil
 	}
 

--- a/internal/cmd/costs_test.go
+++ b/internal/cmd/costs_test.go
@@ -174,6 +174,34 @@ func TestDeriveSessionName(t *testing.T) {
 	}
 }
 
+func TestRunCostsRecord_NoSession_ReturnsNil(t *testing.T) {
+	// Clear all session-related env vars so no session can be derived.
+	envKeys := []string{"GT_SESSION", "GT_ROLE", "GT_RIG", "GT_POLECAT", "GT_CREW", "GT_TOWN"}
+	saved := make(map[string]string)
+	for _, key := range envKeys {
+		saved[key] = os.Getenv(key)
+		os.Unsetenv(key)
+	}
+	defer func() {
+		for key, val := range saved {
+			if val != "" {
+				os.Setenv(key, val)
+			}
+		}
+	}()
+
+	// Clear the flag-based session too
+	oldSession := recordSession
+	recordSession = ""
+	defer func() { recordSession = oldSession }()
+
+	// runCostsRecord should return nil (silent skip) when no session is resolvable
+	err := runCostsRecord(nil, nil)
+	if err != nil {
+		t.Errorf("runCostsRecord() returned error %v, want nil for non-GT session", err)
+	}
+}
+
 func TestCostDigestPayload_ExcludesSessions(t *testing.T) {
 	// Build a digest with many sessions (simulating the 2885-session case)
 	digest := CostDigest{


### PR DESCRIPTION
## Summary

`gt costs record` (called by the Claude Code Stop hook) now exits silently when
it can't determine a session name, instead of returning an error. This fixes the
stop hook error seen when Claude Code is launched outside the GT agent system (no
`GT_SESSION`, `GT_ROLE`, or tmux session).

Adopts the first commit from #1887 by @jason-curtis (with original authorship
preserved). The second commit in #1887 (spawn grace period, gt-es39) is excluded
from this PR — it addresses a separate concern and had review findings that need
independent resolution.

Credit: Original fix by @jason-curtis.

## Related Issue

Supersedes #1887 (first commit only)

## Changes

- Return `nil` instead of an error when no session can be derived in
  `runCostsRecord`, after exhausting all fallback paths (env vars, tmux detection)
- Add verbose-level log line for the silent skip, matching existing `costsVerbose`
  pattern
- Add test verifying `runCostsRecord` returns `nil` for non-GT sessions

## Testing

- [x] Unit tests pass (`go test ./internal/cmd/ -run TestRunCostsRecord`)
- [x] Manual review of all session detection fallback paths

## Checklist

- [x] Code follows project style
- [x] No breaking changes
- [x] Contributor authorship preserved via cherry-pick