### PR TITLE
feat(formula): implement extends and compose/expand support

### DIFF
--- a/internal/formula/integration_test.go
+++ b/internal/formula/integration_test.go
@@ -1,67 +1,45 @@
 package formula
 
 import (
-	"os"
-	"path/filepath"
+	"io/fs"
 	"strings"
 	"testing"
 )
 
-// TestParseRealFormulas tests parsing actual formula files from the filesystem.
-// This is an integration test that validates our parser against real-world files.
+// TestParseRealFormulas tests parsing all embedded formula files.
+// Composition formulas (extends/compose) are now also resolved and validated.
 func TestParseRealFormulas(t *testing.T) {
-	// Find formula files - they're in various .beads/formulas directories
-	formulaDirs := []string{
-		"/Users/stevey/gt/gastown/polecats/slit/.beads/formulas",
-		"/Users/stevey/gt/gastown/mayor/rig/.beads/formulas",
+	// Formulas that use aspect-oriented features not yet implemented.
+	skipFormulas := map[string]string{
+		"security-audit.formula.toml": "uses aspect-oriented features (advice/pointcuts)",
 	}
 
-	var formulaFiles []string
-	for _, dir := range formulaDirs {
-		entries, err := os.ReadDir(dir)
-		if err != nil {
-			continue // Skip if directory doesn't exist
+	entries, err := fs.ReadDir(formulasFS, "formulas")
+	if err != nil {
+		t.Fatalf("reading embedded formulas: %v", err)
+	}
+
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".formula.toml") {
+			continue
 		}
-		for _, e := range entries {
-			if filepath.Ext(e.Name()) == ".toml" {
-				formulaFiles = append(formulaFiles, filepath.Join(dir, e.Name()))
-			}
-		}
-	}
-
-	if len(formulaFiles) == 0 {
-		t.Skip("No formula files found to test")
-	}
-
-	// Known files that use advanced features not yet supported:
-	// - Composition (extends, compose): shiny-enterprise, shiny-secure
-	// - Aspect-oriented (advice, pointcuts): security-audit
-	skipAdvanced := map[string]string{
-		"shiny-enterprise.formula.toml": "uses formula composition (extends)",
-		"shiny-secure.formula.toml":     "uses formula composition (extends)",
-		"security-audit.formula.toml":   "uses aspect-oriented features (advice/pointcuts)",
-	}
-
-	for _, path := range formulaFiles {
-		t.Run(filepath.Base(path), func(t *testing.T) {
-			baseName := filepath.Base(path)
-			if reason, ok := skipAdvanced[baseName]; ok {
-				t.Skipf("Skipping advanced formula: %s", reason)
+		name := entry.Name()
+		t.Run(name, func(t *testing.T) {
+			if reason, ok := skipFormulas[name]; ok {
+				t.Skipf("skipping: %s", reason)
 				return
 			}
 
-			f, err := ParseFile(path)
+			data, err := formulasFS.ReadFile("formulas/" + name)
 			if err != nil {
-				// Check if this is a composition formula (has extends)
-				if strings.Contains(err.Error(), "requires at least one") {
-					t.Skipf("Skipping: likely a composition formula - %v", err)
-					return
-				}
-				t.Errorf("ParseFile failed: %v", err)
-				return
+				t.Fatalf("reading formula: %v", err)
 			}
 
-			// Basic sanity checks
+			f, err := Parse(data)
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+
 			if f.Name == "" {
 				t.Error("Formula name is empty")
 			}
@@ -69,7 +47,17 @@ func TestParseRealFormulas(t *testing.T) {
 				t.Errorf("Invalid formula type: %s", f.Type)
 			}
 
-			// Type-specific checks
+			// Resolve composition formulas (extends/compose).
+			if len(f.Extends) > 0 || f.Compose != nil {
+				resolved, err := Resolve(f, nil)
+				if err != nil {
+					t.Fatalf("Resolve: %v", err)
+				}
+				f = resolved
+				t.Logf("Resolved composition formula with %d steps", len(f.Steps))
+			}
+
+			// Type-specific checks on the (possibly resolved) formula.
 			switch f.Type {
 			case TypeConvoy:
 				if len(f.Legs) == 0 {
@@ -80,7 +68,6 @@ func TestParseRealFormulas(t *testing.T) {
 				if len(f.Steps) == 0 {
 					t.Error("Workflow formula has no steps")
 				}
-				// Test topological sort
 				order, err := f.TopologicalSort()
 				if err != nil {
 					t.Errorf("TopologicalSort failed: %v", err)

--- a/internal/formula/parser.go
+++ b/internal/formula/parser.go
@@ -3,7 +3,9 @@ package formula
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"sort"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -117,7 +119,8 @@ func (f *Formula) validateConvoy() error {
 }
 
 func (f *Formula) validateWorkflow() error {
-	if len(f.Steps) == 0 {
+	// Allow empty steps when extends is set — steps come from parent after Resolve().
+	if len(f.Steps) == 0 && len(f.Extends) == 0 {
 		return fmt.Errorf("workflow formula requires at least one step")
 	}
 
@@ -491,4 +494,223 @@ func (f *Formula) GetAspect(id string) *Aspect {
 		}
 	}
 	return nil
+}
+
+// Resolve processes the extends and compose rules of a formula, returning a new
+// formula with all inherited steps merged and expansion rules applied.
+//
+// Parent formulas named in extends are loaded from the embedded formula FS first,
+// then from any additional searchPaths (in order). searchPaths may be nil.
+//
+// Cycles in extends chains are detected and reported as errors.
+func Resolve(formula *Formula, searchPaths []string) (*Formula, error) {
+	return resolveChain(formula, searchPaths, nil)
+}
+
+// resolveChain is the recursive workhorse for Resolve; chain tracks the current
+// extends chain for cycle detection.
+func resolveChain(formula *Formula, searchPaths []string, chain []string) (*Formula, error) {
+	// Cycle detection
+	for _, name := range chain {
+		if name == formula.Name {
+			return nil, fmt.Errorf("circular extends detected: %s", strings.Join(append(chain, formula.Name), " -> "))
+		}
+	}
+
+	// No inheritance or composition — validate and return as-is.
+	if len(formula.Extends) == 0 && formula.Compose == nil {
+		if err := formula.Validate(); err != nil {
+			return nil, err
+		}
+		return formula, nil
+	}
+
+	chain = append(chain, formula.Name)
+
+	merged := &Formula{
+		Name:        formula.Name,
+		Description: formula.Description,
+		Type:        formula.Type,
+		Version:     formula.Version,
+		Pour:        formula.Pour,
+		Agent:       formula.Agent,
+		Compose:     formula.Compose,
+		Vars:        make(map[string]Var),
+	}
+	if merged.Type == "" {
+		merged.Type = TypeWorkflow
+	}
+
+	// Merge each parent in order.
+	for _, parentName := range formula.Extends {
+		parent, err := loadFormulaByName(parentName, searchPaths)
+		if err != nil {
+			return nil, fmt.Errorf("extends %q: %w", parentName, err)
+		}
+		parent, err = resolveChain(parent, searchPaths, chain)
+		if err != nil {
+			return nil, fmt.Errorf("resolve parent %q: %w", parentName, err)
+		}
+
+		// Inherit vars (child overrides take precedence later).
+		for name, v := range parent.Vars {
+			if _, exists := merged.Vars[name]; !exists {
+				merged.Vars[name] = v
+			}
+		}
+		// Inherit steps (parent steps come first).
+		merged.Steps = append(merged.Steps, parent.Steps...)
+
+		// Use parent description as fallback.
+		if merged.Description == "" {
+			merged.Description = parent.Description
+		}
+	}
+
+	// Apply child vars (override any inherited).
+	for name, v := range formula.Vars {
+		merged.Vars[name] = v
+	}
+	// Append child's own steps after parent steps.
+	merged.Steps = append(merged.Steps, formula.Steps...)
+	// Child description takes priority.
+	if formula.Description != "" {
+		merged.Description = formula.Description
+	}
+
+	// Apply compose expand rules.
+	if formula.Compose != nil {
+		for _, rule := range formula.Compose.Expand {
+			expanded, err := applyExpandRule(merged.Steps, rule, searchPaths)
+			if err != nil {
+				return nil, fmt.Errorf("compose expand %q with %q: %w", rule.Target, rule.With, err)
+			}
+			merged.Steps = expanded
+		}
+		// compose.aspects is recorded but not yet acted upon (future work).
+	}
+
+	if err := merged.Validate(); err != nil {
+		return nil, err
+	}
+	return merged, nil
+}
+
+// loadFormulaByName loads a formula by name: embedded FS first, then searchPaths.
+func loadFormulaByName(name string, searchPaths []string) (*Formula, error) {
+	// Try the embedded formula filesystem first.
+	data, err := GetEmbeddedFormulaContent(name)
+	if err == nil {
+		return Parse(data)
+	}
+
+	// Fall back to on-disk search paths.
+	for _, dir := range searchPaths {
+		path := filepath.Join(dir, name+".formula.toml")
+		if data, err2 := os.ReadFile(path); err2 == nil { //nolint:gosec // G304: path from controlled search paths
+			return Parse(data)
+		}
+	}
+
+	return nil, fmt.Errorf("formula %q not found in embedded FS or search paths", name)
+}
+
+// applyExpandRule replaces a target step in steps with the template steps from an
+// expansion formula.  Steps that depended on the target are updated to depend on
+// the last expanded step instead.
+func applyExpandRule(steps []Step, rule *ExpandRule, searchPaths []string) ([]Step, error) {
+	// Load the expansion formula.
+	expansionData, err := GetEmbeddedFormulaContent(rule.With)
+	if err != nil {
+		// Try search paths as fallback.
+		var found bool
+		for _, dir := range searchPaths {
+			path := filepath.Join(dir, rule.With+".formula.toml")
+			if expansionData, err = os.ReadFile(path); err == nil { //nolint:gosec // G304: controlled path
+				found = true
+				break
+			}
+		}
+		if !found {
+			return nil, fmt.Errorf("expansion formula %q: %w", rule.With, err)
+		}
+	}
+
+	expansion, err := Parse(expansionData)
+	if err != nil {
+		return nil, fmt.Errorf("parse expansion formula %q: %w", rule.With, err)
+	}
+	if expansion.Type != TypeExpansion {
+		return nil, fmt.Errorf("formula %q is type %q, want %q", rule.With, expansion.Type, TypeExpansion)
+	}
+	if len(expansion.Template) == 0 {
+		return nil, fmt.Errorf("expansion formula %q has no template steps", rule.With)
+	}
+
+	// Locate the target step.
+	targetIdx := -1
+	var targetStep Step
+	for i, s := range steps {
+		if s.ID == rule.Target {
+			targetIdx = i
+			targetStep = s
+			break
+		}
+	}
+	if targetIdx == -1 {
+		return nil, fmt.Errorf("target step %q not found in formula steps", rule.Target)
+	}
+
+	// Build expanded steps from the expansion template.
+	expanded := make([]Step, 0, len(expansion.Template))
+	for _, tmpl := range expansion.Template {
+		newStep := Step{
+			ID:          expandPlaceholders(tmpl.ID, rule.Target, targetStep),
+			Title:       expandPlaceholders(tmpl.Title, rule.Target, targetStep),
+			Description: expandPlaceholders(tmpl.Description, rule.Target, targetStep),
+		}
+		if len(tmpl.Needs) == 0 {
+			// First expanded step inherits the target's own needs.
+			newStep.Needs = append([]string(nil), targetStep.Needs...)
+		} else {
+			newStep.Needs = make([]string, len(tmpl.Needs))
+			for i, need := range tmpl.Needs {
+				newStep.Needs[i] = expandPlaceholders(need, rule.Target, targetStep)
+			}
+		}
+		expanded = append(expanded, newStep)
+	}
+
+	lastExpanded := expanded[len(expanded)-1].ID
+
+	// Rebuild step list: replace target with expanded steps; update dependents.
+	result := make([]Step, 0, len(steps)-1+len(expanded))
+	for i, step := range steps {
+		if i == targetIdx {
+			result = append(result, expanded...)
+			continue
+		}
+		// Rewrite any needs that referenced the replaced target.
+		updated := false
+		for j, need := range step.Needs {
+			if need == rule.Target {
+				if !updated {
+					step.Needs = append([]string(nil), step.Needs...)
+					updated = true
+				}
+				step.Needs[j] = lastExpanded
+			}
+		}
+		result = append(result, step)
+	}
+	return result, nil
+}
+
+// expandPlaceholders replaces {target} and {target.title}/{target.description}
+// in expansion template strings with the actual target step values.
+func expandPlaceholders(s, targetID string, targetStep Step) string {
+	s = strings.ReplaceAll(s, "{target.title}", targetStep.Title)
+	s = strings.ReplaceAll(s, "{target.description}", targetStep.Description)
+	s = strings.ReplaceAll(s, "{target}", targetID)
+	return s
 }

--- a/internal/formula/parser_test.go
+++ b/internal/formula/parser_test.go
@@ -517,3 +517,147 @@ description = "No agent override"
 		t.Errorf("Legs[0].Agent = %q, want empty", f.Legs[0].Agent)
 	}
 }
+
+// TestResolve_ShinyEnterprise verifies that Resolve correctly processes the
+// shiny-enterprise formula: inheriting steps from shiny and expanding the
+// "implement" step with the rule-of-five template.
+func TestResolve_ShinyEnterprise(t *testing.T) {
+	data, err := GetEmbeddedFormulaContent("shiny-enterprise")
+	if err != nil {
+		t.Fatalf("GetEmbeddedFormulaContent: %v", err)
+	}
+
+	// Parse should succeed even though shiny-enterprise has no own steps.
+	f, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(f.Extends) == 0 {
+		t.Fatal("expected shiny-enterprise to have extends")
+	}
+
+	// Resolve should merge shiny steps and apply rule-of-five expansion.
+	resolved, err := Resolve(f, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// shiny has: design, implement, review, test, submit (5 steps).
+	// Expand "implement" with rule-of-five (5 template steps) → 9 total steps.
+	wantIDs := []string{
+		"design",
+		"implement.draft",
+		"implement.refine-1",
+		"implement.refine-2",
+		"implement.refine-3",
+		"implement.refine-4",
+		"review",
+		"test",
+		"submit",
+	}
+
+	if len(resolved.Steps) != len(wantIDs) {
+		t.Fatalf("got %d steps, want %d: %v", len(resolved.Steps), len(wantIDs), stepIDs(resolved))
+	}
+	for i, want := range wantIDs {
+		if got := resolved.Steps[i].ID; got != want {
+			t.Errorf("step[%d] = %q, want %q", i, got, want)
+		}
+	}
+
+	// First expanded step should inherit design's successor role: needs nothing
+	// since design has no needs, implement.draft inherits implement's needs
+	// which is also empty (design is a needs of implement).
+	// Actually: implement.needs = ["design"], so implement.draft.needs = ["design"].
+	draftStep := resolved.Steps[1]
+	if len(draftStep.Needs) != 1 || draftStep.Needs[0] != "design" {
+		t.Errorf("implement.draft.Needs = %v, want [design]", draftStep.Needs)
+	}
+
+	// review should now need implement.refine-4 (last expanded step).
+	reviewStep := resolved.Steps[6]
+	if reviewStep.ID != "review" {
+		t.Fatalf("step[6].ID = %q, want review", reviewStep.ID)
+	}
+	if len(reviewStep.Needs) != 1 || reviewStep.Needs[0] != "implement.refine-4" {
+		t.Errorf("review.Needs = %v, want [implement.refine-4]", reviewStep.Needs)
+	}
+}
+
+// TestResolve_ShinySecure verifies that shiny-secure (extends shiny, aspects only)
+// resolves to the shiny steps without error.
+func TestResolve_ShinySecure(t *testing.T) {
+	data, err := GetEmbeddedFormulaContent("shiny-secure")
+	if err != nil {
+		t.Fatalf("GetEmbeddedFormulaContent: %v", err)
+	}
+
+	f, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	resolved, err := Resolve(f, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	// shiny-secure has no expand rules; it should produce the same 5 steps as shiny.
+	wantIDs := []string{"design", "implement", "review", "test", "submit"}
+	if len(resolved.Steps) != len(wantIDs) {
+		t.Fatalf("got %d steps, want %d: %v", len(resolved.Steps), len(wantIDs), stepIDs(resolved))
+	}
+	for i, want := range wantIDs {
+		if got := resolved.Steps[i].ID; got != want {
+			t.Errorf("step[%d] = %q, want %q", i, got, want)
+		}
+	}
+}
+
+// TestResolve_CycleDetection verifies that circular extends chains are rejected.
+func TestResolve_CycleDetection(t *testing.T) {
+	// Manually construct a formula that extends itself.
+	selfRef := &Formula{
+		Name:    "self-ref",
+		Type:    TypeWorkflow,
+		Version: 1,
+		Extends: []string{"shiny"}, // shiny is fine, but we'll simulate cycle below
+	}
+	// Overwrite Extends to point to itself:
+	selfRef.Extends = []string{"self-ref"}
+
+	_, err := Resolve(selfRef, nil)
+	if err == nil {
+		t.Fatal("expected cycle error, got nil")
+	}
+}
+
+// TestResolve_NoExtends verifies formulas without extends pass through unchanged.
+func TestResolve_NoExtends(t *testing.T) {
+	data, err := GetEmbeddedFormulaContent("shiny")
+	if err != nil {
+		t.Fatalf("GetEmbeddedFormulaContent: %v", err)
+	}
+	f, err := Parse(data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+
+	resolved, err := Resolve(f, nil)
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+
+	if len(resolved.Steps) != len(f.Steps) {
+		t.Errorf("step count changed: got %d, want %d", len(resolved.Steps), len(f.Steps))
+	}
+}
+
+// stepIDs returns the IDs of all steps in a formula for test diagnostics.
+func stepIDs(f *Formula) []string {
+	ids := make([]string, len(f.Steps))
+	for i, s := range f.Steps {
+		ids[i] = s.ID
+	}
+	return ids
+}

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -45,11 +45,34 @@ type Formula struct {
 	Steps []Step           `toml:"steps"`
 	Vars  map[string]Var   `toml:"vars"`
 
+	// Composition-specific
+	Extends []string      `toml:"extends"` // Parent formula names to inherit steps from.
+	Compose *ComposeRules `toml:"compose"` // Composition rules applied after inheritance.
+
 	// Expansion-specific
 	Template []Template `toml:"template"`
 
 	// Aspect-specific (similar to convoy but for analysis)
 	Aspects []Aspect `toml:"aspects"`
+}
+
+// ComposeRules defines how a formula can be composed with others.
+type ComposeRules struct {
+	// Expand replaces a single target step with an expansion formula's template steps.
+	Expand []*ExpandRule `toml:"expand"`
+
+	// Aspects lists aspect formula names to apply to this formula.
+	// (Reserved for future implementation.)
+	Aspects []string `toml:"aspects"`
+}
+
+// ExpandRule replaces a target step with the template steps from an expansion formula.
+type ExpandRule struct {
+	// Target is the step ID to replace.
+	Target string `toml:"target"`
+
+	// With is the name of the expansion formula whose template steps replace the target.
+	With string `toml:"with"`
 }
 
 // Aspect represents a parallel analysis aspect in an aspect formula.


### PR DESCRIPTION
## Summary

- Add `Resolve()` to the formula package so workflow formulas can inherit steps from parent formulas via `extends` and replace target steps with expansion template steps via `compose.expand`
- Fix `validateWorkflow` to allow empty steps when `extends` is set (steps come from parent after resolution)
- Update integration test to use embedded formula FS instead of hardcoded paths; `shiny-enterprise` and `shiny-secure` now pass instead of being skipped

## Motivation

The `shiny-enterprise.formula.toml` uses `extends = ["shiny"]` and `[[compose.expand]]` but the formula parser had no support for these features, causing `gt prime --hook` to fail with _"workflow formula requires at least one step"_ for any formula that inherits steps from a parent.

Fixes ge-9hc.

## Test plan

- [x] `TestResolve_ShinyEnterprise` — resolves 9-step merged+expanded formula
- [x] `TestResolve_ShinySecure` — resolves 5-step inherited formula (aspects reserved)
- [x] `TestResolve_CycleDetection` — circular extends chain returns error
- [x] `TestResolve_NoExtends` — plain formula passes through unchanged
- [x] `TestParseRealFormulas/shiny-enterprise.formula.toml` — passes (was skipped)
- [x] `TestParseRealFormulas/shiny-secure.formula.toml` — passes (was skipped)
- [x] All other existing formula tests continue to pass