### PR TITLE
fix: apply --settings flag for Claude agents launched with --agent override

### DIFF
--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1428,6 +1428,13 @@ func withRoleSettingsFlag(rc *RuntimeConfig, role, rigPath string) *RuntimeConfi
 		return rc
 	}
 
+	// Guard against double-adding (ResolveRoleAgentConfig already calls this)
+	for _, arg := range rc.Args {
+		if arg == "--settings" {
+			return rc
+		}
+	}
+
 	settingsDir := RoleSettingsDir(role, rigPath)
 	if settingsDir == "" {
 		return rc
@@ -2311,6 +2318,13 @@ func BuildStartupCommandWithAgentOverride(envVars map[string]string, rigPath, pr
 			}
 		}
 	}
+
+	// Ensure Claude agents get --settings when their settings directory
+	// differs from the session working directory. This must run for ALL
+	// resolution paths (including agent overrides) — previously only the
+	// non-override ResolveRoleAgentConfig path included it, causing hooks
+	// to silently not fire for polecats launched with --agent.
+	rc = withRoleSettingsFlag(rc, role, rigPath)
 
 	// Apply exec wrapper from rig/town settings if not already set on the resolved config.
 	if len(rc.ExecWrapper) == 0 {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -5429,3 +5429,160 @@ func TestBuildStartupCommandWithAgentOverride_ExecWrapper(t *testing.T) {
 		t.Errorf("expected wrapper immediately before claude command, got: %q", cmd)
 	}
 }
