### PR TITLE
fix: protect beads global dolt database

### DIFF
--- a/internal/cmd/install_test.go
+++ b/internal/cmd/install_test.go
@@ -23,14 +23,17 @@ func TestBuildBdInitArgs_AlwaysIncludesServerPort(t *testing.T) {
 
 	args := buildBdInitArgs(townDir)
 
-	if len(args) != 6 {
-		t.Fatalf("expected 6 args, got %d: %v", len(args), args)
+	if len(args) != 7 {
+		t.Fatalf("expected 7 args, got %d: %v", len(args), args)
 	}
 	if args[4] != "--server-port" {
 		t.Fatalf("expected args[4] = --server-port, got %q", args[4])
 	}
 	if args[5] != "3307" {
 		t.Fatalf("expected default port 3307, got %q", args[5])
+	}
+	if args[6] != "--force" {
+		t.Fatalf("expected args[6] = --force, got %q", args[6])
 	}
 }
 

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -2563,15 +2563,26 @@ type OrphanedDatabase struct {
 	SizeBytes int64
 }
 
+// protectedSharedServerDatabases returns the registry of databases that are
+// intentionally hosted by the shared Dolt server but are not referenced by any
+// rig's metadata. Mapped to a human-readable owner label used by
+// CollectDatabaseOwners so `gt dolt list` / `gt dolt status` annotate them as
+// protected rather than reporting them as orphans.
+//
+// Single source of truth for orphan-detection skipping (FindOrphanedDatabases,
+// RemoveDatabase) and owner-label reporting (CollectDatabaseOwners). Adding a
+// new protected database here automatically picks up all three surfaces.
+func protectedSharedServerDatabases() map[string]string {
+	return map[string]string{
+		"beads_global": "global shared beads database (protected)",
+	}
+}
+
 // isProtectedSharedServerDatabase reports databases that are intentionally
 // hosted by the shared Dolt server but are not referenced by rig metadata.
 func isProtectedSharedServerDatabase(dbName string) bool {
-	switch dbName {
-	case "beads_global":
-		return true
-	default:
-		return false
-	}
+	_, ok := protectedSharedServerDatabases()[dbName]
+	return ok
 }
 
 // FindOrphanedDatabases scans .dolt-data/ for databases that are not referenced
@@ -2790,6 +2801,20 @@ func CollectDatabaseOwners(townRoot string) map[string]string {
 					owners[db] = dirName + " rig beads"
 				}
 			}
+		}
+	}
+
+	// Label protected shared-server databases so `gt dolt list` doesn't render
+	// them as orphans. Only labels protected DBs that actually exist on disk —
+	// otherwise we'd advertise a phantom owner. Never overwrites a rig-derived
+	// label if one is already present.
+	config := DefaultConfig(townRoot)
+	for dbName, label := range protectedSharedServerDatabases() {
+		if _, already := owners[dbName]; already {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(config.DataDir, dbName, ".dolt")); err == nil {
+			owners[dbName] = label
 		}
 	}
 

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -47,10 +47,10 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/gofrs/flock"
+	"github.com/steveyegge/gastown/internal/atomicfile"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/style"
-	"github.com/steveyegge/gastown/internal/atomicfile"
 	"gopkg.in/yaml.v3"
 )
 
@@ -2563,6 +2563,17 @@ type OrphanedDatabase struct {
 	SizeBytes int64
 }
 
+// isProtectedSharedServerDatabase reports databases that are intentionally
+// hosted by the shared Dolt server but are not referenced by rig metadata.
+func isProtectedSharedServerDatabase(dbName string) bool {
+	switch dbName {
+	case "beads_global":
+		return true
+	default:
+		return false
+	}
+}
+
 // FindOrphanedDatabases scans .dolt-data/ for databases that are not referenced
 // by any rig's metadata.json dolt_database field. These orphans consume disk space
 // and are served by the Dolt server unnecessarily.
