### PR TITLE
fix(config): update Copilot CLI preset for GA release

### DIFF
--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -367,8 +367,9 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		Command:             "copilot",
 		Args:                []string{"--yolo"},
 		ProcessNames:        []string{"copilot"}, // Copilot CLI binary (Node.js but reports as "copilot")
-		SessionIDEnv:        "",                  // Session IDs stored on disk, not in env
+		SessionIDEnv:        "",                  // Session IDs stored on disk (~/.copilot/session-state/), not in env
 		ResumeFlag:          "--resume",
+		ContinueFlag:        "--continue", // GA: resumes most recent session without picker
 		ResumeStyle:         "flag",
 		SupportsHooks:       true,  // Copilot CLI supports .github/hooks/*.json lifecycle hooks
 		SupportsForkSession: false,
@@ -377,13 +378,14 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		},
 		// Runtime defaults
 		PromptMode:         "arg",
+		ConfigDirEnv:       "COPILOT_HOME", // GA: overrides ~/.copilot/ config directory
 		ConfigDir:          ".copilot",
 		HooksProvider:      "copilot",
 		HooksDir:           ".github/hooks",
 		HooksSettingsFile:  "gastown.json",
 		HooksInformational: false,
-		ReadyPromptPrefix:  "❯ ",
-		ReadyDelayMs:       5000,
+		ReadyPromptPrefix:  "",   // GA: no ❯ prompt; Copilot uses hint text, not a detectable prefix
+		ReadyDelayMs:       5000, // Delay-based readiness detection (no prompt prefix)
 		InstructionsFile:   "AGENTS.md",
 	},
 	AgentPi: {

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -1035,6 +1035,9 @@ func TestCopilotAgentPreset(t *testing.T) {
 	if info.ResumeFlag != "--resume" {
 		t.Errorf("copilot ResumeFlag = %q, want --resume", info.ResumeFlag)
 	}
+	if info.ContinueFlag != "--continue" {
+		t.Errorf("copilot ContinueFlag = %q, want --continue", info.ContinueFlag)
+	}
 	if info.ResumeStyle != "flag" {
 		t.Errorf("copilot ResumeStyle = %q, want flag", info.ResumeStyle)
 	}
@@ -1045,6 +1048,16 @@ func TestCopilotAgentPreset(t *testing.T) {
 
 	if info.SupportsForkSession {
 		t.Error("copilot should not support fork session")
+	}
+
+	// GA: COPILOT_HOME overrides config directory
+	if info.ConfigDirEnv != "COPILOT_HOME" {
+		t.Errorf("copilot ConfigDirEnv = %q, want COPILOT_HOME", info.ConfigDirEnv)
+	}
+
+	// GA: no detectable prompt prefix — uses delay-based readiness
+	if info.ReadyPromptPrefix != "" {
+		t.Errorf("copilot ReadyPromptPrefix = %q, want empty (GA has no ❯ prompt)", info.ReadyPromptPrefix)
 	}
 
 	if info.NonInteractive == nil {
@@ -1125,8 +1138,8 @@ func TestCopilotProviderDefaults(t *testing.T) {
 	}
 
 	configEnv := defaultConfigDirEnv("copilot")
-	if configEnv != "" {
-		t.Errorf("defaultConfigDirEnv(copilot) = %q, want empty", configEnv)
+	if configEnv != "COPILOT_HOME" {
+		t.Errorf("defaultConfigDirEnv(copilot) = %q, want COPILOT_HOME", configEnv)
 	}
 
 	provider := defaultHooksProvider("copilot")
@@ -1157,8 +1170,8 @@ func TestCopilotProviderDefaults(t *testing.T) {
 	}
 
 	prefix := defaultReadyPromptPrefix("copilot")
-	if prefix != "❯ " {
-		t.Errorf("defaultReadyPromptPrefix(copilot) = %q, want \"❯ \"", prefix)
+	if prefix != "" {
+		t.Errorf("defaultReadyPromptPrefix(copilot) = %q, want empty (GA has no ❯ prompt)", prefix)
 	}
 
 	delay := defaultReadyDelayMs("copilot")


### PR DESCRIPTION
## Summary

- Audits the `AgentCopilot` preset against the Copilot CLI GA release (Feb 25, 2026)
- Adds `ContinueFlag: "--continue"` for resuming the most recent session without the picker
- Adds `ConfigDirEnv: "COPILOT_HOME"` — the GA env var for overriding `~/.copilot/` config directory
- Removes `ReadyPromptPrefix: "❯ "` — GA Copilot uses hint text, not a detectable prompt prefix; falls back to delay-based readiness detection (5s)

## Audit Results

| Field | Before | After | Reason |
|-------|--------|-------|--------|
| `ContinueFlag` | (not set) | `--continue` | GA supports `--continue` to resume most recent session |
| `ConfigDirEnv` | (not set) | `COPILOT_HOME` | GA uses `COPILOT_HOME` to override config dir |
| `ReadyPromptPrefix` | `❯ ` | `""` | GA has no `❯` prompt; uses different UI |
| `Args` | `--yolo` | `--yolo` | Still works (alias for `--allow-all`) |
| `HooksDir` | `.github/hooks` | `.github/hooks` | Confirmed |
| `SessionIDEnv` | `""` | `""` | Still no env var exposed |
| `ResumeFlag` | `--resume` | `--resume` | Confirmed |

## Test plan

- [x] `TestCopilotAgentPreset` — verifies new `ContinueFlag`, `ConfigDirEnv`, empty `ReadyPromptPrefix`
- [x] `TestCopilotProviderDefaults` — updated assertions for `ConfigDirEnv` and `ReadyPromptPrefix`
- [x] `TestCopilotRuntimeConfigFromPreset` — passes unchanged
- [x] Full `internal/config` test suite passes

Closes #2664

🤖 Generated with [Claude Code](https://claude.com/claude-code)