### PR TITLE
fix: expose queued canary wisps in merge queue visibility

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -903,13 +903,33 @@ func (b *Beads) ListMergeRequests(opts ListOptions) ([]*Issue, error) {
 		return nil, err
 	}
 
-	// Build dedup map from issues
-	seen := make(map[string]bool, len(issueResults))
-	for _, issue := range issueResults {
-		seen[issue.ID] = true
+	// 2. Query wisps table via SQL for merge-request wisps with full data.
+	query := buildListMergeRequestsWispQuery(opts)
+	sqlOut, sqlErr := b.run("sql", "--json", query)
+	if sqlErr == nil && len(sqlOut) > 0 && isJSONBytes(sqlOut) {
+		var rows []mergeRequestWispRow
+		if jsonErr := json.Unmarshal(sqlOut, &rows); jsonErr == nil {
+			issueResults = appendMergeRequestWispRows(issueResults, rows)
+		}
 	}
 
-	// 2. Query wisps table via SQL for merge-request wisps with full data
+	return issueResults, nil
+}
+
+type mergeRequestWispRow struct {
+	ID          string `json:"id"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	Status      string `json:"status"`
+	Priority    int    `json:"priority"`
+	Assignee    string `json:"assignee"`
+	CreatedAt   string `json:"created_at"`
+	UpdatedAt   string `json:"updated_at"`
+	CreatedBy   string `json:"created_by"`
+	LabelsCSV   string `json:"labels_csv"`
+}
+
+func buildListMergeRequestsWispQuery(opts ListOptions) string {
 	statusFilter := "w.status = 'open'"
 	if opts.Status != "" && strings.EqualFold(opts.Status, "all") {
 		statusFilter = "1=1"
@@ -922,57 +942,55 @@ func (b *Beads) ListMergeRequests(opts ListOptions) ([]*Issue, error) {
 		labelFilter = fmt.Sprintf("l.label = '%s'", strings.ReplaceAll(opts.Label, "'", "''"))
 	}
 
-	query := fmt.Sprintf(
+	return fmt.Sprintf(
 		"SELECT w.id, w.title, w.description, w.status, w.priority, w.assignee, "+
 			"w.created_at, w.updated_at, w.created_by, "+
 			"GROUP_CONCAT(al.label) as labels_csv "+
 			"FROM wisps w "+
-			"JOIN wisp_labels l ON w.id = l.issue_id "+
-			"LEFT JOIN wisp_labels al ON w.id = al.issue_id "+
+			"JOIN (%s) l ON w.id = l.issue_id "+
+			"LEFT JOIN (%s) al ON w.id = al.issue_id "+
 			"WHERE %s AND %s "+
 			"GROUP BY w.id, w.title, w.description, w.status, w.priority, w.assignee, w.created_at, w.updated_at, w.created_by",
-		labelFilter, statusFilter)
+		mergeRequestWispLabelSourceQuery(), mergeRequestWispLabelSourceQuery(), labelFilter, statusFilter)
+}
 
-	sqlOut, sqlErr := b.run("sql", "--json", query)
-	if sqlErr == nil && len(sqlOut) > 0 && isJSONBytes(sqlOut) {
-		var rows []struct {
-			ID          string `json:"id"`
-			Title       string `json:"title"`
-			Description string `json:"description"`
-			Status      string `json:"status"`
-			Priority    int    `json:"priority"`
-			Assignee    string `json:"assignee"`
-			CreatedAt   string `json:"created_at"`
-			UpdatedAt   string `json:"updated_at"`
-			CreatedBy   string `json:"created_by"`
-			LabelsCSV   string `json:"labels_csv"`
-		}
-		if jsonErr := json.Unmarshal(sqlOut, &rows); jsonErr == nil {
-			for _, row := range rows {
-				if seen[row.ID] {
-					continue
-				}
-				issue := &Issue{
-					ID:          row.ID,
-					Title:       row.Title,
-					Description: row.Description,
-					Status:      row.Status,
-					Priority:    row.Priority,
-					Assignee:    row.Assignee,
-					CreatedAt:   row.CreatedAt,
-					UpdatedAt:   row.UpdatedAt,
-					CreatedBy:   row.CreatedBy,
-					Ephemeral:   true,
-				}
-				if row.LabelsCSV != "" {
-					issue.Labels = strings.Split(row.LabelsCSV, ",")
-				}
-				issueResults = append(issueResults, issue)
-			}
-		}
+func appendMergeRequestWispRows(issueResults []*Issue, rows []mergeRequestWispRow) []*Issue {
+	seen := make(map[string]bool, len(issueResults))
+	for _, issue := range issueResults {
+		seen[issue.ID] = true
 	}
 
-	return issueResults, nil
+	for _, row := range rows {
+		if seen[row.ID] {
+			continue
+		}
+		issue := &Issue{
+			ID:          row.ID,
+			Title:       row.Title,
+			Description: row.Description,
+			Status:      row.Status,
+			Priority:    row.Priority,
+			Assignee:    row.Assignee,
+			CreatedAt:   row.CreatedAt,
+			UpdatedAt:   row.UpdatedAt,
+			CreatedBy:   row.CreatedBy,
+			Ephemeral:   true,
+		}
+		if row.LabelsCSV != "" {
+			issue.Labels = strings.Split(row.LabelsCSV, ",")
+		}
+		issueResults = append(issueResults, issue)
+		seen[row.ID] = true
+	}
+
+	return issueResults
+}
+
+func mergeRequestWispLabelSourceQuery() string {
+	// Some legacy/validation-created wisps still carry labels in the shared
+	// issues labels table instead of wisp_labels. Query both so queue visibility
+	// does not depend on which auxiliary label table the writer used.
+	return "SELECT issue_id, label FROM wisp_labels UNION SELECT issue_id, label FROM labels"
 }
 
 // ListByAssignee returns all issues assigned to a specific assignee.

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -148,6 +148,57 @@ func TestBdSupportsAllowStale_ReprobesWhenBinaryPathChanges(t *testing.T) {
 	}
 }
 
+func TestBuildListMergeRequestsWispQuery_UsesLegacyAndWispLabels(t *testing.T) {
+	query := buildListMergeRequestsWispQuery(ListOptions{Label: "gt:merge-request", Status: "open"})
+
+	if !strings.Contains(query, "SELECT issue_id, label FROM wisp_labels UNION SELECT issue_id, label FROM labels") {
+		t.Fatalf("query missing legacy+wisp label source: %s", query)
+	}
+	if !strings.Contains(query, "l.label = 'gt:merge-request'") {
+		t.Fatalf("query missing merge-request label filter: %s", query)
+	}
+	if !strings.Contains(query, "w.status = 'open'") {
+		t.Fatalf("query missing open status filter: %s", query)
+	}
+}
+
+func TestAppendMergeRequestWispRows_IncludesCanaryAndNormalWisps(t *testing.T) {
+	issues := appendMergeRequestWispRows(nil, []mergeRequestWispRow{
+		{
+			ID:          "mr-normal",
+			Title:       "Merge: normal",
+			Description: "branch: polecat/normal/gt-001\ntarget: main\nrig: test-rig",
+			Status:      "open",
+			Priority:    1,
+			LabelsCSV:   "gt:merge-request",
+		},
+		{
+			ID:          "mr-canary",
+			Title:       "Merge: mq visibility canary",
+			Description: "branch: polecat/canary/gt-canary\ntarget: main\nrig: test-rig",
+			Status:      "open",
+			Priority:    1,
+			LabelsCSV:   "gt:merge-request",
+		},
+	})
+
+	if len(issues) != 2 {
+		t.Fatalf("appendMergeRequestWispRows() returned %d issues, want 2", len(issues))
+	}
+
+	got := map[string]*Issue{}
+	for _, issue := range issues {
+		got[issue.ID] = issue
+	}
+
+	if got["mr-normal"] == nil || !got["mr-normal"].Ephemeral {
+		t.Fatalf("normal MR wisp missing or not marked ephemeral: %#v", got["mr-normal"])
+	}
+	if got["mr-canary"] == nil || !got["mr-canary"].Ephemeral {
+		t.Fatalf("canary MR wisp missing or not marked ephemeral: %#v", got["mr-canary"])
+	}
+}
+
 // writeAllowStaleBDStub creates a mock bd binary in dir.
 //
 // The detection function (BdSupportsAllowStaleWithEnv) ignores the exit code


### PR DESCRIPTION
## Summary
- surface queued canary wisps in merge queue visibility so preserved submission state is easier to inspect and recover
- extend beads visibility logic and tests around queued canary entries
- improve debugging for auth-blocked or preserved merge-queue submissions
