### PR TITLE
fix: make gt hooks list workspace hooks directly (#1)

### DIFF
--- a/internal/cmd/hooks.go
+++ b/internal/cmd/hooks.go
@@ -4,17 +4,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	hooksCmdVerbose bool
+	hooksCmdJSON    bool
+)
+
 var hooksCmd = &cobra.Command{
 	Use:     "hooks",
 	GroupID: GroupConfig,
-	Short:   "Centralized hook management for Gas Town",
-	Long: `Manage Claude Code hooks across the Gas Town workspace.
+	Short:   "List Claude Code hooks in workspace (or manage hooks via subcommands)",
+	Long: `List all Claude Code hooks across the Gas Town workspace, grouped by type.
 
-Provides centralized hook configuration with a base config and
-per-role/per-rig overrides. Changes are propagated to all workers
-via the sync command.
+Scans .claude/settings.json files in town root, rigs, polecats, crew,
+witness, and refinery. Shows each hook with its owning agent.
 
-Subcommands:
+Flags:
+  --verbose   Show actual hook commands
+  --json      Machine-readable JSON output
+
+Subcommands (for hook management):
   base       Edit the shared base hook config
   override   Edit overrides for a role or rig
   sync       Regenerate all .claude/settings.json files
@@ -31,14 +39,23 @@ Config structure:
 Merge strategy: base → role → rig+role (more specific wins)
 
 Examples:
+  gt hooks                # List all hooks with agent ownership
+  gt hooks --verbose      # Show actual hook commands
+  gt hooks --json         # Machine-readable output
   gt hooks sync           # Regenerate all settings.json files
   gt hooks diff           # Preview what sync would change
   gt hooks base           # Edit the shared base config
   gt hooks override crew  # Edit overrides for all crew workers
   gt hooks list           # Show managed locations and sync status`,
-	RunE: requireSubcommand,
+	RunE: runHooksDefault,
+}
+
+func runHooksDefault(cmd *cobra.Command, args []string) error {
+	return doHooksScan(hooksCmdVerbose, hooksCmdJSON)
 }
 
 func init() {
 	rootCmd.AddCommand(hooksCmd)
+	hooksCmd.Flags().BoolVarP(&hooksCmdVerbose, "verbose", "v", false, "Show hook commands")
+	hooksCmd.Flags().BoolVar(&hooksCmdJSON, "json", false, "Machine-readable JSON output")
 }

--- a/internal/cmd/hooks_scan.go
+++ b/internal/cmd/hooks_scan.go
@@ -61,6 +61,11 @@ type HooksOutput struct {
 }
 
 func runHooksScan(cmd *cobra.Command, args []string) error {
+	return doHooksScan(hooksScanVerbose, hooksScanJSON)
+}
+
+// doHooksScan is the shared implementation for both `gt hooks` and `gt hooks scan`.
+func doHooksScan(verbose, jsonOut bool) error {
 	townRoot, err := workspace.FindFromCwd()
 	if err != nil {
 		return fmt.Errorf("not in a Gas Town workspace: %w", err)
@@ -72,11 +77,11 @@ func runHooksScan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("discovering hooks: %w", err)
 	}
 
-	if hooksScanJSON {
+	if jsonOut {
 		return outputHooksJSON(townRoot, hookInfos)
 	}
 
-	return outputHooksHuman(townRoot, hookInfos)
+	return outputHooksHuman(townRoot, hookInfos, verbose)
 }
 
 // discoverHooks finds all Claude Code hooks in the workspace using hooks.DiscoverTargets.
@@ -158,7 +163,7 @@ func outputHooksJSON(townRoot string, hookInfos []HookInfo) error {
 	return nil
 }
 
-func outputHooksHuman(townRoot string, hookInfos []HookInfo) error {
+func outputHooksHuman(townRoot string, hookInfos []HookInfo, verbose bool) error {
 	if len(hookInfos) == 0 {
 		fmt.Println(style.Dim.Render("No Claude Code hooks found in workspace"))
 		return nil
@@ -211,7 +216,7 @@ func outputHooksHuman(townRoot string, hookInfos []HookInfo) error {
 
 			fmt.Printf("  %s %-25s%s\n", statusIcon, h.Agent, style.Dim.Render(matcherStr))
 
-			if hooksScanVerbose {
+			if verbose {
 				for _, cmd := range h.Commands {
 					fmt.Printf("    %s %s\n", style.Dim.Render("→"), cmd)
 				}

--- a/internal/cmd/hooks_test.go
+++ b/internal/cmd/hooks_test.go
@@ -325,3 +325,45 @@ func TestResolveSettingsTarget(t *testing.T) {
 		})
 	}
 }
+
+func TestHooksCmdHasVerboseAndJSONFlags(t *testing.T) {
+	verboseFlag := hooksCmd.Flags().Lookup("verbose")
+	if verboseFlag == nil {
+		t.Fatal("hooksCmd missing --verbose flag")
+	}
+	if verboseFlag.Shorthand != "v" {
+		t.Errorf("expected --verbose shorthand -v, got %q", verboseFlag.Shorthand)
+	}
+
+	jsonFlag := hooksCmd.Flags().Lookup("json")
+	if jsonFlag == nil {
+		t.Fatal("hooksCmd missing --json flag")
+	}
+}
+
+func TestOutputHooksHumanVerbose(t *testing.T) {
+	hookInfos := []HookInfo{
+		{
+			Type:     "SessionStart",
+			Location: "/test/.claude/settings.json",
+			Agent:    "gastown/polecats",
+			Matcher:  "",
+			Commands: []string{"gt prime"},
+			Status:   "active",
+		},
+	}
+
+	// Verify the function accepts and uses the verbose parameter without error.
+	if err := outputHooksHuman("/test", hookInfos, false); err != nil {
+		t.Errorf("outputHooksHuman(verbose=false) returned error: %v", err)
+	}
+	if err := outputHooksHuman("/test", hookInfos, true); err != nil {
+		t.Errorf("outputHooksHuman(verbose=true) returned error: %v", err)
+	}
+}
+
+func TestOutputHooksHumanEmpty(t *testing.T) {
+	if err := outputHooksHuman("/test", nil, false); err != nil {
+		t.Errorf("outputHooksHuman(empty) returned error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- `gt hooks` now lists all Claude Code hooks in the workspace when invoked without a subcommand (previously required a subcommand and showed an error)
- Adds `--verbose` (`-v`) flag to show the actual hook commands
- Adds `--json` flag for machine-readable output
- Hook output is grouped by type (SessionStart, PreCompact, etc.) with agent ownership shown

## Changes

- `internal/cmd/hooks.go`: Add `hooksCmdVerbose`/`hooksCmdJSON` flags, change `RunE` from `requireSubcommand` to `runHooksDefault` which calls the shared `doHooksScan`
- `internal/cmd/hooks_scan.go`: Extract `doHooksScan(verbose, jsonOut bool)` shared helper; refactor `outputHooksHuman` to take `verbose` as parameter instead of reading the global `hooksScanVerbose`
- `internal/cmd/hooks_test.go`: Add tests for new flags and `outputHooksHuman` verbose parameter

## Testing

- [x] `go build ./...` passes
- [x] Relevant tests pass (`TestHooksCmdHasVerboseAndJSONFlags`, `TestOutputHooksHumanVerbose`, `TestOutputHooksHumanEmpty`, all existing hooks tests)
- [x] `go vet ./...` passes

Closes #1

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3882"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->