### PR TITLE
fix: render hooked formula wisps as workflow work

### DIFF
--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -126,6 +126,7 @@ type MoleculeStatusInfo struct {
 	HasWork          bool                  `json:"has_work"`
 	PinnedBead       *beads.Issue          `json:"pinned_bead,omitempty"`
 	AttachedMolecule string                `json:"attached_molecule,omitempty"`
+	AttachedFormula  string                `json:"attached_formula,omitempty"`
 	AttachedAt       string                `json:"attached_at,omitempty"`
 	AttachedArgs     string                `json:"attached_args,omitempty"`
 	IsWisp           bool                  `json:"is_wisp"`
@@ -490,6 +491,7 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 		attachment := beads.ParseAttachmentFields(hookBead)
 		if attachment != nil {
 			status.AttachedMolecule = attachment.AttachedMolecule
+			status.AttachedFormula = attachment.AttachedFormula
 			status.AttachedAt = attachment.AttachedAt
 			status.AttachedArgs = attachment.AttachedArgs
 
@@ -500,6 +502,10 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 				progress, _ := getMoleculeProgressInfo(b, attachment.AttachedMolecule)
 				status.Progress = progress
 				status.NextAction = determineNextAction(status)
+			} else if attachment.AttachedFormula != "" {
+				progress, _ := getMoleculeProgressInfo(b, hookBead.ID)
+				status.Progress = progress
+				status.NextAction = determineNextAction(status)
 			}
 		}
 	}
@@ -507,8 +513,10 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 	// Determine next action if no work is slung
 	if !status.HasWork {
 		status.NextAction = "Check inbox for work assignments: gt mail inbox"
-	} else if status.AttachedMolecule == "" {
+	} else if status.AttachedMolecule == "" && status.AttachedFormula == "" {
 		status.NextAction = "Attach a molecule to start work: gt mol attach <bead-id> <molecule-id>"
+	} else if status.AttachedFormula != "" && status.NextAction == "" && status.PinnedBead != nil {
+		status.NextAction = "Show the workflow steps: gt prime or bd mol current " + status.PinnedBead.ID
 	}
 
 	// JSON output
@@ -738,6 +746,9 @@ func outputMoleculeStatus(status MoleculeStatusInfo) error {
 	}
 
 	fmt.Printf("%s %s: %s\n", style.Bold.Render("🪝 Hooked:"), status.PinnedBead.ID, status.PinnedBead.Title)
+	if status.AttachedFormula != "" {
+		fmt.Printf("%s %s\n", style.Bold.Render("📐 Formula:"), status.AttachedFormula)
+	}
 
 	// Show attached molecule
 	if status.AttachedMolecule != "" {
@@ -752,7 +763,7 @@ func outputMoleculeStatus(status MoleculeStatusInfo) error {
 		if status.AttachedArgs != "" {
 			fmt.Printf("   %s %s\n", style.Bold.Render("Args:"), status.AttachedArgs)
 		}
-	} else {
+	} else if status.AttachedFormula == "" {
 		fmt.Printf("%s\n", style.Dim.Render("No molecule attached (hooked bead still triggers autonomous work)"))
 	}
 

--- a/internal/cmd/molecule_status_test.go
+++ b/internal/cmd/molecule_status_test.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func TestOutputMoleculeStatus_FormulaWispShowsWorkflowContext(t *testing.T) {
+	status := MoleculeStatusInfo{
+		HasWork:         true,
+		PinnedBead:      &beads.Issue{ID: "tool-wisp-demo", Title: "demo-hello"},
+		AttachedFormula: "demo-hello",
+		Progress: &MoleculeProgressInfo{
+			RootID:     "tool-wisp-demo",
+			RootTitle:  "demo-hello",
+			TotalSteps: 3,
+			DoneSteps:  0,
+			ReadySteps: []string{"tool-wisp-step-1"},
+		},
+		NextAction: "Show the workflow steps: gt prime or bd mol current tool-wisp-demo",
+	}
+
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	if err := outputMoleculeStatus(status); err != nil {
+		t.Fatalf("outputMoleculeStatus: %v", err)
+	}
+
+	w.Close()
+	var buf bytes.Buffer
+	_, _ = io.Copy(&buf, r)
+	os.Stdout = oldStdout
+	output := buf.String()
+
+	if !strings.Contains(output, "📐 Formula: demo-hello") {
+		t.Fatalf("expected formula line in output, got:\n%s", output)
+	}
+	if strings.Contains(output, "No molecule attached") {
+		t.Fatalf("formula wisp should not be rendered as naked work, got:\n%s", output)
+	}
+	if strings.Contains(output, "Attach a molecule to start work") {
+		t.Fatalf("formula wisp should not suggest gt mol attach, got:\n%s", output)
+	}
+	if !strings.Contains(output, "Show the workflow steps: gt prime or bd mol current tool-wisp-demo") {
+		t.Fatalf("expected workflow next action, got:\n%s", output)
+	}
+}


### PR DESCRIPTION
## Summary
- treat hooked beads with `attached_formula` as workflow work in `gt hook` / `gt mol status`
- compute progress from the hooked formula root when there is no `attached_molecule`
- stop telling users to `gt mol attach` for already-hooked formula wisps
- add a focused regression test for formula-wisp status output

## Problem
When a hooked bead represents formula work and carries `attached_formula`, `gt hook` / `gt mol status` still render it like naked work instead of workflow work.

That leads to misleading output such as:
- `No molecule attached`
- `Next: Attach a molecule to start work: gt mol attach ...`

This is confusing because the formula work is already hooked and should be treated as the active workflow.

## What This Changes
This PR makes formula-backed hooked work render as workflow work by:
- surfacing the formula name in hook/status output
- deriving progress from the hooked formula root when appropriate
- avoiding the misleading naked-work messaging and `gt mol attach` suggestion for formula wisps

## Verification
- `go test ./internal/cmd -run 'TestOutputMoleculeStatus_FormulaWispShowsWorkflowContext' -count=1`
- built a temporary `gt` binary from this branch and verified `gt hook` / `gt hook --json` against a real hooked `demo-hello` formula wisp
