### PR TITLE
fix(dolt): Start verifies databases are loaded before returning (gt-nq1)

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1653,6 +1653,7 @@ func Start(townRoot string) error {
 	}
 	maxAttempts := dbCount * 10 // 10 × 500ms = 5s per database
 	var lastErr error
+	tcpReachable := false
 	for attempt := 0; attempt < maxAttempts; attempt++ {
 		time.Sleep(500 * time.Millisecond)
 
@@ -1661,15 +1662,42 @@ func Start(townRoot string) error {
 			return fmt.Errorf("Dolt server process died during startup (check logs with 'gt dolt logs')")
 		}
 
-		if err := CheckServerReachable(townRoot); err == nil {
-			return nil // Server is up and accepting connections
-		} else {
-			lastErr = err
+		if !tcpReachable {
+			if err := CheckServerReachable(townRoot); err != nil {
+				lastErr = err
+				continue
+			}
+			tcpReachable = true
 		}
+
+		// TCP listener is up. Verify that the expected on-disk databases are
+		// actually being served before declaring success. Without this check
+		// Start() can return on the first iteration where Dolt has bound its
+		// port but is still discovering/loading databases — leaving callers
+		// (and waiting agents) connected to a server that only exposes
+		// information_schema and mysql. Symptom: gt down + gt up cycle leaves
+		// SHOW DATABASES showing no rig databases until the user manually
+		// runs gt dolt stop + gt dolt start. (gt-nq1)
+		if len(databases) == 0 {
+			return nil // Nothing to verify — fresh install or empty data dir
+		}
+		_, missing, verifyErr := VerifyDatabases(townRoot)
+		if verifyErr != nil {
+			lastErr = fmt.Errorf("verifying databases: %w", verifyErr)
+			continue
+		}
+		if len(missing) == 0 {
+			return nil // Server is up and serving every expected database
+		}
+		lastErr = fmt.Errorf("server is reachable but %d/%d databases not yet served (missing: %v)",
+			len(missing), len(databases), missing)
 	}
 
 	totalTimeout := time.Duration(dbCount) * 5 * time.Second
-	return fmt.Errorf("Dolt server process started (PID %d) but not accepting connections after %v (%d databases × 5s): %w\nCheck logs with: gt dolt logs", cmd.Process.Pid, totalTimeout, dbCount, lastErr)
+	if !tcpReachable {
+		return fmt.Errorf("Dolt server process started (PID %d) but not accepting connections after %v (%d databases × 5s): %w\nCheck logs with: gt dolt logs", cmd.Process.Pid, totalTimeout, dbCount, lastErr)
+	}
+	return fmt.Errorf("Dolt server process started (PID %d) and is reachable, but databases failed to load after %v (%d databases × 5s): %w\nRecovery: gt dolt stop && gt dolt start\nCheck logs with: gt dolt logs", cmd.Process.Pid, totalTimeout, dbCount, lastErr)
 }
 
 // cleanupStaleDoltLock removes a stale Dolt LOCK file if no process holds it.


### PR DESCRIPTION
## Summary

After a `gt down` + `gt up` cycle, the Dolt server can come up with its TCP listener bound but no rig databases registered. `SHOW DATABASES` then returns only `information_schema` and `mysql`, even though the on-disk `.dolt-data/` directories exist. The user has to manually `gt dolt stop && gt dolt start` to recover.

## Root cause

`doltserver.Start()` returned success on the first iteration of its readiness loop where TCP was reachable. Dolt opens its listener before finishing database discovery, so callers — and any agents waiting on `WaitForReady` from `gt up`'s Phase 0 — race ahead while databases are still loading or have failed to register entirely. `CheckServerReachable` is a TCP `DialTimeout`; it does not query `SHOW DATABASES`.

## Fix

Extend the existing readiness loop in `Start()` to also call `VerifyDatabases()` once TCP becomes reachable. Only return success when every expected on-disk database is present in `SHOW DATABASES`.

- Reuses the existing per-database time budget (`5s × dbCount`) rather than introducing a new one.
- Returns immediately on TCP-reachable when there are no on-disk databases, so the fresh-install case is unchanged.
- If TCP came up but databases never loaded, surfaces a distinct error that points the user at the manual recovery steps.

## Test plan

- [x] `go vet ./internal/doltserver/` clean
- [x] `go build ./cmd/gt` clean
- [x] `go test ./internal/doltserver/` — all relevant tests pass; the two pre-existing `TestFindBrokenWorkspaces_*` failures on `main` are unrelated to this change.
- [ ] Manual verification: induce the gt-nq1 condition with `gt down && gt up` on a workspace with multiple rig databases and confirm `SHOW DATABASES` returns the rig databases without manual intervention.

Tracks gastown bead `gt-nq1`.