### PR TITLE
fix: force local dolt sql helper to use TCP client mode

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -407,14 +407,20 @@ func (c *Config) HostPort() string {
 	return fmt.Sprintf("%s:%d", host, c.Port)
 }
 
-// buildDoltSQLCmd constructs a dolt sql command that works for both local and remote servers.
-// For local: runs from config.DataDir so dolt auto-detects the running server.
-// For remote: prepends connection flags and passes password via DOLT_CLI_PASSWORD env var.
+// buildDoltSQLCmd constructs a non-interactive dolt sql command that always
+// talks to the running SQL server over TCP.
+//
+// For local servers, this avoids embedded-mode auto-discovery, which can load
+// databases relative to cmd.Dir instead of querying the live shared server.
 func buildDoltSQLCmd(ctx context.Context, config *Config, args ...string) *exec.Cmd {
-	sqlArgs := config.SQLArgs()
-	fullArgs := make([]string, 0, len(sqlArgs)+1+len(args))
-	fullArgs = append(fullArgs, "sql")
-	fullArgs = append(fullArgs, sqlArgs...)
+	fullArgs := make([]string, 0, 8+len(args))
+	fullArgs = append(fullArgs,
+		"--host", config.EffectiveHost(),
+		"--port", strconv.Itoa(config.Port),
+		"--user", config.User,
+		"--no-tls",
+		"sql",
+	)
 	fullArgs = append(fullArgs, args...)
 
 	cmd := exec.CommandContext(ctx, "dolt", fullArgs...)
@@ -425,9 +431,9 @@ func buildDoltSQLCmd(ctx context.Context, config *Config, args ...string) *exec.
 	cmd.Dir = config.DataDir
 	setProcessGroup(cmd)
 
-	if config.IsRemote() && config.Password != "" {
-		cmd.Env = append(os.Environ(), "DOLT_CLI_PASSWORD="+config.Password)
-	}
+	// Always set DOLT_CLI_PASSWORD to suppress interactive prompts.
+	// When empty, dolt connects without a password, which is the local default.
+	cmd.Env = append(os.Environ(), "DOLT_CLI_PASSWORD="+config.Password)
 
 	return cmd
 }

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -3537,22 +3537,26 @@ func TestBuildDoltSQLCmd_Local(t *testing.T) {
 		t.Errorf("cmd.Dir = %q, want %q", cmd.Dir, "/tmp/dolt-data")
 	}
 
-	// Should have: dolt sql -q "SELECT 1" (no connection flags)
+	// Should force a TCP client connection even for local servers.
 	args := cmd.Args
-	if len(args) < 4 {
-		t.Fatalf("expected at least 4 args, got %v", args)
+	if len(args) < 10 {
+		t.Fatalf("expected at least 10 args, got %v", args)
 	}
-	if args[1] != "sql" {
-		t.Errorf("args[1] = %q, want 'sql'", args[1])
-	}
-	if args[2] != "-q" {
-		t.Errorf("args[2] = %q, want '-q'", args[2])
-	}
-	// Should NOT have --host flag
-	for _, arg := range args {
-		if arg == "--host" {
-			t.Error("local cmd should not have --host flag")
+	argStr := strings.Join(args, " ")
+	for _, want := range []string{"--host", "127.0.0.1", "--port", "3307", "--user", "root", "--no-tls", "sql", "-q", "SELECT 1"} {
+		if !strings.Contains(argStr, want) {
+			t.Errorf("args %q missing expected %q", argStr, want)
 		}
+	}
+	found := false
+	for _, env := range cmd.Env {
+		if env == "DOLT_CLI_PASSWORD=" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("local cmd should set empty DOLT_CLI_PASSWORD to suppress prompts")
 	}
 }
 
@@ -3606,12 +3610,13 @@ func TestBuildDoltSQLCmd_RemoteNoPassword(t *testing.T) {
 	ctx := t.Context()
 	cmd := buildDoltSQLCmd(ctx, config, "-q", "SELECT 1")
 
-	// Should NOT have DOLT_CLI_PASSWORD in env
+	// Should still have empty DOLT_CLI_PASSWORD in env to suppress prompts.
 	for _, env := range cmd.Env {
-		if strings.HasPrefix(env, "DOLT_CLI_PASSWORD=") {
-			t.Error("remote cmd without password should not have DOLT_CLI_PASSWORD env var")
+		if env == "DOLT_CLI_PASSWORD=" {
+			return
 		}
 	}
+	t.Error("remote cmd without password should set empty DOLT_CLI_PASSWORD env var")
 }
 
 // =============================================================================


### PR DESCRIPTION
## Problem

buildDoltSQLCmd() used bare dolt sql for local servers, which lets the CLI fall back to embedded-mode or autodiscovery behavior based on the working directory instead of querying the live shared Dolt server.

That can make local verification and status paths read the wrong database context, and it can also trigger interactive credential prompts in non-interactive health checks.

## Fix

Always build the helper as an explicit TCP client command using host, port, user, no-tls, and the sql subcommand.

Also always set DOLT_CLI_PASSWORD, including the empty-string case, so these helper calls stay non-interactive.

This keeps the change narrowly scoped to the shared helper in internal/doltserver and does not change doctor semantics, daemon parity helpers, or IsRunning behavior.

## Testing

- GOTOOLCHAIN=auto go test ./internal/doltserver -run 'TestBuildDoltSQLCmd.*|TestCheckServerReachable.*|TestIsRunning.*'
- GOTOOLCHAIN=auto go test ./internal/doltserver -run 'TestBuildDoltSQLCmd_(Local|Remote|RemoteNoPassword)$'

## Notes

This PR is intentionally limited to the helper and its focused tests. It does not attempt to clean up other Dolt shellout call sites or broaden local-server detection behavior.