### PR TITLE
fix: skip Escape keystroke when nudging Gemini (cancels generation)

### DIFF
--- a/internal/cmd/nudge.go
+++ b/internal/cmd/nudge.go
@@ -265,7 +265,16 @@ func deliverNudge(t *tmux.Tmux, sessionName, message, sender string) error {
 		return nil
 
 	default: // NudgeModeImmediate
-		return t.NudgeSession(sessionName, prefixedMessage)
+		opts := tmux.NudgeOpts{}
+		// Check if the target agent uses Escape as cancel (e.g., Gemini CLI).
+		// For these agents, skip the Escape keystroke to avoid canceling
+		// in-flight generation. (GH#gt-wasn)
+		if agentName, err := t.GetEnvironment(sessionName, "GT_AGENT"); err == nil && agentName != "" {
+			if preset := config.GetAgentPresetByName(agentName); preset != nil && preset.EscapeCancelsRequest {
+				opts.SkipEscape = true
+			}
+		}
+		return t.NudgeSessionWithOpts(sessionName, prefixedMessage, opts)
 	}
 }
 

--- a/internal/cmd/nudge_poller.go
+++ b/internal/cmd/nudge_poller.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/workspace"
@@ -69,6 +70,16 @@ func runNudgePoller(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("session %q not found", sessionName)
 	}
 
+	// Resolve nudge options once at startup: if the target agent uses Escape
+	// as cancel (e.g., Gemini CLI), skip the Escape keystroke during delivery
+	// to avoid canceling in-flight generation. (GH#gt-wasn)
+	nudgeOpts := tmux.NudgeOpts{}
+	if agentName, err := t.GetEnvironment(sessionName, "GT_AGENT"); err == nil && agentName != "" {
+		if preset := config.GetAgentPresetByName(agentName); preset != nil && preset.EscapeCancelsRequest {
+			nudgeOpts.SkipEscape = true
+		}
+	}
+
 	// Set up signal handling for graceful shutdown.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGTERM, syscall.SIGINT)
@@ -111,7 +122,7 @@ func runNudgePoller(cmd *cobra.Command, args []string) error {
 			}
 
 			formatted := nudge.FormatForInjection(drained)
