### PR TITLE
fix(mq): fail submit/done when MR read-back verification fails

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -768,9 +768,17 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		}
 
 		if existingMR != nil {
+			if _, verifyErr := verifyMergeRequestPersisted(bd, existingMR.ID, branch); verifyErr != nil {
+				mrFailed = true
+				errMsg := fmt.Sprintf("existing MR verification failed (id=%s): %v", existingMR.ID, verifyErr)
+				doneErrors = append(doneErrors, errMsg)
+				style.PrintWarning("%s\nBranch is pushed but MR bead not confirmed. Preserving worktree.", errMsg)
+				goto notifyWitness
+			}
+
 			// MR already exists - use it instead of creating a new one
 			mrID = existingMR.ID
-			fmt.Printf("%s MR already exists (idempotent)\n", style.Bold.Render("✓"))
+			fmt.Printf("%s MR already exists (idempotent, verified)\n", style.Bold.Render("✓"))
 			fmt.Printf("  MR ID: %s\n", style.Bold.Render(mrID))
 		} else {
 			// Build MR bead title and description
@@ -832,11 +840,9 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				goto notifyWitness
 			}
 
-			// GH#1945: Verify MR bead is readable before considering it confirmed.
-			// bd.Create() succeeds when the bead is written locally, but if the write
-			// didn't persist (Dolt failure, corrupt state), we'd nuke the worktree
-			// with no MR in the queue — losing the polecat's work permanently.
-			if verifiedMR, verifyErr := bd.Show(mrID); verifyErr != nil || verifiedMR == nil {
+			// GH#1945 + hq-tb2zw: Verify MR bead is readable and structurally valid
+			// before considering it confirmed.
+			if _, verifyErr := verifyMergeRequestPersisted(bd, mrID, branch); verifyErr != nil {
 				mrFailed = true
 				errMsg := fmt.Sprintf("MR bead created but verification read-back failed (id=%s): %v", mrID, verifyErr)
 				doneErrors = append(doneErrors, errMsg)

--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -238,8 +238,14 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 		nudgeRefinery(rigName, "MERGE_READY received - check inbox for pending work")
 	}
 
+	verifiedMR, verifyErr := verifyMergeRequestPersisted(bd, mrIssue.ID, branch)
+	if verifyErr != nil {
+		return fmt.Errorf("merge request bead verification failed (id=%s): %w", mrIssue.ID, verifyErr)
+	}
+	mrIssue = verifiedMR
+
 	// Success output
-	fmt.Printf("%s Submitted to merge queue\n", style.Bold.Render("✓"))
+	fmt.Printf("%s Submitted to merge queue (verified)\n", style.Bold.Render("✓"))
 	fmt.Printf("  MR ID: %s\n", style.Bold.Render(mrIssue.ID))
 	fmt.Printf("  Source: %s\n", branch)
 	fmt.Printf("  Target: %s\n", target)

--- a/internal/cmd/mr_verification.go
+++ b/internal/cmd/mr_verification.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+// verifyMergeRequestPersisted loads an MR by ID and validates it is a real
+// merge-request record for the expected branch.
+func verifyMergeRequestPersisted(bd *beads.Beads, mrID, expectedBranch string) (*beads.Issue, error) {
+	if strings.TrimSpace(mrID) == "" {
+		return nil, fmt.Errorf("empty MR ID")
+	}
+
+	issue, err := bd.Show(mrID)
+	if err != nil {
+		return nil, fmt.Errorf("read-back failed: %w", err)
+	}
+	if err := verifyMergeRequestRecord(issue, expectedBranch); err != nil {
+		return nil, err
+	}
+
+	return issue, nil
+}
+
+// verifyMergeRequestRecord validates the core invariants for a merge-request bead.
+func verifyMergeRequestRecord(issue *beads.Issue, expectedBranch string) error {
+	if issue == nil {
+		return fmt.Errorf("MR read-back returned nil issue")
+	}
+	if !beads.HasLabel(issue, "gt:merge-request") {
+		return fmt.Errorf("missing gt:merge-request label")
+	}
+
+	fields := beads.ParseMRFields(issue)
+	if fields == nil || strings.TrimSpace(fields.Branch) == "" {
+		return fmt.Errorf("missing branch metadata in MR description")
+	}
+
+	if expectedBranch != "" && fields.Branch != expectedBranch {
+		return fmt.Errorf("branch mismatch: expected %q, got %q", expectedBranch, fields.Branch)
+	}
+
+	return nil
+}

--- a/internal/cmd/mr_verification_test.go
+++ b/internal/cmd/mr_verification_test.go
@@ -1,0 +1,78 @@
+package cmd
+
+import (
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func TestVerifyMergeRequestRecord(t *testing.T) {
+	tests := []struct {
+		name           string
+		issue          *beads.Issue
+		expectedBranch string
+		wantErr        bool
+	}{
+		{
+			name:           "valid MR record",
+			expectedBranch: "polecat/furiosa/gt-abc@mk123",
+			issue: &beads.Issue{
+				Labels: []string{"gt:merge-request"},
+				Description: "branch: polecat/furiosa/gt-abc@mk123\n" +
+					"target: main\nsource_issue: gt-abc",
+			},
+			wantErr: false,
+		},
+		{
+			name:           "nil issue",
+			expectedBranch: "polecat/furiosa/gt-abc@mk123",
+			issue:          nil,
+			wantErr:        true,
+		},
+		{
+			name:           "missing merge-request label",
+			expectedBranch: "polecat/furiosa/gt-abc@mk123",
+			issue: &beads.Issue{
+				Labels:      []string{"gt:task"},
+				Description: "branch: polecat/furiosa/gt-abc@mk123",
+			},
+			wantErr: true,
+		},
+		{
+			name:           "missing branch metadata",
+			expectedBranch: "polecat/furiosa/gt-abc@mk123",
+			issue: &beads.Issue{
+				Labels:      []string{"gt:merge-request"},
+				Description: "target: main\nsource_issue: gt-abc",
+			},
+			wantErr: true,
+		},
+		{
+			name:           "branch mismatch",
+			expectedBranch: "polecat/furiosa/gt-abc@mk123",
+			issue: &beads.Issue{
+				Labels:      []string{"gt:merge-request"},
+				Description: "branch: polecat/furiosa/gt-def@mk123\ntarget: main",
+			},
+			wantErr: true,
+		},
+		{
+			name:           "branch check can be skipped",
+			expectedBranch: "",
+			issue: &beads.Issue{
+				Labels:      []string{"gt:merge-request"},
+				Description: "branch: polecat/furiosa/gt-def@mk123\ntarget: main",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := verifyMergeRequestRecord(tt.issue, tt.expectedBranch)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("verifyMergeRequestRecord() error = %v, wantErr %v", err, tt.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- Adds shared `verifyMergeRequestPersisted` helper that validates MR bead read-back, `gt:merge-request` label presence, and branch match
- `gt mq submit` now returns non-zero if the MR bead cannot be verified after creation
- `gt done` verifies both existing-MR and newly-created-MR paths, preserving the worktree on failure instead of silently succeeding
- Adds regression tests covering nil issue, missing label, missing branch metadata, branch mismatch, and valid cases

## Context

Observed during engagekiosk/furiosa recovery (2026-03-04): `gt done` and `gt mq submit` printed success with MR IDs, but `bd show` and `gt mq status` couldn't find them. This caused witness recovery loops (NEEDS_MQ_SUBMIT / not_submitted) and required manual mayor intervention.

Root cause: success was reported before verifying the MR bead actually persisted to the beads store.

## Test plan

- [x] `go test ./internal/cmd/ -run TestVerifyMergeRequestRecord` — all 6 cases pass
- [ ] Manual: run `gt done` in a polecat with valid work — should print "verified" on success
- [ ] Manual: simulate bead store failure — should exit non-zero with actionable error

Fixes: hq-tb2zw

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>