### PR TITLE
fix(daemon): add grace period before auto-closing empty convoys

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -1193,6 +1193,7 @@ type strandedConvoyInfo struct {
 	TrackedCount int      `json:"tracked_count"`
 	ReadyCount   int      `json:"ready_count"`
 	ReadyIssues  []string `json:"ready_issues"`
+	CreatedAt    string   `json:"created_at"`
 }
 
 // readyIssueInfo holds info about a ready (stranded) issue.
@@ -1294,8 +1295,9 @@ func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
 	}
 
 	var convoys []struct {
-		ID    string `json:"id"`
-		Title string `json:"title"`
+		ID        string `json:"id"`
+		Title     string `json:"title"`
+		CreatedAt string `json:"created_at"`
 	}
 	if err := json.Unmarshal(out, &convoys); err != nil {
 		return nil, fmt.Errorf("parsing convoy list: %w", err)
@@ -1319,6 +1321,7 @@ func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
 				TrackedCount: 0,
 				ReadyCount:   0,
 				ReadyIssues:  []string{},
+				CreatedAt:    convoy.CreatedAt,
 			})
 			continue
 		}
@@ -1356,6 +1359,7 @@ func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
 				TrackedCount: len(tracked),
 				ReadyCount:   len(readyIssues),
 				ReadyIssues:  readyIssues,
+				CreatedAt:    convoy.CreatedAt,
 			})
 		} else {
 			// Has tracked issues but none are ready — include in stranded
@@ -1366,6 +1370,7 @@ func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
 				TrackedCount: len(tracked),
 				ReadyCount:   0,
 				ReadyIssues:  []string{},
+				CreatedAt:    convoy.CreatedAt,
 			})
 		}
 	}

