### PR TITLE
fix: Docker Compose bootstrap for dev environment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -78,3 +78,4 @@ result
 
 # Gas Town (added by gt)
 __pycache__/
+.env

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,6 +13,8 @@ RUN apt-get update && apt-get install -y \
     sqlite3 \
     tmux \
     curl \
+    wget \
+    openssh-client \
     ripgrep \
     zsh \
     gh \
@@ -31,7 +33,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/i
 RUN curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash
 
 # Set up directories
-RUN mkdir -p /app /gt && chown agent:agent /app /gt
+RUN mkdir -p /app /gt /gt/.dolt-data && chown -R agent:agent /app /gt
 
 # Environment setup for bash and zsh
 RUN echo 'export PATH="/app/gastown:$PATH"' >> /etc/profile.d/gastown.sh && \
@@ -40,6 +42,51 @@ RUN echo 'export COLORTERM="truecolor"' >> /etc/profile.d/colorterm.sh && \
     echo 'export COLORTERM="truecolor"' >> /etc/zsh/zshenv
 RUN echo 'export TERM="xterm-256color"' >> /etc/profile.d/term.sh && \
     echo 'export TERM="xterm-256color"' >> /etc/zsh/zshenv
+
+################################ Carepatron customisations ###############################
+
+# Versions — keep in sync with .devcontainer/Dockerfile
+ARG NODE_VERSION=24
+ARG YARN_VERSION=3.5.0
+ARG SHFMT_VERSION=3.11.0
+ARG YAMLFMT_VERSION=0.21.0
+
+# 1Password CLI (credential retrieval at container startup)
+RUN curl -sS https://downloads.1password.com/linux/keys/1password.asc | \
+    gpg --dearmor --output /usr/share/keyrings/1password-archive-keyring.gpg && \
+    echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/1password-archive-keyring.gpg] \
+    https://downloads.1password.com/linux/debian/$(dpkg --print-architecture) stable main" | \
+    tee /etc/apt/sources.list.d/1password.list && \
+    apt-get update && apt-get install -y 1password-cli && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+
+# Node.js + corepack + yarn
+# Required for: biome (JSON/TS/CSS formatting), yarn install in worktrees (UI work)
+RUN curl -fsSL https://deb.nodesource.com/setup_${NODE_VERSION}.x | bash - && \
+    apt-get install -y nodejs && \
+    apt-get clean && rm -rf /var/lib/apt/lists/*
+RUN corepack enable && corepack prepare yarn@${YARN_VERSION} --activate
+
+# shfmt + yamlfmt
+RUN ARCH=$(dpkg --print-architecture) && \
+    wget "https://github.com/mvdan/sh/releases/download/v${SHFMT_VERSION}/shfmt_v${SHFMT_VERSION}_linux_${ARCH}" \
+    -O /usr/local/bin/shfmt && \
+    chmod +x /usr/local/bin/shfmt && \
+    YAMLFMT_ARCH=$(case "${ARCH}" in amd64) echo x86_64;; arm64) echo arm64;; *) echo "${ARCH}";; esac) && \
+    wget "https://github.com/google/yamlfmt/releases/download/v${YAMLFMT_VERSION}/yamlfmt_${YAMLFMT_VERSION}_Linux_${YAMLFMT_ARCH}.tar.gz" \
+    -O /tmp/yamlfmt.tar.gz && \
+    tar -xzf /tmp/yamlfmt.tar.gz -C /usr/local/bin yamlfmt && \
+    chmod +x /usr/local/bin/yamlfmt && \
+    rm /tmp/yamlfmt.tar.gz
+
+# .NET SDK 10
+# Matches public-api base image (mcr.microsoft.com/dotnet/sdk:10.0)
+# Required for: dotnet build, dotnet test, dotnet format (Refinery quality gates)
+RUN curl -fsSL https://dot.net/v1/dotnet-install.sh | \
+    bash -s -- --channel 10.0 --install-dir /usr/share/dotnet
+ENV PATH="/usr/share/dotnet:${PATH}"
+
+################################ Carepatron customisations ###############################
 
 USER agent
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,12 +24,17 @@ services:
       IS_SANDBOX: 1
       GIT_USER: ${GIT_USER:-TestUser}
       GIT_EMAIL: ${GIT_EMAIL:-test@example.com}
+      OP_SERVICE_ACCOUNT_TOKEN: ${OP_SERVICE_ACCOUNT_TOKEN:-}
+      TZ: Pacific/Auckland
     volumes:
       # FOLDER must be defined in .env file, e.g. FOLDER=/home/user
       # or provided as an environment variable when running docker compose,
       # e.g. FOLDER=/home/user docker compose up
       - agent-home:/home/agent
       - ${FOLDER}:/gt
+      # Dolt data on a proper ext4 volume (not the macOS bind mount) to                                                                                                                                                                                                                                                                          
+      # avoid journal corruption from VirtioFS fsync semantics.                                                                                                                                                                                                                                                                                  
+      - dolt-data:/gt/.dolt-data               
     ports:
       - "${DASHBOARD_PORT:-8080}:8080"
     command: sleep infinity
@@ -38,3 +43,4 @@ services:
 
 volumes:
   agent-home:
+  dolt-data:

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -11,6 +11,16 @@ if [ -n "$GIT_USER" ] && [ -n "$GIT_EMAIL" ]; then
     dolt config --global --add user.email "$GIT_EMAIL"
 fi
 
+# Fetch credentials from 1Password if service account token is available
+if [ -n "$OP_SERVICE_ACCOUNT_TOKEN" ]; then
+  # Fetch deploy key for git auth
+  /app/gastown/scripts/op/configure-github-deploykey-auth.sh
+  # Fetch signing key for commit signing
+  /app/gastown/scripts/configure-git-signing.sh
+  # Fetch gh CLI token
+  /app/gastown/scripts/op/configure-gh-auth.sh
+fi
+
 if [ ! -f /gt/mayor/town.json ]; then
     echo "Initializing Gas Town workspace at /gt..."
     /app/gastown/gt install /gt --git
@@ -18,5 +28,8 @@ else
     echo "Refreshing Gas Town workspace at /gt..."
     /app/gastown/gt install /gt --git --force
 fi
+
+# Start the web dashboard (mapped to host via DASHBOARD_PORT, default 8080)
+gt dashboard --bind 0.0.0.0 --port 8080 &
 
 exec "$@"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,197 @@
+#!/bin/bash
+# Shared Common Utilities
+# Provides common functions for repository management, token management, and logging
+# Version: 1.0.0
+
+# ============================================================================
+# Logging Utilities
+# ============================================================================
+
+# Only initialize logging if not already initialized
+if [ -z "${COLOR_DEBUG:-}" ]; then
+  # Color codes - respect NO_COLOR environment variable
+  if [ -t 2 ] && [ "${NO_COLOR:-}" = "" ]; then
+    COLOR_DEBUG='\033[0;90m' # Grey (bright black, works in both dark/light themes)
+    COLOR_INFO='\033[0;32m'  # Green
+    COLOR_WARN='\033[0;33m'  # Yellow
+    COLOR_ERROR='\033[0;31m' # Red
+    COLOR_RESET='\033[0m'    # Reset
+  else
+    COLOR_DEBUG=''
+    COLOR_INFO=''
+    COLOR_WARN=''
+    COLOR_ERROR=''
+    COLOR_RESET=''
+  fi
+
+  # Single source of truth: DEBUG=true to enable debug logging
+  OP_DEBUG=true
+
+  # Debug logging - only shown if DEBUG=true
+  debug_log() {
+    if [ "${OP_DEBUG:-false}" = "true" ]; then
+      echo -e "${COLOR_DEBUG}[DEBUG]${COLOR_RESET} $*" >&2
+    fi
+  }
+
+  # Info logging - always shown
+  info_log() {
+    echo -e "${COLOR_INFO}[INFO]${COLOR_RESET} $*" >&2
+  }
+
+  # Warning logging - always shown
+  warn_log() {
+    echo -e "${COLOR_WARN}[WARN]${COLOR_RESET} $*" >&2
+  }
+
+  # Error logging - always shown
+  error_log() {
+    echo -e "${COLOR_ERROR}[ERROR]${COLOR_RESET} $*" >&2
+  }
+fi
+
+# ============================================================================
+# Config Resolution (env vars first, then config.local fallback)
+# ============================================================================
+
+CONFIG_LOCAL_FILE="/workspace/.devcontainer/config.local"
+
+# Read a config value: checks env var first, then config.local file
+# Usage: _read_config_value KEY
+_read_config_value() {
+  local key="$1"
+  # Check env var first (supports gastown container where vars come via docker-compose)
+  local env_val="${!key:-}"
+  if [ -n "$env_val" ]; then
+    echo "$env_val" | tr -d '[:space:]'
+    return
+  fi
+  # Fall back to config.local file (devcontainer path)
+  if [ -f "$CONFIG_LOCAL_FILE" ]; then
+    grep -E "^${key}=" "$CONFIG_LOCAL_FILE" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"'"'" | tr -d '[:space:]'
+  fi
+}
+
+# Read a config value preserving internal whitespace: env var first, then config.local
+# Usage: _read_config_value_raw KEY
+_read_config_value_raw() {
+  local key="$1"
+  # Check env var first
+  local env_val="${!key:-}"
+  if [ -n "$env_val" ]; then
+    echo "$env_val" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+    return
+  fi
+  # Fall back to config.local file
+  if [ -f "$CONFIG_LOCAL_FILE" ]; then
+    grep -E "^${key}=" "$CONFIG_LOCAL_FILE" 2>/dev/null | head -1 | cut -d= -f2- | tr -d '"'"'" | sed 's/^[[:space:]]*//;s/[[:space:]]*$//'
+  fi
+}
+
+# Get the git user name (env: GIT_USER_NAME or GIT_USER, then config.local)
+# Returns: user name or empty string
+get_git_user_name() {
+  local name
+  name=$(_read_config_value_raw "GIT_USER_NAME")
+  # Also check GIT_USER (used by gastown docker-compose)
+  if [ -z "$name" ]; then
+    name="${GIT_USER:-}"
+  fi
+  if [ -n "$name" ]; then
+    debug_log "Git user name: $name"
+    echo "$name"
+  fi
+}
+
+# Get the git user email (env: GIT_USER_EMAIL or GIT_EMAIL, then config.local)
+# Returns: user email or empty string
+get_git_user_email() {
+  local email
+  email=$(_read_config_value "GIT_USER_EMAIL")
+  # Also check GIT_EMAIL (used by gastown docker-compose)
+  if [ -z "$email" ]; then
+    email="${GIT_EMAIL:-}"
+  fi
+  if [ -n "$email" ]; then
+    debug_log "Git user email: $email"
+    echo "$email"
+  fi
+}
+
+# Get the Claude auth mode
+# Returns: "browser" or "api-key"
+get_claude_auth_mode() {
+  local auth_mode
+  auth_mode=$(_read_config_value "CLAUDE_AUTH_MODE")
+  if [ -n "$auth_mode" ]; then
+    debug_log "Claude auth mode: $auth_mode"
+    echo "$auth_mode"
+  else
+    debug_log "No CLAUDE_AUTH_MODE configured — defaulting to browser"
+    echo "browser"
+  fi
+}
+
+# Get the devcontainer profile
+# Returns: profile name (default: "default")
+get_devcontainer_profile() {
+  local profile
+  profile=$(_read_config_value "PROFILE")
+  if [ -n "$profile" ]; then
+    debug_log "Profile: $profile"
+    echo "$profile"
+    return
+  fi
+  debug_log "No profile configured — defaulting to default"
+  echo "default"
+}
+
+# Get the 1Password service account token (env var or config.local)
+# Returns: token value or empty string
+get_op_service_account_token() {
+  local token
+  token=$(_read_config_value "OP_SERVICE_ACCOUNT_TOKEN")
+  if [ -n "$token" ]; then
+    debug_log "OP service account token found (length: ${#token})"
+    echo "$token"
+  fi
+}
+
+# Get the git signing key source
+# Returns: "op", "ssh-agent", or empty string (signing disabled)
+get_git_signing_key_source() {
+  local source
+  source=$(_read_config_value "GIT_SIGNING_KEY_SOURCE")
+  if [ -n "$source" ]; then
+    debug_log "Git signing key source: $source"
+    echo "$source"
+  else
+    debug_log "GIT_SIGNING_KEY_SOURCE not set — signing disabled"
+  fi
+}
+
+# ============================================================================
+# Repository Name Detection
+# ============================================================================
+
+# Returns the repository name for 1Password vault lookups.
+# Hardcoded for gastown — this fork targets Carepatron-App.
+get_repo_name() {
+  echo "Carepatron-App"
+}
+
+# ============================================================================
+# Vault Name Resolution
+# ============================================================================
+
+# Get repository-specific vault name
+# Returns: vault name in format "Gastown {repo-name}"
+# Example: "my-repo" -> "Gastown my-repo"
+get_repo_vault_name() {
+  local repo_name="$1"
+  if [ -z "$repo_name" ]; then
+    error_log "get_repo_vault_name: repo_name is required"
+    return 1
+  fi
+  echo "Gastown ${repo_name}"
+}

