### PR TITLE
docs: add file-level GoDoc comments to 62 Go files

### DIFF
--- a/cmd/gt-proxy-server/config.go
+++ b/cmd/gt-proxy-server/config.go
@@ -1,3 +1,5 @@
+// config.go loads and validates the proxy server's JSON configuration,
+// which specifies TLS certificates, allowed commands, and listen address.
 package main
 
 import (

--- a/internal/quota/executor.go
+++ b/internal/quota/executor.go
@@ -1,3 +1,5 @@
+// Package quota implements automatic account rotation for rate-limited Claude
+// sessions, swapping OAuth tokens via tmux to maintain continuous operation.
 package quota
 
 import (

--- a/internal/quota/keychain.go
+++ b/internal/quota/keychain.go
@@ -1,5 +1,7 @@
 //go:build darwin
 
+// keychain.go reads and writes OAuth tokens in the macOS Keychain
+// to support account rotation without exposing credentials on disk.
 package quota
 
 import (

--- a/internal/quota/keychain_stub.go
+++ b/internal/quota/keychain_stub.go
@@ -1,5 +1,7 @@
 //go:build !darwin
 
+// keychain_stub.go provides no-op stubs for macOS Keychain operations
+// on non-Darwin platforms where the Keychain API is unavailable.
 package quota
 
 import (

--- a/internal/quota/rotate.go
+++ b/internal/quota/rotate.go
@@ -1,3 +1,5 @@
+// rotate.go plans account rotations by scanning for rate-limited sessions,
+// selecting replacement accounts, and validating their tokens before swap.
 package quota
 
 import (

--- a/internal/quota/scan.go
+++ b/internal/quota/scan.go
@@ -1,3 +1,5 @@
+// scan.go detects rate-limited and near-limit Claude sessions by examining
+// tmux pane content for quota exhaustion indicators.
 package quota
 
 import (

--- a/internal/refinery/batch.go
+++ b/internal/refinery/batch.go
@@ -1,3 +1,6 @@
+// batch.go implements the batch-then-bisect merge algorithm: groups merge
+// requests into batches, builds rebase stacks, and bisects on failure to
+// isolate the offending commit.
 package refinery
 
 import (

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -1,3 +1,5 @@
+// manager.go handles refinery lifecycle (start, stop, status) and coordinates
+// the merge queue using beads as the source of truth for pending requests.
 package refinery
 
 import (

--- a/internal/refinery/score.go
+++ b/internal/refinery/score.go
@@ -1,6 +1,5 @@
-// Package refinery provides the merge queue processing agent.
-// This file contains priority scoring logic for merge requests.
-
+// score.go contains priority scoring logic for merge requests,
+// using configurable weights to rank pending items in the queue.
 package refinery
 
 import (

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -1,3 +1,5 @@
+// manager.go handles rig lifecycle: adding and removing rigs, cloning
+// repositories, managing git worktrees, and persisting rig metadata.
 package rig
 
 import (

--- a/internal/rig/overlay.go
+++ b/internal/rig/overlay.go
@@ -1,3 +1,6 @@
+// overlay.go copies runtime overlay files (such as .env) from
+// .runtime/overlay/ into worktrees, and ensures .gitignore contains
+// required Gas Town patterns so runtime artifacts stay untracked.
 package rig
 
 import (

--- a/internal/scheduler/capacity/dispatch.go
+++ b/internal/scheduler/capacity/dispatch.go
@@ -1,3 +1,5 @@
+// dispatch.go orchestrates a single dispatch cycle: evaluates pending beads
+// against available capacity and invokes execute/success/failure callbacks.
 package capacity
 
 import (

--- a/internal/scheduler/capacity/pipeline.go
+++ b/internal/scheduler/capacity/pipeline.go
@@ -1,3 +1,6 @@
+// pipeline.go defines the core dispatch types (PendingBead, DispatchPlan,
+// DispatchParams) and the planning logic that selects which beads to dispatch
+// given current capacity constraints.
 package capacity
 
 import "strings"

--- a/internal/scheduler/capacity/state.go
+++ b/internal/scheduler/capacity/state.go
@@ -1,3 +1,5 @@
+// state.go persists scheduler runtime state (pause/resume flags and in-flight
+// dispatch tracking) to a JSON file so state survives process restarts.
 package capacity
 
 import (

--- a/internal/session/agent_logging_unix.go
+++ b/internal/session/agent_logging_unix.go
@@ -1,5 +1,7 @@
 //go:build !windows
 
+// agent_logging_unix.go spawns a detached gt agent-log process that streams
+// Claude Code's JSONL conversation log to an observability backend.
 package session
 
 import (

--- a/internal/session/agent_logging_windows.go
+++ b/internal/session/agent_logging_windows.go
@@ -1,5 +1,7 @@
 //go:build windows
 
+// agent_logging_windows.go provides no-op stubs for agent logging on Windows,
+// where the detached subprocess mechanism is not supported.
 package session
 
 // ActivateAgentLogging is a no-op on Windows: the detached subprocess relies on

--- a/internal/session/pidtrack.go
+++ b/internal/session/pidtrack.go
@@ -1,3 +1,5 @@
+// pidtrack.go writes and reads PID files with process birth timestamps so
+// orphan cleanup can safely distinguish stale PIDs from recycled ones.
 package session
 
 import (

--- a/internal/session/stale.go
+++ b/internal/session/stale.go
@@ -1,3 +1,5 @@
+// stale.go detects stale sessions by comparing the latest message timestamp
+// against session creation time to identify sessions that predate the current run.
 package session
 
 import (

--- a/internal/shell/integration.go
+++ b/internal/shell/integration.go
@@ -1,6 +1,5 @@
-// ABOUTME: Shell integration installation and removal for Gas Town.
-// ABOUTME: Manages the shell hook in RC files with safe block markers.
-
+// Package shell installs and removes the Gas Town shell hook in RC files
+// (bashrc, zshrc) using safe block markers for idempotent updates.
 package shell
 
 import (

--- a/internal/state/state.go
+++ b/internal/state/state.go
@@ -1,6 +1,5 @@
-// ABOUTME: Global state management for Gas Town enable/disable toggle.
-// ABOUTME: Uses XDG-compliant paths for per-machine state storage.
-
+// Package state manages the global Gas Town enable/disable toggle,
+// persisted to XDG-compliant paths for per-machine state storage.
 package state
 
 import (

--- a/internal/telemetry/subprocess.go
+++ b/internal/telemetry/subprocess.go
@@ -1,3 +1,5 @@
+// subprocess.go propagates OpenTelemetry resource attributes to subprocesses
+// by mapping Gas Town context variables into standard OTEL environment variables.
 package telemetry
 
 import (

--- a/internal/templates/townroot.go
+++ b/internal/templates/townroot.go
@@ -1,3 +1,5 @@
+// townroot.go provides the embedded CLAUDE.md template for town-root
+// initialization, with CLI name substitution and required section validation.
 package templates
 
 import (

--- a/internal/testutil/cmd.go
+++ b/internal/testutil/cmd.go
@@ -1,3 +1,5 @@
+// Package testutil provides test helpers for integration tests, including
+// bd/gt command builders with proper environment isolation and Dolt server management.
 package testutil
 
 import (

--- a/internal/testutil/doltserver.go
+++ b/internal/testutil/doltserver.go
@@ -1,5 +1,7 @@
 //go:build !windows
 
+// doltserver.go manages Dolt Docker containers for integration tests using
+// testcontainers-go, providing isolated database instances per test suite.
 package testutil
 
 import (

--- a/internal/testutil/doltserver_windows.go
+++ b/internal/testutil/doltserver_windows.go
@@ -1,5 +1,7 @@
 //go:build windows
 
+// doltserver_windows.go provides no-op stubs for Dolt Docker test containers
+// on Windows, where testcontainers-go is not supported.
 package testutil
 
 import (

--- a/internal/tmux/process_group_unix.go
+++ b/internal/tmux/process_group_unix.go
@@ -1,5 +1,7 @@
 //go:build !windows
 
+// process_group_unix.go provides Unix process group operations (kill group,
+// get PPID/PGID, find group members) for session cleanup and orphan detection.
 package tmux
 
 import (

--- a/internal/tmux/process_group_windows.go
+++ b/internal/tmux/process_group_windows.go
@@ -1,5 +1,7 @@
 //go:build windows
 
+// process_group_windows.go provides stub implementations of process group
+// operations on Windows, using tasklist as a fallback for process enumeration.
 package tmux
 
 import (

--- a/internal/tui/convoy/keys.go
+++ b/internal/tui/convoy/keys.go
@@ -1,3 +1,5 @@
+// Package convoy implements the interactive convoy browser TUI using Bubble Tea,
+// displaying convoy progress with expandable/collapsible issue trees.
 package convoy
 
 import "github.com/charmbracelet/bubbles/key"

--- a/internal/tui/convoy/model.go
+++ b/internal/tui/convoy/model.go
@@ -1,3 +1,5 @@
+// model.go defines the Bubble Tea model for the convoy browser, handling
+// data fetching, expand/collapse state, and keyboard navigation.
 package convoy
 
 import (

--- a/internal/tui/convoy/view.go
+++ b/internal/tui/convoy/view.go
@@ -1,3 +1,5 @@
+// view.go renders the convoy TUI display using lipgloss styles,
+// including tree connectors, progress indicators, and status coloring.
 package convoy
 
 import (

--- a/internal/tui/feed/convoy.go
+++ b/internal/tui/feed/convoy.go
@@ -1,3 +1,5 @@
+// convoy.go fetches and renders the convoy panel in the feed TUI,
+// displaying convoy progress bars and tracked issue summaries.
 package feed
 
 import (

--- a/internal/tui/feed/convoy_issues.go
+++ b/internal/tui/feed/convoy_issues.go
@@ -1,3 +1,5 @@
+// convoy_issues.go refreshes cross-rig issue statuses for convoy tracked
+// issues, querying each rig's beads database for up-to-date progress.
 package feed
 
 import (

--- a/internal/tui/feed/events.go
+++ b/internal/tui/feed/events.go
@@ -1,3 +1,5 @@
+// events.go defines event sources for the feed TUI: bd activity log tailing,
+// .events.jsonl file tailing, and a combined fan-in source.
 package feed
 
 import (

--- a/internal/tui/feed/keys.go
+++ b/internal/tui/feed/keys.go
@@ -1,3 +1,5 @@
+// keys.go defines the key bindings for the feed TUI, including navigation,
+// panel switching, and the problems view toggle.
 package feed
 
 import "github.com/charmbracelet/bubbles/key"

--- a/internal/tui/feed/model.go
+++ b/internal/tui/feed/model.go
@@ -1,3 +1,5 @@
+// model.go defines the main Bubble Tea model for the feed TUI, composing the
+// agent tree, convoy panel, event feed, and problems view into a unified dashboard.
 package feed
 
 import (

--- a/internal/tui/feed/mq_source.go
+++ b/internal/tui/feed/mq_source.go
@@ -1,3 +1,5 @@
+// mq_source.go is a deprecated stub for the merge queue event source,
+// retained for interface compatibility after mrqueue was removed.
 package feed
 
 import (

--- a/internal/tui/feed/multi_source.go
+++ b/internal/tui/feed/multi_source.go
@@ -1,3 +1,5 @@
+// multi_source.go provides a fan-in multiplexer that merges multiple
+// EventSources into a single ordered stream for the feed TUI.
 package feed
 
 import (

--- a/internal/tui/feed/print_events.go
+++ b/internal/tui/feed/print_events.go
@@ -1,3 +1,5 @@
+// print_events.go implements CLI event printing: reads .events.jsonl with
+// filtering (since, mol, type, rig) and optional follow mode for live tailing.
 package feed
 
 import (

--- a/internal/tui/feed/view.go
+++ b/internal/tui/feed/view.go
@@ -1,3 +1,5 @@
+// view.go renders the feed TUI layout: header, agent tree panel, convoy panel,
+// event feed panel, problems panel, and status bar.
 package feed
 
 import (

--- a/internal/ui/markdown.go
+++ b/internal/ui/markdown.go
@@ -1,3 +1,5 @@
+// markdown.go renders markdown content for terminal display using glamour,
+// with automatic terminal width detection for responsive formatting.
 package ui
 
 import (

--- a/internal/ui/pager.go
+++ b/internal/ui/pager.go
@@ -1,3 +1,5 @@
+// pager.go pipes long command output through a pager (less or the PAGER
+// environment variable) to avoid flooding the terminal.
 package ui
 
 import (

--- a/internal/ui/terminal.go
+++ b/internal/ui/terminal.go
@@ -1,3 +1,5 @@
+// terminal.go detects terminal capabilities: dark/light theme mode, color
+// depth, emoji support, and whether the process is running as an agent.
 package ui
 
 import (

--- a/internal/util/exec.go
+++ b/internal/util/exec.go
@@ -1,3 +1,5 @@
+// exec.go provides command execution helpers (ExecWithOutput, ExecRun) that
+// capture stderr for diagnostics and set up process groups to prevent orphans.
 package util
 
 import (

--- a/internal/util/exec_unix.go
+++ b/internal/util/exec_unix.go
@@ -1,5 +1,7 @@
 //go:build !windows
 
+// exec_unix.go configures process group IDs on child commands so that
+// killing the parent also terminates all descendants, preventing orphans.
 package util
 
 import (

--- a/internal/util/exec_windows.go
+++ b/internal/util/exec_windows.go
@@ -1,5 +1,7 @@
 //go:build windows
 
+// exec_windows.go provides a no-op stub for process group setup on Windows,
+// where the Unix Setpgid mechanism is not available.
 package util
 
 import "os/exec"

--- a/internal/util/orphan.go
+++ b/internal/util/orphan.go
@@ -1,5 +1,7 @@
 //go:build !windows
 
+// orphan.go detects orphaned and zombie Claude processes on Unix and performs
+// graceful cleanup with SIGTERM followed by SIGKILL escalation.
 package util
 
 import (

--- a/internal/util/orphan_windows.go
+++ b/internal/util/orphan_windows.go
@@ -1,5 +1,7 @@
 //go:build windows
 
+// orphan_windows.go provides stub implementations for orphaned and zombie
+// Claude process detection on Windows, where /proc is unavailable.
 package util
 
 // OrphanedProcess represents a claude process running without a controlling terminal.

--- a/internal/util/path.go
+++ b/internal/util/path.go
@@ -1,3 +1,5 @@
+// path.go expands the ~/ prefix in file paths to the user's home directory,
+// caching the home directory lookup for repeated calls.
 package util
 
 import (

--- a/internal/util/url.go
+++ b/internal/util/url.go
@@ -1,3 +1,5 @@
+// url.go redacts credentials from URLs so they can be safely included
+// in log output without leaking passwords or tokens.
 package util
 
 import (

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -1,3 +1,5 @@
+// api.go implements the REST API handler for the web dashboard, providing
+// command execution, session management, and options endpoints with CSRF protection.
 package web
 
 import (

--- a/internal/web/commands.go
+++ b/internal/web/commands.go
@@ -1,3 +1,5 @@
+// commands.go defines the dashboard command whitelist, blocked shell patterns,
+// input sanitization rules, and command palette metadata for the web UI.
 package web
 
 import (

--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -1,3 +1,5 @@
+// fetcher.go provides data fetchers for dashboard panels (convoys, workers,
+// mail, rigs, health checks) by invoking bd/gt subprocesses and parsing output.
 package web
 
 import (

--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -1,3 +1,5 @@
+// handler.go serves the convoy dashboard HTML page, orchestrating parallel
+// data fetches, template rendering, CSRF token injection, and static file serving.
 package web
 
 import (

--- a/internal/web/setup.go
+++ b/internal/web/setup.go
@@ -1,3 +1,5 @@
+// setup.go handles the first-run setup flow, guiding users through workspace
+// creation or detection when no Gas Town workspace exists yet.
 package web
 
 import (

--- a/internal/web/validate.go
+++ b/internal/web/validate.go
@@ -1,3 +1,5 @@
+// validate.go provides input validation for dashboard forms: IDs, rig names,
+// git URLs, mail addresses, and tilde-prefixed path expansion.
 package web
 
 import (

--- a/internal/wisp/io.go
+++ b/internal/wisp/io.go
@@ -1,3 +1,5 @@
+// io.go provides file I/O helpers for the beads directory: ensuring directory
+// existence, resolving bead file paths, and performing atomic JSON writes.
 package wisp
 
 import (

--- a/internal/witness/dedup.go
+++ b/internal/witness/dedup.go
@@ -1,3 +1,5 @@
+// dedup.go provides an in-memory message deduplicator that prevents the same
+// mail or event from being processed twice across witness patrol cycles.
 package witness
 
 import "sync"

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1,3 +1,5 @@
+// handlers.go implements mail and event handlers for the witness patrol cycle,
+// covering polecat lifecycle management, zombie session detection, and bead recovery.
 package witness
 
 import (

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -1,3 +1,5 @@
+// manager.go manages the witness agent lifecycle (start, stop, health checks)
+// using tmux sessions as the source of truth for running state.
 package witness
 
 import (

--- a/internal/witness/patrol_receipts.go
+++ b/internal/witness/patrol_receipts.go
@@ -1,3 +1,5 @@
+// patrol_receipts.go defines machine-readable patrol verdict structs that
+// classify zombie detection outcomes for structured logging and automation.
 package witness
 
 import "strings"

--- a/internal/witness/spawn_count.go
+++ b/internal/witness/spawn_count.go
@@ -1,3 +1,5 @@
+// spawn_count.go tracks bead respawn attempts and implements a circuit breaker
+// to prevent spawn storms when a bead repeatedly fails to start.
 package witness
 
 import (

--- a/internal/wrappers/wrappers.go
+++ b/internal/wrappers/wrappers.go
@@ -1,6 +1,5 @@
-// ABOUTME: Manages wrapper scripts for non-Claude agentic coding tools.
-// ABOUTME: Provides gt-codex and gt-opencode wrappers that run gt prime first.
-
+// Package wrappers installs and manages wrapper scripts for non-Claude agentic
+// coding tools (Codex, OpenCode), ensuring gt prime runs before each invocation.
 package wrappers
 
 import (


### PR DESCRIPTION
## Summary

- Adds file-level doc comments (before `package` line) to 62 Go files across the gastown codebase that were missing them
- Uses `// Package foo ...` convention for the first file alphabetically in each package, and `// filename.go ...` style for subsequent files
- Converts 3 legacy ABOUTME-style comments (`shell/integration.go`, `state/state.go`, `wrappers/wrappers.go`) to proper GoDoc format
- Fixes a stray blank line in `refinery/score.go` that disconnected its doc comment from the package declaration

Resolves bead gt-3e9.

## Test plan

- [x] `go build ./...` passes cleanly
- [ ] Verify `go doc` output renders correctly for affected packages
- [ ] Spot-check that no code logic was modified (comments only)

🤖 Generated with [Claude Code](https://claude.com/claude-code)