### PR TITLE
fix(nudge): use correct tmux target syntax for pane IDs

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1646,12 +1646,24 @@ func (t *Tmux) NudgeSessionWithOpts(session, message string, opts NudgeOpts) err
 	// running the agent rather than sending to the focused pane.
 	target := session
 	if agentPane, err := t.FindAgentPane(session); err == nil && agentPane != "" {
-		// Qualify the pane ID with the session name (e.g., "hq-dog-alpha:%1")
-		// to avoid ambiguity. On some tmux versions (e.g., 3.3 on Windows),
-		// pane IDs are NOT globally unique — every session may have "%1".
-		// A bare "send-keys -t %1" targets the attached session's pane,
-		// not necessarily this session's.
-		target = session + ":" + agentPane
+		if runtime.GOOS == "windows" {
+			// On Windows tmux 3.3, pane IDs are NOT globally unique —
+			// every session may have "%1". Qualify with session and window
+			// using proper tmux target syntax: session:@window.%pane.
+			// (The segment after ":" is a window specifier — bare pane IDs
+			// in that position cause "can't find window" errors.)
+			if winID, err := t.run("display-message", "-t", agentPane, "-p", "#{window_id}"); err == nil {
+				target = session + ":" + strings.TrimSpace(winID) + "." + agentPane
+			} else {
+				target = agentPane
+			}
+		} else {
+			// On macOS/Linux, pane IDs are globally unique — use them
+			// directly. Do NOT use "session:%pane" format: tmux interprets
+			// the segment after ":" as a window specifier, and pane IDs
+			// are not valid window identifiers. (GH#3534)
+			target = agentPane
+		}
 	}
 
 	// 0. Pre-delivery: dismiss Rewind menu if the session is stuck in it.


### PR DESCRIPTION
## Summary

- Fix `NudgeSessionWithOpts` using invalid tmux target format `session:%paneID` — the segment after `:` is a **window** specifier, so `%paneID` there causes "can't find window" errors
- On macOS/Linux, revert to bare pane ID (globally unique); on Windows, use proper `session:@window.%pane` syntax
- Regression introduced in #3387 (`2781602a`, 2026-03-30)

## Test plan

- [x] Verified repro: `tmux send-keys -t "session:%pane"` fails, bare `%pane` works
- [x] Verified fix compiles (`go build ./internal/tmux/`)
- [x] Verified workaround (clearing GT_PANE_ID) restores nudge delivery on live Gas Town instance
- [ ] Run `go test ./internal/tmux/...`
- [ ] Test on Windows with tmux 3.3 (non-unique pane IDs)

Fixes #3534

🤖 Generated with [Claude Code](https://claude.com/claude-code)