### PR TITLE
fix(mq-submit): resolve commit_sha from --branch tip + skip same-branch supersede deletion (ps-7v7)

### DIFF
--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -232,10 +232,13 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// GH#3032: Resolve HEAD commit SHA for MR dedup.
-	commitSHA, shaErr := g.Rev("HEAD")
+	// GH#3032: Resolve commit SHA for MR dedup. ps-7v7 / co-toog: when
+	// --branch is explicit and differs from cwd's current branch (mayor-
+	// driven submit from a non-polecat worktree), use the remote branch
+	// tip — not cwd HEAD, which records the wrong SHA on the MR bead.
+	commitSHA, shaErr := resolveCommitSHA(g, mqSubmitBranch)
 	if shaErr != nil {
-		style.PrintWarning("could not resolve HEAD SHA: %v (falling back to branch-only dedup)", shaErr)
+		style.PrintWarning("could not resolve commit SHA: %v (falling back to branch-only dedup)", shaErr)
 	}
 
 	// Build MR bead title and description
@@ -313,15 +316,21 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 
 					// Delete the old remote branch to auto-close the GitHub PR.
 					// Only polecat branches — non-polecat branches may belong to
-					// contributor forks; deleting them closes upstream PRs. (GH#2669)
+					// contributor forks; deleting them closes upstream PRs (GH#2669).
+					// Skip same-branch supersede (ps-7v7 / co-toog): when the new
+					// MR points at the same branch (mayor's resubmit pattern),
+					// deleting would leave the new MR pointing at a phantom ref.
 					oldFields := beads.ParseMRFields(old)
-					if oldFields != nil && strings.HasPrefix(oldFields.Branch, "polecat/") {
+					if oldFields != nil && shouldDeleteSupersededBranch(oldFields.Branch, branch) {
 						g := git.NewGit(cwd)
 						if err := g.DeleteRemoteBranch("origin", oldFields.Branch); err != nil {
 							style.PrintWarning("could not delete superseded branch %s: %v", oldFields.Branch, err)
 						} else {
 							fmt.Printf("  %s Deleted remote branch: %s\n", style.Dim.Render("○"), oldFields.Branch)
 						}
+					} else if oldFields != nil && oldFields.Branch == branch {
+						fmt.Printf("  %s Same-branch supersede; preserving remote branch: %s\n",
+							style.Dim.Render("○"), oldFields.Branch)
 					}
 				}
 			}

