### PR TITLE
fix(beads): route cross-rig writes by issue id

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -399,6 +399,19 @@ func (b *Beads) getResolvedBeadsDir() string {
 	return ResolveBeadsDir(b.workDir)
 }
 
+// forIssueID returns a Beads wrapper bound to the correct beads directory for
+// the given issue ID. This is needed for cross-rig write operations that use an
+// ID to determine the owning database.
+func (b *Beads) forIssueID(id string) *Beads {
+	resolved := ResolveBeadsDirForID(b.getResolvedBeadsDir(), id)
+	if resolved == "" || resolved == b.getResolvedBeadsDir() {
+		return b
+	}
+	clone := *b
+	clone.beadsDir = resolved
+	return &clone
+}
+
 // Init initializes a new beads database in the working directory.
 // This uses the same environment isolation as other commands.
 // If ServerPort is set (via NewIsolatedWithPort), passes --server-port to bd init

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -407,9 +407,14 @@ func (b *Beads) forIssueID(id string) *Beads {
 	if resolved == "" || resolved == b.getResolvedBeadsDir() {
 		return b
 	}
-	clone := *b
-	clone.beadsDir = resolved
-	return &clone
+	return &Beads{
+		workDir:    b.workDir,
+		beadsDir:   resolved,
+		isolated:   b.isolated,
+		serverPort: b.serverPort,
+		store:      b.store,
+		townRoot:   b.townRoot,
+	}
 }
 
 // Init initializes a new beads database in the working directory.

