### PR TITLE
fix(rig): guard stale add rollback cleanup

### DIFF
--- a/internal/rig/add_ownership_test.go
+++ b/internal/rig/add_ownership_test.go
@@ -1,0 +1,82 @@
+package rig
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoveRigPathIfOwned_MatchingStampRemovesPath(t *testing.T) {
+	rigPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rigPath, "some-file"), []byte("x"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	stamp, err := newAddOwnershipStamp()
+	if err != nil {
+		t.Fatalf("new ownership stamp: %v", err)
+	}
+	if err := writeAddOwnershipStamp(rigPath, stamp); err != nil {
+		t.Fatalf("write ownership stamp: %v", err)
+	}
+
+	removeRigPathIfOwned(rigPath, stamp)
+
+	if _, err := os.Stat(rigPath); !os.IsNotExist(err) {
+		t.Fatalf("expected rig path to be removed, stat err=%v", err)
+	}
+}
+
+func TestRemoveRigPathIfOwned_MismatchedStampKeepsPath(t *testing.T) {
+	rigPath := t.TempDir()
+	preserved := filepath.Join(rigPath, "preserve-me")
+	if err := os.WriteFile(preserved, []byte("important"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+	if err := writeAddOwnershipStamp(rigPath, "newer-stamp"); err != nil {
+		t.Fatalf("write ownership stamp: %v", err)
+	}
+
+	removeRigPathIfOwned(rigPath, "older-stamp")
+
+	if _, err := os.Stat(preserved); err != nil {
+		t.Fatalf("preserved file was deleted: %v", err)
+	}
+}
+
+func TestRemoveRigPathIfOwned_MissingStampOnNonEmptyPathKeepsPath(t *testing.T) {
+	rigPath := t.TempDir()
+	preserved := filepath.Join(rigPath, "rig-content")
+	if err := os.WriteFile(preserved, []byte("important"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	removeRigPathIfOwned(rigPath, "stale-stamp")
+
+	if _, err := os.Stat(preserved); err != nil {
+		t.Fatalf("preserved file was deleted: %v", err)
+	}
+}
+
+func TestRemoveRigPathIfOwned_MissingStampOnEmptyPathRemovesPath(t *testing.T) {
+	rigPath := t.TempDir()
+
+	removeRigPathIfOwned(rigPath, "stale-stamp")
+
+	if _, err := os.Stat(rigPath); !os.IsNotExist(err) {
+		t.Fatalf("expected empty rig path to be removed, stat err=%v", err)
+	}
+}
+
+func TestRemoveRigPathIfOwned_NoExpectedStampRemovesPath(t *testing.T) {
+	rigPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(rigPath, "x"), []byte("x"), 0644); err != nil {
+		t.Fatalf("write file: %v", err)
+	}
+
+	removeRigPathIfOwned(rigPath, "")
+
+	if _, err := os.Stat(rigPath); !os.IsNotExist(err) {
+		t.Fatalf("expected rig path to be removed, stat err=%v", err)
+	}
+}

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -2,6 +2,8 @@ package rig
 
 import (
 	"cmp"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -376,8 +378,20 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 		return nil, fmt.Errorf("creating rig directory: %w", err)
 	}
 
-	// Track cleanup on failure (best-effort cleanup)
-	cleanup := func() { _ = os.RemoveAll(rigPath) }
+	// Stamp the directory so a stale rollback cannot delete a later,
+	// successful re-add of the same rig path.
+	ownershipStamp, err := newAddOwnershipStamp()
+	if err != nil {
+		_ = os.RemoveAll(rigPath)
+		return nil, fmt.Errorf("generating ownership stamp: %w", err)
+	}
+	if err := writeAddOwnershipStamp(rigPath, ownershipStamp); err != nil {
+		_ = os.RemoveAll(rigPath)
+		return nil, fmt.Errorf("writing ownership stamp: %w", err)
+	}
+
+	// Track cleanup on failure, but only if this invocation still owns the path.
+	cleanup := func() { removeRigPathIfOwned(rigPath, ownershipStamp) }
 	success := false
 	defer func() {
 		if !success {
@@ -887,7 +901,67 @@ Use crew for your own workspace. Polecats are for batch work dispatch.
 	}
 
 	success = true
+	// Best-effort cleanup: once the add succeeds, the stamp is no longer needed.
+	_ = clearAddOwnershipStamp(rigPath)
 	return m.loadRig(opts.Name, m.config.Rigs[opts.Name])
+}
+
+// addOwnershipStampFile marks which AddRig invocation currently owns the path.
+const addOwnershipStampFile = ".gt-add-owner"
+
+func newAddOwnershipStamp() (string, error) {
+	var buf [16]byte
+	if _, err := rand.Read(buf[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf[:]), nil
+}
+
+func writeAddOwnershipStamp(rigPath, stamp string) error {
+	return os.WriteFile(filepath.Join(rigPath, addOwnershipStampFile), []byte(stamp), 0644)
+}
+
+func readAddOwnershipStamp(rigPath string) string {
+	data, err := os.ReadFile(filepath.Join(rigPath, addOwnershipStampFile))
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(data))
+}
+
+func clearAddOwnershipStamp(rigPath string) error {
+	return os.Remove(filepath.Join(rigPath, addOwnershipStampFile))
+}
+
+// removeRigPathIfOwned only removes a path if this AddRig invocation still owns
+// it. Missing stamps are only removed when the directory is empty, which avoids
+// deleting a later successful re-add that already cleared its own stamp.
+func removeRigPathIfOwned(rigPath, expectedStamp string) {
+	if expectedStamp == "" {
+		_ = os.RemoveAll(rigPath)
+		return
+	}
+
+	onDisk := readAddOwnershipStamp(rigPath)
+	if onDisk == expectedStamp {
+		_ = os.RemoveAll(rigPath)
+		return
+	}
+
+	if onDisk == "" {
+		if entries, err := os.ReadDir(rigPath); err == nil && len(entries) == 0 {
+			_ = os.RemoveAll(rigPath)
+			return
+		}
+		fmt.Fprintf(os.Stderr,
+			"  Warning: skipping rollback of %s because ownership stamp is missing and directory is non-empty (gh#3683 protection)\n",
+			rigPath)
+		return
+	}
+
+	fmt.Fprintf(os.Stderr,
+		"  Warning: skipping rollback of %s because another rig add now owns this path (gh#3683 protection)\n",
+		rigPath)
 }
 
 // verifyRigIdentity checks that metadata.json points to the correct Dolt database


### PR DESCRIPTION
## Summary

- Refreshes the original fix from #3752 onto current `main` as a narrow replacement branch
- Prevents stale `gt rig add` rollback cleanup from deleting a later successful re-add
- Keeps only the ownership-guard rollback correctness fix plus focused regression tests

## Credit

This replacement PR is based on the original investigation and fix in #3752 by @mmlac.

## Why This Replacement Exists

The original PR identified a real rig lifecycle correctness bug. This replacement branch is a cleaner current-main version from our fork so we can review and land the narrow fix on top of the latest upstream state.

## Validation

- `go test ./internal/rig -run 'TestAddRigRollback.*|TestRollback.*' -count=1`
- `go build ./cmd/gt`
