### PR TITLE
feat(guardian): add quality-review as Deacon plugin

### DIFF
--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -21,6 +21,8 @@ Witness                    Refinery                      Git
    │                          │                           │
    │                    (run tests)                       │
    │                          │                           │
+   │                    (quality review, if enabled)      │
+   │                          │                           │
    │                    (if pass)                         │
    │                          │ merge & push              │
    │                          │──────────────────────────>│
@@ -33,7 +35,7 @@ Witness                    Refinery                      Git
 After successful merge, Refinery sends MERGED mail back to Witness so it can
 complete cleanup (nuke the polecat worktree)."""
 formula = "mol-refinery-patrol"
-version = 4
+version = 5
 
 [[steps]]
 id = "inbox-check"
@@ -212,9 +214,87 @@ go test ./...
 Track results: pass count, fail count, specific failures."""
 
 [[steps]]
+id = "quality-review"
+title = "Quality review merge diff"
+needs = ["run-tests"]
+description = """
+Review the merge diff for quality issues. This step is measurement-only (Phase 1):
+reviews are recorded but do NOT gate merges.
+
+**Step 1: Check if quality review is enabled**
+
+If `judgment_enabled` is not `"true"`, skip this step entirely and proceed to
+handle-failures. Log: "Quality review skipped (judgment_enabled=false)"
+
+**Step 2: Get the merge diff**
+
+```bash
+git diff origin/main...temp
+```
+
+If the diff is empty, skip with: "No diff to review"
+
+**Step 3: Review the diff**
+
+Review the diff yourself using your judgment. Assess:
+
+1. **Correctness**: Logic errors, off-by-one, nil/null handling, race conditions
+2. **Security**: Injection, auth bypass, secrets in code, unsafe deserialization
+3. **Clarity**: Naming, structure, comments where non-obvious
+4. **Style**: Consistency with surrounding code, idiomatic patterns
+
+Depth is controlled by `review_depth`:
+- `quick`: Focus on correctness and security only. Skim for obvious issues.
+- `standard`: All four categories. Moderate detail.
+- `deep`: Thorough line-by-line review. Flag even minor style issues.
+
+**Step 4: Score and recommend**
+
+Assign a score from 0.0 to 1.0:
+- 0.9-1.0: Excellent — no issues or only trivial nits
+- 0.7-0.89: Good — minor issues only
+- 0.45-0.69: Needs work — significant issues found
+- 0.0-0.44: Breach — critical issues (security, correctness)
+
+Recommendation:
+- `approve`: Score >= 0.45
+- `request_changes`: Score < 0.45
+
+**Step 5: Record the result as a wisp**
+
+Record the quality review result. This is fail-open: if the command fails,
+log the error and continue — never block the merge.
+
+```bash
+bd create --ephemeral \\
+  -l type:plugin-run \\
+  -l plugin:quality-review-result \\
+  -l worker:<polecat-name> \\
+  -l rig:<rig-name> \\
+  -l score:<score> \\
+  -l recommendation:<approve|request_changes> \\
+  -l result:success \\
+  --description="Score: <score>, <recommendation>. Issues: <count> (<summary>)"
+```
+
+If `bd create` fails:
+- Log the error: "Quality review recording failed: <error>"
+- Continue to handle-failures — do NOT block the merge
+
+**Step 6: Handle breach scores (measurement-only)**
+
+If score < 0.45 (breach threshold):
+- Add a note to your merge summary: "⚠ Quality review breach (score: X.XX)"
+- List the critical/major issues found
+- Do NOT block the merge — Phase 1 is measurement-only
+- Proceed to handle-failures normally
+
+Track: review score, recommendation, issue count, duration."""
+
+[[steps]]
 id = "handle-failures"
 title = "Handle test failures"
-needs = ["run-tests"]
+needs = ["quality-review"]
 description = """
 **VERIFICATION GATE**: This step enforces the Beads Promise.
 
@@ -467,3 +547,13 @@ Next: [any notes for successor]"
 - Successor picks up from your hook
 
 **DO NOT just exit.** Always use `gt handoff` for proper lifecycle."""
+
+[vars]
+
+[vars.judgment_enabled]
+description = "Enable quality review for merges (true/false)"
+default = "false"
+
+[vars.review_depth]
+description = "Review depth: quick, standard, or deep"
+default = "standard"

