### PR TITLE
fix: patrol molecules use TownRoot instead of rig WorkDir

### DIFF
--- a/internal/cmd/patrol_new.go
+++ b/internal/cmd/patrol_new.go
@@ -60,14 +60,14 @@ func runPatrolNew(cmd *cobra.Command, args []string) error {
 		cfg = PatrolConfig{
 			RoleName:      "witness",
 			PatrolMolName: constants.MolWitnessPatrol,
-			BeadsDir:      roleInfo.WorkDir,
+			BeadsDir:      roleInfo.TownRoot,
 			Assignee:      roleInfo.Rig + "/witness",
 		}
 	case RoleRefinery:
 		cfg = PatrolConfig{
 			RoleName:      "refinery",
 			PatrolMolName: constants.MolRefineryPatrol,
-			BeadsDir:      roleInfo.WorkDir,
+			BeadsDir:      roleInfo.TownRoot,
 			Assignee:      roleInfo.Rig + "/refinery",
 			ExtraVars:     buildRefineryPatrolVars(roleInfo),
 		}

--- a/internal/cmd/patrol_report.go
+++ b/internal/cmd/patrol_report.go
@@ -66,14 +66,14 @@ func runPatrolReport(cmd *cobra.Command, args []string) error {
 		cfg = PatrolConfig{
 			RoleName:      "witness",
 			PatrolMolName: constants.MolWitnessPatrol,
-			BeadsDir:      roleInfo.WorkDir,
+			BeadsDir:      roleInfo.TownRoot,
 			Assignee:      roleInfo.Rig + "/witness",
 		}
 	case RoleRefinery:
 		cfg = PatrolConfig{
 			RoleName:      "refinery",
 			PatrolMolName: constants.MolRefineryPatrol,
-			BeadsDir:      roleInfo.WorkDir,
+			BeadsDir:      roleInfo.TownRoot,
 			Assignee:      roleInfo.Rig + "/refinery",
 			ExtraVars:     buildRefineryPatrolVars(roleInfo),
 		}

--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -309,7 +309,7 @@ func outputWitnessPatrolContext(ctx RoleContext) {
 	cfg := PatrolConfig{
 		RoleName:        "witness",
 		PatrolMolName:   constants.MolWitnessPatrol,
-		BeadsDir:        ctx.WorkDir,
+		BeadsDir:        ctx.TownRoot,
 		Assignee:        ctx.Rig + "/witness",
 		HeaderEmoji:     constants.EmojiWitness,
 		HeaderTitle:     "Witness Patrol Status",
@@ -332,7 +332,7 @@ func outputRefineryPatrolContext(ctx RoleContext) {
 	cfg := PatrolConfig{
 		RoleName:        "refinery",
 		PatrolMolName:   constants.MolRefineryPatrol,
-		BeadsDir:        ctx.WorkDir,
+		BeadsDir:        ctx.TownRoot,
 		Assignee:        ctx.Rig + "/refinery",
 		HeaderEmoji:     "🔧",
 		HeaderTitle:     "Refinery Patrol Status",


### PR DESCRIPTION
## Summary

- Witness and refinery patrol molecules were created in the rig's beads database (`ctx.WorkDir`), causing them to appear as rig-prefixed issues (e.g. `wi-*`) mixed in with real project work
- Deacon already correctly used `ctx.TownRoot` (HQ beads) — this fix makes witness and refinery consistent
- 3 files changed, 6 lines: `WorkDir` → `TownRoot` in all witness/refinery `PatrolConfig.BeadsDir` fields

## Related

- #885 (gastown artifacts leaking into external worktrees — same class of bug)

## Test plan

- [ ] Verify witness/refinery patrol molecules get `hq-` prefix instead of rig prefix
- [ ] Verify `bd list --status=open` in a rig no longer shows patrol beads
- [ ] Verify patrol report/new cycle correctly finds and closes patrols in HQ beads