### PR TITLE
fix(lint): resolve all golangci-lint CI failures

### DIFF
--- a/internal/cmd/health.go
+++ b/internal/cmd/health.go
@@ -25,24 +25,24 @@ var (
 
 // HealthReport is the machine-readable output of gt health --json.
 type HealthReport struct {
-	Timestamp string              `json:"timestamp"`
-	Server    *ServerHealth       `json:"server"`
-	Databases []DatabaseHealth    `json:"databases"`
-	Pollution []PollutionRecord   `json:"pollution,omitempty"`
-	Backups   *BackupHealth       `json:"backups"`
-	Processes *ProcessHealth      `json:"processes"`
-	Orphans   []OrphanDB          `json:"orphans,omitempty"`
+	Timestamp string            `json:"timestamp"`
+	Server    *ServerHealth     `json:"server"`
+	Databases []DatabaseHealth  `json:"databases"`
+	Pollution []PollutionRecord `json:"pollution,omitempty"`
+	Backups   *BackupHealth     `json:"backups"`
+	Processes *ProcessHealth    `json:"processes"`
+	Orphans   []OrphanDB        `json:"orphans,omitempty"`
 }
 
 type ServerHealth struct {
-	Running        bool          `json:"running"`
-	PID            int           `json:"pid,omitempty"`
-	Port           int           `json:"port,omitempty"`
-	LatencyMs      int64         `json:"latency_ms,omitempty"`
-	Connections    int           `json:"connections,omitempty"`
-	MaxConnections int           `json:"max_connections,omitempty"`
-	DiskUsageBytes int64         `json:"disk_usage_bytes,omitempty"`
-	DiskUsageHuman string        `json:"disk_usage_human,omitempty"`
+	Running        bool   `json:"running"`
+	PID            int    `json:"pid,omitempty"`
+	Port           int    `json:"port,omitempty"`
+	LatencyMs      int64  `json:"latency_ms,omitempty"`
+	Connections    int    `json:"connections,omitempty"`
+	MaxConnections int    `json:"max_connections,omitempty"`
+	DiskUsageBytes int64  `json:"disk_usage_bytes,omitempty"`
+	DiskUsageHuman string `json:"disk_usage_human,omitempty"`
 }
 
 type DatabaseHealth struct {
@@ -62,12 +62,12 @@ type PollutionRecord struct {
 }
 
 type BackupHealth struct {
-	DoltFreshness  string `json:"dolt_freshness,omitempty"`
-	DoltAgeSeconds int    `json:"dolt_age_seconds,omitempty"`
-	DoltStale      bool   `json:"dolt_stale"`
-	JSONLFreshness string `json:"jsonl_freshness,omitempty"`
-	JSONLAgeSeconds int   `json:"jsonl_age_seconds,omitempty"`
-	JSONLStale     bool   `json:"jsonl_stale"`
+	DoltFreshness   string `json:"dolt_freshness,omitempty"`
+	DoltAgeSeconds  int    `json:"dolt_age_seconds,omitempty"`
+	DoltStale       bool   `json:"dolt_stale"`
+	JSONLFreshness  string `json:"jsonl_freshness,omitempty"`
+	JSONLAgeSeconds int    `json:"jsonl_age_seconds,omitempty"`
+	JSONLStale      bool   `json:"jsonl_stale"`
 }
 
 type ProcessHealth struct {
@@ -117,12 +117,12 @@ func runHealth(cmd *cobra.Command, args []string) error {
 
 	// 2. Databases (only if server is running)
 	if report.Server.Running {
-		report.Databases = checkDatabaseHealth(townRoot, report.Server.Port)
+		report.Databases = checkDatabaseHealth(report.Server.Port)
 	}
 
 	// 3. Pollution scan
 	if report.Server.Running {
-		report.Pollution = checkPollution(townRoot, report.Server.Port)
+		report.Pollution = checkPollution(report.Server.Port)
 	}
 
 	// 4. Backups
@@ -171,7 +171,7 @@ func checkServerHealth(townRoot string) *ServerHealth {
 	return sh
 }
 
-func checkDatabaseHealth(townRoot string, port int) []DatabaseHealth {
+func checkDatabaseHealth(port int) []DatabaseHealth {
 	productionDBs := []string{"hq", "beads", "gastown"}
 	var results []DatabaseHealth
 
@@ -207,7 +207,7 @@ func checkDatabaseHealth(townRoot string, port int) []DatabaseHealth {
 	return results
 }
 
-func checkPollution(townRoot string, port int) []PollutionRecord {
+func checkPollution(port int) []PollutionRecord {
 	productionDBs := []string{"hq", "beads", "gastown"}
 	var records []PollutionRecord
 

--- a/internal/daemon/compactor_dog.go
+++ b/internal/daemon/compactor_dog.go
@@ -132,7 +132,7 @@ func (d *Daemon) compactorCountCommits(dbName string) (int, error) {
 	defer db.Close()
 
 	var count int
-	query := fmt.Sprintf("SELECT COUNT(*) FROM `%s`.dolt_log", dbName)
+	query := fmt.Sprintf("SELECT COUNT(*) FROM `%s`.dolt_log", dbName) //nolint:gosec // G201: dbName is an internal rig name, not user input
 	if err := db.QueryRowContext(ctx, query).Scan(&count); err != nil {
 		return 0, fmt.Errorf("count dolt_log: %w", err)
 	}
@@ -287,7 +287,7 @@ func (d *Daemon) compactorGetHead(db *sql.DB, dbName string) (string, error) {
 	defer cancel()
 
 	var hash string
-	query := fmt.Sprintf("SELECT DOLT_HASHOF('main') FROM `%s`.dual", dbName)
+	query := fmt.Sprintf("SELECT DOLT_HASHOF('main') FROM `%s`.dual", dbName) //nolint:gosec // G201: dbName is an internal rig name, not user input
 	if err := db.QueryRowContext(ctx, query).Scan(&hash); err != nil {
 		// Fallback: try without dual table.
 		query = fmt.Sprintf("SELECT commit_hash FROM `%s`.dolt_log ORDER BY date DESC LIMIT 1", dbName)
@@ -319,7 +319,7 @@ func (d *Daemon) compactorGetRootCommit(db *sql.DB, dbName string) (string, erro
 	defer cancel()
 
 	var hash string
-	query := fmt.Sprintf("SELECT commit_hash FROM `%s`.dolt_log ORDER BY date ASC LIMIT 1", dbName)
+	query := fmt.Sprintf("SELECT commit_hash FROM `%s`.dolt_log ORDER BY date ASC LIMIT 1", dbName) //nolint:gosec // G201: dbName is an internal rig name, not user input
 	if err := db.QueryRowContext(ctx, query).Scan(&hash); err != nil {
 		return "", err
 	}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2564,7 +2564,7 @@ func (t *Tmux) SetTownCycleBindings(session string) error {
 // Used to skip redundant re-binding on repeated ConfigureGasTownSession /
 // EnsureBindingsOnSocket calls, preserving the user's original fallback.
 //
-// Two forms are recognised:
+// Two forms are recognized:
 //  1. Guarded form (set by SetAgentsBinding/SetFeedBinding): uses if-shell
 //     with a "gt " command — detects both old and new guarded bindings.
 //  2. Unguarded form (set by EnsureBindingsOnSocket): direct run-shell

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1016,7 +1016,7 @@ func DetectZombiePolecats(workDir, rigName string, router *mail.Router) *DetectZ
 		doneIntent := extractDoneIntent(labels)
 
 		if sessionAlive {
-			if zombie, found := detectZombieLiveSession(workDir, rigName, polecatName, agentBeadID, sessionName, t, doneIntent, router); found {
+			if zombie, found := detectZombieLiveSession(workDir, rigName, polecatName, agentBeadID, sessionName, t, doneIntent); found {
 				result.Zombies = append(result.Zombies, zombie)
 			}
 
@@ -1102,7 +1102,7 @@ func DetectZombiePolecats(workDir, rigName string, router *mail.Router) *DetectZ
 //
 // gt-dsgp: Uses restart-first policy. Instead of nuking polecats, restarts their
 // sessions to preserve worktrees and branches.
-func detectZombieLiveSession(workDir, rigName, polecatName, agentBeadID, sessionName string, t *tmux.Tmux, doneIntent *DoneIntent, router *mail.Router) (ZombieResult, bool) {
+func detectZombieLiveSession(workDir, rigName, polecatName, agentBeadID, sessionName string, t *tmux.Tmux, doneIntent *DoneIntent) (ZombieResult, bool) {
 	// Check for done-intent stuck too long (polecat hung in gt done).
 	// gt-dsgp: Restart instead of nuke — the session is stuck trying to exit,
 	// a fresh start will let it retry or pick up its hook cleanly.
@@ -1497,11 +1497,12 @@ func getBeadStatus(workDir, beadID string) string {
 
 // resetAbandonedBead resets a dead polecat's hooked bead so it can be re-dispatched.
 // If the bead is in "hooked" or "in_progress" status, it:
-// 1. Records the respawn in the witness spawn-count ledger
-// 2. Resets status to open
-// 3. Clears assignee
-// 4. Sends mail to deacon for re-dispatch (includes respawn count; SPAWN_STORM
-//    prefix and Urgent priority when count exceeds defaultMaxBeadRespawns)
+//  1. Records the respawn in the witness spawn-count ledger
+//  2. Resets status to open
+//  3. Clears assignee
+//  4. Sends mail to deacon for re-dispatch (includes respawn count; SPAWN_STORM
+//     prefix and Urgent priority when count exceeds defaultMaxBeadRespawns)
+//
 // Returns true if the bead was recovered.
 func resetAbandonedBead(workDir, rigName, hookBead, polecatName string, router *mail.Router) bool {
 	if hookBead == "" {


### PR DESCRIPTION
## Summary

Fixes all 7 golangci-lint errors currently failing CI on main:

- **gosec G201** (compactor_dog.go, 3 issues): Suppress with `//nolint:gosec` — database names are internal rig identifiers interpolated into Dolt system table queries (SQL doesn't support parameterized schema identifiers). Same pattern already used in `wisp_reaper.go`.
- **misspell** (tmux.go): `recognised` -> `recognized` in a comment.
- **unparam** (health.go, 2 issues): Remove unused `townRoot` parameter from `checkDatabaseHealth` and `checkPollution` — never used since file creation in `38f3e974`, both functions hardcode their database list.
- **unparam** (handlers.go): Remove unused `router` parameter from `detectZombieLiveSession` — the `gt-dsgp` refactor (`016381ad`) replaced `NukePolecat`+`resetAbandonedBead` (which needed `router`) with `RestartPolecatSession` (which doesn't send mail), but forgot to remove the parameter.