### PR TITLE
fix: set beads.role to maintainer during gt install (gt-xnqf)

### DIFF
--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -632,6 +632,15 @@ func initTownBeads(townPath string) error {
 
 	beadsEnv := withBeadsDirEnv(beadsDir)
 
+	// Set beads.role to maintainer (town-level beads are always maintainer-owned).
+	// Without this, bd doctor warns about missing role configuration.
+	roleSetCmd := exec.Command("bd", "config", "set", "beads.role", "maintainer")
+	roleSetCmd.Dir = townPath
+	roleSetCmd.Env = beadsEnv
+	if roleOutput, roleErr := roleSetCmd.CombinedOutput(); roleErr != nil {
+		fmt.Printf("   %s Could not set beads.role: %s\n", style.Dim.Render("⚠"), strings.TrimSpace(string(roleOutput)))
+	}
+
 	// Explicitly set issue_prefix config (bd init --prefix may not persist it in newer versions).
 	prefixSetCmd := exec.Command("bd", "config", "set", "issue_prefix", "hq")
 	prefixSetCmd.Dir = townPath


### PR DESCRIPTION
## Summary

- `initTownBeads()` now sets `beads.role = maintainer` during `gt install`
- Without this, `bd doctor` warns about missing role configuration on every run
- Polecats already get `role=contributor` via polecat manager, but town-level beads had no role set

## Test plan

- [x] `go build ./cmd/... ./internal/...` — compiles clean
- [ ] Run `gt install` and verify `bd doctor` no longer warns about beads.role

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)