### PR TITLE
fix: back-link source issue to MR bead on creation

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -901,6 +901,14 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				}
 			}
 
+			// GH#2599: Back-link source issue to MR bead for discoverability.
+			if issueID != "" {
+				comment := fmt.Sprintf("MR created: %s", mrID)
+				if _, err := bd.Run("comments", "add", issueID, comment); err != nil {
+					style.PrintWarning("could not back-link source issue %s to MR %s: %v", issueID, mrID, err)
+				}
+			}
+
 			// Success output
 			fmt.Printf("%s Work submitted to merge queue (verified)\n", style.Bold.Render("✓"))
 			fmt.Printf("  MR ID: %s\n", style.Bold.Render(mrID))

--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -236,6 +236,14 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 
 		// Nudge refinery to pick up the new MR
 		nudgeRefinery(rigName, "MERGE_READY received - check inbox for pending work")
+
+		// GH#2599: Back-link source issue to MR bead for discoverability.
+		if issueID != "" {
+			comment := fmt.Sprintf("MR created: %s", mrIssue.ID)
+			if _, err := bd.Run("comments", "add", issueID, comment); err != nil {
+				style.PrintWarning("could not back-link source issue %s to MR %s: %v", issueID, mrIssue.ID, err)
+			}
+		}
 	}
 
 	// Success output


### PR DESCRIPTION
Closes #2599

## Summary
- When `gt done` or `gt mq submit` creates an MR bead, adds a comment (`MR created: <mr-id>`) on the source issue
- Makes the MR discoverable from the epic via `bd show`/`bd comments` without polling or SQL scans
- Only comments on fresh MR creation (not idempotent retries or checkpoint resumes)

## Test plan
- [x] `go build ./...` passes
- [x] Existing `TestDone*` and `TestMq*` tests pass
- [ ] Manual: run `gt done` on a branch, verify `bd comments <source-issue>` shows the MR bead ID

🤖 Generated with [Claude Code](https://claude.com/claude-code)