### PR TITLE
fix(plugin): initialize ENABLED_RIGS array to avoid unbound variable

### DIFF
--- a/plugins/submodule-commit/run.sh
+++ b/plugins/submodule-commit/run.sh
@@ -19,7 +19,7 @@ if [ -z "$RIG_JSON" ]; then
   exit 0
 fi
 
-declare -a ENABLED_RIGS
+ENABLED_RIGS=()
 while IFS= read -r REPO_PATH; do
   [ -z "$REPO_PATH" ] && continue
   [ ! -f "$REPO_PATH/.gitmodules" ] && continue


### PR DESCRIPTION
## Summary
- `declare -a ENABLED_RIGS` does not satisfy bash's `nounset` (`set -u`) option when the array remains empty after the loop. This causes `${#ENABLED_RIGS[@]}` on line 35 to fail with `unbound variable`.
- Fix: use direct initialization `ENABLED_RIGS=()` instead.

## Test plan
- [x] Reproduced: `bash -x plugins/submodule-commit/run.sh` fails at line 35 when no rigs have `plugins.submodule-commit.enabled=true`
- [x] Verified fix: script exits cleanly with "SKIP: no opt-in rigs with submodules"
- [x] Tested on bash 5.3.9 (macOS)