### PR TITLE
fix: resolve rig-scoped mayor/deacon to town-level address (gt-te23)

### DIFF
--- a/internal/mail/types.go
+++ b/internal/mail/types.go
@@ -564,10 +564,22 @@ func normalizeAddress(s string) string {
 		return "deacon/"
 	}
 
+	// Resolve rig-scoped town-level roles to their canonical form (gt-te23).
+	// "gastown/mayor" → "mayor/", "gastown/deacon" → "deacon/"
+	// Mayor and deacon are town-level singletons, not rig-level agents.
+	parts := strings.Split(s, "/")
+	if len(parts) == 2 {
+		switch parts[1] {
+		case "mayor":
+			return "mayor/"
+		case "deacon":
+			return "deacon/"
+		}
+	}
+
 	// Normalize crew/ and polecats/ to canonical form:
 	// "rig/crew/name" → "rig/name"
 	// "rig/polecats/name" → "rig/name"
-	parts := strings.Split(s, "/")
 	if len(parts) == 3 && (parts[1] == "crew" || parts[1] == "polecats") {
 		return parts[0] + "/" + parts[2]
 	}

--- a/internal/mail/types_test.go
+++ b/internal/mail/types_test.go
@@ -17,6 +17,12 @@ func TestAddressToIdentity(t *testing.T) {
 		{"deacon", "deacon/"},
 		{"deacon/", "deacon/"},
 
+		// Rig-scoped town-level roles resolve to canonical form (gt-te23)
+		{"gastown/mayor", "mayor/"},
+		{"gastown/deacon", "deacon/"},
+		{"laser/mayor", "mayor/"},
+		{"laser/deacon", "deacon/"},
+
 		// Rig-level agents: crew/ and polecats/ normalized to canonical form
 		{"gastown/polecats/Toast", "gastown/Toast"},
 		{"gastown/crew/max", "gastown/max"},


### PR DESCRIPTION
## Summary
- `gt mail send gastown/mayor` silently lost mail — bead created with assignee `gastown/mayor` but mayor inbox checks `mayor/`
- Fix: `normalizeAddress` now resolves `<rig>/mayor` → `mayor/` and `<rig>/deacon` → `deacon/` since these are town-level singletons
- Two mails from laser/crew/happy (hq-wisp-50yd2, hq-wisp-1be1q) were lost due to this bug

## Changes
- **`internal/mail/types.go`**: `normalizeAddress` resolves 2-part addresses where the second part is `mayor` or `deacon` to their town-level canonical form
- **`internal/mail/types_test.go`**: Added test cases for `gastown/mayor`, `gastown/deacon`, `laser/mayor`, `laser/deacon`

## Test plan
- [x] `go build` passes
- [x] `go test ./internal/mail/` — all pass including new address resolution tests
- [x] `TestAddressToIdentity` covers all new cases

🤖 Generated with [Claude Code](https://claude.com/claude-code)