### PR TITLE
doctor/rig-config-sync: use rig directory name (not beads prefix) as expected Dolt DB name

### DIFF
--- a/internal/doctor/rig_config_sync_check.go
+++ b/internal/doctor/rig_config_sync_check.go
@@ -168,14 +168,15 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 
 		// Check if Dolt database exists (only for server mode)
 		if metadata.DoltMode == "server" {
-			// Database name should match the prefix
-			expectedDBName := configPrefix
-			if expectedDBName == "" {
-				expectedDBName = metadata.DoltDatabase // fallback to what's in metadata
-			}
+			// Database name should match the rig directory name (rigName), not the beads
+			// prefix. This is the convention established by doltserver.EnsureMetadata:
+			// the Dolt database identifier is the rig's directory name so that rigs
+			// with short prefixes (e.g. "ts" for trading_scripts) don't collide and
+			// bd can always locate the right database without extra config.
+			expectedDBName := rigName
 
 			if expectedDBName != "" {
-				// Check if database name matches prefix
+				// Check if database name matches the rig directory name
 				if metadata.DoltDatabase != expectedDBName {
 					c.dbNameMismatches = append(c.dbNameMismatches, dbMismatch{
 						rigName:    rigName,
@@ -184,7 +185,7 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 						expectedDB: expectedDBName,
 					})
 					details = append(details, fmt.Sprintf(
-						"Rig %s database name mismatch: metadata has '%s', should be '%s' (prefix)",
+						"Rig %s database name mismatch: metadata has '%s', should be '%s' (rig name)",
 						rigName, metadata.DoltDatabase, expectedDBName))
 				}
 
@@ -343,7 +344,7 @@ func (c *RigConfigSyncCheck) Fix(ctx *CheckContext) error {
 		}
 	}
 
-	// Fix database name mismatches - rename database to match prefix
+	// Fix database name mismatches - rename database to match rig directory name
 	renamedDBs := false
 	for _, mismatch := range c.dbNameMismatches {
 		rigPath := filepath.Join(ctx.TownRoot, mismatch.rigName)
@@ -360,7 +361,7 @@ func (c *RigConfigSyncCheck) Fix(ctx *CheckContext) error {
 			return fmt.Errorf("could not parse metadata.json for %s: %w", mismatch.rigName, err)
 		}
 
-		// Update database name to match prefix
+		// Update database name to match rig directory name
 		metadata["dolt_database"] = mismatch.expectedDB
 
 		// Write updated metadata


### PR DESCRIPTION
## Summary

Fixes #3058.

`gt doctor --fix` was causing a rename loop: it expected the Dolt database to be named after the rig's *beads prefix* (e.g. `ts`) instead of the *rig directory name* (e.g. `trading_scripts`). Since `doltserver.EnsureMetadata` and `bd init` both use the rig directory name as the database identifier, `--fix` would rename `trading_scripts` → `ts` on disk, then Dolt/bd would revert the metadata back to `trading_scripts` on next access, causing an infinite rename loop.

### Root cause

```go
// Before (WRONG):
expectedDBName := configPrefix   // e.g. "ts"

// After (CORRECT):
expectedDBName := rigName        // e.g. "trading_scripts"
```

The convention (established by `doltserver.EnsureMetadata`) is that the Dolt database identifier equals the rig's directory name so that rigs with short prefixes (e.g. `ts`) don't collide and `bd` can always locate the right database without extra config.

### Symptoms of the bug

1. `gt doctor --fix` detects "DB name mismatch: metadata has 'trading_scripts', should be 'ts'"
2. Fix renames `.dolt-data/trading_scripts` → `.dolt-data/ts` and updates metadata.json
3. Next `bd` command or EnsureMetadata call reverts metadata.json back to `trading_scripts`
4. Back to step 1 — infinite loop, Dolt unstable

## Test plan

- [ ] After fix, `gt doctor --fix` no longer renames the trading_scripts database
- [ ] `gt doctor` shows 0 failures for `rig-config-sync` check on affected workspace
- [ ] Unit tests pass: `go test ./internal/doctor/...`