### PR TITLE
fix(heartbeat): sync .deacon-heartbeat with heartbeat.json on every write

### DIFF
--- a/internal/deacon/heartbeat.go
+++ b/internal/deacon/heartbeat.go
@@ -67,7 +67,17 @@ func WriteHeartbeat(townRoot string, hb *Heartbeat) error {
 		return err
 	}
 
-	return os.WriteFile(hbFile, data, 0600)
+	if err := os.WriteFile(hbFile, data, 0600); err != nil {
+		return err
+	}
+
+	// Also touch .deacon-heartbeat for backward compatibility with shell scripts
+	// that check this file's mtime for liveness detection (stuck-agent-dog).
+	// These scripts predate heartbeat.json and check mtime, not file contents.
+	legacyFile := filepath.Join(filepath.Dir(hbFile), ".deacon-heartbeat")
+	_ = os.WriteFile(legacyFile, []byte(""), 0644) //nolint:gosec // G306: world-readable liveness file is intentional
+
+	return nil
 }
 
 // ReadHeartbeat reads the Deacon heartbeat from disk.

--- a/internal/deacon/heartbeat_test.go
+++ b/internal/deacon/heartbeat_test.go
@@ -310,6 +310,31 @@ func TestWriteHeartbeat_CreatesDirectory(t *testing.T) {
 	}
 }
 
+func TestWriteHeartbeat_TouchesLegacyFile(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "deacon-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	hb := &Heartbeat{Cycle: 1}
+	if err := WriteHeartbeat(tmpDir, hb); err != nil {
+		t.Fatalf("WriteHeartbeat error: %v", err)
+	}
+
+	// Legacy .deacon-heartbeat should also exist so shell scripts (stuck-agent-dog)
+	// that check this file's mtime get accurate data.
+	legacyFile := filepath.Join(tmpDir, "deacon", ".deacon-heartbeat")
+	info, err := os.Stat(legacyFile)
+	if err != nil {
+		t.Errorf(".deacon-heartbeat not created: %v", err)
+		return
+	}
+	if time.Since(info.ModTime()) > time.Minute {
+		t.Error(".deacon-heartbeat mtime should be recent")
+	}
+}
+
 func TestWriteHeartbeat_SetsTimestamp(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "deacon-test-*")
 	if err != nil {

--- a/plugins/stuck-agent-dog/plugin.md
+++ b/plugins/stuck-agent-dog/plugin.md
@@ -177,21 +177,31 @@ if ! tmux has-session -t "$DEACON_SESSION" 2>/dev/null; then
   echo "  CRASHED: Deacon session is dead"
   DEACON_ISSUE="crashed"
 else
-  # Check deacon heartbeat file
-  HEARTBEAT_FILE="$TOWN_ROOT/deacon/.deacon-heartbeat"
+  # Check deacon heartbeat file.
+  # heartbeat.json is the canonical file written by `gt deacon heartbeat` on every
+  # patrol cycle (start + mid-cycle checkpoint). .deacon-heartbeat is also kept in
+  # sync by WriteHeartbeat() for backward compatibility. Prefer heartbeat.json here
+  # as it is always written by the Go implementation.
+  #
+  # Threshold: 1200s (20m). The daemon nudges at 10m and logs STUCK at 15m;
+  # stuck-agent-dog fires at 20m to provide context-aware escalation without
+  # racing with the daemon or false-positiving during normal sleep/idle periods.
+  # Deacon patrol cycles take up to ~15 minutes total with heartbeat writes at
+  # start and mid-cycle, so max gap between writes is ~8 minutes + 60s sleep ≈ 9m.
+  HEARTBEAT_FILE="$TOWN_ROOT/deacon/heartbeat.json"
   if [ -f "$HEARTBEAT_FILE" ]; then
     HEARTBEAT_TIME=$(stat -f %m "$HEARTBEAT_FILE" 2>/dev/null || stat -c %Y "$HEARTBEAT_FILE" 2>/dev/null)
     NOW=$(date +%s)
     HEARTBEAT_AGE=$(( NOW - HEARTBEAT_TIME ))
 
-    if [ "$HEARTBEAT_AGE" -gt 600 ]; then
-      echo "  STUCK: Deacon heartbeat stale (${HEARTBEAT_AGE}s old, >10m threshold)"
+    if [ "$HEARTBEAT_AGE" -gt 1200 ]; then
+      echo "  STUCK: Deacon heartbeat stale (${HEARTBEAT_AGE}s old, >20m threshold)"
       DEACON_ISSUE="stuck_heartbeat_${HEARTBEAT_AGE}s"
     else
       echo "  OK: Deacon heartbeat ${HEARTBEAT_AGE}s old"
     fi
   else
-    echo "  WARN: No heartbeat file found"
+    echo "  WARN: No heartbeat file found at $HEARTBEAT_FILE"
   fi
 fi
 ```


### PR DESCRIPTION
## Summary
- `WriteHeartbeat()` now touches `.deacon-heartbeat` alongside `heartbeat.json` so stuck-agent-dog sees fresh mtimes
- Raises stuck detection threshold from 600s to 1200s to prevent false positives during normal deacon sleep/idle
- Fixes spurious escalations every ~20 minutes (950s, 2349s, 4240s stale heartbeat)

## Test plan
- [ ] Verify deacon patrol cycles no longer trigger false stuck_heartbeat escalations
- [ ] Confirm `.deacon-heartbeat` mtime updates on every `gt deacon heartbeat` call
- [ ] Confirm legitimately stuck deacon still triggers escalation after 1200s

🤖 Generated with [Claude Code](https://claude.com/claude-code)