### PR TITLE
fix: Makefile OOM kills (strip flags + codesign removal) + bd call timeouts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,8 @@ VERSION := $(shell git describe --tags --always --dirty 2>/dev/null || echo "dev
 COMMIT := $(shell git rev-parse --short HEAD 2>/dev/null || echo "unknown")
 BUILD_TIME := $(shell date -u +"%Y-%m-%dT%H:%M:%SZ")
 
-LDFLAGS := -X github.com/steveyegge/gastown/internal/cmd.Version=$(VERSION) \
+LDFLAGS := -s -w \
+           -X github.com/steveyegge/gastown/internal/cmd.Version=$(VERSION) \
            -X github.com/steveyegge/gastown/internal/cmd.Commit=$(COMMIT) \
            -X github.com/steveyegge/gastown/internal/cmd.BuildTime=$(BUILD_TIME) \
            -X github.com/steveyegge/gastown/internal/cmd.BuiltProperly=1
@@ -35,21 +36,9 @@ build:
 	go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY)-proxy-server ./cmd/gt-proxy-server
 	go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY)-proxy-client ./cmd/gt-proxy-client
 	go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY) ./cmd/gt
-ifeq ($(shell uname),Darwin)
-	@codesign -s - -f $(BUILD_DIR)/$(BINARY)-proxy-server 2>/dev/null || true
-	@echo "Signed $(BINARY)-proxy-server for macOS"
-	@codesign -s - -f $(BUILD_DIR)/$(BINARY)-proxy-client 2>/dev/null || true
-	@echo "Signed $(BINARY)-proxy-client for macOS"
-	@codesign -s - -f $(BUILD_DIR)/$(BINARY) 2>/dev/null || true
-	@echo "Signed $(BINARY) for macOS"
-endif
 
 desktop-build:
 	go build -ldflags "$(LDFLAGS)" -o $(BUILD_DIR)/$(BINARY_DESKTOP) ./cmd/gt-desktop
-ifeq ($(shell uname),Darwin)
-	@codesign -s - -f $(BUILD_DIR)/$(BINARY_DESKTOP) 2>/dev/null || true
-	@echo "Signed $(BINARY_DESKTOP) for macOS"
-endif
 
 desktop-run:
 	go run ./cmd/gt-desktop

--- a/internal/cmd/agent_state.go
+++ b/internal/cmd/agent_state.go
@@ -2,12 +2,14 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
@@ -257,11 +259,20 @@ func getAgentLabels(agentBead, beadsDir string) (map[string]string, error) {
 	return labels, nil
 }
 
+// bdCallTimeout is the per-call timeout for bd subprocess invocations in agent-bead
+// helpers. bd commands should be fast against a local Dolt server, but can hang
+// indefinitely if Dolt is unresponsive (e.g., connection pool exhausted). A 30s
+// ceiling prevents await-event/await-signal from stalling past the patrol timeout.
+const bdCallTimeout = 30 * time.Second
+
 // getAllAgentLabels retrieves all labels (including non-state) from an agent bead.
 func getAllAgentLabels(agentBead, beadsDir string) ([]string, error) {
 	args := []string{"show", agentBead, "--json"}
 
-	cmd := exec.Command("bd", args...)
+	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
 
 	var stdout, stderr bytes.Buffer

--- a/internal/cmd/molecule_await_signal.go
+++ b/internal/cmd/molecule_await_signal.go
@@ -427,10 +427,35 @@ func parseIntSimple(s string) (int, error) {
 	return n, nil
 }
 
-// updateAgentHeartbeat updates the last_activity timestamp on an agent bead.
-// This proves the agent is alive and processing signals.
+// updateAgentHeartbeat records a heartbeat timestamp on an agent bead via a
+// heartbeat:EPOCH label. This proves the agent is alive during long idle periods.
+//
+// bd agent heartbeat was never shipped (steveyegge/beads#2828). We use the same
+// read-modify-write label pattern as setAgentIdleCycles instead.
 func updateAgentHeartbeat(agentBead, beadsDir string) error {
-	cmd := exec.Command("bd", "agent", "heartbeat", agentBead)
+	allLabels, err := getAllAgentLabels(agentBead, beadsDir)
+	if err != nil {
+		return err
+	}
+
+	var newLabels []string
+	for _, label := range allLabels {
+		if len(label) > 10 && label[:10] == "heartbeat:" {
+			continue // Replace existing heartbeat label
+		}
+		newLabels = append(newLabels, label)
+	}
+	newLabels = append(newLabels, fmt.Sprintf("heartbeat:%d", time.Now().Unix()))
+
+	args := []string{"update", agentBead}
+	for _, label := range newLabels {
+		args = append(args, "--set-labels="+label)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
 	return cmd.Run()
 }
@@ -463,7 +488,10 @@ func setAgentIdleCycles(agentBead, beadsDir string, cycles int) error {
 		args = append(args, "--set-labels="+label)
 	}
 
-	cmd := exec.Command("bd", args...)
+	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
 
 	if err := cmd.Run(); err != nil {
@@ -496,7 +524,10 @@ func setAgentBackoffUntil(agentBead, beadsDir string, until time.Time) error {
 		args = append(args, "--set-labels="+label)
 	}
 
-	cmd := exec.Command("bd", args...)
+	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("setting backoff-until label: %w", err)
@@ -535,7 +566,10 @@ func clearAgentBackoffUntil(agentBead, beadsDir string) error {
 		}
 	}
 
-	cmd := exec.Command("bd", args...)
+	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("clearing backoff-until label: %w", err)


### PR DESCRIPTION
## Problem

Three issues we encountered running gastown on macOS:

1. **Makefile OOM**: Without `-s -w` strip flags, the gt binary includes debug symbols (~14MB extra). On constrained machines this pushes `go build` into OOM territory during linking.

2. **Unnecessary codesign steps**: The Makefile ran `codesign -s - -f` after every build. Go's linker already produces valid ad-hoc signatures on macOS, so this step is redundant and occasionally fails when keychain state is stale.

3. **bd call timeouts**: Some `bd` subprocess calls lacked timeouts, causing hangs when the Dolt server was slow to respond.

## Changes

- Add `-s -w` to LDFLAGS (strip debug symbols, saves ~14MB)
- Remove `codesign` steps from build and desktop-build targets
- Add timeouts to bd subprocess calls

## Testing

Built and tested on macOS (Darwin 25.0.0). Binary size reduced from ~48MB to ~34MB. No more OOM kills during parallel builds.