### PR TITLE
feat(cli): show did-you-mean suggestions for unknown subcommands

### DIFF
--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -251,8 +251,9 @@ Example:
 }
 
 var deaconZombieScanCmd = &cobra.Command{
-	Use:   "zombie-scan",
-	Short: "Find and clean zombie Claude processes not in active tmux sessions",
+	Use:        "zombie-scan",
+	SuggestFor: []string{"orphan-scan", "orphan_scan", "orphan"},
+	Short:      "Find and clean zombie Claude processes not in active tmux sessions",
 	Long: `Find and clean zombie Claude processes not in active tmux sessions.
 
 Unlike cleanup-orphans (which uses TTY detection), zombie-scan uses tmux

--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -216,8 +216,9 @@ Examples:
 }
 
 var rigStatusCmd = &cobra.Command{
-	Use:   "status [rig]",
-	Short: "Show detailed status for a specific rig",
+	Use:        "status [rig]",
+	SuggestFor: []string{"health", "health-check", "healthcheck"},
+	Short:      "Show detailed status for a specific rig",
 	Long: `Show detailed status for a specific rig including all workers.
 
 If no rig is specified, infers the rig from the current directory.

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -308,8 +308,22 @@ func requireSubcommand(cmd *cobra.Command, args []string) error {
 	if len(args) == 0 {
 		return fmt.Errorf("requires a subcommand\n\nRun '%s --help' for usage", buildCommandPath(cmd))
 	}
-	return fmt.Errorf("unknown command %q for %q\n\nRun '%s --help' for available commands",
-		args[0], buildCommandPath(cmd), buildCommandPath(cmd))
+	unknown := args[0]
+	errMsg := fmt.Sprintf("unknown command %q for %q", unknown, buildCommandPath(cmd))
+	// Use cobra's suggestion engine (Levenshtein + SuggestFor lists)
+	if suggestions := cmd.SuggestionsFor(unknown); len(suggestions) > 0 {
+		errMsg += "\n\nDid you mean"
+		if len(suggestions) == 1 {
+			errMsg += " this?\n"
+		} else {
+			errMsg += " one of these?\n"
+		}
+		for _, s := range suggestions {
+			errMsg += fmt.Sprintf("\t%s %s\n", buildCommandPath(cmd), s)
+		}
+	}
+	errMsg += fmt.Sprintf("\nRun '%s --help' for available commands", buildCommandPath(cmd))
+	return fmt.Errorf("%s", errMsg)
 }
 
 // checkHelpFlag checks if --help or -h is the first argument and shows help if so.


### PR DESCRIPTION
## Problem

When an agent or user types an unknown subcommand (e.g. `gt deacon orphan-scan`), gastown returns a bare error with no hints:

```
unknown command "orphan-scan" for "gt deacon"

Run 'gt deacon --help' for available commands
```

This leads to wasted agent turns discovering the correct command name.

## Fix

`requireSubcommand()` now calls cobra's `SuggestionsFor()` (Levenshtein distance + explicit `SuggestFor` lists) and appends matching suggestions to the error message:

```
unknown command "orphan-scan" for "gt deacon"

Did you mean this?
        gt deacon zombie-scan

Run 'gt deacon --help' for available commands
```

### Changes

**`internal/cmd/root.go`** — `requireSubcommand()` enriched with suggestion engine.

**`internal/cmd/deacon.go`** — `SuggestFor` on `zombie-scan`:
```go
SuggestFor: []string{"orphan-scan", "orphan_scan", "orphan"},
```

**`internal/cmd/rig.go`** — `SuggestFor` on `status`:
```go
SuggestFor: []string{"health", "health-check", "healthcheck"},
```

Note: `cobra.EnablePrefixMatching = true` is already set in root, so prefix matches (e.g. `gt deacon zombie`) also work without `SuggestFor`.