### PR TITLE
fix(doltserver): fix nightly integration test failures for wl-commons

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -2480,7 +2480,9 @@ func MigrateRigFromBeads(townRoot, rigName, sourcePath string) error {
 	return nil
 }
 
-// DatabaseExists checks whether a rig database exists in the centralized .dolt-data/ directory.
+// DatabaseExists checks whether a rig database exists on the host filesystem
+// (.dolt-data/<name>/.dolt). This is a conservative filesystem-only check;
+// for containerised Dolt use WLCommons.DatabaseExists instead.
 func DatabaseExists(townRoot, rigName string) bool {
 	config := DefaultConfig(townRoot)
 	doltDir := filepath.Join(config.DataDir, rigName, ".dolt")

--- a/internal/doltserver/wl_commons.go
+++ b/internal/doltserver/wl_commons.go
@@ -68,7 +68,24 @@ func (w *WLCommons) DBName() string {
 }
 
 func (w *WLCommons) EnsureDB() error           { return EnsureWLCommons(w.townRoot) }
-func (w *WLCommons) DatabaseExists(db string) bool { return DatabaseExists(w.townRoot, db) }
+// DatabaseExists checks whether db exists. Tries the host filesystem first;
+// falls back to a live SHOW DATABASES query so containerised Dolt is handled.
+func (w *WLCommons) DatabaseExists(db string) bool {
+	if DatabaseExists(w.townRoot, db) {
+		return true
+	}
+	// Filesystem miss — ask the server directly (data may live inside a container).
+	output, err := doltSQLQuery(w.townRoot, fmt.Sprintf("SHOW DATABASES LIKE '%s'", EscapeSQL(db)))
+	if err != nil {
+		return false
+	}
+	for _, line := range strings.Split(output, "\n") {
+		if strings.TrimSpace(line) == db {
+			return true
+		}
+	}
+	return false
+}
 func (w *WLCommons) InsertWanted(item *WantedItem) error { return InsertWanted(w.townRoot, item) }
 func (w *WLCommons) ClaimWanted(wantedID, rigHandle string) error {
 	return ClaimWanted(w.townRoot, wantedID, rigHandle)
@@ -158,6 +175,13 @@ func EnsureWLCommons(townRoot string) error {
 
 	_, created, err := InitRig(townRoot, WLCommonsDB)
 	if err != nil {
+		// In containerized Dolt the database lives inside the container, so the
+		// host-filesystem guard above misses it and InitRig issues CREATE DATABASE
+		// against a server that already has the DB. Treat this as a successful
+		// no-op: the schema was initialised by the first EnsureDB call.
+		if strings.Contains(err.Error(), "database exists") {
+			return nil
+		}
 		return fmt.Errorf("creating wl-commons database: %w", err)
 	}
 

--- a/internal/doltserver/wl_commons.go
+++ b/internal/doltserver/wl_commons.go
@@ -178,7 +178,7 @@ func EnsureWLCommons(townRoot string) error {
 		// In containerized Dolt the database lives inside the container, so the
 		// host-filesystem guard above misses it and InitRig issues CREATE DATABASE
 		// against a server that already has the DB. Treat this as a successful
-		// no-op: the schema was initialised by the first EnsureDB call.
+		// no-op: the schema was initialized by the first EnsureDB call.
 		if strings.Contains(err.Error(), "database exists") {
 			return nil
 		}

--- a/internal/doltserver/wl_commons_conformance_test.go
+++ b/internal/doltserver/wl_commons_conformance_test.go
@@ -8,9 +8,18 @@ import (
 // wlCommonsConformance is a shared test suite that validates any WLCommonsStore
 // implementation against the expected behavioral contract. It runs against the
 // fake (always) and can run against the real Dolt server with build tags.
-func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsStore) {
+//
+// Pass parallel=false when the store shares a real Dolt working set across
+// subtests. Concurrent DOLT_COMMIT calls can race (one session's DOLT_ADD
+// picks up another's staged changes), causing spurious failures. Sequential
+// execution eliminates the race without requiring per-subtest DB isolation.
+func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsStore, parallel ...bool) {
+	runParallel := len(parallel) == 0 || parallel[0]
+
 	t.Run("InsertAndQuery", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		item := &WantedItem{
@@ -43,7 +52,9 @@ func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsSto
 	})
 
 	t.Run("ClaimOpenItem", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		if err := store.InsertWanted(&WantedItem{ID: "w-conf02", Title: "Claimable"}); err != nil {
@@ -66,7 +77,9 @@ func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsSto
 	})
 
 	t.Run("ClaimNonOpenItem", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		if err := store.InsertWanted(&WantedItem{ID: "w-conf03", Title: "Already claimed"}); err != nil {
@@ -94,7 +107,9 @@ func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsSto
 	})
 
 	t.Run("SubmitCompletionLifecycle", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		if err := store.InsertWanted(&WantedItem{ID: "w-conf04", Title: "Completable"}); err != nil {
@@ -118,7 +133,9 @@ func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsSto
 	})
 
 	t.Run("QueryNotFound", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		_, err := store.QueryWanted("w-nonexistent")
@@ -128,7 +145,9 @@ func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsSto
 	})
 
 	t.Run("InsertEmptyIDFails", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		err := store.InsertWanted(&WantedItem{ID: "", Title: "No ID"})
@@ -138,7 +157,9 @@ func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsSto
 	})
 
 	t.Run("InsertEmptyTitleFails", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		err := store.InsertWanted(&WantedItem{ID: "w-nope", Title: ""})
@@ -148,7 +169,9 @@ func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsSto
 	})
 
 	t.Run("EnsureDBIdempotent", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		if err := store.EnsureDB(); err != nil {
@@ -160,7 +183,9 @@ func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsSto
 	})
 
 	t.Run("DatabaseExistsAfterEnsure", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		if err := store.EnsureDB(); err != nil {
@@ -172,7 +197,9 @@ func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsSto
 	})
 
 	t.Run("DefaultStatusIsOpen", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		if err := store.InsertWanted(&WantedItem{ID: "w-conf05", Title: "Default status"}); err != nil {
@@ -188,7 +215,9 @@ func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsSto
 	})
 
 	t.Run("InsertWithExplicitStatus", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		if err := store.InsertWanted(&WantedItem{ID: "w-conf06", Title: "Explicit status", Status: "withdrawn"}); err != nil {
@@ -204,7 +233,9 @@ func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsSto
 	})
 
 	t.Run("SubmitCompletionOnOpenItem", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		if err := store.InsertWanted(&WantedItem{ID: "w-conf08", Title: "Open item"}); err != nil {
@@ -228,7 +259,9 @@ func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsSto
 	})
 
 	t.Run("SubmitCompletionByWrongRig", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		if err := store.InsertWanted(&WantedItem{ID: "w-conf09", Title: "Wrong rig item"}); err != nil {
@@ -255,7 +288,9 @@ func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsSto
 	})
 
 	t.Run("SubmitCompletionAlreadyDone", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		if err := store.InsertWanted(&WantedItem{ID: "w-conf11", Title: "Already done"}); err != nil {
@@ -285,7 +320,9 @@ func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsSto
 	})
 
 	t.Run("DatabaseExistsWrongName", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		if err := store.EnsureDB(); err != nil {
@@ -297,7 +334,9 @@ func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsSto
 	})
 
 	t.Run("InsertDuplicateIDFails", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		if err := store.InsertWanted(&WantedItem{ID: "w-conf10", Title: "First insert"}); err != nil {
@@ -311,7 +350,9 @@ func wlCommonsConformance(t *testing.T, newStore func(t *testing.T) WLCommonsSto
 	})
 
 	t.Run("ClaimSetsClaimedBy", func(t *testing.T) {
-		t.Parallel()
+		if runParallel {
+			t.Parallel()
+		}
 		store := newStore(t)
 
 		if err := store.InsertWanted(&WantedItem{ID: "w-conf07", Title: "Check claimer"}); err != nil {

--- a/internal/doltserver/wl_commons_integration_test.go
+++ b/internal/doltserver/wl_commons_integration_test.go
@@ -33,16 +33,17 @@ func startIsolatedDoltContainer(t *testing.T) string {
 func TestRealWLCommonsStore_Conformance(t *testing.T) {
 	townRoot := startIsolatedDoltContainer(t)
 
-	// Pre-create the database before parallel subtests to avoid
-	// concurrent CREATE DATABASE races.
-	store := NewWLCommons(townRoot)
-	if err := store.EnsureDB(); err != nil {
-		t.Fatalf("EnsureDB() error: %v", err)
-	}
-
+	// Run subtests sequentially (parallel=false) to prevent concurrent
+	// DOLT_COMMIT calls from racing on the shared wl_commons working set.
+	// Each subtest's newStore call ensures the DB exists (idempotent).
 	wlCommonsConformance(t, func(t *testing.T) WLCommonsStore {
-		return NewWLCommons(townRoot)
-	})
+		t.Helper()
+		store := NewWLCommons(townRoot)
+		if err := store.EnsureDB(); err != nil {
+			t.Fatalf("EnsureDB() error: %v", err)
+		}
+		return store
+	}, false)
 }
 
 // TestIsNothingToCommit_RealDolt verifies that isNothingToCommit correctly detects

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -197,7 +197,7 @@ type freshBranchMeta struct {
 }
 
 // parseFreshBranchName is the structural inverse of freshBranchName. It
-// does not consult git or the filesystem; it recognises the two formats
+// does not consult git or the filesystem; it recognizes the two formats
 // the formatter emits. Used in place of substring heuristics so that
 // branch-naming changes can be made in a single place.
 func parseFreshBranchName(branch string) freshBranchMeta {


### PR DESCRIPTION
Fix three interrelated causes of the nightly integration test failures (antns1/fergus#336).

- EnsureWLCommons: treat database-already-exists error from InitRig as a successful no-op. Containerised Dolt data lives inside the container so the host-filesystem guard misses it; InitRig then issues CREATE DATABASE against a server that already owns the DB (ERROR 1007).
- WLCommons.DatabaseExists: add server-side SHOW DATABASES fallback after the filesystem check so DatabaseExistsAfterEnsure passes for containerised Dolt. The package-level DatabaseExists stays filesystem-only to avoid false positives in FindBrokenWorkspaces.
- wlCommonsConformance: add variadic parallel parameter; integration tests pass false so subtests run sequentially, preventing concurrent DOLT_COMMIT calls from racing on the shared wl_commons working set. Each newStore call also runs EnsureDB (idempotent).

Generated with Claude Code