### PR TITLE
fix: fall back to TownRoot when rig path missing in patrol-molecules-exist check

### DIFF
--- a/internal/doctor/patrol_check.go
+++ b/internal/doctor/patrol_check.go
@@ -65,6 +65,14 @@ func (c *PatrolMoleculesExistCheck) Run(ctx *CheckContext) *CheckResult {
 	var details []string
 	for _, rigName := range rigs {
 		rigPath := filepath.Join(ctx.TownRoot, rigName)
+		// If rigPath doesn't exist, fall back to TownRoot. This handles the case
+		// where gt doctor runs from a mayor's canonical clone, where TownRoot
+		// resolves to the clone itself (e.g. gastown/mayor/rig) rather than the
+		// actual town root. The rig directory won't be a subdirectory of the clone,
+		// but patrol formulas are town-level and accessible from TownRoot itself.
+		if _, statErr := os.Stat(rigPath); os.IsNotExist(statErr) {
+			rigPath = ctx.TownRoot
+		}
 		missing := c.checkPatrolFormulas(rigPath)
 		if len(missing) > 0 {
 			c.missingFormulas[rigName] = missing


### PR DESCRIPTION
## Summary

- Fixes false positive in `patrol-molecules-exist` doctor check where all patrol formulas are reported as missing when `gt doctor` is run from a mayor's canonical clone
- The bug: `checkPatrolFormulas` ran `bd formula list` from `TownRoot/rigName`, which doesn't exist when TownRoot resolves to an inner mayor clone (e.g. `gastown/mayor/rig`)
- Fix: if `TownRoot/rigName` doesn't exist as a directory, fall back to using `TownRoot` itself as the working directory — patrol formulas are town-level and accessible from there

## Root cause

In `internal/doctor/patrol_check.go`, when workspace detection finds `mayor/town.json` in a mayor's canonical clone rather than the actual town root, `ctx.TownRoot` is set to the clone path (e.g. `/home/agent/gt/gastown/mayor/rig`). The check then builds `rigPath = TownRoot/rigName = .../gastown/mayor/rig/gastown`, which doesn't exist. `bd formula list` fails on the non-existent directory, causing all patrol formulas to be reported as missing.

## Test plan

- [x] `TestPatrolMoleculesExistCheck_NoRigs` — no rigs configured → StatusOK
- [x] `TestPatrolMoleculesExistCheck_RigPathMissing_FallbackToTownRoot` — rig dir absent, formulas at TownRoot → StatusOK (regression test for the bug)
- [x] `TestPatrolMoleculesExistCheck_RigPathExists_FormulasPresent` — normal case: rig dir exists with formulas → StatusOK
- [x] All existing `internal/doctor` tests pass

Fixes: gt-6sn

🤖 Generated with [Claude Code](https://claude.com/claude-code)