### PR TITLE
Remove legacy SQLite/Beads Classic code paths

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -293,15 +293,6 @@ func (b *Beads) run(args ...string) (_ []byte, retErr error) {
 		beadsDir = ResolveBeadsDir(b.workDir)
 	}
 
-	// In isolated mode, use --db flag to force specific database path
-	// This bypasses bd's routing logic that can redirect to .beads-planning
-	// Skip --db for init command since it creates the database
-	isInit := len(args) > 0 && args[0] == "init"
-	if b.isolated && !isInit {
-		beadsDB := filepath.Join(beadsDir, "beads.db")
-		fullArgs = append([]string{"--db", beadsDB}, fullArgs...)
-	}
-
 	cmd := exec.Command("bd", fullArgs...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Dir = b.workDir
 

--- a/internal/beads/beads_mr.go
+++ b/internal/beads/beads_mr.go
@@ -19,9 +19,9 @@ func (b *Beads) FindMRForBranchAny(branch string) (*Issue, error) {
 	return b.findMRForBranch(branch, false)
 }
 
-// findMRForBranch searches both the issues table (Dolt) and wisps table
-// (SQLite) for a merge-request bead matching the given branch.
-// Uses status=all which covers both tables with full descriptions.
+// findMRForBranch searches the issues table (Dolt) for a merge-request
+// bead matching the given branch.
+// Uses status=all which includes all issue statuses with full descriptions.
 // When skipClosed is true, closed beads are excluded (for open-MR checks).
 func (b *Beads) findMRForBranch(branch string, skipClosed bool) (*Issue, error) {
 	branchPrefix := "branch: " + branch + "\n"

--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -296,12 +296,6 @@ func ensureDatabaseInitialized(beadsDir string) error {
 		}
 	}
 
-	// Check for SQLite database file (legacy)
-	sqliteDB := filepath.Join(beadsDir, "beads.db")
-	if _, err := os.Stat(sqliteDB); err == nil {
-		return nil
-	}
-
 	// No database found — need to initialize.
 	prefix := detectPrefix(beadsDir)
 

--- a/internal/beads/beads_types_test.go
+++ b/internal/beads/beads_types_test.go
@@ -401,22 +401,11 @@ func TestEnsureDatabaseInitialized(t *testing.T) {
 		_ = ensureDatabaseInitialized(beadsDir)
 	})
 
-	t.Run("beads.db exists — skip init (legacy)", func(t *testing.T) {
-		beadsDir := filepath.Join(t.TempDir(), ".beads")
-		os.MkdirAll(beadsDir, 0755)
-		os.WriteFile(filepath.Join(beadsDir, "beads.db"), []byte("sqlite"), 0644)
-
-		err := ensureDatabaseInitialized(beadsDir)
-		if err != nil {
-			t.Errorf("expected nil error when beads.db exists, got: %v", err)
-		}
-	})
-
 	t.Run("no database artifacts — attempts bd init", func(t *testing.T) {
 		beadsDir := filepath.Join(t.TempDir(), ".beads")
 		os.MkdirAll(beadsDir, 0755)
 
-		// With no dolt/, metadata.json, or beads.db, ensureDatabaseInitialized
+		// With no dolt/ or metadata.json, ensureDatabaseInitialized
 		// must attempt bd init. The result depends on whether bd is available
 		// in the test environment. Either way, it should not panic.
 		_ = ensureDatabaseInitialized(beadsDir)


### PR DESCRIPTION
## Summary
- Remove `--db beads.db` flag from isolated mode in `beads.go` (SQLite no longer supported, Dolt is the only backend)
- Remove SQLite `beads.db` existence check from `ensureDatabaseInitialized` 
- Update comments in `beads_mr.go` to reflect Dolt-only architecture (removed references to "wisps table (SQLite)")
- Remove obsolete test case for SQLite database detection

This completes the cleanup of pre-Dolt Beads Classic storage remnants as described in w-gt-001.

## Test plan
- [ ] `go build ./...` passes
- [ ] `go test ./internal/beads/...` passes
- [ ] Existing integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)