### PR TITLE
refactor: remove JSONL fallback paths in favor of Dolt-only operations

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -60,7 +60,7 @@
 # - linear.api-key
 # - github.org
 # - github.repo
-sync-branch: beads-sync
+# sync-branch: beads-sync  # Legacy — Dolt server mode doesn't use git sync
 
 # Cross-project dependencies (gt-o3is)
 # Maps project names to paths for external dependency resolution

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,1 @@
 
-# Use bd merge for beads JSONL files
-.beads/issues.jsonl merge=beads

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,31 +7,29 @@ on:
     branches: [ main ]
 
 jobs:
-  # Fast check to catch accidental .beads/issues.jsonl changes from contributors
-  check-no-beads-changes:
-    name: Check for .beads changes
+  # Guard: gastown no longer supports issues.jsonl — Dolt server is the only backend.
+  check-no-issues-jsonl:
+    name: Reject issues.jsonl
     runs-on: ubuntu-latest
     if: github.event_name == 'pull_request'
     steps:
       - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
-        with:
-          fetch-depth: 0
 
-      - name: Check for .beads/issues.jsonl changes
+      - name: Reject issues.jsonl if present
         run: |
-          if git diff --name-only origin/${{ github.base_ref }}...HEAD | grep -q "^\.beads/issues\.jsonl$"; then
-            echo "This PR includes changes to .beads/issues.jsonl"
+          if [ -f .beads/issues.jsonl ]; then
+            echo "ERROR: .beads/issues.jsonl must not exist in the repository."
             echo ""
-            echo "This file is the project's issue database and should not be modified in PRs."
+            echo "Gastown requires a Dolt server — issues.jsonl is no longer supported."
             echo ""
             echo "To fix, run:"
-            echo "  git checkout origin/main -- .beads/issues.jsonl"
+            echo "  git rm .beads/issues.jsonl"
             echo "  git commit --amend"
             echo "  git push --force"
             echo ""
             exit 1
           fi
-          echo "No .beads/issues.jsonl changes detected"
+          echo "OK: no issues.jsonl found"
 
   test:
     name: Test

--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ state.json
 # Beads runtime state (not tracked)
 # Formulas ARE tracked for `go install @latest` - see bottom of file
 .beads/redirect
-.beads/issues.jsonl
 .beads/interactions.jsonl
 .beads/metadata.json
 .beads/mq/

--- a/internal/doctor/misclassified_wisp_check.go
+++ b/internal/doctor/misclassified_wisp_check.go
@@ -510,4 +510,3 @@ func bdTableExistsDoctor(workDir, tableName string) bool {
 	err := cmd.Run()
 	return err == nil
 }
-

--- a/internal/doctor/rig_check.go
+++ b/internal/doctor/rig_check.go
@@ -1067,11 +1067,11 @@ func (c *BeadsRedirectCheck) Fix(ctx *CheckContext) error {
 	return nil
 }
 
