### PR TITLE
feat(doltserver): add GT_DOLT_AUTO_GC env var to control auto garbage collection

### DIFF
--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -808,8 +808,15 @@ func writeDaemonDoltConfig(cfg *DoltServerConfig, configPath string) error {
 	if cfg.Host != "" {
 		hostLine = fmt.Sprintf("\n  host: %s", cfg.Host)
 	}
+	autoGC := true
+	if agc := os.Getenv("GT_DOLT_AUTO_GC"); agc != "" {
+		if v, err := strconv.ParseBool(agc); err == nil {
+			autoGC = v
+		}
+	}
 	content := fmt.Sprintf(`# Dolt SQL server configuration — managed by Gas Town daemon
 # Do not edit manually; overwritten on each daemon-managed server start.
+# To disable auto GC, set GT_DOLT_AUTO_GC=false
 
 log_level: info
 
@@ -824,12 +831,13 @@ data_dir: %q
 behavior:
   dolt_transaction_commit: false
   auto_gc_behavior:
-    enable: true
+    enable: %v
     archive_level: 1
 `,
 		cfg.Port,
 		hostLine,
 		cfg.DataDir,
+		autoGC,
 	)
 	return os.WriteFile(configPath, []byte(content), 0600)
 }

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -243,6 +243,11 @@ type Config struct {
 	// Default is "warning" to suppress connection open/close noise. Override with
 	// GT_DOLT_LOGLEVEL=info (or debug) for diagnostics.
 	LogLevel string
+
+	// AutoGC enables Dolt's automatic garbage collection.
+	// Default is true. Override with GT_DOLT_AUTO_GC=false to disable
+	// (recommended for high-throughput batch commit workloads where GC thrashes CPU).
+	AutoGC bool
 }
 
 // DefaultConfig returns the default Dolt server configuration.
