### PR TITLE
fix: show crew status across all rigs

### DIFF
--- a/internal/cmd/crew.go
+++ b/internal/cmd/crew.go
@@ -185,11 +185,14 @@ var crewStatusCmd = &cobra.Command{
 	Long: `Show detailed status for crew workspace(s).
 
 Displays session state, git status, branch info, and mail inbox status.
-If no name given, shows status for all crew workers.
+If no name given, shows status for all crew workers across all rigs.
 
 Examples:
-  gt crew status                  # Status of all crew workers
+  gt crew status                  # Status of all crew workers across all rigs
+  gt crew status beads            # Status of all crew workers in beads
+  gt crew status --rig beads      # Status of all crew workers in beads
   gt crew status dave             # Status of specific worker
+  gt crew status beads/dave       # Status of specific worker in beads
   gt crew status --json           # JSON output`,
 	RunE: runCrewStatus,
 }

--- a/internal/cmd/crew_status.go
+++ b/internal/cmd/crew_status.go
@@ -11,6 +11,7 @@ import (
 	"github.com/steveyegge/gastown/internal/crew"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/mail"
+	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
@@ -50,38 +51,111 @@ func runCrewStatus(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	crewMgr, r, err := getCrewManagerForMember(crewRig, targetName)
-	if err != nil {
-		return err
-	}
+	t := tmux.NewTmux()
+	var items []CrewStatusItem
 
-	var workers []*crew.CrewWorker
-
-	if targetName != "" {
-		// Specific worker
-		worker, err := crewMgr.Get(targetName)
+	if targetName == "" && crewRig == "" {
+		rigs, err := getAllRigs()
 		if err != nil {
-			if err == crew.ErrCrewNotFound {
-				return fmt.Errorf("crew workspace '%s' not found", targetName)
+			return err
+		}
+
+		for _, r := range rigs {
+			rigItems, err := listCrewStatusItems(r, t)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "warning: failed to list crew workers in %s: %v\n", r.Name, err)
+				continue
 			}
-			return fmt.Errorf("getting crew worker: %w", err)
+			items = append(items, rigItems...)
 		}
-		workers = []*crew.CrewWorker{worker}
 	} else {
-		// All workers
-		workers, err = crewMgr.List()
+		crewMgr, r, err := getCrewManagerForMember(crewRig, targetName)
 		if err != nil {
-			return fmt.Errorf("listing crew workers: %w", err)
+			return err
 		}
+
+		var workers []*crew.CrewWorker
+
+		if targetName != "" {
+			// Specific worker
+			worker, err := crewMgr.Get(targetName)
+			if err != nil {
+				if err == crew.ErrCrewNotFound {
+					return fmt.Errorf("crew workspace '%s' not found", targetName)
+				}
+				return fmt.Errorf("getting crew worker: %w", err)
+			}
+			workers = []*crew.CrewWorker{worker}
+		} else {
+			// All workers
+			workers, err = crewMgr.List()
+			if err != nil {
+				return fmt.Errorf("listing crew workers: %w", err)
+			}
+		}
+
+		items = append(items, buildCrewStatusItems(r, workers, t)...)
 	}
 
-	if len(workers) == 0 {
+	if len(items) == 0 {
 		fmt.Println("No crew workspaces found.")
 		return nil
 	}
 
-	t := tmux.NewTmux()
-	var items []CrewStatusItem
+	if crewJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(items)
+	}
+
+	// Text output
+	for i, item := range items {
+		if i > 0 {
+			fmt.Println()
+		}
+
+		sessionStatus := style.Dim.Render("○ stopped")
+		if item.HasSession {
+			sessionStatus = style.Bold.Render("● running")
+		}
+
+		fmt.Printf("%s %s/%s\n", sessionStatus, item.Rig, item.Name)
+		fmt.Printf("  Path:   %s\n", item.Path)
+		fmt.Printf("  Branch: %s\n", item.Branch)
+
+		if item.GitClean {
+			fmt.Printf("  Git:    %s\n", style.Dim.Render("clean"))
+		} else {
+			fmt.Printf("  Git:    %s\n", style.Bold.Render("dirty"))
+			if len(item.GitModified) > 0 {
+				fmt.Printf("          Modified: %s\n", strings.Join(item.GitModified, ", "))
+			}
+			if len(item.GitUntracked) > 0 {
+				fmt.Printf("          Untracked: %s\n", strings.Join(item.GitUntracked, ", "))
+			}
+		}
+
+		if item.MailUnread > 0 {
+			fmt.Printf("  Mail:   %d unread / %d total\n", item.MailUnread, item.MailTotal)
+		} else {
+			fmt.Printf("  Mail:   %s\n", style.Dim.Render(fmt.Sprintf("%d messages", item.MailTotal)))
+		}
+	}
+
+	return nil
+}
+
+func listCrewStatusItems(r *rig.Rig, t *tmux.Tmux) ([]CrewStatusItem, error) {
+	crewMgr := crew.NewManager(r, git.NewGit(r.Path))
+	workers, err := crewMgr.List()
+	if err != nil {
+		return nil, fmt.Errorf("listing crew workers: %w", err)
+	}
+	return buildCrewStatusItems(r, workers, t), nil
+}
+
+func buildCrewStatusItems(r *rig.Rig, workers []*crew.CrewWorker, t *tmux.Tmux) []CrewStatusItem {
+	items := make([]CrewStatusItem, 0, len(workers))
 
 	for _, w := range workers {
 		sessionID := crewSessionName(r.Name, w.Name)
@@ -128,45 +202,5 @@ func runCrewStatus(cmd *cobra.Command, args []string) error {
 		items = append(items, item)
 	}
 
-	if crewJSON {
-		enc := json.NewEncoder(os.Stdout)
-		enc.SetIndent("", "  ")
-		return enc.Encode(items)
-	}
-
-	// Text output
-	for i, item := range items {
-		if i > 0 {
-			fmt.Println()
-		}
-
-		sessionStatus := style.Dim.Render("○ stopped")
-		if item.HasSession {
-			sessionStatus = style.Bold.Render("● running")
-		}
-
-		fmt.Printf("%s %s/%s\n", sessionStatus, item.Rig, item.Name)
-		fmt.Printf("  Path:   %s\n", item.Path)
-		fmt.Printf("  Branch: %s\n", item.Branch)
-
-		if item.GitClean {
-			fmt.Printf("  Git:    %s\n", style.Dim.Render("clean"))
-		} else {
-			fmt.Printf("  Git:    %s\n", style.Bold.Render("dirty"))
-			if len(item.GitModified) > 0 {
-				fmt.Printf("          Modified: %s\n", strings.Join(item.GitModified, ", "))
-			}
-			if len(item.GitUntracked) > 0 {
-				fmt.Printf("          Untracked: %s\n", strings.Join(item.GitUntracked, ", "))
-			}
-		}
-
-		if item.MailUnread > 0 {
-			fmt.Printf("  Mail:   %d unread / %d total\n", item.MailUnread, item.MailTotal)
-		} else {
-			fmt.Printf("  Mail:   %s\n", style.Dim.Render(fmt.Sprintf("%d messages", item.MailTotal)))
-		}
-	}
-
-	return nil
+	return items
 }

--- a/internal/cmd/crew_status_test.go
+++ b/internal/cmd/crew_status_test.go
@@ -1,0 +1,91 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"testing"
+
+	"github.com/spf13/cobra"
+)
+
+func TestRunCrewStatus_NoArgsAggregatesJSONAcrossAllRigs(t *testing.T) {
+	townRoot := setupTestTownForCrewList(t, map[string][]string{
+		"rig-a": {"alice"},
+		"rig-b": {"bob"},
+	})
+
+	originalWd, _ := os.Getwd()
+	defer os.Chdir(originalWd)
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	crewRig = ""
+	crewJSON = true
+	defer func() {
+		crewRig = ""
+		crewJSON = false
+	}()
+
+	output := captureStdout(t, func() {
+		if err := runCrewStatus(&cobra.Command{}, nil); err != nil {
+			t.Fatalf("runCrewStatus failed: %v", err)
+		}
+	})
+
+	var items []CrewStatusItem
+	if err := json.Unmarshal([]byte(output), &items); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if len(items) != 2 {
+		t.Fatalf("expected 2 crew workers, got %d", len(items))
+	}
+
+	rigs := map[string]bool{}
+	for _, item := range items {
+		rigs[item.Rig] = true
+	}
+	if !rigs["rig-a"] || !rigs["rig-b"] {
+		t.Fatalf("expected crew from rig-a and rig-b, got: %#v", rigs)
+	}
+}
+
+func TestRunCrewStatus_RigFlagFiltersJSONFromTownRoot(t *testing.T) {
+	townRoot := setupTestTownForCrewList(t, map[string][]string{
+		"rig-a": {"alice"},
+		"rig-b": {"bob"},
+	})
+
+	originalWd, _ := os.Getwd()
+	defer os.Chdir(originalWd)
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	crewRig = "rig-b"
+	crewJSON = true
+	defer func() {
+		crewRig = ""
+		crewJSON = false
+	}()
+
+	output := captureStdout(t, func() {
+		if err := runCrewStatus(&cobra.Command{}, nil); err != nil {
+			t.Fatalf("runCrewStatus failed: %v", err)
+		}
+	})
+
+	var items []CrewStatusItem
+	if err := json.Unmarshal([]byte(output), &items); err != nil {
+		t.Fatalf("unmarshal output: %v", err)
+	}
+	if len(items) != 1 {
+		t.Fatalf("expected 1 crew worker, got %d", len(items))
+	}
+	if items[0].Rig != "rig-b" {
+		t.Fatalf("expected rig-b, got %s", items[0].Rig)
+	}
+	if items[0].Name != "bob" {
+		t.Fatalf("expected bob, got %s", items[0].Name)
+	}
+}


### PR DESCRIPTION
## Summary
Align `gt crew status` with its help text by making the no-arg path aggregate crew workers across all rigs, including from the town root.

## Related Issue
Closes gt-d05

## Changes
- add an all-rigs aggregation path when `gt crew status` is called without a crew name or `--rig`
- preserve explicit `--rig`, positional rig, and `rig/name` handling
- add regression tests for town-root no-arg and explicit `--rig` invocation
- clarify help text and examples so behavior matches the CLI docs

## Testing
- [x] Unit tests pass (`go test ./internal/cmd -run 'TestRunCrew(List|Status)|TestInferRigFromCrewName' -count=1`)
- [ ] Manual testing performed

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)