### PR TITLE
fix(security): enforce full suffix validation in looksLikeBeadID (GH#3110)

### DIFF
--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -1338,9 +1338,15 @@ func looksLikeBeadID(s string) bool {
 		return false
 	}
 
-	// Check rest starts with alphanumeric and contains only alphanumeric, dots, hyphens
-	first := rest[0]
-	if !((first >= 'a' && first <= 'z') || (first >= '0' && first <= '9')) {
+	// Check rest contains only alphanumeric, dots, hyphens — enforcing the stated contract.
+	// The first character must be alphanumeric (no leading dot/hyphen).
+	for i, c := range rest {
+		if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') {
+			continue
+		}
+		if i > 0 && (c == '.' || c == '-') {
+			continue
+		}
 		return false
 	}
 

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -1190,6 +1190,16 @@ func TestLooksLikeBeadID(t *testing.T) {
 		{"123-abc", false},      // numeric prefix
 		{"a-", false},           // nothing after hyphen
 		{"aaaaaa-b", false},     // prefix too long (6 chars)
+
+		// Shell metacharacters must be rejected (defense-in-depth, GH#3110)
+		{"gt-a$(cmd)", false},
+		{"gt-a;evil", false},
+		{"gt-a|pipe", false},
+		{"gt-a&bg", false},
+		{"gt-a>redir", false},
+		{"gt-a`bt`", false},
+		{"gt-.dot", false},    // leading dot in suffix
+		{"gt--hyphen", false}, // leading hyphen in suffix
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Problem

`looksLikeBeadID` only validated `rest[0]`, leaving the rest of the bead ID suffix unchecked. A string like `gt-a$(cmd)` passed the check despite containing shell metacharacters.

## Risk

Currently low: all downstream uses of bead IDs go through Go's `exec.Command` with argument slices, not shell strings. However the function's stated contract ("only alphanumeric, dots, hyphens") was not enforced, and a future code path passing a bead ID into `fmt.Sprintf` for a shell string would be exploitable.

Found during a dispatch pipeline security audit triggered by the `--model` injection fix in PR #3108.

## Fix

Validate every character in the suffix against `[a-z0-9.-]` with the constraint that the first character must be alphanumeric:

```go
for i, c := range rest {
    if (c >= 'a' && c <= 'z') || (c >= '0' && c <= '9') {
        continue
    }
    if i > 0 && (c == '.' || c == '-') {
        continue
    }
    return false
}
```

## Tests

Added 8 shell-metacharacter test cases to the existing `TestLooksLikeBeadID` table in `sling_test.go`. All pass.

## Checklist

- [x] `go test ./internal/cmd/... -run TestLooksLikeBeadID` passes
- [x] `go build ./internal/cmd/...` passes
- [x] Shell metacharacters (`$(`)`, `;`, `|`, `&`, `>`, backtick) now correctly rejected
- [x] Valid IDs (`gt-abc`, `hq-cv-abc`, `ap-qtsup.16`) still accepted

Closes #3110.