### PR TITLE
fix(test): configure git user in TestBareCloneDefaultBranch

### DIFF
--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -1391,6 +1391,8 @@ func TestBareCloneDefaultBranch(t *testing.T) {
 	gitEnv := append(os.Environ(), "GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null")
 	for _, args := range [][]string{
 		{"git", "init", "-b", "master", srcDir},
+		{"git", "-C", srcDir, "config", "user.email", "test@test.com"},
+		{"git", "-C", srcDir, "config", "user.name", "Test"},
 		{"git", "-C", srcDir, "commit", "--allow-empty", "-m", "init"},
 	} {
 		c := exec.Command(args[0], args[1:]...)


### PR DESCRIPTION
## Summary

- Configure `user.email` and `user.name` in temp repo for `TestBareCloneDefaultBranch`
- Test nulls `GIT_CONFIG_GLOBAL`/`GIT_CONFIG_SYSTEM` for isolation, but this also removes user identity needed for commits

## Root Cause

The test creates a temp git repo with `GIT_CONFIG_GLOBAL=/dev/null` to isolate from user settings, but `git commit` requires `user.email` and `user.name`. On CI runners (and machines without global git config), this causes "Author identity unknown" failures.

## Test plan

- [x] `TestBareCloneDefaultBranch` passes locally
- [x] All `internal/rig/` tests pass

This same fix is in PR #2313 but that PR has other CI issues. This standalone fix unblocks all other open PRs that are failing due to this test.

🤖 Generated with [Claude Code](https://claude.com/claude-code)