### PR TITLE
fix(formula): unblock mol-idea-to-plan + multi-line --set truncation

### DIFF
--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -171,8 +171,13 @@ func init() {
 	formulaRunCmd.Flags().StringVar(&formulaRunRig, "rig", "", "Target rig (default: current or gastown)")
 	formulaRunCmd.Flags().BoolVar(&formulaRunDryRun, "dry-run", false, "Preview execution without running")
 	formulaRunCmd.Flags().StringVar(&formulaRunAgent, "agent", "", "Override agent/runtime for all legs (e.g., gemini, codex, claude-haiku)")
-	formulaRunCmd.Flags().StringSliceVar(&formulaRunFiles, "files", nil, "Files to pass to formula legs (available as {{.files}} in templates)")
-	formulaRunCmd.Flags().StringSliceVar(&formulaRunSet, "set", nil, "Set input variables as key=value pairs (available as {{.key}} in templates)")
+	formulaRunCmd.Flags().StringArrayVar(&formulaRunFiles, "files", nil, "Files to pass to formula legs (available as {{.files}} in templates)")
+	// StringArrayVar (not StringSliceVar): pflag's StringSliceVar runs the value
+	// through csv.Reader, which treats '\n' as a record separator and silently
+	// drops everything after the first newline. That truncated multi-line --set
+	// values like --set "problem=$(cat brief.md)" to just the first line by the
+	// time they reached substituteFormulaVars. (issue gastownhall/gastown#3798)
+	formulaRunCmd.Flags().StringArrayVar(&formulaRunSet, "set", nil, "Set input variables as key=value pairs (available as {{.key}} in templates)")
 
 	// Create flags
 	formulaCreateCmd.Flags().StringVar(&formulaCreateType, "type", "task", "Formula type: task, workflow, or patrol")
@@ -747,6 +752,34 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 	}
 	townBeads := filepath.Join(townRoot, ".beads")
 
+	// Detect orchestrator identity for interactive workflows. When any step is
+	// interactive, all step beads are pre-assigned to this agent so the daemon's
+	// stranded-convoy scan won't slings them to a polecat between steps. The
+	// orchestrator advances through them via `gt mol step done`. Steps that
+	// pour sub-convoys or call `gt formula run` MUST run in a non-polecat role
+	// (polecats are blocked from those calls), so this routing is required for
+	// workflows like mol-idea-to-plan. (issue gastownhall/gastown#3798)
+	hasInteractive := false
+	for _, step := range f.Steps {
+		if step.Interactive {
+			hasInteractive = true
+			break
+		}
+	}
+	var orchestratorID string
+	if hasInteractive {
+		cwd, _ := os.Getwd()
+		if roleInfo, rerr := GetRoleWithContext(cwd, townRoot); rerr == nil {
+			orchestratorID = buildAgentIdentity(RoleContext{
+				Role:     roleInfo.Role,
+				Rig:      roleInfo.Rig,
+				Polecat:  roleInfo.Polecat,
+				TownRoot: townRoot,
+				WorkDir:  cwd,
+			})
+		}
+	}
+
 	// Resolve the target rig's beads prefix and directory
 	rigPrefix := beads.GetPrefixForRig(townRoot, targetRig)
 	rigBeadsDir := townBeads
@@ -816,6 +849,13 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 		if beads.NeedsForceForID(stepBeadID) {
 			stepArgs = append(stepArgs, "--force")
 		}
+		// Pre-assign step beads to the orchestrator for interactive workflows.
+		// isReadyIssue treats beads with a live-session assignee as not stranded,
+		// so the daemon's auto-dispatch won't poach steps from the orchestrator
+		// between `gt mol step done` calls. (gastownhall/gastown#3798)
+		if hasInteractive && orchestratorID != "" {
+			stepArgs = append(stepArgs, "--assignee="+orchestratorID)
+		}
 
 		createCmd := BdCmd(stepArgs...).
 			WithAutoCommit().
