### PR TITLE
gt down: clean up orphan idle-monitors, rogue Dolt servers, and stale .beads/dolt dirs

### DIFF
--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -772,8 +772,9 @@ func findIdleMonitorProcesses(townRoot string) []int {
 			continue
 		}
 
-		// Scope to this town: match by path or by explicit --port argument
-		matchesTown := strings.Contains(line, absRoot) || strings.Contains(line, townRoot)
+		// Scope to this town: match by path (with boundary check to avoid
+		// false matches on sibling paths like /tmp/gt matching /tmp/gt-old)
+		matchesTown := containsPathBoundary(line, absRoot) || containsPathBoundary(line, townRoot)
 		if !matchesTown {
 			// Check for --port <portStr> as a discrete argument
 			args := strings.Fields(line)
@@ -874,8 +875,11 @@ func findOrphanDoltServers(townRoot string) []int {
 		}
 
 		cwdAbs, _ := filepath.Abs(cwd)
-		// Only target processes rooted in our town but NOT in canonical data dir
-		if strings.HasPrefix(cwdAbs, townAbs) && !strings.HasPrefix(cwdAbs, canonicalDir) {
+		// Only target processes rooted in our town but NOT in canonical data dir.
+		// Use path-boundary check to avoid false matches on sibling paths.
+		inTown := cwdAbs == townAbs || strings.HasPrefix(cwdAbs, townAbs+string(filepath.Separator))
+		notCanonical := !strings.HasPrefix(cwdAbs, canonicalDir)
+		if inTown && notCanonical {
 			pids = append(pids, pid)
 		}
 	}
@@ -996,5 +1000,30 @@ func isSafeToRemoveBeadsDolt(dir string) bool {
 	}
 
 	return true
+}
+
+// containsPathBoundary checks whether line contains path as a complete path
+// (not a prefix of a longer path). The character after the match must be a
+// path separator, whitespace, or end-of-string.
+func containsPathBoundary(line, path string) bool {
+	if path == "" {
+		return false
+	}
+	for start := 0; start < len(line); {
+		idx := strings.Index(line[start:], path)
+		if idx < 0 {
+			return false
+		}
+		end := start + idx + len(path)
+		if end >= len(line) {
+			return true
+		}
+		c := line[end]
+		if c == filepath.Separator || c == ' ' || c == '\t' {
+			return true
+		}
+		start = start + idx + 1
+	}
+	return false
 }
 


### PR DESCRIPTION
## Problem

When `gt down` shuts down a town, it does not clean up `bd dolt idle-monitor` background processes or orphan Dolt servers that were spawned from per-rig `.beads/dolt/` directories. These orphaned processes continue running after shutdown and cause several issues:

1. **Port conflicts** on subsequent `gt dolt start` — orphan servers hold the configured port
2. **Data divergence** — orphan servers operate on isolated local databases, not the canonical `.dolt-data/` store
3. **Resource waste** — zombie idle-monitors and servers consume CPU/memory indefinitely

This was observed in a production Gas Town deployment where `gt down` followed by `gt dolt start` would fail because orphan processes from the previous session still held the port.

Related: #2578 (gt down orphaned processes)

## Root Cause

When the canonical Dolt server becomes temporarily unreachable (e.g., during restart), `bd` auto-spawns embedded Dolt servers from per-rig `.beads/dolt/` directories, managed by `bd dolt idle-monitor` background processes. PR #2586 (port-file sync) reduced the frequency of this, but `gt down` still has no mechanism to discover or terminate these processes.

## Solution

Adds **Phase 4b** (4 sub-phases) to the `gt down` shutdown sequence in `internal/cmd/down.go`:

- **Phase 4b-i**: Discover idle-monitor processes scoped to this town via `ps -eo pid,args` and terminate them with SIGTERM (escalating to forced termination after 500ms)
- **Phase 4b-ii**: Discover orphan Dolt server processes whose working directory is within the town but outside the canonical `.dolt-data/` directory
- **Phase 4b-iii**: Remove stale `.beads/dolt/` directories, guarded by `isSafeToRemoveBeadsDolt` (checks for no running server, no `.dolt` marker, directory is under a rig's `.beads/`)
- **Phase 4b-iv**: `verifyShutdown` updated to check for idle-monitor and orphan Dolt stragglers

### Key Design Decisions

- **`os.Process.Signal`/`os.Process` instead of `syscall` directly**: Cross-platform compatible, consistent with Go best practices. The existing codebase uses `syscall` in places, but `os.Process` wraps it portably.

- **Path-boundary-aware matching** (`containsPathBoundary`): Process discovery uses a helper that checks the character *after* a path match is a separator, whitespace, or end-of-string. This prevents false matches on sibling towns with similar path prefixes (e.g., `/tmp/gt` would NOT match `/tmp/gt-old/...`). Raw `strings.Contains` was used initially but caught in code review.

- **Structural `--port` argument parsing**: Port matching parses `--port <value>` and `--port=<value>` as discrete arguments rather than substring matching, preventing false matches on PIDs or other numeric arguments.

- **Safe directory removal**: `isSafeToRemoveBeadsDolt` requires all of: no running Dolt process from that dir, no `.dolt` marker file, and the dir must be under a recognized rig `.beads/` path. This prevents accidental removal of active data.

### Alternatives Considered

- **Signal-based approach (SIGTERM to process group)**: Rejected because idle-monitors and orphan servers aren't in the same process group as the town. They're independently spawned background processes.

- **PID file tracking**: Rejected because idle-monitors don't write PID files. Process discovery via `ps` is the only reliable method and is consistent with the existing `KillImposters` pattern in the codebase.

- **Removing `.beads/dolt/` unconditionally**: Initially implemented but caught in code review as dangerous — could remove actively-used Dolt data. Added safety guard function instead.

## Testing

- `go build ./...` passes
- `go test ./internal/cmd/...` passes (120s)
- No existing `down.go`-specific tests to regress
- Manually verified in Gas Town deployment: orphan processes cleaned up on `gt down`
