### PR TITLE
fix: verify pushed commits before bead closure

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -53,6 +53,7 @@ Examples:
   gt done --target feat/my-branch      # Explicit MR target branch
   gt done --pre-verified --target feat/contract-review  # Pre-verified with explicit target
   gt done --issue gt-abc               # Explicit issue ID
+  gt done --skip-verify                # Audit-only escape hatch for non-code closes
   gt done --status ESCALATED           # Signal blocker, skip MR
   gt done --status DEFERRED            # Pause work, skip MR`,
 	RunE:         runDone,
@@ -67,6 +68,7 @@ var (
 	doneResume        bool
 	donePreVerified   bool
 	doneTarget        string
+	doneSkipVerify    bool
 )
 
 // Valid exit types for gt done
@@ -84,6 +86,7 @@ func init() {
 	doneCmd.Flags().BoolVar(&doneResume, "resume", false, "Resume from last checkpoint (auto-detected, for Witness recovery)")
 	doneCmd.Flags().BoolVar(&donePreVerified, "pre-verified", false, "Mark MR as pre-verified (polecat ran gates after rebasing onto target)")
 	doneCmd.Flags().StringVar(&doneTarget, "target", "", "Explicit MR target branch (overrides formula_vars and auto-detection)")
+	doneCmd.Flags().BoolVar(&doneSkipVerify, "skip-verify", false, "Skip verified-push checks for audit/test-only completion (recorded on bead)")
 
 	rootCmd.AddCommand(doneCmd)
 }
@@ -529,6 +532,21 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 				if !skipClose {
 					closeReason := "Completed with no code changes (already fixed or pushed directly to main)"
+					noMRCommitSHA, _ := g.Rev("HEAD")
+					if doneSkipVerify {
+						noteVerifiedPushSkipped(cwd, issueID, defaultBranch, noMRCommitSHA, "--skip-verify on no-MR close")
+						if noMRCommitSHA != "" {
+							closeReason = fmt.Sprintf("%s\nskip_verify: true\ntarget_branch: %s\ncommit_sha: %s", closeReason, defaultBranch, noMRCommitSHA)
+						}
+					} else if !isNoMergeTask {
+						if verifyErr := g.VerifyPushedCommit("origin", defaultBranch, noMRCommitSHA); verifyErr != nil {
+							noteVerifiedPushFailure(cwd, issueID, defaultBranch, noMRCommitSHA, verifyErr)
+							return fmt.Errorf("cannot close no-MR code bead: %w", verifyErr)
+						}
+						if noMRCommitSHA != "" {
+							closeReason = fmt.Sprintf("%s\ntarget_branch: %s\ncommit_sha: %s", closeReason, defaultBranch, noMRCommitSHA)
+						}
+					}
 					// G15 fix: Force-close bypasses molecule dependency checks.
 					// The polecat is about to be nuked — open wisps should not block closure.
 					// Retry with backoff handles transient dolt lock contention (A2).
@@ -621,6 +639,17 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				style.PrintWarning("%s", errMsg)
 				goto notifyWitness
 			}
+			directCommitSHA, _ := g.Rev("HEAD")
+			if doneSkipVerify {
+				noteVerifiedPushSkipped(cwd, issueID, defaultBranch, directCommitSHA, "--skip-verify on direct merge")
+			} else if verifyErr := g.VerifyPushedCommit("origin", defaultBranch, directCommitSHA); verifyErr != nil {
+				pushFailed = true
+				errMsg := verifyErr.Error()
+				doneErrors = append(doneErrors, errMsg)
+				noteVerifiedPushFailure(cwd, issueID, defaultBranch, directCommitSHA, verifyErr)
+				style.PrintWarning("%s\nDirect merge pushed but remote verification failed. Source bead will remain in progress.", errMsg)
+				goto notifyWitness
+			}
 			fmt.Printf("%s Branch pushed directly to %s\n", style.Bold.Render("✓"), defaultBranch)
 
 			// Close the base issue — no MR/refinery will close it
@@ -652,6 +681,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// Pre-declare push variables for checkpoint goto (gt-aufru)
 		var refspec string
 		var pushErr error
+		var pushedCommitSHA string
 
 		// Resume: skip push if already completed in a previous run (gt-aufru).
 		// Validate checkpoint branch matches current branch (ge-sbo: stale checkpoint
@@ -683,6 +713,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// bypassing the MR/refinery flow (G20 root cause).
 		fmt.Printf("Pushing branch to remote...\n")
 		refspec = branch + ":" + branch
