### PR TITLE
fix: reset to startPoint during polecat reuse (#2536)

### DIFF
--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1562,7 +1562,10 @@ func (m *Manager) ReuseIdlePolecat(name string, opts AddOptions) (*Polecat, erro
 	// Clean worktree state before branch switch — the worktree may have stale
 	// state from a previous dog/pool dispatch (uncommitted changes, detached HEAD,
 	// or checked out on an old dog/alpha-* branch).
-	_ = polecatGit.ResetHard("HEAD")
+	// Reset to startPoint instead of HEAD so the tree matches the target commit.
+	// This prevents "local changes would be overwritten by checkout" when HEAD
+	// and startPoint have different file content (GH#2536).
+	_ = polecatGit.ResetHard(startPoint)
 
 	// Create fresh branch from start point (branch-only, no worktree add/remove)
 	branchName := m.buildBranchName(name, opts.HookBead)


### PR DESCRIPTION
## Summary
- Change `ReuseIdlePolecat` to `git reset --hard <startPoint>` instead of `git reset --hard HEAD`
- When HEAD diverges from origin/main (e.g., polecat was on a feature branch), resetting to HEAD leaves the working tree in a state that conflicts with `git checkout -b <branch> origin/main`
- Resetting to startPoint first makes the working tree match the target commit, eliminating checkout conflicts

Fixes #2536

## Test plan
- [ ] `go build ./internal/polecat/` passes
- [ ] Polecat reuse works when previous worktree has diverged from origin/main
- [ ] No change in behavior when HEAD == startPoint (most common case)

🤖 Generated with [Claude Code](https://claude.com/claude-code)