### PR TITLE
fix: prevent daemon restart during gt down shutdown

### DIFF
--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -169,6 +169,12 @@ func runDaemonStart(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a Gas Town workspace: %w", err)
 	}
 
+	// Refuse to start during shutdown — prevents the race where a dying
+	// agent's subprocess restarts the daemon mid-teardown (GH#2656).
+	if daemon.IsShutdownInProgress(townRoot) {
+		return fmt.Errorf("shutdown in progress — refusing to start daemon")
+	}
+
 	// Check if already running
 	running, pid, err := daemon.IsRunning(townRoot)
 	if err != nil {

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -477,6 +477,12 @@ func disableCurrentAgentDND(townRoot string) (bool, error) {
 
 // ensureDaemon starts the daemon if not running.
 func ensureDaemon(townRoot string) error {
+	// Refuse to start during shutdown — prevents the race where a dying
+	// agent's subprocess restarts the daemon mid-teardown (GH#2656).
+	if daemon.IsShutdownInProgress(townRoot) {
+		return fmt.Errorf("shutdown in progress — refusing to start daemon")
+	}
+
 	running, _, err := daemon.IsRunning(townRoot)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- `gt daemon start` and `ensureDaemon()` now check `IsShutdownInProgress()` before starting a new daemon
- Prevents the race where a dying agent subprocess restarts the daemon 1 second after `gt down` kills it
- Uses the existing `shutdown.lock` flock mechanism — no new infrastructure needed

Fixes #2656

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./internal/cmd/` clean
- [x] Change is a 12-line guard in two functions, using existing `daemon.IsShutdownInProgress()`
- [x] Existing `TestIsShutdownInProgress_*` tests in `daemon_test.go` cover the lock semantics

🤖 Generated with [Claude Code](https://claude.com/claude-code)