### PR TITLE
fix: use configured agent name for hooks sync, not resolved fallback

### DIFF
--- a/internal/cmd/hooks_sync.go
+++ b/internal/cmd/hooks_sync.go
@@ -127,17 +127,48 @@ func runHooksSync(cmd *cobra.Command, args []string) error {
 			if loc.Rig != "" {
 				rigPath = filepath.Join(townRoot, loc.Rig)
 			}
-			rc := config.ResolveRoleAgentConfig(loc.Role, townRoot, rigPath)
-			if rc == nil || rc.Hooks == nil || rc.Hooks.Provider == "" {
-				continue
-			}
-			// Claude targets are already handled by DiscoverTargets + syncTarget above.
-			if rc.Hooks.Provider == "claude" {
+
+			// Use ResolveRoleAgentName to get the *configured* agent name
+			// without binary validation. ResolveRoleAgentConfig falls back
+			// to Claude when the configured agent's binary isn't in PATH,
+			// which would cause us to skip syncing the hook files. But hook
+			// files should be synced based on config, not binary availability.
+			agentName, _ := config.ResolveRoleAgentName(loc.Role, townRoot, rigPath)
+			if agentName == "" || agentName == "claude" {
 				continue
 			}
 
-			preset := config.GetAgentPresetByName(rc.Hooks.Provider)
+			preset := config.GetAgentPresetByName(agentName)
+			if preset == nil {
+				// Not a known preset — try the full resolution path
+				rc := config.ResolveRoleAgentConfig(loc.Role, townRoot, rigPath)
+				if rc == nil || rc.Hooks == nil || rc.Hooks.Provider == "" || rc.Hooks.Provider == "claude" {
+					continue
+				}
+				preset = config.GetAgentPresetByName(rc.Hooks.Provider)
+			}
+
+			// Get hooks config from the preset or resolved config
+			var hooksProvider string
+			var hooksDir, settingsFile string
 			useSettingsDir := preset != nil && preset.HooksUseSettingsDir
+			if preset != nil {
+				rc := config.RuntimeConfigFromPreset(config.AgentPreset(agentName))
+				if rc == nil || rc.Hooks == nil {
+					continue
+				}
+				hooksProvider = rc.Hooks.Provider
+				hooksDir = rc.Hooks.Dir
+				settingsFile = rc.Hooks.SettingsFile
+			} else {
+				rc := config.ResolveRoleAgentConfig(loc.Role, townRoot, rigPath)
+				if rc == nil || rc.Hooks == nil || rc.Hooks.Provider == "" || rc.Hooks.Provider == "claude" {
+					continue
+				}
+				hooksProvider = rc.Hooks.Provider
+				hooksDir = rc.Hooks.Dir
+				settingsFile = rc.Hooks.SettingsFile
+			}
 
 			// Determine sync targets.
 			// - Town-level roles (mayor, deacon): the role dir IS the working directory.
@@ -152,7 +183,7 @@ func runHooksSync(cmd *cobra.Command, args []string) error {
 			}
 
 			for _, dir := range syncDirs {
-				targetPath := filepath.Join(dir, rc.Hooks.Dir, rc.Hooks.SettingsFile)
+				targetPath := filepath.Join(dir, hooksDir, settingsFile)
 				relPath, pathErr := filepath.Rel(townRoot, targetPath)
 				if pathErr != nil {
 					relPath = targetPath
@@ -160,18 +191,18 @@ func runHooksSync(cmd *cobra.Command, args []string) error {
 
 				if hooksSyncDryRun {
 					if _, statErr := os.Stat(targetPath); statErr == nil {
-						fmt.Printf("  %s %s %s\n", style.Warning.Render("~"), relPath, style.Dim.Render("(would check "+rc.Hooks.Provider+")"))
+						fmt.Printf("  %s %s %s\n", style.Warning.Render("~"), relPath, style.Dim.Render("(would check "+hooksProvider+")"))
 					} else {
-						fmt.Printf("  %s %s %s\n", style.Warning.Render("~"), relPath, style.Dim.Render("(would create "+rc.Hooks.Provider+")"))
+						fmt.Printf("  %s %s %s\n", style.Warning.Render("~"), relPath, style.Dim.Render("(would create "+hooksProvider+")"))
 						created++
 					}
 					continue
 				}
 
-				result, syncErr := hooks.SyncForRole(rc.Hooks.Provider, dir, dir, loc.Role,
-					rc.Hooks.Dir, rc.Hooks.SettingsFile, useSettingsDir)
+				result, syncErr := hooks.SyncForRole(hooksProvider, dir, dir, loc.Role,
+					hooksDir, settingsFile, useSettingsDir)
 				if syncErr != nil {
-					fmt.Printf("  %s %s (%s): %v\n", style.Error.Render("✖"), relPath, rc.Hooks.Provider, syncErr)
+					fmt.Printf("  %s %s (%s): %v\n", style.Error.Render("✖"), relPath, hooksProvider, syncErr)
 					errors++
 					failedTargets = append(failedTargets, relPath)
 					continue
@@ -179,13 +210,13 @@ func runHooksSync(cmd *cobra.Command, args []string) error {
 
 				switch result {
 				case hooks.SyncCreated:
-					fmt.Printf("  %s %s %s\n", style.Success.Render("✓"), relPath, style.Dim.Render("(created "+rc.Hooks.Provider+")"))
+					fmt.Printf("  %s %s %s\n", style.Success.Render("✓"), relPath, style.Dim.Render("(created "+hooksProvider+")"))
 					created++
 				case hooks.SyncUpdated:
-					fmt.Printf("  %s %s %s\n", style.Success.Render("✓"), relPath, style.Dim.Render("(updated "+rc.Hooks.Provider+")"))
+					fmt.Printf("  %s %s %s\n", style.Success.Render("✓"), relPath, style.Dim.Render("(updated "+hooksProvider+")"))
 					updated++
 				case hooks.SyncUnchanged:
-					fmt.Printf("  %s %s %s\n", style.Dim.Render("·"), relPath, style.Dim.Render("(unchanged "+rc.Hooks.Provider+")"))
+					fmt.Printf("  %s %s %s\n", style.Dim.Render("·"), relPath, style.Dim.Render("(unchanged "+hooksProvider+")"))
 					unchanged++
 				}
 			}

--- a/internal/cmd/wl_stamp_loop_test.go
+++ b/internal/cmd/wl_stamp_loop_test.go
@@ -126,8 +126,8 @@ func TestStampLoop_EndToEnd(t *testing.T) {
 }
 
 // TestStampLoop_SelfStampFails verifies the yearbook rule (author != subject).
+// Not parallel: mutates package-level wlStamp* globals.
 func TestStampLoop_SelfStampFails(t *testing.T) {
-	t.Parallel()
 
 	// Save/restore globals
 	origQ, origR, origC := wlStampQuality, wlStampReliability, wlStampCreativity
@@ -172,8 +172,8 @@ func TestStampLoop_SelfStampFails(t *testing.T) {
 }
 
 // TestStampLoop_InvalidValence verifies validation rejects out-of-range scores.
+// Not parallel: mutates package-level wlStamp* globals.
 func TestStampLoop_InvalidValence(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name     string
 		quality  float64

--- a/internal/doctor/hooks_sync_check.go
+++ b/internal/doctor/hooks_sync_check.go
@@ -99,16 +99,36 @@ func (c *HooksSyncCheck) Run(ctx *CheckContext) *CheckResult {
 			if loc.Rig != "" {
 				rigPath = filepath.Join(ctx.TownRoot, loc.Rig)
 			}
-			rc := config.ResolveRoleAgentConfig(loc.Role, ctx.TownRoot, rigPath)
-			if rc == nil || rc.Hooks == nil || rc.Hooks.Provider == "" {
-				continue
-			}
-			// Claude targets are handled by Loop 1.
-			if rc.Hooks.Provider == "claude" {
+
+			// Use ResolveRoleAgentName to get the *configured* agent name
+			// without binary validation. ResolveRoleAgentConfig falls back
+			// to Claude when the binary isn't in PATH, which would skip
+			// checking hook files for configured non-Claude agents.
+			agentName, _ := config.ResolveRoleAgentName(loc.Role, ctx.TownRoot, rigPath)
+			if agentName == "" || agentName == "claude" {
 				continue
 			}
 
-			preset := config.GetAgentPresetByName(rc.Hooks.Provider)
+			preset := config.GetAgentPresetByName(agentName)
+			var hooksProvider, hooksDir, settingsFile string
+			if preset != nil {
+				rc := config.RuntimeConfigFromPreset(config.AgentPreset(agentName))
+				if rc == nil || rc.Hooks == nil {
+					continue
+				}
+				hooksProvider = rc.Hooks.Provider
+				hooksDir = rc.Hooks.Dir
+				settingsFile = rc.Hooks.SettingsFile
+			} else {
+				rc := config.ResolveRoleAgentConfig(loc.Role, ctx.TownRoot, rigPath)
+				if rc == nil || rc.Hooks == nil || rc.Hooks.Provider == "" || rc.Hooks.Provider == "claude" {
+					continue
+				}
+				hooksProvider = rc.Hooks.Provider
+				hooksDir = rc.Hooks.Dir
+				settingsFile = rc.Hooks.SettingsFile
+			}
+
 			useSettingsDir := preset != nil && preset.HooksUseSettingsDir
 
 			var checkDirs []string
@@ -120,11 +140,11 @@ func (c *HooksSyncCheck) Run(ctx *CheckContext) *CheckResult {
 
 			for _, dir := range checkDirs {
 				totalTargets++
-				targetPath := filepath.Join(dir, rc.Hooks.Dir, rc.Hooks.SettingsFile)
+				targetPath := filepath.Join(dir, hooksDir, settingsFile)
 
-				expected, err := hooks.ComputeExpectedTemplate(rc.Hooks.Provider, rc.Hooks.SettingsFile, loc.Role)
+				expected, err := hooks.ComputeExpectedTemplate(hooksProvider, settingsFile, loc.Role)
 				if err != nil {
-					details = append(details, fmt.Sprintf("%s (%s): error computing template: %v", targetPath, rc.Hooks.Provider, err))
+					details = append(details, fmt.Sprintf("%s (%s): error computing template: %v", targetPath, hooksProvider, err))
 					continue
 				}
 
@@ -132,17 +152,17 @@ func (c *HooksSyncCheck) Run(ctx *CheckContext) *CheckResult {
 				if readErr != nil {
 					// File missing
 					c.templateOutOfSync = append(c.templateOutOfSync, templateTarget{
-						path: targetPath, dir: dir, provider: rc.Hooks.Provider,
-						role: loc.Role, hooksDir: rc.Hooks.Dir,
-						settingsFile: rc.Hooks.SettingsFile, useSettingsDir: useSettingsDir,
+						path: targetPath, dir: dir, provider: hooksProvider,
+						role: loc.Role, hooksDir: hooksDir,
+						settingsFile: settingsFile, useSettingsDir: useSettingsDir,
 					})
-					details = append(details, fmt.Sprintf("%s (%s): missing", targetPath, rc.Hooks.Provider))
+					details = append(details, fmt.Sprintf("%s (%s): missing", targetPath, hooksProvider))
 					continue
 				}
 
 				// Compare: structural for JSON, byte-exact for other files.
 				inSync := false
-				if filepath.Ext(rc.Hooks.SettingsFile) == ".json" {
+				if filepath.Ext(settingsFile) == ".json" {
 					inSync = hooks.TemplateContentEqual(expected, actual)
 				} else {
 					inSync = bytes.Equal(expected, actual)
@@ -150,11 +170,11 @@ func (c *HooksSyncCheck) Run(ctx *CheckContext) *CheckResult {
 
 				if !inSync {
 					c.templateOutOfSync = append(c.templateOutOfSync, templateTarget{
-						path: targetPath, dir: dir, provider: rc.Hooks.Provider,
-						role: loc.Role, hooksDir: rc.Hooks.Dir,
-						settingsFile: rc.Hooks.SettingsFile, useSettingsDir: useSettingsDir,
+						path: targetPath, dir: dir, provider: hooksProvider,
+						role: loc.Role, hooksDir: hooksDir,
+						settingsFile: settingsFile, useSettingsDir: useSettingsDir,
 					})
-					details = append(details, fmt.Sprintf("%s (%s): out of sync", targetPath, rc.Hooks.Provider))
+					details = append(details, fmt.Sprintf("%s (%s): out of sync", targetPath, hooksProvider))
 				}
 			}
 		}

--- a/internal/hooks/installer.go
+++ b/internal/hooks/installer.go
@@ -157,7 +157,7 @@ func resolveAndSubstitute(provider, hooksFile, role string) ([]byte, error) {
 }
 
 // writeTemplate resolves a template, substitutes placeholders, and writes it to targetPath.
-func writeTemplate(provider, role, hooksDir, hooksFile, targetPath string) error {
+func writeTemplate(provider, role, _, hooksFile, targetPath string) error {
 	content, err := resolveAndSubstitute(provider, hooksFile, role)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- `ResolveRoleAgentConfig` falls back to Claude when a configured non-Claude agent's binary isn't in PATH, which caused `gt hooks sync` and `gt doctor` to silently skip syncing hook files for agents like OpenCode
- Fix: use `ResolveRoleAgentName` to get the *configured* agent name without binary validation, then look up the preset directly for hook file info
- Hook files should be synced based on what's configured, not what's currently installed
- Also removes `t.Parallel()` from two tests that mutate package-level globals (race detector fix)

## Test plan

- [x] `TestHooksSyncCheck_TemplateAgent_InSync` passes
- [x] `TestHooksSyncCheck_TemplateAgent_OutOfSync` passes
- [x] `TestHooksSyncCheck_TemplateAgent_Missing` passes
- [ ] CI: full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>