### PR TITLE
fix: gt prime renders formula steps for town- and rig-level formulas

### DIFF
--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -113,7 +113,7 @@ func showMoleculeExecutionPrompt(workDir, moleculeID string) {
 // extraVars is an optional list of "key=value" overrides that are substituted into
 // step descriptions before rendering, taking precedence over formula defaults.
 func showFormulaSteps(formulaName, label, townRoot, rigName string, extraVars ...[]string) {
-	content, err := formula.GetEmbeddedFormulaContent(formulaName)
+	content, err := formula.ResolveFormulaContent(formulaName, townRoot, rigName)
 	if err != nil {
 		style.PrintWarning("could not load formula %s: %v", formulaName, err)
 		return
@@ -152,7 +152,7 @@ func showFormulaSteps(formulaName, label, townRoot, rigName string, extraVars ..
 // townRoot and rigName are used to load formula overlays (operator customizations).
 // extraVars is an optional list of "key=value" overrides substituted into step descriptions.
 func showFormulaStepsFull(formulaName, townRoot, rigName string, extraVars ...[]string) {
-	content, err := formula.GetEmbeddedFormulaContent(formulaName)
+	content, err := formula.ResolveFormulaContent(formulaName, townRoot, rigName)
 	if err != nil {
 		style.PrintWarning("could not load formula %s: %v", formulaName, err)
 		return

--- a/internal/formula/embed.go
+++ b/internal/formula/embed.go
@@ -44,6 +44,40 @@ type HealthReport struct {
 	Error     int // file could not be read (e.g. permission denied)
 }
 
+// ResolveFormulaContent resolves formula content using the three-tier precedence
+// defined in docs/design/formula-resolution.md: rig > town > embedded.
+//
+// Tier 1 (rig): townRoot/rigName/.beads/formulas/<name>.formula.toml
+// Tier 2 (town): townRoot/.beads/formulas/<name>.formula.toml
+// Tier 3 (embedded): compiled into the binary
+//
+// Either townRoot or rigName may be empty; those tiers are skipped.
+func ResolveFormulaContent(name, townRoot, rigName string) ([]byte, error) {
+	filename := name
+	if !hasFormulaSuffix(filename) {
+		filename = filename + ".formula.toml"
+	}
+
+	// Tier 1: rig-level (most specific)
+	if townRoot != "" && rigName != "" {
+		path := filepath.Join(townRoot, rigName, ".beads", "formulas", filename)
+		if content, err := os.ReadFile(path); err == nil {
+			return content, nil
+		}
+	}
+
+	// Tier 2: town-level
+	if townRoot != "" {
+		path := filepath.Join(townRoot, ".beads", "formulas", filename)
+		if content, err := os.ReadFile(path); err == nil {
+			return content, nil
+		}
+	}
+
+	// Tier 3: embedded (system fallback)
+	return GetEmbeddedFormulaContent(name)
+}
+
 // GetEmbeddedFormulaContent returns the raw content of an embedded formula by name.
 // The name can be with or without the .formula.toml suffix.
 // Returns the content bytes, or an error if the formula is not found.

--- a/internal/formula/embed_test.go
+++ b/internal/formula/embed_test.go
@@ -864,6 +864,98 @@ func TestCheckFormulaHealth_MixedScenarios(t *testing.T) {
 	}
 }
 
+// TestResolveFormulaContent verifies resolution order: rig > town > embedded.
+func TestResolveFormulaContent(t *testing.T) {
+	t.Run("returns embedded formula when no disk overrides exist", func(t *testing.T) {
+		content, err := ResolveFormulaContent("mol-polecat-work", "", "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if len(content) == 0 {
+			t.Error("expected non-empty content")
+		}
+	})
+
+	t.Run("town-level formula shadows embedded", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		formulasDir := filepath.Join(tmpDir, ".beads", "formulas")
+		if err := os.MkdirAll(formulasDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		townContent := []byte("formula = \"mol-polecat-work\"\nversion = 99\n")
+		if err := os.WriteFile(filepath.Join(formulasDir, "mol-polecat-work.formula.toml"), townContent, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		content, err := ResolveFormulaContent("mol-polecat-work", tmpDir, "")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(content) != string(townContent) {
+			t.Error("expected town-level content to shadow embedded")
+		}
+	})
+
+	t.Run("rig-level formula shadows town and embedded", func(t *testing.T) {
+		tmpDir := t.TempDir()
+
+		// Write town-level formula
+		townFormulasDir := filepath.Join(tmpDir, ".beads", "formulas")
+		if err := os.MkdirAll(townFormulasDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		townContent := []byte("formula = \"mol-polecat-work\"\nversion = 99\n")
+		if err := os.WriteFile(filepath.Join(townFormulasDir, "mol-polecat-work.formula.toml"), townContent, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		// Write rig-level formula (takes priority)
+		rigFormulasDir := filepath.Join(tmpDir, "myrig", ".beads", "formulas")
+		if err := os.MkdirAll(rigFormulasDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		rigContent := []byte("formula = \"mol-polecat-work\"\nversion = 100\n")
+		if err := os.WriteFile(filepath.Join(rigFormulasDir, "mol-polecat-work.formula.toml"), rigContent, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		content, err := ResolveFormulaContent("mol-polecat-work", tmpDir, "myrig")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(content) != string(rigContent) {
+			t.Error("expected rig-level content to shadow town and embedded")
+		}
+	})
+
+	t.Run("falls back to town when rig has no override", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		townFormulasDir := filepath.Join(tmpDir, ".beads", "formulas")
+		if err := os.MkdirAll(townFormulasDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		townContent := []byte("formula = \"mol-custom-test\"\nversion = 1\n")
+		if err := os.WriteFile(filepath.Join(townFormulasDir, "mol-custom-test.formula.toml"), townContent, 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		content, err := ResolveFormulaContent("mol-custom-test", tmpDir, "myrig")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if string(content) != string(townContent) {
+			t.Error("expected town-level content when rig has no override")
+		}
+	})
+
+	t.Run("returns error when not found anywhere", func(t *testing.T) {
+		_, err := ResolveFormulaContent("mol-does-not-exist", "", "")
+		if err == nil {
+			t.Error("expected error for non-existent formula")
+		}
+	})
+}
+
 // TestGetEmbeddedFormulaContent verifies extraction of individual embedded formulas.
 func TestGetEmbeddedFormulaContent(t *testing.T) {
 	// Known embedded formula should succeed


### PR DESCRIPTION
## Problem

\`gt prime\` silently drops the Formula Checklist when the formula isn't compiled into the binary. \`showFormulaSteps\` and \`showFormulaStepsFull\` both called \`GetEmbeddedFormulaContent\` exclusively, so any formula placed in \`~/gt/.beads/formulas/\` (tier 2 / town) or a rig's \`.beads/formulas/\` (tier 1 / rig) would fail with a warning and produce no checklist. The polecat would improvise instead of following the workflow.

\`bd\` resolves formulas correctly. Only the \`gt prime\` rendering path was broken.

## Fix

Adds \`ResolveFormulaContent(name, townRoot, rigName string)\` to the \`formula\` package implementing the precedence defined in \`docs/design/formula-resolution.md\`: rig → town → embedded. Both \`showFormulaSteps\` and \`showFormulaStepsFull\` now use it (two-line change in \`prime_molecule.go\`).

Call sites in \`prime_output.go\` already pass \`townRoot\` and \`rigName\`, so they benefit without any further changes.

## Notes

The design doc's pseudocode describes tier 1 as a cwd walk-up to find the project root. For \`gt prime\`, that discovery is already done upstream — \`ctx.Rig\` and \`ctx.TownRoot\` are resolved before these functions are called, so \`filepath.Join(townRoot, rigName)\` directly produces the rig root. This is consistent with how the rest of the codebase locates rig-level resources (see \`rigBeadsRoot()\`). A cwd walk-up would only be needed for a general standalone resolver (e.g., for \`bd cook\`) that lacks \`townRoot\`/\`rigName\` in scope.

## Tests

Five cases in \`TestResolveFormulaContent\`: embedded fallback, town shadows embedded, rig shadows town+embedded, town fallback when rig has no override, error when missing everywhere.