+		pushedCommitSHA, _ = g.Rev("HEAD")
 		pushErr = g.Push("origin", refspec, false)
 		if pushErr != nil {
 			// Primary push failed — try fallback from the bare repo (GH #1348).
@@ -724,31 +755,21 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			goto notifyWitness
 		}
 
-		// Verify the branch actually exists on the push target (GH #1348).
-		// Push can return exit 0 without actually pushing (e.g., stale refs,
-		// worktree/bare-repo state mismatch). Verify before creating MR bead.
-		// Use PushRemoteBranchExists: with a split fetch/push URL (common for
-		// polecats), ls-remote resolves the fetch URL (GitHub) not the push
-		// target (local bare repo).
-		if exists, verifyErr := g.PushRemoteBranchExists("origin", branch); verifyErr != nil {
-			style.PrintWarning("could not verify push: %v (proceeding optimistically)", verifyErr)
-		} else if !exists {
-			// Push "succeeded" but branch not on push target — try bare repo
-			// verification (worktree git may not see the pushed ref).
-			// The branch is a local ref in the bare repo, not a remote ref.
-			rigPath := filepath.Join(townRoot, rigName)
-			bareRepoPath := filepath.Join(rigPath, ".repo.git")
-			if _, statErr := os.Stat(bareRepoPath); statErr == nil {
-				bareGit := git.NewGitWithDir(bareRepoPath, "")
-				exists, verifyErr = bareGit.BranchExists(branch)
-			}
-			if verifyErr != nil || !exists {
-				pushFailed = true
-				errMsg := fmt.Sprintf("push appeared to succeed but branch '%s' not found on push target", branch)
-				doneErrors = append(doneErrors, errMsg)
-				style.PrintWarning("%s\nThis may indicate a stale git context. Witness will be notified.", errMsg)
-				goto notifyWitness
-			}
+		// Verify the pushed branch tip is the exact local commit before creating
+		// any MR bead. Branch-exists checks are insufficient: a stale remote
+		// branch can exist while the new commit never reached origin.
+		if pushedCommitSHA == "" {
+			pushedCommitSHA, _ = g.Rev("HEAD")
+		}
+		if doneSkipVerify {
+			noteVerifiedPushSkipped(cwd, issueID, branch, pushedCommitSHA, "--skip-verify on branch push")
+		} else if verifyErr := verifyPushedCommitWithBareFallback(g, townRoot, rigName, branch, pushedCommitSHA); verifyErr != nil {
+			pushFailed = true
+			errMsg := verifyErr.Error()
+			doneErrors = append(doneErrors, errMsg)
+			noteVerifiedPushFailure(cwd, issueID, branch, pushedCommitSHA, verifyErr)
+			style.PrintWarning("%s\nCommits exist locally but verified push failed. Witness will be notified.", errMsg)
+			goto notifyWitness
 		}
 		fmt.Printf("%s Branch pushed to origin\n", style.Bold.Render("✓"))
 
@@ -893,6 +914,17 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				// Direct push failed — fall through to normal MR creation
 				style.PrintWarning("late direct push to %s failed: %v — falling through to MR", defaultBranch, directPushErr)
 			} else {
+				lateDirectCommitSHA, _ := g.Rev("HEAD")
+				if doneSkipVerify {
+					noteVerifiedPushSkipped(cwd, issueID, defaultBranch, lateDirectCommitSHA, "--skip-verify on late direct merge")
+				} else if verifyErr := g.VerifyPushedCommit("origin", defaultBranch, lateDirectCommitSHA); verifyErr != nil {
+					pushFailed = true
+					errMsg := verifyErr.Error()
+					doneErrors = append(doneErrors, errMsg)
+					noteVerifiedPushFailure(cwd, issueID, defaultBranch, lateDirectCommitSHA, verifyErr)
+					style.PrintWarning("%s\nLate direct merge pushed but remote verification failed. Source bead will remain in progress.", errMsg)
+					goto notifyWitness
+				}
 				fmt.Printf("%s Branch pushed directly to %s\n", style.Bold.Render("✓"), defaultBranch)
 
 				// Close the issue directly — refinery won't process it.
@@ -1030,6 +1062,9 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				branch, target, issueID, rigName)
 			if commitSHA != "" {
 				description += fmt.Sprintf("\ncommit_sha: %s", commitSHA)
+			}
+			if doneSkipVerify {
+				description += "\nskip_verify: true"
 			}
 			if worker != "" {
 				description += fmt.Sprintf("\nworker: %s", worker)
@@ -1339,6 +1374,43 @@ func pushSubmoduleChanges(g *git.Git, defaultBranch string) {
 			fmt.Printf("%s Submodule %s pushed\n", style.Bold.Render("✓"), sc.Path)
 		}
 	}
