### PR TITLE
fix: refinery checks no_merge flag before auto-merging (#2778)

### DIFF
--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -879,6 +879,20 @@ func (e *Engineer) ProcessMRInfo(ctx context.Context, mr *MRInfo) ProcessResult 
 	_, _ = fmt.Fprintf(e.output, "  Worker: %s\n", mr.Worker)
 	_, _ = fmt.Fprintf(e.output, "  Source: %s\n", mr.SourceIssue)
 
+	// Check no_merge flag on source issue. When set, the work should not be
+	// auto-merged — it needs human or automated review first. (GH#2778)
+	if mr.SourceIssue != "" {
+		if sourceIssue, err := e.beads.Show(mr.SourceIssue); err == nil {
+			if af := beads.ParseAttachmentFields(sourceIssue); af != nil && af.NoMerge {
+				_, _ = fmt.Fprintf(e.output, "[Engineer] Skipping merge: source issue %s has no_merge=true (pending review)\n", mr.SourceIssue)
+				return ProcessResult{
+					Success: false,
+					Error:   fmt.Sprintf("source issue %s has no_merge flag set — skipping auto-merge (pending review)", mr.SourceIssue),
+				}
+			}
+		}
+	}
+
 	// Phase 3: Check pre-verification fast-path.
 	// If the polecat already rebased onto the target and ran gates, and the target
 	// hasn't moved since, we can skip running gates entirely (~5s merge).

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -839,3 +839,115 @@ func TestIsClaimStale(t *testing.T) {
 		})
 	}
 }
+
+// TestProcessMRInfo_SkipsNoMerge verifies that ProcessMRInfo returns a failure
+// when the source issue has no_merge=true. This prevents the refinery from
+// auto-merging work that needs human or automated review. (GH#2778)
+func TestProcessMRInfo_SkipsNoMerge(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+
+	// Create a fake bd that returns an issue with no_merge: true.
+	// Write the JSON to a file and cat it, to avoid shell escaping issues.
+	binDir := t.TempDir()
+	issueJSON := `[{"id":"test-issue","status":"in_progress","description":"no_merge: true\ndispatched_by: crew"}]`
+	jsonFile := filepath.Join(binDir, "response.json")
+	if err := os.WriteFile(jsonFile, []byte(issueJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	script := fmt.Sprintf("#!/bin/sh\ncat %s\n", jsonFile)
+	bdPath := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(bdPath, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	// Set up a minimal rig with beads client.
+	// Create .beads dir so ResolveBeadsDir doesn't fail.
+	rigDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	r := &rig.Rig{Name: "test-rig", Path: rigDir}
+	e := NewEngineer(r)
+	var buf bytes.Buffer
+	e.output = &buf
+
+	mr := &MRInfo{
+		ID:          "mr-001",
+		Branch:      "feat/something",
+		Target:      "main",
+		SourceIssue: "test-issue",
+	}
+
+	result := e.ProcessMRInfo(context.Background(), mr)
+
+	if result.Success {
+		t.Error("expected ProcessMRInfo to fail for no_merge issue")
+	}
+	if !strings.Contains(result.Error, "no_merge") {
+		t.Errorf("expected error to mention no_merge, got: %s", result.Error)
+	}
+	output := buf.String()
+	if !strings.Contains(output, "no_merge=true") {
+		t.Errorf("expected output to mention no_merge=true, got: %s", output)
+	}
+}
+
+// TestProcessMRInfo_AllowsMergeWithoutNoMerge verifies that ProcessMRInfo
+// proceeds normally when the source issue does NOT have no_merge set.
+func TestProcessMRInfo_AllowsMergeWithoutNoMerge(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+
+	// Create a fake bd that returns an issue without no_merge.
+	binDir := t.TempDir()
+	issueJSON := `[{"id":"test-issue","status":"in_progress","description":"dispatched_by: crew"}]`
+	jsonFile := filepath.Join(binDir, "response.json")
+	if err := os.WriteFile(jsonFile, []byte(issueJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	script := fmt.Sprintf("#!/bin/sh\ncat %s\n", jsonFile)
+	bdPath := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(bdPath, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	// Set up a real git repo so doMerge can proceed
+	workDir, g, cleanup := testGitRepo(t)
+	defer cleanup()
+	createFeatureBranch(t, workDir, "feat/normal", "normal.txt", "content\n")
+
+	r := &rig.Rig{Name: "test-rig", Path: workDir}
+	e := NewEngineer(r)
+	e.git = g
+	e.workDir = workDir
+	var buf bytes.Buffer
+	e.output = &buf
+	e.mergeSlotEnsureExists = func() (string, error) { return "test-slot", nil }
+	e.mergeSlotAcquire = func(holder string, addWaiter bool) (*beads.MergeSlotStatus, error) {
+		return &beads.MergeSlotStatus{Available: true, Holder: holder}, nil
+	}
+	e.mergeSlotRelease = func(holder string) error { return nil }
+
+	mr := &MRInfo{
+		ID:          "mr-002",
+		Branch:      "feat/normal",
+		Target:      "main",
+		SourceIssue: "test-issue",
+	}
+
+	result := e.ProcessMRInfo(context.Background(), mr)
+
+	output := buf.String()
+	if strings.Contains(output, "no_merge") {
+		t.Errorf("did not expect no_merge skip, got output: %s", output)
+	}
+	// The merge should proceed (may succeed or fail on gates, but shouldn't be blocked by no_merge)
+	if !result.Success && strings.Contains(result.Error, "no_merge") {
+		t.Errorf("merge should not be blocked by no_merge, got error: %s", result.Error)
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `no_merge` flag check in `ProcessMRInfo` before proceeding with auto-merge
- When a source issue has `no_merge: true`, the refinery now skips the merge and returns an error indicating the work needs review
- Gracefully handles cases where the source issue can't be fetched (falls through to normal merge behavior)

Closes #2778

## The bug

When a bead has `no_merge: true`, polecats correctly skip MR creation via `gt done`. But if a PR/branch is later created manually (e.g., `gh pr create`), the refinery picks it up and auto-merges — ignoring the `no_merge` flag entirely. This defeats the purpose of `--no-merge` for teams that want automated or human review before merging.

## The fix

Added a check in `ProcessMRInfo` (the refinery's MR processing entry point) that fetches the source issue and inspects its `AttachmentFields.NoMerge` flag. If set, the merge is skipped with a clear log message.

The check is placed before the pre-verification fast-path and merge logic, so `no_merge` issues are rejected early without wasting time on git operations.

## Test plan

- [x] `TestProcessMRInfo_SkipsNoMerge` — verifies refinery rejects MRs when source issue has `no_merge: true`
- [x] `TestProcessMRInfo_AllowsMergeWithoutNoMerge` — verifies normal MRs proceed when `no_merge` is not set
- [x] `go test ./internal/refinery/...` — all existing tests pass
- [x] `go build ./...` — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)