### PR TITLE
fix: stop creating agent identity beads as ephemeral wisps (gs-smm)

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -221,7 +221,6 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 			"--description=" + description,
 			"--type=agent",
 			"--labels=gt:agent",
-			"--ephemeral",
 		}
 		if NeedsForceForID(id) {
 			a = append(a, "--force")
@@ -234,8 +233,9 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 		return a
 	}
 
-	// Create ephemeral agent bead (wisps table). Agent operational state has
-	// zero git history consumers (gt-bewatn.9).
+	// Create agent bead in the issues table (not wisps). Agent beads must
+	// persist across sessions — ephemeral wisps get deleted by routine GC,
+	// causing identity lookup failures (GH#2768).
 	out, err := b.run(buildArgs()...)
 	if err != nil {
 		out, err = b.run(buildArgs()...)
@@ -344,13 +344,6 @@ func (b *Beads) CreateOrReopenAgentBead(id, title string, fields *AgentFields) (
 	if _, err := target.run("update", id, "--type=agent"); err != nil {
 		return nil, fmt.Errorf("fixing agent bead type: %w", err)
 	}
-	// Ensure agent bead is ephemeral (wisp) — agent operational state has
-	// zero git history consumers (gt-bewatn.9)
-	if _, err := target.run("update", id, "--ephemeral"); err != nil {
-		// Non-fatal: the bead is functional without ephemeral flag
-		_ = err
-	}
-
 	// Note: role slot no longer set - role definitions are config-based
 
 	// Set hook_bead slot so gt mol status can find hooked work via the


### PR DESCRIPTION
## Summary
- Agent identity beads were being created in the ephemeral wisps table, causing routine wisp GC to delete them
- Changed CreateOrReopenAgentBead to create agent beads in the persistent issues table instead
- Removed the ephemeral flag setting in FixAgentBeadType that forced beads into wisps

Fixes GH#2768

## Test plan
- [ ] Verify new agent beads are created in issues table, not wisps
- [ ] Verify existing agent bead lookup still works (ListAgentBeads merges both sources)
- [ ] Verify wisp GC no longer deletes agent beads

Generated by Gas Town polecat nux (gs-smm)