### PR TITLE
fix(convoy): CLI-side cross-database dependency resolution

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -438,6 +438,81 @@ func runBdJSON(dir string, args ...string) ([]byte, error) {
 	return stdout.Bytes(), nil
 }
 
+// bdDepListRawIDs queries the raw dependencies table via bd sql to get
+// dependency target IDs. Unlike bd dep list, this does NOT join with the
+// issues table, so it works for cross-database dependencies where the
+// target issues live in a different Dolt database. See GH #2624.
+//
+// dir should be the town beads directory (.beads) for HQ queries.
+// direction is "down" (issue_id → depends_on_id) or "up" (depends_on_id → issue_id).
+// depType filters by dependency type (e.g., "tracks", "blocks"); empty means all types.
+//
+// Returns deduplicated, unwrapped issue IDs (external:prefix:id → id).
+func bdDepListRawIDs(dir, issueID, direction, depType string) ([]string, error) {
+	// Determine query columns based on direction.
+	// "down": issueID depends on targets → SELECT depends_on_id WHERE issue_id = ?
+	// "up":   issueID is depended on → SELECT issue_id WHERE depends_on_id = ?
+	var selectCol, whereCol string
+	if direction == "up" {
+		selectCol = "issue_id"
+		whereCol = "depends_on_id"
+	} else {
+		selectCol = "depends_on_id"
+		whereCol = "issue_id"
+	}
+
+	// Build SQL query. Bead IDs are system-generated alphanumeric strings
+	// with hyphens and dots — validate to prevent injection.
+	if !isValidBeadID(issueID) {
+		return nil, fmt.Errorf("invalid bead ID: %q", issueID)
+	}
+
+	query := fmt.Sprintf("SELECT %s FROM dependencies WHERE %s = '%s'", selectCol, whereCol, issueID)
+	if depType != "" {
+		if !isValidBeadID(depType) {
+			return nil, fmt.Errorf("invalid dep type: %q", depType)
+		}
+		query += fmt.Sprintf(" AND type = '%s'", depType)
+	}
+
+	out, err := runBdJSON(dir, "sql", query, "--json")
+	if err != nil {
+		return nil, fmt.Errorf("bd sql for deps of %s: %w", issueID, err)
+	}
+
+	// Parse JSON array of single-column rows
+	var rows []map[string]string
+	if err := json.Unmarshal(out, &rows); err != nil {
+		return nil, fmt.Errorf("parsing dep sql for %s: %w", issueID, err)
+	}
+
+	seen := make(map[string]bool, len(rows))
+	var ids []string
+	for _, row := range rows {
+		rawID := row[selectCol]
+		id := beads.ExtractIssueID(rawID)
+		if id != "" && !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
+		}
+	}
+	return ids, nil
+}
+
+// isValidBeadID checks that a string is safe for SQL interpolation in dep queries.
+// Bead IDs contain only alphanumeric chars, hyphens, dots, and underscores.
+func isValidBeadID(s string) bool {
+	if s == "" {
+		return false
+	}
+	for _, c := range s {
+		if !((c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9') || c == '-' || c == '.' || c == '_') {
+			return false
+		}
+	}
+	return true
+}
+
 func runConvoyCreate(cmd *cobra.Command, args []string) error {
 	name := args[0]
 	trackedIssues := args[1:]
@@ -2030,40 +2105,39 @@ func applyFreshIssueDetails(dep *trackedDependency, details *issueDetails) {
 	dep.Labels = details.Labels
 }
 
-// getTrackedIssues uses bd dep list to get issues tracked by a convoy.
+// getTrackedIssues gets issues tracked by a convoy with fresh cross-rig details.
 // Returns issue details including status, type, and worker info.
+//
+// Uses bdDepListRawIDs to query the raw dependencies table (bypasses the JOIN
+// that bd dep list does, which fails for cross-database deps — see GH #2624).
+// Then fetches fresh issue details via bd show with prefix routing.
 func getTrackedIssues(townBeads, convoyID string) ([]trackedIssueInfo, error) {
-	// Use bd dep list to get tracked dependencies
-	// Run from town root (parent of .beads) so bd routes correctly
-	townRoot := filepath.Dir(townBeads)
-	out, err := runBdJSON(townRoot, "dep", "list", convoyID, "--direction=down", "--type=tracks", "--json")
+	// Query raw dependency IDs from the dependencies table. This works for
+	// cross-database deps because it only reads the dependency records (which
+	// live in HQ) without trying to JOIN with the issues table.
+	trackedIDs, err := bdDepListRawIDs(townBeads, convoyID, "down", "tracks")
 	if err != nil {
 		return nil, fmt.Errorf("querying tracked issues for %s: %w", convoyID, err)
 	}
 
-	// Parse the JSON output - bd dep list returns full issue details
+	if len(trackedIDs) == 0 {
+		return nil, nil
+	}
+
+	// Fetch fresh issue details via bd show (uses prefix routing for cross-rig).
+	freshDetails := getIssueDetailsBatch(trackedIDs)
+
+	// Build tracked dependency structs from fresh details
 	var deps []trackedDependency
-	if err := json.Unmarshal(out, &deps); err != nil {
-		return nil, fmt.Errorf("parsing tracked issues for %s: %w", convoyID, err)
-	}
-
-	// Unwrap external:prefix:id format from dep IDs before use
-	for i := range deps {
-		deps[i].ID = beads.ExtractIssueID(deps[i].ID)
-	}
-
-	// Refresh status via cross-rig lookup. bd dep list returns status from
-	// the dependency record in HQ beads which is never updated when cross-rig
-	// issues (e.g., gt-* tracked by hq-* convoys) are closed in their home rig.
-	issueIDs := make([]string, len(deps))
-	for i, dep := range deps {
-		issueIDs[i] = dep.ID
-	}
-	freshDetails := getIssueDetailsBatch(issueIDs)
-	for i, dep := range deps {
-		if details, ok := freshDetails[dep.ID]; ok {
-			applyFreshIssueDetails(&deps[i], details)
+	for _, id := range trackedIDs {
+		dep := trackedDependency{
+			ID:             id,
+			DependencyType: "tracks",
 		}
+		if details, ok := freshDetails[id]; ok {
+			applyFreshIssueDetails(&dep, details)
+		}
+		deps = append(deps, dep)
 	}
 
 	// Collect non-closed issue IDs for worker lookup

--- a/internal/cmd/convoy_empty_test.go
+++ b/internal/cmd/convoy_empty_test.go
@@ -51,6 +51,11 @@ case "$cmd" in
     echo '[{"id":"'"$CONVOY_ID"'","title":"'"$CONVOY_TITLE"'","status":"open","issue_type":"convoy"}]'
     exit 0
     ;;
+  sql)
+    # bdDepListRawIDs uses bd sql for dep queries — return empty
+    echo '[]'
+    exit 0
+    ;;
   dep)
     # Return empty tracked issues
     echo '[]'
@@ -180,6 +185,21 @@ case "$pos0" in
     echo '[{"id":"hq-empty-mix","title":"Empty convoy"},{"id":"hq-feed-mix","title":"Feedable convoy"}]'
     exit 0
     ;;
+  sql)
+    # bdDepListRawIDs: SELECT depends_on_id FROM dependencies WHERE issue_id = '<id>' AND type = 'tracks'
+    case "$*" in
+      *"issue_id = 'hq-empty-mix'"*)
+        echo '[]'
+        ;;
+      *"issue_id = 'hq-feed-mix'"*)
+        echo '[{"depends_on_id":"gt-ready1"}]'
+        ;;
+      *)
+        echo '[]'
+        ;;
+    esac
+    exit 0
+    ;;
   dep)
     # pos2 is the convoy ID (dep list <convoy-id> ...)
     case "$pos2" in
