### PR TITLE
fix(doltserver): clamp Dolt idle wait_timeout to prevent connection exhaustion (gh-3623)

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -3842,6 +3842,11 @@ func moveDir(src, dest string) error {
 // Always connects via explicit --host/--port flags to ensure the command goes
 // through the running sql-server process. Without these flags, `dolt sql` runs
 // in embedded mode (even from the data directory), which creates databases on
+// applyWaitTimeoutFn is the SQL-exec seam used by applyWaitTimeout. Tests
+// override it to verify the policy decision (skip vs. send) and the
+// query-formatting without spawning a real dolt subprocess.
+var applyWaitTimeoutFn = serverExecSQL
+
 // applyWaitTimeout sets MySQL's `wait_timeout` server variable on the running
 // Dolt server so idle connections close in seconds rather than Dolt's 8-hour
 // default. Under sustained load this is the difference between healthy
@@ -3855,10 +3860,16 @@ func applyWaitTimeout(townRoot string, config *Config) {
 	if config.WaitTimeoutSec <= 0 {
 		return
 	}
-	query := fmt.Sprintf("SET GLOBAL wait_timeout = %d", config.WaitTimeoutSec)
-	if err := serverExecSQL(townRoot, query); err != nil {
+	query := buildWaitTimeoutQuery(config.WaitTimeoutSec)
+	if err := applyWaitTimeoutFn(townRoot, query); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: could not set Dolt wait_timeout=%ds: %v\n", config.WaitTimeoutSec, err)
 	}
+}
+
+// buildWaitTimeoutQuery returns the SET GLOBAL statement applyWaitTimeout
+// dispatches. Extracted for direct testability.
+func buildWaitTimeoutQuery(seconds int) string {
+	return fmt.Sprintf("SET GLOBAL wait_timeout = %d", seconds)
 }
 
 // disk but does NOT register them with the live server catalog. This caused

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -153,6 +153,16 @@ const (
 	// Dolt detects the dead connection within this timeout rather than holding CLOSE_WAIT
 	// for Dolt's default 8 hours. Set to match compactor GC timeout.
 	DefaultWriteTimeoutMs = 5 * 60 * 1000 // 5 minutes in milliseconds
+
+	// DefaultWaitTimeoutSec is how long Dolt keeps an idle session alive before
+	// closing it. Dolt's MySQL-compat default is 28800s (8 hours). Under Gas
+	// Town load (mayor + deacon + witness + refinery + N polecats + dashboard
+	// polling), short-lived `bd` processes leak connections faster than the
+	// default timeout reclaims them, leading to a death spiral at the 1000-
+	// connection cap. 30s is aggressive but matches the documented workaround
+	// in gh-3623 and is far longer than any healthy bd query takes.
+	// Override with GT_DOLT_WAIT_TIMEOUT.
+	DefaultWaitTimeoutSec = 30
 )
 
 // doltConfigYAML represents the subset of Dolt's config.yaml that we need to read.
@@ -239,6 +249,12 @@ type Config struct {
 	// Set to 0 to use Dolt's default (28800000 = 8 hours — strongly discouraged).
 	WriteTimeoutMs int
 
+	// WaitTimeoutSec is the idle-session timeout (MySQL `wait_timeout` server
+	// variable) in seconds. Set after the server is reachable via
+	// `SET GLOBAL wait_timeout = N`. See gh-3623.
+	// Set to 0 to skip the override and let Dolt use its 8-hour default.
+	WaitTimeoutSec int
+
 	// LogLevel is the Dolt server log level (trace, debug, info, warning, error, fatal).
 	// Default is "warning" to suppress connection open/close noise. Override with
 	// GT_DOLT_LOGLEVEL=info (or debug) for diagnostics.
@@ -272,7 +288,20 @@ func DefaultConfig(townRoot string) *Config {
 		MaxConnections: DefaultMaxConnections,
 		ReadTimeoutMs:  DefaultReadTimeoutMs,
 		WriteTimeoutMs: DefaultWriteTimeoutMs,
+		WaitTimeoutSec: DefaultWaitTimeoutSec,
 		LogLevel:       "warning",
+	}
+
+	// Optional override for the idle-session timeout. Negative values disable
+	// the override entirely (use Dolt's 8-hour default).
+	if v := os.Getenv("GT_DOLT_WAIT_TIMEOUT"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil {
+			if n < 0 {
+				config.WaitTimeoutSec = 0
+			} else {
+				config.WaitTimeoutSec = n
+			}
+		}
 	}
 
 	if h := os.Getenv("GT_DOLT_HOST"); h != "" {
@@ -1647,7 +1676,8 @@ func Start(townRoot string) error {
 		// SHOW DATABASES showing no rig databases until the user manually
 		// runs gt dolt stop + gt dolt start. (gt-nq1)
 		if len(databases) == 0 {
-			return nil // Nothing to verify — fresh install or empty data dir
+			applyWaitTimeout(townRoot, config) // Best-effort; see gh-3623.
+			return nil                         // Nothing to verify — fresh install or empty data dir
 		}
 		_, missing, verifyErr := VerifyDatabases(townRoot)
 		if verifyErr != nil {
@@ -1655,7 +1685,8 @@ func Start(townRoot string) error {
 			continue
 		}
 		if len(missing) == 0 {
-			return nil // Server is up and serving every expected database
+			applyWaitTimeout(townRoot, config) // Best-effort; see gh-3623.
+			return nil                         // Server is up and serving every expected database
 		}
 		lastErr = fmt.Errorf("server is reachable but %d/%d databases not yet served (missing: %v)",
 			len(missing), len(databases), missing)
@@ -3811,6 +3842,25 @@ func moveDir(src, dest string) error {
 // Always connects via explicit --host/--port flags to ensure the command goes
 // through the running sql-server process. Without these flags, `dolt sql` runs
 // in embedded mode (even from the data directory), which creates databases on
+// applyWaitTimeout sets MySQL's `wait_timeout` server variable on the running
+// Dolt server so idle connections close in seconds rather than Dolt's 8-hour
+// default. Under sustained load this is the difference between healthy
+// connection turnover and a death spiral that exhausts max_connections.
+// See gh-3623.
+//
+// Best-effort: a failure here is logged but does not fail the start, since
+// the server is already up and serving traffic. Callers can still operate;
+// they just inherit the long Dolt default.
+func applyWaitTimeout(townRoot string, config *Config) {
+	if config.WaitTimeoutSec <= 0 {
+		return
+	}
+	query := fmt.Sprintf("SET GLOBAL wait_timeout = %d", config.WaitTimeoutSec)
+	if err := serverExecSQL(townRoot, query); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: could not set Dolt wait_timeout=%ds: %v\n", config.WaitTimeoutSec, err)
+	}
+}
+
 // disk but does NOT register them with the live server catalog. This caused
 // "database not found" errors during gt rig add.
 func serverExecSQL(townRoot, query string) error {

--- a/internal/doltserver/wait_timeout_test.go
+++ b/internal/doltserver/wait_timeout_test.go
@@ -1,0 +1,57 @@
+package doltserver
+
+import (
+	"testing"
+)
+
+// TestDefaultConfig_WaitTimeoutDefault verifies that the default config
+// applies the gh-3623 idle-session timeout.
+func TestDefaultConfig_WaitTimeoutDefault(t *testing.T) {
+	townRoot := t.TempDir()
+	t.Setenv("GT_DOLT_WAIT_TIMEOUT", "")
+
+	config := DefaultConfig(townRoot)
+
+	if config.WaitTimeoutSec != DefaultWaitTimeoutSec {
+		t.Errorf("WaitTimeoutSec = %d, want %d", config.WaitTimeoutSec, DefaultWaitTimeoutSec)
+	}
+}
+
+// TestDefaultConfig_WaitTimeoutEnvOverride verifies the GT_DOLT_WAIT_TIMEOUT
+// env var raises or lowers the configured timeout.
+func TestDefaultConfig_WaitTimeoutEnvOverride(t *testing.T) {
+	townRoot := t.TempDir()
+	t.Setenv("GT_DOLT_WAIT_TIMEOUT", "120")
+
+	config := DefaultConfig(townRoot)
+
+	if config.WaitTimeoutSec != 120 {
+		t.Errorf("WaitTimeoutSec = %d, want 120", config.WaitTimeoutSec)
+	}
+}
+
+// TestDefaultConfig_WaitTimeoutNegativeDisables verifies that a negative
+// value opts out of the override, leaving Dolt's default in place.
+func TestDefaultConfig_WaitTimeoutNegativeDisables(t *testing.T) {
+	townRoot := t.TempDir()
+	t.Setenv("GT_DOLT_WAIT_TIMEOUT", "-1")
+
+	config := DefaultConfig(townRoot)
+
+	if config.WaitTimeoutSec != 0 {
+		t.Errorf("WaitTimeoutSec = %d, want 0 (disabled)", config.WaitTimeoutSec)
+	}
+}
+
+// TestDefaultConfig_WaitTimeoutInvalidIgnored verifies that a non-numeric
+// env value falls back to the default rather than zeroing the timeout.
+func TestDefaultConfig_WaitTimeoutInvalidIgnored(t *testing.T) {
+	townRoot := t.TempDir()
+	t.Setenv("GT_DOLT_WAIT_TIMEOUT", "not-a-number")
+
+	config := DefaultConfig(townRoot)
+
+	if config.WaitTimeoutSec != DefaultWaitTimeoutSec {
+		t.Errorf("WaitTimeoutSec = %d, want default %d when env var is invalid", config.WaitTimeoutSec, DefaultWaitTimeoutSec)
+	}
+}

--- a/internal/doltserver/wait_timeout_test.go
+++ b/internal/doltserver/wait_timeout_test.go
@@ -1,6 +1,7 @@
 package doltserver
 
 import (
+	"errors"
 	"testing"
 )
 
@@ -54,4 +55,73 @@ func TestDefaultConfig_WaitTimeoutInvalidIgnored(t *testing.T) {
 	if config.WaitTimeoutSec != DefaultWaitTimeoutSec {
 		t.Errorf("WaitTimeoutSec = %d, want default %d when env var is invalid", config.WaitTimeoutSec, DefaultWaitTimeoutSec)
 	}
+}
+
+// TestBuildWaitTimeoutQuery verifies the exact SQL emitted by applyWaitTimeout.
+func TestBuildWaitTimeoutQuery(t *testing.T) {
+	got := buildWaitTimeoutQuery(30)
+	want := "SET GLOBAL wait_timeout = 30"
+	if got != want {
+		t.Errorf("buildWaitTimeoutQuery(30) = %q, want %q", got, want)
+	}
+}
+
+// TestApplyWaitTimeout_DisabledShortCircuits verifies that a non-positive
+// WaitTimeoutSec opts out of the SET GLOBAL — the SQL seam must never be
+// invoked.
+func TestApplyWaitTimeout_DisabledShortCircuits(t *testing.T) {
+	prev := applyWaitTimeoutFn
+	t.Cleanup(func() { applyWaitTimeoutFn = prev })
+
+	called := false
+	applyWaitTimeoutFn = func(_, _ string) error {
+		called = true
+		return nil
+	}
+
+	for _, sec := range []int{0, -1, -3600} {
+		applyWaitTimeout("/some/town", &Config{WaitTimeoutSec: sec})
+	}
+
+	if called {
+		t.Errorf("applyWaitTimeoutFn called for non-positive WaitTimeoutSec")
+	}
+}
+
+// TestApplyWaitTimeout_DispatchesQuery verifies that a positive timeout
+// dispatches the expected SET GLOBAL statement against the seam.
+func TestApplyWaitTimeout_DispatchesQuery(t *testing.T) {
+	prev := applyWaitTimeoutFn
+	t.Cleanup(func() { applyWaitTimeoutFn = prev })
+
+	var gotTownRoot, gotQuery string
+	applyWaitTimeoutFn = func(townRoot, query string) error {
+		gotTownRoot = townRoot
+		gotQuery = query
+		return nil
+	}
+
+	applyWaitTimeout("/town/root", &Config{WaitTimeoutSec: 45})
+
+	if gotTownRoot != "/town/root" {
+		t.Errorf("townRoot = %q, want /town/root", gotTownRoot)
+	}
+	if want := "SET GLOBAL wait_timeout = 45"; gotQuery != want {
+		t.Errorf("query = %q, want %q", gotQuery, want)
+	}
+}
+
+// TestApplyWaitTimeout_ErrorIsBestEffort verifies that a SQL failure does
+// not panic or propagate. The Dolt server is already up by the time we
+// apply this; failing here would needlessly fail the start.
+func TestApplyWaitTimeout_ErrorIsBestEffort(t *testing.T) {
+	prev := applyWaitTimeoutFn
+	t.Cleanup(func() { applyWaitTimeoutFn = prev })
+
+	applyWaitTimeoutFn = func(_, _ string) error {
+		return errors.New("simulated SQL failure")
+	}
+
+	// Must not panic. No return value to check — best-effort by contract.
+	applyWaitTimeout("/town/root", &Config{WaitTimeoutSec: 30})
 }


### PR DESCRIPTION
Closes #3623 (the connection-exhaustion half).

## Summary

Dolt inherits MySQL's \`wait_timeout\` default of 28800s (8 hours). Under sustained Gas Town load, short-lived \`bd\` processes leak connections faster than the 8-hour timeout reclaims them; once the 1000-connection cap is hit every subsequent \`bd\` hangs and the only recovery is \`pkill bd && gt dolt stop && gt dolt start\`. The issue documents \`SET GLOBAL wait_timeout = 30\` as the working manual workaround.

This applies that workaround automatically: after \`Start()\` verifies the server is up and serving its expected databases, it issues \`SET GLOBAL wait_timeout = N\`. Default is 30s, override via \`GT_DOLT_WAIT_TIMEOUT\` (negative disables the override entirely). The application is best-effort — if the SQL fails we log a warning instead of failing the start, since the server is already serving traffic and the operator just keeps Dolt's long default.

## Out of scope

Issue #3623 also calls out a second problem: \`gt mail inbox\` taking 23–58s for 5 messages because the command fans out to multiple sequential \`bd\` subprocesses (Go cold-start overhead). That's a separate change in a different package; this PR addresses the connection-exhaustion death spiral specifically.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/doltserver/\` passes (incl. new \`wait_timeout_test.go\` covering default, env override, negative-disables, and invalid-input cases)
- [x] \`go test ./... -short\` passes across all packages
- [x] \`golangci-lint run --new-from-rev=origin/main ./...\` reports 0 new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)