### PR TITLE
fix: initialize ENABLED_RIGS array to avoid unbound variable with set -u

### DIFF
--- a/plugins/submodule-commit/run.sh
+++ b/plugins/submodule-commit/run.sh
@@ -19,7 +19,7 @@ if [ -z "$RIG_JSON" ]; then
   exit 0
 fi
 
-declare -a ENABLED_RIGS
+declare -a ENABLED_RIGS=()
 while IFS= read -r REPO_PATH; do
   [ -z "$REPO_PATH" ] && continue
   [ ! -f "$REPO_PATH/.gitmodules" ] && continue


### PR DESCRIPTION
## Summary

- `declare -a ENABLED_RIGS` → `declare -a ENABLED_RIGS=()` in `plugins/submodule-commit/run.sh`

Under bash 5.2+ with `set -euo pipefail`, referencing an uninitialized array with `${#ENABLED_RIGS[@]}` on line 35 triggers `unbound variable` and aborts the script. Initializing to an empty array with `=()` satisfies `set -u`.

## Test plan

- [ ] Run `plugins/submodule-commit/run.sh` in bash 5.2+ with no opt-in rigs — should exit cleanly with "SKIP: no opt-in rigs with submodules"
- [ ] Verify no regression with opt-in rigs that have submodules

🤖 Generated with [Claude Code](https://claude.com/claude-code)