### PR TITLE
feat: allow disabling individual patrol dogs via disabled_patrols config (gas-ykx)

### DIFF
--- a/docs/examples/town-settings.example.json
+++ b/docs/examples/town-settings.example.json
@@ -96,5 +96,7 @@
         "done_dedupe_window": "10s",
         "sling_aggregate_window": "30s",
         "min_aggregate_count": 3
-    }
+    },
+
+    "disabled_patrols": ["doctor_dog", "compactor_dog"]
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -102,6 +102,16 @@ type TownSettings struct {
 	// These were previously hardcoded as Go constants throughout the codebase.
 	// All values are optional — omitted values use compiled-in defaults.
 	Operational *OperationalConfig `json:"operational,omitempty"`
+
+	// DisabledPatrols lists patrol names to disable at the town level.
+	// This provides a simple way to turn off individual daemon patrol dogs
+	// without editing mayor/daemon.json. Patrol names match the keys used
+	// in daemon.json patrols section (e.g., "deacon", "witness", "refinery",
+	// "doctor_dog", "compactor_dog", "checkpoint_dog", "wisp_reaper",
+	// "dolt_remotes", "dolt_backup", "jsonl_git_backup", "scheduled_maintenance",
+	// "main_branch_test", "handler").
+	// Example: ["doctor_dog", "compactor_dog"]
+	DisabledPatrols []string `json:"disabled_patrols,omitempty"`
 }
 
 // NewTownSettings creates a new TownSettings with defaults.

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -542,6 +542,47 @@ func TestFeedCuratorConfig_OmitemptyZeroCount(t *testing.T) {
 	}
 }
 
