### PR TITLE
fix: route agent bead creation to wisps (ephemeral)

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -221,11 +221,8 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 			"--description=" + description,
 			"--type=agent",
 			"--labels=gt:agent",
+			"--ephemeral",
 		}
-		// Persistent polecats (gt-4ac): agent beads are non-ephemeral (issues table).
-		// They persist across polecat lifecycles and survive Dolt GC.
-		// Previously used --ephemeral (wisps table) but persistent polecats need
-		// durable agent state for idle detection and reuse.
 		if NeedsForceForID(id) {
 			a = append(a, "--force")
 		}
@@ -237,8 +234,8 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 		return a
 	}
 
-	// Create non-ephemeral agent bead (issues table). Persistent polecats (gt-4ac)
-	// need durable agent beads that survive across work assignments.
+	// Create ephemeral agent bead (wisps table). Agent operational state has
+	// zero git history consumers (gt-bewatn.9).
 	out, err := b.run(buildArgs()...)
 	if err != nil {
 		out, err = b.run(buildArgs()...)
@@ -341,13 +338,11 @@ func (b *Beads) CreateOrReopenAgentBead(id, title string, fields *AgentFields) (
 	if _, err := target.run("update", id, "--type=agent"); err != nil {
 		return nil, fmt.Errorf("fixing agent bead type: %w", err)
 	}
-	// Persistent polecats (gt-4ac): agent beads are non-ephemeral.
-	// Migrate any existing ephemeral (wisp) beads to the issues table
-	// by removing the ephemeral flag. This ensures agent state persists
-	// across polecat lifecycles for idle detection and reuse.
-	if _, err := target.run("update", id, "--persistent"); err != nil {
-		// Non-fatal: the bead is functional either way
-		// --persistent promotes wisp to issues table (bd update --help)
+	// Ensure agent bead is ephemeral (wisp) — agent operational state has
+	// zero git history consumers (gt-bewatn.9)
+	if _, err := target.run("update", id, "--ephemeral"); err != nil {
+		// Non-fatal: the bead is functional without ephemeral flag
+		_ = err
 	}
 
 	// Note: role slot no longer set - role definitions are config-based

--- a/internal/doctor/misclassified_wisp_check.go
+++ b/internal/doctor/misclassified_wisp_check.go
@@ -328,9 +328,10 @@ func (c *CheckMisclassifiedWisps) shouldBeWisp(id, title, issueType string, labe
 		return "merge-request type should be ephemeral"
 	}
 
-	// Agent type is NOT ephemeral: persistent polecats design (c410c10a) stores
-	// agent beads in the issues table for durability across polecat lifecycles.
-	// Previously flagged as ephemeral (gt-bewatn.9) but that was reversed.
+	// Check for agent type - agent operational state is ephemeral (gt-bewatn.9)
+	if issueType == "agent" {
+		return "agent type should be ephemeral"
+	}
 
 	// Check for event type - session/cost events are operational telemetry
 	if issueType == "event" {
@@ -355,9 +356,9 @@ func (c *CheckMisclassifiedWisps) shouldBeWisp(id, title, issueType string, labe
 		if label == "gt:mail" || label == "gt:handoff" {
 			return "mail/handoff label indicates ephemeral message"
 		}
-		// gt:agent label is NOT an ephemeral indicator: persistent polecats
-		// design (c410c10a) keeps agent beads in the issues table.
-		// Previously flagged here but that would undo the migration.
+		if label == "gt:agent" {
+			return "agent label indicates ephemeral operational state"
+		}
 	}
 
 	// Check for formula instance patterns in ID


### PR DESCRIPTION
## Summary

- Agent beads (type=agent, label `gt:agent`) are operational state with zero git history consumers
- Mark them ephemeral so they are excluded from JSONL export while remaining fully queryable
- `CreateAgentBead`: add `--ephemeral` flag to `bd create`
- `CreateOrReopenAgentBead`: mark existing beads ephemeral on re-open
- `misclassified_wisp_check`: detect non-ephemeral agent beads for `doctor --fix`
- Fixes the hq-deacon/hq-mayor cycle where Fix() creates beads in issues table and misclassified-wisps Fix() immediately moves them back

Closes: gt-2ivvsv1

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>