### PR TITLE
fix(daemon): checkpoint dog commits on wrong branch (top-level workspace instead of polecat)

### DIFF
--- a/internal/daemon/checkpoint_dog.go
+++ b/internal/daemon/checkpoint_dog.go
@@ -110,20 +110,20 @@ func (d *Daemon) checkpointRigPolecats(rigName string) (int, int) {
 			continue
 		}
 
-		// Polecat worktree layout: <polecatsDir>/<name>/<rigName>/ — the
-		// outer <name>/ dir is just a container holding the named worktree
-		// plus per-polecat scaffolding (.claude/, etc.). The inner directory
-		// is the actual git worktree. Earlier versions of this code passed
-		// just <polecatsDir>/<name>/ which has no .git — git operations would
-		// walk up the tree to the top-level workspace's .git and commit
-		// "WIP: checkpoint (auto)" on the WORKSPACE's branch (usually main),
-		// not the polecat's branch. (gt-checkpoint-workdir fix.)
-		workDir := filepath.Join(polecatsDir, polecatName, rigName)
-		if !isGitWorktree(workDir) {
-			// Skip silently — polecat may be mid-spawn, or layout differs
-			// (defensive against future layout changes). Don't fall back to
-			// the parent dir; the wrong-dir bug is exactly what this fixes.
-			continue
+		// Polecat layout: prefer <polecatsDir>/<name>/<rigName>/ (the new
+		// nested layout where the outer <name>/ dir is a container with
+		// per-polecat scaffolding and the inner dir is the actual git
+		// worktree). Fall back to <polecatsDir>/<name>/ for the legacy
+		// flat layout still supported by polecat.Manager. Both candidates
+		// must contain `.git` — never fall back to a parent dir, since
+		// the original bug here was exactly that: an empty <name>/
+		// container caused git to walk up to the top-level workspace's
+		// .git and commit "WIP: checkpoint (auto)" on the workspace's
+		// branch (usually main) instead of the polecat's branch.
+		// (gt-checkpoint-workdir fix.)
+		workDir := resolveCheckpointWorkDir(polecatsDir, polecatName, rigName)
+		if workDir == "" {
+			continue // Neither layout has a usable .git — skip silently.
 		}
 		if d.checkpointWorktree(workDir, rigName, polecatName) {
 			checkpointed++
@@ -197,6 +197,26 @@ func (d *Daemon) checkpointWorktree(workDir, rigName, polecatName string) bool {
 func isGitWorktree(dir string) bool {
 	_, err := os.Stat(filepath.Join(dir, ".git"))
 	return err == nil
+}
+
+// resolveCheckpointWorkDir picks the actual git-worktree directory for a
+// polecat, supporting both the new nested layout (polecats/<name>/<rigName>/)
+// and the legacy flat layout (polecats/<name>/) that polecat.Manager still
+// recognizes for backward compatibility. Returns "" if neither candidate is
+// a git worktree, in which case the caller MUST skip the polecat — never
+// fall back to a parent directory, since git would walk up to the top-level
+// workspace's .git and commit on the wrong branch (this is the bug this
+// helper exists to prevent).
+func resolveCheckpointWorkDir(polecatsDir, polecatName, rigName string) string {
+	nested := filepath.Join(polecatsDir, polecatName, rigName)
+	if isGitWorktree(nested) {
+		return nested
+	}
+	flat := filepath.Join(polecatsDir, polecatName)
+	if isGitWorktree(flat) {
+		return flat
+	}
+	return ""
 }
 
 // runGitCmd executes a git command in the given directory and returns stdout.

--- a/internal/daemon/checkpoint_dog.go
+++ b/internal/daemon/checkpoint_dog.go
@@ -3,6 +3,7 @@ package daemon
 import (
 	"bytes"
 	"fmt"
+	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
@@ -109,7 +110,21 @@ func (d *Daemon) checkpointRigPolecats(rigName string) (int, int) {
 			continue
 		}
 
-		workDir := filepath.Join(polecatsDir, polecatName)
+		// Polecat worktree layout: <polecatsDir>/<name>/<rigName>/ — the
+		// outer <name>/ dir is just a container holding the named worktree
+		// plus per-polecat scaffolding (.claude/, etc.). The inner directory
+		// is the actual git worktree. Earlier versions of this code passed
+		// just <polecatsDir>/<name>/ which has no .git — git operations would
+		// walk up the tree to the top-level workspace's .git and commit
+		// "WIP: checkpoint (auto)" on the WORKSPACE's branch (usually main),
+		// not the polecat's branch. (gt-checkpoint-workdir fix.)
+		workDir := filepath.Join(polecatsDir, polecatName, rigName)
+		if !isGitWorktree(workDir) {
+			// Skip silently — polecat may be mid-spawn, or layout differs
+			// (defensive against future layout changes). Don't fall back to
+			// the parent dir; the wrong-dir bug is exactly what this fixes.
+			continue
+		}
 		if d.checkpointWorktree(workDir, rigName, polecatName) {
 			checkpointed++
 		}
@@ -172,6 +187,16 @@ func (d *Daemon) checkpointWorktree(workDir, rigName, polecatName string) bool {
 
 	d.logger.Printf("checkpoint_dog: created WIP checkpoint in %s/%s", rigName, polecatName)
 	return true
+}
+
+// isGitWorktree reports whether the given directory is the root of a git
+// worktree (has its own `.git` file or directory). Used to guard checkpoint
+// commits against the "wrong-dir" failure mode where git operations in a
+// non-worktree directory walk up the filesystem tree and commit on the
+// parent workspace's branch.
+func isGitWorktree(dir string) bool {
+	_, err := os.Stat(filepath.Join(dir, ".git"))
+	return err == nil
 }
 
 // runGitCmd executes a git command in the given directory and returns stdout.

--- a/internal/daemon/checkpoint_dog_test.go
+++ b/internal/daemon/checkpoint_dog_test.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 )
@@ -97,5 +99,108 @@ func TestCheckpointDogEnabled(t *testing.T) {
 	config.Patrols.CheckpointDog.Enabled = false
 	if IsPatrolEnabled(config, "checkpoint_dog") {
 		t.Error("expected checkpoint_dog disabled when Enabled=false")
+	}
+}
+
+func TestResolveCheckpointWorkDir_NestedLayout(t *testing.T) {
+	// New polecat layout: polecats/<name>/<rigName>/.git is the worktree.
+	tmp := t.TempDir()
+	rig := "myrig"
+	polecat := "alice"
+	polecatsDir := filepath.Join(tmp, "polecats")
+	worktree := filepath.Join(polecatsDir, polecat, rig)
+	if err := os.MkdirAll(filepath.Join(worktree, ".git"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	got := resolveCheckpointWorkDir(polecatsDir, polecat, rig)
+	if got != worktree {
+		t.Errorf("got %q, want %q", got, worktree)
+	}
+}
+
+func TestResolveCheckpointWorkDir_LegacyFlatLayout(t *testing.T) {
+	// Legacy layout: polecats/<name>/.git directly. polecat.Manager still
+	// recognizes this; checkpoint_dog must too rather than silently skip.
+	tmp := t.TempDir()
+	rig := "myrig"
+	polecat := "bob"
+	polecatsDir := filepath.Join(tmp, "polecats")
+	worktree := filepath.Join(polecatsDir, polecat)
+	if err := os.MkdirAll(filepath.Join(worktree, ".git"), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	got := resolveCheckpointWorkDir(polecatsDir, polecat, rig)
+	if got != worktree {
+		t.Errorf("got %q, want %q (legacy flat layout)", got, worktree)
+	}
+}
+
+func TestResolveCheckpointWorkDir_NoGitNeitherLevel(t *testing.T) {
+	// Critical regression case: polecat container exists but has no .git
+	// at either level. Function MUST return "" so the caller skips, NOT
+	// fall back to a parent dir (which would have the workspace's .git
+	// and cause the wrong-branch checkpoint bug this code prevents).
+	tmp := t.TempDir()
+	rig := "myrig"
+	polecat := "carol"
+	polecatsDir := filepath.Join(tmp, "polecats")
+	if err := os.MkdirAll(filepath.Join(polecatsDir, polecat, rig), 0o755); err != nil {
+		t.Fatalf("setup: %v", err)
+	}
+	// Simulate top-level workspace .git that git would walk up to find.
+	// resolveCheckpointWorkDir must NOT return a path that lets git walk
+	// to this — it should return "" so the caller skips entirely.
+	if err := os.MkdirAll(filepath.Join(tmp, ".git"), 0o755); err != nil {
+		t.Fatalf("setup parent .git: %v", err)
+	}
+	got := resolveCheckpointWorkDir(polecatsDir, polecat, rig)
+	if got != "" {
+		t.Errorf("got %q, want empty (skip — no polecat-level .git)", got)
+	}
+}
+
+func TestResolveCheckpointWorkDir_PrefersNestedOverFlat(t *testing.T) {
+	// If both levels have .git (transitional state during a migration),
+	// prefer the nested (newer) layout.
+	tmp := t.TempDir()
+	rig := "myrig"
+	polecat := "dave"
+	polecatsDir := filepath.Join(tmp, "polecats")
+	flat := filepath.Join(polecatsDir, polecat)
+	nested := filepath.Join(flat, rig)
+	for _, d := range []string{flat, nested} {
+		if err := os.MkdirAll(filepath.Join(d, ".git"), 0o755); err != nil {
+			t.Fatalf("setup %s: %v", d, err)
+		}
+	}
+	got := resolveCheckpointWorkDir(polecatsDir, polecat, rig)
+	if got != nested {
+		t.Errorf("got %q, want nested %q", got, nested)
+	}
+}
+
+func TestIsGitWorktree(t *testing.T) {
+	tmp := t.TempDir()
+	if isGitWorktree(tmp) {
+		t.Error("empty dir should not be a worktree")
+	}
+	// .git as directory (full clone)
+	dirGit := filepath.Join(tmp, "fullclone")
+	if err := os.MkdirAll(filepath.Join(dirGit, ".git"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if !isGitWorktree(dirGit) {
+		t.Error(".git directory should count as worktree")
+	}
+	// .git as file (linked worktree — git uses a file pointing to commondir)
+	fileGit := filepath.Join(tmp, "linked")
+	if err := os.MkdirAll(fileGit, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(fileGit, ".git"), []byte("gitdir: /elsewhere\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if !isGitWorktree(fileGit) {
+		t.Error(".git file (linked worktree) should count as worktree")
 	}
 }


### PR DESCRIPTION
## Summary

`checkpoint_dog` was passing `polecats/<name>/` as workDir for git operations, but that's just a container directory. The actual git worktree is one level deeper at `polecats/<name>/<rigName>/`. Git would walk up the filesystem tree from `polecats/<name>/` (no `.git` there), find the top-level workspace's `.git`, and commit `WIP: checkpoint (auto)` on the **workspace's branch (typically main)** instead of the polecat's branch.

## Symptom

Top-level workspace's local `main` rapidly accumulates `WIP: checkpoint (auto)` commits (one per checkpoint cycle = every 10 min by default × every rig with an active polecat session). Cleaning them up brings them back within 10 minutes. The polecat's own branch never gets checkpointed.

In our dogfooding rig: 62 such commits accumulated on local `main` since last origin sync.

## Fix

- New `resolveCheckpointWorkDir()` helper: prefers the nested layout (`polecats/<name>/<rigName>/`) but falls back to the legacy flat layout (`polecats/<name>/.git`) that `polecat.Manager` still recognizes for backward compatibility.
- New `isGitWorktree()` guard checks for `.git` (file or directory). When neither candidate is a worktree, returns empty string and the caller skips — **never falls back to a parent dir**, since that's exactly the bug being fixed.
- 5 regression tests cover: nested layout, flat layout, no-`.git`-anywhere (must NOT walk up), nested-preferred-over-flat (transitional state), and `isGitWorktree` with both `.git`-as-directory and `.git`-as-file (linked worktree).

## Test plan

- [x] \`go test ./internal/daemon/\` passes (skips with no Docker per the existing pattern; CI should run them)
- [x] Locally: confirmed bug pre-fix (62 WIP commits on top-level main since last origin sync)
- [x] Locally: confirmed fix builds + ships (deployed via \`make build && cp ./gt ~/.local/bin/gt\`); next checkpoint cycle will exercise the new path

## Codex review

Reviewed by codex-rescue agent; one MAJOR finding (legacy flat layout silently skipped) addressed in the second commit, plus the requested regression tests added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3786"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->