### PR TITLE
fix: deduplicate CRASHED_POLECAT notifications in daemon heartbeat (#2795)

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -99,6 +99,12 @@ type Daemon struct {
 	// lastMaintenanceRun tracks when scheduled maintenance last ran.
 	// Only accessed from heartbeat loop goroutine - no sync needed.
 	lastMaintenanceRun time.Time
+
+	// crashNotified tracks polecats that have already been notified as crashed.
+	// Prevents flooding the witness with duplicate CRASHED_POLECAT alerts on
+	// every heartbeat cycle (GH#2795). Cleared when the session comes back alive.
+	// Only accessed from heartbeat loop goroutine - no sync needed.
+	crashNotified map[string]time.Time
 }
 
 // sessionDeath records a detected session death for mass death analysis.
@@ -1966,7 +1972,11 @@ func (d *Daemon) checkPolecatHealth(rigName, polecatName string) {
 	}
 
 	if sessionAlive {
-		// Session is alive - nothing to do
+		// Session is alive - clear any previous crash notification (GH#2795).
+		crashKey := rigName + "/" + polecatName
+		if d.crashNotified != nil {
+			delete(d.crashNotified, crashKey)
+		}
 		return
 	}
 
@@ -2058,6 +2068,19 @@ func (d *Daemon) checkPolecatHealth(rigName, polecatName string) {
 	// Emit session_death event for audit trail / feed visibility
 	_ = events.LogFeed(events.TypeSessionDeath, sessionName,
 		events.SessionDeathPayload(sessionName, rigName+"/polecats/"+polecatName, "crash detected by daemon health check", "daemon"))
+
+	// Dedup guard: only notify witness once per crashed polecat (GH#2795).
+	// Without this, every heartbeat cycle (3 min) sends a duplicate CRASHED_POLECAT
+	// mail, flooding the witness inbox unboundedly.
+	crashKey := rigName + "/" + polecatName
+	if d.crashNotified == nil {
+		d.crashNotified = make(map[string]time.Time)
+	}
+	if _, already := d.crashNotified[crashKey]; already {
+		d.logger.Printf("Skipping duplicate CRASHED_POLECAT notification for %s (already notified)", crashKey)
+		return
+	}
+	d.crashNotified[crashKey] = time.Now()
 
 	// Notify witness — stuck-agent-dog plugin handles context-aware restart
 	d.notifyWitnessOfCrashedPolecat(rigName, polecatName, info.HookBead)

--- a/internal/daemon/polecat_health_test.go
+++ b/internal/daemon/polecat_health_test.go
@@ -376,3 +376,62 @@ func TestCheckPolecatHealth_SkipsNukedPolecat(t *testing.T) {
 		t.Errorf("nuked polecat must not trigger CRASH DETECTED, got: %q", got)
 	}
 }
+
+// TestCheckPolecatHealth_DeduplicatesCrashNotification verifies that the daemon
+// does NOT send duplicate CRASHED_POLECAT notifications on subsequent heartbeat
+// cycles for the same crashed polecat (GH#2795).
+func TestCheckPolecatHealth_DeduplicatesCrashNotification(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mocks for tmux and bd")
+	}
+	binDir := t.TempDir()
+	writeFakeTestTmux(t, binDir)
+	recentTime := time.Now().UTC().Format(time.RFC3339)
+	bdPath := writeFakeTestBD(t, binDir, "working", "working", "gt-xyz", recentTime)
+
+	// Create a fake gt script that logs invocations to a file.
+	gtLog := filepath.Join(t.TempDir(), "gt-invocations.log")
+	fakeGt := filepath.Join(binDir, "gt")
+	gtScript := fmt.Sprintf("#!/bin/sh\necho \"$@\" >> %s\n", gtLog)
+	if err := os.WriteFile(fakeGt, []byte(gtScript), 0755); err != nil {
+		t.Fatalf("writing fake gt: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	var logBuf strings.Builder
+	d := &Daemon{
+		config: &Config{TownRoot: t.TempDir()},
+		logger: log.New(&logBuf, "", 0),
+		tmux:   tmux.NewTmux(),
+		bdPath: bdPath,
+		gtPath: fakeGt,
+	}
+
+	// First call: should send notification.
+	d.checkPolecatHealth("myr", "mycat")
+
+	logData, err := os.ReadFile(gtLog)
+	if err != nil {
+		t.Fatalf("reading gt invocation log: %v", err)
+	}
+	if strings.Count(string(logData), "CRASHED_POLECAT") != 1 {
+		t.Fatalf("expected exactly 1 CRASHED_POLECAT on first call, got %d: %s",
+			strings.Count(string(logData), "CRASHED_POLECAT"), logData)
+	}
+
+	// Second call: should be deduplicated — no new notification.
+	d.checkPolecatHealth("myr", "mycat")
+
+	logData, err = os.ReadFile(gtLog)
+	if err != nil {
+		t.Fatalf("reading gt invocation log: %v", err)
+	}
+	if strings.Count(string(logData), "CRASHED_POLECAT") != 1 {
+		t.Errorf("expected still 1 CRASHED_POLECAT after second call (dedup), got %d: %s",
+			strings.Count(string(logData), "CRASHED_POLECAT"), logData)
+	}
+	if !strings.Contains(logBuf.String(), "Skipping duplicate CRASHED_POLECAT") {
+		t.Errorf("expected dedup log message, got: %q", logBuf.String())
+	}
+}


### PR DESCRIPTION
## Summary

Consecutive daemon heartbeat cycles were sending duplicate CRASHED_POLECAT notifications to the witness for the same crashed polecat, flooding the witness inbox (GH#2795).

**Root cause**: `checkPolecatHealth` notifies the witness unconditionally whenever a polecat session is dead with a hook_bead. On each 3-minute heartbeat, the same crash triggers another notification.

**Fix**: Add `crashNotified map[string]time.Time` to the `Daemon` struct. Before notifying the witness, check if we've already notified for this polecat. Skip if so. Clear the entry when the session comes back alive, so real recoveries + new crashes still trigger alerts.

## Changes

- `internal/daemon/daemon.go`: Add `crashNotified` field + dedup guard before `notifyWitnessOfCrashedPolecat`
- `internal/daemon/polecat_health_test.go`: Add `TestCheckPolecatHealth_DeduplicatesCrashNotification`

## Test

```
go test ./internal/daemon/ -run TestCheckPolecatHealth -v
```

All polecat health tests pass. This replaces PR #2857 (which had accumulated unrelated diffs and conflicts).

Closes #2857