--- a/scripts/configure-git-signing.sh
+++ b/scripts/configure-git-signing.sh
@@ -1,0 +1,172 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================
+# Source Shared Utilities
+# ============================================================================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_FILE="$SCRIPT_DIR/common.sh"
+if [ ! -f "$COMMON_FILE" ]; then
+  echo "ERROR: Could not find common.sh at expected location: $COMMON_FILE" >&2
+  exit 1
+fi
+source "$COMMON_FILE"
+
+# ============================================================================
+# Main
+# ============================================================================
+
+main() {
+  info_log "Configuring git commit signing..."
+
+  local key_source
+  key_source="op"
+
+  if [ -z "$key_source" ]; then
+    info_log "Git commit signing not enabled (set GIT_SIGNING_KEY_SOURCE=ssh-agent or op in config.local to enable)"
+    return 0
+  fi
+
+  info_log "Signing key source: $key_source"
+
+  SSH_DIR="$HOME/.ssh"
+  mkdir -p "$SSH_DIR"
+  chmod 700 "$SSH_DIR"
+
+  SIGNING_KEY_FILE="$SSH_DIR/id_ed25519_signing"
+  ALLOWED_SIGNERS_FILE="$SSH_DIR/allowed_signers"
+
+  local public_key
+  case "$key_source" in
+  op) public_key=$(configure_from_op) ;;
+  ssh-agent) public_key=$(configure_from_ssh_agent) || return 0 ;;
+  none | NA)
+    info_log "Git commit signing explicitly disabled (GIT_SIGNING_KEY_SOURCE=$key_source)"
+    return 0
+    ;;
+  *)
+    error_log "Unknown GIT_SIGNING_KEY_SOURCE: '$key_source'"
+    error_log "Valid values: 'op', 'ssh-agent', 'none', 'NA'"
+    return 1
+    ;;
+  esac
+
+  configure_git_globals "$public_key"
+  info_log "Git commit signing configured successfully (source: $key_source)"
+}
+
+# ============================================================================
+# Key source: 1Password
+# ============================================================================
+
+configure_from_op() {
+  local helper_script="$SCRIPT_DIR/op/retrieve-git-signing-key.sh"
+
+  if [ ! -x "$helper_script" ]; then
+    error_log "Signing key retriever script not found or not executable: $helper_script"
+    return 1
+  fi
+
+  # Cache the private key on disk — keys rotate infrequently and fetching is slow.
+  # To force a re-fetch: rm ~/.ssh/id_ed25519_signing
+  if [ -f "$SIGNING_KEY_FILE" ]; then
+    info_log "Signing key already on disk — skipping 1Password fetch"
+  else
+    debug_log "Fetching signing private key from 1Password..."
+    local private_key
+    private_key=$("$helper_script")
+
+    if [ -z "$private_key" ]; then
+      error_log "Retrieved signing key is empty"
+      return 1
+    fi
+
+    echo "$private_key" >"$SIGNING_KEY_FILE"
+    chmod 600 "$SIGNING_KEY_FILE"
+    info_log "Signing private key written to: $SIGNING_KEY_FILE"
+  fi
+
+  # Derive public key from private key (always — ensures git config stays correct).
+  local public_key
+  public_key=$(ssh-keygen -y -f "$SIGNING_KEY_FILE" 2>&1)
+  if [ $? -ne 0 ] || [ -z "$public_key" ]; then
+    error_log "Failed to derive public key from signing private key"
+    error_log "Output: $public_key"
+    return 1
+  fi
+
+  git config --global user.signingKey "$SIGNING_KEY_FILE"
+  echo "$public_key"
+}
+
+# ============================================================================
+# Key source: host SSH agent
+# ============================================================================
+
+configure_from_ssh_agent() {
+  if [ -z "${SSH_AUTH_SOCK:-}" ]; then
+    warn_log "SSH_AUTH_SOCK is not set — skipping signing config"
+    warn_log "This is expected if the IDE SSH agent socket is not yet forwarded (e.g. during postAttachCommand)"
+    warn_log "Open a new terminal and run: .devcontainer/scripts/configure-git-signing.sh"
+    return 1
+  fi
+
+  local agent_keys
+  agent_keys=$(ssh-add -L 2>&1) || true
+  if [ -z "$agent_keys" ] || echo "$agent_keys" | grep -qE "^(Could not open|The agent has no|Error connecting to agent)"; then
+    warn_log "SSH agent is not accessible or contains no keys — skipping signing config"
+    warn_log "This is expected if the IDE SSH agent socket is not yet forwarded (e.g. during postAttachCommand)"
+    warn_log "Open a new terminal and run: .devcontainer/scripts/configure-git-signing.sh"
+    return 1
+  fi
+
+  local key_count
+  key_count=$(echo "$agent_keys" | wc -l | tr -d ' ')
+  debug_log "SSH agent has $key_count key(s)"
+
+  if [ "$key_count" -gt 1 ]; then
+    warn_log "SSH agent has $key_count keys; using the first one for signing"
+    warn_log "If this is wrong, ensure only your signing key is loaded in the agent"
+  fi
+
+  local public_key
+  public_key=$(echo "$agent_keys" | head -n 1)
+
+  # Write to a .pub file so git config is stable across agent restarts.
+  echo "$public_key" >"${SIGNING_KEY_FILE}.pub"
+  chmod 644 "${SIGNING_KEY_FILE}.pub"
+
+  git config --global user.signingKey "${SIGNING_KEY_FILE}.pub"
+  info_log "Signing key set from SSH agent (public key written to ${SIGNING_KEY_FILE}.pub)"
+  echo "$public_key"
+}
+
+# ============================================================================
+# Shared: write allowed_signers and set git globals
+# ============================================================================
+
+configure_git_globals() {
+  local public_key="$1"
+
+  local git_email
+  git_email=$(git config --global user.email 2>/dev/null || echo "")
+  if [ -z "$git_email" ]; then
+    warn_log "user.email not set in git config — allowed_signers file will be incomplete"
+    git_email="unknown"
+  fi
+
+  echo "$git_email $public_key" >"$ALLOWED_SIGNERS_FILE"
+  chmod 644 "$ALLOWED_SIGNERS_FILE"
+  debug_log "Wrote allowed_signers: $ALLOWED_SIGNERS_FILE"
+
+  git config --global gpg.format ssh
+  git config --global gpg.ssh.allowedSignersFile "$ALLOWED_SIGNERS_FILE"
+  git config --global commit.gpgsign true
+  git config --global tag.gpgsign true
+
+  # also unset gpg ssh program because it comes through from the host (where it's useful) to here (where it's not)
+  git config --global --unset gpg.ssh.program 2>/dev/null || true
+}
+
+# ============================================================================
+main

