### PR TITLE
Fix wisp leak in runDoctorDog

### DIFF
--- a/internal/daemon/doctor_dog.go
+++ b/internal/daemon/doctor_dog.go
@@ -109,6 +109,7 @@ func (d *Daemon) runDoctorDog() {
 		"orphan_threshold":  strconv.Itoa(orphanCount),
 		"backup_threshold":  strconv.FormatFloat(backupStaleSec, 'f', 0, 64) + "s",
 	})
+	defer mol.close()
 
 	if mol.rootID == "" {
 		d.logger.Printf("doctor_dog: molecule pour failed (non-fatal), skipping cycle")


### PR DESCRIPTION
## Summary
- `runDoctorDog()` poured a `mol-dog-doctor` molecule every 5 minutes but never called `mol.close()`, leaking ~4 wisps per cycle (~1000+/day)
- All other patrol functions (`dolt_backup`, `wisp_reaper`, `compactor`, `jsonl_git_backup`) already had `defer mol.close()`
- Added the missing `defer mol.close()` to match the pattern

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/daemon/ -run Doctor` passes
- [x] Deployed locally: confirmed 0 wisp accumulation after daemon restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)