### PR TITLE
fix: workspace.Find returns outermost workspace for nested workspaces (gas-axx)

### DIFF
--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -187,28 +187,28 @@ func (r *Router) expandAnnounce(announceName string) (*config.AnnounceConfig, er
 
 // detectTownRoot finds the town root directory.
 //
-// Prefers the GT_TOWN_ROOT environment variable when set (always set by the
-// Gas Town session manager to the actual outer town root). This prevents
-// nested-workspace misdetection where workspace.Find stops at a rig-level
-// mayor/town.json instead of continuing to the outer town root.
+// Uses workspace.Find which correctly handles nested workspaces by always
+// searching to the filesystem root and returning the outermost workspace.
+// Falls back to GT_TOWN_ROOT/GT_ROOT env vars when workspace.Find cannot
+// locate a workspace (e.g., running from outside any workspace).
 func detectTownRoot(startDir string) string {
-	// Prefer GT_TOWN_ROOT when set by the session manager.
-	// workspace.Find stops at the first primary marker when !inWorktree,
-	// so running from a rig directory (which has its own mayor/town.json)
-	// would return the rig instead of the actual town root.
+	// workspace.Find handles nested workspaces correctly: it always searches
+	// to the filesystem root and returns the outermost mayor/town.json match.
+	townRoot, err := workspace.Find(startDir)
+	if err == nil && townRoot != "" {
+		return townRoot
+	}
+
+	// Fallback: try GT_TOWN_ROOT or GT_ROOT env vars when workspace detection
+	// fails (e.g., running from outside any workspace directory).
 	for _, envName := range []string{"GT_TOWN_ROOT", "GT_ROOT"} {
-		if townRoot := os.Getenv(envName); townRoot != "" {
-			if ok, _ := workspace.IsWorkspace(townRoot); ok {
-				return townRoot
+		if envRoot := os.Getenv(envName); envRoot != "" {
+			if ok, _ := workspace.IsWorkspace(envRoot); ok {
+				return envRoot
 			}
 		}
 	}
-	// Fallback to workspace detection for environments without env vars
-	townRoot, err := workspace.Find(startDir)
-	if err != nil {
-		return ""
-	}
-	return townRoot
+	return ""
 }
 
 // resolveBeadsDir returns the correct .beads directory for mail delivery.

--- a/internal/workspace/find.go
+++ b/internal/workspace/find.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 
 	"github.com/steveyegge/gastown/internal/config"
 )
@@ -28,7 +27,8 @@ const (
 
 // Find locates the town root by walking up from the given directory.
 // It prefers mayor/town.json over mayor/ directory as workspace marker.
-// When in a worktree path (polecats/ or crew/), continues to outermost workspace.
+// Always continues to the outermost workspace, correctly handling nested
+// workspace structures (e.g., rig directories with their own mayor/town.json).
 // Does not resolve symlinks to stay consistent with os.Getwd().
 func Find(startDir string) (string, error) {
 	absDir, err := filepath.Abs(startDir)
@@ -36,22 +36,18 @@ func Find(startDir string) (string, error) {
 		return "", fmt.Errorf("resolving path: %w", err)
 	}
 
-	inWorktree := isInWorktreePath(absDir)
 	var primaryMatch, secondaryMatch string
 
 	current := absDir
 	for {
+		// Always keep updating primaryMatch and secondaryMatch to find the outermost
+		// directory with the respective markers. This handles nested workspace
+		// structures where inner workspaces (e.g., rig directories or worktrees)
+		// have their own mayor/town.json, ensuring we return the actual town root.
 		if _, err := os.Stat(filepath.Join(current, PrimaryMarker)); err == nil {
-			if !inWorktree {
-				return current, nil
-			}
 			primaryMatch = current
 		}
 
-		// Always keep updating secondaryMatch to find the outermost mayor/ directory.
-		// This handles nested structures where rigs have their own mayor/ directories
-		// but only the town root should be detected as the workspace.
-		// The primary marker (mayor/town.json) is authoritative and returns early above.
 		if info, err := os.Stat(filepath.Join(current, SecondaryMarker)); err == nil && info.IsDir() {
 			secondaryMatch = current
 		}
@@ -65,11 +61,6 @@ func Find(startDir string) (string, error) {
 		}
 		current = parent
 	}
-}
-
-func isInWorktreePath(path string) bool {
-	sep := string(filepath.Separator)
-	return strings.Contains(path, sep+"polecats"+sep) || strings.Contains(path, sep+"crew"+sep)
 }
 
 // FindOrError is like Find but returns a user-friendly error if not found.


### PR DESCRIPTION
## Summary
- Fixes workspace.Find to always return the outermost workspace when nested workspaces exist
- Prevents mail router breakage in nested workspace scenarios

## Test plan
- [ ] Verify mail routing works correctly in nested workspace setups
- [ ] Verify non-nested workspaces are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>