### PR TITLE
fix: HandlePolecatDoneFromBead missing notifyMayorSlotOpen call

### DIFF
--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -215,9 +215,18 @@ func HandlePolecatDoneFromBead(bd *BdCli, workDir, rigName, polecatName string, 
 	}
 
 	if hasPendingMR {
-		return handlePolecatDonePendingMR(bd, workDir, rigName, payload, result)
+		result = handlePolecatDonePendingMR(bd, workDir, rigName, payload, result)
+	} else {
+		result = handlePolecatDoneNoMR(workDir, rigName, payload, result)
 	}
-	return handlePolecatDoneNoMR(workDir, rigName, payload, result)
+
+	// Notify Mayor that a slot is open regardless of MR status.
+	// Mirror HandlePolecatDone behavior — polecat is idle, Mayor should sling next bead. (GH#2727)
+	if result.Handled {
+		notifyMayorSlotOpen(workDir, rigName, polecatName, payload.Exit)
+	}
+
+	return result
 }
 
 // TransitionPolecatToIdle sets a polecat's agent_state to idle after the witness


### PR DESCRIPTION
## Summary
- `HandlePolecatDoneFromBead` (bead-state detection path, primary since gt-a6gp) never called `notifyMayorSlotOpen` after processing a polecat completion
- The mail path (`HandlePolecatDone`) and patrol scan path (`processDiscoveredCompletion`) both notify the Mayor — this path was the gap
- Result: Mayor sat idle even when polecat slots opened up, because it never learned about completions discovered via bead state

## Changes
- Mirror the `HandlePolecatDone` pattern: assign result from sub-handler, then call `notifyMayorSlotOpen` if completion was handled
- 9-line change in `internal/witness/handlers.go`

## Test plan
- [x] `go build ./internal/witness/...` succeeds
- [x] `go test ./internal/witness/...` passes
- [x] Verified all three completion paths now call `notifyMayorSlotOpen`

Closes gt-cw65

🤖 Generated with [Claude Code](https://claude.com/claude-code)