### PR TITLE
fix(convoy): add EnsureCustomStatuses and doctor check

### DIFF
--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -20,6 +20,9 @@ import (
 // This persists across CLI invocations to avoid redundant bd config calls.
 const typesSentinel = ".gt-types-configured"
 
+// statusesSentinel is a marker file indicating custom statuses have been configured.
+const statusesSentinel = ".gt-statuses-configured"
+
 // ensuredDirs tracks which beads directories have been ensured this session.
 // This provides fast in-memory caching for multiple creates in the same CLI run.
 var (
@@ -146,6 +149,87 @@ func EnsureCustomTypes(beadsDir string) error {
 	_ = os.WriteFile(sentinelPath, []byte(typesList+"\n"), 0644)
 
 	ensuredDirs[beadsDir] = true
+	return nil
+}
+
+// EnsureCustomStatuses ensures the target beads directory has custom statuses configured.
+// Uses the same two-level caching strategy as EnsureCustomTypes:
+//   - In-memory cache for multiple operations in the same CLI invocation
+//   - Sentinel file on disk for persistence across CLI invocations
+//
+// This function is thread-safe and idempotent.
+func EnsureCustomStatuses(beadsDir string) error {
+	if beadsDir == "" {
+		return fmt.Errorf("empty beads directory")
+	}
+
+	statusesList := strings.Join(constants.BeadsCustomStatusesList(), ",")
+
+	ensuredMu.Lock()
+	defer ensuredMu.Unlock()
+
+	cacheKey := beadsDir + ":statuses"
+
+	// Fast path: in-memory cache (same CLI invocation)
+	if ensuredDirs[cacheKey] {
+		return nil
+	}
+
+	// Fast path: sentinel file matches current statuses list
+	sentinelPath := filepath.Join(beadsDir, statusesSentinel)
+	if data, err := os.ReadFile(sentinelPath); err == nil {
+		if strings.TrimSpace(string(data)) == statusesList {
+			ensuredDirs[cacheKey] = true
+			return nil
+		}
+		// Sentinel exists but is stale — fall through to re-configure
+	}
+
+	// Verify beads directory exists
+	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
+		return fmt.Errorf("beads directory does not exist: %s", beadsDir)
+	}
+
+	// Read current custom statuses and merge with required ones
+	getCmd := exec.Command("bd", "config", "get", "status.custom")
+	getCmd.Dir = beadsDir
+	getCmd.Env = append(stripEnvPrefixes(os.Environ(), "BEADS_DIR="), "BEADS_DIR="+beadsDir)
+	existingOutput, _ := getCmd.Output()
+
+	// Build merged set: existing + required
+	statusSet := make(map[string]bool)
+	if existing := strings.TrimSpace(string(existingOutput)); existing != "" {
+		for _, s := range strings.Split(existing, ",") {
+			s = strings.TrimSpace(s)
+			if s != "" {
+				statusSet[s] = true
+			}
+		}
+	}
+	for _, s := range constants.BeadsCustomStatusesList() {
+		statusSet[s] = true
+	}
+
+	// Build merged list
+	var merged []string
+	for s := range statusSet {
+		merged = append(merged, s)
+	}
+	mergedStr := strings.Join(merged, ",")
+
+	// Configure custom statuses via bd CLI
+	cmd := exec.Command("bd", "config", "set", "status.custom", mergedStr)
+	cmd.Dir = beadsDir
+	cmd.Env = append(stripEnvPrefixes(os.Environ(), "BEADS_DIR="), "BEADS_DIR="+beadsDir)
+	if output, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("configure custom statuses in %s: %s: %w",
+			beadsDir, strings.TrimSpace(string(output)), err)
+	}
+
+	// Write sentinel file
+	_ = os.WriteFile(sentinelPath, []byte(statusesList+"\n"), 0644)
+
+	ensuredDirs[cacheKey] = true
 	return nil
 }
 

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -478,6 +478,11 @@ func runConvoyCreate(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("ensuring custom types: %w", err)
 	}
 
