### PR TITLE
fix: guard submodule init with git tracking check (gt-6g2)

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1185,10 +1185,10 @@ func (g *Git) submoduleReferencePath() string {
 }
 
 // isValidSubmoduleReference checks if a path is suitable as a --reference
-// for git submodule update. It must have .gitmodules and not be a shallow clone
-// (git rejects shallow repos as references).
+// for git submodule update. It must have a tracked .gitmodules and not be a
+// shallow clone (git rejects shallow repos as references).
 func isValidSubmoduleReference(repoPath string) bool {
-	if _, err := os.Stat(filepath.Join(repoPath, ".gitmodules")); err != nil {
+	if !hasTrackedGitmodules(repoPath) {
 		return false
 	}
 	// Check if shallow — git rev-parse --is-shallow-repository
@@ -1786,8 +1786,7 @@ type SubmoduleChange struct {
 // to share git objects from a local clone instead of fetching from remote.
 // This makes submodule init near-instant for large submodules (e.g. 655MB gitlabhq).
 func InitSubmodules(repoPath string, referencePath ...string) error {
-	gitmodules := filepath.Join(repoPath, ".gitmodules")
-	if _, err := os.Stat(gitmodules); os.IsNotExist(err) {
+	if !hasTrackedGitmodules(repoPath) {
 		return nil
 	}
 
@@ -1796,8 +1795,7 @@ func InitSubmodules(repoPath string, referencePath ...string) error {
 	// Use --reference to share objects from a local clone (avoids remote fetch)
 	if len(referencePath) > 0 && referencePath[0] != "" {
 		refPath := referencePath[0]
-		refModules := filepath.Join(refPath, ".gitmodules")
-		if _, err := os.Stat(refModules); err == nil {
+		if hasTrackedGitmodules(refPath) {
 			args = append(args, "--reference", refPath)
 		}
 	}
@@ -1809,6 +1807,21 @@ func InitSubmodules(repoPath string, referencePath ...string) error {
 		return fmt.Errorf("initializing submodules: %s", strings.TrimSpace(stderr.String()))
 	}
 	return nil
+}
+
+// hasTrackedGitmodules checks whether .gitmodules exists on disk AND is tracked
+// by git. After a submodule-to-monorepo migration, .gitmodules may linger as an
+// untracked file (e.g., in a stale mayor/rig clone or bare repo worktree) even
+// though it has been removed from the repository. Checking only os.Stat would
+// incorrectly trigger submodule init on these stale artifacts.
+func hasTrackedGitmodules(repoPath string) bool {
+	gitmodules := filepath.Join(repoPath, ".gitmodules")
+	if _, err := os.Stat(gitmodules); os.IsNotExist(err) {
+		return false
+	}
+	// Verify .gitmodules is actually tracked in the index.
+	cmd := exec.Command("git", "-C", repoPath, "ls-files", "--error-unmatch", ".gitmodules")
+	return cmd.Run() == nil
 }
 
 // InitSparseCheckout initializes sparse checkout with cone mode and configures

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1125,6 +1125,37 @@ func TestInitSubmodules_NoSubmodules(t *testing.T) {
 	}
 }
 
+func TestInitSubmodules_SkipsUntrackedGitmodules(t *testing.T) {
+	dir := initTestRepo(t)
+	gitmodules := filepath.Join(dir, ".gitmodules")
+	content := []byte("[submodule \"libs/sub\"]\n\tpath = libs/sub\n\turl = https://example.com/sub.git\n")
+	if err := os.WriteFile(gitmodules, content, 0644); err != nil {
+		t.Fatalf("write .gitmodules: %v", err)
+	}
+	if err := InitSubmodules(dir); err != nil {
+		t.Fatalf("InitSubmodules should skip untracked .gitmodules: %v", err)
+	}
+}
+
+func TestHasTrackedGitmodules(t *testing.T) {
+	dir := initTestRepo(t)
+	if hasTrackedGitmodules(dir) {
+		t.Fatal("expected false when .gitmodules doesn't exist")
+	}
+	gitmodules := filepath.Join(dir, ".gitmodules")
+	if err := os.WriteFile(gitmodules, []byte("[submodule \"x\"]\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if hasTrackedGitmodules(dir) {
+		t.Fatal("expected false when .gitmodules exists but is untracked")
+	}
+	runGit(t, dir, "add", ".gitmodules")
+	runGit(t, dir, "commit", "-m", "add gitmodules")
+	if !hasTrackedGitmodules(dir) {
+		t.Fatal("expected true when .gitmodules is tracked")
+	}
+}
+
 func TestInitSubmodules_WithSubmodules(t *testing.T) {
 	parent, _ := initTestRepoWithSubmodule(t)
 

--- a/internal/hooks/installer.go
+++ b/internal/hooks/installer.go
@@ -165,11 +165,7 @@ func resolveAndSubstitute(provider, hooksFile, role string) ([]byte, error) {
 }
 
 // writeTemplate resolves a template, substitutes placeholders, and writes it to targetPath.
-<<<<<<< HEAD
-func writeTemplate(provider, role, hooksDir, hooksFile, targetPath string) error {
-=======
 func writeTemplate(provider, role, hooksFile, targetPath string) error {
->>>>>>> b0a01735 (fix(lint): remove unused hooksDir param from writeTemplate)
 	content, err := resolveAndSubstitute(provider, hooksFile, role)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary
- `InitSubmodules` and `isValidSubmoduleReference` now check that `.gitmodules` is **tracked by git** (via `git ls-files --error-unmatch`), not just that it exists on disk
- After a submodule-to-monorepo migration, `.gitmodules` can linger as an untracked file in stale clones (e.g., `mayor/rig`), causing `gt sling` to fail with invalid submodule URLs
- New `hasTrackedGitmodules()` helper used by both functions

## Test plan
- [x] `TestInitSubmodules_SkipsUntrackedGitmodules` — verifies untracked `.gitmodules` is ignored
- [x] `TestHasTrackedGitmodules` — verifies three states: missing, untracked, tracked
- [x] `TestInitSubmodules_WithSubmodules` — existing test still passes
- [x] Full submodule test suite passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)