### PR TITLE
fix: normalize hook show targets and avoid stale polecat hook issue

### DIFF
--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/runtime"
+	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
@@ -444,7 +445,7 @@ func checkPinnedBeadComplete(b *beads.Beads, issue *beads.Issue) (isComplete boo
 func runHookShow(cmd *cobra.Command, args []string) error {
 	var target string
 	if len(args) > 0 {
-		target = args[0]
+		target = normalizeHookShowTarget(args[0])
 	} else {
 		// Auto-detect current agent from context
 		agentID, _, _, err := resolveSelfTarget()
@@ -527,6 +528,62 @@ func runHookShow(cmd *cobra.Command, args []string) error {
 	bead := hookedBeads[0]
 	fmt.Printf("%s: %s '%s' [%s]\n", target, bead.ID, bead.Title, bead.Status)
 	return nil
+}
+
+// normalizeHookShowTarget resolves target aliases/shorthand to canonical agent IDs.
+// Examples:
+//   - "rig/polecat" -> "rig/polecats/polecat"
+//   - "mayor" -> "mayor"
+//
+// If resolution fails, it returns the original target unchanged.
+func normalizeHookShowTarget(target string) string {
+	target = strings.TrimSpace(target)
+	if target == "" {
+		return target
+	}
+
+	// Use the same role/path resolver as dispatching commands, then convert
+	// the resulting tmux session back to a canonical assignee address.
+	// This keeps "hook show" target parsing aligned with sling/hook behavior.
+	if sessionName, err := resolveRoleToSession(target); err == nil && sessionName != "" {
+		if addr, ok := sessionNameToCanonicalAddress(sessionName, target); ok {
+			return addr
+		}
+	}
+
+	// Fallback for explicit/canonical addresses when resolver couldn't help.
+	if identity, err := session.ParseAddress(target); err == nil {
+		return identity.Address()
+	}
+	return target
+}
+
+// sessionNameToCanonicalAddress maps a tmux session name to a canonical agent
+// assignee address (e.g., "gastown/polecats/toast").
+//
+// targetHint is the original user input and is used to seed a temporary
+// prefix→rig mapping for deterministic parsing in tests or minimal
+// environments where the global session registry is not initialized.
+func sessionNameToCanonicalAddress(sessionName, targetHint string) (string, bool) {
+	if identity, err := session.ParseSessionName(sessionName); err == nil {
+		return identity.Address(), true
+	}
+
+	registry := session.NewPrefixRegistry()
+	for rig, prefix := range session.DefaultRegistry().AllRigs() {
+		registry.Register(prefix, rig)
+	}
+	parts := strings.Split(strings.TrimSpace(targetHint), "/")
+	if len(parts) >= 2 && parts[0] != "" {
+		rig := parts[0]
+		registry.Register(session.PrefixFor(rig), rig)
+	}
+
+	identity, err := session.ParseSessionNameWithRegistry(sessionName, registry)
+	if err != nil {
+		return "", false
+	}
+	return identity.Address(), true
 }
 
 // findTownRoot finds the Gas Town root directory.

--- a/internal/cmd/hook_show_integration_test.go
+++ b/internal/cmd/hook_show_integration_test.go
@@ -1,0 +1,99 @@
+//go:build integration
+
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+type hookShowJSON struct {
+	Agent  string `json:"agent"`
+	BeadID string `json:"bead_id"`
+	Status string `json:"status"`
+}
+
+// TestHookShowShorthandResolvesToCanonical verifies that hook show accepts
+// shorthand polecat targets (rig/name) and resolves them to canonical
+// assignee IDs (rig/polecats/name) before querying hooked work.
+func TestHookShowShorthandResolvesToCanonical(t *testing.T) {
+	if _, err := exec.LookPath("bd"); err != nil {
+		t.Skip("bd not installed, skipping integration test")
+	}
+
+	townRoot, polecatDir, rigPrefix := setupHookTestTown(t)
+	_ = townRoot
+
+	rigDir := filepath.Join(polecatDir, "..", "..", "mayor", "rig")
+	initBeadsDBWithPrefix(t, rigDir, rigPrefix)
+
+	b := beads.New(rigDir)
+	issue, err := b.Create(beads.CreateOptions{
+		Title:    "Hook show target normalization test",
+		Type:     "task",
+		Priority: 2,
+	})
+	if err != nil {
+		t.Fatalf("create issue: %v", err)
+	}
+
+	hooked := beads.StatusHooked
+	assignee := "gastown/polecats/toast"
+	if err := b.Update(issue.ID, beads.UpdateOptions{
+		Status:   &hooked,
+		Assignee: &assignee,
+	}); err != nil {
+		t.Fatalf("hook issue: %v", err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(polecatDir); err != nil {
+		t.Fatalf("chdir to polecat dir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWD)
+	})
+
+	prevJSON := moleculeJSON
+	moleculeJSON = true
+	t.Cleanup(func() {
+		moleculeJSON = prevJSON
+	})
+
+	runShow := func(target string) hookShowJSON {
+		out := captureStdout(t, func() {
+			if err := runHookShow(nil, []string{target}); err != nil {
+				t.Fatalf("runHookShow(%q): %v", target, err)
+			}
+		})
+		var parsed hookShowJSON
+		if err := json.Unmarshal([]byte(out), &parsed); err != nil {
+			t.Fatalf("parse runHookShow(%q) output %q: %v", target, out, err)
+		}
+		return parsed
+	}
+
+	canonical := runShow("gastown/polecats/toast")
+	if canonical.BeadID != issue.ID || canonical.Status != beads.StatusHooked {
+		t.Fatalf("canonical target mismatch: got bead=%q status=%q, want bead=%q status=%q",
+			canonical.BeadID, canonical.Status, issue.ID, beads.StatusHooked)
+	}
+
+	shorthand := runShow("gastown/toast")
+	if shorthand.BeadID != issue.ID || shorthand.Status != beads.StatusHooked {
+		t.Fatalf("shorthand target mismatch: got bead=%q status=%q, want bead=%q status=%q",
+			shorthand.BeadID, shorthand.Status, issue.ID, beads.StatusHooked)
+	}
+	if shorthand.Agent != "gastown/polecats/toast" {
+		t.Fatalf("shorthand target did not normalize: got agent=%q, want %q",
+			shorthand.Agent, "gastown/polecats/toast")
+	}
+}

--- a/internal/cmd/hook_test.go
+++ b/internal/cmd/hook_test.go
@@ -95,3 +95,36 @@ func TestHookPolecatEnvCheck(t *testing.T) {
 		})
 	}
 }
+
+func TestNormalizeHookShowTarget(t *testing.T) {
+	tests := []struct {
+		name   string
+		target string
+		want   string
+	}{
+		{
+			name:   "shorthand polecat path resolves",
+			target: "gastown/toast",
+			want:   "gastown/polecats/toast",
+		},
+		{
+			name:   "canonical polecat path stays canonical",
+			target: "gastown/polecats/toast",
+			want:   "gastown/polecats/toast",
+		},
+		{
+			name:   "unknown target stays unchanged",
+			target: "this-is-not-an-agent-path",
+			want:   "this-is-not-an-agent-path",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := normalizeHookShowTarget(tt.target)
+			if got != tt.want {
+				t.Fatalf("normalizeHookShowTarget(%q) = %q, want %q", tt.target, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2005,17 +2005,14 @@ func (m *Manager) unassignWorkBeads(name string) {
 	}
 }
 
-// loadFromBeads gets polecat info from agent bead hook + beads assignee field + tmux session state.
+// loadFromBeads gets polecat info from hooked work beads + beads assignee field + tmux session state.
 // State derivation priority:
-//  1. Agent bead hook_bead set → working (authoritative source for current assignment)
-//  2. Issue assigned via beads assignee → working
-//  3. Tmux session alive → working (session active even if assignment not yet recorded)
-//  4. None of the above → done (ready for cleanup)
-//
-// The hook_bead check (1) is critical for polecat name recycling: when a polecat name
-// is reused across rounds, GetAssignedIssue may return a stale issue from the previous
-// round whose assignee was never cleared. The hook_bead is set atomically at spawn/sling
-// time and is always current. (gt-ckk12)
+//  1. Work bead status=hooked + assignee=<polecat> → working (authoritative source)
+//  2. Legacy agent hook_bead that still points to a currently hooked bead for this assignee
+//     → working (compatibility fallback during migration)
+//  3. Issue assigned via beads assignee (open/in_progress/hooked) → working
+//  4. Tmux session alive → working (session active even if assignment not yet recorded)
+//  5. None of the above → idle
 func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 	// Use clonePath which handles both new (polecats/<name>/<rigname>/)
 	// and old (polecats/<name>/) structures
@@ -2029,22 +2026,43 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 		branchName = fmt.Sprintf("polecat/%s", name)
 	}
 
-	// Check agent bead's hook_bead field first — this is the authoritative source
-	// for what work is currently assigned to this polecat. The hook_bead is set
-	// atomically at spawn/sling time, so it's always current even after polecat
-	// name recycling. GetAssignedIssue queries by assignee which can return stale
-	// data from previous rounds. (gt-ckk12)
-	agentID := m.agentBeadID(name)
-	_, fields, agentErr := m.beads.GetAgentBead(agentID)
-	if agentErr == nil && fields != nil && fields.HookBead != "" {
+	assignee := m.assigneeID(name)
+
+	// Primary source: the work bead itself (status=hooked + assignee).
+	// This is the direct-tracking model introduced in hq-l6mm5.
+	hookedBeads, hookedErr := m.beads.List(beads.ListOptions{
+		Status:   beads.StatusHooked,
+		Assignee: assignee,
+		Priority: -1,
+	})
+	if hookedErr == nil && len(hookedBeads) > 0 {
 		return &Polecat{
 			Name:      name,
 			Rig:       m.rig.Name,
 			State:     StateWorking,
 			ClonePath: clonePath,
 			Branch:    branchName,
-			Issue:     fields.HookBead,
+			Issue:     hookedBeads[0].ID,
 		}, nil
+	}
+
+	// Compatibility fallback: if legacy hook_bead is still set, only trust it when
+	// it resolves to a currently hooked bead for this assignee. This avoids stale
+	// issue reporting when hook_bead diverges from the work bead state.
+	agentID := m.agentBeadID(name)
+	_, fields, agentErr := m.beads.GetAgentBead(agentID)
+	if agentErr == nil && fields != nil && fields.HookBead != "" {
+		if hookIssue, err := m.beads.Show(fields.HookBead); err == nil &&
+			isCurrentHookedIssueForAssignee(hookIssue, assignee) {
+			return &Polecat{
+				Name:      name,
+				Rig:       m.rig.Name,
+				State:     StateWorking,
+				ClonePath: clonePath,
+				Branch:    branchName,
+				Issue:     fields.HookBead,
+			}, nil
+		}
 	}
 
 	// Persistent polecat model (gt-4ac): check agent_state for idle detection.
@@ -2061,7 +2079,6 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 
 	// Fallback: Query beads for assigned issue (for polecats without agent beads
 	// or with empty hook_bead)
-	assignee := m.assigneeID(name)
 	issue, beadsErr := m.beads.GetAssignedIssue(assignee)
 	if beadsErr != nil {
 		// If beads query fails, return basic polecat info as working
@@ -2100,6 +2117,12 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 		Branch:    branchName,
 		Issue:     issueID,
 	}, nil
+}
+
+func isCurrentHookedIssueForAssignee(issue *beads.Issue, assignee string) bool {
+	return issue != nil &&
+		issue.Status == beads.StatusHooked &&
+		issue.Assignee == assignee
 }
 
 // setupSharedBeads creates a redirect file so the polecat uses the rig's shared .beads database.

--- a/internal/polecat/manager_integration_test.go
+++ b/internal/polecat/manager_integration_test.go
@@ -1,0 +1,133 @@
+//go:build integration
+
+package polecat
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/rig"
+	"github.com/steveyegge/gastown/internal/testutil"
+)
+
+var polecatManagerIntegrationCounter atomic.Int32
+
+func initBeadsDBWithPrefix(t *testing.T, dir, prefix string) {
+	t.Helper()
+	testutil.RequireDoltContainer(t)
+
+	args := []string{"init", "--quiet", "--prefix", prefix, "--server-port", testutil.DoltContainerPort()}
+	cmd := exec.Command("bd", args...)
+	cmd.Dir = dir
+	if output, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("bd init failed in %s: %v\n%s", dir, err, output)
+	}
+
+	issuesPath := filepath.Join(dir, ".beads", "issues.jsonl")
+	if err := os.WriteFile(issuesPath, []byte(""), 0644); err != nil {
+		t.Fatalf("create issues.jsonl in %s: %v", dir, err)
+	}
+}
+
+// TestManagerGetPrefersHookedBeadOverStaleAgentHook verifies that manager.Get
+// reports the current hooked work bead when agent hook_bead is stale.
+func TestManagerGetPrefersHookedBeadOverStaleAgentHook(t *testing.T) {
+	if _, err := exec.LookPath("bd"); err != nil {
+		t.Skip("bd not installed, skipping integration test")
+	}
+	testutil.RequireDoltContainer(t)
+
+	n := polecatManagerIntegrationCounter.Add(1)
+	prefix := fmt.Sprintf("pm%d", n)
+
+	townRoot := t.TempDir()
+	rigName := "testrig"
+	rigPath := filepath.Join(townRoot, rigName)
+	mayorRigPath := filepath.Join(rigPath, "mayor", "rig")
+
+	if err := os.MkdirAll(mayorRigPath, 0755); err != nil {
+		t.Fatalf("mkdir mayor rig path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigPath, "polecats", "toast"), 0755); err != nil {
+		t.Fatalf("mkdir polecat dir: %v", err)
+	}
+
+	// Rig .beads redirects to mayor/rig/.beads so NewManager resolves correctly.
+	rigBeadsDir := filepath.Join(rigPath, ".beads")
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir rig .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigBeadsDir, "redirect"), []byte("mayor/rig/.beads\n"), 0644); err != nil {
+		t.Fatalf("write rig redirect: %v", err)
+	}
+
+	// Town routing with unique prefix for this test DB.
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir town .beads: %v", err)
+	}
+	routes := []beads.Route{
+		{Prefix: "hq-", Path: "."},
+		{Prefix: prefix + "-", Path: filepath.Join(rigName, "mayor", "rig")},
+	}
+	if err := beads.WriteRoutes(townBeadsDir, routes); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	initBeadsDBWithPrefix(t, mayorRigPath, prefix)
+
+	r := &rig.Rig{Name: rigName, Path: rigPath}
+	mgr := NewManager(r, git.NewGit(rigPath), nil)
+
+	stale, err := mgr.beads.Create(beads.CreateOptions{
+		Title:    "stale old issue",
+		Type:     "task",
+		Priority: 2,
+	})
+	if err != nil {
+		t.Fatalf("create stale issue: %v", err)
+	}
+	current, err := mgr.beads.Create(beads.CreateOptions{
+		Title:    "current hooked issue",
+		Type:     "task",
+		Priority: 2,
+	})
+	if err != nil {
+		t.Fatalf("create current issue: %v", err)
+	}
+
+	assignee := mgr.assigneeID("toast")
+	hooked := beads.StatusHooked
+	if err := mgr.beads.Update(current.ID, beads.UpdateOptions{
+		Status:   &hooked,
+		Assignee: &assignee,
+	}); err != nil {
+		t.Fatalf("hook current issue: %v", err)
+	}
+
+	agentID := mgr.agentBeadID("toast")
+	if _, err := mgr.beads.CreateOrReopenAgentBead(agentID, assignee, &beads.AgentFields{
+		HookBead:   stale.ID,
+		AgentState: string(beads.AgentStateWorking),
+	}); err != nil {
+		t.Fatalf("create agent bead with stale hook: %v", err)
+	}
+
+	p, err := mgr.Get("toast")
+	if err != nil {
+		t.Fatalf("mgr.Get(toast): %v", err)
+	}
+
+	if p.State != StateWorking {
+		t.Fatalf("polecat state = %q, want %q", p.State, StateWorking)
+	}
+	if p.Issue != current.ID {
+		t.Fatalf("polecat issue = %q, want hooked issue %q (stale hook %q)", p.Issue, current.ID, stale.ID)
+	}
+}

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -714,6 +714,53 @@ func TestIsDoltOptimisticLockError(t *testing.T) {
 	}
 }
 
