### PR TITLE
refactor: add test coverage for tmux socket isolation

### DIFF
--- a/internal/cmd/cycle.go
+++ b/internal/cmd/cycle.go
@@ -88,7 +88,7 @@ Examples:
 // clientOverride: if non-empty, pass as -c flag to tmux switch-client
 func cycleToSession(direction int, sessionOverride, clientOverride string) error {
 	// Override the default tmux socket to match the calling tmux server.
-	// PersistentPreRunE sets the socket to the town name (e.g., "gt"), but
+	// PersistentPreRunE sets the socket to the town path hash (e.g., "gt-a1b2c3"), but
 	// cycle is invoked from tmux run-shell which may be on a different socket
 	// (e.g., "default"). Without this, switch-client silently fails because
 	// the sessions aren't on the town-named socket.

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -724,15 +724,42 @@ func findOrphanedClaudeProcesses(townRoot string) []int {
 	return orphaned
 }
 
+// legacySocketTmux is the subset of tmux.Tmux used by the legacy socket
+// cleanup functions, extracted to allow test injection.
+type legacySocketTmux interface {
+	ListSessions() ([]string, error)
+	KillSessionWithProcesses(name string) error
+}
+
+// Test hooks — nil in production, set by tests to avoid real tmux calls.
+var (
+	legacyTmuxForTest   func(socket string) legacySocketTmux
+	legacySocketForTest func() string // overrides tmux.GetDefaultSocket()
+)
+
+func getDefaultSocket() string {
+	if legacySocketForTest != nil {
+		return legacySocketForTest()
+	}
+	return tmux.GetDefaultSocket()
+}
+
+func newLegacyTmux(socket string) legacySocketTmux {
+	if legacyTmuxForTest != nil {
+		return legacyTmuxForTest(socket)
+	}
+	return tmux.NewTmuxWithSocket(socket)
+}
+
 // cleanupLegacyDefaultSocket removes Gas Town sessions left on the "default"
 // tmux socket by old binaries. Returns the number of sessions cleaned.
 func cleanupLegacyDefaultSocket() int {
-	currentSocket := tmux.GetDefaultSocket()
+	currentSocket := getDefaultSocket()
 	if currentSocket == "" || currentSocket == "default" {
 		return 0 // Already on the default socket, nothing to clean up
 	}
 
-	legacyTmux := tmux.NewTmuxWithSocket("default")
+	legacyTmux := newLegacyTmux("default")
 	sessions, err := legacyTmux.ListSessions()
 	if err != nil {
 		return 0 // No server on default socket
@@ -752,12 +779,12 @@ func cleanupLegacyDefaultSocket() int {
 // countLegacyDefaultSocketSessions counts Gas Town sessions on the "default"
 // tmux socket (for dry-run output).
 func countLegacyDefaultSocketSessions() int {
-	currentSocket := tmux.GetDefaultSocket()
+	currentSocket := getDefaultSocket()
 	if currentSocket == "" || currentSocket == "default" {
 		return 0
 	}
 
-	legacyTmux := tmux.NewTmuxWithSocket("default")
+	legacyTmux := newLegacyTmux("default")
 	sessions, err := legacyTmux.ListSessions()
 	if err != nil {
 		return 0
@@ -776,13 +803,13 @@ func countLegacyDefaultSocketSessions() int {
 // tmux socket (e.g., "gt") by binaries from before path-hashed socket names were
 // introduced (e.g., "gt-a1b2c3"). Returns the number of sessions cleaned.
 func cleanupLegacyBaseSocket(townRoot string) int {
-	currentSocket := tmux.GetDefaultSocket()
+	currentSocket := getDefaultSocket()
 	legacySocket := session.LegacySocketName(townRoot)
 	if currentSocket == legacySocket {
 		return 0 // Same socket, no migration needed
 	}
 
-	legacyTmux := tmux.NewTmuxWithSocket(legacySocket)
+	legacyTmux := newLegacyTmux(legacySocket)
 	sessions, err := legacyTmux.ListSessions()
 	if err != nil {
 		return 0 // No server on legacy socket
@@ -802,13 +829,13 @@ func cleanupLegacyBaseSocket(townRoot string) int {
 // countLegacyBaseSocketSessions counts Gas Town sessions on the old basename-only
 // tmux socket (for dry-run output).
 func countLegacyBaseSocketSessions(townRoot string) int {
-	currentSocket := tmux.GetDefaultSocket()
+	currentSocket := getDefaultSocket()
 	legacySocket := session.LegacySocketName(townRoot)
 	if currentSocket == legacySocket {
 		return 0
 	}
 
-	legacyTmux := tmux.NewTmuxWithSocket(legacySocket)
+	legacyTmux := newLegacyTmux(legacySocket)
 	sessions, err := legacyTmux.ListSessions()
 	if err != nil {
 		return 0

--- a/internal/cmd/down_legacy_socket_test.go
+++ b/internal/cmd/down_legacy_socket_test.go
@@ -1,0 +1,202 @@
+package cmd
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/session"
+)
+
+type mockLegacyTmux struct {
+	sessions []string
+	listErr  error
+	killed   []string
+	killErr  error
+}
+
+func (m *mockLegacyTmux) ListSessions() ([]string, error) {
+	return m.sessions, m.listErr
+}
+
+func (m *mockLegacyTmux) KillSessionWithProcesses(name string) error {
+	if m.killErr != nil {
+		return m.killErr
+	}
+	m.killed = append(m.killed, name)
+	return nil
+}
+
+// setupLegacyHooks wires test hooks and a fresh registry, returning a cleanup func.
+func setupLegacyHooks(t *testing.T, currentSocket string, mock *mockLegacyTmux) {
+	t.Helper()
+
+	origTmuxHook := legacyTmuxForTest
+	origSocketHook := legacySocketForTest
+	origRegistry := session.DefaultRegistry()
+	t.Cleanup(func() {
+		legacyTmuxForTest = origTmuxHook
+		legacySocketForTest = origSocketHook
+		session.SetDefaultRegistry(origRegistry)
+	})
+
+	legacySocketForTest = func() string { return currentSocket }
+	legacyTmuxForTest = func(socket string) legacySocketTmux { return mock }
+
+	r := session.NewPrefixRegistry()
+	r.Register("ga", "gastown")
+	session.SetDefaultRegistry(r)
+}
+
+// ---------------------------------------------------------------------------
+// cleanupLegacyDefaultSocket
+// ---------------------------------------------------------------------------
+
+func TestCleanupLegacyDefaultSocket_SkipsWhenOnDefaultSocket(t *testing.T) {
+	mock := &mockLegacyTmux{}
+	setupLegacyHooks(t, "", mock)
+
+	got := cleanupLegacyDefaultSocket()
+	if got != 0 {
+		t.Errorf("expected 0, got %d", got)
+	}
+}
+
+func TestCleanupLegacyDefaultSocket_SkipsWhenSocketIsDefault(t *testing.T) {
+	mock := &mockLegacyTmux{}
+	setupLegacyHooks(t, "default", mock)
+
+	got := cleanupLegacyDefaultSocket()
+	if got != 0 {
+		t.Errorf("expected 0, got %d", got)
+	}
+}
+
+func TestCleanupLegacyDefaultSocket_CleansGastownSessions(t *testing.T) {
+	mock := &mockLegacyTmux{
+		sessions: []string{"ga-witness", "hq-mayor"},
+	}
+	setupLegacyHooks(t, "gt-abc123", mock)
+
+	got := cleanupLegacyDefaultSocket()
+	if got != 2 {
+		t.Errorf("expected 2 cleaned, got %d", got)
+	}
+	if len(mock.killed) != 2 {
+		t.Fatalf("expected 2 killed, got %d: %v", len(mock.killed), mock.killed)
+	}
+	want := map[string]bool{"ga-witness": true, "hq-mayor": true}
+	for _, k := range mock.killed {
+		if !want[k] {
+			t.Errorf("unexpected kill: %s", k)
+		}
+	}
+}
+
+func TestCleanupLegacyDefaultSocket_IgnoresNonGastownSessions(t *testing.T) {
+	mock := &mockLegacyTmux{
+		sessions: []string{"personal-stuff", "ga-witness"},
+	}
+	setupLegacyHooks(t, "gt-abc123", mock)
+
+	got := cleanupLegacyDefaultSocket()
+	if got != 1 {
+		t.Errorf("expected 1 cleaned, got %d", got)
+	}
+	if len(mock.killed) != 1 || mock.killed[0] != "ga-witness" {
+		t.Errorf("expected only ga-witness killed, got %v", mock.killed)
+	}
+}
+
+func TestCleanupLegacyDefaultSocket_NoDefaultServer(t *testing.T) {
+	mock := &mockLegacyTmux{
+		listErr: fmt.Errorf("no server running"),
+	}
+	setupLegacyHooks(t, "gt-abc123", mock)
+
+	got := cleanupLegacyDefaultSocket()
+	if got != 0 {
+		t.Errorf("expected 0, got %d", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// countLegacyDefaultSocketSessions
+// ---------------------------------------------------------------------------
+
+func TestCountLegacyDefaultSocket_SkipsWhenOnDefault(t *testing.T) {
+	mock := &mockLegacyTmux{}
+	setupLegacyHooks(t, "", mock)
+
+	got := countLegacyDefaultSocketSessions()
+	if got != 0 {
+		t.Errorf("expected 0, got %d", got)
+	}
+}
+
+func TestCountLegacyDefaultSocket_CountsGastownOnly(t *testing.T) {
+	mock := &mockLegacyTmux{
+		sessions: []string{"ga-witness", "personal"},
+	}
+	setupLegacyHooks(t, "gt-abc123", mock)
+
+	got := countLegacyDefaultSocketSessions()
+	if got != 1 {
+		t.Errorf("expected 1, got %d", got)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// cleanupLegacyBaseSocket
+// ---------------------------------------------------------------------------
+
+func TestCleanupLegacyBaseSocket_SkipsWhenSameSocket(t *testing.T) {
+	mock := &mockLegacyTmux{}
+	// LegacySocketName for "/some/path/gt" returns "gt"
+	setupLegacyHooks(t, "gt", mock)
+
+	got := cleanupLegacyBaseSocket("/some/path/gt")
+	if got != 0 {
+		t.Errorf("expected 0, got %d", got)
+	}
+}
+
+func TestCleanupLegacyBaseSocket_CleansOldSessions(t *testing.T) {
+	mock := &mockLegacyTmux{
+		sessions: []string{"ga-witness"},
+	}
+	setupLegacyHooks(t, "gt-abc123", mock)
+
+	got := cleanupLegacyBaseSocket("/some/path/gt")
+	if got != 1 {
+		t.Errorf("expected 1 cleaned, got %d", got)
+	}
+	if len(mock.killed) != 1 || mock.killed[0] != "ga-witness" {
+		t.Errorf("expected ga-witness killed, got %v", mock.killed)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// countLegacyBaseSocketSessions
+// ---------------------------------------------------------------------------
+
+func TestCountLegacyBaseSocket_SkipsWhenSame(t *testing.T) {
+	mock := &mockLegacyTmux{}
+	setupLegacyHooks(t, "gt", mock)
+
+	got := countLegacyBaseSocketSessions("/some/path/gt")
+	if got != 0 {
+		t.Errorf("expected 0, got %d", got)
+	}
+}
+
+func TestCountLegacyBaseSocket_CountsCorrectly(t *testing.T) {
+	mock := &mockLegacyTmux{
+		sessions: []string{"ga-witness", "hq-deacon", "random-thing"},
+	}
+	setupLegacyHooks(t, "gt-abc123", mock)
+
+	got := countLegacyBaseSocketSessions("/some/path/gt")
+	if got != 2 {
+		t.Errorf("expected 2, got %d", got)
+	}
+}

--- a/internal/doctor/integration_test.go
+++ b/internal/doctor/integration_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/tmux"
 )
 
 // TestIntegrationTownSetup verifies that a fresh town setup passes all doctor checks.
@@ -604,7 +605,120 @@ func TestIntegrationSessionNaming(t *testing.T) {
 	}
 }
 
+// TestIntegrationMultiTownSocketIsolation verifies that two towns get distinct
+// tmux sockets and that sessions on one socket are invisible from the other.
+func TestIntegrationMultiTownSocketIsolation(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping integration test in short mode")
+	}
+
+	origSocket := tmux.GetDefaultSocket()
+	origRegistry := session.DefaultRegistry()
+	t.Cleanup(func() {
+		tmux.SetDefaultSocket(origSocket)
+		session.SetDefaultRegistry(origRegistry)
+	})
+
+	townA := setupIntegrationTown(t)
+	townB := setupIntegrationTown(t)
+
+	createTestRig(t, townA, "gastown")
+	createTestRig(t, townB, "gastown")
+
+	// Init townA and capture its socket
+	if err := session.InitRegistry(townA); err != nil {
+		t.Fatalf("InitRegistry(townA): %v", err)
+	}
+	socketA := tmux.GetDefaultSocket()
+
+	// Reset and init townB
+	tmux.SetDefaultSocket("")
+	if err := session.InitRegistry(townB); err != nil {
+		t.Fatalf("InitRegistry(townB): %v", err)
+	}
+	socketB := tmux.GetDefaultSocket()
+
+	if socketA == socketB {
+		t.Fatalf("two towns produced the same socket %q; expected distinct sockets", socketA)
+	}
+	if socketA == "" {
+		t.Fatal("socketA is empty after InitRegistry")
+	}
+	if socketB == "" {
+		t.Fatal("socketB is empty after InitRegistry")
+	}
+	t.Logf("socketA=%s  socketB=%s", socketA, socketB)
+
+	// Real tmux isolation (requires tmux binary)
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Log("tmux not found, skipping live isolation subtests")
+	} else {
+		tmA := tmux.NewTmuxWithSocket(socketA)
+		tmB := tmux.NewTmuxWithSocket(socketB)
+		t.Cleanup(func() {
+			tmA.KillServer()
+			tmB.KillServer()
+		})
+
+		if err := tmA.NewSessionWithCommand("ga-witness", ".", "sleep 300"); err != nil {
+			t.Fatalf("create session on socketA: %v", err)
+		}
+
+		// socketB must NOT see ga-witness
+		sessionsB, err := tmB.ListSessions()
+		if err == nil {
+			for _, s := range sessionsB {
+				if s == "ga-witness" {
+					t.Errorf("socketB sees ga-witness — isolation broken")
+				}
+			}
+		}
+
+		// socketA must see it
+		has, err := tmA.HasSession("ga-witness")
+		if err != nil {
+			t.Errorf("HasSession on socketA: %v", err)
+		}
+		if !has {
+			t.Errorf("socketA does not see ga-witness")
+		}
+	}
+
+	// Verify the split-brain check passes when the "default" socket has no
+	// Gas Town sessions.  We mock the default lister to avoid interacting with
+	// the user's real default tmux socket.
+	tmux.SetDefaultSocket(socketA)
+	checkA := NewSocketSplitBrainCheck()
+	checkA.defaultListerForTest = &emptySessionLister{}
+	result := checkA.Run(&CheckContext{TownRoot: townA})
+	if result.Status != StatusOK {
+		t.Errorf("split-brain check: want StatusOK, got %v: %s", result.Status, result.Message)
+		for _, d := range result.Details {
+			t.Logf("  detail: %s", d)
+		}
+	}
+
+	// Cross-socket isolation via split-brain check: set default to socketB and
+	// ensure sessions created on socketA don't cause a warning for townB.
+	tmux.SetDefaultSocket(socketB)
+	checkB := NewSocketSplitBrainCheck()
+	checkB.defaultListerForTest = &emptySessionLister{}
+	resultB := checkB.Run(&CheckContext{TownRoot: townB})
+	if resultB.Status != StatusOK {
+		t.Errorf("split-brain check for townB: want StatusOK, got %v: %s",
+			resultB.Status, resultB.Message)
+	}
+
+}
+
 // Helper functions
+
+// emptySessionLister is a socketSessionLister that reports no sessions,
+// used to isolate split-brain tests from the real "default" tmux socket.
+type emptySessionLister struct{}
+
+func (e *emptySessionLister) ListSessions() ([]string, error) { return nil, nil }
+func (e *emptySessionLister) KillSessionWithProcesses(string) error { return nil }
 
 // mockEnvReaderIntegration implements SessionEnvReader for integration tests.
 type mockEnvReaderIntegration struct {

--- a/internal/doctor/tmux_socket_check.go
+++ b/internal/doctor/tmux_socket_check.go
@@ -8,13 +8,25 @@ import (
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
+// socketSessionLister is the minimal interface needed to list and kill sessions
+// on a specific tmux socket. Allows injecting mocks in tests.
+type socketSessionLister interface {
+	ListSessions() ([]string, error)
+	KillSessionWithProcesses(name string) error
+}
+
 // SocketSplitBrainCheck detects tmux sessions that exist on both the town
-// socket (e.g., "gt") and the "default" socket. This split-brain causes
+// socket (e.g., "gt-a1b2c3") and the "default" socket. This split-brain causes
 // gt nudge and other session-discovery commands to fail because they only
 // search the town socket.
 type SocketSplitBrainCheck struct {
 	FixableCheck
 	staleSessions []string // Sessions on "default" that also exist on town socket
+
+	townListerForTest    socketSessionLister // nil → real tmux on town socket
+	defaultListerForTest socketSessionLister // nil → real tmux on "default" socket
+	socketForTest        string              // override for tmux.GetDefaultSocket()
+	useSocketForTest     bool                // distinguishes empty override from unset
 }
 
 // NewSocketSplitBrainCheck creates a new socket split-brain check.
@@ -34,6 +46,9 @@ func NewSocketSplitBrainCheck() *SocketSplitBrainCheck {
 // sessions on the town socket.
 func (c *SocketSplitBrainCheck) Run(ctx *CheckContext) *CheckResult {
 	townSocket := tmux.GetDefaultSocket()
+	if c.useSocketForTest {
+		townSocket = c.socketForTest
+	}
 	if townSocket == "" || townSocket == "default" {
 		return &CheckResult{
 			Name:    c.Name(),
@@ -42,11 +57,17 @@ func (c *SocketSplitBrainCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
-	// List sessions on both sockets
-	townTmux := tmux.NewTmux()
-	defaultTmux := tmux.NewTmuxWithSocket("default")
+	var townLister socketSessionLister = tmux.NewTmux()
+	if c.townListerForTest != nil {
+		townLister = c.townListerForTest
+	}
 
-	townSessions, err := townTmux.ListSessions()
+	var defaultLister socketSessionLister = tmux.NewTmuxWithSocket("default")
+	if c.defaultListerForTest != nil {
+		defaultLister = c.defaultListerForTest
+	}
+
+	townSessions, err := townLister.ListSessions()
 	if err != nil {
 		return &CheckResult{
 			Name:    c.Name(),
@@ -55,7 +76,7 @@ func (c *SocketSplitBrainCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
-	defaultSessions, err := defaultTmux.ListSessions()
+	defaultSessions, err := defaultLister.ListSessions()
 	if err != nil {
 		return &CheckResult{
 			Name:    c.Name(),
@@ -119,11 +140,14 @@ func (c *SocketSplitBrainCheck) Fix(ctx *CheckContext) error {
 		return nil
 	}
 
-	defaultTmux := tmux.NewTmuxWithSocket("default")
+	var defaultLister socketSessionLister = tmux.NewTmuxWithSocket("default")
+	if c.defaultListerForTest != nil {
+		defaultLister = c.defaultListerForTest
+	}
 	var lastErr error
 
 	for _, s := range c.staleSessions {
-		if err := defaultTmux.KillSessionWithProcesses(s); err != nil {
+		if err := defaultLister.KillSessionWithProcesses(s); err != nil {
 			lastErr = err
 		}
 	}

--- a/internal/doctor/tmux_socket_check_test.go
+++ b/internal/doctor/tmux_socket_check_test.go
@@ -1,0 +1,268 @@
+package doctor
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/session"
+)
+
+// mockSocketLister implements socketSessionLister for testing.
+type mockSocketLister struct {
+	sessions []string
+	listErr  error
+	killed   []string
+	killErr  error
+}
+
+func (m *mockSocketLister) ListSessions() ([]string, error) {
+	if m.listErr != nil {
+		return nil, m.listErr
+	}
+	return m.sessions, nil
+}
+
+func (m *mockSocketLister) KillSessionWithProcesses(name string) error {
+	m.killed = append(m.killed, name)
+	return m.killErr
+}
+
+// setupSocketTestRegistry registers the "ga" prefix so session.IsKnownSession
+// recognises "ga-*" names, and returns a cleanup function.
+func setupSocketTestRegistry(t *testing.T) {
+	t.Helper()
+	oldRegistry := session.DefaultRegistry()
+	t.Cleanup(func() { session.SetDefaultRegistry(oldRegistry) })
+	r := session.NewPrefixRegistry()
+	r.Register("ga", "gastown")
+	session.SetDefaultRegistry(r)
+}
+
+// --- Run() tests ---
+
+func TestSocketSplitBrainCheck_EmptySocket(t *testing.T) {
+	setupSocketTestRegistry(t)
+
+	check := NewSocketSplitBrainCheck()
+	check.useSocketForTest = true
+	check.socketForTest = ""
+
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected OK, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "no split-brain possible") {
+		t.Errorf("unexpected message: %s", result.Message)
+	}
+}
+
+func TestSocketSplitBrainCheck_DefaultSocket(t *testing.T) {
+	setupSocketTestRegistry(t)
+
+	check := NewSocketSplitBrainCheck()
+	check.useSocketForTest = true
+	check.socketForTest = "default"
+
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected OK, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "no split-brain possible") {
+		t.Errorf("unexpected message: %s", result.Message)
+	}
+}
+
+func TestSocketSplitBrainCheck_NoTownServer(t *testing.T) {
+	setupSocketTestRegistry(t)
+
+	check := NewSocketSplitBrainCheck()
+	check.useSocketForTest = true
+	check.socketForTest = "gt-abc123"
+	check.townListerForTest = &mockSocketLister{listErr: fmt.Errorf("no server running")}
+	check.defaultListerForTest = &mockSocketLister{sessions: []string{}}
+
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected OK, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "server may not be running") {
+		t.Errorf("unexpected message: %s", result.Message)
+	}
+}
+
+func TestSocketSplitBrainCheck_NoDefaultServer(t *testing.T) {
+	setupSocketTestRegistry(t)
+
+	check := NewSocketSplitBrainCheck()
+	check.useSocketForTest = true
+	check.socketForTest = "gt-abc123"
+	check.townListerForTest = &mockSocketLister{sessions: []string{"ga-witness"}}
+	check.defaultListerForTest = &mockSocketLister{listErr: fmt.Errorf("no server running")}
+
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected OK, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "No default socket server") {
+		t.Errorf("unexpected message: %s", result.Message)
+	}
+}
+
+func TestSocketSplitBrainCheck_NoDuplicates(t *testing.T) {
+	setupSocketTestRegistry(t)
+
+	check := NewSocketSplitBrainCheck()
+	check.useSocketForTest = true
+	check.socketForTest = "gt-abc123"
+	check.townListerForTest = &mockSocketLister{sessions: []string{"ga-witness"}}
+	check.defaultListerForTest = &mockSocketLister{sessions: []string{"personal-stuff"}}
+
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected OK, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "No split-brain") {
+		t.Errorf("unexpected message: %s", result.Message)
+	}
+}
+
+func TestSocketSplitBrainCheck_DetectsDuplicates(t *testing.T) {
+	setupSocketTestRegistry(t)
+
+	check := NewSocketSplitBrainCheck()
+	check.useSocketForTest = true
+	check.socketForTest = "gt-abc123"
+	check.townListerForTest = &mockSocketLister{sessions: []string{"ga-witness"}}
+	check.defaultListerForTest = &mockSocketLister{sessions: []string{"ga-witness"}}
+
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+	result := check.Run(ctx)
+
+	if result.Status != StatusError {
+		t.Fatalf("expected Error, got %v: %s", result.Status, result.Message)
+	}
+	if len(result.Details) == 0 {
+		t.Fatal("expected details to be non-empty")
+	}
+	found := false
+	for _, d := range result.Details {
+		if strings.Contains(d, "DUPLICATE") && strings.Contains(d, "ga-witness") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected DUPLICATE detail for ga-witness, got: %v", result.Details)
+	}
+}
+
+func TestSocketSplitBrainCheck_DetectsOrphans(t *testing.T) {
+	setupSocketTestRegistry(t)
+
+	check := NewSocketSplitBrainCheck()
+	check.useSocketForTest = true
+	check.socketForTest = "gt-abc123"
+	check.townListerForTest = &mockSocketLister{sessions: []string{}}
+	check.defaultListerForTest = &mockSocketLister{sessions: []string{"ga-refinery"}}
+
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+	result := check.Run(ctx)
+
+	if result.Status != StatusError {
+		t.Fatalf("expected Error, got %v: %s", result.Status, result.Message)
+	}
+	found := false
+	for _, d := range result.Details {
+		if strings.Contains(d, "ORPHAN") && strings.Contains(d, "ga-refinery") {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("expected ORPHAN detail for ga-refinery, got: %v", result.Details)
+	}
+}
+
+func TestSocketSplitBrainCheck_MixedWithNonGastown(t *testing.T) {
+	setupSocketTestRegistry(t)
+
+	check := NewSocketSplitBrainCheck()
+	check.useSocketForTest = true
+	check.socketForTest = "gt-abc123"
+	check.townListerForTest = &mockSocketLister{sessions: []string{}}
+	check.defaultListerForTest = &mockSocketLister{sessions: []string{"ga-witness", "personal-stuff"}}
+
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+	result := check.Run(ctx)
+
+	if result.Status != StatusError {
+		t.Fatalf("expected Error, got %v: %s", result.Status, result.Message)
+	}
+
+	// ga-witness should be flagged as orphan
+	hasGaWitness := false
+	for _, d := range result.Details {
+		if strings.Contains(d, "ga-witness") {
+			hasGaWitness = true
+		}
+		if strings.Contains(d, "personal-stuff") {
+			t.Errorf("personal-stuff should be ignored, but appeared in details: %v", result.Details)
+		}
+	}
+	if !hasGaWitness {
+		t.Errorf("expected ga-witness in details, got: %v", result.Details)
+	}
+
+	// Only 1 stale session (personal-stuff is ignored)
+	if len(check.staleSessions) != 1 {
+		t.Errorf("expected 1 stale session, got %d: %v", len(check.staleSessions), check.staleSessions)
+	}
+}
+
+// --- Fix() tests ---
+
+func TestSocketSplitBrainCheck_Fix_NoStale(t *testing.T) {
+	check := NewSocketSplitBrainCheck()
+	mock := &mockSocketLister{}
+	check.defaultListerForTest = mock
+
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix() returned error: %v", err)
+	}
+	if len(mock.killed) != 0 {
+		t.Errorf("expected no kills, got: %v", mock.killed)
+	}
+}
+
+func TestSocketSplitBrainCheck_Fix_KillsStale(t *testing.T) {
+	check := NewSocketSplitBrainCheck()
+	check.staleSessions = []string{"ga-refinery", "ga-witness"}
+
+	mock := &mockSocketLister{}
+	check.defaultListerForTest = mock
+
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix() returned error: %v", err)
+	}
+
+	if len(mock.killed) != 2 {
+		t.Fatalf("expected 2 kills, got %d: %v", len(mock.killed), mock.killed)
+	}
+	// staleSessions is sorted, so kills should be in order
+	if mock.killed[0] != "ga-refinery" || mock.killed[1] != "ga-witness" {
+		t.Errorf("unexpected kill order: %v", mock.killed)
+	}
+}

--- a/internal/lock/lock.go
+++ b/internal/lock/lock.go
@@ -294,7 +294,7 @@ func getActiveTmuxSessions() []string {
 	// Format: "session_name:session_id" e.g., "gt-beads-crew-dave:$55"
 	// Use the town's tmux socket so we query the correct server.
 	// Without -L, bare "tmux" queries the "default" socket, which misses
-	// all sessions on the per-town socket (e.g., "gt") and causes
+	// all sessions on the per-town socket (e.g., "gt-a1b2c3") and causes
 	// CleanStaleLocks to incorrectly remove locks for active sessions.
 	args := []string{}
 	if sock := tmux.GetDefaultSocket(); sock != "" {

--- a/internal/tmux/cross_socket_test.go
+++ b/internal/tmux/cross_socket_test.go
@@ -1,0 +1,180 @@
+package tmux
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+var crossSocket = fmt.Sprintf("gt-test-cross-%d", os.Getpid())
+
+func newCrossTestSocket(t *testing.T) *Tmux {
+	t.Helper()
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+	tm := NewTmuxWithSocket(crossSocket)
+	t.Cleanup(func() {
+		_ = tm.KillServer()
+	})
+	return tm
+}
+
+func TestCrossSocketIsolation(t *testing.T) {
+	defaultTm := newTestTmux(t)
+	crossTm := newCrossTestSocket(t)
+
+	sessionA := fmt.Sprintf("gt-test-iso-a-%d", os.Getpid())
+	sessionB := fmt.Sprintf("gt-test-iso-b-%d", os.Getpid())
+
+	if err := defaultTm.NewSessionWithCommand(sessionA, ".", "sleep 300"); err != nil {
+		t.Fatalf("create session A on default socket: %v", err)
+	}
+	t.Cleanup(func() { _ = defaultTm.KillSession(sessionA) })
+
+	if err := crossTm.NewSessionWithCommand(sessionB, ".", "sleep 300"); err != nil {
+		t.Fatalf("create session B on cross socket: %v", err)
+	}
+	t.Cleanup(func() { _ = crossTm.KillSession(sessionB) })
+
+	crossSessions, err := crossTm.ListSessions()
+	if err != nil {
+		t.Fatalf("ListSessions on cross socket: %v", err)
+	}
+	for _, s := range crossSessions {
+		if s == sessionA {
+			t.Errorf("cross socket should NOT see session %q from default socket", sessionA)
+		}
+	}
+
+	defaultSessions, err := defaultTm.ListSessions()
+	if err != nil {
+		t.Fatalf("ListSessions on default socket: %v", err)
+	}
+	for _, s := range defaultSessions {
+		if s == sessionB {
+			t.Errorf("default socket should NOT see session %q from cross socket", sessionB)
+		}
+	}
+
+	hasA, err := defaultTm.HasSession(sessionA)
+	if err != nil {
+		t.Fatalf("HasSession(A) on default: %v", err)
+	}
+	if !hasA {
+		t.Error("default socket should see its own session A")
+	}
+
+	hasB, err := crossTm.HasSession(sessionB)
+	if err != nil {
+		t.Fatalf("HasSession(B) on cross: %v", err)
+	}
+	if !hasB {
+		t.Error("cross socket should see its own session B")
+	}
+}
+
+func TestCrossSocketKill(t *testing.T) {
+	defaultTm := newTestTmux(t)
+	crossTm := newCrossTestSocket(t)
+
+	defaultSession := fmt.Sprintf("gt-test-survive-%d", os.Getpid())
+	crossSession := fmt.Sprintf("gt-test-doomed-%d", os.Getpid())
+
+	if err := defaultTm.NewSessionWithCommand(defaultSession, ".", "sleep 300"); err != nil {
+		t.Fatalf("create session on default socket: %v", err)
+	}
+	t.Cleanup(func() { _ = defaultTm.KillSession(defaultSession) })
+
+	if err := crossTm.NewSessionWithCommand(crossSession, ".", "sleep 300"); err != nil {
+		t.Fatalf("create session on cross socket: %v", err)
+	}
+
+	if err := crossTm.KillServer(); err != nil {
+		t.Fatalf("KillServer on cross socket: %v", err)
+	}
+
+	has, err := defaultTm.HasSession(defaultSession)
+	if err != nil {
+		t.Fatalf("HasSession on default socket after cross KillServer: %v", err)
+	}
+	if !has {
+		t.Error("default socket session should survive KillServer on cross socket")
+	}
+}
+
+func TestSessionsOnMultipleSockets(t *testing.T) {
+	defaultTm := newTestTmux(t)
+	crossTm := newCrossTestSocket(t)
+
+	defaultSessions := []string{
+		fmt.Sprintf("gt-test-multi-d1-%d", os.Getpid()),
+		fmt.Sprintf("gt-test-multi-d2-%d", os.Getpid()),
+	}
+	crossSessions := []string{
+		fmt.Sprintf("gt-test-multi-c1-%d", os.Getpid()),
+		fmt.Sprintf("gt-test-multi-c2-%d", os.Getpid()),
+	}
+
+	for _, name := range defaultSessions {
+		if err := defaultTm.NewSessionWithCommand(name, ".", "sleep 300"); err != nil {
+			t.Fatalf("create %q on default socket: %v", name, err)
+		}
+		t.Cleanup(func() { _ = defaultTm.KillSession(name) })
+	}
+
+	for _, name := range crossSessions {
+		if err := crossTm.NewSessionWithCommand(name, ".", "sleep 300"); err != nil {
+			t.Fatalf("create %q on cross socket: %v", name, err)
+		}
+		t.Cleanup(func() { _ = crossTm.KillSession(name) })
+	}
+
+	gotDefault, err := defaultTm.ListSessions()
+	if err != nil {
+		t.Fatalf("ListSessions on default: %v", err)
+	}
+	gotCross, err := crossTm.ListSessions()
+	if err != nil {
+		t.Fatalf("ListSessions on cross: %v", err)
+	}
+
+	defaultSet := make(map[string]bool)
+	for _, s := range gotDefault {
+		defaultSet[s] = true
+	}
+	crossSet := make(map[string]bool)
+	for _, s := range gotCross {
+		crossSet[s] = true
+	}
+
+	for _, name := range defaultSessions {
+		if !defaultSet[name] {
+			t.Errorf("default socket missing its own session %q", name)
+		}
+		if crossSet[name] {
+			t.Errorf("cross socket should NOT contain default session %q", name)
+		}
+	}
+
+	for _, name := range crossSessions {
+		if !crossSet[name] {
+			t.Errorf("cross socket missing its own session %q", name)
+		}
+		if defaultSet[name] {
+			t.Errorf("default socket should NOT contain cross session %q", name)
+		}
+	}
+
+	crossCount := 0
+	for _, s := range gotCross {
+		for _, name := range crossSessions {
+			if s == name {
+				crossCount++
+			}
+		}
+	}
+	if crossCount != len(crossSessions) {
+		t.Errorf("cross socket has %d of %d expected sessions", crossCount, len(crossSessions))
+	}
+}

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3359,7 +3359,7 @@ func (t *Tmux) SetAgentsBinding(session string) error {
 // specific tmux socket. This is used during gt up to ensure the bindings work
 // even when the user is on a different socket than the town socket.
 //
-// townSocket is the socket name where GT agents live (e.g. "gt"). When
+// townSocket is the socket name where GT agents live (e.g. "gt-a1b2c3"). When
 // non-empty it is embedded in the binding command as GT_TOWN_SOCKET=<name>
 // so that gt agents menu can locate agent sessions even when invoked from a
 // directory outside the town root (e.g. a personal tmux session where


### PR DESCRIPTION
## Summary

- Adds three tiers of test coverage for per-town tmux socket isolation (25 new tests total)
- Makes `SocketSplitBrainCheck` and `gt down` legacy cleanup functions testable via injectable hooks
- Updates stale socket format references in comments

## Test tiers

**Tier 1 -- Unit tests with mocks (21 tests, all pass on main):**
- `internal/doctor/tmux_socket_check_test.go`: 10 tests covering `SocketSplitBrainCheck.Run()` (empty socket, no server, duplicates, orphans, mixed) and `Fix()` (no-op, kill stale)
- `internal/cmd/down_legacy_socket_test.go`: 11 tests covering `cleanupLegacyDefaultSocket`, `cleanupLegacyBaseSocket`, and their count variants

**Tier 2 -- Real tmux cross-socket isolation (3 tests, all pass on main):**
- `internal/tmux/cross_socket_test.go`: verifies sessions on socket A are invisible from socket B, killing one server doesn't affect the other, multi-session isolation

**Tier 3 -- Multi-town integration scenario (1 test, intentionally fails on main):**
- `TestIntegrationMultiTownSocketIsolation` in `internal/doctor/integration_test.go`: creates two towns, calls `InitRegistry` for each, asserts they get different sockets, tests real tmux isolation and split-brain detection

## Intentionally failing test

`TestIntegrationMultiTownSocketIsolation` fails on main with:
```
two towns produced the same socket ""; expected distinct sockets
```

This is expected -- `InitRegistry` currently maps all default cases to `socket=""` due to the revert in 7ea8586a (see #3042). The test passes when #3118 is applied, which restores `townSocketName(townRoot)`. This test serves as verification that #3118 fixes the multi-town collision issue.

## Refactoring (no behavior changes)

- `SocketSplitBrainCheck`: added `socketSessionLister` interface and `*ForTest` fields (nil = production behavior unchanged)
- `down.go` legacy cleanup: added `legacySocketTmux` interface and package-level test hooks (nil = production behavior unchanged)
- Updated stale `"gt"` socket references to `"gt-a1b2c3"` in `cycle.go`, `tmux.go`, `lock.go`

Refs #3042, #761. Companion to #3118.

## Test plan

- [x] `go test ./internal/doctor/ -run TestSocketSplitBrain` -- 10/10 pass
- [x] `go test ./internal/cmd/ -run "TestCleanupLegacy|TestCountLegacy"` -- 11/11 pass
- [x] `go test ./internal/tmux/ -run "TestCrossSocket|TestSessionsOnMultiple"` -- 3/3 pass
- [x] `go test -tags=integration ./internal/doctor/ -run TestIntegrationMultiTown` -- fails as expected (passes with #3118)
- [x] `go build ./...` -- compiles cleanly

Made with [Cursor](https://cursor.com)