### PR TITLE
fix(convoy): use raw SQL for cross-rig dependency tracking

### DIFF
--- a/internal/cmd/compact_report_test.go
+++ b/internal/cmd/compact_report_test.go
@@ -26,7 +26,7 @@ func TestWispTypeToCategory(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.wispType, func(t *testing.T) {
-			got := wispTypeToCategory(tc.wispType)
+			got := wispTypeToCategory(tc.wispType, "")
 			if got != tc.want {
 				t.Errorf("wispTypeToCategory(%q) = %q, want %q", tc.wispType, got, tc.want)
 			}

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -2271,6 +2271,17 @@ func getTrackedIssues(townBeads, convoyID string) ([]trackedIssueInfo, error) {
 	// Fetch fresh issue details via bd show (uses prefix routing for cross-rig).
 	freshDetails := getIssueDetailsBatch(trackedIDs)
 
+	// For any tracked IDs not resolved by the batch lookup, try cross-rig
+	// raw SQL as a fallback. This handles the common case where bd show
+	// can't route to rig databases since beads v0.62. (GH #3581)
+	for _, id := range trackedIDs {
+		if _, ok := freshDetails[id]; !ok {
+			if details := getIssueDetailsCrossRig(townBeads, id); details != nil {
+				freshDetails[id] = details
+			}
+		}
+	}
+
 	// Build tracked dependency structs from fresh details
 	var deps []trackedDependency
 	for _, id := range trackedIDs {
@@ -2505,11 +2516,21 @@ func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 	showCmd.Stdout = &stdout
 
 	if err := showCmd.Run(); err != nil {
-		// Batch failed - fall back to individual lookups for robustness
-		// This handles cases where some IDs are invalid/missing
+		// Batch failed - fall back to individual lookups for robustness.
+		// This handles cases where some IDs are invalid/missing.
+		// For cross-rig beads, try raw SQL against the rig's database
+		// since bd show can't route cross-rig since v0.62. (GH #3581)
+		townBeads := ""
+		if townRoot != "" {
+			townBeads = beads.ResolveBeadsDir(townRoot)
+		}
 		for _, id := range issueIDs {
 			if details := getIssueDetails(id); details != nil {
 				result[id] = details
+			} else if townBeads != "" {
+				if details := getIssueDetailsCrossRig(townBeads, id); details != nil {
+					result[id] = details
+				}
 			}
 		}
 		return result
@@ -2525,6 +2546,50 @@ func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 	}
 
 	return result
+}
+
+// getIssueDetailsCrossRig fetches issue status via raw SQL for cross-rig beads.
+// When bd show fails for a rig-prefixed bead (because bd can't route cross-rig
+// since v0.62), this queries the bead's home database directly on the shared
+// Dolt server. The database name is the bead prefix without the trailing hyphen
+// (e.g., "bh-sct" → database "bh"). See GH #3581.
+func getIssueDetailsCrossRig(townBeads, issueID string) *issueDetails {
+	prefix := beads.ExtractPrefix(issueID)
+	if prefix == "" || prefix == "hq-" {
+		return nil // Not cross-rig or already in hq
+	}
+	dbName := strings.TrimSuffix(prefix, "-")
+	if !isValidBeadID(dbName) || !isValidBeadID(issueID) {
+		return nil
+	}
+
+	query := fmt.Sprintf(
+		"SELECT id, title, status, issue_type, assignee FROM %s.issues WHERE id = '%s'",
+		dbName, issueID,
+	)
+	out, err := runBdJSON(townBeads, "sql", query, "--json")
+	if err != nil {
+		return nil
+	}
+
+	var rows []struct {
+		ID        string `json:"id"`
+		Title     string `json:"title"`
+		Status    string `json:"status"`
+		IssueType string `json:"issue_type"`
+		Assignee  string `json:"assignee"`
+	}
+	if err := json.Unmarshal(out, &rows); err != nil || len(rows) == 0 {
+		return nil
+	}
+
+	return &issueDetails{
+		ID:        rows[0].ID,
+		Title:     rows[0].Title,
+		Status:    rows[0].Status,
+		IssueType: rows[0].IssueType,
+		Assignee:  rows[0].Assignee,
+	}
 }
 
 // getIssueDetails fetches issue details by trying to show it via bd.

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -531,6 +531,39 @@ func bdDepListRawIDs(dir, issueID, direction, depType string) ([]string, error) 
 	return ids, nil
 }
 
+// bdDepAddRawSQL inserts a dependency row via bd sql, bypassing bd dep add's
+// same-database validation that fails for cross-rig beads. This is the write
+// counterpart to bdDepListRawIDs (which reads deps via raw SQL). See GH #3581.
+//
+// dir should be the town beads directory (.beads) where the convoy lives.
+// The dependency target (dependsOnID) may live in a different rig database —
+// this is fine because we only need the ID stored, not validated.
+func bdDepAddRawSQL(dir, issueID, dependsOnID, depType string) error {
+	if !isValidBeadID(issueID) {
+		return fmt.Errorf("invalid issue ID: %q", issueID)
+	}
+	if !isValidBeadID(dependsOnID) {
+		return fmt.Errorf("invalid depends_on ID: %q", dependsOnID)
+	}
+	if depType != "" && !isValidBeadID(depType) {
+		return fmt.Errorf("invalid dep type: %q", depType)
+	}
+	if depType == "" {
+		depType = "tracks"
+	}
+
+	query := fmt.Sprintf(
+		"INSERT INTO dependencies (issue_id, depends_on_id, type, created_at, created_by) "+
+			"VALUES ('%s', '%s', '%s', NOW(), 'gt-sling')",
+		issueID, dependsOnID, depType,
+	)
+
+	if _, err := runBdJSON(dir, "sql", query); err != nil {
+		return fmt.Errorf("inserting dep %s -> %s: %w", issueID, dependsOnID, err)
+	}
+	return nil
+}
+
 // isValidBeadID checks that a string is safe for SQL interpolation in dep queries.
 // Bead IDs contain only alphanumeric chars, hyphens, dots, and underscores.
 func isValidBeadID(s string) bool {
@@ -723,22 +756,13 @@ func runConvoyCreate(cmd *cobra.Command, args []string) error {
 	// routes.jsonl. getTownBeadsDir() already returns the town root.
 	// StripBeadsDir prevents inherited BEADS_DIR from overriding routing.
 
-	// Add 'tracks' relations for each tracked issue
+	// Add 'tracks' relations for each tracked issue.
+	// Use raw SQL INSERT to bypass bd dep add's same-database validation,
+	// which fails for cross-rig beads. See GH #3581.
 	trackedCount := 0
 	for _, issueID := range trackedIssues {
-		// Use --type=tracks for non-blocking tracking relation
-		var depStderr bytes.Buffer
-		if err := BdCmd("dep", "add", convoyID, issueID, "--type=tracks").
-			WithAutoCommit().
-			Dir(townBeads).
-			StripBeadsDir().
-			Stderr(&depStderr).
-			Run(); err != nil {
-			errMsg := strings.TrimSpace(depStderr.String())
-			if errMsg == "" {
-				errMsg = err.Error()
-			}
-			style.PrintWarning("couldn't track %s: %s", issueID, errMsg)
+		if err := bdDepAddRawSQL(townBeads, convoyID, issueID, "tracks"); err != nil {
+			style.PrintWarning("couldn't track %s: %s", issueID, err)
 		} else {
 			trackedCount++
 		}
@@ -843,20 +867,12 @@ func runConvoyAdd(cmd *cobra.Command, args []string) error {
 	// routes.jsonl. getTownBeadsDir() already returns the town root.
 
 	// Add 'tracks' relations for each issue
+	// Use raw SQL INSERT to bypass bd dep add's same-database validation,
+	// which fails for cross-rig beads. See GH #3581.
 	addedCount := 0
 	for _, issueID := range issuesToAdd {
-		var depStderr bytes.Buffer
-		if err := BdCmd("dep", "add", convoyID, issueID, "--type=tracks").
-			Dir(townBeads).
-			WithAutoCommit().
-			StripBeadsDir().
-			Stderr(&depStderr).
-			Run(); err != nil {
-			errMsg := strings.TrimSpace(depStderr.String())
-			if errMsg == "" {
-				errMsg = err.Error()
-			}
-			style.PrintWarning("couldn't add %s: %s", issueID, errMsg)
+		if err := bdDepAddRawSQL(townBeads, convoyID, issueID, "tracks"); err != nil {
+			style.PrintWarning("couldn't add %s: %s", issueID, err)
 		} else {
 			addedCount++
 		}

--- a/internal/cmd/sling_convoy.go
+++ b/internal/cmd/sling_convoy.go
@@ -345,13 +345,13 @@ func createBatchConvoy(beadIDs []string, rigName string, owned bool, mergeStrate
 	}
 
 	// Add tracking relations for all beads, recording which succeed.
-	// Use WithAutoCommit for the same reason as above.
+	// Use raw SQL INSERT to bypass bd dep add's same-database validation,
+	// which fails for cross-rig beads. See GH #3581.
 	var tracked []string
 	for _, beadID := range beadIDs {
-		depArgs := []string{"dep", "add", convoyID, beadID, "--type=tracks"}
-		if out, err := BdCmd(depArgs...).Dir(townRoot).WithAutoCommit().StripBeadsDir().CombinedOutput(); err != nil {
+		if err := bdDepAddRawSQL(townBeads, convoyID, beadID, "tracks"); err != nil {
 			// Log but continue — partial tracking is better than no tracking
-			fmt.Printf("  Warning: could not track %s in convoy: %v\nOutput: %s\n", beadID, err, out)
+			fmt.Printf("  Warning: could not track %s in convoy: %v\n", beadID, err)
 		} else {
 			tracked = append(tracked, beadID)
 		}
@@ -412,14 +412,11 @@ func createAutoConvoy(beadID, beadTitle string, owned bool, mergeStrategy, baseB
 
 	// Add tracking relation: convoy tracks the issue.
 	// bd dep add validates both IDs exist in the same database, which fails for
-	// cross-rig beads (e.g., gas-xyz tracked by an hq-cv- convoy). Since beads
-	// v0.62 removed cross-rig routing from bd, this validation cannot be satisfied
-	// for rig-prefixed beads. We treat tracking failure as non-fatal: the convoy
-	// still works, the witness and daemon provide backup tracking, and PR #3166
-	// will replace this with the Go module API which can route cross-rig.
-	depArgs := []string{"dep", "add", convoyID, beadID, "--type=tracks"}
-	if out, err := BdCmd(depArgs...).Dir(townRoot).WithAutoCommit().StripBeadsDir().CombinedOutput(); err != nil {
-		fmt.Printf("Warning: Could not create auto-convoy tracking: %v\noutput: %s\n", err, out)
+	// cross-rig beads (e.g., bh-xyz tracked by an hq-cv- convoy). Use raw SQL
+	// INSERT to bypass the validation — same approach bdDepListRawIDs uses for
+	// reads. See GH #3581.
+	if err := bdDepAddRawSQL(townBeads, convoyID, beadID, "tracks"); err != nil {
+		fmt.Printf("Warning: Could not create auto-convoy tracking: %v\n", err)
 	}
 
 	return convoyID, nil


### PR DESCRIPTION
## Summary

Fixes cross-rig convoy tracking end-to-end: creation, status resolution, and auto-close.

`bd dep add` validates both IDs exist in the same database, which fails for cross-rig beads (e.g., `hq-cv-xxx` tracking `bh-xxx`). And `bd show` can't route to rig databases since beads v0.62. This broke the entire convoy lifecycle for multi-rig towns.

### Commit 1: Fix dependency tracking (writes)

Replaces `bd dep add` with raw SQL INSERT (`bdDepAddRawSQL`) in all four code paths:
- `gt sling` auto-convoy creation (`createAutoConvoy`)
- `gt sling` batch convoy creation (`createBatchConvoy`)
- `gt convoy create`
- `gt convoy add`

Same raw SQL pattern that `bdDepListRawIDs` (added in #2624) already uses for reads.

### Commit 2: Fix pre-existing test compilation error

`wispTypeToCategory` gained a second parameter (`title`) but `compact_report_test.go` wasn't updated. This broke test compilation for the entire `cmd` package, blocking CI on all PRs.

### Commit 3: Fix status resolution (reads) + auto-close

Adds `getIssueDetailsCrossRig()` that queries rig databases directly via raw SQL when `bd show` fails for cross-rig beads. Resolves bead prefix to database name (`bh-sct` → database `bh`) and queries `<db>.issues` on the shared Dolt server.

Wired into:
- `getIssueDetailsBatch` fallback path
- `getTrackedIssues` for unresolved IDs after batch lookup

**Before:** Convoy status showed `(external) [unassigned]`, convoy check reported open issues even after closure, convoys never auto-closed.

**After:** Full lifecycle works — convoy tracks beads, shows their title/status, detects closure, auto-closes, notifies subscribers.

## Test plan

- [x] `go build ./...` compiles clean
- [x] E2E: `gt convoy create "test" bh-xxx` → Tracking: 1 issues (was 0)
- [x] E2E: `gt convoy status` shows bead title and type (was `[unassigned]`)
- [x] E2E: `bd close bh-xxx && gt convoy check` → auto-closes convoy (was "1 open remaining")
- [x] Pre-existing test compilation error fixed (`compact_report_test.go`)
- [ ] Lint failure (`engineer.go:710` unused ctx) is pre-existing on main — all recent merged PRs have same failure

Fixes #3581