### PR TITLE
fix(convoy): resolve external tracked IDs during launch collection

### DIFF
--- a/internal/cmd/convoy_launch_test.go
+++ b/internal/cmd/convoy_launch_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"runtime"
 	"sort"
 	"strings"
@@ -710,5 +711,82 @@ func TestDispatchWave1_EndToEnd(t *testing.T) {
 		if id == "hq-task-b" {
 			t.Errorf("hq-task-b should NOT be dispatched in Wave 1")
 		}
+	}
+}
+
+// GH-2373 regression:
+// collectConvoyBeads must handle tracked deps returned as id-only external refs
+// (external:<rig>:<id>) and resolve them into raw bead IDs for lookup.
+func TestCollectConvoyBeads_ExternalTrackedIDs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows — shell stubs")
+	}
+
+	townRoot := t.TempDir()
+	townBeads := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(townBeads, 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+
+	binDir := t.TempDir()
+	bdPath := filepath.Join(binDir, "bd")
+	bdScript := `#!/bin/sh
+case "$*" in
+  "show hq-cv-ext --json")
+    echo '[{"id":"hq-cv-ext","title":"Ext convoy","status":"staged_ready","issue_type":"convoy"}]'
+    ;;
+  "dep list hq-cv-ext --direction=down --type=tracks --json")
+    echo '[{"id":"external:ghostty:ghostty-1i4.3"},{"id":"external:ghostty:ghostty-1i4.4"}]'
+    ;;
+  "dep list hq-cv-ext --json")
+    echo '[{"id":"external:ghostty:ghostty-1i4.3"},{"id":"external:ghostty:ghostty-1i4.4"}]'
+    ;;
+  "show ghostty-1i4.3 --json")
+    echo '[{"id":"ghostty-1i4.3","title":"Task 1","status":"open","issue_type":"task"}]'
+    ;;
+  "show ghostty-1i4.4 --json")
+    echo '[{"id":"ghostty-1i4.4","title":"Task 2","status":"open","issue_type":"task"}]'
+    ;;
+  "dep list ghostty-1i4.3 --json"|"dep list ghostty-1i4.4 --json")
+    echo '[]'
+    ;;
+  *)
+    echo "unexpected bd args: $*" >&2
+    exit 1
+    ;;
+esac
+`
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+":"+origPath)
+	origWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("chdir townRoot: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(origWD) })
+
+	beads, deps, err := collectConvoyBeads("hq-cv-ext")
+	if err != nil {
+		t.Fatalf("collectConvoyBeads: %v", err)
+	}
+	if len(beads) != 2 {
+		t.Fatalf("expected 2 tracked beads, got %d", len(beads))
+	}
+	ids := []string{beads[0].ID, beads[1].ID}
+	sort.Strings(ids)
+	if ids[0] != "ghostty-1i4.3" || ids[1] != "ghostty-1i4.4" {
+		t.Fatalf("unexpected bead IDs: %v", ids)
+	}
+	if len(deps) != 0 {
+		t.Fatalf("expected no deps for tracked beads, got %d", len(deps))
 	}
 }

