### PR TITLE
fix: require Dolt server for beads init and reorder doctor prerequisites

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -145,10 +145,17 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 
 	d.Register(doctor.NewGlobalStateCheck())
 
-	// Register built-in checks
+	// Infrastructure prerequisites — these must pass before any check that
+	// shells out to bd/dolt or queries the database. Order matters:
+	// 1. gt binary freshness
+	// 2. bd binary exists
+	// 3. dolt binary exists
+	// 4. Dolt server is reachable (everything downstream depends on this)
 	d.Register(doctor.NewStaleBinaryCheck())
 	d.Register(doctor.NewBeadsBinaryCheck())
-	// All database queries go through bd CLI
+	d.Register(doctor.NewDoltBinaryCheck())
+	d.Register(doctor.NewDoltServerReachableCheck())
+
 	d.Register(doctor.NewTownGitCheck())
 	d.Register(doctor.NewTownRootBranchCheck())
 	d.Register(doctor.NewPreCheckoutHookCheck())
@@ -233,10 +240,8 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewStaleTaskDispatchCheck())
 	d.Register(doctor.NewHooksSyncCheck())
 
-	// Dolt health checks
-	d.Register(doctor.NewDoltBinaryCheck())
+	// Dolt data health checks (binary + server reachability moved to top as prerequisites)
 	d.Register(doctor.NewDoltMetadataCheck())
-	d.Register(doctor.NewDoltServerReachableCheck())
 	d.Register(doctor.NewDoltOrphanedDatabaseCheck())
 	d.Register(doctor.NewUnregisteredBeadsDirsCheck())
 	d.Register(doctor.NewNullAssigneeCheck())

