### PR TITLE
fix: formatPeriod returns "Week of ..." on Mondays instead of "Today"

### DIFF
--- a/internal/cmd/changelog.go
+++ b/internal/cmd/changelog.go
@@ -287,9 +287,8 @@ func formatPeriod(since time.Time) string {
 	y, m, d := now.Date()
 	today := time.Date(y, m, d, 0, 0, 0, 0, time.Local)
 
-	if since.Equal(today) {
-		return "Today"
-	}
+	// Check week start BEFORE today — on Mondays, weekStart == today and
+	// "Week of ..." is more informative than "Today".
 	weekday := int(now.Weekday())
 	if weekday == 0 {
 		weekday = 7
@@ -299,6 +298,9 @@ func formatPeriod(since time.Time) string {
 	weekStart := time.Date(monY, monM, monD, 0, 0, 0, 0, time.Local)
 	if since.Equal(weekStart) {
 		return fmt.Sprintf("Week of %s", since.Format("Jan 02, 2006"))
+	}
+	if since.Equal(today) {
+		return "Today"
 	}
 	return fmt.Sprintf("Since %s", since.Format("Jan 02, 2006"))
 }

--- a/internal/cmd/changelog_test.go
+++ b/internal/cmd/changelog_test.go
@@ -181,15 +181,22 @@ func TestFormatPeriod(t *testing.T) {
 
 	arbitraryPast := time.Date(2026, 1, 1, 0, 0, 0, 0, time.Local)
 
+	// On Mondays, today == weekStart. "Week of ..." takes priority over
+	// "Today" because it's more informative for changelog headers.
+	todayWant := "Today"
+	if today.Equal(weekStart) {
+		todayWant = fmt.Sprintf("Week of %s", today.Format("Jan 02, 2006"))
+	}
+
 	tests := []struct {
 		name  string
 		since time.Time
 		want  string
 	}{
 		{
-			name:  "today returns 'Today'",
+			name:  "today returns 'Today' (or 'Week of ...' on Mondays)",
 			since: today,
-			want:  "Today",
+			want:  todayWant,
 		},
 		{
 			name:  "week start returns 'Week of ...'",


### PR DESCRIPTION
## Summary

- Fixes `TestFormatPeriod` failing every Monday in CI
- On Mondays, `weekStart == today` — the function checked `today` first and returned `"Today"` before reaching the `"Week of ..."` branch
- Fix: check `weekStart` before `today` since `"Week of ..."` is more informative for changelog headers

## Test plan

- [x] `TestFormatPeriod` passes on Monday (today)
- [x] `TestFormatPeriod` test updated to expect `"Week of ..."` when today is Monday

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>