### PR TITLE
fix(formula): resolve deps in rigBeadsDir, not townBeads

### DIFF
--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -639,7 +639,7 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 			for _, legBeadID := range legBeads {
 				_ = BdCmd("dep", "add", synthesisBeadID, legBeadID).
 					WithAutoCommit().
-					Dir(townBeads).
+					Dir(rigBeadsDir).
 					Run()
 			}
 
@@ -823,7 +823,7 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 			}
 			_ = BdCmd("dep", "add", stepBeadID, depBeadID).
 				WithAutoCommit().
-				Dir(townBeads).
+				Dir(rigBeadsDir).
 				Run()
 		}
 


### PR DESCRIPTION
## Summary

- Fix regression from `de3d6b96` where step/leg bead creation was moved to `rigBeadsDir` but `dep add` commands were left pointing at `townBeads`
- This caused "no issue found" errors when wiring dependencies between freshly created steps, because the deps were resolved in a different database than where the beads were created

## Changes

Two `Dir(townBeads)` → `Dir(rigBeadsDir)` in `formula.go`:
- `executeConvoyFormula()`: synthesis→leg dependencies (line 642)
- `executeWorkflowFormula()`: step→step dependencies (line 826)

## Test plan

- [x] `gt formula run spec-workflow` on a fresh rig — step dependencies now resolve correctly
- [x] `bd show <step>` confirms DEPENDS ON / BLOCKS are wired

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>