### PR TITLE
feat(formula): add interactive step support for workflow formulas

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,7 @@ __pycache__/
 
 # Beads / Dolt files (added by bd init)
 .beads-credential-key
+
+# Gas Town (added by gt)
+.runtime/
+CLAUDE.local.md

--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -827,10 +827,22 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 		fmt.Printf("  %s %s: %s%s\n", style.Dim.Render("○"), step.ID, stepBeadID, needsStr)
 	}
 
-	// Step 3: Identify and sling ready steps (those with no dependencies)
+	// Step 3: Identify and dispatch ready steps (those with no dependencies)
+	// Interactive steps are hooked to the current session; others are slung to polecats.
 	fmt.Printf("\n%s Dispatching ready steps...\n\n", style.Bold.Render("→"))
 
+	// Check if any step in the workflow is interactive — if so, we'll need
+	// to handle the molecule lifecycle in the current session.
+	hasInteractive := false
+	for _, step := range f.Steps {
+		if step.Interactive {
+			hasInteractive = true
+			break
+		}
+	}
+
 	slingCount := 0
+	interactiveCount := 0
 	for _, step := range f.Steps {
 		if len(step.Needs) > 0 {
 			continue // has unmet dependencies — will be auto-dispatched
@@ -841,6 +853,23 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 			continue
 		}
 
+		if step.Interactive || hasInteractive {
+			// Interactive step: hook to current session instead of slinging to a polecat.
+			// The user will execute this step in their current crew session.
+			_ = BdCmd("update", stepBeadID, "--status=hooked").
+				WithAutoCommit().
+				Dir(rigBeadsDir).
+				Run()
+
+			fmt.Printf("  %s %s: %s (interactive — hooked to current session)\n",
+				style.Bold.Render("⇨"), step.ID, stepBeadID)
+			fmt.Printf("    %s\n", step.Title)
+			fmt.Printf("    When done: bd close %s\n\n", stepBeadID)
+			interactiveCount++
+			continue
+		}
+
+		// Non-interactive step: sling to a polecat
 		// Agent precedence: CLI --agent > formula-level
 		stepAgent := formulaRunAgent
 		if stepAgent == "" {
@@ -873,11 +902,19 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 	}
 
 	// Summary
-	blockedCount := len(f.Steps) - slingCount
+	blockedCount := len(f.Steps) - slingCount - interactiveCount
 	fmt.Printf("\n%s Workflow dispatched!\n", style.Bold.Render("✓"))
 	fmt.Printf("  Workflow: %s\n", workflowID)
-	fmt.Printf("  Steps:    %d total, %d dispatched, %d awaiting dependencies\n",
-		len(f.Steps), slingCount, blockedCount)
+	if interactiveCount > 0 {
+		fmt.Printf("  Steps:    %d total, %d interactive (current session), %d dispatched, %d awaiting dependencies\n",
+			len(f.Steps), interactiveCount, slingCount, blockedCount)
+		fmt.Printf("\n  This workflow has interactive steps. Work through them sequentially:\n")
+		fmt.Printf("    bd mol current <molecule-id>   — find current step\n")
+		fmt.Printf("    bd close <step-id>             — advance to next step\n")
+	} else {
+		fmt.Printf("  Steps:    %d total, %d dispatched, %d awaiting dependencies\n",
+			len(f.Steps), slingCount, blockedCount)
+	}
 	fmt.Printf("\n  Track progress: gt convoy status %s\n", workflowID)
 
 	return nil

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -123,8 +123,9 @@ type Step struct {
 	Title       string   `toml:"title"`
 	Description string   `toml:"description"`
 	Needs       []string `toml:"needs"`
-	Parallel    bool     `toml:"parallel"`   // If true, this step can run concurrently with other parallel steps that share the same needs
-	Acceptance  string   `toml:"acceptance"` // Exit criteria for this step (used by Ralph loop mode)
+	Parallel    bool     `toml:"parallel"`    // If true, this step can run concurrently with other parallel steps that share the same needs
+	Interactive bool     `toml:"interactive"` // If true, this step requires user dialogue and runs in the current session instead of being dispatched to a polecat
+	Acceptance  string   `toml:"acceptance"`  // Exit criteria for this step (used by Ralph loop mode)
 }
 
 // Template represents a template step in an expansion formula.

--- a/internal/formula/types.go
+++ b/internal/formula/types.go
@@ -124,7 +124,7 @@ type Step struct {
 	Description string   `toml:"description"`
 	Needs       []string `toml:"needs"`
 	Parallel    bool     `toml:"parallel"`    // If true, this step can run concurrently with other parallel steps that share the same needs
-	Interactive bool     `toml:"interactive"` // If true, this step requires user dialogue and runs in the current session instead of being dispatched to a polecat
+	Interactive bool     `toml:"interactive"` // If true, this step requires user dialog and runs in the current session instead of being dispatched to a polecat
 	Acceptance  string   `toml:"acceptance"`  // Exit criteria for this step (used by Ralph loop mode)
 }
 


### PR DESCRIPTION
## Summary

- Add `interactive = true` field to workflow Step struct
- Steps marked interactive are hooked to the current session instead of being dispatched to a polecat
- When any step in a workflow is interactive, all ready steps stay local to avoid spawning polecats that block on user input

## Motivation

Workflow formulas like `spec-workflow` have steps that require user dialogue (brainstorm, questions interview). Previously these were always dispatched to polecats which would block waiting for input with no way to interact. Now crew workers can run these workflows interactively.

## Usage

In formula TOML:
```toml
[[steps]]
id = "step-2-brainstorm"
title = "Step 2: Brainstorm"
needs = ["step-1"]
interactive = true
```

## Test plan

- [x] `gt formula run spec-workflow` with `interactive = true` on steps 2 and 3
- [x] Ready steps hooked to current session instead of spawning polecats
- [x] Non-interactive workflows still dispatch to polecats as before

Co-Authored-By: Claude Opus 4.6 (1M context) <noreply@anthropic.com>