### PR TITLE
fix: session prefix bugs and stale dolt socket cleanup

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1355,6 +1355,20 @@ func Start(townRoot string) error {
 		return err
 	}
 
+	// Clean stale Unix socket from prior crash. Dolt creates /tmp/mysql.sock by
+	// default (or a port-specific variant). If the server crashed, the socket file
+	// persists and Dolt warns "unix socket set up failed: file already in use".
+	// Safe to remove: if a Dolt server were actually running, IsRunning() above
+	// would have detected it and we'd have returned already. (gh-2687)
+	socketPath := "/tmp/mysql.sock"
+	if config.Port != 3306 {
+		socketPath = fmt.Sprintf("/tmp/mysql.%d.sock", config.Port)
+	}
+	if _, statErr := os.Stat(socketPath); statErr == nil {
+		fmt.Fprintf(os.Stderr, "Removing stale Unix socket: %s\n", socketPath)
+		_ = os.Remove(socketPath)
+	}
+
 	// Always write a managed config.yaml from the Config struct before starting.
 	// This ensures critical settings (especially read/write timeouts) are always
 	// present, preventing CLOSE_WAIT accumulation from abandoned connections.

--- a/plugins/session-hygiene/run.sh
+++ b/plugins/session-hygiene/run.sh
@@ -106,10 +106,29 @@ while IFS= read -r SESSION; do
   fi
 done <<< "$SESSIONS"
 
