### PR TITLE
refactor(beads): consolidate FindMRForBranch and FindMRForBranchAny

### DIFF
--- a/internal/beads/beads_mr.go
+++ b/internal/beads/beads_mr.go
@@ -9,31 +9,21 @@ import (
 // Returns the MR bead if found, nil if not found.
 // This enables idempotent `gt done` - if an MR already exists, we skip creation.
 func (b *Beads) FindMRForBranch(branch string) (*Issue, error) {
-	branchPrefix := "branch: " + branch + "\n"
-
-	// Check issues table first (non-ephemeral MR beads)
-	issues, err := b.List(ListOptions{
-		Status: "open",
-		Label:  "gt:merge-request",
-	})
-	if err != nil {
-		return nil, err
-	}
-	for _, issue := range issues {
-		if strings.HasPrefix(issue.Description, branchPrefix) {
-			return issue, nil
-		}
-	}
-
-	// Fallback: check wisps table. MR beads created as ephemeral (b9900940)
-	// live in the wisps table, invisible to bd list --status=open.
-	return b.findMRInWisps(branchPrefix)
+	return b.findMRForBranch(branch, true)
 }
 
 // FindMRForBranchAny searches for a merge-request bead for the given branch
 // across all statuses (open and closed). Used by recovery checks to determine
 // if work was ever submitted to the merge queue. See #1035.
 func (b *Beads) FindMRForBranchAny(branch string) (*Issue, error) {
+	return b.findMRForBranch(branch, false)
+}
+
+// findMRForBranch searches both the issues table (Dolt) and wisps table
+// (SQLite) for a merge-request bead matching the given branch.
+// Uses status=all which covers both tables with full descriptions.
+// When skipClosed is true, closed beads are excluded (for open-MR checks).
+func (b *Beads) findMRForBranch(branch string, skipClosed bool) (*Issue, error) {
 	branchPrefix := "branch: " + branch + "\n"
 
 	issues, err := b.List(ListOptions{
@@ -44,28 +34,7 @@ func (b *Beads) FindMRForBranchAny(branch string) (*Issue, error) {
 		return nil, err
 	}
 	for _, issue := range issues {
-		if strings.HasPrefix(issue.Description, branchPrefix) {
-			return issue, nil
-		}
-	}
-
-	return nil, nil
-}
-
-// findMRInWisps searches the wisps table for an open merge-request bead
-// matching branchPrefix. Uses bd list --status=all which includes both
-// issues (Dolt) and wisps (SQLite) tables with full descriptions.
-// Scoped to gt:merge-request label to keep the result set small.
-func (b *Beads) findMRInWisps(branchPrefix string) (*Issue, error) {
-	issues, err := b.List(ListOptions{
-		Status: "all",
-		Label:  "gt:merge-request",
-	})
-	if err != nil {
-		return nil, err
-	}
-	for _, issue := range issues {
-		if issue.Status == "closed" {
+		if skipClosed && issue.Status == "closed" {
 			continue
 		}
 		if strings.HasPrefix(issue.Description, branchPrefix) {
@@ -75,4 +44,3 @@ func (b *Beads) findMRInWisps(branchPrefix string) (*Issue, error) {
 
 	return nil, nil
 }
-


### PR DESCRIPTION
Follow-up to a3dd60bf which fixed FindMRForBranch to search ephemeral wisps via status=all.

## Problem

That fix left an inconsistency: FindMRForBranch used a two-pass approach (status=open query, then findMRInWisps fallback with status=all), while FindMRForBranchAny already queried status=all directly. The findMRInWisps function duplicated the same status=all query that findMRForBranch could do in one pass.

## Change

Consolidate both public methods into a shared findMRForBranch(branch, skipClosed) helper and remove the now-redundant findMRInWisps. No behavioral change — same coverage, one pass instead of two. No caller changes required.

## Files

- internal/beads/beads_mr.go: Three functions replaced by one shared helper plus two one-liner delegates.