### PR TITLE
fix: remove interactive handoff confirmation from embedded command

### DIFF
--- a/internal/templates/commands/bodies/handoff.md
+++ b/internal/templates/commands/bodies/handoff.md
@@ -4,14 +4,10 @@ User's handoff message (if any): $ARGUMENTS
 
 Execute these steps in order:
 
-1. Ask the user: "Ready to hand off? This will restart the session. (y/N)"
-   - If the user says no or doesn't confirm, stop here. Do NOT run gt handoff.
-   - Only proceed if the user explicitly confirms with 'y' or 'yes'.
-
-2. If user provided a message, run the handoff command with a subject and message:
+1. If user provided a message, run the handoff command with a subject and message:
    `gt handoff -y -s "HANDOFF: Session cycling" -m "USER_MESSAGE_HERE"`
 
-3. If no message was provided, run the handoff command:
+2. If no message was provided, run the handoff command:
    `gt handoff -y`
 
 Note: The new session will auto-prime via the SessionStart hook and find your handoff mail.

--- a/internal/templates/commands/provision_test.go
+++ b/internal/templates/commands/provision_test.go
@@ -31,6 +31,12 @@ func TestBuildCommand_Claude(t *testing.T) {
 	if !strings.Contains(content, "$ARGUMENTS") {
 		t.Error("missing $ARGUMENTS in body")
 	}
+	if strings.Contains(content, "Ready to hand off?") {
+		t.Error("Claude handoff command should not require an interactive confirmation prompt")
+	}
+	if !strings.Contains(content, "gt handoff -y") {
+		t.Error("Claude handoff command should use gt handoff -y")
+	}
 }
 
 func TestBuildCommand_OpenCode(t *testing.T) {


### PR DESCRIPTION
## Summary
- remove the extra interactive confirmation step from the embedded Claude `/handoff` command
- keep the actual CLI handoff invocation explicit and non-interactive with `gt handoff -y`
- add a targeted test that locks the embedded command body to the autonomous-safe shape

## Why
Autonomous agents can already call `gt handoff -y`, but the embedded Claude command template stopped them before they ever reached the CLI by asking for a user confirmation that detached sessions can never provide. That wedges session cycling for headless agents even though the downstream command already has the correct non-interactive flag.

## Validation
- `docker run --rm -v "$PWD":/src -w /src golang:1.25 /usr/local/go/bin/go test ./internal/templates/commands`
- `docker run --rm -v "$PWD":/src -w /src golang:1.25 /usr/local/go/bin/go test ./internal/templates/...`
