### PR TITLE
Remove vestigial sync.mode plumbing and dead config

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -8,20 +8,6 @@
 # Example: issue-prefix: "myproject" creates issues like "myproject-1", "myproject-2", etc.
 # issue-prefix: ""
 
-# Use no-db mode: load from JSONL, no SQLite, write back after each command
-# When true, bd will use .beads/issues.jsonl as the source of truth
-# instead of SQLite database
-# no-db: false
-
-# Disable daemon for RPC communication (forces direct database access)
-# no-daemon: false
-
-# Disable auto-flush of database to JSONL after mutations
-# no-auto-flush: false
-
-# Disable auto-import from JSONL when it's newer than database
-# no-auto-import: false
-
 # Enable JSON output by default
 # json: false
 
@@ -31,26 +17,12 @@
 # Path to database (overridden by BEADS_DB or --db)
 # db: ""
 
-# Auto-start daemon if not running (can also use BEADS_AUTO_START_DAEMON)
-# auto-start-daemon: true
-
-# Debounce interval for auto-flush (can also use BEADS_FLUSH_DEBOUNCE)
-# flush-debounce: "5s"
-
 # Git branch for beads commits (bd sync will commit to this branch)
 # IMPORTANT: Set this for team projects so all clones use the same sync branch.
 # This setting persists across clones (unlike database config which is gitignored).
 # Can also use BEADS_SYNC_BRANCH env var for local override.
 # If not set, bd sync will require you to run 'bd config set sync.branch <branch>'.
 # sync-branch: "beads-sync"
-
-# Multi-repo configuration (experimental - bd-307)
-# Allows hydrating from multiple repositories and routing writes to the correct JSONL
-# repos:
-#   primary: "."  # Primary repo (where this database lives)
-#   additional:   # Additional repos to hydrate from (read-only)
-#     - ~/beads-planning  # Personal planning repo
-#     - ~/work-planning   # Work planning repo
 
 # Integration settings (access with 'bd config get/set')
 # These are stored in the database, not in this file:
@@ -60,7 +32,6 @@
 # - linear.api-key
 # - github.org
 # - github.repo
-# sync-branch: beads-sync  # Legacy — Dolt server mode doesn't use git sync
 
 # Cross-project dependencies (gt-o3is)
 # Maps project names to paths for external dependency resolution
@@ -68,11 +39,5 @@
 external_projects:
   beads: ../../../beads/mayor/rig
 
-# Sync mode: dolt-native means no JSONL, just Dolt commits/push
-sync:
-  mode: dolt-native
-
 # Custom issue types for Gas Town (fallback when database is unavailable)
 types.custom: "agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request"
-
-sync.mode: "dolt-native"

--- a/internal/beads/config_yaml.go
+++ b/internal/beads/config_yaml.go
@@ -7,44 +7,41 @@ import (
 	"strings"
 )
 
-const defaultSyncMode = "dolt-native"
-
 // EnsureConfigYAML ensures config.yaml has both prefix keys set for the given
 // beads namespace. Existing non-prefix settings are preserved.
 func EnsureConfigYAML(beadsDir, prefix string) error {
-	return ensureConfigYAML(beadsDir, prefix, defaultSyncMode, false)
+	return ensureConfigYAML(beadsDir, prefix, false)
 }
 
 // EnsureConfigYAMLIfMissing creates config.yaml with the required defaults when
 // it is missing. Existing files are left untouched.
 func EnsureConfigYAMLIfMissing(beadsDir, prefix string) error {
-	return ensureConfigYAML(beadsDir, prefix, defaultSyncMode, true)
+	return ensureConfigYAML(beadsDir, prefix, true)
 }
 
 // EnsureConfigYAMLFromMetadataIfMissing creates config.yaml when missing using
