### PR TITLE
feat(convoy): create integration branch on batch-pr launch

### DIFF
--- a/internal/cmd/convoy_launch.go
+++ b/internal/cmd/convoy_launch.go
@@ -4,10 +4,15 @@ import (
 	"bytes"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
 
@@ -292,12 +297,12 @@ func runConvoyLaunch(cmd *cobra.Command, args []string) error {
 			}
 
 			// Rebuild DAG from tracked beads and dispatch Wave 1.
-			beads, deps, err := collectConvoyBeads(convoyID)
+			trackedBeads, deps, err := collectConvoyBeads(convoyID)
 			if err != nil {
 				return fmt.Errorf("collect beads for dispatch: %w", err)
 			}
 
-			dag := buildConvoyDAG(beads, deps)
+			dag := buildConvoyDAG(trackedBeads, deps)
 			waves, _, err := computeWaves(dag)
 			if err != nil {
 				return fmt.Errorf("compute waves for dispatch: %w", err)
@@ -306,6 +311,14 @@ func runConvoyLaunch(cmd *cobra.Command, args []string) error {
 			townRoot, err := workspace.FindFromCwdOrError()
 			if err != nil {
 				return fmt.Errorf("resolve town root for dispatch: %w", err)
+			}
+
+			// For batch-pr convoys, create integration branch before dispatch.
+			merge := convoyMergeFromFields(result.Description)
+			if merge == "batch-pr" {
+				if err := createBatchPRIntegrationBranch(convoyID, result.Description, dag, townRoot); err != nil {
+					return fmt.Errorf("create integration branch: %w", err)
+				}
 			}
 
 			// Check for parked/docked rigs before dispatch (gt-4owfd.1, #2120)
@@ -329,4 +342,109 @@ func runConvoyLaunch(cmd *cobra.Command, args []string) error {
 	convoyStageLaunch = true
 	defer func() { convoyStageLaunch = false }()
 	return runConvoyStage(cmd, args)
+}
+
+// createBatchPRIntegrationBranch creates an integration branch for a batch-pr convoy.
+// The branch is created on the primary rig (most common rig among slingable nodes)
+// from the rig's default branch (or the convoy's base_branch if set).
+// The branch name is stored on the convoy bead's description for downstream consumption.
+func createBatchPRIntegrationBranch(convoyID, convoyDesc string, dag *ConvoyDAG, townRoot string) error {
+	// 1. Determine primary rig from DAG.
+	primaryRigName := primaryRigFromDAG(dag)
+	if primaryRigName == "" {
+		return fmt.Errorf("convoy %s: no rig found in DAG for integration branch", convoyID)
+	}
+
+	// 2. Load the rig.
+	rigsConfigPath := filepath.Join(townRoot, "mayor", "rigs.json")
+	rigsConfig, err := config.LoadRigsConfig(rigsConfigPath)
+	if err != nil {
+		return fmt.Errorf("load rigs config: %w", err)
+	}
+	rigMgr := rig.NewManager(townRoot, rigsConfig, git.NewGit(townRoot))
+	r, err := rigMgr.GetRig(primaryRigName)
+	if err != nil {
+		return fmt.Errorf("rig %q not found: %w", primaryRigName, err)
+	}
+
+	// 3. Determine base branch from convoy fields or rig default.
+	convoyFields := beads.ParseConvoyFields(&beads.Issue{Description: convoyDesc})
+	baseBranch := r.DefaultBranch()
+	if convoyFields != nil && convoyFields.BaseBranch != "" {
+		baseBranch = convoyFields.BaseBranch
+	}
+
+	// 4. Determine integration branch name: convoy/<convoy-id>.
+	branchName := "convoy/" + convoyID
+
+	// 5. Get git client for the rig and create the branch.
+	g, err := getRigGit(r.Path)
+	if err != nil {
+		return fmt.Errorf("initializing git for rig %s: %w", primaryRigName, err)
+	}
+
+	fmt.Printf("Creating integration branch %s from %s on rig %s...\n", branchName, baseBranch, primaryRigName)
+
+	if err := g.Fetch("origin"); err != nil {
+		return fmt.Errorf("fetching from origin: %w", err)
+	}
+
+	if err := g.CreateBranchFrom(branchName, "origin/"+baseBranch); err != nil {
+		return fmt.Errorf("creating branch %s: %w", branchName, err)
+	}
+
+	if err := g.Push("origin", branchName, false); err != nil {
+		// Clean up local branch on push failure.
+		_ = g.DeleteBranch(branchName, true)
+		return fmt.Errorf("pushing branch %s to origin: %w", branchName, err)
+	}
+
+	// 6. Store integration branch name on convoy bead.
+	newDesc := beads.AddIntegrationBranchField(convoyDesc, branchName)
+	if err := bdUpdateConvoyDescription(convoyID, newDesc); err != nil {
+		// Non-fatal: branch was created, just metadata update failed.
+		fmt.Printf("  (warning: could not store integration branch on convoy: %v)\n", err)
+	}
+
+	fmt.Printf("  ✓ Integration branch: %s (rig: %s, base: %s)\n", branchName, primaryRigName, baseBranch)
+	return nil
+}
+
+// primaryRigFromDAG returns the most common rig name among slingable nodes in the DAG.
+// Returns empty string if no slingable nodes have a rig assignment.
+func primaryRigFromDAG(dag *ConvoyDAG) string {
+	rigCount := make(map[string]int)
+	for _, node := range dag.Nodes {
+		if !isSlingableType(node.Type) {
+			continue
+		}
+		if node.Rig != "" {
+			rigCount[node.Rig]++
+		}
+	}
+
+	var primaryRig string
+	maxCount := 0
+	for rigName, count := range rigCount {
+		if count > maxCount {
+			maxCount = count
+			primaryRig = rigName
+		}
+	}
+	return primaryRig
+}
+
+// bdUpdateConvoyDescription updates a convoy bead's description.
+// Convoys live in the town HQ beads database.
+func bdUpdateConvoyDescription(convoyID, description string) error {
+	townBeads, err := getTownBeadsDir()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command("bd", "update", convoyID, "--description="+description)
+	cmd.Dir = townBeads
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("bd update %s --description: %w\noutput: %s", convoyID, err, out)
+	}
+	return nil
 }

--- a/internal/cmd/convoy_launch_test.go
+++ b/internal/cmd/convoy_launch_test.go
@@ -798,3 +798,70 @@ esac
 		t.Fatalf("expected no deps for tracked beads, got %d", len(deps))
 	}
 }
