### PR TITLE
fix: add --rig flag to gt crew start for consistency with stop

### DIFF
--- a/internal/cmd/crew.go
+++ b/internal/cmd/crew.go
@@ -387,6 +387,7 @@ func init() {
 	crewRestartCmd.Flags().BoolVar(&crewAll, "all", false, "Restart all running crew sessions")
 	crewRestartCmd.Flags().BoolVar(&crewDryRun, "dry-run", false, "Show what would be restarted without restarting")
 
+	crewStartCmd.Flags().StringVar(&crewRig, "rig", "", "Rig to start crew in (alternative to positional rig arg)")
 	crewStartCmd.Flags().BoolVar(&crewAll, "all", false, "Start all crew members in the rig")
 	crewStartCmd.Flags().StringVar(&crewAccount, "account", "", "Claude Code account handle to use")
 	crewStartCmd.Flags().StringVar(&crewAgentOverride, "agent", "", "Agent alias to run crew worker with (overrides rig/town default)")

--- a/internal/cmd/crew_lifecycle.go
+++ b/internal/cmd/crew_lifecycle.go
@@ -264,7 +264,11 @@ func runCrewStart(cmd *cobra.Command, args []string) error {
 	var rigName string
 	var crewNames []string
 
-	if len(args) == 0 {
+	// --rig flag takes priority (matches crew stop behavior)
+	if crewRig != "" {
+		rigName = crewRig
+		crewNames = args
+	} else if len(args) == 0 {
 		// No args - infer rig from cwd
 		rigName = "" // getCrewManager will infer from cwd
 	} else {


### PR DESCRIPTION
## Summary
- `gt crew stop --rig laneassist gisele` works, but `gt crew start --rig laneassist gisele` fails with "unknown flag: --rig"
- Adds `--rig` flag to `crewStartCmd` matching `crewStopCmd` behavior
- Positional rig arg (`gt crew start laneassist gisele`) still works as before

## Test plan
- [ ] `gt crew start --rig <rig> <name>` starts crew member in specified rig
- [ ] `gt crew start <rig> <name>` still works (positional arg)
- [ ] `gt crew start --rig <rig> --all` starts all crew in rig
- [ ] `gt crew stop --rig <rig> <name>` still works (no regression)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>