### PR TITLE
fix: resolve rig directory for epic children SQL query (gas-v80)

### DIFF
--- a/internal/cmd/scheduler_epic.go
+++ b/internal/cmd/scheduler_epic.go
@@ -301,9 +301,23 @@ type epicChild struct {
 func getEpicChildren(epicID string) ([]epicChild, error) {
 	dir := resolveBeadDir(epicID)
 
+	// bd sql queries the database discovered from cmd.Dir. When the epic lives
+	// in a rig database (not HQ), we must resolve to the rig's directory so
+	// bd sql queries the correct database. resolveBeadDir returns the town root
+	// (for bd CLI routing), but bd sql doesn't use routes.jsonl.
+	sqlDir := dir
+	if prefix := beads.ExtractPrefix(epicID); prefix != "" {
+		townRoot, err := workspace.FindFromCwd()
+		if err == nil {
+			if rigPath := beads.GetRigPathForPrefix(townRoot, prefix); rigPath != "" {
+				sqlDir = rigPath
+			}
+		}
+	}
+
 	// Prefer raw SQL — handles cross-database deps. Falls back to bd dep list
 	// if bd sql is not available (older bd versions).
-	childIDs, err := bdDepListRawIDs(dir, epicID, "down", "depends_on")
+	childIDs, err := bdDepListRawIDs(sqlDir, epicID, "down", "depends_on")
 	if err != nil {
 		// bd sql not supported — fall back to bd dep list.
 		childIDs, err = bdDepListFallback(dir, epicID)

--- a/internal/cmd/show.go
+++ b/internal/cmd/show.go
@@ -91,7 +91,7 @@ func extractBeadIDFromArgs(args []string) string {
 }
 
 // stripEnvKey removes all entries matching the given key from an environment slice.
-func stripEnvKey(env []string, key string) []string {
+func stripEnvKey(env []string, key string) []string { //nolint:unparam // key is always BEADS_DIR today but the function is intentionally generic
 	prefix := key + "="
 	result := make([]string, 0, len(env))
 	for _, e := range env {

--- a/internal/daemon/compactor_dog.go
+++ b/internal/daemon/compactor_dog.go
@@ -546,7 +546,7 @@ func (d *Daemon) surgicalCleanup(db *sql.DB, baseBranch, workBranch string) {
 }
 
 // surgicalAbortAndCleanup aborts an in-progress rebase, then cleans up.
-func (d *Daemon) surgicalAbortAndCleanup(db *sql.DB, baseBranch, workBranch string) {
+func (d *Daemon) surgicalAbortAndCleanup(db *sql.DB, baseBranch, workBranch string) { //nolint:unparam // baseBranch is always "compact-base" but kept for API symmetry with surgicalCleanup
 	ctx, cancel := context.WithTimeout(context.Background(), compactorQueryTimeout)
 	defer cancel()
 	_, _ = db.ExecContext(ctx, "CALL DOLT_REBASE('--abort')")


### PR DESCRIPTION
## Summary
- Fix `getEpicChildren` to resolve the correct rig directory for `bd sql` queries instead of using the town root, which returned "Epic has no child issues" for rig-scoped epics
- Suppress two `unparam` lint warnings for intentionally generic API parameters

## Test plan
- [x] Fixes TestSchedulerMultiRigEpicAutoResolve
- [x] Fixes TestSchedulerEpicDetection  
- [x] Fixes TestSchedulerDirectEpicDispatch
- [x] Fixes golangci-lint CI failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)