### PR TITLE
fix(convoy): cross-database dependency resolution for multi-rig towns

### DIFF
--- a/internal/convoy/multi_store.go
+++ b/internal/convoy/multi_store.go
@@ -1,0 +1,118 @@
+// Package convoy — multi-store resolution for cross-database convoy tracking.
+package convoy
+
+import (
+	"context"
+	"strings"
+
+	beadsdk "github.com/steveyegge/beads"
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+// StoreResolver resolves beads issues across multiple stores using prefix-based
+// routing. In multi-rig Gas Town setups, each rig has its own Dolt database.
+// Convoys live in the HQ store but may track issues in rig stores (e.g., ds-*
+// in dashboard). Without cross-store resolution, convoy tracking sees 0/0 for
+// cross-database dependencies. See GH #2624.
+type StoreResolver struct {
+	// stores maps store names ("hq", "dashboard", etc.) to beads stores.
+	stores map[string]beadsdk.Storage
+
+	// townRoot is the path to the town root, used for prefix → rig name lookup.
+	townRoot string
+}
+
+// NewStoreResolver creates a resolver from the daemon's store map.
+// If stores is nil or empty, all resolution methods fall through gracefully.
+func NewStoreResolver(townRoot string, stores map[string]beadsdk.Storage) *StoreResolver {
+	return &StoreResolver{
+		stores:   stores,
+		townRoot: townRoot,
+	}
+}
+
+// ResolveIssues fetches fresh issue data for the given IDs, looking up each
+// issue in the appropriate store based on its prefix. Issues found in any store
+// are returned in the result map. Issues not found in any store are omitted.
+func (r *StoreResolver) ResolveIssues(ctx context.Context, ids []string) map[string]*beadsdk.Issue {
+	result := make(map[string]*beadsdk.Issue, len(ids))
+	if len(r.stores) == 0 || len(ids) == 0 {
+		return result
+	}
+
+	// Group IDs by target store name via prefix → rig name routing.
+	// IDs whose prefix maps to HQ (empty rig name) use the "hq" store.
+	byStore := make(map[string][]string)
+	for _, id := range ids {
+		storeName := r.storeForID(id)
+		if storeName != "" {
+			byStore[storeName] = append(byStore[storeName], id)
+		}
+	}
+
+	for storeName, storeIDs := range byStore {
+		store := r.stores[storeName]
+		if store == nil {
+			continue
+		}
+
+		issues, err := store.GetIssuesByIDs(ctx, storeIDs)
+		if err != nil {
+			continue
+		}
+		for _, iss := range issues {
+			if iss != nil {
+				result[iss.ID] = iss
+			}
+		}
+	}
+
+	return result
+}
+
+// ResolveDepsWithMetadata fetches dependency metadata for an issue, trying
+// the appropriate store for that issue's prefix. Returns nil on any error.
+func (r *StoreResolver) ResolveDepsWithMetadata(ctx context.Context, issueID string) []*beadsdk.IssueWithDependencyMetadata {
+	if len(r.stores) == 0 {
+		return nil
+	}
+
+	storeName := r.storeForID(issueID)
+	if storeName == "" {
+		return nil
+	}
+	store := r.stores[storeName]
+	if store == nil {
+		return nil
+	}
+
+	deps, err := store.GetDependenciesWithMetadata(ctx, issueID)
+	if err != nil {
+		return nil
+	}
+	return deps
+}
+
+// storeForID returns the store name for a given issue ID based on prefix routing.
+// Returns "hq" for town-level prefixes, rig name for rig prefixes, or "" if unknown.
+func (r *StoreResolver) storeForID(id string) string {
+	// Strip external: wrapper if present
+	if strings.HasPrefix(id, "external:") {
+		parts := strings.SplitN(id, ":", 3)
+		if len(parts) == 3 {
+			id = parts[2]
+		}
+	}
+
+	prefix := beads.ExtractPrefix(id)
+	if prefix == "" {
+		return ""
+	}
+
+	rigName := beads.GetRigNameForPrefix(r.townRoot, prefix)
+	if rigName == "" {
+		// Town-level prefix (e.g., "hq-") or unknown → use hq store
+		return "hq"
+	}
+	return rigName
+}

--- a/internal/convoy/multi_store_test.go
+++ b/internal/convoy/multi_store_test.go
@@ -1,0 +1,184 @@
+package convoy
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	beadsdk "github.com/steveyegge/beads"
+	beadsRouting "github.com/steveyegge/gastown/internal/beads"
+)
+
+// setupTestStoreWithPrefix opens a test store and sets a specific prefix.
+func setupTestStoreWithPrefix(t *testing.T, prefix string) (beadsdk.Storage, func()) {
+	t.Helper()
+	t.Setenv("BEADS_TEST_MODE", "1")
+
+	dir := t.TempDir()
+	beadsDir := filepath.Join(dir, ".beads")
+	doltPath := filepath.Join(beadsDir, "dolt")
+	if err := os.MkdirAll(doltPath, 0755); err != nil {
+		t.Skipf("cannot create test dir: %v", err)
+	}
+
+	ctx := context.Background()
+	store, err := beadsdk.Open(ctx, doltPath)
+	if err != nil {
+		t.Skipf("beads store unavailable (CGO/Dolt required): %v", err)
+	}
+
+	if err := store.SetConfig(ctx, "issue_prefix", prefix); err != nil {
+		_ = store.Close()
+		t.Skipf("SetConfig issue_prefix: %v", err)
+	}
+
+	cleanup := func() { _ = store.Close() }
+	return store, cleanup
+}
+
+func TestStoreResolver_ResolveIssues_SingleStore(t *testing.T) {
+	store, cleanup := setupTestStoreWithPrefix(t, "hq")
+	defer cleanup()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	issue := &beadsdk.Issue{
+		ID:        "hq-test1",
+		Title:     "Test Issue",
+		Status:    beadsdk.StatusOpen,
+		Priority:  2,
+		IssueType: beadsdk.TypeTask,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := store.CreateIssue(ctx, issue, "test"); err != nil {
+		t.Fatalf("CreateIssue: %v", err)
+	}
+
+	// Create a town root with routes pointing hq- to "."
+	townRoot := t.TempDir()
+	beadsDir := filepath.Join(townRoot, ".beads")
+	os.MkdirAll(beadsDir, 0755)
+	beadsRouting.WriteRoutes(beadsDir, []beadsRouting.Route{
+		{Prefix: "hq-", Path: "."},
+	})
+
+	resolver := NewStoreResolver(townRoot, map[string]beadsdk.Storage{
+		"hq": store,
+	})
+
+	result := resolver.ResolveIssues(ctx, []string{"hq-test1"})
+	if len(result) != 1 {
+		t.Fatalf("ResolveIssues returned %d issues, want 1", len(result))
+	}
+	if result["hq-test1"] == nil {
+		t.Fatal("hq-test1 not found in result")
+	}
+	if string(result["hq-test1"].Status) != "open" {
+		t.Errorf("status = %s, want open", result["hq-test1"].Status)
+	}
+}
+
+func TestStoreResolver_ResolveIssues_CrossStore(t *testing.T) {
+	hqStore, hqCleanup := setupTestStoreWithPrefix(t, "hq")
+	defer hqCleanup()
+	dsStore, dsCleanup := setupTestStoreWithPrefix(t, "ds")
+	defer dsCleanup()
+
+	ctx := context.Background()
+	now := time.Now().UTC()
+
+	// Create issue in "ds" store only
+	dsIssue := &beadsdk.Issue{
+		ID:        "ds-abc",
+		Title:     "Dashboard Issue",
+		Status:    beadsdk.StatusClosed,
+		Priority:  1,
+		IssueType: beadsdk.TypeTask,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := dsStore.CreateIssue(ctx, dsIssue, "test"); err != nil {
+		t.Fatalf("CreateIssue ds: %v", err)
+	}
+
+	// Create issue in "hq" store
+	hqIssue := &beadsdk.Issue{
+		ID:        "hq-xyz",
+		Title:     "HQ Issue",
+		Status:    beadsdk.StatusOpen,
+		Priority:  2,
+		IssueType: beadsdk.TypeTask,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	if err := hqStore.CreateIssue(ctx, hqIssue, "test"); err != nil {
+		t.Fatalf("CreateIssue hq: %v", err)
+	}
+
+	// Set up routes
+	townRoot := t.TempDir()
+	beadsDir := filepath.Join(townRoot, ".beads")
+	os.MkdirAll(beadsDir, 0755)
+	beadsRouting.WriteRoutes(beadsDir, []beadsRouting.Route{
+		{Prefix: "hq-", Path: "."},
+		{Prefix: "ds-", Path: "dashboard"},
+	})
+
+	resolver := NewStoreResolver(townRoot, map[string]beadsdk.Storage{
+		"hq":        hqStore,
+		"dashboard": dsStore,
+	})
+
+	// Resolve both cross-store IDs
+	result := resolver.ResolveIssues(ctx, []string{"ds-abc", "hq-xyz"})
+	if len(result) != 2 {
+		t.Fatalf("ResolveIssues returned %d issues, want 2", len(result))
+	}
+	if result["ds-abc"] == nil {
+		t.Fatal("ds-abc not found in result")
+	}
+	if string(result["ds-abc"].Status) != "closed" {
+		t.Errorf("ds-abc status = %s, want closed", result["ds-abc"].Status)
+	}
+	if result["hq-xyz"] == nil {
+		t.Fatal("hq-xyz not found in result")
+	}
+	if string(result["hq-xyz"].Status) != "open" {
+		t.Errorf("hq-xyz status = %s, want open", result["hq-xyz"].Status)
+	}
+}
+
+func TestStoreResolver_NilStores(t *testing.T) {
+	resolver := NewStoreResolver("/nonexistent", nil)
+	result := resolver.ResolveIssues(context.Background(), []string{"ds-abc"})
+	if len(result) != 0 {
+		t.Errorf("expected empty result for nil stores, got %d", len(result))
+	}
+}
+
+func TestStoreResolver_EmptyIDs(t *testing.T) {
+	resolver := NewStoreResolver("/nonexistent", map[string]beadsdk.Storage{})
+	result := resolver.ResolveIssues(context.Background(), nil)
+	if len(result) != 0 {
+		t.Errorf("expected empty result for nil IDs, got %d", len(result))
+	}
+}
+
+func TestStoreResolver_StoreForID_ExternalFormat(t *testing.T) {
+	townRoot := t.TempDir()
+	beadsDir := filepath.Join(townRoot, ".beads")
+	os.MkdirAll(beadsDir, 0755)
+	beadsRouting.WriteRoutes(beadsDir, []beadsRouting.Route{
+		{Prefix: "ds-", Path: "dashboard"},
+	})
+
+	resolver := NewStoreResolver(townRoot, nil)
+	storeName := resolver.storeForID("external:ds:ds-abc")
+	if storeName != "dashboard" {
+		t.Errorf("storeForID(external:ds:ds-abc) = %q, want %q", storeName, "dashboard")
+	}
+}

--- a/internal/convoy/operations.go
+++ b/internal/convoy/operations.go
@@ -32,9 +32,10 @@ import (
 //   - caller: identifier for logging (e.g., "Convoy")
 //   - logger: optional logger function (can be nil)
 //   - gtPath: resolved path to the gt binary (e.g. from exec.LookPath or daemon config)
+//   - resolver: optional StoreResolver for cross-database issue resolution (nil falls back to subprocess)
 //
 // Returns the convoy IDs that were checked (may be empty if issue isn't tracked).
-func CheckConvoysForIssue(ctx context.Context, store beadsdk.Storage, townRoot, issueID, caller string, logger func(format string, args ...interface{}), gtPath string, isRigParked func(string) bool) []string {
+func CheckConvoysForIssue(ctx context.Context, store beadsdk.Storage, townRoot, issueID, caller string, logger func(format string, args ...interface{}), gtPath string, isRigParked func(string) bool, resolver ...*StoreResolver) []string {
 	if logger == nil {
 		logger = func(format string, args ...interface{}) {} // no-op
 	}
@@ -43,6 +44,12 @@ func CheckConvoysForIssue(ctx context.Context, store beadsdk.Storage, townRoot, 
 	}
 	if store == nil {
 		return nil
+	}
+
+	// Extract optional resolver (variadic for backward compatibility)
+	var res *StoreResolver
+	if len(resolver) > 0 {
+		res = resolver[0]
 	}
 
 	// Find convoys tracking this issue
@@ -75,7 +82,7 @@ func CheckConvoysForIssue(ctx context.Context, store beadsdk.Storage, townRoot, 
 		// reactively dispatch the next ready issue. This makes convoy feeding
 		// event-driven instead of relying on polling-based patrol cycles.
 		if !isConvoyClosed(ctx, store, convoyID) {
-			feedNextReadyIssue(ctx, store, townRoot, convoyID, caller, logger, gtPath, isRigParked)
+			feedNextReadyIssue(ctx, store, townRoot, convoyID, caller, logger, gtPath, isRigParked, res)
 		}
 	}
 
@@ -187,17 +194,34 @@ var blockingDepTypes = map[string]bool{
 // that the code was actually integrated. This prevents dispatching work
 // against un-merged code (see #1893).
 //
-// Note: this uses the hq store's dependency metadata snapshot. For cross-rig
-// issues, the blocking issue's status may be stale (see Discovery #11 in
-// convoy-lifecycle.md). This is a known limitation.
-func isIssueBlocked(ctx context.Context, store beadsdk.Storage, issueID string) bool {
+// When a StoreResolver is provided, cross-database dependencies are resolved
+// by querying the appropriate rig store for fresh status. Without a resolver,
+// this falls back to the hq store's dependency metadata snapshot, which may
+// be stale for cross-rig issues (see GH #2624).
+func isIssueBlocked(ctx context.Context, store beadsdk.Storage, issueID string, resolver *StoreResolver) bool {
 	if store == nil {
 		return false // fail-open: no store means we can't check deps
 	}
-	deps, err := store.GetDependenciesWithMetadata(ctx, issueID)
-	if err != nil {
-		return false // On error, assume not blocked (fail-open)
+
+	// Try the resolver first for cross-database accuracy. The resolver looks up
+	// deps in the issue's home store (based on prefix routing), which returns
+	// current status. Fall back to hq store if resolver is nil or returns nothing.
+	var deps []*beadsdk.IssueWithDependencyMetadata
+	if resolver != nil {
+		deps = resolver.ResolveDepsWithMetadata(ctx, issueID)
 	}
+	if len(deps) == 0 {
+		var err error
+		deps, err = store.GetDependenciesWithMetadata(ctx, issueID)
+		if err != nil {
+			return false // On error, assume not blocked (fail-open)
+		}
+	}
+
+	// For cross-rig blocking deps, the metadata snapshot status may be stale.
+	// Collect blocker IDs whose status we need to verify via the resolver.
+	var staleCandidateIDs []string
+	var staleCandidateTypes []string
 
 	for _, d := range deps {
 		depType := string(d.DependencyType)
@@ -208,14 +232,45 @@ func isIssueBlocked(ctx context.Context, store beadsdk.Storage, issueID string) 
 		if status == "tombstone" {
 			continue // always unblocked
 		}
-		if status != "closed" {
-			return true // not closed = blocked
+		if status == "closed" {
+			// For merge-blocks: "closed" alone is not enough — need merge confirmation
+			if depType == "merge-blocks" && !strings.HasPrefix(d.CloseReason, "Merged in ") {
+				return true // closed but not merged = still blocked
+			}
+			continue // closed = unblocked for non-merge-blocks
 		}
-		// For merge-blocks: "closed" alone is not enough — need merge confirmation
-		if depType == "merge-blocks" && !strings.HasPrefix(d.CloseReason, "Merged in ") {
-			return true // closed but not merged = still blocked
+		// Status is not closed/tombstone. If we have a resolver, the dep might
+		// actually be closed in its home store but stale in the snapshot.
+		if resolver != nil {
+			staleCandidateIDs = append(staleCandidateIDs, extractIssueID(d.ID))
+			staleCandidateTypes = append(staleCandidateTypes, depType)
+		} else {
+			return true // not closed = blocked (no resolver to verify)
 		}
 	}
+
+	// Verify stale candidates via cross-store resolution
+	if len(staleCandidateIDs) > 0 {
+		freshMap := resolver.ResolveIssues(ctx, staleCandidateIDs)
+		for i, id := range staleCandidateIDs {
+			fresh, ok := freshMap[id]
+			if !ok {
+				return true // can't resolve = assume blocked
+			}
+			freshStatus := string(fresh.Status)
+			if freshStatus == "tombstone" {
+				continue
+			}
+			if freshStatus != "closed" {
+				return true // confirmed not closed
+			}
+			// For merge-blocks: check close reason from fresh data
+			if staleCandidateTypes[i] == "merge-blocks" && !strings.HasPrefix(fresh.CloseReason, "Merged in ") {
+				return true
+			}
+		}
+	}
+
 	return false
 }
 
@@ -227,8 +282,8 @@ func isIssueBlocked(ctx context.Context, store beadsdk.Storage, issueID string) 
 // Only one issue is dispatched per call. When that issue completes, the
 // next close event triggers another feed cycle.
 // gtPath is the resolved path to the gt binary.
-func feedNextReadyIssue(ctx context.Context, store beadsdk.Storage, townRoot, convoyID, caller string, logger func(format string, args ...interface{}), gtPath string, isRigParked func(string) bool) {
-	tracked := getConvoyTrackedIssues(ctx, store, convoyID, townRoot)
+func feedNextReadyIssue(ctx context.Context, store beadsdk.Storage, townRoot, convoyID, caller string, logger func(format string, args ...interface{}), gtPath string, isRigParked func(string) bool, resolver *StoreResolver) {
+	tracked := getConvoyTrackedIssues(ctx, store, convoyID, townRoot, resolver)
 	if len(tracked) == 0 {
 		return
 	}
@@ -258,7 +313,7 @@ func feedNextReadyIssue(ctx context.Context, store beadsdk.Storage, townRoot, co
 		// Check blocking dependencies: blocks and conditional-blocks with
 		// non-closed targets prevent dispatch. parent-child is NOT treated
 		// as blocking (consistent with molecule step behavior).
-		if isIssueBlocked(ctx, store, issue.ID) {
+		if isIssueBlocked(ctx, store, issue.ID, resolver) {
 			logger("%s: convoy %s: %s is blocked, skipping", caller, convoyID, issue.ID)
 			continue
 		}
@@ -288,8 +343,9 @@ func feedNextReadyIssue(ctx context.Context, store beadsdk.Storage, townRoot, co
 
 // getConvoyTrackedIssues returns issues tracked by a convoy with fresh status.
 // Uses SDK GetDependenciesWithMetadata filtered by tracks, then GetIssuesByIDs for current status.
-// For cross-rig beads not found in the local store, falls back to bd show via fetchCrossRigBeadStatus.
-func getConvoyTrackedIssues(ctx context.Context, store beadsdk.Storage, convoyID, townRoot string) []trackedIssue {
+// When a StoreResolver is provided, cross-rig beads are resolved via direct store queries.
+// Otherwise falls back to bd show subprocess via fetchCrossRigBeadStatus.
+func getConvoyTrackedIssues(ctx context.Context, store beadsdk.Storage, convoyID, townRoot string, resolver *StoreResolver) []trackedIssue {
 	deps, err := store.GetDependenciesWithMetadata(ctx, convoyID)
 	if err != nil || len(deps) == 0 {
 		return nil
@@ -333,18 +389,25 @@ func getConvoyTrackedIssues(ctx context.Context, store beadsdk.Storage, convoyID
 		}
 	}
 
-	// Cross-rig fallback: for beads not found in the local store (e.g., oag-*
-	// beads when convoys live in hq), fetch fresh status via bd show in the
-	// bead's home rig. Without this, stale dependency metadata snapshots are
-	// used, which still show status:"open" after the bead was closed.
-	if townRoot != "" {
-		var missingIDs []string
-		for _, id := range ids {
-			if _, ok := freshMap[id]; !ok {
-				missingIDs = append(missingIDs, id)
-			}
+	// Cross-rig resolution: for beads not found in the local store (e.g., ds-*
+	// beads when convoys live in hq), resolve via the StoreResolver which
+	// queries the appropriate rig store directly. Falls back to bd show
+	// subprocess if no resolver is available. See GH #2624.
+	var missingIDs []string
+	for _, id := range ids {
+		if _, ok := freshMap[id]; !ok {
+			missingIDs = append(missingIDs, id)
 		}
-		if len(missingIDs) > 0 {
+	}
+	if len(missingIDs) > 0 {
+		if resolver != nil {
+			// Direct store queries — faster, no subprocess, no bd dependency
+			crossRigFresh := resolver.ResolveIssues(ctx, missingIDs)
+			for id, fresh := range crossRigFresh {
+				freshMap[id] = fresh
+			}
+		} else if townRoot != "" {
+			// Legacy fallback: subprocess bd show per rig
 			crossRigFresh := fetchCrossRigBeadStatus(townRoot, missingIDs)
 			for id, fresh := range crossRigFresh {
 				freshMap[id] = fresh

--- a/internal/convoy/operations_test.go
+++ b/internal/convoy/operations_test.go
@@ -72,7 +72,7 @@ func TestIsSlingableType(t *testing.T) {
 func TestIsIssueBlocked_NoStore(t *testing.T) {
 	// isIssueBlocked with nil store should fail-open (return false, not panic).
 	// This covers the "store unavailable" failure mode (F-17).
-	result := isIssueBlocked(context.Background(), nil, "test-any-id")
+	result := isIssueBlocked(context.Background(), nil, "test-any-id", nil)
 	if result {
 		t.Error("isIssueBlocked should fail-open (return false) with nil store")
 	}
@@ -216,7 +216,7 @@ func TestIsIssueBlocked_NoDeps(t *testing.T) {
 		t.Fatalf("CreateIssue: %v", err)
 	}
 
-	if isIssueBlocked(ctx, store, issue.ID) {
+	if isIssueBlocked(ctx, store, issue.ID, nil) {
 		t.Error("isIssueBlocked should return false for issue with no dependencies")
 	}
 }
@@ -274,7 +274,7 @@ func TestIsIssueBlocked_BlockedByOpenBlocker(t *testing.T) {
 		t.Fatal("expected at least 1 dependency to be created")
 	}
 
-	result := isIssueBlocked(ctx, store, blocked.ID)
+	result := isIssueBlocked(ctx, store, blocked.ID, nil)
 
 	// GetDependenciesWithMetadata may not work in embedded Dolt mode
 	// (nested query limitation). If it fails, isIssueBlocked returns false
@@ -335,7 +335,7 @@ func TestIsIssueBlocked_NotBlockedByClosedBlocker(t *testing.T) {
 
 	// Even if GetDependenciesWithMetadata works, the blocker is closed so
 	// isIssueBlocked should return false.
-	if isIssueBlocked(ctx, store, blocked.ID) {
+	if isIssueBlocked(ctx, store, blocked.ID, nil) {
 		t.Error("isIssueBlocked should return false when the only blocker is closed")
 	}
 }
@@ -385,7 +385,7 @@ func TestIsIssueBlocked_ParentChildDoesNotBlock(t *testing.T) {
 	}
 
 	// parent-child deps should NOT block dispatch
-	if isIssueBlocked(ctx, store, child.ID) {
+	if isIssueBlocked(ctx, store, child.ID, nil) {
 		t.Error("isIssueBlocked should return false for parent-child dependency (not a blocking type)")
 	}
 }
@@ -397,7 +397,7 @@ func TestIsIssueBlocked_FailOpenOnNonexistentIssue(t *testing.T) {
 	ctx := context.Background()
 
 	// Querying deps for a nonexistent issue should fail-open (return false)
-	if isIssueBlocked(ctx, store, "test-nonexistent-issue") {
+	if isIssueBlocked(ctx, store, "test-nonexistent-issue", nil) {
 		t.Error("isIssueBlocked should fail-open (return false) for nonexistent issue")
 	}
 }
@@ -451,7 +451,7 @@ func TestIsIssueBlocked_MergeBlocksStillBlockedWhenClosedWithoutMerge(t *testing
 		t.Fatalf("AddDependency: %v", err)
 	}
 
-	result := isIssueBlocked(ctx, store, blocked.ID)
+	result := isIssueBlocked(ctx, store, blocked.ID, nil)
 
 	// Check if GetDependenciesWithMetadata works in embedded mode
 	if !result {
@@ -510,7 +510,7 @@ func TestIsIssueBlocked_MergeBlocksUnblockedWhenMerged(t *testing.T) {
 	}
 
 	// Blocker is closed with "Merged in mr-xyz" — should NOT be blocked
-	if isIssueBlocked(ctx, store, blocked.ID) {
+	if isIssueBlocked(ctx, store, blocked.ID, nil) {
 		// Check if it's the embedded Dolt issue
 		_, metaErr := store.GetDependenciesWithMetadata(ctx, blocked.ID)
 		if metaErr != nil {
@@ -573,7 +573,7 @@ func TestIsIssueBlocked_MergeBlocksUnblockedOnTombstone(t *testing.T) {
 	}
 
 	// Tombstone always unblocks, regardless of dep type
-	if isIssueBlocked(ctx, store, blocked.ID) {
+	if isIssueBlocked(ctx, store, blocked.ID, nil) {
 		_, metaErr := store.GetDependenciesWithMetadata(ctx, blocked.ID)
 		if metaErr != nil {
 			t.Skipf("GetDependenciesWithMetadata not supported in embedded mode: %v", metaErr)
@@ -806,7 +806,7 @@ func TestFeedNextReadyIssue_DispatchesFirstReadyIssue(t *testing.T) {
 	gtPath, logPath := makeGTStub(t, 0)
 	logger, _ := makeLogger()
 
-	feedNextReadyIssue(ctx, store, townRoot, convoy.ID, "test", logger, gtPath, func(string) bool { return false })
+	feedNextReadyIssue(ctx, store, townRoot, convoy.ID, "test", logger, gtPath, func(string) bool { return false }, nil)
 
 	// Verify gt was called with the ready issue
 	logData, err := os.ReadFile(logPath)
@@ -883,7 +883,7 @@ func TestFeedNextReadyIssue_SkipsEpicAndDispatchesTask(t *testing.T) {
 	gtPath, logPath := makeGTStub(t, 0)
 	logger, _ := makeLogger()
 
-	feedNextReadyIssue(ctx, store, townRoot, convoy.ID, "test", logger, gtPath, func(string) bool { return false })
+	feedNextReadyIssue(ctx, store, townRoot, convoy.ID, "test", logger, gtPath, func(string) bool { return false }, nil)
 
 	logData, err := os.ReadFile(logPath)
 	if err != nil {
@@ -986,7 +986,7 @@ func TestFeedNextReadyIssue_SkipsBlockedIssue(t *testing.T) {
 	gtPath, logPath := makeGTStub(t, 0)
 	logger, logMsgs := makeLogger()
 
-	feedNextReadyIssue(ctx, store, townRoot, convoy.ID, "test", logger, gtPath, func(string) bool { return false })
+	feedNextReadyIssue(ctx, store, townRoot, convoy.ID, "test", logger, gtPath, func(string) bool { return false }, nil)
 
 	logData, err := os.ReadFile(logPath)
 	if err != nil {
@@ -1069,7 +1069,7 @@ func TestFeedNextReadyIssue_NoReadyIssues_LogsMessage(t *testing.T) {
 	gtPath, _ := makeGTStub(t, 0)
 	logger, logMsgs := makeLogger()
 
-	feedNextReadyIssue(ctx, store, townRoot, convoy.ID, "test", logger, gtPath, func(string) bool { return false })
+	feedNextReadyIssue(ctx, store, townRoot, convoy.ID, "test", logger, gtPath, func(string) bool { return false }, nil)
 
 	// Verify "no ready issues to feed" was logged
 	found := false
@@ -1136,7 +1136,7 @@ func TestFeedNextReadyIssue_SkipsParkedRig(t *testing.T) {
 	logger, logMsgs := makeLogger()
 
 	// isRigParked always returns true
-	feedNextReadyIssue(ctx, store, townRoot, convoy.ID, "test", logger, gtPath, func(string) bool { return true })
+	feedNextReadyIssue(ctx, store, townRoot, convoy.ID, "test", logger, gtPath, func(string) bool { return true }, nil)
 
 	// gt should NOT have been called
 	if _, err := os.ReadFile(logPath); err == nil {
@@ -1594,7 +1594,7 @@ func TestGetConvoyTrackedIssues_CrossRigFallback(t *testing.T) {
 	townRoot, _ := setupTownRootWithCrossRig(t, 0,
 		`[{"id":"oag-19dd9","status":"closed","assignee":"gastown/polecats/alpha","priority":2,"issue_type":"task"}]`)
 
-	tracked := getConvoyTrackedIssues(ctx, store, convoy.ID, townRoot)
+	tracked := getConvoyTrackedIssues(ctx, store, convoy.ID, townRoot, nil)
 
 	// Find the cross-rig bead in tracked results
 	var found *trackedIssue

--- a/internal/daemon/convoy_manager.go
+++ b/internal/daemon/convoy_manager.go
@@ -302,7 +302,8 @@ func (m *ConvoyManager) pollStore(name string, store beadsdk.Storage, stores map
 		}
 
 		m.logger("Convoy: close detected: %s (from %s)", issueID, name)
-		convoy.CheckConvoysForIssue(m.ctx, hqStore, m.townRoot, issueID, "Convoy", m.logger, m.gtPath, m.isRigParked)
+		resolver := convoy.NewStoreResolver(m.townRoot, stores)
+		convoy.CheckConvoysForIssue(m.ctx, hqStore, m.townRoot, issueID, "Convoy", m.logger, m.gtPath, m.isRigParked, resolver)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `StoreResolver` that resolves issues across multiple Dolt databases using prefix-based routing and the daemon's already-open store map
- Wire cross-database resolution through both broken code paths: `getConvoyTrackedIssues()` and `isIssueBlocked()`
- Replace fragile subprocess `bd show` fallback with direct store queries (faster, no external dependency)
- Backward-compatible: `CheckConvoysForIssue` accepts resolver as optional variadic param

## Problem

In multi-rig towns, convoys (`hq-cv-*`) live in the HQ database but track issues with rig-specific prefixes (`ds-*`, `ns-*`) in separate Dolt databases. The dependency resolution cannot cross this boundary:

- `gt convoy status` → "Progress: 0/0 completed"
- `gt convoy launch` → "tracks no beads"
- `bd dep list -v` finds raw deps but can't resolve them
- Daemon auto-feed completely broken for cross-rig convoys

## Fix

The daemon already maintains `map[string]beadsdk.Storage` with all rig stores open. `StoreResolver` uses this to route issue lookups by prefix → rig name → correct store. Two surgical changes:

1. **`getConvoyTrackedIssues()`**: Uses resolver instead of subprocess `fetchCrossRigBeadStatus()` for missing IDs
2. **`isIssueBlocked()`**: Adds cross-database resolution (was completely missing — only used stale HQ metadata)

## Test plan

- [x] All existing convoy tests pass (30/30)
- [x] New `TestStoreResolver_ResolveIssues_CrossStore` — verifies cross-database resolution with two separate Dolt stores
- [x] New `TestStoreResolver_ResolveIssues_SingleStore` — verifies single-store (backward compat)
- [x] New `TestStoreResolver_NilStores` / `TestStoreResolver_EmptyIDs` — edge cases
- [x] New `TestStoreResolver_StoreForID_ExternalFormat` — verifies `external:prefix:id` unwrapping
- [x] `go build ./...` passes

Fixes #2624. Consolidates #2605, #2606, #2604.

🤖 Generated with [Claude Code](https://claude.com/claude-code)