### PR TITLE
fix: persist formula --var context for assignees

### DIFF
--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"reflect"
 	"runtime"
 	"strings"
 	"testing"
@@ -725,7 +726,7 @@ func TestMRFieldsRoundTrip(t *testing.T) {
 		t.Fatal("round-trip parse returned nil")
 	}
 
-	if *parsed != *original {
+	if !reflect.DeepEqual(parsed, original) {
 		t.Errorf("round-trip mismatch:\ngot  %+v\nwant %+v", parsed, original)
 	}
 }
@@ -871,6 +872,17 @@ ATTACHED_AT: 2025-12-21T14:00:00Z`,
 				AttachedAt:       "2025-12-21T14:00:00Z",
 			},
 		},
+		{
+			name: "attached vars",
+			issue: &Issue{
+				Description: `attached_formula: mol-release
+attached_vars: ["version=1.2.3","channel=stable"]`,
+			},
+			wantFields: &AttachmentFields{
+				AttachedFormula: "mol-release",
+				AttachedVars:    []string{"version=1.2.3", "channel=stable"},
+			},
+		},
 	}
 
 	for _, tt := range tests {
@@ -893,6 +905,9 @@ ATTACHED_AT: 2025-12-21T14:00:00Z`,
 			}
 			if fields.AttachedAt != tt.wantFields.AttachedAt {
 				t.Errorf("AttachedAt = %q, want %q", fields.AttachedAt, tt.wantFields.AttachedAt)
+			}
+			if !reflect.DeepEqual(fields.AttachedVars, tt.wantFields.AttachedVars) {
+				t.Errorf("AttachedVars = %#v, want %#v", fields.AttachedVars, tt.wantFields.AttachedVars)
 			}
 		})
 	}
