### PR TITLE
fix: per-prompt mail check for pi and omp extension templates

### DIFF
--- a/internal/hooks/templates/omp/gastown-hook.ts
+++ b/internal/hooks/templates/omp/gastown-hook.ts
@@ -5,7 +5,7 @@
 //
 // Events mapped:
 //   session_start       → gt prime --hook (capture context)
-//   before_agent_start  → inject captured context into system prompt
+//   before_agent_start  → inject captured context + check mail every prompt
 //   session.compacting  → inject compaction recovery instructions
 //   tool_call           → gt tap guard pr-workflow (on git push/pr create)
 //   session_shutdown    → gt costs record
@@ -17,6 +17,7 @@ export default function (pi) {
   const autonomousRoles = new Set(["polecat", "witness", "refinery", "deacon"]);
   let primeContext = null;
   let contextInjected = false;
+  let lastMailCheck = 0;
 
   // SessionStart — run gt prime and capture context for injection.
   pi.on("session_start", async (event, ctx) => {
@@ -32,7 +33,7 @@ export default function (pi) {
       console.error("[gastown] gt prime failed:", e.message);
     }
 
-    // Check mail for autonomous roles.
+    // Check mail at session start for autonomous roles.
     if (autonomousRoles.has(role)) {
       try {
         const mailResult = await pi.exec("gt", ["mail", "check", "--inject"]);
@@ -44,24 +45,62 @@ export default function (pi) {
           }
           console.error("[gastown] mail context appended");
         }
+        lastMailCheck = Date.now();
       } catch (e) {
         console.error("[gastown] gt mail check failed:", e.message);
       }
     }
   });
 
