### PR TITLE
fix(mail): drain crashed polecat notifications

### DIFF
--- a/internal/cmd/mail_drain.go
+++ b/internal/cmd/mail_drain.go
@@ -62,6 +62,7 @@ func init() {
 // bulk-archive. These are routine notifications that don't require individual
 // attention once the information is stale.
 var drainableSubjects = []string{
+	"CRASHED_POLECAT",
 	"POLECAT_DONE",
 	"POLECAT_STARTED",
 	"LIFECYCLE:",

--- a/internal/cmd/mail_drain_test.go
+++ b/internal/cmd/mail_drain_test.go
@@ -10,6 +10,7 @@ func TestIsDrainableMessage(t *testing.T) {
 		drainable bool
 	}{
 		// Drainable protocol messages
+		{"CRASHED_POLECAT: furiosa", true},
 		{"POLECAT_DONE furiosa", true},
 		{"POLECAT_STARTED: furiosa", true},
 		{"LIFECYCLE:Shutdown furiosa", true},


### PR DESCRIPTION
## Summary
- include `CRASHED_POLECAT` in `gt mail drain` drainable subjects
- add a focused test covering the crash notification subject

## Testing
- `go test ./internal/cmd -run TestIsDrainableMessage`

## Notes
- branch is based directly on `upstream/main`
- full `go test ./...` currently has unrelated pre-existing failures outside this change surface