### PR TITLE
fix(reaper): update stale DefaultDatabases and use DiscoverDatabases in CLI

### DIFF
--- a/internal/cmd/reaper.go
+++ b/internal/cmd/reaper.go
@@ -43,7 +43,7 @@ var reaperDatabasesCmd = &cobra.Command{
 	Use:   "databases",
 	Short: "List databases available for reaping",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		dbs := reaper.DefaultDatabases
+		dbs := reaper.DiscoverDatabases("127.0.0.1", reaperPort)
 		if reaperJSON {
 			fmt.Println(reaper.FormatJSON(dbs))
 		} else {
@@ -253,7 +253,7 @@ var reaperRunCmd = &cobra.Command{
 This is the inline fallback for when Dog dispatch is unavailable.
 Normally the daemon dispatches a Dog to execute the mol-dog-reaper formula.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		databases := reaper.DefaultDatabases
+		databases := reaper.DiscoverDatabases("127.0.0.1", reaperPort)
 		if reaperDB != "" {
 			databases = strings.Split(reaperDB, ",")
 		}

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -22,7 +22,7 @@ import (
 var validDBName = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
 // DefaultDatabases is the static fallback list of known production databases.
-var DefaultDatabases = []string{"hq", "beads", "gt"}
+var DefaultDatabases = []string{"hq", "bd", "gastown"}
 
 // testPollutionPrefixes are database name prefixes created by tests.
 var testPollutionPrefixes = []string{"testdb_", "beads_t", "beads_pt", "doctest_"}

--- a/plugins/dolt-archive/plugin.md
+++ b/plugins/dolt-archive/plugin.md
@@ -32,7 +32,7 @@ whether the other layers work.
 
 ```bash
 DOLT_DATA_DIR="$HOME/gt/.dolt-data"
-PROD_DBS=("hq" "beads" "gastown")
+PROD_DBS=("hq" "bd" "gastown")
 JSONL_EXPORT_DIR="$HOME/gt/.dolt-archive/jsonl"
 DOLT_HOST="127.0.0.1"
 DOLT_PORT=3307


### PR DESCRIPTION
## Summary
- `DefaultDatabases` was hardcoded to `["hq", "beads", "gt"]` but actual production databases are `hq`, `bd`, and `gastown`. The names `beads` and `gt` are stale from before the database rename.
- `gt reaper databases` used `DefaultDatabases` directly instead of `DiscoverDatabases()` (added in PR #2262)
- `gt reaper run` also fell back to the stale static list
- `dolt-archive` plugin had `PROD_DBS=("hq" "beads" "gastown")` — `beads` should be `bd`

## Changes
1. Update `DefaultDatabases` to `["hq", "bd", "gastown"]`
2. `gt reaper databases` now uses `DiscoverDatabases()` for dynamic discovery
3. `gt reaper run` now uses `DiscoverDatabases()` as default
4. Fix dolt-archive plugin `PROD_DBS`

## Test plan
- [x] `go build ./internal/reaper/ ./internal/cmd/` — compiles clean
- [x] `go test ./internal/reaper/ -run TestDefaultDatabases` — passes
- [ ] Manual: `gt reaper databases` should list all production DBs dynamically
- [ ] Manual: dolt-archive plugin should export from correct databases

🤖 Generated with [Claude Code](https://claude.com/claude-code)