### PR TITLE
fix(reaper): increase MySQL timeouts to handle large wisp tables

### DIFF
--- a/internal/cmd/reaper.go
+++ b/internal/cmd/reaper.go
@@ -84,7 +84,7 @@ The Dog uses this to understand the state before deciding what to reap.`,
 			return fmt.Errorf("invalid --stale-age: %w", err)
 		}
 
-		db, err := reaper.OpenDB("127.0.0.1", reaperPort, reaperDB, 10*time.Second, 10*time.Second)
+		db, err := reaper.OpenDB("127.0.0.1", reaperPort, reaperDB, 60*time.Second, 60*time.Second)
 		if err != nil {
 			return fmt.Errorf("connect to %s: %w", reaperDB, err)
 		}
@@ -129,7 +129,7 @@ Returns the count of reaped wisps. Use --dry-run to preview.`,
 			return fmt.Errorf("invalid --max-age: %w", err)
 		}
 
-		db, err := reaper.OpenDB("127.0.0.1", reaperPort, reaperDB, 10*time.Second, 10*time.Second)
+		db, err := reaper.OpenDB("127.0.0.1", reaperPort, reaperDB, 60*time.Second, 60*time.Second)
 		if err != nil {
 			return fmt.Errorf("connect to %s: %w", reaperDB, err)
 		}
@@ -220,7 +220,7 @@ Returns the count of closed issues. Use --dry-run to preview.`,
 			return fmt.Errorf("invalid --stale-age: %w", err)
 		}
 
-		db, err := reaper.OpenDB("127.0.0.1", reaperPort, reaperDB, 10*time.Second, 10*time.Second)
+		db, err := reaper.OpenDB("127.0.0.1", reaperPort, reaperDB, 60*time.Second, 60*time.Second)
 		if err != nil {
 			return fmt.Errorf("connect to %s: %w", reaperDB, err)
 		}
@@ -283,7 +283,7 @@ Normally the daemon dispatches a Dog to execute the mol-dog-reaper formula.`,
 				continue
 			}
 
-			db, err := reaper.OpenDB("127.0.0.1", reaperPort, dbName, 30*time.Second, 30*time.Second)
+			db, err := reaper.OpenDB("127.0.0.1", reaperPort, dbName, 60*time.Second, 60*time.Second)
 			if err != nil {
 				fmt.Printf("%s: connect error: %v\n", dbName, err)
 				continue

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -122,7 +122,9 @@ type Anomaly struct {
 
 const (
 	// DefaultQueryTimeout is the timeout for individual reaper SQL queries.
-	DefaultQueryTimeout = 30 * time.Second
+	// Set to 60s to accommodate parentCheckWhere() correlated subqueries on
+	// large wisp tables (e.g. HQ with 22K+ rows / ~10 GB).
+	DefaultQueryTimeout = 60 * time.Second
 	// DefaultBatchSize is the number of rows per batch DELETE operation.
 	DefaultBatchSize = 100
 )


### PR DESCRIPTION
## Summary
- Reaper scan/reap/auto-close commands used 10s MySQL read/write timeouts
- `parentCheckWhere()` correlated subqueries on HQ (22K+ wisps, ~10 GB) need ~40-50s
- Increased all reaper command timeouts to 60s and `DefaultQueryTimeout` from 30s to 60s

## Test plan
- [x] `gt reaper scan --db=hq` completes successfully (was: i/o timeout)
- [x] Returns 20,641 reap candidates, 22,048 open wisps
- [ ] Verify `gt reaper run` full cycle works on HQ

🤖 Generated with [Claude Code](https://claude.com/claude-code)