### PR TITLE
fix(doctor): extend hooks-sync to detect stale gemini settings

### DIFF
--- a/internal/doctor/hooks_sync_check.go
+++ b/internal/doctor/hooks_sync_check.go
@@ -44,6 +44,14 @@ func (c *HooksSyncCheck) Run(ctx *CheckContext) *CheckResult {
 
 	var details []string
 	for _, target := range targets {
+		if target.Provider == "gemini" {
+			if detail := c.checkGeminiTarget(target); detail != "" {
+				details = append(details, detail)
+			}
+			continue
+		}
+
+		// Claude targets: use base+override merge system
 		expected, err := hooks.ComputeExpected(target.Key)
 		if err != nil {
 			details = append(details, fmt.Sprintf("%s: error computing expected: %v", target.DisplayKey(), err))
@@ -84,9 +92,32 @@ func (c *HooksSyncCheck) Run(ctx *CheckContext) *CheckResult {
 		Status:   StatusWarning,
 		Message:  fmt.Sprintf("%d target(s) out of sync", len(c.outOfSync)),
 		Details:  details,
-		FixHint:  "Run 'gt hooks sync' to regenerate settings.json files",
+		FixHint:  "Run 'gt doctor --fix hooks-sync' to regenerate settings files",
 		Category: c.Category(),
 	}
+}
+
+// checkGeminiTarget compares an installed gemini settings file against the
+// current template (with {{GT_BIN}} resolved). Returns a detail string if
+// out of sync, or empty string if in sync.
+func (c *HooksSyncCheck) checkGeminiTarget(target hooks.Target) string {
+	expected, err := hooks.ComputeExpectedTemplate("gemini", "settings.json", target.Role)
+	if err != nil {
+		return fmt.Sprintf("%s: error computing expected template: %v", target.DisplayKey(), err)
+	}
+
+	actual, err := os.ReadFile(target.Path)
+	if err != nil {
+		c.outOfSync = append(c.outOfSync, target)
+		return fmt.Sprintf("%s: cannot read: %v", target.DisplayKey(), err)
+	}
+
+	if !hooks.TemplateContentEqual(expected, actual) {
+		c.outOfSync = append(c.outOfSync, target)
+		return fmt.Sprintf("%s: out of sync", target.DisplayKey())
+	}
+
+	return ""
 }
 
 // Fix runs gt hooks sync to bring all targets into sync.
@@ -97,6 +128,14 @@ func (c *HooksSyncCheck) Fix(ctx *CheckContext) error {
 
 	var errs []string
 	for _, target := range c.outOfSync {
+		if target.Provider == "gemini" {
+			if err := c.fixGeminiTarget(target); err != nil {
+				errs = append(errs, fmt.Sprintf("%s: %v", target.DisplayKey(), err))
+			}
+			continue
+		}
+
+		// Claude targets: use base+override merge system
 		expected, err := hooks.ComputeExpected(target.Key)
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("%s: %v", target.DisplayKey(), err))
@@ -138,5 +177,24 @@ func (c *HooksSyncCheck) Fix(ctx *CheckContext) error {
 	if len(errs) > 0 {
 		return fmt.Errorf("%s", strings.Join(errs, "; "))
 	}
+	return nil
+}
+
+// fixGeminiTarget re-installs a gemini settings file from the current template.
+func (c *HooksSyncCheck) fixGeminiTarget(target hooks.Target) error {
+	content, err := hooks.ComputeExpectedTemplate("gemini", "settings.json", target.Role)
+	if err != nil {
+		return fmt.Errorf("computing template: %w", err)
+	}
+
+	dir := filepath.Dir(target.Path)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		return fmt.Errorf("creating dir: %w", err)
+	}
+
+	if err := os.WriteFile(target.Path, content, 0600); err != nil {
+		return fmt.Errorf("writing: %w", err)
+	}
+
 	return nil
 }

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -169,10 +169,11 @@ func HooksEqual(a, b *HooksConfig) bool {
 
 // Target represents a managed settings.json location.
 type Target struct {
-	Path string // Full path to .claude/settings.json
-	Key  string // Override key: "gastown/crew", "mayor", etc.
-	Rig  string // Rig name or empty for town-level
-	Role string // Informational only — does NOT participate in override resolution (Key does). Singular form matching RoleSettingsDir: crew, witness, refinery, polecat, mayor, deacon.
+	Path     string // Full path to .claude/settings.json or .gemini/settings.json
+	Key      string // Override key: "gastown/crew", "mayor", etc.
+	Rig      string // Rig name or empty for town-level
+	Role     string // Informational only — does NOT participate in override resolution (Key does). Singular form matching RoleSettingsDir: crew, witness, refinery, polecat, mayor, deacon.
+	Provider string // Hook provider: "claude" (default/empty) or "gemini", etc.
 }
 
 // DisplayKey returns a human-readable label for the target.
@@ -463,9 +464,96 @@ func DiscoverTargets(townRoot string) ([]Target, error) {
 				Role: "refinery",
 			})
 		}
+
+		// Gemini targets — per-agent settings in work directories.
+		// Unlike Claude (shared via --settings flag), gemini settings are
+		// installed in each agent's work directory.
+		targets = append(targets, discoverGeminiTargets(rigPath, rigName)...)
 	}
 
 	return targets, nil
