### PR TITLE
fix: preserve routed bead context at town root

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -235,7 +235,7 @@ Examples:
   # Auto-discover issues from an epic's children:
   gt convoy create --from-epic gt-epic-abc
   gt convoy create --from-epic gt-epic-abc --owned --merge=direct`,
-	Args: cobra.ArbitraryArgs,
+	Args:         cobra.ArbitraryArgs,
 	SilenceUsage: true,
 	RunE:         runConvoyCreate,
 }
@@ -247,7 +247,7 @@ var convoyStatusCmd = &cobra.Command{
 
 Displays convoy metadata, tracked issues, and completion progress.
 Without an ID, shows status of all active convoys.`,
-	Args: cobra.MaximumNArgs(1),
+	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE:         runConvoyStatus,
 }
@@ -277,7 +277,7 @@ If the convoy is closed, it will be automatically reopened.
 Examples:
   gt convoy add hq-cv-abc gt-new-issue
   gt convoy add hq-cv-abc gt-issue1 gt-issue2 gt-issue3`,
-	Args: cobra.MinimumNArgs(2),
+	Args:         cobra.MinimumNArgs(2),
 	SilenceUsage: true,
 	RunE:         runConvoyAdd,
 }
@@ -298,7 +298,7 @@ Examples:
   gt convoy check              # Check all open convoys
   gt convoy check hq-cv-abc    # Check specific convoy
   gt convoy check --dry-run    # Preview what would close without acting`,
-	Args: cobra.MaximumNArgs(1),
+	Args:         cobra.MaximumNArgs(1),
 	SilenceUsage: true,
 	RunE:         runConvoyCheck,
 }
