### PR TITLE
fix(rig): drop correct orphan Dolt DB on rig init (gh#3562)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Rig init no longer creates duplicate Dolt databases** — `gt rig add` was
+  leaving an orphan database matching the beads prefix (e.g. `ma` for prefix
+  `ma`) alongside the canonical rig database (e.g. `mobile_apps`), because the
+  cleanup code only knew the legacy `beads_<prefix>` naming used by bd < 0.62.
+  Beads written from the rig could land in the orphan while the mayor read
+  from the canonical DB — a silent data split. Cleanup now removes both
+  naming forms and `AddRig` fails loudly if an orphan persists (gh#3562,
+  hq-j6hur.4.2).
+
 ## [1.1.0] - 2026-05-06
 
 ### Added

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -614,9 +614,10 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 			if output, err := cmd.CombinedOutput(); err != nil {
 				fmt.Printf("  Warning: Could not init bd database: %v (%s)\n", err, strings.TrimSpace(string(output)))
 			}
-			// Drop orphaned beads_<prefix> database if it differs from rigName (gt-sv1h).
-			if orphanDB := "beads_" + opts.BeadsPrefix; orphanDB != opts.Name {
-				_ = doltserver.RemoveDatabase(m.townRoot, orphanDB, true)
+			// Drop orphan databases created by bd init (gh#3562, gt-sv1h).
+			// See dropRigOrphanDBs for naming details across bd versions.
+			if err := dropRigOrphanDBs(m.townRoot, opts.BeadsPrefix, opts.Name); err != nil {
+				fmt.Fprintf(os.Stderr, "Warning: orphan database cleanup: %v\n", err)
 			}
 		}
 
@@ -670,10 +671,11 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 		fmt.Printf("  Run 'gt doctor --fix' to repair, or it will self-heal on next daemon start.\n")
 	}
 
-	// Safety-net: drop orphaned beads_<prefix> database if it differs from rigName (gt-sv1h).
-	// InitBeads already does this, but repeat here in case EnsureMetadata path diverges.
-	if orphanDB := "beads_" + opts.BeadsPrefix; orphanDB != opts.Name {
-		_ = doltserver.RemoveDatabase(m.townRoot, orphanDB, true)
+	// Safety-net: drop orphan databases that may have been created by bd init.
+	// InitBeads already does this, but repeat here in case EnsureMetadata path
+	// diverges, and verify post-condition: no orphan should remain (gh#3562).
+	if err := dropRigOrphanDBs(m.townRoot, opts.BeadsPrefix, opts.Name); err != nil {
+		return nil, fmt.Errorf("rig init left a duplicate Dolt database: %w", err)
 	}
 
 	// Set issue_prefix on the correct server-side database.
@@ -1051,14 +1053,62 @@ func warnDeprecatedRigConfigKeys(data []byte, path string) {
 	}
 }
 
+// dropRigOrphanDBs drops orphan Dolt databases that bd init creates as a side
+// effect of `bd init --prefix <prefix>`. The orphan name depends on bd version:
+//
+//	bd >= 0.62: "<prefix>"        (e.g. "ma" for prefix=ma)
+//	bd <  0.62: "beads_<prefix>"  (e.g. "beads_ma")
+//
+// Either form must be removed when it differs from <rigName>, otherwise beads
+// created from the rig can silently land in the orphan DB while the mayor
+// reads from <rigName> — causing the silent data split documented in gh#3562.
+//
+// On entry the orphan is freshly created by bd init and contains only schema
+// tables, so it is safe to force-drop. If the candidate looks like a real rig
+// database (matches rigName, "hq", or doesn't exist at all) it is skipped.
+//
+// Returns an error only if at least one orphan candidate exists on disk and
+// cannot be removed — callers in AddRig treat that as fatal so the user is not
+// left with a silently-split rig.
+func dropRigOrphanDBs(townRoot, prefix, rigName string) error {
+	if prefix == "" || rigName == "" {
+		return nil
+	}
+	candidates := []string{prefix, "beads_" + prefix}
+	var failures []string
+	for _, name := range candidates {
+		if name == rigName || name == "hq" {
+			continue
+		}
+		if !doltserver.DatabaseExists(townRoot, name) {
+			continue
+		}
+		if err := doltserver.RemoveDatabase(townRoot, name, true); err != nil {
+			failures = append(failures, fmt.Sprintf("%s: %v", name, err))
+			continue
+		}
+		// Re-check: RemoveDatabase may report success but leave files behind
+		// in pathological cases (read-only server, partial DROP).
+		if doltserver.DatabaseExists(townRoot, name) {
+			failures = append(failures, fmt.Sprintf("%s: still present after RemoveDatabase", name))
+		}
+	}
+	if len(failures) > 0 {
+		return fmt.Errorf("orphan database(s) for rig %q (prefix %q) could not be removed: %s — run `gt dolt cleanup --force` to resolve",
+			rigName, prefix, strings.Join(failures, "; "))
+	}
+	return nil
+}
+
 // InitBeads initializes the beads database at rig level.
 // The project's .beads/config.yaml determines sync-branch settings.
 // Use `bd doctor --fix` in the project to configure sync-branch if needed.
 // TODO(bd-yaml): beads config should migrate to JSON (see beads issue)
 //
 // rigName is the rig's database name (e.g. "gastown"). When non-empty and
