### PR TITLE
fix(daemon): use NewSessionWithCommand to prevent empty polecat windows

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -1104,7 +1105,6 @@ func (d *Daemon) isRigOperational(rigName string) (bool, string) {
 	return true, ""
 }
 
-
 // processLifecycleRequests checks for and processes lifecycle requests.
 func (d *Daemon) processLifecycleRequests() {
 	d.ProcessLifecycleRequests()
@@ -1622,21 +1622,31 @@ func (d *Daemon) restartPolecatSession(rigName, polecatName, sessionName string)
 	// Pre-sync workspace (ensure beads are current)
 	d.syncWorkspace(workDir)
 
-	// Create new tmux session
-	// Use EnsureSessionFresh to handle zombie sessions that exist but have dead Claude
-	if err := d.tmux.EnsureSessionFresh(sessionName, workDir); err != nil {
-		return fmt.Errorf("creating session: %w", err)
-	}
-
-	// Set environment variables using centralized AgentEnv
+	// Build startup command BEFORE creating the session so we can use
+	// NewSessionWithCommand (command as initial pane process). This eliminates
+	// the race condition in the old EnsureSessionFresh + SendKeys pattern where
+	// the shell might not be ready to receive keystrokes, producing empty windows.
 	envVars := config.AgentEnv(config.AgentEnvConfig{
 		Role:      "polecat",
 		Rig:       rigName,
 		AgentName: polecatName,
 		TownRoot:  d.config.TownRoot,
 	})
+	rc := config.ResolveRoleAgentConfig("polecat", d.config.TownRoot, rigPath)
+	startCmd := config.BuildStartupCommand(envVars, rigPath, "")
 
-	// Set all env vars in tmux session (for debugging) and they'll also be exported to Claude
+	// Create session with command as initial process (replaces EnsureSessionFresh + SendKeys).
+	// EnsureSessionFreshWithCommand kills zombie sessions and creates a new one atomically.
+	if err := d.tmux.EnsureSessionFreshWithCommand(sessionName, workDir, startCmd); err != nil {
+		if errors.Is(err, tmux.ErrSessionRunning) {
+			d.logger.Printf("Session %s already running with healthy agent, skipping restart", sessionName)
+			return nil
+		}
+		return fmt.Errorf("creating session: %w", err)
+	}
+
+	// Set environment variables in tmux session table (for debugging/monitoring tools).
+	// The process itself gets env vars via 'exec env ...' in the startup command.
 	for k, v := range envVars {
 		_ = d.tmux.SetEnvironment(sessionName, k, v)
 	}
@@ -1645,7 +1655,6 @@ func (d *Daemon) restartPolecatSession(rigName, polecatName, sessionName string)
 	// (e.g., witness patrol) can detect non-Claude agents.
 	// BuildStartupCommand sets GT_AGENT in process env via exec env, but that
 	// isn't visible to tmux show-environment.
-	rc := config.ResolveRoleAgentConfig("polecat", d.config.TownRoot, rigPath)
 	if rc.ResolvedAgent != "" {
 		_ = d.tmux.SetEnvironment(sessionName, "GT_AGENT", rc.ResolvedAgent)
 	}
@@ -1662,15 +1671,7 @@ func (d *Daemon) restartPolecatSession(rigName, polecatName, sessionName string)
 	agentID := fmt.Sprintf("%s/%s", rigName, polecatName)
 	_ = d.tmux.SetPaneDiedHook(sessionName, agentID)
 
-	// Launch Claude with environment exported inline
-	// Pass rigPath so rig agent settings are honored (not town-level defaults)
-	startCmd := config.BuildStartupCommand(envVars, rigPath, "")
-	if err := d.tmux.SendKeys(sessionName, startCmd); err != nil {
-		return fmt.Errorf("sending startup command: %w", err)
-	}
-
-	// Wait for Claude to start, then accept bypass permissions warning if it appears.
-	// This ensures automated restarts aren't blocked by the warning dialog.
+	// Wait for Claude to start, then accept startup dialogs if they appear.
 	if err := d.tmux.WaitForCommand(sessionName, constants.SupportedShells, constants.ClaudeStartTimeout); err != nil {
 		// Non-fatal - Claude might still start
 	}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -39,11 +39,12 @@ var validSessionNameRe = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
 // Common errors
 var (
-	ErrNoServer            = errors.New("no tmux server running")
-	ErrSessionExists       = errors.New("session already exists")
-	ErrSessionNotFound     = errors.New("session not found")
-	ErrInvalidSessionName  = errors.New("invalid session name")
-	ErrIdleTimeout         = errors.New("agent not idle before timeout")
+	ErrNoServer           = errors.New("no tmux server running")
+	ErrSessionExists      = errors.New("session already exists")
+	ErrSessionNotFound    = errors.New("session not found")
+	ErrSessionRunning     = errors.New("session already running with healthy agent")
+	ErrInvalidSessionName = errors.New("invalid session name")
+	ErrIdleTimeout        = errors.New("agent not idle before timeout")
 )
 
 // validateSessionName checks that a session name contains only safe characters.
@@ -270,6 +271,38 @@ func (t *Tmux) EnsureSessionFresh(name, workDir string) error {
 		return nil
 	}
 	return err
+}
+
+// EnsureSessionFreshWithCommand is like EnsureSessionFresh but creates the
+// session with a command as the pane's initial process via NewSessionWithCommand.
+// This eliminates the race condition in the EnsureSessionFresh + SendKeys pattern
+// where the shell may not be ready to receive keystrokes, resulting in empty
+// windows. The command runs as the pane's initial process — no shell involved.
+//
+// If an existing session has a healthy agent, returns ErrSessionRunning.
+func (t *Tmux) EnsureSessionFreshWithCommand(name, workDir, command string) error {
+	if err := validateSessionName(name); err != nil {
+		return err
+	}
+
+	// Check if session exists
+	running, err := t.HasSession(name)
+	if err != nil {
+		return fmt.Errorf("checking session: %w", err)
+	}
+	if running {
+		if t.IsAgentRunning(name) {
+			// Session is healthy — don't replace it
+			return ErrSessionRunning
+		}
+		// Zombie session: tmux alive but agent dead — kill it
+		if err := t.KillSessionWithProcesses(name); err != nil {
+			return fmt.Errorf("killing zombie session: %w", err)
+		}
+	}
+
+	// Create session with command as the initial process
+	return t.NewSessionWithCommand(name, workDir, command)
 }
 
 // KillSession terminates a tmux session. Idempotent: returns nil if the
