### PR TITLE
fix(config): resolve agent process names through wrapper commands

### DIFF
--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -1018,7 +1018,7 @@ func updateSessionEnvForHandoff(t *tmux.Tmux, sessionName, agentOverride string)
 			}
 			rc, _, err := config.ResolveAgentConfigWithOverride(townRoot, rigPath, currentAgent)
 			if err == nil {
-				resolved := config.ResolveProcessNames(currentAgent, rc.Command)
+				resolved := config.ResolveProcessNames(currentAgent, rc.Command, rc.Args...)
 				processNames = strings.Join(resolved, ",")
 			}
 		}

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -895,16 +895,20 @@ func extractWrappedBinary(wrapper string, args []string) string {
 // "opencode" instead of the built-in "codex" binary), and custom agents wrapped
 // in process launchers like `env -u VAR <real-binary>`.
 //
+// args (variadic, optional) is the actual command-line argument slice for the
+// agent invocation. When command is a wrapper (env, sudo, nohup, ...), the
+// real binary is found in args, not on the registered preset's Args (which
+// may belong to the canonical built-in preset, not the user's wrapper).
+//
 // Resolution order:
 //  1. If agentName matches a built-in preset AND the preset's Command matches
 //     the actual command → use the preset's ProcessNames (no mismatch).
-//  2. If the resolved command is a known wrapper (env, sudo, nohup, ...) and
-//     the registered agent has Args, scan the args for the real binary and
-//     resolve to its preset's ProcessNames.
+//  2. If command is a known wrapper, scan args (or the registered preset's Args
+//     as a fallback) for the real binary and resolve to its preset's ProcessNames.
 //  3. Otherwise, find a built-in preset whose Command matches the actual command
 //     and use its ProcessNames (custom agent using a known launcher).
 //  4. Fallback: [command] (fully custom binary).
-func ResolveProcessNames(agentName, command string) []string {
+func ResolveProcessNames(agentName, command string, args ...string) []string {
 	registryMu.Lock()
 	initRegistryLocked()
 	defer registryMu.Unlock()
@@ -922,7 +926,8 @@ func ResolveProcessNames(agentName, command string) []string {
 	// Check if agentName matches a built-in/registered preset with matching command.
 	// Compare against both the raw command and basename to handle registry entries
 	// that store absolute-path commands (e.g., "/opt/bin/my-tool").
-	if info, ok := globalRegistry.Agents[agentName]; ok {
+	info, infoOK := globalRegistry.Agents[agentName]
+	if infoOK {
 		if len(info.ProcessNames) > 0 &&
 			(info.Command == command ||
 				info.Command == cmdBase ||
@@ -931,18 +936,26 @@ func ResolveProcessNames(agentName, command string) []string {
 				cmdBase == "") {
 			return info.ProcessNames
 		}
-		// Wrapper case: agent's Command is `env`/`sudo`/etc. — find the real
-		// binary in Args and resolve to ITS preset's ProcessNames. Try the
-		// runtime registry first; fall back to builtinPresets if the user has
-		// shadowed the canonical preset (e.g., custom "claude" agent that
-		// wraps the real claude binary).
-		if wrapperCommands[cmdBase] && len(info.Args) > 0 {
-			if realBin := extractWrappedBinary(cmdBase, info.Args); realBin != "" {
-				if names := lookupProcessNamesByBinary(realBin); len(names) > 0 {
-					return names
-				}
-				return []string{realBin}
+	}
+
+	// Wrapper case: command is `env`/`sudo`/etc. — find the real binary in
+	// args (caller-supplied) or the registered preset's Args, and resolve to
+	// THAT binary's preset ProcessNames. Caller args take precedence because
+	// the registered preset may be the canonical built-in (not the wrapper).
+	if wrapperCommands[cmdBase] {
+		argSources := [][]string{args}
+		if infoOK && len(info.Args) > 0 {
+			argSources = append(argSources, info.Args)
+		}
+		for _, src := range argSources {
+			realBin := extractWrappedBinary(cmdBase, src)
+			if realBin == "" {
+				continue
 			}
+			if names := lookupProcessNamesByBinary(realBin); len(names) > 0 {
+				return names
+			}
+			return []string{realBin}
 		}
 	}
 

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -790,17 +790,120 @@ func GetProcessNames(agentName string) []string {
 	return info.ProcessNames
 }
 
+// wrapperCommands lists process wrappers that exec into another binary listed
+// in their arguments (e.g., `env -u VAR claude ...`). When the agent's Command
+// is one of these, ResolveProcessNames must look past the wrapper to find the
+// real agent binary in Args, otherwise liveness detection greps for a process
+// named after the wrapper that no longer exists post-exec.
+var wrapperCommands = map[string]bool{
+	"env":    true,
+	"nohup":  true,
+	"setsid": true,
+	"exec":   true,
+	"sudo":   true,
+	"doas":   true,
+	"stdbuf": true,
+	"time":   true,
+}
+
+// wrapperFlagsTakeValue returns the set of short flags that consume the
+// next argument as a value, for the given wrapper. Used by extractWrappedBinary
+// to skip "-flag value" pairs when scanning args for the real binary.
+func wrapperFlagsTakeValue(wrapper string) map[string]bool {
+	switch wrapper {
+	case "env":
+		// env: -u VAR (unset), -C DIR (chdir), -S STRING (split-string)
+		return map[string]bool{"-u": true, "-C": true, "-S": true}
+	case "sudo":
+		// sudo: most options take a value; list the common ones
+		return map[string]bool{
+			"-u": true, "-g": true, "-h": true, "-p": true,
+			"-U": true, "-A": true, "-c": true, "-r": true,
+			"-t": true, "-T": true, "-D": true, "-R": true,
+		}
+	case "stdbuf":
+		// stdbuf: -i, -o, -e all take a value (mode)
+		return map[string]bool{"-i": true, "-o": true, "-e": true}
+	}
+	return nil
+}
+
+// lookupProcessNamesByBinary returns the ProcessNames of the preset whose
+// Command (or its basename) matches realBin. Searches the runtime registry
+// first, then the canonical builtinPresets so shadowed builtins still resolve.
+// Caller must hold registryMu.
+func lookupProcessNamesByBinary(realBin string) []string {
+	for _, preset := range globalRegistry.Agents {
+		if len(preset.ProcessNames) == 0 {
+			continue
+		}
+		if preset.Command == realBin || filepath.Base(preset.Command) == realBin {
+			return preset.ProcessNames
+		}
+	}
+	for _, preset := range builtinPresets {
+		if len(preset.ProcessNames) == 0 {
+			continue
+		}
+		if preset.Command == realBin || filepath.Base(preset.Command) == realBin {
+			return preset.ProcessNames
+		}
+	}
+	return nil
+}
+
+// extractWrappedBinary scans wrapper args for the first non-flag token that
+// looks like a binary, and returns its basename. Returns "" if no real binary
+// is found (e.g., args malformed or wrapper unsupported).
+//
+// Walks args left-to-right: skips short flags (and their values for known
+// value-taking flags), long flags (--foo=bar or --foo), env-style VAR=value
+// assignments (env only), and treats `--` as an end-of-options separator.
+func extractWrappedBinary(wrapper string, args []string) string {
+	flagsTakeValue := wrapperFlagsTakeValue(wrapper)
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if a == "--" {
+			if i+1 < len(args) {
+				return filepath.Base(args[i+1])
+			}
+			return ""
+		}
+		if strings.HasPrefix(a, "-") && a != "-" {
+			// Long option `--foo=bar` carries its own value
+			if strings.HasPrefix(a, "--") && strings.Contains(a, "=") {
+				continue
+			}
+			// Long option `--foo` and unknown short options: assume no value
+			if flagsTakeValue[a] && i+1 < len(args) {
+				i++ // skip the flag's value
+			}
+			continue
+		}
+		// env permits VAR=value assignments interspersed with flags
+		if wrapper == "env" && strings.Contains(a, "=") {
+			continue
+		}
+		return filepath.Base(a)
+	}
+	return ""
+}
+
 // ResolveProcessNames determines the correct process names for liveness detection
 // given an agent name and the actual command binary. This handles custom agents
 // that shadow built-in preset names (e.g., a custom "codex" agent that runs
-// "opencode" instead of the built-in "codex" binary).
+// "opencode" instead of the built-in "codex" binary), and custom agents wrapped
+// in process launchers like `env -u VAR <real-binary>`.
 //
 // Resolution order:
 //  1. If agentName matches a built-in preset AND the preset's Command matches
 //     the actual command → use the preset's ProcessNames (no mismatch).
-//  2. Otherwise, find a built-in preset whose Command matches the actual command
+//  2. If the resolved command is a known wrapper (env, sudo, nohup, ...) and
+//     the registered agent has Args, scan the args for the real binary and
+//     resolve to its preset's ProcessNames.
+//  3. Otherwise, find a built-in preset whose Command matches the actual command
 //     and use its ProcessNames (custom agent using a known launcher).
-//  3. Fallback: [command] (fully custom binary).
+//  4. Fallback: [command] (fully custom binary).
 func ResolveProcessNames(agentName, command string) []string {
 	registryMu.Lock()
 	initRegistryLocked()
@@ -819,13 +922,27 @@ func ResolveProcessNames(agentName, command string) []string {
 	// Check if agentName matches a built-in/registered preset with matching command.
 	// Compare against both the raw command and basename to handle registry entries
 	// that store absolute-path commands (e.g., "/opt/bin/my-tool").
-	if info, ok := globalRegistry.Agents[agentName]; ok && len(info.ProcessNames) > 0 {
-		if info.Command == command ||
-			info.Command == cmdBase ||
-			filepath.Base(info.Command) == cmdBase ||
-			(info.Command == unwrappedCmdBase && strings.HasPrefix(cmdBase, "gt-")) ||
-			cmdBase == "" {
+	if info, ok := globalRegistry.Agents[agentName]; ok {
+		if len(info.ProcessNames) > 0 &&
+			(info.Command == command ||
+				info.Command == cmdBase ||
+				filepath.Base(info.Command) == cmdBase ||
+				(info.Command == unwrappedCmdBase && strings.HasPrefix(cmdBase, "gt-")) ||
+				cmdBase == "") {
 			return info.ProcessNames
+		}
+		// Wrapper case: agent's Command is `env`/`sudo`/etc. — find the real
+		// binary in Args and resolve to ITS preset's ProcessNames. Try the
+		// runtime registry first; fall back to builtinPresets if the user has
+		// shadowed the canonical preset (e.g., custom "claude" agent that
+		// wraps the real claude binary).
+		if wrapperCommands[cmdBase] && len(info.Args) > 0 {
+			if realBin := extractWrappedBinary(cmdBase, info.Args); realBin != "" {
+				if names := lookupProcessNamesByBinary(realBin); len(names) > 0 {
+					return names
+				}
+				return []string{realBin}
+			}
 		}
 	}
 

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -422,6 +422,94 @@ func TestResolveProcessNames(t *testing.T) {
 			}
 		}
 	})
+
+	// Regression: custom agents wrapped in `env -u VAR <real-binary>` (or
+	// nohup/sudo/etc.) used to fall through to GT_PROCESS_NAMES=<wrapper>,
+	// which IsAgentAlive could never match — wrapper has exec'd into the real
+	// binary by then. ResolveProcessNames must look past the wrapper.
+	wrapperCases := []struct {
+		name    string
+		agent   AgentPresetInfo
+		want    []string
+		command string // command passed to ResolveProcessNames
+	}{
+		{
+			name: "env -u VAR claude unwraps to claude preset",
+			agent: AgentPresetInfo{
+				Name:    "claude",
+				Command: "env",
+				Args:    []string{"-u", "ANTHROPIC_API_KEY", "claude", "--dangerously-skip-permissions", "--effort", "high"},
+			},
+			command: "env",
+			want:    []string{"node", "claude"},
+		},
+		{
+			name: "env VAR=val claude unwraps past assignments",
+			agent: AgentPresetInfo{
+				Name:    "claude",
+				Command: "env",
+				Args:    []string{"FOO=bar", "BAZ=qux", "claude"},
+			},
+			command: "env",
+			want:    []string{"node", "claude"},
+		},
+		{
+			name: "env -- claude (separator) unwraps to claude",
+			agent: AgentPresetInfo{
+				Name:    "claude",
+				Command: "env",
+				Args:    []string{"-i", "--", "claude", "--foo"},
+			},
+			command: "env",
+			want:    []string{"node", "claude"},
+		},
+		{
+			name: "nohup opencode unwraps to opencode preset",
+			agent: AgentPresetInfo{
+				Name:    "opencode",
+				Command: "nohup",
+				Args:    []string{"opencode", "--quiet"},
+			},
+			command: "nohup",
+			want:    []string{"opencode", "node", "bun"},
+		},
+		{
+			name: "sudo -u runner codex unwraps to codex preset",
+			agent: AgentPresetInfo{
+				Name:    "codex",
+				Command: "sudo",
+				Args:    []string{"-u", "runner", "codex", "--dangerously-bypass-approvals-and-sandbox"},
+			},
+			command: "sudo",
+			want:    []string{"codex"},
+		},
+		{
+			name: "env wrapping unknown binary returns binary basename",
+			agent: AgentPresetInfo{
+				Name:    "my-agent",
+				Command: "env",
+				Args:    []string{"-u", "FOO", "/opt/my-tool", "--flag"},
+			},
+			command: "env",
+			want:    []string{"my-tool"},
+		},
+	}
+	for _, tc := range wrapperCases {
+		t.Run(tc.name, func(t *testing.T) {
+			RegisterAgentForTesting(string(tc.agent.Name), tc.agent)
+			t.Cleanup(ResetRegistryForTesting)
+
+			got := ResolveProcessNames(string(tc.agent.Name), tc.command)
+			if len(got) != len(tc.want) {
+				t.Fatalf("ResolveProcessNames(%q, %q) = %v, want %v", tc.agent.Name, tc.command, got, tc.want)
+			}
+			for i := range got {
+				if got[i] != tc.want[i] {
+					t.Errorf("got[%d] = %q, want %q", i, got[i], tc.want[i])
+				}
+			}
+		})
+	}
 }
 
 func TestAgentPresetApprovalFlags(t *testing.T) {

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -499,7 +499,7 @@ func TestResolveProcessNames(t *testing.T) {
 			RegisterAgentForTesting(string(tc.agent.Name), tc.agent)
 			t.Cleanup(ResetRegistryForTesting)
 
-			got := ResolveProcessNames(string(tc.agent.Name), tc.command)
+			got := ResolveProcessNames(string(tc.agent.Name), tc.command, tc.agent.Args...)
 			if len(got) != len(tc.want) {
 				t.Fatalf("ResolveProcessNames(%q, %q) = %v, want %v", tc.agent.Name, tc.command, got, tc.want)
 			}
@@ -510,6 +510,28 @@ func TestResolveProcessNames(t *testing.T) {
 			}
 		})
 	}
+
+	// Real-world scenario: Paul's town settings shadow the canonical claude
+	// preset with a wrapper. The registry still holds the built-in claude
+	// preset; Args live only on the caller's RuntimeConfig. Caller args must
+	// take precedence so wrapper-unwrap finds the real binary.
+	t.Run("caller args used when registry holds canonical preset", func(t *testing.T) {
+		ResetRegistryForTesting()
+		t.Cleanup(ResetRegistryForTesting)
+		// No RegisterAgentForTesting — registry has canonical built-in claude
+		// (Command="claude", ProcessNames=[node, claude], Args=[--dangerously-...]).
+		got := ResolveProcessNames("claude", "env",
+			"-u", "ANTHROPIC_API_KEY", "claude", "--dangerously-skip-permissions", "--effort", "high")
+		want := []string{"node", "claude"}
+		if len(got) != len(want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+		for i := range got {
+			if got[i] != want[i] {
+				t.Errorf("got[%d] = %q, want %q", i, got[i], want[i])
+			}
+		}
+	})
 }
 
 func TestAgentPresetApprovalFlags(t *testing.T) {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -2275,8 +2275,9 @@ func BuildStartupCommand(envVars map[string]string, rigPath, prompt string) stri
 	}
 	// Set GT_PROCESS_NAMES for accurate liveness detection. Custom agents may
 	// shadow built-in preset names (e.g., custom "codex" running "opencode"),
-	// so we resolve process names from both agent name and actual command.
-	processNames := ResolveProcessNames(rc.ResolvedAgent, rc.Command)
+	// or wrap the real binary with a launcher (e.g., `env -u VAR claude ...`).
+	// Pass rc.Args so wrapper-unwrap can find the real binary.
+	processNames := ResolveProcessNames(rc.ResolvedAgent, rc.Command, rc.Args...)
 	resolvedEnv["GT_PROCESS_NAMES"] = strings.Join(processNames, ",")
 	// Merge agent-specific env vars (e.g., OPENCODE_PERMISSION for yolo mode)
 	for k, v := range rc.Env {
@@ -2529,7 +2530,9 @@ func BuildStartupCommandWithAgentOverride(envVars map[string]string, rigPath, pr
 		resolvedEnv["GT_AGENT"] = rc.ResolvedAgent
 	}
 	// Set GT_PROCESS_NAMES for accurate liveness detection of custom agents.
-	processNamesOverride := ResolveProcessNames(agentForProcess, rc.Command)
+	// Pass rc.Args so wrapper-unwrap (env/sudo/nohup wrapping a real binary)
+	// can find the real agent binary.
+	processNamesOverride := ResolveProcessNames(agentForProcess, rc.Command, rc.Args...)
 	resolvedEnv["GT_PROCESS_NAMES"] = strings.Join(processNamesOverride, ",")
 	// Merge agent-specific env vars (e.g., OPENCODE_PERMISSION for yolo mode)
 	for k, v := range rc.Env {

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -471,7 +471,7 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 	envVars["GT_TOWN_ROOT"] = townRoot
 	envVars["GT_RUN"] = runID
 	envVars["POLECAT_SLOT"] = fmt.Sprintf("%d", m.polecatSlot(polecat))
-	envVars["GT_PROCESS_NAMES"] = strings.Join(config.ResolveProcessNames(runtimeConfig.ResolvedAgent, runtimeConfig.Command), ",")
+	envVars["GT_PROCESS_NAMES"] = strings.Join(config.ResolveProcessNames(runtimeConfig.ResolvedAgent, runtimeConfig.Command, runtimeConfig.Args...), ",")
 	if polecatGitBranch != "" {
 		envVars["GT_BRANCH"] = polecatGitBranch
 	}

--- a/internal/session/lifecycle.go
+++ b/internal/session/lifecycle.go
@@ -391,17 +391,19 @@ func MergeRuntimeLivenessEnv(envVars map[string]string, runtimeConfig *config.Ru
 	if _, hasProcessNames := envVars["GT_PROCESS_NAMES"]; !hasProcessNames {
 		agentForLookup := runtimeConfig.ResolvedAgent
 		commandForLookup := runtimeConfig.Command
+		argsForLookup := runtimeConfig.Args
 		if existing, ok := envVars["GT_AGENT"]; ok && existing != "" {
 			agentForLookup = existing
 			// When GT_AGENT was set by AgentOverride (differs from the
-			// workspace-resolved agent), the runtimeConfig.Command belongs
-			// to the workspace agent, not the override. Pass empty command
-			// so ResolveProcessNames uses the preset's own command.
+			// workspace-resolved agent), the runtimeConfig.Command/Args
+			// belong to the workspace agent, not the override. Pass empty
+			// command so ResolveProcessNames uses the preset's own command.
 			if existing != runtimeConfig.ResolvedAgent {
 				commandForLookup = ""
+				argsForLookup = nil
 			}
 		}
-		processNames := config.ResolveProcessNames(agentForLookup, commandForLookup)
+		processNames := config.ResolveProcessNames(agentForLookup, commandForLookup, argsForLookup...)
 		if len(processNames) > 0 {
 			envVars["GT_PROCESS_NAMES"] = strings.Join(processNames, ",")
 		}


### PR DESCRIPTION
## Summary

- Refreshes the original fix from #3714 onto current `main` as a clean replacement branch
- Resolves wrapped-agent process names using the actual agent command and args so liveness/session detection follows the real long-running binary
- Keeps the change focused to config/session process-name resolution only

## Credit

This replacement PR is based on the original investigation and fix in #3714 by @certivpaul.

## Why This Replacement Exists

The original PR identified a real infrastructure bug, but the original branch is conflict-dirty now. This replacement branch is a cleaner current-main version from our fork so we can review and land the narrow fix on top of the latest upstream state.

## Validation

- `go test ./internal/config -run TestResolveProcessNames -count=1`
- `go build ./cmd/gt`
