### PR TITLE
fix: disable dolt_transaction_commit to prevent read-only commit storm (#2685)

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1220,7 +1220,7 @@ listener:
 data_dir: "%s"
 
 behavior:
-  dolt_transaction_commit: true
+  dolt_transaction_commit: false
   auto_gc_behavior:
     enable: true
     archive_level: 1


### PR DESCRIPTION
## Summary
- `dolt_transaction_commit: true` causes every read-only query to attempt a COMMIT
- Multi-agent workloads generate 100k+ warnings, 718k connections, eventually crashing Dolt
- `bd` already does explicit COMMIT on writes, so this setting is unnecessary
- Changed to `false` in the config template

Fixes #2685

## Test plan
- [ ] `gt dolt start` generates config with `dolt_transaction_commit: false`
- [ ] Multi-agent workload runs without "nothing to commit" warnings
- [ ] Write operations still commit correctly (bd handles explicit COMMITs)

🤖 Generated with [Claude Code](https://claude.com/claude-code)