### PR TITLE
Fix idle polecat reuse when tmux session is still live

### DIFF
--- a/internal/cmd/polecat_spawn.go
+++ b/internal/cmd/polecat_spawn.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -186,12 +187,16 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 		}
 		reuseOK := false
 		if _, err := polecatMgr.ReuseIdlePolecat(polecatName, addOpts); err != nil {
-			// Branch-only reuse failed — try full worktree repair as fallback
-			fmt.Printf("  Branch-only reuse failed for idle polecat %s: %v, trying full repair...\n", polecatName, err)
-			if _, err := polecatMgr.RepairWorktreeWithOptions(polecatName, true, addOpts); err != nil {
-				fmt.Printf("  Full repair also failed for %s: %v, allocating new...\n", polecatName, err)
+			if errors.Is(err, polecat.ErrSessionRunning) {
+				fmt.Printf("  Idle polecat %s still has a live session, allocating new...\n", polecatName)
 			} else {
-				reuseOK = true
+				// Branch-only reuse failed — try full worktree repair as fallback
+				fmt.Printf("  Branch-only reuse failed for idle polecat %s: %v, trying full repair...\n", polecatName, err)
+				if _, err := polecatMgr.RepairWorktreeWithOptions(polecatName, true, addOpts); err != nil {
+					fmt.Printf("  Full repair also failed for %s: %v, allocating new...\n", polecatName, err)
+				} else {
+					reuseOK = true
+				}
 			}
 		} else {
 			reuseOK = true

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1510,6 +1510,20 @@ func (m *Manager) ReuseIdlePolecat(name string, opts AddOptions) (*Polecat, erro
 		return nil, ErrPolecatNotFound
 	}
 
+	// Revalidate session state under the polecat lock. A prior dispatcher may
+	// have observed this polecat as idle, but by the time reuse begins the tmux
+	// session may still be alive or may have revived.
+	if running, stale := m.polecatSessionState(name); running {
+		if stale {
+			sessionName := session.PolecatSessionName(session.PrefixFor(m.rig.Name), name)
+			if err := m.tmux.KillSessionWithProcesses(sessionName); err != nil {
+				return nil, fmt.Errorf("killing stale session %s: %w", sessionName, err)
+			}
+		} else {
+			return nil, ErrSessionRunning
+		}
+	}
+
 	// Get worktree path (must already exist for reuse)
 	clonePath := m.clonePath(name)
 	if _, err := os.Stat(clonePath); err != nil {
@@ -2033,8 +2047,9 @@ func (m *Manager) unassignWorkBeads(name string) {
 //  2. Legacy agent hook_bead that still points to a currently hooked bead for this assignee
 //     → working (compatibility fallback during migration)
 //  3. Issue assigned via beads assignee (open/in_progress/hooked) → working
-//  4. Tmux session alive → working (session active even if assignment not yet recorded)
-//  5. None of the above → idle
+//  4. Live tmux session → working (session active even if assignment not yet recorded)
+//  5. agent_state=idle with no live session → idle
+//  6. None of the above → idle
 func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 	// Use clonePath which handles both new (polecats/<name>/<rigname>/)
 	// and old (polecats/<name>/) structures
@@ -2087,18 +2102,6 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 		}
 	}
 
-	// Persistent polecat model (gt-4ac): check agent_state for idle detection.
-	// An idle polecat has no hook_bead and agent_state="idle".
-	if agentErr == nil && fields != nil && beads.AgentState(fields.AgentState) == beads.AgentStateIdle {
-		return &Polecat{
-			Name:      name,
-			Rig:       m.rig.Name,
-			State:     StateIdle,
-			ClonePath: clonePath,
-			Branch:    branchName,
-		}, nil
-	}
-
 	// Fallback: Query beads for assigned issue (for polecats without agent beads
 	// or with empty hook_bead)
 	issue, beadsErr := m.beads.GetAssignedIssue(assignee)
@@ -2114,21 +2117,29 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 		}, nil
 	}
 
-	// Persistent model: has issue = working, no issue = check tmux session.
-	// If tmux session is alive, the polecat is still actively working even
-	// if beads hasn't recorded an assignment yet (timing, query failure, etc.).
-	// No issue + no session = idle (persistent) rather than done.
-	// Fixes: gt-o01h4l (polecat list shows 'done' for running polecats)
-	state := StateIdle
+	// Persistent model: has issue = working, otherwise a live tmux session still
+	// means working even if beads state has fallen behind.
 	issueID := ""
 	if issue != nil {
 		issueID = issue.ID
+	} else if running, stale := m.polecatSessionState(name); running && !stale {
+		return &Polecat{
+			Name:      name,
+			Rig:       m.rig.Name,
+			State:     StateWorking,
+			ClonePath: clonePath,
+			Branch:    branchName,
+		}, nil
+	}
+
+	// Persistent polecat model (gt-4ac): only trust agent_state=idle once the
+	// tmux session is gone. This prevents reusing a polecat that still has a live
+	// session when its bead state was cleared early.
+	state := StateIdle
+	if issueID != "" {
 		state = StateWorking
-	} else if m.tmux != nil {
-		sessionName := session.PolecatSessionName(session.PrefixFor(m.rig.Name), name)
-		if running, _ := m.tmux.HasSession(sessionName); running {
-			state = StateWorking
-		}
+	} else if agentErr == nil && fields != nil && beads.AgentState(fields.AgentState) == beads.AgentStateIdle {
+		state = StateIdle
 	}
 
 	return &Polecat{
@@ -2139,6 +2150,20 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 		Branch:    branchName,
 		Issue:     issueID,
 	}, nil
