### PR TITLE
[codex] fix remote polecat prune classifier

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1633,7 +1633,7 @@ func runPolecatStale(cmd *cobra.Command, args []string) error {
 func runPolecatPrune(cmd *cobra.Command, args []string) error {
 	rigName := args[0]
 
-	_, r, err := getPolecatManager(rigName)
+	mgr, r, err := getPolecatManager(rigName)
 	if err != nil {
 		return err
 	}
@@ -1679,47 +1679,65 @@ func runPolecatPrune(cmd *cobra.Command, args []string) error {
 		fmt.Println("Pruning remote polecat branches...")
 
 		defaultBranch := repoGit.RemoteDefaultBranch()
-		remoteRefs, lsErr := repoGit.ListPushRemoteRefs("origin", "refs/heads/polecat/")
-		if lsErr != nil {
-			return fmt.Errorf("listing remote refs: %w", lsErr)
+		remoteCandidates, pruneErr := repoGit.PruneMergedRemoteBranches("origin", "refs/heads/polecat/", "origin/"+defaultBranch, true)
+		if pruneErr != nil {
+			return fmt.Errorf("pruning remote refs: %w", pruneErr)
 		}
 
-		remotePruned := 0
-		for _, ref := range remoteRefs {
-			branch := strings.TrimPrefix(ref, "refs/heads/")
-			// Check if merged to main
-			merged, mergeErr := repoGit.IsAncestor(branch, "origin/"+defaultBranch)
-			if mergeErr != nil {
-				continue
-			}
-			if !merged {
-				continue
-			}
-
-			if polecatPruneDryRun {
-				fmt.Printf("  Would delete remote: %s\n", style.Dim.Render(branch))
-			} else {
-				if delErr := repoGit.DeleteRemoteBranch("origin", branch); delErr != nil {
-					fmt.Printf("  %s remote %s: %v\n", style.Warning.Render("⚠"), branch, delErr)
-				} else {
-					fmt.Printf("  %s deleted remote %s\n", style.Success.Render("✓"), branch)
+		activeBranches := make(map[string]bool)
+		polecats, listErr := mgr.List()
+		if listErr != nil {
+			fmt.Printf("  %s listing polecats: %v (continuing without in-use filter)\n", style.Warning.Render("⚠"), listErr)
+		} else {
+			for _, p := range polecats {
+				if p.Branch != "" {
+					activeBranches[p.Branch] = true
 				}
 			}
-			remotePruned++
 		}
 
-		if remotePruned == 0 {
+		remotePrunedBranches, inUseBranches := filterPrunableRemoteBranches(remoteCandidates, activeBranches)
+		for _, b := range inUseBranches {
+			fmt.Printf("  Keep remote (in use): %s\n", style.Success.Render(b.Name))
+		}
+
+		for _, b := range remotePrunedBranches {
+			if polecatPruneDryRun {
+				fmt.Printf("  Would delete remote: %s\n", style.Dim.Render(b.Name))
+			} else {
+				if delErr := repoGit.DeleteRemoteBranch("origin", b.Name); delErr != nil {
+					fmt.Printf("  %s remote %s: %v\n", style.Warning.Render("⚠"), b.Name, delErr)
+				} else {
+					fmt.Printf("  %s deleted remote %s\n", style.Success.Render("✓"), b.Name)
+				}
+			}
+		}
+
+		if len(remotePrunedBranches) == 0 {
 			fmt.Println("No stale remote polecat branches found.")
 		} else {
 			verb := "Pruned"
 			if polecatPruneDryRun {
 				verb = "Would prune"
 			}
-			fmt.Printf("\n%s %d remote branch(es).\n", verb, remotePruned)
+			fmt.Printf("\n%s %d remote branch(es).\n", verb, len(remotePrunedBranches))
 		}
 	}
 
 	return nil
+}
+
+func filterPrunableRemoteBranches(candidates []git.PrunedBranch, activeBranches map[string]bool) ([]git.PrunedBranch, []git.PrunedBranch) {
+	prunable := make([]git.PrunedBranch, 0, len(candidates))
+	inUse := make([]git.PrunedBranch, 0)
+	for _, branch := range candidates {
+		if activeBranches[branch.Name] {
+			inUse = append(inUse, branch)
+			continue
+		}
+		prunable = append(prunable, branch)
+	}
+	return prunable, inUse
 }
 
 // runPolecatPoolInit creates a persistent polecat pool for a rig.

--- a/internal/cmd/polecat_identity_test.go
+++ b/internal/cmd/polecat_identity_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/style"
 )
 
@@ -54,6 +55,31 @@ func TestExtractWorkType(t *testing.T) {
 				t.Errorf("extractWorkType(%q, %q) = %q, want %q", tt.title, tt.issueType, got, tt.expect)
 			}
 		})
+	}
+}
+
+func TestFilterPrunableRemoteBranchesSkipsActiveBranches(t *testing.T) {
+	candidates := []git.PrunedBranch{
+		{Name: "polecat/obsidian/stale@abc", Reason: "merged"},
+		{Name: "polecat/quartz/active@def", Reason: "merged"},
+	}
+	active := map[string]bool{
+		"polecat/quartz/active@def": true,
+	}
+
+	prunable, inUse := filterPrunableRemoteBranches(candidates, active)
+
+	if len(prunable) != 1 {
+		t.Fatalf("expected 1 prunable branch, got %d", len(prunable))
+	}
+	if prunable[0].Name != "polecat/obsidian/stale@abc" {
+		t.Errorf("prunable branch = %q, want polecat/obsidian/stale@abc", prunable[0].Name)
+	}
+	if len(inUse) != 1 {
+		t.Fatalf("expected 1 in-use branch, got %d", len(inUse))
+	}
+	if inUse[0].Name != "polecat/quartz/active@def" {
+		t.Errorf("in-use branch = %q, want polecat/quartz/active@def", inUse[0].Name)
 	}
 }
 
@@ -208,4 +234,3 @@ func TestFormatCountStyled(t *testing.T) {
 		t.Errorf("formatCountStyled(42) = %q, does not contain '42'", got)
 	}
 }
