### PR TITLE
fix(sling): gt done now honors --merge=local passed to gt sling

### DIFF
--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -756,6 +756,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 
 	// Auto-convoy: check if issue is already tracked by a convoy
 	// If not, create one for dashboard visibility (unless --no-convoy is set)
+	var convoyID string // Hoisted so it's visible at fieldUpdates below (GH #3320)
 	if !slingNoConvoy && formulaName == "" {
 		existingConvoy := isTrackedByConvoy(beadID)
 		if existingConvoy == "" {
@@ -766,7 +767,8 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 					fmt.Printf("Would set convoy merge strategy: %s\n", slingMerge)
 				}
 			} else {
-				convoyID, err := createAutoConvoy(beadID, info.Title, slingOwned, slingMerge, slingBaseBranch)
+				var err error
+				convoyID, err = createAutoConvoy(beadID, info.Title, slingOwned, slingMerge, slingBaseBranch)
 				if err != nil {
 					// Log warning but don't fail - convoy is optional
 					fmt.Printf("%s Could not create auto-convoy: %v\n", style.Dim.Render("Warning:"), err)
@@ -959,6 +961,9 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		NoMerge:          slingNoMerge,
 		ReviewOnly:       slingReviewOnly,
 		FormulaVars:      strings.Join(slingVars, "\n"),
+		MergeStrategy:    slingMerge,
+		ConvoyID:         convoyID,
+		ConvoyOwned:      slingOwned,
 	}
 	if err := storeFieldsInBead(beadID, fieldUpdates); err != nil {
 		// Warn but don't fail - polecat will still complete work

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -2584,3 +2584,142 @@ func TestSlingRejectsDeferredBead(t *testing.T) {
 		})
 	}
 }
+
+// TestStoreFieldsInBeadConvoyFields verifies that MergeStrategy, ConvoyID, and
+// ConvoyOwned are persisted in the bead's attachment fields when passed through
+// beadFieldUpdates. This was the root cause of GH #3320: the fields existed in
+// the struct and the write path, but were never populated in the struct literal.
+func TestStoreFieldsInBeadConvoyFields(t *testing.T) {
+	logPath := filepath.Join(t.TempDir(), "fields.log")
+	t.Setenv("GT_TEST_ATTACHED_MOLECULE_LOG", logPath)
+
+	updates := beadFieldUpdates{
+		Dispatcher:    "test-mayor",
+		MergeStrategy: "local",
+		ConvoyID:      "hq-cv-test42",
+		ConvoyOwned:   true,
+	}
+
+	if err := storeFieldsInBead("gt-fake123", updates); err != nil {
+		t.Fatalf("storeFieldsInBead: %v", err)
+	}
+
+	content, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	desc := string(content)
+
+	for _, want := range []string{
+		"merge_strategy: local",
+		"convoy_id: hq-cv-test42",
+		"convoy_owned: true",
+		"dispatched_by: test-mayor",
+	} {
+		if !strings.Contains(desc, want) {
+			t.Errorf("description missing %q\nGot:\n%s", want, desc)
+		}
+	}
+}
+
+// TestSlingMergeStrategyPersisted verifies that gt sling --merge=local stores
+// the merge_strategy in the bead's description via the full runSling path.
+// Regression test for GH #3320 where MergeStrategy was never wired into
+// the beadFieldUpdates struct literal.
+func TestSlingMergeStrategyPersisted(t *testing.T) {
+	townRoot := t.TempDir()
+
+	// Minimal workspace marker so workspace.FindFromCwd() succeeds.
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir mayor/rig: %v", err)
+	}
+
+	// Create stub bd
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	logPath := filepath.Join(townRoot, "bd.log")
+	bdScript := `#!/bin/sh
+set -e
+echo "ARGS:$*" >> "${BD_LOG}"
+cmd="$1"
+shift || true
+case "$cmd" in
+  show)
+    echo '[{"title":"Test issue","status":"open","assignee":"","description":""}]'
+    ;;
+  update)
+    exit 0
+    ;;
+esac
+exit 0
+`
+	bdScriptWindows := `@echo off
+setlocal enableextensions
+echo ARGS:%*>>"%BD_LOG%"
+set "cmd=%1"
+if not "%cmd%"=="show" goto :notshow
+echo [{"title":"Test issue","status":"open","assignee":"","description":""}]
+exit /b 0
+:notshow
+if "%cmd%"=="update" exit /b 0
+exit /b 0
+`
+	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
+
+	molLogPath := filepath.Join(townRoot, "mol.log")
+	t.Setenv("GT_TEST_ATTACHED_MOLECULE_LOG", molLogPath)
+
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv(EnvGTRole, "mayor")
+	t.Setenv("GT_CREW", "")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("TMUX_PANE", "")
+	t.Setenv("GT_TEST_NO_NUDGE", "1")
+	t.Setenv("GT_TEST_SKIP_HOOK_VERIFY", "1")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	// Save and restore global flags
+	prevDryRun := slingDryRun
+	prevNoConvoy := slingNoConvoy
+	prevMerge := slingMerge
+	prevOwned := slingOwned
+	t.Cleanup(func() {
+		slingDryRun = prevDryRun
+		slingNoConvoy = prevNoConvoy
+		slingMerge = prevMerge
+		slingOwned = prevOwned
+	})
+
+	slingDryRun = false
+	slingNoConvoy = true // Skip convoy creation to avoid complex bd stubs
+	slingMerge = "local" // This is what we're testing (GH #3320)
+	slingOwned = true
+
+	if err := runSling(nil, []string{"gt-test456"}); err != nil {
+		t.Fatalf("runSling: %v", err)
+	}
+
+	molBytes, err := os.ReadFile(molLogPath)
+	if err != nil {
+		t.Fatalf("read molecule log: %v", err)
+	}
+	molContent := string(molBytes)
+
+	if !strings.Contains(molContent, "merge_strategy: local") {
+		t.Errorf("--merge=local not stored in bead description\nDescription:\n%s", molContent)
+	}
+	if !strings.Contains(molContent, "convoy_owned: true") {
+		t.Errorf("--owned not stored in bead description\nDescription:\n%s", molContent)
+	}
+}