@@ -1104,8 +1137,8 @@ func (t *Tmux) NudgePane(pane, message string) error {
 
 // AcceptStartupDialogs dismisses all Claude Code startup dialogs that can block
 // automated sessions. Currently handles (in order):
-//   1. Workspace trust dialog ("Quick safety check" / "trust this folder") — v2.1.55+
-//   2. Bypass permissions warning ("Bypass Permissions mode") — requires Down+Enter
+//  1. Workspace trust dialog ("Quick safety check" / "trust this folder") — v2.1.55+
+//  2. Bypass permissions warning ("Bypass Permissions mode") — requires Down+Enter
 //
 // Call this after starting Claude and waiting for it to initialize (WaitForCommand),
 // but before sending any prompts. Idempotent: safe to call on sessions without dialogs.
@@ -2562,4 +2595,3 @@ func (t *Tmux) SetAutoRespawnHook(session string) error {
 
 	return nil
 }
-

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -316,6 +316,89 @@ func TestEnsureSessionFresh_IdempotentOnZombie(t *testing.T) {
 	}
 }
 
+func TestEnsureSessionFreshWithCommand_NoExisting(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+
+	tm := NewTmux()
+	sessionName := "gt-test-fwc-new-" + t.Name()
+
+	// Clean up any existing session
+	_ = tm.KillSession(sessionName)
+	defer func() { _ = tm.KillSession(sessionName) }()
+
+	// EnsureSessionFreshWithCommand should create a new session with the command
+	// as the initial pane process (no shell involved).
+	if err := tm.EnsureSessionFreshWithCommand(sessionName, "", "sleep 10"); err != nil {
+		t.Fatalf("EnsureSessionFreshWithCommand: %v", err)
+	}
+
+	// Verify session exists
+	has, err := tm.HasSession(sessionName)
+	if err != nil {
+		t.Fatalf("HasSession: %v", err)
+	}
+	if !has {
+		t.Error("expected session to exist")
+	}
+
+	// Verify the command is running (not a shell)
+	cmd, err := tm.GetPaneCommand(sessionName)
+	if err != nil {
+		t.Fatalf("GetPaneCommand: %v", err)
+	}
+	if cmd != "sleep" {
+		t.Logf("pane command = %q (expected 'sleep')", cmd)
+	}
+}
+
+func TestEnsureSessionFreshWithCommand_KillsZombie(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+
+	tm := NewTmux()
+	sessionName := "gt-test-fwc-zombie-" + t.Name()
+
+	// Clean up any existing session
+	_ = tm.KillSession(sessionName)
+	defer func() { _ = tm.KillSession(sessionName) }()
+
+	// Create a zombie session (empty shell, no agent)
+	if err := tm.NewSession(sessionName, ""); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+
+	// Verify it's a zombie
+	if tm.IsAgentRunning(sessionName) {
+		t.Skip("session unexpectedly has agent running")
+	}
+
+	// EnsureSessionFreshWithCommand should kill the zombie and create fresh session
+	if err := tm.EnsureSessionFreshWithCommand(sessionName, "", "sleep 10"); err != nil {
+		t.Fatalf("EnsureSessionFreshWithCommand on zombie: %v", err)
+	}
+
+	// Session should exist with the new command
+	has, err := tm.HasSession(sessionName)
+	if err != nil {
+		t.Fatalf("HasSession: %v", err)
+	}
+	if !has {
+		t.Error("expected session to exist after replacing zombie")
+	}
+
+	// The command should be sleep, not a shell
+	cmd, err := tm.GetPaneCommand(sessionName)
+	if err != nil {
+		t.Fatalf("GetPaneCommand: %v", err)
+	}
+	if cmd != "sleep" {
+		t.Logf("pane command = %q (expected 'sleep' after zombie replacement)", cmd)
+	}
+}
+
 func TestIsAgentRunning(t *testing.T) {
 	if !hasTmux() {
 		t.Skip("tmux not installed")
@@ -1775,7 +1858,7 @@ func TestNudgeSession_WithRetry(t *testing.T) {
 func TestMatchesPromptPrefix(t *testing.T) {
 	const (
 		nbsp          = "\u00a0" // non-breaking space
-		regularPrefix = "❯ "    // default: ❯ + regular space
+		regularPrefix = "❯ "     // default: ❯ + regular space
 	)
 
 	tests := []struct {


### PR DESCRIPTION
## Summary

- Replace unsafe `EnsureSessionFresh` + `SendKeys` pattern with `EnsureSessionFreshWithCommand` in both daemon restart paths
- Add `EnsureSessionFreshWithCommand` to tmux package — kills zombie sessions then creates new session with command as initial pane process
- Eliminates race condition where shell isn't ready to receive keystrokes, producing empty/blank tmux windows

## Problem

The daemon's `restartPolecatSession` (daemon.go) and `restartSession` (lifecycle.go) used a two-step pattern:

1. `EnsureSessionFresh(name, workDir)` — creates session with empty shell
2. `SendKeys(name, startCmd)` — sends the `exec env ... claude ...` command as keystrokes

If the shell isn't fully initialized when `SendKeys` fires (race window between session creation and shell readiness), the command is lost — producing an empty tmux window with no agent running.

## Fix

New `EnsureSessionFreshWithCommand(name, workDir, command)` method:
1. Checks for existing zombie sessions and kills them
2. Creates session via `NewSessionWithCommand` — the command becomes the pane's initial process (no shell intermediary)
3. Returns `ErrSessionRunning` if session already has a healthy agent

This matches the safe pattern already used by `session_manager.Start()` for fresh polecat spawns via `gt sling`.

## Testing

2 new integration tests:
- `TestEnsureSessionFreshWithCommand_NoExisting` — fresh session with command as initial process
- `TestEnsureSessionFreshWithCommand_KillsZombie` — zombie replacement with command

All existing `EnsureSessionFresh` tests pass unchanged.