### PR TITLE
fix: respect global default agent when starting dogs

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1507,9 +1507,10 @@ func tryResolveFromEphemeralTier(role string) (*RuntimeConfig, bool) {
 	return nil, false
 }
 
-// hasExplicitNonClaudeOverride checks if a role has an explicit non-Claude agent
-// assignment in rig or town RoleAgents. This is used to prevent ephemeral cost
-// tiers from silently replacing intentional non-Claude agent selections.
+// hasExplicitNonClaudeOverride checks if there is an explicit non-Claude agent
+// assignment either specifically for the role (in rig or town RoleAgents) or
+// globally (via rig Agent or town DefaultAgent). This prevents fallback logic
+// and cost tiers from silently replacing intentional non-Claude agent selections.
 func hasExplicitNonClaudeOverride(role string, townSettings *TownSettings, rigSettings *RigSettings) bool {
 	// Check rig's RoleAgents
 	if rigSettings != nil && rigSettings.RoleAgents != nil {
@@ -1525,6 +1526,18 @@ func hasExplicitNonClaudeOverride(role string, townSettings *TownSettings, rigSe
 			if rc := lookupAgentConfigIfExists(agentName, townSettings, rigSettings); rc != nil && !isClaudeAgent(rc) {
 				return true
 			}
+		}
+	}
+	// Check rig's global Agent
+	if rigSettings != nil && rigSettings.Agent != "" {
+		if rc := lookupAgentConfigIfExists(rigSettings.Agent, townSettings, rigSettings); rc != nil && !isClaudeAgent(rc) {
+			return true
+		}
+	}
+	// Check town's DefaultAgent
+	if townSettings != nil && townSettings.DefaultAgent != "" {
+		if rc := lookupAgentConfigIfExists(townSettings.DefaultAgent, townSettings, rigSettings); rc != nil && !isClaudeAgent(rc) {
+			return true
 		}
 	}
 	return false


### PR DESCRIPTION
## Summary
Dogs currently default to Claude Haiku unless there is an explicit non-Claude override. The existing override detection only checks role-specific `RoleAgents`, which means dog startup can ignore an intentional global non-Claude default configured via rig `Agent` or town `DefaultAgent`.

This change extends explicit non-Claude override detection so dog resolution also respects:
- rig-level global `Agent`
- town-level global `DefaultAgent`

## Problem
When resolving the runtime config for the `dog` role, the loader has a special-case default that returns the Haiku preset for cheap infrastructure workers. That fast path is supposed to be skipped when the operator has intentionally selected a non-Claude agent.

Before this change, that skip logic only looked at role-specific assignments in rig and town `RoleAgents`. If the non-Claude choice came from the normal global fallback chain instead of a role-specific mapping, the dog path still returned Haiku and silently overrode the configured default.

## What changed
The fix broadens `hasExplicitNonClaudeOverride` so it now checks four places:
- rig `RoleAgents[role]`
- town `RoleAgents[role]`
- rig global `Agent`
- town global `DefaultAgent`

If any of those resolve to a non-Claude agent, dog startup falls through to the normal resolution path instead of forcing the Haiku preset.

## Result
Behavior after this patch:
- dogs still default to Claude Haiku when there is no explicit non-Claude selection
- dogs now honor intentional non-Claude defaults configured globally
- existing role-specific precedence remains unchanged
- cost-tier logic continues to manage Claude model selection without replacing explicit non-Claude agent choices

## Scope and risk
This is a narrow change in `internal/config/loader.go` that only affects the explicit-override check used by dog resolution. No precedence order was changed; the patch only fixes a missing source of explicit intent in the existing decision logic.