### PR TITLE
fix: remove hyphens from rig add help examples (#2769)

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -76,8 +76,8 @@ Use --adopt to register an existing directory instead of creating new:
 
 Example:
   gt rig add gastown https://github.com/steveyegge/gastown
-  gt rig add my-project git@github.com:user/repo.git --prefix mp
-  gt rig add existing-rig --adopt`,
+  gt rig add my_project git@github.com:user/repo.git --prefix mp
+  gt rig add existing_rig --adopt`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: runRigAdd,
 }


### PR DESCRIPTION
## Summary
- Updated `gt rig add` help text examples to use underscores instead of hyphens
- `my-project` → `my_project`, `existing-rig` → `existing_rig`
- Hyphens are rejected by the rig name validator but were shown in examples

Fixes #2769

## Test plan
- [x] `go build ./...` passes
- [x] `gt rig add --help` shows corrected examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)