### PR TITLE
feat: add handler (dog dispatch) to daemon.json lifecycle defaults

### DIFF
--- a/internal/daemon/lifecycle_defaults.go
+++ b/internal/daemon/lifecycle_defaults.go
@@ -47,6 +47,9 @@ func DefaultLifecycleConfig() *DaemonPatrolConfig {
 				Interval:  "daily",
 				Threshold: &threshold,
 			},
+			Handler: &PatrolConfig{
+				Enabled: true,
+			},
 		},
 	}
 }
@@ -94,6 +97,10 @@ func EnsureLifecycleDefaults(config *DaemonPatrolConfig) bool {
 	}
 	if p.ScheduledMaintenance == nil {
 		p.ScheduledMaintenance = d.ScheduledMaintenance
+		changed = true
+	}
+	if p.Handler == nil {
+		p.Handler = d.Handler
 		changed = true
 	}
 

--- a/internal/daemon/lifecycle_defaults_test.go
+++ b/internal/daemon/lifecycle_defaults_test.go
@@ -88,6 +88,9 @@ func TestEnsureLifecycleDefaults_EmptyConfig(t *testing.T) {
 	if config.Patrols.CompactorDog == nil || !config.Patrols.CompactorDog.Enabled {
 		t.Error("expected compactor_dog to be set")
 	}
+	if config.Patrols.Handler == nil || !config.Patrols.Handler.Enabled {
+		t.Error("expected handler to be set")
+	}
 }
 
 func TestEnsureLifecycleDefaults_PreservesExisting(t *testing.T) {


### PR DESCRIPTION
## Summary
- The `handler` patrol controls dog lifecycle and dispatch in the daemon heartbeat
- It was missing from `DefaultLifecycleConfig` and `EnsureLifecycleDefaults`, so it never appeared in `daemon.json`
- Operators who wanted to disable dog dispatch had no way to discover this setting
- Now auto-populated as `enabled: true` (no behavior change), making it visible and configurable

## Test plan
- [ ] Existing test `TestEnsureLifecycleDefaults_EmptyConfig` updated to verify handler is included
- [ ] Verify new installs get `handler` in `daemon.json`
- [ ] Verify existing installs get `handler` auto-populated on next daemon start
- [ ] Verify setting `handler.enabled: false` stops dog dispatch

Closes #2773

🤖 Generated with [Claude Code](https://claude.com/claude-code)