--- a/scripts/op/configure-gh-auth.sh
+++ b/scripts/op/configure-gh-auth.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================
+# Source Shared Utilities
+# ============================================================================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_FILE="$SCRIPT_DIR/../common.sh"
+if [ ! -f "$COMMON_FILE" ]; then
+  echo "ERROR: Could not find common.sh at expected location: $COMMON_FILE" >&2
+  exit 1
+fi
+source "$COMMON_FILE"
+
+# ============================================================================
+# Main Script
+# ============================================================================
+info_log "Configuring GitHub CLI authentication..."
+
+if gh auth status --hostname github.com &>/dev/null; then
+  info_log "GitHub CLI already authenticated — skipping 1Password fetch"
+else
+  HELPER_SCRIPT="$SCRIPT_DIR/retrieve-gh-auth-token.sh"
+
+  if [ ! -x "$HELPER_SCRIPT" ]; then
+    error_log "GitHub PAT helper script not found or not executable: $HELPER_SCRIPT"
+    exit 1
+  fi
+
+  debug_log "Fetching GitHub PAT from 1Password..."
+  PAT=$("$HELPER_SCRIPT")
+  HELPER_EXIT=$?
+
+  if [ $HELPER_EXIT -ne 0 ]; then
+    error_log "Failed to fetch GitHub PAT from 1Password"
+    exit 1
+  fi
+
+  if [ -z "$PAT" ]; then
+    error_log "GitHub PAT is empty"
+    exit 1
+  fi
+
+  debug_log "PAT retrieved successfully (length: ${#PAT})"
+
+  echo "$PAT" | gh auth login --with-token --hostname github.com
+  GH_EXIT=$?
+
+  if [ $GH_EXIT -ne 0 ]; then
+    error_log "Failed to authenticate GitHub CLI with PAT"
+    exit 1
+  fi
+
+  gh auth status --hostname github.com 2>&1 | while IFS= read -r line; do info_log "$line"; done
+
+  info_log "GitHub CLI authenticated successfully"
+fi

