### PR TITLE
fix: resolve merge conflict markers in hooks/installer.go

### DIFF
--- a/internal/hooks/installer.go
+++ b/internal/hooks/installer.go
@@ -165,11 +165,7 @@ func resolveAndSubstitute(provider, hooksFile, role string) ([]byte, error) {
 }
 
 // writeTemplate resolves a template, substitutes placeholders, and writes it to targetPath.
-<<<<<<< HEAD
-func writeTemplate(provider, role, hooksDir, hooksFile, targetPath string) error {
-=======
 func writeTemplate(provider, role, hooksFile, targetPath string) error {
->>>>>>> b0a01735 (fix(lint): remove unused hooksDir param from writeTemplate)
 	content, err := resolveAndSubstitute(provider, hooksFile, role)
 	if err != nil {
 		return err


### PR DESCRIPTION
## Summary

- Commit `5a18dc6a` ("fix(lint): remove unused hooksDir param from writeTemplate") introduced unresolved merge conflict markers into `internal/hooks/installer.go` on main, breaking `make build` for anyone building from HEAD.
- Resolves the conflict by keeping the lint-fixed signature without the unused `hooksDir` parameter, which matches the caller at line 61.

## Test plan

- [x] `make build` succeeds
- [x] `grep -r '<<<<<<' internal/hooks/` returns no results

Fixes #3333

Made with [Cursor](https://cursor.com)