### PR TITLE
fix(routing): unify cross-rig bead ID resolver (au-ofe, au-b9d)

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -518,6 +518,42 @@ func (b *Beads) runWithRouting(args ...string) (_ []byte, retErr error) { //noli
 	return stripStdoutWarnings(stdout.Bytes()), nil
 }
 
+// routesCrossRig reports whether id's prefix routes to a different beads dir
+// than b's own (per routes.jsonl). Returns false if no routing is needed or
+// the route can't be resolved (in which case the caller should use b.run).
+func (b *Beads) routesCrossRig(id string) bool {
+	own := b.getResolvedBeadsDir()
+	target := ResolveRoutingTargetQuiet(b.getTownRoot(), id, own)
+	return target != "" && target != own
+}
+
+// runBDForID executes a bd command that operates on a single bead id, choosing
+// between run (explicit BEADS_DIR for same-rig) and runWithRouting (strips
+// BEADS_DIR so bd does its own prefix routing for cross-rig ids). Pinning
+// BEADS_DIR at a rig's .beads bypasses routes.jsonl and breaks lookups for
+// beads that live in a different database on the shared Dolt server, so we
+// only strip BEADS_DIR when a cross-rig route is detected. See au-ofe, au-b9d.
+func (b *Beads) runBDForID(id string, args ...string) ([]byte, error) {
+	if b.routesCrossRig(id) {
+		return b.runWithRouting(args...)
+	}
+	return b.run(args...)
+}
+
+// runBDForIDs is the multi-id variant of runBDForID. If any id routes to a
+// different rig than b's own, BEADS_DIR is stripped so bd handles routing
+// itself (bd supports mixed-prefix args: `bd close au-foo hq-bar` will route
+// each id to its own database). Same-rig-only invocations use run() so
+// BEADS_DIR stays pinned for consistency with other same-rig ops.
+func (b *Beads) runBDForIDs(ids []string, args ...string) ([]byte, error) {
+	for _, id := range ids {
+		if b.routesCrossRig(id) {
+			return b.runWithRouting(args...)
+		}
+	}
+	return b.run(args...)
+}
+
 // Run executes a bd command and returns stdout.
 // This is a public wrapper around the internal run method for cases where
 // callers need to run arbitrary bd commands.
