### PR TITLE
feat: ci_command — local build/test gate for merge_strategy=local

### DIFF
--- a/docs/reference.md
+++ b/docs/reference.md
@@ -71,6 +71,8 @@ Debug routing: `BD_DEBUG_ROUTING=1 bd show <id>`
     "lint_command": "",
     "test_command": "",
     "build_command": "",
+    "ci_command": "",
+    "merge_strategy": "local",
     "on_conflict": "assign_back",
     "delete_merged_branches": true,
     "retry_flaky_tests": 1,
@@ -135,6 +137,8 @@ Town-level role defaults live in `mayor/config.json` under:
 | `lint_command` | `string` | `""` | Lint command (e.g., `eslint .`) |
 | `test_command` | `string` | `""` | Test command to run. Empty = skip. |
 | `build_command` | `string` | `""` | Build command (e.g., `go build ./...`) |
+| `ci_command` | `string` | `""` | Local CI gate command. Only active when `merge_strategy=local`. After each local merge, runs this command in the worktree root; exit 0 keeps the merge, non-zero reverts it and marks the MR stuck with stderr in the failure report. Example: `"go test ./..."` or `".gastown/verify.sh"`. |
+| `merge_strategy` | `string` | `"direct"` | How the Refinery lands work: `direct` (git push), `pr` (GitHub PR merge via `gh pr merge`), `local` (local merge + optional `ci_command` gate). |
 | `on_conflict` | `string` | `"assign_back"` | Conflict strategy: `assign_back` or `auto_rebase` |
 | `delete_merged_branches` | `bool` | `true` | Delete source branches after merging |
 | `retry_flaky_tests` | `int` | `1` | Number of times to retry flaky tests |
@@ -146,6 +150,41 @@ Town-level role defaults live in `mayor/config.json` under:
 | `integration_branch_auto_land` | `*bool` | `false` | Refinery patrol auto-lands when all children closed |
 
 See [Integration Branches](concepts/integration-branches.md) for integration branch details.
+
+#### merge_strategy and ci_command
+
+`merge_strategy` controls how the Refinery lands approved work:
+
+| `merge_strategy` | Behavior |
+|------------------|----------|
+| `direct` (default) | Git push directly to the base branch |
+| `pr` | Creates a GitHub PR and uses `gh pr merge`; GitHub CI gates the merge |
+| `local` | Merges locally in the Refinery worktree; optionally runs `ci_command` as a gate |
+
+**Local CI gate** (`merge_strategy=local` + `ci_command`):
+
+| `merge_strategy` | `ci_command` | Result |
+|------------------|--------------|--------|
+| `pr` | any | `ci_command` ignored — GitHub CI gates the merge |
+| `local` | unset | Local merge, no gate (unchanged behavior) |
+| `local` | set | Local merge + `ci_command` runs after each merge; non-zero exit reverts the merge and marks the MR stuck |
+
+Configure via `gt rig settings`:
+
+```bash
+gt rig settings set my-project merge_queue.merge_strategy local
+gt rig settings set my-project merge_queue.ci_command "go test ./..."
+```
+
+For complex verification logic, commit a script and point `ci_command` at it:
+
+```bash
+# Commit .gastown/verify.sh with your verification logic
+gt rig settings set my-project merge_queue.ci_command ".gastown/verify.sh"
+```
+
+The script runs in the worktree root. Exit 0 keeps the merge; any non-zero exit reverts
+it and includes the command's stderr in the MR failure report.
 
 ### Runtime (`.runtime/` - gitignored)
 

--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -407,6 +407,9 @@ func buildRefineryPatrolVars(ctx RoleContext) []string {
 		if mq.BuildCommand != "" {
 			vars = append(vars, fmt.Sprintf("build_command=%s", mq.BuildCommand))
 		}
+		if mq.CICommand != "" {
+			vars = append(vars, fmt.Sprintf("ci_command=%s", mq.CICommand))
+		}
 		vars = append(vars, fmt.Sprintf("delete_merged_branches=%t", mq.IsDeleteMergedBranchesEnabled()))
 		vars = append(vars, fmt.Sprintf("judgment_enabled=%t", mq.IsJudgmentEnabled()))
 		vars = append(vars, fmt.Sprintf("review_depth=%s", mq.GetReviewDepth()))
@@ -431,7 +434,7 @@ func buildRefineryPatrolVars(ctx RoleContext) []string {
 					labelMap[label[:idx]] = label[idx+1:]
 				}
 			}
