### PR TITLE
fix(doctor): exclude crew from persistent-role-branches check

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -54,7 +54,7 @@ Cleanup checks (fixable):
   - stale-beads-redirect     Detect stale files in .beads directories with redirects
 
 Clone divergence checks:
-  - persistent-role-branches Detect crew/witness/refinery not on main
+  - persistent-role-branches Detect witness/refinery not on main (excludes crew)
   - clone-divergence         Detect clones significantly behind origin/main
   - default-branch-all-rigs  Verify default_branch exists on remote for all rigs
   - worktree-gitdir-valid    Verify worktree .git files reference existing paths (fixable)


### PR DESCRIPTION
## Summary

- Exclude crew directories from the `persistent-role-branches` doctor check
- Only flag witness and refinery (infrastructure roles) when not on main

## Problem

The `persistent-role-branches` check flags crew members on feature branches as warnings. However, crew members legitimately use feature branches (`fix/`, `feat/`, `chore/`) during PR workflows. This produces false positives every time a crew member is working on an upstream contribution.

## Solution

Remove crew directory scanning from `findPersistentRoleDirs`. Only witness and refinery directories are checked, since they are infrastructure roles that should always remain on main. Updated check description and help text to reflect the change.

## Testing

- `go test ./...` — all tests pass
- `go vet ./...` — clean
- Manual: ran `gt doctor` while on a feature branch in a crew directory — `persistent-role-branches` passes without false positive
- Witness/refinery directories still correctly checked (7 persistent roles reported, all on main)

(gt-249)