### PR TITLE
fix: replace hyphens with underscores in rig name examples (gs-6gj)

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -76,8 +76,8 @@ Use --adopt to register an existing directory instead of creating new:
 
 Example:
   gt rig add gastown https://github.com/steveyegge/gastown
-  gt rig add my-project git@github.com:user/repo.git --prefix mp
-  gt rig add existing-rig --adopt`,
+  gt rig add my_project git@github.com:user/repo.git --prefix mp
+  gt rig add existing_rig --adopt`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: runRigAdd,
 }

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -1102,7 +1102,7 @@ func (m *Manager) ensureGitignoreEntry(gitignorePath, entry string) error {
 }
 
 // deriveBeadsPrefix generates a beads prefix from a rig name.
-// Examples: "gastown" -> "gt", "my-project" -> "mp", "foo" -> "foo"
+// Examples: "gastown" -> "gt", "my_project" -> "mp", "foo" -> "foo"
 func deriveBeadsPrefix(name string) string {
 	// Strip path separators — callers should validate names, but be defensive
 	name = filepath.Base(name)

--- a/internal/web/setup.go
+++ b/internal/web/setup.go
@@ -790,7 +790,7 @@ const setupHTML = `<!DOCTYPE html>
             </p>
             <div class="form-group">
                 <label>Rig Name</label>
-                <input type="text" id="rig-name" placeholder="my-project">
+                <input type="text" id="rig-name" placeholder="my_project">
                 <div class="hint">Short name for this rig (no spaces)</div>
             </div>
             <div class="form-group">


### PR DESCRIPTION
## Summary
- Fix help text for `gt rig add` that showed hyphenated examples (e.g., `my-project`) which the validator rejects
- Updated to use underscores (`my_project`, `existing_rig`) to match what the validator accepts
- Files changed: `internal/cmd/rig.go`, `internal/rig/manager.go`, `internal/web/setup.go`

Upstream issue: https://github.com/steveyegge/gastown/issues/2769
Bead: gs-6gj

## Test plan
- [ ] Verify `gt rig add --help` shows underscore examples
- [ ] Verify existing rig functionality not affected

🤖 Generated with [Claude Code](https://claude.com/claude-code)