### PR TITLE
feat: pass --config flag to dolt sql-server when config.yaml exists

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1083,18 +1083,25 @@ func Start(townRoot string) error {
 		return err
 	}
 
-	// Start dolt sql-server with --data-dir to serve all databases
-	// Note: --user flag is deprecated in newer Dolt; authentication is handled
-	// via privilege system. Default is root user with no password for localhost.
-	args := []string{"sql-server",
-		"--port", strconv.Itoa(config.Port),
-		"--data-dir", config.DataDir,
-	}
-	if config.MaxConnections > 0 {
-		args = append(args, "--max-connections", strconv.Itoa(config.MaxConnections))
-	}
-	if config.LogLevel != "" {
-		args = append(args, "--loglevel", config.LogLevel)
+	// Start dolt sql-server. If a config.yaml exists in the data directory,
+	// pass --config to enable config-only features like auto_gc_behavior.
+	// When --config is used, all other CLI flags are ignored by dolt, so the
+	// config file must contain the full server configuration.
+	var args []string
+	configPath := filepath.Join(config.DataDir, "config.yaml")
+	if _, err := os.Stat(configPath); err == nil {
+		args = []string{"sql-server", "--config", configPath}
+	} else {
+		args = []string{"sql-server",
+			"--port", strconv.Itoa(config.Port),
+			"--data-dir", config.DataDir,
+		}
+		if config.MaxConnections > 0 {
+			args = append(args, "--max-connections", strconv.Itoa(config.MaxConnections))
+		}
+		if config.LogLevel != "" {
+			args = append(args, "--loglevel", config.LogLevel)
+		}
 	}
 	cmd := exec.Command("dolt", args...)
 	cmd.Stdout = logFile


### PR DESCRIPTION
## Summary
- When a `config.yaml` exists in the Dolt data directory, `gt dolt start` now passes `--config <path>` to `dolt sql-server` instead of individual CLI flags
- Falls back to current CLI-flag behavior when no config.yaml exists
- Enables config-only features like `auto_gc_behavior` which prevents chunk accumulation and CPU spikes under heavy write loads

## Motivation
Running 10+ concurrent agents (polecats) generates heavy write pressure on Dolt. Without `auto_gc_behavior` enabled via config, chunks accumulate rapidly causing CPU to spike to 200-400% and eventually journal corruption. The `auto_gc_behavior` setting is only available via config file, not CLI flags.

## Changes
- `internal/doltserver/doltserver.go`: Modified `Start()` function to check for `config.yaml` in data directory and pass `--config` when found

## Test plan
- [ ] Verify `gt dolt start` uses `--config` when config.yaml exists in data-dir
- [ ] Verify `gt dolt start` falls back to CLI flags when no config.yaml exists
- [ ] Verify `gt dolt stop` still works correctly with config-started server
- [ ] Verify `gt dolt status` reports correctly