### PR TITLE
fix(windows): fallback attach for psmux sessions

### DIFF
--- a/internal/cmd/helpers_windows.go
+++ b/internal/cmd/helpers_windows.go
@@ -40,6 +40,24 @@ func attachToTmuxSession(sessionID string) error {
 	cmd.Stderr = os.Stderr
 
 	if err := cmd.Run(); err != nil {
+		// psmux on Windows can successfully list sessions but still fail
+		// attach-session with "can't find session" even when the session exists.
+		// Fall back to a plain attach invocation, which targets the most recent
+		// session and works reliably for the single-session attach workflow.
+		if !isInSameTmuxSocket() {
+			fallbackArgs := []string{"-u"}
+			if socket := tmux.GetDefaultSocket(); socket != "" {
+				fallbackArgs = append(fallbackArgs, "-L", socket)
+			}
+			fallbackArgs = append(fallbackArgs, "attach")
+			fallback := exec.Command(tmuxPath, fallbackArgs...)
+			fallback.Stdin = os.Stdin
+			fallback.Stdout = os.Stdout
+			fallback.Stderr = os.Stderr
+			if fallbackErr := fallback.Run(); fallbackErr == nil {
+				os.Exit(0)
+			}
+		}
 		if exitErr, ok := err.(*exec.ExitError); ok {
 			os.Exit(exitErr.ExitCode())
 		}


### PR DESCRIPTION
## Summary
Fallback to plain tmux attach on Windows when attach-session -t <session> fails under psmux.

## Repro
- PowerShell on Windows with tmux.exe available via psmux
- gt mayor start succeeds
- tmux -L <socket> list-sessions shows hq-mayor
- gt mayor attach or tmux -L <socket> attach -t hq-mayor fails with:
  - psmux: can't find session 'hq-mayor' (no server running)

## Change
- Keep the normal Windows attach path first
- If attach-session -t <session> fails and we are not already inside the same tmux socket, retry with plain attach
- This matches observed psmux behavior where session listing works but targeted attach does not

## Verification
- Built a Windows binary from current source
- Verified from PowerShell that:
  - gt mayor start succeeds
  - gt mayor attach no longer fails with the psmux session-not-found error

## Notes
This PR contains only the Windows attach helper change.
