### PR TITLE
fix: use CommandContext in dog done to prevent Cancel panic (GH#2528)

### DIFF
--- a/internal/cmd/dog.go
+++ b/internal/cmd/dog.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -693,7 +694,9 @@ func runDogDone(cmd *cobra.Command, args []string) error {
 	t := tmux.NewTmux()
 	_ = t.SetRemainOnExit(sessionID, false)
 	fmt.Printf("  Session %s will terminate in 3s\n", sessionID)
-	killCmd := exec.Command("bash", "-c",
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	killCmd := exec.CommandContext(ctx, "bash", "-c",
 		fmt.Sprintf("sleep 3 && tmux kill-session -t '%s' 2>/dev/null", sessionID))
 	util.SetProcessGroup(killCmd)
 	if err := killCmd.Start(); err != nil {


### PR DESCRIPTION
## Summary
- `gt dog done` panics with "command with a non-nil Cancel was not created with CommandContext" because `exec.Command` + `util.SetProcessGroup` sets `cmd.Cancel`, which Go 1.20+ requires `CommandContext` for
- Changed to `exec.CommandContext` with a 10-second timeout, matching the pattern used elsewhere (convoy operations, daemon)
- Without this fix, the tmux session stays alive after dog completion, causing infinite deacon reassignment loops

Fixes #2528

## Test plan
- [ ] Run `gt dog done <name>` — should terminate cleanly without panic
- [ ] Verify tmux session is killed after 3-second delay
- [ ] Verify no infinite reassignment loop from stale dog sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)