### PR TITLE
fix(hooks-sync): use configured agent name for non-Claude hooks (gt-lch)

### DIFF
--- a/internal/cmd/hooks_sync.go
+++ b/internal/cmd/hooks_sync.go
@@ -127,17 +127,33 @@ func runHooksSync(cmd *cobra.Command, args []string) error {
 			if loc.Rig != "" {
 				rigPath = filepath.Join(townRoot, loc.Rig)
 			}
-			rc := config.ResolveRoleAgentConfig(loc.Role, townRoot, rigPath)
-			if rc == nil || rc.Hooks == nil || rc.Hooks.Provider == "" {
-				continue
-			}
-			// Claude targets are already handled by DiscoverTargets + syncTarget above.
-			if rc.Hooks.Provider == "claude" {
+
+			// Use ResolveRoleAgentName (not ResolveRoleAgentConfig) so that hooks are
+			// installed based on the *configured* agent, not the *resolved* one.
+			// ResolveRoleAgentConfig falls back to claude when the agent binary is not
+			// found in PATH (e.g., in CI or on a fresh machine), which would silently
+			// skip creating opencode/gemini/etc. plugin files.
+			agentName, _ := config.ResolveRoleAgentName(loc.Role, townRoot, rigPath)
+			if agentName == "" {
 				continue
 			}
 
-			preset := config.GetAgentPresetByName(rc.Hooks.Provider)
-			useSettingsDir := preset != nil && preset.HooksUseSettingsDir
+			preset := config.GetAgentPresetByName(agentName)
+			if preset == nil || preset.HooksDir == "" || preset.HooksSettingsFile == "" {
+				continue
+			}
+
+			hooksProvider := preset.HooksProvider
+			if hooksProvider == "" {
+				hooksProvider = agentName
+			}
+
+			// Claude targets are already handled by DiscoverTargets + syncTarget above.
+			if hooksProvider == "claude" {
+				continue
+			}
+
+			useSettingsDir := preset.HooksUseSettingsDir
 
 			// Determine sync targets.
 			// - Town-level roles (mayor, deacon): the role dir IS the working directory.
@@ -152,7 +168,7 @@ func runHooksSync(cmd *cobra.Command, args []string) error {
 			}
 
 			for _, dir := range syncDirs {
-				targetPath := filepath.Join(dir, rc.Hooks.Dir, rc.Hooks.SettingsFile)
+				targetPath := filepath.Join(dir, preset.HooksDir, preset.HooksSettingsFile)
 				relPath, pathErr := filepath.Rel(townRoot, targetPath)
 				if pathErr != nil {
 					relPath = targetPath
@@ -160,18 +176,18 @@ func runHooksSync(cmd *cobra.Command, args []string) error {
 
 				if hooksSyncDryRun {
 					if _, statErr := os.Stat(targetPath); statErr == nil {
-						fmt.Printf("  %s %s %s\n", style.Warning.Render("~"), relPath, style.Dim.Render("(would check "+rc.Hooks.Provider+")"))
+						fmt.Printf("  %s %s %s\n", style.Warning.Render("~"), relPath, style.Dim.Render("(would check "+hooksProvider+")"))
 					} else {
-						fmt.Printf("  %s %s %s\n", style.Warning.Render("~"), relPath, style.Dim.Render("(would create "+rc.Hooks.Provider+")"))
+						fmt.Printf("  %s %s %s\n", style.Warning.Render("~"), relPath, style.Dim.Render("(would create "+hooksProvider+")"))
 						created++
 					}
 					continue
 				}
 
-				result, syncErr := hooks.SyncForRole(rc.Hooks.Provider, dir, dir, loc.Role,
-					rc.Hooks.Dir, rc.Hooks.SettingsFile, useSettingsDir)
+				result, syncErr := hooks.SyncForRole(hooksProvider, dir, dir, loc.Role,
+					preset.HooksDir, preset.HooksSettingsFile, useSettingsDir)
 				if syncErr != nil {
-					fmt.Printf("  %s %s (%s): %v\n", style.Error.Render("✖"), relPath, rc.Hooks.Provider, syncErr)
+					fmt.Printf("  %s %s (%s): %v\n", style.Error.Render("✖"), relPath, hooksProvider, syncErr)
 					errors++
 					failedTargets = append(failedTargets, relPath)
 					continue
@@ -179,13 +195,13 @@ func runHooksSync(cmd *cobra.Command, args []string) error {
 
 				switch result {
 				case hooks.SyncCreated:
-					fmt.Printf("  %s %s %s\n", style.Success.Render("✓"), relPath, style.Dim.Render("(created "+rc.Hooks.Provider+")"))
+					fmt.Printf("  %s %s %s\n", style.Success.Render("✓"), relPath, style.Dim.Render("(created "+hooksProvider+")"))
 					created++
 				case hooks.SyncUpdated:
-					fmt.Printf("  %s %s %s\n", style.Success.Render("✓"), relPath, style.Dim.Render("(updated "+rc.Hooks.Provider+")"))
+					fmt.Printf("  %s %s %s\n", style.Success.Render("✓"), relPath, style.Dim.Render("(updated "+hooksProvider+")"))
 					updated++
 				case hooks.SyncUnchanged:
-					fmt.Printf("  %s %s %s\n", style.Dim.Render("·"), relPath, style.Dim.Render("(unchanged "+rc.Hooks.Provider+")"))
+					fmt.Printf("  %s %s %s\n", style.Dim.Render("·"), relPath, style.Dim.Render("(unchanged "+hooksProvider+")"))
 					unchanged++
 				}
 			}

--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -128,12 +128,15 @@ func TestBuildRefineryPatrolVars_FullConfig(t *testing.T) {
 	// DefaultMergeQueueConfig: refinery_enabled=true, auto_land=false, run_tests=true,
 	// test_command="" (language-agnostic), target_branch="main" (from rig config), delete_merged_branches=true
 	// New commands (setup, typecheck, lint, build) default to empty = omitted
+	// judgment_enabled defaults to false, review_depth defaults to "standard"
 	expected := map[string]string{
 		"integration_branch_refinery_enabled": "true",
 		"integration_branch_auto_land":        "false",
 		"run_tests":                           "true",
 		"target_branch":                       "main",
 		"delete_merged_branches":              "true",
+		"judgment_enabled":                    "false",
+		"review_depth":                        "standard",
 	}
 
 	varMap := make(map[string]string)

--- a/internal/cmd/wl_stamp_loop_test.go
+++ b/internal/cmd/wl_stamp_loop_test.go
@@ -126,9 +126,8 @@ func TestStampLoop_EndToEnd(t *testing.T) {
 }
 
 // TestStampLoop_SelfStampFails verifies the yearbook rule (author != subject).
+// Note: not parallel — modifies package-level globals.
 func TestStampLoop_SelfStampFails(t *testing.T) {
-	t.Parallel()
-
 	// Save/restore globals
 	origQ, origR, origC := wlStampQuality, wlStampReliability, wlStampCreativity
 	origSev, origType, origCtx := wlStampSeverity, wlStampType, wlStampContextType
@@ -172,8 +171,8 @@ func TestStampLoop_SelfStampFails(t *testing.T) {
 }
 
 // TestStampLoop_InvalidValence verifies validation rejects out-of-range scores.
+// Note: not parallel — modifies package-level globals.
 func TestStampLoop_InvalidValence(t *testing.T) {
-	t.Parallel()
 	tests := []struct {
 		name     string
 		quality  float64

--- a/internal/hooks/installer.go
+++ b/internal/hooks/installer.go
@@ -58,7 +58,7 @@ func InstallForRole(provider, settingsDir, workDir, role, hooksDir, hooksFile st
 		// Stale file detected — fall through to overwrite with current template
 	}
 
-	return writeTemplate(provider, role, hooksDir, hooksFile, targetPath)
+	return writeTemplate(provider, role, hooksFile, targetPath)
 }
 
 // needsUpgrade returns true if an existing hooks file contains stale patterns
@@ -157,7 +157,7 @@ func resolveAndSubstitute(provider, hooksFile, role string) ([]byte, error) {
 }
 
 // writeTemplate resolves a template, substitutes placeholders, and writes it to targetPath.
-func writeTemplate(provider, role, hooksDir, hooksFile, targetPath string) error {
+func writeTemplate(provider, role, hooksFile, targetPath string) error {
 	content, err := resolveAndSubstitute(provider, hooksFile, role)
 	if err != nil {
 		return err


### PR DESCRIPTION
Fixes #3247

When `gt doctor hooks-sync` or `gt hooks sync` runs for non-Claude template-based agents (OpenCode, Gemini, etc.), it uses `ResolveRoleAgentConfig` which falls back to `claude` when the agent binary is not in PATH (e.g. in CI). This causes non-Claude hook targets to be silently skipped.

**Changes:**
- Use `ResolveRoleAgentName` (reads config directly, no PATH fallback) for determining which template to apply
- Update patrol test to expect the correct number of formula vars (`judgment_enabled`, `review_depth`)
- Remove unused `hooksDir` parameter from `writeTemplate`