### PR TITLE
fix: use prefix routing in runHookShow for rig-scoped agents

### DIFF
--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -461,6 +461,16 @@ func runHookShow(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a beads workspace: %w", err)
 	}
 
+	// For rig-scoped agents, resolve the correct beads directory via prefix
+	// routing. findLocalBeadsDir() walks up from CWD and finds the wrong
+	// .beads dir when called from mayor context. Use ResolveHookDir to route
+	// to the agent's rig DB (mirrors the approach in runMoleculeStatus).
+	if townRoot, townErr := findTownRoot(); townErr == nil && townRoot != "" {
+		if agentBeadID := buildAgentBeadID(target, RoleUnknown, townRoot); agentBeadID != "" {
+			workDir = beads.ResolveHookDir(townRoot, agentBeadID, workDir)
+		}
+	}
+
 	b := beads.New(workDir)
 	// Query for hooked beads assigned to the target
 	hookedBeads, err := b.List(beads.ListOptions{


### PR DESCRIPTION
## Summary

- `runHookShow` used `findLocalBeadsDir()` which naively walks up from CWD, finding the wrong `.beads` directory when called from mayor context for rig-scoped agents (e.g. `gastown_el/refinery`)
- Apply the same prefix routing used by `runMoleculeStatus`: build the agent bead ID via `buildAgentBeadID`, then resolve the correct beads directory via `beads.ResolveHookDir` before querying for hooked work

Fixes: ge-0rs

## Test plan

- [ ] `go test ./internal/cmd/... -run Hook` passes (all hook tests green)
- [ ] `gt hook show gastown_el/refinery` from mayor context returns the correct hooked issue
- [ ] `gt hook show` with town-level agents (mayor, deacon) still works correctly