### PR TITLE
fix: use raw SQL for cross-database dep lookups in convoy/epic (#2832)

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -468,7 +468,7 @@ func runBdJSON(dir string, args ...string) ([]byte, error) {
 // depType filters by dependency type (e.g., "tracks", "blocks"); empty means all types.
 //
 // Returns deduplicated, unwrapped issue IDs (external:prefix:id → id).
-func bdDepListRawIDs(dir, issueID, direction, depType string) ([]string, error) { //nolint:unparam // depType kept for API generality; callers currently only use "tracks"
+func bdDepListRawIDs(dir, issueID, direction, depType string) ([]string, error) {
 	// Determine query columns based on direction.
 	// "down": issueID depends on targets → SELECT depends_on_id WHERE issue_id = ?
 	// "up":   issueID is depended on → SELECT issue_id WHERE depends_on_id = ?
@@ -2225,19 +2225,26 @@ func applyFreshIssueDetails(dep *trackedDependency, details *issueDetails) {
 // getTrackedIssues gets issues tracked by a convoy with fresh cross-rig details.
 // Returns issue details including status, type, and worker info.
 //
-// Uses bd dep list to query tracked dependencies. If dep list returns empty
-// (e.g., cross-database deps where the JOIN fails — see GH #2624), falls back
-// to bd show and extracts tracked dependencies from the convoy's dependencies
-// array. Then fetches fresh issue details via bd show with prefix routing.
+// Prefers raw SQL query against the dependencies table (bdDepListRawIDs) which
+// avoids the JOIN with the issues table that silently drops cross-database
+// dependencies (see GH #2624, #2832). Falls back to bd dep list and bd show
+// for older bd versions that don't support bd sql.
+// Then fetches fresh issue details via bd show with prefix routing.
 func getTrackedIssues(townBeads, convoyID string) ([]trackedIssueInfo, error) {
-	// Try bd dep list first — the standard dependency query path.
-	trackedIDs, err := bdDepListTracked(townBeads, convoyID)
+	// Prefer raw SQL — works for cross-database deps where tracked beads
+	// live in different Dolt databases. Falls back to bd dep list if bd sql
+	// is not available (older bd versions).
+	trackedIDs, err := bdDepListRawIDs(townBeads, convoyID, "down", "tracks")
 	if err != nil {
-		return nil, fmt.Errorf("querying tracked issues for %s: %w", convoyID, err)
+		// bd sql not supported (older bd) — fall back to bd dep list.
+		trackedIDs, err = bdDepListTracked(townBeads, convoyID)
+		if err != nil {
+			return nil, fmt.Errorf("querying tracked issues for %s: %w", convoyID, err)
+		}
 	}
 
-	// Fallback: when dep list returns empty (common for cross-database deps),
-	// parse tracked dependencies from bd show output.
+	// Fallback: when dep queries return empty (common for cross-database deps
+	// on older bd where the JOIN fails), try parsing from bd show output.
 	if len(trackedIDs) == 0 {
 		trackedIDs, err = bdShowTrackedDeps(townBeads, convoyID)
 		if err != nil {

--- a/internal/cmd/scheduler_epic.go
+++ b/internal/cmd/scheduler_epic.go
@@ -296,11 +296,52 @@ type epicChild struct {
 }
 
 // getEpicChildren returns child issues of an epic via dependency lookup.
+// Prefers raw SQL (bdDepListRawIDs) which handles cross-database deps correctly.
+// Falls back to bd dep list for older bd versions (see GH #2624, #2832).
 func getEpicChildren(epicID string) ([]epicChild, error) {
+	dir := resolveBeadDir(epicID)
+
+	// Prefer raw SQL — handles cross-database deps. Falls back to bd dep list
+	// if bd sql is not available (older bd versions).
+	childIDs, err := bdDepListRawIDs(dir, epicID, "down", "depends_on")
+	if err != nil {
+		// bd sql not supported — fall back to bd dep list.
+		childIDs, err = bdDepListFallback(dir, epicID)
+		if err != nil {
+			return nil, fmt.Errorf("querying epic children for %s: %w", epicID, err)
+		}
+	}
+
+	children := make([]epicChild, 0, len(childIDs))
+	for _, id := range childIDs {
+		info, err := getBeadInfo(id)
+		if err != nil {
+			children = append(children, epicChild{
+				ID: id,
+			})
+			continue
+		}
+		children = append(children, epicChild{
+			ID:       id,
+			Title:    info.Title,
+			Status:   info.Status,
+			Assignee: info.Assignee,
+			Labels:   info.Labels,
+		})
+	}
+
+	return children, nil
+}
+
+// bdDepListFallback uses bd dep list to get child dependency IDs.
+// This is the legacy path — it uses a SQL JOIN with the issues table which
+// silently drops cross-database dependencies. Used as fallback when bd sql
+// is not available.
+func bdDepListFallback(dir, epicID string) ([]string, error) {
 	depArgs := beads.MaybePrependAllowStale([]string{"dep", "list", epicID,
 		"--direction=down", "--type=depends_on", "--json"})
 	depCmd := exec.Command("bd", depArgs...)
-	depCmd.Dir = resolveBeadDir(epicID)
+	depCmd.Dir = dir
 	var stdout bytes.Buffer
 	depCmd.Stdout = &stdout
 
@@ -314,33 +355,18 @@ func getEpicChildren(epicID string) ([]epicChild, error) {
 	}
 
 	var deps []struct {
-		ID     string `json:"id"`
-		Title  string `json:"title"`
-		Status string `json:"status"`
+		ID string `json:"id"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &deps); err != nil {
 		return nil, fmt.Errorf("parsing dependency list: %w", err)
 	}
 
-	children := make([]epicChild, 0, len(deps))
+	ids := make([]string, 0, len(deps))
 	for _, dep := range deps {
-		info, err := getBeadInfo(dep.ID)
-		if err != nil {
-			children = append(children, epicChild{
-				ID:     dep.ID,
-				Title:  dep.Title,
-				Status: dep.Status,
-			})
-			continue
+		id := beads.ExtractIssueID(dep.ID)
+		if id != "" {
+			ids = append(ids, id)
 		}
-		children = append(children, epicChild{
-			ID:       dep.ID,
-			Title:    info.Title,
-			Status:   info.Status,
-			Assignee: info.Assignee,
-			Labels:   info.Labels,
-		})
 	}
-
-	return children, nil
+	return ids, nil
 }

--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -618,6 +618,29 @@ func setupMultiRigSchedulerTown(t *testing.T) (hqPath, rig1Path, rig2Path, gtBin
 		t.Fatalf("write rig2 redirect: %v", err)
 	}
 
+	// Drop test databases on cleanup to prevent orphaned databases on the Dolt
+	// server. Without this, databases from multi-rig tests persist and can
+	// contaminate subsequent tests sharing the same server (see #2832).
+	t.Cleanup(func() {
+		port := os.Getenv("GT_DOLT_PORT")
+		if port == "" {
+			port = "3307"
+		}
+		dsn := fmt.Sprintf("root@tcp(127.0.0.1:%s)/", port)
+		db, err := sql.Open("mysql", dsn)
+		if err != nil {
+			t.Logf("cleanup: could not connect to drop test databases: %v", err)
+			return
+		}
+		defer db.Close()
+		for _, prefix := range []string{hqPrefix, rig1Prefix, rig2Prefix} {
+			dbName := "beads_" + prefix
+			if _, err := db.Exec("DROP DATABASE IF EXISTS `" + dbName + "`"); err != nil {
+				t.Logf("cleanup: failed to drop %s: %v", dbName, err)
+			}
+		}
+	})
+
 	// --- Environment ---
 	env = cleanSchedulerTestEnv(tmpDir)
 


### PR DESCRIPTION
## Summary

- Switch `getTrackedIssues()` (convoy.go) and `getEpicChildren()` (scheduler_epic.go) from `bd dep list` to `bdDepListRawIDs()` — the raw SQL query that bypasses the issues table JOIN which silently drops cross-database dependencies
- Add `t.Cleanup()` to `setupMultiRigSchedulerTown` to drop orphaned test databases after multi-rig tests

## Root Cause

`bd dep list` performs a SQL JOIN with the issues table. When tracked beads live in a different Dolt database (cross-rig deps), the JOIN finds no matching issues and silently returns empty results. The codebase already had `bdDepListRawIDs()` — a raw SQL query against the dependencies table designed for exactly this case (GH #2624) — used by `sling_convoy.go` and `convoy_stage.go`. These two functions were missed.

Credit to @rileywhite for identifying the root cause in the issue comments.

## Test plan

- [ ] CI integration tests pass (the two flaky tests should now be stable)
- [ ] `go vet -tags=integration ./internal/cmd/` passes
- [ ] No .beads files included

Fixes #2832

🤖 Generated with [Claude Code](https://claude.com/claude-code)