### PR TITLE
feat: add gt wl show <work-id> command

### DIFF
--- a/internal/cmd/wl_fake_test.go
+++ b/internal/cmd/wl_fake_test.go
@@ -125,3 +125,7 @@ func (f *fakeWLCommonsStore) QueryWanted(wantedID string) (*doltserver.WantedIte
 	cp := *item
 	return &cp, nil
 }
+
+func (f *fakeWLCommonsStore) QueryWantedFull(wantedID string) (*doltserver.WantedItem, error) {
+	return f.QueryWanted(wantedID)
+}

--- a/internal/cmd/wl_show.go
+++ b/internal/cmd/wl_show.go
@@ -1,0 +1,277 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/doltserver"
+	"github.com/steveyegge/gastown/internal/style"
+	"github.com/steveyegge/gastown/internal/wasteland"
+	"github.com/steveyegge/gastown/internal/workspace"
+)
+
+var wlShowJSON bool
+
+var wlShowCmd = &cobra.Command{
+	Use:   "show <work-id>",
+	Short: "Show full details of a wanted item",
+	Long: `Display all fields of a single wanted item from the wl-commons database.
+
+Unlike 'gt wl browse' which truncates titles and omits descriptions,
+'gt wl show' displays every field of the item.
+
+The local wl-commons database is queried directly (kept in sync by gt wl sync).
+
+EXAMPLES:
+  gt wl show w-abc123             # Display all fields
+  gt wl show w-abc123 --json      # JSON output`,
+	Args: cobra.ExactArgs(1),
+	RunE: runWLShow,
+}
+
+func init() {
+	wlShowCmd.Flags().BoolVar(&wlShowJSON, "json", false, "Output as JSON")
+	wlCmd.AddCommand(wlShowCmd)
+}
+
+func runWLShow(cmd *cobra.Command, args []string) error {
+	wantedID := args[0]
+
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("not in a Gas Town workspace: %w", err)
+	}
+
+	doltPath, err := exec.LookPath("dolt")
+	if err != nil {
+		return fmt.Errorf("dolt not found in PATH — install from https://docs.dolthub.com/introduction/installation")
+	}
+
+	cloneDir, tmpDir, err := resolveWLCommonsClone(townRoot, doltPath)
+	if err != nil {
+		return err
+	}
+	if tmpDir != "" {
+		defer os.RemoveAll(tmpDir)
+	} else {
+		// Persistent clone exists — auto-fetch to freshen data.
+		autoFetchWLCommons(doltPath, cloneDir, townRoot)
+	}
+
+	query := buildWLShowQuery(wantedID)
+
+	if wlShowJSON {
+		sqlCmd := exec.Command(doltPath, "sql", "-q", query, "-r", "json")
+		sqlCmd.Dir = cloneDir
+		sqlCmd.Stdout = os.Stdout
+		sqlCmd.Stderr = os.Stderr
+		return sqlCmd.Run()
+	}
+
+	item, err := queryWantedFromClone(doltPath, cloneDir, wantedID)
+	if err != nil {
+		return err
+	}
+	return renderWantedItem(item)
+}
+
+// resolveWLCommonsClone finds the local wl-commons clone directory.
+// Returns (cloneDir, tmpDir, err). If tmpDir is non-empty, caller must
+// defer os.RemoveAll(tmpDir) — a temporary clone was created.
+func resolveWLCommonsClone(townRoot, doltPath string) (cloneDir, tmpDir string, err error) {
+	// Try wasteland config (set by gt wl join).
+	if cfg, cfgErr := wasteland.LoadConfig(townRoot); cfgErr == nil && cfg.LocalDir != "" {
+		if _, statErr := os.Stat(filepath.Join(cfg.LocalDir, ".dolt")); statErr == nil {
+			return cfg.LocalDir, "", nil
+		}
+	}
+
+	// Try standard location: .wasteland/hop/wl-commons.
+	stdPath := wasteland.LocalCloneDir(townRoot, "hop", "wl-commons")
+	if _, statErr := os.Stat(filepath.Join(stdPath, ".dolt")); statErr == nil {
+		return stdPath, "", nil
+	}
+
+	// Try common fallback locations.
+	if forkDir := findWLCommonsFork(townRoot); forkDir != "" {
+		return forkDir, "", nil
+	}
+
+	// No local clone — do a one-time clone-then-discard, like browse.
+	fmt.Fprintf(os.Stderr, "No local wl-commons clone found. Cloning temporarily.\nRun 'gt wl sync' to keep a persistent local copy.\n\n")
+	tmpDir, err = os.MkdirTemp("", "wl-show-*")
+	if err != nil {
+		return "", "", fmt.Errorf("creating temp directory: %w", err)
+	}
+	remote := "hop/wl-commons"
+	cloneDir = filepath.Join(tmpDir, "wl-commons")
+	fmt.Printf("Cloning %s...\n", style.Bold.Render(remote))
+	cloneCmd := exec.Command(doltPath, "clone", remote, cloneDir)
+	cloneCmd.Stderr = os.Stderr
+	if cloneErr := cloneCmd.Run(); cloneErr != nil {
+		os.RemoveAll(tmpDir)
+		return "", "", fmt.Errorf("cloning %s: %w\nEnsure the database exists on DoltHub: https://www.dolthub.com/%s", remote, cloneErr, remote)
+	}
+	return cloneDir, tmpDir, nil
+}
+
+// autoFetchWLCommons runs dolt fetch + merge on the local clone to freshen data.
+// Errors are non-fatal: the command proceeds with whatever local data exists.
+func autoFetchWLCommons(doltPath, cloneDir, townRoot string) {
+	// Use "upstream" remote if this is a wasteland fork, otherwise "origin".
+	remote := "origin"
+	if cfg, err := wasteland.LoadConfig(townRoot); err == nil && cfg.LocalDir == cloneDir {
+		remote = "upstream"
+	}
+	fetchCmd := exec.Command(doltPath, "fetch", remote)
+	fetchCmd.Dir = cloneDir
+	if err := fetchCmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to fetch from %s: %v\n", remote, err)
+		return
+	}
+	mergeCmd := exec.Command(doltPath, "merge", remote+"/main")
+	mergeCmd.Dir = cloneDir
+	if err := mergeCmd.Run(); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to merge %s/main: %v\n", remote, err)
+	}
+}
+
+// buildWLShowQuery returns the SELECT query for a single wanted item.
+func buildWLShowQuery(wantedID string) string {
+	return fmt.Sprintf(
+		"SELECT id, title,"+
+			" COALESCE(description, '') as description,"+
+			" COALESCE(project, '') as project,"+
+			" COALESCE(type, '') as type,"+
+			" priority,"+
+			" COALESCE(tags, JSON_ARRAY()) as tags,"+
+			" COALESCE(posted_by, '') as posted_by,"+
+			" COALESCE(claimed_by, '') as claimed_by,"+
+			" status,"+
+			" COALESCE(effort_level, '') as effort_level,"+
+			" COALESCE(evidence_url, '') as evidence_url,"+
+			" COALESCE(sandbox_required, 0) as sandbox_required,"+
+			" COALESCE(CAST(created_at AS CHAR), '') as created_at,"+
+			" COALESCE(CAST(updated_at AS CHAR), '') as updated_at"+
+			" FROM wanted WHERE id='%s'",
+		doltserver.EscapeSQL(wantedID))
+}
+
+// queryWantedFromClone queries a local dolt clone dir and returns the WantedItem.
+func queryWantedFromClone(doltPath, cloneDir, wantedID string) (*doltserver.WantedItem, error) {
+	query := buildWLShowQuery(wantedID)
+	sqlCmd := exec.Command(doltPath, "sql", "-q", query, "-r", "csv")
+	sqlCmd.Dir = cloneDir
+	output, err := sqlCmd.Output()
+	if err != nil {
+		if exitErr, ok := err.(*exec.ExitError); ok {
+			return nil, fmt.Errorf("query failed: %s", strings.TrimSpace(string(exitErr.Stderr)))
+		}
+		return nil, fmt.Errorf("running query: %w", err)
+	}
+
+	rows := wlParseCSV(string(output))
+	if len(rows) < 2 {
+		return nil, fmt.Errorf("wanted item %q not found", wantedID)
+	}
+
+	headers := rows[0]
+	values := rows[1]
+	data := make(map[string]string, len(headers))
+	for i, h := range headers {
+		if i < len(values) {
+			data[h] = values[i]
+		}
+	}
+
+	item := &doltserver.WantedItem{
+		ID:          data["id"],
+		Title:       data["title"],
+		Description: data["description"],
+		Project:     data["project"],
+		Type:        data["type"],
+		PostedBy:    data["posted_by"],
+		ClaimedBy:   data["claimed_by"],
+		Status:      data["status"],
+		EffortLevel: data["effort_level"],
+		EvidenceURL: data["evidence_url"],
+		CreatedAt:   data["created_at"],
+		UpdatedAt:   data["updated_at"],
+	}
+	if p := data["priority"]; p != "" {
+		_, _ = fmt.Sscanf(p, "%d", &item.Priority)
+	}
+	if data["sandbox_required"] == "1" {
+		item.SandboxRequired = true
+	}
+	if tagsJSON := data["tags"]; tagsJSON != "" && tagsJSON != "[]" {
+		_ = json.Unmarshal([]byte(tagsJSON), &item.Tags)
+	}
+	return item, nil
+}
+
+// showWanted contains the testable logic for displaying a wanted item.
+func showWanted(store doltserver.WLCommonsStore, wantedID string, asJSON bool) error {
+	item, err := store.QueryWantedFull(wantedID)
+	if err != nil {
+		return err
+	}
+
+	if asJSON {
+		data, err := json.MarshalIndent(item, "", "  ")
+		if err != nil {
+			return fmt.Errorf("marshaling JSON: %w", err)
+		}
+		fmt.Println(string(data))
+		return nil
+	}
+
+	return renderWantedItem(item)
+}
+
+func renderWantedItem(item *doltserver.WantedItem) error {
+	tags := strings.Join(item.Tags, ", ")
+
+	sandboxVal := "No"
+	if item.SandboxRequired {
+		sandboxVal = "Yes"
+	}
+
+	rows := []struct{ label, value string }{
+		{"ID", item.ID},
+		{"Title", item.Title},
+		{"Description", item.Description},
+		{"Project", item.Project},
+		{"Type", item.Type},
+		{"Priority", wlFormatPriority(fmt.Sprintf("%d", item.Priority))},
+		{"Tags", tags},
+		{"Posted By", item.PostedBy},
+		{"Claimed By", item.ClaimedBy},
+		{"Status", item.Status},
+		{"Effort", item.EffortLevel},
+		{"Evidence URL", item.EvidenceURL},
+		{"Sandbox", sandboxVal},
+		{"Created", item.CreatedAt},
+		{"Updated", item.UpdatedAt},
+	}
+
+	labelWidth := 13
+	indent := strings.Repeat(" ", labelWidth+2)
+	for _, r := range rows {
+		val := r.value
+		if val == "" {
+			val = "(none)"
+		}
+		lines := strings.Split(val, "\n")
+		fmt.Printf("%-*s  %s\n", labelWidth, r.label+":", lines[0])
+		for _, line := range lines[1:] {
+			fmt.Printf("%s%s\n", indent, line)
+		}
+	}
+	return nil
+}

