### PR TITLE
fix(rig): rig add rollback no longer deletes later successful re-add (gh-3683)

### DIFF
--- a/internal/rig/add_token_test.go
+++ b/internal/rig/add_token_test.go
@@ -1,0 +1,96 @@
+package rig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestRemoveRigPathIfOwned_TokenMatches verifies that when the on-disk token
+// matches the expected token, the directory is removed.
+func TestRemoveRigPathIfOwned_TokenMatches(t *testing.T) {
+	rigPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rigPath, "some-file"), []byte("x"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	token, err := newAddOwnershipToken()
+	if err != nil {
+		t.Fatalf("token: %v", err)
+	}
+	if err := writeAddOwnershipToken(rigPath, token); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+
+	removeRigPathIfOwned(rigPath, token)
+
+	if _, err := os.Stat(rigPath); !os.IsNotExist(err) {
+		t.Fatalf("expected rig path to be removed, stat err=%v", err)
+	}
+}
+
+// TestRemoveRigPathIfOwned_TokenMismatch verifies that when the on-disk token
+// belongs to a different invocation, the directory is preserved (gh#3683).
+func TestRemoveRigPathIfOwned_TokenMismatch(t *testing.T) {
+	rigPath := t.TempDir()
+	preserved := filepath.Join(rigPath, "preserve-me")
+	if err := os.WriteFile(preserved, []byte("important"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	// Disk has a token from a *different* (later, successful) add.
+	if err := writeAddOwnershipToken(rigPath, "newer-token"); err != nil {
+		t.Fatalf("write token: %v", err)
+	}
+
+	// Stale rollback runs with its own (older) token.
+	removeRigPathIfOwned(rigPath, "older-token")
+
+	if _, err := os.Stat(preserved); err != nil {
+		t.Fatalf("preserved file was deleted: %v", err)
+	}
+}
+
+// TestRemoveRigPathIfOwned_TokenMissingNonEmpty verifies that a missing token
+// on a non-empty directory is treated as not-owned and skipped — covers the
+// case where a successful re-add has already cleared its token.
+func TestRemoveRigPathIfOwned_TokenMissingNonEmpty(t *testing.T) {
+	rigPath := t.TempDir()
+	preserved := filepath.Join(rigPath, "rig-content")
+	if err := os.WriteFile(preserved, []byte("important"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	removeRigPathIfOwned(rigPath, "stale-token")
+
+	if _, err := os.Stat(preserved); err != nil {
+		t.Fatalf("preserved file was deleted: %v", err)
+	}
+}
+
+// TestRemoveRigPathIfOwned_TokenMissingEmpty verifies that an empty directory
+// (no token, no content) is removed — there's nothing to protect.
+func TestRemoveRigPathIfOwned_TokenMissingEmpty(t *testing.T) {
+	rigPath := t.TempDir()
+
+	removeRigPathIfOwned(rigPath, "stale-token")
+
+	if _, err := os.Stat(rigPath); !os.IsNotExist(err) {
+		t.Fatalf("expected empty rig path to be removed, stat err=%v", err)
+	}
+}
+
+// TestRemoveRigPathIfOwned_NoExpectedToken verifies that when no token was
+// ever issued (early failure path), cleanup proceeds unconditionally.
+func TestRemoveRigPathIfOwned_NoExpectedToken(t *testing.T) {
+	rigPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rigPath, "x"), []byte("x"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	removeRigPathIfOwned(rigPath, "")
+
+	if _, err := os.Stat(rigPath); !os.IsNotExist(err) {
+		t.Fatalf("expected rig path to be removed, stat err=%v", err)
+	}
+}

--- a/internal/rig/add_token_test.go
+++ b/internal/rig/add_token_test.go
@@ -94,3 +94,62 @@ func TestRemoveRigPathIfOwned_NoExpectedToken(t *testing.T) {
 		t.Fatalf("expected rig path to be removed, stat err=%v", err)
 	}
 }
+
+// TestRemoveRigPathIfOwned_PathMissing covers the os.ReadDir error path
+// inside removeRigPathIfOwned (rigPath does not exist).
+func TestRemoveRigPathIfOwned_PathMissing(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+
+	// Should not panic; should not create the path.
+	removeRigPathIfOwned(missing, "stale-token")
+
+	if _, err := os.Stat(missing); !os.IsNotExist(err) {
+		t.Fatalf("expected missing path to remain missing, stat err=%v", err)
+	}
+}
+
+// TestStampAddOwnershipToken_RoundTrip covers the success path: a fresh
+// token is written and round-trips via readAddOwnershipToken.
+func TestStampAddOwnershipToken_RoundTrip(t *testing.T) {
+	rigPath := t.TempDir()
+
+	token, err := stampAddOwnershipToken(rigPath)
+	if err != nil {
+		t.Fatalf("stamp: %v", err)
+	}
+	if token == "" {
+		t.Fatal("token is empty")
+	}
+
+	got := readAddOwnershipToken(rigPath)
+	if got != token {
+		t.Errorf("readAddOwnershipToken = %q, want %q", got, token)
+	}
+}
+
+// TestStampAddOwnershipToken_WriteFailureCleansUp covers the error path
+// where the underlying os.WriteFile call fails (the rigPath's parent does
+// not exist). The helper must surface the error rather than silently
+// returning an empty token.
+func TestStampAddOwnershipToken_WriteFailureCleansUp(t *testing.T) {
+	parent := t.TempDir()
+	bogus := filepath.Join(parent, "missing-parent", "rig")
+
+	token, err := stampAddOwnershipToken(bogus)
+	if err == nil {
+		t.Fatalf("expected error for unwritable rigPath, got token=%q", token)
+	}
+	if token != "" {
+		t.Errorf("token should be empty on error, got %q", token)
+	}
+}
+
+// TestClearAddOwnershipToken_OnAbsentFile covers the error-return path of
+// clearAddOwnershipToken (called best-effort on success in AddRig).
+func TestClearAddOwnershipToken_OnAbsentFile(t *testing.T) {
+	rigPath := t.TempDir()
+
+	if err := clearAddOwnershipToken(rigPath); err == nil {
+		t.Fatal("expected error removing nonexistent token file")
+	}
+}

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -2,6 +2,8 @@ package rig
 
 import (
 	"cmp"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -376,8 +378,22 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 		return nil, fmt.Errorf("creating rig directory: %w", err)
 	}
 
-	// Track cleanup on failure (best-effort cleanup)
-	cleanup := func() { _ = os.RemoveAll(rigPath) }
+	// Stamp the directory with an ownership token so a stale rollback (e.g.
+	// from a long-running clone whose parent shell has lost track of it)
+	// cannot delete a later, successful re-add of the same rig name.
+	// See gh#3683.
+	addToken, err := newAddOwnershipToken()
+	if err != nil {
+		_ = os.RemoveAll(rigPath)
+		return nil, fmt.Errorf("generating ownership token: %w", err)
+	}
+	if err := writeAddOwnershipToken(rigPath, addToken); err != nil {
+		_ = os.RemoveAll(rigPath)
+		return nil, fmt.Errorf("writing ownership token: %w", err)
+	}
+
+	// Track cleanup on failure (best-effort cleanup, ownership-checked).
+	cleanup := func() { removeRigPathIfOwned(rigPath, addToken) }
 	success := false
 	defer func() {
 		if !success {
@@ -887,7 +903,75 @@ Use crew for your own workspace. Polecats are for batch work dispatch.
 	}
 
 	success = true
+	// Best-effort: clear the ownership token now that the add has completed
+	// successfully. It's fine if this fails — the token's only purpose is
+	// gating rollback inside this AddRig call.
+	_ = clearAddOwnershipToken(rigPath)
 	return m.loadRig(opts.Name, m.config.Rigs[opts.Name])
+}
+
+// addOwnershipTokenFile is the per-rig sentinel that proves a `gt rig add`
+// invocation owns the directory. Used to make rollback safe under
+// concurrent/stale invocations — see gh#3683.
+const addOwnershipTokenFile = ".gt-add-token"
+
+// newAddOwnershipToken generates a 16-byte random token, hex-encoded.
+func newAddOwnershipToken() (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf[:]), nil
+}
+
+func writeAddOwnershipToken(rigPath, token string) error {
+	return os.WriteFile(filepath.Join(rigPath, addOwnershipTokenFile), []byte(token), 0644)
+}
+
+func readAddOwnershipToken(rigPath string) string {
+	data, err := os.ReadFile(filepath.Join(rigPath, addOwnershipTokenFile))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func clearAddOwnershipToken(rigPath string) error {
+	return os.Remove(filepath.Join(rigPath, addOwnershipTokenFile))
+}
+
+// removeRigPathIfOwned cleans up a rig directory, but only if the on-disk
+// ownership token matches `expectedToken`. If the token is missing the
+// directory is removed only when empty; otherwise we log a warning and
+// leave the directory intact so an unrelated successful add isn't deleted.
+func removeRigPathIfOwned(rigPath, expectedToken string) {
+	if expectedToken == "" {
+		// Caller never issued a token (early failure before we wrote one).
+		// Safe to remove since nothing meaningful could have been created.
+		_ = os.RemoveAll(rigPath)
+		return
+	}
+	onDisk := readAddOwnershipToken(rigPath)
+	if onDisk == expectedToken {
+		_ = os.RemoveAll(rigPath)
+		return
+	}
+	if onDisk == "" {
+		// Token file is gone. The directory may have been wiped and
+		// re-populated by another add (which then cleared its own token on
+		// success), or the path may be empty. Only remove when empty.
+		if entries, err := os.ReadDir(rigPath); err == nil && len(entries) == 0 {
+			_ = os.RemoveAll(rigPath)
+			return
+		}
+		fmt.Fprintf(os.Stderr,
+			"  ⚠ Skipping rollback of %s: ownership token missing and directory is non-empty (gh#3683 protection)\n",
+			rigPath)
+		return
+	}
+	fmt.Fprintf(os.Stderr,
+		"  ⚠ Skipping rollback of %s: another rig add now owns this path (gh#3683 protection)\n",
+		rigPath)
 }
 
 // verifyRigIdentity checks that metadata.json points to the correct Dolt database

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -382,14 +382,9 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 	// from a long-running clone whose parent shell has lost track of it)
 	// cannot delete a later, successful re-add of the same rig name.
 	// See gh#3683.
-	addToken, err := newAddOwnershipToken()
+	addToken, err := stampAddOwnershipToken(rigPath)
 	if err != nil {
-		_ = os.RemoveAll(rigPath)
-		return nil, fmt.Errorf("generating ownership token: %w", err)
-	}
-	if err := writeAddOwnershipToken(rigPath, addToken); err != nil {
-		_ = os.RemoveAll(rigPath)
-		return nil, fmt.Errorf("writing ownership token: %w", err)
+		return nil, err
 	}
 
 	// Track cleanup on failure (best-effort cleanup, ownership-checked).
@@ -912,8 +907,28 @@ Use crew for your own workspace. Polecats are for batch work dispatch.
 
 // addOwnershipTokenFile is the per-rig sentinel that proves a `gt rig add`
 // invocation owns the directory. Used to make rollback safe under
-// concurrent/stale invocations — see gh#3683.
+// concurrent/stale invocations — see gh#3683. Despite the name it holds
+// no secret material; it's a random hex marker for ownership.
+//
+//nolint:gosec // G101: filename, not a credential
 const addOwnershipTokenFile = ".gt-add-token"
+
+// stampAddOwnershipToken generates a fresh ownership token and writes it into
+// rigPath. On any failure the (possibly half-stamped) directory is cleaned up
+// so the caller doesn't leak partial state. Returns the token on success so
+// the caller can pass it to removeRigPathIfOwned.
+func stampAddOwnershipToken(rigPath string) (string, error) {
+	token, err := newAddOwnershipToken()
+	if err != nil {
+		_ = os.RemoveAll(rigPath)
+		return "", fmt.Errorf("generating ownership token: %w", err)
+	}
+	if err := writeAddOwnershipToken(rigPath, token); err != nil {
+		_ = os.RemoveAll(rigPath)
+		return "", fmt.Errorf("writing ownership token: %w", err)
+	}
+	return token, nil
+}
 
 // newAddOwnershipToken generates a 16-byte random token, hex-encoded.
 func newAddOwnershipToken() (string, error) {


### PR DESCRIPTION
Closes #3683.

## Summary

\`gt rig add\` had a destructive race in its rollback logic: a stale background invocation whose parent shell had lost track of it would, on eventual exit, delete the entire rig directory — even when the operator had \`rm -rf\`'d the partial state and successfully re-added the same rig in the meantime.

This stamps each rig directory with a per-invocation random ownership token immediately after \`MkdirAll\`. The deferred rollback now refuses to delete unless the on-disk token still matches the rolling-back invocation's token. When tokens differ (a later successful add overwrote ours), or the token is missing on a non-empty directory (a successful add cleared its own token after registering), the rollback logs a warning and leaves the path intact. Empty directories with no token are still cleaned up — there's nothing to protect.

## How the protected race resolves

The scenario from the issue, step by step:

1. Add #1 starts, writes \`<rig>/.gt-add-token\` = T1, begins long clone in background.
2. Operator perceives failure, \`rm -rf <rig>\`, retries.
3. Add #2 starts, writes \`<rig>/.gt-add-token\` = T2, completes successfully, clears the token.
4. Add #1 finally exits with \`success=false\`. Its deferred cleanup reads the on-disk token: missing on a non-empty directory → skip with warning. Add #2's files survive.

If add #1 had instead crashed before \`MkdirAll\` returned, no token was ever written and the cleanup proceeds unconditionally — same as today's behavior.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/rig/\` passes — new \`add_token_test.go\` exercises all five branches (token match, token mismatch, token missing + non-empty, token missing + empty, no token issued)
- [x] \`go test ./... -short\` passes across all packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)