### PR TITLE
Fail fast when Dolt is unavailable during install

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,8 +124,8 @@ Federated work coordination network linking Gas Towns through DoltHub. Rigs post
 
 - **Go 1.25+** - [go.dev/dl](https://go.dev/dl/)
 - **Git 2.25+** - for worktree support
-- **Dolt 1.82.4+** - [github.com/dolthub/dolt](https://github.com/dolthub/dolt)
-- **beads (bd) 0.55.4+** - [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
+- **Dolt 1.82.4+** - `brew install dolt` on macOS, or see [github.com/dolthub/dolt](https://github.com/dolthub/dolt)
+- **beads (bd) 0.55.4+** - installed by `brew install gastown`, or see [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
 - **sqlite3** - for convoy database queries (usually pre-installed on macOS/Linux)
 - **tmux 3.0+** - recommended for full experience
 - **Claude Code CLI** (default runtime) - [claude.ai/code](https://claude.ai/code)
@@ -141,7 +141,8 @@ $ npm install -g @gastown/gt                              # npm
 $ go install github.com/steveyegge/gastown/cmd/gt@latest  # From source (Linux only)
 
 # macOS: go install produces unsigned binaries that macOS will SIGKILL.
-# Use brew install (above) or clone and build with make:
+# Use brew install (above) or install Dolt and clone/build with make:
+$ brew install dolt
 $ git clone https://github.com/steveyegge/gastown.git && cd gastown
 $ make build && mv gt $HOME/go/bin/
 

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -10,8 +10,8 @@ Complete setup guide for Gas Town multi-agent orchestrator.
 |------|---------|-------|---------|
 | **Go** | 1.24+ | `go version` | See [golang.org](https://go.dev/doc/install) |
 | **Git** | 2.20+ | `git --version` | See below |
-| **Dolt** | >= 1.82.4 | `dolt version` | See [dolthub/dolt](https://github.com/dolthub/dolt?tab=readme-ov-file#installation) |
-| **Beads** | >= 0.55.4 | `bd version` | `go install github.com/steveyegge/beads/cmd/bd@latest` |
+| **Dolt** | >= 1.82.4 | `dolt version` | macOS: `brew install dolt`; other platforms: see [dolthub/dolt](https://github.com/dolthub/dolt?tab=readme-ov-file#installation) |
+| **Beads** | >= 0.55.4 | `bd version` | Installed by `brew install gastown`, or from source with `go install github.com/steveyegge/beads/cmd/bd@latest` |
 
 ### Optional (for Full Stack Mode)
 
@@ -32,8 +32,7 @@ Complete setup guide for Gas Town multi-agent orchestrator.
 /bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/Homebrew/install/HEAD/install.sh)"
 
 # Required
-brew install go git
-# Install Dolt: see https://github.com/dolthub/dolt?tab=readme-ov-file#installation
+brew install go git dolt
 
 # Optional (for full stack mode)
 brew install tmux
@@ -90,17 +89,24 @@ brew install gastown
 # Verify installation
 gt version
 bd version
+dolt version
 ```
 
 Homebrew installs the runtime dependencies declared by the core formula. The
 `gastownhall/gastown` tap is reserved for emergency updates. If you build from
-source instead, install `gt` and `bd` with Go and ensure `$GOPATH/bin` (usually
-`~/go/bin`) is in your PATH:
+source instead, install `dolt` first, install `bd` with Go, and ensure
+`$GOPATH/bin` (usually `~/go/bin`) is in your PATH. On macOS, do not install
+`gt` with `go install`: unsigned binaries may be killed by the OS. Clone the
+repository and use `make` instead.
 
 ```bash
-go install github.com/steveyegge/gastown/cmd/gt@latest
+brew install dolt
 go install github.com/steveyegge/beads/cmd/bd@latest
 export PATH="$PATH:$HOME/go/bin"
+git clone https://github.com/steveyegge/gastown.git
+cd gastown
+make build
+mv gt "$HOME/go/bin/"
 ```
 
 ### Step 2: Create Your Workspace

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -1,20 +1,22 @@
 package cmd
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	goruntime "runtime"
 	"strconv"
 	"strings"
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/spf13/cobra"
-	"github.com/steveyegge/gastown/internal/cli"
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/cli"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/deps"
@@ -146,41 +148,34 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		if err := deps.EnsureBeads(true); err != nil {
 			return fmt.Errorf("beads dependency check failed: %w", err)
 		}
-	}
+		if err := ensureInstallDoltReady(); err != nil {
+			return err
+		}
 
-	// Preflight: ensure dolt identity before any workspace mutations.
-	// This prevents a partial install that can't be retried without --force.
-	if !installNoBeads {
-		if _, err := exec.LookPath("dolt"); err == nil {
-			if err := doltserver.EnsureDoltIdentity(); err != nil {
-				return fmt.Errorf("dolt identity setup failed (required for beads): %w\n\nTo fix, run:\n  dolt config --global --add user.name \"Your Name\"\n  dolt config --global --add user.email \"you@example.com\"", err)
-			}
+		// Preflight: ensure dolt identity before any workspace mutations.
+		// This prevents a partial install that can't be retried without --force.
+		if err := doltserver.EnsureDoltIdentity(); err != nil {
+			return fmt.Errorf("dolt identity setup failed (required for beads): %w\n\nTo fix, run:\n  dolt config --global --add user.name \"Your Name\"\n  dolt config --global --add user.email \"you@example.com\"", err)
+		}
 
-			// Preflight: check Dolt port availability before creating any files.
-			// A port conflict would leave a partial install that needs --force to retry.
-			port := doltserver.DefaultPort
-			if installDoltPort != 0 {
-				port = installDoltPort
-				os.Setenv("GT_DOLT_PORT", strconv.Itoa(port))
-			} else if p := os.Getenv("GT_DOLT_PORT"); p != "" {
-				if envPort, err := strconv.Atoi(p); err == nil {
-					port = envPort
-				}
+		// Preflight: check Dolt port availability before creating any files.
+		// A port conflict would leave a partial install that needs --force to retry.
+		port := doltserver.DefaultPort
+		if installDoltPort != 0 {
+			port = installDoltPort
+			os.Setenv("GT_DOLT_PORT", strconv.Itoa(port))
+		} else if p := os.Getenv("GT_DOLT_PORT"); p != "" {
+			if envPort, err := strconv.Atoi(p); err == nil {
+				port = envPort
 			}
-			if err := doltserver.CheckPortAvailable(port); err != nil {
-				// Port is in use — but if a Dolt server is already running
-				// on it, we can reuse it instead of starting a new one.
-				dsn := fmt.Sprintf("root:@tcp(127.0.0.1:%d)/", port)
-				if db, connErr := sql.Open("mysql", dsn); connErr == nil {
-					if pingErr := db.Ping(); pingErr == nil {
-						db.Close()
-						// Usable Dolt server on this port — skip the check.
-						fmt.Printf("   %s Using existing Dolt server on port %d\n",
-							style.Dim.Render("ℹ"), port)
-						goto portOK
-					}
-					db.Close()
-				}
+		}
+		if err := doltserver.CheckPortAvailable(port); err != nil {
+			// Port is in use — but if a Dolt server is already running
+			// for this same town, we can reuse it instead of starting a new one.
+			if canReuseInstallDoltServer(absPath, port) {
+				fmt.Printf("   %s Using existing Dolt server on port %d\n",
+					style.Dim.Render("ℹ"), port)
+			} else {
 				pid, dataDir := doltserver.PortHolder(port)
 				msg := fmt.Sprintf("Dolt port %d is already in use", port)
 				if pid > 0 && dataDir != "" {
@@ -197,7 +192,6 @@ func runInstall(cmd *cobra.Command, args []string) error {
 				}
 				return fmt.Errorf("%s", msg)
 			}
-		portOK:
 		}
 	}
 
@@ -357,27 +351,23 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		// Set up Dolt: identity → init-rig hq → server start.
 		// This ordering works because InitRig falls through to `dolt init`
 		// when the server isn't running yet.
-		if _, err := exec.LookPath("dolt"); err == nil {
-			// Identity was verified in preflight above.
-			// Create HQ database before starting server.
-			if _, _, err := doltserver.InitRig(absPath, "hq"); err != nil {
-				fmt.Printf("   %s Could not init HQ database: %v\n", style.Dim.Render("⚠"), err)
-			}
+		// Identity was verified in preflight above.
+		// Create HQ database before starting server.
+		if _, _, err := doltserver.InitRig(absPath, "hq"); err != nil {
+			return fmt.Errorf("initializing HQ Dolt database: %w", err)
+		}
 
-			// Start the Dolt server — bd commands need a running server.
-			// The server stays running after install (it's lightweight infrastructure,
-			// like a database). Stop it with 'gt dolt stop' when not needed.
-			if err := doltserver.Start(absPath); err != nil {
-				if !strings.Contains(err.Error(), "already running") {
-					fmt.Printf("   %s Could not start Dolt server: %v\n", style.Dim.Render("⚠"), err)
-				}
+		// Start the Dolt server — bd commands need a running server.
+		// The server stays running after install (it's lightweight infrastructure,
+		// like a database). Stop it with 'gt dolt stop' when not needed.
+		if err := doltserver.Start(absPath); err != nil {
+			if !strings.Contains(err.Error(), "already running") {
+				return fmt.Errorf("starting Dolt server for beads: %w", err)
 			}
-		} else {
-			fmt.Printf("   %s dolt not found in PATH — Dolt backend may not fully initialize\n", style.Dim.Render("⚠"))
 		}
 
 		if err := initTownBeads(absPath); err != nil {
-			fmt.Printf("   %s Could not initialize town beads: %v\n", style.Dim.Render("⚠"), err)
+			return fmt.Errorf("initializing town beads: %w", err)
 		} else {
 			fmt.Printf("   ✓ Initialized .beads/ (town-level beads with hq- prefix)\n")
 		}
@@ -495,9 +485,90 @@ func runInstall(cmd *cobra.Command, args []string) error {
 	step++
 	fmt.Printf("  %d. Enter the Mayor's office: %s\n", step, style.Dim.Render("gt mayor attach"))
 	fmt.Println()
-	fmt.Printf("Note: Dolt server is running (stop with %s)\n", style.Dim.Render("gt dolt stop"))
+	if !installNoBeads {
+		fmt.Printf("Note: Dolt server is running (stop with %s)\n", style.Dim.Render("gt dolt stop"))
+	}
 
 	return nil
+}
+
+func ensureInstallDoltReady() error {
+	status, version, detail := deps.CheckDolt()
+	return formatInstallDoltError(status, version, detail, goruntime.GOOS)
+}
+
+const installDoltServerProbeTimeout = 2 * time.Second
+
+func canReuseInstallDoltServer(townRoot string, port int) bool {
+	ctx, cancel := context.WithTimeout(context.Background(), installDoltServerProbeTimeout)
+	defer cancel()
+
+	probeTimeout := installDoltServerProbeTimeout.String()
+	dsn := fmt.Sprintf("root:@tcp(127.0.0.1:%d)/?timeout=%s&readTimeout=%s&writeTimeout=%s",
+		port, probeTimeout, probeTimeout, probeTimeout)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return false
+	}
+	defer db.Close()
+	if err := db.PingContext(ctx); err != nil {
+		return false
+	}
+
+	// Only reuse a server that already belongs to this town. A random
+	// MySQL-compatible service or another town's Dolt server on the same port
+	// must remain a preflight failure; otherwise install can mutate the target
+	// and then fail during bd init.
+	databases, err := doltserver.ListDatabases(townRoot)
+	if err != nil || len(databases) == 0 {
+		return false
+	}
+	legitimate, err := doltserver.VerifyServerDataDir(townRoot)
+	return err == nil && legitimate
+}
+
+func formatInstallDoltError(status deps.DoltStatus, version, detail, goos string) error {
+	switch status {
+	case deps.DoltOK:
+		return nil
+	case deps.DoltNotFound:
+		return fmt.Errorf("dolt is required for gt install with beads enabled but was not found in PATH.\n\nInstall Dolt:\n  %s\n\nTo create an HQ without beads, rerun with --no-beads.\nMore install options: %s", doltInstallHint(goos), deps.DoltInstallURL)
+	case deps.DoltTooOld:
+		return fmt.Errorf("dolt %s is too old for gt install with beads enabled (minimum: %s).\n\nUpgrade Dolt:\n  %s\n\nTo create an HQ without beads, rerun with --no-beads.", version, deps.MinDoltVersion, doltUpgradeHint(goos))
+	case deps.DoltExecFailed:
+		if detail == "" {
+			detail = "no diagnostic output"
+		}
+		return fmt.Errorf("'dolt version' failed, so gt install cannot verify the Dolt dependency required for beads.\n\nDetail: %s\n\nReinstall Dolt:\n  %s\n\nTo create an HQ without beads, rerun with --no-beads.", detail, doltReinstallHint(goos))
+	case deps.DoltUnknown:
+		if detail == "" {
+			detail = "no version output"
+		}
+		return fmt.Errorf("dolt version could not be parsed, so gt install cannot verify the Dolt dependency required for beads.\n\nDetail: %s\n\nReinstall Dolt:\n  %s\n\nTo create an HQ without beads, rerun with --no-beads.", detail, doltReinstallHint(goos))
+	default:
+		return fmt.Errorf("dolt dependency check failed with unknown status %d.\n\nTo create an HQ without beads, rerun with --no-beads.", status)
+	}
+}
+
+func doltInstallHint(goos string) string {
+	if goos == "darwin" {
+		return "brew install dolt"
+	}
+	return "Install Dolt from " + deps.DoltInstallURL
+}
+
+func doltUpgradeHint(goos string) string {
+	if goos == "darwin" {
+		return "brew upgrade dolt"
+	}
+	return "Upgrade Dolt using your package manager or reinstall from " + deps.DoltInstallURL
+}
+
+func doltReinstallHint(goos string) string {
+	if goos == "darwin" {
+		return "brew reinstall dolt"
+	}
+	return "Reinstall Dolt from " + deps.DoltInstallURL
 }
 
 // createTownRootAgentMDs creates a minimal, non-role-specific CLAUDE.md at the

--- a/internal/cmd/install_test.go
+++ b/internal/cmd/install_test.go
@@ -1,13 +1,18 @@
 package cmd
 
 import (
+	"net"
 	"os"
+	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/deps"
 	"github.com/steveyegge/gastown/internal/doltserver"
 )
 
@@ -147,4 +152,243 @@ func TestEnsureBeadsConfigYAML_AddsMissingIssuePrefixKey(t *testing.T) {
 	if !strings.Contains(text, "issue-prefix: hq\n") {
 		t.Fatalf("config.yaml missing issue-prefix: %q", text)
 	}
+}
+
+func TestInstallFailsBeforeMutationWhenDoltMissing(t *testing.T) {
+	tmpDir := t.TempDir()
+	hqPath := filepath.Join(tmpDir, "missing-dolt-hq")
+	gtBinary := buildGT(t)
+
+	cmd := exec.Command(gtBinary, "install", hqPath, "--name", "missing-dolt-test")
+	cmd.Env = installTestEnvWithFakeBD(t, tmpDir)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("gt install should fail when dolt is missing; output:\n%s", output)
+	}
+
+	out := string(output)
+	if !strings.Contains(out, "dolt is required for gt install with beads enabled") {
+		t.Fatalf("expected missing-dolt preflight error, got:\n%s", out)
+	}
+	if !strings.Contains(out, "--no-beads") {
+		t.Fatalf("expected --no-beads fallback hint, got:\n%s", out)
+	}
+	if _, statErr := os.Stat(hqPath); !os.IsNotExist(statErr) {
+		t.Fatalf("install should not create target HQ before missing-dolt failure; statErr=%v", statErr)
+	}
+}
+
+func TestInstallNoBeadsAllowsMissingDolt(t *testing.T) {
+	tmpDir := t.TempDir()
+	hqPath := filepath.Join(tmpDir, "no-beads-hq")
+	gtBinary := buildGT(t)
+
+	cmd := exec.Command(gtBinary, "install", hqPath, "--no-beads", "--name", "no-beads-test")
+	cmd.Env = installTestEnvWithFakeBD(t, tmpDir)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("gt install --no-beads should succeed without dolt: %v\nOutput:\n%s", err, output)
+	}
+
+	if info, statErr := os.Stat(hqPath); statErr != nil {
+		t.Fatalf("HQ root should exist: %v", statErr)
+	} else if !info.IsDir() {
+		t.Fatalf("HQ root should be a directory")
+	}
+	if _, statErr := os.Stat(filepath.Join(hqPath, ".beads")); !os.IsNotExist(statErr) {
+		t.Fatalf("--no-beads install should not create .beads; statErr=%v", statErr)
+	}
+}
+
+func TestInstallFailsBeforeMutationWhenDoltPortOccupiedByNonDolt(t *testing.T) {
+	ln := listenAndHoldTCP(t)
+	tmpDir := t.TempDir()
+	hqPath := filepath.Join(tmpDir, "port-conflict-hq")
+	gtBinary := buildGT(t)
+	port := ln.Addr().(*net.TCPAddr).Port
+
+	cmd := exec.Command(gtBinary, "install", hqPath,
+		"--name", "port-conflict-test",
+		"--dolt-port", strconv.Itoa(port),
+	)
+	cmd.Env = installTestEnvWithFakeBDAndDolt(t, tmpDir)
+	output, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("gt install should fail when a non-Dolt process owns the Dolt port; output:\n%s", output)
+	}
+
+	out := string(output)
+	if !strings.Contains(out, "Dolt port") || !strings.Contains(out, "already in use") {
+		t.Fatalf("expected Dolt port conflict error, got:\n%s", out)
+	}
+	if !strings.Contains(out, "--dolt-port") {
+		t.Fatalf("expected --dolt-port recovery hint, got:\n%s", out)
+	}
+	if _, statErr := os.Stat(hqPath); !os.IsNotExist(statErr) {
+		t.Fatalf("install should not create target HQ before port preflight failure; statErr=%v", statErr)
+	}
+}
+func TestFormatInstallDoltError(t *testing.T) {
+	tests := []struct {
+		name      string
+		status    deps.DoltStatus
+		version   string
+		detail    string
+		goos      string
+		want      []string
+		wantNoErr bool
+	}{
+		{
+			name:      "ok",
+			status:    deps.DoltOK,
+			wantNoErr: true,
+		},
+		{
+			name:   "missing darwin suggests homebrew",
+			status: deps.DoltNotFound,
+			goos:   "darwin",
+			want:   []string{"dolt is required", "brew install dolt", "--no-beads"},
+		},
+		{
+			name:    "too old includes minimum",
+			status:  deps.DoltTooOld,
+			version: "1.0.0",
+			goos:    "linux",
+			want:    []string{"dolt 1.0.0 is too old", deps.MinDoltVersion, "Upgrade Dolt"},
+		},
+		{
+			name:   "exec failed includes detail",
+			status: deps.DoltExecFailed,
+			detail: "permission denied",
+			goos:   "linux",
+			want:   []string{"'dolt version' failed", "permission denied", "Reinstall Dolt"},
+		},
+		{
+			name:   "unknown fails closed",
+			status: deps.DoltUnknown,
+			detail: "unexpected output",
+			goos:   "linux",
+			want:   []string{"version could not be parsed", "unexpected output", "Reinstall Dolt"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := formatInstallDoltError(tt.status, tt.version, tt.detail, tt.goos)
+			if tt.wantNoErr {
+				if err != nil {
+					t.Fatalf("formatInstallDoltError returned error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatal("formatInstallDoltError returned nil, want error")
+			}
+			msg := err.Error()
+			for _, want := range tt.want {
+				if !strings.Contains(msg, want) {
+					t.Fatalf("error missing %q:\n%s", want, msg)
+				}
+			}
+		})
+	}
+}
+
+func TestInstallDoltServerReuseRejectsNonMySQLPortPromptly(t *testing.T) {
+	ln := listenAndHoldTCP(t)
+	port := ln.Addr().(*net.TCPAddr).Port
+	start := time.Now()
+	if canReuseInstallDoltServer(t.TempDir(), port) {
+		t.Fatal("non-MySQL listener should not be reusable as an existing Dolt server")
+	}
+	if elapsed := time.Since(start); elapsed > installDoltServerProbeTimeout+time.Second {
+		t.Fatalf("non-MySQL listener probe took too long: %s", elapsed)
+	}
+}
+
+func listenAndHoldTCP(t *testing.T) net.Listener {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+
+	done := make(chan struct{})
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(conn net.Conn) {
+				defer conn.Close()
+				<-done
+			}(conn)
+		}
+	}()
+	t.Cleanup(func() {
+		close(done)
+		_ = ln.Close()
+	})
+	return ln
+}
+
+func installTestEnvWithFakeBD(t *testing.T, homeDir string) []string {
+	t.Helper()
+	return installTestEnv(t, homeDir, false)
+}
+
+func installTestEnvWithFakeBDAndDolt(t *testing.T, homeDir string) []string {
+	t.Helper()
+	return installTestEnv(t, homeDir, true)
+}
+
+func installTestEnv(t *testing.T, homeDir string, includeDolt bool) []string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	bdName := "bd"
+	mode := os.FileMode(0755)
+	content := "#!/bin/sh\nif [ \"$1\" = \"version\" ]; then\n  echo 'bd version 999.0.0'\n  exit 0\nfi\necho 'fake bd only supports version' >&2\nexit 1\n"
+	if runtime.GOOS == "windows" {
+		bdName = "bd.bat"
+		mode = 0644
+		content = "@echo off\r\nif \"%1\"==\"version\" (\r\n  echo bd version 999.0.0\r\n  exit /b 0\r\n)\r\necho fake bd only supports version 1>&2\r\nexit /b 1\r\n"
+	}
+	if err := os.WriteFile(filepath.Join(binDir, bdName), []byte(content), mode); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	if includeDolt {
+		doltName := "dolt"
+		doltMode := os.FileMode(0755)
+		doltContent := "#!/bin/sh\nif [ \"$1\" = \"version\" ]; then\n  echo 'dolt version 999.0.0'\n  exit 0\nfi\nif [ \"$1\" = \"config\" ] && [ \"$2\" = \"--global\" ] && [ \"$3\" = \"--get\" ]; then\n  case \"$4\" in\n    user.name) echo 'Gas Town Test'; exit 0 ;;\n    user.email) echo 'gastown-test@example.com'; exit 0 ;;\n  esac\nfi\necho 'fake dolt only supports version and config --global --get' >&2\nexit 1\n"
+		if runtime.GOOS == "windows" {
+			doltName = "dolt.bat"
+			doltMode = 0644
+			doltContent = "@echo off\r\nif \"%1\"==\"version\" (\r\n  echo dolt version 999.0.0\r\n  exit /b 0\r\n)\r\nif \"%1\"==\"config\" if \"%2\"==\"--global\" if \"%3\"==\"--get\" (\r\n  if \"%4\"==\"user.name\" (\r\n    echo Gas Town Test\r\n    exit /b 0\r\n  )\r\n  if \"%4\"==\"user.email\" (\r\n    echo gastown-test@example.com\r\n    exit /b 0\r\n  )\r\n)\r\necho fake dolt only supports version and config --global --get 1>&2\r\nexit /b 1\r\n"
+		}
+		if err := os.WriteFile(filepath.Join(binDir, doltName), []byte(doltContent), doltMode); err != nil {
+			t.Fatalf("write fake dolt: %v", err)
+		}
+	}
+
+	env := make([]string, 0, len(os.Environ())+6)
+	for _, entry := range os.Environ() {
+		key, _, _ := strings.Cut(entry, "=")
+		switch strings.ToUpper(key) {
+		case "HOME", "PATH", "BEADS_DIR", "BEADS_DB", "BEADS_DOLT_SERVER_DATABASE", "GT_DOLT_PORT":
+			continue
+		default:
+			env = append(env, entry)
+		}
+	}
+
+	return append(env,
+		"HOME="+homeDir,
+		"PATH="+binDir,
+		"BEADS_DIR=",
+		"BEADS_DB=",
+		"BEADS_DOLT_SERVER_DATABASE=",
+		"GT_DOLT_PORT=",
+	)
 }


### PR DESCRIPTION
Ensure `gt install` checks Dolt before mutating a new HQ when Beads are enabled. Surface actionable install/upgrade/reinstall guidance, keep `--no-beads` working without Dolt. Make required Beads/Dolt bootstrap failures fatal instead of silently creating a partial workspace. Document the macOS Dolt prerequisite and add focused tests for missing Dolt, port conflicts, `--no-beads`, and install error formatting.

## Summary
This makes `gt install` fail fast when Beads are enabled but Dolt is missing, too old, broken, or unusable, before creating any HQ files. It also hardens Dolt port preflight behavior so install does not silently reuse an unrelated process on the configured Dolt port.

## Related Issue
Related to #3516 — addresses the Dolt prerequisite / new-user install failure portion. The rig-name documentation portion of that issue is out of scope for this PR.

## Changes
- Add an early Dolt preflight after the Beads dependency check and before workspace mutation.
- Return actionable platform-specific guidance for missing, outdated, failing, or unparseable Dolt installations.
- Preserve `gt install --no-beads` behavior when Dolt is unavailable.
- Make required Dolt/Beads bootstrap failures fatal instead of warning and continuing with a partial HQ.
- Harden Dolt port conflict handling so only an existing Dolt server for the same town can be reused.
- Document Dolt as an explicit macOS prerequisite in `README.md` and `docs/INSTALLING.md`.
- Add focused tests for missing Dolt, `--no-beads`, Dolt port conflicts, bounded server reuse probing, and error formatting.

## Testing
- [x] Focused affected tests pass: `go test ./internal/deps ./internal/cmd -run '(Dolt|Install|BuildBdInitArgs|EnsureBeadsConfigYAML)' -count=1`
- [x] `gofmt` run on changed Go files
- [x] `git diff --check`
- [x] Manual hidden-Dolt smoke test: default install fails before creating the target HQ; `--no-beads` succeeds without creating `.beads`
- [x] Manual real Dolt/Beads smoke test: isolated temp-port install creates `.beads` and `.dolt-data/hq`, then stops the temp Dolt server cleanly
- [ ] Full `go test ./...` attempted; not marked passing. The full `internal/cmd` package run switches this checkout from the PR branch to `main`, so the install subprocess tests exercise old main-branch install code and hit the previous missing-Dolt warning / non-Dolt port probe hang. Focused affected tests above pass on the PR branch.

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes (or documented in summary)

Oz artifacts:
- Conversation: https://app.warp.dev/conversation/6464ecc0-07e3-40b0-9cd1-876de6cc2cce
- Plan: https://app.warp.dev/drive/notebook/ZeobhiPEhF7FTsAMmwVNqi

Co-Authored-By: Oz <oz-agent@warp.dev>

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3789"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
