### PR TITLE
fix(rig): pre-check remote for empty repo before cloning (GH#3054)

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -991,6 +991,17 @@ func (g *Git) IsEmpty() (bool, error) {
 	return strings.TrimSpace(out) == "", nil
 }
 
+// RemoteIsEmpty checks if a remote repository URL has no refs (no commits).
+// Uses git ls-remote --refs which lists all remote refs without cloning.
+// Returns true if the remote exists but has no refs.
+func (g *Git) RemoteIsEmpty(url string) (bool, error) {
+	out, err := g.run("ls-remote", "--refs", url)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(out) == "", nil
+}
+
 // RemoteBranchExists checks if a branch exists on the remote.
 func (g *Git) RemoteBranchExists(remote, branch string) (bool, error) {
 	out, err := g.run("ls-remote", "--heads", remote, branch)

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -412,6 +412,13 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 		return m.git.CloneBareWithBranch(opts.GitURL, bareRepoPath, branch)
 	}
 
+	// Pre-check: detect empty repos before cloning to surface a clear error.
+	// git clone succeeds on empty repos, but configureRefspec then fails with
+	// "fatal: couldn't find remote ref main" which is confusing. (GH#3054)
+	if empty, err := m.git.RemoteIsEmpty(opts.GitURL); err == nil && empty {
+		return nil, fmt.Errorf("repository %s is empty (no commits). Push at least one commit before adding it as a rig", opts.GitURL)
+	}
+
 	if err := cloneBareWith(opts.DefaultBranch); err != nil {
 		return nil, wrapCloneError(err, opts.GitURL)
 	}


### PR DESCRIPTION
## Summary

- `gt rig add` was emitting a cryptic `fatal: couldn't find remote ref main` when the target repo had no commits. A user-friendly error message already existed but fired too late — `configureRefspec`'s fetch call would fail first.
- Fix: add `RemoteIsEmpty(url)` to `git.go` (uses `git ls-remote --refs`) and call it in `AddRig()` before the clone. If no refs exist, fail immediately with the existing clear message.

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/rig/... ./internal/git/...` passes
- [ ] `gt rig add <name> <empty-repo-url>` now shows: `repository <url> is empty (no commits). Push at least one commit before adding it as a rig`

🤖 Generated with [Claude Code](https://claude.com/claude-code)