### PR TITLE
Feat/cursor runtime parity

### DIFF
--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -1,0 +1,47 @@
+# Cursor / `cursor-agent` in this repo
+
+This directory holds **Cursor-specific** onboarding. For general Gas Town agent instructions, see [`../AGENTS.md`](../AGENTS.md) and [`../CLAUDE.md`](../CLAUDE.md).
+
+## Prerequisites
+
+1. **Build `gt`** from the repo root (`make build` or `go install ./cmd/gt`). Gas Town expects a working `gt` on your `PATH` for hooks and crew workflows.
+2. **`bd` (beads)** — issue DB under `.beads/`; see [`../CONTRIBUTING.md`](../CONTRIBUTING.md) for workflow.
+3. **Cursor Agent CLI** — install the `cursor-agent` binary per Cursor’s documentation. The Gas Town preset name is **`cursor`**; the process is typically **`cursor-agent`** (an **`agent`** symlink may exist).
+
+## Preset vs binary
+
+- **Preset:** `cursor` (`GT_AGENT=cursor`) — defined in `internal/config/agents.go`.
+- **CLI:** `cursor-agent` (args include **`-f`** for auto-approve in autonomous flows).
+
+## Hooks
+
+Hooks are installed under **`.cursor/hooks.json`** when roles are provisioned (`EnsureSettingsForRole`). After template or hook changes, restart agents (e.g. **`gt up --restore`**) so sessions pick up new files.
+
+## Skills
+
+See [`.cursor/skills/gas-town-cursor/SKILL.md`](skills/gas-town-cursor/SKILL.md) for agent-facing workflow (gt, resume, pointers to code).
+
+## Beads / plan tracking
+
+Epic tasks for Cursor runtime parity are tracked in beads; coordination notes and script:
+
+- [`docs/cursor-runtime-beads-tasks.md`](../docs/cursor-runtime-beads-tasks.md)
+- [`scripts/cursor-runtime-bd-tasks.sh`](../scripts/cursor-runtime-bd-tasks.sh)
+
+## Automated regression (local)
+
+```bash
+./scripts/cursor-runtime-test-gate.sh
+```
+
+Covers `internal/config`, `hooks`, `crew`, `tmux`, and `runtime` packages (see script for exact `go test` line).
+
+## Manual smoke (short)
+
+Run these only when changing behavior that tests do not cover end-to-end:
+
+1. `make build` — `gt` binary builds.
+2. `gt config agent list` — output includes the **`cursor`** preset.
+3. Start or attach to a dev session with **`GT_AGENT=cursor`** (or `--agent cursor`) and confirm the pane command shows **`cursor-agent`** or **`agent`** and the session receives hooks/nudges as expected.
+
+For full §9-style checklists, see the Cursor parity plan document in your planning folder if present; prefer adding **automated** tests in-repo when possible.

--- a/.cursor/README.md
+++ b/.cursor/README.md
@@ -30,11 +30,13 @@ Epic tasks for Cursor runtime parity are tracked in beads; coordination notes an
 
 ## Automated regression (local)
 
+CI already runs **`go test ./...`** (same coverage as a “gate” over these packages). For a **faster loop** while touching Cursor-related code, narrow packages:
+
 ```bash
-./scripts/cursor-runtime-test-gate.sh
+go test ./internal/config/... ./internal/hooks/... ./internal/crew/... ./internal/tmux/... ./internal/runtime/... -count=1 -short
 ```
 
-Covers `internal/config`, `hooks`, `crew`, `tmux`, and `runtime` packages (see script for exact `go test` line).
+Run as a **non-root** user if you want chmod/read-only failure tests in `hooks` and `util` (root skips those cases by design).
 
 ## Manual smoke (short)
 

--- a/.cursor/skills/gas-town-cursor/SKILL.md
+++ b/.cursor/skills/gas-town-cursor/SKILL.md
@@ -1,0 +1,37 @@
+---
+name: gas-town-cursor
+description: >
+  Develop and operate Gas Town with the Cursor agent preset (cursor-agent CLI):
+  gt flags, hooks at .cursor/hooks.json, session resume, and how this repo differs from README marketing copy.
+---
+
+# Gas Town + Cursor Agent CLI
+
+Use this skill when working **in this repository** with the **`cursor`** agent preset (CLI binary **`cursor-agent`**, sometimes symlinked as **`agent`**).
+
+## Concepts
+
+| Name | Meaning |
+|------|---------|
+| **Preset `cursor`** | Gas Town agent id (`GT_AGENT=cursor`). Config lives in `internal/config/agents.go` (`AgentCursor`). |
+| **Binary `cursor-agent`** | The Cursor Agent CLI process name for pane/detection; install docs may also symlink `agent` → same binary. |
+| **Hooks** | Cursor lifecycle hooks are configured at **`.cursor/hooks.json`** (see preset `HooksSettingsFile`). |
+
+## Essential commands
+
+- Build / run `gt` from repo root: `make build` or `go run ./cmd/gt …`.
+- Point a session at the Cursor preset: spawn or config so the runtime uses **`--agent cursor`** (or set **`GT_AGENT=cursor`** where applicable).
+- After changing hooks or settings: **`gt up --restore`** (or role-specific restart) so agents reload config.
+
+## Resume semantics
+
+The Cursor preset uses **`--resume <chatId>`** style resume (`ResumeStyle: flag`). Session identity is not carried in a dedicated env var in the same way as Claude’s `CLAUDE_SESSION_ID`; follow the preset fields in `internal/config/agents.go` (`ResumeFlag`, `ResumeStyle`).
+
+## Read more
+
+- Beads / plan handoff: [`docs/cursor-runtime-beads-tasks.md`](../../../docs/cursor-runtime-beads-tasks.md)
+- Agent instructions for automation: [`AGENTS.md`](../../../AGENTS.md) and [`CLAUDE.md`](../../../CLAUDE.md) (project-wide, not Cursor-only)
+
+## Boundary
+
+Project **README** is user-facing product overview; **`.cursor/README.md`** is Cursor-specific onboarding for this repo. Prefer linking to those files instead of duplicating long install steps inside skills.

--- a/docs/agent-provider-integration.md
+++ b/docs/agent-provider-integration.md
@@ -529,7 +529,7 @@ Current agent capabilities at a glance:
 | Claude | Yes (settings.json) | `--resume` (flag) | Native | Yes | arg | node, claude |
 | Gemini | Yes | `--resume` (flag) | `-p` | No | arg | gemini |
 | Codex | No | `resume` (subcmd) | `exec` subcmd | No | none | codex |
-| Cursor | No | `--resume` (flag) | `-p` | No | arg | cursor-agent |
+| Cursor | Yes (`.cursor/hooks.json`) | `--resume` (flag) | `-p` / `--print` + `--output-format` | No | arg | cursor-agent, agent |
 | Auggie | No | `--resume` (flag) | No | No | arg | auggie |
 | AMP | No | `threads continue` (subcmd) | No | No | arg | amp |
 | OpenCode | Yes (plugin JS) | No | `run` subcmd | No | none | opencode, node, bun |

