### PR TITLE
fix(crew): set liveness env vars so non-Claude runtimes survive attach

### DIFF
--- a/internal/cmd/crew_at.go
+++ b/internal/cmd/crew_at.go
@@ -195,6 +195,10 @@ func runCrewAt(cmd *cobra.Command, args []string) error {
 			Topic:            "start",
 			SessionName:      sessionID,
 		})
+		// Merge liveness-critical env vars (GT_AGENT, GT_PROCESS_NAMES) so that
+		// IsAgentAlive can detect non-Claude runtimes. Without this, attach
+		// misclassifies live sessions as dead and recreates them.
+		envVars = session.MergeRuntimeLivenessEnv(envVars, runtimeConfig)
 		for k, v := range envVars {
 			_ = t.SetEnvironment(sessionID, k, v)
 		}
@@ -262,6 +266,23 @@ func runCrewAt(cmd *cobra.Command, args []string) error {
 		if !t.IsAgentAlive(sessionID) {
 			// Runtime has exited, restart it using respawn-pane
 			fmt.Printf("Runtime exited, restarting...\n")
+
+			// Refresh liveness env vars before restart so the next IsAgentAlive
+			// check can detect non-Claude runtimes.
+			restartEnv := config.AgentEnv(config.AgentEnvConfig{
+				Role:             "crew",
+				Rig:              r.Name,
+				AgentName:        name,
+				TownRoot:         townRoot,
+				RuntimeConfigDir: claudeConfigDir,
+				Agent:            crewAgentOverride,
+				Topic:            "restart",
+				SessionName:      sessionID,
+			})
+			restartEnv = session.MergeRuntimeLivenessEnv(restartEnv, runtimeConfig)
+			for k, v := range restartEnv {
+				_ = t.SetEnvironment(sessionID, k, v)
+			}
 
 			// Get pane ID for respawn
 			paneID, err := t.GetPaneID(sessionID)


### PR DESCRIPTION
## Summary

Fix `gt crew at` so it exports runtime liveness env vars for non-Claude/custom agents before attach and restart.

## Problem

`gt crew at` used `config.AgentEnv`, but it did not merge the runtime-specific liveness env (`GT_AGENT`, `GT_PROCESS_NAMES`) into the tmux session environment.

That meant `IsAgentAlive` could not see the resolved runtime metadata for custom/non-Claude agents. In practice it fell back to Claude-oriented process names, misdetected live crew sessions as dead, and recreated them during attach.

## Root Cause

- New crew session creation in `internal/cmd/crew_at.go` exported only `AgentEnv`.
- Existing-session restart in the same command also refreshed only `AgentEnv`.
- Other startup paths already use `session.MergeRuntimeLivenessEnv`, but `gt crew at` did not.

## Changes

- Call `session.MergeRuntimeLivenessEnv` in the new-session path before `t.SetEnvironment`.
- Call `session.MergeRuntimeLivenessEnv` again in the restart path before `respawn-pane`.
- Document in code that the merge is required so `IsAgentAlive` can detect non-Claude runtimes correctly.

## Why This Is Safe

- The change only augments tmux session env with the same helper already used by other lifecycle paths.
- No runtime command construction changed.
- Existing Claude-based behavior is preserved; custom runtime detection becomes consistent.

## Testing

Ran `make test` locally.

Passing packages include the areas relevant to this change:

- `internal/session`
- `internal/config`
- `internal/crew`
- `internal/polecat`

The full suite still fails in unrelated areas outside this patch:

- `internal/cmd`: existing convoy/beads-related failures including `TestRunConvoyList_UsesTownRootAndStripsBeadsDir`, multiple `TestCreateStagedConvoy_*` cases, and `TestJSONOutput_NoHumanReadableText`
- `internal/hooks`: `TestInstallForRole_GeminiRoleAware`
- `internal/mail`: `TestSendFromCrewWorkspace_AvoidsEphemeralPrefixMismatch`
- `internal/tmux`: multiple session-command expectations such as `TestNewSessionWithCommand_Success`, `TestNewSessionWithCommand_ExecEnvSuccess`, `TestWaitForCommand_Timeout`, and `TestGetPaneCommand_MultiPane`

## Patch Summary

- 1 file changed
- 21 insertions
- No behavioral changes outside crew attach/restart env propagation
