### PR TITLE
feat(quota): login-required signal detection in scanner

### DIFF
--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -442,3 +442,19 @@ var DefaultNearLimitPatterns = []string{
 	`\d+\s*(messages?|requests?)\s*(left|remaining)`,               // "10 messages remaining"
 }
 
+// DefaultLoginRequiredPatterns are patterns that indicate a session needs
+// re-authentication (interactive /login). Distinct from rate-limit signals:
+// here the session is blocked on auth, not quota. Surfacing this as a separate
+// signal lets watchers fire user-facing alerts (e.g., Telegram/email) rather
+// than attempting silent rotation, since /login requires interactive input.
+// Matched with (?i) for case-insensitive matching.
+var DefaultLoginRequiredPatterns = []string{
+	`Please (run|use) ['"]?/login['"]?`,             // explicit /login prompt from Claude Code
+	`Authentication required`,                        // generic auth-required message
+	`Please log in to (Claude|continue)`,            // login prompt variants
+	`Run ['"]?/login['"]? to (re-?authenticate|sign in)`, // /login command instruction
+	`Your session has expired\.\s+Please log in`,    // session-expired prompt
+	`401 Unauthorized.*\b(login|auth(entication)?)\b`, // 401 with login/auth context
+	`Invalid (API key|credentials)`,                  // explicit credential rejection
+}
+

--- a/internal/quota/scan.go
+++ b/internal/quota/scan.go
@@ -19,7 +19,8 @@ type ScanResult struct {
 	ConfigDir     string    `json:"config_dir,omitempty"`     // CLAUDE_CONFIG_DIR (even if account unknown)
 	RateLimited   bool      `json:"rate_limited"`             // whether hard rate-limit was detected
 	NearLimit     bool      `json:"near_limit"`               // whether approaching-limit signal was detected
-	MatchedLine   string    `json:"matched_line,omitempty"`   // the line that matched (hard or warning)
+	LoginRequired bool      `json:"login_required"`           // whether /login (re-auth) is required
+	MatchedLine   string    `json:"matched_line,omitempty"`   // the line that matched (hard, warning, or login)
 	ResetsAt      string    `json:"resets_at,omitempty"`      // parsed reset time if available
 }
 
@@ -36,6 +37,7 @@ type Scanner struct {
 	tmux            TmuxClient
 	patterns        []*regexp.Regexp // hard rate-limit patterns
 	warningPatterns []*regexp.Regexp // near-limit warning patterns
+	loginPatterns   []*regexp.Regexp // login-required patterns (re-auth needed)
 	accounts        *config.AccountsConfig
 }
 
@@ -78,6 +80,28 @@ func (s *Scanner) WithWarningPatterns(patterns []string) error {
 		compiled = append(compiled, re)
 	}
 	s.warningPatterns = compiled
+	return nil
+}
+
+// WithLoginPatterns enables login-required detection via pane content patterns.
+// When a session is blocked on /login (re-auth required), it's distinct from
+// rate-limit: rotation cannot help, only an interactive /login can. Watchers
+// can use this signal to fire user-facing alerts.
+// If patterns is nil, DefaultLoginRequiredPatterns are used.
+func (s *Scanner) WithLoginPatterns(patterns []string) error {
+	if patterns == nil {
+		patterns = constants.DefaultLoginRequiredPatterns
+	}
+
+	compiled := make([]*regexp.Regexp, 0, len(patterns))
+	for _, p := range patterns {
+		re, err := regexp.Compile("(?i)" + p)
+		if err != nil {
+			return fmt.Errorf("compiling login pattern %q: %w", p, err)
+		}
+		compiled = append(compiled, re)
+	}
+	s.loginPatterns = compiled
 	return nil
 }
 
