### PR TITLE
fix: refinery respects require_review=true (gt-ihp)

### DIFF
--- a/internal/cmd/patrol_helpers_test.go
+++ b/internal/cmd/patrol_helpers_test.go
@@ -138,6 +138,7 @@ func TestBuildRefineryPatrolVars_FullConfig(t *testing.T) {
 		"delete_merged_branches":              "true",
 		"judgment_enabled":                    "false",
 		"review_depth":                        "standard",
+		"require_review":                      "false",
 	}
 
 	varMap := make(map[string]string)
@@ -480,6 +481,50 @@ func TestBuildRefineryPatrolVars_MergeStrategyDefaultOmitted(t *testing.T) {
 	// merge_strategy should be absent when not explicitly configured
 	if _, ok := varMap["merge_strategy"]; ok {
 		t.Error("merge_strategy should be omitted when not configured (let formula default apply)")
+	}
+}
+
+func TestBuildRefineryPatrolVars_RequireReview(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigDir := filepath.Join(tmpDir, "testrig")
+	settingsDir := filepath.Join(rigDir, "settings")
+	if err := os.MkdirAll(settingsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	mq := config.DefaultMergeQueueConfig()
+	mq.MergeStrategy = "pr"
+	requireReview := true
+	mq.RequireReview = &requireReview
+	settings := config.RigSettings{
+		Type:       "rig-settings",
+		Version:    1,
+		MergeQueue: mq,
+	}
+	data, _ := json.Marshal(settings)
+	if err := os.WriteFile(filepath.Join(settingsDir, "config.json"), data, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := RoleContext{
+		TownRoot: tmpDir,
+		Rig:      "testrig",
+	}
+	vars := buildRefineryPatrolVars(ctx)
+
+	varMap := make(map[string]string)
+	for _, v := range vars {
+		parts := splitFirstEquals(v)
+		if len(parts) == 2 {
+			varMap[parts[0]] = parts[1]
+		}
+	}
+
+	if got := varMap["require_review"]; got != "true" {
+		t.Errorf("require_review = %q, want %q", got, "true")
+	}
+	if got := varMap["merge_strategy"]; got != "pr" {
+		t.Errorf("merge_strategy = %q, want %q", got, "pr")
 	}
 }
 

--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -397,6 +397,7 @@ func buildRefineryPatrolVars(ctx RoleContext) []string {
 		if mq.MergeStrategy != "" {
 			vars = append(vars, fmt.Sprintf("merge_strategy=%s", mq.MergeStrategy))
 		}
+		vars = append(vars, fmt.Sprintf("require_review=%t", mq.IsRequireReviewEnabled()))
 		return vars
 	}
 
@@ -414,7 +415,7 @@ func buildRefineryPatrolVars(ctx RoleContext) []string {
 					labelMap[label[:idx]] = label[idx+1:]
 				}
 			}
-			for _, key := range []string{"integration_branch_refinery_enabled", "integration_branch_auto_land", "run_tests", "delete_merged_branches", "setup_command", "typecheck_command", "lint_command", "test_command", "build_command", "merge_strategy"} {
+			for _, key := range []string{"integration_branch_refinery_enabled", "integration_branch_auto_land", "run_tests", "delete_merged_branches", "setup_command", "typecheck_command", "lint_command", "test_command", "build_command", "merge_strategy", "require_review"} {
 				if val := labelMap[key]; val != "" {
 					vars = append(vars, fmt.Sprintf("%s=%s", key, val))
 				}

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -1142,6 +1142,9 @@ func loadRigCommandVars(townRoot, rig string) []string {
 	if mq.MergeStrategy != "" {
 		vars = append(vars, fmt.Sprintf("merge_strategy=%s", mq.MergeStrategy))
 	}
+	if mq.IsRequireReviewEnabled() {
+		vars = append(vars, "require_review=true")
+	}
 	return vars
 }
 

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -367,6 +367,9 @@ func MergeSettingsCommand(repo, local *MergeQueueConfig) *MergeQueueConfig {
 		if local.MergeStrategy != "" {
 			result.MergeStrategy = local.MergeStrategy
 		}
+		if local.RequireReview != nil {
+			result.RequireReview = local.RequireReview
+		}
 	}
 	return result
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1248,6 +1248,11 @@ type MergeQueueConfig struct {
 	// merges directly to the base branch, "pr" creates a GitHub pull request.
 	MergeStrategy string `json:"merge_strategy,omitempty"`
 
+	// RequireReview controls whether the refinery requires at least one approving
+	// GitHub review before merging a PR. Only meaningful when merge_strategy="pr".
+	// Nil defaults to false (no review required).
+	RequireReview *bool `json:"require_review,omitempty"`
+
 	// OnConflict specifies conflict resolution strategy: "assign_back" or "auto_rebase".
 	OnConflict string `json:"on_conflict"`
 
@@ -1358,6 +1363,15 @@ func (c *MergeQueueConfig) IsJudgmentEnabled() bool {
 		return false
 	}
 	return *c.JudgmentEnabled
+}
+
+// IsRequireReviewEnabled returns whether PR reviews are required before merging.
+// Nil-safe, defaults to false.
+func (c *MergeQueueConfig) IsRequireReviewEnabled() bool {
+	if c.RequireReview == nil {
+		return false
+	}
+	return *c.RequireReview
 }
 
 // GetReviewDepth returns the configured review depth.

--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -67,6 +67,7 @@ source of truth.
 | judgment_enabled | false | Enable quality review for merges (true/false) |
 | review_depth | standard | Review depth: quick, standard, or deep |
 | merge_strategy | direct | Merge strategy: 'direct' (ff-only merge+push) or 'pr' (GitHub PR) |
+| require_review | false | Require at least one approving GitHub review before merging (pr mode only) |
 
 ## Target Resolution Rule
 
@@ -145,6 +146,10 @@ default = "standard"
 [vars.merge_strategy]
 description = "Merge strategy: 'direct' (ff-only merge + push) or 'pr' (create GitHub PR). Default: direct."
 default = "direct"
+
+[vars.require_review]
+description = "Require at least one approving GitHub review before merging (only applies when merge_strategy=pr)."
+default = "false"
 
 [[steps]]
 id = "inbox-check"
@@ -533,6 +538,7 @@ Merge and push. CRITICAL: Notifications come IMMEDIATELY after push.
 **Config: target_branch = {{target_branch}}**
 **Config: delete_merged_branches = {{delete_merged_branches}}**
 **Config: merge_strategy = {{merge_strategy}}**
+**Config: require_review = {{require_review}}**
 
 **Step 1: Merge (strategy-dependent)**
 
@@ -634,7 +640,24 @@ Attempt-Number: 1"
 Then skip to Step 4 (archive mail) and continue patrol.
 
 **If CI checks PASS:**
-Merge the PR:
+
+**Step 1.7 (pr only): CHECK FOR APPROVING REVIEWS (if require_review = true)**
+
+If require_review = "true", you MUST verify at least one approving review exists
+before merging. Do NOT merge PRs with zero approving reviews.
+
+```bash
+REVIEW_DECISION=$(gh pr view <polecat-branch> --repo "$REPO_URL" --json reviewDecision -q '.reviewDecision')
+```
+
+If REVIEW_DECISION is not "APPROVED":
+- Do NOT merge.
+- Skip to Step 4 (archive mail) and continue patrol. The PR stays open awaiting review.
+- On the next patrol cycle, re-check this PR for reviews.
+
+If require_review = "false" (default), skip this check and proceed to merge.
+
+**Merge the PR:**
 ```bash
 gh pr merge <polecat-branch> --repo "$REPO_URL" --merge --delete-branch
 ```


### PR DESCRIPTION
## Summary

- Add `require_review` field to `MergeQueueConfig` so the setting is no longer silently dropped from rig configs
- Thread `require_review` through `buildRefineryPatrolVars` and sling helpers to the refinery patrol formula
- Update `mol-refinery-patrol` formula to check `gh pr view --json reviewDecision` before merging when `require_review=true`

**Root cause**: The `MergeQueueConfig` struct had no `RequireReview` field, so JSON unmarshaling silently discarded the `require_review: true` setting from rig configs (e.g., wombats). The refinery patrol formula had no review-check step, merging PRs immediately after CI passed.

**Reproduce**: wombats PRs #2-6 on digital-twinning/wombats — all merged with zero reviews despite `require_review: true` in settings.

## Test plan

- [x] Existing patrol vars tests pass (updated count expectation)
- [x] New `TestBuildRefineryPatrolVars_RequireReview` verifies the var is injected when enabled
- [x] Config loader tests pass
- [x] `go build ./...` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)