### PR TITLE
feat: add --agent override to gt formula run (GH#2118)

### DIFF
--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -30,6 +30,7 @@ var (
 	formulaRunPR      int
 	formulaRunRig     string
 	formulaRunDryRun  bool
+	formulaRunAgent   string
 	formulaCreateType string
 )
 
@@ -113,16 +114,24 @@ If no formula name is provided, uses the default formula configured in
 the rig's settings/config.json under workflow.default_formula.
 
 Options:
-  --pr=N      Run formula on GitHub PR #N
-  --rig=NAME  Target specific rig (default: current or gastown)
-  --dry-run   Show what would happen without executing
+  --pr=N        Run formula on GitHub PR #N
+  --rig=NAME    Target specific rig (default: current or gastown)
+  --agent=ALIAS Override agent/runtime for all legs (e.g., gemini, codex)
+  --dry-run     Show what would happen without executing
+
+Agent precedence (highest to lowest):
+  1. Per-leg 'agent' field in formula TOML
+  2. --agent CLI flag
+  3. Formula-level 'agent' field in formula TOML
+  4. Rig/town default agent (fallback)
 
 Examples:
   gt formula run shiny                    # Run formula in current rig
   gt formula run                          # Run default formula from rig config
   gt formula run shiny --pr=123           # Run on PR #123
   gt formula run security-audit --rig=beads  # Run in specific rig
-  gt formula run release --dry-run        # Preview execution`,
+  gt formula run release --dry-run        # Preview execution
+  gt formula run code-review --agent=gemini  # All legs use gemini`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runFormulaRun,
 }
