### PR TITLE
fix(config): custom agents inherit Session/Tmux from matched preset

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1852,6 +1852,31 @@ func fillRuntimeDefaults(rc *RuntimeConfig) *RuntimeConfig {
 		}
 	}
 
+	// Auto-fill Session defaults from preset when not explicitly set.
+	// Custom agents (e.g., "claude-opus" with Command:"claude") inherit
+	// SessionIDEnv/ConfigDirEnv from the matched preset, enabling session
+	// resume and GT_SESSION_ID_ENV propagation in handoffs.
+	if result.Session == nil && preset != nil && (preset.SessionIDEnv != "" || preset.ConfigDirEnv != "") {
+		result.Session = &RuntimeSessionConfig{
+			SessionIDEnv: preset.SessionIDEnv,
+			ConfigDirEnv: preset.ConfigDirEnv,
+		}
+	}
+
+	// Auto-fill Tmux defaults from preset for process detection and readiness.
+	// Custom agents matching a known preset by command (e.g., "claude-opus" →
+	// claude preset) get ProcessNames and ReadyPromptPrefix needed for
+	// WaitForRuntimeReady to detect agent startup correctly.
+	if result.Tmux == nil && preset != nil && (len(preset.ProcessNames) > 0 || preset.ReadyPromptPrefix != "" || preset.ReadyDelayMs > 0) {
+		result.Tmux = &RuntimeTmuxConfig{
+			ReadyPromptPrefix: preset.ReadyPromptPrefix,
+			ReadyDelayMs:      preset.ReadyDelayMs,
+		}
+		if len(preset.ProcessNames) > 0 {
+			result.Tmux.ProcessNames = append([]string(nil), preset.ProcessNames...)
+		}
+	}
+
 	// Auto-fill Env defaults from preset.
 	if preset != nil && len(preset.Env) > 0 {
 		if result.Env == nil {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -3212,7 +3212,7 @@ func TestFillRuntimeDefaults(t *testing.T) {
 		}
 	})
 
