### PR TITLE
fix(doctor): don't flag absent env vars when expected value is empty

### DIFF
--- a/internal/doctor/env_check.go
+++ b/internal/doctor/env_check.go
@@ -124,9 +124,12 @@ func (c *EnvVarsCheck) Run(ctx *CheckContext) *CheckResult {
 		// Compare each expected var
 		for key, expectedVal := range expected {
 			actualVal, exists := actual[key]
-			if !exists {
+			if !exists && expectedVal != "" {
+				// Only flag missing vars when the expected value is non-empty.
+				// An absent var has the same effect as an empty one (e.g. CLAUDECODE=""
+				// prevents nested session detection, but so does CLAUDECODE being unset).
 				mismatches = append(mismatches, fmt.Sprintf("%s: missing %s (expected %q)", sess, key, expectedVal))
-			} else if actualVal != expectedVal {
+			} else if exists && actualVal != expectedVal {
 				mismatches = append(mismatches, fmt.Sprintf("%s: %s=%q (expected %q)", sess, key, actualVal, expectedVal))
 			}
 		}


### PR DESCRIPTION
## Summary
- When `AgentEnv` returns `CLAUDECODE=""` to clear nested session detection, the env-vars check incorrectly flagged it as missing when the tmux session simply doesn't have `CLAUDECODE` set
- An absent variable has the same effect as an empty one — both clear the value
- Added guard to skip mismatch warning when expected value is empty and actual is absent

## Test plan
- [x] New test case in `env_check_test.go`
- [ ] Verify `gt doctor` no longer shows false CLAUDECODE mismatch after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)