### PR TITLE
feat: add Cursor hooks support for polecat agent integration

### DIFF
--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -236,15 +236,19 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		SessionIDEnv:        "", // Uses --resume with chatId directly
 		ResumeFlag:          "--resume",
 		ResumeStyle:         "flag",
-		SupportsHooks:       false, // TODO: verify hooks support
+		SupportsHooks:       true,
 		SupportsForkSession: false,
 		NonInteractive: &NonInteractiveConfig{
 			PromptFlag: "-p",
 			OutputFlag: "--output-format json",
 		},
 		// Runtime defaults
-		PromptMode:       "arg",
-		InstructionsFile: "AGENTS.md",
+		PromptMode:        "arg",
+		ConfigDir:         ".cursor",
+		HooksProvider:     "cursor",
+		HooksDir:          ".cursor",
+		HooksSettingsFile: "hooks.json",
+		InstructionsFile:  "AGENTS.md",
 	},
 	AgentAuggie: {
 		Name:                AgentAuggie,

--- a/internal/cursor/config/hooks-autonomous.json
+++ b/internal/cursor/config/hooks-autonomous.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard pr-workflow",
+        "matcher": "Shell(gh pr create*)"
+      },
+      {
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard pr-workflow",
+        "matcher": "Shell(git checkout -b*)"
+      },
+      {
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard pr-workflow",
+        "matcher": "Shell(git switch -c*)"
+      }
+    ],
+    "sessionStart": [
+      {
+        "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime --hook && gt mail check --inject"
+      }
+    ],
+    "preCompact": [
+      {
+        "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime --hook"
+      }
+    ],
+    "beforeSubmitPrompt": [
+      {
+        "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt mail check --inject"
+      }
+    ],
+    "stop": [
+      {
+        "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt costs record"
+      }
+    ]
+  }
+}

--- a/internal/cursor/config/hooks-interactive.json
+++ b/internal/cursor/config/hooks-interactive.json
@@ -1,0 +1,39 @@
+{
+  "version": 1,
+  "hooks": {
+    "preToolUse": [
+      {
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard pr-workflow",
+        "matcher": "Shell(gh pr create*)"
+      },
+      {
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard pr-workflow",
+        "matcher": "Shell(git checkout -b*)"
+      },
+      {
+        "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard pr-workflow",
+        "matcher": "Shell(git switch -c*)"
+      }
+    ],
+    "sessionStart": [
+      {
+        "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime --hook"
+      }
+    ],
+    "preCompact": [
+      {
+        "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime --hook"
+      }
+    ],
+    "beforeSubmitPrompt": [
+      {
+        "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt mail check --inject"
+      }
+    ],
+    "stop": [
+      {
+        "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt costs record"
+      }
+    ]
+  }
+}

