### PR TITLE
fix(test): pre-kill stale tmux session in flaky nudge test

### DIFF
--- a/internal/polecat/session_manager_test.go
+++ b/internal/polecat/session_manager_test.go
@@ -437,6 +437,9 @@ func TestVerifyStartupNudgeDelivery_IdleAgent(t *testing.T) {
 	tm := tmux.NewTmux()
 	sessionName := "gt-test-nudge-verify-" + t.Name()
 
+	// Clean up any stale session from a previous crashed test run
+	_ = tm.KillSession(sessionName)
+
 	// Create a tmux session with a shell
 	if err := tm.NewSession(sessionName, os.TempDir()); err != nil {
 		t.Fatalf("NewSession: %v", err)


### PR DESCRIPTION
## Summary
- Pre-kill any leftover tmux session before creating a new one in `TestVerifyStartupNudgeDelivery_IdleAgent`, preventing "session already exists" failures when a prior test run crashed before cleanup ran.

## Test plan
- [x] Test passes 3/3 with `-count=3`
- [x] `go vet` clean

Fixes gt-eo8d

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>