### PR TITLE
fix(formula): remove go test default from mol-refinery-patrol test_command

### DIFF
--- a/docs/concepts/integration-branches.md
+++ b/docs/concepts/integration-branches.md
@@ -516,7 +516,7 @@ Commands run in this order (any can be empty = skip):
 
 ### Example Configurations
 
-**Go project** (default — only test_command is set by default):
+**Go project** (all commands empty by default — configure per-rig):
 ```json
 {
   "merge_queue": {

--- a/docs/examples/rig-settings.example.json
+++ b/docs/examples/rig-settings.example.json
@@ -32,7 +32,7 @@
         "integration_branch_auto_land": false,
         "on_conflict": "assign_back",
         "run_tests": true,
-        "test_command": "go test ./...",
+        "test_command": "",
         "build_command": "go build ./...",
         "lint_command": "golangci-lint run",
         "setup_command": "",

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -69,7 +69,7 @@ Debug routing: `BD_DEBUG_ROUTING=1 bd show <id>`
     "setup_command": "",
     "typecheck_command": "",
     "lint_command": "",
-    "test_command": "go test ./...",
+    "test_command": "",
     "build_command": "",
     "on_conflict": "assign_back",
     "delete_merged_branches": true,
@@ -133,7 +133,7 @@ Town-level role defaults live in `mayor/config.json` under:
 | `setup_command` | `string` | `""` | Setup/install command (e.g., `pnpm install`) |
 | `typecheck_command` | `string` | `""` | Type check command (e.g., `tsc --noEmit`) |
 | `lint_command` | `string` | `""` | Lint command (e.g., `eslint .`) |
-| `test_command` | `string` | `"go test ./..."` | Test command to run |
+| `test_command` | `string` | `""` | Test command to run. Empty = skip. |
 | `build_command` | `string` | `""` | Build command (e.g., `go build ./...`) |
 | `on_conflict` | `string` | `"assign_back"` | Conflict strategy: `assign_back` or `auto_rebase` |
 | `delete_merged_branches` | `bool` | `true` | Delete source branches after merging |

--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -60,7 +60,7 @@ source of truth.
 | setup_command | (empty) | Setup/install command (e.g., `pnpm install`). Empty = skip. |
 | typecheck_command | (empty) | Type check command (e.g., `tsc --noEmit`). Empty = skip. |
 | lint_command | (empty) | Lint command (e.g., `eslint .`). Empty = skip. |
-| test_command | go test ./... | Test command to run (if run_tests is true) |
+| test_command | (empty) | Test command to run (if run_tests is true). Empty = skip. |
 | build_command | (empty) | Build command (e.g., `go build ./...`). Empty = skip. |
 | target_branch | main | Default target branch for merges |
 | delete_merged_branches | true | Whether to delete source branches after merge |
@@ -119,8 +119,8 @@ description = "Lint command (e.g., eslint .). Empty = skip."
 default = ""
 
 [vars.test_command]
-description = "Test command to run (if run_tests is true)"
-default = "go test ./..."
+description = "Test command to run (if run_tests is true). Empty = skip."
+default = ""
 
 [vars.build_command]
 description = "Build command (e.g., go build ./...). Empty = skip."


### PR DESCRIPTION
## Summary
- Removes the incorrect default `go test ./...` test_command from mol-refinery-patrol formula
- Source issue: gt-g7p

## Merge Details
- Branch: polecat/furiosa/gt-g7p@mn08jh0a
- Worker: furiosa
- Clean rebase on main, ff-only merge

Merged by gastown/refinery