### PR TITLE
fix: inject merge_strategy from rig settings into formula vars

### DIFF
--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -1139,6 +1139,9 @@ func loadRigCommandVars(townRoot, rig string) []string {
 	if mq.BuildCommand != "" {
 		vars = append(vars, fmt.Sprintf("build_command=%s", mq.BuildCommand))
 	}
+	if mq.MergeStrategy != "" {
+		vars = append(vars, fmt.Sprintf("merge_strategy=%s", mq.MergeStrategy))
+	}
 	return vars
 }
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -340,6 +340,9 @@ func MergeSettingsCommand(repo, local *MergeQueueConfig) *MergeQueueConfig {
 		if local.Enabled {
 			result.Enabled = local.Enabled
 		}
+		if local.MergeStrategy != "" {
+			result.MergeStrategy = local.MergeStrategy
+		}
 		if local.OnConflict != "" {
 			result.OnConflict = local.OnConflict
 		}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1222,6 +1222,10 @@ type MergeQueueConfig struct {
 	// Nil defaults to false (manual landing required).
 	IntegrationBranchAutoLand *bool `json:"integration_branch_auto_land,omitempty"`
 
+	// MergeStrategy controls how the refinery lands approved work: "direct" (default)
+	// merges directly to the base branch, "pr" creates a GitHub pull request.
+	MergeStrategy string `json:"merge_strategy,omitempty"`
+
 	// OnConflict specifies conflict resolution strategy: "assign_back" or "auto_rebase".
 	OnConflict string `json:"on_conflict"`
 


### PR DESCRIPTION
## Summary

- Added `MergeStrategy` field to `MergeQueueConfig`
- Wired it through `MergeSettingsCommand` (repo/local merge logic)
- Emit `merge_strategy=<value>` in `loadRigCommandVars`

## Context

`loadRigCommandVars()` mapped 5 build pipeline commands (`setup_command`, `typecheck_command`, `lint_command`, `test_command`, `build_command`) to formula `--var` flags but did not map `merge_strategy`. Rigs with `merge_queue.merge_strategy = "pr"` in their settings silently fell back to the formula default (`direct`).

The workaround was adding `--var merge_strategy=pr` on every `gt sling`, which is tedious and error-prone.

## Test plan

- [x] `go build ./cmd/gt`
- [x] `go vet ./internal/cmd/ ./internal/config/`
- [x] `go test ./internal/config/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)