### PR TITLE
feat(daemon): opt-in pressure checks before agent spawns

### DIFF
--- a/internal/config/operational.go
+++ b/internal/config/operational.go
@@ -47,6 +47,13 @@ const (
 	DefaultRecoveryHeartbeatInterval       = 3 * time.Minute
 	DefaultBootSpawnCooldown               = 2 * time.Minute
 	DefaultDeaconGracePeriod               = 5 * time.Minute
+
+	// Pressure check defaults — fully opt-in. All zero = disabled.
+	// Configure in settings/config.json under operational.daemon to enable.
+	// Example: {"pressure_cpu_threshold": 3.0, "pressure_mem_threshold_gb": 0.5}
+	DefaultPressureCPUThreshold   = 0.0
+	DefaultPressureMemThresholdGB = 0.0
+	DefaultPressureMaxSessions    = 0
 )
 
 // Deacon defaults.
@@ -370,6 +377,30 @@ func (d *DaemonThresholds) DeaconGracePeriodD() time.Duration {
 		return ParseDurationOrDefault(d.DeaconGracePeriod, DefaultDeaconGracePeriod)
 	}
 	return DefaultDeaconGracePeriod
+}
+
+// PressureCPUThresholdV returns the configured or default CPU pressure threshold (load per core).
+func (d *DaemonThresholds) PressureCPUThresholdV() float64 {
+	if d != nil && d.PressureCPUThreshold != nil {
+		return *d.PressureCPUThreshold
+	}
+	return DefaultPressureCPUThreshold
+}
+
+// PressureMemThresholdGBV returns the configured or default memory pressure threshold in GB.
+func (d *DaemonThresholds) PressureMemThresholdGBV() float64 {
+	if d != nil && d.PressureMemThresholdGB != nil {
+		return *d.PressureMemThresholdGB
+	}
+	return DefaultPressureMemThresholdGB
+}
+
+// PressureMaxSessionsV returns the configured or default max concurrent sessions (0 = unlimited).
+func (d *DaemonThresholds) PressureMaxSessionsV() int {
+	if d != nil && d.PressureMaxSessions != nil {
+		return *d.PressureMaxSessions
+	}
+	return DefaultPressureMaxSessions
 }
 
 // --- Deacon accessors ---

--- a/internal/config/operational_test.go
+++ b/internal/config/operational_test.go
@@ -364,3 +364,115 @@ func TestWitnessThresholds_Overrides(t *testing.T) {
 		t.Errorf("DoneIntentRecentGrace: got %v, want 15s", got)
 	}
 }