@@ -930,6 +945,14 @@ attached_at: 2025-12-21T15:30:00Z`,
 				AttachedMolecule: "mol-abc",
 			},
 			want: "attached_molecule: mol-abc",
+		},
+		{
+			name: "attached vars",
+			fields: &AttachmentFields{
+				AttachedFormula: "mol-release",
+				AttachedVars:    []string{"version=1.2.3", "channel=stable"},
+			},
+			want: "attached_formula: mol-release\nattached_vars: [\"version=1.2.3\",\"channel=stable\"]",
 		},
 	}
 
@@ -1042,7 +1065,7 @@ func TestAttachmentFieldsRoundTrip(t *testing.T) {
 		t.Fatal("round-trip parse returned nil")
 	}
 
-	if *parsed != *original {
+	if !reflect.DeepEqual(parsed, original) {
 		t.Errorf("round-trip mismatch:\ngot  %+v\nwant %+v", parsed, original)
 	}
 }
@@ -1115,7 +1138,7 @@ func TestNoMergeField(t *testing.T) {
 		if parsed == nil {
 			t.Fatal("round-trip parse returned nil")
 		}
-		if *parsed != *original {
+		if !reflect.DeepEqual(parsed, original) {
 			t.Errorf("round-trip mismatch:\ngot  %+v\nwant %+v", parsed, original)
 		}
 	})

--- a/internal/beads/fields.go
+++ b/internal/beads/fields.go
@@ -2,6 +2,7 @@
 package beads
 
 import (
+	"encoding/json"
 	"fmt"
 	"sort"
 	"strings"
@@ -16,6 +17,7 @@ type AttachmentFields struct {
 	AttachedFormula  string // Formula name (e.g., "mol-polecat-work") for inline step display
 	AttachedAt       string // ISO 8601 timestamp when attached
 	AttachedArgs     string // Natural language args passed via gt sling --args (no-tmux mode)
+	AttachedVars     []string // Formula variables passed via gt sling --var
 	DispatchedBy     string // Agent ID that dispatched this work (for completion notification)
 	NoMerge          bool   // If true, gt done skips merge queue (for upstream PRs/human review)
 	Mode             string // Execution mode: "" (normal) or "ralph" (Ralph Wiggum loop)
@@ -66,6 +68,9 @@ func ParseAttachmentFields(issue *Issue) *AttachmentFields {
 		case "attached_args", "attached-args", "attachedargs":
 			fields.AttachedArgs = value
 			hasFields = true
+		case "attached_vars", "attached-vars", "attachedvars":
+			fields.AttachedVars = parseAttachedVars(value)
+			hasFields = true
 		case "dispatched_by", "dispatched-by", "dispatchedby":
 			fields.DispatchedBy = value
 			hasFields = true
@@ -114,6 +119,9 @@ func FormatAttachmentFields(fields *AttachmentFields) string {
 	if fields.AttachedArgs != "" {
 		lines = append(lines, "attached_args: "+fields.AttachedArgs)
 	}
+	if len(fields.AttachedVars) > 0 {
+		lines = append(lines, "attached_vars: "+formatAttachedVars(fields.AttachedVars))
+	}
 	if fields.DispatchedBy != "" {
 		lines = append(lines, "dispatched_by: "+fields.DispatchedBy)
 	}
@@ -154,6 +162,9 @@ func SetAttachmentFields(issue *Issue, fields *AttachmentFields) string {
 		"attached_args":     true,
 		"attached-args":     true,
 		"attachedargs":      true,
+		"attached_vars":     true,
+		"attached-vars":     true,
+		"attachedvars":      true,
 		"dispatched_by":     true,
 		"dispatched-by":     true,
 		"dispatchedby":      true,
@@ -317,6 +328,30 @@ func FormatConvoyFields(fields *ConvoyFields) string {
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+func formatAttachedVars(vars []string) string {
+	if len(vars) == 0 {
+		return ""
+	}
+	encoded, err := json.Marshal(vars)
+	if err != nil {
+		return strings.Join(vars, ", ")
+	}
+	return string(encoded)
+}
+
+func parseAttachedVars(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	var vars []string
+	if strings.HasPrefix(raw, "[") {
+		if err := json.Unmarshal([]byte(raw), &vars); err == nil {
+			return vars
+		}
+	}
+	return []string{raw}
 }
 
 // SetConvoyFields updates an issue's description with the given convoy fields.

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -126,8 +126,10 @@ type MoleculeStatusInfo struct {
 	HasWork          bool                  `json:"has_work"`
 	PinnedBead       *beads.Issue          `json:"pinned_bead,omitempty"`
 	AttachedMolecule string                `json:"attached_molecule,omitempty"`
+	AttachedFormula  string                `json:"attached_formula,omitempty"`
 	AttachedAt       string                `json:"attached_at,omitempty"`
 	AttachedArgs     string                `json:"attached_args,omitempty"`
+	AttachedVars     []string              `json:"attached_vars,omitempty"`
 	IsWisp           bool                  `json:"is_wisp"`
 	Progress         *MoleculeProgressInfo `json:"progress,omitempty"`
 	NextAction       string                `json:"next_action,omitempty"`
@@ -490,14 +492,20 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 		attachment := beads.ParseAttachmentFields(hookBead)
 		if attachment != nil {
 			status.AttachedMolecule = attachment.AttachedMolecule
+			status.AttachedFormula = attachment.AttachedFormula
 			status.AttachedAt = attachment.AttachedAt
 			status.AttachedArgs = attachment.AttachedArgs
+			status.AttachedVars = attachment.AttachedVars
 
 			status.IsWisp = strings.Contains(hookBead.Description, "wisp: true") ||
 				strings.Contains(hookBead.Description, "is_wisp: true")
 
 			if attachment.AttachedMolecule != "" {
 				progress, _ := getMoleculeProgressInfo(b, attachment.AttachedMolecule)
+				status.Progress = progress
+				status.NextAction = determineNextAction(status)
+			} else if attachment.AttachedFormula != "" {
+				progress, _ := getMoleculeProgressInfo(b, hookBead.ID)
 				status.Progress = progress
 				status.NextAction = determineNextAction(status)
 			}
@@ -507,8 +515,10 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 	// Determine next action if no work is slung
 	if !status.HasWork {
 		status.NextAction = "Check inbox for work assignments: gt mail inbox"
-	} else if status.AttachedMolecule == "" {
+	} else if status.AttachedMolecule == "" && status.AttachedFormula == "" {
 		status.NextAction = "Attach a molecule to start work: gt mol attach <bead-id> <molecule-id>"
+	} else if status.AttachedFormula != "" && status.NextAction == "" && status.PinnedBead != nil {
+		status.NextAction = "Show the workflow steps: gt prime or bd mol current " + status.PinnedBead.ID
 	}
 
 	// JSON output
@@ -738,7 +748,18 @@ func outputMoleculeStatus(status MoleculeStatusInfo) error {
 	}
 
 	fmt.Printf("%s %s: %s\n", style.Bold.Render("🪝 Hooked:"), status.PinnedBead.ID, status.PinnedBead.Title)
-
+	if status.AttachedFormula != "" {
+		fmt.Printf("%s %s\n", style.Bold.Render("📐 Formula:"), status.AttachedFormula)
+	}
+	if len(status.AttachedVars) > 0 {
+		fmt.Printf("%s\n", style.Bold.Render("🧩 Vars:"))
+		for _, variable := range status.AttachedVars {
+			fmt.Printf("   --var %s\n", variable)
+		}
+	}
+	if status.AttachedArgs != "" {
+		fmt.Printf("%s %s\n", style.Bold.Render("📋 Args:"), status.AttachedArgs)
+	}
 	// Show attached molecule
 	if status.AttachedMolecule != "" {
 		molType := "Molecule"
@@ -748,9 +769,6 @@ func outputMoleculeStatus(status MoleculeStatusInfo) error {
 		fmt.Printf("%s %s: %s\n", style.Bold.Render("🧬 "+molType+":"), status.AttachedMolecule, "")
 		if status.AttachedAt != "" {
 			fmt.Printf("   Attached: %s\n", status.AttachedAt)
-		}
-		if status.AttachedArgs != "" {
-			fmt.Printf("   %s %s\n", style.Bold.Render("Args:"), status.AttachedArgs)
 		}
 	} else {
 		fmt.Printf("%s\n", style.Dim.Render("No molecule attached (hooked bead still triggers autonomous work)"))

--- a/internal/cmd/molecule_status_test.go
+++ b/internal/cmd/molecule_status_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func TestOutputMoleculeStatus_StandaloneFormulaShowsVars(t *testing.T) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	tempDir := t.TempDir()
+	if err := os.Chdir(tempDir); err != nil {
+		t.Fatalf("chdir tempDir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+
+	status := MoleculeStatusInfo{
+		HasWork:         true,
+		PinnedBead:      &beads.Issue{ID: "gt-wisp-xyz", Title: "Standalone formula work"},
+		AttachedFormula: "mol-release",
+		AttachedVars:    []string{"version=1.2.3", "channel=stable"},
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	if err := outputMoleculeStatus(status); err != nil {
+		t.Fatalf("outputMoleculeStatus: %v", err)
+	}
+
+	w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	os.Stdout = oldStdout
+	output := buf.String()
+
+	if !strings.Contains(output, "📐 Formula: mol-release") {
+		t.Fatalf("expected formula in output, got:\n%s", output)
+	}
+	if !strings.Contains(output, "--var version=1.2.3") || !strings.Contains(output, "--var channel=stable") {
+		t.Fatalf("expected formula vars in output, got:\n%s", output)
+	}
+}

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -497,18 +497,22 @@ func checkSlungWork(ctx RoleContext, hookedBead *beads.Issue) bool {
 	}
 
 	attachment := beads.ParseAttachmentFields(hookedBead)
-	hasMolecule := attachment != nil && attachment.AttachedMolecule != ""
+	hasWorkflow := hasWorkflowAttachment(attachment)
 
-	outputAutonomousDirective(ctx, hookedBead, hasMolecule)
+	outputAutonomousDirective(ctx, hookedBead, hasWorkflow)
 	outputHookedBeadDetails(hookedBead)
 
-	if hasMolecule {
+	if hasWorkflow {
 		outputMoleculeWorkflow(ctx, attachment)
 	} else {
 		outputBeadPreview(hookedBead)
 	}
 
 	return true
+}
+
+func hasWorkflowAttachment(attachment *beads.AttachmentFields) bool {
+	return attachment != nil && (attachment.AttachedMolecule != "" || attachment.AttachedFormula != "")
 }
 
 // findAgentWork looks up hooked or in-progress beads assigned to this agent.
@@ -682,6 +686,12 @@ func outputMoleculeWorkflow(ctx RoleContext, attachment *beads.AttachmentFields)
 	if attachment.AttachedMolecule != "" {
 		fmt.Printf("Molecule ID: %s\n", attachment.AttachedMolecule)
 	}
+	if len(attachment.AttachedVars) > 0 {
+		fmt.Printf("\n%s\n", style.Bold.Render("🧩 VARS (instantiated formula inputs):"))
+		for _, variable := range attachment.AttachedVars {
+			fmt.Printf("  --var %s\n", variable)
+		}
+	}
 	if attachment.AttachedArgs != "" {
 		fmt.Printf("\n%s\n", style.Bold.Render("📋 ARGS (use these to guide execution):"))
 		fmt.Printf("  %s\n", attachment.AttachedArgs)
@@ -739,6 +749,9 @@ func outputRalphLoopDirective(_ RoleContext, attachment *beads.AttachmentFields)
 func buildRalphPromptFromMolecule(attachment *beads.AttachmentFields) string {
 	var b strings.Builder
 	b.WriteString("Execute the attached molecule workflow. ")
+	if len(attachment.AttachedVars) > 0 {
+		b.WriteString("Formula vars: " + strings.Join(attachment.AttachedVars, ", ") + ". ")
+	}
 	if attachment.AttachedArgs != "" {
 		b.WriteString("Context: " + attachment.AttachedArgs + ". ")
 	}

--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -512,7 +512,7 @@ func outputAttachmentStatus(ctx RoleContext) {
 
 	// Check first pinned bead for attachment
 	attachment := beads.ParseAttachmentFields(pinnedBeads[0])
-	if attachment == nil || attachment.AttachedMolecule == "" {
+	if !hasWorkflowAttachment(attachment) {
 		// No attachment - interactive mode
 		return
 	}
@@ -521,9 +521,21 @@ func outputAttachmentStatus(ctx RoleContext) {
 	fmt.Println()
 	fmt.Printf("%s\n\n", style.Bold.Render("## 🎯 ATTACHED WORK DETECTED"))
 	fmt.Printf("Pinned bead: %s\n", pinnedBeads[0].ID)
-	fmt.Printf("Attached molecule: %s\n", attachment.AttachedMolecule)
+	if attachment.AttachedFormula != "" {
+		fmt.Printf("Attached formula: %s\n", attachment.AttachedFormula)
+	}
+	if attachment.AttachedMolecule != "" {
+		fmt.Printf("Attached molecule: %s\n", attachment.AttachedMolecule)
+	}
 	if attachment.AttachedAt != "" {
 		fmt.Printf("Attached at: %s\n", attachment.AttachedAt)
+	}
+	if len(attachment.AttachedVars) > 0 {
+		fmt.Println()
+		fmt.Printf("%s\n", style.Bold.Render("🧩 VARS (instantiated formula inputs):"))
+		for _, variable := range attachment.AttachedVars {
+			fmt.Printf("  --var %s\n", variable)
+		}
 	}
 	if attachment.AttachedArgs != "" {
 		fmt.Println()

--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -902,3 +902,40 @@ func TestOutputContinuationDirective(t *testing.T) {
 		}
 	})
 }
+
+func TestCheckSlungWork_StandaloneFormulaUsesWorkflowOutput(t *testing.T) {
+	ctx := RoleContext{Role: RoleCrew}
+	hookedBead := &beads.Issue{
+		ID:    "gt-wisp-xyz",
+		Title: "Standalone formula work",
+		Description: strings.Join([]string{
+			"attached_formula: mol-nonexistent",
+			`attached_vars: ["version=1.2.3"]`,
+		}, "\n"),
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	found := checkSlungWork(ctx, hookedBead)
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stdout = oldStdout
+	output := buf.String()
+
+	if !found {
+		t.Fatalf("checkSlungWork() = false, want true")
+	}
+	if !strings.Contains(output, "ATTACHED FORMULA") {
+		t.Fatalf("expected standalone formula hook to use workflow output, got:\n%s", output)
+	}
+	if strings.Contains(output, "Bead details:") {
+		t.Fatalf("expected standalone formula hook to skip plain bead preview, got:\n%s", output)
+	}
+	if !strings.Contains(output, "--var version=1.2.3") {
+		t.Fatalf("expected standalone formula context to be shown, got:\n%s", output)
+	}
+}

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -906,6 +906,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	fieldUpdates := beadFieldUpdates{
 		Dispatcher:       actor,
 		Args:             slingArgs,
+		Vars:             append([]string(nil), slingVars...),
 		AttachedMolecule: attachedMoleculeID,
 		AttachedFormula:  formulaName,
 		NoMerge:          slingNoMerge,

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -329,6 +329,7 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 	fieldUpdates := beadFieldUpdates{
 		Dispatcher:       actor,
 		Args:             params.Args,
+		Vars:             append([]string(nil), params.Vars...),
 		AttachedMolecule: attachedMoleculeID,
 		AttachedFormula:  params.FormulaName,
 		NoMerge:          params.NoMerge,

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -202,6 +202,7 @@ func runSlingFormula(ctx context.Context, args []string) error {
 	fieldUpdates := beadFieldUpdates{
 		Dispatcher:      actor,
 		Args:            slingArgs,
+		Vars:            append([]string(nil), slingVars...),
 		AttachedFormula: formulaName,
 	}
 	if err := storeFieldsInBead(wispRootID, fieldUpdates); err != nil {

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -255,6 +255,7 @@ func getBeadInfo(beadID string) (*beadInfo, error) {
 type beadFieldUpdates struct {
 	Dispatcher       string // Agent that dispatched the work
 	Args             string // Natural language instructions
+	Vars             []string // Formula variables (key=value pairs)
 	AttachedMolecule string // Wisp root ID
 	AttachedFormula  string // Formula name (e.g., "mol-polecat-work") for inline step display
 	NoMerge          bool   // Skip merge queue on completion
@@ -308,6 +309,9 @@ func storeFieldsInBead(beadID string, updates beadFieldUpdates) error {
 	}
 	if updates.Args != "" {
 		fields.AttachedArgs = updates.Args
+	}
+	if len(updates.Vars) > 0 {
+		fields.AttachedVars = append([]string(nil), updates.Vars...)
 	}
 	if updates.AttachedMolecule != "" {
 		fields.AttachedMolecule = updates.AttachedMolecule

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -695,6 +695,117 @@ exit /b 0
 	}
 }
 
+func TestRunSlingFormulaPersistsVarContext(t *testing.T) {
+	townRoot := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir mayor/rig: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+
+	logPath := filepath.Join(townRoot, "bd.log")
+	bdScript := `#!/bin/sh
+set -e
+echo "$PWD|$*" >> "${BD_LOG}"
+cmd="$1"
+shift || true
+case "$cmd" in
+  formula)
+    echo '{"name":"mol-anything"}'
+    ;;
+  cook)
+    exit 0
+    ;;
+  mol)
+    sub="$1"
+    shift || true
+    case "$sub" in
+      wisp)
+        echo '{"new_epic_id":"gt-wisp-xyz"}'
+        ;;
+    esac
+    ;;
+esac
+exit 0
+`
+	bdScriptWindows := `@echo off
+setlocal enableextensions
+echo %CD%^|%*>>"%BD_LOG%"
+set "cmd=%1"
+set "sub=%2"
+if "%cmd%"=="formula" (
+  echo {"name":"mol-anything"}
+  exit /b 0
+)
+if "%cmd%"=="cook" exit /b 0
+if "%cmd%"=="mol" (
+  if "%sub%"=="wisp" (
+    echo {"new_epic_id":"gt-wisp-xyz"}
+    exit /b 0
+  )
+)
+exit /b 0
+`
+	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
+
+	attachedLogPath := filepath.Join(townRoot, "attached-molecule.log")
+	t.Setenv("GT_TEST_ATTACHED_MOLECULE_LOG", attachedLogPath)
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv(EnvGTRole, "mayor")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("GT_CREW", "")
+	t.Setenv("TMUX_PANE", "")
+	t.Setenv("GT_TEST_NO_NUDGE", "1")
+	t.Setenv("GT_TEST_SKIP_HOOK_VERIFY", "1")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	prevVars := slingVars
+	prevDryRun := slingDryRun
+	prevNoBoot := slingNoBoot
+	t.Cleanup(func() {
+		slingVars = prevVars
+		slingDryRun = prevDryRun
+		slingNoBoot = prevNoBoot
+	})
+
+	slingVars = []string{"version=1.2.3", "channel=stable"}
+	slingDryRun = false
+	slingNoBoot = true
+
+	if err := runSlingFormula(context.Background(), []string{"mol-anything"}); err != nil {
+		t.Fatalf("runSlingFormula: %v", err)
+	}
+
+	attachmentBytes, err := os.ReadFile(attachedLogPath)
+	if err != nil {
+		t.Fatalf("read attachment log: %v", err)
+	}
+	attachment := string(attachmentBytes)
+
+	if !strings.Contains(attachment, "attached_formula: mol-anything") {
+		t.Fatalf("formula attachment missing from persisted description:\n%s", attachment)
+	}
+	if !strings.Contains(attachment, "version=1.2.3") || !strings.Contains(attachment, "channel=stable") {
+		t.Fatalf("formula vars missing from persisted description:\n%s", attachment)
+	}
+}
+
 // TestSlingFormulaOnBeadPassesFeatureAndIssueVars verifies that when using
 // gt sling <formula> --on <bead>, both --var feature=<title> and --var issue=<beadID>
 // are passed to the bd mol wisp command.


### PR DESCRIPTION
## Summary
- persist `gt sling --var` inputs into durable attachment metadata as `attached_vars`
- surface formula vars in `gt prime`, `gt hook` / `gt mol status`, and JSON status output
- add focused regression tests for beads round-trip, sling persistence, prime output, and mol status output

Fixes #2538

## Context
This is the standalone resubmission requested after the earlier stacked PR was closed.

This version is based directly on current `upstream/main` and does **not** carry the old `bd list --json` plain-text parser/fallback from the previous hook-visibility PR discussion.

## Verification
- `go test ./internal/beads -run 'TestParseAttachmentFields|TestFormatAttachmentFields|TestAttachmentFieldsRoundTrip|TestNoMergeField' -count=1`
- `go test ./internal/cmd -run 'TestRunSlingFormulaPersistsVarContext|TestCheckSlungWork_StandaloneFormulaUsesWorkflowOutput|TestOutputMoleculeStatus_StandaloneFormulaShowsVars' -count=1`

## Notes
- `--var` remains a supported formula input path
- this PR focuses only on making those formula inputs durably visible to the assignee-facing views