### PR TITLE
fix(test): update TestBuildBdInitArgs assertion for --force flag (gt-hfg5)

### DIFF
--- a/internal/cmd/install_test.go
+++ b/internal/cmd/install_test.go
@@ -23,14 +23,17 @@ func TestBuildBdInitArgs_AlwaysIncludesServerPort(t *testing.T) {
 
 	args := buildBdInitArgs(townDir)
 
-	if len(args) != 6 {
-		t.Fatalf("expected 6 args, got %d: %v", len(args), args)
+	if len(args) != 7 {
+		t.Fatalf("expected 7 args, got %d: %v", len(args), args)
 	}
 	if args[4] != "--server-port" {
 		t.Fatalf("expected args[4] = --server-port, got %q", args[4])
 	}
 	if args[5] != "3307" {
 		t.Fatalf("expected default port 3307, got %q", args[5])
+	}
+	if args[6] != "--force" {
+		t.Fatalf("expected args[6] = --force, got %q", args[6])
 	}
 }
 


### PR DESCRIPTION
## Summary

- Update `TestBuildBdInitArgs_AlwaysIncludesServerPort` to assert `len(args)==7` (was 6) and check for `--force` at `args[6]`.
- Restores green CI for unit tests on every gastown PR — has been failing on main since #3829 (commit 84594d11) which appended `--force` to `buildBdInitArgs` (`internal/cmd/install.go:635`) without updating the test.

Closes gt-hfg5.

## Test plan

- [x] `go test -run TestBuildBdInitArgs ./internal/cmd/` passes locally (0.543s)
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3851"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->