### PR TITLE
fix(dolt): increase SIGTERM→SIGKILL timeout from 5s to 30s

### DIFF
--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -917,9 +917,10 @@ func (m *DoltServerManager) stopLocked() {
 	select {
 	case <-done:
 		m.logger("Dolt SQL server stopped gracefully")
-	case <-time.After(5 * time.Second):
-		// Force kill
-		m.logger("Dolt SQL server did not stop gracefully, forcing termination")
+	case <-time.After(30 * time.Second):
+		// Force kill — 30s allows Dolt to flush its append-only journal under load.
+		// A SIGKILL mid-journal-write causes corruption requiring dolt fsck to recover.
+		m.logger("Dolt SQL server did not stop gracefully after 30s, forcing termination")
 		_ = sendKillSignal(process)
 	}
 


### PR DESCRIPTION
## Summary
- Increase the Dolt server shutdown timeout from 5s to 30s before sending SIGKILL
- Under load (3M+ connections), Dolt can't flush its append-only noms journal in 5 seconds
- A SIGKILL mid-journal-write causes corruption requiring manual `dolt fsck --revive-journal-with-data-loss`

## Evidence
Observed twice in production (2026-03-14 and 2026-03-18). The cascade:
1. `stopLocked()` sends SIGTERM, waits 5s, sends SIGKILL
2. Journal corruption at write offset
3. All restart attempts fail with "corrupted journal"
4. Rig-level bd commands spawn imposter Dolt instances (now mitigated by #2938)

## Test plan
- [ ] Verify Dolt stops gracefully under load within 30s
- [ ] Verify SIGKILL still fires if Dolt is truly hung (> 30s)
- [ ] Existing tests pass (no test changes needed — timeout is not unit-tested)

🤖 Generated with [Claude Code](https://claude.com/claude-code)