### PR TITLE
fix(refinery): skip MRs with missing branches instead of fatal exit (rc-d46)

### DIFF
--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -244,6 +244,19 @@ Pick next branch from queue. Attempt mechanical rebase on the MR's effective tar
 Resolve `<rebase-target>` using the **Target Resolution Rule** above.
 Do NOT hardcode `main` unless `main` is actually the resolved MR target.
 
+**Step 0.5: Verify branch still exists (race-condition guard)**
+
+Branches can disappear between queue-scan and here (e.g. cherry-picked to target directly).
+
+```bash
+git ls-remote --exit-code origin refs/heads/<polecat-branch>
+```
+
+If the branch no longer exists (exit code non-zero):
+- Close the MR bead: `bd close <mr-id> --reason "Branch no longer exists"`
+- Archive the MERGE_READY mail: `gt mail archive <message-id>`
+- Skip to loop-check — do NOT treat as a merge failure, do NOT nudge the polecat
+
 **Step 1: Checkout and attempt rebase**
 ```bash
 git checkout -b temp origin/<polecat-branch>

--- a/internal/refinery/batch.go
+++ b/internal/refinery/batch.go
@@ -296,6 +296,11 @@ func (e *Engineer) processSingleMR(ctx context.Context, mr *MRInfo, target strin
 		result.Conflicts = []*MRInfo{mr}
 	} else if processResult.TestsFailed {
 		result.Culprits = []*MRInfo{mr}
+	} else if processResult.BranchNotFound {
+		// Branch was cleaned up before we could process it (e.g. cherry-picked to target).
+		// Treat as a skip: log and move on rather than halting the queue.
+		_, _ = fmt.Fprintf(e.output, "[Batch] MR %s: branch %s not found, skipping\n", mr.ID, mr.Branch)
+		result.Conflicts = []*MRInfo{mr}
 	} else {
 		result.Error = fmt.Errorf("merge failed: %s", processResult.Error)
 	}

--- a/internal/refinery/batch_test.go
+++ b/internal/refinery/batch_test.go
@@ -825,6 +825,37 @@ func TestGetMergeMessage_Fallback(t *testing.T) {
 	}
 }
 
+// TestProcessBatch_SingleMR_BranchNotFound verifies that a missing branch is treated as a
+// skippable condition (added to Conflicts) rather than a fatal infrastructure error.
+func TestProcessBatch_SingleMR_BranchNotFound(t *testing.T) {
+	workDir, g, cleanup := testGitRepo(t)
+	defer cleanup()
+
+	e := newTestEngineer(t, workDir, g)
+
+	// MR pointing to a branch that doesn't exist locally or remotely.
+	batch := []*MRInfo{makeMR("mr-gone", "ghost-branch", "main")}
+
+	result := e.ProcessBatch(context.Background(), batch, "main", DefaultBatchConfig())
+
+	// Must NOT be a fatal error.
+	if result.Error != nil {
+		t.Fatalf("expected no fatal error for missing branch, got: %v", result.Error)
+	}
+	// Must be skipped (added to conflicts, not merged or culprits).
+	if len(result.Merged) != 0 {
+		t.Errorf("expected no merged MRs, got %d", len(result.Merged))
+	}
+	if len(result.Conflicts) != 1 || result.Conflicts[0].ID != "mr-gone" {
+		t.Errorf("expected mr-gone in conflicts (skipped), got %v", stackedIDs(result.Conflicts))
+	}
+	// Verify the log message says "skipping" not "fatal".
+	log := e.output.(*bytes.Buffer).String()
+	if !strings.Contains(log, "skipping") {
+		t.Errorf("expected 'skipping' in log output, got: %s", log)
+	}
+}
+
 // --- Helpers ---
 
 func stackedIDs(mrs []*MRInfo) []string {

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -383,12 +383,13 @@ func (e *Engineer) Config() *MergeQueueConfig {
 
 // ProcessResult contains the result of processing a merge request.
 type ProcessResult struct {
-	Success     bool
-	MergeCommit string
-	Error       string
-	Conflict    bool
-	TestsFailed bool
-	SlotTimeout bool // Merge slot contention timeout (distinct from build/test failure)
+	Success        bool
+	MergeCommit    string
+	Error          string
+	Conflict       bool
+	TestsFailed    bool
+	SlotTimeout    bool // Merge slot contention timeout (distinct from build/test failure)
+	BranchNotFound bool // Source branch no longer exists (e.g. cleaned up after cherry-pick)
 }
 
 // doMerge performs the actual git merge operation.
@@ -404,8 +405,9 @@ func (e *Engineer) doMerge(ctx context.Context, branch, target, sourceIssue stri
 	}
 	if !exists {
 		return ProcessResult{
-			Success: false,
-			Error:   fmt.Sprintf("branch %s not found locally", branch),
+			Success:        false,
+			BranchNotFound: true,
+			Error:          fmt.Sprintf("branch %s not found locally", branch),
 		}
 	}
 
@@ -998,6 +1000,13 @@ func (e *Engineer) HandleMRInfoFailure(mr *MRInfo, result ProcessResult) {
 	if result.SlotTimeout {
 		_, _ = fmt.Fprintf(e.output, "[Engineer] ✗ Slot timeout: %s - %s\n", mr.ID, result.Error)
 		_, _ = fmt.Fprintln(e.output, "[Engineer] MR remains in queue for automatic retry (slot contention)")
+		return
+	}
+
+	// Branch-not-found means the remote branch was cleaned up before we could process it
+	// (e.g. cherry-picked to target directly). Skip polecat nudge — the polecat is gone.
+	if result.BranchNotFound {
+		_, _ = fmt.Fprintf(e.output, "[Engineer] MR %s: branch %s no longer exists, skipping (queue continues)\n", mr.ID, mr.Branch)
 		return
 	}
 


### PR DESCRIPTION
## Summary

- **Root cause**: When a polecat branch is cleaned up before the refinery processes it (e.g. cherry-picked to target), `doMerge` returned a plain error. `processSingleMR` treated that as a fatal infrastructure failure (`result.Error`), halting the entire patrol queue instead of skipping to the next MR.
- **Code fix**: Add `BranchNotFound bool` to `ProcessResult` to distinguish "branch gone" from real failures. `processSingleMR` now treats it as a skip (appended to `Conflicts`, consistent with how `BuildRebaseStack` already handles missing branches). `HandleMRInfoFailure` short-circuits when `BranchNotFound` is set—skips the polecat nudge, since the polecat is gone.
- **Formula fix**: Added Step 0.5 to `process-branch` to verify the remote branch still exists before attempting checkout, with explicit instructions to close the MR bead and skip to `loop-check`. Guards the race condition between `queue-scan` and `process-branch`.

## Test plan

- [x] `TestProcessBatch_SingleMR_BranchNotFound`: new test confirms missing branch → no fatal error, MR lands in `Conflicts`, log contains "skipping"
- [x] Full `TestBuildRebaseStack*`, `TestProcessBatch*`, `TestBisect*` suite passes (15s, all green)
- [x] `TestManager_Queue_FiltersClosedMergeRequests` failure is pre-existing on upstream/main (`--flat` flag, unrelated to this PR)
- [x] Rebased onto upstream/main HEAD (`04df5063`)

Fixes rc-d46.

🤖 Generated with [Claude Code](https://claude.com/claude-code)