+	// Ensure custom statuses (staged_ready, staged_warnings) are registered.
+	if err := beads.EnsureCustomStatuses(townBeads); err != nil {
+		return fmt.Errorf("ensuring custom statuses: %w", err)
+	}
+
 	// Create convoy issue in town beads
 	description := fmt.Sprintf("Convoy tracking %d issues", len(trackedIssues))
 

--- a/internal/cmd/convoy_stage.go
+++ b/internal/cmd/convoy_stage.go
@@ -653,6 +653,11 @@ func createStagedConvoy(dag *ConvoyDAG, waves []Wave, status string, title strin
 		return "", fmt.Errorf("ensuring custom types: %w", err)
 	}
 
+	// Ensure custom statuses (staged_ready, staged_warnings) are registered.
+	if err := beads.EnsureCustomStatuses(townBeads); err != nil {
+		return "", fmt.Errorf("ensuring custom statuses: %w", err)
+	}
+
 	// Generate convoy ID.
 	convoyID := fmt.Sprintf("hq-cv-%s", generateShortID())
 

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -175,6 +175,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewBootHealthCheck())
 	d.Register(doctor.NewTownBeadsConfigCheck())
 	d.Register(doctor.NewCustomTypesCheck())
+	d.Register(doctor.NewCustomStatusesCheck())
 	d.Register(doctor.NewRoleLabelCheck())
 	d.Register(doctor.NewFormulaCheck())
 	d.Register(doctor.NewPrefixConflictCheck())

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -131,6 +131,7 @@ func upgradeDoctor(townRoot string) upgradeResult {
 	d.Register(doctor.NewDaemonCheck())
 	d.Register(doctor.NewTownBeadsConfigCheck())
 	d.Register(doctor.NewCustomTypesCheck())
+	d.Register(doctor.NewCustomStatusesCheck())
 	d.Register(doctor.NewRoleLabelCheck())
 	d.Register(doctor.NewFormulaCheck())
 	d.Register(doctor.NewPrefixConflictCheck())

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -169,6 +169,23 @@ func BeadsCustomTypesList() []string {
 	return []string{"agent", "role", "rig", "convoy", "slot", "queue", "event", "message", "molecule", "gate", "merge-request"}
 }
 
+// Beads custom status configuration constants.
+const (
+	// BeadsCustomStatuses is the comma-separated list of custom issue statuses
+	// that Gas Town registers with beads. Convoy staging uses staged_ready and
+	// staged_warnings to track convoy readiness before launch.
+	//
+	// Status origins:
+	//   staged_ready    - Convoy staged with no warnings (ready to launch)
+	//   staged_warnings - Convoy staged with warnings (requires --force to launch)
+	BeadsCustomStatuses = "staged_ready,staged_warnings"
+)
+
+// BeadsCustomStatusesList returns the custom statuses as a slice.
+func BeadsCustomStatusesList() []string {
+	return []string{"staged_ready", "staged_warnings"}
+}
+
 // Git branch names.
 const (
 	// BranchMain is the default main branch name.

--- a/internal/doctor/config_check.go
+++ b/internal/doctor/config_check.go
@@ -725,3 +725,133 @@ func (c *CustomTypesCheck) Fix(ctx *CheckContext) error {
 	}
 	return nil
 }
+
+// CustomStatusesCheck verifies Gas Town custom statuses are registered with beads.
+type CustomStatusesCheck struct {
+	FixableCheck
+	missingStatuses []string // Cached during Run for use in Fix
+	townRoot        string   // Cached during Run for use in Fix
+}
+
+// NewCustomStatusesCheck creates a new custom statuses check.
+func NewCustomStatusesCheck() *CustomStatusesCheck {
+	return &CustomStatusesCheck{
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "beads-custom-statuses",
+				CheckDescription: "Check that Gas Town custom statuses are registered with beads",
+				CheckCategory:    CategoryConfig,
+			},
+		},
+	}
+}
+
+// Run checks if custom statuses are properly configured.
+func (c *CustomStatusesCheck) Run(ctx *CheckContext) *CheckResult {
+	if _, err := exec.LookPath("bd"); err != nil {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "beads not installed (skipped)",
+		}
+	}
+
+	townBeadsDir := filepath.Join(ctx.TownRoot, ".beads")
+	if _, err := os.Stat(townBeadsDir); os.IsNotExist(err) {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "No beads database (skipped)",
+		}
+	}
+
+	// Get current custom statuses configuration
+	cmd := exec.Command("bd", "config", "get", "status.custom")
+	cmd.Dir = ctx.TownRoot
+	output, err := cmd.Output()
+	if err != nil {
+		c.townRoot = ctx.TownRoot
+		c.missingStatuses = constants.BeadsCustomStatusesList()
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: "Custom statuses not configured",
+			Details: []string{
+				"Gas Town custom statuses (staged_ready, staged_warnings) are not registered",
+				"Convoy staging will fail without these statuses",
+			},
+			FixHint: "Run 'gt doctor --fix' or 'bd config set status.custom \"" + constants.BeadsCustomStatuses + "\"'",
+		}
+	}
+
+	configuredStatuses := parseConfigOutput(output)
+	configuredSet := make(map[string]bool)
+	for _, s := range strings.Split(configuredStatuses, ",") {
+		configuredSet[strings.TrimSpace(s)] = true
+	}
+
+	var missing []string
+	for _, required := range constants.BeadsCustomStatusesList() {
+		if !configuredSet[required] {
+			missing = append(missing, required)
+		}
+	}
+
+	if len(missing) == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "All custom statuses registered",
+		}
+	}
+
+	c.townRoot = ctx.TownRoot
+	c.missingStatuses = missing
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusWarning,
+		Message: fmt.Sprintf("%d custom status(es) missing", len(missing)),
+		Details: []string{
+			fmt.Sprintf("Missing statuses: %s", strings.Join(missing, ", ")),
+			fmt.Sprintf("Configured: %s", configuredStatuses),
+			fmt.Sprintf("Required: %s", constants.BeadsCustomStatuses),
+		},
+		FixHint: "Run 'gt doctor --fix' to register missing statuses",
+	}
+}
+
+// Fix registers the missing custom statuses by merging with existing ones.
+func (c *CustomStatusesCheck) Fix(ctx *CheckContext) error {
+	// Read existing statuses
+	getCmd := exec.Command("bd", "config", "get", "status.custom")
+	getCmd.Dir = c.townRoot
+	existingOutput, _ := getCmd.Output()
+
+	// Build merged set
+	statusSet := make(map[string]bool)
+	if existing := strings.TrimSpace(string(existingOutput)); existing != "" {
+		for _, s := range strings.Split(parseConfigOutput(existingOutput), ",") {
+			s = strings.TrimSpace(s)
+			if s != "" {
+				statusSet[s] = true
+			}
+		}
+	}
+	for _, s := range constants.BeadsCustomStatusesList() {
+		statusSet[s] = true
+	}
+
+	var merged []string
+	for s := range statusSet {
+		merged = append(merged, s)
+	}
+
+	cmd := exec.Command("bd", "config", "set", "status.custom", strings.Join(merged, ","))
+	cmd.Dir = c.townRoot
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("bd config set status.custom: %s", strings.TrimSpace(string(output)))
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary
- Convoy staging requires `staged_ready` and `staged_warnings` as valid beads statuses, but these were never auto-configured via `bd config set status.custom`
- Added `BeadsCustomStatuses` constant and `EnsureCustomStatuses()` function (mirrors existing `EnsureCustomTypes` pattern with sentinel file caching)
- Added `CustomStatusesCheck` doctor check with `--fix` support
- `EnsureCustomStatuses` is called alongside `EnsureCustomTypes` in `convoy_stage.go` and `convoy.go`
- Registered the doctor check in both `doctor.go` and `upgrade.go`

## Test plan
- [x] `gt doctor` detects missing `staged_ready` status
- [x] `gt doctor --fix` adds it and reports fixed
- [x] `gt convoy stage` succeeds after fix
- [x] `make install` builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)