### PR TITLE
fix: add explicit gate=manual skip in dispatchPlugins

### DIFF
--- a/internal/daemon/handler.go
+++ b/internal/daemon/handler.go
@@ -239,6 +239,12 @@ func (d *Daemon) dispatchPlugins(mgr *dog.Manager, sm *dog.SessionManager, rigsC
 	router := mail.NewRouterWithTownRoot(d.config.TownRoot, d.config.TownRoot)
 
 	for _, p := range plugins {
+		// Never auto-dispatch manual-gate plugins — they require an explicit trigger.
+		if p.Gate != nil && p.Gate.Type == plugin.GateManual {
+			d.logger.Printf("Handler: skipping plugin %s (gate=manual, requires explicit trigger)", p.Name)
+			continue
+		}
+
 		// Only dispatch plugins with cooldown gates.
 		if p.Gate == nil || p.Gate.Type != plugin.GateCooldown {
 			continue

--- a/internal/daemon/handler_test.go
+++ b/internal/daemon/handler_test.go
@@ -395,3 +395,37 @@ func TestReapIdleDogs_Constants(t *testing.T) {
 		t.Errorf("maxDogPoolSize = %d, want 4", maxDogPoolSize)
 	}
 }
+
+func TestDispatchPlugins_SkipsManualGatePlugin(t *testing.T) {
+	townRoot := t.TempDir()
+	d := testHandlerDaemon(t, townRoot)
+
+	pluginDir := filepath.Join(townRoot, "plugins", "test-manual")
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	pluginMD := "+++\nname = \"test-manual\"\ndescription = \"manual gate plugin\"\n\n[gate]\ntype = \"manual\"\n+++\n\n# Instructions\n"
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.md"), []byte(pluginMD), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	testSetupDogState(t, townRoot, "idle-dog", dog.StateIdle, time.Now().Add(-10*time.Minute))
+
+	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	mgr := dog.NewManager(townRoot, rigsConfig)
+	tm := tmux.NewTmux()
+	sm := dog.NewSessionManager(tm, townRoot, mgr)
+
+	d.dispatchPlugins(mgr, sm, rigsConfig)
+
+	dg, err := mgr.Get("idle-dog")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if dg.State != dog.StateIdle {
+		t.Errorf("dog state = %q, want idle (manual-gate plugin must not auto-dispatch)", dg.State)
+	}
+	if dg.Work != "" {
+		t.Errorf("dog work = %q, want empty (manual-gate plugin must not auto-dispatch)", dg.Work)
+	}
+}


### PR DESCRIPTION
## Problem

`dispatchPlugins()` had no explicit guard for `gate=manual` plugins. It
only skipped non-cooldown types, but this relied on the cooldown check
being reached first. A misconfigured plugin.md using the wrong TOML
field name (`cooldown = "4h"` instead of `duration = "4h"`) caused
`p.Gate.Duration` to be empty, bypassing the cooldown check entirely and
triggering infinite re-dispatch loops.

Additionally, even with a correctly configured cooldown gate, the daemon
had no explicit semantics for `gate=manual` — the intent was implicit.

## Fix

Add an explicit guard at the top of the plugin loop in `dispatchPlugins()`:

```go
if p.Gate != nil && p.Gate.Type == plugin.GateManual {
    d.logger.Printf("Handler: skipping plugin %s (gate=manual, requires explicit trigger)", p.Name)
    continue
}
```

This makes the `gate=manual` contract explicit and logged, and correctly
short-circuits before any cooldown evaluation.

## Tests

Added `TestDispatchPlugins_SkipsManualGatePlugin` — creates a temp town
root with a `gate=manual` plugin.md, an idle dog, and verifies the dog
remains idle after `dispatchPlugins()` runs.

## Background

Tracked in bead hq-suin. Workaround already applied to `mol-dog-reaper`
plugin.md (`type = "manual"`) pending this daemon fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)