### PR TITLE
feat: github-sheriff plugin for PR categorization and status reporting

### DIFF
--- a/plugins/github-sheriff/execute.sh
+++ b/plugins/github-sheriff/execute.sh
@@ -10,8 +10,34 @@ set -euo pipefail
 
 readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 readonly GITHUB_TOKEN="${GITHUB_TOKEN:-}"
-readonly RIGS=("beads" "debt_buying" "gleam" "laser" "payment_portal" "shuffle" "teleport" "gastown")
-readonly DOGS_DIR="/Users/seanbearden/gt/deacon/dogs/charlie"
+
+# Discover town root — walk up from script dir until we find .gt or rigs.json
+find_town_root() {
+    local dir="$SCRIPT_DIR"
+    while [ "$dir" != "/" ]; do
+        if [ -f "$dir/rigs.json" ] || [ -d "$dir/.gt" ]; then
+            echo "$dir"
+            return 0
+        fi
+        dir="$(dirname "$dir")"
+    done
+    # Fallback: GT_TOWN_ROOT env var
+    if [ -n "${GT_TOWN_ROOT:-}" ]; then
+        echo "$GT_TOWN_ROOT"
+        return 0
+    fi
+    return 1
+}
+
+TOWN_ROOT="$(find_town_root)" || { echo "ERROR: cannot find town root" >&2; exit 1; }
+
+# Discover rigs dynamically from rigs.json
+if [ -f "$TOWN_ROOT/rigs.json" ]; then
+    mapfile -t RIGS < <(jq -r 'keys[]' "$TOWN_ROOT/rigs.json" 2>/dev/null)
+else
+    echo "ERROR: rigs.json not found at $TOWN_ROOT/rigs.json" >&2
+    exit 1
+fi
 
 # Color codes for output
 readonly RED='\033[0;31m'
