### PR TITLE
fix(mail): add filesystem fallback and crew/name shorthand for crew member addressing

### DIFF
--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"os"
 	"path/filepath"
 	"strings"
 
@@ -858,7 +859,92 @@ func (r *Router) validateRecipient(identity string) error {
 		}
 	}
 
+	// Filesystem fallback: check if the address corresponds to a known rig agent
+	// directory. This handles crew/polecat members that lack gt:agent beads.
+	// Identity format after AddressToIdentity normalization is "rig/name".
+	if r.townRoot != "" {
+		parts := strings.Split(identity, "/")
+		if len(parts) == 2 {
+			rig, name := parts[0], parts[1]
+			rigDir := filepath.Join(r.townRoot, rig)
+			if fi, err := os.Stat(rigDir); err == nil && fi.IsDir() {
+				// Check crew workers (rig/crew/name)
+				if fi2, err2 := os.Stat(filepath.Join(rigDir, "crew", name)); err2 == nil && fi2.IsDir() {
+					return nil
+				}
+				// Check polecats (rig/polecats/name)
+				if fi2, err2 := os.Stat(filepath.Join(rigDir, "polecats", name)); err2 == nil && fi2.IsDir() {
+					return nil
+				}
+				// Check singleton roles (witness, refinery)
+				for _, role := range []string{"witness", "refinery"} {
+					if name == role {
+						if fi2, err2 := os.Stat(filepath.Join(rigDir, role)); err2 == nil && fi2.IsDir() {
+							return nil
+						}
+					}
+				}
+			}
+		}
+	}
+
 	return fmt.Errorf("no agent found")
+}
+
+// resolveCrewShorthand expands "crew/name" or "polecats/name" shorthand addresses
+// to fully-qualified "rig/name" form by scanning the town filesystem.
+//
+// When gt agents displays crew workers, it shows them as "crew/bob" (without rig).
+// This function enables "gt mail send crew/bob" to work by finding the rig.
+//
+// Returns the normalized identity if exactly one rig contains the crew member,
+// or the original identity unchanged if zero or multiple rigs match (to let
+// validation fail with an informative error).
+func (r *Router) resolveCrewShorthand(identity string) string {
+	if r.townRoot == "" {
+		return identity
+	}
+
+	parts := strings.Split(identity, "/")
+	if len(parts) != 2 {
+		return identity
+	}
+
+	roleDir, name := parts[0], parts[1]
+	// Only handle crew and polecats shorthand (not real rig names)
+	if roleDir != "crew" && roleDir != "polecats" {
+		return identity
+	}
+
+	// Check if "crew" or "polecats" is actually a real rig directory
+	if fi, err := os.Stat(filepath.Join(r.townRoot, roleDir)); err == nil && fi.IsDir() {
+		// It's a real rig, not a shorthand - let normal validation handle it
+		return identity
+	}
+
+	// Scan rig directories for a crew/polecats member with this name
+	entries, err := os.ReadDir(r.townRoot)
+	if err != nil {
+		return identity
+	}
+
+	var matches []string
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		rig := entry.Name()
+		agentDir := filepath.Join(r.townRoot, rig, roleDir, name)
+		if fi, err2 := os.Stat(agentDir); err2 == nil && fi.IsDir() {
+			matches = append(matches, rig+"/"+name)
+		}
+	}
+
+	if len(matches) == 1 {
+		return matches[0] // Unambiguous: expand to rig/name
+	}
+
+	return identity // Ambiguous or not found: let validation handle it
 }
 
 // sendToSingle sends a message to a single recipient.
@@ -875,6 +961,8 @@ func (r *Router) sendToSingle(msg *Message) error {
 
 	// Convert addresses to beads identities
 	toIdentity := AddressToIdentity(msg.To)
+	// Expand crew/polecats shorthand (e.g., "crew/bob" → "pata/bob")
+	toIdentity = r.resolveCrewShorthand(toIdentity)
 
 	// Validate recipient exists
 	if err := r.validateRecipient(toIdentity); err != nil {

--- a/internal/mail/router_test.go
+++ b/internal/mail/router_test.go
@@ -1190,3 +1190,142 @@ func TestAddressToAgentBeadID(t *testing.T) {
 		})
 	}
 }
