### PR TITLE
fix(test): refactor outputRoleDirectives to accept io.Writer, eliminating data race (GH#3140)

### DIFF
--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -408,7 +408,7 @@ func outputRoleContext(ctx RoleContext) (string, error) {
 		return "", err
 	}
 
-	outputRoleDirectives(ctx)
+	outputRoleDirectives(ctx, os.Stdout, primeExplain)
 	outputContextFile(ctx)
 	outputHandoffContent(ctx)
 	outputAttachmentStatus(ctx)

--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -4,6 +4,7 @@ import (
 	"github.com/steveyegge/gastown/internal/cli"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -96,7 +97,11 @@ func outputPrimeContext(ctx RoleContext) (string, error) {
 // outputRoleDirectives loads and emits operator-provided role directives.
 // These come from the directive file layout (town-level and/or rig-level)
 // and override formula defaults where they conflict.
-func outputRoleDirectives(ctx RoleContext) {
+//
+// w and explainEnabled are injected so tests can capture output without
+// mutating os.Stdout or the primeExplain global (avoiding data races
+// under t.Parallel).
+func outputRoleDirectives(ctx RoleContext, w io.Writer, explainEnabled bool) {
 	role := string(ctx.Role)
 	townRoot := ctx.TownRoot
 	rigName := ctx.Rig
@@ -107,11 +112,17 @@ func outputRoleDirectives(ctx RoleContext) {
 		rigPath = filepath.Join(townRoot, rigName, "directives", role+".md")
 	}
 
+	explainf := func(format string, args ...any) {
+		if explainEnabled {
+			fmt.Fprintf(w, "\n[EXPLAIN] "+format+"\n", args...)
+		}
+	}
+
 	content := config.LoadRoleDirective(role, townRoot, rigName)
 	if content == "" {
-		explain(true, fmt.Sprintf("Role directives: no directive files found (checked %s", townPath))
+		explainf("Role directives: no directive files found (checked %s", townPath)
 		if rigPath != "" {
-			explain(true, fmt.Sprintf("Role directives: also checked %s", rigPath))
+			explainf("Role directives: also checked %s", rigPath)
 		}
 		return
 	}
@@ -132,18 +143,18 @@ func outputRoleDirectives(ctx RoleContext) {
 		}
 	}
 
-	explain(true, fmt.Sprintf("Role directives: town=%v rig=%v (town=%s, rig=%s)", hasTown, hasRig, townPath, rigPath))
+	explainf("Role directives: town=%v rig=%v (town=%s, rig=%s)", hasTown, hasRig, townPath, rigPath)
 
-	fmt.Println()
+	fmt.Fprintln(w)
 	if hasTown && hasRig {
-		fmt.Println("## Town & Rig Directives (operator policy — overrides formula where they conflict)")
+		fmt.Fprintln(w, "## Town & Rig Directives (operator policy — overrides formula where they conflict)")
 	} else if hasRig {
-		fmt.Println("## Rig Directives (operator policy — overrides formula where they conflict)")
+		fmt.Fprintln(w, "## Rig Directives (operator policy — overrides formula where they conflict)")
 	} else {
-		fmt.Println("## Town Directives (operator policy — overrides formula where they conflict)")
+		fmt.Fprintln(w, "## Town Directives (operator policy — overrides formula where they conflict)")
 	}
-	fmt.Println()
-	fmt.Println(content)
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, content)
 }
 
 func outputPrimeContextFallback(ctx RoleContext) {

--- a/internal/cmd/prime_output_test.go
+++ b/internal/cmd/prime_output_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -19,9 +20,9 @@ func TestOutputRoleDirectives(t *testing.T) {
 			Rig:      "myrig",
 		}
 
-		out := captureStdout(t, func() {
-			outputRoleDirectives(ctx)
-		})
+		var buf bytes.Buffer
+		outputRoleDirectives(ctx, &buf, false)
+		out := buf.String()
 
 		if strings.Contains(out, "Directives") {
 			t.Errorf("expected no header when no directives, got: %s", out)
@@ -45,9 +46,9 @@ func TestOutputRoleDirectives(t *testing.T) {
 			Rig:      "myrig",
 		}
 
-		out := captureStdout(t, func() {
-			outputRoleDirectives(ctx)
-		})
+		var buf bytes.Buffer
+		outputRoleDirectives(ctx, &buf, false)
+		out := buf.String()
 
 		if !strings.Contains(out, "## Town Directives") {
 			t.Errorf("expected Town Directives header, got: %s", out)
@@ -74,9 +75,9 @@ func TestOutputRoleDirectives(t *testing.T) {
 			Rig:      "myrig",
 		}
 
-		out := captureStdout(t, func() {
-			outputRoleDirectives(ctx)
-		})
+		var buf bytes.Buffer
+		outputRoleDirectives(ctx, &buf, false)
+		out := buf.String()
 
 		if !strings.Contains(out, "## Rig Directives") {
 			t.Errorf("expected Rig Directives header, got: %s", out)
@@ -112,9 +113,9 @@ func TestOutputRoleDirectives(t *testing.T) {
 			Rig:      "myrig",
 		}
 
-		out := captureStdout(t, func() {
-			outputRoleDirectives(ctx)
-		})
+		var buf bytes.Buffer
+		outputRoleDirectives(ctx, &buf, false)
+		out := buf.String()
 
 		if !strings.Contains(out, "## Town & Rig Directives") {
 			t.Errorf("expected combined header, got: %s", out)
@@ -131,24 +132,20 @@ func TestOutputRoleDirectives(t *testing.T) {
 		t.Parallel()
 		townRoot := t.TempDir()
 
-		oldExplain := primeExplain
-		primeExplain = true
-		defer func() { primeExplain = oldExplain }()
-
 		ctx := RoleContext{
 			Role:     RolePolecat,
 			TownRoot: townRoot,
 			Rig:      "myrig",
 		}
 
-		out := captureStdout(t, func() {
-			outputRoleDirectives(ctx)
-		})
+		var buf bytes.Buffer
+		outputRoleDirectives(ctx, &buf, true)
+		out := buf.String()
 
 		if !strings.Contains(out, "[EXPLAIN]") {
 			t.Errorf("expected EXPLAIN output, got: %s", out)
 		}
-		if !strings.Contains(out, "directives/polecat.md") {
+		if !strings.Contains(out, filepath.Join("directives", "polecat.md")) {
 			t.Errorf("expected file path in explain output, got: %s", out)
 		}
 	})
@@ -171,9 +168,9 @@ func TestOutputRoleDirectives(t *testing.T) {
 			Rig:      "",
 		}
 
-		out := captureStdout(t, func() {
-			outputRoleDirectives(ctx)
-		})
+		var buf bytes.Buffer
+		outputRoleDirectives(ctx, &buf, false)
+		out := buf.String()
 
 		if !strings.Contains(out, "## Town Directives") {
 			t.Errorf("expected Town Directives header, got: %s", out)


### PR DESCRIPTION
## Summary

Fixes #3140 — data race in `captureStdout` causes `TestOutputRoleDirectives` and other `internal/cmd` tests to fail under `-race`.

### Root cause (two races)

1. **`os.Stdout` race**: `captureStdout()` swaps `os.Stdout = w` / `os.Stdout = oldStdout`. With `t.Parallel()` subtests in `TestOutputRoleDirectives`, multiple goroutines race on the global — one writes the pipe while another reads via `fmt.Println`.
2. **`primeExplain` race**: The "explain mode shows file paths" subtest mutates the `primeExplain` global under `t.Parallel()`, racing with any concurrent `explain()` reader.

### Fix

Refactor `outputRoleDirectives` to accept an `io.Writer` and `explainEnabled bool` as parameters instead of writing to `os.Stdout` and reading the `primeExplain` global:

- **`prime_output.go`**: Change signature to `outputRoleDirectives(ctx RoleContext, w io.Writer, explainEnabled bool)`. Replace `fmt.Println` with `fmt.Fprintln(w, ...)`. Replace `explain()` calls with a local `explainf` closure that writes to `w`.
- **`prime.go`**: Update the single production caller to pass `os.Stdout, primeExplain`.
- **`prime_output_test.go`**: All 6 subtests now pass a `bytes.Buffer` directly — no `captureStdout`, no `primeExplain` mutation. `t.Parallel()` is retained and safe.

### Context

The prior quick fix for a similar race (PR #3123: remove `t.Parallel()` from `TestValidateStampInputs`) was merged then bulk-reverted in `927c935`. I had also opened PR #3124 with the structural refactor approach (parameter injection via a `stampInputs` struct) but closed it in favor of #3123.

This PR applies that same structural pattern — dependency injection over global mutation — to the `outputRoleDirectives` race. It's the more robust fix: tests stay parallel, the function is more testable, and no globals are touched.

## Test plan

- [x] `go build ./internal/cmd/...` — compiles clean
- [x] `go test -race -count=1 ./internal/cmd/ -run "TestOutputRoleDirectives|TestClassifySchemaChange|TestValidateConvoyStatusTransition"` — all pass, zero race warnings
- [x] Linter clean

Made with [Cursor](https://cursor.com)