### PR TITLE
fix: surface hooked formula wisps in gt hook

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -10,8 +10,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"regexp"
-	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -574,16 +572,12 @@ func (b *Beads) List(opts ListOptions) ([]*Issue, error) {
 		return nil, err
 	}
 
-	// bd list --json may return plain text instead of JSON in some configurations.
-	// Handle explicit empty outputs gracefully, but parse issue table rows when
-	// possible so callers don't silently lose hooked work visibility.
+	// bd list --json may return plain text like "No issues found." instead of JSON
+	// when there are no results. Handle that explicit empty case gracefully.
 	if len(out) == 0 || !isJSONBytes(out) {
 		text := strings.TrimSpace(string(out))
 		if text == "" || strings.Contains(text, "No issues found.") {
 			return nil, nil
-		}
-		if issues := parsePlainListOutput(text); len(issues) > 0 {
-			return issues, nil
 		}
 		return nil, fmt.Errorf("bd list --json returned non-JSON output: %q", firstLine(text))
 	}
@@ -611,30 +605,6 @@ func isJSONBytes(b []byte) bool {
 		}
 	}
 	return false
-}
-
-var plainListRowRE = regexp.MustCompile(`^\S+\s+(\S+)\s+\S+\s+P(\d+)\s+\[([^\]]+)\]\s+(.+?)\s*$`)
-
-func parsePlainListOutput(text string) []*Issue {
-	var issues []*Issue
-	for _, line := range strings.Split(text, "\n") {
-		line = strings.TrimSpace(line)
-		if line == "" {
-			continue
-		}
-		m := plainListRowRE.FindStringSubmatch(line)
-		if m == nil {
-			continue
-		}
-		priority, _ := strconv.Atoi(m[2])
-		issues = append(issues, &Issue{
-			ID:       m[1],
-			Priority: priority,
-			Type:     m[3],
-			Title:    m[4],
-		})
-	}
-	return issues
 }
 
 func firstLine(text string) string {

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -6,7 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 )
@@ -284,105 +283,6 @@ func TestIntegration(t *testing.T) {
 		}
 		t.Logf("Showed issue: %s - %s", issue.ID, issue.Title)
 	})
-}
-
-func TestParsePlainListOutput(t *testing.T) {
-	text := `? gas-wisp-yc3z7 ● P2 [epic] demo-hello
-
---------------------------------------------------------------------------------
-Total: 1 issues (0 open, 0 in progress)
-
-Status: ○ open  ◐ in_progress  ● blocked  ✓ closed  ❄ deferred`
-
-	issues := parsePlainListOutput(text)
-	if len(issues) != 1 {
-		t.Fatalf("parsePlainListOutput() len = %d, want 1", len(issues))
-	}
-	if issues[0].ID != "gas-wisp-yc3z7" {
-		t.Fatalf("issue ID = %q, want gas-wisp-yc3z7", issues[0].ID)
-	}
-	if issues[0].Priority != 2 {
-		t.Fatalf("issue Priority = %d, want 2", issues[0].Priority)
-	}
-	if issues[0].Type != "epic" {
-		t.Fatalf("issue Type = %q, want epic", issues[0].Type)
-	}
-	if issues[0].Title != "demo-hello" {
-		t.Fatalf("issue Title = %q, want demo-hello", issues[0].Title)
-	}
-}
-
-func TestListParsesPlainTextFallback(t *testing.T) {
-	tmpDir := t.TempDir()
-	if err := os.Mkdir(filepath.Join(tmpDir, ".beads"), 0755); err != nil {
-		t.Fatalf("mkdir .beads: %v", err)
-	}
-
-	binDir := filepath.Join(tmpDir, "bin")
-	if err := os.Mkdir(binDir, 0755); err != nil {
-		t.Fatalf("mkdir bin: %v", err)
-	}
-
-	if runtime.GOOS == "windows" {
-		script := `@echo off
-setlocal enableextensions
-set "cmd=%1"
-if "%cmd%"=="--allow-stale" (
-  shift
-  set "cmd=%1"
-)
-if "%cmd%"=="list" (
-  echo ? gas-wisp-yc3z7 ● P2 [epic] demo-hello
-  echo.
-  echo --------------------------------------------------------------------------------
-  echo Total: 1 issues ^(0 open, 0 in progress^)
-  exit /b 0
-)
-if "%cmd%"=="version" exit /b 0
-exit /b 0
-`
-		if err := os.WriteFile(filepath.Join(binDir, "bd.cmd"), []byte(script), 0644); err != nil {
-			t.Fatalf("write bd.cmd: %v", err)
-		}
-	} else {
-		script := `#!/bin/sh
-cmd="$1"
-if [ "$cmd" = "--allow-stale" ]; then
-  shift
-  cmd="$1"
-fi
-case "$cmd" in
-  list)
-    cat <<'EOF'
-? gas-wisp-yc3z7 ● P2 [epic] demo-hello
-
---------------------------------------------------------------------------------
-Total: 1 issues (0 open, 0 in progress)
-EOF
-    ;;
-  version)
-    echo "bd version test"
-    ;;
-esac
-`
-		if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
-			t.Fatalf("write bd: %v", err)
-		}
-	}
-
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-
-	b := New(tmpDir)
-	issues, err := b.List(ListOptions{Status: "hooked", Assignee: "gastown/polecats/furiosa", Priority: -1})
-	if err != nil {
-		t.Fatalf("List() error = %v", err)
-	}
-	if len(issues) != 1 {
-		t.Fatalf("List() len = %d, want 1", len(issues))
-	}
-	if issues[0].ID != "gas-wisp-yc3z7" {
-		t.Fatalf("List() issue ID = %q, want gas-wisp-yc3z7", issues[0].ID)
-	}
 }
 
 // TestParseMRFields tests parsing MR fields from issue descriptions.


### PR DESCRIPTION
## Summary
- make `gt hook` / `gt mol status` prefer direct bead tracking and only use the legacy hook-slot path as validated fallback
- re-fetch the full hooked bead so formula metadata is available and standalone formula wisps get workflow-oriented guidance instead of `gt mol attach`

Fixes #2431

## Scope
This is the slimmer version of the earlier branch.

I removed the `bd list --json` plain-text table parser/fallback and kept only the core behavioral fix for hook visibility:
- direct hooked bead state is authoritative
- the legacy agent `hook_bead` slot is only fallback
- full hooked-bead re-fetch preserves formula metadata for rendering

## Why The Parser Was Removed
After retesting more precisely against the actual `gt` code path, the relevant list command is `bd list --json --flat`.

On my local `bd version 0.59.0 (dev)`, `bd list --json` without `--flat` could still be non-JSON, but `bd list --json --flat` returned valid JSON in the affected environment, and the core `gt hook` fix still worked without the parser.

So this PR now focuses on the main source-issue behavior rather than the beads-side output workaround.

## Verification
- `go test ./internal/beads -run 'TestParseAttachmentFields|TestFormatAttachmentFields' -count=1`
- built a temporary `gt` binary from this branch and ran a real `gt hook` / `gt hook --json` check in a hooked formula workspace
- confirmed the hooked formula bead was visible even with the parser removed