### PR TITLE
fix: respect CLAUDE_CONFIG_DIR in gt costs transcript lookup

### DIFF
--- a/internal/cmd/costs.go
+++ b/internal/cmd/costs.go
@@ -48,8 +48,9 @@ var costsCmd = &cobra.Command{
 	Short:   "Show costs for running Claude sessions",
 	Long: `Display costs for Claude Code sessions in Gas Town.
 
-Costs are calculated from Claude Code transcript files at ~/.claude/projects/
-by summing token usage from assistant messages and applying model-specific pricing.
+Costs are calculated from Claude Code transcript files in
+$CLAUDE_CONFIG_DIR/projects/ (defaults to ~/.claude/projects/) by summing
+token usage from assistant messages and applying model-specific pricing.
 
 Examples:
   gt costs              # Live costs from running sessions
@@ -72,7 +73,8 @@ var costsRecordCmd = &cobra.Command{
 	Long: `Record the final cost of a session to a local log file.
 
 This command is intended to be called from a Claude Code Stop hook.
-It reads token usage from the Claude Code transcript file (~/.claude/projects/...)
+It reads token usage from the Claude Code transcript file
+($CLAUDE_CONFIG_DIR/projects/... or ~/.claude/projects/...)
 and calculates the cost based on model pricing, then appends it to
 ~/.gt/costs.jsonl. This is a simple append operation that never fails
 due to database availability.
@@ -674,9 +676,10 @@ func extractCost(content string) float64 {
 }
 
 // getClaudeProjectDir returns the Claude Code project directory for a working directory.
-// Claude Code stores transcripts in ~/.claude/projects/<path-with-dashes-instead-of-slashes>/
+// Claude Code stores transcripts in <config-dir>/projects/<path-with-dashes-instead-of-slashes>/
+// Respects CLAUDE_CONFIG_DIR env var, falling back to ~/.claude.
 func getClaudeProjectDir(workDir string) (string, error) {
-	home, err := os.UserHomeDir()
+	configDir, err := config.ClaudeConfigDir()
 	if err != nil {
 		return "", err
 	}
@@ -684,7 +687,7 @@ func getClaudeProjectDir(workDir string) (string, error) {
 	// Convert path to Claude's directory naming: replace / with -
 	// Keep leading slash - it becomes a leading dash in Claude's encoding
 	projectName := strings.ReplaceAll(workDir, "/", "-")
-	return filepath.Join(home, ".claude", "projects", projectName), nil
+	return filepath.Join(configDir, "projects", projectName), nil
 }
 
 // findLatestTranscript finds the most recently modified .jsonl file in a directory.

--- a/internal/cmd/costs_test.go
+++ b/internal/cmd/costs_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -290,5 +291,36 @@ func TestCostDigestPayload_ExcludesSessions(t *testing.T) {
 	}
 	if len(asDigest.ByRole) != 3 {
 		t.Errorf("by_role should have 3 entries, got %d", len(asDigest.ByRole))
+	}
+}
+
+func TestGetClaudeProjectDir_Default(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("getting home dir: %v", err)
+	}
+
+	got, err := getClaudeProjectDir("/some/work/dir")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(home, ".claude", "projects", "-some-work-dir")
+	if got != want {
+		t.Errorf("getClaudeProjectDir() = %q, want %q", got, want)
+	}
+}
+
+func TestGetClaudeProjectDir_RespectsEnvVar(t *testing.T) {
+	customDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", customDir)
+
+	got, err := getClaudeProjectDir("/some/work/dir")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(customDir, "projects", "-some-work-dir")
+	if got != want {
+		t.Errorf("getClaudeProjectDir() = %q, want %q", got, want)
 	}
 }

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -605,3 +605,18 @@ func EnvToSlice(env map[string]string) []string {
 	}
 	return result
 }
+
+// ClaudeConfigDir resolves the Claude Code configuration directory.
+// Resolution order:
+//  1. CLAUDE_CONFIG_DIR env var (if set and non-empty)
+//  2. $HOME/.claude (fallback)
+func ClaudeConfigDir() (string, error) {
+	if dir := os.Getenv("CLAUDE_CONFIG_DIR"); dir != "" {
+		return dir, nil
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude"), nil
+}

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -1221,3 +1221,33 @@ func TestAgentEnv_NoDoltPortWithoutConfig(t *testing.T) {
 	assertNotSet(t, env, "GT_DOLT_PORT")
 	assertNotSet(t, env, "BEADS_DOLT_PORT")
 }
+
+func TestClaudeConfigDir_Default(t *testing.T) {
+	t.Setenv("CLAUDE_CONFIG_DIR", "")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Fatalf("getting home dir: %v", err)
+	}
+
+	got, err := ClaudeConfigDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	want := filepath.Join(home, ".claude")
+	if got != want {
+		t.Errorf("ClaudeConfigDir() = %q, want %q", got, want)
+	}
+}
+
+func TestClaudeConfigDir_EnvVar(t *testing.T) {
+	customDir := t.TempDir()
+	t.Setenv("CLAUDE_CONFIG_DIR", customDir)
+
+	got, err := ClaudeConfigDir()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != customDir {
+		t.Errorf("ClaudeConfigDir() = %q, want %q", got, customDir)
+	}
+}


### PR DESCRIPTION
## Summary

`gt costs` returns $0 for all sessions when `CLAUDE_CONFIG_DIR` points to a location other than `$HOME/.claude`. The root cause is `getClaudeProjectDir()` hardcoding `$HOME/.claude` to locate transcripts, even though gastown itself sets `CLAUDE_CONFIG_DIR` when spawning agents.

## Changes

- Add `config.ClaudeConfigDir()` helper in `internal/config/env.go` that checks `CLAUDE_CONFIG_DIR` first, falling back to `$HOME/.claude`
- Update `getClaudeProjectDir()` in `internal/cmd/costs.go` to use the helper
- Update help text for `gt costs` and `gt costs record` to document both paths
- Add unit tests for the helper and the fixed function (default + env var cases)

## Known related locations

The same hardcoded `$HOME/.claude` pattern exists in other files. These are intentionally not included to keep this PR small and reviewable:

- `internal/agentlog/claudecode.go` — `claudeProjectDirFor()` (log tailing)
- `internal/cmd/seance.go` — `findSessionLocation()`, `symlinkSessionToCurrentAccount()`, `cleanupOrphanedSessionSymlinks()`
- `internal/cmd/account.go` — `ensureSharedCommandsSymlink()`

These can be addressed in follow-up work using the `ClaudeConfigDir()` helper introduced here. `internal/config/types.go` (`~/.claude/local/claude`) is the binary install path, not config data — not affected by `CLAUDE_CONFIG_DIR`.

## Testing

- [x] Unit tests pass (`go test -race -short ./internal/cmd/... ./internal/config/...`)
- [x] `go vet ./...` clean
- [x] Manual verification: `CLAUDE_CONFIG_DIR=/custom/path gt costs` reads from correct location

## Reproduction

export CLAUDE_CONFIG_DIR=/workspace/home/.claude
gt costs -v
Before: "lstat /home/user/.claude/projects/...: no such file or directory"
After:  reads from $CLAUDE_CONFIG_DIR/projects/ correctly

## Checklist

- [x] Code follows project style
- [x] Documentation updated (help text)
- [x] No breaking changes
