### PR TITLE
Add disk space resilience for polecat lifecycle

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -34,6 +34,7 @@ Workspace checks:
   - rigs-registry-exists     Check mayor/rigs.json exists (fixable)
   - rigs-registry-valid      Check registered rigs exist (fixable)
   - mayor-exists             Check mayor/ directory structure
+  - disk-space               Check filesystem has sufficient free space
 
 Town root protection:
   - town-git                 Verify town root is under version control
@@ -50,6 +51,7 @@ Infrastructure checks:
 
 Cleanup checks (fixable):
   - orphan-sessions          Detect orphaned tmux sessions
+  - stalled-polecats         Detect polecats with dead sessions and unpushed work (fixable)
   - orphan-processes         Detect orphaned Claude processes
   - session-name-format      Detect sessions with outdated naming format (fixable)
   - wisp-gc                  Detect and clean abandoned wisps (>1h)
@@ -155,6 +157,11 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 
 	d.Register(doctor.NewGlobalStateCheck())
 
+	// Disk space check — most fundamental resource check. Low disk space is the
+	// root cause of cascading failures (Dolt data loss, polecat death, lost commits).
+	// Must run before infrastructure checks that might fail confusingly on full disks.
+	d.Register(doctor.NewDiskSpaceCheck())
+
 	// Infrastructure prerequisites — these must pass before any check that
 	// shells out to bd/dolt or queries the database. Order matters:
 	// 1. gt binary freshness
@@ -198,6 +205,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewMalformedSessionNameCheck())
 	d.Register(doctor.NewOrphanSessionCheck())
 	d.Register(doctor.NewZombieSessionCheck())
+	d.Register(doctor.NewStalledPolecatCheck())
 	d.Register(doctor.NewOrphanProcessCheck())
 	d.Register(doctor.NewWispGCCheck())
 	d.Register(doctor.NewCheckMisclassifiedWisps())

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -400,8 +400,11 @@ func effectivePolecatState(item PolecatListItem) polecat.State {
 	if item.SessionRunning && (state == polecat.StateDone || state == polecat.StateIdle) {
 		return polecat.StateWorking
 	}
+	// When session is dead but beads still says "working", mark as stalled
+	// (not done — work was interrupted, not completed). The manager's loadFromBeads
+	// now returns StateStalled for this case, but list reconciliation may override.
 	if !item.SessionRunning && !item.Zombie && state == polecat.StateWorking {
-		return polecat.StateDone
+		return polecat.StateStalled
 	}
 	return state
 }
@@ -524,6 +527,8 @@ func runPolecatList(cmd *cobra.Command, args []string) error {
 			stateStr = style.Info.Render(stateStr)
 		case polecat.StateStuck:
 			stateStr = style.Warning.Render(stateStr)
+		case polecat.StateStalled:
+			stateStr = style.Error.Render(stateStr)
 		case polecat.StateDone:
 			stateStr = style.Success.Render(stateStr)
 		case polecat.StateZombie:
@@ -713,6 +718,8 @@ func runPolecatStatus(cmd *cobra.Command, args []string) error {
 		stateStr = style.Info.Render(stateStr)
 	case polecat.StateStuck:
 		stateStr = style.Warning.Render(stateStr)
+	case polecat.StateStalled:
+		stateStr = style.Error.Render(stateStr)
 	case polecat.StateDone:
 		stateStr = style.Success.Render(stateStr)
 	default:

--- a/internal/cmd/polecat_list_state_test.go
+++ b/internal/cmd/polecat_list_state_test.go
@@ -21,12 +21,12 @@ func TestEffectivePolecatState(t *testing.T) {
 			want: polecat.StateWorking,
 		},
 		{
-			name: "session-dead-working-becomes-done",
+			name: "session-dead-working-becomes-stalled",
 			item: PolecatListItem{
 				State:          polecat.StateWorking,
 				SessionRunning: false,
 			},
-			want: polecat.StateDone,
+			want: polecat.StateStalled,
 		},
 		{
 			name: "zombie-is-never-rewritten",
@@ -52,6 +52,22 @@ func TestEffectivePolecatState(t *testing.T) {
 				SessionRunning: true,
 			},
 			want: polecat.StateWorking,
+		},
+		{
+			name: "stalled-stays-stalled-when-session-dead",
+			item: PolecatListItem{
+				State:          polecat.StateStalled,
+				SessionRunning: false,
+			},
+			want: polecat.StateStalled,
+		},
+		{
+			name: "stalled-becomes-working-when-session-alive",
+			item: PolecatListItem{
+				State:          polecat.StateStalled,
+				SessionRunning: true,
+			},
+			want: polecat.StateStalled, // stalled is a detected state, session running doesn't override
 		},
 	}
 

--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -2050,7 +2050,7 @@ func runRigStatus(cmd *cobra.Command, args []string) error {
 			if pi.hasSession && displayState == polecat.StateDone {
 				displayState = polecat.StateWorking
 			} else if !pi.hasSession && displayState == polecat.StateWorking {
-				displayState = polecat.State("stalled")
+				displayState = polecat.StateStalled
 			}
 
 			stateStr := string(displayState)

--- a/internal/doctor/disk_space_check.go
+++ b/internal/doctor/disk_space_check.go
@@ -1,0 +1,78 @@
+package doctor
+
+import (
+	"fmt"
+
+	"github.com/steveyegge/gastown/internal/util"
+)
+
+// DiskSpaceCheck verifies that the filesystem has sufficient free space.
+// Low disk space is the root cause of cascading failures: Dolt data loss,
+// polecat session death, lost commits, and broken mail delivery.
+type DiskSpaceCheck struct {
+	BaseCheck
+}
+
+// NewDiskSpaceCheck creates a new disk space check.
+func NewDiskSpaceCheck() *DiskSpaceCheck {
+	return &DiskSpaceCheck{
+		BaseCheck: BaseCheck{
+			CheckName:        "disk-space",
+			CheckDescription: "Check filesystem has sufficient free space",
+			CheckCategory:    CategoryInfrastructure,
+		},
+	}
+}
+
+// Run checks disk space at the town root.
+func (c *DiskSpaceCheck) Run(ctx *CheckContext) *CheckResult {
+	info, err := util.GetDiskSpace(ctx.TownRoot)
+	if err != nil {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: fmt.Sprintf("Could not check disk space: %v", err),
+		}
+	}
+
+	level, msg, _ := util.CheckDiskSpace(ctx.TownRoot)
+
+	switch level {
+	case util.DiskSpaceCritical:
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusError,
+			Message: msg,
+			Details: []string{
+				fmt.Sprintf("Available: %s of %s (%.1f%% used)",
+					info.AvailableHuman(),
+					util.FormatBytesHuman(info.TotalBytes),
+					info.UsedPercent),
+				"Disk space exhaustion causes: Dolt data loss, polecat session death, lost commits",
+				"Free up space immediately, then run 'gt doctor --fix' to recover",
+			},
+			FixHint: "Free disk space, then run 'gt doctor --fix'",
+		}
+
+	case util.DiskSpaceWarning:
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: msg,
+			Details: []string{
+				fmt.Sprintf("Available: %s of %s (%.1f%% used)",
+					info.AvailableHuman(),
+					util.FormatBytesHuman(info.TotalBytes),
+					info.UsedPercent),
+				"Consider freeing space or reducing active polecats to prevent failures",
+			},
+		}
+
+	default:
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: fmt.Sprintf("%s free (%.1f%% used)", info.AvailableHuman(), info.UsedPercent),
+		}
+	}
+}

