### PR TITLE
feat(convoy): add --base-branch support to convoy create

### DIFF
--- a/internal/beads/fields.go
+++ b/internal/beads/fields.go
@@ -228,6 +228,7 @@ type ConvoyFields struct {
 	Notify     string // Additional notification address
 	Molecule   string // Associated molecule/swarm ID
 	Merge      string // Merge strategy
+	BaseBranch string // Target branch for polecats (e.g., "feat/extraction-review")
 }
 
 // ParseConvoyFields extracts convoy fields from an issue's description.
@@ -269,6 +270,9 @@ func ParseConvoyFields(issue *Issue) *ConvoyFields {
 			hasFields = true
 		case "merge":
 			fields.Merge = value
+			hasFields = true
+		case "base_branch", "base-branch", "basebranch":
+			fields.BaseBranch = value
 			hasFields = true
 		}
 	}
@@ -315,6 +319,9 @@ func FormatConvoyFields(fields *ConvoyFields) string {
 	if fields.Molecule != "" {
 		lines = append(lines, "Molecule: "+fields.Molecule)
 	}
+	if fields.BaseBranch != "" {
+		lines = append(lines, "base_branch: "+fields.BaseBranch)
+	}
 
 	return strings.Join(lines, "\n")
 }
@@ -329,10 +336,13 @@ func SetConvoyFields(issue *Issue, fields *ConvoyFields) string {
 
 	// Known convoy field keys (lowercase)
 	convoyKeys := map[string]bool{
-		"owner":    true,
-		"notify":   true,
-		"merge":    true,
-		"molecule": true,
+		"owner":       true,
+		"notify":      true,
+		"merge":       true,
+		"molecule":    true,
+		"base_branch": true,
+		"base-branch": true,
+		"basebranch":  true,
 	}
 
 	// Collect non-convoy lines from existing description

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -69,6 +69,7 @@ var (
 	convoyOwner        string
 	convoyOwned        bool
 	convoyMerge        string
+	convoyBaseBranch   string
 	convoyStatusJSON   bool
 	convoyListJSON     bool
 	convoyListStatus   string
@@ -365,6 +366,7 @@ func init() {
 	convoyCreateCmd.Flags().Lookup("notify").NoOptDefVal = "mayor/"
 	convoyCreateCmd.Flags().BoolVar(&convoyOwned, "owned", false, "Mark convoy as caller-managed lifecycle (no automatic witness/refinery registration)")
 	convoyCreateCmd.Flags().StringVar(&convoyMerge, "merge", "", "Merge strategy: direct (push to main), mr (merge queue, default), local (keep on branch)")
+	convoyCreateCmd.Flags().StringVar(&convoyBaseBranch, "base-branch", "", "Target branch for polecats (e.g., 'feat/extraction-review')")
 
 	// Status flags
 	convoyStatusCmd.Flags().BoolVar(&convoyStatusJSON, "json", false, "Output as JSON")
@@ -493,10 +495,11 @@ func runConvoyCreate(cmd *cobra.Command, args []string) error {
 		owner = detectSender()
 	}
 	convoyFieldValues := &beads.ConvoyFields{
-		Owner:    owner,
-		Notify:   convoyNotify,
-		Merge:    convoyMerge,
-		Molecule: convoyMolecule,
+		Owner:      owner,
+		Notify:     convoyNotify,
+		Merge:      convoyMerge,
+		Molecule:   convoyMolecule,
+		BaseBranch: convoyBaseBranch,
 	}
 	description = beads.SetConvoyFields(&beads.Issue{Description: description}, convoyFieldValues)
 
@@ -572,6 +575,9 @@ func runConvoyCreate(cmd *cobra.Command, args []string) error {
 	}
 	if convoyMolecule != "" {
 		fmt.Printf("  Molecule: %s\n", convoyMolecule)
+	}
+	if convoyBaseBranch != "" {
+		fmt.Printf("  Base:     %s\n", convoyBaseBranch)
 	}
 	if convoyOwned {
 		fmt.Printf("  Owned:    %s\n", style.Warning.Render("caller-managed lifecycle"))
@@ -1194,6 +1200,7 @@ type strandedConvoyInfo struct {
 	ReadyCount   int      `json:"ready_count"`
 	ReadyIssues  []string `json:"ready_issues"`
 	CreatedAt    string   `json:"created_at,omitempty"`
+	BaseBranch   string   `json:"base_branch,omitempty"`
 }
 
 // readyIssueInfo holds info about a ready (stranded) issue.
@@ -1295,9 +1302,10 @@ func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
 	}
 
 	var convoys []struct {
-		ID        string `json:"id"`
-		Title     string `json:"title"`
-		CreatedAt string `json:"created_at"`
+		ID          string `json:"id"`
+		Title       string `json:"title"`
+		CreatedAt   string `json:"created_at"`
+		Description string `json:"description"`
 	}
 	if err := json.Unmarshal(out, &convoys); err != nil {
 		return nil, fmt.Errorf("parsing convoy list: %w", err)
@@ -1305,6 +1313,12 @@ func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
 
 	// Check each convoy for stranded state
 	for _, convoy := range convoys {
+		// Extract base_branch from convoy description fields
+		var baseBranch string
+		if cf := beads.ParseConvoyFields(&beads.Issue{Description: convoy.Description}); cf != nil {
+			baseBranch = cf.BaseBranch
+		}
+
 		tracked, err := getTrackedIssues(townBeads, convoy.ID)
 		if err != nil {
 			// Write to stderr explicitly — stdout may be consumed as JSON
@@ -1322,6 +1336,7 @@ func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
 				ReadyCount:   0,
 				ReadyIssues:  []string{},
 				CreatedAt:    convoy.CreatedAt,
+				BaseBranch:   baseBranch,
 			})
 			continue
 		}
@@ -1360,6 +1375,7 @@ func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
 				ReadyCount:   len(readyIssues),
 				ReadyIssues:  readyIssues,
 				CreatedAt:    convoy.CreatedAt,
+				BaseBranch:   baseBranch,
 			})
 		} else {
 			// Has tracked issues but none are ready — include in stranded
@@ -1371,6 +1387,7 @@ func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
 				ReadyCount:   0,
 				ReadyIssues:  []string{},
 				CreatedAt:    convoy.CreatedAt,
+				BaseBranch:   baseBranch,
 			})
 		}
 	}

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -746,7 +746,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 					fmt.Printf("Would set convoy merge strategy: %s\n", slingMerge)
 				}
 			} else {
-				convoyID, err := createAutoConvoy(beadID, info.Title, slingOwned, slingMerge)
+				convoyID, err := createAutoConvoy(beadID, info.Title, slingOwned, slingMerge, slingBaseBranch)
 				if err != nil {
 					// Log warning but don't fail - convoy is optional
 					fmt.Printf("%s Could not create auto-convoy: %v\n", style.Dim.Render("Warning:"), err)

--- a/internal/cmd/sling_batch_test.go
+++ b/internal/cmd/sling_batch_test.go
@@ -70,7 +70,7 @@ exit 0
 	}
 
 	beadIDs := []string{"gt-aaa", "gt-bbb", "gt-ccc"}
-	convoyID, _, err := createBatchConvoy(beadIDs, "gastown", false, "mr")
+	convoyID, _, err := createBatchConvoy(beadIDs, "gastown", false, "mr", "")
 	if err != nil {
 		t.Fatalf("createBatchConvoy() error: %v", err)
 	}
@@ -164,7 +164,7 @@ exit 0
 		t.Fatalf("chdir: %v", err)
 	}
 
