### PR TITLE
fix: support carry/* branches in build infrastructure

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -58,13 +58,21 @@ check-up-to-date:
 ifndef SKIP_UPDATE_CHECK
 	@# Skip check on detached HEAD (tag checkouts, CI builds)
 	@if ! git symbolic-ref HEAD >/dev/null 2>&1; then exit 0; fi
-	@git fetch origin main --quiet 2>/dev/null || true
-	@LOCAL=$$(git rev-parse HEAD 2>/dev/null); \
-	REMOTE=$$(git rev-parse origin/main 2>/dev/null); \
+	@# Use the current branch's tracking ref (works for main, carry/operational, etc.)
+	@UPSTREAM=$$(git rev-parse --abbrev-ref --symbolic-full-name @{u} 2>/dev/null); \
+	if [ -z "$$UPSTREAM" ]; then \
+		echo "Warning: no upstream tracking branch set, skipping update check"; \
+		exit 0; \
+	fi; \
+	REMOTE_NAME=$$(echo "$$UPSTREAM" | cut -d/ -f1); \
+	REMOTE_BRANCH=$$(echo "$$UPSTREAM" | cut -d/ -f2-); \
+	git fetch "$$REMOTE_NAME" "$$REMOTE_BRANCH" --quiet 2>/dev/null || true; \
+	LOCAL=$$(git rev-parse HEAD 2>/dev/null); \
+	REMOTE=$$(git rev-parse "$$UPSTREAM" 2>/dev/null); \
 	if [ -n "$$REMOTE" ] && [ "$$LOCAL" != "$$REMOTE" ]; then \
-		echo "ERROR: Local branch is not up to date with origin/main"; \
+		echo "ERROR: Local branch is not up to date with $$UPSTREAM"; \
 		echo "  Local:  $$(git rev-parse --short HEAD)"; \
-		echo "  Remote: $$(git rev-parse --short origin/main)"; \
+		echo "  Remote: $$(git rev-parse --short $$UPSTREAM)"; \
 		echo "Run 'git pull' first, or use SKIP_UPDATE_CHECK=1 to override"; \
 		exit 1; \
 	fi

--- a/internal/version/stale.go
+++ b/internal/version/stale.go
@@ -93,13 +93,14 @@ func CheckStaleBinary(repoDir string) *StaleBinaryInfo {
 	}
 	info.RepoCommit = strings.TrimSpace(string(output))
 
-	// Check which branch the repo is on
+	// Check which branch the repo is on.
+	// Accept main/master (upstream) and carry/* (fork operational branches).
 	branchCmd := exec.Command("git", "symbolic-ref", "--short", "HEAD")
 	branchCmd.Dir = repoDir
 	util.SetDetachedProcessGroup(branchCmd)
 	if branchOutput, err := branchCmd.Output(); err == nil {
 		branch := strings.TrimSpace(string(branchOutput))
-		info.OnMainBranch = (branch == "main" || branch == "master")
+		info.OnMainBranch = isBuildBranch(branch)
 	}
 
 	// Compare commits using prefix matching (handles short vs full hash)
@@ -228,6 +229,21 @@ func onlyBeadsChanges(repoDir, binaryCommit string) bool {
 		return false
 	}
 	return strings.TrimSpace(string(output)) == ""
+}
+
+// isBuildBranch returns true if the given branch is safe for automated rebuilds.
+// Accepted branches:
+//   - main, master: upstream default branches
+//   - carry/*: fork operational branches (e.g., carry/operational)
+//
+// This prevents automated rebuilds from random feature, fix, or polecat branches
+// which could cause downgrades or crash loops.
+func isBuildBranch(branch string) bool {
+	switch branch {
+	case "main", "master":
+		return true
+	}
+	return strings.HasPrefix(branch, "carry/")
 }
 
 // SetCommit allows the cmd package to pass in the build-time commit.

--- a/internal/version/stale_test.go
+++ b/internal/version/stale_test.go
@@ -63,6 +63,30 @@ func TestSetCommit(t *testing.T) {
 	}
 }
 
+func TestIsBuildBranch(t *testing.T) {
+	tests := []struct {
+		branch string
+		want   bool
+	}{
+		{"main", true},
+		{"master", true},
+		{"carry/operational", true},
+		{"carry/staging", true},
+		{"carry/", true},
+		{"fix/something", false},
+		{"feat/new-thing", false},
+		{"develop", false},
+		{"", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.branch, func(t *testing.T) {
+			if got := isBuildBranch(tt.branch); got != tt.want {
+				t.Errorf("isBuildBranch(%q) = %v, want %v", tt.branch, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCheckStaleBinary_NoCommit(t *testing.T) {
 	original := Commit
 	defer func() { Commit = original }()


### PR DESCRIPTION
## Problem

The Makefile `check-up-to-date` target and `gt stale` command hardcode `origin/main` as the only valid build target. Forks using a carry-branch model (where `carry/operational` = `main` + local patches) are blocked from automated rebuilds and require `SKIP_UPDATE_CHECK` workarounds.

## Change

Recognize `carry/*` branches as valid build sources alongside `main`. The staleness check compares against the appropriate upstream ref for the current branch.

## Use Case

We run gastown from a fork with a `carry/operational` branch that tracks upstream main plus our operational patches (rebased on top). This is a common fork pattern — the upstream PR workflow uses clean branches off main, while day-to-day work builds from the carry branch.

3 files changed, minimal risk.