### PR TITLE
fix: resolve hook delivery failure for polecats

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -342,7 +342,13 @@ func (b *Beads) run(args ...string) (_ []byte, retErr error) {
 		return nil, b.wrapError(fmt.Errorf("command produced no output"), stderr.String(), args)
 	}
 
-	return stdout.Bytes(), nil
+	// Strip warning lines from stdout. bd may emit warnings (e.g.,
+	// "warning: beads.role not configured") to stdout, which corrupts
+	// JSON output and causes isJSONBytes to return false, silently
+	// dropping valid results. See: GH #TBD (hook delivery failure).
+	out := stripStdoutWarnings(stdout.Bytes())
+
+	return out, nil
 }
 
 // runWithRouting executes a bd command without setting BEADS_DIR, allowing bd's
@@ -376,7 +382,9 @@ func (b *Beads) runWithRouting(args ...string) (_ []byte, retErr error) { //noli
 		return nil, b.wrapError(fmt.Errorf("command produced no output"), stderr.String(), args)
 	}
 
-	return stdout.Bytes(), nil
+	out := stripStdoutWarnings(stdout.Bytes())
+
+	return out, nil
 }
 
 // Run executes a bd command and returns stdout.
@@ -582,6 +590,32 @@ func (b *Beads) List(opts ListOptions) ([]*Issue, error) {
 	}
 
 	return issues, nil
+}
+
+// stripStdoutWarnings removes warning/diagnostic lines that bd may emit to stdout.
+// bd sometimes prints "warning: ..." lines to stdout instead of stderr, which
+// corrupts JSON output. This strips those lines so downstream JSON parsing works.
+func stripStdoutWarnings(data []byte) []byte {
+	// Fast path: no warning prefix present
+	if !bytes.Contains(data, []byte("warning:")) {
+		return data
+	}
+
+	lines := bytes.Split(data, []byte("\n"))
+	var cleaned [][]byte
+	stripped := false
+	for _, line := range lines {
+		if bytes.HasPrefix(bytes.TrimSpace(line), []byte("warning:")) {
+			stripped = true
+			continue
+		}
+		cleaned = append(cleaned, line)
+	}
+
+	if !stripped {
+		return data
+	}
+	return bytes.Join(cleaned, []byte("\n"))
 }
 
 // isJSONBytes returns true if the byte slice starts with [ or { (after whitespace).

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -386,19 +386,29 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 		if err == nil && beads.IsAgentBead(agentBead) {
 			status.AgentBeadID = agentBeadID
 
-			// Read hook_bead from the agent bead's database field (not description!)
-			// The hook_bead column is updated by `bd slot set` in UpdateAgentState.
-			// IMPORTANT: Don't use ParseAgentFields on description - the description
-			// field may contain stale data, causing the wrong issue to be hooked.
-			if agentBead.HookBead != "" {
+			// Read hook_bead: first try the database column, then fall back to
+			// parsing the description. The hook_bead column was maintained by
+			// bd slot set, but slot writes were removed in hq-l6mm5. The
+			// description's hook_bead field is now the authoritative source,
+			// written atomically at spawn time by polecat manager.
+			hookBeadID := agentBead.HookBead
+			if hookBeadID == "" {
+				// Column empty — parse from description (post-hq-l6mm5 path)
+				fields := beads.ParseAgentFields(agentBead.Description)
+				if fields.HookBead != "" && fields.HookBead != "null" {
+					hookBeadID = fields.HookBead
+				}
+			}
+
+			if hookBeadID != "" {
 				// The hooked bead may be in a different database than the agent bead.
 				// Resolve its path using prefix-based routing.
-				hookBeadPath := beads.ResolveHookDir(townRoot, agentBead.HookBead, workDir)
+				hookBeadPath := beads.ResolveHookDir(townRoot, hookBeadID, workDir)
 				hookB := b
 				if hookBeadPath != workDir {
 					hookB = beads.New(hookBeadPath)
 				}
-				hookBead, err = hookB.Show(agentBead.HookBead)
+				hookBead, err = hookB.Show(hookBeadID)
 				if err != nil {
 					// Hook bead referenced but not found - report error but continue
 					hookBead = nil


### PR DESCRIPTION
## Summary

Polecats couldn't find their hooked work after `hq-l6mm5` removed hook_bead slot writes. Every polecat spawned via `gt sling` would immediately terminate with "Nothing on hook - no work slung."

**Root cause — two compounding bugs:**

1. **`molecule_status.go`**: Read `hook_bead` exclusively from the agent bead's database column (line 393), which is always empty since `hq-l6mm5` removed slot writes. The description field — written atomically at spawn time — is now the authoritative source but was never consulted.

2. **`beads.go`**: The fallback path (`bd list --status=hooked --assignee=<agent>`) was also broken because `bd` v0.59.0 emits `warning:` lines to stdout, which corrupts JSON output. `isJSONBytes()` returns false on `warning: beads.role not configured\n[{...}]`, and `List()` silently returns nil.

**Fixes:**

- **`molecule_status.go`**: When `agentBead.HookBead` column is empty, fall back to `ParseAgentFields(description)` to read `hook_bead` from the description text
- **`beads.go`**: Add `stripStdoutWarnings()` to `run()` and `runWithRouting()` — strips `warning:` lines from bd stdout before returning, preventing JSON parse corruption

## Test plan

- [x] Verified fix with patched binary: `gt mol status --json` returns `has_work: true`
- [x] Full end-to-end: `gt sling` → polecat finds work → implements feature → passes gates → `gt done` → self-cleans
- [x] Existing unit tests pass (`go test ./internal/beads/... ./internal/cmd/...`)
- [ ] Add unit test for `stripStdoutWarnings`
- [ ] Add test for description fallback in molecule_status

🤖 Generated with [Claude Code](https://claude.com/claude-code)