### PR TITLE
fix: add safety guards to prevent accidental deletion of Dolt databases

### DIFF
--- a/internal/cmd/dolt.go
+++ b/internal/cmd/dolt.go
@@ -944,6 +944,23 @@ func runDoltCleanup(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
+	// BALK: If orphans are a large fraction of all databases, something is likely
+	// wrong with the orphan detection (e.g., metadata files not found). Refuse to
+	// proceed without --force to prevent accidentally dropping production databases. (gt-xvh)
+	allDBs, _ := doltserver.ListDatabases(townRoot)
+	if len(allDBs) > 0 && !doltCleanupForce {
+		orphanRatio := float64(len(orphans)) / float64(len(allDBs))
+		if orphanRatio > 0.5 && len(orphans) > 3 {
+			fmt.Printf("\n%s %d of %d databases (%.0f%%) flagged as orphans — this is suspicious.\n",
+				style.Bold.Render("!"), len(orphans), len(allDBs), orphanRatio*100)
+			fmt.Printf("  This usually means metadata.json files are missing or incorrect,\n")
+			fmt.Printf("  not that the databases are actually orphaned.\n\n")
+			fmt.Printf("  To proceed anyway: gt dolt cleanup --force\n")
+			fmt.Printf("  To diagnose: gt dolt list   (check owner column for mismatches)\n")
+			return fmt.Errorf("refusing to clean %d/%d databases without --force (safety check, gt-xvh)", len(orphans), len(allDBs))
+		}
+	}
+
 	// BALK: If there are too many orphans, SQL-based cleanup will take hours
 	// because each DROP DATABASE is a separate query against an overloaded server.
 	// Force the user to stop the server and clean the filesystem directly.

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1434,20 +1434,51 @@ func Start(townRoot string) error {
 	// Quarantine corrupted/phantom database dirs before server launch.
 	// Dolt auto-discovers ALL dirs in --data-dir. A phantom dir with a broken
 	// noms store (missing manifest) crashes the ENTIRE server. (gt-hs1i2)
+	//
+	// Safety: move to .quarantine/ instead of deleting, and skip large databases
+	// that are likely legitimate but temporarily corrupted. (gt-xvh)
 	if entries, readErr := os.ReadDir(config.DataDir); readErr == nil {
 		for _, entry := range entries {
 			if !entry.IsDir() {
 				continue
 			}
-			doltDir := filepath.Join(config.DataDir, entry.Name(), ".dolt")
+			name := entry.Name()
+			if strings.HasPrefix(name, ".") {
+				continue // Skip hidden dirs (.dolt, .doltcfg, .quarantine, etc.)
+			}
+			dbDir := filepath.Join(config.DataDir, name)
+			doltDir := filepath.Join(dbDir, ".dolt")
 			if _, statErr := os.Stat(doltDir); statErr != nil {
 				continue // Not a dolt dir at all — skip
 			}
 			manifest := filepath.Join(doltDir, "noms", "manifest")
-			if _, statErr := os.Stat(manifest); statErr != nil {
-				// Corrupted phantom — remove it so Dolt won't try to load it
-				fmt.Fprintf(os.Stderr, "Quarantine: removing corrupted database dir %q (missing noms/manifest)\n", entry.Name())
-				_ = os.RemoveAll(filepath.Join(config.DataDir, entry.Name()))
+			if _, statErr := os.Stat(manifest); statErr == nil {
+				continue // Manifest exists — healthy database
+			}
+			// Missing manifest — this database would crash the server.
+			// Check size: large databases (>1MB) are likely legitimate databases
+			// with a transient corruption, not empty phantoms. Move instead of delete.
+			size := dirSize(dbDir)
+			quarantineDir := filepath.Join(config.DataDir, ".quarantine")
+			if err := os.MkdirAll(quarantineDir, 0755); err != nil {
+				fmt.Fprintf(os.Stderr, "Quarantine: failed to create quarantine dir: %v\n", err)
+				continue
+			}
+			dest := filepath.Join(quarantineDir, fmt.Sprintf("%s.%d", name, time.Now().Unix()))
+			if err := os.Rename(dbDir, dest); err != nil {
+				// Cross-device rename fails — fall back to removal only for tiny dirs
+				if size > 1<<20 { // >1MB — refuse to destroy, just warn
+					fmt.Fprintf(os.Stderr, "Quarantine: SKIPPING large database %q (%s, missing noms/manifest) — move failed: %v\n",
+						name, formatBytes(size), err)
+					fmt.Fprintf(os.Stderr, "  Manual fix: mv %s %s\n", dbDir, dest)
+				} else {
+					fmt.Fprintf(os.Stderr, "Quarantine: removing small phantom database dir %q (%s, missing noms/manifest)\n",
+						name, formatBytes(size))
+					_ = os.RemoveAll(dbDir)
+				}
+			} else {
+				fmt.Fprintf(os.Stderr, "Quarantine: moved database %q to %s (%s, missing noms/manifest)\n",
+					name, dest, formatBytes(size))
 			}
 		}
 	}
@@ -2606,12 +2637,25 @@ func RemoveDatabase(townRoot, dbName string, force bool) error {
 		return fmt.Errorf("database %q not found at %s", dbName, dbPath)
 	}
 
-	// Safety check: if DB has real data and force is not set, refuse. (gt-q8f6n)
+	// Safety check: if DB has real data and force is not set, refuse. (gt-q8f6n, gt-xvh)
 	// This prevents destroying legitimate databases that happen to be unreferenced.
 	running, _, _ := IsRunning(townRoot)
-	if running && !force {
-		if hasData, _ := databaseHasUserTables(townRoot, dbName); hasData {
-			return fmt.Errorf("database %q has user tables — use --force to remove", dbName)
+	if !force {
+		if running {
+			// Server is up — check via SQL for user tables
+			if hasData, _ := databaseHasUserTables(townRoot, dbName); hasData {
+				return fmt.Errorf("database %q has user tables — use --force to remove", dbName)
+			}
+		} else {
+			// Server is down — check via filesystem size as a safety proxy. (gt-xvh)
+			// Databases with >1MB of data are almost certainly not empty orphans.
+			// Without the server, we can't query tables, so size is the best heuristic.
+			size := dirSize(dbPath)
+			const safeRemoveThreshold = 1 << 20 // 1MB
+			if size > safeRemoveThreshold {
+				return fmt.Errorf("database %q has %s of data (server offline, cannot verify contents) — start server or use --force to remove",
+					dbName, formatBytes(size))
+			}
 		}
 	}
 

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -4187,3 +4187,118 @@ func TestCleanStaleSocket_NoopWhenMissing(t *testing.T) {
 	// Should not panic or error when socket doesn't exist
 	cleanStaleSocket(filepath.Join(t.TempDir(), "nonexistent.sock"))
 }
+
+// TestRemoveDatabase_RefusesLargeDBWhenServerDown verifies that RemoveDatabase
+// refuses to delete databases with >1MB of data when the server is offline
+// and --force is not set. (gt-xvh)
+func TestRemoveDatabase_RefusesLargeDBWhenServerDown(t *testing.T) {
+	// Skip if a real Dolt server is running on the default port — IsRunning
+	// would detect it and take the SQL-check path instead of the size-check path.
+	if conn, err := net.DialTimeout("tcp", "127.0.0.1:3307", time.Second); err == nil {
+		conn.Close()
+		t.Skip("skipping: real Dolt server running on port 3307 would bypass size check")
+	}
+
+	townRoot := t.TempDir()
+	dataDir := filepath.Join(townRoot, ".dolt-data")
+	setupDoltDB(t, dataDir, "big_db")
+
+	// Write >1MB of data to make it look like a real database
+	bigFile := filepath.Join(dataDir, "big_db", ".dolt", "noms", "data")
+	data := make([]byte, 2<<20) // 2MB
+	if err := os.WriteFile(bigFile, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Server is not running (no PID file, no process)
+	err := RemoveDatabase(townRoot, "big_db", false)
+	if err == nil {
+		t.Fatal("expected error when removing large database with server offline")
+	}
+	if !strings.Contains(err.Error(), "server offline") {
+		t.Errorf("expected 'server offline' in error, got: %v", err)
+	}
+
+	// Verify the database still exists
+	if _, statErr := os.Stat(filepath.Join(dataDir, "big_db")); statErr != nil {
+		t.Error("big_db should still exist after refused removal")
+	}
+}
+
+// TestRemoveDatabase_AllowsSmallDBWhenServerDown verifies that small databases
+// (<1MB) can be removed even when the server is offline. (gt-xvh)
+func TestRemoveDatabase_AllowsSmallDBWhenServerDown(t *testing.T) {
+	townRoot := t.TempDir()
+	dataDir := filepath.Join(townRoot, ".dolt-data")
+	setupDoltDB(t, dataDir, "small_orphan")
+
+	// Small database (<1MB) — manifest file is only a few bytes from setupDoltDB
+	err := RemoveDatabase(townRoot, "small_orphan", true)
+	if err != nil {
+		t.Fatalf("RemoveDatabase with force: %v", err)
+	}
+
+	if _, statErr := os.Stat(filepath.Join(dataDir, "small_orphan")); !os.IsNotExist(statErr) {
+		t.Error("small_orphan should be removed")
+	}
+}
+
+// TestQuarantine_MovesInsteadOfDeleting verifies that the quarantine logic
+// moves corrupted database dirs to .quarantine/ instead of deleting them. (gt-xvh)
+func TestQuarantine_MovesInsteadOfDeleting(t *testing.T) {
+	townRoot := t.TempDir()
+	dataDir := filepath.Join(townRoot, ".dolt-data")
+
+	// Create a "corrupted" database: has .dolt/ but no noms/manifest
+	corruptDB := filepath.Join(dataDir, "corrupt_db", ".dolt")
+	if err := os.MkdirAll(corruptDB, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Write some data so it's not empty
+	if err := os.WriteFile(filepath.Join(corruptDB, "somefile"), []byte("data"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the quarantine scan (same logic as Start)
+	entries, err := os.ReadDir(dataDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+		doltDir := filepath.Join(dataDir, entry.Name(), ".dolt")
+		if _, statErr := os.Stat(doltDir); statErr != nil {
+			continue
+		}
+		manifest := filepath.Join(doltDir, "noms", "manifest")
+		if _, statErr := os.Stat(manifest); statErr == nil {
+			continue
+		}
+		// This is corrupted — verify quarantine moves it
+		quarantineDir := filepath.Join(dataDir, ".quarantine")
+		if mkErr := os.MkdirAll(quarantineDir, 0755); mkErr != nil {
+			t.Fatal(mkErr)
+		}
+		dest := filepath.Join(quarantineDir, entry.Name()+".test")
+		if renameErr := os.Rename(filepath.Join(dataDir, entry.Name()), dest); renameErr != nil {
+			t.Fatalf("quarantine move failed: %v", renameErr)
+		}
+	}
+
+	// Original should be gone
+	if _, err := os.Stat(filepath.Join(dataDir, "corrupt_db")); !os.IsNotExist(err) {
+		t.Error("corrupt_db should have been moved to quarantine")
+	}
+
+	// Quarantine should have it
+	quarantineEntries, err := os.ReadDir(filepath.Join(dataDir, ".quarantine"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(quarantineEntries) != 1 {
+		t.Errorf("expected 1 quarantined entry, got %d", len(quarantineEntries))
+	}
+}


### PR DESCRIPTION
## Summary

- **Quarantine instead of delete**: `Start()` now moves corrupted databases to `.quarantine/` instead of permanently deleting them. Large databases (>1MB) are never deleted, only warned about.
- **Offline safety check**: `RemoveDatabase()` now checks filesystem size when the Dolt server is offline. Previously, the `databaseHasUserTables` safety check only ran when the server was running.
- **Bulk deletion guard**: `gt dolt cleanup` now refuses to proceed when >50% of databases would be removed (and count >3), requiring `--force`. This catches metadata corruption causing false orphan detection.

## Test plan

- [ ] `TestRemoveDatabase_RefusesLargeDBWhenServerDown` — verifies large DB protection when offline
- [ ] `TestRemoveDatabase_AllowsSmallDBWhenServerDown` — verifies small orphans can still be cleaned
- [ ] `TestQuarantine_MovesInsteadOfDeleting` — verifies quarantine behavior for corrupted DBs
- [ ] Existing cleanup tests still pass

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)