### PR TITLE
fix(convoy): add recovery sweep after Dolt reconnect (fix-merge of #2114)

### DIFF
--- a/internal/daemon/convoy_manager.go
+++ b/internal/daemon/convoy_manager.go
@@ -67,6 +67,16 @@ type ConvoyManager struct {
 	// started guards against double-call of Start() which would spawn duplicate goroutines.
 	started atomic.Bool
 
+	// recoveryMode is set true when an event-poll failure is detected (indicating
+	// Dolt is down). While set, runStrandedScan uses a shorter 5s interval so it
+	// retries quickly once Dolt comes back. Cleared after the first successful scan.
+	recoveryMode atomic.Bool
+
+	// scanMu serializes calls to scan() from runStrandedScan, runStartupSweep,
+	// and the Dolt recovery callback. Without this, concurrent scans can spawn
+	// duplicate convoy checks for the same stranded convoy.
+	scanMu sync.Mutex
+
 	// lastEventIDs tracks per-store high-water marks for event polling.
 	// Key matches stores map keys ("hq", "gastown", etc.).
 	lastEventIDs sync.Map // map[string]int64
@@ -122,6 +132,9 @@ func (m *ConvoyManager) Start() error {
 	m.wg.Add(2)
 	go m.runEventPoll()
 	go m.runStrandedScan()
+	// Run a one-shot sweep to catch convoys that completed during any previous
+	// outage or while the daemon was stopped.
+	go m.runStartupSweep()
 	return nil
 }
 
@@ -223,6 +236,9 @@ func (m *ConvoyManager) pollStore(name string, store beadsdk.Storage, stores map
 	events, err := store.GetAllEventsSince(m.ctx, highWater)
 	if err != nil {
 		m.logger("Convoy: event poll error (%s): %v", name, err)
+		// Signal recovery mode so the stranded scan shortens its interval and
+		// retries quickly once Dolt comes back.
+		m.recoveryMode.Store(true)
 		return
 	}
 
@@ -284,6 +300,9 @@ func (m *ConvoyManager) pollStore(name string, store beadsdk.Storage, stores map
 }
 
 // runStrandedScan is the periodic stranded convoy scan loop.
+// During recovery mode (after Dolt poll errors) the interval shrinks to 5s
+// so a successful scan fires promptly once Dolt comes back. Recovery mode is
+// cleared after the first successful scan.
 func (m *ConvoyManager) runStrandedScan() {
 	defer m.wg.Done()
 
@@ -298,18 +317,31 @@ func (m *ConvoyManager) runStrandedScan() {
 		case <-m.ctx.Done():
 			return
 		case <-ticker.C:
+			// While in recovery mode, shorten the next tick so we retry quickly
+			// after a Dolt outage without waiting the full scan interval.
+			if m.recoveryMode.Load() {
+				ticker.Reset(5 * time.Second)
+			} else {
+				ticker.Reset(m.scanInterval)
+			}
 			m.scan()
 		}
 	}
 }
 
 // scan runs one stranded scan cycle: find stranded convoys, feed or close each.
+// Serialized by scanMu to prevent concurrent scans from spawning duplicate checks.
 func (m *ConvoyManager) scan() {
+	m.scanMu.Lock()
+	defer m.scanMu.Unlock()
+
 	stranded, err := m.findStranded()
 	if err != nil {
 		m.logger("Convoy: stranded scan failed: %s", util.FirstLine(err.Error()))
 		return
 	}
+	// Successful scan: clear recovery mode so the ticker returns to normal interval.
+	m.recoveryMode.Store(false)
 
 	for _, c := range stranded {
 		select {
@@ -406,4 +438,21 @@ func (m *ConvoyManager) closeEmptyConvoy(convoyID string) {
 	if err := cmd.Run(); err != nil {
 		m.logger("Convoy %s: check failed: %s", convoyID, util.FirstLine(stderr.String()))
 	}
+}
+
+// runStartupSweep runs one convoy check pass after a brief delay to catch
+// convoys that completed while the daemon was stopped or Dolt was unavailable.
+// It waits 10 seconds so Dolt has time to stabilise before the first query.
+// This goroutine is not tracked in wg because it is short-lived (exits after
+// a single scan) and does not need to participate in the Stop() shutdown.
+func (m *ConvoyManager) runStartupSweep() {
+	timer := time.NewTimer(10 * time.Second)
+	defer timer.Stop()
+	select {
+	case <-m.ctx.Done():
+		return
+	case <-timer.C:
+	}
+	m.logger("Convoy: running startup sweep for stranded convoys")
+	m.scan()
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -341,6 +341,17 @@ func (d *Daemon) Run() error {
 		d.logger.Println("Convoy manager started")
 	}
 
+	// Wire a recovery callback so that when Dolt transitions from unhealthy
+	// back to healthy, the convoy manager runs a sweep to catch any convoys
+	// that completed during the outage and were missed by the event poller.
+	if d.doltServer != nil {
+		cm := d.convoyManager
+		d.doltServer.SetRecoveryCallback(func() {
+			d.logger.Printf("Dolt recovery detected: triggering convoy recovery sweep")
+			cm.scan()
+		})
+	}
+
 	// Start KRC pruner for automatic ephemeral data cleanup
 	krcPruner, err := NewKRCPruner(d.config.TownRoot, d.logger.Printf)
 	if err != nil {

--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -135,6 +135,12 @@ type DoltServerManager struct {
 	// Populated by checkHealthLocked(), consumed by Daemon.ensureDoltServerRunning().
 	lastWarnings []string // Warnings from the most recent health check
 
+	// onRecoveryFn is called (in a goroutine) when the Dolt server transitions
+	// from unhealthy back to healthy, i.e., when the DOLT_UNHEALTHY signal file
+	// is cleared after having been present. Set by SetRecoveryCallback.
+	// Protected by mu.
+	onRecoveryFn func()
+
 	// Test hooks (nil = use real implementations; set only in tests)
 	healthCheckFn      func() error
 	writeProbeCheckFn  func() error
@@ -161,6 +167,15 @@ func NewDoltServerManager(townRoot string, config *DoltServerConfig, logger func
 		townRoot: townRoot,
 		logger:   logger,
 	}
+}
+
+// SetRecoveryCallback registers fn to be called (in a goroutine) whenever Dolt
+// transitions from unhealthy back to healthy. Only the most recently registered
+// callback is used. Pass nil to clear the callback.
+func (m *DoltServerManager) SetRecoveryCallback(fn func()) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.onRecoveryFn = fn
 }
 
 func (m *DoltServerManager) now() time.Time {
@@ -726,8 +741,18 @@ func (m *DoltServerManager) writeUnhealthySignal(reason, detail string) {
 }
 
 // clearUnhealthySignal removes the DOLT_UNHEALTHY signal file when the server is healthy.
+// If the signal file was present (meaning Dolt was previously unhealthy), it fires the
+// onRecoveryFn callback in a goroutine to trigger a convoy recovery sweep.
+// Must be called with mu held (onRecoveryFn is protected by mu).
 func (m *DoltServerManager) clearUnhealthySignal() {
-	_ = os.Remove(m.unhealthySignalFile())
+	signalFile := m.unhealthySignalFile()
+	_, wasUnhealthy := os.Stat(signalFile)
+	_ = os.Remove(signalFile)
+	// Transition detected: was unhealthy, now healthy — fire recovery callback.
+	if wasUnhealthy == nil && m.onRecoveryFn != nil {
+		fn := m.onRecoveryFn
+		go fn()
+	}
 }
 
 // IsDoltUnhealthy checks if the DOLT_UNHEALTHY signal file exists.


### PR DESCRIPTION
## Summary
Fix-merge of PR #2114 by @pae23 with the following review fixes:

- **Race condition fixed**: Added `scanMu` mutex to serialize concurrent `scan()` calls from `runStrandedScan`, `runStartupSweep`, and the Dolt recovery callback — prevents duplicate convoy checks for the same stranded convoy
- **Callback read protected**: `onRecoveryFn` is read within `mu.Lock()` in `clearUnhealthySignal()`, matching the lock in `SetRecoveryCallback()`
- **Tests added**: 7 new tests covering recovery mode flag, concurrent scan serialization, startup sweep cancellation, and Dolt recovery callback (fire/no-fire/nil-safe)

### Original PR changes (from @pae23):
1. Recovery mode — fast retry (5s) after Dolt outage instead of 30s scan interval
2. Startup sweep — one-shot scan 10s after daemon start to catch missed convoys  
3. Recovery callback — immediate scan when Dolt transitions unhealthy→healthy

Closes #2114

## Test plan
- [x] `TestRecoveryMode_SetOnPollError` — flag set/clear behavior
- [x] `TestRecoveryMode_ClearedAfterSuccessfulScan` — successful scan clears recovery
- [x] `TestScanMu_PreventsConcurrentScans` — concurrent scans don't panic (with -race)
- [x] `TestStartupSweep_RunsAfterDelay` — respects context cancellation
- [x] `TestDoltRecoveryCallback_Fires` — fires on unhealthy→healthy transition
- [x] `TestDoltRecoveryCallback_NoFireWhenAlreadyHealthy` — no false positive
- [x] `TestDoltRecoveryCallback_NilSafe` — no panic without callback

🤖 Generated with [Claude Code](https://claude.com/claude-code)