### PR TITLE
fix(test): scheduler tests look for sling context across all rig dirs

### DIFF
--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -209,19 +209,23 @@ func createSlingContext(t *testing.T, hqPath string, fields *capacity.SlingConte
 	return ctxBead.ID
 }
 
-// findSlingContext finds an open sling context for a work bead in the HQ beads DB.
+// findSlingContext finds an open sling context for a work bead by scanning all
+// rig beads dirs under townRoot. Mirrors production's listAllSlingContexts since
+// sling contexts now live in the target rig's beads dir, not HQ (see dee628d3).
 // Returns nil if none found.
 func findSlingContext(t *testing.T, hqPath, workBeadID string) *capacity.SlingContextFields {
 	t.Helper()
-	townBeads := beads.NewWithBeadsDir(hqPath, filepath.Join(hqPath, ".beads"))
-	_, fields, err := townBeads.FindOpenSlingContext(workBeadID)
-	if err != nil {
-		t.Fatalf("FindOpenSlingContext(%s) failed: %v", workBeadID, err)
+	for _, ctx := range listAllSlingContexts(hqPath) {
+		fields := beads.ParseSlingContextFields(ctx.Description)
+		if fields != nil && fields.WorkBeadID == workBeadID {
+			return fields
+		}
 	}
-	return fields
+	return nil
 }
 
-// hasSlingContext checks if a work bead has an open sling context in HQ.
+// hasSlingContext checks if a work bead has an open sling context anywhere
+// under townRoot (HQ or any rig beads dir).
 func hasSlingContext(t *testing.T, hqPath, workBeadID string) bool {
 	t.Helper()
 	return findSlingContext(t, hqPath, workBeadID) != nil
@@ -456,14 +460,10 @@ func TestSchedulerSlingContextIdempotency(t *testing.T) {
 	slingToScheduler(t, gtBinary, hqPath, env, beadID, "testrig")
 	slingToScheduler(t, gtBinary, hqPath, env, beadID, "testrig")
 
-	// Verify: only one sling context exists
-	townBeads := beads.NewWithBeadsDir(hqPath, filepath.Join(hqPath, ".beads"))
-	contexts, err := townBeads.ListOpenSlingContexts()
-	if err != nil {
-		t.Fatalf("ListOpenSlingContexts failed: %v", err)
-	}
+	// Verify: only one sling context exists across all rig dirs
+	// (sling contexts live in the target rig's beads dir per dee628d3).
 	count := 0
-	for _, ctx := range contexts {
+	for _, ctx := range listAllSlingContexts(hqPath) {
 		fields := beads.ParseSlingContextFields(ctx.Description)
 		if fields != nil && fields.WorkBeadID == beadID {
 			count++


### PR DESCRIPTION
## Summary

After dee628d3 (April 1) moved the `gt sling` sling-context wisp creation from HQ's beads dir to the target rig's beads dir, four scheduler integration tests kept failing on main because the test helpers still looked only at HQ. Production code (`listAllSlingContexts`) already iterates `beadsSearchDirs(townRoot)` to aggregate contexts across rig dirs — this PR makes the test helpers do the same.

- `findSlingContext` now iterates `listAllSlingContexts(hqPath)` and filters by WorkBeadID.
- `TestSchedulerSlingContextIdempotency` inlined the same HQ-only lookup; it now uses `listAllSlingContexts` too.
- Docstrings updated to reflect multi-dir scan.

## Test plan

- [ ] CI Integration Tests job passes (the 4 scheduler tests should flip green):
  - `TestSchedulerAutoConvoyCreation`
  - `TestSchedulerSlingContextIdempotency`
  - `TestSchedulerMultiRigEpicAutoResolve`
  - `TestSchedulerMultiRigConvoyAutoResolve`
- [ ] `TestSchedulerSlingContextInvalidJSONCleanup` (which creates in HQ via `createSlingContext` and verifies cleanup in HQ) stays green — the test writes and reads HQ-local state, so HQ-only lookup is still correct there.

## Notes

This clears the last remaining integration-test failures on main after #3616 and #3628 landed (lint, Windows Smoke Test, TestIsRigParked, TestBuildDoltSQLCmd all fixed by those).

Co-Authored-By: Claude Opus 4.6 (1M context) &lt;noreply@anthropic.com&gt;
