### PR TITLE
fix: use use buildServerSQLCmd() instead of manually constructing the dolt sql command, matching the pattern used by all other internal callers.

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -2012,21 +2012,7 @@ func VerifyExpectedDatabasesAtConfig(config *Config, expected []string) (served,
 	var lastErr error
 	for attempt := 1; attempt <= 3; attempt++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		args := []string{
-			"sql",
-			"--host", config.EffectiveHost(),
-			"--port", strconv.Itoa(config.Port),
-			"--user", config.User,
-			"--no-tls",
-			"-r", "json",
-			"-q", "SHOW DATABASES",
-		}
-		cmd := exec.CommandContext(ctx, "dolt", args...)
-		cmd.Dir = config.DataDir
-		if config.Password != "" {
-			cmd.Env = append(os.Environ(), "DOLT_CLI_PASSWORD="+config.Password)
-		}
-
+		cmd := buildServerSQLCmd(ctx, config, "-r", "json", "-q", "SHOW DATABASES")
 		var stderrBuf bytes.Buffer
 		cmd.Stderr = &stderrBuf
 		output, queryErr := cmd.Output()


### PR DESCRIPTION

## Summary
use buildServerSQLCmd() instead of manually constructing the dolt sql command, matching the pattern used by all other internal callers.
Without this, dolt prompts interactively for a password when no password is configured (the default for local servers). Since the subprocess has no TTY, it hangs until timeout, causing gt doctor to falsely report 'database verification failed' even when the server is healthy

## Related Issue
N/A

## Changes
- use buildServerSQLCmd() consistently

## Testing
- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)
