### PR TITLE
fix: reduce mail inbox dolt churn (gt-05ld)

### DIFF
--- a/internal/cmd/mail_check.go
+++ b/internal/cmd/mail_check.go
@@ -45,8 +45,9 @@ func runMailCheck(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("getting mailbox: %w", err)
 	}
 
-	// Count unread
-	_, unread, err := mailbox.Count()
+	// Load the inbox once. The inject path needs unread messages later, and
+	// calling Count() followed by ListUnread() doubles bd/Dolt reads.
+	messages, _, unread, err := loadInboxSnapshot(mailbox, false)
 	if err != nil {
 		if mailCheckInject {
 			fmt.Fprintf(os.Stderr, "gt mail check: count error for %s: %v\n", address, err)
@@ -90,11 +91,7 @@ func runMailCheck(cmd *cobra.Command, args []string) error {
 		}
 
 		if unread > 0 {
-			messages, listErr := mailbox.ListUnread()
-			if listErr != nil {
-				fmt.Fprintf(os.Stderr, "gt mail check: could not list unread for %s: %v\n", address, listErr)
-				return nil
-			}
+			messages = filterUnreadMessages(messages)
 			fmt.Print(formatInjectOutput(messages))
 			// Ack after output so message is delivered before being marked acked.
 			if ackErr := mailbox.AcknowledgeDeliveries(address, messages); ackErr != nil {

--- a/internal/cmd/mail_check.go
+++ b/internal/cmd/mail_check.go
@@ -50,10 +50,10 @@ func runMailCheck(cmd *cobra.Command, args []string) error {
 	messages, _, unread, err := loadInboxSnapshot(mailbox, false)
 	if err != nil {
 		if mailCheckInject {
-			fmt.Fprintf(os.Stderr, "gt mail check: count error for %s: %v\n", address, err)
+			fmt.Fprintf(os.Stderr, "gt mail check: inbox load error for %s: %v\n", address, err)
 			return nil
 		}
-		return fmt.Errorf("counting messages: %w", err)
+		return fmt.Errorf("loading inbox: %w", err)
 	}
 
 	// JSON output

--- a/internal/cmd/mail_inbox.go
+++ b/internal/cmd/mail_inbox.go
@@ -53,20 +53,11 @@ func runMailInbox(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Get messages
-	// --all is the default behavior (shows all messages)
-	// --unread filters to only unread messages
-	var messages []*mail.Message
-	if mailInboxUnread {
-		messages, err = mailbox.ListUnread()
-	} else {
-		messages, err = mailbox.List()
-	}
+	// Load the inbox once. Count() and ListUnread() both call List(), so using
+	// them here doubles the bd/Dolt reads on the hot patrol path.
+	messages, total, unread, err := loadInboxSnapshot(mailbox, mailInboxUnread)
 	if err != nil {
 		return fmt.Errorf("listing messages: %w", err)
-	}
-	if messages == nil {
-		messages = make([]*mail.Message, 0)
 	}
 
 	// JSON output
@@ -76,18 +67,10 @@ func runMailInbox(cmd *cobra.Command, args []string) error {
 		if err := enc.Encode(messages); err != nil {
 			return err
 		}
-		// Ack after output so JSON reflects accurate read-time state.
-		if ackErr := mailbox.AcknowledgeDeliveries(address, messages); ackErr != nil {
-			fmt.Fprintf(os.Stderr, "gt mail inbox: delivery ack failed: %v\n", ackErr)
-		}
 		return nil
 	}
 
 	// Human-readable output
-	total, unread, err := mailbox.Count()
-	if err != nil {
-		style.PrintWarning("could not count messages: %v", err)
-	}
 	fmt.Printf("%s Inbox: %s (%d messages, %d unread)\n\n",
 		style.Bold.Render("📬"), address, total, unread)
 
@@ -124,12 +107,47 @@ func runMailInbox(cmd *cobra.Command, args []string) error {
 			style.Dim.Render(msg.Timestamp.Local().Format("2006-01-02 15:04")))
 	}
 
-	// Ack after output so human-readable display is not delayed by bd subprocesses.
-	if ackErr := mailbox.AcknowledgeDeliveries(address, messages); ackErr != nil {
-		fmt.Fprintf(os.Stderr, "gt mail inbox: delivery ack failed: %v\n", ackErr)
+	return nil
+}
+
+type inboxLister interface {
+	List() ([]*mail.Message, error)
+}
+
+func loadInboxSnapshot(mailbox inboxLister, unreadOnly bool) ([]*mail.Message, int, int, error) {
+	allMessages, err := mailbox.List()
+	if err != nil {
+		return nil, 0, 0, err
+	}
+	if allMessages == nil {
+		allMessages = make([]*mail.Message, 0)
 	}
 
-	return nil
+	total, unread := countInboxMessages(allMessages)
+	if unreadOnly {
+		return filterUnreadMessages(allMessages), total, unread, nil
+	}
+	return allMessages, total, unread, nil
+}
+
+func countInboxMessages(messages []*mail.Message) (total, unread int) {
+	total = len(messages)
+	for _, msg := range messages {
+		if msg != nil && !msg.Read {
+			unread++
+		}
+	}
+	return total, unread
+}
+
+func filterUnreadMessages(messages []*mail.Message) []*mail.Message {
+	unreadMessages := make([]*mail.Message, 0)
+	for _, msg := range messages {
+		if msg != nil && !msg.Read {
+			unreadMessages = append(unreadMessages, msg)
+		}
+	}
+	return unreadMessages
 }
 
 func runMailRead(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/mail_inbox_test.go
+++ b/internal/cmd/mail_inbox_test.go
@@ -1,0 +1,83 @@
+package cmd
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/mail"
+)
+
+type fakeInboxLister struct {
+	calls    int
+	messages []*mail.Message
+	err      error
+}
+
+func (f *fakeInboxLister) List() ([]*mail.Message, error) {
+	f.calls++
+	return f.messages, f.err
+}
+
+func TestLoadInboxSnapshotListsOnceAndCounts(t *testing.T) {
+	box := &fakeInboxLister{
+		messages: []*mail.Message{
+			{ID: "msg-1", Read: false},
+			{ID: "msg-2", Read: true},
+			{ID: "msg-3", Read: false},
+		},
+	}
+
+	messages, total, unread, err := loadInboxSnapshot(box, false)
+	if err != nil {
+		t.Fatalf("loadInboxSnapshot returned error: %v", err)
+	}
+	if box.calls != 1 {
+		t.Fatalf("List calls = %d, want 1", box.calls)
+	}
+	if total != 3 || unread != 2 {
+		t.Fatalf("counts = (%d total, %d unread), want (3, 2)", total, unread)
+	}
+	if len(messages) != 3 {
+		t.Fatalf("messages len = %d, want 3", len(messages))
+	}
+}
+
+func TestLoadInboxSnapshotUnreadOnlyFiltersAfterSingleList(t *testing.T) {
+	box := &fakeInboxLister{
+		messages: []*mail.Message{
+			{ID: "msg-1", Read: false},
+			{ID: "msg-2", Read: true},
+			{ID: "msg-3", Read: false},
+		},
+	}
+
+	messages, total, unread, err := loadInboxSnapshot(box, true)
+	if err != nil {
+		t.Fatalf("loadInboxSnapshot returned error: %v", err)
+	}
+	if box.calls != 1 {
+		t.Fatalf("List calls = %d, want 1", box.calls)
+	}
+	if total != 3 || unread != 2 {
+		t.Fatalf("counts = (%d total, %d unread), want (3, 2)", total, unread)
+	}
+	if len(messages) != 2 {
+		t.Fatalf("filtered messages len = %d, want 2", len(messages))
+	}
+	if messages[0].ID != "msg-1" || messages[1].ID != "msg-3" {
+		t.Fatalf("filtered messages = [%s %s], want [msg-1 msg-3]", messages[0].ID, messages[1].ID)
+	}
+}
+
+func TestLoadInboxSnapshotPropagatesListError(t *testing.T) {
+	wantErr := errors.New("list failed")
+	box := &fakeInboxLister{err: wantErr}
+
+	_, _, _, err := loadInboxSnapshot(box, false)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("error = %v, want %v", err, wantErr)
+	}
+	if box.calls != 1 {
+		t.Fatalf("List calls = %d, want 1", box.calls)
+	}
+}

--- a/internal/mail/delivery.go
+++ b/internal/mail/delivery.go
@@ -95,7 +95,7 @@ func AcknowledgeDeliveryBead(workDir, beadsDir, beadID, recipientIdentity string
 		fmt.Fprintf(os.Stderr, "delivery ack: could not read labels for %s: %v (proceeding with fresh timestamp)\n", beadID, readErr)
 	}
 
-	for _, label := range DeliveryAckLabelSequenceIdempotent(recipientIdentity, timeNow().UTC(), existingLabels) {
+	for _, label := range DeliveryAckLabelsToWrite(recipientIdentity, timeNow().UTC(), existingLabels) {
 		args := []string{"label", "add", beadID, label}
 		ctx, cancel := bdWriteCtx()
 		_, err := runBdCommand(ctx, args, workDir, beadsDir)
@@ -109,6 +109,30 @@ func AcknowledgeDeliveryBead(workDir, beadsDir, beadID, recipientIdentity string
 		return err
 	}
 	return nil
+}
+
+// DeliveryAckLabelsToWrite returns the idempotent ack labels that are not
+// already present. This avoids duplicate bd label-add calls, which otherwise
+// attempt a Dolt commit and produce "nothing to commit" warnings.
+func DeliveryAckLabelsToWrite(recipientIdentity string, at time.Time, existingLabels []string) []string {
+	sequence := DeliveryAckLabelSequenceIdempotent(recipientIdentity, at, existingLabels)
+	if len(existingLabels) == 0 {
+		return sequence
+	}
+
+	existing := make(map[string]struct{}, len(existingLabels))
+	for _, label := range existingLabels {
+		existing[label] = struct{}{}
+	}
+
+	missing := make([]string, 0, len(sequence))
+	for _, label := range sequence {
+		if _, ok := existing[label]; ok {
+			continue
+		}
+		missing = append(missing, label)
+	}
+	return missing
 }
 
 // routedBeadsDirForID returns the BEADS_DIR value to pass into runBdCommand

--- a/internal/mail/delivery.go
+++ b/internal/mail/delivery.go
@@ -95,7 +95,7 @@ func AcknowledgeDeliveryBead(workDir, beadsDir, beadID, recipientIdentity string
 		fmt.Fprintf(os.Stderr, "delivery ack: could not read labels for %s: %v (proceeding with fresh timestamp)\n", beadID, readErr)
 	}
 
-	for _, label := range DeliveryAckLabelsToWrite(recipientIdentity, timeNow().UTC(), existingLabels) {
+	for _, label := range deliveryAckLabelsToWrite(recipientIdentity, timeNow().UTC(), existingLabels) {
 		args := []string{"label", "add", beadID, label}
 		ctx, cancel := bdWriteCtx()
 		_, err := runBdCommand(ctx, args, workDir, beadsDir)
@@ -111,10 +111,10 @@ func AcknowledgeDeliveryBead(workDir, beadsDir, beadID, recipientIdentity string
 	return nil
 }
 
-// DeliveryAckLabelsToWrite returns the idempotent ack labels that are not
+// deliveryAckLabelsToWrite returns the idempotent ack labels that are not
 // already present. This avoids duplicate bd label-add calls, which otherwise
 // attempt a Dolt commit and produce "nothing to commit" warnings.
-func DeliveryAckLabelsToWrite(recipientIdentity string, at time.Time, existingLabels []string) []string {
+func deliveryAckLabelsToWrite(recipientIdentity string, at time.Time, existingLabels []string) []string {
 	sequence := DeliveryAckLabelSequenceIdempotent(recipientIdentity, at, existingLabels)
 	if len(existingLabels) == 0 {
 		return sequence

--- a/internal/mail/delivery_test.go
+++ b/internal/mail/delivery_test.go
@@ -180,3 +180,33 @@ func TestDeliveryAckLabelSequenceIdempotent(t *testing.T) {
 		}
 	})
 }
+
+func TestDeliveryAckLabelsToWriteSkipsExistingLabels(t *testing.T) {
+	at := time.Date(2026, 2, 17, 14, 0, 0, 0, time.UTC)
+
+	t.Run("partial retry only writes missing ack label", func(t *testing.T) {
+		existing := []string{
+			"delivery:pending",
+			"delivery-acked-by:gastown/worker",
+			"delivery-acked-at:2026-02-17T12:00:00Z",
+		}
+		got := DeliveryAckLabelsToWrite("gastown/worker", at, existing)
+		want := []string{"delivery:acked"}
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("complete retry writes nothing", func(t *testing.T) {
+		existing := []string{
+			"delivery:pending",
+			"delivery-acked-by:gastown/worker",
+			"delivery-acked-at:2026-02-17T12:00:00Z",
+			"delivery:acked",
+		}
+		got := DeliveryAckLabelsToWrite("gastown/worker", at, existing)
+		if len(got) != 0 {
+			t.Fatalf("got %v, want no labels", got)
+		}
+	})
+}

--- a/internal/mail/delivery_test.go
+++ b/internal/mail/delivery_test.go
@@ -190,7 +190,7 @@ func TestDeliveryAckLabelsToWriteSkipsExistingLabels(t *testing.T) {
 			"delivery-acked-by:gastown/worker",
 			"delivery-acked-at:2026-02-17T12:00:00Z",
 		}
-		got := DeliveryAckLabelsToWrite("gastown/worker", at, existing)
+		got := deliveryAckLabelsToWrite("gastown/worker", at, existing)
 		want := []string{"delivery:acked"}
 		if !reflect.DeepEqual(got, want) {
 			t.Fatalf("got %v, want %v", got, want)
@@ -204,7 +204,7 @@ func TestDeliveryAckLabelsToWriteSkipsExistingLabels(t *testing.T) {
 			"delivery-acked-at:2026-02-17T12:00:00Z",
 			"delivery:acked",
 		}
-		got := DeliveryAckLabelsToWrite("gastown/worker", at, existing)
+		got := deliveryAckLabelsToWrite("gastown/worker", at, existing)
 		if len(got) != 0 {
 			t.Fatalf("got %v, want no labels", got)
 		}


### PR DESCRIPTION
## Summary

- Make `gt mail inbox` load one mailbox snapshot and derive total/unread counts in memory.
- Keep `gt mail inbox` read-only by removing delivery acknowledgement writes from the inbox display path.
- Keep delivery acknowledgements on intentional delivery/read paths, but skip already-present ack labels to avoid duplicate Dolt commit attempts.

## Root Cause

`gt mail inbox` called `List()` and then `Count()`, where `Count()` called `List()` again. It also acknowledged deliveries after rendering inbox output, so a read-only patrol check could spawn bd label writes and Dolt commit attempts. Ack retries could add labels that already existed, surfacing Dolt `nothing to commit` warnings.

## Validation

- `go test ./internal/mail`
- `go test ./internal/cmd -run 'TestLoadInboxSnapshot'`
- `make build`
- Representative live timing with built `./gt mail inbox --identity gastown/polecats/furiosa`: 0.90s, 0.58s, 0.92s

## Notes

This branch preserves recovery commit `55ef9393` and adds follow-up cleanup in `43b08f73` per the Gas Town recovery request for `gt-05ld`.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3830"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->