### PR TITLE
fix(doltserver): use server connection for remaining DDL call sites (fixes #3641)

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1961,7 +1961,9 @@ func listDatabasesRemote(config *Config) ([]string, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 
-	cmd := buildDoltSQLCmd(ctx, config, "-r", "json", "-q", "SHOW DATABASES")
+	// SHOW DATABASES is catalog-scoped; must query the running server's in-memory
+	// catalog, not dolt's embedded-mode filesystem view (see #3518 for precedent).
+	cmd := buildServerSQLCmd(ctx, config, "-r", "json", "-q", "SHOW DATABASES")
 
 	var stderrBuf bytes.Buffer
 	cmd.Stderr = &stderrBuf
@@ -2089,7 +2091,9 @@ func verifyDatabasesWithRetry(townRoot string, maxAttempts int) (served, missing
 		}
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		cmd := buildDoltSQLCmd(ctx, config,
+		// SHOW DATABASES is catalog-scoped; embedded mode sees the on-disk catalog
+		// rather than the running server's, which is the exact bug #3518/#3641 fix.
+		cmd := buildServerSQLCmd(ctx, config,
 			"-r", "json",
 			"-q", "SHOW DATABASES",
 		)
@@ -2818,7 +2822,9 @@ func databaseHasUserTables(townRoot, dbName string) (bool, error) {
 	defer cancel()
 
 	query := fmt.Sprintf("USE `%s`; SHOW TABLES", dbName)
-	cmd := buildDoltSQLCmd(ctx, config, "-r", "csv", "-q", query)
+	// USE <db>; SHOW TABLES needs the running server's catalog to resolve <db>;
+	// embedded mode would only see the on-disk layout (see #3518 for precedent).
+	cmd := buildServerSQLCmd(ctx, config, "-r", "csv", "-q", query)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return false, err
@@ -3532,7 +3538,9 @@ func CheckReadOnly(townRoot string) (bool, error) {
 		"USE `%s`; CREATE TABLE IF NOT EXISTS `__gt_health_probe` (v INT PRIMARY KEY); REPLACE INTO `__gt_health_probe` VALUES (1); DROP TABLE IF EXISTS `__gt_health_probe`",
 		db,
 	)
-	cmd := buildDoltSQLCmd(ctx, config, "-q", query)
+	// DDL probe (CREATE/REPLACE/DROP) must land on the running server; embedded
+	// mode would mutate disk without notifying the live catalog (#3518/#3641).
+	cmd := buildServerSQLCmd(ctx, config, "-q", query)
 
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -4007,7 +4015,11 @@ func doltSQLScript(townRoot, script string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancel()
 
-	cmd := buildDoltSQLCmd(ctx, config, "--file", tmpFile.Name())
+	// Scripts typically contain DDL (CREATE TABLE, etc.) for rig workload schemas;
+	// they must execute against the running server's catalog, not embedded-mode
+	// disk-only state. This is the root cause of #3641 — MR-bead script ran
+	// embedded, so later INSERTs over port 3307 hit "no database selected".
+	cmd := buildServerSQLCmd(ctx, config, "--file", tmpFile.Name())
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return fmt.Errorf("%w (output: %s)", err, strings.TrimSpace(string(output)))


### PR DESCRIPTION
## Summary
Fixes #3641 — `gt done` MR-bead creation failed because DDL ran in embedded mode; the server never saw the schema and subsequent inserts over port 3307 hit "no database selected".

Applies the same treatment as the already-merged #3518 to the remaining `buildDoltSQLCmd` DDL call sites in `internal/doltserver/doltserver.go`.

## Changes
- `internal/doltserver/doltserver.go:1964` `listDatabasesRemote` — `SHOW DATABASES` (catalog-scoped) → `buildServerSQLCmd`
- `internal/doltserver/doltserver.go:2092` `verifyDatabasesWithRetry` — `SHOW DATABASES` (catalog-scoped) → `buildServerSQLCmd`
- `internal/doltserver/doltserver.go:2821` `databaseHasUserTables` — `USE <db>; SHOW TABLES` (catalog-scoped) → `buildServerSQLCmd`
- `internal/doltserver/doltserver.go:3535` `CheckReadOnly` — `USE; CREATE/REPLACE/DROP TABLE` (DDL probe) → `buildServerSQLCmd`
- `internal/doltserver/doltserver.go:4010` `doltSQLScript` — multi-statement script runner; callers in `wl_commons.go`/`wl_charsheet.go` run `CREATE TABLE` DDL → `buildServerSQLCmd` (root cause of #3641)

Sites kept on `buildDoltSQLCmd`: none. `buildDoltSQLCmd` itself is preserved unchanged (no signature or body edits) for any future legitimately-embedded use.

## Test plan
- [x] `go build ./...` clean
- [x] `go test ./internal/doltserver/...` — all pass (no pre-existing `FindBrokenWorkspaces` env failures surfaced on this branch/env)
- [x] `go test ./internal/rig/...` — all pass
- [ ] End-to-end `gt done` from a polecat worktree creates MR bead without "no database selected" (hard to reproduce in CI; leave unchecked for reviewer)

Precedent: #3518.