### PR TITLE
fix: separate export statements in Gemini hook templates

### DIFF
--- a/internal/hooks/templates/gemini/settings-autonomous.json
+++ b/internal/hooks/templates/gemini/settings-autonomous.json
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" GT_SESSION_ID=${GT_SESSION_ID:-$(uuidgen)} GT_HOOK_SOURCE=startup && gt prime --hook && gt mail check --inject"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && export GT_SESSION_ID=\"${GT_SESSION_ID:-$(uuidgen)}\" && export GT_HOOK_SOURCE=startup && gt prime --hook && gt mail check --inject"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" GT_HOOK_SOURCE=compact && gt prime --hook"
+            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && export GT_HOOK_SOURCE=compact && gt prime --hook"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- **Fix PATH quoting in Gemini hooks**: The `SessionStart` and `PreCompress` hooks in the autonomous Gemini template packed multiple variable assignments into a single `export` line (`export PATH="..." GT_SESSION_ID=${...} GT_HOOK_SOURCE=...`). When Gemini CLI wraps the command, the nested quoting around the PATH value interacts with the unquoted `$(uuidgen)` subshell, causing parse errors on session start.
- **Separate each export with `&&`** so each quoting context is isolated — matches the pattern used by Claude/Cursor templates and the dynamic hook generator in `config.go`.

Fixes: gt-6y2s

## Test plan
- [ ] Start a Gemini crew session — SessionStart hook should execute without PATH export errors
- [ ] Trigger context compaction in a Gemini session — PreCompress hook should fire cleanly
- [ ] Verify `GT_SESSION_ID` and `GT_HOOK_SOURCE` env vars are set correctly after hook runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)