### PR TITLE
fix: include dogs in findAgentWork startup retry loop

### DIFF
--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -591,7 +591,7 @@ func findAgentWork(ctx RoleContext) (*beads.Issue, error) {
 	// A single attempt suffices — retries would add ~15s of latency to
 	// compaction hooks, causing non-Claude runtimes to report hook failure.
 	maxAttempts := 1
-	if (ctx.Role == RolePolecat || ctx.Role == RoleCrew) && !isCompactResume() {
+	if (ctx.Role == RolePolecat || ctx.Role == RoleCrew || ctx.Role == RoleDog) && !isCompactResume() {
 		maxAttempts = 5
 	}
 


### PR DESCRIPTION
## Summary

- Add `RoleDog` to the retry condition in `findAgentWork()` (`prime.go:594`) so dogs get the same 5-attempt exponential backoff as polecats and crew on fresh session start

Dogs dispatched by the daemon hit the same hook-write timing race — the session starts before the hook write propagates, `gt prime` finds no work, and the dog idles indefinitely. This was observed repeatedly in production affecting 6+ dogs across multiple plugin types (dolt-archive, git-hygiene, stuck-agent-dog, quality-review, rebuild-gt, compactor-dog).

One-line fix: `|| ctx.Role == RoleDog`

## Test plan

- [ ] Dispatch a dog via daemon plugin and verify it picks up work within the retry window
- [ ] Verify compact/resume path still uses `maxAttempts = 1` for dogs (no regression)

Closes #2748

🤖 Generated with [Claude Code](https://claude.com/claude-code)