### PR TITLE
ci(release): verify git tag matches Version constant (gh#3459)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,9 @@ jobs:
             exit 1
           fi
 
+      - name: Verify tag matches Version constant
+        run: make check-version-tag
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@ec59f474b9834571250b370d4735c50f8e2d1e29 # v7
         with:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -154,6 +154,17 @@ For packages with many Dolt-dependent tests, prefer adding
 `testutil.EnsureDoltContainerForTestMain()` in a `TestMain` function so all
 tests in the package share a single container.
 
+## Releasing
+
+Releases are cut from tags of the form `vX.Y.Z`. See [RELEASING.md](RELEASING.md)
+for the full workflow. One guardrail to know about:
+
+- `make check-version-tag` verifies the `Version` constant in
+  `internal/cmd/version.go` matches the tag at HEAD. The release workflow runs
+  this before GoReleaser and fails the release on mismatch. Prevents recurrence
+  of [#3459](https://github.com/steveyegge/gastown/issues/3459). Run it locally
+  after bumping if you want to catch drift before pushing the tag.
+
 ## Questions?
 
 Open an issue for questions about contributing. We're happy to help!

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build desktop-build desktop-run install safe-install check-forward-only clean test test-e2e-container check-up-to-date
+.PHONY: build desktop-build desktop-run install safe-install check-forward-only check-version-tag clean test test-e2e-container check-up-to-date
 
 BINARY := gt
 BINARY_DESKTOP := gt-desktop
@@ -135,6 +135,36 @@ safe-install: check-up-to-date check-forward-only build
 	done
 	@echo "Installed $(BINARY) to $(INSTALL_DIR)/$(BINARY) (daemon NOT restarted)"
 	@echo "Sessions will pick up new binary on next cycle."
+
+# check-version-tag: Verify that if HEAD is tagged vX.Y.Z, the Version constant
+# in internal/cmd/version.go equals X.Y.Z. No-op when HEAD is untagged, so it is
+# safe to run on every build but only fails release tag checkouts.
+# Prevents recurrence of gh#3459 (v0.13.0 shipped reporting 0.12.1).
+check-version-tag:
+	@TAG=$$(git describe --tags --exact-match HEAD 2>/dev/null || true); \
+	if [ -z "$$TAG" ]; then \
+		echo "check-version-tag: HEAD is not a release tag, skipping"; \
+		exit 0; \
+	fi; \
+	case "$$TAG" in \
+		v[0-9]*) TAG_VERSION=$${TAG#v} ;; \
+		*) echo "check-version-tag: tag '$$TAG' is not a vX.Y.Z release tag, skipping"; exit 0 ;; \
+	esac; \
+	CODE_VERSION=$$(grep -E '^[[:space:]]*Version[[:space:]]*=[[:space:]]*"' internal/cmd/version.go | head -1 | sed 's/.*"\([^"]*\)".*/\1/'); \
+	if [ -z "$$CODE_VERSION" ]; then \
+		echo "ERROR: could not parse Version from internal/cmd/version.go"; \
+		exit 1; \
+	fi; \
+	if [ "$$TAG_VERSION" != "$$CODE_VERSION" ]; then \
+		echo "ERROR: version mismatch between git tag and Version constant"; \
+		echo "  git tag at HEAD:          $$TAG (expects Version=$$TAG_VERSION)"; \
+		echo "  internal/cmd/version.go:  Version=$$CODE_VERSION"; \
+		echo ""; \
+		echo "Run scripts/bump-version.sh before tagging, or re-tag HEAD correctly."; \
+		echo "See gh#3459 for background."; \
+		exit 1; \
+	fi; \
+	echo "check-version-tag: OK (tag $$TAG matches Version=$$CODE_VERSION)"
 
 clean:
 	rm -f $(BUILD_DIR)/$(BINARY)

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -51,10 +51,26 @@ gt daemon stop && gt daemon start
 
 The `release.yml` workflow triggers automatically:
 
-1. **goreleaser** job builds binaries for all platforms and creates the GitHub Release
-2. **publish-npm** job publishes to npm (best-effort, `continue-on-error: true`)
+1. **Verify tag matches Version constant** — runs `make check-version-tag` and
+   aborts the release if the pushed tag (`vX.Y.Z`) doesn't match the `Version`
+   constant in `internal/cmd/version.go`. Prevents recurrence of
+   [#3459](https://github.com/steveyegge/gastown/issues/3459) where v0.13.0
+   shipped reporting 0.12.1.
+2. **goreleaser** job builds binaries for all platforms and creates the GitHub Release
+3. **publish-npm** job publishes to npm (best-effort, `continue-on-error: true`)
 
 Homebrew is NOT updated by the workflow. See below.
+
+### Running the tag/version check locally
+
+```bash
+make check-version-tag
+```
+
+The target is a no-op on untagged HEADs, so it's safe to run on any checkout.
+It only fails when HEAD is tagged `vX.Y.Z` and the `Version` constant doesn't
+match. Run it after `scripts/bump-version.sh` and before pushing the tag if you
+want to catch drift before CI does.
 
 ## Homebrew (homebrew-core)
 


### PR DESCRIPTION
## Summary
Adds a release hygiene check that fails when the git tag being released doesn't match the `Version` constant in the source. Prevents recurrence of gh#3459 where v0.13.0 shipped reporting 0.12.1.

## Context
Dispatched by mayor as part of release-gate **hq-j6hur** (minor bump blockers). Polecat: gastown/nux.

Opened by mayor because polecat pushed branch but didn't open the PR (matches gh#3603 — polecat/refinery PR-flow failure, tracked in hq-j6hur.3).

Fixes #3459