### PR TITLE
fix(beads): support bd 0.62 agent state flow

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -553,6 +554,7 @@ func (b *Beads) buildRunEnv() []string {
 		return env
 	}
 	env := stripEnvPrefixes(os.Environ(), "BEADS_DIR=")
+	env = overrideDoltEnvFromBeadsDir(env, b.getResolvedBeadsDir())
 	return translateDoltPort(env)
 }
 
@@ -569,6 +571,7 @@ func (b *Beads) buildRoutingEnv() []string {
 		return env
 	}
 	env := stripEnvPrefixes(os.Environ(), "BEADS_DIR=")
+	env = overrideDoltEnvFromBeadsDir(env, b.getResolvedBeadsDir())
 	return translateDoltPort(env)
 }
 
@@ -633,6 +636,55 @@ func translateDoltPort(env []string) []string {
 		env = append(env, "BEADS_DOLT_SERVER_HOST="+gtHost)
 	}
 	return env
+}
+
+// overrideDoltEnvFromBeadsDir replaces inherited BEADS_DOLT_* values with the
+// authoritative connection data for the selected beads directory when present.
+// This prevents a parent shell's stale Dolt port from routing bd commands to
+// the wrong server when the command explicitly targets another rig's .beads dir.
+func overrideDoltEnvFromBeadsDir(env []string, beadsDir string) []string {
+	port, host := doltConnectionFromBeadsDir(beadsDir)
+	if port != "" {
+		env = stripEnvPrefixes(env, "BEADS_DOLT_PORT=")
+		env = append(env, "BEADS_DOLT_PORT="+port)
+	}
+	if host != "" {
+		env = stripEnvPrefixes(env, "BEADS_DOLT_SERVER_HOST=")
+		env = append(env, "BEADS_DOLT_SERVER_HOST="+host)
+	}
+	return env
+}
+
+// doltConnectionFromBeadsDir reads the preferred Dolt connection info for a
+// beads directory. The per-directory port file is authoritative when present;
+// metadata.json is used as a fallback and to supply the server host.
+func doltConnectionFromBeadsDir(beadsDir string) (port string, host string) {
+	if beadsDir == "" {
+		return "", ""
+	}
+
+	if data, err := os.ReadFile(filepath.Join(beadsDir, "dolt-server.port")); err == nil {
+		port = strings.TrimSpace(string(data))
+	}
+
+	data, err := os.ReadFile(filepath.Join(beadsDir, "metadata.json"))
+	if err != nil {
+		return port, ""
+	}
+
+	var meta struct {
+		DoltServerPort int    `json:"dolt_server_port"`
+		DoltServerHost string `json:"dolt_server_host"`
+	}
+	if err := json.Unmarshal(data, &meta); err != nil {
+		return port, ""
+	}
+
+	if port == "" && meta.DoltServerPort > 0 {
+		port = strconv.Itoa(meta.DoltServerPort)
+	}
+	host = strings.TrimSpace(meta.DoltServerHost)
+	return port, host
 }
 
 // stripEnvPrefixes removes entries matching any of the given prefixes from an

--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -416,25 +416,12 @@ func (b *Beads) ResetAgentBeadForReuse(id, reason string) error {
 }
 
 // UpdateAgentState updates the agent_state field in an agent bead.
-// Uses `bd agent state` command for the database column directly,
-// then syncs the description's agent_state field to match (gt-ulom).
+// bd >= 0.62.0 no longer provides a supported `bd agent state` writer, so
+// Gastown writes agent_state through the description field and readers mirror
+// that contract with fallback to the legacy structured column.
 func (b *Beads) UpdateAgentState(id string, state string) (retErr error) {
 	defer func() { telemetry.RecordAgentStateChange(context.Background(), id, state, nil, retErr) }()
-	// Update agent state using bd agent state command
-	// Use runWithRouting so bd can resolve cross-prefix agent beads (e.g., wa-*
-	// agent beads from hq context) via routes.jsonl instead of BEADS_DIR.
-	_, err := b.runWithRouting("agent", "state", id, state)
-	if err != nil {
-		return fmt.Errorf("updating agent state: %w", err)
-	}
-
-	// Sync the description's agent_state field with the column (gt-ulom).
-	// Without this, the description stays stale (e.g., "spawning" after the
-	// column transitions to "working"), causing bd show and dashboards to
-	// display incorrect state after idle polecat reuse via gt sling.
-	_ = b.UpdateAgentDescriptionFields(id, AgentFieldUpdates{AgentState: &state})
-
-	return nil
+	return b.UpdateAgentDescriptionFields(id, AgentFieldUpdates{AgentState: &state})
 }
 
 // SetHookBead and ClearHookBead removed (hq-l6mm5).
