### PR TITLE
fix: filter git worktrees from agent bead identity scans (#2767)

### DIFF
--- a/internal/doctor/agent_beads_check.go
+++ b/internal/doctor/agent_beads_check.go
@@ -411,7 +411,10 @@ func (c *AgentBeadsCheck) Fix(ctx *CheckContext) error {
 	return errors.Join(errs...)
 }
 
-// listCrewWorkers returns the names of all crew workers in a rig.
+// listCrewWorkers returns the names of canonical crew workers in a rig.
+// Filters out git worktrees and other non-identity directories that may
+// exist under <rig>/crew/ (e.g., fix branches, cross-rig worktrees).
+// See GH#2767.
 func listCrewWorkers(townRoot, rigName string) []string {
 	crewDir := filepath.Join(townRoot, rigName, "crew")
 	entries, err := os.ReadDir(crewDir)
@@ -421,9 +424,18 @@ func listCrewWorkers(townRoot, rigName string) []string {
 
 	var workers []string
 	for _, entry := range entries {
-		if entry.IsDir() && !strings.HasPrefix(entry.Name(), ".") {
-			workers = append(workers, entry.Name())
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
 		}
+		// Git worktrees have a .git FILE (not directory) that contains
+		// "gitdir: /path/to/main/.git/worktrees/<name>". Canonical crew
+		// workers have a .git DIRECTORY (they are the main checkout).
+		// Skip directories where .git is a file — they're worktrees.
+		dotGit := filepath.Join(crewDir, entry.Name(), ".git")
+		if info, err := os.Lstat(dotGit); err == nil && !info.IsDir() {
+			continue // .git is a file → this is a worktree, not a crew identity
+		}
+		workers = append(workers, entry.Name())
 	}
 	return workers
 }
@@ -454,7 +466,8 @@ func verifyLabelAdded(workDir, beadID, label string) bool {
 	return strings.Contains(string(output), "1")
 }
 
-// listPolecats returns the names of polecat directories in a rig.
+// listPolecats returns the names of canonical polecat directories in a rig.
+// Filters out git worktrees (same logic as listCrewWorkers). See GH#2767.
 func listPolecats(townRoot, rigName string) []string {
 	polecatDir := filepath.Join(townRoot, rigName, "polecats")
 	entries, err := os.ReadDir(polecatDir)
@@ -464,9 +477,14 @@ func listPolecats(townRoot, rigName string) []string {
 
 	var polecats []string
 	for _, entry := range entries {
-		if entry.IsDir() && !strings.HasPrefix(entry.Name(), ".") {
-			polecats = append(polecats, entry.Name())
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
 		}
+		dotGit := filepath.Join(polecatDir, entry.Name(), ".git")
+		if info, err := os.Lstat(dotGit); err == nil && !info.IsDir() {
+			continue // worktree — skip
+		}
+		polecats = append(polecats, entry.Name())
 	}
 	return polecats
 }

--- a/internal/doctor/agent_beads_check_test.go
+++ b/internal/doctor/agent_beads_check_test.go
@@ -100,3 +100,87 @@ func TestAgentBeadsExistCheck_ExpectedIDs(t *testing.T) {
 
 	t.Logf("Result: status=%v, message=%s, details=%v", result.Status, result.Message, result.Details)
 }
+
+// TestListCrewWorkers_FiltersWorktrees verifies that listCrewWorkers skips
+// git worktrees (directories where .git is a file) and only returns canonical
+// crew workers (where .git is a directory). This is the fix for GH#2767.
+func TestListCrewWorkers_FiltersWorktrees(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "myrig"
+	crewDir := filepath.Join(tmpDir, rigName, "crew")
+
+	// Create a canonical crew worker: .git is a directory
+	canonicalDir := filepath.Join(crewDir, "alice")
+	if err := os.MkdirAll(filepath.Join(canonicalDir, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a worktree: .git is a file (contains gitdir pointer)
+	worktreeDir := filepath.Join(crewDir, "alice-worktree")
+	if err := os.MkdirAll(worktreeDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(worktreeDir, ".git"),
+		[]byte("gitdir: /path/to/main/.git/worktrees/alice-worktree\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a second canonical worker
+	bobDir := filepath.Join(crewDir, "bob")
+	if err := os.MkdirAll(filepath.Join(bobDir, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a directory without .git at all (should be included — not a worktree)
+	plainDir := filepath.Join(crewDir, "charlie")
+	if err := os.MkdirAll(plainDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	workers := listCrewWorkers(tmpDir, rigName)
+
+	// Should include alice, bob, charlie but NOT alice-worktree
+	expected := map[string]bool{"alice": false, "bob": false, "charlie": false}
+	for _, w := range workers {
+		if w == "alice-worktree" {
+			t.Errorf("listCrewWorkers should skip worktree 'alice-worktree', got: %v", workers)
+		}
+		if _, ok := expected[w]; ok {
+			expected[w] = true
+		}
+	}
+	for name, found := range expected {
+		if !found {
+			t.Errorf("listCrewWorkers should include canonical worker %q, got: %v", name, workers)
+		}
+	}
+}
+
+// TestListPolecats_FiltersWorktrees verifies that listPolecats skips
+// git worktrees, same as listCrewWorkers. See GH#2767.
+func TestListPolecats_FiltersWorktrees(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "myrig"
+	polecatDir := filepath.Join(tmpDir, rigName, "polecats")
+
+	// Canonical polecat
+	if err := os.MkdirAll(filepath.Join(polecatDir, "scout", ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Worktree polecat (.git is a file)
+	wtDir := filepath.Join(polecatDir, "scout-wt")
+	if err := os.MkdirAll(wtDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(wtDir, ".git"),
+		[]byte("gitdir: /path/to/main/.git/worktrees/scout-wt\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	polecats := listPolecats(tmpDir, rigName)
+
+	if len(polecats) != 1 || polecats[0] != "scout" {
+		t.Errorf("listPolecats should return only [scout], got: %v", polecats)
+	}
+}


### PR DESCRIPTION
## Summary
- `listCrewWorkers` and `listPolecats` in the doctor check treated all subdirectories under `crew/` and `polecats/` as agent identities
- Git worktrees (where `.git` is a file pointing to the main repo, not a directory) were counted as phantom agents, causing `gt doctor` to report missing beads for non-existent workers
- Fix: check `.git` type via `os.Lstat` — if it's a file, skip the directory (it's a worktree, not a canonical checkout)

## Test plan
- [x] Added `TestListCrewWorkers_FiltersWorktrees` — creates canonical workers (`.git` dir) and worktree (`.git` file), verifies only canonical ones are returned
- [x] Added `TestListPolecats_FiltersWorktrees` — same pattern for polecats
- [x] Existing doctor tests pass
- [x] `go test ./internal/doctor/` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)