### PR TITLE
feat: add 'gt rig repair' to fix partial beads initialization (#2922)

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -339,6 +339,25 @@ var (
 	promptYesNoUnsafeProceed = promptYesNo
 )
 
+var rigRepairCmd = &cobra.Command{
+	Use:   "repair <rig>",
+	Short: "Re-initialize beads for a rig with a partial or broken beads setup",
+	Long: `Re-run beads initialization for a rig that was left in a broken state.
+
+Common cause: 'gt rig add' succeeded but Dolt went down mid-init, leaving
+metadata.json pointing at the wrong database or missing issue_prefix config.
+
+repair:
+  1. Ensures the rig's Dolt database exists (idempotent)
+  2. Fixes metadata.json to use the correct database name and server mode
+  3. Re-runs 'bd init' if .beads/ is missing entirely
+  4. Re-sets issue_prefix config on the server-side database
+
+Safe to run on a healthy rig — all steps are idempotent.`,
+	Args: cobra.ExactArgs(1),
+	RunE: runRigRepair,
+}
+
 func init() {
 	rootCmd.AddCommand(rigCmd)
 	rigCmd.AddCommand(rigAddCmd)
@@ -346,6 +365,7 @@ func init() {
 	rigCmd.AddCommand(rigListCmd)
 	rigCmd.AddCommand(rigRebootCmd)
 	rigCmd.AddCommand(rigRemoveCmd)
+	rigCmd.AddCommand(rigRepairCmd)
 	rigCmd.AddCommand(rigResetCmd)
 	rigCmd.AddCommand(rigRestartCmd)
 	rigCmd.AddCommand(rigShutdownCmd)
@@ -845,6 +865,95 @@ func runRigList(cmd *cobra.Command, args []string) error {
 		fmt.Println()
 	}
 
+	return nil
+}
+
+func runRigRepair(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("not in a Gas Town workspace: %w", err)
+	}
+
+	rigPath := filepath.Join(townRoot, name)
+	if _, err := os.Stat(rigPath); os.IsNotExist(err) {
+		return fmt.Errorf("rig %q not found at %s", name, rigPath)
+	}
+
+	// Load rig config to get the beads prefix.
+	rigCfg, err := rig.LoadRigConfig(rigPath)
+	if err != nil {
+		return fmt.Errorf("loading rig config for %q: %w (is this a valid rig directory?)", name, err)
+	}
+	prefix := rigCfg.Beads.Prefix
+	if prefix == "" {
+		return fmt.Errorf("rig %q has no beads prefix configured (check config.json)", name)
+	}
+
+	// Require Dolt to be running — repair needs it to fix metadata and
+	// re-create the database if missing.
+	if running, _, err := doltserver.IsRunning(townRoot); err != nil {
+		return fmt.Errorf("checking Dolt server: %w", err)
+	} else if !running {
+		return fmt.Errorf("Dolt server is not running; start it with 'gt up' or 'gt dolt start' then retry")
+	}
+
+	fmt.Printf("Repairing beads for rig %q (prefix: %s)...\n", name, prefix)
+
+	// Step 1: Ensure the Dolt database exists (idempotent — no-op if already present).
+	_, created, err := doltserver.InitRig(townRoot, name)
+	if err != nil {
+		return fmt.Errorf("ensuring Dolt database for %q: %w", name, err)
+	}
+	if created {
+		fmt.Printf("  ✓ Created missing Dolt database %q\n", name)
+	} else {
+		fmt.Printf("  ✓ Dolt database %q exists\n", name)
+	}
+
+	// Step 2: Re-initialize beads if .beads/ is missing or has no metadata.json.
+	beadsDir := filepath.Join(rigPath, ".beads")
+	metadataPath := filepath.Join(beadsDir, "metadata.json")
+	if _, err := os.Stat(metadataPath); os.IsNotExist(err) {
+		fmt.Printf("  Beads not initialized (.beads/metadata.json missing) — running bd init...\n")
+		g := git.NewGit(townRoot)
+		rigsPath := filepath.Join(townRoot, "mayor", "rigs.json")
+		rigsConfig, loadErr := config.LoadRigsConfig(rigsPath)
+		if loadErr != nil {
+			rigsConfig = &config.RigsConfig{Rigs: make(map[string]config.RigEntry)}
+		}
+		mgr := rig.NewManager(townRoot, rigsConfig, g)
+		if initErr := mgr.InitBeads(rigPath, prefix, name); initErr != nil {
+			return fmt.Errorf("bd init failed: %w\nRun 'gt doctor --fix --rig %s' to retry", initErr, name)
+		}
+		fmt.Printf("  ✓ Beads initialized\n")
+	} else {
+		fmt.Printf("  ✓ .beads/metadata.json exists\n")
+	}
+
+	// Step 3: Fix metadata.json to use correct dolt_database and server mode.
+	// This repairs the common partial-init failure where EnsureMetadata was
+	// non-fatal and left metadata pointing at beads_<prefix> instead of <rigName>.
+	if err := doltserver.EnsureMetadata(townRoot, name); err != nil {
+		fmt.Printf("  %s Could not update metadata.json: %v\n", style.Warning.Render("!"), err)
+		fmt.Printf("    Run 'gt doctor --fix --rig %s' to retry after Dolt is healthy.\n", name)
+	} else {
+		fmt.Printf("  ✓ metadata.json points at database %q\n", name)
+	}
+
+	// Step 4: Re-set issue_prefix on the server-side database.
+	resolvedBeadsDir := beads.ResolveBeadsDir(rigPath)
+	prefixCmd := exec.Command("bd", "config", "set", "issue_prefix", prefix)
+	prefixCmd.Dir = rigPath
+	prefixCmd.Env = append(os.Environ(), "BEADS_DIR="+resolvedBeadsDir)
+	if out, err := prefixCmd.CombinedOutput(); err != nil {
+		fmt.Printf("  %s Could not set issue_prefix: %v (%s)\n", style.Warning.Render("!"), err, strings.TrimSpace(string(out)))
+	} else {
+		fmt.Printf("  ✓ issue_prefix set to %q\n", prefix)
+	}
+
+	fmt.Printf("\nRig %q repair complete. Run 'gt doctor --rig %s' to verify.\n", name, name)
 	return nil
 }
 

--- a/internal/cmd/rig_repair_test.go
+++ b/internal/cmd/rig_repair_test.go
@@ -1,0 +1,130 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/rig"
+)
+
+// setupRepairTown creates a minimal town structure for repair tests.
+// Returns townRoot and sets up mayor/town.json so workspace detection works.
+func setupRepairTown(t *testing.T) string {
+	t.Helper()
+	townRoot := t.TempDir()
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	// Minimal town.json so workspace.FindFromCwdOrError can locate the root
+	townJSON := map[string]string{"name": "test-town"}
+	data, _ := json.Marshal(townJSON)
+	if err := os.WriteFile(filepath.Join(mayorDir, "town.json"), data, 0644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+	// Restore cwd after test
+	origWd, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(origWd) })
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("chdir to townRoot: %v", err)
+	}
+	return townRoot
+}
+
+func TestRunRigRepair_RigNotFound(t *testing.T) {
+	setupRepairTown(t)
+
+	cmd := &cobra.Command{}
+	err := runRigRepair(cmd, []string{"nonexistent-rig"})
+	if err == nil {
+		t.Fatal("expected error for nonexistent rig, got nil")
+	}
+	// Should report rig not found
+	msg := err.Error()
+	if !contains(msg, "not found") && !contains(msg, "nonexistent-rig") {
+		t.Errorf("error should mention rig not found, got: %v", err)
+	}
+}
+
+func TestRunRigRepair_InvalidConfig(t *testing.T) {
+	townRoot := setupRepairTown(t)
+
+	// Create rig directory but with invalid config.json
+	rigPath := filepath.Join(townRoot, "badrig")
+	if err := os.MkdirAll(rigPath, 0755); err != nil {
+		t.Fatalf("mkdir rigPath: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), []byte("not-json"), 0644); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+
+	cmd := &cobra.Command{}
+	err := runRigRepair(cmd, []string{"badrig"})
+	if err == nil {
+		t.Fatal("expected error for invalid config, got nil")
+	}
+}
+
+func TestRunRigRepair_NoPrefixConfigured(t *testing.T) {
+	townRoot := setupRepairTown(t)
+
+	// Create a rig with valid config but no beads prefix
+	rigPath := filepath.Join(townRoot, "myrig")
+	if err := os.MkdirAll(rigPath, 0755); err != nil {
+		t.Fatalf("mkdir rigPath: %v", err)
+	}
+	cfg := &rig.RigConfig{
+		Type:    "rig",
+		Version: 1,
+		Name:    "myrig",
+		Beads:   &rig.BeadsConfig{Prefix: ""},
+	}
+	data, _ := json.Marshal(cfg)
+	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), data, 0644); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+
+	cmd := &cobra.Command{}
+	err := runRigRepair(cmd, []string{"myrig"})
+	if err == nil {
+		t.Fatal("expected error for missing prefix, got nil")
+	}
+	if !contains(err.Error(), "prefix") {
+		t.Errorf("error should mention missing prefix, got: %v", err)
+	}
+}
+
+func TestRunRigRepair_DoltNotRunning(t *testing.T) {
+	townRoot := setupRepairTown(t)
+
+	// Create a valid rig with a prefix but no Dolt server
+	rigPath := filepath.Join(townRoot, "myrig")
+	if err := os.MkdirAll(rigPath, 0755); err != nil {
+		t.Fatalf("mkdir rigPath: %v", err)
+	}
+	cfg := &rig.RigConfig{
+		Type:    "rig",
+		Version: 1,
+		Name:    "myrig",
+		Beads:   &rig.BeadsConfig{Prefix: "mr"},
+	}
+	data, _ := json.Marshal(cfg)
+	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), data, 0644); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+
+	// No Dolt server running — should fail with a helpful error.
+	// (doltserver.IsRunning checks for PID file / port, neither exist in tmp dir)
+	cmd := &cobra.Command{}
+	err := runRigRepair(cmd, []string{"myrig"})
+	if err == nil {
+		t.Fatal("expected error when Dolt not running, got nil")
+	}
+	if !contains(err.Error(), "Dolt") && !contains(err.Error(), "running") {
+		t.Errorf("error should mention Dolt not running, got: %v", err)
+	}
+}
+


