### PR TITLE
fix: skip --prefix flag when empty and add camelCase prefix derivation

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -242,7 +242,11 @@ func (b *Beads) getResolvedBeadsDir() string {
 // If ServerPort is set (via NewIsolatedWithPort), passes --server-port to bd init
 // so the database is created on the test Dolt server.
 func (b *Beads) Init(prefix string) error {
-	args := []string{"init", "--prefix", prefix, "--quiet"}
+	args := []string{"init"}
+	if prefix != "" {
+		args = append(args, "--prefix", prefix)
+	}
+	args = append(args, "--quiet")
 	if b.serverPort > 0 {
 		args = append(args, "--server-port", fmt.Sprintf("%d", b.serverPort))
 	}

--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -204,7 +204,12 @@ func ensureDatabaseInitialized(beadsDir string) error {
 	// bd init must run from the parent directory (not inside .beads/).
 	// Use --server to match all production callers (rig/manager.go, doctor/rig_check.go, cmd/install.go).
 	parentDir := filepath.Dir(beadsDir)
-	cmd := exec.Command("bd", "init", "--prefix", prefix, "--server")
+	initArgs := []string{"init"}
+	if prefix != "" {
+		initArgs = append(initArgs, "--prefix", prefix)
+	}
+	initArgs = append(initArgs, "--server")
+	cmd := exec.Command("bd", initArgs...)
 	cmd.Dir = parentDir
 	cmd.Env = append(stripEnvPrefixes(os.Environ(), "BEADS_DIR="), "BEADS_DIR="+beadsDir)
 	if output, err := cmd.CombinedOutput(); err != nil {

--- a/internal/cmd/bead.go
+++ b/internal/cmd/bead.go
@@ -154,14 +154,16 @@ func runBeadMove(cmd *cobra.Command, args []string) error {
 	}
 
 	// Build create command for target
-	createArgs := []string{
-		"create",
-		"--prefix", targetPrefix,
-		"--title=" + source.Title,
+	createArgs := []string{"create"}
+	if targetPrefix != "" && targetPrefix != "-" {
+		createArgs = append(createArgs, "--prefix", targetPrefix)
+	}
+	createArgs = append(createArgs,
+		"--title="+source.Title,
 		"--type", source.Type,
 		"--priority", fmt.Sprintf("%d", source.Priority),
 		"--silent", // Only output the ID
-	}
+	)
 
 	if source.Description != "" {
 		createArgs = append(createArgs, "--description", source.Description)

--- a/internal/doctor/rig_check.go
+++ b/internal/doctor/rig_check.go
@@ -1020,7 +1020,12 @@ func (c *BeadsRedirectCheck) Fix(ctx *CheckContext) error {
 
 		// Run bd init with the configured prefix (Dolt is the only backend since bd v0.51.0).
 		// Gas Town rigs use Dolt server mode via the shared town Dolt sql-server.
-		cmd := exec.Command("bd", "init", "--prefix", prefix, "--server")
+		initArgs := []string{"init"}
+		if prefix != "" {
+			initArgs = append(initArgs, "--prefix", prefix)
+		}
+		initArgs = append(initArgs, "--server")
+		cmd := exec.Command("bd", initArgs...)
 		cmd.Dir = rigPath
 		if output, err := cmd.CombinedOutput(); err != nil {
 			// bd might not be installed — create config.yaml via shared helper.


### PR DESCRIPTION
## Summary
- **Skip `--prefix` flag when prefix is empty**: All `bd init` and `bd create` call sites now conditionally include `--prefix` only when a non-empty value is available. Previously, empty prefix values were passed as `--prefix ""`, which could cause `bd` to fail. When omitted, `bd` handles prefix resolution internally.
- **Add camelCase splitting to `deriveBeadsPrefix`**: Names like `myProject` now correctly derive `mp` (first letter of each camelCase word) instead of falling through to the first-2-chars fallback (`my`). Also handles PascalCase and uppercase runs (e.g., `HTMLParser` → `hp`).

### Files changed
- `internal/beads/beads.go` — `Init()` wrapper
- `internal/beads/beads_types.go` — `ensureDatabaseInitialized()`
- `internal/cmd/bead.go` — `runBeadMove()`
- `internal/doctor/rig_check.go` — `BeadsRedirectCheck.Fix()`
- `internal/rig/manager.go` — `AddRig()`, `InitBeads()`, `deriveBeadsPrefix()`, new `splitCamelCase()`

## Test plan
- [ ] Verify `bd init` works without `--prefix` flag (bd handles it internally)
- [ ] Verify `bd init --prefix <value>` still works when prefix is provided
- [ ] Verify `deriveBeadsPrefix("myProject")` returns `"mp"`
- [ ] Verify `deriveBeadsPrefix("gasStation")` returns `"gs"`
- [ ] Verify existing compound word splitting still works (`"gastown"` → `"gt"`)
- [ ] Verify `gt bead move` with empty prefix doesn't pass `--prefix ""`

🤖 Generated with [Claude Code](https://claude.com/claude-code)