### PR TITLE
feat(effort): add effort_lock setting to allow Claude Code /effort in-chat

### DIFF
--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -213,7 +213,12 @@ func AgentEnv(cfg AgentEnvConfig) map[string]string {
 	if effort == "" {
 		effort = "high"
 	}
-	env["CLAUDE_CODE_EFFORT_LEVEL"] = effort
+	// Setting CLAUDE_CODE_EFFORT_LEVEL in env locks the tier for the session —
+	// Claude Code's in-chat /effort command will refuse to override it. Operators
+	// who want /effort to work can set effort_lock: false in town/rig settings.
+	if ResolveEffortLock(cfg.TownRoot, rigPath) {
+		env["CLAUDE_CODE_EFFORT_LEVEL"] = effort
+	}
 	if shellEffort := os.Getenv("CLAUDE_CODE_EFFORT_LEVEL"); shellEffort != "" {
 		fmt.Fprintf(os.Stderr,
 			"notice: CLAUDE_CODE_EFFORT_LEVEL=%s env var is deprecated and ignored; "+

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -1329,4 +1329,38 @@ func TestAgentEnv_EffortLevel(t *testing.T) {
 			t.Error("CLAUDE_CODE_EFFORT_LEVEL should always be set")
 		}
 	})
+
+	t.Run("effort_lock=false omits CLAUDE_CODE_EFFORT_LEVEL from env", func(t *testing.T) {
+		t.Setenv("CLAUDE_CODE_EFFORT_LEVEL", "")
+		townRoot := t.TempDir()
+		unlocked := false
+		if err := SaveTownSettings(TownSettingsPath(townRoot), &TownSettings{
+			EffortLock: &unlocked,
+		}); err != nil {
+			t.Fatalf("SaveTownSettings failed: %v", err)
+		}
+		env := AgentEnv(AgentEnvConfig{
+			Role:     "crew",
+			TownRoot: townRoot,
+		})
+		if _, ok := env["CLAUDE_CODE_EFFORT_LEVEL"]; ok {
+			t.Errorf("CLAUDE_CODE_EFFORT_LEVEL should be unset when effort_lock=false, got %q", env["CLAUDE_CODE_EFFORT_LEVEL"])
+		}
+	})
+
+	t.Run("effort_lock unset defaults to locked", func(t *testing.T) {
+		t.Setenv("CLAUDE_CODE_EFFORT_LEVEL", "")
+		townRoot := t.TempDir()
+		// Town settings exist but EffortLock is unset (nil pointer)
+		if err := SaveTownSettings(TownSettingsPath(townRoot), &TownSettings{}); err != nil {
+			t.Fatalf("SaveTownSettings failed: %v", err)
+		}
+		env := AgentEnv(AgentEnvConfig{
+			Role:     "crew",
+			TownRoot: townRoot,
+		})
+		if _, ok := env["CLAUDE_CODE_EFFORT_LEVEL"]; !ok {
+			t.Error("CLAUDE_CODE_EFFORT_LEVEL should be set by default (effort_lock unset → true)")
+		}
+	})
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1461,6 +1461,31 @@ func ResolveRoleEffort(role, townRoot, rigPath string) string {
 	return "" // Caller uses env var fallback, then "high" default
 }
 
+// ResolveEffortLock returns whether gt should write CLAUDE_CODE_EFFORT_LEVEL
+// into agent env. When true (default), the env var locks Claude Code's effort
+// tier for the session and the in-chat `/effort` command is refused. When false,
+// the env var is not set, allowing `/effort` to work.
+//
+// Resolution order (first non-nil wins):
+//  1. Rig-level EffortLock
+//  2. Town-level EffortLock
+//  3. Default true (preserves existing fleet semantics)
+func ResolveEffortLock(townRoot, rigPath string) bool {
+	// Rig override
+	if rigPath != "" {
+		if rigSettings, err := LoadRigSettings(RigSettingsPath(rigPath)); err == nil && rigSettings != nil && rigSettings.EffortLock != nil {
+			return *rigSettings.EffortLock
+		}
+	}
+	// Town setting
+	if townRoot != "" {
+		if townSettings, err := LoadOrCreateTownSettings(TownSettingsPath(townRoot)); err == nil && townSettings != nil && townSettings.EffortLock != nil {
+			return *townSettings.EffortLock
+		}
+	}
+	return true
+}
+
 // IsResolvedAgentClaude returns true if the RuntimeConfig represents a Claude agent.
 // Exported for use in witness/daemon code that needs to skip hardcoded
 // Claude start commands when a non-Claude agent is configured.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -98,6 +98,14 @@ type TownSettings struct {
 	// Managed by cost-tier presets alongside RoleAgents.
 	RoleEffort map[string]string `json:"role_effort,omitempty"`
 
+	// EffortLock controls whether gt sets CLAUDE_CODE_EFFORT_LEVEL in agent env.
+	// When true (default, omitted), the env var is set, locking the tier for the
+	// session — Claude Code's in-chat /effort command will refuse to override it.
+	// When false, the env var is NOT set, and Claude Code's /effort works normally.
+	// Pointer for tri-state: nil = use default (true), explicit false = unlock.
+	// Rig-level setting overrides town-level.
+	EffortLock *bool `json:"effort_lock,omitempty"`
+
 	// CostTier tracks which cost tier preset was applied (informational).
 	// Actual model assignments live in RoleAgents and Agents.
 	// Values: "standard", "economy", "budget", or empty for custom configs.
@@ -683,6 +691,10 @@ type RigSettings struct {
 	// Values are effort levels: "low", "medium", "high", "max".
 	// Example: {"crew": "max", "witness": "low"}
 	RoleEffort map[string]string `json:"role_effort,omitempty"`
+
+	// EffortLock controls whether gt sets CLAUDE_CODE_EFFORT_LEVEL in agent env.
+	// Overrides TownSettings.EffortLock for this rig. See TownSettings.EffortLock.
+	EffortLock *bool `json:"effort_lock,omitempty"`
 }
 
 // CrewConfig represents crew workspace settings for a rig.


### PR DESCRIPTION
## Summary

Today gt always sets `CLAUDE_CODE_EFFORT_LEVEL` in the agent's environment, which causes Claude Code to lock the effort tier for the session and refuse the in-chat `/effort` command. Some operators want to seed the role default but still let the agent change tier mid-session via `/effort`. This PR makes the lock optional via a new `effort_lock` setting.

## Motivation

The current behavior is appropriate for tightly-managed fleets where operators want strict per-role effort and don't want agents bumping themselves to higher tiers ad-hoc. But for solo operators and exploratory work, Claude Code's `/effort` is a natural in-chat knob, and the env-var lock surfaces as a confusing error: *"Not applied: CLAUDE_CODE_EFFORT_LEVEL=high overrides effort this session"*. Today the only escape hatches are `gt start --effort` or `GT_EFFORT`, both of which require restarting the session.

## Changes

- `internal/config/types.go`: add `EffortLock *bool` to both `TownSettings` and `RigSettings`. Pointer for tri-state (nil = use default).
- `internal/config/loader.go`: add `ResolveEffortLock(townRoot, rigPath) bool` — rig overrides town, defaults to `true` so existing fleets see no behavior change.
- `internal/config/env.go`: gate the `env["CLAUDE_CODE_EFFORT_LEVEL"] = effort` write on `ResolveEffortLock` returning true.
- `internal/config/env_test.go`: tests for `effort_lock=false` (env var omitted) and unset (defaults to locked).

## Behavior

| `effort_lock` | Env var written? | `/effort` in-chat |
|---|---|---|
| (unset) — default | yes | refused (current behavior) |
| `true` | yes | refused |
| `false` | no | works; Claude Code starts at its own default tier |

When `effort_lock=false`, the role-resolved effort isn't applied at startup. Operators who want both — start at the role default AND allow `/effort` — would need a follow-up that passes effort via Claude Code's `--effort` CLI flag instead of via env var (potentially overridable by `/effort`); that's deliberately out of scope here so the change stays minimal and predictable.

## Configuration

In `<townRoot>/settings/config.json` or `<rigPath>/settings/config.json`:
```json
{ "effort_lock": false }
```

## Testing

- [x] `go test ./internal/config/...` — green, including the two new test cases.
- [x] Manual: with `effort_lock: false` in town settings, started a Claude session and ran `/effort high` in-chat — applied successfully (no override message). With the setting removed, the override message returns.

## Checklist

- [x] Code follows project style.
- [x] No breaking changes — default behavior preserved (`EffortLock` nil → locked, same as before).
- [x] Tests cover both branches and the default.