### PR TITLE
fix(daemon): don't skip non-Dolt tests when Docker unavailable (gt-kw4449)

### DIFF
--- a/internal/daemon/testmain_test.go
+++ b/internal/daemon/testmain_test.go
@@ -18,9 +18,12 @@ func TestMain(m *testing.M) {
 	// those to an isolated container (via BEADS_DOLT_PORT), the databases are
 	// destroyed when the container is terminated at cleanup —
 	// preventing orphan accumulation in the shared production Dolt data dir.
+	//
+	// When Docker is unavailable, Dolt-needing tests self-skip via
+	// setupTestStore → beadsdk.Open failure. Non-Dolt tests (e.g.
+	// boot_spawn_frequency_test.go) still run. (fixes gt-kw4449)
 	if err := testutil.EnsureDoltContainerForTestMain(); err != nil {
-		fmt.Fprintf(os.Stderr, "daemon TestMain: skipping — %v\n", err)
-		os.Exit(0)
+		fmt.Fprintf(os.Stderr, "daemon TestMain: Dolt container unavailable (%v), Dolt-dependent tests will skip\n", err)
 	}
 
 	// Isolate tmux sessions on a package-specific socket.


### PR DESCRIPTION
## Summary
- `internal/daemon/TestMain` previously called `os.Exit(0)` when Docker wasn't available, which silently skipped **all** daemon tests — including the ones that don't need Dolt at all (e.g., `boot_spawn_frequency_test.go`).
- Now `TestMain` logs a warning and continues. Tests that actually need a Dolt store self-skip via `setupTestStore` → `beadsdk.Open` failure, which is the right behavior.

## Why
On Docker-less dev environments, useful daemon tests were invisible. This change recovers those signals without forcing Dolt-dependent tests to fail.

## Test plan
- [ ] CI runs daemon tests; non-Dolt tests pass, Dolt-dependent tests skip with a clear reason on Docker-less runners.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3825"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->