### PR TITLE
feat(doctor): add --no-start flag to suppress daemon startup during --fix

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -15,6 +15,7 @@ var (
 	doctorVerbose         bool
 	doctorRig             string
 	doctorRestartSessions bool
+	doctorNoStart         bool
 	doctorSlow            string
 )
 
@@ -100,6 +101,7 @@ Patrol checks:
   - patrol-plugins-accessible Verify plugin directories
 
 Use --fix to attempt automatic fixes for issues that support it.
+Use --no-start with --fix to suppress starting the daemon and agents.
 Use --rig to check a specific rig instead of the entire workspace.
 Use --slow to highlight slow checks (default threshold: 1s, e.g. --slow=500ms).`,
 	RunE: runDoctor,
@@ -110,6 +112,7 @@ func init() {
 	doctorCmd.Flags().BoolVarP(&doctorVerbose, "verbose", "v", false, "Show detailed output")
 	doctorCmd.Flags().StringVar(&doctorRig, "rig", "", "Check specific rig only")
 	doctorCmd.Flags().BoolVar(&doctorRestartSessions, "restart-sessions", false, "Restart patrol sessions when fixing stale settings (use with --fix)")
+	doctorCmd.Flags().BoolVar(&doctorNoStart, "no-start", false, "Suppress starting daemon/agents during --fix")
 	doctorCmd.Flags().StringVar(&doctorSlow, "slow", "", "Highlight slow checks (optional threshold, default 1s)")
 	// Allow --slow without a value (uses default 1s)
 	doctorCmd.Flags().Lookup("slow").NoOptDefVal = "1s"
@@ -129,6 +132,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 		RigName:         doctorRig,
 		Verbose:         doctorVerbose,
 		RestartSessions: doctorRestartSessions,
+		NoStart:         doctorNoStart,
 	}
 
 	// Create doctor and register checks

--- a/internal/doctor/daemon_check.go
+++ b/internal/doctor/daemon_check.go
@@ -68,6 +68,10 @@ func (c *DaemonCheck) Run(ctx *CheckContext) *CheckResult {
 
 // Fix starts the daemon.
 func (c *DaemonCheck) Fix(ctx *CheckContext) error {
+	if ctx.NoStart {
+		return ErrSkippedNoStart
+	}
+
 	// Find gt executable
 	gtPath, err := os.Executable()
 	if err != nil {

--- a/internal/doctor/doctor.go
+++ b/internal/doctor/doctor.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"time"
@@ -178,6 +179,9 @@ func (d *Doctor) FixStreaming(ctx *CheckContext, w io.Writer, slowThreshold time
 					result.Message = result.Message + " (fixed)"
 					result.Fixed = true
 				}
+			} else if errors.Is(err, ErrSkippedNoStart) {
+				// Fix skipped due to --no-start flag
+				result.Details = append(result.Details, "Skipped: --no-start suppresses startup")
 			} else {
 				// Fix failed, add error to details
 				result.Details = append(result.Details, "Fix failed: "+err.Error())

--- a/internal/doctor/errors.go
+++ b/internal/doctor/errors.go
@@ -6,4 +6,7 @@ import "errors"
 var (
 	// ErrCannotFix is returned when a check does not support auto-fix.
 	ErrCannotFix = errors.New("check does not support auto-fix")
+
+	// ErrSkippedNoStart is returned when a fix is skipped due to --no-start.
+	ErrSkippedNoStart = errors.New("skipped: --no-start suppresses daemon/agent startup")
 )

--- a/internal/doctor/types.go
+++ b/internal/doctor/types.go
@@ -63,6 +63,7 @@ type CheckContext struct {
 	RigName         string // Rig name (empty for town-level checks)
 	Verbose         bool   // Enable verbose output
 	RestartSessions bool   // Restart patrol sessions when fixing (requires explicit --restart-sessions flag)
+	NoStart         bool   // Suppress starting daemon/agents during --fix
 }
 
 // RigPath returns the full path to the rig directory.


### PR DESCRIPTION
## Summary

- Adds `--no-start` flag to `gt doctor --fix` that suppresses starting the daemon (and by extension, all agents/patrols)
- All other fixes still apply normally; only the daemon startup is skipped
- No change to default behavior — `gt doctor --fix` without `--no-start` works exactly as before

## Problem

When running `gt doctor --fix` to resolve configuration issues, the daemon check's fix automatically starts the daemon, which triggers agent and patrol startup. This is disruptive when you're trying to fix things without spinning up the entire Gas Town system — you want to fix config issues in isolation first, then start the system manually when ready.

## Solution

- New `--no-start` CLI flag on `gt doctor`, wired through `CheckContext.NoStart`
- `DaemonCheck.Fix()` returns a new `ErrSkippedNoStart` sentinel when the flag is set
- `FixStreaming` handles this error with a clean "Skipped: --no-start suppresses startup" message instead of showing it as a fix failure

## Usage

```bash
gt doctor --fix --no-start   # Fix everything except daemon startup
gt doctor --fix              # Unchanged — still starts daemon as before
```

## Testing

- `go test ./internal/doctor/` — all pass
- `go vet ./...` — clean
- Manual verification: `./gt doctor --help` shows the new flag correctly