### PR TITLE
fix(witness): emit MERGE_READY channel event to wake refinery

### DIFF
--- a/internal/channelevents/channelevents.go
+++ b/internal/channelevents/channelevents.go
@@ -1,0 +1,97 @@
+// Package channelevents provides file-based event emission for named channels.
+//
+// Channel events are JSON files written to ~/gt/events/<channel>/*.event
+// and consumed by await-event subscribers (e.g., the refinery watching for
+// MERGE_READY events). This is distinct from the activity feed events in
+// the events package (~/gt/.events.jsonl).
+package channelevents
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/workspace"
+)
+
+// ValidChannelName restricts channel names to safe characters (no path traversal).
+var ValidChannelName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+
+// emitSeq is an atomic counter to ensure unique event filenames even when
+// time.Now().UnixNano() has low resolution.
+var emitSeq atomic.Uint64
+
+// Emit creates an event file in the channel directory, resolving the town
+// root from the current working directory.
+func Emit(channel, eventType string, payloadPairs []string) (string, error) {
+	if !ValidChannelName.MatchString(channel) {
+		return "", fmt.Errorf("invalid channel name %q: must match [a-zA-Z0-9_-]", channel)
+	}
+
+	townRoot, err := workspace.FindFromCwd()
+	if err != nil || townRoot == "" {
+		home, _ := os.UserHomeDir()
+		townRoot = filepath.Join(home, "gt")
+	}
+	eventDir := filepath.Join(townRoot, "events", channel)
+	if err := os.MkdirAll(eventDir, 0755); err != nil {
+		return "", fmt.Errorf("creating event directory: %w", err)
+	}
+
+	return emitToDir(eventDir, channel, eventType, payloadPairs)
+}
+
+// EmitToTown creates an event file using an explicit town root.
+// Used by internal callers that already know the town root.
+func EmitToTown(townRoot, channel, eventType string, payloadPairs []string) (string, error) {
+	if !ValidChannelName.MatchString(channel) {
+		return "", fmt.Errorf("invalid channel name %q: must match [a-zA-Z0-9_-]", channel)
+	}
+
+	eventDir := filepath.Join(townRoot, "events", channel)
+	if err := os.MkdirAll(eventDir, 0755); err != nil {
+		return "", fmt.Errorf("creating event directory: %w", err)
+	}
+	return emitToDir(eventDir, channel, eventType, payloadPairs)
+}
+
+// emitToDir writes an event file to the given directory.
+func emitToDir(eventDir, channel, eventType string, payloadPairs []string) (string, error) {
+	if !ValidChannelName.MatchString(channel) {
+		return "", fmt.Errorf("invalid channel name %q: must match [a-zA-Z0-9_-]", channel)
+	}
+
+	payload := make(map[string]string)
+	for _, pair := range payloadPairs {
+		key, val, found := strings.Cut(pair, "=")
+		if found {
+			payload[key] = val
+		}
+	}
+
+	now := time.Now()
+	event := map[string]interface{}{
+		"type":      eventType,
+		"channel":   channel,
+		"timestamp": now.Format(time.RFC3339),
+		"payload":   payload,
+	}
+
+	data, err := json.MarshalIndent(event, "", "  ")
+	if err != nil {
+		return "", fmt.Errorf("marshaling event: %w", err)
+	}
+
+	seq := emitSeq.Add(1)
+	eventFile := filepath.Join(eventDir, fmt.Sprintf("%d-%d-%d.event", now.UnixNano(), seq, os.Getpid()))
+	if err := os.WriteFile(eventFile, data, 0644); err != nil {
+		return "", fmt.Errorf("writing event file: %w", err)
+	}
+
+	return eventFile, nil
+}

