### PR TITLE
Fix dashboard heartbeat "no timestamp" — JSON field name mismatch

### DIFF
--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -1254,7 +1254,7 @@ func (f *LiveConvoyFetcher) FetchHealth() (*HealthRow, error) {
 	heartbeatFile := filepath.Join(f.townRoot, "deacon", "heartbeat.json")
 	if data, err := os.ReadFile(heartbeatFile); err == nil {
 		var hb struct {
-			LastHeartbeat   time.Time `json:"last_heartbeat"`
+			LastHeartbeat   time.Time `json:"timestamp"`
 			Cycle           int64     `json:"cycle"`
 			HealthyAgents   int       `json:"healthy_agents"`
 			UnhealthyAgents int       `json:"unhealthy_agents"`


### PR DESCRIPTION
## Summary

- Fix one-line JSON struct tag mismatch in `FetchHealth()` that caused the dashboard to always show "no timestamp" for the Deacon heartbeat
- The Deacon writes `json:"timestamp"` (`internal/deacon/heartbeat.go:30`) but the dashboard read `json:"last_heartbeat"` (`internal/web/fetcher.go:1257`), so `LastHeartbeat` was always zero

## Diff

```diff
-			LastHeartbeat   time.Time `json:"last_heartbeat"`
+			LastHeartbeat   time.Time `json:"timestamp"`
```

## Test plan

- [x] `go build ./internal/web/...` — builds clean
- [x] `go test ./internal/web/ -run "Heartbeat|Health|Dashboard"` — all pass
- [ ] Manual: `gt dashboard --port 3000` shows formatted timestamp instead of red "no timestamp"

Fixes #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)