### PR TITLE
fix: complete persistent polecats design — stop doctor from undoing agent migration

### DIFF
--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -1,0 +1,48 @@
+package beads
+
+import "testing"
+
+func TestIsAgentBeadByID(t *testing.T) {
+	tests := []struct {
+		name string
+		id   string
+		want bool
+	}{
+		// Full-form IDs (prefix != rig): prefix-rig-role[-name]
+		{name: "full witness", id: "gt-gastown-witness", want: true},
+		{name: "full refinery", id: "gt-gastown-refinery", want: true},
+		{name: "full crew with name", id: "gt-gastown-crew-krystian", want: true},
+		{name: "full polecat with name", id: "gt-gastown-polecat-Toast", want: true},
+		{name: "full deacon", id: "sh-shippercrm-deacon", want: true},
+		{name: "full mayor", id: "ax-axon-mayor", want: true},
+
+		// Collapsed-form IDs (prefix == rig): prefix-role[-name]
+		// These have only 2 parts for witness/refinery, must still be detected.
+		{name: "collapsed witness", id: "bcc-witness", want: true},
+		{name: "collapsed refinery", id: "bcc-refinery", want: true},
+		{name: "collapsed crew with name", id: "bcc-crew-krystian", want: true},
+		{name: "collapsed polecat with name", id: "bcc-polecat-obsidian", want: true},
+
+		// Non-agent IDs
+		{name: "regular issue", id: "gt-12345", want: false},
+		{name: "task bead", id: "bcc-fix-button-color", want: false},
+		{name: "single part", id: "witness", want: false},
+		{name: "empty string", id: "", want: false},
+		{name: "patrol molecule", id: "mol-patrol-abc123", want: false},
+		{name: "merge request", id: "gt-mr-1234", want: false},
+
+		// Edge cases
+		{name: "role in first position", id: "witness-something", want: false},
+		{name: "beads prefix collapsed", id: "bd-beads-witness", want: true},
+		{name: "beads crew", id: "bd-beads-crew-krystian", want: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := isAgentBeadByID(tt.id)
+			if got != tt.want {
+				t.Errorf("isAgentBeadByID(%q) = %v, want %v", tt.id, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/cmd/dolt.go
+++ b/internal/cmd/dolt.go
@@ -282,20 +282,20 @@ After migration, 'bd mol wisp list' will work and agent lifecycle
 }
 
 var (
-	doltLogLines          int
-	doltLogFollow         bool
-	doltMigrateDry        bool
-	doltCleanupDry        bool
-	doltCleanupForce      bool
+	doltLogLines     int
+	doltLogFollow    bool
+	doltMigrateDry   bool
+	doltCleanupDry   bool
+	doltCleanupForce bool
 
-	doltMigrateWispsDry   bool
-	doltMigrateWispsDB    string
-	doltRollbackDry       bool
-	doltRollbackList      bool
-	doltSyncDry           bool
-	doltSyncForce         bool
-	doltSyncDB            string
-	doltSyncGC            bool
+	doltMigrateWispsDry bool
+	doltMigrateWispsDB  string
+	doltRollbackDry     bool
+	doltRollbackList    bool
+	doltSyncDry         bool
+	doltSyncForce       bool
+	doltSyncDB          string
+	doltSyncGC          bool
 )
 
 func init() {
@@ -1496,9 +1496,12 @@ func runDoltMigrateWisps(cmd *cobra.Command, args []string) error {
 		if db == "wl_commons" || strings.HasPrefix(db, "testdb_") {
 			continue
 		}
-		// Find the rig directory for this database
+		// Find the rig directory for this database.
+		// The "hq" database lives at the town root itself, not townRoot/hq.
 		rigDir := filepath.Join(townRoot, db)
-		if _, err := os.Stat(rigDir); os.IsNotExist(err) {
+		if db == "hq" {
+			rigDir = townRoot
+		} else if _, err := os.Stat(rigDir); os.IsNotExist(err) {
 			continue // Not a rig directory
 		}
 		fmt.Printf("\n%s Migrating: %s\n", style.Bold.Render("→"), db)
@@ -1541,5 +1544,3 @@ func printMigrateWispsResult(result *doltserver.MigrateWispsResult) {
 		fmt.Printf("  %s Already migrated (no changes needed)\n", style.Bold.Render("✓"))
 	}
 }
-
-

--- a/internal/doctor/misclassified_wisp_check_test.go
+++ b/internal/doctor/misclassified_wisp_check_test.go
@@ -1,0 +1,180 @@
+package doctor
+
+import "testing"
+
+func TestShouldBeWisp(t *testing.T) {
+	check := NewCheckMisclassifiedWisps()
+
+	tests := []struct {
+		name      string
+		id        string
+		title     string
+		issueType string
+		labels    []string
+		wantWisp  bool
+		wantMsg   string // substring of reason (empty = no reason expected)
+	}{
+		// Types that SHOULD be wisps
+		{
+			name:      "merge-request type is wisp",
+			issueType: "merge-request",
+			wantWisp:  true,
+			wantMsg:   "merge-request",
+		},
+		{
+			name:      "event type is wisp",
+			issueType: "event",
+			wantWisp:  true,
+			wantMsg:   "event",
+		},
+		{
+			name:      "gate type is wisp",
+			issueType: "gate",
+			wantWisp:  true,
+			wantMsg:   "gate",
+		},
+		{
+			name:      "slot type is wisp",
+			issueType: "slot",
+			wantWisp:  true,
+			wantMsg:   "slot",
+		},
+
+		// Agent type should NOT be a wisp (persistent polecats design)
+		{
+			name:      "agent type is NOT a wisp (persistent polecats)",
+			id:        "gt-gastown-witness",
+			title:     "gastown witness",
+			issueType: "agent",
+			labels:    []string{"gt:agent"},
+			wantWisp:  false,
+		},
+		{
+			name:      "agent type with no labels is NOT a wisp",
+			issueType: "agent",
+			wantWisp:  false,
+		},
+
+		// gt:agent label should NOT trigger wisp classification
+		{
+			name:      "gt:agent label is NOT a wisp indicator",
+			id:        "bcc-witness",
+			title:     "bcc witness",
+			issueType: "task", // might have wrong type from legacy
+			labels:    []string{"gt:agent"},
+			wantWisp:  false,
+		},
+
+		// Patrol labels should still be wisps
+		{
+			name:     "patrol label is wisp",
+			labels:   []string{"gt:patrol"},
+			wantWisp: true,
+			wantMsg:  "patrol",
+		},
+
+		// Mail/handoff labels should still be wisps
+		{
+			name:     "mail label is wisp",
+			labels:   []string{"gt:mail"},
+			wantWisp: true,
+			wantMsg:  "mail/handoff",
+		},
+		{
+			name:     "handoff label is wisp",
+			labels:   []string{"gt:handoff"},
+			wantWisp: true,
+			wantMsg:  "mail/handoff",
+		},
+
+		// Patrol ID patterns
+		{
+			name:     "patrol molecule ID",
+			id:       "mol-witness-patrol-abc123",
+			wantWisp: true,
+			wantMsg:  "patrol molecule",
+		},
+
+		// Patrol title patterns
+		{
+			name:     "patrol cycle title",
+			title:    "Patrol Cycle #42",
+			wantWisp: true,
+			wantMsg:  "patrol title",
+		},
+		{
+			name:     "witness patrol title",
+			title:    "Witness Patrol at 14:00",
+			wantWisp: true,
+			wantMsg:  "patrol title",
+		},
+
+		// Regular issues should NOT be wisps
+		{
+			name:      "regular task",
+			id:        "gt-12345",
+			title:     "Fix button color",
+			issueType: "task",
+			labels:    []string{"ui", "bugfix"},
+			wantWisp:  false,
+		},
+		{
+			name:      "feature issue",
+			id:        "bcc-9876",
+			title:     "Add dark mode",
+			issueType: "feature",
+			wantWisp:  false,
+		},
+		{
+			name:      "bug issue",
+			issueType: "bug",
+			wantWisp:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reason := check.shouldBeWisp(tt.id, tt.title, tt.issueType, tt.labels)
+			gotWisp := reason != ""
+			if gotWisp != tt.wantWisp {
+				t.Errorf("shouldBeWisp(id=%q, title=%q, type=%q, labels=%v) = %q, wantWisp=%v",
+					tt.id, tt.title, tt.issueType, tt.labels, reason, tt.wantWisp)
+			}
+			if tt.wantMsg != "" && reason == "" {
+				t.Errorf("expected reason containing %q, got empty", tt.wantMsg)
+			}
+		})
+	}
+}
+
+func TestShouldBeWisp_AgentNotWisp_Regression(t *testing.T) {
+	// Regression test: persistent polecats design (c410c10a) says agent beads
+	// live in the issues table. shouldBeWisp() must NOT flag them for migration
+	// back to wisps, or gt doctor --fix will undo the persistent polecats migration.
+	check := NewCheckMisclassifiedWisps()
+
+	agentIDs := []struct {
+		id    string
+		title string
+	}{
+		{"gt-gastown-witness", "gastown witness"},
+		{"gt-gastown-refinery", "gastown refinery"},
+		{"gt-gastown-crew-krystian", "gastown crew krystian"},
+		{"bcc-witness", "bcc witness"},
+		{"bcc-refinery", "bcc refinery"},
+		{"bcc-crew-krystian", "bcc crew krystian"},
+		{"bd-beads-witness", "beads witness"},
+		{"sh-shippercrm-witness", "shippercrm witness"},
+		{"ax-axon-refinery", "axon refinery"},
+	}
+
+	for _, agent := range agentIDs {
+		t.Run(agent.id, func(t *testing.T) {
+			// Agent with type=agent and label=gt:agent should NOT be classified as wisp
+			reason := check.shouldBeWisp(agent.id, agent.title, "agent", []string{"gt:agent"})
+			if reason != "" {
+				t.Errorf("shouldBeWisp(%q) returned %q — would undo persistent polecats migration!", agent.id, reason)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Stop `gt doctor --fix` from migrating agent beads back to the wisps table, which undoes the persistent polecats migration
- Fix silent flag failure where `--no-ephemeral` is used instead of `--persistent`, preventing wisp-to-issues promotion
- Fix `hq` database path mapping so town-level beads are not silently skipped
- Fix collapsed-form agent ID detection (e.g. `bcc-witness`) so `ListAgentBeadsFromWisps` finds all agents

## Problems in the base branch

1. **`shouldBeWisp()` classifies agent beads as ephemeral** (`misclassified_wisp_check.go:327-330`, `:355-357`). It flags `issue_type == "agent"` and `label == "gt:agent"` as indicators that an issue should be a wisp. This means `gt doctor --fix` actively migrates agent beads FROM the issues table BACK to the wisps table — directly contradicting the persistent polecats design (c410c10a) which deliberately moved them to issues for durability. Any user running `gt doctor --fix` has their agent migration reversed.

2. **`CreateOrReopenAgentBead` uses a nonexistent flag** (`beads_agent.go:380`). It calls `bd update <id> --no-ephemeral` but the beads CLI flag is `--persistent` (`bd update --help` confirms). The command silently fails (exit code ignored as non-fatal), so existing wisp-table agents are never promoted to the issues table during re-spawn.

3. **`hq` database maps to nonexistent path** (`misclassified_wisp_check.go:67`, `dolt.go:1426`). Both `findMisclassifiedWispsDolt` and `runDoltMigrateWisps` compute `rigDir = filepath.Join(townRoot, "hq")`, but the `hq` database lives at the town root itself (not a subdirectory). The path doesn't exist, so `os.Stat` fails and the entire `hq` database is silently skipped.

4. **`isAgentBeadByID` misses collapsed-form IDs** (`beads_agent.go:724-737`). It requires `len(parts) >= 3` and checks `parts[2:]`, but collapsed-form agent IDs where prefix == rig (e.g., `bcc-witness`, `bcc-refinery`) have only 2 parts. These agents are invisible to `ListAgentBeadsFromWisps`, which falls back to `isAgentBeadByID` when wisp JSON omits type/label fields.

## Changes

| # | Problem | Fix |
|---|---------|-----|
| 1 | `shouldBeWisp()` flags agent type | Remove `agent` from type checks, add comment explaining persistent polecats design |
| 2 | `shouldBeWisp()` flags `gt:agent` label | Remove label check, add comment |
| 3 | Wrong `--no-ephemeral` flag | Change to `--persistent` (the actual `bd update` flag) |
| 4 | `hq` path → `townRoot/hq` (nonexistent) in doctor | Map `hq` → `townRoot` before calling `findMisclassifiedWispsDolt` |
| 5 | Same `hq` path bug in `dolt migrate-wisps` | Map `hq` → `townRoot`, skip `os.Stat` check for `hq` |
| 6 | `isAgentBeadByID` requires 3+ parts | Check `parts[1:]` instead of `parts[2:]`, lower minimum to 2 parts |

## Tests

- `TestShouldBeWisp`: Table-driven test covering all type/label combinations — verifies agent type and `gt:agent` label are NOT classified as wisps while merge-request, event, gate, slot, patrol, and mail types still are
- `TestShouldBeWisp_AgentNotWisp_Regression`: Tests all 9 real agent bead IDs across 5 rigs to prevent regression
- `TestIsAgentBeadByID`: Table-driven test covering full-form, collapsed-form, and non-agent IDs — verifies collapsed forms like `bcc-witness` are correctly detected