### PR TITLE
fix: preserve built-in opencode preset fields in overrides

### DIFF
--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -10,6 +10,11 @@ import (
 	"sync"
 )
 
+type rawAgentRegistry struct {
+	Version int                        `json:"version"`
+	Agents  map[string]json.RawMessage `json:"agents"`
+}
+
 // AgentPreset identifies a supported LLM agent runtime.
 // These presets provide sensible defaults that can be overridden in config.
 type AgentPreset string
@@ -560,18 +565,56 @@ func loadAgentRegistryFromPathLocked(path string) error {
 		return err
 	}
 
-	var userRegistry AgentRegistry
+	var userRegistry rawAgentRegistry
 	if err := json.Unmarshal(data, &userRegistry); err != nil {
 		return err
 	}
 
-	for name, preset := range userRegistry.Agents {
-		preset.Name = AgentPreset(name)
-		globalRegistry.Agents[name] = preset
+	for name, rawPreset := range userRegistry.Agents {
+		merged := cloneAgentPresetInfo(globalRegistry.Agents[name])
+		if merged == nil {
+			merged = &AgentPresetInfo{}
+		}
+		if err := json.Unmarshal(rawPreset, merged); err != nil {
+			return err
+		}
+		merged.Name = AgentPreset(name)
+		globalRegistry.Agents[name] = merged
 	}
 
 	loadedPaths[path] = true
 	return nil
+}
+
+func cloneAgentPresetInfo(src *AgentPresetInfo) *AgentPresetInfo {
+	if src == nil {
+		return nil
+	}
+	clone := *src
+	if src.Args != nil {
+		clone.Args = append([]string(nil), src.Args...)
+	}
+	if src.Env != nil {
+		clone.Env = make(map[string]string, len(src.Env))
+		for k, v := range src.Env {
+			clone.Env[k] = v
+		}
+	}
+	if src.ProcessNames != nil {
+		clone.ProcessNames = append([]string(nil), src.ProcessNames...)
+	}
+	if src.NonInteractive != nil {
+		nonInteractive := *src.NonInteractive
+		clone.NonInteractive = &nonInteractive
+	}
+	if src.ACP != nil {
+		acp := *src.ACP
+		if src.ACP.Args != nil {
+			acp.Args = append([]string(nil), src.ACP.Args...)
+		}
+		clone.ACP = &acp
+	}
+	return &clone
 }
 
 // LoadAgentRegistry loads agent definitions from a JSON file and merges with built-ins.
@@ -657,6 +700,10 @@ func DefaultAgentPreset() AgentPreset {
 // can be accessed separately for extended functionality.
 func RuntimeConfigFromPreset(preset AgentPreset) *RuntimeConfig {
 	info := GetAgentPreset(preset)
+	return runtimeConfigFromAgentInfo(preset, info)
+}
+
+func runtimeConfigFromAgentInfo(preset AgentPreset, info *AgentPresetInfo) *RuntimeConfig {
 	if info == nil {
 		// Fall back to Claude defaults
 		return DefaultRuntimeConfig()
@@ -674,12 +721,10 @@ func RuntimeConfigFromPreset(preset AgentPreset) *RuntimeConfig {
 	rc := &RuntimeConfig{
 		Provider: string(info.Name),
 		Command:  info.Command,
-		Args:     append([]string(nil), info.Args...), // Copy to avoid mutation
+		Args:     append([]string(nil), info.Args...),
 		Env:      envCopy,
 	}
 
-	// Resolve command path for claude preset (handles alias installations)
-	// Uses resolveClaudePath() from types.go which finds ~/.claude/local/claude
 	if preset == AgentClaude && rc.Command == "claude" {
 		rc.Command = resolveClaudePath()
 	}

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -873,6 +873,21 @@ func TestLoadRigAgentRegistry(t *testing.T) {
 		if info.Command != "opencode" {
 			t.Errorf("expected opencode agent command to be 'opencode', got %s", info.Command)
 		}
+		if info.ConfigDir != ".opencode" {
+			t.Errorf("expected opencode ConfigDir to inherit '.opencode', got %q", info.ConfigDir)
+		}
+		if info.HooksDir != ".opencode/plugins" {
+			t.Errorf("expected opencode HooksDir to inherit '.opencode/plugins', got %q", info.HooksDir)
+		}
+		if info.HooksSettingsFile != "gastown.js" {
+			t.Errorf("expected opencode HooksSettingsFile to inherit 'gastown.js', got %q", info.HooksSettingsFile)
+		}
+		if len(info.ProcessNames) == 0 {
+			t.Errorf("expected opencode ProcessNames to remain populated after partial override")
+		}
+		if info.ReadyDelayMs != 8000 {
+			t.Errorf("expected opencode ReadyDelayMs to inherit 8000, got %d", info.ReadyDelayMs)
+		}
 	})
 
 	// Test 2: File not found should return nil (no error)

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1239,8 +1239,17 @@ func resolveAgentConfigWithOverrideInternal(townRoot, rigPath, agentOverride str
 	// If an override is requested, validate it exists
 	if agentOverride != "" {
 		var rc *RuntimeConfig
+		// For subcommand-style overrides (e.g. "opencode acp"), prefer the built-in
+		// preset when one exists. Town agent registry overrides often point at wrappers
+		// like gt-opencode, but ACP/subcommand invocations need the underlying runtime
+		// binary and built-in capability metadata.
+		if len(extraArgs) > 0 {
+			if preset, ok := builtinPresets[AgentPreset(agentName)]; ok {
+				rc = runtimeConfigFromAgentInfo(AgentPreset(agentName), preset)
+			}
+		}
 		// Check rig-level custom agents first
-		if rigSettings != nil && rigSettings.Agents != nil {
+		if rc == nil && rigSettings != nil && rigSettings.Agents != nil {
 			if custom, ok := rigSettings.Agents[agentName]; ok && custom != nil {
 				rc = fillRuntimeDefaults(custom)
 			}

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -1205,7 +1205,8 @@ func TestBuildCrewStartupCommand(t *testing.T) {
 }
 
 func TestResolveAgentConfigWithOverride(t *testing.T) {
-	t.Parallel()
+	ResetRegistryForTesting()
+	t.Cleanup(ResetRegistryForTesting)
 	townRoot := t.TempDir()
 	rigPath := filepath.Join(townRoot, "testrig")
 


### PR DESCRIPTION
## Summary
- preserve built-in OpenCode preset fields when settings/agents.json provides a partial override instead of replacing the whole preset
- keep ACP/subcommand resolution on the built-in runtime binary while still allowing wrapper-style town overrides for normal launches
- add regression coverage for inherited preset fields and override resolution behavior

## Validation
- go test ./internal/config
