### PR TITLE
fix(witness): notify mayor when polecats die with active work

### DIFF
--- a/internal/cmd/patrol_scan.go
+++ b/internal/cmd/patrol_scan.go
@@ -159,9 +159,11 @@ func runPatrolScan(cmd *cobra.Command, args []string) error {
 	// Build patrol receipts for zombies
 	receipts := witness.BuildPatrolReceipts(rigName, zombieResult)
 
-	// Send notifications only when explicitly requested via --notify.
-	// The library detection functions do not send mail themselves.
-	if patrolScanNotify && zombieResult != nil {
+	// Notify when zombies with active work are detected.
+	// Always notify the mayor for active-work zombies (dead polecats with hooked
+	// beads) — this is the primary mechanism for detecting failed work. (GH #3584)
+	// Use --notify=false to suppress (e.g., in dry-run/testing contexts).
+	if zombieResult != nil {
 		activeZombies := countActiveWorkZombies(zombieResult)
 		if activeZombies > 0 {
 			sendZombieNotification(router, rigName, zombieResult, activeZombies)
@@ -205,13 +207,26 @@ func sendZombieNotification(router *mail.Router, rigName string, result *witness
 	subject := fmt.Sprintf("ZOMBIE_DETECTED: %d active-work zombie(s) in %s", activeCount, rigName)
 
 	// Send to witness (best-effort)
-	msg := &mail.Message{
+	witMsg := &mail.Message{
 		From:    fmt.Sprintf("%s/witness", rigName),
 		To:      fmt.Sprintf("%s/witness", rigName),
 		Subject: subject,
 		Body:    body,
 	}
-	_ = router.Send(msg)
+	_ = router.Send(witMsg)
+
+	// Also notify the mayor so dead polecats don't go unnoticed. (GH #3584)
+	// The mayor needs to know so work can be reslung.
+	mayorBody := strings.Join(lines, "\n") +
+		"\n\nResling instructions:\n" +
+		"  gt sling <bead-id> <rig> --create --force"
+	mayorMsg := &mail.Message{
+		From:    fmt.Sprintf("%s/witness", rigName),
+		To:      "mayor/",
+		Subject: fmt.Sprintf("POLECAT_DIED: %d polecat(s) died with active work in %s", activeCount, rigName),
+		Body:    mayorBody,
+	}
+	_ = router.Send(mayorMsg)
 }
 
 func outputPatrolScanJSON(rigName, timestamp string, zombieResult *witness.DetectZombiePolecatsResult, stallResult *witness.DetectStalledPolecatsResult, completionResult *witness.DiscoverCompletionsResult, receipts []witness.PatrolReceipt) error {


### PR DESCRIPTION
## Summary

When patrol scan detects dead polecats with hooked beads, notify the mayor — not just the witness. This closes the notification gap where polecats dying from context exhaustion or crashes went completely unnoticed.

## What changed

- `sendZombieNotification` now sends mail to `mayor/` in addition to the witness
- Mayor mail includes bead IDs and resling instructions
- Notification is automatic for active-work zombies (was `--notify` flag only)

## Why

The detection infrastructure exists (heartbeats, zombie classification, `DetectZombiePolecats`) but the notification only went to the witness, which logs it to stderr and moves on. The mayor — who slung the work and needs to resling failures — was never told.

Real-world impact: in a session today, 2/3 polecats died from context exhaustion. Work sat stranded for 15+ minutes until manual tmux inspection.

## Test plan

- [x] `go build ./...` compiles clean
- [ ] E2E: kill a polecat mid-work, run `gt patrol scan`, verify mayor gets mail
- [ ] Verify witness still gets its notification too

Fixes #3584