### PR TITLE
fix: shell-quote agent args and respect role_agents model flags

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -782,16 +782,23 @@ func DefaultRuntimeConfig() *RuntimeConfig {
 }
 
 // BuildCommand returns the full command line string.
-// For use with tmux SendKeys.
+// For use with tmux SendKeys and respawn-pane, where the string is
+// interpreted by the user's shell. Args containing shell-special
+// characters (e.g., brackets in "sonnet[1m]") are quoted to prevent
+// glob expansion.
 func (rc *RuntimeConfig) BuildCommand() string {
 	resolved := normalizeRuntimeConfig(rc)
 
 	cmd := resolved.Command
 	args := resolved.Args
 
-	// Combine command and args
+	// Combine command and args, quoting any that contain shell metacharacters
 	if len(args) > 0 {
-		return cmd + " " + strings.Join(args, " ")
+		quoted := make([]string, len(args))
+		for i, a := range args {
+			quoted[i] = ShellQuote(a)
+		}
+		return cmd + " " + strings.Join(quoted, " ")
 	}
 	return cmd
 }

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -450,6 +450,14 @@ func (d *Daemon) getNeedsPreSync(config *beads.RoleConfig, parsed *ParsedIdentit
 	}
 }
 
+// isBuiltinClaudeStartCommand returns true if the start_command is the
+// built-in default from role TOMLs ("exec claude --dangerously-skip-permissions").
+// Custom start_commands (e.g., "exec run --town {town}") return false.
+func isBuiltinClaudeStartCommand(cmd string) bool {
+	trimmed := strings.TrimPrefix(cmd, "exec ")
+	return trimmed == "claude --dangerously-skip-permissions"
+}
+
 // getStartCommand determines the startup command for an agent.
 // Uses role config if available, then role-based agent selection, then hardcoded defaults.
 // Includes beacon + role-specific instructions in the CLI prompt.
@@ -464,18 +472,10 @@ func (d *Daemon) getStartCommand(roleConfig *beads.RoleConfig, parsed *ParsedIde
 			rigPath = filepath.Join(d.config.TownRoot, parsed.RigName)
 		}
 		rc := config.ResolveRoleAgentConfig(parsed.RoleType, d.config.TownRoot, rigPath)
