### PR TITLE
fix: daemon start retries after removing stale PID file (GH#2107)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1558,9 +1558,7 @@ func isRunningFromPID(townRoot string) (bool, int, error) {
 
 	if !alive {
 		// Process not running, clean up stale PID file
-		if err := os.Remove(pidFile); err == nil {
-			return false, 0, fmt.Errorf("removed stale PID file (process %d not found)", pid)
-		}
+		_ = os.Remove(pidFile)
 		return false, 0, nil
 	}
 


### PR DESCRIPTION
## Summary
- `isRunningFromPID` was returning an error after successfully cleaning up a stale PID file
- Callers treated this as fatal, so `gt daemon start` showed help text instead of starting
- Fix: return `(false, 0, nil)` instead of an error — consistent with the flock-based path and Dolt's stale PID handling

## Test plan
- [x] Added `TestIsRunningFromPID_StalePIDReturnsNoError` — verifies no error on stale cleanup
- [x] Added `TestIsRunningFromPID_NoPIDFile` — verifies clean return with no PID file
- [x] Added `TestIsRunningFromPID_LiveProcess` — verifies live process detection

Fixes #2107

🤖 Generated with [Claude Code](https://claude.com/claude-code)