### PR TITLE
fix: convoy cross-rig tracking via direct SQL INSERT

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -470,6 +470,60 @@ func runBdJSON(dir string, args ...string) ([]byte, error) {
 	return stdout.Bytes(), nil
 }
 
+// runBdSQL executes a write query via bd sql with auto-commit enabled.
+// Used for direct dependency writes that bypass bd dep add's cross-database
+// validation limitation.
+func runBdSQL(dir, query string) ([]byte, error) {
+	cmd := BdCmd("sql", query).
+		WithAutoCommit().
+		Dir(dir).
+		StripBeadsDir()
+	built := cmd.Build()
+	var stdout, stderr bytes.Buffer
+	built.Stdout = &stdout
+	built.Stderr = &stderr
+	if err := built.Run(); err != nil {
+		if errMsg := strings.TrimSpace(stderr.String()); errMsg != "" {
+			return nil, fmt.Errorf("bd sql: %s", errMsg)
+		}
+		return nil, fmt.Errorf("bd sql: %w", err)
+	}
+	return stdout.Bytes(), nil
+}
+
+// addTracksDep writes a 'tracks' dependency row directly into the hq
+// dependencies table via SQL. This bypasses bd dep add, which fails for
+// cross-rig beads because it validates that depends_on_id exists in the
+// local database. Convoys always live in hq while tracked issues live in
+// rigs, so every convoy tracking relation is cross-database.
+//
+// Uses INSERT IGNORE (Dolt/MySQL dialect) so duplicate relations are no-ops.
+func addTracksDep(townBeads, convoyID, issueID, createdBy string) error {
+	if !isValidBeadID(convoyID) || !isValidBeadID(issueID) {
+		return fmt.Errorf("invalid bead ID: %s → %s", convoyID, issueID)
+	}
+	query := fmt.Sprintf(
+		"INSERT IGNORE INTO dependencies (issue_id, depends_on_id, type, created_by) VALUES ('%s', '%s', 'tracks', '%s')",
+		convoyID, issueID, createdBy,
+	)
+	_, err := runBdSQL(townBeads, query)
+	return err
+}
+
+// removeTracksDep removes a 'tracks' dependency row from the hq dependencies
+// table via direct SQL. Companion to addTracksDep for convoy reconciliation.
+func removeTracksDep(townBeads, convoyID, issueID string) error {
+	if !isValidBeadID(convoyID) || !isValidBeadID(issueID) {
+		return fmt.Errorf("invalid bead ID: %s → %s", convoyID, issueID)
+	}
+	query := fmt.Sprintf(
+		"DELETE FROM dependencies WHERE issue_id = '%s' AND depends_on_id = '%s' AND type = 'tracks'",
+		convoyID, issueID,
+	)
+	_, err := runBdSQL(townBeads, query)
+	return err
+}
+
 // bdDepListRawIDs queries the raw dependencies table via bd sql to get
 // dependency target IDs. Unlike bd dep list, this does NOT join with the
 // issues table, so it works for cross-database dependencies where the
