### PR TITLE
fix: refinery closes task beads after successful merge (#2321)

### DIFF
--- a/internal/refinery/batch.go
+++ b/internal/refinery/batch.go
@@ -292,6 +292,8 @@ func (e *Engineer) processSingleMR(ctx context.Context, mr *MRInfo, target strin
 	if processResult.Success {
 		result.Merged = []*MRInfo{mr}
 		result.MergeCommit = processResult.MergeCommit
+		// GH#2321: Run post-merge cleanup (close beads, delete branch, nudge mayor)
+		e.HandleMRInfoSuccess(mr, processResult)
 	} else if processResult.Conflict {
 		result.Conflicts = []*MRInfo{mr}
 	} else if processResult.TestsFailed {
@@ -393,6 +395,16 @@ func (e *Engineer) fastForwardBatch(ctx context.Context, stacked []*MRInfo, targ
 
 	result.Merged = stacked
 	result.MergeCommit = tipSHA
+
+	// GH#2321: Run post-merge cleanup for each merged MR — close source beads,
+	// delete branches, nudge mayor, and check convoy completion.
+	// HandleMRInfoSuccess was previously dead code (never called), causing task
+	// beads to remain open after successful merges.
+	for _, mr := range stacked {
+		mergeResult := ProcessResult{Success: true, MergeCommit: tipSHA}
+		e.HandleMRInfoSuccess(mr, mergeResult)
+	}
+
 	return result
 }
 


### PR DESCRIPTION
## Summary
- Wire `HandleMRInfoSuccess` into `fastForwardBatch` and `processSingleMR`
- This was dead code — defined but never called from any merge path
- After merge, source beads are now closed, branches deleted, mayor nudged, convoys checked

## Root cause
`HandleMRInfoSuccess` performs all post-merge cleanup (close MR bead, close source issue, delete branch, nudge mayor, check convoy completion). It was defined in engineer.go but never called — neither `fastForwardBatch` nor `processSingleMR` invoked it after a successful merge. Task beads stayed open indefinitely after merge.

Fixes #2321

## Test plan
- [x] `go test ./internal/refinery/...` passes (34s)
- [ ] Merge a polecat branch, verify source issue is closed
- [ ] Verify mayor gets MERGED nudge after refinery merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)