### PR TITLE
fix(doctor): claude-settings check runs before daemon to prevent race

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -146,6 +146,11 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewTownGitCheck())
 	d.Register(doctor.NewTownRootBranchCheck())
 	d.Register(doctor.NewPreCheckoutHookCheck())
+	// Claude settings must be fixed BEFORE the daemon starts, so sessions
+	// launched by the daemon find correct settings files. If daemon runs first,
+	// its EnsureSettingsForRole sees stale files → returns early → sessions
+	// start with missing PATH exports. See gt-99u.
+	d.Register(doctor.NewClaudeSettingsCheck())
 	d.Register(doctor.NewDaemonCheck())
 	d.Register(doctor.NewBootHealthCheck())
 	d.Register(doctor.NewTownBeadsConfigCheck())
@@ -193,7 +198,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewSessionHookCheck())
 	d.Register(doctor.NewRuntimeGitignoreCheck())
 	d.Register(doctor.NewLegacyGastownCheck())
-	d.Register(doctor.NewClaudeSettingsCheck())
+	// NOTE: ClaudeSettingsCheck moved before DaemonCheck (gt-99u race fix)
 	d.Register(doctor.NewDeprecatedMergeQueueKeysCheck())
 	d.Register(doctor.NewLandWorktreeGitignoreCheck())
 	d.Register(doctor.NewHooksPathAllRigsCheck())


### PR DESCRIPTION
## Summary

- Move `ClaudeSettingsCheck` registration before `DaemonCheck` in doctor check ordering
- Preserve parent `.claude` directory for correct-location stale files during fix

## Problem

`gt doctor --fix` deletes stale Claude settings.json files (missing PATH exports), but the `DaemonCheck` fix starts the daemon afterwards. The daemon spawns sessions that call `EnsureSettingsForRole`, which short-circuits if any file already exists at the path — regardless of whether content is valid.

This creates a fix cycle: delete stale files → daemon restarts → daemon recreates stale files → next doctor run finds them stale again.

## Solution

1. **Check ordering:** Register `ClaudeSettingsCheck` before `DaemonCheck` so stale settings are deleted and recreated with correct content *before* the daemon spawns sessions. When sessions later call `EnsureSettingsForRole`, they find correct files and skip.

2. **Directory preservation:** Only remove the parent `.claude` directory for wrong-location files. For correct-location stale files (content is wrong but path is right), keep the directory to eliminate a race window between delete and recreate.

## Testing

- All 36 `ClaudeSettings` tests pass
- Full test suite passes (one pre-existing environment-dependent failure in `TestRunAgentsList_EmptyList_Output` unrelated to this change)
- Manual verification: `gt doctor --fix` followed by `gt doctor` no longer shows the claude-settings race