### PR TITLE
fix: resolve lint unparam warnings

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -108,7 +108,7 @@ func (g *Git) run(args ...string) (string, error) {
 }
 
 // runWithEnv executes a git command with additional environment variables.
-func (g *Git) runWithEnv(args []string, extraEnv []string) (string, error) {
+func (g *Git) runWithEnv(args []string, extraEnv []string) (_ string, _ error) { //nolint:unparam // string return kept for consistency with Run()
 	if g.gitDir != "" {
 		args = append([]string{"--git-dir=" + g.gitDir}, args...)
 	}

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -162,7 +162,7 @@ func notifyRefineryMergeReady(workDir, rigName string, payload *PolecatDonePaylo
 
 // handlePolecatDoneNoMR handles a POLECAT_DONE with no pending MR.
 // Tries auto-nuke; falls back to creating a cleanup wisp for manual intervention.
-func handlePolecatDoneNoMR(workDir, rigName string, payload *PolecatDonePayload, result *HandlerResult) *HandlerResult {
+func handlePolecatDoneNoMR(_, _ string, payload *PolecatDonePayload, result *HandlerResult) *HandlerResult {
 	// Persistent polecat model (gt-4ac): polecats go idle after completion, no nuke.
 	// The polecat has already set its own state to "idle" in gt done.
 	// We just acknowledge the completion here.
@@ -301,7 +301,7 @@ func HandleMerged(workDir, rigName string, msg *mail.Message) *HandlerResult {
 // Persistent model (gt-4ac): polecats go idle after merge, sandbox preserved.
 // ZFC #10: still warns about dirty state (uncommitted/stash/unpushed) since
 // that indicates the polecat may have started new work after the MR.
-func handleMergedCleanupStatus(workDir, rigName, polecatName, cleanupStatus, wispID string, result *HandlerResult) {
+func handleMergedCleanupStatus(_, _, polecatName, cleanupStatus, wispID string, result *HandlerResult) {
 	result.Handled = true
 	result.WispCreated = wispID
 


### PR DESCRIPTION
## Summary

Fixes the 3 `unparam` lint warnings on main. Mechanical changes only.

- **`internal/git/git.go:111`** — `runWithEnv` string return value unused by callers. Suppressed with `//nolint:unparam` since the return is kept for API consistency with `Run()`.
- **`internal/witness/handlers.go:165`** — `handlePolecatDoneNoMR(workDir, rigName, ...)` — both params unused after persistent polecat model (gt-4ac) simplified the handler. Blanked with `_`.
- **`internal/witness/handlers.go:304`** — `handleMergedCleanupStatus(workDir, rigName, ...)` — same situation. Blanked with `_`.

Split from #1986 per review feedback.

## Test plan

- [x] `golangci-lint run ./...` reports 0 unparam issues
- [x] `go test ./internal/git/` passes
- [x] `go test ./internal/witness/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)