### PR TITLE
Harden dashboard API against cross-origin and unauthenticated access

### DIFF
--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -119,7 +119,7 @@ func runDashboard(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  launching dashboard at %s  •  api: %s/api/  •  ctrl+c to stop\n", url, url)
 
 	server := &http.Server{
-		Addr:              fmt.Sprintf(":%d", dashboardPort),
+		Addr:              fmt.Sprintf("127.0.0.1:%d", dashboardPort),
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -25,6 +25,8 @@ type CommandRequest struct {
 	Command string `json:"command"`
 	// Timeout in seconds (optional; see WebTimeoutsConfig for defaults)
 	Timeout int `json:"timeout,omitempty"`
+	// Confirmed must be true for commands that require confirmation.
+	Confirmed bool `json:"confirmed,omitempty"`
 }
 
 // CommandResponse is the JSON response from /api/run.
@@ -56,6 +58,8 @@ type APIHandler struct {
 	optionsCacheMu   sync.RWMutex
 	// cmdSem limits concurrent command executions to prevent resource exhaustion.
 	cmdSem chan struct{}
+	// csrfToken is validated on POST requests to prevent cross-site request forgery.
+	csrfToken string
 }
 
 const optionsCacheTTL = 30 * time.Second
@@ -64,8 +68,8 @@ const optionsCacheTTL = 30 * time.Second
 // handleOptions alone spawns 7; allow headroom for other concurrent handlers.
 const maxConcurrentCommands = 12
 
-// NewAPIHandler creates a new API handler with the given run timeouts.
-func NewAPIHandler(defaultRunTimeout, maxRunTimeout time.Duration) *APIHandler {
+// NewAPIHandler creates a new API handler with the given run timeouts and CSRF token.
+func NewAPIHandler(defaultRunTimeout, maxRunTimeout time.Duration, csrfToken string) *APIHandler {
 	// Use PATH lookup for gt binary. Do NOT use os.Executable() here - during
 	// tests it returns the test binary, causing fork bombs when executed.
 	workDir, _ := os.Getwd()
@@ -75,19 +79,26 @@ func NewAPIHandler(defaultRunTimeout, maxRunTimeout time.Duration) *APIHandler {
 		defaultRunTimeout: defaultRunTimeout,
 		maxRunTimeout:     maxRunTimeout,
 		cmdSem:            make(chan struct{}, maxConcurrentCommands),
+		csrfToken:         csrfToken,
 	}
 }
 
 // ServeHTTP routes API requests to the appropriate handler.
 func (h *APIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Set CORS headers for dashboard
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	// No CORS headers — the dashboard is served from the same origin.
+	// Omitting Access-Control-Allow-Origin prevents cross-origin requests.
 
 	if r.Method == http.MethodOptions {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
+	}
+
+	// Validate CSRF token on all POST requests.
+	if r.Method == http.MethodPost && h.csrfToken != "" {
+		if r.Header.Get("X-Dashboard-Token") != h.csrfToken {
+			h.sendError(w, "Invalid or missing dashboard token", http.StatusForbidden)
+			return
+		}
 	}
 
 	path := strings.TrimPrefix(r.URL.Path, "/api")
@@ -141,6 +152,12 @@ func (h *APIHandler) handleRun(w http.ResponseWriter, r *http.Request) {
 	meta, err := ValidateCommand(req.Command)
 	if err != nil {
 		h.sendError(w, fmt.Sprintf("Command blocked: %v", err), http.StatusForbidden)
+		return
+	}
+
+	// Enforce server-side confirmation for dangerous commands
+	if meta.Confirm && !req.Confirmed {
+		h.sendError(w, "This command requires confirmation (set confirmed: true)", http.StatusForbidden)
 		return
 	}
 
@@ -2051,7 +2068,6 @@ func (h *APIHandler) handleSSE(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "text/event-stream")
 	w.Header().Set("Cache-Control", "no-cache")
 	w.Header().Set("Connection", "keep-alive")
-	w.Header().Set("Access-Control-Allow-Origin", "*")
 	w.Header().Set("X-Accel-Buffering", "no")
 
 	ctx := r.Context()

--- a/internal/web/browser_e2e_test.go
+++ b/internal/web/browser_e2e_test.go
@@ -108,7 +108,7 @@ func TestBrowser_ConvoyListLoads(t *testing.T) {
 		},
 	}
 
-	handler, err := NewConvoyHandler(fetcher, 8*time.Second)
+	handler, err := NewConvoyHandler(fetcher, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("Failed to create handler: %v", err)
 	}
@@ -177,7 +177,7 @@ func TestBrowser_LastActivityColors(t *testing.T) {
 		},
 	}
 
-	handler, err := NewConvoyHandler(fetcher, 8*time.Second)
+	handler, err := NewConvoyHandler(fetcher, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("Failed to create handler: %v", err)
 	}
@@ -222,7 +222,7 @@ func TestBrowser_HtmxAutoRefresh(t *testing.T) {
 		},
 	}
 
-	handler, err := NewConvoyHandler(fetcher, 8*time.Second)
+	handler, err := NewConvoyHandler(fetcher, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("Failed to create handler: %v", err)
 	}
@@ -266,7 +266,7 @@ func TestBrowser_EmptyState(t *testing.T) {
 		convoys: []ConvoyRow{}, // Empty convoy list
 	}
 
-	handler, err := NewConvoyHandler(fetcher, 8*time.Second)
+	handler, err := NewConvoyHandler(fetcher, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("Failed to create handler: %v", err)
 	}
@@ -315,7 +315,7 @@ func TestBrowser_StatusIndicators(t *testing.T) {
 		},
 	}
 
-	handler, err := NewConvoyHandler(fetcher, 8*time.Second)
+	handler, err := NewConvoyHandler(fetcher, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("Failed to create handler: %v", err)
 	}
@@ -360,7 +360,7 @@ func TestBrowser_ProgressDisplay(t *testing.T) {
 		},
 	}
 
