### PR TITLE
fix: prevent slice panics on abbreviated SHA hashes

### DIFF
--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -212,7 +212,7 @@ func collectGitCommits(townRoot, actor string, since time.Time) ([]AuditEntry, e
 			Type:      "commit",
 			Actor:     author,
 			Summary:   subject,
-			ID:        hash[:8],
+			ID:        shortHash(hash),
 		})
 	}
 

--- a/internal/cmd/dolt_rebase.go
+++ b/internal/cmd/dolt_rebase.go
@@ -312,7 +312,7 @@ func runDoltRebase(cmd *cobra.Command, args []string) error {
 	}
 	if currentHead != preHead {
 		rebaseCleanupAll(db, baseBranch, workBranch)
-		return fmt.Errorf("ABORT: main HEAD moved during rebase (%s → %s)", preHead[:8], currentHead[:8])
+		return fmt.Errorf("ABORT: main HEAD moved during rebase (%s → %s)", shortHash(preHead), shortHash(currentHead))
 	}
 
 	// Step 9: Swap branches — make compact-work the new main.

--- a/internal/cmd/hash_display.go
+++ b/internal/cmd/hash_display.go
@@ -1,0 +1,10 @@
+package cmd
+
+// shortHash returns at most 8 characters of a hash for display.
+// Prevents panics when git returns abbreviated hashes shorter than 8 chars.
+func shortHash(hash string) string {
+	if len(hash) > 8 {
+		return hash[:8]
+	}
+	return hash
+}

--- a/internal/cmd/hash_display_test.go
+++ b/internal/cmd/hash_display_test.go
@@ -1,0 +1,22 @@
+package cmd
+
+import "testing"
+
+func TestShortHash(t *testing.T) {
+	tests := []struct {
+		input string
+		want  string
+	}{
+		{"abcdef0123456789", "abcdef01"},
+		{"abcdef01", "abcdef01"},
+		{"abcdef0", "abcdef0"},
+		{"abc", "abc"},
+		{"", ""},
+		{"13bd088", "13bd088"},
+	}
+	for _, tt := range tests {
+		if got := shortHash(tt.input); got != tt.want {
+			t.Errorf("shortHash(%q) = %q, want %q", tt.input, got, tt.want)
+		}
+	}
+}

