### PR TITLE
fix: prevent slice bounds panic in PushSubmoduleCommit for short SHAs (#3073)

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1967,7 +1967,11 @@ func (g *Git) PushSubmoduleCommit(submodulePath, sha, remote string) error {
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("pushing submodule %s commit %s: %s", submodulePath, sha[:8], strings.TrimSpace(stderr.String()))
+		abbrev := sha
+		if len(abbrev) > 8 {
+			abbrev = abbrev[:8]
+		}
+		return fmt.Errorf("pushing submodule %s commit %s: %s", submodulePath, abbrev, strings.TrimSpace(stderr.String()))
 	}
 	return nil
 }


### PR DESCRIPTION
## Problem

`gt done` panics with `slice bounds out of range [:8] with length 7` when git returns a 7-character abbreviated SHA in `PushSubmoduleCommit`.

The line `sha[:8]` in the error message formatting panics on any SHA shorter than 8 characters.

## Fix

Guard with `len(sha)` before slicing. If the SHA is already short, use it as-is.

## Note

The root cause (`.claude/worktrees/` directories being detected as submodule gitlinks because both use mode 160000 in `git diff --raw`) is tracked separately in #3073. This fix prevents the immediate panic regardless of how the short SHA arrives.

## Test

```
go build ./internal/git/...
go vet ./internal/git/...
```

Closes #3073 (the panic; root-cause worktree detection to follow)