### PR TITLE
fix: filter MQ list by rig to prevent cross-rig wisp contamination

### DIFF
--- a/internal/cmd/mq_list.go
+++ b/internal/cmd/mq_list.go
@@ -107,6 +107,12 @@ func runMQList(cmd *cobra.Command, args []string) error {
 		// Parse MR fields
 		fields := beads.ParseMRFields(issue)
 
+		// Filter by rig — wisps are shared across all rigs in the Dolt server,
+		// so we must filter to only show MRs belonging to this rig.
+		if fields != nil && fields.Rig != "" && !strings.EqualFold(fields.Rig, rigName) {
+			continue
+		}
+
 		// Filter by worker
 		if mqListWorker != "" {
 			worker := ""


### PR DESCRIPTION
## Summary

- Add rig filter in `runMQList()` to skip wisps whose `rig` field doesn't match the requested rig name
- Fixes shared Dolt wisps table returning MRs from all rigs regardless of which rig was queried

Closes #2718

## Test plan

- [ ] Run `gt mq list <rig_A>` with MRs active in `<rig_B>` — only rig_A MRs should appear
- [ ] Verify MRs with no `rig` field in description are still shown (backwards compat)
- [ ] Verify `--worker`, `--epic`, `--verify` filters still work alongside rig filter

🤖 Generated with [Claude Code](https://claude.com/claude-code)