-	_, _, err = createBatchConvoy([]string{"gt-aaa"}, "gastown", true, "direct")
+	_, _, err = createBatchConvoy([]string{"gt-aaa"}, "gastown", true, "direct", "")
 	if err != nil {
 		t.Fatalf("createBatchConvoy() error: %v", err)
 	}
@@ -225,7 +225,7 @@ exit 0
 		t.Fatalf("chdir: %v", err)
 	}
 
-	_, _, err = createBatchConvoy([]string{"gt-aaa", "gt-bbb"}, "gastown", false, "direct")
+	_, _, err = createBatchConvoy([]string{"gt-aaa", "gt-bbb"}, "gastown", false, "direct", "")
 	if err != nil {
 		t.Fatalf("createBatchConvoy() error: %v", err)
 	}
@@ -246,7 +246,7 @@ exit 0
 // TestCreateBatchConvoy_EmptyBeadIDs verifies that createBatchConvoy returns
 // an error when called with no bead IDs.
 func TestCreateBatchConvoy_EmptyBeadIDs(t *testing.T) {
-	_, _, err := createBatchConvoy(nil, "gastown", false, "")
+	_, _, err := createBatchConvoy(nil, "gastown", false, "", "")
 	if err == nil {
 		t.Fatal("expected error for empty bead IDs, got nil")
 	}
@@ -295,7 +295,7 @@ exit 0
 		t.Fatalf("chdir: %v", err)
 	}
 
