### PR TITLE
fix: isolate 5 tests from live Dolt server and sandbox env

### DIFF
--- a/internal/cmd/dashboard_test.go
+++ b/internal/cmd/dashboard_test.go
@@ -24,8 +24,12 @@ func TestDashboardCmd_FlagsExist(t *testing.T) {
 	if bindFlag == nil {
 		t.Fatal("--bind flag should exist")
 	}
-	if bindFlag.DefValue != "127.0.0.1" {
-		t.Errorf("--bind default should be 127.0.0.1, got %s", bindFlag.DefValue)
+	wantBind := "127.0.0.1"
+	if os.Getenv("IS_SANDBOX") != "" {
+		wantBind = "0.0.0.0"
+	}
+	if bindFlag.DefValue != wantBind {
+		t.Errorf("--bind default should be %s, got %s", wantBind, bindFlag.DefValue)
 	}
 
 	openFlag := dashboardCmd.Flags().Lookup("open")

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -1137,7 +1137,7 @@ func TestResolveDoltPort_ConfigYAMLTakesPrecedence(t *testing.T) {
 }
 
 func TestResolveDoltPort_FromDaemonJSON(t *testing.T) {
-	t.Parallel()
+	t.Setenv("GT_DOLT_PORT", "") // isolate from live Dolt server
 	tmpDir := t.TempDir()
 	mayorDir := filepath.Join(tmpDir, "mayor")
 	if err := os.MkdirAll(mayorDir, 0755); err != nil {
@@ -1155,7 +1155,7 @@ func TestResolveDoltPort_FromDaemonJSON(t *testing.T) {
 }
 
 func TestResolveDoltPort_NoConfig(t *testing.T) {
-	t.Parallel()
+	t.Setenv("GT_DOLT_PORT", "") // isolate from live Dolt server
 	tmpDir := t.TempDir()
 	got := resolveDoltPort(tmpDir)
 	if got != 0 {
@@ -1201,7 +1201,8 @@ func TestAgentEnv_InjectsDoltPort(t *testing.T) {
 }
 
 func TestAgentEnv_NoDoltPortWithoutTownRoot(t *testing.T) {
-	t.Parallel()
+	t.Setenv("GT_DOLT_PORT", "")   // isolate from live Dolt server
+	t.Setenv("BEADS_DOLT_PORT", "") // isolate from live Dolt server
 	env := AgentEnv(AgentEnvConfig{
 		Role: "mayor",
 	})
@@ -1210,7 +1211,8 @@ func TestAgentEnv_NoDoltPortWithoutTownRoot(t *testing.T) {
 }
 
 func TestAgentEnv_NoDoltPortWithoutConfig(t *testing.T) {
-	t.Parallel()
+	t.Setenv("GT_DOLT_PORT", "")   // isolate from live Dolt server
+	t.Setenv("BEADS_DOLT_PORT", "") // isolate from live Dolt server
 	tmpDir := t.TempDir()
 	env := AgentEnv(AgentEnvConfig{
 		Role:     "mayor",


### PR DESCRIPTION
## Summary

Running `go test ./...` on a machine with a live Dolt server on port 3307 caused **production database corruption** — the `gt` and `hq` databases were destroyed because test code read `GT_DOLT_PORT` from the process environment and interacted with the live server instead of an isolated test instance.

This PR fixes 5 tests that were not properly isolated:

- **`TestDashboardCmd_FlagsExist`** (`internal/cmd/dashboard_test.go`): The `--bind` flag default is `0.0.0.0` when `IS_SANDBOX` is set, but the test hardcoded `127.0.0.1`. Fixed by checking the env var to determine the expected default, matching the `init()` logic in `dashboard.go`.

- **4 config tests** (`internal/config/env_test.go`): These tests assumed no Dolt server was running, but the live instance's `GT_DOLT_PORT=3307` leaked into `resolveDoltPort()` and `AgentEnv()`. Fixed by replacing `t.Parallel()` with `t.Setenv("GT_DOLT_PORT", "")` (and `BEADS_DOLT_PORT` where needed) to isolate from the process environment:
  - `TestResolveDoltPort_NoConfig`
  - `TestResolveDoltPort_FromDaemonJSON`
  - `TestAgentEnv_NoDoltPortWithoutTownRoot`
  - `TestAgentEnv_NoDoltPortWithoutConfig`

## Root cause

`resolveDoltPort()` checks `os.Getenv("GT_DOLT_PORT")` as its second resolution step. When a live Dolt server is running (as it always is in a Gas Town workspace), this env var is set to `3307`, which pollutes test assertions that expect no port or a different port from daemon.json.

## Test plan

- [x] All 5 previously-failing tests now pass
- [x] Full `go test ./internal/cmd/` passes
- [x] Full `go test ./internal/config/` passes
- [x] No regressions in other packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)