### PR TITLE
fix: exclude agent beads from AutoClose to prevent polecat state deletion

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -580,7 +580,7 @@ func purgeOldMail(db *sql.DB, dbName string, mailDeleteAge time.Duration, dryRun
 }
 
 // AutoClose closes issues that have been open with no updates past staleAge.
-// Excludes P0/P1 priority, epics, hooked/pinned issues, standing-order labels,
+// Excludes P0/P1 priority, epics, agent beads, standing-order labels,
 // and issues with active dependencies.
 func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (*AutoCloseResult, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
@@ -594,6 +594,7 @@ func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (
 		AND i.updated_at < ?
 		AND i.priority > 1
 		AND i.issue_type != 'epic'
+		AND i.issue_type != 'agent'
 		AND i.id NOT IN (
 			SELECT DISTINCT l.issue_id FROM `+"`%s`"+`.labels l
 			WHERE l.label IN ('gt:standing-orders', 'gt:keep', 'gt:role', 'gt:rig')

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -246,3 +246,25 @@ func TestScanExcludesAgentBeads(t *testing.T) {
 		t.Fatalf("expected Scan() eligibility to exclude agent beads, scan body was:\n%s", scanBody)
 	}
 }
+
+// TestAutoCloseExcludesAgentBeads verifies that AutoClose() excludes agent beads
+// from auto-closure, preventing accidental deletion of persistent agent state
+// (polecat agents, deacon witness, refinery, etc.).
+// See hq-qeae: 5 raybar polecat agent beads were incorrectly auto-closed.
+func TestAutoCloseExcludesAgentBeads(t *testing.T) {
+	sourcePath := "reaper.go"
+	data, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", sourcePath, err)
+	}
+	source := string(data)
+	autoCloseStart := strings.Index(source, "func AutoClose(")
+	batchDeleteStart := strings.Index(source, "func batchDeleteRows(")
+	if autoCloseStart == -1 || batchDeleteStart == -1 || batchDeleteStart <= autoCloseStart {
+		t.Fatalf("could not isolate AutoClose() body in %s", sourcePath)
+	}
+	autoCloseBody := source[autoCloseStart:batchDeleteStart]
+	if !strings.Contains(autoCloseBody, "i.issue_type != 'agent'") {
+		t.Fatalf("expected AutoClose() to exclude agent beads, AutoClose body was:\n%s", autoCloseBody)
+	}
+}


### PR DESCRIPTION
Fixes issue hq-qeae: AutoClose was missing the agent bead filter that Reap and Scan have, causing stale agent beads to be auto-closed.

This led to 5 raybar polecat beads being deleted when they should have been preserved.

Changes:
- Add 'AND i.issue_type != 'agent'' filter to AutoClose WHERE clause
- Update AutoClose docstring to mention agent bead exclusion  
- Add TestAutoCloseExcludesAgentBeads to verify the filter

This matches the existing filters in Reap() and Scan() functions.

Related work:
- Issue: hq-ahhy (Merge gastown fix for reaper AutoClose agent bead filter)
- Root cause: hq-qeae (5 raybar polecat agent beads disappeared)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3849"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->