### PR TITLE
fix: pass --branch to bare clone in gt rig add

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -272,15 +272,31 @@ func (g *Git) CloneBare(url, dest string) error {
 	return g.cloneInternal(url, dest, cloneOptions{bare: true, singleBranch: true, depth: 1})
 }
 
+// CloneBareWithBranch clones a bare repo, checking out a specific branch.
+// Use this when the desired default branch differs from the remote HEAD.
+func (g *Git) CloneBareWithBranch(url, dest, branch string) error {
+	return g.cloneInternal(url, dest, cloneOptions{bare: true, singleBranch: true, depth: 1, branch: branch})
+}
+
 // CloneBarePartial clones a bare repo with a partial clone filter (e.g. "blob:none", "tree:0").
 // Does not use --depth since partial clones handle size reduction via the filter.
 func (g *Git) CloneBarePartial(url, dest, filter string) error {
 	return g.cloneInternal(url, dest, cloneOptions{bare: true, singleBranch: true, filter: filter})
 }
 
+// CloneBarePartialWithBranch clones a bare repo with a partial clone filter and specific branch.
+func (g *Git) CloneBarePartialWithBranch(url, dest, filter, branch string) error {
+	return g.cloneInternal(url, dest, cloneOptions{bare: true, singleBranch: true, filter: filter, branch: branch})
+}
+
 // CloneBarePartialWithReference clones a bare repo with a partial clone filter and local reference.
 func (g *Git) CloneBarePartialWithReference(url, dest, filter, reference string) error {
 	return g.cloneInternal(url, dest, cloneOptions{bare: true, singleBranch: true, filter: filter, reference: reference})
+}
+
+// CloneBarePartialWithReferenceAndBranch clones a bare repo with a partial clone filter, local reference, and specific branch.
+func (g *Git) CloneBarePartialWithReferenceAndBranch(url, dest, filter, reference, branch string) error {
+	return g.cloneInternal(url, dest, cloneOptions{bare: true, singleBranch: true, filter: filter, reference: reference, branch: branch})
 }
 
 // CloneBranchPartialWithReference clones a specific branch with a partial clone filter and reference.
