### PR TITLE
fix: DEFERRED exit incorrectly closing work bead

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -1210,12 +1210,15 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) {
 		}
 	}
 
-	if hookedBeadID != "" {
+	if hookedBeadID != "" && exitType != ExitDeferred {
 		// BUG FIX (gt-pftz): Close hooked bead unless already terminal (closed/tombstone).
 		// Previously checked hookedBead.Status == StatusHooked, but polecats update
 		// their work bead to in_progress during work. The exact-match check caused
 		// gt done to skip closing the bead, leaving it as unassigned open work after
 		// the hook was cleared — triggering infinite dispatch loops.
+		//
+		// DEFERRED exits preserve the bead: work is paused, not done. The bead
+		// stays open/in_progress so it can be resumed on the next session.
 		if hookedBead, err := bd.Show(hookedBeadID); err == nil && !beads.IssueStatus(hookedBead.Status).IsTerminal() {
 			// BUG FIX: Close attached molecule (wisp) BEFORE closing hooked bead.
 			// When using formula-on-bead (gt sling formula --on bead), the base bead


### PR DESCRIPTION
## Summary

When a polecat calls `gt done --status DEFERRED`, `updateAgentStateOnDone()` unconditionally closes the hooked work bead. This is incorrect — DEFERRED means "paused, not done," and the bead should remain open for later resumption.

This causes a failure loop in production:
1. Polecat defers work → bead incorrectly closed
2. Witness detects closed bead with idle polecat
3. Work cannot be resumed because the bead is terminal
4. If the bead is manually reopened and re-slung, the cycle repeats

## Fix

Add `exitType != ExitDeferred` guard at `done.go:1213` so the bead-closing block is skipped for deferred exits. COMPLETED and ESCALATED exits continue to close beads as before.

## Test plan

- [x] Verified pre-existing test failures are unchanged (24 failures on upstream main, same 24 with patch)
- [x] Patched binary deployed and running polecat on rig
- [x] Confirmed intake chain works end-to-end: convoy → rig-local bead → sling → polecat