### PR TITLE
fix(config): revert refinery settings path to parent directory

### DIFF
--- a/internal/cmd/hooks_install.go
+++ b/internal/cmd/hooks_install.go
@@ -182,9 +182,9 @@ func determineTargets(townRoot, role string, allRigs bool, allowedRoles []string
 				targets = append(targets, witnessDir)
 			}
 		case "refinery":
-			refineryRigDir := filepath.Join(rigPath, "refinery", "rig")
-			if info, err := os.Stat(refineryRigDir); err == nil && info.IsDir() {
-				targets = append(targets, refineryRigDir)
+			refineryDir := filepath.Join(rigPath, "refinery")
+			if info, err := os.Stat(refineryDir); err == nil && info.IsDir() {
+				targets = append(targets, refineryDir)
 			}
 		}
 	}
@@ -208,10 +208,8 @@ func resolveSettingsTarget(townRoot, cwd string) string {
 	// parts[0] = rig name (or mayor/deacon), parts[1] = role dir
 	roleDir := parts[1]
 	switch roleDir {
-	case "crew", "polecats", "witness":
+	case "crew", "polecats", "witness", "refinery":
 		return filepath.Join(townRoot, parts[0], roleDir)
-	case "refinery":
-		return filepath.Join(townRoot, parts[0], "refinery", "rig")
 	default:
 		return cwd
 	}

--- a/internal/cmd/hooks_test.go
+++ b/internal/cmd/hooks_test.go
@@ -287,9 +287,9 @@ func TestResolveSettingsTarget(t *testing.T) {
 			expected: "/home/user/gt/myrig/witness",
 		},
 		{
-			name:     "refinery subdir resolves to refinery/rig",
+			name:     "refinery subdir resolves to refinery parent",
 			cwd:      "/home/user/gt/myrig/refinery/rig",
-			expected: "/home/user/gt/myrig/refinery/rig",
+			expected: "/home/user/gt/myrig/refinery",
 		},
 		{
 			name:     "mayor stays at cwd",

--- a/internal/cmd/rig_integration_test.go
+++ b/internal/cmd/rig_integration_test.go
@@ -451,7 +451,9 @@ func TestRigAddCreatesCorrectStructure(t *testing.T) {
 		desc string
 	}{
 		{filepath.Join(rigPath, "witness", "rig", ".claude", "settings.local.json"), "witness/rig/.claude/settings.local.json (stale filename)"},
+		{filepath.Join(rigPath, "refinery", "rig", ".claude", "settings.local.json"), "refinery/rig/.claude/settings.local.json (stale filename)"},
 		{filepath.Join(rigPath, "witness", "rig", ".claude", "settings.json"), "witness/rig/.claude/settings.json (settings belong at parent dir)"},
+		{filepath.Join(rigPath, "refinery", "rig", ".claude", "settings.json"), "refinery/rig/.claude/settings.json (settings belong at parent dir)"},
 	}
 
 	for _, w := range staleSettingsThatShouldNotExist {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1263,10 +1263,8 @@ func withRoleSettingsFlag(rc *RuntimeConfig, role, rigPath string) *RuntimeConfi
 // roles where settings and session directory are the same (mayor, deacon).
 func RoleSettingsDir(role, rigPath string) string {
 	switch role {
-	case "crew", "witness":
+	case "crew", "witness", "refinery":
 		return filepath.Join(rigPath, role)
-	case "refinery":
-		return filepath.Join(rigPath, "refinery", "rig")
 	case "polecat":
 		return filepath.Join(rigPath, "polecats")
 	default:

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -1698,7 +1698,7 @@ func TestRoleSettingsDir(t *testing.T) {
 	}{
 		{"crew", filepath.Join(rigPath, "crew")},
 		{"witness", filepath.Join(rigPath, "witness")},
-		{"refinery", filepath.Join(rigPath, "refinery", "rig")},
+		{"refinery", filepath.Join(rigPath, "refinery")},
 		{"polecat", filepath.Join(rigPath, "polecats")},
 		{"mayor", ""},
 		{"deacon", ""},

--- a/internal/doctor/claude_settings_check_test.go
+++ b/internal/doctor/claude_settings_check_test.go
@@ -212,9 +212,9 @@ func TestClaudeSettingsCheck_ValidRefinerySettings(t *testing.T) {
 	tmpDir := t.TempDir()
 	rigName := "testrig"
 
-	// Create valid refinery settings in correct location (refinery/rig/.claude/settings.json)
-	// Settings are in the working directory, passed via --settings flag.
-	refinerySettings := filepath.Join(tmpDir, rigName, "refinery", "rig", ".claude", "settings.json")
+	// Create valid refinery settings in correct location (refinery/.claude/settings.json)
+	// Settings are now in the parent directory, passed via --settings flag.
+	refinerySettings := filepath.Join(tmpDir, rigName, "refinery", ".claude", "settings.json")
 	createValidSettings(t, refinerySettings)
 
 	check := NewClaudeSettingsCheck()
@@ -389,8 +389,8 @@ func TestClaudeSettingsCheck_WrongLocationRefinery(t *testing.T) {
 	tmpDir := t.TempDir()
 	rigName := "testrig"
 
-	// Create stale settings.local.json at refinery parent dir (old location, wrong)
-	// The correct location is refinery/rig/.claude/settings.json
+	// Create stale settings.local.json at refinery parent dir (old filename, wrong)
+	// The correct file is refinery/.claude/settings.json
 	wrongSettings := filepath.Join(tmpDir, rigName, "refinery", ".claude", "settings.local.json")
 	createValidSettings(t, wrongSettings)
 
@@ -553,7 +553,7 @@ func TestClaudeSettingsCheck_MixedValidAndStale(t *testing.T) {
 	createStaleSettings(t, witnessSettings, "PATH")
 
 	// Create valid refinery settings (settings.json in correct location)
-	refinerySettings := filepath.Join(tmpDir, rigName, "refinery", "rig", ".claude", "settings.json")
+	refinerySettings := filepath.Join(tmpDir, rigName, "refinery", ".claude", "settings.json")
 	createValidSettings(t, refinerySettings)
 
 	check := NewClaudeSettingsCheck()
@@ -1042,7 +1042,7 @@ func TestClaudeSettingsCheck_MissingRefinerySettings(t *testing.T) {
 	tmpDir := t.TempDir()
 	rigName := "testrig"
 
-	// Create refinery directory but NOT the settings.json at refinery/rig/.claude/
+	// Create refinery directory but NOT the settings.json at refinery/.claude/
 	refineryDir := filepath.Join(tmpDir, rigName, "refinery")
 	if err := os.MkdirAll(refineryDir, 0755); err != nil {
 		t.Fatal(err)

--- a/internal/doctor/config_check.go
+++ b/internal/doctor/config_check.go
@@ -532,8 +532,8 @@ func (c *SessionHookCheck) findSettingsFiles(townRoot string) []string {
 			files = append(files, witnessSettings)
 		}
 
-		// Refinery - settings in working directory (refinery/rig/)
-		refinerySettings := filepath.Join(rig, "refinery", "rig", ".claude", "settings.json")
+		// Refinery - settings in parent directory (refinery/)
+		refinerySettings := filepath.Join(rig, "refinery", ".claude", "settings.json")
 		if _, err := os.Stat(refinerySettings); err == nil {
 			files = append(files, refinerySettings)
 		}

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -423,11 +423,11 @@ func DiscoverTargets(townRoot string) ([]Target, error) {
 			})
 		}
 
-		// Refinery — settings in the refinery working directory (refinery/rig/)
-		refineryRigDir := filepath.Join(rigPath, "refinery", "rig")
-		if info, err := os.Stat(refineryRigDir); err == nil && info.IsDir() {
+		// Refinery — settings in the refinery parent directory
+		refineryDir := filepath.Join(rigPath, "refinery")
+		if info, err := os.Stat(refineryDir); err == nil && info.IsDir() {
 			targets = append(targets, Target{
-				Path: filepath.Join(refineryRigDir, ".claude", "settings.json"),
+				Path: filepath.Join(refineryDir, ".claude", "settings.json"),
 				Key:  rigName + "/refinery",
 				Rig:  rigName,
 				Role: "refinery",

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -834,7 +834,7 @@ func TestDiscoverTargets_RoleNames(t *testing.T) {
 	os.MkdirAll(filepath.Join(tmpDir, "rig1", "crew", "alice"), 0755)
 	os.MkdirAll(filepath.Join(tmpDir, "rig1", "polecats", "toast"), 0755)
 	os.MkdirAll(filepath.Join(tmpDir, "rig1", "witness"), 0755)
-	os.MkdirAll(filepath.Join(tmpDir, "rig1", "refinery", "rig"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "rig1", "refinery"), 0755)
 
 	targets, err := DiscoverTargets(tmpDir)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Reverts the refinery-specific changes from PR #1985 that moved settings into the user's repo worktree
- Restores the parent-directory invariant: refinery settings live at `refinery/.claude/`, not `refinery/rig/.claude/`
- Keeps the `TestRoleSettingsDir` test added by #1985, updated with the corrected expectation

## Problem

PR #1985 changed refinery Claude settings from the parent directory (`refinery/.claude/`) into the user's repo worktree (`refinery/rig/.claude/`). This violated the upstream invariant that infrastructure files are kept out of user repos.

The original bead (gt-78j) was misdiagnosed as a settings location problem. The actual root causes were fix/recreate cycles in gt doctor, which were resolved by PRs #1987 (backfill DefaultBase into stale hooks-base.json), #1988 (make no_prime_hook fixable), and #1989 (doctor/daemon ordering race).

## Solution

Restores all 10 files touched by PR #1985 to their pre-PR state for refinery-related paths:

- `RoleSettingsDir`: refinery back in the shared `"crew", "witness", "refinery"` case
- `DiscoverTargets`: checks `refinery/` not `refinery/rig/`
- `determineTargets`: targets `refinery/` not `refinery/rig/`
- `resolveSettingsTarget`: refinery back in the shared case with crew/polecats/witness
- Doctor `findSettingsFiles`: correct=`refinery/.claude/settings.json`, stale=workdir files (with git-tracked skip)
- Doctor `config_check.go`: refinery settings at parent dir
- All test expectations updated to match

## Testing

- `go test ./...` passes (only pre-existing flaky `TestRunAgentsList_EmptyList_Output` fails, tracked as gt-k97)
- `go build` clean, `go vet` clean
- All 7 non-shared files verified byte-identical to pre-PR #1985 state
- Remaining 3 files have only unrelated additions from other PRs; refinery-specific lines match pre-PR state
- Local testing confirms refinery starts and completes full patrol cycles with settings at parent directory