### PR TITLE
fix: add --chown=agent:agent to Dockerfile COPY

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -50,7 +50,7 @@ RUN echo 'export TERM="xterm-256color"' >> /etc/profile.d/term.sh && \
 
 USER agent
 
-COPY . /app/gastown
+COPY --chown=agent:agent . /app/gastown
 
 RUN cd /app/gastown && make build
 


### PR DESCRIPTION
## Summary

- Docker's `COPY` instruction always creates files owned by `root`, regardless of the active `USER` directive
- After `USER agent` is set, `COPY . /app/gastown` produces a directory owned by root, so `make build` fails when the `agent` user tries to write compiled Go binaries into `/app/gastown`
- Adding `--chown=agent:agent` to the `COPY` instruction fixes the permission error

## Reproduction

```
=> ERROR [12/15] RUN cd /app/gastown && make build
copying /tmp/go-build.../exe/a.out: open ./gt-proxy-server: permission denied
```

This manifests on Docker CE (and any non-Docker Desktop setup) when building the image from scratch.

## Test plan

- [ ] `docker compose up --build -d` completes successfully
- [ ] `docker compose exec gastown gt version` returns a version string

🤖 Generated with [Claude Code](https://claude.com/claude-code)