-	handler, err := NewConvoyHandler(fetcher, 8*time.Second)
+	handler, err := NewConvoyHandler(fetcher, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("Failed to create handler: %v", err)
 	}

--- a/internal/web/fetcher_test.go
+++ b/internal/web/fetcher_test.go
@@ -435,7 +435,7 @@ func TestNewConvoyHandler_StoresTimeout(t *testing.T) {
 	mock := &MockConvoyFetcher{}
 	timeout := 15 * time.Second
 
-	handler, err := NewConvoyHandler(mock, timeout)
+	handler, err := NewConvoyHandler(mock, timeout, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler: %v", err)
 	}
@@ -447,7 +447,7 @@ func TestNewConvoyHandler_StoresTimeout(t *testing.T) {
 
 func TestNewConvoyHandler_ZeroTimeout(t *testing.T) {
 	mock := &MockConvoyFetcher{}
-	handler, err := NewConvoyHandler(mock, 0)
+	handler, err := NewConvoyHandler(mock, 0, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler: %v", err)
 	}
@@ -463,7 +463,7 @@ func TestNewAPIHandler_StoresTimeouts(t *testing.T) {
 	defTimeout := 45 * time.Second
 	maxTimeout := 90 * time.Second
 
-	handler := NewAPIHandler(defTimeout, maxTimeout)
+	handler := NewAPIHandler(defTimeout, maxTimeout, "test-token")
 	if handler.defaultRunTimeout != defTimeout {
 		t.Errorf("defaultRunTimeout = %v, want %v", handler.defaultRunTimeout, defTimeout)
 	}

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -106,7 +106,7 @@ func TestConvoyHandler_RendersTemplate(t *testing.T) {
 		},
 	}
 
-	handler, err := NewConvoyHandler(mock, 8*time.Second)
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler() error = %v", err)
 	}
@@ -156,7 +156,7 @@ func TestConvoyHandler_LastActivityColors(t *testing.T) {
 				},
 			}
 
-			handler, err := NewConvoyHandler(mock, 8*time.Second)
+			handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 			if err != nil {
 				t.Fatalf("NewConvoyHandler() error = %v", err)
 			}
@@ -179,7 +179,7 @@ func TestConvoyHandler_EmptyConvoys(t *testing.T) {
 		Convoys: []ConvoyRow{},
 	}
 
-	handler, err := NewConvoyHandler(mock, 8*time.Second)
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler() error = %v", err)
 	}
@@ -204,7 +204,7 @@ func TestConvoyHandler_ContentType(t *testing.T) {
 		Convoys: []ConvoyRow{},
 	}
 
-	handler, err := NewConvoyHandler(mock, 8*time.Second)
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler() error = %v", err)
 	}
@@ -229,7 +229,7 @@ func TestConvoyHandler_MultipleConvoys(t *testing.T) {
 		},
 	}
 
-	handler, err := NewConvoyHandler(mock, 8*time.Second)
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler() error = %v", err)
 	}
@@ -258,7 +258,7 @@ func TestConvoyHandler_FetchConvoysError(t *testing.T) {
 		Error: errFetchFailed,
 	}
 
-	handler, err := NewConvoyHandler(mock, 8*time.Second)
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler() error = %v", err)
 	}
