### PR TITLE
fix: preserve polecat issue on session restart

### DIFF
--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/polecat"
@@ -269,6 +270,9 @@ func runSessionStart(cmd *cobra.Command, args []string) error {
 	opts := polecat.SessionStartOptions{
 		Issue: sessionIssue,
 	}
+	if opts.Issue == "" {
+		opts.Issue = recoverSessionIssue(rigName, polecatName, r)
+	}
 
 	fmt.Printf("Starting session for %s/%s...\n", rigName, polecatName)
 	if err := polecatMgr.Start(polecatName, opts); err != nil {
@@ -283,7 +287,7 @@ func runSessionStart(cmd *cobra.Command, args []string) error {
 	if townRoot, err := workspace.FindFromCwd(); err == nil && townRoot != "" {
 		agent := fmt.Sprintf("%s/%s", rigName, polecatName)
 		logger := townlog.NewLogger(townRoot)
-		_ = logger.Log(townlog.EventWake, agent, sessionIssue)
+		_ = logger.Log(townlog.EventWake, agent, opts.Issue)
 	}
 
 	return nil
@@ -510,10 +514,11 @@ func runSessionRestart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	polecatMgr, _, err := getSessionManager(rigName)
+	polecatMgr, r, err := getSessionManager(rigName)
 	if err != nil {
 		return err
 	}
+	restartIssue := recoverSessionIssue(rigName, polecatName, r)
 
 	// Check if running
 	running, err := polecatMgr.IsRunning(polecatName)
@@ -546,7 +551,7 @@ func runSessionRestart(cmd *cobra.Command, args []string) error {
 
 	// Start fresh session
 	fmt.Printf("Starting session for %s/%s...\n", rigName, polecatName)
-	opts := polecat.SessionStartOptions{}
+	opts := polecat.SessionStartOptions{Issue: restartIssue}
 	if err := polecatMgr.Start(polecatName, opts); err != nil {
 		return fmt.Errorf("starting session: %w", err)
 	}
@@ -555,6 +560,61 @@ func runSessionRestart(cmd *cobra.Command, args []string) error {
 		style.Bold.Render("✓"),
 		style.Dim.Render(fmt.Sprintf("gt session at %s/%s", rigName, polecatName)))
 	return nil
+}
+
+func selectSessionIssue(explicitIssue, polecatIssue, polecatBranch, agentHook string) string {
+	if explicitIssue != "" {
+		return explicitIssue
+	}
+	if polecatIssue != "" {
+		return polecatIssue
+	}
+	if issue := sessionBranchIssue(polecatBranch); issue != "" {
+		return issue
+	}
+	return agentHook
+}
+
+func sessionBranchIssue(branch string) string {
+	if !strings.HasPrefix(branch, "polecat/") {
+		return ""
+	}
+	return parseBranchName(branch).Issue
+}
+
+func recoverSessionIssue(rigName, polecatName string, r *rig.Rig) string {
+	var (
+		polecatIssue  string
+		polecatBranch string
+		polecatState  polecat.State
+		agentHook     string
+	)
+
+	if polecatMgr, _, err := getPolecatManager(rigName); err == nil {
+		if info, infoErr := polecatMgr.Get(polecatName); infoErr == nil && info != nil {
+			polecatIssue = info.Issue
+			polecatBranch = info.Branch
+			polecatState = info.State
+		}
+	}
+
+	if r != nil {
+		bd := beads.New(r.Path)
+		agentBeadID := polecatBeadIDForRig(r, rigName, polecatName)
+		if issue, fields, err := bd.GetAgentBead(agentBeadID); err == nil {
+			if fields != nil && fields.HookBead != "" {
+				agentHook = fields.HookBead
+			} else if issue != nil && issue.HookBead != "" {
+				agentHook = issue.HookBead
+			}
+		}
+	}
+
+	if polecatState == polecat.StateIdle {
+		agentHook = ""
+	}
+
+	return selectSessionIssue("", polecatIssue, polecatBranch, agentHook)
 }
 
 func runSessionStatus(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/session_test.go
+++ b/internal/cmd/session_test.go
@@ -78,3 +78,55 @@ func TestSessionInfoJSONOutputNotRunning(t *testing.T) {
 		t.Errorf("running = %v, want false", parsed["running"])
 	}
 }
+
+func TestSelectSessionIssue(t *testing.T) {
+	tests := []struct {
+		name          string
+		explicit      string
+		polecatIssue  string
+		polecatBranch string
+		agentHook     string
+		want          string
+	}{
+		{
+			name:          "explicit issue wins",
+			explicit:      "tg-explicit",
+			polecatIssue:  "tg-live",
+			polecatBranch: "polecat/furiosa/tg-branch@mk123",
+			agentHook:     "tg-hook",
+			want:          "tg-explicit",
+		},
+		{
+			name:          "active polecat issue wins over branch and hook",
+			polecatIssue:  "tg-live",
+			polecatBranch: "polecat/furiosa/tg-branch@mk123",
+			agentHook:     "tg-hook",
+			want:          "tg-live",
+		},
+		{
+			name:          "issue branch wins over stale hook",
+			polecatBranch: "polecat/furiosa/tg-branch@mk123",
+			agentHook:     "tg-stale",
+			want:          "tg-branch",
+		},
+		{
+			name:          "agent hook rescues base branch restart",
+			polecatBranch: "codex/gamejam-webgpu-rig",
+			agentHook:     "gj-er8.11",
+			want:          "gj-er8.11",
+		},
+		{
+			name: "empty when no source exists",
+			want: "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := selectSessionIssue(tt.explicit, tt.polecatIssue, tt.polecatBranch, tt.agentHook)
+			if got != tt.want {
+				t.Errorf("selectSessionIssue() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -186,64 +186,88 @@ func (m *SessionManager) freshBranchName(polecatName, issue string) string {
 	return fmt.Sprintf("polecat/%s-%s", polecatName, ts)
 }
 
-func (m *SessionManager) canonicalSessionStartPoint(g *git.Git) string {
-	defaultBranch := ""
-	if rigCfg, err := rig.LoadRigConfig(m.rig.Path); err == nil && rigCfg.DefaultBranch != "" {
-		defaultBranch = rigCfg.DefaultBranch
-	}
-	if defaultBranch == "" {
-		defaultBranch = g.RemoteDefaultBranch()
-	}
-	return fmt.Sprintf("origin/%s", defaultBranch)
+type freshBranchPlan struct {
+	Create     bool
+	StartPoint string
+	MergeBase  string
 }
 
-func shouldCreateFreshSessionBranch(currentBranch, issue, canonicalBranch string) bool {
-	if issue != "" && strings.Contains(currentBranch, "/"+issue+"@") {
-		return false
+func chooseFreshBranchPlan(currentBranch, configuredBaseBranch, rigDefaultBranch, remoteDefaultBranch string, refExists func(string) bool) freshBranchPlan {
+	currentBranch = strings.TrimSpace(currentBranch)
+	if currentBranch == "" || currentBranch == "HEAD" {
+		return freshBranchPlan{}
 	}
 
-	if currentBranch == canonicalBranch || currentBranch == "main" || currentBranch == "master" {
-		return true
+	isBaseBranch := false
+	for _, candidate := range []string{configuredBaseBranch, rigDefaultBranch, remoteDefaultBranch, "main", "master"} {
+		if candidate != "" && currentBranch == candidate {
+			isBaseBranch = true
+			break
+		}
+	}
+	if !isBaseBranch {
+		return freshBranchPlan{}
 	}
 
-	return issue != "" && strings.HasPrefix(currentBranch, "polecat/")
+	mergeBase := currentBranch
+	if configuredBaseBranch != "" {
+		mergeBase = configuredBaseBranch
+	}
+
+	startPoint := currentBranch
+	if refExists != nil && mergeBase != "" {
+		switch {
+		case refExists(mergeBase):
+			startPoint = mergeBase
+		case refExists("origin/" + mergeBase):
+			startPoint = "origin/" + mergeBase
+		}
+	}
+
+	return freshBranchPlan{
+		Create:     true,
+		StartPoint: startPoint,
+		MergeBase:  mergeBase,
+	}
 }
 
-func (m *SessionManager) ensureCanonicalSessionBranch(g *git.Git, polecat string, opts SessionStartOptions) string {
-	currentBranch, err := g.CurrentBranch()
-	if err != nil {
-		return ""
+func (m *SessionManager) planFreshBranch(g *git.Git, currentBranch string) freshBranchPlan {
+	if g == nil {
+		return freshBranchPlan{}
 	}
 
-	startPoint := m.canonicalSessionStartPoint(g)
-	canonicalBranch := strings.TrimPrefix(startPoint, "origin/")
-	if !shouldCreateFreshSessionBranch(currentBranch, opts.Issue, canonicalBranch) {
-		return currentBranch
+	configuredBaseBranch, _ := g.ConfigGet(fmt.Sprintf("branch.%s.gh-merge-base", currentBranch))
+	if configuredBaseBranch == "" {
+		configuredBaseBranch, _ = g.ConfigGet("thgames.default-base-branch")
 	}
 
-	// Refresh origin refs before branching so recovered sessions start from the
-	// canonical remote base instead of any preserved local polecat branch.
-	if err := g.Fetch("origin"); err != nil {
-		debugSession("fetch origin for canonical session branch", err)
+	return chooseFreshBranchPlan(
+		currentBranch,
+		configuredBaseBranch,
+		m.rig.DefaultBranch(),
+		g.RemoteDefaultBranch(),
+		func(ref string) bool {
+			exists, err := g.RefExists(ref)
+			return err == nil && exists
+		},
+	)
+}
+
+func setBranchMergeBase(workDir, branch, mergeBase string) error {
+	if workDir == "" || branch == "" || mergeBase == "" {
+		return nil
 	}
 
-	exists, err := g.RefExists(startPoint)
-	if err != nil {
-		debugSession("check canonical session start point", err)
-		return currentBranch
-	}
-	if !exists {
-		debugSession("missing canonical session start point", fmt.Errorf("%s", startPoint))
-		return currentBranch
-	}
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
 
-	newBranch := m.freshBranchName(polecat, opts.Issue)
-	if err := g.CheckoutNewBranch(newBranch, startPoint); err != nil {
-		debugSession("auto-checkout fresh branch on canonical base", err)
-		return currentBranch
+	cmd := exec.CommandContext(ctx, "git", "config", fmt.Sprintf("branch.%s.gh-merge-base", branch), mergeBase) //nolint:gosec // G204: git is a trusted internal tool
+	util.SetDetachedProcessGroup(cmd)
+	cmd.Dir = workDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git config branch.%s.gh-merge-base=%s: %w (%s)", branch, mergeBase, err, strings.TrimSpace(string(out)))
 	}
-
-	return newBranch
+	return nil
 }
 
 // hasPolecat checks if the polecat exists in this rig.
@@ -398,7 +422,23 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 	// branch detection and path resolution without a working directory.
 	polecatGitBranch := ""
 	if g := git.NewGit(workDir); g != nil {
-		polecatGitBranch = m.ensureCanonicalSessionBranch(g, polecat, opts)
+		if b, err := g.CurrentBranch(); err == nil {
+			polecatGitBranch = b
+			// Auto-checkout a fresh branch only when the worktree is sitting on a
+			// base branch (repo default branch, configured integration branch, etc.).
+			// This preserves existing issue branches across restarts instead of
+			// churning them into anonymous polecat/<name>-<timestamp> branches.
+			if plan := m.planFreshBranch(g, polecatGitBranch); plan.Create {
+				newBranch := m.freshBranchName(polecat, opts.Issue)
+				if err := g.CheckoutNewBranch(newBranch, plan.StartPoint); err != nil {
+					// Non-fatal: PRIME.md guard remains as a fallback; log for debugging.
+					debugSession("auto-checkout fresh branch on default", err)
+				} else {
+					debugSession("set gh-merge-base on fresh branch", setBranchMergeBase(workDir, newBranch, plan.MergeBase))
+					polecatGitBranch = newBranch
+				}
+			}
+		}
 	}
 	// Generate the GASTA run ID — the root identifier for all telemetry emitted
 	// by this polecat session and its subprocesses (bd, mail, …).

--- a/internal/polecat/session_manager_test.go
+++ b/internal/polecat/session_manager_test.go
@@ -336,42 +336,29 @@ func TestPolecatStartInjectsFallbackEnvVars(t *testing.T) {
 	}
 }
 
-func TestEnsureCanonicalSessionBranch_UsesOriginDefaultBranch(t *testing.T) {
+func TestPlanFreshBranch_BaseBranchCreatesIssueBranch(t *testing.T) {
 	workDir, repoGit := setupSessionBranchTestRepo(t)
 
-	baseSHA, err := repoGit.Rev("origin/main")
+	baseSHA, err := repoGit.Rev("main")
 	if err != nil {
-		t.Fatalf("resolve origin/main: %v", err)
-	}
-	if err := repoGit.CheckoutNewBranch("polecat/toast-old", "main"); err != nil {
-		t.Fatalf("checkout stale polecat branch: %v", err)
-	}
-	if err := os.WriteFile(filepath.Join(workDir, "stale.txt"), []byte("stale\n"), 0644); err != nil {
-		t.Fatalf("write stale.txt: %v", err)
-	}
-	if err := repoGit.Add("stale.txt"); err != nil {
-		t.Fatalf("git add stale.txt: %v", err)
-	}
-	if err := repoGit.Commit("stale local polecat commit"); err != nil {
-		t.Fatalf("git commit stale.txt: %v", err)
-	}
-	staleSHA, err := repoGit.Rev("HEAD")
-	if err != nil {
-		t.Fatalf("resolve stale HEAD: %v", err)
+		t.Fatalf("resolve main: %v", err)
 	}
 
 	sm := NewSessionManager(tmux.NewTmux(), &rig.Rig{Name: "gastown", Path: workDir})
-	branch := sm.ensureCanonicalSessionBranch(repoGit, "toast", SessionStartOptions{Issue: "gt-9qb"})
+	plan := sm.planFreshBranch(repoGit, "main")
+	if !plan.Create {
+		t.Fatalf("plan.Create = false, want true for base branch")
+	}
+
+	branch := sm.freshBranchName("toast", "gt-9qb")
 	if !strings.Contains(branch, "/gt-9qb@") {
 		t.Fatalf("fresh session branch = %q, want issue-scoped branch", branch)
 	}
-
-	staleAncestor, err := repoGit.IsAncestor(staleSHA, branch)
-	if err != nil {
-		t.Fatalf("check stale ancestry: %v", err)
+	if err := repoGit.CheckoutNewBranch(branch, plan.StartPoint); err != nil {
+		t.Fatalf("checkout fresh branch: %v", err)
 	}
-	if staleAncestor {
-		t.Fatalf("fresh session branch %q unexpectedly includes stale local commit %s", branch, staleSHA)
+	if err := setBranchMergeBase(workDir, branch, plan.MergeBase); err != nil {
+		t.Fatalf("set merge base: %v", err)
 	}
 
 	baseAncestor, err := repoGit.IsAncestor(baseSHA, branch)
@@ -379,11 +366,18 @@ func TestEnsureCanonicalSessionBranch_UsesOriginDefaultBranch(t *testing.T) {
 		t.Fatalf("check canonical ancestry: %v", err)
 	}
 	if !baseAncestor {
-		t.Fatalf("fresh session branch %q should descend from origin/main commit %s", branch, baseSHA)
+		t.Fatalf("fresh session branch %q should descend from main commit %s", branch, baseSHA)
+	}
+	mergeBase, err := repoGit.ConfigGet("branch." + branch + ".gh-merge-base")
+	if err != nil {
+		t.Fatalf("get merge base config: %v", err)
+	}
+	if mergeBase != "main" {
+		t.Fatalf("merge base = %q, want main", mergeBase)
 	}
 }
 
-func TestEnsureCanonicalSessionBranch_KeepsCurrentIssueBranch(t *testing.T) {
+func TestPlanFreshBranch_KeepsCurrentIssueBranch(t *testing.T) {
 	workDir, repoGit := setupSessionBranchTestRepo(t)
 
 	currentBranch := "polecat/toast/gt-9qb@seed"
@@ -392,9 +386,9 @@ func TestEnsureCanonicalSessionBranch_KeepsCurrentIssueBranch(t *testing.T) {
 	}
 
 	sm := NewSessionManager(tmux.NewTmux(), &rig.Rig{Name: "gastown", Path: workDir})
-	branch := sm.ensureCanonicalSessionBranch(repoGit, "toast", SessionStartOptions{Issue: "gt-9qb"})
-	if branch != currentBranch {
-		t.Fatalf("ensureCanonicalSessionBranch changed active issue branch: got %q want %q", branch, currentBranch)
+	plan := sm.planFreshBranch(repoGit, currentBranch)
+	if plan.Create {
+		t.Fatalf("planFreshBranch wants fresh branch for active issue branch %q: %#v", currentBranch, plan)
 	}
 }
 
@@ -529,6 +523,101 @@ func TestAgentEnvOmitsGTAgent_FallbackRequired(t *testing.T) {
 			if hasGTAgent != tc.wantGTAgent {
 				t.Errorf("AgentEnv(Agent=%q): GT_AGENT present=%v, want %v",
 					tc.agent, hasGTAgent, tc.wantGTAgent)
+			}
+		})
+	}
+}
+
+func TestChooseFreshBranchPlan(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name           string
+		currentBranch  string
+		configuredBase string
+		rigDefault     string
+		remoteDefault  string
+		existingRefs   map[string]bool
+		wantCreate     bool
+		wantStartPoint string
+		wantMergeBase  string
+	}{
+		{
+			name:           "issue branch is preserved",
+			currentBranch:  "polecat/furiosa/gj-er8.11@mk123",
+			configuredBase: "codex/gamejam-webgpu-rig",
+			rigDefault:     "main",
+			remoteDefault:  "main",
+			wantCreate:     false,
+		},
+		{
+			name:           "configured integration branch creates fresh issue branch",
+			currentBranch:  "codex/gamejam-webgpu-rig",
+			configuredBase: "codex/gamejam-webgpu-rig",
+			rigDefault:     "main",
+			remoteDefault:  "main",
+			existingRefs: map[string]bool{
+				"codex/gamejam-webgpu-rig": true,
+			},
+			wantCreate:     true,
+			wantStartPoint: "codex/gamejam-webgpu-rig",
+			wantMergeBase:  "codex/gamejam-webgpu-rig",
+		},
+		{
+			name:           "main falls back to configured base when ref exists remotely",
+			currentBranch:  "main",
+			configuredBase: "codex/gamejam-webgpu-rig",
+			rigDefault:     "main",
+			remoteDefault:  "main",
+			existingRefs: map[string]bool{
+				"origin/codex/gamejam-webgpu-rig": true,
+			},
+			wantCreate:     true,
+			wantStartPoint: "origin/codex/gamejam-webgpu-rig",
+			wantMergeBase:  "codex/gamejam-webgpu-rig",
+		},
+		{
+			name:           "main still records configured merge base when ref is missing",
+			currentBranch:  "main",
+			configuredBase: "codex/gamejam-webgpu-rig",
+			rigDefault:     "main",
+			remoteDefault:  "main",
+			wantCreate:     true,
+			wantStartPoint: "main",
+			wantMergeBase:  "codex/gamejam-webgpu-rig",
+		},
+		{
+			name:          "plain default branch keeps itself as merge base",
+			currentBranch: "main",
+			rigDefault:    "main",
+			remoteDefault: "main",
+			existingRefs: map[string]bool{
+				"main": true,
+			},
+			wantCreate:     true,
+			wantStartPoint: "main",
+			wantMergeBase:  "main",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			plan := chooseFreshBranchPlan(
+				tt.currentBranch,
+				tt.configuredBase,
+				tt.rigDefault,
+				tt.remoteDefault,
+				func(ref string) bool { return tt.existingRefs[ref] },
+			)
+
+			if plan.Create != tt.wantCreate {
+				t.Fatalf("Create = %v, want %v", plan.Create, tt.wantCreate)
+			}
+			if plan.StartPoint != tt.wantStartPoint {
+				t.Errorf("StartPoint = %q, want %q", plan.StartPoint, tt.wantStartPoint)
+			}
+			if plan.MergeBase != tt.wantMergeBase {
+				t.Errorf("MergeBase = %q, want %q", plan.MergeBase, tt.wantMergeBase)
 			}
 		})
 	}


### PR DESCRIPTION
## Summary
- Recover a polecat session issue when `gt session start` or `gt session restart` is called without an explicit issue.
- Prefer the active polecat issue, then an issue-scoped polecat branch, then the agent hook bead.
- Pass the recovered issue into session start/restart and log the recovered issue in wake events.

## Why
This is the focused version of the sentifold fix. Restarting a polecat should not silently lose the work item it was already attached to. Keeping the issue identity lets the existing upstream session branch logic make the right choice without introducing a broader branch-planning refactor in this PR.

## Tests
- `go test ./internal/cmd -run TestSelectSessionIssue`