### PR TITLE
feat(mail): add --all flag to gt mail mark-read

### DIFF
--- a/internal/cmd/mail.go
+++ b/internal/cmd/mail.go
@@ -230,8 +230,12 @@ Examples:
 	RunE: runMailArchive,
 }
 
+var (
+	mailMarkReadAll bool
+)
+
 var mailMarkReadCmd = &cobra.Command{
-	Use:     "mark-read <message-id> [message-id...]",
+	Use:     "mark-read [message-id...]",
 	Aliases: []string{"ack"},
 	Short:   "Mark messages as read without archiving",
 	Long: `Mark one or more messages as read without removing them from inbox.
@@ -239,13 +243,12 @@ var mailMarkReadCmd = &cobra.Command{
 This adds a 'read' label to the message, which is reflected in the inbox display.
 The message remains in your inbox (unlike archive which closes/removes it).
 
-Use case: You've read a message but want to keep it visible in your inbox
-for reference or follow-up.
+Use --all to mark all unread messages as read (silences hook re-notifications).
 
 Examples:
   gt mail mark-read hq-abc123
-  gt mail mark-read hq-abc123 hq-def456`,
-	Args: cobra.MinimumNArgs(1),
+  gt mail mark-read hq-abc123 hq-def456
+  gt mail mark-read --all`,
 	RunE: runMailMarkRead,
 }
 
@@ -524,6 +527,7 @@ func init() {
 	mailCmd.AddCommand(mailPeekCmd)
 	mailCmd.AddCommand(mailDeleteCmd)
 	mailCmd.AddCommand(mailArchiveCmd)
+	mailMarkReadCmd.Flags().BoolVar(&mailMarkReadAll, "all", false, "Mark all unread messages as read")
 	mailCmd.AddCommand(mailMarkReadCmd)
 	mailCmd.AddCommand(mailMarkUnreadCmd)
 	mailCmd.AddCommand(mailCheckCmd)

--- a/internal/cmd/mail_inbox.go
+++ b/internal/cmd/mail_inbox.go
@@ -461,6 +461,35 @@ func runMailMarkRead(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// --all: mark all unread messages as read
+	if mailMarkReadAll {
+		if len(args) > 0 {
+			return fmt.Errorf("--all cannot be combined with explicit message IDs")
+		}
+		messages, err := mailbox.ListUnread()
+		if err != nil {
+			return fmt.Errorf("listing unread messages: %w", err)
+		}
+		if len(messages) == 0 {
+			fmt.Printf("%s No unread messages\n", style.Bold.Render("✓"))
+			return nil
+		}
+		marked := 0
+		for _, msg := range messages {
+			if err := mailbox.MarkReadOnly(msg.ID); err != nil {
+				style.PrintWarning("could not mark %s as read: %v", msg.ID, err)
+			} else {
+				marked++
+			}
+		}
+		fmt.Printf("%s Marked %d messages as read\n", style.Bold.Render("✓"), marked)
+		return nil
+	}
+
+	if len(args) == 0 {
+		return fmt.Errorf("message ID required (or use --all to mark all as read)")
+	}
+
 	// Mark all specified messages as read
 	marked := 0
 	var errors []string


### PR DESCRIPTION
## Summary
- Adds `--all` flag to `gt mail mark-read` for bulk mark-read
- Eliminates the need to paste individual message IDs when clearing notifications (e.g., convoy landing notices)

## Test plan
- [x] `gt mail mark-read --all` marks all unread messages as read
- [x] `gt mail mark-read <id>` still works for individual messages
- [x] Builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)