### PR TITLE
fix(mail): remove --id flag that causes prefix mismatch on all sends

### DIFF
--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -1113,12 +1113,10 @@ func (r *Router) sendToSingle(msg *Message) error {
 	// Add actor for attribution (sender identity)
 	args = append(args, "--actor", msg.From)
 
-	// Pass the pre-generated message ID so bd uses it instead of generating its own.
-	// Without this, the ephemeral (SQLite) insert path produces empty IDs,
-	// causing UNIQUE constraint failures on subsequent sends (#2095).
-	if msg.ID != "" {
-		args = append(args, "--id", msg.ID)
-	}
+	// Do NOT pass --id to bd create. The msg.ID (msg-xxx prefix) is for
+	// in-memory tracking only. bd auto-generates IDs with the correct
+	// database prefix (e.g., hq-wisp-xxx). Passing --id causes prefix
+	// mismatch errors when the msg- prefix does not match the database.
 
 	// Add --ephemeral flag for ephemeral messages (wisps, not synced to git)
 	if r.shouldBeWisp(msg) {


### PR DESCRIPTION
## Summary
- `gt mail send` fails on every send with: `prefix mismatch: database uses 'hq-' but ID 'msg-xxx' doesn't match`
- Root cause: `sendToSingle()` passes `--id msg-xxx` to `bd create`, but `GenerateID()` uses a `msg-` prefix that doesn't match any database prefix
- The `--id` passing was introduced in d3649ac3 to fix #2095 (empty IDs from ephemeral SQLite path), but that issue is no longer relevant — bd auto-generates correctly prefixed IDs
- The correct fix was made in 0b091f23 but was lost when PR #2216 merged
- PR #2211 was filed for this same issue but closed prematurely — the bug is still present on main

## Changes
Remove the `--id msg.ID` passing from `sendToSingle()` and let bd auto-generate IDs with the correct database prefix, as the comment on `GenerateID()` already states.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/mail/...` passes
- [x] `gt mail send` works end-to-end (was failing before)
- [x] Messages appear in inbox with correct database-prefixed IDs

🤖 Generated with [Claude Code](https://claude.com/claude-code)