-			for _, key := range []string{"integration_branch_refinery_enabled", "integration_branch_auto_land", "run_tests", "delete_merged_branches", "setup_command", "typecheck_command", "lint_command", "test_command", "build_command", "merge_strategy", "require_review"} {
+			for _, key := range []string{"integration_branch_refinery_enabled", "integration_branch_auto_land", "run_tests", "delete_merged_branches", "setup_command", "typecheck_command", "lint_command", "test_command", "build_command", "ci_command", "merge_strategy", "require_review"} {
 				if val := labelMap[key]; val != "" {
 					vars = append(vars, fmt.Sprintf("%s=%s", key, val))
 				}

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -1150,6 +1150,9 @@ func loadRigCommandVars(townRoot, rig string) []string {
 	if mq.BuildCommand != "" {
 		vars = append(vars, fmt.Sprintf("build_command=%s", mq.BuildCommand))
 	}
+	if mq.CICommand != "" {
+		vars = append(vars, fmt.Sprintf("ci_command=%s", mq.CICommand))
+	}
 	if mq.MergeStrategy != "" {
 		vars = append(vars, fmt.Sprintf("merge_strategy=%s", mq.MergeStrategy))
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1306,6 +1306,10 @@ type MergeQueueConfig struct {
 	// BuildCommand is the command to run for building (used by formulas).
 	BuildCommand string `json:"build_command,omitempty"`
 
+	// CICommand is the shell command run locally after each local merge as a CI gate.
+	// Active only when merge_strategy=local. Exit 0 keeps the merge; non-zero reverts it.
+	CICommand string `json:"ci_command,omitempty"`
+
 	// SetupCommand is the command to run for project setup (e.g., pnpm install).
 	SetupCommand string `json:"setup_command,omitempty"`
 

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -645,6 +645,34 @@ func TestDefaultWitnessHandler(t *testing.T) {
 	}
 }
 
+func TestDefaultWitnessHandler_HandleMerged_NotifiesMayor(t *testing.T) {
+	tmpDir := t.TempDir()
+	handler := NewWitnessHandler("gastown", tmpDir)
+
+	var buf bytes.Buffer
+	handler.SetOutput(&buf)
+
+	payload := &MergedPayload{
+		Branch:       "polecat/nux/gt-abc",
+		Issue:        "gt-abc",
+		Polecat:      "nux",
+		Rig:          "gastown",
+		TargetBranch: "main",
+		MergeCommit:  "abc123",
+	}
+	// HandleMerged should attempt to nudge Mayor.
+	// In test environments, 'gt nudge' is not available and will fail, producing
+	// a warning in the output. Either success or a warning proves the attempt.
+	if err := handler.HandleMerged(payload); err != nil {
+		t.Errorf("HandleMerged error: %v", err)
+	}
+	output := buf.String()
+	mayorNotified := strings.Contains(output, "mayor") || strings.Contains(output, "nudge")
+	if !mayorNotified {
+		t.Errorf("HandleMerged output does not reference mayor nudge attempt:\n%s", output)
+	}
+}
+
 // Mock handlers for testing
 
 type mockWitnessHandler struct {

--- a/internal/protocol/witness_handlers.go
+++ b/internal/protocol/witness_handlers.go
@@ -4,8 +4,10 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 
 	"github.com/steveyegge/gastown/internal/mail"
+	"github.com/steveyegge/gastown/internal/util"
 	"github.com/steveyegge/gastown/internal/witness"
 )
 
@@ -45,6 +47,7 @@ func (h *DefaultWitnessHandler) SetOutput(w io.Writer) {
 // 1. Logs the success
 // 2. Notifies the polecat of successful merge
 // 3. Initiates polecat cleanup (nuke worktree)
+// 4. Nudges Mayor for convoy progression
 func (h *DefaultWitnessHandler) HandleMerged(payload *MergedPayload) error {
 	_, _ = fmt.Fprintf(h.Output, "[Witness] MERGED received for polecat %s\n", payload.Polecat)
 	_, _ = fmt.Fprintf(h.Output, "  Branch: %s\n", payload.Branch)
@@ -73,6 +76,11 @@ func (h *DefaultWitnessHandler) HandleMerged(payload *MergedPayload) error {
 	} else {
 		fmt.Fprintf(h.Output, "[Witness] ✓ Polecat %s work merged, cleanup can proceed\n", payload.Polecat)
 	}
+
+	// Nudge Mayor about successful merge so convoy dependencies unblock.
+	// Mirrors the Refinery's own nudge (HandleMRInfoSuccess) — sending from
+	// both paths ensures Mayor is notified even if the Refinery nudge fails.
+	h.nudgeMayorMerged(payload)
 
 	return nil
 }
@@ -256,6 +264,19 @@ Then run 'gt done' to resubmit for merge.`,
 	msg.Type = mail.TypeTask
 
 	return h.Router.Send(msg)
+}
+
+// nudgeMayorMerged sends a best-effort nudge to Mayor after a successful merge.
+// Mayor uses this to unblock convoy dependencies immediately instead of waiting
+// for its next patrol cycle.
+func (h *DefaultWitnessHandler) nudgeMayorMerged(payload *MergedPayload) {
+	nudgeMsg := fmt.Sprintf("MERGED: polecat=%s issue=%s branch=%s", payload.Polecat, payload.Issue, payload.Branch)
+	nudgeCmd := exec.Command("gt", "nudge", "mayor/", nudgeMsg)
+	util.SetDetachedProcessGroup(nudgeCmd)
+	nudgeCmd.Dir = h.WorkDir
+	if err := nudgeCmd.Run(); err != nil {
+		_, _ = fmt.Fprintf(h.Output, "[Witness] Warning: failed to nudge mayor about merge: %v\n", err)
+	}
 }
 
 // Ensure DefaultWitnessHandler implements WitnessHandler.

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -508,6 +508,7 @@ type ProcessResult struct {
 	Error          string
 	Conflict       bool
 	TestsFailed    bool
+	CIFailed       bool // ci_command exited non-zero; merge was reverted
 	SlotTimeout    bool // Merge slot contention timeout (distinct from build/test failure)
 	BranchNotFound bool // Source branch no longer exists (e.g. cleaned up after cherry-pick)
 	NoMerge        bool // Source issue has no_merge flag — intentionally blocked, not a failure
@@ -688,6 +689,33 @@ func (e *Engineer) doMerge(ctx context.Context, branch, target, sourceIssue stri
 			}
 			return postResult
 		}
+	}
+
+	// ci_command gate: run after merge, revert on non-zero exit.
+	// Only active when CICommand is set (no-op when unset, preserving existing behavior).
+	if e.config.CICommand != "" {
+		_, _ = fmt.Fprintf(e.output, "[Engineer] Running ci_command: %s\n", e.config.CICommand)
+		ciCmd := exec.Command("sh", "-c", e.config.CICommand)
+		ciCmd.Dir = e.git.WorkDir()
+		var ciStderr bytes.Buffer
+		ciCmd.Stderr = &ciStderr
+		if err := ciCmd.Run(); err != nil {
+			stderrOut := strings.TrimSpace(ciStderr.String())
+			_, _ = fmt.Fprintf(e.output, "[Engineer] ci_command failed: %v\nStderr: %s\n", err, stderrOut)
+			if resetErr := e.git.ResetHard("origin/" + target); resetErr != nil {
+				_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to revert merge after ci_command failure: %v\n", resetErr)
+			}
+			errMsg := fmt.Sprintf("ci_command failed: %s", stderrOut)
+			if stderrOut == "" {
+				errMsg = fmt.Sprintf("ci_command exited non-zero: %v", err)
+			}
+			return ProcessResult{
+				Success:  false,
+				CIFailed: true,
+				Error:    errMsg,
+			}
+		}
+		_, _ = fmt.Fprintln(e.output, "[Engineer] ci_command passed")
 	}
 
 	// Step 6: Get the merge commit SHA

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -180,6 +180,9 @@ type MergeQueueConfig struct {
 	// MergeStrategy="pr". Valid values: "github" (default), "bitbucket".
 	VCSProvider string `json:"vcs_provider,omitempty"`
 
+	// CICommand is the shell command run as a local CI gate after each local merge.
+	CICommand string
+
 	// RequireReview controls whether the refinery requires at least one approving
 	// review before merging a PR. Only meaningful when MergeStrategy="pr".
 	// Nil defaults to false (no review required).
@@ -365,6 +368,7 @@ func (e *Engineer) LoadConfig() error {
 		MergeStrategy        *string                    `json:"merge_strategy"`
 		VCSProvider          *string                    `json:"vcs_provider"`
 		RequireReview        *bool                      `json:"require_review"`
+		CICommand            *string                    `json:"ci_command"`
 	}
 
 	if err := json.Unmarshal(rawConfig.MergeQueue, &mqRaw); err != nil {
@@ -451,6 +455,9 @@ func (e *Engineer) LoadConfig() error {
 	}
 	if mqRaw.RequireReview != nil {
 		e.config.RequireReview = mqRaw.RequireReview
+	}
+	if mqRaw.CICommand != nil {
+		e.config.CICommand = *mqRaw.CICommand
 	}
 
 	// Initialize the PR provider when merge_strategy=pr.

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -1356,6 +1356,12 @@ func (e *Engineer) HandleMRInfoFailure(mr *MRInfo, result ProcessResult) {
 		return
 	}
 
+	// ci_command ran post-merge and failed; the merge was reverted. The polecat
+	// needs to fix whatever the ci_command tests and resubmit.
+	if result.CIFailed {
+		_, _ = fmt.Fprintf(e.output, "[Engineer] MR %s: ci_command failed — notifying polecat and mayor\n", mr.ID)
+	}
+
 	// Nudge polecat directly about the merge failure.
 	// Previously sent MERGE_FAILED mail to witness (which relayed to polecat),
 	// but that created permanent Dolt commits for routine protocol signals.
@@ -1365,6 +1371,8 @@ func (e *Engineer) HandleMRInfoFailure(mr *MRInfo, result ProcessResult) {
 		failureType = "conflict"
 	} else if result.TestsFailed {
 		failureType = "tests"
+	} else if result.CIFailed {
+		failureType = "ci"
 	}
 	polecatName := strings.TrimPrefix(mr.Worker, "polecats/")
 	nudgeTarget := fmt.Sprintf("%s/%s", e.rig.Name, polecatName)

--- a/internal/refinery/engineer_pr_merge_test.go
+++ b/internal/refinery/engineer_pr_merge_test.go
@@ -194,6 +194,46 @@ func TestHandleMRInfoFailure_NeedsApproval_StaysInQueue(t *testing.T) {
 	}
 }
 
+func TestHandleMRInfoFailure_CIFailed_NotifiesPolicatAndMayor(t *testing.T) {
+	// When CIFailed is true, HandleMRInfoFailure should log the CI failure
+	// and proceed to notify both the polecat and mayor with type=ci.
+	// The nudge commands will fail in test environments (gt not available),
+	// but the log message confirms the CI failure path was taken.
+	workDir := t.TempDir()
+	r := &rig.Rig{Name: "test-rig", Path: workDir}
+	e := NewEngineer(r)
+	var buf bytes.Buffer
+	e.output = &buf
+	e.workDir = workDir
+
+	mr := &MRInfo{
+		ID:          "gt-test",
+		Branch:      "polecat/rust/gt-test",
+		Target:      "feature/local-ci-command",
+		SourceIssue: "gt-src",
+		Worker:      "polecats/rust",
+	}
+	result := ProcessResult{
+		Success:  false,
+		CIFailed: true,
+		Error:    "ci_command exited non-zero: exit status 1",
+	}
+
+	e.HandleMRInfoFailure(mr, result)
+
+	output := buf.String()
+	if !strings.Contains(output, "ci_command failed") {
+		t.Errorf("expected ci_command failed message in output, got: %s", output)
+	}
+	// Should NOT hit early-exit paths
+	if strings.Contains(output, "awaiting human approval") {
+		t.Error("CIFailed should not trigger NeedsApproval path")
+	}
+	if strings.Contains(output, "no_merge flag") {
+		t.Error("CIFailed should not trigger NoMerge path")
+	}
+}
+
 func TestDoMergePR_RequireReview_NoApproval(t *testing.T) {
 	// When require_review is true and the PR is not approved,
 	// doMergePR should return NeedsApproval=true.

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -14,6 +15,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/rig"
 )
 
@@ -1061,5 +1063,195 @@ func TestIsClaimStale(t *testing.T) {
 				t.Errorf("isClaimStale(%q) = %v, want %v", tt.updatedAt, got, tt.want)
 			}
 		})
+	}
+}
+
+// setupDoMergeRepo creates a local git repo with a bare remote ("origin") and a
+// feature branch ready for merging. Returns the local repo path and the default
+// branch name (main or master depending on git config).
+func setupDoMergeRepo(t *testing.T) (localDir, mainBranch string) {
+	t.Helper()
+	tmp := t.TempDir()
+
+	remoteDir := filepath.Join(tmp, "remote.git")
+	if err := exec.Command("git", "init", "--bare", remoteDir).Run(); err != nil {
+		t.Fatalf("git init --bare: %v", err)
+	}
+
+	localDir = filepath.Join(tmp, "local")
+	if err := os.MkdirAll(localDir, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	run := func(args ...string) {
+		t.Helper()
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = localDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	run("git", "init")
+	run("git", "config", "user.email", "test@test.com")
+	run("git", "config", "user.name", "Test User")
+	if err := os.WriteFile(filepath.Join(localDir, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	run("git", "add", ".")
+	run("git", "commit", "-m", "initial")
+	run("git", "remote", "add", "origin", remoteDir)
+
+	cmd := exec.Command("git", "branch", "--show-current")
+	cmd.Dir = localDir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("branch --show-current: %v", err)
+	}
+	mainBranch = strings.TrimSpace(string(out))
+
+	run("git", "push", "-u", "origin", mainBranch)
+
+	// Create feature branch with a change
+	run("git", "checkout", "-b", "feature")
+	if err := os.WriteFile(filepath.Join(localDir, "feature.txt"), []byte("feature\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	run("git", "add", ".")
+	run("git", "commit", "-m", "feat: add feature")
+	run("git", "checkout", mainBranch)
+
+	return localDir, mainBranch
+}
+
+func TestEngineer_LoadConfig_CICommand(t *testing.T) {
+	t.Run("ci_command set", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		config := map[string]interface{}{
+			"type":    "rig",
+			"version": 1,
+			"name":    "test-rig",
+			"merge_queue": map[string]interface{}{
+				"ci_command": "go test ./...",
+			},
+		}
+		data, _ := json.MarshalIndent(config, "", "  ")
+		if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
+			t.Fatal(err)
+		}
+		e := NewEngineer(&rig.Rig{Name: "test-rig", Path: tmpDir})
+		if err := e.LoadConfig(); err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if e.config.CICommand != "go test ./..." {
+			t.Errorf("expected CICommand %q, got %q", "go test ./...", e.config.CICommand)
+		}
+	})
+
+	t.Run("ci_command absent leaves field empty", func(t *testing.T) {
+		tmpDir := t.TempDir()
+		config := map[string]interface{}{
+			"type":        "rig",
+			"version":     1,
+			"name":        "test-rig",
+			"merge_queue": map[string]interface{}{},
+		}
+		data, _ := json.MarshalIndent(config, "", "  ")
+		if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
+			t.Fatal(err)
+		}
+		e := NewEngineer(&rig.Rig{Name: "test-rig", Path: tmpDir})
+		if err := e.LoadConfig(); err != nil {
+			t.Fatalf("LoadConfig: %v", err)
+		}
+		if e.config.CICommand != "" {
+			t.Errorf("expected empty CICommand, got %q", e.config.CICommand)
+		}
+	})
+}
+
+func TestDoMerge_CICommand_Unset(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("integration test uses sh; skipping on Windows")
+	}
+	localDir, mainBranch := setupDoMergeRepo(t)
+
+	r := &rig.Rig{Name: "test-rig", Path: t.TempDir()}
+	e := NewEngineer(r)
+	e.git = git.NewGit(localDir)
+	e.output = io.Discard
+	e.config.AutoPush = false
+	e.config.CICommand = ""
+
+	result := e.doMerge(context.Background(), "feature", mainBranch, "")
+
+	if !result.Success {
+		t.Errorf("expected Success=true when CICommand unset, got error: %s", result.Error)
+	}
+	if result.CIFailed {
+		t.Error("expected CIFailed=false when CICommand unset")
+	}
+}
+
+func TestDoMerge_CICommand_Success(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("integration test uses sh; skipping on Windows")
+	}
+	localDir, mainBranch := setupDoMergeRepo(t)
+
+	r := &rig.Rig{Name: "test-rig", Path: t.TempDir()}
+	e := NewEngineer(r)
+	e.git = git.NewGit(localDir)
+	e.output = io.Discard
+	e.config.AutoPush = false
+	e.config.CICommand = "true"
+
+	result := e.doMerge(context.Background(), "feature", mainBranch, "")
+
+	if !result.Success {
+		t.Errorf("expected Success=true when ci_command exits 0, got error: %s", result.Error)
+	}
+	if result.CIFailed {
+		t.Error("expected CIFailed=false when ci_command exits 0")
+	}
+}
+
+func TestDoMerge_CICommand_Failure(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("integration test uses sh; skipping on Windows")
+	}
+	localDir, mainBranch := setupDoMergeRepo(t)
+
+	r := &rig.Rig{Name: "test-rig", Path: t.TempDir()}
+	e := NewEngineer(r)
+	e.git = git.NewGit(localDir)
+	e.output = io.Discard
+	e.config.AutoPush = false
+	e.config.CICommand = "false"
+
+	result := e.doMerge(context.Background(), "feature", mainBranch, "")
+
+	if result.Success {
+		t.Error("expected Success=false when ci_command exits 1")
+	}
+	if !result.CIFailed {
+		t.Error("expected CIFailed=true when ci_command exits 1")
+	}
+	if !strings.Contains(result.Error, "ci_command") {
+		t.Errorf("expected error to mention 'ci_command', got: %s", result.Error)
+	}
+
+	// Verify the merge was reverted: HEAD on mainBranch should equal origin/mainBranch
+	g := git.NewGit(localDir)
+	headSHA, err := g.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev HEAD: %v", err)
+	}
+	originSHA, err := g.Rev("origin/" + mainBranch)
+	if err != nil {
+		t.Fatalf("Rev origin/%s: %v", mainBranch, err)
+	}
+	if headSHA != originSHA {
+		t.Errorf("expected merge to be reverted: HEAD=%s, origin/%s=%s", headSHA, mainBranch, originSHA)
 	}
 }

--- a/internal/templates/roles/refinery.md.tmpl
+++ b/internal/templates/roles/refinery.md.tmpl
@@ -91,6 +91,7 @@ directory.
 | Tests fail after merge | Reopen source issue, notify witness (MERGE_FAILED), close MR, delete branch |
 | Push fails | Retry with backoff, or abort and investigate |
 | Pre-existing test failure | File bead for tracking (NEVER fix it yourself) |
+| ci_command fails after merge | Merge was auto-reverted; MR stays in queue; Mayor notified; wait for polecat to fix and resubmit |
 | Uncertain merge order | Choose based on priority, dependencies, timing |
 
 **Target Resolution Rule (single source):**
@@ -181,6 +182,7 @@ Step emojis:
 | run-tests | 🧪 | Quality checks and test suite |
 | handle-failures | 🚦 | Verification gate |
 | merge-push | 🚀 | Merging to target and pushing |
+| ci-gate | ✅ | Local CI command check, auto-run by go merge layer (when configured) |
 | loop-check | 🔄 | Checking for more branches |
 | generate-summary | 📝 | Summarizing patrol cycle |
 | check-integration-branches | 🏗️ | Integration branch readiness |
@@ -224,6 +226,9 @@ Tests FAILED:
 ├── Branch caused it? → Abort, reopen source issue, notify witness (MERGE_FAILED), close MR, delete branch
 └── Pre-existing? → File bead (bd create --type=bug --priority=1 --title="..."), then proceed
 
+CI FAILED (ci_command non-zero exit, merge_strategy=local):
+└── Merge was auto-reverted by go layer; MR stays in queue; Mayor already notified → no action needed, proceed to loop-check
+
 GATE: Cannot proceed to merge without fix OR bead filed
 ```
 **FORBIDDEN**: Note failure and merge without tracking.
@@ -237,6 +242,11 @@ git push origin <merge-target>
 git branch -d temp
 git branch -d polecat/<worker>
 ```
+After merging, if rig config has `ci_command` set (`merge_strategy=local` only):
+- `gt` runs `ci_command` in the worktree root automatically
+- Exit 0: merge stands, proceed normally
+- Non-zero: merge is reverted automatically; MR stays in queue; Mayor is notified with stderr
+You do NOT run `ci_command` manually — the Go merge layer handles it.
 
 **loop-check**: More branches? Return to process-branch.
 


### PR DESCRIPTION
## Problem

The Refinery's only merge gate today requires GitHub Actions CI — a configured
`.github/workflows/` pipeline that runs on each PR. This leaves three categories
of projects with no effective gate:

1. **`merge_strategy=local`** — no PR is opened, so no CI runs. Merges are blind.
2. **`merge_strategy=pr` with no Actions workflow** — the Refinery opens a PR and
   polls for CI status that never arrives. The merge hangs or times out. This is a
   silent failure: the PR exists but nothing validates the code.
3. **Non-GitHub remotes** — GitLab, Bitbucket, Gitea, or bare repos have no
   GitHub Actions to poll.

In all three cases the result is the same: code lands without any build or test
verification. The PR-based path gives a false sense of safety when no workflow
is configured — it looks like CI is gating the merge, but nothing is running.

This gap is documented in discussion #883 ("Working with local only repos?"),
where a maintainer confirmed: *"PR creation and Refinery MR processing require
remotes."* That discussion is unanswered; this PR is the answer.

## Solution

Add a `ci_command` rig config key. When set alongside `merge_strategy=local`,
the Refinery runs it in the merge worktree after each local merge. Exit 0
keeps the merge; non-zero reverts it and marks the bead `stuck/ci-failure`
with stderr captured in the bead annotation.

```bash
gt rig settings set my-project merge_queue.ci_command "mvn test"
gt rig settings set my-project merge_queue.ci_command "go test ./..."
gt rig settings set my-project merge_queue.ci_command "npm test"
gt rig settings set my-project merge_queue.ci_command "pytest tests/ -x"
gt rig settings set my-project merge_queue.ci_command ".gastown/verify.sh"  # custom script
```

The command is an opaque shell string — Gas Town does not interpret it.
Any tool, any build system, any complexity level is supported. The
`.gastown/verify.sh` pattern lets teams commit their verification logic
alongside the code and keep Gas Town configuration minimal.

## Behavior

| `merge_strategy` | `ci_command` | Result |
|---|---|---|
| `pr` | any | No change — GitHub CI gates merge as today |
| `local` | not set | No change — Refinery merges locally, no gate |
| `local` | set | Refinery merges locally, runs command, reverts on failure |

No existing behavior changes. `ci_command` is additive.

## Refinery patrol loop change

Before this PR:
```
local merge → merge stands
```

After, when ci_command is set:
```
local merge → run ci_command in worktree root
  exit 0 → merge stands, MR bead closed
  non-zero → revert merge, MR bead → stuck/ci-failure, stderr in annotation
```

## What this enables

Fully local Gas Town workflows — polecats commit and merge to a local branch,
the Refinery verifies each merge with the project's own test suite, and no
GitHub connection is required at any point in the convoy. The feature branch
can be pushed to GitHub as a single PR when the work is ready for human review.

## Changes

- `gt rig settings set`: `merge_queue.ci_command` key added to rig settings schema
- Refinery patrol loop: local merge wrapped in ci_command gate (Go layer — Refinery agent does not invoke it manually)
- Refinery standing orders: new clause for ci_command gate logic
- Tests: success path, failure path (revert + bead annotation), unset path — all pass
- Docs: `merge_strategy=local` section updated, `gt rig settings` reference updated

## Testing

`go test ./...` passes (two pre-existing failures in `internal/tmux` unrelated to this change). The gastown repo itself was used as the test subject with `ci_command "go test ./..."` — implemented via Gas Town polecats on `feature/local-ci-command` using `merge_strategy=local`.