### PR TITLE
fix(postinstall): handle redirects and file locking during downloads

### DIFF
--- a/npm-package/scripts/postinstall.js
+++ b/npm-package/scripts/postinstall.js
@@ -61,11 +61,20 @@ function downloadFile(url, dest) {
       if (response.statusCode === 301 || response.statusCode === 302) {
         const redirectUrl = response.headers.location;
         console.log(`Following redirect to: ${redirectUrl}`);
-        downloadFile(redirectUrl, dest).then(resolve).catch(reject);
+        // Consume the response so the socket can be freed
+        response.resume();
+        // Close the current write stream before recursing,
+        // otherwise the file stays locked on Windows.
+        file.close(() => {
+          fs.unlink(dest, () => {
+            downloadFile(redirectUrl, dest).then(resolve).catch(reject);
+          });
+        });
         return;
       }
 
       if (response.statusCode !== 200) {
+        file.close(() => fs.unlink(dest, () => { }));
         reject(new Error(`Failed to download: HTTP ${response.statusCode}`));
         return;
       }
@@ -73,8 +82,6 @@ function downloadFile(url, dest) {
       response.pipe(file);
 
       file.on('finish', () => {
-        // Wait for file.close() to complete before resolving
-        // This is critical on Windows where the file may still be locked
         file.close((err) => {
           if (err) reject(err);
           else resolve();
@@ -83,12 +90,12 @@ function downloadFile(url, dest) {
     });
 
     request.on('error', (err) => {
-      fs.unlink(dest, () => {});
+      file.close(() => fs.unlink(dest, () => { }));
       reject(err);
     });
 
     file.on('error', (err) => {
-      fs.unlink(dest, () => {});
+      fs.unlink(dest, () => { });
       reject(err);
     });
   });


### PR DESCRIPTION
## Summary

Fix redirect handling and file locking issues in the npm postinstall download script, primarily affecting Windows where open file handles prevent file operations during HTTP redirects.

## Related Issue
I didn't create one, but it can be easily reproduced by attempting to do a clean install on windows using npm (or pnpm, bun, whatever, all of them displayed the same issue). It will throw the following error:

```
  ⚙️  @gastown/gt [1/1] Installing gt v0.12.0 for windows-amd64...
Downloading gt binary...
Downloading from: https://github.com/steveyegge/gastown/releases/download/v0.12.0/gastown_0.12.0_windows_amd64.zip
Following redirect to: https://github.com/gastownhall/gastown/releases/download/v0.12.0/gastown_0.12.0_windows_amd64.zip
Downloading from: https://github.com/gastownhall/gastown/releases/download/v0.12.0/gastown_0.12.0_windows_amd64.zip
Following redirect to: https://release-assets.githubusercontent.com/github-production-release-asset/1117184424/1b197af4-bc14-4aea-9f2f-415cc4a85d87?sp=r&sv=2018-11-09&sr=b&spr=https&se=2026-04-10T03%3A23%3A59Z&rscd=attachment%3B+filename%3Dgastown_0.12.0_windows_amd64.zip&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2026-04-10T02%3A23%3A06Z&ske=2026-04-10T03%3A23%3A59Z&sks=b&skv=2018-11-09&sig=5ctog7LnxCi%2BbSdQH6ZgLvpLo9LEvStdhsiYbHojKsM%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc3NTc5MDQzNSwibmJmIjoxNzc1Nzg4NjM1LCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.BWXB_3Enbfuf4BtXX8qM2VNfjnhLQtby2EyWqWB7A-Y&response-content-disposition=attachment%3B%20filename%3Dgastown_0.12.0_windows_amd64.zip&response-content-type=application%2Foctet-stream
Downloading from: https://release-assets.githubusercontent.com/github-production-release-asset/1117184424/1b197af4-bc14-4aea-9f2f-415cc4a85d87?sp=r&sv=2018-11-09&sr=b&spr=https&se=2026-04-10T03%3A23%3A59Z&rscd=attachment%3B+filename%3Dgastown_0.12.0_windows_amd64.zip&rsct=application%2Foctet-stream&skoid=96c2d410-5711-43a1-aedd-ab1947aa7ab0&sktid=398a6654-997b-47e9-b12b-9515b896b4de&skt=2026-04-10T02%3A23%3A06Z&ske=2026-04-10T03%3A23%3A59Z&sks=b&skv=2018-11-09&sig=5ctog7LnxCi%2BbSdQH6ZgLvpLo9LEvStdhsiYbHojKsM%3D&jwt=eyJ0eXAiOiJKV1QiLCJhbGciOiJIUzI1NiJ9.eyJpc3MiOiJnaXRodWIuY29tIiwiYXVkIjoicmVsZWFzZS1hc3NldHMuZ2l0aHVidXNlcmNvbnRlbnQuY29tIiwia2V5Ijoia2V5MSIsImV4cCI6MTc3NTc5MDQzNSwibmJmIjoxNzc1Nzg4NjM1LCJwYXRoIjoicmVsZWFzZWFzc2V0cHJvZHVjdGlvbi5ibG9iLmNvcmUud2luZG93cy5uZXQifQ.BWXB_3Enbfuf4BtXX8qM2VNfjnhLQtby2EyWqWB7A-Y&response-content-disposition=attachment%3B%20filename%3Dgastown_0.12.0_windows_amd64.zip&response-content-type=application%2Foctet-stream
Extracting C:\Users\pedro\.bun\install\global\node_modules\@gastown\gt\bin\gastown_0.12.0_windows_amd64.zip...

New-Object : Exception calling ".ctor" with "3" argument(s): "The process cannot access the file
'C:\Users\pedro\.bun\install\global\node_modules\@gastown\gt\bin\gastown_0.12.0_windows_amd64.zip' because it is being
used by another process."
At C:\program files\powershell\7\Modules\Microsoft.PowerShell.Archive\Microsoft.PowerShell.Archive.psm1:946 char:30
+ ... ileStream = New-Object -TypeName System.IO.FileStream -ArgumentList $ ...
+                 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    + CategoryInfo          : InvalidOperation: (:) [New-Object], MethodInvocationException
    + FullyQualifiedErrorId : ConstructorInvokedThrowException,Microsoft.PowerShell.Commands.NewObjectCommand

Error installing gt: Failed to extract archive: Binary not found after extraction: C:\Users\pedro\.bun\install\global\node_modules\@gastown\gt\bin\gt.exe

Installation failed. You can try:
1. Installing manually from: https://github.com/steveyegge/gastown/releases
2. Opening an issue: https://github.com/steveyegge/gastown/issues

error: postinstall script from "@gastown/gt" exited with 1
```

## Changes
- Close the write stream and delete the partial file before following HTTP redirects, preventing file lock conflicts on Windows
- Consume the redirect response body so the underlying socket is properly freed
- Clean up the file handle on non-200 HTTP status codes before rejecting
- Close the file handle before unlinking on request errors, avoiding dangling handles

## Testing
- [x] Unit tests pass (`go test ./...`) (does not apply)
- [x] Manual testing performed

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable) (does not apply)
- [x] No breaking changes (or documented in summary)