### PR TITLE
fix(test): fix flaky TestVerifyStartupNudgeDelivery_IdleAgent session collision

### DIFF
--- a/internal/polecat/session_manager_test.go
+++ b/internal/polecat/session_manager_test.go
@@ -437,8 +437,15 @@ func TestVerifyStartupNudgeDelivery_IdleAgent(t *testing.T) {
 	tm := tmux.NewTmux()
 	sessionName := "gt-test-nudge-verify-" + t.Name()
 
-	// Kill any orphaned session from a previous interrupted test run.
+	// Kill any orphaned session from a previous interrupted test run,
+	// then wait for tmux to fully destroy it (kill-session can be async).
 	_ = tm.KillSession(sessionName)
+	for i := 0; i < 20; i++ {
+		if exists, _ := tm.HasSession(sessionName); !exists {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 
 	// Create a tmux session with a shell
 	if err := tm.NewSession(sessionName, os.TempDir()); err != nil {


### PR DESCRIPTION
## Summary
- Add wait loop after `KillSession` to verify session is fully destroyed before creating a new one
- `tmux kill-session` can be async — the session may briefly persist after the command returns
- Without this, `NewSession` hits "session already exists" when the test runs consecutively

## Test plan
- [x] `go test ./internal/polecat/ -run TestVerifyStartupNudgeDelivery -count=3` — passes all 3 runs
- [x] `go build ./...` — compiles clean

Fixes: gt-eo8d

🤖 Generated with [Claude Code](https://claude.com/claude-code)