### PR TITLE
feat: auto-push submodule changes before parent repo push in gt done

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -523,6 +523,8 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// Handle "direct" strategy: push to target branch, skip MR
 		if convoyInfo != nil && convoyInfo.MergeStrategy == "direct" {
 			fmt.Printf("%s Direct merge strategy: pushing to %s\n", style.Bold.Render("→"), defaultBranch)
+			// Push submodule changes before direct push (gt-dzs)
+			pushSubmoduleChanges(g, defaultBranch)
 			directRefspec := branch + ":" + defaultBranch
 			directPushErr := g.Push("origin", directRefspec, false)
 			if directPushErr != nil {
@@ -575,6 +577,12 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// isn't pushed yet, Refinery finds nothing to merge. The worktree gets
 		// nuked at the end of gt done, so the commits are lost forever.
 		//
+		// Auto-push submodule changes BEFORE parent push (gt-dzs).
+		// If the parent repo's submodule pointer references commits that don't
+		// exist on the submodule's remote, the Refinery MR will be broken.
+		// Detect modified submodules and push each one first.
+		pushSubmoduleChanges(g, defaultBranch)
+
 		// Use explicit refspec (branch:branch) to create the remote branch.
 		// Without refspec, git push follows the tracking config — polecat branches
 		// track origin/main, so a bare push sends commits to main directly,
@@ -1044,6 +1052,35 @@ notifyWitness:
 		fmt.Printf("  Witness will handle cleanup.\n")
 	}
 	return nil
+}
+
+// pushSubmoduleChanges detects submodules modified between origin/defaultBranch
+// and HEAD, and pushes each submodule's new commit to its remote before the
+// parent repo push. This prevents the parent's submodule pointer from
+// referencing commits that don't exist on the submodule's remote (gt-dzs).
+func pushSubmoduleChanges(g *git.Git, defaultBranch string) {
+	subChanges, err := g.SubmoduleChanges("origin/"+defaultBranch, "HEAD")
+	if err != nil {
+		// Non-fatal: repos without submodules return nil, nil.
+		// Only warn if the error is real (not just "no submodules").
+		style.PrintWarning("could not detect submodule changes: %v", err)
+		return
+	}
+	for _, sc := range subChanges {
+		if sc.NewSHA == "" {
+			continue // Submodule removed, nothing to push
+		}
+		shortSHA := sc.NewSHA
+		if len(shortSHA) > 8 {
+			shortSHA = shortSHA[:8]
+		}
+		fmt.Printf("Pushing submodule %s (%s)...\n", sc.Path, shortSHA)
+		if subPushErr := g.PushSubmoduleCommit(sc.Path, sc.NewSHA, "origin"); subPushErr != nil {
+			style.PrintWarning("submodule push failed for %s: %v (parent push may fail)", sc.Path, subPushErr)
+		} else {
+			fmt.Printf("%s Submodule %s pushed\n", style.Bold.Render("✓"), sc.Path)
+		}
+	}
 }
 
 // setDoneIntentLabel writes a done-intent:<type>:<unix-ts> label on the agent bead

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	gitpkg "github.com/steveyegge/gastown/internal/git"
 )
 
 // TestDoneUsesResolveBeadsDir verifies that the done command correctly uses
@@ -1212,5 +1213,138 @@ func TestHookedBeadCloseNotRestrictedToHookedStatus(t *testing.T) {
 				t.Errorf("shouldClose for status %q = %v, want %v", tt.status, shouldClose, tt.wantClose)
 			}
 		})
