### PR TITLE
fix: keep rig agent beads in routed db and skip codex command noise

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -252,7 +252,7 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 	// when the bead's prefix routes to a different rig than our own database.
 	// Without this, agent beads for rig polecats (e.g., be-beads-polecat-rust)
 	// would be created in the wrong database, failing type validation.
-	if targetDir != b.getResolvedBeadsDir() {
+	if targetDir != target.getResolvedBeadsDir() {
 		target = NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
 	}
 

--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -391,7 +391,7 @@ esac
 	t.Setenv("MOCK_BD_LOG", logPath)
 }
 
-func TestCreateAgentBead_UsesTownRootForCrossRigRoutes(t *testing.T) {
+func TestCreateAgentBead_UsesImportedRigDatabaseWhenRouteTargetsCurrentRig(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("path assertions are Unix-oriented")
 	}
@@ -439,17 +439,78 @@ func TestCreateAgentBead_UsesTownRootForCrossRigRoutes(t *testing.T) {
 		t.Fatalf("read mock bd log: %v", err)
 	}
 	logOutput := string(logData)
-	if !strings.Contains(logOutput, "pwd="+townRoot) {
-		t.Fatalf("mock bd log missing town root cwd:\n%s", logOutput)
+	if !strings.Contains(logOutput, "pwd="+workerDir) {
+		t.Fatalf("mock bd log missing imported rig cwd:\n%s", logOutput)
 	}
-	if !strings.Contains(logOutput, "beads_dir="+filepath.Join(townRoot, ".beads")) {
-		t.Fatalf("mock bd log missing town-root BEADS_DIR:\n%s", logOutput)
+	if !strings.Contains(logOutput, "beads_dir="+filepath.Join(workerDir, ".beads")) {
+		t.Fatalf("mock bd log missing imported-rig BEADS_DIR:\n%s", logOutput)
+	}
+	if strings.Contains(logOutput, "beads_dir="+filepath.Join(townRoot, ".beads")) {
+		t.Fatalf("mock bd log unexpectedly used town-root BEADS_DIR:\n%s", logOutput)
 	}
 	if !strings.Contains(logOutput, "create --json --id=pt-imported-polecat-shiny") {
 		t.Fatalf("mock bd log missing create call:\n%s", logOutput)
 	}
 	// Note: hook_bead slot is no longer set — bd slot removed in v0.62 (hq-l6mm5).
 	// Work bead status=hooked and assignee=<agent> is now the authoritative source.
+}
+
+func TestCreateAgentBead_UsesRigDatabaseWhenRouteTargetsCurrentRig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("path assertions are Unix-oriented")
+	}
+
+	townRoot, _ := filepath.EvalSymlinks(t.TempDir())
+	rigRoot := filepath.Join(townRoot, "prodebug")
+	for _, dir := range []string{
+		filepath.Join(townRoot, "mayor"),
+		filepath.Join(townRoot, ".beads"),
+		filepath.Join(rigRoot, ".beads"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte("{\"prefix\":\"prodebug-\",\"path\":\"prodebug\"}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	logPath := filepath.Join(townRoot, "bd.log")
+	installMockBDCreateRecorder(t, logPath)
+
+	bd := NewWithBeadsDir(rigRoot, filepath.Join(rigRoot, ".beads"))
+	issue, err := bd.CreateAgentBead("prodebug-witness", "Witness for prodebug", &AgentFields{
+		RoleType:   "witness",
+		Rig:        "prodebug",
+		AgentState: "idle",
+	})
+	if err != nil {
+		t.Fatalf("CreateAgentBead: %v", err)
+	}
+	if issue == nil {
+		t.Fatal("CreateAgentBead returned nil issue")
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read mock bd log: %v", err)
+	}
+	logOutput := string(logData)
+	if !strings.Contains(logOutput, "pwd="+rigRoot) {
+		t.Fatalf("mock bd log missing rig root cwd:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "beads_dir="+filepath.Join(rigRoot, ".beads")) {
+		t.Fatalf("mock bd log missing rig-root BEADS_DIR:\n%s", logOutput)
+	}
+	if strings.Contains(logOutput, "beads_dir="+filepath.Join(townRoot, ".beads")) {
+		t.Fatalf("mock bd log unexpectedly used town-root BEADS_DIR:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "create --json --id=prodebug-witness") {
+		t.Fatalf("mock bd log missing create call:\n%s", logOutput)
+	}
 }
 
 func TestCreateAgentBead_ParsesMockCreateOutput(t *testing.T) {

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -800,9 +800,11 @@ Use crew for your own workspace. Polecats are for batch work dispatch.
 			fmt.Printf("  %s Could not scaffold polecat settings: %v\n", "!", err)
 		}
 	}
-	if err := commands.ProvisionFor(polecatsPath, defaultAgentName); err != nil {
-		// Non-fatal: commands are convenience, not critical
-		fmt.Printf("  %s Could not scaffold polecat commands: %v\n", "!", err)
+	if commands.IsKnownAgent(defaultAgentName) {
+		if err := commands.ProvisionFor(polecatsPath, defaultAgentName); err != nil {
+			// Non-fatal: commands are convenience, not critical
+			fmt.Printf("  %s Could not scaffold polecat commands: %v\n", "!", err)
+		}
 	}
 
 	// Register route in town-level routes.jsonl BEFORE creating agent beads.


### PR DESCRIPTION
## Summary

This fixes two rig-bootstrap defects found during a fresh-machine setup:

1. Keep rig agent bead creation (`witness` / `refinery`) in the routed rig database when the route target is the current rig, instead of accidentally staying on the temporary town-root wrapper.
2. Skip polecat slash-command scaffolding for built-in Codex, which intentionally has no `config_dir`, to avoid a misleading warning during `gt rig add`.

## Related Issues

Closes #3720
Closes #3721

## Changes

- `internal/beads/beads_agent.go`
  - compare the routed target against the current target wrapper before deciding whether to switch databases
- `internal/beads/beads_agent_test.go`
  - update the imported-rig routing expectation
  - add a regression test for route-targets-current-rig behavior
- `internal/rig/manager.go`
  - only call `commands.ProvisionFor()` when the default agent is command-provisionable

## Testing

- [x] Unit tests pass (`go test ./internal/beads ./internal/rig`)
- [x] Manual testing performed

## Checklist

- [x] Code follows project style
- [ ] Documentation updated (not needed)
- [x] No breaking changes (or documented in summary)
