### PR TITLE
fix: batch fixes — doctor workDir, GUPP threshold, stale comment, mail nudge, UTF-8 truncation

### DIFF
--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -1205,6 +1205,7 @@ func sendHandoffMail(subject, message string) (string, error) {
 	// This prevents subjects like "--help" from being parsed as flags.
 	args := []string{
 		"create",
+		"--id", mail.GenerateID(), // explicit ID: ephemeral path may not read prefix from config
 		"--assignee", agentID,
 		"-d", message,
 		"--priority", "1", // high — handoffs should float above normal mail

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1610,7 +1610,7 @@ func runPolecatPrune(cmd *cobra.Command, args []string) error {
 		fmt.Println("Pruning remote polecat branches...")
 
 		defaultBranch := repoGit.RemoteDefaultBranch()
-		remoteRefs, lsErr := repoGit.ListRemoteRefs("origin", "refs/heads/polecat/")
+		remoteRefs, lsErr := repoGit.ListPushRemoteRefs("origin", "refs/heads/polecat/")
 		if lsErr != nil {
 			return fmt.Errorf("listing remote refs: %w", lsErr)
 		}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -699,6 +699,21 @@ func (g *Git) ListRemoteRefs(remote, prefix string) ([]string, error) {
 	return refs, nil
 }
 
+// ListPushRemoteRefs lists remote refs from the push URL when it differs from
+// the fetch URL. With a fork-based workflow (pushurl configured), branches are
+// pushed to the fork but ls-remote reads from the fetch URL (upstream). This
+// method queries the push URL so cleanup can find branches that were pushed.
+// Falls back to ListRemoteRefs if no custom push URL is configured.
+func (g *Git) ListPushRemoteRefs(remote, prefix string) ([]string, error) {
+	fetchURL, fetchErr := g.RemoteURL(remote)
+	pushURL, pushErr := g.GetPushURL(remote)
+	if fetchErr != nil || pushErr != nil || pushURL == fetchURL {
+		return g.ListRemoteRefs(remote, prefix)
+	}
+	// Query the push URL directly
+	return g.ListRemoteRefs(pushURL, prefix)
+}
+
 // Rebase rebases the current branch onto the given ref.
 func (g *Git) Rebase(onto string) error {
 	_, err := g.run("rebase", onto)

--- a/internal/mail/types.go
+++ b/internal/mail/types.go
@@ -139,7 +139,7 @@ type Message struct {
 // NewMessage creates a new message with a generated ID and thread ID.
 func NewMessage(from, to, subject, body string) *Message {
 	return &Message{
-		ID:        generateID(),
+		ID:        GenerateID(),
 		From:      from,
 		To:        to,
 		Subject:   subject,
@@ -155,7 +155,7 @@ func NewMessage(from, to, subject, body string) *Message {
 // NewReplyMessage creates a reply message that inherits the thread from the original.
 func NewReplyMessage(from, to, subject, body string, original *Message) *Message {
 	return &Message{
-		ID:        generateID(),
+		ID:        GenerateID(),
 		From:      from,
 		To:        to,
 		Subject:   subject,
@@ -173,7 +173,7 @@ func NewReplyMessage(from, to, subject, body string, original *Message) *Message
 // Queue messages have no direct recipient - they are claimed by eligible agents.
 func NewQueueMessage(from, queue, subject, body string) *Message {
 	return &Message{
-		ID:        generateID(),
+		ID:        GenerateID(),
 		From:      from,
 		Queue:     queue,
 		Subject:   subject,
@@ -190,7 +190,7 @@ func NewQueueMessage(from, queue, subject, body string) *Message {
 // Channel messages are visible to all readers of the channel.
 func NewChannelMessage(from, channel, subject, body string) *Message {
 	return &Message{
-		ID:        generateID(),
+		ID:        GenerateID(),
 		From:      from,
 		Channel:   channel,
 		Subject:   subject,
@@ -267,9 +267,11 @@ func (m *Message) Validate() error {
 	return nil
 }
 
-// generateID creates a random message ID.
+// GenerateID creates a random message ID.
 // Falls back to time-based ID if crypto/rand fails (extremely rare).
-func generateID() string {
+// Exported so callers that bypass the mail router (e.g., handoff) can
+// pass an explicit --id to bd create, avoiding the ephemeral empty-ID bug.
+func GenerateID() string {
 	b := make([]byte, 8)
 	if _, err := rand.Read(b); err != nil {
 		// Fallback to time-based ID instead of panicking


### PR DESCRIPTION
## Summary

Batch of fixes from crew (gastown):

- **Fix doctor workDir for HQ database** (existing): Fix `gt doctor --fix` silently failing for misclassified wisps in the HQ database
- **Consolidate GUPP violation threshold** (gt-1emx): Moved 30-minute GUPP threshold to `constants.GUPPViolationThreshold`
- **Fix stale Phase 6 comment** (gt-qzjb): Comment in `down.go` was stale after socket migration
- **Fix-merge PR #2125** (seanbearden): Auto-nudge idle agents on mail delivery
- **Fix-merge PR #2140** (l0g1x): UTF-8 safe title truncation + PrintWarning to stderr

## Test plan

- [x] `go test ./internal/constants/...` — pass
- [x] `go test ./internal/daemon/...` — pass
- [x] `go test ./internal/tui/feed/...` — pass
- [x] `go test ./internal/mail/...` — pass
- [x] `go test ./internal/style/...` — pass
- [x] `go build ./...` — clean

Co-Authored-By: bear <72461227+seanbearden@users.noreply.github.com>
Co-Authored-By: jsonparse <krgebis@gmail.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)