### PR TITLE
feat(rig): support local bootstrap via file URLs

### DIFF
--- a/docs/guides/local-rig-bootstrap.md
+++ b/docs/guides/local-rig-bootstrap.md
@@ -1,0 +1,39 @@
+# Local Rig Bootstrap
+
+For a NightRider-style local setup, prefer a clean bootstrap over `gt rig add --adopt`.
+
+`--adopt` is meant for registering an already-assembled rig directory. It trusts the
+existing shape, which makes it a poor fit for manually assembled local rigs where
+`.repo.git`, worktrees, and metadata may already be inconsistent.
+
+Use the bootstrap script instead:
+
+```bash
+./scripts/bootstrap-local-rig.sh \
+  --town-root /gt \
+  --rig nightrider_local \
+  --local-repo /gt/nightRider \
+  --prefix nr \
+  --polecat-agent claude \
+  --witness-agent codex \
+  --refinery-agent codex
+```
+
+If you omit `--remote`, the script registers the rig with `file://<local-repo>`.
+That is usually the right choice for local-only or private repos inside the
+Gastown container, where the upstream remote may not be reachable or authenticated.
+
+What this does:
+
+- Uses `gt rig add <name> <git-url> --local-repo <path>` so Gas Town creates a fresh,
+  standard rig container instead of inheriting a hand-built one.
+- Reuses objects from the local repo, so bootstrap stays fast and does not modify the
+  source repo.
+- Leaves the resulting rig with the normal `.repo.git`, `mayor/rig`, `refinery/rig`,
+  `settings/`, and `.beads/` layout that Gas Town expects.
+- Optionally pins per-rig role agents in `settings/config.json`.
+
+When to still use `--adopt`:
+
+- You already have a real Gas Town rig directory that was created elsewhere and you
+  only need to register it in a town.

