### PR TITLE
fix: bump compactor-dog default threshold from 500 to 2000

### DIFF
--- a/internal/daemon/compactor_dog.go
+++ b/internal/daemon/compactor_dog.go
@@ -15,9 +15,10 @@ import (
 const (
 	defaultCompactorDogInterval = 24 * time.Hour
 	// defaultCompactorCommitThreshold is the minimum commit count before compaction triggers.
-	// 500 commits is a reasonable daily threshold — prevents unbounded growth
-	// without compacting too aggressively. Configurable via daemon.json.
-	defaultCompactorCommitThreshold = 500
+	// 2000 commits prevents the escalation feedback loop where each compaction
+	// failure creates beads/escalations that add more commits than the compactor
+	// can drain at 500. Configurable via daemon.json.
+	defaultCompactorCommitThreshold = 2000
 	// compactorQueryTimeout is the timeout for individual SQL queries during compaction.
 	compactorQueryTimeout = 30 * time.Second
 	// compactorGCTimeout is the timeout for CALL dolt_gc() after compaction.
@@ -38,7 +39,7 @@ type CompactorDogConfig struct {
 	Enabled     bool     `json:"enabled"`
 	IntervalStr string   `json:"interval,omitempty"`
 	// Threshold is the minimum commit count before compaction triggers.
-	// Defaults to 500 if not set.
+	// Defaults to 2000 if not set.
 	Threshold int `json:"threshold,omitempty"`
 	// Databases lists specific database names to compact.
 	// If empty, falls back to wisp_reaper config, then auto-discovery.

--- a/plugins/compactor-dog/run.sh
+++ b/plugins/compactor-dog/run.sh
@@ -22,7 +22,7 @@ set -euo pipefail
 DOLT_HOST="${DOLT_HOST:-127.0.0.1}"
 DOLT_PORT="${DOLT_PORT:-3307}"
 DOLT_USER="${DOLT_USER:-root}"
-COMMIT_THRESHOLD="${COMMIT_THRESHOLD:-500}"
+COMMIT_THRESHOLD="${COMMIT_THRESHOLD:-2000}"
 # Default: auto-discover production databases via SHOW DATABASES.
 # Override with --databases db1,db2,... for an explicit list.
 DEFAULT_DBS="auto"
@@ -41,7 +41,7 @@ while [[ $# -gt 0 ]]; do
     --check-only)  CHECK_ONLY=true; shift ;;
     --help|-h)
       echo "Usage: $0 [--threshold N] [--databases db1,db2,...] [--dry-run] [--check-only]"
-      echo "  --threshold N        Commit count before compaction (default: 500)"
+      echo "  --threshold N        Commit count before compaction (default: 2000)"
       echo "  --databases db1,...  Comma-separated database list (default: auto-discover)"
       echo "  --dry-run            Report only, don't compact"
       echo "  --check-only         Monitor and report only (no compaction)"


### PR DESCRIPTION
## Summary

At 500 commits, the escalation feedback loop creates more commits than the compactor can drain — each compaction failure generates beads and escalations that add commits, keeping the database permanently above threshold. Bumping to 2000 breaks the loop while still preventing unbounded growth.

Updated in both `plugins/compactor-dog/run.sh` and `internal/daemon/compactor_dog.go`. Still configurable via `--threshold` flag or `daemon.json`.

## Test plan

- [ ] Verify compactor-dog doesn't trigger on databases with <2000 commits
- [ ] Verify compaction still triggers at 2000+
- [ ] `--threshold` flag override still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)