### PR TITLE
fix: skip crash detection for done/nuked polecats (#2795)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1974,6 +1974,18 @@ func (d *Daemon) checkPolecatHealth(rigName, polecatName string) {
 		}
 	}
 
+	// Terminal state guard: skip polecats that have completed or been nuked (GH#2795).
+	// A polecat in agent_state=done or agent_state=nuked has shut down intentionally.
+	// The session being dead is expected — the daemon should NOT fire CRASHED_POLECAT.
+	// Without this, every heartbeat cycle floods the witness with duplicate
+	// RECOVERY_NEEDED alerts for completed/nuked polecats.
+	agentState := beads.AgentState(info.State)
+	if agentState == beads.AgentStateDone || agentState == beads.AgentStateNuked {
+		d.logger.Printf("Skipping crash detection for %s/%s: agent_state=%s (session shutdown expected)",
+			rigName, polecatName, info.State)
+		return
+	}
+
 	// TOCTOU guard: re-verify session is still dead before restarting.
 	// Between the initial check and now, the session may have been restarted
 	// by another heartbeat cycle, witness, or the polecat itself.

--- a/internal/daemon/polecat_health_test.go
+++ b/internal/daemon/polecat_health_test.go
@@ -291,3 +291,70 @@ func TestCheckPolecatHealth_NotifiesWitnessOnCrash(t *testing.T) {
 		t.Errorf("expected witness address myr/witness, got: %q", invocations)
 	}
 }
+
+// TestCheckPolecatHealth_SkipsDonePolecat verifies that checkPolecatHealth does
+// NOT fire CRASHED_POLECAT when the agent_state is "done". This is the fix for
+// the duplicate RECOVERY_NEEDED flood (GH#2795): polecats that completed
+// normally should not trigger crash alerts just because the session is dead.
+func TestCheckPolecatHealth_SkipsDonePolecat(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mocks for tmux and bd")
+	}
+	binDir := t.TempDir()
+	writeFakeTestTmux(t, binDir)
+	recentTime := time.Now().UTC().Format(time.RFC3339)
+	bdPath := writeFakeTestBD(t, binDir, "done", "done", "gt-xyz", recentTime)
+
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	var logBuf strings.Builder
+	d := &Daemon{
+		config: &Config{TownRoot: t.TempDir()},
+		logger: log.New(&logBuf, "", 0),
+		tmux:   tmux.NewTmux(),
+		bdPath: bdPath,
+	}
+
+	d.checkPolecatHealth("myr", "mycat")
+
+	got := logBuf.String()
+	if !strings.Contains(got, "agent_state=done") {
+		t.Errorf("expected log to mention agent_state=done, got: %q", got)
+	}
+	if strings.Contains(got, "CRASH DETECTED") {
+		t.Errorf("done polecat must not trigger CRASH DETECTED, got: %q", got)
+	}
+}
+
+// TestCheckPolecatHealth_SkipsNukedPolecat verifies that checkPolecatHealth
+// does NOT fire CRASHED_POLECAT when the agent_state is "nuked". Polecats
+// killed with `gt polecat nuke --force` are intentionally stopped (GH#2795).
+func TestCheckPolecatHealth_SkipsNukedPolecat(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mocks for tmux and bd")
+	}
+	binDir := t.TempDir()
+	writeFakeTestTmux(t, binDir)
+	recentTime := time.Now().UTC().Format(time.RFC3339)
+	bdPath := writeFakeTestBD(t, binDir, "nuked", "nuked", "gt-xyz", recentTime)
+
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	var logBuf strings.Builder
+	d := &Daemon{
+		config: &Config{TownRoot: t.TempDir()},
+		logger: log.New(&logBuf, "", 0),
+		tmux:   tmux.NewTmux(),
+		bdPath: bdPath,
+	}
+
+	d.checkPolecatHealth("myr", "mycat")
+
+	got := logBuf.String()
+	if !strings.Contains(got, "agent_state=nuked") {
+		t.Errorf("expected log to mention agent_state=nuked, got: %q", got)
+	}
+	if strings.Contains(got, "CRASH DETECTED") {
+		t.Errorf("nuked polecat must not trigger CRASH DETECTED, got: %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Daemon heartbeat fired `CRASHED_POLECAT` for polecats with `agent_state=done` or `agent_state=nuked`, flooding the witness/mayor with duplicate `RECOVERY_NEEDED` alerts every patrol cycle (~30s)
- Added terminal state guard in `checkPolecatHealth`: if `agent_state` is `done` or `nuked`, the dead session is expected — skip crash detection
- The existing `isBeadClosed` guard (hook_bead check) doesn't always catch this: the hook_bead may not be closed yet due to race conditions, or the lookup may fail

## Test plan
- [x] Added `TestCheckPolecatHealth_SkipsDonePolecat` — verifies done polecats don't trigger crash alerts
- [x] Added `TestCheckPolecatHealth_SkipsNukedPolecat` — verifies nuked polecats don't trigger crash alerts
- [x] `go build ./internal/daemon/` — clean
- [x] `go vet ./internal/daemon/` — clean
- [ ] Existing polecat health tests pass (require Docker for TestMain)

🤖 Generated with [Claude Code](https://claude.com/claude-code)