### PR TITLE
fix(done): gate sandbox nuke on MR creation success

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -921,11 +921,11 @@ notifyWitness:
 	if roleInfo, err := GetRoleWithContext(cwd, townRoot); err == nil && roleInfo.Role == RolePolecat {
 		selfCleanAttempted = true
 
-		// Step 1: Nuke the worktree (only for COMPLETED with successful push)
-		// If push failed, preserve the worktree so Witness/Refinery can still
-		// access the branch for recovery. selfNukePolecat also checks
-		// branch-on-remote, so this is defense-in-depth.
-		if exitType == ExitCompleted && !pushFailed {
+		// Step 1: Nuke the worktree (only for COMPLETED with successful push AND MR)
+		// If push or MR creation failed, preserve the worktree so
+		// Witness/Refinery can still access the branch for recovery.
+		// selfNukePolecat also checks branch-on-remote, so this is defense-in-depth.
+		if exitType == ExitCompleted && !pushFailed && !mrFailed {
 			if err := selfNukePolecat(roleInfo, townRoot); err != nil {
 				// Non-fatal: Witness will clean up if we fail
 				style.PrintWarning("worktree nuke failed: %v (Witness will clean up)", err)


### PR DESCRIPTION
## Summary
- `gt done` was destroying polecat worktrees even when MR bead creation failed, causing completed work to be permanently lost
- The `mrFailed` flag was already set (line 781) and reported to Witness (line 862), but never checked before sandbox cleanup (line 928)
- Added `&& !mrFailed` to the cleanup gate, matching the existing `!pushFailed` pattern

## Root Cause
Line 928 gated sandbox destruction on `exitType == ExitCompleted && !pushFailed` but did not check `mrFailed`. When MR bead creation fails (e.g., due to wisp resolution issues or Dolt errors), the polecat's worktree was nuked anyway, leaving the commit only recoverable via `git cat-file` on a dangling SHA.

## What Changed
One line in `internal/cmd/done.go`:
```go
// Before:
if exitType == ExitCompleted && !pushFailed {
// After:
if exitType == ExitCompleted && !pushFailed && !mrFailed {
```

## Test plan
- [ ] Verify polecat sandbox preserved when MR creation fails
- [ ] Verify normal gt done flow still nukes sandbox on success
- [ ] Verify pushFailed still preserves sandbox (no regression)

Closes #1945

🤖 Generated with [Claude Code](https://claude.com/claude-code)