### PR TITLE
fix(doctor): patrol-not-stuck queries Dolt DB instead of stale JSONL

### DIFF
--- a/internal/doctor/patrol_check.go
+++ b/internal/doctor/patrol_check.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"bufio"
+	"encoding/csv"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -228,12 +229,17 @@ func (c *PatrolNotStuckCheck) Run(ctx *CheckContext) *CheckResult {
 
 	var stuckWisps []string
 	for _, rigName := range rigs {
-		// Check main beads database for wisps (issues with Wisp=true)
-		// Follows redirect if present (rig root may redirect to mayor/rig/.beads)
 		rigPath := filepath.Join(ctx.TownRoot, rigName)
-		beadsDir := beads.ResolveBeadsDir(rigPath)
-		beadsPath := filepath.Join(beadsDir, "issues.jsonl")
-		stuck := c.checkStuckWisps(beadsPath, rigName)
+
+		// Try Dolt database first (canonical source in server mode),
+		// fall back to issues.jsonl for non-Dolt rigs or when Dolt is unavailable.
+		stuck, err := c.checkStuckWispsDolt(rigPath, rigName)
+		if err != nil {
+			// Dolt query failed — fall back to JSONL
+			beadsDir := beads.ResolveBeadsDir(rigPath)
+			beadsPath := filepath.Join(beadsDir, "issues.jsonl")
+			stuck = c.checkStuckWisps(beadsPath, rigName)
+		}
 		stuckWisps = append(stuckWisps, stuck...)
 	}
 
@@ -255,7 +261,55 @@ func (c *PatrolNotStuckCheck) Run(ctx *CheckContext) *CheckResult {
 	}
 }
 
