### PR TITLE
feat: add gt assign command

### DIFF
--- a/internal/cmd/assign.go
+++ b/internal/cmd/assign.go
@@ -156,8 +156,10 @@ func runAssign(_ *cobra.Command, args []string) error {
 
 	fmt.Printf("%s Assigned %s to %s — %q\n", style.Bold.Render("✓"), beadID, agentID, title)
 
-	// Step 5: Optionally nudge the agent
-	if assignNudge {
+	// Step 5: Nudge or warn
+	if !assignNudge {
+		fmt.Printf("  %s Agent won't be notified (use --nudge to wake them)\n", style.Dim.Render("ℹ"))
+	} else {
 		nudgeMsg := fmt.Sprintf("New work on your hook: %s", title)
 		nudgeCmd := exec.Command("gt", "nudge", agentID, "-m", nudgeMsg)
 		nudgeCmd.Stderr = os.Stderr


### PR DESCRIPTION
Adds a streamlined way for human users to easily push tasks onto crew hooks. Makes it easy to add work to crew's plate without interrupting flow.

## Summary
- Adds `gt assign <crew-member> <title>` command that creates a bead and hooks it to a crew member in one shot
- Replaces the multi-step `bd create` + `gt hook` workflow
- Supports flags: `-d` description, `-t` type, `-p` priority, `-l` label, `--nudge`, `--rig`, `--dry-run`, `--force`
- Shows warning when `--nudge` is not used (agent won't be notified)
- Reuses existing patterns: `BdCmd`, `inferRigFromCwd`, `slingBackoff` retry logic, `updateAgentHookBead`, `events.LogFeed`

## Test plan
- [x] `go build ./cmd/gt` compiles
- [x] `gt assign --help` shows usage
- [x] `gt assign yeg "Test bead" --dry-run` shows expected output
- [x] `gt assign yeg "Test bead" --dry-run -d "desc" --label urgent --nudge` shows all flags
- [x] Real assignment tested (creates bead, hooks it, nudge works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)