### PR TITLE
Fix idle patrol agents burning CPU/tokens in handoff restart loop

### DIFF
--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/cli"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/events"
@@ -790,6 +791,17 @@ func buildRestartCommandWithOpts(sessionName string, opts buildRestartCommandOpt
 		} else {
 			beacon = "Your account was rotated to avoid a rate limit. Continue your previous task."
 		}
+	} else if isPatrolRole(simpleRole) {
+		// Patrol roles (refinery, witness, deacon) must re-enter their patrol
+		// loop on handoff, not "wait for instructions." Without this, idle
+		// patrol agents cycle through handoff→prime→no-work→handoff burning
+		// CPU and tokens indefinitely. The patrol instruction ensures they
+		// reach the await-event idle state in their burn-or-loop step.
+		beacon = session.BuildStartupPrompt(session.BeaconConfig{
+			Recipient: identity.BeaconAddress(),
+			Sender:    "self",
+			Topic:     "patrol",
+		}, "Run `"+cli.Name()+" prime --hook` and begin patrol.")
 	} else {
 		beacon = session.FormatStartupBeacon(session.BeaconConfig{
 			Recipient: identity.BeaconAddress(),
@@ -1637,4 +1649,15 @@ func recordHandoffTime() {
 	_ = os.MkdirAll(runtimeDir, 0755)
 	tsPath := filepath.Join(runtimeDir, constants.FileLastHandoffTS)
 	_ = os.WriteFile(tsPath, []byte(fmt.Sprintf("%d", time.Now().Unix())), 0644)
+}
+
+// isPatrolRole returns true if the role runs a patrol loop (refinery, witness, deacon).
+// Patrol roles must re-enter their patrol molecule on handoff rather than
+// "waiting for instructions," which leads to idle CPU burn.
+func isPatrolRole(role string) bool {
+	switch role {
+	case "refinery", "witness", "deacon":
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
## Summary

- Patrol roles (refinery, witness, deacon) were entering a handoff→prime→no-work→handoff cycle, burning CPU and API tokens while nominally idle
- Root cause: after handoff, patrol agents received a generic "wait for instructions" beacon instead of being told to re-enter their patrol loop
- Fix adds a `isPatrolRole()` check in `buildRestartCommandWithOpts` that sends a patrol-specific beacon, so agents reach their proper await-event idle state

## Test plan

- [ ] Deploy locally and verify patrol agents (witness, refinery, deacon) idle correctly after handoff
- [ ] Confirm non-patrol roles (mayor, polecat) still receive the standard beacon
- [ ] Monitor token usage to confirm idle burn has stopped

🤖 Generated with [Claude Code](https://claude.com/claude-code)