+}
+
+// discoverGeminiTargets finds .gemini/settings.json files in agent work
+// directories within a rig. Gemini agents don't share a settings directory;
+// each has its own .gemini/settings.json in their work dir.
+func discoverGeminiTargets(rigPath, rigName string) []Target {
+	var targets []Target
+
+	// Crew members: <rig>/crew/<name>/.gemini/settings.json
+	crewDir := filepath.Join(rigPath, "crew")
+	if info, err := os.Stat(crewDir); err == nil && info.IsDir() {
+		members, _ := os.ReadDir(crewDir)
+		for _, m := range members {
+			if !m.IsDir() || strings.HasPrefix(m.Name(), ".") {
+				continue
+			}
+			geminiPath := filepath.Join(crewDir, m.Name(), ".gemini", "settings.json")
+			if _, err := os.Stat(geminiPath); err == nil {
+				targets = append(targets, Target{
+					Path:     geminiPath,
+					Key:      rigName + "/crew/" + m.Name() + "[gemini]",
+					Rig:      rigName,
+					Role:     "crew",
+					Provider: "gemini",
+				})
+			}
+		}
+	}
+
+	// Witness: <rig>/witness/.gemini/settings.json
+	witnessGemini := filepath.Join(rigPath, "witness", ".gemini", "settings.json")
+	if _, err := os.Stat(witnessGemini); err == nil {
+		targets = append(targets, Target{
+			Path:     witnessGemini,
+			Key:      rigName + "/witness[gemini]",
+			Rig:      rigName,
+			Role:     "witness",
+			Provider: "gemini",
+		})
+	}
+
+	// Refinery: check both <rig>/refinery/.gemini/ and <rig>/refinery/rig/.gemini/
+	for _, sub := range []string{"", "rig"} {
+		base := filepath.Join(rigPath, "refinery")
+		if sub != "" {
+			base = filepath.Join(base, sub)
+		}
+		refGemini := filepath.Join(base, ".gemini", "settings.json")
+		if _, err := os.Stat(refGemini); err == nil {
+			targets = append(targets, Target{
+				Path:     refGemini,
+				Key:      rigName + "/refinery[gemini]",
+				Rig:      rigName,
+				Role:     "refinery",
+				Provider: "gemini",
+			})
+			break // Only add one refinery gemini target per rig
+		}
+	}
+
+	// Polecats: <rig>/polecats/<name>/.gemini/settings.json
+	polecatsDir := filepath.Join(rigPath, "polecats")
+	if info, err := os.Stat(polecatsDir); err == nil && info.IsDir() {
+		members, _ := os.ReadDir(polecatsDir)
+		for _, m := range members {
+			if !m.IsDir() || strings.HasPrefix(m.Name(), ".") {
+				continue
+			}
+			geminiPath := filepath.Join(polecatsDir, m.Name(), ".gemini", "settings.json")
+			if _, err := os.Stat(geminiPath); err == nil {
+				targets = append(targets, Target{
+					Path:     geminiPath,
+					Key:      rigName + "/polecats/" + m.Name() + "[gemini]",
+					Rig:      rigName,
+					Role:     "polecat",
+					Provider: "gemini",
+				})
+			}
+		}
+	}
+
+	return targets
 }
 
 // isRig checks if a directory looks like a rig (has crew/, witness/, or polecats/ subdirectory).

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -884,6 +884,70 @@ func TestDiscoverTargets_RoleNames(t *testing.T) {
 	}
 }
 