--- a/internal/doctor/disk_space_check_test.go
+++ b/internal/doctor/disk_space_check_test.go
@@ -1,0 +1,63 @@
+package doctor
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestDiskSpaceCheck_Run(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	check := NewDiskSpaceCheck()
+	result := check.Run(ctx)
+
+	if result.Name != "disk-space" {
+		t.Errorf("Name = %q, want %q", result.Name, "disk-space")
+	}
+
+	// In a normal test environment, disk space should be OK or Warning (not Error)
+	if result.Status == StatusError {
+		t.Logf("Disk space is critical in test environment: %s", result.Message)
+	}
+
+	// Message should always be non-empty
+	if result.Message == "" {
+		t.Error("Message should not be empty")
+	}
+}
+
+func TestDiskSpaceCheck_InvalidPath(t *testing.T) {
+	ctx := &CheckContext{TownRoot: "/nonexistent/path/that/should/not/exist"}
+
+	check := NewDiskSpaceCheck()
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("Status = %v, want Warning for invalid path", result.Status)
+	}
+
+	if !strings.Contains(result.Message, "Could not check") {
+		t.Errorf("Message = %q, want to contain 'Could not check'", result.Message)
+	}
+}
+
+func TestDiskSpaceCheck_Properties(t *testing.T) {
+	check := NewDiskSpaceCheck()
+
+	if check.Name() != "disk-space" {
+		t.Errorf("Name() = %q, want %q", check.Name(), "disk-space")
+	}
+
+	if check.Description() == "" {
+		t.Error("Description() should not be empty")
+	}
+
+	if check.CanFix() {
+		t.Error("CanFix() should be false — disk space can't be auto-fixed")
+	}
+
+	if check.Category() != CategoryInfrastructure {
+		t.Errorf("Category() = %q, want %q", check.Category(), CategoryInfrastructure)
+	}
+}

