### PR TITLE
fix(tmux): refresh cycle bindings when prefix pattern is stale

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -591,6 +591,12 @@ func runRigAdd(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "Warning: failed to sync hooks for new rig: %v\n", err)
 	}
 
+	// Refresh tmux cycle bindings on all running sessions so the new rig's
+	// prefix is recognized by C-b n/p. Without this, existing sessions have
+	// a stale grep pattern that doesn't include the new prefix.
+	// See: https://github.com/steveyegge/gastown/issues/2299
+	refreshCycleBindingsOnExistingSessions()
+
 	elapsed := time.Since(startTime)
 
 	// Read default branch from rig config
@@ -878,6 +884,22 @@ func runRigRemove(cmd *cobra.Command, args []string) error {
 	fmt.Printf("To delete: %s\n", style.Dim.Render(fmt.Sprintf("rm -rf %s", filepath.Join(townRoot, name))))
 
 	return nil
+}
+
+// refreshCycleBindingsOnExistingSessions forces a refresh of the tmux C-b n/p
+// cycle bindings on any existing session. This is needed after gt rig add so
+// the new rig's prefix is included in the grep pattern.
+// Non-fatal: failure only means existing sessions need a restart to pick up the
+// new prefix.
+func refreshCycleBindingsOnExistingSessions() {
+	t := tmux.NewTmux()
+	sessions, err := t.ListSessions()
+	if err != nil || len(sessions) == 0 {
+		return
+	}
+	// Refresh bindings using any existing session as context.
+	// SetCycleBindings' stale-pattern check will detect the mismatch and re-bind.
+	_ = t.SetCycleBindings(sessions[0])
 }
 
 func runRigAdopt(_ *cobra.Command, args []string) error {

--- a/internal/tmux/cycle_bindings_test.go
+++ b/internal/tmux/cycle_bindings_test.go
@@ -1,0 +1,94 @@
+package tmux
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestIsGTBindingCurrent_DetectsStalePattern verifies that isGTBindingCurrent
+// returns false when the baked-in pattern doesn't match the current pattern.
+// This is the core of the gt rig add fix: after adding a rig, the prefix
+// pattern changes and existing bindings become stale.
+func TestIsGTBindingCurrent_DetectsStalePattern(t *testing.T) {
+	tm := newTestTmux(t)
+
+	session := "gt-test-stale-" + t.Name()
+	_ = tm.KillSession(session)
+	defer func() { _ = tm.KillSession(session) }()
+
+	if err := tm.NewSessionWithCommand(session, "", "sleep 30"); err != nil {
+		t.Fatalf("session creation: %v", err)
+	}
+
+	// Install a binding with an OLD pattern (missing a hypothetical "qu" prefix)
+	oldPattern := "^(gt|hq)-"
+	oldIfShell := "echo '#{session_name}' | grep -Eq '" + oldPattern + "'"
+	if _, err := tm.run("bind-key", "-T", "prefix", "n",
+		"if-shell", oldIfShell,
+		"run-shell 'gt cycle next --session #{session_name} --client #{client_tty}'",
+		"next-window"); err != nil {
+		t.Fatalf("installing old binding: %v", err)
+	}
+
+	// Verify the binding has --client (so isGTBindingWithClient returns true)
+	if !tm.isGTBindingWithClient("prefix", "n") {
+		t.Fatal("expected isGTBindingWithClient to return true for the installed binding")
+	}
+
+	// But the pattern is stale — a new pattern with "qu" should not match
+	newPattern := "^(gt|hq|qu)-"
+	if tm.isGTBindingCurrent("prefix", "n", newPattern) {
+		t.Error("expected isGTBindingCurrent to return false for stale pattern")
+	}
+
+	// The old pattern should still match
+	if !tm.isGTBindingCurrent("prefix", "n", oldPattern) {
+		t.Error("expected isGTBindingCurrent to return true for matching pattern")
+	}
+}
+
+// TestSetCycleBindings_RefreshesStalePattern verifies that SetCycleBindings
+// re-binds when the existing binding has a stale prefix pattern, even though
+// it already has --client support.
+func TestSetCycleBindings_RefreshesStalePattern(t *testing.T) {
+	tm := newTestTmux(t)
+
+	session := "gt-test-refresh-" + t.Name()
+	_ = tm.KillSession(session)
+	defer func() { _ = tm.KillSession(session) }()
+
+	if err := tm.NewSessionWithCommand(session, "", "sleep 30"); err != nil {
+		t.Fatalf("session creation: %v", err)
+	}
+
+	// Install a binding with a STALE pattern (only gt|hq, missing other prefixes)
+	stalePattern := "^(gt|hq)-"
+	staleIfShell := "echo '#{session_name}' | grep -Eq '" + stalePattern + "'"
+	if _, err := tm.run("bind-key", "-T", "prefix", "n",
+		"if-shell", staleIfShell,
+		"run-shell 'gt cycle next --session #{session_name} --client #{client_tty}'",
+		"next-window"); err != nil {
+		t.Fatalf("installing stale binding: %v", err)
+	}
+	if _, err := tm.run("bind-key", "-T", "prefix", "p",
+		"if-shell", staleIfShell,
+		"run-shell 'gt cycle prev --session #{session_name} --client #{client_tty}'",
+		"previous-window"); err != nil {
+		t.Fatalf("installing stale binding for p: %v", err)
+	}
+
+	// Call SetCycleBindings — it should detect the stale pattern and re-bind
+	if err := tm.SetCycleBindings(session); err != nil {
+		t.Fatalf("SetCycleBindings: %v", err)
+	}
+
+	// Verify the binding was updated with the current pattern
+	currentPattern := sessionPrefixPattern()
+	output, err := tm.run("list-keys", "-T", "prefix", "n")
+	if err != nil {
+		t.Fatalf("listing keys: %v", err)
+	}
+	if !strings.Contains(output, currentPattern) {
+		t.Errorf("expected binding to contain current pattern %q, got: %s", currentPattern, output)
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -112,7 +112,7 @@ func BuildCommand(args ...string) *exec.Cmd {
 	return BuildCommandContext(context.Background(), args...)
 }
 
-// BuildCommandContext is like BuildCommand but honours a context for cancellation.
+// BuildCommandContext is like BuildCommand but honors a context for cancellation.
 func BuildCommandContext(ctx context.Context, args ...string) *exec.Cmd {
 	allArgs := []string{"-u"}
 	if sock := GetDefaultSocket(); sock != "" {
@@ -2745,6 +2745,17 @@ func (t *Tmux) isGTBindingWithClient(table, key string) bool {
 		strings.Contains(output, "--client")
 }
 
+// isGTBindingCurrent checks whether the existing GT cycle binding has the
+// current prefix pattern. Returns false if the binding is stale (e.g., after
+// gt rig add introduces a new prefix not yet in the grep pattern).
+func (t *Tmux) isGTBindingCurrent(table, key, currentPattern string) bool {
+	output, err := t.run("list-keys", "-T", table, key)
+	if err != nil || output == "" {
+		return false
+	}
+	return strings.Contains(output, currentPattern)
+}
+
 // getKeyBinding returns the current tmux command bound to the given key in the
 // specified key table. Returns empty string if no binding exists or if querying
 // fails. This is used to capture user bindings before overwriting them, so the
@@ -2863,13 +2874,16 @@ func sessionPrefixPattern() string {
 // reliably preserve the session context. tmux expands #{session_name} at binding
 // resolution time (when the key is pressed), giving us the correct session.
 func (t *Tmux) SetCycleBindings(session string) error {
-	// Skip if already correctly configured (has --client for multi-client support).
-	// We must re-bind if an older GT binding exists without --client, since that
-	// version targets the wrong client when multiple tmux clients are attached.
-	if t.isGTBindingWithClient("prefix", "n") {
+	// Skip if already correctly configured:
+	// 1. Has --client for multi-client support
+	// 2. Has the current prefix pattern (not stale from before a gt rig add)
+	// We must re-bind if an older GT binding exists without --client, or if the
+	// prefix pattern is stale (missing newly added rig prefixes).
+	// See: https://github.com/steveyegge/gastown/issues/2299
+	pattern := sessionPrefixPattern()
+	if t.isGTBindingWithClient("prefix", "n") && t.isGTBindingCurrent("prefix", "n", pattern) {
 		return nil
 	}
-	pattern := sessionPrefixPattern()
 	ifShell := fmt.Sprintf("echo '#{session_name}' | grep -Eq '%s'", pattern)
 
 	// Capture existing bindings before overwriting, falling back to tmux defaults


### PR DESCRIPTION
## Summary

- Fix `SetCycleBindings` early-return guard to also check if the prefix pattern is current, not just that a binding with `--client` exists
- After `gt rig add`, proactively refresh cycle bindings on existing sessions so C-b n/p recognizes the new rig immediately
- Add `isGTBindingCurrent()` helper that compares the current `sessionPrefixPattern()` against what's baked into the existing binding

## Root Cause

`SetCycleBindings()` had this guard:
```go
if t.isGTBindingWithClient("prefix", "n") {
    return nil  // Skip - already configured
}
```

This only checked for `--client` support but not whether the grep pattern was stale. After `gt rig add quickbooks` (prefix `qu-`), the existing binding still had `^(gt|hq)-` without `qu`, so `C-b n` in a `qu-crew-*` session fell through to the default `next-window`.

## Changes

| File | Change |
|------|--------|
| `internal/tmux/tmux.go` | Add `isGTBindingCurrent()`, update `SetCycleBindings` guard to check pattern freshness |
| `internal/cmd/rig.go` | Add `refreshCycleBindingsOnExistingSessions()` called after rig creation |
| `internal/tmux/cycle_bindings_test.go` | 2 tests: stale pattern detection + SetCycleBindings refresh behavior |

## Test plan

- [x] New test: `TestIsGTBindingCurrent_DetectsStalePattern` — installs old pattern, verifies detection
- [x] New test: `TestSetCycleBindings_RefreshesStalePattern` — verifies re-bind on stale pattern
- [x] Full tmux test suite passes (84s, no regressions)
- [ ] Manual: `gt rig add testrig <url>` → verify C-b n/p works in existing sessions for new rig prefix

Fixes: https://github.com/steveyegge/gastown/issues/2299

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>