### PR TITLE
fix: propagate BEADS_DOLT_SERVER_HOST from daemon.json + improve discoverability (GH #2830)

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -182,7 +182,8 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewPrefixConflictCheck())
 	d.Register(doctor.NewRigNameMismatchCheck())
 	d.Register(doctor.NewRigConfigSyncCheck()) // Check all registered rigs have config.json
-	d.Register(doctor.NewStaleDoltPortCheck()) // Check for stale Dolt port files
+	d.Register(doctor.NewStaleDoltPortCheck())    // Check for stale Dolt port files
+	d.Register(doctor.NewRemoteDoltHostCheck()) // Check remote host config vs GT_DOLT_HOST
 	d.Register(doctor.NewPrefixMismatchCheck())
 	d.Register(doctor.NewDatabasePrefixCheck())
 	d.Register(doctor.NewIdleTimeoutCheck()) // Verify dolt.idle-timeout: "0" for all rigs

--- a/internal/cmd/dolt.go
+++ b/internal/cmd/dolt.go
@@ -371,7 +371,7 @@ func runDoltStart(cmd *cobra.Command, args []string) error {
 
 	config := doltserver.DefaultConfig(townRoot)
 	if config.IsRemote() {
-		return fmt.Errorf("Dolt server is remote (%s) — start/stop managed externally", config.HostPort())
+		return fmt.Errorf("Dolt server is remote (%s) — start/stop managed externally.\n  To change: edit mayor/daemon.json and set patrols.dolt_server.host", config.HostPort())
 	}
 
 	// Check for databases before starting — user-facing guard for manual starts.
@@ -457,7 +457,7 @@ func runDoltStop(cmd *cobra.Command, args []string) error {
 
 	config := doltserver.DefaultConfig(townRoot)
 	if config.IsRemote() {
-		return fmt.Errorf("Dolt server is remote (%s) — start/stop managed externally", config.HostPort())
+		return fmt.Errorf("Dolt server is remote (%s) — start/stop managed externally.\n  To change: edit mayor/daemon.json and set patrols.dolt_server.host", config.HostPort())
 	}
 
 	_, pid, _ := doltserver.IsRunning(townRoot)

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -309,12 +309,28 @@ func AgentEnv(cfg AgentEnvConfig) map[string]string {
 		env["BEADS_DOLT_AUTO_START"] = "0"
 	}
 
-	// Propagate Dolt server host so bd doesn't fall back to 127.0.0.1 when
-	// the server runs on a remote machine (e.g., mini2 over Tailscale).
+	// Inject Dolt server host so agents connect to the correct remote host
+	// when Dolt runs on another machine (GH#2830). Mirrors port injection above.
+	//
+	// Resolution: daemon.json patrols.dolt_server.host first, then process env.
+	if cfg.TownRoot != "" {
+		if host := resolveDoltHost(cfg.TownRoot); host != "" {
+			env["GT_DOLT_HOST"] = host
+			env["BEADS_DOLT_SERVER_HOST"] = host
+		}
+	}
+	// Propagate GT_DOLT_HOST / BEADS_DOLT_SERVER_HOST from process env when not
+	// already resolved from config. Covers sessions where TownRoot is empty.
+	if _, ok := env["GT_DOLT_HOST"]; !ok {
+		if v := os.Getenv("GT_DOLT_HOST"); v != "" {
+			env["GT_DOLT_HOST"] = v
+			if os.Getenv("BEADS_DOLT_SERVER_HOST") == "" {
+				env["BEADS_DOLT_SERVER_HOST"] = v
+			}
+		}
+	}
 	if _, ok := env["BEADS_DOLT_SERVER_HOST"]; !ok {
 		if v := os.Getenv("BEADS_DOLT_SERVER_HOST"); v != "" {
-			env["BEADS_DOLT_SERVER_HOST"] = v
-		} else if v := os.Getenv("GT_DOLT_HOST"); v != "" {
 			env["BEADS_DOLT_SERVER_HOST"] = v
 		}
 	}
@@ -444,6 +460,41 @@ func resolveDoltPort(townRoot string) int {
 	}
 
 	return 0
+}
+
+// resolveDoltHost determines the Dolt server host for the given town root.
+//
+// Resolution order:
+//  1. GT_DOLT_HOST environment variable
+//  2. mayor/daemon.json patrols.dolt_server.host
+//  3. "" (caller should skip injection — 127.0.0.1 is bd's own default)
+//
+// There is no config.yaml host equivalent (only port is stored there),
+// so daemon.json is the canonical config-file source for host.
+func resolveDoltHost(townRoot string) string {
+	// 1. Environment variable takes precedence over config file.
+	if h := os.Getenv("GT_DOLT_HOST"); h != "" {
+		return h
+	}
+
+	// 2. daemon.json patrols.dolt_server.host
+	daemonJSONPath := filepath.Join(townRoot, "mayor", "daemon.json")
+	if data, err := os.ReadFile(daemonJSONPath); err == nil {
+		var dc struct {
+			Patrols struct {
+				DoltServer struct {
+					Host string `json:"host"`
+				} `json:"dolt_server"`
+			} `json:"patrols"`
+		}
+		if err := json.Unmarshal(data, &dc); err == nil {
+			if h := dc.Patrols.DoltServer.Host; h != "" {
+				return h
+			}
+		}
+	}
+
+	return ""
 }
 
 // parsePortFromConfigYAML extracts the listener port from a Dolt config.yaml

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -1221,3 +1221,106 @@ func TestAgentEnv_NoDoltPortWithoutConfig(t *testing.T) {
 	assertNotSet(t, env, "GT_DOLT_PORT")
 	assertNotSet(t, env, "BEADS_DOLT_PORT")
 }
+
+// TestResolveDoltHost verifies the host resolution order: env var > daemon.json > "".
+func TestResolveDoltHost_FromEnvVar(t *testing.T) {
+	t.Setenv("GT_DOLT_HOST", "mini2.local")
+	tmpDir := t.TempDir()
+
+	got := resolveDoltHost(tmpDir)
+	if got != "mini2.local" {
+		t.Errorf("resolveDoltHost() = %q, want %q", got, "mini2.local")
+	}
+}
+
+func TestResolveDoltHost_FromDaemonJSON(t *testing.T) {
+	t.Setenv("GT_DOLT_HOST", "") // ensure env var doesn't interfere
+	tmpDir := t.TempDir()
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	daemonJSON := `{"patrols":{"dolt_server":{"host":"100.64.1.5"}},"type":"daemon-patrol-config"}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "daemon.json"), []byte(daemonJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveDoltHost(tmpDir)
+	if got != "100.64.1.5" {
+		t.Errorf("resolveDoltHost() = %q, want %q", got, "100.64.1.5")
+	}
+}
+
+func TestResolveDoltHost_EnvVarTakesPrecedence(t *testing.T) {
+	t.Setenv("GT_DOLT_HOST", "env-host.local")
+	tmpDir := t.TempDir()
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	daemonJSON := `{"patrols":{"dolt_server":{"host":"config-host.local"}},"type":"daemon-patrol-config"}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "daemon.json"), []byte(daemonJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	got := resolveDoltHost(tmpDir)
+	if got != "env-host.local" {
+		t.Errorf("resolveDoltHost() = %q, want %q (env var > daemon.json)", got, "env-host.local")
+	}
+}
+
+func TestResolveDoltHost_NoConfig(t *testing.T) {
+	t.Setenv("GT_DOLT_HOST", "")
+	tmpDir := t.TempDir()
+	got := resolveDoltHost(tmpDir)
+	if got != "" {
+		t.Errorf("resolveDoltHost() = %q, want empty string", got)
+	}
+}
+
+// TestAgentEnv_PropagatesDoltHost verifies that GT_DOLT_HOST and BEADS_DOLT_SERVER_HOST
+// are propagated from daemon.json to agent sessions (GH#2830).
+func TestAgentEnv_PropagatesDoltHost(t *testing.T) {
+	// Subtest: GT_DOLT_HOST set in env → both vars propagated
+	t.Run("gt_dolt_host_env", func(t *testing.T) {
+		t.Setenv("GT_DOLT_HOST", "mini2.local")
+		t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+		env := AgentEnv(AgentEnvConfig{Role: "crew", Rig: "myrig", AgentName: "alice"})
+		assertEnv(t, env, "GT_DOLT_HOST", "mini2.local")
+		assertEnv(t, env, "BEADS_DOLT_SERVER_HOST", "mini2.local")
+	})
+
+	// Subtest: daemon.json dolt_server.host → both vars injected when TownRoot set
+	t.Run("from_daemon_json", func(t *testing.T) {
+		t.Setenv("GT_DOLT_HOST", "")
+		t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+		tmpDir := t.TempDir()
+		mayorDir := filepath.Join(tmpDir, "mayor")
+		if err := os.MkdirAll(mayorDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		daemonJSON := `{"patrols":{"dolt_server":{"host":"100.64.1.5"}},"type":"daemon-patrol-config"}`
+		if err := os.WriteFile(filepath.Join(mayorDir, "daemon.json"), []byte(daemonJSON), 0644); err != nil {
+			t.Fatal(err)
+		}
+		env := AgentEnv(AgentEnvConfig{Role: "mayor", TownRoot: tmpDir})
+		assertEnv(t, env, "GT_DOLT_HOST", "100.64.1.5")
+		assertEnv(t, env, "BEADS_DOLT_SERVER_HOST", "100.64.1.5")
+	})
+
+	// Subtest: neither set → neither propagated (local setup)
+	t.Run("neither_set", func(t *testing.T) {
+		t.Setenv("GT_DOLT_HOST", "")
+		t.Setenv("BEADS_DOLT_SERVER_HOST", "")
+		env := AgentEnv(AgentEnvConfig{Role: "mayor"})
+		assertNotSet(t, env, "GT_DOLT_HOST")
+	})
+
+	// Subtest: BEADS_DOLT_SERVER_HOST explicitly set → preserved
+	t.Run("beads_server_host_override", func(t *testing.T) {
+		t.Setenv("GT_DOLT_HOST", "")
+		t.Setenv("BEADS_DOLT_SERVER_HOST", "explicit-beads-host.local")
+		env := AgentEnv(AgentEnvConfig{Role: "crew", Rig: "myrig", AgentName: "alice"})
+		assertEnv(t, env, "BEADS_DOLT_SERVER_HOST", "explicit-beads-host.local")
+	})
+}

--- a/internal/doctor/remote_dolt_host_check.go
+++ b/internal/doctor/remote_dolt_host_check.go
@@ -1,0 +1,115 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// RemoteDoltHostCheck detects cases where daemon.json configures a remote Dolt
+// host but GT_DOLT_HOST is not exported to the shell environment. While gt CLI
+// tools auto-read daemon.json, direct dolt commands and third-party tools rely
+// on the GT_DOLT_HOST environment variable.
+type RemoteDoltHostCheck struct {
+	BaseCheck
+}
+
+// NewRemoteDoltHostCheck creates a new remote Dolt host check.
+func NewRemoteDoltHostCheck() *RemoteDoltHostCheck {
+	return &RemoteDoltHostCheck{
+		BaseCheck: BaseCheck{
+			CheckName:        "remote-dolt-host",
+			CheckDescription: "Verify GT_DOLT_HOST is set when daemon.json configures a remote Dolt server",
+			CheckCategory:    CategoryConfig,
+		},
+	}
+}
+
+// Run checks for remote Dolt host misconfiguration.
+func (c *RemoteDoltHostCheck) Run(ctx *CheckContext) *CheckResult {
+	if ctx.TownRoot == "" {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "No town root — skipped",
+		}
+	}
+
+	configuredHost := c.readDaemonJSONHost(ctx.TownRoot)
+	if configuredHost == "" || !isRemoteHost(configuredHost) {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "Dolt server is local (no remote host configured)",
+		}
+	}
+
+	shellHost := os.Getenv("GT_DOLT_HOST")
+	if shellHost == configuredHost {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: fmt.Sprintf("GT_DOLT_HOST matches daemon.json (%s)", configuredHost),
+		}
+	}
+
+	var details []string
+	var message string
+
+	if shellHost == "" {
+		message = fmt.Sprintf("daemon.json has remote Dolt host (%s) but GT_DOLT_HOST not in shell", configuredHost)
+		details = []string{
+			fmt.Sprintf("daemon.json patrols.dolt_server.host = %q", configuredHost),
+			"gt CLI tools auto-read daemon.json, but direct dolt commands need GT_DOLT_HOST.",
+			fmt.Sprintf("  Add to your shell profile: export GT_DOLT_HOST=%s", configuredHost),
+		}
+	} else {
+		message = fmt.Sprintf("GT_DOLT_HOST=%q conflicts with daemon.json host %q", shellHost, configuredHost)
+		details = []string{
+			fmt.Sprintf("daemon.json patrols.dolt_server.host = %q", configuredHost),
+			fmt.Sprintf("GT_DOLT_HOST (shell env) = %q", shellHost),
+			"Shell env takes precedence — gt CLI will connect to shell host, not daemon.json host.",
+			"Update GT_DOLT_HOST or remove the daemon.json dolt_server.host to resolve the conflict.",
+		}
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusWarning,
+		Message: message,
+		Details: details,
+		FixHint: fmt.Sprintf("Add 'export GT_DOLT_HOST=%s' to your shell profile", configuredHost),
+	}
+}
+
+// readDaemonJSONHost reads the dolt_server.host field from daemon.json.
+func (c *RemoteDoltHostCheck) readDaemonJSONHost(townRoot string) string {
+	daemonJSONPath := filepath.Join(townRoot, "mayor", "daemon.json")
+	data, err := os.ReadFile(daemonJSONPath)
+	if err != nil {
+		return ""
+	}
+
+	var dc struct {
+		Patrols struct {
+			DoltServer struct {
+				Host string `json:"host"`
+			} `json:"dolt_server"`
+		} `json:"patrols"`
+	}
+	if err := json.Unmarshal(data, &dc); err != nil {
+		return ""
+	}
+	return dc.Patrols.DoltServer.Host
+}
+
+// isRemoteHost returns true when the host is not local (mirrors doltserver.IsRemote).
+func isRemoteHost(host string) bool {
+	switch strings.ToLower(host) {
+	case "", "127.0.0.1", "localhost", "::1", "[::1]":
+		return false
+	}
+	return true
+}

