### PR TITLE
fix(molecule): make waitForEventFiles honor ctx cancellation during poll (gt-x2lc)

### DIFF
--- a/internal/cmd/molecule_await_event.go
+++ b/internal/cmd/molecule_await_event.go
@@ -354,8 +354,11 @@ func waitForEventFiles(ctx context.Context, eventDir string) (*AwaitEventResult,
 	for {
 		select {
 		case <-ctx.Done():
-			// Final check for events (race condition safety)
-			events, _ = readPendingEvents(eventDir)
+			// Final check for events (race condition safety). Bound the
+			// read so a stuck filesystem can't prevent us from returning —
+			// the wait has already timed out, and reporting timeout is
+			// more useful than hanging indefinitely on the last read.
+			events = readPendingEventsBounded(ctx, eventDir, 500*time.Millisecond)
 			if len(events) > 0 {
 				return &AwaitEventResult{
 					Reason: "event",
@@ -364,16 +367,63 @@ func waitForEventFiles(ctx context.Context, eventDir string) (*AwaitEventResult,
 			}
 			return &AwaitEventResult{Reason: "timeout"}, nil
 		case <-ticker.C:
-			events, err = readPendingEvents(eventDir)
-			if err != nil {
-				return nil, err
+			// Run readPendingEvents in a goroutine so ctx.Done() can
+			// always interrupt the wait. Without this, a slow/stuck
+			// read (e.g., stalled filesystem, sleeping laptop) would
+			// starve the timeout case until the read returns. This is
+			// the root cause of gt-x2lc: the timeout deadline expired
+			// but waitForEventFiles stayed blocked inside the read.
+			type readRes struct {
+				events []EventFile
+				err    error
 			}
-			if len(events) > 0 {
-				return &AwaitEventResult{
-					Reason: "event",
-					Events: events,
-				}, nil
+			ch := make(chan readRes, 1)
+			go func() {
+				ev, er := readPendingEvents(eventDir)
+				ch <- readRes{events: ev, err: er}
+			}()
+			select {
+			case <-ctx.Done():
+				// Timeout raced with read — abandon the goroutine and
+				// let the outer loop's ctx.Done() case finalize.
+				continue
+			case res := <-ch:
+				if res.err != nil {
+					return nil, res.err
+				}
+				if len(res.events) > 0 {
+					return &AwaitEventResult{
+						Reason: "event",
+						Events: res.events,
+					}, nil
+				}
 			}
+		}
+	}
+}
+
+// readPendingEventsBounded runs readPendingEvents in a goroutine and returns
+// whatever it produces within the given budget, or nil if it doesn't finish.
+// ctx is also honored — whichever deadline fires first wins.
+func readPendingEventsBounded(ctx context.Context, dir string, budget time.Duration) []EventFile {
+	ch := make(chan []EventFile, 1)
+	go func() {
+		events, _ := readPendingEvents(dir)
+		ch <- events
+	}()
+	select {
+	case events := <-ch:
+		return events
+	case <-time.After(budget):
+		return nil
+	case <-ctx.Done():
+		// ctx already done — give the read a tiny grace window so we
+		// don't drop events that were 1ms from arriving.
+		select {
+		case events := <-ch:
+			return events
+		case <-time.After(50 * time.Millisecond):
+			return nil
 		}
 	}
 }

--- a/internal/cmd/molecule_await_event_test.go
+++ b/internal/cmd/molecule_await_event_test.go
@@ -371,6 +371,57 @@ func TestWaitForEventFilesNoDeadline(t *testing.T) {
 	}
 }
 
+func TestWaitForEventFilesTimeoutWithPolling(t *testing.T) {
+	// Regression test for gt-x2lc: the ticker-driven poll must honor
+	// ctx cancellation even if events never arrive. Previously the wait
+	// could stall past the deadline if readPendingEvents was slow.
+	dir := t.TempDir()
+
+	deadline := 600 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+
+	start := time.Now()
+	result, err := waitForEventFiles(ctx, dir)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Reason != "timeout" {
+		t.Errorf("expected reason 'timeout', got %q", result.Reason)
+	}
+	// Must return close to the deadline, not hang.
+	if elapsed > deadline+2*time.Second {
+		t.Errorf("wait took %v; expected ~%v (ctx.Done not honored?)", elapsed, deadline)
+	}
+}
+
+func TestReadPendingEventsBoundedFinishes(t *testing.T) {
+	dir := t.TempDir()
+	os.WriteFile(filepath.Join(dir, "a.event"), []byte(`{"type":"X"}`), 0644)
+
+	events := readPendingEventsBounded(context.Background(), dir, 2*time.Second)
+	if len(events) != 1 {
+		t.Errorf("expected 1 event, got %d", len(events))
+	}
+}
+
+func TestReadPendingEventsBoundedCtxDone(t *testing.T) {
+	dir := t.TempDir()
+	// Even when ctx is already done, the bounded read should return
+	// promptly (within the grace window) rather than hang.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	start := time.Now()
+	_ = readPendingEventsBounded(ctx, dir, 5*time.Second)
+	elapsed := time.Since(start)
+	if elapsed > 500*time.Millisecond {
+		t.Errorf("bounded read took %v with cancelled ctx; expected prompt return", elapsed)
+	}
+}
+
 func TestEventFileStruct(t *testing.T) {
 	ef := EventFile{
 		Path:    "/home/gt/events/refinery/12345.event",


### PR DESCRIPTION
## Summary

Fixes a hang in `waitForEventFiles` where the polling ticker blocked past a context deadline if `readPendingEvents` was slow (stalled filesystem, sleeping laptop).

**Root cause (gt-x2lc):** The `ticker.C` case called `readPendingEvents` synchronously. A slow read prevented `ctx.Done()` from interrupting the wait — the timeout deadline expired but the function stayed blocked until the read returned.

**Fix:** Run `readPendingEvents` in a goroutine on each tick and `select` between the result channel and `ctx.Done()`. Add `readPendingEventsBounded` for the final drain on cancellation — enforces a 500ms hard cap so a stuck filesystem cannot prevent the timeout path from returning.

## Changes
- `internal/cmd/molecule_await_event.go`: goroutine-wrap the ticker poll; add `readPendingEventsBounded`
- `internal/cmd/molecule_await_event_test.go`: three new regression tests
  - `TestWaitForEventFilesTimeoutWithPolling` — ctx cancellation exits within deadline
  - `TestReadPendingEventsBoundedFinishes` — returns events when read completes in time
  - `TestReadPendingEventsBoundedCtxDone` — returns promptly when ctx already cancelled

## Test plan
- [ ] `go test ./internal/cmd/... -run TestWaitForEventFiles` passes
- [ ] Polecat sessions that time out during `gt done` (e.g., sleeping laptop) return promptly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3799"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->