### PR TITLE
fix: gt feed TUI tails appended events live

### DIFF
--- a/internal/tui/feed/events.go
+++ b/internal/tui/feed/events.go
@@ -264,10 +264,6 @@ func (s *GtEventsSource) tail(ctx context.Context) {
 	// regardless of the preload scanner's internal read-ahead buffer.
 	_, _ = s.file.Seek(0, 2)
 
-	// Poll for new lines using a fresh scanner each tick.
-	// bufio.Scanner sets an internal 'done' flag after EOF and won't retry,
-	// so we must create a new scanner each poll cycle while preserving the
-	// file offset (os.File tracks position across scanner instances).
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -276,6 +272,12 @@ func (s *GtEventsSource) tail(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			// Fresh scanner each tick: bufio.Scanner sets an internal 'done'
+			// flag after EOF and won't retry, so reusing one across ticks
+			// would stop reading the file after the first EOF. The *os.File
+			// preserves its offset across scanner instances, so no manual
+			// bookkeeping is needed. Buffer size matches loadRecentEvents
+			// (1 MiB) to handle long JSONL lines without token-too-long errors.
 			scanner := bufio.NewScanner(s.file)
 			scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
 			for scanner.Scan() {

--- a/internal/tui/feed/events.go
+++ b/internal/tui/feed/events.go
@@ -260,12 +260,14 @@ func (s *GtEventsSource) tail(ctx context.Context) {
 	// Load recent events (last 200 lines) for initial display
 	s.loadRecentEvents()
 
-	// Seek to true EOF so the tail scanner starts cleanly,
+	// Seek to true EOF so the tail starts cleanly,
 	// regardless of the preload scanner's internal read-ahead buffer.
 	_, _ = s.file.Seek(0, 2)
 
-	// Now tail for new events
-	scanner := bufio.NewScanner(s.file)
+	// Poll for new lines using a fresh scanner each tick.
+	// bufio.Scanner sets an internal 'done' flag after EOF and won't retry,
+	// so we must create a new scanner each poll cycle while preserving the
+	// file offset (os.File tracks position across scanner instances).
 	ticker := time.NewTicker(100 * time.Millisecond)
 	defer ticker.Stop()
 
@@ -274,11 +276,15 @@ func (s *GtEventsSource) tail(ctx context.Context) {
 		case <-ctx.Done():
 			return
 		case <-ticker.C:
+			scanner := bufio.NewScanner(s.file)
+			scanner.Buffer(make([]byte, 1024*1024), 1024*1024)
 			for scanner.Scan() {
 				line := scanner.Text()
 				if event := parseGtEventLine(line); event != nil {
 					select {
 					case s.events <- *event:
+					case <-ctx.Done():
+						return
 					default:
 					}
 				}

--- a/internal/tui/feed/events_test.go
+++ b/internal/tui/feed/events_test.go
@@ -1,0 +1,71 @@
+package feed
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+// TestGtEventsSource_TailsAppendedLines is a regression test for the bug where
+// the tail goroutine reused a single bufio.Scanner across poll ticks. Once the
+// scanner hit EOF, its internal 'done' flag latched and no subsequent Scan()
+// calls re-read the file, so lines appended after the source was started were
+// silently dropped.
+func TestGtEventsSource_TailsAppendedLines(t *testing.T) {
+	dir := t.TempDir()
+	eventsPath := filepath.Join(dir, ".events.jsonl")
+	if err := os.WriteFile(eventsPath, nil, 0644); err != nil {
+		t.Fatalf("create events file: %v", err)
+	}
+
+	src, err := NewGtEventsSource(dir)
+	if err != nil {
+		t.Fatalf("NewGtEventsSource: %v", err)
+	}
+	defer src.Close()
+
+	// Drain any backlog (should be none for an empty file, but be defensive).
+	drain := time.After(200 * time.Millisecond)
+draining:
+	for {
+		select {
+		case <-src.Events():
+		case <-drain:
+			break draining
+		}
+	}
+
+	// Append a valid JSONL event line after the source is tailing.
+	ev := GtEvent{
+		Timestamp:  time.Now().UTC().Format(time.RFC3339),
+		Source:     "test",
+		Type:       "session_start",
+		Actor:      "gastown/witness",
+		Visibility: "feed",
+		Payload:    map[string]interface{}{"rig": "test"},
+	}
+	b, err := json.Marshal(ev)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	f, err := os.OpenFile(eventsPath, os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		t.Fatalf("open for append: %v", err)
+	}
+	if _, err := f.Write(append(b, '\n')); err != nil {
+		t.Fatalf("append event: %v", err)
+	}
+	_ = f.Close()
+
+	select {
+	case got := <-src.Events():
+		if got.Type != "session_start" {
+			t.Fatalf("unexpected event type: got %q want %q", got.Type, "session_start")
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("timed out waiting for appended event; tail goroutine stopped reading after EOF")
+	}
+}


### PR DESCRIPTION
## Summary

Fix `gt feed` TUI event stream silently stops updating after initial render. A reused `bufio.Scanner` in `(*GtEventsSource).tail` latches at EOF and never re-reads the file on subsequent poll ticks, so the event panel shows only the startup backlog from `loadRecentEvents` — new events never appear.

## Related Issue

No existing upstream issue. Discovered while observing a live Gas Town workspace; `gt feed --plain --follow` tailed correctly from the same `.events.jsonl` while the TUI stayed frozen.

## Changes

- `internal/tui/feed/events.go` — move `bufio.NewScanner(s.file)` inside the ticker loop (fresh scanner per tick). `*os.File` preserves offset across scanner instances, so no manual bookkeeping is needed. Mirror the pattern already in `internal/tui/feed/print_events.go:92-123` (which calls out this exact pitfall in its comment — that's why `--plain --follow` works and the TUI doesn't).
- `internal/tui/feed/events.go` — add `<-ctx.Done()` branch inside the channel-send select to avoid a goroutine leak on shutdown when the buffered channel is full. Minor hardening, not the bug fix itself.
- `internal/tui/feed/events.go` — match `loadRecentEvents`'s 1 MiB scanner buffer for consistency on long JSONL lines; comment at the scanner site explains both the reuse pitfall and the buffer size.
- `internal/tui/feed/events_test.go` — new regression test that appends a JSONL event after the source is tailing and asserts it arrives on `Events()`.

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] Manual testing performed

**Regression guard verified:** stashed the fix, new test fails with `timed out waiting for appended event; tail goroutine stopped reading after EOF`. Restored fix, test passes.

**E2E verified in real TUI:** built fixed + unfixed binaries from this tree, drove `gt feed` in a Python `pexpect` pty (140x40), appended a unique JSONL event mid-run, captured rendered output.

| binary | footer tick | live event visible? |
|---|---|---|
| fixed | `[tree] 2 events` → `[tree] 3 events` | ✅ yes |
| unfixed | `[tree] 2 events` (stuck) | ❌ no — reproduces the reported symptom |

Deterministic across two reruns each.

## Checklist

- [x] Code follows project style (`gofmt`, `go vet` clean)
- [x] Documentation updated (if applicable) — N/A, internal behavior fix
- [x] No breaking changes (or documented in summary)

## Notes

Two commits on the branch; happy to squash on merge.