### PR TITLE
Fix rig .gitignore to ignore Gas Town working directories

### DIFF
--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -1627,13 +1627,31 @@ See docs/deacon-plugins.md for full documentation.
 		return fmt.Errorf("creating rig plugins directory: %w", err)
 	}
 
-	// Add plugins/, .repo.git/, and .land-worktree/ to rig .gitignore
+	// Add Gas Town directories to rig .gitignore so they don't pollute the project repo.
 	gitignorePath := filepath.Join(rigPath, ".gitignore")
-	if err := m.ensureGitignoreEntry(gitignorePath, "plugins/"); err != nil {
-		return err
+	gitignoreEntries := []string{
+		"plugins/",
+		".repo.git/",
+		".land-worktree/",
+		"config.json",
+		"crew/",
+		"mayor/",
+		"polecats/",
+		"refinery/",
+		"witness/",
+		"settings/",
+		".runtime/",
+		"**/state.json",
+		"**/*.lock",
+		"**/*.flock",
+		"**/locks/",
+		"**/audit.log",
+		"**/.gt-types-configured",
 	}
-	if err := m.ensureGitignoreEntry(gitignorePath, ".repo.git/"); err != nil {
-		return err
+	for _, entry := range gitignoreEntries {
+		if err := m.ensureGitignoreEntry(gitignorePath, entry); err != nil {
+			return err
+		}
 	}
-	return m.ensureGitignoreEntry(gitignorePath, ".land-worktree/")
+	return nil
 }


### PR DESCRIPTION
## Summary

- `gt rig add` only added `plugins/`, `.repo.git/`, and `.land-worktree/` to the rig's `.gitignore`
- This left `crew/`, `mayor/`, `refinery/`, `polecats/`, `witness/`, runtime state, lock files, and `config.json` unignored
- Running `git add .` in a rig directory accidentally stages Gas Town infrastructure into the project repo

## Fix

Adds all Gas Town working directories and runtime state patterns to the gitignore entries written by `ensurePlugins()` in `internal/rig/manager.go`.

## Test plan

- [x] `go test ./internal/rig/ -run Gitignore` — all pass
- [x] `go test ./...` — full suite passes
- [x] Verified manually: `gt rig add` with updated binary produces a complete `.gitignore`

🤖 Generated with [Claude Code](https://claude.com/claude-code)