### PR TITLE
fix(dolt): kill unowned port squatters on Start

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1299,6 +1299,28 @@ func Start(townRoot string) error {
 	if err != nil {
 		return fmt.Errorf("checking server status: %w", err)
 	}
+
+	// If IsRunning returns false, the port may still be held by a dolt process
+	// that doesn't match this town's ownership (e.g., a leftover from an old
+	// town setup started with different flags). IsRunning's ownership check
+	// correctly returns false, but we need to evict the squatter before we can
+	// bind the port. (fix: start-kills-unowned-port-holder)
+	if !running {
+		if squatterPID := findDoltServerOnPort(config.Port); squatterPID > 0 {
+			fmt.Fprintf(os.Stderr, "Warning: port %d held by unowned dolt process (PID %d) — killing before start\n", config.Port, squatterPID)
+			if proc, findErr := os.FindProcess(squatterPID); findErr == nil {
+				_ = proc.Signal(syscall.SIGTERM)
+				if err := waitForPortRelease(config.Port, 5*time.Second); err != nil {
+					// SIGTERM didn't work, escalate to SIGKILL
+					_ = proc.Kill()
+					if err := waitForPortRelease(config.Port, 3*time.Second); err != nil {
+						fmt.Fprintf(os.Stderr, "Warning: port %d still occupied after killing PID %d: %v\n", config.Port, squatterPID, err)
+					}
+				}
+			}
+		}
+	}
+
 	if running {
 		// If data directory doesn't exist, this is an orphaned server (e.g., user
 		// deleted ~/gt and re-ran gt install). Kill it so we can start fresh.


### PR DESCRIPTION
## Summary
- When `IsRunning()` returns false because a dolt process on the port fails ownership checks (e.g., leftover from an old town setup with different CLI flags), `Start()` now detects and kills the squatter before attempting to bind the port
- Previously the imposter-killing logic only ran when `IsRunning()` returned true, which by definition can't happen for a non-matching process — so `Start()` always failed with "port already in use"
- Uses SIGTERM with SIGKILL escalation and `waitForPortRelease` to ensure clean handoff

## Test plan
- [x] Existing `TestDoltProcessMatchesTownPaths` tests pass
- [x] Full `go build ./...` succeeds
- [ ] Manual: start a dolt server with old-style `-H/-P` flags on the configured port, then run `gt mayor attach` — should kill squatter and start cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)