### PR TITLE
feat(memory): add city-scoped memory sharing across agents

### DIFF
--- a/internal/cmd/forget.go
+++ b/internal/cmd/forget.go
@@ -8,7 +8,10 @@ import (
 	"github.com/steveyegge/gastown/internal/style"
 )
 
+var forgetScope string
+
 func init() {
+	forgetCmd.Flags().StringVar(&forgetScope, "scope", memoryScopeLocal, "Storage scope to remove from: local (default) or city")
 	forgetCmd.GroupID = GroupWork
 	rootCmd.AddCommand(forgetCmd)
 }
@@ -21,16 +24,40 @@ var forgetCmd = &cobra.Command{
 The key should match the short name shown by 'gt memories'.
 For typed memories, use type/key format or just the key (searches all types).
 
+Use --scope to target city-wide memories instead of local ones.
+
 Examples:
   gt forget refinery-worktree
   gt forget feedback/dont-mock-db
-  gt forget hooks-package-structure`,
+  gt forget --scope city town-wide-convention`,
 	Args: cobra.ExactArgs(1),
 	RunE: runForget,
 }
 
 func runForget(cmd *cobra.Command, args []string) error {
 	key := args[0]
+
+	scope := strings.ToLower(strings.TrimSpace(forgetScope))
+	if scope == "" {
+		scope = memoryScopeLocal
+	}
+	if scope != memoryScopeLocal && scope != memoryScopeCity {
+		return fmt.Errorf("invalid scope %q — valid scopes: local, city", scope)
+	}
+
+	var getFn func(string) (string, error)
+	var clearFn func(string) error
+	if scope == memoryScopeCity {
+		cityDB := cityBeadsPath()
+		if cityDB == "" {
+			return fmt.Errorf("--scope city requires $GT_ROOT or $GT_TOWN_ROOT to be set")
+		}
+		getFn = func(k string) (string, error) { return bdKvGetDB(cityDB, k) }
+		clearFn = func(k string) error { return bdKvClearDB(cityDB, k) }
+	} else {
+		getFn = bdKvGet
+		clearFn = bdKvClear
+	}
 
 	// Strip memory. prefix if the user included it
 	key = strings.TrimPrefix(key, memoryKeyPrefix)
@@ -41,11 +68,11 @@ func runForget(cmd *cobra.Command, args []string) error {
 		shortKey := key[slashIdx+1:]
 		if _, ok := validMemoryTypes[memType]; ok {
 			fullKey := memoryKeyPrefix + memType + "." + shortKey
-			existing, err := bdKvGet(fullKey)
+			existing, err := getFn(fullKey)
 			if err != nil || existing == "" {
 				return fmt.Errorf("memory %q not found", key)
 			}
-			if err := bdKvClear(fullKey); err != nil {
+			if err := clearFn(fullKey); err != nil {
 				return fmt.Errorf("removing memory: %w", err)
 			}
 			fmt.Printf("%s Forgot memory: %s\n", style.Success.Render("✓"), style.Bold.Render(key))
@@ -56,9 +83,9 @@ func runForget(cmd *cobra.Command, args []string) error {
 	// Try typed key first (memory.<type>.<key> for each known type)
 	for _, t := range memoryTypeOrder {
 		fullKey := memoryKeyPrefix + t + "." + key
-		existing, _ := bdKvGet(fullKey)
+		existing, _ := getFn(fullKey)
 		if existing != "" {
-			if err := bdKvClear(fullKey); err != nil {
+			if err := clearFn(fullKey); err != nil {
 				return fmt.Errorf("removing memory: %w", err)
 			}
 			displayKey := key
@@ -72,12 +99,12 @@ func runForget(cmd *cobra.Command, args []string) error {
 
 	// Try legacy untyped key (memory.<key>)
 	fullKey := memoryKeyPrefix + key
-	existing, err := bdKvGet(fullKey)
+	existing, err := getFn(fullKey)
 	if err != nil || existing == "" {
 		return fmt.Errorf("memory %q not found", key)
 	}
 
-	if err := bdKvClear(fullKey); err != nil {
+	if err := clearFn(fullKey); err != nil {
 		return fmt.Errorf("removing memory: %w", err)
 	}
 

--- a/internal/cmd/memories.go
+++ b/internal/cmd/memories.go
@@ -10,9 +10,11 @@ import (
 )
 
 var memoriesTypeFilter string
+var memoriesScope string
 
 func init() {
 	memoriesCmd.Flags().StringVar(&memoriesTypeFilter, "type", "", "Filter by memory type: feedback, project, user, reference, general")
+	memoriesCmd.Flags().StringVar(&memoriesScope, "scope", "all", "Which memories to show: local, city, or all (default: all)")
 	memoriesCmd.GroupID = GroupWork
 	rootCmd.AddCommand(memoriesCmd)
 }
@@ -32,8 +34,14 @@ Use --type to filter by memory category:
   reference  Pointers to external resources
   general    Uncategorized memories
 
+Use --scope to filter by memory scope:
+  local  Only memories stored in this rig's beads store
+  city   Only town-wide memories (visible to all agents in the town)
+  all    Both local and city memories (default)
+
 Examples:
-  gt memories                    # List all memories
+  gt memories                    # List all memories (local + city)
+  gt memories --scope city       # Show only town-wide memories
   gt memories --type feedback    # Show only behavioral corrections
   gt memories refinery           # Search for memories about refinery`,
 	Args: cobra.MaximumNArgs(1),
@@ -41,9 +49,12 @@ Examples:
 }
 
 func runMemories(cmd *cobra.Command, args []string) error {
-	kvs, err := bdKvListJSON()
-	if err != nil {
-		return fmt.Errorf("listing memories: %w", err)
+	scope := strings.ToLower(strings.TrimSpace(memoriesScope))
+	if scope == "" {
+		scope = "all"
+	}
+	if scope != "local" && scope != "city" && scope != "all" {
+		return fmt.Errorf("invalid scope %q — valid scopes: local, city, all", scope)
 	}
 
 	var search string
@@ -58,37 +69,58 @@ func runMemories(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Filter for memory.* keys and optional search/type
 	type memory struct {
 		memType  string
 		shortKey string
 		value    string
+		isCity   bool
 	}
 	var memories []memory
 
-	for k, v := range kvs {
-		if !strings.HasPrefix(k, memoryKeyPrefix) {
-			continue
-		}
-
-		memType, shortKey := parseMemoryKey(k)
-
-		if typeFilter != "" && memType != typeFilter {
-			continue
-		}
-
-		if search != "" {
-			if !strings.Contains(strings.ToLower(shortKey), search) &&
-				!strings.Contains(strings.ToLower(v), search) &&
-				!strings.Contains(strings.ToLower(memType), search) {
+	collectFrom := func(kvs map[string]string, isCity bool) {
+		for k, v := range kvs {
+			if !strings.HasPrefix(k, memoryKeyPrefix) {
 				continue
 			}
+			memType, shortKey := parseMemoryKey(k)
+			if typeFilter != "" && memType != typeFilter {
+				continue
+			}
+			if search != "" {
+				if !strings.Contains(strings.ToLower(shortKey), search) &&
+					!strings.Contains(strings.ToLower(v), search) &&
+					!strings.Contains(strings.ToLower(memType), search) {
+					continue
+				}
+			}
+			memories = append(memories, memory{memType: memType, shortKey: shortKey, value: v, isCity: isCity})
 		}
+	}
 
-		memories = append(memories, memory{memType: memType, shortKey: shortKey, value: v})
+	if scope == memoryScopeLocal || scope == "all" {
+		kvs, err := bdKvListJSON()
+		if err != nil {
+			return fmt.Errorf("listing local memories: %w", err)
+		}
+		collectFrom(kvs, false)
+	}
+
+	if scope == memoryScopeCity || scope == "all" {
+		cityDB := cityBeadsPath()
+		if cityDB != "" {
+			kvs, err := bdKvListJSONDB(cityDB)
+			if err == nil {
+				collectFrom(kvs, true)
+			}
+			// Silently skip city memories if city beads are unreachable
+		}
 	}
 
 	sort.Slice(memories, func(i, j int) bool {
+		// City memories sort after local memories of the same type
+		if memories[i].isCity != memories[j].isCity {
+			return !memories[i].isCity
+		}
 		if memories[i].memType != memories[j].memType {
 			return memTypeRank(memories[i].memType) < memTypeRank(memories[j].memType)
 		}
@@ -107,8 +139,11 @@ func runMemories(cmd *cobra.Command, args []string) error {
 	}
 
 	header := "Memories"
+	if scope != "all" {
+		header = fmt.Sprintf("Memories [%s]", scope)
+	}
 	if typeFilter != "" {
-		header = fmt.Sprintf("Memories [%s]", typeFilter)
+		header = fmt.Sprintf("%s [%s]", header, typeFilter)
 	}
 	if search != "" {
 		header = fmt.Sprintf("%s matching %q", header, search)
@@ -116,13 +151,22 @@ func runMemories(cmd *cobra.Command, args []string) error {
 	fmt.Printf("%s (%d):\n\n", style.Bold.Render(header), len(memories))
 
 	lastType := ""
-	for _, m := range memories {
-		if m.memType != lastType {
+	lastCity := false
+	for i, m := range memories {
+		typeChanged := m.memType != lastType
+		scopeChanged := i > 0 && m.isCity != lastCity
+
+		if typeChanged || scopeChanged {
 			if lastType != "" {
 				fmt.Println()
 			}
-			fmt.Printf("  %s\n", style.Dim.Render("["+m.memType+"]"))
+			label := m.memType
+			if m.isCity {
+				label += " · city"
+			}
+			fmt.Printf("  %s\n", style.Dim.Render("["+label+"]"))
 			lastType = m.memType
+			lastCity = m.isCity
 		}
 		fmt.Printf("  %s\n", style.Bold.Render(m.shortKey))
 		fmt.Printf("    %s\n\n", m.value)

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -466,53 +466,58 @@ var memoryTypeLabels = map[string]string{
 
 // runMemoryInject loads memories from beads kv and outputs them during prime.
 // Memories are grouped by type and ordered by priority (feedback first).
+// City-wide memories (from $GT_ROOT/.beads) are appended after rig-local memories.
 func runMemoryInject() {
-	kvs, err := bdKvListJSON()
-	if err != nil {
-		return // Silently skip if kv list fails
-	}
-
-	// Group memories by type
 	type mem struct {
 		shortKey string
 		value    string
 	}
-	grouped := make(map[string][]mem)
 
-	for k, v := range kvs {
-		if !strings.HasPrefix(k, memoryKeyPrefix) {
-			continue
+	injectSection := func(kvs map[string]string, title string) {
+		grouped := make(map[string][]mem)
+		for k, v := range kvs {
+			if !strings.HasPrefix(k, memoryKeyPrefix) {
+				continue
+			}
+			memType, shortKey := parseMemoryKey(k)
+			grouped[memType] = append(grouped[memType], mem{shortKey: shortKey, value: v})
 		}
-		memType, shortKey := parseMemoryKey(k)
-		grouped[memType] = append(grouped[memType], mem{shortKey: shortKey, value: v})
+		if len(grouped) == 0 {
+			return
+		}
+		for t := range grouped {
+			sort.Slice(grouped[t], func(i, j int) bool {
+				return grouped[t][i].shortKey < grouped[t][j].shortKey
+			})
+		}
+		fmt.Println()
+		fmt.Printf("# %s\n", title)
+		for _, t := range memoryTypeOrder {
+			mems, ok := grouped[t]
+			if !ok || len(mems) == 0 {
+				continue
+			}
+			label := memoryTypeLabels[t]
+			if label == "" {
+				label = t
+			}
+			fmt.Printf("\n## %s\n\n", label)
+			for _, m := range mems {
+				fmt.Printf("- **%s**: %s\n", m.shortKey, m.value)
+			}
+		}
 	}
 
-	if len(grouped) == 0 {
-		return
+	// Inject rig-local memories first.
+	if kvs, err := bdKvListJSON(); err == nil {
+		injectSection(kvs, "Agent Memories")
 	}
 
-	// Sort each group by key
-	for t := range grouped {
-		sort.Slice(grouped[t], func(i, j int) bool {
-			return grouped[t][i].shortKey < grouped[t][j].shortKey
-		})
-	}
-
-	fmt.Println()
-	fmt.Println("# Agent Memories")
-
-	for _, t := range memoryTypeOrder {
-		mems, ok := grouped[t]
-		if !ok || len(mems) == 0 {
-			continue
-		}
-		label := memoryTypeLabels[t]
-		if label == "" {
-			label = t
-		}
-		fmt.Printf("\n## %s\n\n", label)
-		for _, m := range mems {
-			fmt.Printf("- **%s**: %s\n", m.shortKey, m.value)
+	// Inject city-wide memories. Silently skip if GT_ROOT is not set or
+	// city beads are unreachable (not every session has a city context).
+	if cityDB := cityBeadsPath(); cityDB != "" {
+		if kvs, err := bdKvListJSONDB(cityDB); err == nil {
+			injectSection(kvs, "Town Memories (shared city-wide)")
 		}
 	}
 }

--- a/internal/cmd/remember.go
+++ b/internal/cmd/remember.go
@@ -15,6 +15,13 @@ import (
 
 const memoryKeyPrefix = "memory."
 
+// memoryScopeLocal stores the memory in the current rig's beads store (default).
+const memoryScopeLocal = "local"
+
+// memoryScopeCity stores the memory city-wide in $GT_ROOT/.beads.
+// City memories are visible to all agents in the town during gt prime.
+const memoryScopeCity = "city"
+
 // validMemoryTypes are the recognized memory type categories.
 // Typed memories are stored as memory.<type>.<key> in the kv store.
 // Legacy untyped memories (memory.<key>) are treated as "general".
@@ -32,10 +39,12 @@ var memoryTypeOrder = []string{"feedback", "user", "project", "reference", "gene
 
 var rememberKey string
 var rememberType string
+var rememberScope string
 
 func init() {
 	rememberCmd.Flags().StringVar(&rememberKey, "key", "", "Explicit key slug (default: auto-generated from content)")
 	rememberCmd.Flags().StringVar(&rememberType, "type", "", "Memory type: feedback, project, user, reference (default: general)")
+	rememberCmd.Flags().StringVar(&rememberScope, "scope", memoryScopeLocal, "Storage scope: local (this rig) or city (all agents in town)")
 	rememberCmd.GroupID = GroupWork
 	rootCmd.AddCommand(rememberCmd)
 }
@@ -57,11 +66,16 @@ Memory types help organize memories and prioritize injection:
   user       Info about the user's role and preferences
   reference  Pointers to external resources
 
+Memory scopes control who can read the memory:
+  local  (default) Stored in this rig's beads — visible only to agents in this rig
+  city   Stored in town-level beads ($GT_ROOT/.beads) — visible to all agents in the town
+
 Examples:
   gt remember "Refinery uses worktree, cannot checkout main"
   gt remember --type feedback "Don't mock the database in integration tests"
   gt remember --type user --key senior-go-dev "User has 10 years Go experience"
-  gt remember --key refinery-worktree "Refinery uses worktree, cannot checkout main"`,
+  gt remember --scope city "Town-wide convention: always use --rebase on pull"
+  gt remember --scope city --type feedback "Dogs must not delete shared state"`,
 	Args: cobra.ExactArgs(1),
 	RunE: runRemember,
 }
@@ -70,6 +84,15 @@ func runRemember(cmd *cobra.Command, args []string) error {
 	content := args[0]
 	if strings.TrimSpace(content) == "" {
 		return fmt.Errorf("memory content cannot be empty")
+	}
+
+	// Validate --scope
+	scope := strings.ToLower(strings.TrimSpace(rememberScope))
+	if scope == "" {
+		scope = memoryScopeLocal
+	}
+	if scope != memoryScopeLocal && scope != memoryScopeCity {
+		return fmt.Errorf("invalid scope %q — valid scopes: local, city", scope)
 	}
 
 	// Validate --type if provided
@@ -93,14 +116,28 @@ func runRemember(cmd *cobra.Command, args []string) error {
 
 	fullKey := memoryKeyPrefix + memType + "." + key
 
+	var setFn func(string, string) error
+	var getFn func(string) (string, error)
+	if scope == memoryScopeCity {
+		cityDB := cityBeadsPath()
+		if cityDB == "" {
+			return fmt.Errorf("--scope city requires $GT_ROOT or $GT_TOWN_ROOT to be set")
+		}
+		setFn = func(k, v string) error { return bdKvSetDB(cityDB, k, v) }
+		getFn = func(k string) (string, error) { return bdKvGetDB(cityDB, k) }
+	} else {
+		setFn = bdKvSet
+		getFn = bdKvGet
+	}
+
 	// Check if key already exists
-	existing, _ := bdKvGet(fullKey)
+	existing, _ := getFn(fullKey)
 	verb := "Stored"
 	if existing != "" {
 		verb = "Updated"
 	}
 
-	if err := bdKvSet(fullKey, content); err != nil {
+	if err := setFn(fullKey, content); err != nil {
 		return fmt.Errorf("storing memory: %w", err)
 	}
 
@@ -108,7 +145,11 @@ func runRemember(cmd *cobra.Command, args []string) error {
 	if memType != "general" {
 		displayKey = memType + "/" + key
 	}
-	fmt.Printf("%s %s memory: %s\n", style.Success.Render("✓"), verb, style.Bold.Render(displayKey))
+	scopeLabel := ""
+	if scope == memoryScopeCity {
+		scopeLabel = " [city]"
+	}
+	fmt.Printf("%s %s memory%s: %s\n", style.Success.Render("✓"), verb, scopeLabel, style.Bold.Render(displayKey))
 	return nil
 }
 
@@ -218,6 +259,56 @@ func bdKvClear(key string) error {
 // bdKvListJSON calls bd kv list --json and returns the parsed map.
 func bdKvListJSON() (map[string]string, error) {
 	cmd := exec.Command("bd", "kv", "list", "--json")
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, err
+	}
+
+	var kvs map[string]string
+	if err := json.Unmarshal(out, &kvs); err != nil {
+		return nil, fmt.Errorf("parsing kv list: %w", err)
+	}
+	return kvs, nil
+}
+
+// cityBeadsPath returns the path to the city-level beads directory by reading
+// $GT_ROOT or $GT_TOWN_ROOT. Returns empty string if neither is set.
+func cityBeadsPath() string {
+	for _, envName := range []string{"GT_ROOT", "GT_TOWN_ROOT"} {
+		if root := os.Getenv(envName); root != "" {
+			return root + "/.beads"
+		}
+	}
+	return ""
+}
+
+// bdKvSetDB calls bd --db <dbPath> kv set <key> <value>.
+func bdKvSetDB(dbPath, key, value string) error {
+	cmd := exec.Command("bd", "--db", dbPath, "kv", "set", key, value)
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// bdKvGetDB calls bd --db <dbPath> kv get <key>.
+func bdKvGetDB(dbPath, key string) (string, error) {
+	cmd := exec.Command("bd", "--db", dbPath, "kv", "get", key)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// bdKvClearDB calls bd --db <dbPath> kv clear <key>.
+func bdKvClearDB(dbPath, key string) error {
+	cmd := exec.Command("bd", "--db", dbPath, "kv", "clear", key)
+	cmd.Stderr = os.Stderr
+	return cmd.Run()
+}
+
+// bdKvListJSONDB calls bd --db <dbPath> kv list --json and returns the parsed map.
+func bdKvListJSONDB(dbPath string) (map[string]string, error) {
+	cmd := exec.Command("bd", "--db", dbPath, "kv", "list", "--json")
 	out, err := cmd.Output()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
## Summary

- Adds `--scope city` to `gt remember` — stores to `$GT_ROOT/.beads`, visible to all agents in the town
- Adds `--scope all|local|city` to `gt memories` — default shows both rig-local and city memories, city memories labeled `[type · city]`
- Adds `--scope city` to `gt forget` — removes a city-wide memory
- Updates `gt prime` to inject rig-local memories first, then city-wide memories under a separate `# Town Memories (shared city-wide)` section
- Adds `cityBeadsPath()` helper and `bdKvSetDB/GetDB/ClearDB/ListJSONDB` for targeting a specific beads database

## Motivation

Previously every memory was rig-scoped — a crew member in the `gastown` rig couldn't share a memory with crew members in the `beads` rig, and polecats in different rigs each maintained isolated memory stores. City-scope memories solve this: conventions, user preferences, and cross-rig context can now be stored once and surfaced to every agent across the town during `gt prime`.

## Usage

```bash
# Store a town-wide behavioral convention
gt remember --scope city --type feedback "Always use --rebase on git pull"

# Store user context visible to all agents
gt remember --scope city --type user "User is a senior infra engineer"

# List town-wide memories
gt memories --scope city

# List all (default) — local then city
gt memories

# Remove a city memory
gt forget --scope city always-use-rebase
```

## Design notes

- City memories silently fail open if `$GT_ROOT`/`$GT_TOWN_ROOT` is unset or city beads are unreachable — existing behavior is preserved for agents without a city context
- `gt prime` injects city memories in a clearly labeled section after rig-local memories, preserving injection order priority within each section
- No new env vars required — uses existing `GT_ROOT`/`GT_TOWN_ROOT`

## Test plan

- [ ] `go build ./...` passes
- [ ] `go vet ./internal/cmd/...` clean
- [ ] `gt remember --scope city "test" && gt memories --scope city` shows the memory
- [ ] `gt prime` output includes both local and city memory sections when both are populated
- [ ] `gt forget --scope city test` removes the city memory
- [ ] `gt memories` (default) shows `[type · city]` labeled section for city memories

Closes #gt-gx9

🤖 Generated with [Claude Code](https://claude.com/claude-code)