### PR TITLE
fix(sling): auto-burn orphan molecules from hooked-with-no-assignee beads (gh-3697)

### DIFF
--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -810,12 +810,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	if formulaName != "" {
 		existingMolecules := collectExistingMolecules(info)
 		if len(existingMolecules) > 0 {
-			// Auto-burn when bead is unassigned (molecules are definitionally stale),
-			// or when the assigned agent's session is dead. `force` already includes
-			// dead-agent auto-force from the status check above.
-			stale := force ||
-				(info.Assignee == "" && (info.Status == "open" || info.Status == "in_progress")) ||
-				(info.Assignee != "" && isHookedAgentDeadFn(info.Assignee))
+			stale := force || isOrphanMolecule(info)
 			if slingDryRun {
 				fmt.Printf("  Would burn %d stale molecule(s): %s\n",
 					len(existingMolecules), strings.Join(existingMolecules, ", "))

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -109,6 +109,34 @@ func isDeferredBead(info *beadInfo) bool {
 	return false
 }
 
+// isOrphanMolecule reports whether a bead's existing attached molecule(s)
+// can be safely burned at sling time without operator confirmation. Used
+// to gate the auto-burn path that lets sling self-heal from stale state.
+//
+// A molecule is treated as orphaned when:
+//   - the bead has no assignee but is in an active status (open/in_progress)
+//     or stuck in `hooked` with no assignee — the latter covers gh-3697,
+//     where one orphan wisp would otherwise wedge every subsequent sling
+//     to the rig with "bead already has N attached molecule(s)"; or
+//   - the bead has an assignee but that assignee's tmux session is dead.
+//
+// `closed` and `blocked` deliberately fall through to the refuse path:
+// burning molecules off a closed bead would mask completed work, and
+// burning off a blocked bead can mask a real dependency.
+func isOrphanMolecule(info *beadInfo) bool {
+	if info == nil {
+		return false
+	}
+	if info.Assignee == "" {
+		switch info.Status {
+		case "open", "in_progress", "hooked":
+			return true
+		}
+		return false
+	}
+	return isHookedAgentDeadFn(info.Assignee)
+}
+
 // collectExistingMolecules returns all molecule wisp IDs attached to a bead.
 // Checks both dependency bonds (ground truth from bd mol bond) and the
 // description's attached_molecule field (metadata pointer). Wisp IDs are

--- a/internal/cmd/sling_orphan_molecule_test.go
+++ b/internal/cmd/sling_orphan_molecule_test.go
@@ -1,0 +1,89 @@
+package cmd
+
+import "testing"
+
+// TestIsOrphanMolecule_HookedNoAssignee covers gh-3697: a bead stuck in
+// status=hooked with empty assignee was not auto-burnable, so any further
+// sling to the rig refused with "bead already has N attached molecule(s)".
+// The fix treats this state as orphaned so sling can self-heal.
+func TestIsOrphanMolecule_HookedNoAssignee(t *testing.T) {
+	prev := isHookedAgentDeadFn
+	t.Cleanup(func() { isHookedAgentDeadFn = prev })
+	isHookedAgentDeadFn = func(string) bool { return false }
+
+	info := &beadInfo{Status: "hooked", Assignee: ""}
+	if !isOrphanMolecule(info) {
+		t.Errorf("isOrphanMolecule(status=hooked, assignee='') = false, want true (gh-3697)")
+	}
+}
+
+func TestIsOrphanMolecule_TableDriven(t *testing.T) {
+	prev := isHookedAgentDeadFn
+	t.Cleanup(func() { isHookedAgentDeadFn = prev })
+
+	tests := []struct {
+		name     string
+		info     *beadInfo
+		deadFn   func(string) bool
+		expected bool
+	}{
+		{
+			name:     "nil info",
+			info:     nil,
+			deadFn:   func(string) bool { return false },
+			expected: false,
+		},
+		{
+			name:     "open, no assignee — orphan from sling crash",
+			info:     &beadInfo{Status: "open", Assignee: ""},
+			deadFn:   func(string) bool { return false },
+			expected: true,
+		},
+		{
+			name:     "in_progress, no assignee — orphan from sling crash",
+			info:     &beadInfo{Status: "in_progress", Assignee: ""},
+			deadFn:   func(string) bool { return false },
+			expected: true,
+		},
+		{
+			name:     "hooked, no assignee — gh-3697 wedge",
+			info:     &beadInfo{Status: "hooked", Assignee: ""},
+			deadFn:   func(string) bool { return false },
+			expected: true,
+		},
+		{
+			name:     "closed, no assignee — keep refuse path",
+			info:     &beadInfo{Status: "closed", Assignee: ""},
+			deadFn:   func(string) bool { return false },
+			expected: false,
+		},
+		{
+			name:     "blocked, no assignee — keep refuse path",
+			info:     &beadInfo{Status: "blocked", Assignee: ""},
+			deadFn:   func(string) bool { return false },
+			expected: false,
+		},
+		{
+			name:     "hooked, assignee, session alive — refuse",
+			info:     &beadInfo{Status: "hooked", Assignee: "rig/polecats/Toast"},
+			deadFn:   func(string) bool { return false },
+			expected: false,
+		},
+		{
+			name:     "hooked, assignee, session dead — auto-burn",
+			info:     &beadInfo{Status: "hooked", Assignee: "rig/polecats/Toast"},
+			deadFn:   func(string) bool { return true },
+			expected: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isHookedAgentDeadFn = tt.deadFn
+			got := isOrphanMolecule(tt.info)
+			if got != tt.expected {
+				t.Errorf("isOrphanMolecule() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Mitigates #3697.

## Summary

Sling already self-heals from stale attached-molecule state in two cases: explicit \`--force\`, an unassigned bead in \`open\` or \`in_progress\`, or an assignee whose tmux session is dead. Anything else falls through to the refuse path (\`bead already has N attached molecule(s)\`).

Issue #3697 reports a state outside that whitelist: a bead stuck in **status=hooked with an empty assignee**. Once one bead landed in this orphan shape (e.g. from a sling that crashed after setting \`status=hooked\` but before recording the assignee) every subsequent sling to the rig refused, and the witness's exponential-backoff diagnosis just burned Claude usage windows without recovering. The reporter had to delete the wisp by hand.

This extracts the staleness check into \`isOrphanMolecule\` and adds \`hooked + empty-assignee\` to the auto-burn set. \`closed\` and \`blocked\` deliberately stay in the refuse path so we don't mask completed work or a real dependency.

## Scope honesty

The issue body doesn't pin down exactly how the wisp got orphaned, only that the symptom blocks all rig slings. This PR addresses the most plausible orphan shape consistent with the reporter's evidence (status=hooked + no assignee) — that's a state sling cannot create on the happy path, so auto-burning it is safe. If maintainers know of a different orphan shape that also triggers the bug (e.g. stale assignee with malformed format), \`isOrphanMolecule\` is the place to extend; the table-driven test in \`sling_orphan_molecule_test.go\` already covers the bordering cases (closed, blocked, alive session) so regressions are caught.

## Test plan

- [x] \`go build ./...\` clean
- [x] \`go test ./internal/cmd/\` passes — new \`TestIsOrphanMolecule_*\` tests cover all 8 status × assignee × dead-fn combinations
- [x] \`go test ./... -short\` passes across all packages
- [x] \`golangci-lint run --new-from-rev=origin/main ./...\` reports 0 new issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)