### PR TITLE
feat(doctor): add stash-orphan check to surface old git stashes

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -55,6 +55,7 @@ Cleanup checks (fixable):
   - orphan-processes         Detect orphaned Claude processes
   - session-name-format      Detect sessions with outdated naming format (fixable)
   - wisp-gc                  Detect and clean abandoned wisps (>1h)
+  - stash-orphan             Detect git stashes >24h old in rig + crew clones (observational)
   - misclassified-wisps      Detect issues that should be wisps (purges to wisps table, fixable)
   - jsonl-bloat              Detect stale/bloated issues.jsonl vs live database
   - stale-beads-redirect     Detect stale files in .beads directories with redirects
@@ -209,6 +210,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	d.Register(doctor.NewStalledPolecatCheck())
 	d.Register(doctor.NewOrphanProcessCheck())
 	d.Register(doctor.NewWispGCCheck())
+	d.Register(doctor.NewStashOrphanCheck())
 	d.Register(doctor.NewCheckMisclassifiedWisps())
 	d.Register(doctor.NewCheckJSONLBloat())
 	d.Register(doctor.NewStaleBeadsRedirectCheck())

--- a/internal/doctor/stash_orphan_check.go
+++ b/internal/doctor/stash_orphan_check.go
@@ -1,0 +1,189 @@
+package doctor
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"time"
+)
+
+// StashOrphanCheck scans every git working tree under each rig (root, crew clones,
+// polecat worktrees) for stashes older than a threshold. It is purely observational —
+// it never drops, pops, or otherwise mutates stashes. Recovery is the operator's call.
+//
+// Background: agents have been observed running `git stash` to clean their working
+// tree before rebase/checkout, then dying before `git stash pop`. Orphaned stashes
+// accumulate in `.git/refs/stash` indefinitely with no canonical visibility. The
+// `gt-pvx` safety net in `gt done` recovers stashes at session-end, but only for the
+// session that runs `gt done` — stashes from sessions that died abruptly stay hidden.
+//
+// This check surfaces those stashes so an operator can decide whether to pop, drop,
+// or leave them.
+type StashOrphanCheck struct {
+	BaseCheck
+	threshold time.Duration
+}
+
+// NewStashOrphanCheck creates a stash-orphan check with a 24h threshold.
+func NewStashOrphanCheck() *StashOrphanCheck {
+	return &StashOrphanCheck{
+		BaseCheck: BaseCheck{
+			CheckName:        "stash-orphan",
+			CheckDescription: "Detect git stashes older than 24h in rigs and crew clones",
+			CheckCategory:    CategoryCleanup,
+		},
+		threshold: 24 * time.Hour,
+	}
+}
+
+// Run scans every git working tree under each rig and reports stashes older than
+// the threshold. Returns Warning if any are found, OK otherwise.
+func (c *StashOrphanCheck) Run(ctx *CheckContext) *CheckResult {
+	rigs, err := discoverRigs(ctx.TownRoot)
+	if err != nil {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusError,
+			Message: "Failed to discover rigs",
+			Details: []string{err.Error()},
+		}
+	}
+
+	if len(rigs) == 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "No rigs configured",
+		}
+	}
+
+	var details []string
+	totalOrphans := 0
+
+	for _, rigName := range rigs {
+		rigRoot := filepath.Join(ctx.TownRoot, rigName)
+		// Discover every git working tree owned by this rig:
+		//   <rigRoot>/                       (rig root — polecat territory + canonical ref)
+		//   <rigRoot>/crew/<name>/           (crew clones)
+		//   <rigRoot>/polecats/<name>/<rig>/ (polecat worktrees, if any persist)
+		workdirs := discoverGitWorkdirs(rigRoot)
+		for _, wd := range workdirs {
+			orphans := countOrphanStashes(wd, c.threshold)
+			if orphans > 0 {
+				rel, err := filepath.Rel(ctx.TownRoot, wd)
+				if err != nil {
+					rel = wd
+				}
+				details = append(details, fmt.Sprintf("%s: %d stash(es) >%s old", rel, orphans, c.threshold))
+				totalOrphans += orphans
+			}
+		}
+	}
+
+	if totalOrphans > 0 {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusWarning,
+			Message: fmt.Sprintf("%d orphan stash(es) found across rigs (>%s old)", totalOrphans, c.threshold),
+			Details: details,
+			FixHint: "Inspect with 'cd <path> && git stash list', then 'git stash pop' or 'git stash drop'. " +
+				"This check is observational — automatic drop is unsafe.",
+		}
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusOK,
+		Message: "No orphan stashes found",
+	}
+}
+
+// discoverGitWorkdirs returns every directory under rigRoot that has a .git
+// directory or file (i.e. is a git working tree). Probes the rig root itself
+// plus immediate children of crew/ and polecats/. Anything deeper is ignored
+// (we don't walk the entire tree — performance + intent: only sanctioned
+// per-agent paths).
+func discoverGitWorkdirs(rigRoot string) []string {
+	var dirs []string
+
+	// Rig root itself
+	if isGitWorkdir(rigRoot) {
+		dirs = append(dirs, rigRoot)
+	}
+
+	// Crew clones at <rigRoot>/crew/<name>/
+	for _, sub := range []string{"crew", "polecats"} {
+		parent := filepath.Join(rigRoot, sub)
+		entries, err := os.ReadDir(parent)
+		if err != nil {
+			continue
+		}
+		for _, e := range entries {
+			if !e.IsDir() {
+				continue
+			}
+			candidate := filepath.Join(parent, e.Name())
+			// For polecats, the working tree is one level deeper:
+			//   polecats/<name>/<rig-name>/
+			if sub == "polecats" {
+				inner, err := os.ReadDir(candidate)
+				if err != nil {
+					continue
+				}
+				for _, ie := range inner {
+					if !ie.IsDir() {
+						continue
+					}
+					path := filepath.Join(candidate, ie.Name())
+					if isGitWorkdir(path) {
+						dirs = append(dirs, path)
+					}
+				}
+				continue
+			}
+			if isGitWorkdir(candidate) {
+				dirs = append(dirs, candidate)
+			}
+		}
+	}
+
+	return dirs
+}
+
+// isGitWorkdir reports whether dir contains a .git directory or file.
+func isGitWorkdir(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, ".git"))
+	return err == nil
+}
+
+// countOrphanStashes returns the number of stash entries in dir whose author
+// timestamp is older than the threshold. Returns 0 on any error (best-effort).
+func countOrphanStashes(dir string, threshold time.Duration) int {
+	// Use the stash reflog with a parseable format: "<ref>|<author-date-iso>".
+	// %gd = stash ref (e.g. stash@{0}), %ai = author date (ISO 8601 with TZ).
+	cmd := exec.Command("git", "stash", "list", "--format=%gd|%ai")
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil || len(out) == 0 {
+		return 0
+	}
+
+	cutoff := time.Now().Add(-threshold)
+	count := 0
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		parts := strings.SplitN(line, "|", 2)
+		if len(parts) != 2 {
+			continue
+		}
+		ts, err := time.Parse("2006-01-02 15:04:05 -0700", strings.TrimSpace(parts[1]))
+		if err != nil {
+			continue
+		}
+		if ts.Before(cutoff) {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/doctor/stash_orphan_check_test.go
+++ b/internal/doctor/stash_orphan_check_test.go
@@ -1,0 +1,138 @@
+package doctor
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestStashOrphanCheck_Name(t *testing.T) {
+	c := NewStashOrphanCheck()
+	if c.Name() != "stash-orphan" {
+		t.Errorf("Name = %q, want stash-orphan", c.Name())
+	}
+}
+
+func TestStashOrphanCheck_NoRigs(t *testing.T) {
+	c := NewStashOrphanCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+	res := c.Run(ctx)
+	if res.Status != StatusOK {
+		t.Errorf("Status = %v, want OK (no rigs)", res.Status)
+	}
+}
+
+// initRepoWithStash creates a git repo at dir and produces a stash.
+// Sets the stash's reflog timestamp to ageAgo so we can simulate an old stash
+// without sleeping the test.
+func initRepoWithStash(t *testing.T, dir string, ageAgo time.Duration) {
+	t.Helper()
+	for _, cmd := range [][]string{
+		{"git", "init", "-q", "-b", "main"},
+		{"git", "config", "user.email", "test@example.com"},
+		{"git", "config", "user.name", "test"},
+	} {
+		c := exec.Command(cmd[0], cmd[1:]...)
+		c.Dir = dir
+		if err := c.Run(); err != nil {
+			t.Fatalf("%v: %v", cmd, err)
+		}
+	}
+	// Initial commit so we have a HEAD
+	if err := os.WriteFile(filepath.Join(dir, "seed.txt"), []byte("seed"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, cmd := range [][]string{
+		{"git", "add", "."},
+		{"git", "commit", "-q", "-m", "seed"},
+	} {
+		c := exec.Command(cmd[0], cmd[1:]...)
+		c.Dir = dir
+		if err := c.Run(); err != nil {
+			t.Fatalf("%v: %v", cmd, err)
+		}
+	}
+	// Make working tree dirty + stash with backdated commit timestamps so the
+	// stash entry's author date is `ageAgo` in the past.
+	if err := os.WriteFile(filepath.Join(dir, "dirty.txt"), []byte("dirty"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	c := exec.Command("git", "add", ".")
+	c.Dir = dir
+	if err := c.Run(); err != nil {
+		t.Fatal(err)
+	}
+	stashCmd := exec.Command("git", "stash", "push", "-m", "old-stash")
+	stashCmd.Dir = dir
+	when := time.Now().Add(-ageAgo).Format(time.RFC3339)
+	stashCmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_DATE="+when,
+		"GIT_COMMITTER_DATE="+when,
+	)
+	if err := stashCmd.Run(); err != nil {
+		t.Fatalf("git stash: %v", err)
+	}
+}
+
+func TestCountOrphanStashes_OldStash(t *testing.T) {
+	dir := t.TempDir()
+	initRepoWithStash(t, dir, 48*time.Hour) // 2 days old
+
+	// 24h threshold — should detect
+	if got := countOrphanStashes(dir, 24*time.Hour); got != 1 {
+		t.Errorf("countOrphanStashes(48h, threshold=24h) = %d, want 1", got)
+	}
+
+	// 7d threshold — should NOT detect
+	if got := countOrphanStashes(dir, 7*24*time.Hour); got != 0 {
+		t.Errorf("countOrphanStashes(48h, threshold=7d) = %d, want 0", got)
+	}
+
+	// No-stash dir — should be 0
+	empty := t.TempDir()
+	exec.Command("git", "init", "-q", empty).Run()
+	if got := countOrphanStashes(empty, 24*time.Hour); got != 0 {
+		t.Errorf("countOrphanStashes(empty repo) = %d, want 0", got)
+	}
+}
+
+func TestCountOrphanStashes_FreshStash(t *testing.T) {
+	dir := t.TempDir()
+	initRepoWithStash(t, dir, 1*time.Hour) // fresh
+
+	if got := countOrphanStashes(dir, 24*time.Hour); got != 0 {
+		t.Errorf("fresh stash flagged as orphan: got %d, want 0", got)
+	}
+}
+
+func TestDiscoverGitWorkdirs(t *testing.T) {
+	rig := t.TempDir()
+
+	// Create rig root as a git repo
+	exec.Command("git", "init", "-q", rig).Run()
+
+	// Crew clone
+	crewDir := filepath.Join(rig, "crew", "alice")
+	if err := os.MkdirAll(crewDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	exec.Command("git", "init", "-q", crewDir).Run()
+
+	// Polecat worktree (one level deeper: polecats/<name>/<rig>/)
+	polecatDir := filepath.Join(rig, "polecats", "fury", "myrig")
+	if err := os.MkdirAll(polecatDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	exec.Command("git", "init", "-q", polecatDir).Run()
+
+	// Non-git dir under crew/ should be ignored
+	noGitDir := filepath.Join(rig, "crew", "no_git_here")
+	os.MkdirAll(noGitDir, 0755)
+
+	got := discoverGitWorkdirs(rig)
+	if len(got) != 3 {
+		t.Errorf("discoverGitWorkdirs found %d dirs, want 3 (rig root + crew/alice + polecats/fury/myrig): %v", len(got), got)
+	}
+}


### PR DESCRIPTION
## Problem

Gas Town agents sometimes run `git stash` to clean their working tree before a rebase or checkout, then die before `git stash pop`. The stash entries become orphaned in `.git/refs/stash` indefinitely, with no canonical path to discover them.

**Live incident (April 2026, whatsapp_automation rig):** forensic audit found 14+ orphan stashes scattered across crew clones and polecat recovery branches; the oldest contained 82 lines of unsaved dashboard work that took manual diff archeology to recover.

The companion `gt-pvx` fix in #3783 auto-recovers stashes on `gt done`, but only for sessions that explicitly run `gt done`. Sessions that die abruptly (OOM, crash, parent-process kill) leave their stashes behind with no recovery trigger. **Today there is no canonical mechanism to even *see* these stashes.**

## Fix

A new `stash-orphan` cleanup check that:

1. Walks every git working tree under each rig:
   - `<rigRoot>/`              — rig root (polecat territory + canonical ref)
   - `<rigRoot>/crew/<name>/`  — crew clones
   - `<rigRoot>/polecats/<name>/<rig>/` — polecat worktrees, if any persist
2. For each, runs `git stash list --format=%gd|%ai` and counts stashes whose author timestamp is older than 24h
3. Returns `Warning` with per-path details when any are found; `OK` otherwise

## Why observational, not fixable

`gt doctor --fix` is intentionally not implemented for this check. Silent `git stash drop` is unsafe — operators should review each stash and decide pop vs. drop. The `FixHint` directs them to `cd <path> && git stash list` plus `git stash pop` or `git stash drop`.

## Validation against real data

Run on my local 6-rig deployment:

```
○  stash-orphan...  ⚠  stash-orphan 22 orphan stash(es) found across rigs (>24h0m0s old)
```

22 stashes detected, all older than the 24h threshold. Without this check, they'd remain hidden indefinitely.

## Test plan

- [x] `go test ./internal/doctor/... -run "Stash|CountOrphan|DiscoverGitWorkdirs"` passes
- [x] `go vet ./...` clean
- [x] `make build` clean
- [x] Manual: `gt doctor` on real rig deployment surfaces 22 orphans

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3784"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->