### PR TITLE
fix(patrol): remove --root-only flag dropped from bd mol wisp create

### DIFF
--- a/internal/cmd/patrol_helpers.go
+++ b/internal/cmd/patrol_helpers.go
@@ -177,8 +177,8 @@ func autoSpawnPatrol(cfg PatrolConfig) (string, error) {
 		return "", fmt.Errorf("proto %s not found in catalog", cfg.PatrolMolName)
 	}
 
-	// Create the patrol wisp (root-only: no child step wisps, steps inlined at prime time)
-	spawnArgs := []string{"mol", "wisp", "create", protoID, "--actor", cfg.RoleName, "--root-only"}
+	// Create the patrol wisp with all step children materialized
+	spawnArgs := []string{"mol", "wisp", "create", protoID, "--actor", cfg.RoleName}
 	for _, v := range cfg.ExtraVars {
 		spawnArgs = append(spawnArgs, "--var", v)
 	}


### PR DESCRIPTION
## Summary

- `bd mol wisp create` no longer supports the `--root-only` flag (removed in recent beads updates)
- `autoSpawnPatrol` in `patrol_helpers.go` still passes `--root-only`, causing patrol wisp creation to fail
- Removes the flag so patrol cycles work correctly with current `bd`

## Details

The `--root-only` flag was used to create patrol wisps without child step wisps (steps were inlined at prime time). The beads CLI dropped this flag — `bd mol wisp create --help` no longer lists it, and passing it causes an error.

This one-line fix removes the flag from the `spawnArgs` slice in `autoSpawnPatrol()`.