### PR TITLE
fix: re-probe bd --allow-stale support by binary path

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -28,21 +28,50 @@ var (
 )
 
 // bdAllowStale caches whether the installed bd supports --allow-stale.
-// Detected once at first use via `bd --allow-stale version`.
+// The cache is keyed by the resolved bd path so tests and subprocess stubs that
+// replace bd on PATH get re-probed instead of reusing stale capability state.
 var (
-	bdAllowStaleOnce   sync.Once
+	bdAllowStaleMu     sync.Mutex
+	bdAllowStalePath   string
 	bdAllowStaleResult bool
 )
 
+// ResetBdAllowStaleCacheForTest clears the cached bd --allow-stale capability.
+// It exists for tests that swap bd binaries on PATH within a single process.
+func ResetBdAllowStaleCacheForTest() {
+	bdAllowStaleMu.Lock()
+	bdAllowStalePath = ""
+	bdAllowStaleResult = false
+	bdAllowStaleMu.Unlock()
+}
+
 // BdSupportsAllowStale returns true if the installed bd binary accepts --allow-stale.
 func BdSupportsAllowStale() bool {
-	bdAllowStaleOnce.Do(func() {
-		cmd := exec.Command("bd", "--allow-stale", "version") //nolint:gosec // G204: bd is a trusted internal tool
-		if err := cmd.Run(); err == nil {
-			bdAllowStaleResult = true
-		}
-	})
-	return bdAllowStaleResult
+	bdPath, err := exec.LookPath("bd")
+	if err != nil {
+		return false
+	}
+
+	bdAllowStaleMu.Lock()
+	cachedPath := bdAllowStalePath
+	cachedResult := bdAllowStaleResult
+	bdAllowStaleMu.Unlock()
+
+	if cachedPath == bdPath {
+		return cachedResult
+	}
+
+	cmd := exec.Command(bdPath, "--allow-stale", "version") //nolint:gosec // G204: bd is a trusted internal tool
+	supported := cmd.Run() == nil
+
+	bdAllowStaleMu.Lock()
+	if bdAllowStalePath != bdPath {
+		bdAllowStalePath = bdPath
+		bdAllowStaleResult = supported
+	}
+	result := bdAllowStaleResult
+	bdAllowStaleMu.Unlock()
+	return result
 }
 
 // MaybePrependAllowStale prepends --allow-stale to args if bd supports it.

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
@@ -79,6 +80,70 @@ func TestIsFlagLikeTitle(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("IsFlagLikeTitle(%q) = %v, want %v", tt.title, got, tt.want)
 		}
+	}
+}
+
+func TestBdSupportsAllowStale_ReprobesWhenBinaryPathChanges(t *testing.T) {
+	bdAllowStaleMu.Lock()
+	prevPath := bdAllowStalePath
+	prevResult := bdAllowStaleResult
+	bdAllowStaleMu.Unlock()
+	ResetBdAllowStaleCacheForTest()
+	t.Cleanup(func() {
+		bdAllowStaleMu.Lock()
+		bdAllowStalePath = prevPath
+		bdAllowStaleResult = prevResult
+		bdAllowStaleMu.Unlock()
+	})
+
+	supportingDir := t.TempDir()
+	nonSupportingDir := t.TempDir()
+	writeAllowStaleBDStub(t, supportingDir, true)
+	writeAllowStaleBDStub(t, nonSupportingDir, false)
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", supportingDir+string(os.PathListSeparator)+origPath)
+	if !BdSupportsAllowStale() {
+		t.Fatal("expected first stub to support --allow-stale")
+	}
+
+	t.Setenv("PATH", nonSupportingDir+string(os.PathListSeparator)+origPath)
+	if BdSupportsAllowStale() {
+		t.Fatal("expected second stub to be re-probed and report no --allow-stale support")
+	}
+}
+
+func writeAllowStaleBDStub(t *testing.T, dir string, supportsAllowStale bool) {
+	t.Helper()
+
+	var scriptPath, script string
+	if runtime.GOOS == "windows" {
+		scriptPath = filepath.Join(dir, "bd.bat")
+		exitCode := "1"
+		if supportsAllowStale {
+			exitCode = "0"
+		}
+		script = fmt.Sprintf(`@echo off
+setlocal enableextensions
+if "%%1"=="--allow-stale" exit /b %s
+exit /b 1
+`, exitCode)
+	} else {
+		scriptPath = filepath.Join(dir, "bd")
+		exitCode := "1"
+		if supportsAllowStale {
+			exitCode = "0"
+		}
+		script = fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "--allow-stale" ]; then
+  exit %s
+fi
+exit 1
+`, exitCode)
+	}
+
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
 	}
 }
 

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -441,7 +441,6 @@ exit /b 0
 			RigName:     rigName,
 			PolecatName: "Toast",
 			ClonePath:   filepath.Join(townRoot, "fake-polecat"),
-
 		}, nil
 	}
 
@@ -670,7 +669,6 @@ exit /b 0
 			RigName:     rigName,
 			PolecatName: "Toast",
 			ClonePath:   fakeWorkDir,
-
 		}, nil
 	}
 
@@ -869,6 +867,9 @@ exit /b 0
 // visible via regular bd show fail due to database staleness.
 // The fix uses --allow-stale to skip the staleness check for existence verification.
 func TestVerifyBeadExistsAllowStale(t *testing.T) {
+	beads.ResetBdAllowStaleCacheForTest()
+	t.Cleanup(beads.ResetBdAllowStaleCacheForTest)
+
 	townRoot := t.TempDir()
 
 	// Create minimal workspace structure
@@ -939,6 +940,9 @@ exit /b 1
 // TestSlingWithAllowStale tests the full gt sling flow with --allow-stale fix.
 // This is an integration test for the gtl-ncq bug.
 func TestSlingWithAllowStale(t *testing.T) {
+	beads.ResetBdAllowStaleCacheForTest()
+	t.Cleanup(beads.ResetBdAllowStaleCacheForTest)
+
 	townRoot := t.TempDir()
 
 	// Create minimal workspace structure
@@ -2353,6 +2357,7 @@ exit /b 0
 		})
 	}
 }
+
 // TestSlingRejectsDeferredBead verifies that gt sling refuses to sling beads
 // with deferred status or deferral keywords in their description (gt-1326mw).
 // This prevents wasting polecat slots on low-priority deferred work.


### PR DESCRIPTION
## Summary
- cache `bd --allow-stale` support by resolved binary path instead of `sync.Once`
- expose a small reset hook for tests that swap `bd` stubs on `PATH`
- harden the sling allow-stale regression tests against cross-test cache state

## Why
`BdSupportsAllowStale()` was effectively process-global. Tests that replace `bd` on `PATH` could inherit stale capability state from an earlier binary and skip `--allow-stale` when it was actually supported.

This keeps the runtime fix small: re-probe when the resolved `bd` path changes. The explicit test reset keeps `internal/cmd` deterministic when tests install temporary `bd` stubs.

## Verification
- `go test ./internal/beads`
- `go test ./internal/cmd -run 'Test(VerifyBeadExistsAllowStale|SlingWithAllowStale)$'`