### PR TITLE
fix(costs): attribute Boot token spend separately from Deacon

### DIFF
--- a/internal/cmd/costs.go
+++ b/internal/cmd/costs.go
@@ -640,6 +640,11 @@ func parseSessionName(sess string) (role, rig, worker string) {
 	case session.RoleMayor:
 		return constants.RoleMayor, "", "mayor"
 	case session.RoleDeacon:
+		// Boot is modeled as a deacon dog (Role: deacon, Name: boot).
+		// Attribute its costs separately so token spend is visible per role.
+		if identity.Name == "boot" {
+			return constants.RoleBoot, "", "boot"
+		}
 		return constants.RoleDeacon, "", "deacon"
 	case session.RoleWitness:
 		return constants.RoleWitness, identity.Rig, ""

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -253,6 +253,9 @@ const (
 
 	// RoleDeacon is the deacon agent role.
 	RoleDeacon = "deacon"
+
+	// RoleBoot is the boot watchdog role (modeled as a deacon dog).
+	RoleBoot = "boot"
 )
 
 // Role emojis - centralized for easy customization.
@@ -275,6 +278,9 @@ const (
 
 	// EmojiPolecat is the polecat emoji (transient worker).
 	EmojiPolecat = "😺"
+
+	// EmojiBoot is the boot watchdog emoji (dog).
+	EmojiBoot = "🐾"
 )
 
 // Molecule formula names for patrol and dog workflows.
@@ -335,6 +341,8 @@ func RoleEmoji(role string) string {
 		return EmojiCrew
 	case RolePolecat:
 		return EmojiPolecat
+	case RoleBoot:
+		return EmojiBoot
 	default:
 		return "❓"
 	}


### PR DESCRIPTION
## Problem

Boot is modeled in the session identity package as `Role: RoleDeacon, Name: boot`
rather than as a first-class role. `parseSessionName` in `costs.go` had no special
case for this — Boot's costs were silently merged into the `deacon` bucket, making
Boot's real token spend invisible in `gt costs --by-role` output.

The `deacon` total in `gt costs` was actually Deacon + Boot combined, with no way
to separate them or audit Boot's per-cycle cost.

## Fix

- Add `RoleBoot = "boot"` constant to `constants.go`
- Add `EmojiBoot = "🐾"` and its `RoleEmoji` switch case to `constants.go`
- Special-case `identity.Name == "boot"` in the `RoleDeacon` branch of
  `parseSessionName` in `costs.go` to return `constants.RoleBoot` instead
  of `constants.RoleDeacon`

Boot now appears as a distinct `🐾 boot` line in `gt costs --by-role` output.

## Testing

Ran `gt costs --today --by-role` after multiple Boot triage cycles with the new
binary. `🐾 boot` appears as a separate line from `🐺 deacon` with its own
cost figure, confirming the attribution is working correctly.