### PR TITLE
fix(beads): replace bd agent state with description update

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -416,18 +416,30 @@ func (b *Beads) ResetAgentBeadForReuse(id, reason string) error {
 }
 
 // UpdateAgentState updates the agent_state field in an agent bead.
-// Uses `bd agent state` command for the database column directly.
+// Uses description field update since bd 0.62 removed the `bd agent state` command
+// and the agent_state DB column (commit 0bd598ce). The read path in GetAgentBead
+// already falls back to parsing agent_state from the description text.
 func (b *Beads) UpdateAgentState(id string, state string) (retErr error) {
 	defer func() { telemetry.RecordAgentStateChange(context.Background(), id, state, nil, retErr) }()
-	// Update agent state using bd agent state command
-	// Use runWithRouting so bd can resolve cross-prefix agent beads (e.g., wa-*
-	// agent beads from hq context) via routes.jsonl instead of BEADS_DIR.
-	_, err := b.runWithRouting("agent", "state", id, state)
-	if err != nil {
-		return fmt.Errorf("updating agent state: %w", err)
+
+	// Resolve routing for cross-rig agent beads (e.g., wa-* from hq context).
+	targetDir := ResolveRoutingTarget(b.getTownRoot(), id, b.getResolvedBeadsDir())
+	target := b
+	if targetDir != b.getResolvedBeadsDir() {
+		target = NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
 	}
 
-	// Hook slot no longer maintained (hq-l6mm5) — removed hook_bead parameter.
+	issue, err := target.Show(id)
+	if err != nil {
+		return fmt.Errorf("updating agent state: show %s: %w", id, err)
+	}
+
+	fields := ParseAgentFields(issue.Description)
+	fields.AgentState = state
+	description := FormatAgentDescription(issue.Title, fields)
+	if err := target.Update(id, UpdateOptions{Description: &description}); err != nil {
+		return fmt.Errorf("updating agent state: %w", err)
+	}
 
 	return nil
 }
@@ -608,9 +620,9 @@ func (b *Beads) GetAgentBead(id string) (*Issue, *AgentFields, error) {
 	}
 
 	fields := ParseAgentFields(issue.Description)
-	// Prefer the structured agent_state column when present.
-	// Some writers (for example, `bd agent state`) update the DB column directly
-	// without rewriting the description text, so description-derived state can be stale.
+	// agent_state DB column was removed in bd 0.62 (commit 0bd598ce).
+	// State is now stored in the description text only.
+	// Keep column fallback for compat with older bd versions that may still populate it.
 	if issue.AgentState != "" {
 		fields.AgentState = issue.AgentState
 	}


### PR DESCRIPTION
## Summary
- `bd agent state` command was removed in bd v0.62 (commit 0bd598ce), breaking `UpdateAgentState` in gt
- Every polecat sling retried 8 times with exponential backoff (~1 min delay + noisy warnings)
- Fix: `UpdateAgentState` now does Show→Parse→Modify→Update on the description field, matching how other agent field updates already work
- Includes cross-rig routing support for agent beads in different databases

Fixes gas-5a7

## Test plan
- [x] `go build ./...` — compiles clean
- [x] `go test ./internal/beads/ -run Agent` — all agent tests pass
- [ ] `gt sling` a bead — verify no more `bd agent state` retry warnings

🤖 Generated with [Claude Code](https://claude.com/claude-code)