### PR TITLE
fix(beads): route cross-rig agent bead creation from town root

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -212,6 +212,15 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 	// Don't bail out — try the bd create calls anyway (GH#1769).
 	_ = EnsureCustomTypes(targetDir)
 
+	// For routed cross-rig bead IDs, run bd from the town root so bd's own
+	// prefix router resolves the target once. Running from a rig worktree with
+	// a routed BEADS_DIR can double-stack the path for imported rigs.
+	target := b
+	townRoot := b.getTownRoot()
+	if townRoot != "" && ExtractPrefix(id) != "" {
+		target = NewWithBeadsDir(townRoot, filepath.Join(townRoot, ".beads"))
+	}
+
 	description := FormatAgentDescription(title, fields)
 
 	buildArgs := func() []string {
@@ -228,7 +237,7 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 		}
 		// Default actor from BD_ACTOR env var for provenance tracking
 		// Uses getActor() to respect isolated mode (tests)
-		if actor := b.getActor(); actor != "" {
+		if actor := target.getActor(); actor != "" {
 			a = append(a, "--actor="+actor)
 		}
 		return a
@@ -237,9 +246,9 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 	// Create agent bead in the issues table with --no-history to skip
 	// git commit overhead. Agent beads are durable identities that must
 	// survive wisp GC (GH#2768).
-	out, err := b.run(buildArgs()...)
+	out, err := target.run(buildArgs()...)
 	if err != nil {
-		out, err = b.run(buildArgs()...)
+		out, err = target.run(buildArgs()...)
 		if err != nil {
 			// Both bd create attempts failed. Dolt server is required —
 			// no JSONL fallback. Surface the error directly.
@@ -259,7 +268,7 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 	// The fallback query (status=hooked + assignee) is unreliable for
 	// cross-database scenarios. Restoring per hq-gfg.
 	if fields != nil && fields.HookBead != "" {
-		if _, slotErr := b.run("slot", "set", id, "hook", fields.HookBead); slotErr != nil {
+		if _, slotErr := target.run("slot", "set", id, "hook", fields.HookBead); slotErr != nil {
 			// Non-fatal: fallback query may still find the work bead
 		}
 	}

--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -1,9 +1,11 @@
 package beads
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -210,4 +212,118 @@ func TestMergeAgentBeadSources(t *testing.T) {
 			t.Fatalf("len(merged) = %d, want 0", len(merged))
 		}
 	})
+}
+
+func installMockBDCreateRecorder(t *testing.T, logPath string) {
+	t.Helper()
+
+	binDir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Skip("cross-rig create recorder test not implemented on Windows")
+	}
+
+	script := `#!/bin/sh
+printf 'pwd=%s\n' "$(pwd)" >> "$MOCK_BD_LOG"
+printf 'beads_dir=%s\n' "$BEADS_DIR" >> "$MOCK_BD_LOG"
+printf 'args=%s\n' "$*" >> "$MOCK_BD_LOG"
+
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+
+case "$cmd" in
+  create)
+    printf '{"id":"pt-imported-polecat-shiny","title":"shiny","status":"open"}\n'
+    exit 0
+    ;;
+  slot|config|migrate|init|show|update)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	scriptPath := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write mock bd: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("MOCK_BD_LOG", logPath)
+}
+
+func TestCreateAgentBead_UsesTownRootForCrossRigRoutes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("path assertions are Unix-oriented")
+	}
+
+	townRoot := t.TempDir()
+	for _, dir := range []string{
+		filepath.Join(townRoot, "mayor"),
+		filepath.Join(townRoot, ".beads"),
+		filepath.Join(townRoot, "imported", "mayor", "rig", ".beads"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte("{\"prefix\":\"pt-\",\"path\":\"imported/mayor/rig\"}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	logPath := filepath.Join(townRoot, "bd.log")
+	installMockBDCreateRecorder(t, logPath)
+
+	workerDir := filepath.Join(townRoot, "imported", "mayor", "rig")
+	bd := NewWithBeadsDir(workerDir, filepath.Join(workerDir, ".beads"))
+
+	issue, err := bd.CreateAgentBead("pt-imported-polecat-shiny", "shiny", &AgentFields{
+		RoleType:   "polecat",
+		Rig:        "imported",
+		AgentState: "spawning",
+		HookBead:   "pt-task-1",
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentBead: %v", err)
+	}
+	if issue == nil {
+		t.Fatal("CreateAgentBead returned nil issue")
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read mock bd log: %v", err)
+	}
+	logOutput := string(logData)
+	if !strings.Contains(logOutput, "pwd="+townRoot) {
+		t.Fatalf("mock bd log missing town root cwd:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "beads_dir="+filepath.Join(townRoot, ".beads")) {
+		t.Fatalf("mock bd log missing town-root BEADS_DIR:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "create --json --id=pt-imported-polecat-shiny") {
+		t.Fatalf("mock bd log missing create call:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "slot set pt-imported-polecat-shiny hook pt-task-1") {
+		t.Fatalf("mock bd log missing slot set call:\n%s", logOutput)
+	}
+}
+
+func TestCreateAgentBead_ParsesMockCreateOutput(t *testing.T) {
+	raw := []byte(`{"id":"pt-imported-polecat-shiny","title":"shiny","status":"open"}`)
+	var issue Issue
+	if err := json.Unmarshal(raw, &issue); err != nil {
+		t.Fatalf("json.Unmarshal: %v", err)
+	}
+	if issue.ID != "pt-imported-polecat-shiny" {
+		t.Fatalf("issue.ID = %q", issue.ID)
+	}
 }

--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -35,18 +35,20 @@ var (
 // The town root is identified by the presence of mayor/town.json.
 // Returns empty string if not found (reached filesystem root).
 func FindTownRoot(startDir string) string {
+	var found string
 	dir := startDir
 	for {
 		townFile := filepath.Join(dir, "mayor", "town.json")
 		if _, err := os.Stat(townFile); err == nil {
-			return dir
+			found = dir
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return "" // Reached filesystem root
+			break // Reached filesystem root
 		}
 		dir = parent
 	}
+	return found
 }
 
 // ResolveRoutingTarget determines which beads directory a bead ID will route to.

--- a/internal/beads/beads_types_test.go
+++ b/internal/beads/beads_types_test.go
@@ -148,6 +148,17 @@ func TestFindTownRoot(t *testing.T) {
 	if err := os.MkdirAll(deepDir, 0755); err != nil {
 		t.Fatal(err)
 	}
+	innerTown := filepath.Join(tmpDir, "imported", "gastown")
+	if err := os.MkdirAll(filepath.Join(innerTown, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(innerTown, "mayor", "town.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	innerDeepDir := filepath.Join(innerTown, "crew", "worker2")
+	if err := os.MkdirAll(innerDeepDir, 0755); err != nil {
+		t.Fatal(err)
+	}
 
 	tests := []struct {
 		name     string
@@ -157,6 +168,7 @@ func TestFindTownRoot(t *testing.T) {
 		{"from town root", tmpDir, tmpDir},
 		{"from mayor dir", mayorDir, tmpDir},
 		{"from deep nested dir", deepDir, tmpDir},
+		{"prefers outermost town root", innerDeepDir, tmpDir},
 		{"from non-town dir", t.TempDir(), ""},
 	}
 


### PR DESCRIPTION
## Summary
Fix cross-rig agent bead creation when a routed bead ID is created from an imported rig or nested Gas Town checkout.

This change:
- makes `FindTownRoot` prefer the outermost town root
- runs routed `CreateAgentBead` calls from the town root so `bd` resolves the target route only once
- keeps hook slot writes on the same target-scoped execution path

## Why
On latest `main`, routed agent bead creation can still double-stack rig paths in imported-rig layouts, which breaks polecat/crew identity bead creation in cross-rig scenarios.

## Tests
- `go test ./internal/beads`
- added unit coverage for outermost town-root detection
- added a mock-`bd` regression test that asserts routed `CreateAgentBead` executes from town root with town-level `BEADS_DIR`