### PR TITLE
feat(cmd): write telemetry and cost logs to GT_HOME/.gt when set

### DIFF
--- a/internal/cmd/costs.go
+++ b/internal/cmd/costs.go
@@ -944,13 +944,10 @@ type CostLogEntry struct {
 	WorkItem  string    `json:"work_item,omitempty"`
 }
 
-// getCostsLogPath returns the path to the costs log file (~/.gt/costs.jsonl).
+// getCostsLogPath returns the path to the costs log file.
+// Location: $GT_HOME/.gt/costs.jsonl when GT_HOME is set, otherwise ~/.gt/.
 func getCostsLogPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil {
-		return "/tmp/gt-costs.jsonl" // Fallback
-	}
-	return filepath.Join(home, ".gt", "costs.jsonl")
+	return filepath.Join(gtDataDir(), "costs.jsonl")
 }
 
 // runCostsRecord captures the final cost from a session and appends it to a local log file.

--- a/internal/cmd/paths.go
+++ b/internal/cmd/paths.go
@@ -1,0 +1,24 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// gtDataDir returns the directory used for GT's runtime data files
+// (logs, telemetry, cost records, etc.).
+//
+// Resolution order:
+//  1. $GT_HOME/.gt  — when GT_HOME is set, data is kept alongside the GT
+//     workspace rather than in the user's home directory.
+//  2. ~/.gt         — default location when GT_HOME is not set.
+func gtDataDir() string {
+	if h := os.Getenv("GT_HOME"); h != "" {
+		return filepath.Join(h, ".gt")
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(os.TempDir(), ".gt")
+	}
+	return filepath.Join(home, ".gt")
+}

--- a/internal/cmd/telemetry.go
+++ b/internal/cmd/telemetry.go
@@ -10,7 +10,8 @@ import (
 )
 
 // logUsagePath is the JSONL file where command usage is recorded.
-var logUsagePath = filepath.Join(os.Getenv("HOME"), ".gt", "cmd-usage.jsonl")
+// Location: $GT_HOME/.gt when GT_HOME is set, otherwise ~/.gt.
+var logUsagePath = filepath.Join(gtDataDir(), "cmd-usage.jsonl")
 
 // noLogCommands are top-level commands excluded from telemetry.
 // These fire per-tool-use and would dominate the log.
@@ -19,7 +20,8 @@ var noLogCommands = map[string]bool{
 	"signal": true,
 }
 
-// logCommandUsage appends one JSONL line to ~/.gt/cmd-usage.jsonl.
+// logCommandUsage appends one JSONL line to the cmd-usage.jsonl log.
+// Location: $GT_HOME/.gt/cmd-usage.jsonl when GT_HOME is set, else ~/.gt/.
 // Fire-and-forget: all errors are silently ignored.
 func logCommandUsage(cmd *cobra.Command, args []string) {
 	// Walk up to the first subcommand under root to check exclusions.


### PR DESCRIPTION
## Summary

Introduces `gtDataDir()` in `internal/cmd/paths.go` with the same `GT_HOME` resolution logic as the hooks cascading PR:

- Returns `$GT_HOME/.gt` when `GT_HOME` is set
- Falls back to `~/.gt` otherwise

Two callers updated:

| File | Before | After |
|---|---|---|
| `telemetry.go` | `os.Getenv("HOME")+"/.gt/cmd-usage.jsonl"` | `gtDataDir()+"/cmd-usage.jsonl"` |
| `costs.go` | `os.UserHomeDir()+"/.gt/costs.jsonl"` | `gtDataDir()+"/costs.jsonl"` |

`getCostsLogPath()` also drops its now-redundant `/tmp/gt-costs.jsonl` fallback — `gtDataDir()` already handles the `UserHomeDir` error case via `os.TempDir()`.

## Test plan

- [ ] `go build ./internal/cmd/...` passes
- [ ] With `GT_HOME` unset: logs still written to `~/.gt/`
- [ ] With `GT_HOME=/some/path`: `gt costs record` and command usage land in `/some/path/.gt/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)