+func TestDiscoverTargets_GeminiTargets(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	os.MkdirAll(filepath.Join(tmpDir, "mayor"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "deacon"), 0755)
+
+	// Create a rig with gemini crew members and witness
+	os.MkdirAll(filepath.Join(tmpDir, "rig1", "crew", "alice"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "rig1", "witness"), 0755)
+
+	// Install gemini settings for alice (crew member)
+	geminiDir := filepath.Join(tmpDir, "rig1", "crew", "alice", ".gemini")
+	os.MkdirAll(geminiDir, 0755)
+	os.WriteFile(filepath.Join(geminiDir, "settings.json"), []byte(`{"hooks":{}}`), 0644)
+
+	// Install gemini settings for witness
+	witnessGemini := filepath.Join(tmpDir, "rig1", "witness", ".gemini")
+	os.MkdirAll(witnessGemini, 0755)
+	os.WriteFile(filepath.Join(witnessGemini, "settings.json"), []byte(`{"hooks":{}}`), 0644)
+
+	targets, err := DiscoverTargets(tmpDir)
+	if err != nil {
+		t.Fatalf("DiscoverTargets failed: %v", err)
+	}
+
+	// Find gemini targets
+	var geminiTargets []Target
+	for _, tgt := range targets {
+		if tgt.Provider == "gemini" {
+			geminiTargets = append(geminiTargets, tgt)
+		}
+	}
+
+	if len(geminiTargets) != 2 {
+		t.Errorf("expected 2 gemini targets, got %d", len(geminiTargets))
+		for _, tgt := range targets {
+			t.Logf("  target: %s (provider=%s)", tgt.DisplayKey(), tgt.Provider)
+		}
+	}
+
+	found := make(map[string]bool)
+	for _, tgt := range geminiTargets {
+		found[tgt.Key] = true
+	}
+
+	for _, expected := range []string{"rig1/crew/alice[gemini]", "rig1/witness[gemini]"} {
+		if !found[expected] {
+			t.Errorf("expected gemini target %q not found", expected)
+		}
+	}
+
+	// Verify role assignment
+	roleByKey := make(map[string]string)
+	for _, tgt := range geminiTargets {
+		roleByKey[tgt.Key] = tgt.Role
+	}
+	if roleByKey["rig1/crew/alice[gemini]"] != "crew" {
+		t.Errorf("alice gemini target: Role = %q, want %q", roleByKey["rig1/crew/alice[gemini]"], "crew")
+	}
+	if roleByKey["rig1/witness[gemini]"] != "witness" {
+		t.Errorf("witness gemini target: Role = %q, want %q", roleByKey["rig1/witness[gemini]"], "witness")
+	}
+}
+
 func TestTargetDisplayKey(t *testing.T) {
 	tests := []struct {
 		target   Target

--- a/internal/hooks/installer.go
+++ b/internal/hooks/installer.go
@@ -8,6 +8,7 @@ package hooks
 import (
 	"bytes"
 	"embed"
+	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
@@ -165,4 +166,37 @@ func resolveGTBinary() string {
 		return path
 	}
 	return "gt"
+}
+
+// ComputeExpectedTemplate returns the expected file content for a template-based
+// provider (e.g., gemini) with {{GT_BIN}} resolved to the actual gt binary path.
+// This is used by the doctor hooks-sync check to compare installed files against
+// current templates.
+func ComputeExpectedTemplate(provider, hooksFile, role string) ([]byte, error) {
+	content, err := resolveTemplate(provider, hooksFile, role)
+	if err != nil {
+		return nil, err
+	}
+
+	if bytes.Contains(content, []byte("{{GT_BIN}}")) {
+		gtBin := resolveGTBinary()
+		content = bytes.ReplaceAll(content, []byte("{{GT_BIN}}"), []byte(gtBin))
+	}
+
+	return content, nil
+}
+
+// TemplateContentEqual compares two JSON byte slices for structural equality
+// by normalizing whitespace. Returns true if they represent the same JSON.
+func TemplateContentEqual(expected, actual []byte) bool {
+	var e, a interface{}
+	if err := json.Unmarshal(expected, &e); err != nil {
+		return false
+	}
+	if err := json.Unmarshal(actual, &a); err != nil {
+		return false
+	}
+	ej, _ := json.Marshal(e)
+	aj, _ := json.Marshal(a)
+	return string(ej) == string(aj)
 }

--- a/internal/hooks/installer_test.go
+++ b/internal/hooks/installer_test.go
@@ -255,3 +255,68 @@ func TestInstallForRole_CopilotRoleAware(t *testing.T) {
 		t.Error("copilot interactive: content mismatch")
 	}
 }
+
+func TestComputeExpectedTemplate_Gemini(t *testing.T) {
+	// Autonomous role should get settings-autonomous.json template
+	content, err := ComputeExpectedTemplate("gemini", "settings.json", "witness")
+	if err != nil {
+		t.Fatalf("ComputeExpectedTemplate: %v", err)
+	}
+
+	// Should contain resolved gt binary path, not {{GT_BIN}}
+	if strings.Contains(string(content), "{{GT_BIN}}") {
+		t.Error("expected {{GT_BIN}} to be resolved")
+	}
+
+	// Should contain GT_HOOK_SOURCE=compact (from autonomous template)
+	if !strings.Contains(string(content), "GT_HOOK_SOURCE=compact") {
+		t.Error("expected GT_HOOK_SOURCE=compact in autonomous template")
+	}
+
+	// Interactive role should get settings-interactive.json template
+	interactiveContent, err := ComputeExpectedTemplate("gemini", "settings.json", "crew")
+	if err != nil {
+		t.Fatalf("ComputeExpectedTemplate(crew): %v", err)
+	}
+
+	// Interactive template should NOT contain GT_HOOK_SOURCE=compact
+	if strings.Contains(string(interactiveContent), "GT_HOOK_SOURCE=compact") {
+		t.Error("interactive template should not contain GT_HOOK_SOURCE=compact")
+	}
+}
+
+func TestTemplateContentEqual(t *testing.T) {
+	// Same JSON, different formatting
+	a := []byte(`{"hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"test"}]}]}}`)
+	b := []byte(`{
+  "hooks": {
+    "SessionStart": [
+      {
+        "matcher": "",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "test"
+          }
+        ]
+      }
+    ]
+  }
+}`)
+
+	if !TemplateContentEqual(a, b) {
+		t.Error("expected structurally equal JSON to match")
+	}
+
+	// Different content
+	c := []byte(`{"hooks":{"SessionStart":[{"matcher":"","hooks":[{"type":"command","command":"different"}]}]}}`)
+	if TemplateContentEqual(a, c) {
+		t.Error("expected different JSON to not match")
+	}
+
+	// Invalid JSON
+	invalid := []byte(`not json`)
+	if TemplateContentEqual(a, invalid) {
+		t.Error("expected invalid JSON to not match")
+	}
+}


### PR DESCRIPTION
## Summary

- Extends the `hooks-sync` doctor check to detect and auto-fix stale `.gemini/settings.json` files across all rigs
- Adds `Provider` field to `hooks.Target` to distinguish claude vs gemini targets
- `DiscoverTargets` now scans crew member, witness, refinery, and polecat work directories for `.gemini/settings.json`
- Gemini targets are compared against resolved templates (with `{{GT_BIN}}` substituted) rather than the Claude base+override merge system

## Context

Gemini crew sessions (e.g., laneassist/gisele) had stale hook files missing `GT_HOOK_SOURCE=compact` on PreCompress and other env var prefixes. Without these, `isCompactResume()` returns false, the full prime path runs, exceeds gemini's hook timeout, and the hook fails. The root cause was that `gt doctor hooks-sync` only checked Claude settings files — gemini settings were invisible to the check.

## Test plan

- [x] New test `TestDiscoverTargets_GeminiTargets` — verifies gemini targets are discovered with correct keys, roles, and provider
- [x] New test `TestComputeExpectedTemplate_Gemini` — verifies template resolution for autonomous vs interactive roles
- [x] New test `TestTemplateContentEqual` — verifies JSON structural comparison with whitespace normalization
- [x] All existing `hooks` and `doctor` package tests pass
- [ ] Manual: `gt doctor -v` shows gemini targets as out-of-sync for stale installs (laser/crew/jen, laser/witness, laser/refinery)
- [ ] Manual: `gt doctor --fix` re-installs gemini settings from current templates

Closes gt-0j3q

🤖 Generated with [Claude Code](https://claude.com/claude-code)