### PR TITLE
fix(plugins): prevent plugin-run beads from accumulating as open wisps

### DIFF
--- a/internal/cmd/plugin.go
+++ b/internal/cmd/plugin.go
@@ -18,15 +18,19 @@ import (
 
 // Plugin command flags
 var (
-	pluginListJSON     bool
-	pluginShowJSON     bool
-	pluginRunForce     bool
-	pluginRunDryRun    bool
-	pluginHistoryJSON  bool
-	pluginHistoryLimit int
-	pluginSyncSource   string
-	pluginSyncClean    bool
-	pluginSyncDryRun   bool
+	pluginListJSON      bool
+	pluginShowJSON      bool
+	pluginRunForce      bool
+	pluginRunDryRun     bool
+	pluginHistoryJSON   bool
+	pluginHistoryLimit  int
+	pluginSyncSource    string
+	pluginSyncClean     bool
+	pluginSyncDryRun    bool
+	pluginRecordResult  string
+	pluginRecordBody    string
+	pluginRecordRig     string
+	pluginRecordSilent  bool
 )
 
 var pluginCmd = &cobra.Command{
@@ -120,6 +124,23 @@ Examples:
 	RunE: runPluginSync,
 }
 
+var pluginRecordCmd = &cobra.Command{
+	Use:   "record <name>",
+	Short: "Record a plugin run (creates and auto-closes a tracking bead)",
+	Long: `Record that a plugin has been executed. Creates an ephemeral bead
+and immediately closes it, preventing bead accumulation.
+
+This is the preferred way for plugin instructions to record their execution.
+Use this instead of raw "bd create --ephemeral" calls.
+
+Examples:
+  gt plugin record stuck-agent-dog --result success --body "Checked 3 agents, all healthy"
+  gt plugin record compactor-dog --result failure --body "Dolt unreachable"
+  gt plugin record dolt-backup --result success --body "3 DBs synced" --silent`,
+	Args: cobra.ExactArgs(1),
+	RunE: runPluginRecord,
+}
+
 var pluginHistoryCmd = &cobra.Command{
 	Use:   "history <name>",
 	Short: "Show plugin execution history",
@@ -155,12 +176,19 @@ func init() {
 	pluginSyncCmd.Flags().BoolVar(&pluginSyncClean, "clean", false, "Remove plugins from target that don't exist in source")
 	pluginSyncCmd.Flags().BoolVar(&pluginSyncDryRun, "dry-run", false, "Show what would happen without syncing")
 
+	// Record subcommand flags
+	pluginRecordCmd.Flags().StringVar(&pluginRecordResult, "result", "success", "Run result: success, failure, or skipped")
+	pluginRecordCmd.Flags().StringVar(&pluginRecordBody, "body", "", "Description of the run outcome")
+	pluginRecordCmd.Flags().StringVar(&pluginRecordRig, "rig", "", "Rig name (optional)")
+	pluginRecordCmd.Flags().BoolVar(&pluginRecordSilent, "silent", false, "Suppress output")
+
 	// Add subcommands
 	pluginCmd.AddCommand(pluginListCmd)
 	pluginCmd.AddCommand(pluginShowCmd)
 	pluginCmd.AddCommand(pluginRunCmd)
 	pluginCmd.AddCommand(pluginHistoryCmd)
 	pluginCmd.AddCommand(pluginSyncCmd)
+	pluginCmd.AddCommand(pluginRecordCmd)
 
 	rootCmd.AddCommand(pluginCmd)
 }
@@ -484,6 +512,45 @@ func runPluginRun(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "Warning: failed to record run: %v\n", err)
 	} else {
 		fmt.Printf("\n%s Recorded run: %s\n", style.Dim.Render("●"), beadID)
+	}
+
+	return nil
+}
+
+func runPluginRecord(cmd *cobra.Command, args []string) error {
+	name := args[0]
+
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("not in a Gas Town workspace: %w", err)
+	}
+
+	result := plugin.ResultSuccess
+	switch strings.ToLower(pluginRecordResult) {
+	case "failure", "fail":
+		result = plugin.ResultFailure
+	case "skipped", "skip":
+		result = plugin.ResultSkipped
+	case "success", "ok", "":
+		result = plugin.ResultSuccess
+	default:
+		// Accept arbitrary result values (e.g., "warning", "check-only")
+		result = plugin.RunResult(pluginRecordResult)
+	}
+
+	recorder := plugin.NewRecorder(townRoot)
+	beadID, err := recorder.RecordRun(plugin.PluginRunRecord{
+		PluginName: name,
+		RigName:    pluginRecordRig,
+		Result:     result,
+		Body:       pluginRecordBody,
+	})
+	if err != nil {
+		return fmt.Errorf("recording plugin run: %w", err)
+	}
+
+	if !pluginRecordSilent {
+		fmt.Printf("%s Recorded run: %s (%s)\n", style.Dim.Render("●"), beadID, result)
 	}
 
 	return nil

