### PR TITLE
fix: bug: gt rig config set writes to ephemeral wisp layer, silently lost on rig reset or Dolt restart

### DIFF
--- a/internal/cmd/rig_config.go
+++ b/internal/cmd/rig_config.go
@@ -195,6 +195,7 @@ func runRigConfigSet(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("setting %s: %w", key, err)
 		}
 		fmt.Printf("%s Set %s=%s in wisp layer for rig %s\n", style.Success.Render("✓"), key, value, rigName)
+		style.PrintWarning("this value is ephemeral and will not survive a rig reset — use --global to persist")
 	}
 
 	return nil

--- a/internal/cmd/rig_config_test.go
+++ b/internal/cmd/rig_config_test.go
@@ -1,0 +1,156 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/wisp"
+)
+
+// setupTestRigForConfig creates a minimal Gas Town workspace for rig config testing.
+// Returns townRoot and rigName.
+func setupTestRigForConfig(t *testing.T) (string, string) {
+	t.Helper()
+
+	townRoot := t.TempDir()
+	rigName := "testrig"
+
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+
+	townConfig := &config.TownConfig{
+		Type:      "town",
+		Version:   config.CurrentTownVersion,
+		Name:      "test-town",
+		CreatedAt: time.Now().Truncate(time.Second),
+	}
+	if err := config.SaveTownConfig(filepath.Join(mayorDir, "town.json"), townConfig); err != nil {
+		t.Fatalf("save town.json: %v", err)
+	}
+
+	rigsConfig := &config.RigsConfig{
+		Version: 1,
+		Rigs: map[string]config.RigEntry{
+			rigName: {
+				GitURL:  "git@github.com:test/testrig.git",
+				AddedAt: time.Now().Truncate(time.Second),
+			},
+		},
+	}
+	if err := config.SaveRigsConfig(filepath.Join(mayorDir, "rigs.json"), rigsConfig); err != nil {
+		t.Fatalf("save rigs.json: %v", err)
+	}
+
+	rigPath := filepath.Join(townRoot, rigName)
+	if err := os.MkdirAll(rigPath, 0755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+
+	rigConfig := config.NewRigConfig(rigName, "git@github.com:test/testrig.git")
+	if err := config.SaveRigConfig(filepath.Join(rigPath, "config.json"), rigConfig); err != nil {
+		t.Fatalf("save rig config: %v", err)
+	}
+
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("chdir to town root: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(oldCwd) })
+
+	return townRoot, rigName
+}
+
+func TestRigConfigSet_WispLayerWarning(t *testing.T) {
+	t.Run("warns about ephemeral when writing to wisp layer", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForConfig(t)
+
+		rigConfigSetGlobal = false
+		rigConfigSetBlock = false
+
+		stderrOut := captureStderr(t, func() {
+			err := runRigConfigSet(rigConfigSetCmd, []string{rigName, "max_polecats", "5"})
+			if err != nil {
+				t.Fatalf("runRigConfigSet: %v", err)
+			}
+		})
+
+		if !strings.Contains(stderrOut, "ephemeral") {
+			t.Errorf("expected ephemeral warning on stderr, got: %q", stderrOut)
+		}
+		if !strings.Contains(stderrOut, "--global") {
+			t.Errorf("expected --global hint on stderr, got: %q", stderrOut)
+		}
+
+		// Verify value was actually stored in wisp layer
+		wispCfg := wisp.NewConfig(townRoot, rigName)
+		val := wispCfg.Get("max_polecats")
+		if val == nil {
+			t.Error("expected max_polecats to be set in wisp layer")
+		}
+	})
+
+	t.Run("warns for string values in wisp layer", func(t *testing.T) {
+		_, rigName := setupTestRigForConfig(t)
+
+		rigConfigSetGlobal = false
+		rigConfigSetBlock = false
+
+		stderrOut := captureStderr(t, func() {
+			err := runRigConfigSet(rigConfigSetCmd, []string{rigName, "default_formula", "mol-custom"})
+			if err != nil {
+				t.Fatalf("runRigConfigSet: %v", err)
+			}
+		})
+
+		if !strings.Contains(stderrOut, "ephemeral") {
+			t.Errorf("expected ephemeral warning on stderr for string value, got: %q", stderrOut)
+		}
+	})
+
+	t.Run("warns for boolean values in wisp layer", func(t *testing.T) {
+		_, rigName := setupTestRigForConfig(t)
+
+		rigConfigSetGlobal = false
+		rigConfigSetBlock = false
+
+		stderrOut := captureStderr(t, func() {
+			err := runRigConfigSet(rigConfigSetCmd, []string{rigName, "auto_restart", "false"})
+			if err != nil {
+				t.Fatalf("runRigConfigSet: %v", err)
+			}
+		})
+
+		if !strings.Contains(stderrOut, "ephemeral") {
+			t.Errorf("expected ephemeral warning on stderr for boolean value, got: %q", stderrOut)
+		}
+	})
+
+	t.Run("no ephemeral warning when using --block flag", func(t *testing.T) {
+		_, rigName := setupTestRigForConfig(t)
+
+		rigConfigSetGlobal = false
+		rigConfigSetBlock = true
+		t.Cleanup(func() { rigConfigSetBlock = false })
+
+		stderrOut := captureStderr(t, func() {
+			err := runRigConfigSet(rigConfigSetCmd, []string{rigName, "auto_restart"})
+			if err != nil {
+				t.Fatalf("runRigConfigSet with --block: %v", err)
+			}
+		})
+
+		// --block also writes to wisp but has different UX semantics; no ephemeral warning expected
+		if strings.Contains(stderrOut, "ephemeral") {
+			t.Errorf("unexpected ephemeral warning for --block operation, got: %q", stderrOut)
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- `gt rig config set` defaults to the wisp layer, which is ephemeral — values are silently lost on rig reset, Dolt restart, or session clear
- Add a stderr warning at set-time: "this value is ephemeral and will not survive a rig reset — use --global to persist"
- The `--block` path intentionally operates on the transient wisp layer and does not warn

## Changes

- `internal/cmd/rig_config.go`: add `style.PrintWarning` after a successful wisp-layer write in `runRigConfigSet`
- `internal/cmd/rig_config_test.go`: new test file verifying the warning appears on stderr for int, string, and bool values; and that `--block` does not trigger the ephemeral warning

## Testing

- [x] `go build ./...` passes
- [x] `TestRigConfigSet_WispLayerWarning` passes (4 sub-tests)
- [x] `go vet ./...` passes

Closes #3865

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3898"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->