### PR TITLE
fix(doctor): add boot as managed hooks target; detect rig-root stale settings

### DIFF
--- a/internal/doctor/claude_settings_check.go
+++ b/internal/doctor/claude_settings_check.go
@@ -521,6 +521,27 @@ func (c *ClaudeSettingsCheck) findSettingsFiles(townRoot string) []staleSettings
 				}
 			}
 		}
+
+		// Check for STALE rig-root settings (<rig>/.claude/settings.json).
+		// Legacy pattern predating the per-role architecture. Superseded by
+		// per-role files (witness/.claude/, polecats/.claude/, etc.).
+		// Skip if tracked in a customer repo — could be intentional.
+		for _, staleFile := range []string{"settings.json", "settings.local.json"} {
+			rigRootSettings := filepath.Join(rigPath, ".claude", staleFile)
+			if fileExists(rigRootSettings) {
+				gs := c.getGitFileStatus(rigRootSettings)
+				if gs != gitStatusTrackedClean && gs != gitStatusTrackedModified {
+					files = append(files, staleSettingsInfo{
+						path:          rigRootSettings,
+						agentType:     "rig-root",
+						rigName:       rigName,
+						wrongLocation: true,
+						gitStatus:     gs,
+						missing:       []string{"legacy rig-root settings (superseded by per-role files)"},
+					})
+				}
+			}
+		}
 	}
 
 	return files
@@ -714,6 +735,13 @@ func (c *ClaudeSettingsCheck) Fix(ctx *CheckContext) error {
 		// settings before the fix does (gt-99u).
 		if sf.wrongLocation {
 			_ = os.Remove(claudeDir) // Best-effort, will fail if not empty
+		}
+
+		// Rig-root settings: just delete. Per-role files are authoritative.
+		// There is no correct "rig-root" settings location to recreate at.
+		if sf.agentType == "rig-root" {
+			fmt.Printf("\n  %s Rig-root settings removed. Per-role settings in %s/{witness,polecats,...}/.claude/ are authoritative.\n", style.Warning.Render("⚠"), sf.rigName)
+			continue
 		}
 
 		// Handle town-root files: redirect to mayor/ instead of recreating at root.

--- a/internal/doctor/claude_settings_check_test.go
+++ b/internal/doctor/claude_settings_check_test.go
@@ -985,6 +985,72 @@ func TestClaudeSettingsCheck_FixPreservesTrackedCleanFiles(t *testing.T) {
 	}
 }
 