--- a/scripts/op/configure-github-deploykey-auth.sh
+++ b/scripts/op/configure-github-deploykey-auth.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================
+# Source Shared Utilities
+# ============================================================================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_FILE="$SCRIPT_DIR/../common.sh"
+if [ ! -f "$COMMON_FILE" ]; then
+  echo "ERROR: Could not find common.sh at expected location: $COMMON_FILE" >&2
+  exit 1
+fi
+source "$COMMON_FILE"
+
+# ============================================================================
+# Main Script
+# ============================================================================
+info_log "Starting GitHub SSH configuration..."
+
+# Determine repository name from git
+REPO_NAME=$(get_repo_name)
+
+if [ -z "$REPO_NAME" ]; then
+  error_log "Failed to determine repository name"
+  error_log "Not in a git repository or could not detect repository name"
+  exit 1
+fi
+
+info_log "Configuring SSH for repository: $REPO_NAME"
+
+# Create .ssh directory if it doesn't exist
+SSH_DIR="$HOME/.ssh"
+mkdir -p "$SSH_DIR"
+chmod 700 "$SSH_DIR"
+debug_log "Created SSH directory: $SSH_DIR"
+
+KEY_FILE="$SSH_DIR/id_ed25519_${REPO_NAME}"
+
+if [ -f "$KEY_FILE" ]; then
+  info_log "Deploy key already on disk — skipping 1Password fetch"
+else
+  # Fetch private key from 1Password
+  HELPER_SCRIPT="$SCRIPT_DIR/retrieve-github-ssh-key.sh"
+
+  if [ ! -x "$HELPER_SCRIPT" ]; then
+    error_log "GitHub SSH helper script not found or not executable: $HELPER_SCRIPT"
+    exit 1
+  fi
+
+  debug_log "Fetching private key from 1Password..."
+  PRIVATE_KEY=$("$HELPER_SCRIPT")
+  HELPER_EXIT=$?
+
+  if [ $HELPER_EXIT -ne 0 ]; then
+    error_log "Failed to fetch private key from 1Password"
+    error_log "Helper output: $PRIVATE_KEY"
+    exit 1
+  fi
+
+  if [ -z "$PRIVATE_KEY" ]; then
+    error_log "Private key is empty"
+    exit 1
+  fi
+
+  debug_log "Private key retrieved successfully (length: ${#PRIVATE_KEY})"
+
+  echo "$PRIVATE_KEY" >"$KEY_FILE"
+  chmod 600 "$KEY_FILE"
+
+  # Validate the key file is properly formatted (should start with -----BEGIN)
+  if ! head -n 1 "$KEY_FILE" | grep -q "^-----BEGIN"; then
+    error_log "Written key file does not appear to be valid"
+    error_log "First line: $(head -n 1 "$KEY_FILE")"
+    error_log "This may indicate an encoding issue. Check the key file contents."
+    rm -f "$KEY_FILE"
+    exit 1
+  fi
+
+  info_log "✓ Wrote private key to: $KEY_FILE"
+fi
+
+# Configure SSH config to use the deploy key for github.com directly.
+# This avoids rewriting the git remote URL, so the same remote works on both
+# the host (using the host's SSH key) and the container (using the deploy key).
+SSH_CONFIG="$SSH_DIR/config"
+
+debug_log "Configuring SSH config file: $SSH_CONFIG"
+
+# Remove existing github.com configuration if present
+if [ -f "$SSH_CONFIG" ]; then
+  sed "/^Host github\.com$/,/^$/d" "$SSH_CONFIG" >"${SSH_CONFIG}.tmp"
+  mv "${SSH_CONFIG}.tmp" "$SSH_CONFIG"
+fi
+
+# Append new configuration
+cat >>"$SSH_CONFIG" <<EOF
+
+Host github.com
+    HostName github.com
+    User git
+    IdentityFile ${KEY_FILE}
+    IdentitiesOnly yes
+    StrictHostKeyChecking accept-new
+EOF
+
+chmod 600 "$SSH_CONFIG"
+info_log "✓ Updated SSH config for github.com with deploy key"
+
+# ============================================================================
+# GitHub CLI Configuration
+# ============================================================================
+
+info_log "Configuring GitHub CLI..."
+
+# Configure gh to use SSH protocol (will use our configured SSH keys)
+gh config set git_protocol ssh --host github.com 2>/dev/null || true
+
+# Test GitHub CLI authentication
+if gh auth status &>/dev/null; then
+  info_log "✓ GitHub CLI authenticated successfully"
+else
+  # gh will use git's SSH credentials automatically
+  debug_log "GitHub CLI will use SSH authentication via git credentials"
+fi
+
+info_log "GitHub SSH configuration complete!"

