### PR TITLE
fix: prevent cross-town orphan cleanup from killing agents on other towns' sockets

### DIFF
--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -1360,15 +1360,19 @@ func runDeaconCleanupOrphans(cmd *cobra.Command, args []string) error {
 	// Report results
 	var terminated, escalated, unkillable int
 	for _, r := range results {
+		town := r.Process.TownRoot
+		if town == "" {
+			town = "unknown"
+		}
 		switch r.Signal {
 		case "SIGTERM":
-			fmt.Printf("  %s Sent SIGTERM to PID %d (%s)\n", style.Bold.Render("→"), r.Process.PID, r.Process.Cmd)
+			fmt.Printf("  %s Sent SIGTERM to PID %d (%s) town=%s\n", style.Bold.Render("→"), r.Process.PID, r.Process.Cmd, town)
 			terminated++
 		case "SIGKILL":
-			fmt.Printf("  %s Escalated to SIGKILL for PID %d (%s)\n", style.Bold.Render("!"), r.Process.PID, r.Process.Cmd)
+			fmt.Printf("  %s Escalated to SIGKILL for PID %d (%s) town=%s\n", style.Bold.Render("!"), r.Process.PID, r.Process.Cmd, town)
 			escalated++
 		case "UNKILLABLE":
-			fmt.Printf("  %s WARNING: PID %d (%s) survived SIGKILL\n", style.Bold.Render("⚠"), r.Process.PID, r.Process.Cmd)
+			fmt.Printf("  %s WARNING: PID %d (%s) survived SIGKILL town=%s\n", style.Bold.Render("⚠"), r.Process.PID, r.Process.Cmd, town)
 			unkillable++
 		}
 	}
@@ -1406,8 +1410,12 @@ func runDeaconZombieScan(cmd *cobra.Command, args []string) error {
 	if zombieScanDryRun {
 		for _, z := range zombies {
 			ageStr := fmt.Sprintf("%dm", z.Age/60)
-			fmt.Printf("  %s PID %d (%s) TTY=%s age=%s\n",
-				style.Dim.Render("→"), z.PID, z.Cmd, z.TTY, ageStr)
+			town := z.TownRoot
+			if town == "" {
+				town = "unknown"
+			}
+			fmt.Printf("  %s PID %d (%s) TTY=%s age=%s town=%s\n",
+				style.Dim.Render("→"), z.PID, z.Cmd, z.TTY, ageStr, town)
 		}
 		fmt.Printf("%s Dry run - no processes killed\n", style.Dim.Render("○"))
 		return nil
@@ -1422,18 +1430,22 @@ func runDeaconZombieScan(cmd *cobra.Command, args []string) error {
 	// Report results
 	var terminated, escalated, unkillable int
 	for _, r := range results {
+		town := r.Process.TownRoot
+		if town == "" {
+			town = "unknown"
+		}
 		switch r.Signal {
 		case "SIGTERM":
-			fmt.Printf("  %s Sent SIGTERM to PID %d (%s) TTY=%s\n",
-				style.Bold.Render("→"), r.Process.PID, r.Process.Cmd, r.Process.TTY)
+			fmt.Printf("  %s Sent SIGTERM to PID %d (%s) TTY=%s town=%s\n",
+				style.Bold.Render("→"), r.Process.PID, r.Process.Cmd, r.Process.TTY, town)
 			terminated++
 		case "SIGKILL":
-			fmt.Printf("  %s Escalated to SIGKILL for PID %d (%s)\n",
-				style.Bold.Render("!"), r.Process.PID, r.Process.Cmd)
+			fmt.Printf("  %s Escalated to SIGKILL for PID %d (%s) town=%s\n",
+				style.Bold.Render("!"), r.Process.PID, r.Process.Cmd, town)
 			escalated++
 		case "UNKILLABLE":
-			fmt.Printf("  %s WARNING: PID %d (%s) survived SIGKILL\n",
-				style.Bold.Render("⚠"), r.Process.PID, r.Process.Cmd)
+			fmt.Printf("  %s WARNING: PID %d (%s) survived SIGKILL town=%s\n",
+				style.Bold.Render("⚠"), r.Process.PID, r.Process.Cmd, town)
 			unkillable++
 		}
 	}

--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -169,8 +169,20 @@ gt deacon cleanup-orphans
 This command:
 1. Lists all claude/codex processes with `ps -eo pid,tty,comm`
 2. Filters for TTY = "?" (no controlling terminal)
-3. Sends SIGTERM to each orphaned process
-4. Reports how many were killed
+3. Resolves each candidate's Gas Town workspace root (shown as `town=` in output)
+4. Sends SIGTERM to each orphaned process
+5. Reports how many were killed, with their town affiliation
+
+**Multi-town awareness:**
+Multiple Gas Town instances may share the same machine, each with its own tmux
+socket and agent processes. `ps` output shows Claude processes from ALL towns,
+but each town's deacon should only clean up processes belonging to its own town.
+
+- The `gt deacon cleanup-orphans` output shows `town=<path>` for each orphan
+- Only clean up processes where the town path matches this town's root (`$GT_ROOT`)
+- Processes belonging to other towns are managed by those towns' own deacons
+- If you use manual process inspection (`ps aux`), verify a process's working
+  directory is under this town's root before killing it
 
 **Why this is safe:**
 - Processes in terminals (your personal sessions) have a TTY - they won't be touched

--- a/internal/templates/roles/deacon.md.tmpl
+++ b/internal/templates/roles/deacon.md.tmpl
@@ -302,6 +302,17 @@ gt mail delete <id>              # ALWAYS delete after handling
 Agents schedule future wakes by mailing you with subject `TIMER: <identity> wake at <time>`.
 When the time has passed, poke the agent: `{{ cmd }} mail send <identity> -s "WAKE" -m "Timer fired"`
 
+## Multi-Town Awareness
+
+This machine may run multiple independent Gas Town instances simultaneously.
+Each has its own tmux socket, daemon, and set of agents. System-wide `ps` output
+shows Claude processes from ALL towns — not just yours.
+
+- Only manage processes belonging to this town (working directory under `{{ .TownRoot }}`)
+- `gt deacon cleanup-orphans` reports each candidate's town root — use it to verify ownership before acting
+- If you inspect processes manually, check their CWD before killing them
+- Other towns' deacons manage their own processes
+
 ## Responsibilities
 
 **You ARE responsible for:**
@@ -314,6 +325,7 @@ When the time has passed, poke the agent: `{{ cmd }} mail send <identity> -s "WA
 - Managing polecats (Witnesses do that)
 - Work assignment (Mayor does that)
 - Merge processing (Refineries do that)
+- Processes belonging to other Gas Town instances on the same machine
 
 ## State Files
 

--- a/internal/util/orphan.go
+++ b/internal/util/orphan.go
@@ -58,48 +58,63 @@ func addDescendants(parentPID int, childMap map[int][]int, pids map[int]bool) {
 	}
 }
 
-// getTmuxSessionPIDs returns a set of PIDs belonging to ANY tmux session.
+// getTmuxSessionPIDs returns a set of PIDs belonging to ANY tmux session
+// across ALL tmux sockets on this machine.
+//
 // This prevents killing Claude processes that are running in tmux sessions,
 // even if they temporarily show TTY "?" during startup or session transitions.
 //
-// CRITICAL: We protect ALL tmux sessions, not just Gas Town ones (gt-*, hq-*).
-// User's personal Claude sessions (e.g., in sessions named "loomtown", "yaad")
-// must never be killed by orphan cleanup. The TTY="?" check is not reliable
-// during certain operations, so we must explicitly protect all tmux processes.
+// CRITICAL: We protect ALL tmux sessions on ALL sockets. When multiple Gas Town
+// instances run on the same machine, each uses its own tmux socket. A single-socket
+// query would miss processes in other towns' sessions, causing cross-town kills.
 func getTmuxSessionPIDs() map[int]bool {
 	pids := make(map[int]bool)
 
-	// Get list of ALL tmux sessions (not just gt-*/hq-*)
-	out, err := tmux.BuildCommand("list-sessions", "-F", "#{session_name}").Output()
-	if err != nil {
-		return pids // tmux not available or no sessions
-	}
-
-	// Build process tree once, used for all pane PIDs
+	// Build process tree once, shared across all socket scans
 	childMap := buildChildMap()
 
-	// Protect ALL sessions - user's personal sessions are just as important
-	sessions := strings.Split(strings.TrimSpace(string(out)), "\n")
+	// Scan all tmux sockets in the socket directory.
+	// Each Gas Town instance (and any personal tmux servers) gets its own socket.
+	socketDir := tmux.SocketDir()
+	entries, err := os.ReadDir(socketDir)
+	if err == nil {
+		for _, entry := range entries {
+			if entry.IsDir() {
+				continue
+			}
+			socketPath := filepath.Join(socketDir, entry.Name())
+			collectPanePIDs(socketPath, childMap, pids)
+		}
+	}
 
-	// For each session, get the PIDs of processes in its panes
-	for _, session := range sessions {
-		if session == "" {
-			continue
-		}
-		out, err := tmux.BuildCommand("list-panes", "-t", session, "-F", "#{pane_pid}").Output()
-		if err != nil {
-			continue
-		}
+	// Also query the current town's socket via BuildCommand as a fallback.
+	// This handles non-standard socket locations (e.g. GT_TMUX_SOCKET override).
+	out, err := tmux.BuildCommand("list-panes", "-a", "-F", "#{pane_pid}").Output()
+	if err == nil {
 		for _, pidStr := range strings.Split(strings.TrimSpace(string(out)), "\n") {
 			if pid, err := strconv.Atoi(pidStr); err == nil && pid > 0 {
 				pids[pid] = true
-				// Also add child processes of the pane shell
 				addDescendants(pid, childMap, pids)
 			}
 		}
 	}
 
 	return pids
+}
+
+// collectPanePIDs queries a single tmux socket for all pane PIDs and adds them
+// (plus their descendant processes) to the protection set.
+func collectPanePIDs(socketPath string, childMap map[int][]int, pids map[int]bool) {
+	out, err := exec.Command("tmux", "-S", socketPath, "list-panes", "-a", "-F", "#{pane_pid}").Output()
+	if err != nil {
+		return
+	}
+	for _, pidStr := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if pid, err := strconv.Atoi(pidStr); err == nil && pid > 0 {
+			pids[pid] = true
+			addDescendants(pid, childMap, pids)
+		}
+	}
 }
 
 // getACPSessionPIDs returns a set of PIDs belonging to active ACP (Agent Client Protocol) sessions.
@@ -282,28 +297,38 @@ func getProcessCwd(pid int) string {
 	return ""
 }
 
-// isInGasTownWorkspace checks whether a process's working directory is inside
-// a Gas Town workspace (identified by the mayor/town.json marker).
-// Returns true if the process cwd is at or under a Gas Town workspace root.
-// Returns false if the cwd cannot be determined or is not under any workspace.
-func isInGasTownWorkspace(pid int) bool {
+// resolveTownRoot returns the Gas Town workspace root for a process, identified
+// by walking up from its CWD looking for the mayor/town.json marker.
+// Returns the workspace root path, or "" if the process is not in any workspace
+// or its CWD cannot be determined.
+func resolveTownRoot(pid int) string {
 	cwd := getProcessCwd(pid)
 	if cwd == "" {
-		return false // Can't determine cwd; don't kill
+		return ""
 	}
+	return resolveTownRootFromDir(cwd)
+}
 
-	// Walk up from cwd looking for a Gas Town workspace marker
-	current := cwd
+// resolveTownRootFromDir walks up from dir looking for mayor/town.json.
+// Returns the workspace root path, or "" if not found.
+func resolveTownRootFromDir(dir string) string {
+	current := dir
 	for {
 		if _, err := os.Stat(filepath.Join(current, "mayor", "town.json")); err == nil {
-			return true
+			return current
 		}
 		parent := filepath.Dir(current)
 		if parent == current {
-			return false
+			return ""
 		}
 		current = parent
 	}
+}
+
+// isInGasTownWorkspace checks whether a process's working directory is inside
+// a Gas Town workspace (identified by the mayor/town.json marker).
+func isInGasTownWorkspace(pid int) bool {
+	return resolveTownRoot(pid) != ""
 }
 
 // isIDEClaudeProcess checks if a Claude process was spawned by an IDE extension
@@ -382,9 +407,10 @@ func parseEtime(etime string) (int, error) {
 
 // OrphanedProcess represents a claude process running without a controlling terminal.
 type OrphanedProcess struct {
-	PID int
-	Cmd string
-	Age int // Age in seconds
+	PID      int
+	Cmd      string
+	Age      int    // Age in seconds
+	TownRoot string // Gas Town workspace root, or "" if not in any workspace
 }
 
 // FindOrphanedClaudeProcesses finds claude/codex/opencode processes without a controlling terminal.
@@ -474,14 +500,16 @@ func FindOrphanedClaudeProcesses() ([]OrphanedProcess, error) {
 		// Only kill orphaned Claude processes whose cwd is under a Gas Town
 		// workspace root. This prevents killing user's Claude Code instances
 		// running in repos outside ~/gt/ (or wherever the workspace is).
-		if !isInGasTownWorkspace(pid) {
+		townRoot := resolveTownRoot(pid)
+		if townRoot == "" {
 			continue
 		}
 
 		orphans = append(orphans, OrphanedProcess{
-			PID: pid,
-			Cmd: cmd,
-			Age: age,
+			PID:      pid,
+			Cmd:      cmd,
+			Age:      age,
+			TownRoot: townRoot,
 		})
 	}
 
@@ -497,10 +525,11 @@ type CleanupResult struct {
 
 // ZombieProcess represents a claude process not in any active tmux session.
 type ZombieProcess struct {
-	PID int
-	Cmd string
-	Age int    // Age in seconds
-	TTY string // TTY column from ps (may be "?" or a session like "s024")
+	PID      int
+	Cmd      string
+	Age      int    // Age in seconds
+	TTY      string // TTY column from ps (may be "?" or a session like "s024")
+	TownRoot string // Gas Town workspace root, or "" if not in any workspace
 }
 
 // FindZombieClaudeProcesses finds Claude processes with no TTY that are NOT in
@@ -590,16 +619,18 @@ func FindZombieClaudeProcesses() ([]ZombieProcess, error) {
 		// Only kill zombie Claude processes whose cwd is under a Gas Town
 		// workspace root. This prevents killing user's Claude Code instances
 		// running in repos outside ~/gt/.
-		if !isInGasTownWorkspace(pid) {
+		townRoot := resolveTownRoot(pid)
+		if townRoot == "" {
 			continue
 		}
 
 		// This process is NOT in any active tmux session - it's a zombie
 		zombies = append(zombies, ZombieProcess{
-			PID: pid,
-			Cmd: cmd,
-			Age: age,
-			TTY: tty,
+			PID:      pid,
+			Cmd:      cmd,
+			Age:      age,
+			TTY:      tty,
+			TownRoot: townRoot,
 		})
 	}
 

--- a/internal/util/orphan_test.go
+++ b/internal/util/orphan_test.go
@@ -3,9 +3,15 @@
 package util
 
 import (
+	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strconv"
+	"strings"
 	"testing"
+
+	"github.com/steveyegge/gastown/internal/tmux"
 )
 
 func TestParseEtime(t *testing.T) {
@@ -132,5 +138,232 @@ func TestIsInGasTownWorkspace(t *testing.T) {
 	}
 	if !isInGasTownWorkspace(os.Getpid()) {
 		t.Error("isInGasTownWorkspace(self) = false, want true (in GT workspace subdir)")
+	}
+}
+
+// hasTmux returns true if tmux is available on PATH.
+func hasTmux() bool {
+	_, err := exec.LookPath("tmux")
+	return err == nil
+}
+
+// tmuxSocketSession creates a session on the given socket and returns the pane PID.
+// The caller must kill the session or server in cleanup.
+func tmuxSocketSession(t *testing.T, socketName, sessionName string) int {
+	t.Helper()
+	err := exec.Command("tmux", "-L", socketName, "new-session", "-d",
+		"-s", sessionName, "-x", "80", "-y", "24", "sleep", "300").Run()
+	if err != nil {
+		t.Fatalf("create session %q on socket %q: %v", sessionName, socketName, err)
+	}
+
+	out, err := exec.Command("tmux", "-L", socketName,
+		"list-panes", "-t", sessionName, "-F", "#{pane_pid}").Output()
+	if err != nil {
+		t.Fatalf("list-panes for %q on %q: %v", sessionName, socketName, err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(out)))
+	if err != nil {
+		t.Fatalf("parse pane PID %q: %v", string(out), err)
+	}
+	return pid
+}
+
+// killTmuxServer kills a tmux server by socket name.
+func killTmuxServer(socketName string) {
+	_ = exec.Command("tmux", "-L", socketName, "kill-server").Run()
+}
+
+func TestGetTmuxSessionPIDs_CrossSocket(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+
+	socketA := fmt.Sprintf("gt-test-orphan-a-%d", os.Getpid())
+	socketB := fmt.Sprintf("gt-test-orphan-b-%d", os.Getpid())
+	t.Cleanup(func() {
+		killTmuxServer(socketA)
+		killTmuxServer(socketB)
+	})
+
+	pidA := tmuxSocketSession(t, socketA, "session-a")
+	pidB := tmuxSocketSession(t, socketB, "session-b")
+
+	// Set default socket to A — simulates being inside Town A's context
+	oldSocket := tmux.GetDefaultSocket()
+	tmux.SetDefaultSocket(socketA)
+	t.Cleanup(func() { tmux.SetDefaultSocket(oldSocket) })
+
+	pids := getTmuxSessionPIDs()
+
+	if !pids[pidA] {
+		t.Errorf("PID %d from socket A not in protected set (set size=%d)", pidA, len(pids))
+	}
+	if !pids[pidB] {
+		t.Errorf("PID %d from socket B not in protected set — cross-town process would be killed (set size=%d)", pidB, len(pids))
+	}
+}
+
+func TestGetTmuxSessionPIDs_SingleSocket(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+
+	socket := fmt.Sprintf("gt-test-orphan-single-%d", os.Getpid())
+	t.Cleanup(func() { killTmuxServer(socket) })
+
+	pid1 := tmuxSocketSession(t, socket, "session-1")
+	pid2 := tmuxSocketSession(t, socket, "session-2")
+
+	oldSocket := tmux.GetDefaultSocket()
+	tmux.SetDefaultSocket(socket)
+	t.Cleanup(func() { tmux.SetDefaultSocket(oldSocket) })
+
+	pids := getTmuxSessionPIDs()
+
+	if !pids[pid1] {
+		t.Errorf("PID %d from session-1 not in protected set", pid1)
+	}
+	if !pids[pid2] {
+		t.Errorf("PID %d from session-2 not in protected set", pid2)
+	}
+}
+
+// realPath resolves symlinks in a path. On macOS, /var -> /private/var,
+// and lsof returns the real path while t.TempDir() returns the symlinked one.
+func realPath(t *testing.T, p string) string {
+	t.Helper()
+	resolved, err := filepath.EvalSymlinks(p)
+	if err != nil {
+		t.Fatalf("EvalSymlinks(%q): %v", p, err)
+	}
+	return resolved
+}
+
+func TestResolveTownRoot(t *testing.T) {
+	// NOTE: Uses os.Chdir — no t.Parallel().
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(origDir)
+
+	townA := realPath(t, t.TempDir())
+	if err := os.MkdirAll(filepath.Join(townA, "mayor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townA, "mayor", "town.json"),
+		[]byte(`{"name":"town-a"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	townB := realPath(t, t.TempDir())
+	if err := os.MkdirAll(filepath.Join(townB, "mayor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townB, "mayor", "town.json"),
+		[]byte(`{"name":"town-b"}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	// From Town A root
+	if err := os.Chdir(townA); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveTownRoot(os.Getpid()); got != townA {
+		t.Errorf("resolveTownRoot from town A root = %q, want %q", got, townA)
+	}
+
+	// From a subdirectory of Town A
+	subDir := filepath.Join(townA, "polecats", "test-polecat")
+	if err := os.MkdirAll(subDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(subDir); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveTownRoot(os.Getpid()); got != townA {
+		t.Errorf("resolveTownRoot from town A subdir = %q, want %q", got, townA)
+	}
+
+	// From Town B root
+	if err := os.Chdir(townB); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveTownRoot(os.Getpid()); got != townB {
+		t.Errorf("resolveTownRoot from town B root = %q, want %q", got, townB)
+	}
+
+	// From outside any town
+	nonTown := realPath(t, t.TempDir())
+	if err := os.Chdir(nonTown); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveTownRoot(os.Getpid()); got != "" {
+		t.Errorf("resolveTownRoot from outside = %q, want empty string", got)
+	}
+}
+
+func TestResolveTownRoot_DistinguishesAdjacentTowns(t *testing.T) {
+	// Two sibling towns under the same parent (mirrors ~/gastown and ~/gt-financing)
+	origDir, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.Chdir(origDir)
+
+	parent := realPath(t, t.TempDir())
+
+	townA := filepath.Join(parent, "gastown")
+	townB := filepath.Join(parent, "gt-financing")
+	for _, town := range []string{townA, townB} {
+		if err := os.MkdirAll(filepath.Join(town, "mayor"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(town, "mayor", "town.json"),
+			[]byte(`{"name":"test"}`), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if err := os.Chdir(townA); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveTownRoot(os.Getpid()); got != townA {
+		t.Errorf("from townA: resolveTownRoot = %q, want %q", got, townA)
+	}
+
+	if err := os.Chdir(townB); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveTownRoot(os.Getpid()); got != townB {
+		t.Errorf("from townB: resolveTownRoot = %q, want %q", got, townB)
+	}
+
+	// Parent directory itself is NOT a town
+	if err := os.Chdir(parent); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveTownRoot(os.Getpid()); got != "" {
+		t.Errorf("from parent: resolveTownRoot = %q, want empty (parent is not a town)", got)
+	}
+}
+
+func TestOrphanedProcess_TownRoot_Populated(t *testing.T) {
+	// Smoke test: verify TownRoot is populated (or "") on every orphan.
+	// Does not fail if no orphans exist — mirrors TestFindOrphanedClaudeProcesses.
+	orphans, err := FindOrphanedClaudeProcesses()
+	if err != nil {
+		t.Fatalf("FindOrphanedClaudeProcesses() error = %v", err)
+	}
+
+	t.Logf("Found %d orphaned claude processes", len(orphans))
+	for _, o := range orphans {
+		t.Logf("  PID %d: %s town=%q", o.PID, o.Cmd, o.TownRoot)
+		if o.TownRoot != "" {
+			if _, err := os.Stat(o.TownRoot); err != nil {
+				t.Errorf("PID %d: TownRoot %q does not exist on disk", o.PID, o.TownRoot)
+			}
+		}
 	}
 }

--- a/internal/util/orphan_windows.go
+++ b/internal/util/orphan_windows.go
@@ -5,9 +5,10 @@ package util
 // OrphanedProcess represents a claude process running without a controlling terminal.
 // On Windows, orphan cleanup is not supported, so this is a stub definition.
 type OrphanedProcess struct {
-	PID int
-	Cmd string
-	Age int // Age in seconds
+	PID      int
+	Cmd      string
+	Age      int    // Age in seconds
+	TownRoot string // Gas Town workspace root, or "" if not in any workspace
 }
 
 // CleanupResult describes what happened to an orphaned process.
@@ -21,10 +22,11 @@ type CleanupResult struct {
 // ZombieProcess represents a claude process not in any active tmux session.
 // On Windows, zombie cleanup is not supported, so this is a stub definition.
 type ZombieProcess struct {
-	PID int
-	Cmd string
-	Age int    // Age in seconds
-	TTY string // TTY column from ps
+	PID      int
+	Cmd      string
+	Age      int    // Age in seconds
+	TTY      string // TTY column from ps
+	TownRoot string // Gas Town workspace root, or "" if not in any workspace
 }
 
 // ZombieCleanupResult describes what happened to a zombie process.


### PR DESCRIPTION
## Summary

Fixes #3191

When multiple Gas Town instances run on the same machine, each uses its own tmux socket. `getTmuxSessionPIDs()` only queried the **current town's socket** when building the protected PID set, so processes in other towns' tmux sessions were invisible to the protection logic — and could be SIGTERMed as "orphans" by the deacon.

This was confirmed by tracing a production failure: a deacon in Town A ran `ps aux | grep claude`, saw Town B's mayor process, checked `tmux list-sessions` (which only showed Town A's sessions), concluded the process was orphaned, and killed it.

### Changes

- **`getTmuxSessionPIDs()` now scans all sockets** in `/tmp/tmux-{uid}/` instead of only the default socket, matching the documented intent ("protect ALL tmux sessions"). Falls back to `BuildCommand` for non-standard socket locations.
- **Extracted `resolveTownRoot()`** from `isInGasTownWorkspace()` and added `TownRoot` field to `OrphanedProcess`/`ZombieProcess` structs. CLI output now shows `town=<path>` for each candidate so the deacon agent can verify ownership.
- **Updated deacon patrol formula** (`mol-deacon-patrol.formula.toml`) with multi-town awareness: only clean up processes belonging to this town's `$GT_ROOT`.
- **Updated deacon role template** (`deacon.md.tmpl`) with a "Multi-Town Awareness" section.
- **Added 5 tests** including a cross-socket test that directly reproduces the bug.

### ZFC alignment

All changes follow the Zero Framework Cognition principle:
- Go code is pure transport: scans sockets, resolves town roots, exposes data
- Agent cognition (formula + template) decides what to kill based on that data

### Test evidence

The P0 test (`TestGetTmuxSessionPIDs_CrossSocket`) creates two tmux sockets, spawns a session on each, sets the default to Socket A, and asserts both PIDs are protected. It was verified red-to-green against the old implementation:

**Before fix** (old `orphan.go`, test applied):
```
=== RUN   TestGetTmuxSessionPIDs_CrossSocket
    orphan_crosssocket_test.go:63: PID 47367 from socket B not in protected set — cross-town process would be killed (set size=1)
--- FAIL: TestGetTmuxSessionPIDs_CrossSocket (0.59s)
```

**After fix**:
```
=== RUN   TestGetTmuxSessionPIDs_CrossSocket
--- PASS: TestGetTmuxSessionPIDs_CrossSocket (2.43s)
```

## Test plan

- [x] `TestGetTmuxSessionPIDs_CrossSocket` — reproduces the exact bug (P0)
- [x] `TestGetTmuxSessionPIDs_SingleSocket` — regression test for single-town setups (P1)
- [x] `TestResolveTownRoot` — town root resolution from root, subdir, and outside (P1)
- [x] `TestResolveTownRoot_DistinguishesAdjacentTowns` — sibling towns not confused (P2)
- [x] `TestOrphanedProcess_TownRoot_Populated` — TownRoot field wired end-to-end (P2)
- [x] Full `go test ./internal/util/` suite passes
- [x] `go vet` clean on both `internal/util/` and `internal/cmd/`


Made with [Cursor](https://cursor.com)