### PR TITLE
fix(deacon): respawn dead pane instead of kill+recreate to prevent crash loop

### DIFF
--- a/internal/deacon/manager_test.go
+++ b/internal/deacon/manager_test.go
@@ -21,9 +21,16 @@ type mockTmux struct {
 	sessionInfoErr   error
 	sendKeysErr      error
 
+	// Dead pane detection (for respawn-instead-of-kill behavior)
+	paneDead               bool  // true if pane is dead (remain-on-exit)
+	respawnErr             error // error from RespawnPaneDefault
+	agentAliveAfterRespawn bool  // IsAgentAlive result after respawn
+
 	// Call tracking
 	killCalls       []string
 	newSessionCalls int
+	respawnCalls    int
+	respawnChecked  bool // tracks if IsPaneDead was checked
 }
 
 func (m *mockTmux) HasSession(name string) (bool, error) {
@@ -31,7 +38,21 @@ func (m *mockTmux) HasSession(name string) (bool, error) {
 }
 
 func (m *mockTmux) IsAgentAlive(_ string) bool {
+	// After respawn, return the post-respawn result
+	if m.respawnChecked && m.agentAliveAfterRespawn {
+		return true
+	}
 	return m.agentAlive
+}
+
+func (m *mockTmux) IsPaneDead(_ string) bool {
+	return m.paneDead
+}
+
+func (m *mockTmux) RespawnPaneDefault(_ string) error {
+	m.respawnCalls++
+	m.respawnChecked = true
+	return m.respawnErr
 }
 
 func (m *mockTmux) KillSessionWithProcesses(name string) error {
@@ -245,6 +266,97 @@ func TestStart_WaitForCommandFails(t *testing.T) {
 	}
 	// If config failed before reaching NewSessionWithCommand, that's
 	// acceptable - the WaitForCommand path isn't reachable in test env.
+}
+
+// TestStart_DeadPane_RespawnsInsteadOfKill verifies that when the deacon
+// session exists but the pane is dead (process exited with remain-on-exit on),
+// Start() respawns the pane instead of killing the entire session and
+// creating a new one. This is critical for the daemon's crash loop detection:
+// respawning returns ErrAlreadyRunning, which makes the daemon call
+// RecordSuccess() instead of RecordRestart().
+//
+// Regression test for the deacon crash loop: the deacon exits cleanly
+// after each patrol cycle (~3 min), but the daemon heartbeat (also ~3 min)
+// finds the dead pane, kills the "zombie", creates a new session, and
+// increments the restart counter. After 5 restarts -> crash loop.
+func TestStart_DeadPane_RespawnsInsteadOfKill(t *testing.T) {
+	mock := &mockTmux{
+		hasSessionResult:       true,
+		agentAlive:             false, // agent not running (pane dead)
+		paneDead:               true,  // pane is dead, not a zombie shell
+		respawnErr:             nil,   // respawn succeeds
+		agentAliveAfterRespawn: true,  // agent comes back after respawn
+	}
+	m := newTestManager(t.TempDir(), mock)
+
+	err := m.Start("")
+
+	// Should return ErrAlreadyRunning because respawn recovered the session
+	if !errors.Is(err, ErrAlreadyRunning) {
+		t.Errorf("Start() = %v, want ErrAlreadyRunning (respawn should recover dead pane)", err)
+	}
+
+	// Should NOT have killed the session
+	if len(mock.killCalls) > 0 {
+		t.Errorf("Start() killed session %v — should have respawned instead", mock.killCalls)
+	}
+
+	// Should NOT have created a new session
+	if mock.newSessionCalls > 0 {
+		t.Errorf("Start() created %d new sessions — should have respawned existing pane", mock.newSessionCalls)
+	}
+
+	// Should have called RespawnPaneDefault
+	if mock.respawnCalls == 0 {
+		t.Error("Start() did not call RespawnPaneDefault — dead pane should be respawned")
+	}
+}
+
+// TestStart_DeadPane_RespawnFails_FallsThrough verifies that when respawn
+// fails, Start() falls through to the kill+recreate path.
+func TestStart_DeadPane_RespawnFails_FallsThrough(t *testing.T) {
+	mock := &mockTmux{
+		hasSessionResult: true,
+		agentAlive:       false,
+		paneDead:         true,
+		respawnErr:       errors.New("respawn-pane failed"),
+	}
+	m := newTestManager(t.TempDir(), mock)
+
+	// Start will fall through to kill+recreate, then hit config resolution
+	// which may fail in test env. We just verify the fallthrough behavior.
+	_ = m.Start("")
+
+	// Respawn was attempted
+	if mock.respawnCalls == 0 {
+		t.Error("Start() did not attempt RespawnPaneDefault before falling through to kill")
+	}
+
+	// Should have fallen through to kill
+	if len(mock.killCalls) == 0 {
+		t.Error("Start() should fall through to kill when respawn fails")
+	}
+}
+
+// TestStart_ZombieShell_StillKills verifies that a true zombie (shell
+// running but agent dead) is still handled with kill+recreate, not respawn.
+func TestStart_ZombieShell_StillKills(t *testing.T) {
+	mock := &mockTmux{
+		hasSessionResult: true,
+		agentAlive:       false,
+		paneDead:         false, // NOT a dead pane -- zombie shell still running
+	}
+	m := newTestManager(t.TempDir(), mock)
+
+	_ = m.Start("")
+
+	// Zombie shell should be killed, not respawned
+	if len(mock.killCalls) == 0 {
+		t.Error("Start() should kill zombie shell sessions")
+	}
+	if mock.respawnCalls > 0 {
+		t.Error("Start() should not respawn zombie shell -- only dead panes")
+	}
 }
 
 func TestStop_NotRunning(t *testing.T) {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2139,6 +2139,27 @@ func (t *Tmux) SetMailClickBinding(session string) error {
 	return err
 }
 
+// IsPaneDead checks if the pane in a session has exited (remain-on-exit keeps it visible).
+// Returns true if the pane's process has exited but the pane is still displayed.
+// This distinguishes a "dead pane waiting for respawn" from a "zombie shell still running".
+func (t *Tmux) IsPaneDead(session string) bool {
+	out, err := t.run("list-panes", "-t", session, "-F", "#{pane_dead}")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(out) == "1"
+}
+
+// RespawnPaneDefault restarts a dead pane with its original command.
+// This is used when the pane process has exited (remain-on-exit on) and we
+// want to restart it in place without killing the entire session.
+// Unlike RespawnPane, this does NOT specify a new command — tmux reuses the
+// command from when the pane was created or last respawned.
+func (t *Tmux) RespawnPaneDefault(session string) error {
+	_, err := t.run("respawn-pane", "-k", "-t", session)
+	return err
+}
+
 // RespawnPane kills all processes in a pane and starts a new command.
 // This is used for "hot reload" of agent sessions - instantly restart in place.
 // The pane parameter should be a pane ID (e.g., "%0") or session:window.pane format.


### PR DESCRIPTION
## Summary

Adds dead-pane detection to the deacon's `Start()` method so it respawns in place instead of killing and recreating the session, preventing false crash-loop escalation.

## Merge order

This is **PR 1 of 4** from the [tmux reliability split](https://github.com/steveyegge/gastown/pull/2042#issuecomment-3964454473). Each PR is independent and can be reviewed/merged in any order, except PR 2 (auto-respawn hook safety) should merge after this one since it extends the same test file.

1. **This PR** — deacon dead-pane respawn
2. Auto-respawn hook safety (`buildAutoRespawnHookCmd`)
3. Session creation race fix (`EnsureSessionFreshWithCommand`)
4. Socket derivation from town name

## Problem

The deacon exits cleanly after each patrol cycle (~3 min). The daemon heartbeat (also ~3 min) finds the session with a dead pane, treats it as a zombie, kills the entire session, and creates a new one. Each kill+recreate increments the daemon's restart counter. After 5 restarts the daemon declares a crash loop and stops restarting.

The deacon is not crashing — it is completing its patrol and exiting normally. The daemon misclassifies the dead pane as a zombie because it has no way to distinguish "process exited cleanly, pane waiting for respawn" from "shell alive but agent dead."

## Changes

**`internal/tmux/tmux.go`** — Two new methods:
- `IsPaneDead(session)` — queries `#{pane_dead}` via `list-panes` to detect panes where the process exited but `remain-on-exit` keeps them visible
- `RespawnPaneDefault(session)` — runs `respawn-pane -k` without specifying a command, so tmux reuses the original pane command

**`internal/deacon/manager.go`** — `Start()` now checks `IsPaneDead` before falling through to kill+recreate. If the pane is dead, it attempts `RespawnPaneDefault`. If the respawned agent comes back healthy, it returns `ErrAlreadyRunning` (which the daemon treats as success, not a restart). If respawn fails or the agent doesn't recover, it falls through to the existing kill+recreate path.

**`internal/deacon/manager_test.go`** — Three new tests:
- `TestStart_DeadPane_RespawnsInsteadOfKill` — respawn succeeds, no kill, no new session
- `TestStart_DeadPane_RespawnFails_FallsThrough` — respawn fails, falls through to kill+recreate
- `TestStart_ZombieShell_StillKills` — zombie shell (pane alive, agent dead) still uses kill+recreate