### PR TITLE
fix: compactor integrity check fails on concurrent writes

### DIFF
--- a/internal/cmd/dolt_flatten.go
+++ b/internal/cmd/dolt_flatten.go
@@ -162,8 +162,12 @@ func runDoltFlatten(cmd *cobra.Command, args []string) error {
 		if !ok {
 			return fmt.Errorf("integrity FAIL: table %q missing after flatten", table)
 		}
-		if preCount != postCount {
-			return fmt.Errorf("integrity FAIL: %q pre=%d post=%d", table, preCount, postCount)
+		if postCount < preCount {
+			return fmt.Errorf("integrity FAIL: %q lost rows: pre=%d post=%d", table, preCount, postCount)
+		}
+		if postCount > preCount {
+			fmt.Printf("  %s table %q gained %d rows during flatten (concurrent write, safe)\n",
+				style.Bold.Render("⚠"), table, postCount-preCount)
 		}
 	}
 	fmt.Printf("  %s Integrity verified (%d tables match)\n", style.Bold.Render("✓"), len(preCounts))

--- a/internal/daemon/compactor_dog.go
+++ b/internal/daemon/compactor_dog.go
@@ -300,7 +300,9 @@ func (d *Daemon) compactDatabase(dbName string) error {
 	}
 	d.logger.Printf("compactor_dog: %s: committed flattened data", dbName)
 
-	// Step 6: Verify integrity — row counts must match pre-flight.
+	// Step 6: Verify integrity — row counts must not decrease (data loss).
+	// Concurrent writes may increase counts during compaction — this is safe
+	// since the flattened commit includes those rows.
 	postCounts, err := d.compactorGetRowCounts(db, dbName)
 	if err != nil {
 		return fmt.Errorf("post-compact row counts: %w", err)
@@ -311,8 +313,12 @@ func (d *Daemon) compactDatabase(dbName string) error {
 		if !ok {
 			return fmt.Errorf("integrity check: table %q missing after compaction", table)
 		}
-		if preCount != postCount {
-			return fmt.Errorf("integrity check: table %q count mismatch: pre=%d post=%d", table, preCount, postCount)
+		if postCount < preCount {
+			return fmt.Errorf("integrity check: table %q lost rows: pre=%d post=%d", table, preCount, postCount)
+		}
+		if postCount > preCount {
+			d.logger.Printf("compactor_dog: %s: table %q gained %d rows during compaction (concurrent write, safe)",
+				dbName, table, postCount-preCount)
 		}
 	}
 	d.logger.Printf("compactor_dog: %s: integrity verified (%d tables match)", dbName, len(preCounts))
@@ -467,7 +473,8 @@ func (d *Daemon) surgicalRebaseOnce(dbName string, keepRecent int) error {
 	}
 	d.logger.Printf("compactor_dog: %s: rebase executed successfully", dbName)
 
-	// Step 6: Verify integrity.
+	// Step 6: Verify integrity — row counts must not decrease (data loss).
+	// Concurrent writes may increase counts during rebase — this is safe.
 	postCounts, err := d.compactorGetRowCounts(db, dbName)
 	if err != nil {
 		d.logger.Printf("compactor_dog: %s: WARNING: could not verify row counts after rebase: %v", dbName, err)
@@ -478,9 +485,13 @@ func (d *Daemon) surgicalRebaseOnce(dbName string, keepRecent int) error {
 				d.surgicalCleanup(db, baseBranch, workBranch)
 				return fmt.Errorf("integrity: table %q missing after rebase", table)
 			}
-			if preCount != postCount {
+			if postCount < preCount {
 				d.surgicalCleanup(db, baseBranch, workBranch)
-				return fmt.Errorf("integrity: table %q count mismatch: pre=%d post=%d", table, preCount, postCount)
+				return fmt.Errorf("integrity: table %q lost rows: pre=%d post=%d", table, preCount, postCount)
+			}
+			if postCount > preCount {
+				d.logger.Printf("compactor_dog: %s: table %q gained %d rows during rebase (concurrent write, safe)",
+					dbName, table, postCount-preCount)
 			}
 		}
 		d.logger.Printf("compactor_dog: %s: integrity verified (%d tables)", dbName, len(preCounts))


### PR DESCRIPTION
## Summary
- Compactor integrity check uses strict equality (`!=`) for pre/post row counts, causing false failures when concurrent writes insert rows during the compaction window
- Changed to only fail when `postCount < preCount` (actual data loss); `postCount > preCount` logs a warning but succeeds since the new rows are safely included in the flattened commit
- Fixed in all three code paths: `compactDatabase` (flatten mode), `surgicalRebaseOnce` (surgical mode), and `gt dolt flatten` (manual CLI)

## Root cause
Between recording pre-flight row counts and verifying post-compaction counts, other processes (daemon dogs, agents) can insert rows. The events table is especially susceptible since every daemon action creates events. A single inserted row (pre=4403, post=4404) causes the compactor to report failure even though no data was lost.

## Test plan
- [ ] `go build ./...` passes
- [ ] Live verification: compaction succeeded with concurrent daemon activity (the compacted HQ database went from 449 to 122 commits, but the integrity check flagged a +1 row in events)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>