### PR TITLE
fix(done): auto-pop orphaned stashes in gt-pvx safety net

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -271,6 +271,62 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		}
 	}
 
+	// SAFETY NET (gt-pvx, stash recovery): If we detected stashes belonging to
+	// this branch, auto-pop them so the existing uncommitted-work auto-commit
+	// path (below) catches the contents and saves them as a normal commit.
+	//
+	// Background: agents have been observed running `git stash` to clear the
+	// working tree before rebase/checkout, then dying before `git stash pop`.
+	// The stash entries become orphaned in .git/refs/stash, surviving for
+	// indefinite periods and silently leaking work. By popping them on the way
+	// out of `gt done`, the recovery flow turns "lost" stashes into a
+	// committed safety-net snapshot.
+	//
+	// Pop happens oldest-first so the most recent state ends up on top of the
+	// working tree (matches what a user would do manually). If any pop has
+	// conflicts, we stop and let the agent/user resolve — surfacing the
+	// conflict is better than silently dropping the stash.
+	if cwdAvailable && doneCleanupStatus == "stash" {
+		entries, err := g.StashListForBranch()
+		if err != nil {
+			style.PrintWarning("auto-pop: could not list stashes: %v — orphaned stashes may remain", err)
+		} else if len(entries) > 0 {
+			fmt.Printf("\n%s %d stash(es) detected on this branch — auto-popping (gt-pvx safety net)\n",
+				style.Bold.Render("⚠"), len(entries))
+			// Pop oldest first: iterate in reverse so newest lands on top.
+			popFailed := false
+			for i := len(entries) - 1; i >= 0; i-- {
+				e := entries[i]
+				fmt.Printf("  popping %s — %s\n", e.Ref, e.Message)
+				if popErr := g.StashPop(e.Ref); popErr != nil {
+					style.PrintWarning("auto-pop %s failed (likely conflict): %v", e.Ref, popErr)
+					style.PrintWarning("stopping pop chain — resolve conflict manually then re-run gt done")
+					popFailed = true
+					break
+				}
+				// After each pop, stash refs shift; re-fetch the list before next pop.
+				entries, err = g.StashListForBranch()
+				if err != nil || len(entries) == 0 {
+					break
+				}
+			}
+			if !popFailed {
+				// Re-evaluate cleanup status: pops likely produced uncommitted changes
+				// that the next block will auto-commit. Worst case, status was already
+				// uncommitted and the next block runs anyway.
+				if workStatus, wsErr := g.CheckUncommittedWork(); wsErr == nil && workStatus.HasUncommittedChanges {
+					doneCleanupStatus = "uncommitted"
+					fmt.Printf("%s Stash content moved to working tree — will auto-commit below.\n",
+						style.Bold.Render("✓"))
+				} else {
+					// Pops succeeded but produced nothing dirty (e.g. stashes were
+					// already merged). Recompute status normally.
+					doneCleanupStatus = ""
+				}
+			}
+		}
+	}
+
 	// SAFETY NET: Auto-commit uncommitted work before ANY exit path (gt-pvx).
 	// Polecats have been observed running gt done without committing their
 	// implementation work (1000s of lines lost). This happened because:

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1833,6 +1833,67 @@ func (g *Git) StashCount() (int, error) {
 	return count, nil
 }
 
