### PR TITLE
fix(tests): update stale assertions in doltserver and daemon tests

### DIFF
--- a/internal/daemon/lifecycle_defaults_test.go
+++ b/internal/daemon/lifecycle_defaults_test.go
@@ -137,12 +137,13 @@ func TestEnsureLifecycleDefaults_FullyConfigured(t *testing.T) {
 		Type:    "daemon-patrol-config",
 		Version: 1,
 		Patrols: &PatrolsConfig{
-			WispReaper:   &WispReaperConfig{Enabled: false},
-			CompactorDog: &CompactorDogConfig{Enabled: false},
-			DoctorDog:    &DoctorDogConfig{Enabled: false},
+			WispReaper:           &WispReaperConfig{Enabled: false},
+			CompactorDog:         &CompactorDogConfig{Enabled: false},
+			DoctorDog:            &DoctorDogConfig{Enabled: false},
 			JsonlGitBackup:       &JsonlGitBackupConfig{Enabled: false},
 			DoltBackup:           &DoltBackupConfig{Enabled: false},
 			ScheduledMaintenance: &ScheduledMaintenanceConfig{Enabled: false, Threshold: &threshold},
+			Handler:              &PatrolConfig{Enabled: false},
 		},
 	}
 

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -3522,9 +3522,10 @@ func TestBuildDoltSQLCmd_Remote(t *testing.T) {
 	ctx := t.Context()
 	cmd := buildDoltSQLCmd(ctx, config, "-q", "SELECT 1")
 
-	// Should NOT set Dir for remote
-	if cmd.Dir != "" {
-		t.Errorf("cmd.Dir = %q, want empty for remote", cmd.Dir)
+	// Dir is always set to DataDir — even for remote connections (GH#2537)
+	// to prevent dolt from auto-creating .doltcfg/privileges.db in $CWD.
+	if cmd.Dir != config.DataDir {
+		t.Errorf("cmd.Dir = %q, want %q (DataDir set for remote per GH#2537)", cmd.Dir, config.DataDir)
 	}
 
 	// Should have connection flags


### PR DESCRIPTION
## Summary
- `TestBuildDoltSQLCmd_Remote` expected `cmd.Dir=""` for remote connections, but GH#2537 intentionally changed `buildDoltSQLCmd` to always set `Dir` to `DataDir`. Updated assertion to match.
- `TestEnsureLifecycleDefaults_FullyConfigured` was missing the `Handler` patrol config added in PR #2775. Added it to the fixture so the test is truly "fully configured".

These failures are pre-existing on main (reproducible locally) and are blocking CI for PRs #2936 and #2939.

## Test plan
- [x] Both tests pass locally
- [x] Full build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)