### PR TITLE
fix(done): auto-commit uncommitted work as safety net

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -269,6 +269,44 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		}
 	}
 
+	// SAFETY NET: Auto-commit uncommitted work before ANY exit path (gt-pvx).
+	// Polecats have been observed running gt done without committing their
+	// implementation work (1000s of lines lost). This happened because:
+	// 1. The agent skips the "commit changes" formula step
+	// 2. The COMPLETED check blocks, but the agent retries with --status DEFERRED
+	//    which skips all checks
+	// 3. The agent's session dies after the error, before it can commit
+	//
+	// Auto-commit ensures work is NEVER lost regardless of exit type or agent behavior.
+	// The commit message is clearly marked as an auto-save so reviewers know.
+	if cwdAvailable && doneCleanupStatus == "uncommitted" {
+		// Re-check to get file details (cleanup detection already confirmed uncommitted changes)
+		workStatus, err := g.CheckUncommittedWork()
+		if err == nil && workStatus.HasUncommittedChanges && !workStatus.CleanExcludingRuntime() {
+			fmt.Printf("\n%s Uncommitted changes detected — auto-saving to prevent work loss\n", style.Bold.Render("⚠"))
+			fmt.Printf("  Files: %s\n\n", workStatus.String())
+
+			// Stage all changes (git add -A)
+			if addErr := g.Add("-A"); addErr != nil {
+				style.PrintWarning("auto-commit: git add failed: %v — uncommitted work may be at risk", addErr)
+			} else {
+				// Build a descriptive commit message
+				autoMsg := "fix: auto-save uncommitted implementation work (gt-pvx safety net)"
+				if issueFromBranch := parseBranchName(branch).Issue; issueFromBranch != "" {
+					autoMsg = fmt.Sprintf("fix: auto-save uncommitted implementation work (%s, gt-pvx safety net)", issueFromBranch)
+				}
+				if commitErr := g.Commit(autoMsg); commitErr != nil {
+					style.PrintWarning("auto-commit: git commit failed: %v — uncommitted work may be at risk", commitErr)
+				} else {
+					fmt.Printf("%s Auto-committed uncommitted work (safety net)\n", style.Bold.Render("✓"))
+					fmt.Printf("  The agent should have committed before running gt done.\n")
+					fmt.Printf("  This auto-save prevents work loss.\n\n")
+					doneCleanupStatus = "unpushed" // Update status — changes are now committed but not pushed
+				}
+			}
+		}
+	}
+
 	// Parse branch info
 	info := parseBranchName(branch)
 
@@ -1069,7 +1107,20 @@ notifyWitness:
 		// Phase 3 of persistent-polecat-pool: DONE→IDLE syncs to main and deletes old branch.
 		// Non-fatal: if sync fails, the polecat is still IDLE and the Witness
 		// or next gt sling can handle the branch state.
