### PR TITLE
fix: prefer structured agent_state in GetAgentBead

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -620,6 +620,12 @@ func (b *Beads) GetAgentBead(id string) (*Issue, *AgentFields, error) {
 	}
 
 	fields := ParseAgentFields(issue.Description)
+	// Prefer the structured agent_state column when present.
+	// Some writers (for example, `bd agent state`) update the DB column directly
+	// without rewriting the description text, so description-derived state can be stale.
+	if issue.AgentState != "" {
+		fields.AgentState = issue.AgentState
+	}
 	return issue, fields, nil
 }
 

--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -1,6 +1,93 @@
 package beads
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func installMockBDFixedShowOutput(t *testing.T, showOutput string) {
+	t.Helper()
+
+	binDir := t.TempDir()
+	script := `#!/bin/sh
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+
+case "$cmd" in
+  version)
+    exit 0
+    ;;
+  show)
+    printf '%s\n' "$MOCK_BD_SHOW_OUTPUT"
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	scriptPath := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write mock bd: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("MOCK_BD_SHOW_OUTPUT", showOutput)
+}
+
+func TestGetAgentBead_PrefersStructuredAgentState(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	installMockBDFixedShowOutput(t, `[{"id":"gt-gastown-polecat-nux","title":"Polecat nux","issue_type":"agent","labels":["gt:agent"],"description":"role_type: polecat\nrig: gastown\nagent_state: spawning\nhook_bead: null","agent_state":"idle"}]`)
+
+	bd := NewIsolated(tmpDir)
+	issue, fields, err := bd.GetAgentBead("gt-gastown-polecat-nux")
+	if err != nil {
+		t.Fatalf("GetAgentBead: %v", err)
+	}
+	if issue == nil {
+		t.Fatal("GetAgentBead returned nil issue")
+	}
+	if fields == nil {
+		t.Fatal("GetAgentBead returned nil fields")
+	}
+	if issue.AgentState != "idle" {
+		t.Fatalf("issue.AgentState = %q, want %q", issue.AgentState, "idle")
+	}
+	if fields.AgentState != "idle" {
+		t.Fatalf("fields.AgentState = %q, want %q", fields.AgentState, "idle")
+	}
+}
+
+func TestGetAgentBead_FallsBackToDescriptionAgentState(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	installMockBDFixedShowOutput(t, `[{"id":"gt-gastown-polecat-nux","title":"Polecat nux","issue_type":"agent","labels":["gt:agent"],"description":"role_type: polecat\nrig: gastown\nagent_state: spawning\nhook_bead: null"}]`)
+
+	bd := NewIsolated(tmpDir)
+	_, fields, err := bd.GetAgentBead("gt-gastown-polecat-nux")
+	if err != nil {
+		t.Fatalf("GetAgentBead: %v", err)
+	}
+	if fields == nil {
+		t.Fatal("GetAgentBead returned nil fields")
+	}
+	if fields.AgentState != "spawning" {
+		t.Fatalf("fields.AgentState = %q, want %q", fields.AgentState, "spawning")
+	}
+}
 
 func TestIsAgentBeadByID(t *testing.T) {
 	tests := []struct {


### PR DESCRIPTION
## Summary
- prefer the structured `agent_state` column over description-derived state in `GetAgentBead`
- preserve legacy fallback to description when the structured field is empty
- add regression coverage for stale description vs structured state

## Testing
- go test ./internal/beads
- go test ./internal/polecat ./internal/cmd -run 'TestPolecat|TestGet|TestPolecatListState'

Fixes #2577