### PR TITLE
fix: hand TTY to tmux via syscall.Exec in `gt session at`

### DIFF
--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -336,8 +336,18 @@ func runSessionAttach(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Attach (this replaces the process)
-	return polecatMgr.Attach(polecatName)
+	running, err := polecatMgr.IsRunning(polecatName)
+	if err != nil {
+		return fmt.Errorf("checking session: %w", err)
+	}
+	if !running {
+		return polecat.ErrSessionNotFound
+	}
+
+	// Hand the terminal off to tmux via syscall.Exec so tmux inherits our
+	// controlling TTY directly. Running tmux as a subprocess with buffered
+	// stdio triggers "open terminal failed: not a terminal".
+	return attachToTmuxSession(polecatMgr.SessionName(polecatName))
 }
 
 // SessionListItem represents a session in list output.


### PR DESCRIPTION
## Summary

`gt session at <rig>/<polecat>` fails on macOS with:

```
Error: tmux attach-session: open terminal failed: not a terminal
```

Meanwhile `tmux attach -t <session>` directly works fine.

## Root cause

`runSessionAttach` in `internal/cmd/session.go` calls `polecatMgr.Attach` → `tmux.AttachSession` → `t.run()`, which invokes tmux via `exec.Command(...).Run()` with **buffered stdout/stderr** (`cmd.Stdout = &bytes.Buffer{}`, `cmd.Stderr = &bytes.Buffer{}`). tmux's `attach-session` requires its standard streams to be a TTY; it sees pipes instead and prints `open terminal failed: not a terminal`.

Every other attach path in the tree (`crew at`, `handoff`, `mayor at`, `witness at`, `refinery at`, `deacon at`) already routes through `attachToTmuxSession()` in `internal/cmd/helpers_unix.go`, which uses `syscall.Exec` to replace the gt process with tmux, letting tmux inherit the parent shell's controlling terminal directly. `session at` was the outlier.

## Fix

Route `runSessionAttach` through the same `attachToTmuxSession()` helper. Preserves the existing `ErrSessionNotFound` behavior via `polecatMgr.IsRunning`. Windows is covered by the existing stdio-passthrough implementation in `helpers_windows.go`.

## Test plan

- [x] `make build` succeeds
- [x] Reproduced with installed gt: `script -q /dev/null bash -c 'gt session at opcli/jasper'` → `Error: tmux attach-session: open terminal failed: not a terminal`
- [x] Fixed binary under same pty: attaches cleanly (exit 0)
- [x] `go test ./internal/polecat/... ./internal/tmux/...` pass
- [x] `go test ./internal/cmd/... -run TestSession` passes