### PR TITLE
Extract independent collaterals from #3624 (groq doctor probe, cross-rig routing fix, tmux sentinel, bd bump)

### DIFF
--- a/.github/workflows/nightly-integration.yml
+++ b/.github/workflows/nightly-integration.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install beads (bd)
         if: steps.cache-beads.outputs.cache-hit != 'true'
-        run: go install github.com/steveyegge/beads/cmd/bd@v0.55.4
+        run: go install github.com/steveyegge/beads/cmd/bd@v0.57.0
 
       - name: Install Dolt
         run: |

--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -248,6 +248,14 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 		return a
 	}
 
+	// Create agent bead in the target database. Use a routed Beads instance
+	// when the bead's prefix routes to a different rig than our own database.
+	// Without this, agent beads for rig polecats (e.g., be-beads-polecat-rust)
+	// would be created in the wrong database, failing type validation.
+	if targetDir != b.getResolvedBeadsDir() {
+		target = NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
+	}
+
 	out, err := target.run(buildArgs()...)
 	if err != nil {
 		out, err = target.run(buildArgs()...)

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -172,6 +172,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewBeadsBinaryCheck())
 	d.Register(doctor.NewDoltBinaryCheck())
 	d.Register(doctor.NewClaudeBinaryCheck())
+	d.Register(doctor.NewGroqCompoundCheck())
 	d.Register(doctor.NewDoltServerReachableCheck())
 
 	d.Register(doctor.NewTownGitCheck())

--- a/internal/config/groq.go
+++ b/internal/config/groq.go
@@ -1,0 +1,7 @@
+package config
+
+// GroqJSONEnforcement is appended to prompts for groq-compound non-interactive
+// invocations to enforce JSON-only output from the compound model.
+const GroqJSONEnforcement = "\n\n---\nRESPONSE FORMAT: Respond ONLY with a single " +
+	"valid JSON object. No text, markdown, or code fences outside the JSON. " +
+	"If unable to comply, return: {\"error\": \"<reason>\"}"

