### PR TITLE
feat(doctor): make env-vars check auto-fixable via gt doctor --fix

### DIFF
--- a/internal/doctor/env_check.go
+++ b/internal/doctor/env_check.go
@@ -8,46 +8,72 @@ import (
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
-// SessionEnvReader abstracts tmux session environment access for testing.
+// SessionEnvReader abstracts tmux session environment reads for testing.
 type SessionEnvReader interface {
 	ListSessions() ([]string, error)
 	GetAllEnvironment(session string) (map[string]string, error)
 }
 
-// tmuxEnvReader wraps real tmux operations.
-type tmuxEnvReader struct {
+// SessionEnvWriter abstracts tmux session environment writes for testing.
+type SessionEnvWriter interface {
+	SetEnvironment(session, key, value string) error
+}
+
+// SessionEnvAccessor combines read and write access to tmux session environments.
+type SessionEnvAccessor interface {
+	SessionEnvReader
+	SessionEnvWriter
+}
+
+// tmuxEnvReaderWriter wraps real tmux operations for both reading and writing.
+type tmuxEnvReaderWriter struct {
 	t *tmux.Tmux
 }
 
-func (r *tmuxEnvReader) ListSessions() ([]string, error) {
+func (r *tmuxEnvReaderWriter) ListSessions() ([]string, error) {
 	return r.t.ListSessions()
 }
 
-func (r *tmuxEnvReader) GetAllEnvironment(session string) (map[string]string, error) {
+func (r *tmuxEnvReaderWriter) GetAllEnvironment(session string) (map[string]string, error) {
 	return r.t.GetAllEnvironment(session)
+}
+
+func (r *tmuxEnvReaderWriter) SetEnvironment(session, key, value string) error {
+	return r.t.SetEnvironment(session, key, value)
 }
 
 // EnvVarsCheck verifies that tmux session environment variables match expected values.
 type EnvVarsCheck struct {
-	BaseCheck
-	reader SessionEnvReader // nil means use real tmux
+	FixableCheck
+	reader   SessionEnvReader  // nil means use real tmux
+	accessor SessionEnvAccessor // non-nil when Fix() support is needed
 }
 
 // NewEnvVarsCheck creates a new env vars check.
 func NewEnvVarsCheck() *EnvVarsCheck {
 	return &EnvVarsCheck{
-		BaseCheck: BaseCheck{
-			CheckName:        "env-vars",
-			CheckDescription: "Verify tmux session environment variables match expected values",
-			CheckCategory:    CategoryConfig,
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "env-vars",
+				CheckDescription: "Verify tmux session environment variables match expected values",
+				CheckCategory:    CategoryConfig,
+			},
 		},
 	}
 }
 
-// NewEnvVarsCheckWithReader creates a check with a custom reader (for testing).
+// NewEnvVarsCheckWithReader creates a check with a custom reader (for testing Run()).
 func NewEnvVarsCheckWithReader(reader SessionEnvReader) *EnvVarsCheck {
 	c := NewEnvVarsCheck()
 	c.reader = reader
+	return c
+}
+
+// NewEnvVarsCheckWithAccessor creates a check with a custom accessor (for testing Fix()).
+func NewEnvVarsCheckWithAccessor(accessor SessionEnvAccessor) *EnvVarsCheck {
+	c := NewEnvVarsCheck()
+	c.accessor = accessor
+	c.reader = accessor
 	return c
 }
 
@@ -55,7 +81,7 @@ func NewEnvVarsCheckWithReader(reader SessionEnvReader) *EnvVarsCheck {
 func (c *EnvVarsCheck) Run(ctx *CheckContext) *CheckResult {
 	reader := c.reader
 	if reader == nil {
-		reader = &tmuxEnvReader{t: tmux.NewTmux()}
+		reader = &tmuxEnvReaderWriter{t: tmux.NewTmux()}
 	}
 
 	sessions, err := reader.ListSessions()
@@ -176,6 +202,57 @@ func (c *EnvVarsCheck) Run(ctx *CheckContext) *CheckResult {
 		Status:  StatusWarning,
 		Message: fmt.Sprintf("Found %d env var mismatch(es) across %d session(s)", len(mismatches), checkedCount),
 		Details: details,
-		FixHint: "Run 'gt shutdown && gt up' to restart sessions with correct env vars",
+		FixHint: "Run 'gt doctor --fix' to apply missing env vars in-place, or 'gt shutdown && gt up' to restart",
 	}
+}
+
+// Fix applies missing or incorrect env vars to all Gas Town tmux sessions in-place.
+// The running Claude process is unaffected (it already has env vars from startup);
+// this updates the tmux session store so future processes and gt doctor agree.
+func (c *EnvVarsCheck) Fix(ctx *CheckContext) error {
+	accessor := c.accessor
+	if accessor == nil {
+		accessor = &tmuxEnvReaderWriter{t: tmux.NewTmux()}
+	}
+
+	sessions, err := accessor.ListSessions()
+	if err != nil {
+		// No tmux server — nothing to fix.
+		return nil
+	}
+
+	for _, sess := range sessions {
+		if !session.IsKnownSession(sess) {
+			continue
+		}
+		identity, err := session.ParseSessionName(sess)
+		if err != nil {
+			continue
+		}
+
+		role := string(identity.Role)
+		if identity.Role == session.RoleDeacon && identity.Name == "boot" {
+			role = "boot"
+		}
+
+		expected := config.AgentEnv(config.AgentEnvConfig{
+			Role:      role,
+			Rig:       identity.Rig,
+			AgentName: identity.Name,
+			TownRoot:  ctx.TownRoot,
+		})
+
+		actual, err := accessor.GetAllEnvironment(sess)
+		if err != nil {
+			continue
+		}
+
+		for key, expectedVal := range expected {
+			actualVal, exists := actual[key]
+			if !exists || actualVal != expectedVal {
+				_ = accessor.SetEnvironment(sess, key, expectedVal)
+			}
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
## Summary

- `EnvVarsCheck` previously embedded `BaseCheck` (`CanFix()=false`), leaving `gt shutdown && gt up` as the only documented fix
- Root cause analysis showed that `tmux set-environment` can safely update the tmux session env store in-place — running Claude processes already have correct env via `exec env` in startup commands, so no process is affected
- This implements `Fix()` on `EnvVarsCheck` so `gt doctor --fix` resolves env-var mismatches without a full restart

## Changes

- Add `SessionEnvWriter`/`SessionEnvAccessor` interfaces + `tmuxEnvReaderWriter` wrapping both read/write tmux ops
- Rename `tmuxEnvReader` → `tmuxEnvReaderWriter` (now implements both interfaces)
- Change `EnvVarsCheck` to embed `FixableCheck` (was `BaseCheck`) — `CanFix()` now returns `true`
- Add `Fix()`: iterates Gas Town sessions, computes expected vars via `config.AgentEnv()`, applies missing/wrong vars via `SetEnvironment()`; skips non-Gas-Town sessions and sessions that fail to parse
- Add `NewEnvVarsCheckWithAccessor` constructor for testing `Fix()`
- Update `FixHint` to mention `gt doctor --fix` as primary solution
- 4 new tests: `TestEnvVarsCheck_CanFix`, `TestEnvVarsCheck_FixNoSessions`, `TestEnvVarsCheck_FixAppliesMissingVars`, `TestEnvVarsCheck_FixSkipsCorrectVars`

## Background

Two root causes trigger recurring env-var mismatches:
1. **hq-mayor manual startup** (`tmux new-session -s hq-mayor -d "..."`) bypasses Gas Town session lifecycle, leaving zero Gas Town vars in the session env store
2. **Binary upgrade window**: sessions created between old binary run and `gt up` may lack vars added in newer binary versions

Both can now be resolved with `gt doctor --fix` instead of a full restart.

Closes bead gt-126wpg8.

## Test plan

- [x] `go test ./internal/doctor/` — all tests pass (40s)
- [x] `go test ./...` — zero failures across entire suite
- [x] `go build ./...` — builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)