### PR TITLE
fix: sort DiscoverRigs output for stable gt status --watch

### DIFF
--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -1,6 +1,7 @@
 package rig
 
 import (
+	"cmp"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -8,6 +9,7 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -147,6 +149,10 @@ func (m *Manager) DiscoverRigs() ([]*Rig, error) {
 		rigs = append(rigs, rig)
 	}
 
+	slices.SortFunc(rigs, func(a, b *Rig) int {
+		return cmp.Compare(a.Name, b.Name)
+	})
+
 	return rigs, nil
 }
 
@@ -253,16 +259,16 @@ func (m *Manager) loadRig(name string, entry config.RigEntry) (*Rig, error) {
 
 // AddRigOptions configures rig creation.
 type AddRigOptions struct {
-	Name            string   // Rig name (directory name)
-	GitURL          string   // Repository URL (fetch/pull)
-	PushURL         string   // Optional push URL (fork for read-only upstreams)
-	UpstreamURL     string   // Optional upstream URL (for fork workflows)
-	BeadsPrefix     string   // Beads issue prefix (defaults to derived from name)
-	LocalRepo       string   // Optional local repo for reference clones
-	DefaultBranch   string   // Default branch (defaults to auto-detected from remote)
-	SkipDoltCheck   bool     // Skip Dolt server availability check (for tests with mocked beads)
-	CloneFilter     string   // Git clone filter spec (e.g. "blob:none", "tree:0") for partial clones
-	SparseCheckout  []string // Sparse checkout paths (cone mode); empty means no sparse checkout
+	Name           string   // Rig name (directory name)
+	GitURL         string   // Repository URL (fetch/pull)
+	PushURL        string   // Optional push URL (fork for read-only upstreams)
+	UpstreamURL    string   // Optional upstream URL (for fork workflows)
+	BeadsPrefix    string   // Beads issue prefix (defaults to derived from name)
+	LocalRepo      string   // Optional local repo for reference clones
+	DefaultBranch  string   // Default branch (defaults to auto-detected from remote)
+	SkipDoltCheck  bool     // Skip Dolt server availability check (for tests with mocked beads)
+	CloneFilter    string   // Git clone filter spec (e.g. "blob:none", "tree:0") for partial clones
+	SparseCheckout []string // Sparse checkout paths (cone mode); empty means no sparse checkout
 }
 
 func resolveLocalRepo(path, gitURL string) (string, string) {

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -135,6 +135,43 @@ func TestDiscoverRigs(t *testing.T) {
 	}
 }
 
+func TestDiscoverRigs_SortedByName(t *testing.T) {
+	root, rigsConfig := setupTestTown(t)
+
+	// Register rigs in deliberately non-alphabetical order.
+	// Go map iteration is randomized, so without sorting the output
+	// order would be nondeterministic across runs.
+	names := []string{"zebra", "alpha", "middle", "beta"}
+	for _, name := range names {
+		createTestRig(t, root, name)
+		rigsConfig.Rigs[name] = config.RigEntry{
+			GitURL: "git@github.com:test/" + name + ".git",
+		}
+	}
+
+	manager := NewManager(root, rigsConfig, git.NewGit(root))
+
+	// Run multiple iterations to catch nondeterminism — a single pass
+	// could accidentally return sorted order from a random map.
+	for i := 0; i < 10; i++ {
+		rigs, err := manager.DiscoverRigs()
+		if err != nil {
+			t.Fatalf("DiscoverRigs (iter %d): %v", i, err)
+		}
+
+		if len(rigs) != len(names) {
+			t.Fatalf("iter %d: rigs count = %d, want %d", i, len(rigs), len(names))
+		}
+
+		want := []string{"alpha", "beta", "middle", "zebra"}
+		for j, rig := range rigs {
+			if rig.Name != want[j] {
+				t.Errorf("iter %d: rigs[%d].Name = %q, want %q", i, j, rig.Name, want[j])
+			}
+		}
+	}
+}
+
 func TestGetRig(t *testing.T) {
 	root, rigsConfig := setupTestTown(t)
 


### PR DESCRIPTION
## Summary

- `DiscoverRigs()` iterates a Go `map[string]config.RigEntry`, which has randomized iteration order — this caused rigs to jump positions on every `gt status --watch` refresh tick
- Sort the result slice alphabetically by name so display order is deterministic
- Fix pre-existing `gofmt` alignment in `AddRigOptions` struct

## Test plan

- [x] Added `TestDiscoverRigs_SortedByName` — registers 4 rigs in non-alphabetical order, runs 10 iterations to confirm deterministic sorted output
- [x] `go test ./internal/rig/` passes
- [x] `go vet ./internal/rig/` clean
- [x] `gofmt` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)