### PR TITLE
fix: guard against bd v0.58.0 non-JSON output in list parsers

### DIFF
--- a/internal/beads/beads_rig.go
+++ b/internal/beads/beads_rig.go
@@ -249,6 +249,9 @@ func (b *Beads) ListRigBeads() (map[string]*RigFields, error) {
 		return nil, err
 	}
 
+	if !isJSONBytes(out) {
+		return nil, nil
+	}
 	var issues []*Issue
 	if err := json.Unmarshal(out, &issues); err != nil {
 		return nil, fmt.Errorf("parsing bd list output: %w", err)

--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -161,11 +161,13 @@ func (m *Mailbox) listFromDir(beadsDir string) ([]*Message, error) {
 			return nil, err
 		}
 
+		// bd v0.58.0 returns plain text (e.g. "No issues found.") for
+		// empty result sets instead of JSON. Skip non-JSON output.
+		if !isJSON(stdout) {
+			continue
+		}
 		var msgs []BeadsMessage
 		if err := json.Unmarshal(stdout, &msgs); err != nil {
-			if len(stdout) == 0 || string(stdout) == "null" || !isJSON(stdout) {
-				continue
-			}
 			return nil, err
 		}
 
@@ -200,11 +202,11 @@ func (m *Mailbox) listFromDir(beadsDir string) ([]*Message, error) {
 			continue
 		}
 
+		if !isJSON(stdout) {
+			continue
+		}
 		var msgs []BeadsMessage
 		if err := json.Unmarshal(stdout, &msgs); err != nil {
-			if len(stdout) == 0 || string(stdout) == "null" || !isJSON(stdout) {
-				continue
-			}
 			continue // Non-fatal for CC
 		}
 


### PR DESCRIPTION
## Summary

- Use existing `isJSON()` / `isJSONBytes()` helpers as pre-checks before `json.Unmarshal` on `bd list` output
- `mailbox.go`: replace redundant post-Unmarshal fallback with clean pre-check using existing `isJSON()`
- `beads_rig.go`: add `isJSONBytes()` guard to `ListRigBeads()` which was unprotected

Supersedes PR #2399 — same intent, cleaner implementation (no new imports, no redundant checks).

## Context

`bd v0.58.0` returns plain text (e.g. "No issues found.") instead of empty JSON arrays when result sets are empty. This broke `gt hook`, `gt mail inbox`, and `gt patrol`.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/mail/...` passes
- [x] `go test ./internal/beads/...` passes
- [x] Full test suite — only pre-existing failures in tmux/cmd packages (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)