+
+// ============ Crew Shorthand Resolution Tests ============
+
+func TestResolveCrewShorthand(t *testing.T) {
+	// Create a realistic town directory structure
+	tmpDir := t.TempDir()
+
+	// Create pata rig with crew members
+	for _, name := range []string{"alice", "bob"} {
+		dir := filepath.Join(tmpDir, "pata", "crew", name)
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Create pata polecat
+	if err := os.MkdirAll(filepath.Join(tmpDir, "pata", "polecats", "rust"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Create another rig with crew
+	if err := os.MkdirAll(filepath.Join(tmpDir, "beads", "crew", "alice"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewRouterWithTownRoot(tmpDir, tmpDir)
+
+	tests := []struct {
+		name     string
+		identity string
+		want     string
+	}{
+		// crew/name shorthand: unambiguous single rig match
+		{
+			name:     "crew/bob unambiguous",
+			identity: "crew/bob",
+			want:     "pata/bob", // bob only in pata
+		},
+		// crew/name shorthand: ambiguous (in multiple rigs) - leave unchanged
+		{
+			name:     "crew/alice ambiguous",
+			identity: "crew/alice",
+			want:     "crew/alice", // alice in both pata and beads
+		},
+		// Already fully-qualified rig/name - leave unchanged
+		{
+			name:     "pata/bob already canonical",
+			identity: "pata/bob",
+			want:     "pata/bob",
+		},
+		// polecats shorthand
+		{
+			name:     "polecats/rust shorthand",
+			identity: "polecats/rust",
+			want:     "pata/rust", // rust only in pata polecats
+		},
+		// Non-crew address - leave unchanged
+		{
+			name:     "mayor/ unchanged",
+			identity: "mayor/",
+			want:     "mayor/",
+		},
+		// No town root - no resolution attempted
+		{
+			name:     "no town root",
+			identity: "crew/bob",
+			want:     "crew/bob", // tested with empty townRoot below
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			router := r
+			if tt.name == "no town root" {
+				router = NewRouterWithTownRoot(tmpDir, "") // empty townRoot
+			}
+			got := router.resolveCrewShorthand(tt.identity)
+			if got != tt.want {
+				t.Errorf("resolveCrewShorthand(%q) = %q, want %q", tt.identity, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestValidateRecipientFilesystemFallback(t *testing.T) {
+	// Create a realistic town directory structure without any agent beads
+	tmpDir := t.TempDir()
+
+	// Create pata rig structure
+	for _, subpath := range []string{
+		"pata/crew/bob",
+		"pata/crew/alice",
+		"pata/polecats/rust",
+		"pata/witness",
+		"pata/refinery",
+	} {
+		if err := os.MkdirAll(filepath.Join(tmpDir, subpath), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Create mayor/town.json marker
+	if err := os.MkdirAll(filepath.Join(tmpDir, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "mayor", "town.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewRouterWithTownRoot(tmpDir, tmpDir)
+
+	tests := []struct {
+		name     string
+		identity string
+		wantErr  bool
+	}{
+		// Crew members found via filesystem (no agent beads needed)
+		{"crew bob", "pata/bob", false},
+		{"crew alice", "pata/alice", false},
+		// Polecat found via filesystem
+		{"polecat rust", "pata/rust", false},
+		// Singleton roles found via filesystem
+		{"witness", "pata/witness", false},
+		{"refinery", "pata/refinery", false},
+		// Overseer always valid
+		{"overseer", "overseer", false},
+		// Non-existent agent should fail
+		{"nonexistent", "pata/nobody", true},
+		{"wrong rig", "notarig/bob", true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := r.validateRecipient(tt.identity)
+			if tt.wantErr && err == nil {
+				t.Errorf("validateRecipient(%q) expected error, got nil", tt.identity)
+			} else if !tt.wantErr && err != nil {
+				t.Errorf("validateRecipient(%q) unexpected error: %v", tt.identity, err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- `gt mail send crew/bob` and `gt mail send pata/crew/bob` now work correctly
- Crew workers lack `gt:agent` beads but have directories in `rig/crew/<name>`
- Two fixes in `validateRecipient` and new `resolveCrewShorthand` method

## Changes

**`validateRecipient` filesystem fallback**: After failing to find an agent bead, checks if `townRoot/rig/crew/<name>` or `townRoot/rig/polecats/<name>` directory exists. This handles agents that exist on disk but lack agent beads (crew workers, some polecats).

**`resolveCrewShorthand`**: When address is `crew/name` or `polecats/name` (the shorthand format shown by `gt agents`), scans rig directories to find the correct rig and expand to `rig/name`. Unambiguous single-rig matches are expanded; ambiguous matches are left unchanged for validation to report properly.

## Before / After

```
# Before:
$ gt mail send crew/bob -s "DoD" -m "done"
Error: all sends failed: crew/bob: invalid recipient "crew/bob": no agent found

$ gt mail send pata/crew/bob -s "DoD" -m "done"  
Error: all sends failed: pata/crew/bob: invalid recipient "pata/crew/bob": no agent found

# After:
$ gt mail send crew/bob -s "DoD" -m "done"
✓ Message sent to crew/bob

$ gt mail send pata/crew/bob -s "DoD" -m "done"
✓ Message sent to pata/crew/bob
```

## Test plan

- [x] `TestResolveCrewShorthand` - unit tests for shorthand expansion (unambiguous, ambiguous, non-crew)
- [x] `TestValidateRecipientFilesystemFallback` - unit tests for filesystem fallback (crew, polecats, singleton roles, overseer, nonexistent)
- [x] Existing `TestValidateRecipient` tests still pass
- [x] Full `./internal/mail/...` test suite passes

Fixes: hq-q9i835

🤖 Generated with [Claude Code](https://claude.com/claude-code)