### PR TITLE
fix: enable cross-DB routing for mail archive, delete, and mark-read operations

### DIFF
--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -34,6 +34,7 @@ type Mailbox struct {
 	identity string // beads identity (e.g., "gastown/polecats/Toast")
 	workDir  string // directory to run bd commands in
 	beadsDir string // explicit .beads directory path (set via BEADS_DIR)
+	townRoot string // town root directory for cross-DB routing (e.g., ~/gt)
 	path     string // for legacy JSONL mode (crew workers)
 	legacy   bool   // true = use JSONL files, false = use beads
 }
@@ -240,6 +241,38 @@ func (m *Mailbox) identityVariants() []string {
 	return variants
 }
 
+// resolveBeadsDirForID returns the correct .beads directory for a bead ID.
+// If the ID has a prefix that maps to a rig-specific database (via routes.jsonl),
+// returns that rig's .beads directory. Otherwise returns m.beadsDir.
+//
+// This enables cross-DB operations: inbox listing aggregates across all DBs
+// via bd list's built-in routing, but show/close/label operate on a single DB.
+// Without this, operations on rig-prefixed messages (e.g., sm-wisp-*) fail with
+// "not found" when run against the town-level DB.
+func (m *Mailbox) resolveBeadsDirForID(id string) string {
+	if m.townRoot == "" {
+		return m.beadsDir
+	}
+
+	prefix := beads.ExtractPrefix(id)
+	if prefix == "" {
+		return m.beadsDir
+	}
+
+	rigPath := beads.GetRigPathForPrefix(m.townRoot, prefix)
+	if rigPath == "" {
+		return m.beadsDir
+	}
+
+	resolved := filepath.Join(rigPath, ".beads")
+	resolvedFinal := beads.ResolveBeadsDir(rigPath)
+	if resolvedFinal != "" {
+		resolved = resolvedFinal
+	}
+
+	return resolved
+}
+
 func (m *Mailbox) listLegacy() ([]*Message, error) {
 	file, err := os.Open(m.path)
 	if err != nil {
@@ -308,8 +341,7 @@ func (m *Mailbox) Get(id string) (*Message, error) {
 }
 
 func (m *Mailbox) getBeads(id string) (*Message, error) {
-	// Single DB query - wisps and persistent messages in same store
-	return m.getFromDir(id, m.beadsDir)
+	return m.getFromDir(id, m.resolveBeadsDirForID(id))
 }
 
 // getFromDir retrieves a message from a beads directory.
@@ -364,8 +396,7 @@ func (m *Mailbox) MarkRead(id string) error {
 }
 
 func (m *Mailbox) markReadBeads(id string) error {
-	// Single DB - wisps and persistent messages in same store
-	return m.closeInDir(id, m.beadsDir)
+	return m.closeInDir(id, m.resolveBeadsDirForID(id))
 }
 
 // closeInDir closes a message in a specific beads directory.
@@ -432,12 +463,12 @@ func (m *Mailbox) MarkReadOnly(id string) error {
 }
 
 func (m *Mailbox) markReadOnlyBeads(id string) error {
-	// Add "read" label to mark as read without closing
 	args := []string{"label", "add", id, "read"}
 
+	beadsDir := m.resolveBeadsDirForID(id)
 	ctx, cancel := bdWriteCtx()
 	defer cancel()
-	_, err := runBdCommand(ctx, args, m.workDir, m.beadsDir)
+	_, err := runBdCommand(ctx, args, m.workDir, beadsDir)
 	if err != nil {
 		if bdErr, ok := err.(*bdError); ok && bdErr.ContainsError("not found") {
 			return ErrMessageNotFound
@@ -459,12 +490,12 @@ func (m *Mailbox) MarkUnreadOnly(id string) error {
 }
 
 func (m *Mailbox) markUnreadOnlyBeads(id string) error {
-	// Remove "read" label to mark as unread
 	args := []string{"label", "remove", id, "read"}
 
+	beadsDir := m.resolveBeadsDirForID(id)
 	ctx, cancel := bdWriteCtx()
 	defer cancel()
-	_, err := runBdCommand(ctx, args, m.workDir, m.beadsDir)
+	_, err := runBdCommand(ctx, args, m.workDir, beadsDir)
 	if err != nil {
 		if bdErr, ok := err.(*bdError); ok && bdErr.ContainsError("not found") {
 			return ErrMessageNotFound
@@ -490,9 +521,10 @@ func (m *Mailbox) MarkUnread(id string) error {
 func (m *Mailbox) markUnreadBeads(id string) error {
 	args := []string{"reopen", id}
 
+	beadsDir := m.resolveBeadsDirForID(id)
 	ctx, cancel := bdWriteCtx()
 	defer cancel()
-	_, err := runBdCommand(ctx, args, m.workDir, m.beadsDir)
+	_, err := runBdCommand(ctx, args, m.workDir, beadsDir)
 	if err != nil {
 		if bdErr, ok := err.(*bdError); ok && bdErr.ContainsError("not found") {
 			return ErrMessageNotFound
@@ -1019,9 +1051,10 @@ func (m *Mailbox) ListByThread(threadID string) ([]*Message, error) {
 func (m *Mailbox) listByThreadBeads(threadID string) ([]*Message, error) {
 	args := []string{"message", "thread", threadID, "--json"}
 
+	beadsDir := m.resolveBeadsDirForID(threadID)
 	ctx, cancel := bdReadCtx()
 	defer cancel()
-	stdout, err := runBdCommand(ctx, args, m.workDir, m.beadsDir, "BD_IDENTITY="+m.identity)
+	stdout, err := runBdCommand(ctx, args, m.workDir, beadsDir, "BD_IDENTITY="+m.identity)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/mail/mailbox_test.go
+++ b/internal/mail/mailbox_test.go
@@ -704,3 +704,83 @@ func TestMailboxLegacyAtomicArchive(t *testing.T) {
 	}
 }
 
+func TestResolveBeadsDirForID(t *testing.T) {
+	townRoot := t.TempDir()
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a rig directory with its own .beads
+	rigDir := filepath.Join(townRoot, "site_manager")
+	rigBeadsDir := filepath.Join(rigDir, ".beads")
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write routes.jsonl mapping sm- prefix to site_manager
+	routesContent := `{"prefix":"hq-","path":"."}
+{"prefix":"sm-","path":"site_manager"}
+`
+	if err := os.WriteFile(filepath.Join(townBeadsDir, "routes.jsonl"), []byte(routesContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	m := &Mailbox{
+		identity: "mayor/",
+		workDir:  townRoot,
+		beadsDir: townBeadsDir,
+		townRoot: townRoot,
+	}
+
+	tests := []struct {
+		name     string
+		id       string
+		wantDir  string
+	}{
+		{
+			name:    "town-level bead uses default beadsDir",
+			id:      "hq-wisp-abc123",
+			wantDir: townBeadsDir,
+		},
+		{
+			name:    "rig-prefixed bead routes to rig beadsDir",
+			id:      "sm-wisp-xyz789",
+			wantDir: rigBeadsDir,
+		},
+		{
+			name:    "unknown prefix falls back to default beadsDir",
+			id:      "zz-wisp-unknown",
+			wantDir: townBeadsDir,
+		},
+		{
+			name:    "empty ID falls back to default beadsDir",
+			id:      "",
+			wantDir: townBeadsDir,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := m.resolveBeadsDirForID(tt.id)
+			if got != tt.wantDir {
+				t.Errorf("resolveBeadsDirForID(%q) = %q, want %q", tt.id, got, tt.wantDir)
+			}
+		})
+	}
+}
+
+func TestResolveBeadsDirForID_NoTownRoot(t *testing.T) {
+	m := &Mailbox{
+		identity: "mayor/",
+		workDir:  "/some/dir",
+		beadsDir: "/some/dir/.beads",
+		townRoot: "",
+	}
+
+	got := m.resolveBeadsDirForID("sm-wisp-abc123")
+	if got != "/some/dir/.beads" {
+		t.Errorf("without townRoot, resolveBeadsDirForID should return default beadsDir, got %q", got)
+	}
+}
+

--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -1545,7 +1545,9 @@ func isSelfMail(from, to string) bool {
 func (r *Router) GetMailbox(address string) (*Mailbox, error) {
 	beadsDir := r.resolveBeadsDir()
 	workDir := filepath.Dir(beadsDir) // Parent of .beads
-	return NewMailboxFromAddress(address, workDir), nil
+	mb := NewMailboxFromAddress(address, workDir)
+	mb.townRoot = r.townRoot
+	return mb, nil
 }
 
 // notifyRecipient sends a notification to a recipient's tmux session.


### PR DESCRIPTION
## Summary

- Mail operations (archive, delete, mark-read, mark-unread) failed with "not found" for rig-prefixed message IDs (e.g., `sm-wisp-*`, `pt-wisp-*`) because they only queried the town-level `.beads` database
- Added `resolveBeadsDirForID()` to `Mailbox` which extracts the bead ID prefix and resolves the correct rig `.beads` directory via `routes.jsonl`
- All single-bead operations (`Get`, `Delete`/`MarkRead`, `MarkReadOnly`, `MarkUnreadOnly`, `MarkUnread`, `ListByThread`) now route to the correct database

## Root Cause

`bd list` (used by inbox) has built-in cross-DB routing via `routes.jsonl`, so messages from all rigs appear in the inbox. However, `bd show`, `bd close`, and `bd label` operate on a single database specified by `BEADS_DIR`. When the mayor tried to archive a message like `sm-wisp-d6lo`, the `bd close` command looked in the town `.beads` (where `hq-*` beads live) instead of `site_manager/.beads` (where `sm-*` beads live).

## Changes

- `internal/mail/mailbox.go`: Added `townRoot` field and `resolveBeadsDirForID()` method; updated 6 methods to use prefix-based routing
- `internal/mail/router.go`: `GetMailbox()` now passes `townRoot` to the `Mailbox`
- `internal/mail/mailbox_test.go`: Added unit tests for cross-DB routing resolution

## Test plan

- [x] `TestResolveBeadsDirForID` — verifies routing for town-level, rig-prefixed, unknown-prefix, and empty IDs
- [x] `TestResolveBeadsDirForID_NoTownRoot` — verifies graceful fallback when no town root is set
- [x] Full `go test ./internal/mail/` passes (all existing tests unaffected)
- [x] `go build ./...` succeeds

Fixes: sm-zmop (Mayor cannot archive mail whose beads live in rig-specific DBs)

Made with [Cursor](https://cursor.com)