### PR TITLE
Add branch contamination preflight guard for sling/merge flows

### DIFF
--- a/internal/cmd/branch_scope_preflight.go
+++ b/internal/cmd/branch_scope_preflight.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/git"
+)
+
+const branchScopeEnvVar = "GT_BRANCH_SCOPE_PATHS"
+
+// BranchScopeDiagnostics provides machine-readable contamination diagnostics.
+type BranchScopeDiagnostics struct {
+	Classification  string   `json:"classification"`
+	BaseRef         string   `json:"base_ref"`
+	HeadRef         string   `json:"head_ref"`
+	AllowedPrefixes []string `json:"allowed_prefixes"`
+	ChangedFiles    []string `json:"changed_files"`
+	OutOfScopeFiles []string `json:"out_of_scope_files"`
+}
+
+func parseScopePrefixes(raw string) []string {
+	if strings.TrimSpace(raw) == "" {
+		return nil
+	}
+	normalized := make([]string, 0)
+	seen := make(map[string]bool)
+	for _, part := range strings.FieldsFunc(raw, func(r rune) bool {
+		return r == ',' || r == '\n' || r == '\r' || r == '\t'
+	}) {
+		prefix := normalizeScopePath(part)
+		if prefix == "" || seen[prefix] {
+			continue
+		}
+		seen[prefix] = true
+		normalized = append(normalized, prefix)
+	}
+	return normalized
+}
+
+func normalizeScopePath(path string) string {
+	normalized := strings.TrimSpace(strings.ReplaceAll(path, "\\", "/"))
+	normalized = strings.TrimPrefix(normalized, "./")
+	normalized = strings.TrimPrefix(normalized, "/")
+	normalized = strings.TrimSuffix(normalized, "/")
+	return normalized
+}
+
+func outOfScopeFiles(changedFiles, allowedPrefixes []string) []string {
+	if len(changedFiles) == 0 || len(allowedPrefixes) == 0 {
+		return nil
+	}
+	out := make([]string, 0)
+	for _, file := range changedFiles {
+		normalizedFile := normalizeScopePath(file)
+		inScope := false
+		for _, prefix := range allowedPrefixes {
+			if normalizedFile == prefix || strings.HasPrefix(normalizedFile, prefix+"/") {
+				inScope = true
+				break
+			}
+		}
+		if !inScope {
+			out = append(out, normalizedFile)
+		}
+	}
+	return out
+}
+
+func resolveDefaultBaseRef(g *git.Git) string {
+	if exists, err := g.RefExists("origin/main"); err == nil && exists {
+		return "origin/main"
+	}
+	if exists, err := g.RefExists("origin/master"); err == nil && exists {
+		return "origin/master"
+	}
+	return "origin/main"
+}
+
+func runBranchScopePreflight(g *git.Git, baseRef string) error {
+	allowedPrefixes := parseScopePrefixes(os.Getenv(branchScopeEnvVar))
+	if len(allowedPrefixes) == 0 {
+		return nil
+	}
+	if strings.TrimSpace(baseRef) == "" {
+		baseRef = resolveDefaultBaseRef(g)
+	}
+
+	changedFiles, err := g.FilesChangedSince(baseRef, "HEAD")
+	if err != nil {
+		return fmt.Errorf("branch scope preflight: computing changed files: %w", err)
+	}
+	outOfScope := outOfScopeFiles(changedFiles, allowedPrefixes)
+	if len(outOfScope) == 0 {
+		return nil
+	}
+
+	diag := BranchScopeDiagnostics{
+		Classification:  "branch_contamination",
+		BaseRef:         baseRef,
+		HeadRef:         "HEAD",
+		AllowedPrefixes: allowedPrefixes,
+		ChangedFiles:    changedFiles,
+		OutOfScopeFiles: outOfScope,
+	}
+	payload, _ := json.Marshal(diag)
+	return fmt.Errorf("branch scope preflight failed: %s", string(payload))
+}
+
+func runBranchScopePreflightFromCWD(cwd string) error {
+	if len(parseScopePrefixes(os.Getenv(branchScopeEnvVar))) == 0 {
+		return nil
+	}
+	g := git.NewGit(cwd)
+	if !g.IsRepo() {
+		return nil
+	}
+	return runBranchScopePreflight(g, "")
+}

