### PR TITLE
fix: suppress unparam lint errors breaking CI on main

### DIFF
--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -517,7 +517,7 @@ func stopAllPolecats(t *tmux.Tmux, townRoot string, rigNames []string, force boo
 
 // stopAllCrew stops all crew member sessions across all rigs.
 // Returns the number of crew sessions stopped (or would be stopped in dry-run).
-func stopAllCrew(t *tmux.Tmux, townRoot string, rigNames []string, force bool, dryRun bool) int {
+func stopAllCrew(t *tmux.Tmux, townRoot string, rigNames []string, _ bool, dryRun bool) int {
 	stopped := 0
 
 	rigsConfigPath := filepath.Join(townRoot, "mayor", "rigs.json")

--- a/internal/cmd/wl_scorekeeper.go
+++ b/internal/cmd/wl_scorekeeper.go
@@ -57,7 +57,7 @@ func runWlScorekeeper(cmd *cobra.Command, args []string) error {
 	return runScorekeeperWithStore(store, townRoot)
 }
 
-func runScorekeeperWithStore(store doltserver.WLCommonsStore, townRoot string) error {
+func runScorekeeperWithStore(store doltserver.WLCommonsStore, _ string) error {
 	if !wlScorekeeperJSON {
 		fmt.Printf("%s Running scorekeeper...\n", style.Bold.Render("⚡"))
 	}


### PR DESCRIPTION
## Summary

- Prefixes two unused function parameters with `_` to fix `unparam` lint errors that are breaking the Lint CI job on `main` (and therefore blocking all PRs).
- `stopAllCrew` in `down.go`: `force` param exists for signature parity with `stopAllPolecats` but isn't used in the crew shutdown path.
- `runScorekeeperWithStore` in `wl_scorekeeper.go`: `townRoot` is already captured inside the `store` before being passed separately.

Fixes #3135

## Test plan

- [ ] `go build ./internal/cmd/...` passes
- [ ] CI Lint job passes (currently failing on every PR)

Made with [Cursor](https://cursor.com)