### PR TITLE
fix(plugin): give dogs actionable recording instructions

### DIFF
--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -220,9 +220,9 @@ func (p *Plugin) FormatMailBody() string {
 				"Run this command EXACTLY. Do NOT interpret the plugin.md instructions.\n"+
 				"Do NOT write your own implementation. Just run the script and report the output.\n\n"+
 				"After completion:\n"+
-				"1. Create a wisp to record the result (success/failure)\n"+
-				"2. Run `gt dog done` — this clears your work and auto-terminates the session\n",
-			p.Name, p.Description, p.Path)
+				"1. The script should record a plugin-run receipt. If it did not, create one with `bd create --ephemeral` using labels `type:plugin-run`, `plugin:%s`, and `result:<outcome>`.\n"+
+				"2. Run `gt dog done` — this clears your work and auto-terminates the session. Run this even if recording fails.\n",
+			p.Name, p.Description, p.Path, p.Name)
 	}
 
 	var sb strings.Builder
@@ -241,8 +241,8 @@ func (p *Plugin) FormatMailBody() string {
 	sb.WriteString(p.Instructions)
 	sb.WriteString("\n\n---\n\n")
 	sb.WriteString("After completion:\n")
-	sb.WriteString("1. Create a wisp to record the result (success/failure)\n")
-	sb.WriteString("2. Run `gt dog done` — this clears your work and auto-terminates the session\n")
+	sb.WriteString("1. Follow the plugin's recording instructions above. If none are provided, create a receipt with `bd create --ephemeral` using labels `type:plugin-run`, `plugin:" + p.Name + "`, and `result:<outcome>`.\n")
+	sb.WriteString("2. Run `gt dog done` — this clears your work and auto-terminates the session. Run this even if recording fails.\n")
 
 	return sb.String()
 }


### PR DESCRIPTION
## Summary

- `FormatMailBody()` told dog agents to "Create a wisp to record the result" without specifying which command to use
- Dogs tried nonexistent commands like `gt wisp create`, got stuck, never called `gt dog done`, and tasks piled up in `delivery:pending` forever
- Now both code paths (script-based and markdown-based plugins) name `bd create --ephemeral` as the fallback recording command with required labels, while deferring to plugin-specific instructions when present
- Emphasizes that `gt dog done` must run even if recording fails — preventing the stuck-task cascade

## Test plan

- [x] `go build ./cmd/gt`
- [x] `go test ./internal/plugin/...`
- [ ] Deploy and verify dogs complete plugin tasks without getting stuck on the recording step

🤖 Generated with [Claude Code](https://claude.com/claude-code)