-// different from the default "beads_<prefix>" database that bd init creates,
-// InitBeads drops the orphan database to prevent accumulation (gt-sv1h).
+// different from the database that `bd init --prefix` creates (named "<prefix>"
+// on bd >= 0.62 or "beads_<prefix>" on older bd), InitBeads drops the orphan
+// to prevent the silent data split documented in gh#3562.
 func (m *Manager) InitBeads(rigPath, prefix, rigName string) error {
 	// Validate prefix format to prevent command injection from config files
 	if !isValidBeadsPrefix(prefix) {
@@ -1170,14 +1220,19 @@ func (m *Manager) InitBeads(rigPath, prefix, rigName string) error {
 			}
 		}
 
-		// Drop the orphaned beads_<prefix> database created by bd init (gt-sv1h).
-		// bd init --prefix creates a database named beads_<prefix> on the Dolt server,
-		// but the rig uses <rigName> as its database (set by InitRig + EnsureMetadata).
-		// Without cleanup, orphans accumulate with every polecat spawn.
+		// Drop orphan databases created by bd init (gh#3562, gt-sv1h).
+		// bd init --prefix creates a database whose name depends on the bd version:
+		//   bd >= 0.62: "<prefix>"        (e.g. "ma" for prefix=ma)
+		//   bd <  0.62: "beads_<prefix>"  (e.g. "beads_ma")
+		// The rig uses <rigName> as its canonical database (set by InitRig +
+		// EnsureMetadata). Orphans must be dropped or beads created from the
+		// rig will silently land in the wrong DB and become invisible to the mayor.
 		if rigName != "" {
-			orphanDB := "beads_" + prefix
-			if orphanDB != rigName {
-				_ = doltserver.RemoveDatabase(m.townRoot, orphanDB, true)
+			if err := dropRigOrphanDBs(m.townRoot, prefix, rigName); err != nil {
+				// Non-fatal: AddRig has a post-init verification step that errors
+				// loudly if an orphan persists. Log here so the trail is visible
+				// when rig init is invoked outside AddRig.
+				fmt.Fprintf(os.Stderr, "Warning: orphan database cleanup: %v\n", err)
 			}
 		}
 	}

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -737,6 +737,110 @@ func TestIsValidBeadsPrefix(t *testing.T) {
 	}
 }
 
