### PR TITLE
fix: add --allow-empty to reaper purge DOLT_COMMIT calls

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -512,16 +512,12 @@ func purgeClosedWisps(db *sql.DB, dbName string, purgeAge time.Duration, dryRun 
 			return totalDeleted, anomalies, nil
 		}
 		commitMsg := fmt.Sprintf("reaper: purge %d closed wisps from %s", totalDeleted, dbName)
-		if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
-			// "nothing to commit" is expected when wisps are dolt_ignored — deletes
-			// are auto-committed by the SQL layer and Dolt has nothing to version.
-			if !isNothingToCommit(err) {
-				// Non-fatal — log but continue.
-				anomalies = append(anomalies, Anomaly{
-					Type:    "dolt_commit_failed",
-					Message: fmt.Sprintf("dolt commit after purge failed: %v", err),
-				})
-			}
+		if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('--allow-empty', '-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
+			// Non-fatal — log but continue.
+			anomalies = append(anomalies, Anomaly{
+				Type:    "dolt_commit_failed",
+				Message: fmt.Sprintf("dolt commit after purge failed: %v", err),
+			})
 		}
 	}
 
@@ -575,7 +571,7 @@ func purgeOldMail(db *sql.DB, dbName string, mailDeleteAge time.Duration, dryRun
 			return totalDeleted, fmt.Errorf("sql commit: %w", err)
 		}
 		commitMsg := fmt.Sprintf("reaper: purge %d old mail from %s", totalDeleted, dbName)
-		if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
+		if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('--allow-empty', '-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
 			// Non-fatal.
 		}
 	}


### PR DESCRIPTION
## Problem

The reaper's purge phase (`purgeClosedWisps` and `purgeOldMail`) deletes rows with autocommit disabled, flushes via SQL `COMMIT`, then calls `DOLT_COMMIT`. When the deleted tables are `dolt_ignored` or when the SQL `COMMIT` already advances Dolt's working set, `DOLT_COMMIT` finds an empty working set and fails with "nothing to commit."

This generated **4 escalations over 6 weeks** (medium→high severity) despite the purge itself succeeding — no data loss, just noisy errors from the deacon dog.

## Fix

Add `--allow-empty` flag to both `DOLT_COMMIT` calls in `internal/reaper/reaper.go` (`purgeClosedWisps` line 515, `purgeOldMail` line 578). This makes the commit succeed regardless of working set state.

Also simplifies the wisps path by removing the now-unnecessary `isNothingToCommit` check.

## Testing

- Compiles clean (`go build ./internal/reaper/`)
- Existing tests pass (injection safety tests unaffected)
- The fix is minimal and safe — `--allow-empty` is a standard Dolt flag used elsewhere in the codebase

Fixes: hq-sts

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3785"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->