### PR TITLE
feat: add branch contamination preflight before sling/merge flows

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1228,6 +1228,22 @@ func (g *Git) CommitsAhead(base, branch string) (int, error) {
 	return count, nil
 }
 
+// ChangedFilesBetween returns the list of files changed between two refs
+// using three-dot diff (merge-base comparison). This shows files changed
+// on the branch since it diverged from base — useful for detecting
+// branch contamination (unrelated files leaking into a feature branch).
+func (g *Git) ChangedFilesBetween(base, head string) ([]string, error) {
+	out, err := g.run("diff", "--name-only", base+"..."+head)
+	if err != nil {
+		return nil, err
+	}
+	out = strings.TrimSpace(out)
+	if out == "" {
+		return nil, nil
+	}
+	return strings.Split(out, "\n"), nil
+}
+
 // CountCommitsBehind returns the number of commits that HEAD is behind the given ref.
 // For example, CountCommitsBehind("origin/main") returns how many commits
 // are on origin/main that are not on the current HEAD.


### PR DESCRIPTION
## Summary

- Adds `ChangedFilesBetween` git utility using three-dot diff (`base...head`) to list files changed on a branch since diverging from base
- Adds contamination preflight in `gt done`: **blocks** polecats when branch touches 4+ top-level directories; **warns** crew workers
- Adds advisory contamination warning in refinery `doMerge` as a second safety net before squash-merge
- Includes 3 targeted tests: clean branch (pass), no changes (nil), contaminated branch (4+ dirs detected)

Closes #2220

## Test plan

- [x] `go test ./internal/git/ -run TestChangedFilesBetween` — 3/3 pass
- [x] `go test ./internal/git/ ./internal/cmd/ ./internal/refinery/` — all pass
- [x] `golangci-lint run` — 0 issues
- [ ] Manual: create contaminated branch, run `gt done`, verify blocking error for polecats
- [ ] Manual: verify crew workers get warning but can proceed

🤖 Generated with [Claude Code](https://claude.com/claude-code)