### PR TITLE
feat(mail): add --from flag to gt mail send

### DIFF
--- a/internal/cmd/mail.go
+++ b/internal/cmd/mail.go
@@ -18,6 +18,7 @@ var (
 	mailNotify        bool
 	mailNoNotify      bool // Suppress auto-nudge notification to recipient
 	mailTo            string   // --to flag (alternative to positional arg)
+	mailFrom          string   // --from flag (override sender, for relay/bridge use)
 	mailSendSelf      bool
 	mailCC            []string // CC recipients
 	mailInboxJSON     bool
@@ -470,6 +471,7 @@ func init() {
 	mailSendCmd.Flags().BoolVar(&mailWisp, "wisp", true, "Send as wisp (ephemeral, default)")
 	mailSendCmd.Flags().BoolVar(&mailPermanent, "permanent", false, "Send as permanent (not ephemeral, synced to remote)")
 	mailSendCmd.Flags().StringVar(&mailTo, "to", "", "Recipient address (alternative to positional argument)")
+	mailSendCmd.Flags().StringVar(&mailFrom, "from", "", "Override sender address (for relay/bridge use)")
 	mailSendCmd.Flags().BoolVar(&mailSendSelf, "self", false, "Send to self (auto-detect from cwd)")
 	mailSendCmd.Flags().StringArrayVar(&mailCC, "cc", nil, "CC recipients (can be used multiple times)")
 	_ = mailSendCmd.MarkFlagRequired("subject") // cobra flags: error only at runtime if missing

--- a/internal/cmd/mail_send.go
+++ b/internal/cmd/mail_send.go
@@ -71,8 +71,11 @@ func runMailSend(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("not in a Gas Town workspace: %w", err)
 	}
 
-	// Determine sender
-	from := detectSender()
+	// Determine sender (--from overrides auto-detection, for relay/bridge use)
+	from := mailFrom
+	if from == "" {
+		from = detectSender()
+	}
 
 	// Create message with auto-generated ID and thread ID
 	msg := mail.NewMessage(from, to, mailSubject, mailBody)


### PR DESCRIPTION
## Summary

- Adds optional `--from` flag to `gt mail send` to override the auto-detected sender address
- No-op for existing flows — when omitted, sender detection works exactly as before (`GT_ROLE` env → cwd-based → overseer fallback)
- Useful when `gt mail send` is invoked from a non-standard directory (scripts, plugins, bridge tools) where cwd-based sender detection returns the wrong identity

## Examples

```bash
# Existing behavior unchanged — auto-detects sender
gt mail send mayor/ -s "Update" -m "..."

# Override sender when running from a script/cron context
gt mail send mayor/ --from "gastown/crew/navani" -s "Scheduled report" -m "..."

# Cross-town mail relay preserving original sender
gt mail send dalinar --from "xt:woodhouse" -s "Cross-town update" -m "..."
```

## Test plan

- [x] `go build ./cmd/gt`
- [x] `go test ./internal/cmd/... -run Mail`
- [x] Without `--from`: sender auto-detection unchanged
- [x] With `--from`: specified value used as sender

🤖 Generated with [Claude Code](https://claude.com/claude-code)