### PR TITLE
feat: wire judgment_enabled and review_depth from rig config to refinery patrol

### DIFF
--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -392,6 +392,8 @@ func buildRefineryPatrolVars(ctx RoleContext) []string {
 			vars = append(vars, fmt.Sprintf("build_command=%s", mq.BuildCommand))
 		}
 		vars = append(vars, fmt.Sprintf("delete_merged_branches=%t", mq.IsDeleteMergedBranchesEnabled()))
+		vars = append(vars, fmt.Sprintf("judgment_enabled=%t", mq.IsJudgmentEnabled()))
+		vars = append(vars, fmt.Sprintf("review_depth=%s", mq.GetReviewDepth()))
 		return vars
 	}
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1250,6 +1250,17 @@ type MergeQueueConfig struct {
 	// StaleClaimTimeout is how long a claimed MR can go without updates before
 	// being considered abandoned and eligible for re-claim (e.g., "30m").
 	StaleClaimTimeout string `json:"stale_claim_timeout,omitempty"`
+
+	// JudgmentEnabled controls whether the refinery performs quality review
+	// before merging. When true, the refinery patrol's quality-review step
+	// evaluates the diff for correctness, security, and code quality.
+	// Nil defaults to false (no quality review).
+	JudgmentEnabled *bool `json:"judgment_enabled,omitempty"`
+
+	// ReviewDepth controls the thoroughness of quality review when judgment
+	// is enabled. Valid values: "quick", "standard", "deep".
+	// Nil defaults to "standard".
+	ReviewDepth string `json:"review_depth,omitempty"`
 }
 
 // OnConflict strategy constants.
@@ -1302,6 +1313,24 @@ func (c *MergeQueueConfig) IsDeleteMergedBranchesEnabled() bool {
 		return true
 	}
 	return *c.DeleteMergedBranches
+}
+
+// IsJudgmentEnabled returns whether quality review is enabled for merges.
+// Nil-safe, defaults to false.
+func (c *MergeQueueConfig) IsJudgmentEnabled() bool {
+	if c.JudgmentEnabled == nil {
+		return false
+	}
+	return *c.JudgmentEnabled
+}
+
+// GetReviewDepth returns the configured review depth.
+// Nil-safe, defaults to "standard".
+func (c *MergeQueueConfig) GetReviewDepth() string {
+	if c.ReviewDepth == "" {
+		return "standard"
+	}
+	return c.ReviewDepth
 }
 
 // boolPtr returns a pointer to a bool value.


### PR DESCRIPTION
## Summary

- Adds `JudgmentEnabled` and `ReviewDepth` fields to `MergeQueueConfig`
- Wires them through `buildRefineryPatrolVars` so per-rig `settings/config.json` overrides formula defaults
- The refinery patrol formula already supports these variables (`quality-review` step at line 385) but they were unreachable from configuration — formula defaults always won

## Problem

The refinery patrol has a built-in quality review step gated by `judgment_enabled` (default: `false`) with configurable `review_depth` (quick/standard/deep). But `MergeQueueConfig` had no fields for these, and `buildRefineryPatrolVars` didn't extract them from rig settings. There was no way to enable judgment per-rig without editing the embedded formula TOML.

## Usage

```json
// <rig>/settings/config.json
{
  "merge_queue": {
    "judgment_enabled": true,
    "review_depth": "deep"
  }
}
```

## Changes

- `internal/config/types.go`: Add `JudgmentEnabled *bool` and `ReviewDepth string` to `MergeQueueConfig`, with `IsJudgmentEnabled()` and `GetReviewDepth()` accessors following existing patterns
- `internal/cmd/prime_molecule.go`: Add two lines to `buildRefineryPatrolVars` to inject the vars

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/config/` passes
- [ ] Set `judgment_enabled: true` in rig settings, verify refinery patrol runs quality review step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>