--- a/internal/cmd/branch_scope_preflight_test.go
+++ b/internal/cmd/branch_scope_preflight_test.go
@@ -1,0 +1,102 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/git"
+)
+
+func runGitCmd(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s failed: %v\n%s", strings.Join(args, " "), err, string(out))
+	}
+}
+
+func initScopeTestRepo(t *testing.T) (string, string) {
+	t.Helper()
+	tmp := t.TempDir()
+	remote := filepath.Join(tmp, "remote.git")
+	local := filepath.Join(tmp, "local")
+
+	runGitCmd(t, tmp, "init", "--bare", remote)
+	runGitCmd(t, tmp, "init", local)
+	runGitCmd(t, local, "config", "user.email", "test@test.com")
+	runGitCmd(t, local, "config", "user.name", "Test User")
+
+	if err := os.WriteFile(filepath.Join(local, "README.md"), []byte("# test\n"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGitCmd(t, local, "add", ".")
+	runGitCmd(t, local, "commit", "-m", "initial")
+	runGitCmd(t, local, "remote", "add", "origin", remote)
+
+	mainBranchCmd := exec.Command("git", "branch", "--show-current")
+	mainBranchCmd.Dir = local
+	out, err := mainBranchCmd.Output()
+	if err != nil {
+		t.Fatalf("git branch --show-current: %v", err)
+	}
+	mainBranch := strings.TrimSpace(string(out))
+	runGitCmd(t, local, "push", "-u", "origin", mainBranch)
+	return local, mainBranch
+}
+
+func TestRunBranchScopePreflight_PassesWhenChangedFilesAreInScope(t *testing.T) {
+	local, mainBranch := initScopeTestRepo(t)
+	g := git.NewGit(local)
+
+	runGitCmd(t, local, "checkout", "-b", "feature/in-scope")
+	if err := os.MkdirAll(filepath.Join(local, "src"), 0755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(local, "src", "worker.go"), []byte("package main\n"), 0644); err != nil {
+		t.Fatalf("write src file: %v", err)
+	}
+	runGitCmd(t, local, "add", ".")
+	runGitCmd(t, local, "commit", "-m", "in scope change")
+
+	t.Setenv(branchScopeEnvVar, "src")
+	if err := runBranchScopePreflight(g, "origin/"+mainBranch); err != nil {
+		t.Fatalf("runBranchScopePreflight() expected success, got: %v", err)
+	}
+}
+
+func TestRunBranchScopePreflight_FailsWhenChangedFilesAreOutOfScope(t *testing.T) {
+	local, mainBranch := initScopeTestRepo(t)
+	g := git.NewGit(local)
+
+	runGitCmd(t, local, "checkout", "-b", "feature/out-of-scope")
+	if err := os.MkdirAll(filepath.Join(local, "src"), 0755); err != nil {
+		t.Fatalf("mkdir src: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(local, "docs"), 0755); err != nil {
+		t.Fatalf("mkdir docs: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(local, "src", "worker.go"), []byte("package main\n"), 0644); err != nil {
+		t.Fatalf("write src file: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(local, "docs", "note.md"), []byte("out of scope\n"), 0644); err != nil {
+		t.Fatalf("write docs file: %v", err)
+	}
+	runGitCmd(t, local, "add", ".")
+	runGitCmd(t, local, "commit", "-m", "mixed scope change")
+
+	t.Setenv(branchScopeEnvVar, "src")
+	err := runBranchScopePreflight(g, "origin/"+mainBranch)
+	if err == nil {
+		t.Fatal("runBranchScopePreflight() expected contamination error, got nil")
+	}
+	if !strings.Contains(err.Error(), "branch scope preflight failed") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "docs/note.md") {
+		t.Fatalf("expected out-of-scope file in diagnostics, got: %v", err)
+	}
+}

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -335,6 +335,9 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		if branch == defaultBranch || branch == "master" {
 			return fmt.Errorf("cannot submit %s/master branch to merge queue", defaultBranch)
 		}
+		if err := runBranchScopePreflight(g, "origin/"+defaultBranch); err != nil {
+			return err
+		}
 
 		// CRITICAL: Verify work exists before completing (hq-xthqf)
 		// Polecats calling gt done without commits results in lost work.

--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -143,6 +143,9 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 	if branch == defaultBranch || branch == "master" {
 		return fmt.Errorf("cannot submit %s/master branch to merge queue", defaultBranch)
 	}
+	if err := runBranchScopePreflight(g, "origin/"+defaultBranch); err != nil {
+		return err
+	}
 
 	// Parse branch info
 	info := parseBranchName(branch)

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -232,6 +232,11 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	if err != nil {
 		return fmt.Errorf("finding town root: %w", err)
 	}
+	if cwd, cwdErr := os.Getwd(); cwdErr == nil {
+		if err := runBranchScopePreflightFromCWD(cwd); err != nil {
+			return err
+		}
+	}
 	townBeadsDir := filepath.Join(townRoot, ".beads")
 
 	// Normalize target arguments: trim trailing slashes from target to handle tab-completion

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -335,9 +335,9 @@ func configureRefspec(repoPath string, singleBranch bool) error {
 			}
 			return nil
 		}
-		headRef := strings.TrimSpace(headOut.String())        // e.g. "refs/heads/main"
-		branch := strings.TrimPrefix(headRef, "refs/heads/")  // e.g. "main"
-		refspec := branch + ":refs/remotes/origin/" + branch   // e.g. "main:refs/remotes/origin/main"
+		headRef := strings.TrimSpace(headOut.String())       // e.g. "refs/heads/main"
+		branch := strings.TrimPrefix(headRef, "refs/heads/") // e.g. "main"
+		refspec := branch + ":refs/remotes/origin/" + branch // e.g. "main:refs/remotes/origin/main"
 
 		fetchCmd := exec.Command("git", "--git-dir", gitDir, "fetch", "--depth", "1", "origin", refspec)
 		fetchCmd.Stderr = &stderr
@@ -491,10 +491,10 @@ func (g *Git) CommitAll(message string) error {
 
 // GitStatus represents the status of the working directory.
 type GitStatus struct {
-	Clean    bool
-	Modified []string
-	Added    []string
-	Deleted  []string
+	Clean     bool
+	Modified  []string
+	Added     []string
+	Deleted   []string
 	Untracked []string
 }
 
@@ -1192,6 +1192,35 @@ func (g *Git) CountCommitsBehind(ref string) (int, error) {
 	return count, nil
 }
 
+// FilesChangedSince returns files changed between the merge-base of baseRef and
+// headRef. This uses `git diff --name-only <baseRef>...<headRef>`.
+func (g *Git) FilesChangedSince(baseRef, headRef string) ([]string, error) {
+	if strings.TrimSpace(baseRef) == "" {
+		return nil, fmt.Errorf("base ref is required")
+	}
+	if strings.TrimSpace(headRef) == "" {
+		return nil, fmt.Errorf("head ref is required")
+	}
+
+	out, err := g.run("diff", "--name-only", baseRef+"..."+headRef)
+	if err != nil {
+		return nil, err
+	}
+	if strings.TrimSpace(out) == "" {
+		return nil, nil
+	}
+
+	lines := strings.Split(out, "\n")
+	files := make([]string, 0, len(lines))
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed != "" {
+			files = append(files, trimmed)
+		}
+	}
+	return files, nil
+}
+
 // StashCount returns the number of stashes belonging to the current branch.
 // Git stashes are stored in the main repo (.git/refs/stash) and shared across
 // all worktrees. Counting all stashes is incorrect for worktree-based polecats:
@@ -1272,8 +1301,8 @@ type UncommittedWorkStatus struct {
 	StashCount            int
 	UnpushedCommits       int
 	// Details for error messages
-	ModifiedFiles   []string
-	UntrackedFiles  []string
+	ModifiedFiles  []string
+	UntrackedFiles []string
 }
 
 // Clean returns true if there is no uncommitted work.


### PR DESCRIPTION
## Problem
Sling/merge workflows can run from a branch that includes out-of-scope changes, which creates noisy handoffs and contaminated PR scope.

## Why now
This has become a repeated multi-agent operator friction point. We need an early, deterministic branch-scope gate before side effects.

## What changed
- Added `Git.FilesChangedSince(baseRef, headRef)` using `git diff --name-only <base>...<head>`.
- Added branch-scope preflight helpers in `internal/cmd` that:
  - read scope prefixes from `GT_BRANCH_SCOPE_PATHS`
  - compute out-of-scope files against `origin/<default>...HEAD`
  - fail with machine-readable JSON diagnostics when contamination is detected.
- Wired preflight checks into `gt sling`, `gt done` (COMPLETED path), and `gt mq submit`.
- Added targeted tests for:
  - git diff file detection
  - clean in-scope preflight
  - contaminated out-of-scope preflight.

## Validation
- `go test ./internal/git -run "FilesChangedSince"`
- `CGO_ENABLED=0 go test ./internal/cmd -run "BranchScopePreflight"`

Refs #2220
