### PR TITLE
feat: require mayor approval before scope expansion in mol-polecat-work

### DIFF
--- a/internal/formula/formulas/mol-polecat-work.formula.toml
+++ b/internal/formula/formulas/mol-polecat-work.formula.toml
@@ -226,6 +226,13 @@ Do the actual implementation work.
 - Make atomic, focused commits
 - Keep changes scoped to the assigned issue
 - Don't gold-plate or scope-creep
+- **Scope is a contract.** The bead description defines what you build. If you believe \
+the issue requires work beyond what is described, mail the mayor BEFORE implementing it:
+  ```bash
+  gt mail send mayor/ -s "Scope question: {{issue}}" -m "I think we also need X because Y. Proceed?"
+  ```
+  Wait for a response before expanding scope. Do NOT build unrequested features and \
+present them as complete.
 
 **Persist findings as you go (CRITICAL for session survival):**
 Your session can die at any time (context limit, crash, SIGKILL). Code changes


### PR DESCRIPTION
Closes steveyegge/gastown#3405

Adds a scope-contract step to `mol-polecat-work`: if a polecat believes the work requires something beyond the bead description, it must mail the mayor and wait for approval before proceeding. Keeps polecats focused and makes scope changes explicit.