--- a/internal/doctor/remote_dolt_host_check_test.go
+++ b/internal/doctor/remote_dolt_host_check_test.go
@@ -1,0 +1,141 @@
+package doctor
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoteDoltHostCheck_NoTownRoot(t *testing.T) {
+	check := NewRemoteDoltHostCheck()
+	result := check.Run(&CheckContext{TownRoot: ""})
+	if result.Status != StatusOK {
+		t.Errorf("expected OK for empty TownRoot, got %s", result.Status)
+	}
+}
+
+func TestRemoteDoltHostCheck_NoDaemonJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	check := NewRemoteDoltHostCheck()
+	result := check.Run(&CheckContext{TownRoot: tmpDir})
+	if result.Status != StatusOK {
+		t.Errorf("expected OK when daemon.json missing, got %s: %s", result.Status, result.Message)
+	}
+}
+
+func TestRemoteDoltHostCheck_LocalHost(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeDaemonJSONHost(t, tmpDir, "127.0.0.1")
+
+	check := NewRemoteDoltHostCheck()
+	result := check.Run(&CheckContext{TownRoot: tmpDir})
+	if result.Status != StatusOK {
+		t.Errorf("expected OK for local host, got %s: %s", result.Status, result.Message)
+	}
+}
+
+func TestRemoteDoltHostCheck_LocalhostKeyword(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeDaemonJSONHost(t, tmpDir, "localhost")
+
+	check := NewRemoteDoltHostCheck()
+	result := check.Run(&CheckContext{TownRoot: tmpDir})
+	if result.Status != StatusOK {
+		t.Errorf("expected OK for 'localhost', got %s: %s", result.Status, result.Message)
+	}
+}
+
+func TestRemoteDoltHostCheck_RemoteHostNoEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeDaemonJSONHost(t, tmpDir, "mini2.local")
+
+	t.Setenv("GT_DOLT_HOST", "")
+
+	check := NewRemoteDoltHostCheck()
+	result := check.Run(&CheckContext{TownRoot: tmpDir})
+	if result.Status != StatusWarning {
+		t.Errorf("expected Warning when remote host set but GT_DOLT_HOST not in env, got %s: %s", result.Status, result.Message)
+	}
+	if result.FixHint == "" {
+		t.Error("expected FixHint to be set")
+	}
+}
+
+func TestRemoteDoltHostCheck_RemoteHostMatchesEnv(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeDaemonJSONHost(t, tmpDir, "100.64.1.5")
+
+	t.Setenv("GT_DOLT_HOST", "100.64.1.5")
+
+	check := NewRemoteDoltHostCheck()
+	result := check.Run(&CheckContext{TownRoot: tmpDir})
+	if result.Status != StatusOK {
+		t.Errorf("expected OK when GT_DOLT_HOST matches daemon.json, got %s: %s", result.Status, result.Message)
+	}
+}
+
+func TestRemoteDoltHostCheck_ConflictingHosts(t *testing.T) {
+	tmpDir := t.TempDir()
+	writeDaemonJSONHost(t, tmpDir, "mini2.local")
+
+	t.Setenv("GT_DOLT_HOST", "mini3.local")
+
+	check := NewRemoteDoltHostCheck()
+	result := check.Run(&CheckContext{TownRoot: tmpDir})
+	if result.Status != StatusWarning {
+		t.Errorf("expected Warning when hosts conflict, got %s: %s", result.Status, result.Message)
+	}
+}
+
+func TestRemoteDoltHostCheck_EmptyDoltServerInDaemonJSON(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Write daemon.json with no dolt_server section
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	content := `{"type":"daemon-patrol-config","version":1}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "daemon.json"), []byte(content), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewRemoteDoltHostCheck()
+	result := check.Run(&CheckContext{TownRoot: tmpDir})
+	if result.Status != StatusOK {
+		t.Errorf("expected OK when no dolt_server in daemon.json, got %s", result.Status)
+	}
+}
+
+func TestRemoteDoltHostCheck_CannotFix(t *testing.T) {
+	check := NewRemoteDoltHostCheck()
+	if check.CanFix() {
+		t.Error("RemoteDoltHostCheck should not be auto-fixable (cannot set shell env vars)")
+	}
+}
+
+// writeDaemonJSONHost writes a daemon.json with the given dolt_server.host.
+func writeDaemonJSONHost(t *testing.T, townRoot, host string) {
+	t.Helper()
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	config := map[string]interface{}{
+		"type":    "daemon-patrol-config",
+		"version": 1,
+		"patrols": map[string]interface{}{
+			"dolt_server": map[string]interface{}{
+				"host": host,
+			},
+		},
+	}
+	data, err := json.Marshal(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorDir, "daemon.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -269,6 +269,28 @@ func DefaultConfig(townRoot string) *Config {
 		config.Host = h
 	}
 
+	// Fallback: if GT_DOLT_HOST is not in the shell env, read host from
+	// mayor/daemon.json patrols.dolt_server.host. This mirrors the GT_DOLT_PORT
+	// fallback below and ensures gt CLI commands work without requiring
+	// GT_DOLT_HOST to be exported to the shell (GH#2830).
+	if config.Host == "" && townRoot != "" {
+		daemonJSONPath := filepath.Join(townRoot, "mayor", "daemon.json")
+		if data, err := os.ReadFile(daemonJSONPath); err == nil {
+			var dc struct {
+				Patrols struct {
+					DoltServer struct {
+						Host string `json:"host"`
+					} `json:"dolt_server"`
+				} `json:"patrols"`
+			}
+			if err := json.Unmarshal(data, &dc); err == nil {
+				if h := dc.Patrols.DoltServer.Host; h != "" {
+					config.Host = h
+				}
+			}
+		}
+	}
+
 	// Port precedence: config.yaml > env var > default
 	// config.yaml takes precedence to prevent stale env var pollution
 	if port := readPortFromConfigYAML(townRoot); port > 0 {


### PR DESCRIPTION
## Summary

Fixes the asymmetry where `gt` propagated `BEADS_DOLT_PORT` but not `BEADS_DOLT_SERVER_HOST` when Dolt runs on a remote machine.

- **Mirror port propagation for host**: `config/env.go` adds `resolveDoltHost()` (mirrors `resolveDoltPort()`) reading from `GT_DOLT_HOST` env var first, then `daemon.json patrols.dolt_server.host`. `AgentEnv()` now injects both `GT_DOLT_HOST` + `BEADS_DOLT_SERVER_HOST`.
- **`doltserver.DefaultConfig()` host fallback**: When `GT_DOLT_HOST` is not in the shell, reads `daemon.json patrols.dolt_server.host` — same pattern as the existing `GT_DOLT_PORT` fallback. `gt` CLI commands now auto-read the host without requiring `GT_DOLT_HOST` exported to the shell.
- **New `gt doctor remote-dolt-host` check**: Detects when `daemon.json` has a non-local `dolt_server.host` but `GT_DOLT_HOST` is missing/conflicting in the shell (useful for direct `dolt` CLI users).
- **Hint in `gt dolt start/stop` remote error**: When `IsRemote()` blocks start/stop, message now tells user where the host is configured (`mayor/daemon.json patrols.dolt_server.host`).

## Test plan

- [ ] `go test ./internal/config/ -run TestResolveDoltHost` — new `resolveDoltHost` unit tests
- [ ] `go test ./internal/config/ -run TestAgentEnv_PropagatesDoltHost` — AgentEnv host injection
- [ ] `go test ./internal/doctor/ -run TestRemoteDoltHost` — new doctor check tests
- [ ] All existing tests in `internal/config/` and `internal/doctor/` still pass

Closes #2830

🤖 Generated with [Claude Code](https://claude.com/claude-code)