### PR TITLE
fix: EnsureMetadata repairs stale dolt_server_port

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -2480,6 +2480,9 @@ func EnsureMetadata(townRoot, rigName string) error {
 		_ = json.Unmarshal(data, &existing) // best effort
 	}
 
+	// Resolve the authoritative server config (config.yaml > env > daemon.json > default).
+	config := DefaultConfig(townRoot)
+
 	// Patch dolt server fields. Only write when values actually change so tracked
 	// metadata.json files in source repos stay clean.
 	changed := false
@@ -2497,6 +2500,21 @@ func EnsureMetadata(townRoot, rigName string) error {
 	}
 	if existing["dolt_database"] == nil || existing["dolt_database"] == "" {
 		existing["dolt_database"] = rigName
+		changed = true
+	}
+
+	// Ensure server connection fields match the authoritative config.
+	// bd reads dolt_server_host and dolt_server_port from metadata.json to
+	// connect to the Dolt server. Stale values (e.g., port 13729 from a
+	// previous bd init) cause "connection refused" errors.
+	wantHost := config.EffectiveHost()
+	wantPort := float64(config.Port) // JSON numbers are float64
+	if existing["dolt_server_host"] != wantHost {
+		existing["dolt_server_host"] = wantHost
+		changed = true
+	}
+	if existing["dolt_server_port"] != wantPort {
+		existing["dolt_server_port"] = wantPort
 		changed = true
 	}
 

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -1470,6 +1470,56 @@ func TestEnsureMetadata_RepairsMissingDoltFields(t *testing.T) {
 	}
 }
 
+// TestEnsureMetadata_RepairsStalePort tests that EnsureMetadata overwrites
+// a stale dolt_server_port (e.g., 13729 from a previous bd init) with the
+// correct port from DefaultConfig. This is the root cause of "connection
+// refused" errors reported by community users after gt dolt fix-metadata.
+func TestEnsureMetadata_RepairsStalePort(t *testing.T) {
+	townRoot := t.TempDir()
+
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate stale metadata with wrong port (13729 instead of 3307)
+	stale := map[string]interface{}{
+		"backend":          "dolt",
+		"database":         "dolt",
+		"dolt_mode":        "server",
+		"dolt_database":    "hq",
+		"dolt_server_host": "127.0.0.1",
+		"dolt_server_port": 13729,
+	}
+	data, _ := json.Marshal(stale)
+	metaPath := filepath.Join(beadsDir, "metadata.json")
+	if err := os.WriteFile(metaPath, data, 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := EnsureMetadata(townRoot, "hq"); err != nil {
+		t.Fatalf("EnsureMetadata failed: %v", err)
+	}
+
+	repaired, err := os.ReadFile(metaPath)
+	if err != nil {
+		t.Fatalf("reading metadata: %v", err)
+	}
+	var meta map[string]interface{}
+	if err := json.Unmarshal(repaired, &meta); err != nil {
+		t.Fatalf("parsing metadata: %v", err)
+	}
+
+	// Port should now be the default (3307), not the stale 13729
+	wantPort := float64(DefaultPort)
+	if meta["dolt_server_port"] != wantPort {
+		t.Errorf("dolt_server_port = %v, want %v", meta["dolt_server_port"], wantPort)
+	}
+	if meta["dolt_server_host"] != "127.0.0.1" {
+		t.Errorf("dolt_server_host = %v, want 127.0.0.1", meta["dolt_server_host"])
+	}
+}
+
 // TestEnsureAllMetadata_RepairsAllCorrupt tests that EnsureAllMetadata
 // repairs metadata for all known databases, even if some are corrupt.
 func TestEnsureAllMetadata_RepairsAllCorrupt(t *testing.T) {


### PR DESCRIPTION
## Summary
- `EnsureMetadata` (called by `gt dolt fix-metadata`) now reads `DefaultConfig` and repairs `dolt_server_host` / `dolt_server_port` in `metadata.json`
- Previously these fields were never written by `EnsureMetadata`, so stale values from `bd init` (e.g. port 13729) persisted and caused "connection refused" errors
- Adds `TestEnsureMetadata_RepairsStalePort` covering the exact scenario

## Context
Community users (Ellipsoul, Envoy9692) reported that `bd doctor` / `bd list` fail with "connection refused" after `gt dolt fix-metadata` because `metadata.json` still contains a stale port from `bd init`. This fix ensures `fix-metadata` always reconciles the port with the authoritative config chain (config.yaml > GT_DOLT_PORT env > daemon.json > DefaultPort 3307).

## Test plan
- [x] `go test ./internal/doltserver/ -run TestEnsureMetadata` — all 9 tests pass
- [x] `go build ./...` — clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)