### PR TITLE
fix: agent-beads-exist check now verifies polecat beads

### DIFF
--- a/internal/doctor/agent_beads_check.go
+++ b/internal/doctor/agent_beads_check.go
@@ -171,6 +171,13 @@ func (c *AgentBeadsCheck) Run(ctx *CheckContext) *CheckResult {
 			crewID := beads.CrewBeadIDWithPrefix(prefix, rigName, workerName)
 			checkAgentBead(crewID)
 		}
+
+		// Check polecat agents
+		polecatWorkers := listPolecats(ctx.TownRoot, rigName)
+		for _, polecatName := range polecatWorkers {
+			polecatID := beads.PolecatBeadIDWithPrefix(prefix, rigName, polecatName)
+			checkAgentBead(polecatID)
+		}
 	}
 
 	if len(missing) == 0 && len(missingLabel) == 0 {
@@ -353,6 +360,17 @@ func (c *AgentBeadsCheck) Fix(ctx *CheckContext) error {
 			if err := fixAgentBead(bd, rigBeadsPath, crewID,
 				fmt.Sprintf("Crew worker %s in %s - human-managed persistent workspace.", workerName, rigName),
 				&beads.AgentFields{RoleType: "crew", Rig: rigName, AgentState: "idle"},
+			); err != nil {
+				errs = append(errs, err)
+			}
+		}
+
+		polecatWorkers := listPolecats(ctx.TownRoot, rigName)
+		for _, polecatName := range polecatWorkers {
+			polecatID := beads.PolecatBeadIDWithPrefix(prefix, rigName, polecatName)
+			if err := fixAgentBead(bd, rigBeadsPath, polecatID,
+				fmt.Sprintf("Polecat worker %s in %s - autonomous worker with persistent identity.", polecatName, rigName),
+				&beads.AgentFields{RoleType: "polecat", Rig: rigName, AgentState: "idle"},
 			); err != nil {
 				errs = append(errs, err)
 			}


### PR DESCRIPTION
## Summary

- `listPolecats` was defined in `agent_beads_check.go` but never called in `Run()` or `Fix()`
- As a result, polecat agent beads were not checked or created by `gt doctor --fix`
- Adds polecat bead checking in `Run()` and creation in `Fix()`, mirroring the existing crew worker pattern

Closes: gt-5f1skfj

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>