### PR TITLE
fix(dolt): reduce Dolt server crash probability from SIGTERM races (gt-9bxzs)

### DIFF
--- a/internal/doctor/rig_config_sync_check.go
+++ b/internal/doctor/rig_config_sync_check.go
@@ -7,6 +7,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
@@ -394,16 +395,27 @@ func (c *RigConfigSyncCheck) Fix(ctx *CheckContext) error {
 		}
 	}
 
-	// If we renamed databases, restart the Dolt server to pick up the changes
+	// If we renamed databases, restart the Dolt server to pick up the changes.
+	// Guard: skip restart if the server has been running less than 60s — restarting
+	// during startup churn is a known crash trigger (gt-9bxzs: Dolt NomsBlockStore
+	// panic when SIGTERM arrives mid-write). The server will pick up renamed databases
+	// on its next natural restart or on the next doctor --fix run once stable.
 	if renamedDBs {
 		if running, pid, _ := doltserver.IsRunning(ctx.TownRoot); running && pid > 0 {
-			// Stop the server
-			if err := doltserver.Stop(ctx.TownRoot); err != nil {
-				return fmt.Errorf("could not stop Dolt server for restart: %w", err)
-			}
-			// Start the server again
-			if err := doltserver.Start(ctx.TownRoot); err != nil {
-				return fmt.Errorf("could not restart Dolt server: %w", err)
+			const minStableAge = 60 * time.Second
+			state, _ := doltserver.LoadState(ctx.TownRoot)
+			if state != nil && !state.StartedAt.IsZero() && time.Since(state.StartedAt) < minStableAge {
+				// Server started less than 60s ago — skip restart to avoid crash
+				// during Dolt startup churn. Databases will be picked up on next restart.
+			} else {
+				// Stop the server
+				if err := doltserver.Stop(ctx.TownRoot); err != nil {
+					return fmt.Errorf("could not stop Dolt server for restart: %w", err)
+				}
+				// Start the server again
+				if err := doltserver.Start(ctx.TownRoot); err != nil {
+					return fmt.Errorf("could not restart Dolt server: %w", err)
+				}
 			}
 		}
 	}

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1721,6 +1721,47 @@ func cleanStaleSocket(socketPath string) {
 	// If lsof succeeds (exit 0), a process is using it — leave it alone.
 }
 
+// drainConnectionsBeforeStop waits for active queries to complete before SIGTERM,
+// reducing the nbs_manifest race window in Dolt's NomsBlockStore.Close() (gt-9bxzs).
+//
+// Dolt panics (Fatalf) when SIGTERM arrives while a goroutine is mid-write on an
+// nbs_manifest temp file. By waiting until no queries are in-flight, we shrink
+// the window where SIGTERM hits live storage I/O. Non-fatal: if the drain times
+// out or the server is unreachable, we proceed with SIGTERM anyway.
+func drainConnectionsBeforeStop(config *Config) {
+	dsn := fmt.Sprintf("%s@tcp(%s:%d)/?timeout=3s&readTimeout=5s&writeTimeout=5s",
+		config.User, config.EffectiveHost(), config.Port)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return
+	}
+	defer db.Close()
+	db.SetConnMaxLifetime(5 * time.Second)
+	db.SetMaxOpenConns(1)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	// Poll until only 1 connection remains (ours) or the drain window expires.
+	// INFORMATION_SCHEMA.PROCESSLIST counts all server connections including ours.
+	for {
+		select {
+		case <-ctx.Done():
+			return // Drain window expired — proceed with SIGTERM
+		default:
+		}
+		var count int
+		if err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM INFORMATION_SCHEMA.PROCESSLIST").Scan(&count); err != nil {
+			return // Server unreachable — proceed with SIGTERM
+		}
+		if count <= 1 {
+			// Only our drain connection remains — safe to send SIGTERM
+			return
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
 // Stop stops the Dolt SQL server.
 // Works for both servers started via gt dolt start AND externally-started servers.
 func Stop(townRoot string) error {
@@ -1737,6 +1778,13 @@ func Stop(townRoot string) error {
 	process, err := os.FindProcess(pid)
 	if err != nil {
 		return fmt.Errorf("finding process: %w", err)
+	}
+
+	// Drain active connections before sending SIGTERM to reduce the nbs_manifest
+	// race window inside Dolt's NomsBlockStore.Close(). Non-fatal: proceeds even
+	// if drain times out (10s max). Skipped for remote servers (no local PID).
+	if !config.IsRemote() {
+		drainConnectionsBeforeStop(config)
 	}
 
 	// Send SIGTERM for graceful shutdown


### PR DESCRIPTION
## Summary

- **doltserver.Stop()**: add pre-SIGTERM connection drain — waits up to 10s for active queries to complete before sending SIGTERM, shrinking the window where SIGTERM interrupts Dolt's NomsBlockStore nbs_manifest temp file writes
- **RigConfigSyncCheck.Fix()**: guard DB-rename restart — skip Stop/Start cycle if server has been running < 60s, preventing crash-triggering SIGTERM during Dolt startup churn (doctor_dog patrol)

## Root cause

Upstream Dolt bug: `NomsBlockStore.Close()` calls `Fatalf()` (panics) on missing `nbs_manifest_<N>` temp file during SIGTERM shutdown. Confirmed in 3 databases over 5 weeks. Upstream bug report needed separately.

## Also filed

- `gt-z6c4m`: missing `crystallizes` column migration in beads repo (unrelated to crashes but discovered during investigation)

## Test plan

- [x] `go build ./...` passes
- [x] Unit tests pass (`go test -short ./internal/doltserver/ ./internal/doctor/`)
- [ ] No regressions in Stop() behavior — drain is non-fatal (max 10s timeout), always proceeds
- [ ] doctor --fix with newly-started server (< 60s) no longer triggers unnecessary restart

🤖 Generated with [Claude Code](https://claude.ai/claude-code)