### PR TITLE
fix: guard against bd v0.58.0 non-JSON output in list/hook/mail parsing

### DIFF
--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -2,6 +2,7 @@ package mail
 
 import (
 	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -162,6 +163,12 @@ func (m *Mailbox) listFromDir(beadsDir string) ([]*Message, error) {
 		}
 
 		var msgs []BeadsMessage
+		trimmed := bytes.TrimSpace(stdout)
+		if len(trimmed) == 0 || string(trimmed) == "null" || (trimmed[0] != '[' && trimmed[0] != '{') {
+			// bd v0.58.0 returns plain text (e.g. "No issues found.") for
+			// empty result sets instead of JSON. Skip non-JSON output.
+			continue
+		}
 		if err := json.Unmarshal(stdout, &msgs); err != nil {
 			if len(stdout) == 0 || string(stdout) == "null" || !isJSON(stdout) {
 				continue
@@ -201,6 +208,10 @@ func (m *Mailbox) listFromDir(beadsDir string) ([]*Message, error) {
 		}
 
 		var msgs []BeadsMessage
+		trimmedCC := bytes.TrimSpace(stdout)
+		if len(trimmedCC) == 0 || string(trimmedCC) == "null" || (trimmedCC[0] != '[' && trimmedCC[0] != '{') {
+			continue
+		}
 		if err := json.Unmarshal(stdout, &msgs); err != nil {
 			if len(stdout) == 0 || string(stdout) == "null" || !isJSON(stdout) {
 				continue


### PR DESCRIPTION
## Summary

- `bd v0.58.0` returns plain text (e.g. `"No issues found."`) instead of empty JSON arrays when result sets are empty
- This broke `gt hook`, `gt mail inbox`, and `gt patrol` — all witness automation was degraded
- Guard all `bd list` output parsers against non-JSON responses

## Changes

- `internal/beads/beads.go`: check if output starts with `[` before JSON parse
- `internal/deacon/stale_hooks.go`: same guard
- `internal/mail/mailbox.go`: same guard with graceful empty-list fallback

## Test plan

- [ ] `bd list --json` returning plain text no longer causes parse errors
- [ ] `gt hook`, `gt mail inbox`, `gt patrol` work correctly with bd v0.58.0
- [ ] Empty result sets return empty arrays, not errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)