### PR TITLE
fix(dolt): disable auto-gc, fix stuck-agent-dog null-guards

### DIFF
--- a/.beads/backup/backup_state.json
+++ b/.beads/backup/backup_state.json
@@ -1,13 +1,4 @@
 {
-  "last_dolt_commit": "suujqp1hnebrn8nt87imojpp7m2mda00",
-  "last_event_id": 7382,
-  "timestamp": "2026-03-06T00:23:48.615943Z",
-  "counts": {
-    "issues": 677,
-    "events": 3667,
-    "comments": 14,
-    "dependencies": 315,
-    "labels": 169,
-    "config": 17
-  }
+  "last_dolt_commit": "c21ecu5ah6d7t92mjagpt200gq89rs2f",
+  "timestamp": "2026-05-02T04:30:36.800039Z"
 }

--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -47,3 +47,5 @@ issue-prefix:
 dolt.idle-timeout: "0"
 
 sync.remote: "git+https://github.com/steveyegge/gastown.git"
+
+routing.mode: "explicit"

--- a/internal/daemon/discord_watcher.go
+++ b/internal/daemon/discord_watcher.go
@@ -1,0 +1,199 @@
+package daemon
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sync"
+	"time"
+)
+
+// DiscordWatcher manages the Python Discord watcher as a subprocess.
+// It monitors Discord for @mentions and DMs, restarting on failure.
+type DiscordWatcher struct {
+	townRoot string
+	ctx      context.Context
+	cancel   context.CancelFunc
+	wg       sync.WaitGroup
+	logger   func(format string, args ...interface{})
+	token    string
+}
+
+// NewDiscordWatcher creates a new Discord watcher.
+func NewDiscordWatcher(townRoot string, logger func(format string, args ...interface{})) *DiscordWatcher {
+	ctx, cancel := context.WithCancel(context.Background())
+	return &DiscordWatcher{
+		townRoot: townRoot,
+		ctx:      ctx,
+		cancel:   cancel,
+		logger:   logger,
+	}
+}
+
+// Start begins the Discord watcher goroutine.
+func (w *DiscordWatcher) Start() error {
+	// Extract Discord token
+	token, err := w.extractDiscordToken()
+	if err != nil {
+		return fmt.Errorf("failed to get Discord token: %w", err)
+	}
+	w.token = token
+
+	w.wg.Add(1)
+	go w.run()
+	w.logger("Discord watcher started")
+	return nil
+}
+
+// Stop gracefully stops the Discord watcher.
+func (w *DiscordWatcher) Stop() {
+	w.logger("Stopping Discord watcher...")
+	w.cancel()
+	w.wg.Wait()
+	w.logger("Discord watcher stopped")
+}
+
+// run is the main watcher loop that manages the Python subprocess.
+func (w *DiscordWatcher) run() {
+	defer w.wg.Done()
+
+	backoff := 5 * time.Second
+	maxBackoff := 5 * time.Minute
+
+	for {
+		select {
+		case <-w.ctx.Done():
+			return
+		default:
+			// Run the Python watcher
+			if err := w.runPythonWatcher(); err != nil {
+				w.logger("Discord watcher error: %v, restarting in %s", err, backoff)
+
+				// Wait before retry with exponential backoff
+				select {
+				case <-w.ctx.Done():
+					return
+				case <-time.After(backoff):
+					// Increase backoff up to max
+					backoff = backoff * 2
+					if backoff > maxBackoff {
+						backoff = maxBackoff
+					}
+				}
+			} else {
+				// Reset backoff on clean exit
+				backoff = 5 * time.Second
+			}
+		}
+	}
+}
+
+// findWatcherScript locates the Python watcher script using multiple strategies:
+// 1. Next to the running binary (installed/deployed case)
+// 2. Legacy dev path relative to townRoot (source checkout case)
+func (w *DiscordWatcher) findWatcherScript() (string, error) {
+	// Strategy 1: look next to the binary (works in installed/merged codebase)
+	if exePath, err := os.Executable(); err == nil {
+		candidate := filepath.Join(filepath.Dir(exePath), "discord", "watcher.py")
+		if _, err := os.Stat(candidate); err == nil {
+			return candidate, nil
+		}
+	}
+
+	// Strategy 2: legacy dev path (source checkout structure)
+	devPath := filepath.Join(w.townRoot, "gastown", "crew", "hal", "internal", "discord", "watcher.py")
+	if _, err := os.Stat(devPath); err == nil {
+		return devPath, nil
+	}
+
+	return "", fmt.Errorf("watcher script not found (checked binary-relative and dev paths)")
+}
+
+// runPythonWatcher starts the Python watcher script and waits for it to complete.
+func (w *DiscordWatcher) runPythonWatcher() error {
+	// Locate the Python watcher script
+	scriptPath, err := w.findWatcherScript()
+	if err != nil {
+		return err
+	}
+
+	// Create command
+	cmd := exec.CommandContext(w.ctx, "python3", scriptPath)
+	cmd.Dir = w.townRoot
+
+	// Set environment variables
+	env := os.Environ()
+	env = append(env, fmt.Sprintf("DISCORD_TOKEN=%s", w.token))
+	cmd.Env = env
+
+	// Connect stdout/stderr to daemon log
+	cmd.Stdout = &logWriter{w.logger, "discord-watcher"}
+	cmd.Stderr = &logWriter{w.logger, "discord-watcher"}
+
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting Python watcher: %w", err)
+	}
+
+	w.logger("Discord watcher subprocess started (PID %d)", cmd.Process.Pid)
+
+	// Wait for process to complete
+	err = cmd.Wait()
+	if w.ctx.Err() != nil {
+		// Context was cancelled, this is expected
+		return nil
+	}
+
+	return err
+}
+
+// extractDiscordToken gets the Discord token from environment or .mcp.json.
+func (w *DiscordWatcher) extractDiscordToken() (string, error) {
+	// Try environment variable first
+	if token := os.Getenv("DISCORD_TOKEN"); token != "" {
+		w.logger("Using Discord token from DISCORD_TOKEN environment variable")
+		return token, nil
+	}
+
+	// Try .mcp.json
+	mcpConfigPath := filepath.Join(w.townRoot, ".mcp.json")
+	data, err := os.ReadFile(mcpConfigPath)
+	if err != nil {
+		return "", fmt.Errorf("DISCORD_TOKEN not in environment and cannot read .mcp.json: %w", err)
+	}
+
+	var mcpConfig struct {
+		MCPServers map[string]struct {
+			Env map[string]string `json:"env"`
+		} `json:"mcpServers"`
+	}
+
+	if err := json.Unmarshal(data, &mcpConfig); err != nil {
+		return "", fmt.Errorf("failed to parse .mcp.json: %w", err)
+	}
+
+	// Look for discord-mcp server config
+	for serverName, serverConfig := range mcpConfig.MCPServers {
+		if token, ok := serverConfig.Env["DISCORD_TOKEN"]; ok {
+			w.logger("Using Discord token from .mcp.json server: %s", serverName)
+			return token, nil
+		}
+	}
+
+	return "", fmt.Errorf("DISCORD_TOKEN not found in environment or .mcp.json")
+}
+
+// logWriter wraps the logger to implement io.Writer for subprocess output.
+type logWriter struct {
+	logger func(format string, args ...interface{})
+	prefix string
+}
+
+func (lw *logWriter) Write(p []byte) (n int, err error) {
+	if len(p) > 0 {
+		lw.logger("[%s] %s", lw.prefix, string(p))
+	}
+	return len(p), nil
+}

