### PR TITLE
fix: skip VerifyPersistence test on Windows (#2831)

### DIFF
--- a/internal/beads/beads_types_test.go
+++ b/internal/beads/beads_types_test.go
@@ -359,6 +359,9 @@ func TestEnsureCustomTypes(t *testing.T) {
 
 func TestEnsureCustomTypes_VerifyPersistence(t *testing.T) {
 	t.Run("sentinel not written when db verify fails", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("test uses Unix shell script mock for bd")
+		}
 		// Install a mock bd that succeeds on "config set" but returns empty
 		// on "config get types.custom" — simulating a silent write failure.
 		binDir := t.TempDir()


### PR DESCRIPTION
## Summary
- `TestEnsureCustomTypes_VerifyPersistence/sentinel_not_written_when_db_verify_fails` fails on every Windows CI run because it creates an inline `#!/bin/sh` mock script
- Unlike the shared `installMockBDRecorder` helper (which has Windows PowerShell support), this test's inline script has no Windows equivalent
- Add `runtime.GOOS == "windows"` skip to unblock Windows CI on main

## Test plan
- [x] `go build ./internal/beads/` — clean
- [ ] Windows CI passes on main after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)