### PR TITLE
fix: wrap defer resp.Body.Close() to satisfy errcheck linter

### DIFF
--- a/internal/quota/keychain.go
+++ b/internal/quota/keychain.go
@@ -269,7 +269,7 @@ func validateTokenHTTP(token string) error {
 	if err != nil {
 		return nil // Network error → assume valid
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	if resp.StatusCode == http.StatusUnauthorized {
 		return fmt.Errorf("token rejected by API (HTTP 401)")


### PR DESCRIPTION
## Summary
- Wraps `defer resp.Body.Close()` in `internal/quota/keychain.go` with `func() { _ = resp.Body.Close() }()` to satisfy the `errcheck` linter
- Matches the pattern already used in `internal/wasteland/wasteland.go` and `internal/doltserver/dolthub.go`

## Test plan
- [x] `go build ./...` passes
- [x] Single-line change, no behavioral difference

🤖 Generated with [Claude Code](https://claude.com/claude-code)