### PR TITLE
fix: MeasureQueryLatency uses config host instead of hardcoded 127.0.0.1

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -3414,7 +3414,7 @@ func doltSQLWithRecovery(townRoot, rigDB, query string) error {
 func MeasureQueryLatency(townRoot string) (time.Duration, error) {
 	config := DefaultConfig(townRoot)
 
-	dsn := fmt.Sprintf("%s@tcp(127.0.0.1:%d)/", config.User, config.Port)
+	dsn := fmt.Sprintf("%s@tcp(%s:%d)/", config.User, config.EffectiveHost(), config.Port)
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		return 0, fmt.Errorf("opening mysql connection: %w", err)


### PR DESCRIPTION
## Summary

`MeasureQueryLatency` hardcodes `127.0.0.1` in its DSN instead of using `config.EffectiveHost()`. When the Dolt server runs on a remote host (configured via `GT_DOLT_HOST` or `config.yaml`), health checks always fail with "connection refused" while all other Dolt operations connect correctly.

One-line fix: use `config.EffectiveHost()` consistent with every other connection in the file.

## Change

```diff
-	dsn := fmt.Sprintf("%s@tcp(127.0.0.1:%d)/", config.User, config.Port)
+	dsn := fmt.Sprintf("%s@tcp(%s:%d)/", config.User, config.EffectiveHost(), config.Port)
```

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/doltserver/...` passes
- Verified manually: `gt health` now reports correct latency when Dolt runs on a remote LXC container