### PR TITLE
docs: add gt feed and problems view to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,6 +335,8 @@ gt sling <bead-id> <rig> --agent cursor   # Override runtime for this sling/spaw
 gt mayor attach             # Start Mayor session
 gt mayor start --agent auggie           # Run Mayor with a specific agent alias
 gt prime                    # Context recovery (run inside existing session)
+gt feed                     # Real-time activity feed (TUI)
+gt feed --problems          # Start in problems view (stuck agent detection)
 ```
 
 **Built-in agent presets**: `claude`, `gemini`, `codex`, `cursor`, `auggie`, `amp`
@@ -374,6 +376,40 @@ bd mol list                 # List active instances
 ## Cooking Formulas
 
 Gas Town includes built-in formulas for common workflows. See `internal/formula/formulas/` for available recipes.
+
+## Activity Feed
+
+`gt feed` launches an interactive terminal dashboard for monitoring all agent activity in real-time. It combines beads activity, agent events, and merge queue updates into a three-panel TUI:
+
+- **Agent Tree** - Hierarchical view of all agents grouped by rig and role
+- **Convoy Panel** - In-progress and recently-landed convoys
+- **Event Stream** - Chronological feed of creates, completions, slings, nudges, and more
+
+```bash
+gt feed                      # Launch TUI dashboard
+gt feed --problems           # Start in problems view
+gt feed --plain              # Plain text output (no TUI)
+gt feed --window             # Open in dedicated tmux window
+gt feed --since 1h           # Events from last hour
+```
+
+**Navigation:** `j`/`k` to scroll, `Tab` to switch panels, `1`/`2`/`3` to jump to a panel, `?` for help, `q` to quit.
+
+### Problems View
+
+At scale (20-50+ agents), spotting stuck agents in the activity stream becomes difficult. The problems view surfaces agents needing human intervention by analyzing structured beads data.
+
+Press `p` in `gt feed` (or start with `gt feed --problems`) to toggle the problems view, which groups agents by health state:
+
+| State | Condition |
+|-------|-----------|
+| **GUPP Violation** | Hooked work with no progress for an extended period |
+| **Stalled** | Hooked work with reduced progress |
+| **Zombie** | Dead tmux session |
+| **Working** | Active, progressing normally |
+| **Idle** | No hooked work |
+
+**Intervention keys** (in problems view): `n` to nudge the selected agent, `h` to handoff (refresh context).
 
 ## Dashboard
 
@@ -461,7 +497,8 @@ gt completion fish > ~/.config/fish/completions/gt.fish
 - **Use convoys for coordination** - They provide visibility across agents
 - **Leverage hooks for persistence** - Your work won't disappear
 - **Create formulas for repeated tasks** - Save time with Beads recipes
-- **Monitor the dashboard** - Get real-time visibility
+- **Use `gt feed` for live monitoring** - Watch agent activity and catch stuck agents early
+- **Monitor the dashboard** - Get real-time visibility in the browser
 - **Let the Mayor orchestrate** - It knows how to manage agents
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

- Add `gt feed` and `gt feed --problems` to the Key Commands section
- Add new Activity Feed section documenting the TUI dashboard, flags, navigation, and problems view
- Add monitoring tip for `gt feed`

Follow-up to #1583 which added the problems view but didn't update the README.

## Test plan

- [ ] Verify README renders correctly on GitHub
- [ ] Confirm all documented flags match `gt feed --help`

🤖 Generated with [Claude Code](https://claude.com/claude-code)