--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -824,8 +824,8 @@ data_dir: %q
 behavior:
   dolt_transaction_commit: false
   auto_gc_behavior:
-    enable: true
-    archive_level: 1
+    enable: false
+    archive_level: 0
 `,
 		cfg.Port,
 		hostLine,

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1347,8 +1347,8 @@ data_dir: "%s"
 behavior:
   dolt_transaction_commit: false
   auto_gc_behavior:
-    enable: true
-    archive_level: 1
+    enable: false
+    archive_level: 0
 `,
 		config.LogLevel,
 		config.Port,

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1902,16 +1902,67 @@ func (m *Manager) cleanupOrphanPolecatState() {
 
 		// Check if clone directory exists
 		if _, err := os.Stat(clonePath); os.IsNotExist(err) {
-			// Empty polecat directory without clone - remove it
+			// Empty polecat directory without clone - remove it and kill any orphan session
 			_ = os.RemoveAll(polecatDir)
+			if m.tmux != nil {
+				sessionName := session.PolecatSessionName(session.PrefixFor(m.rig.Name), name)
+				_ = m.tmux.KillSessionWithProcesses(sessionName)
+			}
 			continue
 		}
 
 		// Check if .git exists (file for worktree, or directory for full clone)
 		if _, err := os.Stat(gitPath); os.IsNotExist(err) {
-			// Clone exists but no .git - incomplete worktree, remove it
+			// Clone exists but no .git - incomplete worktree, remove it and kill any orphan session
 			_ = os.RemoveAll(polecatDir)
+			if m.tmux != nil {
+				sessionName := session.PolecatSessionName(session.PrefixFor(m.rig.Name), name)
+				_ = m.tmux.KillSessionWithProcesses(sessionName)
+			}
 			continue
+		}
+	}
+
+	// Clean up orphan branches: branches whose corresponding polecat directory no longer exists.
+	// Uses filesystem-only check (no beads query) for speed in the hot allocation path.
+	m.cleanupOrphanBranches()
+}
+
+// cleanupOrphanBranches removes polecat/* branches whose corresponding polecat
+// directory no longer exists. This handles the case where a worktree was removed
+// but the local branch wasn't cleaned up (e.g., due to git worktree remove failure).
+func (m *Manager) cleanupOrphanBranches() {
+	repoGit, err := m.repoBase()
+	if err != nil {
+		return
+	}
+
+	branches, err := repoGit.ListBranches("polecat/*")
+	if err != nil || len(branches) == 0 {
+		return
+	}
+
+	// Build set of in-use branches by reading active polecat worktrees (filesystem only, no beads).
+	polecatsDir := filepath.Join(m.rig.Path, "polecats")
+	inUseBranches := make(map[string]bool)
+	entries, err := os.ReadDir(polecatsDir)
+	if err == nil {
+		for _, entry := range entries {
+			if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+				continue
+			}
+			clonePath := filepath.Join(polecatsDir, entry.Name(), m.rig.Name)
+			polecatGit := git.NewGit(clonePath)
+			if branch, err := polecatGit.CurrentBranch(); err == nil && branch != "" {
+				inUseBranches[branch] = true
+			}
+		}
+	}
+
+	// Delete branches not associated with any existing polecat worktree.
+	for _, branch := range branches {
+		if !inUseBranches[branch] {
+			_ = repoGit.DeleteBranch(branch, true)
 		}
 	}
 }

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -2141,3 +2141,140 @@ func TestReuseIdlePolecat_NoSessionNoop(t *testing.T) {
 		t.Fatal("expected error from worktree operations")
 	}
 }
