### PR TITLE
fix(test): isolate all test packages on ephemeral Dolt server

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,6 +55,10 @@ jobs:
           git config --global user.name "CI Bot"
           git config --global user.email "ci@gastown.test"
 
+      - name: Install Dolt
+        run: |
+          curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
@@ -132,6 +136,10 @@ jobs:
           git config --global user.name "CI Bot"
           git config --global user.email "ci@gastown.test"
 
+      - name: Install Dolt
+        run: |
+          curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | sudo bash
+
       - name: Cache beads (bd)
         id: cache-beads-int
         uses: actions/cache@cdf6c1fa76f9f475f3d7449005a359c84ca0f306 # v5
@@ -155,7 +163,7 @@ jobs:
         run: echo "$(go env GOPATH)/bin" >> $GITHUB_PATH
 
       - name: Integration Tests
-        run: gotestsum --format testname --junitfile junit-integration.xml -- -tags=integration -timeout=5m -v ./internal/cmd/...
+        run: gotestsum --format testname --junitfile junit-integration.xml -- -tags=integration -timeout=15m -v ./internal/cmd/...
 
       - name: Test Report
         if: always()

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -43,6 +43,18 @@ jobs:
           git config --global user.name "CI Bot"
           git config --global user.email "ci@gastown.test"
 
+      - name: Install Dolt
+        shell: pwsh
+        run: |
+          $release = Invoke-RestMethod 'https://api.github.com/repos/dolthub/dolt/releases/latest'
+          $asset = $release.assets | Where-Object { $_.name -like 'dolt-windows-amd64.zip' }
+          $zip = "$env:RUNNER_TEMP\dolt.zip"
+          Invoke-WebRequest -Uri $asset.browser_download_url -OutFile $zip
+          Expand-Archive -Path $zip -DestinationPath "$env:RUNNER_TEMP\dolt"
+          $bin = Get-ChildItem -Path "$env:RUNNER_TEMP\dolt" -Recurse -Filter 'dolt.exe' | Select-Object -First 1
+          Copy-Item $bin.FullName "$env:GOPATH\bin\dolt.exe"
+          dolt version
+
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 

--- a/internal/cmd/integration_testmain_test.go
+++ b/internal/cmd/integration_testmain_test.go
@@ -4,16 +4,32 @@ package cmd
 
 import (
 	"flag"
+	"fmt"
 	"os"
 	"testing"
+
+	"github.com/steveyegge/gastown/internal/testutil"
 )
 
 func TestMain(m *testing.M) {
 	// Force sequential test execution to avoid bd file locks on Windows.
 	_ = flag.Set("test.parallel", "1")
 	flag.Parse()
+
+	// Start an ephemeral Dolt server for this package's integration tests.
+	// Tests like TestAgentWorktreesStayClean and TestBeadsRoutingFromTownRoot
+	// spawn gt/bd subprocesses that create databases (e.g., "tr", "hq").
+	// By routing to an isolated server (via GT_DOLT_PORT), those databases
+	// are destroyed when the server's temp data dir is removed at cleanup —
+	// preventing orphan accumulation in the shared production Dolt data dir.
+	if err := testutil.EnsureDoltForTestMain(); err != nil {
+		fmt.Fprintf(os.Stderr, "integration TestMain: dolt setup: %v\n", err)
+		os.Exit(1)
+	}
+
 	code := m.Run()
-	// Clean up the shared dolt test server if one was started.
-	cleanupDoltServer()
+
+	// Clean up the shared dolt test server.
+	testutil.CleanupDoltServer()
 	os.Exit(code)
 }

--- a/internal/convoy/testmain_test.go
+++ b/internal/convoy/testmain_test.go
@@ -1,0 +1,27 @@
+package convoy
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/testutil"
+)
+
+func TestMain(m *testing.M) {
+	// Start an ephemeral Dolt server for this package's tests.
+	// setupTestStore sets BEADS_TEST_MODE=1, which causes the beads SDK
+	// to create testdb_<hash> databases. By routing those to an isolated
+	// server (via BEADS_DOLT_PORT), the databases are destroyed when the
+	// server's temp data dir is removed at cleanup — preventing orphan
+	// accumulation in the shared production Dolt data dir.
+	if err := testutil.EnsureDoltForTestMain(); err != nil {
+		fmt.Fprintf(os.Stderr, "convoy TestMain: dolt setup: %v\n", err)
+		os.Exit(1)
+	}
+
+	code := m.Run()
+
+	testutil.CleanupDoltServer()
+	os.Exit(code)
+}