--- a/scripts/op/retrieve-gh-auth-token.sh
+++ b/scripts/op/retrieve-gh-auth-token.sh
@@ -1,0 +1,109 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================
+# Source Shared Utilities
+# ============================================================================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_FILE="$SCRIPT_DIR/../common.sh"
+if [ ! -f "$COMMON_FILE" ]; then
+  echo "ERROR: Could not find common.sh at expected location: $COMMON_FILE" >&2
+  exit 1
+fi
+source "$COMMON_FILE"
+
+TOKEN_RETRIEVER_FILE="$SCRIPT_DIR/retrieve-service-account-token.sh"
+if [ ! -f "$TOKEN_RETRIEVER_FILE" ]; then
+  error_log "Could not find retrieve-service-account-token.sh at expected location: $TOKEN_RETRIEVER_FILE"
+  exit 1
+fi
+source "$TOKEN_RETRIEVER_FILE"
+
+# ============================================================================
+# Main Script
+# ============================================================================
+debug_log "Starting GitHub PAT retrieval..."
+
+# Get service account token using convention-based resolution
+REPO_NAME=$(get_repo_name)
+if [ -z "$REPO_NAME" ]; then
+  error_log "Failed to determine repository name"
+  exit 1
+fi
+
+debug_log "Repository name: $REPO_NAME"
+
+# Resolve service account token from config.local
+SERVICE_ACCOUNT_TOKEN=$(get_service_account_token "$REPO_NAME")
+if [ -z "$SERVICE_ACCOUNT_TOKEN" ]; then
+  error_log "Service account token not found for repository: $REPO_NAME"
+  error_log "Expected OP_SERVICE_ACCOUNT_TOKEN in /workspace/.devcontainer/config.local"
+  exit 1
+fi
+
+debug_log "Service account token found (length: ${#SERVICE_ACCOUNT_TOKEN})"
+
+# Configure 1Password CLI to use service account
+export OP_SERVICE_ACCOUNT_TOKEN="$SERVICE_ACCOUNT_TOKEN"
+VAULT=$(get_repo_vault_name "$REPO_NAME")
+
+info_log "Looking up GitHub PAT for repository: $REPO_NAME in vault: $VAULT"
+
+# List all items in the vault
+ALL_ITEMS=$(op item list --vault "$VAULT" --format json 2>/dev/null)
+
+if [ -z "$ALL_ITEMS" ]; then
+  error_log "Failed to list items in vault: $VAULT"
+  error_log "Please verify:"
+  error_log "  1. Service account has access to vault '$VAULT'"
+  error_log "  2. Vault name is correct"
+  error_log "  3. Service account token is valid"
+  exit 1
+fi
+
+debug_log "Retrieved $(echo "$ALL_ITEMS" | jq 'length') items from vault"
+
+# Find items matching "GitHub PAT {REPO_NAME} YYYYMMDD"
+ITEM_NAME_PATTERN="GitHub PAT ${REPO_NAME}"
+debug_log "Searching for items matching pattern: '$ITEM_NAME_PATTERN *'"
+
+MATCHING_ITEMS=$(echo "$ALL_ITEMS" | jq -r --arg pattern "$ITEM_NAME_PATTERN" \
+  '.[] | select(.title | startswith($pattern)) | .title' | sort -r)
+
+if [ -z "$MATCHING_ITEMS" ]; then
+  error_log "No GitHub PAT found for repository: $REPO_NAME"
+  error_log "Expected item name pattern: '$ITEM_NAME_PATTERN YYYYMMDD'"
+  error_log "Vault: $VAULT"
+  error_log ""
+  error_log "To create a PAT:"
+  error_log "  1. Generate a fine-grained PAT at https://github.com/settings/personal-access-tokens"
+  error_log "  2. Create an API Credential item in 1Password vault '$VAULT' with:"
+  error_log "     - Title: '$ITEM_NAME_PATTERN YYYYMMDD' (e.g., '$ITEM_NAME_PATTERN $(date +%Y%m%d)')"
+  error_log "     - Field 'credential': The PAT value"
+  exit 1
+fi
+
+# Get the most recent item (first after reverse sort)
+MOST_RECENT_ITEM=$(echo "$MATCHING_ITEMS" | head -n 1)
+debug_log "Found $(echo "$MATCHING_ITEMS" | wc -l | tr -d ' ') matching item(s)"
+info_log "Using PAT: $MOST_RECENT_ITEM"
+
+# Fetch the credential field from the item
+debug_log "Fetching credential from item..."
+PAT=$(op item get "$MOST_RECENT_ITEM" --vault "$VAULT" --fields label=credential --reveal 2>/dev/null)
+
+if [ -z "$PAT" ]; then
+  error_log "Failed to retrieve credential from item: $MOST_RECENT_ITEM"
+  error_log "Please verify the item has a field labeled 'credential'"
+  exit 1
+fi
+
+debug_log "Successfully retrieved PAT (length: ${#PAT})"
+
+# Strip quotes and whitespace
+PAT=$(echo "$PAT" | tr -d '"\n\r ')
+
+debug_log "After cleaning (length: ${#PAT})"
+
+# Output the PAT
+echo "$PAT"

