### PR TITLE
fix: restrict unsigned binary check to macOS only

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,12 @@ Federated work coordination network linking Gas Towns through DoltHub. Rigs post
 # Install Gas Town
 $ brew install gastown                                    # Homebrew (recommended)
 $ npm install -g @gastown/gt                              # npm
-$ go install github.com/steveyegge/gastown/cmd/gt@latest  # From source (macOS/Linux)
+$ go install github.com/steveyegge/gastown/cmd/gt@latest  # From source (Linux only)
+
+# macOS: go install produces unsigned binaries that macOS will SIGKILL.
+# Use brew install (above) or clone and build with make:
+$ git clone https://github.com/steveyegge/gastown.git && cd gastown
+$ make build && mv gt $HOME/go/bin/
 
 # Windows (or if go install fails): clone and build manually
 $ git clone https://github.com/steveyegge/gastown.git && cd gastown

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"time"
 
@@ -97,7 +98,7 @@ func persistentPreRun(cmd *cobra.Command, args []string) error {
 	// Warning only - doesn't block execution.
 	// Skip warning when Build was set by a package manager (e.g. Homebrew sets
 	// Build to "Homebrew" via ldflags but doesn't set BuiltProperly).
-	if BuiltProperly == "" && Build == "dev" {
+	if BuiltProperly == "" && Build == "dev" && runtime.GOOS == "darwin" {
 		fmt.Fprintln(os.Stderr, "ERROR: This binary was built with 'go build' directly.")
 		fmt.Fprintln(os.Stderr, "       macOS will SIGKILL unsigned binaries. Use 'make build' instead.")
 		if gtRoot := os.Getenv("GT_ROOT"); gtRoot != "" {


### PR DESCRIPTION
## Summary
Fix incorrect crash on Linux by scoping the `os.Exit(1)` guard to macOS (`darwin`) only using a `runtime.GOOS` check. Also update documentation to clarify platform-specific installation methods.

## Related Issue
Fixes https://github.com/gastownhall/gastown/issues/3560

## Changes
- Scope `os.Exit(1)` guard to `darwin` only via `runtime.GOOS`
- Fix `go install` behavior on Linux (no longer crashes)
- Update README to clarify:
  - `go install` is supported on Linux only
  - macOS users should use Homebrew or `make build` (signed binary)

## Testing
- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed
  - Tested by modifying `go.mod` and running `go install` locally on Linux

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)