### PR TITLE
fix: use --no-history instead of --ephemeral for agent identity beads

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -221,7 +221,7 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 			"--description=" + description,
 			"--type=agent",
 			"--labels=gt:agent",
-			"--ephemeral",
+			"--no-history",
 		}
 		if NeedsForceForID(id) {
 			a = append(a, "--force")
@@ -234,8 +234,9 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 		return a
 	}
 
-	// Create ephemeral agent bead (wisps table). Agent operational state has
-	// zero git history consumers (gt-bewatn.9).
+	// Create agent bead in the issues table with --no-history to skip
+	// git commit overhead. Agent beads are durable identities that must
+	// survive wisp GC (GH#2768).
 	out, err := b.run(buildArgs()...)
 	if err != nil {
 		out, err = b.run(buildArgs()...)
@@ -344,10 +345,10 @@ func (b *Beads) CreateOrReopenAgentBead(id, title string, fields *AgentFields) (
 	if _, err := target.run("update", id, "--type=agent"); err != nil {
 		return nil, fmt.Errorf("fixing agent bead type: %w", err)
 	}
-	// Ensure agent bead is ephemeral (wisp) — agent operational state has
-	// zero git history consumers (gt-bewatn.9)
-	if _, err := target.run("update", id, "--ephemeral"); err != nil {
-		// Non-fatal: the bead is functional without ephemeral flag
+	// Ensure agent bead uses --no-history to skip git commit overhead
+	// without making it a wisp (GH#2768: wisps get GC'd, killing agent identities)
+	if _, err := target.run("update", id, "--no-history"); err != nil {
+		// Non-fatal: the bead is functional without --no-history flag
 		_ = err
 	}
 

--- a/internal/doctor/agent_beads_check.go
+++ b/internal/doctor/agent_beads_check.go
@@ -240,9 +240,8 @@ func (c *AgentBeadsCheck) Fix(ctx *CheckContext) error {
 	//   2. If in wisps table (open) → ensure gt:agent label
 	//   3. If exists but closed → REOPEN it (don't recreate)
 	//   4. If truly missing → CREATE it
-	// Uses CreateAgentBead which tries --ephemeral first and falls back to
-	// non-ephemeral if the subprocess crashes (GH#1769: Dolt nil pointer
-	// dereference when wisps table doesn't exist on fresh rigs).
+	// Uses CreateAgentBead which creates agent beads with --no-history
+	// (durable issues, not wisps) so they survive wisp GC (GH#2768).
 	// workDir is the rig directory for direct SQL fallback when bd update
 	// fails silently (e.g., legacy prefixes that can't be routed — GH#2127).
 	fixAgentBead := func(bd *beads.Beads, workDir, id, desc string, fields *beads.AgentFields) error {


### PR DESCRIPTION
## Summary

- Agent identity beads were created as ephemeral wisps (`--ephemeral`), making them eligible for routine wisp GC — causing `gt doctor` to repeatedly report missing agent beads (`agent-beads-exist` failures)
- Switch to `--no-history` so agent beads are durable issues that survive wisp GC while still skipping git commit overhead
- Updates both `CreateAgentBead` (new bead creation) and `CreateOrReopenAgentBead` (re-spawn path)

## Test plan

- [x] `go build ./internal/beads/` — compiles cleanly
- [x] `go build ./internal/doctor/` — compiles cleanly
- [x] `go test ./internal/doctor/ -run TestAgentBeads` — all 3 tests pass
- [ ] Verify `gt doctor` no longer reports `agent-beads-exist` failures after 24h of normal operation
- [ ] Verify agent beads survive wisp GC patrol cycles

Fixes #2768

🤖 Generated with [Claude Code](https://claude.com/claude-code)