-

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1148,10 +1148,16 @@ func (g *Git) BitbucketPRMerge(workspace, repoSlug string, prID int, strategy st
 	return sha, nil
 }
 
-// ListRemoteRefs returns remote ref names matching a prefix using ls-remote.
+// RemoteRef is a ref observed through ls-remote.
+type RemoteRef struct {
+	Hash string
+	Name string
+}
+
+// ListRemoteRefsWithHashes returns remote refs matching a prefix using ls-remote.
 // The prefix filters refs (e.g., "refs/heads/polecat/" for all polecat branches).
 // Returns full ref names like "refs/heads/polecat/furiosa-abc123".
-func (g *Git) ListRemoteRefs(remote, prefix string) ([]string, error) {
+func (g *Git) ListRemoteRefsWithHashes(remote, prefix string) ([]RemoteRef, error) {
 	out, err := g.run("ls-remote", "--refs", remote, prefix+"*")
 	if err != nil {
 		return nil, err
@@ -1159,7 +1165,7 @@ func (g *Git) ListRemoteRefs(remote, prefix string) ([]string, error) {
 	if out == "" {
 		return nil, nil
 	}
-	var refs []string
+	var refs []RemoteRef
 	for _, line := range strings.Split(out, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -1168,8 +1174,21 @@ func (g *Git) ListRemoteRefs(remote, prefix string) ([]string, error) {
 		// ls-remote output format: <sha>\t<refname>
 		parts := strings.Fields(line)
 		if len(parts) >= 2 {
-			refs = append(refs, parts[1])
+			refs = append(refs, RemoteRef{Hash: parts[0], Name: parts[1]})
 		}
+	}
+	return refs, nil
+}
+
+// ListRemoteRefs returns remote ref names matching a prefix using ls-remote.
+func (g *Git) ListRemoteRefs(remote, prefix string) ([]string, error) {
+	refsWithHashes, err := g.ListRemoteRefsWithHashes(remote, prefix)
+	if err != nil {
+		return nil, err
+	}
+	refs := make([]string, 0, len(refsWithHashes))
+	for _, ref := range refsWithHashes {
+		refs = append(refs, ref.Name)
 	}
 	return refs, nil
 }
@@ -1187,6 +1206,16 @@ func (g *Git) ListPushRemoteRefs(remote, prefix string) ([]string, error) {
 	}
 	// Query the push URL directly
 	return g.ListRemoteRefs(pushURL, prefix)
+}
+
+// ListPushRemoteRefsWithHashes is ListPushRemoteRefs with commit hashes.
+func (g *Git) ListPushRemoteRefsWithHashes(remote, prefix string) ([]RemoteRef, error) {
+	fetchURL, fetchErr := g.RemoteURL(remote)
+	pushURL, pushErr := g.GetPushURL(remote)
+	if fetchErr != nil || pushErr != nil || pushURL == fetchURL {
+		return g.ListRemoteRefsWithHashes(remote, prefix)
+	}
+	return g.ListRemoteRefsWithHashes(pushURL, prefix)
 }
 
 // Rebase rebases the current branch onto the given ref.
@@ -2243,6 +2272,65 @@ func (g *Git) BranchPushedToRemote(localBranch, remote string) (bool, int, error
 type PrunedBranch struct {
 	Name   string // Branch name (e.g., "polecat/rictus-mkb0vq9f")
 	Reason string // Why it was pruned: "merged", "no-remote", "no-remote-merged"
+}
+
+// PruneMergedRemoteBranches finds and deletes remote branches whose tips are
+// already reachable from target. In dry-run mode it reports what would be
+// deleted without modifying the remote.
+func (g *Git) PruneMergedRemoteBranches(remote, prefix, target string, dryRun bool) ([]PrunedBranch, error) {
+	if remote == "" {
+		remote = "origin"
+	}
+	if prefix == "" {
+		prefix = "refs/heads/polecat/"
+	}
+	if target == "" {
+		target = remote + "/" + g.RemoteDefaultBranch()
+	}
+
+	remoteRefs, err := g.ListPushRemoteRefsWithHashes(remote, prefix)
+	if err != nil {
+		return nil, err
+	}
+
+	var pruned []PrunedBranch
+	for _, ref := range remoteRefs {
+		if !strings.HasPrefix(ref.Name, "refs/heads/") {
+			continue
+		}
+		branch := strings.TrimPrefix(ref.Name, "refs/heads/")
+		if branch == "" {
+			continue
+		}
+
+		ancestor := ref.Hash
+		if hasTracking, err := g.RemoteTrackingBranchExists(remote, branch); err != nil {
+			return nil, err
+		} else if hasTracking {
+			ancestor = remote + "/" + branch
+		}
+
+		merged, err := g.IsAncestor(ancestor, target)
+		if err != nil {
+			continue
+		}
+		if !merged {
+			continue
+		}
+
+		if !dryRun {
+			if err := g.DeleteRemoteBranch(remote, branch); err != nil {
+				return nil, err
+			}
+		}
+
+		pruned = append(pruned, PrunedBranch{
+			Name:   branch,
+			Reason: "merged",
+		})
+	}
+
+	return pruned, nil
 }
 
 // PruneStaleBranches finds and deletes local branches matching a pattern that are

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -974,6 +974,70 @@ func TestPruneStaleBranches_SkipsUnmerged(t *testing.T) {
 	}
 }
 
+func TestPruneMergedRemoteBranches_DetectsRemoteTrackingBranchWithoutLocalBranch(t *testing.T) {
+	localDir, _, mainBranch := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+
+	if err := g.CreateBranch("polecat/remote-merged"); err != nil {
+		t.Fatalf("CreateBranch: %v", err)
+	}
+	if err := g.Checkout("polecat/remote-merged"); err != nil {
+		t.Fatalf("Checkout: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "remote.txt"), []byte("remote"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := g.Add("remote.txt"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := g.Commit("remote merged work"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+
+	cmd := exec.Command("git", "push", "origin", "polecat/remote-merged")
+	cmd.Dir = localDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("push polecat branch: %v", err)
+	}
+
+	if err := g.Checkout(mainBranch); err != nil {
+		t.Fatalf("Checkout main: %v", err)
+	}
+	if err := g.Merge("polecat/remote-merged"); err != nil {
+		t.Fatalf("Merge: %v", err)
+	}
+	cmd = exec.Command("git", "push", "origin", mainBranch)
+	cmd.Dir = localDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("push main: %v", err)
+	}
+
+	if err := g.DeleteBranch("polecat/remote-merged", false); err != nil {
+		t.Fatalf("DeleteBranch: %v", err)
+	}
+	exists, err := g.BranchExists("polecat/remote-merged")
+	if err != nil {
+		t.Fatalf("BranchExists: %v", err)
+	}
+	if exists {
+		t.Fatal("expected local polecat branch to be absent")
+	}
+
+	pruned, err := g.PruneMergedRemoteBranches("origin", "refs/heads/polecat/", "origin/"+mainBranch, true)
+	if err != nil {
+		t.Fatalf("PruneMergedRemoteBranches: %v", err)
+	}
+	if len(pruned) != 1 {
+		t.Fatalf("expected 1 remote branch in dry-run, got %d", len(pruned))
+	}
+	if pruned[0].Name != "polecat/remote-merged" {
+		t.Errorf("pruned name = %q, want polecat/remote-merged", pruned[0].Name)
+	}
+	if pruned[0].Reason != "merged" {
+		t.Errorf("pruned reason = %q, want merged", pruned[0].Reason)
+	}
+}
+
 func TestPushWithEnv(t *testing.T) {
 	localDir, _, mainBranch := initTestRepoWithRemote(t)
 	g := NewGit(localDir)


### PR DESCRIPTION
## Summary
- fix `gt polecat prune --remote` so merged remote-only polecat refs are classified using `origin/<branch>` tracking refs or the ls-remote hash
- keep the existing push-url behavior by listing remote refs with hashes
- skip deletion candidates whose branch is currently in use by an active polecat

## Root Cause
The remote prune loop trimmed `refs/heads/` and then checked ancestry against the short branch name, e.g. `polecat/obsidian/wb-629@...`. When no local branch with that name existed, `git merge-base --is-ancestor` errored and the stale remote branch was silently skipped.

## Validation
- `go test ./internal/git -count=1`
- `go test ./internal/cmd -run 'TestPolecat|TestPrune|TestFilterPrunableRemoteBranchesSkipsActiveBranches' -count=1`
- `go build -ldflags '-X github.com/steveyegge/gastown/internal/cmd.BuiltProperly=1' -o /tmp/gt-prune-fix ./cmd/gt`
- `/tmp/gt-prune-fix polecat prune wallball --remote --dry-run`

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3847"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->