### PR TITLE
fix: make gt done tolerate Gas Town runtime artifacts in worktrees

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -363,12 +363,16 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			return fmt.Errorf("cannot complete: working directory not available (worktree deleted?)\nUse --status DEFERRED to exit without completing")
 		}
 
-		// Block if there are uncommitted changes (would be lost on completion)
+		// Block if there are uncommitted changes (would be lost on completion).
+		// Runtime artifacts (.claude/, .beads/, .runtime/, __pycache__/) are
+		// excluded — these are toolchain-managed and normally gitignored.
+		// Without this filter, gt done fails on virtually every polecat because
+		// Cursor creates .claude/ at runtime in every workspace.
 		workStatus, err := g.CheckUncommittedWork()
 		if err != nil {
 			return fmt.Errorf("checking git status: %w", err)
 		}
-		if workStatus.HasUncommittedChanges {
+		if workStatus.HasUncommittedChanges && !workStatus.CleanExcludingRuntime() {
 			return fmt.Errorf("cannot complete: uncommitted changes would be lost\nCommit your changes first, or use --status DEFERRED to exit without completing\nUncommitted: %s", workStatus.String())
 		}
 

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1374,6 +1374,55 @@ func isBeadsPath(path string) bool {
 	return strings.Contains(path, ".beads/") || strings.Contains(path, ".beads\\")
 }
 
+// isGasTownRuntimePath returns true if the path is a Gas Town or Cursor runtime
+// artifact that should not block gt done. These paths are managed by the toolchain,
+// not by the developer, and are normally gitignored via EnsureGitignorePatterns.
+func isGasTownRuntimePath(path string) bool {
+	prefixes := []string{
+		".beads/", ".beads\\",
+		".claude/", ".claude\\",
+		".runtime/", ".runtime\\",
+		".logs/", ".logs\\",
+		"__pycache__/", "__pycache__\\",
+	}
+	for _, prefix := range prefixes {
+		if strings.HasPrefix(path, prefix) || strings.Contains(path, "/"+prefix) {
+			return true
+		}
+	}
+	// Also match bare directory entries from git status (e.g. ".claude/")
+	bare := strings.TrimSuffix(strings.TrimSuffix(path, "/"), "\\")
+	for _, name := range []string{".beads", ".claude", ".runtime", ".logs", "__pycache__"} {
+		if bare == name {
+			return true
+		}
+	}
+	return false
+}
+
+// CleanExcludingRuntime returns true if the only uncommitted changes are Gas Town
+// runtime artifacts (.beads/, .claude/, .runtime/, .logs/, __pycache__/).
+// Used by gt done to avoid blocking completion on toolchain-managed files.
+func (s *UncommittedWorkStatus) CleanExcludingRuntime() bool {
+	if s.StashCount > 0 || s.UnpushedCommits > 0 {
+		return false
+	}
+
+	for _, f := range s.ModifiedFiles {
+		if !isGasTownRuntimePath(f) {
+			return false
+		}
+	}
+
+	for _, f := range s.UntrackedFiles {
+		if !isGasTownRuntimePath(f) {
+			return false
+		}
+	}
+
+	return true
+}
+
 // String returns a human-readable summary of uncommitted work.
 func (s *UncommittedWorkStatus) String() string {
 	var issues []string

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1587,3 +1587,107 @@ func TestClearPushURL(t *testing.T) {
 		t.Errorf("ClearPushURL (idempotent) should not error, got: %v", err)
 	}
 }
+
+func TestIsGasTownRuntimePath(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{".claude/", true},
+		{".claude/settings.json", true},
+		{".claude/commands/foo.md", true},
+		{".claude", true},
+		{".runtime/", true},
+		{".runtime/state.json", true},
+		{".runtime", true},
+		{".beads/", true},
+		{".beads/db.json", true},
+		{".logs/agent.log", true},
+		{"__pycache__/", true},
+		{"__pycache__/foo.cpython-312.pyc", true},
+		{"src/__pycache__/bar.pyc", true},
+		{"src/main.go", false},
+		{"README.md", false},
+		{".gitignore", false},
+		{"claude-stuff/foo", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			got := isGasTownRuntimePath(tt.path)
+			if got != tt.want {
+				t.Errorf("isGasTownRuntimePath(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCleanExcludingRuntime(t *testing.T) {
+	tests := []struct {
+		name string
+		s    UncommittedWorkStatus
+		want bool
+	}{
+		{
+			name: "only runtime artifacts",
+			s: UncommittedWorkStatus{
+				HasUncommittedChanges: true,
+				UntrackedFiles:        []string{".claude/", ".runtime/state.json"},
+			},
+			want: true,
+		},
+		{
+			name: "real code changes",
+			s: UncommittedWorkStatus{
+				HasUncommittedChanges: true,
+				ModifiedFiles:         []string{"src/main.go"},
+			},
+			want: false,
+		},
+		{
+			name: "mix of runtime and real",
+			s: UncommittedWorkStatus{
+				HasUncommittedChanges: true,
+				UntrackedFiles:        []string{".claude/settings.json"},
+				ModifiedFiles:         []string{"src/main.go"},
+			},
+			want: false,
+		},
+		{
+			name: "clean",
+			s:    UncommittedWorkStatus{},
+			want: true,
+		},
+		{
+			name: "stashes block",
+			s: UncommittedWorkStatus{
+				StashCount: 1,
+			},
+			want: false,
+		},
+		{
+			name: "unpushed commits block",
+			s: UncommittedWorkStatus{
+				UnpushedCommits: 2,
+			},
+			want: false,
+		},
+		{
+			name: "pycache untracked",
+			s: UncommittedWorkStatus{
+				HasUncommittedChanges: true,
+				UntrackedFiles:        []string{"__pycache__/foo.pyc", ".beads/db"},
+			},
+			want: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := tt.s.CleanExcludingRuntime()
+			if got != tt.want {
+				t.Errorf("CleanExcludingRuntime() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `isGasTownRuntimePath()` helper that recognizes `.beads/`, `.claude/`, `.runtime/`, `.logs/`, `__pycache__/` paths (including nested, e.g. `src/__pycache__/`)
- Adds `CleanExcludingRuntime()` method on `UncommittedWorkStatus` — mirrors the existing `CleanExcludingBeads()` but covers all runtime artifacts
- Changes `gt done` to use `CleanExcludingRuntime()` so it no longer blocks on toolchain-managed files

## Problem

Even with proper `.gitignore` patterns (#2381), worktrees created *before* the fix still have untracked `.claude/` directories. `gt done` sees these as uncommitted changes and refuses to complete, stranding polecat work. This is the tolerance layer that handles existing worktrees.

## Design

Follows the same pattern as the existing `isBeadsPath` / `CleanExcludingBeads`:

```
HasUncommittedChanges  →  true  (raw git status sees .claude/)
CleanExcludingRuntime  →  true  (all dirty files are runtime artifacts)
                       →  gt done proceeds
```

If there are *real* code changes mixed in, `CleanExcludingRuntime()` returns false and the existing error path fires.

## Test plan

- [x] `TestIsGasTownRuntimePath` — 18 cases covering all artifact types, nested paths, bare entries, and negative cases
- [x] `TestCleanExcludingRuntime` — 7 cases: runtime-only, real changes, mixed, clean, stashes, unpushed commits, pycache
- [x] `go build ./...` clean

Fixes #2380 (part 2 of 2, companion to #2381)

Made with [Cursor](https://cursor.com)