### PR TITLE
fix(runtime): resolve wrapped agents and track refinery pid

### DIFF
--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -180,8 +180,8 @@ type ACPConfig struct {
 // ACP mode constants.
 const (
 	ACPModeSubcommand = "subcommand" // Agent has ACP as subcommand (e.g., "opencode acp")
-	ACPModeNative      = "native"    // Agent is native ACP binary (e.g., "claude-agent-acp")
-	ACPModeFlag        = "flag"      // Agent uses flag to enable ACP (e.g., "gemini --acp")
+	ACPModeNative     = "native"     // Agent is native ACP binary (e.g., "claude-agent-acp")
+	ACPModeFlag       = "flag"       // Agent uses flag to enable ACP (e.g., "gemini --acp")
 )
 
 // NonInteractiveConfig contains settings for running agents non-interactively.
@@ -253,11 +253,11 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 			OutputFlag: "--output-format json",
 		},
 		// Runtime defaults
-		PromptMode:        "arg",
-		ConfigDir:         ".gemini",
-		HooksProvider:     "gemini",
-		HooksDir:          ".gemini",
-		HooksSettingsFile: "settings.json",
+		PromptMode:           "arg",
+		ConfigDir:            ".gemini",
+		HooksProvider:        "gemini",
+		HooksDir:             ".gemini",
+		HooksSettingsFile:    "settings.json",
 		ReadyDelayMs:         5000,
 		InstructionsFile:     "AGENTS.md",
 		EscapeCancelsRequest: true, // Gemini CLI uses Escape to abort active generation
@@ -277,10 +277,10 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 			OutputFlag: "--json",
 		},
 		// Runtime defaults
