### PR TITLE
fix: commit remaining f8ii6 installation customizations (dolt-archive DBs + compactor_dog.go integrity)

### DIFF
--- a/internal/daemon/compactor_dog.go
+++ b/internal/daemon/compactor_dog.go
@@ -311,8 +311,8 @@ func (d *Daemon) compactDatabase(dbName string) error {
 		if !ok {
 			return fmt.Errorf("integrity check: table %q missing after compaction", table)
 		}
-		if preCount != postCount {
-			return fmt.Errorf("integrity check: table %q count mismatch: pre=%d post=%d", table, preCount, postCount)
+		if postCount < preCount {
+			return fmt.Errorf("integrity check: table %q lost rows: pre=%d post=%d", table, preCount, postCount)
 		}
 	}
 	d.logger.Printf("compactor_dog: %s: integrity verified (%d tables match)", dbName, len(preCounts))

--- a/plugins/dolt-archive/plugin.md
+++ b/plugins/dolt-archive/plugin.md
@@ -32,7 +32,7 @@ whether the other layers work.
 
 ```bash
 DOLT_DATA_DIR="$HOME/gt/.dolt-data"
-PROD_DBS=("hq" "bd" "gt")
+PROD_DBS=("hq" "gt" "property_scrapers" "wa")
 JSONL_EXPORT_DIR="$HOME/gt/.dolt-archive/jsonl"
 DOLT_HOST="127.0.0.1"
 DOLT_PORT=3307

--- a/plugins/dolt-archive/run.sh
+++ b/plugins/dolt-archive/run.sh
@@ -16,7 +16,7 @@ DOLT_USER="${DOLT_USER:-root}"
 DOLT_DATA_DIR="${DOLT_DATA_DIR:-$HOME/gt/.dolt-data}"
 JSONL_EXPORT_DIR="$HOME/gt/.dolt-archive/jsonl"
 BACKUP_REPO="$HOME/gt/.dolt-archive/git"
-DEFAULT_DBS="hq,bd,gt"
+DEFAULT_DBS="hq,gt,property_scrapers,wa"
 SKIP_GIT=false
 SKIP_DOLT_PUSH=false
 


### PR DESCRIPTION
## Summary

Three uncommitted local installation customizations left over from gt-f8ii6:

- **dolt-archive/run.sh**: update `DEFAULT_DBS` from `hq,bd,gt` to `hq,gt,property_scrapers,wa` — `bd` was renamed to `gt`; `property_scrapers` and `wa` are production databases that need archiving
- **dolt-archive/plugin.md**: update Config section docs to match the correct database list
- **internal/daemon/compactor_dog.go**: use `<` instead of `!=` for the row-count integrity check — only fail when rows are *lost*, not when new rows appear during compaction (mirrors the `-lt` fix already applied in `plugins/compactor-dog/run.sh` via PR #2733)

## Context

The `compactor_dog.go` fix is the Go-daemon equivalent of the shell script fix from PR #2733 (`fix: exclude views from compactor-dog integrity check` series). The shell script compactor already uses `-lt` but the Go daemon still used `!=`, causing false-positive integrity failures when rows are written during compaction.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] dolt-archive plugin runs against all 4 production databases: `hq`, `gt`, `property_scrapers`, `wa`
- [ ] compactor_dog integrity check no longer triggers on concurrent writes

🤖 Generated with [Claude Code](https://claude.com/claude-code)