### PR TITLE
fix(multi-town): isolate tmux sockets per town and validate Dolt ports

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -22,6 +22,7 @@ import (
 	convoyops "github.com/steveyegge/gastown/internal/convoy"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/style"
+	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/tui/convoy"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
@@ -1361,7 +1362,7 @@ func isReadyIssue(t trackedIssueInfo, scheduledSet map[string]bool) bool {
 	}
 
 	// Check if tmux session exists
-	checkCmd := exec.Command("tmux", "has-session", "-t", sessionName)
+	checkCmd := tmux.BuildCommand("has-session", "-t", sessionName)
 	if err := checkCmd.Run(); err != nil {
 		// Session doesn't exist = orphaned molecule or dead worker
 		// This is the key fix: issues with in_progress/hooked status but

--- a/internal/cmd/costs.go
+++ b/internal/cmd/costs.go
@@ -841,7 +841,7 @@ func extractCostFromWorkDir(workDir string) (float64, error) {
 
 // getTmuxSessionWorkDir gets the current working directory of a tmux session.
 func getTmuxSessionWorkDir(session string) (string, error) {
-	cmd := exec.Command("tmux", "display-message", "-t", session, "-p", "#{pane_current_path}")
+	cmd := tmux.BuildCommand("display-message", "-t", session, "-p", "#{pane_current_path}")
 	output, err := cmd.Output()
 	if err != nil {
 		return "", err
@@ -1115,7 +1115,7 @@ func deriveSessionName() string {
 // Note: We don't check TMUX env var because it may not be inherited when Claude Code
 // runs bash commands, even though we are inside a tmux session.
 func detectCurrentTmuxSession() string {
-	cmd := exec.Command("tmux", "display-message", "-p", "#S")
+	cmd := tmux.BuildCommand("display-message", "-p", "#S")
 	output, err := cmd.Output()
 	if err != nil {
 		return ""

--- a/internal/cmd/cycle.go
+++ b/internal/cmd/cycle.go
@@ -2,11 +2,11 @@ package cmd
 
 import (
 	"fmt"
-	"os/exec"
 	"sort"
 
 	"github.com/spf13/cobra"
 	sessionpkg "github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/tmux"
 )
 
 // cycleSession is the --session flag for cycle next/prev commands.
@@ -185,13 +185,12 @@ func cycleInGroup(direction int, currentSession string, sessions []string) error
 		return nil // Only one session
 	}
 
-	args := []string{"-u", "switch-client"}
+	args := []string{"switch-client"}
 	if cycleClientTarget != "" {
 		args = append(args, "-c", cycleClientTarget)
 	}
 	args = append(args, "-t", sessions[targetIdx])
-	cmd := exec.Command("tmux", args...)
-	return cmd.Run()
+	return tmux.BuildCommand(args...).Run()
 }
 
 // cycleRigInfraSession cycles between witness and refinery sessions for a rig.
@@ -216,7 +215,7 @@ func cycleRigInfraSession(direction int, currentSession, rig string) error {
 
 // listTmuxSessions returns all tmux session names.
 func listTmuxSessions() ([]string, error) {
-	out, err := exec.Command("tmux", "list-sessions", "-F", "#{session_name}").Output()
+	out, err := tmux.BuildCommand("list-sessions", "-F", "#{session_name}").Output()
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -107,7 +107,7 @@ Examples:
 }
 
 var (
-	daemonLogLines int
+	daemonLogLines  int
 	daemonLogFollow bool
 )
 
@@ -222,6 +222,7 @@ func runDaemonStatus(cmd *cobra.Command, args []string) error {
 			style.Bold.Render("●"),
 			style.Bold.Render("running"),
 			pid)
+		fmt.Printf("  Town: %s\n", townRoot)
 
 		// Load state for more details
 		state, err := daemon.LoadState(townRoot)

--- a/internal/cmd/feed.go
+++ b/internal/cmd/feed.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	tea "github.com/charmbracelet/bubbletea"
@@ -355,7 +354,7 @@ func runFeedInWindow(workDir string, bdArgs []string) error {
 // windowExists checks if a window with the given name exists in the session.
 // Note: getCurrentTmuxSession is defined in handoff.go
 func windowExists(_ *tmux.Tmux, session, windowName string) (bool, error) { // t unused: direct exec for simplicity
-	cmd := exec.Command("tmux", "list-windows", "-t", session, "-F", "#{window_name}")
+	cmd := tmux.BuildCommand("list-windows", "-t", session, "-F", "#{window_name}")
 	out, err := cmd.Output()
 	if err != nil {
 		return false, err
@@ -372,12 +371,12 @@ func windowExists(_ *tmux.Tmux, session, windowName string) (bool, error) { // t
 // createWindow creates a new tmux window with the given name and command.
 func createWindow(_ *tmux.Tmux, session, windowName, workDir, command string) error { // t unused: direct exec for simplicity
 	args := []string{"new-window", "-t", session, "-n", windowName, "-c", workDir, command}
-	cmd := exec.Command("tmux", args...)
+	cmd := tmux.BuildCommand(args...)
 	return cmd.Run()
 }
 
 // selectWindow switches to the specified window.
 func selectWindow(_ *tmux.Tmux, target string) error { // t unused: direct exec for simplicity
-	cmd := exec.Command("tmux", "select-window", "-t", target)
+	cmd := tmux.BuildCommand("select-window", "-t", target)
 	return cmd.Run()
 }

--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -512,7 +512,7 @@ func runHandoffCycle() error {
 
 // getCurrentTmuxSession returns the current tmux session name.
 func getCurrentTmuxSession() (string, error) {
-	out, err := exec.Command("tmux", "display-message", "-p", "#{session_name}").Output()
+	out, err := tmux.BuildCommand("display-message", "-p", "#{session_name}").Output()
 	if err != nil {
 		return "", err
 	}
@@ -1031,7 +1031,7 @@ func handoffRemoteSession(t *tmux.Tmux, targetSession, restartCmd string) error 
 	if handoffWatch {
 		fmt.Printf("Switching to %s...\n", targetSession)
 		// Use tmux switch-client to move our view to the target session
-		if err := exec.Command("tmux", "-u", "switch-client", "-t", targetSession).Run(); err != nil {
+		if err := tmux.BuildCommand("switch-client", "-t", targetSession).Run(); err != nil {
 			// Non-fatal - they can manually switch
 			fmt.Printf("Note: Could not auto-switch (use: tmux switch-client -t %s)\n", targetSession)
 		}
@@ -1043,7 +1043,7 @@ func handoffRemoteSession(t *tmux.Tmux, targetSession, restartCmd string) error 
 // getSessionPane returns the pane identifier for a session's main pane.
 func getSessionPane(sessionName string) (string, error) {
 	// Get the pane ID for the first pane in the session
-	out, err := exec.Command("tmux", "list-panes", "-t", sessionName, "-F", "#{pane_id}").Output()
+	out, err := tmux.BuildCommand("list-panes", "-t", sessionName, "-F", "#{pane_id}").Output()
 	if err != nil {
 		return "", err
 	}

--- a/internal/cmd/helpers.go
+++ b/internal/cmd/helpers.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/style"
+	"github.com/steveyegge/gastown/internal/tmux"
 )
 
 // inferRigFromCwd tries to determine the rig from the current directory.
@@ -64,7 +65,7 @@ func isInTmuxSession(targetSession string) bool {
 	}
 
 	// Get current session name
-	cmd := exec.Command("tmux", "display-message", "-p", "#{session_name}")
+	cmd := tmux.BuildCommand("display-message", "-p", "#{session_name}")
 	out, err := cmd.Output()
 	if err != nil {
 		return false
@@ -72,6 +73,26 @@ func isInTmuxSession(targetSession string) bool {
 
 	currentSession := strings.TrimSpace(string(out))
 	return currentSession == targetSession
+}
+
+// isInSameTmuxSocket checks if we're inside a tmux session on the same socket
+// as the current town. Used to decide between switch-client and attach-session.
+func isInSameTmuxSocket() bool {
+	tmuxEnv := os.Getenv("TMUX")
+	if tmuxEnv == "" {
+		return false
+	}
+	// TMUX format: /tmp/tmux-UID/socketname,pid,index
+	// Extract socket name from path
+	parts := strings.SplitN(tmuxEnv, ",", 2)
+	socketPath := parts[0]
+	currentSocket := filepath.Base(socketPath)
+
+	targetSocket := tmux.GetDefaultSocket()
+	if targetSocket == "" {
+		targetSocket = "default"
+	}
+	return currentSocket == targetSocket
 }
 
 // attachToTmuxSession attaches to a tmux session.
@@ -85,14 +106,19 @@ func attachToTmuxSession(sessionID string) error {
 		return fmt.Errorf("tmux not found: %w", err)
 	}
 
-	// Build args with -u for UTF-8 support
+	// Base args with UTF-8 and socket support
+	baseArgs := []string{"tmux", "-u"}
+	if socket := tmux.GetDefaultSocket(); socket != "" {
+		baseArgs = append(baseArgs, "-L", socket)
+	}
+
 	var args []string
-	if os.Getenv("TMUX") != "" {
-		// Inside tmux: switch to the target session
-		args = []string{"tmux", "-u", "switch-client", "-t", sessionID}
+	if isInSameTmuxSocket() {
+		// Same tmux socket: switch to the target session
+		args = append(baseArgs, "switch-client", "-t", sessionID)
 	} else {
-		// Outside tmux: attach to the session
-		args = []string{"tmux", "-u", "attach-session", "-t", sessionID}
+		// Outside tmux or different socket: attach to the session
+		args = append(baseArgs, "attach-session", "-t", sessionID)
 	}
 
 	// Replace the Go process with tmux for direct terminal control

--- a/internal/cmd/mayor.go
+++ b/internal/cmd/mayor.go
@@ -281,6 +281,13 @@ func runMayorRestart(cmd *cobra.Command, args []string) error {
 // to the Mayor session. Warns and auto-starts each if absent. Non-fatal:
 // failures are reported but do not block the attach.
 func ensureMayorInfra(townRoot string) {
+	// Load daemon.json env vars (e.g., GT_DOLT_PORT) so Dolt uses the right port.
+	if patrolCfg := daemon.LoadPatrolConfig(townRoot); patrolCfg != nil {
+		for k, v := range patrolCfg.Env {
+			os.Setenv(k, v)
+		}
+	}
+
 	// Daemon
 	daemonRunning, _, _ := daemon.IsRunning(townRoot)
 	if !daemonRunning {
@@ -302,7 +309,7 @@ func ensureMayorInfra(townRoot string) {
 				if err := doltserver.Start(townRoot); err != nil {
 					style.PrintWarning("Dolt server start failed: %v", err)
 				} else {
-					fmt.Printf("  %s Dolt server started (port %d)\n", style.Bold.Render("✓"), doltserver.DefaultPort)
+					fmt.Printf("  %s Dolt server started (port %d)\n", style.Bold.Render("✓"), doltCfg.Port)
 				}
 			}
 		}

--- a/internal/cmd/scheduler.go
+++ b/internal/cmd/scheduler.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -13,6 +12,7 @@ import (
 	"github.com/steveyegge/gastown/internal/scheduler/capacity"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/style"
+	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
 
@@ -475,7 +475,7 @@ func beadsSearchDirs(townRoot string) []string {
 
 // countActivePolecats counts all running polecats across all rigs in the town.
 func countActivePolecats() int {
-	listCmd := exec.Command("tmux", "list-sessions", "-F", "#{session_name}")
+	listCmd := tmux.BuildCommand("list-sessions", "-F", "#{session_name}")
 	out, err := listCmd.Output()
 	if err != nil {
 		return 0

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -353,7 +353,7 @@ func injectStartPrompt(pane, beadID, subject, args string) error {
 func getSessionFromPane(pane string) string {
 	if strings.HasPrefix(pane, "%") {
 		// Pane ID format - query tmux for the session
-		cmd := exec.Command("tmux", "display-message", "-t", pane, "-p", "#{session_name}")
+		cmd := tmux.BuildCommand("display-message", "-t", pane, "-p", "#{session_name}")
 		out, err := cmd.Output()
 		if err != nil {
 			return ""
@@ -430,7 +430,7 @@ func ensureAgentReady(sessionName string) error {
 
 // isSessionYoung returns true if the tmux session was created less than maxAge ago.
 func isSessionYoung(sessionName string, maxAge time.Duration) bool {
-	out, err := exec.Command("tmux", "display-message", "-t", sessionName, "-p", "#{session_created}").Output()
+	out, err := tmux.BuildCommand("display-message", "-t", sessionName, "-p", "#{session_created}").Output()
 	if err != nil {
 		return false
 	}

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -18,6 +18,8 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/crew"
+	"github.com/steveyegge/gastown/internal/daemon"
+	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/mail"
 	"github.com/steveyegge/gastown/internal/rig"
@@ -62,9 +64,37 @@ type TownStatus struct {
 	Name     string         `json:"name"`
 	Location string         `json:"location"`
 	Overseer *OverseerInfo  `json:"overseer,omitempty"` // Human operator
+	Daemon   *ServiceInfo   `json:"daemon,omitempty"`   // Daemon status
+	Dolt     *DoltInfo      `json:"dolt,omitempty"`     // Dolt server status
+	Tmux     *TmuxInfo      `json:"tmux,omitempty"`     // Tmux server status
 	Agents   []AgentRuntime `json:"agents"`             // Global agents (Mayor, Deacon)
 	Rigs     []RigStatus    `json:"rigs"`
 	Summary  StatusSum      `json:"summary"`
+}
+
+// ServiceInfo represents a background service status.
+type ServiceInfo struct {
+	Running bool `json:"running"`
+	PID     int  `json:"pid,omitempty"`
+}
+
+// DoltInfo represents the Dolt server status.
+type DoltInfo struct {
+	Running       bool   `json:"running"`
+	PID           int    `json:"pid,omitempty"`
+	Port          int    `json:"port"`
+	Remote        bool   `json:"remote,omitempty"`
+	DataDir       string `json:"data_dir,omitempty"`
+	PortConflict  bool   `json:"port_conflict,omitempty"`   // Port taken by another town's Dolt
+	ConflictOwner string `json:"conflict_owner,omitempty"`  // --data-dir of the process holding the port
+}
+
+// TmuxInfo represents the tmux server status.
+type TmuxInfo struct {
+	Socket       string `json:"socket"`                  // Socket name (e.g., "mytown" or "default")
+	SocketPath   string `json:"socket_path,omitempty"`   // Full socket path
+	Running      bool   `json:"running"`                 // Is the tmux server running?
+	SessionCount int    `json:"session_count"`            // Number of sessions
 }
 
 // OverseerInfo represents the human operator's identity and status.
@@ -742,6 +772,51 @@ func gatherStatus() (TownStatus, error) {
 		Rigs:     make([]RigStatus, len(rigs)),
 	}
 
+	// Daemon status
+	if daemonRunning, daemonPid, err := daemon.IsRunning(townRoot); err == nil {
+		status.Daemon = &ServiceInfo{Running: daemonRunning, PID: daemonPid}
+	}
+
+	// Dolt status
+	doltCfg := doltserver.DefaultConfig(townRoot)
+	if doltCfg.IsRemote() {
+		status.Dolt = &DoltInfo{Remote: true, Port: doltCfg.Port}
+	} else {
+		doltRunning, doltPid, _ := doltserver.IsRunning(townRoot)
+		doltInfo := &DoltInfo{
+			Running: doltRunning,
+			PID:     doltPid,
+			Port:    doltCfg.Port,
+			DataDir: doltCfg.DataDir,
+		}
+		// Check if port is held by another town's Dolt
+		if !doltRunning {
+			if conflictPid, conflictDir := doltserver.CheckPortConflict(townRoot); conflictPid > 0 {
+				doltInfo.PortConflict = true
+				doltInfo.ConflictOwner = conflictDir
+			}
+		}
+		status.Dolt = doltInfo
+	}
+
+	// Tmux status
+	socket := tmux.GetDefaultSocket()
+	socketLabel := "default"
+	if socket != "" {
+		socketLabel = socket
+	}
+	tmuxInfo := &TmuxInfo{
+		Socket:       socketLabel,
+		SessionCount: len(allSessions),
+		Running:      len(allSessions) > 0,
+	}
+	// Resolve socket path: /tmp/tmux-<UID>/<socket>
+	tmuxInfo.SocketPath = filepath.Join(os.TempDir(), fmt.Sprintf("tmux-%d", os.Getuid()), socketLabel)
+	if _, err := os.Stat(tmuxInfo.SocketPath); err == nil {
+		tmuxInfo.Running = true
+	}
+	status.Tmux = tmuxInfo
+
 	var wg sync.WaitGroup
 
 	// Fetch global agents in parallel with rig discovery
@@ -861,6 +936,39 @@ func outputStatusText(w io.Writer, status TownStatus) error {
 		if status.Overseer.UnreadMail > 0 {
 			fmt.Fprintf(w, "   📬 %d unread\n", status.Overseer.UnreadMail)
 		}
+		fmt.Fprintln(w)
+	}
+
+	// Infrastructure services
+	if status.Daemon != nil || status.Dolt != nil || status.Tmux != nil {
+		fmt.Fprintf(w, "%s ", style.Bold.Render("Services:"))
+		var parts []string
+		if status.Daemon != nil {
+			if status.Daemon.Running {
+				parts = append(parts, fmt.Sprintf("daemon %s", style.Dim.Render(fmt.Sprintf("(PID %d)", status.Daemon.PID))))
+			} else {
+				parts = append(parts, fmt.Sprintf("daemon %s", style.Dim.Render("(stopped)")))
+			}
+		}
+		if status.Dolt != nil {
+			if status.Dolt.Remote {
+				parts = append(parts, fmt.Sprintf("dolt %s", style.Dim.Render(fmt.Sprintf("(remote :%d)", status.Dolt.Port))))
+			} else if status.Dolt.Running {
+				parts = append(parts, fmt.Sprintf("dolt %s", style.Dim.Render(fmt.Sprintf("(PID %d, :%d)", status.Dolt.PID, status.Dolt.Port))))
+			} else if status.Dolt.PortConflict {
+				parts = append(parts, fmt.Sprintf("dolt %s", style.Bold.Render(fmt.Sprintf("(stopped, :%d ⚠ port used by %s)", status.Dolt.Port, status.Dolt.ConflictOwner))))
+			} else {
+				parts = append(parts, fmt.Sprintf("dolt %s", style.Dim.Render(fmt.Sprintf("(stopped, :%d)", status.Dolt.Port))))
+			}
+		}
+		if status.Tmux != nil {
+			if status.Tmux.Running {
+				parts = append(parts, fmt.Sprintf("tmux %s", style.Dim.Render(fmt.Sprintf("(-L %s, %d sessions)", status.Tmux.Socket, status.Tmux.SessionCount))))
+			} else {
+				parts = append(parts, fmt.Sprintf("tmux %s", style.Dim.Render(fmt.Sprintf("(-L %s, no server)", status.Tmux.Socket))))
+			}
+		}
+		fmt.Fprintf(w, "%s\n", strings.Join(parts, "  "))
 		fmt.Fprintln(w)
 	}
 

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -153,6 +153,14 @@ func runUp(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a Gas Town workspace: %w", err)
 	}
 
+	// Load daemon.json env vars so services (Dolt, etc.) use the right config.
+	// The daemon does this too, but gt up starts services before the daemon.
+	if patrolCfg := daemon.LoadPatrolConfig(townRoot); patrolCfg != nil {
+		for k, v := range patrolCfg.Env {
+			os.Setenv(k, v)
+		}
+	}
+
 	allOK := true
 	var services []ServiceStatus
 
@@ -190,7 +198,7 @@ func runUp(cmd *cobra.Command, args []string) error {
 			doltDetail = err.Error()
 		} else {
 			doltOK = true
-			doltDetail = fmt.Sprintf("started (port %d)", doltserver.DefaultPort)
+			doltDetail = fmt.Sprintf("started (port %d)", cfg.Port)
 		}
 	}()
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -127,6 +127,11 @@ func New(config *Config) (*Daemon, error) {
 	patrolConfig := LoadPatrolConfig(config.TownRoot)
 	if patrolConfig != nil {
 		logger.Printf("Loaded patrol config from %s", PatrolConfigFile(config.TownRoot))
+		// Propagate env vars from daemon.json to this process and all spawned sessions.
+		for k, v := range patrolConfig.Env {
+			os.Setenv(k, v)
+			logger.Printf("Set env %s=%s from daemon.json", k, v)
+		}
 	}
 
 	// Initialize Dolt server manager if configured

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -143,10 +143,14 @@ type DoltRemotesConfig struct {
 
 // DaemonPatrolConfig is the structure of mayor/daemon.json.
 type DaemonPatrolConfig struct {
-	Type      string         `json:"type"`
-	Version   int            `json:"version"`
-	Heartbeat *PatrolConfig  `json:"heartbeat,omitempty"`
-	Patrols   *PatrolsConfig `json:"patrols,omitempty"`
+	Type      string            `json:"type"`
+	Version   int               `json:"version"`
+	Heartbeat *PatrolConfig     `json:"heartbeat,omitempty"`
+	Patrols   *PatrolsConfig    `json:"patrols,omitempty"`
+	// Env holds environment variables to set at startup.
+	// Propagated to all sessions spawned by the daemon and read by gt up/mayor attach.
+	// Example: {"GT_DOLT_PORT": "43211"}
+	Env       map[string]string `json:"env,omitempty"`
 }
 
 // PatrolConfigFile returns the path to the patrol config file.

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -375,11 +375,16 @@ func IsRunning(townRoot string) (bool, int, error) {
 		_ = os.Remove(config.PidFile)
 	}
 
-	// No valid PID file - check if port is in use by dolt anyway
-	// This catches externally-started dolt servers
+	// No valid PID file - check if port is in use by dolt anyway.
+	// This catches externally-started dolt servers.
+	// Verify --data-dir matches this town to avoid claiming another town's Dolt.
 	pid := findDoltServerOnPort(config.Port)
 	if pid > 0 {
-		return true, pid, nil
+		processDataDir := getProcessDataDir(pid)
+		if processDataDir == "" || processDataDir == config.DataDir {
+			return true, pid, nil
+		}
+		// Port is used by a different town's Dolt — not ours
 	}
 
 	return false, 0, nil
@@ -508,6 +513,25 @@ func hasServerMode(beadsDir string) bool {
 		return false
 	}
 	return metadata.DoltMode == "server"
+}
+
+// CheckPortConflict checks if the configured port is occupied by another town's Dolt.
+// Returns (conflicting PID, conflicting data-dir) if a foreign Dolt holds the port,
+// or (0, "") if the port is free or used by this town's own Dolt.
+func CheckPortConflict(townRoot string) (int, string) {
+	cfg := DefaultConfig(townRoot)
+	if cfg.IsRemote() {
+		return 0, ""
+	}
+	pid := findDoltServerOnPort(cfg.Port)
+	if pid <= 0 {
+		return 0, ""
+	}
+	dataDir := getProcessDataDir(pid)
+	if dataDir == "" || dataDir == cfg.DataDir {
+		return 0, "" // It's ours or unknown
+	}
+	return pid, dataDir
 }
 
 // findDoltServerOnPort finds a dolt sql-server process listening on the given port.
@@ -689,6 +713,28 @@ func KillImposters(townRoot string) error {
 	return nil
 }
 
+// checkPortAvailable verifies a TCP port is free before starting the server.
+// Returns a user-friendly error if the port is already in use, which commonly
+// happens when multiple Gas Town instances share the same Dolt port.
+func checkPortAvailable(port int) error {
+	ln, err := net.Listen("tcp", fmt.Sprintf("127.0.0.1:%d", port))
+	if err != nil {
+		// Try to identify who holds the port
+		detail := ""
+		if pid := findDoltServerOnPort(port); pid > 0 {
+			if dataDir := getProcessDataDir(pid); dataDir != "" {
+				detail = fmt.Sprintf("\nPort is held by dolt PID %d serving %s", pid, dataDir)
+			}
+		}
+		return fmt.Errorf("port %d is already in use.%s\n"+
+			"If you're running multiple Gas Town instances, each needs a unique Dolt port.\n"+
+			"Set GT_DOLT_PORT in mayor/daemon.json env section:\n"+
+			"  {\"env\": {\"GT_DOLT_PORT\": \"<port>\"}}", port, detail)
+	}
+	_ = ln.Close()
+	return nil
+}
+
 // Start starts the Dolt SQL server.
 func Start(townRoot string) error {
 	config := DefaultConfig(townRoot)
@@ -794,6 +840,12 @@ func Start(townRoot string) error {
 	logFile, err := os.OpenFile(config.LogFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
 		return fmt.Errorf("opening log file: %w", err)
+	}
+
+	// Validate port is available before starting (catches multi-town port conflicts)
+	if err := checkPortAvailable(config.Port); err != nil {
+		logFile.Close()
+		return err
 	}
 
 	// Start dolt sql-server with --data-dir to serve all databases

--- a/internal/doltserver/port_test.go
+++ b/internal/doltserver/port_test.go
@@ -1,0 +1,37 @@
+package doltserver
+
+import (
+	"net"
+	"testing"
+)
+
+func TestCheckPortAvailable_Free(t *testing.T) {
+	// Use port 0 to get an ephemeral port that's guaranteed free
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	port := ln.Addr().(*net.TCPAddr).Port
+	ln.Close()
+
+	// Port should be free now
+	if err := checkPortAvailable(port); err != nil {
+		t.Errorf("checkPortAvailable(%d) returned error for free port: %v", port, err)
+	}
+}
+
+func TestCheckPortAvailable_InUse(t *testing.T) {
+	// Bind a port
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	// Should fail since port is in use
+	if err := checkPortAvailable(port); err == nil {
+		t.Errorf("checkPortAvailable(%d) returned nil for in-use port", port)
+	}
+}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -8,7 +8,6 @@ import (
 	"fmt"
 	"math/rand/v2"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -1863,7 +1862,7 @@ func (m *Manager) DetectStalePolecats(threshold int) ([]*StalenessInfo, error) {
 // checkTmuxSession checks if a tmux session exists.
 func checkTmuxSession(sessionName string) bool {
 	// Use has-session command which returns 0 if session exists
-	cmd := exec.Command("tmux", "has-session", "-t", sessionName) //nolint:gosec // G204: sessionName is constructed internally
+	cmd := tmux.BuildCommand("has-session", "-t", sessionName)
 	return cmd.Run() == nil
 }
 

--- a/internal/session/registry_socket_test.go
+++ b/internal/session/registry_socket_test.go
@@ -1,0 +1,30 @@
+package session
+
+import "testing"
+
+func TestSanitizeTownName(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"mytown", "mytown"},
+		{"MyTown", "mytown"},
+		{"my town", "my-town"},
+		{"my_town!", "my-town"},
+		{"  spaces  ", "spaces"},
+		{"My-Town-123", "my-town-123"},
+		{"café", "caf"},
+		{"", "default"},
+		{"!!!!", "default"},
+		{"a/b/c", "a-b-c"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got := sanitizeTownName(tt.input)
+			if got != tt.want {
+				t.Errorf("sanitizeTownName(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/tmux/socket_test.go
+++ b/internal/tmux/socket_test.go
@@ -1,0 +1,78 @@
+package tmux
+
+import (
+	"testing"
+)
+
+func TestSetGetDefaultSocket(t *testing.T) {
+	// Save and restore
+	orig := defaultSocket
+	defer func() { defaultSocket = orig }()
+
+	// Initially empty
+	SetDefaultSocket("")
+	if got := GetDefaultSocket(); got != "" {
+		t.Errorf("expected empty, got %q", got)
+	}
+
+	SetDefaultSocket("mytown")
+	if got := GetDefaultSocket(); got != "mytown" {
+		t.Errorf("expected %q, got %q", "mytown", got)
+	}
+}
+
+func TestNewTmuxInheritsSocket(t *testing.T) {
+	orig := defaultSocket
+	defer func() { defaultSocket = orig }()
+
+	SetDefaultSocket("testtown")
+	tmx := NewTmux()
+	if tmx.socketName != "testtown" {
+		t.Errorf("NewTmux() socketName = %q, want %q", tmx.socketName, "testtown")
+	}
+}
+
+func TestNewTmuxWithSocket(t *testing.T) {
+	tmx := NewTmuxWithSocket("custom")
+	if tmx.socketName != "custom" {
+		t.Errorf("NewTmuxWithSocket() socketName = %q, want %q", tmx.socketName, "custom")
+	}
+}
+
+func TestBuildCommandNoSocket(t *testing.T) {
+	orig := defaultSocket
+	defer func() { defaultSocket = orig }()
+
+	SetDefaultSocket("")
+	cmd := BuildCommand("list-sessions")
+	args := cmd.Args
+	// Should be: tmux -u list-sessions
+	expected := []string{"tmux", "-u", "list-sessions"}
+	if len(args) != len(expected) {
+		t.Fatalf("args = %v, want %v", args, expected)
+	}
+	for i, a := range args {
+		if a != expected[i] {
+			t.Errorf("args[%d] = %q, want %q", i, a, expected[i])
+		}
+	}
+}
+
+func TestBuildCommandWithSocket(t *testing.T) {
+	orig := defaultSocket
+	defer func() { defaultSocket = orig }()
+
+	SetDefaultSocket("mytown")
+	cmd := BuildCommand("has-session", "-t", "hq-mayor")
+	args := cmd.Args
+	// Should be: tmux -u -L mytown has-session -t hq-mayor
+	expected := []string{"tmux", "-u", "-L", "mytown", "has-session", "-t", "hq-mayor"}
+	if len(args) != len(expected) {
+		t.Fatalf("args = %v, want %v", args, expected)
+	}
+	for i, a := range args {
+		if a != expected[i] {
+			t.Errorf("args[%d] = %q, want %q", i, a, expected[i])
+		}
+	}
+}

--- a/internal/tui/feed/model.go
+++ b/internal/tui/feed/model.go
@@ -11,6 +11,7 @@ import (
 	"github.com/charmbracelet/bubbles/viewport"
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/tmux"
 )
 
 // Panel represents which panel has focus
@@ -611,10 +612,10 @@ func (m *Model) attachToSelected() (tea.Model, tea.Cmd) {
 	var c *exec.Cmd
 	if os.Getenv("TMUX") != "" {
 		// Inside tmux: switch the current client to the target session
-		c = exec.Command("tmux", "switch-client", "-t", agent.SessionID)
+		c = tmux.BuildCommand("switch-client", "-t", agent.SessionID)
 	} else {
 		// Outside tmux: attach to the session
-		c = exec.Command("tmux", "attach-session", "-t", agent.SessionID)
+		c = tmux.BuildCommand("attach-session", "-t", agent.SessionID)
 	}
 	return m, tea.Sequence(
 		tea.ExitAltScreen,

--- a/internal/util/orphan.go
+++ b/internal/util/orphan.go
@@ -12,6 +12,8 @@ import (
 	"strings"
 	"syscall"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/tmux"
 )
 
 // minOrphanAge is the minimum age (in seconds) a process must be before
@@ -31,7 +33,7 @@ func getTmuxSessionPIDs() map[int]bool {
 	pids := make(map[int]bool)
 
 	// Get list of ALL tmux sessions (not just gt-*/hq-*)
-	out, err := exec.Command("tmux", "list-sessions", "-F", "#{session_name}").Output()
+	out, err := tmux.BuildCommand("list-sessions", "-F", "#{session_name}").Output()
 	if err != nil {
 		return pids // tmux not available or no sessions
 	}
@@ -44,7 +46,7 @@ func getTmuxSessionPIDs() map[int]bool {
 		if session == "" {
 			continue
 		}
-		out, err := exec.Command("tmux", "list-panes", "-t", session, "-F", "#{pane_pid}").Output()
+		out, err := tmux.BuildCommand("list-panes", "-t", session, "-F", "#{pane_pid}").Output()
 		if err != nil {
 			continue
 		}
@@ -482,7 +484,7 @@ func FindZombieClaudeProcesses() ([]ZombieProcess, error) {
 	// Returning empty is safer than marking all Claude processes as zombies.
 	if len(validPIDs) == 0 {
 		// Check if tmux is even running
-		if err := exec.Command("tmux", "list-sessions").Run(); err != nil {
+		if err := tmux.BuildCommand("list-sessions").Run(); err != nil {
 			return nil, fmt.Errorf("tmux not available: %w", err)
 		}
 		// tmux is running but no gt-*/hq-* sessions - that's a valid state,


### PR DESCRIPTION
## Summary

- **Tmux socket isolation**: each town now uses its own tmux socket (`tmux -L <townname>`), so `gt mayor attach` connects to the correct instance when multiple towns run on the same machine
- **Dolt port validation**: `Start()` checks port availability before launching, with clear error message pointing to `daemon.json` env config
- **daemon.json `env` propagation**: env vars (e.g. `GT_DOLT_PORT`) defined in `mayor/daemon.json` are now loaded by the daemon, `gt up`, and `gt mayor attach`
- **`gt status` enriched**: shows daemon, Dolt server, and tmux socket status with port conflict detection

## Changes

| Area | Details |
|---|---|
| `internal/tmux/tmux.go` | `socketName` field, `SetDefaultSocket`/`GetDefaultSocket`, `BuildCommand()`, `run()` injects `-L` |
| `internal/session/registry.go` | `InitRegistry()` sets tmux socket from town name via `sanitizeTownName()` |
| `internal/cmd/helpers.go` | `attachToTmuxSession()` uses socket, `isInSameTmuxSocket()` for switch vs attach |
| `internal/doltserver/doltserver.go` | `checkPortAvailable()`, `CheckPortConflict()`, `IsRunning()` cross-checks data-dir |
| `internal/daemon/daemon.go` + `types.go` | `Env` field on `DaemonPatrolConfig`, loaded at daemon startup |
| `internal/cmd/up.go`, `mayor.go` | Load `daemon.json` env vars before starting services |
| `internal/cmd/status.go` | Services line with daemon/dolt/tmux info |
| `internal/cmd/down.go` | `--nuke` targets per-town socket |
| 13 files | Migrated `exec.Command("tmux"...)` → `tmux.BuildCommand()` |

## What doesn't change

- Session names (`hq-mayor`, `gt-witness`, etc.) stay the same — isolation is at the socket level
- 221 existing `NewTmux()` call sites unchanged — they inherit the socket automatically

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/tmux/ ./internal/doltserver/ ./internal/session/` passes
- [ ] Manual: single-town behaves identically (socket = sanitized town name)
- [ ] Manual: two towns with different names → separate tmux sockets, `gt mayor attach` targets the correct one
- [ ] Manual: two towns on same Dolt port → clear error at startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)