### PR TITLE
fix(deacon): correct commands and add heartbeat to patrol formula

### DIFF
--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -43,8 +43,26 @@ description = "Type of wisp created for this molecule"
 default = "patrol"
 
 [[steps]]
+id = "heartbeat"
+title = "Refresh heartbeat"
+description = """
+Signal liveness to the daemon.
+
+The daemon monitors `deacon/heartbeat.json` and kills the Deacon if it goes stale
+(>15 minutes without update). Refresh the heartbeat at the start of every patrol cycle
+so the daemon knows we are alive.
+
+```bash
+gt deacon heartbeat "starting patrol cycle"
+```
+
+This MUST run before any other step. Skipping it risks the daemon killing a healthy
+Deacon mid-cycle."""
+
+[[steps]]
 id = "inbox-check"
 title = "Handle callbacks from agents"
+needs = ["heartbeat"]
 description = """
 First, clean up wisps from previous cycles (closed wisps + abandoned wisps):
 ```bash
@@ -453,9 +471,20 @@ gt mail send gastown/witness -s "Dependency resolved: <bd-xxx>" \\
 Keep notifications brief and actionable. The recipient can run bd show for details."""
 
 [[steps]]
+id = "heartbeat-mid"
+title = "Mid-cycle heartbeat refresh"
+needs = ["orphan-process-cleanup", "test-pollution-cleanup", "dispatch-gated-molecules", "fire-notifications"]
+description = """
+Refresh the heartbeat mid-cycle to prevent the daemon from killing us during long patrols.
+
+```bash
+gt deacon heartbeat "mid-cycle checkpoint"
+```"""
+
+[[steps]]
 id = "health-scan"
 title = "Check Witness and Refinery health"
-needs = ["orphan-process-cleanup", "test-pollution-cleanup", "dispatch-gated-molecules", "fire-notifications"]
+needs = ["heartbeat-mid"]
 description = """
 Check Witness and Refinery health for each rig.
 

--- a/internal/formula/patrol_backoff_test.go
+++ b/internal/formula/patrol_backoff_test.go
@@ -195,3 +195,65 @@ func TestPatrolFormulasHaveWispGC(t *testing.T) {
 		})
 	}
 }
+
+// TestDeaconPatrolHasHeartbeatSteps verifies the deacon patrol formula
+// includes heartbeat refresh steps to prevent the daemon from killing a
+// healthy Deacon mid-cycle.
+//
+// Without heartbeat refreshes, a patrol cycle that exceeds 15 minutes
+// (HeartbeatVeryStaleThreshold) causes the daemon to consider the Deacon
+// stuck and kill it, even though the Deacon is actively executing steps.
+func TestDeaconPatrolHasHeartbeatSteps(t *testing.T) {
+	content, err := formulasFS.ReadFile("formulas/mol-deacon-patrol.formula.toml")
+	if err != nil {
+		t.Fatalf("reading deacon patrol formula: %v", err)
+	}
+
+	f, err := Parse(content)
+	if err != nil {
+		t.Fatalf("parsing deacon patrol formula: %v", err)
+	}
+
+	// The first step must be the heartbeat step (no dependencies)
+	if len(f.Steps) == 0 {
+		t.Fatal("deacon patrol formula has no steps")
+	}
+	if f.Steps[0].ID != "heartbeat" {
+		t.Errorf("first step should be \"heartbeat\", got %q", f.Steps[0].ID)
+	}
+	if !strings.Contains(f.Steps[0].Description, "gt deacon heartbeat") {
+		t.Error("heartbeat step must contain \"gt deacon heartbeat\" command")
+	}
+
+	// inbox-check must depend on heartbeat
+	for _, step := range f.Steps {
+		if step.ID == "inbox-check" {
+			hasHeartbeatDep := false
+			for _, dep := range step.Needs {
+				if dep == "heartbeat" {
+					hasHeartbeatDep = true
+					break
+				}
+			}
+			if !hasHeartbeatDep {
+				t.Error("inbox-check step must depend on \"heartbeat\" step")
+			}
+			break
+		}
+	}
+
+	// There should be a mid-cycle heartbeat step
+	foundMid := false
+	for _, step := range f.Steps {
+		if step.ID == "heartbeat-mid" {
+			foundMid = true
+			if !strings.Contains(step.Description, "gt deacon heartbeat") {
+				t.Error("heartbeat-mid step must contain \"gt deacon heartbeat\" command")
+			}
+			break
+		}
+	}
+	if !foundMid {
+		t.Error("deacon patrol formula must have a \"heartbeat-mid\" step for mid-cycle refresh")
+	}
+}


### PR DESCRIPTION
Three fixes to the deacon patrol formula:

1. **Gated check command**: `bd mol ready --gated --json` does not exist. Corrected to `bd ready --gated --json`.

2. **Stale dog detection**: Step 3 of dog pool maintenance used `gt dog status <name>` to check staleness, but that command does not show staleness in its output. Changed to `gt dogs list --json` which includes `last_active` timestamps needed to identify stale dogs.

3. **Heartbeat refresh**: The patrol formula had no heartbeat step. The initial prompt wrote the heartbeat once at startup, then it went stale during the ~25-step patrol cycle. After 15 minutes (`HeartbeatVeryStaleThreshold`), the daemon considered the deacon stuck and killed it — causing a restart loop (cycle 196+). Added `heartbeat` as the first step and `heartbeat-mid` before `health-scan` to keep the heartbeat fresh throughout the cycle.