### PR TITLE
feat: add schema evolution support to gt wl sync

### DIFF
--- a/internal/cmd/wl_schema_evolution.go
+++ b/internal/cmd/wl_schema_evolution.go
@@ -1,0 +1,136 @@
+package cmd
+
+import (
+	"fmt"
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// SchemaChangeKind describes the type of schema change between two semver strings.
+type SchemaChangeKind int
+
+const (
+	// SchemaUnchanged means local and upstream versions are identical or local is ahead.
+	SchemaUnchanged SchemaChangeKind = iota
+	// SchemaMinorChange means upstream added columns or tables (backwards-compatible).
+	SchemaMinorChange
+	// SchemaMajorChange means upstream made breaking changes that require explicit upgrade.
+	SchemaMajorChange
+)
+
+// ParseSchemaVersion parses a "MAJOR.MINOR" version string into its components.
+func ParseSchemaVersion(s string) (major, minor int, err error) {
+	parts := strings.SplitN(strings.TrimSpace(s), ".", 2)
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("invalid schema version %q: expected MAJOR.MINOR", s)
+	}
+	major, err = strconv.Atoi(parts[0])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid major version in %q: %w", s, err)
+	}
+	minor, err = strconv.Atoi(parts[1])
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid minor version in %q: %w", s, err)
+	}
+	return major, minor, nil
+}
+
+// ClassifySchemaChange compares local and upstream version strings and returns
+// the kind of change. Downgrades (upstream older than local) return SchemaUnchanged.
+func ClassifySchemaChange(local, upstream string) (SchemaChangeKind, error) {
+	localMajor, localMinor, err := ParseSchemaVersion(local)
+	if err != nil {
+		return SchemaUnchanged, fmt.Errorf("local version: %w", err)
+	}
+	upMajor, upMinor, err := ParseSchemaVersion(upstream)
+	if err != nil {
+		return SchemaUnchanged, fmt.Errorf("upstream version: %w", err)
+	}
+
+	switch {
+	case upMajor > localMajor:
+		return SchemaMajorChange, nil
+	case upMajor == localMajor && upMinor > localMinor:
+		return SchemaMinorChange, nil
+	default:
+		return SchemaUnchanged, nil
+	}
+}
+
+// readDoltSchemaVersion reads schema_version from the _meta table of a local
+// dolt fork. asOf specifies the branch/ref (e.g. "HEAD" or "upstream/main").
+// Returns ("", nil) when the _meta table or schema_version row does not exist.
+func readDoltSchemaVersion(doltPath, forkDir, asOf string) (string, error) {
+	var query string
+	if asOf == "" || asOf == "HEAD" {
+		query = "SELECT value FROM _meta WHERE `key` = 'schema_version';"
+	} else {
+		query = fmt.Sprintf(
+			"SELECT value FROM _meta AS OF '%s' WHERE `key` = 'schema_version';",
+			asOf,
+		)
+	}
+
+	cmd := exec.Command(doltPath, "sql", "-r", "csv", "-q", query)
+	cmd.Dir = forkDir
+	out, err := cmd.Output()
+	if err != nil {
+		// _meta may not exist on older forks — treat as unknown, not fatal.
+		return "", nil
+	}
+
+	// Output format: "value\n<version>\n"
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		return "", nil
+	}
+	version := strings.TrimSpace(lines[1])
+	return version, nil
+}
+
+// checkSchemaEvolution fetches upstream version metadata and classifies any
+// schema change. It prints an informational line for MINOR bumps. For MAJOR
+// bumps it returns a descriptive error unless upgrade is true.
+//
+// Precondition: caller has already run `dolt fetch upstream` so that
+// upstream/main is available for AS OF queries.
+//
+// Returns (false, nil) when the fork lacks a _meta table or schema_version row
+// (pre-versioned fork) — the pull proceeds without interruption.
+func checkSchemaEvolution(doltPath, forkDir string, upgrade bool) error {
+	localVer, err := readDoltSchemaVersion(doltPath, forkDir, "HEAD")
+	if err != nil || localVer == "" {
+		return nil // pre-versioned fork — skip check
+	}
+
+	upstreamVer, err := readDoltSchemaVersion(doltPath, forkDir, "upstream/main")
+	if err != nil || upstreamVer == "" {
+		return nil // upstream has no version info — skip check
+	}
+
+	kind, err := ClassifySchemaChange(localVer, upstreamVer)
+	if err != nil {
+		return fmt.Errorf("schema version check: %w", err)
+	}
+
+	switch kind {
+	case SchemaUnchanged:
+		// nothing to report
+	case SchemaMinorChange:
+		fmt.Printf("  Schema: %s → %s (MINOR — auto-applying)\n", localVer, upstreamVer)
+	case SchemaMajorChange:
+		if !upgrade {
+			return fmt.Errorf(
+				"upstream schema version %s is a MAJOR upgrade from your local %s\n\n"+
+					"This may require manual data migration. To proceed:\n\n"+
+					"  gt wl sync --upgrade\n\n"+
+					"Review the upstream CHANGELOG before upgrading.",
+				upstreamVer, localVer,
+			)
+		}
+		fmt.Printf("  Schema: %s → %s (MAJOR — upgrading as requested)\n", localVer, upstreamVer)
+	}
+
+	return nil
+}

