### PR TITLE
docs(polecat): clarify that status arg is '<rig>/<polecat>' not two args

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -125,6 +125,9 @@ Displays comprehensive information including:
   - Session creation time
   - Last activity time
 
+NOTE: The argument is <rig>/<polecat> — a single argument with a slash
+separator, NOT two separate arguments. For example: greenplace/Toast
+
 Examples:
   gt polecat status greenplace/Toast
   gt polecat status greenplace/Toast --json`,


### PR DESCRIPTION
## Problem

Agents repeatedly pass rig and polecat name as two separate positional arguments:

```
gt polecat status greenplace Toast   # wrong — fails
gt polecat status greenplace/Toast   # correct
```

The command help didn't make this explicit.

## Fix

Added a NOTE to the `polecat status` Long description:

```
NOTE: The argument is <rig>/<polecat> — a single argument with a slash
separator, NOT two separate arguments. For example: greenplace/Toast
```