### PR TITLE
fix(tmux): restore ctrl-b+g from personal sessions after cross-socket split

### DIFF
--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -895,9 +895,13 @@ func ensureCrossSocketBindings() {
 
 	// Always ensure bindings on the "default" socket since that's where
 	// users typically have their interactive terminal sessions.
+	// Pass townSocket so the binding embeds GT_TOWN_SOCKET=<name> in the
+	// run-shell command — gt agents menu needs it to locate the right tmux
+	// server when invoked from a non-town directory where InitRegistry is
+	// never called.
 	// EnsureBindingsOnSocket is idempotent and safe if default == town.
 	if townSocket != "default" {
-		_ = tmux.EnsureBindingsOnSocket("default")
+		_ = tmux.EnsureBindingsOnSocket("default", townSocket)
 	}
 }
 


### PR DESCRIPTION
## Root cause

Regression from ab5f06f1 (cross-socket agent menu, Feb 26).

When `ctrl-b g` fires from a **personal session on the default socket**, `gt agents menu` runs in a fresh process. `workspace.FindFromCwd()` fails (CWD is not inside the town), `InitRegistry` is never called, `GetDefaultSocket()` returns `""`. `NewTmux()` with an empty socket name connects to the **current** tmux server (the default one) instead of the town server — so either personal sessions are listed in place of GT agents, or the menu shows "No agent sessions running."

A second bug caused **repeated re-wrapping**: `isGTBinding` only matched the `if-shell + "gt "` form; the bare `run-shell "gt agents menu"` set by `EnsureBindingsOnSocket` wasn't recognised, so every `gt up` call re-captured it as a "user binding" and wrapped it in another `if-shell` layer.

## Fixes

**1. `EnsureBindingsOnSocket(socket, townSocket string)`**
Embeds `GT_TOWN_SOCKET=<name>` in the `run-shell` command. `gt up` now calls `EnsureBindingsOnSocket("default", "gt")` so the binding carries the server name into any invocation context.

**2. `getAllSocketSessions` — `GT_TOWN_SOCKET` fallback**
When `GetDefaultSocket() == ""`, reads `os.Getenv("GT_TOWN_SOCKET")` as the server name. Switches from `NewTmux()` (empty → current socket) to `NewTmuxWithSocket(townSocket)` (explicit).

**3. `isGTBinding` / `getKeyBinding` — recognise unguarded form**
Both functions now also match `"gt agents menu"` and `"gt feed --window"` directly, stopping the re-wrapping cycle.

## Test plan

- [ ] `go build ./...` passes
- [ ] `ctrl-b g` from a personal session (default socket) shows the GT agent menu
- [ ] `ctrl-b g` from a GT session (town socket) still works
- [ ] Running `gt up` twice does not produce a doubly-nested binding (`tmux list-keys -T prefix g`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)