### PR TITLE
fix(test): eliminate data race in TestValidateStampInputs (GH#3122)

### DIFF
--- a/internal/cmd/wl_stamp.go
+++ b/internal/cmd/wl_stamp.go
@@ -79,8 +79,17 @@ func init() {
 }
 
 func runWlStamp(cmd *cobra.Command, args []string) error {
-	// Validate inputs
-	if err := validateStampInputs(); err != nil {
+	in := stampInputs{
+		Quality:     wlStampQuality,
+		Reliability: wlStampReliability,
+		Creativity:  wlStampCreativity,
+		Confidence:  wlStampConfidence,
+		Severity:    wlStampSeverity,
+		Type:        wlStampType,
+		ContextType: wlStampContextType,
+		PilotCohort: wlStampPilotCohort,
+	}
+	if err := validateStampInputs(in); err != nil {
 		return err
 	}
 
@@ -166,34 +175,45 @@ func runWlStamp(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func validateStampInputs() error {
-	if wlStampQuality < 0 || wlStampQuality > 5 {
-		return fmt.Errorf("quality must be 0-5 (got %.1f)", wlStampQuality)
+type stampInputs struct {
+	Quality     float64
+	Reliability float64
+	Creativity  float64
+	Confidence  float64
+	Severity    string
+	Type        string
+	ContextType string
+	PilotCohort string
+}
+
+func validateStampInputs(in stampInputs) error {
+	if in.Quality < 0 || in.Quality > 5 {
+		return fmt.Errorf("quality must be 0-5 (got %.1f)", in.Quality)
 	}
-	if wlStampReliability >= 0 && wlStampReliability > 5 {
-		return fmt.Errorf("reliability must be 0-5 (got %.1f)", wlStampReliability)
+	if in.Reliability >= 0 && in.Reliability > 5 {
+		return fmt.Errorf("reliability must be 0-5 (got %.1f)", in.Reliability)
 	}
-	if wlStampCreativity >= 0 && wlStampCreativity > 5 {
-		return fmt.Errorf("creativity must be 0-5 (got %.1f)", wlStampCreativity)
+	if in.Creativity >= 0 && in.Creativity > 5 {
+		return fmt.Errorf("creativity must be 0-5 (got %.1f)", in.Creativity)
 	}
-	if wlStampConfidence >= 0 && (wlStampConfidence < 0 || wlStampConfidence > 1) {
-		return fmt.Errorf("confidence must be 0.0-1.0 (got %.2f)", wlStampConfidence)
+	if in.Confidence >= 0 && (in.Confidence < 0 || in.Confidence > 1) {
+		return fmt.Errorf("confidence must be 0.0-1.0 (got %.2f)", in.Confidence)
 	}
 
 	validSeverities := map[string]bool{"leaf": true, "branch": true, "root": true}
-	if !validSeverities[wlStampSeverity] {
-		return fmt.Errorf("severity must be leaf, branch, or root (got %q)", wlStampSeverity)
+	if !validSeverities[in.Severity] {
+		return fmt.Errorf("severity must be leaf, branch, or root (got %q)", in.Severity)
 	}
 
 	validStampTypes := map[string]bool{"work": true, "mentoring": true, "peer_review": true, "endorsement": true, "boot_block": true}
-	if !validStampTypes[wlStampType] {
-		return fmt.Errorf("stamp-type must be work, mentoring, peer_review, endorsement, or boot_block (got %q)", wlStampType)
+	if !validStampTypes[in.Type] {
+		return fmt.Errorf("stamp-type must be work, mentoring, peer_review, endorsement, or boot_block (got %q)", in.Type)
 	}
 
-	if wlStampPilotCohort != "" {
+	if in.PilotCohort != "" {
 		validCohorts := map[string]bool{"andela-pilot": true, "commbank-pilot": true, "indie": true}
-		if !validCohorts[wlStampPilotCohort] {
-			return fmt.Errorf("pilot-cohort must be andela-pilot, commbank-pilot, or indie (got %q)", wlStampPilotCohort)
+		if !validCohorts[in.PilotCohort] {
+			return fmt.Errorf("pilot-cohort must be andela-pilot, commbank-pilot, or indie (got %q)", in.PilotCohort)
 		}
 	}
 
@@ -201,8 +221,8 @@ func validateStampInputs() error {
 		"completion": true, "endorsement": true, "boot_block": true,
 		"validation_received": true, "sandboxed_completion": true,
 	}
-	if !validContextTypes[wlStampContextType] {
-		return fmt.Errorf("context-type must be completion, endorsement, boot_block, validation_received, or sandboxed_completion (got %q)", wlStampContextType)
+	if !validContextTypes[in.ContextType] {
+		return fmt.Errorf("context-type must be completion, endorsement, boot_block, validation_received, or sandboxed_completion (got %q)", in.ContextType)
 	}
 
 	return nil

--- a/internal/cmd/wl_stamp_test.go
+++ b/internal/cmd/wl_stamp_test.go
@@ -9,46 +9,31 @@ import (
 
 func TestValidateStampInputs_Valid(t *testing.T) {
 	t.Parallel()
-	// Save and restore globals
-	origQ, origR, origC := wlStampQuality, wlStampReliability, wlStampCreativity
-	origSev, origType, origCtx := wlStampSeverity, wlStampType, wlStampContextType
-	origConf := wlStampConfidence
-	defer func() {
-		wlStampQuality, wlStampReliability, wlStampCreativity = origQ, origR, origC
-		wlStampSeverity, wlStampType, wlStampContextType = origSev, origType, origCtx
-		wlStampConfidence = origConf
-	}()
-
-	wlStampQuality = 4
-	wlStampReliability = 3
-	wlStampCreativity = 2
-	wlStampConfidence = 0.7
-	wlStampSeverity = "leaf"
-	wlStampType = "work"
-	wlStampContextType = "completion"
-
-	if err := validateStampInputs(); err != nil {
+	in := stampInputs{
+		Quality:     4,
+		Reliability: 3,
+		Creativity:  2,
+		Confidence:  0.7,
+		Severity:    "leaf",
+		Type:        "work",
+		ContextType: "completion",
+	}
+	if err := validateStampInputs(in); err != nil {
 		t.Errorf("validateStampInputs() = %v, want nil", err)
 	}
 }
 
 func TestValidateStampInputs_QualityOutOfRange(t *testing.T) {
 	t.Parallel()
-	origQ, origR, origC := wlStampQuality, wlStampReliability, wlStampCreativity
-	origSev, origType, origCtx := wlStampSeverity, wlStampType, wlStampContextType
-	defer func() {
-		wlStampQuality, wlStampReliability, wlStampCreativity = origQ, origR, origC
-		wlStampSeverity, wlStampType, wlStampContextType = origSev, origType, origCtx
-	}()
-
-	wlStampQuality = 6
-	wlStampReliability = -1
-	wlStampCreativity = -1
-	wlStampSeverity = "leaf"
-	wlStampType = "work"
-	wlStampContextType = "completion"
-
-	err := validateStampInputs()
+	in := stampInputs{
+		Quality:     6,
+		Reliability: -1,
+		Creativity:  -1,
+		Severity:    "leaf",
+		Type:        "work",
+		ContextType: "completion",
+	}
+	err := validateStampInputs(in)
 	if err == nil || !strings.Contains(err.Error(), "quality") {
 		t.Errorf("validateStampInputs() = %v, want quality error", err)
 	}
@@ -56,21 +41,15 @@ func TestValidateStampInputs_QualityOutOfRange(t *testing.T) {
 
 func TestValidateStampInputs_BadSeverity(t *testing.T) {
 	t.Parallel()
-	origQ, origR, origC := wlStampQuality, wlStampReliability, wlStampCreativity
-	origSev, origType, origCtx := wlStampSeverity, wlStampType, wlStampContextType
-	defer func() {
-		wlStampQuality, wlStampReliability, wlStampCreativity = origQ, origR, origC
-		wlStampSeverity, wlStampType, wlStampContextType = origSev, origType, origCtx
-	}()
-
-	wlStampQuality = 3
-	wlStampReliability = -1
-	wlStampCreativity = -1
-	wlStampSeverity = "invalid"
-	wlStampType = "work"
-	wlStampContextType = "completion"
-
-	err := validateStampInputs()
+	in := stampInputs{
+		Quality:     3,
+		Reliability: -1,
+		Creativity:  -1,
+		Severity:    "invalid",
+		Type:        "work",
+		ContextType: "completion",
+	}
+	err := validateStampInputs(in)
 	if err == nil || !strings.Contains(err.Error(), "severity") {
 		t.Errorf("validateStampInputs() = %v, want severity error", err)
 	}
@@ -78,21 +57,15 @@ func TestValidateStampInputs_BadSeverity(t *testing.T) {
 
 func TestValidateStampInputs_BadStampType(t *testing.T) {
 	t.Parallel()
-	origQ, origR, origC := wlStampQuality, wlStampReliability, wlStampCreativity
-	origSev, origType, origCtx := wlStampSeverity, wlStampType, wlStampContextType
-	defer func() {
-		wlStampQuality, wlStampReliability, wlStampCreativity = origQ, origR, origC
-		wlStampSeverity, wlStampType, wlStampContextType = origSev, origType, origCtx
-	}()
-
-	wlStampQuality = 3
-	wlStampReliability = -1
-	wlStampCreativity = -1
-	wlStampSeverity = "leaf"
-	wlStampType = "invalid"
-	wlStampContextType = "completion"
-
-	err := validateStampInputs()
+	in := stampInputs{
+		Quality:     3,
+		Reliability: -1,
+		Creativity:  -1,
+		Severity:    "leaf",
+		Type:        "invalid",
+		ContextType: "completion",
+	}
+	err := validateStampInputs(in)
 	if err == nil || !strings.Contains(err.Error(), "stamp-type") {
 		t.Errorf("validateStampInputs() = %v, want stamp-type error", err)
 	}


### PR DESCRIPTION
## Summary

Fixes #3122 — data race in `TestValidateStampInputs_*` tests that poisons unrelated tests under `-race`.

The four `TestValidateStampInputs_*` tests called `t.Parallel()` but concurrently read/wrote package-level globals (`wlStampQuality`, `wlStampSeverity`, etc.) via a save-and-restore pattern. Under `go test -race`, this caused collateral failures in `TestClassifySchemaChange`, `TestParseSchemaVersion_Valid`, and `TestParseSchemaVersion_Invalid`.

**Fix**: Extract a `stampInputs` struct and change `validateStampInputs` to accept it as a parameter instead of reading globals. The single production caller (`runWlStamp`) constructs the struct from cobra flag globals. Tests construct local values directly — no globals touched, `t.Parallel()` is safe.

**Files changed**:
- `internal/cmd/wl_stamp.go` — add `stampInputs` struct, refactor `validateStampInputs(in stampInputs)`, update caller
- `internal/cmd/wl_stamp_test.go` — remove save-and-restore boilerplate, pass `stampInputs` directly

## Test plan

- [x] `go test -race ./internal/cmd/ -run "TestValidateStampInputs|TestClassifySchemaChange|TestParseSchemaVersion"` — all pass, no race warnings
- [x] `go build ./internal/cmd/...` — clean
- [x] Linter clean

Made with [Cursor](https://cursor.com)