### PR TITLE
fix: deduplicate agent bead IDs when prefix equals rig name

### DIFF
--- a/internal/beads/agent_ids.go
+++ b/internal/beads/agent_ids.go
@@ -199,13 +199,23 @@ func ValidateAgentID(id string) error {
 		return fmt.Errorf("agent ID must include content after prefix (got %q)", id)
 	}
 
-	// Case 1: Single part after prefix - must be town-level role
+	// Case 1: Single part after prefix - town-level role, or collapsed prefix
+	// rig-level singleton (when prefix==rig, e.g., "ff-witness"). See GH #1877.
 	if len(parts) == 1 {
 		role := parts[0]
 		if isTownLevelRole(role) {
 			return nil // Valid town-level agent
 		}
+		// Rig-level singleton roles are also valid here because
+		// AgentBeadIDWithPrefix collapses the rig when prefix==rig,
+		// producing IDs like "ff-witness" instead of "ff-ff-witness".
+		if isRigLevelRole(role) {
+			return nil // Valid collapsed-prefix rig-level singleton
+		}
 		if isTownLevelNamedRole(role) {
+			return fmt.Errorf("agent role %q requires name: <prefix>-%s-<name> (got %q)", role, role, id)
+		}
+		if isNamedRole(role) {
 			return fmt.Errorf("agent role %q requires name: <prefix>-%s-<name> (got %q)", role, role, id)
 		}
 		if isValidRole(role) {
@@ -214,11 +224,17 @@ func ValidateAgentID(id string) error {
 		return fmt.Errorf("invalid agent role %q (valid: %s)", role, strings.Join(ValidAgentRoles, ", "))
 	}
 
-	// Case 2: Two parts - could be town-level named (dog-alpha) or needs to scan for role
+	// Case 2: Two parts - could be town-level named (dog-alpha), collapsed prefix
+	// named role (ff-crew-bob when prefix==rig), or needs to scan for role
 	if len(parts) == 2 {
 		// Check if first part is a town-level named role
 		if isTownLevelNamedRole(parts[0]) {
 			return nil // Valid town-level named agent: gt-dog-alpha
+		}
+		// Check if first part is a named role with name following (collapsed prefix
+		// form where prefix==rig, e.g., ff-crew-bob). See GH #1877.
+		if isNamedRole(parts[0]) {
+			return nil // Valid collapsed-prefix named agent: ff-crew-bob
 		}
 		// Check if second part is a rig-level singleton role
 		if isRigLevelRole(parts[1]) {
@@ -324,10 +340,18 @@ func ValidateAgentID(id string) error {
 // For town-level agents (mayor, deacon), pass empty rig and name.
 // For rig-level singletons (witness, refinery), pass empty name.
 // For named agents (crew, polecat), pass all three.
+//
+// When prefix == rig (which happens for short rig names where deriveBeadsPrefix
+// returns the rig name itself, e.g., "ff"), the rig component is omitted to
+// avoid stuttered IDs like "ff-ff-witness". See GH #1877.
 func AgentBeadIDWithPrefix(prefix, rig, role, name string) string {
-	if rig == "" {
-		// Town-level agent: prefix-mayor, prefix-deacon
-		return prefix + "-" + role
+	if rig == "" || rig == prefix {
+		// Town-level agent (rig=="") or deduplicated (rig==prefix):
+		//   prefix-role or prefix-role-name
+		if name == "" {
+			return prefix + "-" + role
+		}
+		return prefix + "-" + role + "-" + name
 	}
 	if name == "" {
 		// Rig-level singleton: prefix-rig-witness, prefix-rig-refinery
@@ -420,7 +444,10 @@ func ParseAgentBeadID(id string) (rig, role, name string, ok bool) {
 	// "witness"), we prefer the named-role interpretation. A named role like
 	// "polecat" at position i-1 consuming the keyword at position i as its
 	// name is more specific than treating the keyword as a singleton role.
-	for i := len(parts) - 1; i >= 1; i-- {
+	// Start at i=0 (not i=1) to handle collapsed-prefix IDs where the role
+	// keyword appears immediately after the prefix (e.g., "ff-crew-bob"
+	// when prefix==rig). See GH #1877.
+	for i := len(parts) - 1; i >= 0; i-- {
 		p := parts[i]
 		if isNamedRole(p) && i < len(parts)-1 {
 			// Named roles with a name following: crew, polecat

--- a/internal/beads/agent_ids_test.go
+++ b/internal/beads/agent_ids_test.go
@@ -144,14 +144,21 @@ func TestValidateAgentID(t *testing.T) {
 		{"mayor with rig suffix", "gt-gastown-mayor", true, "cannot have rig/name suffixes"},
 		{"deacon with rig suffix", "gt-beads-deacon", true, "cannot have rig/name suffixes"},
 
-		// Invalid: per-rig role without rig
-		{"witness alone", "gt-witness", true, "requires rig"},
-		{"refinery alone", "gt-refinery", true, "requires rig"},
+		// Valid: collapsed prefix rig-level singletons (prefix==rig, GH #1877)
+		// When deriveBeadsPrefix returns the rig name itself (e.g., "ff"),
+		// AgentBeadIDWithPrefix collapses "ff-ff-witness" to "ff-witness".
+		{"collapsed prefix witness", "ff-witness", false, ""},
+		{"collapsed prefix refinery", "ff-refinery", false, ""},
+		{"collapsed prefix crew", "ff-crew-bob", false, ""},
+		{"collapsed prefix polecat", "ff-polecat-nux", false, ""},
 
 		// Invalid: named agent without name
 		{"crew no name", "gt-beads-crew", true, "requires name"},
 		{"polecat no name", "gt-gastown-polecat", true, "requires name"},
 		{"dog no name", "gt-dog", true, "requires name"},
+		// Collapsed prefix named roles without name
+		{"collapsed crew no name", "ff-crew", true, "requires name"},
+		{"collapsed polecat no name", "ff-polecat", true, "requires name"},
 
 		// Valid: worker name collides with role keyword
 		{"polecat named witness", "gt-gastown-polecat-witness", false, ""},
@@ -225,6 +232,77 @@ func TestExtractAgentPrefix(t *testing.T) {
 			got := ExtractAgentPrefix(tt.id)
 			if got != tt.wantPrefix {
 				t.Errorf("ExtractAgentPrefix(%q) = %q, want %q", tt.id, got, tt.wantPrefix)
+			}
+		})
+	}
+}
+
+// TestAgentBeadIDWithPrefix_CollapsedPrefix verifies that when prefix==rig,
+// the rig component is omitted to avoid double-prefixed IDs (GH #1877).
+func TestAgentBeadIDWithPrefix_CollapsedPrefix(t *testing.T) {
+	tests := []struct {
+		name   string
+		prefix string
+		rig    string
+		role   string
+		wName  string
+		want   string
+	}{
+		// Normal cases (prefix != rig)
+		{"normal witness", "gt", "gastown", "witness", "", "gt-gastown-witness"},
+		{"normal refinery", "bd", "beads", "refinery", "", "bd-beads-refinery"},
+		{"normal crew", "gt", "gastown", "crew", "bob", "gt-gastown-crew-bob"},
+		{"normal polecat", "gt", "gastown", "polecat", "nux", "gt-gastown-polecat-nux"},
+		// Town-level (no rig)
+		{"town mayor", "hq", "", "mayor", "", "hq-mayor"},
+		{"town deacon", "hq", "", "deacon", "", "hq-deacon"},
+		// Collapsed prefix cases (prefix == rig, GH #1877)
+		{"collapsed witness", "ff", "ff", "witness", "", "ff-witness"},
+		{"collapsed refinery", "ff", "ff", "refinery", "", "ff-refinery"},
+		{"collapsed crew", "ff", "ff", "crew", "bob", "ff-crew-bob"},
+		{"collapsed polecat", "ff", "ff", "polecat", "nux", "ff-polecat-nux"},
+		{"collapsed 3char", "foo", "foo", "witness", "", "foo-witness"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := AgentBeadIDWithPrefix(tt.prefix, tt.rig, tt.role, tt.wName)
+			if got != tt.want {
+				t.Errorf("AgentBeadIDWithPrefix(%q, %q, %q, %q) = %q, want %q",
+					tt.prefix, tt.rig, tt.role, tt.wName, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestParseAgentBeadID_CollapsedPrefix verifies parsing of collapsed-prefix IDs (GH #1877).
+func TestParseAgentBeadID_CollapsedPrefix(t *testing.T) {
+	tests := []struct {
+		name     string
+		id       string
+		wantRig  string
+		wantRole string
+		wantName string
+		wantOK   bool
+	}{
+		// Collapsed singleton: ff-witness → rig="" (prefix IS the rig)
+		{"collapsed witness", "ff-witness", "", "witness", "", true},
+		{"collapsed refinery", "ff-refinery", "", "refinery", "", true},
+		// Collapsed named: ff-crew-bob → rig="" (prefix IS the rig)
+		{"collapsed crew", "ff-crew-bob", "", "crew", "bob", true},
+		{"collapsed polecat", "ff-polecat-nux", "", "polecat", "nux", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rig, role, name, ok := ParseAgentBeadID(tt.id)
+			if ok != tt.wantOK {
+				t.Errorf("ParseAgentBeadID(%q) ok = %v, want %v", tt.id, ok, tt.wantOK)
+				return
+			}
+			if rig != tt.wantRig || role != tt.wantRole || name != tt.wantName {
+				t.Errorf("ParseAgentBeadID(%q) = (%q, %q, %q), want (%q, %q, %q)",
+					tt.id, rig, role, name, tt.wantRig, tt.wantRole, tt.wantName)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

Fixes #1877 — Agent bead IDs get double-prefixed when the rig name equals the derived prefix (e.g., short rig names like "ff" where `deriveBeadsPrefix("ff")` returns `"ff"`).

- `AgentBeadIDWithPrefix` now collapses the rig component when `prefix == rig`, producing `ff-witness` instead of `ff-ff-witness`
- `ValidateAgentID` updated to accept collapsed-prefix forms (e.g., `ff-witness`, `ff-crew-bob`)
- `ParseAgentBeadID` scan loop extended to `i >= 0` to correctly parse collapsed named agents (e.g., `ff-crew-bob`)

## Test plan

- [x] New `TestAgentBeadIDWithPrefix_CollapsedPrefix` — verifies deduplication for all agent types
- [x] New `TestParseAgentBeadID_CollapsedPrefix` — verifies parsing of collapsed IDs
- [x] Updated `TestValidateAgentID` — added collapsed-prefix valid/invalid cases
- [x] All existing agent ID tests pass (no regressions)
- [x] Full test suite passes (only pre-existing daemon/convoy failures unrelated to this change)
- [ ] Manual: create a rig with short name (e.g., `ff`), run `gt doctor` — should no longer report missing agent beads

🤖 Generated with [Claude Code](https://claude.com/claude-code)