### PR TITLE
fix: increase convoy ID entropy to prevent collisions (#2063)

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -26,11 +26,12 @@ import (
 	"github.com/steveyegge/gastown/internal/workspace"
 )
 
-// generateShortID generates a convoy ID suffix using base36.
-// 3 chars of base36 gives ~46K possible values — plenty for convoys.
+// generateShortID generates a collision-resistant convoy ID suffix using base36.
+// 5 chars of base36 gives ~60M possible values (36^5 = 60,466,176).
+// Birthday paradox: ~1% collision at ~1,100 IDs — safe for convoy volumes. (#2063)
 func generateShortID() string {
 	const alphabet = "0123456789abcdefghijklmnopqrstuvwxyz"
-	b := make([]byte, 3)
+	b := make([]byte, 5)
 	_, _ = rand.Read(b)
 	for i := range b {
 		b[i] = alphabet[int(b[i])%len(alphabet)]

--- a/internal/cmd/convoy_id_test.go
+++ b/internal/cmd/convoy_id_test.go
@@ -1,0 +1,41 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestGenerateShortID_Length(t *testing.T) {
+	id := generateShortID()
+	if len(id) != 5 {
+		t.Errorf("generateShortID() = %q (len %d), want length 5", id, len(id))
+	}
+}
+
+func TestGenerateShortID_ValidChars(t *testing.T) {
+	const validChars = "0123456789abcdefghijklmnopqrstuvwxyz"
+	valid := make(map[byte]bool)
+	for i := range validChars {
+		valid[validChars[i]] = true
+	}
+
+	for i := 0; i < 100; i++ {
+		id := generateShortID()
+		for j, c := range []byte(id) {
+			if !valid[c] {
+				t.Errorf("generateShortID()[%d] = %c, not in base36 alphabet", j, c)
+			}
+		}
+	}
+}
+
+func TestGenerateShortID_Uniqueness(t *testing.T) {
+	seen := make(map[string]bool)
+	const n = 1000
+	for i := 0; i < n; i++ {
+		id := generateShortID()
+		if seen[id] {
+			t.Errorf("collision after %d IDs: %q", i, id)
+		}
+		seen[id] = true
+	}
+}


### PR DESCRIPTION
## Summary
- Increase convoy ID suffix from 3 to 5 base36 characters
- Old: ~46K possible values (1% collision at ~150 convoys)
- New: ~60M possible values (1% collision at ~1,100 convoys)
- Add tests for ID length, character validity, and uniqueness

Closes #2063

## Test plan
- [x] `TestGenerateShortID_Length` — verifies 5-char output
- [x] `TestGenerateShortID_ValidChars` — verifies base36 alphabet (100 iterations)
- [x] `TestGenerateShortID_Uniqueness` — verifies no collisions in 1,000 IDs
- [x] `go build ./...` passes
- [x] `go vet ./internal/cmd/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)