### PR TITLE
fix(done): validate checkpoint branch on resume to prevent stale-checkpoint bug

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -570,10 +570,17 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		var refspec string
 		var pushErr error
 
-		// Resume: skip push if already completed in a previous run (gt-aufru)
+		// Resume: skip push if already completed in a previous run (gt-aufru).
+		// Validate checkpoint branch matches current branch (ge-sbo: stale checkpoint
+		// on polecat reassignment causes new work to skip push for old branch).
 		if checkpoints[CheckpointPushed] != "" {
-			fmt.Printf("%s Branch already pushed (resumed from checkpoint)\n", style.Bold.Render("✓"))
-			goto afterPush
+			if checkpoints[CheckpointPushed] == branch {
+				fmt.Printf("%s Branch already pushed (resumed from checkpoint)\n", style.Bold.Render("✓"))
+				goto afterPush
+			}
+			// Stale checkpoint from a previous assignment — discard and push normally.
+			fmt.Printf("→ Discarding stale push checkpoint (was for branch %s, now on %s)\n",
+				checkpoints[CheckpointPushed], branch)
 		}
 
 		// CRITICAL: Push branch BEFORE creating MR bead (hq-6dk53, hq-a4ksk)
@@ -828,10 +835,21 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// Resume: skip MR creation if already completed in a previous run (gt-aufru).
 		// Mirrors the push checkpoint pattern above. Without this, every retry
 		// re-attempts bd.Create which hits unique constraints or creates duplicates.
+		// Validate that the checkpoint MR corresponds to the current branch (ge-sbo:
+		// stale checkpoint on polecat reassignment would reuse old MR for new work).
 		if checkpoints[CheckpointMRCreated] != "" {
-			mrID = checkpoints[CheckpointMRCreated]
-			fmt.Printf("%s MR already created (resumed from checkpoint: %s)\n", style.Bold.Render("✓"), mrID)
-			goto afterMR
+			cpMRID := checkpoints[CheckpointMRCreated]
+			if cpMR, cpErr := bd.Show(cpMRID); cpErr == nil && cpMR != nil {
+				branchPrefix := "branch: " + branch + "\n"
+				if strings.HasPrefix(cpMR.Description, branchPrefix) {
+					mrID = cpMRID
+					fmt.Printf("%s MR already created (resumed from checkpoint: %s)\n", style.Bold.Render("✓"), mrID)
+					goto afterMR
+				}
+				// Checkpoint MR is for a different branch — discard and create fresh.
+				fmt.Printf("→ Discarding stale MR checkpoint %s (was for different branch)\n", cpMRID)
+			}
+			// If MR lookup fails, fall through to create/find MR normally.
 		}
 
 		// Check if MR bead already exists for this branch (idempotency)


### PR DESCRIPTION
## Summary

- `gt done` resumes from `done-cp:*` labels on the agent bead, but these labels persist across polecat reassignments if a previous `gt done` was interrupted after writing checkpoints but before clearing them.
- On the next assignment, `gt done --pre-verified` would skip push+submit for the NEW branch because it trusted the stale checkpoint unconditionally.
- Observed twice in production: ge-8ou (099e5df) and hq-mol-ojac (0eff556).

## Fix

Validate checkpoints against the current branch before trusting them:

- **`CheckpointPushed`**: the stored value IS the branch name — compare to current branch; discard if they differ.
- **`CheckpointMRCreated`**: look up the MR bead by ID and verify its `branch:` field matches current branch; discard if they differ.

Both discarded checkpoints fall through to the normal push/MR-creation paths, which already handle idempotency correctly (`RemoteBranchExists` + `FindMRForBranch`).

## Test plan

- [ ] Simulate: write stale `done-cp:pushed:old-branch:<ts>` and `done-cp:mr-created:<old-mr-id>:<ts>` labels on agent bead, then run `gt done` on a different branch — should NOT skip push/MR
- [ ] Verify: write matching checkpoint labels for current branch — should still resume correctly
- [ ] Regression: existing resume behavior unaffected when branch matches checkpoint

Fixes: ge-sbo