### PR TITLE
fix(prime): suppress spurious session_start on bare gt prime calls

### DIFF
--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -390,7 +390,14 @@ func setupPrimeSession(ctx RoleContext, roleInfo RoleInfo) error {
 		ensureBeadsRedirect(ctx)
 	}
 	repairSessionEnv(ctx, roleInfo)
-	emitSessionEvent(ctx)
+	// Only emit session_start when gt prime is running as a SessionStart or
+	// PreCompact hook. Bare gt prime calls (e.g. an agent reading another
+	// agent's context) must not emit session_start — doing so logs a spurious
+	// event with the target agent's persisted session_id, which pollutes the
+	// event stream and can confuse gt seance discovery.
+	if primeHookMode {
+		emitSessionEvent(ctx)
+	}
 	return nil
 }
 


### PR DESCRIPTION
## Problem

`gt prime` unconditionally emitted a `session_start` event via `emitSessionEvent`
inside `setupPrimeSession`, even when called without `--hook`. Any agent calling
`gt prime <other-agent-dir>` to read context would emit a spurious `session_start`
using the target agent's persisted `session_id`.

**Observed symptom:** Boot's formula calls `cd ~/gt/deacon && gt prime` to read
the Deacon's context. This caused every Boot triage cycle to emit two `session_start`
events — one for Boot itself (correct) and one for the Deacon (spurious), using the
Deacon's stored `session_id` from `.runtime/session_id`. Effects:

- Polluted `gt seance` discovery with phantom sessions
- Made the town event feed misleading (appeared as double spawning)
- Made token cost attribution harder to audit

## Fix

Guard `emitSessionEvent` behind `primeHookMode` in `setupPrimeSession`. Session
events are only emitted when `gt prime` is genuinely running as a `SessionStart`
or `PreCompact` hook (`--hook` flag set). Bare `gt prime` reads are unaffected
functionally.

## Testing

With Gas Town running, observed `~/gt/.events.jsonl` across multiple Boot triage
cycles. Before fix: two `session_start` events per cycle (one with Boot's session_id,
one with Deacon's). After fix: exactly one `session_start` per cycle.

## Note

Pre-existing `go vet` failure in `internal/cmd/compact_report_test.go:29`
(`wispTypeToCategory` argument count mismatch) exists on `main` and is unrelated
to this change.