### PR TITLE
fix: tell polecats to close bead explicitly when nothing to commit

### DIFF
--- a/internal/templates/roles/polecat.md.tmpl
+++ b/internal/templates/roles/polecat.md.tmpl
@@ -41,6 +41,15 @@ Do NOT:
 **Your session should NEVER end without running `{{ cmd }} done`.** If `{{ cmd }} done` fails,
 escalate to Witness — but you must attempt it.
 
+**Exception — bead has nothing to implement** (already done, can't reproduce, not applicable):
+```bash
+bd close <id> --reason="no-changes: <brief explanation>"
+{{ cmd }} done
+```
+Without an explicit `bd close`, the witness zombie patrol resets the bead to `open` and
+re-dispatches it to a new polecat, causing spawn storms. Every polecat session must end
+with either a branch push via `{{ cmd }} done` OR an explicit `bd close` on the hook bead.
+
 ---
 
 ## 🚨 CRITICAL: Directory Discipline 🚨

--- a/templates/polecat-CLAUDE.md
+++ b/templates/polecat-CLAUDE.md
@@ -109,6 +109,16 @@ bd close <step-id>       # Mark step complete
 
 **If NO work on hook and NO mail:** run `gt done` immediately.
 
+**If your assigned bead has nothing to implement** (already done, can't reproduce, not applicable):
+```bash
+bd close <id> --reason="no-changes: <brief explanation>"
+gt done
+```
+**DO NOT** exit without closing the bead. Without an explicit `bd close`, the witness zombie
+patrol resets the bead to `open` and dispatches it to a new polecat — causing spawn storms
+(6-7 polecats assigned the same bead). Every session must end with either a branch push via
+`gt done` OR an explicit `bd close` on the hook bead.
+
 ---
 
 ## Key Commands


### PR DESCRIPTION
## Summary

Polecats that exit without closing their hook bead cause **spawn storms**: the witness zombie patrol resets the bead to `open` and re-dispatches it to a new polecat, repeating indefinitely. Observed in production: 6-7 polecats assigned to the same bead (wc-efj, fai-68u).

The root cause identified by mayor: _"bead never closing after polecats complete without remote git push"_. The "nothing to implement" case (work already done, feature not applicable, can't reproduce) was not documented in polecat instructions.

## Changes

- `templates/polecat-CLAUDE.md` — add explicit "nothing to implement" exit protocol
- `internal/templates/roles/polecat.md.tmpl` — same addition to rendered role context

Both templates now include:
```bash
# When assigned bead has nothing to implement:
bd close <id> --reason="no-changes: <brief explanation>"
gt done
```
With an explanation of *why* skipping `bd close` causes spawn storms.

## Companion PR

- #1920 (`fix/bead-spawn-count`) adds infrastructure-level spawn count tracking so deacon sees a `SPAWN_STORM` alert after 2 respawns of the same bead — this is the safety net if a polecat still misses the protocol.

## Test plan

- [ ] Spawn a polecat against a bead that has no applicable work
- [ ] Polecat closes bead with `bd close <id> --reason="no-changes: ..."` then runs `gt done`
- [ ] Witness does not re-dispatch the bead

🤖 Generated with [Claude Code](https://claude.com/claude-code)