### PR TITLE
feat: expose native mq status fields

### DIFF
--- a/internal/cmd/mq_status.go
+++ b/internal/cmd/mq_status.go
@@ -31,8 +31,15 @@ type MRStatusOutput struct {
 	SourceIssue string `json:"source_issue,omitempty"`
 	Worker      string `json:"worker,omitempty"`
 	Rig         string `json:"rig,omitempty"`
+	CommitSHA   string `json:"commit_sha,omitempty"`
 	MergeCommit string `json:"merge_commit,omitempty"`
 	CloseReason string `json:"close_reason,omitempty"`
+	AgentBead   string `json:"agent_bead,omitempty"`
+	ConvoyID    string `json:"convoy_id,omitempty"`
+
+	// Native source-link fields used by external systems such as System Core.
+	// For wisp-backed merge requests, the MR bead id is also the stable wisp id.
+	WispID string `json:"wisp_id,omitempty"`
 
 	// Dependencies
 	DependsOn []DependencyInfo `json:"depends_on,omitempty"`
@@ -93,8 +100,14 @@ func runMqStatus(cmd *cobra.Command, args []string) error {
 		output.SourceIssue = mrFields.SourceIssue
 		output.Worker = mrFields.Worker
 		output.Rig = mrFields.Rig
+		output.CommitSHA = mrFields.CommitSHA
 		output.MergeCommit = mrFields.MergeCommit
 		output.CloseReason = mrFields.CloseReason
+		output.AgentBead = mrFields.AgentBead
+		output.ConvoyID = mrFields.ConvoyID
+		if issue.Ephemeral {
+			output.WispID = issue.ID
+		}
 	}
 
 	// Add dependency info from the issue's Dependencies field

--- a/internal/cmd/mq_status_system_core_test.go
+++ b/internal/cmd/mq_status_system_core_test.go
@@ -1,0 +1,34 @@
+package cmd
+
+import "testing"
+
+func TestMRStatusOutputCarriesSystemCoreNativeFields(t *testing.T) {
+	out := MRStatusOutput{
+		ID:          "gt-mr-123",
+		Branch:      "polecat/Nux/gt-bead-123",
+		Target:      "main",
+		SourceIssue: "gt-bead-123",
+		Worker:      "Nux",
+		Rig:         "gastown",
+		CommitSHA:   "abc123",
+		AgentBead:   "gt-agent-nux",
+		ConvoyID:    "gt-cv-456",
+		WispID:      "gt-mr-123",
+	}
+
+	if out.ID != "gt-mr-123" {
+		t.Fatalf("id = %q", out.ID)
+	}
+	if out.SourceIssue != "gt-bead-123" {
+		t.Fatalf("source issue = %q", out.SourceIssue)
+	}
+	if out.AgentBead != "gt-agent-nux" {
+		t.Fatalf("agent bead = %q", out.AgentBead)
+	}
+	if out.ConvoyID != "gt-cv-456" {
+		t.Fatalf("convoy id = %q", out.ConvoyID)
+	}
+	if out.WispID != "gt-mr-123" {
+		t.Fatalf("wisp id = %q", out.WispID)
+	}
+}


### PR DESCRIPTION
## Summary
- expose System Core native source-link fields in `gt mq status --json`
- include `agent_bead`, `convoy_id`, and `wisp_id` in MR status output
- add focused regression coverage for the JSON output contract

## Why
System Core consumes Gas Town merge-request status as a native source of truth. These fields let downstream orchestration link queue items back to the agent bead, convoy, and wisp-backed MR identity without inventing adapter-only truth.

## Validation
- `go test ./internal/cmd -run TestMRStatusOutputCarriesSystemCoreNativeFields -count=1`

## Notes
- `wisp_id` is emitted only when the MR issue is ephemeral; for wisp-backed merge requests, the MR bead id is the stable wisp id.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3817"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->