### PR TITLE
fix: gt formula run emits gt-rig-* routing warnings on installs without gastown rig registered

### DIFF
--- a/internal/cmd/compact.go
+++ b/internal/cmd/compact.go
@@ -129,10 +129,17 @@ func loadTTLConfigWithRole(townRoot, rigName string) map[string]time.Duration {
 // applyRigBeadTTLOverrides reads wisp_ttl_* labels from the rig identity bead
 // and applies them as overrides.
 func applyRigBeadTTLOverrides(ttls map[string]time.Duration, townRoot, rigName string) {
+	prefix := beads.GetPrefixForRig(townRoot, rigName)
+	// Skip bead lookup if prefix has no registered route — avoids routing
+	// warnings on installs where the gastown rig is not registered.
+	if beads.GetRigPathForPrefix(townRoot, prefix+"-") == "" {
+		return
+	}
+
 	beadsDir := beads.ResolveBeadsDir(townRoot)
 	bd := beads.NewWithBeadsDir(townRoot, beadsDir)
 
-	rigBeadID := beads.RigBeadIDWithPrefix("gt", rigName)
+	rigBeadID := beads.RigBeadIDWithPrefix(prefix, rigName)
 	issue, err := bd.Show(rigBeadID)
 	if err != nil {
 		return

--- a/internal/cmd/compact_test.go
+++ b/internal/cmd/compact_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -264,5 +266,39 @@ func TestLoadTTLConfigWithRoleSkipsInvalidPaths(t *testing.T) {
 	}
 	if ttls["error"] != defaultTTLs["error"] {
 		t.Errorf("error TTL = %v, want %v", ttls["error"], defaultTTLs["error"])
+	}
+}
+
+// TestApplyRigBeadTTLOverrides_NoRouteForPrefix verifies that the function
+// returns early without emitting routing warnings when the rig's beads prefix
+// has no entry in routes.jsonl. This is the regression test for the compact
+// fix in https://github.com/gastownhall/gastown/issues/3855.
+func TestApplyRigBeadTTLOverrides_NoRouteForPrefix(t *testing.T) {
+	townRoot := t.TempDir()
+
+	// Write routes.jsonl with entries for other prefixes but NOT "gt-".
+	// This simulates an install where the gastown infrastructure rig is absent.
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	routes := `{"prefix":"hq-","path":"."}` + "\n"
+	if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), []byte(routes), 0o644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	// Populate ttls with defaults; applyRigBeadTTLOverrides must leave them unchanged.
+	ttls := make(map[string]time.Duration)
+	for k, v := range defaultTTLs {
+		ttls[k] = v
+	}
+
+	// Must not panic and must not modify ttls.
+	applyRigBeadTTLOverrides(ttls, townRoot, "myrig")
+
+	for k, want := range defaultTTLs {
+		if ttls[k] != want {
+			t.Errorf("TTLs[%q] = %v, want %v (should be unchanged)", k, ttls[k], want)
+		}
 	}
 }

--- a/internal/cmd/rig_helpers.go
+++ b/internal/cmd/rig_helpers.go
@@ -125,6 +125,14 @@ func IsRigParkedOrDocked(townRoot, rigName string) (bool, string) {
 		beadsPath = rigPath
 	}
 
+	// Skip bead lookup if prefix has no registered route. On installs where the
+	// gastown infrastructure rig is not registered at the expected path, the
+	// "gt-" prefix has no route entry, and Show() would emit a routing warning
+	// once per convoy leg. The wisp check above already covers parked state.
+	if beads.GetRigPathForPrefix(townRoot, prefix+"-") == "" {
+		return false, ""
+	}
+
 	bd := beads.New(beadsPath)
 	rigBeadID := beads.RigBeadIDWithPrefix(prefix, rigName)
 	rigBead, err := bd.Show(rigBeadID)

--- a/internal/cmd/rig_helpers_route_test.go
+++ b/internal/cmd/rig_helpers_route_test.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/config"
+)
+
+// TestIsRigParkedOrDocked_NoRouteForPrefix verifies that IsRigParkedOrDocked
+// returns (false, "") without emitting routing warnings when the rig's beads
+// prefix has no entry in routes.jsonl. This is the regression test for
+// https://github.com/gastownhall/gastown/issues/3855.
+func TestIsRigParkedOrDocked_NoRouteForPrefix(t *testing.T) {
+	townRoot := t.TempDir()
+	rigName := "myproject"
+
+	// Set up rig directory with config.json using the default "gt" prefix.
+	// This simulates a project rig at a non-standard install where the gastown
+	// infrastructure rig (which owns the "gt-" prefix route) is not registered.
+	rigPath := filepath.Join(townRoot, rigName)
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig path: %v", err)
+	}
+	rigCfg := &config.RigConfig{
+		Type:    "rig",
+		Version: config.CurrentRigConfigVersion,
+		Name:    rigName,
+		GitURL:  "git@github.com:example/myproject.git",
+		Beads:   &config.BeadsConfig{Prefix: "gt"},
+	}
+	if err := config.SaveRigConfig(filepath.Join(rigPath, "config.json"), rigCfg); err != nil {
+		t.Fatalf("save rig config: %v", err)
+	}
+
+	// Create .beads directory without any routes.jsonl — gastown infra rig
+	// is not registered at this install (the scenario from issue #3855).
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	blocked, reason := IsRigParkedOrDocked(townRoot, rigName)
+	if blocked {
+		t.Errorf("IsRigParkedOrDocked = (%v, %q), want (false, \"\")", blocked, reason)
+	}
+	if reason != "" {
+		t.Errorf("IsRigParkedOrDocked returned unexpected reason %q, want \"\"", reason)
+	}
+}
+
+// TestIsRigParkedOrDocked_WithRoute_ProceedsToBead verifies that when a route
+// IS registered for the rig's prefix, the bead lookup proceeds normally. The
+// route guard must not prevent the docked/parked check when routing is valid.
+func TestIsRigParkedOrDocked_WithRoute_ProceedsToBead(t *testing.T) {
+	townRoot := t.TempDir()
+	rigName := "myproject"
+
+	rigPath := filepath.Join(townRoot, rigName)
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig path: %v", err)
+	}
+	rigCfg := &config.RigConfig{
+		Type:    "rig",
+		Version: config.CurrentRigConfigVersion,
+		Name:    rigName,
+		GitURL:  "git@github.com:example/myproject.git",
+		Beads:   &config.BeadsConfig{Prefix: "gt"},
+	}
+	if err := config.SaveRigConfig(filepath.Join(rigPath, "config.json"), rigCfg); err != nil {
+		t.Fatalf("save rig config: %v", err)
+	}
+
+	// Register a "gt-" route pointing at the rig directory (no real bead DB needed;
+	// bd.Show will fail gracefully and return (false, "")).
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	routes := `{"prefix":"gt-","path":"myproject"}` + "\n"
+	if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), []byte(routes), 0o644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	// With a valid route the code proceeds to bd.Show, which will fail (no Dolt
+	// running in tests) and return (false, "") — same observable result, but the
+	// code path past the route guard is exercised.
+	blocked, reason := IsRigParkedOrDocked(townRoot, rigName)
+	if blocked {
+		t.Errorf("IsRigParkedOrDocked = (%v, %q), want (false, \"\")", blocked, reason)
+	}
+	if reason != "" {
+		t.Errorf("IsRigParkedOrDocked returned unexpected reason %q, want \"\"", reason)
+	}
+}