--- a/internal/cursor/settings.go
+++ b/internal/cursor/settings.go
@@ -1,0 +1,73 @@
+// Package cursor provides Cursor agent configuration management.
+package cursor
+
+import (
+	"embed"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/steveyegge/gastown/internal/constants"
+)
+
+//go:embed config/*.json
+var configFS embed.FS
+
+// RoleType indicates whether a role is autonomous or interactive.
+type RoleType string
+
+const (
+	// Autonomous roles (polecat, witness, refinery) need mail in sessionStart
+	// because they may be triggered externally without user input.
+	Autonomous RoleType = "autonomous"
+
+	// Interactive roles (mayor, crew) wait for user input, so beforeSubmitPrompt
+	// handles mail injection.
+	Interactive RoleType = "interactive"
+)
+
+// RoleTypeFor returns the RoleType for a given role name.
+func RoleTypeFor(role string) RoleType {
+	switch role {
+	case constants.RolePolecat, constants.RoleWitness, constants.RoleRefinery, constants.RoleDeacon, "boot":
+		return Autonomous
+	default:
+		return Interactive
+	}
+}
+
+// EnsureHooksAt ensures a hooks.json file exists at a custom directory/file.
+// Cursor has no --settings flag, so hooks are installed in workDir
+// (the agent's working directory), not a separate settingsDir.
+// If the file already exists, it's left unchanged.
+func EnsureHooksAt(workDir string, roleType RoleType, hooksDir, hooksFile string) error {
+	cursorDir := filepath.Join(workDir, hooksDir)
+	hooksPath := filepath.Join(cursorDir, hooksFile)
+
+	if _, err := os.Stat(hooksPath); err == nil {
+		return nil
+	}
+	if err := os.MkdirAll(cursorDir, 0755); err != nil {
+		return fmt.Errorf("creating hooks directory: %w", err)
+	}
+	var templateName string
+	switch roleType {
+	case Autonomous:
+		templateName = "config/hooks-autonomous.json"
+	default:
+		templateName = "config/hooks-interactive.json"
+	}
+	content, err := configFS.ReadFile(templateName)
+	if err != nil {
+		return fmt.Errorf("reading template %s: %w", templateName, err)
+	}
+	if err := os.WriteFile(hooksPath, content, 0600); err != nil {
+		return fmt.Errorf("writing hooks: %w", err)
+	}
+	return nil
+}
+
+// EnsureHooksForRoleAt is a convenience function that combines RoleTypeFor and EnsureHooksAt.
+func EnsureHooksForRoleAt(workDir, role, hooksDir, hooksFile string) error {
+	return EnsureHooksAt(workDir, RoleTypeFor(role), hooksDir, hooksFile)
+}

