### PR TITLE
fix: always delete polecat branches after merge

### DIFF
--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -964,8 +964,12 @@ func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
 		}
 	}
 
-	// 2. Delete source branch if configured (local and remote)
-	if e.config.DeleteMergedBranches && mr.Branch != "" {
+	// 2. Delete source branch (local and remote).
+	// Polecat branches (polecat/*) are always cleaned up — they are ephemeral
+	// work branches that should never persist after merge. Other branches
+	// respect the DeleteMergedBranches config.
+	isPolecat := strings.HasPrefix(mr.Branch, "polecat/")
+	if mr.Branch != "" && (e.config.DeleteMergedBranches || isPolecat) {
 		if err := e.git.DeleteBranch(mr.Branch, true); err != nil {
 			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to delete local branch %s: %v\n", mr.Branch, err)
 		} else {


### PR DESCRIPTION
## Summary
- Polecat branches (`polecat/*`) are now always cleaned up after merge, regardless of the `DeleteMergedBranches` config setting
- Previously, if a rig had `DeleteMergedBranches=false`, polecat branches would persist on origin with no associated PR, looking like abandoned work
- The `DeleteMergedBranches` config now only controls non-polecat feature branches

Closes #2435

## Test plan
- [ ] With `DeleteMergedBranches=true`: verify polecat branches still deleted (no regression)
- [ ] With `DeleteMergedBranches=false`: verify polecat branches are now deleted, but non-polecat branches are preserved
- [ ] Verify deletion failures are non-fatal (warning logged, merge still succeeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)