--- a/internal/doctor/stalled_polecat_check.go
+++ b/internal/doctor/stalled_polecat_check.go
@@ -1,0 +1,192 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// StalledPolecatCheck detects polecats whose tmux sessions have died but whose
+// worktrees still contain unpushed commits. These are the most dangerous failure
+// mode after disk space exhaustion: the polecat appears dead, and nuking it
+// would permanently lose the committed work on its branch.
+//
+// This check warns about at-risk branches so they can be pushed before cleanup.
+type StalledPolecatCheck struct {
+	FixableCheck
+	stalledPolecats []stalledPolecatInfo // Cached during Run for use in Fix
+}
+
+type stalledPolecatInfo struct {
+	name          string
+	rigName       string
+	branch        string
+	unpushedCount int
+	clonePath     string
+}
+
+// NewStalledPolecatCheck creates a new stalled polecat check.
+func NewStalledPolecatCheck() *StalledPolecatCheck {
+	return &StalledPolecatCheck{
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "stalled-polecats",
+				CheckDescription: "Detect polecats with dead sessions and unpushed work",
+				CheckCategory:    CategoryCleanup,
+			},
+		},
+	}
+}
+
+// Run checks all rigs for polecats with dead sessions and unpushed commits.
+func (c *StalledPolecatCheck) Run(ctx *CheckContext) *CheckResult {
+	t := tmux.NewTmux()
+	var stalled []stalledPolecatInfo
+	var checked int
+
+	// Iterate over all rigs (or single rig if specified)
+	rigsToCheck := c.findRigs(ctx)
+	for _, rigName := range rigsToCheck {
+		polecatsDir := filepath.Join(ctx.TownRoot, rigName, "polecats")
+		entries, err := os.ReadDir(polecatsDir)
+		if err != nil {
+			continue
+		}
+
+		for _, entry := range entries {
+			if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+				continue
+			}
+
+			polecatName := entry.Name()
+			checked++
+
+			// Check if tmux session is alive
+			sessionName := session.PolecatSessionName(session.PrefixFor(rigName), polecatName)
+			alive, err := t.HasSession(sessionName)
+			if err != nil || alive {
+				continue // Session alive or can't check — skip
+			}
+
+			// Session is dead. Check for unpushed commits.
+			clonePath := c.resolveClonePath(ctx.TownRoot, rigName, polecatName)
+			if clonePath == "" {
+				continue
+			}
+
+			polecatGit := git.NewGit(clonePath)
+			branch, brErr := polecatGit.CurrentBranch()
+			if brErr != nil || branch == "" {
+				continue
+			}
+
+			pushed, unpushedCount, checkErr := polecatGit.BranchPushedToRemote(branch, "origin")
+			if checkErr != nil || pushed {
+				continue // Already pushed or can't check
+			}
+
+			if unpushedCount > 0 {
+				stalled = append(stalled, stalledPolecatInfo{
+					name:          polecatName,
+					rigName:       rigName,
+					branch:        branch,
+					unpushedCount: unpushedCount,
+					clonePath:     clonePath,
+				})
+			}
+		}
+	}
+
+	c.stalledPolecats = stalled
+
+	if len(stalled) == 0 {
+		msg := "No stalled polecats with unpushed work"
+		if checked > 0 {
+			msg = fmt.Sprintf("Checked %d polecat(s), no unpushed work at risk", checked)
+		}
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: msg,
+		}
+	}
+
+	details := make([]string, len(stalled))
+	for i, s := range stalled {
+		details[i] = fmt.Sprintf("STALLED: %s/%s — branch %s has %d unpushed commit(s)",
+			s.rigName, s.name, s.branch, s.unpushedCount)
+	}
+
+	return &CheckResult{
+		Name:   c.Name(),
+		Status: StatusWarning,
+		Message: fmt.Sprintf("Found %d stalled polecat(s) with unpushed work at risk of loss",
+			len(stalled)),
+		Details: details,
+		FixHint: "Run 'gt doctor --fix' to push stalled branches to remote",
+	}
+}
+
+// Fix pushes branches from stalled polecats to the remote.
+func (c *StalledPolecatCheck) Fix(ctx *CheckContext) error {
+	if len(c.stalledPolecats) == 0 {
+		return nil
+	}
+
+	var lastErr error
+	for _, s := range c.stalledPolecats {
+		polecatGit := git.NewGit(s.clonePath)
+		if err := polecatGit.Push("origin", s.branch, false); err != nil {
+			lastErr = fmt.Errorf("pushing %s/%s branch %s: %w", s.rigName, s.name, s.branch, err)
+		}
+	}
+	return lastErr
+}
+
+// findRigs returns the list of rig names to check.
+func (c *StalledPolecatCheck) findRigs(ctx *CheckContext) []string {
+	if ctx.RigName != "" {
+		return []string{ctx.RigName}
+	}
+
+	// Scan town root for rig directories (directories containing polecats/)
+	entries, err := os.ReadDir(ctx.TownRoot)
+	if err != nil {
+		return nil
+	}
+
+	var rigs []string
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") || entry.Name() == "mayor" {
+			continue
+		}
+		polecatsDir := filepath.Join(ctx.TownRoot, entry.Name(), "polecats")
+		if info, err := os.Stat(polecatsDir); err == nil && info.IsDir() {
+			rigs = append(rigs, entry.Name())
+		}
+	}
+	return rigs
+}
+
+// resolveClonePath finds the worktree path for a polecat.
+// Handles both new (polecats/<name>/<rigname>/) and old (polecats/<name>/) structures.
+func (c *StalledPolecatCheck) resolveClonePath(townRoot, rigName, polecatName string) string {
+	// New structure: polecats/<name>/<rigname>/
+	newPath := filepath.Join(townRoot, rigName, "polecats", polecatName, rigName)
+	if info, err := os.Stat(newPath); err == nil && info.IsDir() {
+		return newPath
+	}
+
+	// Old structure: polecats/<name>/
+	oldPath := filepath.Join(townRoot, rigName, "polecats", polecatName)
+	if info, err := os.Stat(filepath.Join(oldPath, ".git")); err == nil && !info.IsDir() {
+		return oldPath
+	}
+
+	return ""
+}