--- a/internal/cmd/mq_submit_helpers.go
+++ b/internal/cmd/mq_submit_helpers.go
@@ -1,0 +1,81 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/style"
+)
+
+// commitSHAResolver is the minimal git surface needed by resolveCommitSHA.
+// Defined as an interface so the helper can be table-tested with a fake.
+type commitSHAResolver interface {
+	CurrentBranch() (string, error)
+	FetchBranch(remote, branch string) error
+	Rev(ref string) (string, error)
+}
+
+// resolveCommitSHA returns the commit SHA to record on the MR bead.
+//
+// When --branch is explicit and points at a different branch than the cwd's
+// current branch (e.g., mayor's worktree on holds-gates submitting a polecat
+// branch), the polecat branch tip is the correct commit SHA — not cwd HEAD.
+//
+// Behavior:
+//   - explicitBranch == "" or matches current branch: return Rev("HEAD") (cwd is on the right branch already)
+//   - explicitBranch differs from current branch: fetch origin/<explicitBranch>, then Rev("origin/<explicitBranch>")
+//
+// The fetch is always performed in the cross-branch path. It is idempotent
+// (no harm if already current), single-ref (fast), and protects against the
+// failure mode where cwd's local origin/<branch> ref is stale relative to
+// what was just pushed (the recurring 9-occurrence bug ps-7v7 / co-toog).
+//
+// A fetch failure is non-fatal: emit a warning and proceed with Rev. If the
+// remote ref is missing entirely Rev will fail and the caller surfaces that.
+func resolveCommitSHA(g commitSHAResolver, explicitBranch string) (string, error) {
+	if explicitBranch == "" {
+		return g.Rev("HEAD")
+	}
+
+	currentBranch, err := g.CurrentBranch()
+	if err != nil {
+		// If we can't determine the current branch, fall back to HEAD with
+		// a warning: the explicit branch may or may not match HEAD, but
+		// HEAD is the only ref we can resolve.
+		style.PrintWarning("could not determine current branch: %v (falling back to HEAD)", err)
+		return g.Rev("HEAD")
+	}
+
+	if explicitBranch == currentBranch {
+		return g.Rev("HEAD")
+	}
+
+	if fetchErr := g.FetchBranch("origin", explicitBranch); fetchErr != nil {
+		// Non-fatal: warn and try Rev anyway. If origin/<branch> doesn't
+		// exist locally, Rev will fail and the caller surfaces it.
+		style.PrintWarning("could not fetch origin/%s: %v (commit_sha may be stale)", explicitBranch, fetchErr)
+	}
+
+	sha, err := g.Rev("origin/" + explicitBranch)
+	if err != nil {
+		return "", fmt.Errorf("resolving origin/%s: %w", explicitBranch, err)
+	}
+	return sha, nil
+}
+
+// shouldDeleteSupersededBranch reports whether the old MR's remote branch
+// should be deleted as part of supersede cleanup.
+//
+// Two conditions must hold:
+//   - The old branch must differ from the new MR's branch. Same-branch
+//     supersede (mayor's pattern: rebase → push --force-with-lease →
+//     resubmit) means the new MR points at the same branch — deleting it
+//     would leave the new MR pointing at a phantom origin branch (ps-7v7).
+//   - The old branch must be a polecat/* branch. Non-polecat branches may
+//     belong to contributor forks; deleting them closes upstream PRs (GH#2669).
+func shouldDeleteSupersededBranch(oldBranch, newBranch string) bool {
+	if oldBranch == newBranch {
+		return false
+	}
+	return strings.HasPrefix(oldBranch, "polecat/")
+}

