### PR TITLE
fix(test-leakage): stop sling guard + protocol/nudge tests from hitting production

### DIFF
--- a/internal/cmd/nudge.go
+++ b/internal/cmd/nudge.go
@@ -155,6 +155,20 @@ var idleWatcherPollInterval = 1 * time.Second
 // For "queue" mode: writes to the nudge queue for cooperative delivery.
 // For "wait-idle" mode: waits for idle, then delivers or falls back to queue.
 func deliverNudge(t *tmux.Tmux, sessionName, message, sender string) error {
+	// Test hook: when GT_TEST_NUDGE_LOG is set, log the nudge instead of
+	// delivering through real tmux/queue transport. Prevents test-suite
+	// runs from delivering "test" messages to live agents (mayor reported
+	// recurring synthetic nudges traced to nudge_test.go invocations).
+	// Mirrors the pattern in sling_helpers.go's nudgeWitness/nudgeRefinery.
+	if logPath := os.Getenv("GT_TEST_NUDGE_LOG"); logPath != "" {
+		entry := fmt.Sprintf("nudge:%s:%s:%s\n", sessionName, sender, message)
+		if f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644); err == nil {
+			_, _ = f.WriteString(entry)
+			_ = f.Close()
+		}
+		return nil
+	}
+
 	townRoot, _ := workspace.FindFromCwd()
 
 	// Use the requested mode, but force queue mode for ACP sessions.

--- a/internal/cmd/nudge_test.go
+++ b/internal/cmd/nudge_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -304,6 +305,10 @@ func TestNudgeValidModesAccepted(t *testing.T) {
 		waitIdleTimeout = origTimeout
 	}()
 
+	// Route nudge transport to a log file so the test doesn't deliver "test"
+	// messages to live agents (mayor reported recurring synthetic nudges).
+	t.Setenv("GT_TEST_NUDGE_LOG", filepath.Join(t.TempDir(), "nudge.log"))
+
 	// Shorten wait-idle timeout to avoid 15s test delay
 	waitIdleTimeout = 200 * time.Millisecond
 
@@ -461,6 +466,10 @@ func TestNudgeTrailingSlashNormalization(t *testing.T) {
 		nudgeStdinFlag = origStdin
 		waitIdleTimeout = origTimeout
 	}()
+
+	// Route nudge transport to a log file so this test doesn't deliver to
+	// the real mayor/deacon/witness/refinery sessions on host.
+	t.Setenv("GT_TEST_NUDGE_LOG", filepath.Join(t.TempDir(), "nudge.log"))
 
 	waitIdleTimeout = 200 * time.Millisecond
 	nudgeStdinFlag = false

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -1045,7 +1045,13 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 // checkCrossRigGuard validates that a bead's prefix matches the target rig.
 // Polecats work in their rig's worktree and cannot fix code owned by another rig.
 // Returns an error if the bead belongs to a different rig than the target polecat.
