### PR TITLE
fix: start Codex nudge poller without cancel hook

### DIFF
--- a/internal/nudge/poller.go
+++ b/internal/nudge/poller.go
@@ -68,11 +68,7 @@ func StartPoller(townRoot, session string) (int, error) {
 		return 0, fmt.Errorf("finding gt binary: %w", err)
 	}
 
-	cmd := exec.Command(gtBin, "nudge-poller", session)
-	cmd.Dir = townRoot
-	cmd.Stdout = nil // discard
-	cmd.Stderr = nil // discard
-	util.SetProcessGroup(cmd)
+	cmd := buildPollerCommand(gtBin, townRoot, session)
 
 	if err := cmd.Start(); err != nil {
 		return 0, fmt.Errorf("starting nudge-poller: %w", err)
@@ -91,6 +87,15 @@ func StartPoller(townRoot, session string) (int, error) {
 	_ = cmd.Process.Release()
 
 	return pid, nil
+}
+
+func buildPollerCommand(gtBin, townRoot, session string) *exec.Cmd {
+	cmd := exec.Command(gtBin, "nudge-poller", session)
+	cmd.Dir = townRoot
+	cmd.Stdout = nil // discard
+	cmd.Stderr = nil // discard
+	util.SetDetachedProcessGroup(cmd)
+	return cmd
 }
 
 // StopPoller terminates the nudge-poller for a session, if running.

--- a/internal/nudge/poller_test.go
+++ b/internal/nudge/poller_test.go
@@ -2,9 +2,12 @@ package nudge
 
 import (
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"testing"
+
+	"github.com/steveyegge/gastown/internal/util"
 )
 
 func TestPollerPidFile(t *testing.T) {
@@ -136,5 +139,38 @@ func TestPollerAlive_LiveProcess(t *testing.T) {
 	}
 	if pid != myPid {
 		t.Errorf("pollerAlive() pid = %d, want %d", pid, myPid)
+	}
+}
+
+func TestBuildPollerCommand_UsesDetachedProcessGroup(t *testing.T) {
+	townRoot := t.TempDir()
+	cmd := buildPollerCommand("/tmp/fake-gt", townRoot, "gt-gastown-crew-bear")
+
+	if got, want := cmd.Dir, townRoot; got != want {
+		t.Fatalf("cmd.Dir = %q, want %q", got, want)
+	}
+	if got, want := cmd.Path, "/tmp/fake-gt"; got != want {
+		t.Fatalf("cmd.Path = %q, want %q", got, want)
+	}
+	if len(cmd.Args) != 3 || cmd.Args[1] != "nudge-poller" || cmd.Args[2] != "gt-gastown-crew-bear" {
+		t.Fatalf("cmd.Args = %#v, want poller invocation", cmd.Args)
+	}
+	if cmd.Cancel != nil {
+		t.Fatal("buildPollerCommand() installed cmd.Cancel; detached pollers must leave it nil")
+	}
+	if cmd.Stdout != nil || cmd.Stderr != nil {
+		t.Fatal("buildPollerCommand() should discard stdout/stderr")
+	}
+	if cmd.SysProcAttr == nil {
+		t.Fatal("buildPollerCommand() did not configure SysProcAttr")
+	}
+}
+
+func TestSetProcessGroup_InstallsCancelHook(t *testing.T) {
+	cmd := exec.Command("true")
+	util.SetProcessGroup(cmd)
+
+	if cmd.Cancel == nil {
+		t.Fatal("SetProcessGroup() should install a cancel hook")
 	}
 }

--- a/internal/util/exec_unix.go
+++ b/internal/util/exec_unix.go
@@ -18,3 +18,9 @@ func SetProcessGroup(cmd *exec.Cmd) {
 		return nil
 	}
 }
+
+// SetDetachedProcessGroup configures a command to run in its own process
+// group without installing a cancellation hook.
+func SetDetachedProcessGroup(cmd *exec.Cmd) {
+	cmd.SysProcAttr = &syscall.SysProcAttr{Setpgid: true}
+}

--- a/internal/util/exec_windows.go
+++ b/internal/util/exec_windows.go
@@ -7,3 +7,6 @@ import "os/exec"
 // SetProcessGroup is a no-op on Windows.
 // Process group management is not supported on Windows.
 func SetProcessGroup(cmd *exec.Cmd) {}
+
+// SetDetachedProcessGroup is a no-op on Windows.
+func SetDetachedProcessGroup(cmd *exec.Cmd) {}


### PR DESCRIPTION
## Summary
Fix queued nudge delivery for Codex agents by starting the background `nudge-poller` without installing an `exec.Cmd.Cancel` hook.

## Root cause
`gt nudge` defaults to `wait-idle`, but Codex agents have no prompt detector, so the command intentionally degrades to queue mode. Queue mode then calls `nudge.StartPoller(...)` so queued nudges can drain into the tmux session.

That poller launch used plain `exec.Command(...)` plus `util.SetProcessGroup(...)`, which installs `cmd.Cancel`. On Go 1.25 that is invalid unless the command was created with `exec.CommandContext(...)`, so poller startup failed with:

`exec: command with a non-nil Cancel was not created with CommandContext`

The result was silent queued-nudge failure for Codex agents unless senders manually used `--mode=immediate`.

## Fix
- add a detached process-group helper that does not install `cmd.Cancel`
- use it only for the detached `nudge-poller` launch path
- keep the existing cancel-hook behavior for `CommandContext(...)` callers
- add regression coverage for the poller command construction

## Verification
- `go test ./internal/nudge ./internal/util`
- `go test ./internal/cmd -run 'TestValidModesAccepted|TestValidModeMapsMatchConstants|TestIdleWatcherExitsOnEmptyQueue|TestPostQueueIdleRecovery_SkipsDeliveryWhenDrainEmpty'`
- live smoke with the branch binary:
  - sent default `gt nudge` to active Codex session `barnaby/crew/troy`
  - confirmed queue fallback message
  - confirmed poller startup via `.runtime/nudge_poller/ba-crew-troy.pid`
  - confirmed injected message appeared in Troy's session via `gt peek`
