### PR TITLE
fix: remove nonexistent --global flag from gt enable output (GH#2543)

### DIFF
--- a/internal/cmd/enable.go
+++ b/internal/cmd/enable.go
@@ -22,7 +22,7 @@ When enabled:
   - Claude Code SessionStart hooks run 'gt prime' for context
   - Git repos are auto-registered as rigs (configurable)
 
-Use 'gt disable' to turn off. Use 'gt status --global' to check state.
+Use 'gt disable' to turn off. Use 'gt status' to check state.
 
 Environment overrides:
   GASTOWN_DISABLED=1  - Disable for current session only
@@ -48,7 +48,7 @@ func runEnable(cmd *cobra.Command, args []string) error {
 	fmt.Println()
 	fmt.Printf("Use %s to disable, %s to check status\n",
 		style.Dim.Render("gt disable"),
-		style.Dim.Render("gt status --global"))
+		style.Dim.Render("gt status"))
 
 	return nil
 }


### PR DESCRIPTION
## Summary
- `gt enable` output suggests running `gt status --global` but the `--global` flag doesn't exist on the status command
- Changed both the Long description and the runtime output to use `gt status` instead

Fixes #2543

## Test plan
- [ ] Run `gt enable` and verify the output shows `gt status` (not `gt status --global`)
- [ ] Verify `gt status` works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)