### PR TITLE
test(daemon): reproduce boot spawn-on-every-tick behavior

### DIFF
--- a/internal/daemon/boot_spawn_frequency_test.go
+++ b/internal/daemon/boot_spawn_frequency_test.go
@@ -1,0 +1,100 @@
+package daemon
+
+import (
+	"io"
+	"log"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+func writeFakeTmux(t *testing.T, dir string) {
+	t.Helper()
+	script := `#!/usr/bin/env bash
+set -euo pipefail
+
+cmd=""
+skip_next=0
+for arg in "$@"; do
+  if [[ "$skip_next" -eq 1 ]]; then
+    skip_next=0
+    continue
+  fi
+  if [[ "$arg" == "-u" ]]; then
+    continue
+  fi
+  if [[ "$arg" == "-L" ]]; then
+    skip_next=1
+    continue
+  fi
+  cmd="$arg"
+  break
+done
+
+if [[ -n "${TMUX_LOG:-}" ]]; then
+  printf "%s %s\n" "$cmd" "$*" >> "$TMUX_LOG"
+fi
+
+if [[ "${1:-}" == "-V" ]]; then
+  echo "tmux 3.3a"
+  exit 0
+fi
+
+# Keep session checks simple for this regression repro: no existing boot session.
+if [[ "$cmd" == "has-session" ]]; then
+  exit 1
+fi
+
+exit 0
+`
+	path := filepath.Join(dir, "tmux")
+	if err := os.WriteFile(path, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake tmux: %v", err)
+	}
+}
+
+// Regression test for gt-1z0:
+// daemon should not spawn a fresh Boot session every heartbeat when triage was just run.
+func TestEnsureBootRunning_DoesNotSpawnEveryTick(t *testing.T) {
+	townRoot := t.TempDir()
+	fakeBinDir := t.TempDir()
+	tmuxLog := filepath.Join(t.TempDir(), "tmux.log")
+	if err := os.WriteFile(tmuxLog, []byte{}, 0o644); err != nil {
+		t.Fatalf("create tmux log: %v", err)
+	}
+
+	writeFakeTmux(t, fakeBinDir)
+	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_LOG", tmuxLog)
+	t.Setenv("GT_DEGRADED", "false")
+
+	d := &Daemon{
+		config: &Config{TownRoot: townRoot},
+		logger: log.New(io.Discard, "", 0),
+		tmux:   tmux.NewTmux(),
+	}
+
+	// Simulate two adjacent heartbeats.
+	d.ensureBootRunning()
+	d.ensureBootRunning()
+
+	data, err := os.ReadFile(tmuxLog)
+	if err != nil {
+		t.Fatalf("read tmux log: %v", err)
+	}
+
+	// Desired behavior (cooldown): single spawn in this short interval.
+	// Current behavior: two spawns (fails here).
+	spawns := 0
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if strings.HasPrefix(line, "new-session ") {
+			spawns++
+		}
+	}
+	if spawns != 1 {
+		t.Fatalf("boot spawn count = %d, want 1 (avoid spawning every daemon tick)", spawns)
+	}
+}


### PR DESCRIPTION
## Summary
Add a failing regression test showing Boot is spawned on every daemon tick with no cooldown gate.

This is a repro-only PR (no fix implementation).

## Related Issue
Closes #2084

## Changes
- Add `TestEnsureBootRunning_DoesNotSpawnEveryTick` in `internal/daemon/boot_spawn_frequency_test.go`
- Use a fake `tmux` shim to capture daemon Boot spawn commands deterministically
- Call `ensureBootRunning()` twice in immediate succession
- Assert Boot should spawn once in a short interval (cooldown expectation)

## Why this caused trouble
Without a cooldown, daemon heartbeats trigger repeated Boot spawns even when triage just ran.
That creates unnecessary session churn, extra triage loops, and operational noise/tokens during normal operation.

## Testing
- [ ] Unit tests pass (`go test ./...`)
- [x] Manual testing performed

Manual test run:
- `go test ./internal/daemon -run TestEnsureBootRunning_DoesNotSpawnEveryTick -count=1`
- Result: **fails** with `boot spawn count = 2, want 1 (avoid spawning every daemon tick)`

## Checklist
- [x] Code follows project style
- [ ] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)