--- a/internal/daemon/handler.go
+++ b/internal/daemon/handler.go
@@ -54,6 +54,7 @@ func (d *Daemon) handleDogs() {
 	d.cleanupStuckDogs(mgr, sm)
 	d.detectStaleWorkingDogs(mgr, sm, opCfg)
 	d.reapIdleDogs(mgr, sm, opCfg)
+	d.cleanupStalePluginBeads()
 	d.dispatchPlugins(mgr, sm, rigsConfig)
 }
 
@@ -300,6 +301,22 @@ func (d *Daemon) dispatchPlugins(mgr *dog.Manager, sm *dog.SessionManager, rigsC
 		}
 
 		d.logger.Printf("Handler: dispatched plugin %s to dog %s", p.Name, idleDog.Name)
+	}
+}
+
+// cleanupStalePluginBeads closes any open plugin-run beads that were left
+// unclosed by plugin instructions. Acts as a safety net — properly written
+// plugins use "gt plugin record" which auto-closes, but legacy plugins or
+// crash-interrupted runs can leave orphans.
+func (d *Daemon) cleanupStalePluginBeads() {
+	recorder := plugin.NewRecorder(d.config.TownRoot)
+	closed, err := recorder.CloseStalePluginBeads()
+	if err != nil {
+		d.logger.Printf("Handler: failed to cleanup plugin beads: %v", err)
+		return
+	}
+	if closed > 0 {
+		d.logger.Printf("Handler: closed %d stale plugin-run bead(s)", closed)
 	}
 }
 

--- a/internal/plugin/recording.go
+++ b/internal/plugin/recording.go
@@ -230,3 +230,58 @@ func (r *Recorder) CountRunsSince(pluginName string, since string) (int, error) 
 	}
 	return len(runs), nil
 }
