### PR TITLE
fix: seed types.custom after Dolt restart (st-60o)

### DIFF
--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -422,6 +422,26 @@ func stripYAMLQuotes(s string) string {
 	return s
 }
 
+// InvalidateSentinels removes sentinel files from the given beads directories
+// and clears the in-memory cache, forcing the next EnsureCustomTypes/EnsureCustomStatuses
+// call to re-configure types in the database.
+//
+// This should be called after a Dolt server restart, because the config table
+// may have been reset while sentinel files persisted on disk (st-60o).
+func InvalidateSentinels(beadsDirs ...string) {
+	ensuredMu.Lock()
+	defer ensuredMu.Unlock()
+
+	for _, dir := range beadsDirs {
+		// Remove sentinel files so next EnsureCustomTypes/Statuses re-configures
+		_ = os.Remove(filepath.Join(dir, typesSentinel))
+		_ = os.Remove(filepath.Join(dir, statusesSentinel))
+		// Clear in-memory cache entries
+		delete(ensuredDirs, dir)
+		delete(ensuredDirs, dir+":statuses")
+	}
+}
+
 // ResetEnsuredDirs clears the in-memory cache of ensured directories.
 // This is primarily useful for testing.
 func ResetEnsuredDirs() {

--- a/internal/beads/config_yaml.go
+++ b/internal/beads/config_yaml.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/steveyegge/gastown/internal/constants"
 )
 
 // EnsureConfigYAML ensures config.yaml has both prefix keys set for the given
