### PR TITLE
fix(reaper): don't escalate on Dolt 'nothing to commit'

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -498,11 +498,15 @@ func purgeClosedWisps(db *sql.DB, dbName string, purgeAge time.Duration, dryRun 
 		}
 		commitMsg := fmt.Sprintf("reaper: purge %d closed wisps from %s", totalDeleted, dbName)
 		if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
-			// Non-fatal — log but continue.
-			anomalies = append(anomalies, Anomaly{
-				Type:    "dolt_commit_failed",
-				Message: fmt.Sprintf("dolt commit after purge failed: %v", err),
-			})
+			if !isNothingToCommit(err) {
+				// Non-fatal — log but continue.
+				anomalies = append(anomalies, Anomaly{
+					Type:    "dolt_commit_failed",
+					Message: fmt.Sprintf("dolt commit after purge failed: %v", err),
+				})
+			}
+			// "nothing to commit" is expected when Dolt autocommit=1 already
+			// persisted the DELETEs — not an anomaly.
 		}
 	}
 
@@ -657,10 +661,12 @@ func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (
 		}
 		commitMsg := fmt.Sprintf("reaper: auto-close %d stale issues in %s", len(ids), dbName)
 		if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
-			result.Anomalies = append(result.Anomalies, Anomaly{
-				Type:    "dolt_commit_failed",
-				Message: fmt.Sprintf("dolt commit after auto-close failed: %v", err),
-			})
+			if !isNothingToCommit(err) {
+				result.Anomalies = append(result.Anomalies, Anomaly{
+					Type:    "dolt_commit_failed",
+					Message: fmt.Sprintf("dolt commit after auto-close failed: %v", err),
+				})
+			}
 		}
 	}
 


### PR DESCRIPTION
## Summary
- Stop treating Dolt "nothing to commit" as a `dolt_commit_failed` anomaly in the reaper
- With Dolt autocommit=1 (server default), DELETEs are committed immediately, making the explicit `DOLT_COMMIT` call return "nothing to commit" — this is expected, not an error
- Fixes both `purgeClosedWisps` and `AutoClose` code paths
- Prevents recurring HIGH severity false-positive escalations (3 occurrences so far)

## Test plan
- [ ] Verify reaper purge runs without escalation when autocommit is on
- [ ] Verify real commit failures still escalate

🤖 Generated with [Claude Code](https://claude.com/claude-code)