### PR TITLE
feat(witness): track bead respawn count, alert on spawn storms

### DIFF
--- a/internal/witness/spawn_count.go
+++ b/internal/witness/spawn_count.go
@@ -1,0 +1,82 @@
+package witness
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/workspace"
+)
+
+// defaultMaxBeadRespawns is the threshold above which a SPAWN_STORM warning is
+// included in the RECOVERED_BEAD mail sent to deacon. It does not block respawns
+// — the intent is audit visibility so deacon/mayor can investigate.
+const defaultMaxBeadRespawns = 2
+
+// beadRespawnRecord tracks how many times a single bead has been reset for re-dispatch.
+type beadRespawnRecord struct {
+	BeadID      string    `json:"bead_id"`
+	Count       int       `json:"count"`
+	LastRespawn time.Time `json:"last_respawn"`
+}
+
+// beadRespawnState holds respawn counts for all tracked beads.
+type beadRespawnState struct {
+	Beads       map[string]*beadRespawnRecord `json:"beads"`
+	LastUpdated time.Time                     `json:"last_updated"`
+}
+
+func beadRespawnStateFile(townRoot string) string {
+	return filepath.Join(townRoot, "witness", "bead-respawn-counts.json")
+}
+
+func loadBeadRespawnState(townRoot string) *beadRespawnState {
+	data, err := os.ReadFile(beadRespawnStateFile(townRoot)) //nolint:gosec // G304: path from trusted townRoot
+	if err != nil {
+		return &beadRespawnState{Beads: make(map[string]*beadRespawnRecord)}
+	}
+	var state beadRespawnState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return &beadRespawnState{Beads: make(map[string]*beadRespawnRecord)}
+	}
+	if state.Beads == nil {
+		state.Beads = make(map[string]*beadRespawnRecord)
+	}
+	return &state
+}
+
+func saveBeadRespawnState(townRoot string, state *beadRespawnState) error {
+	stateFile := beadRespawnStateFile(townRoot)
+	if err := os.MkdirAll(filepath.Dir(stateFile), 0755); err != nil {
+		return fmt.Errorf("creating witness dir: %w", err)
+	}
+	state.LastUpdated = time.Now().UTC()
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling respawn state: %w", err)
+	}
+	return os.WriteFile(stateFile, data, 0600)
+}
+
+// recordBeadRespawn increments the respawn count for beadID and returns the new count.
+// workDir is the rig path; townRoot is resolved internally via workspace.Find.
+// On state file errors the count is still incremented in memory and returned, so the
+// caller can log/warn without blocking the respawn itself.
+func recordBeadRespawn(workDir, beadID string) int {
+	townRoot, err := workspace.Find(workDir)
+	if err != nil || townRoot == "" {
+		townRoot = workDir
+	}
+	state := loadBeadRespawnState(townRoot)
+	rec, ok := state.Beads[beadID]
+	if !ok {
+		rec = &beadRespawnRecord{BeadID: beadID}
+		state.Beads[beadID] = rec
+	}
+	rec.Count++
+	rec.LastRespawn = time.Now().UTC()
+	_ = saveBeadRespawnState(townRoot, state) // Non-fatal: tracking failure must not block respawn
+	return rec.Count
+}


### PR DESCRIPTION
## Summary

Infrastructure-level safety net for polecat spawn storms. When `resetAbandonedBead` resets a bead to `open` for re-dispatch, it now records the count in `witness/bead-respawn-counts.json` and includes it in the `RECOVERED_BEAD` mail to deacon.

After 2 respawns (`defaultMaxBeadRespawns`), the mail is upgraded:
- Subject: `SPAWN_STORM RECOVERED_BEAD <id> (respawned Nx)`
- Priority: `Urgent` (was `High`)
- Body: warning explaining likely cause and remediation

The bead is still reset to `open` — this is pure audit/escalation, not a blocker. The intent is to give deacon/mayor visibility so they can investigate or close the bead manually if needed.

## Changes

- `internal/witness/spawn_count.go` — new file: JSON ledger (`witness/bead-respawn-counts.json`), `recordBeadRespawn()`
- `internal/witness/handlers.go` — `resetAbandonedBead` calls `recordBeadRespawn`, includes count in mail, upgrades priority + subject on storm

## Companion PR

- #1919 (`fix/polecat-no-work-exit`) fixes the root cause at the agent level by teaching polecats to `bd close` their bead before `gt done` when there's nothing to implement.

## Test plan

- [ ] `go test ./internal/witness/...` passes
- [ ] Simulate 3 resets of the same bead: third `RECOVERED_BEAD` mail has `SPAWN_STORM` prefix and Urgent priority
- [ ] State file `witness/bead-respawn-counts.json` is created with correct counts

🤖 Generated with [Claude Code](https://claude.com/claude-code)