### PR TITLE
fix: compactor-dog run.sh false positive on concurrent writes

### DIFF
--- a/plugins/compactor-dog/run.sh
+++ b/plugins/compactor-dog/run.sh
@@ -350,8 +350,11 @@ for entry in "${CANDIDATES[@]}"; do
       log "  WARNING: Table $TABLE appeared after compaction (new table?)"
       continue
     fi
-    if [[ "$POST_COUNT" != "$PRE" ]]; then
-      log "  INTEGRITY FAILURE: $DB.$TABLE — pre=$PRE post=$POST_COUNT"
+    # Only fail on data loss (postCount < preCount).
+    # postCount > preCount is safe: concurrent writes during flatten add rows
+    # (merge base shifts, txn is preserved — see compactor_dog.go).
+    if [[ -n "$POST_COUNT" && "$POST_COUNT" -lt "$PRE" ]]; then
+      log "  INTEGRITY FAILURE: $DB.$TABLE — data loss: pre=$PRE post=$POST_COUNT"
       INTEGRITY_OK=false
     fi
   done <<< "$PRE_TABLES"


### PR DESCRIPTION
## Problem

The integrity check in `plugins/compactor-dog/run.sh` used strict inequality (`!=`) to detect data integrity failures. This incorrectly flags the case where `postCount > preCount`, which is actually safe — concurrent writes during the flatten operation can add rows, since the merge base shifts and transactions are preserved.

Only data loss (`postCount < preCount`) should fail.

## Fix

Change the check from:
```bash
if [[ "$POST_COUNT" != "$PRE" ]]; then
```
to:
```bash
if [[ -n "$POST_COUNT" && "$POST_COUNT" -lt "$PRE" ]]; then
```

This matches the logic in `compactor_dog.go` and the same fix already applied in the town-level `plugins/` directory.

## Testing

The fix is consistent with the Go implementation in `compactor_dog.go` which uses `<` for the row count comparison.