### PR TITLE
fix: avoid race condition in Dolt startup readiness check

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1272,19 +1272,17 @@ func Start(townRoot string) error {
 		fmt.Fprintf(os.Stderr, "Warning: failed to save state: %v\n", err)
 	}
 
-	// Wait for the server to be accepting connections, not just alive.
-	// IsRunning only checks PID — we need CheckServerReachable to confirm
-	// the port is listening. Retry with backoff since startup takes time.
+	// Wait for the server to be accepting connections.
+	// Don't use IsRunning() here — it treats "process alive, port not yet
+	// listening" as a stale PID and destructively deletes the PID file we
+	// just wrote. Instead, check the spawned process directly via signal 0.
 	var lastErr error
 	for attempt := 0; attempt < 10; attempt++ {
 		time.Sleep(500 * time.Millisecond)
 
-		running, _, err = IsRunning(townRoot)
-		if err != nil {
-			return fmt.Errorf("verifying server started: %w", err)
-		}
-		if !running {
-			return fmt.Errorf("Dolt server failed to start (check logs with 'gt dolt logs')")
+		// Check if the process we just started is still alive.
+		if err := cmd.Process.Signal(syscall.Signal(0)); err != nil {
+			return fmt.Errorf("Dolt server process exited during startup (check logs with 'gt dolt logs')")
 		}
 
 		if err := CheckServerReachable(townRoot); err == nil {


### PR DESCRIPTION
## Summary

- **Bug**: `Start()` readiness loop called `IsRunning()`, which treats "process alive but port not yet listening" as a stale PID — destructively deleting the PID file. During cold start this causes a false "Dolt server failed to start" error even though the process is still starting up.
- **Fix**: Replace `IsRunning()` in the readiness loop with `cmd.Process.Signal(syscall.Signal(0))` — a direct process liveness check with no destructive side effects. `CheckServerReachable()` still handles port verification on the next iteration.
- The `Signal(0)` pattern is already used elsewhere in `doltserver.go` for process liveness checks.

Fixes #2612

## Test plan

- [ ] Cold start `gt dolt start` on a machine where Dolt takes >500ms to bind port
- [ ] Verify PID file is preserved throughout startup sequence
- [ ] Verify graceful error if process actually crashes during startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>