### PR TITLE
feat(plugins): add gitignore-reconcile and submodule-commit plugins

### DIFF
--- a/plugins/gitignore-reconcile/plugin.md
+++ b/plugins/gitignore-reconcile/plugin.md
@@ -1,0 +1,138 @@
++++
+name = "gitignore-reconcile"
+description = "Auto-untrack files that are tracked but match an active .gitignore rule"
+version = 1
+
+[gate]
+type = "cooldown"
+duration = "6h"
+
+[tracking]
+labels = ["plugin:gitignore-reconcile", "category:git-hygiene"]
+digest = true
+
+[execution]
+timeout = "10m"
+notify_on_failure = true
+severity = "low"
++++
+
+# Gitignore Reconcile
+
+Scans all rig repos for files that are tracked in git but now match an active
+`.gitignore` rule. On clean `main` branches, runs `git rm --cached` to untrack
+them and commits. On dirty branches or active polecat worktrees, creates a
+chore bead instead to avoid interference.
+
+Root cause: `.gitignore` rules only block NEW files. Files committed before the
+rule was added continue to be tracked until manually untracked.
+
+## Step 1: Enumerate rig repos
+
+```bash
+RIG_JSON=$(gt rig list --json 2>/dev/null)
+if [ $? -ne 0 ] || [ -z "$RIG_JSON" ]; then
+  echo "SKIP: could not get rig list"
+  exit 0
+fi
+
+RIG_PATHS=$(echo "$RIG_JSON" | jq -r '.[] | select(.repo_path != null and .repo_path != "") | .repo_path // empty' 2>/dev/null)
+if [ -z "$RIG_PATHS" ]; then
+  echo "SKIP: no rigs with repo paths"
+  exit 0
+fi
+
+RIG_COUNT=$(echo "$RIG_PATHS" | wc -l | tr -d ' ')
+echo "Checking $RIG_COUNT rig repo(s) for tracked+ignored files"
+```
+
+## Step 2: For each rig repo, find and untrack gitignored files
+
+```bash
+TOTAL_UNTRACKED=0
+TOTAL_BEADS=0
+ERRORS=""
+
+while IFS= read -r REPO_PATH; do
+  [ -z "$REPO_PATH" ] && continue
+
+  if ! git -C "$REPO_PATH" rev-parse --git-dir >/dev/null 2>&1; then
+    continue
+  fi
+
+  echo ""
+  echo "=== $REPO_PATH ==="
+
+  # Find tracked files that match gitignore rules
+  IGNORED_TRACKED=$(git -C "$REPO_PATH" ls-files --ignored --exclude-standard --cached 2>/dev/null)
+  if [ -z "$IGNORED_TRACKED" ]; then
+    echo "  Clean — no tracked+ignored files"
+    continue
+  fi
+
+  FILE_COUNT=$(echo "$IGNORED_TRACKED" | wc -l | tr -d ' ')
+  echo "  Found $FILE_COUNT tracked+ignored file(s)"
+
+  # Check branch state
+  CURRENT_BRANCH=$(git -C "$REPO_PATH" branch --show-current 2>/dev/null)
+  IS_DIRTY=$(git -C "$REPO_PATH" status --porcelain 2>/dev/null | grep -v "^??" | head -1)
+  HAS_POLECATS=$(git -C "$REPO_PATH" branch 2>/dev/null | grep -E "^\+?\s+polecat/" | head -1)
+
+  if [ -n "$IS_DIRTY" ] || [ -n "$HAS_POLECATS" ] || [ "$CURRENT_BRANCH" != "main" ]; then
+    # Create a chore bead instead of interfering
+    REASON=""
+    [ -n "$IS_DIRTY" ] && REASON="dirty working tree"
+    [ -n "$HAS_POLECATS" ] && REASON="${REASON:+$REASON, }active polecat worktrees"
+    [ "$CURRENT_BRANCH" != "main" ] && REASON="${REASON:+$REASON, }not on main ($CURRENT_BRANCH)"
+    echo "  SKIP: $REASON — creating chore bead"
+    REPO_NAME=$(basename "$REPO_PATH")
+    bd create "gitignore-reconcile: $REPO_NAME has $FILE_COUNT tracked+ignored file(s)" \
+      -t chore \
+      -l "plugin:gitignore-reconcile,category:git-hygiene" \
+      -d "Repo: $REPO_PATH\nSkipped: $REASON\nFiles:\n$IGNORED_TRACKED" \
+      --silent 2>/dev/null || true
+    TOTAL_BEADS=$((TOTAL_BEADS + 1))
+    continue
+  fi
+
+  # Safe to untrack: clean main branch, no active polecats
+  echo "$IGNORED_TRACKED" | while IFS= read -r FILE; do
+    [ -z "$FILE" ] && continue
+    echo "  Untracking: $FILE"
+    git -C "$REPO_PATH" rm --cached "$FILE" 2>/dev/null || true
+  done
+
+  # Commit if anything was staged
+  STAGED=$(git -C "$REPO_PATH" diff --cached --name-only 2>/dev/null)
+  if [ -n "$STAGED" ]; then
+    COUNT=$(echo "$STAGED" | wc -l | tr -d ' ')
+    git -C "$REPO_PATH" commit -m "chore: untrack $COUNT file(s) now matched by .gitignore
+
+Auto-committed by gitignore-reconcile plugin.
+Files untracked:
+$(echo "$STAGED" | head -10)$([ $(echo "$STAGED" | wc -l) -gt 10 ] && echo "...and more")" \
+      --author="Gas Town <gastown@local>" 2>/dev/null || true
+    echo "  Committed untracking of $COUNT file(s)"
+    TOTAL_UNTRACKED=$((TOTAL_UNTRACKED + COUNT))
+
+    # Push (best effort)
+    git -C "$REPO_PATH" push origin main 2>/dev/null || echo "  WARN: push failed (committed locally)"
+  fi
+done
+```
+
+## Record Result
+
+```bash
+SUMMARY="gitignore-reconcile: $TOTAL_UNTRACKED file(s) untracked, $TOTAL_BEADS chore bead(s) created"
+echo ""
+echo "=== Gitignore Reconcile Summary ==="
+echo "$SUMMARY"
+
+RESULT="success"
+[ -n "$ERRORS" ] && RESULT="warning"
+
+bd create "$SUMMARY" -t chore --ephemeral \
+  -l "type:plugin-run,plugin:gitignore-reconcile,result:$RESULT" \
+  -d "$SUMMARY" --silent 2>/dev/null || true
+```