@@ -2582,7 +2593,7 @@ func FindOrphanedDatabases(townRoot string) ([]OrphanedDatabase, error) {
 	config := DefaultConfig(townRoot)
 	var orphans []OrphanedDatabase
 	for _, dbName := range databases {
-		if referenced[dbName] {
+		if referenced[dbName] || isProtectedSharedServerDatabase(dbName) {
 			continue
 		}
 		dbPath := filepath.Join(config.DataDir, dbName)
@@ -2790,6 +2801,10 @@ func CollectDatabaseOwners(townRoot string) map[string]string {
 // If the Dolt server is running, it will DROP the database first.
 // If force is false and the database has real user tables, it refuses to remove. (gt-q8f6n)
 func RemoveDatabase(townRoot, dbName string, force bool) error {
+	if isProtectedSharedServerDatabase(dbName) {
+		return fmt.Errorf("database %q is a protected shared-server database", dbName)
+	}
+
 	config := DefaultConfig(townRoot)
 	dbPath := filepath.Join(config.DataDir, dbName)
 
@@ -3906,7 +3921,8 @@ func serverExecSQL(townRoot, query string) error {
 //
 // Dolt requires --host, --port, --user, --no-tls as global flags (before the
 // subcommand), not as subcommand flags. The order is:
-//   dolt --host=H --port=P --user=U --no-tls sql -q "..."
+//
+//	dolt --host=H --port=P --user=U --no-tls sql -q "..."
 func buildServerSQLCmd(ctx context.Context, config *Config, args ...string) *exec.Cmd {
 	// Global connection flags must come before the "sql" subcommand.
 	// Always pass --password to prevent dolt from prompting on stdin

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -3953,6 +3953,55 @@ func TestCollectDatabaseOwners_UnknownDB(t *testing.T) {
 	}
 }
 
+// TestCollectDatabaseOwners_ProtectedSharedServerDatabaseLabeled verifies that
+// protected shared-server databases (e.g. beads_global) are reported with a
+// dedicated owner label rather than appearing as orphans in `gt dolt list`.
+// Regression for the operator-confusion gap flagged on PR #3823 — the
+// orphan-detection skip alone wasn't enough; CollectDatabaseOwners has to
+// know about the same registry.
+func TestCollectDatabaseOwners_ProtectedSharedServerDatabaseLabeled(t *testing.T) {
+	townRoot := t.TempDir()
+
+	setupRigsJSON(t, townRoot, []string{})
+	setupRigMetadata(t, townRoot, "hq", "hq")
+
+	// Create a beads_global database directory on disk (no rig metadata
+	// references it — that's the whole reason it would otherwise look like
+	// an orphan).
+	dataDir := DefaultConfig(townRoot).DataDir
+	beadsGlobalPath := filepath.Join(dataDir, "beads_global", ".dolt")
+	if err := os.MkdirAll(beadsGlobalPath, 0o755); err != nil {
+		t.Fatalf("mkdir beads_global: %v", err)
+	}
+
+	owners := CollectDatabaseOwners(townRoot)
+	label, ok := owners["beads_global"]
+	if !ok {
+		t.Fatalf("expected beads_global to have an owner label, got owners=%v", owners)
+	}
+	if !strings.Contains(label, "protected") {
+		t.Errorf("expected protected-DB label to mention 'protected', got %q", label)
+	}
+}
+
+// TestCollectDatabaseOwners_ProtectedDatabaseNotPhantom verifies that the
+// protected-DB labeling only kicks in when the database actually exists on
+// disk — otherwise CollectDatabaseOwners would advertise an owner for a DB
+// that doesn't exist on the filesystem, which would be its own kind of
+// confusion.
+func TestCollectDatabaseOwners_ProtectedDatabaseNotPhantom(t *testing.T) {
+	townRoot := t.TempDir()
+
+	setupRigsJSON(t, townRoot, []string{})
+	setupRigMetadata(t, townRoot, "hq", "hq")
+
+	// Intentionally do NOT create beads_global on disk.
+	owners := CollectDatabaseOwners(townRoot)
+	if _, exists := owners["beads_global"]; exists {
+		t.Errorf("beads_global should not be in owners when absent from disk, got %q", owners["beads_global"])
+	}
+}
+
 // =============================================================================
 // writeServerConfig tests
 // =============================================================================

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -3095,6 +3095,29 @@ func TestFindOrphanedDatabases_DetectsOrphans(t *testing.T) {
 	}
 }
 
+func TestFindOrphanedDatabases_ProtectsBeadsGlobal(t *testing.T) {
+	townRoot := t.TempDir()
+	dataDir := filepath.Join(townRoot, ".dolt-data")
+
+	setupDoltDB(t, dataDir, "hq")
+	setupDoltDB(t, dataDir, "beads_global")
+	setupDoltDB(t, dataDir, "orphan_db")
+
+	setupRigsJSON(t, townRoot, []string{})
+	setupRigMetadata(t, townRoot, "hq", "hq")
+
+	orphans, err := FindOrphanedDatabases(townRoot)
+	if err != nil {
+		t.Fatalf("FindOrphanedDatabases: %v", err)
+	}
+	if len(orphans) != 1 {
+		t.Fatalf("expected 1 orphan, got %d: %v", len(orphans), orphans)
+	}
+	if orphans[0].Name != "orphan_db" {
+		t.Errorf("expected orphan name 'orphan_db', got %q", orphans[0].Name)
+	}
+}
+
 func TestFindOrphanedDatabases_MultipleOrphans(t *testing.T) {
 	townRoot := t.TempDir()
 	dataDir := filepath.Join(townRoot, ".dolt-data")
@@ -3280,6 +3303,23 @@ func TestRemoveDatabase_ErrorOnMissing(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "not found") {
 		t.Errorf("expected 'not found' in error, got: %v", err)
+	}
+}
+
+func TestRemoveDatabase_RefusesProtectedSharedServerDatabase(t *testing.T) {
+	townRoot := t.TempDir()
+	dataDir := filepath.Join(townRoot, ".dolt-data")
+	dbPath := setupDoltDB(t, dataDir, "beads_global")
+
+	err := RemoveDatabase(townRoot, "beads_global", true)
+	if err == nil {
+		t.Fatal("expected error for protected shared-server database")
+	}
+	if !strings.Contains(err.Error(), "protected shared-server database") {
+		t.Errorf("expected protected database error, got: %v", err)
+	}
+	if _, statErr := os.Stat(dbPath); statErr != nil {
+		t.Errorf("expected beads_global to remain on disk, got stat error: %v", statErr)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Protect beads_global from Dolt orphan detection and direct removal.
- Add regression coverage that keeps a real orphan database detectable while preserving beads_global.

## Validation
- go test ./internal/doltserver
- make build
- ./gt dolt cleanup --dry-run
- ./gt dolt status

Note: make test currently fails on origin/main before this branch because internal/daemon/handler_test.go contains a conflict marker at line 448.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3823"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->