### PR TITLE
fix: replace fixed 200ms daemon startup check with polling loop

### DIFF
--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -197,15 +197,20 @@ func runDaemonStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("starting daemon: %w", err)
 	}
 
-	// Wait a moment for the daemon to initialize and acquire the lock
-	time.Sleep(200 * time.Millisecond)
-
-	// Verify it started
-	running, pid, err = daemon.IsRunning(townRoot)
-	if err != nil {
-		return fmt.Errorf("checking daemon status: %w", err)
+	// Poll for daemon to initialize and acquire the lock (up to 3s)
+	var started bool
+	for range 30 {
+		time.Sleep(100 * time.Millisecond)
+		running, pid, err = daemon.IsRunning(townRoot)
+		if err != nil {
+			return fmt.Errorf("checking daemon status: %w", err)
+		}
+		if running {
+			started = true
+			break
+		}
 	}
-	if !running {
+	if !started {
 		return fmt.Errorf("daemon failed to start (check logs with 'gt daemon logs')")
 	}
 


### PR DESCRIPTION
## Summary

- `gt daemon start` used a fixed 200ms sleep before verifying the daemon had started. On slower startups (loading patrol configs, opening beads stores, starting tickers), this wasn't enough time — causing a false "daemon failed to start" error even though the daemon was actually starting fine.
- Replaced with a polling loop (100ms intervals, up to 3s) that waits for the daemon to actually acquire its lock and report as running.

## Test plan

- [ ] `gt daemon stop && gt daemon start` — should report success consistently
- [ ] `gt up` on a cold start — daemon should start without false failure
- [ ] Verify no regression when daemon genuinely fails to start (e.g., port conflict)

🤖 Generated with [Claude Code](https://claude.com/claude-code)