### PR TITLE
fix: DefaultDatabases uses 'gt' instead of 'gastown'

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -22,7 +22,7 @@ import (
 var validDBName = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
 // DefaultDatabases is the static fallback list of known production databases.
-var DefaultDatabases = []string{"hq", "bd", "gt"}
+var DefaultDatabases = []string{"hq", "bd", "gastown"}
 
 // testPollutionPrefixes are database name prefixes created by tests.
 var testPollutionPrefixes = []string{"testdb_", "beads_t", "beads_pt", "doctest_"}


### PR DESCRIPTION
## Summary

- `reaper.DefaultDatabases` had `"gt"` instead of `"gastown"` as the third production database
- `"gt"` is the **beads prefix** (for issue IDs like `gt-abc`), not a Dolt database name
- The actual Dolt database is `"gastown"` (confirmed by `metadata.json` and `.dolt-data/` on disk)
- This caused compactor-dog and dolt-archive to fail when falling back to the default database list

Replaces closed #2777 (which had extra merge commits from fork main).

## Test plan

- [ ] Verify `reaper.DefaultDatabases` contains `"gastown"` not `"gt"`
- [ ] Run compactor-dog — should query hq, bd, gastown successfully
- [ ] Run dolt-archive — JSONL export should succeed for all 3 databases

🤖 Generated with [Claude Code](https://claude.com/claude-code)