### PR TITLE
feat: include bead description and diff stat in PR body

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -769,7 +769,35 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 					if issueTitle == "" {
 						prTitle = issueID
 					}
-					prBody := fmt.Sprintf("## Summary\n\nPolecat branch ready for human review.\n\n- **Issue**: %s\n- **Branch**: %s\n\n---\n*Created by gt done (no_merge=true, merge_strategy=pr)*", issueID, branch)
+					// Build PR body from bead description + diff stat
+					var prBodyBuilder strings.Builder
+					prBodyBuilder.WriteString("## Summary\n\n")
+					if sourceIssueForNoMerge.Description != "" {
+						// Strip attachment metadata lines from description
+						descLines := strings.Split(sourceIssueForNoMerge.Description, "\n")
+						var cleanDesc []string
+						for _, line := range descLines {
+							trimmed := strings.TrimSpace(line)
+							if strings.HasPrefix(trimmed, "attached_") || strings.HasPrefix(trimmed, "dispatched_by:") || strings.HasPrefix(trimmed, "formula_vars:") {
+								continue
+							}
+							cleanDesc = append(cleanDesc, line)
+						}
+						desc := strings.TrimSpace(strings.Join(cleanDesc, "\n"))
+						if desc != "" {
+							prBodyBuilder.WriteString(desc)
+							prBodyBuilder.WriteString("\n\n")
+						}
+					}
+					// Add diff stat for quick review context
+					if diffStat, diffErr := g.DiffStat(defaultBranch + "..." + branch); diffErr == nil && diffStat != "" {
+						prBodyBuilder.WriteString("## Changes\n\n```\n")
+						prBodyBuilder.WriteString(diffStat)
+						prBodyBuilder.WriteString("```\n\n")
+					}
+					prBodyBuilder.WriteString("---\n")
+					prBodyBuilder.WriteString(fmt.Sprintf("*Polecat: %s | Issue: %s*\n", worker, issueID))
+					prBody := prBodyBuilder.String()
 					ghCmd := exec.CommandContext(context.Background(), "gh", "pr", "create",
 						"--base", defaultBranch,
 						"--head", branch,

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1348,6 +1348,11 @@ func (g *Git) BranchCreatedDate(branch string) (string, error) {
 }
 
 // CommitsAhead returns the number of commits that branch has ahead of base.
+// DiffStat returns the --stat output for a diff range (e.g., "main...feature").
+func (g *Git) DiffStat(rangeSpec string) (string, error) {
+	return g.run("diff", "--stat", rangeSpec)
+}
+
 // For example, CommitsAhead("main", "feature") returns how many commits
 // are on feature that are not on main.
 func (g *Git) CommitsAhead(base, branch string) (int, error) {


### PR DESCRIPTION
## Summary

When `require_review=true` creates a GitHub PR via `gt done`, the PR body now includes:

- The bead's description (with attachment metadata stripped)
- A `git diff --stat` block for quick review context
- Polecat name and issue ID in the footer

Previously the body was a static template: "Polecat branch ready for human review" with just the issue ID and branch name — not useful for reviewers.

## Changes

- `internal/cmd/done.go`: Build PR body from `sourceIssueForNoMerge.Description` + `g.DiffStat()`
- `internal/git/git.go`: Add `DiffStat(rangeSpec)` method

## Test plan

- [ ] Sling work with `require_review=true` configured
- [ ] Verify PR body contains bead description and diff stat
- [ ] Verify attachment metadata lines (attached_molecule, dispatched_by, etc.) are stripped
- [ ] Verify empty descriptions still produce a valid PR body

🤖 Generated with [Claude Code](https://claude.com/claude-code)