### PR TITLE
fix: move run_tests skip to top of refinery test step (#2603)

### DIFF
--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -341,7 +341,9 @@ id = "run-tests"
 title = "Run quality checks and tests"
 needs = ["process-branch"]
 description = """
-**Config: run_tests = {{run_tests}}**
+**IMPORTANT — CHECK THIS FIRST: run_tests = {{run_tests}}**
+If run_tests = "false": Skip the test suite below. Only run quality checks, then proceed to handle-failures.
+
 **Config: test_command = {{test_command}}**
 **Config: setup_command = {{setup_command}}**
 **Config: typecheck_command = {{typecheck_command}}**
@@ -369,11 +371,7 @@ Empty commands mean "not configured for this project" — skip silently.
 Proceed to handle-failures step. Track which specific check failed
 (setup/typecheck/lint/build) for the failure diagnosis.
 
-**3. Run the test suite:**
-
-If run_tests = "false": Skip this step entirely. Proceed to handle-failures.
-
-If run_tests = "true":
+**3. Run the test suite (ONLY if run_tests = "true"):**
 
 ```bash
 {{test_command}}            # Run tests (configured per-rig)


### PR DESCRIPTION
## Summary
- The `run_tests=false` skip condition was buried at line 374, after quality check commands
- LLM agents saw and ran `{{test_command}}` before reaching the skip instruction
- Moved the skip check to the very top: `**IMPORTANT — CHECK THIS FIRST: run_tests = {{run_tests}}**`
- Also clarified step 3 heading: "ONLY if run_tests = true"

Fixes #2603

## Test plan
- [x] `go build ./...` passes
- [x] Formula text verified: skip instruction is now first thing agents see

🤖 Generated with [Claude Code](https://claude.com/claude-code)