### PR TITLE
fix: skip redirecting rigs in DatabasePrefixCheck to prevent shared DB corruption

### DIFF
--- a/internal/doctor/beads_check.go
+++ b/internal/doctor/beads_check.go
@@ -420,6 +420,25 @@ func (c *RoleLabelCheck) Fix(ctx *CheckContext) error {
 	return nil
 }
 
+// dbPrefixGetter abstracts querying the database for issue_prefix.
+// Allows mocking in tests without shelling out to bd.
+type dbPrefixGetter interface {
+	GetDBPrefix(rigPath string) (string, error)
+}
+
+// realDBPrefixGetter shells out to bd to query the database.
+type realDBPrefixGetter struct{}
+
+func (r *realDBPrefixGetter) GetDBPrefix(rigPath string) (string, error) {
+	cmd := exec.Command("bd", "config", "get", "issue_prefix")
+	cmd.Dir = rigPath
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
+}
+
 // DatabasePrefixCheck detects when a rig's database has a different issue_prefix
 // than what routes.jsonl specifies. This can happen when:
 // - The database was initialized with a different prefix
@@ -428,9 +447,15 @@ func (c *RoleLabelCheck) Fix(ctx *CheckContext) error {
 //
 // Unlike PrefixMismatchCheck (rigs.json ↔ routes.jsonl), this check verifies
 // the actual database configuration matches the routing table.
+//
+// Rigs that redirect to a shared database (e.g. the town root's .beads) are
+// skipped. Their database prefix is owned by the route that provides the
+// canonical database, not by the redirecting rig. Attempting to "fix" these
+// would overwrite the shared database's prefix with the rig's prefix.
 type DatabasePrefixCheck struct {
 	FixableCheck
-	mismatches []databasePrefixMismatch
+	mismatches     []databasePrefixMismatch
+	prefixGetter   dbPrefixGetter
 }
 
 type databasePrefixMismatch struct {
@@ -477,15 +502,26 @@ func (c *DatabasePrefixCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
-	// Check if bd command is available
-	if _, err := exec.LookPath("bd"); err != nil {
-		return &CheckResult{
-			Name:     c.Name(),
-			Status:   StatusOK,
-			Message:  "beads not installed (skipped)",
-			Category: c.Category(),
+	// Check if bd command is available (skip when using injected mock)
+	if c.prefixGetter == nil {
+		if _, err := exec.LookPath("bd"); err != nil {
+			return &CheckResult{
+				Name:     c.Name(),
+				Status:   StatusOK,
+				Message:  "beads not installed (skipped)",
+				Category: c.Category(),
+			}
 		}
 	}
+
+	getter := c.prefixGetter
+	if getter == nil {
+		getter = &realDBPrefixGetter{}
+	}
+
+	// Resolve the town root's canonical beads directory so we can detect
+	// rigs that redirect to the shared town database.
+	townBeadsDir, _ := filepath.Abs(beads.ResolveBeadsDir(ctx.TownRoot))
 
 	var problems []string
 
@@ -495,26 +531,30 @@ func (c *DatabasePrefixCheck) Run(ctx *CheckContext) *CheckResult {
 			continue
 		}
 
-		// Resolve the rig path and check beads directory exists
 		rigPath := filepath.Join(ctx.TownRoot, route.Path)
 		rigBeadsDir := beads.ResolveBeadsDir(rigPath)
 
 		// Check if beads directory exists
 		if _, err := os.Stat(rigBeadsDir); os.IsNotExist(err) {
-			continue // No beads dir for this rig
-		}
-
-		// Query database for issue_prefix by running bd from the rig directory
-		dbPrefix, err := c.getDBPrefix(rigPath)
-		if err != nil {
-			// No issue_prefix configured - that's OK
 			continue
 		}
 
-		// Normalize routes prefix (strip trailing hyphen)
+		// Skip rigs whose beads redirect resolves to the town root database.
+		// These rigs share the town DB; the prefix is owned by the town root
+		// route, not by this rig. "Fixing" them would overwrite the shared
+		// database's issue_prefix with the rig's route prefix.
+		absRigBeadsDir, _ := filepath.Abs(rigBeadsDir)
+		if absRigBeadsDir == townBeadsDir {
+			continue
+		}
+
+		dbPrefix, err := getter.GetDBPrefix(rigPath)
+		if err != nil {
+			continue
+		}
+
 		routesPrefix := strings.TrimSuffix(route.Prefix, "-")
 
-		// Compare prefixes
 		if dbPrefix != routesPrefix {
 			problems = append(problems, fmt.Sprintf("Route '%s': routes.jsonl says '%s', database has '%s'",
 				route.Path, routesPrefix, dbPrefix))
@@ -545,25 +585,14 @@ func (c *DatabasePrefixCheck) Run(ctx *CheckContext) *CheckResult {
 	}
 }
 
-// getDBPrefix queries the database for issue_prefix config value.
-// Runs bd from the rig directory so it discovers the correct database.
-func (c *DatabasePrefixCheck) getDBPrefix(rigPath string) (string, error) {
-	cmd := exec.Command("bd", "config", "get", "issue_prefix")
-	cmd.Dir = rigPath
-	output, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(output)), nil
-}
-
 // Fix updates database configs to match routes.jsonl prefixes.
+// Only fixes rigs with their own database; rigs that redirect to a shared
+// database are skipped by Run() and will not appear in c.mismatches.
 func (c *DatabasePrefixCheck) Fix(ctx *CheckContext) error {
-	// Re-run check to populate mismatches if needed
 	if len(c.mismatches) == 0 {
 		result := c.Run(ctx)
 		if result.Status == StatusOK {
-			return nil // Nothing to fix
+			return nil
 		}
 	}
 

--- a/internal/doctor/beads_check_test.go
+++ b/internal/doctor/beads_check_test.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -619,5 +620,232 @@ func TestDatabasePrefixCheck_NoBeadsDir(t *testing.T) {
 	// Should be OK - no beads dir for the rig is fine
 	if result.Status != StatusOK {
 		t.Errorf("expected StatusOK when rig beads dir doesn't exist, got %v", result.Status)
+	}
+}
+
+// mockDBPrefixGetter returns canned prefixes by directory for testing.
+type mockDBPrefixGetter struct {
+	prefixes   map[string]string // rigPath -> prefix
+	setCalls   []prefixSetCall   // recorded Fix calls (not used by getter, but handy for the mock)
+}
+
+type prefixSetCall struct {
+	rigPath string
+	prefix  string
+}
+
+func (m *mockDBPrefixGetter) GetDBPrefix(rigPath string) (string, error) {
+	if p, ok := m.prefixes[rigPath]; ok {
+		return p, nil
+	}
+	return "", fmt.Errorf("no prefix configured")
+}
+
+func TestDatabasePrefixCheck_SkipsRigRedirectingToTownDB(t *testing.T) {
+	// Layout:
+	//   <town>/.beads/           <- town root beads (prefix "hq")
+	//   <town>/site_manager/.beads/redirect -> "../.beads"  (shares town DB)
+	//   routes.jsonl has both {"prefix":"hq-","path":"."} and {"prefix":"sm-","path":"site_manager"}
+	//
+	// Before the fix, the check would see site_manager's DB prefix is "hq" (because
+	// it shares the town DB), flag it as a mismatch with "sm", and --fix would
+	// overwrite the shared DB's prefix to "sm", breaking the town.
+
+	tmpDir := t.TempDir()
+
+	// Town-level .beads
+	townBeads := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeads, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// routes.jsonl: town root + site_manager
+	routesContent := `{"prefix":"hq-","path":"."}
+{"prefix":"sm-","path":"site_manager"}`
+	if err := os.WriteFile(filepath.Join(townBeads, "routes.jsonl"), []byte(routesContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// site_manager/.beads/redirect -> ../.beads (shares town DB)
+	smBeads := filepath.Join(tmpDir, "site_manager", ".beads")
+	if err := os.MkdirAll(smBeads, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(smBeads, "redirect"), []byte("../.beads\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockDBPrefixGetter{
+		prefixes: map[string]string{
+			filepath.Join(tmpDir, "site_manager"): "hq",
+		},
+	}
+
+	check := NewDatabasePrefixCheck()
+	check.prefixGetter = mock
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK (redirect rig should be skipped), got %v: %s\nDetails: %v",
+			result.Status, result.Message, result.Details)
+	}
+	if len(check.mismatches) != 0 {
+		t.Errorf("expected 0 mismatches, got %d: %+v", len(check.mismatches), check.mismatches)
+	}
+}
+
+func TestDatabasePrefixCheck_DetectsMismatchForOwnDB(t *testing.T) {
+	// A rig with its own .beads (no redirect) that has a wrong prefix
+	// should still be detected as a mismatch.
+
+	tmpDir := t.TempDir()
+
+	townBeads := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeads, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	routesContent := `{"prefix":"hq-","path":"."}
+{"prefix":"mm-","path":"mission_manager"}`
+	if err := os.WriteFile(filepath.Join(townBeads, "routes.jsonl"), []byte(routesContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// mission_manager has its own .beads (no redirect)
+	mmBeads := filepath.Join(tmpDir, "mission_manager", ".beads")
+	if err := os.MkdirAll(mmBeads, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockDBPrefixGetter{
+		prefixes: map[string]string{
+			filepath.Join(tmpDir, "mission_manager"): "wrong",
+		},
+	}
+
+	check := NewDatabasePrefixCheck()
+	check.prefixGetter = mock
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning for prefix mismatch, got %v: %s", result.Status, result.Message)
+	}
+	if len(check.mismatches) != 1 {
+		t.Fatalf("expected 1 mismatch, got %d", len(check.mismatches))
+	}
+	m := check.mismatches[0]
+	if m.routesPrefix != "mm" || m.dbPrefix != "wrong" {
+		t.Errorf("unexpected mismatch data: routes=%q db=%q", m.routesPrefix, m.dbPrefix)
+	}
+}
+
+func TestDatabasePrefixCheck_MultipleRedirectsSameDB(t *testing.T) {
+	// Multiple rigs all redirect to the town DB. None should be flagged.
+
+	tmpDir := t.TempDir()
+
+	townBeads := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeads, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	routesContent := `{"prefix":"hq-","path":"."}
+{"prefix":"sm-","path":"site_manager"}
+{"prefix":"cr-","path":"camera_relay"}
+{"prefix":"au-","path":"autostart"}`
+	if err := os.WriteFile(filepath.Join(townBeads, "routes.jsonl"), []byte(routesContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// All three rigs redirect to town root
+	for _, rig := range []string{"site_manager", "camera_relay", "autostart"} {
+		rigBeads := filepath.Join(tmpDir, rig, ".beads")
+		if err := os.MkdirAll(rigBeads, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(rigBeads, "redirect"), []byte("../.beads\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mock := &mockDBPrefixGetter{
+		prefixes: map[string]string{
+			filepath.Join(tmpDir, "site_manager"): "hq",
+			filepath.Join(tmpDir, "camera_relay"): "hq",
+			filepath.Join(tmpDir, "autostart"):    "hq",
+		},
+	}
+
+	check := NewDatabasePrefixCheck()
+	check.prefixGetter = mock
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK (all redirect rigs skipped), got %v: %s\nDetails: %v",
+			result.Status, result.Message, result.Details)
+	}
+}
+
+func TestDatabasePrefixCheck_MixedOwnAndRedirect(t *testing.T) {
+	// Mix of rigs: some redirect to town DB (should be skipped), one has
+	// its own DB with a wrong prefix (should be flagged).
+
+	tmpDir := t.TempDir()
+
+	townBeads := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeads, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	routesContent := `{"prefix":"hq-","path":"."}
+{"prefix":"sm-","path":"site_manager"}
+{"prefix":"mm-","path":"mission_manager"}`
+	if err := os.WriteFile(filepath.Join(townBeads, "routes.jsonl"), []byte(routesContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// site_manager redirects to town DB
+	smBeads := filepath.Join(tmpDir, "site_manager", ".beads")
+	if err := os.MkdirAll(smBeads, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(smBeads, "redirect"), []byte("../.beads\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// mission_manager has its own DB (no redirect) with wrong prefix
+	mmBeads := filepath.Join(tmpDir, "mission_manager", ".beads")
+	if err := os.MkdirAll(mmBeads, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	mock := &mockDBPrefixGetter{
+		prefixes: map[string]string{
+			filepath.Join(tmpDir, "site_manager"):    "hq",
+			filepath.Join(tmpDir, "mission_manager"): "wrong",
+		},
+	}
+
+	check := NewDatabasePrefixCheck()
+	check.prefixGetter = mock
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning, got %v: %s", result.Status, result.Message)
+	}
+	if len(check.mismatches) != 1 {
+		t.Fatalf("expected 1 mismatch (only mission_manager), got %d: %+v",
+			len(check.mismatches), check.mismatches)
+	}
+	if check.mismatches[0].rigPath != "mission_manager" {
+		t.Errorf("expected mismatch for mission_manager, got %s", check.mismatches[0].rigPath)
 	}
 }


### PR DESCRIPTION
## Summary

- `DatabasePrefixCheck` assumed each rig has its own beads database. When rigs redirect to a shared town database (via `.beads/redirect`), the check would flag false prefix mismatches and `--fix` would overwrite the shared DB's `issue_prefix`, corrupting prefix routing for the entire town.
- Resolve each rig's beads directory and skip rigs whose resolved path matches the town root's beads directory — their prefix is owned by the town root route, not by the redirecting rig.
- Introduce `dbPrefixGetter` interface to enable testing without shelling out to `bd`.

Fixes #2409

## What changed

**`internal/doctor/beads_check.go`:**
- Add `dbPrefixGetter` interface + `realDBPrefixGetter` to allow mocking the `bd config get issue_prefix` call in tests
- In `Run()`, resolve the town root's canonical beads directory and skip any rig whose resolved beads directory matches it
- Update `Fix()` comments to clarify that shared-DB rigs are excluded by `Run()`

**`internal/doctor/beads_check_test.go`:**
- Add `mockDBPrefixGetter` for testing without `bd`
- `TestDatabasePrefixCheck_SkipsRigRedirectingToTownDB` — single rig redirecting to town DB is skipped
- `TestDatabasePrefixCheck_DetectsMismatchForOwnDB` — rig with its own DB and wrong prefix is still flagged
- `TestDatabasePrefixCheck_MultipleRedirectsSameDB` — multiple redirecting rigs all skipped
- `TestDatabasePrefixCheck_MixedOwnAndRedirect` — mix of redirecting and own-DB rigs: only the own-DB mismatch is flagged

## Test plan

- [x] All 4 new tests pass covering the redirect scenarios
- [x] All 3 existing `DatabasePrefixCheck` tests still pass
- [x] Full `go build ./internal/doctor/` compiles cleanly
- [ ] Manual test in a town with redirecting rigs: `gt doctor` no longer flags false prefix mismatches

Made with [Cursor](https://cursor.com)