-		PromptMode:         "none",
-		ReadyPromptPrefix:  "› ",
-		ReadyDelayMs:       3000,
-		InstructionsFile:   "AGENTS.md",
+		PromptMode:        "none",
+		ReadyPromptPrefix: "› ",
+		ReadyDelayMs:      3000,
+		InstructionsFile:  "AGENTS.md",
 	},
 	AgentCursor: {
 		Name:                AgentCursor,
@@ -372,7 +372,7 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		ResumeFlag:          "--resume",
 		ContinueFlag:        "--continue", // GA: resumes most recent session without picker
 		ResumeStyle:         "flag",
-		SupportsHooks:       true,  // Copilot CLI supports .github/hooks/*.json lifecycle hooks
+		SupportsHooks:       true, // Copilot CLI supports .github/hooks/*.json lifecycle hooks
 		SupportsForkSession: false,
 		NonInteractive: &NonInteractiveConfig{
 			PromptFlag: "-p",
@@ -678,12 +678,17 @@ func ResolveProcessNames(agentName, command string) []string {
 	if command != "" {
 		cmdBase = filepath.Base(command)
 	}
+	unwrappedCmdBase := strings.TrimPrefix(cmdBase, "gt-")
 
 	// Check if agentName matches a built-in/registered preset with matching command.
 	// Compare against both the raw command and basename to handle registry entries
 	// that store absolute-path commands (e.g., "/opt/bin/my-tool").
 	if info, ok := globalRegistry.Agents[agentName]; ok && len(info.ProcessNames) > 0 {
-		if info.Command == command || info.Command == cmdBase || filepath.Base(info.Command) == cmdBase || cmdBase == "" {
+		if info.Command == command ||
+			info.Command == cmdBase ||
+			filepath.Base(info.Command) == cmdBase ||
+			(info.Command == unwrappedCmdBase && strings.HasPrefix(cmdBase, "gt-")) ||
+			cmdBase == "" {
 			return info.ProcessNames
 		}
 	}
@@ -691,7 +696,12 @@ func ResolveProcessNames(agentName, command string) []string {
 	// Agent name doesn't match or command differs — look up by command
 	if cmdBase != "" {
 		for _, info := range globalRegistry.Agents {
-			if (info.Command == command || filepath.Base(info.Command) == cmdBase) && len(info.ProcessNames) > 0 {
+			if len(info.ProcessNames) == 0 {
+				continue
+			}
+			if info.Command == command ||
+				filepath.Base(info.Command) == cmdBase ||
+				(strings.HasPrefix(cmdBase, "gt-") && filepath.Base(info.Command) == unwrappedCmdBase) {
 				return info.ProcessNames
 			}
 		}
@@ -873,12 +883,12 @@ func GetACPArgs(agentName string) []string {
 // Returns true if the RuntimeConfig has ACP configured.
 //
 // ACP can be configured in three ways:
-// 1. Native mode: { "command": "claude-agent-acp", "acp": { "mode": "native" } }
-//    The binary is already an ACP adapter, no transformation needed.
-// 2. Subcommand pattern: { "command": "opencode", "acp": { "command": "acp" } }
-//    Results in: opencode acp
-// 3. Flag pattern: { "command": "gemini", "acp": { "args": ["--acp"] } }
-//    Results in: gemini --acp
+//  1. Native mode: { "command": "claude-agent-acp", "acp": { "mode": "native" } }
+//     The binary is already an ACP adapter, no transformation needed.
+//  2. Subcommand pattern: { "command": "opencode", "acp": { "command": "acp" } }
+//     Results in: opencode acp
+//  3. Flag pattern: { "command": "gemini", "acp": { "args": ["--acp"] } }
+//     Results in: gemini --acp
 func RuntimeConfigSupportsACP(rc *RuntimeConfig) bool {
 	if rc == nil {
 		return false
@@ -911,12 +921,12 @@ func RuntimeConfigSupportsACP(rc *RuntimeConfig) bool {
 // Returns nil if the RuntimeConfig doesn't support ACP.
 //
 // ACP can be configured in three ways:
-// 1. Native mode: { "command": "claude-agent-acp", "acp": { "mode": "native" } }
-//    The binary is already an ACP adapter, no transformation needed.
-// 2. Subcommand pattern: { "command": "opencode", "acp": { "command": "acp" } }
-//    Results in: opencode acp
-// 3. Flag pattern: { "command": "gemini", "acp": { "args": ["--experimental-acp"] } }
-//    Results in: gemini --experimental-acp
+//  1. Native mode: { "command": "claude-agent-acp", "acp": { "mode": "native" } }
+//     The binary is already an ACP adapter, no transformation needed.
+//  2. Subcommand pattern: { "command": "opencode", "acp": { "command": "acp" } }
+//     Results in: opencode acp
+//  3. Flag pattern: { "command": "gemini", "acp": { "args": ["--experimental-acp"] } }
+//     Results in: gemini --experimental-acp
 func GetACPConfigFromRuntime(rc *RuntimeConfig) *ACPConfig {
 	if rc == nil {
 		return nil

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -298,6 +298,12 @@ func TestResolveProcessNames(t *testing.T) {
 			want:      []string{"codex"},
 		},
 		{
+			name:      "built-in preset through gt wrapper command",
+			agentName: "codex",
+			command:   "gt-codex",
+			want:      []string{"codex"},
+		},
+		{
 			name:      "unknown agent with known command",
 			agentName: "my-custom-agent",
 			command:   "claude",
@@ -1477,12 +1483,12 @@ func TestACPModes(t *testing.T) {
 	t.Cleanup(ResetRegistryForTesting)
 
 	tests := []struct {
-		name      string
-		rc        *RuntimeConfig
-		wantACP   bool
-		wantMode  string
-		wantCmd   string
-		wantArgs  []string
+		name     string
+		rc       *RuntimeConfig
+		wantACP  bool
+		wantMode string
+		wantCmd  string
+		wantArgs []string
 	}{
 		{
 			name: "native mode - claude-agent-acp",

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -230,6 +230,11 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 	_ = runtime.RunStartupFallback(t, sessionID, "refinery", runtimeConfig)
 	_ = runtime.DeliverStartupPromptFallback(t, sessionID, initialPrompt, runtimeConfig, constants.ClaudeStartTimeout)
 
+	// Track PID for defense-in-depth orphan cleanup (non-fatal)
+	if err := session.TrackSessionPID(townRoot, sessionID, t); err != nil {
+		log.Printf("warning: tracking session PID for %s: %v", sessionID, err)
+	}
+
 	// Stream refinery's Claude Code JSONL conversation log to VictoriaLogs (opt-in).
 	if os.Getenv("GT_LOG_AGENT_OUTPUT") == "true" && os.Getenv("GT_OTEL_LOGS_URL") != "" {
 		if err := session.ActivateAgentLogging(sessionID, refineryRigDir, runID); err != nil {


### PR DESCRIPTION
## Summary
- resolve process names correctly when agents are launched through `gt-` wrappers
- add refinery session PID tracking for stronger orphan cleanup

## Verification
- `go test ./internal/config -run 'TestResolveProcessNames$|TestACPModes$'`\n- `go test ./internal/refinery -run ^`