### PR TITLE
fix(npm): release HTTPS response stream in postinstall downloadFile (gh#3595) (gt-kl1)

### DIFF
--- a/npm-package/scripts/postinstall.js
+++ b/npm-package/scripts/postinstall.js
@@ -83,8 +83,15 @@ function downloadFile(url, dest) {
 
       file.on('finish', () => {
         file.close((err) => {
-          if (err) reject(err);
-          else resolve();
+          if (err) {
+            reject(err);
+            return;
+          }
+          // On Windows, the HTTPS response stream still holds a file handle
+          // lock after the write stream closes. If we don't destroy it here,
+          // PowerShell's Expand-Archive can't open the ZIP for extraction.
+          response.destroy();
+          resolve();
         });
       });
     });


### PR DESCRIPTION
## Summary

Automated merge from polecat branch.

- **Issue**: gt-kl1
- **Polecat**: slit
- **Branch**: polecat/slit-mnwbv17l
- **Tests**: Passed (verified by refinery)

---
*Created by Gas Town Refinery*

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3804"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->