### PR TITLE
fix: restrict remote branch deletion to polecat branches only

### DIFF
--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -977,10 +977,15 @@ func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
 		} else {
 			_, _ = fmt.Fprintf(e.output, "[Engineer] Deleted local branch: %s\n", mr.Branch)
 		}
-		if err := e.git.DeleteRemoteBranch("origin", mr.Branch); err != nil {
-			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to delete remote branch %s: %v\n", mr.Branch, err)
-		} else {
-			_, _ = fmt.Fprintf(e.output, "[Engineer] Deleted remote branch: %s\n", mr.Branch)
+		// Remote delete — only polecat branches. Non-polecat branches may belong
+		// to contributor forks with open upstream PRs; deleting them from origin
+		// causes GitHub to auto-close those PRs via head_ref_delete. (GH#2669)
+		if isPolecat {
+			if err := e.git.DeleteRemoteBranch("origin", mr.Branch); err != nil {
+				_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to delete remote branch %s: %v\n", mr.Branch, err)
+			} else {
+				_, _ = fmt.Fprintf(e.output, "[Engineer] Deleted remote branch: %s\n", mr.Branch)
+			}
 		}
 	}
 

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -543,26 +543,34 @@ func TestEngineer_DeleteMergedBranchesConfig(t *testing.T) {
 
 func TestPolecatBranchAlwaysDeletedAfterMerge(t *testing.T) {
 	// Polecat branches should be cleaned up regardless of DeleteMergedBranches config.
+	// Non-polecat branches should only be deleted locally, never from the remote,
+	// because the remote may be a contributor's fork with open upstream PRs. (GH#2669)
 	tests := []struct {
 		name                 string
 		branch               string
 		deleteMergedBranches bool
-		wantDelete           bool
+		wantLocalDelete      bool
+		wantRemoteDelete     bool
 	}{
-		{"polecat branch with config true", "polecat/nux/gt-abc", true, true},
-		{"polecat branch with config false", "polecat/nux/gt-abc", false, true},
-		{"non-polecat branch with config true", "feature/my-thing", true, true},
-		{"non-polecat branch with config false", "feature/my-thing", false, false},
-		{"empty branch", "", false, false},
+		{"polecat branch with config true", "polecat/nux/gt-abc", true, true, true},
+		{"polecat branch with config false", "polecat/nux/gt-abc", false, true, true},
+		{"non-polecat branch with config true", "feature/my-thing", true, true, false},
+		{"non-polecat branch with config false", "feature/my-thing", false, false, false},
+		{"empty branch", "", false, false, false},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			isPolecat := strings.HasPrefix(tt.branch, "polecat/")
-			shouldDelete := tt.branch != "" && (tt.deleteMergedBranches || isPolecat)
-			if shouldDelete != tt.wantDelete {
-				t.Errorf("branch=%q deleteMerged=%v: got shouldDelete=%v, want %v",
-					tt.branch, tt.deleteMergedBranches, shouldDelete, tt.wantDelete)
+			shouldDeleteLocal := tt.branch != "" && (tt.deleteMergedBranches || isPolecat)
+			shouldDeleteRemote := tt.branch != "" && isPolecat
+			if shouldDeleteLocal != tt.wantLocalDelete {
+				t.Errorf("branch=%q deleteMerged=%v: got localDelete=%v, want %v",
+					tt.branch, tt.deleteMergedBranches, shouldDeleteLocal, tt.wantLocalDelete)
+			}
+			if shouldDeleteRemote != tt.wantRemoteDelete {
+				t.Errorf("branch=%q deleteMerged=%v: got remoteDelete=%v, want %v",
+					tt.branch, tt.deleteMergedBranches, shouldDeleteRemote, tt.wantRemoteDelete)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary

- Restrict post-merge remote branch deletion (`git push origin --delete`) to polecat branches only
- Non-polecat branches are no longer deleted from the remote after merge
- Local branch deletion (refinery worktree cleanup) unchanged for all branch types

## Problem

After a successful merge, the refinery deletes the source branch from `origin`. When `origin` is a contributor's fork, this deletes the branch from the fork and triggers GitHub's `head_ref_delete` event, which auto-closes any open upstream PRs referencing that branch.

On 2026-03-11, this caused ~20+ branches to be deleted from `seanbearden/gastown`, closing 6 open PRs on upstream (#2421, #2430, #2436, #2466, #2498, #2652).

## Fix

Only delete remote branches for `polecat/*` branches (ephemeral, system-created). Non-polecat branches are left on the remote since they may belong to contributor forks with open upstream PRs.

## Test plan

- [x] Updated `TestPolecatBranchAlwaysDeletedAfterMerge` to verify local vs remote deletion logic separately
- [x] Polecat branches: local delete YES, remote delete YES
- [x] Non-polecat branches: local delete YES, remote delete NO
- [x] Full refinery test suite passes

Closes #2669

🤖 Generated with [Claude Code](https://claude.com/claude-code)