### PR TITLE
fix: update migrated agent bead state directly in wisps

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -415,15 +415,72 @@ func (b *Beads) ResetAgentBeadForReuse(id, reason string) error {
 // that contract with fallback to the legacy structured column via ResolveAgentState.
 //
 // Resolves the concrete target DB first so the update hits the correct database
-// when the agent bead routes to a different beads dir via routes.jsonl.
+// UpdateAgentState updates the agent_state field in an agent bead.
+// Agent beads live in wisps, so bd set-state is unsafe here: it creates a child
+// event bead and can fail its child_counters foreign key because the parent is
+// not stored in issues. Update the wisps column directly, then sync the
+// description's agent_state field to match.
 func (b *Beads) UpdateAgentState(id string, state string) (retErr error) {
 	defer func() { telemetry.RecordAgentStateChange(context.Background(), id, state, nil, retErr) }()
+
+	// Resolve where this bead lives. SQL updates must target the owning beads DB;
+	// they cannot rely on prefix routing the way show/update commands can.
 	targetDir := ResolveRoutingTarget(b.getTownRoot(), id, b.getResolvedBeadsDir())
 	target := b
 	if targetDir != b.getResolvedBeadsDir() {
 		target = NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
 	}
-	return target.UpdateAgentDescriptionFields(id, AgentFieldUpdates{AgentState: &state})
+
+	// Lock the agent bead for the entire state transition so the structured
+	// column write and description sync cannot interleave with another writer.
+	fl, lockErr := b.lockAgentBead(id)
+	if lockErr != nil {
+		return fmt.Errorf("locking agent bead %s: %w", id, lockErr)
+	}
+	defer func() { _ = fl.Unlock() }()
+
+	query := fmt.Sprintf(
+		"UPDATE wisps SET agent_state = '%s' WHERE id = '%s'",
+		escapeSQLString(state),
+		escapeSQLString(id),
+	)
+	output, err := target.run("sql", query)
+	if err != nil {
+		return fmt.Errorf("updating agent state column: %w", err)
+	}
+	rowsUpdated := strings.Contains(strings.ToLower(string(output)), "1 rows affected") ||
+		strings.Contains(strings.ToLower(string(output)), "1 row affected")
+	if !rowsUpdated {
+		issue, fields, getErr := target.GetAgentBead(id)
+		if getErr != nil {
+			return fmt.Errorf("updating agent state column: no wisps row updated for %s", id)
+		}
+		if issue == nil || fields == nil {
+			return fmt.Errorf("updating agent state column: no wisps row updated for %s", id)
+		}
+		if fields.AgentState != state {
+			return fmt.Errorf("updating agent state column: no wisps row updated for %s", id)
+		}
+	}
+
+	// Sync the description's agent_state field with the column while still
+	// holding the bead lock so concurrent writers cannot reintroduce divergence.
+	issue, err := target.Show(id)
+	if err != nil {
+		return fmt.Errorf("syncing agent description state: %w", err)
+	}
+	fields := ParseAgentFields(issue.Description)
+	fields.AgentState = state
+	description := FormatAgentDescription(issue.Title, fields)
+	if err := target.Update(id, UpdateOptions{Description: &description}); err != nil {
+		return fmt.Errorf("syncing agent description state: %w", err)
+	}
+
+	return nil
+}
+
+func escapeSQLString(s string) string {
+	return strings.ReplaceAll(s, "'", "''")
 }
 
 // SetHookBead and ClearHookBead removed (hq-l6mm5).

--- a/internal/beads/beads_agent_update_test.go
+++ b/internal/beads/beads_agent_update_test.go
@@ -1,0 +1,220 @@
+package beads
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func installMockBDAgentStateUpdater(t *testing.T) string {
+	t.Helper()
+	return installMockBDAgentStateUpdaterWithOptions(t, "OK, 1 rows affected", false, "spawning")
+}
+
+func installMockBDAgentStateUpdaterWithOptions(t *testing.T, sqlOutput string, failUpdate bool, showState string) string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "bd.log")
+
+	if runtime.GOOS == "windows" {
+		psPath := filepath.Join(binDir, "bd.ps1")
+		psScript := `
+$logFile = '` + strings.ReplaceAll(logPath, "'", "''") + `'
+$sqlOutput = '` + strings.ReplaceAll(sqlOutput, "'", "''") + `'
+$failUpdate = '` + map[bool]string{true: "1", false: "0"}[failUpdate] + `'
+$showState = '` + showState + `'
+Add-Content -Path $logFile -Value ($args -join ' ')
+
+$cmd = ''
+foreach ($arg in $args) {
+  if ($arg -like '--*') { continue }
+  $cmd = $arg
+  break
+}
+
+switch ($cmd) {
+  'version' { exit 0 }
+  'sql' {
+    Write-Output $sqlOutput
+    exit 0
+  }
+  'show' {
+    Write-Output ('[{"id":"gs-gastown-polecat-guzzle","title":"Polecat guzzle","issue_type":"agent","labels":["gt:agent"],"description":"Polecat guzzle
+
+role_type: polecat
+rig: gastown
+agent_state: ' + $showState + '
+hook_bead: gs-rt0
+cleanup_status: null
+active_mr: null
+notification_level: null","agent_state":"' + $showState + '"}]')
+    exit 0
+  }
+  'update' {
+    if ($failUpdate -eq '1') {
+      Write-Error 'update failed'
+      exit 1
+    }
+    Write-Output '[]'
+    exit 0
+  }
+  default { exit 0 }
+}
+`
+		cmdScript := "@echo off\r\npwsh -NoProfile -NoLogo -File \"" + psPath + "\" %*\r\n"
+		if err := os.WriteFile(psPath, []byte(psScript), 0644); err != nil {
+			t.Fatalf("write mock bd ps1: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(binDir, "bd.cmd"), []byte(cmdScript), 0644); err != nil {
+			t.Fatalf("write mock bd cmd: %v", err)
+		}
+	} else {
+		script := `#!/bin/sh
+LOG_FILE='` + logPath + `'
+SQL_OUTPUT='` + sqlOutput + `'
+FAIL_UPDATE='` + map[bool]string{true: "1", false: "0"}[failUpdate] + `'
+SHOW_STATE='` + showState + `'
+printf '%s
+' "$*" >> "$LOG_FILE"
+
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+
+case "$cmd" in
+  version)
+    exit 0
+    ;;
+  sql)
+    printf '%s
+' "$SQL_OUTPUT"
+    exit 0
+    ;;
+  show)
+    printf '%s
+' "[{\"id\":\"gs-gastown-polecat-guzzle\",\"title\":\"Polecat guzzle\",\"issue_type\":\"agent\",\"labels\":[\"gt:agent\"],\"description\":\"Polecat guzzle\\n\\nrole_type: polecat\\nrig: gastown\\nagent_state: $SHOW_STATE\\nhook_bead: gs-rt0\\ncleanup_status: null\\nactive_mr: null\\nnotification_level: null\",\"agent_state\":\"$SHOW_STATE\"}]"
+    exit 0
+    ;;
+  update)
+    if [ "$FAIL_UPDATE" = "1" ]; then
+      printf 'update failed
+' >&2
+      exit 1
+    fi
+    printf '[]
+'
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+		if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+			t.Fatalf("write mock bd: %v", err)
+		}
+	}
+
+	ResetBdAllowStaleCacheForTest()
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return logPath
+}
+
+func TestUpdateAgentState_UsesDirectWispSQL(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	logPath := installMockBDAgentStateUpdater(t)
+
+	bd := NewIsolated(tmpDir)
+	if err := bd.UpdateAgentState("gs-gastown-polecat-guzzle", "working"); err != nil {
+		t.Fatalf("UpdateAgentState: %v", err)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	log := string(logData)
+
+	if strings.Contains(log, " set-state ") || strings.Contains(log, " agent state ") {
+		t.Fatalf("UpdateAgentState used the wrong bd command:\n%s", log)
+	}
+	if !strings.Contains(log, "sql UPDATE wisps SET agent_state = 'working' WHERE id = 'gs-gastown-polecat-guzzle'") {
+		t.Fatalf("UpdateAgentState did not update wisps.agent_state directly:\n%s", log)
+	}
+	if !strings.Contains(log, "show gs-gastown-polecat-guzzle --json") {
+		t.Fatalf("UpdateAgentState did not reload the agent bead for description sync:\n%s", log)
+	}
+	if !strings.Contains(log, "update gs-gastown-polecat-guzzle") {
+		t.Fatalf("UpdateAgentState did not sync the description field:\n%s", log)
+	}
+}
+
+func TestEscapeSQLString(t *testing.T) {
+	got := escapeSQLString("that's all")
+	if got != "that''s all" {
+		t.Fatalf("escapeSQLString = %q, want %q", got, "that''s all")
+	}
+}
+
+func TestUpdateAgentState_ErrorsWhenNoRowsUpdated(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	installMockBDAgentStateUpdaterWithOptions(t, "OK, 0 rows affected", false, "spawning")
+
+	bd := NewIsolated(tmpDir)
+	err := bd.UpdateAgentState("gs-gastown-polecat-guzzle", "working")
+	if err == nil || !strings.Contains(err.Error(), "no wisps row updated") {
+		t.Fatalf("expected no-row-update error, got %v", err)
+	}
+}
+
+func TestUpdateAgentState_ErrorsWhenDescriptionSyncFails(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	installMockBDAgentStateUpdaterWithOptions(t, "OK, 1 rows affected", true, "spawning")
+
+	bd := NewIsolated(tmpDir)
+	err := bd.UpdateAgentState("gs-gastown-polecat-guzzle", "working")
+	if err == nil || !strings.Contains(err.Error(), "syncing agent description state") {
+		t.Fatalf("expected description sync error, got %v", err)
+	}
+}
+
+func TestUpdateAgentState_RetriesDescriptionSyncAfterZeroRowNoOp(t *testing.T) {
+	tmpDir := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(tmpDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	logPath := installMockBDAgentStateUpdaterWithOptions(t, "OK, 0 rows affected", false, "working")
+
+	bd := NewIsolated(tmpDir)
+	if err := bd.UpdateAgentState("gs-gastown-polecat-guzzle", "working"); err != nil {
+		t.Fatalf("expected success when structured state already matches, got %v", err)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "show gs-gastown-polecat-guzzle --json") {
+		t.Fatalf("expected re-read after zero-row update, got log:\n%s", log)
+	}
+	if !strings.Contains(log, "update gs-gastown-polecat-guzzle") {
+		t.Fatalf("expected description sync after zero-row update, got log:\n%s", log)
+	}
+}


### PR DESCRIPTION
## Summary
- update `UpdateAgentState` to write `wisps.agent_state` directly in the routed beads database
- keep the description `agent_state:` field in sync inside the same critical section
- treat `0 rows affected` as a failure unless a readback already shows the requested structured state
- add focused regression tests for the direct SQL path and the important error/no-op cases

## Why
Follow-up to issue #3354.

Migrated agent beads are wisp-backed, but the higher-level state-update path can still create child-event side effects against issue-backed tables. In practice that can fail on `child_counters` foreign keys during polecat reuse and leave agent-state transitions unreliable.

Writing `wisps.agent_state` directly matches where migrated agent-bead state actually lives today, while still keeping the description field aligned for `bd show` and dashboards.

## Validation
- `GOTOOLCHAIN=auto go test ./internal/beads -run 'TestUpdateAgentState_UsesDirectWispSQL|TestUpdateAgentState_ErrorsWhenNoRowsUpdated|TestUpdateAgentState_ErrorsWhenDescriptionSyncFails|TestUpdateAgentState_RetriesDescriptionSyncAfterZeroRowNoOp|TestEscapeSQLString|TestGetAgentBead_'`

## Notes
- This PR is intentionally limited to migrated/wisp-backed agent state updates.
- It does not broaden into a general rewrite of all agent-state write paths.