### PR TITLE
fix: match custom agent paths in BuildCommandWithPrompt

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -842,19 +842,20 @@ func (rc *RuntimeConfig) BuildCommandWithPrompt(prompt string) string {
 
 	// OpenCode requires --prompt flag for initial prompt in interactive mode.
 	// Positional argument causes opencode to exit immediately.
-	if resolved.Command == "opencode" {
+	// Match both "opencode" and full paths like "/home/user/.opencode/bin/opencode".
+	if resolved.Command == "opencode" || filepath.Base(resolved.Command) == "opencode" {
 		return base + " --prompt " + quoteForShell(p)
 	}
 
-	// Copilot  requires -i flag for initial prompt in interactive mode.
-	if resolved.Command == "copilot" {
+	// Copilot requires -i flag for initial prompt in interactive mode.
+	if resolved.Command == "copilot" || filepath.Base(resolved.Command) == "copilot" {
 		return base + " -i " + quoteForShell(p)
 	}
 
 	// Gemini requires -i (--prompt-interactive) to auto-execute the prompt
 	// while staying in interactive mode. Positional args populate the input
 	// field but don't execute, and -p runs headless (exits after completion).
-	if resolved.Command == "gemini" {
+	if resolved.Command == "gemini" || filepath.Base(resolved.Command) == "gemini" {
 		return base + " -i " + quoteForShell(p)
 	}
 


### PR DESCRIPTION

## Summary
Custom agents (e.g., opencode-foo) might use full binary paths like /home/user/.opencode/bin/opencode instead of bare command names. The prompt-flag checks compared against bare names only, causing the prompt to be passed as a positional argument — which makes opencode exit immediately on startup.

Use filepath.Base() to also match full paths for opencode, copilot, and gemini prompt-flag detection.

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)
