### PR TITLE
fix(test): migrate hook_slot_integration_test Label→Labels

### DIFF
--- a/internal/cmd/hook_slot_integration_test.go
+++ b/internal/cmd/hook_slot_integration_test.go
@@ -114,7 +114,7 @@ func TestHookSlot_BasicHook(t *testing.T) {
 	// Create a test bead
 	issue, err := b.Create(beads.CreateOptions{
 		Title:    "Test task for hooking",
-		Label:    "gt:task",
+		Labels:   []string{"gt:task"},
 		Priority: 2,
 	})
 	if err != nil {
@@ -170,7 +170,7 @@ func TestHookSlot_Singleton(t *testing.T) {
 	// Create and hook first bead
 	issue1, err := b.Create(beads.CreateOptions{
 		Title:    "First task",
-		Label:    "gt:task",
+		Labels:   []string{"gt:task"},
 		Priority: 2,
 	})
 	if err != nil {
@@ -187,7 +187,7 @@ func TestHookSlot_Singleton(t *testing.T) {
 	// Create second bead
 	issue2, err := b.Create(beads.CreateOptions{
 		Title:    "Second task",
-		Label:    "gt:task",
+		Labels:   []string{"gt:task"},
 		Priority: 2,
 	})
 	if err != nil {
@@ -243,7 +243,7 @@ func TestHookSlot_Unhook(t *testing.T) {
 	// Create and hook a bead
 	issue, err := b.Create(beads.CreateOptions{
 		Title:    "Task to unhook",
-		Label:    "gt:task",
+		Labels:   []string{"gt:task"},
 		Priority: 2,
 	})
 	if err != nil {
@@ -306,7 +306,7 @@ func TestHookSlot_DifferentAgents(t *testing.T) {
 	// Create and hook bead to first agent
 	issue1, err := b.Create(beads.CreateOptions{
 		Title:    "Toast's task",
-		Label:    "gt:task",
+		Labels:   []string{"gt:task"},
 		Priority: 2,
 	})
 	if err != nil {
@@ -323,7 +323,7 @@ func TestHookSlot_DifferentAgents(t *testing.T) {
 	// Create and hook bead to second agent
 	issue2, err := b.Create(beads.CreateOptions{
 		Title:    "Nux's task",
-		Label:    "gt:task",
+		Labels:   []string{"gt:task"},
 		Priority: 2,
 	})
 	if err != nil {
@@ -391,7 +391,7 @@ func TestHookSlot_HookPersistence(t *testing.T) {
 	b1 := beads.New(rigDir)
 	issue, err := b1.Create(beads.CreateOptions{
 		Title:    "Persistent task",
-		Label:    "gt:task",
+		Labels:   []string{"gt:task"},
 		Priority: 2,
 	})
 	if err != nil {
@@ -445,7 +445,7 @@ func TestHookSlot_StatusTransitions(t *testing.T) {
 	// Create a bead
 	issue, err := b.Create(beads.CreateOptions{
 		Title:    "Status transition test",
-		Label:    "gt:task",
+		Labels:   []string{"gt:task"},
 		Priority: 2,
 	})
 	if err != nil {


### PR DESCRIPTION
## Summary
- `CreateOptions.Label` (string) was renamed to `Labels` ([]string) per #2317
- The 8 callsites in `hook_slot_integration_test.go` were not updated, causing build failures for integration tests

## Test plan
- [x] `go build ./internal/cmd/` succeeds
- [x] `go vet ./internal/cmd/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)