### PR TITLE
fix(reaper): register --port flag on databases subcommand

### DIFF
--- a/internal/cmd/reaper.go
+++ b/internal/cmd/reaper.go
@@ -396,7 +396,7 @@ func init() {
 		}
 	}
 
-	for _, cmd := range []*cobra.Command{reaperScanCmd, reaperReapCmd, reaperPurgeCmd, reaperAutoCloseCmd, reaperRunCmd} {
+	for _, cmd := range []*cobra.Command{reaperScanCmd, reaperReapCmd, reaperPurgeCmd, reaperAutoCloseCmd, reaperRunCmd, reaperDatabasesCmd} {
 		cmd.Flags().StringVar(&reaperDB, "db", "", "Database name (required for single-db commands)")
 		cmd.Flags().StringVar(&reaperHost, "host", defaultHost, "Dolt server host (env: GT_DOLT_HOST)")
 		cmd.Flags().IntVar(&reaperPort, "port", defaultPort, "Dolt server port (env: GT_DOLT_PORT)")

--- a/internal/formula/formulas/mol-dog-reaper.formula.toml
+++ b/internal/formula/formulas/mol-dog-reaper.formula.toml
@@ -61,7 +61,7 @@ Discover databases and count candidates for each operation.
 
 **1. List databases to scan:**
 ```bash
-gt reaper databases --json
+gt reaper databases --port={{dolt_port}} --json
 ```
 Or use configured database list from {{databases}} variable.
 

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -23,10 +23,10 @@ var validDBName = regexp.MustCompile(`^[a-zA-Z0-9_]+$`)
 
 // DefaultDatabases is the static fallback list of known production databases.
 // Used only when SHOW DATABASES fails (server unreachable).
-// GH#2385: Removed legacy "gt" name — modern towns use "hq" (town beads) and
-// rig-specific names. The "gt" database no longer exists in most installations
-// and its presence in the fallback caused false "database not found" errors.
-var DefaultDatabases = []string{"hq", "bd"}
+// GH#2385: Removed legacy "gt" and "bd" names — modern towns use "hq" (town
+// beads) and rig-specific names. Those databases no longer exist in most
+// installations and their presence in the fallback caused phantom DB errors.
+var DefaultDatabases = []string{"hq"}
 
 // testPollutionPrefixes are database name prefixes created by tests.
 var testPollutionPrefixes = []string{"testdb_", "beads_t", "beads_pt", "doctest_"}


### PR DESCRIPTION
## Summary

- `gt reaper databases` was missing `--host`/`--port` flag registration, causing it to connect to port 0 instead of the actual Dolt port. This made it fall back to a hardcoded list containing phantom databases ("bd", "gt") that don't exist.
- Added `reaperDatabasesCmd` to the shared flag registration loop
- Updated the reaper formula to pass `--port={{dolt_port}}` to `gt reaper databases`
- Removed phantom "bd" from `DefaultDatabases` fallback

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/reaper/ -run TestDefaultDatabases` passes
- [ ] Verify `gt reaper databases` returns actual server databases after rebuild

🤖 Generated with [Claude Code](https://claude.com/claude-code)