### PR TITLE
fix(test): skip bash-dependent daemon tests on Windows

### DIFF
--- a/internal/daemon/boot_spawn_frequency_test.go
+++ b/internal/daemon/boot_spawn_frequency_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -59,6 +60,9 @@ exit 0
 // Regression test for gt-1z0:
 // daemon should not spawn a fresh Boot session every heartbeat when triage was just run.
 func TestEnsureBootRunning_DoesNotSpawnEveryTick(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on Windows — fake tmux requires bash")
+	}
 	townRoot := t.TempDir()
 	fakeBinDir := t.TempDir()
 	tmuxLog := filepath.Join(t.TempDir(), "tmux.log")

--- a/internal/daemon/deacon_crashloop_guard_test.go
+++ b/internal/daemon/deacon_crashloop_guard_test.go
@@ -5,6 +5,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -55,6 +56,9 @@ exit 0
 // Regression test for gt-d61:
 // even when Deacon is in crash-loop state, stale-heartbeat fallback still kills session.
 func TestCheckDeaconHeartbeat_RespectsCrashLoopGuard(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on Windows — fake tmux requires bash")
+	}
 	townRoot := t.TempDir()
 	fakeBinDir := t.TempDir()
 	tmuxLog := filepath.Join(t.TempDir(), "tmux.log")


### PR DESCRIPTION
## Summary
- Skip `TestEnsureBootRunning_DoesNotSpawnEveryTick` and `TestCheckDeaconHeartbeat_RespectsCrashLoopGuard` on Windows
- Both tests create fake tmux bash scripts that can't execute on Windows (no bash interpreter)
- Adds `runtime.GOOS == "windows"` skip guards

Fixes gt-94i9. The original bead title mentioned SIGUSR2 undefined, but that was already fixed via `signals_unix.go`/`signals_windows.go` split. The remaining Windows CI failure was these bash-dependent tests.

## Test plan
- [x] Both tests pass on macOS/Linux (`go test ./internal/daemon/ -run "TestEnsureBootRunning|TestCheckDeaconHeartbeat"`)
- [x] Full daemon test suite passes (`go test ./internal/daemon/ -short`)
- [x] Windows cross-compilation succeeds (`GOOS=windows GOARCH=amd64 go build ./...`)
- [x] Windows test compilation succeeds (`GOOS=windows GOARCH=amd64 go test -c ./internal/daemon/`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)