### PR TITLE
feat(daemon): suppress boot spawns when deacon is healthy (gt-qu883c)

### DIFF
--- a/internal/config/operational.go
+++ b/internal/config/operational.go
@@ -47,6 +47,7 @@ const (
 	DefaultDoctorMolCooldown               = 5 * time.Minute
 	DefaultRecoveryHeartbeatInterval       = 3 * time.Minute
 	DefaultBootSpawnCooldown               = 2 * time.Minute
+	DefaultBootIdleSuppression             = 15 * time.Minute
 	DefaultDeaconGracePeriod               = 5 * time.Minute
 
 	// Pressure check defaults — fully opt-in. All zero = disabled.
@@ -383,6 +384,15 @@ func (d *DaemonThresholds) BootSpawnCooldownD() time.Duration {
 		return ParseDurationOrDefault(d.BootSpawnCooldown, DefaultBootSpawnCooldown)
 	}
 	return DefaultBootSpawnCooldown
+}
+
+// BootIdleSuppressionD returns the configured or default boot idle suppression duration.
+// When Boot's last action was "nothing" (deacon healthy), spawns are suppressed for this long.
+func (d *DaemonThresholds) BootIdleSuppressionD() time.Duration {
+	if d != nil {
+		return ParseDurationOrDefault(d.BootIdleSuppression, DefaultBootIdleSuppression)
+	}
+	return DefaultBootIdleSuppression
 }
 
 // DeaconGracePeriodD returns the configured or default deacon grace period.

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -348,6 +348,10 @@ type DaemonThresholds struct {
 	// BootSpawnCooldown prevents Boot from spawning on every daemon heartbeat (default "2m").
 	BootSpawnCooldown string `json:"boot_spawn_cooldown,omitempty"`
 
+	// BootIdleSuppression is how long to suppress Boot spawns after Boot reported "nothing"
+	// (deacon was healthy). Prevents burning API calls when deacon is running fine (default "15m").
+	BootIdleSuppression string `json:"boot_idle_suppression,omitempty"`
+
 	// DeaconGracePeriod is time to wait after starting Deacon before checking heartbeat (default "5m").
 	DeaconGracePeriod string `json:"deacon_grace_period,omitempty"`
 

--- a/internal/daemon/boot_spawn_frequency_test.go
+++ b/internal/daemon/boot_spawn_frequency_test.go
@@ -8,7 +8,9 @@ import (
 	"runtime"
 	"strings"
 	"testing"
+	"time"
 
+	"github.com/steveyegge/gastown/internal/boot"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
@@ -100,5 +102,112 @@ func TestEnsureBootRunning_DoesNotSpawnEveryTick(t *testing.T) {
 	}
 	if spawns != 1 {
 		t.Fatalf("boot spawn count = %d, want 1 (avoid spawning every daemon tick)", spawns)
+	}
+}
+
+// Regression test for gt-qu883c:
+// daemon should suppress Boot spawns when Boot's last action was "nothing" (deacon healthy).
+func TestEnsureBootRunning_SuppressesWhenDeaconHealthy(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on Windows — fake tmux requires bash")
+	}
+	townRoot := t.TempDir()
+	fakeBinDir := t.TempDir()
+	tmuxLog := filepath.Join(t.TempDir(), "tmux.log")
+	if err := os.WriteFile(tmuxLog, []byte{}, 0o644); err != nil {
+		t.Fatalf("create tmux log: %v", err)
+	}
+
+	writeFakeTmux(t, fakeBinDir)
+	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_LOG", tmuxLog)
+	t.Setenv("GT_DEGRADED", "false")
+
+	// Write a boot-status.json indicating deacon was healthy ("nothing") recently.
+	b := boot.New(townRoot)
+	if err := b.SaveStatus(&boot.Status{
+		StartedAt:   time.Now().Add(-30 * time.Second),
+		CompletedAt: time.Now().Add(-20 * time.Second),
+		LastAction:  "nothing",
+	}); err != nil {
+		t.Fatalf("save boot status: %v", err)
+	}
+
+	d := &Daemon{
+		config: &Config{TownRoot: townRoot},
+		logger: log.New(io.Discard, "", 0),
+		tmux:   tmux.NewTmux(),
+	}
+
+	// Even though cooldown has expired (bootLastSpawned is zero),
+	// idle suppression should prevent spawning.
+	d.ensureBootRunning()
+
+	data, err := os.ReadFile(tmuxLog)
+	if err != nil {
+		t.Fatalf("read tmux log: %v", err)
+	}
+
+	spawns := 0
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if strings.HasPrefix(line, "new-session ") {
+			spawns++
+		}
+	}
+	if spawns != 0 {
+		t.Fatalf("boot spawn count = %d, want 0 (should suppress when deacon healthy)", spawns)
+	}
+}
+
+// Test that idle suppression does NOT prevent spawning when Boot's last action was not "nothing".
+func TestEnsureBootRunning_SpawnsWhenDeaconUnhealthy(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on Windows — fake tmux requires bash")
+	}
+	townRoot := t.TempDir()
+	fakeBinDir := t.TempDir()
+	tmuxLog := filepath.Join(t.TempDir(), "tmux.log")
+	if err := os.WriteFile(tmuxLog, []byte{}, 0o644); err != nil {
+		t.Fatalf("create tmux log: %v", err)
+	}
+
+	writeFakeTmux(t, fakeBinDir)
+	t.Setenv("PATH", fakeBinDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TMUX_LOG", tmuxLog)
+	t.Setenv("GT_DEGRADED", "false")
+
+	// Write a boot-status.json indicating Boot had to wake deacon recently.
+	b := boot.New(townRoot)
+	if err := b.SaveStatus(&boot.Status{
+		StartedAt:   time.Now().Add(-30 * time.Second),
+		CompletedAt: time.Now().Add(-20 * time.Second),
+		LastAction:  "wake",
+		Target:      "deacon",
+	}); err != nil {
+		t.Fatalf("save boot status: %v", err)
+	}
+
+	d := &Daemon{
+		config: &Config{TownRoot: townRoot},
+		logger: log.New(io.Discard, "", 0),
+		tmux:   tmux.NewTmux(),
+	}
+
+	// When last action was "wake" (not "nothing"), Boot should still spawn.
+	d.ensureBootRunning()
+
+	data, err := os.ReadFile(tmuxLog)
+	if err != nil {
+		t.Fatalf("read tmux log: %v", err)
+	}
+
+	spawns := 0
+	for _, line := range strings.Split(strings.TrimSpace(string(data)), "\n") {
+		if strings.HasPrefix(line, "new-session ") {
+			spawns++
+		}
+	}
+	if spawns != 1 {
+		t.Fatalf("boot spawn count = %d, want 1 (should spawn when deacon was unhealthy)", spawns)
 	}
 }

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1302,6 +1302,17 @@ func (d *Daemon) ensureBootRunning() {
 
 	b := boot.New(d.config.TownRoot)
 
+	// Idle suppression: if Boot's last run found deacon healthy ("nothing"),
+	// suppress spawning for longer to avoid burning API calls. (fixes gt-qu883c)
+	idleSuppression := d.loadOperationalConfig().GetDaemonConfig().BootIdleSuppressionD()
+	if status, err := b.LoadStatus(); err == nil && status.LastAction == "nothing" {
+		if !status.CompletedAt.IsZero() && time.Since(status.CompletedAt) < idleSuppression {
+			d.logger.Printf("Boot last reported 'nothing' %s ago, within idle suppression (%s), skipping",
+				time.Since(status.CompletedAt).Round(time.Second), idleSuppression)
+			return
+		}
+	}
+
 	// Check for degraded mode
 	degraded := os.Getenv("GT_DEGRADED") == "true"
 	if degraded || !d.tmux.IsAvailable() {


### PR DESCRIPTION
## Summary
- Adds idle suppression to `ensureBootRunning()`: when Boot's last run reports "nothing" (deacon already healthy), suppress further spawns for a configurable duration (default 15m) instead of re-spawning every cooldown period.
- New config knob `boot_idle_suppression` under `operational.daemon`.

## Why
On stable rigs with a healthy deacon, Boot was being re-invoked every cooldown tick and burning Claude API calls just to confirm nothing needed to happen. Idle suppression collapses these no-op runs while still recovering quickly when something actually changes.

## Test plan
- [ ] Boot idle suppression covered by daemon tests (rig stays healthy → spawn count drops).
- [ ] Regression check: when deacon goes unhealthy, suppression is bypassed and Boot spawns again.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3826"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->