### PR TITLE
test(daemon): reproduce getPatrolRigs parked/docked filtering gap

### DIFF
--- a/internal/daemon/patrol_rigs_filter_test.go
+++ b/internal/daemon/patrol_rigs_filter_test.go
@@ -1,0 +1,45 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"slices"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/wisp"
+)
+
+// Regression test for gt-arz:
+// getPatrolRigs should filter parked/docked rigs at list-building time.
+func TestGetPatrolRigs_FiltersNonOperationalRigs(t *testing.T) {
+	townRoot := t.TempDir()
+
+	// Seed known rigs.
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0o755); err != nil {
+		t.Fatalf("mkdir mayor dir: %v", err)
+	}
+	rigsJSON := `{"rigs":{"alpha":{},"beta":{},"gamma":{}}}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(rigsJSON), 0o644); err != nil {
+		t.Fatalf("write rigs.json: %v", err)
+	}
+
+	// Mark beta/gamma as non-operational via wisp status.
+	if err := wisp.NewConfig(townRoot, "beta").Set("status", "parked"); err != nil {
+		t.Fatalf("set beta parked: %v", err)
+	}
+	if err := wisp.NewConfig(townRoot, "gamma").Set("status", "docked"); err != nil {
+		t.Fatalf("set gamma docked: %v", err)
+	}
+
+	d := &Daemon{
+		config: &Config{TownRoot: townRoot},
+	}
+
+	got := d.getPatrolRigs("witness")
+	slices.Sort(got)
+	want := []string{"alpha"}
+	if !slices.Equal(got, want) {
+		t.Fatalf("getPatrolRigs() = %v, want %v (parked/docked rigs should be filtered here)", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
Add a failing regression test that demonstrates `getPatrolRigs()` does not filter parked/docked rigs at list-building time.

This is a repro-only PR (no behavior fix yet).

## Related Issue
Closes #2082

## Changes
- Add `TestGetPatrolRigs_FiltersNonOperationalRigs` in `internal/daemon/patrol_rigs_filter_test.go`
- Seed `mayor/rigs.json` with `alpha`, `beta`, `gamma`
- Mark `beta` as `parked` and `gamma` as `docked` via wisp status
- Assert `getPatrolRigs("witness")` should only return operational rig `alpha`

## Why this caused trouble
When parked/docked rigs are not filtered here, daemon still re-processes them every heartbeat and only skips later in `ensure*Running`.
That keeps parked rigs in the active patrol loop, creating repeated skip churn and making parked/docked behavior noisy and unreliable to operate.

## Testing
- [ ] Unit tests pass (`go test ./...`)
- [x] Manual testing performed

Manual test run:
- `go test ./internal/daemon -run TestGetPatrolRigs_FiltersNonOperationalRigs -count=1`
- Result: **fails** with `getPatrolRigs() = [alpha beta gamma], want [alpha]`

## Checklist
- [x] Code follows project style
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)
