### PR TITLE
fix: set type=rig on rig identity beads so they don't appear in bd ready

### DIFF
--- a/internal/beads/beads_rig.go
+++ b/internal/beads/beads_rig.go
@@ -149,6 +149,7 @@ func (b *Beads) CreateRigBead(name string, fields *RigFields) (*Issue, error) {
 		"--title=" + name,
 		"--description=" + description,
 		"--labels=gt:rig",
+		"--type=rig",
 	}
 	if NeedsForceForID(id) {
 		args = append(args, "--force")


### PR DESCRIPTION
## Summary

`CreateRigBead` omitted `--type=rig` when creating rig identity beads, causing them to default to `type=task`. This made rig identity beads (e.g., `gt-rig-gastown`) surface as available work in `bd ready`.

The `rig` custom type already exists in the schema and is used in tests, but wasn't being passed at creation time. The codebase has several workarounds for this (`filterIdentityBeads()` in `gt ready`, reaper exclusion, `done` guard) — this fix addresses the root cause so those defenses become belt-and-suspenders rather than load-bearing.

## Test plan
- [x] `go test ./internal/beads/` — passes
- [x] `go build ./cmd/gt` — builds clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)