### PR TITLE
fix(lint): check resp.Body.Close error in github client

### DIFF
--- a/internal/github/client.go
+++ b/internal/github/client.go
@@ -98,7 +98,7 @@ func (c *Client) restRequest(ctx context.Context, method, path string, body any,
 	if err != nil {
 		return fmt.Errorf("github: %s %s: %w", method, path, err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {
@@ -144,7 +144,7 @@ func (c *Client) graphqlRequest(ctx context.Context, query string, variables map
 	if err != nil {
 		return fmt.Errorf("github: graphql: %w", err)
 	}
-	defer resp.Body.Close()
+	defer func() { _ = resp.Body.Close() }()
 
 	respBody, err := io.ReadAll(resp.Body)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Commit `848fe202` (fix-merge PR #3311) added `internal/github/client.go` with two unchecked `resp.Body.Close` calls, breaking the `errcheck` linter on main.
- This blocks CI for every open PR targeting main.
- Fix: wrap both `defer resp.Body.Close()` calls with `defer func() { _ = resp.Body.Close() }()` to explicitly discard the error.

## Test plan

- [x] `make build` succeeds
- [x] `golangci-lint run ./internal/github/...` passes

Fixes #3348

Made with [Cursor](https://cursor.com)