### PR TITLE
fix: gt doctor detects and cleans stale sql-server.info files (#2770)

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -182,7 +182,8 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewPrefixConflictCheck())
 	d.Register(doctor.NewRigNameMismatchCheck())
 	d.Register(doctor.NewRigConfigSyncCheck()) // Check all registered rigs have config.json
-	d.Register(doctor.NewStaleDoltPortCheck()) // Check for stale Dolt port files
+	d.Register(doctor.NewStaleDoltPortCheck())      // Check for stale Dolt port files
+	d.Register(doctor.NewStaleSQLServerInfoCheck()) // Check for stale sql-server.info files (GH#2770)
 	d.Register(doctor.NewPrefixMismatchCheck())
 	d.Register(doctor.NewDatabasePrefixCheck())
 	d.Register(doctor.NewIdleTimeoutCheck()) // Verify dolt.idle-timeout: "0" for all rigs

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -143,6 +143,7 @@ func upgradeDoctor(townRoot string) upgradeResult {
 	d.Register(doctor.NewStaleTaskDispatchCheck())
 	d.Register(doctor.NewHooksSyncCheck())
 	d.Register(doctor.NewStaleDoltPortCheck())
+	d.Register(doctor.NewStaleSQLServerInfoCheck())
 	d.Register(doctor.NewSparseCheckoutCheck())
 	d.Register(doctor.NewPrimingCheck())
 	d.Register(doctor.NewLifecycleHygieneCheck())

--- a/internal/doctor/stale_sql_server_info_check.go
+++ b/internal/doctor/stale_sql_server_info_check.go
@@ -1,0 +1,126 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+)
+
+// StaleSQLServerInfoCheck detects stale sql-server.info files left by crashed
+// or stopped local Dolt servers. When running in dolt_mode=server, these files
+// cause bd to connect to a dead local server instead of the central Dolt server,
+// resulting in "database not found" errors. See GH#2770.
+type StaleSQLServerInfoCheck struct {
+	FixableCheck
+	staleFiles []string
+}
+
+// NewStaleSQLServerInfoCheck creates a new stale sql-server.info check.
+func NewStaleSQLServerInfoCheck() *StaleSQLServerInfoCheck {
+	return &StaleSQLServerInfoCheck{
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "stale-sql-server-info",
+				CheckDescription: "Detect stale Dolt sql-server.info files from dead local servers",
+				CheckCategory:    CategoryConfig,
+			},
+		},
+	}
+}
+
+// Run checks for stale sql-server.info files across all beads directories.
+func (c *StaleSQLServerInfoCheck) Run(ctx *CheckContext) *CheckResult {
+	c.staleFiles = nil
+
+	// Find all sql-server.info files under the town root
+	var details []string
+	_ = filepath.Walk(ctx.TownRoot, func(path string, info os.FileInfo, err error) error {
+		if err != nil {
+			return nil
+		}
+		// Skip .git directories and node_modules
+		if info.IsDir() && (info.Name() == ".git" || info.Name() == "node_modules") {
+			return filepath.SkipDir
+		}
+		if info.Name() != "sql-server.info" {
+			return nil
+		}
+		// Only care about files inside .dolt directories
+		if !strings.Contains(path, ".dolt") {
+			return nil
+		}
+
+		if c.isStale(path) {
+			c.staleFiles = append(c.staleFiles, path)
+			relPath, _ := filepath.Rel(ctx.TownRoot, path)
+			details = append(details, fmt.Sprintf("Stale sql-server.info: %s", relPath))
+		}
+		return nil
+	})
+
+	if len(c.staleFiles) == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "No stale sql-server.info files found",
+		}
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusWarning,
+		Message: fmt.Sprintf("%d stale sql-server.info file(s) from dead Dolt servers", len(c.staleFiles)),
+		Details: details,
+		FixHint: "Run 'gt doctor --fix' to remove stale sql-server.info files",
+	}
+}
+
+// Fix removes all detected stale sql-server.info files.
+func (c *StaleSQLServerInfoCheck) Fix(ctx *CheckContext) error {
+	for _, path := range c.staleFiles {
+		if err := os.Remove(path); err != nil {
+			return fmt.Errorf("could not remove stale sql-server.info %s: %w", path, err)
+		}
+	}
+	return nil
+}
+
+// isStale checks if the sql-server.info file references a dead process.
+// The file format is "PID:port:UUID" (one line).
+func (c *StaleSQLServerInfoCheck) isStale(path string) bool {
+	data, err := os.ReadFile(path) //nolint:gosec // G304: path from filepath.Walk
+	if err != nil {
+		return false
+	}
+
+	content := strings.TrimSpace(string(data))
+	if content == "" {
+		return true // Empty file is stale
+	}
+
+	// Parse PID from "PID:port:UUID" format
+	parts := strings.SplitN(content, ":", 3)
+	if len(parts) < 1 {
+		return true
+	}
+
+	pid, err := strconv.Atoi(parts[0])
+	if err != nil || pid <= 0 {
+		return true // Corrupt or invalid PID
+	}
+
+	// Check if the process is alive using signal 0 (no-op probe)
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return true
+	}
+
+	if err := proc.Signal(syscall.Signal(0)); err != nil {
+		return true // Process is dead
+	}
+
+	return false // Process is alive, not stale
+}

