### PR TITLE
fix: suppress Dolt auto-start for Gas Town agents

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -298,6 +298,17 @@ func AgentEnv(cfg AgentEnvConfig) map[string]string {
 		}
 	}
 
+	// Suppress bd's Dolt auto-start for all Gas Town agents (GH#2930).
+	// Gas Town manages its own Dolt server (gt dolt start/stop). When the
+	// server is momentarily unreachable (restart, journal hiccup), bd's
+	// auto-start tries to launch a shadow server in the agent's .beads/dolt/
+	// directory — which conflicts with the real server on the same port and
+	// triggers an escalation flood loop. Dogs are especially affected because
+	// their kennel's .beads/ has no explicit dolt_server_port in metadata.json.
+	if cfg.TownRoot != "" {
+		env["BEADS_DOLT_AUTO_START"] = "0"
+	}
+
 	// Pass through cloud API credentials and provider configuration from the parent shell.
 	// Only variables explicitly listed here are forwarded; all others are blocked for isolation.
 	for _, key := range []string{


### PR DESCRIPTION
## Summary

- Set `BEADS_DOLT_AUTO_START=0` for all Gas Town agents when `TownRoot` is set, preventing `bd` from auto-starting shadow Dolt servers during transient server outages

## Problem

When Gas Town's Dolt server hiccups (restart, journal issue), `bd` inside dog sessions tries to auto-start a shadow Dolt server in `/gt/deacon/.beads/dolt/`. This fails because port 3307 is held by the real server, causing an escalation flood loop:

1. Dog's `bd` TCP connect to 3307 fails momentarily
2. `AutoStart=true` → `EnsureRunningDetailed()` tries to launch new server
3. `IsRunning()` checks PID at `/gt/deacon/.beads/dolt-server.pid` (doesn't exist) → thinks no server running
4. `Start()` tries port 3307 → "port in use by another project's dolt server"
5. Dog escalates CRITICAL → deacon respawns → repeat

Dogs are especially affected because the deacon's `.beads/metadata.json` has no `dolt_server_port`, so `hasExplicitPort()` returns false and `resolveAutoStart()` defaults to true.

## Fix

Gas Town manages its own Dolt server lifecycle (`gt dolt start/stop`). Agents should never auto-start their own. The `BEADS_DOLT_AUTO_START=0` env var is checked first by `resolveAutoStart()` (priority 2 after test mode), unconditionally suppressing auto-start.

## Test plan

- [x] `go build ./...` compiles clean
- [x] `go test ./internal/config/` passes (all AgentEnv tests)
- [X] Verify dog sessions have `BEADS_DOLT_AUTO_START=0` in environment
- [X] Simulate Dolt restart with dog running — should get clean "server unreachable" instead of shadow server cascade

Closes #2930

🤖 Generated with [Claude Code](https://claude.com/claude-code)