### PR TITLE
fix(doctor): role-aware Stop hook check for polecats (#3648)

### DIFF
--- a/internal/doctor/claude_settings_check.go
+++ b/internal/doctor/claude_settings_check.go
@@ -527,9 +527,16 @@ func (c *ClaudeSettingsCheck) findSettingsFiles(townRoot string) []staleSettings
 }
 
 // checkSettings compares a settings file against the expected template.
-// Returns a list of what's missing.
-// agentType is reserved for future role-specific validation.
-func (c *ClaudeSettingsCheck) checkSettings(path, _ string) []string {
+// Returns a list of what's missing. Stop-hook expectations are role-specific
+// to match the canonical hook templates in internal/hooks/config.go (#3648):
+//
+//   - polecat → `gt tap polecat-stop-check` (idle-polecat catcher)
+//   - everyone else → `gt costs record` (autonomous cost accounting)
+//
+// Without this, doctor never converged for polecats: hooks sync wrote
+// polecat-stop-check, doctor demanded costs record, fix deleted the file,
+// the daemon recreated the same polecat-stop-check file, repeat forever.
+func (c *ClaudeSettingsCheck) checkSettings(path, agentType string) []string {
 	var missing []string
 
 	// Read the actual settings
@@ -547,7 +554,7 @@ func (c *ClaudeSettingsCheck) checkSettings(path, _ string) []string {
 	// All templates should have:
 	// 1. enabledPlugins
 	// 2. SessionStart hook with prime --hook
-	// 3. Stop hook with gt costs record (for autonomous)
+	// 3. Stop hook (role-specific pattern — see expectedStopPattern)
 	// Check enabledPlugins
 	if _, ok := actual["enabledPlugins"]; !ok {
 		missing = append(missing, "enabledPlugins")
@@ -564,12 +571,25 @@ func (c *ClaudeSettingsCheck) checkSettings(path, _ string) []string {
 		missing = append(missing, "SessionStart hook (prime --hook)")
 	}
 
-	// Check Stop hook exists with costs record (for all roles)
-	if !c.hookHasPattern(hooks, "Stop", "costs record") {
-		missing = append(missing, "Stop hook")
+	// Check Stop hook against the expected pattern for this role.
+	expected := expectedStopPattern(agentType)
+	if !c.hookHasPattern(hooks, "Stop", expected) {
+		missing = append(missing, fmt.Sprintf("Stop hook (%s)", expected))
 	}
 
 	return missing
+}
+
+// expectedStopPattern returns the substring that should appear in the role's
+// Stop hook command. Mirrors the templates in internal/hooks/config.go's
+// DefaultOverrides — when those change, this must change too.
+func expectedStopPattern(agentType string) string {
+	switch agentType {
+	case "polecat", "polecats":
+		return "polecat-stop-check"
+	default:
+		return "costs record"
+	}
 }
 
 // getGitFileStatus determines the git status of a file.

--- a/internal/doctor/claude_settings_check_test.go
+++ b/internal/doctor/claude_settings_check_test.go
@@ -81,6 +81,52 @@ func createValidSettings(t *testing.T, path string) {
 	}
 }
 
+// createValidPolecatSettings creates a polecat settings file whose Stop hook
+// invokes `gt tap polecat-stop-check`, matching the canonical template in
+// internal/hooks/config.go DefaultOverrides()["polecats"].
+func createValidPolecatSettings(t *testing.T, path string) {
+	t.Helper()
+
+	settings := map[string]any{
+		"enabledPlugins": []string{"plugin1"},
+		"hooks": map[string]any{
+			"SessionStart": []any{
+				map[string]any{
+					"matcher": "**",
+					"hooks": []any{
+						map[string]any{
+							"type":    "command",
+							"command": "/usr/local/bin/gt prime --hook",
+						},
+					},
+				},
+			},
+			"Stop": []any{
+				map[string]any{
+					"matcher": "",
+					"hooks": []any{
+						map[string]any{
+							"type":    "command",
+							"command": `export PATH="$HOME/go/bin:$HOME/.local/bin:$PATH" && gt tap polecat-stop-check`,
+						},
+					},
+				},
+			},
+		},
+	}
+
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		t.Fatal(err)
+	}
+	data, err := json.MarshalIndent(settings, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+}
+
 // createStaleSettings creates a settings file missing required elements.
 func createStaleSettings(t *testing.T, path string, missingElements ...string) {
 	t.Helper()
@@ -251,9 +297,11 @@ func TestClaudeSettingsCheck_ValidPolecatSettings(t *testing.T) {
 	rigName := "testrig"
 
 	// Create valid polecat settings in correct location (polecats/.claude/settings.json)
-	// Settings are now shared at the polecats parent directory, passed via --settings flag.
+	// with the polecat-specific Stop hook (`gt tap polecat-stop-check`) — see
+	// internal/hooks/config.go DefaultOverrides()["polecats"]. The check
+	// recognizes role-specific Stop patterns (#3648).
 	pcSettings := filepath.Join(tmpDir, rigName, "polecats", ".claude", "settings.json")
-	createValidSettings(t, pcSettings)
+	createValidPolecatSettings(t, pcSettings)
 
 	check := NewClaudeSettingsCheck()
 	ctx := &CheckContext{TownRoot: tmpDir}
@@ -262,6 +310,67 @@ func TestClaudeSettingsCheck_ValidPolecatSettings(t *testing.T) {
 
 	if result.Status != StatusOK {
 		t.Errorf("expected StatusOK for valid polecat settings, got %v: %s", result.Status, result.Message)
+	}
+}
+
+// TestClaudeSettingsCheck_PolecatStopHookRecognized is the regression test for
+// #3648: doctor's claude-settings check used to expect `costs record` in the
+// Stop hook for *all* roles, but the polecat hooks template installs
+// `gt tap polecat-stop-check`. Result: doctor reported polecat settings as
+// stale, --fix deleted them, the daemon recreated the same file, and the
+// check never converged. The fix recognizes role-specific Stop patterns.
+func TestClaudeSettingsCheck_PolecatStopHookRecognized(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+
+	pcSettings := filepath.Join(tmpDir, rigName, "polecats", ".claude", "settings.json")
+	createValidPolecatSettings(t, pcSettings)
+
+	check := NewClaudeSettingsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Fatalf("polecat settings with `gt tap polecat-stop-check` should pass; got %v: %s\nDetails: %v",
+			result.Status, result.Message, result.Details)
+	}
+
+	// Witness role should still expect `costs record` — verify the role-aware
+	// pattern didn't break the canonical case.
+	witnessSettings := filepath.Join(tmpDir, rigName, "witness", ".claude", "settings.json")
+	createValidSettings(t, witnessSettings) // uses `gt costs record`
+
+	result = check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Fatalf("witness settings with `gt costs record` should still pass; got %v: %s\nDetails: %v",
+			result.Status, result.Message, result.Details)
+	}
+}
+
+// TestExpectedStopPattern documents the role → expected-Stop-pattern mapping.
+// If the canonical hooks template in internal/hooks/config.go changes, this
+// test will fail and remind whoever's editing it to keep the doctor check
+// in sync.
+func TestExpectedStopPattern(t *testing.T) {
+	cases := []struct {
+		role string
+		want string
+	}{
+		{"polecat", "polecat-stop-check"},
+		{"polecats", "polecat-stop-check"}, // both singular and plural in use
+		{"witness", "costs record"},
+		{"refinery", "costs record"},
+		{"crew", "costs record"},
+		{"mayor", "costs record"},
+		{"deacon", "costs record"},
+		{"", "costs record"},
+	}
+	for _, c := range cases {
+		got := expectedStopPattern(c.role)
+		if got != c.want {
+			t.Errorf("expectedStopPattern(%q) = %q, want %q", c.role, got, c.want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

`gt doctor` claude-settings check expected `gt costs record` in the Stop hook for **every** role, but the canonical polecat template in `internal/hooks/config.go` installs `gt tap polecat-stop-check`. Result: doctor reported polecat settings.json as stale, `--fix` deleted them, the daemon recreated the same file, and the check never converged. From the bug body in #3648 — the Stop hook **is** present in the regenerated file (\`gt tap polecat-stop-check\`), but doctor doesn't recognize it as a valid Stop hook.

The fix plumbs \`agentType\` through \`checkSettings\` (the parameter was already present but ignored as \`_\`) and selects the expected pattern by role:

| role | expected Stop substring |
|---|---|
| \`polecat\` / \`polecats\` | \`polecat-stop-check\` |
| everyone else | \`costs record\` |

This mirrors \`DefaultOverrides()\` in \`internal/hooks/config.go\`. When those templates change, \`expectedStopPattern\` needs to change too — the new \`TestExpectedStopPattern\` documents the mapping so an out-of-sync edit fails fast.

## Test plan

- [x] \`go test ./internal/doctor/\` — full suite passes (4.7s)
- [x] \`go build ./...\` clean, \`go vet ./internal/doctor/...\` clean
- [ ] Manual: workspace exhibiting the loop in #3648 — \`gt doctor\` should now report claude-settings green without \`--fix\` cycles

### New / updated tests

- \`TestExpectedStopPattern\` — the role → pattern mapping itself; covers \`polecat\`, \`polecats\`, \`witness\`, \`refinery\`, \`crew\`, \`mayor\`, \`deacon\`, and the empty-string fallback.
- \`TestClaudeSettingsCheck_PolecatStopHookRecognized\` — regression test for #3648 (polecat with \`polecat-stop-check\` passes; witness with \`costs record\` still passes).
- \`TestClaudeSettingsCheck_ValidPolecatSettings\` updated to use the polecat-style settings via the new \`createValidPolecatSettings\` helper. The old version was masking the bug by writing a witness-style Stop hook to a polecat path and passing.

Closes #3648.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3816"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->