### PR TITLE
Suppress noisy TOML env skip warnings

### DIFF
--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -5,7 +5,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"log"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -581,8 +580,7 @@ func (d *Daemon) setSessionEnvironment(sessionName string, roleConfig *beads.Rol
 	// canonical qualified values (e.g., GT_ROLE). See: https://github.com/steveyegge/gastown/issues/2492
 	if roleConfig != nil {
 		for k, v := range roleConfig.EnvVars {
-			if existing, alreadySet := envVars[k]; alreadySet {
-				log.Printf("daemon env: skipping TOML %s=%q (AgentEnv already set %q)", k, v, existing)
+			if _, alreadySet := envVars[k]; alreadySet {
 				continue
 			}
 			expanded := beads.ExpandRolePattern(v, d.config.TownRoot, parsed.RigName, parsed.AgentName, parsed.RoleType, session.PrefixFor(parsed.RigName))

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -213,8 +213,7 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	// the canonical qualified GT_ROLE (e.g., "gastown/witness" not "witness").
 	// See: https://github.com/steveyegge/gastown/issues/2492
 	for key, value := range roleConfigEnvVars(roleConfig, townRoot, m.rig.Name) {
-		if existing, alreadySet := envVars[key]; alreadySet {
-			log.Printf("witness env: skipping TOML %s=%q (AgentEnv already set %q)", key, value, existing)
+		if _, alreadySet := envVars[key]; alreadySet {
 			continue
 		}
 		_ = t.SetEnvironment(sessionID, key, value)


### PR DESCRIPTION
## Summary
- Remove `log.Printf` calls in witness and daemon that log every time a TOML env var is skipped because AgentEnv already set it
- The skip behavior is correct by design (prevents TOML from clobbering canonical qualified values like `GT_ROLE`)
- The warning doesn't convey any difference in behavior — the outcome is identical whether logged or not — so it's just noise on every startup for every rig

🤖 Generated with [Claude Code](https://claude.com/claude-code)