### PR TITLE
fix: GetRigLED checks operational state before session state

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -687,20 +687,23 @@ func runRigAdd(cmd *cobra.Command, args []string) error {
 //   - 🅿️ = parked (intentionally paused)
 //   - 🛑 = docked (global shutdown)
 func GetRigLED(hasWitness, hasRefinery bool, opState string) string {
+	// Check operational state FIRST — parked/docked overrides session state.
+	// Sessions may still be running during the race window after park/dock
+	// but before sessions are killed (GH#2555).
+	switch opState {
+	case "PARKED":
+		return "🅿️"
+	case "DOCKED":
+		return "🛑"
+	}
+
 	if hasWitness && hasRefinery {
 		return "🟢"
 	}
 	if hasWitness || hasRefinery {
 		return "🟡"
 	}
-	switch opState {
-	case "PARKED":
-		return "🅿️"
-	case "DOCKED":
-		return "🛑"
-	default:
-		return "⚫"
-	}
+	return "⚫"
 }
 
 // rigStatePriority returns a sort priority for a rig's state.

--- a/internal/cmd/rig_list_test.go
+++ b/internal/cmd/rig_list_test.go
@@ -10,21 +10,23 @@ func TestGetRigLED(t *testing.T) {
 		opState     string
 		want        string
 	}{
+		// Operational state overrides session state (GH#2555)
+		{"parked no sessions", false, false, "PARKED", "🅿️"},
+		{"parked with sessions", true, true, "PARKED", "🅿️"},
+		{"parked partial", true, false, "PARKED", "🅿️"},
+		{"docked no sessions", false, false, "DOCKED", "🛑"},
+		{"docked with sessions", true, true, "DOCKED", "🛑"},
+
 		// Both running - fully active
 		{"both running", true, true, "OPERATIONAL", "🟢"},
-		{"both running parked config", true, true, "PARKED", "🟢"},
-		{"both running docked config", true, true, "DOCKED", "🟢"},
 
 		// One running - partially active
 		{"witness only", true, false, "OPERATIONAL", "🟡"},
 		{"refinery only", false, true, "OPERATIONAL", "🟡"},
-		{"witness only parked", true, false, "PARKED", "🟡"},
 
-		// Nothing running - check config state
+		// Nothing running
 		{"stopped operational", false, false, "OPERATIONAL", "⚫"},
 		{"stopped empty state", false, false, "", "⚫"},
-		{"parked", false, false, "PARKED", "🅿️"},
-		{"docked", false, false, "DOCKED", "🛑"},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- `GetRigLED()` now checks parked/docked state BEFORE checking session state
- Parked rigs always show parking indicator, docked rigs always show stop indicator
- Previously, sessions still running during the teardown race window would show green/yellow instead of the correct park/dock indicator

Fixes #2555

## Test plan
- [x] `go build ./...` passes
- [x] `go vet ./internal/cmd/` clean
- [x] `TestGetRigLED` updated and passing — now verifies parked/docked overrides session state

🤖 Generated with [Claude Code](https://claude.com/claude-code)