### PR TITLE
docs: add GitHub Copilot CLI as supported agent provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # Gas Town
 
-**Multi-agent orchestration system for Claude Code with persistent work tracking**
+**Multi-agent orchestration system for Claude Code, GitHub Copilot, and other AI agents with persistent work tracking**
 
 ## Overview
 
-Gas Town is a workspace manager that lets you coordinate multiple Claude Code agents working on different tasks. Instead of losing context when agents restart, Gas Town persists work state in git-backed hooks, enabling reliable multi-agent workflows.
+Gas Town is a workspace manager that lets you coordinate multiple AI coding agents (Claude Code, GitHub Copilot, Codex, Gemini, and others) working on different tasks. Instead of losing context when agents restart, Gas Town persists work state in git-backed hooks, enabling reliable multi-agent workflows.
 
 ### What Problem Does This Solve?
 
@@ -93,6 +93,7 @@ Git-backed issue tracking system that stores work state as structured data.
 - **tmux 3.0+** - recommended for full experience
 - **Claude Code CLI** (default runtime) - [claude.ai/code](https://claude.ai/code)
 - **Codex CLI** (optional runtime) - [developers.openai.com/codex/cli](https://developers.openai.com/codex/cli)
+- **GitHub Copilot CLI** (optional runtime) - [cli.github.com](https://cli.github.com) (requires Copilot seat)
 
 ### Setup (Docker-Compose below)
 
@@ -339,6 +340,11 @@ Gas Town supports multiple AI coding runtimes. Per-rig runtime settings are in `
 - For runtimes without hooks (e.g., Codex), Gas Town sends a startup fallback
   after the session is ready: `gt prime`, optional `gt mail check --inject`
   for autonomous roles, and `gt nudge deacon session-started`.
+- **GitHub Copilot** (`copilot`) is a built-in preset using `--yolo` for autonomous
+  mode. It uses executable lifecycle hooks in `.github/hooks/gastown.json` (same events
+  as Claude: `sessionStart`, `userPromptSubmitted`, `preToolUse`, `sessionEnd`). Uses a
+  5-second ready delay instead of prompt detection. Requires a Copilot seat and org-level
+  CLI policy. See [docs/INSTALLING.md](docs/INSTALLING.md).
 
 ## Key Commands
 

--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -1,8 +1,23 @@
 # Gas Town Hooks Management
 
-Centralized Claude Code hook management for Gas Town workspaces.
+Centralized hook management for Gas Town workspaces.
 
 ## Overview
+
+Gas Town manages context injection for all supported agents. The mechanism varies by agent:
+
+| Agent | Hook mechanism | Managed file |
+|-------|---------------|-------------|
+| Claude Code, Gemini | `settings.json` lifecycle hooks | `<role>/.claude/settings.json` |
+| OpenCode | JS plugin | `workDir/.opencode/gastown.js` |
+| GitHub Copilot | JSON lifecycle hooks | `workDir/.github/hooks/gastown.json` |
+| Codex, others | Startup nudge fallback | *(no file — nudge only)* |
+
+> **GitHub Copilot note**: Copilot CLI supports full executable lifecycle hooks
+> (`sessionStart`, `userPromptSubmitted`, `preToolUse`, `sessionEnd`) via
+> `.github/hooks/gastown.json`. This is the same lifecycle coverage as Claude Code,
+> delivered in Copilot's JSON format rather than Claude's `settings.json` format.
+> The `gt hooks` commands below apply to Claude Code (and Gemini) only.
 
 Gas Town manages `.claude/settings.json` files in gastown-managed parent directories
 and passes them to Claude Code via the `--settings` flag. This keeps customer repos

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -21,6 +21,7 @@ Complete setup guide for Gas Town multi-agent orchestrator.
 | **Claude Code** (default) | latest | `claude --version` | See [claude.ai/claude-code](https://claude.ai/claude-code) |
 | **Codex CLI** (optional) | latest | `codex --version` | See [developers.openai.com/codex/cli](https://developers.openai.com/codex/cli) |
 | **OpenCode CLI** (optional) | latest | `opencode --version` | See [opencode.ai](https://opencode.ai) |
+| **GitHub Copilot CLI** (optional) | latest | `copilot --version` | See [cli.github.com](https://cli.github.com) (requires Copilot seat) |
 
 ## Installing Prerequisites
 
@@ -145,7 +146,7 @@ gt status              # Show workspace status
 
 ### Step 5: Configure Agents (Optional)
 
-Gas Town supports built-in runtimes (`claude`, `gemini`, `codex`) plus custom agent aliases.
+Gas Town supports built-in runtimes (`claude`, `gemini`, `codex`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`) plus custom agent aliases.
 
 ```bash
 # List available agents

--- a/docs/agent-provider-integration.md
+++ b/docs/agent-provider-integration.md
@@ -166,9 +166,51 @@ Every field from the `AgentPresetInfo` struct in `internal/config/agents.go`:
 }
 ```
 
-### Activating the preset
+### Built-in preset: GitHub Copilot CLI
 
-Once the JSON file exists, configure a rig (or the whole town) to use it:
+`copilot` ships as a built-in preset — no JSON file needed. It uses the `--yolo` flag for
+autonomous mode and flag-style session resume. Copilot CLI supports full executable lifecycle
+hooks via `.github/hooks/gastown.json`:
+
+```json
+{
+  "name": "copilot",
+  "command": "copilot",
+  "args": ["--yolo"],
+  "process_names": ["copilot"],
+  "resume_flag": "--resume",
+  "resume_style": "flag",
+  "ready_delay_ms": 5000,
+  "hooks_provider": "copilot",
+  "hooks_dir": ".github/hooks",
+  "hooks_settings_file": "gastown.json",
+  "instructions_file": "AGENTS.md"
+}
+```
+
+Gas Town provisions `.github/hooks/gastown.json` in the agent's working directory with the
+standard lifecycle hooks (`sessionStart`, `userPromptSubmitted`, `preToolUse`, `sessionEnd`).
+This is the same hook events as Claude Code, just in Copilot's JSON format.
+
+> **Note on readiness detection**: Copilot CLI doesn't emit a detectable prompt prefix, so
+> Gas Town uses a 5-second delay instead of prompt-based detection. Sessions take slightly
+> longer to become ready than Claude.
+
+> **Enterprise requirement**: Copilot CLI must be enabled at two levels before use:
+> 1. Enterprise → Settings → AI controls → Copilot → **"Copilot in the CLI" = Enabled**
+> 2. Org → Settings → Copilot → Policies → **"Copilot in the CLI" = Enabled**
+>
+> Users also need a Copilot seat assigned. See [GitHub Copilot in the CLI](https://docs.github.com/en/copilot/using-github-copilot/using-github-copilot-in-the-command-line).
+
+To activate:
+```bash
+gt config default-agent copilot        # Set as town default
+gt start --agent copilot               # Or pass per-command
+```
+
+### Activating a custom preset
+
+Once a JSON file exists, configure a rig (or the whole town) to use it:
 
 ```json
 // In ~/gt/<rig>/settings/config.json
@@ -347,7 +389,7 @@ delivery mechanism adapts to the agent's plugin API.
 If your agent doesn't support executable hooks but reads an instructions/context
 file, Gas Town can install a markdown file with startup instructions.
 
-Reference: `internal/copilot/plugin/gastown-instructions.md`
+Reference: `internal/hooks/templates/copilot/copilot-instructions.md`
 
 ```markdown
 # Gas Town Agent Context
@@ -365,6 +407,10 @@ This loads your full role context, mail, and pending work.
 
 Set `hooks_informational: true` in the preset. Gas Town will then send
 `gt prime` via tmux nudge as a fallback (since hooks won't run automatically).
+
+> **Note**: GitHub Copilot CLI previously used Pattern C, but now supports full
+> executable lifecycle hooks (Pattern B equivalent, using its own JSON format).
+> See the built-in Copilot preset section above for current configuration.
 
 ### How Gas Town chooses the fallback strategy
 

--- a/docs/design/otel/otel-architecture.md
+++ b/docs/design/otel/otel-architecture.md
@@ -410,7 +410,7 @@ run.id:uuid-1234
 | `GT_POLECAT` | `Toast`, `Shadow`, `Furiosa` | Polecat name (rig-specific) |
 | `GT_CREW` | `max`, `jane` | Crew member name |
 | `GT_SESSION` | `gt-gastown-Toast`, `hq-mayor` | Tmux session name |
-| `GT_AGENT` | `claudecode`, `codex` | Agent override (if specified) |
+| `GT_AGENT` | `claudecode`, `codex`, `copilot` | Agent override (if specified) |
 | `GT_RUN` | UUID v4 | **PR #2199** — Run identifier, primary waterfall correlation key |
 | `GT_ROOT` | `/Users/pa/gt` | Town root path |
 | `CLAUDE_CONFIG_DIR` | `~/gt/.claude` | Runtime config directory (for agent overrides) |

--- a/docs/otel-data-model.md
+++ b/docs/otel-data-model.md
@@ -29,7 +29,7 @@ session carry the same `run.id`.
 | `run.id` | string (UUID v4) | generated at spawn; propagated via `GT_RUN` |
 | `instance` | string | `hostname:basename(town_root)` |
 | `town_root` | string | absolute town root path |
-| `agent_type` | string | `"claudecode"`, `"opencode"`, … |
+| `agent_type` | string | `"claudecode"`, `"opencode"`, `"copilot"`, … |
 | `role` | string | `polecat` · `witness` · `mayor` · `refinery` · `crew` · `deacon` · `dog` · `boot` |
 | `agent_name` | string | specific name within the role (e.g. `"wyvern-Toast"`); equals role for singletons |
 | `session_id` | string | tmux pane name |
@@ -48,7 +48,7 @@ Emitted once per agent spawn. Anchors all subsequent events for that run.
 | `run.id` | string | run UUID |
 | `instance` | string | `hostname:basename(town_root)` |
 | `town_root` | string | absolute town root path |
-| `agent_type` | string | `"claudecode"` · `"opencode"` · … |
+| `agent_type` | string | `"claudecode"` · `"opencode"` · `"copilot"` · … |
 | `role` | string | Gastown role |
 | `agent_name` | string | agent name |
 | `session_id` | string | tmux pane name |

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -456,7 +456,13 @@ gt config agent remove <name>     # Remove custom agent (built-ins protected)
 gt config default-agent [name]    # Get or set town default agent
 ```
 
-**Built-in agents**: `claude`, `gemini`, `codex`, `cursor`, `auggie`, `amp`
+**Built-in agents**: `claude`, `gemini`, `codex`, `cursor`, `auggie`, `amp`, `opencode`, `copilot`
+
+> **Note on GitHub Copilot**: The `copilot` preset uses executable lifecycle hooks in
+> `.github/hooks/gastown.json` (`sessionStart`, `userPromptSubmitted`, `preToolUse`,
+> `sessionEnd`) — the same lifecycle events as Claude Code, in Copilot's JSON format.
+> Copilot uses a 5-second ready delay instead of prompt-based detection. Requires a
+> Copilot seat and org-level CLI policy enabled.
 
 **Custom agents**: Define per-town via CLI or JSON:
 ```bash


### PR DESCRIPTION
## Summary
Documents the copilot built-in adapter added in PR #1500 and subsequently upgraded to executable hooks in PR #2408.

Users may be unaware of gastown’s support of copilot and what’s needed to support copilot.

Changes:
- README.md: update tagline/overview to be multi-agent, add Copilot to prerequisites and runtime config section
- docs/INSTALLING.md: add GitHub Copilot CLI to optional tools table; expand built-in runtimes list to all 8 adapters
- docs/reference.md: add 'opencode' and 'copilot' to built-in agents list; note Copilot's hooks format and 5s ready delay
- docs/HOOKS.md: generalize from Claude-only to multi-agent; add agent-to-hook-mechanism table showing Copilot uses executable JSON hooks at .github/hooks/gastown.json
- docs/agent-provider-integration.md: add Copilot built-in preset example in Tier 1 (JSON config, enterprise requirements, activation commands); fix Pattern C reference path and note Copilot's upgrade to executable hooks
- docs/otel-data-model.md: add 'copilot' to agent_type example values
- docs/design/otel/otel-architecture.md: add 'copilot' to GT_AGENT example values

## Related Issue
Related to #1158 

## Testing
Doc changes only

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)
