### PR TITLE
fix: resolve unparam lint warnings blocking CI on all PRs

### DIFF
--- a/internal/cmd/crew_list.go
+++ b/internal/cmd/crew_list.go
@@ -38,7 +38,7 @@ func runCrewList(cmd *cobra.Command, args []string) error {
 
 	var rigs []*rig.Rig
 	if crewListAll {
-		allRigs, _, err := getAllRigs()
+		allRigs, err := getAllRigs()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -422,7 +422,7 @@ func runPolecatList(cmd *cobra.Command, args []string) error {
 
 	if polecatListAll {
 		// List all rigs
-		allRigs, _, err := getAllRigs()
+		allRigs, err := getAllRigs()
 		if err != nil {
 			return err
 		}

--- a/internal/cmd/rig_helpers.go
+++ b/internal/cmd/rig_helpers.go
@@ -143,11 +143,11 @@ func IsRigParkedOrDocked(townRoot, rigName string) (bool, string) {
 }
 
 // getAllRigs discovers all rigs in the current Gas Town workspace.
-// Returns the list of rigs, the town root path, and any error.
-func getAllRigs() ([]*rig.Rig, string, error) {
+// Returns the list of rigs and any error.
+func getAllRigs() ([]*rig.Rig, error) {
 	townRoot, err := workspace.FindFromCwdOrError()
 	if err != nil {
-		return nil, "", fmt.Errorf("not in a Gas Town workspace: %w", err)
+		return nil, fmt.Errorf("not in a Gas Town workspace: %w", err)
 	}
 
 	rigsConfigPath := filepath.Join(townRoot, "mayor", "rigs.json")
@@ -160,8 +160,8 @@ func getAllRigs() ([]*rig.Rig, string, error) {
 	rigMgr := rig.NewManager(townRoot, rigsConfig, g)
 	rigs, err := rigMgr.DiscoverRigs()
 	if err != nil {
-		return nil, "", err
+		return nil, err
 	}
 
-	return rigs, townRoot, nil
+	return rigs, nil
 }

--- a/internal/cmd/wl_schema_evolution.go
+++ b/internal/cmd/wl_schema_evolution.go
@@ -60,8 +60,8 @@ func ClassifySchemaChange(local, upstream string) (SchemaChangeKind, error) {
 
 // readDoltSchemaVersion reads schema_version from the _meta table of a local
 // dolt fork. asOf specifies the branch/ref (e.g. "HEAD" or "upstream/main").
-// Returns ("", nil) when the _meta table or schema_version row does not exist.
-func readDoltSchemaVersion(doltPath, forkDir, asOf string) (string, error) {
+// Returns "" when the _meta table or schema_version row does not exist.
+func readDoltSchemaVersion(doltPath, forkDir, asOf string) string {
 	var query string
 	if asOf == "" || asOf == "HEAD" {
 		query = "SELECT value FROM _meta WHERE `key` = 'schema_version';"
@@ -77,16 +77,15 @@ func readDoltSchemaVersion(doltPath, forkDir, asOf string) (string, error) {
 	out, err := cmd.Output()
 	if err != nil {
 		// _meta may not exist on older forks — treat as unknown, not fatal.
-		return "", nil
+		return ""
 	}
 
 	// Output format: "value\n<version>\n"
 	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
 	if len(lines) < 2 {
-		return "", nil
+		return ""
 	}
-	version := strings.TrimSpace(lines[1])
-	return version, nil
+	return strings.TrimSpace(lines[1])
 }
 
 // checkSchemaEvolution fetches upstream version metadata and classifies any
@@ -99,13 +98,13 @@ func readDoltSchemaVersion(doltPath, forkDir, asOf string) (string, error) {
 // Returns (false, nil) when the fork lacks a _meta table or schema_version row
 // (pre-versioned fork) — the pull proceeds without interruption.
 func checkSchemaEvolution(doltPath, forkDir string, upgrade bool) error {
-	localVer, err := readDoltSchemaVersion(doltPath, forkDir, "HEAD")
-	if err != nil || localVer == "" {
+	localVer := readDoltSchemaVersion(doltPath, forkDir, "HEAD")
+	if localVer == "" {
 		return nil // pre-versioned fork — skip check
 	}
 
-	upstreamVer, err := readDoltSchemaVersion(doltPath, forkDir, "upstream/main")
-	if err != nil || upstreamVer == "" {
+	upstreamVer := readDoltSchemaVersion(doltPath, forkDir, "upstream/main")
+	if upstreamVer == "" {
 		return nil // upstream has no version info — skip check
 	}
 


### PR DESCRIPTION
## Summary

Two `unparam` lint warnings have been causing golangci-lint to fail on every PR, even when the PR touches unrelated files:

1. **`getAllRigs()`** (`rig_helpers.go:147`): returned a `string` (town root path) that no caller used. Removed the unused return value.
2. **`readDoltSchemaVersion()`** (`wl_schema_evolution.go:64`): returned `(string, error)` but error was always `nil`. Changed to return just `string`.

## Impact

This unblocks CI lint for all open PRs.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [ ] CI lint should now pass (the two reported warnings are eliminated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)