### PR TITLE
fix(tmux): NewTmux() sentinel prevents silent wrong-server connections

### DIFF
--- a/internal/tmux/respawn_hook_test.go
+++ b/internal/tmux/respawn_hook_test.go
@@ -93,7 +93,7 @@ func TestAutoRespawnHook_RespawnWorks(t *testing.T) {
 	testSession(t, socket, session, "sleep 2")
 	defer func() { _ = exec.Command("tmux", "-L", socket, "kill-session", "-t", session).Run() }()
 
-	tmx := NewTmux()
+	tmx := NewTmuxWithSocket(socket)
 	if err := tmx.SetAutoRespawnHook(session); err != nil {
 		t.Fatalf("SetAutoRespawnHook: %v", err)
 	}
@@ -132,7 +132,7 @@ func TestAutoRespawnHook_SkipsAlreadyAlive(t *testing.T) {
 	testSession(t, socket, session, "sleep 300")
 	defer func() { _ = exec.Command("tmux", "-L", socket, "kill-session", "-t", session).Run() }()
 
-	tmx := NewTmux()
+	tmx := NewTmuxWithSocket(socket)
 	if err := tmx.SetAutoRespawnHook(session); err != nil {
 		t.Fatalf("SetAutoRespawnHook: %v", err)
 	}

--- a/internal/tmux/testmain_test.go
+++ b/internal/tmux/testmain_test.go
@@ -1,0 +1,28 @@
+package tmux
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"testing"
+)
+
+// TestMain sets up a dedicated tmux server for the package's integration tests.
+// All tests that call newTestTmux() share this isolated server, which is torn
+// down after all tests complete. This prevents test sessions from appearing on
+// the user's interactive tmux and avoids socket conflicts with other packages.
+func TestMain(m *testing.M) {
+	socket := fmt.Sprintf("gt-test-%d", os.Getpid())
+
+	// Set defaultSocket so NewTmux() connects to the test server, not the
+	// user's personal server or the sentinel that indicates "no town context".
+	SetDefaultSocket(socket)
+
+	code := m.Run()
+
+	// Kill the test tmux server and restore the original socket state.
+	_ = exec.Command("tmux", "-L", socket, "kill-server").Run()
+	SetDefaultSocket("")
+
+	os.Exit(code)
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -103,9 +103,28 @@ type Tmux struct {
 	socketName string // tmux socket name (-L flag), empty = default socket
 }
 
-// NewTmux creates a new Tmux wrapper that inherits the default socket.
+// noTownSocket is a sentinel socket name used when no town socket is configured.
+// Using a non-existent socket causes tmux operations to fail with a clear
+// "no server running" error instead of silently connecting to the wrong server.
+const noTownSocket = "gt-no-town-socket"
+
+// NewTmux creates a new Tmux wrapper using the initialized town socket.
+// Falls back to GT_TOWN_SOCKET env var (set by cross-socket tmux bindings),
+// then to a sentinel socket that fails clearly if neither is available.
 func NewTmux() *Tmux {
-	return &Tmux{socketName: defaultSocket}
+	sock := defaultSocket
+	if sock == "" {
+		// GT_TOWN_SOCKET is embedded in tmux bindings created by EnsureBindingsOnSocket
+		// so that "gt agents menu" / "gt feed" invoked from a personal terminal still
+		// target the correct town server even when InitRegistry was not called.
+		sock = os.Getenv("GT_TOWN_SOCKET")
+	}
+	if sock == "" {
+		// No town context available: use sentinel to produce a clear error rather
+		// than silently connecting to the user's personal tmux server.
+		sock = noTownSocket
+	}
+	return &Tmux{socketName: sock}
 }
 
 // NewTmuxWithSocket creates a Tmux wrapper that targets a named socket.


### PR DESCRIPTION
## Problem

When `InitRegistry` was not called (e.g. `gt agents menu` fired from a personal terminal via a cross-socket tmux binding), `defaultSocket` was empty and `NewTmux()` returned `&Tmux{socketName: ""}`, which connects to whatever tmux server happens to be running — silently targeting the wrong server.

## Fix

`NewTmux()` now falls back through:

1. `defaultSocket` — set by `InitRegistry`, normal path
2. `$GT_TOWN_SOCKET` — embedded in cross-socket bindings by `EnsureBindingsOnSocket` (PR #2099)
3. Sentinel `"gt-no-town-socket"` — causes a clear tmux error (`no server running on …/gt-no-town-socket`) instead of silently targeting the user's personal server

Also adds the missing `testmain_test.go` referenced in a comment in `tmux_test.go`, which gives the package's integration tests a dedicated isolated socket. Fixes two tests in `respawn_hook_test.go` that called `NewTmux()` where they needed `NewTmuxWithSocket(socket)` for their per-test socket.

## Test plan

- [ ] `go build ./...`
- [ ] `go test ./internal/tmux/... -run "TestSetGetDefaultSocket|TestNewTmuxInheritsSocket|TestNewTmuxWithSocket|TestBuildCommand" -v`

🤖 Generated with [Claude Code](https://claude.com/claude-code)