### PR TITLE
fix: remove deprecated role bead lookups (120 bd show errors/week)

### DIFF
--- a/internal/deacon/stuck.go
+++ b/internal/deacon/stuck.go
@@ -8,8 +8,6 @@ import (
 	"os"
 	"path/filepath"
 	"time"
-
-	"github.com/steveyegge/gastown/internal/beads"
 )
 
 // Default parameters for stuck-session detection.
@@ -37,35 +35,11 @@ func DefaultStuckConfig() *StuckConfig {
 	}
 }
 
-// LoadStuckConfig loads stuck detection config from the Deacon's role bead.
-// Returns defaults if no role bead exists or if fields aren't configured.
-// Per ZFC: agents control their own thresholds via their role beads.
-func LoadStuckConfig(townRoot string) *StuckConfig {
-	config := DefaultStuckConfig()
-
-	// Load from hq-deacon-role bead
-	bd := beads.NewWithBeadsDir(townRoot, beads.ResolveBeadsDir(townRoot))
-	roleConfig, err := bd.GetRoleConfig(beads.RoleBeadIDTown("deacon"))
-	if err != nil || roleConfig == nil {
-		return config
-	}
-
-	// Override defaults with role bead values
-	if roleConfig.PingTimeout != "" {
-		if d, err := time.ParseDuration(roleConfig.PingTimeout); err == nil {
-			config.PingTimeout = d
-		}
-	}
-	if roleConfig.ConsecutiveFailures > 0 {
-		config.ConsecutiveFailures = roleConfig.ConsecutiveFailures
-	}
-	if roleConfig.KillCooldown != "" {
-		if d, err := time.ParseDuration(roleConfig.KillCooldown); err == nil {
-			config.Cooldown = d
-		}
-	}
-
-	return config
+// LoadStuckConfig returns the default stuck detection config.
+// Role beads are deprecated as of Phase 2 (config-based roles); thresholds
+// are no longer loaded from hq-deacon-role. Tune via config instead.
+func LoadStuckConfig(_ string) *StuckConfig {
+	return DefaultStuckConfig()
 }
 
 // AgentHealthState tracks the health check state for a single agent.

--- a/internal/doctor/patrol_check.go
+++ b/internal/doctor/patrol_check.go
@@ -205,24 +205,8 @@ func NewPatrolNotStuckCheck() *PatrolNotStuckCheck {
 	}
 }
 
-// loadStuckThreshold loads the stuck threshold from the Deacon's role bead.
-// Returns the default if no config exists.
-func loadStuckThreshold(townRoot string) time.Duration {
-	bd := beads.NewWithBeadsDir(townRoot, beads.ResolveBeadsDir(townRoot))
-	roleConfig, err := bd.GetRoleConfig(beads.RoleBeadIDTown("deacon"))
-	if err != nil || roleConfig == nil || roleConfig.StuckThreshold == "" {
-		return DefaultStuckThreshold
-	}
-	if d, err := time.ParseDuration(roleConfig.StuckThreshold); err == nil {
-		return d
-	}
-	return DefaultStuckThreshold
-}
-
 // Run checks for stuck patrol wisps.
 func (c *PatrolNotStuckCheck) Run(ctx *CheckContext) *CheckResult {
-	// Load threshold from role bead (ZFC: agent-controlled)
-	c.stuckThreshold = loadStuckThreshold(ctx.TownRoot)
 
 	rigs, err := discoverRigs(ctx.TownRoot)
 	if err != nil {


### PR DESCRIPTION
## Problem

`LoadStuckConfig()` (deacon) and `loadStuckThreshold()` (doctor) both call
`bd.GetRoleConfig("hq-deacon-role")` on every deacon patrol cycle.

Role beads were deprecated in Phase 2 — `beads_role.go` carries an explicit
`DEPRECATED` notice: *"The daemon no longer uses role beads as of Phase 2
(config-based roles)."* The `hq-deacon-role` bead no longer exists in the
workspace, so every call produces a failed `bd show` in telemetry:

```
bd show hq-deacon-role --json
→ {"error": "no issues found matching the provided IDs"}
```

Observed impact: **~120 `bd.call` errors per week**, all identical.

Both functions already fell through to return hardcoded defaults when the bead
was missing, so the lookup was entirely dead code producing pure noise.

## Fix

- `internal/deacon/stuck.go`: `LoadStuckConfig` now returns `DefaultStuckConfig()` directly, parameter renamed to `_` to make it clear the townRoot is unused.
- `internal/doctor/patrol_check.go`: `loadStuckThreshold` function removed; `PatrolNotStuckCheck.Run` uses the already-initialized `c.stuckThreshold` (set to `DefaultStuckThreshold` in the constructor).
- Remove orphaned `beads` import from `stuck.go`.

## Test plan

- [x] `go test ./internal/deacon/... ./internal/doctor/...` passes
- [x] `go build ./...` passes
- [ ] Deacon patrol loop generates zero `bd show hq-deacon-role` errors in telemetry

🤖 Generated with [Claude Code](https://claude.com/claude-code)