### PR TITLE
fix: add idempotency checks to compact report

### DIFF
--- a/internal/cmd/compact_report.go
+++ b/internal/cmd/compact_report.go
@@ -109,6 +109,19 @@ func runDailyDigest() error {
 		dateStr = compactReportDate
 	}
 
+	// Idempotency check: see if digest already exists for this date
+	existingID, err := findExistingCompactReport(dateStr)
+	if err != nil {
+		// Non-fatal: continue with creation attempt
+		if compactReportVerbose {
+			fmt.Fprintf(os.Stderr, "warning: idempotency check failed: %v\n", err)
+		}
+	} else if existingID != "" {
+		fmt.Printf("%s Compaction digest already sent for %s (bead: %s)\n",
+			style.Dim.Render("○"), dateStr, existingID)
+		return nil
+	}
+
 	// Run compaction with --json to get results
 	compactOut, err := exec.Command("gt", "compact", "--json").Output()
 	if err != nil {
@@ -348,6 +361,18 @@ func runWeeklyRollup() error {
 	weekEnd := now.Format("2006-01-02")
 	weekStart := now.AddDate(0, 0, -7).Format("2006-01-02")
 
+	// Idempotency check: see if weekly rollup already exists for this week
+	existingID, err := findExistingWeeklyRollup(weekStart, weekEnd)
+	if err != nil {
+		if compactReportVerbose {
+			fmt.Fprintf(os.Stderr, "warning: weekly idempotency check failed: %v\n", err)
+		}
+	} else if existingID != "" {
+		fmt.Printf("%s Weekly rollup already sent for %s to %s (bead: %s)\n",
+			style.Dim.Render("○"), weekStart, weekEnd, existingID)
+		return nil
+	}
+
 	// Query compaction report event beads from the past week
 	reports, err := queryCompactionReports(weekStart, weekEnd)
 	if err != nil {
@@ -395,6 +420,12 @@ func runWeeklyRollup() error {
 		return nil
 	}
 
+	// Create audit event bead for the weekly rollup (for future idempotency checks)
+	beadID, beadErr := createWeeklyRollupBead(rollup, markdown)
+	if beadErr != nil && compactReportVerbose {
+		fmt.Fprintf(os.Stderr, "warning: failed to create weekly rollup bead: %v\n", beadErr)
+	}
+
 	// Send to mayor/
 	subject := fmt.Sprintf("Weekly Wisp Compaction: %s to %s", weekStart, weekEnd)
 	mailCmd := exec.Command("gt", "mail", "send", "mayor/",
@@ -409,6 +440,9 @@ func runWeeklyRollup() error {
 
 	fmt.Printf("%s Weekly compaction rollup sent to mayor/ (%s to %s)\n",
 		style.Success.Render("✓"), weekStart, weekEnd)
+	if beadID != "" {
+		fmt.Printf("  Audit bead: %s\n", beadID)
+	}
 
 	return nil
 }
@@ -516,4 +550,99 @@ func formatWeeklyRollup(rollup *weeklyRollup) string {
 	}
 
 	return sb.String()
+}
+
+// findExistingCompactReport checks if a compaction digest already exists for the given date.
+// Returns the bead ID if found, empty string if not found.
+func findExistingCompactReport(dateStr string) (string, error) {
+	expectedTitle := fmt.Sprintf("Compaction Report %s", dateStr)
+
+	listCmd := exec.Command("bd", "list",
+		"--type=event",
+		"--json",
+		"--limit=50",
+	)
+	listOutput, err := listCmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	var events []struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	}
+	if err := json.Unmarshal(listOutput, &events); err != nil {
+		return "", err
+	}
+
+	for _, evt := range events {
+		if evt.Title == expectedTitle {
+			return evt.ID, nil
+		}
+	}
+	return "", nil
+}
+
+// findExistingWeeklyRollup checks if a weekly rollup already exists for the given week.
+// Returns the bead ID if found, empty string if not found.
+func findExistingWeeklyRollup(weekStart, weekEnd string) (string, error) {
+	expectedTitle := fmt.Sprintf("Weekly Compaction Rollup %s to %s", weekStart, weekEnd)
+
+	listCmd := exec.Command("bd", "list",
+		"--type=event",
+		"--json",
+		"--limit=20",
+	)
+	listOutput, err := listCmd.Output()
+	if err != nil {
+		return "", err
+	}
+
+	var events []struct {
+		ID    string `json:"id"`
+		Title string `json:"title"`
+	}
+	if err := json.Unmarshal(listOutput, &events); err != nil {
+		return "", err
+	}
+
+	for _, evt := range events {
+		if evt.Title == expectedTitle {
+			return evt.ID, nil
+		}
+	}
+	return "", nil
+}
+
+// createWeeklyRollupBead creates a permanent audit bead for the weekly rollup.
+func createWeeklyRollupBead(rollup *weeklyRollup, markdown string) (string, error) {
+	payloadJSON, err := json.Marshal(rollup)
+	if err != nil {
+		return "", fmt.Errorf("marshaling rollup payload: %w", err)
+	}
+
+	title := fmt.Sprintf("Weekly Compaction Rollup %s to %s", rollup.WeekStart, rollup.WeekEnd)
+	bdArgs := []string{
+		"create",
+		"--type=event",
+		"--title=" + title,
+		"--event-category=wisp.compaction.weekly",
+		"--event-payload=" + string(payloadJSON),
+		"--description=" + markdown,
+		"--silent",
+	}
+
+	bdCmd := exec.Command("bd", bdArgs...)
+	output, err := bdCmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("creating weekly rollup bead: %w\nOutput: %s", err, string(output))
+	}
+
+	beadID := strings.TrimSpace(string(output))
+
+	// Auto-close (audit record, not work)
+	closeCmd := exec.Command("bd", "close", beadID, "--reason=weekly compaction rollup")
+	_ = closeCmd.Run()
+
+	return beadID, nil
 }

--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -825,7 +825,7 @@ needs = ["wisp-compact"]
 description = """
 Generate and send the daily compaction digest.
 
-**Step 1: Send daily digest**
+**Step 1: Send daily digest (idempotent — safe to run every cycle)**
 ```bash
 gt compact report
 ```
@@ -835,8 +835,9 @@ builds a per-category breakdown (Heartbeats, Patrols, Errors, Untyped),
 detects anomalies, and sends the digest to deacon/ (cc mayor/).
 
 A permanent event bead (wisp.compaction) is created for audit trail.
+Skips automatically if today's digest was already sent.
 
-**Step 2: Weekly rollup (Mondays only)**
+**Step 2: Weekly rollup (Mondays only, idempotent)**
 If today is Monday, also send the weekly rollup:
 ```bash
 gt compact report --weekly
@@ -844,6 +845,7 @@ gt compact report --weekly
 
 This aggregates the past 7 days of compaction event beads and sends
 trend data (totals, promotion rate, avg deleted/day) to mayor/.
+Skips automatically if this week's rollup was already sent.
 
 **Exit criteria:** Compaction digest sent (or nothing to report)."""
 


### PR DESCRIPTION
## Summary
- Add bead-based idempotency checks to `gt compact report` (daily) and `gt compact report --weekly` so they skip if already sent for the current period, matching the existing pattern in `gt patrol digest`
- Create an audit event bead for weekly rollups (previously missing) so the idempotency check has an artifact to find
- Update `compact-report` formula step description to note commands are idempotent

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./internal/cmd/...` passes
- [ ] Run `gt compact report` twice — second invocation prints skip message with existing bead ID
- [ ] Run `gt compact report --weekly` twice on a Monday — second invocation prints skip message
- [ ] Run deacon for 2-3 patrol cycles and verify mayor inbox has at most one daily digest and one weekly rollup

🤖 Generated with [Claude Code](https://claude.com/claude-code)