### PR TITLE
fix(codex): wait for idle before draining queued nudges

### DIFF
--- a/internal/cmd/nudge_poller.go
+++ b/internal/cmd/nudge_poller.go
@@ -74,9 +74,15 @@ func runNudgePoller(cmd *cobra.Command, args []string) error {
 	// as cancel (e.g., Gemini CLI), skip the Escape keystroke during delivery
 	// to avoid canceling in-flight generation. (GH#gt-wasn)
 	nudgeOpts := tmux.NudgeOpts{}
-	if agentName, err := t.GetEnvironment(sessionName, "GT_AGENT"); err == nil && agentName != "" {
-		if preset := config.GetAgentPresetByName(agentName); preset != nil && preset.EscapeCancelsRequest {
-			nudgeOpts.SkipEscape = true
+	agentName := ""
+	hasPromptDetection := false
+	if name, err := t.GetEnvironment(sessionName, "GT_AGENT"); err == nil && name != "" {
+		agentName = name
+		if preset := config.GetAgentPresetByName(agentName); preset != nil {
+			hasPromptDetection = preset.ReadyPromptPrefix != ""
+			if preset.EscapeCancelsRequest {
+				nudgeOpts.SkipEscape = true
+			}
 		}
 	}
 
@@ -103,13 +109,13 @@ func runNudgePoller(cmd *cobra.Command, args []string) error {
 				continue
 			}
 
-			// Best-effort idle check: try to wait for the agent to become idle.
-			// WaitForIdle is designed for Claude Code's ⏵⏵ status bar and ❯ prompt.
-			// For other agents (Gemini, Codex, etc.) it will always time out because
-			// their TUI doesn't match Claude's idle patterns. In that case we drain
-			// anyway — delivering a nudge mid-work is better than never delivering it.
-			// The poll interval (10s) provides natural rate limiting.
-			_ = t.WaitForIdle(sessionName, idleTimeout)
+			// For runtimes with prompt detection, defer delivery until the session
+			// is actually idle. Runtimes without prompt detection preserve the old
+			// best-effort behavior and drain on the poll interval.
+			waitErr := t.WaitForIdle(sessionName, idleTimeout)
+			if shouldSkipDrainUntilIdle(hasPromptDetection, waitErr) {
+				continue
+			}
 
 			// Drain and inject.
 			drained, err := nudge.Drain(townRoot, sessionName)
@@ -127,4 +133,8 @@ func runNudgePoller(cmd *cobra.Command, args []string) error {
 			}
 		}
 	}
+}
+
+func shouldSkipDrainUntilIdle(hasPromptDetection bool, waitErr error) bool {
+	return hasPromptDetection && waitErr != nil
 }

