### PR TITLE
fix: escape backslashes in mol-refinery-patrol.formula.toml (gas-csr)

### DIFF
--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -614,7 +614,7 @@ If the PR was not created or is in an unexpected state, debug and retry.
 
 ```bash
 # Get the repo URL for gh commands
-REPO_URL=$(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\.git/\1/')
+REPO_URL=$(git remote get-url origin | sed 's/.*github.com[:/]\\(.*\\)\\.git/\\1/')
 
 # Wait for CI checks (timeout 15 minutes)
 gh pr checks <polecat-branch> --repo "$REPO_URL" --watch --fail-fast


### PR DESCRIPTION
## Summary
- Fixes invalid TOML escape `\(` at line 617 of `mol-refinery-patrol.formula.toml`
- This was causing 5 CI test failures (TestParseRealFormulas, TestPatrolFormulasHaveReportCycle, TestPatrolFormulasHaveWispGC)

## Test plan
- [x] All 3 failing formula tests now pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)