--- a/internal/channelevents/channelevents_test.go
+++ b/internal/channelevents/channelevents_test.go
@@ -1,0 +1,115 @@
+package channelevents
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestEmitToTown(t *testing.T) {
+	t.Parallel()
+	townRoot := t.TempDir()
+
+	path, err := EmitToTown(townRoot, "refinery", "MERGE_READY", []string{
+		"source=witness",
+		"rig=dashboard",
+	})
+	if err != nil {
+		t.Fatalf("EmitToTown failed: %v", err)
+	}
+
+	if !strings.HasSuffix(path, ".event") {
+		t.Errorf("expected .event suffix, got %q", path)
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading event file: %v", err)
+	}
+
+	var event map[string]interface{}
+	if err := json.Unmarshal(data, &event); err != nil {
+		t.Fatalf("unmarshaling event: %v", err)
+	}
+
+	if event["type"] != "MERGE_READY" {
+		t.Errorf("type = %v, want MERGE_READY", event["type"])
+	}
+	if event["channel"] != "refinery" {
+		t.Errorf("channel = %v, want refinery", event["channel"])
+	}
+
+	payload, ok := event["payload"].(map[string]interface{})
+	if !ok {
+		t.Fatal("payload is not a map")
+	}
+	if payload["source"] != "witness" {
+		t.Errorf("payload.source = %v, want witness", payload["source"])
+	}
+	if payload["rig"] != "dashboard" {
+		t.Errorf("payload.rig = %v, want dashboard", payload["rig"])
+	}
+}
+
+func TestEmitToTown_InvalidChannel(t *testing.T) {
+	t.Parallel()
+	_, err := EmitToTown(t.TempDir(), "../escape", "TEST", nil)
+	if err == nil {
+		t.Error("expected error for invalid channel name")
+	}
+}
+
+func TestEmitToTown_UniqueFilenames(t *testing.T) {
+	t.Parallel()
+	townRoot := t.TempDir()
+	seen := make(map[string]bool)
+
+	for i := 0; i < 10; i++ {
+		path, err := EmitToTown(townRoot, "test", "EVENT", nil)
+		if err != nil {
+			t.Fatalf("iteration %d: %v", i, err)
+		}
+		if seen[path] {
+			t.Errorf("duplicate filename: %s", path)
+		}
+		seen[path] = true
+	}
+}
+
+func TestValidChannelName(t *testing.T) {
+	t.Parallel()
+	valid := []string{"refinery", "witness", "my-channel", "test_chan", "abc123"}
+	for _, name := range valid {
+		if !ValidChannelName.MatchString(name) {
+			t.Errorf("%q should be valid", name)
+		}
+	}
+
+	invalid := []string{"../escape", "has space", "has/slash", "", "has.dot"}
+	for _, name := range invalid {
+		if ValidChannelName.MatchString(name) {
+			t.Errorf("%q should be invalid", name)
+		}
+	}
+}
+
+func TestEmitToTown_CreatesDirectory(t *testing.T) {
+	t.Parallel()
+	townRoot := t.TempDir()
+	channelDir := filepath.Join(townRoot, "events", "newchannel")
+
+	if _, err := os.Stat(channelDir); !os.IsNotExist(err) {
+		t.Fatal("channel dir should not exist yet")
+	}
+
+	_, err := EmitToTown(townRoot, "newchannel", "TEST", nil)
+	if err != nil {
+		t.Fatalf("EmitToTown failed: %v", err)
+	}
+
+	if _, err := os.Stat(channelDir); err != nil {
+		t.Errorf("channel dir should exist after emit: %v", err)
+	}
+}

--- a/internal/cmd/molecule_await_event.go
+++ b/internal/cmd/molecule_await_event.go
@@ -6,13 +6,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"regexp"
 	"sort"
 	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/channelevents"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
@@ -28,8 +28,8 @@ var (
 	awaitEventCleanup     bool
 )
 
-// validChannelName restricts channel names to safe characters (no path traversal).
-var validChannelName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
+// validChannelName is a convenience alias for the canonical regex in channelevents.
+var validChannelName = channelevents.ValidChannelName
 
 var moleculeAwaitEventCmd = &cobra.Command{
 	Use:   "await-event",

--- a/internal/cmd/molecule_emit_event.go
+++ b/internal/cmd/molecule_emit_event.go
@@ -4,18 +4,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
-	"strings"
-	"sync/atomic"
-	"time"
 
 	"github.com/spf13/cobra"
-	"github.com/steveyegge/gastown/internal/workspace"
+	"github.com/steveyegge/gastown/internal/channelevents"
 )
