### PR TITLE
fix: add missing Handler patrol to lifecycle defaults test

### DIFF
--- a/internal/daemon/lifecycle_defaults_test.go
+++ b/internal/daemon/lifecycle_defaults_test.go
@@ -143,6 +143,7 @@ func TestEnsureLifecycleDefaults_FullyConfigured(t *testing.T) {
 			JsonlGitBackup:       &JsonlGitBackupConfig{Enabled: false},
 			DoltBackup:           &DoltBackupConfig{Enabled: false},
 			ScheduledMaintenance: &ScheduledMaintenanceConfig{Enabled: false, Threshold: &threshold},
+			Handler:              &PatrolConfig{Enabled: false},
 		},
 	}
 


### PR DESCRIPTION
## Summary
- `TestEnsureLifecycleDefaults_FullyConfigured` was missing the `Handler` patrol in its "fully configured" config
- `EnsureLifecycleDefaults` checks for `Handler == nil` and fills it in, so the test incorrectly returned `changed=true`
- This was causing CI test failures across all open PRs

## Test plan
- [x] `go build ./internal/daemon/` passes
- [ ] CI: `TestEnsureLifecycleDefaults_FullyConfigured` should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)