### PR TITLE
fix: send FIX_NEEDED mail to polecat, not witness

### DIFF
--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -682,12 +682,14 @@ gh pr checks <polecat-branch> --repo "$REPO_URL" --watch --fail-fast
 Do NOT merge. Send FIX_NEEDED back to the polecat:
 ```bash
 FAILURE_OUTPUT=$(gh pr checks <polecat-branch> --repo "$REPO_URL" 2>&1)
-gt mail send <rig>/witness -s "FIX_NEEDED <polecat-name>" -m "Branch: <branch>
+gt mail send <rig>/polecats/<polecat-name> -s "FIX_NEEDED <polecat-name>" --stdin <<'BODY'
+Branch: <branch>
 Issue: <issue-id>
 PR: ${PR_URL}
 Failure-Type: ci-checks
 Error: $FAILURE_OUTPUT
-Attempt-Number: 1"
+Attempt-Number: 1
+BODY
 ```
 Then skip to Step 4 (archive mail) and continue patrol.
 


### PR DESCRIPTION
## Summary
FIX_NEEDED mail from the refinery should be delivered to the polecat, not to the witness.

## Changes
- changed a recipient in the refinery formula
- made the heredoc format for that message consistent with others in the same file

## Testing
- Unit tests pass (`go test ./...`)
- TestFindBrokenWorkspaces_* and TestAcceptWorkspaceTrustDialog_NoDialog fail on main before this change — confirmed pre-existing, unrelated to this fix.

## Checklist
- [x] Code follows project style
- [x] No breaking changes (or documented in summary)