-		if cwdAvailable && !pushFailed {
+		//
+		// GUARD (gt-pvx): Refuse to sync if uncommitted changes remain.
+		// If the auto-commit safety net above failed (git add/commit error),
+		// switching branches would discard the work. Better to leave the worktree
+		// dirty on the feature branch so work can be recovered.
+		syncSafe := true
+		if cwdAvailable {
+			if ws, wsErr := g.CheckUncommittedWork(); wsErr == nil && ws.HasUncommittedChanges && !ws.CleanExcludingRuntime() {
+				syncSafe = false
+				style.PrintWarning("uncommitted changes still present — skipping worktree sync to preserve work")
+				fmt.Printf("  Files: %s\n", ws.String())
+			}
+		}
+		if cwdAvailable && !pushFailed && syncSafe {
 			// Remember the old branch so we can delete it after switching
 			oldBranch := branch
 

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -1338,6 +1338,143 @@ func TestPushSubmoduleChanges_NoSubmodules(t *testing.T) {
 	pushSubmoduleChanges(g, "main")
 }
 
+// TestAutoCommitSafetyNet verifies that the gt done auto-commit safety net
+// (gt-pvx) correctly detects uncommitted implementation work and auto-commits it.
+// This tests the git-level operations that underpin the safety net in done.go.
+func TestAutoCommitSafetyNet(t *testing.T) {
+	// Set up a git repo with uncommitted changes
+	dir := t.TempDir()
+	testRunGit(t, dir, "init")
+	testRunGit(t, dir, "config", "user.email", "test@test.com")
+	testRunGit(t, dir, "config", "user.name", "Test")
+
+	// Create initial commit
+	initialFile := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(initialFile, []byte("# Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	testRunGit(t, dir, "add", "README.md")
+	testRunGit(t, dir, "commit", "-m", "initial commit")
+
+	g := gitpkg.NewGit(dir)
+
+	t.Run("detects uncommitted new files", func(t *testing.T) {
+		// Create uncommitted implementation files (simulates polecat forgetting to commit)
+		implFile := filepath.Join(dir, "main.go")
+		if err := os.WriteFile(implFile, []byte("package main\n\nfunc main() {}\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		defer os.Remove(implFile)
+
+		ws, err := g.CheckUncommittedWork()
+		if err != nil {
+			t.Fatalf("CheckUncommittedWork: %v", err)
+		}
+		if !ws.HasUncommittedChanges {
+			t.Error("expected HasUncommittedChanges=true for new file")
+		}
+		if ws.CleanExcludingRuntime() {
+			t.Error("expected CleanExcludingRuntime=false for non-runtime file")
+		}
+	})
+
+	t.Run("auto-commit preserves work", func(t *testing.T) {
+		// Create implementation files
+		implFile := filepath.Join(dir, "handler.go")
+		if err := os.WriteFile(implFile, []byte("package main\n\nfunc handler() {}\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Verify uncommitted
+		ws, err := g.CheckUncommittedWork()
+		if err != nil {
+			t.Fatalf("CheckUncommittedWork: %v", err)
+		}
+		if !ws.HasUncommittedChanges || ws.CleanExcludingRuntime() {
+			t.Fatal("expected non-runtime uncommitted changes")
+		}
+
+		// Simulate the auto-commit safety net
+		if err := g.Add("-A"); err != nil {
+			t.Fatalf("git add: %v", err)
+		}
+		if err := g.Commit("fix: auto-save uncommitted implementation work (gt-pvx safety net)"); err != nil {
+			t.Fatalf("git commit: %v", err)
+		}
+
+		// Verify clean after auto-commit
+		ws2, err := g.CheckUncommittedWork()
+		if err != nil {
+			t.Fatalf("CheckUncommittedWork after commit: %v", err)
+		}
+		if ws2.HasUncommittedChanges {
+			t.Error("expected clean working tree after auto-commit")
+		}
+	})
+
+	t.Run("runtime-only changes skip auto-commit", func(t *testing.T) {
+		// Runtime artifacts should NOT trigger auto-commit
+		runtimeDir := filepath.Join(dir, ".claude")
+		if err := os.MkdirAll(runtimeDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		runtimeFile := filepath.Join(runtimeDir, "settings.json")
+		if err := os.WriteFile(runtimeFile, []byte("{}"), 0644); err != nil {
+			t.Fatal(err)
+		}
+		defer os.RemoveAll(runtimeDir)
+
+		ws, err := g.CheckUncommittedWork()
+		if err != nil {
+			t.Fatalf("CheckUncommittedWork: %v", err)
+		}
+		// HasUncommittedChanges is true (git sees the files), but CleanExcludingRuntime
+		// should be true (only runtime artifacts)
+		if ws.HasUncommittedChanges && !ws.CleanExcludingRuntime() {
+			t.Error("runtime-only changes should be considered clean excluding runtime")
+		}
+	})
+}
+
+// TestSyncGuardWithUncommittedChanges verifies that the worktree sync guard
+// (gt-pvx) prevents switching branches when uncommitted changes remain.
+func TestSyncGuardWithUncommittedChanges(t *testing.T) {
+	// This tests the logic: if auto-commit fails, we should NOT sync to main
+	dir := t.TempDir()
+	testRunGit(t, dir, "init")
+	testRunGit(t, dir, "config", "user.email", "test@test.com")
+	testRunGit(t, dir, "config", "user.name", "Test")
+
+	// Create initial commit on main
+	if err := os.WriteFile(filepath.Join(dir, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	testRunGit(t, dir, "add", ".")
+	testRunGit(t, dir, "commit", "-m", "initial")
+
+	// Create feature branch with uncommitted changes
+	testRunGit(t, dir, "checkout", "-b", "polecat/test")
+	if err := os.WriteFile(filepath.Join(dir, "impl.go"), []byte("package main\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	g := gitpkg.NewGit(dir)
+	ws, err := g.CheckUncommittedWork()
+	if err != nil {
+		t.Fatalf("CheckUncommittedWork: %v", err)
+	}
+
+	// The sync guard condition: if uncommitted non-runtime changes exist, syncSafe = false
+	syncSafe := true
+	if ws.HasUncommittedChanges && !ws.CleanExcludingRuntime() {
+		syncSafe = false
+	}
+
+	if syncSafe {
+		t.Error("syncSafe should be false when uncommitted implementation files exist")
+	}
+}
+
 func testRunGit(t *testing.T, dir string, args ...string) {
 	t.Helper()
 	fullArgs := append([]string{"-c", "protocol.file.allow=always"}, args...)


### PR DESCRIPTION
## Summary
- Adds auto-commit safety net in `gt done` to preserve uncommitted implementation work before any exit path proceeds
- Fixes P1 bug (gt-pvx) where polecats running `gt done` with uncommitted changes would lose work
- Replaces blocking approach with belt-and-suspenders: uncommitted non-runtime changes are auto-committed regardless of exit type (COMPLETED, DEFERRED, ESCALATED)

## Test plan
- [x] TestAutoCommitSafetyNet - detects uncommitted new files
- [x] TestAutoCommitSafetyNet - auto-commit preserves work
- [x] TestSyncGuardWithUncommittedChanges
- [x] Full `go build ./...` and `go vet ./...` pass
- [x] `go test ./internal/cmd/` and `go test ./internal/git/` pass

Bead: gt-pvx

🤖 Generated with [Claude Code](https://claude.com/claude-code)