### PR TITLE
fix(doltserver): clean up dolt_branch_control on RemoveDatabase

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1404,11 +1404,17 @@ func RemoveDatabase(townRoot, dbName string) error {
 		return fmt.Errorf("database %q not found at %s", dbName, dbPath)
 	}
 
-	// If server is running, DROP the database first
+	// If server is running, DROP the database first and clean up branch control entries.
+	// In Dolt 1.81.x, DROP DATABASE does not automatically remove dolt_branch_control
+	// entries for the dropped database. These stale entries cause the database directory
+	// to be recreated when connections reference the database name (gt-zlv7l).
 	running, _, _ := IsRunning(townRoot)
 	if running {
 		// Try to DROP — ignore errors (database might not be loaded)
 		_ = serverExecSQL(townRoot, fmt.Sprintf("DROP DATABASE IF EXISTS `%s`", dbName))
+		// Explicitly clean up branch control entries to prevent the database from being
+		// recreated on subsequent connections. `database` is a reserved word, so backtick-quote it.
+		_ = serverExecSQL(townRoot, fmt.Sprintf("DELETE FROM dolt_branch_control WHERE `database` = '%s'", dbName))
 	}
 
 	// Remove the directory


### PR DESCRIPTION
## Summary

- Fixes phantom "orphaned database" resurrection loop where `gt dolt cleanup` removes a database but it reappears on next run
- Root cause: in Dolt 1.81.x, `DROP DATABASE` does not automatically remove `dolt_branch_control` entries for the dropped database — stale entries cause the directory to be recreated when connections reference the name
- Fix: add explicit `DELETE FROM dolt_branch_control WHERE database = ?` after `DROP DATABASE` in `RemoveDatabase()`

## Test plan

- [ ] Run `gt dolt cleanup` on an orphaned database — verify it does not reappear after cleanup
- [ ] Verify `gt doctor` `dolt-orphaned-databases` check passes and stays clean across daemon restarts

Closes gt-zlv7l

🤖 Generated with [Claude Code](https://claude.com/claude-code)