### PR TITLE
fix(lint): handle resp.Body.Close() errcheck in keychain.go

### DIFF
--- a/internal/quota/keychain.go
+++ b/internal/quota/keychain.go
@@ -269,7 +269,7 @@ func validateTokenHTTP(token string) error {
 	if err != nil {
 		return nil // Network error → assume valid
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return fmt.Errorf("token rejected by API (HTTP 401)")


### PR DESCRIPTION
## Summary
- Wraps deferred `resp.Body.Close()` to explicitly discard error, fixing errcheck lint violation
- This was the last remaining fix from PR #2210 not yet on main — all other fixes from that PR have been independently applied

## Test plan
- [x] `go build ./cmd/gt` passes
- [x] `go vet ./internal/quota/...` passes

Supersedes the remaining content of #2210 (which can be closed after this merges).

🤖 Generated with [Claude Code](https://claude.com/claude-code)