### PR TITLE
docs: add Windows installation workaround for go install issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,12 @@ Git-backed issue tracking system that stores work state as structured data.
 # Install Gas Town
 $ brew install gastown                                    # Homebrew (recommended)
 $ npm install -g @gastown/gt                              # npm
-$ go install github.com/steveyegge/gastown/cmd/gt@latest  # From source
+$ go install github.com/steveyegge/gastown/cmd/gt@latest  # From source (macOS/Linux)
+
+# Windows (or if go install fails): clone and build manually
+$ git clone https://github.com/steveyegge/gastown.git && cd gastown
+$ go build -o gt.exe ./cmd/gt
+$ mv gt.exe $HOME/go/bin/  # or add gastown to PATH
 
 # If using go install, add Go binaries to PATH (add to ~/.zshrc or ~/.bashrc)
 export PATH="$PATH:$HOME/go/bin"


### PR DESCRIPTION
The go install command fails on Windows due to replace directives in go.mod. This PR adds manual clone+build instructions as an alternative for Windows users.

Fixes #1991