### PR TITLE
fix(convoy): add recovery sweep after Dolt reconnect and at daemon startup

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -318,6 +318,17 @@ func (d *Daemon) Run() error {
 		d.logger.Println("Convoy manager started")
 	}
 
+	// Wire a recovery callback so that when Dolt transitions from unhealthy
+	// back to healthy, the convoy manager runs a sweep to catch any convoys
+	// that completed during the outage and were missed by the event poller.
+	if d.doltServer != nil {
+		cm := d.convoyManager
+		d.doltServer.SetRecoveryCallback(func() {
+			d.logger.Printf("Dolt recovery detected: triggering convoy recovery sweep")
+			cm.scan()
+		})
+	}
+
 	// Start KRC pruner for automatic ephemeral data cleanup
 	krcPruner, err := NewKRCPruner(d.config.TownRoot, d.logger.Printf)
 	if err != nil {


### PR DESCRIPTION
## Problem

When the Dolt server is killed mid-run (e.g. by the patrol formula bug fixed in #2110), the ConvoyManager's event poller (`pollStore`) returns errors and drops all close events. Even after Dolt recovers, the stranded-convoy scan runs only every 30s and won't fire a sweep immediately. The result: a convoy that completed during the outage never auto-lands and requires manual `gt convoy check`.

## Fix

Three coordinated changes across `convoy_manager.go`, `dolt.go`, and `daemon.go`.

### 1. Recovery mode — fast retry after Dolt outage (`convoy_manager.go`)

```go
recoveryMode atomic.Bool
```

- Set to `true` when `pollStore()` returns an error (Dolt down)
- While set, `runStrandedScan` resets its ticker to **5s** instead of the normal `scanInterval`
- Cleared after the first successful `scan()` call

### 2. Startup sweep — catch missed convoys on daemon start (`convoy_manager.go`)

```go
func (m *ConvoyManager) runStartupSweep()
```

One-shot goroutine launched in `Start()`. Waits 10s for Dolt to stabilise then calls `scan()` once. Catches convoys that completed while the daemon was stopped.

### 3. Recovery callback — immediate sweep on Dolt reconnect (`dolt.go` + `daemon.go`)

```go
func (m *DoltServerManager) SetRecoveryCallback(fn func())
```

`clearUnhealthySignal()` now detects the unhealthy→healthy transition via `os.Stat()` on the signal file. On transition, fires `onRecoveryFn` in a goroutine. Wired in `daemon.Run()` to call `cm.scan()` immediately when Dolt recovers.

### Recovery flow

```
Dolt killed
  → pollStore() error → recoveryMode=true → strandedScan tick: 5s
  → Dolt restarts → clearUnhealthySignal() → onRecoveryFn() → cm.scan() immediate
  → missed convoy events detected → convoy auto-lands
```

## References

- Issue #04: Convoy does not auto-land when Dolt server is intermittently killed
- PR #2110: fix(patrol) — root cause of Dolt kills