### PR TITLE
fix: deduplicate CRASHED_POLECAT alerts in daemon (#2795)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -99,6 +99,12 @@ type Daemon struct {
 	// lastMaintenanceRun tracks when scheduled maintenance last ran.
 	// Only accessed from heartbeat loop goroutine - no sync needed.
 	lastMaintenanceRun time.Time
+
+	// crashNotified tracks polecats that have already been notified as crashed.
+	// Prevents flooding the witness with duplicate CRASHED_POLECAT alerts on
+	// every heartbeat cycle (GH#2795). Cleared when the session comes back alive.
+	// Only accessed from heartbeat loop goroutine - no sync needed.
+	crashNotified map[string]time.Time
 }
 
 // sessionDeath records a detected session death for mass death analysis.
@@ -1914,7 +1920,11 @@ func (d *Daemon) checkPolecatHealth(rigName, polecatName string) {
 	}
 
 	if sessionAlive {
-		// Session is alive - nothing to do
+		// Session is alive - clear any previous crash notification (GH#2795).
+		crashKey := rigName + "/" + polecatName
+		if d.crashNotified != nil {
+			delete(d.crashNotified, crashKey)
+		}
 		return
 	}
 
@@ -1992,6 +2002,19 @@ func (d *Daemon) checkPolecatHealth(rigName, polecatName string) {
 	// Emit session_death event for audit trail / feed visibility
 	_ = events.LogFeed(events.TypeSessionDeath, sessionName,
 		events.SessionDeathPayload(sessionName, rigName+"/polecats/"+polecatName, "crash detected by daemon health check", "daemon"))
+
+	// Dedup guard: only notify witness once per crashed polecat (GH#2795).
+	// Without this, every heartbeat cycle (3 min) sends a duplicate CRASHED_POLECAT
+	// mail, flooding the witness inbox unboundedly.
+	crashKey := rigName + "/" + polecatName
+	if d.crashNotified == nil {
+		d.crashNotified = make(map[string]time.Time)
+	}
+	if _, already := d.crashNotified[crashKey]; already {
+		d.logger.Printf("Skipping duplicate CRASHED_POLECAT notification for %s (already notified)", crashKey)
+		return
+	}
+	d.crashNotified[crashKey] = time.Now()
 
 	// Notify witness — stuck-agent-dog plugin handles context-aware restart
 	d.notifyWitnessOfCrashedPolecat(rigName, polecatName, info.HookBead)

--- a/internal/daemon/polecat_health_test.go
+++ b/internal/daemon/polecat_health_test.go
@@ -291,3 +291,65 @@ func TestCheckPolecatHealth_NotifiesWitnessOnCrash(t *testing.T) {
 		t.Errorf("expected witness address myr/witness, got: %q", invocations)
 	}
 }
+
+// TestCheckPolecatHealth_DeduplicatesCrashNotification verifies that the daemon
+// does NOT send duplicate CRASHED_POLECAT notifications on subsequent heartbeat
+// cycles for the same crashed polecat (GH#2795).
+func TestCheckPolecatHealth_DeduplicatesCrashNotification(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mocks for tmux and bd")
+	}
+	binDir := t.TempDir()
+	writeFakeTestTmux(t, binDir)
+	recentTime := time.Now().UTC().Format(time.RFC3339)
+	bdPath := writeFakeTestBD(t, binDir, "working", "working", "gt-xyz", recentTime)
+
+	// Create a fake gt script that logs invocations to a file
+	gtLog := filepath.Join(t.TempDir(), "gt-invocations.log")
+	fakeGt := filepath.Join(binDir, "gt")
+	gtScript := fmt.Sprintf("#!/bin/sh\necho \"$@\" >> %s\n", gtLog)
+	if err := os.WriteFile(fakeGt, []byte(gtScript), 0755); err != nil {
+		t.Fatalf("writing fake gt: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	townRoot := t.TempDir()
+	var logBuf strings.Builder
+	d := &Daemon{
+		config: &Config{TownRoot: townRoot},
+		logger: log.New(&logBuf, "", 0),
+		tmux:   tmux.NewTmux(),
+		bdPath: bdPath,
+		gtPath: fakeGt,
+	}
+
+	// First call: should send notification
+	d.checkPolecatHealth("myr", "mycat")
+
+	logData, err := os.ReadFile(gtLog)
+	if err != nil {
+		t.Fatalf("reading gt invocation log: %v", err)
+	}
+	firstCallCount := strings.Count(string(logData), "CRASHED_POLECAT")
+	if firstCallCount != 1 {
+		t.Fatalf("expected exactly 1 CRASHED_POLECAT on first call, got %d", firstCallCount)
+	}
+
+	// Second call: should be deduplicated (no new notification)
+	d.checkPolecatHealth("myr", "mycat")
+
+	logData, err = os.ReadFile(gtLog)
+	if err != nil {
+		t.Fatalf("reading gt invocation log: %v", err)
+	}
+	secondCallCount := strings.Count(string(logData), "CRASHED_POLECAT")
+	if secondCallCount != 1 {
+		t.Errorf("expected still 1 CRASHED_POLECAT after second call (dedup), got %d", secondCallCount)
+	}
+
+	got := logBuf.String()
+	if !strings.Contains(got, "Skipping duplicate CRASHED_POLECAT") {
+		t.Errorf("expected dedup log message, got: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Add `crashNotified` map to daemon to track which polecats have already had CRASHED_POLECAT alerts sent
- Skip re-notification on subsequent heartbeat cycles until the polecat's session comes back alive
- Prevents the witness inbox from being flooded with duplicate crash alerts (86+ messages observed in production)

Fixes #2795

## How it works
- First crash detection for a polecat: send CRASHED_POLECAT mail to witness, record in `crashNotified`
- Subsequent heartbeat cycles: skip notification (log "Skipping duplicate")
- When session comes back alive: clear the entry from `crashNotified`, enabling future crash detection

## Test plan
- [ ] `go build ./...` passes
- [ ] New test `TestCheckPolecatHealth_DeduplicatesCrashNotification` verifies dedup behavior
- [ ] Existing tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)