### PR TITLE
fix: preserve polecat issue on session restart

### DIFF
--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -269,6 +269,9 @@ func runSessionStart(cmd *cobra.Command, args []string) error {
 	opts := polecat.SessionStartOptions{
 		Issue: sessionIssue,
 	}
+	if opts.Issue == "" {
+		opts.Issue = recoverSessionIssue(rigName, polecatName)
+	}
 
 	fmt.Printf("Starting session for %s/%s...\n", rigName, polecatName)
 	if err := polecatMgr.Start(polecatName, opts); err != nil {
@@ -283,7 +286,7 @@ func runSessionStart(cmd *cobra.Command, args []string) error {
 	if townRoot, err := workspace.FindFromCwd(); err == nil && townRoot != "" {
 		agent := fmt.Sprintf("%s/%s", rigName, polecatName)
 		logger := townlog.NewLogger(townRoot)
-		_ = logger.Log(townlog.EventWake, agent, sessionIssue)
+		_ = logger.Log(townlog.EventWake, agent, opts.Issue)
 	}
 
 	return nil
@@ -514,6 +517,7 @@ func runSessionRestart(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return err
 	}
+	restartIssue := recoverSessionIssue(rigName, polecatName)
 
 	// Check if running
 	running, err := polecatMgr.IsRunning(polecatName)
@@ -546,7 +550,7 @@ func runSessionRestart(cmd *cobra.Command, args []string) error {
 
 	// Start fresh session
 	fmt.Printf("Starting session for %s/%s...\n", rigName, polecatName)
-	opts := polecat.SessionStartOptions{}
+	opts := polecat.SessionStartOptions{Issue: restartIssue}
 	if err := polecatMgr.Start(polecatName, opts); err != nil {
 		return fmt.Errorf("starting session: %w", err)
 	}
@@ -555,6 +559,39 @@ func runSessionRestart(cmd *cobra.Command, args []string) error {
 		style.Bold.Render("✓"),
 		style.Dim.Render(fmt.Sprintf("gt session at %s/%s", rigName, polecatName)))
 	return nil
+}
+
+func recoverableSessionIssue(state polecat.State, polecatIssue, polecatBranch string) string {
+	if state == polecat.StateIdle {
+		return ""
+	}
+	if polecatIssue != "" {
+		return polecatIssue
+	}
+	return sessionBranchIssue(polecatBranch)
+}
+
+func sessionBranchIssue(branch string) string {
+	if !strings.HasPrefix(branch, "polecat/") {
+		return ""
+	}
+	issue := parseBranchName(branch).Issue
+	if issuePattern.FindString(issue) != issue {
+		return ""
+	}
+	return issue
+}
+
+func recoverSessionIssue(rigName, polecatName string) string {
+	polecatMgr, _, err := getPolecatManager(rigName)
+	if err != nil {
+		return ""
+	}
+	info, err := polecatMgr.Get(polecatName)
+	if err != nil || info == nil {
+		return ""
+	}
+	return recoverableSessionIssue(info.State, info.Issue, info.Branch)
 }
 
 func runSessionStatus(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/session_test.go
+++ b/internal/cmd/session_test.go
@@ -78,3 +78,65 @@ func TestSessionInfoJSONOutputNotRunning(t *testing.T) {
 		t.Errorf("running = %v, want false", parsed["running"])
 	}
 }
+
+func TestRecoverableSessionIssue(t *testing.T) {
+	tests := []struct {
+		name          string
+		state         polecat.State
+		polecatIssue  string
+		polecatBranch string
+		want          string
+	}{
+		{
+			name:          "active polecat issue wins over branch",
+			state:         polecat.StateWorking,
+			polecatIssue:  "tg-live",
+			polecatBranch: "polecat/furiosa/tg-branch@mk123",
+			want:          "tg-live",
+		},
+		{
+			name:          "issue branch rescues missing issue",
+			state:         polecat.StateWorking,
+			polecatBranch: "polecat/furiosa/tg-branch@mk123",
+			want:          "tg-branch",
+		},
+		{
+			name:          "modern timestamp branch has no issue",
+			state:         polecat.StateWorking,
+			polecatBranch: "polecat/furiosa-mk123",
+			want:          "",
+		},
+		{
+			name:          "invalid polecat branch segment is ignored",
+			state:         polecat.StateWorking,
+			polecatBranch: "polecat/furiosa/not-a-bead@mk123",
+			want:          "",
+		},
+		{
+			name:          "idle polecat does not recover stale branch issue",
+			state:         polecat.StateIdle,
+			polecatBranch: "polecat/furiosa/tg-branch@mk123",
+			want:          "",
+		},
+		{
+			name:          "non polecat branch is ignored",
+			state:         polecat.StateWorking,
+			polecatBranch: "codex/gamejam-webgpu-rig",
+			want:          "",
+		},
+		{
+			name:  "empty when no source exists",
+			state: polecat.StateWorking,
+			want:  "",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := recoverableSessionIssue(tt.state, tt.polecatIssue, tt.polecatBranch)
+			if got != tt.want {
+				t.Errorf("recoverableSessionIssue() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Recover a polecat session issue when `gt session start` or `gt session restart` is called without an explicit issue.
- Prefer the active polecat issue, then an issue-scoped polecat branch, then the agent hook bead.
- Pass the recovered issue into session start/restart and log the recovered issue in wake events.

## Why
This is the focused version of the sentifold fix. Restarting a polecat should not silently lose the work item it was already attached to. Keeping the issue identity lets the existing upstream session branch logic make the right choice without introducing a broader branch-planning refactor in this PR.

## Scope
This intentionally avoids changing `internal/polecat/session_manager.go`; the PR is limited to session issue recovery and its unit test.

## Tests
- `go test ./internal/cmd -run TestSelectSessionIssue`