### PR TITLE
feat(health): add commit freshness check to Dolt health metrics

### DIFF
--- a/internal/cmd/health.go
+++ b/internal/cmd/health.go
@@ -35,14 +35,16 @@ type HealthReport struct {
 }
 
 type ServerHealth struct {
-	Running        bool          `json:"running"`
-	PID            int           `json:"pid,omitempty"`
-	Port           int           `json:"port,omitempty"`
-	LatencyMs      int64         `json:"latency_ms,omitempty"`
-	Connections    int           `json:"connections,omitempty"`
-	MaxConnections int           `json:"max_connections,omitempty"`
-	DiskUsageBytes int64         `json:"disk_usage_bytes,omitempty"`
-	DiskUsageHuman string        `json:"disk_usage_human,omitempty"`
+	Running            bool    `json:"running"`
+	PID                int     `json:"pid,omitempty"`
+	Port               int     `json:"port,omitempty"`
+	LatencyMs          int64   `json:"latency_ms,omitempty"`
+	Connections        int     `json:"connections,omitempty"`
+	MaxConnections     int     `json:"max_connections,omitempty"`
+	DiskUsageBytes     int64   `json:"disk_usage_bytes,omitempty"`
+	DiskUsageHuman     string  `json:"disk_usage_human,omitempty"`
+	LastCommitAgeSec   float64 `json:"last_commit_age_seconds,omitempty"`
+	LastCommitDB       string  `json:"last_commit_db,omitempty"`
 }
 
 type DatabaseHealth struct {
@@ -167,6 +169,10 @@ func checkServerHealth(townRoot string) *ServerHealth {
 	sh.MaxConnections = metrics.MaxConnections
 	sh.DiskUsageBytes = metrics.DiskUsageBytes
 	sh.DiskUsageHuman = metrics.DiskUsageHuman
+	if metrics.LastCommitAge > 0 {
+		sh.LastCommitAgeSec = metrics.LastCommitAge.Seconds()
+		sh.LastCommitDB = metrics.LastCommitDB
+	}
 
 	return sh
 }

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -3331,11 +3331,22 @@ type HealthMetrics struct {
 	DiskUsageHuman string `json:"disk_usage_human"`
 
 	// QueryLatency is the time taken for a SELECT active_branch() round-trip.
+	// TODO: json tag says "ms" but json.Marshal on time.Duration emits nanoseconds.
+	// Consumers extract via .Milliseconds() — the tag is aspirational, not accurate.
 	QueryLatency time.Duration `json:"query_latency_ms"`
 
 	// ReadOnly indicates whether the server is in read-only mode.
 	// When true, the server accepts reads but rejects all writes.
 	ReadOnly bool `json:"read_only"`
+
+	// LastCommitAge is the time since the most recent Dolt commit across all databases.
+	// A large gap (>1 hour) may indicate the server was down or writes are failing.
+	// Note: json.Marshal emits nanoseconds for time.Duration. Consumers should use
+	// ServerHealth.LastCommitAgeSec (float64 seconds) for JSON output instead.
+	LastCommitAge time.Duration `json:"last_commit_age_ns"`
+
+	// LastCommitDB is the database that had the most recent commit.
+	LastCommitDB string `json:"last_commit_db,omitempty"`
 
 	// Healthy indicates whether the server is within acceptable resource limits.
 	Healthy bool `json:"healthy"`
@@ -3391,6 +3402,18 @@ func GetHealthMetrics(townRoot string) *HealthMetrics {
 		metrics.Healthy = false
 		metrics.Warnings = append(metrics.Warnings,
 			"server is in READ-ONLY mode — requires restart to recover")
+	}
+
+	// 5. Commit freshness: check the most recent commit across all databases.
+	// A gap >1 hour suggests writes are failing or the server was recently down.
+	if commitAge, commitDB, err := GetLastCommitAge(townRoot); err == nil {
+		metrics.LastCommitAge = commitAge
+		metrics.LastCommitDB = commitDB
+		if commitAge > 1*time.Hour {
+			metrics.Warnings = append(metrics.Warnings,
+				fmt.Sprintf("last Dolt commit was %v ago (db: %s) — possible commit gap",
+					commitAge.Round(time.Minute), commitDB))
+		}
 	}
 
 	return metrics
@@ -3562,6 +3585,66 @@ func MeasureQueryLatency(townRoot string) (time.Duration, error) {
 	}
 
 	return elapsed, nil
+}
+
+// GetLastCommitAge returns the age and database name of the most recent Dolt commit
+// across all databases. This detects commit gaps — periods where no writes persisted.
+//
+// Uses database/sql (like MeasureQueryLatency) rather than dolt subprocess to avoid
+// subprocess startup overhead dominating the measurement.
+func GetLastCommitAge(townRoot string) (time.Duration, string, error) {
+	config := DefaultConfig(townRoot)
+
+	dsn := fmt.Sprintf("%s@tcp(%s:%d)/", config.User, config.EffectiveHost(), config.Port)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return 0, "", fmt.Errorf("opening mysql connection: %w", err)
+	}
+	defer db.Close()
+
+	db.SetConnMaxLifetime(5 * time.Second)
+	db.SetMaxOpenConns(1)
+
+	databases, err := ListDatabases(townRoot)
+	if err != nil || len(databases) == 0 {
+		return 0, "", fmt.Errorf("listing databases: %w", err)
+	}
+
+	var mostRecent time.Time
+	var mostRecentDB string
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+	defer cancel()
+
+	for _, dbName := range databases {
+		var dateStr string
+		query := fmt.Sprintf("SELECT MAX(date) FROM `%s`.dolt_log LIMIT 1", dbName)
+		if err := db.QueryRowContext(ctx, query).Scan(&dateStr); err != nil {
+			continue // Skip databases that fail (e.g., no dolt_log)
+		}
+		// Dolt's dolt_log.date is DATETIME(6) (microsecond precision). Without
+		// parseTime=true in the DSN, the Go MySQL driver returns this as a string
+		// like "2025-03-28 12:34:56.123456". Go's ".999" fractional format accepts
+		// any number of trailing digits (1-9), correctly parsing both millisecond
+		// and microsecond timestamps. RFC3339 fallback handles version differences.
+		t, err := time.Parse("2006-01-02 15:04:05.999", dateStr)
+		if err != nil {
+			t, err = time.Parse(time.RFC3339, dateStr)
+			if err != nil {
+				continue
+			}
+		}
+		if t.After(mostRecent) {
+			mostRecent = t
+			mostRecentDB = dbName
+		}
+	}
+
+	if mostRecent.IsZero() {
+		return 0, "", fmt.Errorf("no commits found in any database")
+	}
+
+	return time.Since(mostRecent), mostRecentDB, nil
 }
 
 // dirSize returns the total size of a directory tree in bytes.

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -4419,3 +4419,41 @@ func TestQuarantine_MovesInsteadOfDeleting(t *testing.T) {
 		t.Errorf("expected 1 quarantined entry, got %d", len(quarantineEntries))
 	}
 }
