### PR TITLE
fix: add missing .gitignore patterns for Dolt database and runtime files

### DIFF
--- a/internal/cmd/gitinit.go
+++ b/internal/cmd/gitinit.go
@@ -61,18 +61,44 @@ const HQGitignore = `# Gas Town HQ .gitignore
 # =============================================================================
 **/state.json
 **/*.lock
+**/*.flock
+**/locks/
 **/registry.json
 **/*.pid
 **/heartbeat.json
 **/activity.json
 .events.jsonl
 .feed.jsonl
+**/audit.log
+**/last-touched
+**/.local_version
+**/.gt-types-configured
+**/feed-*.json
 
 # =============================================================================
 # Runtime state directories
 # =============================================================================
 daemon/
 logs/
+
+# =============================================================================
+# Centralized Dolt SQL server data directory
+# =============================================================================
+.dolt-data/
+
+# Dolt internal directories at any level (rig databases, nested .beads dolt)
+**/.dolt/
+**/.doltcfg/
+
+# =============================================================================
+# Event stream storage
+# =============================================================================
+events/
+
+# =============================================================================
+# HQ beads directory
+# =============================================================================
+beads_hq/
 
 # =============================================================================
 # Rig git worktrees (recreate with 'gt sling' or 'gt rig add')


### PR DESCRIPTION
## Summary

- Add `.dolt-data/`, `**/.dolt/`, `**/.doltcfg/` patterns to prevent staging ~539 binary Dolt database files
- Add lock file patterns (`**/*.flock`, `**/locks/`) and runtime state files (`audit.log`, `last-touched`, `.local_version`, `.gt-types-configured`, `feed-*.json`)
- Add `events/` and `beads_hq/` directory patterns

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/cmd/...` passes
- [ ] Run `gt git-init` in a fresh workspace and verify `git check-ignore` matches Dolt data, lock files, events, and beads_hq paths

🤖 Generated with [Claude Code](https://claude.com/claude-code)