### PR TITLE
fix(cmd): fix wispTypeToCategory test arg count

### DIFF
--- a/internal/cmd/compact_report_test.go
+++ b/internal/cmd/compact_report_test.go
@@ -26,7 +26,7 @@ func TestWispTypeToCategory(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.wispType, func(t *testing.T) {
-			got := wispTypeToCategory(tc.wispType)
+			got := wispTypeToCategory(tc.wispType, "")
 			if got != tc.want {
 				t.Errorf("wispTypeToCategory(%q) = %q, want %q", tc.wispType, got, tc.want)
 			}


### PR DESCRIPTION
## Summary

- Fix `TestWispTypeToCategory` to pass both required args to `wispTypeToCategory(wispType, title)` — the function signature was updated but the test was not

## Test plan

- [x] `go vet ./...` passes
- [x] `go test ./internal/cmd/...` (was failing to build, now passes)