### PR TITLE
fix: make --allow-stale conditional on bd version support

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -27,6 +27,33 @@ var (
 	ErrFlagTitle    = errors.New("title looks like a CLI flag (starts with '-'); use --title=\"...\" to set flag-like titles intentionally")
 )
 
+// bdAllowStale caches whether the installed bd supports --allow-stale.
+// Detected once at first use via `bd --allow-stale version`.
+var (
+	bdAllowStaleOnce   sync.Once
+	bdAllowStaleResult bool
+)
+
+// BdSupportsAllowStale returns true if the installed bd binary accepts --allow-stale.
+func BdSupportsAllowStale() bool {
+	bdAllowStaleOnce.Do(func() {
+		cmd := exec.Command("bd", "--allow-stale", "version") //nolint:gosec // G204: bd is a trusted internal tool
+		if err := cmd.Run(); err == nil {
+			bdAllowStaleResult = true
+		}
+	})
+	return bdAllowStaleResult
+}
+
+// MaybePrependAllowStale prepends --allow-stale to args if bd supports it.
+// Exported for use by other packages that shell out to bd directly.
+func MaybePrependAllowStale(args []string) []string {
+	if BdSupportsAllowStale() {
+		return append([]string{"--allow-stale"}, args...)
+	}
+	return args
+}
+
 // ExtractIssueID strips the external:prefix:id wrapper from bead IDs.
 // bd dep add wraps cross-rig IDs as "external:prefix:id" for routing,
 // but consumers need the raw bead ID for display and lookups.
