### PR TITLE
fix(diskspace): include APFS purgeable space in available bytes on macOS

### DIFF
--- a/internal/util/diskspace_darwin.go
+++ b/internal/util/diskspace_darwin.go
@@ -58,6 +58,10 @@ func GetDiskSpace(path string) (*DiskSpaceInfo, error) {
 	}, nil
 }
 
+// int8SliceToString converts the signed-byte fields used by darwin's
+// syscall.Statfs_t (e.g. Fstypename, Mntonname) into a Go string. The
+// standard `string(bytes)` idiom doesn't apply because the underlying
+// type is []int8, not []byte (signedness quirk of darwin syscalls).
 func int8SliceToString(b []int8) string {
 	buf := make([]byte, len(b))
 	for i, v := range b {
@@ -100,6 +104,8 @@ func parsePlistUint64(data []byte, key string) (uint64, bool) {
 	for {
 		tok, err := dec.Token()
 		if err != nil {
+			// any xml decode error (incl. io.EOF) → treat as "key not found";
+			// caller falls back to statfs values, which is the safe default.
 			return 0, false
 		}
 		switch t := tok.(type) {

--- a/internal/util/diskspace_darwin.go
+++ b/internal/util/diskspace_darwin.go
@@ -1,0 +1,131 @@
+//go:build darwin
+
+package util
+
+import (
+	"bytes"
+	"context"
+	"encoding/xml"
+	"fmt"
+	"os/exec"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+// GetDiskSpace returns filesystem space information for the given path.
+// On APFS volumes it queries diskutil to include purgeable space (iCloud
+// local copies, Time Machine snapshots, etc.) in the available bytes,
+// preventing false-positive "disk exhausted" blocks on macOS.
+func GetDiskSpace(path string) (*DiskSpaceInfo, error) {
+	var stat syscall.Statfs_t
+	if err := syscall.Statfs(path, &stat); err != nil {
+		return nil, fmt.Errorf("statfs %s: %w", path, err)
+	}
+
+	bsize := uint64(stat.Bsize)
+	total := stat.Blocks * bsize
+	free := uint64(stat.Bavail) * bsize //nolint:unconvert
+	used := total - (stat.Bfree * bsize)
+
+	// On APFS, APFSContainerFree from diskutil includes purgeable space that
+	// macOS reclaims automatically under pressure — statfs Bavail omits it.
+	if int8SliceToString(stat.Fstypename[:]) == "apfs" {
+		mountPoint := int8SliceToString(stat.Mntonname[:])
+		if containerFree, containerSize, err := apfsContainerSpaceFn(mountPoint); err == nil {
+			free = containerFree
+			if containerSize > 0 {
+				total = containerSize
+			}
+			if free <= total {
+				used = total - free
+			} else {
+				used = 0
+			}
+		}
+	}
+
+	var usedPct float64
+	if total > 0 {
+		usedPct = float64(used) / float64(total) * 100
+	}
+
+	return &DiskSpaceInfo{
+		AvailableBytes: free,
+		TotalBytes:     total,
+		UsedBytes:      used,
+		UsedPercent:    usedPct,
+	}, nil
+}
+
+func int8SliceToString(b []int8) string {
+	buf := make([]byte, len(b))
+	for i, v := range b {
+		if v == 0 {
+			return string(buf[:i])
+		}
+		buf[i] = byte(v)
+	}
+	return string(buf)
+}
+
+// apfsContainerSpaceFn is the function used to query APFS container space.
+// It is a variable so tests can replace it with a stub.
+var apfsContainerSpaceFn = apfsContainerSpace
+
+// apfsContainerSpace returns the APFS container free and total bytes by
+// calling diskutil. Returns an error if diskutil is unavailable or the output
+// lacks the expected keys.
+func apfsContainerSpace(mountPoint string) (free, total uint64, err error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	out, err := exec.CommandContext(ctx, "diskutil", "info", "-plist", mountPoint).Output()
+	if err != nil {
+		return 0, 0, fmt.Errorf("diskutil info: %w", err)
+	}
+
+	free, ok := parsePlistUint64(out, "APFSContainerFree")
+	if !ok || free == 0 {
+		return 0, 0, fmt.Errorf("APFSContainerFree not found in diskutil output")
+	}
+	total, _ = parsePlistUint64(out, "APFSContainerSize")
+	return free, total, nil
+}
+
+// parsePlistUint64 extracts a uint64 integer for the given key from Apple plist XML.
+func parsePlistUint64(data []byte, key string) (uint64, bool) {
+	dec := xml.NewDecoder(bytes.NewReader(data))
+	waitForValue := false
+	for {
+		tok, err := dec.Token()
+		if err != nil {
+			return 0, false
+		}
+		switch t := tok.(type) {
+		case xml.StartElement:
+			switch t.Name.Local {
+			case "key":
+				var k string
+				if err := dec.DecodeElement(&k, &t); err == nil {
+					waitForValue = k == key
+				} else {
+					waitForValue = false
+				}
+			case "integer":
+				if waitForValue {
+					var s string
+					if err := dec.DecodeElement(&s, &t); err == nil {
+						if v, err := strconv.ParseUint(s, 10, 64); err == nil {
+							return v, true
+						}
+					}
+					return 0, false
+				}
+				waitForValue = false
+			default:
+				waitForValue = false
+			}
+		}
+	}
+}

--- a/internal/util/diskspace_darwin_test.go
+++ b/internal/util/diskspace_darwin_test.go
@@ -1,0 +1,169 @@
+//go:build darwin
+
+package util
+
+import (
+	"testing"
+)
+
+func TestParsePlistUint64_Found(t *testing.T) {
+	plist := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>SomeOtherKey</key>
+	<string>hello</string>
+	<key>APFSContainerFree</key>
+	<integer>127566721024</integer>
+	<key>APFSContainerSize</key>
+	<integer>994662584320</integer>
+</dict>
+</plist>`)
+
+	free, ok := parsePlistUint64(plist, "APFSContainerFree")
+	if !ok {
+		t.Fatal("expected APFSContainerFree to be found")
+	}
+	if free != 127566721024 {
+		t.Errorf("APFSContainerFree = %d, want 127566721024", free)
+	}
+
+	size, ok := parsePlistUint64(plist, "APFSContainerSize")
+	if !ok {
+		t.Fatal("expected APFSContainerSize to be found")
+	}
+	if size != 994662584320 {
+		t.Errorf("APFSContainerSize = %d, want 994662584320", size)
+	}
+}
+
+func TestParsePlistUint64_Missing(t *testing.T) {
+	plist := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict><key>Other</key><integer>1</integer></dict></plist>`)
+
+	_, ok := parsePlistUint64(plist, "APFSContainerFree")
+	if ok {
+		t.Error("expected APFSContainerFree to be absent")
+	}
+}
+
+func TestParsePlistUint64_KeyFollowedByNonInteger(t *testing.T) {
+	plist := []byte(`<?xml version="1.0" encoding="UTF-8"?>
+<plist version="1.0"><dict>
+	<key>APFSContainerFree</key>
+	<string>not-a-number</string>
+	<key>APFSContainerSize</key>
+	<integer>1000</integer>
+</dict></plist>`)
+
+	_, ok := parsePlistUint64(plist, "APFSContainerFree")
+	if ok {
+		t.Error("expected non-integer value to return not-found")
+	}
+	size, ok := parsePlistUint64(plist, "APFSContainerSize")
+	if !ok || size != 1000 {
+		t.Errorf("APFSContainerSize = %d, ok=%v; want 1000, true", size, ok)
+	}
+}
+
+func TestInt8SliceToString(t *testing.T) {
+	input := []int8{'a', 'p', 'f', 's', 0, 0, 0, 0}
+	got := int8SliceToString(input)
+	if got != "apfs" {
+		t.Errorf("int8SliceToString = %q, want %q", got, "apfs")
+	}
+}
+
+func TestGetDiskSpace_Darwin_APFS(t *testing.T) {
+	// Integration test: on macOS the current dir is on APFS, so APFSContainerFree
+	// should give us a non-zero available value.
+	info, err := GetDiskSpace(".")
+	if err != nil {
+		t.Fatalf("GetDiskSpace(\".\") failed: %v", err)
+	}
+	if info.TotalBytes == 0 {
+		t.Error("TotalBytes should be > 0")
+	}
+	if info.AvailableBytes == 0 {
+		t.Error("AvailableBytes should be > 0 on a non-full disk")
+	}
+	if info.AvailableBytes > info.TotalBytes {
+		t.Errorf("AvailableBytes (%d) > TotalBytes (%d)", info.AvailableBytes, info.TotalBytes)
+	}
+	if info.UsedPercent < 0 || info.UsedPercent > 100 {
+		t.Errorf("UsedPercent = %.1f, want 0-100", info.UsedPercent)
+	}
+}
+
+// TestAPFSPurgeablePreventsBlock reproduces the exact scenario from issue #3854:
+// a 926 GB APFS disk where statfs reports 96% used (41 GB free) but 185 GB is
+// purgeable space macOS can reclaim — the old code would block, the new code must not.
+func TestAPFSPurgeablePreventsBlock(t *testing.T) {
+	const GB = uint64(1024 * 1024 * 1024)
+	containerTotal := 926 * GB
+	purgeableSpace := 185 * GB
+	statfsFree := 41 * GB // what df / old code saw
+	containerFree := statfsFree + purgeableSpace
+
+	// Inject a stub that returns the simulated diskutil values.
+	orig := apfsContainerSpaceFn
+	defer func() { apfsContainerSpaceFn = orig }()
+	apfsContainerSpaceFn = func(_ string) (uint64, uint64, error) {
+		return containerFree, containerTotal, nil
+	}
+
+	info, err := GetDiskSpace(".")
+	if err != nil {
+		t.Fatalf("GetDiskSpace failed: %v", err)
+	}
+
+	// The fix must report available = containerFree (41 + 185 = 226 GB).
+	if info.AvailableBytes != containerFree {
+		t.Errorf("AvailableBytes = %d, want %d (%.1f GB want %.1f GB)",
+			info.AvailableBytes, containerFree,
+			float64(info.AvailableBytes)/float64(GB), float64(containerFree)/float64(GB))
+	}
+
+	// Old code would have used statfs Bavail (~41 GB) → 95.6% → CRITICAL block.
+	oldUsed := containerTotal - statfsFree
+	oldPct := float64(oldUsed) / float64(containerTotal) * 100
+	if oldPct < DiskSpaceCriticalPercent {
+		t.Errorf("test setup broken: old code would show %.1f%% (expected >= %.1f%%)", oldPct, DiskSpaceCriticalPercent)
+	}
+
+	// New code must be below the critical threshold.
+	if info.UsedPercent >= DiskSpaceCriticalPercent {
+		t.Errorf("UsedPercent = %.1f%% >= %.1f%% — fix failed, false positive would still block",
+			info.UsedPercent, DiskSpaceCriticalPercent)
+	}
+
+	// Double-check CheckDiskSpace also clears.
+	level, msg, err := CheckDiskSpace(".")
+	if err != nil {
+		t.Fatalf("CheckDiskSpace failed: %v", err)
+	}
+	if level == DiskSpaceCritical {
+		t.Errorf("CheckDiskSpace returned CRITICAL with purgeable space included: %s", msg)
+	}
+
+	t.Logf("OLD: %.1f GB free, %.1f%% used → would block",
+		float64(statfsFree)/float64(GB), oldPct)
+	t.Logf("NEW: %.1f GB free (includes %.1f GB purgeable), %.1f%% used → passes",
+		float64(info.AvailableBytes)/float64(GB), float64(purgeableSpace)/float64(GB), info.UsedPercent)
+}
+
+func TestApfsContainerSpace_CurrentMount(t *testing.T) {
+	// The repo lives on an APFS volume; verify diskutil returns sensible numbers.
+	// diskutil info requires an absolute path — use the user's home dir which is
+	// always on the main APFS container on macOS.
+	free, total, err := apfsContainerSpace("/System/Volumes/Data")
+	if err != nil {
+		t.Skipf("apfsContainerSpace failed (non-APFS environment?): %v", err)
+	}
+	if free == 0 {
+		t.Error("expected non-zero free bytes from APFSContainerFree")
+	}
+	if total > 0 && free > total {
+		t.Errorf("free (%d) > total (%d)", free, total)
+	}
+}

--- a/internal/util/diskspace_unix.go
+++ b/internal/util/diskspace_unix.go
@@ -1,4 +1,4 @@
-//go:build !windows
+//go:build !windows && !darwin
 
 package util
 


### PR DESCRIPTION
## Summary

On macOS APFS volumes, `syscall.Statfs` (and therefore `df`) reports purgeable space — iCloud Drive local copies, Time Machine local snapshots, Safari caches — as *used*, not as *free*. This caused the polecat scheduler's disk check to fire a false-positive `CRITICAL: disk space exhausted` block even when the machine was not actually out of space, because macOS reclaims purgeable space automatically under memory pressure.

This PR adds a Darwin-specific `GetDiskSpace` implementation that queries `diskutil info -plist <mountpoint>` for `APFSContainerFree`, which is the true available space at the APFS container level (including purgeable). On non-APFS or non-Darwin volumes the behaviour is unchanged. If `diskutil` fails for any reason, the code falls back silently to the original `statfs` values.

## Related Issue

Fixes #3854

## Changes

- `internal/util/diskspace_unix.go` — narrowed build tag from `!windows` → `!windows && !darwin` so Darwin no longer uses the generic Unix path
- `internal/util/diskspace_darwin.go` — new Darwin-specific `GetDiskSpace`: uses `syscall.Statfs` as base, then on APFS volumes replaces available/total/used with container-level values from `diskutil info -plist`; `apfsContainerSpaceFn` is a replaceable variable for testing
- `internal/util/diskspace_darwin_test.go` — unit tests for plist parsing + a scenario test (`TestAPFSPurgeablePreventsBlock`) that reproduces the exact numbers from the issue (926 GB disk, 41 GB statfs-free, 185 GB purgeable) and proves the old code would have blocked while the new code does not

## Testing

- [x] Unit tests pass (`go test ./...`)
- [x] `TestAPFSPurgeablePreventsBlock` reproduces the exact issue scenario end-to-end:
  ```
  OLD: 41.0 GB free, 95.6% used → would block
  NEW: 226.0 GB free (includes 185.0 GB purgeable), 75.6% used → passes
  ```
- [x] `TestApfsContainerSpace_CurrentMount` integration test verifies `diskutil` call works against `/System/Volumes/Data` on a real macOS APFS volume
- [x] Plist parsing unit tests cover: key found, key missing, key followed by non-integer value

## Checklist

- [x] Code follows project style
- [x] Documentation updated (if applicable)
- [x] No breaking changes — `DiskSpaceInfo` API and `CheckDiskSpace` signature are unchanged; behaviour on Linux/Windows is unaffected

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3871"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->