### PR TITLE
fix: stop EnsureAllMetadata oscillating when two DBs map to same rig

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -2977,14 +2977,31 @@ func EnsureAllMetadata(townRoot string) (updated []string, errs []error) {
 		dbToRig[k] = v
 	}
 
+	// Group candidate database names by rig. When routes.jsonl and rigs.json
+	// use different prefixes for the same rig (e.g. "gas" vs "gt" both map to
+	// "gastown"), multiple databases may exist for the same rig. Processing
+	// them all causes oscillation: each one overwrites the other's
+	// dolt_database correction on every startup. (gas-ar0)
+	rigCandidates := make(map[string][]string) // rig -> candidate db names
 	for _, dbName := range databases {
 		rigName := dbName
 		if mapped, ok := dbToRig[dbName]; ok {
 			rigName = mapped
 		}
-		// Special case: "hq" database maps to "hq" rig (town-level)
 		if dbName == "hq" {
 			rigName = "hq"
+		}
+		rigCandidates[rigName] = append(rigCandidates[rigName], dbName)
+	}
+
+	for rigName, candidates := range rigCandidates {
+		// When multiple databases map to the same rig, choose one effective
+		// DB name: prefer whatever is already in metadata.json (if it's among
+		// the valid candidates) to avoid spurious mismatch warnings. Fall back
+		// to the first candidate (alphabetical, from os.ReadDir ordering).
+		dbName := candidates[0]
+		if len(candidates) > 1 {
+			dbName = pickDBForRig(townRoot, rigName, candidates)
 		}
 		// Pass dbName explicitly so EnsureMetadata writes the correct
 		// dolt_database value ("be") rather than the rig dir name ("beads_el").
@@ -2996,6 +3013,28 @@ func EnsureAllMetadata(townRoot string) (updated []string, errs []error) {
 	}
 
 	return updated, errs
+}
+
+// pickDBForRig selects which database name to use for a rig when multiple
+// candidates exist. Prefers the value already in metadata.json to avoid
+// oscillating corrections between two valid aliases for the same rig.
+func pickDBForRig(townRoot, rigName string, candidates []string) string {
+	beadsDir := FindRigBeadsDir(townRoot, rigName)
+	if beadsDir != "" {
+		if data, err := os.ReadFile(filepath.Join(beadsDir, "metadata.json")); err == nil {
+			var meta map[string]interface{}
+			if json.Unmarshal(data, &meta) == nil {
+				if existingDB, _ := meta["dolt_database"].(string); existingDB != "" {
+					for _, c := range candidates {
+						if c == existingDB {
+							return c // Already correct — no repair needed
+						}
+					}
+				}
+			}
+		}
+	}
+	return candidates[0] // Default: first (alphabetical from os.ReadDir)
 }
 
 // buildDatabaseToRigMap loads routes.jsonl and builds a map from database name

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -4164,6 +4164,86 @@ func TestEnsureAllMetadata_FallbackToDbName(t *testing.T) {
 	}
 }
 
+// TestEnsureAllMetadata_NoOscillation verifies that when two databases map to
+// the same rig (e.g. "gastown" and "gt" both map to rig "gastown" via
+// conflicting routes.jsonl/rigs.json entries), EnsureAllMetadata does not
+// oscillate the dolt_database value on repeated calls. (gas-ar0)
+func TestEnsureAllMetadata_NoOscillation(t *testing.T) {
+	townRoot := t.TempDir()
+	dataDir := filepath.Join(townRoot, ".dolt-data")
+
+	// Simulate two databases that both map to "gastown":
+	//   "gastown" — matched by default (db name == rig name)
+	//   "gt"      — matched via rigs.json prefix "gt"
+	setupDoltDB(t, dataDir, "gastown")
+	setupDoltDB(t, dataDir, "gt")
+	setupDoltDB(t, dataDir, "hq")
+
+	// rigs.json: gastown rig uses prefix "gt"
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	rigsData := `{"version":1,"rigs":{"gastown":{"beads":{"prefix":"gt"}}}}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(rigsData), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create beads dirs
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// First call: no existing metadata.json — whichever candidate wins is fine
+	_, errs := EnsureAllMetadata(townRoot)
+	if len(errs) > 0 {
+		t.Fatalf("first EnsureAllMetadata errors: %v", errs)
+	}
+
+	// Read the value that was written
+	metaPath := filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads", "metadata.json")
+	readDB := func() string {
+		data, err := os.ReadFile(metaPath)
+		if err != nil {
+			t.Fatalf("reading metadata.json: %v", err)
+		}
+		var meta map[string]interface{}
+		if err := json.Unmarshal(data, &meta); err != nil {
+			t.Fatalf("parsing metadata.json: %v", err)
+		}
+		db, _ := meta["dolt_database"].(string)
+		return db
+	}
+
+	firstDB := readDB()
+	if firstDB == "" {
+		t.Fatal("dolt_database should be set after first call")
+	}
+
+	// Second call: must produce the same value (no oscillation)
+	_, errs = EnsureAllMetadata(townRoot)
+	if len(errs) > 0 {
+		t.Fatalf("second EnsureAllMetadata errors: %v", errs)
+	}
+	secondDB := readDB()
+	if secondDB != firstDB {
+		t.Errorf("oscillation: first call wrote %q, second call wrote %q", firstDB, secondDB)
+	}
+
+	// Third call: still no change
+	_, errs = EnsureAllMetadata(townRoot)
+	if len(errs) > 0 {
+		t.Fatalf("third EnsureAllMetadata errors: %v", errs)
+	}
+	thirdDB := readDB()
+	if thirdDB != firstDB {
+		t.Errorf("oscillation: first call wrote %q, third call wrote %q", firstDB, thirdDB)
+	}
+}
+
 func TestCleanStaleSocket_RemovesStaleFile(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Unix sockets not applicable on Windows")


### PR DESCRIPTION
## Summary
- Groups databases by rig in `EnsureAllMetadata` — processes each rig exactly once
- When multiple DB candidates exist for a rig, prefers the value already in `metadata.json` to avoid repair churn
- Adds `TestEnsureAllMetadata_NoOscillation` regression test

## Test plan
- [ ] `gt up` no longer prints oscillating metadata repair warnings
- [ ] Fresh install picks correct database name
- [ ] Existing installs with valid metadata.json are left unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)