### PR TITLE
fix: disable dolt_transaction_commit to prevent read-only commit storm (#2685)

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1220,7 +1220,7 @@ listener:
 data_dir: "%s"
 
 behavior:
-  dolt_transaction_commit: true
+  dolt_transaction_commit: false
   auto_gc_behavior:
     enable: true
     archive_level: 1


### PR DESCRIPTION
## Summary
- Changes `dolt_transaction_commit` from `true` to `false` in the Dolt server config template
- Prevents 100k+ "nothing to commit" warnings and 700k+ connections that crash Dolt under multi-agent workloads
- `bd` already does explicit COMMIT on writes, making this setting unnecessary

Fixes #2685

## Test plan
- [x] `go vet` passes
- [ ] CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)