--- a/plugins/gitignore-reconcile/run.sh
+++ b/plugins/gitignore-reconcile/run.sh
@@ -1,0 +1,108 @@
+#!/usr/bin/env bash
+# gitignore-reconcile/run.sh — Auto-untrack files matched by .gitignore
+#
+# Scans all rig repos for tracked files that now match an active .gitignore
+# rule. On clean main branches: git rm --cached + commit. On dirty branches
+# or active polecat worktrees: creates a chore bead instead.
+
+set -euo pipefail
+
+log() { echo "[gitignore-reconcile] $*"; }
+
+# --- Step 1: Enumerate rig repos ---------------------------------------------
+
+RIG_JSON=$(gt rig list --json 2>/dev/null || true)
+if [ -z "$RIG_JSON" ]; then
+  log "SKIP: could not get rig list"
+  exit 0
+fi
+
+RIG_PATHS=$(echo "$RIG_JSON" | jq -r '.[] | select(.repo_path != null and .repo_path != "") | .repo_path // empty' 2>/dev/null || true)
+if [ -z "$RIG_PATHS" ]; then
+  log "SKIP: no rigs with repo paths"
+  exit 0
+fi
+
+RIG_COUNT=$(echo "$RIG_PATHS" | wc -l | tr -d ' ')
+log "Checking $RIG_COUNT rig repo(s) for tracked+ignored files"
+
+# --- Step 2: Process each rig -----------------------------------------------
+
+TOTAL_UNTRACKED=0
+TOTAL_BEADS=0
+
+while IFS= read -r REPO_PATH; do
+  [ -z "$REPO_PATH" ] && continue
+
+  if ! git -C "$REPO_PATH" rev-parse --git-dir >/dev/null 2>&1; then
+    log "SKIP: $REPO_PATH — not a git repo"
+    continue
+  fi
+
+  log ""
+  log "=== $REPO_PATH ==="
+
+  IGNORED_TRACKED=$(git -C "$REPO_PATH" ls-files --ignored --exclude-standard --cached 2>/dev/null || true)
+  if [ -z "$IGNORED_TRACKED" ]; then
+    log "  Clean"
+    continue
+  fi
+
+  FILE_COUNT=$(echo "$IGNORED_TRACKED" | wc -l | tr -d ' ')
+  log "  Found $FILE_COUNT tracked+ignored file(s)"
+
+  CURRENT_BRANCH=$(git -C "$REPO_PATH" branch --show-current 2>/dev/null || true)
+  IS_DIRTY=$(git -C "$REPO_PATH" status --porcelain 2>/dev/null | grep -v "^??" | head -1 || true)
+  HAS_POLECATS=$(git -C "$REPO_PATH" branch 2>/dev/null | grep -E "^\+?\s+polecat/" | head -1 || true)
+
+  if [ -n "$IS_DIRTY" ] || [ -n "$HAS_POLECATS" ] || [ "$CURRENT_BRANCH" != "main" ]; then
+    REASON=""
+    [ -n "$IS_DIRTY" ]       && REASON="dirty working tree"
+    [ -n "$HAS_POLECATS" ]   && REASON="${REASON:+$REASON, }active polecat worktrees"
+    [ "$CURRENT_BRANCH" != "main" ] && REASON="${REASON:+$REASON, }not on main ($CURRENT_BRANCH)"
+    log "  SKIP: $REASON — creating chore bead"
+    REPO_NAME=$(basename "$REPO_PATH")
+    bd create "gitignore-reconcile: $REPO_NAME has $FILE_COUNT tracked+ignored file(s)" \
+      -t chore \
+      -l "plugin:gitignore-reconcile,category:git-hygiene" \
+      -d "$(printf "Repo: %s\nSkipped: %s\nFiles:\n%s" "$REPO_PATH" "$REASON" "$(echo "$IGNORED_TRACKED" | head -20)")" \
+      --silent 2>/dev/null || true
+    TOTAL_BEADS=$((TOTAL_BEADS + 1))
+    continue
+  fi
+
+  # Untrack files
+  UNTRACKED_THIS=0
+  while IFS= read -r FILE; do
+    [ -z "$FILE" ] && continue
+    log "  Untracking: $FILE"
+    git -C "$REPO_PATH" rm --cached "$FILE" 2>/dev/null && UNTRACKED_THIS=$((UNTRACKED_THIS + 1)) || true
+  done <<< "$IGNORED_TRACKED"
+
+  STAGED=$(git -C "$REPO_PATH" diff --cached --name-only 2>/dev/null || true)
+  if [ -n "$STAGED" ]; then
+    COUNT=$(echo "$STAGED" | wc -l | tr -d ' ')
+    COMMIT_MSG="chore: untrack $COUNT file(s) now matched by .gitignore
+
+Auto-committed by gitignore-reconcile plugin."
+    git -C "$REPO_PATH" commit -m "$COMMIT_MSG" \
+      --author="Gas Town <gastown@local>" 2>/dev/null && \
+      log "  Committed untracking of $COUNT file(s)" || \
+      log "  WARN: commit failed"
+    TOTAL_UNTRACKED=$((TOTAL_UNTRACKED + COUNT))
+    git -C "$REPO_PATH" push origin main 2>/dev/null || log "  WARN: push failed (committed locally)"
+  fi
+done <<< "$RIG_PATHS"
+
+# --- Report ------------------------------------------------------------------
+
+log ""
+log "=== Summary ==="
+SUMMARY="gitignore-reconcile: $TOTAL_UNTRACKED file(s) untracked, $TOTAL_BEADS chore bead(s) created"
+log "$SUMMARY"
+
+bd create "$SUMMARY" -t chore --ephemeral \
+  -l "type:plugin-run,plugin:gitignore-reconcile,result:success" \
+  -d "$SUMMARY" --silent 2>/dev/null || true
+
+log "Done."

