### PR TITLE
fix(done): auto-rebase polecat branch onto target before push (gh#3400)

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -640,7 +640,15 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// Branch contamination preflight: check if branch is significantly behind
 		// the effective target branch, which indicates the branch may contain stale merge-base
 		// artifacts that will pollute the PR diff. (GH#2220)
+		//
+		// gh#3400: Refresh remote tracking refs first so contamination check (and
+		// the auto-rebase below) sees the current state of origin. Without this,
+		// the local view of origin/<base> may be stale and we'd skip a rebase that
+		// is actually needed.
 		contaminationBase := doneContaminationBaseRef(defaultBranch, doneTarget)
+		if fetchErr := g.Fetch("origin"); fetchErr != nil {
+			style.PrintWarning("could not fetch origin before contamination check: %v (proceeding with local refs)", fetchErr)
+		}
 		contam, err := g.CheckBranchContamination(contaminationBase)
 		if err == nil && contam.Behind > 0 {
 			const warnThreshold = 50
@@ -652,6 +660,21 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 					contam.Behind, contaminationBase, blockThreshold, contaminationBase)
 			} else if contam.Behind >= warnThreshold {
 				style.PrintWarning("branch is %d commits behind %s — consider rebasing to avoid PR contamination", contam.Behind, contaminationBase)
+			}
+
+			// gh#3400: Auto-rebase the polecat branch onto the latest target before
+			// push, so the resulting MR/PR has a current base.
+			alreadyPushed := checkpoints[CheckpointPushed] == branch
+			rebased, skipReason, rebaseErr := autoRebaseOnTarget(g, contaminationBase, contam.Behind, donePreVerified, alreadyPushed)
+			if rebaseErr != nil {
+				return rebaseErr
+			}
+			if rebased {
+				fmt.Printf("%s Branch rebased onto %s\n", style.Bold.Render("✓"), contaminationBase)
+				// Recompute commits ahead since rebase rewrote history.
+				aheadCount, _ = g.CommitsAhead("origin/"+defaultBranch, "HEAD")
+			} else if skipReason != "" {
+				style.PrintWarning("branch is %d commits behind %s but %s; skipping auto-rebase", contam.Behind, contaminationBase, skipReason)
 			}
 		}
 

--- a/internal/cmd/done_rebase.go
+++ b/internal/cmd/done_rebase.go
@@ -1,0 +1,47 @@
+package cmd
+
+import (
+	"fmt"
+)
+
+// rebaseGit is the subset of *git.Git that autoRebaseOnTarget needs. Defined as
+// an interface so tests can drive the decision logic without standing up a full
+// git repo for every gating case.
+type rebaseGit interface {
+	Rebase(onto string) error
+	AbortRebase() error
+}
+
+// autoRebaseOnTarget rebases the current branch onto base when the branch is
+// behind the target. It is a no-op when there is nothing to rebase, when the
+// polecat ran the formula's pre-verify step (rebasing again would invalidate
+// the gate results that --pre-verified attests to), or when a prior push
+// checkpoint exists (rebasing after pushing would require a force-push).
+//
+// Returns:
+//   - rebased: true if a rebase actually ran successfully.
+//   - skipReason: non-empty when behind > 0 but the rebase was intentionally
+//     skipped. Empty when behind == 0 (no rebase needed) or when rebased == true.
+//   - err: rebase failure, after AbortRebase has been attempted to clean up.
+//
+// gh#3400.
+func autoRebaseOnTarget(g rebaseGit, base string, behind int, preVerified, alreadyPushed bool) (rebased bool, skipReason string, err error) {
+	if behind <= 0 {
+		return false, "", nil
+	}
+	switch {
+	case preVerified:
+		return false, "--pre-verified is set", nil
+	case alreadyPushed:
+		return false, "prior push checkpoint exists", nil
+	}
+
+	fmt.Printf("→ Auto-rebasing onto %s (%d commits behind)\n", base, behind)
+	if rebaseErr := g.Rebase(base); rebaseErr != nil {
+		_ = g.AbortRebase()
+		return false, "", fmt.Errorf("auto-rebase onto %s failed: %w\n"+
+			"Resolve conflicts manually (git fetch origin && git rebase %s), commit the resolution, then rerun gt done.",
+			base, rebaseErr, base)
+	}
+	return true, "", nil
+}

