### PR TITLE
fix: push polecat branch before signaling completion — prevent work loss (gas-556)

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -54,6 +54,7 @@ type AgentFields struct {
 	MRID           string // MR bead ID (if MR was created)
 	Branch         string // Polecat working branch name
 	MRFailed       bool   // True when MR creation was attempted but failed
+	PushFailed     bool   // True when branch push to origin failed (gas-556)
 	CompletionTime string // RFC3339 timestamp of when gt done was called
 }
 
@@ -126,6 +127,9 @@ func FormatAgentDescription(title string, fields *AgentFields) string {
 	if fields.MRFailed {
 		lines = append(lines, "mr_failed: true")
 	}
+	if fields.PushFailed {
+		lines = append(lines, "push_failed: true")
+	}
 	if fields.CompletionTime != "" {
 		lines = append(lines, fmt.Sprintf("completion_time: %s", fields.CompletionTime))
 	}
@@ -180,6 +184,8 @@ func ParseAgentFields(description string) *AgentFields {
 			fields.Branch = value
 		case "mr_failed":
 			fields.MRFailed = value == "true"
+		case "push_failed":
+			fields.PushFailed = value == "true"
 		case "completion_time":
 			fields.CompletionTime = value
 		}
@@ -456,6 +462,7 @@ type AgentFieldUpdates struct {
 	MRID           *string
 	Branch         *string
 	MRFailed       *bool
+	PushFailed     *bool // True when branch push to origin failed (gas-556)
 	CompletionTime *string
 }
 
@@ -516,6 +523,9 @@ func (b *Beads) UpdateAgentDescriptionFields(id string, updates AgentFieldUpdate
 	if updates.MRFailed != nil {
 		fields.MRFailed = *updates.MRFailed
 	}
+	if updates.PushFailed != nil {
+		fields.PushFailed = *updates.PushFailed
+	}
 	if updates.CompletionTime != nil {
 		fields.CompletionTime = *updates.CompletionTime
 	}
@@ -555,6 +565,7 @@ type CompletionMetadata struct {
 	Branch         string // Polecat working branch
 	HookBead       string // The work bead ID
 	MRFailed       bool   // True when MR creation was attempted but failed
+	PushFailed     bool   // True when branch push to origin failed (gas-556)
 	CompletionTime string // RFC3339 timestamp
 }
 
@@ -562,11 +573,13 @@ type CompletionMetadata struct {
 // to an agent bead. Called by gt done to record completion state.
 func (b *Beads) UpdateAgentCompletion(id string, meta *CompletionMetadata) error {
 	mrFailed := meta.MRFailed
+	pushFailed := meta.PushFailed
 	return b.UpdateAgentDescriptionFields(id, AgentFieldUpdates{
 		ExitType:       &meta.ExitType,
 		MRID:           &meta.MRID,
 		Branch:         &meta.Branch,
 		MRFailed:       &mrFailed,
+		PushFailed:     &pushFailed,
 		CompletionTime: &meta.CompletionTime,
 	})
 }
@@ -581,6 +594,7 @@ func (b *Beads) ClearAgentCompletion(id string) error {
 		MRID:           &empty,
 		Branch:         &empty,
 		MRFailed:       &notFailed,
+		PushFailed:     &notFailed,
 		CompletionTime: &empty,
 	})
 }

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -1059,6 +1059,7 @@ notifyWitness:
 			Branch:         branch,
 			HookBead:       issueID,
 			MRFailed:       mrFailed,
+			PushFailed:     pushFailed,
 			CompletionTime: time.Now().UTC().Format(time.RFC3339),
 		}
 		if err := completionBd.UpdateAgentCompletion(agentBeadID, meta); err != nil {

--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -126,7 +126,8 @@ func TestBuildRefineryPatrolVars_FullConfig(t *testing.T) {
 	vars := buildRefineryPatrolVars(ctx)
 
 	// DefaultMergeQueueConfig: refinery_enabled=true, auto_land=false, run_tests=true,
-	// test_command="" (language-agnostic), target_branch="main" (from rig config), delete_merged_branches=true
+	// test_command="" (language-agnostic), target_branch="main" (from rig config),
+	// delete_merged_branches=true, judgment_enabled=false, review_depth="standard"
 	// New commands (setup, typecheck, lint, build) default to empty = omitted
 	expected := map[string]string{
 		"integration_branch_refinery_enabled": "true",
@@ -134,6 +135,8 @@ func TestBuildRefineryPatrolVars_FullConfig(t *testing.T) {
 		"run_tests":                           "true",
 		"target_branch":                       "main",
 		"delete_merged_branches":              "true",
+		"judgment_enabled":                    "false",
+		"review_depth":                        "standard",
 	}
 
 	varMap := make(map[string]string)

--- a/internal/refinery/batch.go
+++ b/internal/refinery/batch.go
@@ -120,7 +120,9 @@ func (e *Engineer) BuildRebaseStack(ctx context.Context, batch []*MRInfo, target
 		// Check branch exists
 		exists, brErr := e.git.BranchExists(mr.Branch)
 		if brErr != nil || !exists {
-			_, _ = fmt.Fprintf(e.output, "[Batch] MR %s: branch %s not found, skipping\n", mr.ID, mr.Branch)
+			// Branch not found — escalate to mayor (gas-556)
+			_, _ = fmt.Fprintf(e.output, "[Batch] MR %s: branch %s not found, escalating to mayor\n", mr.ID, mr.Branch)
+			e.HandleMRInfoFailure(mr, ProcessResult{BranchNotFound: true})
 			conflicts = append(conflicts, mr)
 			continue
 		}
@@ -299,9 +301,8 @@ func (e *Engineer) processSingleMR(ctx context.Context, mr *MRInfo, target strin
 	} else if processResult.TestsFailed {
 		result.Culprits = []*MRInfo{mr}
 	} else if processResult.BranchNotFound {
-		// Branch was cleaned up before we could process it (e.g. cherry-picked to target).
-		// Treat as a skip: log and move on rather than halting the queue.
-		_, _ = fmt.Fprintf(e.output, "[Batch] MR %s: branch %s not found, skipping\n", mr.ID, mr.Branch)
+		// Branch not found on remote — escalate to mayor via HandleMRInfoFailure (gas-556).
+		e.HandleMRInfoFailure(mr, processResult)
 		result.Conflicts = []*MRInfo{mr}
 	} else if processResult.NoMerge {
 		// Source issue has no_merge flag — intentionally blocked. Dequeue silently.

--- a/internal/refinery/batch_test.go
+++ b/internal/refinery/batch_test.go
@@ -855,10 +855,10 @@ func TestProcessBatch_SingleMR_BranchNotFound(t *testing.T) {
 	if len(result.Conflicts) != 1 || result.Conflicts[0].ID != "mr-gone" {
 		t.Errorf("expected mr-gone in conflicts (skipped), got %v", stackedIDs(result.Conflicts))
 	}
-	// Verify the log message says "skipping" not "fatal".
+	// Verify the log message indicates the branch was not found (escalating, not fatal).
 	log := e.output.(*bytes.Buffer).String()
-	if !strings.Contains(log, "skipping") {
-		t.Errorf("expected 'skipping' in log output, got: %s", log)
+	if !strings.Contains(log, "not found") {
+		t.Errorf("expected 'not found' in log output, got: %s", log)
 	}
 }
 

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -1118,10 +1118,19 @@ func (e *Engineer) HandleMRInfoFailure(mr *MRInfo, result ProcessResult) {
 		return
 	}
 
-	// Branch-not-found means the remote branch was cleaned up before we could process it
-	// (e.g. cherry-picked to target directly). Skip polecat nudge — the polecat is gone.
+	// Branch-not-found: the remote branch doesn't exist. This can mean either
+	// the branch was cleanly cherry-picked to target, OR the polecat's work was
+	// lost (e.g., worktree in /tmp wiped by reboot before gt done pushed).
+	// Escalate to mayor so lost work can be re-dispatched (gas-556).
 	if result.BranchNotFound {
-		_, _ = fmt.Fprintf(e.output, "[Engineer] MR %s: branch %s no longer exists, skipping (queue continues)\n", mr.ID, mr.Branch)
+		_, _ = fmt.Fprintf(e.output, "[Engineer] MR %s: branch %s not found on remote — escalating to mayor (possible work loss)\n", mr.ID, mr.Branch)
+		mayorMsg := fmt.Sprintf("BRANCH_MISSING: MR %s branch=%s issue=%s worker=%s — branch not on origin, work may be lost; re-dispatch if needed",
+			mr.ID, mr.Branch, mr.SourceIssue, mr.Worker)
+		mayorCmd := exec.Command("gt", "nudge", "mayor/", mayorMsg)
+		mayorCmd.Dir = e.workDir
+		if err := mayorCmd.Run(); err != nil {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to nudge mayor about missing branch: %v\n", err)
+		}
 		return
 	}
 

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -196,11 +196,30 @@ func HandlePolecatDoneFromBead(bd *BdCli, workDir, rigName, polecatName string, 
 		MRID:        fields.MRID,
 		Branch:      fields.Branch,
 		MRFailed:    fields.MRFailed,
+		PushFailed:  fields.PushFailed,
 	}
 
 	if payload.Exit == "PHASE_COMPLETE" {
 		result.Handled = true
 		result.Action = fmt.Sprintf("phase-complete for %s - session recycled, awaiting gate", polecatName)
+		return result
+	}
+
+	// Push failed: branch never reached origin (gas-556). Report recovery needed.
+	if payload.PushFailed {
+		result.Handled = true
+		result.Action = fmt.Sprintf("push-failed-recovery-needed for %s (branch=%s issue=%s) — branch not on origin, worktree may be at risk",
+			polecatName, payload.Branch, payload.IssueID)
+		townRoot, _ := workspace.Find(workDir)
+		if townRoot != "" {
+			mayorMsg := fmt.Sprintf("PUSH_FAILED: polecat=%s branch=%s issue=%s — branch not on origin, possible work loss",
+				polecatName, payload.Branch, payload.IssueID)
+			mayorSession := session.MayorSessionName()
+			t := tmux.NewTmux()
+			if running, err := t.HasSession(mayorSession); err == nil && running {
+				_ = t.NudgeSession(mayorSession, mayorMsg)
+			}
+		}
 		return result
 	}
 
@@ -1619,6 +1638,7 @@ type CompletionDiscovery struct {
 	MRID           string
 	Branch         string
 	MRFailed       bool
+	PushFailed     bool   // True when branch push to origin failed (gas-556)
 	CompletionTime string
 	Action         string // What was done: "merge-ready-sent", "acknowledged-idle", "phase-complete"
 	WispCreated    string // ID of cleanup wisp if created
@@ -1688,6 +1708,7 @@ func DiscoverCompletions(bd *BdCli, workDir, rigName string, router *mail.Router
 			MRID:           fields.MRID,
 			Branch:         fields.Branch,
 			MRFailed:       fields.MRFailed,
+			PushFailed:     fields.PushFailed,
 			CompletionTime: fields.CompletionTime,
 		}
 
@@ -1699,6 +1720,7 @@ func DiscoverCompletions(bd *BdCli, workDir, rigName string, router *mail.Router
 			MRID:        fields.MRID,
 			Branch:      fields.Branch,
 			MRFailed:    fields.MRFailed,
+			PushFailed:  fields.PushFailed,
 		}
 
 		// Route based on exit type and MR presence
@@ -1722,6 +1744,26 @@ func DiscoverCompletions(bd *BdCli, workDir, rigName string, router *mail.Router
 func processDiscoveredCompletion(bd *BdCli, workDir, rigName string, payload *PolecatDonePayload, discovery *CompletionDiscovery) {
 	if payload.Exit == string(ExitTypePhaseComplete) {
 		discovery.Action = "phase-complete"
+		return
+	}
+
+	// Push failed: branch never reached origin. Work is committed locally only.
+	// The polecat's worktree may be in /tmp and lost on reboot. Escalate so the
+	// witness agent can investigate and trigger recovery (gas-556).
+	if payload.PushFailed {
+		discovery.Action = fmt.Sprintf("push-failed-recovery-needed (branch=%s issue=%s) — branch not on origin, worktree may be at risk",
+			payload.Branch, payload.IssueID)
+		// Notify mayor so a new polecat can be dispatched if work is lost.
+		townRoot, _ := workspace.Find(workDir)
+		if townRoot != "" {
+			mayorMsg := fmt.Sprintf("PUSH_FAILED: polecat=%s branch=%s issue=%s — branch not on origin, possible work loss",
+				payload.PolecatName, payload.Branch, payload.IssueID)
+			mayorSession := session.MayorSessionName()
+			t := tmux.NewTmux()
+			if running, err := t.HasSession(mayorSession); err == nil && running {
+				_ = t.NudgeSession(mayorSession, mayorMsg)
+			}
+		}
 		return
 	}
 

--- a/internal/witness/protocol.go
+++ b/internal/witness/protocol.go
@@ -106,6 +106,7 @@ type PolecatDonePayload struct {
 	Branch      string
 	Gate        string // Gate ID when Exit is PHASE_COMPLETE
 	MRFailed    bool   // True when MR bead creation was attempted but failed
+	PushFailed  bool   // True when branch push to origin failed (gas-556)
 }
 
 // HelpCategory classifies the nature of a help request for routing.


### PR DESCRIPTION
## Summary
- `gt done` now pushes the polecat branch to origin before marking work complete
- Refinery verifies the branch exists before attempting merge, escalates if missing
- Witness handles `BRANCH_NOT_FOUND` lifecycle events

Fixes gas-556 — polecats in `/tmp` worktrees were completing work that was never pushed, causing silent work loss when `/tmp` was cleaned up.

Fix-merge of #3201.

Co-Authored-By: obsidian <jim@wordelman.name>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Test plan
- [x] `go build ./...` compiles clean
- [x] Existing tests pass
- [ ] Verify polecat sling → work → gt done → refinery merge flow preserves branches