--- a/internal/daemon/testmain_test.go
+++ b/internal/daemon/testmain_test.go
@@ -1,0 +1,46 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/testutil"
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+func TestMain(m *testing.M) {
+	// Start an ephemeral Dolt server for this package's tests.
+	// convoy_manager_test.go calls setupTestStore which sets BEADS_TEST_MODE=1,
+	// causing the beads SDK to create testdb_<hash> databases. By routing
+	// those to an isolated server (via BEADS_DOLT_PORT), the databases are
+	// destroyed when the server's temp data dir is removed at cleanup —
+	// preventing orphan accumulation in the shared production Dolt data dir.
+	if err := testutil.EnsureDoltForTestMain(); err != nil {
+		fmt.Fprintf(os.Stderr, "daemon TestMain: dolt setup: %v\n", err)
+		os.Exit(1)
+	}
+
+	// Isolate tmux sessions on a package-specific socket.
+	// handler_test.go creates tmux.NewTmux() instances that query has-session;
+	// polecat_health_test.go uses fake tmux stubs but still constructs Tmux
+	// instances. Routing all of these to an isolated socket prevents
+	// interference with the user's tmux and other packages' tests.
+	var tmuxSocket string
+	if _, err := exec.LookPath("tmux"); err == nil {
+		tmuxSocket = fmt.Sprintf("gt-test-daemon-%d", os.Getpid())
+		tmux.SetDefaultSocket(tmuxSocket)
+	}
+
+	code := m.Run()
+
+	if tmuxSocket != "" {
+		_ = exec.Command("tmux", "-L", tmuxSocket, "kill-server").Run()
+		socketPath := filepath.Join(fmt.Sprintf("/tmp/tmux-%d", os.Getuid()), tmuxSocket)
+		_ = os.Remove(socketPath)
+	}
+	testutil.CleanupDoltServer()
+	os.Exit(code)
+}


### PR DESCRIPTION
## Summary

Tests across three packages (`internal/cmd`, `internal/convoy`, `internal/daemon`) create databases on the production Dolt server (port 3307), leaving orphans in `.dolt-data/` that accumulate across runs. This PR routes all three packages to ephemeral Dolt servers via `TestMain` and installs Dolt in all CI jobs so tests execute instead of being silently skipped or fatally erroring.

## Problem

**1. convoy/daemon tests leak `testdb_*` databases.** `setupTestStore` sets `BEADS_TEST_MODE=1`, causing the beads SDK to create `testdb_<hash>` databases. Neither package has a `TestMain`, so there is no ephemeral server — databases are created on the production Dolt server at port 3307. The cleanup function only closes the connection, never drops the database. Over time, ~100+ orphaned `testdb_*` databases accumulate in `.dolt-data/`.

**2. integration tests in `internal/cmd` leak named databases.** The `integration_testmain_test.go` `TestMain` only calls `cleanupDoltServer()` at exit — it never starts an ephemeral server. Individual tests call `requireDoltServer(t)` lazily, but tests like `TestBeadsDbInitAfterClone` create databases (e.g., `existing-prefix`, `real-prefix`, `testrig`) via `bd init` subprocesses that connect to whatever Dolt server is reachable. Without `GT_DOLT_PORT` being set early, these hit the production server on port 3307.

**3. No CI job installs Dolt.** Neither the `test` job, the `integration` job, nor the Windows job install Dolt. Tests that call `requireDoltServer(t)` silently skip via `t.Skip("dolt not installed")`, meaning Dolt-dependent tests have never run in CI. Packages with `TestMain` that call `EnsureDoltForTestMain()` (convoy, daemon) hard-fail with `os.Exit(1)` when Dolt is missing.

**4. daemon tests interfere with user tmux sessions.** `handler_test.go` creates `tmux.NewTmux()` instances that query `has-session` on the user's default tmux socket, causing interference with running Gas Town sessions during local development.

## What this PR changes

### Add `EnsureDoltForTestMain()` to testutil (addresses #1, #2)

New function in `internal/testutil/doltserver.go` that starts an ephemeral Dolt server (random port, temp data dir) and sets both `GT_DOLT_PORT` and `BEADS_DOLT_PORT` so that all child processes and the beads SDK connect to the isolated server. Returns an error (not skip) when dolt is missing, enforcing that dolt must be installed.

### Add `TestMain` to convoy and daemon packages (addresses #1, #4)

- `internal/convoy/testmain_test.go` — calls `EnsureDoltForTestMain()` before tests and `CleanupDoltServer()` after. The ephemeral server's temp data dir is removed on cleanup, destroying all `testdb_*` databases automatically.
- `internal/daemon/testmain_test.go` — same Dolt isolation, plus routes tmux operations to a PID-scoped socket (`gt-test-daemon-<pid>`) to prevent interference with user sessions.

### Update `internal/cmd` integration TestMain (addresses #2)

The existing `integration_testmain_test.go` now calls `EnsureDoltForTestMain()` eagerly at startup instead of relying on lazy `requireDoltServer(t)` calls. This ensures `GT_DOLT_PORT` is set before any test spawns `bd` or `gt` subprocesses, preventing database creation on the production server.

### Install Dolt in all CI jobs (addresses #3)

- `ci.yml`: added `Install Dolt` step to both the `test` and `integration` jobs (Linux, uses install.sh).
- `windows-ci.yml`: added `Install Dolt` step that downloads the latest Windows zip release and copies `dolt.exe` to `GOPATH/bin`.

## Testing

```bash
# Run integration tests and verify no databases leak to production
go test -tags=integration -count=1 -timeout=300s ./internal/cmd/...

# Verify production .dolt-data/ has no new databases after test run
ls ~/gt/.dolt-data/

# Run convoy tests (creates testdb_* on ephemeral server)
go test -count=1 ./internal/convoy/...

# Run daemon tests (isolated tmux + Dolt)
go test -count=1 ./internal/daemon/...
```

Verified locally that running integration tests on the base branch leaks 7 databases (`existing-prefix`, `empty-prefix`, `real-prefix`, `original-prefix`, `reinit-prefix`, `test`, `testrig`) onto the production Dolt server. With this PR, zero databases appear on production after a full integration test run.