### PR TITLE
fix(scheduler): exclude idle polecats from capacity count

### DIFF
--- a/internal/cmd/capacity_dispatch.go
+++ b/internal/cmd/capacity_dispatch.go
@@ -98,7 +98,7 @@ func dispatchScheduledWork(townRoot, actor string, batchOverride int, dryRun boo
 	polecatNames := make(map[string]string)
 	cycle := &capacity.DispatchCycle{
 		AvailableCapacity: func() (int, error) {
-			active := countActivePolecats()
+			active := countWorkingPolecats()
 			cap := maxPolecats - active
 			if cap <= 0 {
 				return 0, nil // No free slots — PlanDispatch treats <= 0 as no capacity

--- a/internal/cmd/polecat_spawn.go
+++ b/internal/cmd/polecat_spawn.go
@@ -99,16 +99,18 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 	}
 
 	// Polecat count cap (clown show #22): refuse to spawn if there are already
-	// too many active polecats. This is a last-resort safety net for the direct-dispatch
+	// too many working polecats. This is a last-resort safety net for the direct-dispatch
 	// path. For configurable capacity gating, use scheduler.max_polecats in town settings
 	// (see internal/scheduler/capacity/).
+	// Uses countWorkingPolecats to exclude idle polecats (completed work, no hook bead)
+	// that are available for re-sling under the persistent polecat model.
 	const defaultMaxActivePolecats = 25
-	activeCount := countActivePolecats()
-	if activeCount >= defaultMaxActivePolecats {
-		return nil, fmt.Errorf("polecat cap reached: %d active polecats (max %d). "+
+	workingCount := countWorkingPolecats()
+	if workingCount >= defaultMaxActivePolecats {
+		return nil, fmt.Errorf("polecat cap reached: %d working polecats (max %d). "+
 			"This is a safety limit to prevent spawn storms. "+
 			"Investigate why polecats are accumulating before spawning more",
-			activeCount, defaultMaxActivePolecats)
+			workingCount, defaultMaxActivePolecats)
 	}
 
 	// Per-bead respawn circuit breaker (clown show #22):

--- a/internal/cmd/scheduler.go
+++ b/internal/cmd/scheduler.go
@@ -481,7 +481,10 @@ func beadsSearchDirs(townRoot string) []string {
 	return dirs
 }
 
-// countActivePolecats counts all running polecats across all rigs in the town.
+// countActivePolecats counts all running polecat tmux sessions across all rigs.
+// This includes idle polecats (completed work, no hook bead) which still occupy
+// tmux sessions under the persistent polecat model. For capacity gating, use
+// countWorkingPolecats which excludes idle sessions.
 func countActivePolecats() int {
 	listCmd := tmux.BuildCommand("list-sessions", "-F", "#{session_name}")
 	out, err := listCmd.Output()
@@ -501,6 +504,54 @@ func countActivePolecats() int {
 		if identity.Role == session.RolePolecat {
 			count++
 		}
+	}
+	return count
+}
+
+// countWorkingPolecats counts polecat sessions that are actively working.
+// A polecat is "working" if its agent bead has a non-null hook_bead.
+// Idle polecats (completed work, hook_bead=null) don't count toward capacity
+// since they're available for re-sling under the persistent polecat model.
+func countWorkingPolecats() int {
+	townRoot, err := workspace.FindFromCwd()
+	if err != nil {
+		return countActivePolecats() // Fallback to total count
+	}
+
+	listCmd := tmux.BuildCommand("list-sessions", "-F", "#{session_name}")
+	out, err := listCmd.Output()
+	if err != nil {
+		return 0
+	}
+
+	bd := beads.New(townRoot)
+	count := 0
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		identity, err := session.ParseSessionName(line)
+		if err != nil || identity.Role != session.RolePolecat {
+			continue
+		}
+
+		// Check if this polecat has hooked work
+		prefix := identity.Prefix
+		if prefix == "" {
+			prefix = session.PrefixFor(identity.Rig)
+		}
+		agentBeadID := beads.PolecatBeadIDWithPrefix(prefix, identity.Rig, identity.Name)
+		issue, err := bd.Show(agentBeadID)
+		if err != nil || issue == nil {
+			count++ // Can't verify — count conservatively
+			continue
+		}
+
+		fields := beads.ParseAgentFields(issue.Description)
+		if fields.HookBead == "" {
+			continue // Idle — don't count toward cap
+		}
+		count++
 	}
 	return count
 }


### PR DESCRIPTION
## Summary
- `countActivePolecats` counted ALL polecat tmux sessions, including idle ones (completed work, no hook bead)
- Under the persistent polecat model, polecats go idle after completion and sessions are preserved for re-sling
- Idle sessions consumed capacity slots, blocking new dispatches when idle polecats accumulated (e.g., 8 idle switchyard polecats filled the cap)
- Added `countWorkingPolecats` which checks each polecat's agent bead for non-null `hook_bead`
- Idle polecats (hook_bead=null) no longer count toward the spawn cap
- Updated both the spawn safety net (`polecat_spawn.go`) and capacity-gated dispatch (`capacity_dispatch.go`)

## Test plan
- [x] Polecat/Spawn/Capacity/Scheduler tests pass
- [x] Builds clean
- [x] Verified: after killing 8 idle switchyard polecats, dispatch unblocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)