### PR DESCRIPTION
## Summary

`gt sling <bead> <rig> --merge=local` creates the convoy with the correct merge strategy, but never stamps `merge_strategy`, `convoy_id`, or `convoy_owned` on the work bead's attachment fields. When `gt done` runs, it cannot find the merge strategy and falls through to default `mr` behavior — pushing to origin and creating an MR for the refinery.

This means `--merge=local` (and `--merge=direct` via sling) has been effectively broken for the polecat → `gt done` path.

## Root Cause

In `internal/cmd/sling.go` the `beadFieldUpdates` struct literal was missing three fields:

```go
fieldUpdates := beadFieldUpdates{
    Dispatcher:       actor,
    Args:             slingArgs,
    // ... other fields ...
    FormulaVars:      strings.Join(slingVars, "\n"),
    // MergeStrategy: slingMerge,   ← MISSING
    // ConvoyID:      convoyID,     ← MISSING
    // ConvoyOwned:   slingOwned,   ← MISSING
}
```

The full infrastructure was already wired:
- `beadFieldUpdates` struct has the fields (`sling_helpers.go:274`)
- `storeFieldsInBead` handles them (`sling_helpers.go:345-352`)
- `beads.SetAttachmentFields` writes them to the description (`beads/fields.go:148-151`)
- `beads.ParseAttachmentFields` reads them back (`beads/fields.go:91-95`)
- `gt done` checks them to decide merge behavior (`done.go:586-598`)

Only the struct literal population was missing.

## Changes

- **Add `MergeStrategy`, `ConvoyID`, `ConvoyOwned`** to the `beadFieldUpdates` struct literal at `sling.go:964`
- **Hoist `convoyID` declaration** out of the `if !slingNoConvoy` block so it's visible at the struct literal (~200 lines below). Changed `convoyID, err :=` to `var err error` + `convoyID, err =`
- **Add unit test** (`TestStoreFieldsInBeadConvoyFields`): verifies `storeFieldsInBead` persists all three convoy fields to the bead description via `GT_TEST_ATTACHED_MOLECULE_LOG`
- **Add integration test** (`TestSlingMergeStrategyPersisted`): exercises the full `runSling` path with `--merge=local` and `--owned`, asserts the fields appear in the captured description

## Observed vs Expected Behavior

**Before (broken):**
1. `gt sling <bead> <rig> --merge=local` → convoy created correctly with `Merge: local`
2. Polecat does work, calls `gt done`
3. `gt done` can't find merge strategy → pushes to origin, submits MR to merge queue
4. Refinery picks up MR (should never have seen it)

**After (fixed):**
1. `gt sling <bead> <rig> --merge=local` → convoy created, **fields stamped on bead**
2. Polecat does work, calls `gt done`
3. `gt done` reads `merge_strategy: local` from bead → skips push and MR creation

## Testing

- `gofmt` passes on both modified files
- Code review verified: no stale variable paths, all struct fields exist, flag variables are in scope, `storeFieldsInBead` handles all three fields
- **Note:** Full `go test` / `go build` cannot run locally due to a pre-existing `go.sum` checksum mismatch on `steveyegge/beads@v1.0.0` (tag was re-pushed upstream). CI should resolve this.

Closes #3320