### PR TITLE
Fix Dockerfile Go download for multi-arch support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,8 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 # Install Go from official tarball (apt golang-go is too old)
-RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -C /usr/local -xz
+ARG TARGETARCH
+RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${TARGETARCH}.tar.gz" | tar -C /usr/local -xz
 ENV PATH="/usr/local/go/bin:/home/agent/go/bin:${PATH}"
 
 # Install beads (bd) and dolt


### PR DESCRIPTION
## Summary
- Replace hardcoded `linux-amd64` in Go download URL with `${TARGETARCH}` (set automatically by Docker BuildKit)
- Enables building the image on Apple Silicon (arm64) and other architectures

## Test plan
- [ ] Build on amd64: `docker build --platform linux/amd64 -t gastown:latest .`
- [ ] Build on arm64: `docker build --platform linux/arm64 -t gastown:latest .`