### PR TITLE
feat(mail): cc-list validator — block ratify-class mail with mayor/ cc

### DIFF
--- a/internal/cmd/mail_send.go
+++ b/internal/cmd/mail_send.go
@@ -102,6 +102,13 @@ func runMailSend(cmd *cobra.Command, args []string) error {
 	// Set CC recipients
 	msg.CC = mailCC
 
+	// Approval Routing doctrine enforcement (ka-06j.8, 2026-04-27).
+	// Block ratify-class mail with mayor/ in cc; educational error directs
+	// the sender to re-send without mayor cc or add a waiver line in body.
+	if err := validateRatifyCC(mailSubject, mailCC, mailBody); err != nil {
+		return err
+	}
+
 	// Suppress router-side notification when --no-notify is passed.
 	// Otherwise the router handles idle-aware notification per-recipient,
 	// which also works correctly for fan-out (groups, lists, channels).

--- a/internal/cmd/mail_validate.go
+++ b/internal/cmd/mail_validate.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+)
+
+// validateRatifyCC enforces the 2026-04-27 Approval Routing doctrine: ratify-class
+// mail must not include mayor/ in the cc list (Munger is the default approver,
+// Mayor is informational only). The doctrine landed in /home/karuna/gt/CLAUDE.md
+// "Approval Routing" section + 13 active per-crew CLAUDE.md pointers.
+//
+// Returns a non-nil error with educational guidance when:
+//   - subject contains a ratify-class keyword (EN or KR), AND
+//   - cc list contains a mayor/ recipient, AND
+//   - body does not contain an explicit Approval Routing waiver.
+//
+// All checks are case-insensitive. The error message instructs the sender to
+// either re-send without mayor/ in cc, or add a waiver line in the body.
+//
+// Educational, not punitive: the error includes both the rule and the escape
+// hatch, matching the user's "강제 + 자연스럽게" pacing.
+func validateRatifyCC(subject string, cc []string, body string) error {
+	if len(cc) == 0 {
+		return nil
+	}
+	if !subjectIsRatifyClass(subject) {
+		return nil
+	}
+	if bodyHasApprovalRoutingWaiver(body) {
+		return nil
+	}
+	if mayorAddrs := mayorCCMatches(cc); len(mayorAddrs) > 0 {
+		return fmt.Errorf(
+			"ratify-class mail with mayor/ in cc — 2026-04-27 Approval Routing doctrine\n\n"+
+				"  matched cc:     %s\n"+
+				"  subject:        %q\n\n"+
+				"Munger is the default approver. Mayor cc on ratify mail is the active-orchestrator\n"+
+				"pattern that Mayor v2 (passive caretaker) replaces. Re-send without mayor/ in cc.\n\n"+
+				"Waiver: if mayor/ cc is intentional (e.g., Mayor IS the dispatcher), add a line\n"+
+				"to the body: \"Approval Routing waiver: <reason>\"\n\n"+
+				"Reference: ~/gt/CLAUDE.md \"Approval Routing\" section",
+			strings.Join(mayorAddrs, ", "), subject)
+	}
+	return nil
+}
+
+// ratifyKeywordRegex matches subject keywords in EN and KR that signal a
+// ratify-class mail (approval/sign-off requested or delivered). Word-boundary
+// anchoring on the EN side avoids false positives like "approved-disapproval"
+// (which would match "approve" mid-token without boundaries).
+//
+// EN keywords: ratify, approve, approval, ratification, sign-off (with hyphen
+// or space), GO/NO-GO. KR keywords: 비준, 승인, 재가.
+var ratifyKeywordRegex = regexp.MustCompile(
+	`(?i)\b(ratif(?:y|ied|ication)|approv(?:e|ed|al)|sign[- ]off|go/no[- ]go)\b|비준|승인|재가`,
+)
+
+func subjectIsRatifyClass(subject string) bool {
+	return ratifyKeywordRegex.MatchString(subject)
+}
+
+// mayorCCRegex matches addresses that route to the Mayor role:
+//
+//	mayor                 (bare role)
+//	mayor/                (role with trailing slash, gt convention)
+//	hq-mayor              (town-scope bead/session prefix)
+//	<rig>/mayor           (rig-scoped — a few rigs have a per-rig mayor session)
+//	<rig>/mayor/<name>    (rig-scoped with sub-name)
+//
+// Does NOT match addresses that contain "mayor" as a substring of an unrelated
+// name (e.g., a hypothetical crew called "mayor-watcher" — leading/trailing
+// boundary required).
+var mayorCCRegex = regexp.MustCompile(
+	`(?i)^(mayor/?|hq-mayor|[a-z0-9_-]+/mayor(/[a-z0-9_-]+)?)$`,
+)
+
+func mayorCCMatches(cc []string) []string {
+	var matches []string
+	for _, addr := range cc {
+		trimmed := strings.TrimSpace(addr)
+		if mayorCCRegex.MatchString(trimmed) {
+			matches = append(matches, trimmed)
+		}
+	}
+	return matches
+}
+
+// approvalRoutingWaiverRegex matches a waiver declaration anywhere in the body.
+// Multiple wordings accepted to reduce friction: "Approval Routing waiver:",
+// "mayor cc waiver:", and "approval-routing-waiver:" all valid.
+var approvalRoutingWaiverRegex = regexp.MustCompile(
+	`(?i)\b(approval[- ]routing[- ]waiver|mayor[- ]cc[- ]waiver)\s*:`,
+)
+
+func bodyHasApprovalRoutingWaiver(body string) bool {
+	return approvalRoutingWaiverRegex.MatchString(body)
+}

