### PR TITLE
Cross Platform: Add internal/shellcmd helpers for sleep/delay command strings

### DIFF
--- a/internal/acp/keepalive_test.go
+++ b/internal/acp/keepalive_test.go
@@ -8,6 +8,8 @@ import (
 	"runtime"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/shellcmd"
 )
 
 func TestProxy_RunKeepAlive_Logic(t *testing.T) {
@@ -27,7 +29,7 @@ func TestProxy_RunKeepAlive_Logic(t *testing.T) {
 	// Start a dummy process so isProcessAlive() returns true
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
-	p.cmd = exec.CommandContext(ctx, "sleep", "100")
+	p.cmd = exec.CommandContext(ctx, shellcmd.SleepCommand(), "100")
 	p.setupProcessGroup()
 	if err := p.cmd.Start(); err != nil {
 		t.Fatalf("failed to start dummy process: %v", err)

--- a/internal/acp/parity_test.go
+++ b/internal/acp/parity_test.go
@@ -8,6 +8,8 @@ import (
 	"os/exec"
 	"runtime"
 	"testing"
+
+	"github.com/steveyegge/gastown/internal/shellcmd"
 )
 
 type mockWriteCloser struct {
@@ -85,7 +87,7 @@ func TestWriteToAgent_Parity(t *testing.T) {
 			p := NewProxy()
 
 			// Mock process as alive
-			cmd := exec.CommandContext(context.Background(), "sleep", "1")
+			cmd := exec.CommandContext(context.Background(), shellcmd.SleepCommand(), "1")
 			p.cmd = cmd
 			p.setupProcessGroup()
 			if err := cmd.Start(); err != nil {

--- a/internal/acp/proxy_test.go
+++ b/internal/acp/proxy_test.go
@@ -16,6 +16,8 @@ import (
 	"syscall"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/shellcmd"
 )
 
 func TestNewProxy(t *testing.T) {
@@ -783,7 +785,7 @@ func setupProxyWithMockAgent(t *testing.T) (*Proxy, *MockAgent) {
 
 	// Mock p.cmd by starting a real process so that isProcessAlive() returns true.
 	// We use a command that doesn't do much and will be killed on shutdown.
-	p.cmd = exec.CommandContext(context.Background(), "sleep", "60")
+	p.cmd = exec.CommandContext(context.Background(), shellcmd.SleepCommand(), "60")
 	p.setupProcessGroup() // Ensure it's in its own group
 	if err := p.cmd.Start(); err != nil {
 		t.Fatalf("failed to start mock command: %v", err)

--- a/internal/cmd/dog.go
+++ b/internal/cmd/dog.go
@@ -699,7 +699,7 @@ func runDogDone(cmd *cobra.Command, args []string) error {
 	fmt.Printf("  Session %s will terminate in 3s\n", sessionID)
 
 	// Kill the tmux session after a short delay using a goroutine.
-	// Previous approach used bash -c "sleep 3 && tmux kill-session" which
+	// Previous approach used bash -c with a delay before tmux kill-session, which
 	// fails silently on Windows. The goroutine is cross-platform and uses
 	// the tmux package which handles the socket name automatically.
 	go func() {

--- a/internal/cmd/rig_test.go
+++ b/internal/cmd/rig_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/shellcmd"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
@@ -95,7 +96,7 @@ func TestFindRigSessions(t *testing.T) {
 
 	for _, name := range append(matching, nonMatching) {
 		_ = tm.KillSession(name) // clean up any leftovers
-		if err := tm.NewSessionWithCommand(name, "", "sleep 300"); err != nil {
+		if err := tm.NewSessionWithCommand(name, "", shellcmd.Sleep(300)); err != nil {
 			t.Fatalf("creating session %s: %v", name, err)
 		}
 	}

--- a/internal/daemon/convoy_manager_integration_test.go
+++ b/internal/daemon/convoy_manager_integration_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	beadsdk "github.com/steveyegge/beads"
+
+	"github.com/steveyegge/gastown/internal/shellcmd"
 )
 
 // TestConvoyManager_FullLifecycle starts a real ConvoyManager with a real beads
@@ -703,7 +705,7 @@ func TestConvoyManager_ShutdownKillsHangingSubprocess(t *testing.T) {
 	// Mock gt that hangs on stranded (simulates a stuck subprocess).
 	gtScript := `#!/bin/sh
 if [ "$1" = "convoy" ] && [ "$2" = "stranded" ]; then
-  sleep 999
+` + "  " + shellcmd.POSIXSleep(999) + `
   exit 0
 fi
 exit 0
@@ -724,7 +726,7 @@ exit 0
 		t.Fatalf("Start: %v", err)
 	}
 
-	// Let the stranded scan fire and start hanging on `sleep 999`.
+	// Let the stranded scan fire and start hanging on the mock stranded handler.
 	time.Sleep(500 * time.Millisecond)
 
 	// Stop must complete within bounded time despite the hanging subprocess.

--- a/internal/daemon/convoy_manager_test.go
+++ b/internal/daemon/convoy_manager_test.go
@@ -14,6 +14,8 @@ import (
 	"time"
 
 	beadsdk "github.com/steveyegge/beads"
+
+	"github.com/steveyegge/gastown/internal/shellcmd"
 )
 
 // setupTestStore opens a real beads database for integration tests.
@@ -215,7 +217,7 @@ func TestManagerLifecycle_StartStop(t *testing.T) {
 	townRoot := t.TempDir()
 	bdScript := `#!/bin/sh
 echo '{"type":"status","issue_id":"gt-x","new_status":"closed"}'
-sleep 999
+` + shellcmd.POSIXSleep(999) + `
 `
 	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0755); err != nil {
 		t.Fatalf("write mock bd: %v", err)
@@ -1244,7 +1246,7 @@ if [ "$1" = "convoy" ] && [ "$2" = "stranded" ]; then
 fi
 if [ "$1" = "sling" ]; then
   echo "$@" >> "` + slingLogPath + `"
-  sleep 10
+` + "  " + shellcmd.POSIXSleep(10) + `
   exit 0
 fi
 exit 0

--- a/internal/doctor/integration_test.go
+++ b/internal/doctor/integration_test.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/shellcmd"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
@@ -660,7 +661,7 @@ func TestIntegrationMultiTownSocketIsolation(t *testing.T) {
 			tmB.KillServer()
 		})
 
-		if err := tmA.NewSessionWithCommand("ga-witness", ".", "sleep 300"); err != nil {
+		if err := tmA.NewSessionWithCommand("ga-witness", ".", shellcmd.Sleep(300)); err != nil {
 			t.Fatalf("create session on socketA: %v", err)
 		}
 

--- a/internal/mail/router_test.go
+++ b/internal/mail/router_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/shellcmd"
 	"github.com/steveyegge/gastown/internal/testutil"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
@@ -1675,7 +1676,7 @@ func TestNotifyRecipient_BusyAgent(t *testing.T) {
 	sessionName := "gt-crew-busytest"
 
 	// Create a session running sleep — no prompt visible, simulating busy agent.
-	createNotifyTestSession(t, socket, sessionName, "sleep 300")
+	createNotifyTestSession(t, socket, sessionName, shellcmd.Sleep(300))
 
 	townRoot := t.TempDir()
 	r := &Router{
@@ -1726,7 +1727,7 @@ func TestNotifyRecipient_BusyAgent(t *testing.T) {
 func TestNotifyRecipient_BusyAgentEscalationUsesUrgentQueuedNudge(t *testing.T) {
 	socket := requireNotifyTestSocket(t)
 	sessionName := "gt-crew-busy-escalation"
-	createNotifyTestSession(t, socket, sessionName, "sleep 300")
+	createNotifyTestSession(t, socket, sessionName, shellcmd.Sleep(300))
 
 	townRoot := t.TempDir()
 	r := &Router{

--- a/internal/polecat/manager_integration_test.go
+++ b/internal/polecat/manager_integration_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/rig"
+	"github.com/steveyegge/gastown/internal/shellcmd"
 	"github.com/steveyegge/gastown/internal/testutil"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
@@ -47,7 +48,7 @@ func startLiveSession(t *testing.T, sessionName string) {
 	t.Helper()
 
 	tm := tmux.NewTmux()
-	if err := tm.NewSessionWithCommand(sessionName, "", "sleep 60"); err != nil {
+	if err := tm.NewSessionWithCommand(sessionName, "", shellcmd.Sleep(60)); err != nil {
 		t.Fatalf("start tmux session %s: %v", sessionName, err)
 	}
 	t.Cleanup(func() {

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/shellcmd"
 	"github.com/steveyegge/gastown/internal/testutil"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
@@ -1739,7 +1740,7 @@ func TestReuseIdlePolecat_KillsLiveSession(t *testing.T) {
 	// Create a live tmux session (simulates Claude sitting at ❯ after gt done)
 	sessMgr := NewSessionManager(tm, r)
 	sessionName := sessMgr.SessionName(polecatName)
-	if err := tm.NewSessionWithCommand(sessionName, townRoot, "sleep 300"); err != nil {
+	if err := tm.NewSessionWithCommand(sessionName, townRoot, shellcmd.Sleep(300)); err != nil {
 		t.Fatalf("create tmux session: %v", err)
 	}
 	t.Cleanup(func() { _ = tm.KillSessionWithProcesses(sessionName) })
@@ -1823,7 +1824,7 @@ func TestReuseIdlePolecat_KillsStaleSession(t *testing.T) {
 
 	sessMgr := NewSessionManager(tm, r)
 	sessionName := sessMgr.SessionName(polecatName)
-	if err := tm.NewSessionWithCommand(sessionName, townRoot, "sleep 300"); err != nil {
+	if err := tm.NewSessionWithCommand(sessionName, townRoot, shellcmd.Sleep(300)); err != nil {
 		t.Fatalf("create tmux session: %v", err)
 	}
 	t.Cleanup(func() { _ = tm.KillSessionWithProcesses(sessionName) })

--- a/internal/proxy/exec_test.go
+++ b/internal/proxy/exec_test.go
@@ -7,6 +7,7 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -20,6 +21,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/steveyegge/gastown/internal/shellcmd"
 )
 
 // logEntry captures a single structured log record for test assertions.
@@ -530,7 +533,7 @@ func TestExecConcurrencyLimit(t *testing.T) {
 		ctx, cancel := context.WithCancel(context.Background())
 		defer cancel()
 
-		body := `{"argv":["sh","-c","sleep 10"]}`
+		body := fmt.Sprintf(`{"argv":["sh","-c",%q]}`, shellcmd.POSIXSleep(10))
 		req := httptest.NewRequest("POST", "/v1/exec", strings.NewReader(body))
 		req = req.WithContext(ctx)
 

--- a/internal/proxy/git_test.go
+++ b/internal/proxy/git_test.go
@@ -21,6 +21,8 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/steveyegge/gastown/internal/shellcmd"
 )
 
 // pktLine encodes s as a single git pkt-line (4-hex-byte length prefix).
@@ -745,7 +747,7 @@ func TestHandleGitContextCancellation(t *testing.T) {
 		// Without exec, the shell forks sleep and sleep inherits the stdout
 		// pipe; cmd.Wait() then blocks until sleep exits even after the shell
 		// is killed, preventing prompt handler return on context cancellation.
-		require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\nexec sleep 10\n"), 0755))
+		require.NoError(t, os.WriteFile(path, []byte("#!/bin/sh\nexec "+shellcmd.POSIXSleep(10)+"\n"), 0755))
 	}
 	// Prepend scriptDir so exec.CommandContext resolves our stubs first.
 	// minimalEnv() propagates os.Getenv("PATH") to subprocesses, so the

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -15,6 +15,7 @@ import (
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/rig"
+	"github.com/steveyegge/gastown/internal/shellcmd"
 )
 
 func TestDefaultMergeQueueConfig(t *testing.T) {
@@ -562,7 +563,7 @@ func TestRunGate_Timeout(t *testing.T) {
 	e.workDir = t.TempDir()
 
 	result := e.runGate(context.Background(), "slow", &GateConfig{
-		Cmd:     "sleep 10",
+		Cmd:     shellcmd.Sleep(10),
 		Timeout: 100 * time.Millisecond,
 	})
 

--- a/internal/shellcmd/doc.go
+++ b/internal/shellcmd/doc.go
@@ -1,0 +1,7 @@
+// Package shellcmd builds portable shell command strings (e.g. sleep) for
+// tmux pane commands, hooks, and tests. It is separate from internal/shell,
+// which handles interactive shell RC integration.
+//
+// POSIXSleep is for fragments inside sh/bash scripts and hooks where the text
+// must stay POSIX even when Sleep uses cmd.exe’s timeout on Windows.
+package shellcmd

--- a/internal/shellcmd/posix_sleep.go
+++ b/internal/shellcmd/posix_sleep.go
@@ -1,0 +1,11 @@
+package shellcmd
+
+import "strconv"
+
+// POSIXSleep returns a POSIX sleep(1) command line ("sleep N"). Use inside
+// sh/bash hooks, #!/bin/sh scripts, and JSON argv for "sh -c" where the
+// fragment must stay POSIX. For tmux pane commands on Windows (cmd.exe), use
+// Sleep instead.
+func POSIXSleep(seconds int) string {
+	return "sleep " + strconv.Itoa(seconds)
+}

--- a/internal/shellcmd/sleep_unix.go
+++ b/internal/shellcmd/sleep_unix.go
@@ -1,0 +1,16 @@
+//go:build !windows
+
+package shellcmd
+
+import "strconv"
+
+// Sleep returns a shell command line that sleeps for the given number of
+// seconds (POSIX sleep(1)), suitable for tmux NewSessionWithCommand and similar.
+func Sleep(seconds int) string {
+	return "sleep " + strconv.Itoa(seconds)
+}
+
+// SleepCommand returns the basename of the sleep command for this platform.
+func SleepCommand() string {
+	return "sleep"
+}

--- a/internal/shellcmd/sleep_windows.go
+++ b/internal/shellcmd/sleep_windows.go
@@ -1,0 +1,17 @@
+//go:build windows
+
+package shellcmd
+
+import "fmt"
+
+// Sleep returns a shell command line that sleeps for the given number of
+// seconds (Windows timeout), suitable for tmux when the pane runs cmd.exe.
+// The string is not wrapped in powershell.exe; pass it to tmux as the pane command.
+func Sleep(seconds int) string {
+	return fmt.Sprintf("timeout /T %d > NUL", seconds)
+}
+
+// SleepCommand returns the basename of the sleep command for this platform.
+func SleepCommand() string {
+	return "timeout"
+}

--- a/internal/tmux/cross_socket_test.go
+++ b/internal/tmux/cross_socket_test.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"testing"
+
+	"github.com/steveyegge/gastown/internal/shellcmd"
 )
 
 var crossSocket = fmt.Sprintf("gt-test-cross-%d", os.Getpid())
@@ -27,12 +29,12 @@ func TestCrossSocketIsolation(t *testing.T) {
 	sessionA := fmt.Sprintf("gt-test-iso-a-%d", os.Getpid())
 	sessionB := fmt.Sprintf("gt-test-iso-b-%d", os.Getpid())
 
-	if err := defaultTm.NewSessionWithCommand(sessionA, ".", "sleep 300"); err != nil {
+	if err := defaultTm.NewSessionWithCommand(sessionA, ".", shellcmd.Sleep(300)); err != nil {
 		t.Fatalf("create session A on default socket: %v", err)
 	}
 	t.Cleanup(func() { _ = defaultTm.KillSession(sessionA) })
 
-	if err := crossTm.NewSessionWithCommand(sessionB, ".", "sleep 300"); err != nil {
+	if err := crossTm.NewSessionWithCommand(sessionB, ".", shellcmd.Sleep(300)); err != nil {
 		t.Fatalf("create session B on cross socket: %v", err)
 	}
 	t.Cleanup(func() { _ = crossTm.KillSession(sessionB) })
@@ -81,12 +83,12 @@ func TestCrossSocketKill(t *testing.T) {
 	defaultSession := fmt.Sprintf("gt-test-survive-%d", os.Getpid())
 	crossSession := fmt.Sprintf("gt-test-doomed-%d", os.Getpid())
 
-	if err := defaultTm.NewSessionWithCommand(defaultSession, ".", "sleep 300"); err != nil {
+	if err := defaultTm.NewSessionWithCommand(defaultSession, ".", shellcmd.Sleep(300)); err != nil {
 		t.Fatalf("create session on default socket: %v", err)
 	}
 	t.Cleanup(func() { _ = defaultTm.KillSession(defaultSession) })
 
-	if err := crossTm.NewSessionWithCommand(crossSession, ".", "sleep 300"); err != nil {
+	if err := crossTm.NewSessionWithCommand(crossSession, ".", shellcmd.Sleep(300)); err != nil {
 		t.Fatalf("create session on cross socket: %v", err)
 	}
 
@@ -117,14 +119,14 @@ func TestSessionsOnMultipleSockets(t *testing.T) {
 	}
 
 	for _, name := range defaultSessions {
-		if err := defaultTm.NewSessionWithCommand(name, ".", "sleep 300"); err != nil {
+		if err := defaultTm.NewSessionWithCommand(name, ".", shellcmd.Sleep(300)); err != nil {
 			t.Fatalf("create %q on default socket: %v", name, err)
 		}
 		t.Cleanup(func() { _ = defaultTm.KillSession(name) })
 	}
 
 	for _, name := range crossSessions {
-		if err := crossTm.NewSessionWithCommand(name, ".", "sleep 300"); err != nil {
+		if err := crossTm.NewSessionWithCommand(name, ".", shellcmd.Sleep(300)); err != nil {
 			t.Fatalf("create %q on cross socket: %v", name, err)
 		}
 		t.Cleanup(func() { _ = crossTm.KillSession(name) })

--- a/internal/tmux/cycle_bindings_test.go
+++ b/internal/tmux/cycle_bindings_test.go
@@ -3,6 +3,8 @@ package tmux
 import (
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/gastown/internal/shellcmd"
 )
 
 // TestIsGTBindingCurrent_DetectsStalePattern verifies that isGTBindingCurrent
@@ -16,7 +18,7 @@ func TestIsGTBindingCurrent_DetectsStalePattern(t *testing.T) {
 	_ = tm.KillSession(session)
 	defer func() { _ = tm.KillSession(session) }()
 
-	if err := tm.NewSessionWithCommand(session, "", "sleep 30"); err != nil {
+	if err := tm.NewSessionWithCommand(session, "", shellcmd.Sleep(30)); err != nil {
 		t.Fatalf("session creation: %v", err)
 	}
 
@@ -57,7 +59,7 @@ func TestSetCycleBindings_RefreshesStalePattern(t *testing.T) {
 	_ = tm.KillSession(session)
 	defer func() { _ = tm.KillSession(session) }()
 
-	if err := tm.NewSessionWithCommand(session, "", "sleep 30"); err != nil {
+	if err := tm.NewSessionWithCommand(session, "", shellcmd.Sleep(30)); err != nil {
 		t.Fatalf("session creation: %v", err)
 	}
 

--- a/internal/tmux/respawn_hook_test.go
+++ b/internal/tmux/respawn_hook_test.go
@@ -7,6 +7,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/shellcmd"
 )
 
 // requireTestSocket returns a per-test socket name and skips the test if
@@ -96,9 +98,9 @@ func TestAutoRespawnHook_RespawnWorks(t *testing.T) {
 		t.Logf("[+%6.2fs] %s", time.Since(t0).Seconds(), fmt.Sprintf(msg, args...))
 	}
 
-	testSession(t, socket, session, "sleep 2")
+	testSession(t, socket, session, shellcmd.Sleep(2))
 	defer func() { _ = exec.Command("tmux", "-L", socket, "kill-session", "-t", session).Run() }()
-	logT("session created with 'sleep 2'")
+	logT("session created with %q", shellcmd.Sleep(2))
 
 	// Log the initial pane state
 	logT("initial pane_dead=%v, pane_pid=%s", isPaneDead(socket, session), getPanePIDSafe(socket, session))
@@ -125,11 +127,11 @@ func TestAutoRespawnHook_RespawnWorks(t *testing.T) {
 		logT("tmux version: %s", strings.TrimSpace(string(verOut)))
 	}
 
-	// Wait for sleep 2 to exit
+	// Wait for short sleep command to exit
 	deadline := time.Now().Add(5 * time.Second)
 	for time.Now().Before(deadline) {
 		if isPaneDead(socket, session) {
-			logT("pane died (sleep 2 exited)")
+			logT("pane died (%s exited)", shellcmd.Sleep(2))
 			break
 		}
 		time.Sleep(200 * time.Millisecond)
@@ -186,7 +188,7 @@ func TestAutoRespawnHook_SkipsAlreadyAlive(t *testing.T) {
 	socket := requireTestSocket(t)
 	session := "test-skip-alive"
 
-	testSession(t, socket, session, "sleep 300")
+	testSession(t, socket, session, shellcmd.Sleep(300))
 	defer func() { _ = exec.Command("tmux", "-L", socket, "kill-session", "-t", session).Run() }()
 
 	tmx := NewTmuxWithSocket(socket)
@@ -199,7 +201,7 @@ func TestAutoRespawnHook_SkipsAlreadyAlive(t *testing.T) {
 	time.Sleep(500 * time.Millisecond)
 
 	// Simulate daemon: immediately respawn before hook wakes
-	exec.Command("tmux", "-L", socket, "respawn-pane", "-k", "-t", session, "sleep 300").Run()
+	exec.Command("tmux", "-L", socket, "respawn-pane", "-k", "-t", session, shellcmd.Sleep(300)).Run()
 	time.Sleep(300 * time.Millisecond)
 
 	pid1 := getPanePID(t, socket, session)

--- a/internal/tmux/session_creation_test.go
+++ b/internal/tmux/session_creation_test.go
@@ -4,6 +4,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/shellcmd"
 )
 
 // Tests for the two-step session creation (new-session + respawn-pane) and
@@ -60,7 +62,7 @@ func TestNewSessionWithCommand_Success(t *testing.T) {
 	_ = tm.KillSession(session)
 	defer func() { _ = tm.KillSession(session) }()
 
-	err := tm.NewSessionWithCommand(session, "", `sh -c 'echo "SESSION_OK"; sleep 10'`)
+	err := tm.NewSessionWithCommand(session, "", "sh -c 'echo \"SESSION_OK\"; "+shellcmd.POSIXSleep(10)+"'")
 	if err != nil {
 		t.Fatalf("NewSessionWithCommand failed: %v", err)
 	}
@@ -80,7 +82,7 @@ func TestNewSessionWithCommand_ExecEnvSuccess(t *testing.T) {
 	_ = tm.KillSession(session)
 	defer func() { _ = tm.KillSession(session) }()
 
-	cmd := `exec env GT_RIG=testrig GT_POLECAT=testcat sleep 5`
+	cmd := `exec env GT_RIG=testrig GT_POLECAT=testcat ` + shellcmd.POSIXSleep(5)
 	err := tm.NewSessionWithCommand(session, t.TempDir(), cmd)
 	if err != nil {
 		t.Fatalf("NewSessionWithCommand failed: %v", err)
@@ -100,10 +102,10 @@ func TestNewSessionWithCommand_Duplicate(t *testing.T) {
 	_ = tm.KillSession(session)
 	defer func() { _ = tm.KillSession(session) }()
 
-	if err := tm.NewSessionWithCommand(session, "", "sleep 10"); err != nil {
+	if err := tm.NewSessionWithCommand(session, "", shellcmd.Sleep(10)); err != nil {
 		t.Fatalf("first create: %v", err)
 	}
-	err := tm.NewSessionWithCommand(session, "", "sleep 10")
+	err := tm.NewSessionWithCommand(session, "", shellcmd.Sleep(10))
 	if err == nil {
 		t.Error("duplicate session creation should fail")
 	}
@@ -128,7 +130,7 @@ func TestNewSessionWithCommand_Concurrent(t *testing.T) {
 	errs := make(chan error, n)
 	for i := 0; i < n; i++ {
 		go func(idx int) {
-			errs <- tm.NewSessionWithCommand(base+string(rune('a'+idx)), "", "sleep 5")
+			errs <- tm.NewSessionWithCommand(base+string(rune('a'+idx)), "", shellcmd.Sleep(5))
 		}(i)
 	}
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/shellcmd"
 	"github.com/steveyegge/gastown/internal/telemetry"
 )
 
@@ -3904,7 +3905,7 @@ func (t *Tmux) SetAutoRespawnHook(session string) error {
 //     error display from tmux even if the session was killed entirely.
 func buildAutoRespawnHookCmd(tmuxCmd, session string) string {
 	// The shell pipeline:
-	//   sleep 3                              -- debounce rapid crashes
+	//   POSIX sleep (debounce)             -- debounce rapid crashes
 	//   list-panes ... #{pane_dead} | grep   -- guard: only proceed if pane is still dead
 	//   respawn-pane -k                      -- restart with original command
 	//   set-option remain-on-exit on         -- re-enable (respawn-pane resets it to off!)
@@ -3917,6 +3918,6 @@ func buildAutoRespawnHookCmd(tmuxCmd, session string) string {
 	// receives #{pane_dead} and passes it to the nested `tmux list-panes` call
 	// which evaluates it at query time -- giving us the CURRENT pane state.
 	return fmt.Sprintf(
-		`run-shell -b "sleep 3 && %s list-panes -t '%s' -F '##{pane_dead}' 2>/dev/null | grep -q 1 && %s respawn-pane -k -t '%s' && %s set-option -t '%s' remain-on-exit on || true"`,
+		`run-shell -b "`+shellcmd.POSIXSleep(3)+` && %s list-panes -t '%s' -F '##{pane_dead}' 2>/dev/null | grep -q 1 && %s respawn-pane -k -t '%s' && %s set-option -t '%s' remain-on-exit on || true"`,
 		tmuxCmd, session, tmuxCmd, session, tmuxCmd, session)
 }

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -9,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/shellcmd"
 )
 
 func hasTmux() bool {
@@ -308,7 +310,7 @@ func TestEnsureSessionFreshWithCommand_NoExisting(t *testing.T) {
 
 	// EnsureSessionFreshWithCommand should create a new session with the command
 	// as the initial pane process (no shell involved).
-	if err := tm.EnsureSessionFreshWithCommand(sessionName, "", "sleep 10"); err != nil {
+	if err := tm.EnsureSessionFreshWithCommand(sessionName, "", shellcmd.Sleep(10)); err != nil {
 		t.Fatalf("EnsureSessionFreshWithCommand: %v", err)
 	}
 
@@ -354,7 +356,7 @@ func TestEnsureSessionFreshWithCommand_KillsZombie(t *testing.T) {
 	}
 
 	// EnsureSessionFreshWithCommand should kill the zombie and create fresh session
-	if err := tm.EnsureSessionFreshWithCommand(sessionName, "", "sleep 10"); err != nil {
+	if err := tm.EnsureSessionFreshWithCommand(sessionName, "", shellcmd.Sleep(10)); err != nil {
 		t.Fatalf("EnsureSessionFreshWithCommand on zombie: %v", err)
 	}
 
@@ -485,7 +487,7 @@ func TestIsRuntimeRunning_AgentNameRequiresCursorSession(t *testing.T) {
 	tm := newTestTmux(t)
 	sessionName := "gt-test-runtime-agent-filter-" + t.Name()
 	_ = tm.KillSession(sessionName)
-	if err := tm.NewSessionWithCommand(sessionName, "", "sleep 60"); err != nil {
+	if err := tm.NewSessionWithCommand(sessionName, "", shellcmd.Sleep(60)); err != nil {
 		t.Fatalf("NewSessionWithCommand: %v", err)
 	}
 	defer func() { _ = tm.KillSession(sessionName) }()
@@ -542,7 +544,7 @@ func TestIsRuntimeRunning_ShellWithNodeChild(t *testing.T) {
 		sessionName := "gt-test-runtime-direct"
 		_ = tm.KillSession(sessionName)
 
-		if err := tm.NewSessionWithCommand(sessionName, "", "sleep 10"); err != nil {
+		if err := tm.NewSessionWithCommand(sessionName, "", shellcmd.Sleep(10)); err != nil {
 			t.Fatalf("NewSessionWithCommand: %v", err)
 		}
 		defer func() { _ = tm.KillSession(sessionName) }()
@@ -560,7 +562,7 @@ func TestIsRuntimeRunning_ShellWithNodeChild(t *testing.T) {
 		sessionName := "gt-test-runtime-shell-child"
 		_ = tm.KillSession(sessionName)
 
-		if err := tm.NewSessionWithCommand(sessionName, "", "sh -c 'sleep 10'"); err != nil {
+		if err := tm.NewSessionWithCommand(sessionName, "", "sh -c '"+shellcmd.POSIXSleep(10)+"'"); err != nil {
 			t.Fatalf("NewSessionWithCommand: %v", err)
 		}
 		defer func() { _ = tm.KillSession(sessionName) }()
@@ -586,7 +588,7 @@ func TestGetPaneCommand_MultiPane(t *testing.T) {
 	_ = tm.KillSession(sessionName)
 
 	// Create session running sleep (simulates an agent process in pane 0)
-	if err := tm.NewSessionWithCommand(sessionName, "", "sleep 300"); err != nil {
+	if err := tm.NewSessionWithCommand(sessionName, "", shellcmd.Sleep(300)); err != nil {
 		t.Fatalf("NewSessionWithCommand: %v", err)
 	}
 	defer func() { _ = tm.KillSession(sessionName) }()
@@ -708,7 +710,7 @@ func TestKillSessionWithProcesses(t *testing.T) {
 	_ = tm.KillSession(sessionName)
 
 	// Create session with a long-running process
-	cmd := `sleep 300`
+	cmd := shellcmd.Sleep(300)
 	if err := tm.NewSessionWithCommand(sessionName, "", cmd); err != nil {
 		t.Fatalf("NewSessionWithCommand: %v", err)
 	}
@@ -756,7 +758,7 @@ func TestKillSessionWithProcessesExcluding(t *testing.T) {
 	_ = tm.KillSession(sessionName)
 
 	// Create session with a long-running process
-	cmd := `sleep 300`
+	cmd := shellcmd.Sleep(300)
 	if err := tm.NewSessionWithCommand(sessionName, "", cmd); err != nil {
 		t.Fatalf("NewSessionWithCommand: %v", err)
 	}
@@ -795,7 +797,7 @@ func TestKillSessionWithProcessesExcluding_WithExcludePID(t *testing.T) {
 	_ = tm.KillSession(sessionName)
 
 	// Create session with a long-running process
-	cmd := `sleep 300`
+	cmd := shellcmd.Sleep(300)
 	if err := tm.NewSessionWithCommand(sessionName, "", cmd); err != nil {
 		t.Fatalf("NewSessionWithCommand: %v", err)
 	}
@@ -891,7 +893,7 @@ func TestKillSessionWithProcesses_KillsProcessGroup(t *testing.T) {
 
 	// Create session that spawns a child process
 	// The child will stay in the same process group as the shell
-	cmd := `sleep 300 & sleep 300`
+	cmd := shellcmd.Sleep(300) + " & " + shellcmd.Sleep(300)
 	if err := tm.NewSessionWithCommand(sessionName, "", cmd); err != nil {
 		t.Fatalf("NewSessionWithCommand: %v", err)
 	}
@@ -1004,18 +1006,18 @@ func TestCleanupOrphanedSessions(t *testing.T) {
 	// Use NewSessionWithCommand with sleep to avoid loading .zshrc, which spawns
 	// a node process on this system. A node child of the zsh shell would cause
 	// IsAgentAlive to return true, preventing cleanup (gt-it10f6p).
-	if err := tm.NewSessionWithCommand(gtSession, "", "sleep 9999"); err != nil {
+	if err := tm.NewSessionWithCommand(gtSession, "", shellcmd.Sleep(9999)); err != nil {
 		t.Fatalf("NewSessionWithCommand(gt): %v", err)
 	}
 	defer func() { _ = tm.KillSession(gtSession) }()
 
-	if err := tm.NewSessionWithCommand(hqSession, "", "sleep 9999"); err != nil {
+	if err := tm.NewSessionWithCommand(hqSession, "", shellcmd.Sleep(9999)); err != nil {
 		t.Fatalf("NewSessionWithCommand(hq): %v", err)
 	}
 	defer func() { _ = tm.KillSession(hqSession) }()
 
 	// Create a non-GT session (should NOT be cleaned up)
-	if err := tm.NewSessionWithCommand(nonGtSession, "", "sleep 9999"); err != nil {
+	if err := tm.NewSessionWithCommand(nonGtSession, "", shellcmd.Sleep(9999)); err != nil {
 		t.Fatalf("NewSessionWithCommand(other): %v", err)
 	}
 	defer func() { _ = tm.KillSession(nonGtSession) }()
@@ -1144,14 +1146,14 @@ func TestKillSessionWithProcesses_DoesNotKillUnrelatedProcesses(t *testing.T) {
 	_ = tm.KillSession(sessionName)
 
 	// Create session with a long-running process
-	if err := tm.NewSessionWithCommand(sessionName, "", "sleep 300"); err != nil {
+	if err := tm.NewSessionWithCommand(sessionName, "", shellcmd.Sleep(300)); err != nil {
 		t.Fatalf("NewSessionWithCommand: %v", err)
 	}
 	defer func() { _ = tm.KillSession(sessionName) }()
 
 	// Start a separate background process (simulating an unrelated process)
 	// This process runs in its own process group (via setsid or just being separate)
-	sentinel := exec.Command("sleep", "300")
+	sentinel := exec.Command(shellcmd.SleepCommand(), "300")
 	if err := sentinel.Start(); err != nil {
 		t.Fatalf("starting sentinel process: %v", err)
 	}
@@ -1185,7 +1187,7 @@ func TestKillPaneProcessesExcluding(t *testing.T) {
 	_ = tm.KillSession(sessionName)
 
 	// Create session with a long-running process
-	cmd := `sleep 300`
+	cmd := shellcmd.Sleep(300)
 	if err := tm.NewSessionWithCommand(sessionName, "", cmd); err != nil {
 		t.Fatalf("NewSessionWithCommand: %v", err)
 	}
@@ -1215,7 +1217,7 @@ func TestKillPaneProcessesExcluding_WithExcludePID(t *testing.T) {
 	_ = tm.KillSession(sessionName)
 
 	// Create session with a long-running process
-	cmd := `sleep 300`
+	cmd := shellcmd.Sleep(300)
 	if err := tm.NewSessionWithCommand(sessionName, "", cmd); err != nil {
 		t.Fatalf("NewSessionWithCommand: %v", err)
 	}
@@ -1337,7 +1339,7 @@ func TestFindAgentPane_MultiPaneWithNode(t *testing.T) {
 	defer func() { _ = tm.KillSession(sessionName) }()
 
 	// Split and run sleep in the new pane (simulating an agent process)
-	_, err := tm.run("split-window", "-t", sessionName, "-d", "sleep", "10")
+	_, err := tm.run("split-window", "-t", sessionName, "-d", shellcmd.SleepCommand(), "10")
 	if err != nil {
 		t.Fatalf("split-window: %v", err)
 	}
@@ -1581,7 +1583,7 @@ func TestNewSessionWithCommandAndEnv(t *testing.T) {
 	}
 
 	// Create session with env vars and a command that prints GT_ROLE
-	cmd := `bash -c "echo GT_ROLE=$GT_ROLE; sleep 5"`
+	cmd := "bash -c \"echo GT_ROLE=$GT_ROLE; " + shellcmd.POSIXSleep(5) + "\""
 	if err := tm.NewSessionWithCommandAndEnv(sessionName, "", cmd, env); err != nil {
 		t.Fatalf("NewSessionWithCommandAndEnv: %v", err)
 	}
@@ -1622,7 +1624,7 @@ func TestNewSessionWithCommandAndEnvEmpty(t *testing.T) {
 	_ = tm.KillSession(sessionName)
 
 	// Empty env should work like NewSessionWithCommand
-	if err := tm.NewSessionWithCommandAndEnv(sessionName, "", "sleep 5", nil); err != nil {
+	if err := tm.NewSessionWithCommandAndEnv(sessionName, "", shellcmd.Sleep(5), nil); err != nil {
 		t.Fatalf("NewSessionWithCommandAndEnv with nil env: %v", err)
 	}
 	defer func() { _ = tm.KillSession(sessionName) }()
@@ -1846,7 +1848,7 @@ func TestWaitForIdle_Timeout(t *testing.T) {
 
 	// Create a session running a long sleep (no prompt visible)
 	sessionName := fmt.Sprintf("gt-test-idle-%d", time.Now().UnixNano())
-	if err := tm.NewSessionWithCommand(sessionName, os.TempDir(), "sleep 60"); err != nil {
+	if err := tm.NewSessionWithCommand(sessionName, os.TempDir(), shellcmd.Sleep(60)); err != nil {
 		t.Fatalf("NewSessionWithCommand: %v", err)
 	}
 	defer func() { _ = tm.KillSession(sessionName) }()
@@ -2285,7 +2287,7 @@ func TestCheckSessionHealth_ActivityCheck(t *testing.T) {
 	tm := newTestTmux(t)
 	sessionName := fmt.Sprintf("gt-test-activity-%d", os.Getpid())
 	// Use 'sleep' as a stand-in for an agent process
-	if err := tm.NewSessionWithCommand(sessionName, "", "sleep 60"); err != nil {
+	if err := tm.NewSessionWithCommand(sessionName, "", shellcmd.Sleep(60)); err != nil {
 		t.Fatalf("NewSession: %v", err)
 	}
 	defer tm.KillSession(sessionName)

--- a/internal/util/orphan_test.go
+++ b/internal/util/orphan_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/gastown/internal/shellcmd"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
@@ -152,7 +153,7 @@ func hasTmux() bool {
 func tmuxSocketSession(t *testing.T, socketName, sessionName string) int {
 	t.Helper()
 	err := exec.Command("tmux", "-L", socketName, "new-session", "-d",
-		"-s", sessionName, "-x", "80", "-y", "24", "sleep", "300").Run()
+		"-s", sessionName, "-x", "80", "-y", "24", shellcmd.SleepCommand(), "300").Run()
 	if err != nil {
 		t.Fatalf("create session %q on socket %q: %v", sessionName, socketName, err)
 	}

--- a/internal/web/fetcher_test.go
+++ b/internal/web/fetcher_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/steveyegge/gastown/internal/activity"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/shellcmd"
 )
 
 func TestCalculateWorkStatus(t *testing.T) {
@@ -506,7 +507,7 @@ func TestRunCmd_SuccessAndTimeout(t *testing.T) {
 
 	// Use "exec sleep" so sleep replaces the shell process — avoids orphan child
 	// holding stdout open. Use 200ms timeout (not 30ms) for stability under load.
-	_, err = runCmd(200*time.Millisecond, "sh", "-c", "exec sleep 10")
+	_, err = runCmd(200*time.Millisecond, "sh", "-c", "exec "+shellcmd.POSIXSleep(10))
 	if err == nil {
 		t.Fatal("expected timeout error")
 	}
@@ -531,7 +532,7 @@ case "$1" in
     exit 1
     ;;
   sleep)
-    exec sleep 10
+    exec ` + shellcmd.POSIXSleep(10) + `
     ;;
   *)
     echo "ok"


### PR DESCRIPTION
## Summary

This PR is a stepping stone toward full cross-platform behavior for delay/sleep usage across POSIX and Windows. It introduces internal/shellcmd with:

- `Sleep` function for Unix-like systems.
- `SleepCommand` function to return the appropriate sleep command based on the platform.
- `POSIXSleep` function for use in POSIX-compliant scripts (temporary util platform specific calls can be addressed)

Additionally, existing tests and code have been updated to utilize these new utilities, ensuring consistent behavior across different operating systems.

## Related Issue
#3665

## Changes
- add package shellcmd with sleep related functions

## Testing
- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)

## What is intentionally not done yet
Full sleep compatibility is not complete. Some code paths still execute commands via /bin/sh (or otherwise assume a POSIX shell). Those strings must continue to use POSIX sleep semantics; mixing in Windows timeout there would be incorrect. This PR uses POSIXSleep only where we explicitly identified POSIX-only embedding; a later issue/PR should audit remaining sh -c, script heredocs, and subprocess setup so behavior is correct and tested on both families of OS.

Similarly, a few places (e.g. proxy allowlists and JSON that name the sleep binary by argv) were left as explicit literals where changing them would couple tests to platform naming without improving the product yet.