### PR TITLE
fix: unused receipts param in patrol_scan.go (lint)

### DIFF
--- a/internal/cmd/patrol_scan.go
+++ b/internal/cmd/patrol_scan.go
@@ -295,7 +295,7 @@ func outputPatrolScanJSON(rigName, timestamp string, zombieResult *witness.Detec
 	return enc.Encode(output)
 }
 
-func outputPatrolScanHuman(rigName string, zombieResult *witness.DetectZombiePolecatsResult, stallResult *witness.DetectStalledPolecatsResult, completionResult *witness.DiscoverCompletionsResult, receipts []witness.PatrolReceipt) error {
+func outputPatrolScanHuman(rigName string, zombieResult *witness.DetectZombiePolecatsResult, stallResult *witness.DetectStalledPolecatsResult, completionResult *witness.DiscoverCompletionsResult, _ []witness.PatrolReceipt) error {
 	fmt.Printf("%s Patrol scan: %s\n\n", style.Bold.Render("🔍"), rigName)
 
 	// Zombies


### PR DESCRIPTION
## Summary
- Prefix unused `receipts` parameter with `_` in `outputPatrolScanHuman` to fix `unparam` lint error
- This lint failure is blocking CI on main and all open PRs

## Test plan
- [x] `golangci-lint run` passes locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)