### PR TITLE
fix(doctor): handle nested polecat worktree structure in redirect checks

### DIFF
--- a/internal/doctor/beads_redirect_target_check_test.go
+++ b/internal/doctor/beads_redirect_target_check_test.go
@@ -125,8 +125,11 @@ func TestBeadsRedirectTargetCheck_PolecatBrokenTarget(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create polecat with redirect to non-existent target
+	// Create polecat with .git (old flat structure) and redirect to non-existent target
 	if err := os.MkdirAll(polecatBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(polecatDir, ".git"), []byte("gitdir: /fake\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 	if err := os.WriteFile(filepath.Join(polecatBeadsDir, "redirect"), []byte("../../.beads\n"), 0644); err != nil {
@@ -398,6 +401,10 @@ func TestBeadsRedirectTargetCheck_MultipleWorktrees(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(beadsDir, "redirect"), []byte("../../.beads\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
+	}
+	// Mark polecat as old-style flat worktree (has .git)
+	if err := os.WriteFile(filepath.Join(rigDir, "polecats", "polecat1", ".git"), []byte("gitdir: /fake\n"), 0644); err != nil {
+		t.Fatal(err)
 	}
 
 	check := NewBeadsRedirectTargetCheck()


### PR DESCRIPTION
## Summary

- Add `polecatClonePath()` helper to detect both nested (`polecats/<name>/<rig_name>/`) and flat (`polecats/<name>/`) polecat structures
- Update `getWorktreePaths()` and `getBeadsDirsToCheck()` to resolve the actual clone path before checking redirects
- Add test for nested polecat structure; update existing tests to use valid old-style markers

## Problem

The `stale-beads-redirect` and `beads-redirect-target` doctor checks assumed polecats use a flat directory structure (`polecats/<name>/`). Newer polecats use a nested structure (`polecats/<name>/<rig_name>/`) for LLM context, but doctor was looking for `.beads/redirect` at the wrong level. This caused:

1. Every `gt doctor` run reporting 15-27 "missing redirect" warnings for polecats
2. `gt doctor --fix` appearing to succeed but never durably fixing the issue
3. The warnings recurring on every subsequent doctor run

## Solution

Mirror the detection logic from `polecat/manager.go:clonePath()` in a new `polecatClonePath()` helper used by both `getWorktreePaths()` and `getBeadsDirsToCheck()`. The helper checks for:

1. **New nested structure**: `polecats/<name>/<rig_name>/` (directory exists)
2. **Old flat structure**: `polecats/<name>/` (has `.git` file/dir)
3. **Default**: falls back to new nested structure (consistent with manager.go)

## Testing

- All 66 packages pass (`go test ./...`)
- `go vet ./...` clean
- New test: `TestStaleBeadsRedirectCheck_NestedPolecatWorkspace`
- Updated existing polecat tests to properly mark old-style flat structure with `.git`