### PR TITLE
fix: use underscores in gt rig add help examples

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -76,8 +76,8 @@ Use --adopt to register an existing directory instead of creating new:
 
 Example:
   gt rig add gastown https://github.com/steveyegge/gastown
-  gt rig add my-project git@github.com:user/repo.git --prefix mp
-  gt rig add existing-rig --adopt`,
+  gt rig add my_project git@github.com:user/repo.git --prefix mp
+  gt rig add existing_rig --adopt`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: runRigAdd,
 }


### PR DESCRIPTION
## Summary
- Fix help text for `gt rig add` which showed hyphenated rig names (`my-project`, `existing-rig`) that are actually invalid — hyphens are not allowed in rig names
- Updated examples to use underscores (`my_project`, `existing_rig`)

Fixes #2769

## Test plan
- [x] `go build ./...` passes
- [x] Verified help text now shows valid rig name examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)