### PR TITLE
fix: validate git URL before crew clone (#2545)

### DIFF
--- a/internal/crew/manager.go
+++ b/internal/crew/manager.go
@@ -207,6 +207,9 @@ func (m *Manager) addLocked(name string, createBranch bool) (*CrewWorker, error)
 	// Clone the rig repo on the configured default branch.
 	// CloneBranch ensures the crew lands on the rig's default_branch even when
 	// it differs from the remote's HEAD. Falls back gracefully for new/empty repos.
+	if m.rig.GitURL == "" {
+		return nil, fmt.Errorf("rig %q has no git URL configured — crew workspaces require a clonable repository (set git_url in rigs.json or re-add the rig with a remote URL)", m.rig.Name)
+	}
 	defaultBranch := m.rig.DefaultBranch()
 	if m.rig.LocalRepo != "" {
 		if err := m.git.CloneBranchWithReference(m.rig.GitURL, crewPath, defaultBranch, m.rig.LocalRepo); err != nil {


### PR DESCRIPTION
## Summary
- Add early validation in crew `addLocked()` to check that the rig has a non-empty `GitURL` before attempting to clone
- Without this, `gt crew start` on a rig adopted from a local project (no remote) fails with the confusing `fatal: repository '' does not exist`
- Now gives a clear error: "rig has no git URL configured — crew workspaces require a clonable repository"

Fixes #2545

## Test plan
- [ ] `gt crew start` on rig with git URL still works normally
- [ ] `gt crew start` on rig with empty git URL gives clear error message
- [ ] `go build ./internal/crew/` compiles

🤖 Generated with [Claude Code](https://claude.com/claude-code)