--- a/internal/cmd/nudge_poller_test.go
+++ b/internal/cmd/nudge_poller_test.go
@@ -1,0 +1,30 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestShouldSkipDrainUntilIdle(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name               string
+		hasPromptDetection bool
+		waitErr            error
+		want               bool
+	}{
+		{"prompt aware idle", true, nil, false},
+		{"prompt aware busy", true, errors.New("timeout"), true},
+		{"no prompt detection busy", false, errors.New("timeout"), false},
+		{"no prompt detection idle", false, nil, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldSkipDrainUntilIdle(tt.hasPromptDetection, tt.waitErr); got != tt.want {
+				t.Errorf("shouldSkipDrainUntilIdle(%v, %v) = %v, want %v", tt.hasPromptDetection, tt.waitErr, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -277,9 +277,10 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 			OutputFlag: "--json",
 		},
 		// Runtime defaults
-		PromptMode:       "none",
-		ReadyDelayMs:     3000,
-		InstructionsFile: "AGENTS.md",
+		PromptMode:         "none",
+		ReadyPromptPrefix:  "› ",
+		ReadyDelayMs:       3000,
+		InstructionsFile:   "AGENTS.md",
 	},
 	AgentCursor: {
 		Name:                AgentCursor,

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -1192,6 +1192,21 @@ func TestCopilotRuntimeConfigFromPreset(t *testing.T) {
 	}
 }
 
+func TestCodexRuntimeConfigHasPromptDetection(t *testing.T) {
+	t.Parallel()
+
+	rc := RuntimeConfigFromPreset(AgentCodex)
+	if rc == nil {
+		t.Fatal("RuntimeConfigFromPreset(codex) returned nil")
+	}
+	if rc.Tmux == nil {
+		t.Fatal("RuntimeConfigFromPreset(codex).Tmux returned nil")
+	}
+	if rc.Tmux.ReadyPromptPrefix != "› " {
+		t.Errorf("RuntimeConfigFromPreset(codex).Tmux.ReadyPromptPrefix = %q, want %q", rc.Tmux.ReadyPromptPrefix, "› ")
+	}
+}
+
 func TestPiProviderDefaults(t *testing.T) {
 	t.Parallel()
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2420,6 +2420,27 @@ func matchesPromptPrefix(line, readyPromptPrefix string) bool {
 	return strings.HasPrefix(trimmed, normalizedPrefix) || (prefix != "" && trimmed == prefix)
 }
 
+func hasBusyIndicator(line string) bool {
+	trimmed := strings.TrimSpace(line)
+	if trimmed == "" {
+		return false
+	}
+	return strings.Contains(trimmed, "esc to interrupt")
+}
+
+func readyPromptPrefixForSession(t *Tmux, session string) string {
+	promptPrefix := DefaultReadyPromptPrefix
+	agentName, err := t.GetEnvironment(session, "GT_AGENT")
+	if err != nil || agentName == "" {
+		return promptPrefix
+	}
+	preset := config.GetAgentPresetByName(agentName)
+	if preset == nil || preset.ReadyPromptPrefix == "" {
+		return promptPrefix
+	}
+	return preset.ReadyPromptPrefix
+}
+
 func (t *Tmux) WaitForRuntimeReady(session string, rc *config.RuntimeConfig, timeout time.Duration) error {
 	if rc == nil || rc.Tmux == nil {
 		return nil
@@ -2468,7 +2489,7 @@ const DefaultReadyPromptPrefix = "❯ "
 // Returns nil if the agent becomes idle within the timeout.
 // Returns an error if the timeout expires while the agent is still busy.
 func (t *Tmux) WaitForIdle(session string, timeout time.Duration) error {
-	promptPrefix := DefaultReadyPromptPrefix
+	promptPrefix := readyPromptPrefixForSession(t, session)
 	prefix := strings.TrimSpace(promptPrefix)
 
 	// Require 2 consecutive idle polls to filter out transient states.
@@ -2493,16 +2514,13 @@ func (t *Tmux) WaitForIdle(session string, timeout time.Duration) error {
 			continue
 		}
 
-		// Check the status bar first: if "esc to interrupt" is visible,
-		// Claude Code is actively running a tool call — NOT idle,
+		// Busy indicator check: if "esc to interrupt" is visible anywhere in
+		// the recent pane output, the agent is actively working — NOT idle,
 		// regardless of whether the prompt prefix is also visible.
 		statusBarBusy := false
 		for _, line := range lines {
-			trimmed := strings.TrimSpace(line)
-			if strings.Contains(trimmed, "\u23F5\u23F5") || strings.Contains(trimmed, "⏵⏵") {
-				if strings.Contains(trimmed, "esc to interrupt") {
-					statusBarBusy = true
-				}
+			if hasBusyIndicator(line) {
+				statusBarBusy = true
 				break
 			}
 		}
@@ -2578,14 +2596,21 @@ func (t *Tmux) IsIdle(session string) bool {
 	}
 
 	for _, line := range lines {
+		if hasBusyIndicator(line) {
+			return false
+		}
+	}
+
+	promptPrefix := readyPromptPrefixForSession(t, session)
+	for _, line := range lines {
+		if matchesPromptPrefix(line, promptPrefix) {
+			return true
+		}
+	}
+
+	for _, line := range lines {
 		trimmed := strings.TrimSpace(line)
-		// The status bar starts with ⏵⏵ (double play symbols).
-		// When the agent is busy: "⏵⏵ bypass permissions on ... · esc to interrupt"
-		// When the agent is idle: "⏵⏵ bypass permissions on (shift+tab to cycle) · 1 file ..."
 		if strings.Contains(trimmed, "⏵⏵") || strings.Contains(trimmed, "\u23F5\u23F5") {
-			if strings.Contains(trimmed, "esc to interrupt") {
-				return false
-			}
 			return true
 		}
 	}

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1787,6 +1787,29 @@ func TestWaitForIdle_Timeout(t *testing.T) {
 	}
 }
 
+func TestHasBusyIndicator(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		line string
+		want bool
+	}{
+		{"claude status busy", "⏵⏵ bypass permissions on ... · esc to interrupt", true},
+		{"codex status busy", "• Working (2m 18s • esc to interrupt)", true},
+		{"idle line", "› Review ready notification", false},
+		{"blank", "", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := hasBusyIndicator(tt.line); got != tt.want {
+				t.Errorf("hasBusyIndicator(%q) = %v, want %v", tt.line, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestDefaultReadyPromptPrefix(t *testing.T) {
 	t.Parallel()
 	// Verify the constant is set correctly


### PR DESCRIPTION
## Summary
Reduce Codex session interruption by using Codex prompt/busy markers and deferring queued nudge delivery until the session is actually idle.

This change:
- gives the Codex preset a prompt prefix (`› `) for tmux idle detection
- makes tmux idle checks use the target session's agent prompt marker
- treats `esc to interrupt` as a generic busy indicator, not a Claude-only one
- updates the nudge poller to skip drain cycles while prompt-aware agents are still busy

## Why
Latest `main` already starts the Codex nudge poller correctly, but queued notifications can still inject mid-turn because the poller drains even after idle wait fails. That shows up as avoidable Codex conversation interruptions.

## Tests
- `go test ./internal/config ./internal/tmux ./internal/cmd -run 'TestCodexRuntimeConfigHasPromptDetection|TestHasBusyIndicator|TestShouldSkipDrainUntilIdle'`
- `go test ./internal/cmd`
- `go test ./internal/tmux`