### PR TITLE
fix: prevent auto-close of stuck convoys with tracked but unready issues

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -284,13 +284,14 @@ Examples:
 
 var convoyStrandedCmd = &cobra.Command{
 	Use:   "stranded",
-	Short: "Find stranded convoys (ready work or empty) needing attention",
+	Short: "Find stranded convoys (ready work, stuck, or empty) needing attention",
 	Long: `Find convoys that have ready issues but no workers processing them,
-or empty convoys (0 tracked issues) that need cleanup.
+stuck convoys (tracked issues but none ready), or empty convoys that need cleanup.
 
 A convoy is "stranded" when:
 - Convoy is open AND either:
   - Has tracked issues that are ready but unassigned, OR
+  - Has tracked issues but none are ready (stuck — waiting on dependencies/workers), OR
   - Has 0 tracked issues (empty — needs auto-close via convoy check)
 
 Use this to detect convoys that need feeding or cleanup. The Deacon patrol
@@ -1161,10 +1162,11 @@ func removePolecatWorktree(wt convoyWorktreeInfo) error {
 
 // strandedConvoyInfo holds info about a stranded convoy.
 type strandedConvoyInfo struct {
-	ID          string   `json:"id"`
-	Title       string   `json:"title"`
-	ReadyCount  int      `json:"ready_count"`
-	ReadyIssues []string `json:"ready_issues"`
+	ID           string   `json:"id"`
+	Title        string   `json:"title"`
+	TrackedCount int      `json:"tracked_count"`
+	ReadyCount   int      `json:"ready_count"`
+	ReadyIssues  []string `json:"ready_issues"`
 }
 
 // readyIssueInfo holds info about a ready (stranded) issue.
@@ -1199,10 +1201,12 @@ func runConvoyStranded(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%s Found %d stranded convoy(s):\n\n", style.Warning.Render("⚠"), len(stranded))
 	for _, s := range stranded {
 		fmt.Printf("  🚚 %s: %s\n", s.ID, s.Title)
-		if s.ReadyCount == 0 {
+		if s.ReadyCount == 0 && s.TrackedCount == 0 {
 			fmt.Printf("     Empty convoy (0 tracked issues) — needs cleanup\n")
+		} else if s.ReadyCount == 0 && s.TrackedCount > 0 {
+			fmt.Printf("     Stuck convoy (%d tracked issues, 0 ready)\n", s.TrackedCount)
 		} else {
-			fmt.Printf("     Ready issues: %d\n", s.ReadyCount)
+			fmt.Printf("     Ready issues: %d (of %d tracked)\n", s.ReadyCount, s.TrackedCount)
 			for _, issueID := range s.ReadyIssues {
 				fmt.Printf("       • %s\n", issueID)
 			}
@@ -1210,11 +1214,13 @@ func runConvoyStranded(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 	}
 
-	// Separate feed advice (convoys with ready work) from cleanup advice (empty convoys).
-	var feedable, empty []strandedConvoyInfo
+	// Separate feed advice, stuck convoys, and cleanup advice.
+	var feedable, stuck, empty []strandedConvoyInfo
 	for _, s := range stranded {
 		if s.ReadyCount > 0 {
 			feedable = append(feedable, s)
+		} else if s.TrackedCount > 0 {
+			stuck = append(stuck, s)
 		} else {
 			empty = append(empty, s)
 		}
@@ -1226,8 +1232,17 @@ func runConvoyStranded(cmd *cobra.Command, args []string) error {
 			fmt.Printf("  gt sling mol-convoy-feed deacon/dogs --var convoy=%s\n", s.ID)
 		}
 	}
-	if len(empty) > 0 {
+	if len(stuck) > 0 {
 		if len(feedable) > 0 {
+			fmt.Println()
+		}
+		fmt.Println("Stuck convoys (tracked issues exist but none are ready):")
+		for _, s := range stuck {
+			fmt.Printf("  🚚 %s (%d tracked)\n", s.ID, s.TrackedCount)
+		}
+	}
+	if len(empty) > 0 {
+		if len(feedable) > 0 || len(stuck) > 0 {
 			fmt.Println()
 		}
 		fmt.Println("To close empty convoys, run:")
@@ -1276,10 +1291,11 @@ func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
 		// attention (auto-close via convoy check or manual cleanup).
 		if len(tracked) == 0 {
 			stranded = append(stranded, strandedConvoyInfo{
-				ID:          convoy.ID,
-				Title:       convoy.Title,
-				ReadyCount:  0,
-				ReadyIssues: []string{},
+				ID:           convoy.ID,
+				Title:        convoy.Title,
+				TrackedCount: 0,
+				ReadyCount:   0,
+				ReadyIssues:  []string{},
 			})
 			continue
 		}
@@ -1312,10 +1328,22 @@ func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
 
 		if len(readyIssues) > 0 {
 			stranded = append(stranded, strandedConvoyInfo{
-				ID:          convoy.ID,
-				Title:       convoy.Title,
-				ReadyCount:  len(readyIssues),
-				ReadyIssues: readyIssues,
+				ID:           convoy.ID,
+				Title:        convoy.Title,
+				TrackedCount: len(tracked),
+				ReadyCount:   len(readyIssues),
+				ReadyIssues:  readyIssues,
+			})
+		} else {
+			// Stuck convoy: has tracked issues but none are ready.
+			// Include in stranded list so callers (e.g., FeedStranded)
+			// can distinguish stuck from truly empty.
+			stranded = append(stranded, strandedConvoyInfo{
+				ID:           convoy.ID,
+				Title:        convoy.Title,
+				TrackedCount: len(tracked),
+				ReadyCount:   0,
+				ReadyIssues:  []string{},
 			})
 		}
 	}

--- a/internal/cmd/convoy_empty_test.go
+++ b/internal/cmd/convoy_empty_test.go
@@ -233,6 +233,9 @@ esac
 	if empty.ReadyCount != 0 {
 		t.Errorf("empty convoy ReadyCount = %d, want 0", empty.ReadyCount)
 	}
+	if empty.TrackedCount != 0 {
+		t.Errorf("empty convoy TrackedCount = %d, want 0", empty.TrackedCount)
+	}
 	if len(empty.ReadyIssues) != 0 {
 		t.Errorf("empty convoy ReadyIssues = %v, want empty", empty.ReadyIssues)
 	}
@@ -244,6 +247,9 @@ esac
 	}
 	if feedable.ReadyCount != 1 {
 		t.Errorf("feedable convoy ReadyCount = %d, want 1", feedable.ReadyCount)
+	}
+	if feedable.TrackedCount != 1 {
+		t.Errorf("feedable convoy TrackedCount = %d, want 1", feedable.TrackedCount)
 	}
 	if len(feedable.ReadyIssues) != 1 || feedable.ReadyIssues[0] != "gt-ready1" {
 		t.Errorf("feedable convoy ReadyIssues = %v, want [gt-ready1]", feedable.ReadyIssues)
@@ -257,5 +263,85 @@ esac
 	jsonStr := string(jsonBytes)
 	if strings.Contains(jsonStr, `"ready_issues":null`) {
 		t.Error("JSON output contains ready_issues:null — should be [] for empty convoys")
+	}
+	// Verify tracked_count appears in JSON
+	if !strings.Contains(jsonStr, `"tracked_count"`) {
+		t.Error("JSON output missing tracked_count field")
+	}
+}
+
+// TestFindStrandedConvoys_StuckConvoy verifies that a convoy with tracked
+// issues but none ready (stuck) is included in the stranded list with
+// TrackedCount > 0 and ReadyCount == 0, preventing accidental auto-close.
+func TestFindStrandedConvoys_StuckConvoy(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping convoy test on Windows")
+	}
+
+	binDir := t.TempDir()
+	townRoot := t.TempDir()
+	townBeads := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(townBeads, 0755); err != nil {
+		t.Fatalf("mkdir townBeads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townBeads, "routes.jsonl"), []byte(`{"prefix":"gt-","path":"gastown/mayor/rig"}`+"\n"), 0644); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	bdPath := filepath.Join(binDir, "bd")
+
+	// Mock bd: convoy has tracked issues but all are blocked — none are ready.
+	script := `#!/bin/sh
+i=0
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) eval "pos$i=\"$arg\""; i=$((i+1)) ;;
+  esac
+done
+
+case "$pos0" in
+  list)
+    echo '[{"id":"hq-stuck1","title":"Stuck convoy"}]'
+    exit 0
+    ;;
+  dep)
+    # All tracked issues are open but blocked — none are ready
+    echo '[{"id":"gt-busy1","title":"Blocked issue 1","status":"open","issue_type":"task","assignee":"","dependency_type":"tracks"},{"id":"gt-busy2","title":"Blocked issue 2","status":"open","issue_type":"task","assignee":"","dependency_type":"tracks"}]'
+    exit 0
+    ;;
+  show)
+    # Both issues have blockers so isReadyIssue returns false
+    echo '[{"id":"gt-busy1","title":"Blocked issue 1","status":"open","issue_type":"task","assignee":"","blocked_by":["gt-blocker1"],"blocked_by_count":1,"dependencies":[]},{"id":"gt-busy2","title":"Blocked issue 2","status":"open","issue_type":"task","assignee":"","blocked_by":["gt-blocker1"],"blocked_by_count":1,"dependencies":[]}]'
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(bdPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write mock bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	stranded, err := findStrandedConvoys(townBeads)
+	if err != nil {
+		t.Fatalf("findStrandedConvoys() error: %v", err)
+	}
+
+	if len(stranded) != 1 {
+		t.Fatalf("expected 1 stranded convoy (stuck), got %d", len(stranded))
+	}
+
+	s := stranded[0]
+	if s.ID != "hq-stuck1" {
+		t.Errorf("stranded convoy ID = %q, want %q", s.ID, "hq-stuck1")
+	}
+	if s.TrackedCount != 2 {
+		t.Errorf("stuck convoy TrackedCount = %d, want 2", s.TrackedCount)
+	}
+	if s.ReadyCount != 0 {
+		t.Errorf("stuck convoy ReadyCount = %d, want 0", s.ReadyCount)
 	}
 }


### PR DESCRIPTION
## Summary
- Fixes deacon feed-stranded auto-closing convoys that still have tracked but unready issues
- Bead: gt-2qoj

## Test plan
- [ ] Verify convoys with unready tracked issues are not prematurely closed
- [ ] Confirm convoys with all-ready issues still auto-close correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)