+}
+
+func noteVerifiedPushFailure(cwd, issueID, branch, commit string, verifyErr error) {
+	if issueID == "" || cwd == "" {
+		return
+	}
+	bd := beads.New(cwd)
+	inProgress := "in_progress"
+	_ = bd.Update(issueID, beads.UpdateOptions{Status: &inProgress})
+	msg := fmt.Sprintf("verified_push_failed: commit %s not verified on origin/%s: %v", commit, branch, verifyErr)
+	_, _ = bd.Run("comments", "add", issueID, msg)
+}
+
+func noteVerifiedPushSkipped(cwd, issueID, branch, commit, reason string) {
+	if issueID == "" || cwd == "" {
+		return
+	}
+	msg := fmt.Sprintf("verified_push_skipped: commit %s branch origin/%s reason=%s", commit, branch, reason)
+	_, _ = beads.New(cwd).Run("comments", "add", issueID, msg)
+}
+
+func verifyPushedCommitWithBareFallback(g *git.Git, townRoot, rigName, branch, commit string) error {
+	verifyErr := g.VerifyPushedCommit("origin", branch, commit)
+	if verifyErr == nil {
+		return nil
+	}
+
+	bareRepoPath := filepath.Join(townRoot, rigName, ".repo.git")
+	if _, statErr := os.Stat(bareRepoPath); statErr != nil {
+		return verifyErr
+	}
+	bareGit := git.NewGitWithDir(bareRepoPath, "")
+	tip, tipErr := bareGit.Rev("refs/heads/" + branch)
+	if tipErr == nil && strings.TrimSpace(tip) == strings.TrimSpace(commit) {
+		return nil
+	}
+	return verifyErr
 }
 
 // setDoneIntentLabel writes a done-intent:<type>:<unix-ts> label on the agent bead

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1370,6 +1370,16 @@ func (g *Git) RemoteBranchExists(remote, branch string) (bool, error) {
 	return out != "", nil
 }
 
+// RemoteBranchTip returns the SHA at refs/heads/<branch> on the remote.
+// An empty SHA with nil error means the branch is missing.
+func (g *Git) RemoteBranchTip(remote, branch string) (string, error) {
+	out, err := g.run("ls-remote", "--heads", remote, branch)
+	if err != nil {
+		return "", err
+	}
+	return parseLSRemoteTip(out, branch), nil
+}
+
 // PushRemoteBranchExists checks if a branch exists on the push target of a remote.
 // With a fork-based or local-bare-repo workflow (pushurl configured), pushes go to
 // the push URL but ls-remote resolves the fetch URL. This method queries the push
@@ -1386,6 +1396,66 @@ func (g *Git) PushRemoteBranchExists(remote, branch string) (bool, error) {
 		return false, err
 	}
 	return out != "", nil
+}
+
+// PushRemoteBranchTip returns the SHA at refs/heads/<branch> on the push target.
+// This mirrors PushRemoteBranchExists: when remote.<name>.pushurl differs from
+// the fetch URL, verification must query the push URL because that is where the
+// preceding git push wrote.
+func (g *Git) PushRemoteBranchTip(remote, branch string) (string, error) {
+	fetchURL, fetchErr := g.RemoteURL(remote)
+	pushURL, pushErr := g.GetPushURL(remote)
+	if fetchErr != nil || pushErr != nil || pushURL == fetchURL {
+		return g.RemoteBranchTip(remote, branch)
+	}
+	return g.RemoteBranchTip(pushURL, branch)
+}
+
+// VerifyPushedCommit verifies that the push target branch tip is exactly commit.
+// gt/refinery callers invoke this immediately after a push, before closing beads
+// or creating downstream merge artifacts. Exact-tip verification catches the
+// dangerous case where git push exits 0 but leaves the remote branch stale.
+func (g *Git) VerifyPushedCommit(remote, branch, commit string) error {
+	commit = strings.TrimSpace(commit)
+	if commit == "" {
+		return fmt.Errorf("verified_push_failed: empty commit for %s/%s", remote, branch)
+	}
+	tip, err := g.PushRemoteBranchTip(remote, branch)
+	if err != nil {
+		return fmt.Errorf("verified_push_failed: unable to read %s/%s: %w", remote, branch, err)
+	}
+	if tip == "" {
+		return fmt.Errorf("verified_push_failed: branch %s/%s missing after push (expected %s)", remote, branch, shortSHA(commit))
+	}
+	if tip != commit {
+		return fmt.Errorf("verified_push_failed: commit %s not on %s/%s (remote tip %s)", shortSHA(commit), remote, branch, shortSHA(tip))
+	}
+	return nil
+}
+
+func parseLSRemoteTip(out, branch string) string {
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		parts := strings.Fields(line)
+		if len(parts) < 2 {
+			continue
+		}
+		if parts[1] == "refs/heads/"+branch {
+			return parts[0]
+		}
+	}
+	return ""
+}
+
+func shortSHA(sha string) string {
+	sha = strings.TrimSpace(sha)
+	if len(sha) > 8 {
+		return sha[:8]
+	}
+	return sha
 }
 
 // RemoteTrackingBranchExists checks if a remote-tracking branch ref exists locally

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -2051,6 +2051,96 @@ func TestPushRemoteBranchExists_NoPushURL(t *testing.T) {
 	}
 }
 
