### PR TITLE
fix: route sling-context wisp to target rig instead of HQ

### DIFF
--- a/internal/cmd/capacity_dispatch.go
+++ b/internal/cmd/capacity_dispatch.go
@@ -11,6 +11,7 @@ import (
 	"github.com/gofrs/flock"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/scheduler/capacity"
 	"github.com/steveyegge/gastown/internal/style"
@@ -84,8 +85,6 @@ func dispatchScheduledWork(townRoot, actor string, batchOverride int, dryRun boo
 	}
 	spawnDelay := schedulerCfg.GetSpawnDelay()
 
-	townBeads := beads.NewWithBeadsDir(townRoot, filepath.Join(townRoot, ".beads"))
-
 	// Clean up invalid/stale contexts before querying for ready beads.
 	// Skip during dry-run to avoid mutating state.
 	if !dryRun {
@@ -126,7 +125,8 @@ func dispatchScheduledWork(townRoot, actor string, batchOverride int, dryRun boo
 		},
 		OnSuccess: func(b capacity.PendingBead) error {
 			// OnSuccess may be retried — only do the close here, no side effects.
-			return townBeads.CloseSlingContext(b.ID, "dispatched")
+			// Route to the correct rig's beads dir (GH#3468).
+			return beadsForContext(townRoot, b.Context).CloseSlingContext(b.ID, "dispatched")
 		},
 		OnFailure: func(b capacity.PendingBead, err error) {
 			var onSuccessErr *capacity.ErrOnSuccessFailed
@@ -137,7 +137,8 @@ func dispatchScheduledWork(townRoot, actor string, batchOverride int, dryRun boo
 					style.Warning.Render("⚠"), b.WorkBeadID, err)
 				// Last-resort close attempt to prevent double-dispatch on next cycle.
 				// OnSuccess already retried 2x; this is a final attempt before circuit-breaking.
-				if closeErr := townBeads.CloseSlingContext(b.ID, "dispatch-close-failed"); closeErr != nil {
+				ctxBeads := beadsForContext(townRoot, b.Context)
+				if closeErr := ctxBeads.CloseSlingContext(b.ID, "dispatch-close-failed"); closeErr != nil {
 					fmt.Fprintf(os.Stderr, "%s CRITICAL: last-resort close of %s failed — risk of double-dispatch for %s: %v\n",
 						style.Warning.Render("⚠"), b.ID, b.WorkBeadID, closeErr)
 				} else {
@@ -152,7 +153,7 @@ func dispatchScheduledWork(townRoot, actor string, batchOverride int, dryRun boo
 				_ = events.LogFeed(events.TypeSchedulerDispatchFailed, actor,
 					events.SchedulerDispatchFailedPayload(b.WorkBeadID, b.TargetRig, err.Error()))
 			}
-			recordDispatchFailure(townBeads, b, err)
+			recordDispatchFailure(beadsForContext(townRoot, b.Context), b, err)
 		},
 		BatchSize:  batchSize,
 		SpawnDelay: spawnDelay,
@@ -228,11 +229,24 @@ func printDryRunPlan(plan capacity.DispatchPlan, maxPolecats, batchSize int) {
 	}
 }
 
+// beadsForContext returns a Beads instance that can operate on a sling context
+// bead. Sling contexts live in the target rig's beads dir (GH#3468), so we
+// resolve the dir from the context's TargetRig field. Falls back to HQ if
+// the target rig is unknown (e.g., invalid context with nil fields).
+func beadsForContext(townRoot string, fields *capacity.SlingContextFields) *beads.Beads {
+	if fields != nil && fields.TargetRig != "" {
+		rigBeadsDir := doltserver.FindRigBeadsDir(townRoot, fields.TargetRig)
+		if rigBeadsDir != "" {
+			return beads.NewWithBeadsDir(townRoot, rigBeadsDir)
+		}
+	}
+	// Fallback to HQ for contexts without a valid TargetRig
+	return beads.NewWithBeadsDir(townRoot, filepath.Join(townRoot, ".beads"))
+}
+
 // cleanupStaleContexts closes invalid and stale sling context beads.
 // Called explicitly before the dispatch cycle to separate cleanup from querying.
 func cleanupStaleContexts(townRoot string) {
-	townBeads := beads.NewWithBeadsDir(townRoot, filepath.Join(townRoot, ".beads"))
-
 	contexts, err := listAllSlingContexts(townRoot)
 	if err != nil {
 		return
@@ -245,11 +259,13 @@ func cleanupStaleContexts(townRoot string) {
 	for _, ctx := range contexts {
 		fields := beads.ParseSlingContextFields(ctx.Description)
 		if fields == nil {
-			_ = townBeads.CloseSlingContext(ctx.ID, "invalid-context")
+			b := beadsForContext(townRoot, nil)
+			_ = b.CloseSlingContext(ctx.ID, "invalid-context")
 			continue
 		}
 		if fields.DispatchFailures >= maxDispatchFailures {
-			_ = townBeads.CloseSlingContext(ctx.ID, "circuit-broken")
+			b := beadsForContext(townRoot, fields)
+			_ = b.CloseSlingContext(ctx.ID, "circuit-broken")
 			continue
 		}
 		staleCheckContexts = append(staleCheckContexts, ctx)
@@ -278,7 +294,8 @@ func cleanupStaleContexts(townRoot string) {
 		fields := staleCheckFields[i]
 		info, found := workBeadInfo[fields.WorkBeadID]
 		if found && (info.Status == "hooked" || info.Status == "closed" || info.Status == "tombstone") {
-			_ = townBeads.CloseSlingContext(ctx.ID, "stale-work-bead")
+			b := beadsForContext(townRoot, fields)
+			_ = b.CloseSlingContext(ctx.ID, "stale-work-bead")
 		}
 	}
 }
@@ -473,15 +490,22 @@ func recordDispatchFailure(townBeads *beads.Beads, b capacity.PendingBead, dispa
 	}
 }
 
-// listAllSlingContexts returns all open sling context beads from HQ.
-// Sling contexts are always created in the town-root DB (HQ is authoritative),
-// so we query HQ only. This avoids partial-failure scenarios where a rig dir
-// succeeds but HQ fails, silently returning incomplete results.
-// Used by scheduler list/status/clear and cleanupStaleContexts.
+// listAllSlingContexts returns all open sling context beads across all rig
+// beads dirs. Sling contexts are created in the target rig's beads dir
+// (GH#3468), so we scan HQ plus all rig dirs.
+// Used by scheduler list/status/clear, cleanupStaleContexts, and areScheduled.
 // Does NOT filter by readiness or circuit breaker.
 func listAllSlingContexts(townRoot string) ([]*beads.Issue, error) {
-	townBeads := beads.NewWithBeadsDir(townRoot, filepath.Join(townRoot, ".beads"))
-	return townBeads.ListOpenSlingContexts()
+	var all []*beads.Issue
+	for _, dir := range beadsSearchDirs(townRoot) {
+		b := beads.NewWithBeadsDir(dir, beads.ResolveBeadsDir(dir))
+		contexts, err := b.ListOpenSlingContexts()
+		if err != nil {
+			continue // Partial failure is acceptable — skip unavailable dirs
+		}
+		all = append(all, contexts...)
+	}
+	return all, nil
 }
 
 // listReadyWorkBeadIDsWithError returns a set of work bead IDs that are unblocked.

--- a/internal/cmd/scheduler.go
+++ b/internal/cmd/scheduler.go
@@ -294,12 +294,11 @@ func runSchedulerClear(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	townBeads := beads.NewWithBeadsDir(townRoot, filepath.Join(townRoot, ".beads"))
-
 	if schedulerClearBead != "" {
 		// Close ALL sling contexts for this specific work bead (there may be
 		// duplicates if concurrent scheduleBead calls raced past idempotency).
-		contexts, listErr := townBeads.ListOpenSlingContexts()
+		// Scan all rig dirs since contexts live in target rig beads. (GH#3468)
+		contexts, listErr := listAllSlingContexts(townRoot)
 		if listErr != nil {
 			return fmt.Errorf("listing contexts: %w", listErr)
 		}
@@ -308,7 +307,8 @@ func runSchedulerClear(cmd *cobra.Command, args []string) error {
 		for _, ctx := range contexts {
 			fields := beads.ParseSlingContextFields(ctx.Description)
 			if fields != nil && fields.WorkBeadID == schedulerClearBead {
-				if err := townBeads.CloseSlingContext(ctx.ID, "cleared"); err != nil {
+				b := beadsForContext(townRoot, fields)
+				if err := b.CloseSlingContext(ctx.ID, "cleared"); err != nil {
 					fmt.Printf("  %s Could not close context %s: %v\n", style.Dim.Render("Warning:"), ctx.ID, err)
 					continue
 				}
@@ -338,8 +338,9 @@ func runSchedulerClear(cmd *cobra.Command, args []string) error {
 
 	cleared := 0
 	for _, ctx := range allContexts {
-		// Use the townBeads instance for all close operations (contexts are in HQ DB)
-		if err := townBeads.CloseSlingContext(ctx.ID, "cleared"); err != nil {
+		fields := beads.ParseSlingContextFields(ctx.Description)
+		b := beadsForContext(townRoot, fields)
+		if err := b.CloseSlingContext(ctx.ID, "cleared"); err != nil {
 			fmt.Printf("  %s Could not close context %s: %v\n", style.Dim.Render("Warning:"), ctx.ID, err)
 			continue
 		}

--- a/internal/cmd/sling_schedule.go
+++ b/internal/cmd/sling_schedule.go
@@ -10,6 +10,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/scheduler/capacity"
@@ -92,8 +93,13 @@ func scheduleBead(beadID, rigName string, opts ScheduleOptions) error {
 
 	// Idempotency: check for existing open sling context for this work bead.
 	// Fail fast on errors to avoid creating duplicate contexts on transient DB failures.
-	townBeads := beads.NewWithBeadsDir(townRoot, filepath.Join(townRoot, ".beads"))
-	existingCtx, _, findErr := townBeads.FindOpenSlingContext(beadID)
+	//
+	// Create the sling context in the target rig's beads dir so that the target
+	// rig's witness can discover it during patrol. Previously this used the HQ
+	// beads dir, which meant non-HQ rig witnesses never saw the context. (GH#3468)
+	rigBeadsDir := doltserver.FindRigBeadsDir(townRoot, rigName)
+	rigBeads := beads.NewWithBeadsDir(townRoot, rigBeadsDir)
+	existingCtx, _, findErr := rigBeads.FindOpenSlingContext(beadID)
 	if findErr != nil {
 		return fmt.Errorf("checking for existing sling context: %w", findErr)
 	}
@@ -166,8 +172,9 @@ func scheduleBead(beadID, rigName string, opts ScheduleOptions) error {
 	}
 	fields.Owned = opts.Owned
 
-	// Create sling context bead — single atomic operation. No two-step write.
-	ctxBead, err := townBeads.CreateSlingContext(info.Title, beadID, fields)
+	// Create sling context bead in the target rig's beads dir so the rig's
+	// witness discovers it during patrol. (GH#3468)
+	ctxBead, err := rigBeads.CreateSlingContext(info.Title, beadID, fields)
 	if err != nil {
 		return fmt.Errorf("creating sling context: %w", err)
 	}
@@ -183,7 +190,7 @@ func scheduleBead(beadID, rigName string, opts ScheduleOptions) error {
 				fmt.Printf("%s Created convoy %s\n", style.Bold.Render("→"), convoyID)
 				// Update the context bead fields with convoy ID
 				fields.Convoy = convoyID
-				if updateErr := townBeads.UpdateSlingContextFields(ctxBead.ID, fields); updateErr != nil {
+				if updateErr := rigBeads.UpdateSlingContextFields(ctxBead.ID, fields); updateErr != nil {
 					fmt.Printf("%s Could not update context with convoy: %v\n", style.Dim.Render("Warning:"), updateErr)
 				}
 			}
@@ -299,11 +306,10 @@ func resolveFormula(explicit string, hookRawBead bool, townRoot, rigName string)
 const slingContextTTL = 30 * time.Minute
 
 // areScheduled returns a set of bead IDs that have open sling contexts.
-// Queries HQ only — sling contexts are always created in the town-root DB,
-// so HQ is authoritative. This avoids partial-failure scenarios where a rig
-// dir succeeds but HQ fails, which would silently return incomplete results.
-// On error, fails closed: treats ALL requested beads as scheduled to prevent
-// false stranded detection and duplicate scheduling attempts.
+// Scans all rig beads dirs since sling contexts are created in the target
+// rig's beads dir (GH#3468). On error, fails closed: treats ALL requested
+// beads as scheduled to prevent false stranded detection and duplicate
+// scheduling attempts.
 //
 // Sling contexts older than slingContextTTL are ignored — they are likely
 // orphans from failed spawn attempts (GH#2279).
@@ -322,8 +328,8 @@ func areScheduled(beadIDs []string) map[string]bool {
 		return result
 	}
 
-	townBeads := beads.NewWithBeadsDir(townRoot, filepath.Join(townRoot, ".beads"))
-	contexts, err := townBeads.ListOpenSlingContexts()
+	// Scan all rig beads dirs (sling contexts live in target rig's DB). (GH#3468)
+	contexts, err := listAllSlingContexts(townRoot)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%s Warning: could not list sling contexts: %v (treating all as scheduled)\n",
 			style.Dim.Render("⚠"), err)


### PR DESCRIPTION
## Summary

- Create sling-context wisps in the target rig's beads dir (via `doltserver.FindRigBeadsDir`) instead of always using HQ, so the target rig's witness discovers them during patrol
- Update `listAllSlingContexts` to scan all rig beads dirs (reusing `beadsSearchDirs`), keeping the centralized scheduler, `areScheduled` idempotency checks, and `gt scheduler clear` working
- Route close/update operations through `beadsForContext` helper that resolves the correct beads dir from `SlingContextFields.TargetRig`

Fixes #3468

## Test plan

- [ ] `gt sling <bead> www` creates a context with `www-wisp-*` prefix (not `hq-wisp-*`)
- [ ] `gt scheduler list` still shows contexts created in non-HQ rigs
- [ ] `gt scheduler clear` closes contexts across all rigs
- [ ] `gt scheduler run` dispatches contexts from non-HQ rig beads dirs
- [ ] Existing HQ-targeted slings still work (HQ is just another rig for `FindRigBeadsDir`)
- [ ] Idempotency: re-slinging the same bead to the same rig is a no-op

---

:us: Reid Wiseman — Commander
:us: Victor Glover — Pilot
:us: Christina Koch — Mission Specialist
:canada: Jeremy Hansen — Mission Specialist

Artemis II. Open source for all — on this planet and beyond it.