### PR TITLE
fix(dolt): add server-side timeouts to prevent CLOSE_WAIT accumulation

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -128,6 +128,21 @@ const (
 	DefaultPort           = 3307
 	DefaultUser           = "root" // Default Dolt user (no password for local access)
 	DefaultMaxConnections = 1000   // Dolt default; no reason to limit below (Tim Sehn confirmed 1k is fine)
+
+	// DefaultReadTimeoutMs is the server-side timeout for reading a complete request from a client.
+	// Controls how long Dolt waits for a client to send a query on an idle connection.
+	// Prevents CLOSE_WAIT accumulation from abandoned connections: when a client times out
+	// and closes its end, Dolt will detect the dead connection within this window.
+	// 5 minutes matches the compactor GC timeout (compactorGCTimeout) so GC ops complete
+	// before the connection is considered stale.
+	DefaultReadTimeoutMs = 5 * 60 * 1000 // 5 minutes in milliseconds
+
+	// DefaultWriteTimeoutMs is the server-side timeout for writing a response back to a client.
+	// Controls how long Dolt allows a query to run before forcibly closing the connection.
+	// This is the primary defense against CLOSE_WAIT: if a client closes its TCP connection
+	// mid-query, Dolt will close its end within this timeout rather than holding CLOSE_WAIT
+	// for Dolt's default 8 hours. Set to match compactor GC timeout.
+	DefaultWriteTimeoutMs = 5 * 60 * 1000 // 5 minutes in milliseconds
 )
 
 // metadataMu provides per-path mutexes for EnsureMetadata goroutine synchronization.