+func TestTownSettings_DisabledPatrols_RoundTrip(t *testing.T) {
+	t.Parallel()
+	tmpDir := t.TempDir()
+	settingsPath := filepath.Join(tmpDir, "config.json")
+
+	original := NewTownSettings()
+	original.DisabledPatrols = []string{"doctor_dog", "compactor_dog", "witness"}
+
+	if err := SaveTownSettings(settingsPath, original); err != nil {
+		t.Fatalf("SaveTownSettings: %v", err)
+	}
+
+	loaded, err := LoadOrCreateTownSettings(settingsPath)
+	if err != nil {
+		t.Fatalf("LoadOrCreateTownSettings: %v", err)
+	}
+
+	if len(loaded.DisabledPatrols) != 3 {
+		t.Fatalf("expected 3 disabled patrols, got %d", len(loaded.DisabledPatrols))
+	}
+
+	expected := map[string]bool{"doctor_dog": true, "compactor_dog": true, "witness": true}
+	for _, p := range loaded.DisabledPatrols {
+		if !expected[p] {
+			t.Errorf("unexpected disabled patrol: %q", p)
+		}
+	}
+}
+
+func TestTownSettings_DisabledPatrols_OmitemptyWhenNil(t *testing.T) {
+	t.Parallel()
+	ts := NewTownSettings()
+	data, err := json.MarshalIndent(ts, "", "  ")
+	if err != nil {
+		t.Fatalf("Marshal: %v", err)
+	}
+	if strings.Contains(string(data), "disabled_patrols") {
+		t.Error("JSON should not contain disabled_patrols when nil")
+	}
+}
+
 // --- Edge cases for config values ---
 
 func TestParseDurationOrDefault_AllWebTimeoutDefaults(t *testing.T) {

--- a/internal/daemon/checkpoint_dog.go
+++ b/internal/daemon/checkpoint_dog.go
@@ -54,7 +54,7 @@ var runtimeExcludeDirs = []string{
 // compactor_dog's SQL operations). The daemon pours a molecule for
 // observability, then runs git commands via exec.Command.
 func (d *Daemon) runCheckpointDog() {
-	if !IsPatrolEnabled(d.patrolConfig, "checkpoint_dog") {
+	if !d.isPatrolActive("checkpoint_dog") {
 		return
 	}
 

--- a/internal/daemon/compactor_dog.go
+++ b/internal/daemon/compactor_dog.go
@@ -117,7 +117,7 @@ func compactorDogKeepRecent(config *DaemonPatrolConfig) int {
 // (4) concurrent write retry with error classification, (5) row count integrity
 // verification. See mol-dog-compactor.formula.toml for full rationale.
 func (d *Daemon) runCompactorDog() {
-	if !IsPatrolEnabled(d.patrolConfig, "compactor_dog") {
+	if !d.isPatrolActive("compactor_dog") {
 		return
 	}
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -56,6 +56,11 @@ type Daemon struct {
 	doltServer *DoltServerManager
 	krcPruner  *KRCPruner
 
+	// disabledPatrols is loaded from town settings (disabled_patrols field).
+	// Provides a simple way to disable individual patrol dogs without editing
+	// mayor/daemon.json. Checked by isPatrolActive alongside patrolConfig.
+	disabledPatrols map[string]bool
+
 	// Mass death detection: track recent session deaths
 	deathsMu     sync.Mutex
 	recentDeaths []sessionDeath
@@ -175,6 +180,17 @@ func New(config *Config) (*Daemon, error) {
 		}
 	}
 
+	// Load disabled_patrols from town settings (settings/config.json).
+	// This provides a simpler way to disable patrols than editing daemon.json.
+	disabledPatrols := loadDisabledPatrolsFromTownSettings(config.TownRoot)
+	if len(disabledPatrols) > 0 {
+		names := make([]string, 0, len(disabledPatrols))
+		for k := range disabledPatrols {
+			names = append(names, k)
+		}
+		logger.Printf("Patrols disabled via town settings: %v", names)
+	}
+
 	// Initialize Dolt server manager if configured
 	var doltServer *DoltServerManager
 	if patrolConfig != nil && patrolConfig.Patrols != nil && patrolConfig.Patrols.DoltServer != nil {
@@ -267,18 +283,19 @@ func New(config *Config) (*Daemon, error) {
 	}
 
 	return &Daemon{
-		config:         config,
-		patrolConfig:   patrolConfig,
-		tmux:           tmux.NewTmux(),
-		logger:         logger,
-		ctx:            ctx,
-		cancel:         cancel,
-		doltServer:     doltServer,
-		gtPath:         gtPath,
-		bdPath:         bdPath,
-		restartTracker: restartTracker,
-		otelProvider:   otelProvider,
-		metrics:        dm,
+		config:          config,
+		patrolConfig:    patrolConfig,
+		disabledPatrols: disabledPatrols,
+		tmux:            tmux.NewTmux(),
+		logger:          logger,
+		ctx:             ctx,
+		cancel:          cancel,
+		doltServer:      doltServer,
+		gtPath:          gtPath,
+		bdPath:          bdPath,
+		restartTracker:  restartTracker,
+		otelProvider:    otelProvider,
+		metrics:         dm,
 	}, nil
 }
 
@@ -412,7 +429,7 @@ func (d *Daemon) Run() error {
 	// to periodically push databases to their git remotes.
 	var doltRemotesTicker *time.Ticker
 	var doltRemotesChan <-chan time.Time
-	if IsPatrolEnabled(d.patrolConfig, "dolt_remotes") {
+	if d.isPatrolActive("dolt_remotes") {
 		interval := doltRemotesInterval(d.patrolConfig)
 		doltRemotesTicker = time.NewTicker(interval)
 		doltRemotesChan = doltRemotesTicker.C
@@ -424,7 +441,7 @@ func (d *Daemon) Run() error {
 	// Runs filesystem backup sync (dolt backup sync) for production databases.
 	var doltBackupTicker *time.Ticker
 	var doltBackupChan <-chan time.Time
-	if IsPatrolEnabled(d.patrolConfig, "dolt_backup") {
+	if d.isPatrolActive("dolt_backup") {
 		interval := doltBackupInterval(d.patrolConfig)
 		doltBackupTicker = time.NewTicker(interval)
 		doltBackupChan = doltBackupTicker.C
@@ -436,7 +453,7 @@ func (d *Daemon) Run() error {
 	// Exports issues to JSONL, scrubs ephemeral data, pushes to git repo.
 	var jsonlGitBackupTicker *time.Ticker
 	var jsonlGitBackupChan <-chan time.Time
-	if IsPatrolEnabled(d.patrolConfig, "jsonl_git_backup") {
+	if d.isPatrolActive("jsonl_git_backup") {
 		interval := jsonlGitBackupInterval(d.patrolConfig)
 		jsonlGitBackupTicker = time.NewTicker(interval)
 		jsonlGitBackupChan = jsonlGitBackupTicker.C
@@ -448,7 +465,7 @@ func (d *Daemon) Run() error {
 	// Closes stale wisps (abandoned molecule steps, old patrol data) across all databases.
 	var wispReaperTicker *time.Ticker
 	var wispReaperChan <-chan time.Time
-	if IsPatrolEnabled(d.patrolConfig, "wisp_reaper") {
+	if d.isPatrolActive("wisp_reaper") {
 		interval := wispReaperInterval(d.patrolConfig)
 		wispReaperTicker = time.NewTicker(interval)
 		wispReaperChan = wispReaperTicker.C
@@ -460,7 +477,7 @@ func (d *Daemon) Run() error {
 	// Health monitor: TCP check, latency, DB count, gc, zombie detection, backup/disk checks.
 	var doctorDogTicker *time.Ticker
 	var doctorDogChan <-chan time.Time
-	if IsPatrolEnabled(d.patrolConfig, "doctor_dog") {
+	if d.isPatrolActive("doctor_dog") {
 		interval := doctorDogInterval(d.patrolConfig)
 		doctorDogTicker = time.NewTicker(interval)
 		doctorDogChan = doctorDogTicker.C
@@ -472,7 +489,7 @@ func (d *Daemon) Run() error {
 	// Flattens Dolt commit history to reclaim graph storage (daily).
 	var compactorDogTicker *time.Ticker
 	var compactorDogChan <-chan time.Time
-	if IsPatrolEnabled(d.patrolConfig, "compactor_dog") {
+	if d.isPatrolActive("compactor_dog") {
 		interval := compactorDogInterval(d.patrolConfig)
 		compactorDogTicker = time.NewTicker(interval)
 		compactorDogChan = compactorDogTicker.C
@@ -484,7 +501,7 @@ func (d *Daemon) Run() error {
 	// Auto-commits WIP changes in active polecat worktrees to prevent data loss.
 	var checkpointDogTicker *time.Ticker
 	var checkpointDogChan <-chan time.Time
-	if IsPatrolEnabled(d.patrolConfig, "checkpoint_dog") {
+	if d.isPatrolActive("checkpoint_dog") {
 		interval := checkpointDogInterval(d.patrolConfig)
 		checkpointDogTicker = time.NewTicker(interval)
 		checkpointDogChan = checkpointDogTicker.C
@@ -497,7 +514,7 @@ func (d *Daemon) Run() error {
 	// runs `gt maintain --force` when commit counts exceed threshold.
 	var scheduledMaintenanceTicker *time.Ticker
 	var scheduledMaintenanceChan <-chan time.Time
-	if IsPatrolEnabled(d.patrolConfig, "scheduled_maintenance") {
+	if d.isPatrolActive("scheduled_maintenance") {
 		interval := maintenanceCheckInterval(d.patrolConfig)
 		scheduledMaintenanceTicker = time.NewTicker(interval)
 		scheduledMaintenanceChan = scheduledMaintenanceTicker.C
@@ -510,7 +527,7 @@ func (d *Daemon) Run() error {
 	// Periodically runs quality gates on each rig's main branch to catch regressions.
 	var mainBranchTestTicker *time.Ticker
 	var mainBranchTestChan <-chan time.Time
-	if IsPatrolEnabled(d.patrolConfig, "main_branch_test") {
+	if d.isPatrolActive("main_branch_test") {
 		interval := mainBranchTestInterval(d.patrolConfig)
 		mainBranchTestTicker = time.NewTicker(interval)
 		mainBranchTestChan = mainBranchTestTicker.C
@@ -671,7 +688,7 @@ func (d *Daemon) heartbeat(state *State) {
 
 	// 1. Ensure Deacon is running (restart if dead)
 	// Check patrol config - can be disabled in mayor/daemon.json
-	if IsPatrolEnabled(d.patrolConfig, "deacon") {
+	if d.isPatrolActive("deacon") {
 		d.ensureDeaconRunning()
 	} else {
 		d.logger.Printf("Deacon patrol disabled in config, skipping")
@@ -684,20 +701,20 @@ func (d *Daemon) heartbeat(state *State) {
 	// 2. Poke Boot for intelligent triage (stuck/nudge/interrupt)
 	// Boot handles nuanced "is Deacon responsive" decisions
 	// Only run if Deacon patrol is enabled
-	if IsPatrolEnabled(d.patrolConfig, "deacon") {
+	if d.isPatrolActive("deacon") {
 		d.ensureBootRunning()
 	}
 
 	// 3. Direct Deacon heartbeat check (belt-and-suspenders)
 	// Boot may not detect all stuck states; this provides a fallback
 	// Only run if Deacon patrol is enabled
-	if IsPatrolEnabled(d.patrolConfig, "deacon") {
+	if d.isPatrolActive("deacon") {
 		d.checkDeaconHeartbeat()
 	}
 
 	// 4. Ensure Witnesses are running for all rigs (restart if dead)
 	// Check patrol config - can be disabled in mayor/daemon.json
-	if IsPatrolEnabled(d.patrolConfig, "witness") {
+	if d.isPatrolActive("witness") {
 		d.ensureWitnessesRunning()
 	} else {
 		d.logger.Printf("Witness patrol disabled in config, skipping")
@@ -708,7 +725,7 @@ func (d *Daemon) heartbeat(state *State) {
 	// 5. Ensure Refineries are running for all rigs (restart if dead)
 	// Check patrol config - can be disabled in mayor/daemon.json
 	// Pressure-gated: refineries consume API credits, defer when system is loaded.
-	if IsPatrolEnabled(d.patrolConfig, "refinery") {
+	if d.isPatrolActive("refinery") {
 		if p := d.checkPressure("refinery"); !p.OK {
 			d.logger.Printf("Deferring refinery spawn: %s", p.Reason)
 		} else {
@@ -725,7 +742,7 @@ func (d *Daemon) heartbeat(state *State) {
 
 	// 6.5. Handle Dog lifecycle: cleanup stuck dogs and dispatch plugins
 	// Pressure-gated: dog dispatch spawns new agent sessions.
-	if IsPatrolEnabled(d.patrolConfig, "handler") {
+	if d.isPatrolActive("handler") {
 		if p := d.checkPressure("dog"); !p.OK {
 			d.logger.Printf("Deferring dog dispatch: %s", p.Reason)
 			// Still run cleanup phases (stuck/stale/idle) — only skip dispatch

--- a/internal/daemon/doctor_dog.go
+++ b/internal/daemon/doctor_dog.go
@@ -94,7 +94,7 @@ func doctorDogDatabases(config *DaemonPatrolConfig) []string {
 // execute the formula steps (probe, inspect, report). This follows ZFC:
 // daemons schedule, agents decide and act.
 func (d *Daemon) runDoctorDog() {
-	if !IsPatrolEnabled(d.patrolConfig, "doctor_dog") {
+	if !d.isPatrolActive("doctor_dog") {
 		return
 	}
 

--- a/internal/daemon/dolt_backup.go
+++ b/internal/daemon/dolt_backup.go
@@ -38,7 +38,7 @@ func (d *Daemon) syncDoltBackups() {
 	if runtime.GOOS != "darwin" {
 		return
 	}
-	if !IsPatrolEnabled(d.patrolConfig, "dolt_backup") {
+	if !d.isPatrolActive("dolt_backup") {
 		return
 	}
 

--- a/internal/daemon/dolt_remotes.go
+++ b/internal/daemon/dolt_remotes.go
@@ -29,7 +29,7 @@ func doltRemotesInterval(config *DaemonPatrolConfig) time.Duration {
 // pushDoltRemotes commits and pushes each configured database to its remote.
 // Non-fatal: errors are logged but don't stop the patrol.
 func (d *Daemon) pushDoltRemotes() {
-	if !IsPatrolEnabled(d.patrolConfig, "dolt_remotes") {
+	if !d.isPatrolActive("dolt_remotes") {
 		return
 	}
 

--- a/internal/daemon/jsonl_git_backup.go
+++ b/internal/daemon/jsonl_git_backup.go
@@ -78,7 +78,7 @@ func jsonlGitBackupInterval(config *DaemonPatrolConfig) time.Duration {
 // and commits/pushes to a git repository.
 // Non-fatal: errors are logged but don't stop the daemon.
 func (d *Daemon) syncJsonlGitBackup() {
-	if !IsPatrolEnabled(d.patrolConfig, "jsonl_git_backup") {
+	if !d.isPatrolActive("jsonl_git_backup") {
 		return
 	}
 

--- a/internal/daemon/main_branch_test_runner.go
+++ b/internal/daemon/main_branch_test_runner.go
@@ -136,7 +136,7 @@ func loadRigGateConfig(rigPath string) (*rigGateConfig, error) {
 // runMainBranchTests runs quality gates on each rig's main branch.
 // It fetches the latest main, runs configured gates/tests, and escalates failures.
 func (d *Daemon) runMainBranchTests() {
-	if !IsPatrolEnabled(d.patrolConfig, "main_branch_test") {
+	if !d.isPatrolActive("main_branch_test") {
 		return
 	}
 

--- a/internal/daemon/patrol_config_test.go
+++ b/internal/daemon/patrol_config_test.go
@@ -122,6 +122,97 @@ func TestSaveAndLoadPatrolConfig(t *testing.T) {
 	}
 }
 
+func TestLoadDisabledPatrolsFromTownSettings(t *testing.T) {
+	// No settings file: returns nil
+	tmpDir := t.TempDir()
+	got := loadDisabledPatrolsFromTownSettings(tmpDir)
+	if got != nil {
+		t.Errorf("expected nil for missing settings, got %v", got)
+	}
+
+	// Empty disabled_patrols: returns nil
+	settingsDir := filepath.Join(tmpDir, "settings")
+	if err := os.MkdirAll(settingsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(settingsDir, "config.json"), []byte(`{
+		"type": "town-settings", "version": 1
+	}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got = loadDisabledPatrolsFromTownSettings(tmpDir)
+	if got != nil {
+		t.Errorf("expected nil for empty disabled_patrols, got %v", got)
+	}
+
+	// With disabled patrols
+	if err := os.WriteFile(filepath.Join(settingsDir, "config.json"), []byte(`{
+		"type": "town-settings", "version": 1,
+		"disabled_patrols": ["doctor_dog", "compactor_dog"]
+	}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	got = loadDisabledPatrolsFromTownSettings(tmpDir)
+	if len(got) != 2 {
+		t.Fatalf("expected 2 disabled patrols, got %d", len(got))
+	}
+	if !got["doctor_dog"] {
+		t.Error("expected doctor_dog to be disabled")
+	}
+	if !got["compactor_dog"] {
+		t.Error("expected compactor_dog to be disabled")
+	}
+	if got["witness"] {
+		t.Error("expected witness to NOT be disabled")
+	}
+}
+
+func TestIsPatrolActive(t *testing.T) {
+	// Patrol enabled in daemon config, not in disabled list → active
+	d := &Daemon{
+		patrolConfig:    nil, // nil config = all default-enabled patrols enabled
+		disabledPatrols: nil,
+	}
+	if !d.isPatrolActive("witness") {
+		t.Error("expected witness to be active with nil configs")
+	}
+
+	// Patrol enabled in daemon config, but in disabled list → inactive
+	d.disabledPatrols = map[string]bool{"witness": true}
+	if d.isPatrolActive("witness") {
+		t.Error("expected witness to be inactive when in disabled list")
+	}
+
+	// Patrol disabled in daemon config, not in disabled list → inactive
+	d.disabledPatrols = nil
+	d.patrolConfig = &DaemonPatrolConfig{
+		Patrols: &PatrolsConfig{
+			Witness: &PatrolConfig{Enabled: false},
+		},
+	}
+	if d.isPatrolActive("witness") {
+		t.Error("expected witness to be inactive when disabled in daemon config")
+	}
+
+	// Opt-in patrol (doctor_dog) disabled by default, in disabled list → inactive
+	d.patrolConfig = nil
+	d.disabledPatrols = map[string]bool{"doctor_dog": true}
+	if d.isPatrolActive("doctor_dog") {
+		t.Error("expected doctor_dog to be inactive")
+	}
+
+	// Opt-in patrol enabled in daemon config but in disabled list → disabled wins
+	d.patrolConfig = &DaemonPatrolConfig{
+		Patrols: &PatrolsConfig{
+			DoctorDog: &DoctorDogConfig{Enabled: true},
+		},
+	}
+	d.disabledPatrols = map[string]bool{"doctor_dog": true}
+	if d.isPatrolActive("doctor_dog") {
+		t.Error("expected doctor_dog to be inactive when in disabled list, even if enabled in daemon config")
+	}
+}
+
 func TestDoltRemotesInterval(t *testing.T) {
 	// Default interval
 	if got := doltRemotesInterval(nil); got != defaultDoltRemotesInterval {

--- a/internal/daemon/scheduled_maintenance.go
+++ b/internal/daemon/scheduled_maintenance.go
@@ -143,7 +143,7 @@ func shouldRunMaintenance(now time.Time, lastRun time.Time, interval string) boo
 // runScheduledMaintenance checks if we're in the maintenance window and
 // if any database exceeds the commit threshold, runs `gt maintain --force`.
 func (d *Daemon) runScheduledMaintenance() {
-	if !IsPatrolEnabled(d.patrolConfig, "scheduled_maintenance") {
+	if !d.isPatrolActive("scheduled_maintenance") {
 		return
 	}
 

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -346,6 +346,38 @@ func GetPatrolRigs(config *DaemonPatrolConfig, patrol string) []string {
 	return nil // All rigs
 }
 
+// loadDisabledPatrolsFromTownSettings loads the disabled_patrols list from
+// town settings (settings/config.json) as a set for O(1) lookup.
+func loadDisabledPatrolsFromTownSettings(townRoot string) map[string]bool {
+	settingsPath := filepath.Join(townRoot, "settings", "config.json")
+	data, err := os.ReadFile(settingsPath) //nolint:gosec // G304: path constructed internally
+	if err != nil {
+		return nil
+	}
+	var raw struct {
+		DisabledPatrols []string `json:"disabled_patrols"`
+	}
+	if err := json.Unmarshal(data, &raw); err != nil || len(raw.DisabledPatrols) == 0 {
+		return nil
+	}
+	disabled := make(map[string]bool, len(raw.DisabledPatrols))
+	for _, p := range raw.DisabledPatrols {
+		disabled[p] = true
+	}
+	return disabled
+}
+
+// isPatrolActive checks whether a patrol should run, combining the
+// daemon patrol config (mayor/daemon.json) with the town-level
+// disabled_patrols list (settings/config.json). A patrol is active
+// only if it is enabled in daemon config AND not in the disabled list.
+func (d *Daemon) isPatrolActive(patrol string) bool {
+	if d.disabledPatrols[patrol] {
+		return false
+	}
+	return IsPatrolEnabled(d.patrolConfig, patrol)
+}
+
 // LifecycleAction represents a lifecycle request action.
 type LifecycleAction string
 

--- a/internal/daemon/wisp_reaper.go
+++ b/internal/daemon/wisp_reaper.go
@@ -77,7 +77,7 @@ func wispDeleteAge(config *DaemonPatrolConfig) time.Duration {
 // The Dog reads the formula steps and calls `gt reaper` CLI helpers.
 // Falls back to inline execution if Dog dispatch fails.
 func (d *Daemon) reapWisps() {
-	if !IsPatrolEnabled(d.patrolConfig, "wisp_reaper") {
+	if !d.isPatrolActive("wisp_reaper") {
 		return
 	}
 


### PR DESCRIPTION
## Summary
- Adds `disabled_patrols` field to town settings config
- Allows selectively disabling individual deacon patrol dogs (e.g. `dolt-backup`) without stopping the whole deacon
- Prevents escalation spam from patrols that don't apply to the current environment

## Test plan
- [ ] Verify disabled patrol is skipped during deacon cycle
- [ ] Verify non-disabled patrols still run normally
- [ ] Verify config is read without daemon restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>