### PR TITLE
fix(zfc): replace PID signal inference with heartbeat for polecat liveness

### DIFF
--- a/internal/cmd/mail_check.go
+++ b/internal/cmd/mail_check.go
@@ -9,6 +9,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/mail"
 	"github.com/steveyegge/gastown/internal/nudge"
+	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
@@ -70,6 +71,9 @@ func runMailCheck(cmd *cobra.Command, args []string) error {
 	// at the next task boundary, normal/low is informational but still
 	// checked before going idle (prevents mail from sitting unread).
 	if mailCheckInject {
+		// Touch heartbeat file so Go-side liveness checks see recent activity
+		// (ZFC: gt-qjtq — heartbeat replaces PID signal inference).
+		touchSessionHeartbeat(workDir)
 		if unread > 0 {
 			messages, listErr := mailbox.ListUnread()
 			if listErr != nil {
@@ -171,4 +175,14 @@ func formatInjectOutput(messages []*mail.Message) string {
 	}
 
 	return b.String()
+}
+
+// touchSessionHeartbeat touches the heartbeat file for the current tmux session.
+// Best-effort: failures are silently ignored since heartbeat is advisory.
+func touchSessionHeartbeat(townRoot string) {
+	sessionName := tmux.CurrentSessionName()
+	if sessionName == "" {
+		return
+	}
+	_ = session.TouchHeartbeat(townRoot, sessionName)
 }

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -322,6 +322,10 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 		return fmt.Errorf("creating session: %w", err)
 	}
 
+	// Bootstrap heartbeat so isSessionProcessDead sees a fresh heartbeat
+	// before the agent's first gt command runs (ZFC: gt-qjtq).
+	_ = session.TouchHeartbeat(townRoot, sessionID)
+
 	// Set environment (non-fatal: session works without these)
 	// Use centralized AgentEnv for consistency across all role startup paths
 	// Note: townRoot already defined above for ResolveRoleAgentConfig
@@ -455,12 +459,12 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 	return nil
 }
 
-// isSessionStale checks if a tmux session's pane process has died.
-// A stale session exists in tmux but its main process (the agent) is no longer running.
-// This happens when the agent crashes during startup but tmux keeps the dead pane.
-// Delegates to isSessionProcessDead to avoid duplicating process-check logic (gt-qgzj1h).
+// isSessionStale checks if a tmux session's agent has stopped.
+// A stale session exists in tmux but the agent is no longer active.
+// Uses heartbeat staleness (ZFC: gt-qjtq) with PID fallback for pre-heartbeat sessions.
 func (m *SessionManager) isSessionStale(sessionID string) bool {
-	return isSessionProcessDead(m.tmux, sessionID)
+	townRoot := filepath.Dir(m.rig.Path)
+	return isSessionProcessDead(m.tmux, sessionID, townRoot)
 }
 
 // Stop terminates a polecat session.
@@ -486,6 +490,10 @@ func (m *SessionManager) Stop(polecat string, force bool) error {
 	if err := m.tmux.KillSessionWithProcesses(sessionID); err != nil {
 		return fmt.Errorf("killing session: %w", err)
 	}
+
+	// Clean up heartbeat file (ZFC: gt-qjtq).
+	townRoot := filepath.Dir(m.rig.Path)
+	session.CleanupHeartbeat(townRoot, sessionID)
 
 	return nil
 }

--- a/internal/session/heartbeat.go
+++ b/internal/session/heartbeat.go
@@ -1,0 +1,73 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"time"
+)
+
+const (
+	// HeartbeatStaleThreshold is the age at which a polecat heartbeat is
+	// considered stale, indicating the agent process is likely dead.
+	// Polecats touch their heartbeat file on every gt command invocation
+	// (via UserPromptSubmit hook), so a 5-minute gap strongly signals death.
+	HeartbeatStaleThreshold = 5 * time.Minute
+)
+
+// heartbeatsDir returns the directory for session heartbeat files.
+func heartbeatsDir(townRoot string) string {
+	return filepath.Join(townRoot, ".runtime", "heartbeats")
+}
+
+// heartbeatFile returns the path to a heartbeat file for a session.
+func heartbeatFile(townRoot, sessionID string) string {
+	return filepath.Join(heartbeatsDir(townRoot), sessionID)
+}
+
+// TouchHeartbeat creates or updates the heartbeat file for a session.
+// The file's mtime serves as the heartbeat timestamp.
+func TouchHeartbeat(townRoot, sessionID string) error {
+	dir := heartbeatsDir(townRoot)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return err
+	}
+
+	path := heartbeatFile(townRoot, sessionID)
+	now := time.Now()
+
+	// Try to update mtime on existing file first (cheaper than create).
+	if err := os.Chtimes(path, now, now); err == nil {
+		return nil
+	}
+
+	// File doesn't exist — create it.
+	return os.WriteFile(path, nil, 0644)
+}
+
+// HeartbeatAge returns how long ago the heartbeat was last updated.
+// Returns a very large duration if the file doesn't exist or can't be read.
+func HeartbeatAge(townRoot, sessionID string) time.Duration {
+	path := heartbeatFile(townRoot, sessionID)
+	info, err := os.Stat(path)
+	if err != nil {
+		return 24 * time.Hour * 365 // No heartbeat = very stale
+	}
+	return time.Since(info.ModTime())
+}
+
+// IsHeartbeatStale returns true if the session's heartbeat file is older
+// than the given threshold, or doesn't exist at all.
+func IsHeartbeatStale(townRoot, sessionID string, threshold time.Duration) bool {
+	return HeartbeatAge(townRoot, sessionID) >= threshold
+}
+
+// CleanupHeartbeat removes the heartbeat file for a session.
+func CleanupHeartbeat(townRoot, sessionID string) {
+	_ = os.Remove(heartbeatFile(townRoot, sessionID))
+}
+
+// HeartbeatFilePath returns the filesystem path to a session's heartbeat file.
+// Exported for callers that need to check file existence directly.
+func HeartbeatFilePath(townRoot, sessionID string) string {
+	return heartbeatFile(townRoot, sessionID)
+}

