### PR TITLE
fix: fail fast on daemon beads schema mismatch

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Daemon beads compatibility guard** — `gt daemon run` now fail-fast checks
+  workspace beads schema compatibility before Convoy polling starts, and
+  `gt daemon start` surfaces the startup mismatch directly instead of only
+  telling operators to inspect logs.
+
 ## [0.12.1] - 2026-03-15
 
 ### Added

--- a/internal/cmd/daemon.go
+++ b/internal/cmd/daemon.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -211,6 +212,9 @@ func runDaemonStart(cmd *cobra.Command, args []string) error {
 		}
 	}
 	if !started {
+		if msg := readDaemonStartupFailure(townRoot, daemonCmd.Process.Pid); msg != "" {
+			return fmt.Errorf("daemon failed to start: %s", msg)
+		}
 		return fmt.Errorf("daemon failed to start (check logs with 'gt daemon logs')")
 	}
 
@@ -308,6 +312,24 @@ func getBinaryModTime() (time.Time, error) {
 		return time.Time{}, err
 	}
 	return info.ModTime(), nil
+}
+
+func readDaemonStartupFailure(townRoot string, pid int) string {
+	logFile := filepath.Join(townRoot, "daemon", "daemon.log")
+	data, err := os.ReadFile(logFile)
+	if err != nil {
+		return ""
+	}
+
+	prefix := fmt.Sprintf("Daemon startup failed (PID %d): ", pid)
+	lines := strings.Split(string(data), "\n")
+	for i := len(lines) - 1; i >= 0; i-- {
+		line := lines[i]
+		if idx := strings.Index(line, prefix); idx >= 0 {
+			return strings.TrimSpace(line[idx+len(prefix):])
+		}
+	}
+	return ""
 }
 
 func runDaemonLogs(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/daemon_test.go
+++ b/internal/cmd/daemon_test.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestReadDaemonStartupFailure(t *testing.T) {
+	townRoot := t.TempDir()
+	daemonDir := filepath.Join(townRoot, "daemon")
+	if err := os.MkdirAll(daemonDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+
+	logData := "" +
+		"2026/03/28 22:00:00 Daemon startup failed (PID 111): stale error\n" +
+		"2026/03/28 22:00:01 Daemon startup failed (PID 222): incompatible beads workspace / gt binary combination\n"
+	if err := os.WriteFile(filepath.Join(daemonDir, "daemon.log"), []byte(logData), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	got := readDaemonStartupFailure(townRoot, 222)
+	want := "incompatible beads workspace / gt binary combination"
+	if got != want {
+		t.Fatalf("readDaemonStartupFailure() = %q, want %q", got, want)
+	}
+}
+
+func TestReadDaemonStartupFailure_MissingPIDReturnsEmpty(t *testing.T) {
+	townRoot := t.TempDir()
+	daemonDir := filepath.Join(townRoot, "daemon")
+	if err := os.MkdirAll(daemonDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(daemonDir, "daemon.log"), []byte("2026/03/28 22:00:00 Daemon startup failed (PID 111): stale error\n"), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	if got := readDaemonStartupFailure(townRoot, 222); got != "" {
+		t.Fatalf("readDaemonStartupFailure() = %q, want empty string", got)
+	}
+}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2,13 +2,18 @@ package daemon
 
 import (
 	"context"
+	"database/sql"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"regexp"
+	"runtime/debug"
+	"sort"
 	"strconv"
 	"strings"
 	"sync"
@@ -17,16 +22,16 @@ import (
 
 	"github.com/gofrs/flock"
 	beadsdk "github.com/steveyegge/beads"
-	"gopkg.in/natefinch/lumberjack.v2"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/boot"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/deacon"
+	"github.com/steveyegge/gastown/internal/deps"
 	"github.com/steveyegge/gastown/internal/doltserver"
+	"github.com/steveyegge/gastown/internal/estop"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/feed"
-	"github.com/steveyegge/gastown/internal/estop"
 	gitpkg "github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/mayor"
 	"github.com/steveyegge/gastown/internal/polecat"
@@ -38,6 +43,7 @@ import (
 	"github.com/steveyegge/gastown/internal/util"
 	"github.com/steveyegge/gastown/internal/wisp"
 	"github.com/steveyegge/gastown/internal/witness"
+	"gopkg.in/natefinch/lumberjack.v2"
 )
 
 // Daemon is the town-level background service.
@@ -54,8 +60,8 @@ type Daemon struct {
 	curator       *feed.Curator
 	convoyManager *ConvoyManager
 	beadsStores   map[string]beadsdk.Storage
-	doltServer *DoltServerManager
-	krcPruner  *KRCPruner
+	doltServer    *DoltServerManager
+	krcPruner     *KRCPruner
 
 	// disabledPatrols is loaded from town settings (disabled_patrols field).
 	// Provides a simple way to disable individual patrol dogs without editing
@@ -130,6 +136,10 @@ const (
 	// Configurable via operational.daemon.doctor_mol_cooldown.
 	doctorMolCooldown = 5 * time.Minute
 )
+
+const beadsModulePath = "github.com/steveyegge/beads"
+
+var semverPattern = regexp.MustCompile(`v?(\d+\.\d+\.\d+)`)
 
 // New creates a new daemon instance.
 func New(config *Config) (*Daemon, error) {
@@ -301,8 +311,20 @@ func New(config *Config) (*Daemon, error) {
 }
 
 // Run starts the daemon main loop.
-func (d *Daemon) Run() error {
-	d.logger.Printf("Daemon starting (PID %d)", os.Getpid())
+func (d *Daemon) Run() (err error) {
+	pid := os.Getpid()
+	d.logger.Printf("Daemon starting (PID %d)", pid)
+	startupComplete := false
+	defer func() {
+		if err == nil {
+			return
+		}
+		if startupComplete {
+			d.logger.Printf("Daemon exiting with error (PID %d): %v", pid, err)
+			return
+		}
+		d.logger.Printf("Daemon startup failed (PID %d): %v", pid, err)
+	}()
 
 	// Acquire exclusive lock to prevent multiple daemons from running.
 	// This prevents the TOCTOU race condition where multiple concurrent starts
@@ -372,14 +394,24 @@ func (d *Daemon) Run() error {
 	// Start convoy manager (event-driven + periodic stranded scan)
 	// Try opening beads stores eagerly; if Dolt isn't ready yet,
 	// pass the opener as a callback for lazy retry on each poll tick.
-	d.beadsStores = d.openBeadsStores()
+	d.beadsStores, err = d.openBeadsStores()
+	if err != nil {
+		return err
+	}
 	isRigParked := func(rigName string) bool {
 		ok, _ := d.isRigOperational(rigName)
 		return !ok
 	}
 	var storeOpener func() map[string]beadsdk.Storage
 	if len(d.beadsStores) == 0 {
-		storeOpener = d.openBeadsStores
+		storeOpener = func() map[string]beadsdk.Storage {
+			stores, err := d.openBeadsStores()
+			if err != nil {
+				d.logger.Printf("Convoy: beads compatibility check failed: %v", err)
+				return nil
+			}
+			return stores
+		}
 	}
 	d.convoyManager = NewConvoyManager(d.config.TownRoot, d.logger.Printf, d.gtPath, 0, d.beadsStores, storeOpener, isRigParked)
 	if err := d.convoyManager.Start(); err != nil {
@@ -554,6 +586,7 @@ func (d *Daemon) Run() error {
 
 	// Initial heartbeat
 	d.heartbeat(state)
+	startupComplete = true
 
 	for {
 		select {
@@ -904,7 +937,6 @@ func (d *Daemon) pourDoctorMolecule(warnings []string) {
 	mol.closeStep("report")
 }
 
-
 // checkAllRigsDolt verifies all rigs are using the Dolt backend.
 func (d *Daemon) checkAllRigsDolt() error {
 	var problems []string
@@ -953,6 +985,175 @@ func readBeadsBackend(beadsDir string) string {
 	}
 
 	return metadata.Backend
+}
+
+type beadsMetadataReader interface {
+	GetMetadata(ctx context.Context, key string) (string, error)
+}
+
+type beadsDBAccessor interface {
+	DB() *sql.DB
+}
+
+// embeddedBeadsVersion returns the semver of the beads module linked into this binary.
+// Empty string means build info did not include a parseable module version.
+func embeddedBeadsVersion() string {
+	info, ok := debug.ReadBuildInfo()
+	if !ok {
+		return ""
+	}
+	for _, dep := range info.Deps {
+		if dep.Path != beadsModulePath {
+			continue
+		}
+		if dep.Replace != nil {
+			if version := normalizeSemver(dep.Replace.Version); version != "" {
+				return version
+			}
+		}
+		return normalizeSemver(dep.Version)
+	}
+	return ""
+}
+
+func normalizeSemver(version string) string {
+	matches := semverPattern.FindStringSubmatch(version)
+	if len(matches) != 2 {
+		return ""
+	}
+	return matches[1]
+}
+
+func checkBeadsStoreCompatibility(ctx context.Context, stores map[string]beadsdk.Storage, binaryBeadsVersion string) error {
+	if len(stores) == 0 {
+		return nil
+	}
+
+	names := make([]string, 0, len(stores))
+	for name := range stores {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+
+	var problems []string
+	for _, name := range names {
+		problem := checkSingleBeadsStoreCompatibility(ctx, name, stores[name], binaryBeadsVersion)
+		if problem != "" {
+			problems = append(problems, problem)
+		}
+	}
+	if len(problems) == 0 {
+		return nil
+	}
+
+	remediation := "Upgrade or rebuild `gt` against a newer beads release, or switch to a workspace created by a matching release, then retry `gt daemon start`."
+	if binaryBeadsVersion == "" {
+		remediation = "Rebuild `gt` or use a release whose embedded beads version matches this workspace, then retry `gt daemon start`."
+	}
+
+	return fmt.Errorf("daemon startup blocked: incompatible beads workspace / gt binary combination\n\n  %s\n\n%s",
+		strings.Join(problems, "\n  "), remediation)
+}
+
+func checkSingleBeadsStoreCompatibility(ctx context.Context, name string, store beadsdk.Storage, binaryBeadsVersion string) string {
+	if store == nil {
+		return ""
+	}
+
+	label := displayBeadsStoreName(name)
+	var reasons []string
+
+	if workspaceVersion, err := readStoreBDVersion(ctx, store); err != nil {
+		reasons = append(reasons, fmt.Sprintf("cannot read bd_version metadata: %v", err))
+	} else if workspaceVersion != "" && binaryBeadsVersion != "" && deps.CompareVersions(workspaceVersion, binaryBeadsVersion) > 0 {
+		reasons = append(reasons, fmt.Sprintf("workspace bd_version %s is newer than embedded beads %s", workspaceVersion, binaryBeadsVersion))
+	}
+
+	if err := probeStoreEventSchema(ctx, store); err != nil {
+		reasons = append(reasons, fmt.Sprintf("event polling probe failed: %v", err))
+	}
+
+	if len(reasons) == 0 {
+		return ""
+	}
+	return fmt.Sprintf("%s: %s", label, strings.Join(reasons, "; "))
+}
+
+func readStoreBDVersion(ctx context.Context, store beadsdk.Storage) (string, error) {
+	if metadataStore, ok := store.(beadsMetadataReader); ok {
+		return metadataStore.GetMetadata(ctx, "bd_version")
+	}
+
+	dbAccessor, ok := store.(beadsDBAccessor)
+	if !ok || dbAccessor.DB() == nil {
+		return "", nil
+	}
+
+	var version string
+	err := dbAccessor.DB().QueryRowContext(ctx, "SELECT value FROM metadata WHERE `key` = 'bd_version'").Scan(&version)
+	if errors.Is(err, sql.ErrNoRows) {
+		return "", nil
+	}
+	if err != nil {
+		return "", err
+	}
+	return version, nil
+}
+
+func probeStoreEventSchema(ctx context.Context, store beadsdk.Storage) error {
+	if dbAccessor, ok := store.(beadsDBAccessor); ok && dbAccessor.DB() != nil {
+		for _, table := range []string{"events", "wisp_events"} {
+			if err := probeEventTable(ctx, dbAccessor.DB(), table); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+
+	// Fall back to the typed API if the store doesn't expose raw SQL.
+	_, err := store.GetAllEventsSince(ctx, time.Now().Add(24*time.Hour).UTC())
+	return err
+}
+
+func probeEventTable(ctx context.Context, db *sql.DB, table string) error {
+	query := fmt.Sprintf("SELECT id, created_at FROM %s ORDER BY created_at DESC LIMIT 1", table)
+
+	var (
+		id        string
+		createdAt time.Time
+	)
+	err := db.QueryRowContext(ctx, query).Scan(&id, &createdAt)
+	if errors.Is(err, sql.ErrNoRows) {
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("%s table probe: %w", table, err)
+	}
+	return nil
+}
+
+func displayBeadsStoreName(name string) string {
+	if name == "hq" {
+		return "town-root beads store"
+	}
+	return fmt.Sprintf("rig %q beads store", name)
+}
+
+func closeBeadsStores(logger *log.Logger, stores map[string]beadsdk.Storage) {
+	for name, store := range stores {
+		if store == nil {
+			continue
+		}
+		if err := store.Close(); err != nil {
+			if logger != nil {
+				logger.Printf("Convoy: error closing beads store (%s): %v", name, err)
+			}
+			continue
+		}
+		if logger != nil {
+			logger.Printf("Convoy: closed beads store (%s)", name)
+		}
+	}
 }
 
 // DeaconRole is the role name for the Deacon's handoff bead.
@@ -1197,7 +1398,6 @@ func (d *Daemon) checkDeaconHeartbeat() {
 		}
 	}
 }
-
 
 // ensureWitnessesRunning ensures witnesses are running for configured rigs.
 // Called on each heartbeat to maintain witness patrol loops.
@@ -1524,8 +1724,9 @@ func (d *Daemon) killDefaultPrefixGhosts() {
 
 // openBeadsStores opens beads stores for the town (hq) and all known rigs.
 // Returns a map keyed by "hq" for town-level and rig names for per-rig stores.
-// Stores that fail to open are logged and skipped.
-func (d *Daemon) openBeadsStores() map[string]beadsdk.Storage {
+// Stores that fail to open are logged and skipped. Successfully opened stores
+// are compatibility-checked before being returned to Convoy polling.
+func (d *Daemon) openBeadsStores() (map[string]beadsdk.Storage, error) {
 	stores := make(map[string]beadsdk.Storage)
 
 	// Town-level store (hq)
@@ -1552,7 +1753,12 @@ func (d *Daemon) openBeadsStores() map[string]beadsdk.Storage {
 
 	if len(stores) == 0 {
 		d.logger.Printf("Convoy: no beads stores available, event polling disabled")
-		return nil
+		return nil, nil
+	}
+
+	if err := checkBeadsStoreCompatibility(d.ctx, stores, embeddedBeadsVersion()); err != nil {
+		closeBeadsStores(d.logger, stores)
+		return nil, err
 	}
 
 	names := make([]string, 0, len(stores))
@@ -1560,7 +1766,7 @@ func (d *Daemon) openBeadsStores() map[string]beadsdk.Storage {
 		names = append(names, name)
 	}
 	d.logger.Printf("Convoy: opened %d beads store(s): %v", len(stores), names)
-	return stores
+	return stores, nil
 }
 
 // getKnownRigs returns list of registered rig names.
@@ -1639,7 +1845,7 @@ func (d *Daemon) isRigOperational(rigName string) (bool, string) {
 	// Check rig bead labels (global/synced docked status)
 	// This is the persistent docked state set by 'gt rig dock'
 	rigPath := filepath.Join(d.config.TownRoot, rigName)
-	
+
 	// Try to get prefix from rig config.json, fall back to rigs.json registry
 	var prefix string
 	if rigCfg, err := rig.LoadRigConfig(rigPath); err == nil && rigCfg.Beads != nil {
@@ -1648,7 +1854,7 @@ func (d *Daemon) isRigOperational(rigName string) (bool, string) {
 		// Fall back to registry (mayor/rigs.json) when config.json is missing
 		prefix = config.GetRigPrefix(d.config.TownRoot, rigName)
 	}
-	
+
 	rigBeadID := fmt.Sprintf("%s-rig-%s", prefix, rigName)
 	rigBeadsDir := beads.ResolveBeadsDir(rigPath)
 	bd := beads.NewWithBeadsDir(rigPath, rigBeadsDir)

--- a/internal/daemon/daemon_compatibility_test.go
+++ b/internal/daemon/daemon_compatibility_test.go
@@ -1,0 +1,53 @@
+package daemon
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	beadsdk "github.com/steveyegge/beads"
+)
+
+type metadataWriter interface {
+	SetMetadata(ctx context.Context, key, value string) error
+}
+
+func TestCheckBeadsStoreCompatibility_AllowsMatchingVersion(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	metadataStore, ok := store.(metadataWriter)
+	if !ok {
+		t.Skip("store does not expose metadata writes")
+	}
+	if err := metadataStore.SetMetadata(ctx, "bd_version", "0.62.0"); err != nil {
+		t.Fatalf("SetMetadata(bd_version): %v", err)
+	}
+
+	if err := checkBeadsStoreCompatibility(ctx, map[string]beadsdk.Storage{"hq": store}, "0.62.0"); err != nil {
+		t.Fatalf("checkBeadsStoreCompatibility returned unexpected error: %v", err)
+	}
+}
+
+func TestCheckBeadsStoreCompatibility_RejectsNewerWorkspaceVersion(t *testing.T) {
+	store, cleanup := setupTestStore(t)
+	defer cleanup()
+
+	ctx := context.Background()
+	metadataStore, ok := store.(metadataWriter)
+	if !ok {
+		t.Skip("store does not expose metadata writes")
+	}
+	if err := metadataStore.SetMetadata(ctx, "bd_version", "9.9.9"); err != nil {
+		t.Fatalf("SetMetadata(bd_version): %v", err)
+	}
+
+	err := checkBeadsStoreCompatibility(ctx, map[string]beadsdk.Storage{"hq": store}, "0.62.0")
+	if err == nil {
+		t.Fatal("expected incompatibility error, got nil")
+	}
+	if !strings.Contains(err.Error(), "workspace bd_version 9.9.9 is newer than embedded beads 0.62.0") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary
- add a daemon startup compatibility guard for opened beads stores before Convoy polling starts
- compare workspace `bd_version` against the binary's embedded beads module version and run a lightweight event-table probe
- surface startup mismatch errors directly from `gt daemon start`, with regression tests and changelog note

## Testing
- go test ./internal/daemon -run 'TestCheckBeadsStoreCompatibility|TestDaemon_StartsManagerAndScanner|TestDaemon_StopsManagerAndScanner' -count=1
- go test ./internal/cmd -run 'TestReadDaemonStartupFailure' -count=1
- go test ./internal/daemon -run ^ -count=1
- go test ./internal/cmd -run ^ -count=1

Closes #3377