### PR TITLE
fix: daemon restart uses resolved agent instead of hardcoded claude (#2417)

### DIFF
--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -472,9 +472,14 @@ func (d *Daemon) getStartCommand(roleConfig *beads.RoleConfig, parsed *ParsedIde
 			rigPath = filepath.Join(d.config.TownRoot, parsed.RigName)
 		}
 		rc := config.ResolveRoleAgentConfig(parsed.RoleType, d.config.TownRoot, rigPath)
-		if !config.IsResolvedAgentClaude(rc) || !isBuiltinClaudeStartCommand(roleConfig.StartCommand) {
-			// Non-Claude agent OR custom start_command: use TOML pattern
-			// with template expansion.
+		if !config.IsResolvedAgentClaude(rc) {
+			// Non-Claude agent: skip TOML start_command entirely (GH#2417).
+			// Built-in role TOMLs hardcode "exec claude ..." which is wrong
+			// for non-Claude agents. Fall through to BuildStartupCommandFromConfig
+			// which uses the resolved agent's command and args.
+		} else if !isBuiltinClaudeStartCommand(roleConfig.StartCommand) {
+			// Custom (non-builtin) start_command with Claude agent: use TOML
+			// pattern with template expansion.
 			cmd := beads.ExpandRolePattern(roleConfig.StartCommand, d.config.TownRoot, parsed.RigName, parsed.AgentName, parsed.RoleType, session.PrefixFor(parsed.RigName))
 			if strings.HasPrefix(cmd, "exec ") {
 				cmd = "exec env -u CLAUDECODE NODE_OPTIONS='' " + cmd[len("exec "):]


### PR DESCRIPTION
## Summary
- `getStartCommand()` used TOML's hardcoded `start_command` ("exec claude ...") even when the resolved agent was non-Claude (e.g., wen, codex, copilot)
- The condition `!IsResolvedAgentClaude(rc) || !isBuiltinClaudeStartCommand()` entered the TOML expansion branch for non-Claude agents, which still output "exec claude" from the TOML template
- Fix: split the condition — non-Claude agents now skip the TOML start_command entirely and fall through to `BuildStartupCommandFromConfig`, which uses the resolved agent's command and args

## Code flow after fix
```
Daemon restart (non-Claude agent configured):
  getStartCommand()
  → roleConfig.StartCommand = "exec claude ..." (from TOML)
  → ResolveRoleAgentConfig() → resolved to "wen"
  → !IsResolvedAgentClaude → skip TOML, fall through
  → BuildStartupCommandFromConfig(runtimeConfig)
  → uses resolved "wen" command ✅
```

## Test plan
- [x] `go build ./internal/daemon/` — clean
- [x] `go vet ./internal/daemon/` — clean
- [ ] Configure `default_agent: wen`, kill a witness, verify daemon restarts with wen (not claude)

🤖 Generated with [Claude Code](https://claude.com/claude-code)