### PR TITLE
fix(ci): Windows test failures from backslash path separators

### DIFF
--- a/internal/cmd/vitals.go
+++ b/internal/cmd/vitals.go
@@ -250,7 +250,7 @@ func vitalsFormatCount(n int) string {
 
 func vitalsShortHome(path string) string {
 	if home, err := os.UserHomeDir(); err == nil && strings.HasPrefix(path, home) {
-		return "~" + path[len(home):]
+		return "~" + filepath.ToSlash(path[len(home):])
 	}
 	return path
 }

--- a/internal/daemon/jsonl_git_backup.go
+++ b/internal/daemon/jsonl_git_backup.go
@@ -455,7 +455,7 @@ func previousCommitLineCount(gitRepo, relPath string) (int, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), gitCmdTimeout)
 	defer cancel()
 
-	cmd := exec.CommandContext(ctx, "git", "-C", gitRepo, "show", "HEAD:"+relPath)
+	cmd := exec.CommandContext(ctx, "git", "-C", gitRepo, "show", "HEAD:"+filepath.ToSlash(relPath))
 	var stdout bytes.Buffer
 	cmd.Stdout = &stdout
 	// stderr intentionally not captured — "does not exist" is an expected case.


### PR DESCRIPTION
## Summary

- **`vitalsShortHome`**: Apply `filepath.ToSlash` so `~\gt\.dolt-backup` becomes `~/gt/.dolt-backup` on Windows
- **`previousCommitLineCount`**: Apply `filepath.ToSlash` to the `relPath` argument in `git show HEAD:<path>`, which requires forward slashes — backslashes caused silent failure, breaking spike detection

## Root Cause

`filepath.Join` produces backslash paths on Windows. Two functions passed these directly where forward slashes are required:
1. `vitalsShortHome` — display output expected `~/...` notation
2. `previousCommitLineCount` — `git show HEAD:path` requires forward slashes; backslashes made the file "not found", returning 0 (treated as first export), so spike detection never triggered

## Fixes

| Test | Failure | Fix |
|------|---------|-----|
| `TestVitalsShortHome` | got `~\gt\.dolt-backup`, want `~/gt/.dolt-backup` | `filepath.ToSlash` on suffix |
| `TestVerifyExportCounts_ExceedsThreshold` | expected 1 spike, got 0 | `filepath.ToSlash` on git ref path |
| `TestVerifyExportCounts_Drop` | expected 1 spike, got 0 | same |

## Context

Follow-up to #2081 — these 3 failures are pre-existing on `main`, not introduced by that PR.

## Test plan

- [x] `TestVitalsShortHome` — PASS
- [x] `TestVerifyExportCounts_ExceedsThreshold` — PASS
- [x] `TestVerifyExportCounts_Drop` — PASS
- [x] `go build ./cmd/gt` — PASS
- [ ] Windows CI — awaiting CI run

🤖 Generated with [Claude Code](https://claude.com/claude-code)