### PR TITLE
feat(dashboard): enrich convoy panel with progress %, ready/active counts, assignees

### DIFF
--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -165,9 +165,17 @@ func (f *LiveConvoyFetcher) FetchConvoys() ([]ConvoyRow, error) {
 		var mostRecentActivity time.Time
 		var mostRecentUpdated time.Time
 		var hasAssignee bool
+		assigneeSet := make(map[string]struct{})
 		for _, t := range tracked {
 			if t.Status == "closed" {
 				row.Completed++
+			} else if t.Assignee != "" {
+				row.InProgress++
+			} else if t.Status == "open" || t.Status == "in_progress" {
+				// open with no assignee = ready to pick up
+				if t.Assignee == "" {
+					row.ReadyBeads++
+				}
 			}
 			// Track most recent activity from workers
 			if t.LastActivity.After(mostRecentActivity) {
@@ -179,10 +187,20 @@ func (f *LiveConvoyFetcher) FetchConvoys() ([]ConvoyRow, error) {
 			}
 			if t.Assignee != "" {
 				hasAssignee = true
+				assigneeSet[t.Assignee] = struct{}{}
 			}
 		}
 
+		// Collect unique assignees
+		row.Assignees = make([]string, 0, len(assigneeSet))
+		for a := range assigneeSet {
+			row.Assignees = append(row.Assignees, a)
+		}
+
 		row.Progress = fmt.Sprintf("%d/%d", row.Completed, row.Total)
+		if row.Total > 0 {
+			row.ProgressPct = (row.Completed * 100) / row.Total
+		}
 
 		// Calculate activity info from most recent worker activity
 		if !mostRecentActivity.IsZero() {

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -510,6 +510,7 @@ func TestConvoyHandler_ProgressBarRendering(t *testing.T) {
 				Progress:     "3/4",
 				Completed:    3,
 				Total:        4,
+				ProgressPct:  75,
 				LastActivity: activity.Calculate(time.Now()),
 			},
 		},

--- a/internal/web/static/dashboard.css
+++ b/internal/web/static/dashboard.css
@@ -209,6 +209,45 @@
             margin-left: 8px;
         }
 
+        .convoy-assignees {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 4px;
+            margin-top: 4px;
+        }
+
+        .assignee-chip {
+            font-size: 0.65rem;
+            background: rgba(var(--blue-rgb, 79, 142, 255), 0.15);
+            color: var(--blue);
+            border-radius: 3px;
+            padding: 1px 5px;
+            white-space: nowrap;
+            overflow: hidden;
+            text-overflow: ellipsis;
+            max-width: 120px;
+        }
+
+        .convoy-progress-cell {
+            min-width: 80px;
+        }
+
+        .convoy-progress-header {
+            display: flex;
+            align-items: center;
+            gap: 6px;
+        }
+
+        .convoy-progress-fraction {
+            font-size: 0.8rem;
+            color: var(--text-primary);
+        }
+
+        .convoy-progress-pct {
+            font-size: 0.7rem;
+            color: var(--text-muted);
+        }
+
         .progress-bar {
             width: 60px;
             height: 4px;
@@ -223,6 +262,38 @@
             background: var(--green);
             border-radius: 2px;
             transition: width 0.3s ease;
+        }
+
+        .convoy-work-cell {
+            min-width: 80px;
+        }
+
+        .convoy-work-breakdown {
+            display: flex;
+            flex-direction: column;
+            gap: 3px;
+        }
+
+        .work-chip {
+            font-size: 0.65rem;
+            border-radius: 3px;
+            padding: 1px 5px;
+            display: inline-block;
+        }
+
+        .work-ready {
+            background: rgba(var(--cyan-rgb, 0, 215, 210), 0.15);
+            color: var(--cyan);
+        }
+
+        .work-inprogress {
+            background: rgba(var(--yellow-rgb, 230, 192, 0), 0.15);
+            color: var(--yellow);
+        }
+
+        .work-done {
+            background: rgba(var(--green-rgb, 0, 200, 83), 0.15);
+            color: var(--green);
         }
 
         /* Convoy detail view */

--- a/internal/web/templates.go
+++ b/internal/web/templates.go
@@ -204,6 +204,10 @@ type ConvoyRow struct {
 	Progress      string // e.g., "2/5"
 	Completed     int
 	Total         int
+	ProgressPct   int      // 0-100, computed from Completed/Total
+	ReadyBeads    int      // open beads with no assignee (available to pick up)
+	InProgress    int      // beads currently being worked on
+	Assignees     []string // unique assignees across tracked issues
 	LastActivity  activity.Info
 	TrackedIssues []TrackedIssue
 }

--- a/internal/web/templates/convoy.html
+++ b/internal/web/templates/convoy.html
@@ -137,6 +137,7 @@
                                     <th>Status</th>
                                     <th>Convoy</th>
                                     <th>Progress</th>
+                                    <th>Work</th>
                                     <th>Activity</th>
                                 </tr>
                             </thead>
@@ -146,31 +147,44 @@
                                     <td>
                                         <span class="convoy-toggle">▶</span>
                                         {{if eq .WorkStatus "complete"}}
-                                        <span class="badge badge-green">✓</span>
+                                        <span class="badge badge-green" title="All issues completed">✓ Done</span>
                                         {{else if eq .WorkStatus "active"}}
-                                        <span class="badge badge-green">Active</span>
+                                        <span class="badge badge-green" title="Workers actively progressing">Active</span>
                                         {{else if eq .WorkStatus "stale"}}
-                                        <span class="badge badge-yellow">Stale</span>
+                                        <span class="badge badge-yellow" title="No activity in 5-10 minutes">Stale</span>
                                         {{else if eq .WorkStatus "stuck"}}
-                                        <span class="badge badge-red">Stuck</span>
+                                        <span class="badge badge-red" title="No activity for 10+ minutes">Stuck</span>
                                         {{else}}
-                                        <span class="badge badge-muted">Wait</span>
+                                        <span class="badge badge-muted" title="No workers assigned yet">Waiting</span>
                                         {{end}}
                                     </td>
                                     <td>
                                         <span class="convoy-id">{{.ID}}</span>
                                         {{if .Title}}<div class="convoy-title">{{.Title}}</div>{{end}}
+                                        {{if .Assignees}}<div class="convoy-assignees">{{range .Assignees}}<span class="assignee-chip">{{.}}</span>{{end}}</div>{{end}}
                                     </td>
-                                    <td>
-                                        {{.Progress}}
+                                    <td class="convoy-progress-cell">
+                                        <div class="convoy-progress-header">
+                                            <span class="convoy-progress-fraction">{{.Progress}}</span>
+                                            {{if .Total}}<span class="convoy-progress-pct">{{.ProgressPct}}%</span>{{end}}
+                                        </div>
                                         {{if .Total}}
                                         <div class="progress-bar">
-                                            <div class="progress-fill" style="width: {{progressPercent .Completed .Total}}%;"></div>
+                                            <div class="progress-fill" style="width: {{.ProgressPct}}%;"></div>
+                                        </div>
+                                        {{end}}
+                                    </td>
+                                    <td class="convoy-work-cell">
+                                        {{if .Total}}
+                                        <div class="convoy-work-breakdown">
+                                            {{if .ReadyBeads}}<span class="work-chip work-ready" title="Ready to pick up">{{.ReadyBeads}} ready</span>{{end}}
+                                            {{if .InProgress}}<span class="work-chip work-inprogress" title="Being worked on">{{.InProgress}} active</span>{{end}}
+                                            {{if eq .WorkStatus "complete"}}<span class="work-chip work-done">all done</span>{{end}}
                                         </div>
                                         {{end}}
                                     </td>
                                     <td class="{{activityClass .LastActivity}}">
-                                        <span class="activity-dot"></span>
+                                        <span class="activity-dot" title="Worker session activity"></span>
                                         {{.LastActivity.FormattedAge}}
                                     </td>
                                 </tr>


### PR DESCRIPTION
## Summary

- Add **progress percentage label** ("75%") displayed alongside the existing "3/4" fraction
- Add **"Ready: N"** chip showing unassigned open beads (available to pick up)
- Add **"Active: N"** chip showing beads currently being worked on
- Add **assignee chips** per convoy row showing which workers are on it
- Add **tooltip titles** on status badges explaining color semantics (e.g. "No activity for 10+ minutes")

## Motivation

The convoy panel showed `Active` / `Stale` / `Stuck` badges and a progress bar, but gave no actionable breakdown: How many beads are ready? How many are in flight? Who's on it? This made it hard to understand convoy health at a glance.

## Backend changes

Added to `ConvoyRow` struct (templates.go):
- `ProgressPct int` — precomputed 0-100 from Completed/Total
- `ReadyBeads int` — open beads with no assignee
- `InProgress int` — beads with an assignee
- `Assignees []string` — unique assignee names

Populated in `FetchConvoys` (fetcher.go) from the already-fetched tracked issue data.

## Frontend changes

- New `convoy-progress-header` showing fraction + pct side by side
- New `convoy-work-cell` column with ready/active breakdown chips
- Assignee chips under convoy ID/title (collapsed if empty)
- CSS for `.assignee-chip`, `.work-chip`, `.work-ready`, `.work-inprogress`, `.work-done`

## Test plan

- [x] `go test ./internal/web/...` passes (updated mock to set `ProgressPct: 75`)
- [x] `go build ./...` clean
- Note: `internal/tmux` failures are pre-existing timing-sensitive flakes unrelated to this change

🤖 Generated with [Claude Code](https://claude.com/claude-code)