### PR TITLE
fix: stop removing/modifying Dolt-internal files (.dolt/noms/LOCK, manifest, sql-server.info)

### DIFF
--- a/internal/doctor/stale_sql_server_info_check.go
+++ b/internal/doctor/stale_sql_server_info_check.go
@@ -96,17 +96,19 @@ func (c *StaleSQLServerInfoCheck) Run(ctx *CheckContext) *CheckResult {
 		Status:  StatusWarning,
 		Message: fmt.Sprintf("%d stale sql-server.info file(s) from dead Dolt servers", len(c.staleFiles)),
 		Details: details,
-		FixHint: "Run 'gt doctor --fix' to remove stale sql-server.info files",
+		FixHint: "Restart the Dolt server to clear stale sql-server.info files (Dolt writes and cleans these itself)",
 	}
 }
 
-// Fix removes all detected stale sql-server.info files.
+// Fix is a no-op. sql-server.info is a Dolt-internal file written and managed
+// by Dolt itself (see dolt/commands/sqlserver/creds.go). Restarting the Dolt
+// server will create a fresh one.
+//
+// WARNING: DO NOT remove, delete, or modify files inside Dolt's .dolt/
+// directory — including noms/LOCK files. These are Dolt-internal files.
+// Removing them WILL cause unrecoverable data corruption and data loss.
+// Dolt manages these files itself; external interference is never safe.
 func (c *StaleSQLServerInfoCheck) Fix(ctx *CheckContext) error {
-	for _, path := range c.staleFiles {
-		if err := os.Remove(path); err != nil {
-			return fmt.Errorf("could not remove stale sql-server.info %s: %w", path, err)
-		}
-	}
 	return nil
 }
 

--- a/internal/doctor/stale_sql_server_info_check_test.go
+++ b/internal/doctor/stale_sql_server_info_check_test.go
@@ -50,7 +50,7 @@ func TestStaleSQLServerInfoCheck_DetectsStaleFile(t *testing.T) {
 	}
 }
 