+
+// --- Tests for GH#3153: --agent override skips --settings flag ---
+
+func TestWithRoleSettingsFlag_IdempotencyGuard(t *testing.T) {
+	t.Parallel()
+	rigPath := "/fake/town/myrig"
+	rc := &RuntimeConfig{
+		Command: "claude",
+		Args:    []string{"--dangerously-skip-permissions", "--settings", "/already/set/.claude/settings.json"},
+	}
+
+	before := len(rc.Args)
+	result := withRoleSettingsFlag(rc, "polecat", rigPath)
+
+	if len(result.Args) != before {
+		t.Errorf("idempotency guard failed: expected %d args, got %d — Args = %v", before, len(result.Args), result.Args)
+	}
+	count := 0
+	for _, arg := range result.Args {
+		if arg == "--settings" {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("expected exactly 1 --settings flag, got %d — Args = %v", count, result.Args)
+	}
+}
+
+func TestBuildStartupCommandWithAgentOverride_SettingsFlagForClaudeOverride(t *testing.T) {
+	t.Parallel()
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "testrig")
+
+	townSettings := NewTownSettings()
+	townSettings.Agents["claude-sonnet"] = &RuntimeConfig{
+		Command: "claude",
+		Args:    []string{"--model", "sonnet", "--dangerously-skip-permissions"},
+	}
+	if err := SaveTownSettings(TownSettingsPath(townRoot), townSettings); err != nil {
+		t.Fatalf("SaveTownSettings: %v", err)
+	}
+	if err := SaveRigSettings(RigSettingsPath(rigPath), NewRigSettings()); err != nil {
+		t.Fatalf("SaveRigSettings: %v", err)
+	}
+
+	cmd, err := BuildStartupCommandWithAgentOverride(
+		map[string]string{"GT_ROLE": "testrig/polecats/toast"},
+		rigPath,
+		"",
+		"claude-sonnet",
+	)
+	if err != nil {
+		t.Fatalf("BuildStartupCommandWithAgentOverride: %v", err)
+	}
+
+	if !strings.Contains(cmd, "--settings") {
+		t.Errorf("Claude override on polecat role should include --settings, got: %q", cmd)
+	}
+	expectedPath := filepath.Join(rigPath, "polecats", ".claude", "settings.json")
+	if !strings.Contains(cmd, expectedPath) {
+		t.Errorf("expected settings path %q in command, got: %q", expectedPath, cmd)
+	}
+}
+
+func TestBuildPolecatStartupCommandWithAgentOverride_IncludesSettingsFlag(t *testing.T) {
+	t.Parallel()
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "testrig")
+
+	townSettings := NewTownSettings()
+	townSettings.Agents["claude-sonnet"] = &RuntimeConfig{
+		Command: "claude",
+		Args:    []string{"--model", "sonnet", "--dangerously-skip-permissions"},
+	}
+	if err := SaveTownSettings(TownSettingsPath(townRoot), townSettings); err != nil {
+		t.Fatalf("SaveTownSettings: %v", err)
+	}
+	if err := SaveRigSettings(RigSettingsPath(rigPath), NewRigSettings()); err != nil {
+		t.Fatalf("SaveRigSettings: %v", err)
+	}
+
+	cmd, err := BuildPolecatStartupCommandWithAgentOverride("testrig", "toast", rigPath, "", "claude-sonnet")
+	if err != nil {
+		t.Fatalf("BuildPolecatStartupCommandWithAgentOverride: %v", err)
+	}
+
+	if !strings.Contains(cmd, "--settings") {
+		t.Errorf("polecat with Claude override must get --settings for hooks to fire, got: %q", cmd)
+	}
+	expectedPath := filepath.Join(rigPath, "polecats", ".claude", "settings.json")
+	if !strings.Contains(cmd, expectedPath) {
+		t.Errorf("expected settings path %q in command, got: %q", expectedPath, cmd)
+	}
+}
+
+func TestBuildStartupCommandWithAgentOverride_NoSettingsFlagForNonClaude(t *testing.T) {
+	t.Parallel()
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "testrig")
+
+	townSettings := NewTownSettings()
+	if err := SaveTownSettings(TownSettingsPath(townRoot), townSettings); err != nil {
+		t.Fatalf("SaveTownSettings: %v", err)
+	}
+	if err := SaveRigSettings(RigSettingsPath(rigPath), NewRigSettings()); err != nil {
+		t.Fatalf("SaveRigSettings: %v", err)
+	}
+
+	cmd, err := BuildStartupCommandWithAgentOverride(
+		map[string]string{"GT_ROLE": "testrig/polecats/toast"},
+		rigPath,
+		"",
+		"gemini",
+	)
+	if err != nil {
+		t.Fatalf("BuildStartupCommandWithAgentOverride: %v", err)
+	}
+
+	if strings.Contains(cmd, "--settings") {
+		t.Errorf("non-Claude override (gemini) should NOT get --settings, got: %q", cmd)
+	}
+}
+
+func TestBuildStartupCommandWithAgentOverride_NoDoubleSettingsOnNonOverridePath(t *testing.T) {
+	t.Parallel()
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "testrig")
+
+	townSettings := NewTownSettings()
+	if err := SaveTownSettings(TownSettingsPath(townRoot), townSettings); err != nil {
+		t.Fatalf("SaveTownSettings: %v", err)
+	}
+	if err := SaveRigSettings(RigSettingsPath(rigPath), NewRigSettings()); err != nil {
+		t.Fatalf("SaveRigSettings: %v", err)
+	}
+
+	// No override — ResolveRoleAgentConfig already adds --settings for polecat role.
+	// The new withRoleSettingsFlag call in BuildStartupCommandWithAgentOverride should
+	// be a no-op (idempotency guard), not double-add.
+	cmd, err := BuildStartupCommandWithAgentOverride(
+		map[string]string{"GT_ROLE": "testrig/polecats/toast"},
+		rigPath,
+		"",
+		"", // no override
+	)
+	if err != nil {
+		t.Fatalf("BuildStartupCommandWithAgentOverride: %v", err)
+	}
+
+	count := strings.Count(cmd, "--settings")
+	if count > 1 {
+		t.Errorf("expected at most 1 --settings flag (idempotency guard), got %d — cmd: %q", count, cmd)
+	}
+	if count == 0 {
+		t.Errorf("default Claude agent on polecat role should still get --settings, got: %q", cmd)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #3153

- When `gt sling` uses `--agent` (e.g., `--agent claude-sonnet`), the polecat's Claude Code instance launched without `--settings`, so `SessionStart` hooks never fired and `gt prime --hook` context injection was silently skipped.
- Root cause: `BuildStartupCommandWithAgentOverride` resolves through `ResolveAgentConfigWithOverride`, which does not call `withRoleSettingsFlag`. The non-override path (`ResolveRoleAgentConfig`) does.
- Fix: call `withRoleSettingsFlag` in `BuildStartupCommandWithAgentOverride` after all resolution paths, with an idempotency guard to prevent double-adding when the non-override path already includes it.

## Changes

- **`internal/config/loader.go`**: Add idempotency guard to `withRoleSettingsFlag` (scan for existing `--settings` before appending); call `withRoleSettingsFlag` in `BuildStartupCommandWithAgentOverride` after agent resolution.
- **`internal/config/loader_test.go`**: 5 new tests covering idempotency, Claude override gets `--settings`, polecat override scenario (the actual bug), non-Claude override skipped, and no double-add regression on the non-override path.

## Test plan

- [x] `TestWithRoleSettingsFlag_IdempotencyGuard` — calling twice doesn't double-add `--settings`
- [x] `TestBuildStartupCommandWithAgentOverride_SettingsFlagForClaudeOverride` — Claude custom agent override produces correct `--settings` path
- [x] `TestBuildPolecatStartupCommandWithAgentOverride_IncludesSettingsFlag` — the actual bug scenario
- [x] `TestBuildStartupCommandWithAgentOverride_NoSettingsFlagForNonClaude` — non-Claude override correctly omitted
- [x] `TestBuildStartupCommandWithAgentOverride_NoDoubleSettingsOnNonOverridePath` — non-override path still gets exactly 1 `--settings`
- [x] Full `go test ./internal/config/` passes (including integration tests)
- [x] `go build ./...` and `go vet` clean


Made with [Cursor](https://cursor.com)