### PR TITLE
feat(config): add list subcommand to default-agent

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -33,7 +33,8 @@ Commands:
   gt config agent get <name>         Show agent configuration
   gt config agent set <name> <cmd>   Set custom agent command
   gt config agent remove <name>      Remove custom agent
-  gt config default-agent [name]     Get or set default agent`,
+  gt config default-agent [name]     Get or set default agent
+  gt config default-agent list       List available agents`,
 }
 
 // Agent subcommands
@@ -200,13 +201,33 @@ The default agent is used when a rig doesn't specify its own agent
 setting. Can be a built-in preset (claude, gemini, codex) or a
 custom agent name.
 
+Use 'gt config default-agent list' to see all available agents.
+
 Examples:
   gt config default-agent           # Show current default
+  gt config default-agent list      # List available agents
   gt config default-agent claude    # Set to claude
   gt config default-agent gemini    # Set to gemini
   gt config default-agent my-custom # Set to custom agent`,
 	RunE: runConfigDefaultAgent,
 }
+
+var configDefaultAgentListCmd = &cobra.Command{
+	Use:   "list",
+	Short: "List available agents",
+	Long: `List all available agents that can be set as the default.
+
+Shows all built-in agent presets and any custom agents defined in
+your town settings. Equivalent to 'gt config agent list'.
+
+Examples:
+  gt config default-agent list           # Text output
+  gt config default-agent list --json    # JSON output`,
+	RunE: runConfigAgentList,
+}
+
+// Flags for default-agent list
+var configDefaultAgentListJSON bool
 
 var configAgentEmailDomainCmd = &cobra.Command{
 	Use:   "agent-email-domain [domain]",
@@ -231,7 +252,7 @@ Examples:
 
 // Flags
 var (
-	configAgentListJSON  bool
+	configAgentListJSON    bool
 	configAgentSetProvider string
 )
 
@@ -305,7 +326,8 @@ func runConfigAgentList(cmd *cobra.Command, args []string) error {
 		return items[i].Name < items[j].Name
 	})
 
-	if configAgentListJSON {
+	jsonOutput, _ := cmd.Flags().GetBool("json")
+	if jsonOutput {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		return enc.Encode(items)
@@ -554,7 +576,7 @@ func runConfigDefaultAgent(cmd *cobra.Command, args []string) error {
 	}
 
 	if !isValid {
-		return fmt.Errorf("agent '%s' not found (use 'gt config agent list' to see available agents)", name)
+		return fmt.Errorf("agent '%s' not found (use 'gt config default-agent list' to see available agents)", name)
 	}
 
 	// Set default
@@ -1235,6 +1257,7 @@ func parseBool(s string) (bool, error) {
 func init() {
 	// Add flags
 	configAgentListCmd.Flags().BoolVar(&configAgentListJSON, "json", false, "Output as JSON")
+	configDefaultAgentListCmd.Flags().BoolVar(&configDefaultAgentListJSON, "json", false, "Output as JSON")
 	configAgentSetCmd.Flags().StringVar(&configAgentSetProvider, "provider", "", "Agent provider preset (e.g. claude, gemini, codex); inferred from command name if not set")
 
 	// Add agent subcommands
@@ -1251,6 +1274,9 @@ config values such as the default AI model or provider.`,
 	configAgentCmd.AddCommand(configAgentGetCmd)
 	configAgentCmd.AddCommand(configAgentSetCmd)
 	configAgentCmd.AddCommand(configAgentRemoveCmd)
+
+	// Add default-agent subcommands
+	configDefaultAgentCmd.AddCommand(configDefaultAgentListCmd)
 
 	// Add subcommands to config
 	configCmd.AddCommand(configAgentCmd)

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -127,20 +127,15 @@ func TestConfigAgentList(t *testing.T) {
 			t.Fatalf("chdir: %v", err)
 		}
 
-		// Set JSON flag
-		configAgentListJSON = true
-		defer func() { configAgentListJSON = false }()
-
 		// Load agent registry
 		registryPath := config.DefaultAgentRegistryPath(townRoot)
 		if err := config.LoadAgentRegistry(registryPath); err != nil {
 			t.Fatalf("load agent registry: %v", err)
 		}
 
-		// Capture output
-		// Note: This test verifies the command runs without error
-		// Full JSON validation would require capturing stdout
+		// Use a command with the --json flag registered
 		cmd := &cobra.Command{}
+		cmd.Flags().Bool("json", true, "")
 		args := []string{}
 		err := runConfigAgentList(cmd, args)
 		if err != nil {
@@ -681,6 +676,47 @@ func TestConfigDefaultAgent(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "not found") {
 			t.Errorf("error = %v, want 'not found'", err)
+		}
+	})
+}
+
+func TestConfigDefaultAgentList(t *testing.T) {
+	t.Run("lists available agents via default-agent list", func(t *testing.T) {
+		townRoot := setupTestTownForConfig(t)
+
+		originalWd, _ := os.Getwd()
+		defer os.Chdir(originalWd)
+		if err := os.Chdir(townRoot); err != nil {
+			t.Fatalf("chdir: %v", err)
+		}
+
+		// runConfigAgentList is reused by default-agent list
+		cmd := &cobra.Command{}
+		err := runConfigAgentList(cmd, []string{})
+		if err != nil {
+			t.Fatalf("runConfigAgentList (via default-agent list) failed: %v", err)
+		}
+	})
+
+	t.Run("JSON output via default-agent list", func(t *testing.T) {
+		townRoot := setupTestTownForConfig(t)
+
+		originalWd, _ := os.Getwd()
+		defer os.Chdir(originalWd)
+		if err := os.Chdir(townRoot); err != nil {
+			t.Fatalf("chdir: %v", err)
+		}
+
+		registryPath := config.DefaultAgentRegistryPath(townRoot)
+		if err := config.LoadAgentRegistry(registryPath); err != nil {
+			t.Fatalf("load agent registry: %v", err)
+		}
+
+		cmd := &cobra.Command{}
+		cmd.Flags().Bool("json", true, "")
+		err := runConfigAgentList(cmd, []string{})
+		if err != nil {
+			t.Fatalf("runConfigAgentList JSON (via default-agent list) failed: %v", err)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

Add `gt config default-agent list` as a convenience alias for `gt config agent list`, so users can discover available agents directly from the command they use to set defaults.

## Changes

- **New subcommand**: `gt config default-agent list` (reuses `runConfigAgentList` handler, supports `--json`)
- **Updated help text**: `default-agent -h` now mentions `list` and shows it in examples
- **Updated error message**: invalid agent names now point to `default-agent list` instead of `agent list`
- **Refactored JSON flag**: handler reads from `cmd.Flags()` instead of a global var, so both `agent list --json` and `default-agent list --json` work correctly
- **Added tests**: `TestConfigDefaultAgentList` covers text and JSON output

## Testing

```
go test ./internal/cmd/ -run 'TestConfigAgentList|TestConfigDefaultAgent' -v  # all pass
go vet ./internal/cmd/   # clean
gofmt -l internal/cmd/   # clean
```

Pre-existing test failures in `TestOutputRoleDirectives`, `internal/doctor`, and `internal/git` are unrelated.