-	_, _, err = createBatchConvoy([]string{"gt-a", "gt-b", "gt-c", "gt-d", "gt-e"}, "myrig", false, "")
+	_, _, err = createBatchConvoy([]string{"gt-a", "gt-b", "gt-c", "gt-d", "gt-e"}, "myrig", false, "", "")
 	if err != nil {
 		t.Fatalf("createBatchConvoy() error: %v", err)
 	}
@@ -377,7 +377,7 @@ exit 0
 	}
 
 	// Should NOT return error — partial tracking is acceptable
-	convoyID, tracked, err := createBatchConvoy([]string{"gt-aaa", "gt-bbb", "gt-ccc"}, "gastown", false, "")
+	convoyID, tracked, err := createBatchConvoy([]string{"gt-aaa", "gt-bbb", "gt-ccc"}, "gastown", false, "", "")
 	if err != nil {
 		t.Fatalf("createBatchConvoy() should not error on partial dep failure: %v", err)
 	}
@@ -838,7 +838,7 @@ exit 0
 		t.Fatalf("rewrite bd stub: %v", err)
 	}
 
-	convoyID, err := createAutoConvoy("gt-aaa", "Fix the widget", false, "mr")
+	convoyID, err := createAutoConvoy("gt-aaa", "Fix the widget", false, "mr", "")
 	if err != nil {
 		t.Fatalf("createAutoConvoy() error: %v", err)
 	}
@@ -870,7 +870,7 @@ exit 0
 // TestCreateAutoConvoy_FlagLikeTitleReturnsError verifies that a title starting
 // with "--" is rejected.
 func TestCreateAutoConvoy_FlagLikeTitleReturnsError(t *testing.T) {
-	_, err := createAutoConvoy("gt-aaa", "--verbose", false, "")
+	_, err := createAutoConvoy("gt-aaa", "--verbose", false, "", "")
 	if err == nil {
 		t.Fatal("expected error for flag-like title, got nil")
 	}
@@ -897,7 +897,7 @@ exit 0
 		t.Fatalf("rewrite bd stub: %v", err)
 	}
 
-	_, err := createAutoConvoy("gt-aaa", "My task", true, "direct")
+	_, err := createAutoConvoy("gt-aaa", "My task", true, "direct", "")
 	if err != nil {
 		t.Fatalf("createAutoConvoy() error: %v", err)
 	}
@@ -941,7 +941,7 @@ exit 0
 		t.Fatalf("rewrite bd stub: %v", err)
 	}
 
-	_, err := createAutoConvoy("gt-aaa", "My task", false, "")
+	_, err := createAutoConvoy("gt-aaa", "My task", false, "", "")
 	if err == nil {
 		t.Fatal("expected error when dep add fails, got nil")
 	}
@@ -1278,7 +1278,7 @@ exit 0
 		t.Fatalf("chdir: %v", err)
 	}
 
-	convoyID, tracked, err := createBatchConvoy([]string{"gt-aaa", "gt-bbb", "gt-ccc"}, "gastown", false, "")
+	convoyID, tracked, err := createBatchConvoy([]string{"gt-aaa", "gt-bbb", "gt-ccc"}, "gastown", false, "", "")
 	if err != nil {
 		t.Fatalf("createBatchConvoy() error: %v", err)
 	}

