### PR TITLE
fix: set cmd.Dir on all dolt sql invocations to prevent stray .doltcfg (#2537)

### DIFF
--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -252,9 +252,11 @@ func (m *DoltServerManager) buildDoltSQLCmd(ctx context.Context, args ...string)
 	fullArgs = append(fullArgs, args...)
 	cmd := exec.CommandContext(ctx, "dolt", fullArgs...)
 
-	if !m.isRemote() {
-		cmd.Dir = m.config.DataDir
-	}
+	// Always set cmd.Dir to DataDir — even for remote connections (GH#2537).
+	// Without this, dolt auto-creates .doltcfg/privileges.db in $CWD,
+	// which accumulates stray privilege files that cause "multiple
+	// .doltcfg directories detected" or "Access denied" errors.
+	cmd.Dir = m.config.DataDir
 
 	if m.isRemote() && m.config.Password != "" {
 		cmd.Env = append(os.Environ(), "DOLT_CLI_PASSWORD="+m.config.Password)

--- a/internal/daemon/jsonl_git_backup.go
+++ b/internal/daemon/jsonl_git_backup.go
@@ -306,8 +306,9 @@ func (d *Daemon) exportTableToJsonl(table, query, dir, dataDir string) (int, err
 			"sql", "-r", "json", "-q", query)
 	} else {
 		cmd = exec.CommandContext(ctx, "dolt", "sql", "-r", "json", "-q", query)
-		cmd.Dir = dataDir
 	}
+	// Always set cmd.Dir to prevent stray .doltcfg/ creation (GH#2537).
+	cmd.Dir = dataDir
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -381,9 +381,9 @@ func buildDoltSQLCmd(ctx context.Context, config *Config, args ...string) *exec.
 
 	cmd := exec.CommandContext(ctx, "dolt", fullArgs...)
 
-	if !config.IsRemote() {
-		cmd.Dir = config.DataDir
-	}
+	// Always set cmd.Dir to DataDir — even for remote connections (GH#2537).
+	// Without this, dolt auto-creates .doltcfg/privileges.db in $CWD.
+	cmd.Dir = config.DataDir
 
 	if config.IsRemote() && config.Password != "" {
 		cmd.Env = append(os.Environ(), "DOLT_CLI_PASSWORD="+config.Password)
@@ -3042,6 +3042,9 @@ func GetActiveConnectionCount(townRoot string) (int, error) {
 		"-q", "SELECT COUNT(*) AS cnt FROM information_schema.PROCESSLIST",
 	}
 	cmd := exec.CommandContext(ctx, "dolt", fullArgs...)
+	// Run from the data dir to prevent dolt from creating stray .doltcfg/
+	// in the process CWD (GH#2537).
+	cmd.Dir = config.DataDir
 	// Always set DOLT_CLI_PASSWORD to prevent interactive password prompt.
 	// When empty, dolt connects without a password (which is the default for local servers).
 	cmd.Env = append(os.Environ(), "DOLT_CLI_PASSWORD="+config.Password)


### PR DESCRIPTION
## Summary
- Three functions ran `dolt sql` without setting `cmd.Dir` for remote connections, causing dolt to auto-create `.doltcfg/privileges.db` in the process's CWD
- Multiple stray `.doltcfg` directories cause "multiple .doltcfg directories detected" or "Access denied" errors
- Fixed `DoltServerManager.buildDoltSQLCmd` (daemon/dolt.go), `buildDoltSQLCmd` (doltserver.go), `GetActiveConnectionCount` (doltserver.go), and the jsonl backup query to always set `cmd.Dir` to the data directory

## Test plan
- [x] `go build ./internal/daemon/ ./internal/doltserver/` — clean
- [x] `go vet ./internal/daemon/ ./internal/doltserver/` — clean
- [ ] Verify no stray `.doltcfg/` created after daemon health checks with remote Dolt server

🤖 Generated with [Claude Code](https://claude.com/claude-code)