### PR TITLE
fix: verify types.custom persisted before writing sentinel

### DIFF
--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -134,14 +134,28 @@ func EnsureCustomTypes(beadsDir string) error {
 	}
 
 	// Configure custom types via bd CLI
+	bdEnv := append(stripEnvPrefixes(os.Environ(), "BEADS_DIR="), "BEADS_DIR="+beadsDir)
 	cmd := exec.Command("bd", "config", "set", "types.custom", typesList)
 	cmd.Dir = beadsDir
 	// Set BEADS_DIR explicitly to ensure bd operates on the correct database.
 	// Strip inherited BEADS_DIR first — getenv() returns the first match (gt-uygpe).
-	cmd.Env = append(stripEnvPrefixes(os.Environ(), "BEADS_DIR="), "BEADS_DIR="+beadsDir)
+	cmd.Env = bdEnv
 	if output, err := cmd.CombinedOutput(); err != nil {
 		return fmt.Errorf("configure custom types in %s: %s: %w",
 			beadsDir, strings.TrimSpace(string(output)), err)
+	}
+
+	// Verify the config was actually persisted in the database (GH#2637).
+	// bd config set can exit 0 but fail to write if it targets the wrong
+	// database (redirect mismatch, stale metadata, server not running).
+	// Without this check, the sentinel file below would cache a lie,
+	// causing all future EnsureCustomTypes calls to skip re-configuration.
+	verifyCmd := exec.Command("bd", "config", "get", "types.custom")
+	verifyCmd.Dir = beadsDir
+	verifyCmd.Env = bdEnv
+	if verifyOutput, err := verifyCmd.Output(); err != nil || !strings.Contains(string(verifyOutput), "agent") {
+		return fmt.Errorf("types.custom not persisted in %s after bd config set (verify returned %q): db may be misconfigured",
+			beadsDir, strings.TrimSpace(string(verifyOutput)))
 	}
 
 	// Write sentinel file with the types list for staleness detection.

--- a/internal/beads/beads_types_test.go
+++ b/internal/beads/beads_types_test.go
@@ -53,6 +53,9 @@ switch ($cmd) {
     if ($args.Length -ge 3 -and $args[1] -eq 'get' -and $args[2] -eq 'status.custom') {
       Write-Output ''
     }
+    if ($args.Length -ge 3 -and $args[1] -eq 'get' -and $args[2] -eq 'types.custom') {
+      Write-Output 'agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request'
+    }
     exit 0
   }
   'migrate' { exit 0 }
@@ -92,7 +95,14 @@ case "$cmd" in
     printf 'prefix: %s\nissue-prefix: %s-\n' "$prefix" "$prefix" > "$target/config.yaml"
     exit 0
     ;;
-  config|migrate)
+  config)
+    # Return types list for "config get types.custom" verification
+    if echo "$*" | grep -q "get types.custom"; then
+      echo "agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request"
+    fi
+    exit 0
+    ;;
+  migrate)
     exit 0
     ;;
   *)
@@ -343,6 +353,66 @@ func TestEnsureCustomTypes(t *testing.T) {
 
 		if err := EnsureCustomTypes(beadsDir); err != nil {
 			t.Errorf("expected cache hit, got: %v", err)
+		}
+	})
+}
+
+func TestEnsureCustomTypes_VerifyPersistence(t *testing.T) {
+	t.Run("sentinel not written when db verify fails", func(t *testing.T) {
+		// Install a mock bd that succeeds on "config set" but returns empty
+		// on "config get types.custom" — simulating a silent write failure.
+		binDir := t.TempDir()
+		logPath := filepath.Join(binDir, "bd.log")
+		script := `#!/bin/sh
+LOG_FILE='` + logPath + `'
+printf '%s\n' "$*" >> "$LOG_FILE"
+cmd=""
+for arg in "$@"; do
+  case "$arg" in --*) ;; *) cmd="$arg"; break ;; esac
+done
+case "$cmd" in
+  init)
+    target="${BEADS_DIR:-$(pwd)/.beads}"
+    mkdir -p "$target/dolt"
+    printf 'prefix: gt\nissue-prefix: gt-\n' > "$target/config.yaml"
+    exit 0
+    ;;
+  config)
+    # "config set" succeeds but "config get types.custom" returns empty
+    if echo "$*" | grep -q "get types.custom"; then
+      echo ""
+    fi
+    exit 0
+    ;;
+  migrate) exit 0 ;;
+  *) exit 0 ;;
+esac
+`
+		if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+			t.Fatalf("write mock bd: %v", err)
+		}
+		t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+		tmpDir := t.TempDir()
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		if err := os.MkdirAll(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		ResetEnsuredDirs()
+
+		err := EnsureCustomTypes(beadsDir)
+		if err == nil {
+			t.Fatal("expected error when types.custom verify fails, got nil")
+		}
+		if !strings.Contains(err.Error(), "not persisted") {
+			t.Fatalf("expected 'not persisted' error, got: %v", err)
+		}
+
+		// Sentinel file should NOT have been written
+		sentinelPath := filepath.Join(beadsDir, typesSentinel)
+		if _, err := os.Stat(sentinelPath); !os.IsNotExist(err) {
+			t.Error("sentinel file should not exist when verify fails")
 		}
 	})
 }


### PR DESCRIPTION
## Summary
- `EnsureCustomTypes()` trusted the sentinel file without verifying the database actually had `types.custom` configured
- If `bd config set` exited 0 but silently failed to write (wrong DB, redirect mismatch, server restart), the sentinel cached a lie — all future calls skipped re-configuration
- This caused `gt sling` to fail with `invalid issue type: agent` on rigs where the database was recreated but the sentinel survived
- Fix: after `bd config set`, run `bd config get types.custom` to verify the value contains `agent` before writing the sentinel

Fixes #2637

## Test plan
- [x] New test: `TestEnsureCustomTypes_VerifyPersistence` — verifies sentinel is NOT written when `bd config get` returns empty
- [x] Existing tests pass (mock bd updated to return types on `config get types.custom`)
- [x] Manually verified fix on live system: 28 rig databases were missing `types.custom` and got fixed

🤖 Generated with [Claude Code](https://claude.com/claude-code)