### PR TITLE
fix: remove unused dbName parameter in batchDeleteRows (lint)

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -668,7 +668,7 @@ func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (
 }
 
 // batchDeleteRows deletes rows from a primary table and its auxiliary tables in batches.
-func batchDeleteRows(ctx context.Context, db *sql.DB, dbName string, idQuery string, cutoffArg time.Time, primaryTable string, auxTables []string) (int, error) {
+func batchDeleteRows(ctx context.Context, db *sql.DB, _ string, idQuery string, cutoffArg time.Time, primaryTable string, auxTables []string) (int, error) {
 	totalDeleted := 0
 	for {
 		idRows, err := db.QueryContext(ctx, idQuery, cutoffArg)


### PR DESCRIPTION
## Summary

- Remove unused `dbName` parameter in `batchDeleteRows` (flagged by `unparam` linter)
- Only lint issue found by `golangci-lint run ./...` on current main

## Test plan

- [x] `golangci-lint run ./...` reports 0 issues
- [x] `go test ./internal/reaper/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)