### PR TITLE
fix(daemon): gate refinery spawn on pending events

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1022,6 +1022,23 @@ func (d *Daemon) ensureWitnessesRunning() {
 	}
 }
 
+// hasPendingEvents checks if there are pending .event files in the given channel directory.
+// Used to gate agent spawning: don't burn API credits starting a Claude session when
+// there's nothing to process. The agent's await-event handles the actual consumption.
+func (d *Daemon) hasPendingEvents(channel string) bool {
+	eventDir := filepath.Join(d.config.TownRoot, "events", channel)
+	entries, err := os.ReadDir(eventDir)
+	if err != nil {
+		return false // Directory doesn't exist or unreadable = no pending events
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() && strings.HasSuffix(entry.Name(), ".event") {
+			return true
+		}
+	}
+	return false
+}
+
 // ensureWitnessRunning ensures the witness for a specific rig is running.
 // Discover, don't track: uses Manager.Start() which checks tmux directly (gt-zecmc).
 func (d *Daemon) ensureWitnessRunning(rigName string) {
@@ -1081,6 +1098,23 @@ func (d *Daemon) ensureRefineryRunning(rigName string) {
 	if operational, reason := d.isRigOperational(rigName); !operational {
 		d.logger.Printf("Skipping refinery auto-start for %s: %s", rigName, reason)
 		return
+	}
+
+	// Event gate: don't spawn a new Claude session when there's nothing to process.
+	// If a refinery session is already running, Start() returns ErrAlreadyRunning (cheap).
+	// But spawning a NEW session with an empty queue burns API credits for nothing.
+	// The refinery formula uses await-event internally, so it will wake when events appear.
+	if !d.hasPendingEvents("refinery") {
+		// Check if session already exists before skipping — let running sessions continue
+		r := &rig.Rig{
+			Name: rigName,
+			Path: filepath.Join(d.config.TownRoot, rigName),
+		}
+		mgr := refinery.NewManager(r)
+		if running, _ := mgr.IsRunning(); !running {
+			d.logger.Printf("No pending refinery events and no session running for %s, skipping spawn", rigName)
+			return
+		}
 	}
 
 	// Manager.Start() handles: zombie detection, session creation, env vars, theming,

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -402,3 +402,66 @@ func TestDaemon_StopsManagerAndScanner(t *testing.T) {
 		t.Fatal("Stop() did not complete within 5s")
 	}
 }
+
+func TestHasPendingEvents_EmptyDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	eventDir := filepath.Join(tmpDir, "events", "refinery")
+	if err := os.MkdirAll(eventDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	d := &Daemon{config: &Config{TownRoot: tmpDir}}
+
+	if d.hasPendingEvents("refinery") {
+		t.Error("expected false for empty event directory")
+	}
+}
+
+func TestHasPendingEvents_MissingDir(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	d := &Daemon{config: &Config{TownRoot: tmpDir}}
+
+	if d.hasPendingEvents("refinery") {
+		t.Error("expected false when event directory doesn't exist")
+	}
+}
+
+func TestHasPendingEvents_WithEventFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	eventDir := filepath.Join(tmpDir, "events", "refinery")
+	if err := os.MkdirAll(eventDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create an event file
+	eventFile := filepath.Join(eventDir, "1234567890-1-12345.event")
+	if err := os.WriteFile(eventFile, []byte(`{"type":"MQ_SUBMIT"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	d := &Daemon{config: &Config{TownRoot: tmpDir}}
+
+	if !d.hasPendingEvents("refinery") {
+		t.Error("expected true when .event files exist")
+	}
+}
+
+func TestHasPendingEvents_IgnoresNonEventFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	eventDir := filepath.Join(tmpDir, "events", "refinery")
+	if err := os.MkdirAll(eventDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a non-event file (e.g., .tmp or .lock)
+	if err := os.WriteFile(filepath.Join(eventDir, "temp.lock"), []byte{}, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	d := &Daemon{config: &Config{TownRoot: tmpDir}}
+
+	if d.hasPendingEvents("refinery") {
+		t.Error("expected false when only non-.event files exist")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `hasPendingEvents(channel)` helper that checks `events/<channel>/` for `.event` files (pure Go `os.ReadDir`, zero API cost)
- Gates `ensureRefineryRunning()`: skips spawning a new Claude session when the event directory is empty AND no session is already running
- Running sessions continue undisturbed—`Start()` returns `ErrAlreadyRunning` as before

## Problem

The daemon heartbeat (every 3min) unconditionally spawns refinery Claude sessions. Each empty session burns API credits polling an empty merge queue via exponential backoff before exiting. The rafter refinery burned 39 empty cycles before hitting the credit limit.

## Approach

The event infrastructure already exists (`emit-event`, `await-event`, `nudgeRefinery`). The fix is a ~35-line gate in the daemon: check if `events/refinery/` has pending `.event` files before spawning. If no events and no running session, skip the spawn entirely.

- **Idle**: 0 refinery sessions spawned (was ~12/hour across 3 rigs)
- **Active**: 1 session per event batch, same as before
- **Safety net**: 3-minute heartbeat still runs hung-session detection on already-running sessions

## Test plan

- [x] Unit test: empty event dir → `hasPendingEvents` returns false
- [x] Unit test: missing event dir → returns false
- [x] Unit test: dir with `.event` files → returns true
- [x] Unit test: non-`.event` files ignored
- [x] Full daemon test suite passes (128 tests, 0 failures)

🤖 Generated with [Claude Code](https://claude.com/claude-code)