### PR TITLE
fix(formula): update shiny description to remove stale 'Engineer in a Box' reference

### DIFF
--- a/internal/formula/formulas/shiny.formula.toml
+++ b/internal/formula/formulas/shiny.formula.toml
@@ -1,4 +1,4 @@
-description = "Engineer in a Box - the canonical right way. Design before you code. Review before you ship. Test before you submit."
+description = "Shiny - the canonical right way. Design before you code. Review before you ship. Test before you submit."
 formula = "shiny"
 type = "workflow"
 version = 1


### PR DESCRIPTION
## Summary

- The `mol-shiny` formula was renamed from `mol-engineer-in-box` but its `description` field still read "Engineer in a Box - the canonical right way."
- Updated the description to "Shiny - the canonical right way." to match the new name.

## Changes

- `internal/formula/formulas/shiny.formula.toml`: updated `description` field.

## Testing

- [x] `go build ./...` passes
- [x] `go test ./internal/formula/...` passes
- [x] `go vet ./internal/formula/...` passes

Closes #3

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3883"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->