### PR TITLE
fix: gt prime skips patrol wisps on parked/docked rigs (gt-eqa9)

### DIFF
--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -240,6 +240,10 @@ func outputDeaconPatrolContext(ctx RoleContext) {
 // outputWitnessPatrolContext shows patrol molecule status for the Witness.
 // Witness AUTO-BONDS its patrol molecule on startup if one isn't already running.
 func outputWitnessPatrolContext(ctx RoleContext) {
+	if stopped, reason := IsRigParkedOrDocked(ctx.TownRoot, ctx.Rig); stopped {
+		fmt.Printf("\n⏸️  Rig %s is %s — skipping patrol wisp generation.\n", ctx.Rig, reason)
+		return
+	}
 	cfg := PatrolConfig{
 		RoleName:        "witness",
 		PatrolMolName:   constants.MolWitnessPatrol,
@@ -259,6 +263,10 @@ func outputWitnessPatrolContext(ctx RoleContext) {
 // outputRefineryPatrolContext shows patrol molecule status for the Refinery.
 // Refinery AUTO-BONDS its patrol molecule on startup if one isn't already running.
 func outputRefineryPatrolContext(ctx RoleContext) {
+	if stopped, reason := IsRigParkedOrDocked(ctx.TownRoot, ctx.Rig); stopped {
+		fmt.Printf("\n⏸️  Rig %s is %s — skipping patrol wisp generation.\n", ctx.Rig, reason)
+		return
+	}
 	cfg := PatrolConfig{
 		RoleName:        "refinery",
 		PatrolMolName:   constants.MolRefineryPatrol,

--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -406,6 +406,13 @@ func outputStartupDirective(ctx RoleContext) {
 		fmt.Println("   - If mol attached → **RUN IT** (no human input needed)")
 		fmt.Println("   - If no mol → await user instruction")
 	case RoleWitness:
+		if stopped, reason := IsRigParkedOrDocked(ctx.TownRoot, ctx.Rig); stopped {
+			fmt.Println()
+			fmt.Println("---")
+			fmt.Println()
+			fmt.Printf("Rig %s is %s. No patrol needed. Exit cleanly.\n", ctx.Rig, reason)
+			return
+		}
 		fmt.Println()
 		fmt.Println("---")
 		fmt.Println()
@@ -431,6 +438,13 @@ func outputStartupDirective(ctx RoleContext) {
 		fmt.Println("DO NOT wait. DO NOT escalate. DO NOT send idle alerts.")
 		fmt.Println("Just run `" + cli.Name() + " done` and exit.")
 	case RoleRefinery:
+		if stopped, reason := IsRigParkedOrDocked(ctx.TownRoot, ctx.Rig); stopped {
+			fmt.Println()
+			fmt.Println("---")
+			fmt.Println()
+			fmt.Printf("Rig %s is %s. No patrol needed. Exit cleanly.\n", ctx.Rig, reason)
+			return
+		}
 		fmt.Println()
 		fmt.Println("---")
 		fmt.Println()


### PR DESCRIPTION
## Summary
- `gt prime` now checks rig park/dock status before generating patrol wisp instructions for witness and refinery roles
- On parked/docked rigs, outputs a short "no patrol needed" message instead of the full patrol context and startup protocol
- Prevents noise accumulation from patrol wisps on rigs with no active witness/refinery

## What changed

**`internal/cmd/prime_molecule.go`**:
- `outputWitnessPatrolContext`: early return with message when rig is parked/docked

**`internal/cmd/prime_output.go`**:
- Witness startup protocol: skip patrol instructions when rig is parked/docked
- Refinery startup protocol: same skip

Uses the existing `IsRigParkedOrDocked()` helper, consistent with how the daemon and sling dispatch already gate on rig state.

## Cleanup note

Replaces #2513 which had accumulated unrelated fork history. This PR is a single commit with only the ~22-line fix.

## Test plan
- [x] `go build ./cmd/... ./internal/...` — compiles clean
- [ ] Verify witness on parked rig gets "no patrol needed" instead of patrol wisp context
- [ ] Verify refinery on docked rig gets same treatment
- [ ] Verify active (non-parked) rigs still get full patrol context

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)