### PR TITLE
fix(docs): correct ~/.gt path references in formulas and role docs

### DIFF
--- a/internal/cmd/role.go
+++ b/internal/cmd/role.go
@@ -117,7 +117,7 @@ var roleDefCmd = &cobra.Command{
 
 Role configuration is layered:
   1. Built-in defaults (embedded in binary)
-  2. Town-level overrides (~/.gt/roles/<role>.toml)
+  2. Town-level overrides (<town>/roles/<role>.toml)
   3. Rig-level overrides (<rig>/roles/<role>.toml)
 
 Examples:

--- a/internal/formula/formulas/mol-gastown-boot.formula.toml
+++ b/internal/formula/formulas/mol-gastown-boot.formula.toml
@@ -29,8 +29,8 @@ gt daemon status || gt daemon start
 ```
 
 ## Verify
-1. Daemon PID file exists: `~/.gt/daemon.pid`
-2. Process is alive: `kill -0 $(cat ~/.gt/daemon.pid)`
+1. Daemon PID file exists: `$GT_TOWN_ROOT/daemon/daemon.pid`
+2. Process is alive: `kill -0 $(cat $GT_TOWN_ROOT/daemon/daemon.pid)`
 3. Daemon responds: `gt daemon status` returns success
 
 ## OnFail

--- a/internal/formula/formulas/mol-session-gc.formula.toml
+++ b/internal/formula/formulas/mol-session-gc.formula.toml
@@ -95,8 +95,9 @@ git branch --list 'polecat/*' | while read branch; do
   # If > 7 days old and no matching polecat, candidate for cleanup
 done
 
-# Old state files
-find ~/.gt/ -name "*.state" -mtime +7
+# Old runtime state files (stored under <rig>/.runtime/ as *.json).
+# Prefer using `gt doctor -v` to enumerate stale state — it knows all locations.
+find "$GT_TOWN_ROOT" -path "*/.runtime/*.json" -mtime +7 2>/dev/null
 ```
 
 **4. Compile cleanup manifest:**


### PR DESCRIPTION
## Summary

- `mol-gastown-boot.formula.toml`: `~/.gt/daemon.pid` → `$GT_TOWN_ROOT/daemon/daemon.pid` (actual path set by `daemon.DefaultConfig`)
- `mol-session-gc.formula.toml`: `find ~/.gt/ -name "*.state"` → `find "$GT_TOWN_ROOT" -path "*/.runtime/*.json"` (state files are `.json` under `<rig>/.runtime/`, not `.state` under `~/.gt/`; note added pointing to `gt doctor`)
- `internal/cmd/role.go`: `~/.gt/roles/<role>.toml` → `<town>/roles/<role>.toml` (the actual resolver uses `townRoot` from workspace detection, not `~/.gt`)

No code changes — docs/formulas only.

## Test plan

- [ ] Verify formulas still parse correctly (`bd mol list`)
- [ ] Verify `gt role def witness` help text shows the correct path

🤖 Generated with [Claude Code](https://claude.com/claude-code)