### PR TITLE
fix(stuck-agent-dog): use 'gt hook show' to inspect other agents' hooks

### DIFF
--- a/plugins/stuck-agent-dog/run.sh
+++ b/plugins/stuck-agent-dog/run.sh
@@ -45,8 +45,8 @@ while IFS='|' read -r RIG PREFIX; do
 
     if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
       # Session dead — check hook
-      HOOK_BEAD=$(gt hook "$RIG/polecats/$PCAT_NAME" 2>/dev/null \
-        | grep -oE 'Hooked: [^ ]+' | head -1 | sed 's/Hooked: //')
+      HOOK_OUTPUT=$(gt hook show "$RIG/polecats/$PCAT_NAME" 2>/dev/null | head -1)
+      HOOK_BEAD=$(echo "$HOOK_OUTPUT" | grep -v '(empty)' | awk '{print $2}' || true)
 
       if [ -n "$HOOK_BEAD" ]; then
         # Check agent_state
@@ -67,8 +67,8 @@ while IFS='|' read -r RIG PREFIX; do
         PROC_COMM=$(ps -o comm= -p "$PANE_PID" 2>/dev/null)
         if [ -z "$PROC_COMM" ]; then
           # Zombie: process dead, session alive
-          HOOK_BEAD=$(gt hook "$RIG/polecats/$PCAT_NAME" 2>/dev/null \
-            | grep -oE 'Hooked: [^ ]+' | head -1 | sed 's/Hooked: //')
+          HOOK_OUTPUT=$(gt hook show "$RIG/polecats/$PCAT_NAME" 2>/dev/null | head -1)
+          HOOK_BEAD=$(echo "$HOOK_OUTPUT" | grep -v '(empty)' | awk '{print $2}' || true)
           if [ -n "$HOOK_BEAD" ]; then
             STUCK+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD|agent_dead")
             log "  ZOMBIE: $SESSION_NAME (pid=$PANE_PID dead, hook=$HOOK_BEAD)"


### PR DESCRIPTION
## Summary

`plugins/stuck-agent-dog/run.sh` calls `gt hook "$RIG/polecats/$PCAT_NAME"` in two places to check what each polecat is hooked to. After `gt hook` was refactored into subcommands, that bare form treats the first arg as a bead-id-to-attach, not as an agent path. The plugin silently lost the ability to detect crashed or zombie polecats.

## Changes

- `plugins/stuck-agent-dog/run.sh` (two call sites): switch from `gt hook <path>` to `gt hook show <path>`, and update the parse to match the new output format (`<path>: <bead-id> '<subject>' [<status>]`):
  - awk column 2 for the bead id
  - filter out the `(empty)` sentinel

## Testing

- [x] Manual: ran the plugin against a live town with one crashed polecat and one zombie polecat — both detected correctly, entries show up in the CRASHED/STUCK arrays.
- [x] `bash -n plugins/stuck-agent-dog/run.sh` — no syntax errors.

## Checklist

- [x] Code follows project style.
- [x] No breaking changes — external interface (summary line, bd create) unchanged.
- [x] No tests to add/update (pure shell plugin).

## How this was found

Surfaced by both the mayor and the deacon's dogs in our fleet — deacon/dogs/alpha filed `BUG: stuck-agent-dog plugin uses outdated gt hook syntax`, and the mayor independently flagged `CLI regression: 'gt hook <path>' vs 'gt hook show <path>' in stuck-agent-dog plugin`. Same root cause.