### PR TITLE
fix: nudge startup prompts for promptless role agents

### DIFF
--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -221,15 +221,7 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 	}
 
 	_ = runtime.RunStartupFallback(t, sessionID, "refinery", runtimeConfig)
-	startupPromptFallback := runtime.GetStartupPromptFallback(runtimeConfig)
-	if startupPromptFallback.Send {
-		if startupPromptFallback.DelayMs > 0 {
-			_ = t.WaitForRuntimeReady(sessionID,
-				runtime.RuntimeConfigWithMinDelay(runtimeConfig, startupPromptFallback.DelayMs),
-				constants.ClaudeStartTimeout)
-		}
-		_ = t.NudgeSession(sessionID, initialPrompt)
-	}
+	_ = runtime.DeliverStartupPromptFallback(t, sessionID, initialPrompt, runtimeConfig, constants.ClaudeStartTimeout)
 
 	// Stream refinery's Claude Code JSONL conversation log to VictoriaLogs (opt-in).
 	if os.Getenv("GT_LOG_AGENT_OUTPUT") == "true" && os.Getenv("GT_OTEL_LOGS_URL") != "" {

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -2,8 +2,10 @@
 package runtime
 
 import (
+	"fmt"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/steveyegge/gastown/internal/cli"
 	"github.com/steveyegge/gastown/internal/config"
@@ -52,6 +54,11 @@ func EnsureSettingsForRole(settingsDir, workDir, role string, rc *config.Runtime
 	}
 
 	return nil
+}
+
+type startupPromptSession interface {
+	NudgeSession(sessionID, message string) error
+	WaitForRuntimeReady(sessionID string, rc *config.RuntimeConfig, timeout time.Duration) error
 }
 
 // SessionIDFromEnv returns the runtime session ID, if present.
@@ -200,6 +207,31 @@ func GetStartupPromptFallback(rc *config.RuntimeConfig) StartupPromptFallback {
 		Send:    info.SendBeaconNudge,
 		DelayMs: info.StartupNudgeDelayMs,
 	}
+}
+
+// DeliverStartupPromptFallback sends the startup prompt via nudge for runtimes
+// that cannot accept the prompt as a CLI argument.
+func DeliverStartupPromptFallback(
+	t startupPromptSession,
+	sessionID, prompt string,
+	rc *config.RuntimeConfig,
+	timeout time.Duration,
+) error {
+	fallback := GetStartupPromptFallback(rc)
+	if !fallback.Send {
+		return nil
+	}
+
+	if fallback.DelayMs > 0 {
+		if err := t.WaitForRuntimeReady(sessionID, RuntimeConfigWithMinDelay(rc, fallback.DelayMs), timeout); err != nil {
+			return fmt.Errorf("waiting for startup prompt fallback: %w", err)
+		}
+	}
+
+	if err := t.NudgeSession(sessionID, prompt); err != nil {
+		return fmt.Errorf("nudging startup prompt fallback: %w", err)
+	}
+	return nil
 }
 
 // StartupNudgeContent returns the work instructions to send as a startup nudge.

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -3,9 +3,32 @@ package runtime
 import (
 	"os"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/gastown/internal/config"
 )
