### PR TITLE
fix: refuse to run unsigned binary instead of warning

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -98,11 +98,12 @@ func persistentPreRun(cmd *cobra.Command, args []string) error {
 	// Skip warning when Build was set by a package manager (e.g. Homebrew sets
 	// Build to "Homebrew" via ldflags but doesn't set BuiltProperly).
 	if BuiltProperly == "" && Build == "dev" {
-		fmt.Fprintln(os.Stderr, "WARNING: This binary was built with 'go build' directly.")
-		fmt.Fprintln(os.Stderr, "         Use 'make build' to create a properly signed binary.")
+		fmt.Fprintln(os.Stderr, "ERROR: This binary was built with 'go build' directly.")
+		fmt.Fprintln(os.Stderr, "       macOS will SIGKILL unsigned binaries. Use 'make build' instead.")
 		if gtRoot := os.Getenv("GT_ROOT"); gtRoot != "" {
-			fmt.Fprintf(os.Stderr, "         Run from: %s\n", gtRoot)
+			fmt.Fprintf(os.Stderr, "       Run from: %s\n", gtRoot)
 		}
+		os.Exit(1)
 	}
 
 	// Initialize CLI theme (dark/light mode support)


### PR DESCRIPTION
## Problem

Binaries built with raw `go build` (without `make`) are ad-hoc signed and macOS kills them with SIGKILL (exit 137). The existing warning was easy to miss and led to hours of debugging — the binary would start, do some work, then get killed silently.

## Change

Promote the `BuiltProperly` check from a warning to a fatal error with a clear message directing the user to rebuild with `make install`.

## Context

We hit this repeatedly when iterating on the codebase. The SIGKILL happens non-deterministically (usually when the binary allocates enough memory to trigger macOS's signature verification), making it especially confusing to debug.

Small, self-contained fix — 1 file changed.