### PR TITLE
fix(beads/mail): route cross-rig bead ID writes via prefix

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -518,6 +518,42 @@ func (b *Beads) runWithRouting(args ...string) (_ []byte, retErr error) { //noli
 	return stripStdoutWarnings(stdout.Bytes()), nil
 }
 
+// routesCrossRig reports whether id's prefix routes to a different beads dir
+// than b's own (per routes.jsonl). Returns false if no routing is needed or
+// the route can't be resolved (in which case the caller should use b.run).
+func (b *Beads) routesCrossRig(id string) bool {
+	own := b.getResolvedBeadsDir()
+	target := ResolveRoutingTargetQuiet(b.getTownRoot(), id, own)
+	return target != "" && target != own
+}
+
+// runBDForID executes a bd command that operates on a single bead id, choosing
+// between run (explicit BEADS_DIR for same-rig) and runWithRouting (strips
+// BEADS_DIR so bd does its own prefix routing for cross-rig ids). Pinning
+// BEADS_DIR at a rig's .beads bypasses routes.jsonl and breaks lookups for
+// beads that live in a different database on the shared Dolt server, so we
+// only strip BEADS_DIR when a cross-rig route is detected. See au-ofe, au-b9d.
+func (b *Beads) runBDForID(id string, args ...string) ([]byte, error) {
+	if b.routesCrossRig(id) {
+		return b.runWithRouting(args...)
+	}
+	return b.run(args...)
+}
+
+// runBDForIDs is the multi-id variant of runBDForID. If any id routes to a
+// different rig than b's own, BEADS_DIR is stripped so bd handles routing
+// itself (bd supports mixed-prefix args: `bd close au-foo hq-bar` will route
+// each id to its own database). Same-rig-only invocations use run() so
+// BEADS_DIR stays pinned for consistency with other same-rig ops.
+func (b *Beads) runBDForIDs(ids []string, args ...string) ([]byte, error) {
+	for _, id := range ids {
+		if b.routesCrossRig(id) {
+			return b.runWithRouting(args...)
+		}
+	}
+	return b.run(args...)
+}
+
 // Run executes a bd command and returns stdout.
 // This is a public wrapper around the internal run method for cases where
 // callers need to run arbitrary bd commands.