--- a/plugins/quality-review/plugin.md
+++ b/plugins/quality-review/plugin.md
@@ -1,0 +1,123 @@
++++
+name = "quality-review"
+description = "Review merge quality and track per-worker trends"
+version = 1
+
+[gate]
+type = "cooldown"
+duration = "6h"
+
+[tracking]
+labels = ["plugin:quality-review", "category:quality"]
+digest = true
+
+[execution]
+timeout = "5m"
+notify_on_failure = true
+severity = "medium"
++++
+
+# Quality Review — Trend Analysis
+
+This plugin runs every 6h during Deacon patrol. It analyzes quality-review result
+wisps recorded by the Refinery during merges, computes per-worker trends, and
+alerts on quality breaches.
+
+## Step 1: Query recent quality-review results
+
+Fetch all quality-review result wisps from the last 24 hours:
+
+```bash
+bd list --json --all -l type:plugin-run -l plugin:quality-review-result --created-after=-24h
+```
+
+If no results are found, record a run wisp and stop:
+
+```bash
+bd create --ephemeral \
+  -l type:plugin-run \
+  -l plugin:quality-review \
+  -l result:success \
+  --description="No quality-review results in last 24h. Nothing to analyze."
+```
+
+## Step 2: Compute per-worker trends
+
+Parse the wisp labels to extract per-worker data. Each result wisp has labels:
+- `worker:<polecat-name>`
+- `rig:<rig-name>`
+- `score:<0.0-1.0>`
+- `recommendation:<approve|request_changes>`
+
+For each worker, compute:
+- **Average score** across all results in window
+- **Rejection rate**: count of `recommendation:request_changes` / total
+- **Trend direction**: Compare first-half avg vs second-half avg of the window
+  - Difference > 0.05: `improving`
+  - Difference < -0.05: `declining`
+  - Otherwise: `stable`
+
+## Step 3: Classify worker status
+
+Apply thresholds to each worker's average score:
+- **OK**: avg >= 0.60
+- **WARN**: 0.45 <= avg < 0.60
+- **BREACH**: avg < 0.45
+
+## Step 4: Alert on breaches
+
+For each worker in BREACH status, send an alert:
+
+```bash
+gt mail send mayor/ -s "Quality BREACH: <worker>" -m "Worker: <worker>
+Rig: <rig>
+Avg Score: <avg>
+Reviews: <count>
+Rejection Rate: <rate>%
+Trend: <improving|stable|declining>
+
+Action: Review recent merges from this worker for quality issues."
+```
+
+## Step 5: Record run result
+
+Record a summary wisp for this plugin run:
+
+```bash
+bd create --ephemeral \
+  -l type:plugin-run \
+  -l plugin:quality-review \
+  -l result:success \
+  --description="Analyzed <N> workers over <M> reviews. <B> breaches, <W> warnings."
+```
+
+If any step fails unexpectedly, record a failure wisp instead:
+
+```bash
+bd create --ephemeral \
+  -l type:plugin-run \
+  -l plugin:quality-review \
+  -l result:failure \
+  --description="<error description>"
+```
+
+---
+
+## How scores get recorded (reference)
+
+This plugin does NOT record scores itself. The Refinery records result wisps during
+merges via the `quality-review` formula step. Each merge produces a wisp like:
+
+```bash
+bd create --ephemeral \
+  -l type:plugin-run \
+  -l plugin:quality-review-result \
+  -l worker:<polecat-name> \
+  -l rig:<rig-name> \
+  -l score:<0.0-1.0> \
+  -l recommendation:<approve|request_changes> \
+  -l result:success \
+  --description="Score: 0.85, approve. Issues: 1 minor (style)"
+```
+
+This creates the data that Step 1 queries.


### PR DESCRIPTION
## Summary

- Replaces the Go-based Guardian persistence layer (PRs #2167–#2169, now closed) with a wisp-based Deacon plugin approach per Steve's review feedback
- Adds `plugins/quality-review/plugin.md` — town-level Deacon plugin that runs every 6h, queries quality-review-result wisps, computes per-worker trends, and alerts mayor on quality breaches
- Updates `mol-refinery-patrol` formula (v4→v5) with a `quality-review` step between `run-tests` and `handle-failures` that records results as wisps via `bd create --ephemeral`
- Adds `judgment_enabled` (default `"false"`) and `review_depth` (default `"standard"`) formula variables for per-rig opt-in

No Go code changes. No new packages, CLIs, config types, or event types. Phase 1 measurement-only (does not gate merges).

## Test plan

- [x] `go build ./...` passes (no Go changes besides formula TOML)
- [x] `go test ./internal/formula/...` passes (formula parses correctly)
- [ ] `gt plugin list` discovers quality-review plugin
- [ ] `gt plugin show quality-review` displays plugin details
- [ ] Refinery records result wisps when `judgment_enabled=true`
- [ ] Deacon plugin queries wisps and computes trends correctly

🤖 Generated with [Claude Code](https://claude.ai/code)