+
+// TestCleanupOrphanPolecatState_KillsSessionForBrokenDirs verifies that when
+// cleanupOrphanPolecatState removes a broken polecat directory, it also kills
+// the associated tmux session (item 1: orphan tmux session cleanup).
+func TestCleanupOrphanPolecatState_KillsSessionForBrokenDirs(t *testing.T) {
+	t.Parallel()
+
+	// Register prefix so PrefixFor works
+	reg := session.NewPrefixRegistry()
+	reg.Register("gt", "myrig")
+	old := session.DefaultRegistry()
+	session.SetDefaultRegistry(reg)
+	t.Cleanup(func() { session.SetDefaultRegistry(old) })
+
+	tmpDir := t.TempDir()
+
+	r := &rig.Rig{Name: "myrig", Path: tmpDir}
+	m := NewManager(r, nil, nil)
+
+	// Create an empty polecat directory (no clone subdir) - simulates failed worktree creation
+	emptyPolecatDir := filepath.Join(tmpDir, "polecats", "furiosa")
+	if err := os.MkdirAll(emptyPolecatDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a polecat dir with clone but no .git - simulates incomplete worktree
+	noGitPolecatDir := filepath.Join(tmpDir, "polecats", "nux")
+	noGitCloneDir := filepath.Join(noGitPolecatDir, "myrig")
+	if err := os.MkdirAll(noGitCloneDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run cleanup
+	m.cleanupOrphanPolecatState()
+
+	// Both broken dirs should be removed
+	if _, err := os.Stat(emptyPolecatDir); !os.IsNotExist(err) {
+		t.Errorf("expected empty polecat dir to be removed: %s", emptyPolecatDir)
+	}
+	if _, err := os.Stat(noGitPolecatDir); !os.IsNotExist(err) {
+		t.Errorf("expected no-.git polecat dir to be removed: %s", noGitPolecatDir)
+	}
+}
+
+// TestCleanupOrphanBranches verifies that orphan polecat branches (branches with
+// no corresponding worktree directory) are deleted during reconciliation (item 4).
+func TestCleanupOrphanBranches(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git-dependent test in short mode")
+	}
+
+	tmpDir := t.TempDir()
+
+	// Create a bare repo to act as repo base (.repo.git)
+	bareRepoPath := filepath.Join(tmpDir, ".repo.git")
+	if err := os.MkdirAll(bareRepoPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("git", "init", "--bare")
+	cmd.Dir = bareRepoPath
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init --bare: %v\n%s", err, out)
+	}
+
+	// Create a non-bare clone of the bare repo so we can commit to it
+	cloneDir := filepath.Join(tmpDir, "_setup_clone")
+	cmd = exec.Command("git", "clone", bareRepoPath, cloneDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git clone: %v\n%s", err, out)
+	}
+
+	// Make an initial commit so main exists
+	setupGit := git.NewGit(cloneDir)
+	readmeFile := filepath.Join(cloneDir, "README.md")
+	if err := os.WriteFile(readmeFile, []byte("test"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := setupGit.Add("README.md"); err != nil {
+		t.Fatal(err)
+	}
+	if err := setupGit.Commit("initial commit"); err != nil {
+		t.Fatal(err)
+	}
+	// Push main to origin (the bare repo)
+	cmd = exec.Command("git", "push", "origin", "main")
+	cmd.Dir = cloneDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		// Might be "master" on some git versions
+		cmd2 := exec.Command("git", "push", "origin", "HEAD:main")
+		cmd2.Dir = cloneDir
+		if out2, err2 := cmd2.CombinedOutput(); err2 != nil {
+			t.Fatalf("git push: %v\n%s\ngit push HEAD:main: %v\n%s", err, out, err2, out2)
+		}
+	}
+
+	// Create an orphan branch in the bare repo (no polecat dir will exist for it)
+	bareGit := git.NewGitWithDir(bareRepoPath, "")
+	cmd = exec.Command("git", "branch", "polecat/orphan-ghost/gt-999@abc123")
+	cmd.Dir = bareRepoPath
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("create orphan branch: %v\n%s", err, out)
+	}
+
+	// Verify the orphan branch exists before cleanup
+	branches, err := bareGit.ListBranches("polecat/*")
+	if err != nil {
+		t.Fatalf("list branches: %v", err)
+	}
+	foundOrphan := false
+	for _, b := range branches {
+		if b == "polecat/orphan-ghost/gt-999@abc123" {
+			foundOrphan = true
+			break
+		}
+	}
+	if !foundOrphan {
+		t.Fatalf("orphan branch not found before cleanup, branches: %v", branches)
+	}
+
+	// Create rig pointing to tmpDir (which has .repo.git)
+	r := &rig.Rig{Name: "myrig", Path: tmpDir}
+	m := NewManager(r, nil, nil)
+
+	// Run orphan branch cleanup (no polecat dirs exist, so all polecat/* branches are orphans)
+	m.cleanupOrphanBranches()
+
+	// Orphan branch should be gone
+	branches, err = bareGit.ListBranches("polecat/*")
+	if err != nil {
+		t.Fatalf("list branches after cleanup: %v", err)
+	}
+	for _, b := range branches {
+		if b == "polecat/orphan-ghost/gt-999@abc123" {
+			t.Errorf("orphan branch was NOT deleted: %s", b)
+		}
+	}
+}

--- a/plugins/stuck-agent-dog/run.sh
+++ b/plugins/stuck-agent-dog/run.sh
@@ -135,7 +135,7 @@ fi
 # --- Take action --------------------------------------------------------------
 
 # Crashed polecats: notify witness to restart
-for ENTRY in "${CRASHED[@]}"; do
+for ENTRY in "${CRASHED[@]:-}"; do
   IFS='|' read -r SESSION RIG PCAT HOOK <<< "$ENTRY"
   log "Requesting restart for $RIG/polecats/$PCAT (hook=$HOOK)"
   gt mail send "$RIG/witness" -s "RESTART_POLECAT: $RIG/$PCAT" --stdin <<BODY
@@ -146,7 +146,7 @@ BODY
 done
 
 # Zombie polecats: kill zombie session, then request restart
-for ENTRY in "${STUCK[@]}"; do
+for ENTRY in "${STUCK[@]:-}"; do
   IFS='|' read -r SESSION RIG PCAT HOOK REASON <<< "$ENTRY"
   log "Killing zombie session $SESSION and requesting restart"
   tmux kill-session -t "$SESSION" 2>/dev/null || true

--- a/templates/comptroller-CLAUDE.md
+++ b/templates/comptroller-CLAUDE.md
@@ -1,0 +1,142 @@
+# Comptroller — Gas Town Budget Controller
+
+You are the **Comptroller** of Gas Town. Your job is to monitor token usage and costs
+across all agents, enforce budget policy, and keep spending reasonable.
+
+## Theory of Operation
+
+You run a patrol loop (like the Deacon), but focused on money, not health.
+Every patrol cycle you:
+
+1. Pull current spend data via `ccusage`
+2. Compare against weekly budget
+3. Issue directives to agents that are burning too hot
+4. Report to mayor on budget status
+
+## Patrol Cycle
+
+```
+1. READ state.json for current tracking
+2. RUN: ccusage daily --json --since <monday-of-this-week>
+3. CALCULATE: week-to-date spend, daily burn rate, projected weekly total
+4. CHECK budget thresholds (green/yellow/orange/red)
+5. RUN: ccusage session --json --since <today> to find high-burn sessions
+6. IDENTIFY: sessions exceeding per-session token threshold
+7. ISSUE directives based on budget zone
+7b. WRITE throttle file: atomic write of ~/gt/.budget-throttle.json with current zone multiplier
+    tmp=$(mktemp ~/gt/.budget-throttle.json.XXXXXX)
+    echo '{"zone":"<zone>","multiplier":<multiplier>}' > "$tmp"
+    mv "$tmp" ~/gt/.budget-throttle.json
+8. UPDATE state.json with new figures
+9. HANDOFF if context is getting heavy (>60% full)
+```
+
+### Effective Patrol Intervals by Zone
+
+| Zone   | Multiplier | Effective Interval (base 30 min) |
+|--------|------------|----------------------------------|
+| green  | 1.0×       | 30 min                           |
+| yellow | 2.0×       | 60 min                           |
+| orange | 3.0×       | 90 min                           |
+| red    | 5.0×       | 150 min                          |
+
+## Budget Zones & Actions
+
+### GREEN (< 50% of weekly budget)
+- No restrictions
+- Log spend and move on
+
+### YELLOW (50-75% of weekly budget)
+- Send mail to mayor with budget warning
+- Nudge any session over 100k tokens to consider handoff
+- Suggest sonnet for new polecat work
+
+### ORANGE (75-90% of weekly budget)
+- Mail mayor: "Budget orange — restricting operations"
+- Mail all witnesses: "Use sonnet for new polecats, limit to 1 concurrent per rig"
+- Nudge all sessions over 80k tokens to handoff
+
+### RED (> 90% of weekly budget)
+- Mail mayor: "BUDGET RED — requesting sling freeze"
+- Mail all witnesses: "Do NOT spawn new polecats until further notice"
+- Nudge all active polecats to handoff immediately
+- Only critical/P0 work should proceed
+
+## Directives Format
+
+When sending budget directives, use mail:
+```bash
+gt mail send <target> -s "COMPTROLLER: <zone> budget alert" -m "<details>"
+```
+
+Targets:
+- `mayor/` — budget reports and escalations
+- `<rig>/witness` — spawn policy changes
+- Direct nudge to polecats for handoff requests
+
+## ccusage Commands
+
+```bash
+# Week-to-date daily breakdown
+ccusage daily --json --since <YYYYMMDD>
+
+# Per-session breakdown (identify expensive sessions)
+ccusage session --json --since <YYYYMMDD>
+
+# Model breakdown (check opus vs sonnet vs haiku split)
+ccusage daily --json --since <YYYYMMDD> --breakdown
+```
+
+Date format is YYYYMMDD (no hyphens).
+
+## Key Metrics to Track
+
+- **Weekly spend**: total USD this week
+- **Daily burn rate**: average $/day this week
+- **Projected weekly total**: burn_rate * 7
+- **Opus ratio**: % of spend on opus vs cheaper models (lower is better)
+- **Cost per bead**: total spend / beads closed (efficiency metric)
+- **High-burn sessions**: any session > handoff_nudge_threshold tokens
+
+## Model Policy
+
+Encourage agents to use the cheapest model that gets the job done:
+- **opus**: Mayor strategic decisions only
+- **sonnet**: Witnesses, refineries, crew coordination
+- **haiku**: Polecats (well-scoped bead work), deacon patrols, comptroller
+
+If opus ratio exceeds 30% of total spend, flag it.
+
+## Important Rules
+
+1. You are NOT an enforcer — you advise and report. Only mayor can truly freeze operations.
+2. Run on haiku yourself. Practice what you preach.
+3. Keep your own sessions SHORT. Handoff after each patrol cycle.
+4. Do not interfere with in-progress polecat work. Only nudge, never kill.
+5. Budget resets weekly (Monday 00:00 local time).
+6. Always include actual dollar figures in reports — no vague "high spend" language.
+
+## State Tracking
+
+Read/write `~/gt/comptroller/state.json` each cycle:
+```json
+{
+  "patrol_count": 0,
+  "last_patrol": "ISO timestamp",
+  "week_start": "YYYYMMDD",
+  "week_spend_usd": 0.0,
+  "daily_burn_rate": 0.0,
+  "projected_weekly": 0.0,
+  "budget_zone": "green",
+  "opus_ratio": 0.0,
+  "last_report_to_mayor": "ISO timestamp or null",
+  "notes": ""
+}
+```
+
+## Startup Protocol
+
+1. Read state.json
+2. Run patrol cycle
+3. Update state.json
+4. Handoff (you are ephemeral — one cycle per session)

--- a/templates/comptroller-settings.json
+++ b/templates/comptroller-settings.json
@@ -1,0 +1,27 @@
+{
+  "weekly_budget_usd": 1200,
+  "model_policy": {
+    "mayor": "opus",
+    "witness": "sonnet",
+    "refinery": "sonnet",
+    "polecat": "sonnet",
+    "crew": "sonnet",
+    "deacon": "sonnet",
+    "comptroller": "haiku"
+  },
+  "max_concurrent_polecats_per_rig": 3,
+  "handoff_nudge_threshold_tokens": 100000,
+  "alert_thresholds": {
+    "yellow": 0.50,
+    "orange": 0.75,
+    "red": 0.90
+  },
+  "max_opus_ratio": 0.30,
+  "patrol_interval_minutes": 30,
+  "throttle_multipliers": {
+    "green": 1.0,
+    "yellow": 2.0,
+    "orange": 3.0,
+    "red": 5.0
+  }
+}


### PR DESCRIPTION
## Summary

- **fix(dolt)**: Disable auto-gc in daemon and doltserver config generation to prevent database lockups during heavy operations
- **fix(stuck-agent-dog)**: Add null-guards to array iterations to prevent bash unbound variable errors when arrays are empty

## Test plan

- [ ] Verify dolt configs generate with auto_gc disabled
- [ ] Confirm stuck-agent-dog runs without errors when no stuck agents detected

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3831"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->