### PR TITLE
fix: remove daemon test conflict marker (gt-nese)

### DIFF
--- a/internal/daemon/handler_test.go
+++ b/internal/daemon/handler_test.go
@@ -429,6 +429,7 @@ func TestDispatchPlugins_SkipsManualGatePlugin(t *testing.T) {
 		t.Errorf("dog work = %q, want empty (manual-gate plugin must not auto-dispatch)", dg.Work)
 	}
 }
+
 func TestFindDispatchableDog_PicksFirstIdleWhenNoSessionsLive(t *testing.T) {
 	townRoot := t.TempDir()
 	d := testHandlerDaemon(t, townRoot)
@@ -445,38 +446,5 @@ func TestFindDispatchableDog_PicksFirstIdleWhenNoSessionsLive(t *testing.T) {
 	}
 	if got.Name != "alpha" && got.Name != "bravo" {
 		t.Errorf("findDispatchableDog = %q, want alpha or bravo", got.Name)
-=======
-func TestDispatchPlugins_SkipsManualGatePlugin(t *testing.T) {
-	townRoot := t.TempDir()
-	d := testHandlerDaemon(t, townRoot)
-
-	pluginDir := filepath.Join(townRoot, "plugins", "test-manual")
-	if err := os.MkdirAll(pluginDir, 0755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	pluginMD := "+++\nname = \"test-manual\"\ndescription = \"manual gate plugin\"\n\n[gate]\ntype = \"manual\"\n+++\n\n# Instructions\n"
-	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.md"), []byte(pluginMD), 0644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	testSetupDogState(t, townRoot, "idle-dog", dog.StateIdle, time.Now().Add(-10*time.Minute))
-
-	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
-	mgr := dog.NewManager(townRoot, rigsConfig)
-	tm := tmux.NewTmux()
-	sm := dog.NewSessionManager(tm, townRoot, mgr)
-
-	d.dispatchPlugins(mgr, sm, rigsConfig)
-
-	dg, err := mgr.Get("idle-dog")
-	if err != nil {
-		t.Fatalf("Get: %v", err)
-	}
-	if dg.State != dog.StateIdle {
-		t.Errorf("dog state = %q, want idle (manual-gate plugin must not auto-dispatch)", dg.State)
-	}
-	if dg.Work != "" {
-		t.Errorf("dog work = %q, want empty (manual-gate plugin must not auto-dispatch)", dg.Work)
->>>>>>> 5d7eb4383 (fix: add explicit gate=manual skip in dispatchPlugins (hq-suin))
 	}
 }


### PR DESCRIPTION
## Summary
- Remove the stray conflict residue from `internal/daemon/handler_test.go`.
- Restore the affected daemon tests so the package can compile again.

## Recovery Context
This branch was recovered after `gt done --target main` could not push to upstream because the authenticated `rbriski` account has read-only access to the upstream repository. The original local commit is `7f903d1d55dea07d8c6f2ebf8f247e0b5930f8e5` on `polecat/furiosa/gt-nese@mon7e2es`.

A verified local backup also exists at `/Users/bbriski/gt/recovery-backups/gt-nese-furiosa-7f903d1d-20260501T175419Z`.

## Validation
- Targeted `go test ./internal/daemon -run 'TestDispatchPlugins_SkipsManualGatePlugin|TestFindDispatchableDog_PicksFirstIdleWhenNoSessionsLive' -count=1 -timeout=30s -v` passed in the recovered work.
- Full `go test ./internal/daemon` was not completed by the polecat because it produced no output for several minutes and appeared to hang in unrelated package coverage.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3824"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->