### PR TITLE
Fix Docker dashboard port forwarding

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,7 @@ gt mayor attach
 export GIT_USER="<your name>"
 export GIT_EMAIL="<your email>"
 export FOLDER="/Users/you/code"
+export DASHBOARD_PORT=8080  # optional, host port for the web dashboard
 
 docker compose up --build -d
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
       # e.g. FOLDER=/home/user docker compose up
       - ${FOLDER}:${FOLDER}
     ports:
-      - "3000:3000"
+      - "${DASHBOARD_PORT:-8080}:8080"
     command: sleep infinity
 
     # Exec into the container with: docker compose exec gastown zsh

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -46,7 +46,11 @@ Example:
 
 func init() {
 	dashboardCmd.Flags().IntVar(&dashboardPort, "port", 8080, "HTTP port to listen on")
-	dashboardCmd.Flags().StringVar(&dashboardBind, "bind", "127.0.0.1", "Address to bind to (use 0.0.0.0 for all interfaces)")
+	defaultBind := "127.0.0.1"
+	if os.Getenv("IS_SANDBOX") != "" {
+		defaultBind = "0.0.0.0"
+	}
+	dashboardCmd.Flags().StringVar(&dashboardBind, "bind", defaultBind, "Address to bind to (use 0.0.0.0 for all interfaces)")
 	dashboardCmd.Flags().BoolVar(&dashboardOpen, "open", false, "Open browser automatically")
 	rootCmd.AddCommand(dashboardCmd)
 }


### PR DESCRIPTION
## Summary

- Forward port 8080 (the dashboard default) instead of 3000 in docker-compose
- Make the host port configurable via `DASHBOARD_PORT` env var (defaults to 8080)
- Auto-bind to `0.0.0.0` when `IS_SANDBOX` is set so the dashboard is reachable from the host
- Update README with `DASHBOARD_PORT` in Docker Compose setup section

## Test plan

- [ ] `docker compose up --build -d` and verify `gt dashboard` is accessible at `localhost:8080`
- [ ] `DASHBOARD_PORT=9090 docker compose up --build -d` and verify access at `localhost:9090`
- [ ] Verify `gt dashboard` outside Docker still binds to `127.0.0.1` by default