### PR TITLE
fix: prevent tmux socket split-brain causing nudge failures

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -199,6 +199,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewDefaultBranchAllRigsCheck())
 	d.Register(doctor.NewIdentityCollisionCheck())
 	d.Register(doctor.NewLinkedPaneCheck())
+	d.Register(doctor.NewSocketSplitBrainCheck())
 	d.Register(doctor.NewThemeCheck())
 	d.Register(doctor.NewCrashReportCheck())
 	d.Register(doctor.NewEnvVarsCheck())

--- a/internal/doctor/tmux_socket_check.go
+++ b/internal/doctor/tmux_socket_check.go
@@ -1,0 +1,132 @@
+package doctor
+
+import (
+	"fmt"
+	"sort"
+
+	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// SocketSplitBrainCheck detects tmux sessions that exist on both the town
+// socket (e.g., "gt") and the "default" socket. This split-brain causes
+// gt nudge and other session-discovery commands to fail because they only
+// search the town socket.
+type SocketSplitBrainCheck struct {
+	FixableCheck
+	staleSessions []string // Sessions on "default" that also exist on town socket
+}
+
+// NewSocketSplitBrainCheck creates a new socket split-brain check.
+func NewSocketSplitBrainCheck() *SocketSplitBrainCheck {
+	return &SocketSplitBrainCheck{
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "socket-split-brain",
+				CheckDescription: "Detect tmux sessions on wrong socket (causes nudge failures)",
+				CheckCategory:    CategoryInfrastructure,
+			},
+		},
+	}
+}
+
+// Run checks for Gas Town sessions on the "default" socket that duplicate
+// sessions on the town socket.
+func (c *SocketSplitBrainCheck) Run(ctx *CheckContext) *CheckResult {
+	townSocket := tmux.GetDefaultSocket()
+	if townSocket == "" || townSocket == "default" {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "Town socket is default — no split-brain possible",
+		}
+	}
+
+	// List sessions on both sockets
+	townTmux := tmux.NewTmux()
+	defaultTmux := tmux.NewTmuxWithSocket("default")
+
+	townSessions, err := townTmux.ListSessions()
+	if err != nil {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "Could not list town socket sessions (server may not be running)",
+		}
+	}
+
+	defaultSessions, err := defaultTmux.ListSessions()
+	if err != nil {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "No default socket server running — no split-brain",
+		}
+	}
+
+	// Build set of town socket sessions
+	townSet := make(map[string]bool, len(townSessions))
+	for _, s := range townSessions {
+		townSet[s] = true
+	}
+
+	// Find Gas Town sessions on default that are duplicates or orphans
+	var duplicates []string
+	var orphans []string
+
+	for _, s := range defaultSessions {
+		if !session.IsKnownSession(s) {
+			continue // Not a Gas Town session
+		}
+		if townSet[s] {
+			duplicates = append(duplicates, s)
+		} else {
+			orphans = append(orphans, s)
+		}
+	}
+
+	c.staleSessions = append(duplicates, orphans...)
+	sort.Strings(c.staleSessions)
+
+	if len(c.staleSessions) == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: fmt.Sprintf("No split-brain: all Gas Town sessions on %q socket", townSocket),
+		}
+	}
+
+	var details []string
+	for _, s := range duplicates {
+		details = append(details, fmt.Sprintf("DUPLICATE: %s exists on both %q and \"default\" sockets", s, townSocket))
+	}
+	for _, s := range orphans {
+		details = append(details, fmt.Sprintf("ORPHAN: %s only on \"default\" socket (should be on %q)", s, townSocket))
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusError,
+		Message: fmt.Sprintf("Found %d Gas Town session(s) on wrong socket — nudge/discovery will fail", len(c.staleSessions)),
+		Details: details,
+		FixHint: "Run 'gt doctor --fix' to kill stale sessions on wrong socket",
+	}
+}
+
+// Fix kills Gas Town sessions on the "default" socket that shouldn't be there.
+func (c *SocketSplitBrainCheck) Fix(ctx *CheckContext) error {
+	if len(c.staleSessions) == 0 {
+		return nil
+	}
+
+	defaultTmux := tmux.NewTmuxWithSocket("default")
+	var lastErr error
+
+	for _, s := range c.staleSessions {
+		if err := defaultTmux.KillSessionWithProcesses(s); err != nil {
+			lastErr = err
+		}
+	}
+
+	return lastErr
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -302,6 +302,11 @@ func (t *Tmux) NewSessionWithCommandAndEnv(name, workDir, command string, env ma
 	if err := validateSessionName(name); err != nil {
 		return err
 	}
+
+	// Kill stale same-named sessions on other sockets to prevent split-brain.
+	// This is best-effort: failures are silently ignored.
+	t.killSplitBrainSession(name)
+
 	if workDir != "" {
 		info, err := os.Stat(workDir)
 		if err != nil {
@@ -661,6 +666,24 @@ func (t *Tmux) KillSessionWithProcessesExcluding(name string, excludePIDs []stri
 		return nil
 	}
 	return err
+}
+
+// killSplitBrainSession kills a same-named session on the "default" tmux socket
+// if this Tmux instance targets a different socket. This prevents split-brain
+// where stale sessions on the wrong socket shadow the real ones, causing nudge
+// and other session-discovery commands to fail.
+//
+// Best-effort: all errors are silently ignored. The stale session may not exist,
+// the default server may not be running, etc. — none of these should block
+// session creation on the correct socket.
+func (t *Tmux) killSplitBrainSession(name string) {
+	if t.socketName == "" || t.socketName == "default" || t.socketName == noTownSocket {
+		return // Already on default or no town context — nothing to clean up
+	}
+	other := NewTmuxWithSocket("default")
+	if running, _ := other.HasSession(name); running {
+		_ = other.KillSessionWithProcesses(name)
+	}
 }
 
 // collectReparentedGroupMembers returns process group members that have been


### PR DESCRIPTION
## Summary
- **Session creation guard**: Before creating a session on the town socket (e.g., `gt`), `NewSessionWithCommandAndEnv` now kills any stale same-named session on the `default` socket. This prevents split-brain where `gt nudge` can't find sessions on the wrong socket.
- **Doctor check**: New `socket-split-brain` check detects Gas Town sessions on the `default` socket that should be on the town socket. Reports duplicates (exist on both) and orphans (only on `default`). Fixable via `gt doctor --fix`.

## Root Cause
When a process (e.g., mayor) starts on the `default` tmux socket (due to older binary or env mismatch), it spawns crew/polecat sessions that inherit the wrong socket. Later restarts create correct sessions on the `gt` socket, but the stale `default` sessions persist. `gt nudge` only searches the town socket and fails to find sessions on `default`.

Closes #2441

## Test plan
- [ ] `go build ./...` passes
- [ ] Start a session on `default` socket manually, then start same session via `gt` — verify stale session on `default` is killed
- [ ] `gt doctor` reports split-brain when sessions exist on wrong socket
- [ ] `gt doctor --fix` kills stale sessions on wrong socket

🤖 Generated with [Claude Code](https://claude.com/claude-code)