### PR TITLE
feat(feed): add real-time polecat lifecycle to tree panel

### DIFF
--- a/internal/tui/feed/model.go
+++ b/internal/tui/feed/model.go
@@ -61,6 +61,12 @@ type Agent struct {
 	LastEvent  *Event
 	LastUpdate time.Time
 	Expanded   bool
+
+	// Polecat lifecycle fields (populated from gt polecat list)
+	PolecatState          string // working, idle, done, stuck, zombie
+	PolecatIssue          string // assigned bead ID
+	PolecatSessionRunning bool
+	PolecatZombie         bool
 }
 
 // Rig represents a rig with its agents
@@ -83,10 +89,11 @@ type Model struct {
 	feedViewport   viewport.Model
 
 	// Data
-	rigs        map[string]*Rig
-	events      []Event
-	convoyState *ConvoyState
-	townRoot    string
+	rigs         map[string]*Rig
+	events       []Event
+	convoyState  *ConvoyState
+	polecatState *PolecatState
+	townRoot     string
 
 	// UI state
 	keys     KeyMap
@@ -165,6 +172,7 @@ func (m *Model) Init() tea.Cmd {
 	cmds := []tea.Cmd{
 		m.listenForEvents(),
 		m.fetchConvoys(),
+		m.fetchPolecatData(),
 		tea.SetWindowTitle("GT Feed"),
 	}
 	// If starting in problems view, fetch problems immediately
@@ -180,6 +188,11 @@ type eventMsg Event
 // convoyUpdateMsg is sent when convoy data is refreshed
 type convoyUpdateMsg struct {
 	state *ConvoyState
+}
+
+// polecatUpdateMsg is sent when polecat data is refreshed
+type polecatUpdateMsg struct {
+	state *PolecatState
 }
 
 // problemsUpdateMsg is sent when problems data is refreshed
@@ -249,6 +262,29 @@ func (m *Model) convoyRefreshTick() tea.Cmd {
 	})
 }
 
+// fetchPolecatData returns a command that fetches polecat lifecycle data.
+// Captures townRoot under the read lock to avoid racing with SetTownRoot.
+func (m *Model) fetchPolecatData() tea.Cmd {
+	m.mu.RLock()
+	townRoot := m.townRoot
+	m.mu.RUnlock()
+
+	if townRoot == "" {
+		return nil
+	}
+	return func() tea.Msg {
+		state, _ := FetchPolecats(townRoot)
+		return polecatUpdateMsg{state: state}
+	}
+}
+
+// polecatRefreshTick returns a command that schedules the next polecat refresh
+func (m *Model) polecatRefreshTick() tea.Cmd {
+	return tea.Tick(10*time.Second, func(t time.Time) tea.Msg {
+		return polecatUpdateMsg{} // Empty state triggers a refresh
+	})
+}
+
 // fetchProblems returns a command that fetches problem agent data
 func (m *Model) fetchProblems() tea.Cmd {
 	detector := m.stuckDetector
@@ -298,6 +334,19 @@ func (m *Model) Update(msg tea.Msg) (tea.Model, tea.Cmd) {
 		} else {
 			// Tick fired - fetch new data
 			cmds = append(cmds, m.fetchConvoys())
+		}
+
+	case polecatUpdateMsg:
+		if msg.state != nil {
+			// Fresh data arrived - update state and schedule next tick
+			m.mu.Lock()
+			m.polecatState = msg.state
+			m.updateViewContentLocked()
+			m.mu.Unlock()
+			cmds = append(cmds, m.polecatRefreshTick())
+		} else {
+			// Tick fired - fetch new data
+			cmds = append(cmds, m.fetchPolecatData())
 		}
 
 	case problemsUpdateMsg:

--- a/internal/tui/feed/polecats.go
+++ b/internal/tui/feed/polecats.go
@@ -1,0 +1,53 @@
+package feed
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"os/exec"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/constants"
+)
+
+// PolecatInfo represents a polecat's status from gt polecat list --json
+type PolecatInfo struct {
+	Rig            string `json:"rig"`
+	Name           string `json:"name"`
+	State          string `json:"state"`
+	Issue          string `json:"issue,omitempty"`
+	SessionRunning bool   `json:"session_running"`
+	Zombie         bool   `json:"zombie,omitempty"`
+	SessionName    string `json:"session_name,omitempty"`
+}
+
+// PolecatState holds all polecat data for the tree panel
+type PolecatState struct {
+	Polecats   []PolecatInfo
+	LastUpdate time.Time
+}
+
+// FetchPolecats retrieves polecat status from gt polecat list --all --json
+func FetchPolecats(townRoot string) (*PolecatState, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), constants.BdSubprocessTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "gt", "polecat", "list", "--all", "--json") //nolint:gosec // G204: args are constructed internally
+	cmd.Dir = townRoot
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+
+	var polecats []PolecatInfo
+	if err := json.Unmarshal(stdout.Bytes(), &polecats); err != nil {
+		return nil, err
+	}
+
+	return &PolecatState{
+		Polecats:   polecats,
+		LastUpdate: time.Now(),
+	}, nil
+}

