### PR TITLE
fix(formula): pass --no-convoy when slinging convoy legs and workflow steps

### DIFF
--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -692,18 +692,7 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 		// Agent precedence (GH#2118): per-leg > CLI --agent > formula-level
 		legAgent := resolveFormulaLegAgent(leg.Agent, formulaRunAgent, f.Agent)
 
-		// Use gt sling with args for leg-specific context
-		slingArgs := []string{
-			"sling", legBeadID, targetRig,
-			"-a", leg.Description,
-			"-s", leg.Title,
-		}
-		if legAgent != "" {
-			slingArgs = append(slingArgs, "--agent", legAgent)
-		}
-		if leg.ReviewOnly || f.ReviewOnly {
-			slingArgs = append(slingArgs, "--review-only")
-		}
+		slingArgs := buildConvoyLegSlingArgs(legBeadID, targetRig, leg.Description, leg.Title, legAgent, leg.ReviewOnly || f.ReviewOnly)
 
 		slingCmd := exec.Command("gt", slingArgs...)
 		slingCmd.Stdout = os.Stdout
@@ -912,14 +901,7 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 		stepTarget := workflowStepTarget(step, targetRig)
 		stepDescription := workflowStepDescription(step, substituteFormulaVars(step.Description, setVars))
 
-		slingArgs := []string{
-			"sling", stepBeadID, stepTarget,
-			"-a", stepDescription,
-			"-s", step.Title,
-		}
-		if stepAgent != "" {
-			slingArgs = append(slingArgs, "--agent", stepAgent)
-		}
+		slingArgs := buildWorkflowStepSlingArgs(stepBeadID, stepTarget, stepDescription, step.Title, stepAgent)
 
 		slingCmd := exec.Command("gt", slingArgs...)
 		slingCmd.Stdout = os.Stdout
@@ -984,6 +966,41 @@ func truncate(s string, maxLen int) string {
 		return s
 	}
 	return s[:maxLen-3] + "..."
+}
+
+// buildConvoyLegSlingArgs constructs the gt-sling argument list for a convoy leg.
+// --no-convoy is always included: legs are tracked by the parent convoy, so per-leg
+// auto-convoy creation is redundant (closes #3856).
+func buildConvoyLegSlingArgs(beadID, targetRig, description, title, agent string, reviewOnly bool) []string {
+	args := []string{
+		"sling", beadID, targetRig,
+		"-a", description,
+		"-s", title,
+		"--no-convoy",
+	}
+	if agent != "" {
+		args = append(args, "--agent", agent)
+	}
+	if reviewOnly {
+		args = append(args, "--review-only")
+	}
+	return args
+}
+
+// buildWorkflowStepSlingArgs constructs the gt-sling argument list for a workflow step.
+// --no-convoy is always included: steps are tracked by the parent workflow bead, so
+// per-step auto-convoy creation is redundant (closes #3856).
+func buildWorkflowStepSlingArgs(beadID, targetRig, description, title, agent string) []string {
+	args := []string{
+		"sling", beadID, targetRig,
+		"-a", description,
+		"-s", title,
+		"--no-convoy",
+	}
+	if agent != "" {
+		args = append(args, "--agent", agent)
+	}
+	return args
 }
 
 // parseSetVars parses --set key=value pairs into a map for template rendering.

--- a/internal/cmd/formula_test.go
+++ b/internal/cmd/formula_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"slices"
 	"strings"
 	"testing"
 
@@ -128,6 +129,65 @@ func TestAutoInferRig(t *testing.T) {
 			t.Errorf("expected no-rigs error (fallback from malformed JSON), got: %v", err)
 		}
 	})
+}
+
+func TestBuildConvoyLegSlingArgs_AlwaysIncludesNoConvoy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name       string
+		agent      string
+		reviewOnly bool
+		wantFlags  []string
+	}{
+		{"no agent no review", "", false, []string{"--no-convoy"}},
+		{"with agent", "claude", false, []string{"--no-convoy", "--agent", "claude"}},
+		{"review only", "", true, []string{"--no-convoy", "--review-only"}},
+		{"agent and review", "gemini", true, []string{"--no-convoy", "--agent", "gemini", "--review-only"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildConvoyLegSlingArgs("bead-1", "myrig", "desc", "title", tt.agent, tt.reviewOnly)
+			for _, want := range tt.wantFlags {
+				if !slices.Contains(got, want) {
+					t.Errorf("buildConvoyLegSlingArgs() missing %q in %v", want, got)
+				}
+			}
+			if got[0] != "sling" {
+				t.Errorf("first arg must be 'sling', got %q", got[0])
+			}
+		})
+	}
+}
+
+func TestBuildWorkflowStepSlingArgs_AlwaysIncludesNoConvoy(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		agent string
+	}{
+		{"no agent", ""},
+		{"with agent", "claude-haiku"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			got := buildWorkflowStepSlingArgs("bead-2", "myrig", "desc", "title", tt.agent)
+			if !slices.Contains(got, "--no-convoy") {
+				t.Errorf("buildWorkflowStepSlingArgs() missing --no-convoy in %v", got)
+			}
+			if got[0] != "sling" {
+				t.Errorf("first arg must be 'sling', got %q", got[0])
+			}
+			if tt.agent != "" && !slices.Contains(got, tt.agent) {
+				t.Errorf("buildWorkflowStepSlingArgs() missing agent %q in %v", tt.agent, got)
+			}
+		})
+	}
 }
 
 func TestResolveFormulaLegAgent_Precedence(t *testing.T) {


### PR DESCRIPTION
## Summary

- `gt formula run` was creating N spurious `hq-cv-*` convoys (one per leg) in addition to the single correct parent convoy
- Root cause: each `gt sling` call auto-creates a tracking convoy unless `--no-convoy` is passed; convoy formula legs are already tracked by the parent convoy
- Fix: extract sling-arg construction into `buildConvoyLegSlingArgs` and `buildWorkflowStepSlingArgs`, both of which include `--no-convoy` to suppress per-leg/per-step auto-convoy creation

## Changes

- `internal/cmd/formula.go`: replace inline sling-arg construction in `executeConvoyFormula` and `executeWorkflowFormula` with helper functions that always include `--no-convoy`
- `internal/cmd/formula_test.go`: add table-driven tests asserting `--no-convoy` is always present in both helpers, across all agent/review-only combinations

## Testing

- [x] `go build ./...` passes
- [x] `TestBuildConvoyLegSlingArgs_AlwaysIncludesNoConvoy` — 4 sub-cases pass
- [x] `TestBuildWorkflowStepSlingArgs_AlwaysIncludesNoConvoy` — 2 sub-cases pass
- [x] `go vet ./...` passes

Closes #3856

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3896"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->