### PR TITLE
fix: resolve gt binary path in Gemini hook templates at install time

### DIFF
--- a/internal/hooks/installer.go
+++ b/internal/hooks/installer.go
@@ -6,9 +6,11 @@
 package hooks
 
 import (
+	"bytes"
 	"embed"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 
 	"github.com/steveyegge/gastown/internal/hookutil"
@@ -58,6 +60,16 @@ func InstallForRole(provider, settingsDir, workDir, role, hooksDir, hooksFile st
 	content, err := resolveTemplate(provider, hooksFile, role)
 	if err != nil {
 		return fmt.Errorf("resolving template for %s: %w", provider, err)
+	}
+
+	// Substitute {{GT_BIN}} with the resolved gt binary path.
+	// Templates use this placeholder so hooks call gt directly instead of
+	// relying on PATH exports, which fail on Gemini CLI (the hook runner
+	// expands $PATH into an enormous string that breaks command parsing).
+	// GH#gt-6y2s
+	if bytes.Contains(content, []byte("{{GT_BIN}}")) {
+		gtBin := resolveGTBinary()
+		content = bytes.ReplaceAll(content, []byte("{{GT_BIN}}"), []byte(gtBin))
 	}
 
 	// Use restrictive permissions for settings that may contain role instructions
@@ -122,4 +134,18 @@ func roleAwarePatterns(roleType, hooksFile string) []string {
 // isSettingsFile returns true for files that may contain sensitive role config.
 func isSettingsFile(name string) bool {
 	return filepath.Ext(name) == ".json"
+}
+
+// resolveGTBinary returns the absolute path to the gt binary.
+// Tries os.Executable() first (most reliable when running as gt), then
+// falls back to exec.LookPath for PATH-based discovery. If both fail,
+// returns "gt" and hopes the runtime PATH has it.
+func resolveGTBinary() string {
+	if exe, err := os.Executable(); err == nil {
+		return exe
+	}
+	if path, err := exec.LookPath("gt"); err == nil {
+		return path
+	}
+	return "gt"
 }

--- a/internal/hooks/templates/gemini/settings-autonomous.json
+++ b/internal/hooks/templates/gemini/settings-autonomous.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard pr-workflow"
+            "command": "{{GT_BIN}} tap guard pr-workflow"
           }
         ]
       },
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard pr-workflow"
+            "command": "{{GT_BIN}} tap guard pr-workflow"
           }
         ]
       },
@@ -24,7 +24,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard pr-workflow"
+            "command": "{{GT_BIN}} tap guard pr-workflow"
           }
         ]
       }
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" GT_SESSION_ID=${GT_SESSION_ID:-$(uuidgen)} GT_HOOK_SOURCE=startup && gt prime --hook && gt mail check --inject"
+            "command": "GT_SESSION_ID=${GT_SESSION_ID:-$(uuidgen)} GT_HOOK_SOURCE=startup {{GT_BIN}} prime --hook && {{GT_BIN}} mail check --inject"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" GT_HOOK_SOURCE=compact && gt prime --hook"
+            "command": "GT_HOOK_SOURCE=compact {{GT_BIN}} prime --hook"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt mail check --inject"
+            "command": "{{GT_BIN}} mail check --inject"
           }
         ]
       }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt costs record &"
+            "command": "{{GT_BIN}} costs record &"
           }
         ]
       }

--- a/internal/hooks/templates/gemini/settings-interactive.json
+++ b/internal/hooks/templates/gemini/settings-interactive.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard pr-workflow"
+            "command": "{{GT_BIN}} tap guard pr-workflow"
           }
         ]
       },
@@ -15,7 +15,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard pr-workflow"
+            "command": "{{GT_BIN}} tap guard pr-workflow"
           }
         ]
       },
@@ -24,7 +24,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard pr-workflow"
+            "command": "{{GT_BIN}} tap guard pr-workflow"
           }
         ]
       }
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime --hook"
+            "command": "{{GT_BIN}} prime --hook"
           }
         ]
       }
@@ -46,7 +46,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt prime --hook"
+            "command": "{{GT_BIN}} prime --hook"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt mail check --inject"
+            "command": "{{GT_BIN}} mail check --inject"
           }
         ]
       }
@@ -68,7 +68,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/bin:$PATH\" && gt costs record &"
+            "command": "{{GT_BIN}} costs record &"
           }
         ]
       }


### PR DESCRIPTION
## Summary

- Gemini CLI hook templates now use `{{GT_BIN}}` placeholder instead of `export PATH="$HOME/go/bin:..." && gt`
- At install time (`InstallForRole`), the placeholder is resolved to the absolute gt binary path via `os.Executable()` / `exec.LookPath("gt")`
- Eliminates PATH manipulation in hook commands entirely for Gemini

**Problem**: Gemini CLI's hook runner expands `$PATH` into the full system PATH before executing, turning a compact `export PATH=... && gt prime --hook` into a command with a massive PATH string. This causes hook failures:
- `gt prime --hook` fails for PreCompress/SessionStart events
- When gt is installed at `~/.local/bin/gt` (not `~/go/bin/gt`), the hardcoded PATH doesn't find it at all

**Note**: Claude, Codex, Cursor, and Copilot templates still use the PATH export pattern — their hook runners handle it correctly. They can be migrated to `{{GT_BIN}}` in follow-up PRs.

## Test plan

- [ ] Delete existing `.gemini/settings.json` for a crew member, restart — new file should contain absolute gt path (no `export PATH`)
- [ ] Gemini SessionStart hook should succeed (no "No such file" error)
- [ ] Gemini PreCompress hook should succeed
- [ ] Build clean

Fixes: gt-6y2s

🤖 Generated with [Claude Code](https://claude.com/claude-code)