### PR TITLE
fix: mail send prefix mismatch — generate database-prefixed IDs

### DIFF
--- a/internal/beads/config_yaml.go
+++ b/internal/beads/config_yaml.go
@@ -28,6 +28,13 @@ func EnsureConfigYAMLFromMetadataIfMissing(beadsDir, fallbackPrefix string) erro
 	return ensureConfigYAML(beadsDir, prefix, syncMode, true)
 }
 
+// ConfigPrefixFromDir reads the database prefix from a beads directory's metadata.
+// Returns "hq" as default if the prefix cannot be determined.
+func ConfigPrefixFromDir(beadsDir string) string {
+	prefix, _ := ConfigDefaultsFromMetadata(beadsDir, "hq")
+	return prefix
+}
+
 // ConfigDefaultsFromMetadata derives config.yaml defaults from metadata.json.
 // Falls back to fallbackPrefix and dolt-native sync mode when fields are absent.
 func ConfigDefaultsFromMetadata(beadsDir, fallbackPrefix string) (prefix string, syncMode string) {

--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -1206,7 +1206,7 @@ func sendHandoffMail(subject, message string) (string, error) {
 	// This prevents subjects like "--help" from being parsed as flags.
 	args := []string{
 		"create",
-		"--id", mail.GenerateID(), // explicit ID: ephemeral path may not read prefix from config
+		"--id", mail.GeneratePrefixedID(beads.ConfigPrefixFromDir(filepath.Join(townRoot, ".beads")), true),
 		"--assignee", agentID,
 		"-d", message,
 		"--priority", "1", // high — handoffs should float above normal mail


### PR DESCRIPTION
## Summary
- `gt mail send` was broken — all sends failed with "prefix mismatch: database uses 'hq-' but ID 'msg-...' doesn't match"
- Root cause: `GenerateID()` always produced `msg-*` IDs but HQ database requires `hq-` prefix
- Added `GeneratePrefixedID()` that reads the database prefix from metadata.json
- Fixed both `sendToSingle()` in mail router and the `handoff` direct-create path

## Test plan
- [x] Built and installed locally
- [x] `gt mail send overseer/ -s "Test" -m "Test"` succeeds (was failing before)
- [x] Messages appear in inbox with correct `hq-wisp-*` IDs
- [ ] Run `go test ./internal/mail/...`
- [ ] Run `go test ./internal/beads/...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)