### PR TITLE
fix: move run_tests skip check to top of formula step

### DIFF
--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -341,12 +341,16 @@ id = "run-tests"
 title = "Run quality checks and tests"
 needs = ["process-branch"]
 description = """
+**⚠ FIRST CHECK: If run_tests = "false", skip this ENTIRE step. Proceed directly to the next step. Do not run any quality checks or tests.**
+
 **Config: run_tests = {{run_tests}}**
 **Config: test_command = {{test_command}}**
 **Config: setup_command = {{setup_command}}**
 **Config: typecheck_command = {{typecheck_command}}**
 **Config: lint_command = {{lint_command}}**
 **Config: build_command = {{build_command}}**
+
+If run_tests is "false": STOP HERE. Skip everything below and proceed to the next step.
 
 **1. Run quality checks (skip any that are not configured):**
 
@@ -370,10 +374,6 @@ Proceed to handle-failures step. Track which specific check failed
 (setup/typecheck/lint/build) for the failure diagnosis.
 
 **3. Run the test suite:**
-
-If run_tests = "false": Skip this step entirely. Proceed to handle-failures.
-
-If run_tests = "true":
 
 ```bash
 {{test_command}}            # Run tests (configured per-rig)


### PR DESCRIPTION
The run_tests=false condition was item #3 in the refinery patrol formula, after the test_command was displayed. Agents read the command and execute before reaching the skip. Moved to the very first line with strong emphasis. Fixes #2603