### PR TITLE
fix(session): derive tmux socket from town name, not $TMUX

### DIFF
--- a/internal/session/registry_socket_test.go
+++ b/internal/session/registry_socket_test.go
@@ -1,6 +1,98 @@
 package session
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// TestInitRegistry_SocketFromTownName verifies that InitRegistry derives the
+// tmux socket name from the town directory name, NOT from $TMUX.
+//
+// This is the regression test for gt-qkekp: when gt up is run from a terminal
+// attached to the default tmux server ($TMUX=/tmp/tmux-1000/default,...),
+// InitRegistry used to parse "default" from $TMUX and set that as the socket.
+// This caused all sessions to land on the default server instead of a
+// town-specific socket (e.g., -L gt).
+func TestInitRegistry_SocketFromTownName(t *testing.T) {
+	// Save and restore $TMUX and the default socket
+	origTMUX := os.Getenv("TMUX")
+	origSocket := tmux.GetDefaultSocket()
+	t.Cleanup(func() {
+		os.Setenv("TMUX", origTMUX)
+		tmux.SetDefaultSocket(origSocket)
+	})
+
+	tests := []struct {
+		name       string
+		tmuxEnv    string // $TMUX value (simulating being inside tmux)
+		townDir    string // basename of the town root directory
+		wantSocket string // expected tmux socket name
+	}{
+		{
+			name:       "inside default tmux, town=gt",
+			tmuxEnv:    "/tmp/tmux-1000/default,12345,0",
+			townDir:    "gt",
+			wantSocket: "gt",
+		},
+		{
+			name:       "inside gt tmux, town=gt",
+			tmuxEnv:    "/tmp/tmux-1000/gt,12345,0",
+			townDir:    "gt",
+			wantSocket: "gt",
+		},
+		{
+			name:       "outside tmux (daemon), town=gt",
+			tmuxEnv:    "",
+			townDir:    "gt",
+			wantSocket: "gt",
+		},
+		{
+			name:       "town name with spaces",
+			tmuxEnv:    "/tmp/tmux-1000/default,99,0",
+			townDir:    "My Town",
+			wantSocket: "my-town",
+		},
+		{
+			name:       "town name with caps",
+			tmuxEnv:    "",
+			townDir:    "GasTown",
+			wantSocket: "gastown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset socket before each test
+			tmux.SetDefaultSocket("")
+
+			// Set $TMUX to simulate the terminal environment
+			if tt.tmuxEnv != "" {
+				os.Setenv("TMUX", tt.tmuxEnv)
+			} else {
+				os.Unsetenv("TMUX")
+			}
+
+			// Create a minimal fake town root. InitRegistry will fail to load
+			// rigs.json and agents.json but that's fine — we only care about
+			// the socket name it sets.
+			townRoot := filepath.Join(t.TempDir(), tt.townDir)
+			os.MkdirAll(townRoot, 0o755)
+
+			// InitRegistry may return errors for missing config — ignore them.
+			// The socket is set unconditionally before any config loading.
+			_ = InitRegistry(townRoot)
+
+			got := tmux.GetDefaultSocket()
+			if got != tt.wantSocket {
+				t.Errorf("after InitRegistry(%q) with TMUX=%q:\n  socket = %q, want %q",
+					townRoot, tt.tmuxEnv, got, tt.wantSocket)
+			}
+		})
+	}
+}
 
 func TestSanitizeTownName(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary

- **Bug**: `InitRegistry()` parsed `$TMUX` to determine the tmux socket name, causing all sessions to land on the `default` server when `gt up` was run from an interactive terminal. The daemon (no `$TMUX`) left the socket empty, also falling through to the default server.
- **Fix**: Replace `$TMUX` parsing with `sanitizeTownName(filepath.Base(townRoot))`, which deterministically derives the socket from the town directory name (e.g., `/home/user/gt` → `-L gt`). All callers — CLI, daemon, agents — now target the same dedicated tmux server.
- The `sanitizeTownName` function already existed with tests but was never wired into `InitRegistry`.

## Root Cause

Commit `33362a75` (socket migration) introduced per-town sockets but `InitRegistry` at `session/registry.go:121-126` trusted `$TMUX` blindly:

```go
if tmuxEnv := os.Getenv("TMUX"); tmuxEnv != "" {
    if socketPath, _, ok := strings.Cut(tmuxEnv, ","); ok && socketPath != "" {
        tmux.SetDefaultSocket(filepath.Base(socketPath))
    }
}
```

When running from a terminal on the default tmux server, `$TMUX` is `/tmp/tmux-1000/default,...` → socket = `"default"` → sessions created on wrong server.

## Test Plan

New `TestInitRegistry_SocketFromTownName` with 5 cases:
1. Inside default tmux, town=gt → socket should be `"gt"` (was `"default"`)
2. Inside gt tmux, town=gt → socket should be `"gt"` (already worked)
3. Outside tmux (daemon), town=gt → socket should be `"gt"` (was `""`)
4. Town name with spaces → sanitized correctly
5. Town name with caps → lowercased correctly

Closes gt-qkekp