### PR TITLE
fix(beads): FindTownRoot returns outermost town root for nested rigs

### DIFF
--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -34,17 +34,21 @@ var (
 
 // FindTownRoot walks up from startDir to find the Gas Town root directory.
 // The town root is identified by the presence of mayor/town.json.
+// Returns the outermost town root found, so that rig repos which were
+// originally standalone towns (and still contain mayor/town.json) don't
+// shadow the real town root above them.
 // Returns empty string if not found (reached filesystem root).
 func FindTownRoot(startDir string) string {
 	dir := startDir
+	candidate := ""
 	for {
 		townFile := filepath.Join(dir, "mayor", "town.json")
 		if _, err := os.Stat(townFile); err == nil {
-			return dir
+			candidate = dir
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return "" // Reached filesystem root
+			return candidate // Reached filesystem root — return outermost found
 		}
 		dir = parent
 	}

--- a/internal/beads/beads_types_test.go
+++ b/internal/beads/beads_types_test.go
@@ -149,6 +149,21 @@ func TestFindTownRoot(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	// Create a nested rig that was originally a standalone town
+	// (has its own mayor/town.json inside the outer town)
+	rigDir := filepath.Join(tmpDir, "myrig", "mayor", "rig")
+	rigMayorDir := filepath.Join(rigDir, "mayor")
+	if err := os.MkdirAll(rigMayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigMayorDir, "town.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	rigBeadsDir := filepath.Join(rigDir, ".beads")
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
 	tests := []struct {
 		name     string
 		startDir string
@@ -158,6 +173,8 @@ func TestFindTownRoot(t *testing.T) {
 		{"from mayor dir", mayorDir, tmpDir},
 		{"from deep nested dir", deepDir, tmpDir},
 		{"from non-town dir", t.TempDir(), ""},
+		{"nested town prefers outermost", rigBeadsDir, tmpDir},
+		{"nested rig dir prefers outermost", rigDir, tmpDir},
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary
- `FindTownRoot` stopped at the first `mayor/town.json` found while walking up the directory tree
- Rig repos that were originally standalone towns (e.g., geocaching_ai_lab) have their own `mayor/town.json` inside the outer town's tree
- This caused prefix routing to fail — routes.jsonl was loaded from the rig's (empty) `.beads` instead of the town-level one
- Now walks to the filesystem root and returns the **outermost** town root, matching `workspace.Find` which already had this fix

## Test plan
- [x] `TestFindTownRoot/nested_town_prefers_outermost` — new test
- [x] `TestFindTownRoot/nested_rig_dir_prefers_outermost` — new test
- [x] All existing `FindTownRoot` tests pass
- [x] `gt hook` from geocaching_ai_lab no longer warns "no route for prefix gal-"
- [x] Builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)