--- a/scripts/op/retrieve-git-signing-key.sh
+++ b/scripts/op/retrieve-git-signing-key.sh
@@ -1,0 +1,133 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================
+# Source Shared Utilities
+# ============================================================================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_FILE="$SCRIPT_DIR/../common.sh"
+if [ ! -f "$COMMON_FILE" ]; then
+  echo "ERROR: Could not find common.sh at expected location: $COMMON_FILE" >&2
+  exit 1
+fi
+source "$COMMON_FILE"
+
+TOKEN_RETRIEVER_FILE="$SCRIPT_DIR/retrieve-service-account-token.sh"
+if [ ! -f "$TOKEN_RETRIEVER_FILE" ]; then
+  error_log "Could not find retrieve-service-account-token.sh at expected location: $TOKEN_RETRIEVER_FILE"
+  exit 1
+fi
+source "$TOKEN_RETRIEVER_FILE"
+
+# ============================================================================
+# Main Script
+# ============================================================================
+debug_log "Starting git signing key retrieval..."
+
+# Get service account token using convention-based resolution
+REPO_NAME=$(get_repo_name)
+if [ -z "$REPO_NAME" ]; then
+  error_log "Failed to determine repository name"
+  exit 1
+fi
+
+debug_log "Repository name: $REPO_NAME"
+
+# Resolve service account token from config.local
+SERVICE_ACCOUNT_TOKEN=$(get_service_account_token "$REPO_NAME")
+if [ -z "$SERVICE_ACCOUNT_TOKEN" ]; then
+  error_log "Service account token not found for repository: $REPO_NAME"
+  error_log "Expected OP_SERVICE_ACCOUNT_TOKEN in /workspace/.devcontainer/config.local"
+  exit 1
+fi
+
+debug_log "Service account token found (length: ${#SERVICE_ACCOUNT_TOKEN})"
+
+# Configure 1Password CLI to use service account
+export OP_SERVICE_ACCOUNT_TOKEN="$SERVICE_ACCOUNT_TOKEN"
+
+info_log "Looking up signing key for repository: $REPO_NAME"
+
+# Query 1Password for matching items — same vault as auth key
+VAULT=$(get_repo_vault_name "$REPO_NAME")
+TITLE_PATTERN="GitHub Signing Key $REPO_NAME"
+
+debug_log "Searching 1Password vault '$VAULT' for items matching: $TITLE_PATTERN"
+
+MATCHING_ITEMS=$(op item list --vault "$VAULT" --format json 2>&1 |
+  jq -r --arg pattern "$TITLE_PATTERN" \
+    '.[] | select(.title | startswith($pattern)) | .title' 2>/dev/null || true)
+
+if [ -z "$MATCHING_ITEMS" ]; then
+  error_log "No signing key found for repository: $REPO_NAME"
+  error_log "Expected item title pattern: 'GitHub Signing Key $REPO_NAME YYYYMMDD'"
+  error_log "Item type: SSH Key"
+  error_log "Vault: $VAULT"
+  exit 1
+fi
+
+# Sort by date in title (newest first) and take the first one
+MOST_RECENT_ITEM=$(echo "$MATCHING_ITEMS" | sort -r | head -n 1)
+debug_log "Found $(echo "$MATCHING_ITEMS" | wc -l | tr -d ' ') matching item(s)"
+info_log "Using signing key: $MOST_RECENT_ITEM"
+
+# Fetch the private key from the SSH Key item.
+# NOTE: ?ssh-format=openssh is intentionally NOT used — that query parameter causes
+# the op CLI to contact a separate key-conversion endpoint which hangs in this
+# firewall-restricted environment. We convert PKCS#8 -> OpenSSH ourselves using node.
+debug_log "Fetching private key from 1Password (PKCS#8 format)..."
+PRIVATE_KEY=$(op read "op://$VAULT/$MOST_RECENT_ITEM/private key" 2>&1)
+READ_EXIT=$?
+
+if [ $READ_EXIT -ne 0 ]; then
+  error_log "Failed to read signing key from 1Password using 'op read'"
+  error_log "Output: $PRIVATE_KEY"
+  error_log "Please verify this is an SSH Key item type"
+  exit 1
+fi
+
+debug_log "Successfully retrieved private key (length: ${#PRIVATE_KEY})"
+
+if [[ ! "$PRIVATE_KEY" =~ ^-----BEGIN ]]; then
+  error_log "Retrieved key does not appear to be a valid SSH private key"
+  error_log "Key starts with: $(echo "$PRIVATE_KEY" | head -c 50)"
+  error_log "This may indicate an encoding issue. Please check the 1Password item."
+  exit 1
+fi
+
+# Convert PKCS#8 PEM -> OpenSSH PEM using node.js (always available in this container).
+# Constructs the OpenSSH wire format from JWK key material per RFC 8709 / openssh-key-v1.
+debug_log "Converting PKCS#8 key to OpenSSH format via node..."
+PKCS8_KEY="$PRIVATE_KEY" node -e "
+const crypto = require('crypto');
+const key = crypto.createPrivateKey(process.env.PKCS8_KEY);
+const jwk = key.export({ format: 'jwk' });
+const priv = Buffer.from(jwk.d, 'base64url');
+const pub  = Buffer.from(jwk.x, 'base64url');
+function writeStr(s) { const b = Buffer.from(s); const l = Buffer.alloc(4); l.writeUInt32BE(b.length); return Buffer.concat([l, b]); }
+function writeBuf(b) { const l = Buffer.alloc(4); l.writeUInt32BE(b.length); return Buffer.concat([l, b]); }
+const keyType    = writeStr('ssh-ed25519');
+const pubBlock   = Buffer.concat([keyType, writeBuf(pub)]);
+const checkInt   = crypto.randomInt(0, 0xffffffff);
+const checkBuf   = Buffer.alloc(4); checkBuf.writeUInt32BE(checkInt);
+const privBlob   = Buffer.concat([keyType, writeBuf(pub), writeBuf(Buffer.concat([priv, pub])), writeStr('')]);
+const padLen     = (8 - ((privBlob.length + 8) % 8)) % 8;
+const padding    = Buffer.from([...Array(padLen)].map((_, i) => i + 1));
+const inner      = Buffer.concat([checkBuf, checkBuf, privBlob, padding]);
+const outer      = Buffer.concat([
+  Buffer.from('openssh-key-v1\0'),
+  writeStr('none'), writeStr('none'), writeStr(''),
+  Buffer.from([0, 0, 0, 1]),
+  writeBuf(pubBlock),
+  writeBuf(inner),
+]);
+const b64 = outer.toString('base64').match(/.{1,70}/g).join('\n');
+console.log('-----BEGIN OPENSSH PRIVATE KEY-----');
+console.log(b64);
+console.log('-----END OPENSSH PRIVATE KEY-----');
+"
+CONVERT_EXIT=$?
+if [ $CONVERT_EXIT -ne 0 ]; then
+  error_log "Failed to convert private key from PKCS#8 to OpenSSH format"
+  exit 1
+fi

