### PR TITLE
fix: treat empty JSON array as success in bd list calls

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -309,6 +309,11 @@ func (b *Beads) run(args ...string) (_ []byte, retErr error) {
 
 	err := cmd.Run()
 	if err != nil {
+		// bd exits non-zero when a list query returns no results (e.g. --status=pinned with no matches).
+		// An empty JSON array on stdout is a valid success response; don't treat it as an error.
+		if strings.TrimSpace(stdout.String()) == "[]" {
+			return stdout.Bytes(), nil
+		}
 		return nil, b.wrapError(err, stderr.String(), args)
 	}
 


### PR DESCRIPTION
## Problem

`bd list --status=pinned --limit=0` exits non-zero when there are no matching beads, even though it writes `[]` to stdout. The central `run()` dispatcher in `beads.go` treats any non-zero exit as an error, so `[]` was never returned to callers — they received an error instead.

This caused ~91 spurious `bd.call` errors per week in telemetry, all from boot/deacon patrol loops:
```
bd list --json --status=pinned --limit=0   → status=error, stdout=[]
bd list --json --status=pinned --assignee=boot --limit=0   → status=error, stdout=[]
```

Agents receiving these errors waste context processing them as real failures.

## Fix

In `beads.run()`, before propagating a non-zero exit error, check if stdout is `[]`. If so, return success — an empty JSON array is a valid, successful empty result.

```go
if err != nil {
    if strings.TrimSpace(stdout.String()) == "[]" {
        return stdout.Bytes(), nil
    }
    return nil, b.wrapError(err, stderr.String(), args)
}
```

This is a one-line check in the central dispatcher, so it covers all `bd list` callers (pinned, open, by-label, etc.) without touching individual call sites.

## Test plan

- [ ] `bd list --status=pinned --limit=0` in an empty beads dir returns `[]` with exit 0 (or is handled gracefully)
- [ ] `b.List(ListOptions{Status: "pinned"})` returns `([]*Issue{}, nil)` when no pinned beads exist
- [ ] Normal `bd` errors (not-found, bad args) still propagate as errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)