### PR TITLE
fix: include beads_prefix in gt rig list --json output

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -697,12 +697,13 @@ func runRigList(cmd *cobra.Command, args []string) error {
 	t := tmux.NewTmux()
 
 	type rigInfo struct {
-		Name     string `json:"name"`
-		Status   string `json:"status"`
-		Witness  string `json:"witness"`
-		Refinery string `json:"refinery"`
-		Polecats int    `json:"polecats"`
-		Crew     int    `json:"crew"`
+		Name        string `json:"name"`
+		BeadsPrefix string `json:"beads_prefix"`
+		Status      string `json:"status"`
+		Witness     string `json:"witness"`
+		Refinery    string `json:"refinery"`
+		Polecats    int    `json:"polecats"`
+		Crew        int    `json:"crew"`
 		// sorting fields (not exported to JSON)
 		sortPrio int
 	}
@@ -710,16 +711,18 @@ func runRigList(cmd *cobra.Command, args []string) error {
 	var rigs []rigInfo
 
 	for name := range rigsConfig.Rigs {
+		prefix := session.PrefixFor(name)
+
 		r, err := mgr.GetRig(name)
 		if err != nil {
-			rigs = append(rigs, rigInfo{Name: name, Status: "error", sortPrio: 99})
+			rigs = append(rigs, rigInfo{Name: name, BeadsPrefix: prefix, Status: "error", sortPrio: 99})
 			continue
 		}
 
 		opState, _ := getRigOperationalState(townRoot, name)
 
-		witnessSession := session.WitnessSessionName(session.PrefixFor(name))
-		refinerySession := session.RefinerySessionName(session.PrefixFor(name))
+		witnessSession := session.WitnessSessionName(prefix)
+		refinerySession := session.RefinerySessionName(prefix)
 		witnessRunning, _ := t.HasSession(witnessSession)
 		refineryRunning, _ := t.HasSession(refinerySession)
 
@@ -734,13 +737,14 @@ func runRigList(cmd *cobra.Command, args []string) error {
 
 		summary := r.Summary()
 		rigs = append(rigs, rigInfo{
-			Name:     name,
-			Status:   strings.ToLower(opState),
-			Witness:  witnessStatus,
-			Refinery: refineryStatus,
-			Polecats: summary.PolecatCount,
-			Crew:     summary.CrewCount,
-			sortPrio: rigStatePriority(witnessRunning, refineryRunning, opState),
+			Name:        name,
+			BeadsPrefix: prefix,
+			Status:      strings.ToLower(opState),
+			Witness:     witnessStatus,
+			Refinery:    refineryStatus,
+			Polecats:    summary.PolecatCount,
+			Crew:        summary.CrewCount,
+			sortPrio:    rigStatePriority(witnessRunning, refineryRunning, opState),
 		})
 	}
 


### PR DESCRIPTION
## Summary
- `gt rig list --json` only included rig names (e.g., `gastown`, `laneassist`), not beads prefixes (`gt`, `lc`)
- Agents like session-hygiene dog that use this output couldn't match prefix-based tmux session names (`gt-crew-bear`, `lc-polecat-slit`) and killed them as zombies
- Adds `beads_prefix` field to the JSON output

## Context
Companion to PR #2421 (session-hygiene plugin fix). That PR fixes the plugin script to read `rigs.json` directly. This PR ensures `gt rig list --json` also provides prefixes, so if an AI agent deviates from the script and uses the CLI instead, it still gets the right data.

## Example output
```json
[
  {
    "name": "gastown",
    "beads_prefix": "gt",
    "status": "running",
    ...
  }
]
```

## Test plan
- [x] `go build ./...` clean
- [x] JSON output includes `beads_prefix` field

Bead: hq-jz80q

🤖 Generated with [Claude Code](https://claude.com/claude-code)