### PR TITLE
fix: compactor-dog hardcoded database names (gt-2l9lq)

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -22,7 +22,7 @@ import (
 var validDBName = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
 // DefaultDatabases is the static fallback list of known production databases.
-var DefaultDatabases = []string{"hq", "bd", "gt"}
+var DefaultDatabases = []string{"beads_hq", "bd_001", "gt"}
 
 // testPollutionPrefixes are database name prefixes created by tests.
 var testPollutionPrefixes = []string{"testdb_", "beads_t", "beads_pt", "doctest_"}


### PR DESCRIPTION
## Summary
- Fix hardcoded database names in compactor-dog (hq→beads_hq, bd→bd_001)
- Issue: gt-2l9lq

---
*Processed by Gas Town Refinery*