### PR TITLE
fix: honor explicit --target in gt done contamination check

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -76,6 +76,15 @@ const (
 	ExitDeferred  = "DEFERRED"
 )
 
+func doneContaminationBaseRef(defaultBranch, explicitTarget string) string {
+	targetBranch := defaultBranch
+	if explicitTarget != "" {
+		targetBranch = strings.TrimPrefix(explicitTarget, "origin/")
+	}
+
+	return "origin/" + targetBranch
+}
+
 func init() {
 	doneCmd.Flags().StringVar(&doneIssue, "issue", "", "Source issue ID (default: parse from branch name)")
 	doneCmd.Flags().IntVarP(&donePriority, "priority", "p", -1, "Override priority (0-4, default: inherit from issue)")
@@ -555,19 +564,20 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		}
 
 		// Branch contamination preflight: check if branch is significantly behind
-		// origin/main, which indicates the branch may contain stale merge-base
+		// the effective target branch, which indicates the branch may contain stale merge-base
 		// artifacts that will pollute the PR diff. (GH#2220)
-		contam, err := g.CheckBranchContamination(originDefault)
+		contaminationBase := doneContaminationBaseRef(defaultBranch, doneTarget)
+		contam, err := g.CheckBranchContamination(contaminationBase)
 		if err == nil && contam.Behind > 0 {
 			const warnThreshold = 50
 			const blockThreshold = 200
 			if contam.Behind >= blockThreshold {
 				return fmt.Errorf("branch contamination: %d commits behind %s (threshold: %d)\n"+
 					"The branch is severely stale and will include unrelated changes in the PR.\n"+
-					"Fix: git fetch origin && git rebase origin/%s",
-					contam.Behind, originDefault, blockThreshold, defaultBranch)
+					"Fix: git fetch origin && git rebase %s",
+					contam.Behind, contaminationBase, blockThreshold, contaminationBase)
 			} else if contam.Behind >= warnThreshold {
-				style.PrintWarning("branch is %d commits behind %s — consider rebasing to avoid PR contamination", contam.Behind, originDefault)
+				style.PrintWarning("branch is %d commits behind %s — consider rebasing to avoid PR contamination", contam.Behind, contaminationBase)
 			}
 		}
 

--- a/internal/cmd/done_contamination_test.go
+++ b/internal/cmd/done_contamination_test.go
@@ -1,0 +1,40 @@
+package cmd
+
+import "testing"
+
+func TestDoneContaminationBaseRef(t *testing.T) {
+	tests := []struct {
+		name           string
+		defaultBranch  string
+		explicitTarget string
+		want           string
+	}{
+		{
+			name:           "defaults to rig branch",
+			defaultBranch:  "main",
+			explicitTarget: "",
+			want:           "origin/main",
+		},
+		{
+			name:           "uses explicit target branch",
+			defaultBranch:  "main",
+			explicitTarget: "upstream-rebuild-main",
+			want:           "origin/upstream-rebuild-main",
+		},
+		{
+			name:           "avoids double origin prefix",
+			defaultBranch:  "main",
+			explicitTarget: "origin/upstream-rebuild-main",
+			want:           "origin/upstream-rebuild-main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := doneContaminationBaseRef(tt.defaultBranch, tt.explicitTarget)
+			if got != tt.want {
+				t.Fatalf("doneContaminationBaseRef(%q, %q) = %q, want %q", tt.defaultBranch, tt.explicitTarget, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
This fixes a regression where gt done with an explicit target branch still ran contamination validation against the default branch instead of the requested target branch. That blocked valid fork-reconciliation work targeting non-default branches such as upstream-rebuild-main.

## Related Issue
Closes #3650

## Changes
- normalize explicit target input for contamination preflight in gt done
- use the explicit target branch as the contamination base ref instead of hard-coding the default branch
- add focused regression coverage for explicit target contamination behavior
- keep broader target normalization concerns split into follow-up work instead of widening this fix

## Why This PR Exists
The reported bug was narrow: contamination preflight ignored the branch the user explicitly asked gt done to target. This PR fixes that specific behavior with the smallest possible code change. It does not attempt to solve broader target normalization across every downstream gt done path; that is tracked separately so this branch stays bug-sized and reviewable.

## Testing
- [x] Unit tests pass: go test ./internal/cmd -run TestDoneContamination
- [x] Manual validation of the preserved branch diff and targeted lane behavior
- [ ] Full go test ./...

Notes:
- Full-tree tests were not used as the acceptance gate for this PR because they include unrelated existing failures outside this bug scope.

## Checklist
- [x] Code follows project style
- [x] No breaking changes
- [x] Follow-up work for broader normalization remains separate
