### PR TITLE
fix: filter refinery MR listings by rig (cross-rig contamination)

### DIFF
--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -1348,6 +1348,11 @@ func (e *Engineer) ListReadyMRs() ([]*MRInfo, error) {
 			continue // Skip issues without MR fields
 		}
 
+		// Filter by rig — wisps are shared across all rigs (GH#2718).
+		if fields.Rig != "" && !strings.EqualFold(fields.Rig, e.rig.Name) {
+			continue
+		}
+
 		// Skip if already assigned, unless claim is stale (allows re-claim after crash).
 		// NOTE: Only one refinery runs per rig (enforced by ErrAlreadyRunning in
 		// manager.go), so concurrent re-claim race conditions are not a concern.
@@ -1404,6 +1409,11 @@ func (e *Engineer) ListBlockedMRs() ([]*MRInfo, error) {
 			continue
 		}
 
+		// Filter by rig — wisps are shared across all rigs (GH#2718).
+		if fields.Rig != "" && !strings.EqualFold(fields.Rig, e.rig.Name) {
+			continue
+		}
+
 		mr := issueToMRInfo(issue, fields)
 		mr.BlockedBy = blockedBy
 		mrs = append(mrs, mr)
@@ -1438,6 +1448,11 @@ func (e *Engineer) ListAllOpenMRs() ([]*MRInfo, error) {
 			continue
 		}
 
+		// Filter by rig — wisps are shared across all rigs (GH#2718).
+		if fields.Rig != "" && !strings.EqualFold(fields.Rig, e.rig.Name) {
+			continue
+		}
+
 		mr := issueToMRInfo(issue, fields)
 
 		// Check branch existence (local + remote tracking refs)
@@ -1463,7 +1478,17 @@ func (e *Engineer) ListQueueAnomalies(now time.Time) ([]*MRAnomaly, error) {
 		return nil, fmt.Errorf("querying beads for merge-requests: %w", err)
 	}
 
-	return detectQueueAnomalies(issues, now, e.config.StaleClaimWarningAfter, func(branch string) (bool, bool, error) {
+	// Filter by rig — wisps are shared across all rigs (GH#2718).
+	filtered := make([]*beads.Issue, 0, len(issues))
+	for _, issue := range issues {
+		fields := beads.ParseMRFields(issue)
+		if fields != nil && fields.Rig != "" && !strings.EqualFold(fields.Rig, e.rig.Name) {
+			continue
+		}
+		filtered = append(filtered, issue)
+	}
+
+	return detectQueueAnomalies(filtered, now, e.config.StaleClaimWarningAfter, func(branch string) (bool, bool, error) {
 		localExists, err := e.git.BranchExists(branch)
 		if err != nil {
 			return false, false, err

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -321,6 +321,13 @@ func (m *Manager) Queue() ([]QueueItem, error) {
 		if issue == nil || issue.Status != "open" {
 			continue
 		}
+
+		// Filter by rig — wisps are shared across all rigs (GH#2718).
+		fields := beads.ParseMRFields(issue)
+		if fields != nil && fields.Rig != "" && !strings.EqualFold(fields.Rig, m.rig.Name) {
+			continue
+		}
+
 		score := m.calculateIssueScore(issue, now)
 		scored = append(scored, scoredIssue{issue: issue, score: score})
 	}


### PR DESCRIPTION
## Summary

- Add rig filtering to `ListReadyMRs()`, `ListBlockedMRs()`, `ListAllOpenMRs()`, and `ListQueueAnomalies()` in `internal/refinery/engineer.go`
- Add rig filtering to `Queue()` in `internal/refinery/manager.go`
- All rigs share one Dolt wisps table; without filtering, refineries see MRs from all rigs and try to merge branches that don't exist in their repo

## Context

Fixes #2933. This is the server-side counterpart of #2718 / PR #2719 which fixed `gt mq list` (CLI only). The refinery's own listing code was never patched.

## Change

After `fields := beads.ParseMRFields(issue)` and the nil check, each affected method now skips MRs whose `fields.Rig` doesn't match the current rig (case-insensitive comparison via `strings.EqualFold`). For `ListQueueAnomalies`, issues are pre-filtered before being passed to `detectQueueAnomalies()` since that helper function doesn't have access to the rig name.

## Test plan

- [ ] `go build ./...` passes (verified locally)
- [ ] Multi-rig setup: verify refinery on rig A no longer picks up MRs from rig B
- [ ] Single-rig setup: verify no regression (MRs with matching rig or empty rig field still appear)

🤖 Generated with [Claude Code](https://claude.com/claude-code)