### PR TITLE
fix: resolve rig default_formula before falling back to mol-polecat-work

### DIFF
--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -319,7 +319,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 						return fmt.Errorf("%s '%s' cannot be batch-scheduled with an explicit rig\nUse: gt sling %s (children auto-resolve rigs)", idType, id, id)
 					}
 				}
-				return runBatchSchedule(beadIDs, rigName)
+				return runBatchSchedule(beadIDs, rigName, townRoot)
 			}
 			// Explicit rig: print tip about auto-resolve
 			fmt.Printf("  %s the rig can be auto-resolved from bead prefixes. "+
@@ -421,7 +421,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 				}
 			}
 			beadID := args[0]
-			formula := resolveFormula(slingFormula, slingHookRawBead)
+			formula := resolveFormula(slingFormula, slingHookRawBead, townRoot, rigName)
 			return scheduleBead(beadID, rigName, ScheduleOptions{
 				Formula:     formula,
 				Args:        slingArgs,
@@ -447,7 +447,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	if len(args) == 1 {
 		idType, err := detectSchedulerIDType(args[0])
 		if err == nil && idType != "task" {
-			formula := resolveFormula(slingFormula, slingHookRawBead)
+			formula := resolveFormula(slingFormula, slingHookRawBead, townRoot, "")
 
 			switch idType {
 			case "convoy":
@@ -784,7 +784,11 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	// This ensures polecats get structured work guidance through formula-on-bead.
 	// Use --hook-raw-bead to bypass for expert/debugging scenarios.
 	if formulaName == "" && !slingHookRawBead && strings.Contains(targetAgent, "/polecats/") {
-		formulaName = resolveFormula(slingFormula, false)
+		targetRig := ""
+		if parts := strings.SplitN(targetAgent, "/", 2); len(parts) >= 1 {
+			targetRig = parts[0]
+		}
+		formulaName = resolveFormula(slingFormula, false, townRoot, targetRig)
 		if slingFormula != "" {
 			fmt.Printf("  Applying %s for polecat work...\n", formulaName)
 		} else {

--- a/internal/cmd/sling_batch.go
+++ b/internal/cmd/sling_batch.go
@@ -66,7 +66,7 @@ func runBatchSling(beadIDs []string, rigName string, townBeadsDir string) error 
 	}
 
 	// Issue #288: Auto-apply formula for batch sling (resolved via flags)
-	formulaName := resolveFormula(slingFormula, slingHookRawBead)
+	formulaName := resolveFormula(slingFormula, slingHookRawBead, filepath.Dir(townBeadsDir), rigName)
 
 	if slingDryRun {
 		fmt.Printf("%s Batch slinging %d beads to rig '%s':\n", style.Bold.Render("🎯"), len(beadIDs), rigName)

--- a/internal/cmd/sling_schedule.go
+++ b/internal/cmd/sling_schedule.go
@@ -198,7 +198,7 @@ func scheduleBead(beadID, rigName string, opts ScheduleOptions) error {
 
 // runBatchSchedule schedules multiple beads for deferred dispatch.
 // Returns error when all schedule attempts fail.
-func runBatchSchedule(beadIDs []string, rigName string) error {
+func runBatchSchedule(beadIDs []string, rigName, townRoot string) error {
 	if slingDryRun {
 		fmt.Printf("%s Would schedule %d beads to rig '%s':\n", style.Bold.Render("📋"), len(beadIDs), rigName)
 		for _, beadID := range beadIDs {
@@ -211,7 +211,7 @@ func runBatchSchedule(beadIDs []string, rigName string) error {
 
 	successCount := 0
 	for _, beadID := range beadIDs {
-		formula := resolveFormula(slingFormula, slingHookRawBead)
+		formula := resolveFormula(slingFormula, slingHookRawBead, townRoot, rigName)
 		err := scheduleBead(beadID, rigName, ScheduleOptions{
 			Formula:     formula,
 			Args:        slingArgs,
@@ -251,13 +251,22 @@ func resolveRigForBead(townRoot, beadID string) string {
 	return beads.GetRigNameForPrefix(townRoot, prefix)
 }
 
-// resolveFormula determines the formula name from user flags.
-func resolveFormula(explicit string, hookRawBead bool) string {
+// resolveFormula determines the formula name from user flags and rig settings.
+// It checks the rig's workflow.default_formula setting before falling back to
+// the hardcoded "mol-polecat-work" default.
+func resolveFormula(explicit string, hookRawBead bool, townRoot, rigName string) string {
 	if hookRawBead {
 		return ""
 	}
 	if explicit != "" {
 		return explicit
+	}
+	// Check rig's default_formula setting (issue gt-boc).
+	if townRoot != "" && rigName != "" {
+		rigPath := filepath.Join(townRoot, rigName)
+		if df := config.GetDefaultFormula(rigPath); df != "" {
+			return df
+		}
 	}
 	return "mol-polecat-work"
 }


### PR DESCRIPTION
## Summary
- `resolveFormula` in `sling_schedule.go` now checks rig's `workflow.default_formula` setting before hardcoding `mol-polecat-work`
- All call sites updated to pass `townRoot` and `rigName` parameters
- Fixes gt-boc: rigs with `default_formula: "shiny-enterprise"` configured now get their formula respected

## Test plan
- [x] `go build ./...` passes
- [ ] Verify `gt sling` without `--formula` uses rig's `default_formula` when configured
- [ ] Verify fallback to `mol-polecat-work` when no rig setting exists

🤖 Generated with [Claude Code](https://claude.com/claude-code)