### PR TITLE
feat: configurable window tint (window-style) theming

### DIFF
--- a/internal/cmd/theme.go
+++ b/internal/cmd/theme.go
@@ -80,6 +80,7 @@ func init() {
 	themeCmd.AddCommand(themeCLICmd)
 	themeCmd.Flags().BoolVarP(&themeListFlag, "list", "l", false, "List available themes")
 	themeApplyCmd.Flags().BoolVarP(&themeApplyAllFlag, "all", "a", false, "Apply to all rigs, not just current")
+
 }
 
 func runTheme(cmd *cobra.Command, args []string) error {
@@ -195,12 +196,20 @@ func runThemeApply(cmd *cobra.Command, args []string) error {
 			theme = getThemeForRole(rig, role)
 		}
 
-		// Apply theme, window style, and status format
+		// Resolve window tint from config.
+		// If ResolveWindowTint returns nil (no explicit window tint configured),
+		// check if window tinting is enabled — if so, match the status bar colors.
+		theme.Window = session.ResolveWindowTint(rig, role)
+		if theme.Window == nil && session.IsWindowTintEnabled(rig) {
+			theme.Window = &tmux.WindowStyle{BG: theme.BG, FG: theme.FG}
+		}
+
+		// Apply theme and pane tint
 		if err := t.ApplyTheme(sess, theme); err != nil {
 			fmt.Printf("  %s: failed (%v)\n", sess, err)
 			continue
 		}
-		if err := t.ApplyWindowStyle(sess, theme); err != nil {
+		if err := t.ApplyWindowStyle(sess, theme.Window); err != nil {
 			fmt.Printf("  %s: failed to set window style (%v)\n", sess, err)
 			continue
 		}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1114,6 +1114,10 @@ type ThemeConfig struct {
 	// RoleThemes overrides themes for specific roles in this rig.
 	// Keys: "witness", "refinery", "crew", "polecat"
 	RoleThemes map[string]string `json:"role_themes,omitempty"`
+
+	// WindowTint controls window background (window-style) coloring for this rig.
+	// If nil, falls back to town-level window tint config.
+	WindowTint *WindowTint `json:"window_tint,omitempty"`
 }
 
 // CustomTheme allows specifying exact colors for the status bar.
@@ -1127,6 +1131,31 @@ type TownThemeConfig struct {
 	// RoleDefaults sets default themes for roles across all rigs.
 	// Keys: "witness", "refinery", "crew", "polecat"
 	RoleDefaults map[string]string `json:"role_defaults,omitempty"`
+
+	// WindowTint controls window background (window-style) coloring globally.
+	// Per-rig WindowTint in ThemeConfig takes precedence over this.
+	WindowTint *WindowTint `json:"window_tint,omitempty"`
+}
+
+// WindowTint controls window background (window-style) coloring.
+// Mirrors status bar theme customization: palette name, custom colors, per-role overrides.
+// When Enabled is nil or true, window backgrounds are tinted.
+// When Enabled is false, window backgrounds use terminal defaults.
+type WindowTint struct {
+	// Enabled controls whether window tinting is active.
+	// nil or true = enabled, false = disabled (window uses terminal default).
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// Name picks a palette theme for the window background.
+	// If empty, falls back to the session's status bar theme colors.
+	Name string `json:"name,omitempty"`
+
+	// Custom overrides the palette with specific window background colors.
+	Custom *CustomTheme `json:"custom,omitempty"`
+
+	// RoleTints overrides window tint themes for specific roles.
+	// Keys: "witness", "refinery", "crew", "polecat"
+	RoleTints map[string]string `json:"role_tints,omitempty"`
 }
 
 // BuiltinRoleThemes returns the default themes for each role.

--- a/internal/session/window_tint.go
+++ b/internal/session/window_tint.go
@@ -1,0 +1,126 @@
+package session
+
+import (
+	"path/filepath"
+
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/tmux"
+	"github.com/steveyegge/gastown/internal/workspace"
+)
+
+// ResolveWindowTint resolves the window tint style for a session.
+// Resolution order mirrors status bar theming:
+//  1. Per-rig role tint (rig/settings/config.json → theme.window_tint.role_tints)
+//  2. Global role tint (mayor/config.json → theme.window_tint.role_tints)
+//  3. Per-rig window tint (rig/settings/config.json → theme.window_tint.name/custom)
+//  4. Global window tint (mayor/config.json → theme.window_tint.name/custom)
+//  5. Fallback: disabled (nil) — no window tinting by default
+//
+// Returns nil if window tinting is disabled or not configured.
+// Returns a WindowStyle if window tinting is enabled.
+func ResolveWindowTint(rig, role string) *tmux.WindowStyle {
+	townRoot, _ := workspace.FindFromCwd()
+
+	var rigWindowTint, globalWindowTint *config.WindowTint
+
+	// Load per-rig window tint config.
+	if townRoot != "" && rig != "" {
+		settingsPath := filepath.Join(townRoot, rig, "settings", "config.json")
+		if settings, err := config.LoadRigSettings(settingsPath); err == nil {
+			if settings.Theme != nil {
+				rigWindowTint = settings.Theme.WindowTint
+			}
+		}
+	}
+
+	// Load global window tint config.
+	if townRoot != "" {
+		mayorConfigPath := filepath.Join(townRoot, "mayor", "config.json")
+		if mayorCfg, err := config.LoadMayorConfig(mayorConfigPath); err == nil {
+			if mayorCfg.Theme != nil {
+				globalWindowTint = mayorCfg.Theme.WindowTint
+			}
+		}
+	}
+
+	// Check enabled — most specific level wins.
+	if rigWindowTint != nil && rigWindowTint.Enabled != nil && !*rigWindowTint.Enabled {
+		return nil
+	}
+	if globalWindowTint != nil && globalWindowTint.Enabled != nil && !*globalWindowTint.Enabled {
+		return nil
+	}
+
+	// 1. Per-rig role tint.
+	if rigWindowTint != nil && rigWindowTint.RoleTints != nil {
+		if themeName, ok := rigWindowTint.RoleTints[role]; ok {
+			if theme := tmux.GetThemeByName(themeName); theme != nil {
+				return &tmux.WindowStyle{BG: theme.BG, FG: theme.FG}
+			}
+		}
+	}
+
+	// 2. Global role tint.
+	if globalWindowTint != nil && globalWindowTint.RoleTints != nil {
+		if themeName, ok := globalWindowTint.RoleTints[role]; ok {
+			if theme := tmux.GetThemeByName(themeName); theme != nil {
+				return &tmux.WindowStyle{BG: theme.BG, FG: theme.FG}
+			}
+		}
+	}
+
+	// 3. Per-rig window tint (custom or named).
+	if rigWindowTint != nil {
+		if rigWindowTint.Custom != nil {
+			return &tmux.WindowStyle{BG: rigWindowTint.Custom.BG, FG: rigWindowTint.Custom.FG}
+		}
+		if rigWindowTint.Name != "" {
+			if theme := tmux.GetThemeByName(rigWindowTint.Name); theme != nil {
+				return &tmux.WindowStyle{BG: theme.BG, FG: theme.FG}
+			}
+		}
+	}
+
+	// 4. Global window tint (custom or named).
+	if globalWindowTint != nil {
+		if globalWindowTint.Custom != nil {
+			return &tmux.WindowStyle{BG: globalWindowTint.Custom.BG, FG: globalWindowTint.Custom.FG}
+		}
+		if globalWindowTint.Name != "" {
+			if theme := tmux.GetThemeByName(globalWindowTint.Name); theme != nil {
+				return &tmux.WindowStyle{BG: theme.BG, FG: theme.FG}
+			}
+		}
+	}
+
+	// 5. No window tint configured — disabled by default.
+	return nil
+}
+
+// IsWindowTintEnabled checks if window tinting is enabled at any config level.
+// Returns true if enabled explicitly; false if disabled or not configured.
+func IsWindowTintEnabled(rig string) bool {
+	townRoot, _ := workspace.FindFromCwd()
+
+	// Check per-rig config.
+	if townRoot != "" && rig != "" {
+		settingsPath := filepath.Join(townRoot, rig, "settings", "config.json")
+		if settings, err := config.LoadRigSettings(settingsPath); err == nil {
+			if settings.Theme != nil && settings.Theme.WindowTint != nil && settings.Theme.WindowTint.Enabled != nil {
+				return *settings.Theme.WindowTint.Enabled
+			}
+		}
+	}
+
+	// Check global config.
+	if townRoot != "" {
+		mayorConfigPath := filepath.Join(townRoot, "mayor", "config.json")
+		if mayorCfg, err := config.LoadMayorConfig(mayorConfigPath); err == nil {
+			if mayorCfg.Theme != nil && mayorCfg.Theme.WindowTint != nil && mayorCfg.Theme.WindowTint.Enabled != nil {
+				return *mayorCfg.Theme.WindowTint.Enabled
+			}
+		}
+	}
+
+	return false
+}

--- a/internal/tmux/theme.go
+++ b/internal/tmux/theme.go
@@ -6,11 +6,27 @@ import (
 	"hash/fnv"
 )
 
-// Theme represents a tmux status bar color scheme.
+// WindowStyle represents window background colors (tmux window-style).
+type WindowStyle struct {
+	BG string // Background color (hex or tmux color name)
+	FG string // Foreground color (hex or tmux color name)
+}
+
+// Style returns the tmux window-style string.
+func (w WindowStyle) Style() string {
+	return fmt.Sprintf("bg=%s,fg=%s", w.BG, w.FG)
+}
+
+// Theme represents a tmux color scheme for status bar and optional window background.
 type Theme struct {
 	Name string // Human-readable name
 	BG   string // Background color (hex or tmux color name)
 	FG   string // Foreground color (hex or tmux color name)
+
+	// Window is the optional window background style (tmux window-style).
+	// nil = disabled (window uses terminal defaults).
+	// If set, its BG/FG are applied as the window background.
+	Window *WindowStyle `json:"window,omitempty"`
 }
 
 // DefaultPalette is the curated set of distinct, professional color themes.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2642,11 +2642,14 @@ func (t *Tmux) ApplyTheme(session string, theme Theme) error {
 	return err
 }
 
-// ApplyWindowStyle sets the pane background (window-style) for a session.
-// This gives each session a distinct background color matching its theme,
-// complementing the status bar theme set by ApplyTheme.
-func (t *Tmux) ApplyWindowStyle(session string, theme Theme) error {
-	_, err := t.run("set-option", "-t", session, "window-style", theme.Style())
+// ApplyWindowStyle sets or resets the window background (window-style).
+// If ws is nil, resets to terminal defaults. If non-nil, applies the colors.
+func (t *Tmux) ApplyWindowStyle(session string, ws *WindowStyle) error {
+	style := "bg=default,fg=default"
+	if ws != nil {
+		style = ws.Style()
+	}
+	_, err := t.run("set-option", "-t", session, "window-style", style)
 	return err
 }
 
@@ -2717,11 +2720,15 @@ func (t *Tmux) SetDynamicStatus(session string) error {
 // ConfigureGasTownSession applies full Gas Town theming to a session.
 // This is a convenience method that applies theme, status format, dynamic status,
 // and pane background (window-style).
+//
+// Window background is controlled by theme.Window:
+//   - non-nil: apply Window's colors as the window background
+//   - nil: reset window background to terminal defaults (disabled)
 func (t *Tmux) ConfigureGasTownSession(session string, theme Theme, rig, worker, role string) error {
 	if err := t.ApplyTheme(session, theme); err != nil {
 		return fmt.Errorf("applying theme: %w", err)
 	}
-	if err := t.ApplyWindowStyle(session, theme); err != nil {
+	if err := t.ApplyWindowStyle(session, theme.Window); err != nil {
 		return fmt.Errorf("applying window style: %w", err)
 	}
 	if err := t.SetStatusFormat(session, rig, worker, role); err != nil {


### PR DESCRIPTION
## Summary

- **Adds configurable window background (tmux `window-style`) theming** that mirrors the existing status bar theme config system
- Default behavior is **OFF** — no window background coloring unless explicitly enabled via `theme.window_tint.enabled: true` in config
- When enabled with no specific theme, falls back to matching each session's status bar colors
- Resolution chain mirrors status bar: per-rig role → global role → per-rig → global → disabled (nil)

## Background

Commit `91e592d4` introduced `ApplyWindowStyle` which unconditionally applied status bar colors to the entire terminal window background. This was disruptive for users who prefer their terminal's default background.

This PR makes window tinting opt-in and fully configurable, using the same layered config system as status bar theming:

```json
{
  "theme": {
    "window_tint": {
      "enabled": true,
      "name": "ocean",
      "role_tints": {
        "witness": "rust",
        "refinery": "plum"
      }
    }
  }
}
```

## Changes

- **`tmux/theme.go`**: Add `WindowStyle` type, `Theme.Window` field
- **`tmux/tmux.go`**: Consolidate old `ApplyWindowStyle(Theme)` + `ApplyPaneStyle(*PaneStyle)` into single `ApplyWindowStyle(*WindowStyle)` — nil resets to terminal defaults, non-nil applies colors
- **`config/types.go`**: Add `WindowTint` config struct with `enabled`, `name`, `custom`, `role_tints` fields (JSON key: `window_tint`)
- **`session/window_tint.go`**: `ResolveWindowTint()` — 5-level resolution chain matching status bar theming. `IsWindowTintEnabled()` — checks if any config level enables window tinting
- **`cmd/theme.go`**: `gt theme apply` reads window tint config and applies/resets per session

## Design decisions

- **Zero caller changes**: `ConfigureGasTownSession` (10+ callers) passes `theme.Window` through — nil by default, so existing behavior is unchanged
- **Only `gt theme apply` reads config**: Session creation doesn't read window tint config; users opt in by running `gt theme apply` after configuring
- **Consolidated apply/reset**: Single `ApplyWindowStyle(*WindowStyle)` handles both set and reset (nil = `bg=default,fg=default`), avoiding branching logic at call sites

## Test plan

- [x] `gt theme apply --all` with `window_tint.enabled: true` — window backgrounds match status bar colors
- [x] `gt theme apply --all` with `window_tint.enabled: false` — window backgrounds reset to terminal defaults
- [x] `go test ./internal/tmux/ ./internal/session/ ./internal/config/ ./internal/cmd/` — all pass
- [ ] Verify per-rig role tint overrides work
- [ ] Verify custom color overrides work

🤖 Generated with [Claude Code](https://claude.com/claude-code)