### PR TITLE
fix: remove calls to removed `bd agent state` command (gt-3hn3)

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -415,25 +415,16 @@ func (b *Beads) ResetAgentBeadForReuse(id, reason string) error {
 	return nil
 }
 
-// UpdateAgentState updates the agent_state field in an agent bead.
-// Uses `bd agent state` command for the database column directly,
-// then syncs the description's agent_state field to match (gt-ulom).
+// UpdateAgentState updates the agent_state field in an agent bead's description.
+// The description is the authoritative source for agent_state (gt-3hn3).
+// Previously used `bd agent state` to update a DB column directly, but that
+// command was removed in bd upstream refactor (0bd598ce). The column is no
+// longer maintained; reads should use description-parsed state instead.
 func (b *Beads) UpdateAgentState(id string, state string) (retErr error) {
 	defer func() { telemetry.RecordAgentStateChange(context.Background(), id, state, nil, retErr) }()
-	// Update agent state using bd agent state command
-	// Use runWithRouting so bd can resolve cross-prefix agent beads (e.g., wa-*
-	// agent beads from hq context) via routes.jsonl instead of BEADS_DIR.
-	_, err := b.runWithRouting("agent", "state", id, state)
-	if err != nil {
-		return fmt.Errorf("updating agent state: %w", err)
+	if err := b.UpdateAgentDescriptionFields(id, AgentFieldUpdates{AgentState: &state}); err != nil {
+		return fmt.Errorf("updating agent state in description: %w", err)
 	}
-
-	// Sync the description's agent_state field with the column (gt-ulom).
-	// Without this, the description stays stale (e.g., "spawning" after the
-	// column transitions to "working"), causing bd show and dashboards to
-	// display incorrect state after idle polecat reuse via gt sling.
-	_ = b.UpdateAgentDescriptionFields(id, AgentFieldUpdates{AgentState: &state})
-
 	return nil
 }
 
@@ -446,7 +437,7 @@ func (b *Beads) UpdateAgentState(id string, state string) (retErr error) {
 // This allows multiple fields to be updated in a single read-modify-write
 // cycle, avoiding races where concurrent callers overwrite each other's changes.
 type AgentFieldUpdates struct {
-	AgentState        *string // Sync description agent_state with column (gt-ulom)
+	AgentState        *string // Authoritative agent_state source (gt-3hn3, was gt-ulom)
 	CleanupStatus     *string
 	ActiveMR          *string
 	NotificationLevel *string
@@ -617,12 +608,9 @@ func (b *Beads) GetAgentBead(id string) (*Issue, *AgentFields, error) {
 	}
 
 	fields := ParseAgentFields(issue.Description)
-	// Prefer the structured agent_state column when present.
-	// Some writers (for example, `bd agent state`) update the DB column directly
-	// without rewriting the description text, so description-derived state can be stale.
-	if issue.AgentState != "" {
-		fields.AgentState = issue.AgentState
-	}
+	// Description is the authoritative source for agent_state (gt-3hn3).
+	// The agent_state column is no longer maintained since bd removed the
+	// `bd agent state` command (0bd598ce). Description-parsed state is used.
 	return issue, fields, nil
 }
 

--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -70,13 +70,17 @@ esac
 	t.Setenv("MOCK_BD_SHOW_OUTPUT", showOutput)
 }
 
-func TestGetAgentBead_PrefersStructuredAgentState(t *testing.T) {
+// TestGetAgentBead_PrefersDescriptionAgentState verifies that description-parsed
+// agent_state is authoritative over the database column (gt-3hn3).
+// The agent_state column is no longer maintained since bd removed `bd agent state`.
+func TestGetAgentBead_PrefersDescriptionAgentState(t *testing.T) {
 	tmpDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmpDir, ".beads"), 0755); err != nil {
 		t.Fatalf("mkdir .beads: %v", err)
 	}
 
-	installMockBDFixedShowOutput(t, `[{"id":"gt-gastown-polecat-nux","title":"Polecat nux","issue_type":"agent","labels":["gt:agent"],"description":"role_type: polecat\nrig: gastown\nagent_state: spawning\nhook_bead: null","agent_state":"idle"}]`)
+	// Description says "working" (truth), DB column says "spawning" (stale)
+	installMockBDFixedShowOutput(t, `[{"id":"gt-gastown-polecat-nux","title":"Polecat nux","issue_type":"agent","labels":["gt:agent"],"description":"role_type: polecat\nrig: gastown\nagent_state: working\nhook_bead: null","agent_state":"spawning"}]`)
 
 	bd := NewIsolated(tmpDir)
 	issue, fields, err := bd.GetAgentBead("gt-gastown-polecat-nux")
@@ -89,11 +93,13 @@ func TestGetAgentBead_PrefersStructuredAgentState(t *testing.T) {
 	if fields == nil {
 		t.Fatal("GetAgentBead returned nil fields")
 	}
-	if issue.AgentState != "idle" {
-		t.Fatalf("issue.AgentState = %q, want %q", issue.AgentState, "idle")
+	// Column still shows stale value
+	if issue.AgentState != "spawning" {
+		t.Fatalf("issue.AgentState = %q, want %q (raw column)", issue.AgentState, "spawning")
 	}
-	if fields.AgentState != "idle" {
-		t.Fatalf("fields.AgentState = %q, want %q", fields.AgentState, "idle")
+	// Fields should use description (authoritative), not column
+	if fields.AgentState != "working" {
+		t.Fatalf("fields.AgentState = %q, want %q (from description)", fields.AgentState, "working")
 	}
 }
 

--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -1164,15 +1164,16 @@ func sendMail(townRoot, to, subject, body string) {
 	_ = cmd.Run() // Best effort
 }
 
-// updateAgentBeadState updates an agent bead's state.
+// updateAgentBeadState updates an agent bead's state via label-based tracking.
+// Uses `bd set-state` which records an event bead and sets a dimension label (gt-3hn3).
+// Previously used `bd agent state` which was removed in bd upstream refactor (0bd598ce).
 func updateAgentBeadState(townRoot, agent, state, _ string) { // reason unused but kept for API consistency
 	beadID, _, err := agentAddressToIDs(agent)
 	if err != nil {
 		return
 	}
 
-	// Use bd agent state command
-	cmd := exec.Command("bd", "agent", "state", beadID, state)
+	cmd := exec.Command("bd", "set-state", beadID, "agent_state="+state) //nolint:gosec // trusted internal values
 	cmd.Dir = townRoot
 	_ = cmd.Run() // Best effort
 }

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -1467,7 +1467,7 @@ doneStateUpdate:
 	if exitType == ExitEscalated {
 		doneState = "stuck"
 	}
-	// Use UpdateAgentState to sync both column and description (gt-ulom).
+	// Update agent_state in description (gt-3hn3, was gt-ulom).
 	if err := bd.UpdateAgentState(agentBeadID, doneState); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: couldn't set agent %s to %s: %v\n", agentBeadID, doneState, err)
 	}

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -810,7 +810,7 @@ func (d *Daemon) getAgentBeadInfo(agentBeadID string) (*AgentBeadInfo, error) {
 		Description string   `json:"description"`
 		UpdatedAt   string   `json:"updated_at"`
 		HookBead    string   `json:"hook_bead"`   // Read from database column
-		AgentState  string   `json:"agent_state"` // Read from database column
+		AgentState  string   `json:"agent_state"` // Stale column — description is authoritative (gt-3hn3)
 	}
 
 	if err := json.Unmarshal(output, &issues); err != nil {
@@ -840,14 +840,14 @@ func (d *Daemon) getAgentBeadInfo(agentBeadID string) (*AgentBeadInfo, error) {
 		info.Rig = fields.Rig
 	}
 
-	// Use AgentState from database column directly (not from description).
-	// UpdateAgentState updates the DB column but not the description text,
-	// so the description can contain stale state (e.g., "spawning" after
-	// the polecat has transitioned to "working"). Fall back to description
-	// only if the DB column is empty (legacy beads).
-	info.State = issue.AgentState
-	if info.State == "" && fields != nil {
+	// Description is the authoritative source for agent_state (gt-3hn3).
+	// UpdateAgentState now updates the description, not the DB column
+	// (bd removed the `bd agent state` command in 0bd598ce).
+	// Fall back to DB column for beads not yet updated via description.
+	if fields != nil && fields.AgentState != "" {
 		info.State = fields.AgentState
+	} else {
+		info.State = issue.AgentState
 	}
 
 	// Use HookBead from database column directly (not from description)

--- a/internal/daemon/polecat_health_test.go
+++ b/internal/daemon/polecat_health_test.go
@@ -169,20 +169,19 @@ func TestCheckPolecatHealth_SpawningGuardExpires(t *testing.T) {
 	}
 }
 
-// TestCheckPolecatHealth_DBStateOverridesDescription verifies that the daemon
-// reads agent_state from the DB column (source of truth), not the description
-// text. UpdateAgentState updates the DB column but not the description, so a
-// polecat that transitioned from "spawning" to "working" will have stale
-// description text. The DB column must be authoritative.
-func TestCheckPolecatHealth_DBStateOverridesDescription(t *testing.T) {
+// TestCheckPolecatHealth_DescriptionOverridesDBState verifies that the daemon
+// reads agent_state from the description (source of truth), not the DB column.
+// UpdateAgentState updates the description (gt-3hn3); the DB column is no
+// longer maintained since bd removed `bd agent state` (0bd598ce).
+func TestCheckPolecatHealth_DescriptionOverridesDBState(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses Unix shell script mocks for tmux and bd")
 	}
 	binDir := t.TempDir()
 	writeFakeTestTmux(t, binDir)
 	recentTime := time.Now().UTC().Format(time.RFC3339)
-	// Description says "spawning" (stale) but DB column says "working" (truth)
-	bdPath := writeFakeTestBD(t, binDir, "spawning", "working", "gt-xyz", recentTime)
+	// Description says "working" (truth) but DB column says "spawning" (stale)
+	bdPath := writeFakeTestBD(t, binDir, "working", "spawning", "gt-xyz", recentTime)
 
 	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
@@ -197,13 +196,13 @@ func TestCheckPolecatHealth_DBStateOverridesDescription(t *testing.T) {
 	d.checkPolecatHealth("myr", "mycat")
 
 	got := logBuf.String()
-	// Should NOT skip due to spawning guard — DB says "working"
+	// Should NOT skip due to spawning guard — description says "working"
 	if strings.Contains(got, "Skipping restart") {
-		t.Errorf("daemon should use DB agent_state (working), not stale description (spawning), got: %q", got)
+		t.Errorf("daemon should use description agent_state (working), not stale DB column (spawning), got: %q", got)
 	}
-	// Should detect crash since DB says working + session is dead
+	// Should detect crash since description says working + session is dead
 	if !strings.Contains(got, "CRASH DETECTED") {
-		t.Errorf("expected CRASH DETECTED when DB state is 'working' with dead session, got: %q", got)
+		t.Errorf("expected CRASH DETECTED when description state is 'working' with dead session, got: %q", got)
 	}
 }
 

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1802,13 +1802,21 @@ func fetchAgentBeadSnapshot(bd *BdCli, workDir, agentBeadID string) *agentBeadSn
 		return nil
 	}
 
+	fields := beads.ParseAgentFields(issues[0].Description)
+	// Description is the authoritative source for agent_state (gt-3hn3).
+	// The agent_state column is no longer maintained since bd removed the
+	// `bd agent state` command (0bd598ce). Prefer description-parsed state.
+	agentState := fields.AgentState
+	if agentState == "" {
+		agentState = issues[0].AgentState // fallback to stale column for migration
+	}
 	return &agentBeadSnapshot{
-		AgentState: issues[0].AgentState,
+		AgentState: agentState,
 		HookBead:   issues[0].HookBead,
 		Labels:     issues[0].Labels,
 		UpdatedAt:  issues[0].UpdatedAt,
 		ActiveMR:   issues[0].ActiveMR,
-		Fields:     beads.ParseAgentFields(issues[0].Description),
+		Fields:     fields,
 	}
 }
 
@@ -1891,6 +1899,7 @@ func clearCompletionMetadata(bd *BdCli, workDir, agentBeadID string) error {
 
 // getAgentBeadState reads agent_state and hook_bead from an agent bead.
 // Returns the agent_state string and hook_bead ID.
+// Prefers description-parsed agent_state (gt-3hn3), falls back to column.
 func getAgentBeadState(bd *BdCli, workDir, agentBeadID string) (agentState, hookBead string) {
 	output, err := bd.Exec(workDir, "show", agentBeadID, "--json")
 	if err != nil || output == "" {
@@ -1899,14 +1908,20 @@ func getAgentBeadState(bd *BdCli, workDir, agentBeadID string) (agentState, hook
 
 	// Parse JSON response — bd show --json returns an array
 	var issues []struct {
-		AgentState string `json:"agent_state"`
-		HookBead   string `json:"hook_bead"`
+		AgentState  string `json:"agent_state"`
+		HookBead    string `json:"hook_bead"`
+		Description string `json:"description"`
 	}
 	if err := json.Unmarshal([]byte(output), &issues); err != nil || len(issues) == 0 {
 		return "", ""
 	}
 
-	return issues[0].AgentState, issues[0].HookBead
+	// Description is authoritative for agent_state (gt-3hn3).
+	state := issues[0].AgentState
+	if fields := beads.ParseAgentFields(issues[0].Description); fields.AgentState != "" {
+		state = fields.AgentState
+	}
+	return state, issues[0].HookBead
 }
 
 // getAgentBeadAge returns the time since the agent bead was last updated.


### PR DESCRIPTION
## Summary
- `bd agent state` was removed in bd upstream refactor (0bd598ce), but gt still called it causing 10-retry exponential backoff spam on every sling
- Makes the description field the authoritative source for `agent_state` instead of the stale DB column
- Deacon's `updateAgentBeadState` now uses `bd set-state` (label-based) for audit trail

## Changes
- **`internal/beads/beads_agent.go`**: `UpdateAgentState()` uses `UpdateAgentDescriptionFields` only; `GetAgentBead()` uses description-parsed state
- **`internal/cmd/deacon.go`**: Replace `bd agent state` with `bd set-state` (best-effort, label-based)
- **`internal/witness/handlers.go`**: `fetchAgentBeadSnapshot` and `getAgentBeadState` prefer description-parsed state with column fallback
- **`internal/daemon/lifecycle.go`**: `getAgentBeadInfo` prefers description-parsed state with column fallback
- **Tests**: Updated to match new description-authoritative semantics

## Test plan
- [x] `go build` passes (excluding unrelated gt-model-eval)
- [x] `go test ./internal/beads/` — all pass including updated agent state tests
- [x] `go test ./internal/witness/` — all pass
- [x] `go test ./internal/polecat/` — all pass
- [x] `go test ./internal/cmd/ -run TestDone` — all pass
- [ ] Verify no more retry spam in sling logs on live system

🤖 Generated with [Claude Code](https://claude.com/claude-code)