--- a/internal/cmd/orphans.go
+++ b/internal/cmd/orphans.go
@@ -238,7 +238,7 @@ func runOrphans(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%s Found %d orphaned commit(s):\n\n", style.Warning.Render("⚠"), len(filtered))
 		for _, o := range filtered {
 			age := formatAge(o.Date)
-			fmt.Printf("  %s %s\n", style.Bold.Render(o.SHA[:8]), o.Subject)
+			fmt.Printf("  %s %s\n", style.Bold.Render(shortHash(o.SHA)), o.Subject)
 			fmt.Printf("    %s by %s\n\n", style.Dim.Render(age), o.Author)
 		}
 		fmt.Printf("%s\n", style.Dim.Render("To recover a commit:"))
@@ -604,7 +604,7 @@ func runOrphansKill(cmd *cobra.Command, args []string) error {
 	if len(filteredCommits) > 0 {
 		fmt.Printf("%s Found %d orphaned commit(s) to remove:\n\n", style.Warning.Render("⚠"), len(filteredCommits))
 		for _, o := range filteredCommits {
-			fmt.Printf("  %s %s\n", style.Bold.Render(o.SHA[:8]), o.Subject)
+			fmt.Printf("  %s %s\n", style.Bold.Render(shortHash(o.SHA)), o.Subject)
 			fmt.Printf("    %s by %s\n\n", style.Dim.Render(formatAge(o.Date)), o.Author)
 		}
 	} else if len(commitOrphans) > 0 {

--- a/internal/daemon/compactor_dog.go
+++ b/internal/daemon/compactor_dog.go
@@ -14,6 +14,14 @@ import (
 	"github.com/steveyegge/gastown/internal/reaper"
 )
 
+// shortHash returns at most 8 characters of a hash for display.
+func shortHash(hash string) string {
+	if len(hash) > 8 {
+		return hash[:8]
+	}
+	return hash
+}
+
 const (
 	defaultCompactorDogInterval = 24 * time.Hour
 	// defaultCompactorCommitThreshold is the minimum commit count before compaction triggers.
@@ -280,7 +288,7 @@ func (d *Daemon) compactDatabase(dbName string) error {
 	if err != nil {
 		return fmt.Errorf("find root commit: %w", err)
 	}
-	d.logger.Printf("compactor_dog: %s: root commit=%s", dbName, rootHash[:8])
+	d.logger.Printf("compactor_dog: %s: root commit=%s", dbName, shortHash(rootHash))
 
 	// Step 3: USE database for session-scoped operations.
 	ctx, cancel := context.WithTimeout(context.Background(), compactorQueryTimeout)
@@ -294,7 +302,7 @@ func (d *Daemon) compactDatabase(dbName string) error {
 	if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_RESET('--soft', '%s')", rootHash)); err != nil {
 		return fmt.Errorf("soft reset to root: %w", err)
 	}
-	d.logger.Printf("compactor_dog: %s: soft-reset to root %s", dbName, rootHash[:8])
+	d.logger.Printf("compactor_dog: %s: soft-reset to root %s", dbName, shortHash(rootHash))
 
 	// Step 5: Commit all data as a single commit.
 	commitMsg := fmt.Sprintf("compaction: flatten %s history to single commit", dbName)
@@ -403,7 +411,7 @@ func (d *Daemon) surgicalRebaseOnce(dbName string, keepRecent int) error {
 		return fmt.Errorf("pre-flight row counts: %w", err)
 	}
 	d.logger.Printf("compactor_dog: %s: surgical rebase pre-flight HEAD=%s, tables=%d, keep_recent=%d",
-		dbName, preHead[:8], len(preCounts), keepRecent)
+		dbName, shortHash(preHead), len(preCounts), keepRecent)
 
 	rootHash, err := d.compactorGetRootCommit(db, dbName)
 	if err != nil {
@@ -515,7 +523,7 @@ func (d *Daemon) surgicalRebaseOnce(dbName string, keepRecent int) error {
 	}
 	if currentHead != preHead {
 		d.surgicalCleanup(db, baseBranch, workBranch)
-		return fmt.Errorf("concurrency abort: main HEAD moved from %s to %s", preHead[:8], currentHead[:8])
+		return fmt.Errorf("concurrency abort: main HEAD moved from %s to %s", shortHash(preHead), shortHash(currentHead))
 	}
 
 	// Step 8: Swap branches — make compact-work the new main.

--- a/internal/refinery/batch.go
+++ b/internal/refinery/batch.go
@@ -395,7 +395,7 @@ func (e *Engineer) fastForwardBatch(ctx context.Context, stacked []*MRInfo, targ
 	for i, mr := range stacked {
 		ids[i] = mr.ID
 	}
-	_, _ = fmt.Fprintf(e.output, "[Batch] Successfully merged batch: %s (commit %s)\n", strings.Join(ids, ", "), tipSHA[:8])
+	_, _ = fmt.Fprintf(e.output, "[Batch] Successfully merged batch: %s (commit %s)\n", strings.Join(ids, ", "), shortSHA(tipSHA))
 
 	result.Merged = stacked
 	result.MergeCommit = tipSHA

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -25,6 +25,14 @@ import (
 	"github.com/steveyegge/gastown/internal/rig"
 )
 
+// shortSHA returns at most 8 characters of a SHA for display.
+func shortSHA(sha string) string {
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
+}
+
 // DefaultStaleClaimTimeout is the default duration after which a claimed MR
 // is considered abandoned and eligible for re-claim. This is conservative
 // to avoid re-claiming MRs that are legitimately processing long test suites.
@@ -519,7 +527,7 @@ func (e *Engineer) doMerge(ctx context.Context, branch, target, sourceIssue stri
 			if sc.NewSHA == "" {
 				continue // Submodule removed, nothing to push
 			}
-			_, _ = fmt.Fprintf(e.output, "[Engineer] Pushing submodule %s (commit %s)...\n", sc.Path, sc.NewSHA[:8])
+			_, _ = fmt.Fprintf(e.output, "[Engineer] Pushing submodule %s (commit %s)...\n", sc.Path, shortSHA(sc.NewSHA))
 			if pushErr := e.git.PushSubmoduleCommit(sc.Path, sc.NewSHA, "origin"); pushErr != nil {
 				return ProcessResult{
 					Success: false,
@@ -662,7 +670,7 @@ func (e *Engineer) doMerge(ctx context.Context, branch, target, sourceIssue stri
 		_, _ = fmt.Fprintf(e.output, "[Engineer] Auto-push disabled, skipping push to origin/%s\n", target)
 	}
 
-	_, _ = fmt.Fprintf(e.output, "[Engineer] Successfully merged: %s\n", mergeCommit[:8])
+	_, _ = fmt.Fprintf(e.output, "[Engineer] Successfully merged: %s\n", shortSHA(mergeCommit))
 	return ProcessResult{
 		Success:     true,
 		MergeCommit: mergeCommit,
@@ -1276,7 +1284,7 @@ The Refinery will automatically retry the merge after you force-push.`,
 		mr.Branch,
 		mr.ID,
 		mr.Branch,
-		mr.Target, mainSHA[:8],
+		mr.Target, shortSHA(mainSHA),
 		mr.SourceIssue,
 		retryCount,
 		mr.Branch,


### PR DESCRIPTION
  ## Summary
  Prevent runtime panics from `[:8]` slice expressions on SHA hashes shorter than
  8 characters. Git can return abbreviated hashes in shallow clones, submodule
  operations, and early repos with few objects. Add safe truncation helpers and
  apply them across all 12 display-only hash formatting sites. Also fix stale
  hardcoded DB names in dolt-backup plugin docs.
  ## Related Issue
  N/A — discovered during production triage of a `gt done` panic on a short
  submodule SHA.
  ## Changes
  - Add `shortSHA` helper to `internal/refinery/engineer.go` and apply to 3 sites
  - Apply `shortSHA` to 1 site in `internal/refinery/batch.go`
  - Add `shortHash` helper to `internal/daemon/compactor_dog.go` and apply to 4 sites
  - Add shared `shortHash` helper in `internal/cmd/hash_display.go` with unit tests
  - Apply `shortHash` to `internal/cmd/dolt_rebase.go` (1 site), `orphans.go` (2 sites), `audit.go` (1 site)
  - Fix `plugins/dolt-backup/plugin.md` to reflect auto-discovery instead of hardcoded DB names
  ## Testing
  - [x] Unit tests pass (`go test ./...`)
  - [x] Manual testing performed
  - [x] Added `TestShortHash` covering full-length, exactly-8, short, and empty inputs
  ## Checklist
  - [x] Code follows project style
  - [x] Documentation updated (if applicable)
  - [x] No breaking changes (or documented in summary)