### PR TITLE
fix: set cmd.Dir on all dolt CLI invocations to prevent stray .doltcfg (#2537)

### DIFF
--- a/internal/cmd/dolt.go
+++ b/internal/cmd/dolt.go
@@ -766,6 +766,8 @@ func runDoltSQL(cmd *cobra.Command, args []string) error {
 			"sql",
 		}
 		sqlCmd := exec.Command("dolt", sqlArgs...)
+		// GH#2537: Set cmd.Dir to prevent stray .doltcfg/privileges.db in CWD.
+		sqlCmd.Dir = config.DataDir
 		if config.Password != "" {
 			sqlCmd.Env = append(os.Environ(), "DOLT_CLI_PASSWORD="+config.Password)
 		}

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -381,9 +381,10 @@ func buildDoltSQLCmd(ctx context.Context, config *Config, args ...string) *exec.
 
 	cmd := exec.CommandContext(ctx, "dolt", fullArgs...)
 
-	if !config.IsRemote() {
-		cmd.Dir = config.DataDir
-	}
+	// GH#2537: Always set cmd.Dir to prevent dolt from creating stray
+	// .doltcfg/privileges.db files in the caller's CWD. Even TCP client
+	// connections can trigger .doltcfg creation if CWD is uncontrolled.
+	cmd.Dir = config.DataDir
 
 	if config.IsRemote() && config.Password != "" {
 		cmd.Env = append(os.Environ(), "DOLT_CLI_PASSWORD="+config.Password)
@@ -3042,6 +3043,10 @@ func GetActiveConnectionCount(townRoot string) (int, error) {
 		"-q", "SELECT COUNT(*) AS cnt FROM information_schema.PROCESSLIST",
 	}
 	cmd := exec.CommandContext(ctx, "dolt", fullArgs...)
+	// GH#2537: Set cmd.Dir to the server's data directory to prevent dolt from
+	// creating stray .doltcfg/privileges.db files in the caller's CWD. Even in
+	// TCP client mode, dolt may auto-create .doltcfg/ in the working directory.
+	cmd.Dir = config.DataDir
 	// Always set DOLT_CLI_PASSWORD to prevent interactive password prompt.
 	// When empty, dolt connects without a password (which is the default for local servers).
 	cmd.Env = append(os.Environ(), "DOLT_CLI_PASSWORD="+config.Password)


### PR DESCRIPTION
## Summary
- Set `cmd.Dir = config.DataDir` on all dolt CLI invocations that were missing it
- Prevents dolt from creating stray `.doltcfg/privileges.db` files in the caller's CWD
- Fixes three locations: `GetActiveConnectionCount()`, `buildDoltSQLCmd()` remote path, interactive `dolt sql` TCP shell

## Context
When dolt runs without `cmd.Dir`, it creates `.doltcfg/privileges.db` in `$CWD`. Multiple `.doltcfg/` directories cause either "multiple .doltcfg directories detected" (embedded mode) or "Access denied for user '__dolt_local_user__'" (server mode), leading to full Dolt outages.

Fixes #2537

## Test plan
- [ ] Verify `gt dolt sql` from a non-data-dir CWD does not create `.doltcfg/` in CWD
- [ ] Verify `GetActiveConnectionCount` works correctly with `cmd.Dir` set
- [ ] Check no `.doltcfg/` dirs appear outside of `.dolt-data/` after normal operations

🤖 Generated with [Claude Code](https://claude.com/claude-code)