### PR TITLE
fix(daemon): guard StopDaemon against pid=0 when lock held but PID file missing

### DIFF
--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -223,8 +223,10 @@ func runDown(cmd *cobra.Command, args []string) error {
 			if err := daemon.StopDaemon(townRoot); err != nil {
 				printDownStatus("Daemon", false, err.Error())
 				allOK = false
-			} else {
+			} else if pid > 0 {
 				printDownStatus("Daemon", true, fmt.Sprintf("stopped (was PID %d)", pid))
+			} else {
+				printDownStatus("Daemon", true, "stopped (stale lock cleaned)")
 			}
 		} else {
 			printDownStatus("Daemon", true, "not running")

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1579,6 +1579,16 @@ func StopDaemon(townRoot string) error {
 		return fmt.Errorf("daemon is not running")
 	}
 
+	if pid <= 0 {
+		// Lock is held but PID is unknown (race: daemon starting, or stale lock).
+		// Clean up the lock file so the next gt up can start fresh.
+		lockPath := filepath.Join(townRoot, "daemon", "daemon.lock")
+		_ = os.Remove(lockPath)
+		pidFile := filepath.Join(townRoot, "daemon", "daemon.pid")
+		_ = os.Remove(pidFile)
+		return nil
+	}
+
 	process, err := os.FindProcess(pid)
 	if err != nil {
 		return fmt.Errorf("finding process: %w", err)


### PR DESCRIPTION
## Summary

`gt down` crashes with `✖ Daemon: sending SIGTERM: os: process not initialized` when the daemon lock is held but the PID file is absent or empty.

**Root cause:** `IsRunning()` (flock path) returns `(true, 0, nil)` when the lock is held but no PID file exists — a race between lock acquisition and PID file write during daemon startup. `StopDaemon()` then calls `os.FindProcess(0)`, which returns an uninitialized process handle on Unix, and `Signal(SIGTERM)` fails with the Go error "os: process not initialized".

**Fix:**
- **`daemon.go:StopDaemon()`** — When `pid <= 0`, skip signaling and clean up the stale lock/PID files so the next `gt up` starts fresh.
- **`down.go`** — Display "stopped (stale lock cleaned)" instead of "stopped (was PID 0)" for this case.

## Relationship to #2107 / #2216

This is a **companion fix** to PR #2216, which addresses the same underlying stale-PID problem area but on a different code path:

| | PR #2216 | This PR |
|---|---|---|
| **Function** | `isRunningFromPID()` (fallback path) | `StopDaemon()` via `IsRunning()` (flock path) |
| **Symptom** | `daemon start` fails on stale PID | `gt down` crashes with "os: process not initialized" |
| **Fix** | Return `false, 0, nil` instead of error | Guard `pid <= 0` before signaling |

Both PRs reference #2107. Together they close the two remaining stale-PID failure modes in daemon lifecycle management.

## Test plan
- [x] `go build ./...` compiles clean
- [x] Manually verified `gt down` no longer errors when lock held without PID file
- [x] Normal `gt down` with valid daemon PID still works correctly

Closes #2107

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>