### PR TITLE
fix: align reaper scan with reap eligibility

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -234,9 +234,11 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 	parentJoin, parentWhere := parentExcludeJoin(dbName)
 
 	// Count reap candidates: open wisps past max_age with eligible parent status.
+	// Must match Reap() eligibility semantics exactly, including the exclusion of
+	// agent beads, otherwise scan can report candidates that reap will never close.
 	// Uses LEFT JOIN anti-pattern instead of correlated EXISTS to avoid O(n*m) cost (gt-jd1z).
 	reapQuery := fmt.Sprintf(
-		"SELECT COUNT(*) FROM wisps w %s WHERE w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND %s",
+		"SELECT COUNT(*) FROM wisps w %s WHERE w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND w.issue_type != 'agent' AND %s",
 		parentJoin, parentWhere)
 	if err := db.QueryRowContext(ctx, reapQuery, now.Add(-maxAge)).Scan(&result.ReapCandidates); err != nil {
 		return nil, fmt.Errorf("count reap candidates: %w", err)

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -212,15 +212,23 @@ func TestReapExcludesAgentBeads(t *testing.T) {
 	// by checking the source code pattern.
 	// This is a compile-time guard — if the exclusion is removed, this test
 	// will fail when the query pattern doesn't match.
-	
+
 	// The whereClause in Reap() should contain:
 	// "w.issue_type != 'agent'"
 	// This test documents the expected behavior; actual exclusion is tested
 	// in integration tests with a real database.
-	
+
 	// Integration test would require spinning up a Dolt server, which is
 	// beyond the scope of this unit test. The exclusion is verified manually
 	// by checking that agent beads are not closed by the wisp_reaper patrol.
 	t.Log("Agent beads (issue_type='agent') are excluded from wisp reaping")
 	t.Log("This prevents hq-mayor, hq-deacon, witness, refinery, etc. from being closed")
+}
+
+// TestScanExcludesAgentBeads documents that Scan() must use the same eligibility
+// predicate as Reap() for stale open wisps. If Scan counts agent beads but Reap
+// excludes them, the operator sees scan>0 and reap=0 for the same cutoff.
+func TestScanExcludesAgentBeads(t *testing.T) {
+	t.Log("Agent beads (issue_type='agent') are excluded from stale-wisp scan counts")
+	t.Log("This keeps Scan() and Reap() aligned so scan-reported candidates are actually reapable")
 }

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -236,7 +236,13 @@ func TestScanExcludesAgentBeads(t *testing.T) {
 		t.Fatalf("read %s: %v", sourcePath, err)
 	}
 	source := string(data)
-	if !strings.Contains(source, "w.issue_type != 'agent'") {
-		t.Fatalf("expected Scan/Reap eligibility to exclude agent beads, source missing predicate:\n%s", source)
+	scanStart := strings.Index(source, "func Scan(")
+	reapStart := strings.Index(source, "func Reap(")
+	if scanStart == -1 || reapStart == -1 || reapStart <= scanStart {
+		t.Fatalf("could not isolate Scan() body in %s", sourcePath)
+	}
+	scanBody := source[scanStart:reapStart]
+	if !strings.Contains(scanBody, "w.issue_type != 'agent'") {
+		t.Fatalf("expected Scan() eligibility to exclude agent beads, scan body was:\n%s", scanBody)
 	}
 }

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -2,6 +2,7 @@ package reaper
 
 import (
 	"fmt"
+	"os"
 	"strings"
 	"testing"
 )
@@ -229,6 +230,13 @@ func TestReapExcludesAgentBeads(t *testing.T) {
 // predicate as Reap() for stale open wisps. If Scan counts agent beads but Reap
 // excludes them, the operator sees scan>0 and reap=0 for the same cutoff.
 func TestScanExcludesAgentBeads(t *testing.T) {
-	t.Log("Agent beads (issue_type='agent') are excluded from stale-wisp scan counts")
-	t.Log("This keeps Scan() and Reap() aligned so scan-reported candidates are actually reapable")
+	sourcePath := "reaper.go"
+	data, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", sourcePath, err)
+	}
+	source := string(data)
+	if !strings.Contains(source, "w.issue_type != 'agent'") {
+		t.Fatalf("expected Scan/Reap eligibility to exclude agent beads, source missing predicate:\n%s", source)
+	}
 }


### PR DESCRIPTION
## Summary
- make `Scan()` exclude agent wisps using the same stale-wisp eligibility that `Reap()` already uses
- add focused regression coverage so the `Scan()` function body specifically must contain the agent-bead exclusion
- keep the change scoped to scan/reap eligibility alignment only; purge and stale-issue behavior are unchanged

## Related Issue
- Fixes `gs-mn3`

## Bug
A live reproduction on `hq` showed:
- `gt reaper scan --db hq --max-age=24h` reported 4 reap candidates
- `gt reaper reap --db hq --max-age=24h` closed 0

The root cause was a predicate mismatch:
- `Scan()` counted all stale open wisps
- `Reap()` explicitly excluded `issue_type='agent'`

So scan could report candidates that reap would never close, especially when the candidates were all agent wisps.

## Why this fix
This is the smallest safe fix: keep the existing `Reap()` behavior and make `Scan()` use the same eligibility predicate. That makes the operator-facing scan count truthful without widening the change into purge or stale-issue logic.

## Testing
Focused command run:
- `GOTOOLCHAIN=auto go test ./internal/reaper -run 'TestReap|TestScanExcludesAgentBeads'`

Coverage:
- `TestScanExcludesAgentBeads` now scopes its assertion to the `Scan()` function body specifically, so it cannot pass just because `Reap()` already had the agent exclusion.

## Review process
This branch went through pre-implementation review and a second review wave against the implementation branch. Incorporated findings covered:
- keeping the change limited to scan/reap eligibility alignment
- ensuring the regression test actually targets `Scan()` instead of matching the broader file text
- confirming operator-facing scan/reap counts now correspond for agent wisps