+func TestVerifyPushedCommit(t *testing.T) {
+	localDir, _, _ := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+
+	if err := g.CreateBranch("polecat/verified-push"); err != nil {
+		t.Fatalf("CreateBranch: %v", err)
+	}
+	if err := g.Checkout("polecat/verified-push"); err != nil {
+		t.Fatalf("Checkout: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "verified.txt"), []byte("v1\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := g.Add("verified.txt"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := g.Commit("verified push v1"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	v1, err := g.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev v1: %v", err)
+	}
+	if err := g.Push("origin", "polecat/verified-push", false); err != nil {
+		t.Fatalf("Push v1: %v", err)
+	}
+	if err := g.VerifyPushedCommit("origin", "polecat/verified-push", v1); err != nil {
+		t.Fatalf("VerifyPushedCommit v1: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(localDir, "verified.txt"), []byte("v2\n"), 0644); err != nil {
+		t.Fatalf("write v2: %v", err)
+	}
+	if err := g.Add("verified.txt"); err != nil {
+		t.Fatalf("Add v2: %v", err)
+	}
+	if err := g.Commit("verified push v2"); err != nil {
+		t.Fatalf("Commit v2: %v", err)
+	}
+	v2, err := g.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev v2: %v", err)
+	}
+	if err := g.VerifyPushedCommit("origin", "polecat/verified-push", v2); err == nil {
+		t.Fatal("VerifyPushedCommit should fail when remote branch is stale")
+	}
+	if err := g.VerifyPushedCommit("origin", "polecat/missing", v2); err == nil {
+		t.Fatal("VerifyPushedCommit should fail when remote branch is missing")
+	}
+}
+
+func TestVerifyPushedCommitSplitURL(t *testing.T) {
+	localDir, _, _, _ := initTestRepoWithSplitRemote(t)
+	g := NewGit(localDir)
+
+	if err := g.CreateBranch("polecat/verified-split"); err != nil {
+		t.Fatalf("CreateBranch: %v", err)
+	}
+	if err := g.Checkout("polecat/verified-split"); err != nil {
+		t.Fatalf("Checkout: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "split.txt"), []byte("split\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := g.Add("split.txt"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := g.Commit("verified split push"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	sha, err := g.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev: %v", err)
+	}
+	if err := g.Push("origin", "polecat/verified-split", false); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+
+	fetchTip, err := g.RemoteBranchTip("origin", "polecat/verified-split")
+	if err != nil {
+		t.Fatalf("RemoteBranchTip: %v", err)
+	}
+	if fetchTip != "" {
+		t.Fatalf("fetch remote should not have split push branch, got %s", fetchTip)
+	}
+	if err := g.VerifyPushedCommit("origin", "polecat/verified-split", sha); err != nil {
+		t.Fatalf("VerifyPushedCommit should query push URL: %v", err)
+	}
+}
+
 // TestBranchPushedToRemote_SplitURL verifies that BranchPushedToRemote correctly
 // reports a branch as pushed when it exists on the push target (fork), even though
 // it's absent from the fetch URL (upstream). This is the GH#3224 fix.

--- a/internal/refinery/batch.go
+++ b/internal/refinery/batch.go
@@ -395,6 +395,13 @@ func (e *Engineer) fastForwardBatch(ctx context.Context, stacked []*MRInfo, targ
 		result.Error = fmt.Errorf("push to origin: %w", pushErr)
 		return result
 	}
+	if verifyErr := e.git.VerifyPushedCommit("origin", target, tipSHA); verifyErr != nil {
+		if resetErr := e.git.ResetHard("origin/" + target); resetErr != nil {
+			_, _ = fmt.Fprintf(e.output, "[Batch] Warning: failed to reset %s after verified-push failure: %v\n", target, resetErr)
+		}
+		result.Error = verifyErr
+		return result
+	}
 
 	ids := make([]string, len(stacked))
 	for i, mr := range stacked {

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -739,6 +739,15 @@ func (e *Engineer) doMerge(ctx context.Context, branch, target, sourceIssue stri
 				Error:   fmt.Sprintf("failed to push to origin: %v", err),
 			}
 		}
+		if err := e.git.VerifyPushedCommit("origin", target, mergeCommit); err != nil {
+			if resetErr := e.git.ResetHard("origin/" + target); resetErr != nil {
+				_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to reset %s after verified-push failure: %v\n", target, resetErr)
+			}
+			return ProcessResult{
+				Success: false,
+				Error:   err.Error(),
+			}
+		}
 	} else {
 		_, _ = fmt.Fprintf(e.output, "[Engineer] Auto-push disabled, skipping push to origin/%s\n", target)
 	}
@@ -828,6 +837,12 @@ func (e *Engineer) doMergePR(ctx context.Context, branch, target string) Process
 	if mergeCommit == "" {
 		if sha, err := e.git.Rev("HEAD"); err == nil {
 			mergeCommit = sha
+		}
+	}
+	if err := e.git.VerifyPushedCommit("origin", target, mergeCommit); err != nil {
+		return ProcessResult{
+			Success: false,
+			Error:   err.Error(),
 		}
 	}
 
@@ -1208,6 +1223,9 @@ func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
 	// normal close. This matches how gt done handles closures.
 	if mr.SourceIssue != "" {
 		closeReason := fmt.Sprintf("Merged in %s", mr.ID)
+		if result.MergeCommit != "" {
+			closeReason = fmt.Sprintf("%s\ntarget_branch: %s\ncommit_sha: %s", closeReason, mr.Target, result.MergeCommit)
+		}
 		if err := e.beads.ForceCloseWithReason(closeReason, mr.SourceIssue); err != nil {
 			// Check if already closed (by polecat's gt done) — that's fine
 			if issue, showErr := e.beads.Show(mr.SourceIssue); showErr == nil && beads.IssueStatus(issue.Status).IsTerminal() {

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -467,6 +467,7 @@ func (m *Manager) issueToMR(issue *beads.Issue) *MergeRequest {
 		Worker:       fields.Worker,
 		IssueID:      fields.SourceIssue,
 		TargetBranch: target,
+		MergeCommit:  fields.MergeCommit,
 		Status:       MROpen,
 		CreatedAt:    parseTime(issue.CreatedAt),
 	}
@@ -635,6 +636,9 @@ func (m *Manager) PostMerge(idOrBranch string) (*PostMergeResult, error) {
 	// matching how gt done handles closures for the no-MR path.
 	if mr.IssueID != "" {
 		closeReason := fmt.Sprintf("Merged in %s", mr.ID)
+		if mr.MergeCommit != "" {
+			closeReason = fmt.Sprintf("%s\ntarget_branch: %s\ncommit_sha: %s", closeReason, mr.TargetBranch, mr.MergeCommit)
+		}
 		if err := b.ForceCloseWithReason(closeReason, mr.IssueID); err != nil {
 			// Check if already closed (by polecat's gt done) — that's fine
 			if issue, showErr := b.Show(mr.IssueID); showErr == nil && beads.IssueStatus(issue.Status).IsTerminal() {

--- a/internal/refinery/types.go
+++ b/internal/refinery/types.go
@@ -30,6 +30,9 @@ type MergeRequest struct {
 	// TargetBranch is where this should merge (usually integration or main).
 	TargetBranch string `json:"target_branch"`
 
+	// MergeCommit is the SHA that was pushed to the target branch after merge.
+	MergeCommit string `json:"merge_commit,omitempty"`
+
 	// CreatedAt is when the MR was queued.
 	CreatedAt time.Time `json:"created_at"`
 


### PR DESCRIPTION
## Summary

- adds exact remote-tip verification for pushed commits using the push target URL, including split fetch/push remotes
- blocks gt done MR creation, direct source-bead closure, and refinery source-bead closure when the pushed commit is not visible on origin/<target>
- records target_branch and commit_sha in source close reasons and adds --skip-verify audit comments for explicit non-code escapes
- adds regression coverage for success, missing branch, stale remote branch, and split push URL verification

## Verification

- git diff --check
- Not run: gofmt/go test; this host does not have go or gofmt installed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3787"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->