### PR TITLE
feat(deacon): model escalation on re-dispatch (hq-ko4)

### DIFF
--- a/internal/deacon/redispatch.go
+++ b/internal/deacon/redispatch.go
@@ -51,12 +51,47 @@ type BeadRedispatchState struct {
 	// LastRig is the rig where the last re-dispatch was sent.
 	LastRig string `json:"last_rig,omitempty"`
 
+	// LastAgent is the agent alias used for the last re-dispatch (empty = rig default).
+	LastAgent string `json:"last_agent,omitempty"`
+
 	// Escalated is true if this bead has been escalated to Mayor.
 	Escalated bool `json:"escalated,omitempty"`
 
 	// EscalatedAt is when the bead was escalated.
 	EscalatedAt time.Time `json:"escalated_at,omitempty"`
 }
+
+// ModelEscalationRule defines a single agent promotion rule.
+type ModelEscalationRule struct {
+	// FromAgent is the agent alias that triggers this rule (e.g., "claude-sonnet").
+	FromAgent string `json:"from_agent"`
+
+	// ToAgent is the agent alias to promote to (e.g., "claude" for Opus).
+	ToAgent string `json:"to_agent"`
+
+	// PromoteAfterFailures is the number of total failures (initial + re-dispatches)
+	// required before promoting to ToAgent.
+	PromoteAfterFailures int `json:"promote_after_failures"`
+
+	// Comment is an optional human-readable description of this rule.
+	Comment string `json:"comment,omitempty"`
+}
+
+// ModelEscalationConfig defines per-rig agent promotion rules for re-dispatch.
+// Loaded from <rig>/refinery/rig/.gastown/model-escalation.json.
+type ModelEscalationConfig struct {
+	Type             string                `json:"type"`
+	Version          int                   `json:"version"`
+	Enabled          bool                  `json:"enabled"`
+	Description      string                `json:"description,omitempty"`
+	Rules            []ModelEscalationRule `json:"rules"`
+	MaxTotalAttempts int                   `json:"max_total_attempts,omitempty"`
+	Fallback         string                `json:"fallback,omitempty"`
+}
+
+// ModelEscalationConfigPath is the path within a rig project directory where
+// the model escalation config is stored.
+const ModelEscalationConfigPath = ".gastown/model-escalation.json"
 
 // RedispatchResult describes the outcome of a re-dispatch attempt.
 type RedispatchResult struct {
@@ -267,13 +302,17 @@ func Redispatch(townRoot, beadID, sourceRig string, maxAttempts int, cooldown ti
 		return result
 	}
 
+	// Determine agent override from model escalation config (if any).
+	escalationAgent := resolveAgentForRedispatch(townRoot, targetRig, beadState)
+
 	// Re-dispatch via gt sling
-	err = slingBead(townRoot, beadID, targetRig)
+	err = slingBead(townRoot, beadID, targetRig, escalationAgent)
 	if err != nil {
 		result.Action = "error"
 		result.Error = fmt.Errorf("slinging bead to %s: %w", targetRig, err)
 
 		// Record the failed attempt
+		beadState.LastAgent = escalationAgent
 		beadState.RecordAttempt(targetRig)
 		_ = SaveRedispatchState(townRoot, state)
 
@@ -281,10 +320,15 @@ func Redispatch(townRoot, beadID, sourceRig string, maxAttempts int, cooldown ti
 	}
 
 	// Record successful dispatch
+	beadState.LastAgent = escalationAgent
 	beadState.RecordAttempt(targetRig)
 	result.Action = "redispatched"
 	result.Attempts = beadState.AttemptCount
-	result.Message = fmt.Sprintf("re-dispatched to %s (attempt %d/%d)", targetRig, beadState.AttemptCount, maxAttempts)
+	if escalationAgent != "" {
+		result.Message = fmt.Sprintf("re-dispatched to %s with agent %q (attempt %d/%d)", targetRig, escalationAgent, beadState.AttemptCount, maxAttempts)
+	} else {
+		result.Message = fmt.Sprintf("re-dispatched to %s (attempt %d/%d)", targetRig, beadState.AttemptCount, maxAttempts)
+	}
 
 	// Save state
 	if saveErr := SaveRedispatchState(townRoot, state); saveErr != nil {
@@ -350,9 +394,64 @@ func getBeadStatusForRedispatch(townRoot, beadID string) string {
 	return issues[0].Status
 }
 
+// LoadModelEscalationConfig loads model escalation rules from a rig project directory.
+// Returns nil, nil if the file does not exist (no escalation configured).
+func LoadModelEscalationConfig(rigProjectDir string) (*ModelEscalationConfig, error) {
+	path := filepath.Join(rigProjectDir, ModelEscalationConfigPath)
+	data, err := os.ReadFile(path) //nolint:gosec // G304: path is constructed from trusted rigProjectDir
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("reading model escalation config: %w", err)
+	}
+
+	var cfg ModelEscalationConfig
+	if err := json.Unmarshal(data, &cfg); err != nil {
+		return nil, fmt.Errorf("parsing model escalation config %s: %w", path, err)
+	}
+	return &cfg, nil
+}
+
+// resolveAgentForRedispatch determines which agent alias to use when re-dispatching
+// a bead, based on the rig's model escalation config.
+//
+// The "total failures" seen by this bead is beadState.AttemptCount (prior re-dispatches)
+// plus 1 (the original dispatch failure that triggered this re-dispatch).
+// Rules fire when totalFailures >= rule.PromoteAfterFailures.
+//
+// Returns "" (empty) if no escalation is configured or no rule applies — the caller
+// should omit the --agent flag and let the rig use its default.
+func resolveAgentForRedispatch(townRoot, targetRig string, beadState *BeadRedispatchState) string {
+	// Rig project dir is <townRoot>/<rig>/refinery/rig
+	rigProjectDir := filepath.Join(townRoot, targetRig, "refinery", "rig")
+
+	cfg, err := LoadModelEscalationConfig(rigProjectDir)
+	if err != nil || cfg == nil || !cfg.Enabled || len(cfg.Rules) == 0 {
+		return ""
+	}
+
+	// Total failures = prior re-dispatch attempts + 1 (initial failure that triggered
+	// this re-dispatch call). AttemptCount is recorded AFTER each sling, so on entry
+	// it reflects the number of completed re-dispatches, not the current one.
+	totalFailures := beadState.AttemptCount + 1
+
+	for _, rule := range cfg.Rules {
+		if totalFailures >= rule.PromoteAfterFailures {
+			return rule.ToAgent
+		}
+	}
+	return ""
+}
+
 // slingBead dispatches a bead to a rig via gt sling.
-func slingBead(townRoot, beadID, rig string) error {
-	cmd := exec.Command("gt", "sling", beadID, rig, "--force", "--no-convoy")
+// If agent is non-empty, passes --agent <agent> to override the rig's default.
+func slingBead(townRoot, beadID, rig, agent string) error {
+	args := []string{"sling", beadID, rig, "--force", "--no-convoy"}
+	if agent != "" {
+		args = append(args, "--agent", agent)
+	}
+	cmd := exec.Command("gt", args...)
 	cmd.Dir = townRoot
 	util.SetDetachedProcessGroup(cmd)
 	cmd.Stdout = os.Stdout

--- a/internal/deacon/redispatch_test.go
+++ b/internal/deacon/redispatch_test.go
@@ -203,3 +203,157 @@ func TestRedispatchState_GetBeadState(t *testing.T) {
 		t.Error("expected different bead state for different ID")
 	}
 }
+
+func TestLoadModelEscalationConfig(t *testing.T) {
+	t.Run("missing file returns nil", func(t *testing.T) {
+		cfg, err := LoadModelEscalationConfig(t.TempDir())
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg != nil {
+			t.Error("expected nil config for missing file")
+		}
+	})
+
+	t.Run("loads valid config", func(t *testing.T) {
+		dir := t.TempDir()
+		gastown := filepath.Join(dir, ".gastown")
+		if err := os.MkdirAll(gastown, 0755); err != nil {
+			t.Fatal(err)
+		}
+		content := `{
+			"type": "model-escalation",
+			"version": 1,
+			"enabled": true,
+			"rules": [
+				{
+					"from_agent": "claude-sonnet",
+					"to_agent": "claude",
+					"promote_after_failures": 1
+				}
+			]
+		}`
+		if err := os.WriteFile(filepath.Join(gastown, "model-escalation.json"), []byte(content), 0600); err != nil {
+			t.Fatal(err)
+		}
+
+		cfg, err := LoadModelEscalationConfig(dir)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if cfg == nil {
+			t.Fatal("expected non-nil config")
+		}
+		if !cfg.Enabled {
+			t.Error("expected enabled=true")
+		}
+		if len(cfg.Rules) != 1 {
+			t.Fatalf("expected 1 rule, got %d", len(cfg.Rules))
+		}
+		if cfg.Rules[0].ToAgent != "claude" {
+			t.Errorf("expected ToAgent=claude, got %q", cfg.Rules[0].ToAgent)
+		}
+	})
+}
+
+func TestResolveAgentForRedispatch(t *testing.T) {
+	// Build a temp town with a fake rig project directory containing escalation config.
+	townDir := t.TempDir()
+	rigName := "myrig"
+	rigProjectDir := filepath.Join(townDir, rigName, "refinery", "rig", ".gastown")
+	if err := os.MkdirAll(rigProjectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	configContent := `{
+		"type": "model-escalation",
+		"version": 1,
+		"enabled": true,
+		"rules": [
+			{
+				"from_agent": "claude-sonnet",
+				"to_agent": "claude",
+				"promote_after_failures": 1
+			}
+		]
+	}`
+	if err := os.WriteFile(filepath.Join(rigProjectDir, "model-escalation.json"), []byte(configContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name         string
+		attemptCount int
+		wantAgent    string
+	}{
+		{
+			name:         "first re-dispatch (1 total failure) promotes at threshold 1",
+			attemptCount: 0,
+			wantAgent:    "claude",
+		},
+		{
+			name:         "second re-dispatch also promotes",
+			attemptCount: 1,
+			wantAgent:    "claude",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			state := &BeadRedispatchState{
+				BeadID:       "gt-test",
+				AttemptCount: tt.attemptCount,
+			}
+			got := resolveAgentForRedispatch(townDir, rigName, state)
+			if got != tt.wantAgent {
+				t.Errorf("resolveAgentForRedispatch() = %q, want %q", got, tt.wantAgent)
+			}
+		})
+	}
+}
+
+func TestResolveAgentForRedispatch_NoConfig(t *testing.T) {
+	state := &BeadRedispatchState{BeadID: "gt-test", AttemptCount: 0}
+	got := resolveAgentForRedispatch(t.TempDir(), "myrig", state)
+	if got != "" {
+		t.Errorf("expected empty agent when no config, got %q", got)
+	}
+}
+
+func TestResolveAgentForRedispatch_HighThreshold(t *testing.T) {
+	townDir := t.TempDir()
+	rigName := "myrig"
+	rigProjectDir := filepath.Join(townDir, rigName, "refinery", "rig", ".gastown")
+	if err := os.MkdirAll(rigProjectDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// threshold=2: need 2 total failures before promoting
+	configContent := `{
+		"type": "model-escalation",
+		"version": 1,
+		"enabled": true,
+		"rules": [
+			{
+				"from_agent": "claude-sonnet",
+				"to_agent": "claude",
+				"promote_after_failures": 2
+			}
+		]
+	}`
+	if err := os.WriteFile(filepath.Join(rigProjectDir, "model-escalation.json"), []byte(configContent), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	// First re-dispatch: totalFailures=1, threshold=2 → no promotion yet
+	state := &BeadRedispatchState{BeadID: "gt-test", AttemptCount: 0}
+	got := resolveAgentForRedispatch(townDir, rigName, state)
+	if got != "" {
+		t.Errorf("expected no promotion at 1 failure with threshold 2, got %q", got)
+	}
+
+	// Second re-dispatch: totalFailures=2, threshold=2 → promote
+	state.AttemptCount = 1
+	got = resolveAgentForRedispatch(townDir, rigName, state)
+	if got != "claude" {
+		t.Errorf("expected promotion at 2 failures with threshold 2, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Deacon redispatch now reads `.gastown/model-escalation.json` from the target rig's project directory
- When a bead has failed enough times (per `promote_after_failures` threshold), redispatch promotes to a more capable agent (e.g. Sonnet → Opus) via `--agent` flag on `gt sling`
- Tracks `last_agent` in redispatch state for observability

## Test plan
- [x] Unit tests for `LoadModelEscalationConfig` (missing file, valid config)
- [x] Unit tests for `resolveAgentForRedispatch` (no config, threshold=1, threshold=2)
- [x] All existing redispatch tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)