### PR TITLE
fix(beads): route rig-targeted Create via cwd + BEADS_DIR (gh#3641)

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -482,6 +482,34 @@ func (b *Beads) run(args ...string) (_ []byte, retErr error) {
 	return stripStdoutWarnings(stdout.Bytes()), nil
 }
 
+// runInRig executes a bd command targeted at a specific rig's beads store.
+// This is a workaround for bd's --repo flag, which does not follow
+// .beads/redirect files. Rigs that store metadata.json behind a redirect
+// (e.g. <rig>/.beads/redirect → mayor/rig/.beads) hit "no database selected"
+// errors when bd falls back to embedded-dolt mode. Setting the subprocess
+// cwd to the rig directory triggers cwd-based discovery, which does follow
+// the redirect; we also set BEADS_DIR to the resolved path for belt-and-braces.
+func (b *Beads) runInRig(rigName string, args ...string) ([]byte, error) {
+	townRoot := b.getTownRoot()
+	if townRoot == "" {
+		return nil, fmt.Errorf("runInRig: cannot resolve town root from workDir %q", b.workDir)
+	}
+	rigPath := filepath.Join(townRoot, rigName)
+	resolved := ResolveBeadsDir(rigPath)
+	if resolved == "" {
+		return nil, fmt.Errorf("runInRig: cannot resolve beads dir for rig %q at %s", rigName, rigPath)
+	}
+	// Clone the wrapper with rig-targeted workDir + beadsDir so run() sets
+	// cmd.Dir and BEADS_DIR to the rig's resolved beads directory.
+	rigBeads := &Beads{
+		workDir:    rigPath,
+		beadsDir:   resolved,
+		isolated:   b.isolated,
+		serverPort: b.serverPort,
+	}
+	return rigBeads.run(args...)
+}
+
 // runWithRouting executes a bd command without setting BEADS_DIR, allowing bd's
 // native prefix-based routing via routes.jsonl to resolve cross-prefix beads.
 // This is needed for slot operations that reference beads with different prefixes
@@ -1226,9 +1254,6 @@ func (b *Beads) Create(opts CreateOptions) (*Issue, error) {
 	if opts.Ephemeral {
 		args = append(args, "--ephemeral")
 	}
-	if opts.Rig != "" {
-		args = append(args, "--rig="+opts.Rig)
-	}
 	// Default Actor from BD_ACTOR env var if not specified
 	// Uses getActor() to respect isolated mode (tests)
 	actor := opts.Actor
@@ -1239,7 +1264,20 @@ func (b *Beads) Create(opts CreateOptions) (*Issue, error) {
 		args = append(args, "--actor="+actor)
 	}
 
-	out, err := b.run(args...)
+	// When creating a bead in a specific rig, bd's --repo flag does NOT follow
+	// the .beads/redirect file, causing bd to fall back to embedded-dolt mode
+	// and fail with "no database selected" for rigs whose metadata.json lives
+	// behind a redirect (e.g. <rig>/.beads/redirect → mayor/rig/.beads). Instead
+	// of passing --repo, point the subprocess at the rig directory and set
+	// BEADS_DIR to the resolved beads dir — cwd-based discovery does follow the
+	// redirect, so bd finds the server-backed store and MR bead creation works.
+	var out []byte
+	var err error
+	if opts.Rig != "" {
+		out, err = b.runInRig(opts.Rig, args...)
+	} else {
+		out, err = b.run(args...)
+	}
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
## Summary

Fixes gastownhall/gastown#3641.

PR #3540 (37c2b382) routed MR beads to the rig's DB via `--rig`/`--repo`
on `bd create`. This works for rigs with flat `.beads/metadata.json` but
fails for rigs using `.beads/redirect` (→ `mayor/rig/.beads/`): bd's
`--repo` flag does **not** follow the redirect, so it falls back to
embedded-dolt mode and fails schema init with:

```
failed to open target store: embeddeddolt: init schema:
creating schema_migrations table: Error 1105: no database selected
```

This broke `gt done`'s MR bead creation across every redirect-using rig,
taking the whole merge-queue automation offline.

## Fix

When `opts.Rig` is set, run bd via a new `runInRig` helper that:

1. Resolves `<townRoot>/<rig>` → actual beads dir via `ResolveBeadsDir`
   (which *does* follow `.beads/redirect`).
2. Clones the wrapper with `workDir = rigPath` and `beadsDir = resolved`.
3. Invokes `run()` — subprocess `cmd.Dir` + `BEADS_DIR` now both point at
   the rig's real beads directory.

cwd-based discovery already honours redirect, so bd finds the server-
backed store and MR bead creation succeeds. The `--repo` flag is no
longer passed for rig-targeted creates, sidestepping the bd bug entirely.

## Test plan

- [x] `go build ./internal/beads/` passes
- [x] `go test ./internal/beads/` passes (5 tests)
- [x] End-to-end: `b.Create(CreateOptions{Rig: "gastown"})` now succeeds
      against a redirect-style rig (previously failed with "no database
      selected")
- [ ] Verify downstream: `gt done` on a polecat branch creates MR bead
      (will exercise in refinery once deployed)

## Notes

- bd's `--repo` flag still has the underlying redirect-ignoring bug and
  should be fixed upstream in `gastownhall/beads`. This PR works around
  it in gastown rather than waiting for that.
- Filed as gastownhall/gastown#3641 by mayor this morning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)