### PR TITLE
fix: prevent daemon restart during gt down shutdown

### DIFF
--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -30,6 +30,10 @@ const (
 	shutdownLockFile    = "daemon/shutdown.lock"
 	shutdownLockTimeout = 5 * time.Second
 
+	// ShutdownSentinel is a file written during gt down to prevent agents from
+	// restarting the daemon mid-shutdown. Checked by ensureDaemon.
+	ShutdownSentinel = "daemon/shutting-down"
+
 	// defaultDownOrphanGraceSecs is the grace period for orphan cleanup during gt down.
 	// Short because gt down is meant to be quick - processes already had SIGTERM via
 	// KillSessionWithProcesses.
@@ -111,6 +115,12 @@ func runDown(cmd *cobra.Command, args []string) error {
 			// providing no mutual exclusion against a process that creates a
 			// new file at the same path.
 		}()
+
+		// GH#2656: Write shutdown sentinel to prevent agents from restarting the
+		// daemon while we're tearing down. ensureDaemon checks for this file.
+		sentinelPath := filepath.Join(townRoot, ShutdownSentinel)
+		_ = os.WriteFile(sentinelPath, []byte(fmt.Sprintf("%d", os.Getpid())), 0644)
+		defer os.Remove(sentinelPath)
 
 		// Prevent tmux server from exiting when all sessions are killed.
 		// By default, tmux exits when there are no sessions (exit-empty on).

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -477,6 +477,12 @@ func disableCurrentAgentDND(townRoot string) (bool, error) {
 
 // ensureDaemon starts the daemon if not running.
 func ensureDaemon(townRoot string) error {
+	// GH#2656: Don't restart the daemon while gt down is running.
+	sentinelPath := filepath.Join(townRoot, ShutdownSentinel)
+	if _, err := os.Stat(sentinelPath); err == nil {
+		return fmt.Errorf("shutdown in progress (sentinel exists: %s)", sentinelPath)
+	}
+
 	running, _, err := daemon.IsRunning(townRoot)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Writes a shutdown sentinel file during `gt down` to prevent daemon restart
- `ensureDaemon` checks for the sentinel and refuses to start while shutdown is in progress
- Sentinel is cleaned up when `gt down` completes

## Problem

`gt down` stops the daemon (Phase 4) but agents still running (polecats, boot dog) can call `ensureDaemon` and restart it within 1 second. The daemon log shows it restarting immediately after being killed.

## Fix

A sentinel file (`daemon/shutting-down`) is written at the start of `gt down` (after acquiring the shutdown lock) and removed via `defer` when shutdown completes. `ensureDaemon` in `up.go` checks for this file before starting the daemon.

## Test plan

- [x] `go build ./internal/cmd/...` passes
- [ ] CI

Fixes #2656