### PR TITLE
fix(config): dog sessions inherit env vars from base claude agent (#3012)

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1574,7 +1574,23 @@ func resolveRoleAgentConfigCore(role, townRoot, rigPath string) *RuntimeConfig {
 		if hasExplicitNonClaudeOverride(role, townSettings, rigSettings) {
 			// Fall through to normal resolution below
 		} else {
-			return claudeHaikuPreset()
+			preset := claudeHaikuPreset()
+			// Inherit env vars from the base "claude" agent config in agents.json.
+			// claudeHaikuPreset() returns only Command+Args for cost efficiency,
+			// but dogs must still pick up env vars like CLAUDE_CODE_USE_BEDROCK
+			// and AWS_PROFILE that Bedrock deployments require. The preset's own
+			// Env values (if any) take precedence over the base agent's values.
+			if baseRC := lookupAgentConfig("claude", townSettings, rigSettings); len(baseRC.Env) > 0 {
+				if preset.Env == nil {
+					preset.Env = make(map[string]string)
+				}
+				for k, v := range baseRC.Env {
+					if _, exists := preset.Env[k]; !exists {
+						preset.Env[k] = v
+					}
+				}
+			}
+			return preset
 		}
 	}
 

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -4028,6 +4028,48 @@ func TestResolveRoleAgentConfig(t *testing.T) {
 	})
 }
 
+// TestResolveRoleAgentConfig_DogInheritsBaseEnv verifies that dog sessions inherit
+// env vars from the base "claude" agent in agents.json (fixes #3012: claudeHaikuPreset
+// bypasses agents.json env vars so dogs miss Bedrock config).
+func TestResolveRoleAgentConfig_DogInheritsBaseEnv(t *testing.T) {
+	t.Parallel()
+	townRoot := t.TempDir()
+
+	// Town has a "claude" agent with Bedrock env vars in agents.json
+	townSettings := NewTownSettings()
+	townSettings.Agents = map[string]*RuntimeConfig{
+		"claude": {
+			Command: "claude",
+			Args:    []string{"--dangerously-skip-permissions"},
+			Env: map[string]string{
+				"CLAUDE_CODE_USE_BEDROCK": "1",
+				"AWS_PROFILE":            "bedrock-prod",
+			},
+		},
+	}
+	if err := SaveTownSettings(TownSettingsPath(townRoot), townSettings); err != nil {
+		t.Fatalf("SaveTownSettings: %v", err)
+	}
+
+	rc := ResolveRoleAgentConfig("dog", townRoot, "")
+
+	// Dog should use haiku preset (cost efficiency)
+	if !isClaudeCommand(rc.Command) {
+		t.Errorf("Command = %q, want claude", rc.Command)
+	}
+
+	// Dog must inherit Bedrock env vars from the base claude agent
+	if rc.Env == nil {
+		t.Fatal("dog RuntimeConfig.Env is nil — Bedrock env vars not inherited")
+	}
+	if got := rc.Env["CLAUDE_CODE_USE_BEDROCK"]; got != "1" {
+		t.Errorf("Env[CLAUDE_CODE_USE_BEDROCK] = %q, want %q", got, "1")
+	}
+	if got := rc.Env["AWS_PROFILE"]; got != "bedrock-prod" {
+		t.Errorf("Env[AWS_PROFILE] = %q, want %q", got, "bedrock-prod")
+	}
+}
+
 func TestResolveRoleAgentName(t *testing.T) {
 	t.Parallel()
 	townRoot := t.TempDir()


### PR DESCRIPTION
## Summary

- `claudeHaikuPreset()` returned a bare `RuntimeConfig` (Command+Args only), bypassing the `Env` map from `agents.json`
- Dog sessions on Bedrock deployments were missing `CLAUDE_CODE_USE_BEDROCK`, `AWS_PROFILE`, and related env vars
- Fix: after building the haiku preset, merge base `claude` agent's `Env` into it (preset values take precedence)

## Test plan

- [x] New test `TestResolveRoleAgentConfig_DogInheritsBaseEnv` verifies dogs inherit `CLAUDE_CODE_USE_BEDROCK` and `AWS_PROFILE` from base agent
- [x] All existing `TestResolve*` and `TestBuild*` tests pass
- [x] `go build ./...` clean

## Related

Fixes #3012

🤖 Generated with [Claude Code](https://claude.com/claude-code)