### PR TITLE
fix: apply startup fallback for promptless mayor/deacon/boot sessions

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -4,9 +4,9 @@
 package boot
 
 import (
-	"github.com/steveyegge/gastown/internal/cli"
 	"encoding/json"
 	"fmt"
+	"github.com/steveyegge/gastown/internal/cli"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -14,6 +14,8 @@ import (
 
 	"github.com/gofrs/flock"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/util"
@@ -179,20 +181,38 @@ func (b *Boot) spawnTmux(agentOverride string) error {
 	}
 
 	// Use unified session lifecycle for config → settings → command → create → env.
-	_, err := session.StartSession(b.tmux, session.SessionConfig{
-		SessionID: session.BootSessionName(),
-		WorkDir:   b.bootDir,
-		Role:      "boot",
-		TownRoot:  b.townRoot,
-		Beacon: session.BeaconConfig{
-			Recipient: "boot",
-			Sender:    "daemon",
-			Topic:     "triage",
-		},
-		Instructions:  "Run `" + cli.Name() + " boot triage` now.",
+	beaconCfg := session.BeaconConfig{
+		Recipient: "boot",
+		Sender:    "daemon",
+		Topic:     "triage",
+	}
+	instructions := "Run `" + cli.Name() + " boot triage` now."
+	startupPrompt := session.BuildStartupPrompt(beaconCfg, instructions)
+	startResult, err := session.StartSession(b.tmux, session.SessionConfig{
+		SessionID:     session.BootSessionName(),
+		WorkDir:       b.bootDir,
+		Role:          "boot",
+		TownRoot:      b.townRoot,
+		Beacon:        beaconCfg,
+		Instructions:  instructions,
 		AgentOverride: agentOverride,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+
+	if startResult != nil {
+		_ = runtime.RunStartupFallback(b.tmux, session.BootSessionName(), "boot", startResult.RuntimeConfig)
+		_ = runtime.DeliverStartupPromptFallback(
+			b.tmux,
+			session.BootSessionName(),
+			startupPrompt,
+			startResult.RuntimeConfig,
+			constants.ClaudeStartTimeout,
+		)
+	}
+
+	return nil
 }
 
 // spawnDegraded spawns Boot in degraded mode (no tmux).

--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -179,6 +179,13 @@ func (m *Manager) Start(agentOverride string) error {
 	// Accept startup dialogs (workspace trust + bypass permissions) if they appear.
 	_ = t.AcceptStartupDialogs(sessionID)
 
+	// Non-hook runtimes (e.g., Codex) don't execute SessionStart hooks and may
+	// ignore CLI startup prompts (prompt_mode=none). Mirror the legacy deacon
+	// startup path by nudging startup fallback commands after session launch.
+	if realTmux, ok := t.(*tmux.Tmux); ok {
+		_ = runtime.RunStartupFallback(realTmux, sessionID, "deacon", runtimeConfig)
+	}
+
 	time.Sleep(constants.ShutdownNotifyDelay)
 
 	return nil

--- a/internal/mayor/manager.go
+++ b/internal/mayor/manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/steveyegge/gastown/internal/acp"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/templates"
 	"github.com/steveyegge/gastown/internal/tmux"
@@ -159,7 +160,7 @@ func (m *Manager) StartTMUX(agentOverride string) error {
 
 	// Use unified session lifecycle for config → settings → command → create → env → theme → wait.
 	theme := tmux.ResolveSessionTheme(m.townRoot, "", "mayor", "")
-	_, err = session.StartSession(t, session.SessionConfig{
+	startResult, err := session.StartSession(t, session.SessionConfig{
 		SessionID:        sessionID,
 		WorkDir:          mayorDir,
 		Role:             "mayor",
@@ -180,6 +181,9 @@ func (m *Manager) StartTMUX(agentOverride string) error {
 	})
 	if err != nil {
 		return err
+	}
+	if startResult != nil {
+		_ = runtime.RunStartupFallback(t, sessionID, "mayor", startResult.RuntimeConfig)
 	}
 
 	time.Sleep(session.ShutdownDelay())


### PR DESCRIPTION
## Summary

This makes startup behavior consistent for promptless/non-hook runtimes (for example Codex) across town-level sessions.

Before this change, daemon-driven startup for `mayor`, `deacon`, and `boot` could start a tmux session but never deliver startup fallback nudges, leaving the agent idle until manually nudged.

## Related Issues

Closes #3735

## Changes

- `internal/deacon/manager.go`
  - run `runtime.RunStartupFallback(...)` after deacon session launch (mirrors legacy `gt deacon start` behavior)
- `internal/mayor/manager.go`
  - capture `session.StartSession(...)` result and run `runtime.RunStartupFallback(...)` using resolved runtime config
- `internal/boot/boot.go`
  - run `runtime.RunStartupFallback(...)` after `StartSession`
  - for promptless runtimes, deliver startup prompt via `runtime.DeliverStartupPromptFallback(...)` so boot triage instruction is injected reliably

## Testing

- [x] Unit tests pass (`go test ./internal/deacon ./internal/mayor ./internal/boot ./internal/runtime ./internal/config ./internal/session ./internal/hookutil`)

## Checklist

- [x] Code follows project style
- [ ] Documentation updated (not needed)
- [x] No breaking changes (or documented in summary)