-	t.Run("nil nested structs remain nil except auto-filled Hooks", func(t *testing.T) {
+	t.Run("nil nested structs are auto-filled from preset for known agents", func(t *testing.T) {
 		t.Parallel()
 		input := &RuntimeConfig{
 			Command: "claude",
@@ -3221,20 +3221,26 @@ func TestFillRuntimeDefaults(t *testing.T) {
 
 		result := fillRuntimeDefaults(input)
 
-		// Nil nested structs should remain nil (not get zero-value structs)
-		if result.Session != nil {
-			t.Error("Session should remain nil when input has nil Session")
-		}
 		// Hooks is auto-filled for known agents (claude, opencode) to ensure
-		// EnsureSettingsForRole creates the correct settings files
+		// EnsureSettingsForRole creates the correct settings files.
 		if result.Hooks == nil {
 			t.Error("Hooks should be auto-filled for claude command")
 		} else if result.Hooks.Provider != "claude" {
 			t.Errorf("Hooks.Provider = %q, want %q", result.Hooks.Provider, "claude")
 		}
-		if result.Tmux != nil {
-			t.Error("Tmux should remain nil when input has nil Tmux")
+		// Session is auto-filled from preset so handoffs can propagate GT_SESSION_ID_ENV.
+		if result.Session == nil {
+			t.Error("Session should be auto-filled for claude command")
+		} else if result.Session.SessionIDEnv != "CLAUDE_SESSION_ID" {
+			t.Errorf("Session.SessionIDEnv = %q, want CLAUDE_SESSION_ID", result.Session.SessionIDEnv)
 		}
+		// Tmux is auto-filled from preset so WaitForRuntimeReady uses prompt detection.
+		if result.Tmux == nil {
+			t.Error("Tmux should be auto-filled for claude command")
+		} else if result.Tmux.ReadyPromptPrefix != "❯ " {
+			t.Errorf("Tmux.ReadyPromptPrefix = %q, want \"❯ \"", result.Tmux.ReadyPromptPrefix)
+		}
+		// Instructions still remain nil (no preset fills this).
 		if result.Instructions != nil {
 			t.Error("Instructions should remain nil when input has nil Instructions")
 		}
@@ -3345,6 +3351,82 @@ func TestFillRuntimeDefaults(t *testing.T) {
 		}
 		if result.Tmux.ReadyDelayMs != 5000 {
 			t.Errorf("Tmux.ReadyDelayMs = %d, want 5000 (user-specified)", result.Tmux.ReadyDelayMs)
+		}
+	})
+
+	t.Run("custom claude agent inherits Session and Tmux from preset", func(t *testing.T) {
+		t.Parallel()
+		// Simulates: gt config agent set claude-opus 'claude --model claude-opus-4-6'
+		// Custom agent has Command:"claude" but no Session/Tmux set.
+		input := &RuntimeConfig{
+			Command: "claude",
+			Args:    []string{"--dangerously-skip-permissions", "--model", "claude-opus-4-6"},
+		}
+
+		result := fillRuntimeDefaults(input)
+
+		// Session should be auto-filled from the claude preset.
+		if result.Session == nil {
+			t.Fatal("Session should be auto-filled for claude command")
+		}
+		if result.Session.SessionIDEnv != "CLAUDE_SESSION_ID" {
+			t.Errorf("Session.SessionIDEnv = %q, want CLAUDE_SESSION_ID", result.Session.SessionIDEnv)
+		}
+
+		// Tmux should be auto-filled from the claude preset so WaitForRuntimeReady
+		// uses prompt detection instead of returning immediately (rc.Tmux == nil path).
+		if result.Tmux == nil {
+			t.Fatal("Tmux should be auto-filled for claude command")
+		}
+		if result.Tmux.ReadyPromptPrefix != "❯ " {
+			t.Errorf("Tmux.ReadyPromptPrefix = %q, want \"❯ \"", result.Tmux.ReadyPromptPrefix)
+		}
+		found := false
+		for _, n := range result.Tmux.ProcessNames {
+			if n == "claude" {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("Tmux.ProcessNames = %v, want to contain \"claude\"", result.Tmux.ProcessNames)
+		}
+
+		// Custom args must be preserved (not overridden by preset).
+		if len(result.Args) < 2 || result.Args[len(result.Args)-1] != "claude-opus-4-6" {
+			t.Errorf("Args should be preserved: got %v", result.Args)
+		}
+	})
+
+	t.Run("explicit Session config is not overridden by preset", func(t *testing.T) {
+		t.Parallel()
+		input := &RuntimeConfig{
+			Command: "claude",
+			Session: &RuntimeSessionConfig{
+				SessionIDEnv: "MY_CUSTOM_SESSION_ID",
+			},
+		}
+
+		result := fillRuntimeDefaults(input)
+
+		if result.Session.SessionIDEnv != "MY_CUSTOM_SESSION_ID" {
+			t.Errorf("Session.SessionIDEnv = %q, want MY_CUSTOM_SESSION_ID (user-specified)", result.Session.SessionIDEnv)
+		}
+	})
+
+	t.Run("explicit Tmux config is not overridden by preset", func(t *testing.T) {
+		t.Parallel()
+		input := &RuntimeConfig{
+			Command: "claude",
+			Tmux: &RuntimeTmuxConfig{
+				ProcessNames: []string{"my-claude-wrapper"},
+			},
+		}
+
+		result := fillRuntimeDefaults(input)
+
+		if len(result.Tmux.ProcessNames) != 1 || result.Tmux.ProcessNames[0] != "my-claude-wrapper" {
+			t.Errorf("Tmux.ProcessNames = %v, want [my-claude-wrapper] (user-specified)", result.Tmux.ProcessNames)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

- `fillRuntimeDefaults` now auto-fills `Session` and `Tmux` from the matched preset when a custom agent's `Command` matches a known preset (e.g. `claude`), using the same nil-guard pattern already used for `Hooks`, `Env`, and `ACP`
- The pi-specific Tmux block runs first, so pi keeps its existing hardcoded values; general preset filling only applies when `Tmux` is still nil
- Fixes the root cause: `WaitForRuntimeReady` returns immediately when `rc.Tmux == nil`, so the startup beacon was sent before Claude finished loading — agent idled at welcome screen

## Root Cause

When `gt config agent set claude-opus 'claude --model claude-opus-4-6'` creates a custom agent, only `Command` and `Args` are stored. `fillRuntimeDefaults` filled `Hooks` from the claude preset but left `Session` and `Tmux` nil.

`tmux.WaitForRuntimeReady` has an early-return guard: `if rc == nil || rc.Tmux == nil { return nil }`. So for custom agents, readiness detection was skipped entirely — the startup beacon was injected before Claude displayed its prompt and got lost.

`handoff.go` also checks `runtimeConfig.Session != nil` before exporting `GT_SESSION_ID_ENV`, so session ID propagation was broken for custom agents.

## Test Plan

- [x] `TestFillRuntimeDefaults/custom_claude_agent_inherits_Session_and_Tmux_from_preset` — new test verifying Session.SessionIDEnv and Tmux.ReadyPromptPrefix are filled
- [x] `TestFillRuntimeDefaults/explicit_Session_config_is_not_overridden_by_preset` — user-set Session is preserved
- [x] `TestFillRuntimeDefaults/explicit_Tmux_config_is_not_overridden_by_preset` — user-set Tmux is preserved
- [x] Updated `TestFillRuntimeDefaults/nil_nested_structs_are_auto-filled_from_preset_for_known_agents`
- [x] All config tests pass (`go test ./internal/config/... -count=1`)
- [x] All internal tests pass (pre-existing failures in `acp` and `cmd` packages unrelated)

Fixes gt-7z76.

🤖 Generated with [Claude Code](https://claude.com/claude-code)