### PR TITLE
fix: add named Dolt docker volume to avoid journal corruption on macOS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,7 @@ RUN curl -fsSL https://raw.githubusercontent.com/steveyegge/beads/main/scripts/i
 RUN curl -fsSL https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash
 
 # Set up directories
-RUN mkdir -p /app /gt && chown agent:agent /app /gt
+RUN mkdir -p /app /gt /gt/.dolt-data && chown -R agent:agent /app /gt
 
 # Environment setup for bash and zsh
 RUN echo 'export PATH="/app/gastown:$PATH"' >> /etc/profile.d/gastown.sh && \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -30,6 +30,9 @@ services:
       # e.g. FOLDER=/home/user docker compose up
       - agent-home:/home/agent
       - ${FOLDER}:/gt
+      # Dolt data on a proper ext4 volume (not the macOS bind mount) to
+      # avoid journal corruption from VirtioFS fsync semantics.
+      - dolt-data:/gt/.dolt-data
     ports:
       - "${DASHBOARD_PORT:-8080}:8080"
     command: sleep infinity
@@ -38,3 +41,4 @@ services:
 
 volumes:
   agent-home:
+  dolt-data:


### PR DESCRIPTION
## Summary

Moves Dolt's data directory onto a Docker named volume (ext4) instead of the macOS VirtioFS bind mount, fixing repeated journal corruption on `docker compose` restarts.

## Problem

New to Gas Town, wanting to run with host isolation.  Thanks for the docker compose work which dropped a couple of weeks ago!  😍  

After starting up Gas Town I tried verifying state before I started to do real work (and was also seeing error messages popping up besides...).

`dolt fsck` reports corruption after `docker compose down` / `up` cycles:

```
WARNING: Chunk journal is corrupted and some data may be lost.
Run `dolt fsck --revive-journal-with-data-loss` to attempt to recover the journal
by discarding invalid data blocks.
```

I observed this multiple times on fresh container starts. Corruption was silent initially — queries succeeded against a partially-corrupted store; only surfaced via explicit `dolt fsck`.  Although if I left it running it started erroring, I guess with the dolt backup cycles.

### Apparent root cause

`/gt` is a bind mount from macOS via Docker Desktop's VirtioFS layer:

```
/run/host_mark/Users on /gt type fakeowner (rw,nosuid,nodev,relatime,fakeowner)
```

The `fakeowner` driver translates between the Linux container's ext4 expectations and macOS's APFS. **VirtioFS does not fully honor `fsync` semantics** — a write that Dolt's journal considers durable may not actually be flushed to the host filesystem.

Dolt uses an append-only journal file for writes and relies on `fsync` to guarantee durability before acknowledging commits. On a real Linux filesystem this works correctly; on VirtioFS it doesn't.

The corruption cycle on every `docker compose down` + `up`:
1. Container gets SIGTERM → Dolt gets ~30s to flush → VirtioFS may not honor the flush
2. Next boot: `gt install --force` starts Dolt and immediately hammers it with schema migrations and `CREATE DATABASE`
3. Journal corruption from the unclean previous shutdown cascades into the new session

Dolt stats looked something like this;

| Metric | rig DB | hq |
|--------|-------------|-----|
| Reachable chunks | 78 | 2,297 |
| Unreachable chunks | 12,022 | 22,985 |
| Garbage ratio | 99.4% | 90.9% |
| `dolt fsck` | **Corrupted** | Clean |

## Proposed fix

A single Docker named volume for `.dolt-data`:

- Named volumes use **ext4 inside the Linux VM**, where `fsync` works correctly
- Mounts over `/gt/.dolt-data`, so Dolt writes to ext4 while the rest of `/gt` (git repos, config, worktrees) remains on the bind mount for host visibility
- Pre-creates `/gt/.dolt-data` in the Dockerfile so the directory exists before the volume mount

**This does mean `.dolt-data` is opaque on the host.**  Other than this I can't see reason not to make dolt data a docker volume - though it's very possible I just don't fully understand Gas Town.

### Verified

I've been running for some days after applying the fix and have had no recurrence of this issue.