+
+func TestPressureThresholds_Defaults(t *testing.T) {
+	t.Parallel()
+
+	var op *OperationalConfig
+	dt := op.GetDaemonConfig()
+
+	if got := dt.PressureCPUThresholdV(); got != DefaultPressureCPUThreshold {
+		t.Errorf("PressureCPUThreshold: got %v, want %v", got, DefaultPressureCPUThreshold)
+	}
+	if got := dt.PressureMemThresholdGBV(); got != DefaultPressureMemThresholdGB {
+		t.Errorf("PressureMemThresholdGB: got %v, want %v", got, DefaultPressureMemThresholdGB)
+	}
+	if got := dt.PressureMaxSessionsV(); got != DefaultPressureMaxSessions {
+		t.Errorf("PressureMaxSessions: got %v, want %v", got, DefaultPressureMaxSessions)
+	}
+}
+
+func TestPressureThresholds_Overrides(t *testing.T) {
+	t.Parallel()
+
+	cpu := 0.5
+	mem := 8.0
+	sessions := 10
+	dt := &DaemonThresholds{
+		PressureCPUThreshold:   &cpu,
+		PressureMemThresholdGB: &mem,
+		PressureMaxSessions:    &sessions,
+	}
+	if got := dt.PressureCPUThresholdV(); got != 0.5 {
+		t.Errorf("PressureCPUThreshold: got %v, want 0.5", got)
+	}
+	if got := dt.PressureMemThresholdGBV(); got != 8.0 {
+		t.Errorf("PressureMemThresholdGB: got %v, want 8.0", got)
+	}
+	if got := dt.PressureMaxSessionsV(); got != 10 {
+		t.Errorf("PressureMaxSessions: got %v, want 10", got)
+	}
+}
+
+func TestPressureThresholds_DisabledWithZero(t *testing.T) {
+	t.Parallel()
+
+	zero := 0.0
+	zeroInt := 0
+	dt := &DaemonThresholds{
+		PressureCPUThreshold:   &zero,
+		PressureMemThresholdGB: &zero,
+		PressureMaxSessions:    &zeroInt,
+	}
+	if dt.PressureCPUThresholdV() != 0 {
+		t.Error("zero CPU threshold should disable check")
+	}
+	if dt.PressureMemThresholdGBV() != 0 {
+		t.Error("zero mem threshold should disable check")
+	}
+	if dt.PressureMaxSessionsV() != 0 {
+		t.Error("zero max sessions should mean unlimited")
+	}
+}
+
+func TestPressureThresholds_NilReceiver(t *testing.T) {
+	t.Parallel()
+
+	var dt *DaemonThresholds
+	if dt.PressureCPUThresholdV() != DefaultPressureCPUThreshold {
+		t.Error("nil DaemonThresholds should return default CPU threshold")
+	}
+	if dt.PressureMemThresholdGBV() != DefaultPressureMemThresholdGB {
+		t.Error("nil DaemonThresholds should return default mem threshold")
+	}
+	if dt.PressureMaxSessionsV() != DefaultPressureMaxSessions {
+		t.Error("nil DaemonThresholds should return default max sessions")
+	}
+}
+
+func TestPressureThresholds_JSON(t *testing.T) {
+	t.Parallel()
+
+	jsonData := `{
+		"daemon": {
+			"pressure_cpu_threshold": 0.7,
+			"pressure_mem_threshold_gb": 4.0,
+			"pressure_max_sessions": 8
+		}
+	}`
+
+	dir := t.TempDir()
+	configDir := filepath.Join(dir, "settings")
+	if err := os.MkdirAll(configDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(configDir, "config.json"), []byte(`{}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	var raw struct {
+		Daemon *DaemonThresholds `json:"daemon"`
+	}
+	if err := json.Unmarshal([]byte(jsonData), &raw); err != nil {
+		t.Fatal(err)
+	}
+	if raw.Daemon.PressureCPUThresholdV() != 0.7 {
+		t.Errorf("JSON CPU threshold: got %v, want 0.7", raw.Daemon.PressureCPUThresholdV())
+	}
+	if raw.Daemon.PressureMemThresholdGBV() != 4.0 {
+		t.Errorf("JSON mem threshold: got %v, want 4.0", raw.Daemon.PressureMemThresholdGBV())
+	}
+	if raw.Daemon.PressureMaxSessionsV() != 8 {
+		t.Errorf("JSON max sessions: got %v, want 8", raw.Daemon.PressureMaxSessionsV())
+	}
+}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -313,6 +313,20 @@ type DaemonThresholds struct {
 
 	// DeaconGracePeriod is time to wait after starting Deacon before checking heartbeat (default "5m").
 	DeaconGracePeriod string `json:"deacon_grace_period,omitempty"`
+
+	// PressureCPUThreshold is the per-core load average above which new
+	// non-infrastructure spawns are deferred. Disabled by default (0).
+	// Recommended starting value: 3.0 (only trips under severe load).
+	PressureCPUThreshold *float64 `json:"pressure_cpu_threshold,omitempty"`
+
+	// PressureMemThresholdGB is the minimum available memory (in GB) below
+	// which new non-infrastructure spawns are deferred. Disabled by default (0).
+	// Recommended starting value: 0.5 (only trips when swapping).
+	PressureMemThresholdGB *float64 `json:"pressure_mem_threshold_gb,omitempty"`
+
+	// PressureMaxSessions is the maximum number of concurrent agent tmux
+	// sessions before new non-infrastructure spawns are deferred. Disabled by default (0 = unlimited).
+	PressureMaxSessions *int `json:"pressure_max_sessions,omitempty"`
 }
 
 // DeaconThresholds configures deacon health-check and dispatch thresholds.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -627,8 +627,13 @@ func (d *Daemon) heartbeat(state *State) {
 
 	// 5. Ensure Refineries are running for all rigs (restart if dead)
 	// Check patrol config - can be disabled in mayor/daemon.json
+	// Pressure-gated: refineries consume API credits, defer when system is loaded.
 	if IsPatrolEnabled(d.patrolConfig, "refinery") {
-		d.ensureRefineriesRunning()
+		if p := d.checkPressure("refinery"); !p.OK {
+			d.logger.Printf("Deferring refinery spawn: %s", p.Reason)
+		} else {
+			d.ensureRefineriesRunning()
+		}
 	} else {
 		d.logger.Printf("Refinery patrol disabled in config, skipping")
 		// Kill leftover refinery sessions from before patrol was disabled. (hq-2mstj)
@@ -639,8 +644,15 @@ func (d *Daemon) heartbeat(state *State) {
 	d.ensureMayorRunning()
 
 	// 6.5. Handle Dog lifecycle: cleanup stuck dogs and dispatch plugins
+	// Pressure-gated: dog dispatch spawns new agent sessions.
 	if IsPatrolEnabled(d.patrolConfig, "handler") {
-		d.handleDogs()
+		if p := d.checkPressure("dog"); !p.OK {
+			d.logger.Printf("Deferring dog dispatch: %s", p.Reason)
+			// Still run cleanup phases (stuck/stale/idle) — only skip dispatch
+			d.handleDogsCleanupOnly()
+		} else {
+			d.handleDogs()
+		}
 	} else {
 		d.logger.Printf("Handler patrol disabled in config, skipping")
 	}
@@ -673,7 +685,12 @@ func (d *Daemon) heartbeat(state *State) {
 
 	// 14. Dispatch scheduled work (capacity-controlled polecat dispatch).
 	// Shells out to `gt scheduler run` to avoid circular import between daemon and cmd.
-	d.dispatchQueuedWork()
+	// Pressure-gated: polecats are the primary resource consumers.
+	if p := d.checkPressure("polecat"); !p.OK {
+		d.logger.Printf("Deferring polecat dispatch: %s", p.Reason)
+	} else {
+		d.dispatchQueuedWork()
+	}
 
 	// 15. Rotate oversized Dolt logs (copytruncate for child process fds).
 	// daemon.log uses lumberjack for automatic rotation; this handles Dolt server logs.

--- a/internal/daemon/handler.go
+++ b/internal/daemon/handler.go
@@ -57,6 +57,27 @@ func (d *Daemon) handleDogs() {
 	d.dispatchPlugins(mgr, sm, rigsConfig)
 }
 
+// handleDogsCleanupOnly runs dog lifecycle cleanup (stuck, stale, idle) without
+// dispatching new work. Used when pressure checks block new spawns.
+func (d *Daemon) handleDogsCleanupOnly() {
+	rigsConfig, err := d.loadRigsConfig()
+	if err != nil {
+		d.logger.Printf("Handler: failed to load rigs config: %v", err)
+		return
+	}
+
+	opCfg := d.loadOperationalConfig().GetDaemonConfig()
+
+	mgr := dog.NewManager(d.config.TownRoot, rigsConfig)
+	t := tmux.NewTmux()
+	sm := dog.NewSessionManager(t, d.config.TownRoot, mgr)
+
+	d.cleanupStuckDogs(mgr, sm)
+	d.detectStaleWorkingDogs(mgr, sm, opCfg)
+	d.reapIdleDogs(mgr, sm, opCfg)
+	// Skip dispatchPlugins — under pressure
+}
+
 // cleanupStuckDogs finds dogs in state=working whose tmux session is dead and
 // clears their work so they return to idle.
 func (d *Daemon) cleanupStuckDogs(mgr *dog.Manager, sm *dog.SessionManager) {

--- a/internal/daemon/pressure.go
+++ b/internal/daemon/pressure.go
@@ -1,0 +1,143 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"runtime"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// PressureResult holds the outcome of a pressure check.
+type PressureResult struct {
+	// OK is true if spawning should proceed.
+	OK bool
+
+	// Reason describes why spawning was blocked (empty if OK).
+	Reason string
+
+	// LoadAvg1 is the 1-minute load average at check time.
+	LoadAvg1 float64
+
+	// MemAvailableGB is approximate available memory in GB.
+	MemAvailableGB float64
+
+	// ActiveSessions is the count of active Claude agent sessions.
+	ActiveSessions int
+}
+
+// checkPressure evaluates system load and session concurrency to decide
+// whether spawning a new agent session is safe. It checks:
+//
+//  1. CPU pressure: 1-minute load average vs threshold (per-core).
+//  2. Memory pressure: available memory vs minimum threshold.
+//  3. Session concurrency: active tmux sessions vs maximum cap.
+//
+// Infrastructure agents (deacon, witness, mayor) should NOT be gated by
+// pressure—they are the monitoring/recovery layer. Only gate:
+//   - Polecats (dispatchQueuedWork, crash restarts)
+//   - Refineries
+//   - Dogs
+func (d *Daemon) checkPressure(role string) PressureResult {
+	cfg := d.loadOperationalConfig().GetDaemonConfig()
+
+	cpuThreshold := cfg.PressureCPUThresholdV()
+	memThreshold := cfg.PressureMemThresholdGBV()
+	maxSessions := cfg.PressureMaxSessionsV()
+
+	// All checks disabled (default) — skip entirely, no subprocess calls.
+	if cpuThreshold <= 0 && memThreshold <= 0 && maxSessions <= 0 {
+		return PressureResult{OK: true}
+	}
+
+	var result PressureResult
+	result.OK = true
+
+	// Tier 1: CPU pressure (load average per core)
+	if cpuThreshold > 0 {
+		result.LoadAvg1 = loadAverage1()
+		numCPU := float64(runtime.NumCPU())
+		loadPerCore := result.LoadAvg1 / numCPU
+		if loadPerCore > cpuThreshold {
+			result.OK = false
+			result.Reason = fmt.Sprintf("cpu pressure: load/core %.2f exceeds threshold %.2f (load=%.1f, cores=%d)", loadPerCore, cpuThreshold, result.LoadAvg1, int(numCPU))
+			return result
+		}
+	}
+
+	// Tier 1: Memory pressure
+	if memThreshold > 0 {
+		result.MemAvailableGB = availableMemoryGB()
+		if result.MemAvailableGB > 0 && result.MemAvailableGB < memThreshold {
+			result.OK = false
+			result.Reason = fmt.Sprintf("memory pressure: %.1fGB available, minimum %.1fGB", result.MemAvailableGB, memThreshold)
+			return result
+		}
+	}
+
+	// Tier 2: Session concurrency cap
+	if maxSessions > 0 {
+		result.ActiveSessions = d.countAgentSessions()
+		if result.ActiveSessions >= maxSessions {
+			result.OK = false
+			result.Reason = fmt.Sprintf("session cap: %d active sessions, max %d", result.ActiveSessions, maxSessions)
+			return result
+		}
+	}
+
+	return result
+}
+
+// countAgentSessions counts active tmux sessions that belong to Gas Town agents.
+// Uses the town's tmux socket so it only counts sessions for this town.
+func (d *Daemon) countAgentSessions() int {
+	t := tmux.NewTmux()
+	sessions, err := t.ListSessions()
+	if err != nil {
+		return 0
+	}
+
+	count := 0
+	for _, name := range sessions {
+		if isAgentSession(name) {
+			count++
+		}
+	}
+	return count
+}
+
+// isAgentSession returns true if the tmux session name looks like a Gas Town agent.
+// Agent sessions use prefixed names (e.g., "hq-mayor", "rig-witness", "rig-polecat-foo").
+func isAgentSession(name string) bool {
+	// Agent sessions contain role markers
+	for _, marker := range []string{
+		constants.RoleMayor,
+		constants.RoleWitness,
+		constants.RoleRefinery,
+		constants.RolePolecat,
+		constants.RoleDeacon,
+		constants.RoleCrew,
+		"boot",
+		"dog",
+	} {
+		if strings.Contains(name, marker) {
+			return true
+		}
+	}
+	return false
+}
+
+// loadAverage1 returns the 1-minute load average.
+// Falls back to 0 if unavailable (effectively disabling the check).
+func loadAverage1() float64 {
+	data, err := os.ReadFile("/proc/loadavg")
+	if err != nil {
+		// macOS: use sysctl
+		return loadAverage1Sysctl()
+	}
+	var load1 float64
+	_, _ = fmt.Sscanf(string(data), "%f", &load1)
+	return load1
+}

--- a/internal/daemon/pressure_darwin.go
+++ b/internal/daemon/pressure_darwin.go
@@ -1,0 +1,71 @@
+package daemon
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// loadAverage1Sysctl returns the 1-minute load average via sysctl on macOS.
+func loadAverage1Sysctl() float64 {
+	out, err := exec.Command("sysctl", "-n", "vm.loadavg").Output()
+	if err != nil {
+		return 0
+	}
+	// Output format: "{ 1.23 4.56 7.89 }"
+	s := strings.TrimSpace(string(out))
+	s = strings.Trim(s, "{ }")
+	fields := strings.Fields(s)
+	if len(fields) < 1 {
+		return 0
+	}
+	v, err := strconv.ParseFloat(fields[0], 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}
+
+// availableMemoryGB returns approximate available memory in GB on macOS.
+// Uses vm_stat to get free + inactive pages. Returns 0 if unavailable.
+func availableMemoryGB() float64 {
+	out, err := exec.Command("vm_stat").Output()
+	if err != nil {
+		return 0
+	}
+
+	var freePages, inactivePages uint64
+	for _, line := range strings.Split(string(out), "\n") {
+		if strings.HasPrefix(line, "Pages free:") {
+			freePages = parseVMStatValue(line)
+		} else if strings.HasPrefix(line, "Pages inactive:") {
+			inactivePages = parseVMStatValue(line)
+		}
+	}
+
+	// macOS page size is 16384 on Apple Silicon, 4096 on Intel
+	pageSize := uint64(16384) // conservative default for M-series
+	out2, err := exec.Command("sysctl", "-n", "hw.pagesize").Output()
+	if err == nil {
+		if ps, err := strconv.ParseUint(strings.TrimSpace(string(out2)), 10, 64); err == nil {
+			pageSize = ps
+		}
+	}
+
+	availBytes := (freePages + inactivePages) * pageSize
+	return float64(availBytes) / (1024 * 1024 * 1024)
+}
+
+func parseVMStatValue(line string) uint64 {
+	parts := strings.SplitN(line, ":", 2)
+	if len(parts) < 2 {
+		return 0
+	}
+	s := strings.TrimSpace(parts[1])
+	s = strings.TrimSuffix(s, ".")
+	v, err := strconv.ParseUint(s, 10, 64)
+	if err != nil {
+		return 0
+	}
+	return v
+}

--- a/internal/daemon/pressure_linux.go
+++ b/internal/daemon/pressure_linux.go
@@ -1,0 +1,33 @@
+package daemon
+
+import (
+	"fmt"
+	"os"
+	"strings"
+)
+
+// loadAverage1Sysctl is a no-op on Linux — /proc/loadavg is used directly.
+func loadAverage1Sysctl() float64 {
+	return 0
+}
+
+// availableMemoryGB returns available memory in GB on Linux.
+// Reads MemAvailable from /proc/meminfo (kernel 3.14+).
+func availableMemoryGB() float64 {
+	data, err := os.ReadFile("/proc/meminfo")
+	if err != nil {
+		return 0
+	}
+
+	for _, line := range strings.Split(string(data), "\n") {
+		if strings.HasPrefix(line, "MemAvailable:") {
+			var kb uint64
+			_, err := fmt.Sscanf(line, "MemAvailable: %d kB", &kb)
+			if err != nil {
+				return 0
+			}
+			return float64(kb) / (1024 * 1024)
+		}
+	}
+	return 0
+}

--- a/internal/daemon/pressure_test.go
+++ b/internal/daemon/pressure_test.go
@@ -1,0 +1,41 @@
+package daemon
+
+import (
+	"testing"
+)
+
+func TestIsAgentSession(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		{"hq-mayor", true},
+		{"rig-witness", true},
+		{"rig-refinery", true},
+		{"rig-polecat-abc", true},
+		{"hq-deacon", true},
+		{"hq-boot", true},
+		{"rig-dog-fido", true},
+		{"my-personal-session", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := isAgentSession(tt.name); got != tt.want {
+			t.Errorf("isAgentSession(%q) = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestLoadAverage1_DoesNotPanic(t *testing.T) {
+	load := loadAverage1()
+	if load < 0 {
+		t.Errorf("load average should be >= 0, got %f", load)
+	}
+}
+
+func TestAvailableMemoryGB_DoesNotPanic(t *testing.T) {
+	mem := availableMemoryGB()
+	if mem < 0 {
+		t.Errorf("available memory should be >= 0, got %f", mem)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `checkPressure()` to daemon heartbeat gating refinery, polecat, and dog spawns based on system resource pressure
- **Fully opt-in**: all checks disabled by default (zero overhead, no subprocess calls when unconfigured)
- Infrastructure agents (deacon, witness, mayor, boot) are never gated—they're the recovery layer
- Platform-specific implementations for macOS (`sysctl`/`vm_stat`) and Linux (`/proc/loadavg`, `/proc/meminfo`)

### Configuration (in `settings/config.json`)

```json
{
  "operational": {
    "daemon": {
      "pressure_cpu_threshold": 3.0,
      "pressure_mem_threshold_gb": 0.5,
      "pressure_max_sessions": 12
    }
  }
}
```

| Check | Config key | Behavior | Recommended |
|-------|-----------|----------|-------------|
| CPU | `pressure_cpu_threshold` | Per-core load average cap | 3.0 |
| Memory | `pressure_mem_threshold_gb` | Available memory floor (GB) | 0.5 |
| Sessions | `pressure_max_sessions` | Max concurrent agent sessions | 0 (unlimited) |

All default to 0 (disabled). Set to 0 explicitly to disable any individual check.

### What gets gated under pressure

| Spawn | Gated? | Notes |
|-------|--------|-------|
| Polecats (dispatch) | Yes | Deferred to next heartbeat |
| Refineries | Yes | Deferred to next heartbeat |
| Dogs (dispatch) | Yes | Cleanup still runs, only new dispatch deferred |
| Deacon/Boot | No | Recovery infrastructure |
| Witness | No | Monitoring infrastructure |
| Mayor | No | Town management |

## Test plan

- [x] Config accessor tests (defaults, overrides, zero-disables, nil-safe, JSON round-trip)
- [x] `isAgentSession` unit tests
- [x] Platform function smoke tests (no panics)
- [x] Full `go build ./...` clean
- [x] Existing config test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)