### PR TITLE
fix(mol): unhook hooked work beads in forceCloseDescendants

### DIFF
--- a/internal/cmd/molecule_lifecycle.go
+++ b/internal/cmd/molecule_lifecycle.go
@@ -399,11 +399,28 @@ func closeDescendantsImpl(b *beads.Beads, parentID string, force bool) (int, err
 		}
 	}
 
-	// Then close direct children
+	// Then close direct children.
+	// In force mode, unhook work beads (status=hooked) instead of closing them so
+	// they can be re-dispatched. Closing a hooked bead destroys in-progress work;
+	// releasing it back to open preserves the bead for the next polecat (hq-c7d9k).
 	var idsToClose []string
+	var idsToUnhook []string
 	for _, child := range children {
-		if child.Status != "closed" {
+		if child.Status == "closed" {
+			continue
+		}
+		if force && child.Status == "hooked" {
+			idsToUnhook = append(idsToUnhook, child.ID)
+		} else {
 			idsToClose = append(idsToClose, child.ID)
+		}
+	}
+
+	for _, id := range idsToUnhook {
+		if releaseErr := b.ReleaseWithReason(id, "unhooked: polecat force-closed"); releaseErr != nil {
+			errs = append(errs, fmt.Errorf("unhooking child %s of %s: %w", id, parentID, releaseErr))
+		} else {
+			totalClosed++
 		}
 	}
 


### PR DESCRIPTION
## Problem

`forceCloseDescendants` in `closeDescendantsImpl` force-closed **all** non-closed
children of a molecule, including work beads with `status=hooked`. This was the
root cause of 471 falsely closed beads (hq-c7d9k): when a polecat was nuked,
its in-progress work bead got destroyed instead of preserved.

## Fix

In force mode, separate children by status before acting:

- **`status=hooked`** → `ReleaseWithReason("unhooked: polecat force-closed")` — sets
  status back to `open` and clears the assignee, so the bead can be re-dispatched
  to the next polecat.
- **All other non-closed** → force-close as before.

The `totalClosed` counter includes unhooked beads (they were "handled"), preserving
existing telemetry semantics.

## Impact

- Nuking a polecat (`gt polecat nuke --force`) no longer destroys in-flight work
- `gt molecule burn` (also calls `forceCloseDescendants` indirectly) is unaffected —
  burn doesn't call `forceCloseDescendants`, it calls the non-force `closeDescendants`
- `gt molecule squash` similarly calls the non-force path — unaffected

## Test

Existing test in `internal/cmd/done_closeDescendants_test.go` covers the force path.
The new `idsToUnhook` branch follows the same error-handling pattern as `idsToClose`.

Fixes: hq-c7d9k

🤖 Generated with [Claude Code](https://claude.com/claude-code)