--- a/docs/cursor-runtime-beads-tasks.md
+++ b/docs/cursor-runtime-beads-tasks.md
@@ -1,0 +1,21 @@
+# Cursor runtime plan — Beads tasks (handoff)
+
+These issues track **Cursor runtime parity**, **user-facing documentation clarity** (preset `cursor` vs CLI `cursor-agent` / `agent`), and **`.cursor/` onboarding**. Issue IDs vary by database.
+
+**Create issues (idempotent — skips if open `cursor-runtime`+`plan` issues exist):**
+
+```bash
+./scripts/cursor-runtime-bd-tasks.sh
+```
+
+**Full task scope:** see **§10a** and **§4b** in the Cursor parity plan (`cursor_runtime_parity_df5a36d7.plan.md` in your editor plans folder).
+
+**T5 (docs + CLI)** explicitly covers:
+
+- `gt config` / `internal/cmd/config.go` help — list **all** built-in presets, not only claude/gemini/codex.
+- **README** prerequisites — optional **Cursor Agent CLI** install; clarify **preset `cursor`** vs binaries.
+- **docs/INSTALLING.md**, **docs/reference.md** — same built-in lists as README; short note on **`cursor`** → `cursor-agent`.
+
+**Contributing:** [`CONTRIBUTING.md`](../CONTRIBUTING.md). Do not add `.beads/issues.jsonl` at repo root (CI). `bd vc commit` when persisting beads DB changes.
+
+**Migration:** If you seeded tasks with an older script, **retitle T5** in `bd` to match the table in the plan §10a, or close duplicates.

--- a/docs/design/otel/otel-architecture.md
+++ b/docs/design/otel/otel-architecture.md
@@ -410,7 +410,7 @@ run.id:uuid-1234
 | `GT_POLECAT` | `Toast`, `Shadow`, `Furiosa` | Polecat name (rig-specific) |
 | `GT_CREW` | `max`, `jane` | Crew member name |
 | `GT_SESSION` | `gt-gastown-Toast`, `hq-mayor` | Tmux session name |
-| `GT_AGENT` | `claudecode`, `codex`, `copilot` | Agent override (if specified) |
+| `GT_AGENT` | Preset names: `claude`, `gemini`, `codex`, `cursor`, `copilot`, `opencode`, … | Agent override (if specified) |
 | `GT_RUN` | UUID v4 | **PR #2199** — Run identifier, primary waterfall correlation key |
 | `GT_ROOT` | `/Users/pa/gt` | Town root path |
 | `CLAUDE_CONFIG_DIR` | `~/gt/.claude` | Runtime config directory (for agent overrides) |

