### PR TITLE
fix: skip zombie detection for done/nuked polecats (#2795)

### DIFF
--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1310,6 +1310,15 @@ func detectZombieDeadSession(bd *BdCli, workDir, townRoot, rigName, polecatName,
 		return ZombieResult{}, false
 	}
 
+	// GH#2795: A "done" or "nuked" polecat with a dead session has completed
+	// or been intentionally stopped. The dead session is expected — the hook
+	// bead may not be "closed" yet (refinery queue, manual cleanup), but the
+	// polecat is not a zombie. Without this check, isZombieState returns true
+	// on every patrol cycle (hookBead != ""), flooding the mayor inbox.
+	if typedState == beads.AgentStateDone || typedState == beads.AgentStateNuked {
+		return ZombieResult{}, false
+	}
+
 	// GH#2036: Spawning polecats have hook_bead assigned but no tmux session yet.
 	// This is expected during worktree creation and session startup. Skip zombie
 	// detection if the polecat has been spawning for less than SpawnGracePeriod.

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -657,6 +657,26 @@ func TestDetectZombie_DoneIntentRecent(t *testing.T) {
 	}
 }
 
+func TestDetectZombie_DoneOrNukedNotZombie(t *testing.T) {
+	t.Parallel()
+	// GH#2795: Polecats with agent_state=done or agent_state=nuked and a dead
+	// session should NOT be treated as zombies, even if hook_bead is still set.
+	// Without this, isZombieState returns true (hookBead != ""), and the witness
+	// floods the mayor inbox with RECOVERY_NEEDED alerts every patrol cycle.
+	for _, state := range []beads.AgentState{beads.AgentStateDone, beads.AgentStateNuked} {
+		hookBead := "gt-some-issue"
+		// isZombieState returns true because hookBead != ""
+		if !isZombieState(state, hookBead) {
+			t.Errorf("isZombieState(%q, %q) = false, want true (pre-condition)", state, hookBead)
+		}
+		// But the done/nuked check in detectZombieDeadSession should skip these.
+		// Verify the states are terminal (not active).
+		if state.IsActive() {
+			t.Errorf("state %q should not be active", state)
+		}
+	}
+}
+
 func TestDetectZombie_AgentDeadInLiveSession(t *testing.T) {
 	t.Parallel()
 	// Verify the logic: live session + agent process dead → zombie


### PR DESCRIPTION
## Summary
- Adds early return in `detectZombieDeadSession` for `agent_state=done` or `agent_state=nuked` polecats
- These terminal states with dead sessions are expected — not zombies
- Without this fix, `isZombieState` returns true every patrol cycle (hookBead != ""), flooding the mayor inbox with ~6 RECOVERY_NEEDED alerts per cycle

## Root cause
`isZombieState(state, hookBead)` returns true whenever `hookBead != ""`, regardless of agent state. Done/nuked polecats keep their hook_bead set until cleanup, so every patrol cycle re-flags them as zombies and triggers restart attempts.

Fixes #2795

## Test plan
- [x] Added `TestDetectZombie_DoneOrNukedNotZombie` unit test
- [x] `go vet` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)