@@ -273,6 +278,7 @@ func DefaultConfig(townRoot string) *Config {
 		ReadTimeoutMs:  DefaultReadTimeoutMs,
 		WriteTimeoutMs: DefaultWriteTimeoutMs,
 		LogLevel:       "warning",
+		AutoGC:         true,
 	}
 
 	if h := os.Getenv("GT_DOLT_HOST"); h != "" {
@@ -294,6 +300,11 @@ func DefaultConfig(townRoot string) *Config {
 	}
 	if pw := os.Getenv("GT_DOLT_PASSWORD"); pw != "" {
 		config.Password = pw
+	}
+	if agc := os.Getenv("GT_DOLT_AUTO_GC"); agc != "" {
+		if v, err := strconv.ParseBool(agc); err == nil {
+			config.AutoGC = v
+		}
 	}
 	if ll := os.Getenv("GT_DOLT_LOGLEVEL"); ll != "" {
 		config.LogLevel = ll
@@ -1306,7 +1317,7 @@ func writeServerConfig(config *Config, configPath string) error {
 	content := fmt.Sprintf(`# Dolt SQL server configuration — managed by Gas Town (gt dolt start)
 # Do not edit manually; changes are overwritten on each server start.
 # To customize, set Gas Town environment variables:
-#   GT_DOLT_PORT, GT_DOLT_HOST, GT_DOLT_USER, GT_DOLT_PASSWORD, GT_DOLT_LOGLEVEL
+#   GT_DOLT_PORT, GT_DOLT_HOST, GT_DOLT_USER, GT_DOLT_PASSWORD, GT_DOLT_LOGLEVEL, GT_DOLT_AUTO_GC
 
 log_level: %s
 
@@ -1318,7 +1329,7 @@ data_dir: "%s"
 behavior:
   dolt_transaction_commit: false
   auto_gc_behavior:
-    enable: true
+    enable: %v
     archive_level: 1
 `,
 		config.LogLevel,
@@ -1328,6 +1339,7 @@ behavior:
 		readTimeoutLine,
 		writeTimeoutLine,
 		filepath.ToSlash(config.DataDir),
+		config.AutoGC,
 	)
 
 	return os.WriteFile(configPath, []byte(content), 0600)

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -3554,6 +3554,29 @@ func TestDefaultConfig_InvalidPortIgnored(t *testing.T) {
 	}
 }
 
+func TestDefaultConfig_AutoGCDefault(t *testing.T) {
+	config := DefaultConfig(t.TempDir())
+	if !config.AutoGC {
+		t.Error("AutoGC should default to true")
+	}
+}
+
+func TestDefaultConfig_AutoGCEnvVar(t *testing.T) {
+	t.Setenv("GT_DOLT_AUTO_GC", "false")
+	config := DefaultConfig(t.TempDir())
+	if config.AutoGC {
+		t.Error("AutoGC should be false when GT_DOLT_AUTO_GC=false")
+	}
+}
+
+func TestDefaultConfig_AutoGCInvalidIgnored(t *testing.T) {
+	t.Setenv("GT_DOLT_AUTO_GC", "not-a-bool")
+	config := DefaultConfig(t.TempDir())
+	if !config.AutoGC {
+		t.Error("AutoGC should remain true when GT_DOLT_AUTO_GC is invalid")
+	}
+}
+
 func TestBuildDoltSQLCmd_Local(t *testing.T) {
 	config := &Config{
 		Host:    "",
@@ -3928,6 +3951,7 @@ func TestWriteServerConfig_Defaults(t *testing.T) {
 		ReadTimeoutMs:  DefaultReadTimeoutMs,
 		WriteTimeoutMs: DefaultWriteTimeoutMs,
 		LogLevel:       "warning",
+		AutoGC:         true,
 	}
 
 	if err := writeServerConfig(config, configPath); err != nil {
@@ -3948,6 +3972,7 @@ func TestWriteServerConfig_Defaults(t *testing.T) {
 		"data_dir: \"" + dir + "\"",
 		"log_level: warning",
 		"auto_gc_behavior:",
+		"enable: true",
 	}
 	for _, want := range checks {
 		if !strings.Contains(content, want) {
@@ -4015,6 +4040,26 @@ func TestWriteServerConfig_ZeroTimeoutsOmitted(t *testing.T) {
 	}
 	if strings.Contains(content, "write_timeout_millis") {
 		t.Error("zero WriteTimeoutMs should not write write_timeout_millis")
+	}
+}
+
+func TestWriteServerConfig_AutoGCDisabled(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	config := &Config{
+		Port:    3307,
+		DataDir: dir,
+		AutoGC:  false,
+	}
+	if err := writeServerConfig(config, configPath); err != nil {
+		t.Fatal(err)
+	}
+
+	data, _ := os.ReadFile(configPath)
+	content := string(data)
+	if !strings.Contains(content, "enable: false") {
+		t.Errorf("AutoGC=false should produce 'enable: false' in config\nfull content:\n%s", content)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Add `GT_DOLT_AUTO_GC` environment variable to control Dolt's `auto_gc_behavior.enable` setting in the generated `config.yaml`
- Defaults to `true` (backward-compatible). Set `GT_DOLT_AUTO_GC=false` to disable auto GC
- Follows the existing env var pattern (`GT_DOLT_HOST`, `GT_DOLT_PORT`, etc.) using `strconv.ParseBool`

## Problem

The generated `config.yaml` hardcodes `auto_gc_behavior.enable: true`, and the config is regenerated on every `gt dolt start`, so manual edits don't survive restarts.

In high-throughput environments (batch commit mode with many concurrent agents), Dolt's auto GC thrashes CPU at 70%+ and can contribute to OOM on memory-constrained nodes. There was no way to persistently disable it.

## Changes

**`internal/doltserver/doltserver.go`:**
- Add `AutoGC bool` field to `Config` struct (default `true`)
- Read `GT_DOLT_AUTO_GC` in `DefaultConfig()` via `strconv.ParseBool`
- Use `config.AutoGC` in the YAML template instead of hardcoded `true`

**`internal/doltserver/doltserver_test.go`:**
- `TestDefaultConfig_AutoGCDefault` — verifies default is `true`
- `TestDefaultConfig_AutoGCEnvVar` — verifies `GT_DOLT_AUTO_GC=false` disables it
- `TestDefaultConfig_AutoGCInvalidIgnored` — verifies invalid values are ignored
- `TestWriteServerConfig_AutoGCDisabled` — verifies YAML output contains `enable: false`
- Updated `TestWriteServerConfig_Defaults` to also check `enable: true`

## Usage

```bash
# Disable auto GC (recommended for high-throughput batch workloads)
export GT_DOLT_AUTO_GC=false
gt dolt start

# Verify
grep "enable:" ~/.gt/.dolt-data/config.yaml
# → enable: false
```

## Test plan

- [x] `go test ./internal/doltserver/ -run TestDefaultConfig_AutoGC -v` — all 3 pass
- [x] `go test ./internal/doltserver/ -run TestWriteServerConfig_AutoGC -v` — passes
- [x] `go test ./internal/doltserver/ -run TestWriteServerConfig_Defaults -v` — passes
- [x] Manual: `GT_DOLT_AUTO_GC=false gt dolt start` produces `enable: false` in config.yaml
- [x] Manual: `gt dolt start` (no env var) produces `enable: true` (backward-compatible)