### PR TITLE
feat: dog reliability — verify-done ritual, multi-scope guard, dog-death escalation (hq-0ae)

### DIFF
--- a/internal/cmd/dog.go
+++ b/internal/cmd/dog.go
@@ -955,6 +955,8 @@ func runDogHealthCheck(cmd *cobra.Command, args []string) error {
 
 	tm := tmux.NewTmux()
 	hc := dog.NewHealthChecker(mgr, tm)
+	// Wire the dog-death escalator (hq-0ae A3) so abandoned beads surface to Mayor.
+	hc.Escalator = dogEscalateBestEffort
 
 	var results []dog.DogHealthResult
 

--- a/internal/cmd/dog.go
+++ b/internal/cmd/dog.go
@@ -40,6 +40,10 @@ var (
 	dogHealthJSON          bool
 	dogHealthAutoClear     bool
 	dogHealthMaxInactivity time.Duration
+
+	// Done flags (push-verify ritual, hq-0ae).
+	dogDoneSkipVerify bool
+	dogDoneNoPush     bool
 )
 
 var dogCmd = &cobra.Command{
@@ -278,6 +282,10 @@ func init() {
 	dogDispatchCmd.Flags().BoolVar(&dogDispatchJSON, "json", false, "Output as JSON")
 	dogDispatchCmd.Flags().BoolVarP(&dogDispatchDryRun, "dry-run", "n", false, "Show what would be done without doing it")
 	_ = dogDispatchCmd.MarkFlagRequired("plugin")
+
+	// Done flags (push-verify ritual, hq-0ae)
+	dogDoneCmd.Flags().BoolVar(&dogDoneSkipVerify, "skip-verify", false, "Skip the push-verify ritual (use for docs-only or no-code tasks)")
+	dogDoneCmd.Flags().BoolVar(&dogDoneNoPush, "no-push", false, "Do not auto-push unpushed commits; fail instead")
 
 	// Health-check flags
 	dogHealthCheckCmd.Flags().BoolVar(&dogHealthJSON, "json", false, "Output as JSON")
@@ -677,6 +685,23 @@ func runDogDone(cmd *cobra.Command, args []string) error {
 	if d.State == dog.StateIdle && d.Work == "" {
 		fmt.Printf("Dog %s is already idle with no work\n", name)
 		return nil
+	}
+
+	// Push-verify ritual (hq-0ae). Before the dog returns to idle, confirm any
+	// commits in its worktrees are on task-specific branches and visible on
+	// origin. Skipped for docs-only / no-code work via --skip-verify.
+	if !dogDoneSkipVerify {
+		reports, verr := verifyDogWork(d, !dogDoneNoPush)
+		printVerifyReports(reports)
+		if verr != nil {
+			// Do NOT clear work or kill session — leave the dog visible so the
+			// operator can intervene. Fire a best-effort escalation.
+			escMsg := fmt.Sprintf("dog %s verify-done failed: %v", name, verr)
+			if escErr := dogEscalateBestEffort(escMsg); escErr != nil {
+				style.PrintWarning("escalation failed (%v); escalate manually: gt escalate --severity medium %q", escErr, escMsg)
+			}
+			return fmt.Errorf("verify-done failed for dog %s: %w\n  Re-run with --skip-verify once you've confirmed the work is safe to close", name, verr)
+		}
 	}
 
 	if err := mgr.ClearWork(name); err != nil {
@@ -1267,5 +1292,195 @@ func ifStr(cond bool, ifTrue, ifFalse string) string {
 		return ifTrue
 	}
 	return ifFalse
+}
+
+// verifyReport describes the verify-done outcome for one worktree.
+type verifyReport struct {
+	Rig       string // rig name (key from d.Worktrees)
+	Worktree  string // worktree path
+	Skipped   string // non-empty if the worktree was skipped (e.g. not a repo, not present)
+	Branch    string
+	Commit    string
+	Pushed    bool
+	Failure   string // non-empty if this worktree failed verification
+}
+
+// protectedBranches is the set of branch names a dog must NEVER land a commit
+// on directly. Work on these branches indicates the dog committed to the wrong
+// branch (the hq-3rl Part A failure mode).
+var protectedBranches = map[string]bool{
+	"main":    true,
+	"master":  true,
+	"develop": true,
+	"release": true,
+	"":        true, // detached HEAD
+}
+
+// verifyDogWork runs the push-verify ritual across all of a dog's worktrees.
+// Returns per-worktree reports and an overall error if any worktree had a
+// failure or refused to auto-push. Worktrees with no commits ahead of origin
+// are treated as clean no-ops and reported as Pushed=true (nothing to push).
+func verifyDogWork(d *dog.Dog, autoPush bool) ([]verifyReport, error) {
+	reports := make([]verifyReport, 0, len(d.Worktrees))
+	var firstErr error
+
+	for rig, path := range d.Worktrees {
+		r := verifyReport{Rig: rig, Worktree: path}
+
+		if _, statErr := os.Stat(path); statErr != nil {
+			r.Skipped = fmt.Sprintf("worktree not present on disk (%v)", statErr)
+			reports = append(reports, r)
+			continue
+		}
+		if _, statErr := os.Stat(filepath.Join(path, ".git")); statErr != nil {
+			r.Skipped = "not a git worktree (no .git)"
+			reports = append(reports, r)
+			continue
+		}
+
+		branch, err := gitOutput(path, "rev-parse", "--abbrev-ref", "HEAD")
+		if err != nil {
+			r.Failure = fmt.Sprintf("reading current branch: %v", err)
+			reports = append(reports, r)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("%s: %s", rig, r.Failure)
+			}
+			continue
+		}
+		branch = strings.TrimSpace(branch)
+		r.Branch = branch
+		if branch == "HEAD" {
+			branch = ""
+			r.Branch = ""
+		}
+
+		if protectedBranches[branch] {
+			r.Failure = fmt.Sprintf("commits landed on protected branch %q — dogs must commit to a task-specific branch", branch)
+			reports = append(reports, r)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("%s: %s", rig, r.Failure)
+			}
+			continue
+		}
+
+		dirty, err := gitOutput(path, "status", "--porcelain")
+		if err != nil {
+			r.Failure = fmt.Sprintf("checking working tree status: %v", err)
+			reports = append(reports, r)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("%s: %s", rig, r.Failure)
+			}
+			continue
+		}
+		if strings.TrimSpace(dirty) != "" {
+			r.Failure = "working tree has uncommitted changes — commit or stash before done"
+			reports = append(reports, r)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("%s: %s", rig, r.Failure)
+			}
+			continue
+		}
+
+		head, err := gitOutput(path, "rev-parse", "HEAD")
+		if err != nil {
+			r.Failure = fmt.Sprintf("resolving HEAD: %v", err)
+			reports = append(reports, r)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("%s: %s", rig, r.Failure)
+			}
+			continue
+		}
+		r.Commit = strings.TrimSpace(head)
+
+		// Check if HEAD is already on origin/<branch>. We ignore errors from
+		// ls-remote (missing branch, network hiccup) and fall through to the
+		// push branch — push will surface a clearer error.
+		remoteSha, _ := gitOutput(path, "ls-remote", "--heads", "origin", branch)
+		remoteSha = strings.TrimSpace(strings.SplitN(remoteSha, "\t", 2)[0])
+
+		if remoteSha != "" && remoteSha == r.Commit {
+			r.Pushed = true
+			reports = append(reports, r)
+			continue
+		}
+
+		if !autoPush {
+			r.Failure = fmt.Sprintf("HEAD %s not on origin/%s and --no-push set", shortSha(r.Commit), branch)
+			reports = append(reports, r)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("%s: %s", rig, r.Failure)
+			}
+			continue
+		}
+
+		pushCmd := exec.Command("git", "-C", path, "push", "-u", "origin", branch)
+		out, err := pushCmd.CombinedOutput()
+		if err != nil {
+			r.Failure = fmt.Sprintf("auto-push failed: %v\n%s", err, strings.TrimSpace(string(out)))
+			reports = append(reports, r)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("%s: %s", rig, r.Failure)
+			}
+			continue
+		}
+
+		// Re-confirm the push landed.
+		confirmSha, _ := gitOutput(path, "ls-remote", "--heads", "origin", branch)
+		confirmSha = strings.TrimSpace(strings.SplitN(confirmSha, "\t", 2)[0])
+		if confirmSha != r.Commit {
+			r.Failure = fmt.Sprintf("pushed but origin/%s resolves to %s, expected %s", branch, shortSha(confirmSha), shortSha(r.Commit))
+			reports = append(reports, r)
+			if firstErr == nil {
+				firstErr = fmt.Errorf("%s: %s", rig, r.Failure)
+			}
+			continue
+		}
+
+		r.Pushed = true
+		reports = append(reports, r)
+	}
+
+	return reports, firstErr
+}
+
+// printVerifyReports prints a summary of verify-done results to stdout.
+func printVerifyReports(reports []verifyReport) {
+	if len(reports) == 0 {
+		fmt.Println("verify-done: no worktrees to check")
+		return
+	}
+	fmt.Println("verify-done:")
+	for _, r := range reports {
+		switch {
+		case r.Skipped != "":
+			fmt.Printf("  %s: skipped (%s)\n", r.Rig, r.Skipped)
+		case r.Failure != "":
+			fmt.Printf("  %s: ✗ %s\n", r.Rig, r.Failure)
+		default:
+			fmt.Printf("  %s: ✓ %s @ %s (pushed)\n", r.Rig, r.Branch, shortSha(r.Commit))
+		}
+	}
+}
+
+// gitOutput runs `git -C <dir> <args...>` and returns stdout. stderr is
+// captured into the error on failure.
+func gitOutput(dir string, args ...string) (string, error) {
+	full := append([]string{"-C", dir}, args...)
+	cmd := exec.Command("git", full...)
+	var stdout, stderr strings.Builder
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.String(), nil
+}
+
+// shortSha returns the first 8 chars of a SHA, or the full string if shorter.
+func shortSha(sha string) string {
+	if len(sha) <= 8 {
+		return sha
+	}
+	return sha[:8]
 }
 