@@ -307,7 +307,7 @@ func TestConvoyHandler_MergeQueueRendering(t *testing.T) {
 		},
 	}
 
-	handler, err := NewConvoyHandler(mock, 8*time.Second)
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler() error = %v", err)
 	}
@@ -356,7 +356,7 @@ func TestConvoyHandler_EmptyMergeQueue(t *testing.T) {
 		MergeQueue: []MergeQueueRow{},
 	}
 
-	handler, err := NewConvoyHandler(mock, 8*time.Second)
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler() error = %v", err)
 	}
@@ -397,7 +397,7 @@ func TestConvoyHandler_PolecatWorkersRendering(t *testing.T) {
 		},
 	}
 
-	handler, err := NewConvoyHandler(mock, 8*time.Second)
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler() error = %v", err)
 	}
@@ -472,7 +472,7 @@ func TestConvoyHandler_WorkStatusRendering(t *testing.T) {
 				},
 			}
 
-			handler, err := NewConvoyHandler(mock, 8*time.Second)
+			handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 			if err != nil {
 				t.Fatalf("NewConvoyHandler() error = %v", err)
 			}
@@ -515,7 +515,7 @@ func TestConvoyHandler_ProgressBarRendering(t *testing.T) {
 		},
 	}
 
-	handler, err := NewConvoyHandler(mock, 8*time.Second)
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler() error = %v", err)
 	}
@@ -553,7 +553,7 @@ func TestConvoyHandler_HTMXAutoRefresh(t *testing.T) {
 		Convoys: []ConvoyRow{},
 	}
 
-	handler, err := NewConvoyHandler(mock, 8*time.Second)
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler() error = %v", err)
 	}
@@ -617,7 +617,7 @@ func TestConvoyHandler_FullDashboard(t *testing.T) {
 		},
 	}
 
-	handler, err := NewConvoyHandler(mock, 8*time.Second)
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler() error = %v", err)
 	}
@@ -695,7 +695,7 @@ func TestE2E_Server_FullDashboard(t *testing.T) {
 		},
 	}
 
-	handler, err := NewConvoyHandler(mock, 8*time.Second)
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler() error = %v", err)
 	}
@@ -778,7 +778,7 @@ func TestE2E_Server_ActivityColors(t *testing.T) {
 				},
 			}
 
-			handler, err := NewConvoyHandler(mock, 8*time.Second)
+			handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 			if err != nil {
 				t.Fatalf("NewConvoyHandler() error = %v", err)
 			}
@@ -810,7 +810,7 @@ func TestE2E_Server_MergeQueueEmpty(t *testing.T) {
 		Workers:   []WorkerRow{},
 	}
 
-	handler, err := NewConvoyHandler(mock, 8*time.Second)
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler() error = %v", err)
 	}
@@ -870,7 +870,7 @@ func TestE2E_Server_MergeQueueStatuses(t *testing.T) {
 				},
 			}
 
-			handler, err := NewConvoyHandler(mock, 8*time.Second)
+			handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 			if err != nil {
 				t.Fatalf("NewConvoyHandler() error = %v", err)
 			}
@@ -904,7 +904,7 @@ func TestE2E_Server_MergeQueueStatuses(t *testing.T) {
 func TestE2E_Server_HTMLStructure(t *testing.T) {
 	mock := &MockConvoyFetcher{Convoys: []ConvoyRow{}}
 
-	handler, err := NewConvoyHandler(mock, 8*time.Second)
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler() error = %v", err)
 	}
@@ -966,7 +966,7 @@ func TestE2E_Server_RefineryInPolecats(t *testing.T) {
 		},
 	}
 
-	handler, err := NewConvoyHandler(mock, 8*time.Second)
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler() error = %v", err)
 	}
@@ -1114,7 +1114,7 @@ func TestConvoyHandler_NonFatalErrors(t *testing.T) {
 		WorkersError:    errFetchFailed,
 	}
 
-	handler, err := NewConvoyHandler(mock, 8*time.Second)
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
 	if err != nil {
 		t.Fatalf("NewConvoyHandler() error = %v", err)
 	}

--- a/internal/web/setup.go
+++ b/internal/web/setup.go
@@ -15,36 +15,47 @@ import (
 )
 
 // SetupHandler handles the setup flow when no workspace exists.