+}
+
+func (m *Manager) polecatSessionState(name string) (running bool, stale bool) {
+	if m.tmux == nil {
+		return false, false
+	}
+
+	sessionName := session.PolecatSessionName(session.PrefixFor(m.rig.Name), name)
+	running, err := m.tmux.HasSession(sessionName)
+	if err != nil || !running {
+		return false, false
+	}
+
+	return true, NewSessionManager(m.tmux, m.rig).isSessionStale(sessionName)
 }
 
 func isCurrentHookedIssueForAssignee(issue *beads.Issue, assignee string) bool {

--- a/internal/polecat/manager_integration_test.go
+++ b/internal/polecat/manager_integration_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/testutil"
+	"github.com/steveyegge/gastown/internal/tmux"
 )
 
 var polecatManagerIntegrationCounter atomic.Int32
@@ -33,6 +34,25 @@ func initBeadsDBWithPrefix(t *testing.T, dir, prefix string) {
 	if err := os.WriteFile(issuesPath, []byte(""), 0644); err != nil {
 		t.Fatalf("create issues.jsonl in %s: %v", dir, err)
 	}
+}
+
+func requireTmuxIntegration(t *testing.T) {
+	t.Helper()
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed, skipping integration test")
+	}
+}
+
+func startLiveSession(t *testing.T, sessionName string) {
+	t.Helper()
+
+	tm := tmux.NewTmux()
+	if err := tm.NewSessionWithCommand(sessionName, "", "sleep 60"); err != nil {
+		t.Fatalf("start tmux session %s: %v", sessionName, err)
+	}
+	t.Cleanup(func() {
+		_ = tm.KillSessionWithProcesses(sessionName)
+	})
 }
 
 // TestManagerGetPrefersHookedBeadOverStaleAgentHook verifies that manager.Get
@@ -129,5 +149,81 @@ func TestManagerGetPrefersHookedBeadOverStaleAgentHook(t *testing.T) {
 	}
 	if p.Issue != current.ID {
 		t.Fatalf("polecat issue = %q, want hooked issue %q (stale hook %q)", p.Issue, current.ID, stale.ID)
+	}
+}
+
+func TestManagerDoesNotTreatLiveSessionAsIdle(t *testing.T) {
+	if _, err := exec.LookPath("bd"); err != nil {
+		t.Skip("bd not installed, skipping integration test")
+	}
+	requireTmuxIntegration(t)
+	testutil.RequireDoltContainer(t)
+
+	n := polecatManagerIntegrationCounter.Add(1)
+	prefix := fmt.Sprintf("pm%d", n)
+
+	townRoot := t.TempDir()
+	rigName := "testrig"
+	rigPath := filepath.Join(townRoot, rigName)
+	mayorRigPath := filepath.Join(rigPath, "mayor", "rig")
+
+	if err := os.MkdirAll(mayorRigPath, 0755); err != nil {
+		t.Fatalf("mkdir mayor rig path: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(rigPath, "polecats", "toast"), 0755); err != nil {
+		t.Fatalf("mkdir polecat dir: %v", err)
+	}
+
+	rigBeadsDir := filepath.Join(rigPath, ".beads")
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir rig .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigBeadsDir, "redirect"), []byte("mayor/rig/.beads\n"), 0644); err != nil {
+		t.Fatalf("write rig redirect: %v", err)
+	}
+
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir town .beads: %v", err)
+	}
+	routes := []beads.Route{
+		{Prefix: "hq-", Path: "."},
+		{Prefix: prefix + "-", Path: filepath.Join(rigName, "mayor", "rig")},
+	}
+	if err := beads.WriteRoutes(townBeadsDir, routes); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	initBeadsDBWithPrefix(t, mayorRigPath, prefix)
+
+	r := &rig.Rig{Name: rigName, Path: rigPath}
+	tm := tmux.NewTmux()
+	mgr := NewManager(r, git.NewGit(rigPath), tm)
+
+	agentID := mgr.agentBeadID("toast")
+	assignee := mgr.assigneeID("toast")
+	if _, err := mgr.beads.CreateOrReopenAgentBead(agentID, assignee, &beads.AgentFields{
+		AgentState: string(beads.AgentStateIdle),
+	}); err != nil {
+		t.Fatalf("create idle agent bead: %v", err)
+	}
+
+	sessionName := NewSessionManager(tm, r).SessionName("toast")
+	startLiveSession(t, sessionName)
+
+	p, err := mgr.Get("toast")
+	if err != nil {
+		t.Fatalf("mgr.Get(toast): %v", err)
+	}
+	if p.State != StateWorking {
+		t.Fatalf("polecat state = %q, want %q when tmux session is alive", p.State, StateWorking)
+	}
+
+	idle, err := mgr.FindIdlePolecat()
+	if err != nil {
+		t.Fatalf("mgr.FindIdlePolecat(): %v", err)
+	}
+	if idle != nil {
+		t.Fatalf("FindIdlePolecat() = %q, want nil while session %s is alive", idle.Name, sessionName)
 	}
 }


### PR DESCRIPTION
## Summary
- stop treating polecats with live tmux sessions as idle/reusable even when their agent bead says `idle`
- revalidate session state under the reuse lock and skip branch-reuse fallback when the existing session is still alive
- add an integration regression test covering a live tmux session plus `agent_state=idle`

## Testing
- `go test ./internal/polecat ./internal/cmd`
- `go test -tags=integration ./internal/polecat -run TestManagerDoesNotTreatLiveSessionAsIdle -count=1`
- `go test ./...` *(fails on pre-existing unrelated `internal/config` Dolt port tests: `TestAgentEnv_NoDoltPortWithoutTownRoot`, `TestResolveDoltPort_NoConfig`, `TestAgentEnv_NoDoltPortWithoutConfig`, `TestResolveDoltPort_FromDaemonJSON`)*
