### PR TITLE
refinery: deterministic queue tie-breaker for equal scores

### DIFF
--- a/internal/refinery/manager_test.go
+++ b/internal/refinery/manager_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/rig"
@@ -181,5 +182,31 @@ func TestManager_Retry_Deprecated(t *testing.T) {
 	err := mgr.Retry("any-id", false)
 	if err != nil {
 		t.Errorf("Retry() unexpected error: %v", err)
+	}
+}
+
+func TestCompareScoredIssues_UsesDeterministicIDTieBreaker(t *testing.T) {
+	t.Helper()
+
+	first := scoredIssue{
+		issue: &beads.Issue{
+			ID:        "gt-1",
+			CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		},
+		score: 10,
+	}
+	second := scoredIssue{
+		issue: &beads.Issue{
+			ID:        "gt-2",
+			CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		},
+		score: 10,
+	}
+
+	if !compareScoredIssues(first, second) {
+		t.Fatalf("expected gt-1 to sort before gt-2 for equal scores")
+	}
+	if compareScoredIssues(second, first) {
+		t.Fatalf("expected gt-2 to sort after gt-1 for equal scores")
 	}
 }


### PR DESCRIPTION
## Problem
Convoy/merge queue ordering can vary for equally scored items, reducing replay determinism.

## Why now
This is active operator friction in current workflows and needs deterministic behavior for repeatable triage/replay.

## What changed
Added a deterministic tie-breaker (issue ID) for equal score ordering and covered it with a focused unit test.

## Validation
- go test ./internal/refinery -run TestCompareScoredIssues_UsesDeterministicIDTieBreaker (pass)

Refs #1938
