### PR TITLE
fix: dog dispatch defaults to disabled when not in config

### DIFF
--- a/internal/daemon/patrol_config_test.go
+++ b/internal/daemon/patrol_config_test.go
@@ -79,6 +79,33 @@ func TestIsPatrolEnabled_DoltRemotes(t *testing.T) {
 	}
 }
 
+func TestIsPatrolEnabled_Handler(t *testing.T) {
+	// handler (dog dispatch) defaults to disabled even with nil config
+	if IsPatrolEnabled(nil, "handler") {
+		t.Error("expected handler to be disabled with nil config")
+	}
+
+	// handler defaults to disabled when patrols section exists but Handler is nil
+	config := &DaemonPatrolConfig{
+		Patrols: &PatrolsConfig{},
+	}
+	if IsPatrolEnabled(config, "handler") {
+		t.Error("expected handler to be disabled by default")
+	}
+
+	// Explicitly enabled
+	config.Patrols.Handler = &PatrolConfig{Enabled: true}
+	if !IsPatrolEnabled(config, "handler") {
+		t.Error("expected handler to be enabled when configured")
+	}
+
+	// Explicitly disabled
+	config.Patrols.Handler = &PatrolConfig{Enabled: false}
+	if IsPatrolEnabled(config, "handler") {
+		t.Error("expected handler to be disabled when explicitly disabled")
+	}
+}
+
 func TestSaveAndLoadPatrolConfig(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -306,9 +306,13 @@ func IsPatrolEnabled(config *DaemonPatrolConfig, patrol string) bool {
 			return config.Patrols.Deacon.Enabled
 		}
 	case "handler":
+		// Dog dispatch defaults to disabled — must be explicitly enabled in
+		// daemon.json. Without this, dogs silently spawn every heartbeat
+		// even when deacon/doctor_dog/compactor_dog are all disabled. (#2773)
 		if config.Patrols.Handler != nil {
 			return config.Patrols.Handler.Enabled
 		}
+		return false
 	}
 	return true // Default: enabled
 }


### PR DESCRIPTION
## Summary
- The `handler` patrol controls dog lifecycle and dispatch in the daemon heartbeat
- Previously defaulted to **enabled** when absent from `daemon.json`, causing dogs to silently spawn every heartbeat even when `deacon`/`doctor_dog`/`compactor_dog` were all explicitly disabled
- Now defaults to **disabled** (opt-in), matching the pattern used by `dolt_remotes`, `dolt_backup`, and other infrastructure patrols

## Test plan
- [ ] New test `TestIsPatrolEnabled_Handler` covers nil config, empty patrols, explicitly enabled, explicitly disabled
- [ ] Verify dogs don't spawn when `handler` is absent from `daemon.json`
- [ ] Verify dogs spawn normally when `handler` is explicitly enabled

Closes #2773

🤖 Generated with [Claude Code](https://claude.com/claude-code)