### PR DESCRIPTION
## Summary

When \`gt rig add\` completes but Dolt goes down mid-initialization, the rig is left in a broken state: \`EnsureMetadata\` and \`bd config set issue_prefix\` are non-fatal, so the rig appears to succeed but has \`metadata.json\` pointing at \`beads_<prefix>\` instead of \`<rigName>\`, and \`issue_prefix\` is unset. All subsequent \`gt sling\`, \`gt mail\`, and witness patrols on that rig fail.

Until now the only recovery was \`gt doctor --fix --rig <name>\`, which re-runs \`bd init\` but skips the \`EnsureMetadata\` + \`issue_prefix\` repair steps — the exact steps that were broken.

New command: **\`gt rig repair <name>\`**

1. Ensures the Dolt database exists (`InitRig`, idempotent)
2. Runs `bd init` if `.beads/metadata.json` is missing entirely
3. Fixes `metadata.json` to use the correct `dolt_database` and server mode (`EnsureMetadata` — the step that was non-fatal and often left broken)
4. Re-sets `issue_prefix` config on the server-side database

All steps are idempotent — safe to run on a healthy rig.

## Test plan
- [x] Unit tests for all error paths: rig not found, invalid config, missing prefix, Dolt not running
- [x] `go build ./internal/cmd/` and `go vet ./internal/cmd/` clean
- [x] `gt rig repair --help` shows correct usage
- [x] Full repair flow requires Dolt (integration test candidate for follow-up)

Fixes #2922

🤖 Generated with [Claude Code](https://claude.com/claude-code)