@@ -178,6 +202,26 @@ func (s *Scanner) scanSession(session string) ScanResult {
 			for _, re := range s.warningPatterns {
 				if re.MatchString(line) {
 					result.NearLimit = true
+					result.MatchedLine = line
+					return result
+				}
+			}
+		}
+	}
+
+	// No quota signal detected — check login-required patterns. This is an
+	// orthogonal signal: rotation cannot resolve a /login prompt, only an
+	// interactive re-auth can. Surface separately so watchers can route to
+	// user-facing alerts (Telegram/email) rather than rotate.
+	if len(s.loginPatterns) > 0 {
+		for _, line := range bottomLines {
+			line = strings.TrimSpace(line)
+			if line == "" {
+				continue
+			}
+			for _, re := range s.loginPatterns {
+				if re.MatchString(line) {
+					result.LoginRequired = true
 					result.MatchedLine = line
 					return result
 				}

--- a/internal/quota/scan_test.go
+++ b/internal/quota/scan_test.go
@@ -625,3 +625,193 @@ func TestWithWarningPatterns_InvalidPattern(t *testing.T) {
 		t.Error("expected error for invalid warning pattern")
 	}
 }
+
+func TestScanAll_DetectsLoginRequired(t *testing.T) {
+	setupTestRegistry(t)
+
+	tmux := &mockTmux{
+		sessions: []string{"gt-crew-fox", "gt-crew-owl", "gt-crew-deer"},
+		paneContent: map[string]string{
+			"gt-crew-fox":  "Working normally...\nPlease run /login to re-authenticate",
+			"gt-crew-owl":  "Working normally...\nAuthentication required",
+			"gt-crew-deer": "Working normally...",
+		},
+		envVars: map[string]map[string]string{
+			"gt-crew-fox":  {"CLAUDE_CONFIG_DIR": "/home/user/.claude-accounts/work"},
+			"gt-crew-owl":  {"CLAUDE_CONFIG_DIR": "/home/user/.claude-accounts/personal"},
+			"gt-crew-deer": {"CLAUDE_CONFIG_DIR": "/home/user/.claude-accounts/work"},
+		},
+	}
+
+	scanner, err := NewScanner(tmux, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := scanner.WithLoginPatterns(nil); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := scanner.ScanAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	resultMap := make(map[string]ScanResult)
+	for _, r := range results {
+		resultMap[r.Session] = r
+	}
+
+	fox := resultMap["gt-crew-fox"]
+	if !fox.LoginRequired {
+		t.Error("expected gt-crew-fox to be login-required")
+	}
+	if fox.RateLimited || fox.NearLimit {
+		t.Error("expected gt-crew-fox to have no quota signals")
+	}
+	if fox.MatchedLine == "" {
+		t.Error("expected matched line for login detection")
+	}
+
+	owl := resultMap["gt-crew-owl"]
+	if !owl.LoginRequired {
+		t.Error("expected gt-crew-owl to be login-required (Authentication required)")
+	}
+
+	deer := resultMap["gt-crew-deer"]
+	if deer.LoginRequired {
+		t.Error("expected gt-crew-deer to NOT be login-required")
+	}
+}
+
+func TestScanAll_HardLimitTakesPrecedenceOverLogin(t *testing.T) {
+	// A session showing both rate-limit AND login-required text should be
+	// classified as RateLimited (hard signal wins). Login is the fallback
+	// when no quota signal is present.
+	setupTestRegistry(t)
+
+	tmux := &mockTmux{
+		sessions: []string{"gt-crew-bear"},
+		paneContent: map[string]string{
+			"gt-crew-bear": "You've hit your weekly limit\nAlso: Please run /login",
+		},
+		envVars: map[string]map[string]string{
+			"gt-crew-bear": {"CLAUDE_CONFIG_DIR": "/home/user/.claude-accounts/work"},
+		},
+	}
+
+	scanner, err := NewScanner(tmux, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := scanner.WithLoginPatterns(nil); err != nil {
+		t.Fatal(err)
+	}
+
+	results, err := scanner.ScanAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	bear := results[0]
+	if !bear.RateLimited {
+		t.Error("expected RateLimited true (hard limit wins precedence)")
+	}
+	if bear.LoginRequired {
+		t.Error("expected LoginRequired false when RateLimited fires first")
+	}
+}
+
+func TestScanAll_LoginNotEnabled_NoFalsePositive(t *testing.T) {
+	// When WithLoginPatterns is not called, login text in pane should NOT
+	// flip LoginRequired. Validates the opt-in surface.
+	setupTestRegistry(t)
+
+	tmux := &mockTmux{
+		sessions: []string{"gt-crew-bear"},
+		paneContent: map[string]string{
+			"gt-crew-bear": "Working...\nPlease run /login to re-authenticate",
+		},
+		envVars: map[string]map[string]string{
+			"gt-crew-bear": {"CLAUDE_CONFIG_DIR": "/home/user/.claude-accounts/work"},
+		},
+	}
+
+	scanner, err := NewScanner(tmux, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Note: WithLoginPatterns NOT called.
+
+	results, err := scanner.ScanAll()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+	if results[0].LoginRequired {
+		t.Error("expected LoginRequired false when login patterns not enabled")
+	}
+}
+
+func TestWithLoginPatterns_InvalidPattern(t *testing.T) {
+	scanner, err := NewScanner(&mockTmux{}, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = scanner.WithLoginPatterns([]string{"[invalid"})
+	if err == nil {
+		t.Error("expected error for invalid login pattern")
+	}
+}
+
+func TestScanAll_LoginPatternVariations(t *testing.T) {
+	// Verify each DefaultLoginRequiredPatterns entry triggers detection.
+	setupTestRegistry(t)
+
+	cases := []struct {
+		name string
+		line string
+	}{
+		{"slash-login-prompt", "Please run /login"},
+		{"auth-required", "Authentication required"},
+		{"please-log-in", "Please log in to Claude"},
+		{"run-login-reauth", "Run /login to re-authenticate"},
+		{"session-expired", "Your session has expired. Please log in again."},
+		{"401-with-auth", "401 Unauthorized: please re-authenticate via login"},
+		{"invalid-credentials", "Invalid credentials"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			tmux := &mockTmux{
+				sessions: []string{"gt-crew-bear"},
+				paneContent: map[string]string{
+					"gt-crew-bear": "Working...\n" + tc.line,
+				},
+				envVars: map[string]map[string]string{
+					"gt-crew-bear": {"CLAUDE_CONFIG_DIR": "/x"},
+				},
+			}
+			scanner, err := NewScanner(tmux, nil, nil)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := scanner.WithLoginPatterns(nil); err != nil {
+				t.Fatal(err)
+			}
+			results, err := scanner.ScanAll()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if len(results) != 1 || !results[0].LoginRequired {
+				t.Errorf("pattern %q failed to trigger LoginRequired (line=%q)", tc.name, tc.line)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Adds a third signal alongside `RateLimited` and `NearLimit`:
**`LoginRequired`**. When a session is blocked on `/login`, rotation
cannot resolve it — only interactive re-auth can. Surfacing the signal
separately lets watchers fire user-facing alerts (Telegram/email)
rather than attempting silent rotation.

Follows the pattern of #2075 (context-preserving keychain rotation)
and #2205 (proactive near-limit detection): minimal, opt-in additions
to the quota scanner that downstream watchers consume via the existing
JSON output of `gt quota scan`.

## Changes

- `internal/constants/constants.go`: `DefaultLoginRequiredPatterns`
  sibling list (7 patterns: `/login` prompts, "Authentication
  required", log-in prompts, re-auth instructions, session-expired,
  401-with-auth, invalid credentials).
- `internal/quota/scan.go`:
  - `ScanResult.LoginRequired` bool field (JSON tag `login_required`)
  - `Scanner.loginPatterns` field
  - `WithLoginPatterns(patterns []string) error` opt-in method
    matching the existing `WithWarningPatterns` ergonomics
  - Login check runs after hard-limit and near-limit checks (hard
    wins precedence). Opt-in via `WithLoginPatterns` — zero
    behavior change for callers that don't enable it.
- `internal/quota/scan_test.go`: 5 new test functions
  - `TestScanAll_DetectsLoginRequired` — basic detection
  - `TestScanAll_HardLimitTakesPrecedenceOverLogin` — hard-limit
    precedence guarantee
  - `TestScanAll_LoginNotEnabled_NoFalsePositive` — opt-in semantics
  - `TestWithLoginPatterns_InvalidPattern` — error path
  - `TestScanAll_LoginPatternVariations` — table-driven across all
    7 default patterns

## Use case

Gas Town crew daemons want to alert humans when `/login` is required
(rotation can't help) without conflating with rate-limit events. A
forthcoming Gas Town daemon (`gt-director-bottleneck-watch` in the
caller repo) consumes `ScanResult.LoginRequired` alongside its
bd-label-driven escalations.

## Test plan

- [x] `go test ./internal/quota/...` — passes (existing + new tests)
- [x] `go vet ./internal/quota/... ./internal/constants/...` — clean
- [x] `go build ./...` — clean
- [ ] Manual verification on a real session showing `/login` prompt
      (deferred to reviewer; `WithLoginPatterns` is opt-in and tested)

## Notes

- All login-required messages chosen to be specific enough to avoid
  false positives (e.g., `Please (run|use) ['"]?/login['"]?` requires
  the literal `/login` token; `Authentication required` is the exact
  Claude Code prompt).
- Pattern list is conservative — additions can ship in follow-on
  PRs as new false-negative cases surface in production.
- Opt-in design preserves backward compatibility: callers must
  explicitly call `WithLoginPatterns(nil)` (or pass custom patterns)
  to enable detection.