### PR TITLE
fix(security): sanitize --subject/--args before NudgePane injection (gt-sec-002)

### DIFF
--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -357,6 +357,25 @@ func storeFieldsInBead(beadID string, updates beadFieldUpdates) error {
 	return nil
 }
 
+// sanitizeNudgeField strips control characters and newlines from user-supplied
+// fields injected into tmux panes via NudgePane (gt-sec-002). Caps at maxLen
+// to prevent excessively long prompt injections.
+func sanitizeNudgeField(s string, maxLen int) string {
+	var b strings.Builder
+	for _, r := range s {
+		// Strip newlines, carriage returns, and control characters (U+0000–U+001F, U+007F)
+		if r == '\n' || r == '\r' || (r < 0x20) || r == 0x7F {
+			continue
+		}
+		b.WriteRune(r)
+	}
+	result := b.String()
+	if len(result) > maxLen {
+		result = result[:maxLen]
+	}
+	return result
+}
+
 // injectStartPrompt sends a prompt to the target pane to start working.
 // Uses the reliable nudge pattern: literal mode + 500ms debounce + separate Enter.
 func injectStartPrompt(pane, beadID, subject, args string) error {
@@ -368,6 +387,12 @@ func injectStartPrompt(pane, beadID, subject, args string) error {
 	if os.Getenv("GT_TEST_NO_NUDGE") != "" {
 		return nil
 	}
+
+	// gt-sec-002: sanitize user-controlled fields before injecting into NudgePane.
+	// Strip control chars/newlines and cap length to prevent prompt injection.
+	const nudgeFieldMaxLen = 200
+	subject = sanitizeNudgeField(subject, nudgeFieldMaxLen)
+	args = sanitizeNudgeField(args, nudgeFieldMaxLen)
 
 	// Build the prompt to inject
 	var prompt string

--- a/internal/cmd/sling_helpers_test.go
+++ b/internal/cmd/sling_helpers_test.go
@@ -236,3 +236,37 @@ func TestIsSlingConfigError(t *testing.T) {
 		})
 	}
 }
+
+// TestSanitizeNudgeField verifies gt-sec-002: user-controlled fields are stripped
+// of control characters and capped before injection into NudgePane.
+func TestSanitizeNudgeField(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		input  string
+		maxLen int
+		want   string
+	}{
+		{"plain text unchanged", "hello world", 200, "hello world"},
+		{"newline stripped", "hello\nworld", 200, "helloworld"},
+		{"CR stripped", "hello\rworld", 200, "helloworld"},
+		{"CRLF stripped", "hello\r\nworld", 200, "helloworld"},
+		{"null byte stripped", "hello\x00world", 200, "helloworld"},
+		{"tab stripped", "hello\tworld", 200, "helloworld"},
+		{"ESC stripped", "hello\x1bworld", 200, "helloworld"},
+		{"DEL stripped", "hello\x7fworld", 200, "helloworld"},
+		{"multi control stripped", "\x01\x02\x03abc\x04\x05", 200, "abc"},
+		{"capped at maxLen", "abcde", 3, "abc"},
+		{"empty string", "", 200, ""},
+		{"injection attempt newline", "legit\nGT_ROLE=mayor gt session start", 200, "legitGT_ROLE=mayor gt session start"},
+		{"injection attempt null", "legit\x00evil", 200, "legitevil"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := sanitizeNudgeField(tt.input, tt.maxLen)
+			if got != tt.want {
+				t.Errorf("sanitizeNudgeField(%q, %d) = %q, want %q", tt.input, tt.maxLen, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

- **gt-sec-002**: `injectStartPrompt` (sling_helpers.go:362) passed `--subject` and `--args` CLI flags verbatim into `NudgePane`, creating a tmux pane injection surface
- Adds `sanitizeNudgeField()`: strips control characters (newlines, CR, null bytes, ESC, U+0000–U+001F, U+007F) and caps at 200 chars
- Applied to both `subject` and `args` in `injectStartPrompt()` before `NudgePane` call
- 13 test cases covering: plain text, individual control chars, CRLF, capping, injection attempts

**Why sanitization (not beadID substitution like gt-sec-001):**
`args` are intentionally user instructions — they must pass through. beadID substitution doesn't apply. Control-char strip + length cap is the correct mitigation for this class of surface.

## Test plan

- [x] `go build ./...` — clean
- [x] `TestSanitizeNudgeField` — 13/13 PASS
- [x] `TestNudgeRefinerySessionName` — PASS
- [x] No regressions in sling_helpers tests

Closes gt-psxhi. Co-signed by dutch (predator) on request.

🤖 Generated with [Claude Code](https://claude.com/claude-code)