### PR TITLE
fix(dolt-archive): replace mapfile with bash 3.2-compatible read loop

### DIFF
--- a/plugins/dolt-archive/run.sh
+++ b/plugins/dolt-archive/run.sh
@@ -66,7 +66,12 @@ dolt_query_json() {
 
 # Auto-discover production databases or use the explicit list.
 if [[ "$DEFAULT_DBS" == "auto" ]]; then
-  mapfile -t PROD_DBS < <(
+  # `mapfile` would be cleaner here, but it requires bash 4+ and macOS still
+  # ships bash 3.2 by default — fall back to a portable read loop.
+  PROD_DBS=()
+  while IFS= read -r line; do
+    PROD_DBS+=("$line")
+  done < <(
     dolt_query "" "SHOW DATABASES" \
       | grep -v -E '^(information_schema|mysql|dolt_cluster)$' \
       | grep -v -E '^(testdb_|beads_t|beads_pt|doctest_)'


### PR DESCRIPTION
## Summary
- Stock macOS bash is 3.2.57 — `mapfile` requires bash 4.0+, so the auto-discover branch in `plugins/dolt-archive/run.sh` was unrunnable on a default macOS install.
- Swap `mapfile -t PROD_DBS < <(...)` for a portable `while IFS= read -r line; do PROD_DBS+=("$line"); done < <(...)` loop that produces the same array under bash 3.2 and 4+.

## Test plan
- [x] `bash -n plugins/dolt-archive/run.sh` clean under bash 3.2.57
- [x] Standalone behavior check on bash 3.2: read loop populates the array with the expected entries from a piped, grep-filtered source
- [ ] End-to-end run of the plugin against a live Dolt server (needs an environment with the auto-discover path actually exercised)

## Reported via
deacon/dogs/bravo escalation `hq-wisp-x9n`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3879"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->