### PR TITLE
fix: close stale hooked mail beads before each handoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   from the canonical DB — a silent data split. Cleanup now removes both
   naming forms and `AddRig` fails loudly if an orphan persists (gh#3562,
   hq-j6hur.4.2).
+- **Stale hooked mail beads** — `sendHandoffMail()` now closes any `gt:message` beads left in `status=hooked` from previous sessions before creating a new handoff bead, preventing indefinite accumulation across sessions (#3859).
 
 ## [1.1.0] - 2026-05-06
 

--- a/internal/beads/handoff.go
+++ b/internal/beads/handoff.go
@@ -187,6 +187,32 @@ func (b *Beads) ClearMail(reason string) (*ClearMailResult, error) {
 	return result, nil
 }
 
+// CloseStaleHookedMailBeads closes any gt:message beads in status=hooked assigned
+// to agentID. Called before creating a new handoff mail to prevent accumulation of
+// stale beads across sessions. Returns the number of beads closed. (GH#3859)
+func (b *Beads) CloseStaleHookedMailBeads(agentID string) (int, error) {
+	hooked, err := b.List(ListOptions{
+		Status:   StatusHooked,
+		Label:    "gt:message",
+		Assignee: agentID,
+		Priority: -1,
+	})
+	if err != nil {
+		return 0, fmt.Errorf("listing hooked mail beads: %w", err)
+	}
+	if len(hooked) == 0 {
+		return 0, nil
+	}
+	ids := make([]string, len(hooked))
+	for i, h := range hooked {
+		ids[i] = h.ID
+	}
+	if err := b.ForceCloseWithReason("handoff: superseded by new session", ids...); err != nil {
+		return 0, err
+	}
+	return len(ids), nil
+}
+
 // lockBead acquires a cross-process advisory lock for a bead operation.
 // Returns a cleanup function that releases the lock.
 // Lock files are stored in <beadsDir>/locks/<beadID>.flock.

--- a/internal/beads/handoff_test.go
+++ b/internal/beads/handoff_test.go
@@ -2,6 +2,8 @@ package beads
 
 import (
 	"testing"
+
+	beadsdk "github.com/steveyegge/beads"
 )
 
 func TestHandoffBeadTitle(t *testing.T) {
@@ -64,4 +66,89 @@ func TestClearMailResultZeroValues(t *testing.T) {
 	if result.Closed != 0 || result.Cleared != 0 {
 		t.Errorf("expected zero values, got Closed=%d Cleared=%d", result.Closed, result.Cleared)
 	}
+}
+
+func TestCloseStaleHookedMailBeads(t *testing.T) {
+	hookedMailBead := func(store *mockStorage, assignee string) string {
+		id := "test-hm-1"
+		store.issues[id] = &beadsdk.Issue{
+			ID:       id,
+			Title:    "🤝 HANDOFF: prev session",
+			Status:   beadsdk.Status(StatusHooked),
+			Assignee: assignee,
+			Labels:   []string{"gt:message"},
+		}
+		store.labels[id] = []string{"gt:message"}
+		return id
+	}
+
+	t.Run("closes hooked gt:message beads for agent", func(t *testing.T) {
+		store := newMockStorage()
+		b := newTestBeads(store)
+		id := hookedMailBead(store, "gastown/mayor")
+
+		n, err := b.CloseStaleHookedMailBeads("gastown/mayor")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if n != 1 {
+			t.Errorf("want 1 closed, got %d", n)
+		}
+		if !store.closed[id] {
+			t.Errorf("bead %s was not closed", id)
+		}
+	})
+
+	t.Run("does not close hooked gt:task beads", func(t *testing.T) {
+		store := newMockStorage()
+		b := newTestBeads(store)
+		taskID := "test-task-1"
+		store.issues[taskID] = &beadsdk.Issue{
+			ID:       taskID,
+			Status:   beadsdk.Status(StatusHooked),
+			Assignee: "gastown/mayor",
+			Labels:   []string{"gt:task"},
+		}
+		store.labels[taskID] = []string{"gt:task"}
+
+		n, err := b.CloseStaleHookedMailBeads("gastown/mayor")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("want 0 (gt:task bead should be untouched), got %d", n)
+		}
+		if store.closed[taskID] {
+			t.Errorf("gt:task bead %s was incorrectly closed", taskID)
+		}
+	})
+
+	t.Run("returns 0 when no hooked mail beads exist", func(t *testing.T) {
+		b := newTestBeads(newMockStorage())
+
+		n, err := b.CloseStaleHookedMailBeads("gastown/mayor")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("want 0, got %d", n)
+		}
+	})
+
+	t.Run("does not close mail beads belonging to other agents", func(t *testing.T) {
+		store := newMockStorage()
+		b := newTestBeads(store)
+		id := hookedMailBead(store, "gastown/witness")
+
+		n, err := b.CloseStaleHookedMailBeads("gastown/mayor")
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if n != 0 {
+			t.Errorf("want 0 (other agent's bead should be untouched), got %d", n)
+		}
+		if store.closed[id] {
+			t.Errorf("other agent's bead %s was incorrectly closed", id)
+		}
+	})
 }

--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -1284,6 +1284,15 @@ func sendHandoffMail(subject, message string) (string, error) {
 	// Build labels for mail metadata (matches mail router format)
 	labels := fmt.Sprintf("from:%s", agentID)
 
+	// Close stale hooked mail beads from previous sessions before creating a new one.
+	// Without this, each handoff cycle accumulates beads in status=hooked. (GH#3859)
+	townB := beads.New(filepath.Join(townRoot, ".beads"))
+	if n, closeErr := townB.CloseStaleHookedMailBeads(agentID); closeErr != nil {
+		style.PrintWarning("couldn't close previous hooked mail bead(s): %v", closeErr)
+	} else if n > 0 {
+		fmt.Printf("%s Closed %d stale hooked mail bead(s)\n", style.Dim.Render("🧹"), n)
+	}
+
 	// Create mail bead directly using bd create with --silent to get the ID
 	// Mail goes to town-level beads (hq- prefix)
 	// Flags go first, then -- to end flag parsing, then the positional subject.


### PR DESCRIPTION
## Summary

Prevent accumulation of stale hooked mail beads across handoff sessions by closing them before creating a new handoff mail. Each `/handoff` call was leaving the previous session's `gt:message` bead in `status=hooked` indefinitely.

Fixes #3859

## Changes

- Added `CloseStaleHookedMailBeads(agentID string)` to `internal/beads/handoff.go` — finds and force-closes all `gt:message` beads in `status=hooked` for the given agent
- Integrated the cleanup into `sendHandoffMail()` in `internal/cmd/handoff.go` — runs before creating the new handoff bead
- Added `TestCloseStaleHookedMailBeads` with 4 test cases in `internal/beads/handoff_test.go`:
  - Closes hooked `gt:message` beads for the target agent
  - Skips `gt:task` beads (only `gt:message` beads are affected)
  - Returns 0 cleanly when no hooked beads exist
  - Does not touch beads belonging to other agents

## Testing

- [x] Unit tests added and pass (`go test ./internal/beads/...`)
- [x] `go test ./...` passes

## Checklist

- [x] Code follows project style
- [x] No breaking changes
- [x] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3862"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->