### PR TITLE
fix: add response cache to dashboard to prevent bd process storms (#2618)

### DIFF
--- a/internal/web/handler.go
+++ b/internal/web/handler.go
@@ -43,7 +43,20 @@ type ConvoyHandler struct {
 	template     *template.Template
 	fetchTimeout time.Duration
 	csrfToken    string
+
+	// Response cache: prevents cascading bd process storms when multiple
+	// browser tabs or htmx auto-refresh requests arrive faster than fetches
+	// complete. See GH#2618.
+	cacheMu    sync.Mutex
+	cacheBody  []byte
+	cacheTime  time.Time
+	cacheTTL   time.Duration
+	cacheInUse sync.Mutex // serializes concurrent fetches (only one runs at a time)
 }
+
+// defaultCacheTTL is the minimum interval between full dashboard fetches.
+// Requests arriving within this window get the cached response.
+const defaultCacheTTL = 10 * time.Second
 
 // NewConvoyHandler creates a new convoy handler with the given fetcher, fetch timeout, and CSRF token.
 func NewConvoyHandler(fetcher ConvoyFetcher, fetchTimeout time.Duration, csrfToken string) (*ConvoyHandler, error) {
@@ -57,15 +70,77 @@ func NewConvoyHandler(fetcher ConvoyFetcher, fetchTimeout time.Duration, csrfTok
 		template:     tmpl,
 		fetchTimeout: fetchTimeout,
 		csrfToken:    csrfToken,
+		cacheTTL:     defaultCacheTTL,
 	}, nil
 }
 
 // ServeHTTP handles GET / requests and renders the convoy dashboard.
+// Uses a response cache to prevent bd process storms from overlapping
+// requests (htmx auto-refresh, multiple tabs). Only one fetch cycle
+// runs at a time; concurrent requests get the cached response.
 func (h *ConvoyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	// Check for expand parameter (fullscreen a specific panel)
+	// Check for expand parameter — expanded views bypass cache since they
+	// render a different template variant.
 	expandPanel := r.URL.Query().Get("expand")
 
-	// Create a timeout context for all fetches
+	// Fast path: serve from cache if fresh and no expand param.
+	if expandPanel == "" {
+		h.cacheMu.Lock()
+		if len(h.cacheBody) > 0 && time.Since(h.cacheTime) < h.cacheTTL {
+			body := h.cacheBody
+			h.cacheMu.Unlock()
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			if _, err := w.Write(body); err != nil {
+				log.Printf("dashboard: cached response write failed: %v", err)
+			}
+			return
+		}
+		h.cacheMu.Unlock()
+	}
+
+	// Serialize fetch cycles: only one request triggers a full fetch at a time.
+	// Others wait and will likely hit the cache when this one finishes.
+	h.cacheInUse.Lock()
+	defer h.cacheInUse.Unlock()
+
+	// Double-check cache after acquiring lock (another request may have populated it).
+	if expandPanel == "" {
+		h.cacheMu.Lock()
+		if len(h.cacheBody) > 0 && time.Since(h.cacheTime) < h.cacheTTL {
+			body := h.cacheBody
+			h.cacheMu.Unlock()
+			w.Header().Set("Content-Type", "text/html; charset=utf-8")
+			if _, err := w.Write(body); err != nil {
+				log.Printf("dashboard: cached response write failed: %v", err)
+			}
+			return
+		}
+		h.cacheMu.Unlock()
+	}
+
+	body := h.fetchAndRender(r, expandPanel)
+	if body == nil {
+		http.Error(w, "Failed to render template", http.StatusInternalServerError)
+		return
+	}
+
+	// Update cache for non-expanded views
+	if expandPanel == "" {
+		h.cacheMu.Lock()
+		h.cacheBody = body
+		h.cacheTime = time.Now()
+		h.cacheMu.Unlock()
+	}
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	if _, err := w.Write(body); err != nil {
+		log.Printf("dashboard: response write failed: %v", err)
+	}
+}
+
+// fetchAndRender runs all 14 fetchers in parallel and renders the template.
+// Returns the rendered HTML bytes, or nil on template error.
+func (h *ConvoyHandler) fetchAndRender(r *http.Request, expandPanel string) []byte {
 	ctx, cancel := context.WithTimeout(r.Context(), h.fetchTimeout)
 	defer cancel()
 
@@ -245,18 +320,11 @@ func (h *ConvoyHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 
 	var buf bytes.Buffer
 	if err := h.template.ExecuteTemplate(&buf, "convoy.html", data); err != nil {
-		// Security: intentionally returns a generic error message to the client.
-		// Internal error details (err) are not exposed in the HTTP response to
-		// prevent information leakage. The error is logged server-side only.
 		log.Printf("dashboard: template execution failed: %v", err)
-		http.Error(w, "Failed to render template", http.StatusInternalServerError)
-		return
+		return nil
 	}
 
-	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	if _, err := buf.WriteTo(w); err != nil {
-		log.Printf("dashboard: response write failed: %v", err)
-	}
+	return buf.Bytes()
 }
 
 // computeSummary calculates dashboard stats and alerts from fetched data.

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -1106,6 +1106,114 @@ func TestConvoyHandler_TemplateErrorReturns500(t *testing.T) {
 	}
 }
 
+// TestConvoyHandler_CachePreventsDuplicateFetches verifies that rapid requests
+// reuse the cached response instead of spawning fresh fetches (GH#2618).
+func TestConvoyHandler_CachePreventsDuplicateFetches(t *testing.T) {
+	fetchCount := 0
+	mock := &CountingMockFetcher{
+		inner:      &MockConvoyFetcher{Convoys: []ConvoyRow{{ID: "hq-cv-cache", Title: "Cache Test", Status: "open"}}},
+		fetchCount: &fetchCount,
+	}
+
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
+	if err != nil {
+		t.Fatalf("NewConvoyHandler() error = %v", err)
+	}
+	handler.cacheTTL = 5 * time.Second // Explicit TTL for test
+
+	// First request — should trigger a fetch
+	req1 := httptest.NewRequest("GET", "/", nil)
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+
+	if w1.Code != http.StatusOK {
+		t.Fatalf("First request status = %d, want 200", w1.Code)
+	}
+	if fetchCount != 1 {
+		t.Fatalf("After first request, fetchCount = %d, want 1", fetchCount)
+	}
+
+	// Second request — should use cache (within TTL)
+	req2 := httptest.NewRequest("GET", "/", nil)
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+
+	if w2.Code != http.StatusOK {
+		t.Fatalf("Second request status = %d, want 200", w2.Code)
+	}
+	if fetchCount != 1 {
+		t.Errorf("After second request, fetchCount = %d, want 1 (should use cache)", fetchCount)
+	}
+
+	// Verify both responses contain the same content
+	if w1.Body.String() != w2.Body.String() {
+		t.Error("Cached response should match original response")
+	}
+}
+
+// TestConvoyHandler_CacheBypassOnExpand verifies that ?expand= requests bypass cache.
+func TestConvoyHandler_CacheBypassOnExpand(t *testing.T) {
+	fetchCount := 0
+	mock := &CountingMockFetcher{
+		inner:      &MockConvoyFetcher{Convoys: []ConvoyRow{{ID: "hq-cv-expand", Title: "Expand Test", Status: "open"}}},
+		fetchCount: &fetchCount,
+	}
+
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
+	if err != nil {
+		t.Fatalf("NewConvoyHandler() error = %v", err)
+	}
+	handler.cacheTTL = 5 * time.Second
+
+	// Normal request to populate cache
+	req1 := httptest.NewRequest("GET", "/", nil)
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+
+	if fetchCount != 1 {
+		t.Fatalf("After first request, fetchCount = %d, want 1", fetchCount)
+	}
+
+	// Expand request — should bypass cache
+	req2 := httptest.NewRequest("GET", "/?expand=convoys", nil)
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+
+	if fetchCount != 2 {
+		t.Errorf("Expand request fetchCount = %d, want 2 (should bypass cache)", fetchCount)
+	}
+}
+
+// CountingMockFetcher wraps a ConvoyFetcher and counts FetchConvoys calls.
+type CountingMockFetcher struct {
+	inner      ConvoyFetcher
+	fetchCount *int
+}
+
+func (m *CountingMockFetcher) FetchConvoys() ([]ConvoyRow, error) {
+	*m.fetchCount++
+	return m.inner.FetchConvoys()
+}
+func (m *CountingMockFetcher) FetchMergeQueue() ([]MergeQueueRow, error) {
+	return m.inner.FetchMergeQueue()
+}
+func (m *CountingMockFetcher) FetchWorkers() ([]WorkerRow, error)       { return m.inner.FetchWorkers() }
+func (m *CountingMockFetcher) FetchMail() ([]MailRow, error)            { return m.inner.FetchMail() }
+func (m *CountingMockFetcher) FetchRigs() ([]RigRow, error)             { return m.inner.FetchRigs() }
+func (m *CountingMockFetcher) FetchDogs() ([]DogRow, error)             { return m.inner.FetchDogs() }
+func (m *CountingMockFetcher) FetchEscalations() ([]EscalationRow, error) {
+	return m.inner.FetchEscalations()
+}
+func (m *CountingMockFetcher) FetchHealth() (*HealthRow, error)    { return m.inner.FetchHealth() }
+func (m *CountingMockFetcher) FetchQueues() ([]QueueRow, error)    { return m.inner.FetchQueues() }
+func (m *CountingMockFetcher) FetchSessions() ([]SessionRow, error) { return m.inner.FetchSessions() }
+func (m *CountingMockFetcher) FetchHooks() ([]HookRow, error)      { return m.inner.FetchHooks() }
+func (m *CountingMockFetcher) FetchMayor() (*MayorStatus, error)   { return m.inner.FetchMayor() }
+func (m *CountingMockFetcher) FetchIssues() ([]IssueRow, error)    { return m.inner.FetchIssues() }
+func (m *CountingMockFetcher) FetchActivity() ([]ActivityRow, error) {
+	return m.inner.FetchActivity()
+}
+
 func TestConvoyHandler_NonFatalErrors(t *testing.T) {
 	mock := &MockConvoyFetcherWithErrors{
 		Convoys: []ConvoyRow{


### PR DESCRIPTION
## Summary

- Adds a 10-second response cache to the dashboard `ConvoyHandler` that prevents cascading bd process storms
- Serializes fetch cycles so only one full fetch (14 concurrent bd calls) runs at a time; concurrent requests get the cached response
- Expanded panel views (`?expand=`) bypass the cache since they render different content
- Includes tests verifying cache hit behavior and expand bypass

Fixes #2618

## Root cause

Each dashboard page load spawns 14 concurrent goroutines, each running `bd` CLI commands. With htmx auto-refresh every 30s, if previous fetches haven't completed when the next refresh fires, requests stack up and bd process count explodes (60+ processes, load avg 35+ on 4-core VMs).

## How the fix works

1. **Response cache**: Rendered HTML is cached for 10 seconds. Requests within the TTL get the cached response instantly (no bd processes spawned).
2. **Fetch serialization**: A mutex ensures only one fetch cycle runs at a time. If request A is fetching, request B waits and then likely hits the cache that A populated.
3. **Double-check pattern**: After acquiring the serialization lock, the cache is re-checked to avoid redundant fetches.

## Test plan

- [x] All existing web handler tests pass
- [x] New `TestConvoyHandler_CachePreventsDuplicateFetches` verifies second request uses cache
- [x] New `TestConvoyHandler_CacheBypassOnExpand` verifies `?expand=` requests bypass cache
- [ ] Manual: open dashboard, verify data refreshes within ~10-30s, CPU stays stable

🤖 Generated with [Claude Code](https://claude.com/claude-code)