### PR TITLE
Fix deacon patrol startup and stuck-session nudges

### DIFF
--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -526,7 +526,7 @@ func startDeaconSession(t *tmux.Tmux, sessionName, agentOverride string) error {
 		Recipient: "deacon",
 		Sender:    "daemon",
 		Topic:     "patrol",
-	}, "I am Deacon. First run `gt deacon heartbeat`. Then check gt hook, if empty create mol-deacon-patrol wisp and execute it.")
+	}, "I am Deacon. First run `gt deacon heartbeat`. Then check gt hook, and if it is empty run `gt sling mol-deacon-patrol deacon`, then execute the hook it creates.")
 	startupCmd, err := config.BuildStartupCommandFromConfig(config.AgentEnvConfig{
 		Role:             "deacon",
 		TownRoot:         townRoot,

--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -109,7 +109,7 @@ func (m *Manager) Start(agentOverride string) error {
 		Recipient: "deacon",
 		Sender:    "daemon",
 		Topic:     "patrol",
-	}, "I am Deacon. Start patrol: run gt deacon heartbeat, then check gt hook. If no hook, create mol-deacon-patrol wisp and execute it.")
+	}, "I am Deacon. Start patrol: run gt deacon heartbeat, then check gt hook. If no hook, run gt sling mol-deacon-patrol deacon, then execute the hook it creates.")
 	startupCmd, err := config.BuildStartupCommandFromConfig(config.AgentEnvConfig{
 		Role:        "deacon",
 		TownRoot:    m.townRoot,


### PR DESCRIPTION
## Summary
- update Deacon startup prompts to use `gt sling mol-deacon-patrol deacon` instead of the nonexistent `wisp` flow
- fix tmux nudge targeting to use pane ids directly instead of invalid `session:%pane` targets
- add a tmux regression test covering the multi-pane `GT_PANE_ID` nudge path

## Validation
- `go test ./internal/tmux -run 'TestNudgeSession_WithRetry|TestNudgeSession_UsesPaneIDTarget' -count=1`
- `go test ./internal/deacon ./internal/cmd` currently fails on an unrelated pre-existing `internal/cmd/compact_report_test.go` compile error on `main`