### PR TITLE
fix(daemon): use --repo instead of --rig in hasAssignedOpenWork bd list call

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2663,12 +2663,30 @@ func (d *Daemon) isBeadClosed(beadID string) bool {
 // field (updateAgentHookBead is a no-op). Without this fallback, the idle reaper
 // kills working polecats whose agent bead hook_bead is stale.
 func (d *Daemon) hasAssignedOpenWork(rigName, assignee string) bool {
+	// Target the rig's database via --repo. bd's multi-rig routing engine was
+	// removed in steveyegge/beads@d7629204; --rig was retired as part of that
+	// refactor, and bd list now rejects it as an unknown flag. Resolve the rig
+	// name to its directory and pass --repo=<dir> instead, mirroring the fix
+	// applied to bd create in PR #3680 (a2b3b7ca).
+	//
+	// If the rig isn't in routes.jsonl (e.g., town-level lookup or a
+	// misconfigured rig), GetRigDirForName returns an empty string and we
+	// query bd with no explicit repo — bd falls back to its default routing
+	// from the process cwd (d.config.TownRoot), which is the safe pre-routing
+	// behavior.
+	rigDir := beads.GetRigDirForName(d.config.TownRoot, rigName)
 	for _, status := range []string{"hooked", "in_progress", "open"} {
-		cmd := exec.Command(d.bdPath, "list", "--rig="+rigName, "--assignee="+assignee, "--status="+status, "--json") //nolint:gosec // G204: args are constructed internally
+		args := []string{"list", "--assignee=" + assignee, "--status=" + status, "--json"}
+		if rigDir != "" {
+			args = append(args, "--repo="+rigDir)
+		}
+		cmd := exec.Command(d.bdPath, args...) //nolint:gosec // G204: args are constructed internally
 		cmd.Dir = d.config.TownRoot
 		cmd.Env = os.Environ()
 		output, err := cmd.Output()
 		if err != nil {
+			// Best-effort: bd errors are non-fatal here. The caller (idle
+			// reaper) falls through to its primary hook_bead check.
 			continue
 		}
 		var issues []json.RawMessage

--- a/internal/daemon/has_assigned_work_test.go
+++ b/internal/daemon/has_assigned_work_test.go
@@ -1,0 +1,78 @@
+package daemon
+
+import (
+	"log"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// TestHasAssignedOpenWork_DoesNotPassRigFlag is a regression guard for a gt/bd
+// compatibility break. steveyegge/beads@d7629204 removed multi-rig routing and
+// retired the --rig flag from bd list/ready. gt PR #3294 (landed the same day,
+// earlier) added hasAssignedOpenWork which called `bd list --rig=<name>`.
+// From that point on, every invocation errored with "unknown flag: --rig",
+// cmd.Output() returned err!=nil, the loop skipped all three statuses, and
+// the function silently returned false — defeating the idle-reaper-protection
+// purpose it was added for.
+//
+// This test fails if anyone reintroduces --rig to the call.
+func TestHasAssignedOpenWork_DoesNotPassRigFlag(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+	binDir := t.TempDir()
+	argsFile := filepath.Join(binDir, "bd-args.log")
+
+	// Fake bd: log all args to a file, succeed with empty list.
+	// If any invocation passes --rig, a real bd would exit 1 with
+	// "unknown flag: --rig" — we mirror that here so accidental
+	// regressions fail loudly instead of silently.
+	script := "#!/bin/sh\n" +
+		"for arg in \"$@\"; do\n" +
+		"  case \"$arg\" in\n" +
+		"    --rig=*|--rig) echo \"Error: unknown flag: --rig\" >&2; exit 1;;\n" +
+		"  esac\n" +
+		"  echo \"$arg\" >> " + argsFile + "\n" +
+		"done\n" +
+		"echo '[]'\n"
+	bdPath := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(bdPath, []byte(script), 0755); err != nil {
+		t.Fatalf("writing fake bd: %v", err)
+	}
+
+	var logBuf strings.Builder
+	d := &Daemon{
+		config: &Config{TownRoot: t.TempDir()},
+		logger: log.New(&logBuf, "", 0),
+		tmux:   tmux.NewTmux(),
+		bdPath: bdPath,
+	}
+
+	got := d.hasAssignedOpenWork("myr", "myr/polecats/mycat")
+	if got != false {
+		t.Fatalf("hasAssignedOpenWork() with empty bd response = %v, want false", got)
+	}
+
+	argsBytes, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("bd was not invoked (no args file): %v", err)
+	}
+	argsText := string(argsBytes)
+
+	if strings.Contains(argsText, "--rig") {
+		t.Errorf("hasAssignedOpenWork passed --rig to bd — regression of d7629204 compatibility fix.\nCaptured args:\n%s", argsText)
+	}
+
+	// Sanity-check the call shape: should still pass list + assignee + status + json.
+	wantArgs := []string{"list", "--assignee=", "--status=", "--json"}
+	for _, want := range wantArgs {
+		if !strings.Contains(argsText, want) {
+			t.Errorf("expected bd args to contain %q, got:\n%s", want, argsText)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Completes the gt→bd compatibility sweep started by #3680. `bd list --rig` is an unknown flag in bd >= v1.0.0, and `daemon.go:hasAssignedOpenWork` has been silently failing every call since the bd refactor landed.

## What the bug does

`hasAssignedOpenWork` is the authoritative-source fallback the idle reaper uses to decide whether to kill a polecat it thinks is idle. The function queries:

```
bd list --rig=<rig> --assignee=<polecat> --status=<status> --json
```

for `status` ∈ {`hooked`, `in_progress`, `open`}. bd rejects `--rig` with `Error: unknown flag: --rig`, so `cmd.Output()` returns `err != nil`, the loop does `continue`, and the function returns `false` for every polecat. The reaper's fallback protection is defeated — the function's own doc comment flags this exact failure:

> *Without this fallback, the idle reaper kills working polecats whose agent bead hook_bead is stale.*

The failure is silent: no error logged, no metric emitted, no escalation. Polecat deaths look like normal churn.

## Root cause — where the break came from

The break happened on **March 27, 2026** in two commits that landed within hours of each other, in two different repos, authored by two different people.

| Time | Repo | Commit | Author | What |
|------|------|--------|--------|------|
| 10:25 | gastownhall/gastown | `dd113c2f` (#3294) | dannomayernotabot | Added `hasAssignedOpenWork`, called `bd list --rig=<name>` |
| 19:53 | steveyegge/beads | `d7629204` | beads/crew/emma | \"refactor: remove multi-rig routing from beads\" — deleted `routes.go`, `move.go`, `refile.go`; retired `--rig` from `list`/`ready` |

At 10:25 the gt author's manual validation (13 polecats, 20 minutes, zero reaper kills) was genuine — `bd list --rig` still worked. By 19:53 the contract had changed.

`bd list --rig` was originally introduced in bd commit `44dc4a9f` (**Feb 10, 2026**) as a feature — \"add --rig flag to bd list and bd ready for cross-rig queries\". It lived for ~6 weeks before the multi-rig engine got retired in `d7629204`.

bd v1.0.0 (released Apr 2) enshrined the removal. We're on v1.0.2. The break has been live for ~4 weeks.

## Why nobody noticed

1. The removal was buried in a large refactor — 6 files deleted, 10+ simplified.
2. No bd→gt coordination — bd didn't grep external callers of the retired flag.
3. gt had no regression test for `hasAssignedOpenWork`; PR #3294 only had manual validation, which was valid at its runtime.
4. Silent failure mode: `err != nil → continue → return false`. No signal.
5. The visible symptom (polecat occasionally gets reaped) is indistinguishable from ordinary polecat churn.

PR #3680 (`bd create` --rig→--repo, merged Apr 19) began the catch-up. That PR handled `bd create` but didn't grep for other `bd <cmd> --rig=` patterns; `hasAssignedOpenWork` was missed.

## Fix

Resolve the rig name to its filesystem directory via `beads.GetRigDirForName` and pass `--repo=<dir>`, matching the pattern `beads.Create` already uses. When the rig isn't in `routes.jsonl` (town-level query or misconfigured rig), skip the `--repo` flag and let bd fall back to default routing from `cwd` — preserves pre-multi-rig behavior.

```go
rigDir := beads.GetRigDirForName(d.config.TownRoot, rigName)
for _, status := range []string{\"hooked\", \"in_progress\", \"open\"} {
    args := []string{\"list\", \"--assignee=\" + assignee, \"--status=\" + status, \"--json\"}
    if rigDir != \"\" {
        args = append(args, \"--repo=\"+rigDir)
    }
    ...
}
```

## Regression test

Adds `TestHasAssignedOpenWork_DoesNotPassRigFlag`. The fake bd exits 1 with `Error: unknown flag: --rig` if any invocation passes `--rig` — same surface behavior as real bd. Verified this test fails when `--rig=` is reintroduced, passes with the fix.

This test is the guardrail that would have caught the break in March.

## Test plan

- [x] `go build ./cmd/gt` passes
- [x] `go vet ./internal/daemon/` passes
- [x] `go test ./internal/daemon/...` full suite passes (229s)
- [x] New regression test passes with the fix
- [x] New regression test fails if `--rig` is reintroduced (manually verified by reverting the fix in-place, running, seeing FAIL)
- [x] Ran the fixed binary locally for several hours under live daemon load — no regression in polecat health checking

## Related

- bd: `d7629204` (removed `--rig` from list/ready)
- bd: `44dc4a9f` (originally added `--rig` to list/ready, Feb 10)
- gt: PR #3294 `dd113c2f` (added `hasAssignedOpenWork`)
- gt: PR #3680 `a2b3b7ca` (companion --rig→--repo fix for bd create)

🤖 Generated with [Claude Code](https://claude.com/claude-code)