### PR TITLE
fix(handoff): fatal on Dolt failure, log after persist

### DIFF
--- a/internal/cmd/audit.go
+++ b/internal/cmd/audit.go
@@ -380,6 +380,8 @@ func formatTownlogSummary(e townlog.Event) string {
 		return "Completed work"
 	case townlog.EventHandoff:
 		return "Handed off session"
+	case townlog.EventHandoffNoPersist:
+		return "Handoff FAILED (Dolt persistence)"
 	case townlog.EventCrash:
 		if e.Context != "" {
 			return fmt.Sprintf("Crashed: %s", e.Context)

--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -267,15 +267,10 @@ func runHandoff(cmd *cobra.Command, args []string) error {
 	// Handing off ourselves - print feedback then respawn
 	fmt.Printf("%s Handing off %s...\n", style.Bold.Render("🤝"), currentSession)
 
-	// Log handoff event (both townlog and events feed)
-	if townRoot, err := workspace.FindFromCwd(); err == nil && townRoot != "" {
-		agent := sessionToGTRole(currentSession)
-		if agent == "" {
-			agent = currentSession
-		}
-		_ = LogHandoff(townRoot, agent, handoffSubject)
-		// Also log to activity feed
-		_ = events.LogFeed(events.TypeHandoff, agent, events.HandoffPayload(handoffSubject, true))
+	// Resolve agent identity once for both success and failure paths.
+	agent := sessionToGTRole(currentSession)
+	if agent == "" {
+		agent = currentSession
 	}
 
 	// Dry run mode - show what would happen (BEFORE any side effects)
@@ -297,12 +292,27 @@ func runHandoff(cmd *cobra.Command, args []string) error {
 
 	// Send handoff mail to self (defaults applied inside sendHandoffMail).
 	// The mail is auto-hooked so the next session picks it up.
+	// CRITICAL: Mail must persist to Dolt BEFORE logging to town.log.
+	// If Dolt is down, we must NOT log a false handoff to town.log.
 	beadID, err := sendHandoffMail(handoffSubject, handoffMessage)
 	if err != nil {
-		style.PrintWarning("could not send handoff mail: %v", err)
-		// Continue anyway - the respawn is more important
-	} else {
-		fmt.Printf("%s Sent handoff mail %s (auto-hooked)\n", style.Bold.Render("📬"), beadID)
+		// Handoff persistence failure is fatal — do not silently continue.
+		// A silent failure causes the next session to find an empty hook,
+		// losing all handoff context.
+		if townRoot, trErr := workspace.FindFromCwd(); trErr == nil && townRoot != "" {
+			_ = LogHandoffNoPersist(townRoot, agent, handoffSubject, err)
+		}
+		fmt.Fprintf(os.Stderr, "The session was NOT respawned. Fix the issue and retry 'gt handoff'.\n")
+		return fmt.Errorf("handoff mail failed to persist (Dolt may be down): %w", err)
+	}
+	fmt.Printf("%s Sent handoff mail %s (auto-hooked)\n", style.Bold.Render("📬"), beadID)
+
+	// Log handoff event AFTER Dolt persistence succeeds.
+	// Previously this logged BEFORE sendHandoffMail, causing false entries
+	// in town.log when Dolt was down.
+	if townRoot, err := workspace.FindFromCwd(); err == nil && townRoot != "" {
+		_ = LogHandoff(townRoot, agent, handoffSubject)
+		_ = events.LogFeed(events.TypeHandoff, agent, events.HandoffPayload(handoffSubject, true))
 	}
 
 	// NOTE: reportAgentState("stopped") removed (gt-zecmc)
@@ -498,14 +508,22 @@ func runHandoffCycle() error {
 	// Close any in-progress molecule steps before cycling (gt-e26g).
 	cleanupMoleculeOnHandoff()
 
-	// Send handoff mail to self (auto-hooked for successor)
+	// Send handoff mail to self (auto-hooked for successor).
+	// Fatal on failure — same rationale as runHandoff: silent failure causes
+	// the next session to find an empty hook and lose all context.
 	beadID, err := sendHandoffMail(subject, message)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "handoff --cycle: could not send mail: %v\n", err)
-		// Continue — respawn is more important than mail
-	} else {
-		fmt.Fprintf(os.Stderr, "handoff --cycle: saved state to %s\n", beadID)
+		agent := sessionToGTRole(currentSession)
+		if agent == "" {
+			agent = currentSession
+		}
+		if townRoot, trErr := workspace.FindFromCwd(); trErr == nil && townRoot != "" {
+			_ = LogHandoffNoPersist(townRoot, agent, subject, err)
+		}
+		fmt.Fprintf(os.Stderr, "The session was NOT respawned. Fix the issue and retry.\n")
+		return fmt.Errorf("handoff --cycle: mail failed to persist: %w", err)
 	}
+	fmt.Fprintf(os.Stderr, "handoff --cycle: saved state to %s\n", beadID)
 
 	// Write handoff marker so post-cycle prime knows it's post-handoff.
 	// Format: "session_id\nreason" — the reason enables isCompactResume()
@@ -525,7 +543,7 @@ func runHandoffCycle() error {
 	// Record handoff time for cooldown enforcement (gt-058d).
 	recordHandoffTime()
 
-	// Log cycle event
+	// Log cycle event AFTER persistence succeeds.
 	if townRoot, err := workspace.FindFromCwd(); err == nil && townRoot != "" {
 		agent := sessionToGTRole(currentSession)
 		if agent == "" {

--- a/internal/cmd/log.go
+++ b/internal/cmd/log.go
@@ -238,6 +238,8 @@ func printEvent(e townlog.Event) {
 		typeStr = style.Dim.Render("[nudge]")
 	case townlog.EventHandoff:
 		typeStr = style.Bold.Render("[handoff]")
+	case townlog.EventHandoffNoPersist:
+		typeStr = style.Error.Render("[handoff-NOPERSIST]")
 	case townlog.EventDone:
 		typeStr = style.Success.Render("[done]")
 	case townlog.EventCrash:
@@ -287,6 +289,11 @@ func formatEventDetail(e townlog.Event) string {
 			return fmt.Sprintf("handed off (%s)", e.Context)
 		}
 		return "handed off"
+	case townlog.EventHandoffNoPersist:
+		if e.Context != "" {
+			return fmt.Sprintf("handoff FAILED (%s)", e.Context)
+		}
+		return "handoff FAILED (no persist)"
 	case townlog.EventDone:
 		if e.Context != "" {
 			return fmt.Sprintf("completed %s", e.Context)
@@ -437,6 +444,17 @@ func LogNudge(townRoot, agent, message string) error {
 // LogHandoff logs a handoff event.
 func LogHandoff(townRoot, agent, context string) error {
 	return LogEventWithRoot(townRoot, townlog.EventHandoff, agent, context)
+}
+
+// LogHandoffNoPersist logs a failed handoff where Dolt persistence failed.
+// Creates a distinct marker in town.log so crash recovery can identify
+// handoffs that were attempted but never persisted to Dolt.
+func LogHandoffNoPersist(townRoot, agent, context string, persistErr error) error {
+	msg := context
+	if persistErr != nil {
+		msg = fmt.Sprintf("%s — error: %v", context, persistErr)
+	}
+	return LogEventWithRoot(townRoot, townlog.EventHandoffNoPersist, agent, msg)
 }
 
 // LogDone logs a done event.

--- a/internal/townlog/logger.go
+++ b/internal/townlog/logger.go
@@ -27,6 +27,9 @@ const (
 	EventCrash EventType = "crash"
 	// EventKill indicates an agent was killed intentionally.
 	EventKill EventType = "kill"
+	// EventHandoffNoPersist indicates a handoff failed to persist to Dolt.
+	// Distinct from EventHandoff so crash recovery can identify false handoffs.
+	EventHandoffNoPersist EventType = "handoff-NOPERSIST"
 	// EventCallback indicates a callback was processed during patrol.
 	EventCallback EventType = "callback"
 
@@ -135,6 +138,11 @@ func formatLogLine(e Event) string {
 		}
 	case EventHandoff:
 		detail = "handed off"
+		if e.Context != "" {
+			detail += fmt.Sprintf(" (%s)", e.Context)
+		}
+	case EventHandoffNoPersist:
+		detail = "handoff FAILED (Dolt persistence)"
 		if e.Context != "" {
 			detail += fmt.Sprintf(" (%s)", e.Context)
 		}

--- a/internal/townlog/logger_test.go
+++ b/internal/townlog/logger_test.go
@@ -235,3 +235,48 @@ func TestTruncate(t *testing.T) {
 		})
 	}
 }
+
+func TestEventHandoffNoPersist_Format(t *testing.T) {
+	e := Event{
+		Type:    EventHandoffNoPersist,
+		Agent:   "gastown/crew/max",
+		Context: "session cycling — error: connection refused",
+	}
+	line := formatLogLine(e)
+	if !strings.Contains(line, "[handoff-NOPERSIST]") {
+		t.Errorf("expected [handoff-NOPERSIST] in log line, got: %s", line)
+	}
+	if !strings.Contains(line, "handoff FAILED") {
+		t.Errorf("expected 'handoff FAILED' in log line, got: %s", line)
+	}
+}
+
+func TestEventHandoffNoPersist_NoContext(t *testing.T) {
+	e := Event{
+		Type:  EventHandoffNoPersist,
+		Agent: "mayor",
+	}
+	line := formatLogLine(e)
+	if !strings.Contains(line, "handoff FAILED (Dolt persistence)") {
+		t.Errorf("expected default detail, got: %s", line)
+	}
+}
+
+func TestEventHandoffNoPersist_ParseRoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "town.log")
+	logger := &Logger{logPath: logPath}
+
+	if err := logger.Log(EventHandoffNoPersist, "gastown/crew/max", "test failure"); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	line := strings.TrimSpace(string(data))
+	if !strings.Contains(line, "[handoff-NOPERSIST]") {
+		t.Errorf("expected [handoff-NOPERSIST] in written log, got: %s", line)
+	}
+}


### PR DESCRIPTION
## Problem

When Dolt is down during `gt handoff`, two bugs cause silent data loss:

1. `LogHandoff()` writes to town.log BEFORE `sendHandoffMail()` persists to Dolt. If Dolt is down, town.log records a false handoff that never persisted.
2. `sendHandoffMail` failure is swallowed with `PrintWarning` and the session respawns anyway. The next session finds an empty hook — all handoff context is lost.

## Root Cause

Discovered during a 43-hour Dolt commit gap where 3 mayor handoffs were logged to town.log but never persisted. The successor sessions found empty hooks and lost all context.

## Fix

**`runHandoff()`:**
- Move `LogHandoff()` call AFTER `sendHandoffMail()` succeeds
- Make persistence failure fatal: return error, do NOT respawn
- Log `EventHandoffNoPersist` on failure so crash recovery can distinguish real from failed handoffs
- Extract `sessionToGTRole()` above both branches to avoid duplication

**`runHandoffCycle()`:**
- Same fix: fatal on persistence failure, log after persist
- Blocks compaction cycling when Dolt is down (correct — prevents context loss)

**`runHandoffAuto()`:**
- Intentionally left non-fatal: auto is a state-save-only path (no respawn), different failure semantics

## Audit Notes

- `LogHandoff()` has exactly 2 callers: `runHandoff` and `runHandoffCycle`. Both fixed.
- `EventHandoffNoPersist` handled in all 4 display/parsing functions: `logger.go` (formatLogLine), `log.go` (printEvent + formatEventDetail), `audit.go` (formatTownlogSummary).
- The `--yes` flag and `term.IsTerminal` confirmation prompt (added in a4611422) are preserved — this PR does not touch that code path.
- When `sendHandoffMail` fails, the tmux pane stays alive (no respawn). The human can fix Dolt and retry `gt handoff`.

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/townlog/... -run TestEventHandoffNoPersist` — 3 tests pass
- [x] `go test ./internal/cmd/... -run TestSling` — no regressions