### PR TITLE
fix: disable bd per-repo backup for Gas Town agents

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -168,6 +168,16 @@ func AgentEnv(cfg AgentEnvConfig) map[string]string {
 		env["GT_AGENT"] = cfg.Agent
 	}
 
+	// Disable bd's per-repo JSONL auto-backup for all Gas Town agents.
+	// bd auto-enables backup when a git remote exists, then force-adds
+	// .beads/backup/ files (bypassing .gitignore) and commits/pushes them
+	// to the project repo. In Gas Town, Dolt is the persistent data store
+	// and the daemon provides centralized backup patrols (dolt_backup,
+	// jsonl_git_backup), making per-repo backup redundant and harmful —
+	// it pollutes rig git history on both main and feature branches.
+	// See: https://github.com/steveyegge/beads/issues/2241
+	env["BD_BACKUP_ENABLED"] = "false"
+
 	// Clear NODE_OPTIONS to prevent debugger flags (e.g., --inspect from VSCode)
 	// from being inherited through tmux into Claude's Node.js runtime.
 	// This is the PRIMARY guard: setting it here (the single source of truth

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -794,6 +794,39 @@ func TestAgentEnv_IncludesClaudeCodeClearing(t *testing.T) {
 	}
 }
 
+func TestAgentEnv_DisablesBdBackup(t *testing.T) {
+	t.Parallel()
+	// Verify AgentEnv always includes BD_BACKUP_ENABLED=false regardless of role.
+	// In Gas Town, Dolt is the persistent data store and the daemon provides
+	// centralized backup patrols (dolt_backup, jsonl_git_backup). bd's per-repo
+	// auto-backup is redundant and pollutes rig git history via git add -f.
+	// See: https://github.com/steveyegge/beads/issues/2241
+	roles := []struct {
+		role      string
+		rig       string
+		agentName string
+	}{
+		{"mayor", "", ""},
+		{"deacon", "", ""},
+		{"boot", "", ""},
+		{"witness", "myrig", ""},
+		{"refinery", "myrig", ""},
+		{"polecat", "myrig", "Toast"},
+		{"crew", "myrig", "emma"},
+	}
+	for _, r := range roles {
+		t.Run(r.role, func(t *testing.T) {
+			env := AgentEnv(AgentEnvConfig{
+				Role:      r.role,
+				Rig:       r.rig,
+				AgentName: r.agentName,
+				TownRoot:  "/town",
+			})
+			assertEnv(t, env, "BD_BACKUP_ENABLED", "false")
+		})
+	}
+}
+
 func TestBuildStartupCommandWithEnv_IncludesNodeOptions(t *testing.T) {
 	t.Parallel()
 	// Integration test: verify BuildStartupCommandWithEnv output includes NODE_OPTIONS=


### PR DESCRIPTION
## Summary

- Set `BD_BACKUP_ENABLED=false` in `AgentEnv()` for all Gas Town agents
- Adds test coverage for the new env var across all agent roles

## Problem

bd's auto-backup (`PersistentPostRun` → `maybeAutoBackup`) auto-enables when a git remote exists, then runs `git add -f .beads/backup/` (bypassing `.gitignore`) and commits/pushes JSONL backup files to the project repo. This pollutes rig git history on both main and feature branches.

In Gas Town, this is redundant — Dolt is the persistent data store and the daemon provides centralized backup patrols (`dolt_backup`, `jsonl_git_backup`). bd's per-repo backup was designed for solo developers without infrastructure, not for orchestrated multi-agent environments.

## Solution

`AgentEnv()` is the single source of truth for all agent environment variables. Adding `BD_BACKUP_ENABLED=false` there ensures every gastown-managed agent (polecat, witness, refinery, crew, deacon, mayor, dog, boot) inherits it. bd respects this env var and skips auto-backup entirely.

This does not affect bd's backup feature for standalone users — only Gas Town agents are affected.

## Test plan

- [x] New test `TestAgentEnv_DisablesBdBackup` verifies `BD_BACKUP_ENABLED=false` is set for all 7 agent roles
- [x] All existing `AgentEnv` tests pass
- [ ] Manual: verify no `bd: backup` commits appear in rig repos after deploying

Ref: https://github.com/steveyegge/beads/issues/2241

🤖 Generated with [Claude Code](https://claude.com/claude-code)