### PR TITLE
feat(daemon): add quota_dog for automatic rate-limit detection and credential rotation

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -535,6 +535,18 @@ func (d *Daemon) Run() error {
 		d.logger.Printf("Main branch test ticker started (interval %v)", interval)
 	}
 
+	// Start quota dog ticker if configured.
+	// Scans for rate-limited sessions and automatically rotates credentials.
+	var quotaDogTicker *time.Ticker
+	var quotaDogChan <-chan time.Time
+	if d.isPatrolActive("quota_dog") {
+		interval := quotaDogInterval(d.patrolConfig)
+		quotaDogTicker = time.NewTicker(interval)
+		quotaDogChan = quotaDogTicker.C
+		defer quotaDogTicker.Stop()
+		d.logger.Printf("Quota dog ticker started (interval %v)", interval)
+	}
+
 	// Note: PATCH-010 uses per-session hooks in deacon/manager.go (SetAutoRespawnHook).
 	// Global pane-died hooks don't fire reliably in tmux 3.2a, so we rely on the
 	// per-session approach which has been tested to work for continuous recovery.
@@ -634,6 +646,13 @@ func (d *Daemon) Run() error {
 			// rig's main branch to catch regressions from merges or direct pushes.
 			if !d.isShutdownInProgress() {
 				d.runMainBranchTests()
+			}
+
+		case <-quotaDogChan:
+			// Quota dog — scans for rate-limited sessions and automatically
+			// rotates credentials to available accounts via keychain swap.
+			if !d.isShutdownInProgress() {
+				d.runQuotaDog()
 			}
 
 		case <-timer.C:

--- a/internal/daemon/dog_molecule.go
+++ b/internal/daemon/dog_molecule.go
@@ -222,6 +222,8 @@ func (dm *dogMol) discoverSteps() {
 			dm.stepIDs["sync"] = child.ID
 		case strings.Contains(titleLower, "offsite"):
 			dm.stepIDs["offsite"] = child.ID
+		case strings.Contains(titleLower, "rotat"):
+			dm.stepIDs["rotate"] = child.ID
 		}
 	}
 }

--- a/internal/daemon/quota_dog.go
+++ b/internal/daemon/quota_dog.go
@@ -1,0 +1,78 @@
+package daemon
+
+import (
+	"bytes"
+	"context"
+	"os/exec"
+	"time"
+)
+
+const (
+	defaultQuotaDogInterval = 5 * time.Minute
+	// quotaDogTimeout is the maximum time allowed for a single rotation cycle.
+	quotaDogTimeout = 2 * time.Minute
+)
+
+// QuotaDogConfig holds configuration for the quota_dog patrol.
+type QuotaDogConfig struct {
+	// Enabled controls whether the quota dog runs.
+	Enabled bool `json:"enabled"`
+
+	// IntervalStr is how often to run, as a string (e.g., "5m").
+	IntervalStr string `json:"interval,omitempty"`
+}
+
+// quotaDogInterval returns the configured interval, or the default (5m).
+func quotaDogInterval(config *DaemonPatrolConfig) time.Duration {
+	if config != nil && config.Patrols != nil && config.Patrols.QuotaDog != nil {
+		if config.Patrols.QuotaDog.IntervalStr != "" {
+			if d, err := time.ParseDuration(config.Patrols.QuotaDog.IntervalStr); err == nil && d > 0 {
+				return d
+			}
+		}
+	}
+	return defaultQuotaDogInterval
+}
+
+// runQuotaDog executes a quota rotation cycle by shelling out to `gt quota rotate`.
+// The daemon is a thin ticker — `gt quota rotate` handles scanning for rate-limited
+// sessions, planning account assignments, and executing keychain swaps + session restarts.
+//
+// This follows the daemon's "dumb scheduler" principle: the daemon schedules,
+// existing commands do the work. No LLM or molecule needed — pure mechanical rotation.
+func (d *Daemon) runQuotaDog() {
+	if !d.isPatrolActive("quota_dog") {
+		return
+	}
+
+	d.logger.Printf("quota_dog: starting rotation cycle")
+
+	ctx, cancel := context.WithTimeout(d.ctx, quotaDogTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, d.gtPath, "quota", "rotate", "--json") //nolint:gosec // G204: gtPath resolved at daemon init
+	cmd.Dir = d.config.TownRoot
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		// Non-fatal: rotation failure shouldn't crash the daemon.
+		// Common expected failures: <2 accounts, no rate-limited sessions.
+		stderrStr := stderr.String()
+		if stderrStr != "" {
+			d.logger.Printf("quota_dog: rotation failed (non-fatal): %v: %s", err, stderrStr)
+		} else {
+			d.logger.Printf("quota_dog: rotation failed (non-fatal): %v", err)
+		}
+		return
+	}
+
+	outStr := stdout.String()
+	if outStr != "" && outStr != "[]\n" && outStr != "[]" {
+		d.logger.Printf("quota_dog: rotation result: %s", outStr)
+	} else {
+		d.logger.Printf("quota_dog: no rate-limited sessions detected")
+	}
+}

