### PR TITLE
fix(deacon): respawn dead pane instead of kill+recreate to prevent crash loop

### DIFF
--- a/internal/deacon/manager_test.go
+++ b/internal/deacon/manager_test.go
@@ -21,9 +21,16 @@ type mockTmux struct {
 	sessionInfoErr   error
 	sendKeysErr      error
 
+	// Dead pane detection (for respawn-instead-of-kill behavior)
+	paneDead               bool  // true if pane is dead (remain-on-exit)
+	respawnErr             error // error from RespawnPaneDefault
+	agentAliveAfterRespawn bool  // IsAgentAlive result after respawn
+
 	// Call tracking
 	killCalls       []string
 	newSessionCalls int
+	respawnCalls    int
+	respawnChecked  bool // tracks if IsPaneDead was checked
 }
 
 func (m *mockTmux) HasSession(name string) (bool, error) {
@@ -31,7 +38,21 @@ func (m *mockTmux) HasSession(name string) (bool, error) {
 }
 
 func (m *mockTmux) IsAgentAlive(_ string) bool {
+	// After respawn, return the post-respawn result
+	if m.respawnChecked && m.agentAliveAfterRespawn {
+		return true
+	}
 	return m.agentAlive
+}
+
+func (m *mockTmux) IsPaneDead(_ string) bool {
+	return m.paneDead
+}
+
+func (m *mockTmux) RespawnPaneDefault(_ string) error {
+	m.respawnCalls++
+	m.respawnChecked = true
+	return m.respawnErr
 }
 
 func (m *mockTmux) KillSessionWithProcesses(name string) error {
@@ -45,7 +66,7 @@ func (m *mockTmux) NewSessionWithCommand(_, _, _ string) error {
 }
 
 func (m *mockTmux) SetRemainOnExit(_ string, _ bool) error { return nil }
-func (m *mockTmux) SetEnvironment(_, _, _ string) error     { return nil }
+func (m *mockTmux) SetEnvironment(_, _, _ string) error    { return nil }
 func (m *mockTmux) ConfigureGasTownSession(_ string, _ tmux.Theme, _, _, _ string) error {
 	return nil
 }
@@ -54,11 +75,11 @@ func (m *mockTmux) WaitForCommand(_ string, _ []string, _ time.Duration) error {
 	return m.waitErr
 }
 
-func (m *mockTmux) SetAutoRespawnHook(_ string) error              { return nil }
-func (m *mockTmux) AcceptStartupDialogs(_ string) error            { return nil }
-func (m *mockTmux) AcceptWorkspaceTrustDialog(_ string) error      { return nil }
-func (m *mockTmux) AcceptBypassPermissionsWarning(_ string) error  { return nil }
-func (m *mockTmux) SendKeysRaw(_, _ string) error                  { return m.sendKeysErr }
+func (m *mockTmux) SetAutoRespawnHook(_ string) error             { return nil }
+func (m *mockTmux) AcceptStartupDialogs(_ string) error           { return nil }
+func (m *mockTmux) AcceptWorkspaceTrustDialog(_ string) error     { return nil }
+func (m *mockTmux) AcceptBypassPermissionsWarning(_ string) error { return nil }
+func (m *mockTmux) SendKeysRaw(_, _ string) error                 { return m.sendKeysErr }
 func (m *mockTmux) GetSessionInfo(_ string) (*tmux.SessionInfo, error) {
 	return m.sessionInfo, m.sessionInfoErr
 }
@@ -247,6 +268,97 @@ func TestStart_WaitForCommandFails(t *testing.T) {
 	// acceptable - the WaitForCommand path isn't reachable in test env.
 }
 
+// TestStart_DeadPane_RespawnsInsteadOfKill verifies that when the deacon
+// session exists but the pane is dead (process exited with remain-on-exit on),
+// Start() respawns the pane instead of killing the entire session and
+// creating a new one. This is critical for the daemon's crash loop detection:
+// respawning returns ErrAlreadyRunning, which makes the daemon call
+// RecordSuccess() instead of RecordRestart().
+//
+// Regression test for the deacon crash loop: the deacon exits cleanly
+// after each patrol cycle (~3 min), but the daemon heartbeat (also ~3 min)
+// finds the dead pane, kills the "zombie", creates a new session, and
+// increments the restart counter. After 5 restarts → crash loop.
+func TestStart_DeadPane_RespawnsInsteadOfKill(t *testing.T) {
+	mock := &mockTmux{
+		hasSessionResult:       true,
+		agentAlive:             false, // agent not running (pane dead)
+		paneDead:               true,  // pane is dead, not a zombie shell
+		respawnErr:             nil,   // respawn succeeds
+		agentAliveAfterRespawn: true,  // agent comes back after respawn
+	}
+	m := newTestManager(t.TempDir(), mock)
+
+	err := m.Start("")
+
+	// Should return ErrAlreadyRunning because respawn recovered the session
+	if !errors.Is(err, ErrAlreadyRunning) {
+		t.Errorf("Start() = %v, want ErrAlreadyRunning (respawn should recover dead pane)", err)
+	}
+
+	// Should NOT have killed the session
+	if len(mock.killCalls) > 0 {
+		t.Errorf("Start() killed session %v — should have respawned instead", mock.killCalls)
+	}
+
+	// Should NOT have created a new session
+	if mock.newSessionCalls > 0 {
+		t.Errorf("Start() created %d new sessions — should have respawned existing pane", mock.newSessionCalls)
+	}
+
+	// Should have called RespawnPaneDefault
+	if mock.respawnCalls == 0 {
+		t.Error("Start() did not call RespawnPaneDefault — dead pane should be respawned")
+	}
+}
+
+// TestStart_DeadPane_RespawnFails_FallsThrough verifies that when respawn
+// fails, Start() falls through to the kill+recreate path.
+func TestStart_DeadPane_RespawnFails_FallsThrough(t *testing.T) {
+	mock := &mockTmux{
+		hasSessionResult: true,
+		agentAlive:       false,
+		paneDead:         true,
+		respawnErr:       errors.New("respawn-pane failed"),
+	}
+	m := newTestManager(t.TempDir(), mock)
+
+	// Start will fall through to kill+recreate, then hit config resolution
+	// which may fail in test env. We just verify the fallthrough behavior.
+	_ = m.Start("")
+
+	// Respawn was attempted
+	if mock.respawnCalls == 0 {
+		t.Error("Start() did not attempt RespawnPaneDefault before falling through to kill")
+	}
+
+	// Should have fallen through to kill
+	if len(mock.killCalls) == 0 {
+		t.Error("Start() should fall through to kill when respawn fails")
+	}
+}
+
+// TestStart_ZombieShell_StillKills verifies that a true zombie (shell
+// running but agent dead) is still handled with kill+recreate, not respawn.
+func TestStart_ZombieShell_StillKills(t *testing.T) {
+	mock := &mockTmux{
+		hasSessionResult: true,
+		agentAlive:       false,
+		paneDead:         false, // NOT a dead pane — zombie shell still running
+	}
+	m := newTestManager(t.TempDir(), mock)
+
+	_ = m.Start("")
+
+	// Zombie shell should be killed, not respawned
+	if len(mock.killCalls) == 0 {
+		t.Error("Start() should kill zombie shell sessions")
+	}
+	if mock.respawnCalls > 0 {
+		t.Error("Start() should not respawn zombie shell — only dead panes")
+	}
+}
+
 func TestStop_NotRunning(t *testing.T) {
 	mock := &mockTmux{
 		hasSessionResult: false,
@@ -309,11 +421,11 @@ func TestStop_KillFails(t *testing.T) {
 
 func TestIsRunning(t *testing.T) {
 	tests := []struct {
-		name     string
-		running  bool
-		err      error
-		wantRun  bool
-		wantErr  bool
+		name    string
+		running bool
+		err     error
+		wantRun bool
+		wantErr bool
 	}{
 		{
 			name:    "running",

--- a/internal/tmux/respawn_hook_test.go
+++ b/internal/tmux/respawn_hook_test.go
@@ -1,0 +1,293 @@
+package tmux
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+	"testing"
+	"time"
+)
+
+// testSocket creates an isolated tmux server on a unique socket for the test.
+// Returns the socket name and a cleanup function that kills the server.
+func testSocket(t *testing.T) string {
+	t.Helper()
+	socket := fmt.Sprintf("gt-test-%d", time.Now().UnixNano())
+	t.Cleanup(func() {
+		// Kill the entire tmux server on this socket
+		_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	})
+	return socket
+}
+
+// testSession creates a session on the given socket running a simple command.
+// Returns after the session is confirmed alive.
+func testSession(t *testing.T, socket, session, command string) {
+	t.Helper()
+	args := []string{"-L", socket, "new-session", "-d", "-s", session, command}
+	out, err := exec.Command("tmux", args...).CombinedOutput()
+	if err != nil {
+		t.Fatalf("failed to create test session %q on socket %q: %v\n%s", session, socket, err, out)
+	}
+	// Wait for session to be visible
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		err := exec.Command("tmux", "-L", socket, "has-session", "-t", session).Run()
+		if err == nil {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	t.Fatalf("session %q never appeared on socket %q", session, socket)
+}
+
+// isPaneDead checks if a pane is dead on the given socket.
+func isPaneDead(socket, session string) bool {
+	out, err := exec.Command("tmux", "-L", socket, "list-panes", "-t", session, "-F", "#{pane_dead}").CombinedOutput()
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(out)) == "1"
+}
+
+// TestAutoRespawnHook_RespawnWorks is an integration test that verifies the
+// pane-died hook actually respawns the pane on a socket-scoped tmux server.
+//
+// This is the primary regression test for the multi-town socket migration
+// (33362a75) which moved all tmux commands to per-town sockets (-L <town>).
+// The hook's embedded tmux commands must include the socket flag, otherwise
+// `tmux respawn-pane` targets the default server where the session doesn't
+// exist, and respawn silently fails.
+//
+// Sequence:
+// 1. Create session on isolated socket running `sleep 5`
+// 2. Set auto-respawn hook via NewTmuxWithSocket
+// 3. Wait for process to exit naturally
+// 4. Wait for the hook to fire and respawn the pane
+// 5. Verify the pane comes back alive
+func TestAutoRespawnHook_RespawnWorks(t *testing.T) {
+	socket := testSocket(t)
+	session := "test-respawn"
+
+	// Use `sleep 2` — it exits naturally after 2 seconds
+	testSession(t, socket, session, "sleep 2")
+
+	tmx := NewTmuxWithSocket(socket)
+
+	if err := tmx.SetAutoRespawnHook(session); err != nil {
+		t.Fatalf("SetAutoRespawnHook failed: %v", err)
+	}
+
+	// Wait for sleep 2 to exit naturally
+	t.Log("Waiting for process to exit...")
+	deadline := time.Now().Add(5 * time.Second)
+	paneDied := false
+	for time.Now().Before(deadline) {
+		if isPaneDead(socket, session) {
+			paneDied = true
+			t.Log("Pane died, waiting for respawn hook to fire...")
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+	if !paneDied {
+		t.Fatal("pane never died — test setup issue")
+	}
+
+	// Wait for the hook to respawn (3s sleep + startup time)
+	t.Log("Waiting for hook to respawn pane (3s hook sleep + startup)...")
+	alive := false
+	deadline = time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		if !isPaneDead(socket, session) {
+			alive = true
+			t.Log("Pane respawned successfully!")
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	if !alive {
+		t.Error("pane was NOT respawned after death — auto-respawn hook failed " +
+			"(likely because the hook's embedded tmux commands are missing the -L socket flag)")
+	}
+}
+
+// TestAutoRespawnHook_SocketFlagInHookCmd verifies that SetAutoRespawnHook
+// embeds the tmux socket flag (-L) in the hook command when a socket is set.
+//
+// We can't use show-hooks (broken in tmux 3.4 for session-level hooks), so we
+// verify indirectly: create a session on socket A, set the hook, ensure
+// session does NOT exist on the default server, kill the pane, and verify
+// respawn works. If the hook used bare `tmux`, it would target the default
+// server and fail.
+func TestAutoRespawnHook_SocketFlagInHookCmd(t *testing.T) {
+	socket := testSocket(t)
+	session := "test-socket-hook"
+
+	testSession(t, socket, session, "sleep 2")
+
+	tmx := NewTmuxWithSocket(socket)
+
+	if err := tmx.SetAutoRespawnHook(session); err != nil {
+		t.Fatalf("SetAutoRespawnHook failed: %v", err)
+	}
+
+	// Verify session does NOT exist on the default server
+	err := exec.Command("tmux", "has-session", "-t", session).Run()
+	if err == nil {
+		t.Skip("session exists on default server — can't isolate socket test")
+	}
+	t.Logf("Confirmed: session %q does NOT exist on default tmux server", session)
+
+	// Wait for sleep to exit, then for hook to respawn
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if isPaneDead(socket, session) {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	// Wait for respawn (3s hook sleep)
+	alive := false
+	deadline = time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		if !isPaneDead(socket, session) {
+			alive = true
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	if !alive {
+		t.Error("pane was NOT respawned — hook's tmux commands likely missing -L socket flag")
+	}
+}
+
+// TestAutoRespawnHook_NoSocket verifies that when no socket is configured,
+// the hook uses bare tmux (backwards compatibility for single-town setups).
+func TestAutoRespawnHook_NoSocket(t *testing.T) {
+	socket := testSocket(t)
+	session := "test-nosocket"
+
+	testSession(t, socket, session, "sleep 2")
+
+	// Create a Tmux with empty socket (single-town mode).
+	// We need to use the real socket for the set-hook call, but the hook
+	// content should use bare `tmux` (no -L flag).
+	tmx := NewTmuxWithSocket(socket)
+	tmx.socketName = "" // Override: hook content should have bare tmux
+
+	// Set remain-on-exit manually since SetAutoRespawnHook calls it
+	exec.Command("tmux", "-L", socket, "set-option", "-t", session, "remain-on-exit", "on").Run()
+
+	// Build the hook command the same way SetAutoRespawnHook does internally
+	// with empty socketName — bare tmux should be used
+	hookCmd := fmt.Sprintf(`run-shell "sleep 3 && tmux respawn-pane -k -t '%s' && tmux set-option -t '%s' remain-on-exit on"`, session, session)
+
+	// Set it via the real socket
+	out, err := exec.Command("tmux", "-L", socket, "set-hook", "-t", session, "pane-died", hookCmd).CombinedOutput()
+	if err != nil {
+		t.Fatalf("set-hook failed: %v\n%s", err, out)
+	}
+
+	// Wait for sleep to exit
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if isPaneDead(socket, session) {
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	// In single-server context (which this test IS since we only have one socket),
+	// bare `tmux` in run-shell should still work because run-shell runs within
+	// the tmux server process context. Verify respawn works.
+	alive := false
+	deadline = time.Now().Add(8 * time.Second)
+	for time.Now().Before(deadline) {
+		if !isPaneDead(socket, session) {
+			alive = true
+			break
+		}
+		time.Sleep(200 * time.Millisecond)
+	}
+
+	if !alive {
+		t.Log("bare tmux hook did not respawn — expected in multi-server setups")
+		// This is not necessarily a failure — bare tmux works in single-server
+		// context (run-shell inherits server), but may fail in multi-server.
+		// The important test is TestAutoRespawnHook_SocketFlagInHookCmd above.
+	}
+}
+
+// TestIsPaneDead verifies the IsPaneDead method.
+func TestIsPaneDead(t *testing.T) {
+	socket := testSocket(t)
+	session := "test-panedead"
+
+	// Create a session with a short-lived command
+	testSession(t, socket, session, "sleep 300")
+
+	tmx := NewTmuxWithSocket(socket)
+
+	// Pane should be alive
+	if tmx.IsPaneDead(session) {
+		t.Error("IsPaneDead() = true for a running process, want false")
+	}
+
+	// Set remain-on-exit and kill the process
+	_ = tmx.SetRemainOnExit(session, true)
+	exec.Command("tmux", "-L", socket, "send-keys", "-t", session, "C-c", "").Run()
+	time.Sleep(500 * time.Millisecond)
+	// Force kill
+	exec.Command("tmux", "-L", socket, "send-keys", "-t", session, "kill %1 2>/dev/null; exit", "Enter").Run()
+	time.Sleep(1 * time.Second)
+
+	// Pane should now be dead
+	if !isPaneDead(socket, session) {
+		t.Skip("could not kill pane process reliably — skipping dead check")
+	}
+
+	if !tmx.IsPaneDead(session) {
+		t.Error("IsPaneDead() = false for a dead pane, want true")
+	}
+}
+
+// TestRespawnPaneDefault verifies that RespawnPaneDefault restarts
+// a dead pane with its original command.
+func TestRespawnPaneDefault(t *testing.T) {
+	socket := testSocket(t)
+	session := "test-respawn-default"
+
+	// Create a session with sleep 300, set remain-on-exit, kill the process
+	testSession(t, socket, session, "sleep 300")
+
+	tmx := NewTmuxWithSocket(socket)
+	_ = tmx.SetRemainOnExit(session, true)
+
+	// Kill via respawn-pane -k with a quick-exit command, then let it die
+	exec.Command("tmux", "-L", socket, "respawn-pane", "-k", "-t", session, "true").Run()
+	time.Sleep(500 * time.Millisecond)
+
+	if !tmx.IsPaneDead(session) {
+		t.Fatal("pane should be dead after running 'true'")
+	}
+
+	// Respawn with default command (should reuse 'true' since that was last)
+	if err := tmx.RespawnPaneDefault(session); err != nil {
+		t.Fatalf("RespawnPaneDefault failed: %v", err)
+	}
+
+	// The pane should briefly come alive (running 'true' then dying again)
+	// Give it a moment
+	time.Sleep(200 * time.Millisecond)
+
+	// Verify the respawn was attempted (pane existed at some point)
+	// The session should still exist regardless
+	err := exec.Command("tmux", "-L", socket, "has-session", "-t", session).Run()
+	if err != nil {
+		t.Error("session should still exist after RespawnPaneDefault")
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -39,11 +39,11 @@ var validSessionNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 // Common errors
 var (
-	ErrNoServer            = errors.New("no tmux server running")
-	ErrSessionExists       = errors.New("session already exists")
-	ErrSessionNotFound     = errors.New("session not found")
-	ErrInvalidSessionName  = errors.New("invalid session name")
-	ErrIdleTimeout         = errors.New("agent not idle before timeout")
+	ErrNoServer           = errors.New("no tmux server running")
+	ErrSessionExists      = errors.New("session already exists")
+	ErrSessionNotFound    = errors.New("session not found")
+	ErrInvalidSessionName = errors.New("invalid session name")
+	ErrIdleTimeout        = errors.New("agent not idle before timeout")
 )
 
 // validateSessionName checks that a session name contains only safe characters.
@@ -1104,8 +1104,8 @@ func (t *Tmux) NudgePane(pane, message string) error {
 
 // AcceptStartupDialogs dismisses all Claude Code startup dialogs that can block
 // automated sessions. Currently handles (in order):
-//   1. Workspace trust dialog ("Quick safety check" / "trust this folder") — v2.1.55+
-//   2. Bypass permissions warning ("Bypass Permissions mode") — requires Down+Enter
+//  1. Workspace trust dialog ("Quick safety check" / "trust this folder") — v2.1.55+
+//  2. Bypass permissions warning ("Bypass Permissions mode") — requires Down+Enter
 //
 // Call this after starting Claude and waiting for it to initialize (WaitForCommand),
 // but before sending any prompts. Idempotent: safe to call on sessions without dialogs.
@@ -2120,6 +2120,27 @@ func (t *Tmux) SetMailClickBinding(session string) error {
 	return err
 }
 
+// IsPaneDead checks if the pane in a session has exited (remain-on-exit keeps it visible).
+// Returns true if the pane's process has exited but the pane is still displayed.
+// This distinguishes a "dead pane waiting for respawn" from a "zombie shell still running".
+func (t *Tmux) IsPaneDead(session string) bool {
+	out, err := t.run("list-panes", "-t", session, "-F", "#{pane_dead}")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(out) == "1"
+}
+
+// RespawnPaneDefault restarts a dead pane with its original command.
+// This is used when the pane process has exited (remain-on-exit on) and we
+// want to restart it in place without killing the entire session.
+// Unlike RespawnPane, this does NOT specify a new command — tmux reuses the
+// command from when the pane was created or last respawned.
+func (t *Tmux) RespawnPaneDefault(session string) error {
+	_, err := t.run("respawn-pane", "-k", "-t", session)
+	return err
+}
+
 // RespawnPane kills all processes in a pane and starts a new command.
 // This is used for "hot reload" of agent sessions - instantly restart in place.
 // The pane parameter should be a pane ID (e.g., "%0") or session:window.pane format.
@@ -2552,7 +2573,16 @@ func (t *Tmux) SetAutoRespawnHook(session string) error {
 	// IMPORTANT: respawn-pane automatically resets remain-on-exit to off!
 	// We must re-enable it after each respawn for continuous recovery.
 	// The sleep prevents rapid respawn loops if Claude crashes immediately.
-	hookCmd := fmt.Sprintf(`run-shell "sleep 3 && tmux respawn-pane -k -t '%s' && tmux set-option -t '%s' remain-on-exit on"`, safeSession, safeSession)
+	//
+	// When a socket is configured, the embedded tmux commands MUST include
+	// the -L flag. run-shell spawns a subprocess that runs bare `tmux` which
+	// would otherwise connect to the default server instead of the town socket.
+	tmuxCmd := "tmux"
+	if t.socketName != "" {
+		tmuxCmd = fmt.Sprintf("tmux -L %s", t.socketName)
+	}
+	hookCmd := fmt.Sprintf(`run-shell "sleep 3 && %s respawn-pane -k -t '%s' && %s set-option -t '%s' remain-on-exit on"`,
+		tmuxCmd, safeSession, tmuxCmd, safeSession)
 
 	// Set the hook on this specific session
 	_, err := t.run("set-hook", "-t", session, "pane-died", hookCmd)
@@ -2562,4 +2592,3 @@ func (t *Tmux) SetAutoRespawnHook(session string) error {
 
 	return nil
 }
-


### PR DESCRIPTION
## Summary

- The deacon exits cleanly after each ~3-minute patrol cycle, but the daemon's 3-minute heartbeat races with the auto-respawn hook's 3-second sleep. The daemon finds the dead pane, treats it as a zombie, kills + recreates the session, and increments the crash counter. After 5 restarts in 15 minutes → crash loop.
- When the deacon manager finds a dead pane (process exited, `remain-on-exit` on), use `respawn-pane` to restart in place instead of killing the session. Returns `ErrAlreadyRunning` → daemon calls `RecordSuccess()` instead of `RecordRestart()`.
- Also adds `IsPaneDead()` and `RespawnPaneDefault()` to the tmux package, and fixes `SetAutoRespawnHook` to include `-L <socket>` in embedded tmux commands (missed by the multi-town socket migration in 33362a75).

## Changes

- `internal/deacon/manager.go`: Dead pane → try `RespawnPaneDefault` before falling through to kill+recreate
- `internal/deacon/manager_test.go`: 3 new tests for dead pane vs zombie shell recovery paths
- `internal/tmux/tmux.go`: Added `IsPaneDead()`, `RespawnPaneDefault()`, fixed socket flag in `SetAutoRespawnHook`
- `internal/tmux/respawn_hook_test.go`: Integration tests for auto-respawn hook on isolated socket servers

## Testing

- All existing deacon tests pass
- 3 new unit tests verify respawn-instead-of-kill, fallthrough on failure, and zombie-still-kills
- 5 new tmux integration tests verify hook respawn, socket isolation, `IsPaneDead`, `RespawnPaneDefault`
- `go vet` and `golangci-lint` clean