### PR TITLE
fix: resolve pre-existing CI failures in lint and tests

### DIFF
--- a/internal/cmd/hooks_sync_test.go
+++ b/internal/cmd/hooks_sync_test.go
@@ -303,6 +303,16 @@ func TestRunHooksSyncNonClaudeAgent(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
+	// Put a dummy opencode binary on PATH so agent resolution doesn't fall back to claude.
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "opencode"), []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
 	townRoot := filepath.Join(tmpDir, "town")
 
 	// Scaffold workspace: mayor, deacon, and a rig with a crew worktree

--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -134,6 +134,8 @@ func TestBuildRefineryPatrolVars_FullConfig(t *testing.T) {
 		"run_tests":                           "true",
 		"target_branch":                       "main",
 		"delete_merged_branches":              "true",
+		"judgment_enabled":                    "false",
+		"review_depth":                        "standard",
 	}
 
 	varMap := make(map[string]string)

--- a/internal/doctor/hooks_sync_check_test.go
+++ b/internal/doctor/hooks_sync_check_test.go
@@ -16,6 +16,23 @@ func scaffoldWorkspace(t *testing.T, roleAgents map[string]string) string {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
 
+	// Put dummy binaries for non-Claude role agents on PATH so agent
+	// resolution doesn't fall back to claude when the binary is missing.
+	if len(roleAgents) > 0 {
+		binDir := filepath.Join(tmpDir, "bin")
+		if err := os.MkdirAll(binDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		for _, agent := range roleAgents {
+			if agent != "" && agent != "claude" {
+				if err := os.WriteFile(filepath.Join(binDir, agent), []byte("#!/bin/sh\n"), 0755); err != nil {
+					t.Fatal(err)
+				}
+			}
+		}
+		t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	}
+
 	townRoot := filepath.Join(tmpDir, "town")
 
 	// Required workspace structure

--- a/internal/hooks/installer.go
+++ b/internal/hooks/installer.go
@@ -157,6 +157,8 @@ func resolveAndSubstitute(provider, hooksFile, role string) ([]byte, error) {
 }
 
 // writeTemplate resolves a template, substitutes placeholders, and writes it to targetPath.
+//
+//nolint:unparam // hooksDir kept for API symmetry with InstallForRole
 func writeTemplate(provider, role, hooksDir, hooksFile, targetPath string) error {
 	content, err := resolveAndSubstitute(provider, hooksFile, role)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Add `nolint:unparam` to `writeTemplate` for unused `hooksDir` parameter
- Update `TestBuildRefineryPatrolVars_FullConfig` to expect `judgment_enabled` and `review_depth` vars
- Add dummy `opencode` binary to PATH in non-Claude agent tests so agent resolution doesn't fall back to claude
- Add dummy agent binaries to `scaffoldWorkspace` in doctor tests for template agent sync checks

These are pre-existing failures on main that block CI on all new PRs.

## Test plan
- [x] `TestBuildRefineryPatrolVars_FullConfig` passes
- [x] `TestRunHooksSyncNonClaudeAgent` passes
- [x] `TestHooksSyncCheck_TemplateAgent_OutOfSync` passes
- [x] `TestHooksSyncCheck_TemplateAgent_Missing` passes
- [x] `TestHooksSyncCheck_Fix_TemplateAgent` passes
- [x] `golangci-lint` clean on `internal/hooks/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)