+
+// CloseStalePluginBeads finds open beads with the type:plugin-run label
+// and closes them. These beads are created by plugin instructions but should
+// be closed immediately after creation. This method acts as a safety net
+// to clean up any that were missed (e.g., due to agent crash or old plugins
+// that don't use gt plugin record).
+func (r *Recorder) CloseStalePluginBeads() (int, error) {
+	// Query for open plugin-run beads (no --all flag = open only)
+	args := []string{
+		"list",
+		"--json",
+		"-l", "type:plugin-run",
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), constants.BdCommandTimeout)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
+	cmd.Dir = r.townRoot
+	cmd.Env = append(os.Environ(), "BEADS_DIR="+beads.ResolveBeadsDir(r.townRoot))
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		if stderr.Len() == 0 || stdout.String() == "[]\n" {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("querying open plugin beads: %s: %w", stderr.String(), err)
+	}
+
+	var openBeads []struct {
+		ID string `json:"id"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &openBeads); err != nil {
+		if stdout.String() == "[]\n" || stdout.Len() == 0 {
+			return 0, nil
+		}
+		return 0, fmt.Errorf("parsing open plugin beads: %w", err)
+	}
+
+	closed := 0
+	for _, b := range openBeads {
+		closeCtx, closeCancel := context.WithTimeout(context.Background(), constants.BdCommandTimeout)
+		closeCmd := exec.CommandContext(closeCtx, "bd", "close", b.ID, "--reason", "stale plugin-run bead auto-closed") //nolint:gosec // G204: bd is a trusted internal tool
+		closeCmd.Dir = r.townRoot
+		closeCmd.Env = append(os.Environ(), "BEADS_DIR="+beads.ResolveBeadsDir(r.townRoot))
+		if err := closeCmd.Run(); err == nil {
+			closed++
+		}
+		closeCancel()
+	}
+
+	return closed, nil
+}

--- a/plugins/compactor-dog/plugin.md
+++ b/plugins/compactor-dog/plugin.md
@@ -239,23 +239,17 @@ echo "=== $SUMMARY ==="
 
 On success (no escalation needed):
 ```bash
-bd create "compactor-dog: $SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:compactor-dog,result:success \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record compactor-dog --result success --body "$SUMMARY" --silent 2>/dev/null || true
 ```
 
 On escalation:
 ```bash
-bd create "compactor-dog: ESCALATED - $SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:compactor-dog,result:warning \
-  -d "Escalated to Mayor for compaction. $SUMMARY" --silent 2>/dev/null || true
+gt plugin record compactor-dog --result warning --body "Escalated to Mayor for compaction. $SUMMARY" --silent 2>/dev/null || true
 ```
 
 On failure:
 ```bash
-bd create "compactor-dog: FAILED" -t chore --ephemeral \
-  -l type:plugin-run,plugin:compactor-dog,result:failure \
-  -d "Compactor check failed: $ERROR" --silent 2>/dev/null || true
+gt plugin record compactor-dog --result failure --body "Compactor check failed: $ERROR" --silent 2>/dev/null || true
 
 gt escalate "Plugin FAILED: compactor-dog" \
   --severity medium \

--- a/plugins/compactor-dog/run.sh
+++ b/plugins/compactor-dog/run.sh
@@ -201,9 +201,7 @@ log "Skipped (below threshold): ${#SKIPPED[@]}"
 if [[ ${#CANDIDATES[@]} -eq 0 ]]; then
   log "All databases within threshold ($COMMIT_THRESHOLD). No compaction needed."
   SUMMARY="compactor-dog: all ${DB_COUNT} DBs below threshold ($COMMIT_THRESHOLD commits)"
-  bd create "$SUMMARY" -t chore --ephemeral \
-    -l type:plugin-run,plugin:compactor-dog,result:success \
-    -d "$SUMMARY" --silent 2>/dev/null || true
+  gt plugin record compactor-dog --result success --body "$SUMMARY" --silent 2>/dev/null || true
   exit 0
 fi
 
@@ -216,9 +214,7 @@ if $CHECK_ONLY; then
     log "  ${entry%%:*} (${entry##*:} commits) — recommends compaction"
   done
   SUMMARY="compactor-dog: ${#CANDIDATES[@]} DBs exceed threshold ($COMMIT_THRESHOLD commits)"
-  bd create "$SUMMARY" -t chore --ephemeral \
-    -l type:plugin-run,plugin:compactor-dog,result:check-only \
-    -d "$SUMMARY" --silent 2>/dev/null || true
+  gt plugin record compactor-dog --result check-only --body "$SUMMARY" --silent 2>/dev/null || true
   exit 0
 fi
 
@@ -478,13 +474,9 @@ if [[ $ERRORS -gt 0 ]]; then
   gt escalate "compactor-dog: $ERRORS databases had compaction errors" -s MEDIUM \
     --reason "Compaction cycle completed with errors. $SUMMARY" 2>/dev/null || true
 
-  bd create "compactor-dog: ERRORS — $SUMMARY" -t chore --ephemeral \
-    -l type:plugin-run,plugin:compactor-dog,result:warning \
-    -d "Compaction completed with $ERRORS errors. $SUMMARY" --silent 2>/dev/null || true
+  gt plugin record compactor-dog --result warning --body "Compaction completed with $ERRORS errors. $SUMMARY" --silent 2>/dev/null || true
 else
-  bd create "$SUMMARY" -t chore --ephemeral \
-    -l type:plugin-run,plugin:compactor-dog,result:success \
-    -d "$SUMMARY" --silent 2>/dev/null || true
+  gt plugin record compactor-dog --result success --body "$SUMMARY" --silent 2>/dev/null || true
 fi
 
 log "Done."

--- a/plugins/dolt-archive/plugin.md
+++ b/plugins/dolt-archive/plugin.md
@@ -260,9 +260,7 @@ if [ "$EXPORT_FAILED" -gt 0 ] || [ "$DOLT_PUSH_FAILED" -gt 0 ] || [ "$VERIFY_FAI
   RESULT="warning"
 fi
 
-bd create "$SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:dolt-archive,result:$RESULT \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record dolt-archive --result "$RESULT" --body "$SUMMARY" --silent 2>/dev/null || true
 
 if [ "$EXPORT_FAILED" -gt 0 ]; then
   gt escalate "JSONL export failed for $EXPORT_FAILED databases" \

--- a/plugins/dolt-archive/run.sh
+++ b/plugins/dolt-archive/run.sh
@@ -231,9 +231,7 @@ if [[ "$EXPORT_FAILED" -gt 0 ]] || [[ "$DOLT_PUSH_FAILED" -gt 0 ]]; then
   RESULT="warning"
 fi
 
-bd create "$SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:dolt-archive,result:$RESULT \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record dolt-archive --result "$RESULT" --body "$SUMMARY" --silent 2>/dev/null || true
 
 if [[ "$EXPORT_FAILED" -gt 0 ]]; then
   gt escalate "dolt-archive: JSONL export failed for $EXPORT_FAILED databases ($EXPORT_ERRORS)" \

--- a/plugins/dolt-backup/run.sh
+++ b/plugins/dolt-backup/run.sh
@@ -127,16 +127,12 @@ log "$SUMMARY"
 # --- Step 3: Record result and escalate if needed -----------------------------
 
 if [[ "$FAILED" -eq 0 ]]; then
-  # Success — record quietly
-  bd create --title "dolt-backup: $SUMMARY" -t chore --ephemeral \
-    -l type:plugin-run,plugin:dolt-backup,result:success \
-    -d "$SUMMARY" --silent 2>/dev/null || true
+  # Success — record quietly (gt plugin record auto-closes the bead)
+  gt plugin record dolt-backup --result success --body "$SUMMARY" --silent 2>/dev/null || true
 else
   # Failure — record and escalate
   FAIL_MSG="$SUMMARY. Failed:$FAILED_DBS"
-  bd create --title "dolt-backup: FAILED - $FAIL_MSG" -t chore --ephemeral \
-    -l type:plugin-run,plugin:dolt-backup,result:failure \
-    -d "$FAIL_MSG" --silent 2>/dev/null || true
+  gt plugin record dolt-backup --result failure --body "FAILED - $FAIL_MSG" --silent 2>/dev/null || true
 
   gt escalate "dolt-backup FAILED: $FAIL_MSG" \
     --severity high \

--- a/plugins/dolt-snapshots/plugin.md
+++ b/plugins/dolt-snapshots/plugin.md
@@ -135,7 +135,5 @@ if [ $SNAPSHOT_EXIT -ne 0 ]; then
   RESULT="failure"
 fi
 
-bd create "dolt-snapshots: $RESULT" -t chore --ephemeral \
-  -l type:plugin-run,plugin:dolt-snapshots,result:$RESULT \
-  -d "dolt-snapshots plugin completed with exit code $SNAPSHOT_EXIT. Watcher started." --silent 2>/dev/null || true
+gt plugin record dolt-snapshots --result "$RESULT" --body "dolt-snapshots plugin completed with exit code $SNAPSHOT_EXIT. Watcher started." --silent 2>/dev/null || true
 ```

--- a/plugins/git-hygiene/plugin.md
+++ b/plugins/git-hygiene/plugin.md
@@ -207,16 +207,12 @@ echo "$SUMMARY"
 
 On success:
 ```bash
-bd create "git-hygiene: $SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:git-hygiene,result:success \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record git-hygiene --result success --body "$SUMMARY" --silent 2>/dev/null || true
 ```
 
 On failure:
 ```bash
-bd create "git-hygiene: FAILED" -t chore --ephemeral \
-  -l type:plugin-run,plugin:git-hygiene,result:failure \
-  -d "Git hygiene failed: $ERROR" --silent 2>/dev/null || true
+gt plugin record git-hygiene --result failure --body "Git hygiene failed: $ERROR" --silent 2>/dev/null || true
 
 gt escalate "Plugin FAILED: git-hygiene" \
   --severity low \

--- a/plugins/github-sheriff/plugin.md
+++ b/plugins/github-sheriff/plugin.md
@@ -208,16 +208,12 @@ echo "$SUMMARY"
 
 On success:
 ```bash
-bd create "github-sheriff: $SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:github-sheriff,result:success \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record github-sheriff --result success --body "$SUMMARY" --silent 2>/dev/null || true
 ```
 
 On failure:
 ```bash
-bd create "github-sheriff: FAILED" -t chore --ephemeral \
-  -l type:plugin-run,plugin:github-sheriff,result:failure \
-  -d "GitHub sheriff failed: $ERROR" --silent 2>/dev/null || true
+gt plugin record github-sheriff --result failure --body "GitHub sheriff failed: $ERROR" --silent 2>/dev/null || true
 
 gt escalate "Plugin FAILED: github-sheriff" \
   --severity low \

--- a/plugins/quality-review/plugin.md
+++ b/plugins/quality-review/plugin.md
@@ -34,10 +34,7 @@ bd list --json --all -l type:plugin-run,plugin:quality-review-result --created-a
 If no results are found, record a run wisp and stop:
 
 ```bash
-bd create "quality-review: No results in last 24h" -t chore --ephemeral \
-  -l type:plugin-run,plugin:quality-review,result:success \
-  -d "No quality-review results in last 24h. Nothing to analyze." \
-  --silent 2>/dev/null || true
+gt plugin record quality-review --result success --body "No quality-review results in last 24h. Nothing to analyze." --silent 2>/dev/null || true
 ```
 
 ## Step 2: Compute per-worker trends
@@ -91,19 +88,13 @@ gt escalate "Quality BREACH: <worker> (avg: <avg>)" \
 Record a summary wisp for this plugin run:
 
 ```bash
-bd create "quality-review: Analyzed <N> workers over <M> reviews" -t chore --ephemeral \
-  -l type:plugin-run,plugin:quality-review,result:success \
-  -d "Analyzed <N> workers over <M> reviews. <B> breaches, <W> warnings." \
-  --silent 2>/dev/null || true
+gt plugin record quality-review --result success --body "Analyzed <N> workers over <M> reviews. <B> breaches, <W> warnings." --silent 2>/dev/null || true
 ```
 
 If any step fails unexpectedly, record a failure wisp and escalate:
 
 ```bash
-bd create "quality-review: FAILED" -t chore --ephemeral \
-  -l type:plugin-run,plugin:quality-review,result:failure \
-  -d "<error description>" \
-  --silent 2>/dev/null || true
+gt plugin record quality-review --result failure --body "<error description>" --silent 2>/dev/null || true
 
 gt escalate "Plugin FAILED: quality-review" \
   --severity medium \
@@ -118,10 +109,7 @@ This plugin does NOT record scores itself. The Refinery records result wisps dur
 merges via the `quality-review` formula step. Each merge produces a wisp like:
 
 ```bash
-bd create "quality-review: Score 0.85, approve" -t chore --ephemeral \
-  -l type:plugin-run,plugin:quality-review-result,worker:<polecat-name>,rig:<rig-name>,score:0.85,recommendation:approve,result:success \
-  -d "Score: 0.85, approve. Issues: 1 minor (style)" \
-  --silent 2>/dev/null || true
+gt plugin record quality-review-result --result success --body "Score: 0.85, approve. Issues: 1 minor (style)" --silent 2>/dev/null || true
 ```
 
 This creates the data that Step 1 queries.

--- a/plugins/rebuild-gt/plugin.md
+++ b/plugins/rebuild-gt/plugin.md
@@ -47,10 +47,7 @@ Parse the JSON output and check these fields:
 
 If `safe_to_rebuild` is false, record a skip wisp:
 ```bash
-bd create --wisp-type patrol \
-  --labels type:plugin-run,plugin:rebuild-gt,rig:gastown,result:skipped \
-  --description "Skipped: not safe to rebuild (forward=$FORWARD, main=$ON_MAIN)" \
-  "Plugin: rebuild-gt [skipped]"
+gt plugin record rebuild-gt --result skipped --rig gastown --body "Skipped: not safe to rebuild (forward=$FORWARD, main=$ON_MAIN)" --silent 2>/dev/null || true
 ```
 
 ## Pre-flight Checks
@@ -81,18 +78,12 @@ NOT restart the daemon — sessions will pick up the new binary on their next cy
 
 On success:
 ```bash
-bd create --wisp-type patrol \
-  --labels type:plugin-run,plugin:rebuild-gt,rig:gastown,result:success \
-  --description "Rebuilt gt: $OLD → $NEW ($N commits)" \
-  "Plugin: rebuild-gt [success]"
+gt plugin record rebuild-gt --result success --rig gastown --body "Rebuilt gt: $OLD → $NEW ($N commits)" --silent 2>/dev/null || true
 ```
 
 On failure:
 ```bash
-bd create --wisp-type patrol \
-  --labels type:plugin-run,plugin:rebuild-gt,rig:gastown,result:failure \
-  --description "Build failed: $ERROR" \
-  "Plugin: rebuild-gt [failure]"
+gt plugin record rebuild-gt --result failure --rig gastown --body "Build failed: $ERROR" --silent 2>/dev/null || true
 
 gt escalate --severity=medium \
   --subject="Plugin FAILED: rebuild-gt" \

--- a/plugins/stuck-agent-dog/plugin.md
+++ b/plugins/stuck-agent-dog/plugin.md
@@ -315,16 +315,12 @@ echo "=== $SUMMARY ==="
 
 On success (no issues or issues handled):
 ```bash
-bd create "stuck-agent-dog: $SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:stuck-agent-dog,result:success \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record stuck-agent-dog --result success --body "$SUMMARY" --silent 2>/dev/null || true
 ```
 
 On failure:
 ```bash
-bd create "stuck-agent-dog: FAILED" -t chore --ephemeral \
-  -l type:plugin-run,plugin:stuck-agent-dog,result:failure \
-  -d "Agent health check failed: $ERROR" --silent 2>/dev/null || true
+gt plugin record stuck-agent-dog --result failure --body "Agent health check failed: $ERROR" --silent 2>/dev/null || true
 
 gt escalate "Plugin FAILED: stuck-agent-dog" \
   --severity high \


### PR DESCRIPTION
## Summary

- Add `gt plugin record` subcommand wrapping `RecordRun` (create+close atomically)
- Update plugin instructions to use `gt plugin record` instead of raw `bd create`
- Daemon-dispatched dog runs now properly close their beads after reporting

## Problem

Plugin instructions (`plugin.md` and `run.sh`) create beads via `bd create --ephemeral` but never close them. The Go `RecordRun` API properly creates+closes but was only called for manual `gt plugin run`, not daemon-dispatched dog runs. This caused ~145+ open wisps accumulating per cycle.

## Test plan
- [ ] Run a plugin via daemon dispatch and verify bead is created and closed
- [ ] Verify `gt plugin record` CLI works for manual invocation
- [ ] Check HQ inbox after a full daemon cycle — no accumulating open plugin wisps

Closes gt-qfq

🤖 Generated with [Claude Code](https://claude.com/claude-code)