### PR TITLE
feat: promote quality review to merge gate (Phase 2)

### DIFF
--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -128,12 +128,17 @@ func TestBuildRefineryPatrolVars_FullConfig(t *testing.T) {
 	// DefaultMergeQueueConfig: refinery_enabled=true, auto_land=false, run_tests=true,
 	// test_command="" (language-agnostic), target_branch="main" (from rig config), delete_merged_branches=true
 	// New commands (setup, typecheck, lint, build) default to empty = omitted
+	// Judgment fields always emitted with defaults
 	expected := map[string]string{
 		"integration_branch_refinery_enabled": "true",
 		"integration_branch_auto_land":        "false",
 		"run_tests":                           "true",
 		"target_branch":                       "main",
 		"delete_merged_branches":              "true",
+		"judgment_enabled":                    "false",
+		"review_depth":                        "standard",
+		"judgment_gate_enabled":               "false",
+		"judgment_gate_threshold":             "0.45",
 	}
 
 	varMap := make(map[string]string)

--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -394,6 +394,8 @@ func buildRefineryPatrolVars(ctx RoleContext) []string {
 		vars = append(vars, fmt.Sprintf("delete_merged_branches=%t", mq.IsDeleteMergedBranchesEnabled()))
 		vars = append(vars, fmt.Sprintf("judgment_enabled=%t", mq.IsJudgmentEnabled()))
 		vars = append(vars, fmt.Sprintf("review_depth=%s", mq.GetReviewDepth()))
+		vars = append(vars, fmt.Sprintf("judgment_gate_enabled=%t", mq.IsJudgmentGateEnabled()))
+		vars = append(vars, fmt.Sprintf("judgment_gate_threshold=%.2f", mq.GetJudgmentGateThreshold()))
 		return vars
 	}
 
@@ -411,7 +413,7 @@ func buildRefineryPatrolVars(ctx RoleContext) []string {
 					labelMap[label[:idx]] = label[idx+1:]
 				}
 			}
