### PR TITLE
fix(reaper): handle 'nothing to commit' in purge/auto-close

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -502,11 +502,12 @@ func purgeClosedWisps(db *sql.DB, dbName string, purgeAge time.Duration, dryRun 
 		}
 		commitMsg := fmt.Sprintf("reaper: purge %d closed wisps from %s", totalDeleted, dbName)
 		if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
-			// Non-fatal — log but continue.
-			anomalies = append(anomalies, Anomaly{
-				Type:    "dolt_commit_failed",
-				Message: fmt.Sprintf("dolt commit after purge failed: %v", err),
-			})
+			if !isNothingToCommit(err) {
+				anomalies = append(anomalies, Anomaly{
+					Type:    "dolt_commit_failed",
+					Message: fmt.Sprintf("dolt commit after purge failed: %v", err),
+				})
+			}
 		}
 	}
 
@@ -561,7 +562,9 @@ func purgeOldMail(db *sql.DB, dbName string, mailDeleteAge time.Duration, dryRun
 		}
 		commitMsg := fmt.Sprintf("reaper: purge %d old mail from %s", totalDeleted, dbName)
 		if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
-			// Non-fatal.
+			if !isNothingToCommit(err) {
+				return totalDeleted, fmt.Errorf("dolt commit: %w", err)
+			}
 		}
 	}
 
@@ -661,10 +664,12 @@ func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (
 		}
 		commitMsg := fmt.Sprintf("reaper: auto-close %d stale issues in %s", len(ids), dbName)
 		if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
-			result.Anomalies = append(result.Anomalies, Anomaly{
-				Type:    "dolt_commit_failed",
-				Message: fmt.Sprintf("dolt commit after auto-close failed: %v", err),
-			})
+			if !isNothingToCommit(err) {
+				result.Anomalies = append(result.Anomalies, Anomaly{
+					Type:    "dolt_commit_failed",
+					Message: fmt.Sprintf("dolt commit after auto-close failed: %v", err),
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary

- Add `isNothingToCommit(err)` guard to `purgeClosedWisps`, `purgeOldMail`, and `AutoClose` DOLT_COMMIT error handlers
- Aligns with existing pattern in `Reap` (line 404) and `closePluginReceipts` (line 812)
- Eliminates recurring false `dolt_commit_failed` anomalies that trigger escalations from the Reaper Dog

## Context

When Dolt auto-commit processes DELETEs before the explicit `COMMIT` + `DOLT_COMMIT` sequence, the working set already matches HEAD, producing a benign "nothing to commit" error. The `Reap` function handled this correctly; the purge and auto-close paths did not.

This caused recurring MEDIUM/HIGH escalations from the Reaper Dog to overseer and mayor on every 30-minute cycle.

## Test plan

- [x] `go test ./internal/reaper/` passes
- [x] Manual: `gt reaper purge --db=hq --json` no longer reports false anomalies
- [ ] Integration: run full reaper cycle and verify no escalations