### PR TITLE
fix: prevent source installs from being shadowed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Source install PATH shadowing** — shell integration now prepends
+  `~/.local/bin`, `gt doctor` warns when a canonical source install is still
+  shadowed on PATH, and `make install` emits a post-install warning when an
+  older `gt` would still win.
+
 ## [0.12.1] - 2026-03-15
 
 ### Added

--- a/Makefile
+++ b/Makefile
@@ -106,6 +106,16 @@ install: check-up-to-date build
 		fi; \
 	done
 	@echo "Installed $(BINARY) to $(INSTALL_DIR)/$(BINARY)"
+	@resolved_gt=$$(command -v $(BINARY) 2>/dev/null || true); \
+	if [ "$$resolved_gt" != "$(INSTALL_DIR)/$(BINARY)" ]; then \
+		echo "WARNING: PATH still resolves gt to $${resolved_gt:-<not found>} instead of $(INSTALL_DIR)/$(BINARY)"; \
+		case "$$resolved_gt" in \
+			/usr/local/bin/$(BINARY)|/opt/homebrew/bin/$(BINARY)) \
+				echo "Homebrew gt is shadowing the canonical source install." ;; \
+		esac; \
+		echo "Run: $(INSTALL_DIR)/$(BINARY) shell install"; \
+		echo '  or prepend export PATH="$HOME/.local/bin:$HOME/go/bin:$PATH" to your shell rc and open a new shell.'; \
+	fi
 	@# Restart daemon so it picks up the new binary.
 	@# A stale daemon is a recurring source of bugs (wrong session prefixes, etc.)
 	@if $(INSTALL_DIR)/$(BINARY) daemon status >/dev/null 2>&1; then \

--- a/README.md
+++ b/README.md
@@ -138,15 +138,18 @@ Federated work coordination network linking Gas Towns through DoltHub. Rigs post
 # Install Gas Town
 $ brew install gastown                                    # Homebrew (recommended)
 $ npm install -g @gastown/gt                              # npm
-$ go install github.com/steveyegge/gastown/cmd/gt@latest  # From source (macOS/Linux)
+$ git clone https://github.com/steveyegge/gastown.git && cd gastown
+$ make install                                            # From a source checkout (installs to ~/.local/bin/gt)
 
 # Windows (or if go install fails): clone and build manually
 $ git clone https://github.com/steveyegge/gastown.git && cd gastown
 $ go build -o gt.exe ./cmd/gt
 $ mv gt.exe $HOME/go/bin/  # or add gastown to PATH
 
-# If using go install, add Go binaries to PATH (add to ~/.zshrc or ~/.bashrc)
-export PATH="$PATH:$HOME/go/bin"
+# Source installs should make ~/.local/bin win on PATH
+$ ~/.local/bin/gt shell install
+# Or add this to ~/.zshrc / ~/.bashrc:
+export PATH="$HOME/.local/bin:$HOME/go/bin:$PATH"
 
 # Create workspace with git initialization
 gt install ~/gt --git

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -85,21 +85,26 @@ tmux -V           # (Optional) Should show 3.0 or higher
 
 ```bash
 # Install Gas Town CLI
-go install github.com/steveyegge/gastown/cmd/gt@latest
+git clone https://github.com/steveyegge/gastown.git
+cd gastown
+make install
 
 # Install Beads (issue tracker)
 go install github.com/steveyegge/beads/cmd/bd@latest
+
+# Ensure source installs win over older Homebrew / go-install copies
+~/.local/bin/gt shell install
 
 # Verify installation
 gt version
 bd version
 ```
 
-If `gt` is not found, ensure `$GOPATH/bin` (usually `~/go/bin`) is in your PATH:
+If `gt` is still not found or a different older binary wins, ensure `~/.local/bin` is at the front of your PATH:
 
 ```bash
 # Add to ~/.bashrc, ~/.zshrc, or equivalent
-export PATH="$PATH:$HOME/go/bin"
+export PATH="$HOME/.local/bin:$HOME/go/bin:$PATH"
 ```
 
 ### Step 2: Create Your Workspace
