### PR TITLE
fix(nudge): change default delivery mode from immediate to wait-idle

### DIFF
--- a/internal/cmd/nudge.go
+++ b/internal/cmd/nudge.go
@@ -50,7 +50,7 @@ func init() {
 	nudgeCmd.Flags().BoolVarP(&nudgeForceFlag, "force", "f", false, "Send even if target has DND enabled")
 	nudgeCmd.Flags().BoolVar(&nudgeStdinFlag, "stdin", false, "Read message from stdin (avoids shell quoting issues)")
 	nudgeCmd.Flags().BoolVar(&nudgeIfFreshFlag, "if-fresh", false, "Only send if caller's tmux session is <60s old (suppresses compaction nudges)")
-	nudgeCmd.Flags().StringVar(&nudgeModeFlag, "mode", NudgeModeImmediate, "Delivery mode: immediate (default), queue, or wait-idle")
+	nudgeCmd.Flags().StringVar(&nudgeModeFlag, "mode", NudgeModeWaitIdle, "Delivery mode: wait-idle (default), queue, or immediate")
 	nudgeCmd.Flags().StringVar(&nudgePriorityFlag, "priority", nudge.PriorityNormal, "Queue priority: normal (default) or urgent")
 }
 
@@ -65,19 +65,19 @@ Delivers a message to any worker's Claude Code session: polecats, crew,
 witness, refinery, mayor, or deacon.
 
 Delivery modes (--mode):
-  immediate  Send directly via tmux send-keys (default). Interrupts in-flight
-             work but guarantees immediate delivery.
-  queue      Write to a file queue; agent picks up via hook at next turn
-             boundary. Zero interruption. Use for non-urgent coordination.
   wait-idle  Wait for agent to become idle (prompt visible), then deliver
              directly. Falls back to queue on timeout. If both idle-wait and
              queue fail, falls back to immediate delivery as a last resort.
+             This is the default — it avoids interrupting active tool calls.
+  queue      Write to a file queue; agent picks up via hook at next turn
+             boundary. Zero interruption. Use for non-urgent coordination.
+  immediate  Send directly via tmux send-keys. Interrupts in-flight work
+             but guarantees immediate delivery. Use only when you need to
+             break through (e.g., stuck agent, emergency).
 
 Queue and wait-idle modes require the target agent to support hooks
-(UserPromptSubmit) for drain. Agents without hook support should use immediate.
-
-The default is immediate for backward compatibility. For non-urgent messages
-where you don't want to interrupt the agent's current work, use --mode=queue.
+(UserPromptSubmit) for drain. Agents without hook support should use
+--mode=immediate.
 
 This is the ONLY way to send messages to Claude sessions.
 Do not use raw tmux send-keys elsewhere.

--- a/internal/templates/roles/crew.md.tmpl
+++ b/internal/templates/roles/crew.md.tmpl
@@ -340,11 +340,11 @@ Never use raw `tmux send-keys`.
 
 | Mode | Flag | Behavior |
 |------|------|----------|
-| Immediate | `--mode=immediate` (default) | Direct send-keys. Interrupts current work. |
+| Wait-idle | `--mode=wait-idle` (default) | Waits for idle prompt, then delivers. Falls back to queue. |
 | Queue | `--mode=queue` | Writes to file queue. Agent picks up at next turn boundary. |
-| Wait-idle | `--mode=wait-idle` | Waits for idle prompt, then delivers. Falls back to queue. |
+| Immediate | `--mode=immediate` | Direct send-keys. Interrupts current work. Use only for emergencies. |
 
-For non-urgent coordination, prefer `--mode=queue`.
+Default is wait-idle to avoid interrupting active tool calls.
 
 ### Nudge Resilience (for your own work)
 

--- a/internal/templates/roles/mayor.md.tmpl
+++ b/internal/templates/roles/mayor.md.tmpl
@@ -168,7 +168,7 @@ Routes defined in `{{ .TownRoot }}/.beads/routes.jsonl`. `{{ cmd }} rig add` aut
 - **Strategic decisions**: Architecture, priorities, integration planning
 
 **NOT your job**: Per-worker cleanup, session killing, routine nudging (Witness handles that)
-**Exception**: If refinery/witness is stuck, use `{{ cmd }} nudge refinery "Process MQ"`
+**Exception**: If refinery/witness is stuck, use `{{ cmd }} nudge --mode=immediate refinery "Process MQ"`
 
 ## Key Commands
 
@@ -177,8 +177,9 @@ Routes defined in `{{ .TownRoot }}/.beads/routes.jsonl`. `{{ cmd }} rig add` aut
 - `{{ cmd }} mail read <id>` — Read a specific message
 - `{{ cmd }} mail send <addr> -s "Subject" -m "Message"` — Send mail
 - `{{ cmd }} mail mark-read <id>` — Mark message as read
-- `{{ cmd }} nudge <target> "message"` — Send message to agent session
+- `{{ cmd }} nudge <target> "message"` — Send message to agent session (default: wait-idle)
   **ALWAYS use gt nudge, NEVER tmux send-keys**
+  Use `--mode=immediate` only for stuck agents. Default waits for idle, falls back to queue.
 
 ### Status & Coordination
 - `{{ cmd }} status` — Overall town status

--- a/internal/templates/roles/polecat.md.tmpl
+++ b/internal/templates/roles/polecat.md.tmpl
@@ -392,6 +392,7 @@ BODY
 
 - **Escalation**: Use `{{ cmd }} escalate` (preferred) or mail to witness as HELP
 - **Everything else**: Use `{{ cmd }} nudge` — it's ephemeral and creates zero Dolt overhead
+  Default mode (wait-idle) won't interrupt the recipient. Use `--mode=immediate` only for stuck agents.
 - **Completion**: `{{ cmd }} done` handles notification automatically — do NOT mail "I'm done"
 - **Status updates**: If asked for status, respond via nudge, not mail
 


### PR DESCRIPTION
## Summary

- Changes `gt nudge` default `--mode` from `immediate` to `wait-idle`
- Updates command help text and crew template documentation

## Motivation

Immediate mode sends via tmux `send-keys`, which interrupts active tool calls. This caused a crew worker's `Agent` tool invocation to be aborted when another crew member sent a nudge — the nudge text was injected as user input mid-execution:

```
⏺ langchain-agent-architect(Analyze slow "new loan" flow latency)
  ⎿  Search(pattern: "def _ensure_models_loaded", ...)
     Read(src/infrastructure/custom_redis_saver.py)
     +25 more tool uses (ctrl+o to expand)
  ⎿  Interrupted · What should Claude do instead?

❯ [from laneassist/crew/dom] PR #1715 still has merge conflicts...
```

The non-destructive delivery modes (queue, wait-idle) were added in PR #1405 but kept `immediate` as default for backward compatibility. All Gas Town agents now support `UserPromptSubmit` hooks, so `wait-idle` is safe as the default.

**Behavior of wait-idle:**
1. Polls for idle prompt (up to 15s)
2. If idle → delivers directly (same as immediate but safe)
3. If busy → falls back to cooperative queue
4. If queue fails → falls back to immediate as last resort

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/cmd/ -run TestNudge` passes
- [ ] Manual: `gt nudge` without `--mode` flag uses wait-idle
- [ ] Manual: `gt nudge --mode=immediate` still works for emergencies

🤖 Generated with [Claude Code](https://claude.com/claude-code)