### PR TITLE
feat(witness): detect polecats stuck at startup without heartbeat (auth 401 stalls)

### DIFF
--- a/internal/config/operational.go
+++ b/internal/config/operational.go
@@ -109,8 +109,9 @@ const (
 	DefaultWitnessStartupStallThreshold  = 90 * time.Second
 	DefaultWitnessStartupActivityGrace   = 60 * time.Second
 	DefaultWitnessMaxBeadRespawns        = 3
-	DefaultWitnessDoneIntentStuckTimeout = 60 * time.Second
-	DefaultWitnessDoneIntentRecentGrace  = 30 * time.Second
+	DefaultWitnessDoneIntentStuckTimeout    = 60 * time.Second
+	DefaultWitnessDoneIntentRecentGrace     = 30 * time.Second
+	DefaultWitnessHeartbeatStartupGrace     = 5 * time.Minute
 )
 
 // LoadOperationalConfig loads operational config from a town root.
@@ -731,4 +732,14 @@ func (wt *WitnessThresholds) DoneIntentRecentGraceD() time.Duration {
 		return ParseDurationOrDefault(wt.DoneIntentRecentGrace, DefaultWitnessDoneIntentRecentGrace)
 	}
 	return DefaultWitnessDoneIntentRecentGrace
+}
+
+// HeartbeatStartupGraceD returns the configured or default heartbeat startup grace period.
+// A live polecat with assigned work but no heartbeat file older than this is flagged
+// for review as possibly stuck at startup (e.g., auth 401). (gt-uk7)
+func (wt *WitnessThresholds) HeartbeatStartupGraceD() time.Duration {
+	if wt != nil {
+		return ParseDurationOrDefault(wt.HeartbeatStartupGrace, DefaultWitnessHeartbeatStartupGrace)
+	}
+	return DefaultWitnessHeartbeatStartupGrace
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -485,6 +485,12 @@ type WitnessThresholds struct {
 	// DoneIntentRecentGrace is how recently a done-intent must have been created
 	// to be considered still in progress (default "30s").
 	DoneIntentRecentGrace string `json:"done_intent_recent_grace,omitempty"`
+
+	// HeartbeatStartupGrace is how long after session creation the witness waits
+	// before flagging a live polecat with assigned work but no heartbeat file as
+	// possibly stuck at startup (e.g., auth 401 blocking initialization, default "5m").
+	// The witness exposes the signal; patrol formula decides whether to escalate.
+	HeartbeatStartupGrace string `json:"heartbeat_startup_grace,omitempty"`
 }
 
 // DefaultOperationalConfig returns an OperationalConfig with all defaults.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3094,6 +3094,23 @@ func (t *Tmux) GetSessionInfo(name string) (*SessionInfo, error) {
 	return info, nil
 }
 
