### PR TITLE
fix(git): preserve cherry-pick-equivalent commits during Rebase()

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/util"
@@ -1256,8 +1257,49 @@ func (g *Git) ListPushRemoteRefsWithHashes(remote, prefix string) ([]RemoteRef, 
 	return g.ListRemoteRefsWithHashes(pushURL, prefix)
 }
 
+// rebaseSupportsNoSilentDrop is true when the local git binary supports
+// --reapply-cherry-picks (introduced in Git 2.34). Probed once at first use.
+var (
+	rebaseCapOnce       sync.Once
+	rebaseCapNoSilentDrop bool
+)
+
+func probeRebaseCapability() bool {
+	out, err := exec.Command("git", "rebase", "--help").CombinedOutput()
+	if err != nil {
+		// If --help fails, assume old git and fall back to safe default.
+		return false
+	}
+	return strings.Contains(string(out), "--reapply-cherry-picks")
+}
+
 // Rebase rebases the current branch onto the given ref.
+//
+// On Git ≥2.34, two flags prevent silent commit loss in the `gt done`
+// auto-rebase path:
+//
+//   --reapply-cherry-picks  Skip the cherry-pick dedup pass that silently
+//                           drops commits whose patch-id already exists upstream.
+//   --empty=keep            Preserve commits that become empty after rebase
+//                           (i.e. the patch was genuinely identical) so they
+//                           surface as visible empty commits, not silent loss.
+//
+// On older Git, these flags are unavailable and the function falls back to a
+// plain rebase. The README documents Git 2.25+ as the minimum.
+//
+// Without these flags on ≥2.34, when a `gt done` rebase encounters a commit
+// whose content already exists on the target (a parallel fix, a backport),
+// git silently removes it. Downstream commits then conflict against the target,
+// and the natural conflict resolution ("take HEAD") erases the author's changes
+// with no warning.
 func (g *Git) Rebase(onto string) error {
+	rebaseCapOnce.Do(func() {
+		rebaseCapNoSilentDrop = probeRebaseCapability()
+	})
+	if rebaseCapNoSilentDrop {
+		_, err := g.run("rebase", "--empty=keep", "--reapply-cherry-picks", onto)
+		return err
+	}
 	_, err := g.run("rebase", onto)
 	return err
 }

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -486,6 +486,118 @@ func TestCheckConflicts_WithConflict(t *testing.T) {
 	}
 }
 
+// TestRebase_PreservesCherryPickEquivalentCommits verifies that Rebase passes
+// --reapply-cherry-picks (on Git ≥2.34) so commits whose patch-id matches an
+// upstream commit are NOT silently dropped. Without the flag, git rebase ≥2.34
+// treats clean cherry-picks as already-applied and removes them as a
+// preliminary step, which silently erases content during `gt done` auto-rebase
+// when parallel work produces content-equivalent commits.
+//
+// Scenario: feature branch has commit A (introduces "fix" content). Main has
+// independently grown commit A' with the same patch content (e.g. a parallel
+// fix from another branch already merged). The `gt done` auto-rebase must
+// preserve A — losing it means the polecat's authored changes are gone even
+// though the file content happens to match upstream.
+func TestRebase_PreservesCherryPickEquivalentCommits(t *testing.T) {
+	dir := initTestRepo(t)
+	g := NewGit(dir)
+	mainBranch, _ := g.CurrentBranch()
+
+	writeFile := func(name, content string) {
+		t.Helper()
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+
+	// On main: commit A with content "fix\n" in a.txt.
+	writeFile("a.txt", "fix\n")
+	if err := g.Add("a.txt"); err != nil {
+		t.Fatalf("Add a.txt: %v", err)
+	}
+	if err := g.Commit("A: original fix"); err != nil {
+		t.Fatalf("Commit A: %v", err)
+	}
+
+	// Branch off into feature and add commit B that depends on A's tree.
+	if err := g.CreateBranch("feature"); err != nil {
+		t.Fatalf("CreateBranch feature: %v", err)
+	}
+	if err := g.Checkout("feature"); err != nil {
+		t.Fatalf("Checkout feature: %v", err)
+	}
+	writeFile("a.txt", "fix\nfix2\n")
+	if err := g.Add("a.txt"); err != nil {
+		t.Fatalf("Add a.txt (feature): %v", err)
+	}
+	if err := g.Commit("B: depends on A"); err != nil {
+		t.Fatalf("Commit B: %v", err)
+	}
+
+	// Rewrite main so A is replaced by A' — same patch content, different SHA —
+	// and add an unrelated commit so the rebase has to actually move feature.
+	if err := g.Checkout(mainBranch); err != nil {
+		t.Fatalf("Checkout main: %v", err)
+	}
+	resetCmd := exec.Command("git", "reset", "--hard", "HEAD~1")
+	resetCmd.Dir = dir
+	if out, err := resetCmd.CombinedOutput(); err != nil {
+		t.Fatalf("reset --hard: %v\n%s", err, out)
+	}
+	writeFile("a.txt", "fix\n")
+	if err := g.Add("a.txt"); err != nil {
+		t.Fatalf("Add a.txt (A'): %v", err)
+	}
+	if err := g.Commit("A-prime: same content, different SHA"); err != nil {
+		t.Fatalf("Commit A': %v", err)
+	}
+	writeFile("b.txt", "extra\n")
+	if err := g.Add("b.txt"); err != nil {
+		t.Fatalf("Add b.txt: %v", err)
+	}
+	if err := g.Commit("main moved on"); err != nil {
+		t.Fatalf("Commit main-moved: %v", err)
+	}
+
+	// Rebase feature onto main. With --reapply-cherry-picks we expect both
+	// A and B to land on top of main; without it, A is dropped silently.
+	if err := g.Checkout("feature"); err != nil {
+		t.Fatalf("Checkout feature (post-main-rewrite): %v", err)
+	}
+	if err := g.Rebase(mainBranch); err != nil {
+		t.Fatalf("Rebase: %v", err)
+	}
+
+	// Count commits feature has on top of main. Without the flag this is 1
+	// (only B); with the flag it must be 2 (A reapplied, then B).
+	logCmd := exec.Command("git", "log", "--oneline", mainBranch+"..HEAD")
+	logCmd.Dir = dir
+	out, err := logCmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git log: %v\n%s", err, out)
+	}
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) != 2 {
+		t.Errorf("expected 2 commits on top of main after rebase, got %d:\n%s",
+			len(lines), out)
+	}
+
+	// Sanity check: the original commit subjects must both be present.
+	wantSubjects := []string{"A: original fix", "B: depends on A"}
+	for _, want := range wantSubjects {
+		found := false
+		for _, line := range lines {
+			if strings.Contains(line, want) {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("commit %q missing after rebase; got:\n%s", want, out)
+		}
+	}
+}
+
 // TestCloneBareHasOriginRefs verifies that after CloneBare, origin/* refs
 // are available for worktree creation. This was broken before the fix:
 // bare clones had refspec configured but no fetch was run, so origin/main


