### PR TITLE
fix(doctor): route misclassified wisp fixes by workdir

### DIFF
--- a/internal/doctor/misclassified_wisp_check.go
+++ b/internal/doctor/misclassified_wisp_check.go
@@ -26,6 +26,7 @@ type CheckMisclassifiedWisps struct {
 
 type misclassifiedWisp struct {
 	rigName string
+	workDir string
 	id      string
 	title   string
 	reason  string
@@ -61,14 +62,7 @@ func (c *CheckMisclassifiedWisps) Run(ctx *CheckContext) *CheckResult {
 
 	if useDolt {
 		for _, db := range databases {
-			prefix := db + "-"
-			rigDir := beads.GetRigPathForPrefix(ctx.TownRoot, prefix)
-			if rigDir == "" {
-				rigDir = filepath.Join(ctx.TownRoot, db)
-				if db == "hq" {
-					rigDir = ctx.TownRoot
-				}
-			}
+			rigDir := resolveMisclassifiedWispWorkDir(ctx.TownRoot, misclassifiedWisp{rigName: db})
 			found, probeErrors := c.findMisplacedEphemeralsDolt(rigDir, db)
 			totalProbeErrors += probeErrors
 			if len(found) > 0 {
@@ -141,6 +135,7 @@ func (c *CheckMisclassifiedWisps) findMisplacedEphemeralsDolt(rigDir, rigName st
 		}
 		found = append(found, misclassifiedWisp{
 			rigName: rigName,
+			workDir: rigDir,
 			id:      strings.TrimSpace(rec[0]),
 			title:   strings.TrimSpace(rec[1]),
 			reason:  "ephemeral bead in issues table",
@@ -161,18 +156,14 @@ func (c *CheckMisclassifiedWisps) Fix(ctx *CheckContext) error {
 	// Group by rig for batch operations.
 	rigBatches := make(map[string][]misclassifiedWisp)
 	for _, w := range c.misclassified {
-		rigBatches[w.rigName] = append(rigBatches[w.rigName], w)
+		workDir := resolveMisclassifiedWispWorkDir(ctx.TownRoot, w)
+		rigBatches[workDir] = append(rigBatches[workDir], w)
 	}
 
 	var errs []string
 
-	for rigName, batch := range rigBatches {
-		var workDir string
-		if rigName == "town" || rigName == "hq" {
-			workDir = ctx.TownRoot
-		} else {
-			workDir = filepath.Join(ctx.TownRoot, rigName)
-		}
+	for workDir, batch := range rigBatches {
+		rigName := batch[0].rigName
 
 		ids := make([]string, len(batch))
 		for i, w := range batch {
@@ -189,6 +180,22 @@ func (c *CheckMisclassifiedWisps) Fix(ctx *CheckContext) error {
 		return fmt.Errorf("partial fix: %s", strings.Join(errs, "; "))
 	}
 	return nil
+}
+
+func resolveMisclassifiedWispWorkDir(townRoot string, w misclassifiedWisp) string {
+	if w.workDir != "" {
+		return w.workDir
+	}
+
+	if w.rigName == "town" || w.rigName == "hq" {
+		return townRoot
+	}
+
+	if rigDir := beads.GetRigPathForPrefix(townRoot, w.rigName+"-"); rigDir != "" {
+		return rigDir
+	}
+
+	return filepath.Join(townRoot, w.rigName)
 }
 
 // purgeRigBatch migrates a batch of ephemeral beads from issues to wisps:

--- a/internal/doctor/misclassified_wisp_check_test.go
+++ b/internal/doctor/misclassified_wisp_check_test.go
@@ -15,21 +15,34 @@ import (
 func TestFixWorkDir_HQ(t *testing.T) {
 	townRoot := t.TempDir()
 
-	check := NewCheckMisclassifiedWisps()
-	// Inject a misplaced ephemeral with rigName "hq" (as Dolt path would produce).
-	check.misclassified = []misclassifiedWisp{
-		{rigName: "hq", id: "hq-test-event", title: "test event", reason: "ephemeral bead in issues table"},
-	}
-
-	ctx := &CheckContext{TownRoot: townRoot}
-	// Fix will fail (no bd binary in test), but we can verify the workDir
-	// derivation by checking that it does NOT try to use townRoot/hq.
-	_ = check.Fix(ctx)
-
-	// The key assertion: "hq" should resolve to townRoot, not townRoot/hq.
+	got := resolveMisclassifiedWispWorkDir(townRoot, misclassifiedWisp{rigName: "hq"})
 	hqPath := filepath.Join(townRoot, "hq")
 	if hqPath == townRoot {
 		t.Fatal("test setup error: townRoot should not end in /hq")
+	}
+	if got != townRoot {
+		t.Fatalf("resolveMisclassifiedWispWorkDir(%q, hq) = %q, want %q", townRoot, got, townRoot)
+	}
+}
+
+func TestFixWorkDir_RoutedRig(t *testing.T) {
+	townRoot := t.TempDir()
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	routesContent := `{"prefix":"hq-","path":"."}
+{"prefix":"sw-","path":"sallaWork/mayor/rig"}
+`
+	if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), []byte(routesContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	want := filepath.Join(townRoot, "sallaWork/mayor/rig")
+	got := resolveMisclassifiedWispWorkDir(townRoot, misclassifiedWisp{rigName: "sw"})
+	if got != want {
+		t.Fatalf("resolveMisclassifiedWispWorkDir(%q, sw) = %q, want %q", townRoot, got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary
- preserve the resolved rig workdir when detecting misplaced wisps
- batch misclassified-wisp fixes by resolved workdir instead of rebuilding townRoot/<db>
- add regression coverage for hq and routed rig paths

## Context
`gt doctor --fix` could detect misplaced wisps on routed rigs, but the fix path later reconstructed the workdir from the database prefix and ran the migration in the wrong directory.

## Testing
- go test ./internal/doctor -run 'TestFixWorkDir_HQ|TestFixWorkDir_RoutedRig|TestRigDirResolution_Logic|TestGetRigPathForPrefix_RoutesResolution'