### PR TITLE
fix: refinery PR mode must wait for CI and merge before sending MERGED

### DIFF
--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -608,7 +608,40 @@ gh pr view <polecat-branch> --json url,state -q '.url + " " + .state'
 
 If the PR was not created or is in an unexpected state, debug and retry.
 
-⚠️ **STOP HERE - DO NOT PROCEED UNTIL STEPS 1.5 AND 2-3 COMPLETE**
+**Step 1.6 (pr only): WAIT FOR CI CHECKS TO PASS**
+
+⚠️ **DO NOT PROCEED until CI passes. DO NOT send MERGED until the PR is actually merged.**
+
+```bash
+# Get the repo URL for gh commands
+REPO_URL=$(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\.git/\1/')
+
+# Wait for CI checks (timeout 15 minutes)
+gh pr checks <polecat-branch> --repo "$REPO_URL" --watch --fail-fast
+```
+
+**If CI checks FAIL:**
+Do NOT merge. Send FIX_NEEDED back to the polecat:
+```bash
+FAILURE_OUTPUT=$(gh pr checks <polecat-branch> --repo "$REPO_URL" 2>&1)
+gt mail send <rig>/witness -s "FIX_NEEDED <polecat-name>" -m "Branch: <branch>
+Issue: <issue-id>
+PR: ${PR_URL}
+Failure-Type: ci-checks
+Error: $FAILURE_OUTPUT
+Attempt-Number: 1"
+```
+Then skip to Step 4 (archive mail) and continue patrol.
+
+**If CI checks PASS:**
+Merge the PR:
+```bash
+gh pr merge <polecat-branch> --repo "$REPO_URL" --merge --delete-branch
+```
+
+If merge fails (conflict, branch protection), debug and retry.
+
+⚠️ **STOP HERE - DO NOT PROCEED UNTIL THE PR IS ACTUALLY MERGED ON GITHUB**
 
 **Step 2: Send MERGED Notification (REQUIRED - DO THIS IMMEDIATELY)**
 
@@ -629,8 +662,8 @@ PR: ${PR_URL}
 Merged-At: $(date -u +%Y-%m-%dT%H:%M:%SZ)"
 ```
 
-Note: In PR mode, "MERGED" means "PR created and ready for review/merge".
-The actual merge happens when the PR is merged on GitHub (by maintainer or CI).
+Note: In PR mode, MERGED is only sent AFTER `gh pr merge` succeeds — the PR
+is actually merged on GitHub before the witness is notified.
 
 This signals the Witness to nuke the polecat worktree. WITHOUT THIS NOTIFICATION,
 POLECAT WORKTREES ACCUMULATE INDEFINITELY AND THE LIFECYCLE BREAKS.


### PR DESCRIPTION
## Summary

When `merge_strategy=pr`, the refinery sends `MERGED` to the witness immediately
after creating the PR — before CI runs or the PR is actually merged on GitHub.
The witness then cleans up the polecat (deleting the branch), which causes the
PR to be closed without merging. **Work is lost.**

## Root Cause

In `mol-refinery-patrol.formula.toml`, the PR mode flow goes:
1. Create PR
2. Send MERGED ← **too early**
3. Witness cleans up polecat → branch deleted → PR auto-closed

## Fix

Add **Step 1.6** between PR creation and MERGED notification:

1. **Wait for CI checks**: `gh pr checks <branch> --watch --fail-fast`
2. **If CI fails**: Send `FIX_NEEDED` back to polecat (not MERGED)
3. **If CI passes**: Merge the PR with `gh pr merge --merge --delete-branch`
4. **Only then** send MERGED to witness

## Testing

Tested in production on `totalslacker/ContextVault`:
- Before fix: PRs #10, #11, #12, #16, #17, #18, #19 all closed without merging (work lost 4+ times)
- After fix: PR #20 went through the full flow — CI passed, PR merged, changes landed on main

## Test plan

- [ ] Set `merge_strategy=pr` on a rig
- [ ] Sling a task to a polecat
- [ ] Verify refinery creates PR
- [ ] Verify refinery waits for CI checks
- [ ] Verify refinery merges PR after CI passes
- [ ] Verify MERGED sent only after actual merge
- [ ] Verify polecat cleanup happens after merge, not before

🤖 Generated with [Claude Code](https://claude.com/claude-code)