### PR TITLE
fix: ParseSessionName handles hq- prefix collision with rig prefixes

### DIFF
--- a/internal/session/identity.go
+++ b/internal/session/identity.go
@@ -108,7 +108,11 @@ func ParseSessionNameWithRegistry(session string, registry *PrefixRegistry) (*Ag
 		registry = NewPrefixRegistry()
 	}
 
-	// Check for town-level roles (hq- prefix)
+	// Check for town-level roles (hq- prefix).
+	// Note: "hq" may also be a registered rig prefix (e.g., knjn uses "hq").
+	// Known town-level roles are matched first; unknown suffixes fall through
+	// to rig-level parsing so that hq-witness, hq-refinery, hq-<polecat> etc.
+	// resolve correctly when "hq" is a rig prefix.
 	if strings.HasPrefix(session, HQPrefix) {
 		suffix := strings.TrimPrefix(session, HQPrefix)
 		switch suffix {
@@ -129,7 +133,7 @@ func ParseSessionNameWithRegistry(session string, registry *PrefixRegistry) (*Ag
 				}
 				return &AgentIdentity{Role: RoleDog, Name: name}, nil
 			}
-			return nil, fmt.Errorf("invalid session name %q: unknown hq- role", session)
+			// Fall through to rig-level parsing — "hq" may be a rig prefix.
 		}
 	}
 

--- a/internal/session/identity_test.go
+++ b/internal/session/identity_test.go
@@ -12,6 +12,7 @@ func testRegistry() *PrefixRegistry {
 	r.Register("hop", "hop")
 	r.Register("sky", "sky")
 	r.Register("mp", "my-project")
+	r.Register("hq", "knjn")
 	return r
 }
 
@@ -61,6 +62,39 @@ func TestParseSessionName(t *testing.T) {
 			session:  "hq-dog-my-dog",
 			wantRole: RoleDog,
 			wantName: "my-dog",
+		},
+
+		// Rig prefix "hq" collision: hq-refinery/hq-witness/hq-<polecat>
+		// should resolve as rig-level roles when "hq" is a registered prefix.
+		{
+			name:       "hq prefix witness",
+			session:    "hq-witness",
+			wantRole:   RoleWitness,
+			wantRig:    "knjn",
+			wantPrefix: "hq",
+		},
+		{
+			name:       "hq prefix refinery",
+			session:    "hq-refinery",
+			wantRole:   RoleRefinery,
+			wantRig:    "knjn",
+			wantPrefix: "hq",
+		},
+		{
+			name:       "hq prefix polecat",
+			session:    "hq-jasper",
+			wantRole:   RolePolecat,
+			wantRig:    "knjn",
+			wantName:   "jasper",
+			wantPrefix: "hq",
+		},
+		{
+			name:       "hq prefix crew",
+			session:    "hq-crew-rushd",
+			wantRole:   RoleCrew,
+			wantRig:    "knjn",
+			wantName:   "rushd",
+			wantPrefix: "hq",
 		},
 
 		// Witness (new format: <prefix>-witness)
@@ -342,6 +376,10 @@ func TestParseSessionName_RoundTrip(t *testing.T) {
 		"gt-morsov",
 		"hop-ostrom",
 		"sky-furiosa",
+		"hq-witness",
+		"hq-refinery",
+		"hq-jasper",
+		"hq-crew-rushd",
 	}
 
 	for _, sess := range sessions {


### PR DESCRIPTION
## Summary

- When a rig uses `"hq"` as its beads prefix (e.g., knjn), session names like `hq-refinery` and `hq-witness` collide with the `HQPrefix="hq-"` used for town-level roles
- `ParseSessionName("hq-refinery")` errored with "unknown hq- role" instead of resolving as a rig-level refinery
- Fix: in the `hq-` switch default case, fall through to rig-level prefix matching instead of returning an error
- Known town-level roles (mayor, deacon, boot, overseer, dogs) still match first; unknown suffixes resolve via `PrefixRegistry`

## Test plan

- [x] Added test cases for `hq-witness`, `hq-refinery`, `hq-jasper` (polecat), `hq-crew-rushd` with `"hq"` registered as a rig prefix
- [x] Added round-trip tests for all new cases
- [x] All 62 existing session package tests pass
- [x] Existing town-level role parsing (hq-mayor, hq-deacon, hq-boot, hq-overseer, hq-dog-*) unchanged

Fixes: `gt handoff fails: unknown session type hq-refinery`

🤖 Generated with [Claude Code](https://claude.com/claude-code)