@@ -295,7 +300,8 @@ bd doctor                  # Run beads health check
 To update Gas Town and Beads:
 
 ```bash
-go install github.com/steveyegge/gastown/cmd/gt@latest
+git -C ~/path/to/gastown pull --ff-only
+make -C ~/path/to/gastown install
 go install github.com/steveyegge/beads/cmd/bd@latest
 gt doctor --fix            # Fix any post-update issues
 ```

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -158,10 +158,12 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	// Infrastructure prerequisites — these must pass before any check that
 	// shells out to bd/dolt or queries the database. Order matters:
 	// 1. gt binary freshness
-	// 2. bd binary exists
-	// 3. dolt binary exists
-	// 4. Dolt server is reachable (everything downstream depends on this)
+	// 2. canonical ~/.local/bin/gt wins on PATH
+	// 3. bd binary exists
+	// 4. dolt binary exists
+	// 5. Dolt server is reachable (everything downstream depends on this)
 	d.Register(doctor.NewStaleBinaryCheck())
+	d.Register(doctor.NewGTBinaryShadowCheck())
 	d.Register(doctor.NewBeadsBinaryCheck())
 	d.Register(doctor.NewDoltBinaryCheck())
 	d.Register(doctor.NewDoltServerReachableCheck())
@@ -185,7 +187,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewOverlayHealthCheck())
 	d.Register(doctor.NewPrefixConflictCheck())
 	d.Register(doctor.NewRigNameMismatchCheck())
