### PR TITLE
fix: restore provisioned OpenCode refusal auto-continue template

### DIFF
--- a/internal/hooks/installer_test.go
+++ b/internal/hooks/installer_test.go
@@ -178,6 +178,28 @@ func TestSyncForRole_CreatesNewFile(t *testing.T) {
 	}
 }
 
+func TestComputeExpectedTemplate_OpenCodeIncludesRefusalAutoContinue(t *testing.T) {
+	content, err := ComputeExpectedTemplate("opencode", "gastown.js", "polecat")
+	if err != nil {
+		t.Fatalf("ComputeExpectedTemplate: %v", err)
+	}
+
+	got := string(content)
+	checks := []string{
+		`const refusalTexts = new Set([`,
+		`const refusalPrompt = "Continue";`,
+		`const maxConsecutiveRefusalRetries = 4;`,
+		`if (event?.type === "message.updated") {`,
+		`await promptSession(sessionID, refusalPrompt);`,
+		`gt escalate ${summary} -s HIGH -m ${details}`,
+	}
+	for _, check := range checks {
+		if !strings.Contains(got, check) {
+			t.Errorf("expected OpenCode template to contain %q", check)
+		}
+	}
+}
+
 func TestSyncForRole_EmptyProvider(t *testing.T) {
 	dir := t.TempDir()
 	result, err := SyncForRole("", dir, dir, "crew", ".opencode/plugins", "gastown.js", false)

--- a/internal/hooks/templates/opencode/gastown.js
+++ b/internal/hooks/templates/opencode/gastown.js
@@ -1,13 +1,44 @@
 // Gas Town OpenCode plugin: hooks SessionStart/Compaction via events.
 // Injects gt prime context into the system prompt via experimental.chat.system.transform.
-export const GasTown = async ({ $, directory }) => {
+export const GasTown = async ({ client, $, directory }) => {
   const role = (process.env.GT_ROLE || "").toLowerCase();
   const autonomousRoles = new Set(["polecat", "witness", "refinery", "deacon"]);
+  const refusalTexts = new Set([
+    "I'm sorry, but I cannot assist with that request.",
+    "Im sorry, but I cannot assist with that request.",
+  ]);
+  const refusalPrompt = "Continue";
+  const maxConsecutiveRefusalRetries = 4;
   let didInit = false;
+  const refusalState = new Map();
 
   // Promise-based context loading ensures the system transform hook can
   // await the result even if session.created hasn't resolved yet.
   let primePromise = null;
+
+  const log = async (level, message, extra = {}) => {
+    try {
+      await client?.app?.log?.({
+        body: {
+          service: "gastown-opencode-plugin",
+          level,
+          message,
+          extra,
+        },
+      });
+    } catch {}
+  };
+
+  const getSessionState = (sessionID) => {
+    if (!refusalState.has(sessionID)) {
+      refusalState.set(sessionID, {
+        consecutiveRefusals: 0,
+        didEscalate: false,
+        lastHandledMessageID: "",
+      });
+    }
+    return refusalState.get(sessionID);
+  };
 
   const captureRun = async (cmd) => {
     try {
@@ -19,6 +50,110 @@ export const GasTown = async ({ $, directory }) => {
     }
   };
 
+  const fetchAssistantText = async (sessionID, messageID) => {
+    try {
+      const response = await client?.session?.message?.({
+        path: { id: sessionID, messageID },
+      });
+      const data = response?.data || response;
+      const parts = Array.isArray(data?.parts) ? data.parts : [];
+      return parts
+        .filter((part) => part?.type === "text" && !part?.ignored)
+        .map((part) => part.text || "")
+        .join("")
+        .trim();
+    } catch (err) {
+      await log("warn", "failed to fetch completed assistant text", {
+        sessionID,
+        messageID,
+        error: err?.message || String(err),
+      });
+      return null;
+    }
+  };
+
+  const promptSession = async (sessionID, text) => {
+    const body = {
+      parts: [{ type: "text", text }],
+    };
+    if (typeof client?.session?.promptAsync === "function") {
+      await client.session.promptAsync({
+        path: { id: sessionID },
+        body,
+      });
+      return;
+    }
+    if (typeof client?.session?.prompt === "function") {
+      await client.session.prompt({
+        path: { id: sessionID },
+        body,
+      });
+    }
+  };
+
+  const escalateRefusalLoop = async (sessionID, count) => {
+    const summary = "OpenCode refusal auto-continue exhausted";
+    const details = [
+      `role=${role || "unknown"}`,
+      `session=${sessionID}`,
+      `refusals=${count}`,
+      `prompt=${JSON.stringify(refusalPrompt)}`,
+    ].join(" ");
+
+    await log("warn", summary, { sessionID, consecutiveRefusals: count, role });
+
+    try {
+      await $`gt escalate ${summary} -s HIGH -m ${details}`.cwd(directory);
+    } catch (err) {
+      console.error("[gastown] gt escalate failed", err?.message || err);
+    }
+  };
+
+  const handleCompletedAssistantMessage = async (info) => {
+    if (!autonomousRoles.has(role)) {
+      return;
+    }
+
+    const sessionID = info?.sessionID;
+    const messageID = info?.id;
+    if (!sessionID || !messageID || info?.role !== "assistant" || !info?.time?.completed) {
+      return;
+    }
+
+    const state = getSessionState(sessionID);
+    if (state.lastHandledMessageID === messageID) {
+      return;
+    }
+    state.lastHandledMessageID = messageID;
+
+    const text = await fetchAssistantText(sessionID, messageID);
+    if (text == null) {
+      return;
+    }
+
+    if (!refusalTexts.has(text)) {
+      state.consecutiveRefusals = 0;
+      state.didEscalate = false;
+      return;
+    }
+
+    state.consecutiveRefusals += 1;
+    if (state.consecutiveRefusals > maxConsecutiveRefusalRetries) {
+      if (state.didEscalate) {
+        return;
+      }
+      state.didEscalate = true;
+      await escalateRefusalLoop(sessionID, state.consecutiveRefusals);
+      return;
+    }
+
+    await log("info", "sending OpenCode refusal auto-continue prompt", {
+      sessionID,
+      consecutiveRefusals: state.consecutiveRefusals,
+    });
+    await promptSession(sessionID, refusalPrompt);
+  };
+
   const loadPrime = async () => {
     let context = await captureRun("gt prime");
     if (autonomousRoles.has(role)) {
@@ -27,7 +162,7 @@ export const GasTown = async ({ $, directory }) => {
         context += "\n" + mail;
       }
     }
-    // NOTE: session-started nudge to deacon removed — it interrupted
+    // NOTE: session-started nudge to deacon removed - it interrupted
     // the deacon's await-signal backoff. Deacon wakes on beads activity.
     return context;
   };
@@ -44,9 +179,13 @@ export const GasTown = async ({ $, directory }) => {
         // Reset so next system.transform gets fresh context.
         primePromise = loadPrime();
       }
+      if (event?.type === "message.updated") {
+        await handleCompletedAssistantMessage(event.properties?.info);
+      }
       if (event?.type === "session.deleted") {
         const sessionID = event.properties?.info?.id;
         if (sessionID) {
+          refusalState.delete(sessionID);
           await $`gt costs record --session ${sessionID}`.catch(() => {});
         }
       }


### PR DESCRIPTION
## Summary
This restores the authoritative embedded/provisioned OpenCode `gastown.js` template so worker environments again receive the historical refusal auto-continue behavior. The restored template includes the `message.updated` refusal handler, `Continue` retry loop, and escalation after the retry limit.

## Related Issue
Part of #3651

## Changes
- restore refusal auto-continue logic in the embedded OpenCode template
- add regression coverage that the provisioned template contains the expected refusal-handling fragments
- keep worker upgrade-path and remaining behavioral gaps split into follow-up issues instead of widening this PR

## Why This PR Exists
The provisioning lane was fixed first, but review and worker validation showed the template being provisioned no longer contained the historical refusal auto-continue logic that acceptance depends on. This PR restores that template content as the smallest possible bug-fix slice.

## What This PR Does Not Claim
This PR intentionally does not solve every remaining follow-up in the broader refusal stream. Those are tracked separately so this branch stays narrowly bug-scoped:
- existing worker installs may still need explicit refresh/sync (`gt-9eh`)
- assistant-text fetch failure handling still needs a correctness fix (`gt-1wc`)
- role-scope alignment with historical behavior is still open (`gt-e5f`)
- stronger behavior-level regression coverage is still open (`gt-6p7`)
- direct nested command/doctor follow-ups remain separate (`gt-rku`, `gt-5hx`, `gt-jzl`)

## Testing
- [x] `go test ./internal/hooks ./internal/doctor ./internal/runtime`
- [x] `make build`
- [ ] `go test ./...`

Notes:
- Full-tree tests still include unrelated existing failures outside this bug scope.

## Checklist
- [x] Smallest practical bug-fix slice
- [x] Follow-up gaps kept separate
- [x] No new commands or features introduced
