### PR TITLE
fix: set cmd.Dir on all dolt CLI invocations to prevent stray .doltcfg

### DIFF
--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -252,9 +252,11 @@ func (m *DoltServerManager) buildDoltSQLCmd(ctx context.Context, args ...string)
 	fullArgs = append(fullArgs, args...)
 	cmd := exec.CommandContext(ctx, "dolt", fullArgs...)
 
-	if !m.isRemote() {
-		cmd.Dir = m.config.DataDir
-	}
+	// Always set working directory to DataDir so dolt finds the canonical .doltcfg
+	// there instead of creating stray .doltcfg/privileges.db in the caller's CWD.
+	// For local servers this also enables embedded-mode auto-detection.
+	// See GH#2537.
+	cmd.Dir = m.config.DataDir
 
 	if m.isRemote() && m.config.Password != "" {
 		cmd.Env = append(os.Environ(), "DOLT_CLI_PASSWORD="+m.config.Password)

--- a/internal/daemon/jsonl_git_backup.go
+++ b/internal/daemon/jsonl_git_backup.go
@@ -306,8 +306,10 @@ func (d *Daemon) exportTableToJsonl(table, query, dir, dataDir string) (int, err
 			"sql", "-r", "json", "-q", query)
 	} else {
 		cmd = exec.CommandContext(ctx, "dolt", "sql", "-r", "json", "-q", query)
-		cmd.Dir = dataDir
 	}
+	// Always set working directory to dataDir so dolt finds the canonical .doltcfg
+	// instead of creating stray .doltcfg/privileges.db in the caller's CWD (GH#2537).
+	cmd.Dir = dataDir
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -381,9 +381,11 @@ func buildDoltSQLCmd(ctx context.Context, config *Config, args ...string) *exec.
 
 	cmd := exec.CommandContext(ctx, "dolt", fullArgs...)
 
-	if !config.IsRemote() {
-		cmd.Dir = config.DataDir
-	}
+	// Always set working directory to DataDir so dolt finds the canonical .doltcfg
+	// there instead of creating stray .doltcfg/privileges.db in the caller's CWD.
+	// For local servers this also enables embedded-mode auto-detection.
+	// See GH#2537.
+	cmd.Dir = config.DataDir
 
 	if config.IsRemote() && config.Password != "" {
 		cmd.Env = append(os.Environ(), "DOLT_CLI_PASSWORD="+config.Password)
@@ -3042,6 +3044,10 @@ func GetActiveConnectionCount(townRoot string) (int, error) {
 		"-q", "SELECT COUNT(*) AS cnt FROM information_schema.PROCESSLIST",
 	}
 	cmd := exec.CommandContext(ctx, "dolt", fullArgs...)
+	// Set working directory to the data dir so dolt finds the canonical .doltcfg
+	// there instead of creating stray .doltcfg/privileges.db in the caller's CWD.
+	// See GH#2537.
+	cmd.Dir = config.DataDir
 	// Always set DOLT_CLI_PASSWORD to prevent interactive password prompt.
 	// When empty, dolt connects without a password (which is the default for local servers).
 	cmd.Env = append(os.Environ(), "DOLT_CLI_PASSWORD="+config.Password)

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -3522,9 +3522,9 @@ func TestBuildDoltSQLCmd_Remote(t *testing.T) {
 	ctx := t.Context()
 	cmd := buildDoltSQLCmd(ctx, config, "-q", "SELECT 1")
 
-	// Should NOT set Dir for remote
-	if cmd.Dir != "" {
-		t.Errorf("cmd.Dir = %q, want empty for remote", cmd.Dir)
+	// Should set Dir to DataDir even for remote, to prevent stray .doltcfg creation (GH#2537)
+	if cmd.Dir != "/tmp/dolt-data" {
+		t.Errorf("cmd.Dir = %q, want %q for remote (GH#2537)", cmd.Dir, "/tmp/dolt-data")
 	}
 
 	// Should have connection flags


### PR DESCRIPTION
## Summary
- When `dolt` runs from a CWD without `.doltcfg`, it auto-creates `privileges.db` there. Multiple stray `.doltcfg` dirs then cause "access denied" or "multiple .doltcfg directories detected" errors, leading to full Dolt outages.
- Fixed by always setting `cmd.Dir` to `DataDir` in all `buildDoltSQLCmd` variants and `GetActiveConnectionCount`, even for remote server connections. This ensures dolt finds the canonical `.doltcfg` in the data directory.
- Files changed: `doltserver/doltserver.go`, `daemon/dolt.go`, `daemon/jsonl_git_backup.go`, `doltserver/doltserver_test.go`

Fixes #2537

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./internal/doltserver/...` passes (updated `TestBuildDoltSQLCmd_Remote` to expect `cmd.Dir` set)
- [x] `go test ./internal/daemon/...` passes
- [ ] Manual: verify no new `.doltcfg` dirs created after running `gt dolt status` from non-data-dir CWD

🤖 Generated with [Claude Code](https://claude.com/claude-code)