### PR TITLE
fix(witness): zombie-scan skips restart if polecat branch already merged

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1471,6 +1471,15 @@ func (g *Git) IsAncestor(ancestor, descendant string) (bool, error) {
 	return true, nil
 }
 
+// Cherry runs `git cherry <upstream> <head>` to list commits on head that are
+// not yet on upstream, comparing by patch-id. Each output line is prefixed with
+// "+ " (patch not on upstream) or "- " (patch already applied upstream, e.g.
+// via squash merge). Used to detect already-merged work that plain ancestor
+// checks miss. See aa-apw.
+func (g *Git) Cherry(upstream, head string) (string, error) {
+	return g.run("cherry", upstream, head)
+}
+
 // WorktreeAdd creates a new worktree at the given path with a new branch.
 // The new branch is created from the current HEAD.
 // Skips LFS smudge filter during checkout (see WorktreeAddFromRef).

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -970,6 +970,90 @@ func _verifyCommitOnMain(workDir, rigName, polecatName string) (bool, error) {
 	return false, nil
 }
 
+// verifyBranchAlreadyMerged checks whether the polecat's current branch work has
+// already landed on the default branch — including via SQUASH merge, which
+// rewrites commit SHAs and therefore escapes a plain ancestor check.
+//
+// Flow (aa-apw):
+//  1. Fast path: ancestor check via verifyCommitOnMain (catches fast-forward /
+//     regular merges).
+//  2. Patch-id path: `git cherry <remote>/<default> <HEAD>` lines starting with
+//     "-" mean the patch-id is already applied upstream. If every commit the
+//     polecat branch adds on top of origin/main is marked "-", the work is
+//     equivalent to something already merged (e.g., squash-merged). Empty
+//     output is also equivalent — branch has no commits beyond base.
+//
+// Returns:
+//   - true, nil: work on this branch is already on default branch (skip restart,
+//     safe to archive)
+//   - false, nil: work has NOT fully landed — continue with restart
+//   - false, error: couldn't verify — caller should treat as unsafe and restart
+//
+// Package-level var so tests can override.
+var verifyBranchAlreadyMerged = _verifyBranchAlreadyMerged
+
+func _verifyBranchAlreadyMerged(workDir, rigName, polecatName string) (bool, error) {
+	// Fast path: reuse existing ancestor check.
+	if onMain, err := verifyCommitOnMain(workDir, rigName, polecatName); err == nil && onMain {
+		return true, nil
+	}
+
+	townRoot, err := workspace.Find(workDir)
+	if err != nil || townRoot == "" {
+		return false, fmt.Errorf("finding town root: %v", err)
+	}
+
+	defaultBranch := "main"
+	if rigCfg, err := rig.LoadRigConfig(filepath.Join(townRoot, rigName)); err == nil && rigCfg.DefaultBranch != "" {
+		defaultBranch = rigCfg.DefaultBranch
+	}
+
+	polecatPath := filepath.Join(townRoot, rigName, "polecats", polecatName, rigName)
+	if _, err := os.Stat(polecatPath); os.IsNotExist(err) {
+		polecatPath = filepath.Join(townRoot, rigName, "polecats", polecatName)
+	}
+
+	g := git.NewGit(polecatPath)
+
+	remotes, err := g.Remotes()
+	if err != nil || len(remotes) == 0 {
+		remotes = []string{"origin"}
+	}
+
+	// git cherry marks each commit that HEAD introduces on top of <upstream>:
+	//   "+ <sha>" — patch-id not present upstream
+	//   "- <sha>" — patch-id already upstream (e.g., squash-merged)
+	// If no "+" lines remain, the work is fully landed.
+	for _, remote := range remotes {
+		upstream := remote + "/" + defaultBranch
+		out, err := g.Cherry(upstream, "HEAD")
+		if err != nil {
+			continue // try next remote
+		}
+		if !cherryHasUnmergedCommits(out) {
+			return true, nil
+		}
+	}
+
+	return false, nil
+}
+
+// cherryHasUnmergedCommits returns true if `git cherry` output contains at least
+// one commit marked with "+" (not yet upstream). Empty output means no commits
+// beyond base — already merged.
+func cherryHasUnmergedCommits(out string) bool {
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		if strings.HasPrefix(line, "+") {
+			return true
+		}
+	}
+	return false
+}
+
 // ZombieClassification categorizes why a polecat was classified as a zombie.
 // These are distinct from AgentState — they describe the zombie detection
 // reason, not the agent's lifecycle state. See gt-tsut.
