### PR TITLE
fix(ci): resolve lint errors and Windows test failures

### DIFF
--- a/cmd/gt-proxy-client/main.go
+++ b/cmd/gt-proxy-client/main.go
@@ -57,7 +57,7 @@ func main() {
 		os.Exit(1)
 	}
 
-	caPEM, err := os.ReadFile(caFile)
+	caPEM, err := os.ReadFile(caFile) //nolint:gosec // caFile is from trusted env var GT_PROXY_CA
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "gt-proxy-client: read CA: %v\n", err)
 		os.Exit(1)
@@ -90,12 +90,12 @@ func main() {
 		os.Exit(1)
 	}
 
-	resp, err := httpClient.Post(proxyURL+"/v1/exec", "application/json", bytes.NewReader(body))
+	resp, err := httpClient.Post(proxyURL+"/v1/exec", "application/json", bytes.NewReader(body)) //nolint:gosec // proxyURL is from trusted env var GT_PROXY_URL
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "gt-proxy-client: proxy request failed: %v\n", err)
 		os.Exit(1)
 	}
-	defer resp.Body.Close()
+	defer resp.Body.Close() //nolint:errcheck // best-effort close on response body
 
 	if resp.StatusCode != http.StatusOK {
 		msg, _ := io.ReadAll(resp.Body)
@@ -110,10 +110,10 @@ func main() {
 	}
 
 	if result.Stdout != "" {
-		fmt.Fprint(os.Stdout, result.Stdout)
+		_, _ = fmt.Fprint(os.Stdout, result.Stdout)
 	}
 	if result.Stderr != "" {
-		fmt.Fprint(os.Stderr, result.Stderr)
+		_, _ = fmt.Fprint(os.Stderr, result.Stderr)
 	}
 	os.Exit(result.ExitCode)
 }
