### PR TITLE
fix(test): update TestBuildRefineryPatrolVars_FullConfig for judgment fields (GH#3199)

### DIFF
--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -126,7 +126,8 @@ func TestBuildRefineryPatrolVars_FullConfig(t *testing.T) {
 	vars := buildRefineryPatrolVars(ctx)
 
 	// DefaultMergeQueueConfig: refinery_enabled=true, auto_land=false, run_tests=true,
-	// test_command="" (language-agnostic), target_branch="main" (from rig config), delete_merged_branches=true
+	// test_command="" (language-agnostic), target_branch="main" (from rig config),
+	// delete_merged_branches=true, judgment_enabled=false, review_depth="standard"
 	// New commands (setup, typecheck, lint, build) default to empty = omitted
 	expected := map[string]string{
 		"integration_branch_refinery_enabled": "true",
@@ -134,6 +135,8 @@ func TestBuildRefineryPatrolVars_FullConfig(t *testing.T) {
 		"run_tests":                           "true",
 		"target_branch":                       "main",
 		"delete_merged_branches":              "true",
+		"judgment_enabled":                    "false",
+		"review_depth":                        "standard",
 	}
 
 	varMap := make(map[string]string)


### PR DESCRIPTION
Fixes #3199

## Summary

PR #3194 added `judgment_enabled` and `review_depth` to `buildRefineryPatrolVars` but didn't update the test expectations in `patrol_helpers_test.go`. The test expected 5 vars from `DefaultMergeQueueConfig()` but now gets 7, breaking CI on every PR rebased onto current `main`.

## Fix

Add the two new default values to the `expected` map in `TestBuildRefineryPatrolVars_FullConfig`:
- `judgment_enabled` = `"false"` (default from `IsJudgmentEnabled()`)
- `review_depth` = `"standard"` (default from `GetReviewDepth()`)

## Test plan

- `go test ./internal/cmd/ -run TestBuildRefineryPatrolVars_FullConfig` passes locally

Made with [Cursor](https://cursor.com)