### PR TITLE
perf(polecat): skip redundant git fetch when FETCH_HEAD is recent

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -10,6 +10,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 )
 
 // GitError contains raw output from a git command for agent observation.
@@ -394,6 +395,37 @@ func (g *Git) FetchBranchShallow(remote, branch string) error {
 	refspec := branch + ":refs/remotes/" + remote + "/" + branch
 	_, err := g.run("fetch", "--depth", "1", remote, refspec)
 	return err
+}
+
+// FetchIfStale fetches from the remote only if FETCH_HEAD is older than maxAge
+// (or missing). If a recent fetch has been done, it returns nil immediately.
+// This avoids redundant fetches during polecat spawn, which can take ~4.8s on
+// SSH remotes.
+func (g *Git) FetchIfStale(remote string, maxAge time.Duration) error {
+	// Determine the git directory to find FETCH_HEAD.
+	gitDir := g.gitDir
+	if gitDir == "" {
+		// Normal (non-bare) repo: ask git for its git dir.
+		dir, err := g.run("rev-parse", "--git-dir")
+		if err != nil {
+			// If we can't determine the git dir, fall through to fetch.
+			return g.Fetch(remote)
+		}
+		if filepath.IsAbs(dir) {
+			gitDir = dir
+		} else {
+			gitDir = filepath.Join(g.workDir, dir)
+		}
+	}
+
+	fetchHead := filepath.Join(gitDir, "FETCH_HEAD")
+	if info, err := os.Stat(fetchHead); err == nil {
+		if time.Since(info.ModTime()) < maxAge {
+			return nil
+		}
+	}
+
+	return g.Fetch(remote)
 }
 
 // Pull pulls from the remote branch.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -6,6 +6,7 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func initTestRepo(t *testing.T) string {
@@ -1552,5 +1553,149 @@ func TestClearPushURL(t *testing.T) {
 	// Clearing again should be a no-op (not an error)
 	if err := g.ClearPushURL("origin"); err != nil {
 		t.Errorf("ClearPushURL (idempotent) should not error, got: %v", err)
+	}
+}
+
+func TestFetchIfStale_FreshFetchHead_SkipsFetch(t *testing.T) {
+	localDir, _, _ := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+
+	// Write a fresh FETCH_HEAD (1 second old) so it appears recent.
+	fetchHead := filepath.Join(localDir, ".git", "FETCH_HEAD")
+	if err := os.WriteFile(fetchHead, []byte("# test\n"), 0644); err != nil {
+		t.Fatalf("write FETCH_HEAD: %v", err)
+	}
+	// Set mtime to a known time well within maxAge.
+	knownTime := time.Now().Add(-5 * time.Second)
+	if err := os.Chtimes(fetchHead, knownTime, knownTime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	// Record mtime before the call.
+	before, err := os.Stat(fetchHead)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
+
+	// FetchIfStale with 60s maxAge should skip the fetch (no network needed).
+	if err := g.FetchIfStale("origin", 60*time.Second); err != nil {
+		t.Errorf("FetchIfStale with fresh FETCH_HEAD: %v", err)
+	}
+
+	// Verify fetch was skipped: FETCH_HEAD mtime must be unchanged.
+	after, err := os.Stat(fetchHead)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Errorf("FetchIfStale updated FETCH_HEAD mtime (fetch was NOT skipped): before=%v after=%v",
+			before.ModTime(), after.ModTime())
+	}
+}
+
+func TestFetchIfStale_StaleFetchHead_FetchHappens(t *testing.T) {
+	localDir, _, _ := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+
+	// Write a stale FETCH_HEAD (2 minutes old).
+	fetchHead := filepath.Join(localDir, ".git", "FETCH_HEAD")
+	if err := os.WriteFile(fetchHead, []byte("# test\n"), 0644); err != nil {
+		t.Fatalf("write FETCH_HEAD: %v", err)
+	}
+	stale := time.Now().Add(-2 * time.Minute)
+	if err := os.Chtimes(fetchHead, stale, stale); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	// FetchIfStale with 60s maxAge should trigger a real fetch.
+	if err := g.FetchIfStale("origin", 60*time.Second); err != nil {
+		t.Errorf("FetchIfStale with stale FETCH_HEAD: %v", err)
+	}
+
+	// FETCH_HEAD mtime should now be recent.
+	info, err := os.Stat(fetchHead)
+	if err != nil {
+		t.Fatalf("stat FETCH_HEAD: %v", err)
+	}
+	if time.Since(info.ModTime()) > 10*time.Second {
+		t.Error("expected FETCH_HEAD to be updated after fetch")
+	}
+}
+
+func TestFetchIfStale_MissingFetchHead_FetchHappens(t *testing.T) {
+	localDir, _, _ := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+
+	// Remove FETCH_HEAD if it exists so we start clean.
+	fetchHead := filepath.Join(localDir, ".git", "FETCH_HEAD")
+	_ = os.Remove(fetchHead)
+
+	// FetchIfStale should detect missing FETCH_HEAD and fetch.
+	if err := g.FetchIfStale("origin", 60*time.Second); err != nil {
+		t.Errorf("FetchIfStale with missing FETCH_HEAD: %v", err)
+	}
+
+	// FETCH_HEAD should now exist and be recent.
+	info, err := os.Stat(fetchHead)
+	if err != nil {
+		t.Fatalf("FETCH_HEAD not created after fetch: %v", err)
+	}
+	if time.Since(info.ModTime()) > 10*time.Second {
+		t.Error("expected fresh FETCH_HEAD after fetch")
+	}
+}
+
+func TestFetchIfStale_ExplicitGitDir_SkipsFetch(t *testing.T) {
+	_, remoteDir, mainBranch := initTestRepoWithRemote(t)
+
+	// Create a bare clone of the remote (mirrors how polecat rigs work).
+	tmp := t.TempDir()
+	bareDir := filepath.Join(tmp, "bare.git")
+	helper := NewGit(tmp)
+	if err := helper.CloneBare(remoteDir, bareDir); err != nil {
+		t.Fatalf("CloneBare: %v", err)
+	}
+
+	// Verify the clone has the expected branch so origin is reachable.
+	exists, err := NewGitWithDir(bareDir, "").RefExists("origin/" + mainBranch)
+	if err != nil {
+		t.Fatalf("RefExists: %v", err)
+	}
+	if !exists {
+		t.Fatalf("expected origin/%s to exist in bare clone", mainBranch)
+	}
+
+	// Create a Git instance with gitDir set explicitly (bypasses rev-parse --git-dir).
+	g := NewGitWithDir(bareDir, "")
+
+	// Write a fresh FETCH_HEAD directly inside the bare repo (the git dir IS bareDir).
+	fetchHead := filepath.Join(bareDir, "FETCH_HEAD")
+	if err := os.WriteFile(fetchHead, []byte("# test\n"), 0644); err != nil {
+		t.Fatalf("write FETCH_HEAD: %v", err)
+	}
+	knownTime := time.Now().Add(-5 * time.Second)
+	if err := os.Chtimes(fetchHead, knownTime, knownTime); err != nil {
+		t.Fatalf("chtimes: %v", err)
+	}
+
+	// Record mtime before the call.
+	before, err := os.Stat(fetchHead)
+	if err != nil {
+		t.Fatalf("stat before: %v", err)
+	}
+
+	// FetchIfStale with 60s maxAge must skip the fetch when gitDir is explicit.
+	if err := g.FetchIfStale("origin", 60*time.Second); err != nil {
+		t.Errorf("FetchIfStale with explicit gitDir and fresh FETCH_HEAD: %v", err)
+	}
+
+	// FETCH_HEAD mtime must be unchanged — fetch was skipped.
+	after, err := os.Stat(fetchHead)
+	if err != nil {
+		t.Fatalf("stat after: %v", err)
+	}
+	if !after.ModTime().Equal(before.ModTime()) {
+		t.Errorf("FetchIfStale updated FETCH_HEAD mtime (fetch was NOT skipped): before=%v after=%v",
+			before.ModTime(), after.ModTime())
 	}
 }

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -670,8 +670,9 @@ func (m *Manager) AddWithOptions(name string, opts AddOptions) (_ *Polecat, retE
 		return nil, fmt.Errorf("finding repo base: %w", err)
 	}
 
