### PR TITLE
fix(witness): distinguish bead lookup failure from closed/reaped in zombie detection

### DIFF
--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1250,7 +1250,7 @@ func detectZombieLiveSession(bd *BdCli, workDir, townRoot, rigName, polecatName,
 	// Agent alive but hooked bead closed — occupying slot without work (gt-h1l6i).
 	// gt-dsgp: Restart instead of nuke — the fresh session will pick up its hook
 	// and run gt done properly, or go idle waiting for new work.
-	if snapHook != "" && getBeadStatus(bd, workDir, snapHook) == "closed" {
+	if hookSt, hookOk := getBeadStatus(bd, workDir, snapHook); snapHook != "" && hookOk && hookSt == "closed" {
 		zombie := ZombieResult{
 			PolecatName:    polecatName,
 			AgentState:     snapState,
@@ -1309,7 +1309,8 @@ func detectZombieDeadSession(bd *BdCli, workDir, townRoot, rigName, polecatName,
 
 		// If bead is already closed, the polecat completed successfully.
 		// The dead session is expected (gt done kills it). Leave it alone. (gt-sy8)
-		beadAlreadyClosed := snapHook != "" && getBeadStatus(bd, workDir, snapHook) == "closed"
+		hookSt, hookFound := getBeadStatus(bd, workDir, snapHook)
+		beadAlreadyClosed := snapHook != "" && hookFound && (hookSt == "closed" || hookSt == "")
 		if beadAlreadyClosed {
 			// gt-dsgp: Polecat completed its work. Don't nuke, don't restart.
 			// The sandbox is preserved for reuse by future slings.
@@ -1373,12 +1374,14 @@ func detectZombieDeadSession(bd *BdCli, workDir, townRoot, rigName, polecatName,
 	// work successfully. The dead session is expected (gt done kills it).
 	// Don't flag as zombie or trigger re-dispatch. (gt-sy8)
 	// gt-dsgp: Don't nuke — sandbox preserved for reuse.
-	// gt-qbh: Treat missing beads (empty status) as closed. Wisp beads get
-	// reaped after completion, so getBeadStatus returns "" for reaped wisps.
-	// A missing bead is not evidence of a crash.
+	// gt-qbh: Treat missing beads (empty status from successful lookup) as closed.
+	// Wisp beads get reaped after completion, so getBeadStatus returns ("", true)
+	// for reaped wisps. A missing bead is not evidence of a crash.
+	// But a FAILED lookup ("", false) — e.g., cross-rig routing error — must
+	// NOT be treated as closed. Default to restart (safe). (hq-wisp-n530)
 	if snapHook != "" {
-		hookStatus := getBeadStatus(bd, workDir, snapHook)
-		if hookStatus == "closed" || hookStatus == "" {
+		hookStatus, hookFound := getBeadStatus(bd, workDir, snapHook)
+		if hookFound && (hookStatus == "closed" || hookStatus == "") {
 			return ZombieResult{}, false
 		}
 	}
@@ -2006,22 +2009,25 @@ func getAgentBeadAge(bd *BdCli, workDir, agentBeadID string) time.Duration {
 }
 
 // getBeadStatus returns the status of a bead (e.g., "open", "closed", "hooked").
-// Returns empty string if the bead doesn't exist or can't be queried.
-func getBeadStatus(bd *BdCli, workDir, beadID string) string {
+// Returns the status string and true if the lookup succeeded, or ("", false) if
+// the bead couldn't be queried (network error, cross-rig routing failure, etc.).
+// Callers must check the bool to distinguish "bead not found/reaped" from "lookup error."
+func getBeadStatus(bd *BdCli, workDir, beadID string) (string, bool) {
 	if beadID == "" {
-		return ""
+		return "", false
 	}
 	output, err := bd.Exec(workDir, "show", beadID, "--json")
 	if err != nil || output == "" {
-		return ""
+		return "", false
 	}
 	var issues []struct {
 		Status string `json:"status"`
 	}
 	if err := json.Unmarshal([]byte(output), &issues); err != nil || len(issues) == 0 {
-		return ""
+		// Valid response but no results — bead was reaped/deleted.
+		return "", true
 	}
-	return issues[0].Status
+	return issues[0].Status, true
 }
 
 // resetAbandonedBead resets a dead polecat's hooked bead so it can be re-dispatched.
@@ -2039,8 +2045,8 @@ func resetAbandonedBead(bd *BdCli, workDir, rigName, hookBead, polecatName strin
 	if hookBead == "" {
 		return false
 	}
-	status := getBeadStatus(bd, workDir, hookBead)
-	if status != "hooked" && status != "in_progress" {
+	status, ok := getBeadStatus(bd, workDir, hookBead)
+	if !ok || (status != "hooked" && status != "in_progress") {
 		return false
 	}
 
@@ -2400,9 +2406,10 @@ func DetectOrphanedMolecules(bd *BdCli, workDir, rigName string, router *mail.Ro
 			continue // No molecule attached
 		}
 
-		// Check molecule status — skip if already closed
-		molStatus := getBeadStatus(bd, workDir, attachedMol)
-		if molStatus == "closed" || molStatus == "" {
+		// Check molecule status — skip if already closed or reaped.
+		// On lookup failure, skip (safe — don't close what we can't verify).
+		molStatus, molFound := getBeadStatus(bd, workDir, attachedMol)
+		if !molFound || molStatus == "closed" || molStatus == "" {
 			continue
 		}
 

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -747,19 +747,19 @@ func TestExtractPolecatFromJSON_InvalidInputs(t *testing.T) {
 func TestGetBeadStatus_NoBdAvailable(t *testing.T) {
 	t.Parallel()
 	// When bd is not available (test environment), getBeadStatus
-	// should return empty string without panicking
-	result := getBeadStatus(DefaultBdCli(), "/nonexistent", "gt-abc123")
-	if result != "" {
-		t.Errorf("getBeadStatus = %q, want empty when bd unavailable", result)
+	// should return ("", false) without panicking
+	result, ok := getBeadStatus(DefaultBdCli(), "/nonexistent", "gt-abc123")
+	if result != "" || ok {
+		t.Errorf("getBeadStatus = (%q, %v), want (\"\", false) when bd unavailable", result, ok)
 	}
 }
 
 func TestGetBeadStatus_EmptyBeadID(t *testing.T) {
 	t.Parallel()
-	// Empty bead ID should return empty string immediately
-	result := getBeadStatus(DefaultBdCli(), "/nonexistent", "")
-	if result != "" {
-		t.Errorf("getBeadStatus(\"\") = %q, want empty", result)
+	// Empty bead ID should return ("", false) immediately
+	result, ok := getBeadStatus(DefaultBdCli(), "/nonexistent", "")
+	if result != "" || ok {
+		t.Errorf("getBeadStatus(\"\") = (%q, %v), want (\"\", false)", result, ok)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `getBeadStatus()` returned `""` for both "bead reaped" and "lookup failed" (cross-rig routing error, timeout). The zombie detector treated `""` as "closed", skipping restart for polecats with active work.
- Changed `getBeadStatus()` to return `(string, bool)` — callers can now distinguish successful-but-empty lookups (reaped wisp) from failures (cross-rig routing broken).
- On lookup failure, polecats default to **restart** (safe) instead of skip.
- 7 stalled herald polecats were misclassified as "done, needs gc" because their `hr-*`/`he-*` bead lookups failed silently.

## Test plan
- [x] `TestGetBeadStatus_NoBdAvailable` — returns `("", false)` on failure
- [x] `TestGetBeadStatus_EmptyBeadID` — returns `("", false)` for empty input
- [x] All zombie detection tests pass
- [x] Builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)