-// Town-root beads (hq-*) are rejected — tasks must be created in the target rig.
+//
+// When the prefix maps to town root, the guard warns rather than errors: this
+// ambiguous case arises when a crew member's redirect chain is broken and their
+// rig's .beads dir shares the town-level database and prefix (gt-gbu). Blocking
+// here would silently swallow all polecat work for the affected rig.
+//
+// Truly unknown prefixes (not in routes.jsonl at all) are still hard-rejected.
 func checkCrossRigGuard(beadID, targetAgent, townRoot string) error {
 	beadPrefix := beads.ExtractPrefix(beadID)
 	if beadPrefix == "" {
@@ -1062,9 +1068,25 @@ func checkCrossRigGuard(beadID, targetAgent, townRoot string) error {
 
 	if beadRig != targetRig {
 		if beadRig == "" {
-			return fmt.Errorf("bead %s (prefix %q) is not in rig %q — it belongs to town root\n"+
-				"Create the task from the rig directory: cd %s && bd create --title=...\n"+
-				"Use --force to override", beadID, strings.TrimSuffix(beadPrefix, "-"), targetRig, targetRig)
+			// GetRigNameForPrefix returns "" for two distinct cases:
+			//   (a) prefix is in routes.jsonl with path="." (known town-root prefix)
+			//   (b) prefix is not in routes.jsonl at all (unknown prefix)
+			// GetRigPathForPrefix distinguishes them: it returns townRoot for (a),
+			// empty string for (b).
+			if beads.GetRigPathForPrefix(townRoot, beadPrefix) == "" {
+				// Unknown prefix — no route exists, can't resolve rig.
+				return fmt.Errorf("bead %s (prefix %q) is not in rig %q — prefix not in routes\n"+
+					"Create the task from the rig directory: cd %s && bd create --title=...\n"+
+					"Use --force to override", beadID, strings.TrimSuffix(beadPrefix, "-"), targetRig, targetRig)
+			}
+			// Known town-root prefix — warn but allow. A crew member may have a
+			// broken redirect chain causing rig beads to land in the town DB with
+			// the town prefix. Blocking here silently drops all their polecat work
+			// (gt-gbu). The polecat will surface any true mismatch on execution.
+			fmt.Printf("  %s Bead %s has prefix %q (town root) but target is rig %q — "+
+				"proceeding (broken redirect chain? see gt-gbu)\n",
+				style.Warning.Render("⚠"), beadID, strings.TrimSuffix(beadPrefix, "-"), targetRig)
+			return nil
 		}
 		return fmt.Errorf("cross-rig mismatch: bead %s (prefix %q) belongs to rig %q, but target is rig %q\n"+
 			"Create the task from the target rig: cd %s && bd create --title=...\n"+

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -1659,13 +1659,17 @@ func TestCheckCrossRigGuard(t *testing.T) {
 			wantErr:     true,
 		},
 		{
-			name:        "town-level: hq bead to rig (rejected — belongs to town root)",
+			// Known town-root prefix: warn but allow. A crew member with a broken
+			// redirect chain may create hq-* beads that legitimately target a rig
+			// polecat (gt-gbu). Hard-rejecting silently drops all their polecat work.
+			name:        "town-level: hq bead to rig (warns but allows — gt-gbu)",
 			beadID:      "hq-abc123",
 			targetAgent: "gastown/polecats/Toast",
-			wantErr:     true,
+			wantErr:     false,
 		},
 		{
-			name:        "unknown prefix: rejected (no route maps to target rig)",
+			// Truly unknown prefix (not in routes.jsonl): hard reject.
+			name:        "unknown prefix: rejected (no route exists at all)",
 			beadID:      "xx-unknown",
 			targetAgent: "gastown/polecats/Toast",
 			wantErr:     true,
@@ -1686,8 +1690,8 @@ func TestCheckCrossRigGuard(t *testing.T) {
 			}
 			if err != nil && tc.wantErr {
 				errMsg := err.Error()
-				if !strings.Contains(errMsg, "cross-rig mismatch") && !strings.Contains(errMsg, "town root") {
-					t.Errorf("expected cross-rig or town-root error, got: %v", err)
+				if !strings.Contains(errMsg, "cross-rig mismatch") && !strings.Contains(errMsg, "not in routes") {
+					t.Errorf("expected cross-rig mismatch or unknown-prefix error, got: %v", err)
 				}
 				if !strings.Contains(errMsg, "--force") {
 					t.Errorf("error should mention --force override, got: %v", err)

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -586,14 +586,20 @@ func TestWrapRefineryHandlers_InvalidPayload(t *testing.T) {
 }
 
 func TestDefaultWitnessHandler(t *testing.T) {
+	// Prevent GT_TOWN_ROOT / GT_ROOT from pointing NewRouter at production beads.
+	// Without this, synthetic mail ("Work merged successfully", "Merge failed: tests",
+	// "Rebase required") is delivered to live polecats during test runs (gt-gbu nux report).
+	t.Setenv("GT_TOWN_ROOT", "")
+	t.Setenv("GT_ROOT", "")
 	tmpDir := t.TempDir()
 	handler := NewWitnessHandler("gastown", tmpDir)
+	handler.Router = mail.NewRouterWithTownRoot(tmpDir, "")
 
 	// Capture output
 	var buf bytes.Buffer
 	handler.SetOutput(&buf)
 
-	// Test HandleMerged
+	// Test HandleMerged — delivery fails (no .beads in tmpDir); we only verify output.
 	mergedPayload := &MergedPayload{
 		Branch:       "polecat/nux/gt-abc",
 		Issue:        "gt-abc",
@@ -602,9 +608,7 @@ func TestDefaultWitnessHandler(t *testing.T) {
 		TargetBranch: "main",
 		MergeCommit:  "abc123",
 	}
-	if err := handler.HandleMerged(mergedPayload); err != nil {
-		t.Errorf("HandleMerged error: %v", err)
-	}
+	_ = handler.HandleMerged(mergedPayload) // delivery error expected in sandboxed test
 	if !strings.Contains(buf.String(), "MERGED received") {
 		t.Errorf("Output missing expected text: %s", buf.String())
 	}
@@ -620,9 +624,7 @@ func TestDefaultWitnessHandler(t *testing.T) {
 		FailureType:  "tests",
 		Error:        "Test failed",
 	}
-	if err := handler.HandleMergeFailed(failedPayload); err != nil {
-		t.Errorf("HandleMergeFailed error: %v", err)
-	}
+	_ = handler.HandleMergeFailed(failedPayload)
 	if !strings.Contains(buf.String(), "MERGE_FAILED received") {
 		t.Errorf("Output missing expected text: %s", buf.String())
 	}
@@ -637,9 +639,7 @@ func TestDefaultWitnessHandler(t *testing.T) {
 		TargetBranch:  "main",
 		ConflictFiles: []string{"file1.go"},
 	}
-	if err := handler.HandleReworkRequest(reworkPayload); err != nil {
-		t.Errorf("HandleReworkRequest error: %v", err)
-	}
+	_ = handler.HandleReworkRequest(reworkPayload)
 	if !strings.Contains(buf.String(), "REWORK_REQUEST received") {
 		t.Errorf("Output missing expected text: %s", buf.String())
 	}


### PR DESCRIPTION
## Summary

Three related fixes for test-suite runs that were silently leaking synthetic traffic to live agents or dropping real work.

**1. `sling.go` cross-rig guard** (`internal/cmd/sling.go`)**:**
When a crew member's `.beads` dir uses the town-level Dolt database with `issue_prefix=hq`, beads they create get an `hq-` prefix and land in the `hq` DB. `checkCrossRigGuard` previously saw `beadRig=""` (the prefix maps to `path="."`) and rejected every sling as "belongs to town root," silently dropping all completions for those polecats. Fix: distinguish between a known-town-root prefix (present in `routes.jsonl` with `path="."`) and a genuinely-unknown prefix — the former warns and proceeds, the latter still hard-rejects. Test updated to expect the warn-and-allow behavior.

**2. `protocol_test.go` — `TestDefaultWitnessHandler`** (`internal/protocol/protocol_test.go`)**:**
`TestDefaultWitnessHandler` created a live `mail.Router` via `NewWitnessHandler`; with `GT_TOWN_ROOT`/`GT_ROOT` set in the environment (which they are in any agent shell), `detectTownRoot` fell back to the production town root. `HandleMerged` / `HandleMergeFailed` / `HandleReworkRequest` then delivered synthetic "Work merged successfully" / "Merge failed: tests" / "Rebase required" messages to live polecat inboxes on every `go test` run (reported by nux). Fix: clear the env vars during the test and override `handler.Router` with `NewRouterWithTownRoot(tmpDir, "")`. Mirrors the isolation pattern already used by the sibling refinery handler tests.

**3. `nudge.go` — `GT_TEST_NUDGE_LOG` hook** (`internal/cmd/nudge.go`, `nudge_test.go`)**:**
`TestNudgeValidModesAccepted` and `TestNudgeTrailingSlashNormalization` called `runNudge` with valid modes and targets including `"refinery/"` and `"mayor"` — these reached `deliverNudge` and delivered synthetic `"test"` nudges to live mayor/refinery/witness sessions on every test run (reported separately by mayor and refinery). Fix: add a `GT_TEST_NUDGE_LOG` check at the top of `deliverNudge`; when set, logs the nudge to a temp file and returns nil. Both tests set this env var. Mirrors the existing pattern in `sling_helpers.go`'s `nudgeWitness` / `nudgeRefinery` test hooks.

## Test plan

- [x] `go test ./internal/cmd/... -run "TestNudge|TestSling"` — passes
- [x] `go test ./internal/protocol/...` — passes
- [x] Confirmed no live nudge delivery occurs during the nudge test runs (GT_TEST_NUDGE_LOG routes to tmpdir log)
- [x] Confirmed `TestNudgeInvalidMode` and `TestNudgeInvalidPriority` were never actually leaking (they fail at validation before `deliverNudge` is reached)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3845"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->