### PR TITLE
fix: gt done no longer blocks on infrastructure files in polecat worktrees

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1540,8 +1540,15 @@ func isGasTownRuntimePath(path string) bool {
 // CleanExcludingRuntime returns true if the only uncommitted changes are Gas Town
 // runtime artifacts (.beads/, .claude/, .runtime/, .logs/, __pycache__/).
 // Used by gt done to avoid blocking completion on toolchain-managed files.
+//
+// Note: UnpushedCommits is intentionally NOT checked here. This function only
+// evaluates whether uncommitted *file* changes are runtime artifacts. Unpushed
+// commits represent committed (but not yet pushed) work and are handled separately
+// by the CommitsAhead check in gt done. Including UnpushedCommits here caused
+// gt done to block when polecats committed their work and called gt done with
+// only infrastructure files untracked (gas-7vg).
 func (s *UncommittedWorkStatus) CleanExcludingRuntime() bool {
-	if s.StashCount > 0 || s.UnpushedCommits > 0 {
+	if s.StashCount > 0 {
 		return false
 	}
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1752,11 +1752,26 @@ func TestCleanExcludingRuntime(t *testing.T) {
 			want: false,
 		},
 		{
-			name: "unpushed commits block",
+			// Unpushed commits alone do not affect CleanExcludingRuntime — this
+			// function only evaluates uncommitted file changes. Unpushed commits
+			// are handled separately by the CommitsAhead check in gt done (gas-7vg).
+			name: "unpushed commits alone do not block",
 			s: UncommittedWorkStatus{
 				UnpushedCommits: 2,
 			},
-			want: false,
+			want: true,
+		},
+		{
+			// The primary bug scenario (gas-7vg): polecat commits work (1 unpushed
+			// commit) then calls gt done with only infrastructure files untracked.
+			// CleanExcludingRuntime must return true so gt done is not blocked.
+			name: "unpushed commit with only runtime artifacts",
+			s: UncommittedWorkStatus{
+				HasUncommittedChanges: true,
+				UnpushedCommits:       1,
+				UntrackedFiles:        []string{".beads/", ".claude/commands/done.md", ".runtime/state.json"},
+			},
+			want: true,
 		},
 		{
 			name: "pycache untracked",

--- a/internal/rig/overlay.go
+++ b/internal/rig/overlay.go
@@ -143,6 +143,20 @@ func EnsureGitignorePatterns(worktreePath string) error {
 	return nil
 }
 
+// gasTownLocalExcludePatterns returns the patterns to write to the worktree-local
+// .git/info/exclude file. This is a superset of gasTownIgnorePatterns() and
+// includes .beads/ — which is safe here because .git/info/exclude is per-worktree
+// and never committed to the repo (unlike .gitignore, where .beads/ must NOT appear
+// because Beads manages its own .beads/.gitignore via bd init).
+func gasTownLocalExcludePatterns() []string {
+	patterns := gasTownIgnorePatterns()
+	// .beads/ is excluded from gasTownIgnorePatterns() to avoid breaking bd sync
+	// (see EnsureGitignorePatterns comment). The local exclude file is safe to
+	// include it — it's per-worktree and invisible to `git status` without affecting
+	// the tracked .gitignore (gas-7vg defense-in-depth).
+	return append(patterns, ".beads/")
+}
+
 // EnsureLocalExcludePatterns writes the standard Gas Town ignore patterns to the
 // worktree-local git exclude file so the worktree stays clean without mutating a
 // tracked .gitignore.
@@ -164,7 +178,7 @@ func EnsureLocalExcludePatterns(worktreePath string) error {
 	}
 
 	var missing []string
-	for _, pattern := range gasTownIgnorePatterns() {
+	for _, pattern := range gasTownLocalExcludePatterns() {
 		found := false
 		for _, line := range strings.Split(existingContent, "\n") {
 			line = strings.TrimSpace(line)

--- a/internal/rig/overlay_test.go
+++ b/internal/rig/overlay_test.go
@@ -518,6 +518,31 @@ func TestEnsureGitignorePatterns_UpgradePreservesBroadPattern(t *testing.T) {
 	}
 }
 
+// TestGasTownLocalExcludePatterns_IncludesBeads verifies that the local exclude
+// patterns include .beads/ (defense-in-depth for gas-7vg) while the gitignore
+// patterns do NOT include .beads/ (regression guard).
+func TestGasTownLocalExcludePatterns_IncludesBeads(t *testing.T) {
+	localPatterns := gasTownLocalExcludePatterns()
+	found := false
+	for _, p := range localPatterns {
+		if p == ".beads/" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("gasTownLocalExcludePatterns() must include .beads/ (gas-7vg defense-in-depth)")
+	}
+
+	// Regression guard: .gitignore patterns must NOT include .beads/
+	gitignorePatterns := gasTownIgnorePatterns()
+	for _, p := range gitignorePatterns {
+		if p == ".beads/" {
+			t.Error("gasTownIgnorePatterns() must NOT include .beads/ - that breaks bd sync (see overlay.go)")
+		}
+	}
+}
+
 // Helper functions
 
 func containsLine(content, pattern string) bool {


### PR DESCRIPTION
## Summary
- `CleanExcludingRuntime()` no longer checks `UnpushedCommits` — unpushed commits are handled separately by the `CommitsAhead` check in `gt done`. This was the root cause of polecats being unable to call `gt done` after committing their work.
- `EnsureLocalExcludePatterns` now writes `.beads/` to `.git/info/exclude` (per-worktree, defense-in-depth)
- Both changes include regression tests

Fixes gas-7vg. Root cause of dirty-exit pattern across all rigs — polecats committed work, called `gt done`, but it refused due to untracked `.beads/`, `.runtime/`, `.claude/commands/` files.

## Test plan
- [ ] `go test ./internal/git/...` — CleanExcludingRuntime tests pass
- [ ] `go test ./internal/rig/...` — overlay tests pass
- [ ] Polecat can commit work + call `gt done` without being blocked by infra files

🤖 Generated with [Claude Code](https://claude.com/claude-code)