### PR TITLE
fix(scheduler): guard scheduleBead against closed/tombstone beads (hq-ki2)

### DIFF
--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -1247,3 +1247,90 @@ func TestSchedulerDirectConvoyDispatch(t *testing.T) {
 		t.Errorf("direct mode should NOT show 'Would schedule'\noutput: %s", out)
 	}
 }
+
+// TestScheduleBead_RefusesClosed verifies that scheduleBead (deferred dispatch
+// path) refuses to schedule a closed bead. Mirrors the closed-bead guards in
+// runSling and executeSling. Regression test for hq-ki2: the daemon's stranded
+// scan was creating ghost convoys for already-closed cross-prefix beads via
+// scheduleBead → CreateSlingContext, because scheduleBead was the only sling
+// entry point missing the closed-bead guard.
+func TestScheduleBead_RefusesClosed(t *testing.T) {
+	hqPath, rigPath, gtBinary, env := setupSchedulerIntegrationTown(t)
+
+	beadID := createTestBead(t, rigPath, "Closed bead refused by scheduleBead")
+
+	// Close the bead before attempting to schedule.
+	closeCmd := exec.Command("bd", "close", beadID)
+	closeCmd.Dir = rigPath
+	if out, err := closeCmd.CombinedOutput(); err != nil {
+		t.Fatalf("bd close %s failed: %v\n%s", beadID, err, out)
+	}
+
+	// Attempt to sling (deferred mode → scheduleBead) — should fail with
+	// "work already completed".
+	out, err := runGTCmdMayFail(t, gtBinary, hqPath, env,
+		"sling", beadID, "testrig", "--hook-raw-bead")
+	if err == nil {
+		t.Fatalf("expected gt sling to fail for closed bead, got success\noutput: %s", out)
+	}
+	if !strings.Contains(out, "closed") || !strings.Contains(out, "work already completed") {
+		t.Errorf("expected error to mention closed/work already completed, got: %s", out)
+	}
+
+	// Verify no sling context was created for the closed bead.
+	if hasSlingContext(t, hqPath, beadID) {
+		t.Errorf("scheduleBead should not have created a sling context for closed bead %s", beadID)
+	}
+}
+
+// TestScheduleBead_RefusesTombstone verifies that scheduleBead refuses to
+// schedule a tombstoned bead. Companion to TestScheduleBead_RefusesClosed.
+func TestScheduleBead_RefusesTombstone(t *testing.T) {
+	hqPath, rigPath, gtBinary, env := setupSchedulerIntegrationTown(t)
+
+	beadID := createTestBead(t, rigPath, "Tombstone bead refused by scheduleBead")
+
+	// Tombstone the bead. bd uses `bd close --tombstone` for terminal removal.
+	closeCmd := exec.Command("bd", "close", beadID, "--tombstone")
+	closeCmd.Dir = rigPath
+	if out, err := closeCmd.CombinedOutput(); err != nil {
+		t.Fatalf("bd close --tombstone %s failed: %v\n%s", beadID, err, out)
+	}
+
+	out, err := runGTCmdMayFail(t, gtBinary, hqPath, env,
+		"sling", beadID, "testrig", "--hook-raw-bead")
+	if err == nil {
+		t.Fatalf("expected gt sling to fail for tombstone bead, got success\noutput: %s", out)
+	}
+	if !strings.Contains(out, "tombstone") || !strings.Contains(out, "work already completed") {
+		t.Errorf("expected error to mention tombstone/work already completed, got: %s", out)
+	}
+
+	if hasSlingContext(t, hqPath, beadID) {
+		t.Errorf("scheduleBead should not have created a sling context for tombstone bead %s", beadID)
+	}
+}
+
+// TestScheduleBead_ClosedForceDoesNotBypass verifies that --force does NOT
+// bypass the closed-bead guard in scheduleBead. To re-dispatch a closed bead,
+// the bead must be reopened first (matching runSling/executeSling semantics).
+func TestScheduleBead_ClosedForceDoesNotBypass(t *testing.T) {
+	hqPath, rigPath, gtBinary, env := setupSchedulerIntegrationTown(t)
+
+	beadID := createTestBead(t, rigPath, "Closed bead --force does not bypass")
+
+	closeCmd := exec.Command("bd", "close", beadID)
+	closeCmd.Dir = rigPath
+	if out, err := closeCmd.CombinedOutput(); err != nil {
+		t.Fatalf("bd close %s failed: %v\n%s", beadID, err, out)
+	}
+
+	out, err := runGTCmdMayFail(t, gtBinary, hqPath, env,
+		"sling", beadID, "testrig", "--hook-raw-bead", "--force")
+	if err == nil {
+		t.Fatalf("expected gt sling --force to still fail for closed bead, got success\noutput: %s", out)
+	}
+	if !strings.Contains(out, "closed") || !strings.Contains(out, "work already completed") {
+		t.Errorf("--force should not bypass closed guard; got: %s", out)
+	}
+}

