### PR TITLE
fix(agents): set EscapeCancelsRequest on Claude + Copilot presets to gate poller's Escape keystroke

### DIFF
--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -251,6 +251,7 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		InstructionsFile:       "CLAUDE.md",
 		EmitsPermissionWarning: true,
 		HasTurnBoundaryDrain:   true,
+		EscapeCancelsRequest:   true, // Claude Code: Escape cancels in-flight generation (ps-4vb / co-mhh5)
 	},
 	AgentGemini: {
 		Name:                AgentGemini,
@@ -403,10 +404,11 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		HooksProvider:      "copilot",
 		HooksDir:           ".github/hooks",
 		HooksSettingsFile:  "gastown.json",
-		HooksInformational: false,
-		ReadyPromptPrefix:  "",   // GA: no ❯ prompt; Copilot uses hint text, not a detectable prefix
-		ReadyDelayMs:       5000, // Delay-based readiness detection (no prompt prefix)
-		InstructionsFile:   "AGENTS.md",
+		HooksInformational:   false,
+		ReadyPromptPrefix:    "",   // GA: no ❯ prompt; Copilot uses hint text, not a detectable prefix
+		ReadyDelayMs:         5000, // Delay-based readiness detection (no prompt prefix)
+		InstructionsFile:     "AGENTS.md",
+		EscapeCancelsRequest: true, // Copilot CLI: Escape cancels in-flight generation (hq-isz)
 	},
 	AgentPi: {
 		Name:                AgentPi,
@@ -514,6 +516,7 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		ReadyDelayMs:         10000,
 		InstructionsFile:     "CLAUDE.md",
 		HasTurnBoundaryDrain: true,
+		EscapeCancelsRequest: true, // Routes to Claude binary: same Escape semantics (ps-4vb / co-mhh5)
 	},
 }
 

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -568,6 +568,46 @@ func TestAgentPresetApprovalFlags(t *testing.T) {
 	}
 }
 