--- a/internal/daemon/quota_dog_test.go
+++ b/internal/daemon/quota_dog_test.go
@@ -1,0 +1,85 @@
+package daemon
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+)
+
+func TestQuotaDogInterval(t *testing.T) {
+	// Default interval
+	if got := quotaDogInterval(nil); got != defaultQuotaDogInterval {
+		t.Errorf("expected default interval %v, got %v", defaultQuotaDogInterval, got)
+	}
+
+	// Custom interval
+	config := &DaemonPatrolConfig{
+		Patrols: &PatrolsConfig{
+			QuotaDog: &QuotaDogConfig{
+				Enabled:     true,
+				IntervalStr: "2m",
+			},
+		},
+	}
+	if got := quotaDogInterval(config); got != 2*time.Minute {
+		t.Errorf("expected 2m interval, got %v", got)
+	}
+
+	// Invalid interval falls back to default
+	config.Patrols.QuotaDog.IntervalStr = "invalid"
+	if got := quotaDogInterval(config); got != defaultQuotaDogInterval {
+		t.Errorf("expected default interval for invalid config, got %v", got)
+	}
+}
+
+func TestIsPatrolEnabled_QuotaDog(t *testing.T) {
+	// Nil config: disabled (opt-in patrol)
+	if IsPatrolEnabled(nil, "quota_dog") {
+		t.Error("expected quota_dog to be disabled with nil config")
+	}
+
+	// Empty patrols: disabled
+	config := &DaemonPatrolConfig{
+		Patrols: &PatrolsConfig{},
+	}
+	if IsPatrolEnabled(config, "quota_dog") {
+		t.Error("expected quota_dog to be disabled by default")
+	}
+
+	// Explicitly enabled
+	config.Patrols.QuotaDog = &QuotaDogConfig{Enabled: true}
+	if !IsPatrolEnabled(config, "quota_dog") {
+		t.Error("expected quota_dog to be enabled when configured")
+	}
+
+	// Explicitly disabled
+	config.Patrols.QuotaDog = &QuotaDogConfig{Enabled: false}
+	if IsPatrolEnabled(config, "quota_dog") {
+		t.Error("expected quota_dog to be disabled when explicitly disabled")
+	}
+}
+
+func TestQuotaDogConfigJSON(t *testing.T) {
+	jsonData := `{"enabled": true, "interval": "3m"}`
+
+	var config QuotaDogConfig
+	if err := json.Unmarshal([]byte(jsonData), &config); err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+
+	if !config.Enabled {
+		t.Error("expected enabled=true")
+	}
+	if config.IntervalStr != "3m" {
+		t.Errorf("expected interval=3m, got %s", config.IntervalStr)
+	}
+}
+
+func TestQuotaDogDefaultConstants(t *testing.T) {
+	if defaultQuotaDogInterval != 5*time.Minute {
+		t.Errorf("expected default interval 5m, got %v", defaultQuotaDogInterval)
+	}
+	if quotaDogTimeout != 2*time.Minute {
+		t.Errorf("expected timeout 2m, got %v", quotaDogTimeout)
+	}
+}

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -129,6 +129,7 @@ type PatrolsConfig struct {
 	CheckpointDog          *CheckpointDogConfig           `json:"checkpoint_dog,omitempty"`
 	ScheduledMaintenance   *ScheduledMaintenanceConfig    `json:"scheduled_maintenance,omitempty"`
 	MainBranchTest         *MainBranchTestConfig          `json:"main_branch_test,omitempty"`
+	QuotaDog               *QuotaDogConfig                `json:"quota_dog,omitempty"`
 	RestartTracker         *RestartTrackerConfig          `json:"restart_tracker,omitempty"`
 }
 
@@ -300,6 +301,12 @@ func IsPatrolEnabled(config *DaemonPatrolConfig, patrol string) bool {
 			return false
 		}
 		return config.Patrols.MainBranchTest.Enabled
+	}
+	if patrol == "quota_dog" {
+		if config == nil || config.Patrols == nil || config.Patrols.QuotaDog == nil {
+			return false
+		}
+		return config.Patrols.QuotaDog.Enabled
 	}
 
 	if config == nil || config.Patrols == nil {


### PR DESCRIPTION
## Problem

When Claude Code hits a rate limit, crew sessions stop and prompt for login. Credential rotation is 100% LLM-triggered: the existing `gt quota rotate` machinery requires a running agent to notice the rate limit and invoke it. No background code handles this automatically.

## Solution

Add `quota_dog.go` to `internal/daemon/` — a thin daemon patrol that runs `gt quota rotate` on a configurable ticker (default: every 5 minutes).

**Design principle: dumb scheduler.** The daemon schedules; existing commands do the work. `gt quota rotate` already handles:
- Scanning all tmux panes for rate-limit patterns
- Planning account assignments across sessions
- Executing keychain swaps and session restarts

No LLM, no molecule, no new logic — just wire the existing rotation command into the daemon heartbeat.

## Changes

- `internal/daemon/quota_dog.go` — patrol implementation (78 lines)
- `internal/daemon/quota_dog_test.go` — unit tests for config/interval/enabled logic
- `internal/daemon/types.go` — `QuotaDogConfig` struct + `IsPatrolEnabled` case
- `internal/daemon/daemon.go` — ticker integration in heartbeat loop
- `internal/daemon/dog_molecule.go` — patrol name registration

## Configuration

Opt-in via `daemon.json` (disabled by default):

```json
{
  "patrols": {
    "quota_dog": {
      "enabled": true,
      "interval": "5m"
    }
  }
}
```

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/daemon/...` — passes
- [x] `go test ./internal/quota/...` — passes
- [ ] Enable quota_dog in daemon.json, trigger a rate limit, verify rotation fires without LLM intervention

🤖 Generated with [Claude Code](https://claude.com/claude-code)