-			if err := t.NudgeSession(sessionName, formatted); err != nil {
+			if err := t.NudgeSessionWithOpts(sessionName, formatted, nudgeOpts); err != nil {
 				fmt.Fprintf(os.Stderr, "nudge-poller: injection error for %s: %v\n", sessionName, err)
 			}
 		}

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -143,6 +143,15 @@ type AgentPresetInfo struct {
 	// false, a background nudge-poller process is started to periodically drain
 	// the queue and inject via tmux.
 	HasTurnBoundaryDrain bool `json:"has_turn_boundary_drain,omitempty"`
+
+	// EscapeCancelsRequest indicates that sending an Escape keystroke to this
+	// agent cancels its in-flight generation. NudgeSession normally sends
+	// Escape (step 5) to exit vim INSERT mode — harmless for bash/Claude Code,
+	// but destructive for agents like Gemini CLI where Escape aborts the
+	// active request. When true, NudgeSessionWithOpts skips the Escape
+	// keystroke and the 600ms readline timeout that follows it.
+	EscapeCancelsRequest bool `json:"escape_cancels_request,omitempty"`
+
 	// ACP is the configuration for ACP (Agent Communication Protocol) support.
 	// nil means the agent does not support ACP.
 	ACP *ACPConfig `json:"acp,omitempty"`
@@ -249,8 +258,9 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		HooksProvider:     "gemini",
 		HooksDir:          ".gemini",
 		HooksSettingsFile: "settings.json",
-		ReadyDelayMs:      5000,
-		InstructionsFile:  "AGENTS.md",
+		ReadyDelayMs:         5000,
+		InstructionsFile:     "AGENTS.md",
+		EscapeCancelsRequest: true, // Gemini CLI uses Escape to abort active generation
 	},
 	AgentCodex: {
 		Name:                AgentCodex,

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1404,6 +1404,21 @@ func (t *Tmux) sendKeysLiteralWithRetry(target, text string, timeout time.Durati
 // queue up and execute one at a time. This prevents garbled input when
 // SessionStart hooks and nudges arrive simultaneously.
 func (t *Tmux) NudgeSession(session, message string) error {
+	return t.NudgeSessionWithOpts(session, message, NudgeOpts{})
+}
+
+// NudgeOpts controls optional behavior for nudge delivery.
+type NudgeOpts struct {
+	// SkipEscape omits the Escape keystroke (step 5) and the 600ms readline
+	// timeout (step 6) from the delivery protocol. Set this for agents where
+	// Escape cancels in-flight generation (e.g., Gemini CLI) rather than
+	// harmlessly exiting vim INSERT mode.
+	SkipEscape bool
+}
+
+// NudgeSessionWithOpts is like NudgeSession but accepts delivery options.
+// See NudgeOpts for available options.
+func (t *Tmux) NudgeSessionWithOpts(session, message string, opts NudgeOpts) error {
 	// Serialize nudges to this session to prevent interleaving.
 	// Use a timed lock to avoid permanent blocking if a previous nudge hung.
 	if !acquireNudgeLock(session, nudgeLockTimeout) {
@@ -1437,15 +1452,17 @@ func (t *Tmux) NudgeSession(session, message string) error {
 	// 4. Wait 500ms for text delivery to complete (tested, required)
 	time.Sleep(500 * time.Millisecond)
 
-	// 5. Send Escape to exit vim INSERT mode if enabled (harmless in normal mode)
-	// See: https://github.com/anthropics/gastown/issues/307
-	_, _ = t.run("send-keys", "-t", target, "Escape")
+	if !opts.SkipEscape {
+		// 5. Send Escape to exit vim INSERT mode if enabled (harmless in normal mode)
+		// See: https://github.com/anthropics/gastown/issues/307
+		_, _ = t.run("send-keys", "-t", target, "Escape")
 
-	// 6. Wait 600ms — must exceed bash readline's keyseq-timeout (500ms default)
-	// so ESC is processed alone, not as a meta prefix for the subsequent Enter.
-	// Without this, ESC+Enter within 500ms becomes M-Enter (meta-return) which
-	// does NOT submit the line.
-	time.Sleep(600 * time.Millisecond)
+		// 6. Wait 600ms — must exceed bash readline's keyseq-timeout (500ms default)
+		// so ESC is processed alone, not as a meta prefix for the subsequent Enter.
+		// Without this, ESC+Enter within 500ms becomes M-Enter (meta-return) which
+		// does NOT submit the line.
+		time.Sleep(600 * time.Millisecond)
+	}
 
 	// 7. Send Enter with retry (critical for message submission)
 	var lastErr error


### PR DESCRIPTION
## Summary

- NudgeSession sends an Escape key (step 5) to exit vim INSERT mode before Enter. This is harmless for Claude Code/bash but **cancels in-flight generation** in Gemini CLI, causing "request canceled" when nudged via immediate mode during active work.
- Adds `EscapeCancelsRequest` field to `AgentPresetInfo` (set for Gemini) and `NudgeSessionWithOpts` to conditionally skip the Escape keystroke + 600ms readline timeout.
- Applied in both the `deliverNudge` immediate mode path and the `nudge-poller` drain path.

**Note:** Immediate mode works fine when Gemini is idle (Escape has no effect). The bug only manifests when nudging a busy Gemini session.

## Test plan

- [ ] Nudge a busy Gemini session with `--mode=immediate` — should no longer cancel generation
- [ ] Nudge an idle Gemini session with `--mode=immediate` — should still deliver successfully
- [ ] Nudge a Claude session with `--mode=immediate` — unchanged behavior (Escape still sent)
- [ ] Nudge-poller drain to Gemini session — should skip Escape
- [ ] Build all rigs clean after syncing changes

Fixes: gt-wasn

🤖 Generated with [Claude Code](https://claude.com/claude-code)