--- a/plugins/submodule-commit/plugin.md
+++ b/plugins/submodule-commit/plugin.md
@@ -1,0 +1,187 @@
++++
+name = "submodule-commit"
+description = "Auto-commit accumulated changes inside git submodules and update parent pointer"
+version = 1
+
+[gate]
+type = "cooldown"
+duration = "2h"
+
+[tracking]
+labels = ["plugin:submodule-commit", "category:git-hygiene"]
+digest = true
+
+[execution]
+timeout = "15m"
+notify_on_failure = true
+severity = "low"
+
+# Opt-in per rig via plugin frontmatter:
+# [plugin.submodule-commit]
+# enabled = true
+# commit_branch = "main"          # branch to commit on in each submodule
+# push_enabled = false            # push submodule commits (false = local only)
+# allowlist = []                  # empty = all submodules; ["path/to/sub"] = only those
++++
+
+# Submodule Commit
+
+Auto-commits accumulated changes inside git submodules and updates the parent
+repo's submodule pointer. Polecats only operate on parent repo worktrees and
+have no commit mandate for submodule repos — this plugin fills that gap.
+
+**Opt-in only.** Rigs must enable this plugin in their `plugin.md` frontmatter.
+Current enabled rigs: `lilypad_chat` (3 Bitbucket submodules).
+
+## Step 1: Find opt-in rigs with submodules
+
+```bash
+RIG_JSON=$(gt rig list --json 2>/dev/null || true)
+if [ -z "$RIG_JSON" ]; then
+  echo "SKIP: could not get rig list"
+  exit 0
+fi
+
+# Find rigs that have .gitmodules
+ENABLED_RIGS=()
+while IFS= read -r REPO_PATH; do
+  [ -z "$REPO_PATH" ] && continue
+  [ ! -f "$REPO_PATH/.gitmodules" ] && continue
+  # Check rig plugin config for opt-in
+  RIG_NAME=$(basename "$REPO_PATH")
+  PLUGIN_CONFIG=$(gt rig show "$RIG_NAME" --json 2>/dev/null | jq -r '.plugins["submodule-commit"].enabled // false' 2>/dev/null || echo "false")
+  if [ "$PLUGIN_CONFIG" = "true" ]; then
+    ENABLED_RIGS+=("$REPO_PATH")
+  fi
+done < <(echo "$RIG_JSON" | jq -r '.[] | select(.repo_path != null) | .repo_path // empty' 2>/dev/null)
+
+if [ ${#ENABLED_RIGS[@]} -eq 0 ]; then
+  echo "SKIP: no opt-in rigs with submodules found"
+  exit 0
+fi
+
+echo "Processing ${#ENABLED_RIGS[@]} rig(s) with submodules"
+```
+
+## Step 2: For each opt-in rig, process its submodules
+
+```bash
+TOTAL_COMMITTED=0
+TOTAL_PUSHED=0
+TOTAL_PARENT_UPDATED=0
+ERRORS=""
+
+for REPO_PATH in "${ENABLED_RIGS[@]}"; do
+  echo ""
+  echo "=== $REPO_PATH ==="
+
+  RIG_NAME=$(basename "$REPO_PATH")
+
+  # Get plugin config
+  RIG_CONFIG=$(gt rig show "$RIG_NAME" --json 2>/dev/null | jq -r '.plugins["submodule-commit"] // {}' 2>/dev/null || echo "{}")
+  COMMIT_BRANCH=$(echo "$RIG_CONFIG" | jq -r '.commit_branch // "main"')
+  PUSH_ENABLED=$(echo "$RIG_CONFIG" | jq -r '.push_enabled // false')
+  ALLOWLIST=$(echo "$RIG_CONFIG" | jq -r '.allowlist // [] | .[]' 2>/dev/null || true)
+
+  # Parse .gitmodules for submodule paths
+  SUBMODULE_PATHS=$(git -C "$REPO_PATH" config --file .gitmodules --get-regexp 'submodule\..*\.path' 2>/dev/null | awk '{print $2}' || true)
+
+  PARENT_CHANGED=false
+
+  while IFS= read -r SUB_PATH; do
+    [ -z "$SUB_PATH" ] && continue
+
+    # Apply allowlist filter if set
+    if [ -n "$ALLOWLIST" ]; then
+      MATCH=false
+      while IFS= read -r ALLOWED; do
+        [ "$SUB_PATH" = "$ALLOWED" ] && MATCH=true && break
+      done <<< "$ALLOWLIST"
+      $MATCH || continue
+    fi
+
+    FULL_SUB="$REPO_PATH/$SUB_PATH"
+    if [ ! -d "$FULL_SUB/.git" ] && [ ! -f "$FULL_SUB/.git" ]; then
+      echo "  SKIP: $SUB_PATH — not initialized"
+      continue
+    fi
+
+    # Check for uncommitted changes in submodule
+    SUB_DIRTY=$(git -C "$FULL_SUB" status --porcelain 2>/dev/null | head -1 || true)
+    if [ -z "$SUB_DIRTY" ]; then
+      echo "  $SUB_PATH: clean"
+      continue
+    fi
+
+    SUB_BRANCH=$(git -C "$FULL_SUB" branch --show-current 2>/dev/null || true)
+    if [ -z "$SUB_BRANCH" ]; then
+      echo "  SKIP: $SUB_PATH — detached HEAD, skipping"
+      continue
+    fi
+
+    echo "  $SUB_PATH: dirty (branch=$SUB_BRANCH), committing..."
+
+    # Commit changes
+    git -C "$FULL_SUB" add -A 2>/dev/null || true
+    STAGED=$(git -C "$FULL_SUB" diff --cached --name-only 2>/dev/null | wc -l | tr -d ' ')
+    if [ "$STAGED" -gt 0 ]; then
+      git -C "$FULL_SUB" commit -m "chore: accumulated changes [skip ci]
+
+Auto-committed by submodule-commit plugin ($STAGED file(s))." \
+        --author="Gas Town <gastown@local>" 2>/dev/null && \
+        echo "    Committed $STAGED file(s)" && \
+        TOTAL_COMMITTED=$((TOTAL_COMMITTED + 1)) || \
+        { echo "    WARN: commit failed"; continue; }
+
+      # Push (best effort, || true)
+      if [ "$PUSH_ENABLED" = "true" ]; then
+        git -C "$FULL_SUB" push origin "$SUB_BRANCH" 2>/dev/null && \
+          TOTAL_PUSHED=$((TOTAL_PUSHED + 1)) || \
+          echo "    WARN: push failed (local commit preserved)"
+      fi
+
+      PARENT_CHANGED=true
+    fi
+  done <<< "$SUBMODULE_PATHS"
+
+  # Update parent repo submodule pointer if any submodule changed
+  if $PARENT_CHANGED; then
+    PARENT_BRANCH=$(git -C "$REPO_PATH" branch --show-current 2>/dev/null || true)
+    if [ "$PARENT_BRANCH" = "main" ]; then
+      PARENT_DIRTY=$(git -C "$REPO_PATH" status --porcelain 2>/dev/null | grep -v "^??" | head -1 || true)
+      if [ -z "$PARENT_DIRTY" ]; then
+        git -C "$REPO_PATH" add -A -- '*.gitmodules' $(git -C "$REPO_PATH" status --short 2>/dev/null | awk '{print $2}') 2>/dev/null || true
+        PARENT_STAGED=$(git -C "$REPO_PATH" diff --cached --name-only 2>/dev/null | head -1 || true)
+        if [ -n "$PARENT_STAGED" ]; then
+          git -C "$REPO_PATH" commit -m "chore: update submodule pointers [skip ci]
+
+Auto-committed by submodule-commit plugin." \
+            --author="Gas Town <gastown@local>" 2>/dev/null && \
+            TOTAL_PARENT_UPDATED=$((TOTAL_PARENT_UPDATED + 1)) || true
+          git -C "$REPO_PATH" push origin main 2>/dev/null || echo "  WARN: parent push failed (local commit preserved)"
+        fi
+      else
+        echo "  SKIP: parent repo dirty, not updating submodule pointer"
+      fi
+    else
+      echo "  SKIP: parent repo on $PARENT_BRANCH (not main), not updating pointer"
+    fi
+  fi
+done
+```
+
+## Record Result
+
+```bash
+SUMMARY="submodule-commit: $TOTAL_COMMITTED submodule(s) committed, $TOTAL_PUSHED pushed, $TOTAL_PARENT_UPDATED parent pointer(s) updated"
+echo ""
+echo "=== Submodule Commit Summary ==="
+echo "$SUMMARY"
+
+RESULT="success"
+[ -n "$ERRORS" ] && RESULT="warning"
+
+bd create "$SUMMARY" -t chore --ephemeral \
+  -l "type:plugin-run,plugin:submodule-commit,result:$RESULT" \
+  -d "$SUMMARY" --silent 2>/dev/null || true
+```

