### PR TITLE
fix(deacon): accept tmux session activity as health-check response signal

### DIFF
--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -898,17 +898,21 @@ func runDeaconHealthCheck(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("sending health check nudge: %w", err)
 	}
 
-	// Get baseline time AFTER sending nudge to avoid false positives.
-	// If we get the time before the nudge and the bead doesn't exist (time.Time{}),
-	// any subsequent update would incorrectly appear as a response.
-	// By getting the baseline after the nudge, we ensure we're only detecting
-	// activity that happens in response to our health check.
+	// Get baseline times AFTER sending nudge to avoid false positives.
+	// By sampling after the nudge, we only detect activity caused by our check.
 	baselineTime, err := getAgentBeadUpdateTime(townRoot, beadID)
 	if err != nil {
 		// Bead might not exist yet - use current time as baseline
 		// This way only updates AFTER this point count as responses
 		baselineTime = time.Now()
 	}
+
+	// Also capture baseline tmux session activity time.
+	// This is the secondary response signal: if the session shows new output
+	// after our nudge, the agent is alive and processing — even if it hasn't
+	// updated its bead (e.g., witness agents that respond in prose rather than
+	// via a structured bead-update channel).
+	baselineActivity, activityErr := t.GetSessionActivity(sessionName)
 
 	fmt.Printf("%s Sent HEALTH_CHECK to %s, waiting %s...\n",
 		style.Bold.Render("→"), agent, healthCheckTimeout)
@@ -928,15 +932,23 @@ func runDeaconHealthCheck(cmd *cobra.Command, args []string) error {
 		case <-ctx.Done():
 			goto Done
 		case <-ticker.C:
+			// Primary signal: bead update (structured response channel)
 			newTime, err := getAgentBeadUpdateTime(townRoot, beadID)
-			if err != nil {
-				continue
-			}
-
-			// If bead was updated after our baseline, agent responded
-			if newTime.After(baselineTime) {
+			if err == nil && newTime.After(baselineTime) {
 				responded = true
 				goto Done
+			}
+
+			// Secondary signal: tmux session activity (prose/command response)
+			// Agents like the Witness respond to HEALTH_CHECK by running commands
+			// in their session, producing output, but may not update their bead.
+			// Session activity is a reliable liveness signal for these agents.
+			if activityErr == nil {
+				newActivity, err := t.GetSessionActivity(sessionName)
+				if err == nil && newActivity.After(baselineActivity) {
+					responded = true
+					goto Done
+				}
 			}
 		}
 	}

--- a/internal/templates/roles/witness.md.tmpl
+++ b/internal/templates/roles/witness.md.tmpl
@@ -302,7 +302,9 @@ Your handoff state is tracked in a pinned bead: `witness Handoff`
 
 **Do NOT mail on HEALTH_CHECK nudges.** When Deacon sends HEALTH_CHECK, don't
 respond with mail — this floods inboxes every patrol cycle (~30s). The Deacon
-tracks your health via session status, not mail responses.
+detects responsiveness via tmux session activity: any output you produce
+(running a command, responding in prose) counts as a response. You do not need
+to take any special action beyond responding normally to the nudge.
 
 **Village mindset**: If you see Refinery struggling, ping it. If Deacon seems stuck, notify Mayor.
 


### PR DESCRIPTION
## Problem

`gt deacon health-check` was producing false-positive force-kill recommendations
for the mycp/witness despite it being alive and responding.

Root cause: the health-check command only detects agent liveness via bead updates
(`getAgentBeadUpdateTime`). When an agent's bead doesn't exist or when the agent
responds in prose (running commands, producing output) rather than updating a bead,
every health check times out as a failure.

Specifically for the Witness: it receives `HEALTH_CHECK` nudges and responds by
running commands (`date`, `gt patrol scan`, `gt polecat list`), producing session
output — but it never updates a bead. The health-check sees 0 bead updates →
records consecutive failures → recommends force-kill despite the session being healthy.

## Fix

**`internal/cmd/deacon.go`**: Add `GetSessionActivity()` as a secondary liveness
signal alongside bead updates. After sending the nudge, capture a baseline tmux
session activity timestamp. In the polling loop, if either:
- The agent's bead was updated (primary signal), OR
- The tmux session shows new activity (secondary signal — any output/command)

…count the agent as responsive.

This is additive: bead updates still work as before. Session activity is a fallback
for agents that respond in prose rather than via structured bead updates.

**`internal/templates/roles/witness.md.tmpl`**: Fix the misleading documentation
that said "Deacon tracks your health via session status" (which was aspirationally
true but wasn't what the code did). Now accurately describes the dual-signal approach.

## Testing

Built binary locally (`go build ./cmd/gt`), `go vet` passes.

Related: hq-91t (mycp/witness showing 48 consecutive false-positive health check failures)