### PR TITLE
fix(convoy): use Unix epoch instead of zero time for initial event poll

### DIFF
--- a/internal/daemon/convoy_manager.go
+++ b/internal/daemon/convoy_manager.go
@@ -261,8 +261,12 @@ func (m *ConvoyManager) pollStoresSnapshot(stores map[string]beadsdk.Storage) bo
 // The seen set deduplicates issueIDs across stores within a poll cycle.
 // Returns an error if the poll failed (used by caller for backoff decisions).
 func (m *ConvoyManager) pollStore(name string, store beadsdk.Storage, stores map[string]beadsdk.Storage, seen map[string]bool) error {
-	// Load per-store high-water mark
-	var highWater time.Time
+	// Load per-store high-water mark.
+	// Default to Unix epoch (not zero time) because Go's zero time.Time
+	// (0001-01-01) causes Dolt's SQL driver to produce +Inf when converting
+	// to a float parameter, triggering "Error 1366: +Inf is not a valid
+	// value for double". Unix epoch is safe for all SQL backends.
+	highWater := time.Unix(0, 0).UTC()
 	if v, ok := m.lastEventIDs.Load(name); ok {
 		highWater = v.(time.Time)
 	}


### PR DESCRIPTION
## Summary

- Fixes recurring `Error 1366 (HY000): +Inf is not a valid value for double` in convoy event polling
- Root cause: when no previous high-water mark exists, `pollStore` passes Go's zero `time.Time` (0001-01-01) to `GetAllEventsSince`, which the Dolt SQL driver converts to `+Inf` as a float parameter
- Fix: initialize `highWater` to Unix epoch (1970-01-01 UTC) instead of zero time — safe for all SQL backends and semantically equivalent for event polling

## Test plan

- [ ] Start daemon with no previous convoy event state (fresh start)
- [ ] Verify no `+Inf` errors in daemon logs during initial event poll
- [ ] Verify convoy event polling works normally after fix
- [ ] Verify existing high-water marks (non-zero) continue to work

🤖 Generated with [Claude Code](https://claude.com/claude-code)