-  // BeforeAgentStart — inject prime context into system prompt on first prompt.
+  // BeforeAgentStart — inject prime context + check mail every prompt.
   pi.on("before_agent_start", async (event, ctx) => {
+    let mailContext = null;
+
+    // Check mail on every prompt (throttled to once per 30s) for autonomous roles.
+    if (autonomousRoles.has(role)) {
+      const now = Date.now();
+      if (now - lastMailCheck >= 30000) {
+        lastMailCheck = now;
+        try {
+          const mailResult = await pi.exec("gt", ["mail", "check", "--inject"]);
+          if (mailResult.code === 0 && mailResult.stdout?.trim()) {
+            mailContext = mailResult.stdout.trim();
+            console.error("[gastown] mail check: new mail found");
+          }
+        } catch (e) {
+          console.error("[gastown] per-prompt mail check failed:", e.message);
+        }
+      }
+    }
+
+    // Inject prime context on first prompt.
     if (primeContext && !contextInjected) {
       contextInjected = true;
       console.error("[gastown] injecting prime context into session");
-      return {
+      const result = {
         message: {
           customType: "gastown-prime",
           content: primeContext,
           display: false,
         },
         systemPrompt: (event.systemPrompt || "") + "\n\n" + primeContext,
+      };
+      if (mailContext) {
+        result.systemPrompt += "\n\n" + mailContext;
+        result.message.content += "\n\n" + mailContext;
+      }
+      return result;
+    }
+
+    // After first prompt, inject mail if present.
+    if (mailContext) {
+      return {
+        message: {
+          customType: "gastown-mail",
+          content: mailContext,
+          display: false,
+        },
+        systemPrompt: (event.systemPrompt || "") + "\n\n" + mailContext,
       };
     }
   });

--- a/internal/hooks/templates/pi/gastown-hooks.js
+++ b/internal/hooks/templates/pi/gastown-hooks.js
@@ -1,18 +1,22 @@
-// Gas Town Pi Extension — Simple Mode (Claude hooks equivalent)
+// Gas Town Pi Extension — Enhanced (with per-prompt mail check)
 // Deploys the same lifecycle hooks as Claude's settings-autonomous.json
 // but using pi's extension API.
 //
 // Events mapped:
 //   session_start       → gt prime --hook (capture context)
-//   before_agent_start  → inject captured context into system prompt
+//   before_agent_start  → inject captured context + check mail every prompt
 //   tool_call           → gt tap guard pr-workflow (on git push/pr create)
 //   session_shutdown    → gt costs record
+//
+// Enhancement over upstream: mail is checked on every prompt (throttled to
+// 30s) via before_agent_start, matching Claude's UserPromptSubmit behavior.
 //
 // Loaded via: pi -e gastown-hooks.js
 
 export default (pi) => {
   let primeContext = null;
   let contextInjected = false;
+  let lastMailCheck = 0;
 
   // SessionStart — run gt prime and capture context for injection
   pi.on("session_start", async (event, context) => {
@@ -28,7 +32,7 @@ export default (pi) => {
       console.error("[gastown] gt prime failed:", e.message);
     }
 
-    // Check mail
+    // Check mail at session start
     try {
       const mailResult = await pi.exec("gt", ["mail", "check", "--inject"]);
       if (mailResult.code === 0 && mailResult.stdout.trim()) {
@@ -40,24 +44,59 @@ export default (pi) => {
         }
         console.error("[gastown] mail context appended");
       }
+      lastMailCheck = Date.now();
     } catch (e) {
       console.error("[gastown] gt mail check failed:", e.message);
     }
   });
 
-  // BeforeAgentStart — inject prime context into the session
+  // BeforeAgentStart — inject prime context + check mail every prompt
   pi.on("before_agent_start", async (event, context) => {
+    let mailContext = null;
+
+    // Check mail on every prompt (throttled to once per 30s)
+    const now = Date.now();
+    if (now - lastMailCheck >= 30000) {
+      lastMailCheck = now;
+      try {
+        const mailResult = await pi.exec("gt", ["mail", "check", "--inject"]);
+        if (mailResult.code === 0 && mailResult.stdout.trim()) {
+          mailContext = mailResult.stdout.trim();
+          console.error("[gastown] mail check: new mail found");
+        }
+      } catch (e) {
+        console.error("[gastown] per-prompt mail check failed:", e.message);
+      }
+    }
+
     // Inject prime context on first prompt
     if (primeContext && !contextInjected) {
       contextInjected = true;
       console.error("[gastown] injecting prime context into session");
-      return {
+      const result = {
         message: {
           customType: "gastown-prime",
           content: primeContext,
           display: false,
         },
         systemPrompt: event.systemPrompt + "\n\n" + primeContext,
+      };
+      if (mailContext) {
+        result.systemPrompt += "\n\n" + mailContext;
+        result.message.content += "\n\n" + mailContext;
+      }
+      return result;
+    }
+
+    // After first prompt, inject mail if present
+    if (mailContext) {
+      return {
+        message: {
+          customType: "gastown-mail",
+          content: mailContext,
+          display: false,
+        },
+        systemPrompt: event.systemPrompt + "\n\n" + mailContext,
       };
     }
   });


### PR DESCRIPTION
## Summary

- The pi (`gastown-hooks.js`) and omp (`gastown-hook.ts`) templates only check mail at `session_start`, so agents miss mail sent during their session
- Claude agents get per-prompt mail via the `UserPromptSubmit` hook — pi and omp agents had no equivalent
- This adds a throttled (30s) mail check to the `before_agent_start` event in both templates, matching Claude's behavior

## Changes

**pi** (`internal/hooks/templates/pi/gastown-hooks.js`):
- Added `lastMailCheck` state variable for throttling
- `session_start`: initializes `lastMailCheck` after the initial mail check
- `before_agent_start`: checks mail every 30s, injects new mail into both `systemPrompt` and as a hidden `gastown-mail` message

**omp** (`internal/hooks/templates/omp/gastown-hook.ts`):
- Same per-prompt mail check logic, preserving the existing `autonomousRoles` gating so only polecat/witness/refinery/deacon roles check mail
- Preserves omp-specific conventions (`?.` optional chaining, `(event.systemPrompt || "")`)

## Test plan

- [ ] Deploy patched extension to a pi agent workspace
- [ ] Send mail to the agent mid-session
- [ ] Verify agent receives mail within 30s on next prompt
- [ ] Verify no duplicate mail checks within the throttle window
- [ ] Verify session_start mail check still works as before
- [ ] Verify omp role gating — crew/mayor roles should NOT get per-prompt mail checks