### PR TITLE
Fail closed on hooks settings integrity violations

### DIFF
--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -793,6 +793,22 @@ func TestLoadSettings(t *testing.T) {
 	}
 }
 
+func TestLoadSettingsIntegrityError(t *testing.T) {
+	tmpDir := t.TempDir()
+	path := filepath.Join(tmpDir, "settings.json")
+	if err := os.WriteFile(path, []byte(`{"hooks":{"SessionStart":"bad"}}`), 0644); err != nil {
+		t.Fatalf("failed to write: %v", err)
+	}
+
+	_, err := LoadSettings(path)
+	if err == nil {
+		t.Fatal("expected integrity error for malformed settings")
+	}
+	if !IsSettingsIntegrityError(err) {
+		t.Fatalf("expected SettingsIntegrityError, got %T: %v", err, err)
+	}
+}
+
 func TestDiscoverTargets(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Problem
Hook synchronization/install can continue after malformed `.git/worktrees/.../hooks/settings.json` content, which hides integrity problems and leaves hook state inconsistent.

## Why now
Issue #2026 reports concrete operator pain from integrity failures being treated permissively. This causes non-deterministic hook lifecycle behavior across worktrees.

## What changed
- Added a dedicated settings-integrity error type in hooks config loading.
- Treated malformed JSON and invalid hook configuration as integrity violations.
- Updated `hooks sync` and `hooks install` flows to fail closed when any target has integrity failures.
- Added deterministic failure summaries and non-zero exit behavior for integrity violations.
- Added regression tests for integrity error classification and fail-closed sync behavior.

## Validation
- `go test ./internal/hooks ./internal/cmd -run 'TestLoadSettingsIntegrityError|TestSyncTarget|TestRunHooksSyncFailsClosedOnIntegrityViolation'` (pass)

Refs #2026
