### PR TITLE
fix: Witness sends repeated template mail with unsubstituted placeholders (gt-abc)

### DIFF
--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -587,7 +587,13 @@ func TestWrapRefineryHandlers_InvalidPayload(t *testing.T) {
 
 func TestDefaultWitnessHandler(t *testing.T) {
 	tmpDir := t.TempDir()
+	// Prevent detectTownRoot from finding the real town via GT_TOWN_ROOT/GT_ROOT.
+	// Without this, NewRouter falls back to the production beads and delivers
+	// synthetic protocol messages to the live mail system during test runs.
+	t.Setenv("GT_TOWN_ROOT", tmpDir)
+	t.Setenv("GT_ROOT", tmpDir)
 	handler := NewWitnessHandler("gastown", tmpDir)
+	handler.Router = mail.NewRouterWithTownRoot(tmpDir, "")
 
 	// Capture output
 	var buf bytes.Buffer


### PR DESCRIPTION
## Summary

- `TestDefaultWitnessHandler` creates a `DefaultWitnessHandler` with a real `mail.Router`
- When `GT_TOWN_ROOT` or `GT_ROOT` env vars are set (normal in any Gas Town polecat session), `detectTownRoot()` falls back to the real town root
- `HandleMerged`, `HandleMergeFailed`, and `HandleReworkRequest` each call `notifyPolecatMerged/Failed/Rebase` which delivers the synthetic test messages (branch=`polecat/nux/gt-abc`, issue=`gt-abc`, commit=`abc123`) into the live mail system
- The "two waves" in the bug report correspond to two test runs

## Changes

- `internal/protocol/protocol_test.go`: Apply the same isolation guard already present in `TestDefaultRefineryHandler_NotifyMergeOutcome_*` — set `GT_TOWN_ROOT`/`GT_ROOT` to `tmpDir` and override `handler.Router` with `mail.NewRouterWithTownRoot(tmpDir, "")` so mail delivery stays in the isolated temp directory

## Testing

- [x] `go build ./...` passes
- [x] `TestDefaultWitnessHandler` passes
- [x] `./internal/protocol/...` full suite passes
- [x] `go vet ./...` passes

Closes #3881

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3916"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->