### PR TITLE
fix: handle non-JSON output from bd list in ListOpenSlingContexts

### DIFF
--- a/internal/beads/beads_sling_context.go
+++ b/internal/beads/beads_sling_context.go
@@ -102,9 +102,8 @@ func (b *Beads) ListOpenSlingContexts() ([]*Issue, error) {
 		return nil, err
 	}
 
-	// Handle empty output
-	trimmed := strings.TrimSpace(string(out))
-	if trimmed == "" || trimmed == "null" {
+	// Handle empty or non-JSON output (bd list --json returns "No issues found." when empty)
+	if len(out) == 0 || !isJSONBytes(out) {
 		return nil, nil
 	}
 


### PR DESCRIPTION
## Problem

`gt scheduler status`, `gt scheduler list`, and `gt scheduler run` all fail with:

```
Error: listing scheduled beads: parsing sling context list: invalid character 'N' looking for beginning of value
```

This happens when there are no scheduled beads. `bd list --json` returns `"No issues found."` plain text (not `[]`) when the result set is empty. The previous check in `ListOpenSlingContexts` only handled `""` and `"null"`, so the non-JSON text fell through to `json.Unmarshal` and errored.

## Fix

Use the existing `isJSONBytes()` helper (already in `beads.go` for the same reason) to detect non-JSON output and return `nil, nil`.

## Impact

Without this fix, the scheduler is completely broken on first use — before any beads are scheduled, every `gt scheduler` command errors out, blocking the deferred dispatch workflow entirely.

## Testing

Reproduce: `gt config set scheduler.max_polecats 4`, then `gt scheduler status` with no scheduled beads — was: parse error, now: clean empty status.