### PR TITLE
fix(daemon): skip CRASHED_POLECAT alerts for closed hook beads

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1936,6 +1936,17 @@ func (d *Daemon) checkPolecatHealth(rigName, polecatName string) {
 		return
 	}
 
+	// Stale hook guard: skip polecats whose hook_bead is already closed.
+	// When a polecat completes work normally (gt done), the hook_bead gets closed
+	// but may not be cleared from the agent bead before the session stops.
+	// Without this check, every heartbeat cycle fires a false CRASHED_POLECAT alert
+	// for the dead session + non-empty hook_bead combination.
+	if d.isBeadClosed(info.HookBead) {
+		d.logger.Printf("Skipping crash detection for %s/%s: hook_bead %s is already closed (work completed normally)",
+			rigName, polecatName, info.HookBead)
+		return
+	}
+
 	// Spawning guard: skip polecats being actively started by gt sling.
 	// agent_state='spawning' means the polecat bead was created (with hook_bead
 	// set atomically) but the tmux session hasn't been launched yet. Restarting
@@ -2034,6 +2045,30 @@ func (d *Daemon) emitMassDeathEvent() {
 
 	// Clear the deaths to avoid repeated alerts
 	d.recentDeaths = nil
+}
+
+// isBeadClosed checks if a bead's status is "closed" by querying bd show --json.
+// Returns true if the bead exists and has status "closed", false otherwise.
+// On any error (bead not found, bd failure), returns false to err on the side
+// of crash detection rather than silently suppressing alerts.
+func (d *Daemon) isBeadClosed(beadID string) bool {
+	cmd := exec.Command(d.bdPath, "show", beadID, "--json") //nolint:gosec // G204: args are constructed internally
+	cmd.Dir = d.config.TownRoot
+	cmd.Env = os.Environ()
+
+	output, err := cmd.Output()
+	if err != nil {
+		return false
+	}
+
+	var issues []struct {
+		Status string `json:"status"`
+	}
+	if err := json.Unmarshal(output, &issues); err != nil || len(issues) == 0 {
+		return false
+	}
+
+	return issues[0].Status == "closed"
 }
 
 // notifyWitnessOfCrashedPolecat notifies the witness when a polecat crash is detected.
@@ -2136,9 +2171,11 @@ func (d *Daemon) reapIdlePolecat(rigName, polecatName string, timeout time.Durat
 			return
 		}
 
-		// If polecat has hooked work, it might just be stuck (not idle).
+		// If polecat has hooked work that is still open, it might be stuck (not idle).
 		// Don't reap — let checkPolecatSessionHealth handle stuck polecats.
-		if info.HookBead != "" {
+		// But if the hook_bead is closed, the work is done and this is just an idle
+		// polecat with a stale hook reference — safe to reap.
+		if info.HookBead != "" && !d.isBeadClosed(info.HookBead) {
 			return
 		}
 

--- a/internal/daemon/polecat_health_test.go
+++ b/internal/daemon/polecat_health_test.go
@@ -185,6 +185,56 @@ func TestCheckPolecatHealth_DBStateOverridesDescription(t *testing.T) {
 	}
 }
 
+// TestCheckPolecatHealth_SkipsClosedHookBead verifies that checkPolecatHealth
+// does NOT fire CRASHED_POLECAT when the hook_bead is already closed.
+// This is the regression test for the false-positive spam bug (issue hq-1o7):
+// when a polecat completes work normally, the hook_bead gets closed but the
+// stale reference remains on the agent bead, causing repeated false alerts.
+func TestCheckPolecatHealth_SkipsClosedHookBead(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mocks for tmux and bd")
+	}
+	binDir := t.TempDir()
+	writeFakeTestTmux(t, binDir)
+	recentTime := time.Now().UTC().Format(time.RFC3339)
+
+	// Create a bd script that returns different JSON based on the bead ID:
+	// - Agent bead: working state with hook_bead set
+	// - Hook bead: status=closed (work completed normally)
+	agentJSON := fmt.Sprintf(`[{"id":"gt-myr-polecat-mycat","issue_type":"agent","labels":["gt:agent"],"description":"agent_state: working","hook_bead":"fe-xyz","agent_state":"working","updated_at":"%s"}]`, recentTime)
+	hookJSON := `[{"id":"fe-xyz","status":"closed"}]`
+	script := fmt.Sprintf("#!/bin/sh\n"+
+		"case \"$2\" in\n"+
+		"  gt-myr-polecat-mycat) echo '%s';;\n"+
+		"  fe-xyz) echo '%s';;\n"+
+		"  *) echo '[]'; exit 1;;\n"+
+		"esac\n", agentJSON, hookJSON)
+	bdPath := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(bdPath, []byte(script), 0755); err != nil {
+		t.Fatalf("writing fake bd: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	var logBuf strings.Builder
+	d := &Daemon{
+		config: &Config{TownRoot: t.TempDir()},
+		logger: log.New(&logBuf, "", 0),
+		tmux:   tmux.NewTmux(),
+		bdPath: bdPath,
+	}
+
+	d.checkPolecatHealth("myr", "mycat")
+
+	got := logBuf.String()
+	if !strings.Contains(got, "hook_bead fe-xyz is already closed") {
+		t.Errorf("expected log about closed hook_bead, got: %q", got)
+	}
+	if strings.Contains(got, "CRASH DETECTED") {
+		t.Errorf("closed hook_bead must not trigger CRASH DETECTED, got: %q", got)
+	}
+}
+
 // TestCheckPolecatHealth_NotifiesWitnessOnCrash verifies that when a polecat
 // crash is detected, the daemon sends a notification to the witness via
 // `gt mail send` with a CRASHED_POLECAT subject. Restart is deferred to the


### PR DESCRIPTION
## Summary

- Fixes false-positive CRASHED_POLECAT spam when polecats complete work normally
- Adds `isBeadClosed()` check before firing crash alerts — skips if hook_bead is already closed
- Fixes idle reaper to treat closed hook beads as reapable (not stuck)

**Root cause**: When a polecat completes work via `gt done`, the hook_bead gets closed but the stale reference remains on the agent bead. The daemon's `checkPolecatHealth` saw "dead session + non-empty hook_bead" and fired alerts every heartbeat cycle — 9+ false positives in 25 minutes in one incident.

## Test plan

- [x] Added `TestCheckPolecatHealth_SkipsClosedHookBead` regression test
- [x] Verified existing tests still pass (spawning guard, crash detection, DB state override)
- [x] `go vet` clean
- [x] Built and installed locally — daemon restarted with fix active

🤖 Generated with [Claude Code](https://claude.com/claude-code)