@@ -303,6 +323,11 @@ done
 case "$pos0" in
   list)
     echo '[{"id":"hq-stuck1","title":"Stuck convoy"}]'
+    exit 0
+    ;;
+  sql)
+    # bdDepListRawIDs: return tracked bead IDs for hq-stuck1
+    echo '[{"depends_on_id":"gt-busy1"},{"depends_on_id":"gt-busy2"}]'
     exit 0
     ;;
   dep)

--- a/internal/cmd/convoy_launch_test.go
+++ b/internal/cmd/convoy_launch_test.go
@@ -738,6 +738,10 @@ case "$*" in
   "show hq-cv-ext --json")
     echo '[{"id":"hq-cv-ext","title":"Ext convoy","status":"staged_ready","issue_type":"convoy"}]'
     ;;
+  sql\ *"issue_id = 'hq-cv-ext'"*)
+    # bdDepListRawIDs down: return tracked bead IDs
+    echo '[{"depends_on_id":"external:ghostty:ghostty-1i4.3"},{"depends_on_id":"external:ghostty:ghostty-1i4.4"}]'
+    ;;
   "dep list hq-cv-ext --direction=down --type=tracks --json")
     echo '[{"id":"external:ghostty:ghostty-1i4.3"},{"id":"external:ghostty:ghostty-1i4.4"}]'
     ;;
