### PR TITLE
feat: add pre-merge validation checks to refinery

### DIFF
--- a/docs/examples/rig-settings.example.json
+++ b/docs/examples/rig-settings.example.json
@@ -37,6 +37,10 @@
         "lint_command": "golangci-lint run",
         "setup_command": "",
         "typecheck_command": "",
+        "pre_merge_checks": {
+            "build": {"cmd": "go build ./...", "timeout": "2m"},
+            "imports": {"cmd": "go vet ./...", "timeout": "1m"}
+        },
         "delete_merged_branches": true,
         "retry_flaky_tests": 1,
         "poll_interval": "30s",

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -124,6 +124,13 @@ type MergeQueueConfig struct {
 	// before escalation to Mayor.
 	MaxRetryCount int `json:"max_retry_count"`
 
+	// PreMergeChecks defines commands to run on the merged result before pushing.
+	// Unlike Gates (which run before merge on the target branch), PreMergeChecks
+	// validate the actual squash-merged code. This catches issues like broken
+	// imports, boot failures, and missing templates that only manifest in the
+	// combined result. Each check uses the same GateConfig format as Gates.
+	PreMergeChecks map[string]*GateConfig `json:"pre_merge_checks"`
+
 	// Batch holds configuration for the batch-then-bisect merge queue.
 	// When nil or MaxBatchSize <= 1, batching is disabled and MRs process sequentially.
 	Batch *BatchConfig `json:"batch,omitempty"`
@@ -298,6 +305,7 @@ func (e *Engineer) LoadConfig() error {
 		StaleClaimTimeout    *string                    `json:"stale_claim_timeout"`
 		Gates                map[string]*gateConfigRaw  `json:"gates"`
 		GatesParallel        *bool                      `json:"gates_parallel"`
+		PreMergeChecks       map[string]*gateConfigRaw  `json:"pre_merge_checks"`
 	}
 
 	if err := json.Unmarshal(rawConfig.MergeQueue, &mqRaw); err != nil {
@@ -366,6 +374,25 @@ func (e *Engineer) LoadConfig() error {
 		e.config.GatesParallel = *mqRaw.GatesParallel
 	}
 
+	// Parse pre-merge checks configuration
+	if mqRaw.PreMergeChecks != nil {
+		e.config.PreMergeChecks = make(map[string]*GateConfig, len(mqRaw.PreMergeChecks))
+		for name, raw := range mqRaw.PreMergeChecks {
+			gc := &GateConfig{Cmd: raw.Cmd}
+			if raw.Timeout != "" {
+				dur, err := time.ParseDuration(raw.Timeout)
+				if err != nil {
+					return fmt.Errorf("invalid timeout for pre_merge_check %q: %w", name, err)
+				}
+				if dur <= 0 {
+					return fmt.Errorf("pre_merge_check %q timeout must be positive, got %v", name, dur)
+				}
+				gc.Timeout = dur
+			}
+			e.config.PreMergeChecks[name] = gc
+		}
+	}
+
 	return nil
 }
 
@@ -383,13 +410,14 @@ func (e *Engineer) Config() *MergeQueueConfig {
 
 // ProcessResult contains the result of processing a merge request.
 type ProcessResult struct {
-	Success        bool
-	MergeCommit    string
-	Error          string
-	Conflict       bool
-	TestsFailed    bool
-	SlotTimeout    bool // Merge slot contention timeout (distinct from build/test failure)
-	BranchNotFound bool // Source branch no longer exists (e.g. cleaned up after cherry-pick)
+	Success             bool
+	MergeCommit         string
+	Error               string
+	Conflict            bool
+	TestsFailed         bool
+	PreMergeCheckFailed bool // Pre-merge validation failed on the merged result
+	SlotTimeout         bool // Merge slot contention timeout (distinct from build/test failure)
+	BranchNotFound      bool // Source branch no longer exists (e.g. cleaned up after cherry-pick)
 }
 
 // doMerge performs the actual git merge operation.
@@ -544,6 +572,20 @@ func (e *Engineer) doMerge(ctx context.Context, branch, target, sourceIssue stri
 		return ProcessResult{
 			Success: false,
 			Error:   fmt.Sprintf("merge failed: %v", err),
+		}
+	}
+
+	// Step 5.5: Run pre-merge checks on the merged result.
+	// These validate the actual combined code before it goes anywhere.
+	// If any check fails, reset the merge and reject.
+	if !shouldSkipGates && len(e.config.PreMergeChecks) > 0 {
+		pmResult := e.runPreMergeChecks(ctx)
+		if !pmResult.Success {
+			// Reset the target branch to undo the local squash commit
+			if resetErr := e.git.ResetHard("origin/" + target); resetErr != nil {
+				_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to reset %s after pre-merge check failure: %v\n", target, resetErr)
+			}
+			return pmResult
 		}
 	}
 
@@ -850,6 +892,45 @@ func (e *Engineer) runGates(ctx context.Context) ProcessResult {
 	return ProcessResult{Success: true}
 }
 
+// runPreMergeChecks executes configured pre-merge validation checks on the
+// merged result. These run after the squash merge but before pushing, so they
+// validate the actual combined code. Uses the same gate infrastructure as
+// quality gates. Checks always run sequentially since they validate a single
+// merged state and early termination on failure saves time.
+func (e *Engineer) runPreMergeChecks(ctx context.Context) ProcessResult {
+	checks := e.config.PreMergeChecks
+	if len(checks) == 0 {
+		return ProcessResult{Success: true}
+	}
+
+	// Sort check names for deterministic ordering
+	names := make([]string, 0, len(checks))
+	for name := range checks {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	_, _ = fmt.Fprintf(e.output, "[Engineer] Running %d pre-merge check(s) on merged result\n", len(names))
+
+	for _, name := range names {
+		_, _ = fmt.Fprintf(e.output, "[Engineer] Pre-merge check %q: starting (%s)\n", name, checks[name].Cmd)
+		result := e.runGate(ctx, name, checks[name])
+		if result.Success {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] Pre-merge check %q: passed (%v)\n", result.Name, result.Elapsed.Truncate(time.Millisecond))
+		} else {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] Pre-merge check %q: FAILED (%v) - %s\n", result.Name, result.Elapsed.Truncate(time.Millisecond), result.Error)
+			return ProcessResult{
+				Success:             false,
+				PreMergeCheckFailed: true,
+				Error:               fmt.Sprintf("pre-merge check %q failed: %s", name, result.Error),
+			}
+		}
+	}
+
+	_, _ = fmt.Fprintln(e.output, "[Engineer] All pre-merge checks passed")
+	return ProcessResult{Success: true}
+}
+
 // syncCrewWorkspaces pulls latest changes to all crew workspaces.
 // This ensures crew members have access to newly merged code without manual sync.
 func (e *Engineer) syncCrewWorkspaces() {
@@ -1050,6 +1131,8 @@ func (e *Engineer) HandleMRInfoFailure(mr *MRInfo, result ProcessResult) {
 	failureType := "build"
 	if result.Conflict {
 		failureType = "conflict"
+	} else if result.PreMergeCheckFailed {
+		failureType = "pre_merge_check"
 	} else if result.TestsFailed {
 		failureType = "tests"
 	}

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -839,3 +839,181 @@ func TestIsClaimStale(t *testing.T) {
 		})
 	}
 }
