### PR TITLE
fix(tmux): refresh cycle bindings when rig prefix pattern is stale

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -593,6 +593,16 @@ func runRigAdd(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "Warning: failed to sync hooks for new rig: %v\n", err)
 	}
 
+	// Refresh tmux cycle bindings so the new rig's prefix is included
+	// in the session pattern. Without this, C-b n/p won't cycle to the
+	// new rig's sessions until the next agent session start. See GH#2299.
+	if t := tmux.NewTmux(); t.IsAvailable() {
+		// Pass empty session — we only need to update the pattern, not
+		// the session-specific behavior. SetCycleBindings will detect
+		// the stale pattern and re-bind.
+		_ = t.SetCycleBindings("")
+	}
+
 	elapsed := time.Since(startTime)
 
 	// Read default branch from rig config

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2734,15 +2734,22 @@ func (t *Tmux) isGTBinding(table, key string) bool {
 }
 
 // isGTBindingWithClient checks if the given key has a GT binding that includes
-// --client for multi-client support. Older GT bindings without --client cause
-// switch-client to target the wrong client when multiple clients are attached.
+// --client for multi-client support AND has an up-to-date prefix pattern.
+// Returns false if the binding is missing --client (older GT binding) or if the
+// prefix pattern is stale (e.g., a new rig was added via gt rig add). See GH#2299.
 func (t *Tmux) isGTBindingWithClient(table, key string) bool {
 	output, err := t.run("list-keys", "-T", table, key)
 	if err != nil || output == "" {
 		return false
 	}
-	return strings.Contains(output, "if-shell") && strings.Contains(output, "gt ") &&
-		strings.Contains(output, "--client")
+	if !(strings.Contains(output, "if-shell") && strings.Contains(output, "gt ") &&
+		strings.Contains(output, "--client")) {
+		return false
+	}
+	// Verify the baked-in prefix pattern matches the current rig set.
+	// sessionPrefixPattern() returns e.g. "^(gt|hq|qu)-", which is embedded
+	// in the grep command within the if-shell binding.
+	return strings.Contains(output, sessionPrefixPattern())
 }
 
 // getKeyBinding returns the current tmux command bound to the given key in the


### PR DESCRIPTION
## Summary

- `isGTBindingWithClient` now verifies the baked-in prefix pattern matches the current rig set
- When a new rig is added, the stale pattern is detected and bindings are re-created with the updated prefix
- `gt rig add` now explicitly calls `SetCycleBindings` after rig creation for immediate effect

## Root Cause

`SetCycleBindings()` had an early-return guard via `isGTBindingWithClient()` that only checked for `--client` presence. It didn't verify whether the regex prefix pattern embedded in the `if-shell` command included all current rig prefixes. After `gt rig add`, the new prefix was missing from the pattern, so `C-b n/p` wouldn't cycle to the new rig's sessions.

## Note

`SetFeedBinding` and `SetAgentsBinding` have a similar pattern-staleness issue (they use `isGTBinding` which also doesn't check the pattern). Those are lower impact since they affect `C-b a` and `C-b g` rather than session cycling, but could be addressed as a follow-up.

## Test plan

- [ ] Manual: `gt rig add testrig <url>` → verify `tmux list-keys -T prefix n` shows the new prefix in the grep pattern
- [ ] Manual: Start crew in new rig → `C-b n` cycles correctly to/from it
- [ ] Existing sessions detect stale pattern on next `SetCycleBindings` call

Fixes #2299

🤖 Generated with [Claude Code](https://claude.com/claude-code)