### PR TITLE
fix: sweep orphaned wisp_dependencies after compact

### DIFF
--- a/internal/cmd/compact.go
+++ b/internal/cmd/compact.go
@@ -34,10 +34,11 @@ var defaultTTLs = map[string]time.Duration{
 
 // compactResult tracks what happened to each wisp during compaction.
 type compactResult struct {
-	Promoted []compactAction `json:"promoted"`
-	Deleted  []compactAction `json:"deleted"`
-	Skipped  int             `json:"skipped"` // wisps still within TTL
-	Errors   []string        `json:"errors,omitempty"`
+	Promoted         []compactAction `json:"promoted"`
+	Deleted          []compactAction `json:"deleted"`
+	Skipped          int             `json:"skipped"`            // wisps still within TTL
+	OrphanedWispDeps int             `json:"orphaned_wisp_deps"` // stale wisp_dependencies removed
+	Errors           []string        `json:"errors,omitempty"`
 }
 
 type compactAction struct {
@@ -254,6 +255,14 @@ func runCompact(cmd *cobra.Command, args []string) error {
 		}
 	}
 
+	// Clean up orphaned wisp_dependencies left behind by deleted wisps.
+	// When bd delete removes a wisp, it doesn't cascade-delete dependency
+	// records in wisp_dependencies that reference the deleted wisp. Over many
+	// compaction cycles these accumulate as dangling refs. We sweep them here.
+	if !compactDryRun {
+		cleanOrphanedWispDeps(bd, result)
+	}
+
 	// Output results
 	if compactJSON {
 		enc := json.NewEncoder(os.Stdout)
@@ -263,6 +272,27 @@ func runCompact(cmd *cobra.Command, args []string) error {
 
 	printCompactSummary(result)
 	return nil
+}
+
+// cleanOrphanedWispDeps removes wisp_dependencies rows where either side no
+// longer exists in the wisps table. This happens when bd delete removes a wisp
+// but leaves behind its dependency records (bd delete has no cascade logic for
+// the wisp-level tables). Runs as a post-compact sweep.
+func cleanOrphanedWispDeps(bd *beads.Beads, result *compactResult) {
+	const q = `DELETE FROM wisp_dependencies WHERE ` +
+		`NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.issue_id) ` +
+		`OR NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_id)`
+	out, err := bd.Run("sql", q)
+	if err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("orphaned wisp_deps cleanup: %v", err))
+		return
+	}
+	// bd sql reports "OK, N rows affected" for non-SELECT statements.
+	// Parse the count if present; a non-zero result means refs were cleaned.
+	var n int
+	if _, scanErr := fmt.Sscanf(strings.TrimSpace(string(out)), "OK, %d rows affected", &n); scanErr == nil {
+		result.OrphanedWispDeps = n
+	}
 }
 
 // listWisps queries all ephemeral issues from the database.
@@ -364,6 +394,9 @@ func printCompactSummary(result *compactResult) {
 	fmt.Printf("  Promoted: %d\n", promoted)
 	fmt.Printf("  Deleted:  %d\n", deleted)
 	fmt.Printf("  Skipped:  %d (within TTL)\n", result.Skipped)
+	if result.OrphanedWispDeps > 0 {
+		fmt.Printf("  Cleaned:  %d orphaned wisp dependency ref(s)\n", result.OrphanedWispDeps)
+	}
 
 	if len(result.Errors) > 0 {
 		fmt.Printf("\n%s %d errors:\n", style.Warning.Render("⚠"), len(result.Errors))


### PR DESCRIPTION
## Summary

- `bd delete` removes wisps but doesn't cascade-delete rows in `wisp_dependencies` that reference the deleted wisp
- Over many compaction cycles these accumulate as dangling refs (179 parent-child + 2125 blocks = 2304 orphaned rows detected)
- Adds `cleanOrphanedWispDeps()` called at the end of `runCompact()`: single DELETE to purge `wisp_dependencies` rows where either side is no longer present in `wisps`
- Results reported in the compact summary and JSON output via new `orphaned_wisp_deps` field

Closes: gt-7y37lsv

🤖 Generated with [Claude Code](https://claude.com/claude-code)
Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>