### PR TITLE
fix: set cmd.Dir in doltserver.Start() to prevent wrong-CWD launches

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1477,6 +1477,7 @@ func Start(townRoot string) error {
 	}
 	args := []string{"sql-server", "--config", configPath}
 	cmd := exec.Command("dolt", args...)
+	cmd.Dir = config.DataDir
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 


### PR DESCRIPTION
## Summary

- `doltserver.Start()` (CLI path via `gt dolt start`) did not set `cmd.Dir` on the spawned `dolt sql-server` process
- The server inherited the caller's CWD, and if that wasn't the data directory, it failed to discover any databases
- The daemon's equivalent (`daemon/dolt.go:808`) already sets `cmd.Dir = config.DataDir` correctly

## What changed

One line added in `internal/doltserver/doltserver.go`: `cmd.Dir = config.DataDir` after `exec.Command("dolt", args...)`, matching the daemon's implementation.

## Observed failure

Server restarted from `pr_sdk/.beads/dolt/` → 27 rig databases invisible via TCP despite existing on disk → full beads/mail outage across all rigs. `gt dolt status` appeared healthy (directory scan) while the TCP server served nothing.

## Test plan

- [ ] `gt dolt stop && cd /tmp && gt dolt start` — verify server discovers all databases
- [ ] `gt dolt status` output matches actual TCP-served databases
- [ ] Existing `doltserver` tests pass

Fixes #3028
Related: #2537

🤖 Generated with [Claude Code](https://claude.com/claude-code)