### PR TITLE
fix(patrol): cap stale cleanup and break early on active patrol found (gt-18dzn6p)

### DIFF
--- a/internal/cmd/patrol_helpers.go
+++ b/internal/cmd/patrol_helpers.go
@@ -26,6 +26,13 @@ type PatrolConfig struct {
 	Beads         *beads.Beads // optional injected beads instance (for test isolation)
 }
 
+// maxStalePurgePerRun caps the number of stale patrol beads cleaned up in a
+// single findActivePatrol call. Without a cap, N accumulated orphans produce
+// N×K sequential Dolt queries (K = closeDescendants depth), overwhelming the
+// server when multiple patrol agents call gt patrol report concurrently (gt-18dzn6p).
+// Remaining stale beads are cleaned by burnPreviousPatrolWisps at cycle end.
+const maxStalePurgePerRun = 5
+
 // findActivePatrol finds an active patrol molecule for the role.
 // Returns the patrol ID, display line, and whether one was found.
 // Returns an error if discovery fails (e.g. transient bd failure),
@@ -36,7 +43,8 @@ type PatrolConfig struct {
 // This function looks up hooked patrols and distinguishes active ones
 // (with open/in_progress children) from stale ones (all children closed,
 // e.g. after a squash that didn't close the root). Stale patrols are
-// cleaned up automatically.
+// cleaned up incrementally (up to maxStalePurgePerRun per call); any
+// remaining stale beads are cleaned by burnPreviousPatrolWisps at cycle end.
 func findActivePatrol(cfg PatrolConfig) (patrolID, patrolLine string, found bool, err error) {
 	b := cfg.Beads
 	if b == nil {
@@ -53,9 +61,10 @@ func findActivePatrol(cfg PatrolConfig) (patrolID, patrolLine string, found bool
 		return "", "", false, fmt.Errorf("listing hooked beads: %w", listErr)
 	}
 
-	// First pass: identify active patrol and collect stale ones for cleanup.
-	// We process ALL hooked patrols to clean up accumulated orphans (~100
-	// stale patrols can build up over ~12 hours).
+	// Identify active patrol and collect stale ones for cleanup.
+	// Stop scanning as soon as the active patrol is found to avoid N+1
+	// checkHasOpenChildren queries when many accumulated orphans are present.
+	// Stale cleanup is capped at maxStalePurgePerRun to limit write pressure.
 	var activeBead *beads.Issue
 	var staleIDs []string
 	var skipped int // tracks patrols skipped due to child-listing errors
@@ -75,17 +84,21 @@ func findActivePatrol(cfg PatrolConfig) (patrolID, patrolLine string, found bool
 		}
 
 		if !hasOpen {
-			// Stale patrol (no open children) — mark for cleanup
-			staleIDs = append(staleIDs, bead.ID)
+			// Stale patrol (no open children) — schedule for cleanup up to cap.
+			// Excess stale beads are deferred to burnPreviousPatrolWisps.
+			if len(staleIDs) < maxStalePurgePerRun {
+				staleIDs = append(staleIDs, bead.ID)
+			}
 		} else if activeBead == nil {
-			// First active patrol found — this is the one we'll resume
+			// Active patrol found — stop scanning to prevent N+1 queries.
+			// Any unvisited stale beads will be cleaned by burnPreviousPatrolWisps
+			// when the patrol cycle ends and autoSpawnPatrol is called.
 			activeBead = bead
+			break
 		}
-		// else: has open children but we already found an active patrol —
-		// leave it alone to avoid destroying a potentially running patrol
 	}
 
-	// Clean up all stale patrols
+	// Clean up stale patrols (capped at maxStalePurgePerRun)
 	for _, id := range staleIDs {
 		closeDescendants(b, id)
 		if err := b.ForceCloseWithReason("stale patrol cleanup", id); err != nil {

--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -663,17 +663,6 @@ func TestFindActivePatrolMultiple(t *testing.T) {
 		t.Errorf("patrolID = %q, want %q (should return the active one)", patrolID, activeID)
 	}
 
-	// Verify both stale patrols were closed
-	for _, id := range []string{stale1, stale2} {
-		issue, err := b.Show(id)
-		if err != nil {
-			t.Fatalf("show stale %s: %v", id, err)
-		}
-		if issue.Status != "closed" {
-			t.Errorf("stale patrol %s status = %q, want %q", id, issue.Status, "closed")
-		}
-	}
-
 	// Verify active patrol is still hooked
 	issue, err := b.Show(activeID)
 	if err != nil {
@@ -681,6 +670,98 @@ func TestFindActivePatrolMultiple(t *testing.T) {
 	}
 	if issue.Status != beads.StatusHooked {
 		t.Errorf("active patrol status = %q, want %q", issue.Status, beads.StatusHooked)
+	}
+
+	// Stale patrol cleanup is not guaranteed when an active patrol is found —
+	// findActivePatrol breaks early on active discovery to prevent N+1 Dolt queries
+	// (gt-18dzn6p). Remaining stale beads are cleaned by burnPreviousPatrolWisps
+	// when the patrol cycle ends. Verify stale beads are either closed or still hooked
+	// (not left in an intermediate broken state).
+	for _, id := range []string{stale1, stale2} {
+		staleIssue, showErr := b.Show(id)
+		if showErr != nil {
+			t.Fatalf("show stale %s: %v", id, showErr)
+		}
+		if staleIssue.Status != "closed" && staleIssue.Status != beads.StatusHooked {
+			t.Errorf("stale patrol %s status = %q, want closed or hooked", id, staleIssue.Status)
+		}
+	}
+}
+
+// TestFindActivePatrol_StaleCleanupCapped verifies that when many stale patrols
+// accumulate with no active patrol, cleanup is capped at maxStalePurgePerRun per call
+// to prevent overwhelming Dolt with sequential write queries (gt-18dzn6p).
+func TestFindActivePatrol_StaleCleanupCapped(t *testing.T) {
+	requireBd(t)
+	tmpDir, b := setupPatrolTestDB(t)
+
+	molName := "mol-test-patrol"
+	assignee := "testrig/witness"
+
+	// Create more stale patrols than maxStalePurgePerRun (currently 5)
+	numStale := maxStalePurgePerRun + 3 // e.g., 8 total
+	staleIDs := make([]string, numStale)
+	for i := 0; i < numStale; i++ {
+		id := createHookedPatrol(t, b, molName, assignee, true /* with child */)
+		staleIDs[i] = id
+
+		// Close the child to make the patrol stale
+		children, err := b.List(beads.ListOptions{Parent: id, Status: "all", Priority: -1})
+		if err != nil {
+			t.Fatalf("list children of %s: %v", id, err)
+		}
+		for _, child := range children {
+			if closeErr := b.ForceCloseWithReason("test cleanup", child.ID); closeErr != nil {
+				t.Fatalf("close child of %s: %v", id, closeErr)
+			}
+		}
+	}
+
+	cfg := PatrolConfig{
+		PatrolMolName: molName,
+		BeadsDir:      tmpDir,
+		Assignee:      assignee,
+		Beads:         b,
+	}
+
+	_, _, found, findErr := findActivePatrol(cfg)
+	if findErr != nil {
+		t.Fatalf("findActivePatrol error: %v", findErr)
+	}
+	if found {
+		t.Fatal("expected no active patrol (all stale)")
+	}
+
+	// Count how many stale patrols were actually closed
+	closedCount := 0
+	hookedCount := 0
+	for _, id := range staleIDs {
+		issue, err := b.Show(id)
+		if err != nil {
+			t.Fatalf("show stale %s: %v", id, err)
+		}
+		switch issue.Status {
+		case "closed":
+			closedCount++
+		case beads.StatusHooked:
+			hookedCount++
+		default:
+			t.Errorf("stale patrol %s unexpected status %q", id, issue.Status)
+		}
+	}
+
+	// Cleanup must be capped: at most maxStalePurgePerRun beads closed per run
+	if closedCount > maxStalePurgePerRun {
+		t.Errorf("closed %d stale patrols, want at most %d (cap exceeded — Dolt DoS risk)",
+			closedCount, maxStalePurgePerRun)
+	}
+	// But at least some cleanup must happen (the cap should not be zero)
+	if closedCount == 0 {
+		t.Errorf("no stale patrols were closed, expected up to %d", maxStalePurgePerRun)
+	}
+	// Total accounted for
+	if closedCount+hookedCount != numStale {
+		t.Errorf("closed=%d + hooked=%d != total=%d", closedCount, hookedCount, numStale)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `findActivePatrol` was making N+1 Dolt queries for N accumulated stale patrols: one `checkHasOpenChildren` call per patrol bead, then recursive `closeDescendants` for each stale one
- Under load, parallel `gt patrol report` invocations overwhelmed Dolt with hundreds of concurrent queries → circuit breaker trips + CLOSE_WAIT TCP accumulation (3 Dolt crashes in one day)
- **Fix 1**: Break early once an active patrol is found — no need to scan remaining beads
- **Fix 2**: Cap stale cleanup at `maxStalePurgePerRun=5` per `findActivePatrol` call, bounding write pressure to 5×K queries (K = tree depth)

Fixes gt-18dzn6p.

## Test plan

- [ ] Verify `gt patrol report` no longer causes Dolt CPU spikes under accumulated stale wisps
- [ ] Confirm active patrol discovery exits early (check logs / add tracing)
- [ ] Run with multiple orphaned patrol wisps and verify cleanup is capped at 5

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: furiosa <athosmartins@gmail.com>