-		if config.IsResolvedAgentClaude(rc) {
+		if !config.IsResolvedAgentClaude(rc) || !isBuiltinClaudeStartCommand(roleConfig.StartCommand) {
+			// Non-Claude agent OR custom start_command: use TOML pattern
+			// with template expansion.
 			cmd := beads.ExpandRolePattern(roleConfig.StartCommand, d.config.TownRoot, parsed.RigName, parsed.AgentName, parsed.RoleType, session.PrefixFor(parsed.RigName))
-			// Prepend env sanitization: CLAUDECODE causes Claude Code to
-			// reject startup (nested session detection) when inherited from
-			// tmux server environment. NODE_OPTIONS can contain debugger flags
-			// that crash Claude's Node.js runtime.
-			//
-			// The start_command may begin with "exec " (a shell builtin). Since
-			// env(1) treats its first non-option argument as the binary to run,
-			// "env ... exec claude" fails (exec is not a binary). We strip the
-			// "exec " prefix and re-add it before env so the shell processes it:
-			//   exec env -u CLAUDECODE NODE_OPTIONS='' claude ...
 			if strings.HasPrefix(cmd, "exec ") {
 				cmd = "exec env -u CLAUDECODE NODE_OPTIONS='' " + cmd[len("exec "):]
 			} else {
@@ -483,6 +483,8 @@ func (d *Daemon) getStartCommand(roleConfig *beads.RoleConfig, parsed *ParsedIde
 			}
 			return cmd
 		}
+		// Claude agent with built-in start_command: fall through to
+		// BuildStartupCommandFromConfig for proper model flag resolution.
 	}
 
 	rigPath := ""

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -309,22 +309,18 @@ func buildWitnessStartCommand(rigPath, rigName, townRoot, sessionName, agentOver
 		roleConfig = nil
 	}
 	if roleConfig != nil && roleConfig.StartCommand != "" {
-		// Skip the hardcoded start_command when a non-Claude agent is configured.
-		// Built-in role TOMLs hardcode "exec claude ..." which bypasses the
-		// declarative agent resolution system. Fall through to
-		// BuildStartupCommandFromConfig so the correct agent command is built.
+		// Use the TOML start_command for custom (non-Claude) commands that
+		// need template expansion (e.g., "exec run --town {town} --rig {rig}").
+		// For Claude agents, skip the TOML shortcut and fall through to
+		// BuildStartupCommandFromConfig which resolves model flags from
+		// role_agents (e.g., --model sonnet[1m]). The built-in TOML
+		// start_command ("exec claude --dangerously-skip-permissions") strips
+		// these flags, breaking per-role model selection.
 		rc := config.ResolveRoleAgentConfig("witness", townRoot, rigPath)
-		if config.IsResolvedAgentClaude(rc) {
+		if !config.IsResolvedAgentClaude(rc) || !isBuiltinClaudeStartCommand(roleConfig.StartCommand) {
+			// Non-Claude agent OR custom start_command: use TOML pattern
+			// with template expansion.
 			cmd := beads.ExpandRolePattern(roleConfig.StartCommand, townRoot, rigName, "", "witness", session.PrefixFor(rigName))
-			// Prepend env sanitization: CLAUDECODE causes Claude Code to
-			// reject startup (nested session detection) when inherited from
-			// tmux server environment. NODE_OPTIONS can contain debugger flags
-			// that crash Claude's Node.js runtime.
-			// NOTE: "exec" is a shell builtin, not a binary. If the TOML
-			// start_command begins with "exec", we must keep exec as the
-			// outermost command so the shell handles it, then use env for
-			// the actual binary. "env ... exec cmd" fails because env tries
-			// to run "exec" as a program (exit 127).
 			if strings.HasPrefix(cmd, "exec ") {
 				cmd = "exec env -u CLAUDECODE NODE_OPTIONS='' " + strings.TrimPrefix(cmd, "exec ")
 			} else {
@@ -332,6 +328,8 @@ func buildWitnessStartCommand(rigPath, rigName, townRoot, sessionName, agentOver
 			}
 			return cmd, nil
 		}
+		// Claude agent with built-in start_command: fall through to
+		// BuildStartupCommandFromConfig for proper model flag resolution.
 	}
 	initialPrompt := session.BuildStartupPrompt(session.BeaconConfig{
 		Recipient: session.BeaconRecipient("witness", "", rigName),
@@ -350,6 +348,14 @@ func buildWitnessStartCommand(rigPath, rigName, townRoot, sessionName, agentOver
 		return "", fmt.Errorf("building startup command: %w", err)
 	}
 	return command, nil
+}
+
+// isBuiltinClaudeStartCommand returns true if the start_command is the
+// built-in default from role TOMLs ("exec claude --dangerously-skip-permissions").
+// Custom start_commands (e.g., "exec run --town {town}") return false.
+func isBuiltinClaudeStartCommand(cmd string) bool {
+	trimmed := strings.TrimPrefix(cmd, "exec ")
+	return trimmed == "claude --dangerously-skip-permissions"
 }
 
 // Stop stops the witness.


### PR DESCRIPTION
## Summary

- **BuildCommand() now shell-quotes args** containing special characters (e.g., `sonnet[1m]`). Without quoting, zsh in tmux `respawn-pane` glob-expands `[1m]` as a character class, killing refinery/deacon sessions on startup.
- **Witness/daemon startup respects role_agents model flags.** The TOML `start_command` shortcut for Claude agents hardcoded `exec claude --dangerously-skip-permissions` without the `--model` flag from `role_agents`. Witnesses configured for `claude-sonnet` silently ran with the default model instead of `sonnet[1m]`. Now falls through to `BuildStartupCommandFromConfig` for proper model resolution.
- Custom (non-Claude) `start_command` patterns still use the TOML template expansion path.

## Test plan

- [x] Existing `TestBuildWitnessStartCommand_UsesRoleConfig` passes (custom non-Claude commands still use TOML pattern)
- [x] `TestBuildWitnessStartCommand_DefaultsToRuntime` passes
- [x] `TestRuntimeConfigBuildCommand` passes (args with special chars are quoted)
- [x] `TestShellQuote` passes
- [x] Manually verified all 9 sonnet-role agents (4 witnesses, 4 refineries, deacon) start with `--model 'sonnet[1m]'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)