--- a/internal/session/heartbeat_test.go
+++ b/internal/session/heartbeat_test.go
@@ -1,0 +1,137 @@
+package session
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestTouchHeartbeat_CreatesFile(t *testing.T) {
+	townRoot := t.TempDir()
+	sessionID := "gt-test-session"
+
+	if err := TouchHeartbeat(townRoot, sessionID); err != nil {
+		t.Fatalf("TouchHeartbeat: %v", err)
+	}
+
+	path := heartbeatFile(townRoot, sessionID)
+	if _, err := os.Stat(path); err != nil {
+		t.Fatalf("heartbeat file not created: %v", err)
+	}
+}
+
+func TestTouchHeartbeat_UpdatesMtime(t *testing.T) {
+	townRoot := t.TempDir()
+	sessionID := "gt-test-session"
+
+	if err := TouchHeartbeat(townRoot, sessionID); err != nil {
+		t.Fatalf("first touch: %v", err)
+	}
+
+	path := heartbeatFile(townRoot, sessionID)
+	info1, _ := os.Stat(path)
+
+	// Set mtime to the past
+	past := time.Now().Add(-10 * time.Minute)
+	_ = os.Chtimes(path, past, past)
+
+	if err := TouchHeartbeat(townRoot, sessionID); err != nil {
+		t.Fatalf("second touch: %v", err)
+	}
+
+	info2, _ := os.Stat(path)
+	if !info2.ModTime().After(info1.ModTime().Add(-1 * time.Second)) {
+		t.Errorf("mtime not updated: before=%v after=%v", info1.ModTime(), info2.ModTime())
+	}
+}
+
+func TestHeartbeatAge_NoFile(t *testing.T) {
+	townRoot := t.TempDir()
+	age := HeartbeatAge(townRoot, "nonexistent")
+	if age < 24*time.Hour {
+		t.Errorf("expected very large age for missing file, got %v", age)
+	}
+}
+
+func TestHeartbeatAge_FreshFile(t *testing.T) {
+	townRoot := t.TempDir()
+	sessionID := "gt-test-fresh"
+
+	if err := TouchHeartbeat(townRoot, sessionID); err != nil {
+		t.Fatalf("TouchHeartbeat: %v", err)
+	}
+
+	age := HeartbeatAge(townRoot, sessionID)
+	if age > 2*time.Second {
+		t.Errorf("expected fresh heartbeat, got age %v", age)
+	}
+}
+
+func TestIsHeartbeatStale_Fresh(t *testing.T) {
+	townRoot := t.TempDir()
+	sessionID := "gt-test-stale"
+
+	if err := TouchHeartbeat(townRoot, sessionID); err != nil {
+		t.Fatalf("TouchHeartbeat: %v", err)
+	}
+
+	if IsHeartbeatStale(townRoot, sessionID, HeartbeatStaleThreshold) {
+		t.Error("fresh heartbeat should not be stale")
+	}
+}
+
+func TestIsHeartbeatStale_Old(t *testing.T) {
+	townRoot := t.TempDir()
+	sessionID := "gt-test-old"
+
+	if err := TouchHeartbeat(townRoot, sessionID); err != nil {
+		t.Fatalf("TouchHeartbeat: %v", err)
+	}
+
+	// Set mtime to the past
+	path := heartbeatFile(townRoot, sessionID)
+	past := time.Now().Add(-10 * time.Minute)
+	_ = os.Chtimes(path, past, past)
+
+	if !IsHeartbeatStale(townRoot, sessionID, HeartbeatStaleThreshold) {
+		t.Error("old heartbeat should be stale")
+	}
+}
+
+func TestIsHeartbeatStale_NoFile(t *testing.T) {
+	townRoot := t.TempDir()
+	if !IsHeartbeatStale(townRoot, "nonexistent", HeartbeatStaleThreshold) {
+		t.Error("missing heartbeat should be stale")
+	}
+}
+
+func TestCleanupHeartbeat(t *testing.T) {
+	townRoot := t.TempDir()
+	sessionID := "gt-test-cleanup"
+
+	if err := TouchHeartbeat(townRoot, sessionID); err != nil {
+		t.Fatalf("TouchHeartbeat: %v", err)
+	}
+
+	CleanupHeartbeat(townRoot, sessionID)
+
+	path := heartbeatFile(townRoot, sessionID)
+	if _, err := os.Stat(path); !os.IsNotExist(err) {
+		t.Error("heartbeat file should be removed after cleanup")
+	}
+}
+
+func TestCleanupHeartbeat_NoFile(t *testing.T) {
+	townRoot := t.TempDir()
+	// Should not panic or error on missing file.
+	CleanupHeartbeat(townRoot, "nonexistent")
+}
+
+func TestHeartbeatsDir(t *testing.T) {
+	got := heartbeatsDir("/town")
+	want := filepath.Join("/town", ".runtime", "heartbeats")
+	if got != want {
+		t.Errorf("heartbeatsDir() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary
- Replaces PID signal inference for polecat liveness with heartbeat-based detection
- Bead: gt-qjtq (ZFC: polecat PID signal inference for liveness)

## Test plan
- [ ] Verify polecat liveness uses heartbeat instead of PID signals
- [ ] Run polecat liveness test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)