### PR TITLE
feat: add Witness dispatch message types

### DIFF
--- a/internal/witness/protocol.go
+++ b/internal/witness/protocol.go
@@ -35,6 +35,18 @@ var (
 
 	// SWARM_START - mayor initiating batch work
 	PatternSwarmStart = regexp.MustCompile(`^SWARM_START`)
+
+	// DISPATCH_ATTEMPT <polecat-name> - witness attempting to dispatch polecat to bead
+	PatternDispatchAttempt = regexp.MustCompile(`^DISPATCH_ATTEMPT\s+(\S+)`)
+
+	// DISPATCH_OK <polecat-name> - dispatch succeeded
+	PatternDispatchOK = regexp.MustCompile(`^DISPATCH_OK\s+(\S+)`)
+
+	// DISPATCH_FAIL <polecat-name> - dispatch failed
+	PatternDispatchFail = regexp.MustCompile(`^DISPATCH_FAIL\s+(\S+)`)
+
+	// IDLE_PASSIVATED <polecat-name> - polecat passivated after idle timeout
+	PatternIdlePassivated = regexp.MustCompile(`^IDLE_PASSIVATED\s+(\S+)`)
 )
 
 // ProtocolType identifies the type of protocol message.
@@ -49,6 +61,10 @@ const (
 	ProtoMergeReady        ProtocolType = "merge_ready"
 	ProtoHandoff           ProtocolType = "handoff"
 	ProtoSwarmStart        ProtocolType = "swarm_start"
+	ProtoDispatchAttempt   ProtocolType = "dispatch_attempt"
+	ProtoDispatchOK        ProtocolType = "dispatch_ok"
+	ProtoDispatchFail      ProtocolType = "dispatch_fail"
+	ProtoIdlePassivated    ProtocolType = "idle_passivated"
 	ProtoUnknown           ProtocolType = "unknown"
 )
 
@@ -169,6 +185,35 @@ type SwarmStartPayload struct {
 	StartedAt time.Time
 }
 
