### PR TITLE
fix(tmux): reset window-size after WakePane resize dance

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1120,6 +1120,13 @@ func (t *Tmux) WakePane(target string) {
 	_, _ = t.run("resize-window", "-t", target, "-x", fmt.Sprintf("%d", w+1))
 	time.Sleep(50 * time.Millisecond)
 	_, _ = t.run("resize-window", "-t", target, "-x", width)
+
+	// Reset window-size to "latest" after the resize dance. tmux automatically
+	// sets window-size to "manual" whenever resize-window is called, which
+	// permanently locks the window at the current dimensions. This prevents
+	// the window from auto-sizing to a client when a human later attaches,
+	// causing dots around the edges as if another smaller client is viewing.
+	_, _ = t.run("set-option", "-w", "-t", target, "window-size", "latest")
 }
 
 // WakePaneIfDetached triggers a SIGWINCH only if the session is detached.


### PR DESCRIPTION
## Summary

- `WakePane` uses `resize-window` to trigger SIGWINCH for detached sessions, but tmux automatically sets `window-size manual` as a side effect, permanently locking the window at 80x24
- When a human later attaches via `gt mayor attach` (or any session attach), the window never resizes to their terminal — appearing as if another smaller client is viewing the session (dots around edges)
- Fix: reset `window-size` to `latest` after the resize dance so the window auto-sizes to the attaching client