--- a/internal/cmd/mq_submit_helpers_test.go
+++ b/internal/cmd/mq_submit_helpers_test.go
@@ -1,0 +1,296 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/git"
+)
+
+// fakeResolver is a test double for commitSHAResolver.
+type fakeResolver struct {
+	currentBranch    string
+	currentBranchErr error
+
+	fetchedRefs []string // remote/branch concatenated, in call order
+	fetchErr    error
+
+	revs    map[string]string // ref -> sha
+	revErrs map[string]error  // ref -> error to return
+}
+
+func (f *fakeResolver) CurrentBranch() (string, error) {
+	return f.currentBranch, f.currentBranchErr
+}
+
+func (f *fakeResolver) FetchBranch(remote, branch string) error {
+	f.fetchedRefs = append(f.fetchedRefs, remote+"/"+branch)
+	return f.fetchErr
+}
+
+func (f *fakeResolver) Rev(ref string) (string, error) {
+	if err, ok := f.revErrs[ref]; ok {
+		return "", err
+	}
+	if sha, ok := f.revs[ref]; ok {
+		return sha, nil
+	}
+	return "", errors.New("no such ref: " + ref)
+}
+
+func TestResolveCommitSHA(t *testing.T) {
+	tests := []struct {
+		name           string
+		explicitBranch string
+		resolver       *fakeResolver
+		wantSHA        string
+		wantErr        bool
+		wantFetched    []string // expected FetchBranch calls
+	}{
+		{
+			name:           "no explicit branch — returns HEAD",
+			explicitBranch: "",
+			resolver: &fakeResolver{
+				currentBranch: "polecat/quartz/co-toog",
+				revs:          map[string]string{"HEAD": "deadbeef"},
+			},
+			wantSHA:     "deadbeef",
+			wantFetched: nil, // never fetched
+		},
+		{
+			name:           "explicit branch matches current — returns HEAD without fetching",
+			explicitBranch: "polecat/quartz/co-toog",
+			resolver: &fakeResolver{
+				currentBranch: "polecat/quartz/co-toog",
+				revs:          map[string]string{"HEAD": "abc123"},
+			},
+			wantSHA:     "abc123",
+			wantFetched: nil,
+		},
+		{
+			name:           "explicit branch differs from current — fetches and returns origin tip",
+			explicitBranch: "polecat/jasper/co-5qy0",
+			resolver: &fakeResolver{
+				currentBranch: "main",
+				revs:          map[string]string{"origin/polecat/jasper/co-5qy0": "0dc8c4b8"},
+			},
+			wantSHA:     "0dc8c4b8",
+			wantFetched: []string{"origin/polecat/jasper/co-5qy0"},
+		},
+		{
+			name:           "fetch fails but Rev succeeds — proceeds with possibly-stale ref",
+			explicitBranch: "polecat/jasper/co-5qy0",
+			resolver: &fakeResolver{
+				currentBranch: "main",
+				fetchErr:      errors.New("network unreachable"),
+				revs:          map[string]string{"origin/polecat/jasper/co-5qy0": "stale123"},
+			},
+			wantSHA:     "stale123",
+			wantFetched: []string{"origin/polecat/jasper/co-5qy0"},
+		},
+		{
+			name:           "explicit branch differs and remote ref missing — returns error",
+			explicitBranch: "polecat/missing/never-pushed",
+			resolver: &fakeResolver{
+				currentBranch: "main",
+				// no entry in revs map → Rev returns "no such ref"
+			},
+			wantErr:     true,
+			wantFetched: []string{"origin/polecat/missing/never-pushed"},
+		},
+		{
+			name:           "CurrentBranch fails — falls back to HEAD",
+			explicitBranch: "polecat/jasper/co-5qy0",
+			resolver: &fakeResolver{
+				currentBranchErr: errors.New("detached HEAD"),
+				revs:             map[string]string{"HEAD": "headsha"},
+			},
+			wantSHA:     "headsha",
+			wantFetched: nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			sha, err := resolveCommitSHA(tt.resolver, tt.explicitBranch)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Fatalf("resolveCommitSHA() = (%q, nil), want error", sha)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("resolveCommitSHA() unexpected error: %v", err)
+			}
+			if sha != tt.wantSHA {
+				t.Errorf("sha = %q, want %q", sha, tt.wantSHA)
+			}
+
+			if len(tt.resolver.fetchedRefs) != len(tt.wantFetched) {
+				t.Errorf("fetched %v, want %v", tt.resolver.fetchedRefs, tt.wantFetched)
+				return
+			}
+			for i, got := range tt.resolver.fetchedRefs {
+				if got != tt.wantFetched[i] {
+					t.Errorf("fetch[%d] = %q, want %q", i, got, tt.wantFetched[i])
+				}
+			}
+		})
+	}
+}
+
+// TestResolveCommitSHA_RealGit exercises the helper end-to-end against a real
+// local git repo with a remote, validating the full mechanism: a worktree on
+// branch A, --branch B passed, must return B's tip — not A's tip.
+//
+// This is the regression test for ps-7v7 / co-toog Bug 1.
+func TestResolveCommitSHA_RealGit(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	// Set up a "remote" repo (bare).
+	remoteDir := t.TempDir()
+	runGit(t, remoteDir, "init", "--bare")
+
+	// Set up a "local" working clone.
+	localDir := t.TempDir()
+	runGit(t, localDir, "init", "-b", "main")
+	runGit(t, localDir, "config", "user.email", "test@test.com")
+	runGit(t, localDir, "config", "user.name", "Test User")
+	runGit(t, localDir, "remote", "add", "origin", remoteDir)
+
+	// Initial commit on main, push.
+	if err := os.WriteFile(filepath.Join(localDir, "README.md"), []byte("# Test\n"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+	runGit(t, localDir, "add", ".")
+	runGit(t, localDir, "commit", "-m", "initial")
+	runGit(t, localDir, "push", "-u", "origin", "main")
+
+	mainSHA := strings.TrimSpace(captureGit(t, localDir, "rev-parse", "HEAD"))
+
+	// Create feature branch with a different commit, push it.
+	runGit(t, localDir, "checkout", "-b", "polecat/quartz/co-toog")
+	if err := os.WriteFile(filepath.Join(localDir, "feature.md"), []byte("# Feature\n"), 0644); err != nil {
+		t.Fatalf("write feature: %v", err)
+	}
+	runGit(t, localDir, "add", ".")
+	runGit(t, localDir, "commit", "-m", "feature")
+	runGit(t, localDir, "push", "-u", "origin", "polecat/quartz/co-toog")
+
+	featureSHA := strings.TrimSpace(captureGit(t, localDir, "rev-parse", "HEAD"))
+
+	if featureSHA == mainSHA {
+		t.Fatalf("test setup error: feature SHA == main SHA")
+	}
+
+	// Now switch the worktree back to main — this simulates mayor's worktree
+	// on a different branch invoking `gt mq submit --branch <polecat-branch>`.
+	runGit(t, localDir, "checkout", "main")
+
+	// Pre-bug, resolveCommitSHA(g, "polecat/quartz/co-toog") would return
+	// HEAD == mainSHA. The fix returns the polecat branch tip == featureSHA.
+	g := git.NewGit(localDir)
+	got, err := resolveCommitSHA(g, "polecat/quartz/co-toog")
+	if err != nil {
+		t.Fatalf("resolveCommitSHA: %v", err)
+	}
+
+	if got != featureSHA {
+		t.Errorf("got SHA %q (which equals main? %v); want feature SHA %q",
+			got, got == mainSHA, featureSHA)
+	}
+
+	// Sanity-check: when explicitBranch matches the current branch, returns HEAD.
+	gotHead, err := resolveCommitSHA(g, "main")
+	if err != nil {
+		t.Fatalf("resolveCommitSHA(main): %v", err)
+	}
+	if gotHead != mainSHA {
+		t.Errorf("explicit==current path: got %q, want %q", gotHead, mainSHA)
+	}
+}
+
+func TestShouldDeleteSupersededBranch(t *testing.T) {
+	tests := []struct {
+		name      string
+		oldBranch string
+		newBranch string
+		want      bool
+	}{
+		{
+			name:      "same branch — preserve (ps-7v7 / co-toog regression)",
+			oldBranch: "polecat/jasper/co-5qy0",
+			newBranch: "polecat/jasper/co-5qy0",
+			want:      false,
+		},
+		{
+			name:      "different polecat branches — delete (existing GH#2669 behavior)",
+			oldBranch: "polecat/jasper/co-5qy0",
+			newBranch: "polecat/quartz/co-5qy0",
+			want:      true,
+		},
+		{
+			name:      "non-polecat branch — preserve (contributor fork PR)",
+			oldBranch: "feature/some-contrib-fork",
+			newBranch: "polecat/quartz/co-toog",
+			want:      false,
+		},
+		{
+			name:      "old polecat with @timestamp suffix vs same without — different strings, delete",
+			oldBranch: "polecat/quartz/co-1jdx@moucv7bt",
+			newBranch: "polecat/quartz/co-1jdx",
+			want:      true,
+		},
+		{
+			name:      "identical timestamped branches — preserve",
+			oldBranch: "polecat/quartz/co-1jdx@moucv7bt",
+			newBranch: "polecat/quartz/co-1jdx@moucv7bt",
+			want:      false,
+		},
+		{
+			name:      "empty old branch — preserve (defensive)",
+			oldBranch: "",
+			newBranch: "polecat/quartz/co-toog",
+			want:      false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldDeleteSupersededBranch(tt.oldBranch, tt.newBranch)
+			if got != tt.want {
+				t.Errorf("shouldDeleteSupersededBranch(%q, %q) = %v, want %v",
+					tt.oldBranch, tt.newBranch, got, tt.want)
+			}
+		})
+	}
+}
+
+// runGit runs a git command in dir and fails the test if it fails.
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %s: %v: %s", strings.Join(args, " "), err, string(out))
+	}
+}
+
+// captureGit runs a git command in dir and returns its stdout.
+func captureGit(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git %s: %v", strings.Join(args, " "), err)
+	}
+	return string(out)
+}


