### PR TITLE
fix(dolt-archive): skip databases without issues table

### DIFF
--- a/plugins/dolt-archive/run.sh
+++ b/plugins/dolt-archive/run.sh
@@ -92,6 +92,12 @@ for DB in "${PROD_DBS[@]}"; do
 
   log "Exporting $DB..."
 
+  # Skip databases without an issues table (e.g. gastown config DB)
+  if ! dolt_query "$DB" "SHOW TABLES LIKE 'issues'" 2>/dev/null | grep -q 'issues'; then
+    log "  $DB: skipped (no issues table)"
+    continue
+  fi
+
   # Export via Dolt SQL (reliable for all databases with an issues table)
   if dolt_query_json "$DB" "SELECT * FROM issues ORDER BY id" > "$EXPORT_FILE" 2>/dev/null && [[ -s "$EXPORT_FILE" ]]; then
     LINE_COUNT=$(wc -l < "$EXPORT_FILE" | tr -d ' ')


### PR DESCRIPTION
## Summary
- dolt-archive plugin now checks for `issues` table before attempting JSONL export
- Databases without the table (e.g. gastown config DB) are skipped with a log message
- Prevents false CRITICAL escalation alerts

## Test plan
- [x] Verified gastown DB triggers "skipped (no issues table)" path
- [x] Beads databases with issues table still export normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)