### PR TITLE
fix(convoy,done): prevent 0/0 auto-close and handle feature branches in gt done

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -912,6 +912,13 @@ func runConvoyCheck(cmd *cobra.Command, args []string) error {
 // and closes the convoy if so. Returns (true, nil) if the convoy was closed or
 // would be closed (dry-run), (false, nil) if not ready, or (false, err) on failure.
 func closeConvoyIfComplete(townBeads, convoyID, title string, tracked []trackedIssueInfo, dryRun bool) (bool, error) {
+	// If no tracked issues were resolved, skip auto-close. A 0/0 result means
+	// cross-rig tracking resolution failed — not that all issues are done.
+	// Treating 0/0 as "complete" caused false 🚚 Convoy landed notifications. (GH#3xxx)
+	if len(tracked) == 0 {
+		return false, nil
+	}
+
 	allClosed := true
 	openCount := 0
 	for _, t := range tracked {
@@ -932,9 +939,6 @@ func closeConvoyIfComplete(townBeads, convoyID, title string, tracked []trackedI
 	}
 
 	reason := "All tracked issues completed"
-	if len(tracked) == 0 {
-		reason = "Empty convoy (0 tracked issues) — auto-closed as definitionally complete"
-	}
 	closeArgs := []string{"close", convoyID, "-r", reason}
 	closeCmd := exec.Command("bd", closeArgs...)
 	closeCmd.Dir = townBeads

--- a/internal/cmd/convoy_empty_test.go
+++ b/internal/cmd/convoy_empty_test.go
@@ -86,7 +86,10 @@ esac
 	return binDir, townRoot, closeLogPath
 }
 
-func TestCheckSingleConvoy_EmptyConvoyAutoCloses(t *testing.T) {
+func TestCheckSingleConvoy_EmptyConvoyDoesNotAutoClose(t *testing.T) {
+	// When getTrackedIssues returns empty (cross-rig resolution failure or truly
+	// no tracked issues), closeConvoyIfComplete must NOT auto-close. A 0/0 result
+	// means "could not resolve", not "all done". (GH#hq-439)
 	_, townBeads, closeLogPath := mockBdForConvoyTest(t, "hq-empty1", "Empty test convoy")
 
 	err := checkSingleConvoy(townBeads, "hq-empty1", false)
@@ -94,17 +97,10 @@ func TestCheckSingleConvoy_EmptyConvoyAutoCloses(t *testing.T) {
 		t.Fatalf("checkSingleConvoy() error: %v", err)
 	}
 
-	// Verify bd close was called with the empty-convoy reason
-	data, err := os.ReadFile(closeLogPath)
-	if err != nil {
-		t.Fatalf("reading close log: %v", err)
-	}
-	log := string(data)
-	if !strings.Contains(log, "hq-empty1") {
-		t.Errorf("close log should contain convoy ID, got: %q", log)
-	}
-	if !strings.Contains(log, "Empty convoy") {
-		t.Errorf("close log should contain empty-convoy reason, got: %q", log)
+	// Verify bd close was NOT called — 0 tracked issues = no auto-close.
+	_, err = os.ReadFile(closeLogPath)
+	if err == nil {
+		t.Error("convoy with 0 tracked issues should NOT be auto-closed, but close log exists")
 	}
 }
 

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -455,11 +455,23 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// LLM agents read error messages and self-bypass (the original bug).
 		if aheadCount == 0 {
 			if os.Getenv("GT_POLECAT") != "" && doneCleanupStatus != "clean" && !isNoMergeTask {
-				return fmt.Errorf("cannot complete: no commits on branch ahead of %s\n"+
-					"Polecats must have at least 1 commit to submit.\n"+
-					"If the bug was already fixed upstream: gt done --status DEFERRED\n"+
-					"If you're blocked: gt done --status ESCALATED",
-					originDefault)
+				// Before failing, check whether commits exist on the remote feature branch.
+				// After a polecat pushes to origin/<feature-branch> and submits an MR,
+				// if master advances (e.g., other MRs land), the feature branch is no
+				// longer ahead of origin/master — but the work WAS committed and pushed.
+				// In that case, treat as "MR already submitted" and fall through. (GH#wd7)
+				branchPushedWithWork := false
+				if branch != defaultBranch {
+					pushed, unpushed, pushErr := g.BranchPushedToRemote(branch, "origin")
+					branchPushedWithWork = pushErr == nil && pushed && unpushed == 0
+				}
+				if !branchPushedWithWork {
+					return fmt.Errorf("cannot complete: no commits on branch ahead of %s\n"+
+						"Polecats must have at least 1 commit to submit.\n"+
+						"If the bug was already fixed upstream: gt done --status DEFERRED\n"+
+						"If you're blocked: gt done --status ESCALATED",
+						originDefault)
+				}
 			}
 
 			// Non-polecat (crew/mayor), polecat with --cleanup-status=clean


### PR DESCRIPTION
## Summary

- **convoy**: `closeConvoyIfComplete` no longer auto-closes when `len(tracked)==0`. A zero tracked-issue count means cross-rig resolution failed, not that all issues are done. Treating 0/0 as "all complete" caused false 🚚 Convoy landed notifications and premature convoy closure on every cross-rig convoy. (hq-439)

- **done**: When a polecat is on a feature branch and `aheadCount==0` vs `origin/master`, `gt done` now checks whether the remote feature branch exists and HEAD matches it. If so, the MR was already submitted (or master incorporated the work) — it proceeds instead of failing. Previously polecats had to use `gt done --status DEFERRED` as a workaround. (hq-wd7)

## Root Causes

**Convoy 0/0**: `getTrackedIssues` returns nil when cross-rig dep resolution fails (both `bd dep list --type=tracks` and `bd show --json` don't surface cross-rig tracks dependencies in v0.12.1). `closeConvoyIfComplete` treated the resulting empty slice as "all issues resolved" — causing immediate auto-close after convoy creation.

**gt done feature branch**: After pushing to `origin/<feature-branch>` and submitting an MR, if `master` advances (other MRs land), the feature branch is no longer "ahead of origin/master" even though the work was committed and pushed. The polecat commit guard fired incorrectly.

## Test plan

- [x] `TestCheckSingleConvoy_EmptyConvoyDoesNotAutoClose` — replaces the old `TestCheckSingleConvoy_EmptyConvoyAutoCloses`, verifies no auto-close on 0 tracked
- [x] All convoy empty/stranded tests pass
- [x] All routing tests pass
- [x] Pre-existing `TestBuildRefineryPatrolVars_FullConfig` failure is unrelated (exists on main before this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)