### PR TITLE
fix: restore hook_bead slot write on agent bead creation

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -256,9 +256,15 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 
 	// Note: role slot no longer set - role definitions are config-based
 
-	// Hook slot no longer maintained (hq-l6mm5). Work bead status+assignee
-	// is the authoritative source. HookBead in description is still written
-	// by FormatAgentDescription for backward compat with display readers.
+	// Set hook_bead slot so gt mol status can find hooked work via the
+	// agent bead's JSON field (primary lookup path in lookupHookedWork).
+	// The fallback query (status=hooked + assignee) is unreliable for
+	// cross-database scenarios. Restoring per hq-gfg.
+	if fields != nil && fields.HookBead != "" {
+		if _, slotErr := b.run("slot", "set", id, "hook", fields.HookBead); slotErr != nil {
+			// Non-fatal: fallback query may still find the work bead
+		}
+	}
 
 	return &issue, nil
 }
@@ -351,7 +357,15 @@ func (b *Beads) CreateOrReopenAgentBead(id, title string, fields *AgentFields) (
 	}
 
 	// Note: role slot no longer set - role definitions are config-based
-	// Hook slot no longer maintained (hq-l6mm5) - work bead status+assignee is authoritative.
+
+	// Set hook_bead slot so gt mol status can find hooked work via the
+	// agent bead's JSON field (primary lookup path in lookupHookedWork).
+	// Restoring per hq-gfg.
+	if fields != nil && fields.HookBead != "" {
+		if _, slotErr := target.run("slot", "set", id, "hook", fields.HookBead); slotErr != nil {
+			// Non-fatal: fallback query may still find the work bead
+		}
+	}
 
 	// Return the updated bead
 	return target.Show(id)


### PR DESCRIPTION
## Summary

- Restores `bd slot set <agent-bead> hook <work-bead>` calls in `CreateAgentBead` and `CreateOrReopenAgentBead`
- Without this, `agentBead.HookBead` is never populated, so `lookupHookedWork()` in `molecule_status.go` always returns nil via the primary lookup path
- Polecats run `gt prime --hook` → `gt mol status` → find no work → `gt done` in ~60 seconds

## Root cause

`updateAgentHookBead()` in `sling_helpers.go` was made a no-op (marked "redundant" per `hq-l6mm5`), and `hookSetAtomically` is always true so it's never even called. The slot writes in `beads_agent.go` were also removed, leaving no code path that sets `hook_bead` on agent beads.

## Test plan

- [x] Manual: `bd slot set` on agent bead → `gt mol status` finds hooked work → polecat executes
- [x] Dispatched 6+ polecats successfully after applying this fix via workaround script
- [ ] Verify `lookupHookedWork` fallback query (status=hooked + assignee) still works as backup

🤖 Generated with [Claude Code](https://claude.com/claude-code)