### PR TITLE
fix: dog dispatch fails when any rig database is inaccessible

### DIFF
--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -967,14 +967,14 @@ func (r *Router) validateRecipient(identity string) error {
 					}
 				}
 			}
-			if len(queryErrors) > 0 {
-				return fmt.Errorf("no agent found (query errors: %s)", strings.Join(queryErrors, "; "))
-			}
 		}
 	}
 
 	// Fall back to workspace directory validation. Agent beads may be missing
 	// (e.g., Dolt DB reset) even though the agent's workspace directory exists.
+	// This also handles the case where some rig databases are inaccessible
+	// (e.g., cfutons_mobile's beads_cm) — a rig database failure should not
+	// block dispatch to agents in other rigs (GH#2748, gt-za5q3).
 	if r.townRoot != "" && r.validateAgentWorkspace(identity) {
 		return nil
 	}


### PR DESCRIPTION
## Summary

- Remove early return in `validateRecipient()` when rig database queries fail
- Let the workspace directory fallback always run regardless of rig query errors

**Problem**: `validateRecipient()` iterated all rig routes to find agent beads. If any rig's database was inaccessible (e.g., cfutons_mobile's `beads_cm`), it collected the error and returned early with "no agent found (query errors: ...)". This happened before the workspace directory fallback at line 978, which would have found the agent's workspace and validated it.

**Impact**: All dog dispatch and mail delivery to agents was blocked by a single unhealthy rig database. The workaround was `gt dog call`, but dogs wouldn't get plugin instructions.

**Root cause path**: `dog.go:1107` → `router.Send()` → `sendToSingle()` → `validateRecipient()` → iterates routes → cfutons_mobile query fails → early return with errors → workspace fallback never runs.

**Fix**: Remove the early return on query errors. The workspace validation fallback (which checks if the agent's directory exists on disk) is designed exactly for cases where bead registries are unavailable.

Fixes gt-za5q3

## Test plan

- [x] `go build ./internal/mail/` — clean
- [x] `go vet ./internal/mail/` — clean
- [x] `go test ./internal/mail/` — all tests pass
- [ ] Verify dog dispatch works when cfutons_mobile database is inaccessible
- [ ] Verify mail delivery to agents in healthy rigs is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)