### PR TITLE
fix(witness): verify work on main before resetting abandoned beads

### DIFF
--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1630,14 +1630,15 @@ func getBeadStatus(workDir, beadID string) string {
 // 3. Clears assignee
 // 4. Sends mail to deacon for re-dispatch (includes respawn count; SPAWN_STORM
 //    prefix and Urgent priority when count exceeds defaultMaxBeadRespawns)
-// Returns true if the bead was recovered.
-func resetAbandonedBead(workDir, rigName, hookBead, polecatName string, router *mail.Router) bool {
+// Returns (recovered, closed): recovered=true if bead was reset for re-dispatch,
+// closed=true if bead was closed because the work is already on main.
+func resetAbandonedBead(workDir, rigName, hookBead, polecatName string, router *mail.Router) (recovered, closed bool) {
 	if hookBead == "" {
-		return false
+		return false, false
 	}
 	status := getBeadStatus(workDir, hookBead)
 	if status != "hooked" && status != "in_progress" {
-		return false
+		return false, false
 	}
 
 	// Guard: if the polecat's commit is already on the default branch,
@@ -1646,7 +1647,7 @@ func resetAbandonedBead(workDir, rigName, hookBead, polecatName string, router *
 	if onMain, err := verifyCommitOnMain(workDir, rigName, polecatName); err == nil && onMain {
 		reason := fmt.Sprintf("Work already on main (verified by witness, polecat %s)", polecatName)
 		_ = bdRun(workDir, "close", hookBead, "-r", reason)
-		return true
+		return false, true
 	}
 
 	// Track respawn count for audit and storm detection.
@@ -1654,7 +1655,7 @@ func resetAbandonedBead(workDir, rigName, hookBead, polecatName string, router *
 
 	// Reset bead status to open and clear assignee
 	if err := bdRun(workDir, "update", hookBead, "--status=open", "--assignee="); err != nil {
-		return false
+		return false, false
 	}
 
 	// Send mail to deacon for re-dispatch
@@ -1689,7 +1690,7 @@ Please re-dispatch to an available polecat.`,
 		_ = router.Send(msg) // Best-effort
 	}
 
-	return true
+	return true, false
 }
 
 // OrphanedBeadResult contains a single detected orphaned bead.
@@ -1697,7 +1698,8 @@ type OrphanedBeadResult struct {
 	BeadID        string
 	Assignee      string // Original assignee (e.g. "gastown/polecats/alpha")
 	PolecatName   string // Extracted polecat name
-	BeadRecovered bool
+	BeadRecovered bool   // True if bead was reset to open for re-dispatch
+	BeadClosed    bool   // True if bead was closed (work already on main)
 }
 
 // DetectOrphanedBeadsResult contains the results of an orphaned bead scan.
@@ -1813,7 +1815,7 @@ func DetectOrphanedBeads(workDir, rigName string, router *mail.Router) *DetectOr
 			Assignee:    bead.Assignee,
 			PolecatName: polecatName,
 		}
-		orphan.BeadRecovered = resetAbandonedBead(workDir, assigneeRig, bead.ID, polecatName, router)
+		orphan.BeadRecovered, orphan.BeadClosed = resetAbandonedBead(workDir, assigneeRig, bead.ID, polecatName, router)
 		result.Orphans = append(result.Orphans, orphan)
 	}
 
@@ -1827,7 +1829,8 @@ type OrphanedMoleculeResult struct {
 	Assignee      string // The dead polecat's full address
 	PolecatName   string // Just the polecat name
 	Closed        int    // Number of issues closed (molecule + descendants)
-	BeadRecovered bool   // Whether the parent bead was reset for re-dispatch
+	BeadRecovered bool // Whether the parent bead was reset for re-dispatch
+	BeadClosed    bool // Whether the parent bead was closed (work already on main)
 	Error         error
 }
 
@@ -1965,7 +1968,7 @@ func DetectOrphanedMolecules(workDir, rigName string, router *mail.Router) *Dete
 		orphan.Closed = closed
 
 		// Reset the parent bead so it can be re-dispatched
-		orphan.BeadRecovered = resetAbandonedBead(workDir, rigName, b.ID, polecatName, router)
+		orphan.BeadRecovered, orphan.BeadClosed = resetAbandonedBead(workDir, rigName, b.ID, polecatName, router)
 
 		result.Orphans = append(result.Orphans, orphan)
 	}

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -728,20 +728,20 @@ func TestDetectZombie_BeadClosedVsDoneIntent(t *testing.T) {
 
 func TestResetAbandonedBead_EmptyHookBead(t *testing.T) {
 	t.Parallel()
-	// resetAbandonedBead should return false for empty hookBead
-	result := resetAbandonedBead("/tmp", "testrig", "", "nux", nil)
-	if result {
-		t.Error("resetAbandonedBead should return false for empty hookBead")
+	// resetAbandonedBead should return false,false for empty hookBead
+	recovered, closed := resetAbandonedBead("/tmp", "testrig", "", "nux", nil)
+	if recovered || closed {
+		t.Error("resetAbandonedBead should return false,false for empty hookBead")
 	}
 }
 
 func TestResetAbandonedBead_NoRouter(t *testing.T) {
 	t.Parallel()
 	// resetAbandonedBead with nil router should not panic even if bead exists.
-	// It will return false because bd won't find the bead, but shouldn't crash.
-	result := resetAbandonedBead("/tmp/nonexistent", "testrig", "gt-fake123", "nux", nil)
-	if result {
-		t.Error("resetAbandonedBead should return false when bd commands fail")
+	// It will return false,false because bd won't find the bead, but shouldn't crash.
+	recovered, closed := resetAbandonedBead("/tmp/nonexistent", "testrig", "gt-fake123", "nux", nil)
+	if recovered || closed {
+		t.Error("resetAbandonedBead should return false,false when bd commands fail")
 	}
 }
 
@@ -770,9 +770,12 @@ func TestResetAbandonedBead_ClosesWhenWorkOnMain(t *testing.T) {
 		},
 	)
 
-	result := resetAbandonedBead("/tmp/test", "testrig", "gt-work123", "alpha", nil)
-	if !result {
-		t.Error("resetAbandonedBead should return true when work is on main")
+	recovered, closed := resetAbandonedBead("/tmp/test", "testrig", "gt-work123", "alpha", nil)
+	if recovered {
+		t.Error("recovered should be false when work is on main (bead was closed, not re-dispatched)")
+	}
+	if !closed {
+		t.Error("closed should be true when work is on main")
 	}
 
 	// Verify "close" was called, NOT "update ... --status=open"
@@ -816,9 +819,12 @@ func TestResetAbandonedBead_ResetsWhenWorkNotOnMain(t *testing.T) {
 		},
 	)
 
-	result := resetAbandonedBead("/tmp/test", "testrig", "gt-work123", "alpha", nil)
-	if !result {
-		t.Error("resetAbandonedBead should return true when bead is reset")
+	recovered, closed := resetAbandonedBead("/tmp/test", "testrig", "gt-work123", "alpha", nil)
+	if !recovered {
+		t.Error("recovered should be true when work is NOT on main (bead reset for re-dispatch)")
+	}
+	if closed {
+		t.Error("closed should be false when work is NOT on main")
 	}
 
 	// Verify "update --status=open" was called (normal reset path)


### PR DESCRIPTION
## Summary

- Adds a `verifyCommitOnMain` guard at the top of `resetAbandonedBead` in `internal/witness/handlers.go`
- When a zombie polecat's HEAD commit is already on the default branch, the bead is **closed** instead of reset to "open" for re-dispatch
- Prevents the spawn-storm / duplicate-work loop where completed beads are endlessly re-dispatched

## Problem

When `DetectZombiePolecats` nukes a polecat during the `gt done` cleanup window (after work is pushed but before `done-intent` clears), `resetAbandonedBead` resets the bead to "open". A new polecat picks it up, finds nothing to do, exits, and the witness nukes it again — creating a spawn storm.

This was introduced by gt-tr3d (commit 0e5d1a30, Feb 18) which added aggressive nuke paths for live sessions with 30-60s thresholds that overlap with the `gt done` cleanup window.

## Fix

`verifyCommitOnMain` already exists in the codebase (used by `HandleMerged`) but was never called in any of the zombie cleanup paths. This PR adds it as a guard in `resetAbandonedBead`:

```go
if onMain, err := verifyCommitOnMain(workDir, rigName, polecatName); err == nil && onMain {
    _ = bdRun(workDir, "close", hookBead, "-r", reason)
    return true
}
```

The check is fail-safe: if `verifyCommitOnMain` returns an error (e.g., worktree already removed), it falls through to the existing reset behavior.

`verifyCommitOnMain` is also converted from a plain function to a package-level `var` (matching the existing `bdRun`/`bdExec` pattern) so tests can override it.

## Test plan

- [x] `TestResetAbandonedBead_ClosesWhenWorkOnMain` — verifies bead is closed (not reset) when work is on main
- [x] `TestResetAbandonedBead_ResetsWhenWorkNotOnMain` — verifies existing reset behavior is preserved
- [x] All existing witness tests pass (`go test ./internal/witness/...`)
- [x] Full project builds clean (`go build ./...`)

Fixes #2036

🤖 Generated with [Claude Code](https://claude.com/claude-code)