### PR TITLE
fix(lint): resolve unconvert and unparam warnings

### DIFF
--- a/internal/beads/store.go
+++ b/internal/beads/store.go
@@ -571,7 +571,7 @@ func (b *Beads) storeDelegationSet(childID string, d *Delegation) error {
 		return fmt.Errorf("building delegation metadata: %w", err)
 	}
 
-	return b.store.UpdateIssue(ctx, childID, map[string]interface{}{"metadata": json.RawMessage(meta)}, actor)
+	return b.store.UpdateIssue(ctx, childID, map[string]interface{}{"metadata": meta}, actor)
 }
 
 // storeDelegationClear removes the "delegated_from" key from the issue's metadata.
@@ -591,7 +591,7 @@ func (b *Beads) storeDelegationClear(childID string) error {
 		return fmt.Errorf("clearing delegation metadata: %w", err)
 	}
 
-	return b.store.UpdateIssue(ctx, childID, map[string]interface{}{"metadata": json.RawMessage(meta)}, actor)
+	return b.store.UpdateIssue(ctx, childID, map[string]interface{}{"metadata": meta}, actor)
 }
 
 // mergeMetadataKey sets a key in a JSON metadata blob, preserving other keys.

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -529,7 +529,8 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	// Human-readable output
-	return outputMoleculeStatus(status)
+	outputMoleculeStatus(status)
+	return nil
 }
 
 // extractRoleFromIdentity extracts the role name from an agent identity string
@@ -708,7 +709,7 @@ func determineNextAction(status MoleculeStatusInfo) string {
 }
 
 // outputMoleculeStatus outputs human-readable status.
-func outputMoleculeStatus(status MoleculeStatusInfo) error {
+func outputMoleculeStatus(status MoleculeStatusInfo) {
 	// Header with hook icon
 	fmt.Printf("\n%s Hook Status: %s\n", style.Bold.Render("🪝"), status.Target)
 	if status.Role != "" && status.Role != "unknown" {
@@ -719,13 +720,13 @@ func outputMoleculeStatus(status MoleculeStatusInfo) error {
 	if !status.HasWork {
 		fmt.Printf("%s\n", style.Dim.Render("Nothing on hook - no work slung"))
 		fmt.Printf("\n%s %s\n", style.Bold.Render("Next:"), status.NextAction)
-		return nil
+		return
 	}
 
 	// Show hooked bead info
 	if status.PinnedBead == nil {
 		fmt.Printf("%s\n", style.Dim.Render("Work indicated but no bead found"))
-		return nil
+		return
 	}
 
 	// AUTONOMOUS MODE banner - hooked work triggers autonomous execution
@@ -737,7 +738,7 @@ func outputMoleculeStatus(status MoleculeStatusInfo) error {
 		fmt.Printf("%s Hooked bead %s is already closed!\n", style.Bold.Render("⚠"), status.PinnedBead.ID)
 		fmt.Printf("   Title: %s\n", status.PinnedBead.Title)
 		fmt.Printf("   This work was completed elsewhere. Clear your hook with: gt unsling\n")
-		return nil
+		return
 	}
 
 	// Check if this is a mail bead - display mail-specific format
@@ -749,7 +750,7 @@ func outputMoleculeStatus(status MoleculeStatusInfo) error {
 		}
 		fmt.Printf("   Subject: %s\n", status.PinnedBead.Title)
 		fmt.Printf("   Run: gt mail read %s\n", status.PinnedBead.ID)
-		return nil
+		return
 	}
 
 	fmt.Printf("%s %s: %s\n", style.Bold.Render("🪝 Hooked:"), status.PinnedBead.ID, status.PinnedBead.Title)
@@ -813,8 +814,6 @@ func outputMoleculeStatus(status MoleculeStatusInfo) error {
 	if status.NextAction != "" {
 		fmt.Printf("\n%s %s\n", style.Bold.Render("Next:"), status.NextAction)
 	}
-
-	return nil
 }
 
 // showGitDivergenceWarning fetches from origin and checks if the current branch

--- a/internal/cmd/molecule_status_test.go
+++ b/internal/cmd/molecule_status_test.go
@@ -32,9 +32,7 @@ func TestOutputMoleculeStatus_StandaloneFormulaShowsVars(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	if err := outputMoleculeStatus(status); err != nil {
-		t.Fatalf("outputMoleculeStatus: %v", err)
-	}
+	outputMoleculeStatus(status)
 
 	w.Close()
 	var buf bytes.Buffer
@@ -69,9 +67,7 @@ func TestOutputMoleculeStatus_FormulaWispShowsWorkflowContext(t *testing.T) {
 	r, w, _ := os.Pipe()
 	os.Stdout = w
 
-	if err := outputMoleculeStatus(status); err != nil {
-		t.Fatalf("outputMoleculeStatus: %v", err)
-	}
+	outputMoleculeStatus(status)
 
 	w.Close()
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary

Fixes three golangci-lint warnings that fail the Lint CI check on every PR (including `main`).

### Changes

1. **`internal/beads/store.go`** — Remove two unnecessary `json.RawMessage()` conversions (unconvert). `mergeMetadataKey` and `deleteMetadataKey` already return `json.RawMessage`, so the explicit conversion is redundant.

2. **`internal/cmd/molecule_status.go`** — Change `outputMoleculeStatus` return type from `error` to void (unparam). Every code path returned `nil` — the error return was dead code.

### Context

These warnings have been failing the Lint CI check since the functions were introduced. With this fix plus #3394 (test fixes), `main`'s CI should be fully green.

## Test plan

- [x] `go build ./internal/cmd/ ./internal/beads/` — compiles clean
- [x] `go vet ./internal/cmd/ ./internal/beads/` — passes
- [x] `go test ./internal/cmd/ -run MoleculeStatus` — passes (tests updated for new signature)
- [x] Lint check passes in CI (verified on this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)