### PR TITLE
fix: remove legacy 'gt' database from reaper fallback list (#2385)

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -22,7 +22,11 @@ import (
 var validDBName = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
 // DefaultDatabases is the static fallback list of known production databases.
-var DefaultDatabases = []string{"hq", "bd", "gt"}
+// Used only when SHOW DATABASES fails (server unreachable).
+// GH#2385: Removed legacy "gt" name — modern towns use "hq" (town beads) and
+// rig-specific names. The "gt" database no longer exists in most installations
+// and its presence in the fallback caused false "database not found" errors.
+var DefaultDatabases = []string{"hq", "bd"}
 
 // testPollutionPrefixes are database name prefixes created by tests.
 var testPollutionPrefixes = []string{"testdb_", "beads_t", "beads_pt", "doctest_"}


### PR DESCRIPTION
## Summary
- Remove legacy `"gt"` from `DefaultDatabases` fallback list
- Modern towns use `"hq"` (town beads) and rig-specific names
- Eliminates false "database not found" errors when SHOW DATABASES fails

## Context
The reaper's `DiscoverDatabases()` uses live `SHOW DATABASES` but falls back to a static list when the server is unreachable. The static list included `"gt"` — a legacy database name that no longer exists in most installations. This caused false alarms in overseer reaper reports.

Fixes #2385

## Test plan
- [x] `go test ./internal/reaper/...` passes
- [ ] `gt reaper databases --json` returns live databases (no "gt")
- [ ] Reaper scan/run no longer emits "database not found" for "gt"

🤖 Generated with [Claude Code](https://claude.com/claude-code)