### PR TITLE
feat(windows): cherry-pick Windows platform support (PR #3268)

### DIFF
--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -268,7 +268,7 @@ func runSlingFormula(ctx context.Context, args []string) error {
 	// Dog sessions need a nudge sent to their session (not to the bare pane ID
 	// from StartDelayedSession, which is ambiguous on platforms where tmux pane
 	// IDs are not globally unique). Use NudgeSession which qualifies the target
-	// with the session name.
+	// with the session name. (gt-ect)
 	if delayedDogInfo != nil {
 		dogSession := fmt.Sprintf("hq-dog-%s", delayedDogInfo.DogName)
 		if err := t.NudgeSession(dogSession, prompt); err != nil {


### PR DESCRIPTION
## Summary

Cherry-picks the valuable Windows platform support work from @costin-eseanu PR #3268 (+1895/-5260, 116 files), extracting only the platform code and fixing several regressions discovered during review.

**What is included** (100 files, +1484/-393):
- Windows process group support (SetProcessGroup / CREATE_NO_WINDOW) across all subprocess invocations
- Platform splits: helpers, show, sysproc into unix/windows files
- PowerShell/psmux compatibility in tmux, config, hooks
- Toolhelp32-based process tree walker (descendants_windows.go)
- syscall.Exec to exec.Command refactoring for Windows compatibility

**Fixes applied during cherry-pick:**
- SIGTERM to SIGKILL regression: doltserver.go replaced SIGTERM with process.Kill(). Fixed with platform-specific gracefulTerminate()
- HasSession error swallowing: restored proper error discrimination on Unix; Windows-only fallback for psmux
- Import cycle: config to util to lock to tmux to config. Inlined setProcessGroup in lock platform files
- Cancel/CommandContext mismatch: ~120 new callsites switched to SetDetachedProcessGroup
- Cross-compilation: added descendants_stub.go; moved processIsAlive to platform files

**Excluded from cherry-pick:**
- .beads/backup/*.jsonl (contributor local dev data)
- .copilot/commands/ and .github/hooks/ (separate concern)
- Formula TOML changes, .gitignore updates (separate concerns)

## Test plan
- [x] go build ./... passes
- [x] Previously-failing packages pass: util, git, beads, checkpoint, crew, convoy, dog
- [x] Pre-existing TestCrossPlatformBuild/windows failure confirmed on main (not from this PR)

Closes #3268