+	}
+}
+
+// TestPushSubmoduleChanges_Integration verifies that pushSubmoduleChanges detects
+// modified submodules and pushes their commits before the parent repo push (gt-dzs).
+func TestPushSubmoduleChanges_Integration(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Allow file:// transport for submodule operations
+	t.Setenv("GIT_CONFIG_COUNT", "1")
+	t.Setenv("GIT_CONFIG_KEY_0", "protocol.file.allow")
+	t.Setenv("GIT_CONFIG_VALUE_0", "always")
+
+	// Create a "remote" bare repo for the submodule
+	subRemote := filepath.Join(tmp, "sub-remote.git")
+	testRunGit(t, tmp, "init", "--bare", "--initial-branch", "main", subRemote)
+
+	// Create a working clone of the submodule to add initial content
+	subWork := filepath.Join(tmp, "sub-work")
+	testRunGit(t, tmp, "clone", subRemote, subWork)
+	testRunGit(t, subWork, "config", "user.email", "test@test.com")
+	testRunGit(t, subWork, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(subWork, "lib.go"), []byte("package lib\n"), 0644); err != nil {
+		t.Fatalf("write sub file: %v", err)
+	}
+	testRunGit(t, subWork, "add", ".")
+	testRunGit(t, subWork, "commit", "-m", "initial sub commit")
+	testRunGit(t, subWork, "push", "origin", "main")
+
+	// Create a "remote" bare repo for the parent
+	parentRemote := filepath.Join(tmp, "parent-remote.git")
+	testRunGit(t, tmp, "init", "--bare", "--initial-branch", "main", parentRemote)
+
+	// Create the parent repo
+	parent := filepath.Join(tmp, "parent")
+	testRunGit(t, tmp, "init", "--initial-branch", "main", parent)
+	testRunGit(t, parent, "config", "user.email", "test@test.com")
+	testRunGit(t, parent, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(parent, "README.md"), []byte("# Parent\n"), 0644); err != nil {
+		t.Fatalf("write parent file: %v", err)
+	}
+	testRunGit(t, parent, "add", ".")
+	testRunGit(t, parent, "commit", "-m", "initial parent commit")
+
+	// Add the submodule
+	testRunGit(t, parent, "submodule", "add", subRemote, "libs/sub")
+	testRunGit(t, parent, "commit", "-m", "add submodule")
+
+	// Add remote and push to parent remote
+	testRunGit(t, parent, "remote", "add", "origin", parentRemote)
+	testRunGit(t, parent, "push", "origin", "main")
+
+	// Make a new commit in the submodule (but don't push it to submodule remote)
+	subPath := filepath.Join(parent, "libs", "sub")
+	if err := os.WriteFile(filepath.Join(subPath, "new.go"), []byte("package lib\n// new\n"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	testRunGit(t, subPath, "add", ".")
+	testRunGit(t, subPath, "commit", "-m", "unpushed submodule commit")
+
+	// Get the new submodule SHA
+	cmd := exec.Command("git", "-C", subPath, "rev-parse", "HEAD")
+	shaBytes, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("rev-parse: %v", err)
+	}
+	newSHA := strings.TrimSpace(string(shaBytes))
+
+	// Update parent to point to new submodule commit
+	testRunGit(t, parent, "add", "libs/sub")
+	testRunGit(t, parent, "commit", "-m", "update submodule pointer")
+
+	// Verify the new submodule commit is NOT on the submodule remote yet
+	lsCmd := exec.Command("git", "ls-remote", subRemote, "refs/heads/main")
+	lsOut, _ := lsCmd.Output()
+	remoteSHA := strings.Fields(string(lsOut))[0]
+	if remoteSHA == newSHA {
+		t.Fatal("new submodule commit should not be on remote yet")
+	}
+
+	// Call pushSubmoduleChanges — this should push the submodule commit
+	g := gitpkg.NewGit(parent)
+	pushSubmoduleChanges(g, "main")
+
+	// Verify the submodule commit IS now on the remote
+	lsCmd = exec.Command("git", "ls-remote", subRemote, "refs/heads/main")
+	lsOut, _ = lsCmd.Output()
+	remoteSHA = strings.Fields(string(lsOut))[0]
+	if remoteSHA != newSHA {
+		t.Errorf("expected submodule remote main to be %s, got %s", newSHA, remoteSHA)
+	}
+}
+
+// TestPushSubmoduleChanges_NoSubmodules verifies pushSubmoduleChanges is a no-op
+// for repos without submodules (gt-dzs).
+func TestPushSubmoduleChanges_NoSubmodules(t *testing.T) {
+	tmp := t.TempDir()
+
+	// Create a simple repo with a remote
+	parent := filepath.Join(tmp, "repo")
+	remote := filepath.Join(tmp, "remote.git")
+	testRunGit(t, tmp, "init", "--bare", "--initial-branch", "main", remote)
+	testRunGit(t, tmp, "init", "--initial-branch", "main", parent)
+	testRunGit(t, parent, "config", "user.email", "test@test.com")
+	testRunGit(t, parent, "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(parent, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	testRunGit(t, parent, "add", ".")
+	testRunGit(t, parent, "commit", "-m", "initial commit")
+	testRunGit(t, parent, "remote", "add", "origin", remote)
+	testRunGit(t, parent, "push", "origin", "main")
+
+	// Add another commit
+	if err := os.WriteFile(filepath.Join(parent, "main.go"), []byte("package main\n"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	testRunGit(t, parent, "add", ".")
+	testRunGit(t, parent, "commit", "-m", "add main.go")
+
+	// Should not panic or error — just a no-op
+	g := gitpkg.NewGit(parent)
+	pushSubmoduleChanges(g, "main")
+}
+
+func testRunGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	fullArgs := append([]string{"-c", "protocol.file.allow=always"}, args...)
+	cmd := exec.Command("git", fullArgs...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v in %s: %v\n%s", args, dir, err, out)
 	}
 }


### PR DESCRIPTION
## Summary
- `gt done` now auto-detects modified submodules and pushes their commits to the submodule remote **before** pushing the parent repo branch
- Prevents MR rejections when the parent repo's submodule pointer references commits that don't exist on the submodule's remote
- Hit 3+ times on a rig with gitlabhq as a submodule (tracked as gt-dzs)

## Changes
- `internal/cmd/done.go`: Added `pushSubmoduleChanges()` helper called before both direct push and MR push paths. Uses existing `git.SubmoduleChanges()` and `git.PushSubmoduleCommit()` methods.
- `internal/cmd/done_test.go`: Integration tests covering submodule push and no-submodule no-op scenarios.

## Test plan
- [x] Integration test: verifies submodule commit reaches remote after `pushSubmoduleChanges`
- [x] No-op test: repos without submodules don't error
- [ ] Manual: run `gt done` in a rig with submodules, verify submodule pushed before parent

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: furiosa <paentraygues@gmail.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>