### PR TITLE
fix(polecat): use SetAgentStateWithRetry in pool-init to close MVCC race

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1814,8 +1814,13 @@ func runPolecatPoolInit(cmd *cobra.Command, args []string) error {
 			fmt.Printf(" %s %v\n", style.Warning.Render("FAILED"), addErr)
 			continue
 		}
-		// Set agent state to idle (polecat was created without work)
-		if stateErr := mgr.SetAgentState(name, "idle"); stateErr != nil {
+		// Set agent state to idle (polecat was created without work).
+		// Use the retry variant: createAgentBeadWithRetry above leaves a brief
+		// Dolt MVCC visibility window where the just-committed bead isn't yet
+		// readable by the next UpdateAgentState query, surfacing as "issue not
+		// found". Retries with backoff close that window — same pattern as
+		// SetAgentStateWithRetry's other call site in polecat_spawn.go.
+		if stateErr := mgr.SetAgentStateWithRetry(name, "idle"); stateErr != nil {
 			fmt.Printf(" %s (created but couldn't set idle state: %v)\n", style.Warning.Render("⚠"), stateErr)
 		} else {
 			fmt.Printf(" %s (%s)\n", style.Success.Render("✓"), style.Dim.Render(p.ClonePath))


### PR DESCRIPTION
## Problem

`gt polecat pool-init` produces broken polecat slots ~30-50% of the time on warm Dolt servers. The flow:

1. `mgr.Add(name)` — goes through `createAgentBeadWithRetry`, lands the agent bead with `AgentState: "spawning"`. ✅ retries on transient Dolt failures.
2. `mgr.SetAgentState(name, "idle")` — flips state to "idle". ❌ **no retry**.

The just-committed agent bead occasionally isn't yet visible to the next `UpdateAgentState` query (Dolt MVCC visibility lag), surfacing as `"issue not found"`. The polecat directory and worktree exist, but the agent bead stays at `spawning`. Witness later flags these as DEAD / idle 3+ cycles. Operators have to nuke and recreate by hand.

## Reproduction

Run `gt polecat pool-init <rig> --size 10` against a warm Dolt server. Roughly 30-50% of created polecats hit:

```
⚠ (created but couldn't set idle state: issue not found)
```

A subsequent `gt polecat status <name>` shows `Status: not running` for those, and witness flags them in cycles 3+:

```
FLEET: <names> idle 3+ cycles [HIGH PRIORITY]
sessions DEAD and unhooked across cycles 3-5
```

## Fix

`SetAgentStateWithRetry` already exists at `internal/polecat/manager.go:357` and is used for the same race in `internal/cmd/polecat_spawn.go:398`. Pool-init just needs to use it instead of the bare `SetAgentState`.

This is a one-line change with a comment explaining the rationale (matching the existing pattern at the spawn call site). No behavior change for the success path; the warning path on exhausted retries stays intact, just fires far less often.

## Verification

- Build passes (`go build ./...`).
- No new tests added — the existing `SetAgentStateWithRetry` is already exercised, and adding a Dolt-MVCC-race-specific test would require infrastructure beyond what the existing polecat tests scaffold.
- Local repro: pool-init runs that previously printed 3-5 warnings now print 0 against the same server load.

## Related

- The retry shape is borrowed verbatim from `polecat_spawn.go:398` which solved the same race at session-start.
- Witness escalation message that motivates the fix: `FLEET: <names> idle 3+ cycles` — operators have to manually correlate the `couldn't set idle state` warnings with the witness escalation and nuke. This fix removes that toil.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3869"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->