### PR TITLE
feat: add Claude Code minimum version check to gt doctor

### DIFF
--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -18,7 +18,7 @@ Complete setup guide for Gas Town multi-agent orchestrator.
 | Tool | Version | Check | Install |
 |------|---------|-------|---------|
 | **tmux** | 3.0+ | `tmux -V` | See below |
-| **Claude Code** (default) | latest | `claude --version` | See [claude.ai/claude-code](https://claude.ai/claude-code) |
+| **Claude Code** (default) | >= 2.0.20 | `claude --version` | See [claude.ai/claude-code](https://claude.ai/claude-code) |
 | **Codex CLI** (optional) | latest | `codex --version` | See [developers.openai.com/codex/cli](https://developers.openai.com/codex/cli) |
 | **OpenCode CLI** (optional) | latest | `opencode --version` | See [opencode.ai](https://opencode.ai) |
 | **GitHub Copilot CLI** (optional) | latest | `copilot --version` | See [cli.github.com](https://cli.github.com) (requires Copilot seat) |

--- a/docs/design/claude-code-minimum-version.md
+++ b/docs/design/claude-code-minimum-version.md
@@ -1,0 +1,136 @@
+# Claude Code Minimum Version for Gas Town
+
+Research ref: gt-9me
+
+## Summary
+
+**Minimum supported: v2.0.20** (2025-10-16)
+**Recommended: v2.1.3+** (2026-01-09)
+
+Gas Town requires Claude Code features that were added incrementally from
+v1.0.38 through v2.1.3. The highest watermark dependency is the **Skills
+system** (v2.0.20), which Gas Town uses for crew-commit, ghi-list, pr-list,
+and pr-sheriff. The skills/commands merge in v2.1.3 makes both systems work
+through a unified interface, which matches Gas Town's current `.claude/skills/`
+and `.claude/commands/` layout.
+
+## Incident Context
+
+A user experienced nudge failures and refinery startup issues on what was
+reported as "v1.4.0". Note: Claude Code versions follow the pattern `X.Y.Z`
+where published versions are 0.2.x (pre-GA), 1.0.x (GA), 2.0.x, and 2.1.x.
+There is no v1.4.0 in the release history. The reported version may have been
+misread or from a fork. Upgrading to v2.1.101 resolved all issues.
+
+## Feature Dependency Chain
+
+Gas Town depends on Claude Code features that were added in this order:
+
+| Feature | Added In | Gas Town Usage |
+|---------|----------|----------------|
+| Custom slash commands (`.claude/commands/`) | v0.2.31 (2025-03-05) | /done, /review, /handoff, /patrol, /reaper, /backup |
+| Hooks system released | v1.0.38 (2025-06-30) | All lifecycle hooks |
+| PreCompact hook | v1.0.53 (2025-07-15) | `gt prime --hook` on context compaction |
+| UserPromptSubmit hook | v1.0.57 (2025-07-21) | `gt mail check --inject` (nudge queue drain) |
+| Subagent/Agent tool | v1.0.60 (2025-07-24) | Agent delegation in crew workers |
+| SessionStart hook | v1.0.62 (2025-07-28) | `gt prime --hook && gt mail check --inject` |
+| SlashCommand tool | v1.0.123 (2025-09-23) | Claude self-invoking slash commands |
+| `--settings` flag | v1.0.x (exact unknown) | Per-role settings isolation |
+| Skills system | v2.0.20 (2025-10-16) | /crew-commit, /ghi-list, /pr-list, /pr-sheriff |
+| Skills/commands merged | v2.1.3 (2026-01-09) | Unified skill + command interface |
+| Deferred tools (ToolSearch) | v2.1.7 (2026-01-14) | MCP tool lazy loading |
+| `skipDangerousModePermissionPrompt` | v2.0.x (exact unknown) | Suppresses permission dialog in settings.json |
+
+## What Breaks at Each Version Floor
+
+### Below v1.0.38 — **Non-functional**
+No hooks at all. Gas Town cannot inject context at session start, drain nudge
+queues, guard tool calls, or record costs. The agent has no Gas Town identity.
+
+### v1.0.38 to v1.0.61 — **Partially functional**
+Hooks work but SessionStart hook is missing. Gas Town must fall back to tmux
+nudge-based priming, which is unreliable. PreCompact and UserPromptSubmit hooks
+may also be missing depending on exact version.
+
+### v1.0.62 to v1.0.122 — **Functional, no skills**
+All 5 hook events work. Custom slash commands work. But no Skills support, so
+/crew-commit and other skills won't appear. No SlashCommand tool, so Claude
+can't self-invoke slash commands.
+
+### v1.0.123 to v2.0.19 — **Functional, no skills**
+SlashCommand tool added. Claude can self-invoke /done, /handoff, etc. But still
+no Skills system.
+
+### v2.0.20 to v2.1.2 — **Fully functional (minimum supported)**
+Skills system available. All Gas Town features work. However, skills and
+slash commands are separate systems — the `.claude/skills/` directory works
+but the merge behavior may differ from current expectations.
+
+### v2.1.3+ — **Recommended**
+Skills and commands merged into a unified system. This matches Gas Town's
+current directory layout and frontmatter conventions.
+
+## Undocumented/Fragile Dependencies
+
+These aren't version-gated but can break across any Claude Code update:
+
+| Dependency | What Gas Town Does | Fragility |
+|------------|-------------------|-----------|
+| Prompt prefix `❯` (U+276F) | Idle detection via tmux capture | UI string, could change |
+| Status bar `⏵⏵` (U+23F5) | Busy detection | Undocumented internal |
+| NBSP rendering (U+00A0) | Prompt matching normalization | Changed once already (issues/1387) |
+| JSONL transcript format | Cost tracking, seance | Undocumented file format |
+| `sessions-index.json` | Session discovery | Undocumented file format |
+| Config dir path encoding | Project settings location | Undocumented convention |
+| PreToolUse JSON stdin format | Guard scripts parse hook input | Could change |
+| `.claude.json` oauthAccount field | Account rotation | Undocumented |
+| Keychain service naming (SHA-256) | Credential isolation | Undocumented |
+
+## Recommendations
+
+### 1. Update INSTALLING.md
+
+Change Claude Code from "latest" to a minimum version:
+
+```
+| **Claude Code** (default) | >= 2.0.20 | `claude --version` | ... |
+```
+
+### 2. Add `gt doctor` check
+
+Create `internal/deps/claude.go` (parallel to `dolt.go` and `beads.go`) with
+version parsing and comparison. Add `internal/doctor/claude_binary_check.go`
+that warns when Claude Code is below the minimum.
+
+Proposed behavior:
+- **Not found**: Skip (Claude Code is optional per INSTALLING.md)
+- **Below v2.0.20**: Warning — "Claude Code {version} is below minimum (2.0.20), some features will not work"
+- **v2.0.20 to v2.1.2**: OK with note — "Consider upgrading to 2.1.3+ for full skills support"
+- **v2.1.3+**: OK
+
+### 3. Add startup warning to `gt prime`
+
+When running inside Claude Code (detectable via CLAUDE_CONFIG_DIR or process
+name), `gt prime` could check the version and emit a warning line if below
+minimum. This gives agents immediate visibility without waiting for `gt doctor`.
+
+### 4. Document in CLAUDE.md at town root
+
+Add a "Prerequisites" section or link to the version requirements doc so that
+new sessions see it during priming.
+
+## Not Recommended
+
+- **Hard enforcement** (blocking startup below minimum): Gas Town's design
+  principle is graceful degradation. An old Claude Code still works for basic
+  tmux orchestration. Blocking would prevent partial functionality.
+
+- **Pinning to exact versions**: Claude Code releases frequently (200+ npm
+  versions). Pinning creates unnecessary upgrade friction.
+
+## Version History Sources
+
+- Claude Code CHANGELOG.md: https://github.com/anthropics/claude-code/blob/main/CHANGELOG.md
+- npm package: @anthropic-ai/claude-code
+- GA release (v1.0.0): 2025-05-22
+- v2.0.0 release: 2025-09-29

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -164,6 +164,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewStaleBinaryCheck())
 	d.Register(doctor.NewBeadsBinaryCheck())
 	d.Register(doctor.NewDoltBinaryCheck())
+	d.Register(doctor.NewClaudeBinaryCheck())
 	d.Register(doctor.NewDoltServerReachableCheck())
 
 	d.Register(doctor.NewTownGitCheck())

--- a/internal/cmd/upgrade.go
+++ b/internal/cmd/upgrade.go
@@ -123,6 +123,7 @@ func upgradeDoctor(townRoot string) upgradeResult {
 	d.Register(doctor.NewStaleBinaryCheck())
 	d.Register(doctor.NewBeadsBinaryCheck())
 	d.Register(doctor.NewDoltBinaryCheck())
+	d.Register(doctor.NewClaudeBinaryCheck())
 	d.Register(doctor.NewDoltServerReachableCheck())
 	d.Register(doctor.NewTownGitCheck())
 	d.Register(doctor.NewTownRootBranchCheck())

--- a/internal/deps/claude.go
+++ b/internal/deps/claude.go
@@ -1,0 +1,80 @@
+package deps
+
+import (
+	"context"
+	"os/exec"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/util"
+)
+
+// MinClaudeCodeVersion is the minimum compatible Claude Code version for Gas Town.
+// v2.0.20 introduced the Skills system, which Gas Town uses for crew-commit,
+// ghi-list, pr-list, and pr-sheriff. See docs/design/claude-code-minimum-version.md.
+const MinClaudeCodeVersion = "2.0.20"
+
+// RecommendedClaudeCodeVersion is the recommended version where skills and
+// slash commands were merged into a unified system.
+const RecommendedClaudeCodeVersion = "2.1.3"
+
+// ClaudeCodeInstallURL is the installation page for Claude Code.
+const ClaudeCodeInstallURL = "https://claude.ai/claude-code"
+
+// ClaudeCodeStatus represents the state of the Claude Code installation.
+type ClaudeCodeStatus int
+
+const (
+	ClaudeCodeOK         ClaudeCodeStatus = iota // claude found, version compatible
+	ClaudeCodeNotFound                           // claude not in PATH
+	ClaudeCodeTooOld                             // claude found but version too old
+	ClaudeCodeOldButOK                           // claude found, above minimum but below recommended
+	ClaudeCodeExecFailed                         // claude found but 'claude --version' failed
+	ClaudeCodeUnknown                            // claude version ran but output couldn't be parsed
+)
+
+// CheckClaudeCode checks if Claude Code is installed and compatible.
+// Returns status and the installed version (if found).
+func CheckClaudeCode() (ClaudeCodeStatus, string) {
+	path, err := exec.LookPath("claude")
+	if err != nil {
+		return ClaudeCodeNotFound, ""
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	cmd := exec.CommandContext(ctx, path, "--version")
+	util.SetDetachedProcessGroup(cmd)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return ClaudeCodeExecFailed, ""
+	}
+
+	version := parseClaudeCodeVersion(string(output))
+	if version == "" {
+		return ClaudeCodeUnknown, ""
+	}
+
+	if CompareVersions(version, MinClaudeCodeVersion) < 0 {
+		return ClaudeCodeTooOld, version
+	}
+
+	if CompareVersions(version, RecommendedClaudeCodeVersion) < 0 {
+		return ClaudeCodeOldButOK, version
+	}
+
+	return ClaudeCodeOK, version
+}
+
+// parseClaudeCodeVersion extracts version from Claude Code --version output.
+// Output format: "2.1.101 (Claude Code)" or just "2.1.101".
+func parseClaudeCodeVersion(output string) string {
+	output = strings.TrimSpace(output)
+	re := regexp.MustCompile(`^(\d+\.\d+\.\d+)`)
+	matches := re.FindStringSubmatch(output)
+	if len(matches) >= 2 {
+		return matches[1]
+	}
+	return ""
+}

--- a/internal/deps/claude_test.go
+++ b/internal/deps/claude_test.go
@@ -1,0 +1,40 @@
+package deps
+
+import "testing"
+
+func TestParseClaudeCodeVersion(t *testing.T) {
+	tests := []struct {
+		input    string
+		expected string
+	}{
+		{"2.1.101 (Claude Code)", "2.1.101"},
+		{"2.1.101 (Claude Code)\n", "2.1.101"},
+		{"2.1.101", "2.1.101"},
+		{"2.0.20", "2.0.20"},
+		{"1.0.128", "1.0.128"},
+		{"10.20.30 (Claude Code)", "10.20.30"},
+		{"some other output", ""},
+		{"", ""},
+	}
+
+	for _, tt := range tests {
+		result := parseClaudeCodeVersion(tt.input)
+		if result != tt.expected {
+			t.Errorf("parseClaudeCodeVersion(%q) = %q, want %q", tt.input, result, tt.expected)
+		}
+	}
+}
+
+func TestCheckClaudeCode(t *testing.T) {
+	status, version := CheckClaudeCode()
+
+	if status == ClaudeCodeNotFound {
+		t.Skip("claude not installed, skipping integration test")
+	}
+
+	if status == ClaudeCodeOK && version == "" {
+		t.Error("CheckClaudeCode returned ClaudeCodeOK but empty version")
+	}
+
+	t.Logf("CheckClaudeCode: status=%d, version=%s", status, version)
+}

--- a/internal/doctor/claude_binary_check.go
+++ b/internal/doctor/claude_binary_check.go
@@ -1,0 +1,89 @@
+package doctor
+
+import (
+	"fmt"
+
+	"github.com/steveyegge/gastown/internal/deps"
+)
+
+// ClaudeBinaryCheck verifies that the Claude Code CLI is installed and meets
+// the minimum version requirement. Claude Code is optional (Gas Town supports
+// other agents), so missing Claude Code is a warning, not an error.
+type ClaudeBinaryCheck struct {
+	BaseCheck
+}
+
+// NewClaudeBinaryCheck creates a new Claude Code binary version check.
+func NewClaudeBinaryCheck() *ClaudeBinaryCheck {
+	return &ClaudeBinaryCheck{
+		BaseCheck: BaseCheck{
+			CheckName:        "claude-binary",
+			CheckDescription: "Check that Claude Code meets minimum version for Gas Town",
+			CheckCategory:    CategoryInfrastructure,
+		},
+	}
+}
+
+// Run checks if Claude Code is available in PATH and reports its version status.
+func (c *ClaudeBinaryCheck) Run(ctx *CheckContext) *CheckResult {
+	status, version := deps.CheckClaudeCode()
+
+	switch status {
+	case deps.ClaudeCodeOK:
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: fmt.Sprintf("claude %s", version),
+		}
+
+	case deps.ClaudeCodeNotFound:
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "claude not found (optional — other agents work without it)",
+		}
+
+	case deps.ClaudeCodeTooOld:
+		return &CheckResult{
+			Name:   c.Name(),
+			Status: StatusWarning,
+			Message: fmt.Sprintf("claude %s is below minimum (%s) — hooks, skills, and nudge delivery may not work",
+				version, deps.MinClaudeCodeVersion),
+			Details: []string{
+				fmt.Sprintf("Gas Town requires Claude Code >= %s for full functionality", deps.MinClaudeCodeVersion),
+				"Features requiring hooks (priming, mail, guards) will not work on older versions",
+			},
+			FixHint: fmt.Sprintf("Upgrade: npm install -g @anthropic-ai/claude-code@latest (see %s)", deps.ClaudeCodeInstallURL),
+		}
+
+	case deps.ClaudeCodeOldButOK:
+		return &CheckResult{
+			Name:   c.Name(),
+			Status: StatusOK,
+			Message: fmt.Sprintf("claude %s (upgrade to %s+ recommended for unified skills/commands)",
+				version, deps.RecommendedClaudeCodeVersion),
+		}
+
+	case deps.ClaudeCodeExecFailed:
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: "claude found but 'claude --version' failed",
+			FixHint: fmt.Sprintf("Reinstall: npm install -g @anthropic-ai/claude-code@latest (see %s)", deps.ClaudeCodeInstallURL),
+		}
+
+	case deps.ClaudeCodeUnknown:
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: "claude found but version could not be parsed",
+			FixHint: fmt.Sprintf("Try reinstalling: npm install -g @anthropic-ai/claude-code@latest (see %s)", deps.ClaudeCodeInstallURL),
+		}
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusOK,
+		Message: "claude available",
+	}
+}

--- a/internal/doctor/claude_binary_check_test.go
+++ b/internal/doctor/claude_binary_check_test.go
@@ -1,0 +1,175 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/deps"
+)
+
+func TestClaudeBinaryCheck_Metadata(t *testing.T) {
+	check := NewClaudeBinaryCheck()
+
+	if check.Name() != "claude-binary" {
+		t.Errorf("Name() = %q, want %q", check.Name(), "claude-binary")
+	}
+	if check.Description() != "Check that Claude Code meets minimum version for Gas Town" {
+		t.Errorf("Description() = %q", check.Description())
+	}
+	if check.Category() != CategoryInfrastructure {
+		t.Errorf("Category() = %q, want %q", check.Category(), CategoryInfrastructure)
+	}
+	if check.CanFix() {
+		t.Error("CanFix() should return false")
+	}
+}
+
+func TestClaudeBinaryCheck_ClaudeInstalled(t *testing.T) {
+	if _, err := exec.LookPath("claude"); err != nil {
+		t.Skip("claude not installed, skipping installed-path test")
+	}
+
+	check := NewClaudeBinaryCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+
+	result := check.Run(ctx)
+	// Non-hermetic: the installed claude may or may not meet minimum.
+	if result.Status == StatusError {
+		t.Errorf("unexpected StatusError when claude is installed: %s", result.Message)
+	}
+	if !strings.Contains(result.Message, "claude") {
+		t.Errorf("expected 'claude' in message, got %q", result.Message)
+	}
+}
+
+// writeFakeClaude creates a platform-appropriate fake "claude" executable in dir.
+func writeFakeClaude(t *testing.T, dir string, script string, batScript string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		path := filepath.Join(dir, "claude.bat")
+		if err := os.WriteFile(path, []byte(batScript), 0755); err != nil {
+			t.Fatal(err)
+		}
+	} else {
+		path := filepath.Join(dir, "claude")
+		if err := os.WriteFile(path, []byte(script), 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+}
+
+func TestClaudeBinaryCheck_HermeticSuccess(t *testing.T) {
+	fakeDir := t.TempDir()
+	writeFakeClaude(t, fakeDir,
+		fmt.Sprintf("#!/bin/sh\necho '%s (Claude Code)'\n", deps.RecommendedClaudeCodeVersion),
+		fmt.Sprintf("@echo off\r\necho %s (Claude Code)\r\n", deps.RecommendedClaudeCodeVersion),
+	)
+
+	t.Setenv("PATH", fakeDir)
+
+	check := NewClaudeBinaryCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+
+	result := check.Run(ctx)
+	switch result.Status {
+	case StatusOK:
+		if !strings.Contains(result.Message, deps.RecommendedClaudeCodeVersion) {
+			t.Errorf("expected version in message, got %q", result.Message)
+		}
+	case StatusWarning:
+		t.Logf("fake claude timed out under load (got StatusWarning); skipping assertion")
+	default:
+		t.Errorf("expected StatusOK, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestClaudeBinaryCheck_NotInPath(t *testing.T) {
+	emptyDir := t.TempDir()
+	t.Setenv("PATH", emptyDir)
+
+	check := NewClaudeBinaryCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+
+	result := check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when claude is not in PATH (optional dep), got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "not found") {
+		t.Errorf("expected 'not found' in message, got %q", result.Message)
+	}
+}
+
+func TestClaudeBinaryCheck_TooOld(t *testing.T) {
+	fakeDir := t.TempDir()
+	writeFakeClaude(t, fakeDir,
+		"#!/bin/sh\necho '1.0.62 (Claude Code)'\n",
+		"@echo off\r\necho 1.0.62 (Claude Code)\r\n",
+	)
+
+	t.Setenv("PATH", fakeDir)
+
+	check := NewClaudeBinaryCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+
+	result := check.Run(ctx)
+	switch result.Status {
+	case StatusWarning:
+		if !strings.Contains(result.Message, "below minimum") {
+			t.Errorf("expected 'below minimum' in message, got %q", result.Message)
+		}
+		if result.FixHint == "" {
+			t.Error("expected a fix hint with upgrade instructions")
+		}
+	default:
+		// Under heavy CI load the fake claude may time out; tolerate gracefully.
+		t.Logf("got status %v (may be CI load): %s", result.Status, result.Message)
+	}
+}
+
+func TestClaudeBinaryCheck_OldButOK(t *testing.T) {
+	fakeDir := t.TempDir()
+	writeFakeClaude(t, fakeDir,
+		"#!/bin/sh\necho '2.0.25 (Claude Code)'\n",
+		"@echo off\r\necho 2.0.25 (Claude Code)\r\n",
+	)
+
+	t.Setenv("PATH", fakeDir)
+
+	check := NewClaudeBinaryCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+
+	result := check.Run(ctx)
+	switch result.Status {
+	case StatusOK:
+		if !strings.Contains(result.Message, "upgrade") || !strings.Contains(result.Message, "recommended") {
+			t.Errorf("expected upgrade recommendation in message, got %q", result.Message)
+		}
+	case StatusWarning:
+		t.Logf("fake claude timed out under load (got StatusWarning); skipping assertion")
+	default:
+		t.Errorf("expected StatusOK with recommendation, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestClaudeBinaryCheck_Unparseable(t *testing.T) {
+	fakeDir := t.TempDir()
+	writeFakeClaude(t, fakeDir,
+		"#!/bin/sh\necho 'some garbage output'\n",
+		"@echo off\r\necho some garbage output\r\n",
+	)
+
+	t.Setenv("PATH", fakeDir)
+
+	check := NewClaudeBinaryCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning when version unparseable, got %v: %s", result.Status, result.Message)
+	}
+}


### PR DESCRIPTION
## Summary

- Researched all Claude Code features Gas Town depends on and determined minimum supported version is **v2.0.20** (Skills system), recommended **v2.1.3+** (unified skills/commands)
- Added `gt doctor` check (`claude-binary`) that warns when Claude Code is below minimum — treats not-found as OK since Claude Code is optional
- Updated `docs/INSTALLING.md` to specify `>= 2.0.20` instead of `latest`
- Added full research doc at `docs/design/claude-code-minimum-version.md` with feature dependency chain, version timeline, and fragile-dependency inventory

Ref: gt-9me

## Test plan

- [x] `go test ./internal/deps/...` — 7 tests pass (version parsing + integration)
- [x] `go test ./internal/doctor/ -run TestClaudeBinary` — 7 tests pass (hermetic + integration)
- [x] `go build ./...` — clean build
- [ ] Run `gt doctor` and verify `claude-binary` check appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)