--- a/internal/tui/feed/styles.go
+++ b/internal/tui/feed/styles.go
@@ -162,6 +162,15 @@ var (
 	ZombieStyle = lipgloss.NewStyle().
 			Foreground(colorDim)
 
+	// Polecat lifecycle state styles (tree panel)
+	PolecatStuckStyle = lipgloss.NewStyle().
+				Foreground(colorWarning).
+				Bold(true)
+
+	PolecatZombieStyle = lipgloss.NewStyle().
+				Foreground(colorError).
+				Bold(true)
+
 	// Event symbols
 	EventSymbols = map[string]string{
 		"create":   "+",

--- a/internal/tui/feed/view.go
+++ b/internal/tui/feed/view.go
@@ -260,9 +260,16 @@ func getStateStyle(state AgentState) lipgloss.Style {
 // renderTree renders the agent tree content.
 // Caller must hold m.mu.
 func (m *Model) renderTree() string {
-	if len(m.rigs) == 0 {
+	if len(m.rigs) == 0 && m.polecatState == nil {
 		return AgentIdleStyle.Render("No agents active")
 	}
+
+	// Build polecat lookup from lifecycle data
+	polecatLookup := m.buildPolecatLookup()
+
+	// Merge polecat lifecycle data into rigs map so polecats discovered
+	// via gt polecat list appear in the tree even without events
+	m.mergePolecatsIntoRigs(polecatLookup)
 
 	var lines []string
 
@@ -309,6 +316,54 @@ func (m *Model) renderTree() string {
 	}
 
 	return strings.Join(lines, "\n")
+}
+
+// buildPolecatLookup creates a lookup map from rig/name -> PolecatInfo
+func (m *Model) buildPolecatLookup() map[string]*PolecatInfo {
+	lookup := make(map[string]*PolecatInfo)
+	if m.polecatState == nil {
+		return lookup
+	}
+	for i := range m.polecatState.Polecats {
+		p := &m.polecatState.Polecats[i]
+		key := p.Rig + "/" + p.Name
+		lookup[key] = p
+	}
+	return lookup
+}
+
+// mergePolecatsIntoRigs ensures polecats from lifecycle data appear in the tree.
+// Caller must hold m.mu.
+func (m *Model) mergePolecatsIntoRigs(lookup map[string]*PolecatInfo) {
+	for _, p := range lookup {
+		rig, ok := m.rigs[p.Rig]
+		if !ok {
+			rig = &Rig{
+				Name:     p.Rig,
+				Agents:   make(map[string]*Agent),
+				Expanded: true,
+			}
+			m.rigs[p.Rig] = rig
+		}
+
+		agentKey := p.Name
+		agent, ok := rig.Agents[agentKey]
+		if !ok {
+			agent = &Agent{
+				ID:   p.Name,
+				Name: p.Name,
+				Role: "polecat",
+				Rig:  p.Rig,
+			}
+			rig.Agents[agentKey] = agent
+		}
+
+		// Enrich with lifecycle data
+		agent.PolecatState = p.State
+		agent.PolecatIssue = p.Issue
+		agent.PolecatSessionRunning = p.SessionRunning
+		agent.PolecatZombie = p.Zombie
+	}
 }
 
 // groupAgentsByRole groups agents by their role
@@ -368,6 +423,11 @@ func (m *Model) renderAgent(icon string, agent *Agent, indent int) string {
 		name = parts[len(parts)-1]
 	}
 
+	// Use polecat lifecycle state for color coding when available
+	if agent.Role == "polecat" && agent.PolecatState != "" {
+		return prefix + m.renderPolecatAgent(name, agent)
+	}
+
 	nameStyle := AgentIdleStyle
 	statusIndicator := ""
 	if agent.Status == "running" || agent.Status == "working" {
@@ -386,8 +446,58 @@ func (m *Model) renderAgent(icon string, agent *Agent, indent int) string {
 		activity = fmt.Sprintf(" [%s] %s", age, msg)
 	}
 
-	line := prefix + nameStyle.Render(name+statusIndicator) + TimestampStyle.Render(activity)
-	return line
+	line := nameStyle.Render(name+statusIndicator) + TimestampStyle.Render(activity)
+	return prefix + line
+}
+
+// renderPolecatAgent renders a polecat with lifecycle state and bead info
+func (m *Model) renderPolecatAgent(name string, agent *Agent) string {
+	// State indicator with color coding
+	var stateStyle lipgloss.Style
+	var stateSymbol string
+
+	switch agent.PolecatState {
+	case "working":
+		stateStyle = AgentActiveStyle
+		stateSymbol = "●"
+	case "idle":
+		stateStyle = AgentIdleStyle
+		stateSymbol = "○"
+	case "done":
+		stateStyle = EventCompleteStyle
+		stateSymbol = "✓"
+	case "stuck":
+		stateStyle = PolecatStuckStyle
+		stateSymbol = "!"
+	case "zombie":
+		stateStyle = PolecatZombieStyle
+		stateSymbol = "☠"
+	default:
+		stateStyle = AgentIdleStyle
+		stateSymbol = "?"
+	}
+
+	// Name colored by state
+	namePart := stateStyle.Render(stateSymbol+" "+name) + " " + stateStyle.Render(agent.PolecatState)
+
+	// Bead ID + title (if assigned)
+	beadPart := ""
+	if agent.PolecatIssue != "" {
+		beadPart = " " + TimestampStyle.Render("→") + " " + ConvoyIDStyle.Render(agent.PolecatIssue)
+	}
+
+	// Last activity from events (if available)
+	activity := ""
+	if agent.LastEvent != nil {
+		age := formatAge(time.Since(agent.LastEvent.Time))
+		msg := agent.LastEvent.Message
+		if len(msg) > 30 {
+			msg = msg[:27] + "..."
+		}
+		activity = " " + TimestampStyle.Render(fmt.Sprintf("[%s] %s", age, msg))
+	}
+
+	return namePart + beadPart + activity
 }
 
 // renderFeed renders the event feed content.


### PR DESCRIPTION
## Summary
- Wire `gt polecat list --all --json` data into the feed TUI tree refresh cycle
- Polecats now show state (working/idle/done/stuck/zombie) with color coding and assigned bead ID
- New `polecats.go` for fetching lifecycle data, updated model/view/styles

Resolves gt-02b

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)