### PR TITLE
fix(tmux): derive socket from town name and add cross-socket agent menu

### DIFF
--- a/internal/session/registry_socket_test.go
+++ b/internal/session/registry_socket_test.go
@@ -1,6 +1,98 @@
 package session
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// TestInitRegistry_SocketFromTownName verifies that InitRegistry derives the
+// tmux socket name from the town directory name, NOT from $TMUX.
+//
+// This is the regression test for gt-qkekp: when gt up is run from a terminal
+// attached to the default tmux server ($TMUX=/tmp/tmux-1000/default,...),
+// InitRegistry used to parse "default" from $TMUX and set that as the socket.
+// This caused all sessions to land on the default server instead of a
+// town-specific socket (e.g., -L gt).
+func TestInitRegistry_SocketFromTownName(t *testing.T) {
+	// Save and restore $TMUX and the default socket
+	origTMUX := os.Getenv("TMUX")
+	origSocket := tmux.GetDefaultSocket()
+	t.Cleanup(func() {
+		os.Setenv("TMUX", origTMUX)
+		tmux.SetDefaultSocket(origSocket)
+	})
+
+	tests := []struct {
+		name       string
+		tmuxEnv    string // $TMUX value (simulating being inside tmux)
+		townDir    string // basename of the town root directory
+		wantSocket string // expected tmux socket name
+	}{
+		{
+			name:       "inside default tmux, town=gt",
+			tmuxEnv:    "/tmp/tmux-1000/default,12345,0",
+			townDir:    "gt",
+			wantSocket: "gt",
+		},
+		{
+			name:       "inside gt tmux, town=gt",
+			tmuxEnv:    "/tmp/tmux-1000/gt,12345,0",
+			townDir:    "gt",
+			wantSocket: "gt",
+		},
+		{
+			name:       "outside tmux (daemon), town=gt",
+			tmuxEnv:    "",
+			townDir:    "gt",
+			wantSocket: "gt",
+		},
+		{
+			name:       "town name with spaces",
+			tmuxEnv:    "/tmp/tmux-1000/default,99,0",
+			townDir:    "My Town",
+			wantSocket: "my-town",
+		},
+		{
+			name:       "town name with caps",
+			tmuxEnv:    "",
+			townDir:    "GasTown",
+			wantSocket: "gastown",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Reset socket before each test
+			tmux.SetDefaultSocket("")
+
+			// Set $TMUX to simulate the terminal environment
+			if tt.tmuxEnv != "" {
+				os.Setenv("TMUX", tt.tmuxEnv)
+			} else {
+				os.Unsetenv("TMUX")
+			}
+
+			// Create a minimal fake town root. InitRegistry will fail to load
+			// rigs.json and agents.json but that's fine — we only care about
+			// the socket name it sets.
+			townRoot := filepath.Join(t.TempDir(), tt.townDir)
+			os.MkdirAll(townRoot, 0o755)
+
+			// InitRegistry may return errors for missing config — ignore them.
+			// The socket is set unconditionally before any config loading.
+			_ = InitRegistry(townRoot)
+
+			got := tmux.GetDefaultSocket()
+			if got != tt.wantSocket {
+				t.Errorf("after InitRegistry(%q) with TMUX=%q:\n  socket = %q, want %q",
+					townRoot, tt.tmuxEnv, got, tt.wantSocket)
+			}
+		})
+	}
+}
 
 func TestSanitizeTownName(t *testing.T) {
 	tests := []struct {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2438,6 +2438,58 @@ func (t *Tmux) SetAgentsBinding(session string) error {
 	return err
 }
 
+// EnsureBindingsOnSocket sets the gt agents menu and feed keybindings on a
+// specific tmux socket. This is used during gt up to ensure the bindings work
+// even when the user is on a different socket than the town socket.
+//
+// Unlike SetAgentsBinding/SetFeedBinding (called during gt prime), this method:
+//   - Targets a specific socket regardless of the Tmux instance's default
+//   - Skips the session-name guard when there's no pre-existing user binding,
+//     since the user may be in a personal session (not matching GT prefixes)
+//     and still wants the agent menu for cross-socket navigation
+//
+// Safe to call multiple times; skips if bindings already exist.
+func EnsureBindingsOnSocket(socket string) error {
+	t := NewTmuxWithSocket(socket)
+
+	// Agents binding (prefix + g)
+	if !t.isGTBinding("prefix", "g") {
+		ifShell := fmt.Sprintf("echo '#{session_name}' | grep -Eq '%s'", sessionPrefixPattern())
+		fallback := t.getKeyBinding("prefix", "g")
+		if fallback == "" || fallback == ":" {
+			// No user binding to preserve -- always show the GT agent menu.
+			// This is critical for cross-socket use: on the default socket,
+			// no session names match GT prefixes, so the if-shell guard would
+			// prevent the menu from ever appearing.
+			_, _ = t.run("bind-key", "-T", "prefix", "g",
+				"run-shell", "gt agents menu")
+		} else {
+			// User has a custom binding -- guard it
+			_, _ = t.run("bind-key", "-T", "prefix", "g",
+				"if-shell", ifShell,
+				"run-shell 'gt agents menu'",
+				fallback)
+		}
+	}
+
+	// Feed binding (prefix + a)
+	if !t.isGTBinding("prefix", "a") {
+		ifShell := fmt.Sprintf("echo '#{session_name}' | grep -Eq '%s'", sessionPrefixPattern())
+		fallback := t.getKeyBinding("prefix", "a")
+		if fallback == "" || fallback == ":" {
+			_, _ = t.run("bind-key", "-T", "prefix", "a",
+				"run-shell", "gt feed --window")
+		} else {
+			_, _ = t.run("bind-key", "-T", "prefix", "a",
+				"if-shell", ifShell,
+				"run-shell 'gt feed --window'",
+				fallback)
+		}
+	}
+
+	return nil
+}
+
 // GetSessionCreatedUnix returns the Unix timestamp when a session was created.
 // Returns 0 if the session doesn't exist or can't be queried.
 func (t *Tmux) GetSessionCreatedUnix(session string) (int64, error) {


### PR DESCRIPTION
## Summary

Replaces `$TMUX` environment variable parsing for socket determination with deterministic derivation from the town directory name, and adds cross-socket navigation so `prefix+g` works from any tmux server.

## Merge order

This is **PR 4 of 4** from the [tmux reliability split](https://github.com/steveyegge/gastown/pull/2042#issuecomment-3964454473). Independent of PRs 1-3; can merge in any order.

1. Deacon dead-pane respawn (#2057)
2. Auto-respawn hook safety (#2058)
3. Session creation race fix (#2059)
4. **This PR** -- socket derivation from town name

## Problem

**Sessions land on the wrong tmux server.** `InitRegistry()` parses `$TMUX` to determine the socket name. When `gt up` runs from a terminal on the default tmux server, all agent sessions land on socket `"default"` instead of a dedicated town socket. This defeats multi-town isolation and makes sessions visible to (and killable by) the user's interactive tmux.

The `$TMUX` parsing also creates three inconsistent code paths: inside tmux (parses socket from env), outside tmux (falls back to "default"), and on a different tmux server (wrong socket entirely).

**Agent menu doesn't work cross-socket.** `prefix+g` only shows sessions on the current socket. Users on the default socket cannot see or switch to agents on the town socket.

## Changes

**`internal/session/registry.go`** -- `InitRegistry()` now calls `sanitizeTownName(filepath.Base(townRoot))` to derive the socket name deterministically from the town directory. The socket is always the same regardless of whether the user is inside tmux, outside tmux, or on a different tmux server.

**`internal/session/registry_socket_test.go`** -- Tests for `sanitizeTownName`: Unicode handling, special characters, long names, whitespace normalization.

**`internal/cmd/agents.go`** -- Cross-socket agent menu:
- `buildMenuAction`: tries `switch-client` first (instant, no flicker), falls back to `detach+reattach` for actual cross-socket switches
- `getAllSocketSessions`: lists sessions from both town and default sockets with grouped headers
- `--` flag terminator before menu items to handle dash-prefixed session names

**`internal/cmd/agents_test.go`** -- Tests for `DisplayLabel_PersonalSession`, `BuildMenuAction` cross-socket behavior, session grouping.

**`internal/cmd/up.go`** -- Calls `EnsureBindingsOnSocket` on the default socket during `gt up` so `prefix+g` and `prefix+a` work even when the user is on a different tmux server.

**`internal/tmux/tmux.go`** -- `EnsureBindingsOnSocket(socket)`: sets GT keybindings on a specific socket. Skips the session-name guard when there's no pre-existing user binding, since on the default socket no session names match GT prefixes and the guard would prevent the menu from appearing.