### PR TITLE
fix: resolve unparam lint errors in wisps migration code

### DIFF
--- a/internal/cmd/dolt.go
+++ b/internal/cmd/dolt.go
@@ -1456,7 +1456,7 @@ func runDoltMigrateWisps(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		printMigrateWispsResult(doltMigrateWispsDB, result)
+		printMigrateWispsResult(result)
 		return nil
 	}
 
@@ -1482,12 +1482,12 @@ func runDoltMigrateWisps(cmd *cobra.Command, args []string) error {
 			fmt.Printf("  %s %s: %v\n", style.Bold.Render("✗"), db, err)
 			continue
 		}
-		printMigrateWispsResult(db, result)
+		printMigrateWispsResult(result)
 	}
 	return nil
 }
 
-func printMigrateWispsResult(db string, result *doltserver.MigrateWispsResult) {
+func printMigrateWispsResult(result *doltserver.MigrateWispsResult) {
 	if result.WispsTableCreated {
 		fmt.Printf("  %s Created wisps table\n", style.Bold.Render("✓"))
 	}


### PR DESCRIPTION
Fixes #1918

Two `unparam` violations introduced by commit c771e3da ("feat: add wisps table migration for agent beads") that broke lint on `main` and blocked all open PRs.

## Changes

**`internal/doltserver/wisps_migrate.go`**
`bdSQL()` returned `(string, error)` but no caller ever used the string — all call sites were `_, err := bdSQL(...)`. Changed return type to `error` only and updated all call sites.

**`internal/cmd/dolt.go`**
`printMigrateWispsResult(db string, result *...)` had an unused `db` parameter. Removed it and updated both call sites.

## Test plan
- [ ] `go test ./internal/doltserver/...` passes
- [ ] `golangci-lint run` no longer reports unparam errors on these files

🤖 Generated with [Claude Code](https://claude.com/claude-code)