### PR TITLE
fix(polecat): use IsAgentAlive in Start's zombie check

### DIFF
--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -349,17 +349,28 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 	// Check if session already exists.
 	// If an existing session's pane process has died, kill the stale session
 	// and proceed rather than returning ErrSessionRunning (gt-jn40ft).
+	//
+	// For zombie detection, use IsAgentAlive directly rather than the
+	// heartbeat-primary isSessionStale path. The pane process is often a
+	// shell or wrapper that outlives the agent, so heartbeat-fresh + pane-PID
+	// alive can hide a dead agent — wedging gt session restart with
+	// ErrSessionRunning on the very zombie state recovery is meant to handle
+	// (hq-k1ot / np-tt5s). A false-negative here is recoverable: Start is
+	// about to (re)create the session, so killing a transiently-misclassified
+	// healthy session just churns one creation cycle. Patrol-side cleanup
+	// (manager.go:cleanupOrphanedDirs) intentionally keeps the conservative
+	// isSessionProcessDead path to avoid killing healthy sessions during
+	// transient pgrep/ps failures.
 	running, err := m.tmux.HasSession(sessionID)
 	if err != nil {
 		return fmt.Errorf("checking session: %w", err)
 	}
 	if running {
-		if m.isSessionStale(sessionID) {
-			if err := m.tmux.KillSessionWithProcesses(sessionID); err != nil {
-				return fmt.Errorf("killing stale session %s: %w", sessionID, err)
-			}
-		} else {
+		if m.tmux.IsAgentAlive(sessionID) {
 			return fmt.Errorf("%w: %s", ErrSessionRunning, sessionID)
+		}
+		if err := m.tmux.KillSessionWithProcesses(sessionID); err != nil {
+			return fmt.Errorf("killing stale session %s: %w", sessionID, err)
 		}
 	}
 


### PR DESCRIPTION
## Summary

Revised after independent review caught two P1 false-positive-kill regressions in the original approach. Now narrowly targets the **recovery path only** — `isSessionProcessDead` and patrol cleanup are untouched.

- `Start` (internal/polecat/session_manager.go) currently calls `isSessionStale` (= `isSessionProcessDead`) to decide whether to kill an existing session before creating a new one. The heartbeat-primary path is correct, but the heartbeat-fresh + pane-PID-alive case can hide a dead agent (pane shell wrapper outlives the agent process). Result: `gt session restart` wedges with `ErrSessionRunning` on the very zombie state recovery is meant to handle.
- Fix replaces `isSessionStale` with `t.IsAgentAlive` (agent-name walk of descendant tree) in `Start` only. This aligns with `CheckSessionHealth`'s zombie detection.
- **Patrol-side cleanup** (`manager.go:cleanupOrphanedDirs` at ~line 1795) **keeps the conservative `isSessionProcessDead` path unchanged** so transient `pgrep`/`ps` failures don't false-positive kill healthy sessions during periodic scans.
- `isSessionProcessDead` is **untouched**. The `syscall` import stays. No callers of `isSessionProcessDead` change semantics.

## Why narrow Start specifically

Trade-off accepted in `Start`: a transient `IsAgentAlive` false-negative (e.g., `pgrep` rate-limited) will kill a healthy session, but `Start` is about to recreate one anyway — one creation cycle of churn, no data loss. By contrast, patrol cleanup kills sessions that aren't being restarted, so the conservative bias there is right and stays.

## Evidence

Witness patrol mail `hq-xhfc` (2026-04-28) recorded 10 nba_pims polecats hitting `agent-dead-in-session (action=restart-agent-dead-session-failed: session restart failed: Error: starting session: session already running)`. The same pattern recurred on 2026-04-30 across ~30-50% of `gt sling --create --force` re-attempts after a stall.

Failure path before this fix:
1. Agent inside tmux pane crashes; pane wrapper survives.
2. `CheckSessionHealth` → `AgentDead` → `polecatMgr.IsRunning` returns `false`.
3. `runSessionRestart` (cmd/session.go:519) takes the `!running` branch, skips `Stop`.
4. `polecatMgr.Start` finds `HasSession` → true, calls `isSessionStale` → false (pane PID alive), returns `ErrSessionRunning`.

After this fix, step 4 calls `IsAgentAlive` → false (agent gone), `Start` kills the zombie via `KillSessionWithProcesses`, and the new session comes up clean.

## Refs

- `hq-k1ot` (this fix's tracking bead, town beads)
- `np-tt5s` (P0 in nba_pims tracking workload impact)
- `np-386` (codex variant of the same bug)
- Lifecycle family: PR #3787 (np-arb verified-push contract)

## Revision history

- **v1** (commit 2f608e7b, force-pushed away): broadened `isSessionProcessDead`'s fallback to use `IsAgentAlive`. Independent review caught: (a) transient `pgrep` failures would false-positive kill healthy sessions in patrol cleanup, violating the docstring contract "Returns true only when we can confirm the process is dead, not on transient failures" (gt-kncti), and (b) legacy sessions running non-Claude agents without `GT_PROCESS_NAMES` set would be at risk of false-positive kills.
- **v2** (current, 58e60eb9): narrows the change to `Start` only; `isSessionProcessDead` and `syscall` import restored to main.

## Test plan

- [ ] `go test ./internal/polecat/...` (existing tests should pass; no behavior change to `isSessionProcessDead`)
- [ ] Manual: induce a zombie (kill agent process inside live tmux), then `gt session restart <rig>/<polecat>` should succeed instead of erroring with `ErrSessionRunning`
- [ ] Manual: re-sling a stalled polecat via `gt sling <bead> <rig> --create --force` and verify recovery rate improves
- [ ] Followup: introduce a tmux interface so `Start`'s zombie-check is mockable for a regression test

🤖 Generated with [Claude Code](https://claude.com/claude-code)