### PR TITLE
fix: skip crash detection for terminal agent states (done/nuked)

### DIFF
--- a/internal/beads/status.go
+++ b/internal/beads/status.go
@@ -45,6 +45,19 @@ func (s AgentState) IsActive() bool {
 	}
 }
 
+// IsTerminal returns true if the agent has reached a final state where its
+// session being dead is expected, not a crash. Used by crash detection to
+// avoid false CRASHED_POLECAT alerts for polecats that completed normally
+// or were intentionally nuked.
+func (s AgentState) IsTerminal() bool {
+	switch s {
+	case AgentStateDone, AgentStateNuked:
+		return true
+	default:
+		return false
+	}
+}
+
 // IssueStatus represents the lifecycle status of a beads issue.
 // These values are stored in the status field and govern issue workflow transitions.
 //

--- a/internal/beads/status_test.go
+++ b/internal/beads/status_test.go
@@ -47,6 +47,30 @@ func TestAgentStateIsActive(t *testing.T) {
 	}
 }
 
+func TestAgentStateIsTerminal(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		state AgentState
+		want  bool
+	}{
+		{AgentStateDone, true},
+		{AgentStateNuked, true},
+		{AgentStateWorking, false},
+		{AgentStateRunning, false},
+		{AgentStateSpawning, false},
+		{AgentStateIdle, false},
+		{AgentStateStuck, false},
+		{AgentStateEscalated, false},
+		{AgentStateAwaitingGate, false},
+		{AgentState(""), false},
+	}
+	for _, tt := range tests {
+		if got := tt.state.IsTerminal(); got != tt.want {
+			t.Errorf("AgentState(%q).IsTerminal() = %v, want %v", tt.state, got, tt.want)
+		}
+	}
+}
+
 func TestIssueStatusBlocksRemoval(t *testing.T) {
 	t.Parallel()
 	tests := []struct {

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1936,6 +1936,17 @@ func (d *Daemon) checkPolecatHealth(rigName, polecatName string) {
 		return
 	}
 
+	// Terminal state guard: skip polecats whose agent_state indicates the
+	// session being dead is expected (done, nuked). When a polecat completes
+	// normally or is intentionally nuked, the hook_bead may still reference
+	// an open bead (nuked polecats leave the bead open by design). Without
+	// this check, every heartbeat fires a false CRASHED_POLECAT alert.
+	if beads.AgentState(info.State).IsTerminal() {
+		d.logger.Printf("Skipping crash detection for %s/%s: agent_state=%s (terminal — session death expected)",
+			rigName, polecatName, info.State)
+		return
+	}
+
 	// Stale hook guard: skip polecats whose hook_bead is already closed.
 	// When a polecat completes work normally (gt done), the hook_bead gets closed
 	// but may not be cleared from the agent bead before the session stops.

--- a/internal/daemon/polecat_health_test.go
+++ b/internal/daemon/polecat_health_test.go
@@ -235,6 +235,71 @@ func TestCheckPolecatHealth_SkipsClosedHookBead(t *testing.T) {
 	}
 }
 
+// TestCheckPolecatHealth_SkipsTerminalState verifies that checkPolecatHealth
+// does NOT fire CRASHED_POLECAT when the agent_state is terminal (done/nuked).
+// This is the regression test for the false positive flood bug (gt-tey0i):
+// nuked polecats leave the hook_bead open by design, causing repeated false
+// alerts every heartbeat cycle because isBeadClosed returns false.
+func TestCheckPolecatHealth_SkipsTerminalDone(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mocks for tmux and bd")
+	}
+	binDir := t.TempDir()
+	writeFakeTestTmux(t, binDir)
+	recentTime := time.Now().UTC().Format(time.RFC3339)
+	bdPath := writeFakeTestBD(t, binDir, "done", "done", "gt-xyz", recentTime)
+
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	var logBuf strings.Builder
+	d := &Daemon{
+		config: &Config{TownRoot: t.TempDir()},
+		logger: log.New(&logBuf, "", 0),
+		tmux:   tmux.NewTmux(),
+		bdPath: bdPath,
+	}
+
+	d.checkPolecatHealth("myr", "mycat")
+
+	got := logBuf.String()
+	if !strings.Contains(got, "agent_state=done (terminal") {
+		t.Errorf("expected log about terminal agent_state, got: %q", got)
+	}
+	if strings.Contains(got, "CRASH DETECTED") {
+		t.Errorf("terminal agent_state must not trigger CRASH DETECTED, got: %q", got)
+	}
+}
+
+func TestCheckPolecatHealth_SkipsTerminalNuked(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mocks for tmux and bd")
+	}
+	binDir := t.TempDir()
+	writeFakeTestTmux(t, binDir)
+	recentTime := time.Now().UTC().Format(time.RFC3339)
+	bdPath := writeFakeTestBD(t, binDir, "nuked", "nuked", "gt-xyz", recentTime)
+
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	var logBuf strings.Builder
+	d := &Daemon{
+		config: &Config{TownRoot: t.TempDir()},
+		logger: log.New(&logBuf, "", 0),
+		tmux:   tmux.NewTmux(),
+		bdPath: bdPath,
+	}
+
+	d.checkPolecatHealth("myr", "mycat")
+
+	got := logBuf.String()
+	if !strings.Contains(got, "agent_state=nuked (terminal") {
+		t.Errorf("expected log about terminal agent_state, got: %q", got)
+	}
+	if strings.Contains(got, "CRASH DETECTED") {
+		t.Errorf("terminal agent_state must not trigger CRASH DETECTED, got: %q", got)
+	}
+}
+
 // TestCheckPolecatHealth_NotifiesWitnessOnCrash verifies that when a polecat
 // crash is detected, the daemon sends a notification to the witness via
 // `gt mail send` with a CRASHED_POLECAT subject. Restart is deferred to the


### PR DESCRIPTION
## Summary

- Adds `AgentState.IsTerminal()` method that returns true for `done` and `nuked` states
- Adds terminal state guard in `checkPolecatHealth` before the existing `isBeadClosed` check
- Nuked polecats leave hook_bead open by design, so `isBeadClosed` returns false and the existing guard misses them — this new check catches both done and nuked cases

Closes #2795

## Test plan

- [x] `TestAgentStateIsTerminal` — verifies all agent states return correct terminal status
- [x] `TestCheckPolecatHealth_SkipsTerminalDone` — done state skips crash detection
- [x] `TestCheckPolecatHealth_SkipsTerminalNuked` — nuked state skips crash detection
- [x] `go build ./...` passes
- [x] `go test ./internal/beads/ -run TestAgentStateIsTerminal` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)