### PR TITLE
fix: remove gt doctor -v from deacon patrol loop (blocks 60s per cycle)

### DIFF
--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -869,10 +869,12 @@ needs = ["orphan-check"]
 description = """
 **DETECT ONLY** - Check if cleanup is needed and dispatch to dog.
 
-**Step 1: Preview cleanup needs**
+**Step 1: Quick cleanup check (avoid gt doctor -v — takes 60s, blocks patrol)**
 ```bash
-gt doctor -v
-# Check output for issues that need cleaning
+# Fast orphan session check only
+tmux list-sessions 2>/dev/null | wc -l
+# Count open wisps as a proxy for system load
+bd list --status=open --json 2>/dev/null | jq length
 ```
 
 **Step 2: If cleanup needed, dispatch to dog**
@@ -881,8 +883,9 @@ gt doctor -v
 gt sling mol-session-gc deacon/dogs --var mode=conservative
 ```
 
-**Important:** Do NOT run `gt doctor --fix` inline. Dogs handle cleanup.
-The Deacon stays lightweight - detection only.
+**Important:** Do NOT run `gt doctor -v` or `gt doctor --fix` inline.
+`gt doctor -v` takes 60+ seconds and blocks the patrol loop.
+Dogs handle cleanup. The Deacon stays lightweight - detection only.
 
 **Step 3: If nothing to clean**
 Skip dispatch - system is healthy.


### PR DESCRIPTION
## Summary

- Remove `gt doctor -v` from the `session-gc` step in `mol-deacon-patrol` formula
- Replace with fast inline checks: `tmux list-sessions | wc -l` and `bd list --status=open --json | jq length`
- Update warning comment to explicitly call out `gt doctor -v` as the blocked operation

## Problem

`gt doctor -v` was running on every single deacon patrol cycle inside the `session-gc` step. It takes ~60 seconds minimum and can hang indefinitely under Dolt load. This was the root cause of 5 recurring incidents where the deacon would hang mid-patrol and need to be restarted.

Escalation `hq-wisp-pbea9` was filed for this issue.

## Fix

Replace the `gt doctor -v` call with two fast commands:
- `tmux list-sessions | wc -l` — sub-second, detects orphan tmux sessions
- `bd list --status=open --json | jq length` — fast Dolt query, proxy for system load

The deacon's job in this step is **detection only** — it just needs to decide whether to dispatch a session-gc dog. The fast checks are sufficient for that decision without the 60-second blocking call.

## Test plan
- [ ] Deacon patrol cycles complete without hanging at session-gc step
- [ ] Fast checks still trigger dog dispatch when cleanup is needed
- [ ] No more mid-patrol hangs caused by gt doctor -v

Related: hq-wisp-pbea9 (deacon mid-patrol hang incidents)

🤖 Generated with [Claude Code](https://claude.com/claude-code)