### PR TITLE
fix(prime): remind polecats about gt done after compaction

### DIFF
--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -242,6 +242,13 @@ func runPrimeCompactResume(ctx RoleContext) {
 	fmt.Println("\n---")
 	fmt.Println()
 	fmt.Println("**Continue your current task.** If you've lost context, run `gt prime` for full reload.")
+
+	// Remind polecats about gt done — after compaction the agent may have lost
+	// the formula checklist and forgotten that gt done is required to submit work.
+	// Without this, polecats finish implementation and sit at the prompt forever.
+	if ctx.Role == RolePolecat {
+		fmt.Printf("\n**IMPORTANT**: When all work is complete (code committed, tests pass), run `%s done` to submit to the merge queue.\n", cli.Name())
+	}
 }
 
 // validatePrimeFlags checks that CLI flag combinations are valid.
@@ -801,8 +808,9 @@ func outputMoleculeWorkflow(ctx RoleContext, attachment *beads.AttachmentFields)
 	if attachment.AttachedFormula != "" {
 		showFormulaStepsFull(attachment.AttachedFormula, strings.Split(attachment.FormulaVars, "\n"))
 		fmt.Println()
-		fmt.Printf("%s\n", style.Bold.Render("Work through the checklist above. When all steps complete, run `"+cli.Name()+" done`."))
+		fmt.Printf("%s\n", style.Bold.Render("Work through ALL steps above, including submit and cleanup."))
 		fmt.Println("The base bead is your assignment. The formula steps define your workflow.")
+		fmt.Printf("\n%s\n", style.Bold.Render("REQUIRED: When all steps complete, run `"+cli.Name()+" done` to submit to the merge queue. Do NOT stop after implementation — the formula has submit steps you must follow."))
 		return
 	}
 

--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -989,3 +989,54 @@ func TestCheckSlungWork_StandaloneFormulaUsesWorkflowOutput(t *testing.T) {
 		t.Fatalf("expected standalone formula context to be shown, got:\n%s", output)
 	}
 }
+
+// TestCompactResumeReminder_PolecatGetsGtDone verifies that polecats get a
+// gt done reminder after context compaction. This is the regression test for
+// the polecats-no-gt-done bug: after long work sessions, compaction drops the
+// formula checklist and the agent forgets to call gt done.
+func TestCompactResumeReminder_PolecatGetsGtDone(t *testing.T) {
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	ctx := RoleContext{Role: RolePolecat}
+	// Simulate compact source
+	primeHookSource = "compact"
+	defer func() { primeHookSource = "" }()
+
+	runPrimeCompactResume(ctx)
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stdout = oldStdout
+	output := buf.String()
+
+	if !strings.Contains(output, "gt done") {
+		t.Fatalf("compact/resume for polecat must remind about gt done, got:\n%s", output)
+	}
+}
+
+// TestCompactResumeReminder_NonPolecatNoGtDone verifies that non-polecat roles
+// do NOT get the gt done reminder (it's polecat-specific).
+func TestCompactResumeReminder_NonPolecatNoGtDone(t *testing.T) {
+	oldStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	ctx := RoleContext{Role: RoleCrew}
+	primeHookSource = "compact"
+	defer func() { primeHookSource = "" }()
+
+	runPrimeCompactResume(ctx)
+
+	w.Close()
+	var buf bytes.Buffer
+	io.Copy(&buf, r)
+	os.Stdout = oldStdout
+	output := buf.String()
+
+	if strings.Contains(output, "gt done") {
+		t.Fatalf("compact/resume for non-polecat should NOT mention gt done, got:\n%s", output)
+	}
+}


### PR DESCRIPTION
## Summary
Polecats complete work (edit, test, commit) but sit at the `❯` prompt forever instead of calling `gt done`. Root cause: after context compaction, the formula checklist is dropped and the agent loses the `gt done` instruction.

Two changes:
- **Compact/resume path**: Add `gt done` reminder for polecats. After compaction, the agent sees "Continue your current task" but nothing about submitting. Now it also sees "IMPORTANT: run gt done to submit to the merge queue."
- **Startup formula output**: Strengthen from `"When all steps complete, run gt done"` to a prominent REQUIRED block that emphasizes the formula has submit steps beyond implementation.

## Test plan
- [x] `TestCompactResumeReminder_PolecatGetsGtDone` — polecat compact output includes `gt done`
- [x] `TestCompactResumeReminder_NonPolecatNoGtDone` — crew/witness don't get the reminder
- [x] Existing prime tests pass
- [x] Full build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)