### PR TITLE
fix(sling): persist convoy fields for single-bead dispatch

### DIFF
--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -401,7 +401,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 			DryRun:      slingDryRun,
 			Force:       slingForce,
 			NoMerge:     slingNoMerge,
-				ReviewOnly:  slingReviewOnly,
+			ReviewOnly:  slingReviewOnly,
 			Account:     slingAccount,
 			Agent:       slingAgent,
 			HookRawBead: slingHookRawBead,
@@ -764,6 +764,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 
 	// Auto-convoy: check if issue is already tracked by a convoy
 	// If not, create one for dashboard visibility (unless --no-convoy is set)
+	var convoyID string
 	if !slingNoConvoy && formulaName == "" {
 		existingConvoy := isTrackedByConvoy(beadID)
 		if existingConvoy == "" {
@@ -774,7 +775,8 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 					fmt.Printf("Would set convoy merge strategy: %s\n", slingMerge)
 				}
 			} else {
-				convoyID, err := createAutoConvoy(beadID, info.Title, slingOwned, slingMerge, slingBaseBranch)
+				var err error
+				convoyID, err = createAutoConvoy(beadID, info.Title, slingOwned, slingMerge, slingBaseBranch)
 				if err != nil {
 					// Log warning but don't fail - convoy is optional
 					fmt.Printf("%s Could not create auto-convoy: %v\n", style.Dim.Render("Warning:"), err)
@@ -958,16 +960,19 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	// Store all attachment fields in a single read-modify-write cycle.
 	// This eliminates the race condition where sequential independent updates
 	// (dispatcher, args, no_merge, attached_molecule) could overwrite each other.
-	fieldUpdates := beadFieldUpdates{
-		Dispatcher:       actor,
-		Args:             slingArgs,
-		Vars:             append([]string(nil), slingVars...),
-		AttachedMolecule: attachedMoleculeID,
-		AttachedFormula:  formulaName,
-		NoMerge:          slingNoMerge,
-		ReviewOnly:       slingReviewOnly,
-		FormulaVars:      strings.Join(slingVars, "\n"),
-	}
+	fieldUpdates := buildSlingFieldUpdates(
+		actor,
+		slingArgs,
+		append([]string(nil), slingVars...),
+		attachedMoleculeID,
+		formulaName,
+		slingNoMerge,
+		slingReviewOnly,
+		strings.Join(slingVars, "\n"),
+		convoyID,
+		slingMerge,
+		slingOwned,
+	)
 	if err := storeFieldsInBead(beadID, fieldUpdates); err != nil {
 		// Warn but don't fail - polecat will still complete work
 		fmt.Printf("%s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -262,18 +262,46 @@ func getBeadInfo(beadID string) (*beadInfo, error) {
 // This enables a single read-modify-write cycle instead of sequential independent updates,
 // eliminating the race condition where concurrent writers could overwrite each other's fields.
 type beadFieldUpdates struct {
-	Dispatcher       string // Agent that dispatched the work
-	Args             string // Natural language instructions
+	Dispatcher       string   // Agent that dispatched the work
+	Args             string   // Natural language instructions
 	Vars             []string // Formula variables (key=value pairs)
-	AttachedMolecule string // Wisp root ID
-	AttachedFormula  string // Formula name (e.g., "mol-polecat-work") for inline step display
-	NoMerge          bool   // Skip merge queue on completion
-	ReviewOnly       bool   // Review-only mode: assignee must not merge/commit/push
-	Mode             string // Execution mode: "" (normal) or "ralph"
-	ConvoyID         string // Convoy bead ID (e.g., "hq-cv-abc")
-	MergeStrategy    string // Convoy merge strategy: "direct", "mr", "local"
-	ConvoyOwned      bool   // Convoy has gt:owned label (caller-managed lifecycle)
-	FormulaVars      string // Newline-separated key=value pairs for formula template substitution
+	AttachedMolecule string   // Wisp root ID
+	AttachedFormula  string   // Formula name (e.g., "mol-polecat-work") for inline step display
+	NoMerge          bool     // Skip merge queue on completion
+	ReviewOnly       bool     // Review-only mode: assignee must not merge/commit/push
+	Mode             string   // Execution mode: "" (normal) or "ralph"
+	ConvoyID         string   // Convoy bead ID (e.g., "hq-cv-abc")
+	MergeStrategy    string   // Convoy merge strategy: "direct", "mr", "local"
+	ConvoyOwned      bool     // Convoy has gt:owned label (caller-managed lifecycle)
+	FormulaVars      string   // Newline-separated key=value pairs for formula template substitution
+}
+
+func buildSlingFieldUpdates(
+	dispatcher string,
+	args string,
+	vars []string,
+	attachedMolecule string,
+	attachedFormula string,
+	noMerge bool,
+	reviewOnly bool,
+	formulaVars string,
+	convoyID string,
+	mergeStrategy string,
+	convoyOwned bool,
+) beadFieldUpdates {
+	return beadFieldUpdates{
+		Dispatcher:       dispatcher,
+		Args:             args,
+		Vars:             vars,
+		AttachedMolecule: attachedMolecule,
+		AttachedFormula:  attachedFormula,
+		NoMerge:          noMerge,
+		ReviewOnly:       reviewOnly,
+		ConvoyID:         convoyID,
+		MergeStrategy:    mergeStrategy,
+		ConvoyOwned:      convoyOwned,
+		FormulaVars:      formulaVars,
+	}
 }
 
 // storeFieldsInBead performs a single read-modify-write to update all attachment fields
@@ -711,7 +739,7 @@ func InstantiateFormulaOnBead(ctx context.Context, formulaName, beadID, title, h
 		if err := BdCmd("cook", formulaName).
 			Dir(formulaWorkDir).
 			WithGTRoot(townRoot).
-				Run(); err != nil {
+			Run(); err != nil {
 			// Retry with embedded formula
 			resolvedFormula, formulaCleanup = resolveFormulaToTempFile(formulaName)
 			if formulaCleanup != nil {

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -1192,19 +1192,19 @@ func TestLooksLikeBeadID(t *testing.T) {
 		{"aaaaaa-b", false},     // prefix too long (6 chars)
 
 		// Injection / invalid suffix characters - should return false
-		{"gt-abc;rm -rf /", false},       // shell injection in suffix
-		{"gt-abc$(cmd)", false},          // command substitution in suffix
-		{"gt-abc&bg", false},            // ampersand in suffix
-		{"gt-abc|pipe", false},          // pipe in suffix
-		{"gt-abc`tick`", false},         // backtick in suffix
-		{"gt-abc>redir", false},         // redirect in suffix
-		{"gt-abc<redir", false},         // redirect in suffix
-		{"gt-abc'quote", false},         // single quote in suffix
-		{"gt-abc\"dquote", false},       // double quote in suffix
-		{"gt-abc\\slash", false},        // backslash in suffix
-		{"gt-abc xyz", false},           // space in suffix
-		{"gt-ABC", false},              // uppercase in suffix
-		{"gt-abc/path", false},          // slash in suffix
+		{"gt-abc;rm -rf /", false}, // shell injection in suffix
+		{"gt-abc$(cmd)", false},    // command substitution in suffix
+		{"gt-abc&bg", false},       // ampersand in suffix
+		{"gt-abc|pipe", false},     // pipe in suffix
+		{"gt-abc`tick`", false},    // backtick in suffix
+		{"gt-abc>redir", false},    // redirect in suffix
+		{"gt-abc<redir", false},    // redirect in suffix
+		{"gt-abc'quote", false},    // single quote in suffix
+		{"gt-abc\"dquote", false},  // double quote in suffix
+		{"gt-abc\\slash", false},   // backslash in suffix
+		{"gt-abc xyz", false},      // space in suffix
+		{"gt-ABC", false},          // uppercase in suffix
+		{"gt-abc/path", false},     // slash in suffix
 	}
 
 	for _, tt := range tests {
@@ -1742,6 +1742,60 @@ exit /b 0
 		if !strings.Contains(line, "ENV:BD_DOLT_AUTO_COMMIT=off|") {
 			t.Errorf("bd command missing BD_DOLT_AUTO_COMMIT=off: %s", line)
 		}
+	}
+}
+
+func TestBuildSlingFieldUpdatesIncludesConvoyFields(t *testing.T) {
+	got := buildSlingFieldUpdates(
+		"mayor",
+		"review this",
+		[]string{"feature=test"},
+		"gt-wisp-test",
+		"mol-polecat-work",
+		false,
+		false,
+		"feature=test",
+		"hq-cv-test1",
+		"local",
+		true,
+	)
+
+	if got.ConvoyID != "hq-cv-test1" {
+		t.Fatalf("ConvoyID = %q, want %q", got.ConvoyID, "hq-cv-test1")
+	}
+	if got.MergeStrategy != "local" {
+		t.Fatalf("MergeStrategy = %q, want %q", got.MergeStrategy, "local")
+	}
+	if !got.ConvoyOwned {
+		t.Fatal("ConvoyOwned = false, want true")
+	}
+}
+
+func TestStoreFieldsInBeadConvoyFields(t *testing.T) {
+	t.Setenv("GT_TEST_ATTACHED_MOLECULE_LOG", filepath.Join(t.TempDir(), "mol.log"))
+	logPath := os.Getenv("GT_TEST_ATTACHED_MOLECULE_LOG")
+
+	if err := storeFieldsInBead("gt-test123", beadFieldUpdates{
+		ConvoyID:      "hq-cv-test1",
+		MergeStrategy: "local",
+		ConvoyOwned:   true,
+	}); err != nil {
+		t.Fatalf("storeFieldsInBead: %v", err)
+	}
+
+	body, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read log: %v", err)
+	}
+	text := string(body)
+	if !strings.Contains(text, "convoy_id: hq-cv-test1") {
+		t.Fatalf("missing convoy_id in description:\n%s", text)
+	}
+	if !strings.Contains(text, "merge_strategy: local") {
+		t.Fatalf("missing merge_strategy in description:\n%s", text)
+	}
+	if !strings.Contains(text, "convoy_owned: true") {
+		t.Fatalf("missing convoy_owned in description:\n%s", text)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Refreshes the original fix from #3654 onto current `main` as a narrow replacement branch
- Persists `convoy_id`, `merge_strategy`, and `convoy_owned` on single-bead sling attachments so `gt done` can honor `--merge=local` / `--merge=direct`
- Keeps the replacement focused to field construction and persistence tests only

## Credit

This replacement PR is based on the original investigation and fix in #3654 by @alinsim.

## Why This Replacement Exists

The original PR identified a real sling/`gt done` correctness bug, but this replacement branch is a cleaner current-main version from our fork so we can review and land the narrow fix on top of the latest upstream state.

## Validation

- `go test ./internal/cmd -run 'TestBuildSlingFieldUpdatesIncludesConvoyFields|TestStoreFieldsInBeadConvoyFields' -count=1`
- `go build ./cmd/gt`
