### PR TITLE
fix: remove --flat flag from all bd list invocations

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -101,28 +101,10 @@ func MaybePrependAllowStaleWithEnv(env []string, args []string) []string {
 	return args
 }
 
-// InjectFlatForListJSON adds --flat to bd list commands that use --json.
-// bd v0.59+ tree-format output ignores --json; --flat is required for JSON.
-// Exported for use by other packages that call bd list directly.
+// InjectFlatForListJSON is a no-op retained for API compatibility.
+// bd list --json now produces JSON output directly without --flat.
+// Deprecated: will be removed in a future version.
 func InjectFlatForListJSON(args []string) []string {
-	// Only apply to top-level "bd list" commands (args[0] == "list"),
-	// not subcommands like "bd dep list" where --flat is unsupported.
-	if len(args) == 0 || args[0] != "list" {
-		return args
-	}
-	hasJSON := false
-	hasFlat := false
-	for _, a := range args[1:] {
-		switch {
-		case a == "--json":
-			hasJSON = true
-		case a == "--flat":
-			hasFlat = true
-		}
-	}
-	if hasJSON && !hasFlat {
-		return append(args, "--flat")
-	}
 	return args
 }
 
@@ -399,12 +381,6 @@ func (b *Beads) run(args ...string) (_ []byte, retErr error) {
 	defer func() {
 		telemetry.RecordBDCall(context.Background(), args, float64(time.Since(start).Milliseconds()), retErr, stdout.Bytes(), stderr.String())
 	}()
-	// bd v0.59+ requires --flat for --json to produce JSON output on "list" commands.
-	// Without --flat, bd list --json silently returns human-readable tree format,
-	// causing all JSON parsing to fail. Inject --flat before --allow-stale prepend
-	// (which changes args[0] from "list" to "--allow-stale").
-	args = InjectFlatForListJSON(args)
-
 	// Conditionally use --allow-stale to prevent failures when db is temporarily stale
 	// (e.g., after daemon is killed during shutdown). Only if bd supports it.
 	beadsDir := b.beadsDir
@@ -427,27 +403,6 @@ func (b *Beads) run(args ...string) (_ []byte, retErr error) {
 	cmd.Stderr = &stderr
 
 	err := cmd.Run()
-
-	// If bd doesn't support --flat, retry without it. The retry is done here
-	// (not in callers like List) so that InjectFlatForListJSON doesn't re-add
-	// --flat on the retry path.
-	if err != nil && strings.Contains(stderr.String(), "unknown flag: --flat") {
-		retryArgs := make([]string, 0, len(fullArgs))
-		for _, a := range fullArgs {
-			if a != "--flat" {
-				retryArgs = append(retryArgs, a)
-			}
-		}
-		stdout.Reset()
-		stderr.Reset()
-		cmd = exec.Command("bd", retryArgs...) //nolint:gosec // G204: bd is a trusted internal tool
-		cmd.Dir = b.workDir
-		cmd.Env = runEnv
-		cmd.Env = append(cmd.Env, telemetry.OTELEnvForSubprocess()...)
-		cmd.Stdout = &stdout
-		cmd.Stderr = &stderr
-		err = cmd.Run()
-	}
 
 	if err != nil {
 		return nil, b.wrapError(err, stderr.String(), args)
@@ -660,9 +615,7 @@ func (b *Beads) List(opts ListOptions) ([]*Issue, error) {
 		return b.listEphemeral(opts)
 	}
 
-	// --flat is required because bd's default tree mode doesn't output valid JSON
-	// even when --json is specified. This was introduced when bd added tree view.
-	args := []string{"list", "--json", "--flat"}
+	args := []string{"list", "--json"}
 
 	if opts.Status != "" {
 		args = append(args, "--status="+opts.Status)

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -1892,11 +1892,6 @@ func runConvoyList(cmd *cobra.Command, args []string) error {
 	} else if convoyListAll {
 		listArgs = append(listArgs, "--all")
 	}
-	// --flat is required because bd's tree mode doesn't produce valid JSON
-	// even with --json (bd v0.59+). Appended last so flag order matches
-	// bd's expected argument pattern.
-	listArgs = append(listArgs, "--flat")
-
 	out, err := runBdJSON(townBeads, listArgs...)
 	if err != nil {
 		return fmt.Errorf("listing convoys: %w", err)

--- a/internal/cmd/convoy_bd_routing_test.go
+++ b/internal/cmd/convoy_bd_routing_test.go
@@ -97,7 +97,7 @@ if [ -n "$BEADS_DIR" ]; then
 fi
 
 case "$*" in
-  "list --type=convoy --json --all --flat")
+  "list --type=convoy --json --all")
     if [ "$PWD" != "%s" ]; then
       echo "expected town root, got $PWD" >&2
       exit 1

--- a/internal/cmd/polecat_identity.go
+++ b/internal/cmd/polecat_identity.go
@@ -804,7 +804,7 @@ type IssueInfo struct {
 // queryAssignedIssues queries beads for issues assigned to a specific agent.
 func queryAssignedIssues(rigPath, assignee, status string) ([]IssueInfo, error) {
 	// Use bd list with filters
-	args := []string{"list", "--assignee=" + assignee, "--json", "--flat"}
+	args := []string{"list", "--assignee=" + assignee, "--json"}
 	if status != "" {
 		args = append(args, "--status="+status)
 	}

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -1056,7 +1056,7 @@ func setTmuxWorkContext(workRig, workBead, workMol string) {
 // This is called on Mayor startup to surface issues needing human attention.
 func checkPendingEscalations(ctx RoleContext) {
 	// Query for open escalations using bd list with tag filter
-	cmd := exec.Command("bd", "list", "--status=open", "--tag=escalation", "--json", "--flat")
+	cmd := exec.Command("bd", "list", "--status=open", "--tag=escalation", "--json")
 	cmd.Dir = ctx.WorkDir
 	cmd.Env = os.Environ()
 

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -943,7 +943,7 @@ const GUPPViolationTimeout = constants.GUPPViolationTimeout
 // The wisps query is best-effort (gracefully ignored if table doesn't exist).
 func (d *Daemon) listAgentBeadsJSON(dest interface{}) error {
 	// Query issues table (backward compat during migration)
-	cmd := exec.Command(d.bdPath, "list", "--label=gt:agent", "--json", "--flat") //nolint:gosec // G204: bd is a trusted internal tool
+	cmd := exec.Command(d.bdPath, "list", "--label=gt:agent", "--json") //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Dir = d.config.TownRoot
 	cmd.Env = os.Environ()
 

--- a/internal/deacon/stale_hooks.go
+++ b/internal/deacon/stale_hooks.go
@@ -155,7 +155,7 @@ func ScanStaleHooks(townRoot string, cfg *StaleHookConfig) (*StaleHookScanResult
 
 // listHookedBeads returns all beads with status=hooked.
 func listHookedBeads(townRoot string) ([]*HookedBead, error) {
-	cmd := exec.Command("bd", "list", "--status=hooked", "--json", "--flat", "--limit=0")
+	cmd := exec.Command("bd", "list", "--status=hooked", "--json", "--limit=0")
 	cmd.Dir = townRoot
 
 	output, err := cmd.Output()

--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -707,7 +707,7 @@ func (r *Router) queryAgents(descContains string) []*agentBead {
 // queryAgentsInDir queries agent beads in a specific beads directory with optional description filtering.
 // Queries both the issues and wisps tables, merging results.
 func (r *Router) queryAgentsInDir(beadsDir, descContains string) ([]*agentBead, error) {
-	args := []string{"list", "--label=gt:agent", "--json", "--flat", "--limit=0"}
+	args := []string{"list", "--label=gt:agent", "--json", "--limit=0"}
 
 	if descContains != "" {
 		args = append(args, "--desc-contains="+descContains)

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -1603,7 +1603,7 @@ type convoyInfo struct {
 // are complete. Returns the list of convoys that were closed.
 func (e *Engineer) checkAndCloseCompletedConvoys(townRoot, townBeads string) []convoyInfo {
 	// List all open convoys
-	listCmd := exec.Command("bd", "list", "--type=convoy", "--status=open", "--json", "--flat")
+	listCmd := exec.Command("bd", "list", "--type=convoy", "--status=open", "--json")
 	listCmd.Dir = townBeads
 	var stdout bytes.Buffer
 	listCmd.Stdout = &stdout

--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -51,9 +51,6 @@ var fetcherGetSessionEnv = func(sessionName, key string) (string, error) {
 
 // runBdCmd executes a bd command with the configured cmdTimeout in the specified beads directory.
 func (f *LiveConvoyFetcher) runBdCmd(beadsDir string, args ...string) (*bytes.Buffer, error) {
-	// bd v0.59+ requires --flat for list --json to produce JSON output
-	args = beads.InjectFlatForListJSON(args)
-
 	ctx, cancel := context.WithTimeout(context.Background(), f.cmdTimeout)
 	defer cancel()
 

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -67,12 +67,9 @@ type BdCli struct {
 func DefaultBdCli() *BdCli {
 	return &BdCli{
 		Exec: func(workDir string, args ...string) (string, error) {
-			// bd v0.59+ requires --flat for list --json to produce JSON
-			args = beads.InjectFlatForListJSON(args)
 			return util.ExecWithOutput(workDir, "bd", args...)
 		},
 		Run: func(workDir string, args ...string) error {
-			args = beads.InjectFlatForListJSON(args)
 			return util.ExecRun(workDir, "bd", args...)
 		},
 	}


### PR DESCRIPTION
## Summary
- `bd list --flat` is no longer a valid flag, breaking `gt mq list` and `gt patrol report`
- Removes `--flat` from all 11 call sites across the codebase
- Both gitalb and gitalb_ee_insight refineries reported this as HIGH severity

## Changes
- `internal/beads/beads.go`: Remove `--flat` usage and simplify list parsing
- 10 other files: Remove `--flat` from `bd list` invocations

## Test plan
- [x] Verified all `--flat` references removed
- [ ] Manual: run `gt mq list` and `gt patrol report` — should no longer error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: furiosa <paentraygues@gmail.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>