--- a/internal/cmd/convoy_stage.go
+++ b/internal/cmd/convoy_stage.go
@@ -42,14 +42,14 @@ func init() {
 
 // StageResult is the top-level JSON output for gt convoy stage --json.
 type StageResult struct {
-	Status   string           `json:"status"`    // "staged_ready", "staged_warnings", or "error"
-	ConvoyID string           `json:"convoy_id"` // empty if errors prevented creation
-	Restaged bool             `json:"restaged"`  // true if an existing convoy was updated in place
-	Errors   []FindingJSON    `json:"errors"`
-	Warnings []FindingJSON    `json:"warnings"`
-	Waves    []WaveJSON       `json:"waves"`
-	Gated    []GatedTaskJSON  `json:"gated,omitempty"` // tasks blocked by open non-slingable nodes
-	Tree     []TreeNodeJSON   `json:"tree"`
+	Status   string          `json:"status"`    // "staged_ready", "staged_warnings", or "error"
+	ConvoyID string          `json:"convoy_id"` // empty if errors prevented creation
+	Restaged bool            `json:"restaged"`  // true if an existing convoy was updated in place
+	Errors   []FindingJSON   `json:"errors"`
+	Warnings []FindingJSON   `json:"warnings"`
+	Waves    []WaveJSON      `json:"waves"`
+	Gated    []GatedTaskJSON `json:"gated,omitempty"` // tasks blocked by open non-slingable nodes
+	Tree     []TreeNodeJSON  `json:"tree"`
 }
 
 // GatedTaskJSON is the JSON representation of a task gated by non-slingable blockers.
@@ -1307,9 +1307,9 @@ type bdShowResult struct {
 // Each entry is a bead that the queried issue depends on.
 // The IssueID is set by the caller (it's the bead we queried).
 type bdDepResult struct {
-	IssueID        string `json:"-"`               // set by caller
-	DependsOnID    string `json:"id"`              // the dependency target
-	Type           string `json:"dependency_type"` // blocks, parent-child, etc.
+	IssueID     string `json:"-"`               // set by caller
+	DependsOnID string `json:"id"`              // the dependency target
+	Type        string `json:"dependency_type"` // blocks, parent-child, etc.
 }
 
 // ---------------------------------------------------------------------------
@@ -1549,20 +1549,22 @@ func collectConvoyBeads(convoyID string) ([]BeadInfo, []DepInfo, error) {
 		return nil, nil, fmt.Errorf("convoy %s: %w", convoyID, err)
 	}
 
-	// 2. Get deps for the convoy — filter for "tracks" type.
-	deps, err := bdDepList(convoyID)
+	// 2. Read tracked IDs using the same filtered dep-list path used by status
+	// and staged-convoy reconciliation. This handles id-only dep rows and
+	// external:<rig>:<id> wrappers.
+	townBeads, err := getTownBeadsDir()
+	if err != nil {
+		return nil, nil, err
+	}
+	trackedSet, err := convoyTrackedBeadIDs(townBeads, convoyID)
 	if err != nil {
 		return nil, nil, fmt.Errorf("deps for convoy %s: %w", convoyID, err)
 	}
-
-	// Extract tracked bead IDs. bdDepList sets IssueID to the queried bead
-	// (the convoy) and DependsOnID to the JSON "id" field (the tracked bead).
-	var trackedIDs []string
-	for _, d := range deps {
-		if d.Type == "tracks" {
-			trackedIDs = append(trackedIDs, d.DependsOnID)
-		}
+	trackedIDs := make([]string, 0, len(trackedSet))
+	for id := range trackedSet {
+		trackedIDs = append(trackedIDs, id)
 	}
+	sort.Strings(trackedIDs)
 
 	if len(trackedIDs) == 0 {
 		return nil, nil, fmt.Errorf("convoy %s tracks no beads", convoyID)


### PR DESCRIPTION
## Summary
- Fix `collectConvoyBeads` to resolve tracked bead IDs via `convoyTrackedBeadIDs` (same filtered path used by status/reconciliation)
- Correctly unwrap `external:<rig>:<id>` tracked dependency rows before bead lookup
- Keep deterministic ordering of tracked IDs for stable downstream behavior

## Reproduction
- Stage a convoy where tracked deps are stored as id-only external refs (e.g. `external:ghostty:ghostty-1i4.3`)
- `gt convoy stage` shows waves, but `gt convoy status --json` can report `tracked: null, total: 0`
- `gt convoy launch` then fails with `convoy <id> tracks no beads`

## Fix
`collectConvoyBeads` previously consumed unfiltered `bd dep list` rows and only trusted `dependency_type == "tracks"`. In id-only external dep rows, that filter path can drop all tracked items.

Now it reuses `convoyTrackedBeadIDs(...)` which already:
- requests tracked deps with `--direction=down --type=tracks`
- handles id-only dep rows
- unwraps `external:*` IDs

## Tests
Added regression test:
- `TestCollectConvoyBeads_ExternalTrackedIDs` in `internal/cmd/convoy_launch_test.go`

Executed locally:
- `make build`
- `go test ./internal/cmd -run 'TestCollectConvoyBeads_ExternalTrackedIDs|TestDispatchWave1_EndToEnd'`
- `go test ./internal/cmd`

Fixes #2373
