### PR TITLE
fix(tests): prevent Windows pipe deadlock in prime_test stdout capture

### DIFF
--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -16,6 +16,34 @@ import (
 	"github.com/steveyegge/gastown/internal/constants"
 )
 
+// captureStdout redirects os.Stdout to a pipe, calls fn, then returns whatever
+// fn wrote. Reading happens in a goroutine so the pipe buffer cannot deadlock
+// even when fn produces more output than the OS pipe buffer (4 KB on Windows).
+func captureStdout(t *testing.T, fn func()) string {
+	t.Helper()
+	oldStdout := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe: %v", err)
+	}
+	os.Stdout = w
+
+	// Drain the read side concurrently so writes never block.
+	var buf bytes.Buffer
+	done := make(chan struct{})
+	go func() {
+		io.Copy(&buf, r)
+		close(done)
+	}()
+
+	fn()
+
+	w.Close()
+	<-done
+	os.Stdout = oldStdout
+	return buf.String()
+}
+
 func writeTestRoutes(t *testing.T, townRoot string, routes []beads.Route) {
 	t.Helper()
 	beadsDir := filepath.Join(townRoot, ".beads")
@@ -186,24 +214,15 @@ func TestCheckHandoffMarkerDryRun(t *testing.T) {
 		t.Fatalf("write handoff marker: %v", err)
 	}
 
-	// Capture stdout to verify explain output
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
 	// Enable explain mode for this test
 	oldExplain := primeExplain
 	primeExplain = true
 	defer func() { primeExplain = oldExplain }()
 
-	// Call dry-run version
-	checkHandoffMarkerDryRun(workDir)
-
-	w.Close()
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
-	os.Stdout = oldStdout
-	output := buf.String()
+	// Capture stdout to verify explain output
+	output := captureStdout(t, func() {
+		checkHandoffMarkerDryRun(workDir)
+	})
 
 	// Verify marker still exists (not removed in dry-run)
 	if _, err := os.Stat(markerPath); os.IsNotExist(err) {
@@ -235,24 +254,15 @@ func TestCheckHandoffMarkerDryRun_NoMarker(t *testing.T) {
 		t.Fatalf("create runtime dir: %v", err)
 	}
 
-	// Capture stdout
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
 	// Enable explain mode
 	oldExplain := primeExplain
 	primeExplain = true
 	defer func() { primeExplain = oldExplain }()
 
 	// Should not panic when marker doesn't exist
-	checkHandoffMarkerDryRun(workDir)
-
-	w.Close()
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
-	os.Stdout = oldStdout
-	output := buf.String()
+	output := captureStdout(t, func() {
+		checkHandoffMarkerDryRun(workDir)
+	})
 
 	// Verify explain output indicates no marker
 	if !strings.Contains(output, "no handoff marker") {
@@ -445,18 +455,9 @@ func TestOutputState(t *testing.T) {
 			WorkDir: workDir,
 		}
 
-		// Capture stdout
-		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-
-		outputState(ctx, false)
-
-		w.Close()
-		var buf bytes.Buffer
-		io.Copy(&buf, r)
-		os.Stdout = oldStdout
-		output := buf.String()
+		output := captureStdout(t, func() {
+			outputState(ctx, false)
+		})
 
 		if !strings.Contains(output, "state: normal") {
 			t.Fatalf("expected 'state: normal' in output, got: %s", output)
@@ -475,18 +476,9 @@ func TestOutputState(t *testing.T) {
 			WorkDir: workDir,
 		}
 
-		// Capture stdout
-		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-
-		outputState(ctx, true)
-
-		w.Close()
-		var buf bytes.Buffer
-		io.Copy(&buf, r)
-		os.Stdout = oldStdout
-		output := buf.String()
+		output := captureStdout(t, func() {
+			outputState(ctx, true)
+		})
 
 		// Parse JSON output
 		var state SessionState
@@ -523,18 +515,9 @@ func TestOutputState(t *testing.T) {
 			WorkDir: workDir,
 		}
 
-		// Capture stdout
-		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-
-		outputState(ctx, true)
-
-		w.Close()
-		var buf bytes.Buffer
-		io.Copy(&buf, r)
-		os.Stdout = oldStdout
-		output := buf.String()
+		output := captureStdout(t, func() {
+			outputState(ctx, true)
+		})
 
 		// Parse JSON
 		var state SessionState
@@ -554,23 +537,14 @@ func TestOutputState(t *testing.T) {
 // TestExplain tests the explain function output.
 func TestExplain(t *testing.T) {
 	t.Run("explain_enabled_condition_true", func(t *testing.T) {
-		// Capture stdout
-		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-
 		// Enable explain mode
 		oldExplain := primeExplain
 		primeExplain = true
 		defer func() { primeExplain = oldExplain }()
 
-		explain(true, "This is a test explanation")
-
-		w.Close()
-		var buf bytes.Buffer
-		io.Copy(&buf, r)
-		os.Stdout = oldStdout
-		output := buf.String()
+		output := captureStdout(t, func() {
+			explain(true, "This is a test explanation")
+		})
 
 		if !strings.Contains(output, "[EXPLAIN]") {
 			t.Fatalf("expected [EXPLAIN] tag in output, got: %s", output)
@@ -581,23 +555,14 @@ func TestExplain(t *testing.T) {
 	})
 
 	t.Run("explain_enabled_condition_false", func(t *testing.T) {
-		// Capture stdout
-		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-
 		// Enable explain mode
 		oldExplain := primeExplain
 		primeExplain = true
 		defer func() { primeExplain = oldExplain }()
 
-		explain(false, "This should not appear")
-
-		w.Close()
-		var buf bytes.Buffer
-		io.Copy(&buf, r)
-		os.Stdout = oldStdout
-		output := buf.String()
+		output := captureStdout(t, func() {
+			explain(false, "This should not appear")
+		})
 
 		if strings.Contains(output, "[EXPLAIN]") {
 			t.Fatalf("expected no [EXPLAIN] tag when condition is false, got: %s", output)
@@ -605,23 +570,14 @@ func TestExplain(t *testing.T) {
 	})
 
 	t.Run("explain_disabled", func(t *testing.T) {
-		// Capture stdout
-		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-
 		// Disable explain mode
 		oldExplain := primeExplain
 		primeExplain = false
 		defer func() { primeExplain = oldExplain }()
 
-		explain(true, "This should not appear either")
-
-		w.Close()
-		var buf bytes.Buffer
-		io.Copy(&buf, r)
-		os.Stdout = oldStdout
-		output := buf.String()
+		output := captureStdout(t, func() {
+			explain(true, "This should not appear either")
+		})
 
 		if strings.Contains(output, "[EXPLAIN]") {
 			t.Fatalf("expected no [EXPLAIN] tag when explain mode disabled, got: %s", output)
@@ -830,14 +786,9 @@ func TestCheckHandoffMarkerParsesReason(t *testing.T) {
 		}
 
 		// Capture stdout (checkHandoffMarker outputs the warning)
-		oldStdout := os.Stdout
-		_, w, _ := os.Pipe()
-		os.Stdout = w
-
-		checkHandoffMarker(workDir)
-
-		w.Close()
-		os.Stdout = oldStdout
+		captureStdout(t, func() {
+			checkHandoffMarker(workDir)
+		})
 
 		// Verify reason was parsed
 		if primeHandoffReason != "compaction" {
@@ -865,14 +816,9 @@ func TestCheckHandoffMarkerParsesReason(t *testing.T) {
 			t.Fatalf("write marker: %v", err)
 		}
 
-		oldStdout := os.Stdout
-		_, w, _ := os.Pipe()
-		os.Stdout = w
-
-		checkHandoffMarker(workDir)
-
-		w.Close()
-		os.Stdout = oldStdout
+		captureStdout(t, func() {
+			checkHandoffMarker(workDir)
+		})
 
 		// Verify reason is empty (backward compatible)
 		if primeHandoffReason != "" {
@@ -897,21 +843,13 @@ func TestCheckHandoffMarkerParsesReason(t *testing.T) {
 // outputs the expected content without the full autonomous mode block (GH#1965).
 func TestOutputContinuationDirective(t *testing.T) {
 	t.Run("basic_bead", func(t *testing.T) {
-		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-
 		bead := &beads.Issue{
 			ID:    "gt-test123",
 			Title: "Test bead title",
 		}
-		outputContinuationDirective(bead, false)
-
-		w.Close()
-		var buf bytes.Buffer
-		io.Copy(&buf, r)
-		os.Stdout = oldStdout
-		output := buf.String()
+		output := captureStdout(t, func() {
+			outputContinuationDirective(bead, false)
+		})
 
 		// Should contain continuation directive
 		if !strings.Contains(output, "CONTINUE HOOKED WORK") {
@@ -931,21 +869,13 @@ func TestOutputContinuationDirective(t *testing.T) {
 	})
 
 	t.Run("bead_with_molecule", func(t *testing.T) {
-		oldStdout := os.Stdout
-		r, w, _ := os.Pipe()
-		os.Stdout = w
-
 		bead := &beads.Issue{
 			ID:    "gt-mol456",
 			Title: "Molecule bead",
 		}
-		outputContinuationDirective(bead, true)
-
-		w.Close()
-		var buf bytes.Buffer
-		io.Copy(&buf, r)
-		os.Stdout = oldStdout
-		output := buf.String()
+		output := captureStdout(t, func() {
+			outputContinuationDirective(bead, true)
+		})
 
 		if !strings.Contains(output, "bd mol current") {
 			t.Fatalf("expected molecule hint in output, got: %s", output)
@@ -964,17 +894,10 @@ func TestCheckSlungWork_StandaloneFormulaUsesWorkflowOutput(t *testing.T) {
 		}, "\n"),
 	}
 
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
-	found := checkSlungWork(ctx, hookedBead)
-
-	w.Close()
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
-	os.Stdout = oldStdout
-	output := buf.String()
+	var found bool
+	output := captureStdout(t, func() {
+		found = checkSlungWork(ctx, hookedBead)
+	})
 
 	if !found {
 		t.Fatalf("checkSlungWork() = false, want true")
@@ -995,22 +918,14 @@ func TestCheckSlungWork_StandaloneFormulaUsesWorkflowOutput(t *testing.T) {
 // the polecats-no-gt-done bug: after long work sessions, compaction drops the
 // formula checklist and the agent forgets to call gt done.
 func TestCompactResumeReminder_PolecatGetsGtDone(t *testing.T) {
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
 	ctx := RoleContext{Role: RolePolecat}
 	// Simulate compact source
 	primeHookSource = "compact"
 	defer func() { primeHookSource = "" }()
 
-	runPrimeCompactResume(ctx)
-
-	w.Close()
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
-	os.Stdout = oldStdout
-	output := buf.String()
+	output := captureStdout(t, func() {
+		runPrimeCompactResume(ctx)
+	})
 
 	if !strings.Contains(output, "gt done") {
 		t.Fatalf("compact/resume for polecat must remind about gt done, got:\n%s", output)
@@ -1020,21 +935,13 @@ func TestCompactResumeReminder_PolecatGetsGtDone(t *testing.T) {
 // TestCompactResumeReminder_NonPolecatNoGtDone verifies that non-polecat roles
 // do NOT get the gt done reminder (it's polecat-specific).
 func TestCompactResumeReminder_NonPolecatNoGtDone(t *testing.T) {
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
 	ctx := RoleContext{Role: RoleCrew}
 	primeHookSource = "compact"
 	defer func() { primeHookSource = "" }()
 
-	runPrimeCompactResume(ctx)
-
-	w.Close()
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
-	os.Stdout = oldStdout
-	output := buf.String()
+	output := captureStdout(t, func() {
+		runPrimeCompactResume(ctx)
+	})
 
 	if strings.Contains(output, "gt done") {
 		t.Fatalf("compact/resume for non-polecat should NOT mention gt done, got:\n%s", output)
@@ -1047,21 +954,13 @@ func TestCompactResumeReminder_NonPolecatNoGtDone(t *testing.T) {
 // dies-on-spawn bug: polecats died immediately because Claude tried to run
 // /ralph-loop which didn't exist as a provisioned slash command.
 func TestOutputRalphLoopDirective_NoSlashCommand(t *testing.T) {
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
 	attachment := &beads.AttachmentFields{
 		Mode:         "ralph",
 		AttachedArgs: "Run story audit, fix worst gap, commit, loop",
 	}
-	outputRalphLoopDirective(RoleContext{}, attachment)
-
-	w.Close()
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
-	os.Stdout = oldStdout
-	output := buf.String()
+	output := captureStdout(t, func() {
+		outputRalphLoopDirective(RoleContext{}, attachment)
+	})
 
 	// Must NOT reference /ralph-loop (nonexistent slash command)
 	if strings.Contains(output, "/ralph-loop") {
@@ -1088,22 +987,14 @@ func TestOutputRalphLoopDirective_NoSlashCommand(t *testing.T) {
 // TestOutputRalphLoopDirective_WithFormula verifies that ralph mode shows
 // formula steps inline (same as normal mode) when a formula is attached.
 func TestOutputRalphLoopDirective_WithFormula(t *testing.T) {
-	oldStdout := os.Stdout
-	r, w, _ := os.Pipe()
-	os.Stdout = w
-
 	attachment := &beads.AttachmentFields{
 		Mode:            "ralph",
 		AttachedFormula: "mol-polecat-work",
 		FormulaVars:     "base_branch=main",
 	}
-	outputRalphLoopDirective(RoleContext{}, attachment)
-
-	w.Close()
-	var buf bytes.Buffer
-	io.Copy(&buf, r)
-	os.Stdout = oldStdout
-	output := buf.String()
+	output := captureStdout(t, func() {
+		outputRalphLoopDirective(RoleContext{}, attachment)
+	})
 
 	// Should NOT reference /ralph-loop
 	if strings.Contains(output, "/ralph-loop") {

--- a/internal/cmd/status_test.go
+++ b/internal/cmd/status_test.go
@@ -13,29 +13,6 @@ import (
 	"github.com/steveyegge/gastown/internal/rig"
 )
 
-func captureStdout(t *testing.T, fn func()) string {
-	t.Helper()
-	old := os.Stdout
-	r, w, err := os.Pipe()
-	if err != nil {
-		t.Fatalf("create pipe: %v", err)
-	}
-	os.Stdout = w
-
-	fn()
-
-	_ = w.Close()
-	os.Stdout = old
-
-	var buf bytes.Buffer
-	if _, err := io.Copy(&buf, r); err != nil {
-		t.Fatalf("read stdout: %v", err)
-	}
-	_ = r.Close()
-
-	return buf.String()
-}
-
 func captureStderr(t *testing.T, fn func()) string {
 	t.Helper()
 	old := os.Stderr


### PR DESCRIPTION
## Summary
- Replace 17 manual `os.Pipe` stdout capture blocks with a concurrent `captureStdout(t, func())` helper
- The old pattern wrote to the pipe synchronously then read after `Close()` — deadlocks on Windows where pipe buffers are ~4KB (vs 64KB on Linux)
- The 22KB `mol-polecat-work` formula output filled the buffer, blocking `TestOutputRalphLoopDirective_WithFormula` for 8m48s until the 10m test timeout killed the entire test suite (taking 6 unrelated PAUSEd tests with it)
- Also removes a duplicate `captureStdout` from `status_test.go`

## Test plan
- [x] All 17 affected tests pass locally
- [x] `go build ./...` clean
- [ ] Windows CI should pass (was failing on every PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)