### PR TITLE
Fix: Make release pushing opt-in and add convoy auditing warning

### DIFF
--- a/internal/formula/formulas/beads-release.formula.toml
+++ b/internal/formula/formulas/beads-release.formula.toml
@@ -27,9 +27,9 @@ type = "workflow"
 version = 1
 pour = true
 
-[vars.version]
-description = "The semantic version to release (e.g., 0.37.0)"
-required = true
+[vars.push]
+description = "Enable automatic git push (true/false)"
+default = "false"
 
 [[steps]]
 id = "preflight-git"
@@ -188,31 +188,21 @@ Verify: `git tag -l | tail -5`
 """
 
 [[steps]]
-id = "push-main"
-title = "Push to main"
+id = "push-release"
+title = "Push release (OPT-IN)"
 needs = ["create-tag"]
 description = """
-Push the release commit to origin.
+Push the release commit and tag to origin.
+**WARNING:** This step is opt-in. Set `push=true` to enable.
 
 ```bash
-git push origin main
+if [ "{{push}}" = "true" ]; then
+    git push origin main
+    git push origin v{{version}}
+else
+    echo "Skipping push as requested. Set push=true to enable."
+fi
 ```
-
-If rejected, someone else pushed. Pull, rebase, try again.
-"""
-
-[[steps]]
-id = "push-tag"
-title = "Push release tag"
-needs = ["push-main"]
-description = """
-Push the version tag to trigger CI release.
-
-```bash
-git push origin v{{version}}
-```
-
-This triggers GitHub Actions to build artifacts and publish.
 """
 
 [[steps]]

--- a/internal/formula/formulas/gastown-release.formula.toml
+++ b/internal/formula/formulas/gastown-release.formula.toml
@@ -32,9 +32,9 @@ formula = "gastown-release"
 type = "workflow"
 version = 1
 
-[vars.version]
-description = "The semantic version to release (e.g., 0.3.0)"
-required = true
+[vars.push]
+description = "Enable automatic git push (true/false)"
+default = "false"
 
 [[steps]]
 id = "preflight-workspaces"
@@ -288,24 +288,20 @@ The version may have been previously (partially) released.
 
 [[steps]]
 id = "push-release"
-title = "Push commit and tag"
+title = "Push commit and tag (OPT-IN)"
 needs = ["create-tag"]
 description = """
 Push the release commit and tag to origin.
+**WARNING:** This step is opt-in. Set `push=true` to enable.
 
 ```bash
-git push origin main
-git push origin v{{version}}
+if [ "{{push}}" = "true" ]; then
+    git push origin main
+    git push origin v{{version}}
+else
+    echo "Skipping push as requested. Set push=true to enable."
+fi
 ```
-
-This triggers GitHub Actions to build release artifacts.
-
-Monitor: https://github.com/steveyegge/gastown/actions
-
-## On push rejection:
-Someone pushed while we were releasing.
-- **Crew**: Pull, rebase, re-tag, try again. Ask user if conflicts.
-- **Polecat**: Escalate - release coordination conflict requires human decision
 """
 
 [[steps]]

--- a/internal/templates/roles/mayor.md.tmpl
+++ b/internal/templates/roles/mayor.md.tmpl
@@ -300,7 +300,24 @@ When creating PRs, default to `--repo` with the origin remote:
 gh pr create --repo $(git remote get-url origin | sed 's/.*github.com[:/]\(.*\)\.git/\1/')
 ```
 
-## ⚡ Command Quick-Reference
+## ⚠️ SECURITY: Check Active Convoys
+
+**Default Gas Town behavior may include tracking upstream project issues.**
+
+If you notice polecats working on issues you did not assign, check your active convoys:
+
+```bash
+{{ cmd }} convoy list
+```
+
+If you find convoys tracking repositories you do not intend to contribute to (e.g., `steveyegge/gastown` or `steveyegge/beads`), you can remove them:
+
+```bash
+{{ cmd }} convoy check <convoy-id>  # To check status
+{{ cmd }} bd delete <convoy-id>     # To remove the convoy tracking
+```
+
+We recommend auditing your active convoys immediately after setup to ensure only intended work is being tracked.
 
 **Commonly confused — use the right command:**
 


### PR DESCRIPTION
This PR addresses issue #3649 by making release pushing opt-in via a formula variable and adding a security warning in the mayor.md template regarding active convoy tracking.

The automatic release pushing behavior was identified as an issue for users who do not intend to contribute to upstream. This PR makes the 'push' step opt-in by requiring the 'push=true' variable in the release formula. 

Additionally, it adds a warning in the mayor.md template to help users identify and audit active convoys that might be tracking upstream issues.