### PR TITLE
refactor: remove dead heartbeat:EPOCH label write on agent beads

### DIFF
--- a/internal/cmd/molecule_await_event.go
+++ b/internal/cmd/molecule_await_event.go
@@ -204,12 +204,8 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 	}
 	result.Elapsed = time.Since(startTime)
 
-	// Update agent bead idle cycles and heartbeat
+	// Update agent bead idle cycles
 	if awaitEventAgentBead != "" && beadsDir != "" {
-		// Always update heartbeat (both event and timeout) so witness doesn't
-		// think we're dead during long idle periods.
-		_ = updateAgentHeartbeat(awaitEventAgentBead, beadsDir)
-
 		if result.Reason == "timeout" {
 			newIdle := idleCycles + 1
 			if setErr := setAgentIdleCycles(awaitEventAgentBead, beadsDir, newIdle); setErr != nil {

--- a/internal/cmd/molecule_await_signal.go
+++ b/internal/cmd/molecule_await_signal.go
@@ -243,23 +243,9 @@ func runMoleculeAwaitSignal(cmd *cobra.Command, args []string) error {
 		} else {
 			result.IdleCycles = newIdleCycles
 		}
-		// Update last_activity so watchers know agent is still alive
-		if err := updateAgentHeartbeat(awaitSignalAgentBead, beadsDir); err != nil {
-			if !awaitSignalQuiet {
-				fmt.Printf("%s Failed to update agent heartbeat: %v\n",
-					style.Dim.Render("⚠"), err)
-			}
-		}
 		// Clear the backoff window — timeout completed normally
 		_ = clearAgentBackoffUntil(awaitSignalAgentBead, beadsDir)
 	} else if result.Reason == "signal" && awaitSignalAgentBead != "" {
-		// On signal, update last_activity to prove agent is alive
-		if err := updateAgentHeartbeat(awaitSignalAgentBead, beadsDir); err != nil {
-			if !awaitSignalQuiet {
-				fmt.Printf("%s Failed to update agent heartbeat: %v\n",
-					style.Dim.Render("⚠"), err)
-			}
-		}
 		// Report current idle cycles (caller should reset)
 		result.IdleCycles = idleCycles
 		// Clear the backoff window — woken by real activity
@@ -425,39 +411,6 @@ func parseIntSimple(s string) (int, error) {
 		n = n*10 + int(s[i]-'0')
 	}
 	return n, nil
-}
-
-// updateAgentHeartbeat records a heartbeat timestamp on an agent bead via a
-// heartbeat:EPOCH label. This proves the agent is alive during long idle periods.
-//
-// bd agent heartbeat was never shipped (steveyegge/beads#2828). We use the same
-// read-modify-write label pattern as setAgentIdleCycles instead.
-func updateAgentHeartbeat(agentBead, beadsDir string) error {
-	allLabels, err := getAllAgentLabels(agentBead, beadsDir)
-	if err != nil {
-		return err
-	}
-
-	var newLabels []string
-	for _, label := range allLabels {
-		if len(label) > 10 && label[:10] == "heartbeat:" {
-			continue // Replace existing heartbeat label
-		}
-		newLabels = append(newLabels, label)
-	}
-	newLabels = append(newLabels, fmt.Sprintf("heartbeat:%d", time.Now().Unix()))
-
-	args := []string{"update", agentBead}
-	for _, label := range newLabels {
-		args = append(args, "--set-labels="+label)
-	}
-
-	ctx, cancel := context.WithTimeout(context.Background(), bdCallTimeout)
-	defer cancel()
-
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
-	return cmd.Run()
 }
 
 // setAgentIdleCycles sets the idle:N label on an agent bead.


### PR DESCRIPTION
## Summary

Removes `updateAgentHeartbeat` and its three call sites. The function stamped a `heartbeat:<epoch>` label on agent beads whenever `gt mol step await-signal`/`await-event` observed a signal or timed out, intended to signal agent liveness to watchers.

However, nothing in the codebase reads that label. Agent liveness is determined from the file-backed heartbeats at:
- `deacon/heartbeat.json` (daemon liveness monitor, checked by `mol-gastown-boot.formula.toml`)
- `.runtime/heartbeats/<session>.json` (polecat session staleness, `stuck-agent-dog` plugin)

The label was write-only — a vestige of an older approach. Keeping it produces two consequences, both undesirable:

1. **False-positive divergence.** Operators who know the label exists sometimes trust it over the file, producing "stuck heartbeat" alerts that are actually stale-label artifacts rather than real agent stalls.
2. **Unnecessary bd update traffic.** Every await-signal/event cycle performs a read-modify-write bd call purely to rewrite the label.

This change leaves the file-backed heartbeats as the sole source of truth and removes the dead writer.

## Test plan

- [x] `go build ./...` — clean
- [x] `go test ./internal/cmd/ -run 'TestAwait|TestMolecule|TestHeartbeat'` — pass
- [x] Manual: `gt mol step await-signal --agent-bead <bead>` still updates idle cycles and backoff window; no heartbeat-label writes observed on the agent bead

## Notes

The pre-existing `TestPersistentPreRunLoadsAgentRegistry` failure in `internal/cmd/root_test.go` (signed-binary check in `persistentPreRun`) is orthogonal to this change and was failing before this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)