### PR TITLE
fix(rig): make gt rig add atomic — save rigs.json inside AddRig

### DIFF
--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -573,11 +573,7 @@ func runRigAdd(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("adding rig: %w", err)
 	}
-
-	// Save updated rigs config
-	if err := config.SaveRigsConfig(rigsPath, rigsConfig); err != nil {
-		return fmt.Errorf("saving rigs config: %w", err)
-	}
+	// rigs.json is saved atomically inside AddRig; no separate save needed here.
 
 	// Add new rig to daemon.json patrol config (witness + refinery rigs arrays)
 	if err := config.AddRigToDaemonPatrols(townRoot, name); err != nil {

--- a/internal/cmd/rig_integration_test.go
+++ b/internal/cmd/rig_integration_test.go
@@ -720,10 +720,7 @@ func TestRigAddUpdatesRigsJson(t *testing.T) {
 		t.Fatalf("AddRig: %v", err)
 	}
 
-	// Save rigs config (normally done by the command)
-	if err := config.SaveRigsConfig(rigsPath, rigsConfig); err != nil {
-		t.Fatalf("save rigs.json: %v", err)
-	}
+	// AddRig saves rigs.json atomically — no separate save needed.
 
 	// Reload and verify
 	rigsConfig2, err := config.LoadRigsConfig(rigsPath)

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -861,6 +861,16 @@ Use crew for your own workspace. Polecats are for batch work dispatch.
 		fmt.Fprintf(os.Stderr, "  Run 'gt doctor --fix' to repair if needed.\n")
 	}
 
+	// Persist rigs.json atomically before marking success.
+	// This ensures directory creation and rigs.json registration are an atomic unit:
+	// if the save fails, success remains false and the deferred cleanup removes the dir.
+	// Without this, a failure after AddRig returns (but before the caller saves) would
+	// leave a directory that is not registered in rigs.json.
+	rigsPath := filepath.Join(m.townRoot, "mayor", "rigs.json")
+	if err := config.SaveRigsConfig(rigsPath, m.config); err != nil {
+		return nil, fmt.Errorf("registering rig in rigs.json: %w", err)
+	}
+
 	success = true
 	return m.loadRig(opts.Name, m.config.Rigs[opts.Name])
 }


### PR DESCRIPTION
## Summary

- Move `SaveRigsConfig` inside `AddRig` (before `success = true`), making directory creation and `rigs.json` registration an atomic unit
- If the save fails, `success` remains `false` and the existing deferred cleanup (`os.RemoveAll(rigPath)`) removes the directory — no orphaned directory left behind
- Remove the now-redundant `SaveRigsConfig` call from `runRigAdd`
- Update `TestRigAddUpdatesRigsJson` to reflect that `AddRig` handles persistence

**Root cause**: `AddRig` created the directory, did all scaffolding, then returned — and `runRigAdd` called `SaveRigsConfig` separately. If the process was killed or `SaveRigsConfig` failed between those steps, the rig directory existed but wasn't registered in `rigs.json`, leaving the workspace in a broken partial state with no clear recovery path.

Fixes hq-2l3

## Test plan

- [ ] `TestRigAddUpdatesRigsJson` passes (confirms rigs.json is populated without explicit save)
- [ ] Existing integration tests pass
- [ ] If `SaveRigsConfig` fails mid-`AddRig`, directory is cleaned up (deferred remove triggers)

🤖 Generated with [Claude Code](https://claude.com/claude-code)