### PR TITLE
fix(costs): encode underscores as hyphens in Claude project dir path

### DIFF
--- a/internal/cmd/costs.go
+++ b/internal/cmd/costs.go
@@ -684,9 +684,11 @@ func getClaudeProjectDir(workDir string) (string, error) {
 		return "", err
 	}
 
-	// Convert path to Claude's directory naming: replace / with -
-	// Keep leading slash - it becomes a leading dash in Claude's encoding
+	// Convert path to Claude's directory naming: replace / and _ with -
+	// Claude Code encodes both path separators and underscores as hyphens.
+	// Keep leading slash - it becomes a leading dash in Claude's encoding.
 	projectName := strings.ReplaceAll(workDir, "/", "-")
+	projectName = strings.ReplaceAll(projectName, "_", "-")
 	return filepath.Join(configDir, "projects", projectName), nil
 }
 


### PR DESCRIPTION
## Problem

`getClaudeProjectDir` constructs the Claude Code project directory path by replacing `/` with `-` in the working directory. However, Claude Code's actual project directory naming encodes **both** `/` and `_` as `-`.

For any rig whose filesystem path contains underscores, the computed project directory does not match the directory Claude Code created:

```
CWD:             /home/ubuntu/gt/namu_warden/polecats/slit/namu_warden
Gas Town lookup: -home-ubuntu-gt-namu_warden-polecats-slit-namu_warden  ← wrong
Actual Claude:   -home-ubuntu-gt-namu-warden-polecats-slit-namu-warden  ← underscores → hyphens
```

`findLatestTranscript` receives a non-existent directory, returns an error, and `runCostsRecord` silently falls back to `cost_usd: 0.0`. Every polecat session in an underscore-named rig records $0.00 in `~/.gt/costs.jsonl`.

Roles whose paths contain no underscores (mayor `~/gt/mayor`, deacon `~/gt/deacon`, Boot `~/gt/deacon/dogs/boot`) are unaffected.

## Fix

Add a second `ReplaceAll` pass after the `/` pass in `getClaudeProjectDir`:

```go
projectName := strings.ReplaceAll(workDir, "/", "-")
projectName = strings.ReplaceAll(projectName, "_", "-")
```

## Test

From the polecat session directory on a rig with underscores in its path:

```bash
cd ~/gt/namu_warden/polecats/slit/namu_warden
gt costs record --session nw-slit
# Before fix: (no output — $0.00 recorded)
# After fix:  ✓ Recorded $0.67 for nw-slit
```

## Note

Pre-existing `go vet` failure in `internal/cmd/compact_report_test.go:29` (`wispTypeToCategory` argument count mismatch) is unrelated to this change and exists on `main`.