### PR TITLE
Fix sling rollback to clean stale molecule artifacts

### DIFF
--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -971,6 +971,12 @@ func checkCrossRigGuard(beadID, targetAgent, townRoot string) error {
 // rollbackSlingArtifactsFn is a seam for tests. Production uses rollbackSlingArtifacts.
 var rollbackSlingArtifactsFn = rollbackSlingArtifacts
 
+// Rollback seams allow tests to assert molecule-cleanup behavior without
+// depending on full beads storage side effects.
+var getBeadInfoForRollback = getBeadInfo
+var collectExistingMoleculesForRollback = collectExistingMolecules
+var burnExistingMoleculesForRollback = burnExistingMolecules
+
 func restorePinnedBead(townRoot, beadID, assignee string) {
 	if townRoot == "" || beadID == "" {
 		return
@@ -1012,12 +1018,30 @@ func tryAcquireSlingBeadLock(townRoot, beadID string) (func(), error) {
 func rollbackSlingArtifacts(spawnInfo *SpawnedPolecatInfo, beadID, hookWorkDir string) {
 	townRoot, err := workspace.FindFromCwdOrError()
 
-	// 1. Unhook the bead (set status back to open so it can be re-slung).
+	// 1. Burn any attached molecules from partial formula instantiation.
+	// This clears attached_molecule metadata and closes stale wisps that
+	// otherwise block subsequent sling attempts.
 	// Some failure modes happen before any bead is hooked (e.g., wisp creation fails).
 	if beadID != "" {
 		if err != nil {
-			fmt.Printf("  %s Could not find workspace to unhook bead %s: %v\n", style.Dim.Render("Warning:"), beadID, err)
+			fmt.Printf("  %s Could not find workspace to rollback bead %s: %v\n", style.Dim.Render("Warning:"), beadID, err)
 		} else {
+			info, infoErr := getBeadInfoForRollback(beadID)
+			if infoErr != nil {
+				fmt.Printf("  %s Could not inspect bead %s for stale molecules: %v\n", style.Dim.Render("Warning:"), beadID, infoErr)
+			} else {
+				existingMolecules := collectExistingMoleculesForRollback(info)
+				if len(existingMolecules) > 0 {
+					if burnErr := burnExistingMoleculesForRollback(existingMolecules, beadID, townRoot); burnErr != nil {
+						fmt.Printf("  %s Could not burn stale molecule(s) from %s: %v\n", style.Dim.Render("Warning:"), beadID, burnErr)
+					} else {
+						fmt.Printf("  %s Burned %d stale molecule(s): %s\n",
+							style.Dim.Render("○"), len(existingMolecules), strings.Join(existingMolecules, ", "))
+					}
+				}
+			}
+
+			// 2. Unhook the bead (set status back to open so it can be re-slung).
 			unhookDir := beads.ResolveHookDir(townRoot, beadID, hookWorkDir)
 			unhookCmd := exec.Command("bd", "update", beadID, "--status=open", "--assignee=")
 			unhookCmd.Dir = unhookDir

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -467,6 +467,93 @@ exit /b 0
 	}
 }
 
+func TestRollbackSlingArtifactsBurnsAttachedMolecules(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir mayor/rig: %v", err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	bdScript := `#!/bin/sh
+set -e
+cmd="$1"
+shift || true
+case "$cmd" in
+  update)
+    exit 0
+    ;;
+esac
+exit 0
+`
+	bdScriptWindows := `@echo off
+set "cmd=%1"
+if "%cmd%"=="update" exit /b 0
+exit /b 0
+`
+	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv(EnvGTRole, "mayor")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	prevGetBead := getBeadInfoForRollback
+	prevCollect := collectExistingMoleculesForRollback
+	prevBurn := burnExistingMoleculesForRollback
+	t.Cleanup(func() {
+		getBeadInfoForRollback = prevGetBead
+		collectExistingMoleculesForRollback = prevCollect
+		burnExistingMoleculesForRollback = prevBurn
+	})
+
+	getBeadInfoForRollback = func(beadID string) (*beadInfo, error) {
+		if beadID != "gt-abc123" {
+			t.Fatalf("unexpected bead id: %q", beadID)
+		}
+		return &beadInfo{
+			Description: "attached_molecule: gt-wisp-stale",
+			Dependencies: []beads.IssueDep{
+				{ID: "gt-wisp-stale"},
+			},
+		}, nil
+	}
+	collectExistingMoleculesForRollback = collectExistingMolecules
+
+	burnCalled := false
+	burnExistingMoleculesForRollback = func(molecules []string, beadID, gotTownRoot string) error {
+		burnCalled = true
+		if beadID != "gt-abc123" {
+			t.Fatalf("unexpected burn bead id: %q", beadID)
+		}
+		if gotTownRoot != townRoot {
+			t.Fatalf("unexpected town root: got %q want %q", gotTownRoot, townRoot)
+		}
+		if len(molecules) != 1 || molecules[0] != "gt-wisp-stale" {
+			t.Fatalf("unexpected molecules to burn: %#v", molecules)
+		}
+		return nil
+	}
+
+	rollbackSlingArtifacts(&SpawnedPolecatInfo{
+		RigName:     "gastown",
+		PolecatName: "Toast",
+	}, "gt-abc123", "")
+
+	if !burnCalled {
+		t.Fatalf("expected rollbackSlingArtifacts to burn attached molecules")
+	}
+}
+
 func TestSlingFormulaRollsBackSpawnedPolecatOnWispFailure(t *testing.T) {
 	townRoot := t.TempDir()
 


### PR DESCRIPTION
## Summary
- add a regression test proving rollback must clean attached molecule artifacts
- update `rollbackSlingArtifacts` to inspect existing molecule attachments and burn stale molecules before unhooking
- keep rollback best-effort behavior (warn and continue)

## Why
When session start fails after formula instantiation, stale `attached_molecule`/bond state can remain and block re-sling in auto-setup rigs.

## Testing
- `go test ./internal/cmd -run 'TestRollbackSlingArtifactsBurnsAttachedMolecules|TestSlingRollsBackSpawnedPolecatOnInstantiateFailure|TestSlingFormulaRollsBackSpawnedPolecatOnWispFailure' -count=1`
- `go test ./internal/cmd -run '^TestSling|^TestRollbackSlingArtifactsBurnsAttachedMolecules$' -count=1`
- `go test ./...` (fails locally on unrelated `TestDetectWarnings_Clean` in convoy due parked-rig state leakage)