-type SetupHandler struct{}
-
-// NewSetupHandler creates a new setup handler.
-func NewSetupHandler() *SetupHandler {
-	return &SetupHandler{}
+type SetupHandler struct {
+	csrfToken string
 }
 
-// ServeHTTP renders the setup page.
+// NewSetupHandler creates a new setup handler with the given CSRF token.
+func NewSetupHandler(csrfToken string) *SetupHandler {
+	return &SetupHandler{csrfToken: csrfToken}
+}
+
+// ServeHTTP renders the setup page with the CSRF token injected.
 func (h *SetupHandler) ServeHTTP(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, _ = w.Write([]byte(setupHTML))
+	html := strings.Replace(setupHTML, "<!--CSRF_TOKEN-->", h.csrfToken, 1)
+	_, _ = w.Write([]byte(html))
 }
 
 // SetupAPIHandler handles API requests for setup operations.
-type SetupAPIHandler struct{}
+type SetupAPIHandler struct {
+	csrfToken string
+}
 
-// NewSetupAPIHandler creates a new setup API handler.
-func NewSetupAPIHandler() *SetupAPIHandler {
-	return &SetupAPIHandler{}
+// NewSetupAPIHandler creates a new setup API handler with the given CSRF token.
+func NewSetupAPIHandler(csrfToken string) *SetupAPIHandler {
+	return &SetupAPIHandler{csrfToken: csrfToken}
 }
 
 // ServeHTTP routes setup API requests.
 func (h *SetupAPIHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	w.Header().Set("Access-Control-Allow-Origin", "*")
-	w.Header().Set("Access-Control-Allow-Methods", "GET, POST, OPTIONS")
-	w.Header().Set("Access-Control-Allow-Headers", "Content-Type")
+	// No CORS headers — the setup page is served from the same origin.
 
 	if r.Method == http.MethodOptions {
-		w.WriteHeader(http.StatusOK)
+		w.WriteHeader(http.StatusNoContent)
 		return
+	}
+
+	// Validate CSRF token on all POST requests.
+	if r.Method == http.MethodPost && h.csrfToken != "" {
+		if r.Header.Get("X-Dashboard-Token") != h.csrfToken {
+			h.sendJSON(w, SetupResponse{Success: false, Message: "Invalid or missing dashboard token"})
+			return
+		}
 	}
 
 	path := strings.TrimPrefix(r.URL.Path, "/api")
@@ -389,8 +400,9 @@ func (h *SetupAPIHandler) sendJSON(w http.ResponseWriter, resp SetupResponse) {
 
 // NewSetupMux creates the HTTP handler for setup mode.
 func NewSetupMux() (http.Handler, error) {
-	setupHandler := NewSetupHandler()
-	apiHandler := NewSetupAPIHandler()
+	csrfToken := generateCSRFToken()
+	setupHandler := NewSetupHandler(csrfToken)
+	apiHandler := NewSetupAPIHandler(csrfToken)
 
 	mux := http.NewServeMux()
 	mux.Handle("/api/", apiHandler)
@@ -404,6 +416,7 @@ const setupHTML = `<!DOCTYPE html>
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="dashboard-token" content="<!--CSRF_TOKEN-->">
     <title>Gas Town Setup</title>
     <style>
         :root {
@@ -798,6 +811,21 @@ const setupHTML = `<!DOCTYPE html>
     </div>
 
     <script>
+        // CSRF protection: inject token into all POST requests
+        (function() {
+            var orig = window.fetch;
+            var meta = document.querySelector('meta[name="dashboard-token"]');
+            var token = meta ? meta.getAttribute('content') : '';
+            window.fetch = function(url, opts) {
+                opts = opts || {};
+                if (opts.method && opts.method.toUpperCase() === 'POST' && token) {
+                    opts.headers = opts.headers || {};
+                    opts.headers['X-Dashboard-Token'] = token;
+                }
+                return orig.call(this, url, opts);
+            };
+        })();
+
         var workspacePath = '';
 
         function showMode(mode) {

--- a/internal/web/static/dashboard.js
+++ b/internal/web/static/dashboard.js
@@ -2,6 +2,22 @@
     'use strict';
 
     // ============================================
+    // CSRF PROTECTION
+    // ============================================
+    // Inject dashboard token into all POST requests to prevent cross-site request forgery.
+    var _origFetch = window.fetch;
+    var _csrfMeta = document.querySelector('meta[name="dashboard-token"]');
+    var _csrfToken = _csrfMeta ? _csrfMeta.getAttribute('content') : '';
+    window.fetch = function(url, opts) {
+        opts = opts || {};
+        if (opts.method && opts.method.toUpperCase() === 'POST' && _csrfToken) {
+            opts.headers = opts.headers || {};
+            opts.headers['X-Dashboard-Token'] = _csrfToken;
+        }
+        return _origFetch.call(this, url, opts);
+    };
+
+    // ============================================
     // SSE (Server-Sent Events) CONNECTION
     // ============================================
     window.sseConnected = false;
@@ -671,10 +687,16 @@
 
         showToast('info', 'Running...', 'gt ' + cmdName);
 
+        var payload = { command: cmdName };
+        // Include confirmed flag if the command requires server-side confirmation
+        if (matchedCmd && matchedCmd.confirm) {
+            payload.confirmed = true;
+        }
+
         fetch('/api/run', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ command: cmdName })
+            body: JSON.stringify(payload)
         })
         .then(function(r) { return r.json(); })
         .then(function(data) {
@@ -1186,7 +1208,7 @@
         fetch('/api/run', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ command: 'hook detach ' + beadId })
+            body: JSON.stringify({ command: 'hook detach ' + beadId, confirmed: true })
         })
         .then(function(r) { return r.json(); })
         .then(function(data) {
@@ -1249,7 +1271,7 @@
         fetch('/api/run', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ command: 'hook attach ' + beadId })
+            body: JSON.stringify({ command: 'hook attach ' + beadId, confirmed: true })
         })
         .then(function(r) { return r.json(); })
         .then(function(data) {
@@ -1297,7 +1319,7 @@
             fetch('/api/run', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ command: 'hook detach ' + beadId })
+                body: JSON.stringify({ command: 'hook detach ' + beadId, confirmed: true })
             })
             .then(function(r) { return r.json(); })
             .then(function(data) {
@@ -1762,7 +1784,7 @@
         fetch('/api/run', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ command: cmd })
+            body: JSON.stringify({ command: cmd, confirmed: true })
         })
         .then(function(r) { return r.json(); })
         .then(function(data) {
@@ -1830,7 +1852,7 @@
         fetch('/api/run', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ command: cmd })
+            body: JSON.stringify({ command: cmd, confirmed: true })
         })
         .then(function(r) { return r.json(); })
         .then(function(data) {
@@ -2662,7 +2684,7 @@
         fetch('/api/run', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ command: cmd })
+            body: JSON.stringify({ command: cmd, confirmed: true })
         })
         .then(function(r) { return r.json(); })
         .then(function(data) {
@@ -2733,7 +2755,7 @@
         fetch('/api/run', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ command: cmdName })
+            body: JSON.stringify({ command: cmdName, confirmed: true })
         })
         .then(function(r) { return r.json(); })
         .then(function(data) {
@@ -2819,7 +2841,7 @@
             fetch('/api/run', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
-                body: JSON.stringify({ command: cmdName })
+                body: JSON.stringify({ command: cmdName, confirmed: true })
             })
             .then(function(r) { return r.json(); })
             .then(function(data) {

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -31,6 +31,7 @@ type ConvoyData struct {
 	Activity    []ActivityRow
 	Summary     *DashboardSummary
 	Expand      string // Panel to show fullscreen (from ?expand=name)
+	CSRFToken   string // Token for CSRF protection on POST requests
 }
 
 // RigRow represents a registered rig in the dashboard.

--- a/internal/web/templates/convoy.html
+++ b/internal/web/templates/convoy.html
@@ -3,6 +3,7 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta name="dashboard-token" content="{{.CSRFToken}}">
     <title>Gas Town Control Center</title>
     <script src="https://unpkg.com/htmx.org@1.9.10"></script>
     <script src="https://unpkg.com/idiomorph@0.3.0/dist/idiomorph-ext.min.js"></script>


### PR DESCRIPTION
## Summary

- Bind dashboard server to `127.0.0.1` instead of `0.0.0.0` to prevent remote network access
- Remove `Access-Control-Allow-Origin: *` CORS headers from all API and SSE endpoints
- Add per-session CSRF token (generated via `crypto/rand` at startup) validated on all POST requests via `X-Dashboard-Token` header
- Enforce server-side `Confirmed` check for commands marked `Confirm: true` in `AllowedCommands`, preventing automated execution of dangerous commands even if other protections are bypassed

The CSRF token is embedded in the HTML via a `<meta name="dashboard-token">` tag and sent automatically by a `fetch()` interceptor in both the main dashboard JS and setup page JS.

## Testing Done

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] All existing `internal/web` tests pass (12 files changed, test signatures updated)
- [x] New test: `TestAPIHandler_Run_MissingCSRFToken` — POST without token returns 403
- [x] New test: `TestAPIHandler_Run_WrongCSRFToken` — POST with wrong token returns 403
- [x] New test: `TestAPIHandler_Run_ConfirmRequired` — confirm command without `confirmed: true` returns 403