### PR TITLE
fix: check rig-level metadata before town-level beads redirect

### DIFF
--- a/internal/beads/beads_redirect.go
+++ b/internal/beads/beads_redirect.go
@@ -2,6 +2,7 @@
 package beads
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -178,14 +179,39 @@ func ComputeRedirectTarget(townRoot, worktreePath string) (string, error) {
 		return "", fmt.Errorf("cannot create redirect in canonical beads location (mayor/rig)")
 	}
 
-	rigRoot := filepath.Join(townRoot, parts[0])
+	rigName := parts[0]
+	rigRoot := filepath.Join(townRoot, rigName)
+	townBeadsPath := filepath.Join(townRoot, ".beads")
 	rigBeadsPath := filepath.Join(rigRoot, ".beads")
 	mayorBeadsPath := filepath.Join(rigRoot, "mayor", "rig", ".beads")
 
-	// Check rig-level .beads first, fall back to mayor/rig/.beads (tracked beads architecture).
-	// For dolt backend, the actual database lives at mayor/rig/.beads/dolt/, not at rig/.beads/.
-	// The rig-root .beads/ only has metadata.json (runtime state). If rig/.beads exists but has
-	// no database (no dolt/), redirect to mayor/rig/.beads where the DB is.
+	// Check rig-level .beads first: if the rig has its own database
+	// (metadata.json with dolt_database), crew must use rig-level beads
+	// so they see the correct prefix (e.g., lc- for laneassist, not hq-).
+	if rigHasOwnDB(rigBeadsPath) {
+		depth := len(parts) - 1
+		upPath := strings.Repeat("../", depth)
+		return upPath + ".beads", nil
+	}
+
+	// Rig has no own database — try town-level .beads (has routes.jsonl,
+	// config.yaml, Dolt server info, and hq- prefix).
+	townBeadsHasDB := false
+	if info, err := os.Stat(townBeadsPath); err == nil && info.IsDir() {
+		if _, err := os.Stat(filepath.Join(townBeadsPath, "dolt")); err == nil {
+			townBeadsHasDB = true
+		} else if _, err := os.Stat(filepath.Join(townBeadsPath, "config.yaml")); err == nil {
+			townBeadsHasDB = true
+		}
+	}
+
+	if townBeadsHasDB {
+		depth := len(parts)
+		upPath := strings.Repeat("../", depth)
+		return upPath + ".beads", nil
+	}
+
+	// Neither rig nor town has a database — fall back to rig-level beads.
 	usesMayorFallback := false
 	rigBeadsExists := false
 	if _, err := os.Stat(rigBeadsPath); err == nil {
@@ -207,7 +233,7 @@ func ComputeRedirectTarget(townRoot, worktreePath string) (string, error) {
 		// Rig .beads doesn't exist or has no database — check mayor/rig/.beads
 		if _, err := os.Stat(mayorBeadsPath); os.IsNotExist(err) {
 			if !rigBeadsExists {
-				return "", fmt.Errorf("no beads found at %s or %s", rigBeadsPath, mayorBeadsPath)
+				return "", fmt.Errorf("no beads found at %s, %s, or %s", townBeadsPath, rigBeadsPath, mayorBeadsPath)
 			}
 			// Rig .beads exists but has no DB and mayor path doesn't exist either.
 			// Fall through to use rig path (best effort).
@@ -326,4 +352,22 @@ func IsLocalBeadsDir(cwd, resolvedPath string) bool {
 	cleanResolved, _ := filepath.Abs(resolvedPath)
 	cleanLocal, _ := filepath.Abs(localBeads)
 	return cleanResolved == cleanLocal
+}
+
+// rigHasOwnDB checks if a rig's .beads/metadata.json declares its own
+// dolt_database. Rigs with their own database (e.g., laneassist with "lc-"
+// prefix) must not be redirected to town-level beads ("hq-" prefix).
+func rigHasOwnDB(rigBeadsPath string) bool {
+	metadataPath := filepath.Join(rigBeadsPath, "metadata.json")
+	data, err := os.ReadFile(metadataPath) //nolint:gosec // G304: trusted beads path
+	if err != nil {
+		return false
+	}
+	var meta struct {
+		DoltDatabase string `json:"dolt_database"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return false
+	}
+	return meta.DoltDatabase != ""
 }

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -1897,14 +1897,100 @@ func TestDelegationTerms(t *testing.T) {
 
 // TestSetupRedirect tests the beads redirect setup for worktrees.
 func TestSetupRedirect(t *testing.T) {
-	t.Run("crew worktree with local beads", func(t *testing.T) {
-		// Setup: town/rig/.beads (local, no redirect)
+	t.Run("rig with own DB redirects to rig-level beads", func(t *testing.T) {
+		// When rig has its own dolt_database in metadata.json, crew must
+		// redirect to rig-level .beads (not town-level) to see correct prefix.
+		townRoot := t.TempDir()
+		townBeads := filepath.Join(townRoot, ".beads")
+		rigRoot := filepath.Join(townRoot, "testrig")
+		rigBeads := filepath.Join(rigRoot, ".beads")
+		crewPath := filepath.Join(rigRoot, "crew", "max")
+
+		// Create both town-level and rig-level beads
+		if err := os.MkdirAll(filepath.Join(townBeads, "dolt"), 0755); err != nil {
+			t.Fatalf("mkdir town beads: %v", err)
+		}
+		if err := os.MkdirAll(rigBeads, 0755); err != nil {
+			t.Fatalf("mkdir rig beads: %v", err)
+		}
+		// Rig has its own database (e.g., laneassist with lc- prefix)
+		meta := []byte(`{"dolt_database":"testrig","backend":"dolt"}`)
+		if err := os.WriteFile(filepath.Join(rigBeads, "metadata.json"), meta, 0644); err != nil {
+			t.Fatalf("write metadata: %v", err)
+		}
+		if err := os.MkdirAll(crewPath, 0755); err != nil {
+			t.Fatalf("mkdir crew: %v", err)
+		}
+
+		if err := SetupRedirect(townRoot, crewPath); err != nil {
+			t.Fatalf("SetupRedirect failed: %v", err)
+		}
+
+		redirectPath := filepath.Join(crewPath, ".beads", "redirect")
+		content, err := os.ReadFile(redirectPath)
+		if err != nil {
+			t.Fatalf("read redirect: %v", err)
+		}
+
+		// 2 levels up to rig root: crew/max -> testrig, then .beads
+		want := "../../.beads\n"
+		if string(content) != want {
+			t.Errorf("redirect content = %q, want %q", string(content), want)
+		}
+
+		// Verify redirect resolves to rig-level, NOT town-level
+		resolved := ResolveBeadsDir(crewPath)
+		if resolved != rigBeads {
+			t.Errorf("resolved = %q, want %q (rig-level)", resolved, rigBeads)
+		}
+	})
+
+	t.Run("rig without own DB redirects to town-level beads", func(t *testing.T) {
+		// When rig has no own database, crew should use town-level .beads.
+		townRoot := t.TempDir()
+		townBeads := filepath.Join(townRoot, ".beads")
+		rigRoot := filepath.Join(townRoot, "testrig")
+		crewPath := filepath.Join(rigRoot, "crew", "max")
+
+		// Create town-level beads with dolt DB
+		if err := os.MkdirAll(filepath.Join(townBeads, "dolt"), 0755); err != nil {
+			t.Fatalf("mkdir town beads: %v", err)
+		}
+		if err := os.MkdirAll(crewPath, 0755); err != nil {
+			t.Fatalf("mkdir crew: %v", err)
+		}
+
+		if err := SetupRedirect(townRoot, crewPath); err != nil {
+			t.Fatalf("SetupRedirect failed: %v", err)
+		}
+
+		redirectPath := filepath.Join(crewPath, ".beads", "redirect")
+		content, err := os.ReadFile(redirectPath)
+		if err != nil {
+			t.Fatalf("read redirect: %v", err)
+		}
+
+		// 3 levels up: crew/max -> testrig -> townRoot, then .beads
+		want := "../../../.beads\n"
+		if string(content) != want {
+			t.Errorf("redirect content = %q, want %q", string(content), want)
+		}
+
+		// Verify redirect resolves to town-level
+		resolved := ResolveBeadsDir(crewPath)
+		if resolved != townBeads {
+			t.Errorf("resolved = %q, want %q", resolved, townBeads)
+		}
+	})
+
+	t.Run("crew worktree falls back to rig-level beads", func(t *testing.T) {
+		// When neither rig metadata nor town-level .beads exists, fall back to rig-level (2 levels up).
 		townRoot := t.TempDir()
 		rigRoot := filepath.Join(townRoot, "testrig")
 		rigBeads := filepath.Join(rigRoot, ".beads")
 		crewPath := filepath.Join(rigRoot, "crew", "max")
 
-		// Create rig structure
+		// Create rig-level beads only (no town-level, no metadata.json)
 		if err := os.MkdirAll(rigBeads, 0755); err != nil {
 			t.Fatalf("mkdir rig beads: %v", err)
 		}


### PR DESCRIPTION
## Summary
- Fix beads redirect to check rig-level `metadata.json` for `dolt_database` BEFORE falling back to town-level `.beads`
- Rigs with their own database (e.g., laneassist with `lc-` prefix) now correctly redirect crew to rig-level `.beads`
- Fixes regression from b99b7568 which unconditionally preferred town-level, breaking non-gastown rig routing

## What broke
The previous redirect fix (b99b7568, hq-x1ucu) always sent crew worktrees to town-level `.beads` (hq- prefix) when it had a DB. This meant laneassist crew saw `hq-` beads instead of `lc-` beads.

## Fix
Check `<rig>/.beads/metadata.json` for `dolt_database` first. If present, the rig has its own DB and crew must redirect there. Only fall back to town-level when the rig has no own database.

## Test plan
- [x] New test: `rig_with_own_DB_redirects_to_rig-level_beads` — rig with metadata.json gets rig-level redirect
- [x] Renamed test: `rig_without_own_DB_redirects_to_town-level_beads` — rig without metadata gets town-level
- [x] All 14 redirect subtests pass
- [x] `go vet` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)