### PR TITLE
Add Mistral Vibe agent support to Gastown rig

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ internal/events/*/
 # Local config
 config.toml
 !config.example.toml
+!internal/hooks/templates/vibe/config.toml
 gt
 
 # Runtime state (ignore contents, but allow setup-hooks to be tracked)

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -432,7 +432,7 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 	AgentMistral: {
 		Name:                AgentMistral,
 		Command:             "vibe",
-		Args:                []string{},
+		Args:                []string{"--agent", "auto-approve"},
 		ProcessNames:        []string{"vibe"},
 		SessionIDEnv:        "VIBE_SESSION_ID",
 		ResumeFlag:          "--resume",

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -36,6 +36,8 @@ const (
 	// AgentOmp is Oh My Pi (OMP) — Pi fork with hook-based lifecycle.
 	// Inspired by github.com/ProbabilityEngineer/pi-mono gastown integration.
 	AgentOmp AgentPreset = "omp"
+	// AgentMistral is Mistral Vibe CLI.
+	AgentMistral AgentPreset = "vibe"
 )
 
 // AgentPresetInfo contains the configuration details for an agent preset.
@@ -426,6 +428,30 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		NonInteractive: &NonInteractiveConfig{
 			PromptFlag: "--prompt",
 		},
+	},
+	AgentMistral: {
+		Name:                AgentMistral,
+		Command:             "vibe",
+		Args:                []string{},
+		ProcessNames:        []string{"vibe"},
+		SessionIDEnv:        "VIBE_SESSION_ID",
+		ResumeFlag:          "--resume",
+		ContinueFlag:        "--continue",
+		ResumeStyle:         "flag",
+		SupportsHooks:       true,
+		SupportsForkSession: false,
+		NonInteractive: &NonInteractiveConfig{
+			PromptFlag: "-p",
+			OutputFlag: "json",
+		},
+		PromptMode:        "arg",
+		ConfigDir:         ".vibe",
+		HooksProvider:     "vibe",
+		HooksDir:          ".vibe",
+		HooksSettingsFile: "config.toml",
+		ReadyPromptPrefix: "❯ ",
+		ReadyDelayMs:      5000,
+		InstructionsFile:  "AGENTS.md",
 	},
 }
 

--- a/internal/hooks/templates/vibe/config.toml
+++ b/internal/hooks/templates/vibe/config.toml
@@ -1,9 +1,6 @@
 # Gas Town Vibe Configuration
 # Provisioned by Gas Town for agent integration
 
-# Enable auto-approve for autonomous mode
-auto_approve = true
-
 # Model configuration
 active_model = "devstral-2"
 

--- a/internal/hooks/templates/vibe/config.toml
+++ b/internal/hooks/templates/vibe/config.toml
@@ -1,0 +1,40 @@
+# Gas Town Vibe Configuration
+# Provisioned by Gas Town for agent integration
+
+# Enable auto-approve for autonomous mode
+auto_approve = true
+
+# Model configuration
+active_model = "devstral-2"
+
+# Trust the current project directory
+# (Vibe will not ask about trusting this directory)
+
+# Session logging for resume capability
+enable_session_logs = true
+log_dir = ".vibe/logs"
+
+# Tools configuration - enable all tools for autonomous operation
+[tools.bash]
+permission = "always"
+
+[tools.read_file]
+permission = "always"
+
+[tools.write_file]
+permission = "always"
+
+[tools.search_replace]
+permission = "always"
+
+[tools.grep]
+permission = "always"
+
+[tools.glob]
+permission = "always"
+
+[tools.task]
+permission = "always"
+
+[tools.ask_user_question]
+permission = "always"


### PR DESCRIPTION
## Summary
Adds Mistral Vibe CLI support.

## Related Issue
Fixes #3580

## Changes
- Adds AgentMistral structure in agents.go
- Adds AgentMistral to list of presets in tests
- Update documentation

## Testing
- [X] Unit tests pass (`go test ./...`)
- [X] Manual testing performed:  Went through a QA phase of this PR with Gastown/Vibe -- didn't try any complex workflows though

## Checklist
- [X] Code follows project style
- [X] Documentation updated (if applicable)
- [X] No breaking changes (or documented in summary)