@@ -129,7 +129,7 @@ func execReal() {
 	if realBin == "" {
 		realBin = "/usr/local/bin/gt.real"
 	}
-	if err := syscall.Exec(realBin, os.Args, os.Environ()); err != nil {
+	if err := syscall.Exec(realBin, os.Args, os.Environ()); err != nil { //nolint:gosec // realBin is from GT_REAL_BIN or hardcoded default
 		fmt.Fprintf(os.Stderr, "gt-proxy-client: exec %s: %v\n", realBin, err)
 		os.Exit(1)
 	}

--- a/cmd/gt-proxy-server/config.go
+++ b/cmd/gt-proxy-server/config.go
@@ -62,7 +62,7 @@ type ProxyConfig struct {
 // If the file does not exist, an empty ProxyConfig is returned (not an error).
 // JSON parse errors are returned as errors.
 func loadConfig(path string) (ProxyConfig, error) {
-	data, err := os.ReadFile(path)
+	data, err := os.ReadFile(path) //nolint:gosec // path is derived from internal config location
 	if errors.Is(err, os.ErrNotExist) {
 		return ProxyConfig{}, nil
 	}

--- a/cmd/gt-proxy-server/main.go
+++ b/cmd/gt-proxy-server/main.go
@@ -167,7 +167,7 @@ func discoverAllowedSubcmds() string {
 	return result
 }
 
-// buildAllowedSubcmds serialises a map[string][]string back into the semicolon-separated
+// buildAllowedSubcmds serializes a map[string][]string back into the semicolon-separated
 // "cmd:sub1,sub2,..." format expected by parseAllowedSubcmds.
 func buildAllowedSubcmds(m map[string][]string) string {
 	parts := make([]string, 0, len(m))

--- a/internal/agentlog/claudecode.go
+++ b/internal/agentlog/claudecode.go
@@ -98,7 +98,7 @@ func (a *ClaudeCodeAdapter) Watch(ctx context.Context, sessionID, workDir string
 // Formula: $HOME/.claude/projects/<hash> where hash = workDir with '/' → '-'.
 // On Windows, backslashes are converted to forward slashes and the drive
 // letter (e.g. "C:") is stripped before hashing, matching Claude Code's
-// cross-platform behaviour.
+// cross-platform behavior.
 func claudeProjectDirFor(workDir string) (string, error) {
 	abs, err := filepath.Abs(workDir)
 	if err != nil {

--- a/internal/proxy/server.go
+++ b/internal/proxy/server.go
@@ -201,7 +201,7 @@ func (s *Server) DenyCert(serial *big.Int) {
 	s.denyList.Deny(serial)
 }
 
-// Start begins listening and serving. Blocks until ctx is cancelled.
+// Start begins listening and serving. Blocks until ctx is canceled.
 func (s *Server) Start(ctx context.Context) error {
 	pool := x509.NewCertPool()
 	pool.AddCert(s.ca.Cert)

--- a/internal/proxy/server_test.go
+++ b/internal/proxy/server_test.go
@@ -45,28 +45,28 @@ func TestNew(t *testing.T) {
 	})
 
 	t.Run("AllowedCommands are stored in allowed map", func(t *testing.T) {
-		srv, err := New(Config{TownRoot: t.TempDir(), AllowedCommands: []string{"gt", "bd"}, Logger: discardLogger()}, nil)
+		srv, err := New(Config{TownRoot: t.TempDir(), AllowedCommands: []string{"echo", "true"}, Logger: discardLogger()}, nil)
 		require.NoError(t, err)
-		assert.True(t, srv.allowed["gt"])
-		assert.True(t, srv.allowed["bd"])
+		assert.True(t, srv.allowed["echo"])
+		assert.True(t, srv.allowed["true"])
 		assert.False(t, srv.allowed["curl"])
 	})
 
 	t.Run("isAllowed reflects allowed map", func(t *testing.T) {
-		srv, err := New(Config{TownRoot: t.TempDir(), AllowedCommands: []string{"gt", "bd"}, Logger: discardLogger()}, nil)
+		srv, err := New(Config{TownRoot: t.TempDir(), AllowedCommands: []string{"echo", "true"}, Logger: discardLogger()}, nil)
 		require.NoError(t, err)
-		assert.True(t, srv.isAllowed("gt"))
-		assert.True(t, srv.isAllowed("bd"))
+		assert.True(t, srv.isAllowed("echo"))
+		assert.True(t, srv.isAllowed("true"))
 		assert.False(t, srv.isAllowed("curl"))
 		assert.False(t, srv.isAllowed(""))
 	})
 
 	t.Run("AllowedCommands with path separators are rejected", func(t *testing.T) {
-		srv, err := New(Config{TownRoot: t.TempDir(), AllowedCommands: []string{"/usr/bin/gt", "bd", `C:\gt.exe`}, Logger: discardLogger()}, nil)
+		srv, err := New(Config{TownRoot: t.TempDir(), AllowedCommands: []string{"/usr/bin/echo", "true", `C:\echo.exe`}, Logger: discardLogger()}, nil)
 		require.NoError(t, err)
-		assert.False(t, srv.isAllowed("/usr/bin/gt"), "absolute path should be rejected")
-		assert.True(t, srv.isAllowed("bd"), "plain name should be accepted")
-		assert.False(t, srv.isAllowed(`C:\gt.exe`), "windows path should be rejected")
+		assert.False(t, srv.isAllowed("/usr/bin/echo"), "absolute path should be rejected")
+		assert.True(t, srv.isAllowed("true"), "plain name should be accepted")
+		assert.False(t, srv.isAllowed(`C:\echo.exe`), "windows path should be rejected")
 	})
 }
 

--- a/internal/refinery/batch_test.go
+++ b/internal/refinery/batch_test.go
@@ -244,8 +244,9 @@ func TestBuildRebaseStack_SingleMR(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("expected a.txt to exist: %v", readErr)
 	}
-	if string(content) != "hello a\n" {
-		t.Errorf("expected 'hello a\\n', got %q", string(content))
+	got := strings.ReplaceAll(string(content), "\r\n", "\n")
+	if got != "hello a\n" {
+		t.Errorf("expected 'hello a\\n', got %q", got)
 	}
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -112,7 +112,7 @@ func BuildCommand(args ...string) *exec.Cmd {
 	return BuildCommandContext(context.Background(), args...)
 }
 
-// BuildCommandContext is like BuildCommand but honours a context for cancellation.
+// BuildCommandContext is like BuildCommand but honors a context for cancellation.
 func BuildCommandContext(ctx context.Context, args ...string) *exec.Cmd {
 	allArgs := []string{"-u"}
 	if sock := GetDefaultSocket(); sock != "" {

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1032,13 +1032,13 @@ func DetectZombiePolecats(bd *BdCli, workDir, rigName string, router *mail.Route
 				continue
 			}
 
-			if zombie, found := detectZombieLiveSession(bd, workDir, townRoot, rigName, polecatName, agentBeadID, sessionName, t, doneIntent, witCfg, snap); found {
+			if zombie, found := detectZombieLiveSession(bd, workDir, townRoot, rigName, polecatName, sessionName, t, doneIntent, witCfg, snap); found {
 				result.Zombies = append(result.Zombies, zombie)
 			}
 			continue // Either handled or not a zombie
 		}
 
-		if zombie, found := detectZombieDeadSession(bd, workDir, townRoot, rigName, polecatName, agentBeadID, sessionName, t, doneIntent, detectedAt, witCfg, snap); found {
+		if zombie, found := detectZombieDeadSession(bd, workDir, townRoot, rigName, polecatName, sessionName, t, doneIntent, detectedAt, witCfg, snap); found {
 			result.Zombies = append(result.Zombies, zombie)
 		}
 	}
@@ -1051,7 +1051,7 @@ func DetectZombiePolecats(bd *BdCli, workDir, rigName string, router *mail.Route
 //
 // gt-dsgp: Uses restart-first policy. Instead of nuking polecats, restarts their
 // sessions to preserve worktrees and branches.
-func detectZombieLiveSession(bd *BdCli, workDir, townRoot, rigName, polecatName, agentBeadID, sessionName string, t *tmux.Tmux, doneIntent *DoneIntent, witCfg *config.WitnessThresholds, snap *agentBeadSnapshot) (ZombieResult, bool) {
+func detectZombieLiveSession(bd *BdCli, workDir, townRoot, rigName, polecatName, sessionName string, t *tmux.Tmux, doneIntent *DoneIntent, witCfg *config.WitnessThresholds, snap *agentBeadSnapshot) (ZombieResult, bool) {
 	// gt-2gra: Agent state and hook bead are read from the pre-fetched snapshot
 	// instead of calling getAgentBeadState multiple times per code path.
 	snapState, snapHook := "", ""
@@ -1171,7 +1171,7 @@ func detectZombieLiveSession(bd *BdCli, workDir, townRoot, rigName, polecatName,
 //
 // gt-dsgp: Uses restart-first policy. Instead of nuking polecats with dead sessions,
 // restarts them to preserve worktrees and branches.
-func detectZombieDeadSession(bd *BdCli, workDir, townRoot, rigName, polecatName, agentBeadID, sessionName string, t *tmux.Tmux, doneIntent *DoneIntent, detectedAt time.Time, witCfg *config.WitnessThresholds, snap *agentBeadSnapshot) (ZombieResult, bool) {
+func detectZombieDeadSession(bd *BdCli, workDir, townRoot, rigName, polecatName, sessionName string, t *tmux.Tmux, doneIntent *DoneIntent, detectedAt time.Time, witCfg *config.WitnessThresholds, snap *agentBeadSnapshot) (ZombieResult, bool) {
 	// gt-2gra: Agent state and hook bead are read from the pre-fetched snapshot.
 	snapState, snapHook := "", ""
 	snapActiveMR := ""


### PR DESCRIPTION
## Summary

- **misspell** (4): `serialises`→`serializes`, `behaviour`→`behavior`, `cancelled`→`canceled`, `honours`→`honors`
- **errcheck** (2): handle `resp.Body.Close` and `fmt.Fprint` return values in `gt-proxy-client`
- **gosec** (4): add `//nolint:gosec` directives for intentional file reads, SSRF, and subprocess exec
- **unparam** (2): remove unused `agentBeadID` parameter from `detectZombieLiveSession`/`detectZombieDeadSession`
- **proxy tests**: use PATH-available commands (`echo`, `true`) instead of `gt`/`bd` which aren't in CI PATH after LookPath validation was added
- **batch test**: normalize CRLF→LF when comparing file content for Windows compatibility

## Root Cause

All 12 lint issues and 4 unit test failures are pre-existing on `main` (not regressions). The proxy server tests broke when `New()` gained `exec.LookPath` validation — `gt`/`bd` aren't in CI's PATH. The Windows batch test fails because git auto-converts `\n` to `\r\n` on Windows.

## Test plan

- [ ] Lint job passes (all 12 issues resolved)
- [ ] Unit tests pass on Linux (proxy `TestNew` subtests fixed)
- [ ] Windows build passes (CRLF normalization in batch test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)