### PR TITLE
fix: preload witness env before tmux startup

### DIFF
--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -187,35 +187,22 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	// Generate the GASTA run ID for this witness session.
 	runID := uuid.New().String()
 
+	// Compute the full witness environment before starting tmux so the initial
+	// shell inherits witness identity instead of the caller's GT_ROLE/GT_SESSION.
+	// Setting tmux env after session creation is too late for SessionStart hooks.
+	envVars := buildWitnessSessionEnv(m.rig.Name, townRoot, sessionID, agentOverride, runID, runtimeConfig, roleConfig, envOverrides)
+
 	// Create session with command directly to avoid send-keys race condition.
+	// Pass env up front so the first shell sees the correct witness identity.
 	// See: https://github.com/anthropics/gastown/issues/280
-	if err := t.NewSessionWithCommand(sessionID, witnessDir, command); err != nil {
+	// See: https://github.com/steveyegge/gastown/issues/1289
+	if err := t.NewSessionWithCommandAndEnv(sessionID, witnessDir, command, envVars); err != nil {
 		return fmt.Errorf("creating tmux session: %w", err)
 	}
 
-	// Set environment variables (non-fatal: session works without these)
-	// Use centralized AgentEnv for consistency across all role startup paths
-	envVars := config.AgentEnv(config.AgentEnvConfig{
-		Role:        "witness",
-		Rig:         m.rig.Name,
-		TownRoot:    townRoot,
-		Agent:       agentOverride,
-		SessionName: sessionID,
-	})
-	envVars = session.MergeRuntimeLivenessEnv(envVars, runtimeConfig)
+	// Keep tmux's session environment table in sync for respawn/liveness checks.
 	for k, v := range envVars {
 		_ = t.SetEnvironment(sessionID, k, v)
-	}
-	_ = t.SetEnvironment(sessionID, "GT_RUN", runID)
-	// Apply role config env vars if present (non-fatal).
-	for key, value := range roleConfigEnvVars(roleConfig, townRoot, m.rig.Name) {
-		_ = t.SetEnvironment(sessionID, key, value)
-	}
-	// Apply CLI env overrides (highest priority, non-fatal).
-	for _, override := range envOverrides {
-		if key, value, ok := strings.Cut(override, "="); ok {
-			_ = t.SetEnvironment(sessionID, key, value)
-		}
 	}
 
 	// Apply Gas Town theming (non-fatal: theming failure doesn't affect operation)
@@ -287,6 +274,29 @@ func roleConfigEnvVars(roleConfig *beads.RoleConfig, townRoot, rigName string) m
 		expanded[key] = beads.ExpandRolePattern(value, townRoot, rigName, "", "witness", session.PrefixFor(rigName))
 	}
 	return expanded
+}
+
+func buildWitnessSessionEnv(rigName, townRoot, sessionID, agentOverride, runID string, runtimeConfig *config.RuntimeConfig, roleConfig *beads.RoleConfig, envOverrides []string) map[string]string {
+	envVars := config.AgentEnv(config.AgentEnvConfig{
+		Role:        "witness",
+		Rig:         rigName,
+		TownRoot:    townRoot,
+		Agent:       agentOverride,
+		SessionName: sessionID,
+	})
+	envVars = session.MergeRuntimeLivenessEnv(envVars, runtimeConfig)
+	envVars["GT_RUN"] = runID
+
+	for key, value := range roleConfigEnvVars(roleConfig, townRoot, rigName) {
+		envVars[key] = value
+	}
+	for _, override := range envOverrides {
+		if key, value, ok := strings.Cut(override, "="); ok {
+			envVars[key] = value
+		}
+	}
+
+	return envVars
 }
 
 func buildWitnessStartCommand(rigPath, rigName, townRoot, sessionName, agentOverride string, roleConfig *beads.RoleConfig) (string, error) {

--- a/internal/witness/manager_test.go
+++ b/internal/witness/manager_test.go
@@ -56,3 +56,34 @@ func TestBuildWitnessStartCommand_AgentOverrideWins(t *testing.T) {
 		t.Errorf("expected GT_ROLE=gastown/witness in command, got %q", got)
 	}
 }
+
+func TestBuildWitnessSessionEnv_MergesRoleConfigAndOverrides(t *testing.T) {
+	t.Parallel()
+	roleCfg := &beads.RoleConfig{
+		EnvVars: map[string]string{
+			"WITNESS_HOME": "{town}/{rig}/{role}",
+			"GT_ROLE":      "should-be-overridden",
+		},
+	}
+
+	got := buildWitnessSessionEnv("gastown", "/town", "gt-witness", "", "run-123", nil, roleCfg, []string{
+		"CUSTOM_FLAG=1",
+		"GT_ROLE=override/role",
+	})
+
+	if got["GT_RUN"] != "run-123" {
+		t.Fatalf("GT_RUN = %q, want %q", got["GT_RUN"], "run-123")
+	}
+	if got["WITNESS_HOME"] != "/town/gastown/witness" {
+		t.Fatalf("WITNESS_HOME = %q, want %q", got["WITNESS_HOME"], "/town/gastown/witness")
+	}
+	if got["CUSTOM_FLAG"] != "1" {
+		t.Fatalf("CUSTOM_FLAG = %q, want %q", got["CUSTOM_FLAG"], "1")
+	}
+	if got["GT_ROLE"] != "override/role" {
+		t.Fatalf("GT_ROLE = %q, want %q", got["GT_ROLE"], "override/role")
+	}
+	if got["BD_ACTOR"] != "gastown/witness" {
+		t.Fatalf("BD_ACTOR = %q, want %q", got["BD_ACTOR"], "gastown/witness")
+	}
+}


### PR DESCRIPTION
## Summary
  Preload witness session environment variables before the tmux shell starts so witnesses do not inherit the caller's `GT_ROLE`/`GT_SESSION`.

  ## Related Issue
  N/A

  ## Changes
  - Start witness sessions with `NewSessionWithCommandAndEnv(...)` so the initial shell gets the correct witness identity
  - Extract witness env assembly into `buildWitnessSessionEnv(...)`
  - Preserve merged runtime env, role-config env, CLI overrides, and `GT_RUN`
  - Add a regression test covering role-config env and CLI override merging

  ## Testing
  - [x] Unit tests pass (`go test ./internal/witness ./internal/tmux -run 'TestBuildWitness|TestNewSessionWithCommandAndEnv'`)
  - [x] Manual testing performed

  ## Checklist
  - [x] Code follows project style
  - [ ] Documentation updated (if applicable)
  - [x] No breaking changes (or documented in summary)