### PR TITLE
fix: agent-name normalization (#3699) and hook arg parsing (#3701)

### DIFF
--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -627,7 +627,7 @@ func normalizeHookShowTarget(target string) string {
 // environments where the global session registry is not initialized.
 func sessionNameToCanonicalAddress(sessionName, targetHint string) (string, bool) {
 	if identity, err := session.ParseSessionName(sessionName); err == nil {
-		return identity.Address(), true
+		return canonicalAssigneeAddress(identity), true
 	}
 
 	registry := session.NewPrefixRegistry()
@@ -644,7 +644,7 @@ func sessionNameToCanonicalAddress(sessionName, targetHint string) (string, bool
 	if err != nil {
 		return "", false
 	}
-	return identity.Address(), true
+	return canonicalAssigneeAddress(identity), true
 }
 
 // findTownRoot finds the Gas Town root directory.

--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -210,6 +210,15 @@ func runHookClear(cmd *cobra.Command, args []string) error {
 func runHook(_ *cobra.Command, args []string) error {
 	beadID := args[0]
 
+	// Reject non-bead-shaped first args before passing to bd show, which would
+	// emit a confusing "bead 'set' not found" error. cobra has already failed to
+	// match against a registered subcommand, so anything reaching here that
+	// doesn't look like a bead ID is almost certainly a typo'd subcommand.
+	// See GH#3701.
+	if !isBeadID(beadID) {
+		return fmt.Errorf("%q is not a bead ID. See 'gt hook --help' for available subcommands and usage", beadID)
+	}
+
 	// Parse optional target agent
 	var targetAgent string
 	if len(args) > 1 {

--- a/internal/cmd/hook_test.go
+++ b/internal/cmd/hook_test.go
@@ -96,6 +96,32 @@ func TestHookPolecatEnvCheck(t *testing.T) {
 	}
 }
 
+// TestHookRejectsNonBeadArg pins down GH#3701: when cobra fails to match a
+// subcommand and falls through to the bead-id positional, args that don't
+// look like bead IDs should produce a clear error pointing at --help rather
+// than the misleading "bead 'set' not found" emitted by bd show.
+func TestHookRejectsNonBeadArg(t *testing.T) {
+	// Ensure we don't trip the polecat guard.
+	t.Setenv("GT_ROLE", "")
+	t.Setenv("GT_POLECAT", "")
+
+	tests := []string{"set", "list", "delete", "nonexistentword12345"}
+	for _, arg := range tests {
+		t.Run(arg, func(t *testing.T) {
+			err := runHook(nil, []string{arg})
+			if err == nil {
+				t.Fatalf("runHook(%q) returned nil, want error", arg)
+			}
+			if !strings.Contains(err.Error(), "is not a bead ID") {
+				t.Errorf("runHook(%q) error = %q, want substring %q", arg, err.Error(), "is not a bead ID")
+			}
+			if !strings.Contains(err.Error(), "--help") {
+				t.Errorf("runHook(%q) error = %q, want it to point at --help", arg, err.Error())
+			}
+		})
+	}
+}
+
 func TestNormalizeHookShowTarget(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/cmd/polecat_identity_test.go
+++ b/internal/cmd/polecat_identity_test.go
@@ -163,6 +163,27 @@ func TestSessionToAgentID_Fallback(t *testing.T) {
 	}
 }
 
+// TestSessionToAgentID_TownLevel pins down GH#3699: town-level agents (mayor,
+// deacon) must produce a trailing-slash address so writes from gt sling match
+// the form queried by gt hook / runMoleculeStatus / buildAgentIdentity.
+func TestSessionToAgentID_TownLevel(t *testing.T) {
+	tests := []struct {
+		session string
+		want    string
+	}{
+		{"hq-mayor", "mayor/"},
+		{"hq-deacon", "deacon/"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.session, func(t *testing.T) {
+			got := sessionToAgentID(tt.session)
+			if got != tt.want {
+				t.Errorf("sessionToAgentID(%q) = %q, want %q", tt.session, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestFormatCountStyled(t *testing.T) {
 	// Test that zero returns a dim "0"
 	got := formatCountStyled(0, style.Success)

--- a/internal/cmd/sling_target.go
+++ b/internal/cmd/sling_target.go
@@ -51,7 +51,23 @@ func sessionToAgentID(sessionName string) string {
 		// Fallback for unparseable sessions
 		return sessionName
 	}
-	return identity.Address()
+	return canonicalAssigneeAddress(identity)
+}
+
+// canonicalAssigneeAddress returns the address used for bead assignees and
+// hook-status queries. This matches the form emitted by resolveSelfTarget and
+// buildAgentIdentity: town-level agents (mayor, deacon) get a trailing slash.
+// session.AgentIdentity.Address() returns the bare name for those roles, which
+// causes the read/write mismatch in GH#3699.
+func canonicalAssigneeAddress(identity *session.AgentIdentity) string {
+	addr := identity.Address()
+	switch identity.Role {
+	case session.RoleMayor, session.RoleDeacon:
+		if !strings.HasSuffix(addr, "/") {
+			return addr + "/"
+		}
+	}
+	return addr
 }
 
 // resolveSelfTarget determines agent identity, pane, and hook root for slinging to self.


### PR DESCRIPTION
## Summary

Two related papercuts in the agent-name / arg-handling layer.

### #3699 — gt sling assigns bare town-level names; gt hook queries with slash

`gt sling <bead> mayor` wrote `assignee=\"mayor\"` (bare, via `Address()`), but
`gt hook` / `runMoleculeStatus` / `buildAgentIdentity` all query with
`\"mayor/\"` (trailing slash). Result: the bead enters \`HOOKED\` status but the
mayor (or deacon) never picks it up. Self-target (`resolveSelfTarget`) and the
propulsion check at `sling.go:924` already use the slash form, so this only
affected the explicit-target write path.

**Fix:** route `sessionToAgentID` and `sessionNameToCanonicalAddress` through a
new `canonicalAssigneeAddress` helper that adds the trailing slash for
`RoleMayor` / `RoleDeacon`. `Address()` is left alone because `GTRole()` and
other callers depend on the bare form (`GT_ROLE=mayor`, not `mayor/`).

**Before:**
\`\`\`
$ gt sling i4-xxx mayor --dry-run
Would run: bd update i4-xxx --status=hooked --assignee=mayor
\`\`\`

**After:**
\`\`\`
$ gt sling i4-xxx mayor --dry-run
Would run: bd update i4-xxx --status=hooked --assignee=mayor/
\`\`\`

### #3701 — gt hook \"set\" → \"bead 'set' not found\"

When cobra fails to match a subcommand and falls through to the bead-id
positional, args that don't look like bead IDs were passed to \`bd show\`,
which emitted the misleading \`bead 'set' not found (bd show failed)\`. Reuse
the existing \`isBeadID\` helper to validate the first arg before calling
\`bd show\`. Bead-shaped args that don't exist still get the original error
(unchanged).

**Before:**
\`\`\`
$ gt hook set
Error: bead 'set' not found (bd show failed)
\`\`\`

**After:**
\`\`\`
$ gt hook set
Error: \"set\" is not a bead ID. See 'gt hook --help' for available subcommands and usage
\`\`\`

## Unified theme

Both bugs come from the same surface area: how Gas Town disambiguates between
canonical agent names, bead IDs, and free-form positional arguments. #3699 is
two functions producing different canonical forms for the same agent; #3701
is a positional that gets passed through to \`bd\` without a sanity check.

## Test plan

- [x] Repros from each issue verified to fail on \`v1.0.1-4-g91350080\`
- [x] Both repros pass against the patched build
- [x] New unit tests added:
  - \`TestSessionToAgentID_TownLevel\` — pins down \`hq-mayor\` → \`mayor/\`, \`hq-deacon\` → \`deacon/\`
  - \`TestHookRejectsNonBeadArg\` — pins down clear-error path for \`set\`, \`list\`, \`delete\`, etc.
- [x] \`go test ./internal/cmd/...\` and \`go test ./internal/session/...\` green
- [x] Existing \`TestSessionToAgentID\`, \`TestSessionToAgentID_Fallback\`, \`TestHookPolecatEnvCheck\`, \`TestNormalizeHookShowTarget\` unchanged

## Notes for review

- I did not change \`AgentIdentity.Address()\` because \`GTRole()\` (in
  \`internal/session/identity.go:280\`) returns it directly and changing it
  would alter the \`GT_ROLE\` env var format for mayor/deacon. The new helper
  lives in the cmd package, where the \"canonical assignee form\" contract
  already exists (compare \`resolveSelfTarget\` and \`buildAgentIdentity\`).
- This consolidates *three* places that previously emitted \`mayor/\` /
  \`deacon/\` independently. Worth a future pass to centralize them on the
  helper, but I kept the diff narrow.

Closes #3699
Closes #3701

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3788"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->