### PR TITLE
fix: refresh deacon heartbeat before idle wait

### DIFF
--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -1177,6 +1177,12 @@ End of patrol cycle decision.
 
 **If context LOW** (can continue patrolling):
 
+Refresh the heartbeat again immediately before the long idle wait:
+
+```bash
+gt deacon heartbeat "pre-await checkpoint"
+```
+
 Use await-signal with exponential backoff to wait for activity:
 
 ```bash

--- a/internal/formula/patrol_backoff_test.go
+++ b/internal/formula/patrol_backoff_test.go
@@ -277,16 +277,25 @@ func TestDeaconPatrolHasHeartbeatSteps(t *testing.T) {
 
 	// There should be a mid-cycle heartbeat step
 	foundMid := false
+	foundPreAwait := false
 	for _, step := range f.Steps {
 		if step.ID == "heartbeat-mid" {
 			foundMid = true
 			if !strings.Contains(step.Description, "gt deacon heartbeat") {
 				t.Error("heartbeat-mid step must contain \"gt deacon heartbeat\" command")
 			}
-			break
+		}
+		if step.ID == "loop-or-exit" && strings.Contains(step.Description, "pre-await checkpoint") {
+			foundPreAwait = true
+			if !strings.Contains(step.Description, "gt deacon heartbeat") {
+				t.Error("loop-or-exit step must refresh heartbeat before await-signal")
+			}
 		}
 	}
 	if !foundMid {
 		t.Error("deacon patrol formula must have a \"heartbeat-mid\" step for mid-cycle refresh")
+	}
+	if !foundPreAwait {
+		t.Error("deacon patrol formula must refresh heartbeat again before await-signal")
 	}
 }

--- a/internal/formula/patrol_backoff_test.go
+++ b/internal/formula/patrol_backoff_test.go
@@ -290,6 +290,13 @@ func TestDeaconPatrolHasHeartbeatSteps(t *testing.T) {
 			if !strings.Contains(step.Description, "gt deacon heartbeat") {
 				t.Error("loop-or-exit step must refresh heartbeat before await-signal")
 			}
+			heartbeatPos := strings.Index(step.Description, "gt deacon heartbeat \"pre-await checkpoint\"")
+			awaitPos := strings.Index(step.Description, "gt mol step await-signal")
+			if heartbeatPos == -1 || awaitPos == -1 {
+				t.Error("loop-or-exit step must contain both pre-await heartbeat and await-signal commands")
+			} else if heartbeatPos > awaitPos {
+				t.Error("pre-await heartbeat must appear before await-signal to close the stale-heartbeat window")
+			}
 		}
 	}
 	if !foundMid {


### PR DESCRIPTION
## Summary
- add a final `gt deacon heartbeat "pre-await checkpoint"` immediately before the long `await-signal` tail of the deacon patrol cycle
- keep the fix scoped to the patrol cadence path only; plugin threshold/path follow-up remains separate work
- strengthen the patrol heartbeat regression so it asserts the pre-await heartbeat appears *before* the `await-signal` command in the same step

## Related Issues
- Fixes `gs-ogf`
- Related to `gs-0ul`

## Bug
During the overnight upstream review workflow, the town repeatedly escalated a healthy-but-idle deacon as stuck because the deacon heartbeat could go stale during the long tail of a normal patrol cycle.

The deacon patrol already refreshed heartbeat at cycle start and mid-cycle, but there was still a gap late in the cycle before `await-signal` where a healthy deacon could sit long enough to trip stale-heartbeat detection.

## Why this fix
This is the smallest safe cadence fix:
- keep deacon lifecycle semantics, daemon policy, and plugin behavior unchanged
- add one more heartbeat refresh immediately before the long idle wait at the end of the patrol loop
- prove in tests that the refresh remains ordered before `await-signal`, not just present somewhere in the step text

This narrows the stale-heartbeat window without widening the patch into threshold-policy or plugin-path changes.

## Testing
Focused command run:
- `GOTOOLCHAIN=auto go test ./internal/formula -run TestDeaconPatrolHasHeartbeatSteps`

Review-backed coverage now checks:
- patrol has a start heartbeat
- patrol has a mid-cycle heartbeat
- patrol now refreshes heartbeat again immediately before `await-signal`
- the pre-await heartbeat appears before the `await-signal` command in the same step

## Review process
This branch went through correctness, cadence/test-coverage, and scope/ownership review passes. The final branch incorporates the one substantive review ask by making the regression ordering-sensitive instead of merely checking for the presence of the new heartbeat text.
