### PR TITLE
fix(status): show hook info for rig agents

### DIFF
--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -1545,7 +1545,15 @@ func discoverRigHooks(r *rig.Rig, crews []string, townHookedByAssignee map[strin
 	// BeadsPath() returns r.Path which follows the redirect to the rig's
 	// actual beads database (mayor/rig/.beads when tracked, or local).
 	rigHookedByAssignee := loadHookedByAssignee(beads.New(r.BeadsPath()))
+	return resolveRigHooks(r, crews, rigHookedByAssignee, townHookedByAssignee)
+}
 
+// resolveRigHooks builds the per-agent AgentHookInfo list from already-loaded
+// rig and town hooked-work maps. Pure (no I/O) so it can be unit-tested.
+//
+// Precedence: a rig-local hook for an agent shadows a town-level hook for the
+// same agent address. Agents not in either map produce HasWork=false.
+func resolveRigHooks(r *rig.Rig, crews []string, rigHookedByAssignee, townHookedByAssignee map[string]*beads.Issue) []AgentHookInfo {
 	pickHook := func(addr string) *beads.Issue {
 		if issue, ok := rigHookedByAssignee[addr]; ok {
 			return issue
@@ -1589,25 +1597,32 @@ func discoverRigHooks(r *rig.Rig, crews []string, townHookedByAssignee map[strin
 // Hooked beads (work slung but not yet claimed) take precedence over
 // in_progress beads when an assignee has both.
 func loadHookedByAssignee(b *beads.Beads) map[string]*beads.Issue {
+	hooked, _ := b.List(beads.ListOptions{Status: beads.StatusHooked, Priority: -1})
+	inProgress, _ := b.List(beads.ListOptions{Status: "in_progress", Priority: -1})
+	return mergeHookedByAssignee(hooked, inProgress)
+}
+
+// mergeHookedByAssignee builds the assignee→issue index from the two issue
+// lists loadHookedByAssignee fetches. Hooked beads win over in_progress beads
+// when an assignee has both (work just slung is the most current intent);
+// within either list, the first occurrence wins. Issues with empty assignee
+// are skipped — they belong to nobody and shouldn't surface in gt status.
+func mergeHookedByAssignee(hooked, inProgress []*beads.Issue) map[string]*beads.Issue {
 	result := make(map[string]*beads.Issue)
-	if hooked, err := b.List(beads.ListOptions{Status: beads.StatusHooked, Priority: -1}); err == nil {
-		for _, issue := range hooked {
-			if issue.Assignee == "" {
-				continue
-			}
-			if _, exists := result[issue.Assignee]; !exists {
-				result[issue.Assignee] = issue
-			}
+	for _, issue := range hooked {
+		if issue == nil || issue.Assignee == "" {
+			continue
+		}
+		if _, exists := result[issue.Assignee]; !exists {
+			result[issue.Assignee] = issue
 		}
 	}
-	if inProgress, err := b.List(beads.ListOptions{Status: "in_progress", Priority: -1}); err == nil {
-		for _, issue := range inProgress {
-			if issue.Assignee == "" {
-				continue
-			}
-			if _, exists := result[issue.Assignee]; !exists {
-				result[issue.Assignee] = issue
-			}
+	for _, issue := range inProgress {
+		if issue == nil || issue.Assignee == "" {
+			continue
+		}
+		if _, exists := result[issue.Assignee]; !exists {
+			result[issue.Assignee] = issue
 		}
 	}
 	return result

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -760,6 +760,14 @@ func gatherStatus() (TownStatus, error) {
 
 	beadsWg.Wait()
 
+	// Pre-fetch town-level hooked work once. Used by per-rig hook discovery
+	// to surface town beads (e.g. hq-* slung from Mayor) on rig-level agents.
+	// Skipped in --fast mode since hook display is already skipped there.
+	var townHookedByAssignee map[string]*beads.Issue
+	if !statusFast {
+		townHookedByAssignee = loadHookedByAssignee(beads.New(filepath.Join(townRoot, ".beads")))
+	}
+
 	// Create mail router for inbox lookups
 	mailRouter := mail.NewRouter(townRoot)
 
@@ -891,13 +899,13 @@ func gatherStatus() (TownStatus, error) {
 			var rigWg sync.WaitGroup
 
 			// Discover hooks for all agents in this rig
-			// In --fast mode, skip expensive handoff bead lookups. Hook info comes from
+			// In --fast mode, skip expensive bd queries. Hook info comes from
 			// preloaded agent beads via discoverRigAgents instead.
 			if !statusFast {
 				rigWg.Add(1)
 				go func() {
 					defer rigWg.Done()
-					rs.Hooks = discoverRigHooks(r, rs.Crews)
+					rs.Hooks = discoverRigHooks(r, rs.Crews, townHookedByAssignee)
 				}()
 			}
 
@@ -1523,70 +1531,86 @@ func capitalizeFirst(s string) string {
 	return string(s[0]-32) + s[1:]
 }
 
-// discoverRigHooks finds all hook attachments for agents in a rig.
-// It fetches all pinned handoff beads in a single bd call, then resolves
-// each agent's hook in-memory. This replaces the previous N+1 pattern where
-// each agent triggered a separate bd subprocess.
-func discoverRigHooks(r *rig.Rig, crews []string) []AgentHookInfo {
+// discoverRigHooks finds all hook assignments for agents in a rig.
+// It queries the rig's beads database for status=hooked and status=in_progress
+// beads, grouped by assignee. Town-level hooks (e.g. hq-* beads slung to a
+// rig agent) are also matched via townHookedByAssignee.
+//
+// This is the authoritative source for hook display, matching what
+// `gt hook show` and `gt mol status` use. Reading the agent bead's
+// hook_bead column directly returns stale data because that field is
+// no longer maintained (see GH#2371).
+func discoverRigHooks(r *rig.Rig, crews []string, townHookedByAssignee map[string]*beads.Issue) []AgentHookInfo {
+	// Query rig beads for hooked + in_progress work, grouped by assignee.
+	// BeadsPath() returns r.Path which follows the redirect to the rig's
+	// actual beads database (mayor/rig/.beads when tracked, or local).
+	rigHookedByAssignee := loadHookedByAssignee(beads.New(r.BeadsPath()))
+
+	pickHook := func(addr string) *beads.Issue {
+		if issue, ok := rigHookedByAssignee[addr]; ok {
+			return issue
+		}
+		if townHookedByAssignee != nil {
+			if issue, ok := townHookedByAssignee[addr]; ok {
+				return issue
+			}
+		}
+		return nil
+	}
+
 	var hooks []AgentHookInfo
-
-	// Create beads instance for the rig
-	b := beads.New(r.Path)
-
-	// Batch-fetch all handoff beads in one bd call
-	allHandoffs, err := b.FindAllHandoffBeads()
-	if err != nil {
-		// On error, return empty hooks for all agents rather than failing
-		allHandoffs = make(map[string]*beads.Issue)
+	addHook := func(address, roleType string) {
+		hook := AgentHookInfo{Agent: address, Role: roleType}
+		if issue := pickHook(address); issue != nil {
+			hook.HasWork = true
+			hook.Molecule = issue.ID
+			hook.Title = issue.Title
+		}
+		hooks = append(hooks, hook)
 	}
 
-	// Check polecats
 	for _, name := range r.Polecats {
-		hooks = append(hooks, resolveHookFromMap(allHandoffs, name, r.Name+"/"+name, constants.RolePolecat))
+		addHook(r.Name+"/"+name, constants.RolePolecat)
 	}
-
-	// Check crew workers
 	for _, name := range crews {
-		hooks = append(hooks, resolveHookFromMap(allHandoffs, name, r.Name+"/crew/"+name, constants.RoleCrew))
+		addHook(r.Name+"/crew/"+name, constants.RoleCrew)
 	}
-
-	// Check witness
 	if r.HasWitness {
-		hooks = append(hooks, resolveHookFromMap(allHandoffs, constants.RoleWitness, r.Name+"/witness", constants.RoleWitness))
+		addHook(r.Name+"/witness", constants.RoleWitness)
 	}
-
-	// Check refinery
 	if r.HasRefinery {
-		hooks = append(hooks, resolveHookFromMap(allHandoffs, constants.RoleRefinery, r.Name+"/refinery", constants.RoleRefinery))
+		addHook(r.Name+"/refinery", constants.RoleRefinery)
 	}
-
 	return hooks
 }
 
-// resolveHookFromMap builds an AgentHookInfo from a pre-fetched map of handoff beads.
-// This is the in-memory equivalent of getAgentHook, avoiding per-agent bd subprocess calls.
-func resolveHookFromMap(allHandoffs map[string]*beads.Issue, role, agentAddress, roleType string) AgentHookInfo {
-	hook := AgentHookInfo{
-		Agent: agentAddress,
-		Role:  roleType,
+// loadHookedByAssignee queries a beads database for hooked and in_progress
+// work, returning a map of assignee address to the bead they're working on.
+// Hooked beads (work slung but not yet claimed) take precedence over
+// in_progress beads when an assignee has both.
+func loadHookedByAssignee(b *beads.Beads) map[string]*beads.Issue {
+	result := make(map[string]*beads.Issue)
+	if hooked, err := b.List(beads.ListOptions{Status: beads.StatusHooked, Priority: -1}); err == nil {
+		for _, issue := range hooked {
+			if issue.Assignee == "" {
+				continue
+			}
+			if _, exists := result[issue.Assignee]; !exists {
+				result[issue.Assignee] = issue
+			}
+		}
 	}
-
-	handoff, ok := allHandoffs[role]
-	if !ok || handoff == nil {
-		return hook
+	if inProgress, err := b.List(beads.ListOptions{Status: "in_progress", Priority: -1}); err == nil {
+		for _, issue := range inProgress {
+			if issue.Assignee == "" {
+				continue
+			}
+			if _, exists := result[issue.Assignee]; !exists {
+				result[issue.Assignee] = issue
+			}
+		}
 	}
-
-	attachment := beads.ParseAttachmentFields(handoff)
-	if attachment != nil && attachment.AttachedMolecule != "" {
-		hook.HasWork = true
-		hook.Molecule = attachment.AttachedMolecule
-		hook.Title = handoff.Title
-	} else if handoff.Description != "" {
-		hook.HasWork = true
-		hook.Title = handoff.Title
-	}
-
-	return hook
+	return result
 }
 
 // discoverGlobalAgents checks runtime state for town-level agents (Mayor, Deacon).

--- a/internal/cmd/status_hooks_test.go
+++ b/internal/cmd/status_hooks_test.go
@@ -1,0 +1,224 @@
+package cmd
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/rig"
+)
+
+// TestMergeHookedByAssignee_EmptyAssigneeSkipped verifies that issues without
+// an assignee are dropped (they don't belong on any agent's display row).
+func TestMergeHookedByAssignee_EmptyAssigneeSkipped(t *testing.T) {
+	hooked := []*beads.Issue{
+		{ID: "hq-1", Assignee: ""},
+		{ID: "hq-2", Assignee: "rig/witness"},
+	}
+
+	got := mergeHookedByAssignee(hooked, nil)
+	if _, ok := got[""]; ok {
+		t.Errorf("merged map contains entry for empty assignee")
+	}
+	if got["rig/witness"] == nil || got["rig/witness"].ID != "hq-2" {
+		t.Errorf("expected hq-2 for rig/witness, got %+v", got["rig/witness"])
+	}
+}
+
+// TestMergeHookedByAssignee_HookedBeatsInProgress verifies hooked work shadows
+// in_progress work for the same assignee — the most recently-slung intent.
+func TestMergeHookedByAssignee_HookedBeatsInProgress(t *testing.T) {
+	hooked := []*beads.Issue{{ID: "hq-new", Assignee: "rig/refinery"}}
+	inProgress := []*beads.Issue{{ID: "hq-old", Assignee: "rig/refinery"}}
+
+	got := mergeHookedByAssignee(hooked, inProgress)
+	if got["rig/refinery"].ID != "hq-new" {
+		t.Errorf("got %q, want hq-new (hooked must shadow in_progress)", got["rig/refinery"].ID)
+	}
+}
+
+// TestMergeHookedByAssignee_InProgressFillsWhenNoHooked verifies that
+// in_progress is the fallback when an assignee has no hooked work — covers
+// the "session was interrupted mid-work" case.
+func TestMergeHookedByAssignee_InProgressFillsWhenNoHooked(t *testing.T) {
+	hooked := []*beads.Issue{{ID: "hq-other", Assignee: "rig/witness"}}
+	inProgress := []*beads.Issue{{ID: "hq-running", Assignee: "rig/refinery"}}
+
+	got := mergeHookedByAssignee(hooked, inProgress)
+	if got["rig/refinery"].ID != "hq-running" {
+		t.Errorf("got %v, want hq-running for rig/refinery", got["rig/refinery"])
+	}
+	if got["rig/witness"].ID != "hq-other" {
+		t.Errorf("got %v, want hq-other for rig/witness", got["rig/witness"])
+	}
+}
+
+// TestMergeHookedByAssignee_FirstOccurrenceWins verifies that within the
+// hooked list, the first issue for an assignee wins (deterministic).
+func TestMergeHookedByAssignee_FirstOccurrenceWins(t *testing.T) {
+	hooked := []*beads.Issue{
+		{ID: "hq-first", Assignee: "rig/polecats/Toast"},
+		{ID: "hq-second", Assignee: "rig/polecats/Toast"},
+	}
+
+	got := mergeHookedByAssignee(hooked, nil)
+	if got["rig/polecats/Toast"].ID != "hq-first" {
+		t.Errorf("got %q, want hq-first (first occurrence)", got["rig/polecats/Toast"].ID)
+	}
+}
+
+// TestMergeHookedByAssignee_NilIssuesSkipped covers defensive nil-skip.
+func TestMergeHookedByAssignee_NilIssuesSkipped(t *testing.T) {
+	hooked := []*beads.Issue{nil, {ID: "hq-1", Assignee: "rig/witness"}, nil}
+	got := mergeHookedByAssignee(hooked, []*beads.Issue{nil})
+	if len(got) != 1 || got["rig/witness"].ID != "hq-1" {
+		t.Errorf("unexpected merge result: %+v", got)
+	}
+}
+
+// TestResolveRigHooks_PolecatsAndCrew verifies polecat and crew agents are
+// emitted with their address-formatted assignees and matched against the
+// rig map.
+func TestResolveRigHooks_PolecatsAndCrew(t *testing.T) {
+	r := &rig.Rig{Name: "myrig", Polecats: []string{"Toast", "Pickle"}}
+	crews := []string{"alice"}
+	rigMap := map[string]*beads.Issue{
+		"myrig/Toast":      {ID: "mr-1", Title: "polecat work"},
+		"myrig/crew/alice": {ID: "mr-2", Title: "crew work"},
+	}
+
+	hooks := resolveRigHooks(r, crews, rigMap, nil)
+
+	got := indexByAgent(hooks)
+	if !got["myrig/Toast"].HasWork || got["myrig/Toast"].Molecule != "mr-1" {
+		t.Errorf("Toast hook missing/wrong: %+v", got["myrig/Toast"])
+	}
+	if got["myrig/Pickle"].HasWork {
+		t.Errorf("Pickle should be empty: %+v", got["myrig/Pickle"])
+	}
+	if !got["myrig/crew/alice"].HasWork || got["myrig/crew/alice"].Molecule != "mr-2" {
+		t.Errorf("alice hook missing/wrong: %+v", got["myrig/crew/alice"])
+	}
+}
+
+// TestResolveRigHooks_RigShadowsTown verifies a rig-local hook for an agent
+// shadows a town-level hook for the same address.
+func TestResolveRigHooks_RigShadowsTown(t *testing.T) {
+	r := &rig.Rig{Name: "myrig", HasWitness: true}
+	rigMap := map[string]*beads.Issue{
+		"myrig/witness": {ID: "mr-rig", Title: "rig wisp"},
+	}
+	townMap := map[string]*beads.Issue{
+		"myrig/witness": {ID: "hq-town", Title: "town wisp"},
+	}
+
+	hooks := resolveRigHooks(r, nil, rigMap, townMap)
+
+	got := indexByAgent(hooks)
+	if got["myrig/witness"].Molecule != "mr-rig" {
+		t.Errorf("got %q, want mr-rig (rig must shadow town)", got["myrig/witness"].Molecule)
+	}
+}
+
+// TestResolveRigHooks_TownFallback verifies town-level hooks surface for
+// rig agents when there's no rig-local match — covers Mayor→polecat slings
+// where the work bead lives in town beads.
+func TestResolveRigHooks_TownFallback(t *testing.T) {
+	r := &rig.Rig{Name: "myrig", HasRefinery: true}
+	townMap := map[string]*beads.Issue{
+		"myrig/refinery": {ID: "hq-wisp-aaa", Title: "patrol"},
+	}
+
+	hooks := resolveRigHooks(r, nil, nil, townMap)
+
+	got := indexByAgent(hooks)
+	if !got["myrig/refinery"].HasWork || got["myrig/refinery"].Molecule != "hq-wisp-aaa" {
+		t.Errorf("refinery should pick up town hook, got %+v", got["myrig/refinery"])
+	}
+}
+
+// TestResolveRigHooks_NilTownMap verifies a nil townHookedByAssignee map is
+// safe — discoverRigHooks passes nil in --fast mode.
+func TestResolveRigHooks_NilTownMap(t *testing.T) {
+	r := &rig.Rig{Name: "myrig", HasWitness: true}
+	rigMap := map[string]*beads.Issue{
+		"myrig/witness": {ID: "mr-1", Title: "patrol"},
+	}
+
+	hooks := resolveRigHooks(r, nil, rigMap, nil)
+
+	got := indexByAgent(hooks)
+	if !got["myrig/witness"].HasWork || got["myrig/witness"].Molecule != "mr-1" {
+		t.Errorf("witness should resolve from rigMap with nil townMap: %+v", got["myrig/witness"])
+	}
+}
+
+// TestResolveRigHooks_RoleEmittedExactlyOnce verifies the order and roles of
+// emitted entries: polecats first, then crew, then witness, then refinery.
+// Order matters for the `gt status` rendering loop.
+func TestResolveRigHooks_RoleEmittedExactlyOnce(t *testing.T) {
+	r := &rig.Rig{
+		Name:        "myrig",
+		Polecats:    []string{"a", "b"},
+		HasWitness:  true,
+		HasRefinery: true,
+	}
+	hooks := resolveRigHooks(r, []string{"crew1"}, nil, nil)
+
+	gotAddrs := make([]string, 0, len(hooks))
+	gotRoles := make([]string, 0, len(hooks))
+	for _, h := range hooks {
+		gotAddrs = append(gotAddrs, h.Agent)
+		gotRoles = append(gotRoles, h.Role)
+	}
+
+	wantAddrs := []string{"myrig/a", "myrig/b", "myrig/crew/crew1", "myrig/witness", "myrig/refinery"}
+	wantRoles := []string{
+		constants.RolePolecat,
+		constants.RolePolecat,
+		constants.RoleCrew,
+		constants.RoleWitness,
+		constants.RoleRefinery,
+	}
+
+	if !reflect.DeepEqual(gotAddrs, wantAddrs) {
+		t.Errorf("addresses = %v, want %v", gotAddrs, wantAddrs)
+	}
+	if !reflect.DeepEqual(gotRoles, wantRoles) {
+		t.Errorf("roles = %v, want %v", gotRoles, wantRoles)
+	}
+}
+
+// TestResolveRigHooks_NoAgentsNoHooks verifies an empty rig produces no
+// AgentHookInfo entries — the rendering loop relies on len(hooks)==0 to
+// skip the section entirely.
+func TestResolveRigHooks_NoAgentsNoHooks(t *testing.T) {
+	r := &rig.Rig{Name: "empty"}
+	hooks := resolveRigHooks(r, nil, nil, nil)
+	if len(hooks) != 0 {
+		t.Errorf("expected no hooks for empty rig, got %d: %+v", len(hooks), hooks)
+	}
+}
+
+// indexByAgent maps an AgentHookInfo slice by Agent for easier assertions.
+func indexByAgent(hooks []AgentHookInfo) map[string]AgentHookInfo {
+	m := make(map[string]AgentHookInfo, len(hooks))
+	for _, h := range hooks {
+		m[h.Agent] = h
+	}
+	return m
+}
+
+// keys returns the sorted keys of a map[string]X for deterministic assertion.
+func keys[V any](m map[string]V) []string {
+	out := make([]string, 0, len(m))
+	for k := range m {
+		out = append(out, k)
+	}
+	sort.Strings(out)
+	return out
+}
+
+var _ = keys[int] // keep generic helper available


### PR DESCRIPTION
## Summary

\`gt status\` was not displaying what any rig agent (polecat, crew, witness, refinery) is hooked on. Two reasons:

1. **Wrong data source.** \`discoverRigHooks\` looked up pinned "<role> Handoff" beads, the legacy attach-to-handoff model. Sling now writes \`status=hooked\` + \`assignee\` on the work bead directly, so handoff lookups returned nothing and every agent rendered without a hook suffix.
2. **Wrong path.** The pre-fetch of agent beads hard-coded \`r.Path/mayor/rig\`, but rigs that keep beads at the rig root (e.g. \`t2axsome\`, \`fieldnotes\`) have nothing under \`mayor/rig/.beads\`.

This switches \`discoverRigHooks\` to the authoritative source already used by \`gt hook show\` and \`gt mol status\`: list \`status=hooked\` (and \`status=in_progress\`) beads in the rig DB plus town DB, indexed by assignee. Town beads are queried once per invocation so cross-rig \`hq-*\` slings (e.g. Mayor→polecat) resolve too. Rig queries go through \`r.BeadsPath()\` (redirect-aware) instead of \`mayor/rig\`.

Before:
\`\`\`
🦉 witness      ● [claude]
🏭 refinery     ● [claude]
\`\`\`

After:
\`\`\`
🦉 witness      ● [claude] → mol-witness-patrol
🏭 refinery     ● [claude] → mol-refinery-patrol
\`\`\`

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go vet ./...\` clean
- [x] \`go test ./internal/cmd/\` passes
- [x] Manual: \`gt status\` now shows \`→ mol-witness-patrol\` / \`→ mol-refinery-patrol\` for hooked witnesses/refineries across rigs (gastown, t2axsome, walletui, fieldnotes)
- [x] \`gt status --json\` includes populated \`hooks[].molecule\` and \`hooks[].title\`
- [ ] Sling a wisp to a polecat and confirm it shows \`→ <title>\` in \`gt status\` (no polecats currently hooked; infrastructure verified via witness/refinery which use the same code path)

🤖 Generated with [Claude Code](https://claude.com/claude-code)