@@ -340,7 +340,7 @@ Examples:
   gt convoy close hq-cv-abc --force                   # Force close abandoned convoy
   gt convoy close hq-cv-abc --reason="no longer needed" --force
   gt convoy close hq-cv-xyz --notify mayor/`,
-	Args: cobra.ExactArgs(1),
+	Args:         cobra.ExactArgs(1),
 	SilenceUsage: true,
 	RunE:         runConvoyClose,
 }
@@ -2173,11 +2173,11 @@ func formatConvoyStatus(status string) string {
 
 // trackedIssueInfo holds info about an issue being tracked by a convoy.
 type trackedIssueInfo struct {
-	ID        string `json:"id"`
-	Title     string `json:"title"`
-	Status    string `json:"status"`
-	Type      string `json:"dependency_type"`
-	IssueType string `json:"issue_type"`
+	ID        string   `json:"id"`
+	Title     string   `json:"title"`
+	Status    string   `json:"status"`
+	Type      string   `json:"dependency_type"`
+	IssueType string   `json:"issue_type"`
 	Blocked   bool     `json:"blocked,omitempty"`    // True if issue currently has blockers
 	Assignee  string   `json:"assignee,omitempty"`   // Assigned agent (e.g., gastown/polecats/goose)
 	Labels    []string `json:"labels,omitempty"`     // Bead labels (propagated from trackedDependency)
@@ -2477,12 +2477,12 @@ func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 	args := append([]string{"show"}, issueIDs...)
 	args = append(args, "--json")
 
-	// Run from town root so bd's prefix routing (routes.jsonl) can dispatch
-	// to the correct rig database for cross-rig bead lookups. (GH#2960)
-	townRoot, _ := workspace.FindFromCwdOrError()
+	// Run from the bead's resolved directory so non-HQ routed prefixes use the
+	// owning rig context instead of always forcing town-root lookup. (GH#2960, gs-60j)
+	resolvedDir := resolveBeadDir(issueIDs[0])
 	showCmd := exec.Command("bd", args...)
-	if townRoot != "" {
-		showCmd.Dir = townRoot
+	if resolvedDir != "" {
+		showCmd.Dir = resolvedDir
 		showCmd.Env = stripEnvKey(os.Environ(), "BEADS_DIR")
 	}
 	var stdout bytes.Buffer
@@ -2514,14 +2514,12 @@ func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 // getIssueDetails fetches issue details by trying to show it via bd.
 // Prefer getIssueDetailsBatch for multiple issues to avoid N+1 subprocess calls.
 func getIssueDetails(issueID string) *issueDetails {
-	// Use bd show with routing - resolve from town root so bd's prefix
-	// routing (routes.jsonl) can dispatch to the correct rig database.
-	// Without Dir + StripBeadsDir, bd inherits CWD/BEADS_DIR which may
-	// point to a rig that doesn't contain the target bead. (GH#2960)
-	townRoot, _ := workspace.FindFromCwdOrError()
+	// Use the bead's resolved directory so non-HQ routed prefixes use the owning
+	// rig context rather than always forcing town-root lookup. (GH#2960, gs-60j)
+	resolvedDir := resolveBeadDir(issueID)
 	showCmd := exec.Command("bd", "show", issueID, "--json")
-	if townRoot != "" {
-		showCmd.Dir = townRoot
+	if resolvedDir != "" {
+		showCmd.Dir = resolvedDir
 		showCmd.Env = stripEnvKey(os.Environ(), "BEADS_DIR")
 	}
 	var stdout bytes.Buffer

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -2473,39 +2473,46 @@ func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 		return result
 	}
 
-	// Build args: bd show id1 id2 id3 ... --json
-	args := append([]string{"show"}, issueIDs...)
-	args = append(args, "--json")
-
-	// Run from the bead's resolved directory so non-HQ routed prefixes use the
-	// owning rig context instead of always forcing town-root lookup. (GH#2960, gs-60j)
-	resolvedDir := resolveBeadDir(issueIDs[0])
-	showCmd := exec.Command("bd", args...)
-	if resolvedDir != "" {
-		showCmd.Dir = resolvedDir
-		showCmd.Env = stripEnvKey(os.Environ(), "BEADS_DIR")
-	}
-	var stdout bytes.Buffer
-	showCmd.Stdout = &stdout
-
-	if err := showCmd.Run(); err != nil {
-		// Batch failed - fall back to individual lookups for robustness
-		// This handles cases where some IDs are invalid/missing
-		for _, id := range issueIDs {
-			if details := getIssueDetails(id); details != nil {
-				result[id] = details
-			}
+	// Group issue IDs by their resolved execution directory. This preserves the
+	// non-HQ rig routing fix without regressing mixed-prefix batches where town
+	// beads and rig beads share a single convoy view. (gs-60j)
+	grouped := make(map[string][]string)
+	for _, id := range issueIDs {
+		dir := resolveBeadDir(id)
+		if dir == "" {
+			dir = "."
 		}
-		return result
+		grouped[dir] = append(grouped[dir], id)
 	}
 
-	var issues []issueDetailsJSON
-	if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil {
-		return result
-	}
+	for dir, ids := range grouped {
+		args := append([]string{"show"}, ids...)
+		args = append(args, "--json")
 
-	for _, issue := range issues {
-		result[issue.ID] = issue.toIssueDetails()
+		showCmd := exec.Command("bd", args...)
+		showCmd.Dir = dir
+		showCmd.Env = stripEnvKey(os.Environ(), "BEADS_DIR")
+
+		var stdout bytes.Buffer
+		showCmd.Stdout = &stdout
+
+		if err := showCmd.Run(); err != nil {
+			for _, id := range ids {
+				if details := getIssueDetails(id); details != nil {
+					result[id] = details
+				}
+			}
+			continue
+		}
+
+		var issues []issueDetailsJSON
+		if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil {
+			continue
+		}
+
+		for _, issue := range issues {
+			result[issue.ID] = issue.toIssueDetails()
+		}
 	}
 
 	return result

--- a/internal/cmd/show_test.go
+++ b/internal/cmd/show_test.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"bytes"
+	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -79,4 +83,93 @@ func TestResolveBeadDir_UsesRoutesForNonHQPrefix(t *testing.T) {
 	if got := resolveBeadDir("hq-123"); got != townRoot {
 		t.Fatalf("resolveBeadDir(hq-123) = %q, want %q", got, townRoot)
 	}
+}
+
+func TestGetIssueDetailsBatch_GroupsMixedPrefixesByResolvedDir(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	rigDir := filepath.Join(townRoot, "gastown", "mayor", "rig")
+	if err := os.MkdirAll(rigDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	routes := []byte("{\"prefix\":\"gs-\",\"path\":\"gastown/mayor/rig\"}\n{\"prefix\":\"hq-\",\"path\":\".\"}\n")
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), routes, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	logPath := filepath.Join(townRoot, "bd.log")
+	bdScript := `#!/bin/sh
+set -e
+echo "$(pwd)|$*" >> "${BD_LOG}"
+if [ "$1" = "show" ]; then
+  printf '['
+  first=1
+  shift
+  for arg in "$@"; do
+    [ "$arg" = "--json" ] && continue
+    if [ $first -eq 0 ]; then printf ','; fi
+    first=0
+    printf '{"id":"%s","title":"T","status":"open"}' "$arg"
+  done
+  printf ']'
+  exit 0
+fi
+exit 0
+`
+	bdScriptWindows := `@echo off
+setlocal enableextensions
+echo %CD%^|%*>>"%BD_LOG%"
+if "%1"=="show" (
+  echo [{"id":"%2","title":"T","status":"open"}]
+  exit /b 0
+)
+exit /b 0
+`
+	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	got := getIssueDetailsBatch([]string{"gs-60j", "hq-123"})
+	if _, ok := got["gs-60j"]; !ok {
+		t.Fatalf("expected gs-60j in result, got %#v", got)
+	}
+	if _, ok := got["hq-123"]; !ok {
+		t.Fatalf("expected hq-123 in result, got %#v", got)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	logLines := strings.Split(strings.TrimSpace(string(logBytes)), "\n")
+	if len(logLines) != 2 {
+		t.Fatalf("expected two grouped bd show invocations, got %d lines:\n%s", len(logLines), string(logBytes))
+	}
+	if !strings.Contains(logLines[0], rigDir+"|show gs-60j --json") && !strings.Contains(logLines[1], rigDir+"|show gs-60j --json") {
+		t.Fatalf("expected one invocation from rig dir %q, log:\n%s", rigDir, string(logBytes))
+	}
+	if !strings.Contains(logLines[0], townRoot+"|show hq-123 --json") && !strings.Contains(logLines[1], townRoot+"|show hq-123 --json") {
+		t.Fatalf("expected one invocation from town root %q, log:\n%s", townRoot, string(logBytes))
+	}
+	_ = bytes.Buffer{}
+	_ = json.RawMessage{}
+	_ = exec.ErrNotFound
 }

--- a/internal/cmd/show_test.go
+++ b/internal/cmd/show_test.go
@@ -1,6 +1,10 @@
 package cmd
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 func TestExtractBeadIDFromArgs(t *testing.T) {
 	tests := []struct {
@@ -45,5 +49,34 @@ func TestStripEnvKey_NoMatch(t *testing.T) {
 	got := stripEnvKey(env, "BEADS_DIR")
 	if len(got) != 2 {
 		t.Errorf("expected 2 entries (no change), got %d", len(got))
+	}
+}
+
+func TestResolveBeadDir_UsesRoutesForNonHQPrefix(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	routes := []byte("{\"prefix\":\"gs-\",\"path\":\"gastown/mayor/rig\"}\n{\"prefix\":\"hq-\",\"path\":\".\"}\n")
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), routes, 0644); err != nil {
+		t.Fatal(err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	if got := resolveBeadDir("gs-60j"); got != filepath.Join(townRoot, "gastown", "mayor", "rig") {
+		t.Fatalf("resolveBeadDir(gs-60j) = %q, want %q", got, filepath.Join(townRoot, "gastown", "mayor", "rig"))
+	}
+	if got := resolveBeadDir("hq-123"); got != townRoot {
+		t.Fatalf("resolveBeadDir(hq-123) = %q, want %q", got, townRoot)
 	}
 }

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -29,29 +29,62 @@ import (
 )
 
 // resolveBeadDir returns the directory to run bd commands for a given bead ID.
-// Uses prefix-based routing (routes.jsonl) to resolve the correct rig's .beads
-// directory and returns its parent as the working directory for bd.
-//
-// Background: beads v0.62 removed built-in multi-rig routing from bd — all bd
-// commands now operate on the local database only. Cross-rig resolution must
-// happen in gt before invoking bd, by setting the correct working directory
-// (and stripping BEADS_DIR). This function reads routes.jsonl from the town-level
-// .beads directory and resolves the bead's prefix to the owning rig.
-//
-// PR #3166 (steveyegge/gastown) will replace bd shell-outs with the Go module
-// Storage API, making this function unnecessary. Until then, this is the
-// routing bridge between gt and the routing-free bd CLI.
+// For town-level beads (hq-*) this is the town root. For registered non-HQ
+// prefixes, it resolves the owning rig path from town routes.jsonl first, then
+// falls back to rigs.json prefix mapping if routes are missing.
 func resolveBeadDir(beadID string) string {
 	townRoot, err := workspace.FindFromCwd()
 	if err != nil {
 		return "."
 	}
-	townBeadsDir := filepath.Join(townRoot, ".beads")
-	resolved := beads.ResolveBeadsDirForID(townBeadsDir, beadID)
-	// Return the parent of the .beads directory so bd discovers it naturally.
-	// For town-level beads this returns townRoot; for rig beads it returns
-	// the rig's mayor/rig directory (e.g., gastown/mayor/rig).
-	return filepath.Dir(resolved)
+	if beadID == "" || strings.HasPrefix(beadID, "hq-") {
+		return townRoot
+	}
+	if dir := resolveBeadDirFromRoutes(townRoot, beadID); dir != "" {
+		return dir
+	}
+	if prefix := extractBeadPrefix(beadID); prefix != "" {
+		if dir := resolveBeadDirFromRigsJSON(townRoot, prefix); dir != "" {
+			return dir
+		}
+	}
+	return townRoot
+}
+
+func resolveBeadDirFromRoutes(townRoot, beadID string) string {
+	routes, err := beads.LoadRoutes(filepath.Join(townRoot, ".beads"))
+	if err != nil || len(routes) == 0 {
+		return ""
+	}
+	var best beads.Route
+	for _, route := range routes {
+		if route.Prefix == "" || route.Path == "" {
+			continue
+		}
+		if strings.HasPrefix(beadID, route.Prefix) {
+			if best.Prefix == "" || len(route.Prefix) > len(best.Prefix) {
+				best = route
+			}
+		}
+	}
+	if best.Prefix == "" {
+		return ""
+	}
+	if best.Path == "." {
+		return townRoot
+	}
+	return filepath.Join(townRoot, best.Path)
+}
+
+func extractBeadPrefix(beadID string) string {
+	if beadID == "" {
+		return ""
+	}
+	idx := strings.Index(beadID, "-")
+	if idx == -1 {
+		return ""
+	}
+	return beadID[:idx+1]
 }
 
 // resolveBeadDirFromRigsJSON looks up the rig directory from rigs.json using prefix.
@@ -262,18 +295,18 @@ func getBeadInfo(beadID string) (*beadInfo, error) {
 // This enables a single read-modify-write cycle instead of sequential independent updates,
 // eliminating the race condition where concurrent writers could overwrite each other's fields.
 type beadFieldUpdates struct {
-	Dispatcher       string // Agent that dispatched the work
-	Args             string // Natural language instructions
+	Dispatcher       string   // Agent that dispatched the work
+	Args             string   // Natural language instructions
 	Vars             []string // Formula variables (key=value pairs)
-	AttachedMolecule string // Wisp root ID
-	AttachedFormula  string // Formula name (e.g., "mol-polecat-work") for inline step display
-	NoMerge          bool   // Skip merge queue on completion
-	ReviewOnly       bool   // Review-only mode: assignee must not merge/commit/push
-	Mode             string // Execution mode: "" (normal) or "ralph"
-	ConvoyID         string // Convoy bead ID (e.g., "hq-cv-abc")
-	MergeStrategy    string // Convoy merge strategy: "direct", "mr", "local"
-	ConvoyOwned      bool   // Convoy has gt:owned label (caller-managed lifecycle)
-	FormulaVars      string // Newline-separated key=value pairs for formula template substitution
+	AttachedMolecule string   // Wisp root ID
+	AttachedFormula  string   // Formula name (e.g., "mol-polecat-work") for inline step display
+	NoMerge          bool     // Skip merge queue on completion
+	ReviewOnly       bool     // Review-only mode: assignee must not merge/commit/push
+	Mode             string   // Execution mode: "" (normal) or "ralph"
+	ConvoyID         string   // Convoy bead ID (e.g., "hq-cv-abc")
+	MergeStrategy    string   // Convoy merge strategy: "direct", "mr", "local"
+	ConvoyOwned      bool     // Convoy has gt:owned label (caller-managed lifecycle)
+	FormulaVars      string   // Newline-separated key=value pairs for formula template substitution
 }
 
 // storeFieldsInBead performs a single read-modify-write to update all attachment fields
@@ -711,7 +744,7 @@ func InstantiateFormulaOnBead(ctx context.Context, formulaName, beadID, title, h
 		if err := BdCmd("cook", formulaName).
 			Dir(formulaWorkDir).
 			WithGTRoot(townRoot).
-				Run(); err != nil {
+			Run(); err != nil {
 			// Retry with embedded formula
 			resolvedFormula, formulaCleanup = resolveFormulaToTempFile(formulaName)
 			if formulaCleanup != nil {

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -298,6 +298,75 @@ exit /b 0
 	}
 }
 
+func TestVerifyBeadExists_RoutesNonHQPrefixFromTownRoot(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir mayor/rig: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	rigDir := filepath.Join(townRoot, "gastown", "mayor", "rig")
+	if err := os.MkdirAll(rigDir, 0755); err != nil {
+		t.Fatalf("mkdir rigDir: %v", err)
+	}
+	routes := strings.Join([]string{
+		`{"prefix":"gs-","path":"gastown/mayor/rig"}`,
+		`{"prefix":"hq-","path":"."}`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	logPath := filepath.Join(townRoot, "bd.log")
+	bdScript := `#!/bin/sh
+set -e
+echo "$(pwd)|$*" >> "${BD_LOG}"
+if [ "$1" = "show" ]; then
+  echo '[{"title":"Test issue","status":"open","assignee":"","description":""}]'
+  exit 0
+fi
+exit 0
+`
+	bdScriptWindows := `@echo off
+setlocal enableextensions
+echo %CD%^|%*>>"%BD_LOG%"
+if "%1"=="show" (
+  echo [{"title":"Test issue","status":"open","assignee":"","description":""}]
+  exit /b 0
+)
+exit /b 0
+`
+	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := verifyBeadExists("gs-test123"); err != nil {
+		t.Fatalf("verifyBeadExists: %v", err)
+	}
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	if !strings.Contains(string(logBytes), rigDir+"|show gs-test123 --json --allow-stale") {
+		t.Fatalf("expected bd show to run from rig dir %q, log:\n%s", rigDir, string(logBytes))
+	}
+}
+
 func TestSlingRollsBackSpawnedPolecatOnInstantiateFailure(t *testing.T) {
 	townRoot := t.TempDir()
 
@@ -1192,19 +1261,19 @@ func TestLooksLikeBeadID(t *testing.T) {
 		{"aaaaaa-b", false},     // prefix too long (6 chars)
 
 		// Injection / invalid suffix characters - should return false
-		{"gt-abc;rm -rf /", false},       // shell injection in suffix
-		{"gt-abc$(cmd)", false},          // command substitution in suffix
-		{"gt-abc&bg", false},            // ampersand in suffix
-		{"gt-abc|pipe", false},          // pipe in suffix
-		{"gt-abc`tick`", false},         // backtick in suffix
-		{"gt-abc>redir", false},         // redirect in suffix
-		{"gt-abc<redir", false},         // redirect in suffix
-		{"gt-abc'quote", false},         // single quote in suffix
-		{"gt-abc\"dquote", false},       // double quote in suffix
-		{"gt-abc\\slash", false},        // backslash in suffix
-		{"gt-abc xyz", false},           // space in suffix
-		{"gt-ABC", false},              // uppercase in suffix
-		{"gt-abc/path", false},          // slash in suffix
+		{"gt-abc;rm -rf /", false}, // shell injection in suffix
+		{"gt-abc$(cmd)", false},    // command substitution in suffix
+		{"gt-abc&bg", false},       // ampersand in suffix
+		{"gt-abc|pipe", false},     // pipe in suffix
+		{"gt-abc`tick`", false},    // backtick in suffix
+		{"gt-abc>redir", false},    // redirect in suffix
+		{"gt-abc<redir", false},    // redirect in suffix
+		{"gt-abc'quote", false},    // single quote in suffix
+		{"gt-abc\"dquote", false},  // double quote in suffix
+		{"gt-abc\\slash", false},   // backslash in suffix
+		{"gt-abc xyz", false},      // space in suffix
+		{"gt-ABC", false},          // uppercase in suffix
+		{"gt-abc/path", false},     // slash in suffix
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
## Summary
- make town-root `gt show` and sling/convoy helper lookups resolve non-HQ bead prefixes through the owning rig context instead of always forcing town root
- batch mixed-prefix convoy lookups by resolved execution directory so HQ and non-HQ issues no longer silently drop out of the same batch
- keep the fix scoped to town-root CLI/convoy helper paths and split web fetcher parity into follow-up `gs-mdh`
- add focused regression coverage for routed non-HQ `gt show`, routed bead existence checks, existing formula-routing behavior, and mixed-prefix convoy batches

## Related Issues
- Fixes `gs-60j`
- Follow-up: `gs-mdh`

## Bug
Direct routed bead commands could succeed from the owning rig root while higher-level town-root `gastown` paths still failed for the same non-HQ bead IDs. The concrete operator impact was that `gt sling`, `gt show`, and convoy detail fetchers still needed HQ wrapper workarounds for valid `do-`, `gs-`, or `bd-` issues even when `routes.jsonl` was correct.

A first implementation fixed single-prefix town-root lookups but regressed mixed-prefix convoy batches by forcing the entire batch into the first issue's rig context. This final branch fixes both problems while keeping the patch scoped.

## Why this fix
This branch keeps the change at the `gastown` town-root helper layer instead of widening into general beads routing semantics:
- `resolveBeadDir` now resolves registered non-HQ prefixes via town `routes.jsonl` (with `rigs.json` fallback) while keeping `hq-*` at town root
- `gt show` and the sling preflight helpers use that resolved context for non-HQ beads
- convoy batch lookups group issue IDs by resolved directory so mixed HQ + non-HQ batches preserve both contexts instead of dropping whichever IDs do not match the first issue's rig
- a sibling web fetcher parity gap is intentionally filed separately as `gs-mdh` to keep this PR surgical

## Testing
Focused command run:
- `GOTOOLCHAIN=auto go test ./internal/cmd -run 'TestResolveBeadDir_UsesRoutesForNonHQPrefix|TestVerifyBeadExists_RoutesNonHQPrefixFromTownRoot|TestSlingFormulaOnBeadRoutesBDCommandsToTargetRig|TestGetIssueDetailsBatch_GroupsMixedPrefixesByResolvedDir'`

Coverage added/updated:
- routed non-HQ prefix resolution from town root
- town-root bead existence verification for non-HQ prefixes
- existing formula-routing behavior remains intact
- mixed-prefix convoy batch now issues separate grouped lookups for HQ and non-HQ IDs

## Review process
This branch went through review-only passes for correctness, test coverage, scope, style, and operator diagnostics. The final branch incorporates the major review finding by grouping mixed-prefix convoy batches per resolved directory, and explicitly splits web convoy fetcher parity into follow-up `gs-mdh` to keep the scope tight.