--- a/scripts/op/retrieve-github-ssh-key.sh
+++ b/scripts/op/retrieve-github-ssh-key.sh
@@ -1,0 +1,100 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================
+# Source Shared Utilities
+# ============================================================================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_FILE="$SCRIPT_DIR/../common.sh"
+if [ ! -f "$COMMON_FILE" ]; then
+  echo "ERROR: Could not find common.sh at expected location: $COMMON_FILE" >&2
+  exit 1
+fi
+source "$COMMON_FILE"
+
+TOKEN_RETRIEVER_FILE="$SCRIPT_DIR/retrieve-service-account-token.sh"
+if [ ! -f "$TOKEN_RETRIEVER_FILE" ]; then
+  error_log "Could not find retrieve-service-account-token.sh at expected location: $TOKEN_RETRIEVER_FILE"
+  exit 1
+fi
+source "$TOKEN_RETRIEVER_FILE"
+
+# ============================================================================
+# Main Script
+# ============================================================================
+debug_log "Starting GitHub SSH key retrieval..."
+
+# Get service account token using convention-based resolution
+REPO_NAME=$(get_repo_name)
+if [ -z "$REPO_NAME" ]; then
+  error_log "Failed to determine repository name"
+  exit 1
+fi
+
+debug_log "Repository name: $REPO_NAME"
+
+# Resolve service account token from file
+SERVICE_ACCOUNT_TOKEN=$(get_service_account_token "$REPO_NAME")
+if [ -z "$SERVICE_ACCOUNT_TOKEN" ]; then
+  error_log "Service account token not found for repository: $REPO_NAME"
+  error_log "Expected OP_SERVICE_ACCOUNT_TOKEN in /workspace/.devcontainer/config.local"
+  exit 1
+fi
+
+debug_log "Service account token found (length: ${#SERVICE_ACCOUNT_TOKEN})"
+
+# Configure 1Password CLI to use service account
+export OP_SERVICE_ACCOUNT_TOKEN="$SERVICE_ACCOUNT_TOKEN"
+
+info_log "Looking up SSH key for repository: $REPO_NAME"
+
+# Query 1Password for matching items
+VAULT=$(get_repo_vault_name "$REPO_NAME")
+TITLE_PATTERN="GitHub SSH Key $REPO_NAME"
+
+debug_log "Searching 1Password vault '$VAULT' for items matching: $TITLE_PATTERN"
+
+# List all items in vault matching the title pattern (looking for SSH Key item type)
+MATCHING_ITEMS=$(op item list --vault "$VAULT" --format json 2>&1 |
+  jq -r --arg pattern "$TITLE_PATTERN" \
+    '.[] | select(.title | startswith($pattern)) | .title' 2>/dev/null || true)
+
+if [ -z "$MATCHING_ITEMS" ]; then
+  error_log "No SSH key found for repository: $REPO_NAME"
+  error_log "Expected item title pattern: 'GitHub SSH Key $REPO_NAME YYYYMMDD'"
+  error_log "Item type: SSH Key"
+  error_log "Vault: $VAULT"
+  exit 1
+fi
+
+# Sort by date in title (newest first) and take the first one
+MOST_RECENT_ITEM=$(echo "$MATCHING_ITEMS" | sort -r | head -n 1)
+debug_log "Found $(echo "$MATCHING_ITEMS" | wc -l | tr -d ' ') matching item(s)"
+info_log "Using SSH key: $MOST_RECENT_ITEM"
+
+# Fetch the private key from the SSH Key item
+# Use the recommended 'op read' command with ssh-format=openssh query parameter
+# See: https://developer.1password.com/docs/cli/ssh-keys/#get-a-private-key
+debug_log "Fetching private key using op read with OpenSSH format..."
+PRIVATE_KEY=$(op read "op://$VAULT/$MOST_RECENT_ITEM/private key?ssh-format=openssh" 2>&1)
+READ_EXIT=$?
+
+if [ $READ_EXIT -ne 0 ]; then
+  error_log "Failed to read private key from 1Password using 'op read'"
+  error_log "Output: $PRIVATE_KEY"
+  error_log "Please verify this is an SSH Key item type"
+  exit 1
+fi
+
+debug_log "Successfully retrieved private key (length: ${#PRIVATE_KEY})"
+
+# Verify the key looks valid (should start with -----BEGIN)
+if [[ ! "$PRIVATE_KEY" =~ ^-----BEGIN ]]; then
+  error_log "Retrieved key does not appear to be a valid SSH private key"
+  error_log "Key starts with: $(echo "$PRIVATE_KEY" | head -c 50)"
+  error_log "This may indicate an encoding issue. Please check the 1Password item."
+  exit 1
+fi
+
+# Output the private key (should now be properly decoded with actual newlines)
+echo "$PRIVATE_KEY"

