### PR TITLE
fix: inherit CLAUDE_CONFIG_DIR in mayor session startup

### DIFF
--- a/internal/cmd/mayor.go
+++ b/internal/cmd/mayor.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/daemon"
 	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/mayor"
@@ -251,6 +252,18 @@ func runMayorAttach(cmd *cobra.Command, args []string) error {
 			startupCmd, err := config.BuildAgentStartupCommandWithAgentOverride("mayor", "", townRoot, "", beacon, mayorAgentOverride)
 			if err != nil {
 				return fmt.Errorf("building startup command: %w", err)
+			}
+
+			// Resolve CLAUDE_CONFIG_DIR and prepend it so the respawned process
+			// uses the correct account (mirrors what StartTMUX does).
+			accountsPath := constants.MayorAccountsPath(townRoot)
+			claudeConfigDir, _, _ := config.ResolveAccountConfigDir(accountsPath, "")
+			if claudeConfigDir == "" {
+				claudeConfigDir = os.Getenv("CLAUDE_CONFIG_DIR")
+			}
+			if claudeConfigDir != "" {
+				startupCmd = config.PrependEnv(startupCmd, map[string]string{"CLAUDE_CONFIG_DIR": claudeConfigDir})
+				_ = t.SetEnvironment(sessionID, "CLAUDE_CONFIG_DIR", claudeConfigDir)
 			}
 
 			// Set remain-on-exit so the pane survives process death during respawn.

--- a/internal/mayor/manager.go
+++ b/internal/mayor/manager.go
@@ -155,14 +155,23 @@ func (m *Manager) StartTMUX(agentOverride string) error {
 		return fmt.Errorf("creating mayor directory: %w", err)
 	}
 
+	// Resolve account config dir so the mayor session inherits CLAUDE_CONFIG_DIR.
+	// Priority: accounts.json default → GT_ACCOUNT env var → CLAUDE_CONFIG_DIR env var.
+	accountsPath := filepath.Join(m.townRoot, "mayor", "accounts.json")
+	claudeConfigDir, _, _ := config.ResolveAccountConfigDir(accountsPath, "")
+	if claudeConfigDir == "" {
+		claudeConfigDir = os.Getenv("CLAUDE_CONFIG_DIR")
+	}
+
 	// Use unified session lifecycle for config → settings → command → create → env → theme → wait.
 	theme := tmux.ResolveSessionTheme(m.townRoot, "", "mayor")
 	_, err = session.StartSession(t, session.SessionConfig{
-		SessionID: sessionID,
-		WorkDir:   mayorDir,
-		Role:      "mayor",
-		TownRoot:  m.townRoot,
-		AgentName: "Mayor",
+		SessionID:        sessionID,
+		WorkDir:          mayorDir,
+		Role:             "mayor",
+		TownRoot:         m.townRoot,
+		AgentName:        "Mayor",
+		RuntimeConfigDir: claudeConfigDir,
 		Beacon: session.BeaconConfig{
 			Recipient: "mayor",
 			Sender:    "human",


### PR DESCRIPTION
## Summary

- `mayor.StartTMUX` never called `ResolveAccountConfigDir`, so `CLAUDE_CONFIG_DIR` was never set in the mayor tmux session environment — unlike `gt start crew` which resolves the account before starting
- The zombie-respawn path in `runMayorAttach` had the same gap
- Both paths now resolve via: `accounts.json` default → `GT_ACCOUNT` env var → `CLAUDE_CONFIG_DIR` env var fallback

## Test plan

- [ ] Run `gt mayor restart` with `CLAUDE_CONFIG_DIR` set in shell; verify mayor session picks it up
- [ ] Run `gt mayor restart` with a configured `mayor/accounts.json`; verify the account's config dir is used
- [ ] Trigger zombie-respawn path (kill mayor process, run `gt mayor attach`); verify `CLAUDE_CONFIG_DIR` is prepended to the respawned command

> **Note:** I'm not fully confident this is the right fix — open to feedback on whether the env-var fallback is the right approach vs. requiring explicit account config.

🤖 Generated with [Claude Code](https://claude.com/claude-code)