### PR TITLE
fix(polecat): replace branch-name string heuristics with structural parse (follow-up to #3629)

### DIFF
--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -178,12 +178,53 @@ func (m *SessionManager) clonePath(polecat string) string {
 // Mirrors the naming convention in Manager.buildBranchName:
 //   - polecat/<name>/<issue>@<timestamp> when an issue is known
 //   - polecat/<name>-<timestamp> otherwise
+//
+// parseFreshBranchName is the structural inverse.
 func (m *SessionManager) freshBranchName(polecatName, issue string) string {
 	ts := strconv.FormatInt(time.Now().UnixMilli(), 36)
 	if issue != "" {
 		return fmt.Sprintf("polecat/%s/%s@%s", polecatName, issue, ts)
 	}
 	return fmt.Sprintf("polecat/%s-%s", polecatName, ts)
+}
+
+// freshBranchMeta holds the identity decoded from a branch produced by
+// freshBranchName. ok=false means the branch does not match either format.
+type freshBranchMeta struct {
+	polecat string
+	issue   string // empty when the branch has no issue binding
+	ok      bool
+}
+
+// parseFreshBranchName is the structural inverse of freshBranchName. It
+// does not consult git or the filesystem; it recognises the two formats
+// the formatter emits. Used in place of substring heuristics so that
+// branch-naming changes can be made in a single place.
+func parseFreshBranchName(branch string) freshBranchMeta {
+	const prefix = "polecat/"
+	if !strings.HasPrefix(branch, prefix) {
+		return freshBranchMeta{}
+	}
+	rest := branch[len(prefix):]
+	if slash := strings.Index(rest, "/"); slash >= 0 {
+		// polecat/<name>/<issue>@<ts>
+		if slash == 0 {
+			return freshBranchMeta{}
+		}
+		name := rest[:slash]
+		tail := rest[slash+1:]
+		at := strings.LastIndex(tail, "@")
+		if at <= 0 || at == len(tail)-1 {
+			return freshBranchMeta{}
+		}
+		return freshBranchMeta{polecat: name, issue: tail[:at], ok: true}
+	}
+	// polecat/<name>-<ts> (no slash in rest)
+	dash := strings.LastIndex(rest, "-")
+	if dash <= 0 || dash == len(rest)-1 {
+		return freshBranchMeta{}
+	}
+	return freshBranchMeta{polecat: rest[:dash], ok: true}
 }
 
 func (m *SessionManager) canonicalSessionStartPoint(g *git.Git) string {
@@ -194,19 +235,34 @@ func (m *SessionManager) canonicalSessionStartPoint(g *git.Git) string {
 	if defaultBranch == "" {
 		defaultBranch = g.RemoteDefaultBranch()
 	}
+	if defaultBranch == "" {
+		return ""
+	}
 	return fmt.Sprintf("origin/%s", defaultBranch)
 }
 
+// shouldCreateFreshSessionBranch decides whether the session manager should
+// replace the worktree's current branch with a new polecat branch based on
+// the canonical remote base. Decisions are made from structured data —
+// parseFreshBranchName output and the computed canonical branch — not from
+// substring heuristics on the branch name.
 func shouldCreateFreshSessionBranch(currentBranch, issue, canonicalBranch string) bool {
-	if issue != "" && strings.Contains(currentBranch, "/"+issue+"@") {
+	meta := parseFreshBranchName(currentBranch)
+
+	// Same-issue respawn: keep the existing polecat branch so preserved work
+	// for this issue isn't discarded.
+	if meta.ok && issue != "" && meta.issue == issue {
 		return false
 	}
 
-	if currentBranch == canonicalBranch || currentBranch == "main" || currentBranch == "master" {
+	// On the canonical base branch — need a fresh polecat branch to work on.
+	if canonicalBranch != "" && currentBranch == canonicalBranch {
 		return true
 	}
 
-	return issue != "" && strings.HasPrefix(currentBranch, "polecat/")
+	// On some other polecat branch belonging to a different issue — fresh
+	// branch is safer than inheriting unrelated preserved history.
+	return issue != "" && meta.ok
 }
 
 func (m *SessionManager) ensureCanonicalSessionBranch(g *git.Git, polecat string, opts SessionStartOptions) string {
@@ -216,6 +272,10 @@ func (m *SessionManager) ensureCanonicalSessionBranch(g *git.Git, polecat string
 	}
 
 	startPoint := m.canonicalSessionStartPoint(g)
+	if startPoint == "" {
+		debugSession("canonical session start point unresolved", fmt.Errorf("no default branch in rig config or remote"))
+		return currentBranch
+	}
 	canonicalBranch := strings.TrimPrefix(startPoint, "origin/")
 	if !shouldCreateFreshSessionBranch(currentBranch, opts.Issue, canonicalBranch) {
 		return currentBranch

--- a/internal/polecat/session_manager_test.go
+++ b/internal/polecat/session_manager_test.go
@@ -742,3 +742,111 @@ func TestPolecatSlot(t *testing.T) {
 		t.Errorf("with hidden dir: polecatSlot(beta) = %d, want 1", slot)
 	}
 }
+
+func TestParseFreshBranchName_RoundTrip(t *testing.T) {
+	sm := &SessionManager{}
+
+	cases := []struct {
+		name    string
+		polecat string
+		issue   string
+	}{
+		{name: "with issue", polecat: "alpha", issue: "gt-abc"},
+		{name: "no issue", polecat: "beta", issue: ""},
+		{name: "numeric issue", polecat: "nux", issue: "gt-123"},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			branch := sm.freshBranchName(c.polecat, c.issue)
+			meta := parseFreshBranchName(branch)
+			if !meta.ok {
+				t.Fatalf("parseFreshBranchName(%q) not ok", branch)
+			}
+			if meta.polecat != c.polecat {
+				t.Errorf("polecat = %q, want %q (from %q)", meta.polecat, c.polecat, branch)
+			}
+			if meta.issue != c.issue {
+				t.Errorf("issue = %q, want %q (from %q)", meta.issue, c.issue, branch)
+			}
+		})
+	}
+}
+
+func TestParseFreshBranchName_Rejects(t *testing.T) {
+	rejects := []string{
+		"main",
+		"master",
+		"develop",
+		"feature/x",
+		"polecat/",          // empty tail
+		"polecat/alpha",     // no ts or issue
+		"polecat/alpha-",    // trailing dash, no ts
+		"polecat//gt-abc@1", // empty polecat name
+		"polecat/alpha/@1",  // empty issue
+		"polecat/alpha/gt-abc@", // empty ts
+		"",
+	}
+	for _, b := range rejects {
+		if meta := parseFreshBranchName(b); meta.ok {
+			t.Errorf("parseFreshBranchName(%q) = %+v, want ok=false", b, meta)
+		}
+	}
+}
+
+func TestShouldCreateFreshSessionBranch_Structural(t *testing.T) {
+	// Non-standard canonical branch (e.g., "develop") — must be honored even
+	// though the old string-heuristic hardcoded "main"/"master".
+	cases := []struct {
+		name            string
+		currentBranch   string
+		issue           string
+		canonicalBranch string
+		want            bool
+	}{
+		{
+			name:            "on develop as canonical triggers fresh",
+			currentBranch:   "develop",
+			issue:           "gt-abc",
+			canonicalBranch: "develop",
+			want:            true,
+		},
+		{
+			name:            "on main when canonical is develop does NOT trigger fresh",
+			currentBranch:   "main",
+			issue:           "gt-abc",
+			canonicalBranch: "develop",
+			want:            false,
+		},
+		{
+			name:            "same-issue respawn preserves branch",
+			currentBranch:   "polecat/alpha/gt-abc@xyz",
+			issue:           "gt-abc",
+			canonicalBranch: "main",
+			want:            false,
+		},
+		{
+			name:            "other-issue polecat branch triggers fresh",
+			currentBranch:   "polecat/alpha/gt-999@xyz",
+			issue:           "gt-abc",
+			canonicalBranch: "main",
+			want:            true,
+		},
+		{
+			name:            "empty canonical with non-polecat branch does not trigger",
+			currentBranch:   "feature/x",
+			issue:           "gt-abc",
+			canonicalBranch: "",
+			want:            false,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldCreateFreshSessionBranch(c.currentBranch, c.issue, c.canonicalBranch); got != c.want {
+				t.Errorf("shouldCreateFreshSessionBranch(%q, %q, %q) = %v, want %v",
+					c.currentBranch, c.issue, c.canonicalBranch, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Follow-up to #3629 (polecat branch base derivation). That PR fixed a real bug class (stale local polecat refs contaminating new work) but made its decisions with string heuristics on branch names:

```go
strings.Contains(currentBranch, "/"+issue+"@")          // substring-match the issue into the name
currentBranch == "main" || currentBranch == "master"    // hardcoded fallbacks alongside canonicalBranch
strings.HasPrefix(currentBranch, "polecat/")            // "is this a polecat branch" by convention
```

This replaces them with a structural parser (`parseFreshBranchName`), the inverse of `freshBranchName`. Decisions now derive from structured data, not substring patterns.

## Changes

- **`parseFreshBranchName`** (new): structural inverse of `freshBranchName`. Rejects malformed names. Not coupled to git or the filesystem.
- **`shouldCreateFreshSessionBranch`**: derives from `parseFreshBranchName` output + the computed canonicalBranch. Drops `== "main" || == "master"` fallbacks — `canonicalBranch` is the single source of truth for "what's the default base for this rig".
- **`canonicalSessionStartPoint`**: returns empty string when the default branch can't be resolved (rig config + remote both empty) instead of fabricating `origin/`.
- **`ensureCanonicalSessionBranch`**: short-circuits on unresolved canonical base (logs and keeps current branch) instead of falling through to a broken RefExists check.

## Tests

- `TestParseFreshBranchName_RoundTrip` — invariant: `parseFreshBranchName(freshBranchName(n, i))` recovers `(n, i)` for issue-scoped and no-issue formats.
- `TestParseFreshBranchName_Rejects` — malformed inputs (`polecat//x@1`, `polecat/alpha`, `feature/x`, etc.) return `ok=false`.
- `TestShouldCreateFreshSessionBranch_Structural` — non-standard canonical branches (e.g., `develop`) are honored; same-issue respawn preserves the branch; other-issue polecat branches trigger fresh; empty canonical does not fabricate branches.

## Test plan

- [x] `go build ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./internal/polecat/...` passes (including the three new test functions + prior regression coverage from #3629)

## Why now

#3629 landed with tests that encode the invariant; this follow-up does the clerical ZFC cleanup so the decision logic is in structured data rather than name conventions. Zero behavioral change on the common paths; the "main"/"master" fallback is removed because `canonicalBranch` already captures the intent cleanly — and the empty-canonical case is now explicit rather than a silent fabrication.
