### PR TITLE
fix(convoy): bdListChildren falls back to deps table (#3700)

### DIFF
--- a/internal/cmd/bd_list_children_fallback_test.go
+++ b/internal/cmd/bd_list_children_fallback_test.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// TestBdListChildren_FallsBackToDepsTable is the regression test for GH #3700:
+// `gt mountain <epic>` failed with "no slingable tasks in DAG" because
+// `bd list --parent=<epic>` returned `[]` even though parent-child links
+// existed. The deps table query (`bd sql ... type='parent-child'`) is
+// authoritative; the new fallback in bdListChildren consults it whenever
+// the primary --parent index returns empty.
+func TestBdListChildren_FallsBackToDepsTable(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows — shell stub")
+	}
+
+	townRoot, _ := makeRoutingTownWorkspace(t)
+
+	// Route the "ha-" prefix to a rig directory so beadsDirForID can resolve.
+	routes := `{"prefix":"ha-","path":"happyhour"}` + "\n"
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"),
+		[]byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "happyhour", ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+
+	chdirConvoyTest(t, townRoot)
+
+	// bd stub:
+	//   list --parent=ha-epic   → []   (the buggy/empty primary path)
+	//   sql "...parent-child..." → child IDs (the authoritative deps table)
+	//   show ha-c1 / ha-c2      → child rows
+	scriptBody := `
+case "$*" in
+  *"list --parent=ha-epic"*)
+    echo '[]'
+    ;;
+  *"sql"*"parent-child"*"--json"*)
+    # bd sql --json returns rows as a JSON array of {col: val} maps
+    echo '[{"depends_on_id":"ha-c1"},{"depends_on_id":"ha-c2"}]'
+    ;;
+  "show ha-c1 --json")
+    echo '[{"id":"ha-c1","title":"Child one","status":"open","issue_type":"task"}]'
+    ;;
+  "show ha-c2 --json")
+    echo '[{"id":"ha-c2","title":"Child two","status":"open","issue_type":"task"}]'
+    ;;
+  "--allow-stale version")
+    exit 0
+    ;;
+  *)
+    echo "unexpected bd invocation: $*" >&2
+    exit 1
+    ;;
+esac
+`
+	writeRoutingBdStub(t, scriptBody)
+
+	got, err := bdListChildren("ha-epic")
+	if err != nil {
+		t.Fatalf("bdListChildren error: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 children from deps fallback, got %d: %+v", len(got), got)
+	}
+	seen := map[string]bool{}
+	for _, c := range got {
+		seen[c.ID] = true
+	}
+	if !seen["ha-c1"] || !seen["ha-c2"] {
+		t.Errorf("expected children ha-c1 and ha-c2, got %v", seen)
+	}
+}
+
+// TestBdListChildren_PrimaryPathStillUsed verifies the fallback only kicks in
+// when the primary `bd list --parent` path returns empty. When --parent
+// returns rows directly, we use them and never invoke the SQL fallback.
+func TestBdListChildren_PrimaryPathStillUsed(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows — shell stub")
+	}
+
+	townRoot, _ := makeRoutingTownWorkspace(t)
+	routes := `{"prefix":"ha-","path":"happyhour"}` + "\n"
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"),
+		[]byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "happyhour", ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+	chdirConvoyTest(t, townRoot)
+
+	scriptBody := `
+case "$*" in
+  *"list --parent=ha-epic"*)
+    echo '[{"id":"ha-direct","title":"Direct child","status":"open","issue_type":"task"}]'
+    ;;
+  *"sql"*)
+    echo "fallback was called when primary returned rows" >&2
+    exit 1
+    ;;
+  *)
+    echo "unexpected bd invocation: $*" >&2
+    exit 1
+    ;;
+esac
+`
+	writeRoutingBdStub(t, scriptBody)
+
+	got, err := bdListChildren("ha-epic")
+	if err != nil {
+		t.Fatalf("bdListChildren error: %v", err)
+	}
+	if len(got) != 1 || got[0].ID != "ha-direct" {
+		t.Fatalf("expected single ha-direct child from primary path, got %+v", got)
+	}
+}

