### PR TITLE
fix: auto-purge closed ephemeral beads on session end

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -1260,6 +1260,12 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) {
 
 	// No ClearHookBead call needed — agent bead hook slot is no longer maintained (hq-l6mm5).
 
+	// Purge closed ephemeral beads (wisps) accumulated during this and prior sessions.
+	// Without this, closed wisps from mol-polecat-work steps, mol-witness-patrol cycles,
+	// etc. accumulate across sessions and pollute bd ready/list output (hq-6161m).
+	// Best-effort: failures are non-fatal since the work is already done.
+	purgeClosedEphemeralBeads(bd)
+
 	// Self-managed completion (gt-1qlg, polecat-self-managed-completion.md Phase 2):
 	// Polecat sets agent_state=idle directly, skipping the intermediate "done" state.
 	// The witness is no longer in the critical path for routine completions.
@@ -1440,4 +1446,25 @@ func selfKillSession(townRoot string, roleInfo RoleInfo) error {
 	}
 
 	return nil
+}
+
+// purgeClosedEphemeralBeads removes closed ephemeral beads (wisps) that accumulated
+// during this and prior sessions. Polecat/witness sessions create mol-polecat-work
+// steps, mol-witness-patrol cycles, etc. as wisps. These get closed during normal
+// operation but are never deleted, accumulating hundreds of rows that pollute
+// bd ready/list output. (hq-6161m)
+//
+// Best-effort: errors are logged but don't block gt done completion.
+func purgeClosedEphemeralBeads(bd *beads.Beads) {
+	out, err := bd.Run("purge", "--force", "--quiet")
+	if err != nil {
+		// Non-fatal: purge failure shouldn't block session completion
+		fmt.Fprintf(os.Stderr, "Warning: wisp purge failed: %v\n", err)
+		return
+	}
+	// bd purge --force --quiet outputs the count of purged beads
+	outStr := strings.TrimSpace(string(out))
+	if outStr != "" && outStr != "0" {
+		fmt.Fprintf(os.Stderr, "Purged closed ephemeral beads: %s\n", outStr)
+	}
 }

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1357,6 +1357,11 @@ func nukePolecatFull(polecatName, rigName string, mgr *polecat.Manager, r *rig.R
 		fmt.Printf("  %s closed agent bead %s\n", style.Success.Render("✓"), agentBeadID)
 	}
 
+	// Step 6: Purge closed ephemeral beads (wisps) accumulated during sessions.
+	// Without this, closed wisps from mol-polecat-work steps, mol-witness-patrol
+	// cycles, etc. accumulate across sessions and pollute bd ready/list (hq-6161m).
+	purgeClosedEphemeralBeads(bd)
+
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Polecat and witness sessions create mol-polecat-work steps, mol-witness-patrol cycles, and other wisps that get closed during normal operation but are never deleted. These accumulate across sessions (observed 419+126 stale beads in production) and pollute `bd ready/list` output.

- Add `purgeClosedEphemeralBeads()` helper that calls `bd purge --force --quiet`
- Call it from `gt done` after closing hooked bead, before agent state transition
- Call it from `gt polecat nuke` after molecule cleanup

Best-effort: purge failures are logged as warnings but don't block completion.

Fixes: hq-6161m

## Test plan

- [x] `go build ./internal/cmd/` passes
- [x] `go vet ./internal/cmd/` passes
- [x] `go test -run TestDone ./internal/cmd/` passes
- [ ] Manual verification: run `bd purge --dry-run` before/after `gt done` to confirm accumulation stops

Generated with [Claude Code](https://claude.com/claude-code)