--- a/internal/cmd/done_rebase_test.go
+++ b/internal/cmd/done_rebase_test.go
@@ -1,0 +1,254 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	gitpkg "github.com/steveyegge/gastown/internal/git"
+)
+
+// fakeRebaseGit lets us drive autoRebaseOnTarget without a real git repo for
+// the gating-decision tests.
+type fakeRebaseGit struct {
+	rebaseErr   error
+	rebaseCalls int
+	abortCalls  int
+}
+
+func (f *fakeRebaseGit) Rebase(onto string) error {
+	f.rebaseCalls++
+	return f.rebaseErr
+}
+
+func (f *fakeRebaseGit) AbortRebase() error {
+	f.abortCalls++
+	return nil
+}
+
+// TestAutoRebaseOnTarget_GatingDecisions verifies the skip/rebase decision
+// matrix (gh#3400). The behavior under test is the *decision*, not the actual
+// git mechanics — those are exercised separately below against a real repo.
+func TestAutoRebaseOnTarget_GatingDecisions(t *testing.T) {
+	tests := []struct {
+		name          string
+		behind        int
+		preVerified   bool
+		alreadyPushed bool
+		wantRebased   bool
+		wantSkip      string
+		wantCalls     int
+	}{
+		{
+			name:        "not behind: no-op",
+			behind:      0,
+			wantRebased: false,
+			wantSkip:    "",
+			wantCalls:   0,
+		},
+		{
+			name:        "behind by 1: rebase runs",
+			behind:      1,
+			wantRebased: true,
+			wantSkip:    "",
+			wantCalls:   1,
+		},
+		{
+			name:        "behind by 5: rebase runs",
+			behind:      5,
+			wantRebased: true,
+			wantSkip:    "",
+			wantCalls:   1,
+		},
+		{
+			name:        "pre-verified: skip even when behind",
+			behind:      3,
+			preVerified: true,
+			wantRebased: false,
+			wantSkip:    "--pre-verified is set",
+			wantCalls:   0,
+		},
+		{
+			name:          "already pushed: skip to avoid divergence",
+			behind:        3,
+			alreadyPushed: true,
+			wantRebased:   false,
+			wantSkip:      "prior push checkpoint exists",
+			wantCalls:     0,
+		},
+		{
+			name:          "pre-verified takes precedence over already-pushed",
+			behind:        3,
+			preVerified:   true,
+			alreadyPushed: true,
+			wantRebased:   false,
+			wantSkip:      "--pre-verified is set",
+			wantCalls:     0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			fake := &fakeRebaseGit{}
+			rebased, skipReason, err := autoRebaseOnTarget(fake, "origin/main", tt.behind, tt.preVerified, tt.alreadyPushed)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if rebased != tt.wantRebased {
+				t.Errorf("rebased = %v, want %v", rebased, tt.wantRebased)
+			}
+			if skipReason != tt.wantSkip {
+				t.Errorf("skipReason = %q, want %q", skipReason, tt.wantSkip)
+			}
+			if fake.rebaseCalls != tt.wantCalls {
+				t.Errorf("rebase calls = %d, want %d", fake.rebaseCalls, tt.wantCalls)
+			}
+			if fake.abortCalls != 0 {
+				t.Errorf("abort calls = %d on success path, want 0", fake.abortCalls)
+			}
+		})
+	}
+}
+
+// TestAutoRebaseOnTarget_ConflictAborts verifies that a rebase failure causes
+// AbortRebase to fire and the returned error includes remediation guidance.
+func TestAutoRebaseOnTarget_ConflictAborts(t *testing.T) {
+	fake := &fakeRebaseGit{rebaseErr: errors.New("CONFLICT (content): merge conflict in foo.txt")}
+
+	rebased, skipReason, err := autoRebaseOnTarget(fake, "origin/main", 1, false, false)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if rebased {
+		t.Error("rebased should be false on conflict")
+	}
+	if skipReason != "" {
+		t.Errorf("skipReason should be empty on conflict, got %q", skipReason)
+	}
+	if fake.rebaseCalls != 1 {
+		t.Errorf("expected 1 rebase call, got %d", fake.rebaseCalls)
+	}
+	if fake.abortCalls != 1 {
+		t.Errorf("expected AbortRebase to fire on conflict, got %d calls", fake.abortCalls)
+	}
+	// Remediation guidance is part of the contract — agents read this message.
+	msg := err.Error()
+	if !strings.Contains(msg, "auto-rebase onto origin/main failed") {
+		t.Errorf("error missing context: %q", msg)
+	}
+	if !strings.Contains(msg, "git rebase origin/main") {
+		t.Errorf("error missing remediation hint: %q", msg)
+	}
+	if !strings.Contains(msg, "rerun gt done") {
+		t.Errorf("error missing rerun hint: %q", msg)
+	}
+}
+
+// TestAutoRebaseOnTarget_RealRepoSuccess exercises the rebase against a real
+// git working tree to confirm the wiring (Rebase call) actually replays the
+// branch onto a moved base. (gh#3400, scenario (a) from the bead notes.)
+func TestAutoRebaseOnTarget_RealRepoSuccess(t *testing.T) {
+	tmp := t.TempDir()
+	repo := filepath.Join(tmp, "repo")
+	testRunGit(t, tmp, "init", "--initial-branch", "main", repo)
+	testRunGit(t, repo, "config", "user.email", "test@test.com")
+	testRunGit(t, repo, "config", "user.name", "Test")
+
+	// Initial commit on main.
+	writeRepoFile(t, repo, "README.md", "# initial\n")
+	testRunGit(t, repo, "add", ".")
+	testRunGit(t, repo, "commit", "-m", "initial")
+
+	// Branch off and add a polecat commit on a non-conflicting file.
+	testRunGit(t, repo, "checkout", "-b", "feature")
+	writeRepoFile(t, repo, "feature.txt", "feature work\n")
+	testRunGit(t, repo, "add", ".")
+	testRunGit(t, repo, "commit", "-m", "feature")
+
+	// Move main forward independently — also non-conflicting with feature.
+	testRunGit(t, repo, "checkout", "main")
+	writeRepoFile(t, repo, "main-new.txt", "new on main\n")
+	testRunGit(t, repo, "add", ".")
+	testRunGit(t, repo, "commit", "-m", "advance main")
+
+	testRunGit(t, repo, "checkout", "feature")
+
+	g := gitpkg.NewGit(repo)
+	rebased, skipReason, err := autoRebaseOnTarget(g, "main", 1, false, false)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !rebased {
+		t.Fatalf("expected rebased=true, got false (skip=%q)", skipReason)
+	}
+
+	// After rebase, both files must be present and the feature commit must sit
+	// on top of the advance-main commit.
+	if _, statErr := os.Stat(filepath.Join(repo, "main-new.txt")); statErr != nil {
+		t.Errorf("main-new.txt missing after rebase: %v", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(repo, "feature.txt")); statErr != nil {
+		t.Errorf("feature.txt missing after rebase: %v", statErr)
+	}
+}
+
+// TestAutoRebaseOnTarget_RealRepoConflictAborts exercises the conflict path
+// against a real git working tree: feature and main both touch the same file,
+// rebase fails with a CONFLICT, and AbortRebase must restore the working tree
+// so the polecat can address the conflict manually. (gh#3400, scenario (b).)
+func TestAutoRebaseOnTarget_RealRepoConflictAborts(t *testing.T) {
+	tmp := t.TempDir()
+	repo := filepath.Join(tmp, "repo")
+	testRunGit(t, tmp, "init", "--initial-branch", "main", repo)
+	testRunGit(t, repo, "config", "user.email", "test@test.com")
+	testRunGit(t, repo, "config", "user.name", "Test")
+
+	writeRepoFile(t, repo, "shared.txt", "v0\n")
+	testRunGit(t, repo, "add", ".")
+	testRunGit(t, repo, "commit", "-m", "initial")
+
+	// Feature changes shared.txt to v1.
+	testRunGit(t, repo, "checkout", "-b", "feature")
+	writeRepoFile(t, repo, "shared.txt", "v1-feature\n")
+	testRunGit(t, repo, "add", ".")
+	testRunGit(t, repo, "commit", "-m", "feature edit")
+
+	// Main changes shared.txt to a different value — guaranteed conflict.
+	testRunGit(t, repo, "checkout", "main")
+	writeRepoFile(t, repo, "shared.txt", "v1-main\n")
+	testRunGit(t, repo, "add", ".")
+	testRunGit(t, repo, "commit", "-m", "main edit")
+
+	testRunGit(t, repo, "checkout", "feature")
+
+	g := gitpkg.NewGit(repo)
+	rebased, skipReason, err := autoRebaseOnTarget(g, "main", 1, false, false)
+	if err == nil {
+		t.Fatal("expected conflict error, got nil")
+	}
+	if rebased {
+		t.Error("rebased should be false on conflict")
+	}
+	if skipReason != "" {
+		t.Errorf("skipReason should be empty on conflict, got %q", skipReason)
+	}
+
+	// AbortRebase is required to leave the working tree in a clean state. After
+	// abort, the rebase-merge dir must be gone — otherwise the polecat is stuck
+	// in a half-rebased state.
+	if _, statErr := os.Stat(filepath.Join(repo, ".git", "rebase-merge")); !os.IsNotExist(statErr) {
+		t.Errorf(".git/rebase-merge should not exist after abort (stat err: %v)", statErr)
+	}
+	if _, statErr := os.Stat(filepath.Join(repo, ".git", "rebase-apply")); !os.IsNotExist(statErr) {
+		t.Errorf(".git/rebase-apply should not exist after abort (stat err: %v)", statErr)
+	}
+}
+
+func writeRepoFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}


