### PR TITLE
feat: add autopilot types — AutopilotPlan, TaskNode, ResourceSnapshot, GovernorConfig

### DIFF
--- a/internal/autopilot/types.go
+++ b/internal/autopilot/types.go
@@ -1,0 +1,197 @@
+// Package autopilot provides automatic gastown configuration for user tasks.
+//
+// Autopilot decomposes a high-level task description into a structured plan,
+// launches it as a mountain convoy, and governs resource usage dynamically.
+// Three phases: Plan → Launch → Govern.
+package autopilot
+
+import "time"
+
+// Strategy represents the execution mode for an autopilot plan.
+type Strategy string
+
+const (
+	// StrategyPolecats uses independent polecat workers for focused, parallel tasks.
+	StrategyPolecats Strategy = "polecats"
+
+	// StrategyCrew uses a crew for deep-context work (architecture, multi-file refactors).
+	StrategyCrew Strategy = "crew"
+
+	// StrategyHybrid mixes crew for strategic planning with polecats for execution.
+	StrategyHybrid Strategy = "hybrid"
+)
+
+// IsValid returns true if the strategy is a recognized value.
+func (s Strategy) IsValid() bool {
+	switch s {
+	case StrategyPolecats, StrategyCrew, StrategyHybrid:
+		return true
+	default:
+		return false
+	}
+}
+
+// TaskNode represents a single task in the autopilot plan's dependency graph.
+type TaskNode struct {
+	// ID is a short identifier for dependency references (e.g., "t1", "t2").
+	ID string `json:"id"`
+
+	// Title is the human-readable task description.
+	Title string `json:"title"`
+
+	// Type classifies the task for bead creation (e.g., "task", "bug", "test").
+	Type string `json:"type"`
+
+	// DependsOn lists IDs of tasks that must complete before this one can start.
+	DependsOn []string `json:"depends_on,omitempty"`
+
+	// Priority is the task priority (1 = highest, 5 = lowest).
+	Priority int `json:"priority,omitempty"`
+
+	// EstimatedMinutes is the planner's rough time estimate for the task.
+	EstimatedMinutes int `json:"estimated_minutes,omitempty"`
+}
+
+// AutopilotPlan is the structured output from the planner phase.
+// It contains the full task decomposition and execution strategy
+// produced by a claude --print call against the project context.
+type AutopilotPlan struct {
+	// EpicTitle is the top-level epic name for the bead hierarchy.
+	EpicTitle string `json:"epic_title"`
+
+	// Tasks is the ordered list of tasks forming the dependency graph.
+	Tasks []TaskNode `json:"tasks"`
+
+	// Strategy is the recommended execution mode (polecats, crew, or hybrid).
+	Strategy Strategy `json:"strategy"`
+
+	// MaxConcurrency is the recommended number of concurrent workers,
+	// based on resource assessment and task parallelism.
+	MaxConcurrency int `json:"max_concurrency"`
+
+	// Reasoning explains why the planner chose this decomposition and strategy.
+	Reasoning string `json:"reasoning,omitempty"`
+}
+
+// ResourceSnapshot captures system resource state at a point in time.
+// Used by the planner to inform concurrency decisions and by the governor
+// to make dynamic adjustments during execution.
+type ResourceSnapshot struct {
+	// Timestamp is when the snapshot was taken.
+	Timestamp time.Time `json:"timestamp"`
+
+	// MemoryTotalBytes is total physical memory.
+	MemoryTotalBytes uint64 `json:"memory_total_bytes"`
+
+	// MemoryAvailableBytes is memory available for new processes.
+	MemoryAvailableBytes uint64 `json:"memory_available_bytes"`
+
+	// CPUUsagePercent is overall CPU utilization (0-100).
+	CPUUsagePercent float64 `json:"cpu_usage_percent"`
+
+	// NumCores is the number of logical CPU cores.
+	NumCores int `json:"num_cores"`
+
+	// LoadAvg1 is the 1-minute load average.
+	LoadAvg1 float64 `json:"load_avg_1"`
+
+	// ActiveSessions is the count of running Claude agent sessions.
+	ActiveSessions int `json:"active_sessions"`
+}
+
+// MemoryAvailableGB returns available memory in gigabytes.
+func (s *ResourceSnapshot) MemoryAvailableGB() float64 {
+	return float64(s.MemoryAvailableBytes) / (1024 * 1024 * 1024)
+}
+
+// MemoryTotalGB returns total memory in gigabytes.
+func (s *ResourceSnapshot) MemoryTotalGB() float64 {
+	return float64(s.MemoryTotalBytes) / (1024 * 1024 * 1024)
+}
+
+// GovernorConfig controls the autopilot governor's resource management behavior.
+// The governor runs as a deacon patrol molecule, polling at the configured interval
+// and adjusting polecat concurrency based on system pressure.
+type GovernorConfig struct {
+	// PollInterval is how often the governor checks resource state.
+	// Default: 60s.
+	PollInterval time.Duration `json:"poll_interval"`
+
+	// MemoryFloorGB is the minimum free memory before the governor pauses the mountain.
+	// Default: 1.0 (GB).
+	MemoryFloorGB float64 `json:"memory_floor_gb"`
+
+	// MemoryResumeGB is the free memory threshold to resume after a pause.
+	// Default: 1.5 (GB).
+	MemoryResumeGB float64 `json:"memory_resume_gb"`
+
+	// CPUCeiling is the CPU usage percent above which the governor reduces concurrency.
+	// Default: 85.
+	CPUCeiling float64 `json:"cpu_ceiling"`
+
+	// CPUFloor is the CPU usage percent below which the governor may increase concurrency.
+	// Default: 75.
+	CPUFloor float64 `json:"cpu_floor"`
+
+	// MaxPolecats is the upper bound on concurrent polecats (from the plan).
+	MaxPolecats int `json:"max_polecats"`
+
+	// MountainID is the convoy/mountain being governed.
+	MountainID string `json:"mountain_id"`
+
+	// EpicID is the root epic bead being tracked for completion.
+	EpicID string `json:"epic_id"`
+}
+
+// DefaultGovernorConfig returns a GovernorConfig with sensible defaults.
+// MaxPolecats, MountainID, and EpicID must be set by the caller.
+func DefaultGovernorConfig() *GovernorConfig {
+	return &GovernorConfig{
+		PollInterval:   60 * time.Second,
+		MemoryFloorGB:  1.0,
+		MemoryResumeGB: 1.5,
+		CPUCeiling:     85.0,
+		CPUFloor:       75.0,
+	}
+}
+
+// GovernorAction represents a decision made by the governor during a poll cycle.
+type GovernorAction string
+
+const (
+	// GovernorNoop means no adjustment is needed.
+	GovernorNoop GovernorAction = "noop"
+
+	// GovernorPause pauses the mountain due to memory pressure.
+	GovernorPause GovernorAction = "pause"
+
+	// GovernorResume resumes the mountain after memory recovery.
+	GovernorResume GovernorAction = "resume"
+
+	// GovernorScaleDown reduces max_polecats by 1 due to CPU pressure.
+	GovernorScaleDown GovernorAction = "scale_down"
+
+	// GovernorScaleUp increases max_polecats by 1 due to CPU headroom.
+	GovernorScaleUp GovernorAction = "scale_up"
+
+	// GovernorComplete terminates the governor because the mountain is done.
+	GovernorComplete GovernorAction = "complete"
+)
+
+// GovernorDecision captures a governor poll result with the chosen action and reasoning.
+type GovernorDecision struct {
+	// Action is what the governor decided to do.
+	Action GovernorAction `json:"action"`
+
+	// Reason explains why this action was chosen.
+	Reason string `json:"reason"`
+
+	// Snapshot is the resource state that informed the decision.
+	Snapshot ResourceSnapshot `json:"snapshot"`
+
+	// CurrentPolecats is the max_polecats setting before this decision.
+	CurrentPolecats int `json:"current_polecats"`
+
+	// Timestamp is when the decision was made.
+	Timestamp time.Time `json:"timestamp"`
+}

