### PR TITLE
fix: prevent daemon respawn during gt down shutdown (#2656)

### DIFF
--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -476,7 +476,18 @@ func disableCurrentAgentDND(townRoot string) (bool, error) {
 }
 
 // ensureDaemon starts the daemon if not running.
+// Refuses to start during an active shutdown to prevent the race condition
+// where a dying session restarts the daemon after gt down kills it (#2656).
 func ensureDaemon(townRoot string) error {
+	// Check shutdown lock before starting a new daemon.
+	// During gt down, sessions are killed after the daemon. A dying session
+	// (e.g., mayor) can trigger ensureDaemon, spawning a new daemon that
+	// outlives the shutdown. The shutdown.lock is held by gt down for the
+	// entire teardown sequence.
+	if daemon.IsShutdownInProgress(townRoot) {
+		return nil
+	}
+
 	running, _, err := daemon.IsRunning(townRoot)
 	if err != nil {
 		return err

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -266,6 +266,14 @@ func New(config *Config) (*Daemon, error) {
 func (d *Daemon) Run() error {
 	d.logger.Printf("Daemon starting (PID %d)", os.Getpid())
 
+	// Refuse to start if a shutdown is in progress (#2656).
+	// A dying session can spawn a new daemon process after gt down kills the
+	// old one. The shutdown.lock is held for the entire teardown sequence.
+	if IsShutdownInProgress(d.config.TownRoot) {
+		d.logger.Println("Shutdown in progress, refusing to start")
+		return fmt.Errorf("shutdown in progress")
+	}
+
 	// Acquire exclusive lock to prevent multiple daemons from running.
 	// This prevents the TOCTOU race condition where multiple concurrent starts
 	// can all pass the IsRunning() check before any writes the PID file.


### PR DESCRIPTION
## Summary
- `ensureDaemon()` now checks `IsShutdownInProgress()` before spawning a new daemon process
- `Daemon.Run()` also refuses to start if the shutdown lock is held
- Fixes the race where a dying session (e.g., mayor) triggers `ensureDaemon` after `gt down` kills the daemon in Phase 4, spawning a replacement that outlives the teardown

## Root cause
`gt down` kills the daemon in Phase 4, but town sessions (mayor, boot, deacon) are killed in Phase 3. If a session's exit hook or respawn logic calls `ensureDaemon` before the process fully dies, a new daemon starts within ~1 second. The new daemon has no awareness of the in-progress shutdown and keeps all tmux sessions alive overnight.

## Fix
Both `ensureDaemon` and `Daemon.Run` now check the existing `shutdown.lock` (held by `gt down` for the entire teardown). If the lock is held, they silently return without starting.

## Test plan
- [x] `go build ./internal/cmd/... ./internal/daemon/...` — compiles clean
- [x] `go test ./internal/daemon/ -run TestShutdown` — passes
- [ ] Manual: `gt up`, then `gt down` — verify daemon does not respawn

🤖 Generated with [Claude Code](https://claude.com/claude-code)