+
+// ---------------------------------------------------------------------------
+// primaryRigFromDAG tests
+// ---------------------------------------------------------------------------
+
+func TestPrimaryRigFromDAG_SingleRig(t *testing.T) {
+	t.Parallel()
+	dag := &ConvoyDAG{Nodes: map[string]*ConvoyDAGNode{
+		"a": {ID: "a", Type: "task", Rig: "gastown"},
+		"b": {ID: "b", Type: "task", Rig: "gastown"},
+	}}
+
+	got := primaryRigFromDAG(dag)
+	if got != "gastown" {
+		t.Errorf("primaryRigFromDAG = %q, want %q", got, "gastown")
+	}
+}
+
+func TestPrimaryRigFromDAG_MajorityWins(t *testing.T) {
+	t.Parallel()
+	dag := &ConvoyDAG{Nodes: map[string]*ConvoyDAGNode{
+		"a": {ID: "a", Type: "task", Rig: "gastown"},
+		"b": {ID: "b", Type: "task", Rig: "gastown"},
+		"c": {ID: "c", Type: "task", Rig: "beads"},
+	}}
+
+	got := primaryRigFromDAG(dag)
+	if got != "gastown" {
+		t.Errorf("primaryRigFromDAG = %q, want %q", got, "gastown")
+	}
+}
+
+func TestPrimaryRigFromDAG_SkipsNonSlingable(t *testing.T) {
+	t.Parallel()
+	dag := &ConvoyDAG{Nodes: map[string]*ConvoyDAGNode{
+		"a":    {ID: "a", Type: "task", Rig: "beads"},
+		"epic": {ID: "epic", Type: "epic", Rig: "gastown"},
+	}}
+
+	// Epic is not slingable, so only "beads" counts.
+	got := primaryRigFromDAG(dag)
+	if got != "beads" {
+		t.Errorf("primaryRigFromDAG = %q, want %q", got, "beads")
+	}
+}
+
+func TestPrimaryRigFromDAG_NoNodes(t *testing.T) {
+	t.Parallel()
+	dag := &ConvoyDAG{Nodes: map[string]*ConvoyDAGNode{}}
+
+	got := primaryRigFromDAG(dag)
+	if got != "" {
+		t.Errorf("primaryRigFromDAG = %q, want empty", got)
+	}
+}
+
+func TestPrimaryRigFromDAG_NoRigAssigned(t *testing.T) {
+	t.Parallel()
+	dag := &ConvoyDAG{Nodes: map[string]*ConvoyDAGNode{
+		"a": {ID: "a", Type: "task", Rig: ""},
+	}}
+
+	got := primaryRigFromDAG(dag)
+	if got != "" {
+		t.Errorf("primaryRigFromDAG = %q, want empty", got)
+	}
+}