@@ -1078,19 +1114,17 @@ func (b *Beads) ReadyWithType(issueType string) ([]*Issue, error) {
 
 // Show returns detailed information about an issue.
 func (b *Beads) Show(id string) (*Issue, error) {
-	// Route cross-rig queries via routes.jsonl so that rig-level bead IDs
-	// (e.g., "gt-abc123") resolve to the correct rig database.
-	targetDir := ResolveRoutingTarget(b.getTownRoot(), id, b.getResolvedBeadsDir())
-	if targetDir != b.getResolvedBeadsDir() {
-		target := NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
-		return target.Show(id)
-	}
-
 	if b.store != nil {
 		return b.storeShow(id)
 	}
 
-	out, err := b.run("show", id, "--json")
+	// Route cross-rig queries by stripping BEADS_DIR so bd's own prefix-based
+	// routing (via the town's routes.jsonl) resolves the bead. Pinning
+	// BEADS_DIR at a rig's .beads bypasses that routing and fails lookups for
+	// beads whose prefix maps to a different database on the shared Dolt
+	// server. See au-ofe / au-b9d. runBDForID picks run vs runWithRouting
+	// based on whether the ID routes to b's own beadsDir.
+	out, err := b.runBDForID(id, "show", id, "--json")
 	if err != nil {
 		return nil, err
 	}
@@ -1427,6 +1461,11 @@ func normalizeBugTitle(title string) string {
 }
 
 // Update updates an existing issue.
+//
+// When id routes to a different rig than b's own beadsDir, BEADS_DIR is
+// stripped so bd performs its own routes.jsonl-driven lookup. Without this,
+// the bd subprocess would be pinned to b's beadsDir and fail to find the
+// bead (au-ofe).
 func (b *Beads) Update(id string, opts UpdateOptions) error {
 	if b.store != nil {
 		return b.storeUpdate(id, opts)
@@ -1463,13 +1502,16 @@ func (b *Beads) Update(id string, opts UpdateOptions) error {
 		}
 	}
 
-	_, err := b.run(args...)
+	_, err := b.runBDForID(id, args...)
 	return err
 }
 
 // Close closes one or more issues.
 // If a runtime session ID is set in the environment, it is passed to bd close
 // for work attribution tracking (see decision 009-session-events-architecture.md).
+//
+// If any id routes to a different rig than b's own beadsDir, BEADS_DIR is
+// stripped so bd routes each id itself (au-ofe).
 func (b *Beads) Close(ids ...string) error {
 	if len(ids) == 0 {
 		return nil
@@ -1486,13 +1528,16 @@ func (b *Beads) Close(ids ...string) error {
 		args = append(args, "--session="+sessionID)
 	}
 
-	_, err := b.run(args...)
+	_, err := b.runBDForIDs(ids, args...)
 	return err
 }
 
 // CloseWithReason closes one or more issues with a reason.
 // If a runtime session ID is set in the environment, it is passed to bd close
 // for work attribution tracking (see decision 009-session-events-architecture.md).
+//
+// If any id routes to a different rig than b's own beadsDir, BEADS_DIR is
+// stripped so bd routes each id itself (au-ofe).
 func (b *Beads) CloseWithReason(reason string, ids ...string) error {
 	if len(ids) == 0 {
 		return nil
@@ -1510,13 +1555,16 @@ func (b *Beads) CloseWithReason(reason string, ids ...string) error {
 		args = append(args, "--session="+sessionID)
 	}
 
-	_, err := b.run(args...)
+	_, err := b.runBDForIDs(ids, args...)
 	return err
 }
 
 // ForceCloseWithReason closes one or more issues with --force, bypassing
 // dependency checks. Used by gt done where the polecat is about to be nuked
 // and open molecule wisps should not block issue closure.
+//
+// If any id routes to a different rig than b's own beadsDir, BEADS_DIR is
+// stripped so bd routes each id itself (au-ofe).
 func (b *Beads) ForceCloseWithReason(reason string, ids ...string) error {
 	if len(ids) == 0 {
 		return nil
@@ -1539,7 +1587,7 @@ func (b *Beads) ForceCloseWithReason(reason string, ids ...string) error {
 		args = append(args, "--session="+sessionID)
 	}
 
-	_, err := b.run(args...)
+	_, err := b.runBDForIDs(ids, args...)
 	return err
 }
 
@@ -1573,7 +1621,7 @@ func (b *Beads) ReleaseWithReason(id, reason string) error {
 		args = append(args, "--notes=Released: "+reason)
 	}
 
-	_, err := b.run(args...)
+	_, err := b.runBDForID(id, args...)
 	return err
 }
 

--- a/internal/beads/beads_channel.go
+++ b/internal/beads/beads_channel.go
@@ -446,7 +446,7 @@ func (b *Beads) EnforceChannelRetention(name string) error {
 	// Delete marked messages (best-effort)
 	for id := range toDeleteIDs {
 		// Use close instead of delete for audit trail
-		_, _ = b.run("close", id, "--reason=channel retention pruning")
+		_, _ = b.runBDForID(id, "close", id, "--reason=channel retention pruning")
 	}
 
 	return nil
@@ -519,7 +519,7 @@ func (b *Beads) PruneAllChannels() (int, error) {
 
 		// Delete marked messages
 		for id := range toDeleteIDs {
-			if _, err := b.run("close", id, "--reason=patrol retention pruning"); err == nil {
+			if _, err := b.runBDForID(id, "close", id, "--reason=patrol retention pruning"); err == nil {
 				pruned++
 			}
 		}

--- a/internal/beads/beads_delegation.go
+++ b/internal/beads/beads_delegation.go
@@ -69,7 +69,7 @@ func (b *Beads) AddDelegation(d *Delegation) error {
 		if marshalErr != nil {
 			return fmt.Errorf("marshaling delegation: %w", marshalErr)
 		}
-		_, err = b.run("update", d.Child, "--set-metadata=delegated_from="+string(delegationJSON))
+		_, err = b.runBDForID(d.Child, "update", d.Child, "--set-metadata=delegated_from="+string(delegationJSON))
 	}
 	if err != nil {
 		return fmt.Errorf("setting delegation metadata: %w", err)
@@ -91,7 +91,7 @@ func (b *Beads) RemoveDelegation(parent, child string) error {
 		err = b.storeDelegationClear(child)
 	} else {
 		// CLI path: use --unset-metadata flag (bd update in v0.62+).
-		_, err = b.run("update", child, "--unset-metadata=delegated_from")
+		_, err = b.runBDForID(child, "update", child, "--unset-metadata=delegated_from")
 	}
 	if err != nil {
 		return fmt.Errorf("clearing delegation metadata: %w", err)

--- a/internal/beads/beads_escalation.go
+++ b/internal/beads/beads_escalation.go
@@ -259,9 +259,11 @@ func (b *Beads) CloseEscalation(id, closedBy, reason string) error {
 		return err
 	}
 
-	// Close the issue
-	_, err = b.run("close", id, "--reason="+reason)
-	return err
+	// Close the issue. Route on id so cross-rig escalations (au-ofe) resolve
+	// to the correct database. Delegating to CloseWithReason keeps the close
+	// path consistent with Close/ForceCloseWithReason (session tagging, store
+	// handling, and runBDForIDs routing).
+	return b.CloseWithReason(reason, id)
 }
 
 // GetEscalationBead retrieves an escalation bead by ID.

--- a/internal/beads/beads_sling_context.go
+++ b/internal/beads/beads_sling_context.go
@@ -120,7 +120,7 @@ func (b *Beads) ListOpenSlingContexts() ([]*Issue, error) {
 // CloseSlingContext closes a sling context bead with a reason.
 // Idempotent: suppresses "already closed" errors so retries are safe.
 func (b *Beads) CloseSlingContext(contextID, reason string) error {
-	_, err := b.run("close", contextID, "--reason="+reason)
+	_, err := b.runBDForID(contextID, "close", contextID, "--reason="+reason)
 	if err != nil && strings.Contains(err.Error(), "already closed") {
 		return nil // Idempotent — already in desired state
 	}

--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -58,8 +58,22 @@ func FindTownRoot(startDir string) string {
 // It extracts the prefix from the bead ID and looks up the corresponding route.
 // Returns the resolved beads directory path, following any redirects.
 //
-// If townRoot is empty or prefix is not found, falls back to the provided fallbackDir.
+// If townRoot is empty or prefix is not found, falls back to the provided fallbackDir
+// and logs a warning to stderr. Callers that expect a silent fallback (e.g., best-effort
+// mail lookups where the ID may not be routable) should use ResolveRoutingTargetQuiet.
 func ResolveRoutingTarget(townRoot, beadID, fallbackDir string) string {
+	return resolveRoutingTarget(townRoot, beadID, fallbackDir, true)
+}
+
+// ResolveRoutingTargetQuiet is like ResolveRoutingTarget but silently returns
+// fallbackDir if the bead's prefix has no route or the rig beads dir can't be
+// resolved. Useful for best-effort callers (mail Get fallback, etc.) where a
+// missing route is an expected outcome, not a warning condition.
+func ResolveRoutingTargetQuiet(townRoot, beadID, fallbackDir string) string {
+	return resolveRoutingTarget(townRoot, beadID, fallbackDir, false)
+}
+
+func resolveRoutingTarget(townRoot, beadID, fallbackDir string, warn bool) string {
 	if townRoot == "" {
 		return fallbackDir
 	}
@@ -73,14 +87,18 @@ func ResolveRoutingTarget(townRoot, beadID, fallbackDir string) string {
 	// Look up rig path for this prefix
 	rigPath := GetRigPathForPrefix(townRoot, prefix)
 	if rigPath == "" {
-		fmt.Fprintf(os.Stderr, "Warning: no route found for prefix %q (bead %s), falling back to %s\n", prefix, beadID, fallbackDir)
+		if warn {
+			fmt.Fprintf(os.Stderr, "Warning: no route found for prefix %q (bead %s), falling back to %s\n", prefix, beadID, fallbackDir)
+		}
 		return fallbackDir
 	}
 
 	// Resolve redirects and get final beads directory
 	beadsDir := ResolveBeadsDir(rigPath)
 	if beadsDir == "" {
-		fmt.Fprintf(os.Stderr, "Warning: could not resolve beads dir for rig %s (bead %s), falling back to %s\n", rigPath, beadID, fallbackDir)
+		if warn {
+			fmt.Fprintf(os.Stderr, "Warning: could not resolve beads dir for rig %s (bead %s), falling back to %s\n", rigPath, beadID, fallbackDir)
+		}
 		return fallbackDir
 	}
 

--- a/internal/beads/routes.go
+++ b/internal/beads/routes.go
@@ -337,31 +337,36 @@ func GetRigNameForPrefix(townRoot, prefix string) string {
 // (typically the town-level .beads). If the bead ID's prefix maps to a different
 // rig via routes.jsonl, the resolved rig's beads directory is returned.
 // Returns currentBeadsDir if no routing is needed or prefix can't be resolved.
+//
+// This delegates to ResolveRoutingTarget for cross-rig resolution so that all
+// ID→beadsDir lookup paths (bd show, mail read/archive, escalate ack/close,
+// bead Update/Close) behave identically. See beads au-ofe and au-b9d: previously
+// this function only consulted routes.jsonl in currentBeadsDir, which missed
+// rigs whose routes live in the town's beads dir (or other workspaces) and did
+// not follow redirects, so writes against cross-rig bead IDs failed with
+// "issue not found".
 func ResolveBeadsDirForID(currentBeadsDir, beadID string) string {
-	prefix := ExtractPrefix(beadID)
-	if prefix == "" {
-		return currentBeadsDir
+	// Derive town root from currentBeadsDir. ResolveRoutingTarget will look up
+	// the prefix in the town's routes.jsonl and follow any redirects.
+	//
+	// currentBeadsDir is typically ".../<townRoot>/.beads", in which case the
+	// town root is its parent directory. FindTownRoot walks up looking for
+	// mayor/town.json so it still works when currentBeadsDir points at a rig
+	// worktree's .beads (e.g., a polecat's .beads that redirects into town).
+	townRoot := ""
+	if filepath.Base(currentBeadsDir) == ".beads" {
+		townRoot = FindTownRoot(filepath.Dir(currentBeadsDir))
+	} else {
+		townRoot = FindTownRoot(currentBeadsDir)
 	}
-
-	routes, err := LoadRoutes(currentBeadsDir)
-	if err != nil || routes == nil {
-		return currentBeadsDir
+	if townRoot == "" {
+		// Best-effort fallback: assume currentBeadsDir's parent is the town root.
+		townRoot = filepath.Dir(currentBeadsDir)
 	}
-
-	for _, r := range routes {
-		if r.Prefix == prefix {
-			if r.Path == "." {
-				return currentBeadsDir // Town-level — already correct
-			}
-			// Rig-level bead — resolve to rig's beads directory.
-			// Derive town root from currentBeadsDir (parent of .beads).
-			townRoot := filepath.Dir(currentBeadsDir)
-			rigDir := filepath.Join(townRoot, r.Path)
-			return ResolveBeadsDir(rigDir)
-		}
-	}
-
-	return currentBeadsDir
+	// Use the quiet variant: callers like mail.Get probe IDs whose prefixes may
+	// legitimately not have a route (dangling refs, legacy JSONL beads). The
+	// stderr spam was confusing and made the inbox unusable (au-b9d).
+	return ResolveRoutingTargetQuiet(townRoot, beadID, currentBeadsDir)
 }
 
 // ValidateRigPrefix checks that a newly created bead landed in the expected rig's

--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -1018,7 +1018,7 @@ func updateSessionEnvForHandoff(t *tmux.Tmux, sessionName, agentOverride string)
 			}
 			rc, _, err := config.ResolveAgentConfigWithOverride(townRoot, rigPath, currentAgent)
 			if err == nil {
-				resolved := config.ResolveProcessNames(currentAgent, rc.Command)
+				resolved := config.ResolveProcessNames(currentAgent, rc.Command, rc.Args...)
 				processNames = strings.Join(resolved, ",")
 			}
 		}

--- a/internal/cmd/mail_inbox.go
+++ b/internal/cmd/mail_inbox.go
@@ -342,31 +342,45 @@ func runMailArchive(cmd *cobra.Command, args []string) error {
 		return nil
 	}
 
-	// Archive all specified messages
+	// Archive all specified messages.
+	//
+	// Archive is a mail cleanup operation, not a bead operation. If the
+	// underlying bead has been garbage collected (by `bd mol wisp gc` or
+	// `bd compact`), the mail entry is effectively already gone — we
+	// treat ErrMessageNotFound as success so orphaned inbox references
+	// can be cleared without manual surgery. See aa-6hv.
 	archived := 0
-	var errors []string
+	gcd := 0
+	var errMsgs []string
 	for _, msgID := range args {
-		if err := mailbox.Delete(msgID); err != nil {
-			errors = append(errors, fmt.Sprintf("%s: %v", msgID, err))
-		} else {
+		err := mailbox.Delete(msgID)
+		switch {
+		case err == nil:
 			archived++
+		case errors.Is(err, mail.ErrMessageNotFound):
+			gcd++
+			fmt.Printf("  %s %s: underlying bead already gone (GC'd), entry cleared\n",
+				style.Dim.Render("note"), msgID)
+		default:
+			errMsgs = append(errMsgs, fmt.Sprintf("%s: %v", msgID, err))
 		}
 	}
 
 	// Report results
-	if len(errors) > 0 {
+	if len(errMsgs) > 0 {
 		fmt.Printf("%s Archived %d/%d messages\n",
-			style.Bold.Render("⚠"), archived, len(args))
-		for _, e := range errors {
+			style.Bold.Render("⚠"), archived+gcd, len(args))
+		for _, e := range errMsgs {
 			fmt.Printf("  Error: %s\n", e)
 		}
-		return fmt.Errorf("failed to archive %d messages", len(errors))
+		return fmt.Errorf("failed to archive %d messages", len(errMsgs))
 	}
 
-	if len(args) == 1 {
+	total := archived + gcd
+	if total == 1 {
 		fmt.Printf("%s Message archived\n", style.Bold.Render("✓"))
 	} else {
-		fmt.Printf("%s Archived %d messages\n", style.Bold.Render("✓"), archived)
+		fmt.Printf("%s Archived %d messages\n", style.Bold.Render("✓"), total)
 	}
 	return nil
 }
@@ -415,28 +429,40 @@ func runMailArchiveStale(mailbox *mail.Mailbox, address string) error {
 		return nil
 	}
 
+	// GC'd beads (see aa-6hv): if the underlying bead was removed by
+	// `bd mol wisp gc` or `bd compact`, the close call returns
+	// ErrMessageNotFound. That's a success for archive: the mail entry
+	// is already effectively gone.
 	archived := 0
-	var errors []string
+	gcd := 0
+	var errMsgs []string
 	for _, stale := range staleMessages {
-		if err := mailbox.Delete(stale.Message.ID); err != nil {
-			errors = append(errors, fmt.Sprintf("%s: %v", stale.Message.ID, err))
-		} else {
+		err := mailbox.Delete(stale.Message.ID)
+		switch {
+		case err == nil:
 			archived++
+		case errors.Is(err, mail.ErrMessageNotFound):
+			gcd++
+			fmt.Printf("  %s %s: underlying bead already gone (GC'd), entry cleared\n",
+				style.Dim.Render("note"), stale.Message.ID)
+		default:
+			errMsgs = append(errMsgs, fmt.Sprintf("%s: %v", stale.Message.ID, err))
 		}
 	}
 
-	if len(errors) > 0 {
-		fmt.Printf("%s Archived %d/%d stale messages\n", style.Bold.Render("⚠"), archived, len(staleMessages))
-		for _, e := range errors {
+	if len(errMsgs) > 0 {
+		fmt.Printf("%s Archived %d/%d stale messages\n", style.Bold.Render("⚠"), archived+gcd, len(staleMessages))
+		for _, e := range errMsgs {
 			fmt.Printf("  Error: %s\n", e)
 		}
-		return fmt.Errorf("failed to archive %d stale messages", len(errors))
+		return fmt.Errorf("failed to archive %d stale messages", len(errMsgs))
 	}
 
-	if archived == 1 {
+	total := archived + gcd
+	if total == 1 {
 		fmt.Printf("%s Stale message archived\n", style.Bold.Render("✓"))
 	} else {
-		fmt.Printf("%s Archived %d stale messages\n", style.Bold.Render("✓"), archived)
+		fmt.Printf("%s Archived %d stale messages\n", style.Bold.Render("✓"), total)
 	}
 	return nil
 }

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -850,16 +850,20 @@ func extractWrappedBinary(wrapper string, args []string) string {
 // "opencode" instead of the built-in "codex" binary), and custom agents wrapped
 // in process launchers like `env -u VAR <real-binary>`.
 //
+// args (variadic, optional) is the actual command-line argument slice for the
+// agent invocation. When command is a wrapper (env, sudo, nohup, ...), the
+// real binary is found in args, not on the registered preset's Args (which
+// may belong to the canonical built-in preset, not the user's wrapper).
+//
 // Resolution order:
 //  1. If agentName matches a built-in preset AND the preset's Command matches
 //     the actual command → use the preset's ProcessNames (no mismatch).
-//  2. If the resolved command is a known wrapper (env, sudo, nohup, ...) and
-//     the registered agent has Args, scan the args for the real binary and
-//     resolve to its preset's ProcessNames.
+//  2. If command is a known wrapper, scan args (or the registered preset's Args
+//     as a fallback) for the real binary and resolve to its preset's ProcessNames.
 //  3. Otherwise, find a built-in preset whose Command matches the actual command
 //     and use its ProcessNames (custom agent using a known launcher).
 //  4. Fallback: [command] (fully custom binary).
-func ResolveProcessNames(agentName, command string) []string {
+func ResolveProcessNames(agentName, command string, args ...string) []string {
 	registryMu.Lock()
 	initRegistryLocked()
 	defer registryMu.Unlock()
@@ -877,7 +881,8 @@ func ResolveProcessNames(agentName, command string) []string {
 	// Check if agentName matches a built-in/registered preset with matching command.
 	// Compare against both the raw command and basename to handle registry entries
 	// that store absolute-path commands (e.g., "/opt/bin/my-tool").
-	if info, ok := globalRegistry.Agents[agentName]; ok {
+	info, infoOK := globalRegistry.Agents[agentName]
+	if infoOK {
 		if len(info.ProcessNames) > 0 &&
 			(info.Command == command ||
 				info.Command == cmdBase ||
@@ -886,18 +891,26 @@ func ResolveProcessNames(agentName, command string) []string {
 				cmdBase == "") {
 			return info.ProcessNames
 		}
-		// Wrapper case: agent's Command is `env`/`sudo`/etc. — find the real
-		// binary in Args and resolve to ITS preset's ProcessNames. Try the
-		// runtime registry first; fall back to builtinPresets if the user has
-		// shadowed the canonical preset (e.g., custom "claude" agent that
-		// wraps the real claude binary).
-		if wrapperCommands[cmdBase] && len(info.Args) > 0 {
-			if realBin := extractWrappedBinary(cmdBase, info.Args); realBin != "" {
-				if names := lookupProcessNamesByBinary(realBin); len(names) > 0 {
-					return names
-				}
-				return []string{realBin}
+	}
+
+	// Wrapper case: command is `env`/`sudo`/etc. — find the real binary in
+	// args (caller-supplied) or the registered preset's Args, and resolve to
+	// THAT binary's preset ProcessNames. Caller args take precedence because
+	// the registered preset may be the canonical built-in (not the wrapper).
+	if wrapperCommands[cmdBase] {
+		argSources := [][]string{args}
+		if infoOK && len(info.Args) > 0 {
+			argSources = append(argSources, info.Args)
+		}
+		for _, src := range argSources {
+			realBin := extractWrappedBinary(cmdBase, src)
+			if realBin == "" {
+				continue
 			}
+			if names := lookupProcessNamesByBinary(realBin); len(names) > 0 {
+				return names
+			}
+			return []string{realBin}
 		}
 	}
 

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -745,17 +745,120 @@ func GetProcessNames(agentName string) []string {
 	return info.ProcessNames
 }
 
+// wrapperCommands lists process wrappers that exec into another binary listed
+// in their arguments (e.g., `env -u VAR claude ...`). When the agent's Command
+// is one of these, ResolveProcessNames must look past the wrapper to find the
+// real agent binary in Args, otherwise liveness detection greps for a process
+// named after the wrapper that no longer exists post-exec.
+var wrapperCommands = map[string]bool{
+	"env":    true,
+	"nohup":  true,
+	"setsid": true,
+	"exec":   true,
+	"sudo":   true,
+	"doas":   true,
+	"stdbuf": true,
+	"time":   true,
+}
+
+// wrapperFlagsTakeValue returns the set of short flags that consume the
+// next argument as a value, for the given wrapper. Used by extractWrappedBinary
+// to skip "-flag value" pairs when scanning args for the real binary.
+func wrapperFlagsTakeValue(wrapper string) map[string]bool {
+	switch wrapper {
+	case "env":
+		// env: -u VAR (unset), -C DIR (chdir), -S STRING (split-string)
+		return map[string]bool{"-u": true, "-C": true, "-S": true}
+	case "sudo":
+		// sudo: most options take a value; list the common ones
+		return map[string]bool{
+			"-u": true, "-g": true, "-h": true, "-p": true,
+			"-U": true, "-A": true, "-c": true, "-r": true,
+			"-t": true, "-T": true, "-D": true, "-R": true,
+		}
+	case "stdbuf":
+		// stdbuf: -i, -o, -e all take a value (mode)
+		return map[string]bool{"-i": true, "-o": true, "-e": true}
+	}
+	return nil
+}
+
+// lookupProcessNamesByBinary returns the ProcessNames of the preset whose
+// Command (or its basename) matches realBin. Searches the runtime registry
+// first, then the canonical builtinPresets so shadowed builtins still resolve.
+// Caller must hold registryMu.
+func lookupProcessNamesByBinary(realBin string) []string {
+	for _, preset := range globalRegistry.Agents {
+		if len(preset.ProcessNames) == 0 {
+			continue
+		}
+		if preset.Command == realBin || filepath.Base(preset.Command) == realBin {
+			return preset.ProcessNames
+		}
+	}
+	for _, preset := range builtinPresets {
+		if len(preset.ProcessNames) == 0 {
+			continue
+		}
+		if preset.Command == realBin || filepath.Base(preset.Command) == realBin {
+			return preset.ProcessNames
+		}
+	}
+	return nil
+}
+
+// extractWrappedBinary scans wrapper args for the first non-flag token that
+// looks like a binary, and returns its basename. Returns "" if no real binary
+// is found (e.g., args malformed or wrapper unsupported).
+//
+// Walks args left-to-right: skips short flags (and their values for known
+// value-taking flags), long flags (--foo=bar or --foo), env-style VAR=value
+// assignments (env only), and treats `--` as an end-of-options separator.
+func extractWrappedBinary(wrapper string, args []string) string {
+	flagsTakeValue := wrapperFlagsTakeValue(wrapper)
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--" {
+			if i+1 < len(args) {
+				return filepath.Base(args[i+1])
+			}
+			return ""
+		}
+		if strings.HasPrefix(a, "-") && a != "-" {
+			// Long option `--foo=bar` carries its own value
+			if strings.HasPrefix(a, "--") && strings.Contains(a, "=") {
+				continue
+			}
+			// Long option `--foo` and unknown short options: assume no value
+			if flagsTakeValue[a] && i+1 < len(args) {
+				i++ // skip the flag's value
+			}
+			continue
+		}
+		// env permits VAR=value assignments interspersed with flags
+		if wrapper == "env" && strings.Contains(a, "=") {
+			continue
+		}
+		return filepath.Base(a)
+	}
+	return ""
+}
+
 // ResolveProcessNames determines the correct process names for liveness detection
 // given an agent name and the actual command binary. This handles custom agents
 // that shadow built-in preset names (e.g., a custom "codex" agent that runs
-// "opencode" instead of the built-in "codex" binary).
+// "opencode" instead of the built-in "codex" binary), and custom agents wrapped
+// in process launchers like `env -u VAR <real-binary>`.
 //
 // Resolution order:
 //  1. If agentName matches a built-in preset AND the preset's Command matches
 //     the actual command → use the preset's ProcessNames (no mismatch).
-//  2. Otherwise, find a built-in preset whose Command matches the actual command
+//  2. If the resolved command is a known wrapper (env, sudo, nohup, ...) and
+//     the registered agent has Args, scan the args for the real binary and
+//     resolve to its preset's ProcessNames.
+//  3. Otherwise, find a built-in preset whose Command matches the actual command
 //     and use its ProcessNames (custom agent using a known launcher).
-//  3. Fallback: [command] (fully custom binary).
+//  4. Fallback: [command] (fully custom binary).
 func ResolveProcessNames(agentName, command string) []string {
 	registryMu.Lock()
 	initRegistryLocked()
@@ -774,13 +877,27 @@ func ResolveProcessNames(agentName, command string) []string {
 	// Check if agentName matches a built-in/registered preset with matching command.
 	// Compare against both the raw command and basename to handle registry entries
 	// that store absolute-path commands (e.g., "/opt/bin/my-tool").
-	if info, ok := globalRegistry.Agents[agentName]; ok && len(info.ProcessNames) > 0 {
-		if info.Command == command ||
-			info.Command == cmdBase ||
-			filepath.Base(info.Command) == cmdBase ||
-			(info.Command == unwrappedCmdBase && strings.HasPrefix(cmdBase, "gt-")) ||
-			cmdBase == "" {
+	if info, ok := globalRegistry.Agents[agentName]; ok {
+		if len(info.ProcessNames) > 0 &&
+			(info.Command == command ||
+				info.Command == cmdBase ||
+				filepath.Base(info.Command) == cmdBase ||
+				(info.Command == unwrappedCmdBase && strings.HasPrefix(cmdBase, "gt-")) ||
+				cmdBase == "") {
 			return info.ProcessNames
+		}
+		// Wrapper case: agent's Command is `env`/`sudo`/etc. — find the real
+		// binary in Args and resolve to ITS preset's ProcessNames. Try the
+		// runtime registry first; fall back to builtinPresets if the user has
+		// shadowed the canonical preset (e.g., custom "claude" agent that
+		// wraps the real claude binary).
+		if wrapperCommands[cmdBase] && len(info.Args) > 0 {
+			if realBin := extractWrappedBinary(cmdBase, info.Args); realBin != "" {
+				if names := lookupProcessNamesByBinary(realBin); len(names) > 0 {
+					return names
+				}
+				return []string{realBin}
+			}
 		}
 	}
 

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -422,6 +422,94 @@ func TestResolveProcessNames(t *testing.T) {
 			}
 		}
 	})
+
+	// Regression: custom agents wrapped in `env -u VAR <real-binary>` (or
+	// nohup/sudo/etc.) used to fall through to GT_PROCESS_NAMES=<wrapper>,
+	// which IsAgentAlive could never match — wrapper has exec'd into the real
+	// binary by then. ResolveProcessNames must look past the wrapper.
+	wrapperCases := []struct {
+		name    string
+		agent   AgentPresetInfo
+		want    []string
+		command string // command passed to ResolveProcessNames
+	}{
+		{
+			name: "env -u VAR claude unwraps to claude preset",
+			agent: AgentPresetInfo{
+				Name:    "claude",
+				Command: "env",
+				Args:    []string{"-u", "ANTHROPIC_API_KEY", "claude", "--dangerously-skip-permissions", "--effort", "high"},
+			},
+			command: "env",
+			want:    []string{"node", "claude"},
+		},
+		{
+			name: "env VAR=val claude unwraps past assignments",
+			agent: AgentPresetInfo{
+				Name:    "claude",
+				Command: "env",
+				Args:    []string{"FOO=bar", "BAZ=qux", "claude"},
+			},
+			command: "env",
+			want:    []string{"node", "claude"},
+		},
+		{
+			name: "env -- claude (separator) unwraps to claude",
+			agent: AgentPresetInfo{
+				Name:    "claude",
+				Command: "env",
+				Args:    []string{"-i", "--", "claude", "--foo"},
+			},
+			command: "env",
+			want:    []string{"node", "claude"},
+		},
+		{
+			name: "nohup opencode unwraps to opencode preset",
+			agent: AgentPresetInfo{
+				Name:    "opencode",
+				Command: "nohup",
+				Args:    []string{"opencode", "--quiet"},
+			},
+			command: "nohup",
+			want:    []string{"opencode", "node", "bun"},
+		},
+		{
+			name: "sudo -u runner codex unwraps to codex preset",
+			agent: AgentPresetInfo{
+				Name:    "codex",
+				Command: "sudo",
+				Args:    []string{"-u", "runner", "codex", "--dangerously-bypass-approvals-and-sandbox"},
+			},
+			command: "sudo",
+			want:    []string{"codex"},
+		},
+		{
+			name: "env wrapping unknown binary returns binary basename",
+			agent: AgentPresetInfo{
+				Name:    "my-agent",
+				Command: "env",
+				Args:    []string{"-u", "FOO", "/opt/my-tool", "--flag"},
+			},
+			command: "env",
+			want:    []string{"my-tool"},
+		},
+	}
+	for _, tc := range wrapperCases {
+		t.Run(tc.name, func(t *testing.T) {
+			RegisterAgentForTesting(string(tc.agent.Name), tc.agent)
+			t.Cleanup(ResetRegistryForTesting)
+
+			got := ResolveProcessNames(string(tc.agent.Name), tc.command)
+			if len(got) != len(tc.want) {
+				t.Fatalf("ResolveProcessNames(%q, %q) = %v, want %v", tc.agent.Name, tc.command, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("got[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
 }
 
 func TestAgentPresetApprovalFlags(t *testing.T) {

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -499,7 +499,7 @@ func TestResolveProcessNames(t *testing.T) {
 			RegisterAgentForTesting(string(tc.agent.Name), tc.agent)
 			t.Cleanup(ResetRegistryForTesting)
 
-			got := ResolveProcessNames(string(tc.agent.Name), tc.command)
+			got := ResolveProcessNames(string(tc.agent.Name), tc.command, tc.agent.Args...)
 			if len(got) != len(tc.want) {
 				t.Fatalf("ResolveProcessNames(%q, %q) = %v, want %v", tc.agent.Name, tc.command, got, tc.want)
 			}
@@ -510,6 +510,28 @@ func TestResolveProcessNames(t *testing.T) {
 			}
 		})
 	}
+
+	// Real-world scenario: Paul's town settings shadow the canonical claude
+	// preset with a wrapper. The registry still holds the built-in claude
+	// preset; Args live only on the caller's RuntimeConfig. Caller args must
+	// take precedence so wrapper-unwrap finds the real binary.
+	t.Run("caller args used when registry holds canonical preset", func(t *testing.T) {
+		ResetRegistryForTesting()
+		t.Cleanup(ResetRegistryForTesting)
+		// No RegisterAgentForTesting — registry has canonical built-in claude
+		// (Command="claude", ProcessNames=[node, claude], Args=[--dangerously-...]).
+		got := ResolveProcessNames("claude", "env",
+			"-u", "ANTHROPIC_API_KEY", "claude", "--dangerously-skip-permissions", "--effort", "high")
+		want := []string{"node", "claude"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+			}
+		}
+	})
 }
 
 func TestAgentPresetApprovalFlags(t *testing.T) {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -2266,8 +2266,9 @@ func BuildStartupCommand(envVars map[string]string, rigPath, prompt string) stri
 	}
 	// Set GT_PROCESS_NAMES for accurate liveness detection. Custom agents may
 	// shadow built-in preset names (e.g., custom "codex" running "opencode"),
-	// so we resolve process names from both agent name and actual command.
-	processNames := ResolveProcessNames(rc.ResolvedAgent, rc.Command)
+	// or wrap the real binary with a launcher (e.g., `env -u VAR claude ...`).
+	// Pass rc.Args so wrapper-unwrap can find the real binary.
+	processNames := ResolveProcessNames(rc.ResolvedAgent, rc.Command, rc.Args...)
 	resolvedEnv["GT_PROCESS_NAMES"] = strings.Join(processNames, ",")
 	// Merge agent-specific env vars (e.g., OPENCODE_PERMISSION for yolo mode)
 	for k, v := range rc.Env {
@@ -2520,7 +2521,9 @@ func BuildStartupCommandWithAgentOverride(envVars map[string]string, rigPath, pr
 		resolvedEnv["GT_AGENT"] = rc.ResolvedAgent
 	}
 	// Set GT_PROCESS_NAMES for accurate liveness detection of custom agents.
-	processNamesOverride := ResolveProcessNames(agentForProcess, rc.Command)
+	// Pass rc.Args so wrapper-unwrap (env/sudo/nohup wrapping a real binary)
+	// can find the real agent binary.
+	processNamesOverride := ResolveProcessNames(agentForProcess, rc.Command, rc.Args...)
 	resolvedEnv["GT_PROCESS_NAMES"] = strings.Join(processNamesOverride, ",")
 	// Merge agent-specific env vars (e.g., OPENCODE_PERMISSION for yolo mode)
 	for k, v := range rc.Env {

--- a/internal/mail/bd.go
+++ b/internal/mail/bd.go
@@ -52,7 +52,12 @@ func (e *bdError) ContainsError(substr string) bool {
 // runBdCommand executes a bd command with a context timeout and proper environment setup.
 // ctx controls the deadline/timeout for the subprocess.
 // workDir is the directory to run the command in.
-// beadsDir is the BEADS_DIR environment variable value.
+// beadsDir is the BEADS_DIR environment variable value. If beadsDir is empty,
+// BEADS_DIR is stripped from the environment so bd performs its own
+// prefix-based routing via routes.jsonl (see au-ofe). Pass the town-level
+// .beads (or empty) when operating on cross-rig bead IDs; pinning BEADS_DIR
+// at a rig's .beads bypasses routing and breaks lookups for beads whose
+// prefix maps to a different database on the shared Dolt server.
 // extraEnv contains additional environment variables to set (e.g., "BD_IDENTITY=...").
 // Returns stdout bytes on success, or a *bdError on failure.
 func runBdCommand(ctx context.Context, args []string, workDir, beadsDir string, extraEnv ...string) (_ []byte, retErr error) {
@@ -61,7 +66,9 @@ func runBdCommand(ctx context.Context, args []string, workDir, beadsDir string, 
 	// Remove stale dolt-server.pid before spawning bd. A stale PID file causes
 	// bd to connect to port 3307 which may be occupied by a different Dolt server
 	// serving different databases, resulting in hangs until the read timeout kills it.
-	beads.CleanStaleDoltServerPID(beadsDir)
+	if beadsDir != "" {
+		beads.CleanStaleDoltServerPID(beadsDir)
+	}
 
 	// bd v0.59+ requires --flat for list --json to produce JSON output.
 	// Without it, bd returns human-readable tree format that fails JSON parsing.
@@ -73,9 +80,19 @@ func runBdCommand(ctx context.Context, args []string, workDir, beadsDir string, 
 	cmd.Dir = workDir
 	util.SetDetachedProcessGroup(cmd)
 
-	env := append(cmd.Environ(), "BEADS_DIR="+beadsDir)
-	if dbEnv := beads.DatabaseEnv(beadsDir); dbEnv != "" {
-		env = append(env, dbEnv)
+	env := cmd.Environ()
+	if beadsDir == "" {
+		// Strip any inherited BEADS_DIR so bd does native routing via its
+		// cwd walk-up (which finds the town's routes.jsonl).
+		env = filterEnvKey(env, "BEADS_DIR")
+	} else {
+		// Also strip first so glibc getenv() doesn't pick up an inherited
+		// entry that shadows the one we append.
+		env = filterEnvKey(env, "BEADS_DIR")
+		env = append(env, "BEADS_DIR="+beadsDir)
+		if dbEnv := beads.DatabaseEnv(beadsDir); dbEnv != "" {
+			env = append(env, dbEnv)
+		}
 	}
 	env = append(env, extraEnv...)
 	env = append(env, telemetry.OTELEnvForSubprocess()...)
@@ -123,6 +140,20 @@ func firstArg(args []string) string {
 		return args[0]
 	}
 	return ""
+}
+
+// filterEnvKey removes all entries matching the given key= from the env slice.
+// Used to strip an inherited BEADS_DIR before appending the desired value, so
+// glibc getenv() doesn't return a shadowed older entry.
+func filterEnvKey(env []string, key string) []string {
+	prefix := key + "="
+	result := make([]string, 0, len(env))
+	for _, e := range env {
+		if !strings.HasPrefix(e, prefix) {
+			result = append(result, e)
+		}
+	}
+	return result
 }
 
 // bdReadCtx returns a context with the standard bd read timeout.

--- a/internal/mail/delivery.go
+++ b/internal/mail/delivery.go
@@ -80,9 +80,14 @@ func DeliveryAckLabelSequenceIdempotent(recipientIdentity string, at time.Time, 
 // AcknowledgeDeliveryBead writes phase-2 delivery ack labels for a bead.
 // It reads existing labels for idempotent retry (reusing prior timestamps),
 // then writes the ack label sequence. Uses runBdCommand with timeouts.
-// Resolves the correct beadsDir based on the bead ID prefix (GH#2423).
+//
+// If beadID routes to a different rig than beadsDir, BEADS_DIR is stripped
+// ("") so bd performs its own prefix-based routing via routes.jsonl. Pinning
+// BEADS_DIR at a rig's .beads bypasses routing and fails the lookup for
+// beads whose prefix maps to a different database on the shared Dolt
+// server (au-ofe, au-b9d).
 func AcknowledgeDeliveryBead(workDir, beadsDir, beadID, recipientIdentity string) error {
-	beadsDir = beads.ResolveBeadsDirForID(beadsDir, beadID)
+	beadsDir = routedBeadsDirForID(beadsDir, beadID)
 	existingLabels, readErr := readBeadLabelsShared(workDir, beadsDir, beadID)
 	if readErr != nil {
 		// Log but proceed with empty labels — fresh timestamp is acceptable
@@ -104,6 +109,18 @@ func AcknowledgeDeliveryBead(workDir, beadsDir, beadID, recipientIdentity string
 		return err
 	}
 	return nil
+}
+
+// routedBeadsDirForID returns the BEADS_DIR value to pass into runBdCommand
+// so that beadID resolves correctly. Same-rig ids keep currentBeadsDir;
+// cross-rig ids return "" so bd's own prefix routing (via routes.jsonl in
+// the town's .beads) dispatches to the correct database. See au-ofe, au-b9d.
+func routedBeadsDirForID(currentBeadsDir, beadID string) string {
+	target := beads.ResolveBeadsDirForID(currentBeadsDir, beadID)
+	if target == "" || target == currentBeadsDir {
+		return currentBeadsDir
+	}
+	return ""
 }
 
 // readBeadLabelsShared reads the labels for a bead, returning an error on failure

--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -807,6 +807,12 @@ func (m *Mailbox) deleteLegacy(id string) error {
 }
 
 // Archive moves a message to the archive file and removes it from inbox.
+//
+// Archive is a mail cleanup operation, not a bead operation. If the
+// underlying bead has been garbage collected (by `bd mol wisp gc` or
+// `bd compact`), there is nothing to append to the archive and nothing
+// to close — we still return nil so the caller's inbox reference is
+// considered cleared. See aa-6hv.
 func (m *Mailbox) Archive(id string) error {
 	if m.legacy {
 		return m.archiveLegacy(id)
@@ -814,12 +820,24 @@ func (m *Mailbox) Archive(id string) error {
 	// Beads mode: append to archive then close
 	msg, err := m.Get(id)
 	if err != nil {
+		if errors.Is(err, ErrMessageNotFound) {
+			// Underlying bead has been GC'd; nothing to archive or close.
+			return nil
+		}
 		return err
 	}
 	if err := m.appendToArchive(msg); err != nil {
 		return err
 	}
-	return m.Delete(id)
+	if err := m.Delete(id); err != nil {
+		if errors.Is(err, ErrMessageNotFound) {
+			// Bead was GC'd between Get and Delete; metadata is archived,
+			// and there is nothing left to close.
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // archiveLegacy moves a message to the archive file atomically.

--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -92,6 +92,23 @@ func (m *Mailbox) Identity() string {
 	return m.identity
 }
 
+// routedBeadsDir returns the BEADS_DIR value that runBdCommand should use to
+// resolve id. For same-rig ids it returns m.beadsDir (so bd talks to the
+// configured database directly). For cross-rig ids it returns "", which tells
+// runBdCommand to strip BEADS_DIR so bd performs its own prefix-based routing
+// via routes.jsonl. Pinning BEADS_DIR at the rig's .beads bypasses that
+// routing and fails lookups for beads whose prefix maps to a different
+// database on the shared Dolt server (au-ofe, au-b9d).
+func (m *Mailbox) routedBeadsDir(id string) string {
+	target := beads.ResolveBeadsDirForID(m.beadsDir, id)
+	if target == "" || target == m.beadsDir {
+		return m.beadsDir
+	}
+	// Cross-rig: strip BEADS_DIR. bd will walk up from m.workDir and
+	// consult the town's routes.jsonl to dispatch to the right database.
+	return ""
+}
+
 // Path returns the JSONL path for legacy mailboxes.
 func (m *Mailbox) Path() string {
 	return m.path
@@ -466,13 +483,14 @@ func (m *Mailbox) Get(id string) (*Message, error) {
 }
 
 func (m *Mailbox) getBeads(id string) (*Message, error) {
-	// Resolve correct beadsDir based on bead ID prefix (GH#2423)
-	primary := beads.ResolveBeadsDirForID(m.beadsDir, id)
+	// Pick the correct BEADS_DIR for this id: m.beadsDir for same-rig,
+	// "" (strip BEADS_DIR, let bd route) for cross-rig (au-ofe, au-b9d).
+	primary := m.routedBeadsDir(id)
 	msg, err := m.getFromDir(id, primary)
 	if errors.Is(err, ErrMessageNotFound) && primary != m.beadsDir {
-		// Cross-rig bead IDs (e.g. ne-*) may live in the home DB when created
-		// via the mail router (which always uses town beads). Fall back to
-		// m.beadsDir before giving up. See ne-bgr.
+		// Cross-rig ids normally resolve via bd's routing when primary is "".
+		// If that still fails (e.g., a legacy bead whose prefix isn't in
+		// routes.jsonl), fall back to m.beadsDir directly. See ne-bgr.
 		return m.getFromDir(id, m.beadsDir)
 	}
 	return msg, err
@@ -534,13 +552,13 @@ func (m *Mailbox) MarkRead(id string) error {
 }
 
 func (m *Mailbox) markReadBeads(id string) error {
-	// Resolve correct beadsDir based on bead ID prefix (GH#2423)
-	primary := beads.ResolveBeadsDirForID(m.beadsDir, id)
+	// Pick BEADS_DIR for id: m.beadsDir for same-rig, "" (let bd route) for
+	// cross-rig. See au-ofe/au-b9d for why pinning the rig's BEADS_DIR fails.
+	primary := m.routedBeadsDir(id)
 	err := m.closeInDir(id, primary)
 	if errors.Is(err, ErrMessageNotFound) && primary != m.beadsDir {
-		// Cross-rig bead IDs (e.g. ne-*) may live in the home DB when created
-		// via the mail router (which always uses town beads). Fall back to
-		// m.beadsDir before giving up. See ne-bgr.
+		// Fallback for legacy/unknown prefixes that bd routing can't resolve.
+		// See ne-bgr.
 		return m.closeInDir(id, m.beadsDir)
 	}
 	return err
@@ -620,7 +638,8 @@ func (m *Mailbox) markReadOnlyBeads(id string) error {
 
 	// Add "read" label to mark as read without closing
 	args := []string{"label", "add", id, "read"}
-	primary := beads.ResolveBeadsDirForID(m.beadsDir, id)
+	// Route via bd for cross-rig ids (au-ofe); see routedBeadsDir.
+	primary := m.routedBeadsDir(id)
 
 	ctx, cancel := bdWriteCtx()
 	defer cancel()
@@ -665,7 +684,8 @@ func (m *Mailbox) markUnreadOnlyBeads(id string) error {
 
 	// Remove "read" label to mark as unread
 	args := []string{"label", "remove", id, "read"}
-	primary := beads.ResolveBeadsDirForID(m.beadsDir, id)
+	// Route via bd for cross-rig ids (au-ofe); see routedBeadsDir.
+	primary := m.routedBeadsDir(id)
 
 	ctx, cancel := bdWriteCtx()
 	defer cancel()
@@ -714,7 +734,8 @@ func (m *Mailbox) markUnreadBeads(id string) error {
 	}
 
 	args := []string{"reopen", id}
-	primary := beads.ResolveBeadsDirForID(m.beadsDir, id)
+	// Route via bd for cross-rig ids (au-ofe); see routedBeadsDir.
+	primary := m.routedBeadsDir(id)
 
 	ctx, cancel := bdWriteCtx()
 	defer cancel()

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -466,8 +466,9 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 
 	// Set GT_PROCESS_NAMES for accurate liveness detection. Custom agents may
 	// shadow built-in preset names (e.g., custom "codex" running "opencode"),
-	// so we resolve process names from both agent name and actual command.
-	processNames := config.ResolveProcessNames(runtimeConfig.ResolvedAgent, runtimeConfig.Command)
+	// or wrap the real binary (e.g., `env -u VAR claude ...`). Pass Args so
+	// wrapper-unwrap can find the real agent binary.
+	processNames := config.ResolveProcessNames(runtimeConfig.ResolvedAgent, runtimeConfig.Command, runtimeConfig.Args...)
 	debugSession("SetEnvironment GT_PROCESS_NAMES", m.tmux.SetEnvironment(sessionID, "GT_PROCESS_NAMES", strings.Join(processNames, ",")))
 
 	// Record agent's pane_id for ZFC-compliant liveness checks (gt-qmsx).

--- a/internal/session/lifecycle.go
+++ b/internal/session/lifecycle.go
@@ -399,17 +399,19 @@ func MergeRuntimeLivenessEnv(envVars map[string]string, runtimeConfig *config.Ru
 	if _, hasProcessNames := envVars["GT_PROCESS_NAMES"]; !hasProcessNames {
 		agentForLookup := runtimeConfig.ResolvedAgent
 		commandForLookup := runtimeConfig.Command
+		argsForLookup := runtimeConfig.Args
 		if existing, ok := envVars["GT_AGENT"]; ok && existing != "" {
 			agentForLookup = existing
 			// When GT_AGENT was set by AgentOverride (differs from the
-			// workspace-resolved agent), the runtimeConfig.Command belongs
-			// to the workspace agent, not the override. Pass empty command
-			// so ResolveProcessNames uses the preset's own command.
+			// workspace-resolved agent), the runtimeConfig.Command/Args
+			// belong to the workspace agent, not the override. Pass empty
+			// command so ResolveProcessNames uses the preset's own command.
 			if existing != runtimeConfig.ResolvedAgent {
 				commandForLookup = ""
+				argsForLookup = nil
 			}
 		}
-		processNames := config.ResolveProcessNames(agentForLookup, commandForLookup)
+		processNames := config.ResolveProcessNames(agentForLookup, commandForLookup, argsForLookup...)
 		if len(processNames) > 0 {
 			envVars["GT_PROCESS_NAMES"] = strings.Join(processNames, ",")
 		}


### PR DESCRIPTION
## Summary

Unifies cross-rig bead ID resolution so `gt escalate ack/close/show`, `gt mail read/archive`, and bead `Update`/`Close` all route the same way that `bd show` does. Eliminates "issue not found" failures on IDs whose prefix maps to a different rig's database on the shared Dolt server.

Note: the main fix (commits under 85c0b706) landed on `main` before this branch could be opened for review. This PR contains the follow-up `delivery.go` piece discovered during end-to-end testing, where `AcknowledgeDeliveryBead` was still pinning `BEADS_DIR` to a rig and producing `delivery ack: could not read labels for aa-wisp-*` warnings on every `gt mail inbox`.

### Root cause (context)

Pinning `BEADS_DIR` at a rig's `.beads` bypasses bd's routing entirely — the rig's `.beads` has no `routes.jsonl`, only the town's does. The fix, applied throughout gastown's beads/mail call sites, is: when a bead ID routes cross-rig, strip `BEADS_DIR` so bd performs native prefix-based routing via the town's `routes.jsonl`.

### This branch's delta vs main

- `internal/mail/delivery.go`: mirror the `Mailbox.routedBeadsDir` pattern so `AcknowledgeDeliveryBead` strips `BEADS_DIR` for cross-rig bead IDs. Adds `routedBeadsDirForID` helper.

### Earlier landed on main (for reference)

- `runBDForID` / `runBDForIDs` helpers in `internal/beads/beads.go`
- `ResolveRoutingTargetQuiet` + unification of `ResolveBeadsDirForID`
- Mailbox call sites use `m.routedBeadsDir(id)` instead of `beads.ResolveBeadsDirForID`
- `runBdCommand` treats empty `beadsDir` as "strip `BEADS_DIR`"

## Test plan

- [x] `make install` builds cleanly
- [x] `go test ./internal/mail/...` passes
- [x] `gt escalate ack aa-wisp-zfrmi` succeeds cross-rig from town cwd
- [x] `gt escalate close aa-wisp-zfrmi --reason "..."` succeeds cross-rig
- [x] `gt mail read aa-wisp-we837` succeeds
- [x] `gt mail archive aa-wisp-we837` succeeds
- [x] `gt mail inbox` no longer emits `delivery ack: could not read labels` warnings (after this branch's delivery.go fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)