### PR TITLE
fix: clean worktree state before branch switch in ReuseIdlePolecat

### DIFF
--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1543,10 +1543,25 @@ func (m *Manager) ReuseIdlePolecat(name string, opts AddOptions) (*Polecat, erro
 		return nil, fmt.Errorf("start point %s not found — fall back to full repair", startPoint)
 	}
 
+	// Clean worktree state before branch switch — the worktree may have stale
+	// state from a previous dog/pool dispatch (uncommitted changes, detached HEAD,
+	// or checked out on an old dog/alpha-* branch).
+	_ = polecatGit.ResetHard("HEAD")
+
 	// Create fresh branch from start point (branch-only, no worktree add/remove)
 	branchName := m.buildBranchName(name, opts.HookBead)
 	if err := polecatGit.CheckoutNewBranch(branchName, startPoint); err != nil {
-		return nil, fmt.Errorf("creating branch %s from %s: %w", branchName, startPoint, err)
+		// checkout -b fails if we're in detached HEAD or branch already exists.
+		// Fall back to: create branch separately, then checkout.
+		_ = polecatGit.Checkout(startPoint)
+		if err2 := polecatGit.CheckoutNewBranch(branchName, startPoint); err2 != nil {
+			return nil, fmt.Errorf("creating branch %s from %s (retry after cleanup): %w", branchName, startPoint, err2)
+		}
+	}
+
+	// Verify the worktree is actually on the expected branch
+	if actual, err := polecatGit.CurrentBranch(); err == nil && actual != branchName {
+		return nil, fmt.Errorf("branch mismatch after checkout: expected %s, got %s", branchName, actual)
 	}
 
 	// Reset agent bead for reuse


### PR DESCRIPTION
## Summary
- Reset worktree state (`git reset --hard`) before branch switch when reusing an idle polecat
- Add fallback: if `checkout -b` fails (detached HEAD, stale dog branch), checkout startPoint first then retry
- Add post-checkout verification that the branch matches expectations

## Problem
When `gt sling` reuses a polecat worktree that was previously used by a daemon pool dog, the worktree retains the old `dog/alpha-*` branch. `CheckoutNewBranch()` fails silently, causing the polecat to code on the wrong branch. `gt done` then can't push or create MR beads.

Fixes #2621

## Test plan
- [ ] `gt sling` reuses an idle polecat that was previously a dog — verify new polecat branch is checked out
- [ ] `gt sling` reuses a polecat in detached HEAD state — verify recovery
- [ ] `gt done` succeeds after reuse (branch name matches, push works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)