--- a/internal/doctor/stale_sql_server_info_check_test.go
+++ b/internal/doctor/stale_sql_server_info_check_test.go
@@ -1,0 +1,145 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestStaleSQLServerInfoCheck_NoFiles(t *testing.T) {
+	tmpDir := t.TempDir()
+	check := NewStaleSQLServerInfoCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected OK with no sql-server.info files, got %s: %s", result.Status, result.Message)
+	}
+}
+
+func TestStaleSQLServerInfoCheck_DetectsStaleFile(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix process signals")
+	}
+
+	tmpDir := t.TempDir()
+
+	// Create a .dolt directory with a sql-server.info file referencing a dead PID
+	doltDir := filepath.Join(tmpDir, "myrig", ".beads", "dolt", ".dolt")
+	if err := os.MkdirAll(doltDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use PID 999999999 which is almost certainly not running
+	infoPath := filepath.Join(doltDir, "sql-server.info")
+	if err := os.WriteFile(infoPath, []byte("999999999:3307:some-uuid"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewStaleSQLServerInfoCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Errorf("expected Warning for stale sql-server.info, got %s: %s", result.Status, result.Message)
+	}
+	if len(check.staleFiles) != 1 {
+		t.Errorf("expected 1 stale file, got %d", len(check.staleFiles))
+	}
+}
+
+func TestStaleSQLServerInfoCheck_FixRemovesFiles(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix process signals")
+	}
+
+	tmpDir := t.TempDir()
+
+	// Create stale sql-server.info files in two rigs
+	for _, rig := range []string{"rig1", "rig2"} {
+		doltDir := filepath.Join(tmpDir, rig, ".beads", "dolt", ".dolt")
+		if err := os.MkdirAll(doltDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		infoPath := filepath.Join(doltDir, "sql-server.info")
+		if err := os.WriteFile(infoPath, []byte("999999999:3307:uuid"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	check := NewStaleSQLServerInfoCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	// Run to detect
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected Warning, got %s", result.Status)
+	}
+	if len(check.staleFiles) != 2 {
+		t.Fatalf("expected 2 stale files, got %d", len(check.staleFiles))
+	}
+
+	// Fix
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+
+	// Verify files are gone
+	for _, path := range check.staleFiles {
+		if _, err := os.Stat(path); !os.IsNotExist(err) {
+			t.Errorf("expected %s to be removed after fix", path)
+		}
+	}
+}
+
+func TestStaleSQLServerInfoCheck_SkipsLiveProcess(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix process signals")
+	}
+
+	tmpDir := t.TempDir()
+
+	// Create a sql-server.info with our own PID (definitely alive)
+	doltDir := filepath.Join(tmpDir, "myrig", ".beads", "dolt", ".dolt")
+	if err := os.MkdirAll(doltDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	infoPath := filepath.Join(doltDir, "sql-server.info")
+	content := fmt.Sprintf("%d:3307:some-uuid", os.Getpid())
+	if err := os.WriteFile(infoPath, []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewStaleSQLServerInfoCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected OK for live process, got %s: %s", result.Status, result.Message)
+	}
+}
+
+func TestStaleSQLServerInfoCheck_EmptyFile(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	doltDir := filepath.Join(tmpDir, "myrig", ".beads", "dolt", ".dolt")
+	if err := os.MkdirAll(doltDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	infoPath := filepath.Join(doltDir, "sql-server.info")
+	if err := os.WriteFile(infoPath, []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewStaleSQLServerInfoCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Errorf("expected Warning for empty sql-server.info, got %s: %s", result.Status, result.Message)
+	}
+}


### PR DESCRIPTION
## Summary
- Adds `stale-sql-server-info` doctor check that detects stale Dolt `sql-server.info` files left by crashed or stopped local servers
- In `dolt_mode=server`, these stale files cause `bd` to connect to a dead local server instead of the central Dolt server, producing "database not found" errors
- The check walks all `.dolt` directories, parses the PID from the file (format: `PID:port:UUID`), and uses `signal(0)` to detect dead processes
- `gt doctor --fix` removes stale files automatically
- Registered in both `gt doctor` and `gt upgrade`

Fixes #2770

## Test plan
- [x] `go build ./internal/doctor/... ./internal/cmd/...` passes
- [x] 5 new tests pass: no files, stale detection, fix removes files, skips live processes, empty file handling
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)