### PR TITLE
feat: .no-sync marker to skip databases during sync

### DIFF
--- a/internal/doltserver/sync.go
+++ b/internal/doltserver/sync.go
@@ -247,6 +247,13 @@ func SyncDatabases(townRoot string, opts SyncOptions) []SyncResult {
 		dbDir := RigDatabaseDir(townRoot, db)
 		result := SyncResult{Database: db}
 
+		// Skip databases with a .no-sync marker file (local-only databases).
+		if _, err := os.Stat(filepath.Join(dbDir, ".no-sync")); err == nil {
+			result.Skipped = true
+			results = append(results, result)
+			continue
+		}
+
 		// Check for remote (any name — "origin", "github", etc.)
 		remoteName, remoteURL, err := FindRemote(dbDir)
 		if err != nil {
@@ -330,6 +337,14 @@ func SyncDatabasesSQL(townRoot string, opts SyncOptions) []SyncResult {
 
 		result := SyncResult{Database: db}
 
+		// Skip databases with a .no-sync marker file (local-only databases).
+		dbDir := RigDatabaseDir(townRoot, db)
+		if _, err := os.Stat(filepath.Join(dbDir, ".no-sync")); err == nil {
+			result.Skipped = true
+			results = append(results, result)
+			continue
+		}
+
 		// Check for remote via SQL
 		remoteName, remoteURL, err := FindRemoteSQL(townRoot, db)
 		if err != nil {
@@ -341,7 +356,6 @@ func SyncDatabasesSQL(townRoot string, opts SyncOptions) []SyncResult {
 
 		if remoteURL == "" {
 			// Try auto-setup if credentials are available
-			dbDir := RigDatabaseDir(townRoot, db)
 			token := DoltHubToken()
 			org := DoltHubOrg()
 			if token != "" && org != "" {


### PR DESCRIPTION
## Summary
- Databases with a `.no-sync` file in their data directory are skipped by `SyncDatabases` and `SyncDatabasesSQL`
- Prevents auto-provisioning from creating DoltHub repos for local-only databases
- Use case: rigs whose beads databases should never leave the machine (personal/experimental projects)

## Details
When `DOLTHUB_TOKEN` and `DOLTHUB_ORG` are set, `gt dolt sync` auto-creates DoltHub repos for any database without a remote. This is great for production rigs but unwanted for local-only databases. A `.no-sync` marker file in the database directory (`~/.dolt-data/<db>/.no-sync`) opts out of sync entirely.

## Test plan
- [x] Existing sync tests pass
- [ ] Create a database, add `.no-sync`, verify `gt dolt sync` skips it
- [ ] Verify databases without `.no-sync` still sync normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)