### PR TITLE
Remove 'gt config show' from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -384,9 +384,6 @@ gt config agent set codex-low "codex --thinking low"
 
 # Set default agent
 gt config default-agent claude-glm
-
-# View config
-gt config show
 ```
 
 ### Beads Integration


### PR DESCRIPTION
Remove line about viewing config as the command does not exist.

## Summary
<!-- Brief description of changes -->
Remove non-existant command from README.

## Related Issue
<!-- Link to issue: Fixes #123 or Closes #123 -->
n/a

## Changes
<!-- Bullet list of changes -->
- Simple doc update.

## Testing
<!-- How did you test these changes? -->
- [ ] Unit tests pass (`go test ./...`)
- [ ] Manual testing performed

## Checklist
- [ ] Code follows project style
- [x] Documentation updated (if applicable)
- [ ] No breaking changes (or documented in summary)
