### PR TITLE
fix(beads): use --repo instead of --rig for bd create

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -298,7 +298,7 @@ type CreateOptions struct {
 	Parent      string
 	Actor       string // Who is creating this issue (populates created_by)
 	Ephemeral   bool   // Create as ephemeral (wisp) - not synced to git
-	Rig         string // Target rig database (e.g., "gastown"). When set, passes --rig to bd create.
+	Rig         string // Target rig database (e.g., "gastown"). When set, passes --repo to bd create.
 }
 
 // UpdateOptions specifies options for updating an issue.
@@ -1227,7 +1227,7 @@ func (b *Beads) Create(opts CreateOptions) (*Issue, error) {
 		args = append(args, "--ephemeral")
 	}
 	if opts.Rig != "" {
-		args = append(args, "--rig="+opts.Rig)
+		args = append(args, "--repo="+opts.Rig)
 	}
 	// Default Actor from BD_ACTOR env var if not specified
 	// Uses getActor() to respect isolated mode (tests)


### PR DESCRIPTION
## Summary
- `bd` v1.0.0 renamed the `--rig` flag to `--repo` on `bd create`.
- gt still passes `--rig=<name>`, which fails with \`unknown flag: --rig\` and breaks \`gt done\` MR bead creation.
- Symptom in the wild: polecat's branch is pushed to origin, but no MR bead is created, so the Refinery never sees the merge request and the work is stranded until manual recovery.
- One-line flag rename in \`internal/beads/beads.go\` + comment update.

Caught in the wild on \`hosting-config\` rig today — two polecat PRs (\`#1\`, \`#2\` in work2fly/hosting-config) both hit this and had to be opened manually.

## Test plan
- [x] \`go build ./internal/beads/\` passes
- [x] Rebuilt gt locally (\`v1.0.0-74-g677877bf-dirty\`) and verified future \`gt done\` invocations use \`--repo=\`
- [ ] CI green

## Follow-ups (not in this PR)
- \`internal/daemon/daemon.go:2632\` also invokes \`bd list --rig=…\`, but bd list has neither \`--rig\` nor \`--repo\` — separate bug, different code path.
- bd v1.0.0 schema is missing the \`convoy\` issue type, so \`gt sling\`'s auto-convoy creation fails with \`invalid issue type "convoy"\`.