### PR TITLE
fix: align deacon heartbeat JSON field name in dashboard fetcher (#2989)

### DIFF
--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -1254,7 +1254,7 @@ func (f *LiveConvoyFetcher) FetchHealth() (*HealthRow, error) {
 	heartbeatFile := filepath.Join(f.townRoot, "deacon", "heartbeat.json")
 	if data, err := os.ReadFile(heartbeatFile); err == nil {
 		var hb struct {
-			LastHeartbeat   time.Time `json:"last_heartbeat"`
+			LastHeartbeat   time.Time `json:"timestamp"`
 			Cycle           int64     `json:"cycle"`
 			HealthyAgents   int       `json:"healthy_agents"`
 			UnhealthyAgents int       `json:"unhealthy_agents"`

--- a/internal/web/fetcher_test.go
+++ b/internal/web/fetcher_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"bytes"
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -840,5 +841,58 @@ func TestFetchMayor_UsesResolvedRuntime(t *testing.T) {
 	}
 	if status.LastActivity == "" {
 		t.Fatal("expected LastActivity to be populated")
+	}
+}
+
+// TestFetchHealth_DeaconHeartbeatFieldName verifies that FetchHealth reads the
+// "timestamp" field written by heartbeat.go, not the old "last_heartbeat" field
+// that caused dashboard to always show "no timestamp". (GH#2989)
+func TestFetchHealth_DeaconHeartbeatFieldName(t *testing.T) {
+	townRoot := t.TempDir()
+	deaconDir := filepath.Join(townRoot, "deacon")
+	if err := os.MkdirAll(deaconDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Write heartbeat.json using the field name heartbeat.go actually writes.
+	now := time.Now().UTC().Truncate(time.Second)
+	heartbeatJSON := fmt.Sprintf(`{"timestamp":%q,"cycle":42,"healthy_agents":3,"unhealthy_agents":1}`,
+		now.Format(time.RFC3339))
+	if err := os.WriteFile(filepath.Join(deaconDir, "heartbeat.json"), []byte(heartbeatJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	f := &LiveConvoyFetcher{
+		townRoot:                townRoot,
+		heartbeatFreshThreshold: 5 * time.Minute,
+	}
+
+	health, err := f.FetchHealth()
+	if err != nil {
+		t.Fatalf("FetchHealth: %v", err)
+	}
+
+	// DeaconHeartbeat must NOT be "no timestamp" — the field was read correctly.
+	if health.DeaconHeartbeat == "no timestamp" {
+		t.Fatal("DeaconHeartbeat = \"no timestamp\": JSON field name mismatch (GH#2989)")
+	}
+	if health.DeaconHeartbeat == "no heartbeat" {
+		t.Fatal("DeaconHeartbeat = \"no heartbeat\": heartbeat file was not read")
+	}
+
+	// Cycle and agent counts should be populated.
+	if health.DeaconCycle != 42 {
+		t.Errorf("DeaconCycle = %d, want 42", health.DeaconCycle)
+	}
+	if health.HealthyAgents != 3 {
+		t.Errorf("HealthyAgents = %d, want 3", health.HealthyAgents)
+	}
+	if health.UnhealthyAgents != 1 {
+		t.Errorf("UnhealthyAgents = %d, want 1", health.UnhealthyAgents)
+	}
+
+	// Heartbeat should be considered fresh (written just now).
+	if !health.HeartbeatFresh {
+		t.Error("HeartbeatFresh = false for a just-written heartbeat")
 	}
 }


### PR DESCRIPTION
## Summary

One-line JSON tag fix: `fetcher.go` read `"last_heartbeat"` but `heartbeat.go` writes `"timestamp"`. The mismatch caused `LastHeartbeat` to always deserialize as zero, hitting the `"no timestamp"` fallback on every dashboard render even when the Deacon was running healthy.

**Root cause** (from GH#2989):
```go
// heartbeat.go:30 — writes this field name:
Timestamp time.Time `json:"timestamp"`

// fetcher.go:1257 — was reading this (wrong) field name:
LastHeartbeat time.Time `json:"last_heartbeat"`
```

**Fix**: change the json tag in the inline struct in `fetcher.go` from `"last_heartbeat"` to `"timestamp"`.

## Test plan
- [x] `TestFetchHealth_DeaconHeartbeatFieldName` — writes a heartbeat.json with `"timestamp"` field, verifies `DeaconHeartbeat != "no timestamp"`, checks `DeaconCycle`, `HealthyAgents`, `UnhealthyAgents`, and `HeartbeatFresh` are all populated correctly
- [x] `go vet ./internal/web/...` — clean
- [x] `go test ./internal/web/ -run TestFetchHealth` — passes

Fixes #2989

🤖 Generated with [Claude Code](https://claude.com/claude-code)