### PR TITLE
fix(polecat): use local git excludes for ephemeral worktrees

### DIFF
--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -765,8 +765,8 @@ func (m *Manager) addWithOptionsLocked(name string, opts AddOptions, polecatDir 
 		style.PrintWarning("could not copy overlay files: %v", err)
 	}
 
-	if err := rig.EnsureGitignorePatterns(clonePath); err != nil {
-		style.PrintWarning("could not update .gitignore: %v", err)
+	if err := rig.EnsureLocalExcludePatterns(clonePath); err != nil {
+		style.PrintWarning("could not update local git excludes: %v", err)
 	}
 
 	townRoot := filepath.Dir(m.rig.Path)
@@ -945,9 +945,9 @@ func (m *Manager) AddWithOptions(name string, opts AddOptions) (_ *Polecat, retE
 		style.PrintWarning("could not copy overlay files: %v", err)
 	}
 
-	// Ensure .gitignore has required Gas Town patterns
-	if err := rig.EnsureGitignorePatterns(clonePath); err != nil {
-		style.PrintWarning("could not update .gitignore: %v", err)
+	// Keep worktree runtime ignores local so the tracked tree stays clean.
+	if err := rig.EnsureLocalExcludePatterns(clonePath); err != nil {
+		style.PrintWarning("could not update local git excludes: %v", err)
 	}
 
 	// Install runtime settings in the shared polecats parent directory.
@@ -1448,9 +1448,9 @@ func (m *Manager) RepairWorktreeWithOptions(name string, force bool, opts AddOpt
 		style.PrintWarning("could not copy overlay files: %v", err)
 	}
 
-	// Ensure .gitignore has required Gas Town patterns
-	if err := rig.EnsureGitignorePatterns(newClonePath); err != nil {
-		style.PrintWarning("could not update .gitignore: %v", err)
+	// Keep worktree runtime ignores local so the tracked tree stays clean.
+	if err := rig.EnsureLocalExcludePatterns(newClonePath); err != nil {
+		style.PrintWarning("could not update local git excludes: %v", err)
 	}
 
 	// NOTE: Slash commands inherited from town level - no per-workspace copies needed.

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -1119,10 +1119,6 @@ func TestAddWithOptions_NoFilesAddedToRepo(t *testing.T) {
 		if strings.Contains(line, ".beads") {
 			continue
 		}
-		// .gitignore is expected - Gas Town patterns added
-		if strings.Contains(line, ".gitignore") {
-			continue
-		}
 		unexpected = append(unexpected, line)
 	}
 	if len(unexpected) > 0 {

--- a/internal/rig/overlay.go
+++ b/internal/rig/overlay.go
@@ -4,11 +4,22 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
 	"github.com/steveyegge/gastown/internal/style"
 )
+
+func gasTownIgnorePatterns() []string {
+	return []string{
+		".runtime/",
+		".claude/",
+		".logs/",
+		"__pycache__/",
+		"state.json",
+	}
+}
 
 // CopyOverlay copies files from <rigPath>/.runtime/overlay/ to the destination path.
 // This allows storing gitignored files (like .env) that services need at their root.
@@ -75,13 +86,7 @@ func EnsureGitignorePatterns(worktreePath string) error {
 	// but Cursor still creates .claude/ inside worktrees at runtime. The narrow
 	// .claude/commands/ pattern missed other Cursor-created files, causing gt done
 	// to fail with "uncommitted changes would be lost" on untracked .claude/ entries.
-	requiredPatterns := []string{
-		".runtime/",
-		".claude/",
-		".logs/",
-		"__pycache__/",
-		"state.json",
-	}
+	requiredPatterns := gasTownIgnorePatterns()
 
 	// Read existing gitignore content
 	var existingContent string
@@ -135,6 +140,88 @@ func EnsureGitignorePatterns(worktreePath string) error {
 	}
 
 	return nil
+}
+
+// EnsureLocalExcludePatterns writes the standard Gas Town ignore patterns to the
+// worktree-local git exclude file so the worktree stays clean without mutating a
+// tracked .gitignore.
+func EnsureLocalExcludePatterns(worktreePath string) error {
+	excludePath, err := gitLocalExcludePath(worktreePath)
+	if err != nil {
+		return err
+	}
+
+	if err := os.MkdirAll(filepath.Dir(excludePath), 0755); err != nil {
+		return fmt.Errorf("creating local exclude dir: %w", err)
+	}
+
+	var existingContent string
+	if data, err := os.ReadFile(excludePath); err == nil {
+		existingContent = string(data)
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("reading local exclude: %w", err)
+	}
+
+	var missing []string
+	for _, pattern := range gasTownIgnorePatterns() {
+		found := false
+		for _, line := range strings.Split(existingContent, "\n") {
+			line = strings.TrimSpace(line)
+			if matchesGitignorePattern(line, pattern) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			missing = append(missing, pattern)
+		}
+	}
+
+	if len(missing) == 0 {
+		return nil
+	}
+
+	f, err := os.OpenFile(excludePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return fmt.Errorf("opening local exclude: %w", err)
+	}
+	defer f.Close()
+
+	if existingContent != "" && !strings.HasSuffix(existingContent, "\n") {
+		if _, err := f.WriteString("\n"); err != nil {
+			return err
+		}
+	}
+	if existingContent != "" {
+		if _, err := f.WriteString("\n# Gas Town (added by gt)\n"); err != nil {
+			return err
+		}
+	}
+
+	for _, pattern := range missing {
+		if _, err := f.WriteString(pattern + "\n"); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func gitLocalExcludePath(worktreePath string) (string, error) {
+	cmd := exec.Command("git", "-C", worktreePath, "rev-parse", "--git-dir")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("resolving git dir: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	gitDir := strings.TrimSpace(string(out))
+	if gitDir == "" {
+		return "", fmt.Errorf("empty git dir for %s", worktreePath)
+	}
+	if !filepath.IsAbs(gitDir) {
+		gitDir = filepath.Join(worktreePath, gitDir)
+	}
+	return filepath.Join(gitDir, "info", "exclude"), nil
 }
 
 // matchesGitignorePattern checks if a gitignore line covers the required pattern.


### PR DESCRIPTION
## Summary

- stop polecat provisioning from mutating the tracked worktree `.gitignore`
- write Gas Town runtime ignore patterns to the worktree-local git exclude file instead
- tighten the polecat cleanliness regression test so `.gitignore` no longer counts as expected dirt

## Problem

Polecat provisioning currently calls `EnsureGitignorePatterns(...)`, which appends Gas Town runtime patterns into the worktree’s tracked `.gitignore`.

That can leave a polecat worktree dirty even when the polecat did no real code work, for example review-only or no-op tasks. Later cleanup/removal paths see ordinary uncommitted changes and refuse to clean up the polecat.

## Fix

For polecat worktrees only, switch provisioning to use the worktree-local git exclude file (`.git/info/exclude`) rather than editing tracked `.gitignore`.

This keeps runtime/tooling ignore rules local to the ephemeral worktree and avoids creating tracked repo dirt just from provisioning.

This change is intentionally narrow:
- polecats only
- no migration logic for old worktrees
- no changes to crew/refinery behavior

## Testing

- `go test ./internal/rig`
- `go test ./internal/polecat`

## Notes

This fixes the problem for newly provisioned polecat worktrees. Existing legacy polecats with already-dirty `.gitignore` are not automatically repaired by this PR.