### PR TITLE
feat(hooks): add WorktreeCreate/WorktreeRemove hook event support

### DIFF
--- a/internal/cmd/hooks_diff.go
+++ b/internal/cmd/hooks_diff.go
@@ -126,6 +126,8 @@ func diffHooksConfigs(current, expected *hooks.HooksConfig) []string {
 		{"Stop", current.Stop, expected.Stop},
 		{"PreCompact", current.PreCompact, expected.PreCompact},
 		{"UserPromptSubmit", current.UserPromptSubmit, expected.UserPromptSubmit},
+		{"WorktreeCreate", current.WorktreeCreate, expected.WorktreeCreate},
+		{"WorktreeRemove", current.WorktreeRemove, expected.WorktreeRemove},
 	}
 
 	for _, ht := range hookTypes {

--- a/internal/cmd/hooks_registry.go
+++ b/internal/cmd/hooks_registry.go
@@ -97,7 +97,7 @@ func runHooksRegistry(cmd *cobra.Command, args []string) error {
 		name string
 		def  HookDefinition
 	})
-	eventOrder := []string{"PreToolUse", "PostToolUse", "SessionStart", "PreCompact", "UserPromptSubmit", "Stop"}
+	eventOrder := []string{"PreToolUse", "PostToolUse", "SessionStart", "PreCompact", "UserPromptSubmit", "Stop", "WorktreeCreate", "WorktreeRemove"}
 
 	for name, def := range registry.Hooks {
 		if !hooksRegistryAll && !def.Enabled {

--- a/internal/cmd/hooks_scan.go
+++ b/internal/cmd/hooks_scan.go
@@ -27,6 +27,8 @@ Hook types:
   PreToolUse       - Runs before tool execution
   PostToolUse      - Runs after tool execution
   Stop             - Runs when Claude session stops
+  WorktreeCreate   - Runs when agent worktree isolation creates a worktree
+  WorktreeRemove   - Runs when agent worktree isolation removes a worktree
 
 Examples:
   gt hooks scan              # List all hooks in workspace

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -32,6 +32,8 @@ type HooksConfig struct {
 	Stop             []HookEntry `json:"Stop,omitempty"`
 	PreCompact       []HookEntry `json:"PreCompact,omitempty"`
 	UserPromptSubmit []HookEntry `json:"UserPromptSubmit,omitempty"`
+	WorktreeCreate   []HookEntry `json:"WorktreeCreate,omitempty"`
+	WorktreeRemove   []HookEntry `json:"WorktreeRemove,omitempty"`
 }
 
 // SettingsJSON represents the full Claude Code settings.json structure.
@@ -370,7 +372,7 @@ func isRig(path string) bool {
 }
 
 // EventTypes returns the known hook event type names in display order.
-var EventTypes = []string{"PreToolUse", "PostToolUse", "SessionStart", "Stop", "PreCompact", "UserPromptSubmit"}
+var EventTypes = []string{"PreToolUse", "PostToolUse", "SessionStart", "Stop", "PreCompact", "UserPromptSubmit", "WorktreeCreate", "WorktreeRemove"}
 
 // GetEntries returns the hook entries for a given event type.
 func (c *HooksConfig) GetEntries(eventType string) []HookEntry {
@@ -387,6 +389,10 @@ func (c *HooksConfig) GetEntries(eventType string) []HookEntry {
 		return c.PreCompact
 	case "UserPromptSubmit":
 		return c.UserPromptSubmit
+	case "WorktreeCreate":
+		return c.WorktreeCreate
+	case "WorktreeRemove":
+		return c.WorktreeRemove
 	default:
 		return nil
 	}
@@ -407,6 +413,10 @@ func (c *HooksConfig) SetEntries(eventType string, entries []HookEntry) {
 		c.PreCompact = entries
 	case "UserPromptSubmit":
 		c.UserPromptSubmit = entries
+	case "WorktreeCreate":
+		c.WorktreeCreate = entries
+	case "WorktreeRemove":
+		c.WorktreeRemove = entries
 	}
 }
 

--- a/internal/hooks/merge.go
+++ b/internal/hooks/merge.go
@@ -81,6 +81,8 @@ func applyOverride(result, override *HooksConfig) *HooksConfig {
 	result.Stop = mergeEntries(result.Stop, override.Stop)
 	result.PreCompact = mergeEntries(result.PreCompact, override.PreCompact)
 	result.UserPromptSubmit = mergeEntries(result.UserPromptSubmit, override.UserPromptSubmit)
+	result.WorktreeCreate = mergeEntries(result.WorktreeCreate, override.WorktreeCreate)
+	result.WorktreeRemove = mergeEntries(result.WorktreeRemove, override.WorktreeRemove)
 	return result
 }
 
@@ -136,6 +138,8 @@ func cloneConfig(cfg *HooksConfig) *HooksConfig {
 		Stop:             cloneEntries(cfg.Stop),
 		PreCompact:       cloneEntries(cfg.PreCompact),
 		UserPromptSubmit: cloneEntries(cfg.UserPromptSubmit),
+		WorktreeCreate:   cloneEntries(cfg.WorktreeCreate),
+		WorktreeRemove:   cloneEntries(cfg.WorktreeRemove),
 	}
 }
 


### PR DESCRIPTION
Claude Code 2.1.50 introduced `WorktreeCreate` and `WorktreeRemove` hook events, fired when agent worktree isolation (`isolation: worktree` in subagent frontmatter) creates or removes worktrees.

This PR adds support for these two new event types across Gas Town's hook system: `HooksConfig` struct, `EventTypes`, `GetEntries`/`SetEntries`, merge (`applyOverride` + `cloneConfig`), diff, registry, and scan.

### Changes (20 lines, 5 files)

- `internal/hooks/config.go` — Add `WorktreeCreate`/`WorktreeRemove` fields, extend `EventTypes`, `GetEntries`, `SetEntries`
- `internal/hooks/merge.go` — Handle new events in `applyOverride` and `cloneConfig`
- `internal/cmd/hooks_diff.go` — Include new events in diff comparison
- `internal/cmd/hooks_registry.go` — Add to display order
- `internal/cmd/hooks_scan.go` — Add to help text

### Context: how does this relate to Gas Town's worktree architecture?

Gas Town already uses git worktrees as its primary isolation mechanism for polecats. The natural question is: **should Gas Town delegate worktree lifecycle to Claude Code's `isolation: worktree`?**

After analysis, the answer is **not yet** — there's a fundamental architectural mismatch:

| | Gas Town polecats | Claude Code `isolation: worktree` |
|--|---|---|
| **Lifecycle** | Long-lived, persisted across sessions | Ephemeral, per-subagent invocation |
| **Naming** | `polecat/{name}/{issue}@{timestamp}` | Claude-controlled |
| **Tracking** | Agent beads in Dolt, branch isolation | None |
| **Setup** | 7-step sequence (beads, PRIME.md, overlay, gitignore, settings, hooks, agent bead) | Basic `git worktree add` |
| **Git backend** | Bare repo `.repo.git` | Standard repo |

Gas Town needs to **constrain operations within a pre-existing worktree** it created itself. `isolation: worktree` **creates a new worktree** — it solves a different problem (ephemeral subagent isolation).

### Primary use case: blocking unauthorized worktree creation

Gas Town exercises **total control** over the worktree lifecycle — creation, naming, branch assignment, Dolt tracking, teardown. If a Claude subagent creates worktrees via `isolation: worktree` behind Gas Town's back, it causes real problems:

- **Orphan branches** not following the `polecat/{name}/{issue}@{timestamp}` convention
- **Untracked worktrees** with no agent beads in Dolt
- **No 7-step setup** (no PRIME.md, no overlay, no shared beads, no gitignore)
- **Scope enforcement bypass** — the new worktree is outside Gas Town's visibility
- **Cleanup gap** — `RemoveWithOptions` won't know about these worktrees

With this PR, Gas Town can register a `WorktreeCreate` hook that **exits with code 2 to block creation**, ensuring no worktree is created outside Gas Town's managed lifecycle. This is analogous to how `gt tap guard pr-workflow` blocks unauthorized PR creation.

### Other future use cases

1. **Witness / Agent Teams** — When a polecat internally spawns Claude Code subagents via `Task()` with `isolation: worktree`, these hooks let Gas Town react (audit, scope enforcement, cleanup of sub-worktrees created inside a polecat's worktree).

2. **Future Claude Code evolution** — If Claude Code adds support for pointing `isolation: worktree` at an existing path (e.g. `--isolation worktree --worktree-path <path>`), Gas Town would be ready to hook into that lifecycle.

3. **Scope enforcement alternative** — Today's planned `gt validate-worktree-scope` (Step 5 of the witness roadmap) uses PreToolUse hooks reactively. If Claude Code's native worktree isolation becomes configurable, these hooks would be the proactive replacement.

### Question for discussion

Should Gas Town proactively register a **blocking** `WorktreeCreate` hook in the settings templates (`settings-autonomous.json`, `settings-interactive.json`) now — to prevent Claude from creating worktrees outside Gas Town's control? Or wait until there's a concrete incident?