-func TestStaleSQLServerInfoCheck_FixRemovesFiles(t *testing.T) {
+func TestStaleSQLServerInfoCheck_FixIsNoOp(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses Unix process signals")
 	}
@@ -81,15 +81,15 @@ func TestStaleSQLServerInfoCheck_FixRemovesFiles(t *testing.T) {
 		t.Fatalf("expected 2 stale files, got %d", len(check.staleFiles))
 	}
 
-	// Fix
+	// Fix is a no-op — sql-server.info is a Dolt-internal file
 	if err := check.Fix(ctx); err != nil {
 		t.Fatalf("Fix failed: %v", err)
 	}
 
-	// Verify files are gone
+	// Verify files are NOT removed (Fix no longer deletes Dolt-internal files)
 	for _, path := range check.staleFiles {
-		if _, err := os.Stat(path); !os.IsNotExist(err) {
-			t.Errorf("expected %s to be removed after fix", path)
+		if _, err := os.Stat(path); os.IsNotExist(err) {
+			t.Errorf("expected %s to still exist after no-op fix", path)
 		}
 	}
 }

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1487,66 +1487,17 @@ func Start(townRoot string) error {
 	}
 
 	// Quarantine corrupted/phantom database dirs before server launch.
-	// Dolt auto-discovers ALL dirs in --data-dir. A phantom dir with a broken
-	// noms store (missing manifest) crashes the ENTIRE server. (gt-hs1i2)
+	// WARNING: DO NOT remove, delete, or modify files inside Dolt's .dolt/
+	// directory — including noms/LOCK files. These are Dolt-internal files.
+	// Removing them WILL cause unrecoverable data corruption and data loss.
+	// Dolt manages these files itself; external interference is never safe.
 	//
-	// Safety: move to .quarantine/ instead of deleting, and skip large databases
-	// that are likely legitimate but temporarily corrupted. (gt-xvh)
-	if entries, readErr := os.ReadDir(config.DataDir); readErr == nil {
-		for _, entry := range entries {
-			if !entry.IsDir() {
-				continue
-			}
-			name := entry.Name()
-			if strings.HasPrefix(name, ".") {
-				continue // Skip hidden dirs (.dolt, .doltcfg, .quarantine, etc.)
-			}
-			dbDir := filepath.Join(config.DataDir, name)
-			doltDir := filepath.Join(dbDir, ".dolt")
-			if _, statErr := os.Stat(doltDir); statErr != nil {
-				continue // Not a dolt dir at all — skip
-			}
-			manifest := filepath.Join(doltDir, "noms", "manifest")
-			if _, statErr := os.Stat(manifest); statErr == nil {
-				continue // Manifest exists — healthy database
-			}
-			// Missing manifest — this database would crash the server.
-			// Check size: large databases (>1MB) are likely legitimate databases
-			// with a transient corruption, not empty phantoms. Move instead of delete.
-			size := dirSize(dbDir)
-			quarantineDir := filepath.Join(config.DataDir, ".quarantine")
-			if err := os.MkdirAll(quarantineDir, 0755); err != nil {
-				fmt.Fprintf(os.Stderr, "Quarantine: failed to create quarantine dir: %v\n", err)
-				continue
-			}
-			dest := filepath.Join(quarantineDir, fmt.Sprintf("%s.%d", name, time.Now().Unix()))
-			if err := os.Rename(dbDir, dest); err != nil {
-				// Cross-device rename fails — fall back to removal only for tiny dirs
-				if size > 1<<20 { // >1MB — refuse to destroy, just warn
-					fmt.Fprintf(os.Stderr, "Quarantine: SKIPPING large database %q (%s, missing noms/manifest) — move failed: %v\n",
-						name, formatBytes(size), err)
-					fmt.Fprintf(os.Stderr, "  Manual fix: mv %s %s\n", dbDir, dest)
-				} else {
-					fmt.Fprintf(os.Stderr, "Quarantine: removing small phantom database dir %q (%s, missing noms/manifest)\n",
-						name, formatBytes(size))
-					_ = os.RemoveAll(dbDir)
-				}
-			} else {
-				fmt.Fprintf(os.Stderr, "Quarantine: moved database %q to %s (%s, missing noms/manifest)\n",
-					name, dest, formatBytes(size))
-			}
-		}
-	}
+	// Previously this section quarantined/removed database dirs with missing
+	// noms/manifest and cleaned up stale .dolt/noms/LOCK files. Both operations
+	// manipulated Dolt-internal state and risked data corruption. Dolt handles
+	// its own lock files and database integrity on startup.
 
-	// Clean up stale Dolt LOCK files in all database directories
 	databases, _ := ListDatabases(townRoot)
-	for _, db := range databases {
-		dbDir := filepath.Join(config.DataDir, db)
-		if err := cleanupStaleDoltLock(dbDir); err != nil {
-			// Non-fatal warning
-			fmt.Fprintf(os.Stderr, "Warning: %v\n", err)
-		}
-	}
 
 	// Open log file
 	logFile, err := os.OpenFile(config.LogFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
@@ -1672,39 +1623,13 @@ func Start(townRoot string) error {
 	return fmt.Errorf("Dolt server process started (PID %d) but not accepting connections after %v (%d databases × 5s): %w\nCheck logs with: gt dolt logs", cmd.Process.Pid, totalTimeout, dbCount, lastErr)
 }
 
-// cleanupStaleDoltLock removes a stale Dolt LOCK file if no process holds it.
-// Dolt's embedded mode uses a file lock at .dolt/noms/LOCK that can become stale
-// after crashes. This checks if any process holds the lock before removing.
-// Returns nil if lock is held by active processes (this is expected if bd is running).
-func cleanupStaleDoltLock(databaseDir string) error {
-	lockPath := filepath.Join(databaseDir, ".dolt", "noms", "LOCK")
-
-	// Check if lock file exists
-	if _, err := os.Stat(lockPath); os.IsNotExist(err) {
-		return nil // No lock file, nothing to clean
-	}
-
-	// Check if any process holds this file open using lsof
-	cmd := exec.Command("lsof", lockPath)
-	setProcessGroup(cmd)
-	_, err := cmd.Output()
-	if err != nil {
-		// lsof returns exit code 1 when no process has the file open
-		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
-			// No process holds the lock - safe to remove stale lock
-			if err := os.Remove(lockPath); err != nil {
-				return fmt.Errorf("failed to remove stale LOCK file: %w", err)
-			}
-			return nil
-		}
-		// Other error - ignore, let dolt handle it
-		return nil
-	}
-
-	// lsof found processes - lock is legitimately held (likely by bd)
-	// This is not an error condition; dolt server will handle the conflict
-	return nil
-}
+// WARNING: DO NOT remove, delete, or modify files inside Dolt's .dolt/
+// directory — including noms/LOCK files. These are Dolt-internal files.
+// Removing them WILL cause unrecoverable data corruption and data loss.
+// Dolt manages these files itself; external interference is never safe.
+//
+// cleanupStaleDoltLock previously removed stale .dolt/noms/LOCK files.
+// This was unsafe — Dolt manages its own lock files on startup.
 
 // DefaultDoltSocketPath is the default Unix socket Dolt creates.
 const DefaultDoltSocketPath = "/tmp/mysql.sock"

--- a/internal/formula/formulas/mol-dog-phantom-db.formula.toml
+++ b/internal/formula/formulas/mol-dog-phantom-db.formula.toml
@@ -7,19 +7,19 @@ startup, the broken noms store crashes INFORMATION_SCHEMA and can take down
 the entire server. (GH#2051, gt-hs1i2)
 
 Current behavior (from doltserver.go StartServer):
-- Quarantines phantom dirs found during startup (removes them)
-- ListDatabases() skips them with a warning
+- ListDatabases() skips phantom dirs with a warning
 
 This molecule adds continuous monitoring: detect phantoms that appear between
 server restarts (e.g., from DROP DATABASE + branch_control re-materialization),
-and escalate before the next restart hits them.
+and escalate before the next restart hits them. The fix is to restart the Dolt
+server — never to remove or modify files inside .dolt/ directories.
 
 ## Dog Contract
 
 This is infrastructure work. You:
 1. Scan the .dolt-data/ directory for phantom databases
 2. Report findings to Deacon
-3. Quarantine any phantoms found (remove corrupted dirs)
+3. Escalate if phantoms found (do NOT remove or modify any files)
 4. Return to kennel
 
 ## Variables
@@ -30,9 +30,12 @@ This is infrastructure work. You:
 
 ## Safety
 
-Phantom database directories have NO valid data (missing noms/manifest).
-Removing them is safe and prevents server crashes. The quarantine step
-mirrors the existing startup quarantine in doltserver.go."""
+WARNING: DO NOT remove, delete, or modify files inside Dolt's .dolt/
+directory — including noms/LOCK files. These are Dolt-internal files.
+Removing them WILL cause unrecoverable data corruption and data loss.
+Dolt manages these files itself; external interference is never safe.
+
+This molecule detects and escalates only — it never removes files."""
 formula = "mol-dog-phantom-db"
 version = 1
 
@@ -71,44 +74,35 @@ A phantom database has:
 **Exit criteria:** Scan complete, phantoms identified."""
 
 [[steps]]
-id = "quarantine"
-title = "Quarantine phantom databases"
+id = "escalate"
+title = "Escalate phantom databases"
 needs = ["scan"]
 description = """
-Remove phantom database directories to prevent server crashes.
+Escalate phantom database findings — do NOT remove or modify any files.
+
+WARNING: DO NOT remove, delete, or modify files inside Dolt's .dolt/
+directory — including noms/LOCK files. These are Dolt-internal files.
+Removing them WILL cause unrecoverable data corruption and data loss.
+Dolt manages these files itself; external interference is never safe.
 
 **1. If no phantoms found:**
-Skip this step — nothing to quarantine.
+Skip this step — nothing to escalate.
 
-**2. For each phantom database:**
-Remove the corrupted directory:
+**2. If phantoms were found, escalate:**
 ```bash
-rm -rf ~/gt/.dolt-data/<phantom-name>
-```
-
-This is safe because:
-- The directory has no valid noms store (no manifest)
-- It contains no recoverable data
-- Leaving it would crash the server on next restart
-
-**3. Record results:**
-- Count of phantoms quarantined
-- Any errors during removal
-
-**4. Escalate if phantoms were found:**
-```bash
-gt escalate -s HIGH "Dolt: quarantined {{phantom_count}} phantom database(s): {{phantom_names}}"
+gt escalate -s HIGH "Dolt: detected {{phantom_count}} phantom database(s): {{phantom_names}} — requires Dolt server restart to resolve"
 ```
 
 Phantom databases indicate a Dolt bug (DROP DATABASE + catalog re-materialization)
-that should be investigated.
+that should be investigated. The fix is to restart the Dolt server, not to
+remove directories.
 
-**Exit criteria:** All phantoms quarantined (or none found)."""
+**Exit criteria:** Findings escalated (or none found)."""
 
 [[steps]]
 id = "report"
 title = "Report findings and return to kennel"
-needs = ["quarantine"]
+needs = ["escalate"]
 description = """
 Generate summary and signal completion.
 

--- a/internal/templates/roles/dog.md.tmpl
+++ b/internal/templates/roles/dog.md.tmpl
@@ -187,7 +187,10 @@ Steps: scan databases → cleanup orphans → report
 ```bash
 ls -d {{ .TownRoot }}/.dolt-data/*/                  # List database dirs
 # Phantom = has .dolt/ subdir but missing .dolt/noms/manifest
-# Quarantine: rm -rf {{ .TownRoot }}/.dolt-data/<phantom-name>
+# WARNING: DO NOT remove, delete, or modify files inside Dolt's .dolt/
+# directory — including noms/LOCK files. These are Dolt-internal files.
+# Removing them WILL cause unrecoverable data corruption and data loss.
+# Escalate phantom findings; restart Dolt server to resolve.
 ```
 
 Steps: scan → quarantine → report

--- a/internal/templates/townroot/claude.md
+++ b/internal/templates/townroot/claude.md
@@ -51,7 +51,7 @@ production server and degrade performance. This is a recurring problem.
 {{cmd}} dolt cleanup             # Remove orphan databases (safe — protects production DBs)
 ```
 
-**NEVER use `rm -rf` on `~/.dolt-data/` directories.** Use `{{cmd}} dolt cleanup` instead.
+**NEVER use `rm -rf` on `~/.dolt-data/` directories.** NEVER remove, delete, or modify files inside Dolt's `.dolt/` directory — including `noms/LOCK` files. These are Dolt-internal files. Removing them WILL cause unrecoverable data corruption and data loss. Dolt manages these files itself; external interference is never safe.
 
 ### Key commands
 ```bash


### PR DESCRIPTION
## Summary

Related: https://github.com/gastownhall/beads/issues/2933

- **Remove LOCK file cleanup**: `cleanupStaleDoltLock()` in `doltserver.go` deleted `.dolt/noms/LOCK` files before server start. Dolt manages its own lock files on startup — external removal risks data corruption.
- **Remove database directory quarantine**: Pre-startup code inspected `.dolt/noms/manifest` inside database directories and moved/deleted those missing it. A valid `.dolt` directory does not necessarily contain `noms/manifest` — this heuristic was wrong and destroyed legitimate databases. `ListDatabases()` already skips unloadable databases with a warning.
- **Make `sql-server.info` Fix a no-op**: `StaleSQLServerInfoCheck.Fix()` deleted `.dolt/sql-server.info`, which is written and managed by Dolt itself (`dolt/commands/sqlserver/creds.go`). Fix now returns nil; hint directs operators to restart the Dolt server instead.
- **Update dog formula**: `mol-dog-phantom-db` no longer instructs dogs to `rm -rf` database directories. Changed from quarantine to escalation-only.
- **Update templates**: Dog role template and `claude.md` now carry explicit warnings against modifying `.dolt/` internals.

All changes include a standardized warning comment:
```
// WARNING: DO NOT remove, delete, or modify files inside Dolt's .dolt/
// directory — including noms/LOCK files. These are Dolt-internal files.
// Removing them WILL cause unrecoverable data corruption and data loss.
// Dolt manages these files itself; external interference is never safe.
```

## Test plan

- [x] `go build ./internal/doltserver/` compiles clean
- [x] `go build ./internal/doctor/` compiles clean
- [x] `go vet` passes on both packages
- [x] `go test ./internal/doltserver/` passes (pre-existing unrelated socket test failure confirmed on main)
- [x] `go test ./internal/doctor/` passes — renamed test `TestStaleSQLServerInfoCheck_FixIsNoOp` verifies Fix no longer deletes files
- [ ] Verify Dolt server starts correctly with databases that lack `noms/manifest` (they should be skipped via `ListDatabases` warning)
- [ ] Verify `gt dolt cleanup` still works (uses `RemoveDatabase` which already does `DROP DATABASE` via SQL before filesystem removal — unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)