### PR TITLE
fix: block sudo and system package installs in polecat PreToolUse guard

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -154,7 +154,7 @@ The registry (`~/gt/hooks/registry.toml`) defines 7 hooks, 5 enabled by default:
 | mail-check | UserPromptSubmit | Yes | all |
 | costs-record | Stop | Yes | crew, polecat, witness, refinery |
 | clone-guard | PreToolUse | No | crew, polecat |
-| dangerous-command-guard | PreToolUse | No | crew, polecat |
+| dangerous-command-guard | PreToolUse | Yes | crew, polecat |
 
 Additional hooks exist in settings.json files but are not yet in the registry:
 

--- a/internal/cmd/tap_guard_dangerous.go
+++ b/internal/cmd/tap_guard_dangerous.go
@@ -12,10 +12,16 @@ import (
 
 var tapGuardDangerousCmd = &cobra.Command{
 	Use:   "dangerous-command",
-	Short: "Block dangerous commands (rm -rf, force push, etc.)",
+	Short: "Block dangerous commands (sudo, package installs, rm -rf, force push, etc.)",
 	Long: `Block dangerous commands via Claude Code PreToolUse hooks.
 
 This guard blocks operations that could cause irreversible damage:
+  - sudo <anything>      (agents must never elevate privileges)
+  - apt/apt-get/dnf/yum/pacman install (system package managers)
+  - brew install          (Homebrew package installs)
+  - pip install --system  (system-level Python installs)
+  - npm install -g        (global npm installs)
+  - gem install           (system-level Ruby installs)
   - rm -rf /             (only blocks root target; rm -rf ./build/ is allowed)
   - git push --force/-f  (--force-with-lease is allowed)
   - git reset --hard
@@ -70,6 +76,16 @@ func runTapGuardDangerous(cmd *cobra.Command, args []string) error {
 	}
 
 	lower := strings.ToLower(command)
+
+	// Check privilege escalation and package manager commands first
+	if reason := matchesSudo(lower); reason != "" {
+		printDangerousBlock(reason, command)
+		return NewSilentExit(2)
+	}
+	if reason := matchesPackageInstall(lower); reason != "" {
+		printDangerousBlock(reason, command)
+		return NewSilentExit(2)
+	}
 
 	// Check special patterns that need smarter matching
 	if reason := matchesDangerousRmRf(lower); reason != "" {
@@ -153,6 +169,58 @@ func matchesDangerousRmRf(command string) string {
 			return "filesystem destruction (rm -rf /)"
 		}
 	}
+	return ""
+}
+
+// matchesSudo blocks any command that starts with or contains "sudo".
+// Agents must never elevate privileges on the host system.
+func matchesSudo(command string) string {
+	fields := strings.Fields(command)
+	for _, f := range fields {
+		if f == "sudo" {
+			return "Agents must never use sudo — do not elevate privileges or modify the host OS"
+		}
+	}
+	return ""
+}
+
+// packageManagerPatterns lists system package manager install commands.
+// Each entry has the command prefix tokens and a reason.
+var packageManagerPatterns = []struct {
+	tokens []string
+	reason string
+}{
+	{[]string{"apt", "install"}, "System package install (apt) — use workspace tools instead"},
+	{[]string{"apt-get", "install"}, "System package install (apt-get) — use workspace tools instead"},
+	{[]string{"dnf", "install"}, "System package install (dnf) — use workspace tools instead"},
+	{[]string{"yum", "install"}, "System package install (yum) — use workspace tools instead"},
+	{[]string{"pacman", "-s"}, "System package install (pacman) — use workspace tools instead"},
+	{[]string{"brew", "install"}, "Package install (brew) — use workspace tools instead"},
+	{[]string{"gem", "install"}, "System gem install — use workspace tools instead"},
+}
+
+// matchesPackageInstall blocks system package manager install commands.
+// Also blocks "pip install" with --system flag and "npm install -g" (global installs).
+func matchesPackageInstall(command string) string {
+	// Check simple token-based patterns (apt install, dnf install, etc.)
+	for _, p := range packageManagerPatterns {
+		if matchesAllFragments(command, p.tokens) {
+			return p.reason
+		}
+	}
+
+	// pip install --system (but not regular pip install into a venv)
+	if strings.Contains(command, "pip") && strings.Contains(command, "install") && strings.Contains(command, "--system") {
+		return "System-level pip install — use a virtualenv or workspace tools instead"
+	}
+
+	// npm install -g / npm install --global
+	if strings.Contains(command, "npm") && strings.Contains(command, "install") {
+		if strings.Contains(command, " -g ") || strings.Contains(command, " -g") || strings.Contains(command, "--global") {
+			return "Global npm install — use workspace tools instead"
+		}
+	}
+
 	return ""
 }
 

--- a/internal/cmd/tap_guard_dangerous_test.go
+++ b/internal/cmd/tap_guard_dangerous_test.go
@@ -109,6 +109,70 @@ func TestMatchesDangerousGitPush(t *testing.T) {
 	}
 }
 
+func TestMatchesSudo(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		blocked bool
+	}{
+		// Should block
+		{"sudo dnf install", "sudo dnf install -y postgresql-contrib", true},
+		{"sudo rm", "sudo rm -rf /var/log/syslog", true},
+		{"sudo bare", "sudo su", true},
+		{"sudo in pipeline", "echo foo | sudo tee /etc/config", true},
+
+		// Should allow
+		{"no sudo", "echo hello", false},
+		{"sudo in string", "echo 'do not use sudo'", false}, // contains "sudo" as substring of different token? Actually "sudo" IS a token here
+		{"pseudocode", "cat pseudocode.txt", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesSudo(strings.ToLower(tt.command)) != ""
+			if got != tt.blocked {
+				t.Errorf("matchesSudo(%q) blocked=%v, want %v", tt.command, got, tt.blocked)
+			}
+		})
+	}
+}
+
+func TestMatchesPackageInstall(t *testing.T) {
+	tests := []struct {
+		name    string
+		command string
+		blocked bool
+	}{
+		// Should block
+		{"apt install", "apt install -y curl", true},
+		{"apt-get install", "apt-get install -y build-essential", true},
+		{"dnf install", "dnf install -y postgresql-contrib", true},
+		{"yum install", "yum install -y gcc", true},
+		{"pacman -S", "pacman -S git", true},
+		{"brew install", "brew install node", true},
+		{"gem install", "gem install bundler", true},
+		{"pip install --system", "pip install --system requests", true},
+		{"pip3 install --system", "pip3 install --system flask", true},
+		{"npm install -g", "npm install -g typescript", true},
+		{"npm install --global", "npm install --global eslint", true},
+
+		// Should allow
+		{"pip install (venv ok)", "pip install requests", false},
+		{"npm install (local ok)", "npm install express", false},
+		{"npm install --save-dev", "npm install --save-dev jest", false},
+		{"go install", "go install ./...", false},
+		{"cargo install", "cargo install ripgrep", false},
+		{"normal command", "ls -la", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := matchesPackageInstall(strings.ToLower(tt.command)) != ""
+			if got != tt.blocked {
+				t.Errorf("matchesPackageInstall(%q) blocked=%v, want %v", tt.command, got, tt.blocked)
+			}
+		})
+	}
+}
+
 // TestDangerousGuard_Integration tests the full pattern set end-to-end.
 func TestDangerousGuard_Integration(t *testing.T) {
 	tests := []struct {
@@ -116,7 +180,18 @@ func TestDangerousGuard_Integration(t *testing.T) {
 		command string
 		blocked bool
 	}{
-		// Blocked
+		// Blocked — privilege escalation
+		{"sudo command", "sudo dnf install -y foo", true},
+		{"sudo rm", "sudo rm -rf /var/cache", true},
+
+		// Blocked — package installs
+		{"apt install", "apt install -y curl", true},
+		{"dnf install", "dnf install -y postgresql-contrib", true},
+		{"brew install", "brew install node", true},
+		{"npm install -g", "npm install -g typescript", true},
+		{"pip install --system", "pip install --system requests", true},
+
+		// Blocked — destructive operations
 		{"rm -rf /", "rm -rf /", true},
 		{"git push --force", "git push --force origin main", true},
 		{"git reset --hard", "git reset --hard HEAD~1", true},
@@ -130,13 +205,19 @@ func TestDangerousGuard_Integration(t *testing.T) {
 		{"git push --force-with-lease", "git push --force-with-lease origin main", false},
 		{"git push normal", "git push origin main", false},
 		{"git reset soft", "git reset --soft HEAD~1", false},
+		{"pip install (venv)", "pip install requests", false},
+		{"npm install (local)", "npm install express", false},
 		{"normal command", "ls -la", false},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			lower := strings.ToLower(tt.command)
 			blocked := false
-			if matchesDangerousRmRf(lower) != "" {
+			if matchesSudo(lower) != "" {
+				blocked = true
+			} else if matchesPackageInstall(lower) != "" {
+				blocked = true
+			} else if matchesDangerousRmRf(lower) != "" {
 				blocked = true
 			} else if matchesDangerousGitPush(lower) != "" {
 				blocked = true

--- a/internal/cmd/tap_list.go
+++ b/internal/cmd/tap_list.go
@@ -56,9 +56,9 @@ func runTapList(cmd *cobra.Command, args []string) error {
 		{
 			name:        "dangerous-command",
 			kind:        "guard",
-			description: "Block rm -rf, force push, hard reset, etc.",
+			description: "Block sudo, package installs, rm -rf, force push, hard reset, etc.",
 			event:       "PreToolUse",
-			matchers:    []string{"Bash(rm -rf /*)", "Bash(git push --force*)", "Bash(git push -f*)"},
+			matchers:    []string{"Bash(sudo *)", "Bash(apt install*)", "Bash(dnf install*)", "Bash(brew install*)", "Bash(rm -rf /*)", "Bash(git push --force*)", "Bash(git push -f*)"},
 			implemented: true,
 		},
 	}

--- a/internal/formula/formulas/mol-polecat-work.formula.toml
+++ b/internal/formula/formulas/mol-polecat-work.formula.toml
@@ -202,6 +202,9 @@ Do the actual implementation work.
 - Make atomic, focused commits
 - Keep changes scoped to the assigned issue
 - Don't gold-plate or scope-creep
+- **NEVER run `sudo` or install system packages** (apt, dnf, yum, pacman, brew install,
+  pip install --system, npm install -g). Use the tools already in your workspace.
+  If a dependency is missing, file a bead — do not modify the host OS.
 
 **Persist findings as you go (CRITICAL for session survival):**
 Your session can die at any time (context limit, crash, SIGKILL). Code changes

--- a/internal/hooks/templates/claude/settings-autonomous.json
+++ b/internal/hooks/templates/claude/settings-autonomous.json
@@ -32,6 +32,69 @@
             "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard pr-workflow"
           }
         ]
+      },
+      {
+        "matcher": "Bash(sudo *)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard dangerous-command"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash(apt install*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard dangerous-command"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash(apt-get install*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard dangerous-command"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash(dnf install*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard dangerous-command"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash(yum install*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard dangerous-command"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash(pacman -S*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard dangerous-command"
+          }
+        ]
+      },
+      {
+        "matcher": "Bash(brew install*)",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard dangerous-command"
+          }
+        ]
       }
     ],
     "SessionStart": [


### PR DESCRIPTION
## Summary
- Adds sudo/apt/dnf/yum/pacman/brew/pip/npm blocking to the polecat PreToolUse guard
- Polecats were running `sudo` to install system packages, which is dangerous and unnecessary
- Guard rejects commands before they execute with a clear error message
- Includes 85 lines of test coverage for the new guard rules

## Test plan
- [x] Unit tests for blocked commands (sudo, apt install, etc.)
- [x] Unit tests for allowed commands (normal git, go, make, etc.)
- [ ] Existing tap guard tests still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)