### PR TITLE
fix(dog): add RoleDog constant and DogName field to fix dog template rendering

### DIFF
--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -46,6 +46,7 @@ const (
 	RoleRefinery Role = "refinery"
 	RolePolecat  Role = "polecat"
 	RoleCrew     Role = "crew"
+	RoleDog      Role = "dog"
 	RoleUnknown  Role = "unknown"
 )
 

--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -46,6 +46,8 @@ func outputPrimeContext(ctx RoleContext) (string, error) {
 		roleName = "crew"
 	case RoleBoot:
 		roleName = "boot"
+	case RoleDog:
+		roleName = "dog"
 	default:
 		// Unknown role - use fallback
 		outputPrimeContextFallback(ctx)
@@ -73,6 +75,7 @@ func outputPrimeContext(ctx RoleContext) (string, error) {
 		WorkDir:       ctx.WorkDir,
 		DefaultBranch: defaultBranch,
 		Polecat:       ctx.Polecat,
+		DogName:       ctx.Polecat, // ctx.Polecat holds the dog name for RoleDog
 		MayorSession:  session.MayorSessionName(),
 		DeaconSession: session.DeaconSessionName(),
 	}

--- a/internal/cmd/role.go
+++ b/internal/cmd/role.go
@@ -208,7 +208,7 @@ func GetRoleWithContext(cwd, townRoot string) (RoleInfo, error) {
 		// If env is incomplete (missing rig/polecat for roles that need them),
 		// fill gaps from cwd detection and mark as incomplete
 		needsRig := parsedRole == RoleWitness || parsedRole == RoleRefinery || parsedRole == RolePolecat || parsedRole == RoleCrew
-		needsPolecat := parsedRole == RolePolecat || parsedRole == RoleCrew
+		needsPolecat := parsedRole == RolePolecat || parsedRole == RoleCrew || parsedRole == RoleDog
 
 		if needsRig && info.Rig == "" && cwdCtx.Rig != "" {
 			info.Rig = cwdCtx.Rig
@@ -276,6 +276,14 @@ func detectRole(cwd, townRoot string) RoleInfo {
 		return ctx
 	}
 
+	// Check for dog role: deacon/dogs/<name>/
+	// Must check before deacon since dogs are under deacon directory
+	if len(parts) >= 3 && parts[0] == "deacon" && parts[1] == "dogs" {
+		ctx.Role = RoleDog
+		ctx.Polecat = parts[2] // dog name stored in Polecat field
+		return ctx
+	}
+
 	// Check for deacon role: deacon/
 	if len(parts) >= 1 && parts[0] == "deacon" {
 		ctx.Role = RoleDeacon
@@ -337,6 +345,8 @@ func parseRoleString(s string) (Role, string, string) {
 		return RoleDeacon, "", ""
 	case "boot":
 		return RoleBoot, "", ""
+	case "dog":
+		return RoleDog, "", ""
 	}
 
 	// Compound roles: rig/role or rig/polecats/name or rig/crew/name
@@ -443,6 +453,11 @@ func getRoleHome(role Role, rig, polecat, townRoot string) string {
 		return filepath.Join(townRoot, rig, "crew", polecat)
 	case RoleBoot:
 		return filepath.Join(townRoot, "deacon", "dogs", "boot")
+	case RoleDog:
+		if polecat == "" {
+			return ""
+		}
+		return filepath.Join(townRoot, "deacon", "dogs", polecat)
 	default:
 		return ""
 	}

--- a/internal/templates/roles/dog.md.tmpl
+++ b/internal/templates/roles/dog.md.tmpl
@@ -68,7 +68,7 @@ The command auto-detects your dog name from your working directory, so just run
 - `bd show <prefix>-xyz` routes to that rig's beads
 - `bd show hq-abc` routes to town beads
 
-Routes defined in `~/gt/.beads/routes.jsonl`. Debug with: `BD_DEBUG_ROUTING=1 bd show <id>`
+Routes defined in `{{ .TownRoot }}/.beads/routes.jsonl`. Debug with: `BD_DEBUG_ROUTING=1 bd show <id>`
 
 ## Where to File Beads (CRITICAL)
 

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -60,6 +60,7 @@ type RoleData struct {
 	DefaultBranch  string   // default branch for merges (e.g., "main", "develop")
 	Polecat        string   // polecat name (for polecat role)
 	Polecats       []string // list of polecats (for witness role)
+	DogName        string   // dog name (for dog role)
 	BeadsDir       string   // BEADS_DIR path
 	IssuePrefix    string   // beads issue prefix
 	MayorSession   string   // e.g., "gt-ai-mayor" - dynamic mayor session name


### PR DESCRIPTION
## Summary

- `dog.md.tmpl` uses `{{ .DogName }}` in 4 places (working directory, state path, mail identity, session name), but `RoleData` had no `DogName` field — template execution would panic/fail
- The `"dog"` role string had no corresponding `Role` constant, so dog sessions fell through to the unknown-role fallback in `gt prime` instead of rendering their context
- The remaining `~/gt` hardcode in `dog.md.tmpl`'s routes line is also fixed

## Changes

- Add `RoleDog Role = "dog"` constant to `prime.go`
- Add `DogName string` to `templates.RoleData`; populated as `ctx.Polecat` (same pattern crew uses for crew member names)
- CWD detection: `deacon/dogs/<name>/` → `RoleDog`, dog name stored in `RoleInfo.Polecat`
- `parseRoleString("dog")` → `RoleDog`
- `RoleDog` added to `needsPolecat` so `GT_ROLE=dog` fills dog name from CWD when no `GT_POLECAT` is set
- `getRoleHome` case for `RoleDog` → `<townRoot>/deacon/dogs/<name>`
- `outputPrimeContext` routes `RoleDog` to `"dog"` template and passes `DogName: ctx.Polecat`
- Fix `~/gt` → `{{ .TownRoot }}` in `dog.md.tmpl` routes line
- Add `TestRenderRole_Dog` and `TestRenderRole_Dog_NoHardcodedGtPath` regression tests

## Test plan

- [ ] `go test ./internal/templates/... ./internal/cmd/...` passes
- [ ] `TestRenderRole_Dog` verifies dog template renders with correct dog name and town root
- [ ] `TestRenderRole_Dog_NoHardcodedGtPath` verifies no `~/gt` literals remain in rendered output

🤖 Generated with [Claude Code](https://claude.com/claude-code)