### PR TITLE
fix(reaper): replace O(n*m) correlated subqueries with LEFT JOINs (gt-jd1z)

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -147,32 +147,20 @@ func OpenDB(host string, port int, dbName string, readTimeout, writeTimeout time
 	return sql.Open("mysql", dsn)
 }
 
-// parentCheckWhere returns the SQL WHERE fragment that restricts operations to
-// wisps whose parent molecule is closed, that have no parent (orphans), or
-// whose parent was purged (dangling dependency reference).
-func parentCheckWhere(dbName string) string {
-	return fmt.Sprintf(`
-		(
-			NOT EXISTS (
-				SELECT 1 FROM `+"`%s`"+`.wisp_dependencies wd
-				WHERE wd.issue_id = w.id AND wd.type = 'parent-child'
-			)
-			OR
-			EXISTS (
-				SELECT 1 FROM `+"`%s`"+`.wisp_dependencies wd
-				JOIN `+"`%s`"+`.wisps parent ON parent.id = wd.depends_on_id
-				WHERE wd.issue_id = w.id AND wd.type = 'parent-child'
-				AND parent.status = 'closed'
-			)
-			OR
-			EXISTS (
-				SELECT 1 FROM `+"`%s`"+`.wisp_dependencies wd
-				LEFT JOIN `+"`%s`"+`.wisps parent ON parent.id = wd.depends_on_id
-				WHERE wd.issue_id = w.id AND wd.type = 'parent-child'
-				AND parent.id IS NULL
-			)
-		)`, dbName, dbName, dbName, dbName, dbName)
+// parentJoinClause returns a LEFT JOIN fragment that brings in parent-child
+// dependency and parent wisp data without correlated subqueries.
+// This replaces the former parentCheckWhere() which used 3 correlated EXISTS
+// subqueries causing O(n*m) query cost on large wisp tables (gt-jd1z).
+func parentJoinClause(dbName string) string {
+	return fmt.Sprintf(
+		"LEFT JOIN `%s`.wisp_dependencies wd ON wd.issue_id = w.id AND wd.type = 'parent-child' "+
+			"LEFT JOIN `%s`.wisps parent ON parent.id = wd.depends_on_id",
+		dbName, dbName)
 }
+
+// parentWhereClause returns the WHERE condition that filters to wisps eligible
+// for reaping: orphans (no parent dep), closed parent, or dangling parent ref.
+const parentWhereClause = "(wd.issue_id IS NULL OR parent.status = 'closed' OR (wd.issue_id IS NOT NULL AND parent.id IS NULL))"
 
 // Scan counts reaper candidates in a database without modifying anything.
 func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssueAge time.Duration) (*ScanResult, error) {
@@ -181,12 +169,13 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 
 	result := &ScanResult{Database: dbName}
 	now := time.Now().UTC()
-	parentCheck := parentCheckWhere(dbName)
+	parentJoin := parentJoinClause(dbName)
 
 	// Count reap candidates: open wisps past max_age with eligible parent status.
-	reapWhere := fmt.Sprintf(
-		"w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND %s", parentCheck)
-	reapQuery := fmt.Sprintf("SELECT COUNT(*) FROM `%s`.wisps w WHERE %s", dbName, reapWhere)
+	// Uses LEFT JOINs instead of correlated EXISTS subqueries to avoid O(n*m) cost (gt-jd1z).
+	reapQuery := fmt.Sprintf(
+		"SELECT COUNT(DISTINCT w.id) FROM `%s`.wisps w %s WHERE w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND %s",
+		dbName, parentJoin, parentWhereClause)
 	if err := db.QueryRowContext(ctx, reapQuery, now.Add(-maxAge)).Scan(&result.ReapCandidates); err != nil {
 		return nil, fmt.Errorf("count reap candidates: %w", err)
 	}
@@ -263,14 +252,17 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 	defer cancel()
 
 	cutoff := time.Now().UTC().Add(-maxAge)
-	parentCheck := parentCheckWhere(dbName)
-	whereClause := fmt.Sprintf(
-		"w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND %s", parentCheck)
+	parentJoin := parentJoinClause(dbName)
+	// Uses LEFT JOINs instead of correlated EXISTS subqueries to avoid O(n*m) cost (gt-jd1z).
+	baseWhere := fmt.Sprintf(
+		"w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND %s", parentWhereClause)
 
 	result := &ReapResult{Database: dbName, DryRun: dryRun}
 
 	if dryRun {
-		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM `%s`.wisps w WHERE %s", dbName, whereClause)
+		countQuery := fmt.Sprintf(
+			"SELECT COUNT(DISTINCT w.id) FROM `%s`.wisps w %s WHERE %s",
+			dbName, parentJoin, baseWhere)
 		if err := db.QueryRowContext(ctx, countQuery, cutoff).Scan(&result.Reaped); err != nil {
 			return nil, fmt.Errorf("dry-run count: %w", err)
 		}
@@ -292,8 +284,8 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 	// Batch UPDATE: select IDs in chunks, update each chunk.
 	// This avoids holding a write lock on the entire table for minutes.
 	idQuery := fmt.Sprintf(
-		"SELECT w.id FROM `%s`.wisps w WHERE %s LIMIT %d",
-		dbName, whereClause, DefaultBatchSize)
+		"SELECT DISTINCT w.id FROM `%s`.wisps w %s WHERE %s LIMIT %d",
+		dbName, parentJoin, baseWhere, DefaultBatchSize)
 
 	totalReaped := 0
 	for {

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -48,21 +48,32 @@ func TestFormatJSON(t *testing.T) {
 	}
 }
 
-func TestParentCheckWhere(t *testing.T) {
-	sql := parentCheckWhere("testdb")
-	// Should reference the correct database in all subqueries.
-	if sql == "" {
-		t.Error("parentCheckWhere should not return empty string")
+func TestParentJoinClause(t *testing.T) {
+	join := parentJoinClause("testdb")
+	if join == "" {
+		t.Error("parentJoinClause should not return empty string")
 	}
-	// Should contain all three branches: no parent, parent closed, dangling parent.
-	if !contains(sql, "NOT EXISTS") {
-		t.Error("parentCheckWhere should have NOT EXISTS branch for orphans")
+	if !contains(join, "LEFT JOIN") {
+		t.Error("parentJoinClause should use LEFT JOIN")
 	}
-	if !contains(sql, "parent.status = 'closed'") {
-		t.Error("parentCheckWhere should check parent status is closed")
+	if !contains(join, "wisp_dependencies") {
+		t.Error("parentJoinClause should reference wisp_dependencies")
 	}
-	if !contains(sql, "parent.id IS NULL") {
-		t.Error("parentCheckWhere should handle dangling parent refs")
+	if !contains(join, "parent-child") {
+		t.Error("parentJoinClause should filter on parent-child type")
+	}
+}
+
+func TestParentWhereClause(t *testing.T) {
+	// Should contain all three eligibility branches: orphan, closed parent, dangling ref.
+	if !contains(parentWhereClause, "wd.issue_id IS NULL") {
+		t.Error("parentWhereClause should check for orphans (no parent dep)")
+	}
+	if !contains(parentWhereClause, "parent.status = 'closed'") {
+		t.Error("parentWhereClause should check parent status is closed")
+	}
+	if !contains(parentWhereClause, "parent.id IS NULL") {
+		t.Error("parentWhereClause should handle dangling parent refs")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Replace `parentCheckWhere()` (3 correlated EXISTS subqueries) with `parentJoinClause()` + `parentWhereClause` using LEFT JOINs
- Same semantics: orphan wisps, closed parent, or dangling parent ref are eligible for reaping
- Reduces query cost from O(n*m) to O(n+m) — on HQ with 22K+ rows, queries were taking 40-50s causing connection timeouts
- Uses `COUNT(DISTINCT w.id)` and `SELECT DISTINCT w.id` to handle potential multiple join rows

Fixes gt-jd1z.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/reaper/ -v -short` passes (5/5 tests)
- [ ] Verify reaper scan/reap on HQ completes within timeout
- [ ] Confirm reap candidate counts match between old and new queries

🤖 Generated with [Claude Code](https://claude.com/claude-code)