### PR TITLE
fix: repair 8 failing CI tests on main + lint misspell

### DIFF
--- a/internal/cmd/convoy_bd_routing_test.go
+++ b/internal/cmd/convoy_bd_routing_test.go
@@ -97,7 +97,7 @@ if [ -n "$BEADS_DIR" ]; then
 fi
 
 case "$*" in
-  "list --type=convoy --json --all --flat")
+  "list --type=convoy --json --all")
     if [ "$PWD" != "%s" ]; then
       echo "expected town root, got $PWD" >&2
       exit 1

--- a/internal/cmd/convoy_test_helpers_test.go
+++ b/internal/cmd/convoy_test_helpers_test.go
@@ -9,6 +9,8 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/gastown/internal/constants"
 )
 
 // ---------------------------------------------------------------------------
@@ -374,6 +376,16 @@ func (d *testDAG) Setup(t *testing.T) (townRoot, logPath string) {
 	}
 	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
 		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	// Write sentinel files so beads.EnsureCustomTypes/Statuses skip bd calls.
+	typesList := strings.Join(constants.BeadsCustomTypesList(), ",")
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", ".gt-types-configured"), []byte(typesList+"\n"), 0644); err != nil {
+		t.Fatalf("write types sentinel: %v", err)
+	}
+	statusesList := strings.Join(constants.BeadsCustomStatusesList(), ",")
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", ".gt-statuses-configured"), []byte(statusesList+"\n"), 0644); err != nil {
+		t.Fatalf("write statuses sentinel: %v", err)
 	}
 
 	// Install bd stub script.

--- a/internal/cmd/mountain.go
+++ b/internal/cmd/mountain.go
@@ -703,7 +703,7 @@ func runMountainCancel(cmd *cobra.Command, args []string) error {
 	// Best-effort remove paused label too.
 	_ = bdRemoveLabelTown(convoyID, "mountain:paused")
 
-	fmt.Printf("Mountain cancelled on %s.\n", convoyID)
+	fmt.Printf("Mountain canceled on %s.\n", convoyID)
 	fmt.Printf("Convoy remains open for manual management.\n")
 	fmt.Printf("Check convoy status: gt convoy status %s\n", convoyID)
 	return nil

--- a/internal/hooks/installer_test.go
+++ b/internal/hooks/installer_test.go
@@ -188,7 +188,11 @@ func TestInstallForRole_GeminiRoleAware(t *testing.T) {
 
 	got, _ := os.ReadFile(filepath.Join(dir, ".gemini", "settings.json"))
 	want, _ := templateFS.ReadFile("templates/gemini/settings-autonomous.json")
-	if string(got) != string(want) {
+	// Gemini templates contain {{GT_BIN}} which gets resolved at install time.
+	// Apply the same substitution to the expected content for comparison.
+	gtBin := resolveGTBinary()
+	wantResolved := strings.ReplaceAll(string(want), "{{GT_BIN}}", gtBin)
+	if string(got) != wantResolved {
 		t.Error("gemini autonomous: content mismatch")
 	}
 }

--- a/internal/mail/router_test.go
+++ b/internal/mail/router_test.go
@@ -15,6 +15,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/testutil"
@@ -309,6 +310,12 @@ func TestSendFromCrewWorkspace_AvoidsEphemeralPrefixMismatch(t *testing.T) {
 	}
 	if err := os.WriteFile(filepath.Join(mayorDir, "town.json"), []byte(`{"name":"test"}`), 0644); err != nil {
 		t.Fatalf("write town.json: %v", err)
+	}
+
+	// Write sentinel files so beads.EnsureCustomTypes skips bd config calls.
+	typesList := strings.Join(constants.BeadsCustomTypesList(), ",")
+	if err := os.WriteFile(filepath.Join(townBeadsDir, ".gt-types-configured"), []byte(typesList+"\n"), 0644); err != nil {
+		t.Fatalf("write types sentinel: %v", err)
 	}
 
 	// Stub bd to reproduce the old behavior where --id msg-* with --ephemeral


### PR DESCRIPTION
## Summary
- Fix `cancelled` → `canceled` misspell lint error in `mountain.go`
- Fix 6 convoy/stage test failures caused by `EnsureCustomTypes` verify step not working with test bd stubs (sentinel file fast-path)
- Fix `TestRunConvoyList` failure from stale `--flat` flag in test stub
- Fix `TestInstallForRole_GeminiRoleAware` content mismatch by applying `{{GT_BIN}}` template substitution to expected content
- Fix `TestSendFromCrewWorkspace` with same sentinel file approach

All 8 previously-failing tests now pass locally.

## Test plan
- [x] All 8 previously-failing tests pass locally
- [ ] CI should go green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)