### PR DESCRIPTION
## Summary

- Suppresses spurious routing warnings emitted once per convoy leg during `gt formula run` on installs where the gastown infrastructure rig is not registered at the expected path
- `IsRigParkedOrDocked` now checks whether the rig's beads prefix has a registered route before attempting `bd.Show()`; returns early if no route found
- `applyRigBeadTTLOverrides` now uses `GetPrefixForRig` (rig's actual prefix) instead of the hardcoded `"gt"`, and applies the same route guard

## Changes

- `internal/cmd/rig_helpers.go`: Added route existence check in `IsRigParkedOrDocked` before calling `bd.Show()` — avoids `ResolveRoutingTarget` warning when prefix has no route
- `internal/cmd/compact.go`: Replaced hardcoded `"gt"` prefix with `beads.GetPrefixForRig`, added route guard to `applyRigBeadTTLOverrides`
- `internal/cmd/rig_helpers_route_test.go`: New regression tests for route guard in `IsRigParkedOrDocked`
- `internal/cmd/compact_test.go`: Regression test for `applyRigBeadTTLOverrides` with missing route

## Testing

- [x] `go build ./...` passes
- [x] New regression tests pass (`TestIsRigParkedOrDocked_NoRouteForPrefix`, `TestIsRigParkedOrDocked_WithRoute_ProceedsToBead`, `TestApplyRigBeadTTLOverrides_NoRouteForPrefix`)
- [x] `go vet ./...` passes

Closes #3855

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3908"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->