### PR TITLE
fix(reaper): DiscoverDatabases returns error instead of hardcoded fallback (#3013)

### DIFF
--- a/internal/cmd/reaper.go
+++ b/internal/cmd/reaper.go
@@ -46,7 +46,10 @@ var reaperDatabasesCmd = &cobra.Command{
 	Use:   "databases",
 	Short: "List databases available for reaping",
 	RunE: func(cmd *cobra.Command, args []string) error {
-		dbs := reaper.DiscoverDatabases(reaperHost, reaperPort)
+		dbs, err := reaper.DiscoverDatabases(reaperHost, reaperPort)
+		if err != nil {
+			return fmt.Errorf("database discovery failed: %w", err)
+		}
 		if reaperJSON {
 			fmt.Println(reaper.FormatJSON(dbs))
 		} else {
@@ -274,9 +277,15 @@ var reaperRunCmd = &cobra.Command{
 This is the inline fallback for when Dog dispatch is unavailable.
 Normally the daemon dispatches a Dog to execute the mol-dog-reaper formula.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		databases := reaper.DiscoverDatabases(reaperHost, reaperPort)
+		var databases []string
 		if reaperDB != "" {
 			databases = strings.Split(reaperDB, ",")
+		} else {
+			var err error
+			databases, err = reaper.DiscoverDatabases(reaperHost, reaperPort)
+			if err != nil {
+				return fmt.Errorf("database discovery failed: %w", err)
+			}
 		}
 
 		maxAge, err := time.ParseDuration(reaperMaxAge)

--- a/internal/daemon/wisp_reaper.go
+++ b/internal/daemon/wisp_reaper.go
@@ -139,7 +139,13 @@ func (d *Daemon) dispatchReaperDog(vars map[string]string) error {
 func (d *Daemon) reapWispsInline(config *WispReaperConfig, maxAge, deleteAge time.Duration, mol *dogMol) {
 	databases := config.Databases
 	if len(databases) == 0 {
-		databases = reaper.DiscoverDatabases("127.0.0.1", d.doltServerPort())
+		var err error
+		databases, err = reaper.DiscoverDatabases("127.0.0.1", d.doltServerPort())
+		if err != nil {
+			d.logger.Printf("wisp_reaper: database discovery failed: %v", err)
+			mol.failStep("scan", fmt.Sprintf("database discovery failed: %v", err))
+			return
+		}
 	}
 	if len(databases) == 0 {
 		d.logger.Printf("wisp_reaper: no databases to reap")

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -21,11 +21,10 @@ import (
 // validDBName matches safe database names (alphanumeric, underscore, hyphen).
 var validDBName = regexp.MustCompile(`^[a-zA-Z0-9_-]+$`)
 
-// DefaultDatabases is the static fallback list of known production databases.
-// Used only when SHOW DATABASES fails (server unreachable).
-// GH#2385: Removed legacy "gt" and "bd" names — modern towns use "hq" (town
-// beads) and rig-specific names. Those databases no longer exist in most
-// installations and their presence in the fallback caused phantom DB errors.
+// DefaultDatabases is kept for reference and backward compatibility.
+// It is no longer used as a fallback inside DiscoverDatabases — callers
+// should fail explicitly on discovery errors rather than silently operating
+// on a stale hardcoded list. See GH#3013.
 var DefaultDatabases = []string{"hq"}
 
 // testPollutionPrefixes are database name prefixes created by tests.
@@ -50,12 +49,13 @@ func isTableNotFound(err error) bool {
 
 // DiscoverDatabases queries SHOW DATABASES on the Dolt server and returns
 // all production databases, filtering out system databases and test pollution.
-// Falls back to DefaultDatabases on any error.
-func DiscoverDatabases(host string, port int) []string {
+// Returns an error on any failure so callers can decide whether to abort the
+// reaper cycle rather than silently operating on a stale hardcoded list (GH#3013).
+func DiscoverDatabases(host string, port int) ([]string, error) {
 	dsn := fmt.Sprintf("root@tcp(%s:%d)/?parseTime=true&timeout=5s", host, port)
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
-		return DefaultDatabases
+		return nil, fmt.Errorf("opening dolt connection: %w", err)
 	}
 	defer db.Close()
 
@@ -64,7 +64,7 @@ func DiscoverDatabases(host string, port int) []string {
 
 	rows, err := db.QueryContext(ctx, "SHOW DATABASES")
 	if err != nil {
-		return DefaultDatabases
+		return nil, fmt.Errorf("SHOW DATABASES: %w", err)
 	}
 	defer rows.Close()
 
@@ -92,9 +92,9 @@ func DiscoverDatabases(host string, port int) []string {
 	}
 
 	if len(databases) == 0 {
-		return DefaultDatabases
+		return nil, fmt.Errorf("SHOW DATABASES returned no production databases")
 	}
-	return databases
+	return databases, nil
 }
 
 // ScanResult holds the results of scanning a database for reaper candidates.


### PR DESCRIPTION
## Summary

Fixes GH#3013 — `DiscoverDatabases` silently returned `DefaultDatabases` on any failure, causing the reaper to operate on a stale hardcoded list when `SHOW DATABASES` failed.

**Before:** any error (connection failure, timeout, empty result) → silently returns `["hq"]`

**After:** returns `([]string, error)` — callers fail the reaper cycle explicitly and log the discovery error

## Changes

- `internal/reaper/reaper.go`: `DiscoverDatabases` now returns `([]string, error)`. Removed the three silent fallback return paths.
- `internal/cmd/reaper.go`: both `databases` and `run` subcommands return error on discovery failure.
- `internal/daemon/wisp_reaper.go`: logs discovery failure and calls `mol.failStep("scan", ...)`.
- `DefaultDatabases` kept for reference but removed from the fallback path.

## Test plan

- [x] `go test ./internal/reaper/` passes
- [x] `go build ./internal/reaper/ ./internal/cmd/ ./internal/daemon/` clean
- [x] `TestDoctorDogDatabases` failure is pre-existing (same failure on main — tracked in PR #3096)

🤖 Generated with [Claude Code](https://claude.com/claude-code)