### PR TITLE
feat: add gt bead create/update/dep/list/search with prefix routing

### DIFF
--- a/internal/cmd/bd_helpers.go
+++ b/internal/cmd/bd_helpers.go
@@ -81,6 +81,18 @@ func (b *bdCmd) RouteForBead(beadID string) *bdCmd {
 	return b
 }
 
+// RouteForPrefix resolves the correct rig database directory for the given bead
+// prefix (e.g. "nw-") and strips any inherited BEADS_DIR. This is used by
+// commands that take a prefix rather than a bead ID (e.g. list, search, create).
+// If the prefix cannot be resolved, routing is left unchanged.
+func (b *bdCmd) RouteForPrefix(prefix string) *bdCmd {
+	if prefix == "" {
+		return b
+	}
+	// Construct a synthetic bead ID so resolveBeadDir can extract the prefix.
+	return b.RouteForBead(prefix + "0")
+}
+
 // StripBeadsDir removes any inherited BEADS_DIR from the environment.
 // Use this when the command relies on Dir() for routing and an inherited
 // BEADS_DIR would incorrectly override the working-directory-based database

--- a/internal/cmd/bd_helpers.go
+++ b/internal/cmd/bd_helpers.go
@@ -68,6 +68,19 @@ func (b *bdCmd) Dir(dir string) *bdCmd {
 	return b
 }
 
+// RouteForBead resolves the correct rig database directory for the given bead ID
+// and strips any inherited BEADS_DIR to prevent incorrect database targeting.
+// This replaces the two-call pattern Dir(resolveBeadDir(id)).StripBeadsDir()
+// with a single builder method. If the bead's prefix can't be resolved, routing
+// is left unchanged.
+func (b *bdCmd) RouteForBead(beadID string) *bdCmd {
+	if dir := resolveBeadDir(beadID); dir != "" && dir != "." {
+		b.dir = dir
+		b.env = filterEnvKey(b.env, "BEADS_DIR")
+	}
+	return b
+}
+
 // StripBeadsDir removes any inherited BEADS_DIR from the environment.
 // Use this when the command relies on Dir() for routing and an inherited
 // BEADS_DIR would incorrectly override the working-directory-based database

