### PR TITLE
fix: update nix package for v0.8.0 with ldflags

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -8,16 +8,16 @@
         ]
       },
       "locked": {
-        "lastModified": 1768216872,
-        "narHash": "sha256-DwIR/r1TJnpVd/CT1E2OTkAjU7k9/KHbcVwg5zziFVg=",
+        "lastModified": 1771616311,
+        "narHash": "sha256-HTcmGKn2NNoBEg5yRsnVIATNdte5Xw8E86D09e1X5nk=",
         "owner": "steveyegge",
         "repo": "beads",
-        "rev": "279192c5fbf851d0e47feaa7a5b5a9a6df325866",
+        "rev": "21f49ddb1aaa1acd47a264f48981869bd51c4ffa",
         "type": "github"
       },
       "original": {
         "owner": "steveyegge",
-        "ref": "v0.47.1",
+        "ref": "v0.55.4",
         "repo": "beads",
         "type": "github"
       }
@@ -60,11 +60,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1768305791,
-        "narHash": "sha256-AIdl6WAn9aymeaH/NvBj0H9qM+XuAuYbGMZaP0zcXAQ=",
+        "lastModified": 1771848320,
+        "narHash": "sha256-0MAd+0mun3K/Ns8JATeHT1sX28faLII5hVLq0L3BdZU=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "1412caf7bf9e660f2f962917c14b1ea1c3bc695e",
+        "rev": "2fc6539b481e1d2569f25f8799236694180c0993",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -10,8 +10,15 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, beads }:
-    flake-utils.lib.eachDefaultSystem (system:
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      beads,
+    }:
+    flake-utils.lib.eachDefaultSystem (
+      system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
         beads = self.inputs.beads.packages.${system};
@@ -20,9 +27,14 @@
         packages = {
           gt = pkgs.buildGoModule {
             pname = "gt";
-            version = "0.6.0";
+            version = "0.8.0";
             src = ./.;
-            vendorHash = "sha256-ripY9vrYgVW8bngAyMLh0LkU/Xx1UUaLgmAA7/EmWQU=";
+            vendorHash = "sha256-XWv/slFm796AO928eqzVHms0uUX4ZMJk0I4mZz+kp54=";
+
+            ldflags = [
+              "-X github.com/steveyegge/gastown/internal/cmd.Build=nix"
+              "-X github.com/steveyegge/gastown/internal/cmd.BuiltProperly=1"
+            ];
 
             subPackages = [ "cmd/gt" ];
 


### PR DESCRIPTION
Update vendorHash and version. Set Build and BuiltProperly ldflags to suppress the "built with go build directly" warning. Update flake inputs.

By the way, maybe there should be CI to test build of package, and git hooks to update vendorHash before commit?

## Summary
Fixed build of nix package and disabled "This binary was built with 'go build' directly." warning for nix build.

## Changes
Just update of flake.nix and flake.lock

## Testing
<!-- How did you test these changes? -->
- [ ] Unit tests pass (`go test ./...`) *didn't change any code*
- [x] Manual testing performed

## Checklist
- [x] Code follows project style
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)
