### PR TITLE
fix: guard PR branch deletion and add review approval check (gas-fk4)

### DIFF
--- a/internal/cmd/mq.go
+++ b/internal/cmd/mq.go
@@ -562,8 +562,12 @@ func runMQPostMerge(_ *cobra.Command, args []string) error {
 		return nil // non-fatal: beads cleanup succeeded
 	}
 
-	// Delete remote branch
-	if err := rigGit.DeleteRemoteBranch("origin", mr.Branch); err != nil {
+	// Delete remote branch — but skip if there's an open PR on it.
+	// Deleting a branch with an open PR causes GitHub to auto-close the PR
+	// as "closed" (not "merged"), destroying the PR audit trail. (gas-fk4)
+	if rigGit.HasOpenPR(mr.Branch) {
+		fmt.Printf("  %s Skipping remote branch delete for %s: open PR exists (gas-fk4)\n", style.Dim.Render("○"), mr.Branch)
+	} else if err := rigGit.DeleteRemoteBranch("origin", mr.Branch); err != nil {
 		fmt.Printf("  %s remote branch delete: %v\n", style.Warning.Render("⚠"), err)
 	} else {
 		fmt.Printf("  %s Deleted remote branch: %s\n", style.Success.Render("✓"), mr.Branch)

--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -580,7 +580,28 @@ echo "Local:  $LOCAL_SHA"
 echo "Remote: $REMOTE_SHA"
 ```
 
-**If SHAs match**: Push succeeded. Continue to Step 2.
+**If SHAs match**: Push succeeded.
+
+**Step 1.6 (direct only): CHECK FOR OPEN PR ON BRANCH (gas-fk4)**
+
+Before proceeding to post-merge cleanup (which deletes the remote branch),
+check if this branch has an open GitHub PR. Deleting the remote branch would
+cause GitHub to auto-close the PR as "closed" (not "merged"), destroying
+the PR audit trail and making it appear that work was rejected.
+
+```bash
+OPEN_PR=$(gh pr list --head <polecat-branch> --state open --json number --limit 1 2>/dev/null || echo "[]")
+if [ "$OPEN_PR" != "[]" ] && [ "$OPEN_PR" != "" ]; then
+  echo "Open PR found on branch — will use --skip-branch-delete in post-merge"
+  # Set flag for Step 3 (post-merge cleanup) to skip branch deletion
+  SKIP_BRANCH_DELETE=true
+fi
+```
+
+If an open PR exists, pass `--skip-branch-delete` to `gt mq post-merge` in Step 3.
+The PR should be merged or closed through the GitHub API, not by branch deletion.
+
+Continue to Step 2.
 
 **If SHAs differ**: STOP. Push failed silently.
 - DO NOT send MERGED notification
@@ -657,6 +678,44 @@ Attempt-Number: 1"
 Then skip to Step 4 (archive mail) and continue patrol.
 
 **If CI checks PASS:**
+
+**Step 1.7 (pr only): CHECK REVIEW APPROVAL STATUS (gas-fk4)**
+
+⚠️ **DO NOT merge a PR that has not been explicitly approved.**
+Plain review comments (COMMENTED) are NOT approval. Only an explicit
+"APPROVED" reviewDecision allows the merge to proceed.
+
+```bash
+REVIEW_DECISION=$(gh pr view <polecat-branch> --repo "$REPO_URL" --json reviewDecision -q '.reviewDecision')
+echo "Review decision: $REVIEW_DECISION"
+```
+
+| reviewDecision | Action |
+|----------------|--------|
+| `APPROVED` | Proceed to merge |
+| `CHANGES_REQUESTED` | Send FIX_NEEDED to polecat (reviewer rejected), skip merge |
+| `REVIEW_REQUIRED` or empty | PR has not been reviewed yet — skip merge, leave PR open |
+
+**If CHANGES_REQUESTED:**
+```bash
+gt mail send <rig>/polecats/<polecat-name> -s "FIX_NEEDED <polecat-name>" --stdin <<'BODY'
+Branch: <branch>
+Issue: <issue-id>
+PR: ${PR_URL}
+Failure-Type: review-rejected
+Error: Reviewer requested changes on the PR. Address the review feedback and resubmit.
+Attempt-Number: 1
+BODY
+```
+Clean up temp branch, archive MERGE_READY, skip to loop-check.
+
+**If REVIEW_REQUIRED or empty (not yet reviewed):**
+Do NOT merge. Do NOT close. Do NOT send FIX_NEEDED. Leave the PR open
+for human review. Archive the MERGE_READY mail — the PR will be picked
+up on a future patrol cycle if/when it gets approved.
+Clean up temp branch and skip to loop-check.
+
+**If APPROVED:**
 Merge the PR:
 ```bash
 gh pr merge <polecat-branch> --repo "$REPO_URL" --merge --delete-branch
@@ -697,7 +756,11 @@ This single command handles closing the MR bead, closing the source issue, and
 deleting the remote polecat branch (respects delete_merged_branches config):
 
 ```bash
-gt mq post-merge <rig> <mr-bead-id>
+# If an open PR was detected in Step 1.6 (direct) or merge_strategy=pr,
+# pass --skip-branch-delete to avoid auto-closing the PR via head_ref_delete.
+# Otherwise, omit the flag.
+gt mq post-merge <rig> <mr-bead-id>            # normal (no open PR)
+gt mq post-merge <rig> <mr-bead-id> --skip-branch-delete  # open PR exists
 ```
 
 The MR bead ID was in the MERGE_READY message or find via:
@@ -709,7 +772,8 @@ Verify the command output shows all steps succeeded (✓ for each).
 
 **Note**: In PR mode, the source branch is NOT deleted (it's the PR head branch).
 `delete_merged_branches` is ignored when merge_strategy=pr — the branch is cleaned
-up when the PR is merged on GitHub.
+up when the PR is merged on GitHub. The `--skip-branch-delete` flag (gas-fk4) also
+prevents branch deletion when an open PR is detected in direct merge mode.
 
 **Step 4: Archive the MERGE_READY mail (REQUIRED)**
 ```bash

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -781,6 +781,21 @@ func (g *Git) DeleteRemoteBranch(remote, branch string) error {
 	return err
 }
 
+// HasOpenPR checks whether the given branch has an open pull request on GitHub.
+// Uses the gh CLI to query for open PRs with the branch as head ref.
+// Returns false on any error (fail-open: branch deletion proceeds if gh is unavailable).
+func (g *Git) HasOpenPR(branch string) bool {
+	cmd := exec.Command("gh", "pr", "list", "--head", branch, "--state", "open", "--json", "number", "--limit", "1")
+	cmd.Dir = g.workDir
+	out, err := cmd.Output()
+	if err != nil {
+		return false // fail-open: can't determine PR state, allow deletion
+	}
+	out = bytes.TrimSpace(out)
+	// Empty array "[]" means no open PRs
+	return len(out) > 2
+}
+
 // ListRemoteRefs returns remote ref names matching a prefix using ls-remote.
 // The prefix filters refs (e.g., "refs/heads/polecat/" for all polecat branches).
 // Returns full ref names like "refs/heads/polecat/furiosa-abc123".

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -1077,8 +1077,14 @@ func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
 		// Remote delete — only polecat branches. Non-polecat branches may belong
 		// to contributor forks with open upstream PRs; deleting them from origin
 		// causes GitHub to auto-close those PRs via head_ref_delete. (GH#2669)
+		// gas-fk4: Also skip deletion for polecat branches that have open PRs.
+		// When merge_strategy=pr, polecat branches have GitHub PRs that should
+		// be closed via gh pr merge (showing "merged"), not via branch deletion
+		// (which shows "closed" and destroys the PR audit trail).
 		if isPolecat {
-			if err := e.git.DeleteRemoteBranch("origin", mr.Branch); err != nil {
+			if e.git.HasOpenPR(mr.Branch) {
+				_, _ = fmt.Fprintf(e.output, "[Engineer] Skipping remote branch delete for %s: open PR exists (gas-fk4)\n", mr.Branch)
+			} else if err := e.git.DeleteRemoteBranch("origin", mr.Branch); err != nil {
 				_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to delete remote branch %s: %v\n", mr.Branch, err)
 			} else {
 				_, _ = fmt.Fprintf(e.output, "[Engineer] Deleted remote branch: %s\n", mr.Branch)


### PR DESCRIPTION
## Summary

Prevent agents from closing PRs when users leave review comments (gas-fk4).

- Add `HasOpenPR()` to git package — checks for open GitHub PRs before allowing remote branch deletion (fail-open)
- Guard remote branch deletion in `engineer.go` and `mq.go` post-merge — skip when open PR exists, preventing GitHub auto-close via `head_ref_delete`
- Add review approval check (Step 1.7) to refinery patrol formula for `merge_strategy=pr` — only merge when `reviewDecision == APPROVED`
- Add open PR detection (Step 1.6) to refinery patrol formula for `merge_strategy=direct` — pass `--skip-branch-delete` when open PR found

## Test plan

- [ ] Verify `go build ./...` and `go vet ./...` pass
- [ ] Verify `HasOpenPR()` returns false when no PR exists (fail-open)
- [ ] Verify refinery skips remote branch delete when open PR detected
- [ ] Verify refinery formula checks reviewDecision before merging in PR mode

🤖 Generated with [Claude Code](https://claude.com/claude-code)