### PR TITLE
fix(plugin): check heartbeat.json instead of legacy .deacon-heartbeat

### DIFF
--- a/plugins/stuck-agent-dog/run.sh
+++ b/plugins/stuck-agent-dog/run.sh
@@ -107,18 +107,14 @@ else
     log "  Process alive: pid=$DEACON_PID comm=$DEACON_COMM"
   fi
 
-  HEARTBEAT_FILE="$TOWN_ROOT/deacon/.deacon-heartbeat"
+  HEARTBEAT_FILE="$TOWN_ROOT/deacon/heartbeat.json"
   if [ -f "$HEARTBEAT_FILE" ]; then
-    if [ "$(uname)" = "Darwin" ]; then
-      HEARTBEAT_TIME=$(stat -f %m "$HEARTBEAT_FILE" 2>/dev/null)
-    else
-      HEARTBEAT_TIME=$(stat -c %Y "$HEARTBEAT_FILE" 2>/dev/null)
-    fi
+    HEARTBEAT_TIME=$(stat -f %m "$HEARTBEAT_FILE" 2>/dev/null || stat -c %Y "$HEARTBEAT_FILE" 2>/dev/null)
     NOW=$(date +%s)
     HEARTBEAT_AGE=$(( NOW - HEARTBEAT_TIME ))
 
-    if [ "$HEARTBEAT_AGE" -gt 600 ]; then
-      log "  STUCK: Deacon heartbeat stale (${HEARTBEAT_AGE}s old)"
+    if [ "$HEARTBEAT_AGE" -gt 1200 ]; then
+      log "  STUCK: Deacon heartbeat stale (${HEARTBEAT_AGE}s old, >20m threshold)"
       DEACON_ISSUE="stuck_heartbeat_${HEARTBEAT_AGE}s"
     else
       log "  OK: Deacon heartbeat ${HEARTBEAT_AGE}s old"


### PR DESCRIPTION
## Summary

- `stuck-agent-dog/run.sh` checked the legacy `.deacon-heartbeat` file with a 600s threshold
- The canonical heartbeat file is `heartbeat.json` (written by `WriteHeartbeat()` since commit 26bea20a)
- This mismatch caused false-positive "stuck deacon" escalations even when the deacon was healthy
- Now checks `heartbeat.json` with a 1200s threshold, matching the plugin's own `plugin.md` documentation

## Test plan

- [x] Verified `heartbeat.json` is the file written by `WriteHeartbeat()` in `internal/deacon/heartbeat.go`
- [x] Confirmed `plugin.md` already documents `heartbeat.json` with 1200s threshold
- [ ] Deploy and verify no more false-positive stuck deacon alerts

🤖 Generated with [Claude Code](https://claude.com/claude-code)