-
-// emitEventSeq is an atomic counter to ensure unique event filenames even when
-// time.Now().UnixNano() has low resolution (e.g., Windows ~100ns granularity).
-var emitEventSeq atomic.Uint64
 
 var (
 	emitEventChannel string
@@ -73,7 +65,7 @@ func init() {
 }
 
 func runMoleculeEmitEvent(cmd *cobra.Command, args []string) error {
-	path, err := EmitEvent(emitEventChannel, emitEventType, emitEventPayload)
+	path, err := channelevents.Emit(emitEventChannel, emitEventType, emitEventPayload)
 	if err != nil {
 		return err
 	}
@@ -90,82 +82,4 @@ func runMoleculeEmitEvent(cmd *cobra.Command, args []string) error {
 
 	fmt.Println(path)
 	return nil
-}
-
-// EmitEvent creates an event file in the channel directory.
-// This is the programmatic API used by both the CLI command and internal callers
-// (e.g., nudgeRefinery). Returns the path to the created event file.
-func EmitEvent(channel, eventType string, payloadPairs []string) (string, error) {
-	// Validate channel name before any filesystem operations (defense-in-depth)
-	if !validChannelName.MatchString(channel) {
-		return "", fmt.Errorf("invalid channel name %q: must match [a-zA-Z0-9_-]", channel)
-	}
-
-	// Resolve event directory
-	townRoot, err := workspace.FindFromCwd()
-	if err != nil || townRoot == "" {
-		home, _ := os.UserHomeDir()
-		townRoot = filepath.Join(home, "gt")
-	}
-	eventDir := filepath.Join(townRoot, "events", channel)
-	if err := os.MkdirAll(eventDir, 0755); err != nil {
-		return "", fmt.Errorf("creating event directory: %w", err)
-	}
-
-	return emitEventImpl(eventDir, channel, eventType, payloadPairs)
-}
-
-// EmitEventToTown creates an event file using an explicit town root.
-// Used by internal callers that already know the town root (e.g., nudgeRefinery).
-func EmitEventToTown(townRoot, channel, eventType string, payloadPairs []string) (string, error) {
-	// Validate channel name before any filesystem operations (defense-in-depth)
-	if !validChannelName.MatchString(channel) {
-		return "", fmt.Errorf("invalid channel name %q: must match [a-zA-Z0-9_-]", channel)
-	}
-
-	eventDir := filepath.Join(townRoot, "events", channel)
-	if err := os.MkdirAll(eventDir, 0755); err != nil {
-		return "", fmt.Errorf("creating event directory: %w", err)
-	}
-	return emitEventImpl(eventDir, channel, eventType, payloadPairs)
-}
-
-// emitEventImpl writes an event file to the given directory.
-func emitEventImpl(eventDir, channel, eventType string, payloadPairs []string) (string, error) {
-	// Validate channel name (prevent path traversal)
-	if !validChannelName.MatchString(channel) {
-		return "", fmt.Errorf("invalid channel name %q: must match [a-zA-Z0-9_-]", channel)
-	}
-
-	// Build payload from key=value pairs
-	payload := make(map[string]string)
-	for _, pair := range payloadPairs {
-		key, val, found := strings.Cut(pair, "=")
-		if found {
-			payload[key] = val
-		}
-	}
-
-	// Build event JSON
-	now := time.Now()
-	event := map[string]interface{}{
-		"type":      eventType,
-		"channel":   channel,
-		"timestamp": now.Format(time.RFC3339),
-		"payload":   payload,
-	}
-
-	data, err := json.MarshalIndent(event, "", "  ")
-	if err != nil {
-		return "", fmt.Errorf("marshaling event: %w", err)
-	}
-
-	// Write event file with nanosecond timestamp + sequence + PID for uniqueness
-	seq := emitEventSeq.Add(1)
-	eventFile := filepath.Join(eventDir, fmt.Sprintf("%d-%d-%d.event", now.UnixNano(), seq, os.Getpid()))
-	if err := os.WriteFile(eventFile, data, 0644); err != nil {
-		return "", fmt.Errorf("writing event file: %w", err)
-	}
-
-	return eventFile, nil
 }

--- a/internal/cmd/molecule_emit_event_test.go
+++ b/internal/cmd/molecule_emit_event_test.go
@@ -6,18 +6,15 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/gastown/internal/channelevents"
 )
 
 func TestEmitEvent(t *testing.T) {
 	t.Run("basic event creation", func(t *testing.T) {
-		dir := t.TempDir()
-		channel := "test-channel"
-		channelDir := filepath.Join(dir, "events", channel)
-		os.MkdirAll(channelDir, 0755)
+		townRoot := t.TempDir()
 
-		// EmitEvent uses workspace.FindFromCwd which won't work in tests,
-		// so we test the file writing logic directly via the channel dir.
-		path, err := emitEventToDir(channelDir, "MERGE_READY", []string{"polecat=nux", "branch=feat/test"})
+		path, err := channelevents.EmitToTown(townRoot, "test-channel", "MERGE_READY", []string{"polecat=nux", "branch=feat/test"})
 		if err != nil {
 			t.Fatalf("EmitEvent failed: %v", err)
 		}
@@ -58,8 +55,8 @@ func TestEmitEvent(t *testing.T) {
 	})
 
 	t.Run("empty payload", func(t *testing.T) {
-		dir := t.TempDir()
-		path, err := emitEventToDir(dir, "PATROL_WAKE", nil)
+		townRoot := t.TempDir()
+		path, err := channelevents.EmitToTown(townRoot, "test-channel", "PATROL_WAKE", nil)
 		if err != nil {
 			t.Fatalf("EmitEvent failed: %v", err)
 		}
@@ -87,10 +84,10 @@ func TestEmitEvent(t *testing.T) {
 	})
 
 	t.Run("multiple events unique paths", func(t *testing.T) {
-		dir := t.TempDir()
+		townRoot := t.TempDir()
 		paths := make(map[string]bool)
 		for i := 0; i < 5; i++ {
-			path, err := emitEventToDir(dir, "TEST", nil)
+			path, err := channelevents.EmitToTown(townRoot, "test-channel", "TEST", nil)
 			if err != nil {
 				t.Fatalf("EmitEvent failed on iteration %d: %v", i, err)
 			}
@@ -102,8 +99,8 @@ func TestEmitEvent(t *testing.T) {
 	})
 
 	t.Run("malformed payload pair ignored", func(t *testing.T) {
-		dir := t.TempDir()
-		path, err := emitEventToDir(dir, "TEST", []string{"valid=yes", "no-equals-sign"})
+		townRoot := t.TempDir()
+		path, err := channelevents.EmitToTown(townRoot, "test-channel", "TEST", []string{"valid=yes", "no-equals-sign"})
 		if err != nil {
 			t.Fatalf("EmitEvent failed: %v", err)
 		}
@@ -127,36 +124,36 @@ func TestEmitEvent(t *testing.T) {
 }
 
 func TestEmitEventChannelValidation(t *testing.T) {
-	dir := t.TempDir()
+	townRoot := t.TempDir()
 
 	// Valid channel name should succeed
-	_, err := emitEventImpl(dir, "valid-channel", "TEST", nil)
+	_, err := channelevents.EmitToTown(townRoot, "valid-channel", "TEST", nil)
 	if err != nil {
 		t.Errorf("valid channel name rejected: %v", err)
 	}
 
 	// Path traversal should be rejected
-	_, err = emitEventImpl(dir, "../etc", "TEST", nil)
+	_, err = channelevents.EmitToTown(townRoot, "../etc", "TEST", nil)
 	if err == nil {
 		t.Error("expected error for path traversal channel name, got nil")
 	}
 
 	// Slash in channel should be rejected
-	_, err = emitEventImpl(dir, "foo/bar", "TEST", nil)
+	_, err = channelevents.EmitToTown(townRoot, "foo/bar", "TEST", nil)
 	if err == nil {
 		t.Error("expected error for channel with slash, got nil")
 	}
 
 	// Empty channel should be rejected
-	_, err = emitEventImpl(dir, "", "TEST", nil)
+	_, err = channelevents.EmitToTown(townRoot, "", "TEST", nil)
 	if err == nil {
 		t.Error("expected error for empty channel name, got nil")
 	}
 }
 
 func TestEmitEventPIDInFilename(t *testing.T) {
-	dir := t.TempDir()
-	path, err := emitEventImpl(dir, "test-channel", "TEST", nil)
+	townRoot := t.TempDir()
+	path, err := channelevents.EmitToTown(townRoot, "test-channel", "TEST", nil)
 	if err != nil {
 		t.Fatalf("emit failed: %v", err)
 	}
@@ -197,10 +194,4 @@ func TestEmitEventResult(t *testing.T) {
 	if decoded.Type != result.Type {
 		t.Errorf("type = %q, want %q", decoded.Type, result.Type)
 	}
-}
-
-// emitEventToDir is a test helper that writes an event directly to a directory,
-// bypassing workspace resolution.
-func emitEventToDir(dir, eventType string, payloadPairs []string) (string, error) {
-	return emitEventImpl(dir, "test-channel", eventType, payloadPairs)
 }

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -14,6 +14,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/channelevents"
 	"github.com/steveyegge/gastown/internal/cli"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
@@ -609,7 +610,7 @@ func nudgeWitness(rigName, message string) {
 	// Emit a file event so the witness's await-event unblocks instantly.
 	townRoot, _ := workspace.FindFromCwd()
 	if townRoot != "" {
-		_, _ = EmitEventToTown(townRoot, "witness", "POLECAT_DONE", []string{
+		_, _ = channelevents.EmitToTown(townRoot, "witness", "POLECAT_DONE", []string{
 			"source=polecat",
 			"message=" + message,
 		})
@@ -644,7 +645,7 @@ func nudgeRefinery(rigName, message string) {
 	// This is the programmatic bridge between mq submit and the event system.
 	townRoot, _ := workspace.FindFromCwd()
 	if townRoot != "" {
-		_, _ = EmitEventToTown(townRoot, "refinery", "MQ_SUBMIT", []string{
+		_, _ = channelevents.EmitToTown(townRoot, "refinery", "MQ_SUBMIT", []string{
 			"source=sling",
 			"message=" + message,
 		})

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/channelevents"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/git"
@@ -238,12 +239,20 @@ func handlePolecatDonePendingMR(bd *BdCli, workDir, rigName string, payload *Pol
 	return result
 }
 
-// notifyRefineryMergeReady nudges the Refinery to check the merge queue.
-// Previously sent MERGE_READY mail (creating permanent Dolt commits); now
-// just nudges. The Refinery discovers pending MRs from beads queries.
+// notifyRefineryMergeReady emits a MERGE_READY channel event and nudges the
+// Refinery to check the merge queue. The channel event unblocks the refinery's
+// await-event loop instantly; the tmux nudge is a belt-and-suspenders fallback
+// for when the refinery is at the Claude prompt rather than in await-event.
 // Errors are non-fatal (Refinery will still pick up work on next patrol cycle).
 func notifyRefineryMergeReady(workDir, rigName string, result *HandlerResult) {
 	townRoot, _ := workspace.Find(workDir)
+	// Emit file-based event so refinery's await-event unblocks instantly.
+	if townRoot != "" {
+		_, _ = channelevents.EmitToTown(townRoot, "refinery", "MERGE_READY", []string{
+			"source=witness",
+			"rig=" + rigName,
+		})
+	}
 	if nudgeErr := nudgeRefinery(townRoot, rigName); nudgeErr != nil {
 		if result.Error == nil {
 			result.Error = fmt.Errorf("nudging refinery: %w (non-fatal)", nudgeErr)

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -1,6 +1,7 @@
 package witness
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -1825,5 +1826,70 @@ func TestZombieAgentSelfReportedStuck_Classification(t *testing.T) {
 	// Should imply active work (agent is alive and asking for help)
 	if !ZombieAgentSelfReportedStuck.ImpliesActiveWork() {
 		t.Error("ZombieAgentSelfReportedStuck should imply active work")
+	}
+}
+
+func TestNotifyRefineryMergeReady_EmitsChannelEvent(t *testing.T) {
+	// Create a fake town root with the workspace marker so workspace.Find recognizes it
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Set GT_TEST_NUDGE_LOG to prevent actual tmux operations in nudgeRefinery
+	t.Setenv("GT_TEST_NUDGE_LOG", filepath.Join(t.TempDir(), "nudge.log"))
+
+	result := &HandlerResult{}
+	// notifyRefineryMergeReady takes workDir and calls workspace.Find(workDir) internally
+	notifyRefineryMergeReady(townRoot, "dashboard", result)
+
+	// Verify that a MERGE_READY event file was created in the refinery channel
+	eventDir := filepath.Join(townRoot, "events", "refinery")
+	entries, err := os.ReadDir(eventDir)
+	if err != nil {
+		t.Fatalf("reading event dir: %v", err)
+	}
+
+	var eventFiles []string
+	for _, e := range entries {
+		if strings.HasSuffix(e.Name(), ".event") {
+			eventFiles = append(eventFiles, e.Name())
+		}
+	}
+
+	if len(eventFiles) == 0 {
+		t.Fatal("expected at least one .event file in ~/gt/events/refinery/, got none")
+	}
+
+	// Read and verify the event content
+	data, err := os.ReadFile(filepath.Join(eventDir, eventFiles[0]))
+	if err != nil {
+		t.Fatalf("reading event file: %v", err)
+	}
+
+	var event map[string]interface{}
+	if err := json.Unmarshal(data, &event); err != nil {
+		t.Fatalf("parsing event JSON: %v", err)
+	}
+
+	if event["type"] != "MERGE_READY" {
+		t.Errorf("event type = %v, want MERGE_READY", event["type"])
+	}
+	if event["channel"] != "refinery" {
+		t.Errorf("event channel = %v, want refinery", event["channel"])
+	}
+
+	payload, ok := event["payload"].(map[string]interface{})
+	if !ok {
+		t.Fatalf("payload is not a map: %T", event["payload"])
+	}
+	if payload["source"] != "witness" {
+		t.Errorf("payload.source = %v, want witness", payload["source"])
+	}
+	if payload["rig"] != "dashboard" {
+		t.Errorf("payload.rig = %v, want dashboard", payload["rig"])
 	}
 }


### PR DESCRIPTION
## Summary

- Extract channel event emission from `internal/cmd` into a new `internal/channelevents` package to break circular dependency
- Add `MERGE_READY` event emission to `notifyRefineryMergeReady` in the witness, so the refinery's `await-event` loop unblocks instantly when work is ready
- Refactor `molecule_emit_event.go` and `sling_helpers.go` to use the new shared package
- Alias `validChannelName` in `molecule_await_event.go` to the canonical regex in `channelevents`

Fixes #2659

## Problem

The witness only sent a tmux nudge when notifying the refinery about merge-ready work. The refinery patrol loop uses `gt mol step await-event --channel refinery` which watches `~/gt/events/refinery/` for `.event` files. Since no event file was created, the refinery would not wake until backoff timers fired (30s→5min), causing repeated stalls of 15-70+ minutes.

The `nudgeRefinery` in `sling_helpers.go` (called from `gt mq submit`/`gt done`) already correctly emitted `MQ_SUBMIT` events — but the witness's own `notifyRefineryMergeReady` did not.

## Changes

### New: `internal/channelevents/` package
Extracted from `internal/cmd/molecule_emit_event.go`:
- `Emit()` — resolves town root from cwd
- `EmitToTown()` — takes explicit town root
- `ValidChannelName` — exported regex for channel name validation
- Full test coverage

### Fixed: `internal/witness/handlers.go`
`notifyRefineryMergeReady` now emits a `MERGE_READY` event to the `refinery` channel before the tmux nudge. Belt-and-suspenders: event file wakes `await-event`, tmux nudge catches the case where refinery is at the Claude prompt.

### Refactored: `internal/cmd/`
- `molecule_emit_event.go` — thin CLI wrapper around `channelevents.Emit()`
- `sling_helpers.go` — uses `channelevents.EmitToTown()` instead of local `EmitEventToTown()`
- `molecule_await_event.go` — `validChannelName` aliased to `channelevents.ValidChannelName`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/channelevents/` — 5 tests pass (new)
- [x] `go test ./internal/witness/` — all tests pass including new `TestNotifyRefineryMergeReady_EmitsChannelEvent`
- [x] `go test ./internal/cmd/ -run TestEmitEvent` — all emit event tests pass (updated to use channelevents)
- [x] Pre-existing `TestSlingSetsDoltAutoCommitOff` failure confirmed on upstream main (unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)