### PR TITLE
feat: inject prior attempt context when re-dispatching issue to polecat

### DIFF
--- a/internal/beads/beads_mr.go
+++ b/internal/beads/beads_mr.go
@@ -45,3 +45,26 @@ func (b *Beads) findMRForBranch(branch string, skipClosed bool) (*Issue, error) 
 
 	return nil, nil
 }
+
+// FindOpenMRsForIssue returns all open merge-request beads whose source_issue
+// matches the given issue ID. Used to find prior attempts when re-dispatching
+// an issue and to supersede old MRs when a new one is created.
+func (b *Beads) FindOpenMRsForIssue(issueID string) ([]*Issue, error) {
+	needle := "source_issue: " + issueID + "\n"
+
+	issues, err := b.ListMergeRequests(ListOptions{
+		Status: "open",
+		Label:  "gt:merge-request",
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	var matches []*Issue
+	for _, issue := range issues {
+		if strings.Contains(issue.Description, needle) {
+			matches = append(matches, issue)
+		}
+	}
+	return matches, nil
+}

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -289,6 +289,15 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 		if spawnInfo.BaseBranch != "" && spawnInfo.BaseBranch != "main" {
 			allVars = append(allVars, fmt.Sprintf("base_branch=%s", spawnInfo.BaseBranch))
 		}
+
+		// GH#gt-zqvj: Inject prior attempt context when re-dispatching an issue
+		// that already has an open MR from a previous polecat. The new polecat
+		// gets the old branch name so it can cherry-pick prior work instead of
+		// starting from scratch.
+		if priorVars := lookupPriorAttempt(beadsDir, params.BeadID); len(priorVars) > 0 {
+			allVars = append(allVars, priorVars...)
+			fmt.Printf("  %s Prior attempt found — context injected for polecat\n", style.Dim.Render("↻"))
+		}
 		formulaResult, err := InstantiateFormulaOnBead(context.Background(), params.FormulaName, params.BeadID, info.Title, hookWorkDir, townRoot, true, allVars)
 		if err != nil {
 			if params.FormulaFailFatal {

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -1181,3 +1181,30 @@ func updateAgentMode(agentID, mode, workDir, townBeadsDir string) {
 		fmt.Fprintf(os.Stderr, "Warning: couldn't set agent %s mode: %v\n", agentBeadID, err)
 	}
 }
+
+// lookupPriorAttempt checks if there are existing open MRs for the given issue.
+// If found, returns formula variables with the prior branch name so the new
+// polecat can cherry-pick or reference prior work instead of starting from scratch.
+// Returns nil if no prior attempt exists. (GH#gt-zqvj)
+func lookupPriorAttempt(beadsDir, issueID string) []string {
+	bd := beads.New(beadsDir)
+	mrs, err := bd.FindOpenMRsForIssue(issueID)
+	if err != nil || len(mrs) == 0 {
+		return nil
+	}
+
+	// Use the most recent MR (last in list) as the prior attempt.
+	prior := mrs[len(mrs)-1]
+	fields := beads.ParseMRFields(prior)
+	if fields == nil || fields.Branch == "" {
+		return nil
+	}
+
+	vars := []string{
+		fmt.Sprintf("prior_branch=%s", fields.Branch),
+	}
+	if fields.CloseReason != "" {
+		vars = append(vars, fmt.Sprintf("prior_failure=%s", fields.CloseReason))
+	}
+	return vars
+}

--- a/internal/formula/formulas/mol-polecat-work.formula.toml
+++ b/internal/formula/formulas/mol-polecat-work.formula.toml
@@ -150,18 +150,24 @@ git status
 git branch --show-current
 ```
 
-**2. Check for a prior branch from a rejected MR:**
+**2. Check for a prior attempt branch:**
 
-If the bead notes contain "MERGE REJECTION" with a branch name, check if that
-branch still exists on the remote. Reusing it preserves all previous work:
+If `{{prior_branch}}` is set, a previous polecat attempted this issue. Reuse
+their work instead of starting from scratch — cherry-pick their commits onto
+your fresh branch:
 ```bash
 git fetch origin
-# Check for prior branch
-git branch -r | grep <prior-branch>
-# If found, check it out:
-git checkout -b <prior-branch> origin/<prior-branch>
-git rebase origin/{{base_branch}}
+# Create your own fresh branch (isolation guarantee)
+git checkout -b polecat/<name> origin/{{base_branch}}
+
+# If prior_branch is set, cherry-pick prior work:
+# git log origin/{{prior_branch}} --oneline --not origin/{{base_branch}}
+# git cherry-pick <commits>
+# Or if all commits are good:
+# git cherry-pick origin/{{base_branch}}..origin/{{prior_branch}}
 ```
+Prior failure reason (if known): {{prior_failure}}
+Fix the issues from the prior attempt rather than reimplementing from scratch.
 
 **If no prior branch, create a fresh one:**
 ```bash
@@ -677,4 +683,12 @@ default = ""
 
 [vars.build_command]
 description = "Command to run build. Empty = skip."
+default = ""
+
+[vars.prior_branch]
+description = "Branch from a prior polecat attempt on the same issue. Cherry-pick or diff against this to reuse prior work instead of starting from scratch. Empty = no prior attempt."
+default = ""
+
+[vars.prior_failure]
+description = "Failure reason from the prior attempt (e.g., conflict, tests, build). Empty = unknown or no prior attempt."
 default = ""


### PR DESCRIPTION
## Summary

- When sling dispatches an issue that already has an open MR from a prior polecat attempt, the new polecat now receives `prior_branch` and `prior_failure` as formula variables
- The `mol-polecat-work` formula template instructs the polecat to cherry-pick prior commits onto its fresh branch instead of reimplementing from scratch
- Adds `FindOpenMRsForIssue` to beads for querying open MRs by source issue

## Design alignment

This feature works **within** the existing fresh-branch isolation design, not against it:

- **Fresh branches are preserved**: Each polecat still gets its own unique `@timestamp` branch from main. The isolation guarantee (collision-free, no TOCTOU races) is untouched.
- **No branch reuse**: The new polecat does NOT check out the old branch. It creates its own fresh branch and cherry-picks commits from the prior attempt as a starting point.
- **Prior branch availability**: The old branch exists on the remote because `gt done` pushed it, and the refinery only deletes remote branches after successful merge. Failed MR branches persist.
- **Timing**: The lookup runs at sling time (before the new polecat starts work), while MR supersession (#2737) runs at `gt done` time (after the new polecat finishes). So the old MR is still open and discoverable when we look for it.

The enhancement adds **context** to the dispatch, not structural changes. The polecat gets told "there was a prior attempt on branch X that failed for reason Y" and can choose to cherry-pick that work rather than starting from zero.

## Problem

On laser-platform, issue `la-cagb2` required 6 polecat attempts — each started from scratch and lost all prior work. The prior polecat's commits were available on the remote but the new polecat had no way to know about them.

## How it works

1. Sling dispatches issue `la-cagb2` to a new polecat
2. `lookupPriorAttempt` queries `FindOpenMRsForIssue("la-cagb2")`
3. Finds open MR with `source_issue: la-cagb2`, extracts `branch: polecat/furiosa/la-cagb2@mm4heq3e`
4. Injects `prior_branch` and `prior_failure` as formula variables
5. Polecat creates its own fresh branch, then cherry-picks from `origin/<prior_branch>`

## Test plan

- [ ] Sling an issue that has a prior open MR — polecat should see `prior_branch` in formula vars and "Prior attempt found" in sling output
- [ ] Sling an issue with no prior MR — no prior attempt context injected (normal path)
- [ ] Polecat cherry-picks prior commits during branch-setup step
- [ ] Build clean, existing tests pass

**Note**: `FindOpenMRsForIssue` also appears in #2737 (auto-supersede). Whichever merges first, the other will need a rebase.

Fixes: gt-zqvj

🤖 Generated with [Claude Code](https://claude.com/claude-code)