@@ -617,12 +604,7 @@ func (b *Beads) GetAgentBead(id string) (*Issue, *AgentFields, error) {
 	}
 
 	fields := ParseAgentFields(issue.Description)
-	// Prefer the structured agent_state column when present.
-	// Some writers (for example, `bd agent state`) update the DB column directly
-	// without rewriting the description text, so description-derived state can be stale.
-	if issue.AgentState != "" {
-		fields.AgentState = issue.AgentState
-	}
+	fields.AgentState = ResolveAgentState(issue.Description, issue.AgentState)
 	return issue, fields, nil
 }
 

--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -70,7 +71,51 @@ esac
 	t.Setenv("MOCK_BD_SHOW_OUTPUT", showOutput)
 }
 
-func TestGetAgentBead_PrefersStructuredAgentState(t *testing.T) {
+func installMockBDShowRecorder(t *testing.T, showOutput string) string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "bd.log")
+
+	script := `#!/bin/sh
+LOG_FILE='` + logPath + `'
+printf '%s\n' "$*" >> "$LOG_FILE"
+
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+
+case "$cmd" in
+  version)
+    exit 0
+    ;;
+  show)
+    printf '%s\n' "$MOCK_BD_SHOW_OUTPUT"
+    exit 0
+    ;;
+  update)
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	scriptPath := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write mock bd: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("MOCK_BD_SHOW_OUTPUT", showOutput)
+	return logPath
+}
+
+func TestGetAgentBead_PrefersDescriptionAgentState(t *testing.T) {
 	tmpDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmpDir, ".beads"), 0755); err != nil {
 		t.Fatalf("mkdir .beads: %v", err)
@@ -92,8 +137,8 @@ func TestGetAgentBead_PrefersStructuredAgentState(t *testing.T) {
 	if issue.AgentState != "idle" {
 		t.Fatalf("issue.AgentState = %q, want %q", issue.AgentState, "idle")
 	}
-	if fields.AgentState != "idle" {
-		t.Fatalf("fields.AgentState = %q, want %q", fields.AgentState, "idle")
+	if fields.AgentState != "spawning" {
+		t.Fatalf("fields.AgentState = %q, want %q", fields.AgentState, "spawning")
 	}
 }
 
@@ -115,6 +160,31 @@ func TestGetAgentBead_FallsBackToDescriptionAgentState(t *testing.T) {
 	}
 	if fields.AgentState != "spawning" {
 		t.Fatalf("fields.AgentState = %q, want %q", fields.AgentState, "spawning")
+	}
+}
+
+func TestUpdateAgentState_UsesUpdateDescriptionPath(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	logPath := installMockBDShowRecorder(t, `[{"id":"gt-gastown-polecat-nux","title":"Polecat nux","issue_type":"agent","labels":["gt:agent"],"description":"role_type: polecat\nrig: gastown\nagent_state: spawning\nhook_bead: null"}]`)
+	bd := NewIsolated(tmpDir)
+
+	if err := bd.UpdateAgentState("gt-gastown-polecat-nux", "working"); err != nil {
+		t.Fatalf("UpdateAgentState: %v", err)
+	}
+
+	logOutput := readMockBDLog(t, logPath)
+	if !strings.Contains(logOutput, "show gt-gastown-polecat-nux --json") {
+		t.Fatalf("mock bd log %q missing show call", logOutput)
+	}
+	if !strings.Contains(logOutput, "update gt-gastown-polecat-nux") {
+		t.Fatalf("mock bd log %q missing update call", logOutput)
+	}
+	if strings.Contains(logOutput, "agent state") {
+		t.Fatalf("mock bd log %q unexpectedly used obsolete bd agent state path", logOutput)
 	}
 }
 

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -3024,6 +3024,34 @@ func TestBuildRunEnv(t *testing.T) {
 	}
 }
 
+func TestBuildRunEnv_OverridesStaleDoltPortFromBeadsDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "dolt-server.port"), []byte("43113\n"), 0644); err != nil {
+		t.Fatalf("write dolt-server.port: %v", err)
+	}
+
+	t.Setenv("BEADS_DOLT_PORT", "3307")
+
+	env := (&Beads{workDir: tmpDir}).buildRunEnv()
+
+	found := false
+	for _, e := range env {
+		switch e {
+		case "BEADS_DOLT_PORT=43113":
+			found = true
+		case "BEADS_DOLT_PORT=3307":
+			t.Fatalf("stale BEADS_DOLT_PORT preserved in env: %v", env)
+		}
+	}
+	if !found {
+		t.Fatalf("expected BEADS_DOLT_PORT=43113 in env, got %v", env)
+	}
+}
+
 // TestBuildRoutingEnv verifies buildRoutingEnv() returns the correct environment
 // for each mode: default (strip BEADS_DIR only) and isolated (strip all beads vars).
 func TestBuildRoutingEnv(t *testing.T) {
@@ -3076,6 +3104,34 @@ func TestBuildRoutingEnv(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestBuildRoutingEnv_OverridesStaleDoltPortFromBeadsDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "dolt-server.port"), []byte("43113\n"), 0644); err != nil {
+		t.Fatalf("write dolt-server.port: %v", err)
+	}
+
+	t.Setenv("BEADS_DOLT_PORT", "3307")
+
+	env := (&Beads{workDir: tmpDir}).buildRoutingEnv()
+
+	found := false
+	for _, e := range env {
+		switch e {
+		case "BEADS_DOLT_PORT=43113":
+			found = true
+		case "BEADS_DOLT_PORT=3307":
+			t.Fatalf("stale BEADS_DOLT_PORT preserved in env: %v", env)
+		}
+	}
+	if !found {
+		t.Fatalf("expected BEADS_DOLT_PORT=43113 in env, got %v", env)
 	}
 }
 

--- a/internal/beads/status.go
+++ b/internal/beads/status.go
@@ -23,6 +23,18 @@ const (
 	AgentStateAwaitingGate AgentState = "awaiting-gate"
 )
 
+// ResolveAgentState returns the agent state Gastown should act on.
+// bd >= 0.62.0 no longer exposes a supported `bd agent state` writer, so the
+// description's `agent_state:` field is the primary write/read contract.
+// Fall back to the structured column only for legacy beads that do not yet
+// mirror agent_state into the description.
+func ResolveAgentState(description, structured string) string {
+	if fields := ParseAgentFields(description); fields != nil && fields.AgentState != "" {
+		return fields.AgentState
+	}
+	return structured
+}
+
 // ProtectsFromCleanup returns true if this agent state indicates an intentional
 // pause that should prevent the polecat from being cleaned up as stale.
 // States like "stuck" and "awaiting-gate" mean the polecat is paused on purpose.

--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -1171,10 +1171,7 @@ func updateAgentBeadState(townRoot, agent, state, _ string) { // reason unused b
 		return
 	}
 
-	// Use bd agent state command
-	cmd := exec.Command("bd", "agent", "state", beadID, state)
-	cmd.Dir = townRoot
-	_ = cmd.Run() // Best effort
+	_ = beads.New(townRoot).UpdateAgentState(beadID, state) // Best effort
 }
 
 // runDeaconStaleHooks finds and unhooks stale hooked beads.

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -120,15 +120,15 @@ type DNDInfo struct {
 
 // AgentRuntime represents the runtime state of an agent.
 type AgentRuntime struct {
-	Name         string `json:"name"`                    // Display name (e.g., "mayor", "witness")
-	Address      string `json:"address"`                 // Full address (e.g., "greenplace/witness")
-	Session      string `json:"session"`                 // tmux session name
-	Role         string `json:"role"`                    // Role type
-	Running      bool   `json:"running"`                 // Is tmux session running?
-	ACP          bool   `json:"acp"`                     // Is ACP session active?
-	HasWork      bool   `json:"has_work"`                // Has pinned work?
-	WorkTitle    string `json:"work_title,omitempty"`    // Title of pinned work
-	HookBead     string `json:"hook_bead,omitempty"`     // Pinned bead ID from agent bead
+	Name              string `json:"name"`                         // Display name (e.g., "mayor", "witness")
+	Address           string `json:"address"`                      // Full address (e.g., "greenplace/witness")
+	Session           string `json:"session"`                      // tmux session name
+	Role              string `json:"role"`                         // Role type
+	Running           bool   `json:"running"`                      // Is tmux session running?
+	ACP               bool   `json:"acp"`                          // Is ACP session active?
+	HasWork           bool   `json:"has_work"`                     // Has pinned work?
+	WorkTitle         string `json:"work_title,omitempty"`         // Title of pinned work
+	HookBead          string `json:"hook_bead,omitempty"`          // Pinned bead ID from agent bead
 	State             string `json:"state,omitempty"`              // Agent state from agent bead
 	NotificationLevel string `json:"notification_level,omitempty"` // Notification level (verbose, normal, muted)
 	UnreadMail        int    `json:"unread_mail"`                  // Number of unread messages
@@ -1594,7 +1594,7 @@ func discoverGlobalAgents(townRoot string, allSessions map[string]bool, allAgent
 				// Prefer database columns over description parsing
 				// HookBead column is authoritative (cleared by unsling)
 				agent.HookBead = issue.HookBead
-				agent.State = issue.AgentState
+				agent.State = beads.ResolveAgentState(issue.Description, issue.AgentState)
 				if agent.HookBead != "" {
 					agent.HasWork = true
 					// Get hook title from preloaded map
@@ -1604,9 +1604,6 @@ func discoverGlobalAgents(townRoot string, allSessions map[string]bool, allAgent
 				}
 				// Parse description fields for legacy slots (and notification level)
 				if fields := beads.ParseAgentFields(issue.Description); fields != nil {
-					if agent.State == "" {
-						agent.State = fields.AgentState
-					}
 					agent.NotificationLevel = fields.NotificationLevel
 				}
 			}
@@ -1772,7 +1769,7 @@ func discoverRigAgents(allSessions map[string]bool, r *rig.Rig, crews []string, 
 				// Prefer database columns over description parsing
 				// HookBead column is authoritative (cleared by unsling)
 				agent.HookBead = issue.HookBead
-				agent.State = issue.AgentState
+				agent.State = beads.ResolveAgentState(issue.Description, issue.AgentState)
 				if agent.HookBead != "" {
 					agent.HasWork = true
 					// Get hook title from preloaded map
@@ -1782,9 +1779,6 @@ func discoverRigAgents(allSessions map[string]bool, r *rig.Rig, crews []string, 
 				}
 				// Parse description fields for legacy slots (and notification level)
 				if fields := beads.ParseAgentFields(issue.Description); fields != nil {
-					if agent.State == "" {
-						agent.State = fields.AgentState
-					}
 					agent.NotificationLevel = fields.NotificationLevel
 				}
 			}

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -771,7 +771,7 @@ func (d *Daemon) closeMessage(id string) error {
 type AgentBeadInfo struct {
 	ID         string `json:"id"`
 	Type       string `json:"issue_type"`
-	State      string // From DB column (agent_state), fallback to description
+	State      string // From description agent_state, fallback to legacy DB column
 	HookBead   string // From DB column (hook_bead)
 	RoleType   string // Parsed from description: role_type
 	Rig        string // Parsed from description: rig
@@ -840,15 +840,7 @@ func (d *Daemon) getAgentBeadInfo(agentBeadID string) (*AgentBeadInfo, error) {
 		info.Rig = fields.Rig
 	}
 
-	// Use AgentState from database column directly (not from description).
-	// UpdateAgentState updates the DB column but not the description text,
-	// so the description can contain stale state (e.g., "spawning" after
-	// the polecat has transitioned to "working"). Fall back to description
-	// only if the DB column is empty (legacy beads).
-	info.State = issue.AgentState
-	if info.State == "" && fields != nil {
-		info.State = fields.AgentState
-	}
+	info.State = beads.ResolveAgentState(issue.Description, issue.AgentState)
 
 	// Use HookBead from database column directly (not from description)
 	// The description may contain stale data - the slot is the source of truth.
@@ -1086,9 +1078,11 @@ func (d *Daemon) checkRigGUPPViolations(rigName string) {
 			continue // No hooked work - no GUPP violation possible
 		}
 
+		agentState := beads.ResolveAgentState(agent.Description, agent.AgentState)
+
 		// Skip nuked agents — they're intentionally terminated and should not
 		// trigger alerts even if stale hook_bead data remains in the database.
-		if beads.AgentState(agent.AgentState) == beads.AgentStateNuked {
+		if beads.AgentState(agentState) == beads.AgentStateNuked {
 			continue
 		}
 
@@ -1168,11 +1162,12 @@ func (d *Daemon) checkOrphanedWork() {
 func (d *Daemon) checkRigOrphanedWork(rigName string) {
 	// List polecat agent beads (issues + wisps tables)
 	var agents []struct {
-		ID         string   `json:"id"`
-		HookBead   string   `json:"hook_bead"`
-		AgentState string   `json:"agent_state"`
-		Labels     []string `json:"labels"`
-		Type       string   `json:"issue_type"`
+		ID          string   `json:"id"`
+		HookBead    string   `json:"hook_bead"`
+		AgentState  string   `json:"agent_state"`
+		Description string   `json:"description"`
+		Labels      []string `json:"labels"`
+		Type        string   `json:"issue_type"`
 	}
 
 	if err := d.listAgentBeadsJSON(&agents); err != nil {
@@ -1195,9 +1190,11 @@ func (d *Daemon) checkRigOrphanedWork(rigName string) {
 			continue
 		}
 
+		agentState := beads.ResolveAgentState(agent.Description, agent.AgentState)
+
 		// Skip nuked agents — they're intentionally terminated and should not
 		// trigger alerts even if stale hook_bead data remains in the database.
-		if beads.AgentState(agent.AgentState) == beads.AgentStateNuked {
+		if beads.AgentState(agentState) == beads.AgentStateNuked {
 			continue
 		}
 

--- a/internal/daemon/polecat_health_test.go
+++ b/internal/daemon/polecat_health_test.go
@@ -169,19 +169,19 @@ func TestCheckPolecatHealth_SpawningGuardExpires(t *testing.T) {
 	}
 }
 
-// TestCheckPolecatHealth_DBStateOverridesDescription verifies that the daemon
-// reads agent_state from the DB column (source of truth), not the description
-// text. UpdateAgentState updates the DB column but not the description, so a
-// polecat that transitioned from "spawning" to "working" will have stale
-// description text. The DB column must be authoritative.
-func TestCheckPolecatHealth_DBStateOverridesDescription(t *testing.T) {
+// TestCheckPolecatHealth_DescriptionStateOverridesLegacyDBColumn verifies that
+// daemon lifecycle reads the description's agent_state first. bd >= 0.62.0 no
+// longer has a supported structured agent_state writer, so the description is
+// Gastown's active contract and the DB column is legacy fallback only.
+func TestCheckPolecatHealth_DescriptionStateOverridesLegacyDBColumn(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses Unix shell script mocks for tmux and bd")
 	}
 	binDir := t.TempDir()
 	writeFakeTestTmux(t, binDir)
 	recentTime := time.Now().UTC().Format(time.RFC3339)
-	// Description says "spawning" (stale) but DB column says "working" (truth)
+	// Description says "spawning" (current Gastown contract) while the legacy
+	// structured column still says "working".
 	bdPath := writeFakeTestBD(t, binDir, "spawning", "working", "gt-xyz", recentTime)
 
 	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
@@ -197,13 +197,11 @@ func TestCheckPolecatHealth_DBStateOverridesDescription(t *testing.T) {
 	d.checkPolecatHealth("myr", "mycat")
 
 	got := logBuf.String()
-	// Should NOT skip due to spawning guard — DB says "working"
-	if strings.Contains(got, "Skipping restart") {
-		t.Errorf("daemon should use DB agent_state (working), not stale description (spawning), got: %q", got)
+	if !strings.Contains(got, "spawning") {
+		t.Errorf("expected log to mention description-backed spawning state, got: %q", got)
 	}
-	// Should detect crash since DB says working + session is dead
-	if !strings.Contains(got, "CRASH DETECTED") {
-		t.Errorf("expected CRASH DETECTED when DB state is 'working' with dead session, got: %q", got)
+	if strings.Contains(got, "CRASH DETECTED") {
+		t.Errorf("daemon should honor description state 'spawning' and skip crash detection, got: %q", got)
 	}
 }
 

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1774,12 +1774,12 @@ func processDiscoveredCompletion(bd *BdCli, workDir, rigName string, payload *Po
 // Used to avoid redundant subprocess invocations during zombie detection, where the same
 // agent bead was previously queried 3-5 times per polecat per patrol cycle. (gt-2gra)
 type agentBeadSnapshot struct {
-	AgentState  string
-	HookBead    string
-	Labels      []string
-	UpdatedAt   string
-	ActiveMR    string
-	Fields      *beads.AgentFields // parsed from description
+	AgentState string
+	HookBead   string
+	Labels     []string
+	UpdatedAt  string
+	ActiveMR   string
+	Fields     *beads.AgentFields // parsed from description
 }
 
 // fetchAgentBeadSnapshot fetches all agent bead data in a single bd show call.
@@ -1803,7 +1803,7 @@ func fetchAgentBeadSnapshot(bd *BdCli, workDir, agentBeadID string) *agentBeadSn
 	}
 
 	return &agentBeadSnapshot{
-		AgentState: issues[0].AgentState,
+		AgentState: beads.ResolveAgentState(issues[0].Description, issues[0].AgentState),
 		HookBead:   issues[0].HookBead,
 		Labels:     issues[0].Labels,
 		UpdatedAt:  issues[0].UpdatedAt,
@@ -1899,14 +1899,15 @@ func getAgentBeadState(bd *BdCli, workDir, agentBeadID string) (agentState, hook
 
 	// Parse JSON response — bd show --json returns an array
 	var issues []struct {
-		AgentState string `json:"agent_state"`
-		HookBead   string `json:"hook_bead"`
+		AgentState  string `json:"agent_state"`
+		HookBead    string `json:"hook_bead"`
+		Description string `json:"description"`
 	}
 	if err := json.Unmarshal([]byte(output), &issues); err != nil || len(issues) == 0 {
 		return "", ""
 	}
 
-	return issues[0].AgentState, issues[0].HookBead
+	return beads.ResolveAgentState(issues[0].Description, issues[0].AgentState), issues[0].HookBead
 }
 
 // getAgentBeadAge returns the time since the agent bead was last updated.
@@ -1958,13 +1959,13 @@ func getBeadStatus(bd *BdCli, workDir, beadID string) string {
 
 // resetAbandonedBead resets a dead polecat's hooked bead so it can be re-dispatched.
 // If the bead is in "hooked" or "in_progress" status, it:
-// 0. Checks if the polecat's work is already on main — if so, closes
-//    the bead instead of resetting (prevents re-dispatch of completed work)
-// 1. Records the respawn in the witness spawn-count ledger
-// 2. Resets status to open
-// 3. Clears assignee
-// 4. Sends mail to deacon for re-dispatch (includes respawn count; SPAWN_STORM
-//    prefix and Urgent priority when count exceeds max bead respawns config)
+//  0. Checks if the polecat's work is already on main — if so, closes
+//     the bead instead of resetting (prevents re-dispatch of completed work)
+//  1. Records the respawn in the witness spawn-count ledger
+//  2. Resets status to open
+//  3. Clears assignee
+//  4. Sends mail to deacon for re-dispatch (includes respawn count; SPAWN_STORM
+//     prefix and Urgent priority when count exceeds max bead respawns config)
 //
 // Returns true if the bead was recovered.
 func resetAbandonedBead(bd *BdCli, workDir, rigName, hookBead, polecatName string, router *mail.Router) bool {


### PR DESCRIPTION
## Summary
- switch Gastown agent-state writes away from the removed `bd agent state` path
- prefer description-backed agent_state with legacy structured-column fallback
- override stale inherited Dolt connection env when targeting another beads dir

## Verification
- `go test ./internal/beads -run 'Test(GetAgentBead_PrefersDescriptionAgentState|GetAgentBead_FallsBackToDescriptionAgentState|UpdateAgentState_UsesUpdateDescriptionPath|BuildRunEnv_OverridesStaleDoltPortFromBeadsDir|BuildRoutingEnv_OverridesStaleDoltPortFromBeadsDir)$'`\n- `go test -c -o /tmp/pr-bd-daemon.test ./internal/daemon`\n- `go test -c -o /tmp/pr-bd-witness.test ./internal/witness`\n\n## Notes\n- kept draft because `internal/daemon` runtime tests require Docker/testcontainers in this environment