### PR TITLE
fix(mail): retry bd list without --flat for bd < v0.59 compatibility

### DIFF
--- a/internal/mail/bd.go
+++ b/internal/mail/bd.go
@@ -76,6 +76,27 @@ func runBdCommand(ctx context.Context, args []string, workDir, beadsDir string, 
 
 	runErr := cmd.Run()
 
+	// If bd doesn't support --flat (pre-v0.59), retry without it.
+	if runErr != nil && strings.Contains(stderr.String(), "unknown flag: --flat") {
+		retryArgs := make([]string, 0, len(args))
+		for _, a := range args {
+			if a != "--flat" {
+				retryArgs = append(retryArgs, a)
+			}
+		}
+		stdout.Reset()
+		stderr.Reset()
+		cmd = exec.CommandContext(ctx, "bd", retryArgs...) //nolint:gosec // G204: bd is a trusted internal tool
+		cmd.Dir = workDir
+		env2 := append(cmd.Environ(), "BEADS_DIR="+beadsDir)
+		env2 = append(env2, extraEnv...)
+		env2 = append(env2, telemetry.OTELEnvForSubprocess()...)
+		cmd.Env = env2
+		cmd.Stdout = &stdout
+		cmd.Stderr = &stderr
+		runErr = cmd.Run()
+	}
+
 	if runErr != nil {
 		return nil, &bdError{
 			Err:    runErr,

--- a/plugins/dolt-archive/plugin.md
+++ b/plugins/dolt-archive/plugin.md
@@ -32,7 +32,7 @@ whether the other layers work.
 
 ```bash
 DOLT_DATA_DIR="$HOME/gt/.dolt-data"
-PROD_DBS=("hq" "bd" "gt")
+PROD_DBS=("hq" "gt" "property_scrapers" "wa")
 JSONL_EXPORT_DIR="$HOME/gt/.dolt-archive/jsonl"
 DOLT_HOST="127.0.0.1"
 DOLT_PORT=3307


### PR DESCRIPTION
## Problem

bd v0.57.0 does not support `--flat`. The mail router's `runBdCommand` was not retrying without `--flat` like `beads/beads.go` does, causing `gt mail send` to fail with 'no agent found' for all dog/crew recipients.

Also fixes dolt-archive plugin PROD_DBS: 'bd' database does not exist on this instance.

## Changes

- `internal/mail/bd.go`: retry `bd list` without `--flat` when command fails (matching existing pattern in `beads/beads.go`)
- `plugins/dolt-archive/plugin.md`: correct PROD_DBS list (hq, gt, property_scrapers, wa)

## Test

Verified `gt mail send` works correctly after this fix on bd v0.57.0.