### PR TITLE
fix: github-sheriff owner check gates bd list (prevents missing-db escalations)

### DIFF
--- a/plugins/github-sheriff/plugin.md
+++ b/plugins/github-sheriff/plugin.md
@@ -147,10 +147,17 @@ fi
 For each failure, check if a bead already exists:
 
 ```bash
-EXISTING=$(bd list --label ci-failure --status open --json 2>/dev/null || echo "[]")
-
 CREATED=0
 SKIPPED=0
+
+# Only create CI failure beads for repos we own — skip upstream noise
+REPO_OWNER=$(echo "$REPO" | cut -d'/' -f1)
+if [ "$REPO_OWNER" != "athosmartins" ]; then
+  echo "Skipping CI failure beads for upstream repo $REPO (not athosmartins)"
+  SKIPPED=${#FAILURES[@]}
+else
+
+EXISTING=$(bd list --label ci-failure --status open --json 2>/dev/null || echo "[]")
 
 for F in "${FAILURES[@]}"; do
   IFS='|' read -r PR_NUM PR_TITLE CHECK_NAME CHECK_URL <<< "$F"
@@ -181,6 +188,7 @@ Check: $CHECK_URL"
       2>/dev/null || true
   fi
 done
+fi # end athosmartins owner check
 ```
 
 ## Record Result


### PR DESCRIPTION
## Summary

- Move `REPO_OWNER` check **before** `bd list` call in Step 3 of github-sheriff plugin
- Non-`athosmartins` repos now skip the entire Step 3 without attempting a Dolt connection
- Previously `bd list` ran unconditionally, failing in rig contexts where the database doesn't exist (e.g. beads rig) and triggering HIGH escalations via `notify_on_failure=true`

## Problem

The github-sheriff plugin runs across multiple rig contexts. When it runs in a context where the `athosmartins` beads DB doesn't exist, the unconditional `bd list --label ci-failure --status open --json` call fails and triggers a HIGH-severity escalation. This caused spurious escalation `hq-wisp-dg4ub`.

## Fix

Restructure Step 3 so the `REPO_OWNER` check gates everything — `bd list` only runs when we're in an athosmartins repo context where the beads DB is guaranteed to exist.

## Test plan
- [ ] Plugin runs without error on non-athosmartins repos (skips Step 3 cleanly)
- [ ] Plugin still creates CI failure beads for athosmartins repos
- [ ] No spurious HIGH escalations from bd list failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)