### PR TITLE
feat: add push_strategy config — fork push + GitHub PR workflow (gas-ddg)

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -382,6 +383,12 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		defaultBranch = rigCfg.DefaultBranch
 	}
 
+	// Load push strategy from town settings (empty = default MR workflow).
+	pushStrategy := ""
+	if townSettings, err := config.LoadOrCreateTownSettings(config.TownSettingsPath(townRoot)); err == nil {
+		pushStrategy = townSettings.PushStrategy
+	}
+
 	// For COMPLETED, we need an issue ID and branch must not be the default branch
 	var mrID string
 	var pushFailed bool
@@ -599,6 +606,21 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				}
 			}
 
+			goto notifyWitness
+		}
+
+		// Handle "fork" push strategy: push to fork remote, create GitHub PR via gh CLI.
+		// Used by contributor workflows where polecats lack push access to origin.
+		// The fork remote must be configured before gt done runs (gt sling sets it up).
+		if pushStrategy == config.PushStrategyFork {
+			fmt.Printf("%s Fork push strategy: pushing to fork remote and creating GitHub PR\n", style.Bold.Render("→"))
+			forkPushErr := runForkPushStrategy(g, branch, defaultBranch, issueID)
+			if forkPushErr != nil {
+				pushFailed = true
+				errMsg := fmt.Sprintf("fork push strategy failed: %v", forkPushErr)
+				doneErrors = append(doneErrors, errMsg)
+				style.PrintWarning("%s\nFork push or PR creation failed. Witness will be notified.", errMsg)
+			}
 			goto notifyWitness
 		}
 
@@ -1182,6 +1204,87 @@ func pushSubmoduleChanges(g *git.Git, defaultBranch string) {
 			fmt.Printf("%s Submodule %s pushed\n", style.Bold.Render("✓"), sc.Path)
 		}
 	}
+}
+
+// runForkPushStrategy pushes the branch to the fork remote and creates a GitHub PR.
+// Used when push_strategy: fork is configured in town settings. This is the contributor
+// workflow: the polecat lacks push access to origin, so it pushes to its fork and
+// opens a PR for maintainer review.
+//
+// The fork remote must be pre-configured in the worktree (gt sling sets it up).
+// If the remote doesn't exist, this function attempts to create it via gh repo fork.
+func runForkPushStrategy(g *git.Git, branch, defaultBranch, issueID string) error {
+	const forkRemote = "fork"
+
+	// Ensure the fork remote exists. If not, create it via gh repo fork.
+	remotes, err := g.Remotes()
+	if err != nil {
+		return fmt.Errorf("listing remotes: %w", err)
+	}
+	hasForkRemote := false
+	for _, r := range remotes {
+		if r == forkRemote {
+			hasForkRemote = true
+			break
+		}
+	}
+
+	if !hasForkRemote {
+		fmt.Printf("Fork remote not found — creating fork via gh...\n")
+		forkCmd := exec.Command("gh", "repo", "fork", "--clone=false", "--remote", "--remote-name=fork")
+		forkCmd.Stdout = os.Stdout
+		forkCmd.Stderr = os.Stderr
+		if forkErr := forkCmd.Run(); forkErr != nil {
+			return fmt.Errorf("gh repo fork failed: %w\n"+
+				"Ensure gh CLI is authenticated (gh auth status) and the origin remote is a GitHub repo.\n"+
+				"Alternatively, manually add a 'fork' remote: git remote add fork <your-fork-url>", forkErr)
+		}
+		fmt.Printf("%s Fork remote created\n", style.Bold.Render("✓"))
+	}
+
+	// Push branch to fork remote.
+	refspec := branch + ":" + branch
+	fmt.Printf("Pushing branch to fork remote...\n")
+	if pushErr := g.Push(forkRemote, refspec, false); pushErr != nil {
+		return fmt.Errorf("push to fork remote failed: %w", pushErr)
+	}
+	fmt.Printf("%s Branch pushed to fork\n", style.Bold.Render("✓"))
+
+	// Build PR title from issue ID if available.
+	prTitle := fmt.Sprintf("Work: %s", branch)
+	if issueID != "" {
+		prTitle = fmt.Sprintf("Work: %s (%s)", branch, issueID)
+	}
+
+	// Resolve fork owner for the --head flag (GitHub PRs from forks require owner:branch format).
+	headRef := branch
+	if ownerOut, ownerErr := exec.Command("gh", "api", "user", "-q", ".login").Output(); ownerErr == nil {
+		owner := strings.TrimSpace(string(ownerOut))
+		if owner != "" {
+			headRef = owner + ":" + branch
+		}
+	}
+
+	// Create GitHub PR via gh CLI.
+	fmt.Printf("Creating GitHub PR...\n")
+	prArgs := []string{
+		"pr", "create",
+		"--base", defaultBranch,
+		"--head", headRef,
+		"--title", prTitle,
+		"--body", fmt.Sprintf("Automated PR from polecat.\n\nIssue: %s\nBranch: %s", issueID, branch),
+	}
+	prCmd := exec.Command("gh", prArgs...)
+	prCmd.Stdout = os.Stdout
+	prCmd.Stderr = os.Stderr
+	if prErr := prCmd.Run(); prErr != nil {
+		return fmt.Errorf("gh pr create failed: %v\n"+
+			"The branch was pushed to the fork remote successfully.\n"+
+			"You can create the PR manually: gh pr create --base %s --head %s", prErr, defaultBranch, headRef)
+	}
+	fmt.Printf("%s GitHub PR created\n", style.Bold.Render("✓"))
+
+	return nil
 }
 
 // setDoneIntentLabel writes a done-intent:<type>:<unix-ts> label on the agent bead

