### PR TITLE
fix(polecat): use ClonePath for best-effort push in nuke

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1282,11 +1282,12 @@ func nukePolecatFull(polecatName, rigName string, mgr *polecat.Manager, r *rig.R
 	// proceed — --force already means "I accept data loss".
 	if branchToDelete != "" {
 		var pushGit *git.Git
-		// Try worktree first (may still exist), then bare repo fallback
-		if polecatInfo != nil {
-			wtPath := filepath.Join(r.Path, "polecats", polecatName)
-			if _, statErr := os.Stat(wtPath); statErr == nil {
-				pushGit = git.NewGit(wtPath)
+		// Try worktree first (may still exist), then bare repo fallback.
+		// Use ClonePath from the polecat record — the worktree lives at
+		// <rig>/polecats/<name>/<rigName>/, not <rig>/polecats/<name>/.
+		if polecatInfo != nil && polecatInfo.ClonePath != "" {
+			if _, statErr := os.Stat(polecatInfo.ClonePath); statErr == nil {
+				pushGit = git.NewGit(polecatInfo.ClonePath)
 			}
 		}
 		if pushGit == nil {


### PR DESCRIPTION
## Summary

**P0 bug fix (hq-9pcb0).** The best-effort push in `gt polecat nuke --force` was silently failing for every polecat, destroying unpushed branches on nuke.

- **Root cause:** The push guardrail constructed the worktree path as `<rig>/polecats/<name>`, but the actual git worktree lives at `<rig>/polecats/<name>/<rigName>/` (the `ClonePath` on the polecat record). The incorrect path is not a git repo, so `git push` failed with "src refspec does not match any" and nuke proceeded to delete the worktree.
- **Fix:** Use `polecatInfo.ClonePath` instead of manually constructing the path. Added nil-guard for empty `ClonePath`.
- **Impact:** Every polecat nuke since the worktree layout was introduced silently lost unpushed branches. The neuralcodec rig was hit hardest with multiple sessions of work lost.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/cmd/...` passes (including `TestNukeGateGuardLogic`)
- [x] Pre-existing `TestAddWithOptions_HasAgentsMD` failure in `internal/polecat` is unrelated (beads DB not initialized)
- [ ] Manual: `gt polecat nuke --force` on a polecat with unpushed commits — verify branch is pushed before deletion
- [ ] Manual: `gt polecat nuke --force` on a stale polecat where worktree is already gone — verify bare repo fallback still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)