### PR TITLE
fix: WaitForIdle false-positive idle detection during active tool calls

### DIFF
--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -1594,10 +1594,10 @@ func (r *Router) notifyRecipient(msg *Message) error {
 		notification := fmt.Sprintf("📬 You have new mail from %s. Subject: %s. Run 'gt mail inbox' to read.", msg.From, msg.Subject)
 
 		// Wait-idle-first delivery: try direct nudge if the agent is idle,
-		// fall back to cooperative queue if busy. The 3s timeout with 200ms
-		// polling (~15 polls) distinguishes a genuine idle prompt (persists
-		// indefinitely) from brief inter-tool-call gaps (~500ms).
-		// See: https://github.com/steveyegge/gastown/issues/2032
+		// fall back to cooperative queue if busy. WaitForIdle requires 2
+		// consecutive idle polls (prompt visible + no "esc to interrupt"
+		// in the status bar) to distinguish genuine idle from brief
+		// inter-tool-call gaps. See: https://github.com/steveyegge/gastown/issues/2032
 		waitErr := r.tmux.WaitForIdle(sessionID, timeout)
 		if waitErr == nil {
 			// Agent is idle — deliver directly for immediate wakeup.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2363,6 +2363,13 @@ func (t *Tmux) WaitForIdle(session string, timeout time.Duration) error {
 	promptPrefix := DefaultReadyPromptPrefix
 	prefix := strings.TrimSpace(promptPrefix)
 
+	// Require 2 consecutive idle polls to filter out transient states.
+	// During inter-tool-call gaps (~500ms), the prompt may briefly appear
+	// in the pane buffer while Claude Code is still actively working.
+	// Two polls 200ms apart (400ms window) confirms genuine idle state.
+	consecutiveIdle := 0
+	const requiredConsecutive = 2
+
 	deadline := time.Now().Add(timeout)
 	for time.Now().Before(deadline) {
 		lines, err := t.CapturePaneLines(session, 5)
@@ -2373,20 +2380,52 @@ func (t *Tmux) WaitForIdle(session string, timeout time.Duration) error {
 			if errors.Is(err, ErrSessionNotFound) || errors.Is(err, ErrNoServer) {
 				return err
 			}
+			consecutiveIdle = 0
 			time.Sleep(200 * time.Millisecond)
 			continue
 		}
+
+		// Check the status bar first: if "esc to interrupt" is visible,
+		// Claude Code is actively running a tool call — NOT idle,
+		// regardless of whether the prompt prefix is also visible.
+		statusBarBusy := false
+		for _, line := range lines {
+			trimmed := strings.TrimSpace(line)
+			if strings.Contains(trimmed, "\u23F5\u23F5") || strings.Contains(trimmed, "⏵⏵") {
+				if strings.Contains(trimmed, "esc to interrupt") {
+					statusBarBusy = true
+				}
+				break
+			}
+		}
+		if statusBarBusy {
+			consecutiveIdle = 0
+			time.Sleep(200 * time.Millisecond)
+			continue
+		}
+
 		// Scan all captured lines for the prompt prefix.
 		// Claude Code renders a status bar below the prompt line,
 		// so the prompt may not be the last non-empty line.
+		promptFound := false
 		for _, line := range lines {
 			trimmed := strings.TrimSpace(line)
 			if trimmed == "" {
 				continue
 			}
 			if matchesPromptPrefix(trimmed, promptPrefix) || (prefix != "" && trimmed == prefix) {
+				promptFound = true
+				break
+			}
+		}
+
+		if promptFound {
+			consecutiveIdle++
+			if consecutiveIdle >= requiredConsecutive {
 				return nil
 			}
+		} else {
+			consecutiveIdle = 0
 		}
 		time.Sleep(200 * time.Millisecond)
 	}


### PR DESCRIPTION
## Summary
- **Bug**: `WaitForIdle` returned on the first poll finding a `❯` prompt in the pane buffer, but the prompt persists in scrollback during inter-tool-call gaps. This caused `notifyRecipient()` (mail notifications) and `gt nudge --mode=wait-idle` to falsely detect idle and inject text into active sessions.
- **Fix 1**: Check the Claude Code status bar for "esc to interrupt" — if present, the agent is actively executing a tool call and is NOT idle, regardless of prompt visibility.
- **Fix 2**: Require 2 consecutive idle polls (400ms window) to confirm genuine idle state vs transient gap.
- Updates the comment in `notifyRecipient()` to match the new behavior.

## Test plan
- [x] `go build ./internal/tmux/ ./internal/mail/` — compiles clean
- [x] `go test ./internal/tmux/ -run TestWaitForIdle` — passes
- [x] `go test ./internal/mail/` — passes
- [ ] Manual: send mail to a busy agent, verify notification queues instead of interrupting
- [ ] Manual: send mail to an idle agent, verify notification delivers within ~1s

🤖 Generated with [Claude Code](https://claude.com/claude-code)