+func TestIsCurrentHookedIssueForAssignee(t *testing.T) {
+	assignee := "testrig/polecats/toast"
+
+	tests := []struct {
+		name  string
+		issue *beads.Issue
+		want  bool
+	}{
+		{
+			name: "nil issue",
+			want: false,
+		},
+		{
+			name: "hooked and matching assignee",
+			issue: &beads.Issue{
+				Status:   beads.StatusHooked,
+				Assignee: assignee,
+			},
+			want: true,
+		},
+		{
+			name: "hooked but different assignee",
+			issue: &beads.Issue{
+				Status:   beads.StatusHooked,
+				Assignee: "testrig/polecats/nux",
+			},
+			want: false,
+		},
+		{
+			name: "matching assignee but open status",
+			issue: &beads.Issue{
+				Status:   "open",
+				Assignee: assignee,
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isCurrentHookedIssueForAssignee(tt.issue, assignee); got != tt.want {
+				t.Fatalf("isCurrentHookedIssueForAssignee() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestBuildBranchName(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Summary
This PR fixes two related state/reporting bugs around hook visibility and polecat assignment state:

- `gt hook show` now normalizes shorthand/alias targets to canonical assignee IDs before querying hooked work.
- Polecat manager state now prefers direct hooked-bead tracking (`status=hooked` + `assignee`) and only trusts legacy `hook_bead` when it still points to a currently hooked issue for that assignee.

## Changes
- `internal/cmd/hook.go`
  - Added hook-show target normalization path that resolves aliases/shorthand and converts to canonical addresses.
  - Added robust session-to-address conversion with fallback registry seeding for deterministic parsing in minimal/test environments.
- `internal/polecat/manager.go`
  - Changed `loadFromBeads` priority to:
    1. hooked beads by assignee (primary)
    2. legacy `hook_bead` only when it is still current-hooked for assignee
    3. assigned issue fallback
  - Added helper `isCurrentHookedIssueForAssignee`.
- Tests
  - Added/updated unit tests in:
    - `internal/cmd/hook_test.go`
    - `internal/polecat/manager_test.go`
  - Added integration tests:
    - `internal/cmd/hook_show_integration_test.go`
    - `internal/polecat/manager_integration_test.go`

## Verification
Ran locally:

- `go test ./internal/cmd ./internal/polecat -count=1`
- `go test -tags=integration ./internal/cmd -run TestHookShowShorthandResolvesToCanonical -count=1 -v`
- `go test -tags=integration ./internal/polecat -run TestManagerGetPrefersHookedBeadOverStaleAgentHook -count=1 -v`

All passed.

Closes #2371

