### PR TITLE
fix: dolt-archive pruning crash + auto-discover databases

### DIFF
--- a/plugins/dolt-archive/run.sh
+++ b/plugins/dolt-archive/run.sh
@@ -16,7 +16,7 @@ DOLT_USER="${DOLT_USER:-root}"
 DOLT_DATA_DIR="${DOLT_DATA_DIR:-$HOME/gt/.dolt-data}"
 JSONL_EXPORT_DIR="$HOME/gt/.dolt-archive/jsonl"
 BACKUP_REPO="$HOME/gt/.dolt-archive/git"
-DEFAULT_DBS="hq,bd,gt"
+DEFAULT_DBS="auto"
 SKIP_GIT=false
 SKIP_DOLT_PUSH=false
 
@@ -62,9 +62,22 @@ dolt_query_json() {
     --use-db "$db" sql -q "$query" --result-format json 2>>"$LOGFILE"
 }
 
-# --- Step 1: JSONL export ----------------------------------------------------
+# --- Step 1: Discover databases ----------------------------------------------
 
-IFS=',' read -ra PROD_DBS <<< "$DEFAULT_DBS"
+if [[ "$DEFAULT_DBS" == "auto" ]]; then
+  log "Auto-discovering databases from Dolt server..."
+  DISCOVERED=$(dolt_query "" "SHOW DATABASES" | grep -vE '^(information_schema|mysql|dolt)$')
+  if [[ -z "$DISCOVERED" ]]; then
+    log "ERROR: No user databases found on Dolt server at $DOLT_HOST:$DOLT_PORT"
+    exit 1
+  fi
+  IFS=$'\n' read -ra PROD_DBS <<< "$DISCOVERED"
+  log "Discovered databases: ${PROD_DBS[*]}"
+else
+  IFS=',' read -ra PROD_DBS <<< "$DEFAULT_DBS"
+fi
+
+# --- Step 2: JSONL export ----------------------------------------------------
 
 log "Starting archive cycle (databases: ${PROD_DBS[*]})"
 mkdir -p "$JSONL_EXPORT_DIR"
@@ -104,16 +117,16 @@ done
 
 # Prune old exports (keep last 24 snapshots per DB)
 for DB in "${PROD_DBS[@]}"; do
