### PR TITLE
feat(crew): group crew tmux sessions into shared window groups

### DIFF
--- a/internal/cmd/crew_lifecycle.go
+++ b/internal/cmd/crew_lifecycle.go
@@ -17,6 +17,7 @@ import (
 	"github.com/steveyegge/gastown/internal/crew"
 	"github.com/steveyegge/gastown/internal/mail"
 	"github.com/steveyegge/gastown/internal/runtime"
+	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/townlog"
@@ -346,50 +347,84 @@ func runCrewStart(cmd *cobra.Command, args []string) error {
 		KillExisting:    crewResume != "", // Resume needs to kill existing session first
 	}
 
-	// Start each crew member in parallel
+	// Determine window group target for tmux session grouping.
+	// All crew sessions in a rig share a window group so the overseer can
+	// cycle through all crew windows from any attached session.
+	groupTarget := findCrewGroupTarget(rigName, crewMgr)
+
 	type result struct {
 		name    string
 		err     error
 		skipped bool // true if session was already running
 	}
-	results := make(chan result, len(crewNames))
-	var wg sync.WaitGroup
 
 	fmt.Printf("Starting %d crew member(s) in %s...\n", len(crewNames), rigName)
 
-	for _, name := range crewNames {
-		wg.Add(1)
-		go func(crewName string) {
-			defer wg.Done()
-			err := crewMgr.Start(crewName, opts)
-			skipped := errors.Is(err, crew.ErrSessionRunning)
-			if skipped {
-				err = nil // Not an error, just already running
-			}
-			results <- result{name: crewName, err: err, skipped: skipped}
-		}(name)
-	}
-
-	// Wait for all goroutines to complete
-	go func() {
-		wg.Wait()
-		close(results)
-	}()
-
-	// Collect results
 	var lastErr error
 	startedCount := 0
 	skippedCount := 0
-	for res := range results {
-		if res.err != nil {
-			fmt.Printf("  %s %s/%s: %v\n", style.ErrorPrefix, rigName, res.name, res.err)
-			lastErr = res.err
-		} else if res.skipped {
-			fmt.Printf("  %s %s/%s: already running\n", style.Dim.Render("○"), rigName, res.name)
+
+	// If no existing group target and we're starting multiple crew members,
+	// start the first one synchronously as the group anchor.
+	anchorIdx := 0
+	if groupTarget == "" && len(crewNames) > 1 {
+		anchorName := crewNames[0]
+		anchorOpts := opts // no GroupTarget — this is the anchor
+		err := crewMgr.Start(anchorName, anchorOpts)
+		if errors.Is(err, crew.ErrSessionRunning) {
+			fmt.Printf("  %s %s/%s: already running\n", style.Dim.Render("○"), rigName, anchorName)
 			skippedCount++
+			// Already-running session can serve as group target
+			groupTarget = crewMgr.SessionName(anchorName)
+		} else if err != nil {
+			fmt.Printf("  %s %s/%s: %v\n", style.ErrorPrefix, rigName, anchorName, err)
+			lastErr = err
+			// Anchor failed — remaining crew start without grouping
 		} else {
-			fmt.Printf("  %s %s/%s: started\n", style.SuccessPrefix, rigName, res.name)
+			fmt.Printf("  %s %s/%s: started (group anchor)\n", style.SuccessPrefix, rigName, anchorName)
 			startedCount++
+			groupTarget = crewMgr.SessionName(anchorName)
+		}
+		anchorIdx = 1 // skip first name in parallel phase
+	}
+
+	// Start remaining crew members in parallel, joined to the group.
+	remaining := crewNames[anchorIdx:]
+	if len(remaining) > 0 {
+		results := make(chan result, len(remaining))
+		var wg sync.WaitGroup
+
+		for _, name := range remaining {
+			wg.Add(1)
+			go func(crewName string) {
+				defer wg.Done()
+				startOpts := opts
+				startOpts.GroupTarget = groupTarget // may be "" if anchor failed
+				err := crewMgr.Start(crewName, startOpts)
+				skipped := errors.Is(err, crew.ErrSessionRunning)
+				if skipped {
+					err = nil
+				}
+				results <- result{name: crewName, err: err, skipped: skipped}
+			}(name)
+		}
+
+		go func() {
+			wg.Wait()
+			close(results)
+		}()
+
+		for res := range results {
+			if res.err != nil {
+				fmt.Printf("  %s %s/%s: %v\n", style.ErrorPrefix, rigName, res.name, res.err)
+				lastErr = res.err
+			} else if res.skipped {
+				fmt.Printf("  %s %s/%s: already running\n", style.Dim.Render("○"), rigName, res.name)
+				skippedCount++
+			} else {
+				fmt.Printf("  %s %s/%s: started\n", style.SuccessPrefix, rigName, res.name)
+				startedCount++
+			}
 		}
 	}
 
@@ -401,6 +436,24 @@ func runCrewStart(cmd *cobra.Command, args []string) error {
 	}
 
 	return lastErr
+}
+
+// findCrewGroupTarget finds an existing crew session to use as a tmux window
+// group target. Returns the session name if found, empty string otherwise.
+func findCrewGroupTarget(rigName string, crewMgr *crew.Manager) string {
+	t := tmux.NewTmux()
+	sessions, err := t.ListSessions()
+	if err != nil {
+		return ""
+	}
+
+	prefix := session.PrefixFor(rigName) + "-crew-"
+	for _, s := range sessions {
+		if strings.HasPrefix(s, prefix) {
+			return s
+		}
+	}
+	return ""
 }
 
 func runCrewRestart(cmd *cobra.Command, args []string) error {

--- a/internal/crew/manager.go
+++ b/internal/crew/manager.go
@@ -60,6 +60,12 @@ type StartOptions struct {
 	// "last" means resume the most recent session (--resume with no session ID).
 	// Any other non-empty value is a specific session ID to resume.
 	ResumeSessionID string
+
+	// GroupTarget is the name of an existing tmux session whose window group this
+	// session should join. When set, the new session shares windows with the group,
+	// allowing the overseer to see all crew windows from any attached session.
+	// Empty means create a standalone session (the default / group anchor).
+	GroupTarget string
 }
 
 // validateSessionID checks that a resume session ID contains only safe characters.
@@ -826,8 +832,16 @@ func (m *Manager) Start(name string, opts StartOptions) error {
 	// initial shell inherits the correct GT_ROLE (not the parent's).
 	// See: https://github.com/anthropics/gastown/issues/280 (race condition fix)
 	// See: https://github.com/steveyegge/gastown/issues/1289 (env inheritance fix)
-	if err := t.NewSessionWithCommandAndEnv(sessionID, worker.ClonePath, claudeCmd, envVars); err != nil {
-		return fmt.Errorf("creating session: %w", err)
+	if opts.GroupTarget != "" {
+		// Join an existing session's window group so all crew windows are visible
+		// from any attached session. Each crew member gets its own window in the group.
+		if err := t.NewGroupedSessionWithCommandAndEnv(sessionID, worker.ClonePath, claudeCmd, envVars, opts.GroupTarget); err != nil {
+			return fmt.Errorf("creating grouped session: %w", err)
+		}
+	} else {
+		if err := t.NewSessionWithCommandAndEnv(sessionID, worker.ClonePath, claudeCmd, envVars); err != nil {
+			return fmt.Errorf("creating session: %w", err)
+		}
 	}
 
 	// Record agent's pane_id for ZFC-compliant liveness checks (gt-qmsx).
@@ -886,6 +900,13 @@ func (m *Manager) Stop(name string) error {
 	}
 	if !running {
 		return ErrSessionNotFound
+	}
+
+	// If this session is part of a window group, kill its window first.
+	// In a group, kill-session does NOT remove the session's windows — they
+	// persist for other group members as dead panes. Clean up proactively.
+	if t.IsGroupedSession(sessionID) {
+		_ = t.KillGroupedSessionWindow(sessionID)
 	}
 
 	// Kill the session.

--- a/internal/tmux/grouped_session_test.go
+++ b/internal/tmux/grouped_session_test.go
@@ -1,0 +1,198 @@
+package tmux
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// TestNewGroupedSession_Basic verifies that a grouped session joins the anchor's
+// window group and creates a new window visible to both sessions.
+func TestNewGroupedSession_Basic(t *testing.T) {
+	tm := newTestTmux(t)
+
+	anchor := "gt-test-group-anchor-" + t.Name()
+	grouped := "gt-test-group-member-" + t.Name()
+	_ = tm.KillSession(anchor)
+	_ = tm.KillSession(grouped)
+	defer func() {
+		_ = tm.KillSession(grouped)
+		_ = tm.KillSession(anchor)
+	}()
+
+	// Create anchor session
+	if err := tm.NewSessionWithCommand(anchor, "", `sh -c 'echo "ANCHOR"; sleep 30'`); err != nil {
+		t.Fatalf("anchor creation: %v", err)
+	}
+
+	// Create grouped session joining anchor's group
+	err := tm.NewGroupedSessionWithCommandAndEnv(grouped, "", `sh -c 'echo "GROUPED"; sleep 30'`, nil, anchor)
+	if err != nil {
+		t.Fatalf("grouped creation: %v", err)
+	}
+
+	// Both sessions should exist
+	hasAnchor, _ := tm.HasSession(anchor)
+	hasGrouped, _ := tm.HasSession(grouped)
+	if !hasAnchor {
+		t.Error("anchor session not found")
+	}
+	if !hasGrouped {
+		t.Error("grouped session not found")
+	}
+
+	// The grouped session should be in a group
+	if !tm.IsGroupedSession(grouped) {
+		t.Error("grouped session should report as grouped")
+	}
+	// The anchor should also be in a group now (it was joined)
+	if !tm.IsGroupedSession(anchor) {
+		t.Error("anchor session should report as grouped after member joins")
+	}
+
+	// Verify the grouped session's command is running
+	time.Sleep(500 * time.Millisecond)
+	output, _ := tm.CapturePane(grouped, 50)
+	if !strings.Contains(output, "GROUPED") {
+		t.Errorf("expected grouped session output to contain GROUPED, got: %q", strings.TrimSpace(output))
+	}
+}
+
+// TestNewGroupedSession_EnvVars verifies that environment variables are properly
+// set in the grouped session.
+func TestNewGroupedSession_EnvVars(t *testing.T) {
+	tm := newTestTmux(t)
+
+	anchor := "gt-test-groupenv-anchor-" + t.Name()
+	grouped := "gt-test-groupenv-member-" + t.Name()
+	_ = tm.KillSession(anchor)
+	_ = tm.KillSession(grouped)
+	defer func() {
+		_ = tm.KillSession(grouped)
+		_ = tm.KillSession(anchor)
+	}()
+
+	if err := tm.NewSessionWithCommand(anchor, "", "sleep 30"); err != nil {
+		t.Fatalf("anchor creation: %v", err)
+	}
+
+	env := map[string]string{
+		"GT_ROLE":  "crew",
+		"GT_RIG":   "testrig",
+		"GT_AGENT": "testmember",
+	}
+	err := tm.NewGroupedSessionWithCommandAndEnv(grouped, "", `sh -c 'echo "ROLE=$GT_ROLE RIG=$GT_RIG"; sleep 30'`, env, anchor)
+	if err != nil {
+		t.Fatalf("grouped creation: %v", err)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+	output, _ := tm.CapturePane(grouped, 50)
+	if !strings.Contains(output, "ROLE=crew") || !strings.Contains(output, "RIG=testrig") {
+		t.Errorf("expected env vars in output, got: %q", strings.TrimSpace(output))
+	}
+}
+
+// TestNewGroupedSession_MissingGroupTarget verifies that empty groupTarget is rejected.
+func TestNewGroupedSession_MissingGroupTarget(t *testing.T) {
+	tm := newTestTmux(t)
+	err := tm.NewGroupedSessionWithCommandAndEnv("gt-test-nogroup", "", "sleep 1", nil, "")
+	if err == nil {
+		t.Error("expected error for empty groupTarget")
+	}
+}
+
+// TestNewGroupedSession_NonexistentGroupTarget verifies that tmux creates a new
+// group when the target session doesn't exist (tmux -t names a group, not just
+// a session). The session is still created — it's just in a standalone group.
+func TestNewGroupedSession_NonexistentGroupTarget(t *testing.T) {
+	tm := newTestTmux(t)
+	sess := "gt-test-badgroup-" + t.Name()
+	_ = tm.KillSession(sess)
+	defer func() { _ = tm.KillSession(sess) }()
+
+	// tmux -t with a nonexistent target creates a new group (not an error)
+	err := tm.NewGroupedSessionWithCommandAndEnv(sess, "", "sleep 5", nil, "gt-nonexistent-session")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	has, _ := tm.HasSession(sess)
+	if !has {
+		t.Error("session should have been created even with nonexistent group target")
+	}
+}
+
+// TestKillGroupedSessionWindow verifies that killing a grouped session's window
+// removes it from the group without affecting other sessions.
+func TestKillGroupedSessionWindow(t *testing.T) {
+	tm := newTestTmux(t)
+
+	anchor := "gt-test-killwin-anchor-" + t.Name()
+	grouped := "gt-test-killwin-member-" + t.Name()
+	_ = tm.KillSession(anchor)
+	_ = tm.KillSession(grouped)
+	defer func() {
+		_ = tm.KillSession(grouped)
+		_ = tm.KillSession(anchor)
+	}()
+
+	if err := tm.NewSessionWithCommand(anchor, "", "sleep 30"); err != nil {
+		t.Fatalf("anchor creation: %v", err)
+	}
+
+	if err := tm.NewGroupedSessionWithCommandAndEnv(grouped, "", "sleep 30", nil, anchor); err != nil {
+		t.Fatalf("grouped creation: %v", err)
+	}
+
+	// Kill the grouped session's window
+	if err := tm.KillGroupedSessionWindow(grouped); err != nil {
+		t.Fatalf("killing grouped window: %v", err)
+	}
+
+	// Anchor should still be running
+	hasAnchor, _ := tm.HasSession(anchor)
+	if !hasAnchor {
+		t.Error("anchor session should still exist after killing grouped window")
+	}
+}
+
+// TestNewGroupedSession_MultipleMembers verifies that multiple sessions can join
+// the same group and each gets its own window.
+func TestNewGroupedSession_MultipleMembers(t *testing.T) {
+	tm := newTestTmux(t)
+
+	anchor := "gt-test-multi-anchor-" + t.Name()
+	member1 := "gt-test-multi-m1-" + t.Name()
+	member2 := "gt-test-multi-m2-" + t.Name()
+	_ = tm.KillSession(anchor)
+	_ = tm.KillSession(member1)
+	_ = tm.KillSession(member2)
+	defer func() {
+		_ = tm.KillSession(member2)
+		_ = tm.KillSession(member1)
+		_ = tm.KillSession(anchor)
+	}()
+
+	if err := tm.NewSessionWithCommand(anchor, "", "sleep 30"); err != nil {
+		t.Fatalf("anchor creation: %v", err)
+	}
+
+	if err := tm.NewGroupedSessionWithCommandAndEnv(member1, "", "sleep 30", nil, anchor); err != nil {
+		t.Fatalf("member1 creation: %v", err)
+	}
+
+	if err := tm.NewGroupedSessionWithCommandAndEnv(member2, "", "sleep 30", nil, anchor); err != nil {
+		t.Fatalf("member2 creation: %v", err)
+	}
+
+	// All three should exist and be grouped
+	for _, name := range []string{anchor, member1, member2} {
+		has, _ := tm.HasSession(name)
+		if !has {
+			t.Errorf("session %s not found", name)
+		}
+		if !tm.IsGroupedSession(name) {
+			t.Errorf("session %s should be grouped", name)
+		}
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -353,6 +353,110 @@ func (t *Tmux) NewSessionWithCommandAndEnv(name, workDir, command string, env ma
 	return t.checkSessionAfterCreate(name, command)
 }
 
+// NewGroupedSessionWithCommandAndEnv creates a tmux session that joins an existing
+// session's window group. All sessions in a group share the same set of windows,
+// so the overseer can see all crew windows from any attached session.
+//
+// The flow:
+//  1. Create a new session joined to groupTarget's window group (-t flag)
+//  2. Create a new window for this session's command (added to all group members)
+//  3. Run the command in the new window via respawn-pane
+//
+// Requires tmux >= 3.2 (for -e flags).
+func (t *Tmux) NewGroupedSessionWithCommandAndEnv(name, workDir, command string, env map[string]string, groupTarget string) error {
+	if err := validateSessionName(name); err != nil {
+		return err
+	}
+	if groupTarget == "" {
+		return fmt.Errorf("groupTarget is required for grouped session creation")
+	}
+	if workDir != "" {
+		info, err := os.Stat(workDir)
+		if err != nil {
+			return fmt.Errorf("invalid work directory %q: %w", workDir, err)
+		}
+		if !info.IsDir() {
+			return fmt.Errorf("work directory %q is not a directory", workDir)
+		}
+	}
+
+	// Step 1: Create session joined to the group. This shares all existing
+	// windows with the group target. No new window is created yet.
+	args := []string{"new-session", "-d", "-s", name, "-t", groupTarget}
+	if workDir != "" {
+		args = append(args, "-c", workDir)
+	}
+	// Add -e flags for session-level environment (same as NewSessionWithCommandAndEnv).
+	keys := make([]string, 0, len(env))
+	for k := range env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		args = append(args, "-e", fmt.Sprintf("%s=%s", k, env[k]))
+	}
+	if _, err := t.run(args...); err != nil {
+		return fmt.Errorf("creating grouped session %q (group %q): %w", name, groupTarget, err)
+	}
+
+	// Step 2: Create a new window for this crew member's command.
+	// The window is added to the group and visible to all sessions.
+	newWinArgs := []string{"new-window", "-t", name}
+	if workDir != "" {
+		newWinArgs = append(newWinArgs, "-c", workDir)
+	}
+	if _, err := t.run(newWinArgs...); err != nil {
+		_ = t.KillSession(name)
+		return fmt.Errorf("creating window in grouped session %q: %w", name, err)
+	}
+
+	// Step 3: Configure the new window (same as non-grouped path).
+	_, _ = t.run("set-option", "-wt", name, "window-size", "latest")
+	_, _ = t.run("set-option", "-t", name, "remain-on-exit", "on")
+
+	// Step 4: Replace the shell in the new window with the actual command.
+	respawnArgs := []string{"respawn-pane", "-k", "-t", name}
+	if workDir != "" {
+		respawnArgs = append(respawnArgs, "-c", workDir)
+	}
+	respawnArgs = append(respawnArgs, command)
+	if _, err := t.run(respawnArgs...); err != nil {
+		_ = t.KillSession(name)
+		return fmt.Errorf("failed to start command in grouped session %q: %w", name, err)
+	}
+
+	return t.checkSessionAfterCreate(name, command)
+}
+
+// KillGroupedSessionWindow kills the window owned by a grouped session before
+// destroying the session. In a window group, killing a session does NOT remove
+// its windows — they persist for other group members. This method finds and kills
+// the window that was created for the named session.
+func (t *Tmux) KillGroupedSessionWindow(sessionName string) error {
+	// Get the current window index for this session and kill it.
+	// When a grouped session is created, its current window is the one we
+	// created for it (via new-window in NewGroupedSessionWithCommandAndEnv).
+	winIdx, err := t.run("display-message", "-t", sessionName, "-p", "#{window_index}")
+	if err != nil {
+		return nil // Session may already be gone
+	}
+	idx := strings.TrimSpace(winIdx)
+	if idx == "" {
+		return nil
+	}
+	_, _ = t.run("kill-window", "-t", sessionName+":"+idx)
+	return nil
+}
+
+// IsGroupedSession checks whether a tmux session is part of a session group.
+func (t *Tmux) IsGroupedSession(sessionName string) bool {
+	group, err := t.run("display-message", "-t", sessionName, "-p", "#{session_group}")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(group) != ""
+}
+
 // checkSessionAfterCreate verifies that a newly created session's command didn't
 // fail immediately (binary not found, syntax error, etc.). Expects remain-on-exit
 // to already be enabled on the session. Checks the exit status after a brief delay.


### PR DESCRIPTION
## Summary

- Group crew tmux sessions into shared window groups so the overseer can see all crew windows from any attached session
- First crew member creates the group anchor; subsequent members join via `tmux new-session -t <anchor>`
- `gt crew stop` cleans up grouped session windows to prevent dead panes lingering in the group
- When starting additional crew members later, existing sessions are auto-detected as group targets

## Motivation

Currently `gt crew start` creates each crew member as an independent tmux session (1 window each). The overseer must switch between separate sessions rather than cycling windows within a single view. With window groups, all crew windows are visible when attached to any session in the group.

## Changes

| File | Change |
|------|--------|
| `internal/tmux/tmux.go` | Add `NewGroupedSessionWithCommandAndEnv`, `KillGroupedSessionWindow`, `IsGroupedSession` |
| `internal/crew/manager.go` | Add `GroupTarget` to `StartOptions`, use in `Start()`/`Stop()` |
| `internal/cmd/crew_lifecycle.go` | Sequential-first start pattern + `findCrewGroupTarget` helper |
| `internal/tmux/grouped_session_test.go` | 6 integration tests for grouped sessions |

## Test plan

- [x] All existing tmux tests pass (`go test ./internal/tmux/...`)
- [x] All existing crew tests pass (`go test ./internal/crew/...`)
- [x] New grouped session tests pass (basic, env vars, missing target, nonexistent target, kill window, multiple members)
- [ ] Manual: `gt crew start <rig>` → verify `tmux list-sessions` shows grouped sessions
- [ ] Manual: Attach to any crew session → verify all crew windows visible
- [ ] Manual: `gt crew stop <name>` → verify window cleaned up from group
- [ ] Manual: `gt cycle` still works within the group

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>