@@ -175,6 +190,21 @@ type Config struct {
 	// connection storms during mass polecat slings.
 	MaxConnections int
 
+	// ReadTimeoutMs is the server-side read timeout in milliseconds.
+	// Controls how long Dolt waits for a client to send a request on an idle connection.
+	// Prevents abandoned connections from staying in CLOSE_WAIT indefinitely.
+	// Set to 0 to use Dolt's default (28800000 = 8 hours — strongly discouraged).
+	ReadTimeoutMs int
+
+	// WriteTimeoutMs is the server-side write timeout in milliseconds.
+	// Controls how long Dolt allows a query to execute before forcibly closing the connection.
+	// This is the primary defense against CLOSE_WAIT accumulation: when a client closes its
+	// TCP connection while a query is running, Dolt closes its end within WriteTimeoutMs
+	// instead of holding the connection open for up to 8 hours (Dolt default).
+	// Must be >= the longest expected query (e.g., compactor GC at 5 minutes).
+	// Set to 0 to use Dolt's default (28800000 = 8 hours — strongly discouraged).
+	WriteTimeoutMs int
+
 	// LogLevel is the Dolt server log level (trace, debug, info, warning, error, fatal).
 	// Default is "warning" to suppress connection open/close noise. Override with
 	// GT_DOLT_LOGLEVEL=info (or debug) for diagnostics.
@@ -198,6 +228,8 @@ func DefaultConfig(townRoot string) *Config {
 		LogFile:        filepath.Join(daemonDir, "dolt.log"),
 		PidFile:        filepath.Join(daemonDir, "dolt.pid"),
 		MaxConnections: DefaultMaxConnections,
+		ReadTimeoutMs:  DefaultReadTimeoutMs,
+		WriteTimeoutMs: DefaultWriteTimeoutMs,
 		LogLevel:       "warning",
 	}
 
@@ -931,6 +963,67 @@ func checkPortAvailable(port int) error {
 	return nil
 }
 
+// writeServerConfig writes a managed Dolt config.yaml from the Config struct.
+// This ensures all required settings (especially connection timeouts) are always
+// present when the server starts. The file is overwritten on each start to prevent
+// configuration drift.
+//
+// The generated config is a complete Dolt sql-server configuration, equivalent to
+// what Dolt generates with its interactive configuration wizard, but with Gas Town
+// defaults. Users who need advanced settings should modify the Config struct fields
+// rather than editing this file directly (it is overwritten on each start).
+func writeServerConfig(config *Config, configPath string) error {
+	// Build the listener host entry. Omit it when empty to use Dolt's default
+	// (binds to all interfaces), which is the backward-compatible behavior.
+	hostLine := ""
+	if config.Host != "" {
+		hostLine = fmt.Sprintf("\n  host: %s", config.Host)
+	}
+
+	// Build timeout entries. Omit when 0 to use Dolt's defaults (not recommended).
+	readTimeoutLine := ""
+	if config.ReadTimeoutMs > 0 {
+		readTimeoutLine = fmt.Sprintf("\n  read_timeout_millis: %d", config.ReadTimeoutMs)
+	}
+	writeTimeoutLine := ""
+	if config.WriteTimeoutMs > 0 {
+		writeTimeoutLine = fmt.Sprintf("\n  write_timeout_millis: %d", config.WriteTimeoutMs)
+	}
+
+	maxConnLine := ""
+	if config.MaxConnections > 0 {
+		maxConnLine = fmt.Sprintf("\n  max_connections: %d", config.MaxConnections)
+	}
+
+	content := fmt.Sprintf(`# Dolt SQL server configuration — managed by Gas Town (gt dolt start)
+# Do not edit manually; changes are overwritten on each server start.
+# To customize, set Gas Town environment variables:
+#   GT_DOLT_PORT, GT_DOLT_HOST, GT_DOLT_USER, GT_DOLT_PASSWORD, GT_DOLT_LOGLEVEL
+
+log_level: %s
+
+listener:
+  port: %d%s%s%s%s
+
+data_dir: %s
+
+behavior:
+  auto_gc_behavior:
+    enable: true
+    archive_level: 1
+`,
+		config.LogLevel,
+		config.Port,
+		hostLine,
+		maxConnLine,
+		readTimeoutLine,
+		writeTimeoutLine,
+		config.DataDir,
+	)
+
+	return os.WriteFile(configPath, []byte(content), 0600)
+}
+
 // Start starts the Dolt SQL server.
 func Start(townRoot string) error {
 	config := DefaultConfig(townRoot)
@@ -1091,26 +1184,17 @@ func Start(townRoot string) error {
 		return err
 	}
 
-	// Start dolt sql-server. If a config.yaml exists in the data directory,
-	// pass --config to enable config-only features like auto_gc_behavior.
-	// When --config is used, all other CLI flags are ignored by dolt, so the
-	// config file must contain the full server configuration.
-	var args []string
+	// Always write a managed config.yaml from the Config struct before starting.
+	// This ensures critical settings (especially read/write timeouts) are always
+	// present, preventing CLOSE_WAIT accumulation from abandoned connections.
+	// The config file uses --config so all settings come from this file; CLI flags
+	// are ignored by dolt when --config is used.
 	configPath := filepath.Join(config.DataDir, "config.yaml")
-	if _, err := os.Stat(configPath); err == nil {
-		args = []string{"sql-server", "--config", configPath}
-	} else {
-		args = []string{"sql-server",
-			"--port", strconv.Itoa(config.Port),
-			"--data-dir", config.DataDir,
-		}
-		if config.MaxConnections > 0 {
-			args = append(args, "--max-connections", strconv.Itoa(config.MaxConnections))
-		}
-		if config.LogLevel != "" {
-			args = append(args, "--loglevel", config.LogLevel)
-		}
+	if err := writeServerConfig(config, configPath); err != nil {
+		logFile.Close()
+		return fmt.Errorf("writing Dolt config: %w", err)
 	}
+	args := []string{"sql-server", "--config", configPath}
 	cmd := exec.Command("dolt", args...)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -3614,3 +3614,131 @@ func TestCollectDatabaseOwners_UnknownDB(t *testing.T) {
 		t.Error("unknown_db should not have an owner")
 	}
 }
+
+// =============================================================================
+// writeServerConfig tests
+// =============================================================================
+
+func TestWriteServerConfig_Defaults(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	config := &Config{
+		Port:           3307,
+		DataDir:        dir,
+		MaxConnections: 1000,
+		ReadTimeoutMs:  DefaultReadTimeoutMs,
+		WriteTimeoutMs: DefaultWriteTimeoutMs,
+		LogLevel:       "warning",
+	}
+
+	if err := writeServerConfig(config, configPath); err != nil {
+		t.Fatalf("writeServerConfig: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("reading config: %v", err)
+	}
+	content := string(data)
+
+	checks := []string{
+		"port: 3307",
+		"max_connections: 1000",
+		fmt.Sprintf("read_timeout_millis: %d", DefaultReadTimeoutMs),
+		fmt.Sprintf("write_timeout_millis: %d", DefaultWriteTimeoutMs),
+		"data_dir: " + dir,
+		"log_level: warning",
+		"auto_gc_behavior:",
+	}
+	for _, want := range checks {
+		if !strings.Contains(content, want) {
+			t.Errorf("config missing %q\nfull content:\n%s", want, content)
+		}
+	}
+}
+
+func TestWriteServerConfig_NoHost(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	config := &Config{
+		Port:    3307,
+		DataDir: dir,
+		// Host is empty — should not appear in config
+	}
+	if err := writeServerConfig(config, configPath); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(configPath)
+	if strings.Contains(string(data), "host:") {
+		t.Error("empty Host should not write host line to config")
+	}
+}
+
+func TestWriteServerConfig_WithHost(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	config := &Config{
+		Port:    3307,
+		Host:    "127.0.0.1",
+		DataDir: dir,
+	}
+	if err := writeServerConfig(config, configPath); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(configPath)
+	if !strings.Contains(string(data), "host: 127.0.0.1") {
+		t.Error("explicit Host should appear in config")
+	}
+}
+
+func TestWriteServerConfig_ZeroTimeoutsOmitted(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	config := &Config{
+		Port:           3307,
+		DataDir:        dir,
+		ReadTimeoutMs:  0, // zero = use Dolt default
+		WriteTimeoutMs: 0,
+	}
+	if err := writeServerConfig(config, configPath); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(configPath)
+	content := string(data)
+	if strings.Contains(content, "read_timeout_millis") {
+		t.Error("zero ReadTimeoutMs should not write read_timeout_millis")
+	}
+	if strings.Contains(content, "write_timeout_millis") {
+		t.Error("zero WriteTimeoutMs should not write write_timeout_millis")
+	}
+}
+
+func TestWriteServerConfig_Overwrites(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	// Write initial config
+	if err := os.WriteFile(configPath, []byte("old content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	config := &Config{Port: 3307, DataDir: dir, LogLevel: "info"}
+	if err := writeServerConfig(config, configPath); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(configPath)
+	if strings.Contains(string(data), "old content") {
+		t.Error("writeServerConfig should overwrite existing file")
+	}
+	if !strings.Contains(string(data), "log_level: info") {
+		t.Error("new config should have updated log level")
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `ReadTimeoutMs` and `WriteTimeoutMs` to Dolt config struct (default 5 minutes)
- Always writes a managed `config.yaml` from Config struct on Dolt start
- Prevents CLOSE_WAIT accumulation by ensuring Dolt can respond to client FINs

## Root Cause
Dolt's default connection timeouts are 8 hours. When clients timeout and send FIN while a long-running query (GC/REBASE, up to 5min) executes, Dolt can't respond until query completes — leaving connections in CLOSE_WAIT, causing CPU thrash at 180-300%.

## Related
- Bead: gt-75me6a8
- Previous PR: #2285 (gt-18dzn6p patrol DoS fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)