### PR TITLE
chore: require dolt >= 1.82.4 with version check in doctor

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,7 @@ Git-backed issue tracking system that stores work state as structured data.
 
 - **Go 1.23+** - [go.dev/dl](https://go.dev/dl/)
 - **Git 2.25+** - for worktree support
+- **Dolt 1.82.4+** - [github.com/dolthub/dolt](https://github.com/dolthub/dolt)
 - **beads (bd) 0.55.4+** - [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
 - **sqlite3** - for convoy database queries (usually pre-installed on macOS/Linux)
 - **tmux 3.0+** - recommended for full experience

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -10,7 +10,7 @@ Complete setup guide for Gas Town multi-agent orchestrator.
 |------|---------|-------|---------|
 | **Go** | 1.24+ | `go version` | See [golang.org](https://go.dev/doc/install) |
 | **Git** | 2.20+ | `git --version` | See below |
-| **Dolt** | latest | `dolt version` | See [dolthub/dolt](https://github.com/dolthub/dolt?tab=readme-ov-file#installation) |
+| **Dolt** | >= 1.82.4 | `dolt version` | See [dolthub/dolt](https://github.com/dolthub/dolt?tab=readme-ov-file#installation) |
 | **Beads** | >= 0.55.4 | `bd version` | `go install github.com/steveyegge/beads/cmd/bd@latest` |
 
 ### Optional (for Full Stack Mode)
@@ -74,7 +74,7 @@ sudo dnf install -y tmux
 # Check all prerequisites
 go version        # Should show go1.24 or higher
 git --version     # Should show 2.20 or higher
-dolt version      # Should show dolt version string
+dolt version      # Should show 1.82.4 or higher
 tmux -V           # (Optional) Should show 3.0 or higher
 ```
 

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -88,7 +88,7 @@ Session hook checks:
   - stale-task-dispatch      Detect stale task-dispatch guard in settings.json (fixable)
 
 Dolt checks:
-  - dolt-binary              Check that dolt is installed and in PATH
+  - dolt-binary              Check that dolt is installed and meets minimum version
   - dolt-metadata            Check dolt metadata tables exist
   - dolt-server-reachable    Check dolt sql-server is reachable
   - dolt-orphaned-databases  Detect orphaned dolt databases

--- a/internal/deps/beads.go
+++ b/internal/deps/beads.go
@@ -6,8 +6,6 @@ import (
 	"fmt"
 	"os/exec"
 	"regexp"
-	"strconv"
-	"strings"
 	"time"
 )
 
@@ -55,7 +53,7 @@ func CheckBeads() (BeadsStatus, string) {
 	}
 
 	// Compare versions
-	if compareVersions(version, MinBeadsVersion) < 0 {
+	if CompareVersions(version, MinBeadsVersion) < 0 {
 		return BeadsTooOld, version
 	}
 
@@ -124,29 +122,3 @@ func parseBeadsVersion(output string) string {
 	return ""
 }
 
-// compareVersions compares two semver strings.
-// Returns -1 if a < b, 0 if a == b, 1 if a > b.
-func compareVersions(a, b string) int {
-	aParts := parseVersion(a)
-	bParts := parseVersion(b)
-
-	for i := 0; i < 3; i++ {
-		if aParts[i] < bParts[i] {
-			return -1
-		}
-		if aParts[i] > bParts[i] {
-			return 1
-		}
-	}
-	return 0
-}
-
-// parseVersion parses "X.Y.Z" into [3]int.
-func parseVersion(v string) [3]int {
-	var parts [3]int
-	split := strings.Split(v, ".")
-	for i := 0; i < 3 && i < len(split); i++ {
-		parts[i], _ = strconv.Atoi(split[i])
-	}
-	return parts
-}

--- a/internal/deps/beads_test.go
+++ b/internal/deps/beads_test.go
@@ -37,9 +37,9 @@ func TestCompareVersions(t *testing.T) {
 	}
 
 	for _, tt := range tests {
-		result := compareVersions(tt.a, tt.b)
+		result := CompareVersions(tt.a, tt.b)
 		if result != tt.expected {
-			t.Errorf("compareVersions(%q, %q) = %d, want %d", tt.a, tt.b, result, tt.expected)
+			t.Errorf("CompareVersions(%q, %q) = %d, want %d", tt.a, tt.b, result, tt.expected)
 		}
 	}
 }

--- a/internal/deps/dolt.go
+++ b/internal/deps/dolt.go
@@ -1,0 +1,71 @@
+package deps
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// MinDoltVersion is the minimum compatible dolt version for this Gas Town release.
+// Update this when Gas Town requires new dolt features.
+const MinDoltVersion = "1.82.4"
+
+// DoltInstallURL is the installation page for dolt.
+const DoltInstallURL = "https://github.com/dolthub/dolt#installation"
+
+// DoltStatus represents the state of the dolt installation.
+type DoltStatus int
+
+const (
+	DoltOK         DoltStatus = iota // dolt found, version compatible
+	DoltNotFound                     // dolt not in PATH
+	DoltTooOld                       // dolt found but version too old
+	DoltExecFailed                   // dolt found but 'dolt version' failed to execute
+	DoltUnknown                      // dolt version ran but output couldn't be parsed
+)
+
+// CheckDolt checks if dolt is installed and compatible.
+// Returns status, the installed version (if found), and diagnostic detail
+// for failure cases (stderr/error output).
+func CheckDolt() (DoltStatus, string, string) {
+	path, err := exec.LookPath("dolt")
+	if err != nil {
+		return DoltNotFound, "", ""
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path, "version")
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		detail := strings.TrimSpace(string(output))
+		if detail == "" {
+			detail = err.Error()
+		}
+		return DoltExecFailed, "", fmt.Sprintf("at %s: %s", path, detail)
+	}
+
+	version := parseDoltVersion(string(output))
+	if version == "" {
+		return DoltUnknown, "", strings.TrimSpace(string(output))
+	}
+
+	if CompareVersions(version, MinDoltVersion) < 0 {
+		return DoltTooOld, version, ""
+	}
+
+	return DoltOK, version, ""
+}
+
+// parseDoltVersion extracts version from "dolt version X.Y.Z" output.
+func parseDoltVersion(output string) string {
+	re := regexp.MustCompile(`dolt version (\d+\.\d+\.\d+)`)
+	matches := re.FindStringSubmatch(output)
+	if len(matches) >= 2 {
+		return matches[1]
+	}
+	return ""
+}

--- a/internal/deps/dolt_test.go
+++ b/internal/deps/dolt_test.go
@@ -1,0 +1,38 @@
+package deps
+
+import "testing"
+
+func TestParseDoltVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"dolt version 1.82.4", "1.82.4"},
+		{"dolt version 1.82.4\n", "1.82.4"},
+		{"dolt version 1.0.0", "1.0.0"},
+		{"dolt version 10.20.30", "10.20.30"},
+		{"some other output", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		result := parseDoltVersion(tt.input)
+		if result != tt.expected {
+			t.Errorf("parseDoltVersion(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestCheckDolt(t *testing.T) {
+	status, version, _ := CheckDolt()
+
+	if status == DoltNotFound {
+		t.Skip("dolt not installed, skipping integration test")
+	}
+
+	if status == DoltOK && version == "" {
+		t.Error("CheckDolt returned DoltOK but empty version")
+	}
+
+	t.Logf("CheckDolt: status=%d, version=%s", status, version)
+}

--- a/internal/deps/version.go
+++ b/internal/deps/version.go
@@ -1,0 +1,35 @@
+package deps
+
+import (
+	"strconv"
+	"strings"
+)
+
+// CompareVersions compares two semver strings.
+// Returns -1 if a < b, 0 if a == b, 1 if a > b.
+func CompareVersions(a, b string) int {
+	aParts := ParseVersion(a)
+	bParts := ParseVersion(b)
+
+	for i := 0; i < 3; i++ {
+		if aParts[i] < bParts[i] {
+			return -1
+		}
+		if aParts[i] > bParts[i] {
+			return 1
+		}
+	}
+	return 0
+}
+
+// ParseVersion parses a pre-sanitized "X.Y.Z" numeric string into [3]int.
+// Non-numeric parts silently default to 0. Callers should validate input
+// via regex before calling (e.g., parseDoltVersion, parseBeadsVersion).
+func ParseVersion(v string) [3]int {
+	var parts [3]int
+	split := strings.Split(v, ".")
+	for i := 0; i < 3 && i < len(split); i++ {
+		parts[i], _ = strconv.Atoi(split[i])
+	}
+	return parts
+}

--- a/internal/doctor/dolt_binary_check.go
+++ b/internal/doctor/dolt_binary_check.go
@@ -2,12 +2,13 @@ package doctor
 
 import (
 	"fmt"
-	"os/exec"
-	"strings"
+
+	"github.com/steveyegge/gastown/internal/deps"
 )
 
-// DoltBinaryCheck verifies that the dolt binary is installed and accessible in PATH.
-// Dolt is required for the beads storage backend (dolt sql-server).
+// DoltBinaryCheck verifies that the dolt binary is installed, accessible in PATH,
+// and meets the minimum version requirement. Dolt is required for the beads
+// storage backend (dolt sql-server).
 type DoltBinaryCheck struct {
 	BaseCheck
 }
@@ -17,48 +18,71 @@ func NewDoltBinaryCheck() *DoltBinaryCheck {
 	return &DoltBinaryCheck{
 		BaseCheck: BaseCheck{
 			CheckName:        "dolt-binary",
-			CheckDescription: "Check that dolt is installed and in PATH",
+			CheckDescription: "Check that dolt is installed and meets minimum version",
 			CheckCategory:    CategoryInfrastructure,
 		},
 	}
 }
 
-// Run checks if dolt is available in PATH and reports its version.
+// Run checks if dolt is available in PATH and reports its version status.
 func (c *DoltBinaryCheck) Run(ctx *CheckContext) *CheckResult {
-	doltPath, err := exec.LookPath("dolt")
-	if err != nil {
+	status, version, detail := deps.CheckDolt()
+
+	switch status {
+	case deps.DoltOK:
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: fmt.Sprintf("dolt %s", version),
+		}
+
+	case deps.DoltNotFound:
 		return &CheckResult{
 			Name:   c.Name(),
 			Status: StatusError,
 			Message: "dolt not found in PATH",
 			Details: []string{
 				"Dolt is required for the beads storage backend",
-				"Install from: https://github.com/dolthub/dolt#installation",
 			},
-			FixHint: "Install dolt: https://github.com/dolthub/dolt#installation",
+			FixHint: fmt.Sprintf("Install dolt: %s", deps.DoltInstallURL),
 		}
-	}
 
-	// Get version for the OK message
-	cmd := exec.Command(doltPath, "version")
-	output, err := cmd.CombinedOutput()
-	if err != nil {
+	case deps.DoltTooOld:
 		return &CheckResult{
 			Name:   c.Name(),
 			Status: StatusError,
-			Message: fmt.Sprintf("dolt found at %s but 'dolt version' failed: %v", doltPath, err),
+			Message: fmt.Sprintf("dolt %s is too old (minimum: %s)", version, deps.MinDoltVersion),
 			Details: []string{
-				strings.TrimSpace(string(output)),
+				fmt.Sprintf("Installed version %s does not meet the minimum requirement of %s", version, deps.MinDoltVersion),
 			},
-			FixHint: "Reinstall dolt: https://github.com/dolthub/dolt#installation",
+			FixHint: fmt.Sprintf("Upgrade dolt: %s", deps.DoltInstallURL),
+		}
+
+	case deps.DoltExecFailed:
+		return &CheckResult{
+			Name:   c.Name(),
+			Status: StatusError,
+			Message: fmt.Sprintf("dolt found but 'dolt version' failed: %s", detail),
+			Details: []string{
+				"The dolt binary exists but could not report its version",
+			},
+			FixHint: fmt.Sprintf("Reinstall dolt: %s", deps.DoltInstallURL),
+		}
+
+	case deps.DoltUnknown:
+		return &CheckResult{
+			Name:   c.Name(),
+			Status: StatusWarning,
+			Message: fmt.Sprintf("dolt found but version could not be parsed: %s", detail),
+			FixHint: fmt.Sprintf("Reinstall dolt: %s", deps.DoltInstallURL),
 		}
 	}
 
-	ver := strings.TrimSpace(string(output))
-	// dolt version outputs "dolt version X.Y.Z"
+	// Unreachable with current DoltStatus values. Return warning to surface
+	// unexpected states if a new enum value is added without updating this switch.
 	return &CheckResult{
 		Name:    c.Name(),
-		Status:  StatusOK,
-		Message: ver,
+		Status:  StatusWarning,
+		Message: "unexpected dolt check status",
 	}
 }

--- a/internal/doctor/dolt_binary_check_test.go
+++ b/internal/doctor/dolt_binary_check_test.go
@@ -1,12 +1,15 @@
 package doctor
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/gastown/internal/deps"
 )
 
 func TestDoltBinaryCheck_Metadata(t *testing.T) {
@@ -15,7 +18,7 @@ func TestDoltBinaryCheck_Metadata(t *testing.T) {
 	if check.Name() != "dolt-binary" {
 		t.Errorf("Name() = %q, want %q", check.Name(), "dolt-binary")
 	}
-	if check.Description() != "Check that dolt is installed and in PATH" {
+	if check.Description() != "Check that dolt is installed and meets minimum version" {
 		t.Errorf("Description() = %q", check.Description())
 	}
 	if check.Category() != CategoryInfrastructure {
@@ -26,27 +29,7 @@ func TestDoltBinaryCheck_Metadata(t *testing.T) {
 	}
 }
 
-func TestDoltBinaryCheck_DoltInstalled(t *testing.T) {
-	// Skip if dolt is not actually installed in the test environment
-	if _, err := exec.LookPath("dolt"); err != nil {
-		t.Skip("dolt not installed, skipping installed-path test")
-	}
-
-	check := NewDoltBinaryCheck()
-	ctx := &CheckContext{TownRoot: t.TempDir()}
-
-	result := check.Run(ctx)
-	if result.Status != StatusOK {
-		t.Errorf("expected StatusOK when dolt is installed, got %v: %s", result.Status, result.Message)
-	}
-	if !strings.Contains(result.Message, "dolt version") {
-		t.Errorf("expected version string in message, got %q", result.Message)
-	}
-}
-
 // writeFakeDolt creates a platform-appropriate fake "dolt" executable in dir.
-// On Unix, it writes a shell script. On Windows, it writes a .bat file.
-// Returns the filename written (e.g. "dolt" or "dolt.bat").
 func writeFakeDolt(t *testing.T, dir string, script string, batScript string) {
 	t.Helper()
 	if runtime.GOOS == "windows" {
@@ -62,12 +45,37 @@ func writeFakeDolt(t *testing.T, dir string, script string, batScript string) {
 	}
 }
 
+func TestDoltBinaryCheck_DoltInstalled(t *testing.T) {
+	// Skip if dolt is not actually installed in the test environment
+	if _, err := exec.LookPath("dolt"); err != nil {
+		t.Skip("dolt not installed, skipping installed-path test")
+	}
+
+	check := NewDoltBinaryCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+
+	result := check.Run(ctx)
+	// Non-hermetic: the installed dolt may or may not meet MinDoltVersion.
+	switch result.Status {
+	case StatusOK:
+		if !strings.Contains(result.Message, "dolt") {
+			t.Errorf("expected version string in message, got %q", result.Message)
+		}
+	case StatusError:
+		if !strings.Contains(result.Message, "too old") {
+			t.Errorf("expected 'too old' in error message, got %q", result.Message)
+		}
+	default:
+		t.Errorf("unexpected status %v when dolt is installed: %s", result.Status, result.Message)
+	}
+}
+
 func TestDoltBinaryCheck_HermeticSuccess(t *testing.T) {
-	// Create a fake "dolt" binary that prints a version string
 	fakeDir := t.TempDir()
+	// Use deps.MinDoltVersion so this test stays in sync when the minimum is bumped.
 	writeFakeDolt(t, fakeDir,
-		"#!/bin/sh\necho 'dolt version 1.0.0'\n",
-		"@echo off\r\necho dolt version 1.0.0\r\n",
+		fmt.Sprintf("#!/bin/sh\necho 'dolt version %s'\n", deps.MinDoltVersion),
+		fmt.Sprintf("@echo off\r\necho dolt version %s\r\n", deps.MinDoltVersion),
 	)
 
 	t.Setenv("PATH", fakeDir)
@@ -77,16 +85,14 @@ func TestDoltBinaryCheck_HermeticSuccess(t *testing.T) {
 
 	result := check.Run(ctx)
 	if result.Status != StatusOK {
-		t.Errorf("expected StatusOK with fake dolt, got %v: %s", result.Status, result.Message)
+		t.Errorf("expected StatusOK with fake dolt at min version, got %v: %s", result.Status, result.Message)
 	}
-	if result.Message != "dolt version 1.0.0" {
-		t.Errorf("expected 'dolt version 1.0.0', got %q", result.Message)
+	if !strings.Contains(result.Message, deps.MinDoltVersion) {
+		t.Errorf("expected version in message, got %q", result.Message)
 	}
 }
 
 func TestDoltBinaryCheck_DoltNotInPath(t *testing.T) {
-	// Create an empty directory and set PATH to only that directory,
-	// ensuring dolt (and nothing else) is findable.
 	emptyDir := t.TempDir()
 	t.Setenv("PATH", emptyDir)
 
@@ -100,9 +106,6 @@ func TestDoltBinaryCheck_DoltNotInPath(t *testing.T) {
 	if result.Message != "dolt not found in PATH" {
 		t.Errorf("unexpected message: %q", result.Message)
 	}
-	if len(result.Details) != 2 {
-		t.Errorf("expected 2 detail lines, got %d", len(result.Details))
-	}
 	if result.FixHint == "" {
 		t.Error("expected a fix hint with install instructions")
 	}
@@ -111,8 +114,33 @@ func TestDoltBinaryCheck_DoltNotInPath(t *testing.T) {
 	}
 }
 
+func TestDoltBinaryCheck_DoltTooOld(t *testing.T) {
+	fakeDir := t.TempDir()
+	// Use a structurally safe low version to ensure test intent is clear
+	// regardless of future MinDoltVersion changes.
+	writeFakeDolt(t, fakeDir,
+		"#!/bin/sh\necho 'dolt version 0.0.1'\n",
+		"@echo off\r\necho dolt version 0.0.1\r\n",
+	)
+
+	t.Setenv("PATH", fakeDir)
+
+	check := NewDoltBinaryCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+
+	result := check.Run(ctx)
+	if result.Status != StatusError {
+		t.Errorf("expected StatusError for too-old dolt, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "too old") {
+		t.Errorf("expected 'too old' in message, got %q", result.Message)
+	}
+	if result.FixHint == "" {
+		t.Error("expected a fix hint with upgrade instructions")
+	}
+}
+
 func TestDoltBinaryCheck_DoltVersionFails(t *testing.T) {
-	// Create a fake "dolt" binary that exits with an error
 	fakeDir := t.TempDir()
 	writeFakeDolt(t, fakeDir,
 		"#!/bin/sh\nexit 1\n",
@@ -125,13 +153,32 @@ func TestDoltBinaryCheck_DoltVersionFails(t *testing.T) {
 	ctx := &CheckContext{TownRoot: t.TempDir()}
 
 	result := check.Run(ctx)
+	// When dolt version fails to execute, deps.CheckDolt returns DoltExecFailed → StatusError
 	if result.Status != StatusError {
 		t.Errorf("expected StatusError when dolt version fails, got %v: %s", result.Status, result.Message)
 	}
-	if !strings.Contains(result.Message, "dolt version") {
-		t.Errorf("expected message to mention 'dolt version', got %q", result.Message)
+	if !strings.Contains(result.Message, "failed") {
+		t.Errorf("expected 'failed' in message, got %q", result.Message)
 	}
-	if result.FixHint == "" {
-		t.Error("expected a fix hint for broken dolt")
+}
+
+func TestDoltBinaryCheck_DoltVersionUnparseable(t *testing.T) {
+	fakeDir := t.TempDir()
+	writeFakeDolt(t, fakeDir,
+		"#!/bin/sh\necho 'some garbage output'\n",
+		"@echo off\r\necho some garbage output\r\n",
+	)
+
+	t.Setenv("PATH", fakeDir)
+
+	check := NewDoltBinaryCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning when dolt version unparseable, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "could not be parsed") {
+		t.Errorf("expected parse failure detail in message, got %q", result.Message)
 	}
 }


### PR DESCRIPTION
## Summary

Add minimum dolt version enforcement (>= 1.82.4) to `gt doctor`, following the existing beads version check pattern. This ensures users get clear feedback when their dolt installation is missing, too old, or broken.

## Changes

- **`internal/deps/dolt.go`** (new): `MinDoltVersion`, `DoltInstallURL`, `CheckDolt()` with 5-state status enum (`DoltOK`, `DoltNotFound`, `DoltTooOld`, `DoltExecFailed`, `DoltUnknown`). Returns diagnostic detail (stderr/path) for failure cases.
- **`internal/deps/version.go`** (new): Extract shared `CompareVersions()`/`ParseVersion()` from beads.go to support multiple dependency checkers.
- **`internal/deps/beads.go`**: Use exported `CompareVersions()` from version.go, remove old unexported copies.
- **`internal/doctor/dolt_binary_check.go`**: Rewrite to delegate to `deps.CheckDolt()`. `DoltExecFailed` → `StatusError`, `DoltUnknown` → `StatusWarning` (fail-open, matching beads precedent).
- **`internal/doctor/dolt_binary_check_test.go`**: Comprehensive hermetic tests for all 5 status paths with strict assertions (no StatusWarning fallback for success/too-old).
- **`internal/cmd/doctor.go`**: Update help text to say "meets minimum version".
- **`docs/INSTALLING.md`**: Update dolt version from "latest" to ">= 1.82.4".
- **`README.md`**: Add Dolt 1.82.4+ to prerequisites list.

## Testing

- [x] Unit tests pass (`go test ./internal/deps/ ./internal/doctor/`)
- [x] `go build ./...` succeeds
- [x] Environment has dolt 1.81.7 which correctly triggers `DoltTooOld`
- [x] Triple-model review (Claude + Codex + Gemini) — 2 rounds, all findings addressed

## Checklist

- [x] Code follows project style
- [x] Documentation updated (INSTALLING.md, README.md)
- [x] No breaking changes