### PR TITLE
docs: Dolt login is required to join wasteland

### DIFF
--- a/docs/WASTELAND.md
+++ b/docs/WASTELAND.md
@@ -56,6 +56,12 @@ your rig handle and the destination for your fork of the commons database.
 
 ## Joining the Wasteland
 
+Before joining the wasteland, ensure your dolt is authenticated:
+
+```
+dolt login
+```
+
 From your Gas Town workspace directory:
 
 ```bash


### PR DESCRIPTION
## Summary
Documentation change: added a bit that tells users to run `dolt login` before joining a wasteland.
