### PR TITLE
Fix dolt CLI flag ordering in doctor check

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -2012,17 +2012,7 @@ func VerifyExpectedDatabasesAtConfig(config *Config, expected []string) (served,
 	var lastErr error
 	for attempt := 1; attempt <= 3; attempt++ {
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		args := []string{
-			"sql",
-			"--host", config.EffectiveHost(),
-			"--port", strconv.Itoa(config.Port),
-			"--user", config.User,
-			"--no-tls",
-			"-r", "json",
-			"-q", "SHOW DATABASES",
-		}
-		cmd := exec.CommandContext(ctx, "dolt", args...)
-		cmd.Dir = config.DataDir
+		cmd := buildDoltSQLCmd(ctx, config, "-r", "json", "-q", "SHOW DATABASES")
 		if config.Password != "" {
 			cmd.Env = append(os.Environ(), "DOLT_CLI_PASSWORD="+config.Password)
 		}


### PR DESCRIPTION
## Summary

- `VerifyExpectedDatabasesAtConfig` placed `--host`, `--port`, `--user`, and `--no-tls` after the `sql` subcommand, but dolt requires these as global flags before the subcommand
- This caused `gt doctor` to always fail the `dolt-server-reachable` check with `unknown option 'host'`
- Replaced the manually-constructed args with the existing `buildDoltSQLCmd` helper, which already handles flag ordering correctly (matching `VerifyDatabasesWithRetry` and `listDatabasesRemote`)

## Details

The bug only affects the `gt doctor` health check path — all operational code paths (`buildDoltSQLCmd`, `VerifyDatabasesWithRetry`, `listDatabasesRemote`) already use the correct flag ordering. The fix is a net deletion of 10 lines, replacing duplicated arg construction with the existing helper.

## Test plan

- [x] `go test ./internal/doctor/ -run TestDoltServer` — 3/3 pass
- [x] `go test ./internal/doltserver/ -run TestVerify` — 1/1 pass
- [x] `go vet ./internal/doltserver/ ./internal/doctor/` — clean
- [x] Built fixed binary and verified `gt doctor` passes `dolt-server-reachable` check end-to-end against a live Dolt server
- [x] Confirmed broken flag ordering (`dolt sql --host ...`) returns `unknown option 'host'`
- [x] Confirmed fixed flag ordering (`dolt --host ... sql ...`) succeeds
- [x] Full `go test ./...` run — all failures are pre-existing on `main` (e.g. `TestCrossPlatformBuild`, `TestBeadsRedirectTargetCheck_FixMetadataRepairFails`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)