### PR TITLE
fix(doctor): skip rig dirs whose .beads symlinks to town root

### DIFF
--- a/internal/doctor/rig_routes_jsonl_check.go
+++ b/internal/doctor/rig_routes_jsonl_check.go
@@ -139,6 +139,7 @@ func (c *RigRoutesJSONLCheck) findRigDirectories(townRoot string) []string {
 
 	// Source 2: routes.jsonl (for rigs that may not be in registry)
 	townBeadsDir := filepath.Join(townRoot, ".beads")
+	townBeadsInfo, townBeadsErr := os.Stat(townBeadsDir)
 	if routes, err := beads.LoadRoutes(townBeadsDir); err == nil {
 		for _, route := range routes {
 			if route.Path == "." || route.Path == "" {
@@ -169,7 +170,16 @@ func (c *RigRoutesJSONLCheck) findRigDirectories(townRoot string) []string {
 			}
 			rigPath := filepath.Join(townRoot, entry.Name())
 			beadsDir := filepath.Join(rigPath, ".beads")
-			if _, err := os.Stat(beadsDir); err == nil && !seen[rigPath] {
+			beadsDirInfo, err := os.Stat(beadsDir)
+			if err != nil {
+				continue // .beads doesn't exist
+			}
+			// Skip if this rig's .beads is a hard link to the town root .beads
+			// (e.g. deacon uses a hard-linked .beads dir pointing to town beads)
+			if townBeadsErr == nil && os.SameFile(townBeadsInfo, beadsDirInfo) {
+				continue
+			}
+			if !seen[rigPath] {
 				rigDirs = append(rigDirs, rigPath)
 				seen[rigPath] = true
 			}


### PR DESCRIPTION
## Summary

- `rig-routes-jsonl` check was incorrectly treating `deacon/` as a rig because it has a `.beads` directory (a symlink to the town root `.beads`)
- This caused it to find and delete town-level `routes.jsonl` after `routes-config` created it, permanently breaking prefix routing
- Fix uses `os.SameFile()` to skip any rig-level `.beads` that resolves to the same inode as the town root `.beads` directory

Fixes gt-87knhj (P0)

## Test plan
- [ ] Verify `gt doctor` no longer incorrectly identifies `deacon/` as a rig
- [ ] Verify prefix routing persists after `gt doctor --fix` runs
- [ ] Confirm `rig-routes-jsonl` check only touches actual rig directories

🤖 Generated with [Claude Code](https://claude.com/claude-code)