### PR TITLE
fix: start nudge-queue poller for all agents, including Claude

### DIFF
--- a/internal/crew/manager.go
+++ b/internal/crew/manager.go
@@ -878,14 +878,16 @@ func (m *Manager) Start(name string, opts StartOptions) error {
 			_ = t.AcceptStartupDialogs(sessionID)
 		}
 
-		// Start background nudge-queue poller for agents that lack turn-boundary
-		// drain hooks (e.g., Gemini, Codex). Claude drains its queue via
-		// UserPromptSubmit hook so it doesn't need the poller.
-		if preset != nil && !preset.HasTurnBoundaryDrain {
-			if _, pollerErr := nudge.StartPoller(townRoot, sessionID); pollerErr != nil {
-				// Non-fatal — nudges may be delayed but the agent still works.
-				style.PrintWarning("could not start nudge poller for %s: %v", name, pollerErr)
-			}
+		// Start background nudge-queue poller for ALL agents (gt-dgf).
+		// Claude drains its queue via UserPromptSubmit hook, but that hook only
+		// fires when the agent submits a prompt. Idle agents (waiting at prompt
+		// for work) never submit, so queued nudges deadlock: agent waits for
+		// nudge, nudge waits for agent input. The poller breaks this cycle by
+		// polling every 10s and delivering when idle. Drain() is atomic so the
+		// poller and UserPromptSubmit hook coexist safely.
+		if _, pollerErr := nudge.StartPoller(townRoot, sessionID); pollerErr != nil {
+			// Non-fatal — nudges may be delayed but the agent still works.
+			style.PrintWarning("could not start nudge poller for %s: %v", name, pollerErr)
 		}
 	}
 

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -18,6 +18,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/session"
@@ -237,6 +238,13 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 		// Kill the zombie session before returning error
 		_ = t.KillSessionWithProcesses(sessionID)
 		return fmt.Errorf("waiting for refinery to start: %w", err)
+	}
+
+	// Start nudge-queue poller (gt-dgf). Claude's UserPromptSubmit hook only
+	// drains when the agent submits a prompt. Idle agents never submit, so
+	// queued nudges deadlock. The poller breaks the cycle by polling every 10s.
+	if _, pollerErr := nudge.StartPoller(townRoot, sessionID); pollerErr != nil {
+		log.Printf("warning: could not start nudge poller for %s: %v", sessionID, pollerErr)
 	}
 
 	_ = runtime.RunStartupFallback(t, sessionID, "refinery", runtimeConfig)

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/session"
@@ -244,6 +245,13 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	// Track PID for defense-in-depth orphan cleanup (non-fatal)
 	if err := session.TrackSessionPID(townRoot, sessionID, t); err != nil {
 		log.Printf("warning: tracking session PID for %s: %v", sessionID, err)
+	}
+
+	// Start nudge-queue poller (gt-dgf). Claude's UserPromptSubmit hook only
+	// drains when the agent submits a prompt. Idle agents never submit, so
+	// queued nudges deadlock. The poller breaks the cycle by polling every 10s.
+	if _, pollerErr := nudge.StartPoller(townRoot, sessionID); pollerErr != nil {
+		log.Printf("warning: could not start nudge poller for %s: %v", sessionID, pollerErr)
 	}
 
 	_ = runtime.RunStartupFallback(t, sessionID, "witness", runtimeConfig)


### PR DESCRIPTION
## Summary
- Nudge queue poller was only started for non-Claude agents
- Claude agents in crew/witness/refinery roles never drained their nudge queue
- Queued nudges (from xtm-notify, cross-agent coordination) piled up undelivered
- Fix: start the poller unconditionally for all agent types

## Test plan
- [x] `go test ./internal/crew/ ./internal/witness/ ./internal/refinery/` — all pass
- [x] `go build ./cmd/gt` — builds clean
- [x] Deployed locally, verified nudge delivery to idle Claude crew sessions

Fixes: gt-dgf

🤖 Generated with [Claude Code](https://claude.com/claude-code)