--- a/plugins/submodule-commit/run.sh
+++ b/plugins/submodule-commit/run.sh
@@ -1,0 +1,170 @@
+#!/usr/bin/env bash
+# submodule-commit/run.sh — Auto-commit accumulated changes in git submodules.
+#
+# Reads .gitmodules in opt-in rigs, commits any accumulated changes in each
+# submodule on a known branch, pushes with || true (local commit is priority),
+# then updates the parent repo's submodule pointer on main.
+#
+# Opt-in per rig: set plugins.submodule-commit.enabled=true in rig config.
+
+set -euo pipefail
+
+log() { echo "[submodule-commit] $*"; }
+
+# --- Step 1: Find opt-in rigs with submodules --------------------------------
+
+RIG_JSON=$(gt rig list --json 2>/dev/null || true)
+if [ -z "$RIG_JSON" ]; then
+  log "SKIP: could not get rig list"
+  exit 0
+fi
+
+declare -a ENABLED_RIGS
+while IFS= read -r REPO_PATH; do
+  [ -z "$REPO_PATH" ] && continue
+  [ ! -f "$REPO_PATH/.gitmodules" ] && continue
+  RIG_NAME=$(basename "$REPO_PATH")
+  PLUGIN_ENABLED=$(gt rig show "$RIG_NAME" --json 2>/dev/null \
+    | jq -r '.plugins["submodule-commit"].enabled // false' 2>/dev/null || echo "false")
+  if [ "$PLUGIN_ENABLED" = "true" ]; then
+    ENABLED_RIGS+=("$REPO_PATH")
+    log "Opt-in rig: $REPO_PATH"
+  fi
+done < <(echo "$RIG_JSON" | jq -r '.[] | select(.repo_path != null) | .repo_path // empty' 2>/dev/null || true)
+
+if [ ${#ENABLED_RIGS[@]} -eq 0 ]; then
+  log "SKIP: no opt-in rigs with submodules"
+  exit 0
+fi
+
+log "Processing ${#ENABLED_RIGS[@]} opt-in rig(s)"
+
+# --- Step 2: Process each rig ------------------------------------------------
+
+TOTAL_COMMITTED=0
+TOTAL_PUSHED=0
+TOTAL_PARENT_UPDATED=0
+
+for REPO_PATH in "${ENABLED_RIGS[@]}"; do
+  log ""
+  log "=== $REPO_PATH ==="
+
+  RIG_NAME=$(basename "$REPO_PATH")
+
+  # Get plugin config
+  RIG_CONFIG=$(gt rig show "$RIG_NAME" --json 2>/dev/null \
+    | jq -r '.plugins["submodule-commit"] // {}' 2>/dev/null || echo "{}")
+  PUSH_ENABLED=$(echo "$RIG_CONFIG" | jq -r '.push_enabled // false')
+  ALLOWLIST=$(echo "$RIG_CONFIG" | jq -r '.allowlist // [] | .[]' 2>/dev/null || true)
+
+  SUBMODULE_PATHS=$(git -C "$REPO_PATH" config --file .gitmodules --get-regexp 'submodule\..*\.path' 2>/dev/null \
+    | awk '{print $2}' || true)
+
+  if [ -z "$SUBMODULE_PATHS" ]; then
+    log "  No submodules found in .gitmodules"
+    continue
+  fi
+
+  PARENT_CHANGED=false
+
+  while IFS= read -r SUB_PATH; do
+    [ -z "$SUB_PATH" ] && continue
+
+    # Apply allowlist filter
+    if [ -n "$ALLOWLIST" ]; then
+      MATCH=false
+      while IFS= read -r ALLOWED; do
+        [ "$SUB_PATH" = "$ALLOWED" ] && { MATCH=true; break; }
+      done <<< "$ALLOWLIST"
+      $MATCH || { log "  SKIP: $SUB_PATH — not in allowlist"; continue; }
+    fi
+
+    FULL_SUB="$REPO_PATH/$SUB_PATH"
+    if [ ! -d "$FULL_SUB" ]; then
+      log "  SKIP: $SUB_PATH — directory not found"
+      continue
+    fi
+    if [ ! -d "$FULL_SUB/.git" ] && [ ! -f "$FULL_SUB/.git" ]; then
+      log "  SKIP: $SUB_PATH — not initialized (run git submodule update --init)"
+      continue
+    fi
+
+    SUB_DIRTY=$(git -C "$FULL_SUB" status --porcelain 2>/dev/null | head -1 || true)
+    if [ -z "$SUB_DIRTY" ]; then
+      log "  $SUB_PATH: clean"
+      continue
+    fi
+
+    SUB_BRANCH=$(git -C "$FULL_SUB" branch --show-current 2>/dev/null || true)
+    if [ -z "$SUB_BRANCH" ]; then
+      log "  SKIP: $SUB_PATH — detached HEAD"
+      continue
+    fi
+
+    log "  $SUB_PATH: has changes (branch=$SUB_BRANCH)"
+
+    git -C "$FULL_SUB" add -A 2>/dev/null || true
+    STAGED_COUNT=$(git -C "$FULL_SUB" diff --cached --name-only 2>/dev/null | wc -l | tr -d ' ')
+
+    if [ "$STAGED_COUNT" -gt 0 ]; then
+      git -C "$FULL_SUB" commit \
+        -m "chore: accumulated changes [skip ci]
+
+Auto-committed by submodule-commit plugin ($STAGED_COUNT file(s))." \
+        --author="Gas Town <gastown@local>" 2>/dev/null && {
+          log "    Committed $STAGED_COUNT file(s)"
+          TOTAL_COMMITTED=$((TOTAL_COMMITTED + 1))
+          PARENT_CHANGED=true
+        } || { log "    WARN: commit failed"; continue; }
+
+      if [ "$PUSH_ENABLED" = "true" ]; then
+        git -C "$FULL_SUB" push origin "$SUB_BRANCH" 2>/dev/null && \
+          { log "    Pushed to origin/$SUB_BRANCH"; TOTAL_PUSHED=$((TOTAL_PUSHED + 1)); } || \
+          log "    WARN: push failed (local commit preserved)"
+      fi
+    fi
+  done <<< "$SUBMODULE_PATHS"
+
+  # Update parent pointer on main if submodules changed
+  if $PARENT_CHANGED; then
+    PARENT_BRANCH=$(git -C "$REPO_PATH" branch --show-current 2>/dev/null || true)
+    if [ "$PARENT_BRANCH" != "main" ]; then
+      log "  SKIP parent pointer update: on $PARENT_BRANCH (not main)"
+      continue
+    fi
+
+    PARENT_UNSTAGED=$(git -C "$REPO_PATH" status --porcelain 2>/dev/null | grep -v "^??" | head -1 || true)
+    if [ -n "$PARENT_UNSTAGED" ]; then
+      log "  SKIP parent pointer update: parent has other uncommitted changes"
+      continue
+    fi
+
+    # Stage only submodule pointer changes
+    git -C "$REPO_PATH" add -u 2>/dev/null || true
+    PARENT_STAGED=$(git -C "$REPO_PATH" diff --cached --name-only 2>/dev/null || true)
+    if [ -n "$PARENT_STAGED" ]; then
+      git -C "$REPO_PATH" commit \
+        -m "chore: update submodule pointers [skip ci]
+
+Auto-committed by submodule-commit plugin." \
+        --author="Gas Town <gastown@local>" 2>/dev/null && {
+          log "  Parent pointer updated"
+          TOTAL_PARENT_UPDATED=$((TOTAL_PARENT_UPDATED + 1))
+        } || log "  WARN: parent pointer commit failed"
+      git -C "$REPO_PATH" push origin main 2>/dev/null || log "  WARN: parent push failed (local commit preserved)"
+    fi
+  fi
+done
+
+# --- Report ------------------------------------------------------------------
+
+log ""
+log "=== Summary ==="
+SUMMARY="submodule-commit: $TOTAL_COMMITTED submodule(s) committed, $TOTAL_PUSHED pushed, $TOTAL_PARENT_UPDATED parent pointer(s) updated"
+log "$SUMMARY"
+
+bd create "$SUMMARY" -t chore --ephemeral \
+  -l "type:plugin-run,plugin:submodule-commit,result:success" \
+  -d "$SUMMARY" --silent 2>/dev/null || true
+
+log "Done."


