### PR TITLE
fix: make hooks sync support non-Claude agents (GH#3080)

### DIFF
--- a/internal/cmd/hooks_sync.go
+++ b/internal/cmd/hooks_sync.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/hooks"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/workspace"
@@ -16,18 +17,23 @@ var hooksSyncDryRun bool
 
 var hooksSyncCmd = &cobra.Command{
 	Use:   "sync",
-	Short: "Regenerate all .claude/settings.json files",
-	Long: `Regenerate all .claude/settings.json files from the base config and overrides.
+	Short: "Regenerate all agent hook/settings files",
+	Long: `Regenerate hook and settings files for all agents across the workspace.
 
-For each target (mayor, deacon, rig/crew, rig/witness, etc.):
+For Claude agents (settings.json merge):
 1. Load base config
 2. Apply role override (if exists)
 3. Apply rig+role override (if exists)
 4. Merge hooks section into existing settings.json (preserving all fields)
 5. Write updated settings.json
 
+For template-based agents (OpenCode, Gemini, Copilot, etc.):
+1. Resolve the agent configured for each role
+2. Compare deployed hook file against current template
+3. Overwrite if content differs
+
 Examples:
-  gt hooks sync             # Regenerate all settings.json files
+  gt hooks sync             # Regenerate all hook/settings files
   gt hooks sync --dry-run   # Show what would change without writing`,
 	RunE: runHooksSync,
 }
@@ -105,6 +111,84 @@ func runHooksSync(cmd *cobra.Command, args []string) error {
 		case syncUnchanged:
 			fmt.Printf("  %s %s %s\n", style.Dim.Render("·"), relPath, style.Dim.Render("(unchanged)"))
 			unchanged++
+		}
+	}
+
+	// Sync template-based (non-Claude) agents at each role location.
+	// These agents use SyncForRole (content-aware comparison) instead of the
+	// JSON merge path used for Claude targets above.
+	locations, locErr := hooks.DiscoverRoleLocations(townRoot)
+	if locErr != nil {
+		fmt.Printf("  %s discovering role locations: %v\n", style.Error.Render("✖"), locErr)
+		errors++
+	} else {
+		for _, loc := range locations {
+			rigPath := ""
+			if loc.Rig != "" {
+				rigPath = filepath.Join(townRoot, loc.Rig)
+			}
+			rc := config.ResolveRoleAgentConfig(loc.Role, townRoot, rigPath)
+			if rc == nil || rc.Hooks == nil || rc.Hooks.Provider == "" {
+				continue
+			}
+			// Claude targets are already handled by DiscoverTargets + syncTarget above.
+			if rc.Hooks.Provider == "claude" {
+				continue
+			}
+
+			preset := config.GetAgentPresetByName(rc.Hooks.Provider)
+			useSettingsDir := preset != nil && preset.HooksUseSettingsDir
+
+			// Determine sync targets.
+			// - Town-level roles (mayor, deacon): the role dir IS the working directory.
+			// - Rig roles with useSettingsDir: one shared file in the role parent.
+			// - Rig roles without useSettingsDir (OpenCode, etc.): need files in each
+			//   individual worktree subdirectory.
+			var syncDirs []string
+			if loc.Rig == "" || useSettingsDir {
+				syncDirs = []string{loc.Dir}
+			} else {
+				syncDirs = hooks.DiscoverWorktrees(loc.Dir)
+			}
+
+			for _, dir := range syncDirs {
+				targetPath := filepath.Join(dir, rc.Hooks.Dir, rc.Hooks.SettingsFile)
+				relPath, pathErr := filepath.Rel(townRoot, targetPath)
+				if pathErr != nil {
+					relPath = targetPath
+				}
+
+				if hooksSyncDryRun {
+					if _, statErr := os.Stat(targetPath); statErr == nil {
+						fmt.Printf("  %s %s %s\n", style.Warning.Render("~"), relPath, style.Dim.Render("(would check "+rc.Hooks.Provider+")"))
+					} else {
+						fmt.Printf("  %s %s %s\n", style.Warning.Render("~"), relPath, style.Dim.Render("(would create "+rc.Hooks.Provider+")"))
+						created++
+					}
+					continue
+				}
+
+				result, syncErr := hooks.SyncForRole(rc.Hooks.Provider, dir, dir, loc.Role,
+					rc.Hooks.Dir, rc.Hooks.SettingsFile, useSettingsDir)
+				if syncErr != nil {
+					fmt.Printf("  %s %s (%s): %v\n", style.Error.Render("✖"), relPath, rc.Hooks.Provider, syncErr)
+					errors++
+					failedTargets = append(failedTargets, relPath)
+					continue
+				}
+
+				switch result {
+				case hooks.SyncCreated:
+					fmt.Printf("  %s %s %s\n", style.Success.Render("✓"), relPath, style.Dim.Render("(created "+rc.Hooks.Provider+")"))
+					created++
+				case hooks.SyncUpdated:
+					fmt.Printf("  %s %s %s\n", style.Success.Render("✓"), relPath, style.Dim.Render("(updated "+rc.Hooks.Provider+")"))
+					updated++
+				case hooks.SyncUnchanged:
+					fmt.Printf("  %s %s %s\n", style.Dim.Render("·"), relPath, style.Dim.Render("(unchanged "+rc.Hooks.Provider+")"))
+					unchanged++
+				}
+			}
 		}
 	}
 

--- a/internal/cmd/hooks_sync_test.go
+++ b/internal/cmd/hooks_sync_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/hooks"
 )
 
