### PR TITLE
fix(sling): kill session unconditionally when reusing idle polecat

### DIFF
--- a/internal/cmd/polecat_spawn.go
+++ b/internal/cmd/polecat_spawn.go
@@ -2,7 +2,6 @@
 package cmd
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -187,16 +186,12 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 		}
 		reuseOK := false
 		if _, err := polecatMgr.ReuseIdlePolecat(polecatName, addOpts); err != nil {
-			if errors.Is(err, polecat.ErrSessionRunning) {
-				fmt.Printf("  Idle polecat %s still has a live session, allocating new...\n", polecatName)
+			// Branch-only reuse failed — try full worktree repair as fallback
+			fmt.Printf("  Branch-only reuse failed for idle polecat %s: %v, trying full repair...\n", polecatName, err)
+			if _, err := polecatMgr.RepairWorktreeWithOptions(polecatName, true, addOpts); err != nil {
+				fmt.Printf("  Full repair also failed for %s: %v, allocating new...\n", polecatName, err)
 			} else {
-				// Branch-only reuse failed — try full worktree repair as fallback
-				fmt.Printf("  Branch-only reuse failed for idle polecat %s: %v, trying full repair...\n", polecatName, err)
-				if _, err := polecatMgr.RepairWorktreeWithOptions(polecatName, true, addOpts); err != nil {
-					fmt.Printf("  Full repair also failed for %s: %v, allocating new...\n", polecatName, err)
-				} else {
-					reuseOK = true
-				}
+				reuseOK = true
 			}
 		} else {
 			reuseOK = true

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1510,18 +1510,25 @@ func (m *Manager) ReuseIdlePolecat(name string, opts AddOptions) (*Polecat, erro
 		return nil, ErrPolecatNotFound
 	}
 
-	// Revalidate session state under the polecat lock. A prior dispatcher may
-	// have observed this polecat as idle, but by the time reuse begins the tmux
-	// session may still be alive or may have revived.
-	if running, stale := m.polecatSessionState(name); running {
-		if stale {
-			sessionName := session.PolecatSessionName(session.PrefixFor(m.rig.Name), name)
-			if err := m.tmux.KillSessionWithProcesses(sessionName); err != nil {
-				return nil, fmt.Errorf("killing stale session %s: %w", sessionName, err)
-			}
-		} else {
-			return nil, ErrSessionRunning
+	// Kill any existing session unconditionally before reuse.
+	// The polecat was found idle (no hooked work), so even a "live" session is
+	// just Claude sitting at a dead ❯ prompt from the previous task. Leaving it
+	// alive prevents StartSession from creating a fresh session with a proper
+	// gt prime --hook cycle to discover the newly hooked bead.
+	//
+	// Previously, non-stale sessions returned ErrSessionRunning here, causing the
+	// caller to allocate a new polecat. But heartbeat freshness can race with
+	// session lifecycle (e.g. a compact/resume hook refreshes the heartbeat while
+	// the session is functionally idle), leaving the old session alive and the
+	// new work undiscovered.
+	if running, _ := m.polecatSessionState(name); running {
+		sessionName := session.PolecatSessionName(session.PrefixFor(m.rig.Name), name)
+		if err := m.tmux.KillSessionWithProcesses(sessionName); err != nil {
+			return nil, fmt.Errorf("killing existing session %s for reuse: %w", sessionName, err)
 		}
+		// Remove stale heartbeat so SessionManager.Start doesn't see leftover data.
+		townRoot := filepath.Dir(m.rig.Path)
+		RemoveSessionHeartbeat(townRoot, sessionName)
 	}
 
 	// Get worktree path (must already exist for reuse)

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -1,6 +1,7 @@
 package polecat
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -17,6 +18,7 @@ import (
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/testutil"
+	"github.com/steveyegge/gastown/internal/tmux"
 )
 
 // installMockBd places a fake bd binary in PATH that handles the commands
@@ -1690,5 +1692,207 @@ func TestAllocateAndAdd_NoDuplicateNames(t *testing.T) {
 		if count > 1 {
 			t.Errorf("name %q allocated %d times — race condition (GH#2215)", name, count)
 		}
+	}
+}
+
+// TestReuseIdlePolecat_KillsLiveSession verifies that ReuseIdlePolecat kills
+// an existing live (non-stale) tmux session instead of returning ErrSessionRunning.
+// This is the regression test for the sling-reuse-stale-session bug: idle polecats
+// with a live Claude session at a dead ❯ prompt must have their session killed so
+// StartSession can create a fresh session with a proper gt prime --hook cycle.
+func TestReuseIdlePolecat_KillsLiveSession(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tmux not supported on Windows")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	townRoot := t.TempDir()
+	rigName := "testreuse"
+	rigPath := filepath.Join(townRoot, rigName)
+	polecatName := "toast"
+
+	// Create minimal polecat directory structure
+	polecatDir := filepath.Join(rigPath, "polecats", polecatName)
+	if err := os.MkdirAll(polecatDir, 0755); err != nil {
+		t.Fatalf("mkdir polecat dir: %v", err)
+	}
+
+	// Register a unique prefix for session naming
+	reg := session.NewPrefixRegistry()
+	reg.Register("gt", rigName)
+	old := session.DefaultRegistry()
+	session.SetDefaultRegistry(reg)
+	t.Cleanup(func() { session.SetDefaultRegistry(old) })
+
+	tm := tmux.NewTmux()
+	r := &rig.Rig{Name: rigName, Path: rigPath}
+	mgr := NewManager(r, git.NewGit(rigPath), tm)
+
+	// Create a live tmux session (simulates Claude sitting at ❯ after gt done)
+	sessMgr := NewSessionManager(tm, r)
+	sessionName := sessMgr.SessionName(polecatName)
+	if err := tm.NewSessionWithCommand(sessionName, townRoot, "sleep 300"); err != nil {
+		t.Fatalf("create tmux session: %v", err)
+	}
+	t.Cleanup(func() { _ = tm.KillSessionWithProcesses(sessionName) })
+
+	// Write a fresh heartbeat (simulating a session that just finished gt done
+	// but hasn't gone stale yet — this is the exact scenario that previously
+	// caused ReuseIdlePolecat to return ErrSessionRunning)
+	TouchSessionHeartbeat(townRoot, sessionName)
+
+	// Verify session is alive and heartbeat exists
+	running, err := tm.HasSession(sessionName)
+	if err != nil || !running {
+		t.Fatalf("precondition: session %s should be running", sessionName)
+	}
+	if hb := ReadSessionHeartbeat(townRoot, sessionName); hb == nil {
+		t.Fatal("precondition: heartbeat should exist")
+	}
+
+	// Call ReuseIdlePolecat — it will kill the session, then fail on worktree
+	// operations (no real git repo). The important thing is it does NOT return
+	// ErrSessionRunning.
+	_, reuseErr := mgr.ReuseIdlePolecat(polecatName, AddOptions{})
+
+	// Verify it did NOT return ErrSessionRunning (the old buggy behavior)
+	if errors.Is(reuseErr, ErrSessionRunning) {
+		t.Fatalf("ReuseIdlePolecat returned ErrSessionRunning for live session — "+
+			"this is the sling-reuse-stale-session bug: idle polecats with live "+
+			"sessions must have their session killed, not rejected")
+	}
+
+	// We expect an error from later steps (worktree not found), but not from session handling
+	if reuseErr == nil {
+		t.Fatal("expected error from worktree operations (test has no real git repo)")
+	}
+	if !strings.Contains(reuseErr.Error(), "worktree") {
+		t.Logf("ReuseIdlePolecat error (expected worktree-related): %v", reuseErr)
+	}
+
+	// Verify the session was killed
+	running, _ = tm.HasSession(sessionName)
+	if running {
+		t.Error("session should have been killed by ReuseIdlePolecat")
+	}
+
+	// Verify heartbeat was cleaned up
+	if hb := ReadSessionHeartbeat(townRoot, sessionName); hb != nil {
+		t.Error("heartbeat should have been removed after session kill")
+	}
+}
+
+// TestReuseIdlePolecat_KillsStaleSession verifies that ReuseIdlePolecat also
+// handles the stale-session case correctly (regression: the original code path
+// that worked before the fix should still work after).
+func TestReuseIdlePolecat_KillsStaleSession(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tmux not supported on Windows")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	townRoot := t.TempDir()
+	rigName := "teststale"
+	rigPath := filepath.Join(townRoot, rigName)
+	polecatName := "marmalade"
+
+	polecatDir := filepath.Join(rigPath, "polecats", polecatName)
+	if err := os.MkdirAll(polecatDir, 0755); err != nil {
+		t.Fatalf("mkdir polecat dir: %v", err)
+	}
+
+	reg := session.NewPrefixRegistry()
+	reg.Register("gt", rigName)
+	old := session.DefaultRegistry()
+	session.SetDefaultRegistry(reg)
+	t.Cleanup(func() { session.SetDefaultRegistry(old) })
+
+	tm := tmux.NewTmux()
+	r := &rig.Rig{Name: rigName, Path: rigPath}
+	mgr := NewManager(r, git.NewGit(rigPath), tm)
+
+	sessMgr := NewSessionManager(tm, r)
+	sessionName := sessMgr.SessionName(polecatName)
+	if err := tm.NewSessionWithCommand(sessionName, townRoot, "sleep 300"); err != nil {
+		t.Fatalf("create tmux session: %v", err)
+	}
+	t.Cleanup(func() { _ = tm.KillSessionWithProcesses(sessionName) })
+
+	// Write a STALE heartbeat (old timestamp)
+	dir := filepath.Join(townRoot, ".runtime", "heartbeats")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-10 * time.Minute).UTC()
+	data := []byte(`{"timestamp":"` + oldTime.Format(time.RFC3339Nano) + `","state":"exiting"}`)
+	if err := os.WriteFile(filepath.Join(dir, sessionName+".json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	_, reuseErr := mgr.ReuseIdlePolecat(polecatName, AddOptions{})
+
+	// Should not return ErrSessionRunning
+	if errors.Is(reuseErr, ErrSessionRunning) {
+		t.Fatal("ReuseIdlePolecat should not return ErrSessionRunning for stale session")
+	}
+
+	// Session should be killed
+	running, _ := tm.HasSession(sessionName)
+	if running {
+		t.Error("stale session should have been killed")
+	}
+
+	// Heartbeat should be cleaned up
+	if hb := ReadSessionHeartbeat(townRoot, sessionName); hb != nil {
+		t.Error("heartbeat should have been removed after stale session kill")
+	}
+}
+
+// TestReuseIdlePolecat_NoSessionNoop verifies that ReuseIdlePolecat proceeds
+// normally when there's no existing session (the most common reuse case: session
+// was already killed by the Witness or expired).
+func TestReuseIdlePolecat_NoSessionNoop(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("tmux not supported on Windows")
+	}
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	townRoot := t.TempDir()
+	rigName := "testnoop"
+	rigPath := filepath.Join(townRoot, rigName)
+	polecatName := "jam"
+
+	polecatDir := filepath.Join(rigPath, "polecats", polecatName)
+	if err := os.MkdirAll(polecatDir, 0755); err != nil {
+		t.Fatalf("mkdir polecat dir: %v", err)
+	}
+
+	reg := session.NewPrefixRegistry()
+	reg.Register("gt", rigName)
+	old := session.DefaultRegistry()
+	session.SetDefaultRegistry(reg)
+	t.Cleanup(func() { session.SetDefaultRegistry(old) })
+
+	tm := tmux.NewTmux()
+	r := &rig.Rig{Name: rigName, Path: rigPath}
+	mgr := NewManager(r, git.NewGit(rigPath), tm)
+
+	// No tmux session, no heartbeat — the common idle case
+	_, reuseErr := mgr.ReuseIdlePolecat(polecatName, AddOptions{})
+
+	// Should not return ErrSessionRunning
+	if errors.Is(reuseErr, ErrSessionRunning) {
+		t.Fatal("ReuseIdlePolecat should not return ErrSessionRunning when no session exists")
+	}
+
+	// Error should be from later steps (worktree ops), not session handling
+	if reuseErr == nil {
+		t.Fatal("expected error from worktree operations")
 	}
 }


### PR DESCRIPTION
## Summary
- When `gt sling` reuses an idle polecat, any existing tmux session is now killed unconditionally (not just when stale)
- Previously, a non-stale session caused `ReuseIdlePolecat` to return `ErrSessionRunning`, forcing allocation of a new polecat instead of reuse
- Heartbeat freshness can race with session lifecycle (compact/resume hooks refresh the heartbeat while Claude sits idle at a dead `❯` prompt), leaving the old session alive and new work undiscovered
- Also cleans up the heartbeat file after killing the session to prevent stale data from confusing `SessionManager.Start`

## Test plan
- [x] `TestReuseIdlePolecat_KillsLiveSession` — verifies a live (non-stale) session is killed instead of returning `ErrSessionRunning`
- [x] `TestReuseIdlePolecat_KillsStaleSession` — regression: stale session path still works
- [x] `TestReuseIdlePolecat_NoSessionNoop` — no-session case proceeds normally
- [x] Existing heartbeat tests pass
- [x] Full build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)