### PR TITLE
fix: resolve mayor dashboard runtime from agent config

### DIFF
--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -18,6 +18,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
 
@@ -44,6 +45,9 @@ func runCmd(timeout time.Duration, name string, args ...string) (*bytes.Buffer, 
 }
 
 var fetcherRunCmd = runCmd
+var fetcherGetSessionEnv = func(sessionName, key string) (string, error) {
+	return tmux.NewTmux().GetEnvironment(sessionName, key)
+}
 
 // runBdCmd executes a bd command with the configured cmdTimeout in the specified beads directory.
 func (f *LiveConvoyFetcher) runBdCmd(beadsDir string, args ...string) (*bytes.Buffer, error) {
@@ -259,7 +263,6 @@ type trackedIssueInfo struct {
 	LastActivity time.Time
 	UpdatedAt    time.Time // Fallback for activity when no assignee
 }
-
 
 // getTrackedIssues fetches tracked issues for a convoy.
 func (f *LiveConvoyFetcher) getTrackedIssues(convoyID string) ([]trackedIssueInfo, error) {
@@ -1341,7 +1344,7 @@ func (f *LiveConvoyFetcher) FetchQueues() ([]QueueRow, error) {
 // FetchSessions returns active tmux sessions with role detection.
 func (f *LiveConvoyFetcher) FetchSessions() ([]SessionRow, error) {
 	// List tmux sessions
-	stdout, err := runCmd(f.tmuxCmdTimeout, "tmux", "list-sessions", "-F", "#{session_name}:#{session_activity}")
+	stdout, err := fetcherRunCmd(f.tmuxCmdTimeout, "tmux", "list-sessions", "-F", "#{session_name}:#{session_activity}")
 	if err != nil {
 		return nil, nil // tmux not running or no sessions
 	}
@@ -1484,12 +1487,66 @@ func (f *LiveConvoyFetcher) FetchMayor() (*MayorStatus, error) {
 		}
 	}
 
-	// Try to detect runtime from mayor config or session
 	if status.IsAttached {
-		status.Runtime = "claude" // Default; could enhance to detect actual runtime
+		status.Runtime = f.resolveMayorRuntime(mayorSessionName)
 	}
 
 	return status, nil
+}
+
+func (f *LiveConvoyFetcher) resolveMayorRuntime(sessionName string) string {
+	if agentName, err := fetcherGetSessionEnv(sessionName, "GT_AGENT"); err == nil && strings.TrimSpace(agentName) != "" {
+		agentName = strings.TrimSpace(agentName)
+		rc, _, resolveErr := config.ResolveAgentConfigWithOverride(f.townRoot, "", agentName)
+		if resolveErr == nil {
+			return runtimeLabelForRuntimeConfig(rc, agentName)
+		}
+		if roleRC := config.ResolveRoleAgentConfig(constants.RoleMayor, f.townRoot, ""); roleRC != nil && strings.TrimSpace(roleRC.ResolvedAgent) == agentName {
+			return runtimeLabelForRuntimeConfig(roleRC, agentName)
+		}
+		return agentName
+	}
+
+	return runtimeLabelForRuntimeConfig(config.ResolveRoleAgentConfig(constants.RoleMayor, f.townRoot, ""), "")
+}
+
+func runtimeLabelForRuntimeConfig(rc *config.RuntimeConfig, fallback string) string {
+	if rc == nil {
+		if fallback != "" {
+			return fallback
+		}
+		return "claude"
+	}
+	if fallback == "" {
+		fallback = rc.ResolvedAgent
+	}
+	return runtimeLabelFromConfig(rc.Command, rc.Args, fallback)
+}
+
+func runtimeLabelFromConfig(command string, args []string, fallback string) string {
+	command = strings.TrimSpace(command)
+	cmd := ""
+	if command != "" {
+		cmd = strings.TrimSpace(filepath.Base(command))
+	}
+	if cmd == "" {
+		cmd = fallback
+	}
+	if cmd == "" {
+		cmd = "claude"
+	}
+	if cmd == "cgroup-wrap" && len(args) > 0 {
+		cmd = filepath.Base(args[0])
+	}
+
+	for i := 0; i < len(args); i++ {
+		arg := args[i]
+		if (arg == "--model" || arg == "-m") && i+1 < len(args) && strings.TrimSpace(args[i+1]) != "" {
+			return cmd + "/" + strings.TrimSpace(args[i+1])
+		}
+	}
+
+	return cmd
 }
 
 // FetchIssues returns open issues (the backlog).

--- a/internal/web/fetcher_test.go
+++ b/internal/web/fetcher_test.go
@@ -1,6 +1,7 @@
 package web
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -9,6 +10,8 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/activity"
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/constants"
 )
 
 func TestCalculateWorkStatus(t *testing.T) {
@@ -569,4 +572,259 @@ esac
 			t.Fatalf("expected timeout error, got: %v", err)
 		}
 	})
