### PR TITLE
fix(tmux): use bare pane ID in send-keys target

### DIFF
--- a/internal/cmd/capacity_dispatch.go
+++ b/internal/cmd/capacity_dispatch.go
@@ -247,10 +247,7 @@ func beadsForContext(townRoot string, fields *capacity.SlingContextFields) *bead
 // cleanupStaleContexts closes invalid and stale sling context beads.
 // Called explicitly before the dispatch cycle to separate cleanup from querying.
 func cleanupStaleContexts(townRoot string) {
-	contexts, err := listAllSlingContexts(townRoot)
-	if err != nil {
-		return
-	}
+	contexts := listAllSlingContexts(townRoot)
 
 	// First pass: close invalid and circuit-broken contexts, collect work bead IDs
 	// that need status checks for stale detection.
@@ -351,10 +348,7 @@ func batchFetchBeadInfoByIDs(townRoot string, ids []string) map[string]beadStatu
 // is checked across all rig dirs since work beads live in rig-local DBs.
 func getReadySlingContexts(townRoot string) ([]capacity.PendingBead, error) {
 	// 1. List all open sling context beads from HQ (authoritative)
-	allContexts, err := listAllSlingContexts(townRoot)
-	if err != nil {
-		return nil, fmt.Errorf("listing sling contexts: %w", err)
-	}
+	allContexts := listAllSlingContexts(townRoot)
 
 	if len(allContexts) == 0 {
 		return nil, nil
@@ -495,7 +489,7 @@ func recordDispatchFailure(townBeads *beads.Beads, b capacity.PendingBead, dispa
 // (GH#3468), so we scan HQ plus all rig dirs.
 // Used by scheduler list/status/clear, cleanupStaleContexts, and areScheduled.
 // Does NOT filter by readiness or circuit breaker.
-func listAllSlingContexts(townRoot string) ([]*beads.Issue, error) {
+func listAllSlingContexts(townRoot string) []*beads.Issue {
 	var all []*beads.Issue
 	for _, dir := range beadsSearchDirs(townRoot) {
 		b := beads.NewWithBeadsDir(dir, beads.ResolveBeadsDir(dir))
@@ -505,7 +499,7 @@ func listAllSlingContexts(townRoot string) ([]*beads.Issue, error) {
 		}
 		all = append(all, contexts...)
 	}
-	return all, nil
+	return all
 }
 
 // listReadyWorkBeadIDsWithError returns a set of work bead IDs that are unblocked.

--- a/internal/cmd/compact_report_test.go
+++ b/internal/cmd/compact_report_test.go
@@ -10,25 +10,27 @@ import (
 func TestWispTypeToCategory(t *testing.T) {
 	tests := []struct {
 		wispType string
+		title    string
 		want     string
 	}{
-		{"heartbeat", "Heartbeats"},
-		{"ping", "Heartbeats"},
-		{"patrol", "Patrols"},
-		{"gc_report", "Patrols"},
-		{"error", "Errors"},
-		{"recovery", "Errors"},
-		{"escalation", "Errors"},
-		{"", "Untyped"},
-		{"unknown", "Untyped"},
-		{"default", "Untyped"},
+		{"heartbeat", "", "Heartbeats"},
+		{"ping", "", "Heartbeats"},
+		{"patrol", "", "Patrols"},
+		{"gc_report", "", "Patrols"},
+		{"error", "", "Errors"},
+		{"recovery", "", "Errors"},
+		{"escalation", "", "Errors"},
+		{"", "Patrol cycle", "Patrols"},
+		{"", "", "Untyped"},
+		{"unknown", "", "Untyped"},
+		{"default", "", "Untyped"},
 	}
 
 	for _, tc := range tests {
-		t.Run(tc.wispType, func(t *testing.T) {
-			got := wispTypeToCategory(tc.wispType)
+		t.Run(tc.wispType+"/"+tc.title, func(t *testing.T) {
+			got := wispTypeToCategory(tc.wispType, tc.title)
 			if got != tc.want {
-				t.Errorf("wispTypeToCategory(%q) = %q, want %q", tc.wispType, got, tc.want)
+				t.Errorf("wispTypeToCategory(%q, %q) = %q, want %q", tc.wispType, tc.title, got, tc.want)
 			}
 		})
 	}

--- a/internal/cmd/scheduler.go
+++ b/internal/cmd/scheduler.go
@@ -298,11 +298,7 @@ func runSchedulerClear(cmd *cobra.Command, args []string) error {
 		// Close ALL sling contexts for this specific work bead (there may be
 		// duplicates if concurrent scheduleBead calls raced past idempotency).
 		// Scan all rig dirs since contexts live in target rig beads. (GH#3468)
-		contexts, listErr := listAllSlingContexts(townRoot)
-		if listErr != nil {
-			return fmt.Errorf("listing contexts: %w", listErr)
-		}
-
+		contexts := listAllSlingContexts(townRoot)
 		closed := 0
 		for _, ctx := range contexts {
 			fields := beads.ParseSlingContextFields(ctx.Description)
@@ -326,10 +322,7 @@ func runSchedulerClear(cmd *cobra.Command, args []string) error {
 	}
 
 	// Close all open sling contexts across all dirs
-	allContexts, err := listAllSlingContexts(townRoot)
-	if err != nil {
-		return fmt.Errorf("listing sling contexts: %w", err)
-	}
+	allContexts := listAllSlingContexts(townRoot)
 
 	if len(allContexts) == 0 {
 		fmt.Println("Scheduler is already empty.")
@@ -365,10 +358,7 @@ func runSchedulerRun(cmd *cobra.Command, args []string) error {
 // Reconciles sling context beads with work bead readiness to mark blocked status.
 // Uses batch fetch for work bead info to avoid N+1 subprocess spawns.
 func listScheduledBeads(townRoot string) ([]scheduledBeadInfo, error) {
-	allContexts, err := listAllSlingContexts(townRoot)
-	if err != nil {
-		return nil, err
-	}
+	allContexts := listAllSlingContexts(townRoot)
 
 	if len(allContexts) == 0 {
 		return nil, nil
@@ -432,10 +422,7 @@ func listScheduledBeads(townRoot string) ([]scheduledBeadInfo, error) {
 
 // listAllScheduledBeadIDs returns the work bead IDs of all scheduled beads.
 func listAllScheduledBeadIDs(townRoot string) ([]string, error) {
-	allContexts, err := listAllSlingContexts(townRoot)
-	if err != nil {
-		return nil, err
-	}
+	allContexts := listAllSlingContexts(townRoot)
 
 	var ids []string
 	seen := make(map[string]bool)

--- a/internal/cmd/sling_schedule.go
+++ b/internal/cmd/sling_schedule.go
@@ -2,7 +2,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -329,16 +328,7 @@ func areScheduled(beadIDs []string) map[string]bool {
 	}
 
 	// Scan all rig beads dirs (sling contexts live in target rig's DB). (GH#3468)
-	contexts, err := listAllSlingContexts(townRoot)
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "%s Warning: could not list sling contexts: %v (treating all as scheduled)\n",
-			style.Dim.Render("⚠"), err)
-		// Fail closed: treat all as scheduled to avoid duplicate scheduling
-		for _, id := range beadIDs {
-			result[id] = true
-		}
-		return result
-	}
+	contexts := listAllSlingContexts(townRoot)
 
 	// Build lookup of work bead IDs from open contexts, skipping stale ones.
 	scheduledWorkBeads := make(map[string]bool)

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -588,7 +588,7 @@ func (e *Engineer) doMerge(ctx context.Context, branch, target, sourceIssue stri
 	// local squash merge + direct push. This respects branch protection rules
 	// and preserves the PR audit trail.
 	if e.config.MergeStrategy == "pr" {
-		return e.doMergePR(ctx, branch, target)
+		return e.doMergePR(branch, target)
 	}
 
 	// Step 5: Perform the actual merge using squash merge
@@ -707,7 +707,7 @@ func (e *Engineer) doMerge(ctx context.Context, branch, target, sourceIssue stri
 // doMergePR handles merging via GitHub's PR merge API (merge_strategy=pr).
 // This respects branch protection rules including required reviews.
 // Called from doMerge after quality gates have passed.
-func (e *Engineer) doMergePR(ctx context.Context, branch, target string) ProcessResult {
+func (e *Engineer) doMergePR(branch, target string) ProcessResult {
 	_, _ = fmt.Fprintln(e.output, "[Engineer] Using PR merge strategy (merge_strategy=pr)")
 
 	// Step PR.1: Find the GitHub PR for this branch

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1646,12 +1646,17 @@ func (t *Tmux) NudgeSessionWithOpts(session, message string, opts NudgeOpts) err
 	// running the agent rather than sending to the focused pane.
 	target := session
 	if agentPane, err := t.FindAgentPane(session); err == nil && agentPane != "" {
-		// Qualify the pane ID with the session name (e.g., "hq-dog-alpha:%1")
-		// to avoid ambiguity. On some tmux versions (e.g., 3.3 on Windows),
-		// pane IDs are NOT globally unique — every session may have "%1".
-		// A bare "send-keys -t %1" targets the attached session's pane,
-		// not necessarily this session's.
-		target = session + ":" + agentPane
+		if strings.HasPrefix(agentPane, "%") {
+			// Pane IDs (%N) are globally unique in tmux 3.4+ on Linux/macOS.
+			// Using "session:%N" is invalid tmux syntax — tmux treats the token
+			// after ":" as a window specifier, not a pane ID, giving
+			// "can't find window: %N". Use the bare pane ID instead.
+			target = agentPane
+		} else {
+			// Non-% pane references (e.g. index "0") need session qualification
+			// to avoid targeting the wrong session's pane.
+			target = session + ":" + agentPane
+		}
 	}
 
 	// 0. Pre-delivery: dismiss Rewind menu if the session is stuck in it.


### PR DESCRIPTION
## Problem

`gt nudge` was failing with `Error: nudging session: tmux send-keys: can't find window: %198` on tmux 3.6a. The bug was in how `NudgeSession` built the `send-keys` target: it concatenated the session name with the pane ID as `session:%N`. In tmux, the `:` separator is used to split *session* from *window* — it does not introduce a pane ID. So `session:%198` is parsed as "window named `%198` in `session`", which doesn't exist, causing the error.

## Solution

When the pane reference starts with `%`, it's a globally unique pane ID (tmux 3.4+ on Linux/macOS) and should be used bare as the `send-keys` target. Session qualification (`session:window`) is only needed for numeric window/pane indices that are not globally unique.

Also includes fixes for pre-existing CI failures inherited from the base branch:
- `compact_report_test.go`: test called `wispTypeToCategory` with 1 arg; function signature takes 2 (`wispType, title`)
- `engineer.go`: `doMergePR` accepted a `ctx context.Context` it never used (unparam lint)
- `capacity_dispatch.go` / `scheduler.go` / `sling_schedule.go`: `listAllSlingContexts` declared an error return that was always `nil`; removed it and updated all callers