### PR TITLE
refactor: make daemon recovery/boot/deacon thresholds config-driven (gt-8l3w batch 2)

### DIFF
--- a/internal/config/operational.go
+++ b/internal/config/operational.go
@@ -44,6 +44,9 @@ const (
 	DefaultMaxLifecycleMessageAge          = 6 * time.Hour
 	DefaultSyncFailureEscalationThreshold  = 3
 	DefaultDoctorMolCooldown               = 5 * time.Minute
+	DefaultRecoveryHeartbeatInterval       = 3 * time.Minute
+	DefaultBootSpawnCooldown               = 2 * time.Minute
+	DefaultDeaconGracePeriod               = 5 * time.Minute
 )
 
 // Deacon defaults.
@@ -334,6 +337,30 @@ func (d *DaemonThresholds) DoctorMolCooldownD() time.Duration {
 		return ParseDurationOrDefault(d.DoctorMolCooldown, DefaultDoctorMolCooldown)
 	}
 	return DefaultDoctorMolCooldown
+}
+
+// RecoveryHeartbeatIntervalD returns the configured or default recovery heartbeat interval.
+func (d *DaemonThresholds) RecoveryHeartbeatIntervalD() time.Duration {
+	if d != nil {
+		return ParseDurationOrDefault(d.RecoveryHeartbeatInterval, DefaultRecoveryHeartbeatInterval)
+	}
+	return DefaultRecoveryHeartbeatInterval
+}
+
+// BootSpawnCooldownD returns the configured or default boot spawn cooldown.
+func (d *DaemonThresholds) BootSpawnCooldownD() time.Duration {
+	if d != nil {
+		return ParseDurationOrDefault(d.BootSpawnCooldown, DefaultBootSpawnCooldown)
+	}
+	return DefaultBootSpawnCooldown
+}
+
+// DeaconGracePeriodD returns the configured or default deacon grace period.
+func (d *DaemonThresholds) DeaconGracePeriodD() time.Duration {
+	if d != nil {
+		return ParseDurationOrDefault(d.DeaconGracePeriod, DefaultDeaconGracePeriod)
+	}
+	return DefaultDeaconGracePeriod
 }
 
 // --- Deacon accessors ---

--- a/internal/config/operational_test.go
+++ b/internal/config/operational_test.go
@@ -104,6 +104,15 @@ func TestDaemonThresholds_Defaults(t *testing.T) {
 	if got := daemon.MaxLifecycleMessageAgeD(); got != DefaultMaxLifecycleMessageAge {
 		t.Errorf("MaxLifecycleMessageAge: got %v, want %v", got, DefaultMaxLifecycleMessageAge)
 	}
+	if got := daemon.RecoveryHeartbeatIntervalD(); got != DefaultRecoveryHeartbeatInterval {
+		t.Errorf("RecoveryHeartbeatInterval: got %v, want %v", got, DefaultRecoveryHeartbeatInterval)
+	}
+	if got := daemon.BootSpawnCooldownD(); got != DefaultBootSpawnCooldown {
+		t.Errorf("BootSpawnCooldown: got %v, want %v", got, DefaultBootSpawnCooldown)
+	}
+	if got := daemon.DeaconGracePeriodD(); got != DefaultDeaconGracePeriod {
+		t.Errorf("DeaconGracePeriod: got %v, want %v", got, DefaultDeaconGracePeriod)
+	}
 }
 
 func TestDaemonThresholds_Overrides(t *testing.T) {
@@ -127,6 +136,29 @@ func TestDaemonThresholds_Overrides(t *testing.T) {
 	// Non-overridden fields should still return defaults
 	if got := daemon.MassDeathThresholdV(); got != DefaultMassDeathThreshold {
 		t.Errorf("MassDeathThreshold: got %v, want %v (default)", got, DefaultMassDeathThreshold)
+	}
+}
+
+func TestDaemonThresholds_NewFieldOverrides(t *testing.T) {
+	t.Parallel()
+
+	op := &OperationalConfig{
+		Daemon: &DaemonThresholds{
+			RecoveryHeartbeatInterval: "5m",
+			BootSpawnCooldown:         "90s",
+			DeaconGracePeriod:         "10m",
+		},
+	}
+
+	daemon := op.GetDaemonConfig()
+	if got := daemon.RecoveryHeartbeatIntervalD(); got != 5*time.Minute {
+		t.Errorf("RecoveryHeartbeatInterval: got %v, want 5m", got)
+	}
+	if got := daemon.BootSpawnCooldownD(); got != 90*time.Second {
+		t.Errorf("BootSpawnCooldown: got %v, want 90s", got)
+	}
+	if got := daemon.DeaconGracePeriodD(); got != 10*time.Minute {
+		t.Errorf("DeaconGracePeriod: got %v, want 10m", got)
 	}
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -301,6 +301,15 @@ type DaemonThresholds struct {
 
 	// DoctorMolCooldown is min interval between mol-dog-doctor molecules (default "5m").
 	DoctorMolCooldown string `json:"doctor_mol_cooldown,omitempty"`
+
+	// RecoveryHeartbeatInterval is the fixed interval for recovery-focused daemon heartbeat (default "3m").
+	RecoveryHeartbeatInterval string `json:"recovery_heartbeat_interval,omitempty"`
+
+	// BootSpawnCooldown prevents Boot from spawning on every daemon heartbeat (default "2m").
+	BootSpawnCooldown string `json:"boot_spawn_cooldown,omitempty"`
+
+	// DeaconGracePeriod is time to wait after starting Deacon before checking heartbeat (default "5m").
+	DeaconGracePeriod string `json:"deacon_grace_period,omitempty"`
 }
 
 // DeaconThresholds configures deacon health-check and dispatch thresholds.


### PR DESCRIPTION
## Summary
- Move `recoveryHeartbeatInterval`, `bootSpawnCooldown`, and `deaconGracePeriod` from hardcoded Go constants to config-driven methods
- Follows existing `DaemonThresholds`/`OperationalConfig` pattern with `ParseDurationOrDefault`
- Part of gt-8l3w threshold refactoring (batch 2, following PR #2224 witness thresholds)

## Changes
- `internal/config/types.go` — Add 3 new fields to `DaemonThresholds` struct
- `internal/config/operational.go` — Add 3 default constants + 3 accessor methods
- `internal/config/operational_test.go` — Add default and override tests
- `internal/daemon/daemon.go` — Replace `const` with `func (d *Daemon)` methods that read from config

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/config/...` — all pass including new tests
- [x] `go test ./internal/daemon/...` — all pass
- [x] Non-overridden fields return defaults
- [x] Override fields via JSON config strings ("5m", "90s", "10m")

🤖 Generated with [Claude Code](https://claude.com/claude-code)