### PR TITLE
fix(protocol): isolate NotifyMergeOutcome tests from production mail

### DIFF
--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -709,22 +709,30 @@ func TestDefaultRefineryHandler_HandleMergeReady(t *testing.T) {
 
 func TestDefaultRefineryHandler_NotifyMergeOutcome_Success(t *testing.T) {
 	tmpDir := t.TempDir()
+	// Prevent detectTownRoot from finding the real town via GT_TOWN_ROOT/GT_ROOT.
+	// Without this, NewRouter falls back to the production beads and delivers
+	// synthetic "MERGED nux" messages to the live mail system during test runs.
+	t.Setenv("GT_TOWN_ROOT", tmpDir)
+	t.Setenv("GT_ROOT", tmpDir)
 	handler := NewRefineryHandler("gastown", tmpDir)
+	handler.Router = mail.NewRouterWithTownRoot(tmpDir, "")
 
 	outcome := MergeOutcome{
 		Success:     true,
 		MergeCommit: "abc123",
 	}
 
-	// SendMerged will fail (no mail setup) but we're testing the routing logic
+	// Testing routing logic only — delivery will fail (no .beads in tmpDir)
 	err := handler.NotifyMergeOutcome("nux", "polecat/nux/gt-abc", "gt-abc", "main", outcome)
-	// Error is expected because mail router has no valid config in tmpdir
 	_ = err
 }
 
 func TestDefaultRefineryHandler_NotifyMergeOutcome_Conflict(t *testing.T) {
 	tmpDir := t.TempDir()
+	t.Setenv("GT_TOWN_ROOT", tmpDir)
+	t.Setenv("GT_ROOT", tmpDir)
 	handler := NewRefineryHandler("gastown", tmpDir)
+	handler.Router = mail.NewRouterWithTownRoot(tmpDir, "")
 
 	outcome := MergeOutcome{
 		Success:       false,
@@ -738,7 +746,10 @@ func TestDefaultRefineryHandler_NotifyMergeOutcome_Conflict(t *testing.T) {
 
 func TestDefaultRefineryHandler_NotifyMergeOutcome_Failure(t *testing.T) {
 	tmpDir := t.TempDir()
+	t.Setenv("GT_TOWN_ROOT", tmpDir)
+	t.Setenv("GT_ROOT", tmpDir)
 	handler := NewRefineryHandler("gastown", tmpDir)
+	handler.Router = mail.NewRouterWithTownRoot(tmpDir, "")
 
 	outcome := MergeOutcome{
 		Success:     false,


### PR DESCRIPTION
## Summary

Three `TestDefaultRefineryHandler_NotifyMergeOutcome_*` tests in `internal/protocol/protocol_test.go` were silently delivering synthetic protocol messages (`MERGED nux`, `REWORK_REQUEST nux`, etc.) to the live production mail system on every `go test` run.

**Root cause:** `NewRefineryHandler("gastown", tmpDir)` calls `mail.NewRouter(tmpDir)`, which calls `detectTownRoot(tmpDir)`. For a `/tmp/...` path, `workspace.Find` finds nothing — but `detectTownRoot` then falls back to the `GT_TOWN_ROOT`/`GT_ROOT` env vars. In any Gas Town agent session these vars point to the real town root, so the router silently used production beads. The test comment "Error is expected because mail router has no valid config in tmpdir" was incorrect: delivery succeeded.

Spotted by the refinery and witness, who both started seeing recurring `MERGED nux` / `REWORK_REQUEST nux` messages referencing placeholder branch `polecat/nux/gt-abc` and merge commit `abc123`.

## Fix

Two-layer isolation for each affected test:

1. `t.Setenv("GT_TOWN_ROOT", tmpDir)` and `t.Setenv("GT_ROOT", tmpDir)` — neutralises the env-var fallback in `detectTownRoot` for the duration of the test.
2. `handler.Router = mail.NewRouterWithTownRoot(tmpDir, "")` — explicitly replaces the router with one that has no town root, so `resolveBeadsDir` returns `tmpDir/.beads` (non-existent) regardless of env state.

Both layers are belt-and-suspenders. Either alone would prevent production delivery; together they make the isolation explicit and unconditional.

## Test plan

- [x] `go test ./internal/protocol/...` — green after fix
- [x] Verified no synthetic messages appear in production beads after fix applied (refinery/witness noise stops)
- [x] The three fixed tests still exercise the routing logic (which outcome branch is taken) — the test assertions are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3811"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->