+}
+
+func withMayorFetcherHooks(t *testing.T, sessionEnv func(sessionName, key string) (string, error), runCmdFunc func(time.Duration, string, ...string) (*bytes.Buffer, error)) {
+	t.Helper()
+
+	originalGetEnv := fetcherGetSessionEnv
+	originalRunCmd := fetcherRunCmd
+	t.Cleanup(func() {
+		fetcherGetSessionEnv = originalGetEnv
+		fetcherRunCmd = originalRunCmd
+	})
+	t.Cleanup(config.ResetRegistryForTesting)
+
+	if sessionEnv != nil {
+		fetcherGetSessionEnv = sessionEnv
+	}
+	if runCmdFunc != nil {
+		fetcherRunCmd = runCmdFunc
+	}
+}
+
+func TestResolveMayorRuntime(t *testing.T) {
+	tests := []struct {
+		name        string
+		sessionEnv  func(sessionName, key string) (string, error)
+		setup       func(t *testing.T, townRoot string)
+		wantRuntime string
+	}{
+		{
+			name: "uses session agent env",
+			sessionEnv: func(sessionName, key string) (string, error) {
+				if sessionName != "hq-mayor" || key != "GT_AGENT" {
+					t.Fatalf("unexpected session env lookup: %s %s", sessionName, key)
+				}
+				return "codex", nil
+			},
+			wantRuntime: "codex",
+		},
+		{
+			name: "falls back to town settings",
+			sessionEnv: func(string, string) (string, error) {
+				return "", os.ErrNotExist
+			},
+			setup: func(t *testing.T, townRoot string) {
+				t.Helper()
+				settings := config.NewTownSettings()
+				settings.DefaultAgent = "codex"
+				if err := config.SaveTownSettings(config.TownSettingsPath(townRoot), settings); err != nil {
+					t.Fatalf("SaveTownSettings: %v", err)
+				}
+			},
+			wantRuntime: "codex",
+		},
+		{
+			name: "uses custom role agent alias",
+			sessionEnv: func(string, string) (string, error) {
+				return "", os.ErrNotExist
+			},
+			setup: func(t *testing.T, townRoot string) {
+				t.Helper()
+				settings := config.NewTownSettings()
+				settings.RoleAgents[constants.RoleMayor] = "claude-sonnet"
+				settings.Agents["claude-sonnet"] = &config.RuntimeConfig{
+					Command: "claude",
+					Args:    []string{"--dangerously-skip-permissions", "--model", "sonnet"},
+				}
+				if err := config.SaveTownSettings(config.TownSettingsPath(townRoot), settings); err != nil {
+					t.Fatalf("SaveTownSettings: %v", err)
+				}
+			},
+			wantRuntime: "claude/sonnet",
+		},
+		{
+			name: "uses registry agent from session env",
+			sessionEnv: func(sessionName, key string) (string, error) {
+				if sessionName != "hq-mayor" || key != "GT_AGENT" {
+					t.Fatalf("unexpected session env lookup: %s %s", sessionName, key)
+				}
+				return "mayor-registry", nil
+			},
+			setup: func(t *testing.T, townRoot string) {
+				t.Helper()
+				registry := &config.AgentRegistry{
+					Version: config.CurrentAgentRegistryVersion,
+					Agents: map[string]*config.AgentPresetInfo{
+						"mayor-registry": {
+							Name:    "mayor-registry",
+							Command: "opencode",
+							Args:    []string{"run", "--model", "gpt-5"},
+						},
+					},
+				}
+				if err := config.SaveAgentRegistry(config.DefaultAgentRegistryPath(townRoot), registry); err != nil {
+					t.Fatalf("SaveAgentRegistry: %v", err)
+				}
+			},
+			wantRuntime: "opencode/gpt-5",
+		},
+		{
+			name: "uses ephemeral tier agent from session env",
+			sessionEnv: func(sessionName, key string) (string, error) {
+				if sessionName != "hq-mayor" || key != "GT_AGENT" {
+					t.Fatalf("unexpected session env lookup: %s %s", sessionName, key)
+				}
+				return "claude-sonnet", nil
+			},
+			setup: func(t *testing.T, townRoot string) {
+				t.Helper()
+				if err := config.SaveTownSettings(config.TownSettingsPath(townRoot), config.NewTownSettings()); err != nil {
+					t.Fatalf("SaveTownSettings: %v", err)
+				}
+				t.Setenv("GT_COST_TIER", "economy")
+			},
+			wantRuntime: "claude/sonnet",
+		},
+		{
+			name: "uses provider only role agent alias",
+			sessionEnv: func(string, string) (string, error) {
+				return "", os.ErrNotExist
+			},
+			setup: func(t *testing.T, townRoot string) {
+				t.Helper()
+				settings := config.NewTownSettings()
+				settings.RoleAgents[constants.RoleMayor] = "mayor-custom"
+				settings.Agents["mayor-custom"] = &config.RuntimeConfig{
+					Provider: "codex",
+				}
+				if err := config.SaveTownSettings(config.TownSettingsPath(townRoot), settings); err != nil {
+					t.Fatalf("SaveTownSettings: %v", err)
+				}
+			},
+			wantRuntime: "codex",
+		},
+		{
+			name: "returns unknown alias verbatim when unresolved",
+			sessionEnv: func(sessionName, key string) (string, error) {
+				if sessionName != "hq-mayor" || key != "GT_AGENT" {
+					t.Fatalf("unexpected session env lookup: %s %s", sessionName, key)
+				}
+				return "mystery-agent", nil
+			},
+			wantRuntime: "mystery-agent",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			withMayorFetcherHooks(t, tt.sessionEnv, nil)
+
+			townRoot := t.TempDir()
+			if tt.setup != nil {
+				tt.setup(t, townRoot)
+			}
+
+			f := &LiveConvoyFetcher{townRoot: townRoot}
+			if got := f.resolveMayorRuntime("hq-mayor"); got != tt.wantRuntime {
+				t.Fatalf("resolveMayorRuntime() = %q, want %q", got, tt.wantRuntime)
+			}
+		})
+	}
+}
+
+func TestRuntimeLabelFromConfig(t *testing.T) {
+	tests := []struct {
+		name     string
+		command  string
+		args     []string
+		fallback string
+		want     string
+	}{
+		{
+			name:     "claude model flag",
+			command:  "claude",
+			args:     []string{"--dangerously-skip-permissions", "--model", "sonnet"},
+			fallback: "claude-sonnet",
+			want:     "claude/sonnet",
+		},
+		{
+			name:     "short model flag",
+			command:  "opencode",
+			args:     []string{"run", "-m", "gpt-5"},
+			fallback: "custom-opencode",
+			want:     "opencode/gpt-5",
+		},
+		{
+			name:     "cgroup wrap unwraps binary",
+			command:  "cgroup-wrap",
+			args:     []string{"/usr/local/bin/codex", "--dangerously-bypass-approvals-and-sandbox"},
+			fallback: "codex",
+			want:     "codex",
+		},
+		{
+			name:     "empty command falls back to alias",
+			command:  "",
+			args:     nil,
+			fallback: "mystery-agent",
+			want:     "mystery-agent",
+		},
+		{
+			name:     "empty command and fallback defaults to claude",
+			command:  "",
+			args:     nil,
+			fallback: "",
+			want:     "claude",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := runtimeLabelFromConfig(tt.command, tt.args, tt.fallback); got != tt.want {
+				t.Fatalf("runtimeLabelFromConfig(%q, %v, %q) = %q, want %q", tt.command, tt.args, tt.fallback, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFetchMayor_UsesResolvedRuntime(t *testing.T) {
+	withMayorFetcherHooks(
+		t,
+		func(sessionName, key string) (string, error) {
+			if sessionName != "hq-mayor" || key != "GT_AGENT" {
+				t.Fatalf("unexpected session env lookup: %s %s", sessionName, key)
+			}
+			return "codex", nil
+		},
+		func(_ time.Duration, name string, args ...string) (*bytes.Buffer, error) {
+			if name != "tmux" {
+				t.Fatalf("unexpected command: %s %v", name, args)
+			}
+			return bytes.NewBufferString("hq-mayor:1731328320\nhq-deacon:1731328300\n"), nil
+		},
+	)
+
+	f := &LiveConvoyFetcher{
+		townRoot:             t.TempDir(),
+		mayorActiveThreshold: 24 * time.Hour,
+		tmuxCmdTimeout:       time.Second,
+	}
+
+	status, err := f.FetchMayor()
+	if err != nil {
+		t.Fatalf("FetchMayor: %v", err)
+	}
+	if !status.IsAttached {
+		t.Fatal("expected mayor to be attached")
+	}
+	if status.SessionName != "hq-mayor" {
+		t.Fatalf("SessionName = %q, want %q", status.SessionName, "hq-mayor")
+	}
+	if status.Runtime != "codex" {
+		t.Fatalf("Runtime = %q, want %q", status.Runtime, "codex")
+	}
+	if status.LastActivity == "" {
+		t.Fatal("expected LastActivity to be populated")
+	}
 }


### PR DESCRIPTION
## Problem
The dashboard Mayor banner always reported the runtime as `claude` once the session was attached, even when the Mayor was actually running on another agent such as `codex`.

That produced incorrect UI in real workspaces and was especially misleading after switching a town to a non-Claude default agent.

## What changed
- removed the hardcoded `claude` runtime from the dashboard Mayor fetch path
- resolve the runtime label from the Mayor session's `GT_AGENT` value when present
- fall back to Gas Town's canonical role/config resolution for Mayor when `GT_AGENT` is missing
- handle custom role aliases, `settings/agents.json` registry agents, provider-only aliases, and ephemeral cost-tier aliases
- keep an explicit fallback to the raw alias when a live session exposes an unknown agent name that current config cannot resolve

## Why this approach
The dashboard now uses the same config resolution paths Gas Town already uses for startup and role-agent selection instead of re-implementing ad hoc lookup logic in the web layer.

That keeps the dashboard aligned with:
- `role_agents`
- `default_agent`
- custom aliases in `settings/config.json`
- registry-defined agents in `settings/agents.json`
- ephemeral `GT_COST_TIER` role resolution

## Tests
Added coverage for:
- `resolveMayorRuntime()` with session `GT_AGENT`
- fallback to `default_agent`
- custom role aliases such as `claude-sonnet`
- registry-defined agents from `settings/agents.json`
- provider-only custom aliases
- ephemeral cost-tier aliases
- unknown alias fallback behavior
- direct runtime label formatting cases
- `FetchMayor()` end-to-end unit behavior

## Verification
- `go test ./internal/web -run 'TestResolveMayorRuntime|TestRuntimeLabelFromConfig|TestFetchMayor'`
- `go test ./internal/web`

## Manual check
Built the patched `gt` binary locally, launched the dashboard against an existing Gas Town workspace, and verified the Mayor banner showed `codex` instead of `claude`.
