### PR TITLE
fix: use continuation directive after compaction instead of full re-init

### DIFF
--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -525,6 +525,23 @@ func outputAttachmentStatus(ctx RoleContext) {
 	showMoleculeExecutionPrompt(ctx.WorkDir, attachment.AttachedMolecule)
 }
 
+// outputContinuationDirective displays a brief continuation prompt for post-compact/resume.
+// Unlike outputAutonomousDirective, this does NOT ask the agent to re-announce or
+// re-run startup protocol — it just reminds the agent what's on the hook. (GH#1965)
+func outputContinuationDirective(hookedBead *beads.Issue, hasMolecule bool) {
+	fmt.Println()
+	fmt.Printf("%s\n\n", style.Bold.Render("## ▶ CONTINUE HOOKED WORK"))
+	fmt.Println("Your context was compacted/resumed. **Continue working on your hooked bead.**")
+	fmt.Println("Do NOT re-announce, re-initialize, or re-read the bead from scratch.")
+	fmt.Println("Pick up where you left off.")
+	fmt.Println()
+	fmt.Printf("  Hooked: %s — %s\n", style.Bold.Render(hookedBead.ID), hookedBead.Title)
+	if hasMolecule {
+		fmt.Println("  (Has attached molecule — check `bd mol current` for next step)")
+	}
+	fmt.Println()
+}
+
 // outputHandoffWarning outputs the post-handoff warning message.
 func outputHandoffWarning(prevSession string) {
 	fmt.Println()


### PR DESCRIPTION
## Summary

Fixes #1965 — After context compaction, the `UserPromptSubmit`/`SessionStart` hook re-injects the full `AUTONOMOUS WORK MODE` startup prompt, causing agents to re-announce and re-initialize instead of continuing their current work.

**Root cause**: Two paths led to the same bug:
- **Non-crew roles** (default `PreCompact` → `gt prime --hook` with `source=compact`): `runPrimeCompactResume` called `checkSlungWork` which always output the full autonomous directive with "Announce yourself" and "run `bd show`"
- **Crew workers** (`PreCompact` override → `gt handoff --cycle --reason compaction`): The new session got `source=startup`, bypassing `isCompactResume()` entirely and running the full prime path

**Fix**:
- Store the handoff reason in the marker file (`session_id\nreason` format, backward compatible)
- Extend `isCompactResume()` to detect compaction-triggered handoff cycles via `primeHandoffReason == "compaction"`
- Add `outputContinuationDirective()` — a lighter directive that reminds the agent of hooked work without the announce/re-init protocol
- Replace `checkSlungWork` in `runPrimeCompactResume` with `findAgentWork` + `outputContinuationDirective`

## Changed files

- `internal/cmd/prime.go` — Add `primeHandoffReason`, extend `isCompactResume()`, refactor `runPrimeCompactResume`
- `internal/cmd/prime_output.go` — Add `outputContinuationDirective()`
- `internal/cmd/prime_session.go` — Parse reason from handoff marker in `checkHandoffMarker`
- `internal/cmd/handoff.go` — Write reason to handoff marker in `runHandoffCycle`
- `internal/cmd/prime_test.go` — 12 new test cases covering detection, parsing, and output

## Test plan

- [x] `TestIsCompactResume` — 7 cases covering all source/reason combinations
- [x] `TestCheckHandoffMarkerParsesReason` — 3 cases: with reason, without reason (backward compat), no marker
- [x] `TestOutputContinuationDirective` — 2 cases: basic bead, bead with molecule
- [x] All existing `prime_test.go` tests pass (including dry-run, session state, explain)
- [x] Full `internal/cmd/` test suite passes
- [x] `golangci-lint` reports 0 issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)