### PR TITLE
fix: gt mail read with no args shows actionable error

### DIFF
--- a/internal/cmd/mail.go
+++ b/internal/cmd/mail.go
@@ -176,9 +176,10 @@ Examples:
   gt mail read hq-abc123    # Read by message ID
   gt mail read 3            # Read the 3rd message in inbox
 
+Use 'gt mail inbox' to list messages and their IDs.
 Use 'gt mail mark-read' to mark messages as read.`,
 	Aliases: []string{"show"},
-	Args:    cobra.ExactArgs(1),
+	Args:    cobra.MaximumNArgs(1),
 	RunE:    runMailRead,
 }
 

--- a/internal/cmd/mail_inbox.go
+++ b/internal/cmd/mail_inbox.go
@@ -134,7 +134,7 @@ func runMailInbox(cmd *cobra.Command, args []string) error {
 
 func runMailRead(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
-		return errors.New("message ID or index required")
+		return fmt.Errorf("message ID or index required\n\nRun 'gt mail inbox' to list messages and their IDs")
 	}
 	msgRef := args[0]
 


### PR DESCRIPTION
## Problem

Mayor calls `gt mail read` without a message ID. The cobra `ExactArgs(1)`
constraint fires before `runMailRead` is even reached, producing:

```
Error: accepts 1 arg(s), received 0
Usage:
  gt mail read <message-id|index> [flags]
...
```

Mayor sees the usage block, doesn't know what to do next, and retries
the exact same command 4 times in a row — burning context and generating
noise in telemetry.

The generic cobra error gives no hint that `gt mail inbox` is the right
next step to obtain a valid ID or index.

## Fix

- Change `Args` from `cobra.ExactArgs(1)` to `cobra.MaximumNArgs(1)` so
  the 0-arg case reaches `runMailRead`.
- Return an actionable error message that names the correct command:
  `"message ID or index required — run 'gt mail inbox' to list messages and their IDs"`
- Add `gt mail inbox` to the command's Long description as a cross-reference.

## Test plan

- [ ] `gt mail read` (no args) prints the new error message instead of cobra usage
- [ ] `gt mail read hq-abc123` still works as before
- [ ] `gt mail read 1` (numeric index) still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)