--- a/internal/cmd/gitinit.go
+++ b/internal/cmd/gitinit.go
@@ -13,8 +13,8 @@ import (
 )
 
 var (
-	gitInitGitHub  string
-	gitInitPublic  bool
+	gitInitGitHub string
+	gitInitPublic bool
 )
 
 var gitInitCmd = &cobra.Command{
@@ -144,7 +144,7 @@ beads_hq/
 # Explicitly track (override above patterns)
 # =============================================================================
 # Note: .beads/ has its own .gitignore that handles database files
-# and keeps issues.jsonl, metadata.json, config file as source of truth
+# and keeps metadata.json, config file as source of truth
 `
 
 func runGitInit(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -508,8 +508,17 @@ func writeJSON(path string, data interface{}) error {
 
 // initTownBeads initializes town-level beads database using bd init.
 // Town beads use the "hq-" prefix for mayor mail and cross-rig coordination.
-// Uses Dolt backend in server mode (Gas Town runs a shared Dolt sql-server).
+// Uses Dolt backend in server mode (Gas Town requires a running Dolt sql-server).
 func initTownBeads(townPath string) error {
+	// Dolt server is required — refuse to proceed without it.
+	running, _, err := doltserver.IsRunning(townPath)
+	if err != nil {
+		return fmt.Errorf("checking Dolt server: %w", err)
+	}
+	if !running {
+		return fmt.Errorf("Dolt server is not running (required for beads init); start it with 'gt dolt start'")
+	}
+
 	// Run: bd init --prefix hq --server
 	// Dolt is the only backend since bd v0.51.0; no --backend flag needed.
 	// Filter inherited BEADS_DIR so bd init targets this town, not a parent .beads.

--- a/internal/cmd/ready.go
+++ b/internal/cmd/ready.go
@@ -1,10 +1,10 @@
 package cmd
 
 import (
-	"bufio"
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -378,40 +378,29 @@ func filterFormulaScaffolds(issues []*beads.Issue, formulaNames map[string]bool)
 	return filtered
 }
 
-// getWispIDs reads issues.jsonl and returns a set of IDs that are wisps.
-// Wisps are ephemeral issues (wisp: true flag) that shouldn't appear in ready work.
+// getWispIDs queries Dolt for wisp IDs that shouldn't appear in ready work.
+// Wisps are ephemeral issues (wisp/ephemeral flag) used for operational workflows.
 // This is a defense-in-depth exclusion - bd ready should already filter wisps,
 // but we double-check at the display layer to ensure operational work doesn't leak.
 func getWispIDs(beadsPath string) map[string]bool {
-	beadsDir := beads.ResolveBeadsDir(beadsPath)
-	issuesPath := filepath.Join(beadsDir, "issues.jsonl")
-	file, err := os.Open(issuesPath)
+	cmd := exec.Command("bd", "mol", "wisp", "list", "--json")
+	cmd.Dir = beadsPath
+	output, err := cmd.Output()
 	if err != nil {
-		return nil // No issues file
-	}
-	defer file.Close()
-
-	wispIDs := make(map[string]bool)
-	scanner := bufio.NewScanner(file)
-	for scanner.Scan() {
-		line := scanner.Text()
-		if line == "" {
-			continue
-		}
-
-		var issue struct {
-			ID   string `json:"id"`
-			Wisp bool   `json:"wisp"`
-		}
-		if err := json.Unmarshal([]byte(line), &issue); err != nil {
-			continue
-		}
-
-		if issue.Wisp {
-			wispIDs[issue.ID] = true
-		}
+		return nil // Wisp table may not exist or Dolt unavailable
 	}
 
+	var wisps []struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(output, &wisps); err != nil {
+		return nil
+	}
+
+	wispIDs := make(map[string]bool, len(wisps))
+	for _, w := range wisps {
+		wispIDs[w.ID] = true
+	}
 	return wispIDs
 }
 

--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -16,6 +16,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/crew"
 	"github.com/steveyegge/gastown/internal/deps"
+	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/hooks"
 	"github.com/steveyegge/gastown/internal/polecat"
@@ -1029,6 +1030,11 @@ func runRigAdopt(_ *cobra.Command, args []string) error {
 			if prefix == "" {
 				break
 			}
+			// Dolt server is required for beads init.
+			if running, _, sErr := doltserver.IsRunning(townRoot); sErr != nil || !running {
+				fmt.Printf("  %s Could not init bd database: Dolt server is not running\n", style.Warning.Render("!"))
+				break
+			}
 			if err := mgr.InitBeads(rigPath, prefix, name); err != nil {
 				fmt.Printf("  %s Could not init bd database: %v\n", style.Warning.Render("!"), err)
 			} else {
@@ -1041,7 +1047,10 @@ func runRigAdopt(_ *cobra.Command, args []string) error {
 	// If no existing .beads/ candidate was found, initialize a fresh database
 	// to match the behavior of the normal (non-adopt) gt rig add path.
 	if !foundBeadsCandidate && result.BeadsPrefix != "" {
-		if err := mgr.InitBeads(rigPath, result.BeadsPrefix, name); err != nil {
+		// Dolt server is required for beads init.
+		if running, _, sErr := doltserver.IsRunning(townRoot); sErr != nil || !running {
+			fmt.Printf("  %s Could not init beads database: Dolt server is not running\n", style.Warning.Render("!"))
+		} else if err := mgr.InitBeads(rigPath, result.BeadsPrefix, name); err != nil {
 			fmt.Printf("  %s Could not init beads database: %v\n", style.Warning.Render("!"), err)
 		} else {
 			fmt.Printf("  %s Initialized beads database\n", style.Success.Render("✓"))

--- a/internal/doctor/rig_routes_jsonl_check.go
+++ b/internal/doctor/rig_routes_jsonl_check.go
@@ -18,7 +18,7 @@ import (
 // 3. These files often exist due to a bug where bd's auto-export wrote issue data to routes.jsonl
 //
 // Fix: Delete routes.jsonl unconditionally. The Dolt database is the source
-// of truth, and bd will auto-export to issues.jsonl on next run.
+// of truth.
 type RigRoutesJSONLCheck struct {
 	FixableCheck
 	// affectedRigs tracks which rigs have routes.jsonl
@@ -100,8 +100,7 @@ func (c *RigRoutesJSONLCheck) Run(ctx *CheckContext) *CheckResult {
 }
 
 // Fix deletes routes.jsonl files in rig .beads directories.
-// The Dolt database is the source of truth - bd will auto-export
-// to issues.jsonl on next run.
+// The Dolt database is the source of truth.
 func (c *RigRoutesJSONLCheck) Fix(ctx *CheckContext) error {
 	// Re-run check to populate affectedRigs if needed
 	if len(c.affectedRigs) == 0 {

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -2119,8 +2119,8 @@ func FindOrCreateRigBeadsDir(townRoot, rigName string) (string, error) {
 	// The mayor/rig/.beads path should only be used when the source repo
 	// has tracked beads (checked out via git clone). Creating it here would
 	// cause InitBeads to misdetect an untracked repo as having tracked beads,
-	// taking the redirect early-return and skipping config.yaml/issues.jsonl
-	// creation (see rig/manager.go InitBeads).
+	// taking the redirect early-return and skipping config.yaml creation
+	// (see rig/manager.go InitBeads).
 	if err := os.MkdirAll(rigBeads, 0755); err != nil {
 		return "", fmt.Errorf("creating beads dir: %w", err)
 	}
@@ -2707,4 +2707,3 @@ func doltSQLScriptWithRetry(townRoot, script string) error {
 	}
 	return fmt.Errorf("after %d retries: %w", maxRetries, lastErr)
 }
-

--- a/internal/rig/overlay.go
+++ b/internal/rig/overlay.go
@@ -65,9 +65,9 @@ func EnsureGitignorePatterns(worktreePath string) error {
 
 	// Required patterns for Gas Town worktrees.
 	// DO NOT add ".beads/" here. Beads manages its own .beads/.gitignore
-	// (created by bd init) which selectively ignores runtime files while
-	// tracking issues.jsonl. Adding .beads/ here overrides that and breaks
-	// bd sync. This has regressed twice (PR #753 added it, #891 removed it,
+	// (created by bd init) which selectively ignores runtime files.
+	// Adding .beads/ here overrides that and breaks bd sync.
+	// This has regressed twice (PR #753 added it, #891 removed it,
 	// #966 re-added it). See overlay_test.go for a regression guard.
 	//
 	// NOTE: .claude/settings.json is NOT listed here because settings are now


### PR DESCRIPTION
## Summary

- Gate `AddRig`, `InitBeads`, and `initTownBeads` on `doltserver.IsRunning()` so they fail fast when the server is down
- Move `dolt-binary` and `dolt-server-reachable` doctor checks to positions 3-4, before any check that shells out to `bd`
- Rewrite `getWispIDs` from JSONL file parsing to `bd mol wisp list --json` (live Dolt query)
- Remove stale `issues.jsonl` creation from `InitBeads`

## Problem

1. **Silent failures on missing Dolt server.** `gt rig add` and `gt install` call `bd init` without checking if the Dolt server is running. When it's down, `bd init` fails with cryptic errors deep in the call stack. Users see confusing output instead of a clear "Dolt server is not running" message.

2. **Doctor checks run in wrong order.** `dolt-binary` and `dolt-server-reachable` are registered at positions ~25, after 20+ checks that shell out to `bd` or query the database. When Dolt is down, those earlier checks produce misleading failures before the root cause is identified.

3. **`getWispIDs` reads stale JSONL.** `ready.go` parses `issues.jsonl` to filter wisps from ready work. Since nothing exports Dolt data back to JSONL, this reads an empty or stale file and silently skips wisp filtering, leaking operational work into `gt ready` output.

4. **`InitBeads` creates empty `issues.jsonl`.** This placeholder file serves no purpose in Dolt-server mode and misleads code that checks for its existence as a signal that beads data exists.

## Changes

| File | Change |
|------|--------|
| `cmd/install.go` | Add `doltserver.IsRunning()` gate before `initTownBeads` |
| `cmd/rig.go` | Add `doltserver.IsRunning()` gate before both `InitBeads` call sites in `runRigAdopt` |
| `rig/manager.go` | Add `doltserver.IsRunning()` gate in `AddRig`; remove `issues.jsonl` creation from `InitBeads` |
| `cmd/doctor.go` | Move `DoltBinaryCheck` + `DoltServerReachableCheck` to positions 3-4 |
| `cmd/ready.go` | Rewrite `getWispIDs` from JSONL parsing to `bd mol wisp list --json` |
| `cmd/rig_integration_test.go` | Add `requireDoltServer(t)` + `.dolt-data` directory setup |
| `cmd/gitinit.go` | Remove stale JSONL reference from gitignore template comment |
| `doctor/rig_routes_jsonl_check.go` | Remove stale "auto-export to issues.jsonl" comments |
| `doltserver/doltserver.go` | Remove stale "skipping issues.jsonl creation" comment |
| `rig/overlay.go` | Remove stale "tracking issues.jsonl" comment |

Independent of #2042 (tmux reliability). Cherry-picked from the non-conflicting parts of #2004 (closed — upstream took a different approach to the JSONL fallback question in e04237ab).