### PR TITLE
fix(doctor): priming Fix() follows beads redirects for missing_prime_md

### DIFF
--- a/internal/doctor/priming_check.go
+++ b/internal/doctor/priming_check.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
-	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/runtime"
 )
 
@@ -440,22 +439,10 @@ func (c *PrimingCheck) Fix(ctx *CheckContext) error {
 				errors = append(errors, fmt.Sprintf("%s: failed to remove orphaned .beads: %v", issue.location, err))
 			}
 		case "missing_prime_md":
-			// Provision PRIME.md at the appropriate location
-			var targetPath string
-
-			// Parse the location to determine where to provision
-			if strings.Contains(issue.location, "/crew/") || strings.Contains(issue.location, "/polecats/") {
-				// Worker location - use beads.ProvisionPrimeMDForWorktree
-				worktreePath := filepath.Join(ctx.TownRoot, issue.location)
-				if err := beads.ProvisionPrimeMDForWorktree(worktreePath); err != nil {
-					errors = append(errors, fmt.Sprintf("%s: %v", issue.location, err))
-				}
-			} else {
-				// Rig location - provision directly
-				targetPath = filepath.Join(ctx.TownRoot, issue.location, constants.DirBeads)
-				if err := beads.ProvisionPrimeMD(targetPath); err != nil {
-					errors = append(errors, fmt.Sprintf("%s: %v", issue.location, err))
-				}
+			// Provision PRIME.md at the appropriate location, following any beads redirect.
+			worktreePath := filepath.Join(ctx.TownRoot, issue.location)
+			if err := beads.ProvisionPrimeMDForWorktree(worktreePath); err != nil {
+				errors = append(errors, fmt.Sprintf("%s: %v", issue.location, err))
 			}
 
 		case "stale_intermediate_instructions_md":


### PR DESCRIPTION
## Summary

- `gt doctor --fix` could not fix missing PRIME.md for rigs using `.beads/redirect` — the fix kept silently succeeding while the check kept failing
- Replaced the rig-vs-worker branching logic with a single `beads.ProvisionPrimeMDForWorktree()` call that correctly follows redirects for all locations

## Root Cause

PR #1433 (commit d7a6d526) fixed the `Run()` method to follow beads redirects via `beads.ResolveBeadsDir()`, but the `Fix()` method was not updated. It still provisioned at the unresolved path (e.g., `venft/.beads/`), where PRIME.md already existed. The redirect target (`venft/mayor/rig/.beads/`) never received the file.

`ProvisionPrimeMDForWorktree()` already handles redirect resolution and works for all location types (rigs, crew, polecats), so the separate if/else was unnecessary.

## Related
- Fixes #2265 (regression from #1428 / PR #1433)

**Note on branch name**: CONTRIBUTING.md recommends `fix/*` branches, but gastown's pre-push hook blocks that pattern. Using `polecat/fix-priming-redirects` as a workaround. See #2265 or a follow-up issue for suggested clarification of the intended convention — should the hook allowlist `fix/*`, or should CONTRIBUTING.md be updated to reflect the actual allowed patterns?

## Files Changed
- `internal/doctor/priming_check.go` — simplify Fix() missing_prime_md case, remove unused `constants` import

## Test plan
- [x] `go build ./internal/doctor/...` — compiles cleanly
- [x] `go test ./internal/doctor/...` — all tests pass
- [x] `go test ./...` — full suite run; 3 failures are pre-existing on main (`TestCrossPlatformBuild/windows_amd64`, `TestAddRig_UpstreamURL` requires Dolt, `TestFindAgentPane_MultiPaneNoAgent` flaky tmux env test)
- [x] Verified fix against a rig (venft) where `.beads/redirect` → `mayor/rig/.beads/`