### PR TITLE
docs: add Gas Town communication instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -70,3 +70,69 @@ git push              # Push to remote
 - **Dependencies**: `bd ready` shows only unblocked work
 
 <!-- end-beads-agent-instructions -->
+
+<!-- gastown-agent-instructions-v1 -->
+
+---
+
+## Gas Town Multi-Agent Communication
+
+This workspace is part of a **Gas Town** multi-agent environment. You communicate
+with other agents using `gt` commands — never by printing text or using raw tmux.
+
+### Nudging Agents (Immediate Delivery)
+
+`gt nudge` sends a message directly to another agent's active session:
+
+```bash
+gt nudge mayor "Status update: PR review complete"
+gt nudge laneassist/crew/dom "Check your mail — PR ready for review"
+gt nudge witness "Polecat health check needed"
+gt nudge refinery "Merge queue has items"
+```
+
+**Target formats:**
+- Role shortcuts: `mayor`, `deacon`, `witness`, `refinery`
+- Full path: `<rig>/crew/<name>`, `<rig>/polecats/<name>`
+
+**Important:** `gt nudge` is the ONLY way to send text to another agent's session.
+Never print "Hey @name" — the other agent cannot see your terminal output.
+
+### Sending Mail (Persistent Messages)
+
+`gt mail` sends messages that persist across session restarts:
+
+```bash
+# Reading
+gt mail inbox                    # List messages
+gt mail read <id>                # Read a specific message
+
+# Sending (use --stdin for multi-line content)
+gt mail send mayor/ -s "Subject" -m "Short message"
+gt mail send laneassist/crew/dom -s "PR Review" --stdin <<'BODY'
+Multi-line message content here.
+Details about the PR and what to look for.
+BODY
+gt mail send --human -s "Subject" -m "Message to overseer"
+```
+
+### When to Use Which
+
+| Want to... | Command | Why |
+|------------|---------|-----|
+| Wake a sleeping agent | `gt nudge <target> "msg"` | Immediate delivery |
+| Send detailed task/info | `gt mail send <target> -s "..." --stdin` | Persists across restarts |
+| Both: send + wake | `gt mail send` then `gt nudge` | Mail carries payload, nudge wakes |
+
+### Context Recovery
+
+After compaction or new session, run `gt prime` to reload your full role context,
+identity, and any pending work.
+
+```bash
+gt prime              # Full context reload
+gt hook               # Check for assigned work
+gt mail inbox         # Check for messages
+```
+
+<!-- end-gastown-agent-instructions -->


### PR DESCRIPTION
## Summary
Non-Claude agents (Gemini CLI, Codex, Cursor) read `AGENTS.md` for instructions but don't process hook output as injected context. This means `gt prime`'s instructions about `gt nudge`, `gt mail`, and inter-agent communication are invisible to these agents — they print text like "Hey @dom" instead of running `gt nudge`.

Adds a `<!-- gastown-agent-instructions-v1 -->` block (matching the existing beads integration pattern) documenting:
- `gt nudge` for immediate agent-to-agent messaging
- `gt mail` for persistent messages across session restarts
- Decision table: when to use nudge vs mail vs both
- Context recovery commands (`gt prime`, `gt hook`, `gt mail inbox`)

## Context
- Claude reads `CLAUDE.md` and gets Gas Town context via `gt prime --hook` (SessionStart hook output is injected into context)
- Gemini/Codex/Cursor read `AGENTS.md` and show hook output as a warning banner, not context
- The existing `AGENTS.md` only had beads integration — no Gas Town communication docs
- This is the same pattern as `<!-- beads-agent-instructions-v2 -->` — static content with HTML comment markers

## Test plan
- [x] Verified Gemini agent reads AGENTS.md on startup
- [x] Block follows existing marker comment pattern
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)