### PR TITLE
fix: persist home directory in a managed Docker volume

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,17 +1,8 @@
 # Run with
-# docker build -t gastown:latest -f Dockerfile . \
-#   --build-arg GIT_USER=TestUser --build-arg GIT_EMAIL=test@example.com
+# docker build -t gastown:latest -f Dockerfile .
 FROM docker/sandbox-templates:claude-code
 
-ARG GIT_USER
-ARG GIT_EMAIL
 ARG GO_VERSION=1.25.6
-
-RUN if [ -z "$GIT_USER" ] || [ -z "$GIT_EMAIL" ]; then \
-    echo "ERROR: Required build arguments missing"; \
-    echo "Build with: docker build --build-arg GIT_USER=<name> --build-arg GIT_EMAIL=<email> ."; \
-    exit 1; \
-    fi
 
 USER root
 
@@ -53,13 +44,6 @@ USER agent
 COPY --chown=agent:agent . /app/gastown
 
 RUN cd /app/gastown && make build
-
-# Configure git and dolt for the user
-RUN git config --global credential.helper store && \
-    git config --global user.name "${GIT_USER}" && \
-    git config --global user.email "${GIT_EMAIL}" && \
-    dolt config --global --add user.name "${GIT_USER}" && \
-    dolt config --global --add user.email "${GIT_EMAIL}"
 
 COPY --chown=agent:agent docker-entrypoint.sh /app/docker-entrypoint.sh
 RUN chmod +x /app/docker-entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -132,16 +132,16 @@ export GIT_USER="<your name>"
 export GIT_EMAIL="<your email>"
 export FOLDER="/Users/you/code"
 
-docker compose up --build -d
+docker compose build              # only needed on first run or after code changes
+docker compose up -d
 
-docker compose exec gastown zsh # or bash
+docker compose exec gastown zsh   # or bash
 
 gt up
 
-gh auth login #if you want gh to work
+gh auth login                     # if you want gh to work
 
 gt mayor attach
-
 ```
 
 ## Quick Start Guide

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,11 @@
 # Run with
-# GIT_USER="<your name>" GIT_EMAIL="<your email>" FOLDER="/Users/you/code" docker compose up --build -d
+# GIT_USER="<your name>" GIT_EMAIL="<your email>" FOLDER="/Users/you/code" docker compose up -d
 
 services:
   gastown:
     build:
       context: .
       dockerfile: Dockerfile
-      args:
-        GIT_USER: ${GIT_USER:-TestUser}
-        GIT_EMAIL: ${GIT_EMAIL:-test@example.com}
     container_name: gastown-sandbox
     stdin_open: false
     tty: false
@@ -25,13 +22,19 @@ services:
       - NET_RAW
     environment:
       IS_SANDBOX: 1
+      GIT_USER: ${GIT_USER:-TestUser}
+      GIT_EMAIL: ${GIT_EMAIL:-test@example.com}
     volumes:
       # FOLDER must be defined in .env file, e.g. FOLDER=/home/user
       # or provided as an environment variable when running docker compose,
       # e.g. FOLDER=/home/user docker compose up
+      - agent-home:/home/agent
       - ${FOLDER}:/gt
     ports:
       - "3000:3000"
     command: sleep infinity
 
     # Exec into the container with: docker compose exec gastown zsh
+
+volumes:
+  agent-home:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,6 +1,16 @@
 #!/bin/sh
 set -e
 
+# Re-apply git/dolt config on every start so env var changes take effect
+# even when the home volume already exists from a previous run.
+if [ -n "$GIT_USER" ] && [ -n "$GIT_EMAIL" ]; then
+    git config --global user.name "$GIT_USER"
+    git config --global user.email "$GIT_EMAIL"
+    git config --global credential.helper store
+    dolt config --global --add user.name "$GIT_USER"
+    dolt config --global --add user.email "$GIT_EMAIL"
+fi
+
 if [ ! -f /gt/mayor/town.json ]; then
     echo "Initializing Gas Town workspace at /gt..."
     /app/gastown/gt install /gt --git


### PR DESCRIPTION
> **Note:** This PR includes the changes in the `fix/docker-mount-folder-to-gt` branch (#2509). That PR should be reviewed/merged first.

## Summary
- Add `agent-home` named volume mounted at `/home/agent` so user-level config (`.claude`, `.config/gh`, `.gitconfig`, etc.) survives container rebuilds
- Move git/dolt identity config from build-time args to runtime env vars (`GIT_USER`, `GIT_EMAIL`) applied by the entrypoint on every start — the image
  is now user-agnostic and fully cacheable
- Remove `GIT_USER`/`GIT_EMAIL` build args and validation gate from Dockerfile

## Test plan
- [ ] `docker compose build` succeeds without any `GIT_USER`/`GIT_EMAIL` args
- [ ] `docker compose up -d` — first run: volume created, `git config --global user.name` returns correct value
- [ ] Exec in, create a file in `~`, `docker compose down && docker compose up -d` — file persists
- [ ] Rebuild with a different `GIT_USER` value — verify new name appears in `git config --global user.name`