### PR TITLE
fix(doctor): detect and recover corrupt .repo.git bare repos

### DIFF
--- a/internal/doctor/bare_repo_exists_check_test.go
+++ b/internal/doctor/bare_repo_exists_check_test.go
@@ -36,28 +36,9 @@ func TestBareRepoExistsCheck_BareRepoExists(t *testing.T) {
 	rigName := "testrig"
 	rigDir := filepath.Join(tmpDir, rigName)
 
-	// Create .repo.git directory (bare repo)
-	bareRepo := filepath.Join(rigDir, ".repo.git")
-	if err := os.MkdirAll(bareRepo, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create refinery/rig with a .git file pointing to .repo.git
-	refineryRig := filepath.Join(rigDir, "refinery", "rig")
-	if err := os.MkdirAll(refineryRig, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	// Create .repo.git/worktrees/rig directory (so the target exists)
-	worktreeDir := filepath.Join(bareRepo, "worktrees", "rig")
-	if err := os.MkdirAll(worktreeDir, 0755); err != nil {
-		t.Fatal(err)
-	}
-
-	gitContent := "gitdir: " + filepath.Join(bareRepo, "worktrees", "rig") + "\n"
-	if err := os.WriteFile(filepath.Join(refineryRig, ".git"), []byte(gitContent), 0644); err != nil {
-		t.Fatal(err)
-	}
+	// Create a real bare repo so the structural health check passes.
+	bareRepo := initBareRepoWithRemote(t, rigDir, "https://github.com/example/repo.git")
+	setupWorktreeRef(t, rigDir, bareRepo)
 
 	check := NewBareRepoExistsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir, RigName: rigName}
@@ -378,6 +359,265 @@ func TestBareRepoExistsCheck_FixPushURLMismatch(t *testing.T) {
 	result2 := check2.Run(ctx)
 	if result2.Status != StatusOK {
 		t.Errorf("expected StatusOK after fix, got %v: %s", result2.Status, result2.Message)
+	}
+}
+
+// corruptBareRepo simulates the recurring partial-shell corruption mode:
+// .repo.git is reduced to objects/ + worktrees/ (no HEAD, refs, config, hooks, info).
+func corruptBareRepo(t *testing.T, bareRepo string) {
+	t.Helper()
+	for _, name := range []string{"HEAD", "config", "refs", "hooks", "info", "packed-refs"} {
+		_ = os.RemoveAll(filepath.Join(bareRepo, name))
+	}
+}
+
+func TestBareRepoExistsCheck_CorruptBareRepoDetected(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+	rigDir := filepath.Join(tmpDir, rigName)
+
+	bareRepo := initBareRepoWithRemote(t, rigDir, "https://github.com/example/repo.git")
+	setupWorktreeRef(t, rigDir, bareRepo)
+	corruptBareRepo(t, bareRepo)
+
+	check := NewBareRepoExistsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir, RigName: rigName}
+
+	result := check.Run(ctx)
+	if result.Status != StatusError {
+		t.Fatalf("expected StatusError for corrupt bare repo, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(strings.ToLower(result.Message), "corrupt") &&
+		!strings.Contains(strings.ToLower(result.Message), "unusable") {
+		t.Errorf("expected message to mention corruption/unusable, got %q", result.Message)
+	}
+	if result.FixHint == "" {
+		t.Error("expected non-empty FixHint for corrupt bare repo")
+	}
+}
+
+func TestBareRepoExistsCheck_FixCorruptBareRepoReclones(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+	rigDir := filepath.Join(tmpDir, rigName)
+
+	// Stand up an upstream bare repo on disk to clone from.
+	upstream := filepath.Join(tmpDir, "upstream.git")
+	if out, err := exec.Command("git", "init", "--bare", upstream).CombinedOutput(); err != nil {
+		t.Fatalf("git init upstream failed: %v\n%s", err, out)
+	}
+	// Seed upstream with a commit so clone has a default branch.
+	work := filepath.Join(tmpDir, "work")
+	if out, err := exec.Command("git", "init", "-b", "main", work).CombinedOutput(); err != nil {
+		t.Fatalf("git init work failed: %v\n%s", err, out)
+	}
+	if err := os.WriteFile(filepath.Join(work, "README"), []byte("hi"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	for _, args := range [][]string{
+		{"-C", work, "-c", "user.email=t@t", "-c", "user.name=t", "add", "README"},
+		{"-C", work, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "-m", "init"},
+		{"-C", work, "remote", "add", "origin", upstream},
+		{"-C", work, "push", "origin", "main"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v failed: %v\n%s", args, err, out)
+		}
+	}
+
+	// Set up the rig with a corrupt .repo.git pointing at our upstream.
+	bareRepo := initBareRepoWithRemote(t, rigDir, upstream)
+	writeConfigJSON(t, rigDir, upstream, "")
+	setupWorktreeRef(t, rigDir, bareRepo)
+	corruptBareRepo(t, bareRepo)
+
+	check := NewBareRepoExistsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir, RigName: rigName}
+
+	result := check.Run(ctx)
+	if result.Status != StatusError {
+		t.Fatalf("expected StatusError for corrupt repo, got %v: %s", result.Status, result.Message)
+	}
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+
+	// The bare repo must be re-cloned and pass the structural health check.
+	if err := bareRepoHealth(bareRepo); err != nil {
+		t.Fatalf("bare repo still unhealthy after Fix: %v", err)
+	}
+	// Re-running the check should now return OK.
+	check2 := NewBareRepoExistsCheck()
+	if result2 := check2.Run(ctx); result2.Status != StatusOK {
+		t.Errorf("expected StatusOK after Fix re-cloned, got %v: %s", result2.Status, result2.Message)
+	}
+}
+
+func TestBareRepoRefspecCheck_CorruptBareRepoErrors(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+	rigDir := filepath.Join(tmpDir, rigName)
+
+	bareRepo := initBareRepoWithRemote(t, rigDir, "https://github.com/example/repo.git")
+	corruptBareRepo(t, bareRepo)
+
+	check := NewBareRepoRefspecCheck()
+	ctx := &CheckContext{TownRoot: tmpDir, RigName: rigName}
+
+	result := check.Run(ctx)
+	if result.Status != StatusError {
+		t.Fatalf("expected StatusError on corrupt bare repo, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestBareRepoRefspecCheck_FixRefusesCorrupt(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+	rigDir := filepath.Join(tmpDir, rigName)
+
+	bareRepo := initBareRepoWithRemote(t, rigDir, "https://github.com/example/repo.git")
+	corruptBareRepo(t, bareRepo)
+
+	check := NewBareRepoRefspecCheck()
+	ctx := &CheckContext{TownRoot: tmpDir, RigName: rigName}
+
+	if err := check.Fix(ctx); err == nil {
+		t.Fatal("expected Fix to refuse writing config to a corrupt bare repo, got nil error")
+	}
+	// Critically: Fix must NOT have created .repo.git/config (the original bug).
+	if _, err := os.Stat(filepath.Join(bareRepo, "config")); err == nil {
+		t.Error("Fix wrote .repo.git/config on a corrupt bare repo — this is the bug it must prevent")
+	}
+}
+
+func TestBareRepoExistsCheck_FixCorruptPreservesWorktreeHead(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+	rigDir := filepath.Join(tmpDir, rigName)
+
+	upstream := filepath.Join(tmpDir, "upstream.git")
+	if out, err := exec.Command("git", "init", "--bare", upstream).CombinedOutput(); err != nil {
+		t.Fatalf("git init upstream: %v\n%s", err, out)
+	}
+	work := filepath.Join(tmpDir, "work")
+	for _, args := range [][]string{
+		{"init", "-b", "main", work},
+		{"-C", work, "-c", "user.email=t@t", "-c", "user.name=t", "commit", "--allow-empty", "-m", "init"},
+		{"-C", work, "remote", "add", "origin", upstream},
+		{"-C", work, "push", "origin", "main"},
+	} {
+		if out, err := exec.Command("git", args...).CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	bareRepo := initBareRepoWithRemote(t, rigDir, upstream)
+	writeConfigJSON(t, rigDir, upstream, "")
+	setupWorktreeRef(t, rigDir, bareRepo)
+	// Pre-populate the worktree's HEAD with a non-default branch ref.
+	customHead := "ref: refs/heads/feature-branch\n"
+	headFile := filepath.Join(bareRepo, "worktrees", "rig", "HEAD")
+	if err := os.WriteFile(headFile, []byte(customHead), 0644); err != nil {
+		t.Fatal(err)
+	}
+	corruptBareRepo(t, bareRepo)
+
+	check := NewBareRepoExistsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir, RigName: rigName}
+	if result := check.Run(ctx); result.Status != StatusError {
+		t.Fatalf("expected StatusError, got %v: %s", result.Status, result.Message)
+	}
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+
+	// After Fix, the re-registered worktree HEAD should match the captured value,
+	// not the default "refs/heads/main".
+	got, err := os.ReadFile(headFile)
+	if err != nil {
+		t.Fatalf("reading re-registered HEAD: %v", err)
+	}
+	if string(got) != customHead {
+		t.Errorf("expected captured HEAD %q after re-clone, got %q", customHead, string(got))
+	}
+}
+
+func TestBareRepoExistsCheck_FixSkipsRepairedBetweenRunAndFix(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+	rigDir := filepath.Join(tmpDir, rigName)
+
+	bareRepo := initBareRepoWithRemote(t, rigDir, "https://github.com/example/repo.git")
+	setupWorktreeRef(t, rigDir, bareRepo)
+	corruptBareRepo(t, bareRepo)
+
+	check := NewBareRepoExistsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir, RigName: rigName}
+	if result := check.Run(ctx); result.Status != StatusError {
+		t.Fatalf("expected StatusError, got %v: %s", result.Status, result.Message)
+	}
+
+	// Operator manually repairs the repo between Run and Fix (TOCTOU window).
+	// Re-init the bare repo in place.
+	if err := os.RemoveAll(bareRepo); err != nil {
+		t.Fatal(err)
+	}
+	if out, err := exec.Command("git", "init", "--bare", bareRepo).CombinedOutput(); err != nil {
+		t.Fatalf("re-init: %v\n%s", err, out)
+	}
+	// Capture the new HEAD inode/mtime to verify Fix doesn't touch it.
+	infoBefore, err := os.Stat(filepath.Join(bareRepo, "HEAD"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+
+	infoAfter, err := os.Stat(filepath.Join(bareRepo, "HEAD"))
+	if err != nil {
+		t.Fatalf("HEAD missing after Fix — Fix should have skipped a healthy repo: %v", err)
+	}
+	if !infoBefore.ModTime().Equal(infoAfter.ModTime()) {
+		t.Errorf("Fix re-created the bare repo even though it was healthy at Fix time")
+	}
+}
+
+func TestBareRepoHealth_RejectsNonBareRepo(t *testing.T) {
+	tmpDir := t.TempDir()
+	work := filepath.Join(tmpDir, "work")
+	if out, err := exec.Command("git", "init", "-b", "main", work).CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+	// Point bareRepoHealth at the .git directory of a non-bare repo.
+	if err := bareRepoHealth(filepath.Join(work, ".git")); err == nil {
+		t.Error("expected bareRepoHealth to reject non-bare .git directory")
+	}
+}
+
+func TestBareRepoRefspecCheck_HealthyRepoStillFixes(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+	rigDir := filepath.Join(tmpDir, rigName)
+
+	bareRepo := initBareRepoWithRemote(t, rigDir, "https://github.com/example/repo.git")
+	// Strip the refspec so Fix has work to do.
+	if out, err := exec.Command("git", "-C", bareRepo, "config", "--unset", "remote.origin.fetch").CombinedOutput(); err != nil {
+		t.Fatalf("unset refspec failed: %v\n%s", err, out)
+	}
+
+	check := NewBareRepoRefspecCheck()
+	ctx := &CheckContext{TownRoot: tmpDir, RigName: rigName}
+
+	if result := check.Run(ctx); result.Status != StatusError {
+		t.Fatalf("expected StatusError when refspec missing, got %v: %s", result.Status, result.Message)
+	}
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed on healthy repo: %v", err)
+	}
+	if result := check.Run(ctx); result.Status != StatusOK {
+		t.Errorf("expected StatusOK after Fix, got %v: %s", result.Status, result.Message)
 	}
 }
 

--- a/internal/doctor/rig_check.go
+++ b/internal/doctor/rig_check.go
@@ -1112,6 +1112,42 @@ func hasBeadsData(beadsDir string) bool {
 	return false
 }
 
+// bareRepoHealth returns nil if .repo.git is structurally usable as a bare repo,
+// or an error describing why it is not. Catches the recurring corruption mode
+// where .repo.git is reduced to objects/ + worktrees/ (no HEAD, refs, config),
+// and also rejects a non-bare repo masquerading as .repo.git (which would let
+// refspec repair write into a working tree's git dir).
+func bareRepoHealth(bareRepoPath string) error {
+	if _, err := os.Stat(filepath.Join(bareRepoPath, "HEAD")); err != nil {
+		return fmt.Errorf("HEAD missing: %w", err)
+	}
+	cmd := exec.Command("git", "-C", bareRepoPath, "rev-parse", "--git-dir")
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return fmt.Errorf("git rev-parse --git-dir failed: %s", msg)
+	}
+	stderr.Reset()
+	bareCmd := exec.Command("git", "-C", bareRepoPath, "rev-parse", "--is-bare-repository")
+	bareCmd.Stderr = &stderr
+	out, err := bareCmd.Output()
+	if err != nil {
+		msg := strings.TrimSpace(stderr.String())
+		if msg == "" {
+			msg = err.Error()
+		}
+		return fmt.Errorf("git rev-parse --is-bare-repository failed: %s", msg)
+	}
+	if strings.TrimSpace(string(out)) != "true" {
+		return fmt.Errorf(".repo.git is not a bare repository")
+	}
+	return nil
+}
+
 // BareRepoRefspecCheck verifies that the shared bare repo has the correct refspec configured.
 // Without this, worktrees created from the bare repo cannot fetch and see origin/* refs.
 // See: https://github.com/anthropics/gastown/issues/286
@@ -1149,6 +1185,22 @@ func (c *BareRepoRefspecCheck) Run(ctx *CheckContext) *CheckResult {
 			Name:    c.Name(),
 			Status:  StatusOK,
 			Message: "No shared bare repo found (using individual clones)",
+		}
+	}
+
+	// Before checking refspec, verify the bare repo is fundamentally usable.
+	// Without this guard, a partial-shell .repo.git (objects/ + worktrees/ only)
+	// will pass after Fix auto-creates a config file, masking the real corruption.
+	if healthErr := bareRepoHealth(bareRepoPath); healthErr != nil {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusError,
+			Message: "Bare repo is structurally broken — refspec check cannot verify",
+			Details: []string{
+				healthErr.Error(),
+				"Configuring a refspec on a corrupt repo would silently mask the corruption.",
+			},
+			FixHint: "Run 'gt doctor --fix --rig " + ctx.RigName + "' (bare-repo-exists check will re-clone)",
 		}
 	}
 
@@ -1199,6 +1251,13 @@ func (c *BareRepoRefspecCheck) Fix(ctx *CheckContext) error {
 	bareRepoPath := filepath.Join(ctx.RigPath(), ".repo.git")
 	if _, err := os.Stat(bareRepoPath); os.IsNotExist(err) {
 		return nil // No bare repo to fix
+	}
+
+	// Refuse to write config into a structurally broken bare repo. `git config`
+	// auto-creates .repo.git/config, which would make subsequent BareRepoRefspecCheck
+	// runs return OK and hide the real corruption from operators.
+	if healthErr := bareRepoHealth(bareRepoPath); healthErr != nil {
+		return fmt.Errorf("refusing to set refspec: bare repo is structurally broken (%s); run bare-repo-exists fix to re-clone", healthErr)
 	}
 
 	cmd := exec.Command("git", "-C", bareRepoPath, "config", "remote.origin.fetch", "+refs/heads/*:refs/remotes/origin/*")
@@ -1411,8 +1470,10 @@ func (c *DefaultBranchAllRigsCheck) Run(ctx *CheckContext) *CheckResult {
 // never created), all those worktrees break with "fatal: not a git repository".
 type BareRepoExistsCheck struct {
 	FixableCheck
-	brokenWorktrees []string // worktree paths with broken .repo.git references
-	pushURLMismatch bool     // config.json push_url differs from .repo.git push URL
+	brokenWorktrees []string          // worktree paths with broken .repo.git references
+	pushURLMismatch bool              // config.json push_url differs from .repo.git push URL
+	bareRepoCorrupt bool              // .repo.git exists but is not a usable git directory
+	recoveredHeads  map[string]string // rig-relative worktree path -> HEAD ref captured before re-clone
 }
 
 // NewBareRepoExistsCheck creates a new bare repo exists check.
@@ -1445,6 +1506,8 @@ func (c *BareRepoExistsCheck) Run(ctx *CheckContext) *CheckResult {
 	// Reset mutable state to avoid stale values if check is reused across rigs.
 	c.brokenWorktrees = nil
 	c.pushURLMismatch = false
+	c.bareRepoCorrupt = false
+	c.recoveredHeads = nil
 	worktreeDirs := c.findWorktreeDirs(rigPath, ctx.RigName)
 
 	for _, wtDir := range worktreeDirs {
@@ -1485,6 +1548,33 @@ func (c *BareRepoExistsCheck) Run(ctx *CheckContext) *CheckResult {
 					relPath = wtDir
 				}
 				c.brokenWorktrees = append(c.brokenWorktrees, relPath)
+			}
+		}
+	}
+
+	// If .repo.git exists, first verify it is structurally usable. A bare repo
+	// reduced to objects/ + worktrees/ (no HEAD/refs/config) blocks `gt sling --create`
+	// with "fatal: not a git repository" and is the recurring corruption mode this
+	// check exists to catch. Detect it here as a hard error so --fix triggers re-clone.
+	if _, err := os.Stat(bareRepoPath); err == nil {
+		if healthErr := bareRepoHealth(bareRepoPath); healthErr != nil {
+			c.bareRepoCorrupt = true
+			details := []string{
+				fmt.Sprintf("Bare repo at %s is structurally broken", bareRepoPath),
+				healthErr.Error(),
+				"Worktrees and `gt sling --create` cannot operate on this repo until it is re-cloned.",
+			}
+			if len(c.brokenWorktrees) > 0 {
+				details = append(details, fmt.Sprintf("Also: %d worktree(s) have broken references", len(c.brokenWorktrees)))
+				details = append(details, c.brokenWorktrees...)
+			}
+			return &CheckResult{
+				Name:     c.Name(),
+				Status:   StatusError,
+				Message:  "Shared bare repo exists but is unusable (corrupt)",
+				Details:  details,
+				FixHint:  "Run 'gt doctor --fix --rig " + ctx.RigName + "' to re-clone .repo.git",
+				Category: c.Category(),
 			}
 		}
 	}
@@ -1660,6 +1750,42 @@ func (c *BareRepoExistsCheck) Fix(ctx *CheckContext) error {
 	rigPath := ctx.RigPath()
 	bareRepoPath := filepath.Join(rigPath, ".repo.git")
 
+	// If .repo.git is corrupt (exists but unusable), nuke it so the missing-repo
+	// branch below re-clones from config.json. We cannot repair a partial-shell
+	// bare repo in place — git refuses to operate on it.
+	//
+	// Before nuking:
+	//   1. Re-verify health to guard against stale state — Run may have flagged
+	//      corruption minutes ago and the operator could have repaired it manually
+	//      between Run and Fix. Refusing to delete a now-healthy repo prevents
+	//      data loss from a TOCTOU window.
+	//   2. Capture every worktree that references .repo.git AND its HEAD ref.
+	//      Run only flags worktrees whose .repo.git/worktrees/<name> gitdir was
+	//      already missing — but after we delete .repo.git, ALL referencing
+	//      worktrees are broken and must be re-registered. HEAD must be captured
+	//      now because os.RemoveAll will erase .repo.git/worktrees/<name>/HEAD.
+	if c.bareRepoCorrupt {
+		if _, err := os.Stat(bareRepoPath); err == nil {
+			if healthErr := bareRepoHealth(bareRepoPath); healthErr == nil {
+				// Repaired between Run and Fix — drop the corrupt flag and skip deletion.
+				c.bareRepoCorrupt = false
+			} else {
+				refs := c.collectBareRepoReferences(rigPath, ctx.RigName)
+				c.recoveredHeads = make(map[string]string, len(refs))
+				c.brokenWorktrees = c.brokenWorktrees[:0]
+				for _, r := range refs {
+					c.brokenWorktrees = append(c.brokenWorktrees, r.relPath)
+					if r.headRef != "" {
+						c.recoveredHeads[r.relPath] = r.headRef
+					}
+				}
+				if rmErr := os.RemoveAll(bareRepoPath); rmErr != nil {
+					return fmt.Errorf("removing corrupt .repo.git: %w", rmErr)
+				}
+			}
+		}
+	}
+
 	// Fix push URL mismatch on existing .repo.git.
 	// Only apply if .repo.git exists — if missing, recreation below sets the correct push URL.
 	// Note: config.json is parsed inline here (not via config.RigEntry) because the doctor
@@ -1691,12 +1817,13 @@ func (c *BareRepoExistsCheck) Fix(ctx *CheckContext) error {
 		}
 	}
 
-	if len(c.brokenWorktrees) == 0 {
-		// No worktrees to fix — push URL mismatch (if any) already handled above
+	if len(c.brokenWorktrees) == 0 && !c.bareRepoCorrupt {
+		// No worktrees to fix and bare repo is healthy — push URL mismatch
+		// (if any) already handled above.
 		return nil
 	}
 
-	// Recreate .repo.git if it's missing; skip clone if it already exists
+	// Recreate .repo.git if it's missing (originally absent or removed above as corrupt).
 	if _, err := os.Stat(bareRepoPath); err != nil {
 		// Read git_url from config.json
 		configPath := filepath.Join(rigPath, "config.json")
@@ -1783,12 +1910,13 @@ func (c *BareRepoExistsCheck) Fix(ctx *CheckContext) error {
 			continue
 		}
 
-		// Detect which branch the worktree was on by looking at HEAD in the worktree.
-		// If we can't determine, default to HEAD.
+		// Detect which branch the worktree was on. Prefer a HEAD captured before
+		// .repo.git was nuked (corrupt-recovery path), fall back to reading from
+		// the live worktree gitdir (legacy missing-bare-repo path), then to main.
 		headContent := "ref: refs/heads/main\n"
-		// Try to read the old HEAD from the worktree's git metadata
-		oldHeadPath := filepath.Join(gitdir, "HEAD")
-		if oldHead, err := os.ReadFile(oldHeadPath); err == nil {
+		if saved, ok := c.recoveredHeads[relPath]; ok && saved != "" {
+			headContent = saved
+		} else if oldHead, err := os.ReadFile(filepath.Join(gitdir, "HEAD")); err == nil {
 			headContent = string(oldHead)
 		}
 
@@ -1799,6 +1927,62 @@ func (c *BareRepoExistsCheck) Fix(ctx *CheckContext) error {
 	}
 
 	return nil
+}
+
+// bareRepoWorktreeRef captures everything we need to re-register a worktree
+// after .repo.git is re-cloned. HEAD is captured BEFORE deletion because
+// os.RemoveAll erases .repo.git/worktrees/<name>/HEAD; without this the
+// re-registration would silently default to main.
+type bareRepoWorktreeRef struct {
+	relPath  string // rig-relative worktree directory path
+	headRef  string // contents of the worktree's HEAD (e.g. "ref: refs/heads/foo\n"), empty if unreadable
+}
+
+// collectBareRepoReferences returns refs for every worktree dir whose .git
+// file points into <rigPath>/.repo.git/worktrees/<name>. Used during corrupt
+// .repo.git recovery: all referencing worktrees must be re-registered after
+// re-clone, regardless of whether the gitdir target was already missing.
+//
+// Path matching is exact (resolved + cleaned + prefix check) so a worktree
+// from another rig that happens to contain ".repo.git" in its path is not
+// mis-collected.
+func (c *BareRepoExistsCheck) collectBareRepoReferences(rigPath, rigName string) []bareRepoWorktreeRef {
+	bareRepoPrefix := filepath.Clean(filepath.Join(rigPath, ".repo.git", "worktrees")) + string(filepath.Separator)
+	var refs []bareRepoWorktreeRef
+	for _, wtDir := range c.findWorktreeDirs(rigPath, rigName) {
+		gitFile := filepath.Join(wtDir, ".git")
+		info, err := os.Stat(gitFile)
+		if err != nil || info.IsDir() {
+			continue
+		}
+		content, err := os.ReadFile(gitFile)
+		if err != nil {
+			continue
+		}
+		line := strings.TrimSpace(string(content))
+		if !strings.HasPrefix(line, "gitdir: ") {
+			continue
+		}
+		gitdir := strings.TrimPrefix(line, "gitdir: ")
+		if !filepath.IsAbs(gitdir) {
+			gitdir = filepath.Join(wtDir, gitdir)
+		}
+		gitdir = filepath.Clean(gitdir)
+		if !strings.HasPrefix(gitdir, bareRepoPrefix) {
+			continue
+		}
+		relPath, _ := filepath.Rel(rigPath, wtDir)
+		if relPath == "" {
+			relPath = wtDir
+		}
+		ref := bareRepoWorktreeRef{relPath: relPath}
+		// Capture HEAD now, before the caller removes .repo.git.
+		if headBytes, err := os.ReadFile(filepath.Join(gitdir, "HEAD")); err == nil {
+			ref.headRef = string(headBytes)
+		}
+		refs = append(refs, ref)
+	}
+	return refs
 }
 
 // findWorktreeDirs returns paths to directories that may be git worktrees within a rig.


### PR DESCRIPTION
## Summary

Fixes the case where a `.repo.git` reduced to `objects/` + `worktrees/`
(no HEAD/refs/config) makes `gt doctor` report healthy, blocking
`--fix` from re-cloning. After this state, `gt sling --create` fails
with `fatal: not a git repository: '.repo.git'`. Manual nuke + re-clone
was the only recovery.

Bug had two parts in `internal/doctor/rig_check.go`:

1. `BareRepoRefspecCheck.Fix` ran `git config remote.origin.fetch ...`,
   which auto-creates `.repo.git/config` even on a partial-shell repo.
   Subsequent `Run` calls then found the config and returned OK,
   masking the corruption.
2. `BareRepoExistsCheck` only emitted `StatusWarning` when `git remote`
   queries failed, and `Warning` does not trigger `--fix`. The Fix path
   also had no branch for "exists but corrupt" — only "missing".

## Changes

- New `bareRepoHealth()` helper requires HEAD, `rev-parse --git-dir`,
  and `rev-parse --is-bare-repository=true`.
- `BareRepoRefspecCheck.Run`/`Fix` gate on `bareRepoHealth`. `Fix`
  refuses to write config to a structurally broken repo (the masking
  bug).
- `BareRepoExistsCheck` adds a `bareRepoCorrupt` flag, returns
  `StatusError` on corruption, and `Fix` removes + re-clones the bare
  repo. Captures referencing worktrees and their `HEAD` refs **before**
  `os.RemoveAll` (since the gitdir HEADs are about to be erased) so
  re-registration restores the original branch instead of defaulting
  to `main`.
- Re-verifies health right before deletion to handle the TOCTOU window
  between Run and Fix.

## Test plan

- [x] `go test ./internal/doctor/` — passes (full suite)
- [x] 8 new tests:
  - corruption detection returns `StatusError`
  - Fix re-clones from `git_url` and the rebuilt repo passes `bareRepoHealth`
  - HEAD captured before deletion is restored on re-registration (custom
    branch survives, not defaulted to `main`)
  - Fix skips deletion when the operator repaired the repo between Run
    and Fix (TOCTOU)
  - refspec Fix refuses to write config to a corrupt repo (the original
    masking bug)
  - refspec Fix still works on healthy repos with missing refspec
  - `bareRepoHealth` rejects a non-bare repo masquerading as `.repo.git`
- [x] Existing fake-`.repo.git` test (`os.MkdirAll` only) updated to use
  a real bare repo — the fake one is now correctly detected as corrupt.
- [x] `go vet ./...` clean.

## Out of scope

Codex review surfaced two pre-existing issues in the worktree
re-registration loop that predate this PR but are exposed by the
new corrupt-recovery code path:

- The loop writes `gitdir` and `HEAD` but never `commondir`, which
  modern git requires for linked worktrees.
- Per-worktree errors are silently swallowed via `continue`.

Both apply equally to the existing missing-bare-repo recovery. Worth
follow-up but kept out of this PR to keep the diff focused on the
detection/masking bug from the issue.

## Notes

- Branch follows the polecat naming convention (`polecat/<name>/<bead>@<molecule>`); feel free to rename or rebase as preferred.
- Caught while diagnosing recurring `.repo.git` corruption on the houmanoids_www rig.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3790"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->