### PR TITLE
fix: remove deprecated role bead TTL layer from compact

### DIFF
--- a/internal/cmd/compact_test.go
+++ b/internal/cmd/compact_test.go
@@ -194,8 +194,8 @@ func TestLoadTTLConfigDefaults(t *testing.T) {
 }
 
 func TestLoadTTLConfigWithRoleDefaults(t *testing.T) {
-	// With empty town root and no role, should return hardcoded defaults
-	ttls := loadTTLConfigWithRole("", "", "")
+	// With empty town root, should return hardcoded defaults
+	ttls := loadTTLConfigWithRole("", "")
 
 	for k, want := range defaultTTLs {
 		if got := ttls[k]; got != want {
@@ -205,8 +205,8 @@ func TestLoadTTLConfigWithRoleDefaults(t *testing.T) {
 }
 
 func TestLoadTTLConfigWithRoleSkipsInvalidPaths(t *testing.T) {
-	// With nonexistent paths, role bead lookup should gracefully skip
-	ttls := loadTTLConfigWithRole("/nonexistent/town", "myrig", "deacon")
+	// With nonexistent paths, rig bead lookup should gracefully skip
+	ttls := loadTTLConfigWithRole("/nonexistent/town", "myrig")
 
 	// Should still have defaults even though lookups failed
 	if ttls["patrol"] != defaultTTLs["patrol"] {


### PR DESCRIPTION
## Summary

- Removes `applyRoleBeadTTLOverrides` from `compact.go` — role beads (`hq-deacon-role` etc.) are deprecated since Phase 2 and never exist in production
- Every `gt compact` run was issuing a `bd show` subprocess for a role bead lookup that always fails, generating OTEL noise
- Same pattern as #1917 (removed from patrol loop), but this one ran at compaction time
- Drops the unused `roleName` parameter from `loadTTLConfigWithRole` and updates tests accordingly
- Also adds `RecordPaneOutput` to `telemetry/recorder.go` (unblocks build for pane-log work)

## Test plan

- [ ] `go test ./internal/cmd/ -run "TestGetTTL|TestWispAge|TestLoadTTL"` — all pass
- [ ] `gt compact --dry-run` no longer triggers `bd show hq-deacon-role` subprocess

🤖 Generated with [Claude Code](https://claude.com/claude-code)