### PR TITLE
fix(daemon): use --repo instead of --rig in hasAssignedOpenWork bd list call

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1513,7 +1513,6 @@ func (d *Daemon) checkDeaconHeartbeat() {
 	}
 }
 
-
 // restartStuckDeacon kills a stuck Deacon session and respawns it.
 // Uses RestartTracker for exponential backoff and crash-loop prevention.
 // Notifies via gt-notify (zero token cost) if the notify script exists.
@@ -2663,8 +2662,14 @@ func (d *Daemon) isBeadClosed(beadID string) bool {
 // field (updateAgentHookBead is a no-op). Without this fallback, the idle reaper
 // kills working polecats whose agent bead hook_bead is stale.
 func (d *Daemon) hasAssignedOpenWork(rigName, assignee string) bool {
+	rigDir := beads.GetRigDirForName(d.config.TownRoot, rigName)
+
 	for _, status := range []string{"hooked", "in_progress", "open"} {
-		cmd := exec.Command(d.bdPath, "list", "--rig="+rigName, "--assignee="+assignee, "--status="+status, "--json") //nolint:gosec // G204: args are constructed internally
+		args := []string{"list", "--assignee=" + assignee, "--status=" + status, "--json"}
+		if rigDir != "" {
+			args = append(args, "--repo="+rigDir)
+		}
+		cmd := exec.Command(d.bdPath, args...) //nolint:gosec // G204: args are constructed internally
 		cmd.Dir = d.config.TownRoot
 		cmd.Env = os.Environ()
 		output, err := cmd.Output()
@@ -2694,7 +2699,7 @@ Restart deferred to stuck-agent-dog plugin for context-aware recovery.`,
 	cmd := exec.Command(d.gtPath, "mail", "send", witnessAddr, "-s", subject, "-m", body) //nolint:gosec // G204: args are constructed internally
 	setSysProcAttr(cmd)
 	cmd.Dir = d.config.TownRoot
-	cmd.Env = append(os.Environ(), "BD_ACTOR=daemon")// Identify as daemon, not overseer
+	cmd.Env = append(os.Environ(), "BD_ACTOR=daemon") // Identify as daemon, not overseer
 	if err := cmd.Run(); err != nil {
 		d.logger.Printf("Warning: failed to notify witness of crashed polecat: %v", err)
 	}

--- a/internal/daemon/has_assigned_work_test.go
+++ b/internal/daemon/has_assigned_work_test.go
@@ -1,0 +1,75 @@
+package daemon
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+func TestHasAssignedOpenWork_UsesRepoRoutingInsteadOfRigFlag(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mocks")
+	}
+
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0o755); err != nil {
+		t.Fatalf("mkdir town beads: %v", err)
+	}
+	if err := os.WriteFile(
+		filepath.Join(townRoot, ".beads", "routes.jsonl"),
+		[]byte("{\"prefix\":\"gt-\",\"path\":\"gastown/mayor/rig\"}\n"),
+		0o644,
+	); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(binDir, "bd.log")
+	expectedRepo := filepath.Join(townRoot, "gastown", "mayor", "rig")
+	script := `#!/bin/sh
+for arg in "$@"; do
+  if [ "$arg" = "--repo=` + expectedRepo + `" ]; then
+    repo_seen=1
+  fi
+  case "$arg" in
+    --rig=*)
+      echo "Error: unknown flag: --rig" >&2
+      exit 1
+      ;;
+  esac
+done
+if [ "${repo_seen:-0}" -ne 1 ]; then
+  echo "missing expected --repo flag" >&2
+  exit 1
+fi
+printf '%s\n' "$*" >> "` + logPath + `"
+printf '[{"id":"gt-123"}]\n'
+`
+	bdPath := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(bdPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+
+	d := &Daemon{
+		config: &Config{TownRoot: townRoot},
+		bdPath: bdPath,
+	}
+
+	if !d.hasAssignedOpenWork("gastown", "polecats/rust") {
+		t.Fatal("expected assigned work lookup to succeed")
+	}
+
+	logOutput, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	loggedArgs := string(logOutput)
+	if strings.Contains(loggedArgs, "--rig=") {
+		t.Fatalf("expected bd call to avoid --rig, got %q", loggedArgs)
+	}
+	if !strings.Contains(loggedArgs, "--repo="+expectedRepo) {
+		t.Fatalf("expected bd call to include resolved --repo flag, got %q", loggedArgs)
+	}
+}


### PR DESCRIPTION
## Summary

- Refreshes the original fix from #3744 onto current `main` as a narrow replacement branch
- Fixes `hasAssignedOpenWork` to use `--repo` instead of the removed `--rig` flag when querying bd
- Adds the focused regression test from the original work

## Credit

This replacement PR is based on the original investigation and fix in #3744 by @A3Ackerman.

## Why This Replacement Exists

The original PR identified a real infrastructure bug, but this replacement branch is a cleaner current-main version from our fork so we can review and land the narrow fix on top of the latest upstream state.

## Validation

- `go build ./cmd/gt`
- focused regression test coverage for `hasAssignedOpenWork`
- Note: the full `internal/daemon` package suite is Docker-backed in this environment, so this branch was kept intentionally minimal for review against the original PR's broader validation notes.
