### PR TITLE
fix(convoy): route stranded scan warnings to stderr (#2142)

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -1269,7 +1269,9 @@ func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
 	for _, convoy := range convoys {
 		tracked, err := getTrackedIssues(townBeads, convoy.ID)
 		if err != nil {
-			style.PrintWarning("skipping convoy %s: %v", convoy.ID, err)
+			// Write to stderr explicitly — stdout may be consumed as JSON
+			// by the daemon's JSON parser (fixes #2142).
+			fmt.Fprintf(os.Stderr, "⚠ Warning: skipping convoy %s: %v\n", convoy.ID, err)
 			continue
 		}
 		// Empty convoys (0 tracked issues) are stranded — they need

--- a/internal/daemon/convoy_manager.go
+++ b/internal/daemon/convoy_manager.go
@@ -341,7 +341,9 @@ func (m *ConvoyManager) findStranded() ([]strandedConvoyInfo, error) {
 
 	var stranded []strandedConvoyInfo
 	if err := json.Unmarshal(stdout.Bytes(), &stranded); err != nil {
-		return nil, fmt.Errorf("parsing stranded JSON: %w", err)
+		// Include first line of raw output for debugging (e.g., non-JSON warnings on stdout)
+		raw := util.FirstLine(stdout.String())
+		return nil, fmt.Errorf("parsing stranded JSON: %w (raw: %q)", err, raw)
 	}
 
 	return stranded, nil


### PR DESCRIPTION
## Summary
- `findStrandedConvoys()` used `style.PrintWarning()` which wrote to stdout, contaminating JSON output when `--json` flag was set
- Daemon's JSON parser failed on the warning text (U+26A0 prefix before the JSON array)
- Fix: use `fmt.Fprintf(os.Stderr, ...)` directly, ensuring stdout contains only valid JSON
- Also improve daemon error message to include raw stdout snippet for debugging

## Impact
System-wide: convoy auto-spawning was broken whenever a ghost convoy wisp existed. Daemon restart didn't help (data issue, not process state).

## Test plan
- [ ] `gt convoy stranded --json` with a ghost convoy wisp outputs clean JSON to stdout
- [ ] Warnings appear on stderr, not stdout
- [ ] Daemon successfully parses stranded JSON output

Closes #2142

🤖 Generated with [Claude Code](https://claude.com/claude-code)