### PR TITLE
feat(plugins): implement 4 spec-only plugins

### DIFF
--- a/plugins/dolt-snapshots/run.sh
+++ b/plugins/dolt-snapshots/run.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+# dolt-snapshots/run.sh — Build and run the dolt-snapshots Go binary.
+set -euo pipefail
+
+PLUGIN_DIR="$(cd "$(dirname "$0")" && pwd)"
+BINARY="$PLUGIN_DIR/dolt-snapshots"
+
+# Build if binary doesn't exist or source is newer
+if [ ! -f "$BINARY" ] || [ "$PLUGIN_DIR/main.go" -nt "$BINARY" ]; then
+  echo "[dolt-snapshots] Building binary..."
+  (cd "$PLUGIN_DIR" && go build -o dolt-snapshots .) || {
+    echo "[dolt-snapshots] Build failed"
+    exit 1
+  }
+fi
+
+exec "$BINARY" "$@"

--- a/plugins/git-hygiene/run.sh
+++ b/plugins/git-hygiene/run.sh
@@ -1,0 +1,175 @@
+#!/usr/bin/env bash
+# git-hygiene/run.sh — Clean stale branches, stashes, and loose objects.
+#
+# Runs across all rig repos. Covers:
+# - Merged local branches
+# - Orphan local branches (polecat/*, dog/*, fix/*, etc. with no remote)
+# - Merged remote branches on GitHub
+# - Stale stashes
+# - Git garbage collection
+
+set -euo pipefail
+
+log() { echo "[git-hygiene] $*"; }
+
+# --- Enumerate rig repos -----------------------------------------------------
+
+RIG_JSON=$(gt rig list --json 2>/dev/null) || {
+  log "SKIP: could not get rig list"
+  exit 0
+}
+
+RIG_PATHS=$(echo "$RIG_JSON" | python3 -c "
+import json, sys
+rigs = json.load(sys.stdin)
+for r in rigs:
+    p = r.get('repo_path') or ''
+    if p: print(p)
+" 2>/dev/null)
+
+if [ -z "$RIG_PATHS" ]; then
+  log "SKIP: no rigs with repo paths found"
+  exit 0
+fi
+
+RIG_COUNT=$(echo "$RIG_PATHS" | wc -l | tr -d ' ')
+log "Found $RIG_COUNT rig repo(s) to clean"
+
+# --- Process each rig repo ----------------------------------------------------
+
+TOTAL_LOCAL_MERGED=0
+TOTAL_LOCAL_ORPHAN=0
+TOTAL_REMOTE=0
+TOTAL_STASHES=0
+TOTAL_GC=0
+
+while IFS= read -r REPO_PATH; do
+  [ -z "$REPO_PATH" ] && continue
+
+  if ! git -C "$REPO_PATH" rev-parse --git-dir >/dev/null 2>&1; then
+    log "SKIP: $REPO_PATH is not a git repo"
+    continue
+  fi
+
+  log ""
+  log "=== Cleaning: $REPO_PATH ==="
+
+  # Detect default branch
+  DEFAULT_BRANCH=$(git -C "$REPO_PATH" symbolic-ref refs/remotes/origin/HEAD 2>/dev/null \
+    | sed 's|refs/remotes/origin/||')
+  if [ -z "$DEFAULT_BRANCH" ]; then
+    DEFAULT_BRANCH="main"
+  fi
+  CURRENT_BRANCH=$(git -C "$REPO_PATH" branch --show-current 2>/dev/null)
+
+  # Step 1: Prune remote tracking refs
+  log "  Pruning remote tracking refs..."
+  git -C "$REPO_PATH" fetch --prune --all 2>/dev/null || true
+
+  # Step 2: Delete merged local branches
+  log "  Deleting merged local branches..."
+  MERGED_BRANCHES=$(git -C "$REPO_PATH" branch --merged "$DEFAULT_BRANCH" 2>/dev/null \
+    | grep -v "^\*" \
+    | grep -v "^+" \
+    | grep -v -E "^\s*(main|master)$" \
+    | sed 's/^[[:space:]]*//' || true)
+
+  LOCAL_MERGED=0
+  while IFS= read -r BRANCH; do
+    [ -z "$BRANCH" ] && continue
+    if [ "$BRANCH" = "$CURRENT_BRANCH" ] || [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
+      continue
+    fi
+    case "$BRANCH" in
+      refinery-patrol|merge/*) continue ;;
+    esac
+    log "    Deleting merged: $BRANCH"
+    git -C "$REPO_PATH" branch -d "$BRANCH" 2>/dev/null && LOCAL_MERGED=$((LOCAL_MERGED + 1))
+  done <<< "$MERGED_BRANCHES"
+  TOTAL_LOCAL_MERGED=$((TOTAL_LOCAL_MERGED + LOCAL_MERGED))
+
+  # Step 3: Delete stale unmerged orphan branches
+  log "  Deleting stale orphan branches..."
+  STALE_PATTERNS="polecat/|dog/|fix/|pr-|integration/|worktree-agent-"
+  ALL_BRANCHES=$(git -C "$REPO_PATH" branch 2>/dev/null \
+    | grep -v "^\*" \
+    | grep -v "^+" \
+    | sed 's/^[[:space:]]*//' || true)
+
+  LOCAL_ORPHAN=0
+  while IFS= read -r BRANCH; do
+    [ -z "$BRANCH" ] && continue
+    if ! echo "$BRANCH" | grep -qE "^($STALE_PATTERNS)"; then
+      continue
+    fi
+    if [ "$BRANCH" = "$CURRENT_BRANCH" ] || [ "$BRANCH" = "$DEFAULT_BRANCH" ]; then
+      continue
+    fi
+    case "$BRANCH" in
+      main|master|refinery-patrol|merge/*) continue ;;
+    esac
+    if git -C "$REPO_PATH" rev-parse --verify "refs/remotes/origin/$BRANCH" >/dev/null 2>&1; then
+      continue
+    fi
+    log "    Deleting orphan: $BRANCH"
+    git -C "$REPO_PATH" branch -D "$BRANCH" 2>/dev/null && LOCAL_ORPHAN=$((LOCAL_ORPHAN + 1))
+  done <<< "$ALL_BRANCHES"
+  TOTAL_LOCAL_ORPHAN=$((TOTAL_LOCAL_ORPHAN + LOCAL_ORPHAN))
+
+  # Step 4: Delete merged remote branches on GitHub
+  log "  Deleting merged remote branches..."
+  REMOTE_DELETED=0
+
+  GH_REPO=$(git -C "$REPO_PATH" remote get-url origin 2>/dev/null \
+    | sed -E 's|.*github\.com[:/]||; s|\.git$||')
+
+  if [ -n "$GH_REPO" ]; then
+    REMOTE_BRANCHES=$(git -C "$REPO_PATH" branch -r 2>/dev/null \
+      | grep -v HEAD \
+      | grep -v "origin/$DEFAULT_BRANCH" \
+      | grep -v "origin/dependabot/" \
+      | grep -v "origin/refinery-patrol" \
+      | grep -vE "origin/merge/" \
+      | sed 's|^[[:space:]]*origin/||' || true)
+
+    REMOTE_PATTERNS="polecat/|fix/|pr-|integration/|worktree-agent-"
+
+    while IFS= read -r RBRANCH; do
+      [ -z "$RBRANCH" ] && continue
+      if ! echo "$RBRANCH" | grep -qE "^($REMOTE_PATTERNS)"; then
+        continue
+      fi
+      if git -C "$REPO_PATH" merge-base --is-ancestor "origin/$RBRANCH" "origin/$DEFAULT_BRANCH" 2>/dev/null; then
+        log "    Deleting remote: origin/$RBRANCH"
+        gh api "repos/$GH_REPO/git/refs/heads/$RBRANCH" -X DELETE 2>/dev/null && REMOTE_DELETED=$((REMOTE_DELETED + 1))
+      fi
+    done <<< "$REMOTE_BRANCHES"
+  fi
+  TOTAL_REMOTE=$((TOTAL_REMOTE + REMOTE_DELETED))
+
+  # Step 5: Clear stale stashes
+  log "  Clearing stashes..."
+  STASH_COUNT=$(git -C "$REPO_PATH" stash list 2>/dev/null | wc -l | tr -d ' ')
+  if [ "$STASH_COUNT" -gt 0 ]; then
+    log "    Clearing $STASH_COUNT stash(es)"
+    git -C "$REPO_PATH" stash clear 2>/dev/null
+    TOTAL_STASHES=$((TOTAL_STASHES + STASH_COUNT))
+  fi
+
+  # Step 6: Garbage collect
+  log "  Running git gc..."
+  git -C "$REPO_PATH" gc --prune=now --quiet 2>/dev/null && TOTAL_GC=$((TOTAL_GC + 1))
+
+  log "  Done: $LOCAL_MERGED merged, $LOCAL_ORPHAN orphan, $REMOTE_DELETED remote, $STASH_COUNT stash(es)"
+done <<< "$RIG_PATHS"
+
+# --- Report -------------------------------------------------------------------
+
+SUMMARY="$RIG_COUNT rig(s): $TOTAL_LOCAL_MERGED merged, $TOTAL_LOCAL_ORPHAN orphan, $TOTAL_REMOTE remote, $TOTAL_STASHES stash(es), $TOTAL_GC gc"
+log ""
+log "=== Git Hygiene Summary ==="
+log "$SUMMARY"
+
+bd create "git-hygiene: $SUMMARY" -t chore --ephemeral \
+  -l type:plugin-run,plugin:git-hygiene,result:success \
+  -d "$SUMMARY" --silent 2>/dev/null || true

--- a/plugins/rebuild-gt/run.sh
+++ b/plugins/rebuild-gt/run.sh
@@ -1,0 +1,88 @@
+#!/usr/bin/env bash
+# rebuild-gt/run.sh — Rebuild gt binary from gastown source if stale.
+#
+# SAFETY: Only rebuilds forward (binary is ancestor of HEAD) and only
+# from main branch. A bad rebuild caused a crash loop (every session's
+# startup hook failed, witness respawned, loop repeated every 1-2 min).
+
+set -euo pipefail
+
+TOWN_ROOT="${GT_TOWN_ROOT:-$(gt town root 2>/dev/null)}"
+RIG_ROOT="${TOWN_ROOT}/gastown/mayor/rig"
+
+log() { echo "[rebuild-gt] $*"; }
+
+# --- Detection ---------------------------------------------------------------
+
+log "Checking binary staleness..."
+STALE_JSON=$(gt stale --json 2>/dev/null) || {
+  log "gt stale --json failed, skipping"
+  exit 0
+}
+
+IS_STALE=$(echo "$STALE_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('stale', False))" 2>/dev/null || echo "False")
+SAFE=$(echo "$STALE_JSON" | python3 -c "import json,sys; print(json.load(sys.stdin).get('safe_to_rebuild', False))" 2>/dev/null || echo "False")
+
+if [ "$IS_STALE" != "True" ]; then
+  log "Binary is fresh. Nothing to do."
+  bd create "rebuild-gt: binary is fresh" -t chore --ephemeral \
+    -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:success \
+    --silent 2>/dev/null || true
+  exit 0
+fi
+
+if [ "$SAFE" != "True" ]; then
+  log "Not safe to rebuild (not on main or would be a downgrade). Skipping."
+  bd create "Plugin: rebuild-gt [skipped]" -t chore --ephemeral \
+    -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:skipped \
+    -d "Skipped: not safe to rebuild" --silent 2>/dev/null || true
+  exit 0
+fi
+
+# --- Pre-flight checks -------------------------------------------------------
+
+log "Pre-flight checks..."
+
+if [ ! -d "$RIG_ROOT" ]; then
+  log "Rig root $RIG_ROOT does not exist. Skipping."
+  exit 0
+fi
+
+DIRTY=$(git -C "$RIG_ROOT" status --porcelain 2>/dev/null)
+if [ -n "$DIRTY" ]; then
+  log "Repo is dirty, skipping rebuild."
+  bd create "Plugin: rebuild-gt [skipped]" -t chore --ephemeral \
+    -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:skipped \
+    -d "Skipped: repo has uncommitted changes" --silent 2>/dev/null || true
+  exit 0
+fi
+
+BRANCH=$(git -C "$RIG_ROOT" branch --show-current 2>/dev/null)
+if [ "$BRANCH" != "main" ]; then
+  log "Not on main branch (on $BRANCH), skipping rebuild."
+  bd create "Plugin: rebuild-gt [skipped]" -t chore --ephemeral \
+    -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:skipped \
+    -d "Skipped: not on main branch (on $BRANCH)" --silent 2>/dev/null || true
+  exit 0
+fi
+
+# --- Build -------------------------------------------------------------------
+
+OLD_VER=$(gt version 2>/dev/null | head -1 || echo "unknown")
+log "Rebuilding gt from $RIG_ROOT..."
+
+if (cd "$RIG_ROOT" && make build && make safe-install) 2>&1; then
+  NEW_VER=$(gt version 2>/dev/null | head -1 || echo "unknown")
+  log "Rebuilt: $OLD_VER -> $NEW_VER"
+  bd create "rebuild-gt: $OLD_VER -> $NEW_VER" -t chore --ephemeral \
+    -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:success \
+    --silent 2>/dev/null || true
+else
+  ERROR="make build/safe-install failed"
+  log "FAILED: $ERROR"
+  bd create "Plugin: rebuild-gt [failure]" -t chore --ephemeral \
+    -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:failure \
+    -d "Build failed: $ERROR" --silent 2>/dev/null || true
+  gt escalate "Plugin FAILED: rebuild-gt" -s medium 2>/dev/null || true
+  exit 1
+fi

--- a/plugins/stuck-agent-dog/run.sh
+++ b/plugins/stuck-agent-dog/run.sh
@@ -1,0 +1,180 @@
+#!/usr/bin/env bash
+# stuck-agent-dog/run.sh — Context-aware stuck/crashed agent detection.
+#
+# SCOPE: Only polecats and deacon. NEVER touches crew, mayor, witness, or refinery.
+# The daemon detects; this plugin inspects context before acting.
+
+set -euo pipefail
+
+TOWN_ROOT="${GT_TOWN_ROOT:-$(gt town root 2>/dev/null)}"
+RIGS_JSON_PATH="${TOWN_ROOT}/mayor/rigs.json"
+
+log() { echo "[stuck-agent-dog] $*"; }
+
+# --- Enumerate agents ---------------------------------------------------------
+
+log "=== Checking agent health ==="
+
+if [ ! -f "$RIGS_JSON_PATH" ]; then
+  log "SKIP: rigs.json not found"
+  exit 0
+fi
+
+# Build rig_name|prefix mapping
+RIG_PREFIX_MAP=$(jq -r '.rigs | to_entries[] | "\(.key)|\(.value.beads.prefix // .key)"' "$RIGS_JSON_PATH" 2>/dev/null)
+if [ -z "$RIG_PREFIX_MAP" ]; then
+  log "SKIP: no rigs in rigs.json"
+  exit 0
+fi
+
+# --- Check polecat health ----------------------------------------------------
+
+CRASHED=()
+STUCK=()
+HEALTHY=0
+
+while IFS='|' read -r RIG PREFIX; do
+  [ -z "$RIG" ] && continue
+  POLECAT_DIR="$TOWN_ROOT/$RIG/polecats"
+  [ -d "$POLECAT_DIR" ] || continue
+
+  for PCAT_PATH in "$POLECAT_DIR"/*/; do
+    [ -d "$PCAT_PATH" ] || continue
+    PCAT_NAME=$(basename "$PCAT_PATH")
+    SESSION_NAME="${PREFIX}-${PCAT_NAME}"
+
+    if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
+      # Session dead — check hook
+      HOOK_BEAD=$(gt hook "$RIG/polecats/$PCAT_NAME" 2>/dev/null \
+        | grep -oE 'Hooked: [^ ]+' | head -1 | sed 's/Hooked: //')
+
+      if [ -n "$HOOK_BEAD" ]; then
+        # Check agent_state
+        AGENT_STATE=$(bd show "$HOOK_BEAD" --json 2>/dev/null \
+          | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0].get('status',''))" 2>/dev/null || echo "")
+
+        case "$AGENT_STATE" in
+          closed) log "  SKIP $SESSION_NAME: bead closed (completed normally)"; continue ;;
+        esac
+
+        CRASHED+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD")
+        log "  CRASHED: $SESSION_NAME (hook=$HOOK_BEAD)"
+      fi
+    else
+      # Session alive — check process
+      PANE_PID=$(tmux list-panes -t "$SESSION_NAME" -F '#{pane_pid}' 2>/dev/null | head -1)
+      if [ -n "$PANE_PID" ]; then
+        PROC_COMM=$(ps -o comm= -p "$PANE_PID" 2>/dev/null)
+        if [ -z "$PROC_COMM" ]; then
+          # Zombie: process dead, session alive
+          HOOK_BEAD=$(gt hook "$RIG/polecats/$PCAT_NAME" 2>/dev/null \
+            | grep -oE 'Hooked: [^ ]+' | head -1 | sed 's/Hooked: //')
+          if [ -n "$HOOK_BEAD" ]; then
+            STUCK+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD|agent_dead")
+            log "  ZOMBIE: $SESSION_NAME (pid=$PANE_PID dead, hook=$HOOK_BEAD)"
+          fi
+        else
+          HEALTHY=$((HEALTHY + 1))
+        fi
+      else
+        HEALTHY=$((HEALTHY + 1))
+      fi
+    fi
+  done
+done <<< "$RIG_PREFIX_MAP"
+
+log ""
+log "Polecat health: ${#CRASHED[@]} crashed, ${#STUCK[@]} stuck, $HEALTHY healthy"
+
+# --- Check deacon health -----------------------------------------------------
+
+log ""
+log "=== Deacon Health ==="
+
+DEACON_SESSION="hq-deacon"
+DEACON_ISSUE=""
+
+if ! tmux has-session -t "$DEACON_SESSION" 2>/dev/null; then
+  log "  CRASHED: Deacon session is dead"
+  DEACON_ISSUE="crashed"
+else
+  DEACON_PID=$(tmux list-panes -t "$DEACON_SESSION" -F '#{pane_pid}' 2>/dev/null | head -1)
+  DEACON_COMM=$(ps -o comm= -p "$DEACON_PID" 2>/dev/null)
+  if [ -z "$DEACON_COMM" ]; then
+    log "  ZOMBIE: Deacon process dead (pid=$DEACON_PID), session alive"
+    DEACON_ISSUE="zombie"
+  else
+    log "  Process alive: pid=$DEACON_PID comm=$DEACON_COMM"
+  fi
+
+  HEARTBEAT_FILE="$TOWN_ROOT/deacon/.deacon-heartbeat"
+  if [ -f "$HEARTBEAT_FILE" ]; then
+    if [ "$(uname)" = "Darwin" ]; then
+      HEARTBEAT_TIME=$(stat -f %m "$HEARTBEAT_FILE" 2>/dev/null)
+    else
+      HEARTBEAT_TIME=$(stat -c %Y "$HEARTBEAT_FILE" 2>/dev/null)
+    fi
+    NOW=$(date +%s)
+    HEARTBEAT_AGE=$(( NOW - HEARTBEAT_TIME ))
+
+    if [ "$HEARTBEAT_AGE" -gt 600 ]; then
+      log "  STUCK: Deacon heartbeat stale (${HEARTBEAT_AGE}s old)"
+      DEACON_ISSUE="stuck_heartbeat_${HEARTBEAT_AGE}s"
+    else
+      log "  OK: Deacon heartbeat ${HEARTBEAT_AGE}s old"
+    fi
+  fi
+fi
+
+# --- Mass death check ---------------------------------------------------------
+
+TOTAL_ISSUES=$(( ${#CRASHED[@]} + ${#STUCK[@]} ))
+if [ "$TOTAL_ISSUES" -ge 3 ]; then
+  log ""
+  log "MASS DEATH: $TOTAL_ISSUES agents down — escalating instead of restarting"
+  gt escalate "Mass agent death: $TOTAL_ISSUES agents down" \
+    -s CRITICAL 2>/dev/null || true
+fi
+
+# --- Take action --------------------------------------------------------------
+
+# Crashed polecats: notify witness to restart
+for ENTRY in "${CRASHED[@]}"; do
+  IFS='|' read -r SESSION RIG PCAT HOOK <<< "$ENTRY"
+  log "Requesting restart for $RIG/polecats/$PCAT (hook=$HOOK)"
+  gt mail send "$RIG/witness" -s "RESTART_POLECAT: $RIG/$PCAT" --stdin <<BODY
+Polecat $PCAT crash confirmed by stuck-agent-dog plugin.
+hook_bead: $HOOK
+action: restart requested
+BODY
+done
+
+# Zombie polecats: kill zombie session, then request restart
+for ENTRY in "${STUCK[@]}"; do
+  IFS='|' read -r SESSION RIG PCAT HOOK REASON <<< "$ENTRY"
+  log "Killing zombie session $SESSION and requesting restart"
+  tmux kill-session -t "$SESSION" 2>/dev/null || true
+  gt mail send "$RIG/witness" -s "RESTART_POLECAT: $RIG/$PCAT (zombie cleared)" --stdin <<BODY
+Polecat $PCAT zombie session cleared by stuck-agent-dog plugin.
+hook_bead: $HOOK
+reason: $REASON
+action: restart requested
+BODY
+done
+
+# Deacon issues: escalate
+if [ -n "$DEACON_ISSUE" ]; then
+  log "Escalating deacon issue: $DEACON_ISSUE"
+  gt escalate "Deacon $DEACON_ISSUE detected by stuck-agent-dog" -s HIGH 2>/dev/null || true
+fi
+
+# --- Report -------------------------------------------------------------------
+
+SUMMARY="Agent health: ${#CRASHED[@]} crashed, ${#STUCK[@]} stuck, $HEALTHY healthy"
+[ -n "$DEACON_ISSUE" ] && SUMMARY="$SUMMARY, deacon=$DEACON_ISSUE"
+log ""
+log "=== $SUMMARY ==="
+
+bd create "stuck-agent-dog: $SUMMARY" -t chore --ephemeral \
+  -l type:plugin-run,plugin:stuck-agent-dog,result:success \
+  -d "$SUMMARY" --silent 2>/dev/null || true


### PR DESCRIPTION
## Summary

Four plugins had complete specifications in `plugin.md` but no executable `run.sh`. This PR adds implementations for all four, following the existing plugin pattern (cooldown gate, bd wisp recording, escalation on failure).

- **stuck-agent-dog** (5m cooldown): Context-aware stuck/crashed agent detection for polecats and deacon. Checks tmux session + process health, notifies witness for restarts, escalates on mass death (>=3 agents). Scoped to polecats and deacon only — never touches crew, mayor, witness, or refinery sessions.

- **rebuild-gt** (1h cooldown): Safe binary rebuild from gastown source. Uses `gt stale --json` to verify staleness and forward-safety before building. Only rebuilds on main branch — prevents the crash-loop incident where a bad rebuild broke every session's startup hook.

- **git-hygiene** (12h cooldown): Stale branch, stash, and gc cleanup across all rig repos. Deletes merged local branches, orphan agent branches (`polecat/*`, `dog/*`, `fix/*`) with no remote tracking branch, merged remote branches on GitHub via `gh api`, clears stashes, and runs `git gc --prune=now`.

- **dolt-snapshots**: Build/run wrapper for the existing Go binary (`main.go`) that tags Dolt databases at convoy boundaries for audit, diff, and rollback.

## Test plan

- [ ] `bash -n` syntax check passes for all 4 scripts
- [ ] stuck-agent-dog: correctly enumerates polecats from rigs.json, detects dead sessions, skips crew
- [ ] rebuild-gt: skips when binary is fresh, skips when `safe_to_rebuild=false`, rebuilds when stale+safe
- [ ] git-hygiene: deletes merged branches, preserves main/master/refinery-patrol, runs gc
- [ ] dolt-snapshots: builds Go binary and executes it

🤖 Generated with [Claude Code](https://claude.com/claude-code)