--- a/internal/daemon/convoy_manager.go
+++ b/internal/daemon/convoy_manager.go
@@ -19,15 +19,21 @@ import (
 const (
 	defaultStrandedScanInterval = 30 * time.Second
 	eventPollInterval           = 5 * time.Second
+
+	// convoyGracePeriod is how long after creation a convoy is immune from
+	// auto-close. This prevents a race where the daemon's stranded scan
+	// fires before the sling's bd dep add is visible in Dolt. See GH#2303.
+	convoyGracePeriod = 5 * time.Minute
 )
 
 // strandedConvoyInfo matches the JSON output of `gt convoy stranded --json`.
 type strandedConvoyInfo struct {
-	ID           string   `json:"id"`
-	Title        string   `json:"title"`
-	TrackedCount int      `json:"tracked_count"`
-	ReadyCount   int      `json:"ready_count"`
-	ReadyIssues  []string `json:"ready_issues"`
+	ID           string    `json:"id"`
+	Title        string    `json:"title"`
+	TrackedCount int       `json:"tracked_count"`
+	ReadyCount   int       `json:"ready_count"`
+	ReadyIssues  []string  `json:"ready_issues"`
+	CreatedAt    time.Time `json:"created_at"`
 }
 
 // ConvoyManager monitors beads events for issue closes and periodically scans for stranded convoys.
@@ -354,7 +360,12 @@ func (m *ConvoyManager) scan() {
 		if c.ReadyCount > 0 {
 			m.feedFirstReady(c)
 		} else if c.TrackedCount == 0 {
-			// Truly empty convoy — safe to auto-close mechanically.
+			// Empty convoy — but skip if it was just created (GH#2303).
+			// The sling's bd dep add may not be visible in Dolt yet.
+			if !c.CreatedAt.IsZero() && time.Since(c.CreatedAt) < convoyGracePeriod {
+				m.logger("Convoy %s: empty but within grace period (created %s ago) — skipping", c.ID, time.Since(c.CreatedAt).Round(time.Second))
+				continue
+			}
 			m.closeEmptyConvoy(c.ID)
 		} else {
 			// Tracked issues exist but none are ready. This requires agent

--- a/internal/daemon/convoy_manager_test.go
+++ b/internal/daemon/convoy_manager_test.go
@@ -279,6 +279,71 @@ func TestScanStranded_ClosesEmptyConvoys(t *testing.T) {
 	}
 }
 
+func TestScanStranded_GracePeriodSkipsRecentConvoy(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on Windows")
+	}
+
+	// Convoy created 30 seconds ago — well within the 5-minute grace period.
+	recentTime := time.Now().UTC().Add(-30 * time.Second).Format(time.RFC3339)
+	strandedJSON := fmt.Sprintf(`[{"id":"hq-new1","title":"New","tracked_count":0,"ready_count":0,"ready_issues":[],"created_at":"%s"}]`, recentTime)
+
+	paths := mockGtForScanTest(t, scanTestOpts{
+		strandedJSON: strandedJSON,
+	})
+
+	var logged []string
+	logger := func(format string, args ...interface{}) {
+		logged = append(logged, fmt.Sprintf(format, args...))
+	}
+
+	m := NewConvoyManager(paths.townRoot, logger, "gt", 10*time.Minute, nil, nil, nil)
+	m.scan()
+
+	// Convoy check must NOT have been called — grace period should protect it.
+	if _, err := os.Stat(paths.checkLogPath); err == nil {
+		data, _ := os.ReadFile(paths.checkLogPath)
+		t.Errorf("convoy check was called for recent convoy (grace period should protect): %s", data)
+	}
+
+	// Should see grace period log message.
+	found := false
+	for _, s := range logged {
+		if strings.Contains(s, "grace period") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected grace period log message, got: %v", logged)
+	}
+}
+
+func TestScanStranded_GracePeriodAllowsOldConvoy(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on Windows")
+	}
+
+	// Convoy created 10 minutes ago — past the 5-minute grace period.
+	oldTime := time.Now().UTC().Add(-10 * time.Minute).Format(time.RFC3339)
+	strandedJSON := fmt.Sprintf(`[{"id":"hq-old1","title":"Old","tracked_count":0,"ready_count":0,"ready_issues":[],"created_at":"%s"}]`, oldTime)
+
+	paths := mockGtForScanTest(t, scanTestOpts{
+		strandedJSON: strandedJSON,
+	})
+
+	m := NewConvoyManager(paths.townRoot, func(string, ...interface{}) {}, "gt", 10*time.Minute, nil, nil, nil)
+	m.scan()
+
+	data, err := os.ReadFile(paths.checkLogPath)
+	if err != nil {
+		t.Fatalf("read check log: %v", err)
+	}
+	if !strings.Contains(string(data), "hq-old1") {
+		t.Errorf("expected gt convoy check for hq-old1 (past grace period), got: %q", data)
+	}
+}
+
 func TestScanStranded_NoStrandedConvoys(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on Windows")


### PR DESCRIPTION
## Summary

- Adds a 5-minute grace period before the daemon auto-closes empty convoys
- Fixes race condition where `gt sling` creates a convoy + tracking dep, but the daemon's stranded scan fires ~30s later before the `bd dep add` is visible in Dolt
- Convoys younger than 5 minutes with 0 tracked issues are skipped instead of auto-closed
- Backward compatible: convoys without `created_at` (zero value) are still closed immediately

## Test plan

- [x] New test: `TestScanStranded_GracePeriodSkipsRecentConvoy` — verifies convoy created 30s ago is NOT auto-closed
- [x] New test: `TestScanStranded_GracePeriodAllowsOldConvoy` — verifies convoy created 10min ago IS auto-closed
- [x] Existing `TestScanStranded_ClosesEmptyConvoys` still passes (no `created_at` = zero value = no grace period)
- [ ] Manual: `gt sling <bead> <rig>` → wait 30s → `gt convoy list` should show convoy still open

Fixes #2303

🤖 Generated with [Claude Code](https://claude.com/claude-code)