@@ -719,26 +773,14 @@ func runConvoyCreate(cmd *cobra.Command, args []string) error {
 
 	// Notify address is stored in description (line 166-168) and read from there
 
-	// Run dep add from town root so bd routes correctly across rigs via
-	// routes.jsonl. getTownBeadsDir() already returns the town root.
-	// StripBeadsDir prevents inherited BEADS_DIR from overriding routing.
-
-	// Add 'tracks' relations for each tracked issue
+	// Add 'tracks' relations via direct SQL INSERT into the hq dependencies
+	// table. This bypasses bd dep add which fails for cross-rig beads because
+	// bd validates that depends_on_id exists in the local database — but
+	// convoys always live in hq while tracked issues live in rigs.
 	trackedCount := 0
 	for _, issueID := range trackedIssues {
-		// Use --type=tracks for non-blocking tracking relation
-		var depStderr bytes.Buffer
-		if err := BdCmd("dep", "add", convoyID, issueID, "--type=tracks").
-			WithAutoCommit().
-			Dir(townBeads).
-			StripBeadsDir().
-			Stderr(&depStderr).
-			Run(); err != nil {
-			errMsg := strings.TrimSpace(depStderr.String())
-			if errMsg == "" {
-				errMsg = err.Error()
-			}
-			style.PrintWarning("couldn't track %s: %s", issueID, errMsg)
+		if err := addTracksDep(townBeads, convoyID, issueID, "gt convoy create"); err != nil {
+			style.PrintWarning("couldn't track %s: %s", issueID, err)
 		} else {
 			trackedCount++
 		}
@@ -839,24 +881,12 @@ func runConvoyAdd(cmd *cobra.Command, args []string) error {
 		fmt.Printf("%s Reopened convoy %s\n", style.Bold.Render("↺"), convoyID)
 	}
 
-	// Run dep add from town root so bd routes correctly across rigs via
-	// routes.jsonl. getTownBeadsDir() already returns the town root.
-
-	// Add 'tracks' relations for each issue
+	// Add 'tracks' relations via direct SQL INSERT (bypasses bd dep add's
+	// cross-database validation — convoys live in hq, tracked issues in rigs).
 	addedCount := 0
 	for _, issueID := range issuesToAdd {
-		var depStderr bytes.Buffer
-		if err := BdCmd("dep", "add", convoyID, issueID, "--type=tracks").
-			Dir(townBeads).
-			WithAutoCommit().
-			StripBeadsDir().
-			Stderr(&depStderr).
-			Run(); err != nil {
-			errMsg := strings.TrimSpace(depStderr.String())
-			if errMsg == "" {
-				errMsg = err.Error()
-			}
-			style.PrintWarning("couldn't add %s: %s", issueID, errMsg)
+		if err := addTracksDep(townBeads, convoyID, issueID, "gt convoy add"); err != nil {
+			style.PrintWarning("couldn't add %s: %s", issueID, err)
 		} else {
 			addedCount++
 		}
@@ -2514,16 +2544,13 @@ func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 // getIssueDetails fetches issue details by trying to show it via bd.
 // Prefer getIssueDetailsBatch for multiple issues to avoid N+1 subprocess calls.
 func getIssueDetails(issueID string) *issueDetails {
-	// Use bd show with routing - resolve from town root so bd's prefix
-	// routing (routes.jsonl) can dispatch to the correct rig database.
-	// Without Dir + StripBeadsDir, bd inherits CWD/BEADS_DIR which may
-	// point to a rig that doesn't contain the target bead. (GH#2960)
-	townRoot, _ := workspace.FindFromCwdOrError()
+	// Resolve the correct rig directory for this bead's prefix, since bd
+	// no longer routes cross-rig via routes.jsonl. resolveBeadDir maps
+	// the prefix to the rig's beads directory so bd discovers the right DB.
+	dir := resolveBeadDir(issueID)
 	showCmd := exec.Command("bd", "show", issueID, "--json")
-	if townRoot != "" {
-		showCmd.Dir = townRoot
-		showCmd.Env = stripEnvKey(os.Environ(), "BEADS_DIR")
-	}
+	showCmd.Dir = dir
+	showCmd.Env = stripEnvKey(os.Environ(), "BEADS_DIR")
 	var stdout bytes.Buffer
 	showCmd.Stdout = &stdout
 

--- a/internal/cmd/convoy_bd_routing_test.go
+++ b/internal/cmd/convoy_bd_routing_test.go
@@ -212,10 +212,14 @@ esac
 	}
 }
 
-// TestConvoyCreate_DepAddUsesTownRoot verifies that `dep add` during convoy
-// create runs from the town root (not its parent), so bd's prefix routing
-// can resolve cross-rig beads via routes.jsonl. This was the root cause of
-// "no beads database found" when tracking beads from other rigs. (GH#2960)
+// TestConvoyCreate_DepAddUsesTownRoot verifies that tracking dependency
+// creation during convoy create runs bd sql from the town root (not its
+// parent), so the INSERT goes into the correct hq database. This was the
+// root cause of "no beads database found" when tracking beads from other
+// rigs. (GH#2960)
+//
+// Updated: convoy create now uses direct SQL INSERT instead of bd dep add,
+// bypassing bd's cross-database validation entirely.
 func TestConvoyCreate_DepAddUsesTownRoot(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows - shell stubs")
@@ -231,21 +235,22 @@ func TestConvoyCreate_DepAddUsesTownRoot(t *testing.T) {
 	_ = os.WriteFile(filepath.Join(beadsDir, ".gt-types-configured"), []byte(typesList), 0644)
 	_ = os.WriteFile(filepath.Join(beadsDir, ".gt-statuses-configured"), []byte("staged_ready,staged_warnings"), 0644)
 
-	// Track which directory dep add runs from.
-	depLogPath := filepath.Join(t.TempDir(), "dep-add.log")
+	// Track which directory bd sql runs from.
+	sqlLogPath := filepath.Join(t.TempDir(), "sql.log")
 
 	scriptBody := fmt.Sprintf(`
 case "$1" in
   create)
     echo '[{"id":"hq-cv-test"}]'
     ;;
-  dep)
-    # Log the working directory for dep add calls
-    echo "$PWD" >> %s
+  sql)
+    # Log the working directory and query for sql calls
+    echo "$PWD: $2" >> %s
     if [ "$PWD" != "%s" ]; then
-      echo "dep add: expected town root %s, got $PWD" >&2
+      echo "bd sql: expected town root %s, got $PWD" >&2
       exit 1
     fi
+    echo "1 row(s) affected"
     ;;
   init|config)
     exit 0
@@ -254,7 +259,7 @@ case "$1" in
     echo '[]'
     ;;
 esac
-`, depLogPath, expectedWD, expectedWD)
+`, sqlLogPath, expectedWD, expectedWD)
 	writeRoutingBdStub(t, scriptBody)
 
 	// Override the entropy source for deterministic convoy IDs.
@@ -269,13 +274,18 @@ esac
 		t.Fatalf("runConvoyCreate: %v", err)
 	}
 
-	// Verify dep add was called from the town root
-	logData, err := os.ReadFile(depLogPath)
+	// Verify bd sql was called from the town root
+	logData, err := os.ReadFile(sqlLogPath)
 	if err != nil {
-		t.Fatalf("dep add was never called (no log file): %v", err)
+		t.Fatalf("bd sql was never called (no log file): %v", err)
 	}
-	logged := strings.TrimSpace(string(logData))
-	if logged != expectedWD {
-		t.Errorf("dep add ran from %q, want town root %q", logged, expectedWD)
+	lines := strings.Split(strings.TrimSpace(string(logData)), "\n")
+	for _, line := range lines {
+		if !strings.HasPrefix(line, expectedWD+":") {
+			t.Errorf("bd sql ran from wrong dir: %s", line)
+		}
+		if !strings.Contains(line, "INSERT IGNORE INTO dependencies") {
+			t.Errorf("expected INSERT query, got: %s", line)
+		}
 	}
 }

--- a/internal/cmd/convoy_stage.go
+++ b/internal/cmd/convoy_stage.go
@@ -732,16 +732,11 @@ func createStagedConvoy(dag *ConvoyDAG, waves []Wave, status string, title strin
 		return "", fmt.Errorf("bd update convoy status: %w\noutput: %s", err, out)
 	}
 
-	// Track each slingable bead via bd dep add.
-	// Cross-rig tracking may fail because bd validates both IDs exist in the
-	// same database (beads v0.62 removed cross-rig routing). Non-fatal: the
-	// convoy still works without tracking deps.
+	// Track each slingable bead via direct SQL INSERT. Bypasses bd dep add
+	// which fails for cross-rig beads (bd validates both IDs in same DB).
 	for _, beadID := range slingableIDs {
-		if out, err := BdCmd("dep", "add", convoyID, beadID, "--type=tracks").
-			Dir(townBeads).WithAutoCommit().StripBeadsDir().
-			CombinedOutput(); err != nil {
+		if err := addTracksDep(townBeads, convoyID, beadID, "gt convoy stage"); err != nil {
 			fmt.Printf("  Warning: could not track %s in convoy: %v\n", beadID, err)
-			_ = out
 		}
 	}
 
@@ -773,27 +768,20 @@ func updateStagedConvoy(existingConvoyID string, dag *ConvoyDAG, waves []Wave, s
 		return fmt.Errorf("reading tracked beads for %s: %w", existingConvoyID, err)
 	}
 
-	// Add new beads not currently tracked.
-	// Cross-rig tracking may fail (bd validates both IDs in same DB). Non-fatal.
+	// Add new beads not currently tracked via direct SQL INSERT.
 	for _, id := range desiredIDs {
 		if !currentIDs[id] {
-			if out, err := BdCmd("dep", "add", existingConvoyID, id, "--type=tracks").
-				Dir(townBeads).WithAutoCommit().StripBeadsDir().
-				CombinedOutput(); err != nil {
+			if err := addTracksDep(townBeads, existingConvoyID, id, "gt convoy stage"); err != nil {
 				fmt.Printf("  Warning: could not track %s in convoy: %v\n", id, err)
-				_ = out
 			}
 		}
 	}
 
-	// Remove stale beads no longer in the DAG.
+	// Remove stale beads no longer in the DAG via direct SQL DELETE.
 	for id := range currentIDs {
 		if !desiredSet[id] {
-			if out, err := BdCmd("dep", "remove", existingConvoyID, id, "--type=tracks").
-				Dir(townBeads).WithAutoCommit().StripBeadsDir().
-				CombinedOutput(); err != nil {
+			if err := removeTracksDep(townBeads, existingConvoyID, id); err != nil {
 				fmt.Printf("  Warning: could not untrack %s from convoy: %v\n", id, err)
-				_ = out
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

Convoy tracking relations are 100% broken on bd >= v0.62 because `bd dep add`
validates that both issue IDs exist in the same database. Since convoys live
in hq while tracked issues live in rigs, every convoy tracking relation is
cross-database by definition.

- Replace `bd dep add` with direct SQL `INSERT IGNORE INTO dependencies` via
  `bd sql`, which writes to the hq dependencies table without resolving the
  foreign issue ID
- Extract `addTracksDep`/`removeTracksDep` helpers (5 call sites across
  convoy create, add, stage, and stage-update)
- Fix `getIssueDetails` to use `resolveBeadDir()` for cross-rig `bd show`,
  so `convoy status` correctly fetches rig issue details

## Context

- `bd dep add` validates both IDs exist in the local store (by design — bd
  is gt-unaware per maintainer policy)
- The read side (`bdDepListRawIDs`, `getTrackedIssues`) already uses raw SQL
  for the same cross-database reason (#2624, #2832)
- `bd sql` for writes has precedent in `doctor/null_assignee_check.go`,
  `doltserver/wisps_migrate.go`, and others
- Works across all Dolt modes (server, embedded) and multi-server configs
  since the INSERT only targets the hq database

## Test plan

- [x] `TestConvoyCreate_DepAddUsesTownRoot` updated — verifies SQL INSERT
  runs from town root with correct query
- [x] All existing convoy tests pass (`go test ./internal/cmd/ -run TestConvoy`)
- [x] Full suite passes (`go test ./...` — 0 regressions)
- [x] Manual e2e: create convoy tracking 3 rig issues, close them
  one by one, verify `convoy status` shows progress (0/3 → 1/3 → 2/3 → 3/3),
  `convoy check` auto-closes on completion