### PR TITLE
fix: use runWithRouting for cross-prefix dep persistence (gs-aa6)

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -1406,14 +1406,17 @@ func (b *Beads) ReleaseWithReason(id, reason string) error {
 }
 
 // AddDependency adds a dependency: issue depends on dependsOn.
+// Uses runWithRouting so bd can resolve cross-prefix dependencies
+// (e.g., adding a dep from rig A's bead to rig B's bead) via routes.jsonl.
 func (b *Beads) AddDependency(issue, dependsOn string) error {
-	_, err := b.run("dep", "add", issue, dependsOn)
+	_, err := b.runWithRouting("dep", "add", issue, dependsOn)
 	return err
 }
 
 // RemoveDependency removes a dependency.
+// Uses runWithRouting so bd can resolve cross-prefix dependencies via routes.jsonl.
 func (b *Beads) RemoveDependency(issue, dependsOn string) error {
-	_, err := b.run("dep", "remove", issue, dependsOn)
+	_, err := b.runWithRouting("dep", "remove", issue, dependsOn)
 	return err
 }
 

--- a/internal/beads/beads_sling_context.go
+++ b/internal/beads/beads_sling_context.go
@@ -62,7 +62,8 @@ func (b *Beads) CreateSlingContext(workBeadTitle, workBeadID string, fields *cap
 	}
 
 	// Add tracks dependency: context bead → work bead
-	_, depErr := b.run("dep", "add", issue.ID, workBeadID, "--type=tracks")
+	// Use runWithRouting so bd can resolve cross-prefix beads via routes.jsonl.
+	_, depErr := b.runWithRouting("dep", "add", issue.ID, workBeadID, "--type=tracks")
 	if depErr != nil {
 		// Non-fatal: the context bead was created, just missing the dep link.
 		// This can happen if the work bead is in a different DB and external refs aren't set up.


### PR DESCRIPTION
## Summary
- `bd dep add` for cross-prefix dependencies silently failed because `run()` only searches the local beads DB
- Changed `AddDependency`, `RemoveDependency`, and sling context dep tracking to use `runWithRouting` which resolves cross-prefix beads via routes.jsonl

## Test plan
- [ ] Verify `bd dep add` persists cross-prefix dependencies
- [ ] Verify `bd dep remove` works for cross-prefix dependencies

Generated by Gas Town polecat nux (gs-aa6)