+// DispatchAttemptPayload contains parsed data from a DISPATCH_ATTEMPT message.
+type DispatchAttemptPayload struct {
+	PolecatName string
+	BeadID      string
+	AttemptedAt time.Time
+}
+
+// DispatchOKPayload contains parsed data from a DISPATCH_OK message.
+type DispatchOKPayload struct {
+	PolecatName string
+	BeadID      string
+	DispatchedAt time.Time
+}
+
+// DispatchFailPayload contains parsed data from a DISPATCH_FAIL message.
+type DispatchFailPayload struct {
+	PolecatName string
+	BeadID      string
+	Reason      string
+	FailedAt    time.Time
+}
+
+// IdlePassivatedPayload contains parsed data from an IDLE_PASSIVATED message.
+type IdlePassivatedPayload struct {
+	PolecatName  string
+	IdleDuration string
+	PassivatedAt time.Time
+}
+
 // ClassifyMessage determines the protocol type from a message subject.
 func ClassifyMessage(subject string) ProtocolType {
 	switch {
@@ -188,6 +233,14 @@ func ClassifyMessage(subject string) ProtocolType {
 		return ProtoHandoff
 	case PatternSwarmStart.MatchString(subject):
 		return ProtoSwarmStart
+	case PatternDispatchAttempt.MatchString(subject):
+		return ProtoDispatchAttempt
+	case PatternDispatchOK.MatchString(subject):
+		return ProtoDispatchOK
+	case PatternDispatchFail.MatchString(subject):
+		return ProtoDispatchFail
+	case PatternIdlePassivated.MatchString(subject):
+		return ProtoIdlePassivated
 	default:
 		return ProtoUnknown
 	}
@@ -404,6 +457,114 @@ func ParseSwarmStart(body string) (*SwarmStartPayload, error) {
 			}
 		} else if strings.HasPrefix(line, "Total:") {
 			_, _ = fmt.Sscanf(line, "Total: %d", &payload.Total)
+		}
+	}
+
+	return payload, nil
+}
+
+// ParseDispatchAttempt extracts payload from a DISPATCH_ATTEMPT message.
+// Subject format: DISPATCH_ATTEMPT <polecat-name>
+// Body format:
+//
+//	Bead: <bead-id>
+func ParseDispatchAttempt(subject, body string) (*DispatchAttemptPayload, error) {
+	matches := PatternDispatchAttempt.FindStringSubmatch(subject)
+	if len(matches) < 2 {
+		return nil, fmt.Errorf("invalid DISPATCH_ATTEMPT subject: %s", subject)
+	}
+
+	payload := &DispatchAttemptPayload{
+		PolecatName: matches[1],
+		AttemptedAt: time.Now(),
+	}
+
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Bead:") {
+			payload.BeadID = strings.TrimSpace(strings.TrimPrefix(line, "Bead:"))
+		}
+	}
+
+	return payload, nil
+}
+
+// ParseDispatchOK extracts payload from a DISPATCH_OK message.
+// Subject format: DISPATCH_OK <polecat-name>
+// Body format:
+//
+//	Bead: <bead-id>
+func ParseDispatchOK(subject, body string) (*DispatchOKPayload, error) {
+	matches := PatternDispatchOK.FindStringSubmatch(subject)
+	if len(matches) < 2 {
+		return nil, fmt.Errorf("invalid DISPATCH_OK subject: %s", subject)
+	}
+
+	payload := &DispatchOKPayload{
+		PolecatName:  matches[1],
+		DispatchedAt: time.Now(),
+	}
+
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "Bead:") {
+			payload.BeadID = strings.TrimSpace(strings.TrimPrefix(line, "Bead:"))
+		}
+	}
+
+	return payload, nil
+}
+
+// ParseDispatchFail extracts payload from a DISPATCH_FAIL message.
+// Subject format: DISPATCH_FAIL <polecat-name>
+// Body format:
+//
+//	Bead: <bead-id>
+//	Reason: <failure-reason>
+func ParseDispatchFail(subject, body string) (*DispatchFailPayload, error) {
+	matches := PatternDispatchFail.FindStringSubmatch(subject)
+	if len(matches) < 2 {
+		return nil, fmt.Errorf("invalid DISPATCH_FAIL subject: %s", subject)
+	}
+
+	payload := &DispatchFailPayload{
+		PolecatName: matches[1],
+		FailedAt:    time.Now(),
+	}
+
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		switch {
+		case strings.HasPrefix(line, "Bead:"):
+			payload.BeadID = strings.TrimSpace(strings.TrimPrefix(line, "Bead:"))
+		case strings.HasPrefix(line, "Reason:"):
+			payload.Reason = strings.TrimSpace(strings.TrimPrefix(line, "Reason:"))
+		}
+	}
+
+	return payload, nil
+}
+
+// ParseIdlePassivated extracts payload from an IDLE_PASSIVATED message.
+// Subject format: IDLE_PASSIVATED <polecat-name>
+// Body format:
+//
+//	IdleDuration: <duration>
+func ParseIdlePassivated(subject, body string) (*IdlePassivatedPayload, error) {
+	matches := PatternIdlePassivated.FindStringSubmatch(subject)
+	if len(matches) < 2 {
+		return nil, fmt.Errorf("invalid IDLE_PASSIVATED subject: %s", subject)
+	}
+
+	payload := &IdlePassivatedPayload{
+		PolecatName:  matches[1],
+		PassivatedAt: time.Now(),
+	}
+
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "IdleDuration:") {
+			payload.IdleDuration = strings.TrimSpace(strings.TrimPrefix(line, "IdleDuration:"))
 		}
 	}
 

--- a/internal/witness/protocol_test.go
+++ b/internal/witness/protocol_test.go
@@ -633,6 +633,193 @@ func TestFormatHelpSummary_WithAssessment(t *testing.T) {
 	}
 }
 
