### PR TITLE
feat(effort): add xhigh/auto levels + ephemeral --effort flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`gt start --effort <level>`** — Ephemeral session-scoped effort override
+  (low/medium/high/max/xhigh/auto), exported as `GT_EFFORT`. Beats
+  `GT_COST_TIER` and rig/town `role_effort` so operators can push a whole
+  session into `xhigh` or `auto` without editing config.
+- **`xhigh` and `auto` effort levels** — `ValidEffortLevels` now accepts the
+  two levels Claude Code 2.x adds for 4.x-class reasoning. Rigs can opt into
+  deeper reasoning via `role_effort.<role>: xhigh` in `settings/config.json`.
+
 ### Fixed
 
 - **`gt dog done` closes accumulated plugin mails** — Plugin dispatch mails sent

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **`gt start --effort <level>`** — Ephemeral session-scoped effort override
+  (low/medium/high/max/xhigh/auto), exported as `GT_EFFORT`. Beats
+  `GT_COST_TIER` and rig/town `role_effort` so operators can push a whole
+  session into `xhigh` or `auto` without editing config.
+- **`xhigh` and `auto` effort levels** — `ValidEffortLevels` now accepts the
+  two levels Claude Code 2.x adds for 4.x-class reasoning. Rigs can opt into
+  deeper reasoning via `role_effort.<role>: xhigh` in `settings/config.json`.
+
 ## [1.0.1] - 2026-04-25
 
 ### Fixed

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -44,6 +44,7 @@ var (
 	startCrewAccount            string
 	startCrewAgentOverride      string
 	startCostTier               string
+	startEffort                 string
 	shutdownGraceful            bool
 	shutdownWait                int
 	shutdownAll                 bool
@@ -135,6 +136,7 @@ func init() {
 		"Also start Witnesses and Refineries for all rigs")
 	startCmd.Flags().StringVar(&startAgentOverride, "agent", "", "Agent alias to run Mayor/Deacon with (overrides town default)")
 	startCmd.Flags().StringVar(&startCostTier, "cost-tier", "", "Ephemeral cost tier for this session (standard/economy/budget)")
+	startCmd.Flags().StringVar(&startEffort, "effort", "", "Ephemeral effort level for this session (low/medium/high/max/xhigh/auto); overrides rig/town role_effort")
 
 	startCrewCmd.Flags().StringVar(&startCrewRig, "rig", "", "Rig to use")
 	startCrewCmd.Flags().StringVar(&startCrewAccount, "account", "", "Claude Code account handle to use")
@@ -189,6 +191,17 @@ func runStart(cmd *cobra.Command, args []string) error {
 		}
 		os.Setenv("GT_COST_TIER", startCostTier)
 		fmt.Printf("Using ephemeral cost tier: %s\n", style.Bold.Render(startCostTier))
+	}
+
+	// Apply ephemeral effort override if specified. GT_EFFORT takes precedence
+	// over GT_COST_TIER's per-role effort map and over rig/town role_effort, so
+	// operators can push an entire session into xhigh/auto without editing config.
+	if startEffort != "" {
+		if !config.IsValidEffortLevel(startEffort) {
+			return fmt.Errorf("invalid effort level %q (valid: %s)", startEffort, strings.Join(config.ValidEffortLevels(), ", "))
+		}
+		os.Setenv("GT_EFFORT", startEffort)
+		fmt.Printf("Using ephemeral effort level: %s\n", style.Bold.Render(startEffort))
 	}
 
 	if err := config.EnsureDaemonPatrolConfig(townRoot); err != nil {

--- a/internal/config/cost_tier.go
+++ b/internal/config/cost_tier.go
@@ -176,14 +176,20 @@ func CostTierRoleEffort(tier CostTier) map[string]string {
 }
 
 // ValidEffortLevels returns all valid effort level values.
+//
+// "xhigh" and "auto" were added to track Claude Code 2.x's expanded effort
+// axis — xhigh enables extended reasoning budgets on 4.x-class models, and
+// auto lets Claude Code pick adaptively. Gastown only validates the string;
+// whether the running Claude Code binary honors each level is a separate
+// concern (older binaries will ignore unknown levels silently).
 func ValidEffortLevels() []string {
-	return []string{"low", "medium", "high", "max"}
+	return []string{"low", "medium", "high", "max", "xhigh", "auto"}
 }
 
 // IsValidEffortLevel checks if a string is a valid effort level.
 func IsValidEffortLevel(level string) bool {
 	switch level {
-	case "low", "medium", "high", "max":
+	case "low", "medium", "high", "max", "xhigh", "auto":
 		return true
 	default:
 		return false

--- a/internal/config/cost_tier_test.go
+++ b/internal/config/cost_tier_test.go
@@ -671,6 +671,8 @@ func TestIsValidEffortLevel(t *testing.T) {
 		{"medium", true},
 		{"high", true},
 		{"max", true},
+		{"xhigh", true},
+		{"auto", true},
 		{"", false},
 		{"extreme", false},
 		{"High", false}, // case-sensitive

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -218,7 +218,8 @@ func AgentEnv(cfg AgentEnvConfig) map[string]string {
 		fmt.Fprintf(os.Stderr,
 			"notice: CLAUDE_CODE_EFFORT_LEVEL=%s env var is deprecated and ignored; "+
 				"%s effort resolved to %q via config. "+
-				"Set per-role effort with role_effort in settings or gt config cost-tier.\n",
+				"For session-scoped overrides use `gt start --effort <level>` (or set GT_EFFORT); "+
+				"for persistent per-role config use role_effort in rig/town settings.\n",
 			shellEffort, cfg.Role, effort)
 	}
 

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -1329,4 +1329,42 @@ func TestAgentEnv_EffortLevel(t *testing.T) {
 			t.Error("CLAUDE_CODE_EFFORT_LEVEL should always be set")
 		}
 	})
+
+	t.Run("GT_EFFORT overrides default for every role", func(t *testing.T) {
+		t.Setenv("CLAUDE_CODE_EFFORT_LEVEL", "")
+		t.Setenv("GT_EFFORT", "xhigh")
+		for _, role := range []string{"crew", "mayor", "witness", "polecat"} {
+			env := AgentEnv(AgentEnvConfig{
+				Role:     role,
+				TownRoot: "/tmp/nonexistent-town",
+			})
+			if got := env["CLAUDE_CODE_EFFORT_LEVEL"]; got != "xhigh" {
+				t.Errorf("role %s: CLAUDE_CODE_EFFORT_LEVEL = %q, want %q", role, got, "xhigh")
+			}
+		}
+	})
+
+	t.Run("GT_EFFORT=auto is accepted", func(t *testing.T) {
+		t.Setenv("CLAUDE_CODE_EFFORT_LEVEL", "")
+		t.Setenv("GT_EFFORT", "auto")
+		env := AgentEnv(AgentEnvConfig{
+			Role:     "crew",
+			TownRoot: "/tmp/nonexistent-town",
+		})
+		if got := env["CLAUDE_CODE_EFFORT_LEVEL"]; got != "auto" {
+			t.Errorf("CLAUDE_CODE_EFFORT_LEVEL = %q, want %q", got, "auto")
+		}
+	})
+
+	t.Run("invalid GT_EFFORT falls through to default", func(t *testing.T) {
+		t.Setenv("CLAUDE_CODE_EFFORT_LEVEL", "")
+		t.Setenv("GT_EFFORT", "extreme")
+		env := AgentEnv(AgentEnvConfig{
+			Role:     "crew",
+			TownRoot: "/tmp/nonexistent-town",
+		})
+		if got := env["CLAUDE_CODE_EFFORT_LEVEL"]; got != "high" {
+			t.Errorf("CLAUDE_CODE_EFFORT_LEVEL = %q, want %q (invalid GT_EFFORT should be skipped)", got, "high")
+		}
+	})
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1426,12 +1426,25 @@ func ResolveWorkerAgentConfig(workerName, townRoot, rigPath string) *RuntimeConf
 
 // ResolveRoleEffort resolves the effort level for a role.
 // Resolution order:
-//  1. Rig's RoleEffort[role]
-//  2. Town's RoleEffort[role]
-//  3. Returns "" (caller falls back to env var / default "high")
+//  1. GT_EFFORT env var (session-scoped, set by `gt start --effort`)
+//  2. GT_COST_TIER env var's per-role effort map (session-scoped)
+//  3. Rig's RoleEffort[role]
+//  4. Town's RoleEffort[role]
+//  5. Returns "" (caller falls back to default "high")
 //
 // Invalid effort levels are warned about and skipped.
 func ResolveRoleEffort(role, townRoot, rigPath string) string {
+	// Tier 0: session-ephemeral effort override applied to every role.
+	// Set by `gt start --effort <level>`; takes precedence over tier/rig/town
+	// so operators can push a whole session into xhigh/auto without editing
+	// config. Invalid values are warned and skipped (callers fall through).
+	if effort := os.Getenv("GT_EFFORT"); effort != "" {
+		if IsValidEffortLevel(effort) {
+			return effort
+		}
+		fmt.Fprintf(os.Stderr, "warning: GT_EFFORT=%q is not a valid effort level, ignoring\n", effort)
+	}
+
 	// Tier 1: ephemeral cost tier override (mirrors agent resolution)
 	if tierName := os.Getenv("GT_COST_TIER"); tierName != "" && IsValidTier(tierName) {
 		if roleEffort := CostTierRoleEffort(CostTier(tierName)); roleEffort != nil {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1417,12 +1417,25 @@ func ResolveWorkerAgentConfig(workerName, townRoot, rigPath string) *RuntimeConf
 
 // ResolveRoleEffort resolves the effort level for a role.
 // Resolution order:
-//  1. Rig's RoleEffort[role]
-//  2. Town's RoleEffort[role]
-//  3. Returns "" (caller falls back to env var / default "high")
+//  1. GT_EFFORT env var (session-scoped, set by `gt start --effort`)
+//  2. GT_COST_TIER env var's per-role effort map (session-scoped)
+//  3. Rig's RoleEffort[role]
+//  4. Town's RoleEffort[role]
+//  5. Returns "" (caller falls back to default "high")
 //
 // Invalid effort levels are warned about and skipped.
 func ResolveRoleEffort(role, townRoot, rigPath string) string {
+	// Tier 0: session-ephemeral effort override applied to every role.
+	// Set by `gt start --effort <level>`; takes precedence over tier/rig/town
+	// so operators can push a whole session into xhigh/auto without editing
+	// config. Invalid values are warned and skipped (callers fall through).
+	if effort := os.Getenv("GT_EFFORT"); effort != "" {
+		if IsValidEffortLevel(effort) {
+			return effort
+		}
+		fmt.Fprintf(os.Stderr, "warning: GT_EFFORT=%q is not a valid effort level, ignoring\n", effort)
+	}
+
 	// Tier 1: ephemeral cost tier override (mirrors agent resolution)
 	if tierName := os.Getenv("GT_COST_TIER"); tierName != "" && IsValidTier(tierName) {
 		if roleEffort := CostTierRoleEffort(CostTier(tierName)); roleEffort != nil {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -93,7 +93,7 @@ type TownSettings struct {
 
 	// RoleEffort maps role names to effort levels for per-role effort configuration.
 	// Keys are role names: "mayor", "deacon", "witness", "refinery", "polecat", "crew", "boot", "dog".
-	// Values are effort levels: "low", "medium", "high", "max".
+	// Values are effort levels: "low", "medium", "high", "max", "xhigh", "auto".
 	// Allows cost/speed optimization by using lower effort for simpler roles.
 	// Managed by cost-tier presets alongside RoleAgents.
 	RoleEffort map[string]string `json:"role_effort,omitempty"`
@@ -680,8 +680,8 @@ type RigSettings struct {
 
 	// RoleEffort maps role names to effort levels, overriding TownSettings.RoleEffort for this rig.
 	// Keys are role names: "witness", "refinery", "polecat", "crew".
-	// Values are effort levels: "low", "medium", "high", "max".
-	// Example: {"crew": "max", "witness": "low"}
+	// Values are effort levels: "low", "medium", "high", "max", "xhigh", "auto".
+	// Example: {"crew": "xhigh", "witness": "low"}
 	RoleEffort map[string]string `json:"role_effort,omitempty"`
 }
 


### PR DESCRIPTION
## Summary

Adds two new effort levels (`xhigh` and `auto`) to `ValidEffortLevels`, plus an ephemeral `--effort` flag on `gt start` and a `GT_EFFORT` environment-variable tier in `ResolveRoleEffort`.

## Motivation

Multi-agent fleets benefit from being able to bump a single session to a higher effort tier for a specific task without permanently editing per-role config. Today the only knobs are the role-default tier in `role_effort.<role>` (persistent) and command-line effort flags on downstream commands — there is no way to say "just this `gt start`, run the agent at xhigh effort." The ephemeral `--effort` flag and `GT_EFFORT` env var fill that gap, and `xhigh`/`auto` give the fleet meaningful higher tiers to target.

## Changes

- `internal/config/types.go`, `internal/config/cost_tier.go`: add `xhigh` and `auto` to `ValidEffortLevels` and the cost-tier ordering.
- `internal/config/env.go`, `internal/config/loader.go`, `internal/config/env_test.go`, `internal/config/cost_tier_test.go`: add `GT_EFFORT` as a tier in `ResolveRoleEffort` (env > flag > role > default), with tests.
- `internal/cmd/start.go`: add `--effort` flag to `gt start`, ephemeral (applies only to that invocation, does not modify config).
- `CHANGELOG.md`: note the additions.

## Testing

- [x] `go test ./internal/config/...` — green, including the new `env_test.go` cases.
- [x] `go test ./...` — green locally.
- [x] Manual: `GT_EFFORT=xhigh gt start <role>` picks up the tier; `gt start <role> --effort auto` picks up the flag; neither persists after the session ends.

## Checklist

- [x] Code follows project style (conventional commits, existing config package conventions).
- [x] Tests added for env-var tier resolution and the new level ordering.
- [x] No breaking changes — existing `low`/`medium`/`high` continue to work unchanged; `xhigh` and `auto` are additive.

## Notes

This change originated as an operational patch on our fork's `carry/operational` branch. Filing upstream per the "graduate to upstream" path in our carry-patch lifecycle — both towns would benefit from not maintaining a local carry patch for this.