-	d.Register(doctor.NewRigConfigSyncCheck()) // Check all registered rigs have config.json
+	d.Register(doctor.NewRigConfigSyncCheck())      // Check all registered rigs have config.json
 	d.Register(doctor.NewStaleDoltPortCheck())      // Check for stale Dolt port files
 	d.Register(doctor.NewStaleSQLServerInfoCheck()) // Check for stale sql-server.info files (GH#2770)
 	d.Register(doctor.NewPrefixMismatchCheck())

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -121,6 +121,7 @@ func upgradeDoctor(townRoot string) upgradeResult {
 	d.RegisterAll(doctor.WorkspaceChecks()...)
 	d.Register(doctor.NewGlobalStateCheck())
 	d.Register(doctor.NewStaleBinaryCheck())
+	d.Register(doctor.NewGTBinaryShadowCheck())
 	d.Register(doctor.NewBeadsBinaryCheck())
 	d.Register(doctor.NewDoltBinaryCheck())
 	d.Register(doctor.NewDoltServerReachableCheck())

--- a/internal/doctor/gt_binary_shadow_check.go
+++ b/internal/doctor/gt_binary_shadow_check.go
@@ -1,0 +1,248 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+)
+
+// GTBinaryShadowCheck verifies that a source-installed gt in ~/.local/bin is
+// the one that plain `gt` resolves to on PATH.
+type GTBinaryShadowCheck struct {
+	BaseCheck
+}
+
+// NewGTBinaryShadowCheck creates a new gt binary shadowing check.
+func NewGTBinaryShadowCheck() *GTBinaryShadowCheck {
+	return &GTBinaryShadowCheck{
+		BaseCheck: BaseCheck{
+			CheckName:        "gt-binary-shadow",
+			CheckDescription: "Check whether a canonical ~/.local/bin/gt install is shadowed on PATH",
+			CheckCategory:    CategoryInfrastructure,
+		},
+	}
+}
+
+func (c *GTBinaryShadowCheck) Run(ctx *CheckContext) *CheckResult {
+	info, err := detectGTBinaryShadow()
+	if err != nil {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: "Could not inspect gt PATH shadowing",
+			Details: []string{err.Error()},
+		}
+	}
+
+	if !info.CanonicalExists {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: fmt.Sprintf("No canonical source install detected at %s", info.CanonicalDisplay),
+		}
+	}
+
+	if !info.Shadowed {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: fmt.Sprintf("PATH resolves canonical gt install (%s)", info.CanonicalDisplay),
+		}
+	}
+
+	message := fmt.Sprintf("PATH resolves gt to %s instead of canonical source install %s",
+		info.PathDisplay, info.CanonicalDisplay)
+	if info.PathResolved == "" {
+		message = fmt.Sprintf("PATH does not resolve gt, but canonical source install exists at %s",
+			info.CanonicalDisplay)
+	} else if info.HomebrewShadow {
+		message = fmt.Sprintf("Homebrew gt at %s shadows canonical source install %s",
+			info.PathDisplay, info.CanonicalDisplay)
+	}
+
+	details := []string{
+		fmt.Sprintf("PATH hit: %s", info.PathDisplay),
+		fmt.Sprintf("Canonical source install: %s", info.CanonicalDisplay),
+	}
+	if info.RunningDisplay != "" && !sameExecutablePath(info.RunningResolved, info.PathResolved) {
+		details = append(details, fmt.Sprintf("Current executable: %s", info.RunningDisplay))
+	}
+
+	fixHint := fmt.Sprintf("Run '%s shell install' or prepend 'export PATH=\"$HOME/.local/bin:$HOME/go/bin:$PATH\"' to your shell rc, then open a new shell.",
+		info.CanonicalDisplay)
+	if info.HomebrewShadow {
+		fixHint += " If you want source builds to win, unlink or uninstall the Homebrew gt binary."
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusWarning,
+		Message: message,
+		Details: details,
+		FixHint: fixHint,
+	}
+}
+
+type gtBinaryShadowInfo struct {
+	CanonicalExists  bool
+	CanonicalPath    string
+	CanonicalDisplay string
+	PathResolved     string
+	PathDisplay      string
+	RunningResolved  string
+	RunningDisplay   string
+	Shadowed         bool
+	HomebrewShadow   bool
+}
+
+func detectGTBinaryShadow() (*gtBinaryShadowInfo, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return nil, fmt.Errorf("home dir: %w", err)
+	}
+
+	canonicalBase := filepath.Join(home, ".local", "bin", "gt")
+	canonicalPath, canonicalExists := findExistingExecutable(canonicalBase)
+	pathResolved, err := exec.LookPath("gt")
+	if err != nil {
+		pathResolved = ""
+	}
+	runningResolved, err := os.Executable()
+	if err != nil {
+		runningResolved = ""
+	}
+
+	info := &gtBinaryShadowInfo{
+		CanonicalExists:  canonicalExists,
+		CanonicalPath:    canonicalPath,
+		CanonicalDisplay: displayUserPath(firstNonEmpty(canonicalPath, canonicalBase)),
+		PathResolved:     normalizeExecutablePath(pathResolved),
+		PathDisplay:      displayLookPathResult(pathResolved),
+		RunningResolved:  normalizeExecutablePath(runningResolved),
+		RunningDisplay:   displayUserPath(normalizeExecutablePath(runningResolved)),
+	}
+
+	if canonicalExists {
+		info.Shadowed = pathResolved == "" || !sameExecutablePath(info.CanonicalPath, info.PathResolved)
+		info.HomebrewShadow = isLikelyHomebrewGT(info.PathResolved)
+	}
+
+	return info, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if value != "" {
+			return value
+		}
+	}
+	return ""
+}
+
+func displayLookPathResult(path string) string {
+	if path == "" {
+		return "not found"
+	}
+	return displayUserPath(normalizeExecutablePath(path))
+}
+
+func displayUserPath(path string) string {
+	if path == "" {
+		return ""
+	}
+	home, err := os.UserHomeDir()
+	if err == nil {
+		home = filepath.Clean(home)
+		path = filepath.Clean(path)
+		if path == home {
+			return "~"
+		}
+		prefix := home + string(os.PathSeparator)
+		if strings.HasPrefix(path, prefix) {
+			return "~" + string(os.PathSeparator) + strings.TrimPrefix(path, prefix)
+		}
+	}
+	return path
+}
+
+func isLikelyHomebrewGT(path string) bool {
+	if path == "" {
+		return false
+	}
+	clean := filepath.ToSlash(path)
+	return clean == "/usr/local/bin/gt" ||
+		clean == "/opt/homebrew/bin/gt" ||
+		strings.HasPrefix(clean, "/usr/local/Cellar/") ||
+		strings.HasPrefix(clean, "/opt/homebrew/Cellar/")
+}
+
+func normalizeExecutablePath(path string) string {
+	if path == "" {
+		return ""
+	}
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolved
+	}
+	if abs, err := filepath.Abs(path); err == nil {
+		path = abs
+	}
+	return filepath.Clean(path)
+}
+
+func sameExecutablePath(a, b string) bool {
+	if a == "" || b == "" {
+		return false
+	}
+	a = normalizeExecutablePath(a)
+	b = normalizeExecutablePath(b)
+	if a == b {
+		return true
+	}
+	aInfo, aErr := os.Stat(a)
+	bInfo, bErr := os.Stat(b)
+	if aErr == nil && bErr == nil {
+		return os.SameFile(aInfo, bInfo)
+	}
+	return false
+}
+
+func findExistingExecutable(basePath string) (string, bool) {
+	for _, candidate := range executableCandidates(basePath) {
+		info, err := os.Stat(candidate)
+		if err == nil && !info.IsDir() {
+			return normalizeExecutablePath(candidate), true
+		}
+	}
+	return "", false
+}
+
+func executableCandidates(basePath string) []string {
+	candidates := []string{basePath}
+	if runtime.GOOS != "windows" {
+		return candidates
+	}
+
+	seen := map[string]bool{basePath: true}
+	exts := []string{".exe", ".bat", ".cmd"}
+	if pathext := os.Getenv("PATHEXT"); pathext != "" {
+		exts = append(strings.Split(strings.ToLower(pathext), ";"), exts...)
+	}
+	for _, ext := range exts {
+		if ext == "" {
+			continue
+		}
+		if !strings.HasPrefix(ext, ".") {
+			ext = "." + ext
+		}
+		candidate := basePath + ext
+		if seen[candidate] {
+			continue
+		}
+		seen[candidate] = true
+		candidates = append(candidates, candidate)
+	}
+	return candidates
+}

