### PR TITLE
fix(deacon): stop undocking rigs that Mayor intentionally docked

### DIFF
--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -500,11 +500,14 @@ gt rig status <rig>
 # Check the Status: line - if DOCKED or PARKED, skip entirely
 ```
 
-DOCKED rigs are globally shut down - do NOT:
+DOCKED rigs are intentionally offline (Mayor or human docked them). Do NOT:
 - Check their witness/refinery status
 - Send health pings
 - Attempt restarts
-Simply skip them and move to the next rig.
+- Undock the rig (NEVER run `gt rig undock`)
+- Escalate or send mail about a docked rig being offline
+- "Restore" a docked rig to operational status
+A docked rig is NOT broken. It is off on purpose. Skip it entirely.
 
 **IMPORTANT: Idle Town Protocol**
 Before sending health check nudges, check if the town is idle:

--- a/internal/templates/roles/deacon.md.tmpl
+++ b/internal/templates/roles/deacon.md.tmpl
@@ -316,7 +316,7 @@ shows Claude processes from ALL towns — not just yours.
 ## Responsibilities
 
 **You ARE responsible for:**
-- Keeping Mayor and Witnesses alive
+- Keeping Mayor and Witnesses alive **on operational (undocked, unparked) rigs**
 - Processing lifecycle requests
 - Running scheduled plugins
 - Escalating issues you can't resolve
@@ -326,6 +326,21 @@ shows Claude processes from ALL towns — not just yours.
 - Work assignment (Mayor does that)
 - Merge processing (Refineries do that)
 - Processes belonging to other Gas Town instances on the same machine
+
+## Docked Rigs Are Off-Limits
+
+**CRITICAL**: Docked rigs (`status:docked`) are intentionally offline. The Mayor
+or human docked them for a reason. You MUST NOT:
+
+- Undock a docked rig (`{{ cmd }} rig undock`)
+- Start witness/refinery on a docked rig
+- Escalate about a docked rig being offline
+- Send mail about a docked rig's agents being stopped
+
+A docked rig is not broken — it is parked on purpose. Treat it as invisible.
+Only `{{ cmd }} rig list` output marked as operational is your responsibility.
+If `{{ cmd }} rig list` shows a rig as docked, skip it entirely — no checks,
+no escalation, no action.
 
 ## State Files
 


### PR DESCRIPTION
## Summary
- Deacon health-scan patrol step already says to skip docked rigs, but the deacon ignores this and "restores" docked rigs by undocking them and restarting witness/refinery
- This creates an undock/dock fight loop when the Mayor intentionally docks a rig
- **Role template**: Added explicit "Docked Rigs Are Off-Limits" section making docked rigs invisible to the deacon -- no checks, no escalation, no action
- **Patrol formula**: Expanded the skip-docked instruction to explicitly prohibit undocking, escalating about, or "restoring" docked rigs

## Test plan
- [ ] Dock a rig with `gt rig dock <rig>`, verify deacon patrol skips it entirely
- [ ] Verify deacon does not send escalation mail about docked rigs
- [ ] Verify operational rigs still get health-scanned normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)