+// StashEntry represents one entry from `git stash list`, scoped to the current branch.
+type StashEntry struct {
+	Ref     string // e.g. "stash@{2}"
+	Message string // e.g. "WIP on main: <hash> <subject>"
+}
+
+// StashListForBranch returns all stash entries belonging to the current branch,
+// ordered as `git stash list` returns them (newest first, i.e. stash@{0} first).
+// Filtering matches StashCount: only entries with ": WIP on <branch>:" or
+// ": On <branch>:" prefixes are returned, since stashes are global to the repo
+// but conceptually belong to the worktree where they were created.
+func (g *Git) StashListForBranch() ([]StashEntry, error) {
+	out, err := g.run("stash", "list")
+	if err != nil {
+		return nil, err
+	}
+	if out == "" {
+		return nil, nil
+	}
+
+	branch, branchErr := g.CurrentBranch()
+	filterByBranch := branchErr == nil && branch != "" && branch != "HEAD"
+	wipPrefix := ": WIP on " + branch + ":"
+	onPrefix := ": On " + branch + ":"
+
+	var entries []StashEntry
+	for _, line := range strings.Split(out, "\n") {
+		if line == "" {
+			continue
+		}
+		if filterByBranch {
+			if !strings.Contains(line, wipPrefix) && !strings.Contains(line, onPrefix) {
+				continue
+			}
+		}
+		// Lines have the form "stash@{N}: <message>"
+		colonIdx := strings.Index(line, ":")
+		if colonIdx <= 0 {
+			continue
+		}
+		entries = append(entries, StashEntry{
+			Ref:     line[:colonIdx],
+			Message: strings.TrimSpace(line[colonIdx+1:]),
+		})
+	}
+	return entries, nil
+}
+
+// StashPop applies the given stash ref to the working tree and drops it on success.
+// Returns an error if the pop has conflicts (working tree is left as-is for manual
+// resolution). Callers should treat conflict errors as "stop, escalate to user".
+func (g *Git) StashPop(ref string) error {
+	if ref == "" {
+		return fmt.Errorf("stash ref required")
+	}
+	if _, err := g.run("stash", "pop", ref); err != nil {
+		return fmt.Errorf("git stash pop %s: %w", ref, err)
+	}
+	return nil
+}
+
 // UnpushedCommits returns the number of commits that are not pushed to the remote.
 // It checks if the current branch has an upstream and counts commits ahead.
 // Returns 0 if there is no upstream configured.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1,6 +1,7 @@
 package git
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1660,6 +1661,102 @@ func TestStashCount_NoFalsePositiveFromCommitMessage(t *testing.T) {
 	}
 	if count != 0 {
 		t.Errorf("StashCount on 'fix' branch = %d, want 0 (stash belongs to 'develop', commit msg has 'on fix:')", count)
+	}
+}
+
+// TestStashListForBranch verifies StashListForBranch returns entries scoped
+// to the current branch with parsed Ref/Message fields.
+func TestStashListForBranch(t *testing.T) {
+	t.Parallel()
+	dir := initTestRepo(t)
+	g := NewGit(dir)
+
+	// Empty repo — no stashes
+	entries, err := g.StashListForBranch()
+	if err != nil {
+		t.Fatalf("StashListForBranch (empty): %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("StashListForBranch (empty) = %d entries, want 0", len(entries))
+	}
+
+	// Create two stashes on main
+	for i, content := range []string{"first", "second"} {
+		if err := os.WriteFile(filepath.Join(dir, "f.txt"), []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		cmd := exec.Command("git", "add", ".")
+		cmd.Dir = dir
+		_ = cmd.Run()
+		cmd = exec.Command("git", "stash", "push", "-m", fmt.Sprintf("stash-%d", i))
+		cmd.Dir = dir
+		if err := cmd.Run(); err != nil {
+			t.Fatalf("git stash %d: %v", i, err)
+		}
+	}
+
+	entries, err = g.StashListForBranch()
+	if err != nil {
+		t.Fatalf("StashListForBranch: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Errorf("StashListForBranch = %d entries, want 2", len(entries))
+	}
+	// Newest first: stash@{0} is "second", stash@{1} is "first"
+	if entries[0].Ref != "stash@{0}" || entries[1].Ref != "stash@{1}" {
+		t.Errorf("Ref ordering = [%s, %s], want [stash@{0}, stash@{1}]",
+			entries[0].Ref, entries[1].Ref)
+	}
+	if entries[0].Message == "" || entries[1].Message == "" {
+		t.Errorf("Empty messages: [%s, %s]", entries[0].Message, entries[1].Message)
+	}
+}
+
+// TestStashPop verifies StashPop applies and drops a stash, leaving the
+// working tree dirty (so the gt-pvx auto-commit path catches it).
+func TestStashPop(t *testing.T) {
+	t.Parallel()
+	dir := initTestRepo(t)
+	g := NewGit(dir)
+
+	// Create a stash
+	if err := os.WriteFile(filepath.Join(dir, "dirty.txt"), []byte("dirty"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "add", ".")
+	cmd.Dir = dir
+	_ = cmd.Run()
+	cmd = exec.Command("git", "stash", "push", "-m", "popme")
+	cmd.Dir = dir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git stash: %v", err)
+	}
+
+	// Confirm one stash exists
+	count, _ := g.StashCount()
+	if count != 1 {
+		t.Fatalf("StashCount before pop = %d, want 1", count)
+	}
+
+	// Pop it
+	if err := g.StashPop("stash@{0}"); err != nil {
+		t.Fatalf("StashPop: %v", err)
+	}
+
+	// Stash should be gone
+	count, _ = g.StashCount()
+	if count != 0 {
+		t.Errorf("StashCount after pop = %d, want 0", count)
+	}
+
+	// Working tree should now have the file (dirty)
+	if _, err := os.Stat(filepath.Join(dir, "dirty.txt")); err != nil {
+		t.Errorf("dirty.txt should exist after pop: %v", err)
+	}
+
+	// Empty ref should error
+	if err := g.StashPop(""); err == nil {
+		t.Error("StashPop(\"\") should error")
 	}
 }
 


### PR DESCRIPTION
## Problem

Agents running `git stash` to clear their working tree before rebase/checkout sometimes die before `git stash pop`. The stash entries become orphaned in `.git/refs/stash` and silently accumulate, with no canonical recovery path.

The existing `gt-pvx` safety net in `gt done` auto-commits *uncommitted* work (line ~284 of `internal/cmd/done.go`), but it does not touch stashes. `CheckUncommittedWork` already detects branch-scoped stashes and flags `doneCleanupStatus = "stash"`, but no code acts on that signal.

**Live incident (April 2026, whatsapp_automation rig):** 14 orphaned stashes detected across crew clones + polecat recovery branches. One stash contained 82 lines of unsaved dashboard work that required forensic recovery (forensic report: `dc-wisp-nf7`). Forensics confirmed multiple weeks of intermittent work loss tied to orphaned stashes.

## Fix

Extend the `gt done` safety net so when stashes belong to the current branch, they auto-pop **oldest first** before the existing auto-commit path. Stash content lands in the working tree, then the existing auto-commit block catches it and produces a normal `(gt-pvx safety net)` commit.

- Pop oldest-first so newest state ends up on top (matches what a user would do manually)
- A pop conflict halts the chain and warns the user — silent drop would be worse than a noisy stop
- After successful pops, recompute `doneCleanupStatus` so the next block runs

## API additions

- `git.StashListForBranch() ([]StashEntry, error)` — branch-scoped list using the same filter as `StashCount`
- `git.StashPop(ref string) error` — wraps `git stash pop <ref>` with conflict surfacing

## Test plan

- [x] `go test ./internal/git/... -run TestStash` passes (existing + new tests)
- [x] `go vet ./...` clean
- [x] `go build ./...` clean
- [ ] Manual: create stash on a polecat branch, run `gt done`, verify stash is popped + auto-committed
- [ ] Manual: simulate pop conflict (overlapping changes), verify chain halts cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3783"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->