@@ -857,17 +897,8 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 
 	// Step 3: Identify and dispatch ready steps (those with no dependencies)
 	// Interactive steps are hooked to the current session; others are slung to polecats.
+	// hasInteractive was computed at function entry alongside orchestratorID.
 	fmt.Printf("\n%s Dispatching ready steps...\n\n", style.Bold.Render("→"))
-
-	// Check if any step in the workflow is interactive — if so, we'll need
-	// to handle the molecule lifecycle in the current session.
-	hasInteractive := false
-	for _, step := range f.Steps {
-		if step.Interactive {
-			hasInteractive = true
-			break
-		}
-	}
 
 	slingCount := 0
 	interactiveCount := 0

--- a/internal/formula/formulas/mol-idea-to-plan.formula.toml
+++ b/internal/formula/formulas/mol-idea-to-plan.formula.toml
@@ -55,10 +55,11 @@ each, await their findings, apply fixes to the plan, then proceed to the next ro
 """
 formula = "mol-idea-to-plan"
 type = "workflow"
-version = 2
+version = 3
 
 [[steps]]
 id = "intake"
+interactive = true
 title = "Structure idea into draft PRD"
 description = """
 Read the conversation context and produce a structured PRD draft.
@@ -113,6 +114,7 @@ echo "prd_draft=.prd-reviews/{{review_id}}/prd-draft.md" >> .prd-reviews/{{revie
 
 [[steps]]
 id = "prd-review"
+interactive = true
 title = "Run parallel PRD review (6 legs)"
 needs = ["intake"]
 description = """
@@ -151,6 +153,7 @@ cat .prd-reviews/<review-id>/prd-review.md
 
 [[steps]]
 id = "human-clarify"
+interactive = true
 title = "Gather human clarifications on PRD"
 needs = ["prd-review"]
 description = """
@@ -203,6 +206,7 @@ A: <human's answer>
 
 [[steps]]
 id = "generate-plan"
+interactive = true
 title = "Generate implementation plan (6 design dimensions)"
 needs = ["human-clarify"]
 description = """
@@ -252,6 +256,7 @@ Pay attention to:
 
 [[steps]]
 id = "prd-align-1"
+interactive = true
 title = "PRD alignment round 1: requirements + goals"
 needs = ["generate-plan"]
 description = """
@@ -313,6 +318,7 @@ Read both reports. For each must-fix and should-fix finding:
 
 [[steps]]
 id = "prd-align-2"
+interactive = true
 title = "PRD alignment round 2: constraints + non-goals"
 needs = ["prd-align-1"]
 description = """
@@ -376,6 +382,7 @@ Cut scope-creep items. Add constraint-respecting guardrails. Log changes in
 
 [[steps]]
 id = "prd-align-3"
+interactive = true
 title = "PRD alignment round 3: user-stories + open-questions"
 needs = ["prd-align-2"]
 description = """
@@ -459,6 +466,7 @@ Proceeding to plan self-review...
 
 [[steps]]
 id = "plan-review-1"
+interactive = true
 title = "Plan self-review round 1: completeness + sequencing"
 needs = ["prd-align-3"]
 description = """
@@ -525,6 +533,7 @@ Read both reports. Apply all must-fix and should-fix changes to
 
 [[steps]]
 id = "plan-review-2"
+interactive = true
 title = "Plan self-review round 2: risk + scope-creep"
 needs = ["plan-review-1"]
 description = """
@@ -594,6 +603,7 @@ Log in `.plan-reviews/{{review_id}}/review-round-2.md`.
 
 [[steps]]
 id = "plan-review-3"
+interactive = true
 title = "Plan self-review round 3: testability + coherence"
 needs = ["plan-review-2"]
 description = """
@@ -683,6 +693,7 @@ Proceeding to bead creation...
 
 [[steps]]
 id = "create-beads"
+interactive = true
 title = "Convert approved plan to beads"
 needs = ["plan-review-3"]
 description = """
@@ -762,6 +773,7 @@ Epic created. Human notified."""
 
 [[steps]]
 id = "verify-beads-pass-1"
+interactive = true
 title = "Verify beads coverage against plan (pass 1)"
 needs = ["create-beads"]
 description = """
@@ -821,6 +833,7 @@ Log what you found and created. If no gaps: say so explicitly.
 
 [[steps]]
 id = "verify-beads-pass-2"
+interactive = true
 title = "Verify beads coverage against plan (pass 2)"
 needs = ["verify-beads-pass-1"]
 description = """
@@ -850,6 +863,7 @@ requirements that only become visible after the first pass filled gaps.
 
 [[steps]]
 id = "verify-beads-pass-3"
+interactive = true
 title = "Final verification pass"
 needs = ["verify-beads-pass-2"]
 description = """


### PR DESCRIPTION
## Summary

Closes #3798. Two bugs that together made `gt formula run mol-idea-to-plan` unable to complete end-to-end.

### 1. Multi-line `--set` truncation

pflag's `StringSliceVar` runs each value through `csv.Reader`, which treats `\n` as a record separator and silently drops everything after it. So:

```bash
gt formula run mol-idea-to-plan --set \"problem=\$(cat brief.md)\"
```

…reached `substituteFormulaVars` as just the first line of `brief.md`.

**Fix:** switched `--set` and `--files` to `StringArrayVar` (verbatim, no csv parsing).

Reproduced and confirmed in a one-off:

```go
fs.StringSliceVar(&slice, ...); fs.StringArrayVar(&array, ...)
fs.Parse([]string{\"--slice\", \"problem=line1\\nline2\\nline3\",
                  \"--array\", \"problem=line1\\nline2\\nline3\"})
// slice = [\"problem=line1\"]
// array = [\"problem=line1\\nline2\\nline3\"]
```

### 2. Workflow steps slung to polecats that can't run them

The mol-idea-to-plan pipeline (intake → prd-review → human-clarify → generate-plan → 3×prd-align → 3×plan-review → create-beads → 3×verify-beads) has steps that pour sub-convoys (`gt formula run mol-prd-review`, `gt formula run design`) and dispatch polecat reviewers (`gt sling --prompt=…`). The daemon's stranded-convoy scan was slinging these to polecats, which are blocked at the system level from `gt sling` and from running formulas. The workflow stalled one step after intake.

The formula's own description says \"The orchestrating crew worker runs through steps sequentially\" — `interactive = true` matches that intent.

**Fix (formula):** added `interactive = true` to all 14 steps, bumped version 2 → 3.

**Fix (executor):** when a workflow has any interactive step, `executeWorkflowFormula` now detects the orchestrator's agent identity and pre-assigns every step bead to it via `--assignee` at create time. `isReadyIssue` (`internal/cmd/convoy.go:1575`) treats beads with a live-session assignee as not stranded, so the daemon's auto-dispatch won't poach steps from the orchestrator between `gt mol step done` calls.

Without that pre-assignment, marking the formula interactive only protects the first ready step. The dependent steps go through the daemon's stranded scan as their dependencies close, and get slung to polecats.

## Test plan

- [x] `make build` clean, `go vet ./internal/cmd/... ./internal/formula/...` clean
- [x] `gt formula run mol-idea-to-plan --set \"problem=multi\nline\nbrief\" --dry-run` shows all three lines in the rendered context (was: only first line)
- [x] `gt formula show mol-idea-to-plan` parses with new \`interactive = true\` lines
- [ ] End-to-end: pour mol-idea-to-plan against a real idea, walk it through to bead creation. (Local fix is installed and ready to verify; haven't pushed a real idea through yet — recommend running it once before merge.)

## Related

- #3793 — substitution fix (`{{problem}}` was never being filled). This PR depends on its semantics for the multi-line value to actually flow into the rendered template.
- #3613 — original `--set` flag (was convoy-only at the time)
- #3505 — workflow type support in `gt formula run`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3807"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->