@@ -1078,19 +1114,17 @@ func (b *Beads) ReadyWithType(issueType string) ([]*Issue, error) {
 
 // Show returns detailed information about an issue.
 func (b *Beads) Show(id string) (*Issue, error) {
-	// Route cross-rig queries via routes.jsonl so that rig-level bead IDs
-	// (e.g., "gt-abc123") resolve to the correct rig database.
-	targetDir := ResolveRoutingTarget(b.getTownRoot(), id, b.getResolvedBeadsDir())
-	if targetDir != b.getResolvedBeadsDir() {
-		target := NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
-		return target.Show(id)
-	}
-
 	if b.store != nil {
 		return b.storeShow(id)
 	}
 
-	out, err := b.run("show", id, "--json")
+	// Route cross-rig queries by stripping BEADS_DIR so bd's own prefix-based
+	// routing (via the town's routes.jsonl) resolves the bead. Pinning
+	// BEADS_DIR at a rig's .beads bypasses that routing and fails lookups for
+	// beads whose prefix maps to a different database on the shared Dolt
+	// server. See au-ofe / au-b9d. runBDForID picks run vs runWithRouting
+	// based on whether the ID routes to b's own beadsDir.
+	out, err := b.runBDForID(id, "show", id, "--json")
 	if err != nil {
 		return nil, err
 	}
@@ -1427,6 +1461,11 @@ func normalizeBugTitle(title string) string {
 }
 
 // Update updates an existing issue.
+//
+// When id routes to a different rig than b's own beadsDir, BEADS_DIR is
+// stripped so bd performs its own routes.jsonl-driven lookup. Without this,
+// the bd subprocess would be pinned to b's beadsDir and fail to find the
+// bead (au-ofe).
 func (b *Beads) Update(id string, opts UpdateOptions) error {
 	if b.store != nil {
 		return b.storeUpdate(id, opts)
@@ -1463,13 +1502,16 @@ func (b *Beads) Update(id string, opts UpdateOptions) error {
 		}
 	}
 
-	_, err := b.run(args...)
+	_, err := b.runBDForID(id, args...)
 	return err
 }
 
 // Close closes one or more issues.
 // If a runtime session ID is set in the environment, it is passed to bd close
 // for work attribution tracking (see decision 009-session-events-architecture.md).
+//
+// If any id routes to a different rig than b's own beadsDir, BEADS_DIR is
+// stripped so bd routes each id itself (au-ofe).
 func (b *Beads) Close(ids ...string) error {
 	if len(ids) == 0 {
 		return nil
@@ -1486,13 +1528,16 @@ func (b *Beads) Close(ids ...string) error {
 		args = append(args, "--session="+sessionID)
 	}
 
-	_, err := b.run(args...)
+	_, err := b.runBDForIDs(ids, args...)
 	return err
 }
 
 // CloseWithReason closes one or more issues with a reason.
 // If a runtime session ID is set in the environment, it is passed to bd close
 // for work attribution tracking (see decision 009-session-events-architecture.md).
+//
+// If any id routes to a different rig than b's own beadsDir, BEADS_DIR is
+// stripped so bd routes each id itself (au-ofe).
 func (b *Beads) CloseWithReason(reason string, ids ...string) error {
 	if len(ids) == 0 {
 		return nil
@@ -1510,13 +1555,16 @@ func (b *Beads) CloseWithReason(reason string, ids ...string) error {
 		args = append(args, "--session="+sessionID)
 	}
 
-	_, err := b.run(args...)
+	_, err := b.runBDForIDs(ids, args...)
 	return err
 }
 
 // ForceCloseWithReason closes one or more issues with --force, bypassing
 // dependency checks. Used by gt done where the polecat is about to be nuked
 // and open molecule wisps should not block issue closure.
+//
+// If any id routes to a different rig than b's own beadsDir, BEADS_DIR is
+// stripped so bd routes each id itself (au-ofe).
 func (b *Beads) ForceCloseWithReason(reason string, ids ...string) error {
 	if len(ids) == 0 {
 		return nil
@@ -1539,7 +1587,7 @@ func (b *Beads) ForceCloseWithReason(reason string, ids ...string) error {
 		args = append(args, "--session="+sessionID)
 	}
 
-	_, err := b.run(args...)
+	_, err := b.runBDForIDs(ids, args...)
 	return err
 }
 
@@ -1573,7 +1621,7 @@ func (b *Beads) ReleaseWithReason(id, reason string) error {
 		args = append(args, "--notes=Released: "+reason)
 	}
 
-	_, err := b.run(args...)
+	_, err := b.runBDForID(id, args...)
 	return err
 }
 

--- a/internal/beads/beads_channel.go
+++ b/internal/beads/beads_channel.go
@@ -446,7 +446,7 @@ func (b *Beads) EnforceChannelRetention(name string) error {
 	// Delete marked messages (best-effort)
 	for id := range toDeleteIDs {
 		// Use close instead of delete for audit trail
-		_, _ = b.run("close", id, "--reason=channel retention pruning")
+		_, _ = b.runBDForID(id, "close", id, "--reason=channel retention pruning")
 	}
 
 	return nil
@@ -519,7 +519,7 @@ func (b *Beads) PruneAllChannels() (int, error) {
 
 		// Delete marked messages
 		for id := range toDeleteIDs {
-			if _, err := b.run("close", id, "--reason=patrol retention pruning"); err == nil {
+			if _, err := b.runBDForID(id, "close", id, "--reason=patrol retention pruning"); err == nil {
 				pruned++
 			}
 		}

--- a/internal/beads/beads_delegation.go
+++ b/internal/beads/beads_delegation.go
@@ -69,7 +69,7 @@ func (b *Beads) AddDelegation(d *Delegation) error {
 		if marshalErr != nil {
 			return fmt.Errorf("marshaling delegation: %w", marshalErr)
 		}
-		_, err = b.run("update", d.Child, "--set-metadata=delegated_from="+string(delegationJSON))
+		_, err = b.runBDForID(d.Child, "update", d.Child, "--set-metadata=delegated_from="+string(delegationJSON))
 	}
 	if err != nil {
 		return fmt.Errorf("setting delegation metadata: %w", err)
@@ -91,7 +91,7 @@ func (b *Beads) RemoveDelegation(parent, child string) error {
 		err = b.storeDelegationClear(child)
 	} else {
 		// CLI path: use --unset-metadata flag (bd update in v0.62+).
-		_, err = b.run("update", child, "--unset-metadata=delegated_from")
+		_, err = b.runBDForID(child, "update", child, "--unset-metadata=delegated_from")
 	}
 	if err != nil {
 		return fmt.Errorf("clearing delegation metadata: %w", err)

--- a/internal/beads/beads_escalation.go
+++ b/internal/beads/beads_escalation.go
@@ -259,9 +259,11 @@ func (b *Beads) CloseEscalation(id, closedBy, reason string) error {
 		return err
 	}
 
-	// Close the issue
-	_, err = b.run("close", id, "--reason="+reason)
-	return err
+	// Close the issue. Route on id so cross-rig escalations (au-ofe) resolve
+	// to the correct database. Delegating to CloseWithReason keeps the close
+	// path consistent with Close/ForceCloseWithReason (session tagging, store
+	// handling, and runBDForIDs routing).
+	return b.CloseWithReason(reason, id)
 }
 
 // GetEscalationBead retrieves an escalation bead by ID.

--- a/internal/beads/beads_sling_context.go
+++ b/internal/beads/beads_sling_context.go
@@ -120,7 +120,7 @@ func (b *Beads) ListOpenSlingContexts() ([]*Issue, error) {
 // CloseSlingContext closes a sling context bead with a reason.
 // Idempotent: suppresses "already closed" errors so retries are safe.
 func (b *Beads) CloseSlingContext(contextID, reason string) error {
-	_, err := b.run("close", contextID, "--reason="+reason)
+	_, err := b.runBDForID(contextID, "close", contextID, "--reason="+reason)
 	if err != nil && strings.Contains(err.Error(), "already closed") {
 		return nil // Idempotent — already in desired state
 	}

--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -58,8 +58,22 @@ func FindTownRoot(startDir string) string {
 // It extracts the prefix from the bead ID and looks up the corresponding route.
 // Returns the resolved beads directory path, following any redirects.
 //
-// If townRoot is empty or prefix is not found, falls back to the provided fallbackDir.
+// If townRoot is empty or prefix is not found, falls back to the provided fallbackDir
+// and logs a warning to stderr. Callers that expect a silent fallback (e.g., best-effort
+// mail lookups where the ID may not be routable) should use ResolveRoutingTargetQuiet.
 func ResolveRoutingTarget(townRoot, beadID, fallbackDir string) string {
+	return resolveRoutingTarget(townRoot, beadID, fallbackDir, true)
+}
+
+// ResolveRoutingTargetQuiet is like ResolveRoutingTarget but silently returns
+// fallbackDir if the bead's prefix has no route or the rig beads dir can't be
+// resolved. Useful for best-effort callers (mail Get fallback, etc.) where a
+// missing route is an expected outcome, not a warning condition.
+func ResolveRoutingTargetQuiet(townRoot, beadID, fallbackDir string) string {
+	return resolveRoutingTarget(townRoot, beadID, fallbackDir, false)
+}
+
+func resolveRoutingTarget(townRoot, beadID, fallbackDir string, warn bool) string {
 	if townRoot == "" {
 		return fallbackDir
 	}
@@ -73,14 +87,18 @@ func ResolveRoutingTarget(townRoot, beadID, fallbackDir string) string {
 	// Look up rig path for this prefix
 	rigPath := GetRigPathForPrefix(townRoot, prefix)
 	if rigPath == "" {
-		fmt.Fprintf(os.Stderr, "Warning: no route found for prefix %q (bead %s), falling back to %s\n", prefix, beadID, fallbackDir)
+		if warn {
+			fmt.Fprintf(os.Stderr, "Warning: no route found for prefix %q (bead %s), falling back to %s\n", prefix, beadID, fallbackDir)
+		}
 		return fallbackDir
 	}
 
 	// Resolve redirects and get final beads directory
 	beadsDir := ResolveBeadsDir(rigPath)
 	if beadsDir == "" {
-		fmt.Fprintf(os.Stderr, "Warning: could not resolve beads dir for rig %s (bead %s), falling back to %s\n", rigPath, beadID, fallbackDir)
+		if warn {
+			fmt.Fprintf(os.Stderr, "Warning: could not resolve beads dir for rig %s (bead %s), falling back to %s\n", rigPath, beadID, fallbackDir)
+		}
 		return fallbackDir
 	}
 

--- a/internal/beads/routes.go
+++ b/internal/beads/routes.go
@@ -337,31 +337,36 @@ func GetRigNameForPrefix(townRoot, prefix string) string {
 // (typically the town-level .beads). If the bead ID's prefix maps to a different
 // rig via routes.jsonl, the resolved rig's beads directory is returned.
 // Returns currentBeadsDir if no routing is needed or prefix can't be resolved.
+//
+// This delegates to ResolveRoutingTarget for cross-rig resolution so that all
+// ID→beadsDir lookup paths (bd show, mail read/archive, escalate ack/close,
+// bead Update/Close) behave identically. See beads au-ofe and au-b9d: previously
+// this function only consulted routes.jsonl in currentBeadsDir, which missed
+// rigs whose routes live in the town's beads dir (or other workspaces) and did
+// not follow redirects, so writes against cross-rig bead IDs failed with
+// "issue not found".
 func ResolveBeadsDirForID(currentBeadsDir, beadID string) string {
-	prefix := ExtractPrefix(beadID)
-	if prefix == "" {
-		return currentBeadsDir
+	// Derive town root from currentBeadsDir. ResolveRoutingTarget will look up
+	// the prefix in the town's routes.jsonl and follow any redirects.
+	//
+	// currentBeadsDir is typically ".../<townRoot>/.beads", in which case the
+	// town root is its parent directory. FindTownRoot walks up looking for
+	// mayor/town.json so it still works when currentBeadsDir points at a rig
+	// worktree's .beads (e.g., a polecat's .beads that redirects into town).
+	townRoot := ""
+	if filepath.Base(currentBeadsDir) == ".beads" {
+		townRoot = FindTownRoot(filepath.Dir(currentBeadsDir))
+	} else {
+		townRoot = FindTownRoot(currentBeadsDir)
 	}
-
-	routes, err := LoadRoutes(currentBeadsDir)
-	if err != nil || routes == nil {
-		return currentBeadsDir
+	if townRoot == "" {
+		// Best-effort fallback: assume currentBeadsDir's parent is the town root.
+		townRoot = filepath.Dir(currentBeadsDir)
 	}
-
-	for _, r := range routes {
-		if r.Prefix == prefix {
-			if r.Path == "." {
-				return currentBeadsDir // Town-level — already correct
-			}
-			// Rig-level bead — resolve to rig's beads directory.
-			// Derive town root from currentBeadsDir (parent of .beads).
-			townRoot := filepath.Dir(currentBeadsDir)
-			rigDir := filepath.Join(townRoot, r.Path)
-			return ResolveBeadsDir(rigDir)
-		}
-	}
-
-	return currentBeadsDir
+	// Use the quiet variant: callers like mail.Get probe IDs whose prefixes may
+	// legitimately not have a route (dangling refs, legacy JSONL beads). The
+	// stderr spam was confusing and made the inbox unusable (au-b9d).
+	return ResolveRoutingTargetQuiet(townRoot, beadID, currentBeadsDir)
 }
 
 // ValidateRigPrefix checks that a newly created bead landed in the expected rig's

--- a/internal/mail/bd.go
+++ b/internal/mail/bd.go
@@ -52,7 +52,12 @@ func (e *bdError) ContainsError(substr string) bool {
 // runBdCommand executes a bd command with a context timeout and proper environment setup.
 // ctx controls the deadline/timeout for the subprocess.
 // workDir is the directory to run the command in.
-// beadsDir is the BEADS_DIR environment variable value.
+// beadsDir is the BEADS_DIR environment variable value. If beadsDir is empty,
+// BEADS_DIR is stripped from the environment so bd performs its own
+// prefix-based routing via routes.jsonl (see au-ofe). Pass the town-level
+// .beads (or empty) when operating on cross-rig bead IDs; pinning BEADS_DIR
+// at a rig's .beads bypasses routing and breaks lookups for beads whose
+// prefix maps to a different database on the shared Dolt server.
 // extraEnv contains additional environment variables to set (e.g., "BD_IDENTITY=...").
 // Returns stdout bytes on success, or a *bdError on failure.
 func runBdCommand(ctx context.Context, args []string, workDir, beadsDir string, extraEnv ...string) (_ []byte, retErr error) {
@@ -61,7 +66,9 @@ func runBdCommand(ctx context.Context, args []string, workDir, beadsDir string, 
 	// Remove stale dolt-server.pid before spawning bd. A stale PID file causes
 	// bd to connect to port 3307 which may be occupied by a different Dolt server
 	// serving different databases, resulting in hangs until the read timeout kills it.
-	beads.CleanStaleDoltServerPID(beadsDir)
+	if beadsDir != "" {
+		beads.CleanStaleDoltServerPID(beadsDir)
+	}
 
 	// bd v0.59+ requires --flat for list --json to produce JSON output.
 	// Without it, bd returns human-readable tree format that fails JSON parsing.
@@ -73,9 +80,19 @@ func runBdCommand(ctx context.Context, args []string, workDir, beadsDir string, 
 	cmd.Dir = workDir
 	util.SetDetachedProcessGroup(cmd)
 
-	env := append(cmd.Environ(), "BEADS_DIR="+beadsDir)
-	if dbEnv := beads.DatabaseEnv(beadsDir); dbEnv != "" {
-		env = append(env, dbEnv)
+	env := cmd.Environ()
+	if beadsDir == "" {
+		// Strip any inherited BEADS_DIR so bd does native routing via its
+		// cwd walk-up (which finds the town's routes.jsonl).
+		env = filterEnvKey(env, "BEADS_DIR")
+	} else {
+		// Also strip first so glibc getenv() doesn't pick up an inherited
+		// entry that shadows the one we append.
+		env = filterEnvKey(env, "BEADS_DIR")
+		env = append(env, "BEADS_DIR="+beadsDir)
+		if dbEnv := beads.DatabaseEnv(beadsDir); dbEnv != "" {
+			env = append(env, dbEnv)
+		}
 	}
 	env = append(env, extraEnv...)
 	env = append(env, telemetry.OTELEnvForSubprocess()...)
@@ -123,6 +140,20 @@ func firstArg(args []string) string {
 		return args[0]
 	}
 	return ""
+}
+
+// filterEnvKey removes all entries matching the given key= from the env slice.
+// Used to strip an inherited BEADS_DIR before appending the desired value, so
+// glibc getenv() doesn't return a shadowed older entry.
+func filterEnvKey(env []string, key string) []string {
+	prefix := key + "="
+	result := make([]string, 0, len(env))
+	for _, e := range env {
+		if !strings.HasPrefix(e, prefix) {
+			result = append(result, e)
+		}
+	}
+	return result
 }
 
 // bdReadCtx returns a context with the standard bd read timeout.

--- a/internal/mail/delivery.go
+++ b/internal/mail/delivery.go
@@ -80,9 +80,14 @@ func DeliveryAckLabelSequenceIdempotent(recipientIdentity string, at time.Time, 
 // AcknowledgeDeliveryBead writes phase-2 delivery ack labels for a bead.
 // It reads existing labels for idempotent retry (reusing prior timestamps),
 // then writes the ack label sequence. Uses runBdCommand with timeouts.
-// Resolves the correct beadsDir based on the bead ID prefix (GH#2423).
+//
+// If beadID routes to a different rig than beadsDir, BEADS_DIR is stripped
+// ("") so bd performs its own prefix-based routing via routes.jsonl. Pinning
+// BEADS_DIR at a rig's .beads bypasses routing and fails the lookup for
+// beads whose prefix maps to a different database on the shared Dolt
+// server (au-ofe, au-b9d).
 func AcknowledgeDeliveryBead(workDir, beadsDir, beadID, recipientIdentity string) error {
-	beadsDir = beads.ResolveBeadsDirForID(beadsDir, beadID)
+	beadsDir = routedBeadsDirForID(beadsDir, beadID)
 	existingLabels, readErr := readBeadLabelsShared(workDir, beadsDir, beadID)
 	if readErr != nil {
 		// Log but proceed with empty labels — fresh timestamp is acceptable
@@ -104,6 +109,18 @@ func AcknowledgeDeliveryBead(workDir, beadsDir, beadID, recipientIdentity string
 		return err
 	}
 	return nil
+}
+
+// routedBeadsDirForID returns the BEADS_DIR value to pass into runBdCommand
+// so that beadID resolves correctly. Same-rig ids keep currentBeadsDir;
+// cross-rig ids return "" so bd's own prefix routing (via routes.jsonl in
+// the town's .beads) dispatches to the correct database. See au-ofe, au-b9d.
+func routedBeadsDirForID(currentBeadsDir, beadID string) string {
+	target := beads.ResolveBeadsDirForID(currentBeadsDir, beadID)
+	if target == "" || target == currentBeadsDir {
+		return currentBeadsDir
+	}
+	return ""
 }
 
 // readBeadLabelsShared reads the labels for a bead, returning an error on failure

--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -92,6 +92,23 @@ func (m *Mailbox) Identity() string {
 	return m.identity
 }
 
+// routedBeadsDir returns the BEADS_DIR value that runBdCommand should use to
+// resolve id. For same-rig ids it returns m.beadsDir (so bd talks to the
+// configured database directly). For cross-rig ids it returns "", which tells
+// runBdCommand to strip BEADS_DIR so bd performs its own prefix-based routing
+// via routes.jsonl. Pinning BEADS_DIR at the rig's .beads bypasses that
+// routing and fails lookups for beads whose prefix maps to a different
+// database on the shared Dolt server (au-ofe, au-b9d).
+func (m *Mailbox) routedBeadsDir(id string) string {
+	target := beads.ResolveBeadsDirForID(m.beadsDir, id)
+	if target == "" || target == m.beadsDir {
+		return m.beadsDir
+	}
+	// Cross-rig: strip BEADS_DIR. bd will walk up from m.workDir and
+	// consult the town's routes.jsonl to dispatch to the right database.
+	return ""
+}
+
 // Path returns the JSONL path for legacy mailboxes.
 func (m *Mailbox) Path() string {
 	return m.path
@@ -466,13 +483,14 @@ func (m *Mailbox) Get(id string) (*Message, error) {
 }
 
 func (m *Mailbox) getBeads(id string) (*Message, error) {
-	// Resolve correct beadsDir based on bead ID prefix (GH#2423)
-	primary := beads.ResolveBeadsDirForID(m.beadsDir, id)
+	// Pick the correct BEADS_DIR for this id: m.beadsDir for same-rig,
+	// "" (strip BEADS_DIR, let bd route) for cross-rig (au-ofe, au-b9d).
+	primary := m.routedBeadsDir(id)
 	msg, err := m.getFromDir(id, primary)
 	if errors.Is(err, ErrMessageNotFound) && primary != m.beadsDir {
-		// Cross-rig bead IDs (e.g. ne-*) may live in the home DB when created
-		// via the mail router (which always uses town beads). Fall back to
-		// m.beadsDir before giving up. See ne-bgr.
+		// Cross-rig ids normally resolve via bd's routing when primary is "".
+		// If that still fails (e.g., a legacy bead whose prefix isn't in
+		// routes.jsonl), fall back to m.beadsDir directly. See ne-bgr.
 		return m.getFromDir(id, m.beadsDir)
 	}
 	return msg, err
@@ -534,13 +552,13 @@ func (m *Mailbox) MarkRead(id string) error {
 }
 
 func (m *Mailbox) markReadBeads(id string) error {
-	// Resolve correct beadsDir based on bead ID prefix (GH#2423)
-	primary := beads.ResolveBeadsDirForID(m.beadsDir, id)
+	// Pick BEADS_DIR for id: m.beadsDir for same-rig, "" (let bd route) for
+	// cross-rig. See au-ofe/au-b9d for why pinning the rig's BEADS_DIR fails.
+	primary := m.routedBeadsDir(id)
 	err := m.closeInDir(id, primary)
 	if errors.Is(err, ErrMessageNotFound) && primary != m.beadsDir {
-		// Cross-rig bead IDs (e.g. ne-*) may live in the home DB when created
-		// via the mail router (which always uses town beads). Fall back to
-		// m.beadsDir before giving up. See ne-bgr.
+		// Fallback for legacy/unknown prefixes that bd routing can't resolve.
+		// See ne-bgr.
 		return m.closeInDir(id, m.beadsDir)
 	}
 	return err
@@ -620,7 +638,8 @@ func (m *Mailbox) markReadOnlyBeads(id string) error {
 
 	// Add "read" label to mark as read without closing
 	args := []string{"label", "add", id, "read"}
-	primary := beads.ResolveBeadsDirForID(m.beadsDir, id)
+	// Route via bd for cross-rig ids (au-ofe); see routedBeadsDir.
+	primary := m.routedBeadsDir(id)
 
 	ctx, cancel := bdWriteCtx()
 	defer cancel()
@@ -665,7 +684,8 @@ func (m *Mailbox) markUnreadOnlyBeads(id string) error {
 
 	// Remove "read" label to mark as unread
 	args := []string{"label", "remove", id, "read"}
-	primary := beads.ResolveBeadsDirForID(m.beadsDir, id)
+	// Route via bd for cross-rig ids (au-ofe); see routedBeadsDir.
+	primary := m.routedBeadsDir(id)
 
 	ctx, cancel := bdWriteCtx()
 	defer cancel()
@@ -714,7 +734,8 @@ func (m *Mailbox) markUnreadBeads(id string) error {
 	}
 
 	args := []string{"reopen", id}
-	primary := beads.ResolveBeadsDirForID(m.beadsDir, id)
+	// Route via bd for cross-rig ids (au-ofe); see routedBeadsDir.
+	primary := m.routedBeadsDir(id)
 
 	ctx, cancel := bdWriteCtx()
 	defer cancel()


### PR DESCRIPTION
## Summary

`gt mail`, `gt escalate ack/close`, and refinery delivery acks all wrote to the **caller's** beads store regardless of which rig owned the target bead. When mayor (town-level) handed work to a rig polecat — or a polecat in rig A acked a message originating from rig B — the writes landed in the wrong database. The bead would appear "updated" in the source store but the canonical store (where the bead actually lives) saw nothing.

This caused two visible bugs:
- **au-ofe**: `gt escalate` ack/close + Update path didn't use ID-based routing.
- **au-b9d**: wisp/handoff beads became unqueryable from mail inboxes — the metadata writes were silently going to the wrong DB.

## Approach

Bead IDs are already prefixed by rig (e.g. `aa-`, `au-`, `si-`, `ma-`). We use that prefix as the routing key — same scheme upstream PR #3680 introduced for `--repo=<rig_dir>` lookup via `routes.jsonl`. This PR extends the same prefix→rig resolver to all mail / escalation / delivery write paths.

## Changes

- `internal/beads/beads.go` + `routes.go`: add prefix-based write routing helpers and apply them to channel, delegation, escalation, and sling-context paths.
- `internal/beads/beads_types.go`: thread routing context through the cross-rig call paths.
- `internal/mail/mailbox.go` + `bd.go`: route mail metadata writes via the recipient bead's prefix, not the caller's CWD.
- `internal/mail/delivery.go`: route refinery delivery acks the same way.

## Testing

- [x] Unit tests pass (`go test ./internal/beads/... ./internal/mail/...`)
- [x] Build clean (`go build ./cmd/gt`)
- [x] Verified live: `gt escalate ack` from mayor on a `au-*` bead now lands in `alleago_ui/.beads/`, not town-level.

## Checklist
- [x] Code follows project style
- [x] No breaking changes — falls back to caller-CWD when the prefix doesn't resolve to a known rig (legacy behavior)

Fixes: au-ofe, au-b9d (Alleago internal tracker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)