### PR TITLE
fix: add missing BdCli argument to getAgentBeadState call

### DIFF
--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1815,7 +1815,7 @@ func IsBeadActivelyWorked(workDir, rigName, beadID, excludePolecat string) bool 
 		// Check if this polecat has our bead hooked
 		prefix := beads.GetPrefixForRig(townRoot, rigName)
 		agentBeadID := beads.PolecatBeadIDWithPrefix(prefix, rigName, polecatName)
-		_, hookBead := getAgentBeadState(workDir, agentBeadID)
+		_, hookBead := getAgentBeadState(DefaultBdCli(), workDir, agentBeadID)
 		if hookBead != beadID {
 			continue
 		}


### PR DESCRIPTION
The function signature requires *BdCli as first argument but the call at line 1818 was missing it, causing a build error:

  not enough arguments in call to getAgentBeadState
      have (string, string)
      want (*BdCli, string, string)

## Summary
<!-- Brief description of changes -->

## Related Issue
<!-- Link to issue: Fixes #123 or Closes #123 -->

## Changes
<!-- Bullet list of changes -->
-

## Testing
<!-- How did you test these changes? -->
- [ ] Unit tests pass (`go test ./...`)
- [ ] Manual testing performed

## Checklist
- [ ] Code follows project style
- [ ] Documentation updated (if applicable)
- [ ] No breaking changes (or documented in summary)
