### PR TITLE
fix(wl): let claim/done use joined wl-commons clone when server DB is absent

### DIFF
--- a/internal/cmd/wl_claim.go
+++ b/internal/cmd/wl_claim.go
@@ -2,6 +2,8 @@ package cmd
 
 import (
 	"fmt"
+	"os/exec"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/doltserver"
@@ -45,14 +47,23 @@ func runWlClaim(cmd *cobra.Command, args []string) error {
 	}
 	rigHandle := wlCfg.RigHandle
 
+	var item *doltserver.WantedItem
 	if !doltserver.DatabaseExists(townRoot, doltserver.WLCommonsDB) {
-		return fmt.Errorf("database %q not found\nJoin a wasteland first with: gt wl join <org/db>", doltserver.WLCommonsDB)
-	}
-
-	store := doltserver.NewWLCommons(townRoot)
-	item, err := claimWanted(store, wantedID, rigHandle)
-	if err != nil {
-		return err
+		// Fallback for wl-commons clone-based workspaces (join creates .wasteland clone).
+		if wlCfg.LocalDir == "" {
+			return fmt.Errorf("database %q not found\nJoin a wasteland first with: gt wl join <org/db>", doltserver.WLCommonsDB)
+		}
+		if err := claimWantedInLocalClone(wlCfg.LocalDir, wantedID, rigHandle); err != nil {
+			return err
+		}
+		item = &doltserver.WantedItem{ID: wantedID, Status: "claimed", ClaimedBy: rigHandle}
+	} else {
+		store := doltserver.NewWLCommons(townRoot)
+		var err error
+		item, err = claimWanted(store, wantedID, rigHandle)
+		if err != nil {
+			return err
+		}
 	}
 
 	fmt.Printf("%s Claimed %s\n", style.Bold.Render("✓"), wantedID)
@@ -80,4 +91,24 @@ func claimWanted(store doltserver.WLCommonsStore, wantedID, rigHandle string) (*
 	}
 
 	return item, nil
+}
+
+func claimWantedInLocalClone(localDir, wantedID, rigHandle string) error {
+	script := fmt.Sprintf(`UPDATE wanted SET claimed_by='%s', status='claimed', updated_at=NOW()
+WHERE id='%s' AND status='open';
+CALL DOLT_ADD('-A');
+CALL DOLT_COMMIT('-m', 'wl claim: %s');`,
+		doltserver.EscapeSQL(rigHandle), doltserver.EscapeSQL(wantedID), doltserver.EscapeSQL(wantedID))
+
+	cmd := exec.Command("dolt", "sql", "-q", script)
+	cmd.Dir = localDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		s := strings.ToLower(string(out))
+		if strings.Contains(s, "nothing to commit") {
+			return fmt.Errorf("wanted item %s is not open or does not exist", wantedID)
+		}
+		return fmt.Errorf("claiming wanted item: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }

--- a/internal/cmd/wl_done.go
+++ b/internal/cmd/wl_done.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"crypto/sha256"
 	"fmt"
+	"os/exec"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -55,15 +57,21 @@ func runWlDone(cmd *cobra.Command, args []string) error {
 	}
 	rigHandle := wlCfg.RigHandle
 
-	if !doltserver.DatabaseExists(townRoot, doltserver.WLCommonsDB) {
-		return fmt.Errorf("database %q not found\nJoin a wasteland first with: gt wl join <org/db>", doltserver.WLCommonsDB)
-	}
-
-	store := doltserver.NewWLCommons(townRoot)
 	completionID := generateCompletionID(wantedID, rigHandle)
 
-	if err := submitDone(store, wantedID, rigHandle, wlDoneEvidence, completionID); err != nil {
-		return err
+	if !doltserver.DatabaseExists(townRoot, doltserver.WLCommonsDB) {
+		// Fallback for wl-commons clone-based workspaces (join creates .wasteland clone).
+		if wlCfg.LocalDir == "" {
+			return fmt.Errorf("database %q not found\nJoin a wasteland first with: gt wl join <org/db>", doltserver.WLCommonsDB)
+		}
+		if err := submitDoneInLocalClone(wlCfg.LocalDir, wantedID, rigHandle, wlDoneEvidence, completionID); err != nil {
+			return err
+		}
+	} else {
+		store := doltserver.NewWLCommons(townRoot)
+		if err := submitDone(store, wantedID, rigHandle, wlDoneEvidence, completionID); err != nil {
+			return err
+		}
 	}
 
 	fmt.Printf("%s Completion submitted for %s\n", style.Bold.Render("✓"), wantedID)
@@ -101,4 +109,31 @@ func generateCompletionID(wantedID, rigHandle string) string {
 	now := time.Now().UTC().Format(time.RFC3339)
 	h := sha256.Sum256([]byte(wantedID + "|" + rigHandle + "|" + now))
 	return fmt.Sprintf("c-%x", h[:8])
+}
+
+func submitDoneInLocalClone(localDir, wantedID, rigHandle, evidence, completionID string) error {
+	script := fmt.Sprintf(`UPDATE wanted SET status='in_review', evidence_url='%s', updated_at=NOW()
+  WHERE id='%s' AND status='claimed' AND claimed_by='%s';
+INSERT IGNORE INTO completions (id, wanted_id, completed_by, evidence, completed_at)
+  SELECT '%s', '%s', '%s', '%s', NOW()
+  FROM wanted WHERE id='%s' AND status='in_review' AND claimed_by='%s'
+  AND NOT EXISTS (SELECT 1 FROM completions WHERE wanted_id='%s');
+CALL DOLT_ADD('-A');
+CALL DOLT_COMMIT('-m', 'wl done: %s');`,
+		doltserver.EscapeSQL(evidence), doltserver.EscapeSQL(wantedID), doltserver.EscapeSQL(rigHandle),
+		doltserver.EscapeSQL(completionID), doltserver.EscapeSQL(wantedID), doltserver.EscapeSQL(rigHandle), doltserver.EscapeSQL(evidence),
+		doltserver.EscapeSQL(wantedID), doltserver.EscapeSQL(rigHandle), doltserver.EscapeSQL(wantedID),
+		doltserver.EscapeSQL(wantedID))
+
+	cmd := exec.Command("dolt", "sql", "-q", script)
+	cmd.Dir = localDir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		s := strings.ToLower(string(out))
+		if strings.Contains(s, "nothing to commit") {
+			return fmt.Errorf("wanted item %s is not claimed by %q or does not exist", wantedID, rigHandle)
+		}
+		return fmt.Errorf("submitting completion: %w (%s)", err, strings.TrimSpace(string(out)))
+	}
+	return nil
 }


### PR DESCRIPTION
## Problem
`gt wl claim` and `gt wl done` currently hard-fail with:

```
database "wl_commons" not found
Join a wasteland first with: gt wl join <org/db>
```

in real joined workspaces where `gt wl join` created a local clone at:

```
<town>/.wasteland/<org>/wl-commons
```

This happens because claim/done only use the doltserver path (`WLCommonsDB = wl_commons`) and do not fall back to the clone-backed `LocalDir` from wasteland config.

## Fix
- `internal/cmd/wl_claim.go`
  - keep existing server-DB path when available
  - add fallback to `wlCfg.LocalDir` (clone-backed flow) when `WLCommonsDB` is missing
  - execute equivalent `dolt sql` script in clone dir
- `internal/cmd/wl_done.go`
  - same fallback pattern for completion submit flow
  - preserve existing validations/error semantics (`nothing to commit` => precondition-style error)

## Why this is safe
- No behavior change when `WLCommonsDB` exists.
- Fallback only triggers when old path is absent.
- Uses same SQL lifecycle (`UPDATE/INSERT + DOLT_ADD + DOLT_COMMIT`) already used in server-backed implementation.

## Validation
- Reproduced failure before patch in joined workspace.
- After patch, `gt wl done` no longer fails on missing `wl_commons`; it reaches real status checks.
- Tests pass for cmd package:

```bash
go test ./internal/cmd -run 'Test.*(Wl|wl).*' -count=1
```
