### PR TITLE
fix: degrade wait-idle to queue for agents without prompt detection

### DIFF
--- a/internal/cmd/nudge.go
+++ b/internal/cmd/nudge.go
@@ -187,6 +187,14 @@ func deliverNudge(t *tmux.Tmux, sessionName, message, sender string) error {
 					}})
 					return t.NudgeSession(sessionName, formatted)
 				}
+				// Ensure a nudge-poller is running so the queue actually drains.
+				// The poller is normally started by gt crew start, but if the
+				// session was started manually (or the poller crashed), queued
+				// nudges sit undelivered forever. StartPoller is idempotent —
+				// it no-ops if a poller is already alive for this session.
+				if _, pollerErr := nudge.StartPoller(townRoot, sessionName); pollerErr != nil {
+					fmt.Fprintf(os.Stderr, "wait-idle: could not start nudge poller for %s: %v\n", sessionName, pollerErr)
+				}
 				return nil
 			}
 		}


### PR DESCRIPTION
## Summary

- `WaitForIdle` hardcodes Claude Code's prompt (`❯`) and status bar (`⏵⏵`) patterns for idle detection
- Non-Claude agents (Gemini, Codex) have no `ReadyPromptPrefix` in their agent preset, causing false positives — `WaitForIdle` sees no busy indicator and reports "idle" when the agent is still working
- Before delivering via wait-idle, check the target session's `GT_AGENT` env var and look up its preset. If `ReadyPromptPrefix` is empty, degrade to queue mode so the nudge-poller handles delivery instead

## Test plan

- [x] `go build ./internal/...` compiles cleanly
- [x] `go test ./internal/cmd/ -run TestNudge` — all pass
- [x] `go vet ./internal/cmd/` — clean
- [ ] Manual: `gt nudge --mode=wait-idle` to a Gemini session should log "using queue mode" and enqueue
- [ ] Manual: `gt nudge --mode=wait-idle` to a Claude session should behave as before (wait for idle)

Fixes gt-5ey3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)