--- a/internal/cmd/dog_verify_test.go
+++ b/internal/cmd/dog_verify_test.go
@@ -1,0 +1,217 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/dog"
+)
+
+// initVerifyRepo creates a temp git repo with an initial commit on main, plus
+// an origin remote pointing at a bare repo. Returns the worktree path and the
+// bare remote path.
+func initVerifyRepo(t *testing.T) (worktree, remote string) {
+	t.Helper()
+	tmp := t.TempDir()
+	worktree = filepath.Join(tmp, "wt")
+	remote = filepath.Join(tmp, "remote.git")
+
+	mustGit(t, "", "init", "--bare", remote)
+	mustGit(t, "", "init", "--initial-branch=main", worktree)
+	mustGit(t, worktree, "config", "user.email", "test@test.com")
+	mustGit(t, worktree, "config", "user.name", "Test User")
+	mustGit(t, worktree, "config", "commit.gpgsign", "false")
+	if err := os.WriteFile(filepath.Join(worktree, "README.md"), []byte("# test\n"), 0644); err != nil {
+		t.Fatalf("write readme: %v", err)
+	}
+	mustGit(t, worktree, "add", ".")
+	mustGit(t, worktree, "commit", "-m", "initial")
+	mustGit(t, worktree, "remote", "add", "origin", remote)
+	mustGit(t, worktree, "push", "-u", "origin", "main")
+	return worktree, remote
+}
+
+// mustGit runs a git command and fails the test on error.
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	full := args
+	if dir != "" {
+		full = append([]string{"-C", dir}, args...)
+	}
+	cmd := exec.Command("git", full...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+}
+
+// makeFeatureCommit creates a new branch, commits a file, and returns the branch name.
+func makeFeatureCommit(t *testing.T, worktree, branch, filename string) {
+	t.Helper()
+	mustGit(t, worktree, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(worktree, filename), []byte("feature\n"), 0644); err != nil {
+		t.Fatalf("write feature file: %v", err)
+	}
+	mustGit(t, worktree, "add", ".")
+	mustGit(t, worktree, "commit", "-m", "feature")
+}
+
+func TestVerifyDogWork_CleanAlreadyPushed(t *testing.T) {
+	wt, _ := initVerifyRepo(t)
+	makeFeatureCommit(t, wt, "feature/x", "a.txt")
+	mustGit(t, wt, "push", "-u", "origin", "feature/x")
+
+	d := &dog.Dog{Name: "alpha", Worktrees: map[string]string{"testrig": wt}}
+	reports, err := verifyDogWork(d, true)
+	if err != nil {
+		t.Fatalf("unexpected failure: %v", err)
+	}
+	if len(reports) != 1 {
+		t.Fatalf("want 1 report, got %d", len(reports))
+	}
+	r := reports[0]
+	if r.Failure != "" {
+		t.Errorf("unexpected Failure: %s", r.Failure)
+	}
+	if !r.Pushed {
+		t.Errorf("expected Pushed=true")
+	}
+	if r.Branch != "feature/x" {
+		t.Errorf("Branch = %q, want feature/x", r.Branch)
+	}
+}
+
+func TestVerifyDogWork_AutoPushesUnpushedCommit(t *testing.T) {
+	wt, _ := initVerifyRepo(t)
+	makeFeatureCommit(t, wt, "feature/y", "b.txt")
+
+	d := &dog.Dog{Name: "alpha", Worktrees: map[string]string{"testrig": wt}}
+	reports, err := verifyDogWork(d, true)
+	if err != nil {
+		t.Fatalf("unexpected failure: %v", err)
+	}
+	if !reports[0].Pushed {
+		t.Errorf("expected auto-push to succeed")
+	}
+
+	// Confirm origin now has the commit.
+	remoteSha, _ := gitOutput(wt, "ls-remote", "--heads", "origin", "feature/y")
+	if strings.TrimSpace(strings.SplitN(remoteSha, "\t", 2)[0]) != reports[0].Commit {
+		t.Errorf("origin does not have expected commit after auto-push")
+	}
+}
+
+func TestVerifyDogWork_NoPushFailsIfUnpushed(t *testing.T) {
+	wt, _ := initVerifyRepo(t)
+	makeFeatureCommit(t, wt, "feature/z", "c.txt")
+
+	d := &dog.Dog{Name: "alpha", Worktrees: map[string]string{"testrig": wt}}
+	reports, err := verifyDogWork(d, false)
+	if err == nil {
+		t.Fatal("expected failure when --no-push set on unpushed commit")
+	}
+	if !strings.Contains(reports[0].Failure, "not on origin") {
+		t.Errorf("Failure = %q, want contains 'not on origin'", reports[0].Failure)
+	}
+}
+
+func TestVerifyDogWork_RejectsProtectedBranch(t *testing.T) {
+	wt, _ := initVerifyRepo(t)
+	if err := os.WriteFile(filepath.Join(wt, "extra.txt"), []byte("x\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	mustGit(t, wt, "add", ".")
+	mustGit(t, wt, "commit", "-m", "on main")
+
+	d := &dog.Dog{Name: "alpha", Worktrees: map[string]string{"testrig": wt}}
+	_, err := verifyDogWork(d, true)
+	if err == nil {
+		t.Fatal("expected verify to refuse commits on main")
+	}
+	if !strings.Contains(err.Error(), "protected branch") {
+		t.Errorf("error = %v, want contains 'protected branch'", err)
+	}
+}
+
+func TestVerifyDogWork_RejectsDirtyTree(t *testing.T) {
+	wt, _ := initVerifyRepo(t)
+	makeFeatureCommit(t, wt, "feature/dirty", "d.txt")
+	if err := os.WriteFile(filepath.Join(wt, "uncommitted.txt"), []byte("dirty\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	d := &dog.Dog{Name: "alpha", Worktrees: map[string]string{"testrig": wt}}
+	_, err := verifyDogWork(d, true)
+	if err == nil {
+		t.Fatal("expected verify to refuse dirty working tree")
+	}
+	if !strings.Contains(err.Error(), "uncommitted") {
+		t.Errorf("error = %v, want contains 'uncommitted'", err)
+	}
+}
+
+func TestVerifyDogWork_SkipsMissingWorktree(t *testing.T) {
+	d := &dog.Dog{Name: "alpha", Worktrees: map[string]string{"ghost": "/nonexistent/path"}}
+	reports, err := verifyDogWork(d, true)
+	if err != nil {
+		t.Fatalf("unexpected error for missing worktree: %v", err)
+	}
+	if reports[0].Skipped == "" {
+		t.Errorf("expected Skipped to be set for missing worktree")
+	}
+}
+
+func TestVerifyDogWork_SkipsNonGitDir(t *testing.T) {
+	tmp := t.TempDir()
+	d := &dog.Dog{Name: "alpha", Worktrees: map[string]string{"testrig": tmp}}
+	reports, err := verifyDogWork(d, true)
+	if err != nil {
+		t.Fatalf("unexpected error for non-git dir: %v", err)
+	}
+	if reports[0].Skipped == "" {
+		t.Errorf("expected Skipped to be set for non-git directory")
+	}
+}
+
+func TestVerifyDogWork_MultipleWorktreesMixedResult(t *testing.T) {
+	wt1, _ := initVerifyRepo(t)
+	makeFeatureCommit(t, wt1, "feature/ok", "ok.txt")
+	mustGit(t, wt1, "push", "-u", "origin", "feature/ok")
+
+	wt2, _ := initVerifyRepo(t)
+	if err := os.WriteFile(filepath.Join(wt2, "on-main.txt"), []byte("x\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	mustGit(t, wt2, "add", ".")
+	mustGit(t, wt2, "commit", "-m", "on main")
+
+	d := &dog.Dog{
+		Name: "alpha",
+		Worktrees: map[string]string{
+			"good": wt1,
+			"bad":  wt2,
+		},
+	}
+	reports, err := verifyDogWork(d, true)
+	if err == nil {
+		t.Fatal("expected overall failure because one worktree is on main")
+	}
+	if len(reports) != 2 {
+		t.Fatalf("want 2 reports, got %d", len(reports))
+	}
+	// Exactly one should have Failure and one should be clean.
+	var failures, ok int
+	for _, r := range reports {
+		if r.Failure != "" {
+			failures++
+		} else if r.Pushed {
+			ok++
+		}
+	}
+	if failures != 1 || ok != 1 {
+		t.Errorf("want 1 failure + 1 ok, got failures=%d ok=%d", failures, ok)
+	}
+}

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -135,6 +135,9 @@ var (
 	slingFormula       string // --formula: override formula for dispatch (default: mol-polecat-work)
 	slingCrew          string // --crew: target a crew member in the specified rig
 	slingReviewOnly    bool   // --review-only: mark work as review-only (no merge/commit/push)
+
+	// Bead hygiene flags (hq-0ae A2).
+	slingAllowMultiScope bool // --allow-multi-scope: bypass the multi-scope bead guard
 )
 
 func init() {
@@ -163,6 +166,7 @@ func init() {
 	slingCmd.Flags().StringVar(&slingFormula, "formula", "", "Formula to apply (default: mol-polecat-work for polecat targets)")
 	slingCmd.Flags().StringVar(&slingCrew, "crew", "", "Target a crew member in the specified rig (e.g., --crew mel with target gastown → gastown/crew/mel)")
 	slingCmd.Flags().BoolVar(&slingReviewOnly, "review-only", false, "Mark work as review-only: assignee evaluates and reports back, must NOT merge/commit/push")
+	slingCmd.Flags().BoolVar(&slingAllowMultiScope, "allow-multi-scope", false, "Bypass the multi-scope bead guard (allows slinging a bead that defines both Part A: and Part B: scopes)")
 
 	slingCmd.AddCommand(slingRespawnResetCmd)
 	rootCmd.AddCommand(slingCmd)
@@ -590,6 +594,15 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	// Use --force to override when intentionally re-activating deferred work.
 	if isDeferredBead(info) && !slingForce {
 		return fmt.Errorf("refusing to sling deferred bead %s: %q\nDeferred work should not consume polecat slots. Use --force to override", beadID, info.Title)
+	}
+
+	// Guard against slinging multi-scope beads (hq-0ae A2).
+	// A bead that declares both "Part A:" and "Part B:" is a split waiting to
+	// happen — the hq-3rl Part A failure mode is for the agent to ship one
+	// part and silently drop the other. Refuse unless the dispatcher has
+	// explicitly opted in with --allow-multi-scope.
+	if multi, reason := isMultiScopeBead(info); multi && !slingAllowMultiScope {
+		return fmt.Errorf("refusing to sling multi-scope bead %s: %q\n  %s\n  Use --allow-multi-scope to override, or split into separate beads before dispatch", beadID, info.Title, reason)
 	}
 
 	originalStatus := info.Status

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -93,6 +93,42 @@ type beadInfo struct {
 	IssueType    string           `json:"issue_type,omitempty"`
 }
 
+// isMultiScopeBead reports whether a bead description defines more than one
+// distinct work scope (e.g., "Part A: ..." and "Part B: ..."). When an agent
+// is slung a multi-scope bead, the failure mode observed in hq-3rl is for
+// the agent to complete one part, claim the whole bead, and silently drop
+// the rest. The guard requires the dispatcher to split the bead first, or
+// explicitly opt out with --allow-multi-scope.
+//
+// The heuristic deliberately matches only the structural "Part X:" /
+// "Part X (...)" pattern that declares scope, not narrative text like
+// "Part A landed in PR #157". Returns the first matched reason on true.
+func isMultiScopeBead(info *beadInfo) (bool, string) {
+	if info == nil || info.Description == "" {
+		return false, ""
+	}
+	desc := strings.ToLower(info.Description)
+	hasScopeMarker := func(label string) bool {
+		// Match "part a:", "part a (", "part a —", "part a -"
+		for _, sep := range []string{":", " (", " —", " -"} {
+			if strings.Contains(desc, label+sep) {
+				return true
+			}
+		}
+		return false
+	}
+	partA := hasScopeMarker("part a")
+	partB := hasScopeMarker("part b")
+	if partA && partB {
+		return true, "description declares both Part A and Part B scopes; split into separate beads before dispatch"
+	}
+	// Also catch the three-part pattern.
+	if partB && hasScopeMarker("part c") {
+		return true, "description declares multiple Part scopes; split into separate beads before dispatch"
+	}
+	return false, ""
+}
+
 // isDeferredBead checks whether a bead should be rejected from slinging because
 // it has been deferred. Returns true if the bead has status "deferred" or if its
 // description contains deferral keywords like "deferred to post-launch".

--- a/internal/cmd/sling_multiscope_test.go
+++ b/internal/cmd/sling_multiscope_test.go
@@ -1,0 +1,70 @@
+package cmd
+
+import "testing"
+
+func TestIsMultiScopeBead(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+		wantMatch   bool
+	}{
+		{
+			name:        "empty description",
+			description: "",
+			wantMatch:   false,
+		},
+		{
+			name:        "single-scope bead",
+			description: "Install pre-commit in polecat spawn template.",
+			wantMatch:   false,
+		},
+		{
+			name:        "narrative mention of part A (no colon)",
+			description: "Part A landed in PR #157. This bead covers the rest.",
+			wantMatch:   false,
+		},
+		{
+			name:        "declarative Part A: and Part B:",
+			description: "Part A: update CLAUDE.md conventions.\nPart B: install pre-commit in spawn template.",
+			wantMatch:   true,
+		},
+		{
+			name:        "parenthetical scope markers",
+			description: "Part A (app repo): add conventions.\nPart B (Gas Town infra): add spawn hook.",
+			wantMatch:   true,
+		},
+		{
+			name:        "em-dash separator",
+			description: "Part A — docs.\nPart B — code.",
+			wantMatch:   true,
+		},
+		{
+			name:        "case-insensitive match",
+			description: "PART A: first.\nPART B: second.",
+			wantMatch:   true,
+		},
+		{
+			name:        "only part B with scope marker",
+			description: "Part B: the leftover scope from the previous bead.",
+			wantMatch:   false,
+		},
+		{
+			name:        "three-part split",
+			description: "Part B: second task.\nPart C: third task.",
+			wantMatch:   true,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			info := &beadInfo{Description: tc.description}
+			got, reason := isMultiScopeBead(info)
+			if got != tc.wantMatch {
+				t.Errorf("isMultiScopeBead() = %v, want %v (reason=%q)", got, tc.wantMatch, reason)
+			}
+			if got && reason == "" {
+				t.Errorf("expected non-empty reason when match is true")
+			}
+		})
+	}
+}

--- a/internal/dog/health.go
+++ b/internal/dog/health.go
@@ -30,11 +30,28 @@ type DogHealthResult struct {
 type HealthChecker struct {
 	mgr     *Manager
 	checker sessionChecker
+
+	// Escalator is an optional hook invoked when a dog is auto-cleared
+	// from a dead-session state while it still had work claimed. It is
+	// the glue for hq-0ae A3: surfacing abandoned work to the Mayor so
+	// the bead can be re-dispatched rather than silently stalling. The
+	// message is a human-readable summary; errors are best-effort.
+	Escalator func(msg string) error
 }
 
 // NewHealthChecker creates a HealthChecker.
 func NewHealthChecker(mgr *Manager, checker sessionChecker) *HealthChecker {
 	return &HealthChecker{mgr: mgr, checker: checker}
+}
+
+// fireDogDeathEscalation sends a best-effort notice when a dog session died
+// with a claim still open. Safe to call with a nil Escalator.
+func (hc *HealthChecker) fireDogDeathEscalation(dogName, bead, reason string) {
+	if hc.Escalator == nil || bead == "" {
+		return
+	}
+	msg := fmt.Sprintf("DOG_DEAD: %s on %s (%s) — bead abandoned, re-dispatch needed", dogName, bead, reason)
+	_ = hc.Escalator(msg)
 }
 
 // dogSessionName returns the tmux session name for a dog.
@@ -67,9 +84,11 @@ func (hc *HealthChecker) Check(d *Dog, maxInactivity time.Duration, autoClear bo
 			result.NeedsAttention = true
 			result.Recommendation = "zombie: session dead but state=working"
 			if autoClear {
+				abandonedBead := d.Work
 				if err := hc.mgr.ClearWork(d.Name); err == nil {
 					result.AutoCleared = true
 					result.Recommendation = "zombie auto-cleared (session dead)"
+					hc.fireDogDeathEscalation(d.Name, abandonedBead, "session dead")
 				}
 			}
 
@@ -79,9 +98,11 @@ func (hc *HealthChecker) Check(d *Dog, maxInactivity time.Duration, autoClear bo
 			result.Recommendation = "zombie: agent dead in session"
 			if autoClear {
 				_ = hc.checker.KillSession(session)
+				abandonedBead := d.Work
 				if err := hc.mgr.ClearWork(d.Name); err == nil {
 					result.AutoCleared = true
 					result.Recommendation = "zombie auto-cleared (agent dead, session killed)"
+					hc.fireDogDeathEscalation(d.Name, abandonedBead, "agent dead")
 				}
 			}
 

--- a/internal/dog/health_test.go
+++ b/internal/dog/health_test.go
@@ -277,6 +277,139 @@ func TestHealth_AutoClear_AgentDead(t *testing.T) {
 }
 
 // =============================================================================
+// Dog-death escalation (hq-0ae A3)
+// =============================================================================
+
+func TestHealth_Escalate_SessionDeadWithClaim(t *testing.T) {
+	m, _ := testManager(t)
+	now := time.Now()
+	setupDogWithState(t, m, "alpha", &DogState{
+		Name: "alpha", State: StateWorking, Work: "hq-7777",
+		WorkStartedAt: now.Add(-30 * time.Minute), LastActive: now,
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	mc := newMockChecker()
+	mc.healthResults["hq-dog-alpha"] = tmux.SessionDead
+	hc := NewHealthChecker(m, mc)
+
+	var captured []string
+	hc.Escalator = func(msg string) error {
+		captured = append(captured, msg)
+		return nil
+	}
+
+	d, _ := m.Get("alpha")
+	_ = hc.Check(d, 30*time.Minute, true)
+
+	if len(captured) != 1 {
+		t.Fatalf("want 1 escalation, got %d", len(captured))
+	}
+	if !contains(captured[0], "DOG_DEAD") || !contains(captured[0], "alpha") || !contains(captured[0], "hq-7777") {
+		t.Errorf("escalation message missing expected fields: %q", captured[0])
+	}
+}
+
+func TestHealth_Escalate_AgentDeadWithClaim(t *testing.T) {
+	m, _ := testManager(t)
+	now := time.Now()
+	setupDogWithState(t, m, "alpha", &DogState{
+		Name: "alpha", State: StateWorking, Work: "hq-8888",
+		WorkStartedAt: now.Add(-30 * time.Minute), LastActive: now,
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	mc := newMockChecker()
+	mc.healthResults["hq-dog-alpha"] = tmux.AgentDead
+	hc := NewHealthChecker(m, mc)
+
+	var captured []string
+	hc.Escalator = func(msg string) error {
+		captured = append(captured, msg)
+		return nil
+	}
+
+	d, _ := m.Get("alpha")
+	_ = hc.Check(d, 30*time.Minute, true)
+
+	if len(captured) != 1 {
+		t.Fatalf("want 1 escalation, got %d", len(captured))
+	}
+	if !contains(captured[0], "hq-8888") {
+		t.Errorf("escalation message missing bead ID: %q", captured[0])
+	}
+}
+
+func TestHealth_Escalate_NoFireWhenNoClaim(t *testing.T) {
+	m, _ := testManager(t)
+	now := time.Now()
+	// Dog is "working" but Work is empty — this is degenerate but possible.
+	setupDogWithState(t, m, "alpha", &DogState{
+		Name: "alpha", State: StateWorking, Work: "",
+		WorkStartedAt: now.Add(-30 * time.Minute), LastActive: now,
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	mc := newMockChecker()
+	mc.healthResults["hq-dog-alpha"] = tmux.SessionDead
+	hc := NewHealthChecker(m, mc)
+
+	var captured []string
+	hc.Escalator = func(msg string) error {
+		captured = append(captured, msg)
+		return nil
+	}
+
+	d, _ := m.Get("alpha")
+	_ = hc.Check(d, 30*time.Minute, true)
+
+	if len(captured) != 0 {
+		t.Errorf("expected no escalation when dog had no claim; got %v", captured)
+	}
+}
+
+func TestHealth_Escalate_NoFireWhenEscalatorNil(t *testing.T) {
+	// Backwards-compat: existing callers that don't wire Escalator must still
+	// get working auto-clear behavior.
+	m, _ := testManager(t)
+	now := time.Now()
+	setupDogWithState(t, m, "alpha", &DogState{
+		Name: "alpha", State: StateWorking, Work: "hq-9999",
+		WorkStartedAt: now.Add(-30 * time.Minute), LastActive: now,
+		CreatedAt: now, UpdatedAt: now,
+	})
+
+	mc := newMockChecker()
+	mc.healthResults["hq-dog-alpha"] = tmux.SessionDead
+	hc := NewHealthChecker(m, mc)
+	// Escalator intentionally nil.
+
+	d, _ := m.Get("alpha")
+	r := hc.Check(d, 30*time.Minute, true)
+
+	if !r.AutoCleared {
+		t.Error("auto-clear must still work when Escalator is nil")
+	}
+}
+
+// contains is a small helper that avoids importing strings in this test file.
+func contains(s, sub string) bool {
+	return len(s) >= len(sub) && (s == sub || indexOf(s, sub) >= 0)
+}
+
+func indexOf(s, sub string) int {
+	if len(sub) == 0 {
+		return 0
+	}
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return i
+		}
+	}
+	return -1
+}
+
+// =============================================================================
 // Orphan sessions
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Three atomic commits implementing Deacon's hq-0ae design doc (option A). Closes the dog-reliability gaps observed in hq-3rl/hq-6cm dispatches on 2026-04-21.

**A1 — `gt dog done` push-verify ritual.** Before a dog returns to idle, verify each worktree: working tree clean, branch is task-specific (not main/master/develop/release or detached HEAD), HEAD visible on origin (auto-push if not, or fail with `--no-push`). On failure: do not clear work, do not kill session, fire a MEDIUM escalation so Mayor can intervene. `--skip-verify` preserves existing behavior for docs-only / no-code tasks.

**A2 — multi-scope bead guard in `gt sling`.** Refuse to sling a bead whose description declares both `Part A:` and `Part B:` scopes; the hq-3rl failure mode is for the agent to ship one part and silently drop the rest. Heuristic matches structural scope markers (\`Part A:\`, \`Part A (…)\`, \`Part A —\`) but ignores narrative text like \"Part A landed in PR #157\" so follow-ups that reference completed parts pass. `--allow-multi-scope` opts out.

**A3 — auto-escalate on dog death with open claim.** When the health checker auto-clears a zombie dog (SessionDead or AgentDead) that still had a bead claimed, fire `DOG_DEAD: <dog> on <bead>` so Mayor can re-dispatch rather than silently stalling. Escalator is an injectable hook on `HealthChecker`; a nil hook is a no-op for backward compat.

## Test plan
- [x] 8 new tests for `verifyDogWork` — clean/auto-push/no-push/protected-branch/dirty-tree/missing/non-git/mixed-results all pass
- [x] 9 new tests for `isMultiScopeBead` — table driven, covers narrative-vs-declarative, parenthetical, em-dash, case-insensitivity, three-part
- [x] 4 new tests for dog-death escalation — SessionDead/AgentDead with claim, no claim = no fire, nil escalator = no regress
- [x] Existing `gt dog done` tests still pass
- [x] `go build ./...` green
- [ ] Manual end-to-end: deliberately commit to main in a dog worktree, run `gt dog done`, confirm refuses-and-escalates

## Design ref
`/home/ian/gt/deacon/docs/dog-reliability-hq-0ae.md` (Deacon's self-review of hq-3rl + ranked failure modes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)