### PR TITLE
fix(tmux): prevent silent wrong-server connections when town context is missing

### DIFF
--- a/internal/tmux/respawn_hook_test.go
+++ b/internal/tmux/respawn_hook_test.go
@@ -93,7 +93,7 @@ func TestAutoRespawnHook_RespawnWorks(t *testing.T) {
 	testSession(t, socket, session, "sleep 2")
 	defer func() { _ = exec.Command("tmux", "-L", socket, "kill-session", "-t", session).Run() }()
 
-	tmx := NewTmux()
+	tmx := NewTmuxWithSocket(socket)
 	if err := tmx.SetAutoRespawnHook(session); err != nil {
 		t.Fatalf("SetAutoRespawnHook: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestAutoRespawnHook_SkipsAlreadyAlive(t *testing.T) {
 	testSession(t, socket, session, "sleep 300")
 	defer func() { _ = exec.Command("tmux", "-L", socket, "kill-session", "-t", session).Run() }()
 
-	tmx := NewTmux()
+	tmx := NewTmuxWithSocket(socket)
 	if err := tmx.SetAutoRespawnHook(session); err != nil {
 		t.Fatalf("SetAutoRespawnHook: %v", err)
 	}

--- a/internal/tmux/testmain_test.go
+++ b/internal/tmux/testmain_test.go
@@ -1,0 +1,28 @@
+package tmux
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// TestMain sets up a dedicated tmux server for the package's integration tests.
+// All tests that call newTestTmux() share this isolated server, which is torn
+// down after all tests complete. This prevents test sessions from appearing on
+// the user's interactive tmux and avoids socket conflicts with other packages.
+func TestMain(m *testing.M) {
+	socket := fmt.Sprintf("gt-test-%d", os.Getpid())
+
+	// Set defaultSocket so NewTmux() connects to the test server, not the
+	// user's personal server or the sentinel that indicates "no town context".
+	SetDefaultSocket(socket)
+
+	code := m.Run()
+
+	// Kill the test tmux server and restore the original socket state.
+	_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	SetDefaultSocket("")
+
+	os.Exit(code)
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -103,9 +103,28 @@ type Tmux struct {
 	socketName string // tmux socket name (-L flag), empty = default socket
 }
 
-// NewTmux creates a new Tmux wrapper that inherits the default socket.
+// noTownSocket is a sentinel socket name used when no town socket is configured.
+// Using a non-existent socket causes tmux operations to fail with a clear
+// "no server running" error instead of silently connecting to the wrong server.
+const noTownSocket = "gt-no-town-socket"
+
+// NewTmux creates a new Tmux wrapper using the initialized town socket.
+// Falls back to GT_TOWN_SOCKET env var (set by cross-socket tmux bindings),
+// then to a sentinel socket that fails clearly if neither is available.
 func NewTmux() *Tmux {
-	return &Tmux{socketName: defaultSocket}
+	sock := defaultSocket
+	if sock == "" {
+		// GT_TOWN_SOCKET is embedded in tmux bindings created by EnsureBindingsOnSocket
+		// so that "gt agents menu" / "gt feed" invoked from a personal terminal still
+		// target the correct town server even when InitRegistry was not called.
+		sock = os.Getenv("GT_TOWN_SOCKET")
+	}
+	if sock == "" {
+		// No town context available: use sentinel to produce a clear error rather
+		// than silently connecting to the user's personal tmux server.
+		sock = noTownSocket
+	}
+	return &Tmux{socketName: sock}
 }
 
 // NewTmuxWithSocket creates a Tmux wrapper that targets a named socket.


### PR DESCRIPTION
## Problem

When `gt agents menu` (or `gt feed`) is invoked via a cross-socket tmux binding from a personal terminal, `workspace.FindFromCwd()` fails because the CWD is not inside the town. This means `InitRegistry` is never called, `defaultSocket` stays empty, and `NewTmux()` silently connects to whatever tmux server happens to be running (typically the user's personal `default` socket) rather than the town's isolated socket.

## Fix

Two complementary changes:

### 1. `persistentPreRun` uses env var fallbacks (root.go)

Replace `workspace.FindFromCwd()` with `detectTownRootFromCwd()` (already exists in `handoff.go`), which also checks `$GT_TOWN_ROOT` and `$GT_ROOT` after CWD detection fails. This ensures `InitRegistry` — and therefore `SetDefaultSocket` — is called for any command invoked in an environment where the town root is set via env var (polecat sessions, shell integrations, etc.).

### 2. `NewTmux()` sentinel for missing town context (tmux.go)

Instead of silently using an empty socket (which connects to the default server), `NewTmux()` now follows this fallback chain:

1. `defaultSocket` (set by `InitRegistry`) — normal case
2. `$GT_TOWN_SOCKET` (embedded in cross-socket bindings by `EnsureBindingsOnSocket`, see PR #2099)
3. Sentinel `"gt-no-town-socket"` — produces a clear tmux error (`no server running on …/gt-no-town-socket`) rather than silently targeting the wrong server

### 3. Missing `testmain_test.go` (tmux package)

The comment in `tmux_test.go` referenced a `TestMain` that was never created. Added the missing file so the package's integration tests use a dedicated isolated socket instead of the user's default server. Also fixed two tests in `respawn_hook_test.go` that used `NewTmux()` where they should have used `NewTmuxWithSocket(socket)` for their per-test socket.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/tmux/... -short` passes (socket unit tests: TestSetGetDefaultSocket, TestNewTmuxInheritsSocket, etc.)
- [ ] `go test ./internal/cmd/... -short` passes
- [ ] `TestNewSessionWithCommand_Success` failure is pre-existing on `main` (confirmed independently)

🤖 Generated with [Claude Code](https://claude.com/claude-code)