### PR TITLE
feat(consensus): fan-out prompt dispatch to multiple sessions

### DIFF
--- a/internal/cmd/consensus.go
+++ b/internal/cmd/consensus.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/consensus"
+	"github.com/steveyegge/gastown/internal/style"
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+var (
+	consensusTimeout  time.Duration
+	consensusJSON     bool
+	consensusDryRun   bool
+	consensusSessions []string
+)
+
+func init() {
+	consensusCmd.Flags().DurationVar(&consensusTimeout, "timeout", 5*time.Minute, "Per-session wait timeout")
+	consensusCmd.Flags().BoolVar(&consensusJSON, "json", false, "Output results as JSON")
+	consensusCmd.Flags().BoolVar(&consensusDryRun, "dry-run", false, "Show target sessions without sending")
+	consensusCmd.Flags().StringSliceVar(&consensusSessions, "session", nil, "Target specific sessions (repeatable)")
+	rootCmd.AddCommand(consensusCmd)
+}
+
+var consensusCmd = &cobra.Command{
+	Use:     "consensus <prompt>",
+	Aliases: []string{"fanout"},
+	GroupID: GroupWork,
+	Short:   "Fan-out a prompt to multiple sessions and collect responses",
+	Long: `Send the same prompt to multiple Claude Code sessions in parallel
+and collect their responses for comparison.
+
+By default, targets all idle crew and polecat sessions.
+Use --session to target specific sessions.
+
+Examples:
+  gt consensus "What time is it?"
+  gt consensus --timeout 10m "Summarize the current PR"
+  gt consensus --session gt-crew-bear --session gt-crew-cat "test prompt"
+  gt consensus --dry-run "show targets"
+  gt consensus --json "prompt" | jq .`,
+	Args: cobra.ExactArgs(1),
+	RunE: runConsensus,
+}
+
+func runConsensus(cmd *cobra.Command, args []string) error {
+	prompt := args[0]
+	if prompt == "" {
+		return fmt.Errorf("prompt cannot be empty")
+	}
+
+	// Resolve target sessions.
+	sessions, err := resolveConsensusSessions()
+	if err != nil {
+		return err
+	}
+
+	if len(sessions) == 0 {
+		fmt.Println("No idle sessions found to target.")
+		return nil
+	}
+
+	// Dry run: show what would be targeted.
+	if consensusDryRun {
+		fmt.Printf("Would fan-out to %d session(s):\n\n", len(sessions))
+		for _, s := range sessions {
+			fmt.Printf("  %s\n", s)
+		}
+		fmt.Printf("\nPrompt: %s\n", prompt)
+		fmt.Printf("Timeout: %s\n", consensusTimeout)
+		return nil
+	}
+
+	// Run the consensus.
+	t := tmux.NewTmux()
+	runner := consensus.NewRunner(t)
+
+	fmt.Printf("Sending prompt to %d session(s)...\n\n", len(sessions))
+
+	result := runner.Run(consensus.Request{
+		Prompt:   prompt,
+		Sessions: sessions,
+		Timeout:  consensusTimeout,
+	})
+
+	// Output results.
+	if consensusJSON {
+		return outputConsensusJSON(result)
+	}
+	outputConsensusText(result)
+	return nil
+}
+
+// resolveConsensusSessions determines which sessions to target.
+func resolveConsensusSessions() ([]string, error) {
+	// If explicit sessions specified, use those (check idle status).
+	if len(consensusSessions) > 0 {
+		t := tmux.NewTmux()
+		var idle []string
+		for _, s := range consensusSessions {
+			if t.IsIdle(s) {
+				idle = append(idle, s)
+			} else {
+				fmt.Printf("%s %s (not idle, skipping)\n", style.WarningPrefix, s)
+			}
+		}
+		return idle, nil
+	}
+
+	// Default: all idle crew + polecat sessions.
+	agents, err := getAgentSessions(true) // include polecats
+	if err != nil {
+		return nil, fmt.Errorf("listing sessions: %w", err)
+	}
+
+	// Exclude self.
+	self := os.Getenv("BD_ACTOR")
+
+	t := tmux.NewTmux()
+	var sessions []string
+	for _, agent := range agents {
+		if agent.Type != AgentCrew && agent.Type != AgentPolecat {
+			continue
+		}
+		name := formatAgentName(agent)
+		if self != "" && name == self {
+			continue
+		}
+		if t.IsIdle(agent.Name) {
+			sessions = append(sessions, agent.Name)
+		}
+	}
+	return sessions, nil
+}
+
+func outputConsensusJSON(result *consensus.Result) error {
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	return enc.Encode(result)
+}
+
+func outputConsensusText(result *consensus.Result) {
+	for i, sr := range result.Sessions {
+		if i > 0 {
+			fmt.Println(strings.Repeat("─", 60))
+		}
+
+		statusIcon := style.SuccessPrefix
+		switch sr.Status {
+		case consensus.StatusTimeout:
+			statusIcon = style.WarningPrefix
+		case consensus.StatusError, consensus.StatusRateLimited:
+			statusIcon = style.ErrorPrefix
+		case consensus.StatusNotIdle:
+			statusIcon = style.WarningPrefix
+		}
+
+		fmt.Printf("%s %s  (%s, %s)\n", statusIcon, sr.Session, sr.Status, sr.Duration.Round(time.Millisecond))
+
+		if sr.Error != "" {
+			fmt.Printf("  Error: %s\n", sr.Error)
+		}
+		if sr.Response != "" {
+			fmt.Println()
+			// Indent response lines for readability.
+			for _, line := range strings.Split(sr.Response, "\n") {
+				fmt.Printf("  %s\n", line)
+			}
+			fmt.Println()
+		}
+	}
+
+	fmt.Printf("\nTotal: %d session(s), %s\n", len(result.Sessions), result.Duration.Round(time.Millisecond))
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -68,6 +68,7 @@ var beadsExemptCommands = map[string]bool{
 	"signal":        true, // Hook signal handlers must be fast, handle beads internally
 	"metrics":       true, // Metrics reads local JSONL, no beads needed
 	"krc":           true, // KRC doesn't require beads
+	"consensus":     true, // Fan-out consensus doesn't require beads
 	"run-migration":       true, // Migration orchestrator handles its own beads checks
 	"health":              true, // Health check doesn't require beads
 }

--- a/internal/consensus/collector.go
+++ b/internal/consensus/collector.go
@@ -1,0 +1,109 @@
+package consensus
+
+import (
+	"strings"
+	"time"
+)
+
+// collectOne waits for a session to become idle after prompt dispatch,
+// captures the pane, and diffs against the pre-send snapshot to extract
+// the new response content.
+func collectOne(tmux TmuxClient, session, preSnapshot string, timeout time.Duration) SessionResult {
+	start := time.Now()
+
+	// Wake the pane to ensure the event loop processes our input.
+	tmux.WakePane(session)
+
+	// Wait for the session to finish processing.
+	if err := tmux.WaitForIdle(session, timeout); err != nil {
+		status := StatusTimeout
+		if !strings.Contains(err.Error(), "timeout") && !strings.Contains(err.Error(), "idle") {
+			status = StatusError
+		}
+		return SessionResult{
+			Session:  session,
+			Status:   status,
+			Duration: time.Since(start),
+			Error:    err.Error(),
+		}
+	}
+
+	// Capture the pane after completion.
+	post, err := tmux.CapturePaneAll(session)
+	if err != nil {
+		return SessionResult{
+			Session:  session,
+			Status:   StatusError,
+			Duration: time.Since(start),
+			Error:    err.Error(),
+		}
+	}
+
+	// Diff pre/post to extract new content.
+	response := extractNewContent(preSnapshot, post)
+	response = stripTrailingPrompt(response)
+
+	return SessionResult{
+		Session:  session,
+		Status:   StatusOK,
+		Response: response,
+		Duration: time.Since(start),
+	}
+}
+
+// extractNewContent finds new output by diffing pre/post pane snapshots.
+// The post snapshot is the pre snapshot with new content appended (the pane
+// scrollback grows). We match pre lines as a prefix of post and return
+// everything after.
+func extractNewContent(pre, post string) string {
+	if pre == "" {
+		return strings.TrimSpace(post)
+	}
+
+	preLines := strings.Split(pre, "\n")
+	postLines := strings.Split(post, "\n")
+
+	// Match pre lines from the start of post. The pane scrollback means
+	// post should begin with the same content as pre.
+	matchLen := 0
+	for i := 0; i < len(preLines) && i < len(postLines); i++ {
+		if preLines[i] == postLines[i] {
+			matchLen = i + 1
+		} else {
+			break
+		}
+	}
+
+	if matchLen == 0 {
+		return strings.TrimSpace(post)
+	}
+
+	// Everything after the matched prefix is new content.
+	newLines := postLines[matchLen:]
+	return strings.TrimSpace(strings.Join(newLines, "\n"))
+}
+
+// stripTrailingPrompt removes trailing Claude Code prompt and status bar lines.
+// The prompt character is ❯ (U+276F) and the status bar starts with ⏵⏵.
+func stripTrailingPrompt(content string) string {
+	if content == "" {
+		return content
+	}
+
+	lines := strings.Split(content, "\n")
+
+	// Remove trailing empty lines, prompt lines, and status bar lines.
+	for len(lines) > 0 {
+		trimmed := strings.TrimSpace(lines[len(lines)-1])
+		if trimmed == "" ||
+			strings.HasPrefix(trimmed, "❯") ||
+			strings.Contains(trimmed, "⏵⏵") ||
+			strings.Contains(trimmed, "\u23F5\u23F5") {
+			lines = lines[:len(lines)-1]
+			continue
+		}
+		break
+	}
+
+	return strings.TrimSpace(strings.Join(lines, "\n"))
+}

--- a/internal/consensus/consensus.go
+++ b/internal/consensus/consensus.go
@@ -1,0 +1,141 @@
+// Package consensus implements fan-out prompt dispatch to multiple Claude Code
+// sessions with parallel response collection. It sends the same prompt to
+// several tmux sessions and captures their responses for comparison.
+package consensus
+
+import (
+	"sync"
+	"time"
+)
+
+// ResultStatus describes the outcome of a single session's response.
+type ResultStatus string
+
+const (
+	StatusOK          ResultStatus = "ok"
+	StatusTimeout     ResultStatus = "timeout"
+	StatusError       ResultStatus = "error"
+	StatusRateLimited ResultStatus = "rate_limited"
+	StatusNotIdle     ResultStatus = "not_idle"
+)
+
+// Request specifies what to send and where.
+type Request struct {
+	Prompt   string
+	Sessions []string      // tmux session names
+	Timeout  time.Duration // per-session wait timeout
+}
+
+// SessionResult holds the outcome for a single session.
+type SessionResult struct {
+	Session  string        `json:"session"`
+	Status   ResultStatus  `json:"status"`
+	Response string        `json:"response,omitempty"`
+	Duration time.Duration `json:"duration"`
+	Error    string        `json:"error,omitempty"`
+}
+
+// Result aggregates all session outcomes.
+type Result struct {
+	Prompt   string          `json:"prompt"`
+	Sessions []SessionResult `json:"sessions"`
+	Duration time.Duration   `json:"duration"`
+}
+
+// TmuxClient is the interface for tmux operations needed by the consensus runner.
+type TmuxClient interface {
+	IsIdle(session string) bool
+	SendKeys(session, keys string) error
+	WaitForIdle(session string, timeout time.Duration) error
+	CapturePaneAll(session string) (string, error)
+	WakePane(target string)
+}
+
+// Runner orchestrates fan-out prompt dispatch and response collection.
+type Runner struct {
+	tmux TmuxClient
+}
+
+// NewRunner creates a Runner with the given tmux client.
+func NewRunner(tmux TmuxClient) *Runner {
+	return &Runner{tmux: tmux}
+}
+
+// Run sends a prompt to all requested sessions and collects responses.
+//
+// Strategy:
+//  1. Pre-flight: filter to idle sessions
+//  2. Snapshot pane state before sending (for diff)
+//  3. Sequential send via SendKeys (fast, avoids interleave)
+//  4. Parallel wait via goroutines (the slow part)
+//  5. Capture + diff responses
+func (r *Runner) Run(req Request) *Result {
+	start := time.Now()
+	result := &Result{
+		Prompt: req.Prompt,
+	}
+
+	if len(req.Sessions) == 0 {
+		result.Duration = time.Since(start)
+		return result
+	}
+
+	// 1. Pre-flight: check which sessions are idle.
+	type target struct {
+		session     string
+		preSnapshot string
+	}
+	var targets []target
+	for _, sess := range req.Sessions {
+		if !r.tmux.IsIdle(sess) {
+			result.Sessions = append(result.Sessions, SessionResult{
+				Session: sess,
+				Status:  StatusNotIdle,
+			})
+			continue
+		}
+
+		// 2. Snapshot pane state before sending.
+		pre, err := r.tmux.CapturePaneAll(sess)
+		if err != nil {
+			result.Sessions = append(result.Sessions, SessionResult{
+				Session: sess,
+				Status:  StatusError,
+				Error:   err.Error(),
+			})
+			continue
+		}
+
+		targets = append(targets, target{session: sess, preSnapshot: pre})
+	}
+
+	// 3. Sequential send to all targets (SendKeys is fast).
+	var sendable []target
+	for _, t := range targets {
+		if err := r.tmux.SendKeys(t.session, req.Prompt); err != nil {
+			result.Sessions = append(result.Sessions, SessionResult{
+				Session: t.session,
+				Status:  StatusError,
+				Error:   err.Error(),
+			})
+			continue
+		}
+		sendable = append(sendable, t)
+	}
+
+	// 4. Parallel wait + capture (the slow part).
+	collected := make([]SessionResult, len(sendable))
+	var wg sync.WaitGroup
+	for i, t := range sendable {
+		wg.Add(1)
+		go func(idx int, tgt target) {
+			defer wg.Done()
+			collected[idx] = collectOne(r.tmux, tgt.session, tgt.preSnapshot, req.Timeout)
+		}(i, t)
+	}
+	wg.Wait()
+
+	result.Sessions = append(result.Sessions, collected...)
+	result.Duration = time.Since(start)
+	return result
+}

--- a/internal/consensus/consensus_test.go
+++ b/internal/consensus/consensus_test.go
@@ -1,0 +1,305 @@
+package consensus
+
+import (
+	"fmt"
+	"sync"
+	"testing"
+	"time"
+)
+
+// mockTmux implements TmuxClient for testing.
+type mockTmux struct {
+	mu           sync.Mutex
+	idleSessions map[string]bool           // session -> is idle
+	paneContent  map[string]string         // session -> pane content (pre-send)
+	sendErr      map[string]error          // session -> SendKeys error
+	waitErr      map[string]error          // session -> WaitForIdle error
+	captureErr   map[string]error          // session -> CapturePaneAll error
+	postContent  map[string]string         // session -> content after processing
+	sent         map[string]bool           // session -> SendKeys was called
+	wakeCalled   map[string]bool           // session -> WakePane was called
+}
+
+func newMockTmux() *mockTmux {
+	return &mockTmux{
+		idleSessions: make(map[string]bool),
+		paneContent:  make(map[string]string),
+		sendErr:      make(map[string]error),
+		waitErr:      make(map[string]error),
+		captureErr:   make(map[string]error),
+		postContent:  make(map[string]string),
+		sent:         make(map[string]bool),
+		wakeCalled:   make(map[string]bool),
+	}
+}
+
+func (m *mockTmux) IsIdle(session string) bool {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return m.idleSessions[session]
+}
+
+func (m *mockTmux) SendKeys(session, keys string) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err, ok := m.sendErr[session]; ok {
+		return err
+	}
+	m.sent[session] = true
+	return nil
+}
+
+func (m *mockTmux) WaitForIdle(session string, timeout time.Duration) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err, ok := m.waitErr[session]; ok {
+		return err
+	}
+	return nil
+}
+
+func (m *mockTmux) CapturePaneAll(session string) (string, error) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if err, ok := m.captureErr[session]; ok {
+		return "", err
+	}
+	// After send + wake, return post content to simulate completed response.
+	if m.sent[session] && m.wakeCalled[session] {
+		if post, ok := m.postContent[session]; ok {
+			return post, nil
+		}
+	}
+	content, ok := m.paneContent[session]
+	if !ok {
+		return "", fmt.Errorf("session %s not found", session)
+	}
+	return content, nil
+}
+
+func (m *mockTmux) WakePane(target string) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.wakeCalled[target] = true
+}
+
+func TestRun_AllIdle(t *testing.T) {
+	mock := newMockTmux()
+	mock.idleSessions["sess-a"] = true
+	mock.idleSessions["sess-b"] = true
+	mock.paneContent["sess-a"] = "old output a\n❯ "
+	mock.paneContent["sess-b"] = "old output b\n❯ "
+	mock.postContent["sess-a"] = "old output a\n❯ \nResponse from A\n❯ \n⏵⏵ status"
+	mock.postContent["sess-b"] = "old output b\n❯ \nResponse from B\n❯ \n⏵⏵ status"
+
+	runner := NewRunner(mock)
+	result := runner.Run(Request{
+		Prompt:   "What time is it?",
+		Sessions: []string{"sess-a", "sess-b"},
+		Timeout:  5 * time.Minute,
+	})
+
+	if result.Prompt != "What time is it?" {
+		t.Errorf("expected prompt preserved, got %q", result.Prompt)
+	}
+	if len(result.Sessions) != 2 {
+		t.Fatalf("expected 2 session results, got %d", len(result.Sessions))
+	}
+
+	for _, sr := range result.Sessions {
+		if sr.Status != StatusOK {
+			t.Errorf("session %s: expected status ok, got %s (error: %s)", sr.Session, sr.Status, sr.Error)
+		}
+		if sr.Response == "" {
+			t.Errorf("session %s: expected non-empty response", sr.Session)
+		}
+	}
+
+	if result.Duration <= 0 {
+		t.Error("expected positive duration")
+	}
+}
+
+func TestRun_SomeNotIdle(t *testing.T) {
+	mock := newMockTmux()
+	mock.idleSessions["sess-a"] = true
+	mock.idleSessions["sess-b"] = false // busy
+	mock.paneContent["sess-a"] = "old a\n❯ "
+	mock.postContent["sess-a"] = "old a\n❯ \nResponse A\n❯ "
+
+	runner := NewRunner(mock)
+	result := runner.Run(Request{
+		Prompt:   "test",
+		Sessions: []string{"sess-a", "sess-b"},
+		Timeout:  1 * time.Minute,
+	})
+
+	if len(result.Sessions) != 2 {
+		t.Fatalf("expected 2 results, got %d", len(result.Sessions))
+	}
+
+	statusMap := make(map[string]ResultStatus)
+	for _, sr := range result.Sessions {
+		statusMap[sr.Session] = sr.Status
+	}
+
+	if statusMap["sess-a"] != StatusOK {
+		t.Errorf("sess-a: expected ok, got %s", statusMap["sess-a"])
+	}
+	if statusMap["sess-b"] != StatusNotIdle {
+		t.Errorf("sess-b: expected not_idle, got %s", statusMap["sess-b"])
+	}
+}
+
+func TestRun_Timeout(t *testing.T) {
+	mock := newMockTmux()
+	mock.idleSessions["sess-a"] = true
+	mock.paneContent["sess-a"] = "old\n❯ "
+	mock.waitErr["sess-a"] = fmt.Errorf("idle timeout exceeded")
+
+	runner := NewRunner(mock)
+	result := runner.Run(Request{
+		Prompt:   "test",
+		Sessions: []string{"sess-a"},
+		Timeout:  1 * time.Second,
+	})
+
+	if len(result.Sessions) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result.Sessions))
+	}
+	if result.Sessions[0].Status != StatusTimeout {
+		t.Errorf("expected timeout status, got %s", result.Sessions[0].Status)
+	}
+}
+
+func TestRun_SendFails(t *testing.T) {
+	mock := newMockTmux()
+	mock.idleSessions["sess-a"] = true
+	mock.paneContent["sess-a"] = "old\n❯ "
+	mock.sendErr["sess-a"] = fmt.Errorf("send failed: session dead")
+
+	runner := NewRunner(mock)
+	result := runner.Run(Request{
+		Prompt:   "test",
+		Sessions: []string{"sess-a"},
+		Timeout:  1 * time.Minute,
+	})
+
+	if len(result.Sessions) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(result.Sessions))
+	}
+	if result.Sessions[0].Status != StatusError {
+		t.Errorf("expected error status, got %s", result.Sessions[0].Status)
+	}
+	if result.Sessions[0].Error == "" {
+		t.Error("expected error message")
+	}
+}
+
+func TestRun_NoSessions(t *testing.T) {
+	mock := newMockTmux()
+	runner := NewRunner(mock)
+	result := runner.Run(Request{
+		Prompt:   "test",
+		Sessions: nil,
+		Timeout:  1 * time.Minute,
+	})
+
+	if len(result.Sessions) != 0 {
+		t.Errorf("expected 0 results, got %d", len(result.Sessions))
+	}
+	if result.Duration <= 0 {
+		t.Error("expected positive duration")
+	}
+}
+
+func TestExtractNewContent(t *testing.T) {
+	tests := []struct {
+		name string
+		pre  string
+		post string
+		want string
+	}{
+		{
+			name: "simple diff",
+			pre:  "old output\n❯ ",
+			post: "old output\n❯ \nNew response line 1\nNew response line 2\n❯ ",
+			want: "New response line 1\nNew response line 2\n❯",
+		},
+		{
+			name: "empty pre",
+			pre:  "",
+			post: "Some output here",
+			want: "Some output here",
+		},
+		{
+			name: "no new content",
+			pre:  "same content\n❯ ",
+			post: "same content\n❯ ",
+			want: "",
+		},
+		{
+			name: "multi-line response",
+			pre:  "previous output\n❯ ",
+			post: "previous output\n❯ \nLine 1\nLine 2\nLine 3\n❯ \n⏵⏵ status bar",
+			want: "Line 1\nLine 2\nLine 3\n❯ \n⏵⏵ status bar",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractNewContent(tt.pre, tt.post)
+			if got != tt.want {
+				t.Errorf("extractNewContent():\n  got:  %q\n  want: %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestStripTrailingPrompt(t *testing.T) {
+	tests := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{
+			name: "trailing prompt",
+			in:   "Response text\n❯ ",
+			want: "Response text",
+		},
+		{
+			name: "trailing status bar",
+			in:   "Response text\n❯ \n⏵⏵ bypass permissions",
+			want: "Response text",
+		},
+		{
+			name: "no prompt",
+			in:   "Clean response",
+			want: "Clean response",
+		},
+		{
+			name: "empty",
+			in:   "",
+			want: "",
+		},
+		{
+			name: "only prompt",
+			in:   "❯ \n⏵⏵ status",
+			want: "",
+		},
+		{
+			name: "response with embedded prompt char",
+			in:   "The ❯ char appears here\nActual response\n❯ ",
+			want: "The ❯ char appears here\nActual response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := stripTrailingPrompt(tt.in)
+			if got != tt.want {
+				t.Errorf("stripTrailingPrompt():\n  got:  %q\n  want: %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- New `gt consensus` command (alias: `gt fanout`) sends the same prompt to multiple Claude Code sessions in parallel and collects responses
- New `internal/consensus/` package with `Runner` orchestrator, pre/post pane diffing, and `TmuxClient` interface
- Defaults to all idle crew+polecat sessions; supports `--timeout`, `--json`, `--dry-run`, `--session` flags
- Added `consensus` to beads-exempt commands in `root.go`

## Test plan
- [x] `go build ./internal/... ./cmd/...` — clean build
- [x] `go test ./internal/consensus/ -v` — 7 unit tests pass
- [x] `go vet ./internal/consensus/ ./internal/cmd/` — clean
- [ ] `gt consensus --dry-run "test"` — shows target sessions
- [ ] `gt consensus "What time is it?"` — live fan-out (needs 2+ idle sessions)

🤖 Generated with [Claude Code](https://claude.com/claude-code)