### PR TITLE
Fix vitals zombie detection flagging sibling Gas Town instances

### DIFF
--- a/internal/cmd/vitals.go
+++ b/internal/cmd/vitals.go
@@ -58,21 +58,51 @@ func printVitalsDoltServers(townRoot string) {
 	}
 
 	// Zombie dolt processes (test servers not cleaned up)
-	for _, z := range findVitalsZombies(config.Port) {
-		fmt.Printf("  %s :%s test zombie PID %s\n", style.Warning.Render("○"), z.port, z.pid)
+	for _, z := range findVitalsZombies(townRoot, config.Port) {
+		if z.foreign {
+			fmt.Printf("  %s :%s foreign workspace PID %s\n", style.Dim.Render("○"), z.port, z.pid)
+		} else {
+			fmt.Printf("  %s :%s test zombie PID %s\n", style.Warning.Render("○"), z.port, z.pid)
+		}
 	}
 }
 
-type vitalsZombie struct{ pid, port string }
+type vitalsZombie struct {
+	pid, port string
+	foreign   bool // true if process belongs to another Gas Town workspace
+}
 
 // findVitalsZombies finds Dolt servers not on the production port.
 // Uses lsof-based port discovery instead of pgrep/ps string matching (ZFC fix: gt-fj87).
-func findVitalsZombies(prodPort int) []vitalsZombie {
+// Checks workspace ownership to avoid flagging sibling Gas Town instances as zombies.
+func findVitalsZombies(townRoot string, prodPort int) []vitalsZombie {
 	listeners := doltserver.FindAllDoltListeners()
+	expectedDataDir, _ := filepath.Abs(filepath.Join(townRoot, ".dolt-data"))
 	var zombies []vitalsZombie
 	for _, l := range listeners {
 		if l.Port == prodPort {
 			continue
+		}
+		// Check if this Dolt process belongs to a Gas Town workspace.
+		// If its --data-dir is a .dolt-data directory under a valid workspace,
+		// it's a sibling instance, not a test zombie.
+		dataDir := doltserver.GetDoltDataDirFromProcess(l.PID)
+		if dataDir != "" {
+			absDataDir, _ := filepath.Abs(dataDir)
+			if absDataDir == expectedDataDir {
+				// Our own workspace on a different port — still a zombie
+			} else if filepath.Base(absDataDir) == ".dolt-data" {
+				parentDir := filepath.Dir(absDataDir)
+				if isWs, _ := workspace.IsWorkspace(parentDir); isWs {
+					// Legitimate sibling Gas Town workspace
+					zombies = append(zombies, vitalsZombie{
+						pid:     strconv.Itoa(l.PID),
+						port:    strconv.Itoa(l.Port),
+						foreign: true,
+					})
+					continue
+				}
+			}
 		}
 		zombies = append(zombies, vitalsZombie{
 			pid:  strconv.Itoa(l.PID),

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -492,7 +492,7 @@ func IsRunning(townRoot string) (bool, int, error) {
 							// Cross-check process args as tiebreaker against PID reuse:
 							// if the OS recycled this PID for a different town's dolt
 							// after the original stopped, its --data-dir flag will differ.
-							if actualDir := getDoltDataDirFromProcess(pid); actualDir != "" {
+							if actualDir := GetDoltDataDirFromProcess(pid); actualDir != "" {
 								expected, _ := filepath.Abs(config.DataDir)
 								actual, _ := filepath.Abs(actualDir)
 								ours = actual == expected
@@ -518,7 +518,7 @@ func IsRunning(townRoot string) (bool, int, error) {
 		serverDataDir := getServerDataDir(townRoot, pid)
 		if serverDataDir == "" || serverDataDir == config.DataDir {
 			// Cross-check process args to guard against PID reuse.
-			actualDir := getDoltDataDirFromProcess(pid)
+			actualDir := GetDoltDataDirFromProcess(pid)
 			if actualDir == "" {
 				return true, pid, nil
 			}
@@ -809,14 +809,14 @@ func getServerDataDir(townRoot string, pid int) string {
 	return ""
 }
 
-// getDoltDataDirFromProcess reads the --data-dir flag value from the running
+// GetDoltDataDirFromProcess reads the --data-dir flag value from the running
 // process's command-line arguments. This is structural (reading a well-defined
 // CLI flag), not heuristic string matching. Used as a tiebreaker when the
 // state-file based check is inconclusive (e.g. PID reuse across towns).
 //
 // Supported on macOS and Linux via POSIX ps. Returns empty string on Windows
 // (not supported) or on any error.
-func getDoltDataDirFromProcess(pid int) string {
+func GetDoltDataDirFromProcess(pid int) string {
 	if runtime.GOOS == "windows" {
 		return "" // ps not available; caller falls back to trusting state file
 	}


### PR DESCRIPTION
## Summary

- `findVitalsZombies()` now checks workspace ownership before labeling Dolt processes as zombies, using the same `--data-dir` inspection approach that `KillImposters()` already uses
- Processes belonging to sibling Gas Town workspaces are labeled "foreign workspace" (dimmed) instead of "test zombie" (warning), preventing the deacon from killing them
- Exports `GetDoltDataDirFromProcess()` so the vitals command can use it

## Test plan

- [ ] Run `gt vitals` on a machine with multiple Gas Town workspaces — sibling Dolt servers should show as "foreign workspace" not "test zombie"
- [ ] Run `gt vitals` on a machine with actual test zombie Dolt processes — they should still be flagged as "test zombie"
- [ ] Verify existing vitals tests pass (`go test ./internal/cmd/ -run Vitals`)

Fixes #2998

🤖 Generated with [Claude Code](https://claude.com/claude-code)