### PR TITLE
fix(daemon): show failure reason when daemon fails to start

### DIFF
--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -559,7 +559,10 @@ func ensureDaemon(townRoot string) error {
 		return err
 	}
 	if !running {
-		return fmt.Errorf("daemon failed to start")
+		if msg := readDaemonStartupFailure(townRoot, cmd.Process.Pid); msg != "" {
+			return fmt.Errorf("daemon failed to start: %s", msg)
+		}
+		return fmt.Errorf("daemon failed to start (check logs with 'gt daemon logs')")
 	}
 
 	return nil


### PR DESCRIPTION
When the daemon fails to start, the error message now includes the actual failure reason from logs when available, or suggests checking logs with 'gt daemon logs' as a fallback.

## Summary
Improved ensureDaemon() error reporting so users see why the daemon failed to start, instead of a generic error message.

## Related Issue
N/A

## Changes
- Read startup failure reason via readDaemonStartupFailure and include it in the error message                                                                                                                                                                                                         
- Add fallback message pointing users to gt daemon logs when no specific reason is found

## Testing
- Unit tests pass (go test ./...) — pre-existing compilation failure in compact_report_test.go is unrelated to this change                                                                                                                                                                             
- Manual testing performed

## Checklist
- Code follows project style
- Documentation updated (if applicable)
- No breaking changes (or documented in summary)