--- a/internal/autopilot/types_test.go
+++ b/internal/autopilot/types_test.go
@@ -1,0 +1,168 @@
+package autopilot
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestStrategyIsValid(t *testing.T) {
+	tests := []struct {
+		s    Strategy
+		want bool
+	}{
+		{StrategyPolecats, true},
+		{StrategyCrew, true},
+		{StrategyHybrid, true},
+		{"unknown", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		if got := tt.s.IsValid(); got != tt.want {
+			t.Errorf("Strategy(%q).IsValid() = %v, want %v", tt.s, got, tt.want)
+		}
+	}
+}
+
+func TestResourceSnapshotMemoryHelpers(t *testing.T) {
+	s := &ResourceSnapshot{
+		MemoryTotalBytes:     8 * 1024 * 1024 * 1024, // 8 GB
+		MemoryAvailableBytes: 2 * 1024 * 1024 * 1024, // 2 GB
+	}
+
+	if got := s.MemoryTotalGB(); got != 8.0 {
+		t.Errorf("MemoryTotalGB() = %v, want 8.0", got)
+	}
+	if got := s.MemoryAvailableGB(); got != 2.0 {
+		t.Errorf("MemoryAvailableGB() = %v, want 2.0", got)
+	}
+}
+
+func TestDefaultGovernorConfig(t *testing.T) {
+	cfg := DefaultGovernorConfig()
+
+	if cfg.PollInterval != 60*time.Second {
+		t.Errorf("PollInterval = %v, want 60s", cfg.PollInterval)
+	}
+	if cfg.MemoryFloorGB != 1.0 {
+		t.Errorf("MemoryFloorGB = %v, want 1.0", cfg.MemoryFloorGB)
+	}
+	if cfg.MemoryResumeGB != 1.5 {
+		t.Errorf("MemoryResumeGB = %v, want 1.5", cfg.MemoryResumeGB)
+	}
+	if cfg.CPUCeiling != 85.0 {
+		t.Errorf("CPUCeiling = %v, want 85.0", cfg.CPUCeiling)
+	}
+	if cfg.CPUFloor != 75.0 {
+		t.Errorf("CPUFloor = %v, want 75.0", cfg.CPUFloor)
+	}
+	if cfg.MaxPolecats != 0 {
+		t.Errorf("MaxPolecats = %v, want 0 (caller must set)", cfg.MaxPolecats)
+	}
+}
+
+func TestAutopilotPlanJSONRoundtrip(t *testing.T) {
+	plan := AutopilotPlan{
+		EpicTitle: "implement computer-use verification",
+		Tasks: []TaskNode{
+			{
+				ID:    "t1",
+				Title: "create data types",
+				Type:  "task",
+			},
+			{
+				ID:        "t2",
+				Title:     "implement resource snapshot",
+				Type:      "task",
+				DependsOn: []string{"t1"},
+				Priority:  1,
+			},
+		},
+		Strategy:       StrategyPolecats,
+		MaxConcurrency: 2,
+		Reasoning:      "independent tasks suitable for parallel polecats",
+	}
+
+	data, err := json.Marshal(plan)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var decoded AutopilotPlan
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if decoded.EpicTitle != plan.EpicTitle {
+		t.Errorf("EpicTitle = %q, want %q", decoded.EpicTitle, plan.EpicTitle)
+	}
+	if len(decoded.Tasks) != 2 {
+		t.Fatalf("len(Tasks) = %d, want 2", len(decoded.Tasks))
+	}
+	if decoded.Tasks[1].DependsOn[0] != "t1" {
+		t.Errorf("Tasks[1].DependsOn[0] = %q, want %q", decoded.Tasks[1].DependsOn[0], "t1")
+	}
+	if decoded.Strategy != StrategyPolecats {
+		t.Errorf("Strategy = %q, want %q", decoded.Strategy, StrategyPolecats)
+	}
+	if decoded.MaxConcurrency != 2 {
+		t.Errorf("MaxConcurrency = %d, want 2", decoded.MaxConcurrency)
+	}
+}
+
+func TestGovernorDecisionJSON(t *testing.T) {
+	now := time.Now().Truncate(time.Second)
+	d := GovernorDecision{
+		Action: GovernorPause,
+		Reason: "memory below floor",
+		Snapshot: ResourceSnapshot{
+			Timestamp:            now,
+			MemoryAvailableBytes: 512 * 1024 * 1024, // 512 MB
+			CPUUsagePercent:      45.0,
+		},
+		CurrentPolecats: 3,
+		Timestamp:       now,
+	}
+
+	data, err := json.Marshal(d)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	var decoded GovernorDecision
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		t.Fatalf("Unmarshal failed: %v", err)
+	}
+
+	if decoded.Action != GovernorPause {
+		t.Errorf("Action = %q, want %q", decoded.Action, GovernorPause)
+	}
+	if decoded.CurrentPolecats != 3 {
+		t.Errorf("CurrentPolecats = %d, want 3", decoded.CurrentPolecats)
+	}
+}
+
+func TestTaskNodeOmitsEmptyFields(t *testing.T) {
+	node := TaskNode{
+		ID:    "t1",
+		Title: "simple task",
+		Type:  "task",
+	}
+
+	data, err := json.Marshal(node)
+	if err != nil {
+		t.Fatalf("Marshal failed: %v", err)
+	}
+
+	// Verify omitted fields don't appear in JSON
+	var raw map[string]interface{}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatalf("Unmarshal to map failed: %v", err)
+	}
+
+	for _, field := range []string{"depends_on", "priority", "estimated_minutes"} {
+		if _, ok := raw[field]; ok {
+			t.Errorf("field %q should be omitted when zero/empty", field)
+		}
+	}
+}


### PR DESCRIPTION
## Summary
- **internal/autopilot/types.go**: Core autopilot type definitions — AutopilotPlan, TaskNode, ResourceSnapshot, GovernorConfig
- **internal/autopilot/types_test.go**: Tests for autopilot types

## Test plan
- [x] Tests pass locally
- [ ] CI passes on PR

Executed-By: gastown/polecats/chrome (gt-zw2.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)