### PR TITLE
polecat: forward D-Bus + XDG runtime to sessions for keyring access (hq-6cm)

### DIFF
--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -415,6 +415,15 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 	if polecatGitBranch != "" {
 		envVarsToInject["GT_BRANCH"] = polecatGitBranch
 	}
+	// Forward D-Bus session + XDG runtime so Claude Code (and other agents) can
+	// reach the system keyring via libsecret for OAuth tokens (hq-6cm). Without
+	// these, polecats spawn without keyring access and hit "Not logged in"
+	// despite having onboarding state seeded.
+	for _, key := range []string{"DBUS_SESSION_BUS_ADDRESS", "XDG_RUNTIME_DIR"} {
+		if v := os.Getenv(key); v != "" {
+			envVarsToInject[key] = v
+		}
+	}
 	command = config.PrependEnv(command, envVarsToInject)
 
 	// Create session with command directly to avoid send-keys race condition.
@@ -459,6 +468,13 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 	debugSession("SetEnvironment GT_TOWN_ROOT", m.tmux.SetEnvironment(sessionID, "GT_TOWN_ROOT", townRoot))
 	// Set GT_RUN in the session environment so respawned processes also inherit it.
 	debugSession("SetEnvironment GT_RUN", m.tmux.SetEnvironment(sessionID, "GT_RUN", runID))
+
+	// Forward D-Bus + XDG runtime for keyring access (hq-6cm).
+	for _, key := range []string{"DBUS_SESSION_BUS_ADDRESS", "XDG_RUNTIME_DIR"} {
+		if v := os.Getenv(key); v != "" {
+			debugSession("SetEnvironment "+key, m.tmux.SetEnvironment(sessionID, key, v))
+		}
+	}
 
 	// Disable Dolt auto-commit in tmux session environment (gt-5cc2p).
 	// This ensures respawned processes also inherit the setting.


### PR DESCRIPTION
## Summary

Forward `DBUS_SESSION_BUS_ADDRESS` and `XDG_RUNTIME_DIR` from the launching `gt` process into polecat tmux sessions, so agents running inside a polecat can reach the user's keyring daemon via libsecret (`org.freedesktop.secrets` on the session bus).

Two touch points in `internal/polecat/session_manager.go`:

1. `envVarsToInject` — the initial command env used by `NewSessionWithCommand`.
2. `m.tmux.SetEnvironment(...)` — the tmux session environment table, so respawned processes also inherit.

Both loops skip gracefully when either env var is unset, so headless / system-service invocations won't override with empty values.

## Why

Polecats already override `HOME` to the polecat dir for GPG isolation (hq-0ir). That breaks the keyring-via-libsecret auth path: without a D-Bus session bus address, libsecret cannot find a secrets service, and agents like Claude Code that look up OAuth credentials there hit "Not logged in" despite having onboarding state seeded.

Observed today while diagnosing `hq-6cm` in a downstream town: fresh polecats skip the theme picker once `.claude.json` is pre-seeded, but still hit "Not logged in" until D-Bus + XDG forwarding is in place. In that particular setup the subscription tokens happen to live in `~/.claude/.credentials.json` (file-based), so CC ended up authing through file creds anyway. But the D-Bus path is the correct long-term fix for:

- Agents that use the system keyring (current CC OAuth flow on systems that prefer it).
- MCP servers that call libsecret for their own credential storage.
- Future CC versions / non-Claude agents with keyring-only auth.

## Test plan

- [x] `go test ./internal/polecat/...` green on the change (ran locally, 8.7s).
- [ ] Spawn a polecat on a host with an active `gnome-keyring-daemon` and verify `tmux show-environment` shows both env vars.
- [ ] Verify `dbus-send --session --print-reply --dest=org.freedesktop.secrets ...` succeeds from inside a polecat session on such a host.
- [ ] No regression when the launching env has neither var set (headless CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)