### PR TITLE
fix(test): skip shell-script mock on Windows (#2831)

### DIFF
--- a/internal/beads/beads_types_test.go
+++ b/internal/beads/beads_types_test.go
@@ -359,6 +359,9 @@ func TestEnsureCustomTypes(t *testing.T) {
 
 func TestEnsureCustomTypes_VerifyPersistence(t *testing.T) {
 	t.Run("sentinel not written when db verify fails", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("shell script mock requires Unix")
+		}
 		// Install a mock bd that succeeds on "config set" but returns empty
 		// on "config get types.custom" — simulating a silent write failure.
 		binDir := t.TempDir()


### PR DESCRIPTION
## Summary
- The "sentinel not written when db verify fails" subtest uses a Unix shell script mock (`#!/bin/sh`)
- The first mock in the same file already has Windows/PowerShell handling, but this one doesn't
- Adds `runtime.GOOS == "windows"` skip to fix consistent Windows CI failure on main

Fixes #2831

## Test plan
- [x] `go build ./...` passes
- [x] Test runs on Unix (macOS/Linux)
- [x] Test skips on Windows with clear message

🤖 Generated with [Claude Code](https://claude.com/claude-code)