### PR TITLE
fix: refinery checks no_merge flag before merging

### DIFF
--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -879,6 +879,20 @@ func (e *Engineer) ProcessMRInfo(ctx context.Context, mr *MRInfo) ProcessResult 
 	_, _ = fmt.Fprintf(e.output, "  Worker: %s\n", mr.Worker)
 	_, _ = fmt.Fprintf(e.output, "  Source: %s\n", mr.SourceIssue)
 
+	// Check no_merge flag on source issue — if set, skip the merge and leave
+	// the PR open for review (GH#2778).
+	if mr.SourceIssue != "" {
+		if sourceIssue, err := e.beads.Show(mr.SourceIssue); err == nil && sourceIssue != nil {
+			if af := beads.ParseAttachmentFields(sourceIssue); af != nil && af.NoMerge {
+				_, _ = fmt.Fprintf(e.output, "[Engineer] Source issue %s has no_merge=true — skipping merge\n", mr.SourceIssue)
+				return ProcessResult{
+					Success: false,
+					Error:   fmt.Sprintf("source issue %s has no_merge flag set — skipping merge (GH#2778)", mr.SourceIssue),
+				}
+			}
+		}
+	}
+
 	// Phase 3: Check pre-verification fast-path.
 	// If the polecat already rebased onto the target and ran gates, and the target
 	// hasn't moved since, we can skip running gates entirely (~5s merge).


### PR DESCRIPTION
## Summary
- Refinery now checks `no_merge` flag on the source issue before processing a merge
- When `no_merge=true`, the refinery skips the merge and returns early, leaving the PR open for review
- Previously only `gt done` respected this flag — manually created PRs would still get auto-merged

Fixes #2778

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./internal/refinery/` clean
- [x] Change is a 14-line guard clause in `ProcessMRInfo`, uses existing `ParseAttachmentFields` pattern from `done.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)