### PR TITLE
feat(config): set CLAUDE_CODE_EFFORT_LEVEL for all agents

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -201,6 +201,17 @@ func AgentEnv(cfg AgentEnvConfig) map[string]string {
 	// this empty value with intentional settings like --max-old-space-size.
 	env["NODE_OPTIONS"] = ""
 
+	// Set Claude Code effort level for all agents. Opus 4.6 defaults to "medium"
+	// which under-utilizes the model's reasoning capability. Propagate any
+	// user-level override (from shell env); otherwise default to "high".
+	// Users can set CLAUDE_CODE_EFFORT_LEVEL=max in their profile for maximum
+	// reasoning depth (Opus 4.6 only, more expensive).
+	if effortLevel := os.Getenv("CLAUDE_CODE_EFFORT_LEVEL"); effortLevel != "" {
+		env["CLAUDE_CODE_EFFORT_LEVEL"] = effortLevel
+	} else {
+		env["CLAUDE_CODE_EFFORT_LEVEL"] = "high"
+	}
+
 	// Clear CLAUDECODE to prevent nested session detection in Claude Code v2.x.
 	// When gt sling is invoked from within a Claude Code session, CLAUDECODE=1
 	// leaks through tmux's global environment into new polecat sessions, causing


### PR DESCRIPTION
## Summary

- Sets `CLAUDE_CODE_EFFORT_LEVEL=high` for all Gas Town agents via `AgentEnv()` (the single source of truth for agent env vars)
- Opus 4.6 defaults to "medium" effort which under-utilizes reasoning capability — "high" is significantly better for autonomous work
- Respects user-level overrides: if `CLAUDE_CODE_EFFORT_LEVEL` is already set in the shell environment, that value is propagated instead
- Users wanting maximum depth can set `CLAUDE_CODE_EFFORT_LEVEL=max` in their profile (Opus 4.6 only, most expensive)

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/config/ -run Env` passes — all existing env tests green
- [ ] Verify new agents start with `CLAUDE_CODE_EFFORT_LEVEL=high` in their environment
- [ ] Verify user override (`export CLAUDE_CODE_EFFORT_LEVEL=max`) takes precedence

🤖 Generated with [Claude Code](https://claude.com/claude-code)