### PR TITLE
fix: clean stale sql-server.info before bd commands in server mode (gs-bwm)

### DIFF
--- a/internal/beads/stale_pid.go
+++ b/internal/beads/stale_pid.go
@@ -44,3 +44,45 @@ func CleanStaleDoltServerPID(beadsDir string) {
 		fmt.Fprintf(os.Stderr, "Cleaned stale dolt-server.pid (PID %d) from %s\n", pid, beadsDir)
 	}
 }
+
+// CleanStaleSQLServerInfo removes the sql-server.info file inside
+// .beads/dolt/.dolt/ if the referenced process is no longer alive. Dolt writes
+// this file (format: "PID:PORT:UUID") when starting a SQL server. In server
+// mode, this local lock file is irrelevant — bd should connect directly to the
+// central Dolt server — but a stale copy causes bd to refuse to connect,
+// producing "database not found" errors even though the central server is
+// healthy.
+func CleanStaleSQLServerInfo(beadsDir string) {
+	infoPath := filepath.Join(beadsDir, "dolt", ".dolt", "sql-server.info")
+	data, err := os.ReadFile(infoPath) //nolint:gosec // G304: path is constructed internally
+	if err != nil {
+		return // No info file, nothing to clean
+	}
+
+	// Format: "PID:PORT:UUID"
+	parts := strings.SplitN(strings.TrimSpace(string(data)), ":", 3)
+	if len(parts) < 1 {
+		_ = os.Remove(infoPath)
+		return
+	}
+
+	pid, err := strconv.Atoi(parts[0])
+	if err != nil || pid <= 0 {
+		// Corrupt info file — remove it
+		_ = os.Remove(infoPath)
+		return
+	}
+
+	// Check if the process is alive using signal 0 (no-op probe)
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		_ = os.Remove(infoPath)
+		return
+	}
+
+	if err := proc.Signal(syscall.Signal(0)); err != nil {
+		// Process is dead — remove stale info file
+		_ = os.Remove(infoPath)
+		fmt.Fprintf(os.Stderr, "Cleaned stale sql-server.info (PID %d) from %s\n", pid, beadsDir)
+	}
+}

