### PR TITLE
fix(mail/delivery): route delivery ack writes via bd prefix routing

### DIFF
--- a/internal/mail/delivery.go
+++ b/internal/mail/delivery.go
@@ -80,9 +80,14 @@ func DeliveryAckLabelSequenceIdempotent(recipientIdentity string, at time.Time, 
 // AcknowledgeDeliveryBead writes phase-2 delivery ack labels for a bead.
 // It reads existing labels for idempotent retry (reusing prior timestamps),
 // then writes the ack label sequence. Uses runBdCommand with timeouts.
-// Resolves the correct beadsDir based on the bead ID prefix (GH#2423).
+//
+// If beadID routes to a different rig than beadsDir, BEADS_DIR is stripped
+// ("") so bd performs its own prefix-based routing via routes.jsonl. Pinning
+// BEADS_DIR at a rig's .beads bypasses routing and fails the lookup for
+// beads whose prefix maps to a different database on the shared Dolt
+// server (au-ofe, au-b9d).
 func AcknowledgeDeliveryBead(workDir, beadsDir, beadID, recipientIdentity string) error {
-	beadsDir = beads.ResolveBeadsDirForID(beadsDir, beadID)
+	beadsDir = routedBeadsDirForID(beadsDir, beadID)
 	existingLabels, readErr := readBeadLabelsShared(workDir, beadsDir, beadID)
 	if readErr != nil {
 		// Log but proceed with empty labels — fresh timestamp is acceptable
@@ -104,6 +109,18 @@ func AcknowledgeDeliveryBead(workDir, beadsDir, beadID, recipientIdentity string
 		return err
 	}
 	return nil
+}
+
+// routedBeadsDirForID returns the BEADS_DIR value to pass into runBdCommand
+// so that beadID resolves correctly. Same-rig ids keep currentBeadsDir;
+// cross-rig ids return "" so bd's own prefix routing (via routes.jsonl in
+// the town's .beads) dispatches to the correct database. See au-ofe, au-b9d.
+func routedBeadsDirForID(currentBeadsDir, beadID string) string {
+	target := beads.ResolveBeadsDirForID(currentBeadsDir, beadID)
+	if target == "" || target == currentBeadsDir {
+		return currentBeadsDir
+	}
+	return ""
 }
 
 // readBeadLabelsShared reads the labels for a bead, returning an error on failure


### PR DESCRIPTION
Replacement for #3812 — re-cut on a clean current-main branch as Bella requested.

Follow-up to #3796 (which fixed cross-rig prefix routing for the Mailbox path).

`AcknowledgeDeliveryBead` was still calling `beads.ResolveBeadsDirForID` directly and pinning `BEADS_DIR` to the resolved rig `.beads` dir. That bypasses bd's own prefix routing via `routes.jsonl`, producing repeated warnings on every `gt mail inbox` whenever an ack write targets a cross-rig bead:

```
delivery ack: could not read labels for aa-wisp-…
```

This change mirrors the pattern from #3796 in `internal/mailbox/mailbox.go`: when the bead routes to a rig different from `currentBeadsDir`, pass `""` as the override so bd performs its own prefix-based routing via the town's `routes.jsonl`.

### Test plan
- `go build ./cmd/gt` — clean
- `go test ./internal/mail/...` — passing
- Verified in production: warnings cleared from `gt mail inbox` after deploying this fix to Alleago/gastown 2026-04-20.

### Linked beads (Alleago)
- au-ofe, au-b9d

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3818"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->