--- a/internal/doctor/gt_binary_shadow_check_test.go
+++ b/internal/doctor/gt_binary_shadow_check_test.go
@@ -1,0 +1,132 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func writeFakeGT(t *testing.T, dir string) string {
+	t.Helper()
+
+	if runtime.GOOS == "windows" {
+		path := filepath.Join(dir, "gt.bat")
+		if err := os.WriteFile(path, []byte("@echo off\r\nexit /b 0\r\n"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		return path
+	}
+
+	path := filepath.Join(dir, "gt")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+func TestGTBinaryShadowCheck_Metadata(t *testing.T) {
+	check := NewGTBinaryShadowCheck()
+
+	if check.Name() != "gt-binary-shadow" {
+		t.Fatalf("Name() = %q, want %q", check.Name(), "gt-binary-shadow")
+	}
+	if check.Description() != "Check whether a canonical ~/.local/bin/gt install is shadowed on PATH" {
+		t.Fatalf("Description() = %q", check.Description())
+	}
+	if check.Category() != CategoryInfrastructure {
+		t.Fatalf("Category() = %q, want %q", check.Category(), CategoryInfrastructure)
+	}
+	if check.CanFix() {
+		t.Fatal("CanFix() should be false")
+	}
+}
+
+func TestGTBinaryShadowCheck_NoCanonicalInstall(t *testing.T) {
+	home := t.TempDir()
+	pathDir := t.TempDir()
+	writeFakeGT(t, pathDir)
+
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", pathDir)
+
+	check := NewGTBinaryShadowCheck()
+	result := check.Run(&CheckContext{TownRoot: t.TempDir()})
+	if result.Status != StatusOK {
+		t.Fatalf("expected StatusOK, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "No canonical source install detected") {
+		t.Fatalf("unexpected message: %q", result.Message)
+	}
+}
+
+func TestGTBinaryShadowCheck_CanonicalInstallWins(t *testing.T) {
+	home := t.TempDir()
+	canonicalDir := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(canonicalDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeGT(t, canonicalDir)
+
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", canonicalDir)
+
+	check := NewGTBinaryShadowCheck()
+	result := check.Run(&CheckContext{TownRoot: t.TempDir()})
+	if result.Status != StatusOK {
+		t.Fatalf("expected StatusOK, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "PATH resolves canonical gt install") {
+		t.Fatalf("unexpected message: %q", result.Message)
+	}
+}
+
+func TestGTBinaryShadowCheck_WarnsWhenShadowed(t *testing.T) {
+	home := t.TempDir()
+	canonicalDir := filepath.Join(home, ".local", "bin")
+	if err := os.MkdirAll(canonicalDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	writeFakeGT(t, canonicalDir)
+
+	shadowDir := t.TempDir()
+	shadowPath := writeFakeGT(t, shadowDir)
+
+	t.Setenv("HOME", home)
+	t.Setenv("PATH", shadowDir+string(os.PathListSeparator)+canonicalDir)
+
+	check := NewGTBinaryShadowCheck()
+	result := check.Run(&CheckContext{TownRoot: t.TempDir()})
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "PATH resolves gt to") {
+		t.Fatalf("unexpected message: %q", result.Message)
+	}
+	if !strings.Contains(result.Message, filepath.Base(shadowPath)) {
+		t.Fatalf("message should mention shadow path, got: %q", result.Message)
+	}
+	if result.FixHint == "" {
+		t.Fatal("expected fix hint")
+	}
+}
+
+func TestIsLikelyHomebrewGT(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{"/usr/local/bin/gt", true},
+		{"/opt/homebrew/bin/gt", true},
+		{"/usr/local/Cellar/gastown/0.12.1/bin/gt", true},
+		{"/tmp/custom/gt", false},
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		if got := isLikelyHomebrewGT(tt.path); got != tt.want {
+			t.Fatalf("isLikelyHomebrewGT(%q) = %v, want %v", tt.path, got, tt.want)
+		}
+	}
+}

--- a/internal/shell/integration.go
+++ b/internal/shell/integration.go
@@ -156,6 +156,22 @@ var shellHookScript = `#!/bin/bash
 # Installed by: gt install --shell
 # Location: ~/.config/gastown/shell-hook.sh
 
+_gastown_prepend_path() {
+    local dir="$1"
+    [[ -z "$dir" ]] && return 0
+    [[ -d "$dir" ]] || return 0
+    case ":$PATH:" in
+        *":$dir:"*) ;;
+        *) PATH="$dir${PATH:+:$PATH}" ;;
+    esac
+}
+
+_gastown_ensure_path() {
+    _gastown_prepend_path "$HOME/.local/bin"
+    _gastown_prepend_path "$HOME/go/bin"
+    export PATH
+}
+
 _gastown_enabled() {
     [[ -n "$GASTOWN_DISABLED" ]] && return 1
     [[ -n "$GASTOWN_ENABLED" ]] && return 0
@@ -281,6 +297,8 @@ _gastown_hook() {
 
     return $previous_exit_status
 }
+
+_gastown_ensure_path
 
 _gastown_chpwd_hook() {
     _GASTOWN_OFFER_ADD=1

--- a/internal/shell/integration_test.go
+++ b/internal/shell/integration_test.go
@@ -130,3 +130,21 @@ func TestUpdateRCFile(t *testing.T) {
 		t.Errorf("RC file has %d start markers, want 1", startCount)
 	}
 }
+
+func TestShellHookScript_EnsuresCanonicalBinPaths(t *testing.T) {
+	if !strings.Contains(shellHookScript, `_gastown_prepend_path "$HOME/.local/bin"`) {
+		t.Error("shell hook should prepend ~/.local/bin to PATH")
+	}
+	if !strings.Contains(shellHookScript, `_gastown_prepend_path "$HOME/go/bin"`) {
+		t.Error("shell hook should prepend ~/go/bin to PATH")
+	}
+	if !strings.Contains(shellHookScript, "_gastown_ensure_path") {
+		t.Error("shell hook should call _gastown_ensure_path")
+	}
+}
+
+func TestShellHookScript_AvoidsDuplicatePathEntries(t *testing.T) {
+	if !strings.Contains(shellHookScript, `case ":$PATH:" in`) {
+		t.Error("shell hook should guard against duplicate PATH entries")
+	}
+}


### PR DESCRIPTION
## Summary
- prepend `~/.local/bin` and `~/go/bin` from the shell hook so source installs win on fresh shells
- add a `gt doctor` / `gt upgrade` infrastructure check that warns when a canonical source install is shadowed on PATH
- make `make install` emit a post-install warning when another `gt` would still win, and update install docs to the canonical source flow

## Testing
- go test ./internal/doctor -run 'TestGTBinaryShadowCheck|TestIsLikelyHomebrewGT' -count=1
- go test ./internal/shell -run 'TestShellHookScript|TestAddRemoveFromRCFile|TestUpdateRCFile' -count=1
- go test ./internal/cmd -run ^ -count=1

Closes #3077