### PR TITLE
fix: gt upgrade repairs missing identity beads (GH #2766)

### DIFF
--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -148,6 +148,13 @@ func upgradeDoctor(townRoot string) upgradeResult {
 	d.Register(doctor.NewLifecycleHygieneCheck())
 	d.Register(doctor.NewWorktreeGitdirCheck())
 
+	// Identity bead repair: backfill missing rig, agent, and role beads (GH#2766).
+	// Previously omitted from upgrade, leaving identity gaps that gt doctor --fix
+	// could repair but gt upgrade would not.
+	d.Register(doctor.NewAgentBeadsCheck())
+	d.Register(doctor.NewRigBeadsCheck())
+	d.Register(doctor.NewRoleBeadsCheck())
+
 	var report *doctor.Report
 	if upgradeDryRun {
 		report = d.RunStreaming(ctx, os.Stdout, 0)


### PR DESCRIPTION
## Summary

Add `NewAgentBeadsCheck`, `NewRigBeadsCheck`, and `NewRoleBeadsCheck` to `upgradeDoctor()` in `upgrade.go`.

Previously, `gt upgrade` could not backfill missing identity beads — only `gt doctor --fix` could. Towns with transient bead creation failures (e.g., Dolt outage during `gt rig add`) remained permanently degraded.

Re-opens #2859 (closed due to stale branch with pre-existing CI failure).

## Test plan

- [x] `go build ./internal/cmd/` passes
- [x] `gt upgrade` now includes identity bead checks in its doctor run
- [x] Existing `gt upgrade` behavior unchanged for healthy towns

Fixes #2766

🤖 Generated with [Claude Code](https://claude.com/claude-code)