### PR TITLE
fix(test): prevent test suite from leaking Dolt databases into production

### DIFF
--- a/internal/cmd/hook_slot_integration_test.go
+++ b/internal/cmd/hook_slot_integration_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/testutil"
 )
 
 // setupHookTestTown creates a minimal Gas Town with a polecat for testing hooks.
@@ -70,11 +71,12 @@ func setupHookTestTown(t *testing.T) (townRoot, polecatDir string) {
 	return townRoot, polecatDir
 }
 
-// initBeadsDB initializes the beads database by running bd init.
+// initBeadsDB initializes the beads database by running bd init on the test server.
 func initBeadsDB(t *testing.T, dir string) {
 	t.Helper()
+	testutil.RequireDoltServer(t)
 
-	cmd := exec.Command("bd", "init")
+	cmd := exec.Command("bd", "init", "--server-port", testutil.DoltTestPort())
 	cmd.Dir = dir
 	if output, err := cmd.CombinedOutput(); err != nil {
 		t.Fatalf("bd init failed: %v\n%s", err, output)

--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -457,6 +457,8 @@ func setupPatrolTestDB(t *testing.T) (string, *beads.Beads) {
 		if _, err := db.Exec("DROP DATABASE IF EXISTS `" + dbName + "`"); err != nil {
 			t.Logf("cleanup: failed to drop %s: %v", dbName, err)
 		}
+		// Purge dropped databases to prevent accumulation on disk
+		db.Exec("CALL dolt_purge_dropped_databases()") //nolint:errcheck
 	})
 
 	return tmpDir, b

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"sort"
+	"strconv"
 	"strings"
 	"testing"
 	"time"
@@ -15,6 +16,7 @@ import (
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/testutil"
 )
 
 // installMockBd places a fake bd binary in PATH that handles the commands
@@ -838,7 +840,9 @@ func TestAddWithOptions_NoPrimeMDCreatedLocally(t *testing.T) {
 	// Use real bd if available; fall back to a mock for environments (like
 	// Windows CI) where bd is not installed.
 	if _, err := exec.LookPath("bd"); err == nil {
-		bd := beads.NewWithBeadsDir(mayorRig, mayorBeads)
+		testutil.RequireDoltServer(t)
+		port, _ := strconv.Atoi(testutil.DoltTestPort())
+		bd := beads.NewIsolatedWithPort(mayorRig, port)
 		if err := bd.Init("gt"); err != nil {
 			t.Fatalf("bd init: %v", err)
 		}
@@ -950,7 +954,9 @@ func TestAddWithOptions_NoFilesAddedToRepo(t *testing.T) {
 	// Use real bd if available; fall back to a mock for environments (like
 	// Windows CI) where bd is not installed.
 	if _, err := exec.LookPath("bd"); err == nil {
-		bd := beads.NewWithBeadsDir(mayorRig, mayorBeads)
+		testutil.RequireDoltServer(t)
+		port, _ := strconv.Atoi(testutil.DoltTestPort())
+		bd := beads.NewIsolatedWithPort(mayorRig, port)
 		if err := bd.Init("gt"); err != nil {
 			t.Fatalf("bd init: %v", err)
 		}
@@ -1094,7 +1100,9 @@ func TestAddWithOptions_SettingsInstalledInPolecatsDir(t *testing.T) {
 	// Use real bd if available; fall back to a mock for environments (like
 	// Windows CI) where bd is not installed.
 	if _, err := exec.LookPath("bd"); err == nil {
-		bd := beads.NewWithBeadsDir(mayorRig, mayorBeads)
+		testutil.RequireDoltServer(t)
+		port, _ := strconv.Atoi(testutil.DoltTestPort())
+		bd := beads.NewIsolatedWithPort(mayorRig, port)
 		if err := bd.Init("gt"); err != nil {
 			t.Fatalf("bd init: %v", err)
 		}

--- a/internal/polecat/testmain_test.go
+++ b/internal/polecat/testmain_test.go
@@ -1,0 +1,14 @@
+package polecat
+
+import (
+	"os"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	testutil.CleanupDoltServer()
+	os.Exit(code)
+}

--- a/internal/refinery/manager_test.go
+++ b/internal/refinery/manager_test.go
@@ -3,12 +3,14 @@ package refinery
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"testing"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/testutil"
 )
 
 func setupTestRegistry(t *testing.T) {
@@ -100,7 +102,9 @@ func TestManager_Queue_NoBeads(t *testing.T) {
 
 func TestManager_Queue_FiltersClosedMergeRequests(t *testing.T) {
 	mgr, rigPath := setupTestManager(t)
-	b := beads.New(rigPath)
+	testutil.RequireDoltServer(t)
+	port, _ := strconv.Atoi(testutil.DoltTestPort())
+	b := beads.NewIsolatedWithPort(rigPath, port)
 	if err := b.Init("gt"); err != nil {
 		t.Skipf("bd init unavailable in test environment: %v", err)
 	}

--- a/internal/refinery/testmain_test.go
+++ b/internal/refinery/testmain_test.go
@@ -1,0 +1,14 @@
+package refinery
+
+import (
+	"os"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	code := m.Run()
+	testutil.CleanupDoltServer()
+	os.Exit(code)
+}


### PR DESCRIPTION
## Summary

- Route all test `bd init` calls through the isolated test Dolt server instead of production (port 3307)
- Add `TestMain` with `CleanupDoltServer()` to packages that were missing it
- Add `dolt_purge_dropped_databases()` to patrol test cleanup to prevent disk accumulation

## Problem

Several test files called `beads.New()` / `beads.NewWithBeadsDir()` followed by `.Init()` without using `testutil.RequireDoltServer(t)` or `NewIsolatedWithPort()`. This caused `bd init` to connect to the default production Dolt server on port 3307, creating databases there instead of on an isolated test server. These databases accumulated in `~/gt/.dolt-data/.dolt_dropped_databases/` (49 entries observed) and were never purged.

**Primary leakers:**
- `polecat/manager_test.go` — 3 occurrences of `beads.NewWithBeadsDir(...).Init("gt")`
- `refinery/manager_test.go` — 1 occurrence of `beads.New(...).Init("gt")`

**Secondary leaker (integration test):**
- `cmd/hook_slot_integration_test.go` — `initBeadsDB()` ran bare `exec.Command("bd", "init")` without `--server-port`

## Solution

- **polecat/manager_test.go**: Replace `NewWithBeadsDir` with `testutil.RequireDoltServer(t)` + `NewIsolatedWithPort` at all 3 init sites
- **refinery/manager_test.go**: Replace `beads.New` with `testutil.RequireDoltServer(t)` + `NewIsolatedWithPort`
- **hook_slot_integration_test.go**: Add `testutil.RequireDoltServer(t)` and pass `--server-port` to `bd init`
- **New testmain_test.go**: Add `TestMain` with `CleanupDoltServer()` to `polecat` and `refinery` packages (they had none)
- **patrol_helpers_test.go**: Add `CALL dolt_purge_dropped_databases()` after `DROP DATABASE` in cleanup to prevent on-disk accumulation

## Testing

- `go build ./...` — passes
- `go vet ./internal/polecat/ ./internal/refinery/ ./internal/cmd/` — passes
- `go test ./...` — all modified packages pass; only pre-existing failure is `TestRunAgentsList_EmptyList_Output` (workspace detection issue, unrelated)

(gt-xpd)