### PR TITLE
fix: cross-prefix deps queryable via raw SQL fallback

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -2236,8 +2236,16 @@ func getTrackedIssues(townBeads, convoyID string) ([]trackedIssueInfo, error) {
 		return nil, fmt.Errorf("querying tracked issues for %s: %w", convoyID, err)
 	}
 
-	// Fallback: when dep list returns empty (common for cross-database deps),
-	// parse tracked dependencies from bd show output.
+	// Fallback 1: raw SQL query on dependencies table — works for cross-database
+	// deps where bd dep list's JOIN fails silently. (GH#2786, GH#2624)
+	if len(trackedIDs) == 0 {
+		trackedIDs, err = bdDepListRawIDs(townBeads, convoyID, "down", "tracks")
+		if err != nil {
+			return nil, fmt.Errorf("raw sql dep query for %s: %w", convoyID, err)
+		}
+	}
+
+	// Fallback 2: parse tracked dependencies from bd show output.
 	if len(trackedIDs) == 0 {
 		trackedIDs, err = bdShowTrackedDeps(townBeads, convoyID)
 		if err != nil {

--- a/internal/cmd/convoy_bd_routing_test.go
+++ b/internal/cmd/convoy_bd_routing_test.go
@@ -111,6 +111,9 @@ case "$*" in
     fi
     echo '[]'
     ;;
+  "sql SELECT depends_on_id FROM dependencies WHERE issue_id = 'hq-cv-town' AND type = 'tracks' --json")
+    echo '[]'
+    ;;
   "show hq-cv-town --json")
     if [ "$PWD" != "%s" ]; then
       echo "expected town root, got $PWD" >&2
@@ -177,6 +180,9 @@ case "$*" in
       echo "expected town root, got $PWD" >&2
       exit 1
     fi
+    echo '[]'
+    ;;
+  "sql SELECT depends_on_id FROM dependencies WHERE issue_id = 'hq-cv-status' AND type = 'tracks' --json")
     echo '[]'
     ;;
   *)

--- a/internal/cmd/convoy_external_tracking_test.go
+++ b/internal/cmd/convoy_external_tracking_test.go
@@ -69,6 +69,9 @@ case "$*" in
   "dep list hq-cv-ext --direction=down --type=tracks --json")
     echo '[]'
     ;;
+  "sql SELECT depends_on_id FROM dependencies WHERE issue_id = 'hq-cv-ext' AND type = 'tracks' --json")
+    echo '[]'
+    ;;
   "show hq-cv-ext --json")
     echo '[{"id":"hq-cv-ext","title":"External convoy","status":"open","issue_type":"convoy","dependencies":[{"id":"external:ghostty:ghostty-123","title":"Ghost 123","status":"open","type":"task","dependency_type":"tracks"},{"id":"external:ghostty:ghostty-456","title":"Ghost 456","status":"closed","type":"task","dependency_type":"tracks"},{"id":"gt-ignore","title":"Ignore me","status":"open","type":"task","dependency_type":"blocks"}]}]'
     ;;
@@ -109,5 +112,51 @@ esac
 	}
 	if statusByID["ghostty-123"] != "open" || statusByID["ghostty-456"] != "closed" {
 		t.Fatalf("unexpected tracked statuses: %#v", statusByID)
+	}
+}
+
+// TestGetTrackedIssues_RawSQLResolvesCrossPrefixDeps verifies that when
+// bd dep list returns empty (cross-database JOIN failure), the raw SQL
+// fallback via bdDepListRawIDs finds the dependency. (GH#2786)
+func TestGetTrackedIssues_RawSQLResolvesCrossPrefixDeps(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	townRoot, townBeads, _ := makeExternalTrackingTownWorkspace(t)
+	chdirExternalTrackingTest(t, townRoot)
+
+	// bd dep list returns empty (cross-db JOIN fails), but raw SQL finds the dep.
+	scriptBody := fmt.Sprintf(`
+case "$*" in
+  "dep list hq-cv-cross --direction=down --type=tracks --json")
+    echo '[]'
+    ;;
+  "sql SELECT depends_on_id FROM dependencies WHERE issue_id = 'hq-cv-cross' AND type = 'tracks' --json")
+    echo '[{"depends_on_id":"external:gt:gt-pye"}]'
+    ;;
+  "show gt-pye --json")
+    echo '[{"id":"gt-pye","title":"Cross-prefix bead","status":"closed","issue_type":"task"}]'
+    ;;
+  *)
+    echo "unexpected bd args: $*" >&2
+    exit 1
+    ;;
+esac
+`)
+	writeExternalTrackingBdStub(t, scriptBody)
+
+	tracked, err := getTrackedIssues(townBeads, "hq-cv-cross")
+	if err != nil {
+		t.Fatalf("getTrackedIssues: %v", err)
+	}
+	if len(tracked) != 1 {
+		t.Fatalf("expected 1 tracked issue, got %d", len(tracked))
+	}
+	if tracked[0].ID != "gt-pye" {
+		t.Fatalf("expected tracked ID gt-pye, got %s", tracked[0].ID)
+	}
+	if tracked[0].Status != "closed" {
+		t.Fatalf("expected status closed, got %s", tracked[0].Status)
 	}
 }


### PR DESCRIPTION
## Summary
- `getTrackedIssues()` now uses `bdDepListRawIDs` as a fallback when `bdDepListTracked` returns empty
- This resolves cross-database dependency queries where the JOIN-based `bd dep list` silently fails
- Convoys tracking beads in other databases (e.g., `hq-cv-*` → `gt-*`) now correctly show progress
- Added test for the cross-prefix raw SQL resolution path

## Test plan
- [x] `go build ./cmd/gt` — compiles
- [x] `go vet ./internal/cmd/` — clean
- [x] `TestGetTrackedIssues_FallsBackToShowTrackedDependencies` — passes (full fallback chain)
- [x] `TestGetTrackedIssues_RawSQLResolvesCrossPrefixDeps` — passes (new test, raw SQL succeeds)
- [x] `TestRunConvoyList_UsesTownRootAndStripsBeadsDir` — passes
- [x] `TestRunConvoyStatus_UsesTownRootAndStripsBeadsDir` — passes

Fixes #2786

🤖 Generated with [Claude Code](https://claude.com/claude-code)