### PR TITLE
fix: add tini to dockerfile for reaping zombies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -17,6 +17,7 @@ RUN apt-get update && apt-get install -y \
     zsh \
     gh \
     netcat-openbsd \
+    tini \
     vim \
     && rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
 
@@ -51,5 +52,5 @@ RUN chmod +x /app/docker-entrypoint.sh
 
 WORKDIR /gt
 
-ENTRYPOINT ["/app/docker-entrypoint.sh"]
+ENTRYPOINT ["tini", "--", "/app/docker-entrypoint.sh"]
 CMD ["sleep", "infinity"]


### PR DESCRIPTION
## Summary
Add tini as PID 1 for dockerfile, otherwise zombies don't get reaped and collect (e.g. I got 64k dolt process zombies).
