### PR TITLE
fix(test): add Handler to fully-configured fixture in lifecycle_defaults_test

### DIFF
--- a/internal/daemon/lifecycle_defaults_test.go
+++ b/internal/daemon/lifecycle_defaults_test.go
@@ -143,6 +143,7 @@ func TestEnsureLifecycleDefaults_FullyConfigured(t *testing.T) {
 			JsonlGitBackup:       &JsonlGitBackupConfig{Enabled: false},
 			DoltBackup:           &DoltBackupConfig{Enabled: false},
 			ScheduledMaintenance: &ScheduledMaintenanceConfig{Enabled: false, Threshold: &threshold},
+			Handler:              &PatrolConfig{Enabled: false},
 		},
 	}
 


### PR DESCRIPTION
## Summary
- `EnsureLifecycleDefaults` now fills in a default Handler patrol when nil
- The fully-configured fixture in `lifecycle_defaults_test.go` was missing `Handler`, causing the 'no changes' assertion to fail
- Adds `Handler: &PatrolConfig{Enabled: false}` to the test fixture

## Test plan
- [ ] CI passes on this standalone change
- [ ] `lifecycle_defaults_test.go` tests pass