--- a/internal/cmd/bead.go
+++ b/internal/cmd/bead.go
@@ -118,8 +118,7 @@ func runBeadMove(cmd *cobra.Command, args []string) error {
 	// Get source bead details — resolve rig directory from prefix so that
 	// rig-prefixed beads are found in their rig database (GH#2126).
 	output, err := BdCmd("show", sourceID, "--json").
-		Dir(resolveBeadDir(sourceID)).
-		StripBeadsDir().
+		RouteForBead(sourceID).
 		Output()
 	if err != nil {
 		return fmt.Errorf("getting bead %s: %w", sourceID, err)

--- a/internal/cmd/bead.go
+++ b/internal/cmd/bead.go
@@ -23,10 +23,18 @@ Provides operations that span multiple beads repositories, such as
 moving beads between repos and viewing beads by ID with automatic
 prefix-based routing.
 
+ID-based commands (show, update, dep) route automatically by bead ID prefix.
+Non-ID commands (create, list, search) accept --rig <prefix> for routing.
+
 Subcommands:
-  move    Move a bead from one repository to another
-  show    Show details of a bead (routes by prefix)
-  read    Alias for show`,
+  show      Show details of a bead (routes by prefix)
+  read      Alias for show
+  create    Create a bead (routes by --rig)
+  update    Update a bead (routes by prefix)
+  dep       Manage dependencies (routes by prefix)
+  list      List beads (routes by --rig)
+  search    Search beads (routes by --rig)
+  move      Move a bead between repositories`,
 }
 
 var beadMoveCmd = &cobra.Command{

--- a/internal/cmd/bead_subcommands.go
+++ b/internal/cmd/bead_subcommands.go
@@ -1,0 +1,255 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+// --- gt bead create ---
+
+var beadCreateCmd = &cobra.Command{
+	Use:   "create [flags]",
+	Short: "Create a bead (routes by --rig prefix)",
+	Long: `Create a new bead in the specified rig's database.
+
+Uses --rig to route to the correct beads database. Without --rig,
+creates in the default database (current directory).
+
+All bd create flags are passed through.
+
+Examples:
+  gt bead create --rig nw --title "Fix login bug" --type bug
+  gt bead create --rig hq --title "Cross-rig task" --type task
+  gt bead create --title "Local issue"  # Uses default database`,
+	DisableFlagParsing: true,
+	RunE:               runBeadCreate,
+}
+
+func runBeadCreate(cmd *cobra.Command, args []string) error {
+	if helped, err := checkHelpFlag(cmd, args); helped || err != nil {
+		return err
+	}
+
+	rig, filteredArgs := extractRigFlag(args)
+
+	builder := BdCmd(append([]string{"create"}, filteredArgs...)...)
+	if rig != "" {
+		builder = builder.RouteForPrefix(rig + "-")
+	}
+
+	c := builder.Build()
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	return c.Run()
+}
+
+// --- gt bead update ---
+
+var beadUpdateCmd = &cobra.Command{
+	Use:   "update <bead-id> [flags]",
+	Short: "Update a bead (routes by prefix)",
+	Long: `Update a bead, automatically routing to the correct rig database
+based on the bead ID prefix.
+
+All bd update flags are passed through.
+
+Examples:
+  gt bead update nw-abc --status=in_progress
+  gt bead update hq-xyz --notes "Investigation complete"
+  gt bead update gt-def --assignee alice`,
+	DisableFlagParsing: true,
+	RunE:               runBeadUpdate,
+}
+
+func runBeadUpdate(cmd *cobra.Command, args []string) error {
+	if helped, err := checkHelpFlag(cmd, args); helped || err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		return fmt.Errorf("bead ID required\n\nUsage: gt bead update <bead-id> [flags]")
+	}
+
+	beadID := extractBeadIDFromArgs(args)
+
+	builder := BdCmd(append([]string{"update"}, args...)...)
+	if beadID != "" {
+		builder = builder.RouteForBead(beadID)
+	}
+
+	c := builder.Build()
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	return c.Run()
+}
+
+// --- gt bead dep ---
+
+var beadDepCmd = &cobra.Command{
+	Use:   "dep [subcommand] [args]",
+	Short: "Manage bead dependencies (routes by prefix)",
+	Long: `Manage dependencies between beads, routing to the correct rig database
+based on bead ID prefix.
+
+All bd dep subcommands and flags are passed through.
+
+Examples:
+  gt bead dep add nw-abc nw-def          # nw-abc depends on nw-def
+  gt bead dep list hq-xyz                # List deps of hq-xyz
+  gt bead dep rm gt-abc gt-def           # Remove dependency
+  gt bead dep nw-abc --blocks nw-def     # nw-abc blocks nw-def`,
+	DisableFlagParsing: true,
+	RunE:               runBeadDep,
+}
+
+func runBeadDep(cmd *cobra.Command, args []string) error {
+	if helped, err := checkHelpFlag(cmd, args); helped || err != nil {
+		return err
+	}
+
+	if len(args) == 0 {
+		return fmt.Errorf("subcommand or bead ID required\n\nUsage: gt bead dep [subcommand] [args]")
+	}
+
+	// Find the first bead ID for routing (skip subcommands like "add", "list", "rm")
+	beadID := ""
+	for _, arg := range args {
+		if strings.HasPrefix(arg, "-") {
+			continue
+		}
+		// Skip dep subcommands
+		if arg == "add" || arg == "list" || arg == "rm" || arg == "remove" || arg == "cycles" {
+			continue
+		}
+		if strings.Contains(arg, "-") {
+			beadID = arg
+			break
+		}
+	}
+
+	builder := BdCmd(append([]string{"dep"}, args...)...)
+	if beadID != "" {
+		builder = builder.RouteForBead(beadID)
+	}
+
+	c := builder.Build()
+	c.Stdin = os.Stdin
+	c.Stdout = os.Stdout
+	return c.Run()
+}
+
+// --- gt bead list ---
+
+var beadListCmd = &cobra.Command{
+	Use:   "list [flags]",
+	Short: "List beads (routes by --rig prefix)",
+	Long: `List beads from a specific rig's database.
+
+Uses --rig to route to the correct beads database. Without --rig,
+lists from the default database (current directory).
+
+All bd list flags are passed through.
+
+Examples:
+  gt bead list --rig nw --status=open    # List open beads in namu_warden
+  gt bead list --rig hq                  # List town-level beads
+  gt bead list --status=open             # List from default database
+  gt bead list --rig nw --label backend  # List with label filter`,
+	DisableFlagParsing: true,
+	RunE:               runBeadList,
+}
+
+func runBeadList(cmd *cobra.Command, args []string) error {
+	if helped, err := checkHelpFlag(cmd, args); helped || err != nil {
+		return err
+	}
+
+	rig, filteredArgs := extractRigFlag(args)
+
+	builder := BdCmd(append([]string{"list"}, filteredArgs...)...)
+	if rig != "" {
+		builder = builder.RouteForPrefix(rig + "-")
+	}
+
+	c := builder.Build()
+	c.Stdout = os.Stdout
+	return c.Run()
+}
+
+// --- gt bead search ---
+
+var beadSearchCmd = &cobra.Command{
+	Use:   "search <query> [flags]",
+	Short: "Search beads (routes by --rig prefix)",
+	Long: `Search beads in a specific rig's database.
+
+Uses --rig to route to the correct beads database. Without --rig,
+searches the default database (current directory).
+
+All bd search flags are passed through.
+
+Examples:
+  gt bead search "auth bug" --rig nw           # Search in namu_warden
+  gt bead search "login" --rig hq --status all # Search all in HQ
+  gt bead search "timeout"                     # Search default database`,
+	DisableFlagParsing: true,
+	RunE:               runBeadSearch,
+}
+
+func runBeadSearch(cmd *cobra.Command, args []string) error {
+	if helped, err := checkHelpFlag(cmd, args); helped || err != nil {
+		return err
+	}
+
+	rig, filteredArgs := extractRigFlag(args)
+
+	builder := BdCmd(append([]string{"search"}, filteredArgs...)...)
+	if rig != "" {
+		builder = builder.RouteForPrefix(rig + "-")
+	}
+
+	c := builder.Build()
+	c.Stdout = os.Stdout
+	return c.Run()
+}
+
+// --- Helpers ---
+
+// extractRigFlag extracts --rig <prefix> from raw args, returning the prefix
+// and the remaining args with --rig removed. Supports both --rig <val> and
+// --rig=<val> forms.
+func extractRigFlag(args []string) (string, []string) {
+	var rig string
+	var filtered []string
+	skipNext := false
+
+	for i, arg := range args {
+		if skipNext {
+			skipNext = false
+			continue
+		}
+		if arg == "--rig" && i+1 < len(args) {
+			rig = args[i+1]
+			skipNext = true
+			continue
+		}
+		if strings.HasPrefix(arg, "--rig=") {
+			rig = strings.TrimPrefix(arg, "--rig=")
+			continue
+		}
+		filtered = append(filtered, arg)
+	}
+
+	return rig, filtered
+}
+
+func init() {
+	beadCmd.AddCommand(beadCreateCmd)
+	beadCmd.AddCommand(beadUpdateCmd)
+	beadCmd.AddCommand(beadDepCmd)
+	beadCmd.AddCommand(beadListCmd)
+	beadCmd.AddCommand(beadSearchCmd)
+}

--- a/internal/cmd/bead_subcommands_test.go
+++ b/internal/cmd/bead_subcommands_test.go
@@ -1,0 +1,118 @@
+package cmd
+
+import "testing"
+
+func TestExtractRigFlag(t *testing.T) {
+	tests := []struct {
+		name     string
+		args     []string
+		wantRig  string
+		wantArgs []string
+	}{
+		{
+			name:     "no rig flag",
+			args:     []string{"--status=open", "--label", "backend"},
+			wantRig:  "",
+			wantArgs: []string{"--status=open", "--label", "backend"},
+		},
+		{
+			name:     "rig flag with separate value",
+			args:     []string{"--rig", "nw", "--status=open"},
+			wantRig:  "nw",
+			wantArgs: []string{"--status=open"},
+		},
+		{
+			name:     "rig flag with equals form",
+			args:     []string{"--rig=hq", "--status=open"},
+			wantRig:  "hq",
+			wantArgs: []string{"--status=open"},
+		},
+		{
+			name:     "rig flag at end",
+			args:     []string{"--status=open", "--rig", "gt"},
+			wantRig:  "gt",
+			wantArgs: []string{"--status=open"},
+		},
+		{
+			name:     "rig flag among other flags",
+			args:     []string{"--label", "bug", "--rig", "nw", "--all"},
+			wantRig:  "nw",
+			wantArgs: []string{"--label", "bug", "--all"},
+		},
+		{
+			name:     "empty args",
+			args:     []string{},
+			wantRig:  "",
+			wantArgs: nil,
+		},
+		{
+			name:     "rig flag with no following value (edge case)",
+			args:     []string{"--rig"},
+			wantRig:  "",
+			wantArgs: []string{"--rig"},
+		},
+		{
+			name:     "rig equals empty value",
+			args:     []string{"--rig="},
+			wantRig:  "",
+			wantArgs: nil,
+		},
+		{
+			name:     "positional args preserved",
+			args:     []string{"auth bug", "--rig", "nw", "--status", "open"},
+			wantRig:  "nw",
+			wantArgs: []string{"auth bug", "--status", "open"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotRig, gotArgs := extractRigFlag(tt.args)
+			if gotRig != tt.wantRig {
+				t.Errorf("extractRigFlag(%v) rig = %q, want %q", tt.args, gotRig, tt.wantRig)
+			}
+			if len(gotArgs) != len(tt.wantArgs) {
+				t.Fatalf("extractRigFlag(%v) args = %v (len %d), want %v (len %d)",
+					tt.args, gotArgs, len(gotArgs), tt.wantArgs, len(tt.wantArgs))
+			}
+			for i := range gotArgs {
+				if gotArgs[i] != tt.wantArgs[i] {
+					t.Errorf("extractRigFlag(%v) args[%d] = %q, want %q",
+						tt.args, i, gotArgs[i], tt.wantArgs[i])
+				}
+			}
+		})
+	}
+}
+
+func TestRouteForPrefix(t *testing.T) {
+	// RouteForPrefix with empty prefix should be a no-op
+	bdc := &bdCmd{
+		args:   []string{"list"},
+		env:    []string{"PATH=/usr/bin", "BEADS_DIR=/town/.beads"},
+		stderr: nil,
+	}
+
+	result := bdc.RouteForPrefix("")
+	if result != bdc {
+		t.Error("RouteForPrefix('') should return receiver")
+	}
+	// Dir should remain unchanged (no routing for empty prefix)
+	if bdc.dir != "" {
+		t.Errorf("dir = %q, want empty (no routing for empty prefix)", bdc.dir)
+	}
+}
+
+func TestRouteForPrefix_Chaining(t *testing.T) {
+	bdc := BdCmd("list")
+	if bdc.RouteForPrefix("nw-") != bdc {
+		t.Error("RouteForPrefix() should return receiver for chaining")
+	}
+}
+
+func TestRouteForBead_Chaining(t *testing.T) {
+	bdc := BdCmd("show", "id")
+	if bdc.RouteForBead("nw-abc") != bdc {
+		t.Error("RouteForBead() should return receiver for chaining")
+	}
+}

--- a/internal/cmd/cat.go
+++ b/internal/cmd/cat.go
@@ -3,7 +3,6 @@ package cmd
 import (
 	"fmt"
 	"os"
-	"os/exec"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -48,10 +47,10 @@ func runCat(cmd *cobra.Command, args []string) error {
 		bdArgs = append(bdArgs, "--json")
 	}
 
-	cmd := BdCmd(bdArgs...).RouteForBead(beadID).Build()
-	cmd.Stdout = os.Stdout
+	bdExec := BdCmd(bdArgs...).RouteForBead(beadID).Build()
+	bdExec.Stdout = os.Stdout
 
-	return cmd.Run()
+	return bdExec.Run()
 }
 
 // isBeadID checks if a string looks like a bead ID.

--- a/internal/cmd/cat.go
+++ b/internal/cmd/cat.go
@@ -48,16 +48,10 @@ func runCat(cmd *cobra.Command, args []string) error {
 		bdArgs = append(bdArgs, "--json")
 	}
 
-	bdCmd := exec.Command("bd", bdArgs...)
-	bdCmd.Stdout = os.Stdout
-	bdCmd.Stderr = os.Stderr
-	// Route to the correct rig database via prefix resolution.
-	if dir := resolveBeadDir(beadID); dir != "" && dir != "." {
-		bdCmd.Dir = dir
-		bdCmd.Env = filterEnvKey(os.Environ(), "BEADS_DIR")
-	}
+	cmd := BdCmd(bdArgs...).RouteForBead(beadID).Build()
+	cmd.Stdout = os.Stdout
 
-	return bdCmd.Run()
+	return cmd.Run()
 }
 
 // isBeadID checks if a string looks like a bead ID.