--- a/internal/cmd/sling_convoy.go
+++ b/internal/cmd/sling_convoy.go
@@ -320,7 +320,7 @@ func printConvoyConflict(beadID, convoyID string) {
 // dep add failed should not reference a convoy that has no knowledge of it.
 // If owned is true, the convoy is marked with gt:owned label.
 // beadIDs must be non-empty. The convoy title uses the rig name and bead count.
-func createBatchConvoy(beadIDs []string, rigName string, owned bool, mergeStrategy string) (string, []string, error) {
+func createBatchConvoy(beadIDs []string, rigName string, owned bool, mergeStrategy, baseBranch string) (string, []string, error) {
 	if len(beadIDs) == 0 {
 		return "", nil, fmt.Errorf("no beads to track")
 	}
@@ -337,7 +337,8 @@ func createBatchConvoy(beadIDs []string, rigName string, owned bool, mergeStrate
 	convoyTitle := fmt.Sprintf("Batch: %d beads to %s", len(beadIDs), rigName)
 	prose := fmt.Sprintf("Auto-created convoy tracking %d beads", len(beadIDs))
 	description := beads.SetConvoyFields(&beads.Issue{Description: prose}, &beads.ConvoyFields{
-		Merge: mergeStrategy,
+		Merge:      mergeStrategy,
+		BaseBranch: baseBranch,
 	})
 
 	createArgs := []string{
@@ -380,7 +381,7 @@ func createBatchConvoy(beadIDs []string, rigName string, owned bool, mergeStrate
 // If owned is true, the convoy is marked with the gt:owned label for caller-managed lifecycle.
 // mergeStrategy is optional: "direct", "mr", or "local" (empty = default mr).
 // Returns the created convoy ID.
-func createAutoConvoy(beadID, beadTitle string, owned bool, mergeStrategy string) (_ string, retErr error) {
+func createAutoConvoy(beadID, beadTitle string, owned bool, mergeStrategy, baseBranch string) (_ string, retErr error) {
 	defer func() { telemetry.RecordConvoyCreate(context.Background(), beadID, retErr) }()
 	// Guard against flag-like titles propagating into convoy names (gt-e0kx5)
 	if beads.IsFlagLikeTitle(beadTitle) {
@@ -402,7 +403,8 @@ func createAutoConvoy(beadID, beadTitle string, owned bool, mergeStrategy string
 	convoyTitle := fmt.Sprintf("Work: %s", beadTitle)
 	prose := fmt.Sprintf("Auto-created convoy tracking %s", beadID)
 	description := beads.SetConvoyFields(&beads.Issue{Description: prose}, &beads.ConvoyFields{
-		Merge: mergeStrategy,
+		Merge:      mergeStrategy,
+		BaseBranch: baseBranch,
 	})
 
 	createArgs := []string{

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -249,7 +249,7 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 		existingConvoy := isTrackedByConvoy(params.BeadID)
 		if existingConvoy == "" {
 			var err error
-			convoyID, err = createAutoConvoy(params.BeadID, info.Title, params.Owned, params.Merge)
+			convoyID, err = createAutoConvoy(params.BeadID, info.Title, params.Owned, params.Merge, params.BaseBranch)
 			if err != nil {
 				fmt.Printf("  %s Could not create auto-convoy: %v\n", style.Dim.Render("Warning:"), err)
 			} else {

--- a/internal/cmd/sling_schedule.go
+++ b/internal/cmd/sling_schedule.go
@@ -173,7 +173,7 @@ func scheduleBead(beadID, rigName string, opts ScheduleOptions) error {
 	if !opts.NoConvoy {
 		existingConvoy := isTrackedByConvoy(beadID)
 		if existingConvoy == "" {
-			convoyID, err := createAutoConvoy(beadID, info.Title, opts.Owned, opts.Merge)
+			convoyID, err := createAutoConvoy(beadID, info.Title, opts.Owned, opts.Merge, opts.BaseBranch)
 			if err != nil {
 				fmt.Printf("%s Could not create auto-convoy: %v\n", style.Dim.Render("Warning:"), err)
 			} else {

--- a/internal/convoy/operations.go
+++ b/internal/convoy/operations.go
@@ -233,6 +233,14 @@ func feedNextReadyIssue(ctx context.Context, store beadsdk.Storage, townRoot, co
 		return
 	}
 
+	// Extract base_branch from convoy description fields
+	var baseBranch string
+	if convoy, err := store.GetIssue(ctx, convoyID); err == nil && convoy != nil {
+		if cf := beads.ParseConvoyFields(&beads.Issue{Description: convoy.Description}); cf != nil {
+			baseBranch = cf.BaseBranch
+		}
+	}
+
 	// Sort by priority (lower = higher) then by ID for deterministic tie-breaking.
 	sort.Slice(tracked, func(i, j int) bool {
 		if tracked[i].Priority != tracked[j].Priority {
@@ -276,7 +284,7 @@ func feedNextReadyIssue(ctx context.Context, store beadsdk.Storage, townRoot, co
 		}
 
 		logger("%s: convoy %s: feeding next ready issue %s to %s", caller, convoyID, issue.ID, rig)
-		if err := dispatchIssue(ctx, townRoot, issue.ID, rig, gtPath); err != nil {
+		if err := dispatchIssue(ctx, townRoot, issue.ID, rig, gtPath, baseBranch); err != nil {
 			logger("%s: convoy %s: dispatch %s failed: %s", caller, convoyID, issue.ID, util.FirstLine(err.Error()))
 			continue // Try next issue on dispatch failure
 		}
@@ -453,8 +461,12 @@ func fetchCrossRigBeadStatus(townRoot string, ids []string) map[string]*beadsdk.
 // dispatchIssue dispatches an issue to a rig via gt sling.
 // The context parameter enables cancellation on daemon shutdown.
 // gtPath is the resolved path to the gt binary.
-func dispatchIssue(ctx context.Context, townRoot, issueID, rig, gtPath string) error {
-	cmd := exec.CommandContext(ctx, gtPath, "sling", issueID, rig, "--no-boot")
+func dispatchIssue(ctx context.Context, townRoot, issueID, rig, gtPath, baseBranch string) error {
+	args := []string{"sling", issueID, rig, "--no-boot"}
+	if baseBranch != "" {
+		args = append(args, "--base-branch="+baseBranch)
+	}
+	cmd := exec.CommandContext(ctx, gtPath, args...)
 	cmd.Dir = townRoot
 	util.SetProcessGroup(cmd)
 	var stderr bytes.Buffer

--- a/internal/convoy/operations_test.go
+++ b/internal/convoy/operations_test.go
@@ -1170,7 +1170,7 @@ func TestDispatchIssue_Success(t *testing.T) {
 	townRoot := t.TempDir()
 	gtPath, logPath := makeGTStub(t, 0)
 
-	err := dispatchIssue(context.Background(), townRoot, "test-abc", "myrig", gtPath)
+	err := dispatchIssue(context.Background(), townRoot, "test-abc", "myrig", gtPath, "")
 	if err != nil {
 		t.Fatalf("dispatchIssue returned error: %v", err)
 	}
@@ -1194,7 +1194,7 @@ func TestDispatchIssue_Failure(t *testing.T) {
 	townRoot := t.TempDir()
 	gtPath, _ := makeGTStub(t, 1)
 
-	err := dispatchIssue(context.Background(), townRoot, "test-fail", "myrig", gtPath)
+	err := dispatchIssue(context.Background(), townRoot, "test-fail", "myrig", gtPath, "")
 	if err == nil {
 		t.Fatal("dispatchIssue should return error when gt exits 1")
 	}

--- a/internal/daemon/convoy_manager.go
+++ b/internal/daemon/convoy_manager.go
@@ -34,6 +34,7 @@ type strandedConvoyInfo struct {
 	ReadyCount   int       `json:"ready_count"`
 	ReadyIssues  []string  `json:"ready_issues"`
 	CreatedAt    time.Time `json:"created_at"`
+	BaseBranch   string    `json:"base_branch,omitempty"`
 }
 
 // ConvoyManager monitors beads events for issue closes and periodically scans for stranded convoys.
@@ -428,7 +429,11 @@ func (m *ConvoyManager) feedFirstReady(c strandedConvoyInfo) {
 
 		m.logger("Convoy %s: feeding %s to %s", c.ID, issueID, rig)
 
-		cmd := exec.CommandContext(m.ctx, m.gtPath, "sling", issueID, rig, "--no-boot")
+		slingArgs := []string{"sling", issueID, rig, "--no-boot"}
+		if c.BaseBranch != "" {
+			slingArgs = append(slingArgs, "--base-branch="+c.BaseBranch)
+		}
+		cmd := exec.CommandContext(m.ctx, m.gtPath, slingArgs...)
 		cmd.Dir = m.townRoot
 		util.SetProcessGroup(cmd)
 		var stderr bytes.Buffer


### PR DESCRIPTION
## Summary
- Add `BaseBranch` field to `ConvoyFields` so convoys can specify a target branch at creation time
- Propagate `--base-branch` through `feedFirstReady` in convoy_manager.go so slung issues inherit the convoy's base branch
- Without this, convoys targeting feature branches require manual `--base-branch` on every sling

## Context
Feature request from monorepo/rainier. Working with 12 extraction review gap beads targeting `feat/extraction-review`, not main. No way to set base-branch at convoy level previously.

## Test plan
- [ ] Verify `gt convoy create "name" <issues> --base-branch feat/branch` stores BaseBranch
- [ ] Verify polecats slung via convoy feedFirstReady receive `--base-branch`
- [ ] Verify default behavior (no --base-branch) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>
Executed-By: gastown/furiosa