--- a/internal/cmd/wl_show_test.go
+++ b/internal/cmd/wl_show_test.go
@@ -1,0 +1,180 @@
+package cmd
+
+import (
+	"encoding/json"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/doltserver"
+)
+
+func TestShowWantedJSON(t *testing.T) {
+	store := newFakeWLCommonsStore()
+	_ = store.InsertWanted(&doltserver.WantedItem{
+		ID:          "w-json1",
+		Title:       "Fix auth",
+		Description: "Auth is broken",
+		Project:     "gastown",
+		Type:        "bug",
+		Priority:    1,
+		Tags:        []string{"auth", "urgent"},
+		PostedBy:    "my-rig",
+		Status:      "open",
+		EffortLevel: "small",
+		EvidenceURL: "https://example.com",
+		CreatedAt:   "2026-01-01",
+		UpdatedAt:   "2026-01-02",
+	})
+
+	out := captureStdout(t, func() {
+		if err := showWanted(store, "w-json1", true); err != nil {
+			t.Errorf("showWanted() error: %v", err)
+		}
+	})
+
+	var item doltserver.WantedItem
+	if err := json.Unmarshal([]byte(out), &item); err != nil {
+		t.Fatalf("output is not valid JSON: %v\noutput: %s", err, out)
+	}
+	if item.ID != "w-json1" {
+		t.Errorf("ID = %q, want %q", item.ID, "w-json1")
+	}
+	if item.Title != "Fix auth" {
+		t.Errorf("Title = %q, want %q", item.Title, "Fix auth")
+	}
+	if item.Description != "Auth is broken" {
+		t.Errorf("Description = %q, want %q", item.Description, "Auth is broken")
+	}
+	if item.Priority != 1 {
+		t.Errorf("Priority = %d, want 1", item.Priority)
+	}
+	if len(item.Tags) != 2 {
+		t.Errorf("Tags = %v, want 2 elements", item.Tags)
+	}
+}
+
+func TestShowWantedText(t *testing.T) {
+	store := newFakeWLCommonsStore()
+	_ = store.InsertWanted(&doltserver.WantedItem{
+		ID:          "w-text1",
+		Title:       "Improve logging",
+		Description: "Add structured logs",
+		Project:     "gastown",
+		Type:        "feature",
+		Priority:    2,
+		Tags:        []string{"logging"},
+		PostedBy:    "their-rig",
+		Status:      "open",
+		EffortLevel: "medium",
+		EvidenceURL: "https://example.com/evidence",
+		CreatedAt:   "2026-02-01",
+		UpdatedAt:   "2026-02-02",
+	})
+
+	out := captureStdout(t, func() {
+		if err := showWanted(store, "w-text1", false); err != nil {
+			t.Errorf("showWanted() error: %v", err)
+		}
+	})
+
+	for _, want := range []string{
+		"ID:", "w-text1",
+		"Title:", "Improve logging",
+		"Description:", "Add structured logs",
+		"Project:", "gastown",
+		"Type:", "feature",
+		"Priority:", "P2",
+		"Tags:", "logging",
+		"Posted By:", "their-rig",
+		"Status:", "open",
+		"Effort:", "medium",
+		"Evidence URL:", "https://example.com/evidence",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q\nfull output:\n%s", want, out)
+		}
+	}
+}
+
+func TestShowWantedNotFound(t *testing.T) {
+	t.Parallel()
+	store := newFakeWLCommonsStore()
+
+	err := showWanted(store, "w-nonexistent", false)
+	if err == nil {
+		t.Fatal("showWanted() expected error for non-existent ID")
+	}
+	if !strings.Contains(err.Error(), "w-nonexistent") {
+		t.Errorf("error %q should mention the missing ID", err.Error())
+	}
+}
+
+func TestShowWantedEmptyFields(t *testing.T) {
+	store := newFakeWLCommonsStore()
+	_ = store.InsertWanted(&doltserver.WantedItem{
+		ID:    "w-sparse1",
+		Title: "Minimal item",
+		// All optional fields left empty
+	})
+
+	out := captureStdout(t, func() {
+		if err := showWanted(store, "w-sparse1", false); err != nil {
+			t.Errorf("showWanted() error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "w-sparse1") {
+		t.Errorf("output missing ID\nfull output:\n%s", out)
+	}
+	if !strings.Contains(out, "Minimal item") {
+		t.Errorf("output missing title\nfull output:\n%s", out)
+	}
+	// All labels must appear even when values are empty.
+	for _, label := range []string{
+		"ID:", "Title:", "Description:", "Project:", "Type:",
+		"Priority:", "Tags:", "Posted By:", "Claimed By:", "Status:",
+		"Effort:", "Evidence URL:",
+	} {
+		if !strings.Contains(out, label) {
+			t.Errorf("output missing label %q\nfull output:\n%s", label, out)
+		}
+	}
+	// Empty optional fields must render as "(none)".
+	if strings.Count(out, "(none)") == 0 {
+		t.Errorf("output missing (none) placeholder for empty fields\nfull output:\n%s", out)
+	}
+}
+
+func TestShowWantedMultilineDescription(t *testing.T) {
+	store := newFakeWLCommonsStore()
+	_ = store.InsertWanted(&doltserver.WantedItem{
+		ID:          "w-multi1",
+		Title:       "Complex task",
+		Description: "Line one\nLine two\nLine three",
+	})
+
+	out := captureStdout(t, func() {
+		if err := showWanted(store, "w-multi1", false); err != nil {
+			t.Errorf("showWanted() error: %v", err)
+		}
+	})
+
+	if !strings.Contains(out, "Line one") {
+		t.Errorf("output missing first line of description\nfull output:\n%s", out)
+	}
+	// All lines of a multiline description must appear.
+	if !strings.Contains(out, "Line two") {
+		t.Errorf("output missing second line of description\nfull output:\n%s", out)
+	}
+	if !strings.Contains(out, "Line three") {
+		t.Errorf("output missing third line of description\nfull output:\n%s", out)
+	}
+	// Continuation lines must be indented with the 15-char (labelWidth+2) prefix.
+	indent := strings.Repeat(" ", 15)
+	if !strings.Contains(out, indent+"Line two") {
+		t.Errorf("Line two not indented with %d-space prefix\nfull output:\n%s", 15, out)
+	}
+	if !strings.Contains(out, indent+"Line three") {
+		t.Errorf("Line three not indented with %d-space prefix\nfull output:\n%s", 15, out)
+	}
+}

--- a/internal/cmd/wl_test.go
+++ b/internal/cmd/wl_test.go
@@ -46,7 +46,7 @@ func TestWlCommandGroup(t *testing.T) {
 }
 
 func TestWlSubcommands(t *testing.T) {
-	expected := []string{"join", "post", "claim", "done", "browse", "sync"}
+	expected := []string{"join", "post", "claim", "done", "browse", "sync", "show"}
 	for _, name := range expected {
 		found := false
 		for _, c := range wlCmd.Commands() {
@@ -76,6 +76,15 @@ func TestWlDoneRequiresArg(t *testing.T) {
 	}
 	if err := wlDoneCmd.Args(wlDoneCmd, []string{"w-abc123"}); err != nil {
 		t.Errorf("done should accept 1 argument: %v", err)
+	}
+}
+
+func TestWlShowRequiresArg(t *testing.T) {
+	if err := wlShowCmd.Args(wlShowCmd, []string{}); err == nil {
+		t.Error("show should require exactly 1 argument")
+	}
+	if err := wlShowCmd.Args(wlShowCmd, []string{"w-abc123"}); err != nil {
+		t.Errorf("show should accept 1 argument: %v", err)
 	}
 }
 

--- a/internal/doltserver/wl_commons.go
+++ b/internal/doltserver/wl_commons.go
@@ -9,6 +9,7 @@ import (
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -27,6 +28,7 @@ type WLCommonsStore interface {
 	ClaimWanted(wantedID, rigHandle string) error
 	SubmitCompletion(completionID, wantedID, rigHandle, evidence string) error
 	QueryWanted(wantedID string) (*WantedItem, error)
+	QueryWantedFull(wantedID string) (*WantedItem, error)
 }
 
 // WLCommons implements WLCommonsStore using the real Dolt server.
@@ -47,21 +49,27 @@ func (w *WLCommons) SubmitCompletion(completionID, wantedID, rigHandle, evidence
 func (w *WLCommons) QueryWanted(wantedID string) (*WantedItem, error) {
 	return QueryWanted(w.townRoot, wantedID)
 }
+func (w *WLCommons) QueryWantedFull(wantedID string) (*WantedItem, error) {
+	return QueryWantedFull(w.townRoot, wantedID)
+}
 
 // WantedItem represents a row in the wanted table.
 type WantedItem struct {
-	ID              string
-	Title           string
-	Description     string
-	Project         string
-	Type            string
-	Priority        int
-	Tags            []string
-	PostedBy        string
-	ClaimedBy       string
-	Status          string
-	EffortLevel     string
-	SandboxRequired bool
+	ID              string   `json:"id"`
+	Title           string   `json:"title"`
+	Description     string   `json:"description,omitempty"`
+	Project         string   `json:"project,omitempty"`
+	Type            string   `json:"type,omitempty"`
+	Priority        int      `json:"priority"`
+	Tags            []string `json:"tags,omitempty"`
+	PostedBy        string   `json:"posted_by,omitempty"`
+	ClaimedBy       string   `json:"claimed_by,omitempty"`
+	Status          string   `json:"status"`
+	EffortLevel     string   `json:"effort_level,omitempty"`
+	EvidenceURL     string   `json:"evidence_url,omitempty"`
+	SandboxRequired bool     `json:"sandbox_required,omitempty"`
+	CreatedAt       string   `json:"created_at,omitempty"`
+	UpdatedAt       string   `json:"updated_at,omitempty"`
 }
 
 // isNothingToCommit returns true if the error indicates DOLT_COMMIT found no
@@ -370,6 +378,48 @@ func QueryWanted(townRoot, wantedID string) (*WantedItem, error) {
 		Title:     row["title"],
 		Status:    row["status"],
 		ClaimedBy: row["claimed_by"],
+	}
+	return item, nil
+}
+
+// QueryWantedFull fetches all fields of a wanted item by ID. Returns nil if not found.
+func QueryWantedFull(townRoot, wantedID string) (*WantedItem, error) {
+	query := fmt.Sprintf(`USE %s; SELECT id, title, COALESCE(description, '') as description, COALESCE(project, '') as project, COALESCE(type, '') as type, priority, COALESCE(tags, JSON_ARRAY()) as tags, COALESCE(posted_by, '') as posted_by, COALESCE(claimed_by, '') as claimed_by, status, COALESCE(effort_level, '') as effort_level, COALESCE(evidence_url, '') as evidence_url, COALESCE(sandbox_required, 0) as sandbox_required, COALESCE(CAST(created_at AS CHAR), '') as created_at, COALESCE(CAST(updated_at AS CHAR), '') as updated_at FROM wanted WHERE id='%s';`,
+		WLCommonsDB, EscapeSQL(wantedID))
+
+	output, err := doltSQLQuery(townRoot, query)
+	if err != nil {
+		return nil, err
+	}
+
+	rows := parseSimpleCSV(output)
+	if len(rows) == 0 {
+		return nil, fmt.Errorf("wanted item %q not found", wantedID)
+	}
+
+	row := rows[0]
+	item := &WantedItem{
+		ID:          row["id"],
+		Title:       row["title"],
+		Description: row["description"],
+		Project:     row["project"],
+		Type:        row["type"],
+		PostedBy:    row["posted_by"],
+		ClaimedBy:   row["claimed_by"],
+		Status:      row["status"],
+		EffortLevel: row["effort_level"],
+		EvidenceURL: row["evidence_url"],
+		CreatedAt:   row["created_at"],
+		UpdatedAt:   row["updated_at"],
+	}
+	if p := row["priority"]; p != "" {
+		_, _ = fmt.Sscanf(p, "%d", &item.Priority)
+	}
+	if row["sandbox_required"] == "1" {
+		item.SandboxRequired = true
+	}
+	if tagsJSON := row["tags"]; tagsJSON != "" && tagsJSON != "[]" {
+		_ = json.Unmarshal([]byte(tagsJSON), &item.Tags)
 	}
 	return item, nil
 }

--- a/internal/doltserver/wl_commons_fake_test.go
+++ b/internal/doltserver/wl_commons_fake_test.go
@@ -122,3 +122,7 @@ func (f *fakeWLCommonsStore) QueryWanted(wantedID string) (*WantedItem, error) {
 	cp := *item
 	return &cp, nil
 }
+
+func (f *fakeWLCommonsStore) QueryWantedFull(wantedID string) (*WantedItem, error) {
+	return f.QueryWanted(wantedID)
+}


### PR DESCRIPTION
## Summary

- Adds `gt wl show <work-id>` to display full details of a single wasteland wanted item, solving the problem of truncated titles and missing descriptions in `gt wl browse`
- Supports `--json` flag for machine-readable output
- Queries the local `.wasteland` clone with auto-fetch from upstream for fresh data

## Changes

- **`internal/cmd/wl_show.go`** — New cobra command with text and JSON output modes. Queries the local wasteland clone via `dolt` CLI subprocess. Auto-fetches upstream before querying to ensure fresh data. Falls back to clone-then-discard if no local clone exists.
- **`internal/doltserver/wl_commons.go`** — Extended `WantedItem` struct with JSON tags, `EvidenceURL`, `CreatedAt`, `UpdatedAt` fields. Added `QueryWantedFull()` to fetch all columns including tags (JSON array parsing).
- **`internal/cmd/wl_show_test.go`** — Unit tests covering JSON output, text output, not-found errors, empty fields (`(none)` placeholder), and multiline description indentation.
- **`internal/cmd/wl_fake_test.go`** / **`internal/doltserver/wl_commons_fake_test.go`** — Added `QueryWantedFull` to fake store implementations.

## Output examples

```
$ gt wl show w-hop-001
ID:            w-hop-001
Title:         Write public protocol spec (sanitized design.md)
Description:   Create a public-facing protocol specification...
Project:       hop
Type:          docs
Priority:      P1
Tags:          docs, protocol, specification
Posted By:     steveyegge
Claimed By:    (none)
Status:        open
Effort:        large
Evidence URL:  (none)
Sandbox:       No
Created:       2026-02-16 14:06:59
Updated:       2026-02-16 14:06:59
```

```
$ gt wl show w-hop-001 --json | jq .
{ "id": "w-hop-001", "title": "...", ... }
```

Closes #2792

## Test plan

- [x] `gt wl browse` → pick item → `gt wl show <id>` shows full details
- [x] `gt wl show <id> --json | jq` produces valid JSON with all fields
- [x] `gt wl show w-nonexistent` returns clear error
- [x] Empty optional fields display `(none)` in text mode
- [x] Unit tests pass: `go test ./internal/cmd/ -run TestShowWanted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)