### PR TITLE
reaper: suppress dolt_commit_failed anomaly for 'nothing to commit'

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -502,11 +502,15 @@ func purgeClosedWisps(db *sql.DB, dbName string, purgeAge time.Duration, dryRun 
 		}
 		commitMsg := fmt.Sprintf("reaper: purge %d closed wisps from %s", totalDeleted, dbName)
 		if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
-			// Non-fatal — log but continue.
-			anomalies = append(anomalies, Anomaly{
-				Type:    "dolt_commit_failed",
-				Message: fmt.Sprintf("dolt commit after purge failed: %v", err),
-			})
+			// "nothing to commit" is expected when wisps are dolt_ignored — deletes
+			// are auto-committed by the SQL layer and Dolt has nothing to version.
+			if !isNothingToCommit(err) {
+				// Non-fatal — log but continue.
+				anomalies = append(anomalies, Anomaly{
+					Type:    "dolt_commit_failed",
+					Message: fmt.Sprintf("dolt commit after purge failed: %v", err),
+				})
+			}
 		}
 	}
 
@@ -661,10 +665,13 @@ func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (
 		}
 		commitMsg := fmt.Sprintf("reaper: auto-close %d stale issues in %s", len(ids), dbName)
 		if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
-			result.Anomalies = append(result.Anomalies, Anomaly{
-				Type:    "dolt_commit_failed",
-				Message: fmt.Sprintf("dolt commit after auto-close failed: %v", err),
-			})
+			// "nothing to commit" is expected when the updated tables are dolt_ignored.
+			if !isNothingToCommit(err) {
+				result.Anomalies = append(result.Anomalies, Anomaly{
+					Type:    "dolt_commit_failed",
+					Message: fmt.Sprintf("dolt commit after auto-close failed: %v", err),
+				})
+			}
 		}
 	}
 

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -160,6 +160,36 @@ func TestPurgeBatchQueryNoDatabaseNameInjection(t *testing.T) {
 	}
 }
 
+// TestIsNothingToCommit verifies that "nothing to commit" errors are recognized
+// correctly. This prevents false-positive dolt_commit_failed anomalies when the
+// reaper operates on dolt_ignored tables (wisps, wisp_*), where Dolt has nothing
+// to version after a successful SQL DELETE.
+func TestIsNothingToCommit(t *testing.T) {
+	cases := []struct {
+		msg  string
+		want bool
+	}{
+		{"nothing to commit", true},
+		{"NOTHING TO COMMIT", true},
+		{"Error 1105 (HY000): nothing to commit", true},
+		{"no changes to commit", false}, // must also contain "commit" — see isNothingToCommit
+		{"no changes", false},
+		{"connection refused", false},
+		{"table not found: wisps", false},
+		{"", false},
+	}
+	for _, c := range cases {
+		var err error
+		if c.msg != "" {
+			err = fmt.Errorf("%s", c.msg)
+		}
+		got := isNothingToCommit(err)
+		if got != c.want {
+			t.Errorf("isNothingToCommit(%q) = %v, want %v", c.msg, got, c.want)
+		}
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
 }


### PR DESCRIPTION
## Summary

- `purgeClosedWisps` and `AutoClose` were appending a `dolt_commit_failed` anomaly for **any** `DOLT_COMMIT` error, including the benign `"nothing to commit"` response
- `"nothing to commit"` is **expected** when the reaper operates on dolt_ignored tables (`wisps`, `wisp_*`) — SQL deletes are auto-committed by the server; Dolt has nothing to version
- This produced false-alarm escalations reported as potential data loss (see hq-d9c)
- `Reap()` and `ClosePluginReceipts()` already used `isNothingToCommit()` correctly; this PR applies the same guard to the two missing sites

## Changes

- `purgeClosedWisps`: wrap `dolt_commit_failed` anomaly in `!isNothingToCommit(err)` guard
- `AutoClose`: same guard
- Added `TestIsNothingToCommit` unit test covering key error string variants

## Test plan

- [ ] `go test ./internal/reaper/...` — all 10 tests pass
- [ ] `gt reaper purge --db=hq --json` on a workspace with dolt_ignored wisps produces no `dolt_commit_failed` anomaly