### PR TITLE
fix: non-Claude agents bypass hardcoded TOML start_command

### DIFF
--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -472,9 +472,9 @@ func (d *Daemon) getStartCommand(roleConfig *beads.RoleConfig, parsed *ParsedIde
 			rigPath = filepath.Join(d.config.TownRoot, parsed.RigName)
 		}
 		rc := config.ResolveRoleAgentConfig(parsed.RoleType, d.config.TownRoot, rigPath)
-		if !config.IsResolvedAgentClaude(rc) || !isBuiltinClaudeStartCommand(roleConfig.StartCommand) {
-			// Non-Claude agent OR custom start_command: use TOML pattern
-			// with template expansion.
+		if config.IsResolvedAgentClaude(rc) && !isBuiltinClaudeStartCommand(roleConfig.StartCommand) {
+			// Claude agent with custom (non-built-in) start_command: use
+			// TOML pattern with template expansion.
 			cmd := beads.ExpandRolePattern(roleConfig.StartCommand, d.config.TownRoot, parsed.RigName, parsed.AgentName, parsed.RoleType, session.PrefixFor(parsed.RigName))
 			if strings.HasPrefix(cmd, "exec ") {
 				cmd = "exec env -u CLAUDECODE NODE_OPTIONS='' " + cmd[len("exec "):]
@@ -483,8 +483,9 @@ func (d *Daemon) getStartCommand(roleConfig *beads.RoleConfig, parsed *ParsedIde
 			}
 			return cmd
 		}
-		// Claude agent with built-in start_command: fall through to
-		// BuildStartupCommandFromConfig for proper model flag resolution.
+		// Non-Claude agent OR Claude with built-in start_command: fall
+		// through to BuildStartupCommandFromConfig for proper agent and
+		// model flag resolution.
 	}
 
 	rigPath := ""

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -309,17 +309,10 @@ func buildWitnessStartCommand(rigPath, rigName, townRoot, sessionName, agentOver
 		roleConfig = nil
 	}
 	if roleConfig != nil && roleConfig.StartCommand != "" {
-		// Use the TOML start_command for custom (non-Claude) commands that
-		// need template expansion (e.g., "exec run --town {town} --rig {rig}").
-		// For Claude agents, skip the TOML shortcut and fall through to
-		// BuildStartupCommandFromConfig which resolves model flags from
-		// role_agents (e.g., --model sonnet[1m]). The built-in TOML
-		// start_command ("exec claude --dangerously-skip-permissions") strips
-		// these flags, breaking per-role model selection.
 		rc := config.ResolveRoleAgentConfig("witness", townRoot, rigPath)
-		if !config.IsResolvedAgentClaude(rc) || !isBuiltinClaudeStartCommand(roleConfig.StartCommand) {
-			// Non-Claude agent OR custom start_command: use TOML pattern
-			// with template expansion.
+		if config.IsResolvedAgentClaude(rc) && !isBuiltinClaudeStartCommand(roleConfig.StartCommand) {
+			// Claude agent with custom (non-built-in) start_command: use
+			// TOML pattern with template expansion.
 			cmd := beads.ExpandRolePattern(roleConfig.StartCommand, townRoot, rigName, "", "witness", session.PrefixFor(rigName))
 			if strings.HasPrefix(cmd, "exec ") {
 				cmd = "exec env -u CLAUDECODE NODE_OPTIONS='' " + strings.TrimPrefix(cmd, "exec ")
@@ -328,8 +321,9 @@ func buildWitnessStartCommand(rigPath, rigName, townRoot, sessionName, agentOver
 			}
 			return cmd, nil
 		}
-		// Claude agent with built-in start_command: fall through to
-		// BuildStartupCommandFromConfig for proper model flag resolution.
+		// Non-Claude agent OR Claude with built-in start_command: fall
+		// through to BuildStartupCommandFromConfig for proper agent and
+		// model flag resolution.
 	}
 	initialPrompt := session.BuildStartupPrompt(session.BeaconConfig{
 		Recipient: session.BeaconRecipient("witness", "", rigName),


### PR DESCRIPTION
## Problem

When the agent is configured as `copilot` (or any non-Claude agent), witness and daemon startup still used the hardcoded TOML `start_command = "exec claude --dangerously-skip-permissions"`, causing exit status 127 when `claude` isn't installed.

## Root Cause

The condition in both `buildWitnessStartCommand()` and daemon `getStartCommand()`:

```go
```


## Fix

Flip to `&&`:

```go
```

Now only Claude agents with *custom* (non-built-in) start commands use the TOML path. Non-Claude agents and Claude with the built-in command both fall through to `BuildStartupCommandFromConfig` which correctly resolves the configured agent.

## Testing

- Existing witness tests pass
- Verified: all three rig witnesses start successfully with `[copilot]` agent after fix