-// checkStuckWisps returns descriptions of stuck wisps in a rig.
+// stuckWispsQuery selects in_progress issues for stuck-wisp detection via Dolt.
+const stuckWispsQuery = `SELECT id, title, status, updated_at FROM issues WHERE status = 'in_progress' ORDER BY updated_at ASC`
+
+// checkStuckWispsDolt queries the Dolt database for stuck wisps using bd sql.
+// Returns an error if the query fails (caller should fall back to JSONL).
+func (c *PatrolNotStuckCheck) checkStuckWispsDolt(rigPath string, rigName string) ([]string, error) {
+	cmd := exec.Command("bd", "sql", "--csv", stuckWispsQuery) //nolint:gosec // G204: query is a constant
+	cmd.Dir = rigPath
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return nil, fmt.Errorf("bd sql: %w", err)
+	}
+
+	r := csv.NewReader(strings.NewReader(string(output)))
+	records, err := r.ReadAll()
+	if err != nil || len(records) < 2 {
+		return nil, nil // No results or parse error
+	}
+
+	var stuck []string
+	cutoff := time.Now().Add(-c.stuckThreshold)
+
+	for _, rec := range records[1:] { // Skip CSV header
+		if len(rec) < 4 {
+			continue
+		}
+		id := strings.TrimSpace(rec[0])
+		title := strings.TrimSpace(rec[1])
+		updatedAt := strings.TrimSpace(rec[3])
+
+		t, err := time.Parse("2006-01-02 15:04:05", updatedAt)
+		if err != nil {
+			// Try RFC3339 as fallback
+			t, err = time.Parse(time.RFC3339, updatedAt)
+			if err != nil {
+				continue
+			}
+		}
+
+		if !t.IsZero() && t.Before(cutoff) {
+			stuck = append(stuck, fmt.Sprintf("%s: %s (%s) - stale since %s",
+				rigName, id, title, t.Format("2006-01-02 15:04")))
+		}
+	}
+
+	return stuck, nil
+}
+
+// checkStuckWisps returns descriptions of stuck wisps in a rig (JSONL fallback).
 func (c *PatrolNotStuckCheck) checkStuckWisps(issuesPath string, rigName string) []string {
 	file, err := os.Open(issuesPath)
 	if err != nil {

--- a/internal/doctor/patrol_check_test.go
+++ b/internal/doctor/patrol_check_test.go
@@ -1,9 +1,12 @@
 package doctor
 
 import (
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/gastown/internal/config"
 )
@@ -187,3 +190,159 @@ func TestPatrolHooksWiredCheck_FixPreservesExisting(t *testing.T) {
 		t.Error("existing custom patrol was overwritten")
 	}
 }
+
+func TestCheckStuckWisps_JSONLFallback_NoFile(t *testing.T) {
+	check := NewPatrolNotStuckCheck()
+	result := check.checkStuckWisps("/nonexistent/path/issues.jsonl", "testrig")
+	if len(result) != 0 {
+		t.Errorf("expected no stuck wisps for missing file, got %d", len(result))
+	}
+}
+
+func TestCheckStuckWisps_JSONLFallback_StuckIssue(t *testing.T) {
+	tmpDir := t.TempDir()
+	issuesPath := filepath.Join(tmpDir, "issues.jsonl")
+
+	staleTime := time.Now().Add(-2 * time.Hour) // 2 hours ago, exceeds 1h threshold
+	issue := map[string]interface{}{
+		"id":         "test-abc",
+		"title":      "stuck wisp",
+		"status":     "in_progress",
+		"updated_at": staleTime.Format(time.RFC3339),
+	}
+	data, _ := json.Marshal(issue)
+	if err := os.WriteFile(issuesPath, data, 0644); err != nil {
+		t.Fatalf("write issues.jsonl: %v", err)
+	}
+
+	check := NewPatrolNotStuckCheck()
+	result := check.checkStuckWisps(issuesPath, "testrig")
+	if len(result) != 1 {
+		t.Fatalf("expected 1 stuck wisp, got %d", len(result))
+	}
+	if result[0] == "" {
+		t.Error("stuck wisp description should not be empty")
+	}
+}
+
+func TestCheckStuckWisps_JSONLFallback_FreshIssue(t *testing.T) {
+	tmpDir := t.TempDir()
+	issuesPath := filepath.Join(tmpDir, "issues.jsonl")
+
+	freshTime := time.Now().Add(-5 * time.Minute) // 5 minutes ago, within 1h threshold
+	issue := map[string]interface{}{
+		"id":         "test-def",
+		"title":      "fresh wisp",
+		"status":     "in_progress",
+		"updated_at": freshTime.Format(time.RFC3339),
+	}
+	data, _ := json.Marshal(issue)
+	if err := os.WriteFile(issuesPath, data, 0644); err != nil {
+		t.Fatalf("write issues.jsonl: %v", err)
+	}
+
+	check := NewPatrolNotStuckCheck()
+	result := check.checkStuckWisps(issuesPath, "testrig")
+	if len(result) != 0 {
+		t.Errorf("expected no stuck wisps for fresh issue, got %d", len(result))
+	}
+}
+
+func TestCheckStuckWispsDolt_FallsBackOnMissingBd(t *testing.T) {
+	// When bd is not available or rigPath is invalid, checkStuckWispsDolt should return an error
+	// so the caller falls back to JSONL.
+	check := NewPatrolNotStuckCheck()
+	_, err := check.checkStuckWispsDolt("/nonexistent/rig/path", "testrig")
+	if err == nil {
+		t.Error("expected error when bd sql fails on nonexistent path")
+	}
+}
+
+func TestPatrolNotStuckCheck_Run_FallsBackToJSONL(t *testing.T) {
+	// Set up a town with one rig that has a stale JSONL entry but no Dolt database.
+	// The check should fall back to JSONL and detect the stuck wisp.
+	tmpDir := t.TempDir()
+
+	// Create rigs.json
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	rigsConfig := config.RigsConfig{
+		Rigs: map[string]config.RigEntry{
+			"testrig": {},
+		},
+	}
+	rigsData, _ := json.Marshal(rigsConfig)
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), rigsData, 0644); err != nil {
+		t.Fatalf("write rigs.json: %v", err)
+	}
+
+	// Create rig with .beads/issues.jsonl containing a stale entry
+	rigBeadsDir := filepath.Join(tmpDir, "testrig", ".beads")
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir rig beads: %v", err)
+	}
+
+	staleTime := time.Now().Add(-3 * time.Hour)
+	issue := map[string]interface{}{
+		"id":         "tr-stuck1",
+		"title":      "stuck patrol wisp",
+		"status":     "in_progress",
+		"updated_at": staleTime.Format(time.RFC3339),
+	}
+	issueData, _ := json.Marshal(issue)
+	if err := os.WriteFile(filepath.Join(rigBeadsDir, "issues.jsonl"), issueData, 0644); err != nil {
+		t.Fatalf("write issues.jsonl: %v", err)
+	}
+
+	check := NewPatrolNotStuckCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("Status = %v, want Warning (stuck wisp detected via JSONL fallback)", result.Status)
+	}
+	if len(result.Details) != 1 {
+		t.Errorf("Details count = %d, want 1", len(result.Details))
+	}
+}
+
+func TestPatrolNotStuckCheck_Run_NoStuckWisps(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create rigs.json with one rig
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	rigsConfig := config.RigsConfig{
+		Rigs: map[string]config.RigEntry{
+			"cleanrig": {},
+		},
+	}
+	rigsData, _ := json.Marshal(rigsConfig)
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), rigsData, 0644); err != nil {
+		t.Fatalf("write rigs.json: %v", err)
+	}
+
+	// Create rig with empty .beads/issues.jsonl
+	rigBeadsDir := filepath.Join(tmpDir, "cleanrig", ".beads")
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir rig beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigBeadsDir, "issues.jsonl"), []byte(""), 0644); err != nil {
+		t.Fatalf("write issues.jsonl: %v", err)
+	}
+
+	check := NewPatrolNotStuckCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("Status = %v, want OK (no stuck wisps)", result.Status)
+	}
+}
+
+// Suppress unused import warning for fmt (used in test output formatting).
+var _ = fmt.Sprintf


### PR DESCRIPTION
## Summary

- patrol-not-stuck doctor check now queries the Dolt database via `bd sql --csv` instead of reading `issues.jsonl`
- Falls back to JSONL when Dolt is unavailable (non-server rigs, server down)
- Adds 6 tests covering both Dolt and JSONL code paths

## Problem

The `patrol-not-stuck` doctor check reads from `issues.jsonl`, a cache/export file in `.beads/`. In Dolt server mode, this file becomes stale when wisps are compacted or deleted from the database. Ghost entries remain in the JSONL file, causing the doctor to report stuck wisps that no longer exist.

Example: doctor reports `dypt-mol-cr5` as stuck since 2026-02-18, but `bd show` and direct Dolt SQL queries return no results — the entry only exists in the stale JSONL file.

## Solution

Follows the same pattern as `NullAssigneeCheck`: for each rig, try `bd sql --csv` first to query canonical data from the Dolt database. If `bd sql` fails (Dolt not running, non-server rig), fall back to JSONL parsing.

The `checkStuckWispsDolt()` method handles both `2006-01-02 15:04:05` and RFC3339 timestamp formats from Dolt output.

## Testing

- 6 new unit tests in `patrol_check_test.go`
- JSONL fallback: missing file, stuck issue, fresh issue
- Dolt path: error fallback on missing bd
- Integration: `Run()` with JSONL fallback, clean rig with no stuck wisps
- Full `go test ./internal/doctor/` passes
- `go vet` and `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)