### PR TITLE
Fix SetAgentState failure: deterministic agentBeadID across spawn and session

### DIFF
--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -381,7 +381,6 @@ func TestNewManager_NamepoolFromRigConfig(t *testing.T) {
 		t.Errorf("expected first name from rig config (alpha), got %q", name)
 	}
 }
-
 // Note: State persistence tests removed - state is now derived from beads assignee field.
 // Integration tests should verify beads-based state management.
 


### PR DESCRIPTION
## Summary
- Fixes #3676
- `SetAgentState` failed with "issue not found" on every polecat spawn because `agentBeadID()` computed different IDs from the main rig path vs the polecat worktree path
- The Manager now uses a deterministic town root so the agent bead ID is consistent regardless of whether it's called during spawn or session start

## Impact
- Polecats were working but invisible to the Gas Town Control Center dashboard
- `gt polecat list` showed working polecats as "stalled"
- Witness escalated unnecessarily on healthy polecats

## Test plan
- [ ] `gt sling` a bead — verify no `SetAgentState` warnings
- [ ] `gt polecat list` shows polecat as "working" (not "stalled")
- [ ] Dashboard shows polecat count > 0
- [ ] `gt polecat nuke` no longer reports "agent bead not found"