### PR TITLE
fix: update rig add help text to use underscores instead of hyphens

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -76,8 +76,11 @@ Use --adopt to register an existing directory instead of creating new:
 
 Example:
   gt rig add gastown https://github.com/steveyegge/gastown
-  gt rig add my-project git@github.com:user/repo.git --prefix mp
-  gt rig add existing-rig --adopt`,
+  gt rig add my_project git@github.com:user/repo.git --prefix mp
+  gt rig add existing_rig --adopt
+
+Note: rig names must use alphanumeric characters and underscores only.
+Hyphens are reserved for agent ID parsing (format: prefix-rig-role).`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: runRigAdd,
 }


### PR DESCRIPTION
## Summary

- Update `gt rig add` help examples from `my-project`/`existing-rig` to `my_project`/`existing_rig`
- Add a note explaining that hyphens are reserved for agent ID parsing

**Problem**: The help text showed `gt rig add my-project ...` but the validator rejects hyphens because they're reserved as delimiters in agent ID format (`prefix-rig-role`). Users try the documented example and get an error.

**Solution**: Fix the documentation to match the constraint. The error message already suggests underscores, but the help text was contradicting it.

Fixes #2769

## Test plan

- [x] `go build ./internal/cmd/` — clean
- [x] `go vet ./internal/cmd/` — clean
- [ ] `gt rig add --help` shows underscore examples

🤖 Generated with [Claude Code](https://claude.com/claude-code)