+
+type fakeStartupPromptSession struct {
+	nudges    []string
+	waitCalls int
+	waitRC    *config.RuntimeConfig
+	waitErr   error
+	nudgeErr  error
+}
+
+func (f *fakeStartupPromptSession) NudgeSession(_ string, message string) error {
+	if f.nudgeErr != nil {
+		return f.nudgeErr
+	}
+	f.nudges = append(f.nudges, message)
+	return nil
+}
+
+func (f *fakeStartupPromptSession) WaitForRuntimeReady(_ string, rc *config.RuntimeConfig, _ time.Duration) error {
+	f.waitCalls++
+	f.waitRC = rc
+	return f.waitErr
+}
 
 func TestSessionIDFromEnv_Default(t *testing.T) {
 	// Clear all environment variables
@@ -415,8 +438,81 @@ func TestGetStartupPromptFallback_WithPrompt(t *testing.T) {
 	if fallback.Send {
 		t.Error("Prompt-capable runtimes should not need a startup prompt nudge")
 	}
-	if fallback.DelayMs <= 0 {
-		t.Error("Prompt-capable runtimes should preserve the startup nudge delay metadata")
+	if fallback.DelayMs != DefaultPrimeWaitMs {
+		t.Errorf("DelayMs = %d, want %d", fallback.DelayMs, DefaultPrimeWaitMs)
+	}
+}
+
+func TestDeliverStartupPromptFallback_NoPromptWaitsAndNudges(t *testing.T) {
+	rc := &config.RuntimeConfig{
+		PromptMode: "none",
+		Hooks: &config.RuntimeHooksConfig{
+			Provider: "none",
+		},
+		Tmux: &config.RuntimeTmuxConfig{
+			ReadyPromptPrefix: "should-be-cleared",
+			ReadyDelayMs:      100,
+		},
+	}
+	tm := &fakeStartupPromptSession{}
+
+	err := DeliverStartupPromptFallback(tm, "sess-1", "begin patrol", rc, 30*time.Second)
+	if err != nil {
+		t.Fatalf("DeliverStartupPromptFallback() error = %v", err)
+	}
+	if tm.waitCalls != 1 {
+		t.Fatalf("waitCalls = %d, want 1", tm.waitCalls)
+	}
+	if tm.waitRC == nil || tm.waitRC.Tmux == nil {
+		t.Fatalf("waitRC missing tmux config: %#v", tm.waitRC)
+	}
+	if tm.waitRC.Tmux.ReadyPromptPrefix != "" {
+		t.Fatalf("ReadyPromptPrefix = %q, want empty", tm.waitRC.Tmux.ReadyPromptPrefix)
+	}
+	if tm.waitRC.Tmux.ReadyDelayMs < DefaultPrimeWaitMs {
+		t.Fatalf("ReadyDelayMs = %d, want >= %d", tm.waitRC.Tmux.ReadyDelayMs, DefaultPrimeWaitMs)
+	}
+	if len(tm.nudges) != 1 || tm.nudges[0] != "begin patrol" {
+		t.Fatalf("nudges = %#v, want [\"begin patrol\"]", tm.nudges)
+	}
+}
+
+func TestDeliverStartupPromptFallback_WithPromptNoOp(t *testing.T) {
+	rc := &config.RuntimeConfig{
+		PromptMode: "arg",
+		Hooks: &config.RuntimeHooksConfig{
+			Provider: "none",
+		},
+	}
+	tm := &fakeStartupPromptSession{}
+
+	err := DeliverStartupPromptFallback(tm, "sess-1", "begin patrol", rc, 30*time.Second)
+	if err != nil {
+		t.Fatalf("DeliverStartupPromptFallback() error = %v", err)
+	}
+	if tm.waitCalls != 0 {
+		t.Fatalf("waitCalls = %d, want 0", tm.waitCalls)
+	}
+	if len(tm.nudges) != 0 {
+		t.Fatalf("nudges = %#v, want none", tm.nudges)
+	}
+}
+
+func TestDeliverStartupPromptFallback_WaitError(t *testing.T) {
+	rc := &config.RuntimeConfig{
+		PromptMode: "none",
+		Hooks: &config.RuntimeHooksConfig{
+			Provider: "none",
+		},
+	}
+	tm := &fakeStartupPromptSession{waitErr: os.ErrDeadlineExceeded}
+
+	err := DeliverStartupPromptFallback(tm, "sess-1", "begin patrol", rc, 30*time.Second)
+	if err == nil {
+		t.Fatal("DeliverStartupPromptFallback() error = nil, want non-nil")
+	}
+	if len(tm.nudges) != 0 {
+		t.Fatalf("nudges = %#v, want none after wait failure", tm.nudges)
 	}
 }
 

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -247,20 +247,12 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	}
 
 	_ = runtime.RunStartupFallback(t, sessionID, "witness", runtimeConfig)
-	startupPromptFallback := runtime.GetStartupPromptFallback(runtimeConfig)
-	if startupPromptFallback.Send {
-		if startupPromptFallback.DelayMs > 0 {
-			_ = t.WaitForRuntimeReady(sessionID,
-				runtime.RuntimeConfigWithMinDelay(runtimeConfig, startupPromptFallback.DelayMs),
-				constants.ClaudeStartTimeout)
-		}
-		initialPrompt := session.BuildStartupPrompt(session.BeaconConfig{
-			Recipient: session.BeaconRecipient("witness", "", m.rig.Name),
-			Sender:    "deacon",
-			Topic:     "patrol",
-		}, "Run `gt prime --hook` and begin patrol.")
-		_ = t.NudgeSession(sessionID, initialPrompt)
-	}
+	initialPrompt := session.BuildStartupPrompt(session.BeaconConfig{
+		Recipient: session.BeaconRecipient("witness", "", m.rig.Name),
+		Sender:    "deacon",
+		Topic:     "patrol",
+	}, "Run `gt prime --hook` and begin patrol.")
+	_ = runtime.DeliverStartupPromptFallback(t, sessionID, initialPrompt, runtimeConfig, constants.ClaudeStartTimeout)
 
 	// Stream witness's Claude Code JSONL conversation log to VictoriaLogs (opt-in).
 	if os.Getenv("GT_LOG_AGENT_OUTPUT") == "true" && os.Getenv("GT_OTEL_LOGS_URL") != "" {


### PR DESCRIPTION
## Problem

When Gas Town spawns witness or refinery sessions using a promptless runtime (e.g. Codex, where \`prompt_mode: none\`), the startup patrol prompt was silently dropped. The sessions received the fallback \`gt prime && gt mail check --inject\` commands but never received the actual patrol instruction, leaving them idling while appearing healthy.

The effect is operationally serious: ready merge queue entries sit unclaimed indefinitely and role agents appear running while doing nothing. Polecats already had the correct fallback path implemented — witness and refinery did not.

## Fix

- Added \`GetStartupPromptFallback\` helper to \`internal/runtime\` to detect when a startup prompt must be delivered via nudge for promptless runtimes
- Wired \`internal/witness/manager.go\` and \`internal/refinery/manager.go\` to send the patrol prompt after startup fallback completes
- Added unit coverage in \`internal/runtime/runtime_test.go\`

## Verification

- Confirmed live witness and refinery sessions now receive the patrol prompt after startup under Codex
- Confirmed stuck merge queue entries were subsequently claimed and merged