### PR TITLE
fix: prevent TOML env from overwriting AgentEnv identity vars

### DIFF
--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -208,7 +208,14 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	}
 	_ = t.SetEnvironment(sessionID, "GT_RUN", runID)
 	// Apply role config env vars if present (non-fatal).
+	// Skip keys already set by AgentEnv — AgentEnv is the single source of truth
+	// for identity vars (GT_ROLE, BD_ACTOR, etc.) and produces fully-qualified
+	// values (e.g., "beacon/witness"). TOML [env] sections contain unqualified
+	// values (e.g., "witness") that would overwrite the correct ones.
 	for key, value := range roleConfigEnvVars(roleConfig, townRoot, m.rig.Name) {
+		if _, alreadySet := envVars[key]; alreadySet {
+			continue
+		}
 		_ = t.SetEnvironment(sessionID, key, value)
 	}
 	// Apply CLI env overrides (highest priority, non-fatal).


### PR DESCRIPTION
## Summary

`witness.Manager.Start()` applies TOML `[env]` vars **after** `AgentEnv`, overwriting the correctly qualified `GT_ROLE=beacon/witness` with the TOML's unqualified `GT_ROLE=witness`. This causes `gt prime` to resolve the wrong role context — the witness thinks it's boot and adopts mayor context.

The refinery doesn't have this bug because its manager never applies `roleConfigEnvVars`.

**Root cause**: `internal/witness/manager.go` lines 211-213 iterate `roleConfigEnvVars(roleConfig, ...)` and call `SetEnvironment` unconditionally, even for keys already set by `AgentEnv`.

**Fix**: Skip keys already present in the `AgentEnv` output. `AgentEnv` is documented as "the single source of truth for agent environment variables" (comment on line 197), so TOML `[env]` should only add new vars, not override identity vars.

## Reproduction

1. `gt rig start beacon`
2. `tmux -L gt show-environment -t be-witness | grep GT_ROLE` → `GT_ROLE=witness` (wrong)
3. `tmux -L gt show-environment -t be-refinery | grep GT_ROLE` → `GT_ROLE=beacon/refinery` (correct)
4. Witness runs `gt prime` → "ROLE/LOCATION MISMATCH: You are boot"

## Test plan

- [x] `go vet ./internal/witness/` passes
- [ ] Manual: after fix, `tmux show-environment -t be-witness` shows `GT_ROLE=beacon/witness`
- [ ] Witness `gt prime` produces Witness Context (not Mayor/Boot)

Regression of #1289. Fixes #2492.

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>