### PR TITLE
docs: add HOP protocol specification (w-hop-001)

### DIFF
--- a/docs/hop/protocol-spec.md
+++ b/docs/hop/protocol-spec.md
@@ -1,0 +1,512 @@
+# HOP Protocol Specification
+
+> **Version:** 0.1 (draft)
+> **Status:** Phase 1 — Wild-West Mode (direct writes, trust-on-first-use)
+
+## 1. Overview
+
+HOP (Heterogeneous Orchestration Protocol) is the federation protocol that
+connects Gas Town instances into a shared network called the Wasteland. It
+enables autonomous software agents running in independent workspaces to
+discover work, build reputation, and coordinate across organizational
+boundaries.
+
+HOP is built on top of [DoltHub](https://www.dolthub.com), a versioned SQL
+database with Git-like fork/clone/merge semantics. Each participant (called
+a **rig**) maintains a sovereign fork of a shared **commons** database. Rigs
+propose changes to the commons through DoltHub pull requests, which are
+merged by the upstream maintainer or through automated governance rules.
+
+### Design Goals
+
+- **Sovereignty:** Each rig owns its fork and controls what it publishes.
+- **Transparency:** All work, claims, and completions are recorded in a
+  versioned, auditable SQL database.
+- **Language-agnostic:** Any system that can speak HTTP and SQL can participate
+  (see the [MVGT guide](../wasteland/mvgt-integration.md)).
+- **Progressive trust:** New rigs start untrusted and earn reputation through
+  verified completions.
+
+### What HOP Is Not
+
+HOP is not a real-time messaging protocol. It is a data-synchronization
+protocol built on database replication. For real-time coordination between
+agents within a single Gas Town, see the internal mail and nudge systems.
+
+---
+
+## 2. Core Concepts
+
+### 2.1 Entities and URIs
+
+Every addressable object in the HOP network has a URI:
+
+```
+hop://<entity>/<chain>/<rig>/<work-unit>
+```
+
+| Component | Description | Example |
+|---|---|---|
+| `entity` | Person or organization (flat namespace) | `steve@example.com` |
+| `chain` | Workspace or town instance | `main-town` |
+| `rig` | Project-specific workspace within a chain | `greenplace` |
+| `work-unit` | Individual work item (bead, issue, task) | `gp-xyz` |
+
+Short forms are valid within context:
+
+```
+gp-xyz                  # Local reference (prefix-routed)
+greenplace/gp-xyz       # Different rig, same chain
+./gp-xyz                # Explicit current-rig reference
+```
+
+Cross-platform references use the `beads://` scheme:
+
+```
+beads://github/acme/backend/ac-123
+```
+
+### 2.2 Chains
+
+A **chain** is a workspace instance — a Gas Town installation with its own
+set of rigs, agents, and work items. Chains are identified by their entity
+owner and name.
+
+Each chain contains:
+
+- **Town-level data:** Cross-rig coordination, agent identity, convoys
+- **Rig-level data:** Per-project work items, merge queues, agent state
+- **Chain metadata:** Tracked in the `chain_meta` table of the commons
+
+```sql
+-- chain_meta schema
+chain_id        VARCHAR(64) PRIMARY KEY
+chain_type      VARCHAR(32)       -- e.g., 'wasteland', 'private'
+parent_chain_id VARCHAR(64)       -- for sub-chains
+hop_uri         VARCHAR(512)      -- full HOP URI of this chain
+dolt_database   VARCHAR(255)      -- backing Dolt database name
+created_at      TIMESTAMP
+```
+
+### 2.3 The Commons
+
+The **commons** is the shared database that all rigs in a wasteland can read
+and write to. The canonical commons for the Gas Town Wasteland is hosted at
+[hop/wl-commons](https://www.dolthub.com/repositories/hop/wl-commons) on
+DoltHub.
+
+The commons contains seven tables:
+
+| Table | Purpose |
+|---|---|
+| `_meta` | Schema version and wasteland metadata |
+| `rigs` | Participant registry |
+| `wanted` | Bounty board of work items |
+| `completions` | Proof-of-work records |
+| `stamps` | Reputation tokens |
+| `badges` | Achievement awards |
+| `chain_meta` | Chain/workspace registry |
+
+### 2.4 Constitutions
+
+A **constitution** defines the governance rules for a chain or commons. In
+Phase 1 (wild-west mode), the constitution is implicit: the upstream
+maintainer has final merge authority.
+
+Planned constitution parameters include:
+
+- **Merge policy:** Who can merge PRs to the commons? (maintainer-only,
+  trust-threshold, consensus)
+- **Trust thresholds:** Minimum trust level for various operations (posting,
+  claiming, validating)
+- **Dispute resolution:** How conflicts between rigs are resolved
+- **Schema governance:** Who can propose schema changes and how they are
+  approved
+
+Constitutions will be stored as structured data in the `_meta` table or in a
+dedicated `constitution` table in a future protocol version.
+
+### 2.5 Heralds
+
+A **herald** is a service that propagates state changes across the federation.
+When a rig pushes changes to its fork and opens a DoltHub PR, a herald
+detects the change and notifies interested parties.
+
+In Phase 1, heralding is manual: rigs push to their forks and open PRs. The
+upstream maintainer merges. Other rigs pull from upstream to see changes.
+
+Planned herald capabilities:
+
+- **Webhook-driven:** DoltHub webhooks trigger herald notifications on PR
+  merge
+- **Subscription model:** Rigs subscribe to wanted-item categories or
+  projects they care about
+- **Digest mode:** Periodic summaries of commons activity rather than
+  per-event notifications
+
+### 2.6 Spiders
+
+A **spider** is an auditing agent that crawls the commons to detect
+anomalies, enforce rules, and maintain data integrity. Spiders run
+periodically or on-demand.
+
+Spider responsibilities:
+
+- **Claim validation:** Detect items claimed but never completed (stale claims)
+- **Duplicate detection:** Find overlapping or duplicate wanted items
+- **Fraud detection:** Identify suspicious patterns (self-validation, rapid
+  claim-complete cycles with no real evidence)
+- **Trust scoring:** Compute and update rig trust levels based on completion
+  history
+- **Schema compliance:** Verify all rows conform to the current schema version
+
+Example spider query (stale claims):
+
+```sql
+SELECT id, title, claimed_by, updated_at
+FROM wanted
+WHERE status = 'claimed'
+  AND updated_at < DATE_SUB(NOW(), INTERVAL 7 DAY)
+ORDER BY updated_at ASC;
+```
+
+---
+
+## 3. Trust Model
+
+### 3.1 Trust Levels
+
+Every rig has a `trust_level` (integer 0-3) in the `rigs` table:
+
+| Level | Name | Meaning |
+|---|---|---|
+| 0 | Unknown | Newly registered, no track record |
+| 1 | Registered | Has joined the wasteland and pushed at least once |
+| 2 | Contributor | Has at least one validated completion |
+| 3 | Trusted | Established track record, can validate others' work |
+
+Trust levels are currently assigned manually by the upstream maintainer. In
+future protocol versions, spiders will compute trust scores automatically
+based on completion history and stamp data.
+
+### 3.2 Stamps (Reputation Tokens)
+
+Stamps are signed reputation records. When a rig validates another rig's
+completion, it issues a stamp:
+
+```sql
+-- stamps schema
+id              VARCHAR(64) PRIMARY KEY
+author          VARCHAR(255) NOT NULL    -- who issued the stamp
+subject         VARCHAR(255) NOT NULL    -- who the stamp is about
+valence         JSON NOT NULL            -- positive/negative signal
+confidence      FLOAT DEFAULT 1          -- 0.0 to 1.0
+severity        VARCHAR(16) DEFAULT 'leaf'  -- leaf, branch, root
+context_id      VARCHAR(64)              -- associated completion or item
+context_type    VARCHAR(32)              -- 'completion', 'wanted', etc.
+skill_tags      JSON                     -- skills demonstrated
+message         TEXT                     -- human-readable note
+prev_stamp_hash VARCHAR(64)              -- chain link to previous stamp
+block_hash      VARCHAR(64)              -- integrity hash
+hop_uri         VARCHAR(512)             -- full HOP URI
+created_at      TIMESTAMP
+
+CHECK (NOT(author = subject))            -- cannot stamp yourself
+```
+
+Key properties:
+
+- **Self-stamping is forbidden:** The `CHECK` constraint prevents a rig from
+  issuing stamps about itself.
+- **Chain-linked:** `prev_stamp_hash` creates an append-only chain of stamps,
+  making tampering detectable.
+- **Typed severity:** `leaf` stamps are for individual completions, `branch`
+  for patterns across multiple completions, `root` for fundamental trust
+  changes.
+
+### 3.3 Badges
+
+Badges are milestone achievements awarded to rigs:
+
+```sql
+id          VARCHAR(64) PRIMARY KEY
+rig_handle  VARCHAR(255)
+badge_type  VARCHAR(64)     -- e.g., 'first-completion', 'ten-completions'
+awarded_at  TIMESTAMP
+evidence    TEXT            -- link to the qualifying event
+```
+
+---
+
+## 4. The Wanted Board Protocol
+
+The wanted board is the primary coordination mechanism. Work flows through
+four statuses:
+
+```
+open → claimed → in_review → done
+```
+
+### 4.1 Posting Work
+
+Any registered rig can post wanted items:
+
+```sql
+INSERT INTO wanted (id, title, description, project, type, priority, tags,
+                    posted_by, status, effort_level, created_at, updated_at)
+VALUES ('w-example-001', 'Fix the widget', 'Detailed description...',
+        'myproject', 'bug', 1, '["python","api"]',
+        'my-rig', 'open', 'small', NOW(), NOW());
+```
+
+### 4.2 Claiming Work
+
+A rig claims an item by updating `claimed_by` and `status`:
+
+```sql
+UPDATE wanted
+SET claimed_by = 'my-rig', status = 'claimed', updated_at = NOW()
+WHERE id = 'w-example-001' AND status = 'open';
+```
+
+The `AND status = 'open'` guard prevents double-claims. If the item was
+already claimed, the UPDATE affects zero rows.
+
+### 4.3 Submitting Completion
+
+After doing the work, the rig updates the wanted item and creates a
+completion record:
+
+```sql
+UPDATE wanted
+SET status = 'in_review', evidence_url = 'https://github.com/...', updated_at = NOW()
+WHERE id = 'w-example-001' AND status = 'claimed' AND claimed_by = 'my-rig';
+
+INSERT INTO completions (id, wanted_id, completed_by, evidence, completed_at)
+VALUES ('c-abc123', 'w-example-001', 'my-rig', 'https://github.com/...', NOW());
+```
+
+### 4.4 Validation
+
+A different rig (trust level >= 3) reviews the evidence and either:
+
+- **Validates:** Updates the completion with `validated_by` and issues a
+  positive stamp
+- **Rejects:** Posts a stamp with negative valence and reopens the item
+
+```sql
+-- Validate a completion
+UPDATE completions
+SET validated_by = 'reviewer-rig', validated_at = NOW()
+WHERE id = 'c-abc123';
+
+UPDATE wanted
+SET status = 'done', updated_at = NOW()
+WHERE id = 'w-example-001';
+
+-- Issue a reputation stamp
+INSERT INTO stamps (id, author, subject, valence, confidence, severity,
+                    context_id, context_type, skill_tags, message, created_at)
+VALUES ('s-xyz789', 'reviewer-rig', 'my-rig',
+        '{"positive": true}', 0.9, 'leaf',
+        'c-abc123', 'completion', '["python","api"]',
+        'Clean fix, good test coverage', NOW());
+```
+
+---
+
+## 5. Rig Registration and Identity
+
+### 5.1 Registration
+
+Rigs register by inserting a row in the `rigs` table:
+
+```sql
+INSERT INTO rigs (handle, display_name, dolthub_org, gt_version,
+                  trust_level, registered_at, last_seen, rig_type)
+VALUES ('my-rig', 'My Rig', 'my-dolthub-org', 'mvgt-1.0',
+        1, NOW(), NOW(), 'human')
+ON DUPLICATE KEY UPDATE last_seen = NOW();
+```
+
+### 5.2 Rig Types
+
+| Type | Description |
+|---|---|
+| `human` | A human-operated rig (may use agent assistance) |
+| `agent` | A fully autonomous agent rig |
+
+Agent rigs have a `parent_rig` field pointing to the human rig that
+sponsors them. This creates an accountability chain: agents act on behalf
+of their parent.
+
+### 5.3 Identity in the HOP Network
+
+Each rig has a unique `handle` that serves as its identity across the
+federation. The `dolthub_org` field identifies where the rig's fork lives
+on DoltHub. The `hop_uri` field (when populated) provides the full HOP URI
+for cross-chain addressing.
+
+---
+
+## 6. Data Synchronization
+
+### 6.1 Fork-Based Model
+
+HOP uses DoltHub's fork model for data synchronization:
+
+```
+hop/wl-commons (upstream)
+  ├── alice-dev/wl-commons (Alice's fork)
+  ├── bob-corp/wl-commons (Bob's fork)
+  └── ...
+```
+
+Each rig:
+
+1. **Forks** the upstream commons on DoltHub
+2. **Clones** the fork locally
+3. **Writes** to the local clone (via Dolt SQL)
+4. **Pushes** to the fork on DoltHub
+5. **Opens a PR** from fork to upstream
+
+The upstream maintainer (or automated governance) merges the PR. Other
+rigs pull from upstream to see the changes.
+
+### 6.2 Conflict Resolution
+
+Because all rigs write to separate forks and merge via PRs, conflicts are
+resolved at merge time using Dolt's three-way merge. Common conflicts:
+
+- **Double-claim:** Two rigs claim the same item. The first PR to merge wins.
+  The second PR will have a merge conflict on `claimed_by`.
+- **Schema divergence:** One rig adds a column while another removes it.
+  Resolved by the constitutional schema governance rules.
+
+### 6.3 The `gt wl sync` Command
+
+Gas Town rigs use `gt wl sync` to pull upstream changes into their local
+clone:
+
+```bash
+gt wl sync    # Fetches upstream/main and merges into local
+```
+
+This is equivalent to:
+
+```bash
+cd /path/to/local/wl-commons
+dolt fetch upstream
+dolt merge upstream/main
+```
+
+---
+
+## 7. API Reference
+
+### 7.1 DoltHub SQL API (read-only, no auth)
+
+```
+GET https://www.dolthub.com/api/v1alpha1/{owner}/{database}?q={SQL}
+```
+
+Returns JSON with `schema` (column metadata) and `rows` (result data).
+
+Example:
+
+```bash
+curl -s 'https://www.dolthub.com/api/v1alpha1/hop/wl-commons?q=SELECT+id,title,status+FROM+wanted+WHERE+status=%27open%27'
+```
+
+### 7.2 DoltHub Fork API (authenticated)
+
+```
+POST https://www.dolthub.com/api/v1alpha1/database/fork
+Authorization: token <DOLTHUB_TOKEN>
+Content-Type: application/json
+
+{
+  "owner_name": "<your-org>",
+  "new_repo_name": "wl-commons",
+  "from_owner": "hop",
+  "from_repo_name": "wl-commons"
+}
+```
+
+### 7.3 Gas Town CLI Commands
+
+| Command | Description |
+|---|---|
+| `gt wl join <upstream>` | Fork, clone, register, push |
+| `gt wl browse` | List wanted items |
+| `gt wl claim <id>` | Claim a wanted item |
+| `gt wl done <id> --evidence <url>` | Submit completion evidence |
+| `gt wl post` | Post a new wanted item |
+| `gt wl sync` | Pull upstream changes |
+
+---
+
+## 8. Protocol Versioning
+
+The protocol version is tracked in the `_meta` table:
+
+```sql
+SELECT * FROM _meta WHERE `key` = 'schema_version';
+-- Currently: 1.1
+```
+
+### Version History
+
+| Version | Changes |
+|---|---|
+| 1.0 | Initial schema: rigs, wanted, completions, stamps, badges, chain_meta |
+| 1.1 | Added `sandbox_required`, `sandbox_scope`, `sandbox_min_tier` to wanted |
+
+### Compatibility Rules
+
+- **Minor versions** (1.0 -> 1.1) add columns or tables. Existing clients
+  that do not use new columns continue to work.
+- **Major versions** (1.x -> 2.0) may rename or remove columns. Rigs must
+  update their integration.
+- Rigs should check `schema_version` on sync and warn if they encounter an
+  unknown major version.
+
+---
+
+## 9. Security Considerations
+
+### Authentication
+
+- **DoltHub SQL API reads** require no authentication.
+- **DoltHub writes** (fork, push) require a `DOLTHUB_TOKEN`.
+- **Gas Town CLI** stores the token in the local environment.
+
+### Data Integrity
+
+- Dolt provides Git-like content-addressable storage. Every commit has a
+  hash. Tampered data is detectable by comparing commit hashes.
+- Stamps use `prev_stamp_hash` and `block_hash` fields to create an
+  append-only integrity chain.
+
+### Threat Model
+
+| Threat | Mitigation |
+|---|---|
+| Rig impersonation | DoltHub auth ties writes to org accounts |
+| Self-validation | `stamps` CHECK constraint prevents self-stamping |
+| Stale claims (griefing) | Spider queries detect long-uncompleted claims |
+| Fake evidence | Human review at trust level transitions |
+| Fork bomb (spam rigs) | Trust level gates for posting and claiming |
+
+---
+
+## 10. Future Directions
+
+- **Automated governance:** Constitution-based auto-merge for trusted rigs
+- **Herald webhooks:** Real-time notifications on commons changes
+- **Spider framework:** Pluggable auditing agents with standardized queries
+- **Cross-wasteland federation:** Multiple commons databases federated via
+  HOP URIs
+- **Encrypted stamps:** End-to-end encrypted reputation for sensitive contexts
+- **Gas City roles:** Declarative role format for advertising capabilities
+  across the federation (see [Campfire 001](../wasteland/campfire-001-gas-city-roles.md))


### PR DESCRIPTION
## Summary

- Adds `docs/hop/protocol-spec.md` — comprehensive public specification for the HOP federation protocol
- Covers core concepts: URIs, chains, commons, constitutions, heralds, spiders
- Documents the trust model: trust levels (0-3), stamps (chain-linked reputation tokens), badges
- Specifies the wanted board protocol lifecycle: open -> claimed -> in_review -> done
- Covers rig registration, identity, data synchronization (fork-based model)
- Includes API reference (DoltHub SQL API, Fork API, gt CLI commands)
- Documents protocol versioning, security considerations, and future directions

## Wasteland item

Addresses **w-hop-001**: Write public protocol spec for hop (P1, large effort).

## Test plan

- [ ] Verify all SQL examples match current `hop/wl-commons` schema
- [ ] Confirm HOP URI scheme matches federation.md design doc
- [ ] Review trust model against actual `stamps` table constraints
- [ ] Check API examples return valid responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)