### PR TITLE
fix(patrol): use gt dolt kill-imposters instead of hardcoded port-3307 kill loop

### DIFF
--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -196,20 +196,13 @@ live processes.
 
 **1. Rogue dolt servers**
 
-Any `dolt sql-server` process NOT on port 3307 (the shared server) is a leaked
-test server. Kill and log.
+Any `dolt sql-server` process that holds this workspace's configured port
+(set via `GT_DOLT_PORT`, default 3307) but uses a different data directory
+is an "imposter" — a leaked server from another workspace. Kill and log.
 
 ```bash
-# Find all dolt sql-server processes
-ps aux | grep 'dolt sql-server' | grep -v grep | while read -r line; do
-  PID=$(echo "$line" | awk '{print $2}')
-  # Check if this is the shared server (port 3307)
-  if echo "$line" | grep -q -- '--port 3307'; then
-    continue  # Skip the shared server
-  fi
-  # Kill rogue server
-  kill "$PID" 2>/dev/null && echo "Killed rogue dolt server PID=$PID"
-done
+# Use gt dolt kill-imposters which checks data-dir — safe for multi-workspace setups
+gt dolt kill-imposters 2>/dev/null || true
 ```
 
 **2. Stale test temp dirs**
@@ -283,7 +276,7 @@ Test pollution cleanup: rogue_dolt=N stale_dirs=N stale_pids=N dead_worktrees=N
 If all counts are 0, log "Test pollution cleanup: clean" and move on.
 
 **Safety:**
-- NEVER kill the shared dolt server (port 3307)
+- NEVER kill this workspace's own legitimate dolt server (checked via data-dir)
 - NEVER remove dirs where lsof shows active file handles
 - NEVER remove PID files where the PID is still alive
 - NEVER prune worktrees for dogs with live tmux sessions


### PR DESCRIPTION
## Problem

The Deacon patrol formula (`mol-deacon-patrol.formula.toml`) contained a hardcoded bash snippet that killed every `dolt sql-server` process **not on port 3307**. This assumed 3307 is always the "shared server" — but gastown workspaces configure their Dolt port via `GT_DOLT_PORT` (default 3307). Any workspace running on a different port (e.g. 3308) had its legitimate Dolt server killed every ~30s patrol cycle.

**Impact observed** (test run "The Crypto Tales", 1911s):
- ~60 Dolt server kills during the run
- All `bd` calls failed during outage windows
- ConvoyManager lost close events → convoy never auto-landed (required manual `gt convoy check`)

## Fix

### 1. New CLI command: `gt dolt kill-imposters`

Added to `internal/cmd/dolt.go`. Uses the existing `doltserver.CheckPortConflict()` and `doltserver.KillImposters()` functions which identify imposters by **data directory**, not port number:

- Checks which `dolt sql-server` process holds the workspace's configured port
- If its `--data-dir` differs from this workspace's `.dolt-data/` → it's an imposter → kill it
- Supports `--dry-run` for preview

```
gt dolt kill-imposters          # Kill imposters on configured port
gt dolt kill-imposters --dry-run # Preview without killing
```

### 2. Updated patrol formula

Replaced the 8-line hardcoded bash kill loop with:

```bash
gt dolt kill-imposters 2>/dev/null || true
```

Updated prose to document `GT_DOLT_PORT` (default 3307) as the port source of truth.

## Safety

`KillImposters()` was already written to be data-dir-aware. This PR just exposes it as a CLI command and wires the patrol formula to use it. A workspace's own Dolt server is never touched.

## References

- `internal/doltserver/doltserver.go`: `CheckPortConflict()`, `KillImposters()`
- `internal/formula/formulas/mol-deacon-patrol.formula.toml`: patrol step 1