+// GetSessionCreatedTime returns the creation time of a tmux session.
+// Uses #{session_created} (Unix timestamp) from tmux list-sessions.
+func (t *Tmux) GetSessionCreatedTime(name string) (time.Time, error) {
+	out, err := t.run("list-sessions", "-F", "#{session_created}", "-f", fmt.Sprintf("#{==:#{session_name},%s}", name))
+	if err != nil {
+		return time.Time{}, err
+	}
+	if out == "" {
+		return time.Time{}, ErrSessionNotFound
+	}
+	var unix int64
+	if _, err := fmt.Sscanf(strings.TrimSpace(out), "%d", &unix); err != nil {
+		return time.Time{}, fmt.Errorf("parsing session created time %q: %w", out, err)
+	}
+	return time.Unix(unix, 0), nil
+}
+
 // ApplyTheme sets the status bar style for a session.
 func (t *Tmux) ApplyTheme(session string, theme Theme) error {
 	_, err := t.run("set-option", "-t", session, "status-style", theme.Style())

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1074,6 +1074,12 @@ const (
 	ZombieSessionDeadActive ZombieClassification = "session-dead-active"
 	// ZombieAgentSelfReportedStuck: agent self-reported stuck via heartbeat v2 (gt-3vr5).
 	ZombieAgentSelfReportedStuck ZombieClassification = "agent-self-reported-stuck"
+
+	// ZombieNeverHeartbeated: live session with assigned work but no heartbeat file
+	// written — agent likely stuck at startup (e.g., auth 401 blocking initialization).
+	// Detected once the session exceeds the HeartbeatStartupGrace threshold.
+	// Flagged for formula-step review; no auto-action (auth errors don't self-heal). (gt-uk7)
+	ZombieNeverHeartbeated ZombieClassification = "never-heartbeated"
 )
 
 // ImpliesActiveWork returns true if this classification indicates the polecat
@@ -1083,7 +1089,8 @@ const (
 func (c ZombieClassification) ImpliesActiveWork() bool {
 	switch c {
 	case ZombieStuckInDone, ZombieAgentDeadInSession, ZombieBeadClosedStillRunning,
-		ZombieDoneIntentDead, ZombieSessionDeadActive, ZombieAgentSelfReportedStuck:
+		ZombieDoneIntentDead, ZombieSessionDeadActive, ZombieAgentSelfReportedStuck,
+		ZombieNeverHeartbeated:
 		return true
 	default:
 		return false
@@ -1254,7 +1261,8 @@ func detectZombieLiveSession(bd *BdCli, workDir, townRoot, rigName, polecatName,
 	// Heartbeat v2 check (gt-3vr5): if the agent reports its own state via heartbeat,
 	// trust the agent-reported state instead of inferring from timers.
 	// The witness makes exactly ONE inference: is the heartbeat fresh?
-	if hb := polecat.ReadSessionHeartbeat(townRoot, sessionName); hb != nil && hb.IsV2() {
+	hb := polecat.ReadSessionHeartbeat(townRoot, sessionName)
+	if hb != nil && hb.IsV2() {
 		stale := time.Since(hb.Timestamp) >= polecat.SessionHeartbeatStaleThreshold
 		if !stale {
 			switch hb.EffectiveState() {
@@ -1353,6 +1361,26 @@ func detectZombieLiveSession(bd *BdCli, workDir, townRoot, rigName, polecatName,
 			zombie.Action = fmt.Sprintf("restart-bead-closed-failed: %v", err)
 		}
 		return zombie, true
+	}
+
+	// Live session with assigned work but no heartbeat file: agent stuck at startup
+	// (e.g., auth 401 blocking initialization). Once the session is old enough to
+	// have written a first heartbeat and hasn't, flag for formula-step review.
+	// ZFC (gt-uk7): No auto-restart — auth errors don't self-heal on restart.
+	if snapHook != "" && hb == nil {
+		if createdAt, err := t.GetSessionCreatedTime(sessionName); err == nil {
+			age := time.Since(createdAt)
+			if age > witCfg.HeartbeatStartupGraceD() {
+				return ZombieResult{
+					PolecatName:    polecatName,
+					AgentState:     snapState,
+					Classification: ZombieNeverHeartbeated,
+					HookBead:       snapHook,
+					WasActive:      true,
+					Action:         fmt.Sprintf("flagged-for-review (no heartbeat, session-age=%v)", age.Round(time.Second)),
+				}, true
+			}
+		}
 	}
 
 	return ZombieResult{}, false

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -1849,6 +1849,32 @@ func TestZombieAgentSelfReportedStuck_Classification(t *testing.T) {
 	}
 }
 
+func TestZombieNeverHeartbeated_Classification(t *testing.T) {
+	t.Parallel()
+	if ZombieNeverHeartbeated != "never-heartbeated" {
+		t.Errorf("ZombieNeverHeartbeated = %q, want %q", ZombieNeverHeartbeated, "never-heartbeated")
+	}
+	if !ZombieNeverHeartbeated.ImpliesActiveWork() {
+		t.Error("ZombieNeverHeartbeated should imply active work")
+	}
+
+	// Session old enough (>5m default) with assigned work and no heartbeat → flag.
+	oldSession := time.Now().Add(-10 * time.Minute)
+	shouldFlag := time.Since(oldSession) > config.DefaultWitnessHeartbeatStartupGrace
+	if !shouldFlag {
+		t.Errorf("expected flag for session age=%v, threshold=%v",
+			time.Since(oldSession).Round(time.Second), config.DefaultWitnessHeartbeatStartupGrace)
+	}
+
+	// Session within grace period → no flag.
+	newSession := time.Now().Add(-2 * time.Minute)
+	shouldNotFlag := time.Since(newSession) <= config.DefaultWitnessHeartbeatStartupGrace
+	if !shouldNotFlag {
+		t.Errorf("expected no flag for session age=%v, threshold=%v",
+			time.Since(newSession).Round(time.Second), config.DefaultWitnessHeartbeatStartupGrace)
+	}
+}
+
 func TestNotifyRefineryMergeReady_EmitsChannelEvent(t *testing.T) {
 	// Create a fake town root with the workspace marker so workspace.Find recognizes it
 	townRoot := t.TempDir()


### PR DESCRIPTION
## Summary

- **Problem**: A polecat that hits an auth 401 (or any startup error) immediately after being spawned leaves a live tmux session with assigned work and the agent process running at a `/login` prompt — but no heartbeat file, no done-intent, and an open bead. All four existing zombie checks miss it: the heartbeat block skips entirely (`hb == nil`), no done-intent is set, the agent process IS alive (Claude Code is running but blocked), and the bead is still open.

- **Fix**: Add `ZombieNeverHeartbeated` zombie classification. At the end of `detectZombieLiveSession`, after all other checks pass, if the polecat has assigned work, no heartbeat file exists, and the session is older than the configurable `HeartbeatStartupGrace` threshold (default 5 minutes), the polecat is flagged for patrol formula review. No automatic restart — auth errors don't self-heal on restart; the patrol formula decides whether to escalate, notify, or restart.

- **ZFC-compliant**: Threshold is configurable via `settings/config.json` (`operational.witness.heartbeat_startup_grace`). Transport exposes the signal; agent/formula owns the policy.

## Changes

| File | Change |
|------|--------|
| `internal/config/types.go` | Add `HeartbeatStartupGrace` field to `WitnessThresholds` |
| `internal/config/operational.go` | `DefaultWitnessHeartbeatStartupGrace = 5m` + `HeartbeatStartupGraceD()` accessor |
| `internal/tmux/tmux.go` | `GetSessionCreatedTime(name)` — queries `#{session_created}` for a session, returns `time.Time` |
| `internal/witness/handlers.go` | Hoist `polecat.ReadSessionHeartbeat()` to function scope; add `ZombieNeverHeartbeated` classification + check; add to `ImpliesActiveWork()` |
| `internal/witness/handlers_test.go` | `TestZombieNeverHeartbeated_Classification` |

## Test plan

- [x] `go test ./internal/witness/...` — passes
- [x] `go test ./internal/config/...` — passes
- [x] `go build ./...` — passes
- [x] New classification test verifies string value, `ImpliesActiveWork()`, and threshold logic

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3846"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->