### PR TITLE
fix(sling): serialize concurrent hook writes with per-assignee flock (#3114)

### DIFF
--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -899,9 +899,19 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 
 	// Hook the bead with retry and verification.
 	// See: https://github.com/steveyegge/gastown/issues/148
+	//
+	// Acquire a per-assignee lock before writing hook_bead to serialize concurrent slings
+	// targeting the same polecat. Without this, multiple concurrent slings race on the
+	// same assignee's row in Dolt, causing silent rollbacks (issue #3114).
+	assigneeUnlock, assigneeLockErr := tryAcquireSlingAssigneeLock(townRoot, targetAgent)
+	if assigneeLockErr != nil {
+		return fmt.Errorf("serializing hook write for %s: %w", targetAgent, assigneeLockErr)
+	}
 	hookDir := beads.ResolveHookDir(townRoot, beadID, hookWorkDir)
-	if err := hookBeadWithRetry(beadID, targetAgent, hookDir); err != nil {
-		return err
+	hookErr := hookBeadWithRetry(beadID, targetAgent, hookDir)
+	assigneeUnlock()
+	if hookErr != nil {
+		return hookErr
 	}
 
 	// Emit a propulsion signal if the target is the mayor.
@@ -1086,6 +1096,27 @@ func tryAcquireSlingBeadLock(townRoot, beadID string) (func(), error) {
 	}
 	if !locked {
 		return nil, fmt.Errorf("bead %s is already being slung; retry after the current assignment completes", beadID)
+	}
+
+	return release, nil
+}
+
+// tryAcquireSlingAssigneeLock acquires a per-assignee file lock to serialize concurrent
+// hook writes to the same polecat. The per-bead lock (tryAcquireSlingBeadLock) prevents
+// double-sling of the same bead, but does not prevent concurrent slings from racing on
+// the same assignee's hook_bead field. This lock is held only during hookBeadWithRetry.
+// See: https://github.com/steveyegge/gastown/issues/3114
+func tryAcquireSlingAssigneeLock(townRoot, targetAgent string) (func(), error) {
+	lockDir := filepath.Join(townRoot, ".runtime", "locks", "sling")
+	if err := os.MkdirAll(lockDir, 0755); err != nil {
+		return nil, fmt.Errorf("creating sling lock dir: %w", err)
+	}
+
+	safeAgent := strings.NewReplacer("/", "_", ":", "_").Replace(targetAgent)
+	lockPath := filepath.Join(lockDir, "assignee_"+safeAgent+".flock")
+	release, err := lock.FlockAcquire(lockPath)
+	if err != nil {
+		return nil, fmt.Errorf("acquiring assignee sling lock for %s: %w", targetAgent, err)
 	}
 
 	return release, nil


### PR DESCRIPTION
## Summary

Fixes the TOCTOU race condition causing silent hook loss under concurrent batch sling (#3114).

**Root cause**: Multiple concurrent `gt sling` calls targeting the same polecat all raced to write `hook_bead` to Dolt simultaneously. Dolt's optimistic concurrency silently rolled back conflicting writes — polecats ended up with empty hooks even though each sling reported success.

**What was missing**: The per-bead flock (`tryAcquireSlingBeadLock`) serializes slings of the *same bead* but does not prevent multiple distinct beads from racing to write the *same assignee's* hook_bead field.

**Fix**: Add `tryAcquireSlingAssigneeLock()` — a per-assignee blocking flock (`assignee_<safe-agent>.flock`) in `.runtime/locks/sling/`. Acquired immediately before `hookBeadWithRetry`, released immediately after. This serializes hook writes per polecat without blocking unrelated sling operations.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./internal/cmd/...` — clean  
- [x] Sling dispatch/lock tests — PASS
- [x] No new lock contention for different-assignee slings (distinct lock files per assignee)

Closes #3114.

🤖 Generated with [Claude Code](https://claude.com/claude-code)