### PR TITLE
fix: mount FOLDER to /gt with runtime workspace initialization

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -61,6 +61,10 @@ RUN git config --global credential.helper store && \
     dolt config --global --add user.name "${GIT_USER}" && \
     dolt config --global --add user.email "${GIT_EMAIL}"
 
-RUN /app/gastown/gt install /gt --git
+COPY --chown=agent:agent docker-entrypoint.sh /app/docker-entrypoint.sh
+RUN chmod +x /app/docker-entrypoint.sh
 
 WORKDIR /gt
+
+ENTRYPOINT ["/app/docker-entrypoint.sh"]
+CMD ["sleep", "infinity"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       # FOLDER must be defined in .env file, e.g. FOLDER=/home/user
       # or provided as an environment variable when running docker compose,
       # e.g. FOLDER=/home/user docker compose up
-      - ${FOLDER}:${FOLDER}
+      - ${FOLDER}:/gt
     ports:
       - "3000:3000"
     command: sleep infinity

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+set -e
+
+if [ ! -f /gt/mayor/town.json ]; then
+    echo "Initializing Gas Town workspace at /gt..."
+    /app/gastown/gt install /gt --git
+else
+    echo "Refreshing Gas Town workspace at /gt..."
+    /app/gastown/gt install /gt --git --force
+fi
+
+exec "$@"


### PR DESCRIPTION
## Summary

- Changes Docker volume mount from `${FOLDER}:${FOLDER}` to `${FOLDER}:/gt` so the host folder is available at the gastown workspace path
- Moves `gt install /gt --git` from build-time to a runtime entrypoint script (`docker-entrypoint.sh`), so it runs after the volume is mounted rather
than being overlaid by it
- First boot does a full install; subsequent boots use `--force` to refresh settings while preserving existing workspace state

## Test plan

- [ ] `FOLDER=/tmp/test-gt GIT_USER=Test GIT_EMAIL=test@test.com docker compose up --build -d`
- [ ] Verify workspace initialized: `docker compose exec gastown ls /gt/mayor/town.json`
- [ ] Verify host directory received files: `ls /tmp/test-gt/mayor/town.json`
- [ ] Restart and verify idempotent: `docker compose restart && docker compose logs gastown | grep "Refreshing"`
- [ ] Clean up: `docker compose down && rm -rf /tmp/test-gt`