### PR TITLE
fix: align tests and lint with recent beads v0.62 changes

### DIFF
--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -130,30 +130,33 @@ func TestBdSupportsAllowStale_ReprobesWhenBinaryPathChanges(t *testing.T) {
 func writeAllowStaleBDStub(t *testing.T, dir string, supportsAllowStale bool) {
 	t.Helper()
 
+	// bd v0.60+ exits 0 even on unknown flags, printing the error to stderr.
+	// Detection now checks output for "unknown flag" rather than exit code.
 	var scriptPath, script string
 	if runtime.GOOS == "windows" {
 		scriptPath = filepath.Join(dir, "bd.bat")
-		exitCode := "1"
 		if supportsAllowStale {
-			exitCode = "0"
+			script = `@echo off
+exit /b 0
+`
+		} else {
+			script = `@echo off
+echo unknown flag --allow-stale 1>&2
+exit /b 0
+`
 		}
-		script = fmt.Sprintf(`@echo off
-setlocal enableextensions
-if "%%1"=="--allow-stale" exit /b %s
-exit /b 1
-`, exitCode)
 	} else {
 		scriptPath = filepath.Join(dir, "bd")
-		exitCode := "1"
 		if supportsAllowStale {
-			exitCode = "0"
+			script = `#!/bin/sh
+exit 0
+`
+		} else {
+			script = `#!/bin/sh
+echo "unknown flag --allow-stale" >&2
+exit 0
+`
 		}
-		script = fmt.Sprintf(`#!/bin/sh
-if [ "$1" = "--allow-stale" ]; then
-  exit %s
-fi
-exit 1
-`, exitCode)
 	}
 
 	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {

--- a/internal/beads/store.go
+++ b/internal/beads/store.go
@@ -545,7 +545,7 @@ func (b *Beads) storeDelegationSet(childID string, d *Delegation) error {
 		return fmt.Errorf("building delegation metadata: %w", err)
 	}
 
-	return b.store.UpdateIssue(ctx, childID, map[string]interface{}{"metadata": json.RawMessage(meta)}, actor)
+	return b.store.UpdateIssue(ctx, childID, map[string]interface{}{"metadata": meta}, actor)
 }
 
 // storeDelegationClear removes the "delegated_from" key from the issue's metadata.
@@ -565,7 +565,7 @@ func (b *Beads) storeDelegationClear(childID string) error {
 		return fmt.Errorf("clearing delegation metadata: %w", err)
 	}
 
-	return b.store.UpdateIssue(ctx, childID, map[string]interface{}{"metadata": json.RawMessage(meta)}, actor)
+	return b.store.UpdateIssue(ctx, childID, map[string]interface{}{"metadata": meta}, actor)
 }
 
 // mergeMetadataKey sets a key in a JSON metadata blob, preserving other keys.

--- a/internal/cmd/sling_batch_test.go
+++ b/internal/cmd/sling_batch_test.go
@@ -951,9 +951,10 @@ exit 0
 	}
 }
 
-// TestCreateAutoConvoy_DepFailCleansUpOrphan verifies that when the dep add
-// fails, the convoy is closed to prevent orphans.
-func TestCreateAutoConvoy_DepFailCleansUpOrphan(t *testing.T) {
+// TestCreateAutoConvoy_DepFailIsNonFatal verifies that when the dep add
+// fails, the convoy is still returned (dep failure is non-fatal since
+// cross-rig beads can't satisfy bd dep add validation after beads v0.62).
+func TestCreateAutoConvoy_DepFailIsNonFatal(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows")
 	}
@@ -973,9 +974,6 @@ case "$cmd" in
   dep)
     exit 1
     ;;
-  close)
-    exit 0
-    ;;
 esac
 exit 0
 `
@@ -985,25 +983,25 @@ exit 0
 		t.Fatalf("rewrite bd stub: %v", err)
 	}
 
-	_, err := createAutoConvoy("gt-aaa", "My task", false, "", "")
-	if err == nil {
-		t.Fatal("expected error when dep add fails, got nil")
+	convoyID, err := createAutoConvoy("gt-aaa", "My task", false, "", "")
+	if err != nil {
+		t.Fatalf("expected dep failure to be non-fatal, got error: %v", err)
 	}
-	if !strings.Contains(err.Error(), "tracking relation") {
-		t.Errorf("error should mention tracking relation, got: %v", err)
+	if convoyID == "" {
+		t.Fatal("expected convoy ID to be returned even when dep add fails")
 	}
 
-	// Verify close was called (orphan cleanup)
+	// Verify dep was attempted but close was NOT called (no orphan cleanup)
 	logBytes, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatalf("read log: %v", err)
 	}
 	logContent := string(logBytes)
-	if !strings.Contains(logContent, "CMD:close") {
-		t.Errorf("expected close command for orphan cleanup:\n%s", logContent)
+	if !strings.Contains(logContent, "CMD:dep") {
+		t.Errorf("expected dep add to be attempted:\n%s", logContent)
 	}
-	if !strings.Contains(logContent, "tracking dep failed") {
-		t.Errorf("close should include 'tracking dep failed' reason:\n%s", logContent)
+	if strings.Contains(logContent, "CMD:close") {
+		t.Errorf("close should NOT be called — dep failure is non-fatal:\n%s", logContent)
 	}
 }
 


### PR DESCRIPTION
## Summary
- **Lint**: Remove unnecessary `json.RawMessage()` conversions in `store.go` (lines 548, 568) — `meta` is already `json.RawMessage`
- **TestCreateAutoConvoy_DepFailCleansUpOrphan**: Update test to match 103b6aaa which made dep-add failure non-fatal for cross-rig beads after beads v0.62
- **TestBdSupportsAllowStale_ReprobesWhenBinaryPathChanges**: Update test stubs to emit "unknown flag" on stderr, matching 9dfe19a3 which switched from exit-code to output-based detection

## Context
All three CI jobs on main (Integration Tests, Lint, Test) are failing. These are test/lint regressions from two recent commits that changed production behavior without updating the corresponding tests.

## Test plan
- [x] `TestBdSupportsAllowStale_ReprobesWhenBinaryPathChanges` passes locally
- [x] `TestCreateAutoConvoy_DepFailIsNonFatal` passes locally
- [x] `golangci-lint --enable unconvert ./internal/beads/` clean
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)