### PR TITLE
feat(rig): add recovery and operator lock surfaces

### DIFF
--- a/internal/cmd/rig_doctor.go
+++ b/internal/cmd/rig_doctor.go
@@ -1,0 +1,394 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/daemon"
+	"github.com/steveyegge/gastown/internal/nudge"
+	"github.com/steveyegge/gastown/internal/rig"
+	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/style"
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+var rigDoctorJSON bool
+
+var rigDoctorCmd = &cobra.Command{
+	Use:   "doctor [rig]",
+	Short: "Check what a rig is actually running",
+	Long: `Run a runtime truth check for a local rig.
+
+This compares configured patrol expectations against observable runtime signals:
+  - daemon supervision state
+  - tmux session existence and health
+  - tracked session PID files
+  - queued nudges
+  - nudge-poller PID files
+
+The goal is operator trust: show what is actually alive, what is only configured,
+and where those signals disagree.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runRigDoctor,
+}
+
+func init() {
+	rigDoctorCmd.Flags().BoolVar(&rigDoctorJSON, "json", false, "Output as JSON")
+	rigCmd.AddCommand(rigDoctorCmd)
+}
+
+type rigDoctorReport struct {
+	Rig               string                 `json:"rig"`
+	OperationalState  string                 `json:"operational_state"`
+	OperationalSource string                 `json:"operational_source"`
+	Daemon            rigDoctorDaemonTruth   `json:"daemon"`
+	Patrols           []rigDoctorTargetTruth `json:"patrols"`
+	SlingLocks        []slingLockTruth       `json:"sling_locks,omitempty"`
+	Findings          []string               `json:"findings"`
+}
+
+type rigDoctorDaemonTruth struct {
+	Running       bool      `json:"running"`
+	PID           int       `json:"pid,omitempty"`
+	LastHeartbeat time.Time `json:"last_heartbeat,omitempty"`
+}
+
+type rigDoctorTargetTruth struct {
+	Name            string   `json:"name"`
+	Role            string   `json:"role"`
+	Session         string   `json:"session"`
+	ExpectedRunning bool     `json:"expected_running"`
+	TmuxSession     bool     `json:"tmux_session"`
+	TmuxHealth      string   `json:"tmux_health"`
+	TrackedPIDFile  bool     `json:"tracked_pid_file"`
+	TrackedPID      int      `json:"tracked_pid,omitempty"`
+	TrackedPIDLive  bool     `json:"tracked_pid_live"`
+	NudgeQueue      int      `json:"nudge_queue"`
+	NudgeReady      int      `json:"nudge_ready"`
+	NudgeDeferred   int      `json:"nudge_deferred"`
+	NudgeExpired    int      `json:"nudge_expired"`
+	NudgeMalformed  int      `json:"nudge_malformed"`
+	NudgeStaleClaim int      `json:"nudge_stale_claim"`
+	PollerPIDFile   bool     `json:"poller_pid_file"`
+	PollerPID       int      `json:"poller_pid,omitempty"`
+	PollerPIDLive   bool     `json:"poller_pid_live"`
+	Findings        []string `json:"findings,omitempty"`
+}
+
+type pidTruth struct {
+	Exists bool
+	PID    int
+	Live   bool
+}
+
+func runRigDoctor(cmd *cobra.Command, args []string) error {
+	rigName, err := resolveRigDoctorName(args)
+	if err != nil {
+		return err
+	}
+
+	townRoot, r, err := getRig(rigName)
+	if err != nil {
+		return err
+	}
+
+	report := buildRigDoctorReport(townRoot, r)
+
+	if rigDoctorJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+
+	printRigDoctorReport(report)
+	return nil
+}
+
+func resolveRigDoctorName(args []string) (string, error) {
+	if len(args) > 0 {
+		return args[0], nil
+	}
+
+	roleInfo, err := GetRole()
+	if err != nil {
+		return "", fmt.Errorf("detecting rig from current directory: %w", err)
+	}
+	if roleInfo.Rig == "" {
+		return "", fmt.Errorf("could not detect rig from current directory; please specify rig name")
+	}
+	return roleInfo.Rig, nil
+}
+
+func buildRigDoctorReport(townRoot string, r *rig.Rig) rigDoctorReport {
+	opState, opSource := getRigOperationalState(townRoot, r.Name)
+
+	daemonRunning, daemonPID, _ := daemon.IsRunning(townRoot)
+	daemonState, _ := daemon.LoadState(townRoot)
+
+	report := rigDoctorReport{
+		Rig:               r.Name,
+		OperationalState:  opState,
+		OperationalSource: opSource,
+		Daemon: rigDoctorDaemonTruth{
+			Running: daemonRunning,
+			PID:     daemonPID,
+		},
+	}
+	if daemonState != nil {
+		report.Daemon.LastHeartbeat = daemonState.LastHeartbeat
+	}
+
+	expectedPatrols := opState == "OPERATIONAL"
+	prefix := session.PrefixFor(r.Name)
+	t := tmux.NewTmux()
+
+	report.Patrols = []rigDoctorTargetTruth{
+		inspectRigDoctorTarget(townRoot, t, "witness", "patrol", session.WitnessSessionName(prefix), expectedPatrols),
+		inspectRigDoctorTarget(townRoot, t, "refinery", "patrol", session.RefinerySessionName(prefix), expectedPatrols),
+	}
+	report.SlingLocks = inspectSlingLocks(townRoot, time.Now())
+
+	report.Findings = evaluateRigDoctorReportFindings(report)
+	return report
+}
+
+func inspectRigDoctorTarget(townRoot string, t *tmux.Tmux, name, role, sessionName string, expectedRunning bool) rigDoctorTargetTruth {
+	hasSession, _ := t.HasSession(sessionName)
+	health := t.CheckSessionHealth(sessionName, 0).String()
+	trackedPID := readPIDTruth(filepath.Join(townRoot, constants.DirRuntime, "pids", sessionName+".pid"))
+	pollerPID := readPIDTruth(filepath.Join(townRoot, constants.DirRuntime, "nudge_poller", strings.ReplaceAll(sessionName, "/", "_")+".pid"))
+	queueStats, _ := nudge.InspectQueue(townRoot, sessionName)
+
+	target := rigDoctorTargetTruth{
+		Name:            name,
+		Role:            role,
+		Session:         sessionName,
+		ExpectedRunning: expectedRunning,
+		TmuxSession:     hasSession,
+		TmuxHealth:      health,
+		TrackedPIDFile:  trackedPID.Exists,
+		TrackedPID:      trackedPID.PID,
+		TrackedPIDLive:  trackedPID.Live,
+		NudgeQueue:      queueStats.Retained(),
+		NudgeReady:      queueStats.Ready,
+		NudgeDeferred:   queueStats.Deferred,
+		NudgeExpired:    queueStats.Expired,
+		NudgeMalformed:  queueStats.Malformed,
+		NudgeStaleClaim: queueStats.StaleClaims,
+		PollerPIDFile:   pollerPID.Exists,
+		PollerPID:       pollerPID.PID,
+		PollerPIDLive:   pollerPID.Live,
+	}
+	target.Findings = evaluateRigDoctorTargetFindings(target)
+	return target
+}
+
+func evaluateRigDoctorReportFindings(report rigDoctorReport) []string {
+	var findings []string
+
+	if report.OperationalState == "OPERATIONAL" && !report.Daemon.Running {
+		findings = append(findings, "daemon is not running, so configured patrols are not supervised")
+	}
+
+	if report.OperationalState != "OPERATIONAL" {
+		for _, patrol := range report.Patrols {
+			if patrol.TmuxSession {
+				findings = append(findings, fmt.Sprintf("%s patrol session is running even though rig state is %s", patrol.Name, strings.ToLower(report.OperationalState)))
+			}
+		}
+	}
+
+	for _, patrol := range report.Patrols {
+		for _, finding := range patrol.Findings {
+			findings = append(findings, fmt.Sprintf("%s: %s", patrol.Name, finding))
+		}
+	}
+	for _, slingLock := range report.SlingLocks {
+		switch slingLock.State {
+		case "stale":
+			findings = append(findings, fmt.Sprintf("stale sling lock for %s %q is left behind by dead pid %d; run 'gt rig recover'", slingLock.Kind, slingLock.Subject, slingLock.PID))
+		case "invalid":
+			findings = append(findings, "invalid sling lock metadata should be cleaned with 'gt rig recover'")
+		case "abandoned":
+			findings = append(findings, fmt.Sprintf("sling lock for %s %q has been held by pid %d for %s; run 'gt rig recover' for explicit recovery", slingLock.Kind, slingLock.Subject, slingLock.PID, slingLock.Age.Round(time.Second)))
+		case "legacy-stale":
+			findings = append(findings, fmt.Sprintf("legacy sling lock file for %s %q is present without owner metadata and is no longer held; run 'gt rig recover'", slingLock.Kind, slingLock.Subject))
+		case "legacy-active":
+			findings = append(findings, fmt.Sprintf("legacy sling lock file for %s %q is still held but has no owner metadata; wait for the active sling or restart it under the rebuilt container", slingLock.Kind, slingLock.Subject))
+		}
+	}
+
+	return findings
+}
+
+func evaluateRigDoctorTargetFindings(target rigDoctorTargetTruth) []string {
+	var findings []string
+
+	if target.ExpectedRunning && !target.TmuxSession {
+		findings = append(findings, "configured patrol is not running")
+	}
+	if target.TmuxHealth == tmux.AgentDead.String() {
+		findings = append(findings, "tmux session exists but the agent process is dead")
+	}
+	if target.TmuxHealth == tmux.AgentHung.String() {
+		findings = append(findings, "tmux session exists but the agent appears hung")
+	}
+	if target.TmuxSession && !target.TrackedPIDFile {
+		findings = append(findings, "tmux session exists but tracked pid file is missing")
+	}
+	if !target.TmuxSession && target.TrackedPIDFile && target.TrackedPIDLive {
+		findings = append(findings, "tracked pid is still live but tmux session is missing")
+	}
+	if !target.TmuxSession && target.TrackedPIDFile && !target.TrackedPIDLive {
+		findings = append(findings, "stale tracked pid file remains after the session exited")
+	}
+	if target.NudgeQueue > 0 && !target.TmuxSession {
+		findings = append(findings, fmt.Sprintf("%d queued nudges are retained for eventual delivery, but the patrol session is absent", target.NudgeQueue))
+	}
+	if target.NudgeQueue > 0 && target.TmuxHealth == tmux.AgentDead.String() {
+		findings = append(findings, fmt.Sprintf("%d queued nudges are retained for eventual delivery, but the patrol is not actually alive", target.NudgeQueue))
+	}
+	if target.NudgeExpired > 0 || target.NudgeMalformed > 0 {
+		staleCount := target.NudgeExpired + target.NudgeMalformed
+		findings = append(findings, fmt.Sprintf("%d stale nudge queue entries should be pruned with 'gt rig recover'", staleCount))
+	}
+	if target.NudgeStaleClaim > 0 {
+		findings = append(findings, fmt.Sprintf("%d stale nudge claim files should be requeued with 'gt rig recover'", target.NudgeStaleClaim))
+	}
+	if target.PollerPIDFile && !target.PollerPIDLive {
+		findings = append(findings, "stale nudge-poller pid file remains")
+	}
+	if target.PollerPIDLive && !target.TmuxSession {
+		findings = append(findings, "nudge-poller is live but the patrol session is absent")
+	}
+
+	return findings
+}
+
+func readPIDTruth(path string) pidTruth {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return pidTruth{}
+	}
+
+	fields := strings.SplitN(strings.TrimSpace(string(data)), "|", 2)
+	pid, err := strconv.Atoi(fields[0])
+	if err != nil {
+		return pidTruth{Exists: true}
+	}
+
+	return pidTruth{
+		Exists: true,
+		PID:    pid,
+		Live:   pidIsLive(pid),
+	}
+}
+
+func pidIsLive(pid int) bool {
+	if pid <= 0 {
+		return false
+	}
+	proc, err := os.FindProcess(pid)
+	if err != nil {
+		return false
+	}
+	return proc.Signal(syscall.Signal(0)) == nil
+}
+
+func printRigDoctorReport(report rigDoctorReport) {
+	fmt.Printf("%s\n", style.Bold.Render(report.Rig))
+	fmt.Printf("  Operational: %s (%s)\n", report.OperationalState, report.OperationalSource)
+	fmt.Printf("  Daemon: %s\n", formatRigDoctorDaemon(report.Daemon))
+	fmt.Println()
+
+	fmt.Printf("%s\n", style.Bold.Render("Patrol Truth"))
+	for _, patrol := range report.Patrols {
+		fmt.Printf("  %s: %s\n", patrol.Name, formatRigDoctorPatrolSummary(patrol))
+	}
+
+	if len(report.SlingLocks) > 0 {
+		fmt.Println()
+		fmt.Printf("%s\n", style.Bold.Render("Sling Locks"))
+		for _, slingLock := range report.SlingLocks {
+			fmt.Printf("  %s %q: %s\n", slingLock.Kind, slingLock.Subject, formatRigDoctorSlingLockSummary(slingLock))
+		}
+	}
+
+	fmt.Println()
+	fmt.Printf("%s\n", style.Bold.Render("Findings"))
+	if len(report.Findings) == 0 {
+		fmt.Printf("  %s no mismatches detected\n", style.Success.Render("✓"))
+		return
+	}
+
+	for _, finding := range report.Findings {
+		fmt.Printf("  %s %s\n", style.Warning.Render("!"), finding)
+	}
+}
+
+func formatRigDoctorDaemon(daemonTruth rigDoctorDaemonTruth) string {
+	if !daemonTruth.Running {
+		return "not running"
+	}
+
+	parts := []string{"running"}
+	if daemonTruth.PID > 0 {
+		parts = append(parts, fmt.Sprintf("pid %d", daemonTruth.PID))
+	}
+	if !daemonTruth.LastHeartbeat.IsZero() {
+		parts = append(parts, fmt.Sprintf("last heartbeat %s ago", time.Since(daemonTruth.LastHeartbeat).Round(time.Second)))
+	}
+	return strings.Join(parts, ", ")
+}
+
+func formatRigDoctorPatrolSummary(target rigDoctorTargetTruth) string {
+	return fmt.Sprintf(
+		"tmux=%s health=%s tracked-pid=%s nudge-queue=%d poller=%s expected=%t",
+		boolWord(target.TmuxSession),
+		target.TmuxHealth,
+		describePIDState(target.TrackedPIDFile, target.TrackedPIDLive),
+		target.NudgeQueue,
+		describePIDState(target.PollerPIDFile, target.PollerPIDLive),
+		target.ExpectedRunning,
+	)
+}
+
+func formatRigDoctorSlingLockSummary(lockTruth slingLockTruth) string {
+	parts := []string{lockTruth.State}
+	if lockTruth.PID > 0 {
+		parts = append(parts, fmt.Sprintf("pid %d", lockTruth.PID))
+	}
+	if !lockTruth.AcquiredAt.IsZero() {
+		parts = append(parts, fmt.Sprintf("age %s", lockTruth.Age.Round(time.Second)))
+	}
+	if lockTruth.RecoveryNote != "" {
+		parts = append(parts, lockTruth.RecoveryNote)
+	}
+	return strings.Join(parts, ", ")
+}
+
+func describePIDState(exists, live bool) string {
+	switch {
+	case !exists:
+		return "missing"
+	case live:
+		return "live"
+	default:
+		return "stale"
+	}
+}
+
+func boolWord(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}

--- a/internal/cmd/rig_doctor_test.go
+++ b/internal/cmd/rig_doctor_test.go
@@ -1,0 +1,115 @@
+package cmd
+
+import (
+	"testing"
+	"time"
+)
+
+func TestEvaluateRigDoctorTargetFindings_QueuedNudgesWithoutSession(t *testing.T) {
+	target := rigDoctorTargetTruth{
+		Name:            "witness",
+		ExpectedRunning: true,
+		TmuxSession:     false,
+		TmuxHealth:      "session-dead",
+		NudgeQueue:      2,
+	}
+
+	findings := evaluateRigDoctorTargetFindings(target)
+
+	assertContainsFinding(t, findings, "configured patrol is not running")
+	assertContainsFinding(t, findings, "2 queued nudges are retained for eventual delivery, but the patrol session is absent")
+}
+
+func TestEvaluateRigDoctorTargetFindings_SessionWithoutTrackedPID(t *testing.T) {
+	target := rigDoctorTargetTruth{
+		Name:            "refinery",
+		ExpectedRunning: true,
+		TmuxSession:     true,
+		TmuxHealth:      "healthy",
+		TrackedPIDFile:  false,
+	}
+
+	findings := evaluateRigDoctorTargetFindings(target)
+
+	assertContainsFinding(t, findings, "tmux session exists but tracked pid file is missing")
+}
+
+func TestEvaluateRigDoctorReportFindings_DaemonDown(t *testing.T) {
+	report := rigDoctorReport{
+		OperationalState: "OPERATIONAL",
+		Daemon: rigDoctorDaemonTruth{
+			Running: false,
+		},
+	}
+
+	findings := evaluateRigDoctorReportFindings(report)
+
+	assertContainsFinding(t, findings, "daemon is not running, so configured patrols are not supervised")
+}
+
+func TestEvaluateRigDoctorReportFindings_SlingLockRecovery(t *testing.T) {
+	report := rigDoctorReport{
+		SlingLocks: []slingLockTruth{
+			{
+				Kind:    "bead",
+				Subject: "gt-123",
+				PID:     4242,
+				State:   "stale",
+			},
+			{
+				Kind:        "assignee",
+				Subject:     "gastown/polecats/nux",
+				PID:         5252,
+				State:       "abandoned",
+				Age:         12 * time.Minute,
+				Recoverable: true,
+			},
+		},
+	}
+
+	findings := evaluateRigDoctorReportFindings(report)
+
+	assertContainsFinding(t, findings, "stale sling lock for bead \"gt-123\" is left behind by dead pid 4242; run 'gt rig recover'")
+	assertContainsFinding(t, findings, "sling lock for assignee \"gastown/polecats/nux\" has been held by pid 5252 for 12m0s; run 'gt rig recover' for explicit recovery")
+}
+
+func TestEvaluateRigDoctorReportFindings_LegacySlingLockRecovery(t *testing.T) {
+	report := rigDoctorReport{
+		SlingLocks: []slingLockTruth{
+			{Kind: "bead", Subject: "nr-3kn", State: "legacy-stale"},
+			{Kind: "assignee", Subject: "nightrider_rig_polecats_rust", State: "legacy-active"},
+		},
+	}
+
+	findings := evaluateRigDoctorReportFindings(report)
+
+	assertContainsFinding(t, findings, "legacy sling lock file for bead \"nr-3kn\" is present without owner metadata and is no longer held; run 'gt rig recover'")
+	assertContainsFinding(t, findings, "legacy sling lock file for assignee \"nightrider_rig_polecats_rust\" is still held but has no owner metadata; wait for the active sling or restart it under the rebuilt container")
+}
+
+func TestEvaluateRigDoctorTargetFindings_StaleQueueEntries(t *testing.T) {
+	target := rigDoctorTargetTruth{
+		Name:            "witness",
+		ExpectedRunning: true,
+		TmuxSession:     true,
+		TmuxHealth:      "healthy",
+		NudgeExpired:    2,
+		NudgeMalformed:  1,
+		NudgeStaleClaim: 1,
+	}
+
+	findings := evaluateRigDoctorTargetFindings(target)
+
+	assertContainsFinding(t, findings, "3 stale nudge queue entries should be pruned with 'gt rig recover'")
+	assertContainsFinding(t, findings, "1 stale nudge claim files should be requeued with 'gt rig recover'")
+}
+
+func assertContainsFinding(t *testing.T, findings []string, want string) {
+	t.Helper()
+	for _, finding := range findings {
+		if finding == want {
+			return
+		}
+	}
+	t.Fatalf("findings %v do not contain %q", findings, want)
+}

--- a/internal/cmd/rig_recover.go
+++ b/internal/cmd/rig_recover.go
@@ -1,0 +1,351 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/daemon"
+	"github.com/steveyegge/gastown/internal/nudge"
+	"github.com/steveyegge/gastown/internal/refinery"
+	"github.com/steveyegge/gastown/internal/rig"
+	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/style"
+	"github.com/steveyegge/gastown/internal/tmux"
+	"github.com/steveyegge/gastown/internal/witness"
+)
+
+var rigRecoverCmd = &cobra.Command{
+	Use:   "recover [rig]",
+	Short: "Recover patrol runtime drift for a local rig",
+	Long: `Recover patrol runtime drift for an operational local rig.
+
+This is the write-side companion to 'gt rig doctor':
+  - starts the daemon if supervision is missing
+  - removes stale tracked PID files
+  - removes or stops stale nudge-poller processes
+  - starts or restarts witness/refinery patrol sessions
+  - re-tracks live patrol sessions that are missing PID tracking
+
+The command is intentionally explicit and conservative. It only repairs
+runtime drift for OPERATIONAL rigs and refuses cases that still need
+human judgment, such as a live tracked PID with no tmux session.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runRigRecover,
+}
+
+func init() {
+	rigCmd.AddCommand(rigRecoverCmd)
+}
+
+type rigRecoverPlan struct {
+	StartDaemon bool
+	Patrols     []rigRecoverPatrolPlan
+	SlingLocks  []rigRecoverSlingLockPlan
+}
+
+type rigRecoverPatrolPlan struct {
+	Name             string
+	Session          string
+	Start            bool
+	Restart          bool
+	ReTrackPID       bool
+	RemoveTrackedPID bool
+	StopPoller       bool
+	RemovePollerPID  bool
+	PruneNudges      bool
+	RetainNudges     int
+}
+
+type rigRecoverSlingLockPlan struct {
+	Kind    string
+	Subject string
+	State   string
+}
+
+func runRigRecover(cmd *cobra.Command, args []string) error {
+	rigName, err := resolveRigDoctorName(args)
+	if err != nil {
+		return err
+	}
+
+	townRoot, r, err := getRig(rigName)
+	if err != nil {
+		return err
+	}
+
+	before := buildRigDoctorReport(townRoot, r)
+	if err := validateRigRecoverReport(before); err != nil {
+		return err
+	}
+
+	plan := buildRigRecoverPlan(before)
+	if !plan.hasActions() {
+		fmt.Printf("%s Rig %s has no recoverable drift\n", style.Success.Render("✓"), rigName)
+		return nil
+	}
+
+	fmt.Printf("Recovering rig %s...\n", style.Bold.Render(rigName))
+
+	if plan.StartDaemon {
+		fmt.Printf("  Starting daemon supervision...\n")
+		if err := startDaemonForRecover(townRoot); err != nil {
+			return fmt.Errorf("starting daemon: %w", err)
+		}
+	}
+
+	for _, patrol := range plan.Patrols {
+		if err := applyRigRecoverPatrolPlan(townRoot, r, patrol); err != nil {
+			return fmt.Errorf("recovering %s: %w", patrol.Name, err)
+		}
+	}
+	if len(plan.SlingLocks) > 0 {
+		fmt.Printf("  recovering %d sling lock(s)\n", len(plan.SlingLocks))
+		recovered, err := recoverSlingLocks(townRoot, time.Now())
+		if err != nil {
+			return fmt.Errorf("recovering sling locks: %w", err)
+		}
+		if recovered > 0 {
+			fmt.Printf("  recovered %d sling lock(s)\n", recovered)
+		}
+	}
+
+	after := buildRigDoctorReport(townRoot, r)
+	if len(after.Findings) > 0 {
+		return fmt.Errorf("recovery incomplete:\n- %s", strings.Join(after.Findings, "\n- "))
+	}
+
+	fmt.Printf("%s Rig %s recovered\n", style.Success.Render("✓"), rigName)
+	return nil
+}
+
+func validateRigRecoverReport(report rigDoctorReport) error {
+	if report.OperationalState != "OPERATIONAL" {
+		return fmt.Errorf("rig %s is %s (%s); recovery only supports OPERATIONAL rigs", report.Rig, strings.ToLower(report.OperationalState), report.OperationalSource)
+	}
+
+	for _, patrol := range report.Patrols {
+		if !patrol.TmuxSession && patrol.TrackedPIDFile && patrol.TrackedPIDLive {
+			return fmt.Errorf("%s has a live tracked pid but no tmux session; inspect manually before recovery", patrol.Name)
+		}
+	}
+
+	return nil
+}
+
+func buildRigRecoverPlan(report rigDoctorReport) rigRecoverPlan {
+	plan := rigRecoverPlan{
+		StartDaemon: !report.Daemon.Running,
+	}
+
+	for _, patrol := range report.Patrols {
+		patrolPlan := rigRecoverPatrolPlan{
+			Name:    patrol.Name,
+			Session: patrol.Session,
+		}
+
+		if !patrol.TmuxSession && patrol.TrackedPIDFile && !patrol.TrackedPIDLive {
+			patrolPlan.RemoveTrackedPID = true
+		}
+		if patrol.PollerPIDLive && !patrol.TmuxSession {
+			patrolPlan.StopPoller = true
+		}
+		if patrol.PollerPIDFile && !patrol.PollerPIDLive {
+			patrolPlan.RemovePollerPID = true
+		}
+		if patrol.NudgeExpired > 0 || patrol.NudgeMalformed > 0 || patrol.NudgeStaleClaim > 0 {
+			patrolPlan.PruneNudges = true
+		}
+		patrolPlan.RetainNudges = patrol.NudgeQueue
+
+		switch {
+		case patrol.ExpectedRunning && !patrol.TmuxSession:
+			patrolPlan.Start = true
+		case patrol.TmuxHealth == tmux.AgentDead.String() || patrol.TmuxHealth == tmux.AgentHung.String():
+			patrolPlan.Restart = true
+		case patrol.ExpectedRunning && patrol.TmuxSession && !patrol.TrackedPIDFile:
+			patrolPlan.ReTrackPID = true
+		}
+
+		if patrolPlan.hasActions() {
+			plan.Patrols = append(plan.Patrols, patrolPlan)
+		}
+	}
+	for _, slingLock := range report.SlingLocks {
+		if slingLock.Recoverable {
+			plan.SlingLocks = append(plan.SlingLocks, rigRecoverSlingLockPlan{
+				Kind:    slingLock.Kind,
+				Subject: slingLock.Subject,
+				State:   slingLock.State,
+			})
+		}
+	}
+
+	return plan
+}
+
+func (p rigRecoverPlan) hasActions() bool {
+	return p.StartDaemon || len(p.Patrols) > 0 || len(p.SlingLocks) > 0
+}
+
+func (p rigRecoverPatrolPlan) hasActions() bool {
+	return p.Start || p.Restart || p.ReTrackPID || p.RemoveTrackedPID || p.StopPoller || p.RemovePollerPID || p.PruneNudges
+}
+
+func applyRigRecoverPatrolPlan(townRoot string, r *rig.Rig, plan rigRecoverPatrolPlan) error {
+	if plan.PruneNudges {
+		result, err := nudge.PruneQueue(townRoot, plan.Session)
+		if err != nil {
+			return err
+		}
+		if result.RemovedExpired > 0 || result.RemovedBadJSON > 0 || result.RequeuedClaims > 0 {
+			fmt.Printf("  %s: pruned stale nudge queue entries", plan.Name)
+			if result.RemovedExpired > 0 {
+				fmt.Printf(" expired=%d", result.RemovedExpired)
+			}
+			if result.RemovedBadJSON > 0 {
+				fmt.Printf(" malformed=%d", result.RemovedBadJSON)
+			}
+			if result.RequeuedClaims > 0 {
+				fmt.Printf(" requeued-claims=%d", result.RequeuedClaims)
+			}
+			fmt.Println()
+		}
+	}
+
+	if plan.RemoveTrackedPID {
+		fmt.Printf("  %s: removing stale tracked pid file\n", plan.Name)
+		if err := os.Remove(trackedPIDPathForRecover(townRoot, plan.Session)); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	if plan.StopPoller {
+		fmt.Printf("  %s: stopping orphaned nudge-poller\n", plan.Name)
+		if err := nudge.StopPoller(townRoot, plan.Session); err != nil {
+			return err
+		}
+	}
+
+	if plan.RemovePollerPID {
+		fmt.Printf("  %s: removing stale nudge-poller pid file\n", plan.Name)
+		if err := os.Remove(pollerPIDPathForRecover(townRoot, plan.Session)); err != nil && !os.IsNotExist(err) {
+			return err
+		}
+	}
+
+	if plan.Restart {
+		fmt.Printf("  %s: restarting patrol session\n", plan.Name)
+		if err := restartRigRecoverPatrol(r, plan.Name); err != nil {
+			return err
+		}
+	}
+
+	if plan.Start {
+		fmt.Printf("  %s: starting patrol session\n", plan.Name)
+		if err := startRigRecoverPatrol(r, plan.Name); err != nil {
+			return err
+		}
+	}
+
+	if plan.ReTrackPID {
+		fmt.Printf("  %s: re-tracking session pid\n", plan.Name)
+		if err := session.TrackSessionPID(townRoot, plan.Session, tmux.NewTmux()); err != nil {
+			return err
+		}
+	}
+
+	if plan.RetainNudges > 0 && (plan.Start || plan.Restart) {
+		fmt.Printf("  %s: retaining %d queued nudges for delivery after patrol recovery\n", plan.Name, plan.RetainNudges)
+	}
+
+	return nil
+}
+
+func startRigRecoverPatrol(r *rig.Rig, name string) error {
+	switch name {
+	case "witness":
+		mgr := witness.NewManager(r)
+		if err := mgr.Start(false, "", nil); err != nil && err != witness.ErrAlreadyRunning {
+			return err
+		}
+		return nil
+	case "refinery":
+		mgr := refinery.NewManager(r)
+		if err := mgr.Start(false, ""); err != nil && err != refinery.ErrAlreadyRunning {
+			return err
+		}
+		return nil
+	default:
+		return fmt.Errorf("unsupported patrol %q", name)
+	}
+}
+
+func restartRigRecoverPatrol(r *rig.Rig, name string) error {
+	switch name {
+	case "witness":
+		mgr := witness.NewManager(r)
+		_ = mgr.Stop()
+		return mgr.Start(false, "", nil)
+	case "refinery":
+		mgr := refinery.NewManager(r)
+		if err := mgr.Stop(); err != nil && err != refinery.ErrNotRunning {
+			return err
+		}
+		return mgr.Start(false, "")
+	default:
+		return fmt.Errorf("unsupported patrol %q", name)
+	}
+}
+
+func startDaemonForRecover(townRoot string) error {
+	running, _, err := daemon.IsRunning(townRoot)
+	if err != nil {
+		return err
+	}
+	if running {
+		return nil
+	}
+
+	gtPath, err := os.Executable()
+	if err != nil {
+		return fmt.Errorf("finding executable: %w", err)
+	}
+
+	cmd := exec.Command(gtPath, "daemon", "run")
+	cmd.Dir = townRoot
+	cmd.Stdin = nil
+	cmd.Stdout = nil
+	cmd.Stderr = nil
+
+	if err := cmd.Start(); err != nil {
+		return err
+	}
+
+	for range 30 {
+		time.Sleep(100 * time.Millisecond)
+		running, _, err = daemon.IsRunning(townRoot)
+		if err != nil {
+			return err
+		}
+		if running {
+			return nil
+		}
+	}
+
+	return fmt.Errorf("daemon failed to start (check logs with 'gt daemon logs')")
+}
+
+func trackedPIDPathForRecover(townRoot, sessionName string) string {
+	return filepath.Join(townRoot, constants.DirRuntime, "pids", sessionName+".pid")
+}
+
+func pollerPIDPathForRecover(townRoot, sessionName string) string {
+	safe := strings.ReplaceAll(sessionName, "/", "_")
+	return filepath.Join(townRoot, constants.DirRuntime, "nudge_poller", safe+".pid")
+}

--- a/internal/cmd/rig_recover_test.go
+++ b/internal/cmd/rig_recover_test.go
@@ -1,0 +1,124 @@
+package cmd
+
+import "testing"
+
+func TestBuildRigRecoverPlan_CurrentObservedFailureMode(t *testing.T) {
+	report := rigDoctorReport{
+		Rig:              "gastown",
+		OperationalState: "OPERATIONAL",
+		Daemon: rigDoctorDaemonTruth{
+			Running: false,
+		},
+		Patrols: []rigDoctorTargetTruth{
+			{
+				Name:            "witness",
+				Session:         "gt-gastown-witness",
+				ExpectedRunning: true,
+				TmuxSession:     false,
+				TmuxHealth:      "session-dead",
+				TrackedPIDFile:  true,
+				TrackedPIDLive:  false,
+			},
+			{
+				Name:            "refinery",
+				Session:         "gt-gastown-refinery",
+				ExpectedRunning: true,
+				TmuxSession:     false,
+				TmuxHealth:      "session-dead",
+				NudgeQueue:      1,
+			},
+		},
+	}
+
+	plan := buildRigRecoverPlan(report)
+
+	if !plan.StartDaemon {
+		t.Fatalf("expected daemon start")
+	}
+	if len(plan.Patrols) != 2 {
+		t.Fatalf("expected 2 patrol plans, got %d", len(plan.Patrols))
+	}
+
+	witnessPlan := plan.Patrols[0]
+	if !witnessPlan.Start || !witnessPlan.RemoveTrackedPID {
+		t.Fatalf("expected witness plan to start and remove stale pid, got %+v", witnessPlan)
+	}
+
+	refineryPlan := plan.Patrols[1]
+	if !refineryPlan.Start {
+		t.Fatalf("expected refinery plan to start, got %+v", refineryPlan)
+	}
+}
+
+func TestValidateRigRecoverReportRejectsLiveTrackedPIDWithoutSession(t *testing.T) {
+	report := rigDoctorReport{
+		Rig:              "gastown",
+		OperationalState: "OPERATIONAL",
+		Patrols: []rigDoctorTargetTruth{
+			{
+				Name:            "witness",
+				ExpectedRunning: true,
+				TmuxSession:     false,
+				TrackedPIDFile:  true,
+				TrackedPIDLive:  true,
+			},
+		},
+	}
+
+	if err := validateRigRecoverReport(report); err == nil {
+		t.Fatalf("expected validation error")
+	}
+}
+
+func TestBuildRigRecoverPlan_ReTracksHealthySessionWithoutPID(t *testing.T) {
+	report := rigDoctorReport{
+		Rig:              "gastown",
+		OperationalState: "OPERATIONAL",
+		Daemon: rigDoctorDaemonTruth{
+			Running: true,
+		},
+		Patrols: []rigDoctorTargetTruth{
+			{
+				Name:            "witness",
+				Session:         "gt-gastown-witness",
+				ExpectedRunning: true,
+				TmuxSession:     true,
+				TmuxHealth:      "healthy",
+				TrackedPIDFile:  false,
+			},
+		},
+	}
+
+	plan := buildRigRecoverPlan(report)
+	if plan.StartDaemon {
+		t.Fatalf("did not expect daemon action")
+	}
+	if len(plan.Patrols) != 1 {
+		t.Fatalf("expected 1 patrol plan, got %d", len(plan.Patrols))
+	}
+	if !plan.Patrols[0].ReTrackPID {
+		t.Fatalf("expected re-track action, got %+v", plan.Patrols[0])
+	}
+}
+
+func TestBuildRigRecoverPlan_IncludesRecoverableSlingLocks(t *testing.T) {
+	report := rigDoctorReport{
+		Rig:              "gastown",
+		OperationalState: "OPERATIONAL",
+		Daemon: rigDoctorDaemonTruth{
+			Running: true,
+		},
+		SlingLocks: []slingLockTruth{
+			{Kind: "bead", Subject: "gt-123", State: "stale", Recoverable: true},
+			{Kind: "assignee", Subject: "gastown/polecats/nux", State: "active", Recoverable: false},
+		},
+	}
+
+	plan := buildRigRecoverPlan(report)
+	if len(plan.SlingLocks) != 1 {
+		t.Fatalf("expected 1 recoverable sling lock, got %+v", plan.SlingLocks)
+	}
+	if plan.SlingLocks[0].Subject != "gt-123" {
+		t.Fatalf("unexpected sling lock plan: %+v", plan.SlingLocks[0])
+	}
+}

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -13,7 +13,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/events"
-	"github.com/steveyegge/gastown/internal/lock"
 	"github.com/steveyegge/gastown/internal/mail"
 	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/style"
@@ -401,7 +400,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 			DryRun:      slingDryRun,
 			Force:       slingForce,
 			NoMerge:     slingNoMerge,
-				ReviewOnly:  slingReviewOnly,
+			ReviewOnly:  slingReviewOnly,
 			Account:     slingAccount,
 			Agent:       slingAgent,
 			HookRawBead: slingHookRawBead,
@@ -1092,19 +1091,21 @@ func restorePinnedBead(townRoot, beadID, assignee string) {
 }
 
 func tryAcquireSlingBeadLock(townRoot, beadID string) (func(), error) {
-	lockDir := filepath.Join(townRoot, ".runtime", "locks", "sling")
+	lockDir := slingLockDir(townRoot)
 	if err := os.MkdirAll(lockDir, 0755); err != nil {
 		return nil, fmt.Errorf("creating sling lock dir: %w", err)
 	}
 
-	safeBeadID := strings.NewReplacer("/", "_", ":", "_").Replace(beadID)
-	lockPath := filepath.Join(lockDir, safeBeadID+".flock")
-	release, locked, err := lock.FlockTryAcquire(lockPath)
+	lockPath := slingLockPathForBead(townRoot, beadID)
+	release, locked, err := tryAcquireSlingLock(lockPath, slingLockInfo{
+		Kind:    slingLockKindBead,
+		Subject: beadID,
+	})
 	if err != nil {
 		return nil, fmt.Errorf("acquiring sling lock for bead %s: %w", beadID, err)
 	}
 	if !locked {
-		return nil, fmt.Errorf("bead %s is already being slung; retry after the current assignment completes", beadID)
+		return nil, fmt.Errorf("bead %s is already being slung (%s)", beadID, describeContendedSlingLock(lockPath))
 	}
 
 	return release, nil
@@ -1118,20 +1119,22 @@ func tryAcquireSlingBeadLock(townRoot, beadID string) (func(), error) {
 // indefinite blocking if a sling gets stuck.
 // See: https://github.com/steveyegge/gastown/issues/3114
 func tryAcquireSlingAssigneeLock(townRoot, targetAgent string) (func(), error) {
-	lockDir := filepath.Join(townRoot, ".runtime", "locks", "sling")
+	lockDir := slingLockDir(townRoot)
 	if err := os.MkdirAll(lockDir, 0755); err != nil {
 		return nil, fmt.Errorf("creating sling lock dir: %w", err)
 	}
 
-	safeAgent := strings.NewReplacer("/", "_", ":", "_").Replace(targetAgent)
-	lockPath := filepath.Join(lockDir, "assignee_"+safeAgent+".flock")
+	lockPath := slingLockPathForAssignee(townRoot, targetAgent)
 
 	// Try non-blocking acquire with retry. hookBeadWithRetry itself has 10 retries
 	// with up to 30s backoff, so we allow generous total wait time for the lock.
 	const maxAttempts = 20
 	const retryInterval = 500 // milliseconds
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
-		release, locked, err := lock.FlockTryAcquire(lockPath)
+		release, locked, err := tryAcquireSlingLock(lockPath, slingLockInfo{
+			Kind:    slingLockKindAssignee,
+			Subject: targetAgent,
+		})
 		if err != nil {
 			return nil, fmt.Errorf("acquiring assignee sling lock for %s: %w", targetAgent, err)
 		}
@@ -1143,7 +1146,7 @@ func tryAcquireSlingAssigneeLock(townRoot, targetAgent string) (func(), error) {
 		}
 	}
 
-	return nil, fmt.Errorf("timed out acquiring assignee sling lock for %s after %ds (another sling may be stuck)", targetAgent, maxAttempts*retryInterval/1000)
+	return nil, fmt.Errorf("timed out acquiring assignee sling lock for %s after %ds (%s)", targetAgent, maxAttempts*retryInterval/1000, describeContendedSlingLock(lockPath))
 }
 
 // rollbackSlingArtifacts cleans up artifacts left by a partial sling when session start fails.

--- a/internal/cmd/sling_lock_runtime.go
+++ b/internal/cmd/sling_lock_runtime.go
@@ -1,0 +1,319 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+)
+
+const slingLockAbandonAfter = 10 * time.Minute
+
+type slingLockKind string
+
+const (
+	slingLockKindBead     slingLockKind = "bead"
+	slingLockKindAssignee slingLockKind = "assignee"
+)
+
+type slingLockInfo struct {
+	Kind       slingLockKind `json:"kind"`
+	Subject    string        `json:"subject"`
+	PID        int           `json:"pid"`
+	AcquiredAt time.Time     `json:"acquired_at"`
+	Hostname   string        `json:"hostname,omitempty"`
+}
+
+type slingLockTruth struct {
+	Path         string        `json:"path"`
+	Kind         string        `json:"kind"`
+	Subject      string        `json:"subject"`
+	PID          int           `json:"pid"`
+	AcquiredAt   time.Time     `json:"acquired_at"`
+	Age          time.Duration `json:"-"`
+	State        string        `json:"state"`
+	Recoverable  bool          `json:"recoverable"`
+	RecoveryNote string        `json:"recovery_note,omitempty"`
+}
+
+func slingLockDir(townRoot string) string {
+	return filepath.Join(townRoot, ".runtime", "locks", "sling")
+}
+
+func slingLockPathForBead(townRoot, beadID string) string {
+	return filepath.Join(slingLockDir(townRoot), sanitizeSlingLockSubject(beadID)+".flock")
+}
+
+func slingLockPathForAssignee(townRoot, targetAgent string) string {
+	return filepath.Join(slingLockDir(townRoot), "assignee_"+sanitizeSlingLockSubject(targetAgent)+".flock")
+}
+
+func sanitizeSlingLockSubject(subject string) string {
+	return strings.NewReplacer("/", "_", ":", "_").Replace(subject)
+}
+
+func slingLockInfoPath(lockPath string) string {
+	return lockPath + ".json"
+}
+
+func tryAcquireSlingLock(lockPath string, info slingLockInfo) (func(), bool, error) {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644) //nolint:gosec // lock files are local operational state
+	if err != nil {
+		return nil, false, fmt.Errorf("opening sling lock: %w", err)
+	}
+
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if err == syscall.EWOULDBLOCK {
+			return nil, false, nil
+		}
+		return nil, false, fmt.Errorf("acquiring sling lock: %w", err)
+	}
+
+	info.PID = os.Getpid()
+	info.AcquiredAt = time.Now()
+	info.Hostname, _ = os.Hostname()
+	if err := writeSlingLockInfo(slingLockInfoPath(lockPath), info); err != nil {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+		return nil, false, fmt.Errorf("writing sling lock metadata: %w", err)
+	}
+
+	release := func() {
+		_ = os.Remove(slingLockInfoPath(lockPath))
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}
+	return release, true, nil
+}
+
+func writeSlingLockInfo(path string, info slingLockInfo) error {
+	data, err := json.MarshalIndent(info, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal sling lock metadata: %w", err)
+	}
+
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, data, 0644); err != nil { //nolint:gosec // local operational metadata
+		return fmt.Errorf("write temp sling lock metadata: %w", err)
+	}
+	if err := os.Rename(tmp, path); err != nil {
+		_ = os.Remove(tmp)
+		return fmt.Errorf("rename sling lock metadata: %w", err)
+	}
+	return nil
+}
+
+func readSlingLockInfo(path string) (*slingLockInfo, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+
+	var info slingLockInfo
+	if err := json.Unmarshal(data, &info); err != nil {
+		return nil, err
+	}
+	return &info, nil
+}
+
+func inspectSlingLocks(townRoot string, now time.Time) []slingLockTruth {
+	dir := slingLockDir(townRoot)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return nil
+	}
+
+	metadataByLock := make(map[string]string)
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".flock.json") {
+			continue
+		}
+		lockName := strings.TrimSuffix(entry.Name(), ".json")
+		metadataByLock[filepath.Join(dir, lockName)] = filepath.Join(dir, entry.Name())
+	}
+
+	var truths []slingLockTruth
+	for _, entry := range entries {
+		if entry.IsDir() || !strings.HasSuffix(entry.Name(), ".flock") {
+			continue
+		}
+
+		lockPath := filepath.Join(dir, entry.Name())
+		infoPath, hasMetadata := metadataByLock[lockPath]
+		if !hasMetadata {
+			truths = append(truths, inspectLegacySlingLock(lockPath, entry, now))
+			continue
+		}
+
+		info, err := readSlingLockInfo(infoPath)
+		if err != nil {
+			truths = append(truths, slingLockTruth{
+				Path:         infoPath,
+				State:        "invalid",
+				Recoverable:  true,
+				RecoveryNote: "metadata is unreadable",
+			})
+			continue
+		}
+
+		truth := slingLockTruth{
+			Path:       infoPath,
+			Kind:       string(info.Kind),
+			Subject:    info.Subject,
+			PID:        info.PID,
+			AcquiredAt: info.AcquiredAt,
+			Age:        now.Sub(info.AcquiredAt),
+		}
+
+		switch {
+		case info.PID <= 0 || !pidIsLive(info.PID):
+			truth.State = "stale"
+			truth.Recoverable = true
+			truth.RecoveryNote = "owner pid is not alive"
+		case truth.Age > slingLockAbandonAfter:
+			truth.State = "abandoned"
+			truth.Recoverable = true
+			truth.RecoveryNote = fmt.Sprintf("lock age %s exceeds %s", truth.Age.Round(time.Second), slingLockAbandonAfter)
+		default:
+			truth.State = "active"
+		}
+
+		truths = append(truths, truth)
+	}
+
+	return truths
+}
+
+func inspectLegacySlingLock(lockPath string, entry os.DirEntry, now time.Time) slingLockTruth {
+	info, err := entry.Info()
+	if err != nil {
+		info = nil
+	}
+	truth := slingLockTruth{
+		Path:        lockPath,
+		Kind:        legacySlingLockKind(entry.Name()),
+		Subject:     legacySlingLockSubject(entry.Name()),
+		Recoverable: false,
+	}
+	if info != nil {
+		truth.AcquiredAt = info.ModTime()
+		truth.Age = now.Sub(info.ModTime())
+	}
+
+	release, locked, err := tryAcquireLegacySlingLock(lockPath)
+	switch {
+	case err != nil:
+		truth.State = "legacy-opaque"
+		truth.RecoveryNote = "pre-metadata sling lock could not be inspected"
+	case locked:
+		release()
+		truth.State = "legacy-stale"
+		truth.Recoverable = true
+		truth.RecoveryNote = "pre-metadata sling lock file is not held"
+	default:
+		truth.State = "legacy-active"
+		truth.RecoveryNote = "pre-metadata sling lock is still held and has no owner metadata"
+	}
+
+	return truth
+}
+
+func legacySlingLockKind(name string) string {
+	base := strings.TrimSuffix(name, ".flock")
+	if strings.HasPrefix(base, "assignee_") {
+		return string(slingLockKindAssignee)
+	}
+	return string(slingLockKindBead)
+}
+
+func legacySlingLockSubject(name string) string {
+	base := strings.TrimSuffix(name, ".flock")
+	base = strings.TrimPrefix(base, "assignee_")
+	return base
+}
+
+func tryAcquireLegacySlingLock(lockPath string) (func(), bool, error) {
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0644) //nolint:gosec // local operational lock files
+	if err != nil {
+		return nil, false, err
+	}
+	if err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB); err != nil {
+		_ = f.Close()
+		if err == syscall.EWOULDBLOCK {
+			return nil, false, nil
+		}
+		return nil, false, err
+	}
+	return func() {
+		_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+		_ = f.Close()
+	}, true, nil
+}
+
+func recoverSlingLocks(townRoot string, now time.Time) (int, error) {
+	truths := inspectSlingLocks(townRoot, now)
+	recovered := 0
+
+	for _, truth := range truths {
+		if !truth.Recoverable {
+			continue
+		}
+
+		switch truth.State {
+		case "stale", "invalid":
+			if err := os.Remove(truth.Path); err != nil && !os.IsNotExist(err) {
+				return recovered, fmt.Errorf("removing stale sling lock metadata %s: %w", truth.Path, err)
+			}
+			recovered++
+		case "legacy-stale":
+			if err := os.Remove(truth.Path); err != nil && !os.IsNotExist(err) {
+				return recovered, fmt.Errorf("removing legacy stale sling lock %s: %w", truth.Path, err)
+			}
+			recovered++
+		case "abandoned":
+			if truth.PID > 0 && pidIsLive(truth.PID) {
+				proc, err := os.FindProcess(truth.PID)
+				if err == nil {
+					_ = proc.Signal(syscall.SIGTERM)
+				}
+				deadline := now.Add(3 * time.Second)
+				for time.Now().Before(deadline) {
+					if !pidIsLive(truth.PID) {
+						break
+					}
+					time.Sleep(100 * time.Millisecond)
+				}
+			}
+			if truth.PID > 0 && pidIsLive(truth.PID) {
+				return recovered, fmt.Errorf("sling lock for %s %q is still held by live pid %d after SIGTERM", truth.Kind, truth.Subject, truth.PID)
+			}
+			if err := os.Remove(truth.Path); err != nil && !os.IsNotExist(err) {
+				return recovered, fmt.Errorf("removing abandoned sling lock metadata %s: %w", truth.Path, err)
+			}
+			recovered++
+		}
+	}
+
+	return recovered, nil
+}
+
+func describeContendedSlingLock(lockPath string) string {
+	info, err := readSlingLockInfo(slingLockInfoPath(lockPath))
+	if err != nil {
+		return "owner unknown"
+	}
+
+	age := time.Since(info.AcquiredAt).Round(time.Second)
+	switch {
+	case info.PID <= 0 || !pidIsLive(info.PID):
+		return fmt.Sprintf("stale metadata from dead pid %d, run 'gt rig recover'", info.PID)
+	case age > slingLockAbandonAfter:
+		return fmt.Sprintf("held by pid %d for %s (older than %s, run 'gt rig recover' for explicit recovery)", info.PID, age, slingLockAbandonAfter)
+	default:
+		return fmt.Sprintf("held by pid %d for %s", info.PID, age)
+	}
+}

