### PR TITLE
prime: add bd close to command quick-reference tables

### DIFF
--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -278,6 +278,7 @@ func outputCommandQuickReference(ctx RoleContext) {
 	case RoleMayor:
 		fmt.Println("| Want to... | Correct command | Common mistake |")
 		fmt.Println("|------------|----------------|----------------|")
+		fmt.Println("| Close/complete a bead | `bd close <id>` | ~~bd complete~~ (not a command), ~~bd update --status done~~ (invalid status) |")
 		fmt.Printf("| Dispatch work to polecat | `%s sling <bead> <rig>` | ~~gt polecat spawn~~ (not a command) |\n", c)
 		fmt.Printf("| Message another agent | `%s nudge <target> \"msg\"` | ~~tmux send-keys~~ (unreliable) |\n", c)
 		fmt.Printf("| Kill stuck polecat | `%s polecat nuke <rig>/<name> --force` | ~~gt polecat kill~~ (not a command) |\n", c)
@@ -288,6 +289,7 @@ func outputCommandQuickReference(ctx RoleContext) {
 	case RoleCrew:
 		fmt.Println("| Want to... | Correct command | Common mistake |")
 		fmt.Println("|------------|----------------|----------------|")
+		fmt.Println("| Close/complete a bead | `bd close <id>` | ~~bd complete~~ (not a command), ~~bd update --status done~~ (invalid status) |")
 		fmt.Printf("| Message another agent | `%s nudge <target> \"msg\"` | ~~tmux send-keys~~ (unreliable) |\n", c)
 		fmt.Printf("| Dispatch work to polecat | `%s sling <bead> <rig>` | ~~gt polecat spawn~~ (not a command) |\n", c)
 		fmt.Printf("| Stop my session | `%s crew stop %s` | ~~gt rig stop~~ (stops rig agents, not crew) |\n", c, ctx.Polecat)
@@ -298,6 +300,7 @@ func outputCommandQuickReference(ctx RoleContext) {
 		fmt.Println("| Want to... | Correct command | Common mistake |")
 		fmt.Println("|------------|----------------|----------------|")
 		fmt.Printf("| Signal work complete | `%s done` | ~~bd close <root-issue>~~ (Refinery closes it) |\n", c)
+		fmt.Println("| Close a sub-issue | `bd close <id>` | ~~bd complete~~ (not a command), ~~bd update --status done~~ (invalid status) |")
 		fmt.Printf("| Message another agent | `%s nudge <target> \"msg\"` | ~~tmux send-keys~~ (unreliable) |\n", c)
 		fmt.Println("| Check workflow steps | `bd mol current` | ~~bd ready~~ (excludes molecule steps) |")
 		fmt.Println("| Create issues | `bd create \"title\"` | ~~gt issue create~~ (not a command) |")
@@ -306,6 +309,7 @@ func outputCommandQuickReference(ctx RoleContext) {
 	case RoleWitness:
 		fmt.Println("| Want to... | Correct command | Common mistake |")
 		fmt.Println("|------------|----------------|----------------|")
+		fmt.Println("| Close/complete a bead | `bd close <id>` | ~~bd complete~~ (not a command), ~~bd update --status done~~ (invalid status) |")
 		fmt.Printf("| Message a polecat | `%s nudge %s/<name> \"msg\"` | ~~tmux send-keys~~ (unreliable) |\n", c, ctx.Rig)
 		fmt.Printf("| Kill stuck polecat | `%s polecat nuke %s/<name> --force` | ~~gt polecat kill~~ (not a command) |\n", c, ctx.Rig)
 		fmt.Printf("| View polecat output | `%s peek %s/<name> 50` | |\n", c, ctx.Rig)

--- a/internal/templates/roles/crew.md.tmpl
+++ b/internal/templates/roles/crew.md.tmpl
@@ -421,11 +421,16 @@ See `{{ .TownRoot }}/docs/AGENT-ERGONOMICS.md` for the philosophy.
 
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
+| Close/complete a bead | `bd close <id>` | ~~bd complete~~ (not a command), ~~bd update --status done~~ (invalid status) |
+| Claim work | `bd update <id> --claim` | ~~bd update --status=in_progress~~ (works but --claim is atomic) |
 | Message another agent | `{{ cmd }} nudge <target> "msg"` | ~~tmux send-keys~~ (unreliable) |
 | Dispatch work to polecat | `{{ cmd }} sling <bead> <rig>` | ~~gt polecat spawn~~ (not a command) |
 | Stop my session | `{{ cmd }} crew stop {{ .Polecat }}` | ~~gt rig stop~~ (stops rig agents, not crew) |
 | Pause rig (daemon won't restart) | `{{ cmd }} rig park <rig>` | ~~gt rig stop~~ (daemon will restart it) |
 | Permanently disable rig | `{{ cmd }} rig dock <rig>` | ~~gt rig park~~ (temporary only) |
+
+**Beads valid statuses:** `open`, `in_progress`, `blocked`, `deferred`, `closed`, `pinned`, `hooked`
+(there is NO `done` or `complete` status)
 
 **Rig lifecycle commands (park vs dock vs stop):**
 - `park/unpark` — Temporary pause. Daemon skips parked rigs.

--- a/internal/templates/roles/mayor.md.tmpl
+++ b/internal/templates/roles/mayor.md.tmpl
@@ -256,12 +256,16 @@ gh pr create --repo $(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\
 
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
+| Close/complete a bead | `bd close <id>` | ~~bd complete~~ (not a command), ~~bd update --status done~~ (invalid status) |
 | Dispatch work to polecat | `{{ cmd }} sling <bead> <rig>` | ~~gt polecat spawn~~ (not a command) |
 | Message another agent | `{{ cmd }} nudge <target> "msg"` | ~~tmux send-keys~~ (unreliable) |
 | Kill stuck polecat | `{{ cmd }} polecat nuke <rig>/<name> --force` | ~~gt polecat kill~~ (not a command) |
 | Pause rig (daemon won't restart) | `{{ cmd }} rig park <rig>` | ~~gt rig stop~~ (daemon will restart it) |
 | Permanently disable rig | `{{ cmd }} rig dock <rig>` | ~~gt rig park~~ (temporary only) |
 | Create issues | `bd create "title"` | ~~gt issue create~~ (not a command) |
+
+**Beads valid statuses:** `open`, `in_progress`, `blocked`, `deferred`, `closed`, `pinned`, `hooked`
+(there is NO `done` or `complete` status)
 
 **Rig lifecycle commands (park vs dock vs stop):**
 - `park/unpark` — Temporary pause. Daemon skips parked rigs.

--- a/internal/templates/roles/polecat.md.tmpl
+++ b/internal/templates/roles/polecat.md.tmpl
@@ -419,10 +419,14 @@ For long-running operations, prefer `run_in_background: true` on Task and Bash t
 | Want to... | Correct command | Common mistake |
 |------------|----------------|----------------|
 | Signal work complete | `{{ cmd }} done` | ~~bd close <root-issue>~~ (Refinery closes it) |
+| Close a sub-issue | `bd close <id>` | ~~bd complete~~ (not a command), ~~bd update --status done~~ (invalid status) |
 | Message another agent | `{{ cmd }} nudge <target> "msg"` | ~~tmux send-keys~~ (unreliable) |
 | Check workflow steps | `{{ cmd }} prime` (shows inline checklist) | ~~bd mol current~~ (steps not materialized) |
 | Create issues | `bd create "title"` | ~~gt issue create~~ (not a command) |
 | Escalate blocker | `{{ cmd }} escalate "desc" -s HIGH` | ~~waiting for human~~ (never wait) |
+
+**Beads valid statuses:** `open`, `in_progress`, `blocked`, `deferred`, `closed`, `pinned`, `hooked`
+(there is NO `done` or `complete` status)
 
 Polecat: {{ .Polecat }}
 Rig: {{ .RigName }}

--- a/internal/templates/roles/witness.md.tmpl
+++ b/internal/templates/roles/witness.md.tmpl
@@ -307,6 +307,7 @@ Never use `tmux has-session -t deacon` — that session does not exist.
 | Message a polecat | `{{ cmd }} nudge {{ .RigName }}/<name> "msg"` | ~~tmux send-keys~~ (unreliable) |
 | Kill stuck polecat | `{{ cmd }} polecat nuke {{ .RigName }}/<name> --force` | ~~gt polecat kill~~ (not a command) |
 | View polecat output | `{{ cmd }} peek {{ .RigName }}/<name> 50` | |
+| Close/complete a bead | `bd close <id>` | ~~bd complete~~ (not a command), ~~bd update --status done~~ (invalid status) |
 | Create issues | `bd create "title"` | ~~gt issue create~~ (not a command) |
 
 **Rig lifecycle commands (for reference):**


### PR DESCRIPTION
## Summary

- Agents frequently guess wrong commands when closing beads: `bd complete` (doesn't exist), `bd update --status done` (invalid status "done"), or the verbose `bd update --status closed`
- Added "Close/complete a bead → `bd close <id>`" row to the Quick-Reference tables in all role templates (crew, mayor, polecat, witness) and Go fallback code
- Added "valid statuses" reminder line listing built-in statuses to crew, mayor, and polecat templates

## Motivation

Observed agents (crew and mayor) failing 1-2 times before discovering `bd close`:

```
bd complete lc-6ar        → Error: unknown command "complete"
bd update lc-6ar --status done  → Error: invalid status "done"
bd update lc-6ar --status closed → ✓ (works, but bd close is the right command)
```

The Quick-Reference table already prevents similar mistakes for `gt` commands (e.g., `gt sling` vs `gt polecat spawn`). This extends the same pattern to beads lifecycle commands.

## Test plan

- [ ] `go build ./...` passes
- [ ] Verify `gt prime` output includes new row in quick-reference table
- [ ] Verify templates render correctly for each role

🤖 Generated with [Claude Code](https://claude.com/claude-code)