### PR TITLE
fix: make Dolt diagnostics non-fatal (gt-65t8)

### DIFF
--- a/internal/cmd/dolt.go
+++ b/internal/cmd/dolt.go
@@ -7,7 +7,6 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
-	"syscall"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -122,13 +121,11 @@ var doltLogsCmd = &cobra.Command{
 
 var doltDumpCmd = &cobra.Command{
 	Use:   "dump",
-	Short: "Dump Dolt server goroutine stacks for debugging",
-	Long: `Send SIGQUIT to the Dolt server to dump goroutine stacks to its log file.
+	Short: "Collect non-fatal Dolt server diagnostics",
+	Long: `Collect a non-fatal Dolt diagnostic snapshot for incident response.
 
-Per Tim Sehn (Dolt CEO): kill -QUIT prints all goroutine stacks to stderr,
-which is redirected to the server log. Useful for diagnosing hung servers.
-
-The dump is written to the server log file. Use 'gt dolt logs' to view it.`,
+This command does not send SIGQUIT. Dolt 1.86.5 terminates sql-server after
+SIGQUIT, so default diagnostics gather process metadata and recent logs only.`,
 	RunE: runDoltDump,
 }
 
@@ -747,22 +744,48 @@ func runDoltDump(cmd *cobra.Command, args []string) error {
 
 	config := doltserver.DefaultConfig(townRoot)
 
-	// Send SIGQUIT to get goroutine stack dump (written to server's stderr = log file)
-	proc, err := os.FindProcess(pid)
-	if err != nil {
-		return fmt.Errorf("finding process %d: %w", pid, err)
+	fmt.Printf("Dolt diagnostic snapshot (non-fatal)\n")
+	fmt.Printf("  Live PID:   %d\n", pid)
+	fmt.Printf("  Port:       %d\n", config.Port)
+	fmt.Printf("  Data dir:   %s\n", config.DataDir)
+	fmt.Printf("  Log file:   %s\n", config.LogFile)
+	fmt.Printf("  Connection: %s\n", doltserver.GetConnectionString(townRoot))
+
+	if info, err := doltserver.ReadSQLServerInfo(townRoot); err == nil {
+		fmt.Printf("  SQL metadata: %s\n", info.Path)
+		fmt.Printf("    PID:       %d\n", info.PID)
+		fmt.Printf("    Port:      %d\n", info.Port)
+		if info.ServerID != "" {
+			fmt.Printf("    Server ID: %s\n", info.ServerID)
+		}
+	} else {
+		fmt.Printf("  SQL metadata: unavailable (%v)\n", err)
 	}
 
-	fmt.Printf("Sending SIGQUIT to Dolt server (PID %d)...\n", pid)
-	if err := proc.Signal(syscall.SIGQUIT); err != nil {
-		return fmt.Errorf("sending SIGQUIT: %w", err)
+	if state, err := doltserver.LoadState(townRoot); err == nil && state.PID > 0 {
+		fmt.Printf("  Daemon state: %s\n", doltserver.StateFile(townRoot))
+		fmt.Printf("    PID:       %d", state.PID)
+		if state.PID != pid {
+			fmt.Printf(" (stale; live PID is %d)", pid)
+		}
+		fmt.Println()
+		if !state.StartedAt.IsZero() {
+			fmt.Printf("    Started:   %s\n", state.StartedAt.Format("2006-01-02 15:04:05"))
+		}
+		if state.DataDir != "" {
+			fmt.Printf("    Data dir:  %s\n", state.DataDir)
+		}
 	}
 
-	// Give the server a moment to write the dump
-	time.Sleep(500 * time.Millisecond)
+	fmt.Printf("\nRecent Dolt log lines:\n")
+	tailCmd := exec.Command("tail", "-n", "200", config.LogFile)
+	tailCmd.Stdout = os.Stdout
+	tailCmd.Stderr = os.Stderr
+	if err := tailCmd.Run(); err != nil {
+		fmt.Printf("  (unable to read recent logs: %v)\n", err)
+	}
 
-	fmt.Printf("Goroutine stack dump written to: %s\n", config.LogFile)
-	fmt.Printf("View with: gt dolt logs -n 200\n")
+	fmt.Printf("\nNo signal was sent. Do not use kill -QUIT for routine diagnostics unless the Dolt version has been verified not to terminate on SIGQUIT.\n")
 
 	return nil
 }

--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -9,11 +9,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"runtime"
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/doltserver"
@@ -428,9 +426,11 @@ func (m *DoltServerManager) EnsureRunning() error {
 		m.lastCheck = m.now()
 		if err := m.checkHealthLocked(); err != nil {
 			m.logger("Dolt server unhealthy: %v, restarting...", err)
-			m.sendUnhealthyAlert(err)
-			m.writeUnhealthySignal("health_check_failed", err.Error())
-			m.captureGoroutineDump()
+			if m.writeUnhealthySignal("health_check_failed", err.Error()) {
+				m.sendUnhealthyAlert(err)
+			} else {
+				m.logger("Dolt incident already active; suppressing duplicate unhealthy alert")
+			}
 			m.stopLocked()
 			return m.restartWithBackoff()
 		}
@@ -440,9 +440,11 @@ func (m *DoltServerManager) EnsureRunning() error {
 		// state that requires a server restart to clear.
 		if err := m.checkWriteHealthLocked(); err != nil {
 			m.logger("Dolt server read-only: %v, restarting...", err)
-			m.sendReadOnlyAlert(err)
-			m.writeUnhealthySignal("read_only", err.Error())
-			m.captureGoroutineDump()
+			if m.writeUnhealthySignal("read_only", err.Error()) {
+				m.sendReadOnlyAlert(err)
+			} else {
+				m.logger("Dolt incident already active; suppressing duplicate read-only alert")
+			}
 			m.stopLocked()
 			return m.restartWithBackoff()
 		}
@@ -454,9 +456,11 @@ func (m *DoltServerManager) EnsureRunning() error {
 			m.lastIdentityCheck = now
 			if err := m.checkDatabaseIdentityLocked(); err != nil {
 				m.logger("Dolt server identity check failed: %v, restarting...", err)
-				m.sendUnhealthyAlert(fmt.Errorf("identity check: %w", err))
-				m.writeUnhealthySignal("imposter_detected", err.Error())
-				m.captureGoroutineDump()
+				if m.writeUnhealthySignal("imposter_detected", err.Error()) {
+					m.sendUnhealthyAlert(fmt.Errorf("identity check: %w", err))
+				} else {
+					m.logger("Dolt incident already active; suppressing duplicate identity alert")
+				}
 				m.stopLocked()
 				// Also kill any imposters before restarting
 				if killErr := doltserver.KillImposters(m.townRoot); killErr != nil {
@@ -476,8 +480,11 @@ func (m *DoltServerManager) EnsureRunning() error {
 	// Not running, start it
 	if pid > 0 {
 		m.logger("Dolt server PID %d is dead, cleaning up and restarting...", pid)
-		m.sendCrashAlert(pid)
-		m.writeUnhealthySignal("server_dead", fmt.Sprintf("PID %d is dead", pid))
+		if m.writeUnhealthySignal("server_dead", fmt.Sprintf("PID %d is dead", pid)) {
+			m.sendCrashAlert(pid)
+		} else {
+			m.logger("Dolt incident already active; suppressing duplicate crash alert")
+		}
 	}
 	return m.restartWithBackoff()
 }
@@ -769,12 +776,33 @@ func (m *DoltServerManager) unhealthySignalFile() string {
 
 // writeUnhealthySignal writes the DOLT_UNHEALTHY signal file.
 // This file signals to witness patrols that the Dolt server is degraded.
-func (m *DoltServerManager) writeUnhealthySignal(reason, detail string) {
+// It returns true only for the first write in an active incident. Existing
+// signal files are preserved so repeated health ticks do not reset the
+// incident timestamp or re-trigger diagnostics.
+func (m *DoltServerManager) writeUnhealthySignal(reason, detail string) bool {
+	signalFile := m.unhealthySignalFile()
 	payload := fmt.Sprintf(`{"reason":%q,"detail":%q,"timestamp":%q}`,
-		reason, detail, time.Now().UTC().Format(time.RFC3339))
-	if err := os.WriteFile(m.unhealthySignalFile(), []byte(payload), 0644); err != nil {
-		m.logger("Warning: failed to write DOLT_UNHEALTHY signal: %v", err)
+		reason, detail, m.now().UTC().Format(time.RFC3339))
+	f, err := os.OpenFile(signalFile, os.O_WRONLY|os.O_CREATE|os.O_EXCL, 0644)
+	if os.IsExist(err) {
+		return false
 	}
+	if err != nil {
+		m.logger("Warning: failed to write DOLT_UNHEALTHY signal: %v", err)
+		return true
+	}
+	if _, err := f.WriteString(payload); err != nil {
+		_ = f.Close()
+		_ = os.Remove(signalFile)
+		m.logger("Warning: failed to write DOLT_UNHEALTHY signal: %v", err)
+		return true
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(signalFile)
+		m.logger("Warning: failed to write DOLT_UNHEALTHY signal: %v", err)
+		return true
+	}
+	return true
 }
 
 // clearUnhealthySignal removes the DOLT_UNHEALTHY signal file when the server is healthy.
@@ -941,33 +969,6 @@ func (m *DoltServerManager) Stop() error {
 }
 
 // stopLocked stops the Dolt server. Must be called with m.mu held.
-// captureGoroutineDump sends SIGQUIT to the Dolt server to dump goroutine stacks
-// to its log file. Per Tim Sehn (Dolt CEO): kill -QUIT prints all goroutine stacks
-// to stderr, which is redirected to the server log. Called before stopping an
-// unhealthy server so the dump captures what it was stuck on.
-func (m *DoltServerManager) captureGoroutineDump() {
-	pid, running := m.isRunning()
-	if !running {
-		return
-	}
-	process, err := os.FindProcess(pid)
-	if err != nil {
-		return
-	}
-	m.logger("Capturing goroutine dump from Dolt server (PID %d) before restart...", pid)
-	if runtime.GOOS == "windows" {
-		m.logger("Goroutine dump via SIGQUIT not supported on Windows, skipping")
-		return
-	}
-	if err := process.Signal(syscall.SIGQUIT); err != nil {
-		m.logger("Warning: failed to send SIGQUIT for goroutine dump: %v", err)
-		return
-	}
-	// Give the server a moment to write the dump to its log file.
-	time.Sleep(500 * time.Millisecond)
-	m.logger("Goroutine dump written to server log. View with: gt dolt logs -n 200")
-}
-
 func (m *DoltServerManager) stopLocked() {
 	if m.stopFn != nil {
 		m.stopFn()

--- a/internal/daemon/dolt_backoff_test.go
+++ b/internal/daemon/dolt_backoff_test.go
@@ -591,7 +591,9 @@ func TestWriteAndClearUnhealthySignal(t *testing.T) {
 	}
 
 	// Write signal
-	m.writeUnhealthySignal("server_dead", "PID 12345 is dead")
+	if first := m.writeUnhealthySignal("server_dead", "PID 12345 is dead"); !first {
+		t.Fatal("expected first unhealthy signal write to report a new incident")
+	}
 
 	if _, err := os.Stat(m.unhealthySignalFile()); err != nil {
 		t.Error("expected unhealthy signal after write")
@@ -605,6 +607,17 @@ func TestWriteAndClearUnhealthySignal(t *testing.T) {
 	content := string(data)
 	if content == "" {
 		t.Error("signal file should not be empty")
+	}
+
+	if second := m.writeUnhealthySignal("read_only", "duplicate incident"); second {
+		t.Fatal("expected duplicate unhealthy signal write to be suppressed")
+	}
+	data, err = os.ReadFile(m.unhealthySignalFile())
+	if err != nil {
+		t.Fatalf("failed to read signal file after duplicate write: %v", err)
+	}
+	if string(data) != content {
+		t.Fatalf("duplicate write changed signal file: got %q, want %q", string(data), content)
 	}
 
 	// Clear signal
@@ -1232,6 +1245,39 @@ func TestEnsureRunning_ReadOnlyWritesUnhealthySignal(t *testing.T) {
 	content := string(data)
 	if !strings.Contains(content, "read_only") {
 		t.Errorf("expected 'read_only' reason in signal file, got: %s", content)
+	}
+}
+
+func TestEnsureRunning_SuppressesDuplicateUnhealthyAlerts(t *testing.T) {
+	var running atomic.Bool
+	var alertCount atomic.Int32
+	running.Store(true)
+
+	m := newTestManager(t)
+	m.runningFn = func() (int, bool) {
+		if running.Load() {
+			return 1234, true
+		}
+		return 0, false
+	}
+	m.healthCheckFn = func() error { return fmt.Errorf("connection refused") }
+	m.stopFn = func() { running.Store(false) }
+	m.startFn = func() error {
+		running.Store(true)
+		return nil
+	}
+	m.unhealthyAlertFn = func(error) { alertCount.Add(1) }
+	m.sleepFn = func(d time.Duration) {}
+
+	if err := m.EnsureRunning(); err != nil {
+		t.Fatalf("first EnsureRunning: %v", err)
+	}
+	if err := m.EnsureRunning(); err != nil {
+		t.Fatalf("second EnsureRunning: %v", err)
+	}
+
+	if got := alertCount.Load(); got != 1 {
+		t.Fatalf("unhealthy alert count = %d, want 1", got)
 	}
 }
 

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -47,10 +47,10 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/gofrs/flock"
+	"github.com/steveyegge/gastown/internal/atomicfile"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/style"
-	"github.com/steveyegge/gastown/internal/atomicfile"
 	"gopkg.in/yaml.v3"
 )
 
@@ -505,9 +505,60 @@ type State struct {
 	Databases []string `json:"databases,omitempty"`
 }
 
+// SQLServerInfo is Dolt's own runtime metadata from .dolt/sql-server.info.
+type SQLServerInfo struct {
+	PID      int
+	Port     int
+	ServerID string
+	Path     string
+}
+
 // StateFile returns the path to the state file.
 func StateFile(townRoot string) string {
 	return filepath.Join(townRoot, "daemon", "dolt-state.json")
+}
+
+func sqlServerInfoPath(config *Config) string {
+	return filepath.Join(config.DataDir, ".dolt", "sql-server.info")
+}
+
+// SQLServerInfoPath returns the Dolt-managed sql-server.info path for a town.
+func SQLServerInfoPath(townRoot string) string {
+	return sqlServerInfoPath(DefaultConfig(townRoot))
+}
+
+// ReadSQLServerInfo reads Dolt's own sql-server.info metadata for a town.
+func ReadSQLServerInfo(townRoot string) (*SQLServerInfo, error) {
+	return readSQLServerInfo(DefaultConfig(townRoot))
+}
+
+func readSQLServerInfo(config *Config) (*SQLServerInfo, error) {
+	path := sqlServerInfoPath(config)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, err
+	}
+	parts := strings.SplitN(strings.TrimSpace(string(data)), ":", 3)
+	if len(parts) < 2 {
+		return nil, fmt.Errorf("malformed sql-server.info at %s", path)
+	}
+	pid, err := strconv.Atoi(parts[0])
+	if err != nil {
+		return nil, fmt.Errorf("malformed sql-server.info PID at %s: %w", path, err)
+	}
+	port, err := strconv.Atoi(parts[1])
+	if err != nil {
+		return nil, fmt.Errorf("malformed sql-server.info port at %s: %w", path, err)
+	}
+	info := &SQLServerInfo{
+		PID:  pid,
+		Port: port,
+		Path: path,
+	}
+	if len(parts) > 2 {
+		info.ServerID = parts[2]
+	}
+	return info, nil
 }
 
 // LoadState loads Dolt server state from disk.
@@ -580,6 +631,15 @@ func IsRunning(townRoot string) (bool, int, error) {
 		}
 		_ = conn.Close()
 		return true, 0, nil
+	}
+
+	// Prefer Dolt's own runtime metadata when present. During daemon restarts,
+	// daemon/dolt-state.json and daemon/dolt.pid can lag behind the live
+	// sql-server process, but .dolt/sql-server.info is written by Dolt itself.
+	if info, err := readSQLServerInfo(config); err == nil && info.Port == config.Port && info.PID > 0 {
+		if processIsAlive(info.PID) && isDoltServerOnPort(config.Port) && doltProcessMatchesTown(townRoot, info.PID, config) {
+			return true, info.PID, nil
+		}
 	}
 
 	// First check PID file
@@ -1257,6 +1317,21 @@ func CheckPortAvailable(port int) error {
 // without it, returns PID only (ZFC fix: gt-utuk).
 func PortHolder(port int) (pid int, dataDir string) {
 	pid = findDoltServerOnPort(port)
+	if pid <= 0 {
+		return 0, ""
+	}
+	if dataDir = GetDoltDataDirFromProcess(pid); dataDir != "" {
+		return pid, dataDir
+	}
+	if configPath := getDoltConfigPathFromProcess(pid); configPath != "" {
+		if filepath.Base(configPath) == "config.yaml" {
+			return pid, filepath.Dir(configPath)
+		}
+		return pid, configPath
+	}
+	if cwd := getProcessCWD(pid); cwd != "" {
+		return pid, cwd
+	}
 	return pid, ""
 }
 
@@ -3906,7 +3981,8 @@ func serverExecSQL(townRoot, query string) error {
 //
 // Dolt requires --host, --port, --user, --no-tls as global flags (before the
 // subcommand), not as subcommand flags. The order is:
-//   dolt --host=H --port=P --user=U --no-tls sql -q "..."
+//
+//	dolt --host=H --port=P --user=U --no-tls sql -q "..."
 func buildServerSQLCmd(ctx context.Context, config *Config, args ...string) *exec.Cmd {
 	// Global connection flags must come before the "sql" subcommand.
 	// Always pass --password to prevent dolt from prompting on stdin

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -125,6 +125,50 @@ func TestGetDoltFlagFromArgs(t *testing.T) {
 	}
 }
 
+func TestReadSQLServerInfo(t *testing.T) {
+	dataDir := t.TempDir()
+	infoDir := filepath.Join(dataDir, ".dolt")
+	if err := os.MkdirAll(infoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	infoPath := filepath.Join(infoDir, "sql-server.info")
+	if err := os.WriteFile(infoPath, []byte("62569:3307:757ce4ea-40c5-40f1-9eaf-4d584cae87b0\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	info, err := readSQLServerInfo(&Config{DataDir: dataDir})
+	if err != nil {
+		t.Fatalf("readSQLServerInfo: %v", err)
+	}
+	if info.PID != 62569 {
+		t.Fatalf("PID = %d, want 62569", info.PID)
+	}
+	if info.Port != 3307 {
+		t.Fatalf("Port = %d, want 3307", info.Port)
+	}
+	if info.ServerID != "757ce4ea-40c5-40f1-9eaf-4d584cae87b0" {
+		t.Fatalf("ServerID = %q", info.ServerID)
+	}
+	if info.Path != infoPath {
+		t.Fatalf("Path = %q, want %q", info.Path, infoPath)
+	}
+}
+
+func TestReadSQLServerInfoRejectsMalformedContent(t *testing.T) {
+	dataDir := t.TempDir()
+	infoDir := filepath.Join(dataDir, ".dolt")
+	if err := os.MkdirAll(infoDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(infoDir, "sql-server.info"), []byte("not-a-pid:3307"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := readSQLServerInfo(&Config{DataDir: dataDir}); err == nil {
+		t.Fatal("expected malformed sql-server.info to fail")
+	}
+}
+
 func TestDoltProcessMatchesTownPaths(t *testing.T) {
 	expectedDir := "/town/.dolt-data"
 

--- a/internal/templates/townroot.go
+++ b/internal/templates/townroot.go
@@ -12,7 +12,7 @@ var townRootCLAUDEmdRaw string
 
 // TownRootCLAUDEmdVersion is the version of the embedded town-root CLAUDE.md.
 // Increment this when updating the template content with new sections.
-const TownRootCLAUDEmdVersion = 1
+const TownRootCLAUDEmdVersion = 2
 
 // TownRootCLAUDEmd returns the canonical town-root CLAUDE.md content
 // with the CLI command name substituted.

--- a/internal/templates/townroot/claude.md
+++ b/internal/templates/townroot/claude.md
@@ -18,20 +18,24 @@ Symptoms: `bd` commands hang/timeout, "connection refused", "database not found"
 query latency > 5s, unexpected empty results.
 
 **BEFORE restarting Dolt, collect diagnostics.** Dolt hangs are hard to
-reproduce. A blind restart destroys the evidence. Always:
+reproduce. A blind restart destroys the evidence. Always use non-fatal
+diagnostics:
 
 ```bash
-# 1. Capture goroutine dump (safe — does not kill the process)
-kill -QUIT $(cat ~/gt/.dolt-data/dolt.pid)  # Dumps stacks to Dolt's stderr log
+# 1. Capture process metadata and recent logs without signaling Dolt
+{{cmd}} dolt dump 2>&1 | tee /tmp/dolt-hang-$(date +%s).log
 
 # 2. Capture server status while it's still (mis)behaving
-{{cmd}} dolt status 2>&1 | tee /tmp/dolt-hang-$(date +%s).log
+{{cmd}} dolt status 2>&1 | tee /tmp/dolt-status-$(date +%s).log
 
 # 3. THEN escalate with the evidence
 {{cmd}} escalate -s HIGH "Dolt: <describe symptom>"
 ```
 
 **Do NOT just `{{cmd}} dolt stop && {{cmd}} dolt start` without steps 1-2.**
+**Do NOT use `kill -QUIT` for routine diagnostics.** Dolt 1.86.5 terminates
+`sql-server` after SIGQUIT; only use it if the current Dolt version has been
+verified not to exit on that signal.
 
 **Escalation path** (any agent can do this):
 ```bash


### PR DESCRIPTION
## Summary
- Replace fatal SIGQUIT-based Dolt diagnostics with non-fatal metadata/log snapshots.
- Prefer live Dolt sql-server metadata for PID discovery before stale daemon PID/state.
- Suppress duplicate DOLT_UNHEALTHY incident alerts while an incident is active.
- Update town-root agent guidance to avoid `kill -QUIT` for routine Dolt diagnostics.

## Recovery Context
This branch was recovered after `gt done --target main` could not push to upstream because the authenticated `rbriski` account has read-only access to `gastownhall/gastown`. The original local commit is `38b186ba8090ed7d1ce68ece1e3648f35d79e467` on `polecat/furiosa/gt-65t8@mon61pbu`.

A verified local backup also exists at `/Users/bbriski/gt/recovery-backups/gt-65t8-furiosa-38b186ba-20260501T173424Z`.

## Validation
- Not rerun during recovery; preserving furiosa's completed commit and opening this PR was the recovery action.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3822"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->