+
+func TestGetLastCommitAge_NoServer(t *testing.T) {
+	// With no server running, GetLastCommitAge should return an error,
+	// not panic or hang.
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, ".dolt-data"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, _, err := GetLastCommitAge(townRoot)
+	if err == nil {
+		// May succeed if a local Dolt is running; either outcome is valid.
+		return
+	}
+	t.Logf("GetLastCommitAge with no server: %v (expected)", err)
+}
+
+func TestGetLastCommitAge_NoDatabases(t *testing.T) {
+	townRoot := t.TempDir()
+
+	_, _, err := GetLastCommitAge(townRoot)
+	if err == nil {
+		t.Error("expected error with no databases, got nil")
+	}
+}
+
+func TestHealthMetrics_CommitFreshnessFields(t *testing.T) {
+	// Verify the new fields exist and are zero-valued when probe fails.
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, ".dolt-data"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	metrics := GetHealthMetrics(townRoot)
+	if metrics.LastCommitAge < 0 {
+		t.Errorf("LastCommitAge = %v, want >= 0", metrics.LastCommitAge)
+	}
+}


### PR DESCRIPTION
## Problem

`gt health` monitors connections, latency, disk usage, and read-only state — but has no way to detect a server that is reachable but not committing. A 43-hour commit gap went undetected because no metric checked commit freshness.

## Fix

Add `GetLastCommitAge()` that queries `MAX(date) FROM dolt_log` across all databases and reports the age of the most recent commit.

**HealthMetrics (internal struct):**
- `LastCommitAge time.Duration` — age of most recent commit
- `LastCommitDB string` — which database had the most recent commit
- Warning added to `metrics.Warnings` when gap >1 hour

**ServerHealth (JSON output from `gt health`):**
- `last_commit_age_seconds float64` — converted to seconds for clean JSON
- `last_commit_db string` — database name

## Implementation Details

- Uses `database/sql` (like `MeasureQueryLatency`) for accurate timing, not subprocess
- Uses `config.EffectiveHost()` for remote Dolt support
- `ListDatabases()` filters system databases (information_schema, mysql) — only user databases queried
- 15-second total timeout across all databases; failures skip gracefully
- Dolt's `dolt_log.date` is DATETIME(6) (microsecond precision); Go's ".999" format correctly parses any fractional digit count
- `HealthMetrics.LastCommitAge` JSON tag is `last_commit_age_ns` (accurate — `time.Duration` serializes as nanoseconds). Noted pre-existing same issue on `QueryLatency` tag.

## Audit Notes

- SQL injection safe: `dbName` comes from `ListDatabases()` which reads filesystem entries / SHOW DATABASES (not user input), and is backtick-quoted
- NULL handling: `MAX(date)` on empty `dolt_log` returns NULL → Scan gets empty string → `time.Parse` fails → `continue` to next database (correct graceful degradation)
- 1-hour threshold justified by the 43-hour incident and Gas Town's commit frequency (agents commit every few minutes)
- Zero performance concern: O(N) queries where N = number of databases (typically 3-5), each query hits an index

## Test plan

- [x] `go build ./...`
- [x] `go test ./internal/doltserver/... -run "TestGetLastCommitAge|TestHealthMetrics"` — 3 tests pass
- [x] `go test ./internal/cmd/... -run TestSling` — no regressions