@@ -295,5 +296,143 @@ func TestRunHooksSyncFailsClosedOnIntegrityViolation(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "failed closed") {
 		t.Fatalf("expected fail-closed error, got: %v", err)
+	}
+}
+
+func TestRunHooksSyncNonClaudeAgent(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	townRoot := filepath.Join(tmpDir, "town")
+
+	// Scaffold workspace: mayor, deacon, and a rig with a crew worktree
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "deacon"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "myrig", "crew", "alice"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Workspace marker
+	if err := os.WriteFile(
+		filepath.Join(townRoot, "mayor", "town.json"),
+		[]byte(`{"type":"town","version":1,"name":"test"}`),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Configure crew role to use opencode
+	townSettings := config.NewTownSettings()
+	townSettings.RoleAgents = map[string]string{"crew": "opencode"}
+	settingsDir := filepath.Join(townRoot, "settings")
+	if err := os.MkdirAll(settingsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveTownSettings(config.TownSettingsPath(townRoot), townSettings); err != nil {
+		t.Fatal(err)
+	}
+
+	// Base hooks config (needed for Claude targets to not error)
+	base := &hooks.HooksConfig{
+		SessionStart: []hooks.HookEntry{
+			{Matcher: "", Hooks: []hooks.Hook{{Type: "command", Command: "echo test"}}},
+		},
+	}
+	if err := hooks.SaveBase(base); err != nil {
+		t.Fatalf("SaveBase failed: %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	hooksSyncDryRun = false
+	if err := runHooksSync(nil, nil); err != nil {
+		t.Fatalf("runHooksSync failed: %v", err)
+	}
+
+	// Verify OpenCode plugin was synced to the worktree (not the parent)
+	pluginPath := filepath.Join(townRoot, "myrig", "crew", "alice", ".opencode", "plugins", "gastown.js")
+	if _, err := os.Stat(pluginPath); os.IsNotExist(err) {
+		t.Error("opencode plugin not created in worktree alice")
+	}
+
+	// Verify it was NOT created in the parent (crew/) since useSettingsDir=false
+	parentPlugin := filepath.Join(townRoot, "myrig", "crew", ".opencode", "plugins", "gastown.js")
+	if _, err := os.Stat(parentPlugin); !os.IsNotExist(err) {
+		t.Error("opencode plugin should not be in the parent crew/ directory")
+	}
+}
+
+func TestRunHooksSyncNonClaudeAgentDryRun(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	townRoot := filepath.Join(tmpDir, "town")
+
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "deacon"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "myrig", "crew", "alice"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(
+		filepath.Join(townRoot, "mayor", "town.json"),
+		[]byte(`{"type":"town","version":1,"name":"test"}`),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	townSettings := config.NewTownSettings()
+	townSettings.RoleAgents = map[string]string{"crew": "opencode"}
+	if err := os.MkdirAll(filepath.Join(townRoot, "settings"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveTownSettings(config.TownSettingsPath(townRoot), townSettings); err != nil {
+		t.Fatal(err)
+	}
+
+	base := &hooks.HooksConfig{
+		SessionStart: []hooks.HookEntry{
+			{Matcher: "", Hooks: []hooks.Hook{{Type: "command", Command: "echo test"}}},
+		},
+	}
+	if err := hooks.SaveBase(base); err != nil {
+		t.Fatalf("SaveBase failed: %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	hooksSyncDryRun = true
+	defer func() { hooksSyncDryRun = false }()
+	if err := runHooksSync(nil, nil); err != nil {
+		t.Fatalf("runHooksSync dry-run failed: %v", err)
+	}
+
+	// Dry run should NOT create the file
+	pluginPath := filepath.Join(townRoot, "myrig", "crew", "alice", ".opencode", "plugins", "gastown.js")
+	if _, err := os.Stat(pluginPath); !os.IsNotExist(err) {
+		t.Error("dry-run should not create opencode plugin file")
 	}
 }

--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -126,7 +126,8 @@ func TestBuildRefineryPatrolVars_FullConfig(t *testing.T) {
 	vars := buildRefineryPatrolVars(ctx)
 
 	// DefaultMergeQueueConfig: refinery_enabled=true, auto_land=false, run_tests=true,
-	// test_command="" (language-agnostic), target_branch="main" (from rig config), delete_merged_branches=true
+	// test_command="" (language-agnostic), target_branch="main" (from rig config),
+	// delete_merged_branches=true, judgment_enabled=false, review_depth="standard"
 	// New commands (setup, typecheck, lint, build) default to empty = omitted
 	expected := map[string]string{
 		"integration_branch_refinery_enabled": "true",
@@ -134,6 +135,8 @@ func TestBuildRefineryPatrolVars_FullConfig(t *testing.T) {
 		"run_tests":                           "true",
 		"target_branch":                       "main",
 		"delete_merged_branches":              "true",
+		"judgment_enabled":                    "false",
+		"review_depth":                        "standard",
 	}
 
 	varMap := make(map[string]string)

--- a/internal/doctor/hooks_sync_check.go
+++ b/internal/doctor/hooks_sync_check.go
@@ -1,18 +1,32 @@
 package doctor
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/hooks"
 )
 
-// HooksSyncCheck verifies all settings.json files match what gt hooks sync would generate.
+// templateTarget tracks a non-Claude template-based agent file that is out of sync.
+type templateTarget struct {
+	path           string
+	dir            string
+	provider       string
+	role           string
+	hooksDir       string
+	settingsFile   string
+	useSettingsDir bool
+}
+
+// HooksSyncCheck verifies all hook/settings files match what gt hooks sync would generate.
 type HooksSyncCheck struct {
 	FixableCheck
-	outOfSync []hooks.Target
+	outOfSync         []hooks.Target   // Claude targets
+	templateOutOfSync []templateTarget // Non-Claude template-based targets
 }
 
 // NewHooksSyncCheck creates a new hooks sync validation check.
@@ -28,10 +42,15 @@ func NewHooksSyncCheck() *HooksSyncCheck {
 	}
 }
 
-// Run checks all managed settings.json files for sync status.
+// Run checks all managed hook/settings files for sync status.
 func (c *HooksSyncCheck) Run(ctx *CheckContext) *CheckResult {
 	c.outOfSync = nil
+	c.templateOutOfSync = nil
 
+	var details []string
+	totalTargets := 0
+
+	// Loop 1: Claude targets — use base+override merge system via DiscoverTargets.
 	targets, err := hooks.DiscoverTargets(ctx.TownRoot)
 	if err != nil {
 		return &CheckResult{
@@ -42,16 +61,9 @@ func (c *HooksSyncCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
-	var details []string
 	for _, target := range targets {
-		if target.Provider == "gemini" {
-			if detail := c.checkGeminiTarget(target); detail != "" {
-				details = append(details, detail)
-			}
-			continue
-		}
+		totalTargets++
 
-		// Claude targets: use base+override merge system
 		expected, err := hooks.ComputeExpected(target.Key)
 		if err != nil {
 			details = append(details, fmt.Sprintf("%s: error computing expected: %v", target.DisplayKey(), err))
@@ -64,7 +76,6 @@ func (c *HooksSyncCheck) Run(ctx *CheckContext) *CheckResult {
 			continue
 		}
 
-		// Check if file exists
 		_, statErr := os.Stat(target.Path)
 		fileExists := statErr == nil
 
@@ -78,11 +89,83 @@ func (c *HooksSyncCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
-	if len(c.outOfSync) == 0 {
+	// Loop 2: Non-Claude template-based agents — use DiscoverRoleLocations + SyncForRole comparison.
+	locations, locErr := hooks.DiscoverRoleLocations(ctx.TownRoot)
+	if locErr != nil {
+		details = append(details, fmt.Sprintf("discovering role locations: %v", locErr))
+	} else {
+		for _, loc := range locations {
+			rigPath := ""
+			if loc.Rig != "" {
+				rigPath = filepath.Join(ctx.TownRoot, loc.Rig)
+			}
+			rc := config.ResolveRoleAgentConfig(loc.Role, ctx.TownRoot, rigPath)
+			if rc == nil || rc.Hooks == nil || rc.Hooks.Provider == "" {
+				continue
+			}
+			// Claude targets are handled by Loop 1.
+			if rc.Hooks.Provider == "claude" {
+				continue
+			}
+
+			preset := config.GetAgentPresetByName(rc.Hooks.Provider)
+			useSettingsDir := preset != nil && preset.HooksUseSettingsDir
+
+			var checkDirs []string
+			if loc.Rig == "" || useSettingsDir {
+				checkDirs = []string{loc.Dir}
+			} else {
+				checkDirs = hooks.DiscoverWorktrees(loc.Dir)
+			}
+
+			for _, dir := range checkDirs {
+				totalTargets++
+				targetPath := filepath.Join(dir, rc.Hooks.Dir, rc.Hooks.SettingsFile)
+
+				expected, err := hooks.ComputeExpectedTemplate(rc.Hooks.Provider, rc.Hooks.SettingsFile, loc.Role)
+				if err != nil {
+					details = append(details, fmt.Sprintf("%s (%s): error computing template: %v", targetPath, rc.Hooks.Provider, err))
+					continue
+				}
+
+				actual, readErr := os.ReadFile(targetPath)
+				if readErr != nil {
+					// File missing
+					c.templateOutOfSync = append(c.templateOutOfSync, templateTarget{
+						path: targetPath, dir: dir, provider: rc.Hooks.Provider,
+						role: loc.Role, hooksDir: rc.Hooks.Dir,
+						settingsFile: rc.Hooks.SettingsFile, useSettingsDir: useSettingsDir,
+					})
+					details = append(details, fmt.Sprintf("%s (%s): missing", targetPath, rc.Hooks.Provider))
+					continue
+				}
+
+				// Compare: structural for JSON, byte-exact for other files.
+				inSync := false
+				if filepath.Ext(rc.Hooks.SettingsFile) == ".json" {
+					inSync = hooks.TemplateContentEqual(expected, actual)
+				} else {
+					inSync = bytes.Equal(expected, actual)
+				}
+
+				if !inSync {
+					c.templateOutOfSync = append(c.templateOutOfSync, templateTarget{
+						path: targetPath, dir: dir, provider: rc.Hooks.Provider,
+						role: loc.Role, hooksDir: rc.Hooks.Dir,
+						settingsFile: rc.Hooks.SettingsFile, useSettingsDir: useSettingsDir,
+					})
+					details = append(details, fmt.Sprintf("%s (%s): out of sync", targetPath, rc.Hooks.Provider))
+				}
+			}
+		}
+	}
+
+	outOfSyncCount := len(c.outOfSync) + len(c.templateOutOfSync)
+	if outOfSyncCount == 0 {
 		return &CheckResult{
 			Name:     c.Name(),
 			Status:   StatusOK,
-			Message:  fmt.Sprintf("All %d hook targets in sync", len(targets)),
+			Message:  fmt.Sprintf("All %d hook targets in sync", totalTargets),
 			Category: c.Category(),
 		}
 	}
@@ -90,52 +173,23 @@ func (c *HooksSyncCheck) Run(ctx *CheckContext) *CheckResult {
 	return &CheckResult{
 		Name:     c.Name(),
 		Status:   StatusWarning,
-		Message:  fmt.Sprintf("%d target(s) out of sync", len(c.outOfSync)),
+		Message:  fmt.Sprintf("%d target(s) out of sync", outOfSyncCount),
 		Details:  details,
 		FixHint:  "Run 'gt doctor --fix hooks-sync' to regenerate settings files",
 		Category: c.Category(),
 	}
 }
 
-// checkGeminiTarget compares an installed gemini settings file against the
-// current template (with {{GT_BIN}} resolved). Returns a detail string if
-// out of sync, or empty string if in sync.
-func (c *HooksSyncCheck) checkGeminiTarget(target hooks.Target) string {
-	expected, err := hooks.ComputeExpectedTemplate("gemini", "settings.json", target.Role)
-	if err != nil {
-		return fmt.Sprintf("%s: error computing expected template: %v", target.DisplayKey(), err)
-	}
-
-	actual, err := os.ReadFile(target.Path)
-	if err != nil {
-		c.outOfSync = append(c.outOfSync, target)
-		return fmt.Sprintf("%s: cannot read: %v", target.DisplayKey(), err)
-	}
-
-	if !hooks.TemplateContentEqual(expected, actual) {
-		c.outOfSync = append(c.outOfSync, target)
-		return fmt.Sprintf("%s: out of sync", target.DisplayKey())
-	}
-
-	return ""
-}
-
-// Fix runs gt hooks sync to bring all targets into sync.
+// Fix brings all out-of-sync targets back into sync.
 func (c *HooksSyncCheck) Fix(ctx *CheckContext) error {
-	if len(c.outOfSync) == 0 {
+	if len(c.outOfSync) == 0 && len(c.templateOutOfSync) == 0 {
 		return nil
 	}
 
 	var errs []string
-	for _, target := range c.outOfSync {
-		if target.Provider == "gemini" {
-			if err := c.fixGeminiTarget(target); err != nil {
-				errs = append(errs, fmt.Sprintf("%s: %v", target.DisplayKey(), err))
-			}
-			continue
-		}
 
-		// Claude targets: use base+override merge system
+	// Fix Claude targets via merge system.
+	for _, target := range c.outOfSync {
 		expected, err := hooks.ComputeExpected(target.Key)
 		if err != nil {
 			errs = append(errs, fmt.Sprintf("%s: %v", target.DisplayKey(), err))
@@ -174,27 +228,17 @@ func (c *HooksSyncCheck) Fix(ctx *CheckContext) error {
 		}
 	}
 
+	// Fix template-based targets via SyncForRole.
+	for _, tt := range c.templateOutOfSync {
+		_, err := hooks.SyncForRole(tt.provider, tt.dir, tt.dir, tt.role,
+			tt.hooksDir, tt.settingsFile, tt.useSettingsDir)
+		if err != nil {
+			errs = append(errs, fmt.Sprintf("%s: %v", tt.path, err))
+		}
+	}
+
 	if len(errs) > 0 {
 		return fmt.Errorf("%s", strings.Join(errs, "; "))
 	}
-	return nil
-}
-
-// fixGeminiTarget re-installs a gemini settings file from the current template.
-func (c *HooksSyncCheck) fixGeminiTarget(target hooks.Target) error {
-	content, err := hooks.ComputeExpectedTemplate("gemini", "settings.json", target.Role)
-	if err != nil {
-		return fmt.Errorf("computing template: %w", err)
-	}
-
-	dir := filepath.Dir(target.Path)
-	if err := os.MkdirAll(dir, 0755); err != nil {
-		return fmt.Errorf("creating dir: %w", err)
-	}
-
-	if err := os.WriteFile(target.Path, content, 0600); err != nil {
-		return fmt.Errorf("writing: %w", err)
-	}
-
 	return nil
 }

--- a/internal/doctor/hooks_sync_check_test.go
+++ b/internal/doctor/hooks_sync_check_test.go
@@ -1,0 +1,288 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/hooks"
+)
+
+// scaffoldWorkspace creates a minimal town workspace in a temp directory with
+// the given role agents configured. Returns the town root path.
+func scaffoldWorkspace(t *testing.T, roleAgents map[string]string) string {
+	t.Helper()
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	townRoot := filepath.Join(tmpDir, "town")
+
+	// Required workspace structure
+	for _, dir := range []string{"mayor", "deacon"} {
+		if err := os.MkdirAll(filepath.Join(townRoot, dir), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	// Workspace marker
+	if err := os.WriteFile(
+		filepath.Join(townRoot, "mayor", "town.json"),
+		[]byte(`{"type":"town","version":1,"name":"test"}`),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Town settings with role agents
+	townSettings := config.NewTownSettings()
+	townSettings.RoleAgents = roleAgents
+	if err := os.MkdirAll(filepath.Join(townRoot, "settings"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveTownSettings(config.TownSettingsPath(townRoot), townSettings); err != nil {
+		t.Fatal(err)
+	}
+
+	// Base hooks config (required for Claude targets)
+	base := &hooks.HooksConfig{
+		SessionStart: []hooks.HookEntry{
+			{Matcher: "", Hooks: []hooks.Hook{{Type: "command", Command: "echo test"}}},
+		},
+	}
+	if err := hooks.SaveBase(base); err != nil {
+		t.Fatalf("SaveBase: %v", err)
+	}
+
+	return townRoot
+}
+
+// syncAllClaudeTargets creates in-sync .claude/settings.json for every
+// Claude target that DiscoverTargets would find. This prevents false
+// positives from unrelated Claude targets in template agent tests.
+func syncAllClaudeTargets(t *testing.T, townRoot string) {
+	t.Helper()
+	targets, err := hooks.DiscoverTargets(townRoot)
+	if err != nil {
+		t.Fatalf("DiscoverTargets: %v", err)
+	}
+	for _, target := range targets {
+		if target.Provider != "" && target.Provider != "claude" {
+			continue
+		}
+		expected, err := hooks.ComputeExpected(target.Key)
+		if err != nil {
+			t.Fatalf("ComputeExpected(%s): %v", target.Key, err)
+		}
+		settings := &hooks.SettingsJSON{Hooks: *expected}
+		data, err := hooks.MarshalSettings(settings)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Dir(target.Path), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(target.Path, append(data, '\n'), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestHooksSyncCheck_ClaudeTargetInSync(t *testing.T) {
+	townRoot := scaffoldWorkspace(t, nil)
+
+	// Create a rig with a crew worktree
+	worktree := filepath.Join(townRoot, "myrig", "crew", "alice")
+	if err := os.MkdirAll(worktree, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sync ALL Claude targets (mayor, deacon, crew worktree)
+	syncAllClaudeTargets(t, townRoot)
+
+	check := NewHooksSyncCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK for in-sync Claude targets, got %v: %s", result.Status, result.Message)
+		for _, d := range result.Details {
+			t.Logf("  detail: %s", d)
+		}
+	}
+}
+
+func TestHooksSyncCheck_TemplateAgent_InSync(t *testing.T) {
+	townRoot := scaffoldWorkspace(t, map[string]string{"crew": "opencode"})
+
+	// Create a crew worktree
+	worktree := filepath.Join(townRoot, "myrig", "crew", "alice")
+	if err := os.MkdirAll(worktree, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sync Claude targets first
+	syncAllClaudeTargets(t, townRoot)
+
+	// Install the correct OpenCode template file
+	expectedContent, err := hooks.ComputeExpectedTemplate("opencode", "gastown.js", "crew")
+	if err != nil {
+		t.Fatalf("ComputeExpectedTemplate: %v", err)
+	}
+	pluginDir := filepath.Join(worktree, ".opencode", "plugins")
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "gastown.js"), expectedContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewHooksSyncCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK for in-sync template agent, got %v: %s", result.Status, result.Message)
+		for _, d := range result.Details {
+			t.Logf("  detail: %s", d)
+		}
+	}
+}
+
+func TestHooksSyncCheck_TemplateAgent_OutOfSync(t *testing.T) {
+	townRoot := scaffoldWorkspace(t, map[string]string{"crew": "opencode"})
+
+	// Create a crew worktree with stale content
+	worktree := filepath.Join(townRoot, "myrig", "crew", "alice")
+	pluginDir := filepath.Join(worktree, ".opencode", "plugins")
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "gastown.js"), []byte("// old stale content"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sync Claude targets so any Warning comes from the template agent
+	syncAllClaudeTargets(t, townRoot)
+
+	check := NewHooksSyncCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning for out-of-sync template agent, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestHooksSyncCheck_TemplateAgent_Missing(t *testing.T) {
+	townRoot := scaffoldWorkspace(t, map[string]string{"crew": "opencode"})
+
+	// Create a crew worktree but DON'T install the plugin
+	worktree := filepath.Join(townRoot, "myrig", "crew", "alice")
+	if err := os.MkdirAll(worktree, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sync Claude targets
+	syncAllClaudeTargets(t, townRoot)
+
+	check := NewHooksSyncCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning for missing template agent file, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestHooksSyncCheck_Fix_TemplateAgent(t *testing.T) {
+	townRoot := scaffoldWorkspace(t, map[string]string{"crew": "opencode"})
+
+	// Create a crew worktree with stale content
+	worktree := filepath.Join(townRoot, "myrig", "crew", "alice")
+	pluginDir := filepath.Join(worktree, ".opencode", "plugins")
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "gastown.js"), []byte("// stale"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Sync Claude targets
+	syncAllClaudeTargets(t, townRoot)
+
+	check := NewHooksSyncCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+
+	// Run to detect out-of-sync
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning before fix, got %v", result.Status)
+	}
+
+	// Fix should write correct content
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+
+	// Verify file now matches expected template
+	pluginPath := filepath.Join(pluginDir, "gastown.js")
+	actual, err := os.ReadFile(pluginPath)
+	if err != nil {
+		t.Fatalf("reading fixed file: %v", err)
+	}
+	expected, err := hooks.ComputeExpectedTemplate("opencode", "gastown.js", "crew")
+	if err != nil {
+		t.Fatalf("ComputeExpectedTemplate: %v", err)
+	}
+	if string(actual) != string(expected) {
+		t.Error("fixed file does not match expected template")
+	}
+}
+
+func TestHooksSyncCheck_Fix_PreservesClaudePath(t *testing.T) {
+	townRoot := scaffoldWorkspace(t, nil)
+
+	// Sync all Claude targets first (creates in-sync settings for mayor, deacon)
+	syncAllClaudeTargets(t, townRoot)
+
+	// THEN overwrite mayor's settings with stale hooks but a custom editorMode
+	mayorClaudeDir := filepath.Join(townRoot, "mayor", ".claude")
+	stale := &hooks.SettingsJSON{
+		EditorMode: "vim",
+		Hooks: hooks.HooksConfig{
+			SessionStart: []hooks.HookEntry{
+				{Matcher: "", Hooks: []hooks.Hook{{Type: "command", Command: "old-cmd"}}},
+			},
+		},
+	}
+	data, err := hooks.MarshalSettings(stale)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorClaudeDir, "settings.json"), append(data, '\n'), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewHooksSyncCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+
+	// Run to detect out-of-sync
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning before fix, got %v: %s", result.Status, result.Message)
+	}
+
+	// Fix
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+
+	// Verify editorMode was preserved (merge path, not overwrite)
+	settings, err := hooks.LoadSettings(filepath.Join(mayorClaudeDir, "settings.json"))
+	if err != nil {
+		t.Fatalf("LoadSettings: %v", err)
+	}
+	if settings.EditorMode != "vim" {
+		t.Errorf("editorMode not preserved: got %q, want %q", settings.EditorMode, "vim")
+	}
+}

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -574,6 +574,84 @@ func discoverGeminiTargets(rigPath, rigName string) []Target {
 	return targets
 }
 
+// RoleLocation represents a discovered role directory in the workspace,
+// independent of any specific agent. Used by callers that need to resolve
+// agent configuration for each location (e.g., syncing non-Claude agents).
+type RoleLocation struct {
+	Dir  string // Absolute path to the role's parent directory (e.g., .../rig/crew)
+	Rig  string // Rig name, or empty for town-level roles
+	Role string // Role name: crew, polecat, witness, refinery, mayor, deacon
+}
+
+// DiscoverRoleLocations finds all role directories in a workspace.
+// Unlike DiscoverTargets (which returns Claude-specific paths), this returns
+// agent-agnostic directory locations that callers can use with any agent config.
+func DiscoverRoleLocations(townRoot string) ([]RoleLocation, error) {
+	var locations []RoleLocation
+
+	// Town-level roles
+	for _, role := range []string{"mayor", "deacon"} {
+		dir := filepath.Join(townRoot, role)
+		if info, err := os.Stat(dir); err == nil && info.IsDir() {
+			locations = append(locations, RoleLocation{Dir: dir, Role: role})
+		}
+	}
+
+	// Scan rigs
+	entries, err := os.ReadDir(townRoot)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || entry.Name() == "mayor" || entry.Name() == "deacon" ||
+			entry.Name() == ".beads" || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
+		rigName := entry.Name()
+		rigPath := filepath.Join(townRoot, rigName)
+
+		if !isRig(rigPath) {
+			continue
+		}
+
+		// Map subdirectories to roles
+		for _, sub := range []struct{ dir, role string }{
+			{"crew", "crew"},
+			{"polecats", "polecat"},
+			{"witness", "witness"},
+			{"refinery", "refinery"},
+		} {
+			dir := filepath.Join(rigPath, sub.dir)
+			if info, err := os.Stat(dir); err == nil && info.IsDir() {
+				locations = append(locations, RoleLocation{Dir: dir, Rig: rigName, Role: sub.role})
+			}
+		}
+	}
+
+	return locations, nil
+}
+
+// DiscoverWorktrees returns subdirectories within a role parent directory that
+// are individual worktrees (e.g., crew/alice, crew/bob, polecats/toast).
+// Skips hidden directories and non-directories.
+func DiscoverWorktrees(roleDir string) []string {
+	entries, err := os.ReadDir(roleDir)
+	if err != nil {
+		return nil
+	}
+
+	var dirs []string
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		dirs = append(dirs, filepath.Join(roleDir, entry.Name()))
+	}
+	return dirs
+}
+
 // isRig checks if a directory looks like a rig (has crew/, witness/, or polecats/ subdirectory).
 func isRig(path string) bool {
 	for _, sub := range []string{"crew", "witness", "polecats", "refinery"} {

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -483,96 +483,11 @@ func DiscoverTargets(townRoot string) ([]Target, error) {
 			})
 		}
 
-		// Gemini targets — per-agent settings in work directories.
-		// Unlike Claude (shared via --settings flag), gemini settings are
-		// installed in each agent's work directory.
-		targets = append(targets, discoverGeminiTargets(rigPath, rigName)...)
 	}
 
 	return targets, nil
 }
 
-// discoverGeminiTargets finds .gemini/settings.json files in agent work
-// directories within a rig. Gemini agents don't share a settings directory;
-// each has its own .gemini/settings.json in their work dir.
-func discoverGeminiTargets(rigPath, rigName string) []Target {
-	var targets []Target
-
-	// Crew members: <rig>/crew/<name>/.gemini/settings.json
-	crewDir := filepath.Join(rigPath, "crew")
-	if info, err := os.Stat(crewDir); err == nil && info.IsDir() {
-		members, _ := os.ReadDir(crewDir)
-		for _, m := range members {
-			if !m.IsDir() || strings.HasPrefix(m.Name(), ".") {
-				continue
-			}
-			geminiPath := filepath.Join(crewDir, m.Name(), ".gemini", "settings.json")
-			if _, err := os.Stat(geminiPath); err == nil {
-				targets = append(targets, Target{
-					Path:     geminiPath,
-					Key:      rigName + "/crew/" + m.Name() + "[gemini]",
-					Rig:      rigName,
-					Role:     "crew",
-					Provider: "gemini",
-				})
-			}
-		}
-	}
-
-	// Witness: <rig>/witness/.gemini/settings.json
-	witnessGemini := filepath.Join(rigPath, "witness", ".gemini", "settings.json")
-	if _, err := os.Stat(witnessGemini); err == nil {
-		targets = append(targets, Target{
-			Path:     witnessGemini,
-			Key:      rigName + "/witness[gemini]",
-			Rig:      rigName,
-			Role:     "witness",
-			Provider: "gemini",
-		})
-	}
-
-	// Refinery: check both <rig>/refinery/.gemini/ and <rig>/refinery/rig/.gemini/
-	for _, sub := range []string{"", "rig"} {
-		base := filepath.Join(rigPath, "refinery")
-		if sub != "" {
-			base = filepath.Join(base, sub)
-		}
-		refGemini := filepath.Join(base, ".gemini", "settings.json")
-		if _, err := os.Stat(refGemini); err == nil {
-			targets = append(targets, Target{
-				Path:     refGemini,
-				Key:      rigName + "/refinery[gemini]",
-				Rig:      rigName,
-				Role:     "refinery",
-				Provider: "gemini",
-			})
-			break // Only add one refinery gemini target per rig
-		}
-	}
-
-	// Polecats: <rig>/polecats/<name>/.gemini/settings.json
-	polecatsDir := filepath.Join(rigPath, "polecats")
-	if info, err := os.Stat(polecatsDir); err == nil && info.IsDir() {
-		members, _ := os.ReadDir(polecatsDir)
-		for _, m := range members {
-			if !m.IsDir() || strings.HasPrefix(m.Name(), ".") {
-				continue
-			}
-			geminiPath := filepath.Join(polecatsDir, m.Name(), ".gemini", "settings.json")
-			if _, err := os.Stat(geminiPath); err == nil {
-				targets = append(targets, Target{
-					Path:     geminiPath,
-					Key:      rigName + "/polecats/" + m.Name() + "[gemini]",
-					Rig:      rigName,
-					Role:     "polecat",
-					Provider: "gemini",
-				})
-			}
-		}
-	}
-
-	return targets
-}
 
 // RoleLocation represents a discovered role directory in the workspace,
 // independent of any specific agent. Used by callers that need to resolve

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -948,6 +948,127 @@ func TestDiscoverTargets_GeminiTargets(t *testing.T) {
 	}
 }
 
+func TestDiscoverRoleLocations(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	os.MkdirAll(filepath.Join(tmpDir, "mayor"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "deacon"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "rig1", "crew", "alice"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "rig1", "polecats", "toast"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "rig1", "witness"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "rig1", "refinery"), 0755)
+
+	locations, err := DiscoverRoleLocations(tmpDir)
+	if err != nil {
+		t.Fatalf("DiscoverRoleLocations failed: %v", err)
+	}
+
+	// Build lookup by role+rig
+	type key struct{ rig, role string }
+	found := make(map[key]RoleLocation)
+	for _, loc := range locations {
+		found[key{loc.Rig, loc.Role}] = loc
+	}
+
+	expected := []struct {
+		rig, role string
+	}{
+		{"", "mayor"},
+		{"", "deacon"},
+		{"rig1", "crew"},
+		{"rig1", "polecat"},
+		{"rig1", "witness"},
+		{"rig1", "refinery"},
+	}
+
+	for _, e := range expected {
+		loc, ok := found[key{e.rig, e.role}]
+		if !ok {
+			t.Errorf("expected location rig=%q role=%q not found", e.rig, e.role)
+			continue
+		}
+		if loc.Dir == "" {
+			t.Errorf("location rig=%q role=%q has empty Dir", e.rig, e.role)
+		}
+	}
+
+	if len(locations) != len(expected) {
+		t.Errorf("expected %d locations, got %d", len(expected), len(locations))
+	}
+}
+
+func TestDiscoverRoleLocations_SkipsNonRigs(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create a directory that isn't a rig (no crew/witness/polecats/refinery subdirs)
+	os.MkdirAll(filepath.Join(tmpDir, "notarig", "something"), 0755)
+	// Hidden dirs should be skipped
+	os.MkdirAll(filepath.Join(tmpDir, ".beads"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, ".hidden", "crew"), 0755)
+
+	locations, err := DiscoverRoleLocations(tmpDir)
+	if err != nil {
+		t.Fatalf("DiscoverRoleLocations failed: %v", err)
+	}
+
+	for _, loc := range locations {
+		if loc.Rig == "notarig" || loc.Rig == ".beads" || loc.Rig == ".hidden" {
+			t.Errorf("unexpected location found: rig=%q role=%q", loc.Rig, loc.Role)
+		}
+	}
+}
+
+func TestDiscoverWorktrees(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	// Create worktree subdirectories
+	os.MkdirAll(filepath.Join(tmpDir, "alice"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "bob"), 0755)
+	// Hidden dirs should be skipped
+	os.MkdirAll(filepath.Join(tmpDir, ".claude"), 0755)
+	// Files should be skipped
+	os.WriteFile(filepath.Join(tmpDir, "state.json"), []byte("{}"), 0644)
+
+	dirs := DiscoverWorktrees(tmpDir)
+
+	if len(dirs) != 2 {
+		t.Errorf("expected 2 worktrees, got %d: %v", len(dirs), dirs)
+	}
+
+	names := make(map[string]bool)
+	for _, d := range dirs {
+		names[filepath.Base(d)] = true
+	}
+	if !names["alice"] || !names["bob"] {
+		t.Errorf("expected alice and bob, got %v", names)
+	}
+	if names[".claude"] {
+		t.Error("hidden directory should be skipped")
+	}
+}
+
+func TestDiscoverWorktrees_EmptyDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	dirs := DiscoverWorktrees(tmpDir)
+	if len(dirs) != 0 {
+		t.Errorf("expected 0 worktrees, got %d", len(dirs))
+	}
+}
+
+func TestDiscoverWorktrees_InvalidDir(t *testing.T) {
+	dirs := DiscoverWorktrees("/nonexistent/path/that/does/not/exist")
+	if dirs != nil {
+		t.Errorf("expected nil for invalid dir, got %v", dirs)
+	}
+}
+
+func TestDiscoverRoleLocations_ReadError(t *testing.T) {
+	_, err := DiscoverRoleLocations("/nonexistent/path/that/does/not/exist")
+	if err == nil {
+		t.Error("expected error for nonexistent directory")
+	}
+}
+
 func TestTargetDisplayKey(t *testing.T) {
 	tests := []struct {
 		target   Target

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -884,67 +884,32 @@ func TestDiscoverTargets_RoleNames(t *testing.T) {
 	}
 }
 
-func TestDiscoverTargets_GeminiTargets(t *testing.T) {
+func TestDiscoverTargets_ReturnsOnlyClaude(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	os.MkdirAll(filepath.Join(tmpDir, "mayor"), 0755)
 	os.MkdirAll(filepath.Join(tmpDir, "deacon"), 0755)
 
-	// Create a rig with gemini crew members and witness
+	// Create a rig with crew members that have both Claude and Gemini settings.
+	// DiscoverTargets should only return Claude targets; non-Claude agents are
+	// discovered via DiscoverRoleLocations instead.
 	os.MkdirAll(filepath.Join(tmpDir, "rig1", "crew", "alice"), 0755)
 	os.MkdirAll(filepath.Join(tmpDir, "rig1", "witness"), 0755)
 
-	// Install gemini settings for alice (crew member)
+	// Install gemini settings (should NOT appear in DiscoverTargets results)
 	geminiDir := filepath.Join(tmpDir, "rig1", "crew", "alice", ".gemini")
 	os.MkdirAll(geminiDir, 0755)
 	os.WriteFile(filepath.Join(geminiDir, "settings.json"), []byte(`{"hooks":{}}`), 0644)
-
-	// Install gemini settings for witness
-	witnessGemini := filepath.Join(tmpDir, "rig1", "witness", ".gemini")
-	os.MkdirAll(witnessGemini, 0755)
-	os.WriteFile(filepath.Join(witnessGemini, "settings.json"), []byte(`{"hooks":{}}`), 0644)
 
 	targets, err := DiscoverTargets(tmpDir)
 	if err != nil {
 		t.Fatalf("DiscoverTargets failed: %v", err)
 	}
 
-	// Find gemini targets
-	var geminiTargets []Target
 	for _, tgt := range targets {
 		if tgt.Provider == "gemini" {
-			geminiTargets = append(geminiTargets, tgt)
+			t.Errorf("DiscoverTargets should not return gemini targets, got: %s", tgt.DisplayKey())
 		}
-	}
-
-	if len(geminiTargets) != 2 {
-		t.Errorf("expected 2 gemini targets, got %d", len(geminiTargets))
-		for _, tgt := range targets {
-			t.Logf("  target: %s (provider=%s)", tgt.DisplayKey(), tgt.Provider)
-		}
-	}
-
-	found := make(map[string]bool)
-	for _, tgt := range geminiTargets {
-		found[tgt.Key] = true
-	}
-
-	for _, expected := range []string{"rig1/crew/alice[gemini]", "rig1/witness[gemini]"} {
-		if !found[expected] {
-			t.Errorf("expected gemini target %q not found", expected)
-		}
-	}
-
-	// Verify role assignment
-	roleByKey := make(map[string]string)
-	for _, tgt := range geminiTargets {
-		roleByKey[tgt.Key] = tgt.Role
-	}
-	if roleByKey["rig1/crew/alice[gemini]"] != "crew" {
-		t.Errorf("alice gemini target: Role = %q, want %q", roleByKey["rig1/crew/alice[gemini]"], "crew")
-	}
-	if roleByKey["rig1/witness[gemini]"] != "witness" {
-		t.Errorf("witness gemini target: Role = %q, want %q", roleByKey["rig1/witness[gemini]"], "witness")
 	}
 }
 

--- a/internal/hooks/installer.go
+++ b/internal/hooks/installer.go
@@ -21,11 +21,20 @@ import (
 var templateFS embed.FS
 
 // InstallForRole provisions hook/settings files for an agent based on its preset config.
-// settingsDir is the gastown-managed parent (used by agents with --settings flag).
-// workDir is the agent's working directory.
-// role is the Gas Town role (e.g., "polecat", "crew", "witness").
-// hooksDir and hooksFile come from the preset's HooksDir and HooksSettingsFile.
-// provider is the preset's HooksProvider (e.g., "claude", "gemini").
+// It creates the file if it does not exist, or overwrites if the existing file contains
+// known stale patterns (e.g., legacy "export PATH=" format). Otherwise it does not
+// overwrite — this is the safe path for session startup, where Claude's settings.json
+// may have been customized by syncTarget (base + role overrides merge) and must not
+// be clobbered.
+//
+// For explicit sync operations that should update stale files, use SyncForRole.
+//
+// Parameters:
+//   - provider: the preset's HooksProvider (e.g., "claude", "gemini").
+//   - settingsDir: the gastown-managed parent (used by agents with --settings flag).
+//   - workDir: the agent's working directory.
+//   - role: the Gas Town role (e.g., "polecat", "crew", "witness").
+//   - hooksDir/hooksFile: from the preset's HooksDir and HooksSettingsFile.
 //
 // Template resolution:
 //   - Role-aware agents (have both autonomous and interactive templates):
@@ -40,44 +49,117 @@ func InstallForRole(provider, settingsDir, workDir, role, hooksDir, hooksFile st
 		return nil
 	}
 
-	// Determine install root
+	targetPath := installTargetPath(settingsDir, workDir, hooksDir, hooksFile, useSettingsDir)
+
+	if existing, err := os.ReadFile(targetPath); err == nil {
+		if !needsUpgrade(existing) {
+			return nil // File exists and is current — don't overwrite
+		}
+		// Stale file detected — fall through to overwrite with current template
+	}
+
+	return writeTemplate(provider, role, hooksDir, hooksFile, targetPath)
+}
+
+// needsUpgrade returns true if an existing hooks file contains stale patterns
+// that should be replaced by the current template. This allows the installer
+// to auto-upgrade hooks from earlier versions without requiring manual intervention.
+func needsUpgrade(content []byte) bool {
+	// Stale pattern: export PATH=... && gt — replaced by {{GT_BIN}} in current templates.
+	// The PATH export breaks Gemini CLI's hook runner which expands $PATH into
+	// an enormous string. Also catches files missing GT_HOOK_SOURCE env vars.
+	return bytes.Contains(content, []byte(`export PATH=`))
+}
+
+// SyncResult describes what SyncForRole did.
+type SyncResult int
+
+const (
+	SyncUnchanged SyncResult = iota // File already matches template
+	SyncCreated                     // File did not exist, created
+	SyncUpdated                     // File existed but content differed, updated
+)
+
+// SyncForRole compares the deployed hook/settings file against the current template
+// and overwrites if content differs. Returns what action was taken.
+//
+// This is the explicit sync path used by "gt hooks sync" for template-based agents
+// (OpenCode, Copilot, Pi, OMP, etc.). It should NOT be used for agents whose settings
+// are managed by the JSON merge path (Claude), as that would clobber merged overrides.
+func SyncForRole(provider, settingsDir, workDir, role, hooksDir, hooksFile string, useSettingsDir bool) (SyncResult, error) {
+	if provider == "" || hooksDir == "" || hooksFile == "" {
+		return SyncUnchanged, nil
+	}
+
+	targetPath := installTargetPath(settingsDir, workDir, hooksDir, hooksFile, useSettingsDir)
+
+	content, err := resolveAndSubstitute(provider, hooksFile, role)
+	if err != nil {
+		return 0, err
+	}
+
+	fileExisted := false
+	if existing, err := os.ReadFile(targetPath); err == nil {
+		fileExisted = true
+		if bytes.Equal(existing, content) {
+			return SyncUnchanged, nil
+		}
+	}
+
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+		return 0, fmt.Errorf("creating hooks directory: %w", err)
+	}
+
+	perm := os.FileMode(0644)
+	if isSettingsFile(hooksFile) {
+		perm = 0600
+	}
+
+	if err := os.WriteFile(targetPath, content, perm); err != nil {
+		return 0, fmt.Errorf("writing hooks file: %w", err)
+	}
+
+	if fileExisted {
+		return SyncUpdated, nil
+	}
+	return SyncCreated, nil
+}
+
+// installTargetPath computes the full path for a hook/settings file.
+func installTargetPath(settingsDir, workDir, hooksDir, hooksFile string, useSettingsDir bool) string {
 	installDir := workDir
 	if useSettingsDir {
 		installDir = settingsDir
 	}
+	return filepath.Join(installDir, hooksDir, hooksFile)
+}
 
-	targetPath := filepath.Join(installDir, hooksDir, hooksFile)
+// resolveAndSubstitute resolves the template and performs {{GT_BIN}} substitution.
+func resolveAndSubstitute(provider, hooksFile, role string) ([]byte, error) {
+	content, err := resolveTemplate(provider, hooksFile, role)
+	if err != nil {
+		return nil, fmt.Errorf("resolving template for %s: %w", provider, err)
+	}
 
-	// Check if existing file needs upgrading. Stale hooks from earlier
-	// versions used `export PATH=...` which breaks Gemini CLI's hook runner.
-	// Replace them with the current template that uses absolute gt paths.
-	if existing, err := os.ReadFile(targetPath); err == nil {
-		if !needsUpgrade(existing) {
-			return nil // Existing file is current — don't overwrite
-		}
-		// Stale file detected — fall through to overwrite with current template
+	if bytes.Contains(content, []byte("{{GT_BIN}}")) {
+		gtBin := resolveGTBinary()
+		content = bytes.ReplaceAll(content, []byte("{{GT_BIN}}"), []byte(gtBin))
+	}
+
+	return content, nil
+}
+
+// writeTemplate resolves a template, substitutes placeholders, and writes it to targetPath.
+func writeTemplate(provider, role, hooksDir, hooksFile, targetPath string) error {
+	content, err := resolveAndSubstitute(provider, hooksFile, role)
+	if err != nil {
+		return err
 	}
 
 	if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
 		return fmt.Errorf("creating hooks directory: %w", err)
 	}
 
-	// Try role-aware templates first (autonomous/interactive variants)
-	content, err := resolveTemplate(provider, hooksFile, role)
-	if err != nil {
-		return fmt.Errorf("resolving template for %s: %w", provider, err)
-	}
-
-	// Substitute {{GT_BIN}} with the resolved gt binary path.
-	// Templates use this placeholder so hooks call gt directly instead of
-	// relying on PATH exports, which fail on Gemini CLI (the hook runner
-	// expands $PATH into an enormous string that breaks command parsing).
-	if bytes.Contains(content, []byte("{{GT_BIN}}")) {
-		gtBin := resolveGTBinary()
-		content = bytes.ReplaceAll(content, []byte("{{GT_BIN}}"), []byte(gtBin))
-	}
-
-	// Use restrictive permissions for settings that may contain role instructions
 	perm := os.FileMode(0644)
 	if isSettingsFile(hooksFile) {
 		perm = 0600
@@ -139,19 +221,6 @@ func roleAwarePatterns(roleType, hooksFile string) []string {
 // isSettingsFile returns true for files that may contain sensitive role config.
 func isSettingsFile(name string) bool {
 	return filepath.Ext(name) == ".json"
-}
-
-// needsUpgrade returns true if an existing hooks file contains stale patterns
-// that should be replaced by the current template. This allows the installer
-// to auto-upgrade hooks from earlier versions without requiring manual intervention.
-func needsUpgrade(content []byte) bool {
-	// Stale pattern: export PATH=... && gt — replaced by {{GT_BIN}} in current templates.
-	// The PATH export breaks Gemini CLI's hook runner which expands $PATH into
-	// an enormous string. Also catches files missing GT_HOOK_SOURCE env vars.
-	if bytes.Contains(content, []byte(`export PATH=`)) {
-		return true
-	}
-	return false
 }
 
 // resolveGTBinary returns the absolute path to the gt binary.

--- a/internal/hooks/installer.go
+++ b/internal/hooks/installer.go
@@ -58,7 +58,7 @@ func InstallForRole(provider, settingsDir, workDir, role, hooksDir, hooksFile st
 		// Stale file detected — fall through to overwrite with current template
 	}
 
-	return writeTemplate(provider, role, hooksDir, hooksFile, targetPath)
+	return writeTemplate(provider, role, hooksFile, targetPath)
 }
 
 // needsUpgrade returns true if an existing hooks file contains stale patterns
@@ -157,7 +157,7 @@ func resolveAndSubstitute(provider, hooksFile, role string) ([]byte, error) {
 }
 
 // writeTemplate resolves a template, substitutes placeholders, and writes it to targetPath.
-func writeTemplate(provider, role, hooksDir, hooksFile, targetPath string) error {
+func writeTemplate(provider, role, hooksFile, targetPath string) error {
 	content, err := resolveAndSubstitute(provider, hooksFile, role)
 	if err != nil {
 		return err

--- a/internal/hooks/installer.go
+++ b/internal/hooks/installer.go
@@ -101,8 +101,15 @@ func SyncForRole(provider, settingsDir, workDir, role, hooksDir, hooksFile strin
 	fileExisted := false
 	if existing, err := os.ReadFile(targetPath); err == nil {
 		fileExisted = true
-		if bytes.Equal(existing, content) {
-			return SyncUnchanged, nil
+		if isSettingsFile(hooksFile) {
+			// JSON files: use structural comparison to tolerate whitespace differences.
+			if TemplateContentEqual(existing, content) {
+				return SyncUnchanged, nil
+			}
+		} else {
+			if bytes.Equal(existing, content) {
+				return SyncUnchanged, nil
+			}
 		}
 	}
 
@@ -242,17 +249,7 @@ func resolveGTBinary() string {
 // This is used by the doctor hooks-sync check to compare installed files against
 // current templates.
 func ComputeExpectedTemplate(provider, hooksFile, role string) ([]byte, error) {
-	content, err := resolveTemplate(provider, hooksFile, role)
-	if err != nil {
-		return nil, err
-	}
-
-	if bytes.Contains(content, []byte("{{GT_BIN}}")) {
-		gtBin := resolveGTBinary()
-		content = bytes.ReplaceAll(content, []byte("{{GT_BIN}}"), []byte(gtBin))
-	}
-
-	return content, nil
+	return resolveAndSubstitute(provider, hooksFile, role)
 }
 
 // TemplateContentEqual compares two JSON byte slices for structural equality

--- a/internal/hooks/installer_test.go
+++ b/internal/hooks/installer_test.go
@@ -89,6 +89,151 @@ func TestInstallForRole_SkipsExisting(t *testing.T) {
 	}
 }
 
+func TestInstallForRole_UpgradesStaleExportPath(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, ".opencode/plugins", "gastown.js")
+	os.MkdirAll(filepath.Dir(hooksPath), 0755)
+
+	// Write a stale file with the legacy "export PATH=" pattern
+	os.WriteFile(hooksPath, []byte(`export PATH=/usr/local/bin:$PATH && gt hook`), 0644)
+
+	err := InstallForRole("opencode", dir, dir, "crew", ".opencode/plugins", "gastown.js", false)
+	if err != nil {
+		t.Fatalf("InstallForRole: %v", err)
+	}
+
+	got, _ := os.ReadFile(hooksPath)
+	if strings.Contains(string(got), "export PATH=") {
+		t.Error("stale export PATH pattern was not upgraded")
+	}
+	// Should now match the current template
+	template, _ := templateFS.ReadFile("templates/opencode/gastown.js")
+	if string(got) != string(template) {
+		t.Error("upgraded file does not match current template")
+	}
+}
+
+func TestSyncForRole_UpdatesStaleContent(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, ".opencode/plugins", "gastown.js")
+	os.MkdirAll(filepath.Dir(hooksPath), 0755)
+	os.WriteFile(hooksPath, []byte("stale-content"), 0644)
+
+	result, err := SyncForRole("opencode", dir, dir, "crew", ".opencode/plugins", "gastown.js", false)
+	if err != nil {
+		t.Fatalf("SyncForRole: %v", err)
+	}
+	if result != SyncUpdated {
+		t.Errorf("expected SyncUpdated, got %d", result)
+	}
+
+	got, _ := os.ReadFile(hooksPath)
+	if string(got) == "stale-content" {
+		t.Error("stale file was not updated")
+	}
+
+	// Should match the template
+	template, _ := templateFS.ReadFile("templates/opencode/gastown.js")
+	if string(got) != string(template) {
+		t.Error("updated file does not match current template")
+	}
+}
+
+func TestSyncForRole_SkipsMatchingContent(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, ".opencode/plugins", "gastown.js")
+	os.MkdirAll(filepath.Dir(hooksPath), 0755)
+
+	// Write the actual template content — should report unchanged
+	template, _ := templateFS.ReadFile("templates/opencode/gastown.js")
+	os.WriteFile(hooksPath, template, 0644)
+
+	result, err := SyncForRole("opencode", dir, dir, "crew", ".opencode/plugins", "gastown.js", false)
+	if err != nil {
+		t.Fatalf("SyncForRole: %v", err)
+	}
+	if result != SyncUnchanged {
+		t.Errorf("expected SyncUnchanged, got %d", result)
+	}
+}
+
+func TestSyncForRole_CreatesNewFile(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, ".opencode/plugins", "gastown.js")
+
+	result, err := SyncForRole("opencode", dir, dir, "polecat", ".opencode/plugins", "gastown.js", false)
+	if err != nil {
+		t.Fatalf("SyncForRole: %v", err)
+	}
+	if result != SyncCreated {
+		t.Errorf("expected SyncCreated, got %d", result)
+	}
+
+	if _, err := os.Stat(hooksPath); os.IsNotExist(err) {
+		t.Error("file was not created")
+	}
+}
+
+func TestSyncForRole_EmptyProvider(t *testing.T) {
+	dir := t.TempDir()
+	result, err := SyncForRole("", dir, dir, "crew", ".opencode/plugins", "gastown.js", false)
+	if err != nil {
+		t.Fatalf("expected nil error for empty provider, got: %v", err)
+	}
+	if result != SyncUnchanged {
+		t.Errorf("expected SyncUnchanged for empty provider, got %d", result)
+	}
+}
+
+func TestSyncForRole_InvalidProvider(t *testing.T) {
+	dir := t.TempDir()
+	_, err := SyncForRole("nonexistent-provider", dir, dir, "crew", ".test", "settings.json", false)
+	if err == nil {
+		t.Error("expected error for invalid provider")
+	}
+}
+
+func TestSyncForRole_WriteError(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("Windows does not support read-only directories reliably")
+	}
+
+	dir := t.TempDir()
+	// Create a read-only parent to prevent MkdirAll from creating the hooks dir
+	readOnlyDir := filepath.Join(dir, "readonly")
+	os.MkdirAll(readOnlyDir, 0755)
+	os.Chmod(readOnlyDir, 0444)
+	defer os.Chmod(readOnlyDir, 0755) // cleanup
+
+	_, err := SyncForRole("opencode", readOnlyDir, readOnlyDir, "crew", ".opencode/plugins", "gastown.js", false)
+	if err == nil {
+		t.Error("expected error when directory is read-only")
+	}
+}
+
+func TestSyncForRole_GeminiWithGTBinSubstitution(t *testing.T) {
+	dir := t.TempDir()
+
+	result, err := SyncForRole("gemini", dir, dir, "witness", ".gemini", "settings.json", false)
+	if err != nil {
+		t.Fatalf("SyncForRole: %v", err)
+	}
+	if result != SyncCreated {
+		t.Errorf("expected SyncCreated, got %d", result)
+	}
+
+	got, _ := os.ReadFile(filepath.Join(dir, ".gemini", "settings.json"))
+	// Verify {{GT_BIN}} was substituted (should not appear in output)
+	if strings.Contains(string(got), "{{GT_BIN}}") {
+		t.Error("{{GT_BIN}} placeholder was not substituted")
+	}
+	// Verify the resolved binary path is present
+	gtBin := resolveGTBinary()
+	if !strings.Contains(string(got), gtBin) {
+		t.Errorf("expected resolved gt binary %q in output", gtBin)
+	}
+}
+
 func TestInstallForRole_SettingsDirVsWorkDir(t *testing.T) {
 	settingsDir := t.TempDir()
 	workDir := t.TempDir()

--- a/internal/hooks/installer_test.go
+++ b/internal/hooks/installer_test.go
@@ -211,6 +211,44 @@ func TestSyncForRole_WriteError(t *testing.T) {
 	}
 }
 
+func TestSyncForRole_JSONWhitespaceInsensitive(t *testing.T) {
+	dir := t.TempDir()
+
+	// First, create the file via SyncForRole
+	result, err := SyncForRole("gemini", dir, dir, "crew", ".gemini", "settings.json", false)
+	if err != nil {
+		t.Fatalf("initial SyncForRole: %v", err)
+	}
+	if result != SyncCreated {
+		t.Fatalf("expected SyncCreated, got %d", result)
+	}
+
+	// Read the canonical file, reformat with different whitespace
+	targetPath := filepath.Join(dir, ".gemini", "settings.json")
+	original, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("reading created file: %v", err)
+	}
+
+	// Add extra whitespace — structurally identical JSON, different bytes
+	reformatted := strings.ReplaceAll(string(original), ":", " : ")
+	if string(original) == reformatted {
+		t.Fatal("reformatted content should differ from original bytes")
+	}
+	if err := os.WriteFile(targetPath, []byte(reformatted), 0600); err != nil {
+		t.Fatalf("writing reformatted file: %v", err)
+	}
+
+	// SyncForRole should treat this as unchanged (structurally equal JSON)
+	result, err = SyncForRole("gemini", dir, dir, "crew", ".gemini", "settings.json", false)
+	if err != nil {
+		t.Fatalf("SyncForRole after reformat: %v", err)
+	}
+	if result != SyncUnchanged {
+		t.Errorf("expected SyncUnchanged for whitespace-only JSON difference, got %d", result)
+	}
+}
+
 func TestSyncForRole_GeminiWithGTBinSubstitution(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary
`gt hooks sync` only discovered `.claude/settings.json` targets, silently skipping all non-Claude agents (OpenCode, Cursor, Gemini, Copilot, Pi, OMP).

- Add `SyncForRole` for content-aware template sync (separate from `InstallForRole` which remains create-only)
- Add `DiscoverRoleLocations` and `DiscoverWorktrees` for agent-agnostic target discovery
- Update `hooks sync` to resolve the configured agent per role and sync template-based agents
- Make `gt doctor hooks-sync` agent-agnostic to match

Fix-merge of #3080.

Co-Authored-By: Jeff Woolley <jeff.woolley@attributesoftware.com>
Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

## Test plan
- [x] `go build ./...` compiles clean
- [x] Unit tests for `SyncForRole`, `DiscoverRoleLocations`, `DiscoverWorktrees`
- [x] Integration tests for `runHooksSync` with non-Claude agent
- [x] All existing tests pass