@@ -749,6 +753,10 @@ case "$*" in
     ;;
   "show ghostty-1i4.4 --json")
     echo '[{"id":"ghostty-1i4.4","title":"Task 2","status":"open","issue_type":"task"}]'
+    ;;
+  show\ *--json)
+    # Batch show fallback - return details for any known IDs
+    echo '[{"id":"ghostty-1i4.3","title":"Task 1","status":"open","issue_type":"task"},{"id":"ghostty-1i4.4","title":"Task 2","status":"open","issue_type":"task"}]'
     ;;
   "dep list ghostty-1i4.3 --json"|"dep list ghostty-1i4.4 --json")
     echo '[]'

--- a/internal/cmd/convoy_stage.go
+++ b/internal/cmd/convoy_stage.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"sort"
 	"strings"
 	"time"
@@ -474,27 +473,18 @@ func dagSlingableIDs(dag *ConvoyDAG) []string {
 }
 
 // convoyTrackedBeadIDs returns the set of bead IDs tracked by a convoy.
-// It calls `bd dep list <convoyID> --direction=down --type=tracks --json`
-// against the town beads directory and unwraps external:prefix:id references.
+// Uses bdDepListRawIDs to query the raw dependencies table, which works
+// for cross-database deps where tracked issues live in a different Dolt
+// database (e.g., ds-* issues tracked by an hq-cv-* convoy). See GH #2624.
 func convoyTrackedBeadIDs(townBeads, convoyID string) (map[string]bool, error) {
-	townRoot := filepath.Dir(townBeads)
-	depCmd := exec.Command("bd", "dep", "list", convoyID, "--direction=down", "--type=tracks", "--json")
-	depCmd.Dir = townRoot
-	out, err := depCmd.Output()
+	trackedIDs, err := bdDepListRawIDs(townBeads, convoyID, "down", "tracks")
 	if err != nil {
-		return nil, fmt.Errorf("bd dep list %s --direction=down --type=tracks: %w", convoyID, err)
+		return nil, fmt.Errorf("tracked deps for %s: %w", convoyID, err)
 	}
 
-	var tracked []struct {
-		ID string `json:"id"`
-	}
-	if err := json.Unmarshal(out, &tracked); err != nil {
-		return nil, fmt.Errorf("parsing tracked deps for %s: %w", convoyID, err)
-	}
-
-	ids := make(map[string]bool, len(tracked))
-	for _, t := range tracked {
-		ids[beads.ExtractIssueID(t.ID)] = true
+	ids := make(map[string]bool, len(trackedIDs))
+	for _, id := range trackedIDs {
+		ids[id] = true
 	}
 	return ids, nil
 }

--- a/internal/cmd/convoy_test_helpers_test.go
+++ b/internal/cmd/convoy_test_helpers_test.go
@@ -227,6 +227,39 @@ func (d *testDAG) BdStubScript() string {
 		sb.WriteString("    ;;\n")
 	}
 
+	// --- handle: sql "SELECT ..." --json (bdDepListRawIDs) ---
+	// bdDepListRawIDs calls: bd sql "SELECT depends_on_id FROM dependencies WHERE issue_id = '<id>' AND type = 'tracks'" --json
+	// or: bd sql "SELECT issue_id FROM dependencies WHERE depends_on_id = '<id>' AND type = 'tracks'" --json
+	sb.WriteString("  sql\\ *)\n")
+	sb.WriteString("    # Handle SQL queries for dependency lookups\n")
+	// For "down" direction (convoy → tracked beads): match on issue_id = '<convoyID>'
+	for id, b := range d.beads {
+		if b.Type == "convoy" {
+			trackedSQLJSON := d.trackedBeadsSQLJSONFor(id)
+			sb.WriteString(`    case "$ALL_ARGS" in` + "\n")
+			sb.WriteString(fmt.Sprintf("      *\"issue_id = '%s'\"*)\n", id))
+			sb.WriteString(fmt.Sprintf("        echo '%s'\n", trackedSQLJSON))
+			sb.WriteString("        exit 0\n")
+			sb.WriteString("        ;;\n")
+			sb.WriteString("    esac\n")
+		}
+	}
+	// For "up" direction (bead → tracking convoys): match on depends_on_id = '<beadID>'
+	for id := range d.beads {
+		trackersJSON := d.trackersSQLJSONFor(id)
+		if trackersJSON != "[]" {
+			sb.WriteString(`    case "$ALL_ARGS" in` + "\n")
+			sb.WriteString(fmt.Sprintf("      *\"depends_on_id = '%s'\"*)\n", id))
+			sb.WriteString(fmt.Sprintf("        echo '%s'\n", trackersJSON))
+			sb.WriteString("        exit 0\n")
+			sb.WriteString("        ;;\n")
+			sb.WriteString("    esac\n")
+		}
+	}
+	sb.WriteString("    echo '[]'\n")
+	sb.WriteString("    exit 0\n")
+	sb.WriteString("    ;;\n")
+
 	// --- handle: dep list --direction=down (tracked beads for convoys) ---
 	// Must come before generic dep list handler.
 	sb.WriteString("  dep\\ list\\ *--direction=down*)\n")
@@ -509,6 +542,48 @@ func (d *testDAG) trackedBeadsJSONFor(convoyID string) string {
 		// tracks deps: IssueID is the convoy, DependsOnID is the tracked bead.
 		if dep.Type == "tracks" && dep.IssueID == convoyID {
 			out = append(out, idOnly{ID: dep.DependsOnID})
+		}
+	}
+	if out == nil {
+		return "[]"
+	}
+	raw, _ := json.Marshal(out)
+	return string(raw)
+}
+
+// trackedBeadsSQLJSONFor returns the JSON array for `bd sql "SELECT depends_on_id
+// FROM dependencies WHERE issue_id = '<convoyID>' AND type = 'tracks'" --json`.
+// Returns [{"depends_on_id":"<id>"},...] for each tracked bead.
+func (d *testDAG) trackedBeadsSQLJSONFor(convoyID string) string {
+	type sqlRow struct {
+		DependsOnID string `json:"depends_on_id"`
+	}
+
+	var out []sqlRow
+	for _, dep := range d.deps {
+		if dep.Type == "tracks" && dep.IssueID == convoyID {
+			out = append(out, sqlRow{DependsOnID: dep.DependsOnID})
+		}
+	}
+	if out == nil {
+		return "[]"
+	}
+	raw, _ := json.Marshal(out)
+	return string(raw)
+}
+
+// trackersSQLJSONFor returns the JSON array for `bd sql "SELECT issue_id
+// FROM dependencies WHERE depends_on_id = '<beadID>' AND type = 'tracks'" --json`.
+// Returns [{"issue_id":"<convoyID>"},...] for each convoy tracking this bead.
+func (d *testDAG) trackersSQLJSONFor(beadID string) string {
+	type sqlRow struct {
+		IssueID string `json:"issue_id"`
+	}
+
+	var out []sqlRow
+	for _, dep := range d.deps {
+		if dep.Type == "tracks" && dep.DependsOnID == beadID {
+			out = append(out, sqlRow{IssueID: dep.IssueID})
 		}
 	}
 	if out == nil {

--- a/internal/cmd/sling_batch_test.go
+++ b/internal/cmd/sling_batch_test.go
@@ -454,6 +454,30 @@ cmd="$1"
 shift || true
 
 case "$cmd" in
+  sql)
+    # bdDepListRawIDs up: SELECT issue_id FROM dependencies WHERE depends_on_id = '<beadID>' AND type = 'tracks'
+    case "$*" in
+      *"depends_on_id = 'gt-bbb'"*)
+        echo '[{"issue_id":"hq-cv-existing"}]'
+        ;;
+      *)
+        echo '[]'
+        ;;
+    esac
+    exit 0
+    ;;
+  show)
+    # bdShow: return convoy details for isTrackedByConvoy check
+    case "$1" in
+      hq-cv-existing)
+        echo '[{"id":"hq-cv-existing","issue_type":"convoy","status":"open"}]'
+        ;;
+      *)
+        echo '[]'
+        ;;
+    esac
+    exit 0
+    ;;
   dep)
     sub="$1"; shift || true
     beadID="$1"
