### PR TITLE
fix(test): use sleep sessions in TestCleanupOrphanedSessions to avoid .zshrc node

### DIFF
--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -973,20 +973,23 @@ func TestCleanupOrphanedSessions(t *testing.T) {
 	_ = tm.KillSession(hqSession)
 	_ = tm.KillSession(nonGtSession)
 
-	// Create zombie sessions (tmux alive, but just shell - no Claude)
-	if err := tm.NewSession(gtSession, ""); err != nil {
-		t.Fatalf("NewSession(gt): %v", err)
+	// Create zombie sessions (tmux alive, but process is sleep - no Claude/node).
+	// Use NewSessionWithCommand with sleep to avoid loading .zshrc, which spawns
+	// a node process on this system. A node child of the zsh shell would cause
+	// IsAgentAlive to return true, preventing cleanup (gt-it10f6p).
+	if err := tm.NewSessionWithCommand(gtSession, "", "sleep 9999"); err != nil {
+		t.Fatalf("NewSessionWithCommand(gt): %v", err)
 	}
 	defer func() { _ = tm.KillSession(gtSession) }()
 
-	if err := tm.NewSession(hqSession, ""); err != nil {
-		t.Fatalf("NewSession(hq): %v", err)
+	if err := tm.NewSessionWithCommand(hqSession, "", "sleep 9999"); err != nil {
+		t.Fatalf("NewSessionWithCommand(hq): %v", err)
 	}
 	defer func() { _ = tm.KillSession(hqSession) }()
 
 	// Create a non-GT session (should NOT be cleaned up)
-	if err := tm.NewSession(nonGtSession, ""); err != nil {
-		t.Fatalf("NewSession(other): %v", err)
+	if err := tm.NewSessionWithCommand(nonGtSession, "", "sleep 9999"); err != nil {
+		t.Fatalf("NewSessionWithCommand(other): %v", err)
 	}
 	defer func() { _ = tm.KillSession(nonGtSession) }()
 


### PR DESCRIPTION
## Problem

`TestCleanupOrphanedSessions` uses `NewSession("")` which creates a bare zsh shell that loads `.zshrc`. On some systems, `.zshrc` spawns a `node` process a few seconds after session creation.

`CleanupOrphanedSessions` kills the first test session (taking ~4s due to grace period). By the time it checks subsequent sessions, `node` has started as a descendant. `hasDescendantWithNames` finds `node` and `IsAgentAlive` returns `true`, preventing cleanup — causing the test to fail intermittently.

## Fix

Use `NewSessionWithCommand(name, "", "sleep 9999")` for all three test sessions instead of `NewSession("")`. The `sleep` process:
- Does not load `.zshrc`
- Has no `node` descendants
- Is correctly detected as a zombie by `CleanupOrphanedSessions`

## Testing

The fix ensures deterministic test behavior regardless of `.zshrc` contents on the host system.