### PR TITLE
fix: normalize double slashes in GT_ROLE parsing

### DIFF
--- a/internal/cmd/role.go
+++ b/internal/cmd/role.go
@@ -338,6 +338,12 @@ func detectRole(cwd, townRoot string) RoleInfo {
 func parseRoleString(s string) (Role, string, string) {
 	s = strings.TrimSpace(s)
 
+	// Normalize consecutive slashes (e.g. "gamestore//refinery" → "gamestore/refinery")
+	for strings.Contains(s, "//") {
+		s = strings.ReplaceAll(s, "//", "/")
+	}
+	s = strings.TrimSuffix(s, "/")
+
 	// Simple roles
 	switch s {
 	case constants.RoleMayor:

--- a/internal/cmd/role_boot_test.go
+++ b/internal/cmd/role_boot_test.go
@@ -22,6 +22,12 @@ func TestParseRoleStringBoot(t *testing.T) {
 		{"west/boot", Role("west/boot"), "", ""},
 		// Extra path segments should NOT match RoleBoot
 		{"deacon/boot/extra", Role("deacon/boot/extra"), "", ""},
+		// Double-slash normalization
+		{"gamestore//refinery", RoleRefinery, "gamestore", ""},
+		{"gamestore//witness", RoleWitness, "gamestore", ""},
+		{"gamestore///refinery", RoleRefinery, "gamestore", ""},
+		{"gamestore/refinery/", RoleRefinery, "gamestore", ""},
+		{"gamestore//polecats//alpha", RolePolecat, "gamestore", "alpha"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary

- `GT_ROLE=gamestore//refinery` was parsed as `polecat` instead of `refinery` because `strings.Split` on `//` produces an empty string element that falls through to the default case
- Added slash normalization (collapse `//` → `/`, trim trailing `/`) in `parseRoleString` before splitting
- Added test cases for double-slash, triple-slash, trailing-slash, and nested double-slash scenarios

## Impact

This bug blocked refinery patrol, `gt handoff`, and `gt done` for any role with a double-slash in `GT_ROLE`.

## Test plan

- [x] All existing `TestParseRoleStringBoot` cases pass
- [x] New double-slash normalization cases pass
- [x] Manual verification: `GT_ROLE="gamestore//refinery" gt role show` → `refinery`

Fixes ga-hg9

🤖 Generated with [Claude Code](https://claude.com/claude-code)