### PR TITLE
fix(test): add Handler to fully-configured lifecycle defaults test

### DIFF
--- a/internal/daemon/lifecycle_defaults_test.go
+++ b/internal/daemon/lifecycle_defaults_test.go
@@ -143,6 +143,7 @@ func TestEnsureLifecycleDefaults_FullyConfigured(t *testing.T) {
 			JsonlGitBackup:       &JsonlGitBackupConfig{Enabled: false},
 			DoltBackup:           &DoltBackupConfig{Enabled: false},
 			ScheduledMaintenance: &ScheduledMaintenanceConfig{Enabled: false, Threshold: &threshold},
+			Handler:              &PatrolConfig{Enabled: false},
 		},
 	}
 


### PR DESCRIPTION
## Summary
- The `TestEnsureLifecycleDefaults_FullyConfigured` fixture was missing the `Handler` patrol config
- `EnsureLifecycleDefaults` fills in nil `Handler` with defaults, returning `changed=true`
- This has been failing CI on **every PR** since Handler was added to `DefaultLifecycleConfig()`
- One-line fix: add `Handler: &PatrolConfig{Enabled: false}` to the test fixture

Note: PR #2821 has the same fix. This PR is identical — whichever merges first unblocks CI.

## Test plan
- [x] `go build ./...` passes
- [x] Test logic verified: Handler is now included in "fully configured" fixture

🤖 Generated with [Claude Code](https://claude.com/claude-code)