### PR TITLE
fix: configure git user in TestBareCloneDefaultBranch

### DIFF
--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -1391,6 +1391,8 @@ func TestBareCloneDefaultBranch(t *testing.T) {
 	gitEnv := append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
 	for _, args := range [][]string{
 		{"git", "init", "-b", "master", srcDir},
+		{"git", "-C", srcDir, "config", "user.email", "test@test.com"},
+		{"git", "-C", srcDir, "config", "user.name", "Test"},
 		{"git", "-C", srcDir, "commit", "--allow-empty", "-m", "init"},
 	} {
 		c := exec.Command(args[0], args[1:]...)


### PR DESCRIPTION
## Summary
- Fix `TestBareCloneDefaultBranch` failure when `GIT_CONFIG_GLOBAL=/dev/null` strips git user identity
- Add repo-level `user.email` and `user.name` config before the `git commit --allow-empty` call

## Test plan
- [x] `TestBareCloneDefaultBranch` passes
- [x] All `internal/rig/` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)