### PR TITLE
fix(docker): bump Go version to 1.25.8 (gh#3502)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # docker build -t gastown:latest -f Dockerfile .
 FROM docker/sandbox-templates:claude-code
 
-ARG GO_VERSION=1.25.6
+ARG GO_VERSION=1.25.8
 
 USER root
 


### PR DESCRIPTION
## Summary
- Bumps `ARG GO_VERSION` in `Dockerfile` from `1.25.6` to `1.25.8` so the Docker build satisfies `go.mod` (Gas Town requires `go 1.25.8`, beads@v0.63.3 also requires `>=1.25.8`).

Fixes #3502.

## Why
Reporter (#3502) hit:
```
go: github.com/steveyegge/beads@v0.63.3: module github.com/steveyegge/beads@v0.63.3 requires go >= 1.25.8 (running go 1.25.6)
```
`docker build` (or `docker compose up -d --build`) installs Go from the official tarball using `${GO_VERSION}`, which was pinned one patch below what `go.mod` now requires.

## Test plan
- [ ] `docker build -t gastown:latest -f Dockerfile .` completes through `make build`
- [ ] `go vet ./...` (run locally on the repo) — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)