### PR TITLE
fix(mail): fall back to explicit agent workspaces

### DIFF
--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -945,6 +945,7 @@ func (r *Router) validateRecipient(identity string) error {
 	}
 
 	// Query agents from rig-level beads via routes.jsonl
+	var routeQueryErr error
 	if r.townRoot != "" {
 		townBeadsDir := filepath.Join(r.townRoot, ".beads")
 		routes, err := beads.LoadRoutes(townBeadsDir)
@@ -968,7 +969,7 @@ func (r *Router) validateRecipient(identity string) error {
 				}
 			}
 			if len(queryErrors) > 0 {
-				return fmt.Errorf("no agent found (query errors: %s)", strings.Join(queryErrors, "; "))
+				routeQueryErr = fmt.Errorf("no agent found (query errors: %s)", strings.Join(queryErrors, "; "))
 			}
 		}
 	}
@@ -977,6 +978,10 @@ func (r *Router) validateRecipient(identity string) error {
 	// (e.g., Dolt DB reset) even though the agent's workspace directory exists.
 	if r.townRoot != "" && r.validateAgentWorkspace(identity) {
 		return nil
+	}
+
+	if routeQueryErr != nil {
+		return routeQueryErr
 	}
 
 	return fmt.Errorf("no agent found")
@@ -1005,6 +1010,10 @@ func (r *Router) validateAgentWorkspace(identity string) bool {
 			}
 		}
 	case 3:
+		// Explicit role paths: rig/crew/<name> or rig/polecats/<name>
+		if parts[1] == "crew" || parts[1] == "polecats" {
+			return dirExists(filepath.Join(r.townRoot, parts[0], parts[1], parts[2]))
+		}
 		// Dog addresses: deacon/dogs/<name>
 		if dirExists(filepath.Join(r.townRoot, parts[0], parts[1], parts[2])) {
 			return true

--- a/internal/mail/router_test.go
+++ b/internal/mail/router_test.go
@@ -1463,8 +1463,10 @@ func TestValidateRecipientFilesystemFallback(t *testing.T) {
 		// Crew members found via filesystem (no agent beads needed)
 		{"crew bob", "pata/bob", false},
 		{"crew alice", "pata/alice", false},
+		{"explicit crew bob", "pata/crew/bob", false},
 		// Polecat found via filesystem
 		{"polecat rust", "pata/rust", false},
+		{"explicit polecat rust", "pata/polecats/rust", false},
 		// Singleton roles found via filesystem
 		{"witness", "pata/witness", false},
 		{"refinery", "pata/refinery", false},
@@ -1482,6 +1484,37 @@ func TestValidateRecipientFilesystemFallback(t *testing.T) {
 				t.Errorf("validateRecipient(%q) expected error, got nil", tt.identity)
 			} else if !tt.wantErr && err != nil {
 				t.Errorf("validateRecipient(%q) unexpected error: %v", tt.identity, err)
+			}
+		})
+	}
+}
+
+func TestValidateRecipientFilesystemFallbackWithRouteErrors(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	for _, subpath := range []string{
+		".beads",
+		"mayor",
+		"sfn1_fast/crew/arch",
+	} {
+		if err := os.MkdirAll(filepath.Join(tmpDir, subpath), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "mayor", "town.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	routes := []byte("{\"prefix\":\"sf-\",\"path\":\"missing/mayor/rig\"}\n")
+	if err := os.WriteFile(filepath.Join(tmpDir, ".beads", "routes.jsonl"), routes, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := NewRouterWithTownRoot(tmpDir, tmpDir)
+
+	for _, identity := range []string{"sfn1_fast/arch", "sfn1_fast/crew/arch"} {
+		t.Run(identity, func(t *testing.T) {
+			if err := r.validateRecipient(identity); err != nil {
+				t.Fatalf("validateRecipient(%q) unexpected error: %v", identity, err)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
Teach mail recipient validation to accept explicit workspace-style agent addresses when bead lookup fails.

This change:
- accepts `rig/crew/name` and `rig/polecats/name` in filesystem fallback
- preserves route-query errors without letting them mask a valid on-disk workspace
- adds regression coverage for route-error plus workspace-fallback behavior

## Why
In practice, agents sometimes need durable mail sent to explicit reviewer or polecat paths even when agent-bead queries are temporarily failing. Latest `main` still rejects some of those valid addresses.

## Tests
- `go test ./internal/mail -run 'TestValidateRecipientFilesystemFallback|TestValidateRecipientFilesystemFallbackWithRouteErrors'`
- `go test ./internal/mail`