### PR TITLE
fix(beads): keep agent state updates on target db

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -426,10 +426,18 @@ func (b *Beads) ResetAgentBeadForReuse(id, reason string) error {
 // then syncs the description's agent_state field to match (gt-ulom).
 func (b *Beads) UpdateAgentState(id string, state string) (retErr error) {
 	defer func() { telemetry.RecordAgentStateChange(context.Background(), id, state, nil, retErr) }()
-	// Update agent state using bd set-state command (bd 0.62.0+).
-	// Use runWithRouting so bd can resolve cross-prefix agent beads (e.g., wa-*
-	// agent beads from hq context) via routes.jsonl instead of BEADS_DIR.
-	_, err := b.runWithRouting("set-state", id, "agent_state="+state)
+	// Resolve the concrete target DB first, then run set-state there.
+	// Using runWithRouting here strips BEADS_DIR, which can send set-state to a
+	// different database than CreateAgentBead/Update when the wrapper already has
+	// an explicit target beads dir. That creates "missing parent row" failures in
+	// Dolt when the agent bead exists in one DB but set-state hits another.
+	targetDir := ResolveRoutingTarget(b.getTownRoot(), id, b.getResolvedBeadsDir())
+	target := b
+	if targetDir != b.getResolvedBeadsDir() {
+		target = NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
+	}
+
+	_, err := target.run("set-state", id, "agent_state="+state)
 	if err != nil {
 		return fmt.Errorf("updating agent state: %w", err)
 	}
@@ -438,7 +446,7 @@ func (b *Beads) UpdateAgentState(id string, state string) (retErr error) {
 	// Without this, the description stays stale (e.g., "spawning" after the
 	// column transitions to "working"), causing bd show and dashboards to
 	// display incorrect state after idle polecat reuse via gt sling.
-	_ = b.UpdateAgentDescriptionFields(id, AgentFieldUpdates{AgentState: &state})
+	_ = target.UpdateAgentDescriptionFields(id, AgentFieldUpdates{AgentState: &state})
 
 	return nil
 }

--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -1,6 +1,7 @@
 package beads
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -70,6 +71,80 @@ esac
 	t.Setenv("MOCK_BD_SHOW_OUTPUT", showOutput)
 }
 
+func installMockBDRequireExplicitBeadsDir(t *testing.T, expectedBeadsDir string) {
+	t.Helper()
+
+	binDir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		scriptPath := filepath.Join(binDir, "bd.cmd")
+		script := fmt.Sprintf(`@echo off
+setlocal EnableDelayedExpansion
+set "cmd="
+:findcmd
+if "%%~1"=="" goto havecmd
+set "arg=%%~1"
+if /I "!arg:~0,2!"=="--" (
+  shift
+  goto findcmd
+)
+set "cmd=%%~1"
+:havecmd
+set "target=%%BEADS_DIR%%"
+if "%%target%%"=="" set "target=%%CD%%\.beads"
+if /I not "%%target%%"=="%s" (
+  >&2 echo wrong target %%target%%
+  exit /b 9
+)
+if /I "%%cmd%%"=="version" exit /b 0
+if /I "%%cmd%%"=="show" (
+  echo([{"id":"gt-gastown-polecat-nux","title":"Polecat nux","issue_type":"agent","labels":["gt:agent"],"description":"role_type: polecat\nrig: gastown\nagent_state: idle\nhook_bead: null","agent_state":"idle"}]
+  exit /b 0
+)
+exit /b 0
+`, expectedBeadsDir)
+		if err := os.WriteFile(scriptPath, []byte(script), 0644); err != nil {
+			t.Fatalf("write mock bd: %v", err)
+		}
+		t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+		return
+	}
+
+	script := fmt.Sprintf(`#!/bin/sh
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+
+target="${BEADS_DIR:-$(pwd)/.beads}"
+if [ "$target" != "%s" ]; then
+  echo "wrong target $target" >&2
+  exit 9
+fi
+
+case "$cmd" in
+  version)
+    exit 0
+    ;;
+  show)
+    printf '%%s\n' '[{"id":"gt-gastown-polecat-nux","title":"Polecat nux","issue_type":"agent","labels":["gt:agent"],"description":"role_type: polecat\nrig: gastown\nagent_state: idle\nhook_bead: null","agent_state":"idle"}]'
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`, expectedBeadsDir)
+	scriptPath := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write mock bd: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
 func TestGetAgentBead_PrefersStructuredAgentState(t *testing.T) {
 	tmpDir := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(tmpDir, ".beads"), 0755); err != nil {
@@ -115,6 +190,21 @@ func TestGetAgentBead_FallsBackToDescriptionAgentState(t *testing.T) {
 	}
 	if fields.AgentState != "spawning" {
 		t.Fatalf("fields.AgentState = %q, want %q", fields.AgentState, "spawning")
+	}
+}
+
+func TestUpdateAgentState_UsesExplicitBeadsDir(t *testing.T) {
+	workDir := t.TempDir()
+	targetBeadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(targetBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir target .beads: %v", err)
+	}
+
+	installMockBDRequireExplicitBeadsDir(t, targetBeadsDir)
+
+	bd := NewWithBeadsDir(workDir, targetBeadsDir)
+	if err := bd.UpdateAgentState("gt-gastown-polecat-nux", "spawning"); err != nil {
+		t.Fatalf("UpdateAgentState: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- run `bd set-state` against the same explicit beads DB as the agent bead itself
- avoid stripping `BEADS_DIR` in `UpdateAgentState`, which could send the state update to a different database
- add a regression test that fails if agent state updates stop honoring the explicit target beads dir

## Testing
- go test ./internal/beads -run 'Test(UpdateAgentState_UsesExplicitBeadsDir|GetAgentBead_PrefersStructuredAgentState|GetAgentBead_FallsBackToDescriptionAgentState)$' -count=1