### PR TITLE
fix(polecat): reconcile gt polecat list JSON state with session liveness

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -389,6 +389,20 @@ type PolecatListItem struct {
 	SessionName    string        `json:"session_name,omitempty"`
 }
 
+// effectivePolecatState returns the observable state used by polecat list output.
+// Session liveness is ground truth for working/done transitions. Zombie entries
+// are never auto-rewritten.
+func effectivePolecatState(item PolecatListItem) polecat.State {
+	state := item.State
+	if item.SessionRunning && state == polecat.StateDone {
+		return polecat.StateWorking
+	}
+	if !item.SessionRunning && !item.Zombie && state == polecat.StateWorking {
+		return polecat.StateDone
+	}
+	return state
+}
+
 // getPolecatManager creates a polecat manager for the given rig.
 func getPolecatManager(rigName string) (*polecat.Manager, *rig.Rig, error) {
 	_, r, err := getRig(rigName)
@@ -477,6 +491,10 @@ func runPolecatList(cmd *cobra.Command, args []string) error {
 	}
 
 	// Output
+	for i := range allPolecats {
+		allPolecats[i].State = effectivePolecatState(allPolecats[i])
+	}
+
 	if polecatListJSON {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
@@ -496,20 +514,9 @@ func runPolecatList(cmd *cobra.Command, args []string) error {
 			sessionStatus = style.Success.Render("●")
 		}
 
-		// Display actual state, reconciled with tmux session liveness.
-		// Per gt-zecmc design: tmux is ground truth for observable states.
-		// If session is running but beads says done, the polecat is still alive.
-		// If session is dead but beads says working, the polecat is actually done.
-		displayState := p.State
-		if p.SessionRunning && displayState == polecat.StateDone {
-			displayState = polecat.StateWorking
-		} else if !p.SessionRunning && !p.Zombie && displayState == polecat.StateWorking {
-			displayState = polecat.StateDone
-		}
-
 		// State color
-		stateStr := string(displayState)
-		switch displayState {
+		stateStr := string(p.State)
+		switch p.State {
 		case polecat.StateWorking:
 			stateStr = style.Info.Render(stateStr)
 		case polecat.StateStuck:

--- a/internal/cmd/polecat_list_state_test.go
+++ b/internal/cmd/polecat_list_state_test.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/polecat"
+)
+
+func TestEffectivePolecatState(t *testing.T) {
+	tests := []struct {
+		name string
+		item PolecatListItem
+		want polecat.State
+	}{
+		{
+			name: "session-running-done-becomes-working",
+			item: PolecatListItem{
+				State:          polecat.StateDone,
+				SessionRunning: true,
+			},
+			want: polecat.StateWorking,
+		},
+		{
+			name: "session-dead-working-becomes-done",
+			item: PolecatListItem{
+				State:          polecat.StateWorking,
+				SessionRunning: false,
+			},
+			want: polecat.StateDone,
+		},
+		{
+			name: "zombie-is-never-rewritten",
+			item: PolecatListItem{
+				State:          polecat.StateZombie,
+				SessionRunning: false,
+				Zombie:         true,
+			},
+			want: polecat.StateZombie,
+		},
+		{
+			name: "idle-unchanged",
+			item: PolecatListItem{
+				State:          polecat.StateIdle,
+				SessionRunning: false,
+			},
+			want: polecat.StateIdle,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := effectivePolecatState(tt.item)
+			if got != tt.want {
+				t.Fatalf("effectivePolecatState() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+


### PR DESCRIPTION
## Summary
Fix `gt polecat list` output parity so `--json` returns the same effective observable state as plain output.

Previously, plain output reconciled `state` using tmux session liveness, but JSON emitted raw unreconciled state. This caused cases like `state=working` with `session_running=false` in JSON while plain output showed `done`.

## Changes
- `internal/cmd/polecat.go`
  - Added `effectivePolecatState(...)` helper.
  - Applied reconciliation before both JSON and human rendering.
  - Removed duplicate inline reconciliation logic from human-only output path.
- `internal/cmd/polecat_list_state_test.go`
  - Added unit tests for:
    - done -> working when session is running
    - working -> done when session is not running (non-zombie)
    - zombie unchanged
    - idle unchanged

## Verification
- `go test ./internal/cmd -run TestEffectivePolecatState -count=1`
- `go test ./internal/cmd ./internal/polecat -count=1`
- `make build`
- Runtime check against town data using built binary:
  - `gt polecat list --all`
  - `gt polecat list --all --json`
  - Verified state parity between plain and JSON outputs.

Closes #2378