+// TestDropRigOrphanDBs_RemovesPrefixDB is the regression test for gh#3562.
+//
+// `bd init --prefix <prefix> --server` creates a Dolt database whose name
+// matches the prefix exactly (e.g. "ma" for prefix=ma) on bd >= 0.62. The rig
+// uses <rigName> as its canonical database, so the prefix-named DB is an
+// orphan that must be removed — otherwise beads created from the rig land in
+// the orphan while the mayor reads from <rigName>, silently splitting the data.
+//
+// This test simulates the post-init filesystem state, runs the orphan dropper,
+// and asserts that exactly one rig database remains on disk.
+func TestDropRigOrphanDBs_RemovesPrefixDB(t *testing.T) {
+	// Disable the running-server check so RemoveDatabase falls through to
+	// pure filesystem cleanup. Pointing GT_DOLT_PORT at a definitely-unused
+	// port keeps the test independent of any real Dolt server on the host.
+	t.Setenv("GT_DOLT_PORT", "1") // privileged port, definitely not running dolt
+
+	townRoot := t.TempDir()
+	dataDir := filepath.Join(townRoot, ".dolt-data")
+
+	const rigName = "mobile_apps"
+	const prefix = "ma"
+
+	// Simulate post-init state: rigName DB (correct) and prefix DB (orphan).
+	for _, db := range []string{rigName, prefix} {
+		doltDir := filepath.Join(dataDir, db, ".dolt")
+		if err := os.MkdirAll(doltDir, 0755); err != nil {
+			t.Fatalf("seed %s: %v", db, err)
+		}
+	}
+
+	if err := dropRigOrphanDBs(townRoot, prefix, rigName); err != nil {
+		t.Fatalf("dropRigOrphanDBs: %v", err)
+	}
+
+	// Orphan must be gone.
+	if _, err := os.Stat(filepath.Join(dataDir, prefix)); !os.IsNotExist(err) {
+		t.Errorf("prefix DB %q should have been removed; stat err = %v", prefix, err)
+	}
+
+	// Canonical rig DB must remain.
+	if _, err := os.Stat(filepath.Join(dataDir, rigName, ".dolt")); err != nil {
+		t.Errorf("rig DB %q should be preserved; stat err = %v", rigName, err)
+	}
+}
+
+// TestDropRigOrphanDBs_RemovesLegacyBeadsPrefixDB covers the bd < 0.62
+// naming convention where bd init created "beads_<prefix>" instead of
+// "<prefix>". Both forms must be cleaned up to keep older workspaces
+// functional after upgrade.
+func TestDropRigOrphanDBs_RemovesLegacyBeadsPrefixDB(t *testing.T) {
+	t.Setenv("GT_DOLT_PORT", "1")
+
+	townRoot := t.TempDir()
+	dataDir := filepath.Join(townRoot, ".dolt-data")
+
+	const rigName = "mobile_apps"
+	const prefix = "ma"
+	const legacyOrphan = "beads_ma"
+
+	for _, db := range []string{rigName, legacyOrphan} {
+		if err := os.MkdirAll(filepath.Join(dataDir, db, ".dolt"), 0755); err != nil {
+			t.Fatalf("seed %s: %v", db, err)
+		}
+	}
+
+	if err := dropRigOrphanDBs(townRoot, prefix, rigName); err != nil {
+		t.Fatalf("dropRigOrphanDBs: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dataDir, legacyOrphan)); !os.IsNotExist(err) {
+		t.Errorf("legacy orphan %q should have been removed; stat err = %v", legacyOrphan, err)
+	}
+	if _, err := os.Stat(filepath.Join(dataDir, rigName, ".dolt")); err != nil {
+		t.Errorf("rig DB %q should be preserved; stat err = %v", rigName, err)
+	}
+}
+
+// TestDropRigOrphanDBs_PreservesRigDB is the safety check that the helper
+// never removes a database whose name happens to match the prefix when the
+// rig itself is named after its prefix (e.g. rig "gastown" with prefix "gt"
+// where neither candidate is an orphan).
+func TestDropRigOrphanDBs_PreservesRigDB(t *testing.T) {
+	t.Setenv("GT_DOLT_PORT", "1")
+
+	townRoot := t.TempDir()
+	dataDir := filepath.Join(townRoot, ".dolt-data")
+
+	// Pathological case: rigName == prefix. Nothing should be dropped.
+	const rigName = "gt"
+	const prefix = "gt"
+
+	if err := os.MkdirAll(filepath.Join(dataDir, rigName, ".dolt"), 0755); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if err := dropRigOrphanDBs(townRoot, prefix, rigName); err != nil {
+		t.Fatalf("dropRigOrphanDBs: %v", err)
+	}
+
+	if _, err := os.Stat(filepath.Join(dataDir, rigName, ".dolt")); err != nil {
+		t.Errorf("rig DB %q must be preserved when prefix == rigName; stat err = %v", rigName, err)
+	}
+}
+
 func TestInitBeadsRejectsInvalidPrefix(t *testing.T) {
 	rigPath := t.TempDir()
 	manager := &Manager{}


### PR DESCRIPTION
## Summary

- Closes gh#3562 (rig init can create duplicate Dolt databases)
- `bd init --prefix <X>` creates a database named `<X>` on bd >= 0.62 (and `beads_<X>` on older bd). Our cleanup only removed the legacy form, leaving the prefix-named DB as a permanent orphan alongside the canonical `<rigName>` DB. Beads written from the rig could land in the orphan while the mayor read from `<rigName>` -- silent data split.
- New `dropRigOrphanDBs(townRoot, prefix, rigName)` helper handles both naming forms with a verify-after-remove check. The three orphan-drop call sites in `internal/rig/manager.go` (one in `InitBeads`, two in `AddRig`) now share this helper.
- `AddRig`'s safety-net cleanup is upgraded from silent ignore (`_ = doltserver.RemoveDatabase(...)`) to a fatal error -- the user is never left with a silently-split rig. Error guides them to `gt dolt cleanup --force`.

## Reproduction

`bd 0.62.0 init --prefix tdup --server` reports `Database: tdup` and creates `~/gt/.dolt-data/tdup/`. Without this fix, that orphan persists after rig init. Verified on the dev workspace (`gt dolt status` showed `ga` + `gascity` and `beads_hop` + `hop` co-existing).

## Test plan

- [x] `go test ./internal/rig/...` -- all rig tests pass including 3 new regression tests:
  - `TestDropRigOrphanDBs_RemovesPrefixDB` -- bd >= 0.62 naming
  - `TestDropRigOrphanDBs_RemovesLegacyBeadsPrefixDB` -- bd < 0.62 naming
  - `TestDropRigOrphanDBs_PreservesRigDB` -- `rigName == prefix` passthrough
- [x] `go test ./...` -- only pre-existing macOS unsigned-binary failure in `TestPersistentPreRunLoadsAgentRegistry` (reproduces on `main` without my changes)
- [x] `go vet ./...` -- clean
- [x] `gofmt -l` -- clean
- [ ] Manual: `gt rig add` with mismatched name/prefix on a clean workspace produces exactly one DB

## Constraints honoured

- Backward compat: existing duplicate-DB workspaces are NOT auto-merged. The fix only prevents NEW duplicates from being created and surfaces existing ones via the post-init verification (which now errors loudly).
- v1.1.1 hotfix scope: surgical change confined to `internal/rig/manager.go` + tests + CHANGELOG.

Bead: hq-j6hur.4.2

Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3876"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->