+func TestClaudeSettingsCheck_RigRootSettingsFlagged(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+
+	// Create a rig with witness so it's recognised as a rig
+	if err := os.MkdirAll(filepath.Join(tmpDir, rigName, "witness"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a rig-root settings.json (legacy pattern)
+	rigRootSettings := filepath.Join(tmpDir, rigName, ".claude", "settings.json")
+	createValidSettings(t, rigRootSettings)
+
+	check := NewClaudeSettingsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+	if result.Status == StatusOK {
+		t.Fatal("expected non-OK result when rig-root settings.json exists")
+	}
+
+	foundRigRoot := false
+	for _, sf := range check.staleSettings {
+		if sf.agentType == "rig-root" && sf.path == rigRootSettings {
+			foundRigRoot = true
+			if !sf.wrongLocation {
+				t.Error("expected wrongLocation=true for rig-root settings")
+			}
+		}
+	}
+	if !foundRigRoot {
+		t.Errorf("expected rig-root stale entry for %s", rigRootSettings)
+	}
+}
+
+func TestClaudeSettingsCheck_RigRootSettingsFixDeletes(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+
+	// Create a rig with witness so it's recognised as a rig
+	if err := os.MkdirAll(filepath.Join(tmpDir, rigName, "witness"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create rig-root settings.json
+	rigRootSettings := filepath.Join(tmpDir, rigName, ".claude", "settings.json")
+	createValidSettings(t, rigRootSettings)
+
+	check := NewClaudeSettingsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+	if result.Status == StatusOK {
+		t.Fatal("expected non-OK result before fix")
+	}
+
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+
+	// Rig-root settings.json should be deleted
+	if _, err := os.Stat(rigRootSettings); !os.IsNotExist(err) {
+		t.Error("expected rig-root settings.json to be deleted by Fix")
+	}
+}
+
 // NOTE: TestClaudeSettingsCheck_DetectsStaleCLAUDEmdAtTownRoot and
 // TestClaudeSettingsCheck_FixMovesCLAUDEmdToMayor were removed because
 // CLAUDE.md at town root is now intentionally created by gt install.

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -418,6 +418,19 @@ func DiscoverTargets(townRoot string) ([]Target, error) {
 		Role: "deacon",
 	})
 
+	// Boot watchdog — ephemeral Claude agent in deacon/dogs/boot/.
+	// Only added when the directory exists (gitignored and optional).
+	// Adding it here ensures HooksSyncCheck manages the file and Fix() preserves
+	// custom fields (e.g. model) via the LoadSettings → MarshalSettings round-trip.
+	bootDir := filepath.Join(townRoot, "deacon", "dogs", "boot")
+	if info, err := os.Stat(bootDir); err == nil && info.IsDir() {
+		targets = append(targets, Target{
+			Path: filepath.Join(bootDir, ".claude", "settings.json"),
+			Key:  "boot",
+			Role: "boot",
+		})
+	}
+
 	// Scan rigs
 	entries, err := os.ReadDir(townRoot)
 	if err != nil {

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -913,6 +913,54 @@ func TestDiscoverTargets_ReturnsOnlyClaude(t *testing.T) {
 	}
 }
 
+func TestDiscoverTargets_BootIncluded(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	os.MkdirAll(filepath.Join(tmpDir, "mayor"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "deacon", "dogs", "boot"), 0755)
+
+	targets, err := DiscoverTargets(tmpDir)
+	if err != nil {
+		t.Fatalf("DiscoverTargets failed: %v", err)
+	}
+
+	found := false
+	for _, tgt := range targets {
+		if tgt.Key == "boot" {
+			found = true
+			wantPath := filepath.Join(tmpDir, "deacon", "dogs", "boot", ".claude", "settings.json")
+			if tgt.Path != wantPath {
+				t.Errorf("boot target Path = %q, want %q", tgt.Path, wantPath)
+			}
+			if tgt.Role != "boot" {
+				t.Errorf("boot target Role = %q, want %q", tgt.Role, "boot")
+			}
+		}
+	}
+	if !found {
+		t.Error("expected boot target when deacon/dogs/boot/ exists, not found")
+	}
+}
+
+func TestDiscoverTargets_BootAbsent(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	os.MkdirAll(filepath.Join(tmpDir, "mayor"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "deacon"), 0755)
+	// No deacon/dogs/boot directory
+
+	targets, err := DiscoverTargets(tmpDir)
+	if err != nil {
+		t.Fatalf("DiscoverTargets failed: %v", err)
+	}
+
+	for _, tgt := range targets {
+		if tgt.Key == "boot" {
+			t.Errorf("expected no boot target when deacon/dogs/boot/ absent, got one: %+v", tgt)
+		}
+	}
+}
+
 func TestDiscoverRoleLocations(t *testing.T) {
 	tmpDir := t.TempDir()
 


### PR DESCRIPTION
## Summary

- Add `deacon/dogs/boot` to `DiscoverTargets()` so `HooksSyncCheck` manages the boot watchdog's settings file. The `LoadSettings`→`MarshalSettings` round-trip in `Fix()` preserves custom fields (e.g. `model`) via `Extra`, preventing silent reversion after hooks sync.
- Add rig-root settings detection in `ClaudeSettingsCheck`: flags `<rig>/.claude/settings.{json,local.json}` as stale wrong-location files (legacy pre-per-role-architecture pattern). Tracked files are skipped.
- `Fix()` for `rig-root` type deletes the file only — no recreate since per-role files are authoritative.

## Changes

- `internal/hooks/config.go`: add boot target to `DiscoverTargets()` (conditional on dir existence)
- `internal/doctor/claude_settings_check.go`: add rig-root detection in `findSettingsFiles()`; add `rig-root` branch in `Fix()` to delete without recreating
- `internal/hooks/config_test.go`: `TestDiscoverTargets_BootIncluded`, `TestDiscoverTargets_BootAbsent`
- `internal/doctor/claude_settings_check_test.go`: `TestClaudeSettingsCheck_RigRootSettingsFlagged`, `TestClaudeSettingsCheck_RigRootSettingsFixDeletes`

## Testing

- [x] `go build ./...` passes
- [x] `go test ./internal/hooks/... ./internal/doctor/...` passes
- [x] `go vet ./...` passes

Closes #3852

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3907"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->