### PR TITLE
fix: make hung session threshold config-driven (gt-ohqi)

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -357,6 +357,12 @@ type RigSettings struct {
 	// Overrides TownSettings.RoleAgents for this specific rig.
 	// Example: {"witness": "claude-haiku", "polecat": "claude-sonnet"}
 	RoleAgents map[string]string `json:"role_agents,omitempty"`
+
+	// HungSessionThresholdMinutes is the number of minutes of tmux inactivity
+	// after which a live agent session is considered hung. The witness uses this
+	// to detect agents that are alive but have stopped producing output.
+	// Default: 30 (from witness.DefaultHungSessionThresholdMinutes).
+	HungSessionThresholdMinutes int `json:"hung_session_threshold_minutes,omitempty"`
 }
 
 // CrewConfig represents crew workspace settings for a rig.


### PR DESCRIPTION
## Summary
- Moves hardcoded `HungSessionThresholdMinutes=30` constant to `RigSettings.HungSessionThresholdMinutes`
- Witness loads threshold from rig config at patrol time, falls back to `DefaultHungSessionThresholdMinutes` (30)
- Allows per-rig tuning for rigs where agents legitimately have longer silent periods

## Usage
In rig `settings/config.json`:
```json
{
  "hung_session_threshold_minutes": 45
}
```

## Test plan
- [x] `go build ./...` clean
- [x] `go vet` clean
- [ ] Tests needed for config resolution (WIP — tests forthcoming)

Fixes gt-ohqi

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>