### PR TITLE
fix(daemon): kill leftover witness/refinery on docked rigs

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1198,6 +1198,16 @@ func (d *Daemon) ensureWitnessRunning(rigName string) {
 	// Check rig operational state before auto-starting
 	if operational, reason := d.isRigOperational(rigName); !operational {
 		d.logger.Printf("Skipping witness auto-start for %s: %s", rigName, reason)
+		// Kill leftover witness session if rig is not operational (docked/parked).
+		// Without this, sessions started before the rig was docked survive until
+		// the next explicit 'gt rig dock' command. (hq-snx61)
+		name := session.WitnessSessionName(session.PrefixFor(rigName))
+		if exists, _ := d.tmux.HasSession(name); exists {
+			d.logger.Printf("Killing leftover witness %s (rig %s)", name, reason)
+			if err := d.tmux.KillSessionWithProcesses(name); err != nil {
+				d.logger.Printf("Error killing leftover witness %s: %v", name, err)
+			}
+		}
 		return
 	}
 
@@ -1247,6 +1257,16 @@ func (d *Daemon) ensureRefineryRunning(rigName string) {
 	// Check rig operational state before auto-starting
 	if operational, reason := d.isRigOperational(rigName); !operational {
 		d.logger.Printf("Skipping refinery auto-start for %s: %s", rigName, reason)
+		// Kill leftover refinery session if rig is not operational (docked/parked).
+		// Without this, sessions started before the rig was docked survive until
+		// the next explicit 'gt rig dock' command. (hq-snx61)
+		name := session.RefinerySessionName(session.PrefixFor(rigName))
+		if exists, _ := d.tmux.HasSession(name); exists {
+			d.logger.Printf("Killing leftover refinery %s (rig %s)", name, reason)
+			if err := d.tmux.KillSessionWithProcesses(name); err != nil {
+				d.logger.Printf("Error killing leftover refinery %s: %v", name, err)
+			}
+		}
 		return
 	}
 


### PR DESCRIPTION
## Summary

- Daemon correctly prevents auto-starting agents for docked/parked rigs via `isRigOperational()`
- However, pre-existing sessions started before the rig was docked survive indefinitely
- Now `ensureWitnessRunning()` and `ensureRefineryRunning()` actively kill sessions for non-operational rigs on each heartbeat
- Matches the existing pattern in `killWitnessSessions()`/`killRefinerySessions()` used when patrols are disabled entirely

## Repro

1. Start witness/refinery for a rig (`gt rig start sundr`)
2. Dock the rig (`gt rig dock sundr`) -- this kills sessions
3. Something else starts agents (manual start, stale tmux session, etc.)
4. Daemon heartbeat fires, sees rig is docked, skips auto-start -- but does NOT kill the existing session
5. Agent runs indefinitely on a docked rig, burning API credits

## Test plan

- [ ] Verify daemon kills leftover witness session when rig is docked
- [ ] Verify daemon kills leftover refinery session when rig is docked
- [ ] Verify normal (undocked) witness/refinery auto-start still works
- [ ] Verify `isRigOperational` fail-safe ("Dolt unavailable") also triggers cleanup

🤖 Generated with [Claude Code](https://claude.com/claude-code)