-	// Fetch latest from origin to ensure worktree starts from up-to-date code
-	if err := repoGit.Fetch("origin"); err != nil {
+	// Fetch latest from origin to ensure worktree starts from up-to-date code.
+	// Skip if a fetch was done within the last 60s to avoid redundant SSH round-trips.
+	if err := repoGit.FetchIfStale("origin", 60*time.Second); err != nil {
 		// Non-fatal - proceed with potentially stale code
 		style.PrintWarning("could not fetch origin: %v", err)
 	}
@@ -1141,8 +1142,9 @@ func (m *Manager) RepairWorktreeWithOptions(name string, force bool, opts AddOpt
 		}
 	}
 
-	// Fetch latest from origin to ensure we have fresh commits (non-fatal: may be offline)
-	_ = repoGit.Fetch("origin")
+	// Fetch latest from origin to ensure we have fresh commits (non-fatal: may be offline).
+	// Skip if a fetch was done within the last 60s to avoid redundant SSH round-trips.
+	_ = repoGit.FetchIfStale("origin", 60*time.Second)
 
 	// Ensure polecat directory exists for new structure
 	if err := os.MkdirAll(polecatDir, 0755); err != nil {


### PR DESCRIPTION
## Problem

During polecat spawn, `AddWithOptions` and `RepairWorktreeWithOptions` unconditionally call `repoGit.Fetch("origin")`, which takes ~4.8s on SSH remotes. Polecats also self-fetch during branch setup, making this doubly redundant.

## Solution

Add `FetchIfStale(remote string, maxAge time.Duration) error` to `internal/git/git.go`:
- Checks mtime of `FETCH_HEAD` in the repo's git directory
- Returns nil immediately if last fetch was within `maxAge`
- Falls through to a normal `Fetch()` if stale or missing

Replace both `Fetch("origin")` call sites in `manager.go` with `FetchIfStale("origin", 60*time.Second)`.

## Changes

- `internal/git/git.go`: add `FetchIfStale`, add `time` import
- `internal/polecat/manager.go`: use `FetchIfStale` in `AddWithOptions` and `RepairWorktreeWithOptions`
- `internal/git/git_test.go`: four tests covering fresh/stale/missing FETCH_HEAD and explicit gitDir cases

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/git/... -run TestFetchIfStale` — all 4 pass
- [ ] Observe spawn latency reduction on SSH remotes (~4.8s saved per spawn when FETCH_HEAD is fresh)