### PR TITLE
fix: protect beads_global from orphan cleanup

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -47,10 +47,10 @@ import (
 
 	_ "github.com/go-sql-driver/mysql"
 	"github.com/gofrs/flock"
+	"github.com/steveyegge/gastown/internal/atomicfile"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/style"
-	"github.com/steveyegge/gastown/internal/atomicfile"
 	"gopkg.in/yaml.v3"
 )
 
@@ -2563,6 +2563,17 @@ type OrphanedDatabase struct {
 	SizeBytes int64
 }
 
+const beadsGlobalDatabaseName = "beads_global"
+
+func protectedSharedServerDatabaseOwner(dbName string) (string, bool) {
+	switch dbName {
+	case beadsGlobalDatabaseName:
+		return "Beads shared-server global database", true
+	default:
+		return "", false
+	}
+}
+
 // FindOrphanedDatabases scans .dolt-data/ for databases that are not referenced
 // by any rig's metadata.json dolt_database field. These orphans consume disk space
 // and are served by the Dolt server unnecessarily.
@@ -2583,6 +2594,9 @@ func FindOrphanedDatabases(townRoot string) ([]OrphanedDatabase, error) {
 	var orphans []OrphanedDatabase
 	for _, dbName := range databases {
 		if referenced[dbName] {
+			continue
+		}
+		if _, ok := protectedSharedServerDatabaseOwner(dbName); ok {
 			continue
 		}
 		dbPath := filepath.Join(config.DataDir, dbName)
@@ -2709,6 +2723,11 @@ func collectReferencedDatabases(townRoot string) map[string]bool {
 // accidental drops of production databases. (GH#2252)
 func CollectDatabaseOwners(townRoot string) map[string]string {
 	owners := make(map[string]string)
+
+	if DatabaseExists(townRoot, beadsGlobalDatabaseName) {
+		owner, _ := protectedSharedServerDatabaseOwner(beadsGlobalDatabaseName)
+		owners[beadsGlobalDatabaseName] = owner
+	}
 
 	// Check town-level beads (hq)
 	townBeadsDir := filepath.Join(townRoot, ".beads")
@@ -3906,7 +3925,8 @@ func serverExecSQL(townRoot, query string) error {
 //
 // Dolt requires --host, --port, --user, --no-tls as global flags (before the
 // subcommand), not as subcommand flags. The order is:
-//   dolt --host=H --port=P --user=U --no-tls sql -q "..."
+//
+//	dolt --host=H --port=P --user=U --no-tls sql -q "..."
 func buildServerSQLCmd(ctx context.Context, config *Config, args ...string) *exec.Cmd {
 	// Global connection flags must come before the "sql" subcommand.
 	// Always pass --password to prevent dolt from prompting on stdin

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -3095,6 +3095,39 @@ func TestFindOrphanedDatabases_DetectsOrphans(t *testing.T) {
 	}
 }
 
+func TestFindOrphanedDatabases_ProtectsBeadsGlobal(t *testing.T) {
+	townRoot := t.TempDir()
+	dataDir := filepath.Join(townRoot, ".dolt-data")
+
+	// Create referenced databases plus the shared Beads global database.
+	setupDoltDB(t, dataDir, "hq")
+	setupDoltDB(t, dataDir, "gastown")
+	setupDoltDB(t, dataDir, "beads_global")
+
+	// Keep a real orphan present to prove cleanup behavior is preserved.
+	setupDoltDB(t, dataDir, "old_setup")
+
+	setupRigsJSON(t, townRoot, []string{"gastown"})
+	setupRigMetadata(t, townRoot, "hq", "hq")
+	setupRigMetadata(t, townRoot, "gastown", "gastown")
+
+	orphans, err := FindOrphanedDatabases(townRoot)
+	if err != nil {
+		t.Fatalf("FindOrphanedDatabases: %v", err)
+	}
+	if len(orphans) != 1 {
+		t.Fatalf("expected only the real orphan, got %d: %v", len(orphans), orphans)
+	}
+	if orphans[0].Name != "old_setup" {
+		t.Fatalf("expected orphan old_setup, got %q", orphans[0].Name)
+	}
+
+	owners := CollectDatabaseOwners(townRoot)
+	if owner := owners["beads_global"]; owner != "Beads shared-server global database" {
+		t.Fatalf("expected beads_global owner label, got %q", owner)
+	}
+}
+
 func TestFindOrphanedDatabases_MultipleOrphans(t *testing.T) {
 	townRoot := t.TempDir()
 	dataDir := filepath.Join(townRoot, ".dolt-data")


### PR DESCRIPTION
Recovery PR for gt-09kp from gastown/furiosa after push_failed.\n\nCommit: d9e701253c4992d0b3c0bee7f03d27319515154d\nBackup: /Users/bbriski/gt/recovery-backups/gt-09kp-furiosa-d9e70125-20260501T192430Z\n\nThis patch differs from the older nux recovery PR #3823 (different stable patch-id) and includes the latest furiosa verification notes on gt-09kp.\n\nReported verification from the completed work:\n- make build passes\n- go test ./internal/doltserver passes\n- go vet ./internal/doltserver passes\n- ./gt dolt status no longer reports beads_global as an orphan\n- ./gt dolt cleanup --dry-run reports no orphaned databases\n- ./gt dolt list labels beads_global as a Beads shared-server global database\n\nFull go test ./... was attempted by the worker but still has unrelated existing failures outside this change.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3827"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->