--- a/internal/cmd/sling_lock_test.go
+++ b/internal/cmd/sling_lock_test.go
@@ -1,10 +1,13 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"sync"
 	"testing"
+	"time"
 )
 
 func TestTryAcquireSlingBeadLock_Contention(t *testing.T) {
@@ -20,6 +23,9 @@ func TestTryAcquireSlingBeadLock_Contention(t *testing.T) {
 	if err != nil {
 		t.Fatalf("first lock acquire failed: %v", err)
 	}
+	if _, err := os.Stat(slingLockInfoPath(slingLockPathForBead(townRoot, beadID))); err != nil {
+		t.Fatalf("expected bead lock metadata to exist: %v", err)
+	}
 
 	release2, err := tryAcquireSlingBeadLock(townRoot, beadID)
 	if err == nil {
@@ -29,8 +35,14 @@ func TestTryAcquireSlingBeadLock_Contention(t *testing.T) {
 	if !strings.Contains(err.Error(), "already being slung") {
 		t.Fatalf("expected deterministic contention error, got: %v", err)
 	}
+	if !strings.Contains(err.Error(), "held by pid") {
+		t.Fatalf("expected ownership detail in contention error, got: %v", err)
+	}
 
 	release1()
+	if _, err := os.Stat(slingLockInfoPath(slingLockPathForBead(townRoot, beadID))); !os.IsNotExist(err) {
+		t.Fatalf("expected bead lock metadata to be removed on release, got: %v", err)
+	}
 
 	release3, err := tryAcquireSlingBeadLock(townRoot, beadID)
 	if err != nil {
@@ -66,6 +78,76 @@ func TestTryAcquireSlingAssigneeLock_Serialization(t *testing.T) {
 		t.Fatalf("lock acquire after release failed: %v", err)
 	}
 	release2()
+}
+
+func TestInspectAndRecoverSlingLocks_StaleMetadata(t *testing.T) {
+	townRoot := t.TempDir()
+	lockDir := slingLockDir(townRoot)
+	if err := os.MkdirAll(lockDir, 0755); err != nil {
+		t.Fatalf("mkdir lock dir: %v", err)
+	}
+
+	lockPath := filepath.Join(lockDir, "gt-test.flock")
+	info := slingLockInfo{
+		Kind:       slingLockKindBead,
+		Subject:    "gt-test",
+		PID:        999999999,
+		AcquiredAt: time.Now().Add(-time.Hour),
+	}
+	if err := writeSlingLockInfo(slingLockInfoPath(lockPath), info); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	truths := inspectSlingLocks(townRoot, time.Now())
+	if len(truths) != 1 {
+		t.Fatalf("expected 1 sling lock truth, got %d", len(truths))
+	}
+	if truths[0].State != "stale" {
+		t.Fatalf("expected stale state, got %+v", truths[0])
+	}
+
+	recovered, err := recoverSlingLocks(townRoot, time.Now())
+	if err != nil {
+		t.Fatalf("recoverSlingLocks: %v", err)
+	}
+	if recovered != 1 {
+		t.Fatalf("expected 1 recovered lock, got %d", recovered)
+	}
+	if _, err := os.Stat(slingLockInfoPath(lockPath)); !os.IsNotExist(err) {
+		t.Fatalf("expected stale metadata removed, got: %v", err)
+	}
+}
+
+func TestInspectAndRecoverSlingLocks_LegacyStaleFlock(t *testing.T) {
+	townRoot := t.TempDir()
+	lockDir := slingLockDir(townRoot)
+	if err := os.MkdirAll(lockDir, 0755); err != nil {
+		t.Fatalf("mkdir lock dir: %v", err)
+	}
+
+	lockPath := filepath.Join(lockDir, "assignee_test_lock.flock")
+	if err := os.WriteFile(lockPath, nil, 0644); err != nil {
+		t.Fatalf("write legacy flock: %v", err)
+	}
+
+	truths := inspectSlingLocks(townRoot, time.Now())
+	if len(truths) != 1 {
+		t.Fatalf("expected 1 lock truth, got %d", len(truths))
+	}
+	if truths[0].State != "legacy-stale" {
+		t.Fatalf("expected legacy-stale state, got %+v", truths[0])
+	}
+
+	recovered, err := recoverSlingLocks(townRoot, time.Now())
+	if err != nil {
+		t.Fatalf("recoverSlingLocks: %v", err)
+	}
+	if recovered != 1 {
+		t.Fatalf("expected 1 recovered legacy lock, got %d", recovered)
+	}
+	if _, err := os.Stat(lockPath); !os.IsNotExist(err) {
+		t.Fatalf("expected legacy flock removed, got: %v", err)
+	}
 }
 
 func TestTryAcquireSlingAssigneeLock_DifferentAgents(t *testing.T) {

--- a/internal/nudge/queue.go
+++ b/internal/nudge/queue.go
@@ -70,6 +70,29 @@ type QueuedNudge struct {
 	DeliverAfter time.Time `json:"deliver_after,omitempty"`
 }
 
+// QueueStats describes the operator-visible state of a session's nudge queue.
+type QueueStats struct {
+	Ready       int `json:"ready"`
+	Deferred    int `json:"deferred"`
+	Expired     int `json:"expired"`
+	Malformed   int `json:"malformed"`
+	StaleClaims int `json:"stale_claims"`
+	FreshClaims int `json:"fresh_claims"`
+}
+
+// Retained returns the entries worth keeping for eventual delivery.
+func (s QueueStats) Retained() int {
+	return s.Ready + s.Deferred
+}
+
+// PruneResult reports what a maintenance pass changed.
+type PruneResult struct {
+	Before         QueueStats `json:"before"`
+	RemovedExpired int        `json:"removed_expired"`
+	RemovedBadJSON int        `json:"removed_bad_json"`
+	RequeuedClaims int        `json:"requeued_claims"`
+}
+
 // queueDir returns the nudge queue directory for a given session.
 // Path: <townRoot>/.runtime/nudge_queue/<session>/
 func queueDir(townRoot, session string) string {
@@ -150,6 +173,27 @@ func Requeue(townRoot, session string, nudges []QueuedNudge) error {
 		}
 	}
 	return nil
+}
+
+// InspectQueue classifies a session's queued nudge files without mutating them.
+// This is intended for operator reporting and maintenance decisions.
+func InspectQueue(townRoot, session string) (QueueStats, error) {
+	return inspectQueue(townRoot, session, false)
+}
+
+// PruneQueue removes entries that are already undeliverable (expired or malformed)
+// and requeues stale .claimed files for later delivery.
+func PruneQueue(townRoot, session string) (PruneResult, error) {
+	before, err := inspectQueue(townRoot, session, true)
+	if err != nil {
+		return PruneResult{}, err
+	}
+	return PruneResult{
+		Before:         before,
+		RemovedExpired: before.Expired,
+		RemovedBadJSON: before.Malformed,
+		RequeuedClaims: before.StaleClaims,
+	}, nil
 }
 
 // Drain reads and removes all queued nudges for a session, returning them
@@ -276,6 +320,90 @@ func Drain(townRoot, session string) ([]QueuedNudge, error) {
 	}
 
 	return nudges, nil
+}
+
+func inspectQueue(townRoot, session string, repair bool) (QueueStats, error) {
+	dir := queueDir(townRoot, session)
+
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return QueueStats{}, nil
+		}
+		return QueueStats{}, fmt.Errorf("reading nudge queue: %w", err)
+	}
+
+	staleThreshold := nudgeConfig(townRoot).StaleClaimThresholdD()
+	now := time.Now()
+	var stats QueueStats
+
+	for _, entry := range entries {
+		if entry.IsDir() {
+			continue
+		}
+
+		name := entry.Name()
+		path := filepath.Join(dir, name)
+
+		if strings.Contains(name, ".claimed") {
+			info, err := entry.Info()
+			if err != nil {
+				continue
+			}
+			if now.Sub(info.ModTime()) > staleThreshold {
+				stats.StaleClaims++
+				if repair {
+					claimedIdx := strings.Index(name, ".claimed")
+					restoredPath := filepath.Join(dir, name[:claimedIdx])
+					if err := os.Rename(path, restoredPath); err != nil {
+						fmt.Fprintf(os.Stderr, "Warning: failed to requeue orphaned claim %s: %v\n", name, err)
+					}
+				}
+			} else {
+				stats.FreshClaims++
+			}
+			continue
+		}
+
+		if !strings.HasSuffix(name, ".json") {
+			continue
+		}
+
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return QueueStats{}, fmt.Errorf("reading nudge entry %s: %w", name, err)
+		}
+
+		var n QueuedNudge
+		if err := json.Unmarshal(data, &n); err != nil {
+			stats.Malformed++
+			if repair {
+				if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) {
+					return QueueStats{}, fmt.Errorf("removing malformed nudge %s: %w", name, rmErr)
+				}
+			}
+			continue
+		}
+
+		if !n.ExpiresAt.IsZero() && now.After(n.ExpiresAt) {
+			stats.Expired++
+			if repair {
+				if rmErr := os.Remove(path); rmErr != nil && !os.IsNotExist(rmErr) {
+					return QueueStats{}, fmt.Errorf("removing expired nudge %s: %w", name, rmErr)
+				}
+			}
+			continue
+		}
+
+		if !n.DeliverAfter.IsZero() && now.Before(n.DeliverAfter) {
+			stats.Deferred++
+			continue
+		}
+
+		stats.Ready++
+	}
+
+	return stats, nil
 }
 
 // Pending returns the count of queued nudges for a session without draining.

