### PR TITLE
fix(env): pass cloud API credentials from shell to agent sessions

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -124,6 +124,68 @@ func AgentEnv(cfg AgentEnvConfig) map[string]string {
 	// this empty value with intentional settings like --max-old-space-size.
 	env["NODE_OPTIONS"] = ""
 
+	// Pass through cloud API credentials and provider configuration from the parent shell.
+	// Only variables explicitly listed here are forwarded; all others are blocked for isolation.
+	for _, key := range []string{
+		// Anthropic API (direct)
+		"ANTHROPIC_API_KEY",
+		"ANTHROPIC_AUTH_TOKEN",
+		"ANTHROPIC_BASE_URL",
+		"ANTHROPIC_CUSTOM_HEADERS",
+
+		// Model selection
+		"ANTHROPIC_MODEL",
+		"ANTHROPIC_DEFAULT_HAIKU_MODEL",
+		"ANTHROPIC_DEFAULT_SONNET_MODEL",
+		"ANTHROPIC_DEFAULT_OPUS_MODEL",
+		"CLAUDE_CODE_SUBAGENT_MODEL",
+
+		// AWS Bedrock
+		"CLAUDE_CODE_USE_BEDROCK",
+		"CLAUDE_CODE_SKIP_BEDROCK_AUTH",
+		"AWS_ACCESS_KEY_ID",
+		"AWS_SECRET_ACCESS_KEY",
+		"AWS_SESSION_TOKEN",
+		"AWS_REGION",
+		"AWS_PROFILE",
+		"AWS_BEARER_TOKEN_BEDROCK",
+		"ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION",
+
+		// Microsoft Foundry
+		"CLAUDE_CODE_USE_FOUNDRY",
+		"CLAUDE_CODE_SKIP_FOUNDRY_AUTH",
+		"ANTHROPIC_FOUNDRY_API_KEY",
+		"ANTHROPIC_FOUNDRY_BASE_URL",
+		"ANTHROPIC_FOUNDRY_RESOURCE",
+
+		// Google Vertex AI
+		"CLAUDE_CODE_USE_VERTEX",
+		"CLAUDE_CODE_SKIP_VERTEX_AUTH",
+		"GOOGLE_APPLICATION_CREDENTIALS",
+		"GOOGLE_CLOUD_PROJECT",
+		"VERTEX_PROJECT",
+		"VERTEX_LOCATION",
+		"VERTEX_REGION_CLAUDE_3_5_HAIKU",
+		"VERTEX_REGION_CLAUDE_3_7_SONNET",
+		"VERTEX_REGION_CLAUDE_4_0_OPUS",
+		"VERTEX_REGION_CLAUDE_4_0_SONNET",
+		"VERTEX_REGION_CLAUDE_4_1_OPUS",
+
+		// Proxy / network
+		"HTTP_PROXY",
+		"HTTPS_PROXY",
+		"NO_PROXY",
+
+		// mTLS
+		"CLAUDE_CODE_CLIENT_CERT",
+		"CLAUDE_CODE_CLIENT_KEY",
+		"CLAUDE_CODE_CLIENT_KEY_PASSPHRASE",
+	} {
+		if val := os.Getenv(key); val != "" {
+			env[key] = val
+		}
+	}
+
 	return env
 }
 


### PR DESCRIPTION
## Problem

Gas Town agents ignored cloud API credentials set in the parent shell. `AgentEnv()` only populated `GT_*` variables and `NODE_OPTIONS`—nothing else reached the `exec env` startup command that Claude Code reads. Sessions always fell back to Claude subscription billing instead of using configured cloud providers.

**Symptom:** `claude` in the terminal used AWS Bedrock correctly; `gt mayor attach` or any agent did not.

## Root Cause

`BuildStartupCommand()` passes env to agents via `exec env VAR=VAL ...`, so only variables explicitly included in the `AgentEnv()` return map are visible to Claude Code. Cloud credentials were present in the tmux session environment but never copied into that map.

## Fix

Adds explicit passthrough in `AgentEnv()` for all Claude Code provider configuration variables, sourced from the official CC env var reference. Variables are only forwarded if non-empty in the parent environment:

- **Anthropic direct:** `ANTHROPIC_API_KEY`, `ANTHROPIC_AUTH_TOKEN`, `ANTHROPIC_BASE_URL`, `ANTHROPIC_CUSTOM_HEADERS`
- **Model selection:** `ANTHROPIC_MODEL`, `ANTHROPIC_DEFAULT_*_MODEL`, `CLAUDE_CODE_SUBAGENT_MODEL`
- **AWS Bedrock:** `CLAUDE_CODE_USE_BEDROCK`, `CLAUDE_CODE_SKIP_BEDROCK_AUTH`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY`, `AWS_SESSION_TOKEN`, `AWS_REGION`, `AWS_PROFILE`, `AWS_BEARER_TOKEN_BEDROCK`, `ANTHROPIC_SMALL_FAST_MODEL_AWS_REGION`
- **Microsoft Foundry:** `CLAUDE_CODE_USE_FOUNDRY`, `CLAUDE_CODE_SKIP_FOUNDRY_AUTH`, `ANTHROPIC_FOUNDRY_API_KEY`, `ANTHROPIC_FOUNDRY_BASE_URL`, `ANTHROPIC_FOUNDRY_RESOURCE`
- **Google Vertex AI:** `CLAUDE_CODE_USE_VERTEX`, `CLAUDE_CODE_SKIP_VERTEX_AUTH`, `GOOGLE_APPLICATION_CREDENTIALS`, `GOOGLE_CLOUD_PROJECT`, `VERTEX_PROJECT`, `VERTEX_LOCATION`, `VERTEX_REGION_*` per-model overrides
- **Proxy/network:** `HTTP_PROXY`, `HTTPS_PROXY`, `NO_PROXY`
- **mTLS:** `CLAUDE_CODE_CLIENT_CERT`, `CLAUDE_CODE_CLIENT_KEY`, `CLAUDE_CODE_CLIENT_KEY_PASSPHRASE`

Uses an explicit allowlist rather than full env passthrough for isolation—no other shell variables leak into agent sessions.

## Notes

- Backward compatible—additive only
- Complements `RuntimeConfig.env` (static per-rig values) which cannot handle dynamic/rotating credentials like `AWS_SESSION_TOKEN`
- One file changed, one clean commit on top of current main

🤖 Generated with [Claude Code](https://claude.com/claude-code)