### PR TITLE
feat: add rig menu (C-b r) with per-rig status and actions

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -350,6 +350,7 @@ func init() {
 	rigCmd.AddCommand(rigRestartCmd)
 	rigCmd.AddCommand(rigShutdownCmd)
 	rigCmd.AddCommand(rigStartCmd)
+	rigCmd.AddCommand(rigMenuCmd)
 	rigCmd.AddCommand(rigStatusCmd)
 	rigCmd.AddCommand(rigStopCmd)
 
@@ -852,6 +853,129 @@ func runRigList(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+var rigMenuCmd = &cobra.Command{
+	Use:    "menu",
+	Short:  "Show interactive rig menu in tmux",
+	Long:   `Display a tmux popup menu listing all rigs with status indicators and per-rig actions.`,
+	Hidden: true, // Internal command called by keybinding
+	RunE:   runRigMenu,
+}
+
+func runRigMenu(cmd *cobra.Command, args []string) error {
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("not in a Gas Town workspace: %w", err)
+	}
+
+	rigsPath := filepath.Join(townRoot, "mayor", "rigs.json")
+	rigsConfig, err := config.LoadRigsConfig(rigsPath)
+	if err != nil || len(rigsConfig.Rigs) == 0 {
+		return fmt.Errorf("no rigs configured")
+	}
+
+	t := tmux.NewTmux()
+
+	type menuRig struct {
+		name     string
+		led      string
+		running  bool
+		opState  string
+		sortPrio int
+	}
+
+	var rigs []menuRig
+	for name := range rigsConfig.Rigs {
+		prefix := session.PrefixFor(name)
+		opState, _ := getRigOperationalState(townRoot, name)
+
+		witnessSession := session.WitnessSessionName(prefix)
+		refinerySession := session.RefinerySessionName(prefix)
+		hasWitness, _ := t.HasSession(witnessSession)
+		hasRefinery, _ := t.HasSession(refinerySession)
+
+		led := GetRigLED(hasWitness, hasRefinery, opState)
+		rigs = append(rigs, menuRig{
+			name:     name,
+			led:      led,
+			running:  hasWitness || hasRefinery,
+			opState:  opState,
+			sortPrio: rigStatePriority(hasWitness, hasRefinery, opState),
+		})
+	}
+
+	sort.Slice(rigs, func(i, j int) bool {
+		if rigs[i].sortPrio != rigs[j].sortPrio {
+			return rigs[i].sortPrio < rigs[j].sortPrio
+		}
+		return rigs[i].name < rigs[j].name
+	})
+
+	menuArgs := []string{
+		"display-menu",
+		"-T", "#[align=centre,fg=cyan,bold]⛽ Rigs", //nolint:misspell // tmux uses British spelling
+		"-x", "C",
+		"-y", "C",
+		"--",
+	}
+
+	keyIndex := 0
+	for _, r := range rigs {
+		// Rig name entry — opens status popup
+		space := " "
+		if r.led == "🅿️" {
+			space = "  "
+		}
+		label := fmt.Sprintf("%s%s%s", r.led, space, r.name)
+		key := shortcutKey(keyIndex)
+		action := fmt.Sprintf("display-popup -E -w 80 -h 25 -T ' %s ' 'gt rig status %s; echo; echo \"Press any key to close\"; read -rsn1'", r.name, r.name)
+		menuArgs = append(menuArgs, label, key, action)
+		keyIndex++
+
+		// Contextual actions (no shortcut keys)
+		if r.running {
+			menuArgs = append(menuArgs,
+				"   Stop", "", fmt.Sprintf("run-shell 'gt rig stop %s'", r.name),
+				"   Reboot", "", fmt.Sprintf("run-shell 'gt rig reboot %s'", r.name),
+			)
+		} else if r.opState == "PARKED" {
+			menuArgs = append(menuArgs,
+				"   Unpark", "", fmt.Sprintf("run-shell 'gt rig unpark %s'", r.name),
+				"   Start", "", fmt.Sprintf("run-shell 'gt rig start %s'", r.name),
+			)
+		} else if r.opState == "DOCKED" {
+			menuArgs = append(menuArgs,
+				"   Undock", "", fmt.Sprintf("run-shell 'gt rig undock %s'", r.name),
+			)
+		} else {
+			// Stopped but not parked/docked
+			menuArgs = append(menuArgs,
+				"   Start", "", fmt.Sprintf("run-shell 'gt rig start %s'", r.name),
+			)
+		}
+
+		// Park/dock available for non-parked/docked rigs
+		if r.opState != "PARKED" && r.opState != "DOCKED" {
+			menuArgs = append(menuArgs,
+				"   Park", "", fmt.Sprintf("run-shell 'gt rig park %s'", r.name),
+			)
+		}
+
+		// Separator between rigs
+		menuArgs = append(menuArgs, "")
+	}
+
+	tmuxPath, err := exec.LookPath("tmux")
+	if err != nil {
+		return fmt.Errorf("tmux not found: %w", err)
+	}
+
+	execCmd := exec.Command(tmuxPath, menuArgs...)
+	execCmd.Stdin = os.Stdin
+	execCmd.Stdout = os.Stdout
+	execCmd.Stderr = os.Stderr
+	return execCmd.Run()
 }
 
 func runRigRemove(cmd *cobra.Command, args []string) error {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2966,6 +2966,9 @@ func (t *Tmux) ConfigureGasTownSession(session string, theme *Theme, rig, worker
 	if err := t.SetAgentsBinding(session); err != nil {
 		return fmt.Errorf("setting agents binding: %w", err)
 	}
+	if err := t.SetRigMenuBinding(session); err != nil {
+		return fmt.Errorf("setting rig menu binding: %w", err)
+	}
 	if err := t.SetCycleBindings(session); err != nil {
 		return fmt.Errorf("setting cycle bindings: %w", err)
 	}
@@ -3116,7 +3119,8 @@ func (t *Tmux) isGTBinding(table, key string) bool {
 	}
 	// Unguarded form: direct GT commands set by EnsureBindingsOnSocket.
 	return strings.Contains(output, "gt agents menu") ||
-		strings.Contains(output, "gt feed --window")
+		strings.Contains(output, "gt feed --window") ||
+		strings.Contains(output, "gt rig menu")
 }
 
 // isGTBindingWithClient checks if the given key has a GT binding that includes
@@ -3355,6 +3359,25 @@ func (t *Tmux) SetAgentsBinding(session string) error {
 	return err
 }
 
+// SetRigMenuBinding configures C-b r to open the rig menu popup.
+// This runs `gt rig menu` which displays a tmux display-menu with all rigs
+// and per-rig actions (start, stop, park, etc.).
+func (t *Tmux) SetRigMenuBinding(session string) error {
+	if t.isGTBinding("prefix", "r") {
+		return nil
+	}
+	ifShell := fmt.Sprintf("echo '#{session_name}' | grep -Eq '%s'", sessionPrefixPattern())
+	fallback := t.getKeyBinding("prefix", "r")
+	if fallback == "" {
+		fallback = ":"
+	}
+	_, err := t.run("bind-key", "-T", "prefix", "r",
+		"if-shell", ifShell,
+		"run-shell 'gt rig menu'",
+		fallback)
+	return err
+}
+
 // EnsureBindingsOnSocket sets the gt agents menu and feed keybindings on a
 // specific tmux socket. This is used during gt up to ensure the bindings work
 // even when the user is on a different socket than the town socket.
@@ -3417,6 +3440,25 @@ func EnsureBindingsOnSocket(socket, townSocket string) error {
 			_, _ = t.run("bind-key", "-T", "prefix", "a",
 				"if-shell", ifShell,
 				"run-shell '"+feedCmd+"'",
+				fallback)
+		}
+	}
+
+	// Rig menu binding (prefix + r)
+	rigMenuCmd := "gt rig menu"
+	if townSocket != "" {
+		rigMenuCmd = fmt.Sprintf("GT_TOWN_SOCKET=%s gt rig menu", townSocket)
+	}
+	if !t.isGTBinding("prefix", "r") {
+		ifShell := fmt.Sprintf("echo '#{session_name}' | grep -Eq '%s'", sessionPrefixPattern())
+		fallback := t.getKeyBinding("prefix", "r")
+		if fallback == "" || fallback == ":" {
+			_, _ = t.run("bind-key", "-T", "prefix", "r",
+				"run-shell", rigMenuCmd)
+		} else {
+			_, _ = t.run("bind-key", "-T", "prefix", "r",
+				"if-shell", ifShell,
+				"run-shell '"+rigMenuCmd+"'",
 				fallback)
 		}
 	}


### PR DESCRIPTION
## Summary

- Adds `gt rig menu` command displaying a tmux `display-menu` with all rigs and LED status indicators
- Each rig entry opens a status popup; contextual actions (start/stop/reboot/park/unpark/undock) shown based on rig state
- Bound to `C-b r` in Gas Town sessions via `SetRigMenuBinding`

## Test plan

- [ ] Verify `C-b r` opens the rig menu in a Gas Town tmux session
- [ ] Confirm LED status indicators reflect actual rig states
- [ ] Test contextual actions (start/stop/reboot/park/unpark/undock) from menu

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)