### PR TITLE
fix: sync OpenCode hooks in nested polecat worktrees

### DIFF
--- a/docs/HOOKS.md
+++ b/docs/HOOKS.md
@@ -9,7 +9,7 @@ Gas Town manages context injection for all supported agents. The mechanism varie
 | Agent | Hook mechanism | Managed file |
 |-------|---------------|-------------|
 | Claude Code, Gemini | `settings.json` lifecycle hooks | `<role>/.claude/settings.json` |
-| OpenCode | JS plugin | `workDir/.opencode/gastown.js` |
+| OpenCode | JS plugin | `workDir/.opencode/plugins/gastown.js` |
 | GitHub Copilot | JSON lifecycle hooks | `workDir/.github/hooks/gastown.json` |
 | Codex, others | Startup nudge fallback | *(no file — nudge only)* |
 

--- a/docs/agent-provider-integration.md
+++ b/docs/agent-provider-integration.md
@@ -346,7 +346,7 @@ config.RegisterHookInstaller("kiro", func(settingsDir, workDir, role, hooksDir, 
 If your agent uses a plugin system (like OpenCode's JS plugins), Gas Town can
 install a plugin file instead of a settings.json.
 
-Reference: `internal/opencode/plugin/gastown.js`
+Reference: `internal/hooks/templates/opencode/gastown.js`
 
 ```javascript
 export const GasTown = async ({ $, directory }) => {

--- a/internal/cmd/hooks_sync_test.go
+++ b/internal/cmd/hooks_sync_test.go
@@ -454,3 +454,85 @@ func TestRunHooksSyncNonClaudeAgentDryRun(t *testing.T) {
 		t.Error("dry-run should not create opencode plugin file")
 	}
 }
+
+func TestRunHooksSyncNonClaudeAgentNestedPolecatWorktree(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(binDir, "opencode"), []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	townRoot := filepath.Join(tmpDir, "town")
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "deacon"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	worktree := filepath.Join(townRoot, "myrig", "polecats", "fury", "gastown")
+	if err := os.MkdirAll(filepath.Join(worktree, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := os.WriteFile(
+		filepath.Join(townRoot, "mayor", "town.json"),
+		[]byte(`{"type":"town","version":1,"name":"test"}`),
+		0644,
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	townSettings := config.NewTownSettings()
+	townSettings.RoleAgents = map[string]string{"polecat": "opencode"}
+	townSettings.Agents = map[string]*config.RuntimeConfig{
+		"opencode": {
+			Provider: "opencode",
+			Command:  "opencode",
+		},
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "settings"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := config.SaveTownSettings(config.TownSettingsPath(townRoot), townSettings); err != nil {
+		t.Fatal(err)
+	}
+
+	base := &hooks.HooksConfig{
+		SessionStart: []hooks.HookEntry{
+			{Matcher: "", Hooks: []hooks.Hook{{Type: "command", Command: "echo test"}}},
+		},
+	}
+	if err := hooks.SaveBase(base); err != nil {
+		t.Fatalf("SaveBase failed: %v", err)
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.Chdir(cwd) }()
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	hooksSyncDryRun = false
+	if err := runHooksSync(nil, nil); err != nil {
+		t.Fatalf("runHooksSync failed: %v", err)
+	}
+
+	pluginPath := filepath.Join(worktree, ".opencode", "plugins", "gastown.js")
+	if _, err := os.Stat(pluginPath); os.IsNotExist(err) {
+		t.Fatalf("opencode plugin not created in nested polecat worktree %s", pluginPath)
+	}
+
+	wrongParentPath := filepath.Join(townRoot, "myrig", "polecats", "fury", ".opencode", "plugins", "gastown.js")
+	if _, err := os.Stat(wrongParentPath); !os.IsNotExist(err) {
+		t.Fatalf("opencode plugin should not be created in polecat slot parent %s", wrongParentPath)
+	}
+}

--- a/internal/doctor/hooks_sync_check_test.go
+++ b/internal/doctor/hooks_sync_check_test.go
@@ -256,6 +256,40 @@ func TestHooksSyncCheck_Fix_TemplateAgent(t *testing.T) {
 	}
 }
 
+func TestHooksSyncCheck_PolecatNestedWorktree_InSync(t *testing.T) {
+	townRoot := scaffoldWorkspace(t, map[string]string{"polecat": "opencode"})
+
+	worktree := filepath.Join(townRoot, "myrig", "polecats", "fury", "gastown")
+	if err := os.MkdirAll(filepath.Join(worktree, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	syncAllClaudeTargets(t, townRoot)
+
+	expectedContent, err := hooks.ComputeExpectedTemplate("opencode", "gastown.js", "polecat")
+	if err != nil {
+		t.Fatalf("ComputeExpectedTemplate: %v", err)
+	}
+	pluginDir := filepath.Join(worktree, ".opencode", "plugins")
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginDir, "gastown.js"), expectedContent, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewHooksSyncCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK for in-sync nested polecat worktree, got %v: %s", result.Status, result.Message)
+		for _, d := range result.Details {
+			t.Logf("  detail: %s", d)
+		}
+	}
+}
+
 func TestHooksSyncCheck_Fix_PreservesClaudePath(t *testing.T) {
 	townRoot := scaffoldWorkspace(t, nil)
 

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -489,7 +489,6 @@ func DiscoverTargets(townRoot string) ([]Target, error) {
 	return targets, nil
 }
 
-
 // RoleLocation represents a discovered role directory in the workspace,
 // independent of any specific agent. Used by callers that need to resolve
 // agent configuration for each location (e.g., syncing non-Claude agents).
@@ -552,6 +551,11 @@ func DiscoverRoleLocations(townRoot string) ([]RoleLocation, error) {
 // DiscoverWorktrees returns subdirectories within a role parent directory that
 // are individual worktrees (e.g., crew/alice, crew/bob, polecats/toast).
 // Skips hidden directories and non-directories.
+//
+// Some roles, especially polecats, keep the git worktree one level below the
+// agent slot directory (for example, polecats/fury/gastown). When an immediate
+// child contains nested git worktree roots, prefer those nested directories so
+// hooks are synced into the real repo root instead of the slot parent.
 func DiscoverWorktrees(roleDir string) []string {
 	entries, err := os.ReadDir(roleDir)
 	if err != nil {
@@ -563,9 +567,43 @@ func DiscoverWorktrees(roleDir string) []string {
 		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
 			continue
 		}
-		dirs = append(dirs, filepath.Join(roleDir, entry.Name()))
+
+		path := filepath.Join(roleDir, entry.Name())
+		nested := nestedWorktreeRoots(path)
+		if len(nested) > 0 {
+			dirs = append(dirs, nested...)
+			continue
+		}
+
+		dirs = append(dirs, path)
 	}
 	return dirs
+}
+
+func nestedWorktreeRoots(parent string) []string {
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		return nil
+	}
+
+	var dirs []string
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
+		path := filepath.Join(parent, entry.Name())
+		if isGitWorktreeRoot(path) {
+			dirs = append(dirs, path)
+		}
+	}
+
+	return dirs
+}
+
+func isGitWorktreeRoot(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, ".git"))
+	return err == nil
 }
 
 // isRig checks if a directory looks like a rig (has crew/, witness/, or polecats/ subdirectory).

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -1020,6 +1020,36 @@ func TestDiscoverWorktrees_EmptyDir(t *testing.T) {
 	}
 }
 
+func TestDiscoverWorktrees_PrefersNestedGitWorktreeRoots(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	worktree := filepath.Join(tmpDir, "fury", "gastown")
+	if err := os.MkdirAll(filepath.Join(worktree, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, "dust"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	dirs := DiscoverWorktrees(tmpDir)
+
+	if len(dirs) != 2 {
+		t.Fatalf("expected 2 worktrees, got %d: %v", len(dirs), dirs)
+	}
+
+	got := make(map[string]bool)
+	for _, dir := range dirs {
+		got[dir] = true
+	}
+
+	if !got[worktree] {
+		t.Fatalf("expected nested worktree root %q, got %v", worktree, dirs)
+	}
+	if !got[filepath.Join(tmpDir, "dust")] {
+		t.Fatalf("expected direct worktree fallback %q, got %v", filepath.Join(tmpDir, "dust"), dirs)
+	}
+}
+
 func TestDiscoverWorktrees_InvalidDir(t *testing.T) {
 	dirs := DiscoverWorktrees("/nonexistent/path/that/does/not/exist")
 	if dirs != nil {


### PR DESCRIPTION
## Summary
This fixes nested polecat worktree discovery for OpenCode hook provisioning and hooks-sync doctor checks. Polecat worktrees live under `polecats/<name>/<rig>`, but the existing discovery logic only considered the immediate role directory and could skip the actual nested git worktree, leaving worker environments without the expected `gastown.js` plugin.

## Related Issue
Part of #3651

## Changes
- detect nested polecat git worktrees during hook discovery
- extend command-level `gt hooks sync` regression coverage for nested polecat layouts
- extend hooks-sync doctor coverage for nested polecat layouts
- update stale docs to the correct `.opencode/plugins/gastown.js` path

## Why This PR Exists
This is the smallest practical bug-fix slice for the provisioning side of the OpenCode lane. It ensures worker environments that should receive the plugin actually get it in nested polecat layouts.

## What This PR Does Not Claim
This PR intentionally does not claim to solve the broader refusal stream by itself. Those concerns remain split into separate follow-up work:
- worker-style end-to-end refusal behavior validation (`gt-jbf`)
- restored template behavior (`gt-tz5`)
- refresh behavior for already-installed stale worker hooks (`gt-9eh`)
- narrower correctness/test follow-ups if needed after review

## Testing
- [x] `go test ./internal/hooks ./internal/doctor ./internal/cmd -run HooksSync|DiscoverWorktrees`
- [x] Focused review of the clean branch diff
- [ ] Full `go test ./...`

Notes:
- Full-tree tests were not used as the acceptance gate for this PR because unrelated existing failures remain outside this bug scope.

## Checklist
- [x] Smallest practical bug-fix slice
- [x] Follow-up gaps kept separate
- [x] No new commands or features introduced
