### PR TITLE
Fix dog_molecule JSON parsing for bd show --children output

### DIFF
--- a/internal/daemon/dog_molecule.go
+++ b/internal/daemon/dog_molecule.go
@@ -132,12 +132,9 @@ func (dm *dogMol) closeRemainingSteps() {
 		return
 	}
 
-	var children []struct {
-		ID     string `json:"id"`
-		Status string `json:"status"`
-	}
-	if err := json.Unmarshal([]byte(out), &children); err != nil {
-		dm.logger.Printf("dog_molecule: closeRemainingSteps: parse children JSON for %s failed: %v", dm.rootID, err)
+	children, parseErr := parseChildrenJSON(out)
+	if parseErr != nil {
+		dm.logger.Printf("dog_molecule: closeRemainingSteps: parse children JSON for %s failed: %v", dm.rootID, parseErr)
 		return
 	}
 
@@ -176,12 +173,9 @@ func (dm *dogMol) discoverSteps() {
 		return
 	}
 
-	var children []struct {
-		ID    string `json:"id"`
-		Title string `json:"title"`
-	}
-	if err := json.Unmarshal([]byte(out), &children); err != nil {
-		dm.logger.Printf("dog_molecule: discover steps: parse children JSON for %s failed: %v", dm.rootID, err)
+	children, parseErr := parseChildrenJSON(out)
+	if parseErr != nil {
+		dm.logger.Printf("dog_molecule: discover steps: parse children JSON for %s failed: %v", dm.rootID, parseErr)
 		return
 	}
 
@@ -228,6 +222,36 @@ func (dm *dogMol) discoverSteps() {
 			dm.stepIDs["offsite"] = child.ID
 		}
 	}
+}
+
+// childInfo holds fields from child wisp JSON used by discoverSteps and
+// closeRemainingSteps.
+type childInfo struct {
+	ID     string `json:"id"`
+	Title  string `json:"title"`
+	Status string `json:"status"`
+}
+
+// parseChildrenJSON parses the output of `bd show <id> --children --json`.
+// bd returns a map keyed by parent ID: {"hq-wisp-abc": [{...}, ...]}.
+// For forward compatibility, a bare array is also accepted.
+func parseChildrenJSON(raw string) ([]childInfo, error) {
+	data := []byte(raw)
+
+	var arr []childInfo
+	if err := json.Unmarshal(data, &arr); err == nil {
+		return arr, nil
+	}
+
+	var wrapped map[string][]childInfo
+	if err := json.Unmarshal(data, &wrapped); err == nil {
+		for _, children := range wrapped {
+			return children, nil
+		}
+		return nil, nil
+	}
+
+	return nil, fmt.Errorf("unrecognized JSON shape: %.200s", raw)
 }
 
 // knownSteps returns the list of known step slugs for debugging.

--- a/internal/daemon/dog_molecule_test.go
+++ b/internal/daemon/dog_molecule_test.go
@@ -68,6 +68,60 @@ func TestStripANSI(t *testing.T) {
 	}
 }
 
+func TestParseChildrenJSON(t *testing.T) {
+	tests := []struct {
+		name      string
+		input     string
+		wantCount int
+		wantErr   bool
+	}{
+		{
+			name:      "bare array",
+			input:     `[{"id":"a","title":"Probe","status":"open"}]`,
+			wantCount: 1,
+		},
+		{
+			name:      "map wrapper from bd show",
+			input:     `{"hq-wisp-root":[{"id":"hq-wisp-a","title":"Probe","status":"open"},{"id":"hq-wisp-b","title":"Report","status":"open"}]}`,
+			wantCount: 2,
+		},
+		{
+			name:      "empty map wrapper",
+			input:     `{"hq-wisp-root":[]}`,
+			wantCount: 0,
+		},
+		{
+			name:      "empty array",
+			input:     `[]`,
+			wantCount: 0,
+		},
+		{
+			name:    "invalid json",
+			input:   `not json`,
+			wantErr: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseChildrenJSON(tt.input)
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("expected error, got nil")
+				}
+				return
+			}
+			if err != nil {
+				t.Errorf("unexpected error: %v", err)
+				return
+			}
+			if len(got) != tt.wantCount {
+				t.Errorf("got %d children, want %d", len(got), tt.wantCount)
+			}
+		})
+	}
+}
+
 func TestDogMolGracefulDegradation(t *testing.T) {
 	// A dogMol with empty rootID should be a no-op for all operations.
 	dm := &dogMol{


### PR DESCRIPTION
## Summary

- `bd show --children --json` returns `{"parent-id": [{...}]}` (map keyed by parent ID), but `discoverSteps()` and `closeRemainingSteps()` expected a bare JSON array
- Every call failed with `cannot unmarshal object into []struct`, leaving child wisps permanently open (~500+/day accumulation)
- Add `parseChildrenJSON()` helper that handles both the map wrapper and bare array formats

## Test plan

- [x] Unit test for `parseChildrenJSON` covering both formats, empty inputs, and invalid JSON
- [x] Built binary, installed, and verified in production: daemon now reports `poured mol-dog-backup → hq-wisp-edqt (2 steps)` and `closeRemainingSteps: closed 3 orphan step wisp(s)` (vs previous `0 steps` and JSON parse failure)
- [x] Confirmed 0 orphan open wisps after daemon cycle (previously 50+ per hour)