### PR TITLE
fix(rig): detect empty repo before clone to give clear error (GH#3054)

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -991,6 +991,26 @@ func (g *Git) IsEmpty() (bool, error) {
 	return strings.TrimSpace(out) == "", nil
 }
 
+// RemoteURLHasRefs returns true if the remote at url has any heads (branches).
+// Used to detect empty repositories before attempting a clone.
+// Returns (false, nil) for an empty repo, (true, nil) if refs exist,
+// or (false, err) if the remote is unreachable.
+func RemoteURLHasRefs(url string) (bool, error) {
+	var stdout, stderr bytes.Buffer
+	cmd := exec.Command("git", "ls-remote", "--heads", "--exit-code", url)
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	if err == nil {
+		return true, nil
+	}
+	// exit code 2 from --exit-code means no matching refs (empty repo)
+	if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 2 {
+		return false, nil
+	}
+	return false, fmt.Errorf("checking remote refs: %s", strings.TrimSpace(stderr.String()))
+}
+
 // RemoteBranchExists checks if a branch exists on the remote.
 func (g *Git) RemoteBranchExists(remote, branch string) (bool, error) {
 	out, err := g.run("ls-remote", "--heads", remote, branch)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1758,3 +1758,44 @@ func TestCheckBranchContamination(t *testing.T) {
 		t.Errorf("Ahead (from main) = %d, want 5", contam.Ahead)
 	}
 }
+
+func TestRemoteURLHasRefs(t *testing.T) {
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	t.Run("empty repo returns false", func(t *testing.T) {
+		dir := t.TempDir()
+		run("git", "init", "--initial-branch=main", dir)
+		run("git", "-C", dir, "config", "user.email", "t@t.com")
+		run("git", "-C", dir, "config", "user.name", "T")
+
+		got, err := RemoteURLHasRefs(dir)
+		if err != nil {
+			t.Fatalf("RemoteURLHasRefs: %v", err)
+		}
+		if got {
+			t.Error("want false for empty repo, got true")
+		}
+	})
+
+	t.Run("repo with commits returns true", func(t *testing.T) {
+		dir := t.TempDir()
+		run("git", "init", "--initial-branch=main", dir)
+		run("git", "-C", dir, "config", "user.email", "t@t.com")
+		run("git", "-C", dir, "config", "user.name", "T")
+		run("git", "-C", dir, "commit", "--allow-empty", "-m", "init")
+
+		got, err := RemoteURLHasRefs(dir)
+		if err != nil {
+			t.Fatalf("RemoteURLHasRefs: %v", err)
+		}
+		if !got {
+			t.Error("want true for repo with commits, got false")
+		}
+	})
+}

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -412,6 +412,14 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 		return m.git.CloneBareWithBranch(opts.GitURL, bareRepoPath, branch)
 	}
 
+	// Pre-clone check: detect empty repositories before attempting clone.
+	// An empty repo has no branches, so configureRefspec (called inside cloneInternal)
+	// would fail with "fatal: couldn't find remote ref main" — a cryptic error
+	// that doesn't tell the user what's wrong (GH#3054).
+	if hasRefs, err := git.RemoteURLHasRefs(opts.GitURL); err == nil && !hasRefs {
+		return nil, fmt.Errorf("repository %s is empty (no commits). Push at least one commit before adding it as a rig", opts.GitURL)
+	}
+
 	if err := cloneBareWith(opts.DefaultBranch); err != nil {
 		return nil, wrapCloneError(err, opts.GitURL)
 	}

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -1553,3 +1553,47 @@ func TestBareCloneDefaultBranch(t *testing.T) {
 		t.Errorf("DefaultBranch() = %q, want %q", got, "master")
 	}
 }
+
+// TestAddRig_EmptyRepo verifies that AddRig returns a clear, user-friendly error
+// when the target repository has no commits (GH#3054).
+// Without the fix, the error is a cryptic "couldn't find remote ref main" from
+// the configureRefspec fetch step inside cloneInternal.
+func TestAddRig_EmptyRepo(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-based bd shim not reliable on Windows CI")
+	}
+
+	fakeBDForAddRig(t)
+
+	// Create a git repo with no commits.
+	emptyRepo := t.TempDir()
+	for _, args := range [][]string{
+		{"git", "init", "--initial-branch=main", emptyRepo},
+		{"git", "-C", emptyRepo, "config", "user.email", "test@test.com"},
+		{"git", "-C", emptyRepo, "config", "user.name", "Test User"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	root, rigsConfig := setupTestTown(t)
+	manager := NewManager(root, rigsConfig, git.NewGit(root))
+
+	_, err := manager.AddRig(AddRigOptions{
+		Name:          "emptyrig",
+		GitURL:        emptyRepo,
+		BeadsPrefix:   "er",
+		SkipDoltCheck: true,
+	})
+	if err == nil {
+		t.Fatal("AddRig: expected error for empty repo, got nil")
+	}
+	if !strings.Contains(err.Error(), "empty") {
+		t.Errorf("AddRig error = %q; want message containing 'empty'", err.Error())
+	}
+	if strings.Contains(err.Error(), "couldn't find remote ref") {
+		t.Errorf("AddRig error = %q; should not leak cryptic git error", err.Error())
+	}
+}


### PR DESCRIPTION
## Summary

- `gt rig add` on an empty (no-commit) repository now shows a clear diagnostic instead of a cryptic git error
- Adds `RemoteURLHasRefs(url)` to `internal/git/git.go` — runs `git ls-remote --heads --exit-code` before any clone
- Pre-clone check in `AddRig` returns the existing friendly message: *"repository <url> is empty (no commits). Push at least one commit before adding it as a rig."*

**Root cause**: `configureRefspec` (called inside `cloneInternal`) attempted `git fetch origin main` on the freshly-cloned empty bare repo, failing with `fatal: couldn't find remote ref main`. The existing `IsEmpty()` guard in `AddRig` never ran because the error propagated from inside `cloneBareWith` first.

Closes #3054

## Test plan

- [ ] `TestAddRig_EmptyRepo` — verifies error message contains "empty" and does not expose the raw git error
- [ ] `TestRemoteURLHasRefs` — unit tests empty repo (→ false) and repo with commits (→ true)
- [ ] Full `internal/rig` and `internal/git` test suites pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)