--- a/internal/cmd/convoy_stage.go
+++ b/internal/cmd/convoy_stage.go
@@ -45,9 +45,9 @@ func init() {
 
 // StageResult is the top-level JSON output for gt convoy stage --json.
 type StageResult struct {
-	Status           string          `json:"status"`              // "staged_ready", "staged_warnings", or "error"
-	ConvoyID         string          `json:"convoy_id"`           // empty if errors prevented creation
-	Restaged         bool            `json:"restaged"`            // true if an existing convoy was updated in place
+	Status           string          `json:"status"`                       // "staged_ready", "staged_warnings", or "error"
+	ConvoyID         string          `json:"convoy_id"`                    // empty if errors prevented creation
+	Restaged         bool            `json:"restaged"`                     // true if an existing convoy was updated in place
 	ValidationBeadID string          `json:"validation_bead_id,omitempty"` // capstone validation bead (epic input only)
 	Errors           []FindingJSON   `json:"errors"`
 	Warnings         []FindingJSON   `json:"warnings"`
@@ -1417,10 +1417,11 @@ func buildGatedJSON(gated []GatedTask, dag *ConvoyDAG) []GatedTaskJSON {
 
 // bdShowResult matches the JSON output of `bd show <id> --json`.
 type bdShowResult struct {
-	ID        string `json:"id"`
-	Title     string `json:"title"`
-	Status    string `json:"status"`
-	IssueType string `json:"issue_type"`
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Status      string `json:"status"`
+	IssueType   string `json:"issue_type"`
+	Description string `json:"description"`
 }
 
 // bdDepResult matches the JSON output of `bd dep list <id> --json`.


### PR DESCRIPTION
## Summary
- When a convoy has `merge=batch-pr`, creates an integration branch (`convoy/<convoy-id>`) before dispatching Wave 1
- Branch is created on the primary rig (most common rig among slingable DAG nodes) from the convoy's `base_branch` or the rig's default branch
- Follows the established pattern from `runMqIntegrationCreate`: fetch → create → push → store on bead

## Bead
gt-3ya — Create integration branch on batch-pr convoy launch

## Test plan
- [x] 5 unit tests for `primaryRigFromDAG` (single rig, majority wins, skips non-slingable, empty DAG, no rig assigned)
- [ ] Manual: stage a convoy with `merge:batch-pr` field and run `gt convoy launch` — verify branch created and pushed
- [ ] Verify non-batch-pr convoys remain unaffected (no integration branch created)

🤖 Generated with [Claude Code](https://claude.com/claude-code)