### PR TITLE
fix(formula,compact): call bd comments add instead of bd comment

### DIFF
--- a/internal/cmd/compact.go
+++ b/internal/cmd/compact.go
@@ -361,7 +361,7 @@ func promoteWisp(bd *beads.Beads, w *compactIssue, reason string, result *compac
 	}
 
 	// Add comment noting the promotion
-	_, _ = bd.Run("comment", w.ID, fmt.Sprintf("Promoted from Level 0: %s", reason))
+	_, _ = bd.Run("comments", "add", w.ID, fmt.Sprintf("Promoted from Level 0: %s", reason))
 
 	result.Promoted = append(result.Promoted, action)
 

--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -706,7 +706,7 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 			fmt.Printf("%s Failed to sling leg %s: %v\n",
 				style.Dim.Render("Warning:"), leg.ID, err)
 			// Add comment to bead about failure
-			commentArgs := []string{"comment", legBeadID, fmt.Sprintf("Failed to sling: %v", err)}
+			commentArgs := []string{"comments", "add", legBeadID, fmt.Sprintf("Failed to sling: %v", err)}
 			commentCmd := exec.Command("bd", commentArgs...)
 			commentCmd.Dir = townBeads
 			_ = commentCmd.Run()
@@ -920,7 +920,7 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 		if err := slingCmd.Run(); err != nil {
 			fmt.Printf("%s Failed to sling step %s: %v\n",
 				style.Dim.Render("Warning:"), step.ID, err)
-			_ = BdCmd("comment", stepBeadID, fmt.Sprintf("Failed to sling: %v", err)).
+			_ = BdCmd("comments", "add", stepBeadID, fmt.Sprintf("Failed to sling: %v", err)).
 				Dir(townBeads).
 				Run()
 			continue


### PR DESCRIPTION
## Summary

Three callsites in the formula dispatcher and compactor invoke `bd comment <issue> <text>`, but the `bd` CLI has no `comment` command — the correct leaf is `bd comments add <issue> <text>`. At runtime these calls fail with `unknown command comment for bd`, blocking formula-based patrol dispatch (`mol-deacon-patrol` dispatches 0/N steps).

## Changes

- `internal/cmd/formula.go:709` (leg dispatcher) — `"comment"` → `"comments", "add"`
- `internal/cmd/formula.go:923` (step dispatcher) — `"comment"` → `"comments", "add"`
- `internal/cmd/compact.go:364` (wisp promotion annotation) — `"comment"` → `"comments", "add"`

## Why this is safe

The corrected form is already the convention elsewhere in this codebase:

- `internal/cmd/done.go:1140` — `bd.Run("comments", "add", issueID, comment)`
- `internal/cmd/mq_submit.go:293` — `bd.Run("comments", "add", issueID, comment)`

So this PR brings the three broken callsites in line with existing correct ones, no new convention.

## Repro (before fix)

```
gt formula run mol-deacon-patrol
# Convoy created but 0/26 steps dispatched
# Each step fails: "unknown command comment for bd"
```

## Test plan

- [x] `go build ./internal/cmd/...` clean
- [ ] `gt formula run mol-deacon-patrol` dispatches all steps (verify in deployment)

Reported by a deacon agent (`hq-wisp-hrmzd`) after a `mol-deacon-patrol` convoy (`hq-wf-ipjqu`) dispatched 0/26 steps.
