### PR TITLE
fix: clean dirty worktree before polecat reuse (#2536)

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1037,6 +1037,13 @@ func (g *Git) ResetHard(ref string) error {
 	return err
 }
 
+// CleanForce removes untracked files and directories from the working tree.
+// Excludes .runtime/ to preserve agent lock files and session state.
+func (g *Git) CleanForce() error {
+	_, err := g.run("clean", "-fd", "--exclude=.runtime")
+	return err
+}
+
 // Rev returns the commit hash for the given ref.
 func (g *Git) Rev(ref string) (string, error) {
 	return g.run("rev-parse", ref)

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1559,16 +1559,19 @@ func (m *Manager) ReuseIdlePolecat(name string, opts AddOptions) (*Polecat, erro
 		return nil, fmt.Errorf("start point %s not found — fall back to full repair", startPoint)
 	}
 
-	// Clean worktree state before branch switch — the worktree may have stale
-	// state from a previous dog/pool dispatch (uncommitted changes, detached HEAD,
-	// or checked out on an old dog/alpha-* branch).
-	_ = polecatGit.ResetHard("HEAD")
+	// GH#2536: Clean worktree state before branch switch — the worktree may have
+	// stale state from a previous dog/pool dispatch (uncommitted changes, untracked
+	// files, detached HEAD, or checked out on an old dog/alpha-* branch).
+	// Reset to the start point directly (not HEAD) to avoid "local changes would
+	// be overwritten" errors when the start point has different file content.
+	_ = polecatGit.ResetHard(startPoint)
+	_ = polecatGit.CleanForce()
 
 	// Create fresh branch from start point (branch-only, no worktree add/remove)
 	branchName := m.buildBranchName(name, opts.HookBead)
 	if err := polecatGit.CheckoutNewBranch(branchName, startPoint); err != nil {
-		// checkout -b fails if we're in detached HEAD or branch already exists.
-		// Fall back to: create branch separately, then checkout.
+		// checkout -b fails if branch already exists or other edge case.
+		// Fall back to: checkout start point, then create branch.
 		_ = polecatGit.Checkout(startPoint)
 		if err2 := polecatGit.CheckoutNewBranch(branchName, startPoint); err2 != nil {
 			return nil, fmt.Errorf("creating branch %s from %s (retry after cleanup): %w", branchName, startPoint, err2)


### PR DESCRIPTION
## Summary
- Reset worktree to start point (not HEAD) before branch creation during polecat reuse
- Add `git clean -fd` to remove untracked files from previous dispatch
- Adds `Git.CleanForce()` method (excludes `.runtime/` to preserve agent locks)

## Context
When a polecat is reused (idle → working), `git checkout -b newbranch origin/main` fails if the worktree has uncommitted changes from the previous dispatch. The old code reset to HEAD first, but the checkout to a different start point still sees dirty files. Resetting directly to the start point + cleaning untracked files eliminates the "local changes would be overwritten" error.

Fixes #2536

## Test plan
- [ ] Dispatch a polecat, let it make uncommitted changes, mark idle
- [ ] Re-dispatch the same polecat to a different branch
- [ ] Verify branch-only reuse succeeds without falling back to full repair

🤖 Generated with [Claude Code](https://claude.com/claude-code)