### PR TITLE
fix(peek): support 'gt peek mayor/deacon/boot' for town-level agents

### DIFF
--- a/internal/cmd/peek.go
+++ b/internal/cmd/peek.go
@@ -5,8 +5,10 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/steveyegge/gastown/internal/session"
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/tmux"
+	"github.com/steveyegge/gastown/internal/workspace"
 )
 
 // Peek command flags
@@ -30,15 +32,18 @@ The nudge/peek pair provides the canonical interface for agent sessions:
   gt nudge - send messages TO a session (reliable delivery)
   gt peek  - read output FROM a session (capture-pane wrapper)
 
-Supports both polecats and crew workers:
+Supports polecats, crew workers, and town-level agents:
   - Polecats: rig/name format (e.g., greenplace/furiosa)
   - Crew: rig/crew/name format (e.g., beads/crew/dave)
+  - Town-level: mayor, deacon, boot (or hq/mayor, hq/deacon, hq/boot)
 
 Examples:
   gt peek greenplace/furiosa         # Polecat: last 100 lines (default)
   gt peek greenplace/furiosa 50      # Polecat: last 50 lines
   gt peek beads/crew/dave            # Crew: last 100 lines
-  gt peek beads/crew/dave -n 200     # Crew: last 200 lines`,
+  gt peek beads/crew/dave -n 200     # Crew: last 200 lines
+  gt peek mayor                      # Mayor: last 100 lines
+  gt peek deacon -n 50               # Deacon: last 50 lines`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: runPeek,
 }
@@ -54,6 +59,30 @@ func runPeek(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("invalid line count: %s", args[1])
 		}
 		lines = n
+	}
+
+	// Handle town-level agents: mayor, deacon, boot
+	// These use session names like "hq-mayor", "hq-deacon" but have no rig.
+	townAgentSessions := map[string]string{
+		"mayor":     "hq-mayor",
+		"hq/mayor":  "hq-mayor",
+		"deacon":    "hq-deacon",
+		"hq/deacon": "hq-deacon",
+		"boot":      "hq-boot",
+		"hq/boot":   "hq-boot",
+	}
+	if sessionName, ok := townAgentSessions[address]; ok {
+		_, err := workspace.FindFromCwdOrError()
+		if err != nil {
+			return fmt.Errorf("not in a Gas Town workspace: %w", err)
+		}
+		t := tmux.NewTmux()
+		output, err := t.CapturePane(sessionName, lines)
+		if err != nil {
+			return fmt.Errorf("capturing %s: %w", address, err)
+		}
+		fmt.Print(output)
+		return nil
 	}
 
 	rigName, polecatName, err := parseAddress(address)


### PR DESCRIPTION
## Problem

`gt peek mayor` fails because `parseAddress()` expects a `rig/polecat` format with a slash. Town-level agents (mayor, deacon, boot) have no rig — their tmux sessions are named `hq-mayor`, `hq-deacon`, `hq-boot`.

## Fix

Add a lookup table in `runPeek()` that intercepts town-level agent addresses before `parseAddress()` and calls `tmux.CapturePane()` directly on the `hq-*` session name.

Supported forms:

| Input | Session |
|-------|---------|
| `gt peek mayor` | `hq-mayor` |
| `gt peek hq/mayor` | `hq-mayor` |
| `gt peek deacon` | `hq-deacon` |
| `gt peek hq/deacon` | `hq-deacon` |
| `gt peek boot` | `hq-boot` |
| `gt peek hq/boot` | `hq-boot` |

Help text updated to document town-level agent support and add examples.