### PR TITLE
fix(doctor): detect stale agent beads from deregistered rigs

### DIFF
--- a/internal/doctor/stale_agent_beads_check.go
+++ b/internal/doctor/stale_agent_beads_check.go
@@ -177,7 +177,7 @@ func (c *StaleAgentBeadsCheck) Run(ctx *CheckContext) *CheckResult {
 			if info, exists := prefixToRig[idPrefix]; exists {
 				switch role {
 				case "crew":
-					_, workerName, _ := parseCrewOrPolecatFromID(id, idPrefix, info.name, "crew")
+					workerName := parseCrewOrPolecatFromID(id, idPrefix, info.name, "crew")
 					if workerName != "" {
 						crewWorkers := listCrewWorkers(ctx.TownRoot, info.name)
 						found := false
@@ -192,7 +192,7 @@ func (c *StaleAgentBeadsCheck) Run(ctx *CheckContext) *CheckResult {
 						}
 					}
 				case "polecat":
-					_, workerName, _ := parseCrewOrPolecatFromID(id, idPrefix, info.name, "polecat")
+					workerName := parseCrewOrPolecatFromID(id, idPrefix, info.name, "polecat")
 					if workerName != "" {
 						polecats := listPolecats(ctx.TownRoot, info.name)
 						found := false
@@ -232,8 +232,8 @@ func (c *StaleAgentBeadsCheck) Run(ctx *CheckContext) *CheckResult {
 }
 
 // parseCrewOrPolecatFromID extracts the worker name from a crew or polecat bead ID.
-// Returns the prefix, worker name, and whether parsing succeeded.
-func parseCrewOrPolecatFromID(id, prefix, rigName, role string) (string, string, bool) {
+// Returns the worker name, or empty string if the ID doesn't match the expected pattern.
+func parseCrewOrPolecatFromID(id, prefix, rigName, role string) string {
 	// Build the expected prefix pattern: prefix-rig-role- or prefix-role- (collapsed)
 	var idPrefix string
 	if prefix == rigName {
@@ -242,12 +242,9 @@ func parseCrewOrPolecatFromID(id, prefix, rigName, role string) (string, string,
 		idPrefix = prefix + "-" + rigName + "-" + role + "-"
 	}
 	if strings.HasPrefix(id, idPrefix) {
-		workerName := strings.TrimPrefix(id, idPrefix)
-		if workerName != "" {
-			return prefix, workerName, true
-		}
+		return strings.TrimPrefix(id, idPrefix)
 	}
-	return "", "", false
+	return ""
 }
 
 // dedup removes duplicate strings from a slice, preserving order.

--- a/internal/doctor/stale_agent_beads_check_test.go
+++ b/internal/doctor/stale_agent_beads_check_test.go
@@ -183,9 +183,7 @@ func TestParseCrewOrPolecatFromID(t *testing.T) {
 		prefix     string
 		rigName    string
 		role       string
-		wantPrefix string
 		wantWorker string
-		wantOK     bool
 	}{
 		{
 			name:       "standard crew ID",
@@ -193,9 +191,7 @@ func TestParseCrewOrPolecatFromID(t *testing.T) {
 			prefix:     "gt",
 			rigName:    "gastown",
 			role:       "crew",
-			wantPrefix: "gt",
 			wantWorker: "alice",
-			wantOK:     true,
 		},
 		{
 			name:       "standard polecat ID",
@@ -203,9 +199,7 @@ func TestParseCrewOrPolecatFromID(t *testing.T) {
 			prefix:     "gt",
 			rigName:    "gastown",
 			role:       "polecat",
-			wantPrefix: "gt",
 			wantWorker: "nux",
-			wantOK:     true,
 		},
 		{
 			name:       "collapsed form (prefix == rigName)",
@@ -213,9 +207,7 @@ func TestParseCrewOrPolecatFromID(t *testing.T) {
 			prefix:     "ff",
 			rigName:    "ff",
 			role:       "crew",
-			wantPrefix: "ff",
 			wantWorker: "joe",
-			wantOK:     true,
 		},
 		{
 			name:       "collapsed polecat (prefix == rigName)",
@@ -223,9 +215,7 @@ func TestParseCrewOrPolecatFromID(t *testing.T) {
 			prefix:     "ff",
 			rigName:    "ff",
 			role:       "polecat",
-			wantPrefix: "ff",
 			wantWorker: "toast",
-			wantOK:     true,
 		},
 		{
 			name:       "different prefix and rigName",
@@ -233,9 +223,7 @@ func TestParseCrewOrPolecatFromID(t *testing.T) {
 			prefix:     "sh",
 			rigName:    "shippercrm",
 			role:       "crew",
-			wantPrefix: "sh",
 			wantWorker: "controllers",
-			wantOK:     true,
 		},
 		{
 			name:       "ID does not match pattern",
@@ -243,9 +231,7 @@ func TestParseCrewOrPolecatFromID(t *testing.T) {
 			prefix:     "gt",
 			rigName:    "gastown",
 			role:       "crew",
-			wantPrefix: "",
 			wantWorker: "",
-			wantOK:     false,
 		},
 		{
 			name:       "wrong prefix",
@@ -253,9 +239,7 @@ func TestParseCrewOrPolecatFromID(t *testing.T) {
 			prefix:     "gt",
 			rigName:    "gastown",
 			role:       "crew",
-			wantPrefix: "",
 			wantWorker: "",
-			wantOK:     false,
 		},
 		{
 			name:       "empty worker name after prefix strip",
@@ -263,21 +247,13 @@ func TestParseCrewOrPolecatFromID(t *testing.T) {
 			prefix:     "gt",
 			rigName:    "gastown",
 			role:       "crew",
-			wantPrefix: "",
 			wantWorker: "",
-			wantOK:     false,
 		},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			prefix, worker, ok := parseCrewOrPolecatFromID(tt.id, tt.prefix, tt.rigName, tt.role)
-			if ok != tt.wantOK {
-				t.Errorf("ok = %v, want %v", ok, tt.wantOK)
-			}
-			if prefix != tt.wantPrefix {
-				t.Errorf("prefix = %q, want %q", prefix, tt.wantPrefix)
-			}
+			worker := parseCrewOrPolecatFromID(tt.id, tt.prefix, tt.rigName, tt.role)
 			if worker != tt.wantWorker {
 				t.Errorf("worker = %q, want %q", worker, tt.wantWorker)
 			}


### PR DESCRIPTION
## Summary

- Add Phase 2 to `stale-agent-beads` doctor check: scans the town (`hq`) database for orphaned agent beads whose prefix doesn't match any route in `routes.jsonl`
- Fix the `Fix()` method to close orphan beads via the town beads client instead of silently skipping them when no route matches their prefix
- Add tests for Phase 2 detection, `parseCrewOrPolecatFromID` helper, `dedup` helper, and fix fallback path

## Problem

When a rig is deregistered via `gt rig remove`, its agent beads in the `hq` database are not cleaned up. Both `agent-beads-exist` and `stale-agent-beads` only iterate over rigs found in `routes.jsonl`, making deregistered rig orphans invisible. These stale beads pollute `bd ready` output indefinitely.

Additionally, when `Fix()` encountered an orphan bead with an unknown prefix, `bd == nil` caused it to silently skip the bead — the close was never attempted.

## Investigation

Full investigation report: https://gist.github.com/l0g1x/ef6dc1a971fa124e8d5939f3115b4e7d (Finding 6)

Example: After deregistering the `openedi` rig, 5 agent beads (`oe-openedi-crew-*`, `oe-openedi-refinery`, `oe-openedi-witness`) remained open in `hq` and were invisible to all doctor checks.

## Changes

**`stale_agent_beads_check.go`:**
- Phase 2 in `Run()`: scan town beads for agent beads with unknown prefixes (deregistered rigs) and for beads stored in `hq` for known rigs whose workers were removed from disk
- `Fix()`: use town beads client as fallback when no route matches the bead's prefix; collect errors instead of failing on first

**`stale_agent_beads_check_test.go`:**
- Table-driven tests for `parseCrewOrPolecatFromID` (8 cases)
- Table-driven tests for `dedup` (6 cases)
- Integration tests for Phase 2 code paths (no-Dolt graceful handling, known prefix tracking, fix fallback)

## Testing

```
go test -v -run 'TestStaleAgentBeads|TestParseCrewOrPolecat|TestDedup' ./internal/doctor/
# 12 tests pass (4 existing + 8 new)

go test ./internal/doctor/
# Full package passes
```