@@ -968,6 +992,7 @@ exit 0
 // ---------------------------------------------------------------------------
 
 // TestConvoyTracksBead_ExactMatch verifies exact bead ID match.
+// Uses bd sql --json output format (depends_on_id column).
 func TestConvoyTracksBead_ExactMatch(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows")
@@ -976,16 +1001,9 @@ func TestConvoyTracksBead_ExactMatch(t *testing.T) {
 	binDir := t.TempDir()
 	beadsDir := t.TempDir()
 
-	deps := []struct {
-		ID string `json:"id"`
-	}{
-		{ID: "gt-aaa"},
-		{ID: "gt-bbb"},
-	}
-	depsJSON, _ := json.Marshal(deps)
-
+	// bd sql returns rows with depends_on_id column
 	bdScript := `#!/bin/sh
-echo '` + string(depsJSON) + `'
+echo '[{"depends_on_id":"gt-aaa"},{"depends_on_id":"gt-bbb"}]'
 exit 0
 `
 	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0755); err != nil {
@@ -1003,7 +1021,7 @@ exit 0
 }
 
 // TestConvoyTracksBead_ExternalWrappedMatch verifies matching through
-// the "external:prefix:beadID" format.
+// the "external:prefix:beadID" format (unwrapped by bdDepListRawIDs).
 func TestConvoyTracksBead_ExternalWrappedMatch(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows")
@@ -1012,15 +1030,9 @@ func TestConvoyTracksBead_ExternalWrappedMatch(t *testing.T) {
 	binDir := t.TempDir()
 	beadsDir := t.TempDir()
 
-	deps := []struct {
-		ID string `json:"id"`
-	}{
-		{ID: "external:gt:gt-abc"},
-	}
-	depsJSON, _ := json.Marshal(deps)
-
+	// bd sql returns raw depends_on_id which may contain external: wrapping
 	bdScript := `#!/bin/sh
-echo '` + string(depsJSON) + `'
+echo '[{"depends_on_id":"external:gt:gt-abc"}]'
 exit 0
 `
 	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0755); err != nil {
@@ -1042,15 +1054,8 @@ func TestConvoyTracksBead_NoMatch(t *testing.T) {
 	binDir := t.TempDir()
 	beadsDir := t.TempDir()
 
-	deps := []struct {
-		ID string `json:"id"`
-	}{
-		{ID: "gt-aaa"},
-	}
-	depsJSON, _ := json.Marshal(deps)
-
 	bdScript := `#!/bin/sh
-echo '` + string(depsJSON) + `'
+echo '[{"depends_on_id":"gt-aaa"}]'
 exit 0
 `
 	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0755); err != nil {
@@ -1484,6 +1489,11 @@ case "$cmd" in
     echo '[{"id":"hq-cv-manual","description":"Manually created convoy"}]'
     exit 0
     ;;
+  sql)
+    # bdDepListRawIDs down: return tracked bead IDs
+    echo '[{"depends_on_id":"gt-abc"}]'
+    exit 0
+    ;;
   dep)
     # dep list <convoyID> --direction=down --type=tracks --json
     echo '[{"id":"gt-abc"}]'
@@ -1515,12 +1525,22 @@ func TestIsTrackedByConvoy_FoundViaDepList(t *testing.T) {
 
 	townRoot, logPath := setupTownWithBdStub(t, "")
 
-	// bd stub: dep list returns a tracking convoy for direction=up.
+	// bd stub: sql returns a tracking convoy ID for direction=up, show returns details.
 	bdScript := fmt.Sprintf(`#!/bin/sh
 echo "CMD:$*" >> "%s"
 cmd="$1"
 shift || true
 case "$cmd" in
+  sql)
+    # bdDepListRawIDs up: return convoy IDs tracking this bead
+    echo '[{"issue_id":"hq-cv-found"}]'
+    exit 0
+    ;;
+  show)
+    # bdShow: return convoy details
+    echo '[{"id":"hq-cv-found","issue_type":"convoy","status":"open"}]'
+    exit 0
+    ;;
   dep)
     echo '[{"id":"hq-cv-found","issue_type":"convoy","status":"open"}]'
     exit 0
@@ -1600,16 +1620,30 @@ echo "CMD:$*" >> "%s"
 cmd="$1"
 shift || true
 case "$cmd" in
+  sql)
+    # bdDepListRawIDs down: return tracked bead IDs for convoy
+    echo '[{"depends_on_id":"gt-aaa"},{"depends_on_id":"gt-bbb"}]'
+    exit 0
+    ;;
   show)
-    # Check if this is a convoy show or a batch issue details show
-    first_id="$1"
-    case "$first_id" in
-      hq-cv-test)
+    # Check all remaining args to handle both single and batch show
+    all_show_args="$*"
+    case "$all_show_args" in
+      hq-cv-test*)
         echo '[{"title":"Test convoy title","labels":[]}]'
         ;;
-      *)
+      *gt-aaa*gt-bbb*|*gt-bbb*gt-aaa*)
         # Batch show for issue details - return details for each ID
         echo '[{"id":"gt-aaa","title":"First bead","status":"open","issue_type":"task"},{"id":"gt-bbb","title":"Second bead","status":"closed","issue_type":"task"}]'
+        ;;
+      *gt-aaa*)
+        echo '[{"id":"gt-aaa","title":"First bead","status":"open","issue_type":"task"}]'
+        ;;
+      *gt-bbb*)
+        echo '[{"id":"gt-bbb","title":"Second bead","status":"closed","issue_type":"task"}]'
+        ;;
+      *)
+        echo '[]'
         ;;
     esac
     exit 0

--- a/internal/cmd/sling_convoy.go
+++ b/internal/cmd/sling_convoy.go
@@ -25,29 +25,31 @@ func slingGenerateShortID() string {
 
 // isTrackedByConvoy checks if an issue is already being tracked by a convoy.
 // Returns the convoy ID if tracked, empty string otherwise.
+//
+// Uses bdDepListRawIDs for cross-database dep resolution (GH #2624).
+// For direction=up queries, the raw SQL approach queries the same table but
+// looks for rows where depends_on_id matches the beadID, returning the
+// issue_id (which is the convoy). Since this only returns IDs (no issue_type
+// or status), we verify each candidate via bd show.
 func isTrackedByConvoy(beadID string) string {
 	townRoot, err := workspace.FindFromCwd()
 	if err != nil {
 		return ""
 	}
+	townBeads := filepath.Join(townRoot, ".beads")
 
-	// Primary: Use bd dep list to find what tracks this issue (direction=up)
-	// This is authoritative when cross-rig routing works
-	depCmd := exec.Command("bd", "dep", "list", beadID, "--direction=up", "--type=tracks", "--json")
-	depCmd.Dir = townRoot
-
-	out, err := depCmd.Output()
-	if err == nil {
-		var trackers []struct {
-			ID        string `json:"id"`
-			IssueType string `json:"issue_type"`
-			Status    string `json:"status"`
-		}
-		if err := json.Unmarshal(out, &trackers); err == nil {
-			for _, tracker := range trackers {
-				if tracker.IssueType == "convoy" && tracker.Status == "open" {
-					return tracker.ID
-				}
+	// Primary: Use raw dep query to find what tracks this issue (direction=up).
+	// This returns convoy IDs that have a "tracks" dep on beadID.
+	trackerIDs, err := bdDepListRawIDs(townBeads, beadID, "up", "tracks")
+	if err == nil && len(trackerIDs) > 0 {
+		// Check each tracker to find an open convoy
+		for _, trackerID := range trackerIDs {
+			result, err := bdShow(trackerID)
+			if err != nil {
+				continue
+			}
+			if result.IssueType == "convoy" && result.Status == "open" {
+				return trackerID
 			}
 		}
 	}
@@ -104,37 +106,18 @@ func findConvoyByDescription(townRoot, beadID string) string {
 }
 
 // convoyTracksBead checks if a convoy has a tracks dependency on the given beadID.
-// Handles both raw bead IDs and external-formatted references (e.g., "external:gt-mol:gt-mol-xyz").
+// Uses bdDepListRawIDs for cross-database dep resolution (GH #2624).
 func convoyTracksBead(beadsDir, convoyID, beadID string) bool {
-	depCmd := exec.Command("bd", "dep", "list", convoyID, "--direction=down", "--type=tracks", "--json")
-	depCmd.Dir = beadsDir
-
-	out, err := depCmd.Output()
+	trackedIDs, err := bdDepListRawIDs(beadsDir, convoyID, "down", "tracks")
 	if err != nil {
 		return false
 	}
 
-	var tracked []struct {
-		ID string `json:"id"`
-	}
-	if err := json.Unmarshal(out, &tracked); err != nil {
-		return false
-	}
-
-	for _, t := range tracked {
-		// Exact match (raw beadID stored as-is)
-		if t.ID == beadID {
+	for _, id := range trackedIDs {
+		if id == beadID {
 			return true
 		}
-		// External reference match: unwrap "external:prefix:beadID" format
-		if strings.HasPrefix(t.ID, "external:") {
-			parts := strings.SplitN(t.ID, ":", 3)
-			if len(parts) == 3 && parts[2] == beadID {
-				return true
-			}
-		}
 	}
-
 	return false
 }
 

--- a/internal/cmd/sling_convoy_test.go
+++ b/internal/cmd/sling_convoy_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 // TestConvoyTracksBeadExactMatch verifies that convoyTracksBead finds a bead
-// when the dep list returns the raw beadID (no external: wrapping).
+// when the dep query returns the raw beadID.
 func TestConvoyTracksBeadExactMatch(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows")
@@ -17,9 +17,9 @@ func TestConvoyTracksBeadExactMatch(t *testing.T) {
 	binDir := t.TempDir()
 	beadsDir := t.TempDir()
 
-	// Stub bd to return a tracked dep with raw beadID
+	// Stub bd sql to return a tracked dep with raw beadID
 	bdScript := `#!/bin/sh
-echo '[{"id":"gt-abc123"}]'
+echo '[{"depends_on_id":"gt-abc123"}]'
 `
 	bdPath := filepath.Join(binDir, "bd")
 	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
@@ -35,7 +35,7 @@ echo '[{"id":"gt-abc123"}]'
 }
 
 // TestConvoyTracksBeadExternalRef verifies that convoyTracksBead finds a bead
-// when the dep list returns an external-formatted reference.
+// when the dep query returns an external-formatted reference.
 func TestConvoyTracksBeadExternalRef(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows")
@@ -44,9 +44,9 @@ func TestConvoyTracksBeadExternalRef(t *testing.T) {
 	binDir := t.TempDir()
 	beadsDir := t.TempDir()
 
-	// Stub bd to return a tracked dep with external:prefix:beadID format
+	// Stub bd sql to return a tracked dep with external:prefix:beadID format
 	bdScript := `#!/bin/sh
-echo '[{"id":"external:gt-abc:gt-abc123"}]'
+echo '[{"depends_on_id":"external:gt-abc:gt-abc123"}]'
 `
 	bdPath := filepath.Join(binDir, "bd")
 	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
@@ -71,9 +71,9 @@ func TestConvoyTracksBeadNoMatch(t *testing.T) {
 	binDir := t.TempDir()
 	beadsDir := t.TempDir()
 
-	// Stub bd to return a tracked dep with a different beadID
+	// Stub bd sql to return a tracked dep with a different beadID
 	bdScript := `#!/bin/sh
-echo '[{"id":"gt-other456"}]'
+echo '[{"depends_on_id":"gt-other456"}]'
 `
 	bdPath := filepath.Join(binDir, "bd")
 	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
@@ -98,7 +98,7 @@ func TestConvoyTracksBeadEmptyDeps(t *testing.T) {
 	binDir := t.TempDir()
 	beadsDir := t.TempDir()
 
-	// Stub bd to return empty array
+	// Stub bd sql to return empty array
 	bdScript := `#!/bin/sh
 echo '[]'
 `
@@ -125,9 +125,9 @@ func TestConvoyTracksBeadMultipleDeps(t *testing.T) {
 	binDir := t.TempDir()
 	beadsDir := t.TempDir()
 
-	// Stub bd to return multiple tracked deps, one of which matches
+	// Stub bd sql to return multiple tracked deps, one of which matches
 	bdScript := `#!/bin/sh
-echo '[{"id":"gt-other1"},{"id":"external:gt-abc:gt-abc123"},{"id":"gt-other2"}]'
+echo '[{"depends_on_id":"gt-other1"},{"depends_on_id":"external:gt-abc:gt-abc123"},{"depends_on_id":"gt-other2"}]'
 `
 	bdPath := filepath.Join(binDir, "bd")
 	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
@@ -139,5 +139,19 @@ echo '[{"id":"gt-other1"},{"id":"external:gt-abc:gt-abc123"},{"id":"gt-other2"}]
 
 	if !convoyTracksBead(beadsDir, "hq-cv-test5", "gt-abc123") {
 		t.Error("convoyTracksBead should return true when bead found among multiple deps")
+	}
+}
+
+// TestBdDepListRawIDsValidation verifies that bdDepListRawIDs rejects
+// invalid bead IDs to prevent SQL injection.
+func TestBdDepListRawIDsValidation(t *testing.T) {
+	_, err := bdDepListRawIDs("/tmp", "'; DROP TABLE deps; --", "down", "tracks")
+	if err == nil {
+		t.Error("bdDepListRawIDs should reject SQL injection attempts")
+	}
+
+	_, err = bdDepListRawIDs("/tmp", "valid-id", "down", "'; DROP TABLE deps; --")
+	if err == nil {
+		t.Error("bdDepListRawIDs should reject SQL injection in depType")
 	}
 }


### PR DESCRIPTION
## Summary

- Fix `gt convoy status`, `gt convoy stranded`, and `gt convoy launch` showing 0 tracked / 0 ready for HQ convoys tracking cross-database issues (e.g., `hq-cv-*` tracking `ds-*`)
- Root cause: `bd dep list` JOINs deps with the issues table, failing when tracked issues live in a different Dolt database
- Add `bdDepListRawIDs()` using `bd sql` to query raw dependency records (no JOIN), then resolve via `bd show` with prefix routing

## Test plan

- [x] `gt convoy status hq-cv-urdf` now shows 6/14 completed (was 0/0)
- [x] Same-database convoys (`hq-cv-52zag`) still show correct results (21/21)
- [x] All convoy-related unit tests pass (14/15; 1 pre-existing failure unrelated)
- [x] SQL injection validation in `bdDepListRawIDs` tested

Companion to daemon-side fix (aaa46701). Fixes #2624 (CLI side).

🤖 Generated with [Claude Code](https://claude.com/claude-code)