### PR TITLE
test: remove Windows from cross-platform build targets

### DIFF
--- a/cmd/gt/build_test.go
+++ b/cmd/gt/build_test.go
@@ -31,7 +31,6 @@ func TestCrossPlatformBuild(t *testing.T) {
 		{"linux", "arm64", "0"},
 		{"darwin", "amd64", "0"},
 		{"darwin", "arm64", "0"},
-		{"windows", "amd64", "0"},
 		{"freebsd", "amd64", "0"},
 	}
 


### PR DESCRIPTION
## Summary

- Removes `windows/amd64` from the `TestCrossPlatformBuild` platform list

Gas Town requires tmux and Unix process signals (`SIGTSTP`, `SIGCONT`, `kill(-pgid, sig)`) which have no native Windows equivalent. WSL2 is the supported path for Windows users (per the discussion in #2716).

Keeping Windows in the cross-compile matrix causes spurious build failures whenever Unix-only code is added — most recently `estop.go` (PR #3237), which uses `syscall.SIGTSTP`, `syscall.SIGCONT`, and `syscall.Kill`.

## Test plan

- [ ] `go test ./cmd/gt/... -run TestCrossPlatformBuild` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)