### PR TITLE
fix(tmux): restore per-town socket isolation reverted by 7ea8586a

### DIFF
--- a/internal/session/registry.go
+++ b/internal/session/registry.go
@@ -123,12 +123,12 @@ func InitRegistry(townRoot string) error {
 	var errs []error
 
 	// Determine the tmux socket name from GT_TMUX_SOCKET env var:
-	//   unset / "default" / "auto" → use the default tmux socket (empty name)
+	//   unset / "default" / "auto" → per-town socket derived from town directory path
 	//   any other value            → use that name as-is
 	socket := os.Getenv("GT_TMUX_SOCKET")
 	switch socket {
 	case "", "default", "auto":
-		socket = ""
+		socket = townSocketName(townRoot)
 	}
 	tmux.SetDefaultSocket(socket)
 

--- a/internal/session/registry_socket_test.go
+++ b/internal/session/registry_socket_test.go
@@ -10,7 +10,7 @@ import (
 )
 
 // TestInitRegistry_SocketFromTownName verifies GT_TMUX_SOCKET socket selection:
-//   - unset / "default" / "auto" → use the default tmux socket (empty name)
+//   - unset / "default" / "auto" → per-town socket derived from town directory path
 //   - explicit value              → that value verbatim
 func TestInitRegistry_SocketFromTownName(t *testing.T) {
 	origTMUX := os.Getenv("TMUX")
@@ -75,9 +75,10 @@ func TestInitRegistry_SocketFromTownName(t *testing.T) {
 			_ = InitRegistry(townRoot)
 
 			got := tmux.GetDefaultSocket()
-			if got != "" {
-				t.Errorf("after InitRegistry(%q) with GT_TMUX_SOCKET=%q:\n  socket = %q, want default socket \"\"",
-					townRoot, tt.gtTmuxSocket, got)
+			want := townSocketName(townRoot)
+			if got != want {
+				t.Errorf("after InitRegistry(%q) with GT_TMUX_SOCKET=%q:\n  socket = %q, want %q",
+					townRoot, tt.gtTmuxSocket, got, want)
 			}
 
 			tmux.SetDefaultSocket("")
@@ -120,10 +121,48 @@ func TestInitRegistry_SocketFromTownName(t *testing.T) {
 		_ = InitRegistry(townB)
 		socketB := tmux.GetDefaultSocket()
 
-		if socketA != "" || socketB != "" {
-			t.Errorf("default socket should stay empty across towns: A=%q, B=%q", socketA, socketB)
+		if socketA == "" || socketB == "" {
+			t.Errorf("sockets should be non-empty: A=%q, B=%q", socketA, socketB)
+		}
+		if socketA == socketB {
+			t.Errorf("different town paths should get different sockets: A=%q, B=%q", socketA, socketB)
+		}
+		if !strings.HasPrefix(socketA, "gt-") || !strings.HasPrefix(socketB, "gt-") {
+			t.Errorf("sockets should start with 'gt-': A=%q, B=%q", socketA, socketB)
 		}
 	})
+}
+
+func TestInitRegistry_SocketFormat(t *testing.T) {
+	origSocket := tmux.GetDefaultSocket()
+	origGTSocket := os.Getenv("GT_TMUX_SOCKET")
+	t.Cleanup(func() {
+		os.Setenv("GT_TMUX_SOCKET", origGTSocket)
+		tmux.SetDefaultSocket(origSocket)
+	})
+
+	os.Unsetenv("GT_TMUX_SOCKET")
+	tmux.SetDefaultSocket("")
+
+	townRoot := filepath.Join(t.TempDir(), "myproject")
+	os.MkdirAll(townRoot, 0o755)
+	_ = InitRegistry(townRoot)
+
+	got := tmux.GetDefaultSocket()
+
+	if !strings.HasPrefix(got, "myproject-") {
+		t.Fatalf("socket %q should start with 'myproject-'", got)
+	}
+	hash := strings.TrimPrefix(got, "myproject-")
+	if len(hash) != 6 {
+		t.Errorf("socket hash suffix %q should be 6 hex chars, got %d", hash, len(hash))
+	}
+	for _, c := range hash {
+		if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')) {
+			t.Errorf("socket hash suffix %q contains non-hex char %c", hash, c)
+			break
+		}
+	}
 }
 
 func TestSanitizeTownName(t *testing.T) {


### PR DESCRIPTION
## Summary

- Restores `townSocketName(townRoot)` in `InitRegistry`, undoing the revert in 7ea8586a that broke per-town tmux socket isolation (re-opens #761)
- Fixes test assertions in `registry_socket_test.go` to expect per-town socket names instead of empty string
- Adds `TestInitRegistry_SocketFormat` validating the `basename-hash6` socket name format

## Context

Commit `86d3c77e` (cherry-pick from PR #2473) introduced per-town tmux socket namespacing to fix #761 (multi-town collisions on shared hosts). The next day, `7ea8586a` reverted the one critical line — changing `townSocketName(townRoot)` back to `""` — with the justification "matches main's test expectations."

The revert left the codebase in an internally inconsistent state:
- `townSocketName()` exists but is dead code (never called at runtime)
- Test names describe per-town behavior but assertions validate the reverted empty-socket behavior
- The doctor split-brain check (`tmux_socket_check.go`) short-circuits as no-op when socket is empty
- Comments in `down.go` describe per-town sockets as active, which was false after the revert

This PR restores the intended behavior. The existing `townSocketName`, `LegacySocketName`, legacy cleanup in `down.go`, and the doctor split-brain check were all written to support per-town sockets — they just needed the one-line revert undone.

Re-closes #761, addresses #3042.

## Test plan

- [x] `go test ./internal/session/` — all socket tests pass with corrected assertions
- [x] `go test ./internal/tmux/ ./internal/lock/ ./internal/doctor/` — no regressions
- [x] `go test ./internal/cmd/ -run "Socket|Legacy|SplitBrain"` — no regressions
- [x] `go build ./...` — compiles cleanly

Made with [Cursor](https://cursor.com)