### PR TITLE
fix: clear hook_bead on gt done and treat missing beads as closed (gt-qbh)

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -457,6 +457,7 @@ type AgentFieldUpdates struct {
 	ActiveMR          *string
 	NotificationLevel *string
 	Mode              *string
+	HookBead          *string // Clear hook_bead on completion (gt-qbh)
 	// Completion metadata fields (gt-x7t9)
 	ExitType       *string
 	MRID           *string
@@ -509,6 +510,9 @@ func (b *Beads) UpdateAgentDescriptionFields(id string, updates AgentFieldUpdate
 	}
 	if updates.Mode != nil {
 		fields.Mode = *updates.Mode
+	}
+	if updates.HookBead != nil {
+		fields.HookBead = *updates.HookBead
 	}
 	// Completion metadata fields (gt-x7t9)
 	if updates.ExitType != nil {

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -1450,7 +1450,15 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) {
 	}
 
 doneStateUpdate:
-	// No ClearHookBead call needed — agent bead hook slot is no longer maintained (hq-l6mm5).
+	// Clear hook_bead on the agent bead (gt-qbh). The hq-l6mm5 refactor made
+	// SetHookBead/ClearHookBead no-ops, but the witness still reads the
+	// hook_bead field from the agent bead snapshot. If the hooked bead is a
+	// wisp that gets reaped, the witness can't verify it was closed and flags
+	// the polecat as a zombie. Clearing hook_bead prevents this false positive.
+	emptyHook := ""
+	if err := bd.UpdateAgentDescriptionFields(agentBeadID, beads.AgentFieldUpdates{HookBead: &emptyHook}); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: couldn't clear hook_bead on %s: %v\n", agentBeadID, err)
+	}
 
 	// Purge closed ephemeral beads (wisps) accumulated during this and prior sessions.
 	// Without this, closed wisps from mol-polecat-work steps, mol-witness-patrol cycles,

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1350,12 +1350,18 @@ func detectZombieDeadSession(bd *BdCli, workDir, townRoot, rigName, polecatName,
 		// Spawning for too long — fall through to zombie handling
 	}
 
-	// A polecat whose hook bead is already CLOSED completed its work
-	// successfully. The dead session is expected (gt done kills it).
+	// A polecat whose hook bead is already CLOSED (or reaped) completed its
+	// work successfully. The dead session is expected (gt done kills it).
 	// Don't flag as zombie or trigger re-dispatch. (gt-sy8)
 	// gt-dsgp: Don't nuke — sandbox preserved for reuse.
-	if snapHook != "" && getBeadStatus(bd, workDir, snapHook) == "closed" {
-		return ZombieResult{}, false
+	// gt-qbh: Treat missing beads (empty status) as closed. Wisp beads get
+	// reaped after completion, so getBeadStatus returns "" for reaped wisps.
+	// A missing bead is not evidence of a crash.
+	if snapHook != "" {
+		hookStatus := getBeadStatus(bd, workDir, snapHook)
+		if hookStatus == "closed" || hookStatus == "" {
+			return ZombieResult{}, false
+		}
 	}
 
 	// TOCTOU guard: verify session wasn't recreated since detection.


### PR DESCRIPTION
## Summary
- gt done now clears `hook_bead` on the agent bead via `UpdateAgentDescriptionFields`. The hq-l6mm5 refactor made Set/ClearHookBead no-ops, but the witness still reads `hook_bead` from the snapshot — stale values caused false zombie classification.
- Witness zombie detection treats missing beads (empty status from `getBeadStatus`) as closed. Wisp hook beads get reaped after completion, making them invisible to the witness.

## Test plan
- [x] `go test ./internal/beads/ -run Agent` — all pass
- [x] `go test ./internal/witness/ -run Zombie` — all pass
- [ ] Verify false positive CRASHED_POLECAT mails stop after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)