### PR TITLE
fix: strip --allow-stale in runBdJSON when bd doesn't support it

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -440,6 +440,16 @@ func getTownBeadsDir() (string, error) {
 // "exit status 1". BEADS_DIR is stripped from the subprocess environment to
 // prevent stale overrides from interfering with bd's workspace detection.
 func runBdJSON(dir string, args ...string) ([]byte, error) {
+	// Strip --allow-stale if bd doesn't support it (version mismatch).
+	if !beads.BdSupportsAllowStale() {
+		filtered := make([]string, 0, len(args))
+		for _, a := range args {
+			if a != "--allow-stale" {
+				filtered = append(filtered, a)
+			}
+		}
+		args = filtered
+	}
 	cmd := exec.Command("bd", args...)
 	cmd.Dir = dir
 	// Strip BEADS_DIR so bd discovers the correct database from cmd.Dir


### PR DESCRIPTION
## Summary

- `runBdJSON()` passes `--allow-stale` directly to `exec.Command` without checking bd capability
- bd v0.60+ removed `--allow-stale`, causing `bdDepListTracked` to fail with "unknown flag"
- Add the same stripping logic that `BdCmd.resolvedArgs()` already uses

Fixes #3049

## Test plan

- [x] `gt convoy status <id>` no longer errors with bd v0.60+
- [x] `gt convoy add <convoy> <cross-prefix-bead>` works
- [x] Builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)