@@ -159,6 +168,7 @@ func init() {
 	formulaRunCmd.Flags().IntVar(&formulaRunPR, "pr", 0, "GitHub PR number to run formula on")
 	formulaRunCmd.Flags().StringVar(&formulaRunRig, "rig", "", "Target rig (default: current or gastown)")
 	formulaRunCmd.Flags().BoolVar(&formulaRunDryRun, "dry-run", false, "Preview execution without running")
+	formulaRunCmd.Flags().StringVar(&formulaRunAgent, "agent", "", "Override agent/runtime for all legs (e.g., gemini, codex, claude-haiku)")
 
 	// Create flags
 	formulaCreateCmd.Flags().StringVar(&formulaCreateType, "type", "task", "Formula type: task, workflow, or patrol")
@@ -292,6 +302,14 @@ func dryRunFormula(f *formula.Formula, formulaName, targetRig string) error {
 	if formulaRunPR > 0 {
 		fmt.Printf("  PR:      #%d\n", formulaRunPR)
 	}
+	// Show effective agent override (GH#2118)
+	effectiveAgent := formulaRunAgent
+	if effectiveAgent == "" {
+		effectiveAgent = f.Agent
+	}
+	if effectiveAgent != "" {
+		fmt.Printf("  Agent:   %s\n", effectiveAgent)
+	}
 
 	if f.Type == formula.TypeConvoy && len(f.Legs) > 0 {
 		// Generate review ID for dry-run display
@@ -349,9 +367,17 @@ func dryRunFormula(f *formula.Formula, formulaName, targetRig string) error {
 				}
 				legPattern := renderTemplateOrDefault(f.Output.LegPattern, legCtx, leg.ID+"-findings.md")
 				outputPath := filepath.Join(outputDir, legPattern)
-				fmt.Printf("    • %s: %s\n      → %s\n", leg.ID, leg.Title, outputPath)
+				agentSuffix := resolveFormulaLegAgent(leg.Agent, formulaRunAgent, f.Agent)
+				if agentSuffix != "" {
+					agentSuffix = fmt.Sprintf(" [agent: %s]", agentSuffix)
+				}
+				fmt.Printf("    • %s: %s%s\n      → %s\n", leg.ID, leg.Title, agentSuffix, outputPath)
 			} else {
-				fmt.Printf("    • %s: %s\n", leg.ID, leg.Title)
+				agentSuffix := resolveFormulaLegAgent(leg.Agent, formulaRunAgent, f.Agent)
+				if agentSuffix != "" {
+					agentSuffix = fmt.Sprintf(" [agent: %s]", agentSuffix)
+				}
+				fmt.Printf("    • %s: %s%s\n", leg.ID, leg.Title, agentSuffix)
 			}
 		}
 		if f.Synthesis != nil {
@@ -598,11 +624,17 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 		// Build context message for the polecat
 		contextMsg := fmt.Sprintf("Convoy leg: %s\nFocus: %s", leg.Title, leg.Focus)
 
+		// Agent precedence (GH#2118): per-leg > CLI --agent > formula-level
+		legAgent := resolveFormulaLegAgent(leg.Agent, formulaRunAgent, f.Agent)
+
 		// Use gt sling with args for leg-specific context
 		slingArgs := []string{
 			"sling", legBeadID, targetRig,
 			"-a", leg.Description,
 			"-s", leg.Title,
+		}
+		if legAgent != "" {
+			slingArgs = append(slingArgs, "--agent", legAgent)
 		}
 
 		slingCmd := exec.Command("gt", slingArgs...)
@@ -971,6 +1003,19 @@ Perform the patrol inspection.
 # description = "Enable verbose output"
 # default = "false"
 `, name, title, name)
+}
+
+// resolveFormulaLegAgent returns the effective agent for a convoy leg using
+// the precedence: per-leg > CLI --agent > formula-level. Returns "" if no
+// agent override applies. See GH#2118.
+func resolveFormulaLegAgent(legAgent, cliAgent, formulaAgent string) string {
+	if legAgent != "" {
+		return legAgent
+	}
+	if cliAgent != "" {
+		return cliAgent
+	}
+	return formulaAgent
 }
 
 // promptYesNo asks the user a yes/no question

--- a/internal/cmd/formula_test.go
+++ b/internal/cmd/formula_test.go
@@ -1,0 +1,34 @@
+package cmd
+
+import "testing"
+
+func TestResolveFormulaLegAgent_Precedence(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name         string
+		legAgent     string
+		cliAgent     string
+		formulaAgent string
+		want         string
+	}{
+		{"all empty", "", "", "", ""},
+		{"formula only", "", "", "gemini", "gemini"},
+		{"cli only", "", "codex", "", "codex"},
+		{"leg only", "claude-haiku", "", "", "claude-haiku"},
+		{"cli overrides formula", "", "codex", "gemini", "codex"},
+		{"leg overrides cli", "claude-haiku", "codex", "gemini", "claude-haiku"},
+		{"leg overrides formula", "claude-haiku", "", "gemini", "claude-haiku"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := resolveFormulaLegAgent(tt.legAgent, tt.cliAgent, tt.formulaAgent)
+			if got != tt.want {
+				t.Errorf("resolveFormulaLegAgent(%q, %q, %q) = %q, want %q",
+					tt.legAgent, tt.cliAgent, tt.formulaAgent, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -402,3 +402,69 @@ title = "Leg 3"
 		t.Errorf("ReadySteps({leg1}) = %v, want 2 legs", ready)
 	}
 }
+
+func TestParse_ConvoyWithAgent(t *testing.T) {
+	t.Parallel()
+	data := []byte(`
+formula = "agent-test"
+type = "convoy"
+version = 1
+agent = "gemini"
+
+[[legs]]
+id = "default-agent"
+title = "Uses formula default"
+description = "No per-leg agent"
+
+[[legs]]
+id = "custom-agent"
+title = "Uses custom agent"
+description = "Has per-leg agent"
+agent = "codex"
+`)
+
+	f, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if f.Agent != "gemini" {
+		t.Errorf("Formula.Agent = %q, want %q", f.Agent, "gemini")
+	}
+	if len(f.Legs) != 2 {
+		t.Fatalf("len(Legs) = %d, want 2", len(f.Legs))
+	}
+	if f.Legs[0].Agent != "" {
+		t.Errorf("Legs[0].Agent = %q, want empty", f.Legs[0].Agent)
+	}
+	if f.Legs[1].Agent != "codex" {
+		t.Errorf("Legs[1].Agent = %q, want %q", f.Legs[1].Agent, "codex")
+	}
+}
+
+func TestParse_ConvoyWithoutAgent(t *testing.T) {
+	t.Parallel()
+	// Existing formulas without agent field should continue to work
+	data := []byte(`
+formula = "no-agent"
+type = "convoy"
+version = 1
+
+[[legs]]
+id = "leg1"
+title = "Normal leg"
+description = "No agent override"
+`)
+
+	f, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse failed: %v", err)
+	}
+
+	if f.Agent != "" {
+		t.Errorf("Formula.Agent = %q, want empty", f.Agent)
+	}
+	if f.Legs[0].Agent != "" {
+		t.Errorf("Legs[0].Agent = %q, want empty", f.Legs[0].Agent)
+	}
+}

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -31,6 +31,7 @@ type Formula struct {
 	Description string      `toml:"description"`
 	Type        FormulaType `toml:"type"`
 	Version     int         `toml:"version"`
+	Agent       string      `toml:"agent"` // Default agent for all legs (GH#2118)
 
 	// Convoy-specific
 	Inputs    map[string]Input `toml:"inputs"`
@@ -80,6 +81,7 @@ type Leg struct {
 	Title       string `toml:"title"`
 	Focus       string `toml:"focus"`
 	Description string `toml:"description"`
+	Agent       string `toml:"agent"` // Per-leg agent override (GH#2118)
 }
 
 // Synthesis represents the synthesis step that combines leg outputs.


### PR DESCRIPTION
## Summary
- Adds `--agent` CLI flag to `gt formula run` for runtime override
- Adds `agent` field to formula TOML schema (formula-level default)
- Adds `agent` field to convoy leg TOML schema (per-leg override)
- Precedence: per-leg `agent` > `--agent` CLI > formula-level `agent` > rig default
- Passes `--agent` through to `gt sling` when dispatching convoy legs
- Shows effective agent in `--dry-run` output

Fixes #2118

## Test plan
- [x] Parser tests: convoy with agent fields, convoy without agent fields (backward compat)
- [x] Precedence tests: all 7 combinations of leg/cli/formula agent values
- [x] Full formula test suite passes
- [x] Full cmd test suite passes
- [x] Lint clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)