### PR TITLE
fix: compactor-dog hash validation accepts Dolt base32 hashes

### DIFF
--- a/plugins/compactor-dog/run.sh
+++ b/plugins/compactor-dog/run.sh
@@ -76,11 +76,11 @@ validate_name() {
   return 0
 }
 
-# Validate that a value looks like a Dolt commit hash (hex string).
+# Validate that a value looks like a Dolt commit hash (base32 encoding: a-v plus 0-9).
 validate_hash() {
   local hash="$1"
   local context="$2"
-  if [[ ! "$hash" =~ ^[a-fA-F0-9]+$ ]]; then
+  if [[ ! "$hash" =~ ^[a-v0-9]+$ ]]; then
     log "ERROR: Unsafe $context hash rejected: '$hash'"
     return 1
   fi

--- a/plugins/compactor-dog/run_test.sh
+++ b/plugins/compactor-dog/run_test.sh
@@ -1,0 +1,78 @@
+#!/usr/bin/env bash
+# Tests for compactor-dog/run.sh helper functions.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+FAILURES=0
+
+# Source just the helper functions from run.sh by extracting them.
+# We can't source the whole script (it runs immediately), so redefine here.
+log() { echo "[test] $*"; }
+
+# --- Copy validate_hash from run.sh (must stay in sync) ---
+validate_hash() {
+  local hash="$1"
+  local context="$2"
+  if [[ ! "$hash" =~ ^[a-v0-9]+$ ]]; then
+    log "ERROR: Unsafe $context hash rejected: '$hash'"
+    return 1
+  fi
+  return 0
+}
+
+# Verify our copy matches run.sh (guard against drift).
+RUN_SH_REGEX=$(sed -n '/^validate_hash/,/^}/p' "$SCRIPT_DIR/run.sh" | grep -oP '\^\[.*\]\+\$')
+TEST_REGEX=$(sed -n '/^validate_hash/,/^}/p' "$0" | grep -oP '\^\[.*\]\+\$')
+if [[ "$RUN_SH_REGEX" != "$TEST_REGEX" ]]; then
+  echo "FAIL: validate_hash regex in test ($TEST_REGEX) doesn't match run.sh ($RUN_SH_REGEX)"
+  echo "      Update the test to match run.sh"
+  exit 1
+fi
+
+assert_valid() {
+  local hash="$1"
+  if ! validate_hash "$hash" "test" >/dev/null 2>&1; then
+    echo "FAIL: expected valid hash: '$hash'"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+assert_invalid() {
+  local hash="$1"
+  if validate_hash "$hash" "test" >/dev/null 2>&1; then
+    echo "FAIL: expected invalid hash: '$hash'"
+    FAILURES=$((FAILURES + 1))
+  fi
+}
+
+# --- Tests ---
+
+echo "=== validate_hash tests ==="
+
+# Dolt base32 hashes (real examples)
+assert_valid "aecqtmbdbabpalqnamq8atfv86ehjf7r"
+assert_valid "0123456789abcdefghijklmnopqrstuv"
+assert_valid "abc123"
+assert_valid "00000000"
+
+# Hex-only hashes should still pass (subset of base32)
+assert_valid "deadbeef"
+assert_valid "abcdef0123456789"
+
+# Invalid: characters outside base32 range
+assert_invalid "xyz"
+assert_invalid "ABCDEF"
+assert_invalid "hash-with-dashes"
+assert_invalid "hash_with_underscores"
+assert_invalid "hash with spaces"
+assert_invalid ""
+assert_invalid "../../../etc/passwd"
+assert_invalid "'; DROP TABLE issues; --"
+
+echo ""
+if [[ $FAILURES -gt 0 ]]; then
+  echo "FAILED: $FAILURES test(s) failed"
+  exit 1
+else
+  echo "PASSED: all tests passed"
+fi


### PR DESCRIPTION
## Summary
- Dolt commit hashes use base32 encoding (`a-v` plus `0-9`), not hex
- The `validate_hash()` regex `^[a-fA-F0-9]+$` rejected every valid Dolt hash, causing the compactor-dog plugin's `run.sh` to always fail
- Fix: `^[a-v0-9]+$`
- Added `run_test.sh` with drift guard and assertions for valid/invalid hashes

## Test plan
- [x] Verified against live Dolt hashes from running server
- [x] `bash plugins/compactor-dog/run_test.sh` passes
- [ ] Run compactor-dog plugin against a test database to confirm end-to-end compaction works

🤖 Generated with [Claude Code](https://claude.com/claude-code)