### PR TITLE
fix(config): refinery settings path wrong in RoleSettingsDir and hooks subsystem

### DIFF
--- a/internal/cmd/hooks_install.go
+++ b/internal/cmd/hooks_install.go
@@ -182,9 +182,9 @@ func determineTargets(townRoot, role string, allRigs bool, allowedRoles []string
 				targets = append(targets, witnessDir)
 			}
 		case "refinery":
-			refineryDir := filepath.Join(rigPath, "refinery")
-			if info, err := os.Stat(refineryDir); err == nil && info.IsDir() {
-				targets = append(targets, refineryDir)
+			refineryRigDir := filepath.Join(rigPath, "refinery", "rig")
+			if info, err := os.Stat(refineryRigDir); err == nil && info.IsDir() {
+				targets = append(targets, refineryRigDir)
 			}
 		}
 	}
@@ -208,8 +208,10 @@ func resolveSettingsTarget(townRoot, cwd string) string {
 	// parts[0] = rig name (or mayor/deacon), parts[1] = role dir
 	roleDir := parts[1]
 	switch roleDir {
-	case "crew", "polecats", "witness", "refinery":
+	case "crew", "polecats", "witness":
 		return filepath.Join(townRoot, parts[0], roleDir)
+	case "refinery":
+		return filepath.Join(townRoot, parts[0], "refinery", "rig")
 	default:
 		return cwd
 	}

--- a/internal/cmd/hooks_test.go
+++ b/internal/cmd/hooks_test.go
@@ -287,9 +287,9 @@ func TestResolveSettingsTarget(t *testing.T) {
 			expected: "/home/user/gt/myrig/witness",
 		},
 		{
-			name:     "refinery subdir resolves to refinery parent",
+			name:     "refinery subdir resolves to refinery/rig",
 			cwd:      "/home/user/gt/myrig/refinery/rig",
-			expected: "/home/user/gt/myrig/refinery",
+			expected: "/home/user/gt/myrig/refinery/rig",
 		},
 		{
 			name:     "mayor stays at cwd",

--- a/internal/cmd/rig_integration_test.go
+++ b/internal/cmd/rig_integration_test.go
@@ -451,9 +451,7 @@ func TestRigAddCreatesCorrectStructure(t *testing.T) {
 		desc string
 	}{
 		{filepath.Join(rigPath, "witness", "rig", ".claude", "settings.local.json"), "witness/rig/.claude/settings.local.json (stale filename)"},
-		{filepath.Join(rigPath, "refinery", "rig", ".claude", "settings.local.json"), "refinery/rig/.claude/settings.local.json (stale filename)"},
 		{filepath.Join(rigPath, "witness", "rig", ".claude", "settings.json"), "witness/rig/.claude/settings.json (settings belong at parent dir)"},
-		{filepath.Join(rigPath, "refinery", "rig", ".claude", "settings.json"), "refinery/rig/.claude/settings.json (settings belong at parent dir)"},
 	}
 
 	for _, w := range staleSettingsThatShouldNotExist {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1263,8 +1263,10 @@ func withRoleSettingsFlag(rc *RuntimeConfig, role, rigPath string) *RuntimeConfi
 // roles where settings and session directory are the same (mayor, deacon).
 func RoleSettingsDir(role, rigPath string) string {
 	switch role {
-	case "crew", "witness", "refinery":
+	case "crew", "witness":
 		return filepath.Join(rigPath, role)
+	case "refinery":
+		return filepath.Join(rigPath, "refinery", "rig")
 	case "polecat":
 		return filepath.Join(rigPath, "polecats")
 	default:

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -1689,6 +1689,29 @@ func TestWithRoleSettingsFlag_InjectsForClaude(t *testing.T) {
 	}
 }
 
+func TestRoleSettingsDir(t *testing.T) {
+	t.Parallel()
+	rigPath := "/fake/rig"
+	tests := []struct {
+		role string
+		want string
+	}{
+		{"crew", filepath.Join(rigPath, "crew")},
+		{"witness", filepath.Join(rigPath, "witness")},
+		{"refinery", filepath.Join(rigPath, "refinery", "rig")},
+		{"polecat", filepath.Join(rigPath, "polecats")},
+		{"mayor", ""},
+		{"deacon", ""},
+		{"", ""},
+	}
+	for _, tt := range tests {
+		got := RoleSettingsDir(tt.role, rigPath)
+		if got != tt.want {
+			t.Errorf("RoleSettingsDir(%q, %q) = %q, want %q", tt.role, rigPath, got, tt.want)
+		}
+	}
+}
+
 func TestDaemonPatrolConfigRoundTrip(t *testing.T) {
 	t.Parallel()
 	dir := t.TempDir()

--- a/internal/doctor/claude_settings_check.go
+++ b/internal/doctor/claude_settings_check.go
@@ -347,8 +347,8 @@ func (c *ClaudeSettingsCheck) findSettingsFiles(townRoot string) []staleSettings
 		// Check for refinery settings
 		refineryDir := filepath.Join(rigPath, "refinery")
 		if dirExists(refineryDir) {
-			// CORRECT: refinery/.claude/settings.json (parent directory)
-			refineryCorrectSettings := filepath.Join(refineryDir, ".claude", "settings.json")
+			// CORRECT: refinery/rig/.claude/settings.json (working directory)
+			refineryCorrectSettings := filepath.Join(refineryDir, "rig", ".claude", "settings.json")
 			if fileExists(refineryCorrectSettings) {
 				files = append(files, staleSettingsInfo{
 					path:        refineryCorrectSettings,
@@ -365,33 +365,18 @@ func (c *ClaudeSettingsCheck) findSettingsFiles(townRoot string) []staleSettings
 					missingFile: true,
 				})
 			}
-			// STALE: old settings.local.json in parent directory (not a customer repo)
-			refineryParentStaleLocal := filepath.Join(refineryDir, ".claude", "settings.local.json")
-			if fileExists(refineryParentStaleLocal) {
-				files = append(files, staleSettingsInfo{
-					path:          refineryParentStaleLocal,
-					agentType:     "refinery",
-					rigName:       rigName,
-					sessionName:   session.RefinerySessionName(session.PrefixFor(rigName)),
-					wrongLocation: true,
-					missing:       []string{"stale settings.local.json (settings now in refinery/.claude/settings.json)"},
-				})
-			}
-			// STALE: old settings in workdir (rig/) — skip if tracked in customer repo
+			// STALE: old settings in parent directory (refinery/.claude/)
 			for _, staleFile := range []string{"settings.json", "settings.local.json"} {
-				stalePath := filepath.Join(refineryDir, "rig", ".claude", staleFile)
+				stalePath := filepath.Join(refineryDir, ".claude", staleFile)
 				if fileExists(stalePath) {
-					gs := c.getGitFileStatus(stalePath)
-					if gs != gitStatusTrackedClean && gs != gitStatusTrackedModified {
-						files = append(files, staleSettingsInfo{
-							path:          stalePath,
-							agentType:     "refinery",
-							rigName:       rigName,
-							sessionName:   session.RefinerySessionName(session.PrefixFor(rigName)),
-							wrongLocation: true,
-							missing:       []string{"stale settings in workdir (settings now in refinery/.claude/settings.json)"},
-						})
-					}
+					files = append(files, staleSettingsInfo{
+						path:          stalePath,
+						agentType:     "refinery",
+						rigName:       rigName,
+						sessionName:   session.RefinerySessionName(session.PrefixFor(rigName)),
+						wrongLocation: true,
+						missing:       []string{fmt.Sprintf("stale %s in parent dir (settings now in refinery/rig/.claude/)", staleFile)},
+					})
 				}
 			}
 		}

--- a/internal/doctor/claude_settings_check_test.go
+++ b/internal/doctor/claude_settings_check_test.go
@@ -212,9 +212,9 @@ func TestClaudeSettingsCheck_ValidRefinerySettings(t *testing.T) {
 	tmpDir := t.TempDir()
 	rigName := "testrig"
 
-	// Create valid refinery settings in correct location (refinery/.claude/settings.json)
-	// Settings are now in the parent directory, passed via --settings flag.
-	refinerySettings := filepath.Join(tmpDir, rigName, "refinery", ".claude", "settings.json")
+	// Create valid refinery settings in correct location (refinery/rig/.claude/settings.json)
+	// Settings are in the working directory, passed via --settings flag.
+	refinerySettings := filepath.Join(tmpDir, rigName, "refinery", "rig", ".claude", "settings.json")
 	createValidSettings(t, refinerySettings)
 
 	check := NewClaudeSettingsCheck()
@@ -389,8 +389,8 @@ func TestClaudeSettingsCheck_WrongLocationRefinery(t *testing.T) {
 	tmpDir := t.TempDir()
 	rigName := "testrig"
 
-	// Create stale settings.local.json at refinery parent dir (old filename, wrong)
-	// The correct file is refinery/.claude/settings.json
+	// Create stale settings.local.json at refinery parent dir (old location, wrong)
+	// The correct location is refinery/rig/.claude/settings.json
 	wrongSettings := filepath.Join(tmpDir, rigName, "refinery", ".claude", "settings.local.json")
 	createValidSettings(t, wrongSettings)
 
@@ -553,7 +553,7 @@ func TestClaudeSettingsCheck_MixedValidAndStale(t *testing.T) {
 	createStaleSettings(t, witnessSettings, "PATH")
 
 	// Create valid refinery settings (settings.json in correct location)
-	refinerySettings := filepath.Join(tmpDir, rigName, "refinery", ".claude", "settings.json")
+	refinerySettings := filepath.Join(tmpDir, rigName, "refinery", "rig", ".claude", "settings.json")
 	createValidSettings(t, refinerySettings)
 
 	check := NewClaudeSettingsCheck()
@@ -1042,7 +1042,7 @@ func TestClaudeSettingsCheck_MissingRefinerySettings(t *testing.T) {
 	tmpDir := t.TempDir()
 	rigName := "testrig"
 
-	// Create refinery directory but NOT the settings.json at refinery/.claude/
+	// Create refinery directory but NOT the settings.json at refinery/rig/.claude/
 	refineryDir := filepath.Join(tmpDir, rigName, "refinery")
 	if err := os.MkdirAll(refineryDir, 0755); err != nil {
 		t.Fatal(err)

--- a/internal/doctor/config_check.go
+++ b/internal/doctor/config_check.go
@@ -532,8 +532,8 @@ func (c *SessionHookCheck) findSettingsFiles(townRoot string) []string {
 			files = append(files, witnessSettings)
 		}
 
-		// Refinery - settings in parent directory (refinery/)
-		refinerySettings := filepath.Join(rig, "refinery", ".claude", "settings.json")
+		// Refinery - settings in working directory (refinery/rig/)
+		refinerySettings := filepath.Join(rig, "refinery", "rig", ".claude", "settings.json")
 		if _, err := os.Stat(refinerySettings); err == nil {
 			files = append(files, refinerySettings)
 		}

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -345,11 +345,11 @@ func DiscoverTargets(townRoot string) ([]Target, error) {
 			})
 		}
 
-		// Refinery — settings in the refinery parent directory
-		refineryDir := filepath.Join(rigPath, "refinery")
-		if info, err := os.Stat(refineryDir); err == nil && info.IsDir() {
+		// Refinery — settings in the refinery working directory (refinery/rig/)
+		refineryRigDir := filepath.Join(rigPath, "refinery", "rig")
+		if info, err := os.Stat(refineryRigDir); err == nil && info.IsDir() {
 			targets = append(targets, Target{
-				Path: filepath.Join(refineryDir, ".claude", "settings.json"),
+				Path: filepath.Join(refineryRigDir, ".claude", "settings.json"),
 				Key:  rigName + "/refinery",
 				Rig:  rigName,
 				Role: "refinery",

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -712,7 +712,7 @@ func TestDiscoverTargets_RoleNames(t *testing.T) {
 	os.MkdirAll(filepath.Join(tmpDir, "rig1", "crew", "alice"), 0755)
 	os.MkdirAll(filepath.Join(tmpDir, "rig1", "polecats", "toast"), 0755)
 	os.MkdirAll(filepath.Join(tmpDir, "rig1", "witness"), 0755)
-	os.MkdirAll(filepath.Join(tmpDir, "rig1", "refinery"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "rig1", "refinery", "rig"), 0755)
 
 	targets, err := DiscoverTargets(tmpDir)
 	if err != nil {


### PR DESCRIPTION
## Summary

- `RoleSettingsDir("refinery", rigPath)` returned `rigPath/refinery` but the refinery runs from `rigPath/refinery/rig/` — settings were installed to the wrong directory
- The hooks subsystem (`DiscoverTargets`, `determineTargets`, `resolveSettingsTarget`) also hardcoded the old `refinery/` path, causing `gt hooks sync` to continuously recreate stale settings at the wrong location
- Updates doctor checks and tests to match the correct location

## Problem

The refinery's working directory is `rigPath/refinery/rig/` (a git worktree), but `RoleSettingsDir` returned `rigPath/refinery/` for the refinery role. This caused:

1. `settings.json` installed at `refinery/.claude/settings.json` (via `EnsureSettingsForRole`)
2. `--settings` flag pointing to `refinery/.claude/settings.json`
3. Claude auto-creating `settings.local.json` at `refinery/rig/.claude/settings.local.json` (in the actual working directory)

The split between `settings.json` (parent dir) and `settings.local.json` (working dir) meant Claude couldn't find accepted permissions, causing the refinery to exit on startup.

Additionally, even after fixing `RoleSettingsDir`, the hooks subsystem had three locations that independently hardcoded the old `refinery/` path:

- `hooks/config.go:DiscoverTargets()` — scanned `refinery/.claude/settings.json` for hook discovery
- `cmd/hooks_install.go:determineTargets()` — installed hooks to `refinery/` parent directory
- `cmd/hooks_install.go:resolveSettingsTarget()` — resolved CWD to `refinery/` instead of `refinery/rig/`

This meant `gt hooks sync` (run by the daemon) would recreate stale settings files at the old location on every sync cycle, even after doctor deleted them.

## Solution

### Core fix
Change `RoleSettingsDir` to return `rigPath/refinery/rig` for the refinery case, aligning settings installation with the actual working directory.

### Hooks subsystem fix
Update all three hardcoded paths in the hooks subsystem:
- `DiscoverTargets` now looks for `refinery/rig/` subdirectory
- `determineTargets` now targets `refinery/rig/` for hook installation
- `resolveSettingsTarget` now resolves refinery CWD to `refinery/rig/`

### Doctor checks
Update doctor to treat `refinery/.claude/` as stale (old location) and `refinery/rig/.claude/` as the correct location.

## Files Changed

| File | Change |
|------|--------|
| `internal/config/loader.go` | `RoleSettingsDir` returns `refinery/rig` |
| `internal/config/loader_test.go` | Added `TestRoleSettingsDir` |
| `internal/doctor/claude_settings_check.go` | Swapped correct/stale paths |
| `internal/doctor/claude_settings_check_test.go` | Updated 4 test cases |
| `internal/doctor/config_check.go` | Updated refinery settings path |
| `internal/cmd/rig_integration_test.go` | Removed refinery from stale list |
| `internal/hooks/config.go` | `DiscoverTargets` refinery path |
| `internal/hooks/config_test.go` | Updated test directory structure |
| `internal/cmd/hooks_install.go` | `determineTargets` + `resolveSettingsTarget` |
| `internal/cmd/hooks_test.go` | Updated test expectation |

## Testing

- Added `TestRoleSettingsDir` unit test covering all roles
- Updated existing doctor tests for new refinery path
- Updated hooks config tests for new directory structure
- Updated integration test expectations
- Full `go test ./...` passes
- Verified with `gt doctor`: stale files no longer reappear after hooks sync