### PR TITLE
fix: explicit idle-wait instruction for crew workers (Gemini loop fix)

### DIFF
--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -467,7 +467,9 @@ func outputStartupDirective(ctx RoleContext) {
 		fmt.Println("4. If there's a 🤝 HANDOFF message, read it and continue the work")
 		fmt.Println("5. Check for attached work: `" + cli.Name() + " hook`")
 		fmt.Println("   - If attachment found → **RUN IT** (no human input needed)")
-		fmt.Println("   - If no attachment → await user instruction")
+		fmt.Println("   - If no attachment → **STOP and wait for input**. Do NOT run")
+		fmt.Println("     any more commands. Do NOT poll mail. Do NOT check status.")
+		fmt.Println("     Sit idle at your prompt — a nudge or user message will arrive.")
 	case RoleDeacon:
 		// Skip startup protocol if paused - the pause message was already shown
 		paused, _, _ := deacon.IsPaused(ctx.TownRoot)


### PR DESCRIPTION
## Summary

- Crew startup directive changed from vague "await user instruction" to explicit "STOP and wait for input. Do NOT run any more commands. Do NOT poll mail."
- Claude Code naturally stops at its prompt, but Gemini CLI interprets "await" as "keep checking" — causing an infinite self-prompting loop where it repeatedly checks mail, finds nothing, checks again

**Problem observed**: Gisele (Gemini crew) loops endlessly checking mail when idle. A queued nudge from Dom sits in the tmux input buffer but can't be processed because Gemini never stops executing its own commands long enough to read it.

## Test plan

- [ ] Start Gemini crew member with no work — should stop and wait silently instead of looping
- [ ] Nudge a waiting Gemini crew member — nudge should be processed
- [ ] Claude crew behavior unchanged (already stops naturally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)