### PR TITLE
fix(scheduler): skip missing-bead polecats in capacity count + log zero-capacity dispatch

### DIFF
--- a/internal/cmd/capacity_dispatch.go
+++ b/internal/cmd/capacity_dispatch.go
@@ -194,6 +194,9 @@ func dispatchScheduledWork(townRoot, actor string, batchOverride int, dryRun boo
 	if report.Dispatched > 0 || report.Failed > 0 {
 		fmt.Printf("\n%s Dispatched %d, failed %d (reason: %s)\n",
 			style.Bold.Render("✓"), report.Dispatched, report.Failed, report.Reason)
+	} else if report.Skipped > 0 {
+		fmt.Printf("\n%s Skipped %d bead(s) — zero capacity (working: %d)\n",
+			style.Dim.Render("○"), report.Skipped, countWorkingPolecats())
 	}
 
 	return report.Dispatched, nil

--- a/internal/cmd/scheduler.go
+++ b/internal/cmd/scheduler.go
@@ -526,7 +526,9 @@ func countWorkingPolecats() int {
 		agentBeadID := beads.PolecatBeadIDWithPrefix(prefix, identity.Rig, identity.Name)
 		issue, err := bd.Show(agentBeadID)
 		if err != nil || issue == nil {
-			count++ // Can't verify — count conservatively
+			// Agent bead missing or unreachable — skip instead of counting
+			// as working. Dolt-down case (all lookups fail → count=0) is
+			// safe because polecat_spawn.go gates on Dolt health.
 			continue
 		}
 

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -2423,6 +2423,17 @@ func TestDatabaseExists_NoDataDir(t *testing.T) {
 func TestFindBrokenWorkspaces_HealthyWorkspace(t *testing.T) {
 	townRoot := t.TempDir()
 
+	// Point the test at a port nothing listens on so IsRunning returns false
+	// and doesn't accidentally connect to a real Dolt server on the default port.
+	doltDataDir := filepath.Join(townRoot, ".dolt-data")
+	if err := os.MkdirAll(doltDataDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(doltDataDir, "config.yaml"),
+		[]byte("listener:\n  port: 13307\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
 	// Create a healthy workspace: metadata says dolt, and database exists
 	beadsDir := filepath.Join(townRoot, ".beads")
 	if err := os.MkdirAll(beadsDir, 0755); err != nil {
@@ -2563,6 +2574,16 @@ func TestFindBrokenWorkspaces_SqliteNotBroken(t *testing.T) {
 
 func TestFindBrokenWorkspaces_MultipleRigs(t *testing.T) {
 	townRoot := t.TempDir()
+
+	// Isolate from real Dolt server on default port
+	doltDataDir := filepath.Join(townRoot, ".dolt-data")
+	if err := os.MkdirAll(doltDataDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(doltDataDir, "config.yaml"),
+		[]byte("listener:\n  port: 13307\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
 
 	// Set up rigs.json with two rigs
 	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {

--- a/internal/util/diskspace_unix.go
+++ b/internal/util/diskspace_unix.go
@@ -14,9 +14,10 @@ func GetDiskSpace(path string) (*DiskSpaceInfo, error) {
 		return nil, fmt.Errorf("statfs %s: %w", path, err)
 	}
 
-	total := stat.Blocks * uint64(stat.Bsize)
-	free := stat.Bavail * uint64(stat.Bsize) // Bavail = available to non-root
-	used := total - (stat.Bfree * uint64(stat.Bsize))
+	bsize := uint64(stat.Bsize)
+	total := stat.Blocks * bsize
+	free := uint64(stat.Bavail) * bsize // Bavail is int64 on some platforms (freebsd)
+	used := total - (stat.Bfree * bsize)
 
 	var usedPct float64
 	if total > 0 {


### PR DESCRIPTION
## Summary
- `countWorkingPolecats()` counted polecats with missing/unreachable agent beads as "working," inflating capacity and blocking all dispatch. With 7 orphan sessions, capacity computed as `5-7=-2` — the scheduler dispatched nothing for 12+ hours.
- Dispatch now logs when skipping beads due to zero capacity, instead of returning silently.

## Changes
- `internal/cmd/scheduler.go:528`: missing-bead polecats skip instead of `count++`. Dolt-down case (count→0) is safe because `polecat_spawn.go` gates on Dolt health.
- `internal/cmd/capacity_dispatch.go:197`: added `else if report.Skipped > 0` branch to print skip count and working polecat count.

## Also fixes pre-existing test failures
- `internal/util/diskspace_unix.go:18`: cast `stat.Bavail` to `uint64` for freebsd compatibility (int64 on freebsd, uint64 on linux)
- `internal/doltserver/doltserver_test.go`: isolate `FindBrokenWorkspaces` tests from real Dolt server on default port by writing `config.yaml` with unused port

## Test plan
- [x] `go test ./...` — 72/72 packages pass, zero failures
- [x] `go vet ./internal/cmd/`
- [x] `gofmt` clean on changed files
- [x] Pre-existing `TestCrossPlatformBuild/freebsd_amd64` now passes
- [x] Pre-existing `TestFindBrokenWorkspaces_*` now pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)