### PR TITLE
chore: bump bd to v0.60.0 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,7 @@ jobs:
 
       - name: Install beads (bd)
         if: steps.cache-beads-int.outputs.cache-hit != 'true'
-        run: go install github.com/steveyegge/beads/cmd/bd@v0.57.0
+        run: go install github.com/steveyegge/beads/cmd/bd@v0.60.0
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/.github/workflows/nightly-integration.yml
+++ b/.github/workflows/nightly-integration.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install beads (bd)
         if: steps.cache-beads.outputs.cache-hit != 'true'
-        run: go install github.com/steveyegge/beads/cmd/bd@v0.55.4
+        run: go install github.com/steveyegge/beads/cmd/bd@v0.60.0
 
       - name: Install Dolt
         run: |

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -58,7 +58,7 @@ jobs:
           & "$gopathBin\dolt.exe" version
 
       - name: Install bd
-        run: go install github.com/steveyegge/beads/cmd/bd@v0.57.0
+        run: go install github.com/steveyegge/beads/cmd/bd@v0.60.0
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -12,7 +12,7 @@
 FROM golang:1.26-alpine
 
 ARG DOLT_VERSION=1.82.4
-ARG BD_VERSION=v0.57.0
+ARG BD_VERSION=v0.60.0
 
 # Install dependencies including CGO build requirements for beads daemon
 # procps and lsof are required by gt dolt start for process verification


### PR DESCRIPTION
## Summary

- Bump bd from v0.57.0 to v0.60.0 in ci.yml, windows-ci.yml, and Dockerfile.e2e
- Bump bd from v0.55.4 to v0.60.0 in nightly-integration.yml

Picks up cross-prefix dep routing fix (#2296), Dolt driver updates, and auto-commit fix (#2474).

## Test plan

- [ ] CI workflows install bd v0.60.0 successfully
- [ ] Integration tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)