### PR TITLE
fix(test): mock isRigParkedFn in TestDetectWarnings_Clean

### DIFF
--- a/internal/cmd/convoy_stage_test.go
+++ b/internal/cmd/convoy_stage_test.go
@@ -1439,6 +1439,11 @@ func TestRenderWarnings_Format(t *testing.T) {
 
 // Test detectWarnings clean DAG — no warnings
 func TestDetectWarnings_Clean(t *testing.T) {
+	// Override isRigParkedFn so the test doesn't depend on real rig state.
+	origFn := isRigParkedFn
+	isRigParkedFn = func(townRoot, rigName string) bool { return false }
+	t.Cleanup(func() { isRigParkedFn = origFn })
+
 	// All tasks on same rig, all have deps between them, epic input.
 	dag := &ConvoyDAG{Nodes: map[string]*ConvoyDAGNode{
 		"epic-1": {ID: "epic-1", Type: "epic", Children: []string{"gt-a", "gt-b", "gt-c"}},


### PR DESCRIPTION
## Summary
- `TestDetectWarnings_Clean` fails when run inside a Gas Town workspace with a parked rig because `detectParkedRigs` hits the real filesystem via the unmocked `isRigParkedFn` seam
- Override `isRigParkedFn` to always return `false`, matching the pattern already used by `TestDetectWarnings_ParkedRig`
- Fix integration tests failing because `cleanSchedulerTestEnv` stripped `GT_DOLT_PORT`, preventing gt subprocesses from connecting to the ephemeral Dolt test server
- Fix `InitBeads` not passing `--server-port` to `bd init --server`, causing bd to use default port 3307 instead of the dynamic test port

## Test plan
- [x] `go test -run TestDetectWarnings_Clean ./internal/cmd/...` passes
- [x] Full `go test ./internal/cmd/...` passes
- [x] Full `go test ./internal/rig/...` passes
- [ ] CI Integration Tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)