### PR TITLE
fix(formula): substitute --set vars in workflow step descriptions

### DIFF
--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"text/template"
@@ -797,12 +798,16 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 	// Step 2: Create step beads and wire dependencies
 	stepBeads := make(map[string]string) // step.ID -> bead ID
 
+	// Parse --set key=value pairs so {{var}} placeholders in step descriptions
+	// (e.g., {{problem}}, {{context}}) are filled before the bead is written.
+	// Placeholders for keys not provided via --set (e.g., {{review_id}} which
+	// is computed by the executing agent at runtime) are left intact.
+	setVars := parseSetVars(formulaRunSet)
+
 	for _, step := range f.Steps {
 		stepBeadID := fmt.Sprintf("%s-wfs-%s", rigPrefix, generateFormulaShortID())
 
-		// Step descriptions contain {{var}} placeholders (e.g., {{problem}},
-		// {{context}}) that are instructions for the executing AGENT, not Go
-		// template vars. Do not render them — pass through verbatim.
+		stepDescription := substituteFormulaVars(step.Description, setVars)
 
 		// Use --body-file=- (stdin) for the description to avoid CLI arg
 		// length limits and quoting issues with large markdown descriptions.
@@ -822,7 +827,7 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 			Dir(rigBeadsDir).
 			Stderr(os.Stderr).
 			Build()
-		createCmd.Stdin = strings.NewReader(step.Description)
+		createCmd.Stdin = strings.NewReader(stepDescription)
 		if err := createCmd.Run(); err != nil {
 			fmt.Printf("%s Failed to create step bead for %s: %v\n",
 				style.Dim.Render("Warning:"), step.ID, err)
@@ -906,7 +911,7 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 
 		slingArgs := []string{
 			"sling", stepBeadID, targetRig,
-			"-a", step.Description,
+			"-a", substituteFormulaVars(step.Description, setVars),
 			"-s", step.Title,
 		}
 		if stepAgent != "" {
@@ -969,6 +974,32 @@ func parseSetVars(setArgs []string) map[string]interface{} {
 		}
 	}
 	return vars
+}
+
+// formulaVarPlaceholder matches {{key}} placeholders with optional whitespace,
+// where key is a Go-style identifier. Used by substituteFormulaVars to fill
+// in formula step descriptions without invoking Go's text/template (which
+// rejects bare {{name}} syntax — it expects {{.name}}).
+var formulaVarPlaceholder = regexp.MustCompile(`\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}`)
+
+// substituteFormulaVars replaces {{key}} placeholders in text with values
+// from vars. Placeholders whose key is absent from vars are left intact, so
+// downstream rendering (or the executing agent) can fill them in later.
+func substituteFormulaVars(text string, vars map[string]interface{}) string {
+	if len(vars) == 0 {
+		return text
+	}
+	return formulaVarPlaceholder.ReplaceAllStringFunc(text, func(match string) string {
+		sub := formulaVarPlaceholder.FindStringSubmatch(match)
+		if len(sub) < 2 {
+			return match
+		}
+		v, ok := vars[sub[1]]
+		if !ok {
+			return match
+		}
+		return fmt.Sprint(v)
+	})
 }
 
 // findFormulaFile searches for a formula file by name

--- a/internal/cmd/formula_test.go
+++ b/internal/cmd/formula_test.go
@@ -1,6 +1,9 @@
 package cmd
 
-import "testing"
+import (
+	"strings"
+	"testing"
+)
 
 func TestResolveFormulaLegAgent_Precedence(t *testing.T) {
 	t.Parallel()
@@ -31,4 +34,127 @@ func TestResolveFormulaLegAgent_Precedence(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestSubstituteFormulaVars(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		text string
+		vars map[string]interface{}
+		want string
+	}{
+		{
+			name: "empty vars returns text unchanged",
+			text: "Hello {{problem}}",
+			vars: nil,
+			want: "Hello {{problem}}",
+		},
+		{
+			name: "single substitution",
+			text: "Build {{problem}} for me",
+			vars: map[string]interface{}{"problem": "a widget"},
+			want: "Build a widget for me",
+		},
+		{
+			name: "multiple substitutions",
+			text: "{{problem}} given {{context}}",
+			vars: map[string]interface{}{"problem": "P", "context": "C"},
+			want: "P given C",
+		},
+		{
+			name: "whitespace inside braces",
+			text: "{{ problem }} and {{  context  }}",
+			vars: map[string]interface{}{"problem": "P", "context": "C"},
+			want: "P and C",
+		},
+		{
+			name: "unknown placeholders preserved",
+			text: "{{problem}} -> {{review_id}}",
+			vars: map[string]interface{}{"problem": "P"},
+			want: "P -> {{review_id}}",
+		},
+		{
+			name: "no recursion: replacement value is not re-rendered",
+			text: "{{problem}}",
+			vars: map[string]interface{}{"problem": "{{context}}", "context": "C"},
+			want: "{{context}}",
+		},
+		{
+			name: "multiline text with placeholders",
+			text: "Line 1: {{problem}}\nLine 2: {{context}}\nLine 3: end",
+			vars: map[string]interface{}{"problem": "alpha", "context": "beta"},
+			want: "Line 1: alpha\nLine 2: beta\nLine 3: end",
+		},
+		{
+			name: "value with embedded commas/newlines preserved",
+			text: "Idea: {{problem}}",
+			vars: map[string]interface{}{"problem": "a, b, c\nmore"},
+			want: "Idea: a, b, c\nmore",
+		},
+		{
+			name: "no placeholders",
+			text: "Plain text",
+			vars: map[string]interface{}{"problem": "ignored"},
+			want: "Plain text",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := substituteFormulaVars(tt.text, tt.vars)
+			if got != tt.want {
+				t.Errorf("substituteFormulaVars\n  text=%q\n  vars=%v\n  got =%q\n  want=%q",
+					tt.text, tt.vars, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseSetVars(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		args []string
+		want map[string]interface{}
+	}{
+		{"empty", nil, map[string]interface{}{}},
+		{"single", []string{"problem=hello"}, map[string]interface{}{"problem": "hello"}},
+		{"value with equals", []string{"q=a=b=c"}, map[string]interface{}{"q": "a=b=c"}},
+		{"missing equals ignored", []string{"badentry"}, map[string]interface{}{}},
+		{"empty key ignored", []string{"=val"}, map[string]interface{}{}},
+		{"multiple", []string{"a=1", "b=2"}, map[string]interface{}{"a": "1", "b": "2"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := parseSetVars(tt.args)
+			if len(got) != len(tt.want) {
+				t.Fatalf("len(parseSetVars(%v)) = %d, want %d (%v vs %v)",
+					tt.args, len(got), len(tt.want), got, tt.want)
+			}
+			for k, v := range tt.want {
+				if gv, ok := got[k]; !ok {
+					t.Errorf("parseSetVars(%v) missing key %q", tt.args, k)
+				} else if gv != v {
+					t.Errorf("parseSetVars(%v)[%q] = %v, want %v", tt.args, k, gv, v)
+				}
+			}
+		})
+	}
+
+	// Sanity: round-trip a set var through substitution.
+	t.Run("integration with substituteFormulaVars", func(t *testing.T) {
+		t.Parallel()
+		vars := parseSetVars([]string{"problem=Hello, world"})
+		got := substituteFormulaVars("Idea: {{problem}}", vars)
+		want := "Idea: Hello, world"
+		if !strings.Contains(got, want) {
+			t.Errorf("substitution dropped value: got %q, want contains %q", got, want)
+		}
+	})
 }


### PR DESCRIPTION
## Summary

`gt formula run --set key=value` documents itself as the way to fill `{{problem}}`, `{{context}}`, etc. on workflow-type formulas (e.g. `mol-idea-to-plan`), but `executeWorkflowFormula` was passing `step.Description` through verbatim into both the bead body and `gt sling -a`. Polecats received literal `{{problem}}` placeholders and bailed.

Two underlying issues:

1. The existing `renderTemplate` helper uses Go's `text/template`, which rejects bare `{{name}}` (it requires `{{.name}}`). Formulas use the bare form, so even on the convoy path `renderTemplate` silently fell back to the raw template via the error-fallback branch.
2. The workflow path (`internal/cmd/formula.go:803-805`) explicitly skipped substitution with a comment claiming placeholders were *"instructions for the executing AGENT, not Go template vars"* — but the executing agent is a polecat in a fresh session with no source for the value, so the variable was effectively dead.

## Changes

- New helper `substituteFormulaVars(text, vars)` that fills `{{key}}` placeholders from a parsed `--set` map. Handles whitespace variants (`{{ key }}`). Placeholders without a matching `--set` key (e.g. `{{review_id}}`, computed at runtime by the agent) are left intact, so existing semantics for agent-computed slugs are preserved.
- Apply substitution at both write sites of `executeWorkflowFormula`: bead body creation (`createCmd.Stdin`) and the subsequent `gt sling -a` args.
- Replace the misleading comment.
- Table-driven tests for `substituteFormulaVars` and `parseSetVars`, plus a round-trip integration test that confirms a value containing commas survives `parseSetVars` → `substituteFormulaVars`.

Scope is intentionally narrow: only the workflow path is fixed in this PR. The convoy path uses `renderTemplate` and could benefit from the same helper as a follow-up, but `convoy` is not blocked the way `workflow` is, so I kept the change surgical.

## Reproduction

Before:
```
$ gt formula run mol-idea-to-plan --set "problem=foo"
# polecat closes intake leg with reason:
#   "unfilled template variables ({{problem}}, {{context}}, {{review_id}});
#    no input to draft a PRD from"
```

After: the intake bead body and sling args contain the supplied problem text, and the workflow proceeds normally to the PRD review legs.

## Test plan

- [x] `go test ./internal/cmd/ -run "Formula"` — all formula tests pass (16 subtests across `TestSubstituteFormulaVars` and `TestParseSetVars`)
- [x] `make install` — clean build of `gt`
- [x] End-to-end: `gt formula run mol-idea-to-plan --set "problem=$(cat idea.txt)"` — verified the resulting workflow step bead body contains the substituted problem text instead of `{{problem}}`
- [x] `{{review_id}}` (intentionally not provided via `--set`) remains as a placeholder for the agent to fill

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3793"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->