### PR DESCRIPTION
## Summary

Two new automated git hygiene plugins that address recurring problems Gas Town doesn't currently fix automatically:

### gitignore-reconcile (6h cooldown)
- Scans all rig repos for tracked files matching an active .gitignore rule
- Root cause: .gitignore only blocks NEW files; files committed before the rule was added stay tracked
- On clean main branches: runs git rm --cached + commits the untracking
- On dirty/polecat branches: creates a chore bead instead to avoid interference

### submodule-commit (2h cooldown, opt-in per rig)
- Reads .gitmodules in opt-in rigs, checks each submodule for uncommitted changes
- Commits on the current branch with [skip ci], pushes with || true (local commit is priority)
- Updates parent repo submodule pointer when submodules were committed
- Opt-in via rig plugin config: plugins[submodule-commit].enabled = true

## Why

Polecats only operate on parent repo worktrees. Submodules accumulate real code changes with no automated commit workflow. Similarly, .gitignore rules added after first commit leave files permanently tracked without intervention.

## Test plan
- [ ] gitignore-reconcile: runs clean on repos with no tracked+ignored files
- [ ] gitignore-reconcile: untracks and commits files on clean main
- [ ] gitignore-reconcile: creates chore bead on dirty/polecat branches
- [ ] submodule-commit: skips rigs without opt-in config
- [ ] submodule-commit: commits submodule changes and updates parent pointer

Generated with Claude Code