### PR TITLE
fix: move --flat fallback into Beads.run to prevent re-injection

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -427,6 +427,28 @@ func (b *Beads) run(args ...string) (_ []byte, retErr error) {
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
+
+	// If bd doesn't support --flat, retry without it. The retry is done here
+	// (not in callers like List) so that InjectFlatForListJSON doesn't re-add
+	// --flat on the retry path.
+	if err != nil && strings.Contains(stderr.String(), "unknown flag: --flat") {
+		retryArgs := make([]string, 0, len(fullArgs))
+		for _, a := range fullArgs {
+			if a != "--flat" {
+				retryArgs = append(retryArgs, a)
+			}
+		}
+		stdout.Reset()
+		stderr.Reset()
+		cmd = exec.Command("bd", retryArgs...) //nolint:gosec // G204: bd is a trusted internal tool
+		cmd.Dir = b.workDir
+		cmd.Env = runEnv
+		cmd.Env = append(cmd.Env, telemetry.OTELEnvForSubprocess()...)
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		err = cmd.Run()
+	}
+
 	if err != nil {
 		return nil, b.wrapError(err, stderr.String(), args)
 	}
@@ -672,15 +694,6 @@ func (b *Beads) List(opts ListOptions) ([]*Issue, error) {
 	}
 
 	out, err := b.run(args...)
-	if err != nil && strings.Contains(err.Error(), "unknown flag: --flat") {
-		fallbackArgs := make([]string, 0, len(args)-1)
-		for _, arg := range args {
-			if arg != "--flat" {
-				fallbackArgs = append(fallbackArgs, arg)
-			}
-		}
-		out, err = b.run(fallbackArgs...)
-	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

- Move the `--flat` retry logic from `List()` into `Beads.run()` to fix integration test failures
- `List()` had a fallback that stripped `--flat` and retried via `b.run()`, but `run()` calls `InjectFlatForListJSON()` which re-added `--flat` — making the retry always fail identically
- By handling the fallback inside `run()` (after `InjectFlatForListJSON` has already executed), the retry correctly strips `--flat` without re-injection

## Test plan

- [x] `TestBeadsListFromPolecatDirectory` — was failing, now fixed
- [x] `TestBeadsListFromCrewDirectory` — was failing, now fixed
- [x] `go test ./internal/beads/...` passes
- [x] `golangci-lint run ./internal/beads/...` — 0 issues
- [x] CI integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)