--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -489,7 +489,7 @@ func runRigAdd(cmd *cobra.Command, args []string) error {
 	gitURL := args[1]
 
 	if !isGitRemoteURL(gitURL) {
-		return fmt.Errorf("invalid git URL %q: expected a remote URL (e.g. https://, git@host:, ssh://, s3://)\n\nTo register a local directory, use:\n  gt rig add %s --adopt", gitURL, name)
+		return fmt.Errorf("invalid git URL %q: expected a remote URL (e.g. https://, git@host:, ssh://, s3://, file:///abs/path)\n\nTo use a local repo as the source, pass a file:// URL. To register an already-assembled rig directory, use:\n  gt rig add %s --adopt", gitURL, name)
 	}
 
 	// Ensure beads (bd) is available before proceeding
@@ -1010,19 +1010,19 @@ func runRigAdopt(_ *cobra.Command, args []string) error {
 
 	// Validate --url if provided
 	if rigAddAdoptURL != "" && !isGitRemoteURL(rigAddAdoptURL) {
-		return fmt.Errorf("invalid git URL %q: expected a remote URL (e.g. https://, git@host:, ssh://, s3://)", rigAddAdoptURL)
+		return fmt.Errorf("invalid git URL %q: expected a remote URL (e.g. https://, git@host:, ssh://, s3://, file:///abs/path)", rigAddAdoptURL)
 	}
 
 	// Validate --push-url if provided
 	rigAddPushURL = strings.TrimSpace(rigAddPushURL)
 	if rigAddPushURL != "" && !isGitRemoteURL(rigAddPushURL) {
-		return fmt.Errorf("invalid push URL %q: expected a remote URL (e.g. https://, git@host:, ssh://, s3://)", rigAddPushURL)
+		return fmt.Errorf("invalid push URL %q: expected a remote URL (e.g. https://, git@host:, ssh://, s3://, file:///abs/path)", rigAddPushURL)
 	}
 
 	// Validate --upstream-url if provided
 	rigAddUpstreamURL = strings.TrimSpace(rigAddUpstreamURL)
 	if rigAddUpstreamURL != "" && !isGitRemoteURL(rigAddUpstreamURL) {
-		return fmt.Errorf("invalid upstream URL %q: expected a remote URL (e.g. https://, git@host:, ssh://, s3://)", rigAddUpstreamURL)
+		return fmt.Errorf("invalid upstream URL %q: expected a remote URL (e.g. https://, git@host:, ssh://, s3://, file:///abs/path)", rigAddUpstreamURL)
 	}
 
 	// Register the existing rig
@@ -2277,8 +2277,8 @@ func commitTownConfigChanges(townRoot, rigName string) {
 }
 
 // isGitRemoteURL returns true if s looks like a remote git URL rather than a
-// local path. Accepts any scheme:// URL (git delegates to git-remote-<scheme>
-// helpers, e.g. git-remote-s3 for s3:// URLs) as well as SCP-style SSH URLs.
+// local path. Accepts any scheme:// URL (including file:// for explicit local
+// mirrors) as well as SCP-style SSH URLs.
 func isGitRemoteURL(s string) bool {
 	// Reject flag-like strings (defense-in-depth against argument injection)
 	if strings.HasPrefix(s, "-") {
@@ -2300,12 +2300,8 @@ func isGitRemoteURL(s string) bool {
 	if strings.HasPrefix(s, "~/") {
 		return false
 	}
-	// Reject file:// URIs (local filesystem access)
-	if strings.HasPrefix(s, "file://") {
-		return false
-	}
 	// Accept any scheme:// URL where scheme is alphanumeric (plus + - .).
-	// This covers https://, ssh://, git://, s3://, codecommit://, etc.
+	// This covers https://, ssh://, git://, s3://, file://, codecommit://, etc.
 	// Git invokes git-remote-<scheme> for non-builtin schemes.
 	if idx := strings.Index(s, "://"); idx > 0 {
 		scheme := s[:idx]

--- a/internal/cmd/rig_test.go
+++ b/internal/cmd/rig_test.go
@@ -38,10 +38,10 @@ func TestIsGitRemoteURL(t *testing.T) {
 		// Bare directory name — should return false
 		{"foo", false},
 
-		// file:// URIs — should return false (local filesystem)
-		{"file:///tmp/evil-repo", false},
-		{"file:///Users/scott/projects/foo", false},
-		{"file://user@localhost:/tmp/evil-repo", false},
+		// file:// URIs — explicit local git remotes are allowed
+		{"file:///tmp/local-repo.git", true},
+		{"file:///Users/scott/projects/foo", true},
+		{"file://user@localhost:/tmp/local-repo.git", true},
 
 		// Argument injection — should return false
 		{"-oProxyCommand=evil", false},

--- a/scripts/bootstrap-local-rig.sh
+++ b/scripts/bootstrap-local-rig.sh
@@ -1,0 +1,186 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  cat <<'EOF'
+Usage:
+  bootstrap-local-rig.sh --town-root PATH --rig NAME --local-repo PATH [options]
+
+Create a clean Gas Town rig from a local source repo by using `gt rig add` with
+`--local-repo` instead of adopting a manually assembled rig directory.
+
+Required:
+  --town-root PATH       Gas Town town root
+  --rig NAME             New rig name
+  --local-repo PATH      Existing local repo to use as the object reference
+
+Optional:
+  --remote URL           Git URL to register for the rig
+                         (default: file://<local-repo>)
+  --gt-bin PATH          gt binary to use (default: ./gt if present, else gt)
+  --prefix PREFIX        Beads prefix override
+  --branch NAME          Default branch override
+  --polecat-agent NAME   Write rig settings role_agents.polecat
+  --witness-agent NAME   Write rig settings role_agents.witness
+  --refinery-agent NAME  Write rig settings role_agents.refinery
+
+Example:
+  ./scripts/bootstrap-local-rig.sh \
+    --town-root /gt \
+    --rig nightrider_local \
+    --local-repo /gt/nightRider \
+    --prefix nr \
+    --polecat-agent claude \
+    --witness-agent codex \
+    --refinery-agent codex
+EOF
+}
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+DEFAULT_GT_BIN="gt"
+if [[ -x "${SCRIPT_DIR}/../gt" ]]; then
+  DEFAULT_GT_BIN="${SCRIPT_DIR}/../gt"
+fi
+
+TOWN_ROOT=""
+RIG_NAME=""
+REMOTE_URL=""
+LOCAL_REPO=""
+GT_BIN="${DEFAULT_GT_BIN}"
+PREFIX=""
+BRANCH=""
+POLECAT_AGENT=""
+WITNESS_AGENT=""
+REFINERY_AGENT=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --town-root)
+      TOWN_ROOT="${2:-}"
+      shift 2
+      ;;
+    --rig)
+      RIG_NAME="${2:-}"
+      shift 2
+      ;;
+    --remote)
+      REMOTE_URL="${2:-}"
+      shift 2
+      ;;
+    --local-repo)
+      LOCAL_REPO="${2:-}"
+      shift 2
+      ;;
+    --gt-bin)
+      GT_BIN="${2:-}"
+      shift 2
+      ;;
+    --prefix)
+      PREFIX="${2:-}"
+      shift 2
+      ;;
+    --branch)
+      BRANCH="${2:-}"
+      shift 2
+      ;;
+    --polecat-agent)
+      POLECAT_AGENT="${2:-}"
+      shift 2
+      ;;
+    --witness-agent)
+      WITNESS_AGENT="${2:-}"
+      shift 2
+      ;;
+    --refinery-agent)
+      REFINERY_AGENT="${2:-}"
+      shift 2
+      ;;
+    -h|--help)
+      usage
+      exit 0
+      ;;
+    *)
+      echo "Unknown argument: $1" >&2
+      usage >&2
+      exit 2
+      ;;
+  esac
+done
+
+for required in TOWN_ROOT RIG_NAME LOCAL_REPO; do
+  if [[ -z "${!required}" ]]; then
+    echo "Missing required argument: ${required}" >&2
+    usage >&2
+    exit 2
+  fi
+done
+
+if [[ ! -d "${TOWN_ROOT}" ]]; then
+  echo "Town root does not exist: ${TOWN_ROOT}" >&2
+  exit 1
+fi
+
+if [[ ! -d "${LOCAL_REPO}" ]]; then
+  echo "Local repo does not exist: ${LOCAL_REPO}" >&2
+  exit 1
+fi
+
+if ! git -C "${LOCAL_REPO}" rev-parse --git-dir >/dev/null 2>&1; then
+  echo "Local repo is not a git repository: ${LOCAL_REPO}" >&2
+  exit 1
+fi
+
+if [[ -z "${REMOTE_URL}" ]]; then
+  REMOTE_URL="file://${LOCAL_REPO}"
+fi
+
+RIG_PATH="${TOWN_ROOT}/${RIG_NAME}"
+if [[ -e "${RIG_PATH}" ]]; then
+  echo "Target rig already exists: ${RIG_PATH}" >&2
+  exit 1
+fi
+
+GT_ARGS=("rig" "add" "${RIG_NAME}" "${REMOTE_URL}" "--local-repo" "${LOCAL_REPO}")
+if [[ -n "${PREFIX}" ]]; then
+  GT_ARGS+=("--prefix" "${PREFIX}")
+fi
+if [[ -n "${BRANCH}" ]]; then
+  GT_ARGS+=("--branch" "${BRANCH}")
+fi
+
+(
+  cd "${TOWN_ROOT}"
+  "${GT_BIN}" "${GT_ARGS[@]}"
+)
+
+if [[ -n "${POLECAT_AGENT}" || -n "${WITNESS_AGENT}" || -n "${REFINERY_AGENT}" ]]; then
+  SETTINGS_PATH="${RIG_PATH}/settings/config.json"
+  mkdir -p "$(dirname "${SETTINGS_PATH}")"
+  python3 - "${SETTINGS_PATH}" "${POLECAT_AGENT}" "${WITNESS_AGENT}" "${REFINERY_AGENT}" <<'PY'
+import json
+import os
+import sys
+
+settings_path, polecat, witness, refinery = sys.argv[1:]
+data = {}
+if os.path.exists(settings_path):
+    with open(settings_path, "r", encoding="utf-8") as fh:
+        data = json.load(fh)
+
+data.setdefault("type", "rig-settings")
+data.setdefault("version", 1)
+role_agents = data.setdefault("role_agents", {})
+if polecat:
+    role_agents["polecat"] = polecat
+if witness:
+    role_agents["witness"] = witness
+if refinery:
+    role_agents["refinery"] = refinery
+
+with open(settings_path, "w", encoding="utf-8") as fh:
+    json.dump(data, fh, indent=2)
+    fh.write("\n")
+PY
+fi
+
+echo "Rig bootstrapped at ${RIG_PATH}"


### PR DESCRIPTION
## Summary
- allow explicit `file://` git URLs for local rig bootstrap flows
- update command validation and user-facing guidance
- add local rig bootstrap guide and helper script

## Verification
- `go test ./internal/cmd -run 'TestIsGitRemoteURL$'`