### PR TITLE
fix(docker): detect arch dynamically and add gt to PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -21,8 +21,9 @@ RUN apt-get update && apt-get install -y \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
 # Install Go from official tarball (apt golang-go is too old)
-RUN curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-amd64.tar.gz" | tar -C /usr/local -xz
-ENV PATH="/usr/local/go/bin:/home/agent/go/bin:${PATH}"
+RUN ARCH=$(dpkg --print-architecture) && \
+    curl -fsSL "https://go.dev/dl/go${GO_VERSION}.linux-${ARCH}.tar.gz" | tar -C /usr/local -xz
+ENV PATH="/app/gastown:/usr/local/go/bin:/home/agent/go/bin:${PATH}"
 
 # Install beads (bd) and dolt
 RUN curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/install.sh | bash


### PR DESCRIPTION
## Summary
- Fix Dockerfile hardcoded `linux-amd64` Go tarball download that fails on ARM64 (Apple Silicon)
- Use `dpkg --print-architecture` for dynamic arch detection
- Add `/app/gastown` to `ENV PATH` so `gt` is available in `docker exec` without manual PATH exports

## Spike Findings (gt-gq8)
Full Docker Desktop isolation spike results are persisted on bead gt-gq8. Key findings:
- docker exec sessions work (~52ms overhead)
- Host Dolt reachable via `host.docker.internal`
- tmux send-keys work host→container
- Startup latency ~100ms (container) + ~50ms (per exec)
- Git/GitHub network access works; auth needs credential mounting
- Docker isolation superior to sandbox-exec (full PID/network/filesystem namespaces)

## Test plan
- [x] `docker build -t gastown:spike-test -f Dockerfile .` succeeds on ARM64 Mac
- [x] Container starts and gt/bd CLIs work via docker exec
- [x] Host build (`make build`) still passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)