### PR TITLE
fix(test): align allow-stale stub and convoy dep-fail test with code behavior

### DIFF
--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -127,33 +127,49 @@ func TestBdSupportsAllowStale_ReprobesWhenBinaryPathChanges(t *testing.T) {
 	}
 }
 
+// writeAllowStaleBDStub creates a mock bd binary in dir.
+//
+// The detection function (BdSupportsAllowStaleWithEnv) ignores the exit code
+// and checks output for "unknown flag" (matching real bd v0.60+ behavior where
+// unknown flags exit 0 but print an error to stderr). The stubs must match:
+//   - Supporting: exit 0, no output
+//   - Non-supporting: exit 0, print "unknown flag" to stderr
 func writeAllowStaleBDStub(t *testing.T, dir string, supportsAllowStale bool) {
 	t.Helper()
 
 	var scriptPath, script string
 	if runtime.GOOS == "windows" {
 		scriptPath = filepath.Join(dir, "bd.bat")
-		exitCode := "1"
 		if supportsAllowStale {
-			exitCode = "0"
-		}
-		script = fmt.Sprintf(`@echo off
+			script = `@echo off
 setlocal enableextensions
-if "%%1"=="--allow-stale" exit /b %s
-exit /b 1
-`, exitCode)
+if "%1"=="--allow-stale" exit /b 0
+exit /b 0
+`
+		} else {
+			script = `@echo off
+setlocal enableextensions
+if "%1"=="--allow-stale" (
+  echo Error: unknown flag: --allow-stale 1>&2
+  exit /b 0
+)
+exit /b 0
+`
+		}
 	} else {
 		scriptPath = filepath.Join(dir, "bd")
-		exitCode := "1"
 		if supportsAllowStale {
-			exitCode = "0"
-		}
-		script = fmt.Sprintf(`#!/bin/sh
+			script = `#!/bin/sh
+exit 0
+`
+		} else {
+			script = `#!/bin/sh
 if [ "$1" = "--allow-stale" ]; then
-  exit %s
+  echo "Error: unknown flag: --allow-stale" >&2
 fi
-exit 1
-`, exitCode)
+exit 0
+`
+		}
 	}
 
 	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {

--- a/internal/cmd/sling_batch_test.go
+++ b/internal/cmd/sling_batch_test.go
@@ -951,9 +951,12 @@ exit 0
 	}
 }
 
-// TestCreateAutoConvoy_DepFailCleansUpOrphan verifies that when the dep add
-// fails, the convoy is closed to prevent orphans.
-func TestCreateAutoConvoy_DepFailCleansUpOrphan(t *testing.T) {
+// TestCreateAutoConvoy_DepFailIsNonFatal verifies that when the dep add fails
+// (e.g., cross-rig bead), createAutoConvoy succeeds with a warning rather than
+// returning an error. Tracking failure is non-fatal since commit 103b6aaa because
+// beads v0.62 removed cross-rig routing from bd dep add. The convoy still works
+// without the tracking dep — witness and daemon provide backup tracking.
+func TestCreateAutoConvoy_DepFailIsNonFatal(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows")
 	}
@@ -985,25 +988,25 @@ exit 0
 		t.Fatalf("rewrite bd stub: %v", err)
 	}
 
-	_, err := createAutoConvoy("gt-aaa", "My task", false, "", "")
-	if err == nil {
-		t.Fatal("expected error when dep add fails, got nil")
+	convoyID, err := createAutoConvoy("gt-aaa", "My task", false, "", "")
+	if err != nil {
+		t.Fatalf("expected no error (dep fail is non-fatal), got: %v", err)
 	}
-	if !strings.Contains(err.Error(), "tracking relation") {
-		t.Errorf("error should mention tracking relation, got: %v", err)
+	if convoyID == "" {
+		t.Fatal("expected non-empty convoy ID")
 	}
 
-	// Verify close was called (orphan cleanup)
+	// Verify create was called but close was NOT called (convoy is not orphaned)
 	logBytes, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatalf("read log: %v", err)
 	}
 	logContent := string(logBytes)
-	if !strings.Contains(logContent, "CMD:close") {
-		t.Errorf("expected close command for orphan cleanup:\n%s", logContent)
+	if !strings.Contains(logContent, "CMD:create") {
+		t.Errorf("expected create command in log:\n%s", logContent)
 	}
-	if !strings.Contains(logContent, "tracking dep failed") {
-		t.Errorf("close should include 'tracking dep failed' reason:\n%s", logContent)
+	if strings.Contains(logContent, "CMD:close") {
+		t.Errorf("close should NOT be called (dep fail is non-fatal):\n%s", logContent)
 	}
 }
 


### PR DESCRIPTION
## Summary

Fixes two tests that have been failing on `main` since commit 103b6aaa, breaking the Test and Integration Test CI checks for all PRs.

### 1. TestBdSupportsAllowStale_ReprobesWhenBinaryPathChanges

**Root cause:** The non-supporting `bd` stub exited 1 with no output, but `BdSupportsAllowStaleWithEnv` (line 79-81) ignores exit codes and detects unsupported flags by checking output for `"unknown flag"` — matching real `bd v0.60+` behavior where unknown flags exit 0 but print the error to stderr. Since both stubs produced no output, both were detected as "supporting".

**Fix:** Non-supporting stub now prints `"Error: unknown flag: --allow-stale"` to stderr and exits 0, matching what real `bd v0.60+` does. Both Unix and Windows stubs updated.

### 2. TestCreateAutoConvoy_DepFailCleansUpOrphan → TestCreateAutoConvoy_DepFailIsNonFatal

**Root cause:** Commit 103b6aaa deliberately changed `createAutoConvoy` from fatal-with-cleanup to non-fatal-warning when `bd dep add` fails. From that commit message:

> *bd dep add validates both IDs exist in the same database, which fails for cross-rig beads (e.g., hq-cv convoy tracking a gas- bead) since beads v0.62 removed routing. Made these non-fatal with warnings.*

The test was written for the old fatal behavior and was never updated to match. Related: #3217 (cross-rig routing failure), #3181 (cross-prefix resolution failure).

**Fix:** Renamed test to `TestCreateAutoConvoy_DepFailIsNonFatal`. Verifies the current intentional behavior: no error returned, convoy ID non-empty, `create` logged, `close` NOT logged.

### CI impact

Together with #3393 (lint fixes), this should make `main`'s CI fully green:
- #3393 fixes Lint ✓
- #3394 fixes Test + Integration Tests ✓

## Test plan

- [x] `go test ./internal/beads/ -run TestBdSupportsAllowStale -v` — passes
- [x] `go test ./internal/cmd/ -run TestCreateAutoConvoy_DepFail -v` — passes
- [x] `go build ./...` — compiles clean
- [x] `go vet ./...` — passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)