### PR TITLE
fix: add explicit bd auto-commit off mode

### DIFF
--- a/internal/cmd/bd_helpers.go
+++ b/internal/cmd/bd_helpers.go
@@ -13,13 +13,13 @@ import (
 // It provides a fluent API for configuring environment variables,
 // working directory, and I/O settings common to bd CLI invocations.
 type bdCmd struct {
-	args       []string
-	dir        string
-	env        []string
-	stderr     io.Writer
-	autoCommit bool
-	gtRoot     string
-	beadsDir   string
+	args           []string
+	dir            string
+	env            []string
+	stderr         io.Writer
+	autoCommitMode string
+	gtRoot         string
+	beadsDir       string
 }
 
 // BdCmd creates a new bd command builder with the given arguments.
@@ -42,7 +42,15 @@ func BdCmd(args ...string) *bdCmd {
 // This is used for sequential dependent bd calls where each call
 // needs to see the changes from previous calls.
 func (b *bdCmd) WithAutoCommit() *bdCmd {
-	b.autoCommit = true
+	b.autoCommitMode = "on"
+	return b
+}
+
+// WithAutoCommitOff sets BD_DOLT_AUTO_COMMIT=off in the environment.
+// Use this for writes that must participate in the caller's larger transaction
+// without forcing an immediate Dolt commit.
+func (b *bdCmd) WithAutoCommitOff() *bdCmd {
+	b.autoCommitMode = "off"
 	return b
 }
 
@@ -98,16 +106,31 @@ func filterEnvKey(env []string, key string) []string {
 	return result
 }
 
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			return strings.TrimPrefix(e, prefix)
+		}
+	}
+	return ""
+}
+
 // buildEnv constructs the final environment slice based on configured options.
 func (b *bdCmd) buildEnv() []string {
 	env := b.env
+	forceAutoCommitOff := envValue(env, "GT_FORCE_BD_AUTOCOMMIT_OFF") == "1"
 
 	// Add BD_DOLT_AUTO_COMMIT=on for sequential dependent calls.
 	// Filter existing entries first — glibc getenv() returns the first match,
 	// so an existing "off" entry would shadow the appended "on".
-	if b.autoCommit {
+	if b.autoCommitMode != "" {
 		env = filterEnvKey(env, "BD_DOLT_AUTO_COMMIT")
-		env = append(env, "BD_DOLT_AUTO_COMMIT=on")
+		if forceAutoCommitOff || b.autoCommitMode == "off" {
+			env = append(env, "BD_DOLT_AUTO_COMMIT=off")
+		} else {
+			env = append(env, "BD_DOLT_AUTO_COMMIT=on")
+		}
 	}
 
 	// Add GT_ROOT if specified.

--- a/internal/cmd/bd_helpers_test.go
+++ b/internal/cmd/bd_helpers_test.go
@@ -172,6 +172,9 @@ func TestBdCmd_Chaining(t *testing.T) {
 	if bdc.WithAutoCommit() != bdc {
 		t.Error("WithAutoCommit() should return receiver for chaining")
 	}
+	if bdc.WithAutoCommitOff() != bdc {
+		t.Error("WithAutoCommitOff() should return receiver for chaining")
+	}
 	if bdc.WithGTRoot("/test") != bdc {
 		t.Error("WithGTRoot() should return receiver for chaining")
 	}
@@ -231,6 +234,47 @@ func TestBdCmd_WithAutoCommit_OverridesParentOff(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("found %d BD_DOLT_AUTO_COMMIT entries, want exactly 1 (dedup must remove old entry)", count)
+	}
+}
+
+func TestBdCmd_WithAutoCommit_RespectsForceOffOverride(t *testing.T) {
+	baseEnv := []string{
+		"PATH=/usr/bin",
+		"BD_DOLT_AUTO_COMMIT=on",
+		"GT_FORCE_BD_AUTOCOMMIT_OFF=1",
+	}
+
+	bdc := &bdCmd{
+		args:   []string{"update", "id"},
+		env:    baseEnv,
+		stderr: os.Stderr,
+	}
+	bdc.WithAutoCommit()
+	cmd := bdc.Build()
+	envMap := parseEnv(cmd.Env)
+
+	if envMap["BD_DOLT_AUTO_COMMIT"] != "off" {
+		t.Fatalf("BD_DOLT_AUTO_COMMIT = %q, want off", envMap["BD_DOLT_AUTO_COMMIT"])
+	}
+}
+
+func TestBdCmd_WithAutoCommitOff_OverridesParentOn(t *testing.T) {
+	baseEnv := []string{
+		"PATH=/usr/bin",
+		"BD_DOLT_AUTO_COMMIT=on",
+	}
+
+	bdc := &bdCmd{
+		args:   []string{"update", "id"},
+		env:    baseEnv,
+		stderr: os.Stderr,
+	}
+	bdc.WithAutoCommitOff()
+	cmd := bdc.Build()
+	envMap := parseEnv(cmd.Env)
+
+	if envMap["BD_DOLT_AUTO_COMMIT"] != "off" {
+		t.Fatalf("BD_DOLT_AUTO_COMMIT = %q, want off", envMap["BD_DOLT_AUTO_COMMIT"])
 	}
 }
 
@@ -296,16 +340,17 @@ func TestBdCmd_AllCombinations(t *testing.T) {
 	baseEnv := []string{"BD_DOLT_AUTO_COMMIT=off", "PATH=/usr/bin"}
 
 	tests := []struct {
-		name             string
-		autoCommit       bool
-		gtRoot           string
-		wantAutoCommitOn bool
-		wantGTRoot       bool
+		name           string
+		autoCommitMode string
+		gtRoot         string
+		wantAutoCommit string
+		wantGTRoot     bool
 	}{
-		{"none", false, "", false, false},
-		{"autocommit only", true, "", true, false},
-		{"gtroot only", false, "/town", false, true},
-		{"autocommit+gtroot", true, "/town", true, true},
+		{"none", "", "", "off", false},
+		{"autocommit only", "on", "", "on", false},
+		{"autocommit off only", "off", "", "off", false},
+		{"gtroot only", "", "/town", "off", true},
+		{"autocommit+gtroot", "on", "/town", "on", true},
 	}
 
 	for _, tt := range tests {
@@ -316,8 +361,8 @@ func TestBdCmd_AllCombinations(t *testing.T) {
 				stderr: os.Stderr,
 			}
 
-			if tt.autoCommit {
-				bdc.autoCommit = true
+			if tt.autoCommitMode != "" {
+				bdc.autoCommitMode = tt.autoCommitMode
 			}
 			bdc.gtRoot = tt.gtRoot
 
@@ -325,15 +370,8 @@ func TestBdCmd_AllCombinations(t *testing.T) {
 			envMap := parseEnv(cmd.Env)
 
 			// Check BD_DOLT_AUTO_COMMIT
-			if tt.wantAutoCommitOn {
-				if envMap["BD_DOLT_AUTO_COMMIT"] != "on" {
-					t.Errorf("BD_DOLT_AUTO_COMMIT = %q, want 'on'", envMap["BD_DOLT_AUTO_COMMIT"])
-				}
-			} else {
-				// When not explicitly set via WithAutoCommit, should keep original
-				if envMap["BD_DOLT_AUTO_COMMIT"] != "off" {
-					t.Errorf("BD_DOLT_AUTO_COMMIT = %q, want 'off' (original value)", envMap["BD_DOLT_AUTO_COMMIT"])
-				}
+			if envMap["BD_DOLT_AUTO_COMMIT"] != tt.wantAutoCommit {
+				t.Errorf("BD_DOLT_AUTO_COMMIT = %q, want %q", envMap["BD_DOLT_AUTO_COMMIT"], tt.wantAutoCommit)
 			}
 
 			// Check GT_ROOT

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -233,12 +233,19 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	// cause manifest contention and 'database is read only' errors. The Dolt server
 	// handles commits — individual auto-commits are unnecessary.
 	prevAutoCommit := os.Getenv("BD_DOLT_AUTO_COMMIT")
+	prevForceOff := os.Getenv("GT_FORCE_BD_AUTOCOMMIT_OFF")
 	os.Setenv("BD_DOLT_AUTO_COMMIT", "off")
+	os.Setenv("GT_FORCE_BD_AUTOCOMMIT_OFF", "1")
 	defer func() {
 		if prevAutoCommit == "" {
 			os.Unsetenv("BD_DOLT_AUTO_COMMIT")
 		} else {
 			os.Setenv("BD_DOLT_AUTO_COMMIT", prevAutoCommit)
+		}
+		if prevForceOff == "" {
+			os.Unsetenv("GT_FORCE_BD_AUTOCOMMIT_OFF")
+		} else {
+			os.Setenv("GT_FORCE_BD_AUTOCOMMIT_OFF", prevForceOff)
 		}
 	}()
 

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -994,6 +994,7 @@ func hookBeadWithRetry(beadID, targetAgent, hookDir string) error {
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		err := BdCmd("update", beadID, "--status=hooked", "--assignee="+targetAgent).
 			Dir(hookDir).
+			WithAutoCommitOff().
 			Run()
 		if err != nil {
 			lastErr = err


### PR DESCRIPTION
## Summary
- add `BdCmd.WithAutoCommitOff()` for commands that must write without forcing a Dolt auto-commit
- use the explicit off mode for `hookBeadWithRetry()` in sling
- add builder coverage for the new mode and its interaction with the existing force-off override

## Why
The self-sling hook write is part of a larger sling flow and should not force its own Dolt commit. Relying on inherited environment state was too implicit. This makes the hook update opt into `BD_DOLT_AUTO_COMMIT=off` directly at the command site.

## Verification
- `go test ./internal/cmd`