### PR TITLE
fix(sling): restore WithAutoCommit on hook writes to prevent DEFERRED polecats

### DIFF
--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -362,9 +362,18 @@ func storeFieldsInBead(beadID string, updates beadFieldUpdates) error {
 		return nil
 	}
 
+	// WithAutoCommit ensures the description (containing attached_molecule,
+	// attached_vars, dispatcher, etc.) is immediately visible to new Dolt
+	// connections — specifically the freshly-spawned polecat whose `gt prime`
+	// reads these fields. Without the explicit commit, the polecat can see
+	// the bead as hooked but without its molecule attachment, producing a
+	// degraded work hand-off. runSling globally sets BD_DOLT_AUTO_COMMIT=off
+	// for manifest-contention avoidance (gt-u6n6a); this call opts back in
+	// because visibility is load-bearing here. See hq-8xl.
 	if err := BdCmd("update", beadID, "--description="+newDesc).
 		Dir(resolveBeadDir(beadID)).
 		StripBeadsDir().
+		WithAutoCommit().
 		Run(); err != nil {
 		return fmt.Errorf("updating bead description: %w", err)
 	}
@@ -995,6 +1004,15 @@ func isHookedAgentDead(assignee string) bool {
 // and post-hook verification. This ensures the hook sticks even under Dolt concurrency.
 // Fails fast on configuration/initialization errors (gt-2ra).
 // See: https://github.com/steveyegge/gastown/issues/148
+//
+// The hook write uses .WithAutoCommit() to force an explicit Dolt commit on the
+// status=hooked + assignee write. runSling globally sets BD_DOLT_AUTO_COMMIT=off
+// (gt-u6n6a) to avoid manifest contention under batch load, but the hook write
+// is the one bd write that MUST be immediately visible to new connections —
+// specifically, the freshly-spawned polecat whose `gt prime --hook` queries
+// status=hooked+assignee on a new Dolt session. Without the explicit commit,
+// that query races the write and the polecat exits DEFERRED with an empty hook.
+// See hq-8xl (GH#2389 regressed by PR #2517/dc1d11db).
 func hookBeadWithRetry(beadID, targetAgent, hookDir string) error {
 	const maxRetries = 10
 	const baseBackoff = 500 * time.Millisecond
@@ -1005,6 +1023,7 @@ func hookBeadWithRetry(beadID, targetAgent, hookDir string) error {
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		err := BdCmd("update", beadID, "--status=hooked", "--assignee="+targetAgent).
 			Dir(hookDir).
+			WithAutoCommit().
 			Run()
 		if err != nil {
 			lastErr = err

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -1734,9 +1734,15 @@ exit /b 0
 		if line == "" {
 			continue
 		}
-		// Commands using .WithAutoCommit() (e.g., "update --status=hooked")
-		// legitimately override to "on" for sequential consistency.
+		// Commands using .WithAutoCommit() legitimately override to "on" for
+		// cross-connection visibility to the freshly-spawned polecat:
+		//   - update --status=hooked : sets hook state (hookBeadWithRetry)
+		//   - update --description=  : sets attachment fields (storeFieldsInBead)
+		// See hq-8xl for the regression history.
 		if strings.Contains(line, "update") && strings.Contains(line, "--status=hooked") {
+			continue
+		}
+		if strings.Contains(line, "update") && strings.Contains(line, "--description=") {
 			continue
 		}
 		if !strings.Contains(line, "ENV:BD_DOLT_AUTO_COMMIT=off|") {


### PR DESCRIPTION
## Summary

Fixes a race where freshly-spawned polecats exit DEFERRED with an empty hook, even though `gt sling` reports success and the bead shows `status=hooked` + correct assignee.

PR #2517 (commit dc1d11db) removed `WithAutoCommit()` from `hookBeadWithRetry` to satisfy `TestSlingSetsDoltAutoCommitOff` — but this regressed the exact race GH#2389 / commit 60743cb3 was introduced to fix.

`runSling` globally sets `BD_DOLT_AUTO_COMMIT=off` (gt-u6n6a) to avoid manifest contention under batch load. That's the correct default for bulk writes. But it silently disabled the explicit Dolt commit on the ONE write the freshly-spawned polecat absolutely must see: the `status=hooked` + `assignee` update. Without that commit, the polecat's first `gt prime --hook` opens a new Dolt connection that races the uncommitted write and sees an empty hook → polecat exits DEFERRED with `started with empty hook and empty inbox`.

Reported repro (hq-8xl, racecadence):
- Polecat spawns ~1s AFTER molecule is attached to the bead
- `gt mol status` inside the polecat returns empty hook
- Up to 6 consecutive DEFERREDs on the same identity, including after re-sling to a fresh bead
- Witness: `started with empty hook and empty inbox`

## Fix

1. Restore `.WithAutoCommit()` on the `status=hooked`+`assignee` write in `hookBeadWithRetry` (the load-bearing cross-connection write).
2. Add `.WithAutoCommit()` to the description write in `storeFieldsInBead` so the polecat also sees `attached_molecule` / `attached_vars` on its first read — otherwise a polecat that survives the hook race could still miss its formula workflow.
3. Update `TestSlingSetsDoltAutoCommitOff`'s carve-out to also allow `update --description=` in addition to `update --status=hooked`. The test's intent is to prevent accidental commits on bulk / incidental writes, not to block deliberate visibility writes the polecat depends on.

These two writes happen once per sling (serialized, not batched) so they do NOT contribute to the manifest-contention scenario that gt-u6n6a was protecting against.

## Why this matters

Dispatch reliability is load-bearing for any Gas Town workflow. With this regression live, every `gt sling` is a coin-flip on whether the polecat actually picks up the work.

## Test plan

- [x] `go test ./internal/cmd/...` passes (14s, including `TestSlingSetsDoltAutoCommitOff`)
- [x] `go build ./...` clean
- [x] Binary builds and reports version
- [ ] Live sling test on real rig (not yet attempted — deferred to avoid disrupting live system)

🤖 Generated with [Claude Code](https://claude.com/claude-code)