### PR TITLE
fix: suppress clone progress output when --json flag is set (#2793)

### DIFF
--- a/internal/cmd/wl_browse.go
+++ b/internal/cmd/wl_browse.go
@@ -74,14 +74,20 @@ func runWLBrowse(cmd *cobra.Command, args []string) error {
 	cloneDir := filepath.Join(tmpDir, commonsDB)
 
 	remote := fmt.Sprintf("%s/%s", commonsOrg, commonsDB)
-	fmt.Printf("Cloning %s...\n", style.Bold.Render(remote))
+	if !wlBrowseJSON {
+		fmt.Printf("Cloning %s...\n", style.Bold.Render(remote))
+	}
 
 	cloneCmd := exec.Command(doltPath, "clone", remote, cloneDir)
-	cloneCmd.Stderr = os.Stderr
+	if !wlBrowseJSON {
+		cloneCmd.Stderr = os.Stderr
+	}
 	if err := cloneCmd.Run(); err != nil {
 		return fmt.Errorf("cloning %s: %w\nEnsure the database exists on DoltHub: https://www.dolthub.com/%s", remote, err, remote)
 	}
-	fmt.Printf("%s Cloned successfully\n\n", style.Bold.Render("✓"))
+	if !wlBrowseJSON {
+		fmt.Printf("%s Cloned successfully\n\n", style.Bold.Render("✓"))
+	}
 
 	query := buildBrowseQuery(BrowseFilter{
 		Status:   wlBrowseStatus,


### PR DESCRIPTION
## Summary

Fixes #2793 — `gt wl browse --json | jq` fails because "Cloning..." and "Cloned successfully" messages are printed to stdout before the JSON output, producing invalid JSON.

## Changes

- Wrap progress messages in `wl_browse.go` with `if !wlBrowseJSON` guards
- Suppress clone stderr in JSON mode to prevent dolt clone progress from contaminating output

## Test plan

- [X] `gt wl browse --json | jq` produces valid JSON without parse errors
- [X] `gt wl browse` (without --json) still shows clone progress as before

## Checklist
- [X] Code follows project style
- [X] Documentation updated (if applicable)
- [X] No breaking changes (or documented in summary)
