### PR TITLE
Migrate witness from GetRoleConfig to config.LoadRoleDefinition

### DIFF
--- a/internal/doctor/beads_check.go
+++ b/internal/doctor/beads_check.go
@@ -308,7 +308,6 @@ func (r *realLabelAdder) AddLabel(townRoot, id, label string) error {
 }
 
 // RoleLabelCheck verifies that role beads have the gt:role label.
-// This label is required for GetRoleConfig to recognize role beads.
 // Role beads created before the label migration may be missing this label.
 type RoleLabelCheck struct {
 	FixableCheck

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -256,14 +256,18 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 }
 
 func (m *Manager) roleConfig() (*beads.RoleConfig, error) {
-	// Role beads use hq- prefix and live in town-level beads, not rig beads
 	townRoot := m.townRoot()
-	bd := beads.NewWithBeadsDir(townRoot, beads.ResolveBeadsDir(townRoot))
-	roleConfig, err := bd.GetRoleConfig(beads.RoleBeadIDTown("witness"))
+	roleDef, err := config.LoadRoleDefinition(townRoot, m.rig.Path, "witness")
 	if err != nil {
 		return nil, fmt.Errorf("loading witness role config: %w", err)
 	}
-	return roleConfig, nil
+	return &beads.RoleConfig{
+		SessionPattern: roleDef.Session.Pattern,
+		WorkDirPattern: roleDef.Session.WorkDir,
+		NeedsPreSync:   roleDef.Session.NeedsPreSync,
+		StartCommand:   roleDef.Session.StartCommand,
+		EnvVars:        roleDef.Env,
+	}, nil
 }
 
 func (m *Manager) townRoot() string {


### PR DESCRIPTION
## Summary
- Migrates the witness manager's `roleConfig()` from deprecated `beads.GetRoleConfig()` to `config.LoadRoleDefinition()`
- This was the **last production caller** of `GetRoleConfig` — the method can now be removed in v0.7.0
- Removes stale comment referencing `GetRoleConfig` in doctor's `RoleLabelCheck`

## Context
Part of #1170 deprecation cleanup. The daemon already migrated to config-based roles (Phase 2). This brings the witness manager in line with the same pattern.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/witness/...` passes
- [x] `go test ./internal/doctor/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)