### PR TITLE
fix: mail router missing --flat for bd list JSON output

### DIFF
--- a/internal/mail/bd.go
+++ b/internal/mail/bd.go
@@ -62,6 +62,12 @@ func runBdCommand(ctx context.Context, args []string, workDir, beadsDir string, 
 	// serving different databases, resulting in hangs until the read timeout kills it.
 	beads.CleanStaleDoltServerPID(beadsDir)
 
+	// bd v0.59+ requires --flat for list --json to produce JSON output.
+	// Without it, bd returns human-readable tree format that fails JSON parsing.
+	// The mail package calls bd directly (not via beads.Run), so it needs its
+	// own injection. (GH#2746)
+	args = beads.InjectFlatForListJSON(args)
+
 	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Dir = workDir
 
@@ -75,6 +81,25 @@ func runBdCommand(ctx context.Context, args []string, workDir, beadsDir string, 
 	cmd.Stderr = &stderr
 
 	runErr := cmd.Run()
+
+	// If bd doesn't support --flat (< v0.59), retry without it.
+	// Same fallback pattern as beads.Run. (GH#2746)
+	if runErr != nil && strings.Contains(stderr.String(), "unknown flag: --flat") {
+		retryArgs := make([]string, 0, len(args))
+		for _, a := range args {
+			if a != "--flat" {
+				retryArgs = append(retryArgs, a)
+			}
+		}
+		stdout.Reset()
+		stderr.Reset()
+		retryCmd := exec.CommandContext(ctx, "bd", retryArgs...) //nolint:gosec // G204: bd is a trusted internal tool
+		retryCmd.Dir = workDir
+		retryCmd.Env = env
+		retryCmd.Stdout = &stdout
+		retryCmd.Stderr = &stderr
+		runErr = retryCmd.Run()
+	}
 
 	if runErr != nil {
 		return nil, &bdError{


### PR DESCRIPTION
## Summary

Fixes #2746 — `gt mail send` fails when mail router's `runBdCommand()` calls `bd list --json` without `--flat`.

- bd v0.59+ requires `--flat` for `list --json` to return JSON (without it, returns human-readable tree format)
- `beads.Run()`, `web/fetcher.go`, and `witness/handlers.go` already call `beads.InjectFlatForListJSON()` — the mail package was the only caller that didn't
- Adds `InjectFlatForListJSON` call in `runBdCommand()` plus retry-without-flat fallback for bd < v0.59

Root cause: `queryAgentsInDir()` builds args `["list", "--label=gt:agent", "--json", "--limit=0"]` and passes them to `runBdCommand()` which exec'd bd directly without flat injection.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./...` passes
- [ ] Manual: `gt mail send` resolves agent addresses correctly on bd v0.59+ (--flat injected)
- [ ] Manual: `gt mail send` still works on bd < v0.59 (retry without --flat)

🤖 Generated with [Claude Code](https://claude.com/claude-code)