### PR TITLE
fix(reaper): replace O(n*m) correlated EXISTS with LEFT JOIN anti-pattern in Scan/Reap

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -147,31 +147,35 @@ func OpenDB(host string, port int, dbName string, readTimeout, writeTimeout time
 	return sql.Open("mysql", dsn)
 }
 
-// parentCheckWhere returns the SQL WHERE fragment that restricts operations to
-// wisps whose parent molecule is closed, that have no parent (orphans), or
-// whose parent was purged (dangling dependency reference).
-func parentCheckWhere(dbName string) string {
-	return fmt.Sprintf(`
-		(
-			NOT EXISTS (
-				SELECT 1 FROM `+"`%s`"+`.wisp_dependencies wd
-				WHERE wd.issue_id = w.id AND wd.type = 'parent-child'
-			)
-			OR
-			EXISTS (
-				SELECT 1 FROM `+"`%s`"+`.wisp_dependencies wd
-				JOIN `+"`%s`"+`.wisps parent ON parent.id = wd.depends_on_id
-				WHERE wd.issue_id = w.id AND wd.type = 'parent-child'
-				AND parent.status = 'closed'
-			)
-			OR
-			EXISTS (
-				SELECT 1 FROM `+"`%s`"+`.wisp_dependencies wd
-				LEFT JOIN `+"`%s`"+`.wisps parent ON parent.id = wd.depends_on_id
-				WHERE wd.issue_id = w.id AND wd.type = 'parent-child'
-				AND parent.id IS NULL
-			)
-		)`, dbName, dbName, dbName, dbName, dbName)
+// parentExcludeJoin returns a LEFT JOIN clause and WHERE condition that restricts
+// results to wisps whose parent molecule is closed, missing, or nonexistent.
+//
+// This replaces the previous parentCheckWhere() which used 3 correlated EXISTS
+// subqueries per row, causing O(n*m) query cost on large wisp tables (gt-jd1z).
+// The LEFT JOIN approach runs the subquery once and hash-joins: O(n+m).
+//
+// Semantics (unchanged from parentCheckWhere):
+//   - No parent-child dependency → eligible (orphan wisps)
+//   - Parent status is 'closed' → eligible (parent already reaped)
+//   - Parent row missing (dangling ref) → eligible (parent already purged)
+//
+// The inverse is simpler: exclude wisps that have an OPEN parent.
+//
+// Usage:
+//
+//	join, where := parentExcludeJoin(dbName)
+//	query := fmt.Sprintf("SELECT ... FROM `%s`.wisps w %s WHERE ... AND %s", dbName, join, where)
+func parentExcludeJoin(dbName string) (joinClause, whereCondition string) {
+	joinClause = fmt.Sprintf(
+		`LEFT JOIN (
+			SELECT DISTINCT wd.issue_id
+			FROM `+"`%s`"+`.wisp_dependencies wd
+			INNER JOIN `+"`%s`"+`.wisps parent ON parent.id = wd.depends_on_id
+			WHERE wd.type = 'parent-child'
+			AND parent.status IN ('open', 'hooked', 'in_progress')
+		) open_parent ON open_parent.issue_id = w.id`, dbName, dbName)
+	whereCondition = "open_parent.issue_id IS NULL"
+	return
 }
 
 // Scan counts reaper candidates in a database without modifying anything.
@@ -181,12 +185,13 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 
 	result := &ScanResult{Database: dbName}
 	now := time.Now().UTC()
-	parentCheck := parentCheckWhere(dbName)
+	parentJoin, parentWhere := parentExcludeJoin(dbName)
 
 	// Count reap candidates: open wisps past max_age with eligible parent status.
-	reapWhere := fmt.Sprintf(
-		"w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND %s", parentCheck)
-	reapQuery := fmt.Sprintf("SELECT COUNT(*) FROM `%s`.wisps w WHERE %s", dbName, reapWhere)
+	// Uses LEFT JOIN anti-pattern instead of correlated EXISTS to avoid O(n*m) cost (gt-jd1z).
+	reapQuery := fmt.Sprintf(
+		"SELECT COUNT(*) FROM `%s`.wisps w %s WHERE w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND %s",
+		dbName, parentJoin, parentWhere)
 	if err := db.QueryRowContext(ctx, reapQuery, now.Add(-maxAge)).Scan(&result.ReapCandidates); err != nil {
 		return nil, fmt.Errorf("count reap candidates: %w", err)
 	}
@@ -263,14 +268,14 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 	defer cancel()
 
 	cutoff := time.Now().UTC().Add(-maxAge)
-	parentCheck := parentCheckWhere(dbName)
+	parentJoin, parentWhere := parentExcludeJoin(dbName)
 	whereClause := fmt.Sprintf(
-		"w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND %s", parentCheck)
+		"w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND %s", parentWhere)
 
 	result := &ReapResult{Database: dbName, DryRun: dryRun}
 
 	if dryRun {
-		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM `%s`.wisps w WHERE %s", dbName, whereClause)
+		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM `%s`.wisps w %s WHERE %s", dbName, parentJoin, whereClause)
 		if err := db.QueryRowContext(ctx, countQuery, cutoff).Scan(&result.Reaped); err != nil {
 			return nil, fmt.Errorf("dry-run count: %w", err)
 		}
@@ -291,9 +296,10 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 
 	// Batch UPDATE: select IDs in chunks, update each chunk.
 	// This avoids holding a write lock on the entire table for minutes.
+	// Uses LEFT JOIN anti-pattern instead of correlated EXISTS to avoid O(n*m) cost (gt-jd1z).
 	idQuery := fmt.Sprintf(
-		"SELECT w.id FROM `%s`.wisps w WHERE %s LIMIT %d",
-		dbName, whereClause, DefaultBatchSize)
+		"SELECT w.id FROM `%s`.wisps w %s WHERE %s LIMIT %d",
+		dbName, parentJoin, whereClause, DefaultBatchSize)
 
 	totalReaped := 0
 	for {

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -48,21 +48,34 @@ func TestFormatJSON(t *testing.T) {
 	}
 }
 
