### PR TITLE
fix(resilience): subprocess timeout + parallel rig scan for Dolt memory pressure

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -434,6 +434,27 @@ func (b *Beads) Init(prefix string) error {
 	return err
 }
 
+// bdSubprocessTimeout caps how long a single bd subprocess may run before
+// being killed. Without this, bd can block indefinitely waiting on a slow
+// Dolt server (e.g. paging from swap under memory pressure), and macOS
+// Jetsam may SIGKILL the orphaned bd process before it ever returns.
+// 60s is large enough to cover normal slow-path retries (Dolt MySQL client
+// retries up to 30s) but short enough to fail fast and surface to callers.
+// Override via GT_BD_TIMEOUT_SEC env var for testing or unusual workloads.
+// Investigation: dc-1pq8 (forensic report 2026-05-02).
+const bdSubprocessTimeout = 60 * time.Second
+
+// resolveBdSubprocessTimeout returns the configured timeout, honoring the
+// GT_BD_TIMEOUT_SEC env var override (must parse as a positive integer).
+func resolveBdSubprocessTimeout() time.Duration {
+	if v := os.Getenv("GT_BD_TIMEOUT_SEC"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return bdSubprocessTimeout
+}
+
 // run executes a bd command and returns stdout.
 func (b *Beads) run(args ...string) (_ []byte, retErr error) {
 	start := time.Now()
@@ -457,10 +478,16 @@ func (b *Beads) run(args ...string) (_ []byte, retErr error) {
 	runEnv := append(b.buildRunEnv(), "BEADS_DIR="+beadsDir)
 	fullArgs := MaybePrependAllowStaleWithEnv(runEnv, args)
 
+	// Bound the subprocess runtime so a slow Dolt response doesn't leave bd
+	// blocking forever (under memory pressure that invites Jetsam SIGKILL).
+	// The context covers both the initial attempt and the --flat retry.
+	ctx, cancel := context.WithTimeout(context.Background(), resolveBdSubprocessTimeout())
+	defer cancel()
+
 	// Always explicitly set BEADS_DIR to prevent inherited env vars from
 	// causing prefix mismatches. Use explicit beadsDir if set, otherwise
 	// resolve from working directory.
-	cmd := exec.Command("bd", fullArgs...) //nolint:gosec // G204: bd is a trusted internal tool
+	cmd := exec.CommandContext(ctx, "bd", fullArgs...) //nolint:gosec // G204: bd is a trusted internal tool
 	util.SetDetachedProcessGroup(cmd)
 	cmd.Dir = b.workDir
 
@@ -484,7 +511,7 @@ func (b *Beads) run(args ...string) (_ []byte, retErr error) {
 		}
 		stdout.Reset()
 		stderr.Reset()
-		cmd = exec.Command("bd", retryArgs...) //nolint:gosec // G204: bd is a trusted internal tool
+		cmd = exec.CommandContext(ctx, "bd", retryArgs...) //nolint:gosec // G204: bd is a trusted internal tool
 		util.SetDetachedProcessGroup(cmd)
 		cmd.Dir = b.workDir
 		cmd.Env = runEnv
@@ -522,7 +549,11 @@ func (b *Beads) runWithRouting(args ...string) (_ []byte, retErr error) { //noli
 	runEnv := b.buildRoutingEnv()
 	fullArgs := MaybePrependAllowStaleWithEnv(runEnv, args)
 
-	cmd := exec.Command("bd", fullArgs...) //nolint:gosec // G204: bd is a trusted internal tool
+	// Bound subprocess runtime — see bdSubprocessTimeout doc comment.
+	ctx, cancel := context.WithTimeout(context.Background(), resolveBdSubprocessTimeout())
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "bd", fullArgs...) //nolint:gosec // G204: bd is a trusted internal tool
 	util.SetDetachedProcessGroup(cmd)
 	cmd.Dir = b.workDir
 

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -3376,3 +3376,34 @@ func TestIsSubprocessCrash(t *testing.T) {
 		})
 	}
 }
+
+// TestResolveBdSubprocessTimeout verifies the timeout default + GT_BD_TIMEOUT_SEC override.
+func TestResolveBdSubprocessTimeout(t *testing.T) {
+	tests := []struct {
+		name    string
+		envVal  string
+		envSet  bool
+		wantSec int
+	}{
+		{name: "default", envSet: false, wantSec: 60},
+		{name: "override 5s", envSet: true, envVal: "5", wantSec: 5},
+		{name: "override 120s", envSet: true, envVal: "120", wantSec: 120},
+		{name: "invalid falls to default", envSet: true, envVal: "abc", wantSec: 60},
+		{name: "zero falls to default", envSet: true, envVal: "0", wantSec: 60},
+		{name: "negative falls to default", envSet: true, envVal: "-1", wantSec: 60},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.envSet {
+				t.Setenv("GT_BD_TIMEOUT_SEC", tt.envVal)
+			} else {
+				_ = os.Unsetenv("GT_BD_TIMEOUT_SEC")
+			}
+			got := resolveBdSubprocessTimeout()
+			want := time.Duration(tt.wantSec) * time.Second
+			if got != want {
+				t.Errorf("resolveBdSubprocessTimeout() = %v, want %v", got, want)
+			}
+		})
+	}
+}

