### PR TITLE
fix(beads): add --flat flag to bd list for valid JSON output

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -534,7 +534,9 @@ func stripEnvPrefixes(environ []string, prefixes ...string) []string {
 
 // List returns issues matching the given options.
 func (b *Beads) List(opts ListOptions) ([]*Issue, error) {
-	args := []string{"list", "--json"}
+	// --flat is required because bd's default tree mode doesn't output valid JSON
+	// even when --json is specified. This was introduced when bd added tree view.
+	args := []string{"list", "--json", "--flat"}
 
 	if opts.Status != "" {
 		args = append(args, "--status="+opts.Status)


### PR DESCRIPTION
## Summary

The `bd` CLI's tree view mode (now default) doesn't output valid JSON even when `--json` is specified. This caused `beads.List()` to silently return empty results, which in turn caused polecats to think they had no hooked work.

## Related Issue

Fixes #2496

## Root Cause

When `bd` added tree view as the default display mode, the `--json` flag alone no longer produces valid JSON output. The tree formatting is applied even with `--json`, resulting in output that can't be parsed:

```
# bd list --json (broken - tree mode)
├─ ● br-123: Some task [P1]
│  └─ ○ br-456: Subtask [P2]

# bd list --json --flat (correct - valid JSON)
[{"id":"br-123",...},{"id":"br-456",...}]
```

## How We Found This

1. Observed polecats immediately running `gt done` after spawn, claiming "no work on hook"
2. Verified via `bd show` that work WAS hooked with correct assignee
3. Added debug logging to trace the query path
4. Discovered `beads.List()` was returning 0 results despite work existing
5. Tested `bd list --json` manually and saw non-JSON tree output
6. Adding `--flat` flag produced valid JSON and fixed the issue

## Changes

- Add `--flat` flag to `bd list` command in `beads.List()` to ensure valid JSON output

## Testing

- [x] Unit tests pass (`go test ./internal/beads/...`)
- [x] Manual testing performed:
  - Slung work to polecat
  - Verified polecat saw hooked work via `gt hook`
  - Verified `gt prime --state` returned `autonomous` with correct `hooked_bead`
  - Polecat successfully began work implementation

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable) - N/A, internal fix
- [x] No breaking changes

---
Pull Request opened by [Augment Code](https://www.augmentcode.com/) with guidance from the PR author