+// --- Dispatch message types (te-l0o) ---
+
+func TestClassifyMessage_DispatchTypes(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		subject  string
+		expected ProtocolType
+	}{
+		{"DISPATCH_ATTEMPT nux", ProtoDispatchAttempt},
+		{"DISPATCH_ATTEMPT slit", ProtoDispatchAttempt},
+		{"DISPATCH_OK nux", ProtoDispatchOK},
+		{"DISPATCH_OK furiosa", ProtoDispatchOK},
+		{"DISPATCH_FAIL nux", ProtoDispatchFail},
+		{"DISPATCH_FAIL ace", ProtoDispatchFail},
+		{"IDLE_PASSIVATED nux", ProtoIdlePassivated},
+		{"IDLE_PASSIVATED slit", ProtoIdlePassivated},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.subject, func(t *testing.T) {
+			result := ClassifyMessage(tc.subject)
+			if result != tc.expected {
+				t.Errorf("ClassifyMessage(%q) = %v, want %v", tc.subject, result, tc.expected)
+			}
+		})
+	}
+}
+
+func TestParseDispatchAttempt(t *testing.T) {
+	t.Parallel()
+	subject := "DISPATCH_ATTEMPT nux"
+	body := "Bead: gt-abc123"
+
+	payload, err := ParseDispatchAttempt(subject, body)
+	if err != nil {
+		t.Fatalf("ParseDispatchAttempt() error = %v", err)
+	}
+
+	if payload.PolecatName != "nux" {
+		t.Errorf("PolecatName = %q, want %q", payload.PolecatName, "nux")
+	}
+	if payload.BeadID != "gt-abc123" {
+		t.Errorf("BeadID = %q, want %q", payload.BeadID, "gt-abc123")
+	}
+	if payload.AttemptedAt.IsZero() {
+		t.Error("AttemptedAt should not be zero")
+	}
+}
+
+func TestParseDispatchAttempt_InvalidSubject(t *testing.T) {
+	t.Parallel()
+	_, err := ParseDispatchAttempt("Not a dispatch", "body")
+	if err == nil {
+		t.Error("ParseDispatchAttempt() expected error for invalid subject")
+	}
+}
+
+func TestParseDispatchOK(t *testing.T) {
+	t.Parallel()
+	subject := "DISPATCH_OK nux"
+	body := "Bead: gt-abc123"
+
+	payload, err := ParseDispatchOK(subject, body)
+	if err != nil {
+		t.Fatalf("ParseDispatchOK() error = %v", err)
+	}
+
+	if payload.PolecatName != "nux" {
+		t.Errorf("PolecatName = %q, want %q", payload.PolecatName, "nux")
+	}
+	if payload.BeadID != "gt-abc123" {
+		t.Errorf("BeadID = %q, want %q", payload.BeadID, "gt-abc123")
+	}
+	if payload.DispatchedAt.IsZero() {
+		t.Error("DispatchedAt should not be zero")
+	}
+}
+
+func TestParseDispatchOK_InvalidSubject(t *testing.T) {
+	t.Parallel()
+	_, err := ParseDispatchOK("Not a dispatch ok", "body")
+	if err == nil {
+		t.Error("ParseDispatchOK() expected error for invalid subject")
+	}
+}
+
+func TestParseDispatchFail(t *testing.T) {
+	t.Parallel()
+	subject := "DISPATCH_FAIL nux"
+	body := `Bead: gt-abc123
+Reason: bead already claimed`
+
+	payload, err := ParseDispatchFail(subject, body)
+	if err != nil {
+		t.Fatalf("ParseDispatchFail() error = %v", err)
+	}
+
+	if payload.PolecatName != "nux" {
+		t.Errorf("PolecatName = %q, want %q", payload.PolecatName, "nux")
+	}
+	if payload.BeadID != "gt-abc123" {
+		t.Errorf("BeadID = %q, want %q", payload.BeadID, "gt-abc123")
+	}
+	if payload.Reason != "bead already claimed" {
+		t.Errorf("Reason = %q, want %q", payload.Reason, "bead already claimed")
+	}
+	if payload.FailedAt.IsZero() {
+		t.Error("FailedAt should not be zero")
+	}
+}
+
+func TestParseDispatchFail_MinimalBody(t *testing.T) {
+	t.Parallel()
+	subject := "DISPATCH_FAIL ace"
+	body := "Reason: polecat state changed"
+
+	payload, err := ParseDispatchFail(subject, body)
+	if err != nil {
+		t.Fatalf("ParseDispatchFail() error = %v", err)
+	}
+
+	if payload.PolecatName != "ace" {
+		t.Errorf("PolecatName = %q, want %q", payload.PolecatName, "ace")
+	}
+	if payload.BeadID != "" {
+		t.Errorf("BeadID = %q, want empty", payload.BeadID)
+	}
+	if payload.Reason != "polecat state changed" {
+		t.Errorf("Reason = %q, want %q", payload.Reason, "polecat state changed")
+	}
+}
+
+func TestParseDispatchFail_InvalidSubject(t *testing.T) {
+	t.Parallel()
+	_, err := ParseDispatchFail("Not a dispatch fail", "body")
+	if err == nil {
+		t.Error("ParseDispatchFail() expected error for invalid subject")
+	}
+}
+
+func TestParseIdlePassivated(t *testing.T) {
+	t.Parallel()
+	subject := "IDLE_PASSIVATED nux"
+	body := "IdleDuration: 24h0m0s"
+
+	payload, err := ParseIdlePassivated(subject, body)
+	if err != nil {
+		t.Fatalf("ParseIdlePassivated() error = %v", err)
+	}
+
+	if payload.PolecatName != "nux" {
+		t.Errorf("PolecatName = %q, want %q", payload.PolecatName, "nux")
+	}
+	if payload.IdleDuration != "24h0m0s" {
+		t.Errorf("IdleDuration = %q, want %q", payload.IdleDuration, "24h0m0s")
+	}
+	if payload.PassivatedAt.IsZero() {
+		t.Error("PassivatedAt should not be zero")
+	}
+}
+
+func TestParseIdlePassivated_MinimalBody(t *testing.T) {
+	t.Parallel()
+	subject := "IDLE_PASSIVATED slit"
+	body := ""
+
+	payload, err := ParseIdlePassivated(subject, body)
+	if err != nil {
+		t.Fatalf("ParseIdlePassivated() error = %v", err)
+	}
+
+	if payload.PolecatName != "slit" {
+		t.Errorf("PolecatName = %q, want %q", payload.PolecatName, "slit")
+	}
+	if payload.IdleDuration != "" {
+		t.Errorf("IdleDuration = %q, want empty", payload.IdleDuration)
+	}
+}
+
+func TestParseIdlePassivated_InvalidSubject(t *testing.T) {
+	t.Parallel()
+	_, err := ParseIdlePassivated("Not idle passivated", "body")
+	if err == nil {
+		t.Error("ParseIdlePassivated() expected error for invalid subject")
+	}
+}
+
 // --- Agent state and exit type constants (gt-x7t9) ---
 
 func TestAgentStateConstants(t *testing.T) {


### PR DESCRIPTION
## Summary

- Add `DISPATCH_ATTEMPT`, `DISPATCH_OK`, `DISPATCH_FAIL`, `IDLE_PASSIVATED` protocol message types to `internal/witness/protocol.go`
- Includes regex patterns, ProtocolType constants, payload structs, parser functions, and ClassifyMessage routing
- No backward-incompatible changes — existing message types untouched

## Context

Phase 1 of the idle polecat auto-dispatch feature (te-l0o). These message types will be emitted by the Witness `dispatchCheck()` loop (te-ak6) and the idle passivation handler.

## Test plan

- [x] All new parser functions have unit tests (happy path, minimal body, invalid subject)
- [x] ClassifyMessage routing tested for all 4 new types
- [x] Full `go test ./internal/witness/` passes (0 failures)
- [x] No changes to existing tests or behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)