### PR TITLE
fix: resolve prefix→rig mapping in doctor checks to prevent DB drops

### DIFF
--- a/internal/doctor/migration_check.go
+++ b/internal/doctor/migration_check.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/util"
 )
@@ -69,9 +70,17 @@ func (c *DoltMetadataCheck) Run(ctx *CheckContext) *CheckResult {
 	rigsPath := filepath.Join(ctx.TownRoot, "mayor", "rigs.json")
 	rigs := c.loadRigs(rigsPath)
 	for rigName := range rigs {
-		// Only check rigs that have a dolt database
+		// Resolve the expected DB name: some rigs use their prefix as the
+		// database name (e.g., "lc" for laneassist) rather than the rig name.
+		// Check both rig name and prefix in .dolt-data/. (gt-85w7)
+		expectedDB := rigName
+		prefix := config.GetRigPrefix(ctx.TownRoot, rigName)
 		if _, err := os.Stat(filepath.Join(doltDataDir, rigName)); os.IsNotExist(err) {
-			continue
+			// Rig name not found — check if prefix-named DB exists
+			if _, err := os.Stat(filepath.Join(doltDataDir, prefix)); os.IsNotExist(err) {
+				continue // No database under either name
+			}
+			expectedDB = prefix
 		}
 
 		beadsDir := c.findRigBeadsDir(ctx.TownRoot, rigName)
@@ -81,7 +90,7 @@ func (c *DoltMetadataCheck) Run(ctx *CheckContext) *CheckResult {
 			continue
 		}
 
-		if !c.hasDoltMetadata(beadsDir, rigName) {
+		if !c.hasDoltMetadata(beadsDir, expectedDB) {
 			relPath, _ := filepath.Rel(ctx.TownRoot, beadsDir)
 			missing = append(missing, rigName+" ("+relPath+")")
 			c.missingMetadata = append(c.missingMetadata, rigName)
@@ -168,11 +177,23 @@ func (c *DoltMetadataCheck) writeDoltMetadata(townRoot, rigName string) error {
 		_ = json.Unmarshal(data, &existing)
 	}
 
+	// Resolve the correct database name. Some rigs use their prefix as the
+	// DB name (e.g., "lc" for laneassist). Preserve existing dolt_database
+	// if it matches a known prefix; otherwise fall back to rig name. (gt-85w7)
+	dbName := rigName
+	if existingDB, ok := existing["dolt_database"].(string); ok && existingDB != "" {
+		// Preserve the existing DB name if it's a known prefix
+		prefix := config.GetRigPrefix(townRoot, rigName)
+		if existingDB == prefix {
+			dbName = existingDB
+		}
+	}
+
 	// Set dolt server fields
 	existing["database"] = "dolt"
 	existing["backend"] = "dolt"
 	existing["dolt_mode"] = "server"
-	existing["dolt_database"] = rigName
+	existing["dolt_database"] = dbName
 
 	data, err := json.MarshalIndent(existing, "", "  ")
 	if err != nil {

--- a/internal/doctor/stale_beads_redirect_check.go
+++ b/internal/doctor/stale_beads_redirect_check.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -309,6 +310,11 @@ func cleanStaleBeadsFiles(beadsDir string) error {
 		return fmt.Errorf("no redirect file found - refusing to clean")
 	}
 
+	// Check if metadata.json declares a dolt_database — if so, preserve it.
+	// Removing it would disconnect the rig from its database and make the
+	// prefix-named DB appear orphaned. (gt-85w7)
+	preserveMetadata := metadataHasDoltDB(beadsDir)
+
 	// Remove files matching stale patterns
 	for _, pattern := range staleFilePatterns {
 		matches, err := filepath.Glob(filepath.Join(beadsDir, pattern))
@@ -316,6 +322,9 @@ func cleanStaleBeadsFiles(beadsDir string) error {
 			continue
 		}
 		for _, match := range matches {
+			if preserveMetadata && filepath.Base(match) == "metadata.json" {
+				continue
+			}
 			if err := os.RemoveAll(match); err != nil {
 				return fmt.Errorf("removing %s: %w", filepath.Base(match), err)
 			}
@@ -331,6 +340,23 @@ func cleanStaleBeadsFiles(beadsDir string) error {
 	}
 
 	return nil
+}
+
+// metadataHasDoltDB checks if a .beads/metadata.json declares a dolt_database.
+// This is used to protect metadata.json from stale-file cleanup when the
+// directory has a redirect alongside valid DB configuration (tracked beads case).
+func metadataHasDoltDB(beadsDir string) bool {
+	data, err := os.ReadFile(filepath.Join(beadsDir, "metadata.json"))
+	if err != nil {
+		return false
+	}
+	var meta struct {
+		DoltDatabase string `json:"dolt_database"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return false
+	}
+	return meta.DoltDatabase != ""
 }
 
 // verifyRedirectTopology checks that all worktrees in a rig have correct redirects.

--- a/internal/doctor/stale_runtime_files_check.go
+++ b/internal/doctor/stale_runtime_files_check.go
@@ -9,6 +9,20 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 )
 
+// buildPrefixSet builds a set of all known rig prefixes from rigs.json.
+// This maps prefix→true for efficient lookup. (gt-85w7)
+func buildPrefixSet(registeredRigs map[string]bool, townRoot string) map[string]bool {
+	prefixes := make(map[string]bool)
+	for rigName := range registeredRigs {
+		prefixes[rigName] = true // rig name itself is always valid
+		prefix := config.GetRigPrefix(townRoot, rigName)
+		if prefix != "" {
+			prefixes[prefix] = true
+		}
+	}
+	return prefixes
+}
+
 // StaleRuntimeFilesCheck detects stale PID files and wisp configs for rigs
 // that are no longer registered. These can cause the daemon to incorrectly
 // think agents are running or try to start agents for removed rigs.
@@ -54,6 +68,10 @@ func (c *StaleRuntimeFilesCheck) Run(ctx *CheckContext) *CheckResult {
 		registeredRigs[rigName] = true
 	}
 
+	// Build prefix set that includes both rig names and their beads prefixes.
+	// Some rigs use prefix as DB/PID name (e.g., "lc" for laneassist). (gt-85w7)
+	knownPrefixes := buildPrefixSet(registeredRigs, ctx.TownRoot)
+
 	var details []string
 
 	// Check PID files in .runtime/pids/
@@ -71,8 +89,8 @@ func (c *StaleRuntimeFilesCheck) Run(ctx *CheckContext) *CheckResult {
 				// Town-level agents (hq, gt) are always valid
 				continue
 			}
-			// Check if this rig is registered
-			if !isRegisteredPrefix(rigPrefix, registeredRigs) {
+			// Check if this rig is registered (by name or prefix)
+			if !knownPrefixes[rigPrefix] {
 				c.stalePIDFiles = append(c.stalePIDFiles, filepath.Join(pidsDir, name))
 				details = append(details, fmt.Sprintf("Stale PID file for unregistered rig: %s", name))
 			}
@@ -157,10 +175,3 @@ func extractRigPrefix(filename string) string {
 	return name
 }
 
-// isRegisteredPrefix checks if a prefix belongs to a registered rig.
-func isRegisteredPrefix(prefix string, registeredRigs map[string]bool) bool {
-	// Check if any registered rig has this prefix
-	// We need to load the rigs config to get prefixes
-	// For now, just check if the prefix matches a rig name directly
-	return registeredRigs[prefix]
-}

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -48,6 +48,7 @@ import (
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/gofrs/flock"
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/util"
 	"gopkg.in/yaml.v3"
@@ -2457,6 +2458,14 @@ func collectReferencedDatabases(townRoot string) map[string]bool {
 				referenced[db] = true
 			}
 		}
+	}
+
+	// Safety net: also mark all rig prefixes from rigs.json as referenced.
+	// Some rigs use their prefix as the database name (e.g., "lc" for laneassist,
+	// "gt" for gastown). If metadata.json is missing or corrupted, the prefix-named
+	// DB would appear orphaned without this fallback. (gt-85w7)
+	for _, prefix := range config.AllRigPrefixes(townRoot) {
+		referenced[prefix] = true
 	}
 
 	return referenced


### PR DESCRIPTION
## Summary

Rebased version of #2949 (closed due to stale branch).

Doctor assumed database name == rig name, but 4 rigs (gastown, beads, laser, laneassist) use their **prefix** as the DB name in `.dolt-data/`. Multiple doctor checks failed to consult `rigs.json` for the prefix→rig mapping, causing prefix-named databases to be misidentified as orphaned and dropped.

### Changes

1. **`collectReferencedDatabases`** (doltserver.go): Add rigs.json prefix fallback — all rig prefixes are now always marked as referenced, even if `metadata.json` is missing
2. **`DoltMetadataCheck`** (migration_check.go): Use `config.GetRigPrefix()` for expected DB name; check `.dolt-data/<prefix>` when `.dolt-data/<rigName>` missing; preserve existing `dolt_database` in `writeDoltMetadata` when it matches a known prefix
3. **`cleanStaleBeadsFiles`** (stale_beads_redirect_check.go): Skip `metadata.json` removal when it declares a valid `dolt_database`
4. **`StaleRuntimeFilesCheck`** (stale_runtime_files_check.go): Build prefix set from rigs.json so PID files named with prefixes aren't falsely flagged as stale

Fixes: gt-85w7

## Test plan

- [x] `go build ./internal/doctor/... ./internal/doltserver/... ./internal/cmd/...` — clean
- [x] `go test ./internal/doctor/...` — all pass
- [ ] `gt doctor` on workspace with prefix-named DBs — no false orphan warnings
- [ ] `gt doctor --fix` — does not drop prefix-named databases

🤖 Generated with [Claude Code](https://claude.com/claude-code)