### PR TITLE
Prevent gt status hangs in bd allow-stale probe

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -37,6 +37,9 @@ var (
 	bdAllowStaleMu     sync.Mutex
 	bdAllowStalePath   string
 	bdAllowStaleResult bool
+	// bdAllowStaleProbeTimeout bounds the capability probe so a wedged bd
+	// binary cannot hang higher-level commands such as gt status.
+	bdAllowStaleProbeTimeout = 2 * time.Second
 )
 
 // ResetBdAllowStaleCacheForTest clears the cached bd --allow-stale capability.
@@ -70,18 +73,23 @@ func BdSupportsAllowStaleWithEnv(env []string) bool {
 		return cachedResult
 	}
 
-	cmd := exec.Command(bdPath, "--allow-stale", "version") //nolint:gosec // G204: bd is a trusted internal tool
-	util.SetDetachedProcessGroup(cmd)
+	ctx, cancel := context.WithTimeout(context.Background(), bdAllowStaleProbeTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, bdPath, "--allow-stale", "version") //nolint:gosec // G204: bd is a trusted internal tool
+	util.SetProcessGroup(cmd)
 	if env != nil {
 		cmd.Env = env
 	}
 	var combinedOut bytes.Buffer
 	cmd.Stdout = &combinedOut
 	cmd.Stderr = &combinedOut
-	_ = cmd.Run()
+	err = cmd.Run()
 	// bd v0.60+ exits 0 even on unknown flags, printing the error to stderr.
-	// Check output for "unknown flag" to detect lack of support.
-	supported := !strings.Contains(combinedOut.String(), "unknown flag")
+	// Check output for "unknown flag" to detect lack of support. Treat probe
+	// errors/timeouts as unsupported so higher-level commands fail closed
+	// instead of hanging on a wedged bd subprocess.
+	supported := err == nil && !strings.Contains(combinedOut.String(), "unknown flag")
 
 	bdAllowStaleMu.Lock()
 	if bdAllowStalePath != bdPath {

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -9,6 +9,7 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 )
 
 // TestNew verifies the constructor.
@@ -148,6 +149,47 @@ func TestBdSupportsAllowStale_ReprobesWhenBinaryPathChanges(t *testing.T) {
 	}
 }
 
+func TestBdSupportsAllowStale_TimeoutTreatsProbeAsUnsupported(t *testing.T) {
+	bdAllowStaleMu.Lock()
+	prevPath := bdAllowStalePath
+	prevResult := bdAllowStaleResult
+	bdAllowStaleMu.Unlock()
+	prevTimeout := bdAllowStaleProbeTimeout
+	ResetBdAllowStaleCacheForTest()
+	bdAllowStaleProbeTimeout = 100 * time.Millisecond
+	t.Cleanup(func() {
+		bdAllowStaleMu.Lock()
+		bdAllowStalePath = prevPath
+		bdAllowStaleResult = prevResult
+		bdAllowStaleMu.Unlock()
+		bdAllowStaleProbeTimeout = prevTimeout
+	})
+
+	hangingDir := t.TempDir()
+	markerPath := filepath.Join(hangingDir, "allow-stale-timeout-marker")
+	writeHangingAllowStaleBDStub(t, hangingDir, markerPath)
+
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", hangingDir+string(os.PathListSeparator)+origPath)
+
+	start := time.Now()
+	if BdSupportsAllowStale() {
+		t.Fatal("expected hanging probe to time out and report no --allow-stale support")
+	}
+	if elapsed := time.Since(start); elapsed > time.Second {
+		t.Fatalf("expected probe timeout to return promptly, took %v", elapsed)
+	}
+
+	if runtime.GOOS != "windows" {
+		time.Sleep(250 * time.Millisecond)
+		if _, err := os.Stat(markerPath); err == nil {
+			t.Fatal("expected timed-out probe to kill the entire process group")
+		} else if !os.IsNotExist(err) {
+			t.Fatalf("stat timeout marker: %v", err)
+		}
+	}
+}
+
 // writeAllowStaleBDStub creates a mock bd binary in dir.
 //
 // The detection function (BdSupportsAllowStaleWithEnv) ignores the exit code
@@ -197,6 +239,39 @@ exit 0
 
 	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
 		t.Fatalf("write bd stub: %v", err)
+	}
+}
+
+func writeHangingAllowStaleBDStub(t *testing.T, dir, markerPath string) {
+	t.Helper()
+
+	var scriptPath, script string
+	if runtime.GOOS == "windows" {
+		scriptPath = filepath.Join(dir, "bd.bat")
+		script = `@echo off
+setlocal enableextensions
+if "%1"=="--allow-stale" (
+  ping -n 6 127.0.0.1 >nul
+)
+exit /b 0
+`
+	} else {
+		scriptPath = filepath.Join(dir, "bd")
+		script = fmt.Sprintf(`#!/bin/sh
+if [ "$1" = "--allow-stale" ]; then
+  (
+    sleep 0.2
+    : > %q
+  ) &
+  child=$!
+  wait "$child"
+fi
+exit 0
+`, markerPath)
+	}
+
+	if err := os.WriteFile(scriptPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write hanging bd stub: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- bound the internal `bd --allow-stale version` capability probe with a timeout so `gt status` and related commands fail closed instead of hanging on a wedged `bd` subprocess
- run the probe in its own cancellable process group so timeout cleanup reaches child processes too
- add regression coverage for both probe re-detection and the timeout/cleanup path
- clarify the fail-closed behavior inline in the probe implementation

## Testing
- `go test ./internal/beads`
- `go test -race -short -timeout=10m ./internal/beads ./internal/cmd -run "(BdSupportsAllowStale|Status|DiscoverRigAgents|BuildStatusIndicator|RunStatusWatch)"`
- manual repro: verified `gt status` returns normally against the local HQ that previously hung

Co-Authored-By: Oz <oz-agent@warp.dev>
