### PR TITLE
fix(rig): show actionable guidance when removing an orphaned rig directory

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -3,6 +3,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -24,6 +25,7 @@ import (
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/style"
+	"github.com/steveyegge/gastown/internal/suggest"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/wisp"
 	"github.com/steveyegge/gastown/internal/witness"
@@ -851,6 +853,23 @@ func runRigRemove(cmd *cobra.Command, args []string) error {
 	}
 
 	if err := mgr.RemoveRig(name); err != nil {
+		if errors.Is(err, rig.ErrRigNotFound) {
+			rigPath := filepath.Join(townRoot, name)
+			if info, statErr := os.Stat(rigPath); statErr == nil && info.IsDir() {
+				fmt.Printf("%s Rig %q is not registered but directory exists at %s\n\n",
+					style.Warning.Render("!"), name, rigPath)
+				fmt.Printf("This is an inconsistent state. To fix it, either:\n")
+				fmt.Printf("  Adopt the directory:  %s\n",
+					style.Dim.Render(fmt.Sprintf("gt rig add %s --adopt", name)))
+				fmt.Printf("  Delete the directory: %s\n",
+					style.Dim.Render(fmt.Sprintf("rm -rf %s", rigPath)))
+				return fmt.Errorf("rig %q not in registry but directory exists", name)
+			}
+			// Directory doesn't exist either — suggest similar rig names
+			suggestions := suggest.FindSimilar(name, mgr.ListRigNames(), 3)
+			return fmt.Errorf("removing rig: %s",
+				suggest.FormatSuggestion("rig", name, suggestions, ""))
+		}
 		return fmt.Errorf("removing rig: %w", err)
 	}
 

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -204,6 +204,23 @@ func TestRemoveRigNotFound(t *testing.T) {
 	}
 }
 
+func TestRemoveRigNotFoundWithOrphanDir(t *testing.T) {
+	root, rigsConfig := setupTestTown(t)
+	manager := NewManager(root, rigsConfig, git.NewGit(root))
+
+	// Create an orphaned directory on disk without registering it in config
+	orphanDir := filepath.Join(root, "orphan-rig")
+	if err := os.MkdirAll(orphanDir, 0o755); err != nil {
+		t.Fatalf("creating orphan dir: %v", err)
+	}
+
+	// Manager should still return ErrRigNotFound (UX is handled in cmd layer)
+	err := manager.RemoveRig("orphan-rig")
+	if err != ErrRigNotFound {
+		t.Errorf("RemoveRig orphan dir = %v, want ErrRigNotFound", err)
+	}
+}
+
 func TestAddRig_RejectsInvalidNames(t *testing.T) {
 	root, rigsConfig := setupTestTown(t)
 	manager := NewManager(root, rigsConfig, git.NewGit(root))


### PR DESCRIPTION
## Summary
- When `gt rig remove` hits a rig not in `rigs.json` but whose directory exists on disk, it now explains the inconsistent state and suggests `gt rig add <name> --adopt` or `rm -rf <path>`
- When neither the directory nor registry entry exists, it suggests similar rig names via fuzzy matching

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/rig/... -run RemoveRig -v` — all 3 tests pass (including new `TestRemoveRigNotFoundWithOrphanDir`)
- [ ] Manual: `gt rig remove <nonexistent>` shows suggestions
- [ ] Manual: create orphan dir in town root, run `gt rig remove <name>`, verify adopt/delete guidance

🤖 Generated with [Claude Code](https://claude.com/claude-code)