### PR TITLE
fix(formula): resolve refinery agent bead ID dynamically

### DIFF
--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -880,10 +880,16 @@ End of patrol cycle decision. Use the signals from context-check to decide.
 
 **If you decide to continue patrolling:**
 
-Use await-event to subscribe to the refinery event channel with exponential backoff:
+Resolve your agent bead ID for this patrol cycle. You MUST replace `<YOUR_RIG>` below with your actual rig name (e.g., `beads`, `town`) before running:
+```bash
+bd list --type=agent --desc-contains="role_type: refinery" --json | jq -r '.[] | select(.status != "closed") | select(.description | test("(?m)^\\\\s*rig: <YOUR_RIG>\\\\s*$")) | .id'
+```
+This must return exactly one bead ID. If it returns zero results, STOP and report an error — verify you substituted `<YOUR_RIG>` correctly. If it returns multiple results, STOP and report an error — manual disambiguation is required. Use the single resolved bead ID as YOUR_AGENT_BEAD in the commands below.
+
+Then use await-event to subscribe to the refinery event channel with exponential backoff:
 
 ```bash
-gt mol step await-event --channel refinery --agent-bead gt-<rig>-refinery \
+gt mol step await-event --channel refinery --agent-bead YOUR_AGENT_BEAD \
   --backoff-base 30s --backoff-mult 2 --backoff-max 5m --cleanup
 ```
 

--- a/internal/formula/patrol_backoff_test.go
+++ b/internal/formula/patrol_backoff_test.go
@@ -172,6 +172,63 @@ func TestPatrolFormulasHaveWispGC(t *testing.T) {
 	}
 }
 
+// TestPatrolFormulasUseDynamicBeadResolution verifies that patrol formulas
+// resolve their agent bead ID dynamically at runtime via `bd list`, rather
+// than hardcoding a prefix like `gt-<rig>-refinery`.
+//
+// Hardcoded IDs break when AgentBeadIDWithPrefix collapses the rig component
+// (prefix == rig), producing e.g. "cp-refinery" instead of "gt-cp-refinery".
+//
+// Regression test for hq-9xs.
+func TestPatrolFormulasUseDynamicBeadResolution(t *testing.T) {
+	patrolFormulas := []string{
+		"mol-witness-patrol.formula.toml",
+		"mol-refinery-patrol.formula.toml",
+	}
+
+	for _, name := range patrolFormulas {
+		t.Run(name, func(t *testing.T) {
+			content, err := formulasFS.ReadFile("formulas/" + name)
+			if err != nil {
+				t.Fatalf("reading %s: %v", name, err)
+			}
+
+			f, err := Parse(content)
+			if err != nil {
+				t.Fatalf("parsing %s: %v", name, err)
+			}
+
+			// Find the loop/exit step
+			var loopDesc string
+			for _, step := range f.Steps {
+				if step.ID == "loop-or-exit" || step.ID == "burn-or-loop" {
+					loopDesc = step.Description
+					break
+				}
+			}
+			if loopDesc == "" {
+				t.Fatalf("%s: loop step not found or has empty description", name)
+			}
+
+			// Must use dynamic resolution via bd list
+			if !strings.Contains(loopDesc, "bd list --type=agent") {
+				t.Errorf("%s loop step missing dynamic agent bead resolution (bd list --type=agent).\n"+
+					"Agent bead IDs must be resolved at runtime, not hardcoded.\n"+
+					"See hq-9xs.",
+					name)
+			}
+
+			// Must NOT hardcode gt-<rig> prefix pattern
+			if strings.Contains(loopDesc, "gt-<rig>") {
+				t.Errorf("%s loop step hardcodes gt-<rig> prefix.\n"+
+					"This breaks when AgentBeadIDWithPrefix collapses the ID (prefix == rig).\n"+
+					"See hq-9xs.",
+					name)
+			}
+		})
+	}
+}
+
 // TestDeaconPatrolHasHeartbeatSteps verifies the deacon patrol formula
 // includes heartbeat refresh steps to prevent the daemon from killing a
 // healthy Deacon mid-cycle.


### PR DESCRIPTION
## Summary

The refinery patrol formula hardcodes the wrong agent bead ID, causing it to loop with "no issue found" errors after any DB reset/recovery. 

This PR updates the refinery patrol formula with dynamic resolution matching the witness pattern for finding the agent bead.

Note: I'm fairly new to Gas Town - the Claude-based reasoning on why the correct fix is to update the formula seems plausible to me but I'm happy to be corrected on this.  

## Details

After a Gas Town restart I noticed the Refinery looping with:
```
Could not read agent bead (starting at idle=0): Error fetching gt-foo-refinery: no issue found matching "gt-foo-refinery"
```

The root cause according to Claude is that the `burn-or-loop` step in `mol-refinery-patrol.formula.toml` hardcodes `gt-<rig>-refinery` as the agent bead ID. 

Two bugs compound:

1. The formula uses `gt` as the prefix, but non-gastown rigs use their own prefix (e.g. `foo` for Foobar)
2. `AgentBeadIDWithPrefix()` in `agent_ids.go` collapses the ID when prefix == rig — so for rig `foo` with prefix `foo`, the actual bead ID is `foo-refinery`, not `gt-foo-refinery`

The witness formula already handles this correctly by resolving its agent bead ID dynamically at runtime via `bd list --type=agent`.

The fix was to replace the hardcoded ID with the same `bd list` dynamic resolution pattern used by the witness. Also added a regression test (`TestPatrolFormulasUseDynamicBeadResolution`) to prevent re-hardcoding.

## Verification

After restarting Gas Town with this fix the Refinery was able to find its agent bead and enter normal patrol on non-`gt`-prefixed rigs.