### PR TITLE
fix(npm): release HTTPS response stream in postinstall downloadFile (gh#3595)

### DIFF
--- a/npm-package/scripts/postinstall.js
+++ b/npm-package/scripts/postinstall.js
@@ -83,8 +83,15 @@ function downloadFile(url, dest) {
 
       file.on('finish', () => {
         file.close((err) => {
-          if (err) reject(err);
-          else resolve();
+          if (err) {
+            reject(err);
+            return;
+          }
+          // On Windows, the HTTPS response stream still holds a file handle
+          // lock after the write stream closes. If we don't destroy it here,
+          // PowerShell's Expand-Archive can't open the ZIP for extraction.
+          response.destroy();
+          resolve();
         });
       });
     });


### PR DESCRIPTION
## Summary
Closes the HTTPS response stream in `postinstall.js` `downloadFile()` before rename, fixing the file-handle leak that prevented zip extraction on Windows.

## Scope
Partial fix for hq-j6hur.6 (install/build breakage). Covers:
- [x] gh#3595 — npm postinstall file-handle leak (Windows)
- [ ] gh#3451 — brew HEAD gastown on Linux (follow-up)
- [ ] gh#3502 — Docker build (follow-up)

## Context
Dispatched by mayor as part of release-gate **hq-j6hur**. Polecat: gastown/slit.

Opened by mayor because polecat pushed branch but did not open the PR (matches gh#3603, tracked in hq-j6hur.3).

Fixes #3595
