### PR TITLE
feat: pluggable PushStrategy interface for gt done submission path

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -376,10 +376,17 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		polecat.TouchSessionHeartbeatWithState(townRoot, sessionName, polecat.HeartbeatExiting, "gt done", issueID)
 	}
 
-	// Get configured default branch for this rig
+	// Get configured default branch for this rig, and select push strategy.
 	defaultBranch := "main" // fallback
-	if rigCfg, err := rig.LoadRigConfig(filepath.Join(townRoot, rigName)); err == nil && rigCfg.DefaultBranch != "" {
-		defaultBranch = rigCfg.DefaultBranch
+	var pushStrategy PushStrategy = &DefaultPushStrategy{}
+	if rigCfg, err := rig.LoadRigConfig(filepath.Join(townRoot, rigName)); err == nil {
+		if rigCfg.DefaultBranch != "" {
+			defaultBranch = rigCfg.DefaultBranch
+		}
+		pushStrategy = selectPushStrategy(rigCfg)
+	}
+	if pushStrategy.Name() != "default" {
+		fmt.Printf("  Push strategy: %s\n", pushStrategy.Name())
 	}
 
 	// For COMPLETED, we need an issue ID and branch must not be the default branch
@@ -605,8 +612,11 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// Default: "mr" strategy (or no convoy) — push branch, create MR bead
 
 		// Pre-declare push variables for checkpoint goto (gt-aufru)
-		var refspec string
 		var pushErr error
+		verifyRemote := "origin"
+		if pushStrategy.IsFork() {
+			verifyRemote = "fork"
+		}
 
 		// Resume: skip push if already completed in a previous run (gt-aufru)
 		if checkpoints[CheckpointPushed] != "" {
@@ -623,78 +633,47 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// If the parent repo's submodule pointer references commits that don't
 		// exist on the submodule's remote, the Refinery MR will be broken.
 		// Detect modified submodules and push each one first.
-		pushSubmoduleChanges(g, defaultBranch)
-
-		// Use explicit refspec (branch:branch) to create the remote branch.
-		// Without refspec, git push follows the tracking config — polecat branches
-		// track origin/main, so a bare push sends commits to main directly,
-		// bypassing the MR/refinery flow (G20 root cause).
-		fmt.Printf("Pushing branch to remote...\n")
-		refspec = branch + ":" + branch
-		pushErr = g.Push("origin", refspec, false)
-		if pushErr != nil {
-			// Primary push failed — try fallback from the bare repo (GH #1348).
-			// When polecat sessions are reused or worktrees are stale, the worktree's
-			// git context may be broken. But the branch always exists in the bare repo
-			// (.repo.git) because worktree commits share the same object database.
-			style.PrintWarning("primary push failed: %v — trying bare repo fallback...", pushErr)
-			rigPath := filepath.Join(townRoot, rigName)
-			bareRepoPath := filepath.Join(rigPath, ".repo.git")
-			if _, statErr := os.Stat(bareRepoPath); statErr == nil {
-				bareGit := git.NewGitWithDir(bareRepoPath, "")
-				pushErr = bareGit.Push("origin", refspec, false)
-				if pushErr != nil {
-					style.PrintWarning("bare repo push also failed: %v", pushErr)
-				} else {
-					fmt.Printf("%s Branch pushed via bare repo fallback\n", style.Bold.Render("✓"))
-				}
-			} else {
-				// No bare repo — try mayor/rig as last resort
-				mayorPath := filepath.Join(rigPath, "mayor", "rig")
-				if _, statErr := os.Stat(mayorPath); statErr == nil {
-					mayorGit := git.NewGit(mayorPath)
-					pushErr = mayorGit.Push("origin", refspec, false)
-					if pushErr != nil {
-						style.PrintWarning("mayor/rig push also failed: %v", pushErr)
-					} else {
-						fmt.Printf("%s Branch pushed via mayor/rig fallback\n", style.Bold.Render("✓"))
-					}
-				}
-			}
+		// Submodule push only applies to the default (origin) strategy.
+		if !pushStrategy.IsFork() {
+			pushSubmoduleChanges(g, defaultBranch)
 		}
 
+		// Dispatch to push strategy. DefaultPushStrategy pushes to origin with
+		// bare repo / mayor fallbacks. ForkPushStrategy pushes to the fork remote.
+		fmt.Printf("Pushing branch to remote...\n")
+		pushErr = pushStrategy.Push(g, branch, townRoot, rigName)
 		if pushErr != nil {
-			// All push attempts failed
 			pushFailed = true
-			errMsg := fmt.Sprintf("push failed for branch '%s': %v", branch, pushErr)
+			errMsg := pushErr.Error()
 			doneErrors = append(doneErrors, errMsg)
 			style.PrintWarning("%s\nCommits exist locally but failed to push. Witness will be notified.", errMsg)
 			goto notifyWitness
 		}
 
-		// Verify the branch actually exists on remote (GH #1348).
-		// Push can return exit 0 without actually pushing (e.g., stale refs,
-		// worktree/bare-repo state mismatch). Verify before creating MR bead.
-		if exists, verifyErr := g.RemoteBranchExists("origin", branch); verifyErr != nil {
+		// Verify the branch actually exists on the target remote (GH #1348).
+		// Push can return exit 0 without actually pushing (e.g., stale refs).
+		// For fork strategy, verify against the fork remote; for default, origin.
+		if exists, verifyErr := g.RemoteBranchExists(verifyRemote, branch); verifyErr != nil {
 			style.PrintWarning("could not verify push: %v (proceeding optimistically)", verifyErr)
 		} else if !exists {
-			// Push "succeeded" but branch not on remote — try bare repo verification
-			// (worktree git may not see the pushed ref)
-			rigPath := filepath.Join(townRoot, rigName)
-			bareRepoPath := filepath.Join(rigPath, ".repo.git")
-			if _, statErr := os.Stat(bareRepoPath); statErr == nil {
-				bareGit := git.NewGitWithDir(bareRepoPath, "")
-				exists, verifyErr = bareGit.RemoteBranchExists("origin", branch)
+			// For default strategy: try bare repo verification as fallback.
+			if !pushStrategy.IsFork() {
+				rigPath := filepath.Join(townRoot, rigName)
+				bareRepoPath := filepath.Join(rigPath, ".repo.git")
+				if _, statErr := os.Stat(bareRepoPath); statErr == nil {
+					bareGit := git.NewGitWithDir(bareRepoPath, "")
+					exists, verifyErr = bareGit.RemoteBranchExists("origin", branch)
+				}
 			}
 			if verifyErr != nil || !exists {
 				pushFailed = true
-				errMsg := fmt.Sprintf("push appeared to succeed but branch '%s' not found on remote", branch)
+				errMsg := fmt.Sprintf("push appeared to succeed but branch '%s' not found on remote %s", branch, verifyRemote)
 				doneErrors = append(doneErrors, errMsg)
 				style.PrintWarning("%s\nThis may indicate a stale git context. Witness will be notified.", errMsg)
 				goto notifyWitness
 			}
 		}
-		fmt.Printf("%s Branch pushed to origin\n", style.Bold.Render("✓"))
+		fmt.Printf("%s Branch pushed to %s\n", style.Bold.Render("✓"), verifyRemote)
 
 		// Fix cleanup_status after successful push (gt-wcr).
 		// Status was detected before push, so "unpushed" is now stale.
@@ -861,7 +840,6 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		}
 
 		// Pre-declare for checkpoint goto (gt-aufru)
-		var existingMR *beads.Issue
 		var commitSHA string
 
 		// GH#3032: Resolve HEAD commit SHA for MR dedup.
@@ -870,149 +848,36 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// distinguishes genuinely new submissions from idempotent retries.
 		commitSHA, _ = g.Rev("HEAD")
 
-		// Resume: skip MR creation if already completed in a previous run (gt-aufru).
-		// Mirrors the push checkpoint pattern above. Without this, every retry
-		// re-attempts bd.Create which hits unique constraints or creates duplicates.
+		// Resume: skip submission if already completed in a previous run (gt-aufru).
 		if checkpoints[CheckpointMRCreated] != "" {
 			mrID = checkpoints[CheckpointMRCreated]
 			fmt.Printf("%s MR already created (resumed from checkpoint: %s)\n", style.Bold.Render("✓"), mrID)
 			goto afterMR
 		}
 
-		// Check if MR bead already exists for this branch+SHA (idempotency)
-		if commitSHA != "" {
-			existingMR, err = bd.FindMRForBranchAndSHA(branch, commitSHA)
-		} else {
-			existingMR, err = bd.FindMRForBranch(branch)
-		}
+		// Dispatch to push strategy for submission (MR bead or GitHub PR).
+		mrID, err = pushStrategy.Submit(StrategySubmitParams{
+			G:           g,
+			BD:          bd,
+			Branch:      branch,
+			Target:      target,
+			IssueID:     issueID,
+			Priority:    priority,
+			CommitSHA:   commitSHA,
+			Worker:      worker,
+			AgentBeadID: agentBeadID,
+			PreVerified: donePreVerified,
+			RigName:     rigName,
+		})
 		if err != nil {
-			style.PrintWarning("could not check for existing MR: %v", err)
-			// Continue with creation attempt - Create will fail if duplicate
-		}
-
-		if existingMR != nil {
-			// MR already exists with same branch AND commit — true idempotent retry
-			mrID = existingMR.ID
-			fmt.Printf("%s MR already exists (idempotent)\n", style.Bold.Render("✓"))
-			fmt.Printf("  MR ID: %s\n", style.Bold.Render(mrID))
-		} else {
-			// Build MR bead title and description
-			title := fmt.Sprintf("Merge: %s", issueID)
-			description := fmt.Sprintf("branch: %s\ntarget: %s\nsource_issue: %s\nrig: %s",
-				branch, target, issueID, rigName)
-			if commitSHA != "" {
-				description += fmt.Sprintf("\ncommit_sha: %s", commitSHA)
-			}
-			if worker != "" {
-				description += fmt.Sprintf("\nworker: %s", worker)
-			}
-			if agentBeadID != "" {
-				description += fmt.Sprintf("\nagent_bead: %s", agentBeadID)
-			}
-
-			// Add conflict resolution tracking fields (initialized, updated by Refinery)
-			description += "\nretry_count: 0"
-			description += "\nlast_conflict_sha: null"
-			description += "\nconflict_task_id: null"
-
-			// Phase 3: Add pre-verification metadata if polecat ran gates after rebasing.
-			// The refinery uses these fields to fast-path merge without re-running gates.
-			if donePreVerified {
-				description += "\npre_verified: true"
-				description += fmt.Sprintf("\npre_verified_at: %s", time.Now().UTC().Format(time.RFC3339))
-				// Capture current origin/target HEAD as the verified base.
-				// The polecat rebased onto this SHA before running gates.
-				if verifiedBase, baseErr := g.Rev("origin/" + target); baseErr == nil {
-					description += fmt.Sprintf("\npre_verified_base: %s", verifiedBase)
-				} else {
-					style.PrintWarning("could not resolve origin/%s for pre-verified base: %v (pre-verification data incomplete)", target, baseErr)
-				}
-			}
-
-			mrIssue, err := bd.Create(beads.CreateOptions{
-				Title:       title,
-				Labels:      []string{"gt:merge-request"},
-				Priority:    priority,
-				Description: description,
-				Ephemeral:   true,
-			})
-			if err != nil {
-				// Non-fatal: record the error and skip to notifyWitness.
-				// Push succeeded so branch is on remote, but MR bead failed.
-				// Set mrFailed so the witness knows not to send MERGE_READY.
-				mrFailed = true
-				errMsg := fmt.Sprintf("MR bead creation failed: %v", err)
-				doneErrors = append(doneErrors, errMsg)
-				style.PrintWarning("%s\nBranch is pushed but MR bead not created. Witness will be notified.", errMsg)
-				goto notifyWitness
-			}
-			mrID = mrIssue.ID
-
-			// Guard against empty ID from bd create (observed in ephemeral/wisp mode).
-			// Fail fast with a clear message rather than passing "" to bd.Show.
-			if mrID == "" {
-				mrFailed = true
-				errMsg := "MR bead creation returned empty ID"
-				doneErrors = append(doneErrors, errMsg)
-				style.PrintWarning("%s\nBranch is pushed but MR bead has no ID. Witness will be notified.", errMsg)
-				goto notifyWitness
-			}
-
-			// GH#1945: Verify MR bead is readable before considering it confirmed.
-			// bd.Create() succeeds when the bead is written locally, but if the write
-			// didn't persist (Dolt failure, corrupt state), we'd nuke the worktree
-			// with no MR in the queue — losing the polecat's work permanently.
-			if verifiedMR, verifyErr := bd.Show(mrID); verifyErr != nil || verifiedMR == nil {
-				mrFailed = true
-				errMsg := fmt.Sprintf("MR bead created but verification read-back failed (id=%s): %v", mrID, verifyErr)
-				doneErrors = append(doneErrors, errMsg)
-				style.PrintWarning("%s\nBranch is pushed but MR bead not confirmed. Preserving worktree.", errMsg)
-				goto notifyWitness
-			}
-
-			// GH#3032: Supersede older open MRs for the same source issue.
-			// When a polecat re-submits after fixing a gate failure, the old MR
-			// (same branch, different SHA) is stale. Close it so the refinery
-			// doesn't process the old submission.
-			if issueID != "" {
-				if oldMRs, findErr := bd.FindOpenMRsForIssue(issueID); findErr == nil {
-					for _, old := range oldMRs {
-						if old.ID == mrID {
-							continue // skip the one we just created
-						}
-						reason := fmt.Sprintf("superseded by %s", mrID)
-						if closeErr := bd.CloseWithReason(reason, old.ID); closeErr != nil {
-							style.PrintWarning("could not supersede old MR %s: %v", old.ID, closeErr)
-							continue
-						}
-						fmt.Printf("  %s Superseded old MR: %s\n", style.Dim.Render("○"), old.ID)
-					}
-				}
-			}
-
-			// Update agent bead with active_mr reference (for traceability)
-			if agentBeadID != "" {
-				if err := bd.UpdateAgentActiveMR(agentBeadID, mrID); err != nil {
-					style.PrintWarning("could not update agent bead with active_mr: %v", err)
-				}
-			}
-
-			// GH#2599: Back-link source issue to MR bead for discoverability.
-			if issueID != "" {
-				comment := fmt.Sprintf("MR created: %s", mrID)
-				if _, err := bd.Run("comments", "add", issueID, comment); err != nil {
-					style.PrintWarning("could not back-link source issue %s to MR %s: %v", issueID, mrID, err)
-				}
-			}
-
-			// Success output
-			fmt.Printf("%s Work submitted to merge queue (verified)\n", style.Bold.Render("✓"))
-			fmt.Printf("  MR ID: %s\n", style.Bold.Render(mrID))
-
-			// NOTE: Refinery nudge is deferred to AFTER the Dolt branch merge
-			// (see post-merge nudge below). Nudging here would race with the
-			// merge — refinery wakes up and queries main before the polecat's
-			// Dolt branch (containing the MR bead) is merged.
+			// Non-fatal: record the error and skip to notifyWitness.
+			// Push succeeded so branch is on remote, but submission failed.
+			// Set mrFailed so the witness knows not to send MERGE_READY.
+			mrFailed = true
+			errMsg := err.Error()
+			doneErrors = append(doneErrors, errMsg)
+			style.PrintWarning("%s\nBranch is pushed but submission failed. Witness will be notified.", errMsg)
+			goto notifyWitness
 		}
 
 		// Write MR checkpoint for resume (gt-aufru)
@@ -1030,7 +895,11 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		}
 		fmt.Printf("  Priority: P%d\n", priority)
 		fmt.Println()
-		fmt.Printf("%s\n", style.Dim.Render("The Refinery will process your merge request."))
+		if pushStrategy.IsFork() {
+			fmt.Printf("%s\n", style.Dim.Render("Pull request submitted for review."))
+		} else {
+			fmt.Printf("%s\n", style.Dim.Render("The Refinery will process your merge request."))
+		}
 	} else {
 		// For ESCALATED or DEFERRED, just print status
 		fmt.Printf("%s Signaling %s\n", style.Bold.Render("→"), exitType)
@@ -1041,8 +910,9 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 	}
 
 notifyWitness:
-	// Nudge refinery — MR bead is already on main (transaction-based shared main).
-	if mrID != "" {
+	// Nudge refinery for default strategy — MR bead is on main (Dolt shared main).
+	// Fork strategy uses GitHub review, not Refinery, so skip the nudge.
+	if mrID != "" && !pushStrategy.IsFork() {
 		nudgeRefinery(rigName, "MERGE_READY received - check inbox for pending work")
 	}
 

--- a/internal/cmd/push_strategy.go
+++ b/internal/cmd/push_strategy.go
@@ -1,0 +1,340 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/rig"
+	"github.com/steveyegge/gastown/internal/style"
+)
+
+// PushStrategy abstracts the branch push and merge submission mechanism.
+// Implementations differ in how they push (origin vs fork remote) and how
+// they submit work for merge (MR bead vs GitHub PR).
+//
+// The strategy is selected per-rig based on rig config:
+//   - DefaultPushStrategy: push to origin, submit via MR bead (Refinery workflow)
+//   - ForkPushStrategy: push to fork remote, submit via GitHub PR (fork workflow)
+type PushStrategy interface {
+	// Name returns a human-readable identifier for logging and diagnostics.
+	Name() string
+	// IsFork returns true if this strategy uses a fork/PR workflow.
+	// Used by tap guards to allow or block gh pr create operations.
+	IsFork() bool
+	// Push pushes the branch to the appropriate remote. Returns an error if all
+	// push attempts fail. The townRoot and rigName are used for fallback paths.
+	Push(g *git.Git, branch, townRoot, rigName string) error
+	// Submit creates the merge request: an MR bead (DefaultPushStrategy) or
+	// a GitHub PR (ForkPushStrategy). Returns the resulting MR/PR identifier.
+	Submit(params StrategySubmitParams) (string, error)
+}
+
+// StrategySubmitParams holds the parameters needed for Submit().
+type StrategySubmitParams struct {
+	G           *git.Git
+	BD          *beads.Beads
+	Branch      string
+	Target      string
+	IssueID     string
+	Priority    int
+	CommitSHA   string
+	Worker      string
+	AgentBeadID string
+	PreVerified bool
+	RigName     string
+}
+
+// selectPushStrategy returns the PushStrategy for the given rig config.
+// Uses ForkPushStrategy when the rig has a PushURL (indicating a fork
+// workflow), DefaultPushStrategy otherwise.
+func selectPushStrategy(rigCfg *rig.RigConfig) PushStrategy {
+	if rigCfg != nil && rigCfg.PushURL != "" {
+		return &ForkPushStrategy{pushURL: rigCfg.PushURL, upstreamURL: rigCfg.UpstreamURL}
+	}
+	return &DefaultPushStrategy{}
+}
+
+// ─── DefaultPushStrategy ─────────────────────────────────────────────────────
+
+// DefaultPushStrategy pushes to origin and submits via MR bead.
+// This is the standard Gas Town workflow where the Refinery merges the work.
+type DefaultPushStrategy struct{}
+
+func (s *DefaultPushStrategy) Name() string  { return "default" }
+func (s *DefaultPushStrategy) IsFork() bool  { return false }
+
+// Push pushes the branch to origin with fallback to bare repo and mayor/rig.
+func (s *DefaultPushStrategy) Push(g *git.Git, branch, townRoot, rigName string) error {
+	refspec := branch + ":" + branch
+	err := g.Push("origin", refspec, false)
+	if err == nil {
+		return nil
+	}
+
+	// Primary push failed — try fallback from the bare repo (GH #1348).
+	style.PrintWarning("primary push failed: %v — trying bare repo fallback...", err)
+	rigPath := filepath.Join(townRoot, rigName)
+	bareRepoPath := filepath.Join(rigPath, ".repo.git")
+	if _, statErr := os.Stat(bareRepoPath); statErr == nil {
+		bareGit := git.NewGitWithDir(bareRepoPath, "")
+		if bareErr := bareGit.Push("origin", refspec, false); bareErr != nil {
+			style.PrintWarning("bare repo push also failed: %v", bareErr)
+		} else {
+			fmt.Printf("%s Branch pushed via bare repo fallback\n", style.Bold.Render("✓"))
+			return nil
+		}
+	} else {
+		// No bare repo — try mayor/rig as last resort.
+		mayorPath := filepath.Join(rigPath, "mayor", "rig")
+		if _, statErr := os.Stat(mayorPath); statErr == nil {
+			mayorGit := git.NewGit(mayorPath)
+			if mayorErr := mayorGit.Push("origin", refspec, false); mayorErr != nil {
+				style.PrintWarning("mayor/rig push also failed: %v", mayorErr)
+			} else {
+				fmt.Printf("%s Branch pushed via mayor/rig fallback\n", style.Bold.Render("✓"))
+				return nil
+			}
+		}
+	}
+
+	return fmt.Errorf("push failed for branch '%s': %w", branch, err)
+}
+
+// Submit creates an MR bead in the shared beads store for the Refinery to process.
+func (s *DefaultPushStrategy) Submit(params StrategySubmitParams) (string, error) {
+	if params.BD == nil {
+		return "", fmt.Errorf("beads instance required for default push strategy submit")
+	}
+
+	// Check for an existing MR bead (idempotency).
+	var (
+		existingMR *beads.Issue
+		err        error
+	)
+	if params.CommitSHA != "" {
+		existingMR, err = params.BD.FindMRForBranchAndSHA(params.Branch, params.CommitSHA)
+	} else {
+		existingMR, err = params.BD.FindMRForBranch(params.Branch)
+	}
+	if err != nil {
+		style.PrintWarning("could not check for existing MR: %v", err)
+	}
+
+	if existingMR != nil {
+		mrID := existingMR.ID
+		fmt.Printf("%s MR already exists (idempotent)\n", style.Bold.Render("✓"))
+		fmt.Printf("  MR ID: %s\n", style.Bold.Render(mrID))
+		return mrID, nil
+	}
+
+	// Build MR bead description.
+	description := fmt.Sprintf("branch: %s\ntarget: %s\nsource_issue: %s\nrig: %s",
+		params.Branch, params.Target, params.IssueID, params.RigName)
+	if params.CommitSHA != "" {
+		description += fmt.Sprintf("\ncommit_sha: %s", params.CommitSHA)
+	}
+	if params.Worker != "" {
+		description += fmt.Sprintf("\nworker: %s", params.Worker)
+	}
+	if params.AgentBeadID != "" {
+		description += fmt.Sprintf("\nagent_bead: %s", params.AgentBeadID)
+	}
+	description += "\nretry_count: 0"
+	description += "\nlast_conflict_sha: null"
+	description += "\nconflict_task_id: null"
+
+	if params.PreVerified {
+		description += "\npre_verified: true"
+		description += fmt.Sprintf("\npre_verified_at: %s", time.Now().UTC().Format(time.RFC3339))
+		if verifiedBase, baseErr := params.G.Rev("origin/" + params.Target); baseErr == nil {
+			description += fmt.Sprintf("\npre_verified_base: %s", verifiedBase)
+		} else {
+			style.PrintWarning("could not resolve origin/%s for pre-verified base: %v", params.Target, baseErr)
+		}
+	}
+
+	mrIssue, err := params.BD.Create(beads.CreateOptions{
+		Title:       fmt.Sprintf("Merge: %s", params.IssueID),
+		Labels:      []string{"gt:merge-request"},
+		Priority:    params.Priority,
+		Description: description,
+		Ephemeral:   true,
+	})
+	if err != nil {
+		return "", fmt.Errorf("MR bead creation failed: %w", err)
+	}
+	mrID := mrIssue.ID
+	if mrID == "" {
+		return "", fmt.Errorf("MR bead creation returned empty ID")
+	}
+
+	// Verify MR bead is readable (GH#1945).
+	if verified, verifyErr := params.BD.Show(mrID); verifyErr != nil || verified == nil {
+		return "", fmt.Errorf("MR bead created but verification read-back failed (id=%s): %w", mrID, verifyErr)
+	}
+
+	// Supersede older open MRs for the same source issue (GH#3032).
+	if params.IssueID != "" {
+		if oldMRs, findErr := params.BD.FindOpenMRsForIssue(params.IssueID); findErr == nil {
+			for _, old := range oldMRs {
+				if old.ID == mrID {
+					continue
+				}
+				reason := fmt.Sprintf("superseded by %s", mrID)
+				if closeErr := params.BD.CloseWithReason(reason, old.ID); closeErr != nil {
+					style.PrintWarning("could not supersede old MR %s: %v", old.ID, closeErr)
+					continue
+				}
+				fmt.Printf("  %s Superseded old MR: %s\n", style.Dim.Render("○"), old.ID)
+			}
+		}
+	}
+
+	// Update agent bead with active_mr reference.
+	if params.AgentBeadID != "" {
+		if err := params.BD.UpdateAgentActiveMR(params.AgentBeadID, mrID); err != nil {
+			style.PrintWarning("could not update agent bead with active_mr: %v", err)
+		}
+	}
+
+	// Back-link source issue to MR bead (GH#2599).
+	if params.IssueID != "" {
+		comment := fmt.Sprintf("MR created: %s", mrID)
+		if _, err := params.BD.Run("comments", "add", params.IssueID, comment); err != nil {
+			style.PrintWarning("could not back-link source issue %s to MR %s: %v", params.IssueID, mrID, err)
+		}
+	}
+
+	fmt.Printf("%s Work submitted to merge queue (verified)\n", style.Bold.Render("✓"))
+	fmt.Printf("  MR ID: %s\n", style.Bold.Render(mrID))
+
+	return mrID, nil
+}
+
+// ─── ForkPushStrategy ────────────────────────────────────────────────────────
+
+// ForkPushStrategy pushes to the configured fork remote and submits via GitHub PR.
+// Used for rigs where origin is read-only (e.g., upstream maintainer repos) and
+// contributions go through a fork + pull request workflow.
+type ForkPushStrategy struct {
+	pushURL     string // fork remote URL (rig.PushURL)
+	upstreamURL string // upstream URL (rig.UpstreamURL), used for PR base
+}
+
+func (s *ForkPushStrategy) Name() string  { return "fork" }
+func (s *ForkPushStrategy) IsFork() bool  { return true }
+
+// Push pushes the branch to the fork remote ("fork" by convention).
+func (s *ForkPushStrategy) Push(g *git.Git, branch, townRoot, rigName string) error {
+	forkRemote := "fork"
+	refspec := branch + ":" + branch
+
+	fmt.Printf("Pushing branch to fork remote (%s)...\n", forkRemote)
+	if err := g.Push(forkRemote, refspec, false); err != nil {
+		return fmt.Errorf("fork push failed for branch '%s': %w", branch, err)
+	}
+	fmt.Printf("%s Branch pushed to %s\n", style.Bold.Render("✓"), forkRemote)
+	return nil
+}
+
+// Submit creates a GitHub PR from the fork branch to the upstream repo.
+// Returns the PR URL as the submission identifier.
+func (s *ForkPushStrategy) Submit(params StrategySubmitParams) (string, error) {
+	// Determine the fork org from the push URL.
+	forkOrg, err := extractGitHubOrg(s.pushURL)
+	if err != nil {
+		return "", fmt.Errorf("cannot determine fork org from push URL %q: %w", s.pushURL, err)
+	}
+
+	// Determine upstream repo path for --repo flag.
+	upstreamRepo, err := extractGitHubRepo(s.upstreamURL)
+	if err != nil {
+		// Fallback: use origin remote URL from git config.
+		if originURL, gErr := params.G.RemoteURL("origin"); gErr == nil {
+			upstreamRepo, err = extractGitHubRepo(originURL)
+		}
+		if err != nil {
+			return "", fmt.Errorf("cannot determine upstream repo: %w", err)
+		}
+	}
+
+	title := fmt.Sprintf("Merge: %s", params.IssueID)
+	body := fmt.Sprintf("source_issue: %s\nbranch: %s\ntarget: %s\nrig: %s\nstrategy: fork",
+		params.IssueID, params.Branch, params.Target, params.RigName)
+	if params.CommitSHA != "" {
+		body += fmt.Sprintf("\ncommit_sha: %s", params.CommitSHA)
+	}
+	if params.Worker != "" {
+		body += fmt.Sprintf("\nworker: %s", params.Worker)
+	}
+
+	// head is "forkOrg:branch" for cross-repo PRs.
+	head := forkOrg + ":" + params.Branch
+
+	fmt.Printf("Creating GitHub PR from %s to %s/%s...\n", head, upstreamRepo, params.Target)
+
+	args := []string{
+		"pr", "create",
+		"--repo", upstreamRepo,
+		"--head", head,
+		"--base", params.Target,
+		"--title", title,
+		"--body", body,
+	}
+
+	cmd := exec.Command("gh", args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return "", fmt.Errorf("gh pr create failed: %w\nOutput: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	prURL := strings.TrimSpace(string(out))
+	fmt.Printf("%s Pull request created\n", style.Bold.Render("✓"))
+	fmt.Printf("  PR: %s\n", style.Bold.Render(prURL))
+
+	return prURL, nil
+}
+
+// extractGitHubOrg returns the org/user part from a GitHub remote URL.
+// Supports both HTTPS and SSH URL formats.
+func extractGitHubOrg(remoteURL string) (string, error) {
+	// HTTPS: https://github.com/org/repo.git
+	if strings.HasPrefix(remoteURL, "https://github.com/") {
+		path := strings.TrimPrefix(remoteURL, "https://github.com/")
+		parts := strings.SplitN(path, "/", 2)
+		if len(parts) >= 1 && parts[0] != "" {
+			return parts[0], nil
+		}
+	}
+	// SSH: git@github.com:org/repo.git
+	if strings.HasPrefix(remoteURL, "git@github.com:") {
+		path := strings.TrimPrefix(remoteURL, "git@github.com:")
+		parts := strings.SplitN(path, "/", 2)
+		if len(parts) >= 1 && parts[0] != "" {
+			return parts[0], nil
+		}
+	}
+	return "", fmt.Errorf("unsupported remote URL format (expected GitHub HTTPS or SSH): %q", remoteURL)
+}
+
+// extractGitHubRepo returns the "org/repo" path from a GitHub remote URL.
+// Supports both HTTPS and SSH URL formats.
+func extractGitHubRepo(remoteURL string) (string, error) {
+	// HTTPS: https://github.com/org/repo.git
+	if strings.HasPrefix(remoteURL, "https://github.com/") {
+		path := strings.TrimPrefix(remoteURL, "https://github.com/")
+		return strings.TrimSuffix(path, ".git"), nil
+	}
+	// SSH: git@github.com:org/repo.git
+	if strings.HasPrefix(remoteURL, "git@github.com:") {
+		path := strings.TrimPrefix(remoteURL, "git@github.com:")
+		return strings.TrimSuffix(path, ".git"), nil
+	}
+	return "", fmt.Errorf("unsupported remote URL format (expected GitHub HTTPS or SSH): %q", remoteURL)
+}

--- a/internal/cmd/push_strategy_test.go
+++ b/internal/cmd/push_strategy_test.go
@@ -1,0 +1,280 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/rig"
+)
+
+// ─── selectPushStrategy ──────────────────────────────────────────────────────
+
+func TestSelectPushStrategyDefault(t *testing.T) {
+	// No PushURL → DefaultPushStrategy
+	cfg := &rig.RigConfig{Name: "testrip"}
+	s := selectPushStrategy(cfg)
+	if s.Name() != "default" {
+		t.Errorf("got strategy %q, want %q", s.Name(), "default")
+	}
+	if s.IsFork() {
+		t.Error("expected IsFork()=false for default strategy")
+	}
+}
+
+func TestSelectPushStrategyFork(t *testing.T) {
+	cfg := &rig.RigConfig{
+		Name:    "testrip",
+		PushURL: "https://github.com/myfork/repo.git",
+	}
+	s := selectPushStrategy(cfg)
+	if s.Name() != "fork" {
+		t.Errorf("got strategy %q, want %q", s.Name(), "fork")
+	}
+	if !s.IsFork() {
+		t.Error("expected IsFork()=true for fork strategy")
+	}
+}
+
+func TestSelectPushStrategyNilConfig(t *testing.T) {
+	s := selectPushStrategy(nil)
+	if s.Name() != "default" {
+		t.Errorf("got strategy %q, want %q for nil config", s.Name(), "default")
+	}
+}
+
+// ─── extractGitHubOrg ────────────────────────────────────────────────────────
+
+func TestExtractGitHubOrgHTTPS(t *testing.T) {
+	tests := []struct {
+		url     string
+		wantOrg string
+		wantErr bool
+	}{
+		{"https://github.com/myorg/myrepo.git", "myorg", false},
+		{"https://github.com/quad341/gastown.git", "quad341", false},
+		{"git@github.com:myorg/myrepo.git", "myorg", false},
+		{"https://gitlab.com/myorg/myrepo.git", "", true},
+		{"not-a-url", "", true},
+		{"", "", true},
+	}
+	for _, tt := range tests {
+		got, err := extractGitHubOrg(tt.url)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("extractGitHubOrg(%q): expected error, got %q", tt.url, got)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("extractGitHubOrg(%q): unexpected error: %v", tt.url, err)
+			}
+			if got != tt.wantOrg {
+				t.Errorf("extractGitHubOrg(%q) = %q, want %q", tt.url, got, tt.wantOrg)
+			}
+		}
+	}
+}
+
+func TestExtractGitHubRepo(t *testing.T) {
+	tests := []struct {
+		url      string
+		wantRepo string
+		wantErr  bool
+	}{
+		{"https://github.com/myorg/myrepo.git", "myorg/myrepo", false},
+		{"https://github.com/steveyegge/gastown.git", "steveyegge/gastown", false},
+		{"git@github.com:myorg/myrepo.git", "myorg/myrepo", false},
+		{"https://gitlab.com/myorg/myrepo.git", "", true},
+	}
+	for _, tt := range tests {
+		got, err := extractGitHubRepo(tt.url)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("extractGitHubRepo(%q): expected error, got %q", tt.url, got)
+			}
+		} else {
+			if err != nil {
+				t.Errorf("extractGitHubRepo(%q): unexpected error: %v", tt.url, err)
+			}
+			if got != tt.wantRepo {
+				t.Errorf("extractGitHubRepo(%q) = %q, want %q", tt.url, got, tt.wantRepo)
+			}
+		}
+	}
+}
+
+// ─── DefaultPushStrategy.Push failure paths ──────────────────────────────────
+
+func TestDefaultPushStrategyPushFailsAllPaths(t *testing.T) {
+	// Create a git repo with no remotes so all push attempts fail.
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repoDir, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	g := git.NewGit(repoDir)
+
+	s := &DefaultPushStrategy{}
+	err := s.Push(g, "polecat/test/branch", tmpDir, "testrip")
+	if err == nil {
+		t.Error("expected push to fail when no remote configured, got nil error")
+	}
+}
+
+func TestDefaultPushStrategyPushSucceedsWithOrigin(t *testing.T) {
+	// Create an origin bare repo and a clone pointing to it.
+	tmpDir := t.TempDir()
+
+	// Bare "origin"
+	originDir := filepath.Join(tmpDir, "origin.git")
+	if out, err := exec.Command("git", "init", "--bare", originDir).CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare: %v\n%s", err, out)
+	}
+
+	// Clone with a branch
+	cloneDir := filepath.Join(tmpDir, "clone")
+	if out, err := exec.Command("git", "clone", originDir, cloneDir).CombinedOutput(); err != nil {
+		t.Fatalf("git clone: %v\n%s", err, out)
+	}
+	// Create a commit so we have something to push
+	testFile := filepath.Join(cloneDir, "test.txt")
+	if err := os.WriteFile(testFile, []byte("test"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", cloneDir, "config", "user.email", "test@test.com").CombinedOutput(); err != nil {
+		t.Fatalf("git config email: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", cloneDir, "config", "user.name", "Test").CombinedOutput(); err != nil {
+		t.Fatalf("git config name: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", cloneDir, "add", ".").CombinedOutput(); err != nil {
+		t.Fatalf("git add: %v\n%s", err, out)
+	}
+	if out, err := exec.Command("git", "-C", cloneDir, "commit", "-m", "init").CombinedOutput(); err != nil {
+		t.Fatalf("git commit: %v\n%s", err, out)
+	}
+
+	// Create a feature branch
+	branchName := "polecat/test/feature"
+	if out, err := exec.Command("git", "-C", cloneDir, "checkout", "-b", branchName).CombinedOutput(); err != nil {
+		t.Fatalf("git checkout -b: %v\n%s", err, out)
+	}
+
+	g := git.NewGit(cloneDir)
+	s := &DefaultPushStrategy{}
+	err := s.Push(g, branchName, tmpDir, "testrip")
+	if err != nil {
+		t.Errorf("unexpected push error: %v", err)
+	}
+}
+
+// ─── DefaultPushStrategy.Submit failure paths ────────────────────────────────
+
+func TestDefaultPushStrategySubmitNilBeads(t *testing.T) {
+	s := &DefaultPushStrategy{}
+	_, err := s.Submit(StrategySubmitParams{
+		BD:      nil,
+		Branch:  "polecat/test/branch",
+		IssueID: "gas-abc",
+	})
+	if err == nil {
+		t.Error("expected error when BD is nil, got nil")
+	}
+}
+
+// TestDefaultPushStrategySubmitIDempotent verifies that if an MR bead already
+// exists for the branch+SHA, Submit returns the existing MR ID without creating
+// a new one.
+func TestDefaultPushStrategySubmitIDempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	bdDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(bdDir, 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	bd := beads.New(tmpDir)
+	if bd == nil {
+		t.Skip("beads.New returned nil — no beads DB in test environment")
+	}
+
+	// If beads isn't initialized, skip rather than fail.
+	existingMR, err := bd.FindMRForBranchAndSHA("polecat/test/br", "abc123")
+	if err != nil && errors.Is(err, errors.New("test")) {
+		t.Skip("beads not available in test environment")
+	}
+	if existingMR != nil {
+		// Already exists — verify idempotency by calling Submit.
+		s := &DefaultPushStrategy{}
+		mrID, submitErr := s.Submit(StrategySubmitParams{
+			BD:        bd,
+			Branch:    "polecat/test/br",
+			CommitSHA: "abc123",
+			IssueID:   "gas-abc",
+		})
+		if submitErr != nil {
+			t.Errorf("unexpected submit error: %v", submitErr)
+		}
+		if mrID != existingMR.ID {
+			t.Errorf("idempotent submit returned %q, want %q", mrID, existingMR.ID)
+		}
+	}
+	// Test passes if no existing MR (can't fully test without initialized beads).
+}
+
+// ─── ForkPushStrategy.Submit ─────────────────────────────────────────────────
+
+func TestForkPushStrategySubmitBadPushURL(t *testing.T) {
+	s := &ForkPushStrategy{
+		pushURL:     "https://gitlab.com/myorg/repo.git", // not GitHub
+		upstreamURL: "https://github.com/upstream/repo.git",
+	}
+	g := git.NewGit(t.TempDir())
+	_, err := s.Submit(StrategySubmitParams{
+		G:        g,
+		Branch:   "polecat/test/br",
+		Target:   "main",
+		IssueID:  "gas-abc",
+		RigName:  "testrip",
+		Priority: 2,
+	})
+	if err == nil {
+		t.Error("expected error for non-GitHub push URL, got nil")
+	}
+}
+
+func TestForkPushStrategyIsFork(t *testing.T) {
+	s := &ForkPushStrategy{pushURL: "https://github.com/org/repo.git"}
+	if !s.IsFork() {
+		t.Error("ForkPushStrategy.IsFork() should return true")
+	}
+	if s.Name() != "fork" {
+		t.Errorf("ForkPushStrategy.Name() = %q, want %q", s.Name(), "fork")
+	}
+}
+
+// ─── ForkPushStrategy.Push failure path ──────────────────────────────────────
+
+func TestForkPushStrategyPushNoForkRemote(t *testing.T) {
+	// Create a repo with no "fork" remote; push should fail.
+	tmpDir := t.TempDir()
+	repoDir := filepath.Join(tmpDir, "repo")
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if out, err := exec.Command("git", "-C", repoDir, "init").CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+
+	g := git.NewGit(repoDir)
+	s := &ForkPushStrategy{pushURL: "https://github.com/myorg/repo.git"}
+	err := s.Push(g, "polecat/test/branch", tmpDir, "testrip")
+	if err == nil {
+		t.Error("expected push error when fork remote doesn't exist, got nil")
+	}
+}

--- a/internal/cmd/tap_guard.go
+++ b/internal/cmd/tap_guard.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/rig"
+	"github.com/steveyegge/gastown/internal/workspace"
 )
 
 var tapGuardCmd = &cobra.Command{
@@ -69,6 +72,12 @@ func init() {
 func runTapGuardPRWorkflow(cmd *cobra.Command, args []string) error {
 	// Check if we're in a Gas Town agent context
 	if isGasTownAgentContext() {
+		// If the rig uses a fork push strategy, PR creation is part of the
+		// submission flow (ForkPushStrategy.Submit calls gh pr create).
+		// Allow it rather than blocking.
+		if isRigForkStrategy() {
+			return nil
+		}
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "╔══════════════════════════════════════════════════════════════════╗")
 		fmt.Fprintln(os.Stderr, "║  ❌ PR WORKFLOW BLOCKED                                          ║")
@@ -136,6 +145,35 @@ func isGasTownAgentContext() bool {
 	}
 
 	return false
+}
+
+// isRigForkStrategy returns true if the current rig is configured to use the
+// fork push strategy (i.e., rig config has a PushURL set). Agents in fork rigs
+// need to run gh pr create as part of the submission flow.
+func isRigForkStrategy() bool {
+	townRoot, cwd, err := workspace.FindFromCwdWithFallback()
+	if err != nil || cwd == "" {
+		return false
+	}
+	// Derive rig name from cwd relative to town root.
+	relPath, err := filepath.Rel(townRoot, cwd)
+	if err != nil {
+		return false
+	}
+	parts := strings.SplitN(relPath, string(filepath.Separator), 2)
+	if len(parts) == 0 || parts[0] == "" || parts[0] == "." {
+		return false
+	}
+	rigName := parts[0]
+	if envRig := os.Getenv("GT_RIG"); envRig != "" {
+		rigName = envRig
+	}
+
+	rigCfg, err := rig.LoadRigConfig(filepath.Join(townRoot, rigName))
+	if err != nil {
+		return false
+	}
+	return selectPushStrategy(rigCfg).IsFork()
 }
 
 // isMaintainerOrigin returns true if the origin remote points to the maintainer's repo.

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -762,6 +762,14 @@ func (m *Manager) addWithOptionsLocked(name string, opts AddOptions, polecatDir 
 		style.PrintWarning("could not provision polecat CLAUDE.md: %v", err)
 	}
 
+	// Ensure fork remote is configured in the bare repo for fork-strategy rigs.
+	// Polecat worktrees inherit remotes from the bare repo, so this ensures
+	// pushes to the fork remote work correctly. Non-fatal: worktree can still
+	// function even if fork remote setup fails (e.g., PushURL not reachable).
+	if err := m.setupForkRemoteInWorktree(repoGit); err != nil {
+		style.PrintWarning("could not set up fork remote: %v", err)
+	}
+
 	if err := m.setupSharedBeads(clonePath); err != nil {
 		cleanupOnError()
 		return nil, fmt.Errorf("setting up shared beads: %w (polecat cannot submit MRs without shared beads)", err)
@@ -935,6 +943,11 @@ func (m *Manager) AddWithOptions(name string, opts AddOptions) (_ *Polecat, retE
 	if _, err := templates.CreatePolecatCLAUDEmd(clonePath, rigName, name); err != nil {
 		// Non-fatal — polecat can still learn via gt prime hook
 		style.PrintWarning("could not provision polecat CLAUDE.md: %v", err)
+	}
+
+	// Ensure fork remote is configured in the bare repo for fork-strategy rigs.
+	if err := m.setupForkRemoteInWorktree(repoGit); err != nil {
+		style.PrintWarning("could not set up fork remote: %v", err)
 	}
 
 	// Set up shared beads: polecat uses rig's .beads via redirect file.
@@ -2221,6 +2234,43 @@ func isCurrentHookedIssueForAssignee(issue *beads.Issue, assignee string) bool {
 // setupSharedBeads creates a redirect file so the polecat uses the rig's shared .beads database.
 // This eliminates the need for git sync between polecat clones - all polecats share one database.
 // Also propagates beads git config (role, issue_prefix) so bd commands work without warnings.
+// setupForkRemoteInWorktree ensures the fork remote is configured in the bare
+// repo for rigs that use the fork push strategy (PushURL set in config.json).
+// Polecat worktrees inherit remotes from the bare repo, so configuring the
+// bare repo once makes the remote available to all worktrees.
+//
+// This function is called from both AddWithOptions and addWithOptionsLocked.
+// Having it in one place (rather than duplicated inline) prevents divergence
+// when the setup logic evolves.
+func (m *Manager) setupForkRemoteInWorktree(repoGit *git.Git) error {
+	rigCfg, err := rig.LoadRigConfig(m.rig.Path)
+	if err != nil || rigCfg.PushURL == "" {
+		// Not a fork-strategy rig — nothing to do.
+		return nil
+	}
+
+	// Ensure the "fork" remote exists in the bare repo.
+	// The remote name "fork" is the convention for the push-only fork URL.
+	const forkRemoteName = "fork"
+	existingURL, err := repoGit.RemoteURL(forkRemoteName)
+	if err != nil {
+		// Remote doesn't exist — add it.
+		if _, addErr := repoGit.AddRemote(forkRemoteName, rigCfg.PushURL); addErr != nil {
+			return fmt.Errorf("adding fork remote %q: %w", rigCfg.PushURL, addErr)
+		}
+		return nil
+	}
+
+	// Remote exists — update URL if it changed.
+	if existingURL != rigCfg.PushURL {
+		if _, setErr := repoGit.SetRemoteURL(forkRemoteName, rigCfg.PushURL); setErr != nil {
+			return fmt.Errorf("updating fork remote URL to %q: %w", rigCfg.PushURL, setErr)
+		}
+	}
+
+	return nil
+}
+
 func (m *Manager) setupSharedBeads(clonePath string) error {
 	townRoot := filepath.Dir(m.rig.Path)
 	if err := beads.SetupRedirect(townRoot, clonePath); err != nil {


### PR DESCRIPTION
## Summary
- Adds `PushStrategy` interface with `Push()` and `Submit()` methods
- `DefaultPushStrategy`: refactored existing MR bead path from done.go
- `ForkPushStrategy`: push to fork remote + create GitHub PR
- Per-rig strategy configuration (not town-wide)
- Tap guard integration checks strategy-level permissions
- Tests for push/submit failure paths

Supersedes #3152 (closed) per Steve's architecture feedback — pluggable framework instead of hardcoded fork support. Also supersedes #3205 (community PR with same hardcoded approach).

Fixes gas-dcz

## Test plan
- [x] `go build ./...` compiles clean
- [x] `go test ./internal/cmd/ -run PushStrategy` passes
- [ ] End-to-end: verify fork workflow with polecat sling → gt done → PR created

🤖 Generated with [Claude Code](https://claude.com/claude-code)