### PR TITLE
fix(daemon): clear agent identity env vars at startup (#3006)

### DIFF
--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -343,6 +343,15 @@ func runDaemonRun(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a Gas Town workspace: %w", err)
 	}
 
+	// Clear agent identity env vars inherited from the launch environment.
+	// When the daemon is started from an agent session, GT_ROLE/GT_CREW are
+	// set to that agent's identity. Any subprocess (e.g. gt mail send) that
+	// derives sender identity from ambient env vars would then be misattributed
+	// to the launching agent instead of the daemon. GH#3006.
+	os.Unsetenv("GT_ROLE")  //nolint:errcheck
+	os.Unsetenv("GT_CREW")  //nolint:errcheck
+	os.Setenv("BD_ACTOR", "daemon") //nolint:errcheck
+
 	config := daemon.DefaultConfig(townRoot)
 	d, err := daemon.New(config)
 	if err != nil {


### PR DESCRIPTION
Fixes GH#3006 — daemon inherits agent identity from launch environment.

When `gt daemon run` is launched from an agent session, `GT_ROLE`, `GT_CREW`, and `BD_ACTOR` are inherited from that session. Any subprocess that derives sender identity from these vars (e.g. `gt mail send`) is then misattributed to the launching agent.

**Fix**: add three lines to `runDaemonRun` before daemon creation:
```go
os.Unsetenv("GT_ROLE")
os.Unsetenv("GT_CREW")
os.Setenv("BD_ACTOR", "daemon")
```

The `BD_ACTOR=daemon` override already existed on some `exec.Command` calls (`daemon.go:2154`) using `os.Environ() + append`, but that pattern loses to GT_ROLE-based sender detection. Clearing at process startup ensures no residual agent identity leaks through any subprocess.

## Test plan
- [x] `go build ./internal/cmd/` clean
- [x] `go vet ./internal/cmd/` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)