### PR TITLE
fix(seance): find sessions in single-account setups without accounts.json

### DIFF
--- a/internal/cmd/seance.go
+++ b/internal/cmd/seance.go
@@ -382,62 +382,86 @@ func findSessionLocation(townRoot, sessionID string) *sessionLocation {
 	// Load accounts config
 	accountsPath := constants.MayorAccountsPath(townRoot)
 	cfg, err := config.LoadAccountsConfig(accountsPath)
-	if err != nil {
-		return nil
-	}
-
-	// Search each account's config directory
-	for _, acct := range cfg.Accounts {
-		if acct.ConfigDir == "" {
-			continue
-		}
-
-		// Expand ~ in path
-		configDir := acct.ConfigDir
-		if strings.HasPrefix(configDir, "~/") {
-			home, _ := os.UserHomeDir()
-			configDir = filepath.Join(home, configDir[2:])
-		}
-
-		// Search all sessions-index.json files in this account
-		projectsDir := filepath.Join(configDir, "projects")
-		if _, err := os.Stat(projectsDir); os.IsNotExist(err) {
-			continue
-		}
-
-		// Walk through project directories
-		entries, err := os.ReadDir(projectsDir)
-		if err != nil {
-			continue
-		}
-
-		for _, entry := range entries {
-			if !entry.IsDir() {
+	if err == nil {
+		// Search each account's config directory
+		for _, acct := range cfg.Accounts {
+			if acct.ConfigDir == "" {
 				continue
 			}
 
-			indexPath := filepath.Join(projectsDir, entry.Name(), "sessions-index.json")
-			if _, err := os.Stat(indexPath); os.IsNotExist(err) {
+			// Expand ~ in path
+			configDir := acct.ConfigDir
+			if strings.HasPrefix(configDir, "~/") {
+				home, _ := os.UserHomeDir()
+				configDir = filepath.Join(home, configDir[2:])
+			}
+
+			// Search all sessions-index.json files in this account
+			projectsDir := filepath.Join(configDir, "projects")
+			if _, err := os.Stat(projectsDir); os.IsNotExist(err) {
 				continue
 			}
 
-			// Read and parse the sessions index
-			data, err := os.ReadFile(indexPath)
+			// Walk through project directories
+			entries, err := os.ReadDir(projectsDir)
 			if err != nil {
 				continue
 			}
 
-			var index sessionsIndex
-			if err := json.Unmarshal(data, &index); err != nil {
-				continue
-			}
+			for _, entry := range entries {
+				if !entry.IsDir() {
+					continue
+				}
 
-			// Check if this index contains our session
-			for _, rawEntry := range index.Entries {
-				var e sessionsIndexEntry
-				if json.Unmarshal(rawEntry, &e) == nil && e.SessionID == sessionID {
+				indexPath := filepath.Join(projectsDir, entry.Name(), "sessions-index.json")
+				if _, err := os.Stat(indexPath); os.IsNotExist(err) {
+					continue
+				}
+
+				// Read and parse the sessions index
+				data, err := os.ReadFile(indexPath)
+				if err != nil {
+					continue
+				}
+
+				var index sessionsIndex
+				if err := json.Unmarshal(data, &index); err != nil {
+					continue
+				}
+
+				// Check if this index contains our session
+				for _, rawEntry := range index.Entries {
+					var e sessionsIndexEntry
+					if json.Unmarshal(rawEntry, &e) == nil && e.SessionID == sessionID {
+						return &sessionLocation{
+							configDir:  configDir,
+							projectDir: entry.Name(),
+						}
+					}
+				}
+			}
+		}
+	}
+
+	// Fallback: direct scan of ~/.claude/projects/ for single-account setups
+	// where accounts.json is missing or yields no results
+	home, homeErr := os.UserHomeDir()
+	if homeErr == nil {
+		claudeDir := filepath.Join(home, ".claude")
+		resolved, evalErr := filepath.EvalSymlinks(claudeDir)
+		if evalErr != nil {
+			resolved = claudeDir
+		}
+		fallbackProjectsDir := filepath.Join(resolved, "projects")
+		if fallbackEntries, readErr := os.ReadDir(fallbackProjectsDir); readErr == nil {
+			for _, entry := range fallbackEntries {
+				if !entry.IsDir() {
+					continue
+				}
+				sessionFile := filepath.Join(fallbackProjectsDir, entry.Name(), sessionID+".jsonl")
+				if _, statErr := os.Stat(sessionFile); statErr == nil {
 					return &sessionLocation{
-						configDir:  configDir,
+						configDir:  resolved,
 						projectDir: entry.Name(),
 					}
 				}
@@ -478,9 +502,30 @@ func symlinkSessionToConfigDir(townRoot, sessionID, targetConfigDir string) (cle
 		return nil, fmt.Errorf("session not found in any account")
 	}
 
-	// If session is already in the target account, nothing to do
+	// Session in same account but possibly different project dir.
+	// Symlink into cwd-based project dir so Claude can find it via --resume.
 	if loc.configDir == targetConfigDir {
-		return nil, nil
+		cwd, cwdErr := os.Getwd()
+		if cwdErr != nil {
+			return nil, nil
+		}
+		cwdProjectDir := strings.ReplaceAll(cwd, "/", "-")
+		if cwdProjectDir == loc.projectDir {
+			return nil, nil // Already in correct project dir
+		}
+		sourceFile := filepath.Join(targetConfigDir, "projects", loc.projectDir, sessionID+".jsonl")
+		targetDir := filepath.Join(targetConfigDir, "projects", cwdProjectDir)
+		if mkErr := os.MkdirAll(targetDir, 0755); mkErr != nil {
+			return nil, nil
+		}
+		targetFile := filepath.Join(targetDir, sessionID+".jsonl")
+		if _, lstatErr := os.Lstat(targetFile); lstatErr == nil {
+			return nil, nil // Already exists
+		}
+		if symlinkErr := os.Symlink(sourceFile, targetFile); symlinkErr != nil {
+			return nil, nil
+		}
+		return func() { _ = os.Remove(targetFile) }, nil
 	}
 
 	// Source: the session file in the other account

--- a/internal/cmd/seance_test.go
+++ b/internal/cmd/seance_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/config"
@@ -240,20 +241,48 @@ func TestSymlinkSessionToCurrentAccount(t *testing.T) {
 		}
 	})
 
-	t.Run("returns nil cleanup for session in current account", func(t *testing.T) {
+	t.Run("returns nil cleanup for session in current account same project", func(t *testing.T) {
 		townRoot, fakeHome, cleanup := setupSeanceTestEnv(t)
 		defer cleanup()
 
-		// Create session in account1 (the current account)
+		// Create session in account1 (the current account) using cwd-based project dir
+		cwd, _ := os.Getwd()
+		cwdProjectDir := strings.ReplaceAll(cwd, "/", "-")
 		account1Dir := filepath.Join(fakeHome, "claude-config-account1")
-		createTestSession(t, account1Dir, "local-project", "session-local456")
+		createTestSession(t, account1Dir, cwdProjectDir, "session-local456")
 
 		cleanupFn, err := symlinkSessionToCurrentAccount(townRoot, "session-local456")
 		if err != nil {
 			t.Fatalf("unexpected error: %v", err)
 		}
 		if cleanupFn != nil {
-			t.Error("expected nil cleanup for session in current account")
+			t.Error("expected nil cleanup for session in current account and project dir")
+		}
+	})
+
+	t.Run("symlinks session from different project dir in same account", func(t *testing.T) {
+		townRoot, fakeHome, cleanup := setupSeanceTestEnv(t)
+		defer cleanup()
+
+		// Create session in account1 but with a different project dir
+		account1Dir := filepath.Join(fakeHome, "claude-config-account1")
+		createTestSession(t, account1Dir, "other-project", "session-crossproj789")
+
+		cleanupFn, err := symlinkSessionToCurrentAccount(townRoot, "session-crossproj789")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cleanupFn == nil {
+			t.Fatal("expected non-nil cleanup for cross-project-dir session")
+		}
+		defer cleanupFn()
+
+		// Verify symlink was created in cwd-based project dir
+		cwd, _ := os.Getwd()
+		cwdProjectDir := strings.ReplaceAll(cwd, "/", "-")
+		symlinkPath := filepath.Join(account1Dir, "projects", cwdProjectDir, "session-crossproj789.jsonl")
+		if _, err := os.Lstat(symlinkPath); err != nil {
+			t.Errorf("expected symlink at %s: %v", symlinkPath, err)
 		}
 	})
 


### PR DESCRIPTION
## Summary

- `findSessionLocation()` returns nil when `accounts.json` is missing (single-account setups), so `gt seance --talk <id>` fails with "session not found" even when the transcript exists in `~/.claude/projects/`
- Adds a fallback that scans `~/.claude/projects/*/` directly for the `.jsonl` file when `accounts.json` is absent or yields no results
- Handles cross-project-dir lookups within the same account by symlinking the session into the cwd-based project dir so Claude can find it via `--resume`

## Test plan

- [x] `go build ./cmd/gt/` compiles
- [x] Existing `TestFindSessionLocation` tests pass
- [x] Updated `TestSymlinkSessionToCurrentAccount` tests pass (same-project returns nil cleanup, cross-project creates symlink)
- [x] `gt seance --talk <prefix>` successfully loads a session from a different project dir in a single-account setup

🤖 Generated with [Claude Code](https://claude.com/claude-code)