### PR TITLE
Fix dog sessions to honor role_agents (avoid Opus fallback)

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -12,7 +12,7 @@ import (
 // AgentEnvConfig specifies the configuration for generating agent environment variables.
 // This is the single source of truth for all agent environment configuration.
 type AgentEnvConfig struct {
-	// Role is the agent role: mayor, deacon, witness, refinery, crew, polecat, boot
+	// Role is the agent role: mayor, deacon, witness, refinery, crew, polecat, dog, boot
 	Role string
 
 	// Rig is the rig name (empty for town-level agents like mayor/deacon)
@@ -114,6 +114,18 @@ func AgentEnv(cfg AgentEnvConfig) map[string]string {
 		env["GT_CREW"] = cfg.AgentName
 		env["BD_ACTOR"] = fmt.Sprintf("%s/crew/%s", cfg.Rig, cfg.AgentName)
 		env["GIT_AUTHOR_NAME"] = cfg.AgentName
+
+	case "dog":
+		// Dogs are town-level workers with role_agents key "dog".
+		// GT_ROLE must be set so startup command resolution can honor role_agents.dog.
+		env["GT_ROLE"] = "dog"
+		if cfg.AgentName != "" {
+			env["BD_ACTOR"] = fmt.Sprintf("dog/%s", cfg.AgentName)
+			env["GIT_AUTHOR_NAME"] = cfg.AgentName
+		} else {
+			env["BD_ACTOR"] = "dog"
+			env["GIT_AUTHOR_NAME"] = "dog"
+		}
 	}
 
 	// Only set GT_ROOT if provided

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -116,6 +116,21 @@ func TestAgentEnv_Boot(t *testing.T) {
 	assertNotSet(t, env, "GT_RIG")
 }
 
+func TestAgentEnv_Dog(t *testing.T) {
+	t.Parallel()
+	env := AgentEnv(AgentEnvConfig{
+		Role:      "dog",
+		AgentName: "alpha",
+		TownRoot:  "/town",
+	})
+
+	assertEnv(t, env, "GT_ROLE", "dog")
+	assertEnv(t, env, "BD_ACTOR", "dog/alpha")
+	assertEnv(t, env, "GIT_AUTHOR_NAME", "alpha")
+	assertEnv(t, env, "GT_ROOT", "/town")
+	assertNotSet(t, env, "GT_RIG")
+}
+
 func TestAgentEnv_WithRuntimeConfigDir(t *testing.T) {
 	t.Parallel()
 	env := AgentEnv(AgentEnvConfig{


### PR DESCRIPTION
## Summary
Dog sessions could silently start on the default agent/model (often Opus) even when `role_agents.dog` was configured to `claude-haiku`.

This burned tokens because dog startup command generation did not export `GT_ROLE=dog`, so role-based resolution never engaged.

## Root Cause
- `session.StartSession` starts dogs with `Role: "dog"`.
- `BuildAgentStartupCommand` relies on `AgentEnv(...)` for `GT_ROLE` export.
- `AgentEnv` had no `dog` case, so startup command lacked `GT_ROLE`, and command resolution fell back to `default_agent`.

## Fix
- Add `dog` role handling to `AgentEnv`:
  - `GT_ROLE=dog`
  - `BD_ACTOR=dog/<name>` when available (or `dog` fallback)
  - `GIT_AUTHOR_NAME=<name>` when available (or `dog` fallback)

## Tests
Added regression tests:
- `TestAgentEnv_Dog` (fails before fix)
- `TestBuildAgentStartupCommand_DogUsesRoleAgents` (fails before fix)

Verification:
- `go test ./internal/config -run 'TestAgentEnv_Dog|TestBuildAgentStartupCommand_DogUsesRoleAgents' -count=1`
- `go test ./internal/config -count=1`

## Why this matters
With this patch, setting `settings/config.json` like:

```json
{
  "role_agents": {
    "dog": "claude-haiku"
  }
}
```

actually controls dog startup model, preventing unexpected Opus token burn.