--- a/internal/doctor/stale_agent_beads_check.go
+++ b/internal/doctor/stale_agent_beads_check.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"path/filepath"
 	"strings"
+	"sync"
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/constants"
@@ -73,67 +74,86 @@ func (c *StaleAgentBeadsCheck) Run(ctx *CheckContext) *CheckResult {
 	}
 
 	var stale []string
+	var staleMu sync.Mutex
 
 	// Phase 1: Check known rigs for stale crew/polecat beads.
+	// Run rigs in parallel — each rig spawns 2 bd subprocesses (List +
+	// ListAgentBeadsFromWisps). With 6 rigs sequentially, that's 12 calls;
+	// under Dolt memory pressure each can take 30s of retry, so the check
+	// would block the whole doctor for ~6 minutes. Parallelizing collapses
+	// the wall-clock time to roughly the slowest single rig.
+	// Investigation: dc-1pq8 (forensic report 2026-05-02).
+	var wg sync.WaitGroup
 	for prefix, info := range prefixToRig {
-		rigBeadsPath := filepath.Join(ctx.TownRoot, info.beadsPath)
-		bd := beads.New(rigBeadsPath)
-		rigName := info.name
+		wg.Add(1)
+		go func(prefix string, info rigInfo) {
+			defer wg.Done()
 
-		// Get actual crew workers on disk
-		crewDiskWorkers := listCrewWorkers(ctx.TownRoot, rigName)
-		crewDiskSet := make(map[string]bool, len(crewDiskWorkers))
-		for _, w := range crewDiskWorkers {
-			crewDiskSet[w] = true
-		}
+			rigBeadsPath := filepath.Join(ctx.TownRoot, info.beadsPath)
+			bd := beads.New(rigBeadsPath)
+			rigName := info.name
 
-		// Get actual polecats on disk
-		polecatDiskWorkers := listPolecats(ctx.TownRoot, rigName)
-		polecatDiskSet := make(map[string]bool, len(polecatDiskWorkers))
-		for _, w := range polecatDiskWorkers {
-			polecatDiskSet[w] = true
-		}
+			// Get actual crew workers on disk
+			crewDiskWorkers := listCrewWorkers(ctx.TownRoot, rigName)
+			crewDiskSet := make(map[string]bool, len(crewDiskWorkers))
+			for _, w := range crewDiskWorkers {
+				crewDiskSet[w] = true
+			}
 
-		// Agent bead ID patterns:
-		// Crew:    prefix-rig-crew-name (or prefix-crew-name when prefix == rig)
-		// Polecat: prefix-rig-polecat-name (or prefix-polecat-name when prefix == rig)
-		// Use AgentBeadIDWithPrefix to get the correct prefix, handling the
-		// collapsed form when prefix == rigName (GH#1877).
-		crewPrefix := beads.AgentBeadIDWithPrefix(prefix, rigName, constants.RoleCrew, "") + "-"
-		polecatPrefix := beads.AgentBeadIDWithPrefix(prefix, rigName, constants.RolePolecat, "") + "-"
-		allBeads, err := bd.List(beads.ListOptions{
-			Status:   "open",
-			Priority: -1,
-			Label:    "gt:agent",
-		})
-		if err != nil {
-			continue
-		}
+			// Get actual polecats on disk
+			polecatDiskWorkers := listPolecats(ctx.TownRoot, rigName)
+			polecatDiskSet := make(map[string]bool, len(polecatDiskWorkers))
+			for _, w := range polecatDiskWorkers {
+				polecatDiskSet[w] = true
+			}
 
-		// Also check wisps table for migrated agent beads
-		if wispMap, _ := bd.ListAgentBeadsFromWisps(); len(wispMap) > 0 {
-			for _, w := range wispMap {
-				if w.Status == "open" || w.Status == "in_progress" || w.Status == "hooked" {
-					allBeads = append(allBeads, w)
+			// Agent bead ID patterns:
+			// Crew:    prefix-rig-crew-name (or prefix-crew-name when prefix == rig)
+			// Polecat: prefix-rig-polecat-name (or prefix-polecat-name when prefix == rig)
+			crewPrefix := beads.AgentBeadIDWithPrefix(prefix, rigName, constants.RoleCrew, "") + "-"
+			polecatPrefix := beads.AgentBeadIDWithPrefix(prefix, rigName, constants.RolePolecat, "") + "-"
+			allBeads, err := bd.List(beads.ListOptions{
+				Status:   "open",
+				Priority: -1,
+				Label:    "gt:agent",
+			})
+			if err != nil {
+				return
+			}
+
+			// Also check wisps table for migrated agent beads
+			if wispMap, _ := bd.ListAgentBeadsFromWisps(); len(wispMap) > 0 {
+				for _, w := range wispMap {
+					if w.Status == "open" || w.Status == "in_progress" || w.Status == "hooked" {
+						allBeads = append(allBeads, w)
+					}
 				}
 			}
-		}
 
-		for _, issue := range allBeads {
-			switch {
-			case strings.HasPrefix(issue.ID, crewPrefix):
-				workerName := strings.TrimPrefix(issue.ID, crewPrefix)
-				if workerName != "" && !crewDiskSet[workerName] {
-					stale = append(stale, issue.ID)
-				}
-			case strings.HasPrefix(issue.ID, polecatPrefix):
-				workerName := strings.TrimPrefix(issue.ID, polecatPrefix)
-				if workerName != "" && !polecatDiskSet[workerName] {
-					stale = append(stale, issue.ID)
+			var rigStale []string
+			for _, issue := range allBeads {
+				switch {
+				case strings.HasPrefix(issue.ID, crewPrefix):
+					workerName := strings.TrimPrefix(issue.ID, crewPrefix)
+					if workerName != "" && !crewDiskSet[workerName] {
+						rigStale = append(rigStale, issue.ID)
+					}
+				case strings.HasPrefix(issue.ID, polecatPrefix):
+					workerName := strings.TrimPrefix(issue.ID, polecatPrefix)
+					if workerName != "" && !polecatDiskSet[workerName] {
+						rigStale = append(rigStale, issue.ID)
+					}
 				}
 			}
-		}
+
+			if len(rigStale) > 0 {
+				staleMu.Lock()
+				stale = append(stale, rigStale...)
+				staleMu.Unlock()
+			}
+		}(prefix, info)
 	}
+	wg.Wait()
 
 	// Phase 2: Detect orphaned agent beads from deregistered rigs.
 	// Scan the town beads database for agent beads whose prefix doesn't match


### PR DESCRIPTION
## Problem

When the shared Dolt server is paged from swap (extreme memory pressure on the host), bd subprocesses block indefinitely waiting for slow MySQL responses. macOS Jetsam then SIGKILLs the orphaned bd processes, surfacing to gt as `"signal: killed"` across `gt mail`, `gt sling`, and `gt doctor`.

The `agent-beads-exist` doctor check amplifies the symptom: 6 rigs × 2 sequential bd calls × up to 30s of beadsdk retries = ~6 minutes of wall-clock hang on a single check, even when only one rig is slow.

**Forensic investigation:** [dc-1pq8 report](https://github.com/athosmartins/whatsapp-automation/blob/main/docs/investigations/dc-1pq8-dolt-instability-2026-05-02.md) — identified three failure modes sharing the same root cause (extreme memory pressure → Jetsam). Live observation: ~80MB free on a 16GB host with 13 concurrent Claude Code sessions + Dolt server + Homebrew `dolt send-metrics` background process eating 280MB and 48% CPU.

## Changes

### 1. `internal/beads/beads.go` — bound subprocess runtime

`run()` and `runWithRouting()` now use `exec.CommandContext` with a 60s default timeout (overridable via `GT_BD_TIMEOUT_SEC`). 60s comfortably covers beadsdk's 30s retry budget and fails fast enough to surface real problems.

```go
const bdSubprocessTimeout = 60 * time.Second

ctx, cancel := context.WithTimeout(context.Background(), resolveBdSubprocessTimeout())
defer cancel()
cmd := exec.CommandContext(ctx, "bd", fullArgs...)
```

### 2. `internal/doctor/stale_agent_beads_check.go` — parallelize Phase 1

The 6-rig loop now uses goroutines + `sync.Mutex` on the result slice. Wall-clock time collapses from sum-of-rigs to roughly the slowest single rig.

## What's NOT in this PR

Per-check timeout in `doctor.go:RunStreaming` was deferred — change #2 alone resolves the dominant ~6min hang case. Worth revisiting if other checks become problematic.

## Test plan

- [x] `TestResolveBdSubprocessTimeout` — default + `GT_BD_TIMEOUT_SEC` override (valid / invalid / zero / negative) ✓
- [x] Existing `internal/beads/...` and `internal/doctor/...` tests pass ✓
- [x] `go vet ./...` clean ✓
- [x] `go build ./...` clean ✓
- [ ] Manual: trigger memory pressure, verify `gt mail` and `gt doctor` fail fast (60s) instead of hanging until SIGKILL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3832"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->