### PR TITLE
fix(witness): replace hardcoded zombie state classification with typed constants (ZFC)

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -33,6 +33,30 @@ func (b *Beads) lockAgentBead(id string) (*flock.Flock, error) {
 	return fl, nil
 }
 
+// Agent state constants. These are the known values for AgentFields.AgentState.
+const (
+	AgentStateSpawning  = "spawning"
+	AgentStateWorking   = "working"
+	AgentStateRunning   = "running"
+	AgentStateDone      = "done"
+	AgentStateStuck     = "stuck"
+	AgentStateEscalated = "escalated"
+	AgentStateIdle      = "idle"
+	AgentStateNuked     = "nuked"
+)
+
+// IsActiveAgentState returns true if the given agent state indicates the agent
+// was actively working. Used by zombie detection to distinguish stale (was doing
+// work) from orphan (no evidence of recent work) zombies.
+func IsActiveAgentState(state string) bool {
+	switch state {
+	case AgentStateWorking, AgentStateRunning, AgentStateSpawning:
+		return true
+	default:
+		return false
+	}
+}
+
 // AgentFields holds structured fields for agent beads.
 // These are stored as "key: value" lines in the description.
 type AgentFields struct {

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -957,6 +957,7 @@ type ZombieResult struct {
 	PolecatName   string
 	AgentState    string
 	HookBead      string
+	WasActive     bool   // true if evidence of recent work (active state or hooked bead)
 	Action        string // "restarted", "escalated", "cleanup-wisp-created", "auto-nuked" (explicit nuke only)
 	BeadRecovered bool   // true if hooked bead was reset to open for re-dispatch
 	Error         error
@@ -1056,6 +1057,7 @@ func DetectZombiePolecats(workDir, rigName string, router *mail.Router) *DetectZ
 					PolecatName: polecatName,
 					AgentState:  "agent-dead-in-session",
 					HookBead:    deadAgentHookBead,
+					WasActive:   true,
 					Action:      "restarted-agent-dead-session",
 				}
 				// gt-dsgp: Restart instead of nuke — preserve worktree and branch
@@ -1076,6 +1078,7 @@ func DetectZombiePolecats(workDir, rigName string, router *mail.Router) *DetectZ
 						PolecatName: polecatName,
 						AgentState:  "bead-closed-still-running",
 						HookBead:    hookBead,
+						WasActive:   true,
 						Action:      "restarted-bead-closed-polecat",
 					}
 					if err := RestartPolecatSession(workDir, rigName, polecatName); err != nil {
@@ -1098,6 +1101,7 @@ func DetectZombiePolecats(workDir, rigName string, router *mail.Router) *DetectZ
 								PolecatName: polecatName,
 								AgentState:  "agent-hung",
 								HookBead:    hungHookBead,
+								WasActive:   true,
 								Action:      fmt.Sprintf("restarted-hung-session (inactive %dm)", inactiveMinutes),
 							}
 							if err := RestartPolecatSession(workDir, rigName, polecatName); err != nil {
@@ -1135,6 +1139,7 @@ func detectZombieLiveSession(workDir, rigName, polecatName, agentBeadID, session
 			PolecatName: polecatName,
 			AgentState:  "stuck-in-done",
 			HookBead:    stuckHookBead,
+			WasActive:   true,
 			Action:      fmt.Sprintf("restarted-stuck-session (done-intent age=%v)", time.Since(doneIntent.Timestamp).Round(time.Second)),
 		}
 		if err := RestartPolecatSession(workDir, rigName, polecatName); err != nil {
@@ -1152,6 +1157,7 @@ func detectZombieLiveSession(workDir, rigName, polecatName, agentBeadID, session
 			PolecatName: polecatName,
 			AgentState:  "agent-dead-in-session",
 			HookBead:    deadAgentHookBead,
+			WasActive:   true,
 			Action:      "restarted-agent-dead-session",
 		}
 		if err := RestartPolecatSession(workDir, rigName, polecatName); err != nil {
@@ -1170,6 +1176,7 @@ func detectZombieLiveSession(workDir, rigName, polecatName, agentBeadID, session
 			PolecatName: polecatName,
 			AgentState:  "bead-closed-still-running",
 			HookBead:    hookBead,
+			WasActive:   true,
 			Action:      "restarted-bead-closed-polecat",
 		}
 		if err := RestartPolecatSession(workDir, rigName, polecatName); err != nil {
@@ -1219,6 +1226,7 @@ func detectZombieDeadSession(workDir, rigName, polecatName, agentBeadID, session
 			PolecatName: polecatName,
 			AgentState:  "done-intent-dead",
 			HookBead:    diHookBead,
+			WasActive:   true,
 			Action:      fmt.Sprintf("restarted (done-intent age=%v, type=%s)", age.Round(time.Second), doneIntent.ExitType),
 		}
 		if err := RestartPolecatSession(workDir, rigName, polecatName); err != nil {
@@ -1251,6 +1259,7 @@ func detectZombieDeadSession(workDir, rigName, polecatName, agentBeadID, session
 		PolecatName: polecatName,
 		AgentState:  agentState,
 		HookBead:    hookBead,
+		WasActive:   hookBead != "" || beads.IsActiveAgentState(agentState),
 	}
 
 	// gt-dsgp: Restart instead of nuking. For dirty state, escalate AND restart.
@@ -1264,7 +1273,7 @@ func isZombieState(agentState, hookBead string) bool {
 	if hookBead != "" {
 		return true
 	}
-	return agentState == "working" || agentState == "running" || agentState == "spawning"
+	return beads.IsActiveAgentState(agentState)
 }
 
 // handleZombieRestart determines the restart action for a confirmed zombie (gt-dsgp).

--- a/internal/witness/patrol_receipts.go
+++ b/internal/witness/patrol_receipts.go
@@ -28,20 +28,10 @@ type PatrolReceipt struct {
 }
 
 func receiptVerdictForZombie(z ZombieResult) PatrolVerdict {
-	if strings.TrimSpace(z.HookBead) != "" {
+	if z.WasActive {
 		return PatrolVerdictStale
 	}
-	// All states from DetectZombiePolecats that indicate a polecat was recently
-	// active are classified as stale. States without evidence of recent work
-	// (e.g. "idle") fall through to orphan.
-	switch z.AgentState {
-	case "working", "running", "spawning",
-		"stuck-in-done", "agent-dead-in-session",
-		"bead-closed-still-running", "done-intent-dead":
-		return PatrolVerdictStale
-	default:
-		return PatrolVerdictOrphan
-	}
+	return PatrolVerdictOrphan
 }
 
 // BuildPatrolReceipt projects a zombie patrol result into a stable JSON-ready receipt.


### PR DESCRIPTION
## Summary
- Add typed `AgentState` constants and `IsActiveAgentState()` helper to beads package
- Add `WasActive` field to `ZombieResult`, set at detection time by each zombie path
- `isZombieState()` now uses `beads.IsActiveAgentState()` instead of hardcoded string comparisons
- `receiptVerdictForZombie()` reads `WasActive` field instead of maintaining a parallel switch over state strings

Eliminates two independently-maintained state classification lists that could drift out of sync.

Fixes: gt-tsut

## Test plan
- [x] `go build ./...` — full project compiles
- [x] `go test ./internal/witness/...` — all witness tests pass
- [x] `TestReceiptVerdictForZombie_AllStates` — all verdict classifications correct
- [x] `TestBuildPatrolReceipt_*` — receipt building works with WasActive field

🤖 Generated with [Claude Code](https://claude.com/claude-code)