--- a/internal/beads/stale_pid_test.go
+++ b/internal/beads/stale_pid_test.go
@@ -1,0 +1,99 @@
+package beads
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCleanStaleSQLServerInfo_NoFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Should not panic or error when file doesn't exist
+	CleanStaleSQLServerInfo(tmpDir)
+}
+
+func TestCleanStaleSQLServerInfo_StaleProcess(t *testing.T) {
+	tmpDir := t.TempDir()
+	doltDir := filepath.Join(tmpDir, "dolt", ".dolt")
+	if err := os.MkdirAll(doltDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	infoPath := filepath.Join(doltDir, "sql-server.info")
+	// PID 999999999 is almost certainly not running
+	if err := os.WriteFile(infoPath, []byte("999999999:3307:some-uuid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	CleanStaleSQLServerInfo(tmpDir)
+
+	if _, err := os.Stat(infoPath); !os.IsNotExist(err) {
+		t.Error("expected stale sql-server.info to be removed")
+	}
+}
+
+func TestCleanStaleSQLServerInfo_LiveProcess(t *testing.T) {
+	tmpDir := t.TempDir()
+	doltDir := filepath.Join(tmpDir, "dolt", ".dolt")
+	if err := os.MkdirAll(doltDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	infoPath := filepath.Join(doltDir, "sql-server.info")
+	// Use our own PID — guaranteed to be alive
+	content := fmt.Sprintf("%d:3307:some-uuid", os.Getpid())
+	if err := os.WriteFile(infoPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	CleanStaleSQLServerInfo(tmpDir)
+
+	if _, err := os.Stat(infoPath); os.IsNotExist(err) {
+		t.Error("expected sql-server.info for live process to be preserved")
+	}
+}
+
+func TestCleanStaleSQLServerInfo_MalformedFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	doltDir := filepath.Join(tmpDir, "dolt", ".dolt")
+	if err := os.MkdirAll(doltDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	infoPath := filepath.Join(doltDir, "sql-server.info")
+	if err := os.WriteFile(infoPath, []byte("not-a-pid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	CleanStaleSQLServerInfo(tmpDir)
+
+	if _, err := os.Stat(infoPath); !os.IsNotExist(err) {
+		t.Error("expected malformed sql-server.info to be removed")
+	}
+}
+
+func TestCleanStaleDoltServerPID_NoFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Should not panic or error when file doesn't exist
+	CleanStaleDoltServerPID(tmpDir)
+}
+
+func TestCleanStaleDoltServerPID_StaleProcess(t *testing.T) {
+	tmpDir := t.TempDir()
+	doltDir := filepath.Join(tmpDir, "dolt")
+	if err := os.MkdirAll(doltDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	pidPath := filepath.Join(doltDir, "dolt-server.pid")
+	if err := os.WriteFile(pidPath, []byte("999999999"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	CleanStaleDoltServerPID(tmpDir)
+
+	if _, err := os.Stat(pidPath); !os.IsNotExist(err) {
+		t.Error("expected stale dolt-server.pid to be removed")
+	}
+}

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -182,7 +182,8 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewPrefixConflictCheck())
 	d.Register(doctor.NewRigNameMismatchCheck())
 	d.Register(doctor.NewRigConfigSyncCheck()) // Check all registered rigs have config.json
-	d.Register(doctor.NewStaleDoltPortCheck()) // Check for stale Dolt port files
+	d.Register(doctor.NewStaleDoltPortCheck())       // Check for stale Dolt port files
+	d.Register(doctor.NewStaleSQLServerInfoCheck()) // Check for stale sql-server.info files
 	d.Register(doctor.NewPrefixMismatchCheck())
 	d.Register(doctor.NewDatabasePrefixCheck())
 	d.Register(doctor.NewIdleTimeoutCheck()) // Verify dolt.idle-timeout: "0" for all rigs

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -143,6 +143,7 @@ func upgradeDoctor(townRoot string) upgradeResult {
 	d.Register(doctor.NewStaleTaskDispatchCheck())
 	d.Register(doctor.NewHooksSyncCheck())
 	d.Register(doctor.NewStaleDoltPortCheck())
+	d.Register(doctor.NewStaleSQLServerInfoCheck())
 	d.Register(doctor.NewSparseCheckoutCheck())
 	d.Register(doctor.NewPrimingCheck())
 	d.Register(doctor.NewLifecycleHygieneCheck())

--- a/internal/doctor/stale_sql_server_info_check.go
+++ b/internal/doctor/stale_sql_server_info_check.go
@@ -1,0 +1,142 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+
+	"github.com/steveyegge/gastown/internal/config"
+)
+
+// StaleSQLServerInfoCheck detects stale sql-server.info files in .beads/dolt/.dolt/
+// directories. These files are written by Dolt when starting a SQL server and contain
+// "PID:PORT:UUID". In server mode, a stale copy causes bd to refuse to connect,
+// producing "database not found" errors even though the central Dolt server is healthy.
+type StaleSQLServerInfoCheck struct {
+	FixableCheck
+	staleFiles []staleInfoFile
+}
+
+type staleInfoFile struct {
+	path string
+	pid  int
+}
+
+// NewStaleSQLServerInfoCheck creates a new stale sql-server.info check.
+func NewStaleSQLServerInfoCheck() *StaleSQLServerInfoCheck {
+	return &StaleSQLServerInfoCheck{
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "stale-sql-server-info",
+				CheckDescription: "Detect stale sql-server.info files in beads directories",
+				CheckCategory:    CategoryCleanup,
+			},
+		},
+	}
+}
+
+// Run checks for stale sql-server.info files across all beads directories.
+func (c *StaleSQLServerInfoCheck) Run(ctx *CheckContext) *CheckResult {
+	c.staleFiles = nil
+
+	var details []string
+
+	// Collect all beads directories to check
+	beadsDirs := findAllBeadsDirs(ctx.TownRoot)
+
+	for _, beadsDir := range beadsDirs {
+		infoPath := filepath.Join(beadsDir, "dolt", ".dolt", "sql-server.info")
+		data, err := os.ReadFile(infoPath) //nolint:gosec // G304: path is constructed internally
+		if err != nil {
+			continue // No info file
+		}
+
+		// Format: "PID:PORT:UUID"
+		parts := strings.SplitN(strings.TrimSpace(string(data)), ":", 3)
+		if len(parts) < 1 {
+			c.staleFiles = append(c.staleFiles, staleInfoFile{path: infoPath, pid: 0})
+			relPath, _ := filepath.Rel(ctx.TownRoot, infoPath)
+			details = append(details, fmt.Sprintf("Malformed sql-server.info: %s", relPath))
+			continue
+		}
+
+		pid, err := strconv.Atoi(parts[0])
+		if err != nil || pid <= 0 {
+			c.staleFiles = append(c.staleFiles, staleInfoFile{path: infoPath, pid: 0})
+			relPath, _ := filepath.Rel(ctx.TownRoot, infoPath)
+			details = append(details, fmt.Sprintf("Malformed sql-server.info: %s", relPath))
+			continue
+		}
+
+		// Check if the process is alive
+		proc, err := os.FindProcess(pid)
+		if err != nil {
+			c.staleFiles = append(c.staleFiles, staleInfoFile{path: infoPath, pid: pid})
+			relPath, _ := filepath.Rel(ctx.TownRoot, infoPath)
+			details = append(details, fmt.Sprintf("Stale sql-server.info (PID %d, process not found): %s", pid, relPath))
+			continue
+		}
+
+		if err := proc.Signal(syscall.Signal(0)); err != nil {
+			c.staleFiles = append(c.staleFiles, staleInfoFile{path: infoPath, pid: pid})
+			relPath, _ := filepath.Rel(ctx.TownRoot, infoPath)
+			details = append(details, fmt.Sprintf("Stale sql-server.info (PID %d, process dead): %s", pid, relPath))
+		}
+	}
+
+	if len(c.staleFiles) == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "No stale sql-server.info files found",
+		}
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusWarning,
+		Message: fmt.Sprintf("%d stale sql-server.info file(s)", len(c.staleFiles)),
+		Details: details,
+		FixHint: "Run 'gt doctor --fix' to remove stale sql-server.info files",
+	}
+}
+
+// Fix removes stale sql-server.info files.
+func (c *StaleSQLServerInfoCheck) Fix(ctx *CheckContext) error {
+	for _, info := range c.staleFiles {
+		if err := os.Remove(info.path); err != nil && !os.IsNotExist(err) {
+			return fmt.Errorf("could not remove %s: %w", info.path, err)
+		}
+	}
+	return nil
+}
+
+// findAllBeadsDirs returns all .beads directories in the town.
+func findAllBeadsDirs(townRoot string) []string {
+	var dirs []string
+
+	// Town-level .beads
+	townBeads := filepath.Join(townRoot, ".beads")
+	if info, err := os.Stat(townBeads); err == nil && info.IsDir() {
+		dirs = append(dirs, townBeads)
+	}
+
+	// Rig-level .beads directories
+	rigsConfigPath := filepath.Join(townRoot, "mayor", "rigs.json")
+	rigsConfig, err := config.LoadRigsConfig(rigsConfigPath)
+	if err != nil {
+		return dirs
+	}
+
+	for rigName := range rigsConfig.Rigs {
+		rigBeads := filepath.Join(townRoot, rigName, "mayor", "rig", ".beads")
+		if info, err := os.Stat(rigBeads); err == nil && info.IsDir() {
+			dirs = append(dirs, rigBeads)
+		}
+	}
+
+	return dirs
+}

--- a/internal/doctor/stale_sql_server_info_check_test.go
+++ b/internal/doctor/stale_sql_server_info_check_test.go
@@ -1,0 +1,136 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestStaleSQLServerInfoCheck_NoFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupMinimalTown(t, tmpDir)
+
+	check := NewStaleSQLServerInfoCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when no sql-server.info exists, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestStaleSQLServerInfoCheck_StaleFile(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupMinimalTown(t, tmpDir)
+
+	// Create stale sql-server.info in town .beads
+	doltDir := filepath.Join(tmpDir, ".beads", "dolt", ".dolt")
+	if err := os.MkdirAll(doltDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// PID 999999999 is almost certainly dead
+	if err := os.WriteFile(filepath.Join(doltDir, "sql-server.info"), []byte("999999999:3307:some-uuid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewStaleSQLServerInfoCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning for stale sql-server.info, got %v: %s", result.Status, result.Message)
+	}
+	if len(result.Details) == 0 {
+		t.Error("expected details to describe the stale file")
+	}
+}
+
+func TestStaleSQLServerInfoCheck_LiveProcess(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupMinimalTown(t, tmpDir)
+
+	// Create sql-server.info with our own PID (alive)
+	doltDir := filepath.Join(tmpDir, ".beads", "dolt", ".dolt")
+	if err := os.MkdirAll(doltDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := fmt.Sprintf("%d:3307:some-uuid", os.Getpid())
+	if err := os.WriteFile(filepath.Join(doltDir, "sql-server.info"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewStaleSQLServerInfoCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK for live process, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestStaleSQLServerInfoCheck_FixRemovesFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	setupMinimalTown(t, tmpDir)
+
+	// Create stale sql-server.info
+	doltDir := filepath.Join(tmpDir, ".beads", "dolt", ".dolt")
+	if err := os.MkdirAll(doltDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	infoPath := filepath.Join(doltDir, "sql-server.info")
+	if err := os.WriteFile(infoPath, []byte("999999999:3307:some-uuid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewStaleSQLServerInfoCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	// Run to detect
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning before fix, got %v", result.Status)
+	}
+
+	// Fix
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix() failed: %v", err)
+	}
+
+	// Verify removed
+	if _, err := os.Stat(infoPath); !os.IsNotExist(err) {
+		t.Error("expected sql-server.info to be removed after fix")
+	}
+
+	// Re-run check should pass
+	result = check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK after fix, got %v: %s", result.Status, result.Message)
+	}
+}
+
+// setupMinimalTown creates the minimum directory structure for a town.
+func setupMinimalTown(t *testing.T, tmpDir string) {
+	t.Helper()
+
+	// Create mayor/rigs.json
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	rigs := map[string]interface{}{"rigs": map[string]interface{}{}}
+	rigsBytes, _ := json.Marshal(rigs)
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), rigsBytes, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create .beads directory
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/mail/bd.go
+++ b/internal/mail/bd.go
@@ -57,10 +57,11 @@ func (e *bdError) ContainsError(substr string) bool {
 func runBdCommand(ctx context.Context, args []string, workDir, beadsDir string, extraEnv ...string) (_ []byte, retErr error) {
 	defer func() { telemetry.RecordMail(ctx, "bd."+firstArg(args), retErr) }()
 
-	// Remove stale dolt-server.pid before spawning bd. A stale PID file causes
-	// bd to connect to port 3307 which may be occupied by a different Dolt server
-	// serving different databases, resulting in hangs until the read timeout kills it.
+	// Remove stale Dolt state files before spawning bd. A stale PID or
+	// sql-server.info file causes bd to connect to the wrong port or refuse
+	// to connect, resulting in hangs or "database not found" errors.
 	beads.CleanStaleDoltServerPID(beadsDir)
+	beads.CleanStaleSQLServerInfo(beadsDir)
 
 	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Dir = workDir


### PR DESCRIPTION
## Summary
- Add `CleanStaleSQLServerInfo()` to remove stale `sql-server.info` files before bd commands in server mode
- Add `gt doctor` check to detect and fix stale `sql-server.info` across all beads directories
- Prevents "database not found" errors when stale lock files exist but central Dolt server is healthy

Upstream issue: https://github.com/steveyegge/gastown/issues/2770
Bead: gs-bwm

## Test plan
- [ ] Verify bd commands work when stale sql-server.info exists
- [ ] Verify `gt doctor` detects and fixes stale sql-server.info files
- [ ] Run new unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)