### PR TITLE
fix: use -i for copilot interactive prompt

### DIFF
--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -206,16 +206,16 @@ func TestRigSettingsWithCustomMergeQueue(t *testing.T) {
 		Type:    "rig-settings",
 		Version: 1,
 		MergeQueue: &MergeQueueConfig{
-			Enabled:              true,
+			Enabled:                          true,
 			IntegrationBranchPolecatEnabled:  boolPtr(false),
 			IntegrationBranchRefineryEnabled: boolPtr(false),
-			OnConflict:           OnConflictAutoRebase,
-			RunTests:             boolPtr(true),
-			TestCommand:          "make test",
-			DeleteMergedBranches: boolPtr(false),
-			RetryFlakyTests:      3,
-			PollInterval:         "1m",
-			MaxConcurrent:        2,
+			OnConflict:                       OnConflictAutoRebase,
+			RunTests:                         boolPtr(true),
+			TestCommand:                      "make test",
+			DeleteMergedBranches:             boolPtr(false),
+			RetryFlakyTests:                  3,
+			PollInterval:                     "1m",
+			MaxConcurrent:                    2,
 		},
 	}
 
@@ -974,6 +974,13 @@ func TestRuntimeConfigBuildCommandWithPrompt(t *testing.T) {
 			rc:           &RuntimeConfig{Command: "aider", Args: []string{}, InitialPrompt: "/help"},
 			prompt:       "custom prompt",
 			wantContains: []string{"aider", `"custom prompt"`},
+			isClaudeCmd:  false,
+		},
+		{
+			name:         "copilot uses -i flag for prompt",
+			rc:           &RuntimeConfig{Command: "copilot", Args: []string{"--yolo"}, PromptMode: "arg"},
+			prompt:       "test prompt",
+			wantContains: []string{"copilot", "--yolo", "-i", `"test prompt"`},
 			isClaudeCmd:  false,
 		},
 	}
@@ -4541,11 +4548,11 @@ func TestMergeQueueConfig_PartialJSON_BoolDefaults(t *testing.T) {
 		name string
 		json string
 		// Expected accessor results when *bool fields are omitted (nil)
-		wantRunTests               bool
-		wantDeleteMerged           bool
-		wantPolecatIntegration     bool
-		wantRefineryIntegration    bool
-		wantAutoLand               bool
+		wantRunTests            bool
+		wantDeleteMerged        bool
+		wantPolecatIntegration  bool
+		wantRefineryIntegration bool
+		wantAutoLand            bool
 	}{
 		{
 			name: "minimal config — all *bool fields omitted",

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -753,6 +753,11 @@ func (rc *RuntimeConfig) BuildCommandWithPrompt(prompt string) string {
 		return base + " --prompt " + quoteForShell(p)
 	}
 
+	// Copilot  requires -i flag for initial prompt in interactive mode.
+	if resolved.Command == "copilot" {
+		return base + " -i " + quoteForShell(p)
+	}
+
 	// Quote the prompt for shell safety (positional arg for claude and others)
 	return base + " " + quoteForShell(p)
 }
@@ -773,7 +778,6 @@ func (rc *RuntimeConfig) BuildArgsWithPrompt(prompt string) []string {
 
 	return args
 }
-
 
 func normalizeRuntimeConfig(rc *RuntimeConfig) *RuntimeConfig {
 	if rc == nil {
@@ -1199,7 +1203,7 @@ func DefaultMergeQueueConfig() *MergeQueueConfig {
 		RetryFlakyTests:                  1,
 		PollInterval:                     "30s",
 		MaxConcurrent:                    1,
-		StaleClaimTimeout:               "30m",
+		StaleClaimTimeout:                "30m",
 	}
 }
 
@@ -1256,7 +1260,7 @@ func DefaultAccountsConfigDir() (string, error) {
 // QuotaState represents the quota management state (mayor/quota.json).
 // Tracks which accounts are rate-limited and when they were last rotated.
 type QuotaState struct {
-	Version  int                         `json:"version"`  // schema version
+	Version  int                          `json:"version"`  // schema version
 	Accounts map[string]AccountQuotaState `json:"accounts"` // handle -> quota state
 }
 
@@ -1276,7 +1280,7 @@ const (
 
 // AccountQuotaState tracks the quota status of a single account.
 type AccountQuotaState struct {
-	Status    AccountQuotaStatus `json:"status"`              // current status
+	Status    AccountQuotaStatus `json:"status"`               // current status
 	LimitedAt string             `json:"limited_at,omitempty"` // RFC3339 when limit was detected
 	ResetsAt  string             `json:"resets_at,omitempty"`  // Human-readable reset time from provider (e.g. "7pm (America/Los_Angeles)")
 	LastUsed  string             `json:"last_used,omitempty"`  // RFC3339 when account was last assigned to a session


### PR DESCRIPTION
## Summary
Fix prompt argument handling for the `copilot` runtime command so interactive prompts are passed with `-i`.

## Problem
`BuildCommandWithPrompt` previously appended prompt text as a positional argument for non-`claude`/`aider` commands. For `copilot`, this is incorrect for interactive usage and can cause prompt input to be handled improperly.

## Changes
- Updated `RuntimeConfig.BuildCommandWithPrompt` in `internal/config/types.go`:
  - When `resolved.Command == "copilot"`, the command now appends `-i <prompt>`.
- Added test coverage in `internal/config/loader_test.go`:
  - New case validates generated command contains `copilot`, existing args, and `-i "<prompt>"`.

## Behavior Impact
- Affects only the `copilot` command path in prompt-building logic.
- No intended behavior changes for `claude`, `aider`, or other command configurations.

## Validation
- Unit test updated to assert the copilot-specific prompt flag behavior.
- Additional full-suite test execution was not run in this session.
