### PR TITLE
fix: doctor --fix silent failure for agent-beads and misclassified-wisps

### DIFF
--- a/internal/doctor/misclassified_wisp_check.go
+++ b/internal/doctor/misclassified_wisp_check.go
@@ -398,7 +398,9 @@ func (c *CheckMisclassifiedWisps) Fix(ctx *CheckContext) error {
 
 	for rigName, batch := range rigBatches {
 		var workDir string
-		if rigName == "town" {
+		if rigName == "town" || rigName == "hq" {
+			// Both "town" (JSONL path) and "hq" (Dolt path) refer to
+			// town-level beads which live at the town root, not townRoot/hq.
 			workDir = ctx.TownRoot
 		} else {
 			workDir = filepath.Join(ctx.TownRoot, rigName)


### PR DESCRIPTION
## Summary

Fixes two root causes of `gt doctor --fix` silently failing (#2127):

- **agent-beads-exist**: `bd.Update()` exits 0 but does nothing for beads with legacy/unroutable prefixes (e.g. `gt-estate_spotter-refinery`). Fix adds post-update verification and falls back to direct SQL `INSERT IGNORE INTO labels` when `bd update` is a no-op.
- **misclassified-wisps**: `Fix()` mapped "hq" rigName to `townRoot/hq` but hq database lives at `townRoot`. `Run()` already had the correct mapping (line 69-70) but `Fix()` only checked for "town". Added "hq" to the same mapping.

## Test plan

- [x] All existing doctor tests pass (full suite)
- [x] `go build ./...` clean
- [x] `go vet ./internal/doctor/` clean
- [x] Added regression test `TestFixWorkDir_HQ` for hq workDir mapping
- [ ] Manual: run `gt doctor --fix` on a town with legacy-prefix beads missing `gt:agent` label — label should now be added via SQL fallback

Fixes #2127

🤖 Generated with [Claude Code](https://claude.com/claude-code)