### PR TITLE
fix: refinery checks no_merge flag on source issue before merging

### DIFF
--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -1336,6 +1336,19 @@ func (e *Engineer) ListReadyMRs() ([]*MRInfo, error) {
 			continue // Skip issues without MR fields
 		}
 
+		// Check no_merge flag on the source issue (GH#2778).
+		// gt done enforces no_merge at the polecat level, but manually-created
+		// PRs can bypass that. The refinery must also check before merging.
+		if fields.SourceIssue != "" {
+			if sourceIssue, err := e.beads.Show(fields.SourceIssue); err == nil {
+				attachFields := beads.ParseAttachmentFields(sourceIssue)
+				if attachFields != nil && attachFields.NoMerge {
+					_, _ = fmt.Fprintf(e.output, "[Engineer] Skipping MR %s: source issue %s has no_merge=true\n", issue.ID, fields.SourceIssue)
+					continue
+				}
+			}
+		}
+
 		// Skip if already assigned, unless claim is stale (allows re-claim after crash).
 		// NOTE: Only one refinery runs per rig (enforced by ErrAlreadyRunning in
 		// manager.go), so concurrent re-claim race conditions are not a concern.


### PR DESCRIPTION
## Summary

- Add `no_merge` check in `ListReadyMRs()` that looks up the source issue's attachment fields
- MRs whose source bead has `no_merge: true` are skipped with a log message

**Problem**: `no_merge: true` was only enforced at the polecat level (`gt done`), but if a PR was created manually or through other paths, the refinery would auto-merge it anyway, ignoring the flag.

**Solution**: Check the source issue's `no_merge` flag in `ListReadyMRs()` before the MR enters the merge queue. This is the same place where `gt:owned-direct` and blocker checks happen.

Fixes #2778

## Test plan

- [x] `go build ./internal/refinery/` — clean
- [x] `go vet ./internal/refinery/` — clean
- [x] `go test ./internal/refinery/` — all tests pass
- [ ] Verify MR with `no_merge` source issue is skipped in refinery log
- [ ] Verify normal MRs still process correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)