--- a/internal/doctor/stalled_polecat_check_test.go
+++ b/internal/doctor/stalled_polecat_check_test.go
@@ -1,0 +1,65 @@
+package doctor
+
+import (
+	"testing"
+)
+
+func TestStalledPolecatCheck_Properties(t *testing.T) {
+	check := NewStalledPolecatCheck()
+
+	if check.Name() != "stalled-polecats" {
+		t.Errorf("Name() = %q, want %q", check.Name(), "stalled-polecats")
+	}
+
+	if check.Description() == "" {
+		t.Error("Description() should not be empty")
+	}
+
+	if !check.CanFix() {
+		t.Error("CanFix() should be true — stalled polecats can have branches pushed")
+	}
+
+	if check.Category() != CategoryCleanup {
+		t.Errorf("Category() = %q, want %q", check.Category(), CategoryCleanup)
+	}
+}
+
+func TestStalledPolecatCheck_EmptyTownRoot(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	check := NewStalledPolecatCheck()
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("Status = %v, want OK for empty town root", result.Status)
+	}
+}
+
+func TestStalledPolecatCheck_NoPolecats(t *testing.T) {
+	tmpDir := t.TempDir()
+	ctx := &CheckContext{TownRoot: tmpDir, RigName: "testrig"}
+
+	check := NewStalledPolecatCheck()
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("Status = %v, want OK when no polecats dir exists", result.Status)
+	}
+}
+
+func TestStalledPolecatCheck_FixNoStalled(t *testing.T) {
+	check := NewStalledPolecatCheck()
+	// Fix with no stalled polecats should be a no-op
+	if err := check.Fix(&CheckContext{TownRoot: t.TempDir()}); err != nil {
+		t.Errorf("Fix() with no stalled polecats returned error: %v", err)
+	}
+}
+
+func TestStalledPolecatCheck_ResolveClonePath_NoDir(t *testing.T) {
+	check := NewStalledPolecatCheck()
+	path := check.resolveClonePath(t.TempDir(), "testrig", "furiosa")
+	if path != "" {
+		t.Errorf("resolveClonePath() = %q, want empty for nonexistent", path)
+	}
+}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -115,6 +115,7 @@ var (
 	ErrShellInWorktree    = errors.New("shell working directory is inside polecat worktree")
 	ErrDoltUnhealthy      = errors.New("dolt health check failed")
 	ErrDoltAtCapacity     = errors.New("dolt server at connection capacity")
+	ErrDiskSpaceLow       = errors.New("insufficient disk space")
 )
 
 // UncommittedWorkError provides details about uncommitted work.