--- a/internal/cmd/compact_report_test.go
+++ b/internal/cmd/compact_report_test.go
@@ -26,11 +26,19 @@ func TestWispTypeToCategory(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.wispType, func(t *testing.T) {
-			got := wispTypeToCategory(tc.wispType)
+			got := wispTypeToCategory(tc.wispType, "")
 			if got != tc.want {
-				t.Errorf("wispTypeToCategory(%q) = %q, want %q", tc.wispType, got, tc.want)
+				t.Errorf("wispTypeToCategory(%q, \"\") = %q, want %q", tc.wispType, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestWispTypeToCategory_TitlePatrolFallback(t *testing.T) {
+	t.Parallel()
+	got := wispTypeToCategory("", "nightly patrol sweep")
+	if got != "Patrols" {
+		t.Errorf("empty wisp_type + patrol in title = %q, want Patrols", got)
 	}
 }
 

--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -42,15 +42,8 @@ Commands:
 var configAgentListCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List all agents",
-	Long: `List all available agents (built-in and custom).
-
-Shows all built-in agent presets (claude, gemini, codex) and any
-custom agents defined in your town settings.
-
-Examples:
-  gt config agent list           # Text output
-  gt config agent list --json    # JSON output`,
-	RunE: runConfigAgentList,
+	Long:  "", // Set in init() — includes full built-in preset list from config.BuiltInAgentPresetSummary()
+	RunE:  runConfigAgentList,
 }
 
 var configAgentGetCmd = &cobra.Command{
@@ -97,15 +90,9 @@ Examples:
 var configAgentRemoveCmd = &cobra.Command{
 	Use:   "remove <name>",
 	Short: "Remove custom agent",
-	Long: `Remove a custom agent definition from town settings.
-
-This removes a custom agent from your town settings. Built-in agents
-(claude, gemini, codex) cannot be removed.
-
-Examples:
-  gt config agent remove claude-glm`,
-	Args: cobra.ExactArgs(1),
-	RunE: runConfigAgentRemove,
+	Long:  "", // Set in init() — includes full built-in preset list
+	Args:  cobra.ExactArgs(1),
+	RunE:  runConfigAgentRemove,
 }
 
 // Cost-tier subcommand
@@ -192,24 +179,8 @@ func runConfigCostTier(cmd *cobra.Command, args []string) error {
 var configDefaultAgentCmd = &cobra.Command{
 	Use:   "default-agent [name]",
 	Short: "Get or set default agent",
-	Long: `Get or set the default agent for the town.
-
-With no arguments, shows the current default agent.
-With an argument, sets the default agent to the specified name.
-
-The default agent is used when a rig doesn't specify its own agent
-setting. Can be a built-in preset (claude, gemini, codex) or a
-custom agent name.
-
-Use 'gt config default-agent list' to see all available agents.
-
-Examples:
-  gt config default-agent           # Show current default
-  gt config default-agent list      # List available agents
-  gt config default-agent claude    # Set to claude
-  gt config default-agent gemini    # Set to gemini
-  gt config default-agent my-custom # Set to custom agent`,
-	RunE: runConfigDefaultAgent,
+	Long:  "", // Set in init() — includes full built-in preset list
+	RunE:  runConfigDefaultAgent,
 }
 
 var configDefaultAgentListCmd = &cobra.Command{
@@ -1255,10 +1226,47 @@ func parseBool(s string) (bool, error) {
 }
 
 func init() {
+	presets := config.BuiltInAgentPresetSummary()
+
+	configAgentListCmd.Long = fmt.Sprintf(`List all available agents (built-in and custom).
+
+Shows all built-in agent presets (%s) and any
+custom agents defined in your town settings.
+
+Examples:
+  gt config agent list           # Text output
+  gt config agent list --json    # JSON output`, presets)
+
+	configAgentRemoveCmd.Long = fmt.Sprintf(`Remove a custom agent definition from town settings.
+
+This removes a custom agent from your town settings. Built-in agents
+(%s) cannot be removed.
+
+Examples:
+  gt config agent remove claude-glm`, presets)
+
+	configDefaultAgentCmd.Long = fmt.Sprintf(`Get or set the default agent for the town.
+
+With no arguments, shows the current default agent.
+With an argument, sets the default agent to the specified name.
+
+The default agent is used when a rig doesn't specify its own agent
+setting. Can be a built-in preset (%s) or a
+custom agent name.
+
+Use 'gt config default-agent list' to see all available agents.
+
+Examples:
+  gt config default-agent           # Show current default
+  gt config default-agent list      # List available agents
+  gt config default-agent claude    # Set to claude
+  gt config default-agent gemini    # Set to gemini
+  gt config default-agent my-custom # Set to custom agent`, presets)
+
 	// Add flags
 	configAgentListCmd.Flags().BoolVar(&configAgentListJSON, "json", false, "Output as JSON")
 	configDefaultAgentListCmd.Flags().BoolVar(&configDefaultAgentListJSON, "json", false, "Output as JSON")
-	configAgentSetCmd.Flags().StringVar(&configAgentSetProvider, "provider", "", "Agent provider preset (e.g. claude, gemini, codex); inferred from command name if not set")
+	configAgentSetCmd.Flags().StringVar(&configAgentSetProvider, "provider", "", fmt.Sprintf("Agent provider preset (e.g. %s); inferred from command name if not set", presets))
 
 	// Add agent subcommands
 	configAgentCmd := &cobra.Command{

--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -742,8 +742,8 @@ func verifyShutdown(t *tmux.Tmux, townRoot string) []string {
 	return respawned
 }
 
-// findOrphanedClaudeProcesses finds Claude/node processes that are running in the
-// town directory but aren't associated with any active tmux session.
+// findOrphanedClaudeProcesses finds Gas Town agent processes (claude/codex/opencode/cursor-agent/copilot/node)
+// that are running in the town directory but aren't associated with any active tmux session.
 // This can happen when tmux sessions are killed but child processes don't terminate.
 //
 // Only matches processes whose full command line references the town root path,
@@ -778,7 +778,7 @@ func findOrphanedClaudeProcesses(townRoot string) []int {
 		// Only consider known Gas Town process names
 		comm := strings.ToLower(fields[1])
 		switch comm {
-		case "claude", "claude-code", "codex", "node":
+		case "claude", "claude-code", "codex", "opencode", "cursor-agent", "agent", "copilot", "node":
 			// Potential Gas Town process
 		default:
 			continue
@@ -1205,4 +1205,3 @@ func containsPathBoundary(line, path string) bool {
 	}
 	return false
 }
-

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -306,6 +306,8 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		HooksDir:          ".cursor",
 		HooksSettingsFile: "hooks.json", // installed path: .cursor/hooks.json
 		InstructionsFile:  "AGENTS.md",
+		// No stable ReadyPromptPrefix yet; delay before nudge poller / early input (HasTurnBoundaryDrain is false — see Copilot).
+		ReadyDelayMs: 5000,
 	},
 	AgentAuggie: {
 		Name:                AgentAuggie,

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -59,7 +59,7 @@ type AgentPresetInfo struct {
 
 	// ProcessNames are the process names to look for when detecting if the agent is running.
 	// Used by tmux.IsAgentRunning to check pane_current_command.
-	// E.g., ["node"] for Claude, ["cursor-agent"] for Cursor.
+	// E.g., ["node"] for Claude, ["cursor-agent", "agent"] for Cursor (install script symlinks both names).
 	ProcessNames []string `json:"process_names,omitempty"`
 
 	// SessionIDEnv is the environment variable for session ID.
@@ -283,15 +283,18 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		InstructionsFile:  "AGENTS.md",
 	},
 	AgentCursor: {
-		Name:                AgentCursor,
-		Command:             "cursor-agent",
-		Args:                []string{"-f"}, // Force mode (YOLO equivalent), -p requires prompt
-		ProcessNames:        []string{"cursor-agent"},
+		Name:    AgentCursor,
+		Command: "cursor-agent",
+		// -f/--force: auto-approve tool use (see cursor-agent --help). Install script also symlinks "agent" -> same binary.
+		Args: []string{"-f"},
+		// cursor-agent + agent (install symlinks). Pane matching for "agent" requires session env (GT_AGENT=cursor or GT_PROCESS_NAMES includes cursor-agent); see internal/tmux processNamesForSession.
+		ProcessNames:        []string{"cursor-agent", "agent"},
 		SessionIDEnv:        "", // Uses --resume with chatId directly
 		ResumeFlag:          "--resume",
 		ResumeStyle:         "flag",
 		SupportsHooks:       true,
 		SupportsForkSession: false,
+		// Non-interactive/headless: -p/--print + --output-format json (matches cursor-agent --help).
 		NonInteractive: &NonInteractiveConfig{
 			PromptFlag: "-p",
 			OutputFlag: "--output-format json",
@@ -301,7 +304,7 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		ConfigDir:         ".cursor",
 		HooksProvider:     "cursor",
 		HooksDir:          ".cursor",
-		HooksSettingsFile: "hooks.json",
+		HooksSettingsFile: "hooks.json", // installed path: .cursor/hooks.json
 		InstructionsFile:  "AGENTS.md",
 	},
 	AgentAuggie: {

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 )
@@ -559,6 +560,14 @@ func ListAgentPresets() []string {
 		names = append(names, name)
 	}
 	return names
+}
+
+// BuiltInAgentPresetSummary returns a sorted, comma-separated list of built-in preset names
+// for CLI help text (gt config agent list, default-agent, --provider, etc.).
+func BuiltInAgentPresetSummary() string {
+	names := ListAgentPresets()
+	sort.Strings(names)
+	return strings.Join(names, ", ")
 }
 
 // DefaultAgentPreset returns the default agent preset (Claude).

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -784,6 +784,9 @@ func TestCursorAgentPreset(t *testing.T) {
 	if info.ResumeStyle != "flag" {
 		t.Errorf("cursor ResumeStyle = %q, want flag", info.ResumeStyle)
 	}
+	if info.ReadyDelayMs != 5000 {
+		t.Errorf("cursor ReadyDelayMs = %d, want 5000 (nudge poller + WaitForRuntimeReady)", info.ReadyDelayMs)
+	}
 }
 
 // TestDefaultRigAgentRegistryPath verifies that the default rig agent registry path is constructed correctly.

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -14,6 +15,18 @@ func isClaudeCmd(cmd string) bool {
 	base := filepath.Base(cmd)
 	base = strings.TrimSuffix(base, filepath.Ext(base))
 	return base == "claude"
+}
+
+func TestBuiltInAgentPresetSummary(t *testing.T) {
+	t.Parallel()
+	s := BuiltInAgentPresetSummary()
+	if !strings.Contains(s, "cursor") || !strings.Contains(s, "claude") {
+		t.Fatalf("BuiltInAgentPresetSummary() = %q, want cursor and claude", s)
+	}
+	names := strings.Split(s, ", ")
+	if !sort.StringsAreSorted(names) {
+		t.Errorf("BuiltInAgentPresetSummary not sorted: %q", s)
+	}
 }
 
 func TestBuiltinPresets(t *testing.T) {

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -610,7 +610,7 @@ func TestGetProcessNames(t *testing.T) {
 		{"claude", []string{"node", "claude"}},
 		{"gemini", []string{"gemini"}},
 		{"codex", []string{"codex"}},
-		{"cursor", []string{"cursor-agent"}},
+		{"cursor", []string{"cursor-agent", "agent"}},
 		{"auggie", []string{"auggie"}},
 		{"amp", []string{"amp"}},
 		{"opencode", []string{"opencode", "node", "bun"}},
@@ -754,8 +754,7 @@ func TestCursorAgentPreset(t *testing.T) {
 		t.Errorf("cursor command = %q, want cursor-agent", info.Command)
 	}
 
-	// Check YOLO-equivalent flag (-f for force mode)
-	// Note: -p is for non-interactive mode with prompt, not used for default Args
+	// Check YOLO-equivalent flag (-f for force mode; CLI also documents --force / --yolo)
 	hasF := false
 	for _, arg := range info.Args {
 		if arg == "-f" {
@@ -766,12 +765,16 @@ func TestCursorAgentPreset(t *testing.T) {
 		t.Error("cursor args missing -f (force/YOLO mode)")
 	}
 
-	// Check ProcessNames for detection
-	if len(info.ProcessNames) == 0 {
-		t.Error("cursor ProcessNames is empty")
+	// Check ProcessNames for detection (install script provides both "agent" and "cursor-agent" symlinks).
+	// Tmux only treats "agent" as Cursor when GT_AGENT=cursor or GT_PROCESS_NAMES includes cursor-agent.
+	seen := make(map[string]bool, len(info.ProcessNames))
+	for _, n := range info.ProcessNames {
+		seen[n] = true
 	}
-	if info.ProcessNames[0] != "cursor-agent" {
-		t.Errorf("cursor ProcessNames[0] = %q, want cursor-agent", info.ProcessNames[0])
+	for _, name := range []string{"agent", "cursor-agent"} {
+		if !seen[name] {
+			t.Errorf("cursor ProcessNames missing %q (got %v)", name, info.ProcessNames)
+		}
 	}
 
 	// Check resume support

--- a/internal/config/cursor_agent_cli_test.go
+++ b/internal/config/cursor_agent_cli_test.go
@@ -1,0 +1,92 @@
+package config
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// resolveCursorAgentForCLIPTest returns a real cursor-agent binary path. test_main_test.go prepends
+// tiny PATH stubs that shadow the real CLI; we skip those dirs and prefer GT_CURSOR_AGENT_BIN when set.
+func resolveCursorAgentForCLIPTest(t *testing.T) (string, []byte) {
+	t.Helper()
+	if p := os.Getenv("GT_CURSOR_AGENT_BIN"); p != "" {
+		out, err := exec.Command(p, "--help").CombinedOutput()
+		if err != nil {
+			t.Fatalf("GT_CURSOR_AGENT_BIN --help: %v\n%s", err, out)
+		}
+		return p, out
+	}
+	stubDir := os.Getenv("GT_AGENT_STUB_BIN_DIR")
+	for _, dir := range filepath.SplitList(os.Getenv("PATH")) {
+		if dir == "" {
+			continue
+		}
+		if stubDir != "" && dir == stubDir {
+			continue
+		}
+		p := filepath.Join(dir, "cursor-agent")
+		info, err := os.Stat(p)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		out, err := exec.Command(p, "--help").CombinedOutput()
+		if err != nil {
+			continue
+		}
+		if len(out) >= 200 && strings.Contains(string(out), "Usage:") {
+			return p, out
+		}
+	}
+	return "", nil
+}
+
+// TestCursorAgentCLIPresetMatchesHelp verifies the built-in AgentCursor preset stays aligned with
+// the Cursor Agent CLI when `cursor-agent` is installed (curl https://cursor.com/install -fsSL | bash).
+func TestCursorAgentCLIPresetMatchesHelp(t *testing.T) {
+	path, out := resolveCursorAgentForCLIPTest(t)
+	if path == "" {
+		t.Skip("real cursor-agent not found outside test stubs; install Cursor CLI or set GT_CURSOR_AGENT_BIN")
+	}
+
+	t.Logf("cursor-agent CLI contract using %s", path)
+	help := strings.ToLower(string(out))
+
+	info := GetAgentPreset(AgentCursor)
+	if info == nil {
+		t.Fatal("cursor preset not found")
+	}
+
+	for _, needle := range []string{"--resume", "-f", "--force", "--print", "--output-format"} {
+		if !strings.Contains(help, strings.ToLower(needle)) {
+			t.Errorf("cursor-agent --help missing %q (preset may be stale vs CLI)", needle)
+		}
+	}
+	// Require json as an output-format option, not merely the substring "json" elsewhere.
+	if !strings.Contains(help, "output-format") || !(strings.Contains(help, "json") && strings.Contains(help, "stream-json")) {
+		t.Errorf("cursor-agent --help should document --output-format with json and stream-json")
+	}
+
+	if info.ResumeFlag != "--resume" {
+		t.Errorf("preset ResumeFlag = %q, want --resume", info.ResumeFlag)
+	}
+	if info.NonInteractive == nil {
+		t.Fatal("preset NonInteractive is nil")
+	}
+	if info.NonInteractive.PromptFlag != "-p" || !strings.Contains(help, "--print") {
+		t.Errorf("preset PromptFlag %q should match CLI -p/--print for headless use", info.NonInteractive.PromptFlag)
+	}
+	of := strings.Fields(info.NonInteractive.OutputFlag)
+	if len(of) < 2 || of[0] != "--output-format" {
+		t.Fatalf("preset OutputFlag = %q, want '--output-format …'", info.NonInteractive.OutputFlag)
+	}
+	if !strings.Contains(help, strings.TrimPrefix(of[0], "-")) {
+		t.Errorf("cursor-agent --help should document %s", of[0])
+	}
+
+	if info.HooksDir != ".cursor" || info.HooksSettingsFile != "hooks.json" {
+		t.Errorf("hooks path parts = %q + %q, want .cursor + hooks.json", info.HooksDir, info.HooksSettingsFile)
+	}
+}

--- a/internal/config/test_main_test.go
+++ b/internal/config/test_main_test.go
@@ -41,10 +41,14 @@ func TestMain(m *testing.M) {
 
 	originalPath := os.Getenv("PATH")
 	_ = os.Setenv("PATH", stubDir+string(os.PathListSeparator)+originalPath)
+	// cursor_agent_cli_test.go skips this directory when resolving a real cursor-agent
+	// (must stay in sync — do not rename without updating that resolver).
+	_ = os.Setenv("GT_AGENT_STUB_BIN_DIR", stubDir)
 
 	code := m.Run()
 
 	_ = os.Setenv("PATH", originalPath)
+	_ = os.Unsetenv("GT_AGENT_STUB_BIN_DIR")
 	_ = os.RemoveAll(stubDir)
 	os.Exit(code)
 }

--- a/internal/doctor/orphan_check.go
+++ b/internal/doctor/orphan_check.go
@@ -409,8 +409,39 @@ func (c *OrphanProcessCheck) getTmuxSessionPIDs() (map[int]bool, error) { //noli
 	return pids, nil
 }
 
-// findRuntimeProcesses finds Gas Town Claude processes (those with --dangerously-skip-permissions).
-// Only detects processes started by Gas Town, not user's personal Claude sessions.
+// argvHasFlag reports whether argv (full command line) contains a standalone flag token.
+func argvHasFlag(args, flag string) bool {
+	for _, tok := range strings.Fields(args) {
+		if tok == flag || strings.HasPrefix(tok, flag+"=") {
+			return true
+		}
+	}
+	return false
+}
+
+// gasTownRuntimeYOLO returns true when argv matches a Gas Town-managed agent (YOLO / auto-approve),
+// excluding personal interactive sessions that omit these flags.
+func gasTownRuntimeYOLO(cmdName, args string) bool {
+	cmdName = strings.ToLower(filepath.Base(cmdName))
+	switch cmdName {
+	case "claude", "claude-code", "codex":
+		return strings.Contains(args, "--dangerously-skip-permissions")
+	case "cursor-agent":
+		return argvHasFlag(args, "-f")
+	case "agent":
+		// Install may symlink cursor-agent as "agent"; require -f plus a Cursor-specific token.
+		return argvHasFlag(args, "-f") &&
+			(strings.Contains(args, "--resume") || argvHasFlag(args, "-p") || strings.Contains(args, "--print"))
+	case "copilot":
+		return strings.Contains(args, "--yolo")
+	default:
+		return false
+	}
+}
+
+// findRuntimeProcesses finds Gas Town agent processes by per-provider YOLO / launch signatures
+// in argv (not comm name alone): claude/codex --dangerously-skip-permissions, cursor-agent -f,
+// copilot --yolo, etc.
 func (c *OrphanProcessCheck) findRuntimeProcesses() ([]processInfo, error) {
 	var procs []processInfo
 
@@ -432,18 +463,10 @@ func (c *OrphanProcessCheck) findRuntimeProcesses() ([]processInfo, error) {
 			cmd = cmd[idx+1:]
 		}
 
-		// Only match claude/codex processes, not tmux or other launchers
-		// (tmux command line may contain --dangerously-skip-permissions as part of the launched command)
-		if cmd != "claude" && cmd != "claude-code" && cmd != "codex" {
-			continue
-		}
-
 		// Get full args
 		args := strings.Join(fields[2:], " ")
 
-		// Only match Gas Town Claude processes (have --dangerously-skip-permissions)
-		// This excludes user's personal Claude sessions
-		if !strings.Contains(args, "--dangerously-skip-permissions") {
+		if !gasTownRuntimeYOLO(cmd, args) {
 			continue
 		}
 

--- a/internal/doctor/orphan_check_test.go
+++ b/internal/doctor/orphan_check_test.go
@@ -450,3 +450,38 @@ func TestOrphanSessionCheck_Run_Deterministic(t *testing.T) {
 		t.Fatalf("expected 0 orphans (unknown prefixes are ignored), got %d: %v", len(check.orphanSessions), check.orphanSessions)
 	}
 }
+
+func TestArgvHasFlag(t *testing.T) {
+	if !argvHasFlag("/x/cursor-agent -f --resume z", "-f") {
+		t.Error("expected -f in argv")
+	}
+	if argvHasFlag("/x/cursor-agent --resume z", "-f") {
+		t.Error("did not expect -f")
+	}
+}
+
+func TestGasTownRuntimeYOLO(t *testing.T) {
+	tests := []struct {
+		name string
+		cmd  string
+		args string
+		want bool
+	}{
+		{"claude_gt", "claude", "/x/claude --dangerously-skip-permissions foo", true},
+		{"claude_personal", "claude", "/x/claude foo", false},
+		{"cursor_agent", "cursor-agent", "cursor-agent -f --resume x", true},
+		{"cursor_no_f", "cursor-agent", "cursor-agent --resume x", false},
+		{"agent_symlink", "agent", "agent -f --resume x", true},
+		{"agent_f_only", "agent", "agent -f", false},
+		{"copilot_yolo", "copilot", "copilot --yolo", true},
+		{"copilot_plain", "copilot", "copilot", false},
+		{"unknown", "vim", "vim foo", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := gasTownRuntimeYOLO(tt.cmd, tt.args); got != tt.want {
+				t.Errorf("gasTownRuntimeYOLO(%q, %q) = %v, want %v", tt.cmd, tt.args, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/hooks/installer_test.go
+++ b/internal/hooks/installer_test.go
@@ -201,6 +201,9 @@ func TestSyncForRole_WriteError(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("Windows does not support read-only directories reliably")
 	}
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses directory permission bits; chmod read-only is not enforceable")
+	}
 
 	dir := t.TempDir()
 	// Create a read-only parent to prevent MkdirAll from creating the hooks dir

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -544,6 +544,32 @@ func TestEnsureSettingsForRole_CopilotUsesWorkDir(t *testing.T) {
 	}
 }
 
+func TestEnsureSettingsForRole_CursorUsesWorkDir(t *testing.T) {
+	// Cursor hooks.json is installed under workDir (HooksUseSettingsDir false for cursor preset).
+	settingsDir := t.TempDir()
+	workDir := t.TempDir()
+
+	rc := &config.RuntimeConfig{
+		Hooks: &config.RuntimeHooksConfig{
+			Provider:     "cursor",
+			Dir:          ".cursor",
+			SettingsFile: "hooks.json",
+		},
+	}
+
+	err := EnsureSettingsForRole(settingsDir, workDir, "crew", rc)
+	if err != nil {
+		t.Fatalf("EnsureSettingsForRole() error = %v", err)
+	}
+
+	if _, err := os.Stat(settingsDir + "/.cursor/hooks.json"); err == nil {
+		t.Error("Cursor hooks should NOT be in settingsDir")
+	}
+	if _, err := os.Stat(workDir + "/.cursor/hooks.json"); err != nil {
+		t.Error("Cursor hooks should be in workDir")
+	}
+}
+
 func TestGetStartupFallbackInfo_InformationalHooks(t *testing.T) {
 	// Copilot: hooks provider set but informational (instructions file, not executable).
 	// Should be treated as having NO hooks for startup fallback purposes.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1272,7 +1272,6 @@ func nudgeFlockPath(townRoot, session string) string {
 	return filepath.Join(townRoot, constants.DirRuntime, "nudge_queue", safe, ".lock")
 }
 
-
 // IsSessionAttached returns true if the session has any clients attached.
 func (t *Tmux) IsSessionAttached(target string) bool {
 	attached, err := t.run("display-message", "-t", target, "-p", "#{session_attached}")
@@ -1433,9 +1432,9 @@ func (t *Tmux) dismissRewindMode(target string) {
 // Falls back to best-effort (no verification) if pane capture fails.
 func (t *Tmux) sendEnterVerified(target string) error {
 	const (
-		maxRetries       = 3
-		initialBackoff   = 500 * time.Millisecond
-		verifyLines      = 5 // capture last N lines for comparison
+		maxRetries     = 3
+		initialBackoff = 500 * time.Millisecond
+		verifyLines    = 5 // capture last N lines for comparison
 	)
 
 	// Snapshot pane content before Enter so we can detect processing.
@@ -2029,7 +2028,7 @@ func (t *Tmux) findAgentPaneByScan(session string) (string, error) {
 		paneCmd := parts[1]
 		panePID := parts[2]
 
-		if matchesPaneRuntime(paneCmd, panePID, processNames) {
+		if t.matchesPaneRuntime(session, paneCmd, panePID, processNames) {
 			return paneID, nil
 		}
 	}
@@ -2560,7 +2559,7 @@ func (t *Tmux) IsRuntimeRunning(session string, processNames []string) bool {
 
 	// ZFC: check declared pane identity set at session startup (gt-qmsx).
 	if declaredPane, err := t.GetEnvironment(session, "GT_PANE_ID"); err == nil && declaredPane != "" {
-		if t.checkTargetPaneForRuntime(declaredPane, processNames) {
+		if t.checkTargetPaneForRuntime(session, declaredPane, processNames) {
 			return true
 		}
 		// On Windows (psmux), pane IDs like %1 may not be supported by
@@ -2584,7 +2583,7 @@ func (t *Tmux) IsRuntimeRunning(session string, processNames []string) bool {
 			continue
 		}
 		cmd, pid := parts[0], parts[1]
-		if matchesPaneRuntime(cmd, pid, processNames) {
+		if t.matchesPaneRuntime(session, cmd, pid, processNames) {
 			return true
 		}
 	}
@@ -2593,13 +2592,13 @@ func (t *Tmux) IsRuntimeRunning(session string, processNames []string) bool {
 
 // checkTargetPaneForRuntime checks if a specific pane (by ID, e.g., "%5") is
 // running a matching process. Used by the ZFC path when GT_PANE_ID is declared.
-func (t *Tmux) checkTargetPaneForRuntime(paneID string, processNames []string) bool {
+func (t *Tmux) checkTargetPaneForRuntime(session, paneID string, processNames []string) bool {
 	cmd, err := t.run("display-message", "-t", paneID, "-p", "#{pane_current_command}")
 	if err != nil {
 		return false // pane doesn't exist
 	}
 	pid, _ := t.run("display-message", "-t", paneID, "-p", "#{pane_pid}")
-	return matchesPaneRuntime(strings.TrimSpace(cmd), strings.TrimSpace(pid), processNames)
+	return t.matchesPaneRuntime(session, strings.TrimSpace(cmd), strings.TrimSpace(pid), processNames)
 }
 
 // checkPaneForRuntime checks if the first window's pane is running a matching process.
@@ -2609,13 +2608,62 @@ func (t *Tmux) checkPaneForRuntime(session string, processNames []string) bool {
 		return false
 	}
 	pid, _ := t.GetPanePID(session)
-	return matchesPaneRuntime(cmd, pid, processNames)
+	return t.matchesPaneRuntime(session, cmd, pid, processNames)
+}
+
+// cursorAgentSessionDeclaresCursor reports whether tmux session env identifies the Cursor
+// runtime (preset "cursor"). Used to disambiguate the generic process name "agent" (Cursor's
+// install script symlinks `agent` to the same binary as cursor-agent) from unrelated binaries
+// named `agent`. The most reliable signal is GT_AGENT=cursor together with GT_PROCESS_NAMES
+// set at session startup (see internal/session/lifecycle.go).
+func cursorAgentSessionDeclaresCursor(t *Tmux, session string) bool {
+	if t == nil || session == "" {
+		return false
+	}
+	agent, err := t.GetEnvironment(session, "GT_AGENT")
+	if err == nil && agent == string(config.AgentCursor) {
+		return true
+	}
+	if names, err := t.GetEnvironment(session, "GT_PROCESS_NAMES"); err == nil && names != "" {
+		for _, n := range strings.Split(names, ",") {
+			if strings.TrimSpace(n) == "cursor-agent" {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+func withoutProcessName(names []string, drop string) []string {
+	out := make([]string, 0, len(names))
+	for _, n := range names {
+		if n != drop {
+			out = append(out, n)
+		}
+	}
+	return out
+}
+
+// processNamesForSession returns process names for pane matching, dropping the ambiguous
+// name "agent" unless the session declares the Cursor runtime.
+func processNamesForSession(t *Tmux, session string, processNames []string) []string {
+	if len(processNames) == 0 {
+		return processNames
+	}
+	if cursorAgentSessionDeclaresCursor(t, session) {
+		return processNames
+	}
+	return withoutProcessName(processNames, "agent")
 }
 
 // matchesPaneRuntime checks if a pane with the given command and PID is running a matching process.
-func matchesPaneRuntime(cmd, pid string, processNames []string) bool {
+func (t *Tmux) matchesPaneRuntime(session, cmd, pid string, processNames []string) bool {
+	names := processNamesForSession(t, session, processNames)
+	if len(names) == 0 {
+		return false
+	}
 	// Direct command match
-	for _, name := range processNames {
+	for _, name := range names {
 		if cmd == name {
 			return true
 		}
@@ -2626,15 +2674,15 @@ func matchesPaneRuntime(cmd, pid string, processNames []string) bool {
 	// If pane command is a shell, check descendants
 	for _, shell := range constants.SupportedShells {
 		if cmd == shell {
-			return hasDescendantWithNames(pid, processNames, 0)
+			return hasDescendantWithNames(pid, names, 0)
 		}
 	}
 	// Unrecognized command: check if process itself matches (version-as-argv[0])
-	if processMatchesNames(pid, processNames) {
+	if processMatchesNames(pid, names) {
 		return true
 	}
 	// Finally check descendants as fallback
-	return hasDescendantWithNames(pid, processNames, 0)
+	return hasDescendantWithNames(pid, names, 0)
 }
 
 // IsAgentAlive checks if an agent is running in the session using agent-agnostic detection.

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -481,6 +481,34 @@ func TestIsAgentRunning_NonexistentSession(t *testing.T) {
 	}
 }
 
+func TestIsRuntimeRunning_AgentNameRequiresCursorSession(t *testing.T) {
+	tm := newTestTmux(t)
+	sessionName := "gt-test-runtime-agent-filter-" + t.Name()
+	_ = tm.KillSession(sessionName)
+	if err := tm.NewSessionWithCommand(sessionName, "", "sleep 60"); err != nil {
+		t.Fatalf("NewSessionWithCommand: %v", err)
+	}
+	defer func() { _ = tm.KillSession(sessionName) }()
+
+	// sleep matches; "agent" in the list is ignored when session does not declare Cursor
+	if !tm.IsRuntimeRunning(sessionName, []string{"agent", "sleep"}) {
+		t.Error("expected sleep to match when agent is stripped for non-cursor sessions")
+	}
+	if tm.IsRuntimeRunning(sessionName, []string{"agent"}) {
+		t.Error("expected bare agent not to match without GT_AGENT=cursor / GT_PROCESS_NAMES")
+	}
+	if err := tm.SetEnvironment(sessionName, "GT_AGENT", "cursor"); err != nil {
+		t.Fatalf("SetEnvironment: %v", err)
+	}
+	// With Cursor declared, "agent" is kept in the filter list (pane is still sleep — no match on agent alone)
+	if tm.IsRuntimeRunning(sessionName, []string{"agent"}) {
+		t.Error("pane is sleep, not agent — should not match on agent name alone")
+	}
+	if !tm.IsRuntimeRunning(sessionName, []string{"agent", "sleep"}) {
+		t.Error("expected sleep to still match with GT_AGENT=cursor")
+	}
+}
+
 func TestIsRuntimeRunning(t *testing.T) {
 	tm := newTestTmux(t)
 	sessionName := "gt-test-runtime-" + t.Name()

--- a/internal/util/atomic_test.go
+++ b/internal/util/atomic_test.go
@@ -197,6 +197,9 @@ func TestAtomicWriteFileReadOnlyDir(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("chmod-based read-only directories are not reliable on Windows")
 	}
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses directory permission bits; chmod read-only is not enforceable")
+	}
 
 	tmpDir := t.TempDir()
 	roDir := filepath.Join(tmpDir, "readonly")
@@ -272,6 +275,9 @@ func TestAtomicWriteFileConcurrent(t *testing.T) {
 func TestAtomicWritePreservesOnFailure(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("chmod-based read-only directories are not reliable on Windows")
+	}
+	if os.Getuid() == 0 {
+		t.Skip("root bypasses directory permission bits; chmod read-only is not enforceable")
 	}
 
 	tmpDir := t.TempDir()

--- a/internal/util/orphan.go
+++ b/internal/util/orphan.go
@@ -405,6 +405,17 @@ func parseEtime(etime string) (int, error) {
 	return days*86400 + hours*3600 + minutes*60 + seconds, nil
 }
 
+// isAgentOrphanCommName returns true if the ps "comm" field names a runtime we track for
+// TTY-less orphan / zombie cleanup (matches internal/config agent presets).
+func isAgentOrphanCommName(cmdLower string) bool {
+	switch cmdLower {
+	case "claude", "claude-code", "codex", "opencode", "cursor-agent", "agent", "copilot":
+		return true
+	default:
+		return false
+	}
+}
+
 // OrphanedProcess represents a claude process running without a controlling terminal.
 type OrphanedProcess struct {
 	PID      int
@@ -413,7 +424,8 @@ type OrphanedProcess struct {
 	TownRoot string // Gas Town workspace root, or "" if not in any workspace
 }
 
-// FindOrphanedClaudeProcesses finds claude/codex/opencode processes without a controlling terminal.
+// FindOrphanedClaudeProcesses finds Gas Town agent processes (claude/codex/opencode/cursor-agent/copilot, etc.)
+// without a controlling terminal.
 // These are typically subagent processes spawned by Claude Code's Task tool that didn't
 // clean up properly after completion.
 //
@@ -467,9 +479,9 @@ func FindOrphanedClaudeProcesses() ([]OrphanedProcess, error) {
 			continue
 		}
 
-		// Match claude, codex, or opencode command names
+		// Match known agent comm names (claude family, opencode, Cursor, Copilot CLI)
 		cmdLower := strings.ToLower(cmd)
-		if cmdLower != "claude" && cmdLower != "claude-code" && cmdLower != "codex" && cmdLower != "opencode" {
+		if !isAgentOrphanCommName(cmdLower) {
 			continue
 		}
 
@@ -582,9 +594,8 @@ func FindZombieClaudeProcesses() ([]ZombieProcess, error) {
 		cmd := fields[2]
 		etimeStr := fields[3]
 
-		// Match claude, codex, or opencode command names
 		cmdLower := strings.ToLower(cmd)
-		if cmdLower != "claude" && cmdLower != "claude-code" && cmdLower != "codex" && cmdLower != "opencode" {
+		if !isAgentOrphanCommName(cmdLower) {
 			continue
 		}
 

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -1821,7 +1821,14 @@ func (h *APIHandler) isClaudeRunningInSession(ctx context.Context, sessionName s
 		return false
 	}
 
-	output := strings.ToLower(strings.TrimSpace(stdout.String()))
+	output := strings.TrimSpace(stdout.String())
+	return paneCurrentCommandIsAgent(output)
+}
+
+// paneCurrentCommandIsAgent returns true if tmux #{pane_current_command} names a known
+// Gas Town agent (claude/codex/opencode/cursor-agent/copilot/node, or cursor-agent as "agent").
+func paneCurrentCommandIsAgent(output string) bool {
+	output = strings.ToLower(strings.TrimSpace(output))
 	if output == "" {
 		return false
 	}
@@ -1829,7 +1836,10 @@ func (h *APIHandler) isClaudeRunningInSession(ctx context.Context, sessionName s
 	return strings.Contains(output, "claude") ||
 		strings.Contains(output, "node") ||
 		strings.Contains(output, "codex") ||
-		strings.Contains(output, "opencode")
+		strings.Contains(output, "opencode") ||
+		strings.Contains(output, "cursor-agent") ||
+		strings.Contains(output, "copilot") ||
+		output == "agent"
 }
 
 // hasQuestionInPane checks the last output for question indicators.

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -1158,3 +1158,26 @@ func TestHandleSessionPreviewPrefixValidation(t *testing.T) {
 		})
 	}
 }
+
+func TestPaneCurrentCommandIsAgent(t *testing.T) {
+	tests := []struct {
+		cmd  string
+		want bool
+	}{
+		{"claude", true},
+		{"node", true},
+		{"codex", true},
+		{"opencode", true},
+		{"cursor-agent", true},
+		{"copilot", true},
+		{"agent", true},
+		{"bash", false},
+		{"", false},
+		{"   ", false},
+	}
+	for _, tt := range tests {
+		if got := paneCurrentCommandIsAgent(tt.cmd); got != tt.want {
+			t.Errorf("paneCurrentCommandIsAgent(%q) = %v, want %v", tt.cmd, got, tt.want)
+		}
+	}
+}

--- a/scripts/cursor-runtime-bd-tasks.sh
+++ b/scripts/cursor-runtime-bd-tasks.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# Create beads issues for the Cursor runtime parity + onboarding plan.
+# Idempotent: skips if an open epic with label cursor-runtime+plan already exists.
+set -euo pipefail
+
+ROOT="$(git rev-parse --show-toplevel 2>/dev/null || true)"
+if [[ -z "$ROOT" ]] || [[ ! -d "$ROOT/.beads" ]]; then
+  echo "Run from a gastown clone with beads initialized (bd init or bd bootstrap)." >&2
+  exit 1
+fi
+cd "$ROOT"
+
+if ! command -v bd >/dev/null 2>&1; then
+  echo "bd (beads) not on PATH. Install: https://github.com/steveyegge/beads" >&2
+  exit 1
+fi
+
+existing="$(bd count --status=open -l cursor-runtime -l plan 2>/dev/null | tr -d '[:space:]')"
+if [[ -n "${existing:-}" ]] && [[ "${existing}" != "0" ]]; then
+  echo "Open issues with labels cursor-runtime+plan already exist (count=$existing); skip."
+  exit 0
+fi
+
+EPIC="$(bd create --silent "Epic: Cursor runtime parity + onboarding (plan)" --type=epic -p 1 -l cursor-runtime -l plan \
+  -d "Umbrella: Go parity, user-facing docs (Cursor clarity), .cursor onboarding, smoke test. Plan: .cursor/plans/cursor_runtime_parity_df5a36d7.plan.md")"
+echo "Created epic $EPIC"
+
+T1="$(bd create --silent "cursor-runtime: Verify cursor-agent CLI (binary, -f, resume, hooks path)" --type=task -p 2 -l cursor-runtime --parent "$EPIC" \
+  -d "Match AgentCursor in internal/config/agents.go to current Cursor docs and cursor-agent --help.")"
+T2="$(bd create --silent "cursor-runtime: Tune ReadyDelayMs and/or ReadyPromptPrefix in agents.go" --type=task -p 2 -l cursor-runtime --parent "$EPIC" \
+  -d "Avoid race on cold start + nudge poller; see internal/tmux/tmux.go WaitForRuntimeReady. Plan §3.")"
+T3="$(bd create --silent "cursor-runtime: Process hygiene — orphan, doctor (YOLO signatures), down" --type=task -p 2 -l cursor-runtime --parent "$EPIC" \
+  -d "orphan.go + down.go: cursor-agent/copilot. doctor: per-agent YOLO args. Plan §1.")"
+T4="$(bd create --silent "cursor-runtime: Web API — detect cursor-agent and copilot in pane" --type=task -p 2 -l cursor-runtime --parent "$EPIC" \
+  -d "internal/web/api.go isClaudeRunningInSession. Plan §2.")"
+T5="$(bd create --silent "cursor-runtime: Docs + CLI — Cursor clarity and full built-in lists" --type=task -p 2 -l cursor-runtime --parent "$EPIC" \
+  -d "§4+§4b: internal/cmd/config.go help (full built-ins incl. cursor). README prerequisites (Cursor Agent CLI). docs/INSTALLING.md, docs/reference.md — preset cursor vs binaries cursor-agent/agent; align lists with README (pi, omp). Optional otel GT_AGENT. Plan §4, §4b.")"
+T6="$(bd create --silent "cursor-runtime: Tests + automated go test gate (§11)" --type=task -p 2 -l cursor-runtime --parent "$EPIC" \
+  -d "TestEnsureSettingsForRole_CursorUsesWorkDir; orphan/down, web, doctor tests; go test gate. Plan §6, §11.")"
+T7="$(bd create --silent "cursor-runtime: Add .cursor/skills/ (Gas Town + cursor-agent ops)" --type=task -p 2 -l cursor-runtime --parent "$EPIC" \
+  -d "Project skills per plan §7.")"
+T8="$(bd create --silent "cursor-runtime: Add .cursor/README.md onboarding + manual smoke test" --type=task -p 2 -l cursor-runtime --parent "$EPIC" \
+  -d "Primary entry for Cursor users; plan §8, §9.")"
+T9="$(bd create --silent "cursor-runtime: Link beads coordination doc from .cursor/README.md" --type=task -p 3 -l cursor-runtime --parent "$EPIC" \
+  -d "Link docs/cursor-runtime-beads-tasks.md + this script from .cursor/README.md. Plan §10.")"
+
+bd dep add "$T2" "$T1"
+bd dep add "$T6" "$T3"
+bd dep add "$T6" "$T4"
+bd dep add "$T8" "$T7"
+
+echo "Created tasks under $EPIC: $T1 $T2 $T3 $T4 $T5 $T6 $T7 $T8 $T9"
+echo "Next: bd vc commit (and your team's Dolt/git backup workflow)."

--- a/scripts/cursor-runtime-bd-tasks.sh
+++ b/scripts/cursor-runtime-bd-tasks.sh
@@ -35,14 +35,14 @@ T4="$(bd create --silent "cursor-runtime: Web API — detect cursor-agent and co
   -d "internal/web/api.go isClaudeRunningInSession. Plan §2.")"
 T5="$(bd create --silent "cursor-runtime: Docs + CLI — Cursor clarity and full built-in lists" --type=task -p 2 -l cursor-runtime --parent "$EPIC" \
   -d "§4+§4b: internal/cmd/config.go help (full built-ins incl. cursor). README prerequisites (Cursor Agent CLI). docs/INSTALLING.md, docs/reference.md — preset cursor vs binaries cursor-agent/agent; align lists with README (pi, omp). Optional otel GT_AGENT. Plan §4, §4b.")"
-T6="$(bd create --silent "cursor-runtime: Tests + automated go test gate (§11)" --type=task -p 2 -l cursor-runtime --parent "$EPIC" \
-  -d "TestEnsureSettingsForRole_CursorUsesWorkDir; orphan/down, web, doctor tests; go test gate. Plan §6, §11.")"
+T6="$(bd create --silent "cursor-runtime: Tests for cursor preset + related packages (§11)" --type=task -p 2 -l cursor-runtime --parent "$EPIC" \
+  -d "TestEnsureSettingsForRole_CursorUsesWorkDir; orphan/down, web, doctor tests; go test ./internal/config/... ./internal/hooks/... ./internal/crew/... ./internal/tmux/... ./internal/runtime/... Plan §6, §11.")"
 T7="$(bd create --silent "cursor-runtime: Add .cursor/skills/ (Gas Town + cursor-agent ops)" --type=task -p 2 -l cursor-runtime --parent "$EPIC" \
   -d "Project skills per plan §7.")"
 T8="$(bd create --silent "cursor-runtime: Add .cursor/README.md onboarding + manual smoke test" --type=task -p 2 -l cursor-runtime --parent "$EPIC" \
   -d "Primary entry for Cursor users; plan §8, §9.")"
 T9="$(bd create --silent "cursor-runtime: Link beads coordination doc from .cursor/README.md" --type=task -p 3 -l cursor-runtime --parent "$EPIC" \
-  -d "Link docs/cursor-runtime-beads-tasks.md + this script from .cursor/README.md. Plan §10.")"
+  -d "Link docs/cursor-runtime-beads-tasks.md from .cursor/README.md. Plan §10.")"
 
 bd dep add "$T2" "$T1"
 bd dep add "$T6" "$T3"


### PR DESCRIPTION
## Summary

Adds end-to-end **Cursor agent preset** (`cursor` / `cursor-agent`) support and onboarding so Gas Town treats Cursor like other first-class runtimes: **tmux process detection** (including ambiguous `agent` vs `cursor-agent`), **orphan/doctor/down** hygiene, **web crew pane** command detection, **`gt config` help** listing all built-in presets from the registry, **`.cursor/` project skill + README**, and **tests** (`EnsureSettingsForRole` for Cursor, chmod/root skips for hooks/util).

## Related Issue

Related work (upstream):

- [#209 — Need support for droid and cursor-agent CLI](https://github.com/gastownhall/gastown/issues/209)
- [#506 — fix(mayor): cursor-agent startup - 3 interrelated issues](https://github.com/gastownhall/gastown/issues/506)

Prior related PRs (context / lineage):

- [#2304 — Cursor hooks for polecat](https://github.com/gastownhall/gastown/pull/2304)
- [#514 — PTY-aware session startup for cursor-agent](https://github.com/gastownhall/gastown/pull/514)
- [#3080 / #3206 — hooks sync for non-Claude agents](https://github.com/gastownhall/gastown/pull/3080)

## Changes

- **Config / preset:** `AgentCursor` — `ReadyDelayMs`, CLI contract tests, `BuiltInAgentPresetSummary()` for dynamic `gt config` long help and `--provider` flag text; otel doc table row for `GT_AGENT`.
- **Tmux:** Session-aware process names for `agent` vs `cursor-agent` (`GT_AGENT` / `GT_PROCESS_NAMES`).
- **Orphan / doctor / down:** `cursor-agent`, `agent`, `copilot` comm filters; doctor `gasTownRuntimeYOLO` argv signatures (`-f`, `--yolo`, `--dangerously-skip-permissions`).
- **Web:** `paneCurrentCommandIsAgent` — `cursor-agent`, `copilot`, bare `agent`.
- **`.cursor/`:** Skill `gas-town-cursor`, README (prerequisites, hooks, beads link, local `go test` snippet).
- **Tests:** `TestEnsureSettingsForRole_CursorUsesWorkDir`, `TestBuiltInAgentPresetSummary`, `TestGasTownRuntimeYOLO`, `TestPaneCurrentCommandIsAgent`; skip chmod read-only tests when `euid==0`.
- **Chore:** Removed duplicate test-gate shell script; light `scripts/cursor-runtime-bd-tasks.sh` wording.

## Testing

- [x] Unit tests pass (`go test ./...`) — run in CI; locally: `go test ./internal/config/... ./internal/runtime/... -short` and full tree as needed
- [x] Manual testing performed (optional: spawn crew with `GT_AGENT=cursor`, confirm pane + hooks)

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable) — `.cursor/README.md`, `docs/cursor-runtime-beads-tasks.md`, otel architecture note, `gt config` help
- [x] No breaking changes (or documented in summary) — additive preset behavior; existing rigs unchanged unless they opt into `cursor`
