### PR TITLE
fix: add StripBeadsDir to convoy dep add/remove for rig-prefixed beads

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -543,6 +543,7 @@ func runConvoyCreate(cmd *cobra.Command, args []string) error {
 		if err := BdCmd("dep", "add", convoyID, issueID, "--type=tracks").
 			WithAutoCommit().
 			Dir(townBeads).
+			StripBeadsDir().
 			Stderr(&depStderr).
 			Run(); err != nil {
 			errMsg := strings.TrimSpace(depStderr.String())
@@ -651,6 +652,7 @@ func runConvoyAdd(cmd *cobra.Command, args []string) error {
 		if err := BdCmd("dep", "add", convoyID, issueID, "--type=tracks").
 			Dir(townBeads).
 			WithAutoCommit().
+			StripBeadsDir().
 			Stderr(&depStderr).
 			Run(); err != nil {
 			errMsg := strings.TrimSpace(depStderr.String())

--- a/internal/cmd/convoy_stage.go
+++ b/internal/cmd/convoy_stage.go
@@ -711,7 +711,7 @@ func createStagedConvoy(dag *ConvoyDAG, waves []Wave, status string, title strin
 	// Track each slingable bead via bd dep add.
 	for _, beadID := range slingableIDs {
 		if out, err := BdCmd("dep", "add", convoyID, beadID, "--type=tracks").
-			Dir(townBeads).WithAutoCommit().
+			Dir(townBeads).WithAutoCommit().StripBeadsDir().
 			CombinedOutput(); err != nil {
 			return "", fmt.Errorf("bd dep add %s %s: %w\noutput: %s", convoyID, beadID, err, out)
 		}
@@ -749,7 +749,7 @@ func updateStagedConvoy(existingConvoyID string, dag *ConvoyDAG, waves []Wave, s
 	for _, id := range desiredIDs {
 		if !currentIDs[id] {
 			if out, err := BdCmd("dep", "add", existingConvoyID, id, "--type=tracks").
-				Dir(townBeads).WithAutoCommit().
+				Dir(townBeads).WithAutoCommit().StripBeadsDir().
 				CombinedOutput(); err != nil {
 				return fmt.Errorf("bd dep add %s %s: %w\noutput: %s", existingConvoyID, id, err, out)
 			}
@@ -760,7 +760,7 @@ func updateStagedConvoy(existingConvoyID string, dag *ConvoyDAG, waves []Wave, s
 	for id := range currentIDs {
 		if !desiredSet[id] {
 			if out, err := BdCmd("dep", "remove", existingConvoyID, id, "--type=tracks").
-				Dir(townBeads).WithAutoCommit().
+				Dir(townBeads).WithAutoCommit().StripBeadsDir().
 				CombinedOutput(); err != nil {
 				return fmt.Errorf("bd dep remove %s %s: %w\noutput: %s", existingConvoyID, id, err, out)
 			}

--- a/internal/cmd/sling_convoy.go
+++ b/internal/cmd/sling_convoy.go
@@ -365,7 +365,7 @@ func createBatchConvoy(beadIDs []string, rigName string, owned bool, mergeStrate
 	var tracked []string
 	for _, beadID := range beadIDs {
 		depArgs := []string{"dep", "add", convoyID, beadID, "--type=tracks"}
-		if out, err := BdCmd(depArgs...).Dir(townRoot).WithAutoCommit().CombinedOutput(); err != nil {
+		if out, err := BdCmd(depArgs...).Dir(townRoot).WithAutoCommit().StripBeadsDir().CombinedOutput(); err != nil {
 			// Log but continue — partial tracking is better than no tracking
 			fmt.Printf("  Warning: could not track %s in convoy: %v\nOutput: %s\n", beadID, err, out)
 		} else {
@@ -430,9 +430,9 @@ func createAutoConvoy(beadID, beadTitle string, owned bool, mergeStrategy string
 	// matching what gt convoy create/add already do (convoy.go:368, convoy.go:464).
 	// Use WithAutoCommit for the same reason as above.
 	depArgs := []string{"dep", "add", convoyID, beadID, "--type=tracks"}
-	if out, err := BdCmd(depArgs...).Dir(townRoot).WithAutoCommit().CombinedOutput(); err != nil {
+	if out, err := BdCmd(depArgs...).Dir(townRoot).WithAutoCommit().StripBeadsDir().CombinedOutput(); err != nil {
 		// Tracking failed — delete the orphan convoy to prevent accumulation
-		_ = BdCmd("close", convoyID, "-r", "tracking dep failed").Dir(townRoot).Run()
+		_ = BdCmd("close", convoyID, "-r", "tracking dep failed").Dir(townRoot).StripBeadsDir().Run()
 		return "", fmt.Errorf("adding tracking relation for %s: %w\noutput: %s", beadID, err, out)
 	}
 


### PR DESCRIPTION
## Summary
- Convoy dep add/remove calls used `Dir(townBeads)` without `StripBeadsDir()`, causing inherited `BEADS_DIR` to override `Dir` and route rig-prefixed bead IDs to the wrong database
- Added `StripBeadsDir()` to all 7 affected call sites across `convoy.go`, `convoy_stage.go`, and `sling_convoy.go`
- Fixes gt-1gunh (GH#2423 audit)

## Test plan
- [ ] Verify `bd dep add` with rig-prefixed beads routes to correct database
- [ ] Verify `bd dep remove` with rig-prefixed beads routes correctly
- [ ] Run existing convoy tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>