### PR TITLE
fix: re-apply atomic counter in generateStampID for Windows CI

### DIFF
--- a/internal/cmd/wl_stamp.go
+++ b/internal/cmd/wl_stamp.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -227,9 +228,15 @@ func buildSkillTagsJSON(skills []string) string {
 	return "[" + strings.Join(quoted, ",") + "]"
 }
 
+// stampCounter provides a monotonically-incrementing component for generateStampID.
+// On Windows, time.Now() has ~100ns–15ms resolution, making back-to-back calls
+// return identical timestamps and therefore identical IDs (GH#3104).
+var stampCounter atomic.Uint64
+
 func generateStampID(author, subject, valence, contextID string) string {
 	now := time.Now().UTC().Format(time.RFC3339Nano)
-	input := fmt.Sprintf("%s|%s|%s|%s|%s", author, subject, valence, contextID, now)
+	seq := stampCounter.Add(1)
+	input := fmt.Sprintf("%s|%s|%s|%s|%s|%d", author, subject, valence, contextID, now, seq)
 	hash := sha256.Sum256([]byte(input))
 	return fmt.Sprintf("s-%s", hex.EncodeToString(hash[:])[:12])
 }


### PR DESCRIPTION
## Summary

- Re-applies the atomic counter fix from `c74602ba` (#3104) that was removed as collateral in the `927c935e` session revert.
- On Windows, `time.Now()` has ~100ns–15ms resolution, so back-to-back `generateStampID` calls produce identical timestamps and therefore identical stamp IDs.
- Adds a package-level `atomic.Uint64` counter included in the SHA-256 input, guaranteeing uniqueness regardless of platform timer resolution.

Fixes #3137

## Test plan

- [x] `TestGenerateStampID_Unique` passes 10/10 runs locally
- [x] Windows CI `TestGenerateStampID_Unique` passes

Made with [Cursor](https://cursor.com)