### PR TITLE
fix: plugin cooldown gate uses months instead of minutes

### DIFF
--- a/internal/plugin/recording.go
+++ b/internal/plugin/recording.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"strings"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
@@ -138,13 +137,16 @@ func (r *Recorder) queryRuns(pluginName string, limit int, since string) ([]*Plu
 		args = append(args, fmt.Sprintf("--limit=%d", limit))
 	}
 	if since != "" {
-		// Convert duration like "1h" to created-after format
-		// bd supports relative dates with - prefix (e.g., -1h, -24h)
-		sinceArg := since
-		if !strings.HasPrefix(since, "-") {
-			sinceArg = "-" + since
+		// Parse as Go duration and compute an absolute RFC3339 cutoff.
+		// bd's compact duration uses "m" for months, but plugin gate
+		// durations use Go's time.ParseDuration where "m" means minutes.
+		// Passing an absolute timestamp avoids this unit mismatch.
+		d, err := time.ParseDuration(since)
+		if err != nil {
+			return nil, fmt.Errorf("parsing duration %q: %w", since, err)
 		}
-		args = append(args, "--created-after="+sinceArg)
+		cutoff := time.Now().Add(-d).UTC().Format(time.RFC3339)
+		args = append(args, "--created-after="+cutoff)
 	}
 
 	ctx, cancel := context.WithTimeout(context.Background(), constants.BdCommandTimeout)

--- a/internal/plugin/recording_test.go
+++ b/internal/plugin/recording_test.go
@@ -2,6 +2,7 @@ package plugin
 
 import (
 	"testing"
+	"time"
 )
 
 func TestPluginRunRecord(t *testing.T) {
@@ -42,6 +43,50 @@ func TestNewRecorder(t *testing.T) {
 	}
 	if recorder.townRoot != "/tmp/test-town" {
 		t.Errorf("expected townRoot '/tmp/test-town', got %q", recorder.townRoot)
+	}
+}
+
+func TestCooldownDurationParsing(t *testing.T) {
+	t.Parallel()
+	// Verify that plugin gate durations (Go time.ParseDuration format)
+	// are parsed correctly. This is critical because bd's compact duration
+	// uses "m" for months, while Go uses "m" for minutes. The fix computes
+	// an absolute RFC3339 cutoff instead of passing the raw duration to bd.
+	cases := []struct {
+		input   string
+		wantDur time.Duration
+		wantErr bool
+	}{
+		{"5m", 5 * time.Minute, false},
+		{"30m", 30 * time.Minute, false},
+		{"1h", 1 * time.Hour, false},
+		{"24h", 24 * time.Hour, false},
+		{"1h30m", 90 * time.Minute, false},
+		{"500ms", 500 * time.Millisecond, false},
+		{"bogus", 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.input, func(t *testing.T) {
+			d, err := time.ParseDuration(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Errorf("expected error for %q, got nil", tc.input)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.input, err)
+			}
+			if d != tc.wantDur {
+				t.Errorf("ParseDuration(%q) = %v, want %v", tc.input, d, tc.wantDur)
+			}
+			// Verify the cutoff time is in the past and approximately correct.
+			cutoff := time.Now().Add(-d)
+			elapsed := time.Since(cutoff)
+			if elapsed < d-time.Second || elapsed > d+time.Second {
+				t.Errorf("cutoff drift: expected ~%v ago, got %v ago", d, elapsed)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

- Plugin cooldown gate durations like `"5m"` (5 minutes) were passed directly to bd's `--created-after` flag, but bd's compact duration parser interprets `"m"` as **months**, not minutes. A 5-minute cooldown became a 5-month lookback, finding all recent runs and keeping the gate permanently closed.
- Fix: parse duration with Go's `time.ParseDuration` (where `"m"` correctly means minutes) and compute an absolute RFC3339 timestamp for `--created-after`, avoiding the unit semantics mismatch entirely.

## Test plan

- [x] Added `TestCooldownDurationParsing` covering minute, hour, mixed, and error cases
- [x] All existing plugin tests pass
- [ ] Manual verification: deploy and confirm plugins with minute-based cooldowns (e.g., `5m`, `30m`) correctly reopen after their cooldown expires

🤖 Generated with [Claude Code](https://claude.com/claude-code)