### PR TITLE
feat: per-crew-member theme colors + window tint fixes

### DIFF
--- a/internal/cmd/crew_at.go
+++ b/internal/cmd/crew_at.go
@@ -205,7 +205,7 @@ func runCrewAt(cmd *cobra.Command, args []string) error {
 
 		// Apply rig-based theming (non-fatal: theming failure doesn't affect operation)
 		// Note: ConfigureGasTownSession includes cycle bindings
-		theme := tmux.ResolveSessionTheme(townRoot, r.Name, "crew")
+		theme := tmux.ResolveSessionTheme(townRoot, r.Name, "crew", name)
 		_ = t.ConfigureGasTownSession(sessionID, theme, r.Name, name, "crew")
 
 		// Wait for shell to be ready after session creation

--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -555,7 +555,7 @@ func startDeaconSession(t *tmux.Tmux, sessionName, agentOverride string) error {
 
 	// Apply Deacon theme (non-fatal: theming failure doesn't affect operation)
 	// Note: ConfigureGasTownSession includes cycle bindings
-	theme := tmux.ResolveSessionTheme(townRoot, "", "deacon")
+	theme := tmux.ResolveSessionTheme(townRoot, "", "deacon", "")
 	_ = t.ConfigureGasTownSession(sessionName, theme, "", "Deacon", "health-check")
 
 	// Wait for Claude to start

--- a/internal/cmd/theme.go
+++ b/internal/cmd/theme.go
@@ -163,13 +163,14 @@ func runThemeApply(cmd *cobra.Command, args []string) error {
 			continue
 		}
 
+		var crewMember string
 		switch identity.Role {
 		case session.RoleMayor:
-			theme = tmux.ResolveSessionTheme(townRoot, "", constants.RoleMayor)
+			theme = tmux.ResolveSessionTheme(townRoot, "", constants.RoleMayor, "")
 			worker = "Mayor"
 			role = constants.RoleMayor
 		case session.RoleDeacon:
-			theme = tmux.ResolveSessionTheme(townRoot, "", constants.RoleDeacon)
+			theme = tmux.ResolveSessionTheme(townRoot, "", constants.RoleDeacon, "")
 			worker = "Deacon"
 			role = constants.RoleDeacon
 		default:
@@ -188,12 +189,14 @@ func runThemeApply(cmd *cobra.Command, args []string) error {
 				worker = constants.RoleRefinery
 			case session.RoleCrew:
 				worker = identity.Name
+				crewMember = identity.Name
 			default:
 				worker = identity.Name
+				crewMember = identity.Name
 			}
 
-			// Use role-based theme resolution
-			theme = tmux.ResolveSessionTheme(townRoot, rig, role)
+			// Use role-based theme resolution (with per-member override)
+			theme = tmux.ResolveSessionTheme(townRoot, rig, role, crewMember)
 		}
 
 		// Resolve window tint from config.

--- a/internal/cmd/theme.go
+++ b/internal/cmd/theme.go
@@ -203,7 +203,11 @@ func runThemeApply(cmd *cobra.Command, args []string) error {
 		if theme != nil {
 			theme.Window = session.ResolveWindowTint(rig, role)
 			if theme.Window == nil && session.IsWindowTintEnabled(rig) {
-				theme.Window = &tmux.WindowStyle{BG: theme.BG, FG: theme.FG}
+				factor := session.ResolveTintFactor(rig)
+				theme.Window = &tmux.WindowStyle{
+					BG: tmux.DarkenColor(theme.BG, factor),
+					FG: theme.FG,
+				}
 			}
 		}
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1147,6 +1147,12 @@ type ThemeConfig struct {
 	// Custom overrides the palette with specific colors.
 	Custom *CustomTheme `json:"custom,omitempty"`
 
+	// CrewThemes maps crew member names to theme names.
+	// Checked before RoleThemes, so individual crew members can have distinct colors
+	// while other crew members fall back to the role-level theme.
+	// Example: {"krieger": "teal", "mallory": "ember"}
+	CrewThemes map[string]string `json:"crew_themes,omitempty"`
+
 	// RoleThemes overrides themes for specific roles in this rig.
 	// Keys: "witness", "refinery", "crew", "polecat".
 	// A value of "none" disables tmux theming for that role.
@@ -1175,6 +1181,10 @@ type TownThemeConfig struct {
 	// Custom overrides the palette with specific colors when no role-specific
 	// override exists.
 	Custom *CustomTheme `json:"custom,omitempty"`
+
+	// CrewThemes maps crew member names to theme names (town-wide defaults).
+	// Checked before RoleDefaults. Per-rig CrewThemes take precedence.
+	CrewThemes map[string]string `json:"crew_themes,omitempty"`
 
 	// RoleDefaults sets default themes for roles across all rigs.
 	// Keys: "mayor", "deacon", "witness", "refinery", "crew", "polecat".

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1215,6 +1215,13 @@ type WindowTint struct {
 	// RoleTints overrides window tint themes for specific roles.
 	// Keys: "witness", "refinery", "crew", "polecat"
 	RoleTints map[string]string `json:"role_tints,omitempty"`
+
+	// TintFactor controls how much the window background is darkened when
+	// inheriting from the status bar theme (0.0–1.0). Lower = darker.
+	// Default: 0.4 (40% of status bar brightness).
+	// Only applies when window tint inherits from the status bar theme
+	// (i.e., no explicit name, custom, or role_tints match).
+	TintFactor *float64 `json:"tint_factor,omitempty"`
 }
 
 // BuiltinRoleThemes returns the default themes for each role.

--- a/internal/crew/manager.go
+++ b/internal/crew/manager.go
@@ -848,7 +848,7 @@ func (m *Manager) Start(name string, opts StartOptions) error {
 	}
 
 	// Apply rig-based theming (non-fatal: theming failure doesn't affect operation)
-	theme := tmux.ResolveSessionTheme(townRoot, m.rig.Name, "crew")
+	theme := tmux.ResolveSessionTheme(townRoot, m.rig.Name, "crew", name)
 	_ = t.ConfigureGasTownSession(sessionID, theme, m.rig.Name, name, "crew")
 
 	// Set up C-b n/p keybindings for crew session cycling (non-fatal)

--- a/internal/crew/manager.go
+++ b/internal/crew/manager.go
@@ -849,6 +849,16 @@ func (m *Manager) Start(name string, opts StartOptions) error {
 
 	// Apply rig-based theming (non-fatal: theming failure doesn't affect operation)
 	theme := tmux.ResolveSessionTheme(townRoot, m.rig.Name, "crew", name)
+	if theme != nil {
+		theme.Window = session.ResolveWindowTint(m.rig.Name, "crew")
+		if theme.Window == nil && session.IsWindowTintEnabled(m.rig.Name) {
+			factor := session.ResolveTintFactor(m.rig.Name)
+			theme.Window = &tmux.WindowStyle{
+				BG: tmux.DarkenColor(theme.BG, factor),
+				FG: theme.FG,
+			}
+		}
+	}
 	_ = t.ConfigureGasTownSession(sessionID, theme, m.rig.Name, name, "crew")
 
 	// Set up C-b n/p keybindings for crew session cycling (non-fatal)

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -609,7 +609,7 @@ func (d *Daemon) applySessionTheme(sessionName string, parsed *ParsedIdentity) {
 		rigName = ""
 		worker = "Mayor"
 	}
-	theme := tmux.ResolveSessionTheme(d.config.TownRoot, rigName, role)
+	theme := tmux.ResolveSessionTheme(d.config.TownRoot, rigName, role, parsed.AgentName)
 	_ = d.tmux.ConfigureGasTownSession(sessionName, theme, rigName, worker, role)
 }
 

--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -151,7 +151,7 @@ func (m *Manager) Start(agentOverride string) error {
 	}
 
 	// Apply Deacon theming (non-fatal: theming failure doesn't affect operation)
-	theme := tmux.ResolveSessionTheme(m.townRoot, "", "deacon")
+	theme := tmux.ResolveSessionTheme(m.townRoot, "", "deacon", "")
 	_ = t.ConfigureGasTownSession(sessionID, theme, "", "Deacon", "health-check")
 
 	// Wait for Claude to start - fatal if Claude fails to launch

--- a/internal/mayor/manager.go
+++ b/internal/mayor/manager.go
@@ -158,7 +158,7 @@ func (m *Manager) StartTMUX(agentOverride string) error {
 	}
 
 	// Use unified session lifecycle for config → settings → command → create → env → theme → wait.
-	theme := tmux.ResolveSessionTheme(m.townRoot, "", "mayor")
+	theme := tmux.ResolveSessionTheme(m.townRoot, "", "mayor", "")
 	_, err = session.StartSession(t, session.SessionConfig{
 		SessionID:        sessionID,
 		WorkDir:          mayorDir,

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -440,7 +440,7 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 	}
 
 	// Apply theme (non-fatal)
-	theme := tmux.ResolveSessionTheme(townRoot, m.rig.Name, "polecat")
+	theme := tmux.ResolveSessionTheme(townRoot, m.rig.Name, "polecat", polecat)
 	debugSession("ConfigureGasTownSession", m.tmux.ConfigureGasTownSession(sessionID, theme, m.rig.Name, polecat, "polecat"))
 
 	// Set pane-died hook for crash detection (non-fatal)

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -226,7 +226,7 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 	_ = t.SetEnvironment(sessionID, "GT_RUN", runID)
 
 	// Apply theme (non-fatal: theming failure doesn't affect operation)
-	theme := tmux.ResolveSessionTheme(townRoot, m.rig.Name, "refinery")
+	theme := tmux.ResolveSessionTheme(townRoot, m.rig.Name, "refinery", "")
 	_ = t.ConfigureGasTownSession(sessionID, theme, m.rig.Name, "refinery", "refinery")
 
 	// Accept startup dialogs (workspace trust + bypass permissions) if they appear.

--- a/internal/session/window_tint.go
+++ b/internal/session/window_tint.go
@@ -43,34 +43,22 @@ func ResolveWindowTint(rig, role string) *tmux.WindowStyle {
 		}
 	}
 
-	// Check enabled — most specific level wins.
-	if rigWindowTint != nil && rigWindowTint.Enabled != nil && !*rigWindowTint.Enabled {
-		return nil
-	}
-	if globalWindowTint != nil && globalWindowTint.Enabled != nil && !*globalWindowTint.Enabled {
-		return nil
-	}
-
-	// 1. Per-rig role tint.
-	if rigWindowTint != nil && rigWindowTint.RoleTints != nil {
-		if themeName, ok := rigWindowTint.RoleTints[role]; ok {
-			if theme := tmux.GetThemeByName(themeName); theme != nil {
-				return &tmux.WindowStyle{BG: theme.BG, FG: theme.FG}
-			}
-		}
-	}
-
-	// 2. Global role tint.
-	if globalWindowTint != nil && globalWindowTint.RoleTints != nil {
-		if themeName, ok := globalWindowTint.RoleTints[role]; ok {
-			if theme := tmux.GetThemeByName(themeName); theme != nil {
-				return &tmux.WindowStyle{BG: theme.BG, FG: theme.FG}
-			}
-		}
-	}
-
-	// 3. Per-rig window tint (custom or named).
+	// If the rig has its own window_tint config, it's the final word.
+	// The rig either specifies exact colors or returns nil (inherit from status bar).
+	// This prevents global role_tints from overriding rig-level intent — e.g.,
+	// a rig with crew_themes wants window tint to match per-member status bar colors,
+	// not a global role-level default.
 	if rigWindowTint != nil {
+		if rigWindowTint.Enabled != nil && !*rigWindowTint.Enabled {
+			return nil
+		}
+		if rigWindowTint.RoleTints != nil {
+			if themeName, ok := rigWindowTint.RoleTints[role]; ok {
+				if theme := tmux.GetThemeByName(themeName); theme != nil {
+					return &tmux.WindowStyle{BG: theme.BG, FG: theme.FG}
+				}
+			}
+		}
 		if rigWindowTint.Custom != nil {
 			return &tmux.WindowStyle{BG: rigWindowTint.Custom.BG, FG: rigWindowTint.Custom.FG}
 		}
@@ -79,10 +67,23 @@ func ResolveWindowTint(rig, role string) *tmux.WindowStyle {
 				return &tmux.WindowStyle{BG: theme.BG, FG: theme.FG}
 			}
 		}
+		// Rig opted in but provided no specific colors → return nil so the
+		// caller inherits from the status bar theme (which includes crew_themes).
+		return nil
 	}
 
-	// 4. Global window tint (custom or named).
+	// No rig-level window_tint — fall through to global config.
 	if globalWindowTint != nil {
+		if globalWindowTint.Enabled != nil && !*globalWindowTint.Enabled {
+			return nil
+		}
+		if globalWindowTint.RoleTints != nil {
+			if themeName, ok := globalWindowTint.RoleTints[role]; ok {
+				if theme := tmux.GetThemeByName(themeName); theme != nil {
+					return &tmux.WindowStyle{BG: theme.BG, FG: theme.FG}
+				}
+			}
+		}
 		if globalWindowTint.Custom != nil {
 			return &tmux.WindowStyle{BG: globalWindowTint.Custom.BG, FG: globalWindowTint.Custom.FG}
 		}
@@ -93,7 +94,7 @@ func ResolveWindowTint(rig, role string) *tmux.WindowStyle {
 		}
 	}
 
-	// 5. No window tint configured — disabled by default.
+	// No window tint configured — disabled by default.
 	return nil
 }
 

--- a/internal/session/window_tint.go
+++ b/internal/session/window_tint.go
@@ -98,6 +98,38 @@ func ResolveWindowTint(rig, role string) *tmux.WindowStyle {
 	return nil
 }
 
+// DefaultTintFactor is the default darkening factor for window backgrounds
+// when inheriting from the status bar theme.
+const DefaultTintFactor = 0.4
+
+// ResolveTintFactor returns the tint_factor from the most specific config level.
+// Falls back to DefaultTintFactor if not configured.
+func ResolveTintFactor(rig string) float64 {
+	townRoot, _ := workspace.FindFromCwd()
+
+	// Check per-rig config.
+	if townRoot != "" && rig != "" {
+		settingsPath := filepath.Join(townRoot, rig, "settings", "config.json")
+		if settings, err := config.LoadRigSettings(settingsPath); err == nil {
+			if settings.Theme != nil && settings.Theme.WindowTint != nil && settings.Theme.WindowTint.TintFactor != nil {
+				return *settings.Theme.WindowTint.TintFactor
+			}
+		}
+	}
+
+	// Check global config.
+	if townRoot != "" {
+		mayorConfigPath := filepath.Join(townRoot, "mayor", "config.json")
+		if mayorCfg, err := config.LoadMayorConfig(mayorConfigPath); err == nil {
+			if mayorCfg.Theme != nil && mayorCfg.Theme.WindowTint != nil && mayorCfg.Theme.WindowTint.TintFactor != nil {
+				return *mayorCfg.Theme.WindowTint.TintFactor
+			}
+		}
+	}
+
+	return DefaultTintFactor
+}
+
 // IsWindowTintEnabled checks if window tinting is enabled at any config level.
 // Returns true if enabled explicitly; false if disabled or not configured.
 func IsWindowTintEnabled(rig string) bool {

--- a/internal/tmux/theme.go
+++ b/internal/tmux/theme.go
@@ -4,6 +4,8 @@ package tmux
 import (
 	"fmt"
 	"hash/fnv"
+	"strconv"
+	"strings"
 )
 
 // WindowStyle represents window background colors (tmux window-style).
@@ -94,6 +96,26 @@ func AssignThemeFromPalette(rigName string, palette []Theme) Theme {
 // Style returns the tmux status-style string for this theme.
 func (t Theme) Style() string {
 	return fmt.Sprintf("bg=%s,fg=%s", t.BG, t.FG)
+}
+
+// DarkenColor reduces a hex color's brightness by the given factor (0.0–1.0).
+// A factor of 0.4 means 40% of original brightness. Non-hex colors (e.g.,
+// "default") are returned unchanged.
+func DarkenColor(hex string, factor float64) string {
+	hex = strings.TrimPrefix(hex, "#")
+	if len(hex) != 6 {
+		return "#" + hex // Not a standard hex color, return as-is.
+	}
+	r, err1 := strconv.ParseUint(hex[0:2], 16, 8)
+	g, err2 := strconv.ParseUint(hex[2:4], 16, 8)
+	b, err3 := strconv.ParseUint(hex[4:6], 16, 8)
+	if err1 != nil || err2 != nil || err3 != nil {
+		return "#" + hex
+	}
+	dr := uint8(float64(r) * factor)
+	dg := uint8(float64(g) * factor)
+	db := uint8(float64(b) * factor)
+	return fmt.Sprintf("#%02x%02x%02x", dr, dg, db)
 }
 
 // ListThemeNames returns the names of all themes in the default palette.

--- a/internal/tmux/theme_resolver.go
+++ b/internal/tmux/theme_resolver.go
@@ -10,14 +10,16 @@ import (
 
 // ResolveSessionTheme returns the configured tmux theme for a session.
 // A nil theme means tmux theming is explicitly disabled.
-func ResolveSessionTheme(townRoot, rigName, role string) *Theme {
+// crewMember is the crew member name (e.g. "krieger"); pass "" for non-crew roles.
+// When non-empty, crew_themes config is checked before role-level fallback.
+func ResolveSessionTheme(townRoot, rigName, role, crewMember string) *Theme {
 	role = normalizeThemeRole(role)
 
-	if rigTheme := resolveRigSessionTheme(townRoot, rigName, role); rigTheme != unresolvedTheme {
+	if rigTheme := resolveRigSessionTheme(townRoot, rigName, role, crewMember); rigTheme != unresolvedTheme {
 		return rigTheme
 	}
 
-	if townTheme := resolveTownSessionTheme(townRoot, role); townTheme != unresolvedTheme {
+	if townTheme := resolveTownSessionTheme(townRoot, role, crewMember); townTheme != unresolvedTheme {
 		return townTheme
 	}
 
@@ -48,7 +50,7 @@ func ResolveSessionTheme(townRoot, rigName, role string) *Theme {
 
 var unresolvedTheme = &Theme{Name: "__unresolved__"}
 
-func resolveRigSessionTheme(townRoot, rigName, role string) *Theme {
+func resolveRigSessionTheme(townRoot, rigName, role, crewMember string) *Theme {
 	if townRoot == "" || rigName == "" {
 		return unresolvedTheme
 	}
@@ -57,6 +59,13 @@ func resolveRigSessionTheme(townRoot, rigName, role string) *Theme {
 	settings, err := config.LoadRigSettings(settingsPath)
 	if err != nil || settings.Theme == nil {
 		return unresolvedTheme
+	}
+
+	// Per-member theme takes priority over role-level theme.
+	if crewMember != "" && settings.Theme.CrewThemes != nil {
+		if resolved, ok := resolveRoleThemeName(settings.Theme.CrewThemes[crewMember]); ok {
+			return resolved
+		}
 	}
 
 	if settings.Theme.RoleThemes != nil {
@@ -68,7 +77,7 @@ func resolveRigSessionTheme(townRoot, rigName, role string) *Theme {
 	return resolveThemeConfig(settings.Theme)
 }
 
-func resolveTownSessionTheme(townRoot, role string) *Theme {
+func resolveTownSessionTheme(townRoot, role, crewMember string) *Theme {
 	if townRoot == "" {
 		return unresolvedTheme
 	}
@@ -76,6 +85,13 @@ func resolveTownSessionTheme(townRoot, role string) *Theme {
 	mayorCfg, err := config.LoadMayorConfig(filepath.Join(townRoot, "mayor", "config.json"))
 	if err != nil || mayorCfg.Theme == nil {
 		return unresolvedTheme
+	}
+
+	// Per-member theme takes priority over role defaults at town level too.
+	if crewMember != "" && mayorCfg.Theme.CrewThemes != nil {
+		if resolved, ok := resolveRoleThemeName(mayorCfg.Theme.CrewThemes[crewMember]); ok {
+			return resolved
+		}
 	}
 
 	if mayorCfg.Theme.RoleDefaults != nil {

--- a/internal/tmux/theme_resolver_test.go
+++ b/internal/tmux/theme_resolver_test.go
@@ -11,7 +11,7 @@ func TestResolveSessionTheme_AutoRigTheme(t *testing.T) {
 	t.Parallel()
 
 	townRoot := t.TempDir()
-	got := ResolveSessionTheme(townRoot, "gastown", "crew")
+	got := ResolveSessionTheme(townRoot, "gastown", "crew", "")
 	want := AssignTheme("gastown")
 
 	if got == nil {
@@ -33,7 +33,7 @@ func TestResolveSessionTheme_DisabledRigTheme(t *testing.T) {
 		t.Fatalf("SaveRigSettings: %v", err)
 	}
 
-	if got := ResolveSessionTheme(townRoot, "gastown", "crew"); got != nil {
+	if got := ResolveSessionTheme(townRoot, "gastown", "crew", ""); got != nil {
 		t.Fatalf("ResolveSessionTheme = %+v, want nil", *got)
 	}
 }
@@ -49,7 +49,7 @@ func TestResolveSessionTheme_NamedRigTheme(t *testing.T) {
 		t.Fatalf("SaveRigSettings: %v", err)
 	}
 
-	got := ResolveSessionTheme(townRoot, "gastown", "crew")
+	got := ResolveSessionTheme(townRoot, "gastown", "crew", "")
 	if got == nil || got.Name != "forest" {
 		t.Fatalf("ResolveSessionTheme = %+v, want forest", got)
 	}
@@ -68,7 +68,7 @@ func TestResolveSessionTheme_CustomRigTheme(t *testing.T) {
 		t.Fatalf("SaveRigSettings: %v", err)
 	}
 
-	got := ResolveSessionTheme(townRoot, "gastown", "crew")
+	got := ResolveSessionTheme(townRoot, "gastown", "crew", "")
 	if got == nil {
 		t.Fatal("ResolveSessionTheme returned nil, want custom theme")
 	}
@@ -93,7 +93,7 @@ func TestResolveSessionTheme_RoleOverrideNoneWins(t *testing.T) {
 		t.Fatalf("SaveRigSettings: %v", err)
 	}
 
-	if got := ResolveSessionTheme(townRoot, "gastown", "witness"); got != nil {
+	if got := ResolveSessionTheme(townRoot, "gastown", "witness", ""); got != nil {
 		t.Fatalf("ResolveSessionTheme = %+v, want nil", *got)
 	}
 }
@@ -113,13 +113,133 @@ func TestResolveSessionTheme_MayorAndDeaconTownOverrides(t *testing.T) {
 		t.Fatalf("SaveMayorConfig: %v", err)
 	}
 
-	mayorTheme := ResolveSessionTheme(townRoot, "", "mayor")
+	mayorTheme := ResolveSessionTheme(townRoot, "", "mayor", "")
 	if mayorTheme == nil || mayorTheme.Name != "forest" {
 		t.Fatalf("mayor theme = %+v, want forest", mayorTheme)
 	}
 
-	deaconTheme := ResolveSessionTheme(townRoot, "", "deacon")
+	deaconTheme := ResolveSessionTheme(townRoot, "", "deacon", "")
 	if deaconTheme == nil || deaconTheme.Name != "plum" {
 		t.Fatalf("deacon theme = %+v, want plum", deaconTheme)
+	}
+}
+
+func TestResolveSessionTheme_CrewMemberOverride(t *testing.T) {
+	t.Parallel()
+
+	townRoot := t.TempDir()
+	settings := config.NewRigSettings()
+	settings.Theme = &config.ThemeConfig{
+		Name: "ocean",
+		CrewThemes: map[string]string{
+			"krieger": "teal",
+			"mallory": "ember",
+		},
+	}
+	rigPath := filepath.Join(townRoot, "gastown")
+	if err := config.SaveRigSettings(config.RigSettingsPath(rigPath), settings); err != nil {
+		t.Fatalf("SaveRigSettings: %v", err)
+	}
+
+	// Named crew member gets their specific theme.
+	krieger := ResolveSessionTheme(townRoot, "gastown", "crew", "krieger")
+	if krieger == nil || krieger.Name != "teal" {
+		t.Fatalf("krieger theme = %+v, want teal", krieger)
+	}
+
+	mallory := ResolveSessionTheme(townRoot, "gastown", "crew", "mallory")
+	if mallory == nil || mallory.Name != "ember" {
+		t.Fatalf("mallory theme = %+v, want ember", mallory)
+	}
+
+	// Unlisted crew member falls back to rig theme.
+	other := ResolveSessionTheme(townRoot, "gastown", "crew", "cyril")
+	if other == nil || other.Name != "ocean" {
+		t.Fatalf("cyril theme = %+v, want ocean (rig fallback)", other)
+	}
+
+	// Empty crew member also falls back to rig theme.
+	empty := ResolveSessionTheme(townRoot, "gastown", "crew", "")
+	if empty == nil || empty.Name != "ocean" {
+		t.Fatalf("empty member theme = %+v, want ocean (rig fallback)", empty)
+	}
+}
+
+func TestResolveSessionTheme_CrewMemberNoneDisables(t *testing.T) {
+	t.Parallel()
+
+	townRoot := t.TempDir()
+	settings := config.NewRigSettings()
+	settings.Theme = &config.ThemeConfig{
+		Name: "ocean",
+		CrewThemes: map[string]string{
+			"krieger": "none",
+		},
+	}
+	rigPath := filepath.Join(townRoot, "gastown")
+	if err := config.SaveRigSettings(config.RigSettingsPath(rigPath), settings); err != nil {
+		t.Fatalf("SaveRigSettings: %v", err)
+	}
+
+	// "none" disables theming for that member.
+	if got := ResolveSessionTheme(townRoot, "gastown", "crew", "krieger"); got != nil {
+		t.Fatalf("krieger theme = %+v, want nil (disabled)", *got)
+	}
+}
+
+func TestResolveSessionTheme_CrewMemberTownFallback(t *testing.T) {
+	t.Parallel()
+
+	townRoot := t.TempDir()
+
+	// Town-level crew_themes (no rig-level config).
+	mayorCfg := config.NewMayorConfig()
+	mayorCfg.Theme = &config.TownThemeConfig{
+		CrewThemes: map[string]string{
+			"krieger": "wine",
+		},
+	}
+	if err := config.SaveMayorConfig(filepath.Join(townRoot, "mayor", "config.json"), mayorCfg); err != nil {
+		t.Fatalf("SaveMayorConfig: %v", err)
+	}
+
+	got := ResolveSessionTheme(townRoot, "gastown", "crew", "krieger")
+	if got == nil || got.Name != "wine" {
+		t.Fatalf("krieger town theme = %+v, want wine", got)
+	}
+}
+
+func TestResolveSessionTheme_CrewMemberRigOverridesTown(t *testing.T) {
+	t.Parallel()
+
+	townRoot := t.TempDir()
+
+	// Rig-level: krieger=teal
+	settings := config.NewRigSettings()
+	settings.Theme = &config.ThemeConfig{
+		CrewThemes: map[string]string{
+			"krieger": "teal",
+		},
+	}
+	rigPath := filepath.Join(townRoot, "gastown")
+	if err := config.SaveRigSettings(config.RigSettingsPath(rigPath), settings); err != nil {
+		t.Fatalf("SaveRigSettings: %v", err)
+	}
+
+	// Town-level: krieger=wine
+	mayorCfg := config.NewMayorConfig()
+	mayorCfg.Theme = &config.TownThemeConfig{
+		CrewThemes: map[string]string{
+			"krieger": "wine",
+		},
+	}
+	if err := config.SaveMayorConfig(filepath.Join(townRoot, "mayor", "config.json"), mayorCfg); err != nil {
+		t.Fatalf("SaveMayorConfig: %v", err)
+	}
+
+	// Rig-level should win.
+	got := ResolveSessionTheme(townRoot, "gastown", "crew", "krieger")
+	if got == nil || got.Name != "teal" {
+		t.Fatalf("krieger theme = %+v, want teal (rig override)", got)
 	}
 }

--- a/internal/tmux/theme_test.go
+++ b/internal/tmux/theme_test.go
@@ -121,6 +121,30 @@ func TestAssignThemeFromPalette_EmptyPalette(t *testing.T) {
 	}
 }
 
+func TestDarkenColor(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		hex    string
+		factor float64
+		want   string
+	}{
+		{"#ffffff", 0.5, "#7f7f7f"},
+		{"#0d5c63", 0.4, "#052427"},
+		{"#722f37", 0.4, "#2d1216"},
+		{"#1e3a5f", 0.4, "#0c1726"},
+		{"#000000", 0.4, "#000000"},
+		{"default", 0.4, "#default"}, // non-hex passthrough
+	}
+	for _, tt := range tests {
+		t.Run(tt.hex, func(t *testing.T) {
+			got := DarkenColor(tt.hex, tt.factor)
+			if got != tt.want {
+				t.Errorf("DarkenColor(%q, %.1f) = %q, want %q", tt.hex, tt.factor, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestAssignThemeFromPalette_CustomPalette(t *testing.T) {
 	t.Parallel()
 	custom := []Theme{

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -226,7 +226,7 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	}
 
 	// Apply Gas Town theming (non-fatal: theming failure doesn't affect operation)
-	theme := tmux.ResolveSessionTheme(townRoot, m.rig.Name, "witness")
+	theme := tmux.ResolveSessionTheme(townRoot, m.rig.Name, "witness", "")
 	_ = t.ConfigureGasTownSession(sessionID, theme, m.rig.Name, "witness", "witness")
 
 	// Wait for Claude to start - fatal if Claude fails to launch


### PR DESCRIPTION
## Summary

Four related theming improvements that enable per-crew-member tmux color assignments and fix window tint application:

1. **Per-crew-member theme colors** — `ThemeConfig` and `TownThemeConfig` gain a `crew_themes` map (`json:"crew_themes"`) that maps individual crew names to palette themes. Checked before `role_themes` so individual crew members can have distinct colors while others fall back to the role default. `ResolveSessionTheme` accepts a `crewMember` parameter for the lookup.

2. **Rig-level window_tint overrides global role_tints** — When a rig config specifies `window_tint` settings, they now correctly take precedence over town-level `role_tints`. Previously the resolution order was inverted.

3. **Darken window background fallback** — When `window_tint.enabled` is true but no explicit window tint color is configured, the window background is auto-darkened from the status bar theme color using a configurable factor. Prevents the jarring mismatch of colored status bar + default black terminal background.

4. **Window tint on crew start/resume** — `crew/manager.go` resolved the status bar theme but skipped window tint resolution, so crew sessions started without background tinting. Added the same `ResolveWindowTint` + `DarkenColor` fallback logic that `cmd/theme.go` uses.

## Test plan
- [x] `go test ./internal/tmux/` — passes
- [x] `go test ./internal/crew/` — passes
- [x] `go test ./internal/config/` — passes
- [x] `go test ./internal/session/` — passes
- [x] `go build ./cmd/gt` — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)