@@ -385,6 +401,11 @@ func configureRefspec(repoPath string, singleBranch bool) error {
 // Uses --single-branch --depth 1 for efficiency on repos with many branches.
 func (g *Git) CloneBareWithReference(url, dest, reference string) error {
 	return g.cloneInternal(url, dest, cloneOptions{bare: true, reference: reference, singleBranch: true, depth: 1})
+}
+
+// CloneBareWithReferenceAndBranch clones a bare repo using a local reference, checking out a specific branch.
+func (g *Git) CloneBareWithReferenceAndBranch(url, dest, reference, branch string) error {
+	return g.cloneInternal(url, dest, cloneOptions{bare: true, reference: reference, singleBranch: true, depth: 1, branch: branch})
 }
 
 // Checkout checks out the given ref.

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -371,30 +371,32 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 	// Mayor remains a separate clone (doesn't need branch visibility).
 	fmt.Printf("  Cloning repository (this may take a moment)...\n")
 	bareRepoPath := filepath.Join(rigPath, ".repo.git")
-	if opts.CloneFilter != "" && localRepo != "" {
-		if err := m.git.CloneBarePartialWithReference(opts.GitURL, bareRepoPath, opts.CloneFilter, localRepo); err != nil {
-			fmt.Printf("  Warning: could not use local repo reference with filter: %v\n", err)
-			_ = os.RemoveAll(bareRepoPath)
-			if err := m.git.CloneBarePartial(opts.GitURL, bareRepoPath, opts.CloneFilter); err != nil {
-				return nil, wrapCloneError(err, opts.GitURL)
+	// cloneBareWith selects the right CloneBare variant based on filter/reference/branch.
+	// When branch is non-empty, git clone --branch is passed so HEAD and the initial
+	// single-branch fetch both target the user-specified branch instead of the remote HEAD.
+	cloneBareWith := func(branch string) error {
+		if opts.CloneFilter != "" && localRepo != "" {
+			if err := m.git.CloneBarePartialWithReferenceAndBranch(opts.GitURL, bareRepoPath, opts.CloneFilter, localRepo, branch); err != nil {
+				fmt.Printf("  Warning: could not use local repo reference with filter: %v\n", err)
+				_ = os.RemoveAll(bareRepoPath)
+				return m.git.CloneBarePartialWithBranch(opts.GitURL, bareRepoPath, opts.CloneFilter, branch)
 			}
-		}
-	} else if opts.CloneFilter != "" {
-		if err := m.git.CloneBarePartial(opts.GitURL, bareRepoPath, opts.CloneFilter); err != nil {
-			return nil, wrapCloneError(err, opts.GitURL)
-		}
-	} else if localRepo != "" {
-		if err := m.git.CloneBareWithReference(opts.GitURL, bareRepoPath, localRepo); err != nil {
-			fmt.Printf("  Warning: could not use local repo reference: %v\n", err)
-			_ = os.RemoveAll(bareRepoPath)
-			if err := m.git.CloneBare(opts.GitURL, bareRepoPath); err != nil {
-				return nil, wrapCloneError(err, opts.GitURL)
+			return nil
+		} else if opts.CloneFilter != "" {
+			return m.git.CloneBarePartialWithBranch(opts.GitURL, bareRepoPath, opts.CloneFilter, branch)
+		} else if localRepo != "" {
+			if err := m.git.CloneBareWithReferenceAndBranch(opts.GitURL, bareRepoPath, localRepo, branch); err != nil {
+				fmt.Printf("  Warning: could not use local repo reference: %v\n", err)
+				_ = os.RemoveAll(bareRepoPath)
+				return m.git.CloneBareWithBranch(opts.GitURL, bareRepoPath, branch)
 			}
+			return nil
 		}
-	} else {
-		if err := m.git.CloneBare(opts.GitURL, bareRepoPath); err != nil {
-			return nil, wrapCloneError(err, opts.GitURL)
-		}
+		return m.git.CloneBareWithBranch(opts.GitURL, bareRepoPath, branch)
+	}
+
+	if err := cloneBareWith(opts.DefaultBranch); err != nil {
+		return nil, wrapCloneError(err, opts.GitURL)
 	}
 	if opts.CloneFilter != "" {
 		fmt.Printf("   ✓ Created shared bare repo (partial: --filter=%s)\n", opts.CloneFilter)

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -1381,6 +1381,105 @@ func TestAddRig_UpstreamURL(t *testing.T) {
 	_ = rig
 }
 
+// TestAddRig_BranchFlag verifies that --branch is passed to the bare clone so
+// the bare repo's HEAD and origin tracking ref both point to the specified branch.
+func TestAddRig_BranchFlag(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-based bd shim not reliable on Windows CI")
+	}
+
+	fakeBDForAddRig(t)
+
+	// Create a remote with two branches: main (default) and develop.
+	repoDir := t.TempDir()
+	for _, args := range [][]string{
+		{"git", "init", "--initial-branch=main", repoDir},
+		{"git", "-C", repoDir, "config", "user.email", "test@test.com"},
+		{"git", "-C", repoDir, "config", "user.name", "Test User"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("# test\n"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	for _, args := range [][]string{
+		{"git", "-C", repoDir, "add", "."},
+		{"git", "-C", repoDir, "commit", "-m", "Initial commit"},
+		{"git", "-C", repoDir, "checkout", "-b", "develop"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "develop.txt"), []byte("develop branch\n"), 0644); err != nil {
+		t.Fatalf("write develop.txt: %v", err)
+	}
+	for _, args := range [][]string{
+		{"git", "-C", repoDir, "add", "."},
+		{"git", "-C", repoDir, "commit", "-m", "develop commit"},
+		// Switch back to main so remote HEAD points to main (the default branch).
+		{"git", "-C", repoDir, "checkout", "main"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	root, rigsConfig := setupTestTown(t)
+	manager := NewManager(root, rigsConfig, git.NewGit(root))
+
+	_, err := manager.AddRig(AddRigOptions{
+		Name:          "testrig",
+		GitURL:        repoDir,
+		BeadsPrefix:   "tr",
+		DefaultBranch: "develop",
+		SkipDoltCheck: true,
+	})
+	if err != nil {
+		t.Fatalf("AddRig: %v", err)
+	}
+
+	rigPath := filepath.Join(root, "testrig")
+	bareRepoPath := filepath.Join(rigPath, ".repo.git")
+	bareGit := git.NewGitWithDir(bareRepoPath, "")
+
+	t.Run("bare repo HEAD points to develop", func(t *testing.T) {
+		got := bareGit.DefaultBranch()
+		if got != "develop" {
+			t.Errorf("bare repo DefaultBranch() = %q, want %q", got, "develop")
+		}
+	})
+
+	t.Run("origin/develop tracking ref exists in bare repo", func(t *testing.T) {
+		exists, err := bareGit.RefExists("refs/remotes/origin/develop")
+		if err != nil {
+			t.Fatalf("RefExists: %v", err)
+		}
+		if !exists {
+			t.Error("refs/remotes/origin/develop does not exist in bare repo")
+		}
+	})
+
+	t.Run("config.json DefaultBranch is develop", func(t *testing.T) {
+		data, err := os.ReadFile(filepath.Join(rigPath, "config.json"))
+		if err != nil {
+			t.Fatalf("reading config.json: %v", err)
+		}
+		var cfg RigConfig
+		if err := json.Unmarshal(data, &cfg); err != nil {
+			t.Fatalf("parsing config.json: %v", err)
+		}
+		if cfg.DefaultBranch != "develop" {
+			t.Errorf("config.json DefaultBranch = %q, want %q", cfg.DefaultBranch, "develop")
+		}
+	})
+}
+
 // TestBareCloneDefaultBranch verifies that DefaultBranch() returns the correct
 // branch for a bare clone whose remote uses a non-"main" default branch.
 func TestBareCloneDefaultBranch(t *testing.T) {


### PR DESCRIPTION
## Summary
- When `--branch` is specified with `gt rig add`, the flag was ignored for the bare repo clone (`.repo.git`). The `CloneBare*` functions had no branch parameter, so git always cloned the remote HEAD branch.
- Adds `CloneBareWithBranch` and related functions to `git.go`; updates `manager.go` to use them so the initial bare clone sets HEAD and single-branch fetch to the user-specified branch.
- Adds `TestAddRig_BranchFlag` to cover the scenario.

Fixes https://github.com/steveyegge/gastown/issues/2940

## Test plan
- [x] New test `TestAddRig_BranchFlag` verifies bare clone uses specified branch
- [ ] Manual: `gt rig add --branch <non-default> <repo>` creates bare clone with correct HEAD

🤖 Generated with [Claude Code](https://claude.com/claude-code)