@@ -53,9 +79,9 @@ main() {
 
     # Iterate through all rigs
     for rig in "${RIGS[@]}"; do
-        local repo_path="$DOGS_DIR/$rig"
+        local repo_path="$TOWN_ROOT/$rig"
 
-        # Verify repository exists
+        # Verify repository exists (rig root should be a git clone)
         if [ ! -d "$repo_path/.git" ]; then
             log_info "Repository not found or not a git repo: $repo_path"
             continue

--- a/plugins/github-sheriff/plugin.md
+++ b/plugins/github-sheriff/plugin.md
@@ -29,158 +29,27 @@ Monitors open pull requests across all Gas Town rigs and categorizes them by com
 
 ## Detection
 
-Check for git remote and PR sources:
-
-```bash
-RIGS=("beads" "debt_buying" "gleam" "laser" "payment_portal" "shuffle" "teleport" "gastown")
-GITHUB_TOKEN="${GITHUB_TOKEN:-}"
-
-if [ -z "$GITHUB_TOKEN" ]; then
-  # No GitHub token, cannot fetch PRs
-  bd wisp create \
-    --label type:plugin-run \
-    --label plugin:github-sheriff \
-    --label result:skipped \
-    --body "GitHub token not configured - skipping PR categorization"
-  exit 0
-fi
-```
+Discovers rigs dynamically from `rigs.json` in the town root. Requires `GITHUB_TOKEN` env var.
 
 ## Action
 
 ### 1. Fetch open PRs for each rig
 
-```bash
-for RIG in "${RIGS[@]}"; do
-  REPO_PATH="/Users/seanbearden/gt/deacon/dogs/charlie/$RIG"
-
-  if [ ! -d "$REPO_PATH/.git" ]; then
-    continue
-  fi
-
-  # Extract GitHub owner/repo from git remote
-  REMOTE_URL=$(cd "$REPO_PATH" && git config --get remote.origin.url)
-  OWNER=$(echo "$REMOTE_URL" | sed -E 's|.*[:/]([^/]+)/([^/]+)\.git$|\1|')
-  REPO=$(echo "$REMOTE_URL" | sed -E 's|.*[:/]([^/]+)/([^/]+)\.git$|\2|')
-
-  if [ -z "$OWNER" ] || [ -z "$REPO" ]; then
-    continue
-  fi
-done
-```
+Iterates over rigs discovered from `rigs.json`, extracts GitHub owner/repo from each rig's git remote, and fetches open PRs via the GitHub API.
 
 ### 2. Categorize each PR
 
-```bash
-# Easy Wins: Green
-# - CI passing (all checks pass)
-# - Small PR (< 200 lines changed)
-# - No merge conflicts
-# - Author is a bot or trusted integrations
+- **Easy Wins**: CI passing, small (<200 lines), no merge conflicts
+- **Needs Review**: CI failing, large, or has conflicts
 
-# Needs Review: Yellow
-# - CI failing or incomplete
-# - Large PR (>= 200 lines changed)
-# - Merge conflicts present
-# - Sensitive files changed
-# - Multiple reviewers requested
+### 3. Record result
 
-EASY_WINS=()
-NEEDS_REVIEW=()
-
-# Use GitHub API to fetch PR details and categorize
-curl -s -H "Authorization: token $GITHUB_TOKEN" \
-  "https://api.github.com/repos/$OWNER/$REPO/pulls?state=open&sort=updated&direction=desc" \
-  | jq -r '.[] | @json' \
-  | while read -r PR_JSON; do
-    PR=$(echo "$PR_JSON" | jq -r '.')
-    PR_NUMBER=$(echo "$PR" | jq -r '.number')
-    PR_TITLE=$(echo "$PR" | jq -r '.title')
-    AUTHOR=$(echo "$PR" | jq -r '.user.login')
-    CI_STATUS=$(echo "$PR" | jq -r '.statuses_url // .commits_url' | head -1)
-
-    # Fetch status
-    STATUS=$(curl -s -H "Authorization: token $GITHUB_TOKEN" \
-      "$CI_STATUS" 2>/dev/null | jq -r '.status // "unknown"')
-
-    if [ "$STATUS" = "success" ]; then
-      EASY_WINS+=("$RIG/$PR_NUMBER: $PR_TITLE (author: $AUTHOR)")
-    else
-      NEEDS_REVIEW+=("$RIG/$PR_NUMBER: $PR_TITLE (status: $STATUS)")
-    fi
-  done
-```
-
-### 3. Record Result
-
-Count and categorize:
-
-```bash
-EASY_COUNT=${#EASY_WINS[@]}
-NEEDS_COUNT=${#NEEDS_REVIEW[@]}
-TOTAL_COUNT=$((EASY_COUNT + NEEDS_COUNT))
-
-if [ $TOTAL_COUNT -eq 0 ]; then
-  # No open PRs
-  bd wisp create \
-    --label type:plugin-run \
-    --label plugin:github-sheriff \
-    --label result:success \
-    --body "PR Sheriff patrol complete: no open PRs found"
-  exit 0
-fi
-```
-
-### On success:
-
-```bash
-EASY_LIST=$(printf '%s\n' "${EASY_WINS[@]}")
-NEEDS_LIST=$(printf '%s\n' "${NEEDS_REVIEW[@]}")
-
-bd wisp create \
-  --label type:plugin-run \
-  --label plugin:github-sheriff \
-  --label result:success \
-  --body "PR Sheriff patrol complete: $EASY_COUNT easy wins, $NEEDS_COUNT need review
-
-**Easy Wins (ready to sling):**
-$EASY_LIST
-
-**Needs Review (flag for human):**
-$NEEDS_LIST"
-```
-
-### On failure:
-
-```bash
-ERROR_MSG="${1:-Unknown error}"
-
-bd wisp create \
-  --label type:plugin-run \
-  --label plugin:github-sheriff \
-  --label result:failure \
-  --body "PR Sheriff patrol failed: $ERROR_MSG"
-
-gt escalate --severity=medium \
-  --subject="Plugin FAILED: github-sheriff" \
-  --body="Error during PR categorization: $ERROR_MSG" \
-  --source="plugin:github-sheriff"
-```
+Creates a wisp with categorized summary. On failure, escalates via `gt escalate`.
 
 ## Notes
 
-- Runs hourly to keep PR status current
-- Requires GITHUB_TOKEN environment variable
-- Monitors all standard Gas Town rigs
-- Easy wins are candidates for auto-merge or quick sling to other crew
-- Complex PRs flagged for human review and decision-making
+- Runs hourly via cron gate
+- Requires `GITHUB_TOKEN` environment variable
+- Discovers rigs dynamically from `rigs.json` (no hardcoded rig list)
+- Executed via `execute.sh` — not AI-interpreted
 - Results stored as wisps for audit trail
-- Categories extensible for custom rules
-
-## Future Enhancements
-
-- Auto-merge simple PRs (with human approval rules)
-- Slack notifications for new PRs
-- Custom categorization rules per rig
-- Lint/test requirement integration
-- Historical PR metrics dashboard


### PR DESCRIPTION
## Summary

- Implements github-sheriff plugin with `execute.sh` for automated PR monitoring
- Discovers rigs dynamically from `rigs.json` (no hardcoded rig list)
- Categorizes open PRs as "easy wins" (CI passing, small, mergeable) vs "needs review"
- Reports summary via beads wisps, escalates on failure
- Runs hourly via cron gate, requires `GITHUB_TOKEN` env var

Split from #2615 for focused review.

## Test plan

- [ ] Verify `execute.sh` discovers rigs from `rigs.json`
- [ ] Verify PR categorization with valid `GITHUB_TOKEN`
- [ ] Verify graceful skip when `GITHUB_TOKEN` is not set

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>