### PR TITLE
fix: use rig root for beads queries in prime hook lookup

### DIFF
--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -551,8 +551,15 @@ func findAgentWork(ctx RoleContext) *beads.Issue {
 
 // findAgentWorkOnce performs a single attempt to find hooked work for an agent.
 func findAgentWorkOnce(ctx RoleContext, agentID string) *beads.Issue {
-	b := beads.New(ctx.WorkDir)
-	// Primary: agent bead's hook_bead field (authoritative, set by bd slot set during sling)
+	// Use rig root for beads queries instead of ctx.WorkDir. Polecat worktrees
+	// rely on .beads/redirect which can fail to resolve in edge cases, causing
+	// polecats to miss hooked work and exit immediately. The rig root directory
+	// always has the authoritative .beads/ database. (GH#2503)
+	b := beads.New(rigBeadsRoot(ctx))
+
+	// Agent bead's hook_bead field. NOTE: updateAgentHookBead was made a no-op
+	// (see sling_helpers.go), so HookBead is typically empty. Kept for backward
+	// compatibility with agent beads that still have hook_bead set.
 	agentBeadID := buildAgentBeadID(agentID, ctx.Role, ctx.TownRoot)
 	if agentBeadID != "" {
 		agentBeadDir := beads.ResolveHookDir(ctx.TownRoot, agentBeadID, ctx.WorkDir)
@@ -613,6 +620,20 @@ func findAgentWorkOnce(ctx RoleContext, agentID string) *beads.Issue {
 		return nil
 	}
 	return hookedBeads[0]
+}
+
+// rigBeadsRoot returns the directory to use for beads queries.
+// For rig-level agents (polecats, crew, witness, refinery), returns the rig
+// root (e.g., ~/gt/myrig/) which has the authoritative .beads/ database.
+// For town-level agents, returns ctx.WorkDir unchanged.
+//
+// This avoids relying on .beads/redirect in polecat worktrees, which can
+// fail to resolve and cause polecats to see no hooked work. (GH#2503)
+func rigBeadsRoot(ctx RoleContext) string {
+	if ctx.Rig != "" && ctx.TownRoot != "" {
+		return filepath.Join(ctx.TownRoot, ctx.Rig)
+	}
+	return ctx.WorkDir
 }
 
 // outputAutonomousDirective displays the AUTONOMOUS WORK MODE header and instructions.


### PR DESCRIPTION
## Summary

Minimal fix for #2503. After `updateAgentHookBead` was made a no-op, polecats depend on the fallback assignee query to find hooked work. This query uses `beads.New(ctx.WorkDir)`, but polecat worktrees rely on `.beads/redirect` which can fail to resolve — causing polecats to miss hooked work and exit immediately with DEFERRED status.

**Fix:** Add `rigBeadsRoot()` helper that returns `filepath.Join(townRoot, rig)` for rig-level agents, bypassing the unreliable redirect. Town-level agents continue using `ctx.WorkDir` unchanged.

## Changes

- `findAgentWorkOnce`: use `rigBeadsRoot(ctx)` instead of `ctx.WorkDir` for beads queries
- Add `rigBeadsRoot()` helper (8 lines)
- Update comment on the `HookBead` primary path to document it's non-functional

## Rationale

PRs #2523, #2524, and #2506 address overlapping aspects of this issue but include unrelated changes. This PR isolates the minimal fix: one function changed, one helper added, no new imports or dependencies.

## Test plan

- `go vet ./internal/cmd/` passes
- `go build ./...` passes
- Verified in production: polecats were unable to find hooked work across 4 consecutive sling attempts; after this patch, the rig root query resolves correctly