+func TestAgentPresetEscapeCancelsRequest(t *testing.T) {
+	t.Parallel()
+	// Per-preset truth for whether sending Escape cancels in-flight generation.
+	// Callers that route through the registry (`gt nudge`, `nudge-poller`) read
+	// this flag and set `tmux.NudgeOpts.SkipEscape` so the destructive Escape
+	// keystroke is suppressed during delivery. ps-4vb / co-mhh5: misconfiguring
+	// Claude here produced fabricated `[Request interrupted by user]` events
+	// every poll cycle. (hq-isz: same root cause, narrower fix for Copilot.)
+	tests := []struct {
+		preset AgentPreset
+		want   bool
+	}{
+		{AgentClaude, true},       // Claude Code: Escape interrupts active request
+		{AgentGroqCompound, true}, // Routes through Claude binary
+		{AgentGemini, true},       // Gemini CLI: Escape aborts active generation
+		{AgentCopilot, true},      // Copilot CLI: Escape cancels (was hardcoded carve-out in tmux.go)
+		{AgentCodex, false},       // Codex: Escape is safe (no cancel binding)
+		{AgentCursor, false},      // Cursor: Escape is safe
+		{AgentAuggie, false},      // Auggie: Escape is safe
+		{AgentAmp, false},         // Amp: Escape is safe
+		{AgentOpenCode, false},    // OpenCode: Escape is safe
+		{AgentPi, false},          // Pi: Escape is safe
+		{AgentOmp, false},         // Omp: Escape is safe
+		{AgentMistral, false},     // Vibe: Escape is safe
+	}
+
+	for _, tt := range tests {
+		t.Run(string(tt.preset), func(t *testing.T) {
+			info := GetAgentPreset(tt.preset)
+			if info == nil {
+				t.Fatalf("preset %s not found", tt.preset)
+			}
+			if info.EscapeCancelsRequest != tt.want {
+				t.Errorf("preset %s EscapeCancelsRequest = %v, want %v",
+					tt.preset, info.EscapeCancelsRequest, tt.want)
+			}
+		})
+	}
+}
+
 func TestMergeWithPreset(t *testing.T) {
 	t.Parallel()
 	// Test that user config overrides preset defaults

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1725,18 +1725,12 @@ func (t *Tmux) NudgeSessionWithOpts(session, message string, opts NudgeOpts) err
 	time.Sleep(adaptiveTextDelay(len(sanitized)))
 
 	if !opts.SkipEscape {
-		// Auto-skip Escape for Copilot CLI sessions. Escape cancels in-flight
-		// generation in Copilot CLI (like Gemini), leaving the nudge text
-		// stranded in the input field without Enter being processed. (hq-isz)
-		agentType, _ := t.GetEnvironment(session, "GT_AGENT")
-		if agentType == "copilot" {
-			opts.SkipEscape = true
-		}
-	}
-
-	if !opts.SkipEscape {
 		// 5. Send Escape to exit vim INSERT mode if enabled (harmless in normal mode)
 		// See: https://github.com/anthropics/gastown/issues/307
+		// Per-agent gating lives in the registry (`EscapeCancelsRequest`); callers
+		// that route through the registry (`gt nudge`, `nudge-poller`) set
+		// `SkipEscape` upstream, so this branch is unreachable for agents whose
+		// preset has `EscapeCancelsRequest: true` (Claude, Copilot, Gemini, ...).
 		_, _ = t.run("send-keys", "-t", target, "Escape")
 
 		// 6. Wait 600ms — must exceed bash readline's keyseq-timeout (500ms default)


### PR DESCRIPTION
## Summary

The nudge-poller fabricates `[Request interrupted by user]` events on Claude
sessions because its `NudgeSessionWithOpts` injection sends an unconditional
Escape keystroke (tmux.go step 5) on every drain — and Escape is Claude
Code's user-interrupt binding.

**Cadence-signature evidence**: interrupts cluster on 10-second poll
boundaries (`:07/:17/:27/:37/:47/:57`). 39 fabricated interrupts observed
across 6 sessions in 2 rigs in a single investigation pass. Operator
workaround was killing poller PIDs manually.

## Mechanism

The infrastructure to gate this was already 95% built under [gt-wasn]
for Gemini:

- `AgentPresetInfo.EscapeCancelsRequest` on the registry (`config/agents.go`)
- `tmux.NudgeOpts.SkipEscape`
- Wiring in `nudge_poller.go:79-87` and `nudge.go:271-278` that reads the
  preset and sets `SkipEscape` upstream
- Gating at `tmux.go:1737` that suppresses the Escape keystroke + the
  600ms readline timeout when `SkipEscape` is true

What was missing: **Claude's preset** (and `AgentGroqCompound`, which
routes through the Claude binary) had `EscapeCancelsRequest` defaulting to
`false`, so the poller's drain loop sent Escape every cycle into a Claude
pane that treats Escape as cancel.

## Fix

1. Set `EscapeCancelsRequest: true` on the **Claude** and **GroqCompound**
   presets. The existing plumbing propagates correctly with no other
   change.

2. **Bundled cleanup**: replace the hardcoded
   `if agentType == \"copilot\" { SkipEscape = true }` carve-out at
   `tmux.go:1727-1735` (added under [hq-isz]) with the registry-driven
   path. Set `EscapeCancelsRequest: true` on the **Copilot** preset and
   remove the per-agent `if` block.

   This is the same architectural pattern the operator's bar requires:
   registry truth, not per-rig carve-outs.

## Why no spawn-time gate

An earlier framing of this bug suggested skipping the nudge-poller spawn
entirely for Claude. Three spawn sites (`crew/manager.go:892`,
`witness/manager.go:264`, `refinery/manager.go:251`) explicitly justify
starting the poller for Claude — under [gt-dgf], to break the deadlock
where idle Claude sessions never submit a prompt and never trigger
`UserPromptSubmit` drain.

Skipping spawn for Claude would regress gt-dgf. The bug is the destructive
Escape during *delivery*, not the spawn.

## Tests

- New `TestAgentPresetEscapeCancelsRequest` in `internal/config/agents_test.go`
  covering the per-preset matrix (12 subtests: Claude/GroqCompound/Gemini/
  Copilot true; rest false).
- Existing `TestNudgeSession_*` integration coverage in
  `internal/tmux/tmux_test.go` continues to pass after the carve-out
  removal.

## Test plan

- [x] `go build ./...` clean
- [x] `go test ./internal/config/ ./internal/nudge/` green
- [x] `go test ./internal/tmux/ -run TestNudgeSession` green (NudgeSession
  delivery semantics unchanged for Claude path; carve-out removal does
  not regress existing behavior because callers route through the
  registry which now sets `SkipEscape` for Copilot)
- [ ] CI runs full suite (this PR)

Closes co-mhh5 (mirrors town-root ps-4vb).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3858"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->