### PR TITLE
fix(quota): sync tokens to swapped keychain entries after re-login

### DIFF
--- a/internal/cmd/quota.go
+++ b/internal/cmd/quota.go
@@ -775,7 +775,7 @@ func executeKeychainRotation(
 	// Context recovery is handled by --continue in the restart command.
 	result.ResumedSession = "continue"
 
-	// Update quota state: mark account as used
+	// Update quota state: mark account as used and record swap mapping
 	if err := mgr.WithLock(func() error {
 		state, loadErr := mgr.Load()
 		if loadErr != nil {
@@ -784,6 +784,11 @@ func executeKeychainRotation(
 		existing := state.Accounts[newAccount]
 		existing.LastUsed = time.Now().UTC().Format(time.RFC3339)
 		state.Accounts[newAccount] = existing
+
+		// Record the swap mapping so SyncSwappedTokens can propagate
+		// fresh tokens if the source account re-authenticates later.
+		quota.RecordSwap(state, currentConfigDir, newAccount)
+
 		return mgr.SaveUnlocked(state)
 	}); err != nil {
 		style.PrintWarning("could not update LastUsed for %s: %v", newAccount, err)
@@ -876,6 +881,20 @@ func runWatchCycle(townRoot string, acctCfg *config.AccountsConfig) {
 	}
 
 	mgr := quota.NewManager(townRoot)
+
+	// Sync swapped tokens: if a source account re-authenticated since the
+	// last rotation, propagate the fresh token to all target keychain entries.
+	if state, err := mgr.Load(); err == nil && len(state.ActiveSwaps) > 0 {
+		resolved := quota.ResolveSwapSourceDirs(state.ActiveSwaps, acctCfg.Accounts)
+		if n := quota.SyncSwappedTokens(resolved); n > 0 {
+			now := time.Now().Format("15:04:05")
+			fmt.Printf(" [%s] %s synced %d swapped keychain(s)\n",
+				style.Dim.Render(now),
+				style.Info.Render("Sync:"),
+				n)
+		}
+	}
+
 	plan, err := quota.PlanRotation(scanner, mgr, acctCfg, quota.PlanOpts{IncludeNearLimit: true})
 	if err != nil {
 		style.PrintWarning("planning rotation: %v", err)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1420,6 +1420,17 @@ func DefaultAccountsConfigDir() (string, error) {
 type QuotaState struct {
 	Version  int                          `json:"version"`  // schema version
 	Accounts map[string]AccountQuotaState `json:"accounts"` // handle -> quota state
+
+	// ActiveSwaps tracks keychain swap mappings from quota rotation.
+	// Key: target config dir (where the swapped token was written)
+	// Value: source account handle (whose token was swapped in)
+	//
+	// When a session is rotated, its config dir's keychain entry gets
+	// overwritten with the source account's token. If the source account
+	// later re-authenticates, the fresh token goes to the source's own
+	// keychain entry — not the target's. SyncSwappedTokens uses this map
+	// to propagate fresh tokens to all target keychain entries.
+	ActiveSwaps map[string]string `json:"active_swaps,omitempty"` // targetConfigDir -> sourceAccountHandle
 }
 
 // AccountQuotaStatus is the rate-limit status of an account.

--- a/internal/quota/keychain.go
+++ b/internal/quota/keychain.go
@@ -277,6 +277,52 @@ func validateTokenHTTP(token string) error {
 	return nil
 }
 
+// SyncSwappedTokens propagates fresh tokens from source accounts to target
+// keychain entries that were swapped during quota rotation.
+//
+// When rotation swaps account X's token into config dir Y's keychain entry,
+// later re-authentication of account X writes the fresh token to X's own
+// keychain entry — not Y's. This function reads each source account's current
+// token and writes it to the target's keychain entry if they differ.
+//
+// swapDirs maps target config dir → source config dir (already resolved from
+// account handles via ResolveSwapSourceDirs).
+//
+// Returns the number of keychain entries updated.
+func SyncSwappedTokens(swapDirs map[string]string) int {
+	updated := 0
+	for targetConfigDir, sourceConfigDir := range swapDirs {
+		targetSvc := KeychainServiceName(targetConfigDir)
+		sourceSvc := KeychainServiceName(sourceConfigDir)
+
+		if targetSvc == sourceSvc {
+			continue // same keychain entry, nothing to sync
+		}
+
+		// Read current tokens from both keychain entries
+		targetToken, err := ReadKeychainToken(targetSvc)
+		if err != nil {
+			continue // target entry doesn't exist or can't be read
+		}
+		sourceToken, err := ReadKeychainToken(sourceSvc)
+		if err != nil {
+			continue // source entry doesn't exist or can't be read
+		}
+
+		// If tokens match, no sync needed
+		if targetToken == sourceToken {
+			continue
+		}
+
+		// Source has a different (presumably fresher) token — propagate it
+		if err := WriteKeychainToken(targetSvc, "claude-code", sourceToken); err != nil {
+			continue // best-effort
+		}
+		updated++
+	}
+	return updated
+}
+
 // expandTilde expands a leading ~/ to the user's home directory.
 func expandTilde(path string) string {
 	if strings.HasPrefix(path, "~/") {

--- a/internal/quota/keychain_stub.go
+++ b/internal/quota/keychain_stub.go
@@ -23,3 +23,4 @@ func RestoreKeychainToken(_ *KeychainCredential) error                          
 func SwapOAuthAccount(_, _ string) (json.RawMessage, error)                        { return nil, errNotDarwin }
 func RestoreOAuthAccount(_ string, _ json.RawMessage) error                        { return errNotDarwin }
 func ValidateKeychainToken(_ string) error                                         { return nil }
+func SyncSwappedTokens(_ map[string]string) int                                    { return 0 }

--- a/internal/quota/state.go
+++ b/internal/quota/state.go
@@ -207,6 +207,37 @@ func (m *Manager) EnsureAccountsTracked(state *config.QuotaState, accounts map[s
 	}
 }
 
+// RecordSwap records a keychain swap mapping in quota state.
+// targetConfigDir is the config dir whose keychain entry was overwritten.
+// sourceHandle is the account handle whose token was swapped in.
+// The caller must hold the quota lock or call this within WithLock.
+func RecordSwap(state *config.QuotaState, targetConfigDir, sourceHandle string) {
+	if state.ActiveSwaps == nil {
+		state.ActiveSwaps = make(map[string]string)
+	}
+	state.ActiveSwaps[targetConfigDir] = sourceHandle
+}
+
+// ClearSwap removes a swap mapping when the config dir is no longer swapped.
+// The caller must hold the quota lock or call this within WithLock.
+func ClearSwap(state *config.QuotaState, targetConfigDir string) {
+	delete(state.ActiveSwaps, targetConfigDir)
+}
+
+// ResolveSwapSourceDirs resolves activeSwaps (targetConfigDir -> accountHandle)
+// to targetConfigDir -> sourceConfigDir using the accounts config.
+func ResolveSwapSourceDirs(activeSwaps map[string]string, accounts map[string]config.Account) map[string]string {
+	resolved := make(map[string]string, len(activeSwaps))
+	for targetDir, handle := range activeSwaps {
+		acct, ok := accounts[handle]
+		if !ok {
+			continue
+		}
+		resolved[targetDir] = util.ExpandHome(acct.ConfigDir)
+	}
+	return resolved
+}
+
 // ClearExpired checks all limited accounts and marks them available if their
 // ResetsAt time has passed. Returns the number of accounts cleared.
 // The caller is responsible for persisting state if changes were made.

--- a/internal/quota/state_test.go
+++ b/internal/quota/state_test.go
@@ -390,6 +390,103 @@ func TestSaveCreatesDirectory(t *testing.T) {
 	}
 }
 
+// --- Swap tracking tests ---
+
+func TestRecordSwap(t *testing.T) {
+	state := &config.QuotaState{
+		Accounts: make(map[string]config.AccountQuotaState),
+	}
+
+	// Record a swap
+	RecordSwap(state, "/home/user/.claude-accounts/clh", "dev1")
+
+	if len(state.ActiveSwaps) != 1 {
+		t.Fatalf("expected 1 active swap, got %d", len(state.ActiveSwaps))
+	}
+	if state.ActiveSwaps["/home/user/.claude-accounts/clh"] != "dev1" {
+		t.Errorf("expected dev1, got %s", state.ActiveSwaps["/home/user/.claude-accounts/clh"])
+	}
+
+	// Record another swap (overwrites)
+	RecordSwap(state, "/home/user/.claude-accounts/clh", "dev2")
+	if state.ActiveSwaps["/home/user/.claude-accounts/clh"] != "dev2" {
+		t.Errorf("expected dev2 after overwrite, got %s", state.ActiveSwaps["/home/user/.claude-accounts/clh"])
+	}
+}
+
+func TestClearSwap(t *testing.T) {
+	state := &config.QuotaState{
+		Accounts: make(map[string]config.AccountQuotaState),
+		ActiveSwaps: map[string]string{
+			"/home/user/.claude-accounts/clh": "dev1",
+			"/home/user/.claude-accounts/xyz": "dev2",
+		},
+	}
+
+	ClearSwap(state, "/home/user/.claude-accounts/clh")
+
+	if len(state.ActiveSwaps) != 1 {
+		t.Fatalf("expected 1 active swap after clear, got %d", len(state.ActiveSwaps))
+	}
+	if _, ok := state.ActiveSwaps["/home/user/.claude-accounts/clh"]; ok {
+		t.Error("expected clh swap to be cleared")
+	}
+}
+
+func TestResolveSwapSourceDirs(t *testing.T) {
+	activeSwaps := map[string]string{
+		"/home/user/.claude-accounts/clh": "dev1",
+		"/home/user/.claude-accounts/xyz": "dev2",
+		"/home/user/.claude-accounts/abc": "unknown", // not in accounts
+	}
+	accounts := map[string]config.Account{
+		"dev1": {ConfigDir: "/home/user/.claude-accounts/dev1"},
+		"dev2": {ConfigDir: "/home/user/.claude-accounts/dev2"},
+	}
+
+	resolved := ResolveSwapSourceDirs(activeSwaps, accounts)
+
+	if len(resolved) != 2 {
+		t.Fatalf("expected 2 resolved, got %d", len(resolved))
+	}
+	if resolved["/home/user/.claude-accounts/clh"] != "/home/user/.claude-accounts/dev1" {
+		t.Errorf("clh should resolve to dev1's dir, got %s", resolved["/home/user/.claude-accounts/clh"])
+	}
+	if resolved["/home/user/.claude-accounts/xyz"] != "/home/user/.claude-accounts/dev2" {
+		t.Errorf("xyz should resolve to dev2's dir, got %s", resolved["/home/user/.claude-accounts/xyz"])
+	}
+}
+
+func TestActiveSwaps_PersistsThroughSaveLoad(t *testing.T) {
+	townRoot := setupTestTown(t)
+	mgr := NewManager(townRoot)
+
+	state := &config.QuotaState{
+		Accounts: map[string]config.AccountQuotaState{
+			"dev1": {Status: config.QuotaStatusAvailable},
+		},
+		ActiveSwaps: map[string]string{
+			"/home/user/.claude-accounts/clh": "dev1",
+		},
+	}
+
+	if err := mgr.Save(state); err != nil {
+		t.Fatalf("Save() error: %v", err)
+	}
+
+	loaded, err := mgr.Load()
+	if err != nil {
+		t.Fatalf("Load() error: %v", err)
+	}
+
+	if len(loaded.ActiveSwaps) != 1 {
+		t.Fatalf("expected 1 active swap after load, got %d", len(loaded.ActiveSwaps))
+	}
+	if loaded.ActiveSwaps["/home/user/.claude-accounts/clh"] != "dev1" {
+		t.Errorf("expected dev1, got %s", loaded.ActiveSwaps["/home/user/.claude-accounts/clh"])
+	}
+}
+
 // --- ParseResetTime tests ---
 
 func TestParseResetTime_SimpleAMPM(t *testing.T) {


### PR DESCRIPTION
## Summary

- Track active keychain swap mappings (`target config dir → source account`) in `QuotaState.ActiveSwaps`
- On each `gt quota watch` cycle, sync fresh tokens from source accounts to all target keychain entries that hold swapped tokens
- Record swap mappings during `executeKeychainRotation` so the sync has a registry of what to propagate

Fixes the bug where `gt quota rotate` writes account X's token into config dir Y's keychain entry, but a later re-login of X refreshes X's own keychain entry — sessions reading from Y's keychain never see the new token.

## Changes

| File | Change |
|------|--------|
| `config/types.go` | Add `ActiveSwaps` field to `QuotaState` |
| `quota/keychain.go` | Add `SyncSwappedTokens()` — compares source/target tokens, propagates if different |
| `quota/keychain_stub.go` | Non-Darwin stub for `SyncSwappedTokens` |
| `quota/state.go` | Add `RecordSwap`, `ClearSwap`, `ResolveSwapSourceDirs` helpers |
| `cmd/quota.go` | Record swap in rotation; call sync in watch cycle |
| `quota/state_test.go` | Tests for swap tracking and persistence |

## Test plan

- [x] All existing `internal/quota` tests pass
- [x] New tests: `TestRecordSwap`, `TestClearSwap`, `TestResolveSwapSourceDirs`, `TestActiveSwaps_PersistsThroughSaveLoad`
- [x] `go vet` clean
- [ ] Manual: rotate an account, re-login the source, verify watch cycle propagates the fresh token

🤖 Generated with [Claude Code](https://claude.com/claude-code)