### PR TITLE
fix: scheduler multi-rig tests leak databases causing flaky failures (#2832)

### DIFF
--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -618,6 +618,29 @@ func setupMultiRigSchedulerTown(t *testing.T) (hqPath, rig1Path, rig2Path, gtBin
 		t.Fatalf("write rig2 redirect: %v", err)
 	}
 
+	// Drop test databases on cleanup to prevent orphaned databases on the Dolt server.
+	// Without this, databases from multi-rig tests persist and contaminate subsequent
+	// tests that share the same Dolt server (see #2832).
+	t.Cleanup(func() {
+		port := os.Getenv("GT_DOLT_PORT")
+		if port == "" {
+			port = "3307"
+		}
+		dsn := fmt.Sprintf("root@tcp(127.0.0.1:%s)/", port)
+		db, err := sql.Open("mysql", dsn)
+		if err != nil {
+			t.Logf("cleanup: could not connect to drop test databases: %v", err)
+			return
+		}
+		defer db.Close()
+		for _, prefix := range []string{hqPrefix, rig1Prefix, rig2Prefix} {
+			dbName := "beads_" + prefix
+			if _, err := db.Exec("DROP DATABASE IF EXISTS `" + dbName + "`"); err != nil {
+				t.Logf("cleanup: failed to drop %s: %v", dbName, err)
+			}
+		}
+	})
+
 	// --- Environment ---
 	env = cleanSchedulerTestEnv(tmpDir)
 


### PR DESCRIPTION
## Summary
- `setupMultiRigSchedulerTown` creates 3 Dolt databases per test but never drops them
- `setupSchedulerIntegrationTown` (single-rig) has cleanup but multi-rig does not
- Orphaned databases contaminate subsequent tests, causing different tests to fail each run
- Added matching `t.Cleanup()` to drop `beads_h<n>`, `beads_r<n>`, `beads_s<n>` after each multi-rig test

Fixes #2832

## Test plan
- [ ] Run scheduler integration tests multiple times: `go test -tags=integration -run 'TestScheduler' -timeout 5m -count=3 -v ./internal/cmd/`
- [ ] Verify no flaky failures across runs
- [ ] Verify test databases are cleaned up after each test

🤖 Generated with [Claude Code](https://claude.com/claude-code)