-  SNAPSHOTS=$(ls -t "$JSONL_EXPORT_DIR/${DB}-2"*.jsonl 2>/dev/null | tail -n +25)
-  if [[ -n "$SNAPSHOTS" ]]; then
-    echo "$SNAPSHOTS" | xargs rm -f
+  mapfile -t ALL_SNAPS < <(ls -t "$JSONL_EXPORT_DIR/${DB}-2"*.jsonl 2>/dev/null || true)
+  if (( ${#ALL_SNAPS[@]} > 24 )); then
+    printf '%s\n' "${ALL_SNAPS[@]:24}" | xargs rm -f
     log "Pruned old $DB snapshots"
   fi
 done
 
 log "JSONL export: $EXPORTED succeeded, $EXPORT_FAILED failed"
 
-# --- Step 2: Git commit and push ---------------------------------------------
+# --- Step 3: Git commit and push ---------------------------------------------
 
 GIT_PUSHED=false
 
@@ -158,7 +171,7 @@ elif ! $SKIP_GIT; then
   log "No git backup repo at $BACKUP_REPO — skipping git push"
 fi
 
-# --- Step 3: Dolt native push ------------------------------------------------
+# --- Step 4: Dolt native push ------------------------------------------------
 
 DOLT_PUSHED=0
 DOLT_PUSH_FAILED=0
@@ -198,7 +211,7 @@ if ! $SKIP_DOLT_PUSH; then
   log "Dolt push: $DOLT_PUSHED succeeded, $DOLT_PUSH_FAILED failed"
 fi
 
-# --- Step 4: Report results --------------------------------------------------
+# --- Step 5: Report results --------------------------------------------------
 
 log ""
 log "=== Archive Cycle Complete ==="


### PR DESCRIPTION
## Summary

Two bugs in `plugins/dolt-archive/run.sh` that cause the archive plugin to fail completely:

1. **Snapshot pruning crashes under `set -euo pipefail`** — The `ls -t "${DB}-2"*.jsonl | tail -n +25` pipeline fails when no snapshot files exist for a database. `ls` returns non-zero for unmatched globs, and `pipefail` propagates the failure, aborting the entire script mid-run.

2. **`DEFAULT_DBS` hardcodes deployment-specific database names** — Was set to `"hq,bd,gt"` but the correct names vary across deployments. This is the same bug fixed in PRs #2369, #2715, #2747, #2777, #2781 — the hardcoded list keeps drifting out of sync with production. Rather than picking yet another set of names, this PR defaults to `"auto"` which discovers databases via `SHOW DATABASES` at runtime, filtering out system databases (`information_schema`, `mysql`, `dolt`). The `--databases` flag still allows explicit override when needed.

## The DEFAULT_DBS churn

This hardcoded list has been wrong in at least 5 prior PRs:

| PR | Changed from | Changed to |
|----|-------------|------------|
| #2369 | `hq,beads,gastown` | `hq,beads,gt` |
| #2715 | `hq,bd,gastown` | `hq,gt,property_scrapers,wa` |
| #2747 | `hq,bd,gt` | proposed auto-discovery |
| #2777 | `hq,beads,gt` | `hq,beads,gastown` |
| #2781 | `hq,beads,gt` | `hq,beads,gastown` |

Every deployment has different databases. Hardcoding any specific list just creates the next bug. Auto-discovery via `SHOW DATABASES` eliminates this class of bug entirely while still allowing explicit `--databases db1,db2` override for targeted backups.

## Fix details

**Auto-discovery** (new Step 1):
```bash
# Default is now "auto" — queries the server for its databases
DEFAULT_DBS="auto"

# At runtime:
if [[ "$DEFAULT_DBS" == "auto" ]]; then
  DISCOVERED=$(dolt_query "" "SHOW DATABASES" | grep -vE '^(information_schema|mysql|dolt)$')
  IFS=$'\n' read -ra PROD_DBS <<< "$DISCOVERED"
fi
```

Still supports explicit override: `./run.sh --databases hq,mydb`

**Pruning fix**:
```bash
# Before (crashes when no files match):
SNAPSHOTS=$(ls -t "$JSONL_EXPORT_DIR/${DB}-2"*.jsonl 2>/dev/null | tail -n +25)

# After (handles empty results):
mapfile -t ALL_SNAPS < <(ls -t "$JSONL_EXPORT_DIR/${DB}-2"*.jsonl 2>/dev/null || true)
if (( ${#ALL_SNAPS[@]} > 24 )); then
    printf '%s\n' "${ALL_SNAPS[@]:24}" | xargs rm -f
```

## Impact

When both bugs trigger together (common on fresh deployments or after database renames), the archive plugin:
1. Fails to export any database (wrong names)
2. Crashes during pruning (no snapshots to prune for the nonexistent DBs)
3. Triggers critical escalation via `gt escalate` for every failed database
4. Dogs and overseer generate duplicate escalation storms that flood the mayor inbox

In our deployment, this produced 12+ critical/medium escalation beads over ~7 days before diagnosis.

## Related issues

- Relates to #2772 — rogue rig-level Dolt servers adopting port 3307 (dolt-archive connects to whatever is on 3307)
- Relates to #2770 — stale `sql-server.info` blocking `bd` in server mode (same infrastructure fragility)

## Test plan

- [ ] Run `./run.sh` with no arguments — should auto-discover and archive all user databases
- [ ] Run `./run.sh --databases hq,mydb` — explicit list should still work
- [ ] Run on a server with no existing snapshots — pruning should not crash
- [ ] Verify `information_schema`, `mysql`, `dolt` are excluded from auto-discovery

🤖 Generated with [Claude Code](https://claude.com/claude-code)