### PR TITLE
Fix gt-pvx auto-save committing deletions of tracked files

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -288,7 +288,8 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			fmt.Printf("\n%s Uncommitted changes detected — auto-saving to prevent work loss\n", style.Bold.Render("⚠"))
 			fmt.Printf("  Files: %s\n\n", workStatus.String())
 
-			// Stage all changes (git add -A), then unstage overlay files (gt-p35).
+			// Stage all changes (git add -A), then unstage overlay/runtime files (gt-p35)
+			// and any deletions of tracked files (gt-pvx safety: never commit deletions).
 			if addErr := g.Add("-A"); addErr != nil {
 				style.PrintWarning("auto-commit: git add failed: %v — uncommitted work may be at risk", addErr)
 			} else {
@@ -300,6 +301,18 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 					if strings.Contains(string(claudeData), templates.PolecatLifecycleMarker) {
 						_ = g.ResetFiles("CLAUDE.md")
 					}
+				}
+				// Unstage runtime/ephemeral directories (mirrors checkpoint_dog exclusions).
+				for _, dir := range []string{".beads/", ".claude/", ".runtime/", "__pycache__/"} {
+					_ = g.ResetFiles(dir)
+				}
+				// Unstage deletions of tracked files. A safety-net auto-commit should
+				// preserve work (additions + modifications), never destroy it (deletions).
+				// This prevents the bug where a polecat's working tree has a missing
+				// tracked file (e.g. .beads/metadata.json) and the auto-save commits
+				// the deletion, breaking infrastructure for subsequent sessions.
+				if stagedDeletions, delErr := g.StagedDeletions(); delErr == nil && len(stagedDeletions) > 0 {
+					_ = g.ResetFiles(stagedDeletions...)
 				}
 				// Build a descriptive commit message
 				autoMsg := "fix: auto-save uncommitted implementation work (gt-pvx safety net)"

--- a/internal/daemon/checkpoint_dog.go
+++ b/internal/daemon/checkpoint_dog.go
@@ -143,6 +143,20 @@ func (d *Daemon) checkpointWorktree(workDir, rigName, polecatName string) bool {
 		_, _ = runGitCmd(workDir, "reset", "HEAD", "--", dir)
 	}
 
+	// Unstage deletions of tracked files. A checkpoint should preserve work
+	// (additions + modifications), never commit deletions of tracked files.
+	// This prevents the bug where a polecat's working tree has a missing
+	// tracked file and the checkpoint commits the deletion (gt-pvx fix).
+	if delOut, err := runGitCmd(workDir, "diff", "--cached", "--name-only", "--diff-filter=D"); err == nil {
+		if dels := strings.TrimSpace(delOut); dels != "" {
+			for _, f := range strings.Split(dels, "\n") {
+				if f != "" {
+					_, _ = runGitCmd(workDir, "reset", "HEAD", "--", f)
+				}
+			}
+		}
+	}
+
 	// Check if anything is staged after exclusions
 	diffOut, err := runGitCmd(workDir, "diff", "--cached", "--quiet")
 	if err == nil && strings.TrimSpace(diffOut) == "" {

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -555,6 +555,20 @@ func (g *Git) ResetFiles(paths ...string) error {
 	return err
 }
 
+// StagedDeletions returns the list of tracked files staged for deletion.
+// Used by auto-save to unstage deletions — safety nets should preserve work, not destroy it.
+func (g *Git) StagedDeletions() ([]string, error) {
+	out, err := g.run("diff", "--cached", "--name-only", "--diff-filter=D")
+	if err != nil {
+		return nil, err
+	}
+	trimmed := strings.TrimSpace(out)
+	if trimmed == "" {
+		return nil, nil
+	}
+	return strings.Split(trimmed, "\n"), nil
+}
+
 // ShowFile returns the contents of a file at a given ref (e.g., "origin/main:CLAUDE.md").
 // Returns empty string and no error if the file does not exist at that ref.
 func (g *Git) ShowFile(ref, path string) (string, error) {


### PR DESCRIPTION
## Summary

- Both auto-save mechanisms (`gt done` safety net and `checkpoint_dog`) use `git add -A` which stages deletions of tracked files
- A polecat whose working tree has a missing tracked file (e.g. `.beads/metadata.json`) gets that deletion auto-committed, breaking infrastructure for subsequent sessions
- Fix: after `git add -A`, unstage all staged deletions via `git diff --cached --name-only --diff-filter=D`
- Also adds runtime dir exclusions to `done.go` (`.beads/`, `.claude/`, `.runtime/`, `__pycache__/`) matching `checkpoint_dog`'s existing `runtimeExcludeDirs`

Fixes #3615

## Changes

- `internal/git/git.go` — new `StagedDeletions()` method
- `internal/cmd/done.go` — add runtime dir exclusions + deletion unstaging
- `internal/daemon/checkpoint_dog.go` — add deletion unstaging after existing runtime dir exclusions

## Design rationale

A safety-net auto-commit should preserve work (additions + modifications), never destroy it (deletions). Renames are unaffected — git detects them as `R` status, not `D`, even with content changes down to 75% similarity.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/git/...` passes
- [x] `go test ./internal/daemon/...` passes
- [x] Verified renames not caught by `--diff-filter=D` (tested at 100% and 75% similarity)
- [x] Verified complete file replacement (0% similarity) correctly unstages deletion, preserving the new file
- [ ] `go test ./internal/cmd/...` has pre-existing compile error in `compact_report_test.go` (unrelated)