--- a/internal/cmd/sling_schedule.go
+++ b/internal/cmd/sling_schedule.go
@@ -108,6 +108,16 @@ func scheduleBead(beadID, rigName string, opts ScheduleOptions) error {
 		return nil
 	}
 
+	// Guard against scheduling closed/tombstone beads (defense-in-depth, hq-ki2).
+	// Mirrors the closed-bead guards in runSling (sling.go) and executeSling
+	// (sling_dispatch.go). The daemon's stranded scan can route closed cross-prefix
+	// beads through scheduleBead in deferred dispatch mode; without this check, a
+	// fresh ghost convoy is created for already-completed work. Not bypassed by
+	// --force — if you need to re-dispatch, reopen the bead first.
+	if info.Status == "closed" || info.Status == "tombstone" {
+		return fmt.Errorf("bead %s is %s (work already completed)", beadID, info.Status)
+	}
+
 	if (info.Status == "pinned" || info.Status == "hooked" || info.Status == "in_progress") && !opts.Force {
 		return fmt.Errorf("bead %s is already %s to %s\nUse --force to override", beadID, info.Status, info.Assignee)
 	}


### PR DESCRIPTION
## Summary

- Adds the missing closed/tombstone-bead guard to `scheduleBead` in `internal/cmd/sling_schedule.go`, mirroring the existing guards in `runSling` (sling.go:584) and `executeSling` (sling_dispatch.go:136).
- Breaks the convoy respawn loop documented in **hq-ki2**: the daemon's 30s stranded scan was repeatedly creating ghost convoys for already-closed cross-prefix beads via `scheduleBead → CreateSlingContext`, and force-closing a ghost just freed up the loop to spawn the next one.
- This is **fix #3 of the three-link chain** in hq-ki2 — the one-line stopgap that immediately stops the bleeding while fixes #1 (cross-prefix `bd show` routing from HQ root) and #2 (defensive default in `getTrackedIssues`) get triaged separately.

## Why

`runSling` and `executeSling` both refuse closed/tombstone beads as defense-in-depth. `scheduleBead` was the odd one out — it checked `pinned`/`hooked`/`in_progress` but not `closed`/`tombstone`. In deferred dispatch mode (`max_polecats > 0`), `gt sling <bead> <rig>` routes through `scheduleBead`, so a closed bead would create a fresh sling context + auto-convoy with no warning. Combined with the two upstream cross-prefix bugs, this produced unbounded ghost convoy accumulation.

Live evidence in the affected town when the bug was filed:
- `hq-cv-hthvc` / `hq-cv-6wsqq` tracking `pie-3ej` / `pie-fen` — both **CLOSED**
- `hq-cv-ru7xp` tracking 10 closed `ce-*` beads (cell rig docked)

## Behavior

- Closed bead → `bead X is closed (work already completed)` error, no sling context created.
- Tombstone bead → `bead X is tombstone (work already completed)` error, no sling context created.
- `--force` does **not** bypass — to re-dispatch, reopen the bead first (matches runSling/executeSling semantics).

## Test plan

Three new integration tests under the `integration` build tag, mirroring the existing `sling_closed_guard_test.go` pattern but exercising the deferred-dispatch path:

- [x] `TestScheduleBead_RefusesClosed` — closed bead rejected, no sling context created
- [x] `TestScheduleBead_RefusesTombstone` — tombstone bead rejected, no sling context created
- [x] `TestScheduleBead_ClosedForceDoesNotBypass` — `--force` cannot bypass the closed guard
- [x] `go vet -tags=integration ./internal/cmd/` — clean
- [x] `go build -tags=integration ./...` — clean
- [x] Pre-existing unit-test failure (`TestBuildBdInitArgs_AlwaysIncludesServerPort`) verified present on `main` — unrelated to this change

Refs: hq-ki2
Related: hq-0td (convoy auto-close fails for cross-prefix tracked beads — this bug is downstream), hq-ilt (patrol stained-slot detection)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3840"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->