### PR TITLE
fix: use filepath.Join in explain_mode test for Windows compatibility

### DIFF
--- a/internal/cmd/prime_output_test.go
+++ b/internal/cmd/prime_output_test.go
@@ -148,7 +148,8 @@ func TestOutputRoleDirectives(t *testing.T) {
 		if !strings.Contains(out, "[EXPLAIN]") {
 			t.Errorf("expected EXPLAIN output, got: %s", out)
 		}
-		if !strings.Contains(out, "directives/polecat.md") {
+		// Use filepath.Join for OS-appropriate separator (backslash on Windows).
+		if !strings.Contains(out, filepath.Join("directives", "polecat.md")) {
 			t.Errorf("expected file path in explain output, got: %s", out)
 		}
 	})


### PR DESCRIPTION
## Summary

- Fixes `TestOutputRoleDirectives/explain_mode_shows_file_paths` failing on Windows CI
- The assertion used a hardcoded `"directives/polecat.md"` (forward slash) while `filepath.Join` produces backslashes on Windows
- Fix: use `filepath.Join("directives", "polecat.md")` to match the OS-appropriate separator

## Test plan

- [x] Test passes on Linux
- [ ] Test should now pass on Windows CI (backslash path separators)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>