### PR TITLE
polecat: auto-checkout fresh branch in session start when on default branch

### DIFF
--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -173,6 +174,18 @@ func (m *SessionManager) clonePath(polecat string) string {
 	return newPath
 }
 
+// freshBranchName returns a unique branch name for a new polecat session.
+// Mirrors the naming convention in Manager.buildBranchName:
+//   - polecat/<name>/<issue>@<timestamp> when an issue is known
+//   - polecat/<name>-<timestamp> otherwise
+func (m *SessionManager) freshBranchName(polecatName, issue string) string {
+	ts := strconv.FormatInt(time.Now().UnixMilli(), 36)
+	if issue != "" {
+		return fmt.Sprintf("polecat/%s/%s@%s", polecatName, issue, ts)
+	}
+	return fmt.Sprintf("polecat/%s-%s", polecatName, ts)
+}
+
 // hasPolecat checks if the polecat exists in this rig.
 func (m *SessionManager) hasPolecat(polecat string) bool {
 	polecatPath := m.polecatDir(polecat)
@@ -325,6 +338,20 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 	if g := git.NewGit(workDir); g != nil {
 		if b, err := g.CurrentBranch(); err == nil {
 			polecatGitBranch = b
+			// Auto-checkout a fresh branch if the worktree is on the default branch.
+			// After gt done merges a polecat's work, the worktree reverts to main/master.
+			// Starting a new session on main triggers the PRIME.md branch guard, which
+			// nukes the polecat — causing the zombie loop seen in production (hq-h01n8).
+			defaultBranch := g.DefaultBranch()
+			if polecatGitBranch == defaultBranch || polecatGitBranch == "master" || polecatGitBranch == "main" {
+				newBranch := m.freshBranchName(polecat, opts.Issue)
+				if err := g.CheckoutNewBranch(newBranch, defaultBranch); err != nil {
+					// Non-fatal: PRIME.md guard remains as a fallback; log for debugging.
+					debugSession("auto-checkout fresh branch on default", err)
+				} else {
+					polecatGitBranch = newBranch
+				}
+			}
 		}
 	}
 	// Generate the GASTA run ID — the root identifier for all telemetry emitted


### PR DESCRIPTION
## Problem

After `gt done` merges a polecat's work, the git worktree reverts to `main`/`master`. The next `gt session start` inherits this branch, causing PRIME.md's on-master guard to fire and nuke the polecat — producing a zombie loop.

Observed in production affecting `capable`, `furiosa`, `dementus`, `dag` with ~20min recurrence (hq-h01n8).

## Fix

In `SessionManager.Start()`, after reading the current branch, detect if the worktree is on the default branch. If so, create and checkout a fresh `polecat/<name>-<ts>` branch before launching the session.

- Mirrors the existing `Manager.buildBranchName` naming convention
- Non-fatal: if checkout fails, `debugSession` logs it and PRIME.md guard remains as fallback
- No new flags needed — behavior is automatic and safe

## Test plan

- [ ] Existing `internal/polecat` tests pass (`go test ./internal/polecat/...`)
- [ ] Manually verify: after `gt done` lands a worktree on `main`, `gt session start` now starts the polecat on a fresh `polecat/<name>-<ts>` branch
- [ ] Verify `GT_BRANCH` env var is set correctly in the new session

Fixes: hq-h01n8

🤖 Generated with [Claude Code](https://claude.com/claude-code)