### PR TITLE
fix(mq): repair two bugs that orphan every polecat's MR bead

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -298,7 +298,17 @@ type CreateOptions struct {
 	Parent      string
 	Actor       string // Who is creating this issue (populates created_by)
 	Ephemeral   bool   // Create as ephemeral (wisp) - not synced to git
-	Rig         string // Target rig database (e.g., "gastown"). When set, passes --rig to bd create.
+	// Rig names the target rig database (e.g., "gastown").
+	//
+	// Advisory only: bd has no --rig flag. Routing is determined by the
+	// Beads wrapper's workdir/BEADS_DIR (see run at L411). Callers construct
+	// beads.New(cwd) where cwd is inside the target rig, which sets
+	// BEADS_DIR=<rig>/.beads automatically.
+	//
+	// mq_submit and done validate the landing DB post-create via
+	// ValidateRigPrefix, so a wrong-rig outcome is surfaced as a warning
+	// rather than silently succeeding.
+	Rig string
 }
 
 // UpdateOptions specifies options for updating an issue.
@@ -1226,9 +1236,11 @@ func (b *Beads) Create(opts CreateOptions) (*Issue, error) {
 	if opts.Ephemeral {
 		args = append(args, "--ephemeral")
 	}
-	if opts.Rig != "" {
-		args = append(args, "--rig="+opts.Rig)
-	}
+	// opts.Rig is advisory — see CreateOptions.Rig. Do not pass --rig to bd;
+	// bd has no such flag and rejects it. Routing is via the wrapper's
+	// workdir/BEADS_DIR; mq_submit and done verify the landing DB with
+	// ValidateRigPrefix after create.
+	_ = opts.Rig
 	// Default Actor from BD_ACTOR env var if not specified
 	// Uses getActor() to respect isolated mode (tests)
 	actor := opts.Actor

--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -232,10 +232,26 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// GH#3032: Resolve HEAD commit SHA for MR dedup.
-	commitSHA, shaErr := g.Rev("HEAD")
+	// GH#3032: Resolve source-branch commit SHA for MR dedup.
+	// Resolve from the branch arg, not HEAD: when mq submit is invoked from
+	// a worktree that is NOT checked out on the source branch (e.g. the
+	// refinery's main-tracking worktree manually submitting a polecat's
+	// pushed branch), HEAD is the wrong ref and yields the wrong SHA.
+	// Fall back to origin/<branch> when the branch isn't present locally,
+	// then finally to HEAD for the legacy "submit from the source branch"
+	// caller shape.
+	commitSHA, shaErr := g.Rev(branch)
 	if shaErr != nil {
-		style.PrintWarning("could not resolve HEAD SHA: %v (falling back to branch-only dedup)", shaErr)
+		if originSHA, originErr := g.Rev("origin/" + branch); originErr == nil {
+			commitSHA = originSHA
+			shaErr = nil
+		} else if headSHA, headErr := g.Rev("HEAD"); headErr == nil {
+			commitSHA = headSHA
+			shaErr = nil
+		}
+	}
+	if shaErr != nil {
+		style.PrintWarning("could not resolve SHA for branch %q: %v (falling back to branch-only dedup)", branch, shaErr)
 	}
 
 	// Build MR bead title and description


### PR DESCRIPTION
## Summary

`gt mq submit` (and the same code path in `gt done`) has been silently orphaning every polecat's merge-request bead. Work pushes cleanly to origin, `bd close` marks the source issue CLOSED, but the MR bead that tells the refinery "merge this" is never created — so branches pile up on origin and nothing lands on `main`. Two distinct bugs compound:

### Bug A — `bd create` rejects `--rig`

[`internal/beads/beads.go:Beads.Create`](https://github.com/gastownhall/gastown/blob/main/internal/beads/beads.go#L1229-L1231) appends `--rig=<rigName>` when `CreateOptions.Rig` is set ([gt-7y7](https://github.com/gastownhall/gastown/issues?q=gt-7y7)). `bd` has no such flag and exits with \`Error: unknown flag: --rig\`. Reproduction against `bd 1.0.2`:

\`\`\`
$ gt mq submit --branch polecat/rust/rg-9tw@mo3meyfq --issue rg-9tw
Error: creating merge request bead: bd create --json --title=Merge: rg-9tw
  --labels=gt:merge-request --priority=2 --description=...
  --ephemeral --rig=robot_grid --actor=mayor: Error: unknown flag: --rig
\`\`\`

Routing to the rig's DB was already correct independently — the \`Beads\` wrapper sets \`BEADS_DIR\` from its workdir ([\`beads.go:run\`](https://github.com/gastownhall/gastown/blob/main/internal/beads/beads.go#L411)), and both call sites (\`mq_submit\`, \`done\`) construct \`beads.New(cwd)\` where \`cwd\` is inside the target rig. The \`--rig\` flag addition was dead code that claimed to do routing but only served to crash the call.

**Fix:** stop emitting \`--rig\`. \`CreateOptions.Rig\` is now documented as advisory, with a pointer to the real routing mechanism (workdir-based \`BEADS_DIR\` + the post-create \`ValidateRigPrefix\` check both call sites already run).

### Bug B — `commit_sha` is resolved from `HEAD`, not the source branch

[`internal/cmd/mq_submit.go:236`](https://github.com/gastownhall/gastown/blob/main/internal/cmd/mq_submit.go#L236) calls \`g.Rev(\"HEAD\")\`. When \`gt mq submit\` runs from a worktree that isn't checked out on the source branch — e.g. the refinery's \`main\`-tracking worktree manually submitting a polecat's pushed branch after Bug A trips — HEAD is the wrong ref. In practice \`commit_sha\` becomes the repo's init commit on every MR the refinery files, which breaks branch+SHA MR dedup (\`FindMRForBranchAndSHA\`).

**Fix:** resolve the SHA from the \`--branch\` argument first, with fallbacks to \`origin/<branch>\` (branch not yet fetched locally) and finally \`HEAD\` (preserves the legacy \"submit from the source branch\" caller shape so \`gt done\` keeps working).

## Impact

Every polecat completion with \`gt done\` currently:
1. Pushes the branch to origin ✅
2. Closes the source issue ✅
3. **Fails silently to create the MR bead** ❌
4. Sends HELP to the witness, which escalates to the mayor
5. Leaves the branch orphaned on origin until someone hand-merges

Both bugs have been present since at least \`gt dev\` @ \`bdbe8c4\` (current \`main\`). Observed in-the-wild on two back-to-back polecat runs on a fresh \`robot_grid\` rig.

## Test plan

- [x] \`go build ./...\` — clean
- [x] \`go test ./internal/beads/...\` — pass
- [x] \`go test ./internal/cmd/... -run \"TestParseBranchName|TestValidateMoleculePrereqs|TestMakeTestMR|TestValidateBranchName|TestBuildIntegrationBranch|TestResolveEpic|TestIsReadyToLand|TestDone|TestSubmitDone\"\` — pass
- [x] \`go vet ./internal/beads/ ./internal/cmd/\` — clean
- [ ] Reproduce: before the fix, \`gt mq submit --branch polecat/rust/rg-XXX@YYY --issue rg-XXX\` from a refinery worktree errors with \`unknown flag: --rig\` (tracked against \`bd 1.0.2\`). After the fix, the MR bead is created and \`commit_sha\` resolves to the source branch's tip.
- [ ] Polecat-side: \`gt done\` from a polecat's own worktree continues to work unchanged (HEAD fallback path preserves legacy behavior).

Intentionally minimal diff — no behavior change for any caller already succeeding; only unblocks the silently-failing paths.