### PR TITLE
fix: exclude views from compactor-dog integrity check

### DIFF
--- a/plugins/compactor-dog/run.sh
+++ b/plugins/compactor-dog/run.sh
@@ -236,7 +236,7 @@ for entry in "${CANDIDATES[@]}"; do
   # Step 3a: Record pre-flight row counts for integrity verification.
   log "  Recording pre-flight row counts..."
   PRE_TABLES=$(dolt_query "$DB" \
-    "SELECT table_name FROM information_schema.tables WHERE table_schema = '$DB' AND table_name NOT LIKE 'dolt_%'")
+    "SELECT table_name FROM information_schema.tables WHERE table_schema = '$DB' AND table_name NOT LIKE 'dolt_%' AND table_type = 'BASE TABLE'")
 
   # Clear pre-counts file for this database.
   : > "$PRE_COUNTS_FILE"
@@ -357,7 +357,7 @@ for entry in "${CANDIDATES[@]}"; do
 
   # Check for missing tables (tables present before but gone after).
   POST_TABLES=$(dolt_query "$DB" \
-    "SELECT table_name FROM information_schema.tables WHERE table_schema = '$DB' AND table_name NOT LIKE 'dolt_%'")
+    "SELECT table_name FROM information_schema.tables WHERE table_schema = '$DB' AND table_name NOT LIKE 'dolt_%' AND table_type = 'BASE TABLE'")
   while IFS=$'\t' read -r TABLE _; do
     [[ -z "$TABLE" ]] && continue
     if ! printf '%s' "$POST_TABLES" | grep -qx "$TABLE"; then


### PR DESCRIPTION
## Summary
- **Exclude views from integrity check**: `blocked_issues` and `ready_issues` are views, not tables. Their row counts change during soft-reset, causing false integrity failures. Added `AND table_type = 'BASE TABLE'` filter to `information_schema` queries in `run.sh`.

## Test plan
- [ ] Run `./plugins/compactor-dog/run.sh --dry-run` against a DB with views — should not list views in pre-flight
- [ ] Run full compaction on a test DB with views — integrity check should pass

Replaces #2729 (clean single-commit PR from dedicated branch).

🤖 Generated with [Claude Code](https://claude.com/claude-code)