-func TestParentCheckWhere(t *testing.T) {
-	sql := parentCheckWhere("testdb")
-	// Should reference the correct database in all subqueries.
-	if sql == "" {
-		t.Error("parentCheckWhere should not return empty string")
+func TestParentExcludeJoin(t *testing.T) {
+	joinClause, whereCondition := parentExcludeJoin("testdb")
+
+	// JOIN clause should reference the correct database.
+	if joinClause == "" {
+		t.Error("parentExcludeJoin joinClause should not be empty")
 	}
-	// Should contain all three branches: no parent, parent closed, dangling parent.
-	if !contains(sql, "NOT EXISTS") {
-		t.Error("parentCheckWhere should have NOT EXISTS branch for orphans")
+	if !contains(joinClause, "`testdb`") {
+		t.Error("parentExcludeJoin joinClause should reference the database")
 	}
-	if !contains(sql, "parent.status = 'closed'") {
-		t.Error("parentCheckWhere should check parent status is closed")
+
+	// JOIN should select wisps with open parents from wisp_dependencies.
+	if !contains(joinClause, "wisp_dependencies") {
+		t.Error("parentExcludeJoin should query wisp_dependencies")
 	}
-	if !contains(sql, "parent.id IS NULL") {
-		t.Error("parentCheckWhere should handle dangling parent refs")
+	if !contains(joinClause, "parent-child") {
+		t.Error("parentExcludeJoin should filter on parent-child type")
+	}
+	if !contains(joinClause, "'open', 'hooked', 'in_progress'") {
+		t.Error("parentExcludeJoin should check for open parent statuses")
+	}
+
+	// WHERE condition should be an IS NULL anti-join filter.
+	if whereCondition == "" {
+		t.Error("parentExcludeJoin whereCondition should not be empty")
+	}
+	if !contains(whereCondition, "IS NULL") {
+		t.Error("parentExcludeJoin whereCondition should use IS NULL for anti-join")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Replace `parentCheckWhere()` (3 correlated EXISTS subqueries per row, O(n*m)) with `parentExcludeJoin()` (single non-correlated LEFT JOIN subquery, O(n+m))
- Fixes Scan() and Reap() timeouts on HQ with 22K+ wisp rows causing 40-50s queries
- Completes the parent-check optimization started in b7d601aa (which fixed Purge only)

## Root Cause

`parentCheckWhere()` generated three correlated subqueries against `wisp_dependencies` that ran for **every row** in the outer `wisps` query. On large tables this caused O(n*m) cost, CPU spikes, and connection timeouts.

## Fix

Replace with a LEFT JOIN anti-join pattern:
1. Subquery: find all wisp IDs that have an **open** parent (runs once)
2. LEFT JOIN + IS NULL: exclude those wisps from the result

Semantics are identical — eligible wisps are those with no parent, a closed parent, or a missing/dangling parent reference.

## Test plan

- [x] `go test ./internal/reaper/` — all pass
- [x] `go vet ./internal/reaper/` — clean
- [x] `golangci-lint run ./internal/reaper/` — 0 issues
- [x] `go build ./...` — compiles clean

Fixes: gt-jd1z
Closes: #2292 (supersedes the timeout band-aid approach)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>