### PR TITLE
fix: sync agent_state between column and description on state transitions

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -416,7 +416,8 @@ func (b *Beads) ResetAgentBeadForReuse(id, reason string) error {
 }
 
 // UpdateAgentState updates the agent_state field in an agent bead.
-// Uses `bd agent state` command for the database column directly.
+// Uses `bd agent state` command for the database column directly,
+// then syncs the description's agent_state field to match (gt-ulom).
 func (b *Beads) UpdateAgentState(id string, state string) (retErr error) {
 	defer func() { telemetry.RecordAgentStateChange(context.Background(), id, state, nil, retErr) }()
 	// Update agent state using bd agent state command
@@ -427,7 +428,11 @@ func (b *Beads) UpdateAgentState(id string, state string) (retErr error) {
 		return fmt.Errorf("updating agent state: %w", err)
 	}
 
-	// Hook slot no longer maintained (hq-l6mm5) — removed hook_bead parameter.
+	// Sync the description's agent_state field with the column (gt-ulom).
+	// Without this, the description stays stale (e.g., "spawning" after the
+	// column transitions to "working"), causing bd show and dashboards to
+	// display incorrect state after idle polecat reuse via gt sling.
+	_ = b.UpdateAgentDescriptionFields(id, AgentFieldUpdates{AgentState: &state})
 
 	return nil
 }
@@ -441,6 +446,7 @@ func (b *Beads) UpdateAgentState(id string, state string) (retErr error) {
 // This allows multiple fields to be updated in a single read-modify-write
 // cycle, avoiding races where concurrent callers overwrite each other's changes.
 type AgentFieldUpdates struct {
+	AgentState        *string // Sync description agent_state with column (gt-ulom)
 	CleanupStatus     *string
 	ActiveMR          *string
 	NotificationLevel *string
@@ -482,6 +488,9 @@ func (b *Beads) UpdateAgentDescriptionFields(id string, updates AgentFieldUpdate
 
 	fields := ParseAgentFields(issue.Description)
 
+	if updates.AgentState != nil {
+		fields.AgentState = *updates.AgentState
+	}
 	if updates.CleanupStatus != nil {
 		fields.CleanupStatus = *updates.CleanupStatus
 	}

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -1416,7 +1416,8 @@ doneStateUpdate:
 	if exitType == ExitEscalated {
 		doneState = "stuck"
 	}
-	if _, err := bd.Run("agent", "state", agentBeadID, doneState); err != nil {
+	// Use UpdateAgentState to sync both column and description (gt-ulom).
+	if err := bd.UpdateAgentState(agentBeadID, doneState); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: couldn't set agent %s to %s: %v\n", agentBeadID, doneState, err)
 	}
 

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1635,6 +1635,15 @@ func (m *Manager) ReuseIdlePolecat(name string, opts AddOptions) (*Polecat, erro
 		return nil, fmt.Errorf("agent bead required for polecat tracking: %w", err)
 	}
 
+	// Sync agent_state column to "spawning" (gt-ulom).
+	// createAgentBeadWithRetry sets agent_state in the description only.
+	// The column stays stale (e.g., "idle" from previous gt done) until
+	// StartSession sets it to "working". Without this, the column and
+	// description diverge, causing dashboards to show incorrect state.
+	if err := m.beads.UpdateAgentState(agentID, "spawning"); err != nil {
+		style.PrintWarning("could not sync agent_state column to spawning: %v", err)
+	}
+
 	now := time.Now()
 	return &Polecat{
 		Name:      name,


### PR DESCRIPTION
## Summary

- Fixes agent_state column and description diverging after idle polecat reuse via `gt sling`
- `UpdateAgentState()` now syncs the description's `agent_state` field to match the column
- `ReuseIdlePolecat()` explicitly sets column to "spawning" on reuse
- `done.go` uses `UpdateAgentState()` instead of raw `bd.Run()` for description sync

## Problem

When an idle polecat is reused via `gt sling`, the agent bead's `agent_state` description field stays stale (e.g., "spawning") while the column transitions correctly. This causes dashboards and `bd show` to display incorrect state.

## Test plan

- [ ] Sling work to an idle polecat, verify agent_state shows "working" in both `bd show` description and column
- [ ] Run `gt done`, verify agent_state shows "idle" in both places

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>