### PR DESCRIPTION
## Summary

Fixes two related metadata bugs in `gt mq submit` that have caused recurring friction on mayor-driven submits (9 occurrences across 4 days, 2026-05-04 → 2026-05-07). Both bugs share the same code path and the same UX failure mode: `gt mq submit --branch X` invoked from a worktree on a different branch.

### Bug 1: `commit_sha` populated from cwd HEAD instead of `--branch` tip

`mq_submit.go:236` (pre-fix) called `g.Rev(\"HEAD\")` unconditionally. When `gt mq submit --branch X` was invoked from a worktree on branch Y, the resulting MR-bead recorded Y's tip as `commit_sha`, not X's. Mayor manually corrected via `bd update --body-file` on every observed submit. Polecat-side `gt done` auto-completion was unaffected (cwd is always on the polecat's own branch when it auto-submits).

**Fix**: extracted `resolveCommitSHA(g, explicitBranch)`. When `--branch` is empty or matches the current branch, returns `Rev(\"HEAD\")` (preserves auto-completion path). Otherwise fetches `origin/<branch>` (single-ref, idempotent) and returns `Rev(\"origin/\" + branch)`.

The fetch is intentionally always performed in the cross-branch path. It protects against the failure mode where cwd's local `origin/<branch>` ref is stale relative to what the polecat just pushed — the exact mode the 9 occurrences exhibited.

### Bug 2: supersede-cleanup deletes the same branch the new MR points at

`mq_submit.go:314-325` (pre-fix) called `git push --delete origin <old-branch>` when superseding an old MR (per GH#2669, to auto-close the prior GH PR). When mayor resubmitted against the **same** source branch (rebase + force-push pattern), the old MR's branch field equaled the new MR's branch field — and the supersede-time delete killed the branch the new MR was pointing at. Refinery then saw a phantom-branch MR.

Observed twice this session (`co-1jdx-cherry-pick / co-wisp-3i0`; `co-5qy0-rebased / co-wisp-t53`); both required mayor to manually re-push the SHA.

**Fix**: extracted `shouldDeleteSupersededBranch(oldBranch, newBranch) bool`. Preserves the existing GH#2669 polecat-prefix gate AND adds a same-branch skip. Cross-branch supersede (different polecat branches for the same issue) continues to delete the old branch as before — keeping GH PR-auto-close UX intact.

Surgical fix preferred over deferring all branch-delete to `gt mq post-merge`, because cross-branch supersede's GH PR-auto-close is currently load-bearing UX (per GH#2669).

## What changes for which UX path

| Path | Before | After |
|------|--------|-------|
| Polecat `gt done` auto-completion | HEAD recorded (correct, cwd on polecat branch) | unchanged |
| Mayor-driven submit from different worktree | HEAD recorded (**WRONG**) | `--branch` tip recorded (correct) |
| Same-branch resubmit (rebase + force-push) | branch deleted, MR phantom | branch preserved with informational message |
| Cross-branch supersede (different polecat branches) | branch deleted, GH PR auto-closes | unchanged |

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./...` clean
- [x] New tests pass: `TestResolveCommitSHA` (6 fake-resolver scenarios), `TestResolveCommitSHA_RealGit` (end-to-end with real git remote), `TestShouldDeleteSupersededBranch` (6 cases including the regression, GH#2669 cross-branch, contributor-fork, timestamp variants)
- [x] Existing mq tests unaffected (`TestValidateMoleculePrereqs`, `TestParseBranchName`, etc.)
- [ ] Reviewer to confirm `gt mq submit --branch X` from a different-branch worktree records correct `commit_sha`
- [ ] Reviewer to confirm same-branch resubmit no longer deletes the branch

Test failures unrelated to this change (`TestFindActivePatrolHooked`, `TestManager_Queue_FiltersClosedMergeRequests`, `internal/tmux/dialog_acceptance_test.go`) are environment-dependent (Dolt container, tmux dialog timing) and exist on `origin/main` — not regressions from this PR.

## Manual workaround burden being removed

Mayor manually corrected `commit_sha` via `bd update --body-file` on **every** observed submit (9 occurrences). Each correction required:
1. Mayor to know the bug exists (new mayor sessions silently re-trip)
2. Mayor to pre-correct before refinery picks up the MR
3. Re-push to restore branches deleted by Bug 2

This PR removes both the metadata-correction burden AND the branch-restore burden.

## Refs

- ps-7v7 (gastown internal tracking)
- co-toog (gastown internal tracking, Phase 1+2)
- GH#2669 (cross-branch supersede PR-auto-close, behavior preserved)
- GH#3032 (commit_sha for MR dedup, the original feature being fixed)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3857"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->