### PR TITLE
fix: set window-style (pane background) at session creation

### DIFF
--- a/internal/cmd/theme.go
+++ b/internal/cmd/theme.go
@@ -195,9 +195,13 @@ func runThemeApply(cmd *cobra.Command, args []string) error {
 			theme = getThemeForRole(rig, role)
 		}
 
-		// Apply theme and status format
+		// Apply theme, window style, and status format
 		if err := t.ApplyTheme(sess, theme); err != nil {
 			fmt.Printf("  %s: failed (%v)\n", sess, err)
+			continue
+		}
+		if err := t.ApplyWindowStyle(sess, theme); err != nil {
+			fmt.Printf("  %s: failed to set window style (%v)\n", sess, err)
 			continue
 		}
 		if err := t.SetStatusFormat(sess, rig, worker, role); err != nil {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2642,6 +2642,14 @@ func (t *Tmux) ApplyTheme(session string, theme Theme) error {
 	return err
 }
 
+// ApplyWindowStyle sets the pane background (window-style) for a session.
+// This gives each session a distinct background color matching its theme,
+// complementing the status bar theme set by ApplyTheme.
+func (t *Tmux) ApplyWindowStyle(session string, theme Theme) error {
+	_, err := t.run("set-option", "-t", session, "window-style", theme.Style())
+	return err
+}
+
 // roleIcons maps role names to display icons for the status bar.
 // Uses centralized emojis from constants package.
 // Includes legacy keys ("coordinator", "health-check") for backwards compatibility.
@@ -2707,10 +2715,14 @@ func (t *Tmux) SetDynamicStatus(session string) error {
 }
 
 // ConfigureGasTownSession applies full Gas Town theming to a session.
-// This is a convenience method that applies theme, status format, and dynamic status.
+// This is a convenience method that applies theme, status format, dynamic status,
+// and pane background (window-style).
 func (t *Tmux) ConfigureGasTownSession(session string, theme Theme, rig, worker, role string) error {
 	if err := t.ApplyTheme(session, theme); err != nil {
 		return fmt.Errorf("applying theme: %w", err)
+	}
+	if err := t.ApplyWindowStyle(session, theme); err != nil {
+		return fmt.Errorf("applying window style: %w", err)
 	}
 	if err := t.SetStatusFormat(session, rig, worker, role); err != nil {
 		return fmt.Errorf("setting status format: %w", err)


### PR DESCRIPTION
## Summary

- Add `ApplyWindowStyle` method to `Tmux` that sets tmux `window-style` (pane background) for a session
- Call `ApplyWindowStyle` from `ConfigureGasTownSession` so pane backgrounds are set at session creation time, alongside the status bar theme
- Update `gt theme apply` to also set `window-style` when manually reapplying themes

## Problem

`ApplyTheme` only sets `status-style` (status bar color). Pane backgrounds (`window-style`) were only set by `gt-theme-panes` via the tmux `after-new-session` hook. If the hook wasn't installed when the session was created (e.g., session created before hook was in place), or if the hook was invoked with wrong session name, pane backgrounds would revert to the terminal default.

This was most visible with the Mayor session — gold status bar but default terminal background.

## Fix

Set `window-style` directly at session creation time in `ConfigureGasTownSession`, using the same theme colors already used for `status-style`. The `gt-theme-panes` hook remains as a secondary mechanism for sessions created outside the daemon lifecycle.

## Test plan

- [x] Existing theme tests pass (`go test ./internal/tmux/ ./internal/cmd/ ./internal/deacon/`)
- [x] Build passes (`go build ./...`)
- [ ] Manual verification: restart Mayor session, confirm pane background matches gold theme without needing to run `gt-theme-panes --all`

🤖 Generated with [Claude Code](https://claude.com/claude-code)