### PR TITLE
test: update allow-stale stubs to match output-based detection

### DIFF
--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -133,27 +133,28 @@ func writeAllowStaleBDStub(t *testing.T, dir string, supportsAllowStale bool) {
 	var scriptPath, script string
 	if runtime.GOOS == "windows" {
 		scriptPath = filepath.Join(dir, "bd.bat")
-		exitCode := "1"
 		if supportsAllowStale {
-			exitCode = "0"
+			script = `@echo off
+exit /b 0
+`
+		} else {
+			script = `@echo off
+echo unknown flag: --allow-stale
+exit /b 0
+`
 		}
-		script = fmt.Sprintf(`@echo off
-setlocal enableextensions
-if "%%1"=="--allow-stale" exit /b %s
-exit /b 1
-`, exitCode)
 	} else {
 		scriptPath = filepath.Join(dir, "bd")
-		exitCode := "1"
 		if supportsAllowStale {
-			exitCode = "0"
+			script = `#!/bin/sh
+exit 0
+`
+		} else {
+			script = `#!/bin/sh
+echo "unknown flag: --allow-stale"
+exit 0
+`
 		}
-		script = fmt.Sprintf(`#!/bin/sh
-if [ "$1" = "--allow-stale" ]; then
-  exit %s
-fi
-exit 1
-`, exitCode)
 	}
 
 	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {


### PR DESCRIPTION
## Summary

- Updates `writeAllowStaleBDStub` in `beads_test.go` to match the detection logic introduced in 9dfe19a

Commit 9dfe19a changed `BdSupportsAllowStale` to detect `--allow-stale` support by checking for `"unknown flag"` in combined stdout/stderr output, since bd v0.60+ always exits 0 even for unknown flags. The test stubs were not updated at the time, leaving both the supporting and non-supporting stubs producing no output — making `BdSupportsAllowStale` always return `true` regardless of which stub is active, so `TestBdSupportsAllowStale_ReprobesWhenBinaryPathChanges` always failed.

The non-supporting stub now prints `"unknown flag: --allow-stale"` and exits 0, matching what bd v0.60+ actually does.

## Test plan

- [ ] `go test ./internal/beads/... -run TestBdSupportsAllowStale` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)