### PR DESCRIPTION
## Summary
The refinery's merge pipeline (`internal/refinery/engineer.go::doMerge`) calls `Git.Rebase(onto)` on every MR before merging. The current implementation runs a bare `git rebase <onto>`, which under modern git (≥2.34, default `rebase.reapplyCherryPicks=false`) **silently drops** any commit whose patch-id matches a commit already on the target branch.

In a merge-queue context this is the wrong default. When a parallel MR has already landed a content-equivalent commit (`A'`), and an in-flight MR contains the original (`A`) plus downstream commits (`B`, `C`) that depend on `A`'s tree, the rebase removes `A` preemptively. `B` and `C` then conflict against main, the operator resolves by taking HEAD — and the MR author's actual changes are silently erased. The merge completes with no warning.

This was caught live in the `whatsapp_automation` rig (2026-05-08): refinery output showed `dropping 17a4fd8e... fix: v3.10 multi-owner lot click expande -- patch contents already upstream`, immediately followed by a conflict on a downstream commit that depended on the dropped commit's tree. Mayor had to bypass the queue manually for the affected MRs.

## Fix
Pass two flags to `git rebase`:

| Flag | Why it's needed |
| --- | --- |
| `--reapply-cherry-picks` | Skip the preliminary cherry-pick deduplication step that drops `A` outright. |
| `--empty=keep` | After `A` is reapplied on top of `A'`, the resulting tree is empty; without `--empty=keep` (default for non-interactive rebase is `drop`) the empty commit is removed and `A` is gone again. |

Both are required — using only one still drops the commit. The combination guarantees `git rebase --empty=keep --reapply-cherry-picks <onto>` produces a branch with the same commit count it started with. Genuine duplicates surface as visible empty commits the operator can resolve deliberately, never as silent loss.

## Test plan
Added `TestRebase_PreservesCherryPickEquivalentCommits` that constructs the exact failure scenario:

1. Initial commit + commit `A` ("fix" → `a.txt`)
2. Branch `feature`, add commit `B` (depends on `A`'s tree)
3. Reset `main` and recreate `A'` (same patch content, different SHA), then add an unrelated commit
4. Rebase `feature` onto `main` and assert both `A` and `B` are preserved

Without the fix the test fails with only `B` reaching HEAD; with the fix both commits land.

- [x] New test passes against the patched `Rebase()`
- [x] Full `go test ./internal/git/` suite passes (21.9s, no regressions)
- [x] `go build ./...` succeeds (no callers of `Rebase` need changes — the contract is strictly "more commits preserved", not "different signature")
- [x] Shell-level repro confirms the same flag combination preserves both commits in a fresh repo

## Related
- Diagnostic bead in the affected rig: `dc-41k3` (whatsapp_automation rig) with full investigation notes, smoking-gun production capture, and reproduction recipe.
- Affected rig conversation thread: `dc-wisp-71pq` (mayor → batista, 2026-05-07) where the bypass workaround is documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3891"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->