@@ -1431,6 +1515,20 @@ func isZombieState(agentState beads.AgentState, hookBead string) bool {
 func handleZombieRestart(bd *BdCli, workDir, rigName, polecatName, hookBead, cleanupStatus string, zombie *ZombieResult) {
 	zombie.CleanupStatus = cleanupStatus
 	skipRestart := false
+
+	// aa-apw: If this polecat's branch work is already merged into the default
+	// branch (including via squash merge, which rewrites SHAs and fools a plain
+	// ancestor check), do NOT restart. Restarting would let the polecat push its
+	// pre-squash HEAD and create a duplicate MR for work already in main.
+	// Instead archive the polecat — its work is done.
+	if merged, err := verifyBranchAlreadyMerged(workDir, rigName, polecatName); err == nil && merged {
+		zombie.Action = "archived-work-already-merged (aa-apw)"
+		if nukeErr := NukePolecat(bd, workDir, rigName, polecatName); nukeErr != nil {
+			zombie.Error = fmt.Errorf("archive: %w", nukeErr)
+			zombie.Action = fmt.Sprintf("archive-failed-work-already-merged: %v", nukeErr)
+		}
+		return
+	}
 
 	// Persistence interlock (gt-qnp): check if Mayor ACP session is active before cleanup.
 	townRoot := workDirToTownRoot(workDir)

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -1913,3 +1913,87 @@ func TestNotifyRefineryMergeReady_EmitsChannelEvent(t *testing.T) {
 		t.Errorf("payload.rig = %v, want dashboard", payload["rig"])
 	}
 }
+
+// TestCherryHasUnmergedCommits covers the git-cherry output parser used by
+// verifyBranchAlreadyMerged (aa-apw).
+func TestCherryHasUnmergedCommits(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		name string
+		in   string
+		want bool
+	}{
+		{"empty output — branch has no commits beyond base", "", false},
+		{"whitespace only", "  \n\n", false},
+		{"all squash-applied (-)", "- abc123\n- def456\n", false},
+		{"one unmerged (+)", "+ abc123\n", true},
+		{"mixed", "- abc123\n+ def456\n", true},
+		{"unmerged only", "+ a\n+ b\n+ c\n", true},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			if got := cherryHasUnmergedCommits(tc.in); got != tc.want {
+				t.Errorf("cherryHasUnmergedCommits(%q) = %v, want %v", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestHandleZombieRestart_SkipsWhenBranchAlreadyMerged verifies the aa-apw fix:
+// when a stopped polecat's branch work is already merged to origin/main (e.g.,
+// via squash-merge), the witness must NOT restart the session — restarting
+// would let the polecat re-push its pre-squash HEAD and create a duplicate MR.
+// Instead the polecat is archived.
+//
+// Not parallel: overrides the package-level verifyBranchAlreadyMerged var.
+func TestHandleZombieRestart_SkipsWhenBranchAlreadyMerged(t *testing.T) {
+	oldVerify := verifyBranchAlreadyMerged
+	verifyBranchAlreadyMerged = func(workDir, rigName, polecatName string) (bool, error) {
+		return true, nil
+	}
+	t.Cleanup(func() { verifyBranchAlreadyMerged = oldVerify })
+
+	bd, _ := mockBd(
+		func(args []string) (string, error) { return "[]", nil },
+		func(args []string) error { return nil },
+	)
+
+	z := &ZombieResult{PolecatName: "scavenger", HookBead: "ma-poc.4"}
+	handleZombieRestart(bd, t.TempDir(), "testrig", "scavenger", "ma-poc.4", "has_unpushed", z)
+
+	// Action must reflect the archive decision; must NOT be a "restarted*" action.
+	if !strings.Contains(z.Action, "work-already-merged") {
+		t.Errorf("action = %q, want it to mention work-already-merged (aa-apw)", z.Action)
+	}
+	if strings.HasPrefix(z.Action, "restarted") || strings.HasPrefix(z.Action, "restart-") {
+		t.Errorf("action = %q, polecat must not be restarted when work is already merged", z.Action)
+	}
+}
+
+// TestHandleZombieRestart_RestartsWhenBranchNotMerged verifies the pre-aa-apw
+// behavior is preserved when work is NOT merged: handleZombieRestart proceeds
+// to its normal cleanup/restart flow.
+//
+// Not parallel: overrides the package-level verifyBranchAlreadyMerged var.
+func TestHandleZombieRestart_RestartsWhenBranchNotMerged(t *testing.T) {
+	oldVerify := verifyBranchAlreadyMerged
+	verifyBranchAlreadyMerged = func(workDir, rigName, polecatName string) (bool, error) {
+		return false, nil
+	}
+	t.Cleanup(func() { verifyBranchAlreadyMerged = oldVerify })
+
+	bd, _ := mockBd(
+		func(args []string) (string, error) { return "[]", nil },
+		func(args []string) error { return nil },
+	)
+
+	z := &ZombieResult{PolecatName: "scavenger", HookBead: "ma-poc.4"}
+	handleZombieRestart(bd, t.TempDir(), "testrig", "scavenger", "ma-poc.4", "clean", z)
+
+	// Should NOT take the archive path.
+	if strings.Contains(z.Action, "work-already-merged") {
+		t.Errorf("action = %q, should not archive when work is not merged", z.Action)
+	}
+}


### PR DESCRIPTION
## Problem

When the witness zombie-scan restarts a stopped polecat whose work has already been squash-merged into `origin/main`, the polecat's `gt done` re-pushes the pre-squash HEAD and the refinery opens a duplicate MR.

The existing `verifyCommitOnMain` helper uses `git merge-base --is-ancestor`, which cannot detect squash merges (they rewrite commit SHAs). So a polecat whose work landed via squash gets restarted and re-submits the same work.

Observed on 2026-04-22 with `scavenger/ma-poc.4`: polecat branch HEAD `e38d8ca` was patch-identical to squash-merge `d4189e7` on `origin/main`, but zombie-scan restart → `gt done` → duplicate MR `ma-wisp-jmm`.

## Fix

Add a patch-id equivalence check using `git cherry <remote>/<default> HEAD` before restarting a zombie polecat:

- `+` lines indicate patches not yet on the remote
- `-` lines indicate patches already on the remote (including squash-merges)

If there are no `+` lines, the polecat's work has already landed — archive the polecat via `NukePolecat` instead of restarting it.

## Changes

- `internal/git/git.go` — thin `Cherry(upstream, head)` wrapper around `git cherry`.
- `internal/witness/handlers.go` — new `verifyBranchAlreadyMerged` (pkg var for testability) combining the existing ancestor check with a patch-id equivalence check; early return + archive in `handleZombieRestart` when work is already merged.
- `internal/witness/handlers_test.go` — 3 new tests, 6 sub-cases.

## Tests

- `TestHandleZombieRestart_SkipsWhenBranchAlreadyMerged`
- `TestHandleZombieRestart_RestartsWhenBranchNotMerged`
- `TestCherryHasUnmergedCommits`

All pass. Full `./internal/witness/...` and `./internal/daemon/...` suites pass.

Reported by `mobile_apps/witness` in thread-bf9901a065c2.