--- a/internal/cmd/convoy_stage.go
+++ b/internal/cmd/convoy_stage.go
@@ -1491,6 +1491,12 @@ func bdDepList(beadID string) ([]bdDepResult, error) {
 // bd list is CWD-sensitive — it only searches the beads database in the current
 // directory. We resolve the correct .beads directory from the bead's prefix via
 // routes.jsonl so this works regardless of the caller's working directory.
+//
+// When the `--parent` index returns no rows, we fall back to a direct query
+// against the dependencies table (parent-child links) and resolve each child
+// via bdShow. This handles the case (GH #3700) where the index used by
+// `bd list --parent` doesn't see children that were added via `bd dep add ...
+// --type=parent-child`. The deps table is authoritative.
 func bdListChildren(parentID string) ([]bdShowResult, error) {
 	cmd := exec.Command("bd", "list", "--parent="+parentID, "--json")
 	// Route to the correct rig database via prefix resolution.
@@ -1507,10 +1513,10 @@ func bdListChildren(parentID string) ([]bdShowResult, error) {
 		return nil, fmt.Errorf("bd list --parent=%s: %w", parentID, err)
 	}
 
-	// Handle empty output (no children).
+	// Handle empty output (no children) — try the deps-table fallback first.
 	trimmed := strings.TrimSpace(string(out))
 	if trimmed == "" || trimmed == "[]" {
-		return nil, nil
+		return bdListChildrenViaDeps(parentID)
 	}
 
 	var results []bdShowResult
@@ -1518,6 +1524,41 @@ func bdListChildren(parentID string) ([]bdShowResult, error) {
 		return nil, fmt.Errorf("bd list --parent=%s: parse JSON: %w (raw: %s)", parentID, err, out)
 	}
 
+	return results, nil
+}
+
+// bdListChildrenViaDeps resolves children by querying the dependencies table
+// directly for parent-child links, then loading each child via bdShow.
+//
+// Used as a fallback when `bd list --parent=<id>` returns empty even though
+// children exist (GH #3700). Returns nil (not an error) when the prefix can't
+// be resolved or no parent-child deps exist.
+func bdListChildrenViaDeps(parentID string) ([]bdShowResult, error) {
+	beadsDir := beadsDirForID(parentID)
+	if beadsDir == "" {
+		// Can't resolve the rig; nothing more we can do.
+		return nil, nil
+	}
+
+	// Production data stores parent-child as (issue_id=parent, depends_on_id=child).
+	// "down" returns depends_on_id rows where issue_id = parentID — i.e., the
+	// epic's children. See `bd dep list <epic>` in the bug report.
+	childIDs, err := bdDepListRawIDs(beadsDir, parentID, "down", "parent-child")
+	if err != nil {
+		return nil, nil // best-effort — caller still gets the empty primary result
+	}
+	if len(childIDs) == 0 {
+		return nil, nil
+	}
+
+	results := make([]bdShowResult, 0, len(childIDs))
+	for _, id := range childIDs {
+		child, err := bdShow(id)
+		if err != nil || child == nil {
+			continue
+		}
+		results = append(results, *child)
+	}
 	return results, nil
 }
 


### PR DESCRIPTION
## Summary

`gt mountain <epic>` and `gt convoy create --from-epic <epic>` failed with "no slingable tasks in DAG" when the epic had children added via `bd dep add ... --type=parent-child`. Root cause: `bdListChildren` only asked `bd list --parent=<id>`, whose underlying index can return empty for links the dependencies table actually holds. The bug repro from #3700 hits exactly this path.

When the primary `--parent` query returns empty, fall back to a direct query against the dependencies table for parent-child rows, then load each child via `bdShow`. The deps table is authoritative; the fallback only kicks in when the primary returns nothing, so existing behavior is unchanged for healthy data.

Both call sites benefit: `collectEpicBeads` in `convoy_stage.go` (the mountain BFS) and `collectEpicChildren` in `convoy.go` (the convoy `--from-epic` BFS).

## Test plan

- [x] `go test -run 'TestBdListChildren_' ./internal/cmd/` — both new tests pass
- [x] `go test -run 'TestBdListChildren|TestCollectEpicBeads|TestCollectEpicChildren|TestStrandedScan|TestRunConvoyList|TestConvoyStage_' ./internal/cmd/` — no regressions in adjacent suites
- [x] `go build ./...` clean, `go vet ./internal/cmd/...` clean
- [ ] Manual: `gt mountain <real-epic>` on a workspace exhibiting #3700

### New tests

- `TestBdListChildren_FallsBackToDepsTable` — primary returns `[]`, SQL fallback returns `ha-c1` + `ha-c2`, `bdShow` lookups succeed, both children flow through.
- `TestBdListChildren_PrimaryPathStillUsed` — primary returns rows, SQL is never invoked (the stub fails the test if it is). Confirms the change doesn't add overhead to healthy queries.

Closes #3700.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3815"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->