--- a/internal/cmd/wl_schema_evolution_test.go
+++ b/internal/cmd/wl_schema_evolution_test.go
@@ -1,0 +1,96 @@
+package cmd
+
+import (
+	"testing"
+)
+
+func TestParseSchemaVersion_Valid(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		input      string
+		wantMajor  int
+		wantMinor  int
+	}{
+		{"1.0", 1, 0},
+		{"2.3", 2, 3},
+		{"0.0", 0, 0},
+		{"10.42", 10, 42},
+		{" 1.0 ", 1, 0}, // leading/trailing space
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			t.Parallel()
+			major, minor, err := ParseSchemaVersion(tt.input)
+			if err != nil {
+				t.Fatalf("ParseSchemaVersion(%q) unexpected error: %v", tt.input, err)
+			}
+			if major != tt.wantMajor || minor != tt.wantMinor {
+				t.Errorf("ParseSchemaVersion(%q) = (%d, %d), want (%d, %d)",
+					tt.input, major, minor, tt.wantMajor, tt.wantMinor)
+			}
+		})
+	}
+}
+
+func TestParseSchemaVersion_Invalid(t *testing.T) {
+	t.Parallel()
+	cases := []string{"1", "1.0.0", "", "abc", "1.x", "x.0"}
+	for _, input := range cases {
+		t.Run(input, func(t *testing.T) {
+			t.Parallel()
+			_, _, err := ParseSchemaVersion(input)
+			if err == nil {
+				t.Errorf("ParseSchemaVersion(%q) expected error, got nil", input)
+			}
+		})
+	}
+}
+
+func TestClassifySchemaChange(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		local    string
+		upstream string
+		want     SchemaChangeKind
+	}{
+		// Unchanged
+		{"1.0", "1.0", SchemaUnchanged},
+		{"2.5", "2.5", SchemaUnchanged},
+		// Minor bump
+		{"1.0", "1.1", SchemaMinorChange},
+		{"1.0", "1.9", SchemaMinorChange},
+		{"2.0", "2.1", SchemaMinorChange},
+		// Major bump
+		{"1.0", "2.0", SchemaMajorChange},
+		{"1.5", "2.0", SchemaMajorChange},
+		{"1.9", "3.0", SchemaMajorChange},
+		// Downgrade (local newer) — treated as unchanged
+		{"1.1", "1.0", SchemaUnchanged},
+		{"2.0", "1.9", SchemaUnchanged},
+	}
+	for _, tt := range tests {
+		t.Run(tt.local+"->"+tt.upstream, func(t *testing.T) {
+			t.Parallel()
+			got, err := ClassifySchemaChange(tt.local, tt.upstream)
+			if err != nil {
+				t.Fatalf("ClassifySchemaChange(%q, %q) unexpected error: %v", tt.local, tt.upstream, err)
+			}
+			if got != tt.want {
+				t.Errorf("ClassifySchemaChange(%q, %q) = %v, want %v",
+					tt.local, tt.upstream, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestClassifySchemaChange_InvalidVersion(t *testing.T) {
+	t.Parallel()
+	_, err := ClassifySchemaChange("bad", "1.0")
+	if err == nil {
+		t.Error("expected error for invalid local version")
+	}
+	_, err = ClassifySchemaChange("1.0", "bad")
+	if err == nil {
+		t.Error("expected error for invalid upstream version")
+	}
+}

--- a/internal/cmd/wl_sync.go
+++ b/internal/cmd/wl_sync.go
@@ -13,6 +13,7 @@ import (
 )
 
 var wlSyncDryRun bool
+var wlSyncUpgrade bool
 
 var wlSyncCmd = &cobra.Command{
 	Use:   "sync",
@@ -24,13 +25,19 @@ var wlSyncCmd = &cobra.Command{
 If you have a local fork of wl-commons (created by gt wl join), this pulls
 the latest changes from upstream.
 
+Schema evolution is handled automatically based on semantic versioning:
+  - MINOR version bump (e.g. 1.0 → 1.1): auto-applied (new columns, tables)
+  - MAJOR version bump (e.g. 1.0 → 2.0): requires --upgrade flag
+
 EXAMPLES:
   gt wl sync                # Pull upstream changes
-  gt wl sync --dry-run      # Show what would change`,
+  gt wl sync --dry-run      # Show what would change
+  gt wl sync --upgrade      # Proceed through a MAJOR schema version bump`,
 }
 
 func init() {
 	wlSyncCmd.Flags().BoolVar(&wlSyncDryRun, "dry-run", false, "Show what would change without pulling")
+	wlSyncCmd.Flags().BoolVar(&wlSyncUpgrade, "upgrade", false, "Allow MAJOR schema version upgrades")
 
 	wlCmd.AddCommand(wlSyncCmd)
 }
@@ -73,6 +80,10 @@ func runWLSync(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("fetching upstream: %w", err)
 		}
 
+		if err := checkSchemaEvolution(doltPath, forkDir, wlSyncUpgrade); err != nil {
+			return err
+		}
+
 		diffCmd := exec.Command(doltPath, "diff", "--stat", "HEAD", "upstream/main")
 		diffCmd.Dir = forkDir
 		diffCmd.Stdout = os.Stdout
@@ -83,14 +94,27 @@ func runWLSync(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	fmt.Printf("\nPulling from upstream...\n")
+	fmt.Printf("\nFetching from upstream...\n")
 
-	pullCmd := exec.Command(doltPath, "pull", "upstream", "main")
+	fetchCmd := exec.Command(doltPath, "fetch", "upstream")
+	fetchCmd.Dir = forkDir
+	fetchCmd.Stderr = os.Stderr
+	if err := fetchCmd.Run(); err != nil {
+		return fmt.Errorf("fetching upstream: %w", err)
+	}
+
+	if err := checkSchemaEvolution(doltPath, forkDir, wlSyncUpgrade); err != nil {
+		return err
+	}
+
+	fmt.Printf("Merging upstream changes...\n")
+
+	pullCmd := exec.Command(doltPath, "merge", "upstream/main")
 	pullCmd.Dir = forkDir
 	pullCmd.Stdout = os.Stdout
 	pullCmd.Stderr = os.Stderr
 	if err := pullCmd.Run(); err != nil {
-		return fmt.Errorf("pulling from upstream: %w", err)
+		return fmt.Errorf("merging upstream: %w", err)
 	}
 
 	fmt.Printf("\n%s Synced with upstream\n", style.Bold.Render("✓"))


### PR DESCRIPTION
## Summary

- Parse `MAJOR.MINOR` schema versions from the wl-commons `_meta` table after `dolt fetch`
- MINOR bumps (e.g. `1.0 → 1.1`) auto-proceed with an informational message
- MAJOR bumps (e.g. `1.0 → 2.0`) return an actionable error unless `--upgrade` is passed
- Split `dolt pull` into `dolt fetch` + schema check + `dolt merge` so the version check runs between fetch and merge (upstream/main available via `AS OF` query)
- Add `--upgrade` flag to `gt wl sync`

## Files changed

- `internal/cmd/wl_schema_evolution.go` — `ParseSchemaVersion`, `ClassifySchemaChange`, `readDoltSchemaVersion`, `checkSchemaEvolution`
- `internal/cmd/wl_schema_evolution_test.go` — unit tests for parsing and classification
- `internal/cmd/wl_sync.go` — `--upgrade` flag; fetch/check/merge split

## Test plan

- [x] `go test ./internal/cmd/ -run "TestParseSchemaVersion|TestClassifySchemaChange"` — all pass
- [x] `go build ./...` — clean
- [x] Existing `TestFindWLCommonsFork_*` tests unaffected

Closes gp-c7e (Wasteland w-wl-004)