### PR TITLE
fix: auto-repair missing refinery worktree on startup

### DIFF
--- a/internal/doctor/rig_check.go
+++ b/internal/doctor/rig_check.go
@@ -570,9 +570,38 @@ func (c *RefineryExistsCheck) Fix(ctx *CheckContext) error {
 		}
 	}
 
-	// Note: Cannot auto-fix clone without knowing the repo URL
+	// Auto-repair refinery worktree from shared bare repo (.repo.git).
+	// The refinery/rig is a worktree (not a full clone), so we don't need
+	// the repo URL -- we just create a worktree from the local bare repo.
 	if c.needsClone {
-		return fmt.Errorf("cannot auto-create refinery/rig/ clone (requires repo URL)")
+		bareRepoPath := filepath.Join(c.rigPath, ".repo.git")
+		if _, err := os.Stat(bareRepoPath); os.IsNotExist(err) {
+			return fmt.Errorf("cannot auto-create refinery/rig/ worktree: bare repo not found at %s", bareRepoPath)
+		}
+
+		bareGit := git.NewGitWithDir(bareRepoPath, "")
+		_ = bareGit.WorktreePrune()
+
+		rigClone := filepath.Join(refineryDir, "rig")
+		// Detect default branch from rig config
+		rigCfgPath := filepath.Join(c.rigPath, "settings", "rig.json")
+		defaultBranch := "main"
+		if data, err := os.ReadFile(rigCfgPath); err == nil {
+			var cfg struct {
+				DefaultBranch string `json:"default_branch"`
+			}
+			if json.Unmarshal(data, &cfg) == nil && cfg.DefaultBranch != "" {
+				defaultBranch = cfg.DefaultBranch
+			}
+		}
+
+		if err := bareGit.WorktreeAddExisting(rigClone, defaultBranch); err != nil {
+			return fmt.Errorf("creating refinery worktree from bare repo: %w", err)
+		}
+
+		// Configure hooks path
+		refineryGit := git.NewGit(rigClone)
+		_ = refineryGit.ConfigureHooksPath()
 	}
 
 	return nil

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -17,6 +17,7 @@ import (
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/session"
@@ -135,12 +136,18 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 	// Background mode: spawn a Claude agent in a tmux session
 	// The Claude agent handles MR processing using git commands and beads
 
-	// Working directory is the refinery worktree (shares .git with mayor/polecats)
+	// Working directory is the refinery worktree (shares .git with mayor/polecats).
+	// If the worktree is missing (pruned, deleted, or corrupted), auto-repair it
+	// from the shared bare repo (.repo.git) instead of falling back to mayor/rig.
+	// Falling back to mayor/rig causes the refinery to operate in the mayor's
+	// clone, which can interfere with mayor operations and confuse agents.
 	refineryRigDir := filepath.Join(m.rig.Path, "refinery", "rig")
 	if _, err := os.Stat(refineryRigDir); os.IsNotExist(err) {
-		// Fall back to mayor/rig (legacy architecture) - ensures we use project git, not town git.
-		// Using rig.Path directly would find town's .git with rig-named remotes instead of "origin".
-		refineryRigDir = filepath.Join(m.rig.Path, "mayor", "rig")
+		if repairErr := m.repairRefineryWorktree(refineryRigDir); repairErr != nil {
+			// Repair failed — fall back to mayor/rig as last resort.
+			_, _ = fmt.Fprintf(m.output, "⚠ Could not repair refinery worktree: %v (falling back to mayor/rig)\n", repairErr)
+			refineryRigDir = filepath.Join(m.rig.Path, "mayor", "rig")
+		}
 	}
 
 	// Ensure runtime settings exist in the shared refinery parent directory.
@@ -233,6 +240,43 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 	session.RecordAgentInstantiateFromDir(context.Background(), runID, runtimeConfig.ResolvedAgent,
 		"refinery", "refinery", sessionID, m.rig.Name, townRoot, "", refineryRigDir)
 
+	return nil
+}
+
+// repairRefineryWorktree recreates a missing refinery/rig worktree from the
+// shared bare repo (.repo.git). The refinery worktree is created during
+// `gt rig add` but can be lost if `git worktree prune` runs, the directory
+// is deleted, or the .git file becomes corrupted. This self-heals on startup
+// instead of requiring manual intervention.
+func (m *Manager) repairRefineryWorktree(refineryRigDir string) error {
+	bareRepoPath := filepath.Join(m.rig.Path, ".repo.git")
+	if _, err := os.Stat(bareRepoPath); os.IsNotExist(err) {
+		return fmt.Errorf("bare repo not found at %s", bareRepoPath)
+	}
+
+	// Ensure parent directory exists
+	if err := os.MkdirAll(filepath.Dir(refineryRigDir), 0755); err != nil {
+		return fmt.Errorf("creating refinery dir: %w", err)
+	}
+
+	// Prune stale worktree entries so git doesn't reject the add
+	bareGit := git.NewGitWithDir(bareRepoPath, "")
+	_ = bareGit.WorktreePrune()
+
+	// Create worktree on the rig's default branch
+	defaultBranch := m.rig.DefaultBranch()
+	if err := bareGit.WorktreeAddExisting(refineryRigDir, defaultBranch); err != nil {
+		return fmt.Errorf("git worktree add: %w", err)
+	}
+
+	// Configure hooks path (matches rig add behavior)
+	refineryGit := git.NewGit(refineryRigDir)
+	if err := refineryGit.ConfigureHooksPath(); err != nil {
+		// Non-fatal: worktree is usable without hooks
+		_, _ = fmt.Fprintf(m.output, "⚠ Could not configure hooks for repaired worktree: %v\n", err)
+	}
+
+	_, _ = fmt.Fprintf(m.output, "✓ Auto-repaired missing refinery worktree at %s\n", refineryRigDir)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

- Auto-repair missing `refinery/rig/` worktree from `.repo.git` during refinery `Start()` instead of silently falling back to `mayor/rig`
- Fix `gt doctor --fix` to recreate refinery worktree from bare repo instead of erroring with "requires repo URL"
- Retain `mayor/rig` fallback as last resort if repair fails

## Context

The `refinery/rig/` worktree is created during `gt rig add` but can be lost when `git worktree prune` runs, the directory is deleted, or the `.git` file becomes corrupted. This has caused refinery crashes in at least 3 production incidents (hq-u2o9.7, hq-u2o9.10, hq-u2o9.13).

Fixes #2720

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/refinery/` passes
- [ ] Manual test: delete `refinery/rig/` from a rig, run `gt rig start <rig>`, verify worktree is auto-repaired
- [ ] Manual test: delete `refinery/rig/`, run `gt doctor --fix`, verify worktree is recreated

🤖 Generated with [Claude Code](https://claude.com/claude-code)