### PR TITLE
fix: preserve canonical rig beads identity on adopt

### DIFF
--- a/internal/cmd/beads_db_init_test.go
+++ b/internal/cmd/beads_db_init_test.go
@@ -304,9 +304,9 @@ func TestBeadsDbInitAfterClone(t *testing.T) {
 		}
 	})
 
-	t.Run("TrackedRepoWithNoIssuesFallsBackToDerivedPrefix", func(t *testing.T) {
-		// Test the fallback behavior: when a tracked beads repo has NO issues
-		// and NO --prefix is provided, gt rig add should derive prefix from rig name.
+	t.Run("TrackedRepoWithNoIssuesPreservesTrackedPrefix", func(t *testing.T) {
+		// Even without issues, config.yaml still carries the canonical prefix.
+		// Adopt should preserve that prefix so routes and metadata stay aligned.
 
 		townRoot := filepath.Join(tmpDir, "town-derived")
 
@@ -324,7 +324,7 @@ func TestBeadsDbInitAfterClone(t *testing.T) {
 		rigDir := filepath.Join(townRoot, "testrig")
 		createTrackedBeadsRepoWithNoIssues(t, rigDir, "original-prefix")
 
-		// Add rig WITHOUT --prefix - should derive from rig name "testrig"
+		// Add rig WITHOUT --prefix - should preserve the tracked prefix.
 		cmd = exec.Command(gtBinary, "rig", "add", "testrig", "--adopt", "--force")
 		cmd.Dir = townRoot
 		cmd.Env = append(os.Environ(), "HOME="+tmpDir)
@@ -333,7 +333,15 @@ func TestBeadsDbInitAfterClone(t *testing.T) {
 			t.Fatalf("gt rig add (no --prefix) failed: %v\nOutput: %s", err, output)
 		}
 
-		// Verify bd operations work - the key test is that the database was initialized
+		routesContent, err := os.ReadFile(filepath.Join(townRoot, ".beads", "routes.jsonl"))
+		if err != nil {
+			t.Fatalf("read routes.jsonl: %v", err)
+		}
+		if !strings.Contains(string(routesContent), `"prefix":"original-prefix-"`) {
+			t.Fatalf("routes.jsonl should contain original-prefix-, got:\n%s", routesContent)
+		}
+
+		// Verify bd operations work from the adopted rig using the preserved prefix.
 		cmd = exec.Command("bd", "--json", "-q", "create",
 			"--type", "task", "--title", "test-derived-prefix")
 		cmd.Dir = rigDir
@@ -349,12 +357,9 @@ func TestBeadsDbInitAfterClone(t *testing.T) {
 			t.Fatalf("parse output: %v", err)
 		}
 
-		// The ID should have SOME prefix (derived from "testrig")
-		// We don't care exactly what it is, just that bd works
-		if result.ID == "" {
-			t.Error("expected non-empty issue ID")
+		if !strings.HasPrefix(result.ID, "original-prefix-") {
+			t.Fatalf("expected original-prefix- prefix, got %s", result.ID)
 		}
-		t.Logf("Created issue with derived prefix: %s", result.ID)
 	})
 
 	t.Run("MissingMetadataTriggersReInit", func(t *testing.T) {

--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -296,31 +296,31 @@ Examples:
 
 // Flags
 var (
-	rigAddPrefix       string
-	rigAddLocalRepo    string
-	rigAddBranch       string
-	rigAddPushURL      string
-	rigAddUpstreamURL  string
-	rigAddAdopt           bool
+	rigAddPrefix         string
+	rigAddLocalRepo      string
+	rigAddBranch         string
+	rigAddPushURL        string
+	rigAddUpstreamURL    string
+	rigAddAdopt          bool
 	rigAddAdoptURL       string
 	rigAddAdoptForce     bool
 	rigAddFilter         string
 	rigAddSparseCheckout []string
-	rigResetHandoff    bool
-	rigResetMail       bool
-	rigResetStale      bool
-	rigResetDryRun     bool
-	rigResetRole       string
-	rigShutdownForce   bool
-	rigShutdownNuclear bool
-	rigRebootForce     bool
-	rigRebootNuclear   bool
-	rigStopForce       bool
-	rigStopNuclear     bool
-	rigRestartForce    bool
-	rigRestartNuclear  bool
-	rigListJSON        bool
-	rigRemoveForce     bool
+	rigResetHandoff      bool
+	rigResetMail         bool
+	rigResetStale        bool
+	rigResetDryRun       bool
+	rigResetRole         string
+	rigShutdownForce     bool
+	rigShutdownNuclear   bool
+	rigRebootForce       bool
+	rigRebootNuclear     bool
+	rigStopForce         bool
+	rigStopNuclear       bool
+	rigRestartForce      bool
+	rigRestartNuclear    bool
+	rigListJSON          bool
+	rigRemoveForce       bool
 )
 
 var (
@@ -2477,6 +2477,42 @@ func commitTownConfigChanges(townRoot, rigName string) {
 			fmt.Fprintf(os.Stderr, "  Warning: could not commit town config files: %v\n", err)
 		}
 	}
+}
+
+// finalizeBeadsAfterInit performs the post-InitBeads steps needed to connect
+// beads to the correct Dolt database. InitBeads creates a database named
+// beads_<prefix>, but the rig uses <rigName> as its database. This corrects
+// the metadata, drops the orphan database, and re-sets config on the right DB.
+//
+// The AddRig path in manager.go already does these steps inline. The adopt
+// path was missing them, causing bd to fail with "database not found".
+func finalizeBeadsAfterInit(townRoot, rigPath, prefix, rigName string) {
+	// Correct metadata.json: dolt_database must be <rigName>, not beads_<prefix>.
+	if err := doltserver.EnsureMetadata(townRoot, rigName); err != nil {
+		fmt.Printf("  Warning: Could not set Dolt server metadata: %v\n", err)
+		fmt.Printf("  Run 'gt doctor --fix' to repair, or it will self-heal on next daemon start.\n")
+	}
+
+	// Drop orphaned beads_<prefix> database if it differs from rigName.
+	if orphanDB := "beads_" + prefix; orphanDB != rigName {
+		_ = doltserver.RemoveDatabase(townRoot, orphanDB, true)
+	}
+
+	// Re-set issue_prefix and types.custom on the correct database.
+	resolvedBeadsDir := beads.ResolveBeadsDir(rigPath)
+	env := beads.BoundEnv(os.Environ(), resolvedBeadsDir)
+
+	prefixCmd := exec.Command("bd", "config", "set", "issue_prefix", prefix)
+	prefixCmd.Dir = rigPath
+	prefixCmd.Env = env
+	if out, err := prefixCmd.CombinedOutput(); err != nil {
+		fmt.Printf("  Warning: Could not set issue_prefix on rig database: %v (%s)\n", err, strings.TrimSpace(string(out)))
+	}
+
+	typesCmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
+	typesCmd.Dir = rigPath
+	typesCmd.Env = env
+	_, _ = typesCmd.CombinedOutput()
 }
 
 // isGitRemoteURL returns true if s looks like a remote git URL rather than a

--- a/internal/cmd/rig_adopt_beads_test.go
+++ b/internal/cmd/rig_adopt_beads_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -76,7 +78,7 @@ func TestRigAdoptBeadsCandidateDetection(t *testing.T) {
 // and a prefix is available, the fallback init path is triggered.
 func TestRigAdoptFallbackInitNeeded(t *testing.T) {
 	tests := []struct {
-		name       string
+		name         string
 		hasDotBeads  bool
 		hasPrefix    bool
 		wantFallback bool
@@ -117,5 +119,65 @@ func TestRigAdoptFallbackInitNeeded(t *testing.T) {
 					needsFallback, tt.wantFallback, foundBeadsCandidate, beadsPrefix)
 			}
 		})
+	}
+}
+
+func TestFinalizeBeadsAfterInitUsesBoundEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake bd stub is bash-only")
+	}
+
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "demo")
+	beadsDir := filepath.Join(rigPath, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"backend":"dolt","database":"dolt","dolt_mode":"server","dolt_database":"wrongdb"}`), 0644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	logPath := filepath.Join(t.TempDir(), "bd-env.log")
+	binDir := t.TempDir()
+	bdPath := filepath.Join(binDir, "bd")
+	script := `#!/usr/bin/env bash
+set -e
+printf '%s|%s|%s\n' "${BEADS_DIR:-<unset>}" "${BEADS_DB:-<unset>}" "${BEADS_DOLT_SERVER_DATABASE:-<unset>}" >> "$BD_ENV_LOG"
+exit 0
+`
+	if err := os.WriteFile(bdPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_ENV_LOG", logPath)
+	t.Setenv("BEADS_DIR", "/wrong/.beads")
+	t.Setenv("BEADS_DB", "wrong")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "wrongdb")
+
+	finalizeBeadsAfterInit(townRoot, rigPath, "dp", "demo")
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read env log: %v", err)
+	}
+	lines := strings.Split(strings.TrimSpace(string(logData)), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 bd config calls, got %d (%q)", len(lines), string(logData))
+	}
+	for _, line := range lines {
+		parts := strings.Split(line, "|")
+		if len(parts) != 3 {
+			t.Fatalf("unexpected env log line %q", line)
+		}
+		if parts[0] != beadsDir {
+			t.Fatalf("BEADS_DIR = %q, want %q", parts[0], beadsDir)
+		}
+		if parts[1] != "<unset>" {
+			t.Fatalf("BEADS_DB = %q, want <unset>", parts[1])
+		}
+		if parts[2] != "demo" {
+			t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want %q", parts[2], "demo")
+		}
 	}
 }

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -1413,6 +1413,19 @@ func detectBeadsPrefixFromConfig(configPath string) string {
 	return ""
 }
 
+func detectExistingRigBeadsPrefix(rigPath string) string {
+	configCandidates := []string{
+		filepath.Join(rigPath, "mayor", "rig", ".beads", "config.yaml"),
+		filepath.Join(rigPath, ".beads", "config.yaml"),
+	}
+	for _, configPath := range configCandidates {
+		if prefix := detectBeadsPrefixFromConfig(configPath); prefix != "" {
+			return prefix
+		}
+	}
+	return ""
+}
+
 // RemoveRig unregisters a rig (does not delete files).
 func (m *Manager) RemoveRig(name string) error {
 	if !m.RigExists(name) {
@@ -1504,7 +1517,14 @@ func (m *Manager) RegisterRig(opts RegisterRigOptions) (*RegisterRigResult, erro
 		result.GitURL = opts.GitURL
 	}
 
-	// Derive beads prefix
+	// Prefer the tracked beads prefix when adopting an existing rig so routes,
+	// config, and database finalization all converge on the canonical identity.
+	if detectedPrefix := detectExistingRigBeadsPrefix(rigPath); detectedPrefix != "" {
+		if opts.BeadsPrefix != "" && strings.TrimSuffix(opts.BeadsPrefix, "-") != detectedPrefix {
+			return nil, fmt.Errorf("prefix mismatch: source repo uses '%s' but --prefix '%s' was provided", detectedPrefix, opts.BeadsPrefix)
+		}
+		result.BeadsPrefix = detectedPrefix
+	}
 	if result.BeadsPrefix == "" && opts.BeadsPrefix == "" {
 		result.BeadsPrefix = deriveBeadsPrefix(opts.Name)
 	}
@@ -1580,6 +1600,23 @@ func (m *Manager) RegisterRig(opts RegisterRigOptions) (*RegisterRigResult, erro
 		if saveErr := m.saveRigConfig(rigPath, existingConfig); saveErr != nil {
 			// Non-fatal: town.json has the value, but doctor may flag a mismatch
 			fmt.Fprintf(os.Stderr, "Warning: could not update config.json with push URL: %v\n", saveErr)
+		}
+	}
+
+	if existingConfig != nil {
+		needsSave := false
+		if existingConfig.Beads == nil {
+			existingConfig.Beads = &BeadsConfig{}
+			needsSave = true
+		}
+		if existingConfig.Beads.Prefix != result.BeadsPrefix {
+			existingConfig.Beads.Prefix = result.BeadsPrefix
+			needsSave = true
+		}
+		if needsSave {
+			if saveErr := m.saveRigConfig(rigPath, existingConfig); saveErr != nil {
+				fmt.Fprintf(os.Stderr, "Warning: could not update config.json with beads prefix: %v\n", saveErr)
+			}
 		}
 	}
 

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -1244,6 +1244,49 @@ func TestRegisterRig_LegacyConfigPreservesExistingPushURL(t *testing.T) {
 	_ = result
 }
 
+func TestRegisterRig_PrefersTrackedBeadsPrefixAndSyncsConfig(t *testing.T) {
+	root, rigsConfig := setupTestTown(t)
+	manager := NewManager(root, rigsConfig, git.NewGit(root))
+
+	rigName := "trackedrig"
+	rigPath := filepath.Join(root, rigName)
+	if err := os.MkdirAll(filepath.Join(rigPath, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigPath, ".beads", "config.yaml"), []byte("prefix: canonical-prefix\nissue-prefix: canonical-prefix\n"), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+
+	configData := `{"type":"rig","version":1,"name":"trackedrig","git_url":"","default_branch":"main","beads":{"prefix":"stale-prefix"}}`
+	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), []byte(configData), 0644); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+
+	result, err := manager.RegisterRig(RegisterRigOptions{Name: rigName, Force: true})
+	if err != nil {
+		t.Fatalf("RegisterRig: %v", err)
+	}
+	if result.BeadsPrefix != "canonical-prefix" {
+		t.Fatalf("BeadsPrefix = %q, want %q", result.BeadsPrefix, "canonical-prefix")
+	}
+
+	entry, ok := rigsConfig.Rigs[rigName]
+	if !ok {
+		t.Fatalf("rig entry %q missing from config", rigName)
+	}
+	if entry.BeadsConfig == nil || entry.BeadsConfig.Prefix != "canonical-prefix" {
+		t.Fatalf("rigs config prefix = %#v, want canonical-prefix", entry.BeadsConfig)
+	}
+
+	updatedConfig, err := LoadRigConfig(rigPath)
+	if err != nil {
+		t.Fatalf("LoadRigConfig: %v", err)
+	}
+	if updatedConfig.Beads == nil || updatedConfig.Beads.Prefix != "canonical-prefix" {
+		t.Fatalf("config.json prefix = %#v, want canonical-prefix", updatedConfig.Beads)
+	}
+}
+
 func TestEnsureMetadata_SetsRequiredFields(t *testing.T) {
 	// Verify that EnsureMetadata writes the fields that AddRig depends on:
 	// dolt_mode=server, dolt_database=<rigName>, backend=dolt


### PR DESCRIPTION
## Summary
- preserve canonical rig beads identity during rig adopt instead of leaving adopt paths pointed at orphaned beads databases
- add adopt-path regression coverage for beads candidate detection, fallback initialization, and bound-env finalization
- keep adopt finalization aligned with shared Dolt/beads bindings used by the non-adopt path
