### PR TITLE
fix(lint): correct 'recognises' misspelling in comments

### DIFF
--- a/internal/doctor/tmux_socket_check_test.go
+++ b/internal/doctor/tmux_socket_check_test.go
@@ -29,7 +29,7 @@ func (m *mockSocketLister) KillSessionWithProcesses(name string) error {
 }
 
 // setupSocketTestRegistry registers the "ga" prefix so session.IsKnownSession
-// recognises "ga-*" names, and returns a cleanup function.
+// recognizes "ga-*" names, and returns a cleanup function.
 func setupSocketTestRegistry(t *testing.T) {
 	t.Helper()
 	oldRegistry := session.DefaultRegistry()

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -197,7 +197,7 @@ type freshBranchMeta struct {
 }
 
 // parseFreshBranchName is the structural inverse of freshBranchName. It
-// does not consult git or the filesystem; it recognises the two formats
+// does not consult git or the filesystem; it recognizes the two formats
 // the formatter emits. Used in place of substring heuristics so that
 // branch-naming changes can be made in a single place.
 func parseFreshBranchName(branch string) freshBranchMeta {


### PR DESCRIPTION
The misspell linter flags 'recognises' → 'recognizes' in two comments introduced by recent commits. Pure comment-only fix; no behavior change.

- `internal/polecat/session_manager.go:200`
- `internal/doctor/tmux_socket_check_test.go:32`

This is currently failing CI Lint on main: https://github.com/Alleago/gastown/actions/runs/24940404926