### PR TITLE
fix: refresh agents/feed bindings when rig prefix pattern is stale

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3362,11 +3362,13 @@ func (t *Tmux) SetCycleBindings(session string) error {
 // See: https://github.com/steveyegge/gastown/issues/13
 // See: https://github.com/steveyegge/gastown/issues/1548
 func (t *Tmux) SetFeedBinding(session string) error {
-	// Skip if already configured — preserves user's original fallback from first call
-	if t.isGTBinding("prefix", "a") {
+	pattern := sessionPrefixPattern()
+	// Skip if already configured with the current rig prefix pattern.
+	// Must re-bind if the pattern is stale (e.g., after gt rig add adds a new prefix).
+	if t.isGTBinding("prefix", "a") && t.isGTBindingCurrent("prefix", "a", pattern) {
 		return nil
 	}
-	ifShell := fmt.Sprintf("echo '#{session_name}' | grep -Eq '%s'", sessionPrefixPattern())
+	ifShell := fmt.Sprintf("echo '#{session_name}' | grep -Eq '%s'", pattern)
 	fallback := t.getKeyBinding("prefix", "a")
 	if fallback == "" {
 		// No prior binding — do nothing in non-GT sessions
@@ -3388,11 +3390,13 @@ func (t *Tmux) SetFeedBinding(session string) error {
 // press is silently ignored.
 // See: https://github.com/steveyegge/gastown/issues/1548
 func (t *Tmux) SetAgentsBinding(session string) error {
-	// Skip if already configured — preserves user's original fallback from first call
-	if t.isGTBinding("prefix", "g") {
+	pattern := sessionPrefixPattern()
+	// Skip if already configured with the current rig prefix pattern.
+	// Must re-bind if the pattern is stale (e.g., after gt rig add adds a new prefix).
+	if t.isGTBinding("prefix", "g") && t.isGTBindingCurrent("prefix", "g", pattern) {
 		return nil
 	}
-	ifShell := fmt.Sprintf("echo '#{session_name}' | grep -Eq '%s'", sessionPrefixPattern())
+	ifShell := fmt.Sprintf("echo '#{session_name}' | grep -Eq '%s'", pattern)
 	fallback := t.getKeyBinding("prefix", "g")
 	if fallback == "" {
 		// No prior binding — do nothing in non-GT sessions


### PR DESCRIPTION
## Problem

`SetAgentsBinding` and `SetFeedBinding` only checked `isGTBinding` (is there already a GT binding → skip), never whether the binding's pattern was stale. After adding a new rig (e.g. `qc` for qcore), the `C-b g` and `C-b a` bindings still held the old `^(gt|hq)-` pattern, so sessions like `qc-crew-mallory` fell through to the `:` fallback.

`SetCycleBindings` already had this check via `isGTBindingCurrent` — this fix applies the same pattern to the agents and feed bindings.

## Fix

Skip binding setup only if BOTH `isGTBinding` (it's a GT binding) AND `isGTBindingCurrent` (the pattern matches current rig prefixes) pass. On mismatch, force-refresh the binding with the full current prefix set.

## Testing

Existing `TestIsGTBindingCurrent_DetectsStalePattern` and `TestSetCycleBindings_RefreshesStalePattern` pass. The fix applies the same guard pattern already validated by those tests.

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>