### PR TITLE
fix: nudge mayor on merge failure, not just success

### DIFF
--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -1053,6 +1053,15 @@ func (e *Engineer) HandleMRInfoFailure(mr *MRInfo, result ProcessResult) {
 		_, _ = fmt.Fprintf(e.output, "[Engineer] Nudged %s about merge failure (%s)\n", polecatName, failureType)
 	}
 
+	// Nudge mayor about merge failure so dispatcher can unblock or reassign
+	// dependent work immediately. Mirrors the success nudge in HandleMRInfoSuccess.
+	mayorMsg := fmt.Sprintf("MERGE_FAILED: %s issue=%s branch=%s type=%s", mr.ID, mr.SourceIssue, mr.Branch, failureType)
+	mayorCmd := exec.Command("gt", "nudge", "mayor/", mayorMsg)
+	mayorCmd.Dir = e.workDir
+	if err := mayorCmd.Run(); err != nil {
+		_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to nudge mayor about merge failure: %v\n", err)
+	}
+
 	// If this was a conflict, create a conflict-resolution task for dispatch
 	// and block the MR until the task is resolved (non-blocking delegation)
 	if result.Conflict {


### PR DESCRIPTION
## Summary

- Refinery's `HandleMRInfoFailure` now nudges mayor with `MERGE_FAILED: <mr-id> issue=<issue> branch=<branch> type=<failure-type>` after notifying the polecat
- Mirrors the existing success path (`MERGED` nudge in `HandleMRInfoSuccess`)
- Skipped for slot timeouts (transient, auto-retried) and branch-not-found (already cleaned up)
- Enables dispatcher to unblock or reassign dependent work immediately on failure

## Test plan

- [ ] Trigger a merge failure (conflict or test failure) — verify mayor receives `MERGE_FAILED` nudge
- [ ] Trigger a successful merge — verify existing `MERGED` nudge still works
- [ ] Trigger a slot timeout — verify no mayor nudge (transient, auto-retry)
- [ ] Build clean

Fixes: gt-cynf

🤖 Generated with [Claude Code](https://claude.com/claude-code)