### PR TITLE
fix(formula): infer rig from workspace instead of hardcoding gastown default

### DIFF
--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -118,7 +118,7 @@ the rig's settings/config.json under workflow.default_formula.
 
 Options:
   --pr=N        Run formula on GitHub PR #N
-  --rig=NAME    Target specific rig (default: current or gastown)
+  --rig=NAME    Target specific rig (default: inferred from cwd, or sole registered rig)
   --agent=ALIAS Override agent/runtime for all legs (e.g., gemini, codex)
   --dry-run     Show what would happen without executing
 
@@ -169,7 +169,7 @@ func init() {
 
 	// Run flags
 	formulaRunCmd.Flags().IntVar(&formulaRunPR, "pr", 0, "GitHub PR number to run formula on")
-	formulaRunCmd.Flags().StringVar(&formulaRunRig, "rig", "", "Target rig (default: current or gastown)")
+	formulaRunCmd.Flags().StringVar(&formulaRunRig, "rig", "", "Target rig (default: inferred from cwd, or sole registered rig)")
 	formulaRunCmd.Flags().BoolVar(&formulaRunDryRun, "dry-run", false, "Preview execution without running")
 	formulaRunCmd.Flags().StringVar(&formulaRunAgent, "agent", "", "Override agent/runtime for all legs (e.g., gemini, codex, claude-haiku)")
 	formulaRunCmd.Flags().StringSliceVar(&formulaRunFiles, "files", nil, "Files to pass to formula legs (available as {{.files}} in templates)")
@@ -232,14 +232,20 @@ func runFormulaRun(cmd *cobra.Command, args []string) error {
 					rigPath = r.Path
 				}
 			}
