### PR TITLE
fix(daemon,mail): stale PID returns nil + pass msg ID to bd create (#2107, #2095)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1557,10 +1557,10 @@ func isRunningFromPID(townRoot string) (bool, int, error) {
 	}
 
 	if !alive {
-		// Process not running, clean up stale PID file
-		if err := os.Remove(pidFile); err == nil {
-			return false, 0, fmt.Errorf("removed stale PID file (process %d not found)", pid)
-		}
+		// Process not running, clean up stale PID file.
+		// This is a successful recovery, not an error — the caller can
+		// proceed as if no daemon is running (fixes #2107).
+		os.Remove(pidFile) // best-effort cleanup
 		return false, 0, nil
 	}
 

--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -1113,6 +1113,13 @@ func (r *Router) sendToSingle(msg *Message) error {
 	// Add actor for attribution (sender identity)
 	args = append(args, "--actor", msg.From)
 
+	// Pass the pre-generated message ID so bd uses it instead of generating its own.
+	// Without this, the ephemeral (SQLite) insert path produces empty IDs,
+	// causing UNIQUE constraint failures on subsequent sends (#2095).
+	if msg.ID != "" {
+		args = append(args, "--id", msg.ID)
+	}
+
 	// Add --ephemeral flag for ephemeral messages (wisps, not synced to git)
 	if r.shouldBeWisp(msg) {
 		args = append(args, "--ephemeral")


### PR DESCRIPTION
## Summary
- **daemon**: `IsRunning` stale PID cleanup now returns `false, 0, nil` instead of an error, so `daemon start` succeeds on first attempt after stale PID.
- **mail**: `sendToSingle` passes pre-generated message ID to `bd create` via `--id` flag, preventing empty IDs and UNIQUE constraint failures.

Supersedes #2155 and #2157 (applied cleanly to current main without issues in those PRs).

## Test plan
- [x] `go build ./...` compiles clean
- [x] `go test ./internal/daemon/...` passes
- [x] `go test ./internal/mail/...` passes

Closes #2107, Closes #2095

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>