### PR TITLE
fix(EnsureAllMetadata): prevent ping-pong when two databases map to same rig (gt-cn4)

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -39,6 +39,7 @@ import (
 	"path/filepath"
 
 	"runtime"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -2977,6 +2978,12 @@ func EnsureAllMetadata(townRoot string) (updated []string, errs []error) {
 		dbToRig[k] = v
 	}
 
+	// Group databases by rig name to detect collisions (e.g., "gastown" and
+	// "gt" both mapping to the "gastown" rig). Preserve encounter order so
+	// the result slice is deterministic.
+	rigToDbs := make(map[string][]string)
+	var rigOrder []string
+	seenRig := make(map[string]bool)
 	for _, dbName := range databases {
 		rigName := dbName
 		if mapped, ok := dbToRig[dbName]; ok {
@@ -2986,6 +2993,19 @@ func EnsureAllMetadata(townRoot string) (updated []string, errs []error) {
 		if dbName == "hq" {
 			rigName = "hq"
 		}
+		rigToDbs[rigName] = append(rigToDbs[rigName], dbName)
+		if !seenRig[rigName] {
+			seenRig[rigName] = true
+			rigOrder = append(rigOrder, rigName)
+		}
+	}
+
+	// For each rig, choose exactly one canonical database. When multiple
+	// databases map to the same rig (e.g., "gastown" and "gt" for the gastown
+	// rig), prefer whichever database metadata.json already records — this
+	// prevents ping-pong where each database's turn overwrites the other's value.
+	for _, rigName := range rigOrder {
+		dbName := chooseCanonicalDB(townRoot, rigName, rigToDbs[rigName])
 		// Pass dbName explicitly so EnsureMetadata writes the correct
 		// dolt_database value ("be") rather than the rig dir name ("beads_el").
 		if err := EnsureMetadata(townRoot, rigName, dbName); err != nil {
@@ -2996,6 +3016,38 @@ func EnsureAllMetadata(townRoot string) (updated []string, errs []error) {
 	}
 
 	return updated, errs
+}
+
+// chooseCanonicalDB picks the single database name to use for a rig when
+// multiple Dolt databases map to the same rig directory. It reads the rig's
+// existing metadata.json and returns the current dolt_database value if it is
+// in the candidate list (stable — avoids rewriting metadata.json). If no
+// stable choice exists it returns the lexicographically first candidate.
+func chooseCanonicalDB(townRoot, rigName string, candidates []string) string {
+	if len(candidates) == 1 {
+		return candidates[0]
+	}
+	// Build a set for O(1) lookup.
+	valid := make(map[string]bool, len(candidates))
+	for _, db := range candidates {
+		valid[db] = true
+	}
+	// Check what metadata.json currently records.
+	beadsDir := FindRigBeadsDir(townRoot, rigName)
+	metadataPath := filepath.Join(beadsDir, "metadata.json")
+	if data, readErr := os.ReadFile(metadataPath); readErr == nil {
+		var meta map[string]interface{}
+		if json.Unmarshal(data, &meta) == nil {
+			if current, ok := meta["dolt_database"].(string); ok && valid[current] {
+				return current // already stable — keep it
+			}
+		}
+	}
+	// No stable value — pick lexicographically first for determinism.
+	sorted := make([]string, len(candidates))
+	copy(sorted, candidates)
+	sort.Strings(sorted)
+	return sorted[0]
 }
 
 // buildDatabaseToRigMap loads routes.jsonl and builds a map from database name

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -4164,6 +4164,83 @@ func TestEnsureAllMetadata_FallbackToDbName(t *testing.T) {
 	}
 }
 
+// TestEnsureAllMetadata_NoPingPong is a regression test for the bug where two
+// Dolt databases map to the same rig (e.g., "gastown" and "gt" both resolving
+// to the "gastown" rig). Previously, each call to EnsureMetadata overwrote the
+// other's dolt_database value on every invocation of EnsureAllMetadata, causing
+// alternating "correcting" warnings in gt up output.
+//
+// Expected: EnsureAllMetadata calls EnsureMetadata exactly once per rig,
+// and the chosen database is stable across repeated calls.
+func TestEnsureAllMetadata_NoPingPong(t *testing.T) {
+	townRoot := t.TempDir()
+	dataDir := filepath.Join(townRoot, ".dolt-data")
+
+	// Both "gastown" and "gt" databases exist.
+	setupDoltDB(t, dataDir, "gastown")
+	setupDoltDB(t, dataDir, "gt")
+
+	// routes.jsonl maps prefix "gt-" → rig "gastown".
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	routesContent := `{"prefix":"gt-","path":"gastown/mayor/rig"}
+`
+	if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), []byte(routesContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create gastown rig beads directory.
+	gastownBeads := filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads")
+	if err := os.MkdirAll(gastownBeads, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// First call: no prior metadata — a canonical database is chosen.
+	updated1, errs1 := EnsureAllMetadata(townRoot)
+	if len(errs1) > 0 {
+		t.Fatalf("first call: unexpected errors: %v", errs1)
+	}
+	// Both databases exist but map to the same rig → only one update expected.
+	if len(updated1) != 1 {
+		t.Errorf("first call: expected 1 updated entry (one per rig), got %d: %v", len(updated1), updated1)
+	}
+
+	// Read what was written.
+	meta1 := readMetadataJSON(t, filepath.Join(gastownBeads, "metadata.json"))
+	chosen := meta1["dolt_database"].(string)
+	if chosen != "gastown" && chosen != "gt" {
+		t.Fatalf("first call: unexpected dolt_database %q", chosen)
+	}
+
+	// Second call: metadata already set — same database should be kept.
+	updated2, errs2 := EnsureAllMetadata(townRoot)
+	if len(errs2) > 0 {
+		t.Fatalf("second call: unexpected errors: %v", errs2)
+	}
+	meta2 := readMetadataJSON(t, filepath.Join(gastownBeads, "metadata.json"))
+	if meta2["dolt_database"] != chosen {
+		t.Errorf("ping-pong detected: first call chose %q, second call chose %q",
+			chosen, meta2["dolt_database"])
+	}
+	_ = updated2 // may be 0 or 1 depending on whether anything changed
+}
+
+// readMetadataJSON reads and parses a metadata.json file, failing the test on error.
+func readMetadataJSON(t *testing.T, path string) map[string]interface{} {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("reading metadata.json at %s: %v", path, err)
+	}
+	var meta map[string]interface{}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		t.Fatalf("parsing metadata.json at %s: %v", path, err)
+	}
+	return meta
+}
+
 func TestCleanStaleSocket_RemovesStaleFile(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix sockets not applicable on Windows")


### PR DESCRIPTION
Fixes ping-pong when two Dolt databases map to the same rig (e.g. 'gastown' and 'gt' both mapping to gastown rig). When multiple databases resolve to the same rig, prefer the one `metadata.json` already points to. Eliminates `Warning: metadata.json dolt_database was "X", correcting to "Y"` spam during `gt up`.

Fixes #3222