@@ -282,9 +309,9 @@ func (b *Beads) run(args ...string) (_ []byte, retErr error) {
 	defer func() {
 		telemetry.RecordBDCall(context.Background(), args, float64(time.Since(start).Milliseconds()), retErr, stdout.Bytes(), stderr.String())
 	}()
-	// Use --allow-stale to prevent failures when db is temporarily stale
-	// (e.g., after daemon is killed during shutdown).
-	fullArgs := append([]string{"--allow-stale"}, args...)
+	// Conditionally use --allow-stale to prevent failures when db is temporarily stale
+	// (e.g., after daemon is killed during shutdown). Only if bd supports it.
+	fullArgs := MaybePrependAllowStale(args)
 
 	// Always explicitly set BEADS_DIR to prevent inherited env vars from
 	// causing prefix mismatches. Use explicit beadsDir if set, otherwise
@@ -329,7 +356,7 @@ func (b *Beads) runWithRouting(args ...string) (_ []byte, retErr error) { //noli
 	defer func() {
 		telemetry.RecordBDCall(context.Background(), args, float64(time.Since(start).Milliseconds()), retErr, stdout.Bytes(), stderr.String())
 	}()
-	fullArgs := append([]string{"--allow-stale"}, args...)
+	fullArgs := MaybePrependAllowStale(args)
 
 	cmd := exec.Command("bd", fullArgs...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Dir = b.workDir
@@ -543,12 +570,35 @@ func (b *Beads) List(opts ListOptions) ([]*Issue, error) {
 		return nil, err
 	}
 
+	// bd list --json may return plain text (e.g., "No issues found.") instead
+	// of an empty JSON array when there are no results. Handle gracefully.
+	if len(out) == 0 || !isJSONBytes(out) {
+		return nil, nil
+	}
+
 	var issues []*Issue
 	if err := json.Unmarshal(out, &issues); err != nil {
 		return nil, fmt.Errorf("parsing bd list output: %w", err)
 	}
 
 	return issues, nil
+}
+
+// isJSONBytes returns true if the byte slice starts with [ or { (after whitespace).
+// bd list --json may return plain text like "No issues found." instead of JSON
+// when there are no results.
+func isJSONBytes(b []byte) bool {
+	for _, c := range b {
+		switch c {
+		case ' ', '\t', '\n', '\r':
+			continue
+		case '[', '{':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
 }
 
 // ListByAssignee returns all issues assigned to a specific assignee.

--- a/internal/cmd/bd_helpers.go
+++ b/internal/cmd/bd_helpers.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 // bdCmd is a builder for constructing bd exec.Command calls.
@@ -129,11 +131,26 @@ func (b *bdCmd) buildEnv() []string {
 // Build returns the configured exec.Cmd.
 // This allows callers to further customize the command before execution.
 func (b *bdCmd) Build() *exec.Cmd {
-	cmd := exec.Command("bd", b.args...)
+	args := b.resolvedArgs()
+	cmd := exec.Command("bd", args...)
 	cmd.Dir = b.dir
 	cmd.Env = b.buildEnv()
 	cmd.Stderr = b.stderr
 	return cmd
+}
+
+// resolvedArgs returns the final args, stripping --allow-stale if bd doesn't support it.
+func (b *bdCmd) resolvedArgs() []string {
+	if beads.BdSupportsAllowStale() {
+		return b.args
+	}
+	filtered := make([]string, 0, len(b.args))
+	for _, a := range b.args {
+		if a != "--allow-stale" {
+			filtered = append(filtered, a)
+		}
+	}
+	return filtered
 }
 
 // Run builds and runs the command, returning any error.
@@ -154,7 +171,8 @@ func (b *bdCmd) Output() ([]byte, error) {
 // This overrides the configured Stderr writer to capture both streams.
 // Useful for including command output in error messages.
 func (b *bdCmd) CombinedOutput() ([]byte, error) {
-	cmd := exec.Command("bd", b.args...)
+	args := b.resolvedArgs()
+	cmd := exec.Command("bd", args...)
 	cmd.Dir = b.dir
 	cmd.Env = b.buildEnv()
 	return cmd.CombinedOutput()

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -2145,8 +2145,8 @@ func getExternalIssueDetails(townBeads, rigName, issueID string) *issueDetails {
 	}
 
 	// Query the rig database by running bd show from the rig directory
-	// Use --allow-stale to handle cases where the database may be temporarily stale
-	showCmd := exec.Command("bd", "show", issueID, "--json", "--allow-stale")
+	showArgs := beads.MaybePrependAllowStale([]string{"show", issueID, "--json"})
+	showCmd := exec.Command("bd", showArgs...)
 	showCmd.Dir = rigDir // Set working directory to rig directory
 	var stdout bytes.Buffer
 	showCmd.Stdout = &stdout

--- a/internal/doctor/misclassified_wisp_check.go
+++ b/internal/doctor/misclassified_wisp_check.go
@@ -291,7 +291,7 @@ func (c *CheckMisclassifiedWisps) findMisclassifiedWispsJSONL(path string, rigNa
 // Uses --allow-stale to survive DB/JSONL drift (consistent with all other bd invocations).
 // Returns an error if the probe fails, so callers can track and surface failures.
 func isIssueStillOpen(workDir, id string) (bool, error) {
-	cmd := exec.Command("bd", "--allow-stale", "show", id, "--json")
+	cmd := exec.Command("bd", beads.MaybePrependAllowStale([]string{"show", id, "--json"})...)
 	cmd.Dir = workDir
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/doltserver/sync.go
+++ b/internal/doltserver/sync.go
@@ -10,6 +10,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 // SyncOptions controls the behavior of SyncDatabases.
@@ -245,9 +247,8 @@ func PurgeClosedEphemerals(townRoot, dbName string, dryRun bool) (int, error) {
 	// Build bd purge command with safety-net timeout.
 	// bd purge v2 uses batched SQL (completes in seconds), but we keep a
 	// generous timeout as a circuit breaker against future regressions.
-	// --allow-stale prevents failures when database is temporarily stale,
-	// consistent with all other bd invocations in the codebase.
-	args := []string{"--allow-stale", "purge", "--json"}
+	// Conditionally use --allow-stale if bd supports it.
+	args := beads.MaybePrependAllowStale([]string{"purge", "--json"})
 	if dryRun {
 		args = append(args, "--dry-run")
 	}

--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -163,7 +163,7 @@ func (m *Mailbox) listFromDir(beadsDir string) ([]*Message, error) {
 
 		var msgs []BeadsMessage
 		if err := json.Unmarshal(stdout, &msgs); err != nil {
-			if len(stdout) == 0 || string(stdout) == "null" {
+			if len(stdout) == 0 || string(stdout) == "null" || !isJSON(stdout) {
 				continue
 			}
 			return nil, err
@@ -202,7 +202,7 @@ func (m *Mailbox) listFromDir(beadsDir string) ([]*Message, error) {
 
 		var msgs []BeadsMessage
 		if err := json.Unmarshal(stdout, &msgs); err != nil {
-			if len(stdout) == 0 || string(stdout) == "null" {
+			if len(stdout) == 0 || string(stdout) == "null" || !isJSON(stdout) {
 				continue
 			}
 			continue // Non-fatal for CC
@@ -1063,4 +1063,21 @@ func (m *Mailbox) listByThreadLegacy(threadID string) ([]*Message, error) {
 	})
 
 	return thread, nil
+}
+
+// isJSON returns true if the byte slice looks like JSON (starts with [ or {).
+// bd list --json may return plain text like "No issues found." instead of JSON
+// when there are no results.
+func isJSON(b []byte) bool {
+	for _, c := range b {
+		switch c {
+		case ' ', '\t', '\n', '\r':
+			continue
+		case '[', '{':
+			return true
+		default:
+			return false
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

- **Detect bd `--allow-stale` support at startup** via `sync.Once` probe (`bd --allow-stale version`). Only pass the flag when bd accepts it, preventing crashes with older bd versions.
- **Handle non-JSON `bd list --json` output** — older bd returns plain text ("No issues found.") instead of `[]` when there are no results. Both `beads.List()` and `mail.listFromDir()` now check if output is valid JSON before attempting unmarshal.
- **Centralized flag handling** — exported `beads.MaybePrependAllowStale()` and `beads.BdSupportsAllowStale()` for all packages that shell out to bd directly. `BdCmd.Build()` automatically strips `--allow-stale` from args when unsupported.

Fixes gt 0.9.0 + bd 0.59.0 incompatibility that broke `gt hook`, `gt mail inbox`, and patrol commands.

## Files changed

| File | Change |
|------|--------|
| `internal/beads/beads.go` | Add version detection, `MaybePrependAllowStale()`, `isJSONBytes()` guard |
| `internal/cmd/bd_helpers.go` | `BdCmd.resolvedArgs()` strips unsupported flags |
| `internal/cmd/convoy.go` | Use `MaybePrependAllowStale()` |
| `internal/doctor/misclassified_wisp_check.go` | Use `MaybePrependAllowStale()` |
| `internal/doltserver/sync.go` | Use `MaybePrependAllowStale()` |
| `internal/mail/mailbox.go` | Add `isJSON()` guard for non-JSON bd output |

## Test plan

- [x] `gt hook status` succeeds with both old and new bd
- [x] `gt mail inbox` succeeds with both old and new bd
- [x] `go build ./...` clean
- [x] `go vet` clean on changed packages (pre-existing test failures unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)