### PR TITLE
fix: stop creating agent identity beads as ephemeral wisps

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -221,7 +221,6 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 			"--description=" + description,
 			"--type=agent",
 			"--labels=gt:agent",
-			"--ephemeral",
 		}
 		if NeedsForceForID(id) {
 			a = append(a, "--force")
@@ -234,8 +233,9 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 		return a
 	}
 
-	// Create ephemeral agent bead (wisps table). Agent operational state has
-	// zero git history consumers (gt-bewatn.9).
+	// Create persistent agent bead (issues table). Agent beads were previously
+	// ephemeral (wisps) but wisp GC deleted them (GH#2768). When bd gains
+	// --no-history support, switch to that to avoid Dolt commit noise.
 	out, err := b.run(buildArgs()...)
 	if err != nil {
 		out, err = b.run(buildArgs()...)
@@ -344,12 +344,8 @@ func (b *Beads) CreateOrReopenAgentBead(id, title string, fields *AgentFields) (
 	if _, err := target.run("update", id, "--type=agent"); err != nil {
 		return nil, fmt.Errorf("fixing agent bead type: %w", err)
 	}
-	// Ensure agent bead is ephemeral (wisp) — agent operational state has
-	// zero git history consumers (gt-bewatn.9)
-	if _, err := target.run("update", id, "--ephemeral"); err != nil {
-		// Non-fatal: the bead is functional without ephemeral flag
-		_ = err
-	}
+	// Agent beads are now persistent (GH#2768) — wisp GC was deleting them.
+	// Will switch to --no-history when bd supports it.
 
 	// Note: role slot no longer set - role definitions are config-based
 


### PR DESCRIPTION
## Summary

- Remove `--ephemeral` flag from `CreateAgentBead()` — agent beads now go to the issues table instead of wisps
- Remove `--ephemeral` update from `CreateOrReopenAgentBead()` — reopened agent beads also stay persistent
- Existing agent beads in the wisps table remain discoverable via `ListAgentBeads()` which queries both tables

**Problem**: Agent identity beads were created with `--ephemeral`, making them wisps subject to wisp GC. The reaper deleted them on every patrol cycle, causing `gt doctor` to report 85+ missing agent beads. This is the root cause of the identity beads cluster (#2766, #2767).

**Solution**: Stop creating agent beads as ephemeral. The `--ephemeral` flag was originally added to avoid Dolt commit noise from agent state changes, but the GC side-effect made agent beads unreliable. When `bd` gains `--no-history` support (beads PR #2622), agent beads should switch to that for the best of both worlds.

Fixes #2768

## Test plan

- [x] `go build ./internal/beads/` — clean
- [x] `go vet ./internal/beads/` — clean
- [x] `go test ./internal/beads/ -run Agent` — passes
- [ ] Verify new agent beads appear in issues table (not wisps)
- [ ] Verify wisp GC no longer deletes agent beads
- [ ] Verify `gt doctor` agent-beads-exist check passes after patrol cycle

🤖 Generated with [Claude Code](https://claude.com/claude-code)