### PR TITLE
fix(polecat): check-recovery treats CLOSED bead as terminal (aa-55d8)

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1036,20 +1036,16 @@ func runPolecatCheckRecovery(cmd *cobra.Command, args []string) error {
 	// verify the work was actually submitted to the merge queue.
 	// Without this check, polecats that crashed between push and MQ submission
 	// would be nuked with orphaned branches on the remote. See #1035.
+	//
+	// Exception: if the polecat's assigned bead is already CLOSED/TOMBSTONE,
+	// the work is terminal and MQ submission is moot. Reporting NEEDS_MQ_SUBMIT
+	// on a closed bead triggered a zombie-restart loop (see aa-55d8): witness
+	// patrols kept auto-restarting the polecat to "finish" work that was already
+	// done, which just ran `gt done` again and died, over and over.
 	if status.Verdict == "SAFE_TO_NUKE" && status.Branch != "" {
 		mqBd := beads.New(r.Path)
-		mr, mrErr := mqBd.FindMRForBranchAny(status.Branch)
-		if mrErr != nil {
-			// Can't verify MQ — be conservative
-			status.MQStatus = "unknown"
-		} else if mr != nil {
-			status.MQStatus = "submitted"
-		} else {
-			// Work was pushed but never entered the merge queue
-			status.MQStatus = "not_submitted"
-			status.NeedsRecovery = true
-			status.Verdict = "NEEDS_MQ_SUBMIT"
-		}
+		beadTerminal := isAssignedBeadTerminal(mqBd, status.Issue)
+		applyMQCheck(&status, mqBd, beadTerminal)
 	}
 
 	// JSON output
@@ -1092,6 +1088,56 @@ func runPolecatCheckRecovery(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// mrFinder is the subset of *beads.Beads that applyMQCheck needs. It lets us
+// unit-test the verdict logic without a real bd binary.
+type mrFinder interface {
+	FindMRForBranchAny(branch string) (*beads.Issue, error)
+}
+
+// isAssignedBeadTerminal reports whether the polecat's assigned bead (if any)
+// is in a terminal status (closed/tombstone). Returns false on any lookup
+// failure — callers must only use this to *skip* further escalation, never to
+// escalate, so a false negative is safe.
+func isAssignedBeadTerminal(bd *beads.Beads, issueID string) bool {
+	if issueID == "" || bd == nil {
+		return false
+	}
+	issue, err := bd.Show(issueID)
+	if err != nil || issue == nil {
+		return false
+	}
+	return beads.IssueStatus(issue.Status).IsTerminal()
+}
+
+// applyMQCheck mutates status based on merge-queue state for the polecat's
+// branch. If beadTerminal is true, the assigned bead is already closed, so
+// there is nothing to submit and we leave the verdict as SAFE_TO_NUKE.
+//
+// This guard fixes the zombie-restart loop documented in bead aa-55d8:
+// a closed "no-op audit" bead (e.g. aa-xtee) used to report NEEDS_MQ_SUBMIT
+// forever, causing witness patrols to restart the polecat on every cycle.
+func applyMQCheck(status *RecoveryStatus, bd mrFinder, beadTerminal bool) {
+	if beadTerminal {
+		// Nothing to submit — the bead is already terminal.
+		status.MQStatus = "submitted"
+		return
+	}
+	mr, mrErr := bd.FindMRForBranchAny(status.Branch)
+	if mrErr != nil {
+		// Can't verify MQ — be conservative
+		status.MQStatus = "unknown"
+		return
+	}
+	if mr != nil {
+		status.MQStatus = "submitted"
+		return
+	}
+	// Work was pushed but never entered the merge queue
+	status.MQStatus = "not_submitted"
+	status.NeedsRecovery = true
+	status.Verdict = "NEEDS_MQ_SUBMIT"
 }
 
 func runPolecatGC(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/polecat_check_recovery_test.go
+++ b/internal/cmd/polecat_check_recovery_test.go
@@ -1,0 +1,90 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+// fakeMRFinder is a test stub for the mrFinder interface used by applyMQCheck.
+type fakeMRFinder struct {
+	issue *beads.Issue
+	err   error
+}
+
+func (f fakeMRFinder) FindMRForBranchAny(branch string) (*beads.Issue, error) {
+	return f.issue, f.err
+}
+
+func TestApplyMQCheck(t *testing.T) {
+	tests := []struct {
+		name            string
+		finder          mrFinder
+		beadTerminal    bool
+		initialVerdict  string
+		wantVerdict     string
+		wantMQStatus    string
+		wantNeedsRecov  bool
+	}{
+		{
+			// The regression this change fixes: assigned bead is CLOSED
+			// (e.g. aa-xtee no-op audit). Must NOT return NEEDS_MQ_SUBMIT
+			// because there is nothing to submit — the work is terminal.
+			name:            "closed bead skips MQ submit check",
+			finder:          fakeMRFinder{issue: nil, err: nil},
+			beadTerminal:    true,
+			initialVerdict:  "SAFE_TO_NUKE",
+			wantVerdict:     "SAFE_TO_NUKE",
+			wantMQStatus:    "submitted",
+			wantNeedsRecov:  false,
+		},
+		{
+			name:            "open bead with no MR escalates to NEEDS_MQ_SUBMIT",
+			finder:          fakeMRFinder{issue: nil, err: nil},
+			beadTerminal:    false,
+			initialVerdict:  "SAFE_TO_NUKE",
+			wantVerdict:     "NEEDS_MQ_SUBMIT",
+			wantMQStatus:    "not_submitted",
+			wantNeedsRecov:  true,
+		},
+		{
+			name:            "open bead with MR stays SAFE_TO_NUKE",
+			finder:          fakeMRFinder{issue: &beads.Issue{ID: "mr-1"}, err: nil},
+			beadTerminal:    false,
+			initialVerdict:  "SAFE_TO_NUKE",
+			wantVerdict:     "SAFE_TO_NUKE",
+			wantMQStatus:    "submitted",
+			wantNeedsRecov:  false,
+		},
+		{
+			name:            "MR lookup error is conservative (unknown, no escalation)",
+			finder:          fakeMRFinder{issue: nil, err: errors.New("bd exploded")},
+			beadTerminal:    false,
+			initialVerdict:  "SAFE_TO_NUKE",
+			wantVerdict:     "SAFE_TO_NUKE",
+			wantMQStatus:    "unknown",
+			wantNeedsRecov:  false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			status := RecoveryStatus{
+				Verdict: tt.initialVerdict,
+				Branch:  "polecat/test",
+			}
+			applyMQCheck(&status, tt.finder, tt.beadTerminal)
+
+			if status.Verdict != tt.wantVerdict {
+				t.Errorf("Verdict = %q, want %q", status.Verdict, tt.wantVerdict)
+			}
+			if status.MQStatus != tt.wantMQStatus {
+				t.Errorf("MQStatus = %q, want %q", status.MQStatus, tt.wantMQStatus)
+			}
+			if status.NeedsRecovery != tt.wantNeedsRecov {
+				t.Errorf("NeedsRecovery = %v, want %v", status.NeedsRecovery, tt.wantNeedsRecov)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Symptom

`alleago_api/witness` patrols kept detecting `alleago_api/obsidian` as `session-dead-active` and auto-restarting it. The restarted session found no work (its assigned bead was already closed), ran `gt done`, went idle, and died. The next patrol detected the zombie again and restarted. Loop forever, burning tokens every cycle.

## Root cause (diagnosed in bead aa-55d8)

`gt polecat check-recovery` would return **`NEEDS_MQ_SUBMIT`** for a polecat whose assigned bead was already **CLOSED**.

In `runPolecatCheckRecovery` (`internal/cmd/polecat.go`), the MQ-submit guard fires whenever the verdict is `SAFE_TO_NUKE` and the polecat has a branch — without ever asking whether the bead itself is still open. But `NEEDS_MQ_SUBMIT` only makes sense while the bead is open and work is actively landing. Once the bead is closed, there is nothing to submit.

### Concrete case

- `alleago_api/obsidian` was assigned `aa-xtee` — a "no-op audit" bead.
- The polecat correctly closed `aa-xtee` with `no-changes: audit found zero callers`.
- But `check-recovery` kept returning `NEEDS_MQ_SUBMIT`.
- `git-state` simultaneously reported `CLEAN (safe to kill)`.
- The two signals disagreed and the witness escalation loop won.

## The fix

Extract the MQ gate into `applyMQCheck` and short-circuit when the polecat's assigned bead is in a terminal `IssueStatus` (closed or tombstone, via `beads.IssueStatus.IsTerminal()`).

- Terminal bead: verdict stays `SAFE_TO_NUKE`, `MQStatus` is reported as `submitted` (nothing to submit).
- Open bead, no MR found: escalates to `NEEDS_MQ_SUBMIT` as before.
- Open bead, MR found: stays `SAFE_TO_NUKE` as before.
- Lookup failure: conservative `MQStatus=unknown`, no escalation — unchanged from existing behavior.

`isAssignedBeadTerminal` deliberately returns `false` on any lookup failure so a transient bd/routing error can never be used to *suppress* escalation — false negatives here are safe, false positives would not be.

Small, surgical fix. No changes to data shapes, flags, or existing verdicts outside the documented case.

## Test added

`TestApplyMQCheck` in `internal/cmd/polecat_check_recovery_test.go` covers four scenarios:

1. **Closed bead skips MQ submit check** — the regression this fixes. `beadTerminal=true` with no MR found must stay `SAFE_TO_NUKE`, not escalate.
2. Open bead with no MR escalates to `NEEDS_MQ_SUBMIT` (pre-existing behavior preserved).
3. Open bead with MR stays `SAFE_TO_NUKE` with `MQStatus=submitted`.
4. MR lookup error stays conservative (`unknown`, no escalation).

Uses a small `mrFinder` interface and `fakeMRFinder` stub so the logic is pure-function testable without a real `bd` binary.

## Test plan

- [x] `go build -o /tmp/gt-test ./cmd/gt` — succeeds.
- [x] `go test ./internal/cmd/...` — passes (75s).
- [x] `go test ./internal/polecat/...` — passes (74s).
- [x] `go vet ./internal/cmd/...` — clean.
- [ ] In a live rig with a polecat whose assigned bead is closed: `gt polecat check-recovery rig/polecat` returns `SAFE_TO_NUKE`, not `NEEDS_MQ_SUBMIT`.

Co-Authored-By: Claude <noreply@anthropic.com>