--- a/internal/doctor/groq_compound_check.go
+++ b/internal/doctor/groq_compound_check.go
@@ -1,0 +1,128 @@
+package doctor
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/config"
+)
+
+
+// GroqCompoundCheck probes the groq-compound agent for JSON output compliance.
+// It is skipped when groq-compound is not configured in any role.
+type GroqCompoundCheck struct {
+	BaseCheck
+}
+
+// NewGroqCompoundCheck creates a new groq-compound JSON probe check.
+func NewGroqCompoundCheck() *GroqCompoundCheck {
+	return &GroqCompoundCheck{
+		BaseCheck: BaseCheck{
+			CheckName:        "groq-compound-json",
+			CheckDescription: "Probe groq-compound agent for JSON output compliance",
+			CheckCategory:    CategoryInfrastructure,
+		},
+	}
+}
+
+// Run executes the groq-compound JSON probe check.
+func (c *GroqCompoundCheck) Run(ctx *CheckContext) *CheckResult {
+	// Skip if groq-compound is not configured for any role.
+	if !c.groqCompoundConfigured(ctx.TownRoot) {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "groq-compound not configured (skipped)",
+		}
+	}
+
+	// Skip if GROQ_API_KEY is not set.
+	if os.Getenv("GROQ_API_KEY") == "" {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: "GROQ_API_KEY not set (skipped)",
+		}
+	}
+
+	// Skip if claude binary is not available.
+	if _, err := exec.LookPath("claude"); err != nil {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: "claude binary not found (skipped)",
+		}
+	}
+
+	// Build probe prompt with JSON enforcement appended.
+	// NonInteractiveConfig equivalent: {OutputFormat:"json", NoColor:true, MaxTurns:1}
+	probe := `Respond with exactly: {"status":"ok"}` + config.GroqJSONEnforcement
+
+	out, err := c.invokeGroqCompound(probe)
+	if err != nil {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusError,
+			Message: fmt.Sprintf("invocation failed: %v", err),
+		}
+	}
+
+	// Attempt JSON unmarshal; pass if it succeeds, fail with raw output if not.
+	var result map[string]interface{}
+	if err := json.Unmarshal(out, &result); err != nil {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusError,
+			Message: "groq-compound returned non-JSON output",
+			Details: []string{strings.TrimSpace(string(out))},
+		}
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusOK,
+		Message: "groq-compound returns valid JSON",
+	}
+}
+
+// invokeGroqCompound calls the claude binary with Groq routing and returns stdout.
+func (c *GroqCompoundCheck) invokeGroqCompound(prompt string) ([]byte, error) {
+	groqAPIKey := os.Getenv("GROQ_API_KEY")
+	env := append(os.Environ(),
+		"ANTHROPIC_BASE_URL=https://api.groq.com/openai/v1",
+		"ANTHROPIC_MODEL=compound-beta",
+		"ANTHROPIC_API_KEY="+groqAPIKey,
+	)
+	cmd := exec.Command("claude",
+		"--dangerously-skip-permissions",
+		"--output-format", "json",
+		"--max-turns", "1",
+		"-p", prompt,
+	)
+	cmd.Env = env
+	return cmd.Output()
+}
+
+// groqCompoundConfigured returns true if groq-compound is configured for any role
+// in the town or any registered rig.
+func (c *GroqCompoundCheck) groqCompoundConfigured(townRoot string) bool {
+	if townRoot == "" {
+		return false
+	}
+	townSettings, err := config.LoadOrCreateTownSettings(config.TownSettingsPath(townRoot))
+	if err != nil {
+		return false
+	}
+	if townSettings.DefaultAgent == string(config.AgentGroqCompound) {
+		return true
+	}
+	for _, agent := range townSettings.RoleAgents {
+		if agent == string(config.AgentGroqCompound) {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/doctor/groq_compound_check_test.go
+++ b/internal/doctor/groq_compound_check_test.go
@@ -1,0 +1,110 @@
+package doctor
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/config"
+)
+
+func TestNewGroqCompoundCheck(t *testing.T) {
+	c := NewGroqCompoundCheck()
+	if c.Name() != "groq-compound-json" {
+		t.Errorf("Name() = %q, want %q", c.Name(), "groq-compound-json")
+	}
+	if c.Description() == "" {
+		t.Error("Description() is empty")
+	}
+	if c.Category() != CategoryInfrastructure {
+		t.Errorf("Category() = %v, want %v", c.Category(), CategoryInfrastructure)
+	}
+	if c.CanFix() {
+		t.Error("CanFix() = true, want false")
+	}
+}
+
+func TestGroqCompoundConfigured_EmptyTownRoot(t *testing.T) {
+	c := NewGroqCompoundCheck()
+	if c.groqCompoundConfigured("") {
+		t.Error("groqCompoundConfigured(\"\") = true, want false")
+	}
+}
+
+func TestGroqCompoundConfigured_NoSettingsFile(t *testing.T) {
+	tmp := t.TempDir()
+	c := NewGroqCompoundCheck()
+	if c.groqCompoundConfigured(tmp) {
+		t.Error("groqCompoundConfigured with no settings file = true, want false (default agent is claude)")
+	}
+}
+
+func TestGroqCompoundConfigured_DefaultAgent(t *testing.T) {
+	tmp := t.TempDir()
+	settings := config.NewTownSettings()
+	settings.DefaultAgent = string(config.AgentGroqCompound)
+	writeTownSettings(t, tmp, settings)
+
+	c := NewGroqCompoundCheck()
+	if !c.groqCompoundConfigured(tmp) {
+		t.Error("groqCompoundConfigured = false, want true when DefaultAgent is groq-compound")
+	}
+}
+
+func TestGroqCompoundConfigured_RoleAgent(t *testing.T) {
+	tmp := t.TempDir()
+	settings := config.NewTownSettings()
+	settings.RoleAgents["refinery"] = string(config.AgentGroqCompound)
+	writeTownSettings(t, tmp, settings)
+
+	c := NewGroqCompoundCheck()
+	if !c.groqCompoundConfigured(tmp) {
+		t.Error("groqCompoundConfigured = false, want true when a role uses groq-compound")
+	}
+}
+
+func TestGroqCompoundConfigured_NoMatch(t *testing.T) {
+	tmp := t.TempDir()
+	settings := config.NewTownSettings()
+	settings.RoleAgents["refinery"] = "claude"
+	writeTownSettings(t, tmp, settings)
+
+	c := NewGroqCompoundCheck()
+	if c.groqCompoundConfigured(tmp) {
+		t.Error("groqCompoundConfigured = true, want false when no role uses groq-compound")
+	}
+}
+
+func TestGroqCompoundCheck_Run_SkipWhenNotConfigured(t *testing.T) {
+	tmp := t.TempDir()
+	c := NewGroqCompoundCheck()
+	res := c.Run(&CheckContext{TownRoot: tmp})
+	if res.Status != StatusOK {
+		t.Errorf("Run status = %v, want OK (skip path)", res.Status)
+	}
+}
+
+func TestGroqCompoundCheck_Run_WarnWhenNoAPIKey(t *testing.T) {
+	tmp := t.TempDir()
+	settings := config.NewTownSettings()
+	settings.DefaultAgent = string(config.AgentGroqCompound)
+	writeTownSettings(t, tmp, settings)
+
+	t.Setenv("GROQ_API_KEY", "")
+	c := NewGroqCompoundCheck()
+	res := c.Run(&CheckContext{TownRoot: tmp})
+	if res.Status != StatusWarning {
+		t.Errorf("Run status = %v, want Warning when GROQ_API_KEY missing", res.Status)
+	}
+}
+
+func writeTownSettings(t *testing.T, townRoot string, settings *config.TownSettings) {
+	t.Helper()
+	dir := filepath.Join(townRoot, "settings")
+	if err := os.MkdirAll(dir, 0755); err != nil {
+		t.Fatalf("mkdir settings: %v", err)
+	}
+	if err := config.SaveTownSettings(config.TownSettingsPath(townRoot), settings); err != nil {
+		t.Fatalf("SaveTownSettings: %v", err)
+	}
+}

--- a/internal/tmux/testmain_test.go
+++ b/internal/tmux/testmain_test.go
@@ -18,6 +18,16 @@ func TestMain(m *testing.M) {
 	// user's personal server or the sentinel that indicates "no town context".
 	SetDefaultSocket(socket)
 
+	// Start a sentinel session to keep the server alive for the entire test run.
+	// Without this, tests that kill their last session inadvertently take down
+	// the server, leaving a stale socket that prevents subsequent new-session
+	// calls from restarting it (tmux sees the socket file but no listener).
+	// The sentinel uses a name no individual test touches, so it outlives all
+	// per-test sessions. TestMain kills the whole server at the end.
+	if _, err := exec.LookPath("tmux"); err == nil {
+		_ = exec.Command("tmux", "-u", "-L", socket, "new-session", "-d", "-s", "gt-test-sentinel").Run()
+	}
+
 	code := m.Run()
 
 	// Kill the test tmux server and restore the original socket state.


### PR DESCRIPTION
## Summary

Lands the drive-by fixes and additions from #3624 (kab0rn — "feat: swarm foundation for nostown consensus extension") that stand on their own, separate from the speculative swarm/nostown pieces.

Vibe-maintainer split-merge: the original PR mixes a speculative external-dependency hook (`nostown`, not yet a committed roadmap item) with several independently valuable fixes. The clerical work to separate them lives with the maintainer, not the contributor.

## Included

- **`internal/beads/beads_agent.go`** — fix cross-rig routing in `CreateAgentBead` so polecat agent beads land in the target rig's DB, not the caller's.
- **`internal/config/groq.go`** (new) — `GroqJSONEnforcement` constant for groq-compound non-interactive prompts.
- **`internal/doctor/groq_compound_check.go`** (new) + test — `gt doctor` probe that verifies groq-compound returns valid JSON when configured.
- **`internal/cmd/doctor.go`** — register the new check.
- **`internal/tmux/testmain_test.go`** — sentinel session keeps the tmux test server alive across test runs (fixes stale-socket flakiness).
- **`.github/workflows/nightly-integration.yml`** — bump bd to v0.57.0.

## Excluded (held for decision on #3624)

- Swarm hook + `SwarmConfig`/`NonInteractiveConfig` types + swarm tests — depend on a `nostown` binary that is not yet a committed roadmap item.
- Refinery manager groq-force-claude guard — silently overrides operator intent; needs separate scrutiny.
- `cost_tier.go` groq preset change — reverts live-key resolution to a shell-env sentinel; behavioral change kept out of this split.
- `internal/cmd/scheduler_integration_test.go` rewrites — superseded by main's direct-SQL approach to the `crystallizes` column issue.

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./internal/doctor/... ./internal/beads/... ./internal/config/...` passes
- [x] New groq probe skips cleanly when groq-compound not configured

Co-authored-by: Keith <37914030+kab0rn@users.noreply.github.com>