-			// If we still don't have a target rig but have townRoot, use gastown
+			// Still no rig — auto-select when there is exactly one registered rig,
+			// otherwise surface a helpful error (e.g. Deacon at HQ level on
+			// non-default installs where "gastown" rig does not exist).
 			if targetRig == "" {
-				targetRig = "gastown"
-				rigPath = filepath.Join(townRoot, "gastown")
+				name, path, inferErr := autoInferRig(townRoot)
+				if inferErr != nil {
+					return inferErr
+				}
+				targetRig = name
+				rigPath = path
 			}
 		} else {
-			// No town root found, fall back to gastown without rigPath
-			targetRig = "gastown"
+			// No town root found, cannot determine target rig
+			return fmt.Errorf("cannot determine target rig: not in a Gas Town workspace; use --rig=NAME")
 		}
 	} else {
 		// If rig specified, construct path

--- a/internal/cmd/formula_test.go
+++ b/internal/cmd/formula_test.go
@@ -97,8 +97,8 @@ func TestAutoInferRig(t *testing.T) {
 		if err == nil {
 			t.Fatal("expected error for no rigs, got nil")
 		}
-		if !strings.Contains(err.Error(), "cannot determine target rig") {
-			t.Errorf("expected rig-detection error, got: %v", err)
+		if !strings.Contains(err.Error(), "no rigs registered") {
+			t.Errorf("error should mention no rigs registered, got: %v", err)
 		}
 		if !strings.Contains(err.Error(), "--rig=NAME") {
 			t.Errorf("error should suggest --rig=NAME, got: %v", err)

--- a/internal/cmd/formula_test.go
+++ b/internal/cmd/formula_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -8,6 +9,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/formula"
 )
 
@@ -28,16 +30,19 @@ func TestAutoInferRig(t *testing.T) {
 
 	writeRigsJSON := func(t *testing.T, root string, rigNames []string) {
 		t.Helper()
-		content := `{"version":1,"rigs":{`
-		for i, name := range rigNames {
-			if i > 0 {
-				content += ","
-			}
-			content += `"` + name + `":{}`
+		cfg := &config.RigsConfig{
+			Version: 1,
+			Rigs:    make(map[string]config.RigEntry),
 		}
-		content += `}}`
+		for _, name := range rigNames {
+			cfg.Rigs[name] = config.RigEntry{}
+		}
+		data, err := json.Marshal(cfg)
+		if err != nil {
+			t.Fatalf("marshal rigs.json: %v", err)
+		}
 		path := filepath.Join(root, "mayor", "rigs.json")
-		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		if err := os.WriteFile(path, data, 0o644); err != nil {
 			t.Fatalf("write rigs.json: %v", err)
 		}
 	}
@@ -102,6 +107,25 @@ func TestAutoInferRig(t *testing.T) {
 		}
 		if !strings.Contains(err.Error(), "--rig=NAME") {
 			t.Errorf("error should suggest --rig=NAME, got: %v", err)
+		}
+	})
+
+	t.Run("malformed rigs.json surfaces error", func(t *testing.T) {
+		t.Parallel()
+		root := makeWorkspace(t)
+		path := filepath.Join(root, "mayor", "rigs.json")
+		if err := os.WriteFile(path, []byte("not json"), 0o644); err != nil {
+			t.Fatalf("write rigs.json: %v", err)
+		}
+
+		// discoverRigsForTownRoot silently falls back to an empty config on
+		// parse error, so autoInferRig surfaces the "no rigs registered" path.
+		_, _, err := autoInferRig(root)
+		if err == nil {
+			t.Fatal("expected error for malformed rigs.json, got nil")
+		}
+		if !strings.Contains(err.Error(), "no rigs registered") {
+			t.Errorf("expected no-rigs error (fallback from malformed JSON), got: %v", err)
 		}
 	})
 }

--- a/internal/cmd/formula_test.go
+++ b/internal/cmd/formula_test.go
@@ -1,12 +1,110 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/formula"
 )
+
+// TestAutoInferRig verifies the rig auto-selection logic used when --rig is
+// not provided and cwd-based detection finds nothing (e.g. Deacon at HQ level
+// on a non-default install where "gastown" rig does not exist).
+func TestAutoInferRig(t *testing.T) {
+	t.Parallel()
+
+	makeWorkspace := func(t *testing.T) (root string) {
+		t.Helper()
+		root = t.TempDir()
+		if err := os.MkdirAll(filepath.Join(root, "mayor"), 0o755); err != nil {
+			t.Fatalf("mkdir mayor: %v", err)
+		}
+		return root
+	}
+
+	writeRigsJSON := func(t *testing.T, root string, rigNames []string) {
+		t.Helper()
+		content := `{"version":1,"rigs":{`
+		for i, name := range rigNames {
+			if i > 0 {
+				content += ","
+			}
+			content += `"` + name + `":{}`
+		}
+		content += `}}`
+		path := filepath.Join(root, "mayor", "rigs.json")
+		if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+			t.Fatalf("write rigs.json: %v", err)
+		}
+	}
+
+	t.Run("single rig auto-selects", func(t *testing.T) {
+		t.Parallel()
+		root := makeWorkspace(t)
+		rigDir := filepath.Join(root, "myrig")
+		if err := os.MkdirAll(rigDir, 0o755); err != nil {
+			t.Fatalf("mkdir myrig: %v", err)
+		}
+		writeRigsJSON(t, root, []string{"myrig"})
+
+		name, path, err := autoInferRig(root)
+		if err != nil {
+			t.Fatalf("expected success, got error: %v", err)
+		}
+		if name != "myrig" {
+			t.Errorf("name = %q, want %q", name, "myrig")
+		}
+		if path != rigDir {
+			t.Errorf("path = %q, want %q", path, rigDir)
+		}
+	})
+
+	t.Run("multiple rigs require explicit --rig", func(t *testing.T) {
+		t.Parallel()
+		root := makeWorkspace(t)
+		for _, name := range []string{"rig1", "rig2"} {
+			if err := os.MkdirAll(filepath.Join(root, name), 0o755); err != nil {
+				t.Fatalf("mkdir %s: %v", name, err)
+			}
+		}
+		writeRigsJSON(t, root, []string{"rig1", "rig2"})
+
+		_, _, err := autoInferRig(root)
+		if err == nil {
+			t.Fatal("expected error for multiple rigs, got nil")
+		}
+		if !strings.Contains(err.Error(), "cannot determine target rig") {
+			t.Errorf("expected rig-detection error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "--rig=NAME") {
+			t.Errorf("error should suggest --rig=NAME, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "rig1") || !strings.Contains(err.Error(), "rig2") {
+			t.Errorf("error should list available rigs, got: %v", err)
+		}
+	})
+
+	t.Run("no rigs registered", func(t *testing.T) {
+		t.Parallel()
+		root := makeWorkspace(t)
+		writeRigsJSON(t, root, []string{})
+
+		_, _, err := autoInferRig(root)
+		if err == nil {
+			t.Fatal("expected error for no rigs, got nil")
+		}
+		if !strings.Contains(err.Error(), "cannot determine target rig") {
+			t.Errorf("expected rig-detection error, got: %v", err)
+		}
+		if !strings.Contains(err.Error(), "--rig=NAME") {
+			t.Errorf("error should suggest --rig=NAME, got: %v", err)
+		}
+	})
+}
 
 func TestResolveFormulaLegAgent_Precedence(t *testing.T) {
 	t.Parallel()

--- a/internal/cmd/rig_helpers.go
+++ b/internal/cmd/rig_helpers.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
@@ -158,6 +159,38 @@ func rigBeadsPrefix(townRoot, rigPath, rigName string) string {
 	}
 
 	return ""
+}
+
+// autoInferRig returns the sole registered rig for a given townRoot, or an
+// actionable error when the result is ambiguous. Callers use this when no
+// --rig flag was provided and cwd-based detection found nothing (e.g. Deacon
+// at HQ level on a non-default install where "gastown" rig does not exist).
+func autoInferRig(townRoot string) (name, path string, err error) {
+	rigsConfigPath := filepath.Join(townRoot, "mayor", "rigs.json")
+	rigsConfig, loadErr := config.LoadRigsConfig(rigsConfigPath)
+	if loadErr != nil {
+		rigsConfig = &config.RigsConfig{Rigs: make(map[string]config.RigEntry)}
+	}
+
+	g := git.NewGit(townRoot)
+	rigMgr := rig.NewManager(townRoot, rigsConfig, g)
+	rigs, err := rigMgr.DiscoverRigs()
+	if err != nil {
+		return "", "", fmt.Errorf("cannot determine target rig: %w; use --rig=NAME", err)
+	}
+
+	switch len(rigs) {
+	case 1:
+		return rigs[0].Name, rigs[0].Path, nil
+	case 0:
+		return "", "", fmt.Errorf("cannot determine target rig: not inside a rig directory (and GT_RIG not set); use --rig=NAME")
+	default:
+		names := make([]string, len(rigs))
+		for i, r := range rigs {
+			names[i] = r.Name
+		}
+		return "", "", fmt.Errorf("cannot determine target rig (available: %s); use --rig=NAME", strings.Join(names, ", "))
+	}
 }
 
 // getAllRigs discovers all rigs in the current Gas Town workspace.

--- a/internal/cmd/rig_helpers.go
+++ b/internal/cmd/rig_helpers.go
@@ -161,20 +161,26 @@ func rigBeadsPrefix(townRoot, rigPath, rigName string) string {
 	return ""
 }
 
-// autoInferRig returns the sole registered rig for a given townRoot, or an
-// actionable error when the result is ambiguous. Callers use this when no
-// --rig flag was provided and cwd-based detection found nothing (e.g. Deacon
-// at HQ level on a non-default install where "gastown" rig does not exist).
-func autoInferRig(townRoot string) (name, path string, err error) {
-	rigsConfigPath := filepath.Join(townRoot, "mayor", "rigs.json")
-	rigsConfig, loadErr := config.LoadRigsConfig(rigsConfigPath)
-	if loadErr != nil {
+// discoverRigsForTownRoot loads the rigs config for the given town root and
+// returns all registered rigs. Callers that don't yet have a town root
+// should use getAllRigs, which resolves it from the cwd first.
+func discoverRigsForTownRoot(townRoot string) ([]*rig.Rig, error) {
+	rigsConfig, err := config.LoadRigsConfig(constants.MayorRigsPath(townRoot))
+	if err != nil {
 		rigsConfig = &config.RigsConfig{Rigs: make(map[string]config.RigEntry)}
 	}
 
 	g := git.NewGit(townRoot)
 	rigMgr := rig.NewManager(townRoot, rigsConfig, g)
-	rigs, err := rigMgr.DiscoverRigs()
+	return rigMgr.DiscoverRigs()
+}
+
+// autoInferRig returns the sole registered rig for a given townRoot, or an
+// actionable error when the result is ambiguous. Callers use this when no
+// --rig flag was provided and cwd-based detection found nothing (e.g. Deacon
+// at HQ level on a non-default install where "gastown" rig does not exist).
+func autoInferRig(townRoot string) (name, path string, err error) {
+	rigs, err := discoverRigsForTownRoot(townRoot)
 	if err != nil {
 		return "", "", fmt.Errorf("cannot determine target rig: %w; use --rig=NAME", err)
 	}
@@ -183,7 +189,7 @@ func autoInferRig(townRoot string) (name, path string, err error) {
 	case 1:
 		return rigs[0].Name, rigs[0].Path, nil
 	case 0:
-		return "", "", fmt.Errorf("cannot determine target rig: not inside a rig directory (and GT_RIG not set); use --rig=NAME")
+		return "", "", fmt.Errorf("cannot determine target rig: no rigs registered in this workspace; use --rig=NAME")
 	default:
 		names := make([]string, len(rigs))
 		for i, r := range rigs {
@@ -200,19 +206,5 @@ func getAllRigs() ([]*rig.Rig, error) {
 	if err != nil {
 		return nil, fmt.Errorf("not in a Gas Town workspace: %w", err)
 	}
-
-	rigsConfigPath := filepath.Join(townRoot, "mayor", "rigs.json")
-	rigsConfig, err := config.LoadRigsConfig(rigsConfigPath)
-	if err != nil {
-		rigsConfig = &config.RigsConfig{Rigs: make(map[string]config.RigEntry)}
-	}
-
-	g := git.NewGit(townRoot)
-	rigMgr := rig.NewManager(townRoot, rigsConfig, g)
-	rigs, err := rigMgr.DiscoverRigs()
-	if err != nil {
-		return nil, err
-	}
-
-	return rigs, nil
+	return discoverRigsForTownRoot(townRoot)
 }


### PR DESCRIPTION
## Summary

- Replaces the hardcoded `"gastown"` rig fallback in `gt formula run` with a workspace-aware auto-selection strategy
- Adds `autoInferRig(townRoot)` helper in `rig_helpers.go` that: auto-selects the sole registered rig on single-rig installs; returns a clear error listing available rigs when multiple are present
- Converts the "no town root found" branch from a silent fallback to a clear error
- Updates `--rig` flag description and help text to remove the misleading "default: current or gastown" wording

## Test plan

- [x] `TestAutoInferRig/single_rig_auto-selects` — verifies auto-selection when one rig is registered
- [x] `TestAutoInferRig/multiple_rigs_require_explicit_--rig` — verifies actionable error with rig list when multiple rigs exist
- [x] `TestAutoInferRig/no_rigs_registered` — verifies clear error when no rigs are registered
- [x] `TestAutoInferRig/malformed_rigs.json_surfaces_error` — verifies graceful fallback on parse error
- [x] `go build ./...` passes
- [ ] On a non-default install (`~/my-gastown/`), `gt formula run mol-deacon-patrol` no longer fails with "default rig 'gastown' does not exist"

## Notes

Fixes #3861. Related to #3855 (same install context, different symptom). The `autoInferRig` function lives in `rig_helpers.go` alongside the existing `getAllRigs()` because it already has the `rig`, `git`, and `config` imports needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3872"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->