--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -126,7 +126,8 @@ func TestBuildRefineryPatrolVars_FullConfig(t *testing.T) {
 	vars := buildRefineryPatrolVars(ctx)
 
 	// DefaultMergeQueueConfig: refinery_enabled=true, auto_land=false, run_tests=true,
-	// test_command="" (language-agnostic), target_branch="main" (from rig config), delete_merged_branches=true
+	// test_command="" (language-agnostic), target_branch="main" (from rig config),
+	// delete_merged_branches=true, judgment_enabled=false, review_depth="standard"
 	// New commands (setup, typecheck, lint, build) default to empty = omitted
 	expected := map[string]string{
 		"integration_branch_refinery_enabled": "true",
@@ -134,6 +135,8 @@ func TestBuildRefineryPatrolVars_FullConfig(t *testing.T) {
 		"run_tests":                           "true",
 		"target_branch":                       "main",
 		"delete_merged_branches":              "true",
+		"judgment_enabled":                    "false",
+		"review_depth":                        "standard",
 	}
 
 	varMap := make(map[string]string)

--- a/internal/cmd/tap_guard.go
+++ b/internal/cmd/tap_guard.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/workspace"
 )
 
 var tapGuardCmd = &cobra.Command{
@@ -67,6 +70,12 @@ func init() {
 }
 
 func runTapGuardPRWorkflow(cmd *cobra.Command, args []string) error {
+	// Allow PR creation when push_strategy: fork is configured.
+	// This is the contributor workflow where polecats push to a fork and create PRs.
+	if isPushStrategyFork() {
+		return nil // Allowed — fork PR workflow
+	}
+
 	// Check if we're in a Gas Town agent context
 	if isGasTownAgentContext() {
 		fmt.Fprintln(os.Stderr, "")
@@ -136,6 +145,21 @@ func isGasTownAgentContext() bool {
 	}
 
 	return false
+}
+
+// isPushStrategyFork returns true if push_strategy: fork is configured in town settings.
+// When true, polecats are allowed to use gh pr create as part of their submission workflow.
+func isPushStrategyFork() bool {
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return false
+	}
+	settingsPath := filepath.Join(townRoot, "settings", "config.json")
+	settings, err := config.LoadOrCreateTownSettings(settingsPath)
+	if err != nil {
+		return false
+	}
+	return settings.PushStrategy == config.PushStrategyFork
 }
 
 // isMaintainerOrigin returns true if the origin remote points to the maintainer's repo.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -112,7 +112,23 @@ type TownSettings struct {
 	// "main_branch_test", "handler").
 	// Example: ["doctor_dog", "compactor_dog"]
 	DisabledPatrols []string `json:"disabled_patrols,omitempty"`
+
+	// PushStrategy controls how polecats push branches and submit work.
+	// Values:
+	//   ""       - default: push to origin, create internal MR bead for Refinery
+	//   "fork"   - push to fork remote, create GitHub PR via gh CLI, never attempt origin
+	//
+	// Use "fork" for contributor workflows where polecats lack push access to origin.
+	// The fork remote must be configured before gt done runs (gt sling sets it up).
+	PushStrategy string `json:"push_strategy,omitempty"`
 }
+
+// Push strategy constants.
+const (
+	// PushStrategyFork pushes to the fork remote and creates a GitHub PR instead of
+	// pushing to origin and creating an internal MR bead.
+	PushStrategyFork = "fork"
+)
 
 // NewTownSettings creates a new TownSettings with defaults.
 func NewTownSettings() *TownSettings {

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -790,6 +790,13 @@ func (m *Manager) addWithOptionsLocked(name string, opts AddOptions, polecatDir 
 		style.PrintWarning("could not run setup hooks: %v", err)
 	}
 
+	// If push_strategy: fork is configured, set up the fork remote in the worktree.
+	// This ensures gt done can push to the fork remote without creating it on the fly.
+	if townSettings, tsErr := config.LoadOrCreateTownSettings(config.TownSettingsPath(townRoot)); tsErr == nil &&
+		townSettings.PushStrategy == config.PushStrategyFork {
+		setupForkRemoteInWorktree(clonePath)
+	}
+
 	agentID := m.agentBeadID(name)
 	if err = m.createAgentBeadWithRetry(agentID, &beads.AgentFields{
 		RoleType:   "polecat",
@@ -813,6 +820,33 @@ func (m *Manager) addWithOptionsLocked(name string, opts AddOptions, polecatDir 
 	}
 
 	return polecat, nil
+}
+
+// setupForkRemoteInWorktree configures the fork remote in the polecat worktree.
+// When push_strategy: fork is set, polecats push to the fork remote instead of origin.
+// This function is non-fatal: if gh repo fork fails, gt done will retry it.
+func setupForkRemoteInWorktree(clonePath string) {
+	worktreeGit := git.NewGit(clonePath)
+	remotes, err := worktreeGit.Remotes()
+	if err != nil {
+		style.PrintWarning("could not list remotes in worktree: %v", err)
+		return
+	}
+	for _, r := range remotes {
+		if r == "fork" {
+			return // Fork remote already configured
+		}
+	}
+
+	// Add fork remote via gh repo fork (--clone=false avoids re-cloning into a new dir).
+	forkCmd := exec.Command("gh", "repo", "fork", "--clone=false", "--remote", "--remote-name=fork")
+	forkCmd.Dir = clonePath
+	if out, forkErr := forkCmd.CombinedOutput(); forkErr != nil {
+		// Non-fatal: gt done will retry if the remote is missing.
+		style.PrintWarning("could not set up fork remote (will retry at gt done time): %s", strings.TrimSpace(string(out)))
+		return
+	}
+	fmt.Printf("   ✓ Fork remote configured (push_strategy: fork)\n")
 }
 
 // AddWithOptions creates a new polecat with the specified options.
@@ -981,6 +1015,13 @@ func (m *Manager) AddWithOptions(name string, opts AddOptions) (_ *Polecat, retE
 	if err := rig.RunSetupHooks(m.rig.Path, clonePath); err != nil {
 		// Non-fatal - log warning but continue
 		style.PrintWarning("could not run setup hooks: %v", err)
+	}
+
+	// If push_strategy: fork is configured, set up the fork remote in the worktree.
+	// This ensures gt done can push to the fork remote without creating it on the fly.
+	if townSettings, tsErr := config.LoadOrCreateTownSettings(config.TownSettingsPath(townRoot)); tsErr == nil &&
+		townSettings.PushStrategy == config.PushStrategyFork {
+		setupForkRemoteInWorktree(clonePath)
 	}
 
 	// NOTE: Slash commands (.claude/commands/) are provisioned at town level by gt install.


### PR DESCRIPTION
## Summary
Adds `push_strategy: fork` to `TownSettings` so polecats can push to a fork remote and create GitHub PRs instead of pushing to origin.

- `internal/config/types.go`: Add `PushStrategy` field + `PushStrategyFork` constant
- `internal/cmd/done.go`: Add `runForkPushStrategy()` — sets up fork remote, pushes branch, creates PR via `gh pr create`
- `internal/polecat/manager.go`: Add `setupForkRemoteInWorktree()` helper at spawn time
- `internal/cmd/tap_guard.go`: Allow `gh pr create` when fork strategy configured

Enables community contributor workflow where polecats lack push access to origin.

Fix-merge of #3152. Conflict resolved: merged alongside `disabled_patrols` field from #3151.

Co-Authored-By: obsidian <jim@wordelman.name>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Test plan
- [x] `go build ./...` compiles clean
- [ ] Config tests pass
- [ ] End-to-end: `push_strategy: fork` → `gt done` → fork push + PR creation