+# --- Step 3.5: Kill threshold safeguard ---------------------------------------
+
+# If >50% of sessions would be killed, abort and escalate. A plugin that
+# kills the entire town is never correct — this indicates a data source bug.
+
+ZOMBIE_COUNT=${#ZOMBIES[@]}
+if [ "$ZOMBIE_COUNT" -gt 0 ] && [ "$SESSION_COUNT" -gt 0 ]; then
+  KILL_PERCENT=$(( ZOMBIE_COUNT * 100 / SESSION_COUNT ))
+  if [ "$KILL_PERCENT" -gt 50 ]; then
+    ZOMBIE_LIST=$(printf '%s, ' "${ZOMBIES[@]}")
+    log "ABORT: $ZOMBIE_COUNT of $SESSION_COUNT sessions (${KILL_PERCENT}%) would be killed — exceeds 50% threshold"
+    log "Would-be zombies: $ZOMBIE_LIST"
+    log "This likely indicates a data source bug (stale rigs.json, missing prefixes). Escalating."
+    gt escalate "session-hygiene: ABORT — ${KILL_PERCENT}% of sessions classified as zombies" \
+      -s HIGH \
+      --reason "session-hygiene would kill $ZOMBIE_COUNT of $SESSION_COUNT sessions (${KILL_PERCENT}%). Aborting. Would-be zombies: ${ZOMBIE_LIST}" 2>/dev/null || true
+    exit 1
+  fi
+fi
+
 # --- Step 4: Kill zombie sessions ---------------------------------------------
 
 KILLED=0
-ZOMBIE_COUNT=${#ZOMBIES[@]}
 for ZOMBIE in "${ZOMBIES[@]+"${ZOMBIES[@]}"}"; do
   [ -z "$ZOMBIE" ] && continue
   if $DRY_RUN; then

--- a/plugins/stuck-agent-dog/plugin.md
+++ b/plugins/stuck-agent-dog/plugin.md
@@ -59,15 +59,30 @@ Gather all polecats and the deacon session. We check both crashed sessions
 echo "=== Stuck Agent Dog: Checking agent health ==="
 
 TOWN_ROOT="$HOME/gt"
+RIGS_JSON_PATH="${TOWN_ROOT}/mayor/rigs.json"
 
-# Get all rig names
-RIG_JSON=$(gt rig list --json 2>/dev/null)
-if [ $? -ne 0 ] || [ -z "$RIG_JSON" ]; then
-  echo "SKIP: could not get rig list"
+# Read rigs.json for rig names and beads prefixes
+# CRITICAL: We need both the rig name (for filesystem paths like $TOWN_ROOT/$RIG/polecats/)
+# and the beads prefix (for tmux session names like $PREFIX-polecat-$NAME).
+# These can differ — e.g. rig "cfutons" may have prefix "CF".
+if [ ! -f "$RIGS_JSON_PATH" ]; then
+  echo "SKIP: rigs.json not found at $RIGS_JSON_PATH"
   exit 0
 fi
 
-RIG_NAMES=$(echo "$RIG_JSON" | jq -r '.[].name // empty' 2>/dev/null)
+RIGS_FILE=$(cat "$RIGS_JSON_PATH" 2>/dev/null)
+if [ -z "$RIGS_FILE" ]; then
+  echo "SKIP: could not read rigs.json"
+  exit 0
+fi
+
+# Build a mapping of rig_name -> beads_prefix for session name construction
+# Each line: rig_name|beads_prefix
+RIG_PREFIX_MAP=$(echo "$RIGS_FILE" | jq -r '.rigs | to_entries[] | "\(.key)|\(.value.beads.prefix // .key)"' 2>/dev/null)
+if [ -z "$RIG_PREFIX_MAP" ]; then
+  echo "SKIP: no rigs found in rigs.json"
+  exit 0
+fi
 ```
 
 ## Step 2: Check polecat health
@@ -82,7 +97,8 @@ CRASHED=()
 STUCK=()
 HEALTHY=0
 
-for RIG in $RIG_NAMES; do
+while IFS='|' read -r RIG PREFIX; do
+  [ -z "$RIG" ] && continue
   # List polecat directories
   POLECAT_DIR="$TOWN_ROOT/$RIG/polecats"
   [ -d "$POLECAT_DIR" ] || continue
@@ -90,7 +106,8 @@ for RIG in $RIG_NAMES; do
   for PCAT_PATH in "$POLECAT_DIR"/*/; do
     [ -d "$PCAT_PATH" ] || continue
     PCAT_NAME=$(basename "$PCAT_PATH")
-    SESSION_NAME="${RIG}-polecat-${PCAT_NAME}"
+    # Use beads prefix (not rig name) for tmux session name
+    SESSION_NAME="${PREFIX}-polecat-${PCAT_NAME}"
 
     # Check if session exists
     if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
@@ -135,7 +152,7 @@ for RIG in $RIG_NAMES; do
       fi
     fi
   done
-done
+done <<< "$RIG_PREFIX_MAP"
 
 echo ""
 echo "Health summary: ${#CRASHED[@]} crashed, ${#STUCK[@]} stuck, $HEALTHY healthy"


### PR DESCRIPTION
## Summary

- **stuck-agent-dog** (gh-2707): Fixed session name construction to use beads prefix from `rigs.json` instead of rig name from `gt rig list --json`. When prefix != name (e.g. rig "cfutons" with prefix "CF"), the plugin was looking for sessions like `cfutons-polecat-foo` instead of `CF-polecat-foo`, making it blind to all stuck/crashed polecats.
- **session-hygiene** (gh-2707): Added kill threshold safeguard — if >50% of sessions would be classified as zombies, abort and escalate instead of killing. Prevents a data source bug from causing a town-wide outage.
- **doltserver** (gh-2687): Clean stale `/tmp/mysql.sock` (or port-specific variant) before starting Dolt server. After a crash, the orphaned socket file causes "unix socket set up failed" warnings. Safe because `IsRunning()` already returned false at this point.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/doltserver/` passes
- [ ] Verify stuck-agent-dog correctly detects stuck polecats on rigs where beads prefix != rig name
- [ ] Verify session-hygiene aborts when >50% kill threshold exceeded
- [ ] Verify `gt dolt start` cleans stale socket after simulated crash

🤖 Generated with [Claude Code](https://claude.com/claude-code)