-// hasBeadsData checks if a beads directory has actual data (issues.jsonl, issues.db, config.yaml)
+// hasBeadsData checks if a beads directory has actual data (issues.db, config.yaml)
 // as opposed to just being a redirect-only directory.
 func hasBeadsData(beadsDir string) bool {
-	// Check for actual beads data files
-	dataFiles := []string{"issues.jsonl", "issues.db", "config.yaml"}
+	// Check for actual beads data files (Dolt-only — issues.jsonl is no longer supported)
+	dataFiles := []string{"issues.db", "config.yaml"}
 	for _, f := range dataFiles {
 		if _, err := os.Stat(filepath.Join(beadsDir, f)); err == nil {
 			return true

--- a/internal/doctor/rig_check_test.go
+++ b/internal/doctor/rig_check_test.go
@@ -475,12 +475,12 @@ func TestBeadsRedirectCheck_FixConflictingLocalBeads(t *testing.T) {
 	rigName := "testrig"
 	rigDir := filepath.Join(tmpDir, rigName)
 
-	// Create tracked beads at mayor/rig/.beads
+	// Create tracked beads at mayor/rig/.beads with config.yaml as data marker
 	trackedBeads := filepath.Join(rigDir, "mayor", "rig", ".beads")
 	if err := os.MkdirAll(trackedBeads, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(trackedBeads, "issues.jsonl"), []byte(`{"id":"tr-1"}`), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(trackedBeads, "config.yaml"), []byte("prefix: tr\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -489,7 +489,7 @@ func TestBeadsRedirectCheck_FixConflictingLocalBeads(t *testing.T) {
 	if err := os.MkdirAll(localBeads, 0755); err != nil {
 		t.Fatal(err)
 	}
-	if err := os.WriteFile(filepath.Join(localBeads, "issues.jsonl"), []byte(`{"id":"local-1"}`), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(localBeads, "config.yaml"), []byte("prefix: local\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
@@ -505,11 +505,6 @@ func TestBeadsRedirectCheck_FixConflictingLocalBeads(t *testing.T) {
 	// Apply fix - should remove conflicting local beads and create redirect
 	if err := check.Fix(ctx); err != nil {
 		t.Fatalf("Fix failed: %v", err)
-	}
-
-	// Verify local issues.jsonl was removed
-	if _, err := os.Stat(filepath.Join(localBeads, "issues.jsonl")); !os.IsNotExist(err) {
-		t.Error("local issues.jsonl should have been removed")
 	}
 
 	// Verify redirect was created

--- a/internal/doctor/stale_beads_redirect_check.go
+++ b/internal/doctor/stale_beads_redirect_check.go
@@ -58,8 +58,7 @@ var staleFilePatterns = []string{
 	"*.db",
 	"*.db-*",
 	"*.db?*",
-	// JSONL data files (tracked but stale in redirect locations)
-	"issues.jsonl",
+	// Legacy JSONL data files (stale in redirect locations)
 	"interactions.jsonl",
 	// Sync and metadata
 	"metadata.json",

--- a/internal/doctor/stale_beads_redirect_check_test.go
+++ b/internal/doctor/stale_beads_redirect_check_test.go
@@ -99,8 +99,9 @@ func TestStaleBeadsRedirectCheck_FixRemovesStaleFiles(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create stale files (config.yaml excluded - may be tracked in git)
-	staleFiles := []string{"issues.jsonl", "issues.db", "metadata.json"}
+	// Create stale files (config.yaml excluded - may be tracked in git;
+	// issues.jsonl no longer recognized — Dolt server is the only backend)
+	staleFiles := []string{"issues.db", "metadata.json"}
 	for _, f := range staleFiles {
 		if err := os.WriteFile(filepath.Join(beadsDir, f), []byte("stale data"), 0644); err != nil {
 			t.Fatal(err)

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -912,78 +912,26 @@ func TestDetectBeadsPrefixFromConfig_TrailingDash(t *testing.T) {
 	}
 }
 
-func TestDetectBeadsPrefixFromConfig_FallbackIssuesJSONL(t *testing.T) {
-	tests := []struct {
-		name       string
-		issuesJSON string
-		want       string
-	}{
-		{
-			name:       "regular issue ID extracts prefix",
-			issuesJSON: `{"id":"gt-mawit","title":"test"}`,
-			want:       "gt",
-		},
-		{
-			name: "skips agent bead with multi-hyphen ID",
-			issuesJSON: `{"id":"gt-demo-witness","title":"agent"}
-{"id":"gt-abc12","title":"regular"}`,
-			want: "gt",
-		},
-		{
-			name:       "skips agent bead when only entry",
-			issuesJSON: `{"id":"gt-demo-witness","title":"agent"}`,
-			want:       "",
-		},
-		{
-			name:       "multi-hyphen prefix with regular hash",
-			issuesJSON: `{"id":"baseball-v3-abc12","title":"test"}`,
-			want:       "baseball-v3",
-		},
-		{
-			name: "multiple regular issues agree on prefix",
-			issuesJSON: `{"id":"gt-mawit","title":"a"}
-{"id":"gt-1nfip","title":"b"}
-{"id":"gt-6vvz1","title":"c"}`,
-			want: "gt",
-		},
-		{
-			name: "filters out merge request IDs (10-char suffix)",
-			issuesJSON: `{"id":"gt-mr-abc1234567","title":"mr"}
-{"id":"gt-mawit","title":"regular"}`,
-			want: "gt",
-		},
-		{
-			name:       "empty issues file returns empty",
-			issuesJSON: "",
-			want:       "",
-		},
-		{
-			name: "mixed agent and regular IDs returns correct prefix",
-			issuesJSON: `{"id":"gt-gastown-polecat-cheedo","title":"agent"}
-{"id":"gt-gastown-witness","title":"agent"}
-{"id":"gt-abc12","title":"regular"}
-{"id":"gt-xyz99","title":"regular"}`,
-			want: "gt",
-		},
+func TestDetectBeadsPrefixFromConfig_NoFallbackToJSONL(t *testing.T) {
+	// Verify that detectBeadsPrefixFromConfig does NOT fall back to issues.jsonl.
+	// Gastown requires Dolt server — JSONL is not a supported data source.
+	dir := t.TempDir()
+
+	// Write config.yaml without a prefix key
+	configPath := filepath.Join(dir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("# no prefix\n"), 0644); err != nil {
+		t.Fatalf("writing config.yaml: %v", err)
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			dir := t.TempDir()
-			// Write config.yaml without a prefix key to trigger fallback
-			configPath := filepath.Join(dir, "config.yaml")
-			if err := os.WriteFile(configPath, []byte("# no prefix\n"), 0644); err != nil {
-				t.Fatalf("writing config.yaml: %v", err)
-			}
-			issuesPath := filepath.Join(dir, "issues.jsonl")
-			if err := os.WriteFile(issuesPath, []byte(tt.issuesJSON), 0644); err != nil {
-				t.Fatalf("writing issues.jsonl: %v", err)
-			}
-			got := detectBeadsPrefixFromConfig(configPath)
-			if got != tt.want {
-				t.Errorf("detectBeadsPrefixFromConfig() = %q, want %q", got, tt.want)
-			}
-		})
+	// Write issues.jsonl with valid data — should be ignored
+	issuesPath := filepath.Join(dir, "issues.jsonl")
+	if err := os.WriteFile(issuesPath, []byte(`{"id":"gt-mawit","title":"test"}`), 0644); err != nil {
+		t.Fatalf("writing issues.jsonl: %v", err)
+	}
+
+	got := detectBeadsPrefixFromConfig(configPath)
+	if got != "" {
+		t.Errorf("detectBeadsPrefixFromConfig() = %q, want empty (should not read issues.jsonl)", got)
 	}
 }
 


### PR DESCRIPTION
## Problem

After upstream commit e04237ab added JSONL bloat detection and kept JSONL as a fallback, the codebase still contains dead JSONL fallback code paths that:

1. **Silently mask Dolt failures** — `beads_agent.go` falls back to `createAgentBeadViaJSONL` when Dolt writes fail, hiding real errors from operators
2. **Duplicate logic in patrol and wisp checks** — `patrol_check.go` and `wisp_check.go` each maintain a complete JSONL fallback path that reads and parses `issues.jsonl`, doubling the code surface area for bugs
3. **Use `issues.jsonl` as a beads-data marker** — `rig_check.go` treats the presence of `issues.jsonl` as proof that beads data exists, but this file is no longer the source of truth
4. **Carry stale git tooling** — `.gitattributes` defines a JSONL merge driver and `.gitignore` excludes `issues.jsonl`, both of which serve no purpose now that JSONL is not written

## Solution

Remove all JSONL fallback paths so that every beads operation goes exclusively through Dolt:

- **(1)** Remove `createAgentBeadViaJSONL` fallback in `beads_agent.go` — Dolt failures now surface immediately
- **(2)** Remove JSONL fallback branches in `patrol_check.go` and `wisp_check.go` — both now use Dolt-only paths
- **(3)** Remove `issues.jsonl` from `hasBeadsData` check in `rig_check.go` and from stale-file lists in `stale_beads_redirect_check.go`
- **(4)** Remove `.gitattributes` JSONL merge driver, `.gitignore` entry, and comment out `sync-branch` in `.beads/config.yaml`
- Add CI guardrail that rejects `issues.jsonl` if accidentally reintroduced
- Remove all JSONL-specific tests and test helpers (net deletion: ~400 lines)