### PR TITLE
fix: sling retry noise, convoy cross-rig routing, mail error detection

### DIFF
--- a/internal/cmd/convoy_stage.go
+++ b/internal/cmd/convoy_stage.go
@@ -726,9 +726,11 @@ func createStagedConvoy(dag *ConvoyDAG, waves []Wave, status string, title strin
 	}
 
 	// Set the staged status.
-	statusCmd := exec.Command("bd", "update", convoyID, "--status="+status)
-	statusCmd.Dir = townBeads
-	if out, err := statusCmd.CombinedOutput(); err != nil {
+	// Strip BEADS_DIR so bd discovers the correct database from Dir()
+	// rather than using an inherited (possibly wrong) override.
+	if out, err := BdCmd("update", convoyID, "--status="+status).
+		Dir(townBeads).StripBeadsDir().WithAutoCommit().
+		CombinedOutput(); err != nil {
 		return "", fmt.Errorf("bd update convoy status: %w\noutput: %s", err, out)
 	}
 
@@ -1504,8 +1506,14 @@ func bdDepList(beadID string) ([]bdDepResult, error) {
 // routes.jsonl so this works regardless of the caller's working directory.
 func bdListChildren(parentID string) ([]bdShowResult, error) {
 	cmd := exec.Command("bd", "list", "--parent="+parentID, "--json")
-	if dir := beadsDirForID(parentID); dir != "" {
+	// Route to the correct rig database via prefix resolution.
+	// resolveBeadDir returns the parent of .beads (the working directory bd
+	// expects), unlike beadsDirForID which returns the .beads directory itself.
+	// Also strip BEADS_DIR to prevent inherited overrides from interfering
+	// with bd's workspace detection (consistent with bdShow/bdDepList).
+	if dir := resolveBeadDir(parentID); dir != "" && dir != "." {
 		cmd.Dir = dir
+		cmd.Env = filterEnvKey(os.Environ(), "BEADS_DIR")
 	}
 	out, err := cmd.Output()
 	if err != nil {

--- a/internal/cmd/convoy_test_helpers_test.go
+++ b/internal/cmd/convoy_test_helpers_test.go
@@ -407,7 +407,7 @@ func (d *testDAG) Setup(t *testing.T) (townRoot, logPath string) {
 	}
 
 	// Create rig .beads directories referenced by routes so that
-	// beadsDirForID() can resolve them and bdListChildren() can chdir.
+	// resolveBeadDir() can resolve them and bdListChildren() can chdir.
 	for _, b := range d.beads {
 		if b.Rig != "" {
 			rigBeadsDir := filepath.Join(townRoot, b.Rig, ".beads")

--- a/internal/mail/delivery.go
+++ b/internal/mail/delivery.go
@@ -98,7 +98,7 @@ func AcknowledgeDeliveryBead(workDir, beadsDir, beadID, recipientIdentity string
 		if err == nil {
 			continue // bd label add silently succeeds on duplicate labels.
 		}
-		if bdErr, ok := err.(*bdError); ok && bdErr.ContainsError("not found") {
+		if bdErr, ok := err.(*bdError); ok && (bdErr.ContainsError("not found") || bdErr.ContainsError("no issue found")) {
 			return ErrMessageNotFound
 		}
 		return err

--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -490,7 +490,7 @@ func (m *Mailbox) getFromDir(id, beadsDir string) (*Message, error) {
 	defer cancel()
 	stdout, err := runBdCommand(ctx, args, m.workDir, beadsDir)
 	if err != nil {
-		if bdErr, ok := err.(*bdError); ok && bdErr.ContainsError("not found") {
+		if bdErr, ok := err.(*bdError); ok && (bdErr.ContainsError("not found") || bdErr.ContainsError("no issue found") || bdErr.ContainsError("no issue found")) {
 			return nil, ErrMessageNotFound
 		}
 		return nil, err
@@ -566,7 +566,7 @@ func (m *Mailbox) closeInDir(id, beadsDir string) error {
 		To: m.identity,
 	}, err)
 	if err != nil {
-		if bdErr, ok := err.(*bdError); ok && bdErr.ContainsError("not found") {
+		if bdErr, ok := err.(*bdError); ok && bdErr.ContainsError("not found") || bdErr.ContainsError("no issue found") {
 			return ErrMessageNotFound
 		}
 		return err
@@ -626,14 +626,14 @@ func (m *Mailbox) markReadOnlyBeads(id string) error {
 	defer cancel()
 	_, err := runBdCommand(ctx, args, m.workDir, primary)
 	if err != nil {
-		if bdErr, ok := err.(*bdError); ok && bdErr.ContainsError("not found") {
+		if bdErr, ok := err.(*bdError); ok && bdErr.ContainsError("not found") || bdErr.ContainsError("no issue found") {
 			if primary != m.beadsDir {
 				// Cross-rig bead IDs (e.g. ne-*) may live in the home DB. See ne-bgr.
 				ctx2, cancel2 := bdWriteCtx()
 				defer cancel2()
 				_, err2 := runBdCommand(ctx2, args, m.workDir, m.beadsDir)
 				if err2 != nil {
-					if bdErr2, ok := err2.(*bdError); ok && bdErr2.ContainsError("not found") {
+					if bdErr2, ok := err2.(*bdError); ok && bdErr2.ContainsError("not found") || bdErr2.ContainsError("no issue found") {
 						return ErrMessageNotFound
 					}
 					return err2
@@ -671,14 +671,14 @@ func (m *Mailbox) markUnreadOnlyBeads(id string) error {
 	defer cancel()
 	_, err := runBdCommand(ctx, args, m.workDir, primary)
 	if err != nil {
-		if bdErr, ok := err.(*bdError); ok && bdErr.ContainsError("not found") {
+		if bdErr, ok := err.(*bdError); ok && bdErr.ContainsError("not found") || bdErr.ContainsError("no issue found") {
 			if primary != m.beadsDir {
 				// Cross-rig bead IDs (e.g. ne-*) may live in the home DB. See ne-bgr.
 				ctx2, cancel2 := bdWriteCtx()
 				defer cancel2()
 				_, err2 := runBdCommand(ctx2, args, m.workDir, m.beadsDir)
 				if err2 != nil {
-					if bdErr2, ok := err2.(*bdError); ok && bdErr2.ContainsError("not found") {
+					if bdErr2, ok := err2.(*bdError); ok && bdErr2.ContainsError("not found") || bdErr2.ContainsError("no issue found") {
 						return ErrMessageNotFound
 					}
 					if bdErr2, ok := err2.(*bdError); ok && bdErr2.ContainsError("does not have label") {
@@ -720,14 +720,14 @@ func (m *Mailbox) markUnreadBeads(id string) error {
 	defer cancel()
 	_, err := runBdCommand(ctx, args, m.workDir, primary)
 	if err != nil {
-		if bdErr, ok := err.(*bdError); ok && bdErr.ContainsError("not found") {
+		if bdErr, ok := err.(*bdError); ok && bdErr.ContainsError("not found") || bdErr.ContainsError("no issue found") {
 			if primary != m.beadsDir {
 				// Cross-rig bead IDs (e.g. ne-*) may live in the home DB. See ne-bgr.
 				ctx2, cancel2 := bdWriteCtx()
 				defer cancel2()
 				_, err2 := runBdCommand(ctx2, args, m.workDir, m.beadsDir)
 				if err2 != nil {
-					if bdErr2, ok := err2.(*bdError); ok && bdErr2.ContainsError("not found") {
+					if bdErr2, ok := err2.(*bdError); ok && bdErr2.ContainsError("not found") || bdErr2.ContainsError("no issue found") {
 						return ErrMessageNotFound
 					}
 					return err2

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -38,6 +38,15 @@ const (
 	doltMaxRetries  = 10
 	doltBaseBackoff = 500 * time.Millisecond
 	doltBackoffMax  = 30 * time.Second
+
+	// doltStateRetries is a reduced retry count for SetAgentStateWithRetry.
+	// Agent state is a monitoring concern, not a correctness requirement (see
+	// comment on SetAgentStateWithRetry). 10 retries with exponential backoff
+	// wastes ~2 minutes on persistent failures, blocking `gt sling` for no
+	// benefit since the caller already treats errors as warn-only.
+	// 3 retries (total backoff ~3.5s) is sufficient to ride out transient
+	// Dolt hiccups without punishing interactive workflows.
+	doltStateRetries = 3
 )
 
 // doltBackoff calculates exponential backoff with ±25% jitter for a given attempt (1-indexed).
@@ -339,7 +348,7 @@ func (m *Manager) createAgentBeadWithRetry(agentID string, fields *beads.AgentFi
 // Fails fast on configuration/initialization errors (gt-2ra).
 func (m *Manager) SetAgentStateWithRetry(name string, state string) error {
 	var lastErr error
-	for attempt := 1; attempt <= doltMaxRetries; attempt++ {
+	for attempt := 1; attempt <= doltStateRetries; attempt++ {
 		err := m.SetAgentState(name, state)
 		if err == nil {
 			return nil
@@ -349,13 +358,13 @@ func (m *Manager) SetAgentStateWithRetry(name string, state string) error {
 		if isDoltConfigError(err) {
 			return fmt.Errorf("setting agent state failed (DB not initialized — not retrying): %w", err)
 		}
-		if attempt < doltMaxRetries {
+		if attempt < doltStateRetries {
 			backoff := doltBackoff(attempt)
 			style.PrintWarning("SetAgentState attempt %d failed, retrying in %v: %v", attempt, backoff, err)
 			time.Sleep(backoff)
 		}
 	}
-	return fmt.Errorf("setting agent state after %d attempts: %w", doltMaxRetries, lastErr)
+	return fmt.Errorf("setting agent state after %d attempts: %w", doltStateRetries, lastErr)
 }
 
 // assigneeID returns the beads assignee identifier for a polecat.


### PR DESCRIPTION
## Summary
- **Sling retries**: Reduce `SetAgentStateWithRetry` from 10 retries (~2min) to 3 (~3.5s). Agent state is monitoring-only; caller treats errors as warn-only.
- **Convoy cross-rig routing**: Fix `bdListChildren` to use `resolveBeadDir` (returns parent of .beads) instead of `beadsDirForID` (returns .beads itself, causing bd to look for .beads/.beads/). Also strip BEADS_DIR and fix raw exec.Command in `createStagedConvoy`.
- **Mail error detection**: Add "no issue found" match to all `ContainsError` checks. bd returns "no issue found matching" but mail only checked for "not found", preventing cross-rig wisp fallback from triggering.

## Test plan
- [x] `bd show sh-wisp-xxx` works from both town and shipyard contexts
- [x] `gt mail read sh-wisp-xxx` returns wisp content
- [x] `bd create` from town root generates `hq-` prefix (not `sh-`)
- [x] `bd show`, `bd close` work for both prefixes
- [ ] `gt convoy create --from-epic` with cross-rig dependencies
- [ ] `gt sling` completes without 2-minute retry delay

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>