### PR TITLE
fix(mail): prefer GT_TOWN_ROOT env var for town root detection (gt-0lwl6)

### DIFF
--- a/internal/cmd/mail_identity.go
+++ b/internal/cmd/mail_identity.go
@@ -19,7 +19,19 @@ import (
 //
 // Mail ALWAYS uses town beads, regardless of sender or recipient address.
 // This ensures messages are visible to all agents in the town.
+//
+// GT_TOWN_ROOT is preferred over workspace detection because workspace.Find
+// stops at the first mayor/town.json when not in a worktree path. Rigs that
+// have their own mayor/town.json (e.g., gastown/) would be misidentified as
+// the town root when running from the rig directory.
 func findMailWorkDir() (string, error) {
+	for _, envName := range []string{"GT_TOWN_ROOT", "GT_ROOT"} {
+		if townRoot := os.Getenv(envName); townRoot != "" {
+			if ok, _ := workspace.IsWorkspace(townRoot); ok {
+				return townRoot, nil
+			}
+		}
+	}
 	return workspace.FindFromCwdOrError()
 }
 

--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -186,9 +186,22 @@ func (r *Router) expandAnnounce(announceName string) (*config.AnnounceConfig, er
 }
 
 // detectTownRoot finds the town root using workspace.Find.
-// This ensures consistent detection with the rest of the codebase,
-// supporting both primary (mayor/town.json) and secondary (mayor/) markers.
+// Prefers the GT_TOWN_ROOT environment variable when set (always set by the
+// Gas Town session manager to the actual outer town root). This prevents
+// nested-workspace misdetection where workspace.Find stops at a rig-level
+// mayor/town.json instead of continuing to the outer town root.
 func detectTownRoot(startDir string) string {
+	// Prefer GT_TOWN_ROOT when set by the session manager.
+	// workspace.Find stops at the first primary marker when !inWorktree,
+	// so running from a rig directory (which has its own mayor/town.json)
+	// would incorrectly return the rig as the town root.
+	for _, envName := range []string{"GT_TOWN_ROOT", "GT_ROOT"} {
+		if townRoot := os.Getenv(envName); townRoot != "" {
+			if ok, _ := workspace.IsWorkspace(townRoot); ok {
+				return townRoot
+			}
+		}
+	}
 	townRoot, err := workspace.Find(startDir)
 	if err != nil {
 		return ""

--- a/internal/mail/router_test.go
+++ b/internal/mail/router_test.go
@@ -23,6 +23,11 @@ import (
 )
 
 func TestDetectTownRoot(t *testing.T) {
+	// Unset GT_TOWN_ROOT/GT_ROOT so tests exercise workspace.Find fallback.
+	// (The real session always has these set; this tests the detection logic itself.)
+	t.Setenv("GT_TOWN_ROOT", "")
+	t.Setenv("GT_ROOT", "")
+
 	// Create temp directory structure
 	tmpDir := t.TempDir()
 	townRoot := filepath.Join(tmpDir, "town")
@@ -74,6 +79,44 @@ func TestDetectTownRoot(t *testing.T) {
 				t.Errorf("detectTownRoot(%q) = %q, want %q", tt.startDir, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestDetectTownRoot_PrefersEnvVar verifies that GT_TOWN_ROOT takes priority
+// over workspace detection, preventing rig-level mayor/town.json from being
+// mistaken for the town root.
+func TestDetectTownRoot_PrefersEnvVar(t *testing.T) {
+	tmpDir := t.TempDir()
+	// Outer town root (the actual town)
+	outerTown := filepath.Join(tmpDir, "town")
+	if err := os.MkdirAll(filepath.Join(outerTown, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(outerTown, "mayor", "town.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// Rig with its own mayor/town.json (nested workspace)
+	rigDir := filepath.Join(outerTown, "gastown")
+	if err := os.MkdirAll(filepath.Join(rigDir, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigDir, "mayor", "town.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Without env var, workspace.Find from the rig directory returns the rig (wrong).
+	t.Setenv("GT_TOWN_ROOT", "")
+	t.Setenv("GT_ROOT", "")
+	got := detectTownRoot(rigDir)
+	if got != rigDir {
+		t.Errorf("without env var, detectTownRoot(%q) = %q, want %q (rig)", rigDir, got, rigDir)
+	}
+
+	// With GT_TOWN_ROOT set to the outer town, detectTownRoot should return it.
+	t.Setenv("GT_TOWN_ROOT", outerTown)
+	got = detectTownRoot(rigDir)
+	if got != outerTown {
+		t.Errorf("with GT_TOWN_ROOT, detectTownRoot(%q) = %q, want %q (outer town)", rigDir, got, outerTown)
 	}
 }
 
@@ -292,6 +335,9 @@ func TestSendFromCrewWorkspace_AvoidsEphemeralPrefixMismatch(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses a bash bd stub")
 	}
+	// Clear GT_TOWN_ROOT so detectTownRoot falls back to workspace detection.
+	t.Setenv("GT_TOWN_ROOT", "")
+	t.Setenv("GT_ROOT", "")
 
 	tmpDir := t.TempDir()
 	townRoot := filepath.Join(tmpDir, "town")


### PR DESCRIPTION
## Summary

- `detectTownRoot()` and `findMailWorkDir()` now prefer `GT_TOWN_ROOT`/`GT_ROOT` env vars over workspace detection
- Fixes mail routing to rig beads (gt- prefix) when commands run from a rig directory with its own `mayor/town.json`
- `workspace.Find` stops at the first `mayor/town.json` when `inWorktree=false`; nested workspaces (like `gastown/`) were misidentified as the town root

## Root Cause

`detectTownRoot(rigDir)` → `workspace.Find(rigDir)` with `inWorktree=false` returns `rigDir` immediately on finding `mayor/town.json`, never reaching the outer town root at `~/gt/`. Mail routed to `gt-` database (rig beads) instead of `hq-` (town beads).

## Fix

- Prefer `GT_TOWN_ROOT`/`GT_ROOT` env vars (always set by session manager to the actual outer town root)
- Workspace detection kept as fallback for environments without the env var (CI, fresh installs)
- Added `TestDetectTownRoot_PrefersEnvVar` documenting the nested-workspace scenario
- Updated existing tests to clear env vars so they exercise the fallback path

## Test plan

- [x] `go test ./internal/mail/...` passes
- [x] `go test ./internal/workspace/...` passes
- [ ] `gt mail inbox` from rig directory shows `hq-` prefixed beads (manual verify)

Fixes gt-0lwl6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)