@@ -88,11 +90,13 @@ func ensureConfigYAML(beadsDir, prefix string, onlyIfMissing bool) error {
 	wantIssuePrefix := "issue-prefix: " + prefix
 	// Gas Town rigs should disable idle-monitor to use centralized Dolt server
 	wantIdleTimeout := "dolt.idle-timeout: \"0\""
+	// Persistent fallback for custom types — survives Dolt config table resets. (st-60o)
+	wantTypesCustom := "types.custom: \"" + constants.BeadsCustomTypes + "\""
 
 	data, err := os.ReadFile(configPath)
 	if os.IsNotExist(err) {
 		// New config: include all Gas Town defaults
-		content := wantPrefix + "\n" + wantIssuePrefix + "\n" + wantIdleTimeout + "\n"
+		content := wantPrefix + "\n" + wantIssuePrefix + "\n" + wantIdleTimeout + "\n" + wantTypesCustom + "\n"
 		return os.WriteFile(configPath, []byte(content), 0644)
 	}
 	if err != nil {
@@ -107,6 +111,7 @@ func ensureConfigYAML(beadsDir, prefix string, onlyIfMissing bool) error {
 	foundPrefix := false
 	foundIssuePrefix := false
 	foundIdleTimeout := false
+	foundTypesCustom := false
 
 	for i, line := range lines {
 		trimmed := strings.TrimSpace(line)
@@ -125,6 +130,11 @@ func ensureConfigYAML(beadsDir, prefix string, onlyIfMissing bool) error {
 			foundIdleTimeout = true
 			continue
 		}
+		if strings.HasPrefix(trimmed, "types.custom:") {
+			lines[i] = wantTypesCustom
+			foundTypesCustom = true
+			continue
+		}
 	}
 
 	if !foundPrefix {
@@ -135,6 +145,9 @@ func ensureConfigYAML(beadsDir, prefix string, onlyIfMissing bool) error {
 	}
 	if !foundIdleTimeout {
 		lines = append(lines, wantIdleTimeout)
+	}
+	if !foundTypesCustom {
+		lines = append(lines, wantTypesCustom)
 	}
 
 	newContent := strings.Join(lines, "\n")

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -318,6 +318,13 @@ func runUp(cmd *cobra.Command, args []string) error {
 		portStr := fmt.Sprintf("%d", doltCfg.Port)
 		os.Setenv("GT_DOLT_PORT", portStr)
 		os.Setenv("BEADS_DOLT_PORT", portStr)
+
+		// Seed custom types and statuses in all beads databases after Dolt restart.
+		// The Dolt config table may lose types.custom when the server restarts,
+		// while sentinel files persist on disk — causing EnsureCustomTypes() to
+		// skip re-configuration and bd create --type=agent to fail. Invalidate
+		// sentinels and re-seed to prevent this. (st-60o)
+		seedBeadsCustomConfig(townRoot, rigs)
 	}
 
 	// 5 & 6. Witnesses and Refineries (using prefetched rigs)
@@ -962,6 +969,52 @@ const doltReadyTimeout = 10 * time.Second
 func waitForDoltReady(townRoot string) {
 	if err := doltserver.WaitForReady(townRoot, doltReadyTimeout); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: %v (agents may see connection errors)\n", err)
+	}
+}
+
+// seedBeadsCustomConfig invalidates sentinel files and re-seeds custom types and
+// statuses in all beads databases after a Dolt server start. This prevents the
+// scenario where the Dolt config table loses types.custom on restart but sentinel
+// files persist, causing EnsureCustomTypes to skip re-configuration and agent
+// bead creation to fail with "invalid issue type: agent". (st-60o)
+func seedBeadsCustomConfig(townRoot string, rigNames []string) {
+	// Collect all beads directories: town-level + each rig
+	var beadsDirs []string
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	if _, err := os.Stat(townBeadsDir); err == nil {
+		beadsDirs = append(beadsDirs, townBeadsDir)
+	}
+
+	for _, rigName := range rigNames {
+		// Check for rig-level beads (may be in mayor/rig/.beads via redirect)
+		rigDir := filepath.Join(townRoot, rigName)
+		rigBeadsDir := filepath.Join(rigDir, ".beads")
+		if _, err := os.Stat(rigBeadsDir); err == nil {
+			// ResolveBeadsDir follows redirects (e.g., .beads/redirect → mayor/rig/.beads)
+			resolved := beads.ResolveBeadsDir(rigDir)
+			if resolved != "" {
+				beadsDirs = append(beadsDirs, resolved)
+			} else {
+				beadsDirs = append(beadsDirs, rigBeadsDir)
+			}
+		}
+	}
+
+	if len(beadsDirs) == 0 {
+		return
+	}
+
+	// Invalidate sentinel files so EnsureCustomTypes actually runs bd config set
+	beads.InvalidateSentinels(beadsDirs...)
+
+	// Re-seed types and statuses in each database (errors are non-fatal)
+	for _, dir := range beadsDirs {
+		if err := beads.EnsureCustomTypes(dir); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not seed custom types in %s: %v\n", dir, err)
+		}
+		if err := beads.EnsureCustomStatuses(dir); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not seed custom statuses in %s: %v\n", dir, err)
+		}
 	}
 }
 

--- a/internal/doctor/agent_beads_check.go
+++ b/internal/doctor/agent_beads_check.go
@@ -209,6 +209,13 @@ func (c *AgentBeadsCheck) Run(ctx *CheckContext) *CheckResult {
 
 // Fix creates missing agent beads and adds gt:agent labels to beads missing them.
 func (c *AgentBeadsCheck) Fix(ctx *CheckContext) error {
+	// Invalidate sentinel files and re-seed custom types before creating agent beads.
+	// After a Dolt restart, types.custom may be cleared from the config table while
+	// sentinel files persist on disk. Without this, CreateAgentBead → EnsureCustomTypes
+	// sees the stale sentinel, skips bd config set, and bd create --type=agent fails
+	// with "invalid issue type: agent". (st-60o)
+	invalidateAndReseedTypes(ctx.TownRoot)
+
 	// Pre-load all known agent bead IDs (from both issues and wisps tables)
 	// so we can check existence without per-bead Show() calls that miss ephemeral wisps.
 	allAgentBeads := make(map[string]*beads.Issue) // from issues table
@@ -469,4 +476,50 @@ func listPolecats(townRoot, rigName string) []string {
 		}
 	}
 	return polecats
+}
+
+// invalidateAndReseedTypes removes sentinel files and re-seeds custom types
+// and statuses in all beads databases. This ensures that CreateAgentBead →
+// EnsureCustomTypes actually calls bd config set instead of trusting a stale
+// sentinel file left over from before a Dolt restart. (st-60o)
+func invalidateAndReseedTypes(townRoot string) {
+	seen := make(map[string]bool)
+	var beadsDirs []string
+
+	addDir := func(dir string) {
+		if dir != "" && !seen[dir] {
+			seen[dir] = true
+			beadsDirs = append(beadsDirs, dir)
+		}
+	}
+
+	// Town-level beads
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	if _, err := os.Stat(townBeadsDir); err == nil {
+		addDir(townBeadsDir)
+	}
+
+	// Rig-level beads (from routes.jsonl)
+	routes, err := beads.LoadRoutes(townBeadsDir)
+	if err == nil {
+		for _, r := range routes {
+			// Route paths are relative to town root (e.g., "ScaledTest/mayor/rig")
+			rigWorkDir := filepath.Join(townRoot, r.Path)
+			resolved := beads.ResolveBeadsDir(rigWorkDir)
+			addDir(resolved)
+		}
+	}
+
+	if len(beadsDirs) == 0 {
+		return
+	}
+
+	// Invalidate sentinels so EnsureCustomTypes bypasses the cache
+	beads.InvalidateSentinels(beadsDirs...)
+
+	// Re-seed types in each database (best-effort)
+	for _, dir := range beadsDirs {
+		_ = beads.EnsureCustomTypes(dir)
+		_ = beads.EnsureCustomStatuses(dir)
+	}
 }


### PR DESCRIPTION
## Summary
- After a Dolt server restart, the config table may lose `types.custom` while sentinel files (`.gt-types-configured`) persist on disk, causing `EnsureCustomTypes()` to skip re-configuration
- This results in `gt doctor --fix` silently failing to create agent beads with "invalid issue type: agent"
- Three-layer fix:
  1. **`gt up`**: invalidates sentinels and re-seeds `types.custom` in all beads databases after Dolt becomes ready
  2. **`gt doctor --fix`**: invalidates sentinels before creating missing agent beads
  3. **`config.yaml`**: includes `types.custom` as persistent YAML fallback via `EnsureConfigYAML()`

## Changes
- `internal/beads/beads_types.go`: Add `InvalidateSentinels()` public API
- `internal/beads/config_yaml.go`: Include `types.custom` in new and updated config.yaml files
- `internal/cmd/up.go`: Add `seedBeadsCustomConfig()` called after Dolt is ready
- `internal/doctor/agent_beads_check.go`: Add `invalidateAndReseedTypes()` called before agent bead creation in Fix()

## Test plan
- [x] All existing tests pass (`go test ./internal/beads/ ./internal/doctor/`)
- [x] `go build ./...` succeeds
- [x] `gt doctor` passes after changes
- [ ] Verify fix by doing `gt down && gt up` and confirming `agent-beads-exist` passes without manual intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)