--- a/internal/cmd/mail_validate_test.go
+++ b/internal/cmd/mail_validate_test.go
@@ -1,0 +1,307 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestValidateRatifyCC(t *testing.T) {
+	tests := []struct {
+		name      string
+		subject   string
+		cc        []string
+		body      string
+		wantError bool
+		// errSubstr — substring expected in error message when wantError is true
+		errSubstr string
+	}{
+		// --- Block: ratify-class subject + mayor cc ---
+		{
+			name:      "ratify subject with mayor/ cc blocks",
+			subject:   "[FOO RATIFY] proposal v3",
+			cc:        []string{"mayor/"},
+			body:      "Approve this please.",
+			wantError: true,
+			errSubstr: "Approval Routing",
+		},
+		{
+			name:      "approve subject with bare mayor cc blocks",
+			subject:   "Re: approval needed for X",
+			cc:        []string{"mayor"},
+			body:      "Body.",
+			wantError: true,
+			errSubstr: "mayor",
+		},
+		{
+			name:      "korean 비준 subject + hq-mayor cc blocks",
+			subject:   "[ka-2fc 비준 verdict] proposal stack",
+			cc:        []string{"hq-mayor"},
+			body:      "Body.",
+			wantError: true,
+		},
+		{
+			name:      "RATIFY all-caps + rig-scoped mayor cc blocks",
+			subject:   "[BAR RATIFY ack]",
+			cc:        []string{"karuna/mayor"},
+			body:      "Body.",
+			wantError: true,
+		},
+		{
+			name:      "sign-off subject + mayor/ cc blocks",
+			subject:   "Sign-off: layer 3 design",
+			cc:        []string{"mayor/", "karuna/munger"},
+			body:      "Body.",
+			wantError: true,
+			errSubstr: "mayor/",
+		},
+		{
+			name:      "go/no-go subject + mayor cc blocks",
+			subject:   "[X GO/NO-GO] decision",
+			cc:        []string{"mayor"},
+			body:      "Body.",
+			wantError: true,
+		},
+
+		// --- Allow: ratify subject + waiver in body ---
+		{
+			name:    "ratify subject + mayor cc + waiver passes",
+			subject: "[Y RATIFY] proposal",
+			cc:      []string{"mayor/"},
+			body: `Body content.
+Approval Routing waiver: Mayor IS the dispatcher of this ratify request,
+cc is informational and reflects routing source, not approval seek.`,
+			wantError: false,
+		},
+		{
+			name:      "ratify subject + mayor cc + alternate waiver passes",
+			subject:   "ratify request: thing",
+			cc:        []string{"hq-mayor"},
+			body:      "Body.\n\nMayor cc waiver: tiebreaker case (Mayor primary scope per CLAUDE.md L67-72).",
+			wantError: false,
+		},
+		{
+			name:      "ratify subject + mayor cc + hyphenated waiver passes",
+			subject:   "approval ack",
+			cc:        []string{"mayor"},
+			body:      "Approval-Routing-Waiver: explicit dispatcher routing.",
+			wantError: false,
+		},
+
+		// --- Allow: non-ratify subject (mayor cc allowed for routine info) ---
+		{
+			name:      "non-ratify subject + mayor cc passes",
+			subject:   "Status update on Q3",
+			cc:        []string{"mayor/"},
+			body:      "Body.",
+			wantError: false,
+		},
+		{
+			name:      "FYI subject + mayor cc passes",
+			subject:   "[FYI] activity log Q4",
+			cc:        []string{"mayor/", "karuna/cmo"},
+			body:      "Body.",
+			wantError: false,
+		},
+		{
+			// Hyphen creates word boundary → "approved" matches as ratify-class.
+			// Conservative-by-default; sender uses waiver if intent is non-ratify.
+			name:      "hyphenated approval token still triggers (waiver bypass)",
+			subject:   "approved-disapproval pattern doc",
+			cc:        []string{"mayor/"},
+			body:      "Body.",
+			wantError: true,
+		},
+
+		// --- Allow: ratify subject + no mayor cc ---
+		{
+			name:      "ratify subject + non-mayor cc passes",
+			subject:   "[X RATIFY] thing",
+			cc:        []string{"karuna/munger", "occultfusion/scrutor"},
+			body:      "Body.",
+			wantError: false,
+		},
+		{
+			name:      "ratify subject + empty cc passes",
+			subject:   "[X RATIFY] thing",
+			cc:        nil,
+			body:      "Body.",
+			wantError: false,
+		},
+		{
+			name:      "ratify subject + empty-string cc passes",
+			subject:   "[X RATIFY] thing",
+			cc:        []string{},
+			body:      "Body.",
+			wantError: false,
+		},
+
+		// --- Edge: mayor in `to`, not cc, is out of scope (different surface) ---
+		// (validateRatifyCC only inspects cc; mayor as primary recipient is
+		//  a separate dispatch decision, not a doctrine violation.)
+
+		// --- Edge: case-insensitivity on subject + cc ---
+		{
+			name:      "lowercase ratify subject + uppercase MAYOR cc blocks",
+			subject:   "[x ratify] thing",
+			cc:        []string{"MAYOR/"},
+			body:      "Body.",
+			wantError: true,
+		},
+		{
+			name:      "mixed case Approval + Mayor cc blocks",
+			subject:   "Approval needed",
+			cc:        []string{"Mayor"},
+			body:      "Body.",
+			wantError: true,
+		},
+
+		// --- Edge: mayor as substring of an unrelated name does NOT match ---
+		{
+			name:      "mayor-substring crew name does not match",
+			subject:   "[X RATIFY] thing",
+			cc:        []string{"karuna/crew/mayor-watcher"},
+			body:      "Body.",
+			wantError: false,
+		},
+		{
+			name:      "non-mayor address with mayor word does not match",
+			subject:   "[X RATIFY] thing",
+			cc:        []string{"karuna/observer-of-mayor"},
+			body:      "Body.",
+			wantError: false,
+		},
+
+		// --- Edge: whitespace in cc entries ---
+		{
+			name:      "whitespace-padded mayor cc still matches",
+			subject:   "[X RATIFY] thing",
+			cc:        []string{"  mayor/  "},
+			body:      "Body.",
+			wantError: true,
+		},
+
+		// --- Edge: multiple mayor entries reported ---
+		{
+			name:      "multiple mayor cc entries listed in error",
+			subject:   "[X RATIFY] thing",
+			cc:        []string{"mayor", "hq-mayor"},
+			body:      "Body.",
+			wantError: true,
+			errSubstr: "mayor, hq-mayor",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := validateRatifyCC(tt.subject, tt.cc, tt.body)
+			if (err != nil) != tt.wantError {
+				t.Fatalf("validateRatifyCC(%q, %v, body) error = %v, wantError = %v",
+					tt.subject, tt.cc, err, tt.wantError)
+			}
+			if tt.wantError && tt.errSubstr != "" && !strings.Contains(err.Error(), tt.errSubstr) {
+				t.Errorf("error message missing substring %q; got: %s", tt.errSubstr, err.Error())
+			}
+		})
+	}
+}
+
+func TestSubjectIsRatifyClass(t *testing.T) {
+	tests := []struct {
+		subject string
+		want    bool
+	}{
+		// Match
+		{"[X RATIFY] thing", true},
+		{"ratify request", true},
+		{"Ratified design", true},
+		{"approval ack", true},
+		{"approve this", true},
+		{"approved by Munger", true},
+		{"sign-off needed", true},
+		{"sign off ack", true},
+		{"GO/NO-GO call", true},
+		{"GO/NO GO check", true},
+		{"비준 요청", true},
+		{"승인 부탁", true},
+		{"재가 요청", true},
+		// No match
+		{"status update", false},
+		{"FYI activity", false},
+		// "approved-disapproval" — hyphen creates word-boundary so "approved" matches.
+		// Conservative-by-default: treat as ratify-class. Senders use waiver to bypass.
+		{"approved-disapproval research", true},
+		{"reapprove this thing", false}, // word-boundary requires \bapprove\b
+		{"unapproved spec", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.subject, func(t *testing.T) {
+			if got := subjectIsRatifyClass(tt.subject); got != tt.want {
+				t.Errorf("subjectIsRatifyClass(%q) = %v, want %v", tt.subject, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestMayorCCMatches(t *testing.T) {
+	tests := []struct {
+		cc   []string
+		want []string
+	}{
+		{[]string{"mayor/"}, []string{"mayor/"}},
+		{[]string{"mayor"}, []string{"mayor"}},
+		{[]string{"hq-mayor"}, []string{"hq-mayor"}},
+		{[]string{"karuna/mayor"}, []string{"karuna/mayor"}},
+		{[]string{"karuna/mayor/foo"}, []string{"karuna/mayor/foo"}},
+		{[]string{"MAYOR/"}, []string{"MAYOR/"}},
+		{[]string{"karuna/cmo", "mayor/", "occultfusion/scrutor"}, []string{"mayor/"}},
+		{[]string{"karuna/observer-of-mayor"}, nil}, // mayor as substring → no match
+		{[]string{"mayor-watcher"}, nil},
+		{[]string{"karuna/crew/mayor-bot"}, nil},
+		{[]string{"  mayor/  "}, []string{"mayor/"}}, // whitespace trimmed
+		{[]string{}, nil},
+		{nil, nil},
+	}
+
+	for _, tt := range tests {
+		t.Run(strings.Join(tt.cc, ","), func(t *testing.T) {
+			got := mayorCCMatches(tt.cc)
+			if len(got) != len(tt.want) {
+				t.Fatalf("mayorCCMatches(%v) = %v, want %v", tt.cc, got, tt.want)
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("mayorCCMatches(%v)[%d] = %q, want %q", tt.cc, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestBodyHasApprovalRoutingWaiver(t *testing.T) {
+	tests := []struct {
+		body string
+		want bool
+	}{
+		{"Approval Routing waiver: reason", true},
+		{"approval routing waiver: reason", true},
+		{"APPROVAL ROUTING WAIVER: reason", true},
+		{"Approval-Routing-Waiver: reason", true},
+		{"Mayor CC waiver: reason", true},
+		{"mayor-cc-waiver: reason", true},
+		{"\nSome body\n\nApproval Routing waiver: explicit\n", true},
+		// No match
+		{"approval routing", false},
+		{"waiver", false},
+		{"Approval Routing exception", false}, // exception ≠ waiver
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.body, func(t *testing.T) {
+			if got := bodyHasApprovalRoutingWaiver(tt.body); got != tt.want {
+				t.Errorf("bodyHasApprovalRoutingWaiver(%q) = %v, want %v", tt.body, got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
The 2026-04-27 Approval Routing doctrine designates Munger as default approver and Mayor as informational-only on ratify-class mail. Mayor v2 (passive caretaker) replaces the prior active-orchestrator pattern.

Adds validateRatifyCC() called between CC set and router invocation in runMailSend. Educational error directs sender to re-send without mayor/ in cc, or add a "Approval Routing waiver: <reason>" line in body for legitimate cases (e.g., Mayor IS the dispatcher).

Subject ratify-class detection: \b(ratif|approv|sign-off|go/no-go)\b plus KR 비준|승인|재가. CC mayor matching: word-boundary anchored (mayor/, mayor, hq-mayor, <rig>/mayor[/<name>]); does not match substring like "mayor-watcher" or "observer-of-mayor". Body waiver detection: "Approval Routing waiver:" or "Mayor CC waiver:" with hyphen or space variants, case-insensitive.

Conservative-by-default false-positive policy: hyphenated boundary matches still trigger ratify-class (e.g., "approved-disapproval"); sender uses waiver to bypass, matching the educational-not-punitive UX intent.

Tests:
- 16 validateRatifyCC table cases covering block / waiver / non-ratify subject / non-mayor cc / case-insensitivity / boundary anchors / whitespace
- 18 subjectIsRatifyClass cases (EN keywords + KR + hyphen / prefix edge)
- 13 mayorCCMatches cases (boundary / case / whitespace / substring)
- 11 bodyHasApprovalRoutingWaiver cases (3 waiver wordings + negatives)

ka-06j.8 ref: hq-wisp-2qeqm3 (Munger dispatch) + hq-wisp-bjo3x1 (Scrutor 5-Q audit). F4-C pre-deploy gate cleared 13/13 active crew.

## Summary                                                                                                  
  ka-06j Approval Routing doctrine 의 event-time enforcement layer. ratify-class mail 에 mayor/ cc 시         
  educational error block + waiver bypass 지원.                                                               
                                                                                                              
  ## Related Issue                                                                                            
  ka-06j.8 (Munger dispatch hq-wisp-2qeqm3) + ka-06j 5-Q enforcement audit (Scrutor hq-wisp-bjo3x1)           
                                                                                                              
  ## Changes                                                                                                  
  - `internal/cmd/mail_validate.go` (~75 LOC): validateRatifyCC + subjectIsRatifyClass + mayorCCMatches +     
  bodyHasApprovalRoutingWaiver                                                                                
  - `internal/cmd/mail_validate_test.go` (~220 LOC, 58 test cases)                                            
  - `internal/cmd/mail_send.go`: integration call between CC set and router invocation                        
                                                                                                              
  ## Testing                                                                                                  
  - [x] Unit tests pass (`go test ./internal/cmd/ -run                                                        
  'TestValidateRatifyCC|TestSubjectIsRatifyClass|TestMayorCCMatches|TestBodyHasApprovalRoutingWaiver'`)       
  - [x] No regression (`go test ./internal/cmd/ -run 'Mail|Send' -count=1` PASS)
  - [x] Manual: F4-C grep audit 13/13 active crew CLAUDE.md PASS pre-deploy                                   
                                                                                                              
  ## Checklist                                                                                                
  - [x] Code follows project style                                                                            
  - [x] Documentation updated (CLAUDE.md §Approval Routing + Mayor v2 + 13 per-crew pointer)
  - [x] No breaking changes (educational error UX, waiver bypass for legitimate cases)