### PR TITLE
fix(doctor): repair beads redirect targets with missing config.yaml (fix-merge of #2134)

### DIFF
--- a/internal/doctor/beads_redirect_target_check.go
+++ b/internal/doctor/beads_redirect_target_check.go
@@ -2,6 +2,7 @@ package doctor
 
 import (
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
@@ -173,10 +174,10 @@ func (c *BeadsRedirectTargetCheck) Fix(ctx *CheckContext) error {
 		// written (e.g., due to a crash or interrupted setup).
 		if strings.Contains(bt.reason, "no beads setup") && dirExists(bt.resolvedPath) {
 			rigName := extractRigName(ctx.TownRoot, bt.worktreePath)
-			if err := beads.EnsureConfigYAMLFromMetadataIfMissing(bt.resolvedPath, rigName); err == nil {
-				if hasBeadsSetup(bt.resolvedPath) {
-					continue // Fixed — config.yaml created successfully
-				}
+			if err := beads.EnsureConfigYAMLFromMetadataIfMissing(bt.resolvedPath, rigName); err != nil {
+				log.Printf("[doctor] beads-redirect-target: could not create config.yaml from metadata in %s: %v", bt.resolvedPath, err)
+			} else if hasBeadsSetup(bt.resolvedPath) {
+				continue // Fixed — config.yaml created successfully
 			}
 		}
 


### PR DESCRIPTION
## Summary
Fix-merge of PR #2134 by @l0g1x. Cherry-picked both commits as-is — tests were added in the second commit per review request.

- `gt doctor --fix` now repairs broken beads redirect targets where `.beads` directory has `metadata.json` but is missing `config.yaml` (partial `gt rig add`)
- Uses `beads.EnsureConfigYAMLFromMetadataIfMissing` to derive prefix and sync mode from metadata before falling back to redirect recomputation
- `extractRigName` helper derives rig name from first path component relative to town root

Closes #2134

## Test plan
- [x] `TestExtractRigName` — table-driven: normal/single/nested/edge paths
- [x] `TestBeadsRedirectTargetCheck_FixWithMissingConfigYaml` — metadata.json + no config.yaml → fix creates config
- [x] `TestBeadsRedirectTargetCheck_FixMetadataRepairFails` — read-only dir → graceful fallback
- [x] All existing doctor tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)