### PR TITLE
refactor: deduplicate config lookup and convoy close pipelines

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -897,6 +897,46 @@ func runConvoyCheck(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+// closeConvoyIfComplete checks whether all tracked issues in a convoy are resolved
+// and closes the convoy if so. Returns (true, nil) if the convoy was closed or
+// would be closed (dry-run), (false, nil) if not ready, or (false, err) on failure.
+func closeConvoyIfComplete(townBeads, convoyID, title string, tracked []trackedIssueInfo, dryRun bool) (bool, error) {
+	allClosed := true
+	openCount := 0
+	for _, t := range tracked {
+		if t.Status != "closed" && t.Status != "tombstone" {
+			allClosed = false
+			openCount++
+		}
+	}
+
+	if !allClosed {
+		fmt.Printf("%s Convoy %s has %d open issue(s) remaining\n", style.Dim.Render("○"), convoyID, openCount)
+		return false, nil
+	}
+
+	if dryRun {
+		fmt.Printf("%s Would auto-close convoy 🚚 %s: %s\n", style.Warning.Render("⚠"), convoyID, title)
+		return true, nil
+	}
+
+	reason := "All tracked issues completed"
+	if len(tracked) == 0 {
+		reason = "Empty convoy (0 tracked issues) — auto-closed as definitionally complete"
+	}
+	closeArgs := []string{"close", convoyID, "-r", reason}
+	closeCmd := exec.Command("bd", closeArgs...)
+	closeCmd.Dir = townBeads
+
+	if err := closeCmd.Run(); err != nil {
+		return false, fmt.Errorf("closing convoy: %w", err)
+	}
+
+	fmt.Printf("%s Auto-closed convoy 🚚 %s: %s\n", style.Bold.Render("✓"), convoyID, title)
+	notifyConvoyCompletion(townBeads, convoyID, title)
+	return true, nil
+}
+
 // checkSingleConvoy checks a specific convoy and closes it if all tracked issues are complete.
 func checkSingleConvoy(townBeads, convoyID string, dryRun bool) error {
 	// Get convoy details
@@ -946,47 +986,9 @@ func checkSingleConvoy(townBeads, convoyID string, dryRun bool) error {
 	if err != nil {
 		return fmt.Errorf("checking convoy %s: %w", convoyID, err)
 	}
-	// A convoy with 0 tracked issues is definitionally complete
-	// (tracking deps were likely lost). Treat as all-closed.
-	allClosed := true
-	openCount := 0
-	for _, t := range tracked {
-		if t.Status != "closed" && t.Status != "tombstone" {
-			allClosed = false
-			openCount++
-		}
-	}
 
-	if !allClosed {
-		fmt.Printf("%s Convoy %s has %d open issue(s) remaining\n", style.Dim.Render("○"), convoyID, openCount)
-		return nil
-	}
-
-	// All tracked issues are complete (or convoy is empty) - close the convoy
-	if dryRun {
-		fmt.Printf("%s Would auto-close convoy 🚚 %s: %s\n", style.Warning.Render("⚠"), convoyID, convoy.Title)
-		return nil
-	}
-
-	// Actually close the convoy
-	reason := "All tracked issues completed"
-	if len(tracked) == 0 {
-		reason = "Empty convoy (0 tracked issues) — auto-closed as definitionally complete"
-	}
-	closeArgs := []string{"close", convoyID, "-r", reason}
-	closeCmd := exec.Command("bd", closeArgs...)
-	closeCmd.Dir = townBeads
-
-	if err := closeCmd.Run(); err != nil {
-		return fmt.Errorf("closing convoy: %w", err)
-	}
-
-	fmt.Printf("%s Auto-closed convoy 🚚 %s: %s\n", style.Bold.Render("✓"), convoyID, convoy.Title)
-
-	// Send completion notification
-	notifyConvoyCompletion(townBeads, convoyID, convoy.Title)
-
-	return nil
+	_, err = closeConvoyIfComplete(townBeads, convoyID, convoy.Title, tracked, dryRun)
+	return err
 }
 
 func runConvoyClose(cmd *cobra.Command, args []string) error {
@@ -1675,41 +1677,13 @@ func checkAndCloseCompletedConvoys(townBeads string, dryRun bool) ([]struct{ ID,
 			style.PrintWarning("skipping convoy %s: %v", convoy.ID, err)
 			continue
 		}
-		// A convoy with 0 tracked issues is definitionally complete
-		// (tracking deps were likely lost). Close it.
-		allClosed := true
-		for _, t := range tracked {
-			if t.Status != "closed" && t.Status != "tombstone" {
-				allClosed = false
-				break
-			}
+		ready, err := closeConvoyIfComplete(townBeads, convoy.ID, convoy.Title, tracked, dryRun)
+		if err != nil {
+			style.PrintWarning("couldn't close convoy %s: %v", convoy.ID, err)
+			continue
 		}
-
-		if allClosed {
-			if dryRun {
-				// In dry-run mode, just record what would be closed
-				closed = append(closed, struct{ ID, Title string }{convoy.ID, convoy.Title})
-				continue
-			}
-
-			// Close the convoy
-			reason := "All tracked issues completed"
-			if len(tracked) == 0 {
-				reason = "Empty convoy (0 tracked issues) — auto-closed as definitionally complete"
-			}
-			closeArgs := []string{"close", convoy.ID, "-r", reason}
-			closeCmd := exec.Command("bd", closeArgs...)
-			closeCmd.Dir = townBeads
-
-			if err := closeCmd.Run(); err != nil {
-				style.PrintWarning("couldn't close convoy %s: %v", convoy.ID, err)
-				continue
-			}
-
+		if ready {
 			closed = append(closed, struct{ ID, Title string }{convoy.ID, convoy.Title})
-
-			// Check if convoy has notify address and send notification
-			notifyConvoyCompletion(townBeads, convoy.ID, convoy.Title)
 		}
 	}
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1318,6 +1318,24 @@ func ResolveRoleAgentConfig(role, townRoot, rigPath string) *RuntimeConfig {
 	return withRoleSettingsFlag(rc, role, rigPath)
 }
 
+// tryResolveNamedAgent attempts to resolve a named agent through the custom agent
+// and standard lookup pipelines. Returns the resolved config with ResolvedAgent set,
+// or nil if validation fails. The warnPrefix is used in the fallback warning message
+// (e.g., "worker_agents[denali]" or "crew_agents[denali]").
+func tryResolveNamedAgent(agentName, warnPrefix string, townSettings *TownSettings, rigSettings *RigSettings) *RuntimeConfig {
+	if rc := lookupCustomAgentConfig(agentName, townSettings, rigSettings); rc != nil {
+		rc.ResolvedAgent = agentName
+		return rc
+	}
+	if err := ValidateAgentConfig(agentName, townSettings, rigSettings); err != nil {
+		fmt.Fprintf(os.Stderr, "warning: %s=%s - %v, falling back\n", warnPrefix, agentName, err)
+		return nil
+	}
+	rc := lookupAgentConfig(agentName, townSettings, rigSettings)
+	rc.ResolvedAgent = agentName
+	return rc
+}
+
 // ResolveWorkerAgentConfig resolves the agent configuration for a named crew worker.
 // Resolution order:
 //  1. Rig's WorkerAgents[workerName] — per-worker override
@@ -1329,7 +1347,7 @@ func ResolveWorkerAgentConfig(workerName, townRoot, rigPath string) *RuntimeConf
 	resolveConfigMu.Lock()
 	defer resolveConfigMu.Unlock()
 
-	// Check rig's WorkerAgents
+	// Tier 1: rig's per-worker override
 	if workerName != "" && rigPath != "" {
 		if rigSettings, err := LoadRigSettings(RigSettingsPath(rigPath)); err == nil && rigSettings != nil {
 			if agentName, ok := rigSettings.WorkerAgents[workerName]; ok && agentName != "" {
@@ -1339,22 +1357,14 @@ func ResolveWorkerAgentConfig(workerName, townRoot, rigPath string) *RuntimeConf
 				}
 				_ = LoadAgentRegistry(DefaultAgentRegistryPath(townRoot))
 				_ = LoadRigAgentRegistry(RigAgentRegistryPath(rigPath))
-				if rc := lookupCustomAgentConfig(agentName, townSettings, rigSettings); rc != nil {
-					rc.ResolvedAgent = agentName
-					return withRoleSettingsFlag(rc, "crew", rigPath)
-				}
-				if err := ValidateAgentConfig(agentName, townSettings, rigSettings); err != nil {
-					fmt.Fprintf(os.Stderr, "warning: worker_agents[%s]=%s - %v, falling back\n", workerName, agentName, err)
-				} else {
-					rc := lookupAgentConfig(agentName, townSettings, rigSettings)
-					rc.ResolvedAgent = agentName
+				if rc := tryResolveNamedAgent(agentName, fmt.Sprintf("worker_agents[%s]", workerName), townSettings, rigSettings); rc != nil {
 					return withRoleSettingsFlag(rc, "crew", rigPath)
 				}
 			}
 		}
 	}
 
-	// Check town's CrewAgents
+	// Tier 2: town's per-crew override
 	if workerName != "" && townRoot != "" {
 		townSettings, err := LoadOrCreateTownSettings(TownSettingsPath(townRoot))
 		if err == nil && townSettings != nil {
@@ -1367,22 +1377,14 @@ func ResolveWorkerAgentConfig(workerName, townRoot, rigPath string) *RuntimeConf
 				if rigPath != "" {
 					_ = LoadRigAgentRegistry(RigAgentRegistryPath(rigPath))
 				}
-				if rc := lookupCustomAgentConfig(agentName, townSettings, rigSettings); rc != nil {
-					rc.ResolvedAgent = agentName
-					return withRoleSettingsFlag(rc, "crew", rigPath)
-				}
-				if err := ValidateAgentConfig(agentName, townSettings, rigSettings); err != nil {
-					fmt.Fprintf(os.Stderr, "warning: crew_agents[%s]=%s - %v, falling back\n", workerName, agentName, err)
-				} else {
-					rc := lookupAgentConfig(agentName, townSettings, rigSettings)
-					rc.ResolvedAgent = agentName
+				if rc := tryResolveNamedAgent(agentName, fmt.Sprintf("crew_agents[%s]", workerName), townSettings, rigSettings); rc != nil {
 					return withRoleSettingsFlag(rc, "crew", rigPath)
 				}
 			}
 		}
 	}
 
-	// Fall back to crew role resolution (already holds lock; use core function)
+	// Tier 3: fall back to crew role resolution (already holds lock; use core function)
 	rc := resolveRoleAgentConfigCore("crew", townRoot, rigPath)
 	return withRoleSettingsFlag(rc, "crew", rigPath)
 }
@@ -1678,27 +1680,11 @@ func ResolveRoleAgentName(role, townRoot, rigPath string) (agentName string, isR
 
 // lookupAgentConfig looks up an agent by name.
 // Checks rig-level custom agents first, then town's custom agents, then built-in presets from agents.go.
+// Falls back to DefaultRuntimeConfig() if no match is found.
 func lookupAgentConfig(name string, townSettings *TownSettings, rigSettings *RigSettings) *RuntimeConfig {
-	// First check rig's custom agents (NEW - fix for rig-level agent support)
-	if rigSettings != nil && rigSettings.Agents != nil {
-		if custom, ok := rigSettings.Agents[name]; ok && custom != nil {
-			return fillRuntimeDefaults(custom)
-		}
+	if rc := lookupAgentConfigIfExists(name, townSettings, rigSettings); rc != nil {
+		return rc
 	}
-
-	// Then check town's custom agents (existing)
-	if townSettings != nil && townSettings.Agents != nil {
-		if custom, ok := townSettings.Agents[name]; ok && custom != nil {
-			return fillRuntimeDefaults(custom)
-		}
-	}
-
-	// Check built-in presets from agents.go
-	if preset := GetAgentPresetByName(name); preset != nil {
-		return RuntimeConfigFromPreset(AgentPreset(name))
-	}
-
-	// Fallback to claude defaults
 	return DefaultRuntimeConfig()
 }
 


### PR DESCRIPTION
Closes #3024

## Summary

Three small refactors to eliminate duplicated code paths:

- **lookupAgentConfig delegates to lookupAgentConfigIfExists** — the 3-tier lookup (rig custom agents, town custom agents, built-in presets) was duplicated verbatim between these two functions. Now lookupAgentConfig calls lookupAgentConfigIfExists and falls back to DefaultRuntimeConfig(). Future changes to lookup order only need to happen in one place.

- **Extract closeConvoyIfComplete in convoy.go** — checkSingleConvoy and checkAndCloseCompletedConvoys independently implemented the same close-if-complete pipeline: check tracked issue statuses, build close reason, execute bd close, print output, call notifyConvoyCompletion. Both now delegate to a shared helper.

- **Extract tryResolveNamedAgent in loader.go** — ResolveWorkerAgentConfig had structurally identical rig-tier and town-tier resolution blocks (custom lookup, validate, standard lookup, set ResolvedAgent). Extracted to a shared helper, reducing ~50 lines to ~25.

Net result: -40 lines (73 added, 113 removed). No behavioral changes.

## Test plan

- [x] go build -o gt ./cmd/gt — clean build
- [x] go vet ./internal/config/... ./internal/cmd/... — clean
- [x] go test ./internal/config/... — all tests pass
- [x] go test ./internal/cmd/... — all tests pass (pre-existing TestUpgradeCLAUDEMD_CreatesMissingFile Windows symlink failure is unrelated, verified on main)
- [x] go test ./... — only pre-existing internal/proxy failure, unrelated to these changes
- [x] gofmt: both files have pre-existing formatting drift on main, no new drift introduced