### PR TITLE
fix(plugins): replace mapfile with while-read for bash 3.2 compat

### DIFF
--- a/plugins/dolt-archive/run.sh
+++ b/plugins/dolt-archive/run.sh
@@ -66,7 +66,10 @@ dolt_query_json() {
 
 # Auto-discover production databases or use the explicit list.
 if [[ "$DEFAULT_DBS" == "auto" ]]; then
-  mapfile -t PROD_DBS < <(
+  PROD_DBS=()
+  while IFS= read -r line; do
+    PROD_DBS+=("$line")
+  done < <(
     dolt_query "" "SHOW DATABASES" \
       | grep -v -E '^(information_schema|mysql|dolt_cluster)$' \
       | grep -v -E '^(testdb_|beads_t|beads_pt|doctest_)'

--- a/plugins/dolt-backup/run.sh
+++ b/plugins/dolt-backup/run.sh
@@ -46,7 +46,10 @@ log() {
 if [[ -n "$EXPLICIT_DBS" ]]; then
   IFS=',' read -ra PROD_DBS <<< "$EXPLICIT_DBS"
 else
-  mapfile -t PROD_DBS < <(
+  PROD_DBS=()
+  while IFS= read -r line; do
+    PROD_DBS+=("$line")
+  done < <(
     for d in "$DOLT_DATA_DIR"/*/; do
       name="$(basename "$d")"
       [[ -d "$d/.dolt" ]] || continue


### PR DESCRIPTION
## Summary

- `plugins/dolt-archive/run.sh:69` and `plugins/dolt-backup/run.sh:49` use `mapfile`, a bash 4.0 builtin, so both scripts exit 127 on macOS (system bash 3.2.57). The JSONL recovery layer and the `dolt backup sync` runner silently stop working on macOS patrol.
- Replaces `mapfile -t ARR < <(...)` with the bash 3.2-compatible `ARR=(); while IFS= read -r line; do ARR+=(\"\$line\"); done < <(...)` pattern already used elsewhere in the same files.
- Fixes #3635.

## Why this regressed

This exact fix was applied twice before (4c5f269e, e297e732) and regressed in **4d63c184** (*fix(plugins): auto-discover databases instead of hardcoded list*). That commit reintroduced `mapfile` while rewriting the DB-discovery path. Linux CI doesn't catch it because bash 4+ is the default there; macOS users hit it on every patrol tick.

The bug is **gated** by the auto-discovery branch — if you invoke with `--databases foo,bar` it takes the `IFS=',' read -ra` path and works, which is probably why manual testing missed it.

## Test plan

- [x] Repro against `upstream/main` HEAD `677877bf` on darwin25 / bash 3.2.57(1): both scripts exit 127 with `mapfile: command not found`.
- [x] After patch, `./plugins/dolt-archive/run.sh --skip-git --skip-dolt-push` auto-discovers 16 production DBs and exports JSONL to completion.
- [x] After patch, `./plugins/dolt-backup/run.sh --dry-run` auto-discovers 16 production DBs and completes the dry-run loop (exit 0).
- [x] `bash -n` syntax check passes on both files.
- [ ] Reviewer: re-run under Linux CI to confirm no regression on bash 4+ (pattern is portable; no change in semantics).

## Suggested follow-up (not in this PR)

Add a `bash -n` / `shellcheck --shell=bash` CI job (or a macOS runner) for `plugins/*/run.sh` so this regression can't land a fourth time.