### PR TITLE
Auto-heal witness beads redirects

### DIFF
--- a/.beads/.gitignore
+++ b/.beads/.gitignore
@@ -1,5 +1,6 @@
 # Dolt database (managed by Dolt, not git)
 dolt/
+embeddeddolt/
 
 # Runtime files
 bd.sock

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -45,3 +45,5 @@ types.custom: "agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merg
 prefix: 
 issue-prefix: 
 dolt.idle-timeout: "0"
+
+sync.remote: "git+https://github.com/steveyegge/gastown.git"

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -1130,7 +1130,7 @@ func getAgentBeadID(ctx RoleContext) string {
 // Uses the shared SetupRedirect helper which handles both tracked and local beads.
 func ensureBeadsRedirect(ctx RoleContext) {
 	// Only applies to worktree-based roles that use shared beads
-	if ctx.Role != RoleCrew && ctx.Role != RolePolecat && ctx.Role != RoleRefinery {
+	if ctx.Role != RoleCrew && ctx.Role != RolePolecat && ctx.Role != RoleRefinery && ctx.Role != RoleWitness {
 		return
 	}
 

--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -948,6 +948,36 @@ func TestCompactResumeReminder_NonPolecatNoGtDone(t *testing.T) {
 	}
 }
 
+func TestEnsureBeadsRedirect_WitnessCreatesRedirect(t *testing.T) {
+	townRoot := t.TempDir()
+	rigRoot := filepath.Join(townRoot, "testrig")
+	witnessDir := filepath.Join(rigRoot, "witness")
+	mayorBeadsDir := filepath.Join(rigRoot, "mayor", "rig", ".beads")
+	if err := os.MkdirAll(witnessDir, 0755); err != nil {
+		t.Fatalf("mkdir witness dir: %v", err)
+	}
+	if err := os.MkdirAll(mayorBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir mayor beads dir: %v", err)
+	}
+
+	ctx := RoleContext{
+		Role:     RoleWitness,
+		WorkDir:  witnessDir,
+		TownRoot: townRoot,
+	}
+
+	ensureBeadsRedirect(ctx)
+
+	redirectPath := filepath.Join(witnessDir, ".beads", "redirect")
+	content, err := os.ReadFile(redirectPath)
+	if err != nil {
+		t.Fatalf("read redirect: %v", err)
+	}
+	if got, want := string(content), "../mayor/rig/.beads\n"; got != want {
+		t.Fatalf("redirect content = %q, want %q", got, want)
+	}
+}
+
 // TestOutputRalphLoopDirective_NoSlashCommand verifies that ralph mode emits
 // inline iterative work instructions instead of referencing a nonexistent
 // /ralph-loop slash command. This is the regression test for the ralph-loop

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -149,15 +149,17 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 
 	// Note: No PID check per ZFC - tmux session is the source of truth
 
-	// Working directory
-	witnessDir := m.witnessDir()
-
 	// Ensure runtime settings exist in the shared witness parent directory.
 	// Settings are passed to Claude Code via --settings flag.
 	// ResolveRoleAgentConfig is internally serialized (resolveConfigMu in
 	// package config) to prevent concurrent rig starts from corrupting the
 	// global agent registry.
+	// Working directory
+	witnessDir := m.witnessDir()
 	townRoot := m.townRoot()
+	if err := beads.SetupRedirect(townRoot, witnessDir); err != nil {
+		return fmt.Errorf("ensuring witness beads redirect: %w", err)
+	}
 
 	// Resolve CLAUDE_CONFIG_DIR from accounts.json so witness sessions
 	// use the correct account. Mirrors the daemon restart path (lifecycle.go).


### PR DESCRIPTION
## Summary
- include witness in gt prime's automatic .beads redirect healing
- provision the shared beads redirect when starting a witness session
- add a regression test covering witness redirect creation

## Verification
- go test ./internal/cmd -run 'TestEnsureBeadsRedirect_WitnessCreatesRedirect|TestCompactResumeReminder_PolecatGetsGtDone|TestCompactResumeReminder_NonPolecatNoGtDone'
- go test ./internal/witness

## Context
This fixes a live ManaSutra witness incident where patrol commands run from <rig>/witness fell back to an incomplete rig-root .beads directory and failed before patrol could proceed.