### PR TITLE
fix(daemon): record plugin dispatch immediately to enforce cooldown gate

### DIFF
--- a/internal/daemon/handler.go
+++ b/internal/daemon/handler.go
@@ -300,6 +300,18 @@ func (d *Daemon) dispatchPlugins(mgr *dog.Manager, sm *dog.SessionManager, rigsC
 		}
 
 		d.logger.Printf("Handler: dispatched plugin %s to dog %s", p.Name, idleDog.Name)
+
+		// Record the dispatch immediately so the cooldown gate is satisfied
+		// for the next 1h regardless of what the dog does. Dogs create their
+		// own completion beads but don't reliably use the label convention the
+		// gate requires, causing infinite re-dispatch loops.
+		if _, err := recorder.RecordRun(plugin.PluginRunRecord{
+			PluginName: p.Name,
+			Result:     plugin.ResultSuccess,
+			Body:       fmt.Sprintf("Dispatched to dog %s", idleDog.Name),
+		}); err != nil {
+			d.logger.Printf("Handler: failed to record dispatch for plugin %s: %v", p.Name, err)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- Records plugin dispatch at invocation time instead of relying on dog completion beads
- Prevents infinite re-dispatch loops when dogs create completion beads without the required `type:plugin-run` + `plugin:<name>` labels
- Observed: `dolt-archive` was being dispatched every ~3 min for hours because the cooldown gate found 0 qualifying beads

## Test plan

- [ ] Verify daemon handler records dispatch immediately on plugin invocation
- [ ] Confirm cooldown gate prevents re-dispatch within cooldown period
- [ ] Test that plugins still execute correctly with early recording

Co-Authored-By: Claude Sonnet 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)