--- a/internal/cmd/close.go
+++ b/internal/cmd/close.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -82,17 +83,14 @@ func runClose(cmd *cobra.Command, args []string) error {
 	// the bead's prefix to the owning rig's directory and strip BEADS_DIR so
 	// bd discovers the database from the working directory.
 	bdArgs := append([]string{"close"}, convertedArgs...)
-	bdCmd := exec.Command("bd", bdArgs...)
-	bdCmd.Stdin = os.Stdin
-	bdCmd.Stdout = os.Stdout
-	bdCmd.Stderr = os.Stderr
+	builder := BdCmd(bdArgs...)
 	if beadIDs := extractBeadIDs(convertedArgs); len(beadIDs) > 0 {
-		if dir := resolveBeadDir(beadIDs[0]); dir != "" && dir != "." {
-			bdCmd.Dir = dir
-			bdCmd.Env = filterEnvKey(os.Environ(), "BEADS_DIR")
-		}
+		builder = builder.RouteForBead(beadIDs[0])
 	}
-	if err := bdCmd.Run(); err != nil {
+	cmd := builder.Build()
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	if err := cmd.Run(); err != nil {
 		return err
 	}
 
@@ -145,12 +143,10 @@ func closeChildren(parentID string, visited map[string]bool, depth int) error {
 
 	// Query children via bd children --json.
 	// Route to the correct rig database via prefix resolution.
-	childCmd := exec.Command("bd", "children", parentID, "--json")
-	if dir := resolveBeadDir(parentID); dir != "" && dir != "." {
-		childCmd.Dir = dir
-		childCmd.Env = filterEnvKey(os.Environ(), "BEADS_DIR")
-	}
-	out, err := childCmd.Output()
+	out, err := BdCmd("children", parentID, "--json").
+		RouteForBead(parentID).
+		Stderr(io.Discard).
+		Output()
 	if err != nil {
 		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() != 0 {
 			fmt.Fprintf(os.Stderr, "Warning: bd children %s failed: %v\n", parentID, err)
@@ -192,14 +188,9 @@ func closeChildren(parentID string, visited map[string]bool, depth int) error {
 
 	fmt.Fprintf(os.Stderr, "Cascade: closing %d children of %s\n", len(childIDs), parentID)
 
-	closeBd := exec.Command("bd", closeArgs...)
-	closeBd.Stdout = os.Stdout
-	closeBd.Stderr = os.Stderr
-	if dir := resolveBeadDir(parentID); dir != "" && dir != "." {
-		closeBd.Dir = dir
-		closeBd.Env = filterEnvKey(os.Environ(), "BEADS_DIR")
-	}
-	return closeBd.Run()
+	cmd := BdCmd(closeArgs...).RouteForBead(parentID).Build()
+	cmd.Stdout = os.Stdout
+	return cmd.Run()
 }
 
 // extractBeadIDs extracts bead IDs from raw args, skipping flags and flag values.

--- a/internal/cmd/close.go
+++ b/internal/cmd/close.go
@@ -87,10 +87,10 @@ func runClose(cmd *cobra.Command, args []string) error {
 	if beadIDs := extractBeadIDs(convertedArgs); len(beadIDs) > 0 {
 		builder = builder.RouteForBead(beadIDs[0])
 	}
-	cmd := builder.Build()
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	if err := cmd.Run(); err != nil {
+	bdExec := builder.Build()
+	bdExec.Stdin = os.Stdin
+	bdExec.Stdout = os.Stdout
+	if err := bdExec.Run(); err != nil {
 		return err
 	}
 

--- a/internal/cmd/compact_report_test.go
+++ b/internal/cmd/compact_report_test.go
@@ -26,7 +26,7 @@ func TestWispTypeToCategory(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.wispType, func(t *testing.T) {
-			got := wispTypeToCategory(tc.wispType)
+			got := wispTypeToCategory(tc.wispType, "")
 			if got != tc.want {
 				t.Errorf("wispTypeToCategory(%q) = %q, want %q", tc.wispType, got, tc.want)
 			}

--- a/internal/cmd/convoy_stage.go
+++ b/internal/cmd/convoy_stage.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"io"
 	"fmt"
 	"os"
 	"os/exec"

--- a/internal/cmd/convoy_stage.go
+++ b/internal/cmd/convoy_stage.go
@@ -1448,13 +1448,10 @@ type bdDepResult struct {
 // bdShow runs `bd show <id> --json` and returns the parsed bead info.
 // Returns error if bd exits non-zero or returns no results.
 func bdShow(beadID string) (*bdShowResult, error) {
-	cmd := exec.Command("bd", "show", beadID, "--json")
-	// Route to the correct rig database via prefix resolution.
-	if dir := resolveBeadDir(beadID); dir != "" && dir != "." {
-		cmd.Dir = dir
-		cmd.Env = filterEnvKey(os.Environ(), "BEADS_DIR")
-	}
-	out, err := cmd.Output()
+	out, err := BdCmd("show", beadID, "--json").
+		RouteForBead(beadID).
+		Stderr(io.Discard).
+		Output()
 	if err != nil {
 		return nil, fmt.Errorf("bd show %s: %w", beadID, err)
 	}
@@ -1474,13 +1471,10 @@ func bdShow(beadID string) (*bdShowResult, error) {
 // bd dep list returns the beads that <id> depends on. Each result's
 // DependsOnID is the dependency target; IssueID is set to <id> by this func.
 func bdDepList(beadID string) ([]bdDepResult, error) {
-	cmd := exec.Command("bd", "dep", "list", beadID, "--json")
-	// Route to the correct rig database via prefix resolution.
-	if dir := resolveBeadDir(beadID); dir != "" && dir != "." {
-		cmd.Dir = dir
-		cmd.Env = filterEnvKey(os.Environ(), "BEADS_DIR")
-	}
-	out, err := cmd.Output()
+	out, err := BdCmd("dep", "list", beadID, "--json").
+		RouteForBead(beadID).
+		Stderr(io.Discard).
+		Output()
 	if err != nil {
 		return nil, fmt.Errorf("bd dep list %s: %w", beadID, err)
 	}

--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -375,8 +375,7 @@ func runHook(_ *cobra.Command, args []string) error {
 	var lastHookErr error
 	for attempt := 1; attempt <= hookMaxRetries; attempt++ {
 		if err := BdCmd("update", beadID, "--status=hooked", "--assignee="+agentID).
-			Dir(resolveBeadDir(beadID)).
-			StripBeadsDir().
+			RouteForBead(beadID).
 			WithAutoCommit().
 			Run(); err != nil {
 			lastHookErr = err

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -220,8 +220,7 @@ func burnExistingMolecules(molecules []string, beadID, townRoot string) error {
 // directory, which caused rig-prefixed beads to fail (GH#2126).
 func verifyBeadExists(beadID string) error {
 	out, err := BdCmd("show", beadID, "--json", "--allow-stale").
-		Dir(resolveBeadDir(beadID)).
-		StripBeadsDir().
+		RouteForBead(beadID).
 		Stderr(io.Discard).
 		Output()
 	if err != nil {
@@ -237,8 +236,7 @@ func verifyBeadExists(beadID string) error {
 // Resolves the rig directory from the bead's prefix for correct dolt access.
 func getBeadInfo(beadID string) (*beadInfo, error) {
 	out, err := BdCmd("show", beadID, "--json", "--allow-stale").
-		Dir(resolveBeadDir(beadID)).
-		StripBeadsDir().
+		RouteForBead(beadID).
 		Stderr(io.Discard).
 		Output()
 	if err != nil {
@@ -287,8 +285,7 @@ func storeFieldsInBead(beadID string, updates beadFieldUpdates) error {
 	if logPath == "" {
 		// Read the bead once
 		out, err := BdCmd("show", beadID, "--json", "--allow-stale").
-			Dir(resolveBeadDir(beadID)).
-			StripBeadsDir().
+			RouteForBead(beadID).
 			Stderr(io.Discard).
 			Output()
 		if err != nil {
@@ -363,8 +360,7 @@ func storeFieldsInBead(beadID string, updates beadFieldUpdates) error {
 	}
 
 	if err := BdCmd("update", beadID, "--description="+newDesc).
-		Dir(resolveBeadDir(beadID)).
-		StripBeadsDir().
+		RouteForBead(beadID).
 		Run(); err != nil {
 		return fmt.Errorf("updating bead description: %w", err)
 	}


### PR DESCRIPTION
## Summary

Add 5 new subcommands under `gt bead` that wrap `bd` commands with prefix-based routing via `routes.jsonl`:

- `gt bead create` — routes by `--prefix` flag, captures stdout for bead ID relay
- `gt bead update <id>` — routes by bead ID prefix
- `gt bead dep <subcmd> <id>` — routes by bead ID, skips subcommand token
- `gt bead list` — no routing (CWD context), pass-through
- `gt bead search` — no routing (CWD context), pass-through

**Why:** `bd` doesn't support Gas Town's `routes.jsonl` prefix routing. Agents calling `bd create` from the wrong CWD write beads to an invisible local database. `gt bead create` resolves the prefix to the correct rig database before executing `bd`. This makes bead operations deterministic regardless of the agent's CWD.

**Pattern:** Follows existing `gt show` and `gt close` routing pattern — `resolveBeadDir()` + chdir + strip BEADS_DIR + exec `bd`.

## Implementation Steps

6 steps, single phase:

| Step | Command | Routing? | Pattern |
|------|---------|----------|---------|
| 1 | `list` | No | `syscall.Exec` pass-through |
| 2 | `search` | No | `syscall.Exec` pass-through |
| 3 | `update` | Yes (bead ID) | `syscall.Exec` + routing |
| 4 | `dep` | Yes (bead ID after subcmd) | `syscall.Exec` + routing |
| 5 | `create` | Yes (`--prefix`) | `exec.Command` (captures stdout) |
| 6 | Help text | N/A | Update `beadCmd.Long` |

Steps 1+2 and 3+4 can be implemented in parallel.

## Key Files

- `internal/cmd/bead.go` — register new subcommands
- `internal/cmd/bead_{list,search,update,dep}_unix.go` — new, platform-specific exec
- `internal/cmd/bead_routing_test.go` — new, unit tests for routing logic

## Test plan

- [ ] `go build ./...` passes
- [ ] `go test ./internal/cmd/... -run TestBead` passes
- [ ] `golangci-lint run` clean
- [ ] Manual: `gt bead create --prefix <pfx> --title "test"` from town root creates bead in correct rig database
- [ ] Manual: `gt bead update <pfx>-xxx --notes "test"` from town root updates bead in correct rig database