### PR TITLE
fix: read rig beads prefix from rigs.json instead of missing config.json

### DIFF
--- a/internal/cmd/rig_helpers.go
+++ b/internal/cmd/rig_helpers.go
@@ -68,8 +68,14 @@ func getRig(rigName string) (string, *rig.Rig, error) {
 // Returns false if the rig config or bead can't be loaded (safe default).
 func hasRigBeadLabel(townRoot, rigName, label string) bool {
 	rigPath := filepath.Join(townRoot, rigName)
-	rigCfg, err := rig.LoadRigConfig(rigPath)
-	if err != nil || rigCfg.Beads == nil {
+	prefix := ""
+	rigsConfigPath := constants.MayorRigsPath(townRoot)
+	if rigsConfig, err := config.LoadRigsConfig(rigsConfigPath); err == nil {
+		if entry, ok := rigsConfig.Rigs[rigName]; ok && entry.BeadsConfig != nil {
+			prefix = entry.BeadsConfig.Prefix
+		}
+	}
+	if prefix == "" {
 		return false
 	}
 
@@ -79,7 +85,7 @@ func hasRigBeadLabel(townRoot, rigName, label string) bool {
 	}
 
 	bd := beads.New(beadsPath)
-	rigBeadID := beads.RigBeadIDWithPrefix(rigCfg.Beads.Prefix, rigName)
+	rigBeadID := beads.RigBeadIDWithPrefix(prefix, rigName)
 
 	rigBead, err := bd.Show(rigBeadID)
 	if err != nil {
@@ -111,10 +117,18 @@ func IsRigParkedOrDocked(townRoot, rigName string) (bool, string) {
 		return true, "parked"
 	}
 
-	// Single bead lookup for both parked and docked labels
+	// Single bead lookup for both parked and docked labels.
+	// Look up the beads prefix from rigs.json (the rig registry) instead of
+	// <rigPath>/config.json which doesn't exist for most rigs.
 	rigPath := filepath.Join(townRoot, rigName)
-	rigCfg, err := rig.LoadRigConfig(rigPath)
-	if err != nil || rigCfg.Beads == nil {
+	prefix := ""
+	rigsConfigPath := constants.MayorRigsPath(townRoot)
+	if rigsConfig, err := config.LoadRigsConfig(rigsConfigPath); err == nil {
+		if entry, ok := rigsConfig.Rigs[rigName]; ok && entry.BeadsConfig != nil {
+			prefix = entry.BeadsConfig.Prefix
+		}
+	}
+	if prefix == "" {
 		return false, ""
 	}
 
@@ -124,7 +138,7 @@ func IsRigParkedOrDocked(townRoot, rigName string) (bool, string) {
 	}
 
 	bd := beads.New(beadsPath)
-	rigBeadID := beads.RigBeadIDWithPrefix(rigCfg.Beads.Prefix, rigName)
+	rigBeadID := beads.RigBeadIDWithPrefix(prefix, rigName)
 	rigBead, err := bd.Show(rigBeadID)
 	if err != nil {
 		return false, ""

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1381,6 +1381,33 @@ func (d *Daemon) getKnownRigs() []string {
 	return rigs
 }
 
+// getRigBeadsPrefix returns the beads prefix for a rig by reading rigs.json.
+// Returns "" if the prefix cannot be determined.
+func (d *Daemon) getRigBeadsPrefix(rigName string) string {
+	rigsPath := filepath.Join(d.config.TownRoot, "mayor", "rigs.json")
+	data, err := os.ReadFile(rigsPath)
+	if err != nil {
+		return ""
+	}
+
+	var parsed struct {
+		Rigs map[string]struct {
+			Beads *struct {
+				Prefix string `json:"prefix"`
+			} `json:"beads,omitempty"`
+		} `json:"rigs"`
+	}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		return ""
+	}
+
+	entry, ok := parsed.Rigs[rigName]
+	if !ok || entry.Beads == nil {
+		return ""
+	}
+	return entry.Beads.Prefix
+}
+
 // getPatrolRigs returns the list of operational rigs for a patrol.
 // If the patrol config specifies a rigs filter, only those rigs are returned.
 // Otherwise, all known rigs are returned. In both cases, non-operational
@@ -1435,8 +1462,12 @@ func (d *Daemon) isRigOperational(rigName string) (bool, string) {
 	// Check rig bead labels (global/synced docked status)
 	// This is the persistent docked state set by 'gt rig dock'
 	rigPath := filepath.Join(d.config.TownRoot, rigName)
-	if rigCfg, err := rig.LoadRigConfig(rigPath); err == nil && rigCfg.Beads != nil {
-		rigBeadID := fmt.Sprintf("%s-rig-%s", rigCfg.Beads.Prefix, rigName)
+	// Look up the beads prefix from rigs.json (the daemon's authoritative
+	// rig registry).  The previous code used rig.LoadRigConfig which reads
+	// <rigPath>/config.json — a file that doesn't exist for most rigs,
+	// silently skipping the bead-label check and ignoring dock state.
+	if prefix := d.getRigBeadsPrefix(rigName); prefix != "" {
+		rigBeadID := fmt.Sprintf("%s-rig-%s", prefix, rigName)
 		rigBeadsDir := beads.ResolveBeadsDir(rigPath)
 		bd := beads.NewWithBeadsDir(rigPath, rigBeadsDir)
 		if issue, err := bd.Show(rigBeadID); err == nil {


### PR DESCRIPTION
## Summary

Fixes #2590 — `gt rig dock` bead labels are silently ignored because `LoadRigConfig` reads a non-existent `config.json`.

- **`internal/daemon/daemon.go`**: `isRigOperational()` now reads the beads prefix from `rigs.json` via a new `getRigBeadsPrefix()` helper, instead of `rig.LoadRigConfig(rigPath)` which fails for most rigs.
- **`internal/cmd/rig_helpers.go`**: `IsRigParkedOrDocked()` and `hasRigBeadLabel()` now read the prefix from `rigs.json` via `config.LoadRigsConfig(constants.MayorRigsPath(...))`.

This is a regression from PR #2120 which introduced these functions with the correct intent but used the wrong config path (`<rigPath>/config.json` doesn't exist — the rig registry lives in `mayor/rigs.json`).

## Test plan

- [x] `go build ./internal/daemon/ && go build ./internal/cmd/` — compiles clean
- [x] `go test ./internal/daemon/` — all tests pass, including `TestGetPatrolRigs_FiltersNonOperationalRigs`
- [x] Manual: `gt rig dock <rig>` → `gt up` now correctly shows "skipped (rig docked)"
- [x] Manual: daemon heartbeat no longer restarts docked rigs

🤖 Generated with [Claude Code](https://claude.com/claude-code)