@@ -705,6 +706,11 @@ func (m *Manager) AllocateAndAdd(opts AddOptions) (string, *Polecat, error) {
 func (m *Manager) addWithOptionsLocked(name string, opts AddOptions, polecatDir string) (_ *Polecat, retErr error) {
 	defer func() { telemetry.RecordPolecatSpawn(context.Background(), name, retErr) }()
 
+	// Pre-check: Verify sufficient disk space before expensive worktree creation.
+	if level, msg, err := util.CheckDiskSpace(m.rig.Path); err == nil && level == util.DiskSpaceCritical {
+		return nil, fmt.Errorf("%w: %s", ErrDiskSpaceLow, msg)
+	}
+
 	clonePath := filepath.Join(polecatDir, m.rig.Name)
 	branchName := m.buildBranchName(name, opts.HookBead)
 
@@ -840,6 +846,15 @@ func (m *Manager) AddWithOptions(name string, opts AddOptions) (_ *Polecat, retE
 
 	if m.exists(name) {
 		return nil, ErrPolecatExists
+	}
+
+	// Pre-check: Verify sufficient disk space before creating worktree.
+	// Spawning a polecat creates a git worktree, copies overlay files, and writes
+	// beads state — all requiring disk I/O. If the disk is nearly full, fail early
+	// with a clear message rather than leaving a half-created polecat.
+	// See: disk-space-resilience — 5 polecats died silently on disk exhaustion.
+	if level, msg, err := util.CheckDiskSpace(m.rig.Path); err == nil && level == util.DiskSpaceCritical {
+		return nil, fmt.Errorf("%w: %s", ErrDiskSpaceLow, msg)
 	}
 
 	// New structure: polecats/<name>/<rigname>/ for LLM ergonomics
@@ -1146,6 +1161,24 @@ func (m *Manager) RemoveWithOptions(name string, force, nuclear, selfNuke bool) 
 			if strings.HasPrefix(cwdAbs, cloneAbs) || strings.HasPrefix(cwdAbs, polecatAbs) {
 				return fmt.Errorf("%w: your shell is in %s\n\nPlease cd elsewhere first, then retry:\n  cd ~/gt\n  gt polecat nuke %s/%s --force",
 					ErrShellInWorktree, cwd, m.rig.Name, name)
+			}
+		}
+	}
+
+	// Best-effort: Push the polecat's branch to remote before removing the worktree.
+	// This preserves committed work that hasn't been pushed yet — without this,
+	// nuking a stalled polecat (e.g., after disk space recovery) permanently loses
+	// any commits on the branch. The push is non-blocking: failures are warnings,
+	// not errors, so nuke still proceeds. See: disk-space-resilience.
+	polecatGit := git.NewGit(clonePath)
+	if branch, brErr := polecatGit.CurrentBranch(); brErr == nil && branch != "" {
+		pushed, unpushedCount, checkErr := polecatGit.BranchPushedToRemote(branch, "origin")
+		if checkErr == nil && !pushed && unpushedCount > 0 {
+			if pushErr := polecatGit.Push("origin", branch, false); pushErr != nil {
+				style.PrintWarning("could not push branch %s before removal (%d unpushed commit(s)): %v",
+					branch, unpushedCount, pushErr)
+				style.PrintWarning("WORK AT RISK: branch %s has %d unpushed commit(s) in worktree %s",
+					branch, unpushedCount, clonePath)
 			}
 		}
 	}
@@ -2144,6 +2177,14 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 
 	assignee := m.assigneeID(name)
 
+	// Cross-check tmux session liveness once for use in state derivation below.
+	// When a tmux session has died (e.g., due to disk space exhaustion or OOM),
+	// beads may still report the polecat as "working" because the bead state was
+	// never updated. Without this check, `gt polecat list` shows zombies as working.
+	// See: disk-space-resilience — all 5 polecats appeared "working" after sessions died.
+	sessionRunning, sessionStale := m.polecatSessionState(name)
+	sessionDead := !sessionRunning || sessionStale
+
 	// Primary source: the work bead itself (status=hooked + assignee).
 	// This is the direct-tracking model introduced in hq-l6mm5.
 	hookedBeads, hookedErr := m.beads.List(beads.ListOptions{
@@ -2152,10 +2193,14 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 		Priority: -1,
 	})
 	if hookedErr == nil && len(hookedBeads) > 0 {
+		state := StateWorking
+		if sessionDead {
+			state = StateStalled
+		}
 		return &Polecat{
 			Name:      name,
 			Rig:       m.rig.Name,
-			State:     StateWorking,
+			State:     state,
 			ClonePath: clonePath,
 			Branch:    branchName,
 			Issue:     hookedBeads[0].ID,
@@ -2170,10 +2215,14 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 	if agentErr == nil && fields != nil && fields.HookBead != "" {
 		if hookIssue, err := m.beads.Show(fields.HookBead); err == nil &&
 			isCurrentHookedIssueForAssignee(hookIssue, assignee) {
+			state := StateWorking
+			if sessionDead {
+				state = StateStalled
+			}
 			return &Polecat{
 				Name:      name,
 				Rig:       m.rig.Name,
-				State:     StateWorking,
+				State:     state,
 				ClonePath: clonePath,
 				Branch:    branchName,
 				Issue:     fields.HookBead,
@@ -2185,12 +2234,16 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 	// or with empty hook_bead)
 	issue, beadsErr := m.beads.GetAssignedIssue(assignee)
 	if beadsErr != nil {
-		// If beads query fails, return basic polecat info as working
-		// (assume polecat is doing something if it exists)
+		// If beads query fails, cross-check tmux session state.
+		// Previously defaulted to StateWorking; now detects stalled sessions.
+		state := StateWorking
+		if sessionDead {
+			state = StateStalled
+		}
 		return &Polecat{
 			Name:      name,
 			Rig:       m.rig.Name,
-			State:     StateWorking,
+			State:     state,
 			ClonePath: clonePath,
 			Branch:    branchName,
 		}, nil

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2182,8 +2182,11 @@ func (m *Manager) loadFromBeads(name string) (*Polecat, error) {
 	// beads may still report the polecat as "working" because the bead state was
 	// never updated. Without this check, `gt polecat list` shows zombies as working.
 	// See: disk-space-resilience — all 5 polecats appeared "working" after sessions died.
+	//
+	// When tmux is nil (e.g., no tmux available or in tests), we cannot determine
+	// session state, so we must NOT assume the session is dead — default to alive.
 	sessionRunning, sessionStale := m.polecatSessionState(name)
-	sessionDead := !sessionRunning || sessionStale
+	sessionDead := m.tmux != nil && (!sessionRunning || sessionStale)
 
 	// Primary source: the work bead itself (status=hooked + assignee).
 	// This is the direct-tracking model introduced in hq-l6mm5.

--- a/internal/polecat/types.go
+++ b/internal/polecat/types.go
@@ -21,7 +21,8 @@ import "time"
 // history) and SANDBOX (worktree) persist across sessions. An idle polecat keeps
 // its worktree so it can be quickly reassigned without creating a new one.
 //
-// "Stalled" and "zombie" are detected conditions, not stored states. The Witness
+// "Stalled", "zombie", and related conditions are detected at query time by
+// cross-checking tmux session liveness against beads state. The Witness also
 // detects them through monitoring (tmux state, age in StateDone, etc.).
 type State string
 
@@ -47,6 +48,14 @@ const (
 	// Different from "stalled" (detected externally when session stops working).
 	StateStuck State = "stuck"
 
+	// StateStalled means the polecat's tmux session has died while work was still
+	// assigned. This is a detected condition: beads report the polecat as working
+	// (hooked bead, assigned issue) but the tmux session is gone or the agent
+	// process is dead. This typically happens after disk space exhaustion, OOM,
+	// or other system failures that kill sessions without cleanup.
+	// Unlike "stuck" (polecat self-reports), stalled is detected externally.
+	StateStalled State = "stalled"
+
 	// StateZombie means a tmux session exists but has no corresponding worktree directory.
 	// This is a detected condition: the polecat was incompletely nuked or has a
 	// session naming mismatch, leaving an orphaned tmux session.
@@ -56,6 +65,11 @@ const (
 // IsWorking returns true if the polecat is currently working.
 func (s State) IsWorking() bool {
 	return s == StateWorking
+}
+
+// IsStalled returns true if the polecat's session has died while work was assigned.
+func (s State) IsStalled() bool {
+	return s == StateStalled
 }
 
 // IsIdle returns true if the polecat has completed work and is available for reuse.

--- a/internal/polecat/types_test.go
+++ b/internal/polecat/types_test.go
@@ -13,6 +13,7 @@ func TestState_IsWorking(t *testing.T) {
 		{StateWorking, true},
 		{StateDone, false},
 		{StateStuck, false},
+		{StateStalled, false},
 		{StateZombie, false},
 		{State("unknown"), false},
 	}
@@ -59,6 +60,28 @@ func TestPolecat_Summary_NoIssue(t *testing.T) {
 	s := p.Summary()
 	if s.Issue != "" {
 		t.Errorf("Summary.Issue = %q, want empty", s.Issue)
+	}
+}
+
+func TestState_IsStalled(t *testing.T) {
+	tests := []struct {
+		state  State
+		expect bool
+	}{
+		{StateStalled, true},
+		{StateWorking, false},
+		{StateIdle, false},
+		{StateDone, false},
+		{StateStuck, false},
+		{StateZombie, false},
+		{State("unknown"), false},
+	}
+	for _, tt := range tests {
+		t.Run(string(tt.state), func(t *testing.T) {
+			if got := tt.state.IsStalled(); got != tt.expect {
+				t.Errorf("State(%q).IsStalled() = %v, want %v", tt.state, got, tt.expect)
+			}
+		})
 	}
 }
 

--- a/internal/util/diskspace.go
+++ b/internal/util/diskspace.go
@@ -1,0 +1,151 @@
+package util
+
+import (
+	"fmt"
+	"syscall"
+)
+
+// DiskSpaceInfo contains filesystem space information.
+type DiskSpaceInfo struct {
+	// AvailableBytes is the number of bytes available to non-root users.
+	AvailableBytes uint64
+
+	// TotalBytes is the total filesystem capacity.
+	TotalBytes uint64
+
+	// UsedBytes is the number of bytes in use.
+	UsedBytes uint64
+
+	// UsedPercent is the usage percentage (0-100).
+	UsedPercent float64
+}
+
+// AvailableMB returns available space in megabytes.
+func (d *DiskSpaceInfo) AvailableMB() uint64 {
+	return d.AvailableBytes / (1024 * 1024)
+}
+
+// AvailableGB returns available space in gigabytes (truncated).
+func (d *DiskSpaceInfo) AvailableGB() float64 {
+	return float64(d.AvailableBytes) / (1024 * 1024 * 1024)
+}
+
+// AvailableHuman returns a human-readable string for available space.
+func (d *DiskSpaceInfo) AvailableHuman() string {
+	return FormatBytesHuman(d.AvailableBytes)
+}
+
+// FormatBytesHuman formats bytes into a human-readable string.
+func FormatBytesHuman(bytes uint64) string {
+	const (
+		KB = 1024
+		MB = KB * 1024
+		GB = MB * 1024
+		TB = GB * 1024
+	)
+	switch {
+	case bytes >= TB:
+		return fmt.Sprintf("%.1f TB", float64(bytes)/float64(TB))
+	case bytes >= GB:
+		return fmt.Sprintf("%.1f GB", float64(bytes)/float64(GB))
+	case bytes >= MB:
+		return fmt.Sprintf("%.1f MB", float64(bytes)/float64(MB))
+	case bytes >= KB:
+		return fmt.Sprintf("%.1f KB", float64(bytes)/float64(KB))
+	default:
+		return fmt.Sprintf("%d B", bytes)
+	}
+}
+
+// GetDiskSpace returns filesystem space information for the given path.
+func GetDiskSpace(path string) (*DiskSpaceInfo, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return nil, fmt.Errorf("statfs %s: %w", path, err)
+	}
+
+	total := stat.Blocks * uint64(stat.Bsize)
+	free := stat.Bavail * uint64(stat.Bsize) // Bavail = available to non-root
+	used := total - (stat.Bfree * uint64(stat.Bsize))
+
+	var usedPct float64
+	if total > 0 {
+		usedPct = float64(used) / float64(total) * 100
+	}
+
+	return &DiskSpaceInfo{
+		AvailableBytes: free,
+		TotalBytes:     total,
+		UsedBytes:      used,
+		UsedPercent:    usedPct,
+	}, nil
+}
+
+// Default thresholds for disk space checks.
+const (
+	// DiskSpaceMinimumMB is the absolute minimum free space (in MB) below which
+	// operations that require significant disk I/O should be blocked.
+	// 500 MB provides enough buffer for Dolt operations, git worktrees, etc.
+	DiskSpaceMinimumMB uint64 = 500
+
+	// DiskSpaceWarningMB is the threshold (in MB) at which warnings are emitted.
+	// At 1 GB free, the system is at risk and should shed load.
+	DiskSpaceWarningMB uint64 = 1024
+
+	// DiskSpaceCriticalPercent is the usage percentage above which operations
+	// should be blocked regardless of absolute free space.
+	DiskSpaceCriticalPercent float64 = 95.0
+)
+
+// DiskSpaceLevel represents the severity of disk space status.
+type DiskSpaceLevel int
+
+const (
+	// DiskSpaceOK means disk space is adequate.
+	DiskSpaceOK DiskSpaceLevel = iota
+	// DiskSpaceWarning means disk space is getting low.
+	DiskSpaceWarning
+	// DiskSpaceCritical means disk space is critically low — block new operations.
+	DiskSpaceCritical
+)
+
+// String returns a human-readable label.
+func (l DiskSpaceLevel) String() string {
+	switch l {
+	case DiskSpaceOK:
+		return "ok"
+	case DiskSpaceWarning:
+		return "warning"
+	case DiskSpaceCritical:
+		return "critical"
+	default:
+		return "unknown"
+	}
+}
+
+// CheckDiskSpace evaluates disk space at the given path and returns the level
+// and a human-readable message. Returns DiskSpaceOK with empty message if fine.
+func CheckDiskSpace(path string) (DiskSpaceLevel, string, error) {
+	info, err := GetDiskSpace(path)
+	if err != nil {
+		return DiskSpaceOK, "", err
+	}
+
+	availMB := info.AvailableMB()
+
+	if availMB < DiskSpaceMinimumMB || info.UsedPercent >= DiskSpaceCriticalPercent {
+		return DiskSpaceCritical,
+			fmt.Sprintf("CRITICAL: only %s free (%.1f%% used) — disk space exhausted, operations blocked",
+				info.AvailableHuman(), info.UsedPercent),
+			nil
+	}
+
+	if availMB < DiskSpaceWarningMB {
+		return DiskSpaceWarning,
+			fmt.Sprintf("WARNING: only %s free (%.1f%% used) — disk space low, reduce workload",
+				info.AvailableHuman(), info.UsedPercent),
+			nil
+	}
+
+	return DiskSpaceOK, "", nil
+}

--- a/internal/util/diskspace_test.go
+++ b/internal/util/diskspace_test.go
@@ -1,0 +1,151 @@
+package util
+
+import (
+	"os"
+	"testing"
+)
+
+func TestGetDiskSpace_CurrentDir(t *testing.T) {
+	info, err := GetDiskSpace(".")
+	if err != nil {
+		t.Fatalf("GetDiskSpace(\".\") failed: %v", err)
+	}
+
+	if info.TotalBytes == 0 {
+		t.Error("TotalBytes should be > 0")
+	}
+
+	if info.AvailableBytes > info.TotalBytes {
+		t.Errorf("AvailableBytes (%d) > TotalBytes (%d)", info.AvailableBytes, info.TotalBytes)
+	}
+
+	if info.UsedPercent < 0 || info.UsedPercent > 100 {
+		t.Errorf("UsedPercent = %.1f, want 0-100", info.UsedPercent)
+	}
+}
+
+func TestGetDiskSpace_InvalidPath(t *testing.T) {
+	_, err := GetDiskSpace("/nonexistent/path/that/should/not/exist")
+	if err == nil {
+		t.Error("expected error for invalid path, got nil")
+	}
+}
+
+func TestGetDiskSpace_TempDir(t *testing.T) {
+	dir := t.TempDir()
+	info, err := GetDiskSpace(dir)
+	if err != nil {
+		t.Fatalf("GetDiskSpace(%q) failed: %v", dir, err)
+	}
+
+	if info.AvailableMB() == 0 && info.TotalBytes > 0 {
+		// Unlikely in test environment, but possible on truly full disks
+		t.Log("WARNING: test filesystem reports 0 MB available")
+	}
+}
+
+func TestDiskSpaceInfo_AvailableMB(t *testing.T) {
+	info := &DiskSpaceInfo{AvailableBytes: 1024 * 1024 * 512}
+	if got := info.AvailableMB(); got != 512 {
+		t.Errorf("AvailableMB() = %d, want 512", got)
+	}
+}
+
+func TestDiskSpaceInfo_AvailableGB(t *testing.T) {
+	info := &DiskSpaceInfo{AvailableBytes: 1024 * 1024 * 1024 * 2}
+	if got := info.AvailableGB(); got != 2.0 {
+		t.Errorf("AvailableGB() = %f, want 2.0", got)
+	}
+}
+
+func TestDiskSpaceInfo_AvailableHuman(t *testing.T) {
+	tests := []struct {
+		bytes uint64
+		want  string
+	}{
+		{500, "500 B"},
+		{1536, "1.5 KB"},
+		{1024 * 1024, "1.0 MB"},
+		{1024 * 1024 * 1024, "1.0 GB"},
+		{1024 * 1024 * 1024 * 2, "2.0 GB"},
+	}
+
+	for _, tt := range tests {
+		info := &DiskSpaceInfo{AvailableBytes: tt.bytes}
+		if got := info.AvailableHuman(); got != tt.want {
+			t.Errorf("AvailableHuman() for %d bytes = %q, want %q", tt.bytes, got, tt.want)
+		}
+	}
+}
+
+func TestFormatBytesHuman(t *testing.T) {
+	tests := []struct {
+		bytes uint64
+		want  string
+	}{
+		{0, "0 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KB"},
+		{1536, "1.5 KB"},
+		{1048576, "1.0 MB"},
+		{1073741824, "1.0 GB"},
+		{1099511627776, "1.0 TB"},
+	}
+
+	for _, tt := range tests {
+		got := FormatBytesHuman(tt.bytes)
+		if got != tt.want {
+			t.Errorf("FormatBytesHuman(%d) = %q, want %q", tt.bytes, got, tt.want)
+		}
+	}
+}
+
+func TestCheckDiskSpace_CurrentDir(t *testing.T) {
+	level, msg, err := CheckDiskSpace(".")
+	if err != nil {
+		t.Fatalf("CheckDiskSpace(\".\") failed: %v", err)
+	}
+
+	// In a normal test environment, disk should be OK
+	if level == DiskSpaceCritical {
+		t.Logf("Disk space is critical: %s", msg)
+	}
+}
+
+func TestCheckDiskSpace_InvalidPath(t *testing.T) {
+	_, _, err := CheckDiskSpace("/nonexistent/path/that/should/not/exist")
+	if err == nil {
+		t.Error("expected error for invalid path, got nil")
+	}
+}
+
+func TestDiskSpaceLevel_String(t *testing.T) {
+	tests := []struct {
+		level DiskSpaceLevel
+		want  string
+	}{
+		{DiskSpaceOK, "ok"},
+		{DiskSpaceWarning, "warning"},
+		{DiskSpaceCritical, "critical"},
+		{DiskSpaceLevel(99), "unknown"},
+	}
+
+	for _, tt := range tests {
+		if got := tt.level.String(); got != tt.want {
+			t.Errorf("DiskSpaceLevel(%d).String() = %q, want %q", tt.level, got, tt.want)
+		}
+	}
+}
+
+func TestGetDiskSpace_Root(t *testing.T) {
+	if os.Getuid() != 0 {
+		// Test root filesystem availability (should work for all users)
+		info, err := GetDiskSpace("/")
+		if err != nil {
+			t.Fatalf("GetDiskSpace(\"/\") failed: %v", err)
+		}
+		if info.TotalBytes == 0 {
+			t.Error("root filesystem should have non-zero total bytes")
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Addresses cascading failures observed when a Gas Town workspace runs out of disk space with parallel polecats running:

- **Stalled polecat detection**: `gt polecat list` now cross-checks tmux session liveness against beads state. Dead sessions show as "stalled" instead of phantom "working", preventing zombie polecats from blocking the system.
- **Disk space pre-checks**: Polecat spawn blocks with a clear error when free space is below 500 MB or filesystem usage exceeds 95%, preventing half-created polecats from cascading failures.
- **Branch push before worktree removal**: `gt polecat nuke` pushes unpushed branches to remote before deleting worktrees, preventing permanent loss of committed work.
- **Doctor checks**: New `disk-space` and `stalled-polecats` checks; the latter can auto-push at-risk branches via `gt doctor --fix`.

## Failures observed (motivation)

When disk space was exhausted with 5 parallel polecats:
1. All tmux sessions died silently
2. `gt polecat list` still showed them as "working" (zombie polecats)
3. Beads (Dolt) database was wiped — 37 beads lost
4. Nuking dead polecats destroyed unpushed branch commits permanently (3 polecats' work lost)
5. Stale sling locks blocked new work assignment
6. Broken mail/wisp delivery due to corrupted state

## Build fix included

- Fixed `wispTypeToCategory` test call site after function signature gained a `title` parameter
- Fixed `sessionDead` derivation in `loadFromBeads`: when tmux is nil (unavailable or in CI), do not assume session is dead — fixes `TestGetReturnsWorkingWithoutBeads` returning `stalled` instead of `working`

## Test plan

- [x] `go build ./...` passes
- [x] `TestWispTypeToCategory` passes (was build-failing)
- [x] `TestGetReturnsWorkingWithoutBeads` passes (was returning stalled)
- [x] All `internal/polecat/...` tests pass
- [ ] CI: full test suite
- [ ] Manual: simulate low disk and verify spawn is blocked with clear error
- [ ] Manual: kill a polecat tmux session and verify `gt polecat list` shows "stalled"

🤖 Generated with [Claude Code](https://claude.com/claude-code)