### PR TITLE
fix: warn when deprecated merge_queue.target_branch is in rig config

### DIFF
--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -767,7 +767,27 @@ func LoadRigConfig(rigPath string) (*RigConfig, error) {
 	if err := json.Unmarshal(data, &cfg); err != nil {
 		return nil, err
 	}
+	warnDeprecatedRigConfigKeys(data, configPath)
 	return &cfg, nil
+}
+
+// warnDeprecatedRigConfigKeys detects merge_queue keys in rig root config.json
+// that are silently ignored by json.Unmarshal (RigConfig has no merge_queue field).
+// Without this warning, users can set merge_queue.target_branch believing it
+// controls MR targets, while gt mq submit / gt done actually use default_branch.
+func warnDeprecatedRigConfigKeys(data []byte, path string) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return
+	}
+	if mq, ok := raw["merge_queue"]; ok {
+		var mqMap map[string]json.RawMessage
+		if json.Unmarshal(mq, &mqMap) == nil {
+			if _, has := mqMap["target_branch"]; has {
+				fmt.Fprintf(os.Stderr, "WARNING: %s: merge_queue.target_branch is deprecated and ignored — set default_branch instead\n", path)
+			}
+		}
+	}
 }
 
 // InitBeads initializes the beads database at rig level.


### PR DESCRIPTION
## Summary

Fixes #2267.

`LoadRigConfig` silently discards `merge_queue` keys because `RigConfig` has no such field. Users who set `merge_queue.target_branch` in their rig's `config.json` believe it controls MR targets, but `gt mq submit` and `gt done` actually use `default_branch` — leading to MRs merging to the wrong branch with no warning.

The existing `warnDeprecatedMergeQueueKeys` in `config/loader.go` only covers `settings/config.json`. This adds a parallel check in `LoadRigConfig` for the rig root `config.json`, where the misconfiguration is more likely to occur.

## Changes

- **`internal/rig/manager.go`**: Add `warnDeprecatedRigConfigKeys` — after unmarshaling, check the raw JSON for `merge_queue.target_branch` and print a `WARNING` to stderr directing the user to set `default_branch` instead.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/rig/...` passes
- [x] Verified: rig `config.json` with `merge_queue.target_branch` now prints `WARNING: ... merge_queue.target_branch is deprecated and ignored — set default_branch instead`