### PR TITLE
fix(metrics): emit gastown.polecat.spawns.total on polecat session spawn

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1839,6 +1839,9 @@ func (d *Daemon) restartPolecatSession(rigName, polecatName, sessionName string)
 		return fmt.Errorf("creating session: %w", err)
 	}
 
+	// Record polecat spawn metric.
+	d.metrics.recordPolecatSpawn(d.ctx, rigName)
+
 	// Set environment variables in tmux session table (for debugging/monitoring tools).
 	// The process itself gets env vars via 'exec env ...' in the startup command.
 	for k, v := range envVars {

--- a/internal/daemon/metrics.go
+++ b/internal/daemon/metrics.go
@@ -20,6 +20,9 @@ type daemonMetrics struct {
 	// restartTotal counts agent session restarts, labeled by agent type.
 	restartTotal metric.Int64Counter
 
+	// polecatSpawns counts polecat session spawns, labeled by rig name.
+	polecatSpawns metric.Int64Counter
+
 	// doltMu protects dolt gauge values written by the health check goroutine.
 	doltMu             sync.RWMutex
 	doltConnections    int64
@@ -47,6 +50,13 @@ func newDaemonMetrics() (*daemonMetrics, error) {
 
 	dm.restartTotal, err = m.Int64Counter("gastown.daemon.restart.total",
 		metric.WithDescription("Total number of agent session restarts"),
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	dm.polecatSpawns, err = m.Int64Counter("gastown.polecat.spawns.total",
+		metric.WithDescription("Total number of polecat session spawns"),
 	)
 	if err != nil {
 		return nil, err
@@ -124,6 +134,16 @@ func (dm *daemonMetrics) recordRestart(ctx context.Context, agentType string) {
 	}
 	dm.restartTotal.Add(ctx, 1,
 		metric.WithAttributes(attribute.String("agent.type", agentType)),
+	)
+}
+
+// recordPolecatSpawn increments the polecat spawn counter, labeled with the rig name.
+func (dm *daemonMetrics) recordPolecatSpawn(ctx context.Context, rigName string) {
+	if dm == nil {
+		return
+	}
+	dm.polecatSpawns.Add(ctx, 1,
+		metric.WithAttributes(attribute.String("rig", rigName)),
 	)
 }
 


### PR DESCRIPTION
## Problem

`gastown_polecat_spawns_total` showed `(no data)` in VictoriaMetrics even after polecats were successfully spawned. The counter was defined nowhere on the spawn path — only the daemon's heartbeat loop emitted metrics, not `restartPolecatSession()`.

## Fix

**`internal/daemon/metrics.go`** — new counter:
```go
dm.polecatSpawns, err = m.Int64Counter("gastown.polecat.spawns.total",
    metric.WithDescription("Total number of polecat session spawns"),
)
```

**`internal/daemon/daemon.go`** — increment in `restartPolecatSession()` after the tmux session is created successfully:
```go
d.metrics.recordPolecatSpawn(d.ctx, rigName)
```

`recordPolecatSpawn()` is nil-safe (no-op when daemon runs without OTEL).

**Metric attributes:** `rig=<rigName>`

## Impact

Enables Grafana dashboards for polecat spawn rate, cost-per-polecat analysis, and anomaly detection (no spawns for N minutes despite open issues).