-// metadata-derived defaults for prefix/sync mode when available.
+// metadata-derived defaults for prefix when available.
 func EnsureConfigYAMLFromMetadataIfMissing(beadsDir, fallbackPrefix string) error {
-	prefix, syncMode := ConfigDefaultsFromMetadata(beadsDir, fallbackPrefix)
-	return ensureConfigYAML(beadsDir, prefix, syncMode, true)
+	prefix := ConfigDefaultsFromMetadata(beadsDir, fallbackPrefix)
+	return ensureConfigYAML(beadsDir, prefix, true)
 }
 
 // ConfigDefaultsFromMetadata derives config.yaml defaults from metadata.json.
-// Falls back to fallbackPrefix and dolt-native sync mode when fields are absent.
-func ConfigDefaultsFromMetadata(beadsDir, fallbackPrefix string) (prefix string, syncMode string) {
-	prefix = strings.TrimSpace(strings.TrimSuffix(fallbackPrefix, "-"))
+// Falls back to fallbackPrefix when fields are absent.
+func ConfigDefaultsFromMetadata(beadsDir, fallbackPrefix string) string {
+	prefix := strings.TrimSpace(strings.TrimSuffix(fallbackPrefix, "-"))
 	if prefix == "" {
 		prefix = fallbackPrefix
 	}
-	syncMode = defaultSyncMode
 
 	data, err := os.ReadFile(filepath.Join(beadsDir, "metadata.json"))
 	if err != nil {
-		return prefix, syncMode
+		return prefix
 	}
 
 	var meta map[string]interface{}
 	if err := json.Unmarshal(data, &meta); err != nil {
-		return prefix, syncMode
+		return prefix
 	}
 
 	if derived := firstString(meta, "issue_prefix", "issue-prefix", "prefix"); derived != "" {
@@ -52,14 +49,8 @@ func ConfigDefaultsFromMetadata(beadsDir, fallbackPrefix string) (prefix string,
 	} else if doltDB := firstString(meta, "dolt_database"); doltDB != "" {
 		prefix = normalizeDoltDatabasePrefix(doltDB)
 	}
-	if mode := firstString(meta, "sync.mode", "sync_mode", "syncMode"); mode != "" {
-		syncMode = strings.TrimSpace(strings.Trim(mode, `"'`))
-	}
-	if syncMode == "" {
-		syncMode = defaultSyncMode
-	}
 
-	return prefix, syncMode
+	return prefix
 }
 
 func firstString(values map[string]interface{}, keys ...string) string {
@@ -91,15 +82,14 @@ func normalizeDoltDatabasePrefix(dbName string) string {
 	return name
 }
 
-func ensureConfigYAML(beadsDir, prefix, syncMode string, onlyIfMissing bool) error {
+func ensureConfigYAML(beadsDir, prefix string, onlyIfMissing bool) error {
 	configPath := filepath.Join(beadsDir, "config.yaml")
 	wantPrefix := "prefix: " + prefix
 	wantIssuePrefix := "issue-prefix: " + prefix
-	wantSyncMode := "sync.mode: " + syncMode
 
 	data, err := os.ReadFile(configPath)
 	if os.IsNotExist(err) {
-		content := wantPrefix + "\n" + wantIssuePrefix + "\n" + wantSyncMode + "\n"
+		content := wantPrefix + "\n" + wantIssuePrefix + "\n"
 		return os.WriteFile(configPath, []byte(content), 0644)
 	}
 	if err != nil {
@@ -113,7 +103,6 @@ func ensureConfigYAML(beadsDir, prefix, syncMode string, onlyIfMissing bool) err
 	lines := strings.Split(content, "\n")
 	foundPrefix := false
 	foundIssuePrefix := false
-	foundSyncMode := false
 
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
@@ -127,15 +116,6 @@ func ensureConfigYAML(beadsDir, prefix, syncMode string, onlyIfMissing bool) err
 			foundIssuePrefix = true
 			continue
 		}
-		if strings.HasPrefix(trimmed, "sync.mode:") {
-			foundSyncMode = true
-			value := strings.TrimSpace(strings.TrimPrefix(trimmed, "sync.mode:"))
-			value = strings.Trim(value, `"'`)
-			// Respect explicit non-default modes, but migrate missing/legacy defaults.
-			if value == "" || value == syncMode {
-				lines[i] = wantSyncMode
-			}
-		}
 	}
 
 	if !foundPrefix {
@@ -143,9 +123,6 @@ func ensureConfigYAML(beadsDir, prefix, syncMode string, onlyIfMissing bool) err
 	}
 	if !foundIssuePrefix {
 		lines = append(lines, wantIssuePrefix)
-	}
-	if !foundSyncMode {
-		lines = append(lines, wantSyncMode)
 	}
 
 	newContent := strings.Join(lines, "\n")

--- a/internal/beads/config_yaml_test.go
+++ b/internal/beads/config_yaml_test.go
@@ -10,7 +10,7 @@ import (
 func TestEnsureConfigYAMLIfMissing_DoesNotOverwriteExisting(t *testing.T) {
 	beadsDir := t.TempDir()
 	configPath := filepath.Join(beadsDir, "config.yaml")
-	original := "prefix: keep\nissue-prefix: keep\nsync.mode: custom\n"
+	original := "prefix: keep\nissue-prefix: keep\n"
 	if err := os.WriteFile(configPath, []byte(original), 0644); err != nil {
 		t.Fatalf("write config.yaml: %v", err)
 	}
@@ -50,24 +50,18 @@ func TestEnsureConfigYAMLFromMetadataIfMissing_UsesMetadataPrefix(t *testing.T) 
 	if !strings.Contains(got, "issue-prefix: foo\n") {
 		t.Fatalf("config.yaml missing metadata issue-prefix: %q", got)
 	}
-	if !strings.Contains(got, "sync.mode: dolt-native\n") {
-		t.Fatalf("config.yaml missing sync.mode default: %q", got)
-	}
 }
 
 func TestConfigDefaultsFromMetadata_FallsBackToDoltDatabase(t *testing.T) {
 	beadsDir := t.TempDir()
-	metadata := `{"backend":"dolt","dolt_mode":"server","dolt_database":"hq-custom","sync_mode":"belt-and-suspenders"}`
+	metadata := `{"backend":"dolt","dolt_mode":"server","dolt_database":"hq-custom"}`
 	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(metadata), 0644); err != nil {
 		t.Fatalf("write metadata.json: %v", err)
 	}
 
-	prefix, syncMode := ConfigDefaultsFromMetadata(beadsDir, "hq")
+	prefix := ConfigDefaultsFromMetadata(beadsDir, "hq")
 	if prefix != "hq-custom" {
 		t.Fatalf("prefix = %q, want %q", prefix, "hq-custom")
-	}
-	if syncMode != "belt-and-suspenders" {
-		t.Fatalf("syncMode = %q, want %q", syncMode, "belt-and-suspenders")
 	}
 }
 
@@ -78,12 +72,9 @@ func TestConfigDefaultsFromMetadata_StripsLegacyBeadsPrefixFromDoltDatabase(t *t
 		t.Fatalf("write metadata.json: %v", err)
 	}
 
-	prefix, syncMode := ConfigDefaultsFromMetadata(beadsDir, "fallback")
+	prefix := ConfigDefaultsFromMetadata(beadsDir, "fallback")
 	if prefix != "hq" {
 		t.Fatalf("prefix = %q, want %q", prefix, "hq")
-	}
-	if syncMode != "dolt-native" {
-		t.Fatalf("syncMode = %q, want %q", syncMode, "dolt-native")
 	}
 }
 

--- a/internal/cmd/install_integration_test.go
+++ b/internal/cmd/install_integration_test.go
@@ -149,10 +149,6 @@ func TestInstallBeadsHasCorrectPrefix(t *testing.T) {
 	if !strings.Contains(configText, "issue-prefix: hq") {
 		t.Errorf("config.yaml missing issue-prefix: hq, got:\n%s", configText)
 	}
-	if !strings.Contains(configText, "sync.mode: dolt-native") {
-		t.Errorf("config.yaml missing sync.mode: dolt-native, got:\n%s", configText)
-	}
-
 	// Optional online smoke check: verify prefix via bd CLI when Dolt is reachable.
 	// Core assertions already validate prefix from tracked config.yaml above.
 	bdCmd := exec.Command("bd", "config", "get", "issue_prefix")

--- a/internal/cmd/install_test.go
+++ b/internal/cmd/install_test.go
@@ -22,7 +22,7 @@ func TestEnsureBeadsConfigYAML_CreatesWhenMissing(t *testing.T) {
 	}
 
 	got := string(data)
-	want := "prefix: hq\nissue-prefix: hq\nsync.mode: dolt-native\n"
+	want := "prefix: hq\nissue-prefix: hq\n"
 	if got != want {
 		t.Fatalf("config.yaml = %q, want %q", got, want)
 	}
@@ -57,9 +57,6 @@ func TestEnsureBeadsConfigYAML_RepairsPrefixKeysAndPreservesOtherLines(t *testin
 	if !strings.Contains(text, "issue-prefix: hq\n") {
 		t.Fatalf("config.yaml missing repaired issue-prefix: %q", text)
 	}
-	if !strings.Contains(text, "sync.mode: dolt-native\n") {
-		t.Fatalf("config.yaml missing sync.mode: %q", text)
-	}
 	if !strings.Contains(text, "sync-branch: main\n") {
 		t.Fatalf("config.yaml should preserve unrelated settings: %q", text)
 	}
@@ -86,30 +83,5 @@ func TestEnsureBeadsConfigYAML_AddsMissingIssuePrefixKey(t *testing.T) {
 	}
 	if !strings.Contains(text, "issue-prefix: hq\n") {
 		t.Fatalf("config.yaml missing issue-prefix: %q", text)
-	}
-	if !strings.Contains(text, "sync.mode: dolt-native\n") {
-		t.Fatalf("config.yaml missing sync.mode: %q", text)
-	}
-}
-
-func TestEnsureBeadsConfigYAML_PreservesExplicitNonDefaultSyncMode(t *testing.T) {
-	beadsDir := t.TempDir()
-	path := filepath.Join(beadsDir, "config.yaml")
-	initial := "prefix: hq\nissue-prefix: hq\nsync.mode: belt-and-suspenders\n"
-	if err := os.WriteFile(path, []byte(initial), 0644); err != nil {
-		t.Fatalf("write config.yaml: %v", err)
-	}
-
-	if err := beads.EnsureConfigYAML(beadsDir, "hq"); err != nil {
-		t.Fatalf("EnsureConfigYAML: %v", err)
-	}
-
-	data, err := os.ReadFile(path)
-	if err != nil {
-		t.Fatalf("read config.yaml: %v", err)
-	}
-	text := string(data)
-	if !strings.Contains(text, "sync.mode: belt-and-suspenders\n") {
-		t.Fatalf("config.yaml should preserve explicit non-default sync mode: %q", text)
 	}
 }

--- a/internal/doctor/town_beads_config_check_test.go
+++ b/internal/doctor/town_beads_config_check_test.go
@@ -63,10 +63,6 @@ func TestTownBeadsConfigCheck_FixCreatesConfigFromMetadata(t *testing.T) {
 	if !strings.Contains(got, "issue-prefix: foo\n") {
 		t.Fatalf("config.yaml missing metadata-derived issue-prefix: %q", got)
 	}
-	if !strings.Contains(got, "sync.mode: dolt-native\n") {
-		t.Fatalf("config.yaml missing sync.mode default: %q", got)
-	}
-
 	result = check.Run(ctx)
 	if result.Status != StatusOK {
 		t.Fatalf("Status after fix = %v, want %v", result.Status, StatusOK)
@@ -79,7 +75,7 @@ func TestTownBeadsConfigCheck_FixDoesNotOverwriteExistingConfig(t *testing.T) {
 	if err := os.MkdirAll(beadsDir, 0755); err != nil {
 		t.Fatalf("mkdir .beads: %v", err)
 	}
-	original := "prefix: custom\nissue-prefix: custom\nsync.mode: belt-and-suspenders\n"
+	original := "prefix: custom\nissue-prefix: custom\nsync-branch: main\n"
 	configPath := filepath.Join(beadsDir, "config.yaml")
 	if err := os.WriteFile(configPath, []byte(original), 0644); err != nil {
 		t.Fatalf("write config.yaml: %v", err)

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -927,15 +927,6 @@ func (m *Manager) InitBeads(rigPath, prefix, rigName string) error {
 			return fmt.Errorf("bd config set issue_prefix failed: %s", strings.TrimSpace(string(prefixOutput)))
 		}
 
-		// Default to Dolt-native sync mode for new Gas Town rig beads.
-		// Non-fatal: the shared helper below will persist sync.mode to config.yaml.
-		syncModeCmd := exec.Command("bd", "config", "set", "sync.mode", "dolt-native")
-		syncModeCmd.Dir = rigPath
-		syncModeCmd.Env = filteredEnv
-		if syncModeOutput, syncModeErr := syncModeCmd.CombinedOutput(); syncModeErr != nil {
-			fmt.Printf("   ⚠ Could not set sync.mode via bd: %s\n", strings.TrimSpace(string(syncModeOutput)))
-		}
-
 		// Drop the orphaned beads_<prefix> database created by bd init (gt-sv1h).
 		// bd init --prefix creates a database named beads_<prefix> on the Dolt server,
 		// but the rig uses <rigName> as its database (set by InitRig + EnsureMetadata).

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -469,7 +469,7 @@ exit 1
 	if err != nil {
 		t.Fatalf("reading config.yaml: %v", err)
 	}
-	want := "prefix: gt\nissue-prefix: gt\nsync.mode: dolt-native\n"
+	want := "prefix: gt\nissue-prefix: gt\n"
 	if string(config) != want {
 		t.Fatalf("config.yaml = %q, want %q", string(config), want)
 	}
@@ -515,10 +515,6 @@ exit 0
 	// Verify bd config set issue_prefix was called with the correct prefix
 	if !strings.Contains(cmds, "config set issue_prefix myrig") {
 		t.Errorf("expected 'bd config set issue_prefix myrig' in commands log, got:\n%s", cmds)
-	}
-	// Verify sync mode is explicitly set to dolt-native for new rig beads.
-	if !strings.Contains(cmds, "config set sync.mode dolt-native") {
-		t.Errorf("expected 'bd config set sync.mode dolt-native' in commands log, got:\n%s", cmds)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Remove the `defaultSyncMode` constant and sync.mode parameter threading through `ensureConfigYAML` and `ConfigDefaultsFromMetadata` — sync.mode was written to config.yaml but never read (dolt-native was the only mode)
- Remove belt-and-suspenders test fixtures and sync.mode assertions from test files across `internal/beads`, `internal/cmd`, `internal/doctor`, and `internal/rig`
- Clean up dead commented config in `.beads/config.yaml` (no-db, no-daemon, sync.mode, multi-repo JSONL config)

Net: 8 files changed, +20 −136 lines.

## Test plan

- [x] `go vet ./internal/doctor/ ./internal/rig/` — clean
- [x] `go test ./internal/doctor/ -run TestTownBeadsConfig` — 4/4 PASS
- [x] `go test ./internal/rig/ -run TestInitBeads` — 5/5 PASS
- [ ] `internal/beads` and `internal/cmd` packages have a pre-existing build failure (`beads_test.go:40` / `done_test.go:277`: unknown field `Label` in `CreateOptions`) that prevents running their tests — exists on main, not introduced by this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)