--- a/internal/nudge/queue_test.go
+++ b/internal/nudge/queue_test.go
@@ -451,6 +451,112 @@ func TestDrainSweepsOrphanedClaims(t *testing.T) {
 	}
 }
 
+func TestInspectQueueClassifiesRetainedAndStale(t *testing.T) {
+	townRoot := t.TempDir()
+	session := "gt-test-inspect"
+	dir := filepath.Join(townRoot, ".runtime", "nudge_queue", session)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Enqueue(townRoot, session, QueuedNudge{
+		Sender:  "ready",
+		Message: "deliver now",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Enqueue(townRoot, session, QueuedNudge{
+		Sender:       "later",
+		Message:      "deliver later",
+		DeliverAfter: time.Now().Add(10 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Enqueue(townRoot, session, QueuedNudge{
+		Sender:    "expired",
+		Message:   "too old",
+		ExpiresAt: time.Now().Add(-10 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "bad.json"), []byte("not-json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	staleClaimPath := filepath.Join(dir, "stale.json.claimed.deadbeef")
+	if err := os.WriteFile(staleClaimPath, []byte(`{"sender":"ghost","message":"hi"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-10 * time.Minute)
+	if err := os.Chtimes(staleClaimPath, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := InspectQueue(townRoot, session)
+	if err != nil {
+		t.Fatalf("InspectQueue: %v", err)
+	}
+	if stats.Ready != 1 || stats.Deferred != 1 || stats.Expired != 1 || stats.Malformed != 1 || stats.StaleClaims != 1 {
+		t.Fatalf("unexpected stats: %+v", stats)
+	}
+}
+
+func TestPruneQueueRemovesOnlyUndeliverableEntries(t *testing.T) {
+	townRoot := t.TempDir()
+	session := "gt-test-prune"
+	dir := filepath.Join(townRoot, ".runtime", "nudge_queue", session)
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Enqueue(townRoot, session, QueuedNudge{
+		Sender:  "ready",
+		Message: "keep ready",
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Enqueue(townRoot, session, QueuedNudge{
+		Sender:       "later",
+		Message:      "keep deferred",
+		DeliverAfter: time.Now().Add(10 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := Enqueue(townRoot, session, QueuedNudge{
+		Sender:    "expired",
+		Message:   "drop expired",
+		ExpiresAt: time.Now().Add(-10 * time.Minute),
+	}); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "bad.json"), []byte("not-json"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	staleClaimPath := filepath.Join(dir, "stale.json.claimed.deadbeef")
+	if err := os.WriteFile(staleClaimPath, []byte(`{"sender":"ghost","message":"rescue"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	oldTime := time.Now().Add(-10 * time.Minute)
+	if err := os.Chtimes(staleClaimPath, oldTime, oldTime); err != nil {
+		t.Fatal(err)
+	}
+
+	result, err := PruneQueue(townRoot, session)
+	if err != nil {
+		t.Fatalf("PruneQueue: %v", err)
+	}
+	if result.RemovedExpired != 1 || result.RemovedBadJSON != 1 || result.RequeuedClaims != 1 {
+		t.Fatalf("unexpected prune result: %+v", result)
+	}
+
+	stats, err := InspectQueue(townRoot, session)
+	if err != nil {
+		t.Fatalf("InspectQueue after prune: %v", err)
+	}
+	if stats.Ready != 2 || stats.Deferred != 1 || stats.Expired != 0 || stats.Malformed != 0 || stats.StaleClaims != 0 {
+		t.Fatalf("unexpected post-prune stats: %+v", stats)
+	}
+}
+
 func TestConcurrentEnqueueNoDuplicateLoss(t *testing.T) {
 	townRoot := t.TempDir()
 	session := "gt-test-concurrent"


### PR DESCRIPTION
## Summary
- add `rig doctor` and `rig recover` operator surfaces
- add nudge queue inspection/prune helpers
- make sling lock contention and recovery state more visible

## Verification
- `go test ./internal/nudge -run 'Test(InspectQueueClassifiesRetainedAndStale|PruneQueueRemovesOnlyUndeliverableEntries)$'`\n- `go test ./internal/cmd -run 'Test(TryAcquireSlingBeadLock_Contention|TryAcquireSlingAssigneeLock_Serialization|TryAcquireSlingAssigneeLock_DifferentAgents|InspectAndRecoverSlingLocks_StaleMetadata|InspectAndRecoverSlingLocks_LegacyStaleFlock)$'`\n\n## Known issue\n- stays draft because `TestInspectAndRecoverSlingLocks_StaleMetadata` currently fails in this branch