### PR TITLE
fix: add RoleDog to session identity for quota rotation restart

### DIFF
--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -1026,6 +1026,8 @@ func sessionWorkDir(sessionName, townRoot string) (string, error) {
 			return fmt.Sprintf("%s/%s/refinery/rig", townRoot, identity.Rig), nil
 		case session.RolePolecat:
 			return fmt.Sprintf("%s/%s/polecats/%s", townRoot, identity.Rig, identity.Name), nil
+		case session.RoleDog:
+			return fmt.Sprintf("%s/deacon/dogs/%s", townRoot, identity.Name), nil
 		default:
 			return "", fmt.Errorf("unknown session type: %s (role %s, try specifying role explicitly)", sessionName, identity.Role)
 		}

--- a/internal/session/identity.go
+++ b/internal/session/identity.go
@@ -17,13 +17,14 @@ const (
 	RoleRefinery Role = "refinery"
 	RoleCrew     Role = "crew"
 	RolePolecat  Role = "polecat"
+	RoleDog      Role = "dog"
 )
 
 // AgentIdentity represents a parsed Gas Town agent identity.
 type AgentIdentity struct {
-	Role   Role   // mayor, deacon, witness, refinery, crew, polecat
-	Rig    string // rig name (empty for mayor/deacon)
-	Name   string // crew/polecat name (empty for mayor/deacon/witness/refinery)
+	Role   Role   // mayor, deacon, witness, refinery, crew, polecat, dog
+	Rig    string // rig name (empty for mayor/deacon/dog)
+	Name   string // crew/polecat/dog name (empty for mayor/deacon/witness/refinery)
 	Prefix string // beads prefix for rig-level agents (e.g., "gt", "bd", "hop")
 }
 
@@ -120,6 +121,14 @@ func ParseSessionNameWithRegistry(session string, registry *PrefixRegistry) (*Ag
 		case "overseer":
 			return &AgentIdentity{Role: RoleOverseer}, nil
 		default:
+			// Dogs: hq-dog-<name>
+			if strings.HasPrefix(suffix, "dog-") {
+				name := suffix[4:] // len("dog-") = 4
+				if name == "" {
+					return nil, fmt.Errorf("invalid session name %q: empty dog name", session)
+				}
+				return &AgentIdentity{Role: RoleDog, Name: name}, nil
+			}
 			return nil, fmt.Errorf("invalid session name %q: unknown hq- role", session)
 		}
 	}
@@ -180,6 +189,8 @@ func (a *AgentIdentity) SessionName() string {
 		return CrewSessionName(a.prefix(), a.Name)
 	case RolePolecat:
 		return PolecatSessionName(a.prefix(), a.Name)
+	case RoleDog:
+		return DogSessionName(a.Name)
 	default:
 		return ""
 	}
@@ -221,6 +232,8 @@ func (a *AgentIdentity) BeaconAddress() string {
 		return BeaconRecipient("crew", a.Name, a.Rig)
 	case RolePolecat:
 		return BeaconRecipient("polecat", a.Name, a.Rig)
+	case RoleDog:
+		return BeaconRecipient("dog", a.Name, "")
 	default:
 		return ""
 	}
@@ -250,6 +263,8 @@ func (a *AgentIdentity) Address() string {
 		return fmt.Sprintf("%s/crew/%s", a.Rig, a.Name)
 	case RolePolecat:
 		return fmt.Sprintf("%s/polecats/%s", a.Rig, a.Name)
+	case RoleDog:
+		return fmt.Sprintf("deacon/dogs/%s", a.Name)
 	default:
 		return ""
 	}

--- a/internal/session/identity_test.go
+++ b/internal/session/identity_test.go
@@ -49,6 +49,20 @@ func TestParseSessionName(t *testing.T) {
 			wantName: "boot",
 		},
 
+		// Dogs (town-level: hq-dog-<name>)
+		{
+			name:     "dog alpha",
+			session:  "hq-dog-alpha",
+			wantRole: RoleDog,
+			wantName: "alpha",
+		},
+		{
+			name:     "dog hyphenated name",
+			session:  "hq-dog-my-dog",
+			wantRole: RoleDog,
+			wantName: "my-dog",
+		},
+
 		// Witness (new format: <prefix>-witness)
 		{
 			name:       "witness gastown",
@@ -243,6 +257,11 @@ func TestAgentIdentity_SessionName(t *testing.T) {
 			identity: AgentIdentity{Role: RolePolecat, Rig: "hop", Name: "ostrom", Prefix: "hop"},
 			want:     "hop-ostrom",
 		},
+		{
+			name:     "dog",
+			identity: AgentIdentity{Role: RoleDog, Name: "alpha"},
+			want:     "hq-dog-alpha",
+		},
 	}
 
 	for _, tt := range tests {
@@ -290,6 +309,11 @@ func TestAgentIdentity_Address(t *testing.T) {
 			identity: AgentIdentity{Role: RolePolecat, Rig: "gastown", Name: "Toast", Prefix: "gt"},
 			want:     "gastown/polecats/Toast",
 		},
+		{
+			name:     "dog",
+			identity: AgentIdentity{Role: RoleDog, Name: "alpha"},
+			want:     "deacon/dogs/alpha",
+		},
 	}
 
 	for _, tt := range tests {
@@ -311,6 +335,7 @@ func TestParseSessionName_RoundTrip(t *testing.T) {
 	sessions := []string{
 		"hq-mayor",
 		"hq-deacon",
+		"hq-dog-alpha",
 		"gt-witness",
 		"bd-refinery",
 		"gt-crew-max",

--- a/internal/session/names.go
+++ b/internal/session/names.go
@@ -59,3 +59,10 @@ func OverseerSessionName() string {
 func BootSessionName() string {
 	return HQPrefix + "boot"
 }
+
+// DogSessionName returns the session name for a named dog agent.
+// Dogs are town-level (managed by deacon), so they use the hq- prefix.
+// Pattern: hq-dog-<name> (e.g., hq-dog-alpha).
+func DogSessionName(name string) string {
+	return fmt.Sprintf("%sdog-%s", HQPrefix, name)
+}


### PR DESCRIPTION
## Summary
- Dogs (`hq-dog-<name>`) were not recognized by `ParseSessionNameWithRegistry`, causing quota rotation to fail when restarting rate-limited dog sessions
- `sessionWorkDir` also lacked a dog case, so `buildRestartCommandWithOpts` couldn't construct the restart command
- Adds `RoleDog` constant, `DogSessionName()` helper, and dog cases to all identity methods (`SessionName`, `BeaconAddress`, `Address`) and `sessionWorkDir`

## Test plan
- [x] All existing session tests pass (`go test ./internal/session/...`)
- [x] All dog package tests pass (`go test ./internal/dog/...`)
- [x] New tests: dog parsing, round-trip, session name, address
- [ ] Manual: trigger quota rotation on a rate-limited dog session — should restart successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)