### PR TITLE
fix: refinery formula checks run_tests before displaying test_command (#2603)

### DIFF
--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -87,7 +87,7 @@ resolve that placeholder with this rule:
 You MUST process steps in strict DAG order. Walk through each step sequentially,
 unless you are explicitly told to skip to a step."""
 formula = "mol-refinery-patrol"
-version = 12
+version = 13
 
 [vars]
 [vars.wisp_type]
@@ -341,7 +341,14 @@ id = "run-tests"
 title = "Run quality checks and tests"
 needs = ["process-branch"]
 description = """
+**FIRST: Check run_tests before doing anything else.**
+
 **Config: run_tests = {{run_tests}}**
+
+If run_tests = "false": **SKIP THE ENTIRE TEST SUITE (step 3 below).** You MUST
+still run quality checks (step 1) if they are configured. But do NOT run the
+test command under any circumstances when run_tests = "false".
+
 **Config: test_command = {{test_command}}**
 **Config: setup_command = {{setup_command}}**
 **Config: typecheck_command = {{typecheck_command}}**
@@ -369,9 +376,10 @@ Empty commands mean "not configured for this project" — skip silently.
 Proceed to handle-failures step. Track which specific check failed
 (setup/typecheck/lint/build) for the failure diagnosis.
 
-**3. Run the test suite:**
+**3. Run the test suite (ONLY if run_tests = "true"):**
 
-If run_tests = "false": Skip this step entirely. Proceed to handle-failures.
+If run_tests = "false": Do NOT run tests. Skip to handle-failures. This is
+non-negotiable — the rig owner explicitly disabled tests.
 
 If run_tests = "true":
 


### PR DESCRIPTION
## Summary

- Moves the `run_tests` guard to the very first line of the run-tests step description in the refinery patrol formula
- Previously the skip condition was buried as item #3, causing agents to start executing tests before reading the conditional
- Adds explicit "non-negotiable" language reinforcing that `run_tests=false` means no tests under any circumstances
- Bumps formula version to 13

Fixes #2603

## Test plan

- [ ] Deploy formula to a rig with `run_tests=false` in config.json
- [ ] Verify refinery skips test execution during patrol
- [ ] Verify quality checks (lint, typecheck, build) still run when configured

🤖 Generated with [Claude Code](https://claude.com/claude-code)