### PR TITLE
fix(escalate): pass description via stdin to bd create

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -456,7 +456,15 @@ func resolveBdSubprocessTimeout() time.Duration {
 }
 
 // run executes a bd command and returns stdout.
-func (b *Beads) run(args ...string) (_ []byte, retErr error) {
+func (b *Beads) run(args ...string) ([]byte, error) {
+	return b.runWithStdin(nil, args...)
+}
+
+// runWithStdin executes a bd command, optionally piping stdinData to bd's stdin.
+// When stdinData is nil, behaves identically to run. Use this for flags like
+// --body-file=- that read multi-line content from stdin (avoids embedding
+// newlines in --description, which bd 1.0.3+ rejects).
+func (b *Beads) runWithStdin(stdinData []byte, args ...string) (_ []byte, retErr error) {
 	start := time.Now()
 	// Declare buffers before defer so the closure captures them after cmd.Run.
 	var stdout, stderr bytes.Buffer
@@ -496,6 +504,9 @@ func (b *Beads) run(args ...string) (_ []byte, retErr error) {
 
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
+	if stdinData != nil {
+		cmd.Stdin = bytes.NewReader(stdinData)
+	}
 
 	err := cmd.Run()
 
@@ -518,6 +529,9 @@ func (b *Beads) run(args ...string) (_ []byte, retErr error) {
 		cmd.Env = append(cmd.Env, telemetry.OTELEnvForSubprocess()...)
 		cmd.Stdout = &stdout
 		cmd.Stderr = &stderr
+		if stdinData != nil {
+			cmd.Stdin = bytes.NewReader(stdinData)
+		}
 		err = cmd.Run()
 	}
 

--- a/internal/beads/beads_escalation.go
+++ b/internal/beads/beads_escalation.go
@@ -167,9 +167,13 @@ func (b *Beads) CreateEscalationBead(title string, fields *EscalationFields) (*I
 
 	description := FormatEscalationDescription(title, fields)
 
+	// Pass description via stdin (--body-file=-) instead of --description=...
+	// to avoid embedding newlines in a flag value. bd 1.0.3+ rejects newline-
+	// containing flag values, which broke `gt escalate` for any escalation
+	// with structured YAML metadata in the description.
 	args := []string{"create", "--json",
 		"--title=" + title,
-		"--description=" + description,
+		"--body-file=-",
 		"--type=task",
 		"--ephemeral",
 		"--wisp-type=escalation",
@@ -187,7 +191,7 @@ func (b *Beads) CreateEscalationBead(title string, fields *EscalationFields) (*I
 		args = append(args, "--actor="+actor)
 	}
 
-	out, err := b.run(args...)
+	out, err := b.runWithStdin([]byte(description), args...)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/beads/beads_escalation_test.go
+++ b/internal/beads/beads_escalation_test.go
@@ -1,6 +1,8 @@
 package beads
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -320,5 +322,88 @@ func TestBumpSeverity(t *testing.T) {
 				t.Errorf("bumpSeverity(%q) = %q, want %q", tt.input, got, tt.want)
 			}
 		})
+	}
+}
+
+// TestCreateEscalationBead_PassesDescriptionViaStdin verifies that
+// CreateEscalationBead passes the multi-line description through bd's stdin
+// (--body-file=-) rather than embedding newlines in --description=...
+//
+// Regression test for dc-1bxe: bd 1.0.3+ rejects newlines inside --description
+// flag values, which broke `gt escalate` for any escalation containing the
+// structured YAML metadata block (severity, reason, escalated_by, etc.).
+func TestCreateEscalationBead_PassesDescriptionViaStdin(t *testing.T) {
+	stubDir := t.TempDir()
+	argsPath := filepath.Join(stubDir, "args.txt")
+	stdinPath := filepath.Join(stubDir, "stdin.txt")
+
+	// Stub bd: write each arg on its own line to args.txt, capture stdin to
+	// stdin.txt, and emit a minimal valid issue JSON so unmarshal succeeds.
+	stubScript := `#!/bin/sh
+for a in "$@"; do
+  printf '%s\n' "$a" >> "` + argsPath + `"
+done
+cat > "` + stdinPath + `"
+echo '{"id":"dc-test1","title":"x","status":"open","priority":2,"type":"task","labels":["gt:escalation"]}'
+exit 0
+`
+	stubPath := filepath.Join(stubDir, "bd")
+	if err := os.WriteFile(stubPath, []byte(stubScript), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+	t.Setenv("PATH", stubDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// Reset --allow-stale capability cache so the stub gets probed fresh.
+	ResetBdAllowStaleCacheForTest()
+
+	b := New(t.TempDir())
+	fields := &EscalationFields{
+		Severity:    "high",
+		Reason:      "multi-line\nreason\nwith embedded newlines",
+		EscalatedBy: "test/agent",
+		EscalatedAt: "2026-05-08T15:00:00Z",
+	}
+
+	if _, err := b.CreateEscalationBead("Test escalation", fields); err != nil {
+		t.Fatalf("CreateEscalationBead: %v", err)
+	}
+
+	argsData, err := os.ReadFile(argsPath)
+	if err != nil {
+		t.Fatalf("read stub args: %v", err)
+	}
+	args := string(argsData)
+
+	// Must use --body-file=- to read description from stdin.
+	if !strings.Contains(args, "--body-file=-") {
+		t.Errorf("expected --body-file=- in bd args, got:\n%s", args)
+	}
+	// Must NOT pass --description=... at all (any --description value would
+	// embed the newline-containing structured description and fail bd 1.0.3+).
+	for _, line := range strings.Split(args, "\n") {
+		if strings.HasPrefix(line, "--description=") {
+			t.Errorf("--description=... must not be used (bd rejects newlines), got %q", line)
+		}
+	}
+
+	stdinData, err := os.ReadFile(stdinPath)
+	if err != nil {
+		t.Fatalf("read stub stdin: %v", err)
+	}
+	stdin := string(stdinData)
+	// The structured description must reach bd via stdin.
+	wantInStdin := []string{
+		"Test escalation",
+		"severity: high",
+		"escalated_by: test/agent",
+	}
+	for _, want := range wantInStdin {
+		if !strings.Contains(stdin, want) {
+			t.Errorf("expected stdin to contain %q, got:\n%s", want, stdin)
+		}
+	}
+	// Sanity: stdin must contain newlines (it's the multi-line description).
+	if !strings.Contains(stdin, "\n") {
+		t.Errorf("expected stdin to be multi-line, got %q", stdin)
 	}
 }


### PR DESCRIPTION
## Summary

`gt escalate` is currently broken: every invocation fails because `CreateEscalationBead` builds a multi-line YAML metadata block (severity, reason, escalated_by, …) and passes it through `bd create --description=…`. `bd` 1.0.3+ rejects newline-containing flag values, so it prints help and exits non-zero. Reproducer:

```
$ gt escalate 'Test' -s high -r 'reason'
Error: creating escalation bead: bd create --json --title=Test
  --description=Test\n\nseverity: high\nreason: reason\n... (etc)
  --type=task --ephemeral ...
  Usage: bd create ...
```

This PR switches `CreateEscalationBead` to feed the description through stdin via `bd create --body-file=-`. To support that, `internal/beads/beads.go` adds a `runWithStdin([]byte, ...string)` helper. `run()` is a thin wrapper around it (`runWithStdin(nil, args...)`) so existing callers are unaffected. Stdin is re-attached on the `--flat` retry path so a re-exec doesn't lose the input.

Reported by `batista` (dc-wisp-zcb2, 2026-05-07); tracked downstream as `dc-1bxe` in the whatsapp_automation rig.

## Test plan
- [x] `go test ./internal/beads/...` — passes (10s)
- [x] New regression test `TestCreateEscalationBead_PassesDescriptionViaStdin` — fake bd stub asserts `--body-file=-` is set, `--description=…` is **not** in args, and the multi-line description reaches bd via stdin
- [x] `go test ./...` — only failures are pre-existing on `origin/main` (`internal/tmux/dialog_acceptance_test.go` timing flakes and `TestNudgeSession_*`); none touch beads/escalate
- [x] Confirmed end-to-end: stub bd subprocess receives the structured YAML metadata via stdin and returns valid JSON (real `gt escalate` from `~/gt` no longer fails at flag parsing — the only remaining failure mode is a separate, pre-existing bd auto-import 60s-timeout issue, untouched by this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3890"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->