### PR TITLE
fix: scan dolt_rebase.rebase_order as string to handle DECIMAL type

### DIFF
--- a/internal/cmd/dolt_rebase.go
+++ b/internal/cmd/dolt_rebase.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
+	"strconv"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
@@ -189,10 +191,18 @@ func runDoltRebase(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Rebase plan: %d commits\n", totalPlan)
 
 	// Calculate how many to squash: everything except first (must stay pick) and last N.
-	var minOrder, maxOrder int
-	if err := db.QueryRowContext(ctx, "SELECT MIN(rebase_order), MAX(rebase_order) FROM dolt_rebase").Scan(&minOrder, &maxOrder); err != nil {
+	// Dolt returns rebase_order as DECIMAL — the MySQL driver delivers it as
+	// []uint8 (e.g. "1.00") which cannot be scanned directly into int.
+	// Scan as string, parse to float, then truncate to int.
+	var minOrderStr, maxOrderStr string
+	if err := db.QueryRowContext(ctx, "SELECT MIN(rebase_order), MAX(rebase_order) FROM dolt_rebase").Scan(&minOrderStr, &maxOrderStr); err != nil {
 		rebaseAbortAndCleanup(db, baseBranch, workBranch)
 		return fmt.Errorf("getting rebase order range: %w", err)
+	}
+	minOrder, maxOrder, err := parseRebaseOrderRange(minOrderStr, maxOrderStr)
+	if err != nil {
+		rebaseAbortAndCleanup(db, baseBranch, workBranch)
+		return fmt.Errorf("parsing rebase order range: %w", err)
 	}
 
 	squashThreshold := maxOrder - doltRebaseKeepRecent
@@ -221,9 +231,13 @@ func runDoltRebase(cmd *cobra.Command, args []string) error {
 		defer rows.Close()
 
 		for rows.Next() {
-			var order int
+			var orderStr string
 			var action, hash, msg string
-			if err := rows.Scan(&order, &action, &hash, &msg); err != nil {
+			if err := rows.Scan(&orderStr, &action, &hash, &msg); err != nil {
+				continue
+			}
+			order, err := parseRebaseOrder(orderStr)
+			if err != nil {
 				continue
 			}
 			marker := "pick"
@@ -354,6 +368,29 @@ func rebaseAbortAndCleanup(db *sql.DB, baseBranch, workBranch string) {
 //nolint:unparam // baseBranch always "compact-base" — API kept flexible for future callers
 func rebaseCleanupAll(db *sql.DB, baseBranch, workBranch string) {
 	rebaseCleanup(db, baseBranch, workBranch)
+}
+
+// parseRebaseOrder converts a rebase_order value (returned by Dolt as DECIMAL
+// string, e.g. "1.00") to an int.
+func parseRebaseOrder(s string) (int, error) {
+	f, err := strconv.ParseFloat(s, 64)
+	if err != nil {
+		return 0, fmt.Errorf("invalid rebase_order %q: %w", s, err)
+	}
+	return int(math.Round(f)), nil
+}
+
+// parseRebaseOrderRange parses min/max rebase_order strings to ints.
+func parseRebaseOrderRange(minStr, maxStr string) (int, int, error) {
+	minVal, err := parseRebaseOrder(minStr)
+	if err != nil {
+		return 0, 0, err
+	}
+	maxVal, err := parseRebaseOrder(maxStr)
+	if err != nil {
+		return 0, 0, err
+	}
+	return minVal, maxVal, nil
 }
 
 // rebaseCleanupBase cleans up only the base branch (work branch not yet created).

--- a/internal/daemon/compactor_dog.go
+++ b/internal/daemon/compactor_dog.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"database/sql"
 	"fmt"
+	"math"
+	"strconv"
 	"strings"
 	"time"
 
@@ -444,10 +446,17 @@ func (d *Daemon) surgicalRebaseOnce(dbName string, keepRecent int) error {
 	d.logger.Printf("compactor_dog: %s: interactive rebase started", dbName)
 
 	// Step 4: Read rebase plan bounds and mark old commits as squash.
-	var minOrder, maxOrder int
-	if err := db.QueryRowContext(ctx, "SELECT MIN(rebase_order), MAX(rebase_order) FROM dolt_rebase").Scan(&minOrder, &maxOrder); err != nil {
+	// Dolt returns rebase_order as DECIMAL — the MySQL driver delivers it as
+	// []uint8 (e.g. "1.00") which cannot be scanned directly into int.
+	var minOrderStr, maxOrderStr string
+	if err := db.QueryRowContext(ctx, "SELECT MIN(rebase_order), MAX(rebase_order) FROM dolt_rebase").Scan(&minOrderStr, &maxOrderStr); err != nil {
 		d.surgicalAbortAndCleanup(db, baseBranch, workBranch)
 		return fmt.Errorf("read rebase bounds: %w", err)
+	}
+	minOrder, maxOrder, err := parseRebaseOrder2(minOrderStr, maxOrderStr)
+	if err != nil {
+		d.surgicalAbortAndCleanup(db, baseBranch, workBranch)
+		return fmt.Errorf("parse rebase bounds: %w", err)
 	}
 
 	squashThreshold := maxOrder - keepRecent
@@ -544,6 +553,21 @@ func (d *Daemon) surgicalAbortAndCleanup(db *sql.DB, baseBranch, workBranch stri
 	_, _ = db.ExecContext(ctx, "CALL DOLT_CHECKOUT('main')")
 	_, _ = db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_BRANCH('-D', '%s')", workBranch))
 	_, _ = db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_BRANCH('-D', '%s')", baseBranch))
+}
+
+// parseRebaseOrder2 parses min/max rebase_order DECIMAL strings to ints.
+// Dolt's dolt_rebase table returns rebase_order as DECIMAL which the MySQL
+// driver delivers as []uint8 (e.g. "1.00"), not directly scannable to int.
+func parseRebaseOrder2(minStr, maxStr string) (int, int, error) {
+	minF, err := strconv.ParseFloat(minStr, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid min rebase_order %q: %w", minStr, err)
+	}
+	maxF, err := strconv.ParseFloat(maxStr, 64)
+	if err != nil {
+		return 0, 0, fmt.Errorf("invalid max rebase_order %q: %w", maxStr, err)
+	}
+	return int(math.Round(minF)), int(math.Round(maxF)), nil
 }
 
 // surgicalCleanupBase removes only the base branch (work branch not yet created).


### PR DESCRIPTION
## Summary

- **Bug**: `gt dolt rebase` fails with `sql: Scan error on column index 0, name MIN(rebase_order): converting driver.Value type []uint8 (1.00) to a int: invalid syntax`
- **Root cause**: Dolt's `dolt_rebase` system table returns `rebase_order` as a `DECIMAL` column. The `go-sql-driver/mysql` driver delivers DECIMAL values as `[]uint8` byte strings (e.g. `"1.00"`), which cannot be directly scanned into Go `int` variables.
- **Fix**: Scan `rebase_order` into `string`, parse via `strconv.ParseFloat`, then `math.Round` to `int`. Applied to both the CLI command (`dolt_rebase.go`) and daemon (`compactor_dog.go`).

## Test plan

- [ ] Verify `go build ./...` passes (confirmed locally)
- [ ] Run `gt dolt rebase <db> --dry-run` against a database with >50 commits — should show the rebase plan without the scan error
- [ ] Run `gt dolt rebase <db> --yes-i-am-sure` on a test database — should complete surgical compaction successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)