--- a/internal/cursor/settings_test.go
+++ b/internal/cursor/settings_test.go
@@ -1,0 +1,110 @@
+package cursor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRoleTypeFor(t *testing.T) {
+	tests := []struct {
+		role     string
+		expected RoleType
+	}{
+		{"polecat", Autonomous},
+		{"witness", Autonomous},
+		{"refinery", Autonomous},
+		{"deacon", Autonomous},
+		{"boot", Autonomous},
+		{"mayor", Interactive},
+		{"crew", Interactive},
+		{"unknown", Interactive},
+	}
+	for _, tt := range tests {
+		t.Run(tt.role, func(t *testing.T) {
+			actual := RoleTypeFor(tt.role)
+			assert.Equal(t, tt.expected, actual)
+		})
+	}
+}
+
+func TestEnsureHooksAt_CreatesAutonomousHooks(t *testing.T) {
+	tmpDir := t.TempDir()
+	err := EnsureHooksAt(tmpDir, Autonomous, ".cursor", "hooks.json")
+	require.NoError(t, err)
+	hooksPath := filepath.Join(tmpDir, ".cursor", "hooks.json")
+	content, err := os.ReadFile(hooksPath)
+	require.NoError(t, err)
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(content, &result))
+	assert.Equal(t, float64(1), result["version"])
+	hooks, ok := result["hooks"].(map[string]interface{})
+	require.True(t, ok)
+	sessionStart, ok := hooks["sessionStart"].([]interface{})
+	require.True(t, ok)
+	require.Len(t, sessionStart, 1)
+	cmd := sessionStart[0].(map[string]interface{})["command"].(string)
+	assert.Contains(t, cmd, "gt prime --hook")
+	assert.Contains(t, cmd, "gt mail check --inject")
+}
+
+func TestEnsureHooksAt_CreatesInteractiveHooks(t *testing.T) {
+	tmpDir := t.TempDir()
+	err := EnsureHooksAt(tmpDir, Interactive, ".cursor", "hooks.json")
+	require.NoError(t, err)
+	hooksPath := filepath.Join(tmpDir, ".cursor", "hooks.json")
+	content, err := os.ReadFile(hooksPath)
+	require.NoError(t, err)
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(content, &result))
+	hooks := result["hooks"].(map[string]interface{})
+	sessionStart := hooks["sessionStart"].([]interface{})
+	require.Len(t, sessionStart, 1)
+	cmd := sessionStart[0].(map[string]interface{})["command"].(string)
+	assert.Contains(t, cmd, "gt prime --hook")
+	assert.NotContains(t, cmd, "gt mail check --inject")
+}
+
+func TestEnsureHooksAt_DoesNotOverwriteExisting(t *testing.T) {
+	tmpDir := t.TempDir()
+	cursorDir := filepath.Join(tmpDir, ".cursor")
+	require.NoError(t, os.MkdirAll(cursorDir, 0755))
+	existingContent := []byte(`{"version":1,"hooks":{"custom":true}}`)
+	hooksPath := filepath.Join(cursorDir, "hooks.json")
+	require.NoError(t, os.WriteFile(hooksPath, existingContent, 0600))
+	err := EnsureHooksAt(tmpDir, Autonomous, ".cursor", "hooks.json")
+	require.NoError(t, err)
+	content, err := os.ReadFile(hooksPath)
+	require.NoError(t, err)
+	assert.Equal(t, existingContent, content)
+}
+
+func TestEnsureHooksForRoleAt(t *testing.T) {
+	tmpDir := t.TempDir()
+	err := EnsureHooksForRoleAt(tmpDir, "polecat", ".cursor", "hooks.json")
+	require.NoError(t, err)
+	hooksPath := filepath.Join(tmpDir, ".cursor", "hooks.json")
+	content, err := os.ReadFile(hooksPath)
+	require.NoError(t, err)
+	assert.Contains(t, string(content), "gt mail check --inject")
+}
+
+func TestEnsureHooksAt_HasAllExpectedEvents(t *testing.T) {
+	tmpDir := t.TempDir()
+	err := EnsureHooksAt(tmpDir, Autonomous, ".cursor", "hooks.json")
+	require.NoError(t, err)
+	content, err := os.ReadFile(filepath.Join(tmpDir, ".cursor", "hooks.json"))
+	require.NoError(t, err)
+	var result map[string]interface{}
+	require.NoError(t, json.Unmarshal(content, &result))
+	hooks := result["hooks"].(map[string]interface{})
+	expectedEvents := []string{"sessionStart", "preCompact", "beforeSubmitPrompt", "preToolUse", "stop"}
+	for _, event := range expectedEvents {
+		_, ok := hooks[event]
+		assert.True(t, ok, "missing hook event: %s", event)
+	}
+}

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -10,6 +10,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/copilot"
+	"github.com/steveyegge/gastown/internal/cursor"
 	"github.com/steveyegge/gastown/internal/gemini"
 	"github.com/steveyegge/gastown/internal/omp"
 	"github.com/steveyegge/gastown/internal/opencode"
@@ -40,6 +41,10 @@ func init() {
 	config.RegisterHookInstaller("omp", func(settingsDir, workDir, role, hooksDir, hooksFile string) error {
 		// OMP hooks stay in workDir — loaded via --hook flag.
 		return omp.EnsureHookAt(workDir, hooksDir, hooksFile)
+	})
+	config.RegisterHookInstaller("cursor", func(settingsDir, workDir, role, hooksDir, hooksFile string) error {
+		// Cursor has no --settings flag; install hooks in workDir.
+		return cursor.EnsureHooksForRoleAt(workDir, role, hooksDir, hooksFile)
 	})
 	config.RegisterHookInstaller("pi", func(settingsDir, workDir, role, hooksDir, hooksFile string) error {
 		// Pi extensions stay in workDir — loaded via -e flag.


### PR DESCRIPTION
## Summary

- Enable hooks support for the Cursor agent preset (`SupportsHooks: true`)
- Register a dedicated `cursor` hook installer in runtime that writes hook config into `.cursor/` directory
- Add Cursor settings module with hooks configuration for both autonomous and interactive modes
- Include unit tests for the new Cursor settings functionality

## Test plan

- [ ] Verify `go test ./internal/cursor/...` passes
- [ ] Verify `go test ./...` passes with no regressions
- [ ] Test hook installation on a real project with Cursor agent