-			for _, key := range []string{"integration_branch_refinery_enabled", "integration_branch_auto_land", "run_tests", "delete_merged_branches", "setup_command", "typecheck_command", "lint_command", "test_command", "build_command"} {
+			for _, key := range []string{"integration_branch_refinery_enabled", "integration_branch_auto_land", "run_tests", "delete_merged_branches", "setup_command", "typecheck_command", "lint_command", "test_command", "build_command", "judgment_gate_enabled", "judgment_gate_threshold"} {
 				if val := labelMap[key]; val != "" {
 					vars = append(vars, fmt.Sprintf("%s=%s", key, val))
 				}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1271,6 +1271,17 @@ type MergeQueueConfig struct {
 	// is enabled. Valid values: "quick", "standard", "deep".
 	// Nil defaults to "standard".
 	ReviewDepth string `json:"review_depth,omitempty"`
+
+	// JudgmentGateEnabled promotes quality review from measurement-only (Phase 1)
+	// to a real merge gate (Phase 2). When true, breach scores block merges and
+	// route feedback to the polecat for rework. Requires JudgmentEnabled.
+	// Nil defaults to false (measurement-only).
+	JudgmentGateEnabled *bool `json:"judgment_gate_enabled,omitempty"`
+
+	// JudgmentGateThreshold is the score below which a merge is blocked when
+	// judgment gating is enabled. Scores below this value are considered breaches.
+	// Zero value defaults to 0.45.
+	JudgmentGateThreshold float64 `json:"judgment_gate_threshold,omitempty"`
 }
 
 // OnConflict strategy constants.
@@ -1341,6 +1352,24 @@ func (c *MergeQueueConfig) GetReviewDepth() string {
 		return "standard"
 	}
 	return c.ReviewDepth
+}
+
+// IsJudgmentGateEnabled returns whether quality review acts as a merge gate.
+// Nil-safe, defaults to false.
+func (c *MergeQueueConfig) IsJudgmentGateEnabled() bool {
+	if c.JudgmentGateEnabled == nil {
+		return false
+	}
+	return *c.JudgmentGateEnabled
+}
+
+// GetJudgmentGateThreshold returns the score threshold below which merges are
+// blocked when judgment gating is enabled. Zero value defaults to 0.45.
+func (c *MergeQueueConfig) GetJudgmentGateThreshold() float64 {
+	if c.JudgmentGateThreshold == 0 {
+		return 0.45
+	}
+	return c.JudgmentGateThreshold
 }
 
 // boolPtr returns a pointer to a bool value.

--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -66,6 +66,8 @@ source of truth.
 | delete_merged_branches | true | Whether to delete source branches after merge |
 | judgment_enabled | false | Enable quality review for merges (true/false) |
 | review_depth | standard | Review depth: quick, standard, or deep |
+| judgment_gate_enabled | false | Promote quality review to a merge gate (Phase 2). Requires judgment_enabled. |
+| judgment_gate_threshold | 0.45 | Score below which merge is blocked when judgment gating is enabled |
 | merge_strategy | direct | Merge strategy: 'direct' (ff-only merge+push) or 'pr' (GitHub PR) |
 
 ## Target Resolution Rule
@@ -388,9 +390,14 @@ needs = ["run-tests"]
 description = """
 **Config: judgment_enabled = {{judgment_enabled}}**
 **Config: review_depth = {{review_depth}}**
+**Config: judgment_gate_enabled = {{judgment_gate_enabled}}**
+**Config: judgment_gate_threshold = {{judgment_gate_threshold}}**
 
-Review the merge diff for quality issues. This step is measurement-only (Phase 1):
-reviews are recorded but do NOT gate merges.
+Review the merge diff for quality issues.
+
+**Mode:**
+- If judgment_gate_enabled is "true": Phase 2 — breach scores BLOCK merges.
+- Otherwise: Phase 1 (measurement-only) — reviews are recorded but do NOT gate merges.
 
 **Step 1: Check if quality review is enabled**
 
@@ -443,12 +450,32 @@ bd create "quality-review: Score <score>, <recommendation>" -t chore --ephemeral
   --silent 2>/dev/null || true
 ```
 
-**Step 6: Handle breach scores (measurement-only)**
+**Step 6: Handle breach scores**
 
-If score < 0.45 (breach threshold):
+If score < {{judgment_gate_threshold}} (breach threshold):
+
+**If judgment_gate_enabled is "true" (Phase 2 — blocking gate):**
+- Record the breach wisp (same as measurement — Step 5 above)
+- Set the quality review outcome to BLOCKED:
+  - Write a file `.gt-quality-gate-blocked` in the repo root with content:
+    ```
+    QUALITY_GATE_BLOCKED=true
+    SCORE=<score>
+    THRESHOLD={{judgment_gate_threshold}}
+    ISSUES=<count>
+    REVIEW_SUMMARY=<one-line summary of critical/major issues>
+    ```
+  - This file signals handle-failures to send FIX_NEEDED instead of proceeding
+- Do NOT proceed to merge — handle-failures will route the feedback
+
+**If judgment_gate_enabled is NOT "true" (Phase 1 — measurement-only):**
 - Add a note to your merge summary: "Warning: Quality review breach (score: X.XX)"
 - List the critical/major issues found
 - Do NOT block the merge — Phase 1 is measurement-only
+- Proceed to handle-failures normally
+
+If score >= {{judgment_gate_threshold}}:
+- Remove `.gt-quality-gate-blocked` if it exists (ensure clean state)
 - Proceed to handle-failures normally
 
 Track: review score, recommendation, issue count, duration."""
@@ -459,6 +486,39 @@ title = "Handle quality check or test failures"
 needs = ["quality-review"]
 description = """
 **VERIFICATION GATE**: This step enforces the Beads Promise.
+
+**Step 0: Check for quality gate block (Phase 2)**
+
+If the file `.gt-quality-gate-blocked` exists in the repo root:
+1. Read its contents to get SCORE, THRESHOLD, ISSUES, and REVIEW_SUMMARY
+2. Treat this as a branch-caused failure (same as test failure):
+   - Abort merge (clean up temp branch)
+   - Send FIX_NEEDED to the polecat with the quality review feedback:
+     ```bash
+     gt mail send <rig>/polecats/<polecat-name> -s "FIX_NEEDED <polecat-name>" --stdin <<'BODY'
+     Branch: <branch>
+     Issue: <issue-id>
+     Polecat: <polecat-name>
+     Rig: <rig>
+     Target: <target-branch>
+     Failed-At: $(date -u +%Y-%m-%dT%H:%M:%SZ)
+     Failure-Type: quality-review
+     Error: Quality gate breach — score <SCORE> below threshold <THRESHOLD>. Issues: <REVIEW_SUMMARY>
+     MR-Bead-ID: <mr-bead-id>
+     Attempt-Number: <N>
+     BODY
+     ```
+   - Update the bead with failure details:
+     ```bash
+     bd update <issue-id> --notes "Quality gate breach (attempt <N>): score <SCORE> < threshold <THRESHOLD>. <REVIEW_SUMMARY>"
+     ```
+   - Clean up: `rm .gt-quality-gate-blocked`, clean temp branch
+   - Follow the FIX_NEEDED CHECKLIST below, then skip to loop-check
+3. Do NOT proceed to merge
+
+If `.gt-quality-gate-blocked` does NOT exist: continue with normal failure handling below.
+
+---
 
 If all checks and tests PASSED: This step auto-completes. Proceed to merge.
 


### PR DESCRIPTION
## Summary

Promotes the refinery's quality-review step from measurement-only (Phase 1) to an actual merge gate (Phase 2). When enabled, breach scores block merges and route feedback to the polecat for rework.

Builds on PR #3194 which wired `judgment_enabled` and `review_depth` from rig config to the refinery patrol.

## Background

- PRs #2167-#2169: Original Go-based "Guardian" system
- PR #2263 (Rob Fox, fix-merged by crew/jack): Replaced Guardian with wisp-based quality-review, explicitly labeled "measurement-only Phase 1"
- PR #3194: Wired `judgment_enabled` and `review_depth` from per-rig config to refinery patrol
- This PR: Completes Phase 2 — makes the quality review a real gate

## Changes

- `internal/config/types.go`: Add `JudgmentGateEnabled *bool` and `JudgmentGateThreshold float64` to `MergeQueueConfig` with accessor methods
- `internal/cmd/prime_molecule.go`: Wire new fields through `buildRefineryPatrolVars`
- `mol-refinery-patrol.formula.toml`: Update `quality-review` step to block merges when gate enabled and score < threshold; update `handle-failures` step to send FIX_NEEDED on quality breach
- `internal/cmd/patrol_helpers_test.go`: Test for new config wiring

## Gradual rollout

| Configuration | Behavior | Phase |
|---|---|---|
| `judgment_enabled: false` | No review | — |
| `judgment_enabled: true, judgment_gate_enabled: false` | Score and record, never block | Phase 1 |
| `judgment_enabled: true, judgment_gate_enabled: true` | Score and block on breach | Phase 2 |

## Usage

```json
{
  "merge_queue": {
    "judgment_enabled": true,
    "judgment_gate_enabled": true,
    "judgment_gate_threshold": 0.45,
    "review_depth": "deep"
  }
}
```

## Test plan

- [x] `go build ./...` passes
- [ ] Set Phase 1 config, verify scores recorded but merges proceed
- [ ] Set Phase 2 config, verify breach score blocks merge and sends FIX_NEEDED

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>