### PR TITLE
fix: resolve hostname to detect loopback in IsRemote()

### DIFF
--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -220,9 +220,20 @@ func (m *DoltServerManager) isRemote() bool {
 	if m.config == nil {
 		return false
 	}
-	switch strings.ToLower(m.config.Host) {
+	host := strings.ToLower(m.config.Host)
+	switch host {
 	case "", "127.0.0.1", "localhost", "::1", "[::1]":
 		return false
+	}
+	// Resolve hostname and check if it points to loopback.
+	addrs, err := net.LookupHost(m.config.Host)
+	if err != nil {
+		return true
+	}
+	for _, addr := range addrs {
+		if ip := net.ParseIP(addr); ip != nil && ip.IsLoopback() {
+			return false
+		}
 	}
 	return true
 }

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -360,10 +360,21 @@ func readDaemonEnvVar(path, key string) string {
 
 // IsRemote returns true when the config points to a non-local Dolt server.
 // Empty host, "127.0.0.1", "localhost", "::1", and "[::1]" are all considered local.
+// Hostnames that resolve to a loopback address are also treated as local.
 func (c *Config) IsRemote() bool {
 	switch strings.ToLower(c.Host) {
 	case "", "127.0.0.1", "localhost", "::1", "[::1]":
 		return false
+	}
+	// Resolve hostname and check if it points to loopback.
+	addrs, err := net.LookupHost(c.Host)
+	if err != nil {
+		return true
+	}
+	for _, addr := range addrs {
+		if ip := net.ParseIP(addr); ip != nil && ip.IsLoopback() {
+			return false
+		}
 	}
 	return true
 }

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -3367,6 +3367,10 @@ func TestIsRemote(t *testing.T) {
 		{"10.0.0.5", true},
 		{"dolt.internal", true},
 		{"192.168.1.100", true},
+		// Hostnames resolving to loopback should be treated as local.
+		// This covers /etc/hosts entries like "127.0.0.1 dolt.home.arpa".
+		// Note: "localhost" is already covered above; any hostname that
+		// the OS resolves to 127.0.0.1 or ::1 should also be local.
 	}
 	for _, tt := range tests {
 		c := &Config{Host: tt.host}


### PR DESCRIPTION
## Summary

- `IsRemote()` / `isRemote()` only recognized a hardcoded set of loopback strings (`localhost`, `127.0.0.1`, `::1`). Any other hostname was treated as remote even if it resolved to a loopback address via `/etc/hosts` or DNS.
- Now falls back to `net.LookupHost` when the hostname doesn't match the hardcoded set, and checks whether any resolved address is loopback via `net.IP.IsLoopback()`.
- No behavior change for existing configurations — the hardcoded cases still short-circuit before any DNS lookup.

## Motivation

Claude Code's network sandbox uses a hostname allowlist. Users need a dedicated hostname (e.g., `dolt.home.arpa` mapped to `127.0.0.1` in `/etc/hosts`) to scope sandbox access to Dolt without opening `localhost` to all local services. With the current code, `gt dolt start` rejects this with "Dolt server is remote — start/stop managed externally".

## Changes

- `internal/doltserver/doltserver.go` — `Config.IsRemote()`: added `net.LookupHost` fallback
- `internal/daemon/dolt.go` — `DoltServerManager.isRemote()`: same fallback (duplicated because it operates on a different config type)
- `internal/doltserver/doltserver_test.go` — added comments documenting the DNS resolution behavior

## Test plan

- [ ] Existing `TestIsRemote` cases still pass (hardcoded loopback strings)
- [ ] `GT_DOLT_HOST=dolt.home.arpa gt dolt start` succeeds when `dolt.home.arpa` resolves to `127.0.0.1`
- [ ] Non-loopback hostnames (e.g., `10.0.0.5`, `dolt.internal` pointing to a real remote) still treated as remote
- [ ] Unresolvable hostnames treated as remote (safe fallback)