--- a/scripts/op/retrieve-service-account-token.sh
+++ b/scripts/op/retrieve-service-account-token.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -euo pipefail
+
+# ============================================================================
+# Source Shared Utilities
+# ============================================================================
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+COMMON_FILE="$SCRIPT_DIR/../common.sh"
+if [ ! -f "$COMMON_FILE" ]; then
+  echo "ERROR: Could not find common.sh at expected location: $COMMON_FILE" >&2
+  exit 1
+fi
+source "$COMMON_FILE"
+
+# ============================================================================
+# Main Script
+# ============================================================================
+# Get service account token from config.local
+# Returns: token value or empty string if not found
+get_service_account_token() {
+  local repo_name="$1"
+  local token=""
+
+  token=$(get_op_service_account_token)
+
+  if [ -z "$token" ]; then
+    error_log "Service account token not found for repository: $repo_name"
+    error_log "Set OP_SERVICE_ACCOUNT_TOKEN as an env var or in config.local"
+    return 1
+  fi
+
+  echo "$token"
+  return 0
+}


### PR DESCRIPTION
## Summary
- Install pre-requisites (1Password CLI, GitHub CLI, git-lfs) in Dockerfile
- Wire in 1Password Connect for secret management (env vars, docker-compose volumes)
- Set timezone in container
- Add named Dolt data volume for persistence across restarts
- Fix volume permissions: start as root to chown, then exec as agent user via docker-entrypoint.sh
- Add helper scripts for git signing, GitHub auth, and SSH key retrieval via 1Password

## Test plan
- [ ] `docker compose up --build` starts successfully
- [ ] Dolt data persists across container restarts
- [ ] 1Password-based git signing works inside the container
- [ ] GitHub CLI auth works inside the container