### PR TITLE
fix: add CLAUDE.local.md to gitignore patterns

### DIFF
--- a/internal/rig/overlay.go
+++ b/internal/rig/overlay.go
@@ -19,6 +19,7 @@ func gasTownIgnorePatterns() []string {
 		"__pycache__/",
 		"state.json",
 		"CLAUDE.md",
+		"CLAUDE.local.md",
 	}
 }
 

--- a/internal/rig/overlay_test.go
+++ b/internal/rig/overlay_test.go
@@ -400,7 +400,7 @@ func TestEnsureGitignorePatterns_AllPatternsPresent(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create existing .gitignore with all required patterns.
-	existing := ".runtime/\n.claude/\n.beads/\n.logs/\n__pycache__/\nstate.json\nCLAUDE.md\n"
+	existing := ".runtime/\n.claude/\n.beads/\n.logs/\n__pycache__/\nstate.json\nCLAUDE.md\nCLAUDE.local.md\n"
 	if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte(existing), 0644); err != nil {
 		t.Fatalf("Failed to create .gitignore: %v", err)
 	}
@@ -430,7 +430,7 @@ func TestEnsureGitignorePatterns_NarrowPatternPresent(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	// Create .gitignore with the exact required patterns
-	existing := ".runtime/\n.claude/\n.logs/\n__pycache__/\nstate.json\nCLAUDE.md\n"
+	existing := ".runtime/\n.claude/\n.logs/\n__pycache__/\nstate.json\nCLAUDE.md\nCLAUDE.local.md\n"
 	if err := os.WriteFile(filepath.Join(tmpDir, ".gitignore"), []byte(existing), 0644); err != nil {
 		t.Fatalf("Failed to create .gitignore: %v", err)
 	}


### PR DESCRIPTION
## Summary

- `EnsureGitignorePatterns()` included `CLAUDE.md` but not `CLAUDE.local.md`
- When `CLAUDE.local.md` was created before being gitignored, it got tracked in git and propagated identity overwrites across all crew clones on pull
- One-line addition to `gasTownIgnorePatterns()` plus test updates

## Context

`CreatePolecatCLAUDEmd()` correctly writes to `CLAUDE.local.md` to avoid polluting tracked `CLAUDE.md`, but the gitignore patterns didn't include `CLAUDE.local.md`. This meant the file could get indexed and committed, then propagate polecat lifecycle content into crew worktrees via merge.

## Test plan

- [x] `TestEnsureGitignorePatterns_AllPatternsPresent` — updated to include `CLAUDE.local.md`
- [x] `TestEnsureGitignorePatterns_NarrowPatternPresent` — updated to include `CLAUDE.local.md`
- [x] All existing gitignore tests pass
- [x] `go vet ./internal/rig/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)