### PR TITLE
fix: make setupSharedBeads fatal — MR beads invisible to Refinery without redirect

### DIFF
--- a/internal/beads/beads_redirect.go
+++ b/internal/beads/beads_redirect.go
@@ -317,3 +317,13 @@ func SetupRedirect(townRoot, worktreePath string) error {
 
 	return nil
 }
+
+// IsLocalBeadsDir returns true if resolvedPath is the cwd's own .beads/ directory
+// (i.e., no redirect was followed). This indicates the beads client will write to
+// a local database that other agents (e.g., the Refinery) will never read.
+func IsLocalBeadsDir(cwd, resolvedPath string) bool {
+	localBeads := filepath.Join(cwd, ".beads")
+	cleanResolved, _ := filepath.Abs(resolvedPath)
+	cleanLocal, _ := filepath.Abs(localBeads)
+	return cleanResolved == cleanLocal
+}

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -624,8 +624,14 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			return fmt.Errorf("cannot determine source issue from branch '%s'; use --issue to specify", branch)
 		}
 
-		// Initialize beads
-		bd := beads.New(beads.ResolveBeadsDir(cwd))
+		// Initialize beads — warn if resolved to a local .beads/ (no redirect).
+		// Without a redirect, MR beads are invisible to the Refinery.
+		resolvedBeads := beads.ResolveBeadsDir(cwd)
+		if beads.IsLocalBeadsDir(cwd, resolvedBeads) {
+			fmt.Fprintf(os.Stderr, "WARNING: beads resolved to local dir %s (no shared-beads redirect)\n", resolvedBeads)
+			fmt.Fprintf(os.Stderr, "  MR beads written here will be invisible to the Refinery — run 'gt polecat repair' to fix\n")
+		}
+		bd := beads.New(resolvedBeads)
 
 		// Check for no_merge flag - if set, skip merge queue and notify for review
 		sourceIssueForNoMerge, err := bd.Show(issueID)

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -753,7 +753,8 @@ func (m *Manager) addWithOptionsLocked(name string, opts AddOptions, polecatDir 
 	worktreeCreated = true
 
 	if err := m.setupSharedBeads(clonePath); err != nil {
-		style.PrintWarning("could not set up shared beads: %v", err)
+		cleanupOnError()
+		return nil, fmt.Errorf("setting up shared beads: %w (polecat cannot submit MRs without shared beads)", err)
 	}
 
 	if err := beads.ProvisionPrimeMDForWorktree(clonePath); err != nil {
@@ -922,10 +923,11 @@ func (m *Manager) AddWithOptions(name string, opts AddOptions) (_ *Polecat, retE
 
 	// Set up shared beads: polecat uses rig's .beads via redirect file.
 	// This eliminates git sync overhead - all polecats share one database.
+	// Fatal: without shared beads, gt done writes MR beads to a local .beads/
+	// that the Refinery never reads, causing the merge queue to stay empty.
 	if err := m.setupSharedBeads(clonePath); err != nil {
-		// Non-fatal - polecat can still work with local beads
-		// Log warning but don't fail the spawn
-		style.PrintWarning("could not set up shared beads: %v", err)
+		cleanupOnError()
+		return nil, fmt.Errorf("setting up shared beads: %w (polecat cannot submit MRs without shared beads)", err)
 	}
 
 	// Provision PRIME.md with Gas Town context for this worker.
@@ -1432,9 +1434,11 @@ func (m *Manager) RepairWorktreeWithOptions(name string, force bool, opts AddOpt
 	// Only ~/gt/CLAUDE.md (town-root identity anchor) exists on disk.
 	// Full context is injected ephemerally via SessionStart hook (gt prime).
 
-	// Set up shared beads
+	// Set up shared beads — fatal during repair too, same reason as spawn.
 	if err := m.setupSharedBeads(newClonePath); err != nil {
-		style.PrintWarning("could not set up shared beads: %v", err)
+		_ = repoGit.WorktreeRemove(newClonePath, true)
+		_ = os.RemoveAll(newClonePath)
+		return nil, fmt.Errorf("setting up shared beads after repair: %w (polecat cannot submit MRs without shared beads)", err)
 	}
 
 	// Copy overlay files from .runtime/overlay/ to polecat root.

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -403,6 +403,20 @@ func TestAddWithOptions_HasAgentsMD(t *testing.T) {
 		t.Fatalf("git update-ref: %v\n%s", err, out)
 	}
 
+	// Create rig-level .beads directory with redirect to mayor/rig/.beads
+	rigBeads := filepath.Join(root, ".beads")
+	if err := os.MkdirAll(rigBeads, 0755); err != nil {
+		t.Fatalf("mkdir rig .beads: %v", err)
+	}
+	mayorBeads := filepath.Join(mayorRig, ".beads")
+	if err := os.MkdirAll(mayorBeads, 0755); err != nil {
+		t.Fatalf("mkdir mayor/rig/.beads: %v", err)
+	}
+	rigRedirect := filepath.Join(rigBeads, "redirect")
+	if err := os.WriteFile(rigRedirect, []byte("mayor/rig/.beads\n"), 0644); err != nil {
+		t.Fatalf("write rig redirect: %v", err)
+	}
+
 	// Create rig pointing to root
 	r := &rig.Rig{
 		Name: "rig",


### PR DESCRIPTION
## Summary

Fixes #2281.

When `setupSharedBeads` fails during polecat spawn, the polecat writes MR beads to a local `.beads/` that the Refinery never reads, causing `gt mq list` to stay empty despite branches being pushed.

## Changes

- **`internal/polecat/manager.go`**: Make `setupSharedBeads` failure fatal in all 3 call sites (two Add paths + RepairWorktree). A polecat without shared beads is broken for the MQ workflow.
- **`internal/cmd/done.go`**: Defense-in-depth — warn if `ResolveBeadsDir` falls back to local `.beads/` (no redirect).
- **`internal/beads/beads_redirect.go`**: Add `IsLocalBeadsDir()` helper for the done.go check.
- **`internal/polecat/manager_test.go`**: Update `TestAddWithOptions_HasAgentsMD` to include beads fixture (now required).

## Test plan

- `go build ./...` passes
- `go test ./internal/beads/...` passes
- `go test -run TestAddWithOptions_HasAgentsMD ./internal/polecat/...` passes
- 3 other polecat test failures are pre-existing on main (verified by running on origin/main)