### PR DESCRIPTION
## Summary

When `gt done` runs, the polecat branch is now fetched + rebased onto the target before push. Closes #3400.

- Fetches `origin` and rebases onto `origin/<base>` whenever `contam.Behind > 0`.
- On rebase conflict, aborts the rebase and returns a remediation message directing the polecat to resolve manually and rerun `gt done`.
- Skips auto-rebase when `--pre-verified` is set (the polecat already rebased + ran gates; a second rebase would silently invalidate that contract) and when a prior push checkpoint matches the current branch (rebase after push would require force-push to converge — out of scope here).

## Classification rationale

**Go bug, fixed in `internal/cmd/done.go` — not policy overlay.**

The canonical contract is already rebase-before-submit: `internal/formula/formulas/mol-polecat-work.formula.toml:421-479` defines a `pre-verify` step that fetches and rebases onto `origin/<base>`. Exit criteria L479: *"Branch rebased onto latest origin/<base>"*.

But enforcement was only opt-in. `internal/cmd/done.go` previously called `CheckBranchContamination` and only blocked at >=200 commits behind, warned at >=50, and was silent under 50 — meaning a branch behind by 1-49 was silently pushed with a stale base. The `--pre-verified` flag was just metadata recording, not enforcement.

The PR-flow contrib-harness overlay (`docs/contrib-harnesses/polecat-pr-flow/`) was the wrong surface: rebase affects all polecat work, not only rigs that opt into PR review.

## Test plan

- [x] `go test ./internal/cmd/ -run TestAutoRebase -v` — five new tests pass:
  - Gating decision matrix (behind=0/1/5, pre-verified, already-pushed, precedence).
  - Conflict path against a fake driver — verifies AbortRebase fires and the error contains the remediation hint.
  - Real-repo success: branch + main both advance on non-conflicting files; after rebase both files exist on the rebased branch.
  - Real-repo conflict abort: same file edited on both sides; rebase fails, AbortRebase fires, `.git/rebase-merge` and `.git/rebase-apply` are cleaned up.
- [x] `go test ./internal/cmd/ -run 'TestDone|TestContamination|TestCheckpoint|TestMRBead|TestConvoy'` — all related done-path tests still pass.
- [x] `go vet ./...` clean.
- [ ] Pre-existing `TestPersistentPreRunLoadsAgentRegistry` failure on this worktree is unrelated (test invokes the `gt` binary, which the macOS binary-signing check rejects when built via `go build` directly; reproduced on baseline before this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3875"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->