--- a/internal/beads/beads_escalation.go
+++ b/internal/beads/beads_escalation.go
@@ -13,22 +13,21 @@ import (
 // EscalationFields holds structured fields for escalation beads.
 // These are stored as "key: value" lines in the description.
 type EscalationFields struct {
-	Severity           string // critical, high, medium, low
-	Reason             string // Why this was escalated
-	Source             string // Source identifier (e.g., plugin:rebuild-gt, patrol:deacon)
-	EscalatedBy        string // Agent address that escalated (e.g., "gastown/Toast")
-	EscalatedAt        string // ISO 8601 timestamp
-	AckedBy            string // Agent that acknowledged (empty if not acked)
-	AckedAt            string // When acknowledged (empty if not acked)
-	ClosedBy           string // Agent that closed (empty if not closed)
-	ClosedReason       string // Resolution reason (empty if not closed)
-	RelatedBead        string // Optional: related bead ID (task, bug, etc.)
-	OriginalSeverity   string // Original severity before any re-escalation
-	ReescalationCount  int    // Number of times this has been re-escalated
-	LastReescalatedAt  string // When last re-escalated (empty if never)
-	LastReescalatedBy  string // Who last re-escalated (empty if never)
+	Severity          string // critical, high, medium, low
+	Reason            string // Why this was escalated
+	Source            string // Source identifier (e.g., plugin:rebuild-gt, patrol:deacon)
+	EscalatedBy       string // Agent address that escalated (e.g., "gastown/Toast")
+	EscalatedAt       string // ISO 8601 timestamp
+	AckedBy           string // Agent that acknowledged (empty if not acked)
+	AckedAt           string // When acknowledged (empty if not acked)
+	ClosedBy          string // Agent that closed (empty if not closed)
+	ClosedReason      string // Resolution reason (empty if not closed)
+	RelatedBead       string // Optional: related bead ID (task, bug, etc.)
+	OriginalSeverity  string // Original severity before any re-escalation
+	ReescalationCount int    // Number of times this has been re-escalated
+	LastReescalatedAt string // When last re-escalated (empty if never)
+	LastReescalatedBy string // Who last re-escalated (empty if never)
 }
-
 
 // FormatEscalationDescription creates a description string from escalation fields.
 func FormatEscalationDescription(title string, fields *EscalationFields) string {
@@ -204,8 +203,9 @@ func (b *Beads) CreateEscalationBead(title string, fields *EscalationFields) (*I
 // AckEscalation acknowledges an escalation bead.
 // Sets acked_by and acked_at fields, adds "acked" label.
 func (b *Beads) AckEscalation(id, ackedBy string) error {
+	target := b.forIssueID(id)
 	// First get current issue to preserve other fields
-	issue, err := b.Show(id)
+	issue, err := target.Show(id)
 	if err != nil {
 		return err
 	}
@@ -223,7 +223,7 @@ func (b *Beads) AckEscalation(id, ackedBy string) error {
 	// Format new description
 	description := FormatEscalationDescription(issue.Title, fields)
 
-	return b.Update(id, UpdateOptions{
+	return target.Update(id, UpdateOptions{
 		Description: &description,
 		AddLabels:   []string{"acked"},
 	})
@@ -232,8 +232,9 @@ func (b *Beads) AckEscalation(id, ackedBy string) error {
 // CloseEscalation closes an escalation bead with a resolution reason.
 // Sets closed_by and closed_reason fields, closes the issue.
 func (b *Beads) CloseEscalation(id, closedBy, reason string) error {
+	target := b.forIssueID(id)
 	// First get current issue to preserve other fields
-	issue, err := b.Show(id)
+	issue, err := target.Show(id)
 	if err != nil {
 		return err
 	}
@@ -252,7 +253,7 @@ func (b *Beads) CloseEscalation(id, closedBy, reason string) error {
 	description := FormatEscalationDescription(issue.Title, fields)
 
 	// Update description first
-	if err := b.Update(id, UpdateOptions{
+	if err := target.Update(id, UpdateOptions{
 		Description: &description,
 		AddLabels:   []string{"resolved"},
 	}); err != nil {
@@ -260,14 +261,14 @@ func (b *Beads) CloseEscalation(id, closedBy, reason string) error {
 	}
 
 	// Close the issue
-	_, err = b.run("close", id, "--reason="+reason)
+	_, err = target.run("close", id, "--reason="+reason)
 	return err
 }
 
 // GetEscalationBead retrieves an escalation bead by ID.
 // Returns nil if not found.
 func (b *Beads) GetEscalationBead(id string) (*Issue, *EscalationFields, error) {
-	issue, err := b.Show(id)
+	issue, err := b.forIssueID(id).Show(id)
 	if err != nil {
 		if errors.Is(err, ErrNotFound) {
 			return nil, nil, nil
@@ -415,7 +416,7 @@ func (b *Beads) ReescalateEscalation(id, reescalatedBy string, maxReescalations 
 	description := FormatEscalationDescription(issue.Title, fields)
 
 	// Update the bead with new description and severity label
-	if err := b.Update(id, UpdateOptions{
+	if err := b.forIssueID(id).Update(id, UpdateOptions{
 		Description:  &description,
 		AddLabels:    []string{"reescalated", "severity:" + newSeverity},
 		RemoveLabels: []string{"severity:" + result.OldSeverity},

--- a/internal/beads/routes.go
+++ b/internal/beads/routes.go
@@ -343,7 +343,17 @@ func ResolveBeadsDirForID(currentBeadsDir, beadID string) string {
 		return currentBeadsDir
 	}
 
-	routes, err := LoadRoutes(currentBeadsDir)
+	routesBeadsDir := currentBeadsDir
+	routes, err := LoadRoutes(routesBeadsDir)
+	if (err != nil || routes == nil) && currentBeadsDir != "" {
+		if townRoot := FindTownRoot(filepath.Dir(currentBeadsDir)); townRoot != "" {
+			townBeadsDir := filepath.Join(townRoot, ".beads")
+			if townBeadsDir != currentBeadsDir {
+				routesBeadsDir = townBeadsDir
+				routes, err = LoadRoutes(routesBeadsDir)
+			}
+		}
+	}
 	if err != nil || routes == nil {
 		return currentBeadsDir
 	}
@@ -351,11 +361,11 @@ func ResolveBeadsDirForID(currentBeadsDir, beadID string) string {
 	for _, r := range routes {
 		if r.Prefix == prefix {
 			if r.Path == "." {
-				return currentBeadsDir // Town-level — already correct
+				return routesBeadsDir
 			}
 			// Rig-level bead — resolve to rig's beads directory.
-			// Derive town root from currentBeadsDir (parent of .beads).
-			townRoot := filepath.Dir(currentBeadsDir)
+			// Derive town root from the routes directory we actually used.
+			townRoot := filepath.Dir(routesBeadsDir)
 			rigDir := filepath.Join(townRoot, r.Path)
 			return ResolveBeadsDir(rigDir)
 		}
@@ -372,7 +382,7 @@ func ResolveBeadsDirForID(currentBeadsDir, beadID string) string {
 // typically indicates the bd create routing resolved to the town-level database
 // instead of the rig's database. Callers should log the warning and continue.
 func ValidateRigPrefix(townRoot, rigName, beadID string) error {
-	expectedPrefix := GetPrefixForRig(townRoot, rigName) // e.g., "gt"
+	expectedPrefix := GetPrefixForRig(townRoot, rigName)           // e.g., "gt"
 	actualPrefix := strings.TrimSuffix(ExtractPrefix(beadID), "-") // e.g., "gt"
 	if actualPrefix == "" {
 		return nil // Can't determine prefix — not an error

--- a/internal/beads/routes_test.go
+++ b/internal/beads/routes_test.go
@@ -299,6 +299,44 @@ func TestResolveBeadsDirForID_NoRoutes(t *testing.T) {
 	}
 }
 
+func TestResolveBeadsDirForID_UsesTownRoutesFromWorktreeBeadsDir(t *testing.T) {
+	tmpDir := t.TempDir()
+	townBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	worktreeBeadsDir := filepath.Join(tmpDir, "gastown", "polecats", "chrome", "gastown", ".beads")
+	if err := os.MkdirAll(worktreeBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	rigBeadsDir := filepath.Join(tmpDir, "gastown", "mayor", "rig", ".beads")
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(tmpDir, "mayor", "town.json"), []byte("{}"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	routesContent := `{"prefix": "gt-", "path": "gastown/mayor/rig"}
+{"prefix": "hq-", "path": "."}
+`
+	if err := os.WriteFile(filepath.Join(townBeadsDir, "routes.jsonl"), []byte(routesContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	result := ResolveBeadsDirForID(worktreeBeadsDir, "gt-abc")
+	if result != rigBeadsDir {
+		t.Fatalf("ResolveBeadsDirForID(%q, %q) = %q, want %q", worktreeBeadsDir, "gt-abc", result, rigBeadsDir)
+	}
+	result = ResolveBeadsDirForID(worktreeBeadsDir, "hq-wisp-abc")
+	if result != townBeadsDir {
+		t.Fatalf("ResolveBeadsDirForID(%q, %q) = %q, want %q", worktreeBeadsDir, "hq-wisp-abc", result, townBeadsDir)
+	}
+}
+
 func TestGetRigNameForPrefix(t *testing.T) {
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")
@@ -320,9 +358,9 @@ func TestGetRigNameForPrefix(t *testing.T) {
 	}{
 		{"gt-", "gastown"},
 		{"bd-", "beads"},
-		{"hq-", ""},       // Town-level, no specific rig
-		{"unknown-", ""},  // Not in routes
-		{"", ""},          // Empty prefix
+		{"hq-", ""},      // Town-level, no specific rig
+		{"unknown-", ""}, // Not in routes
+		{"", ""},         // Empty prefix
 	}
 
 	for _, tc := range tests {
@@ -356,8 +394,8 @@ func TestGetRigDirForName(t *testing.T) {
 	}{
 		{"gantry", filepath.Join(tmpDir, "gantry")},
 		{"algoanki", filepath.Join(tmpDir, "algoanki/mayor/rig")},
-		{"unknown", ""},        // Not in routes
-		{"", ""},               // Empty rig name
+		{"unknown", ""}, // Not in routes
+		{"", ""},        // Empty rig name
 	}
 
 	for _, tc := range tests {


### PR DESCRIPTION
## Summary

- Refreshes the original fix from #3716 onto current `main` as a narrow replacement branch
- Routes cross-rig bead writes by issue ID instead of assuming the caller's current beads store owns the target bead
- Keeps the fix focused to route resolution and escalation write paths only

## Credit

This replacement PR is based on the original investigation and fix in #3716 by @certivpaul.

## Why This Replacement Exists

The original PR identified a real cross-rig write-routing bug, but this replacement branch is a cleaner current-main version from our fork so we can review and land the narrow fix on top of the latest upstream state.

## Validation

- `go test ./internal/beads/...`
- `go test ./internal/mail/... -run 'Test.*Route|Test.*CrossRig|Test.*Delivery' -count=1`
- `go build ./cmd/gt`
- Note: full Docker-backed mail/daemon integration suites were not required for this narrowed replacement branch.