+
+func TestRunPreMergeChecks_AllPass(t *testing.T) {
+	r := &rig.Rig{Name: "test-rig", Path: t.TempDir()}
+	e := NewEngineer(r)
+	e.workDir = t.TempDir()
+	e.output = io.Discard
+	e.config.PreMergeChecks = map[string]*GateConfig{
+		"check-a": {Cmd: "true"},
+		"check-b": {Cmd: "true"},
+	}
+
+	result := e.runPreMergeChecks(context.Background())
+	if !result.Success {
+		t.Errorf("expected success, got error: %s", result.Error)
+	}
+}
+
+func TestRunPreMergeChecks_FailureStopsExecution(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("gate commands run via sh -c; touch with Windows paths breaks under MSYS2 shell")
+	}
+	r := &rig.Rig{Name: "test-rig", Path: t.TempDir()}
+	e := NewEngineer(r)
+	e.workDir = t.TempDir()
+	e.output = io.Discard
+
+	markerDir := t.TempDir()
+	e.config.PreMergeChecks = map[string]*GateConfig{
+		"a_pass": {Cmd: fmt.Sprintf("touch %s/a", markerDir)},
+		"b_fail": {Cmd: "exit 1"},
+		"c_skip": {Cmd: fmt.Sprintf("touch %s/c", markerDir)},
+	}
+
+	result := e.runPreMergeChecks(context.Background())
+	if result.Success {
+		t.Error("expected failure")
+	}
+	if !result.PreMergeCheckFailed {
+		t.Error("expected PreMergeCheckFailed to be true")
+	}
+	if !strings.Contains(result.Error, "b_fail") {
+		t.Errorf("expected error to mention 'b_fail', got: %s", result.Error)
+	}
+
+	// Gate "a_pass" should have run
+	if _, err := os.Stat(filepath.Join(markerDir, "a")); os.IsNotExist(err) {
+		t.Error("check 'a_pass' should have run")
+	}
+	// Gate "c_skip" should NOT have run (stopped after b_fail)
+	if _, err := os.Stat(filepath.Join(markerDir, "c")); !os.IsNotExist(err) {
+		t.Error("check 'c_skip' should not have run after failure")
+	}
+}
+
+func TestRunPreMergeChecks_Empty(t *testing.T) {
+	r := &rig.Rig{Name: "test-rig", Path: t.TempDir()}
+	e := NewEngineer(r)
+	e.workDir = t.TempDir()
+	e.output = io.Discard
+	e.config.PreMergeChecks = nil
+
+	result := e.runPreMergeChecks(context.Background())
+	if !result.Success {
+		t.Error("expected success with no pre-merge checks configured")
+	}
+}
+
+func TestRunPreMergeChecks_WithTimeout(t *testing.T) {
+	r := &rig.Rig{Name: "test-rig", Path: t.TempDir()}
+	e := NewEngineer(r)
+	e.workDir = t.TempDir()
+	e.output = io.Discard
+	e.config.PreMergeChecks = map[string]*GateConfig{
+		"slow": {Cmd: "sleep 10", Timeout: 100 * time.Millisecond},
+	}
+
+	result := e.runPreMergeChecks(context.Background())
+	if result.Success {
+		t.Error("expected timeout failure")
+	}
+	if !result.PreMergeCheckFailed {
+		t.Error("expected PreMergeCheckFailed to be true")
+	}
+	if !strings.Contains(result.Error, "timed out") {
+		t.Errorf("expected timeout error, got: %s", result.Error)
+	}
+}
+
+func TestEngineer_LoadConfig_WithPreMergeChecks(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "engineer-premerge-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	config := map[string]interface{}{
+		"merge_queue": map[string]interface{}{
+			"pre_merge_checks": map[string]interface{}{
+				"boot": map[string]interface{}{
+					"cmd":     "python -c 'from app import create_app; create_app()'",
+					"timeout": "30s",
+				},
+				"imports": map[string]interface{}{
+					"cmd": "python -m compileall src/",
+				},
+			},
+		},
+	}
+
+	data, _ := json.MarshalIndent(config, "", "  ")
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &rig.Rig{Name: "test-rig", Path: tmpDir}
+	e := NewEngineer(r)
+
+	if err := e.LoadConfig(); err != nil {
+		t.Fatalf("unexpected error loading config: %v", err)
+	}
+
+	if len(e.config.PreMergeChecks) != 2 {
+		t.Fatalf("expected 2 pre-merge checks, got %d", len(e.config.PreMergeChecks))
+	}
+	if e.config.PreMergeChecks["boot"].Cmd != "python -c 'from app import create_app; create_app()'" {
+		t.Errorf("expected boot check cmd, got %q", e.config.PreMergeChecks["boot"].Cmd)
+	}
+	if e.config.PreMergeChecks["boot"].Timeout != 30*time.Second {
+		t.Errorf("expected boot timeout 30s, got %v", e.config.PreMergeChecks["boot"].Timeout)
+	}
+	if e.config.PreMergeChecks["imports"].Timeout != 0 {
+		t.Errorf("expected imports timeout 0 (no timeout), got %v", e.config.PreMergeChecks["imports"].Timeout)
+	}
+}
+
+func TestEngineer_LoadConfig_PreMergeCheckInvalidTimeout(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "engineer-premerge-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	tests := []struct {
+		name    string
+		timeout string
+	}{
+		{"not a duration", "not-a-duration"},
+		{"negative", "-5m"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			config := map[string]interface{}{
+				"merge_queue": map[string]interface{}{
+					"pre_merge_checks": map[string]interface{}{
+						"bad": map[string]interface{}{
+							"cmd":     "echo test",
+							"timeout": tt.timeout,
+						},
+					},
+				},
+			}
+
+			data, _ := json.MarshalIndent(config, "", "  ")
+			if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
+				t.Fatal(err)
+			}
+
+			r := &rig.Rig{Name: "test-rig", Path: tmpDir}
+			e := NewEngineer(r)
+
+			err := e.LoadConfig()
+			if err == nil {
+				t.Errorf("expected error for pre_merge_check timeout %q", tt.timeout)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Add configurable `pre_merge_checks` that run on the squash-merged result **before** pushing to origin, catching broken code that only manifests in the combined result (boot failures, import errors, missing templates)
- Reuses existing `GateConfig` format and `runGate()` infrastructure — checks run sequentially with per-check timeouts
- On failure, resets the merge and reports `pre_merge_check` failure type to the polecat for targeted fixing

## What this catches
The failures mentioned in gt-cng that would have been caught:
- `st-7ip`: ModuleNotFoundError (wrong modules in wrong repo)
- `ytb-red`: Wrong repo modification
- PR #183: Duplicate blueprint registration ValueError

## Configuration
```json
"merge_queue": {
    "pre_merge_checks": {
        "boot": {"cmd": "python -c 'from app import create_app; create_app()'", "timeout": "30s"},
        "imports": {"cmd": "python -m compileall src/", "timeout": "1m"},
        "templates": {"cmd": "./scripts/check_templates.sh", "timeout": "30s"}
    }
}
```

## Test plan
- [x] TestRunPreMergeChecks_AllPass — all checks pass
- [x] TestRunPreMergeChecks_FailureStopsExecution — sequential early termination
- [x] TestRunPreMergeChecks_Empty — no checks configured = success
- [x] TestRunPreMergeChecks_WithTimeout — per-check timeout enforcement
- [x] TestEngineer_LoadConfig_WithPreMergeChecks — config parsing
- [x] TestEngineer_LoadConfig_PreMergeCheckInvalidTimeout — validation
- [ ] CI build validation

🤖 Generated with [Claude Code](https://claude.com/claude-code)