### PR TITLE
fix(mq): verify branch on origin before registering MR

### DIFF
--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -232,10 +232,11 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// GH#3032: Resolve HEAD commit SHA for MR dedup.
-	commitSHA, shaErr := g.Rev("HEAD")
+	// GH#3032/wa-skj: resolve the submitted branch tip for MR dedup and
+	// verification. With --branch this can differ from the checked-out HEAD.
+	commitSHA, shaErr := resolveMQSubmitCommitSHA(g, branch)
 	if shaErr != nil {
-		style.PrintWarning("could not resolve HEAD SHA: %v (falling back to branch-only dedup)", shaErr)
+		style.PrintWarning("could not resolve submitted branch SHA: %v (falling back to branch-only dedup)", shaErr)
 	}
 
 	// Build MR bead title and description
@@ -378,6 +379,10 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func resolveMQSubmitCommitSHA(g *git.Git, branch string) (string, error) {
+	return g.Rev(fmt.Sprintf("refs/heads/%s^{commit}", branch))
 }
 
 // checkMoleculeStepDeps verifies that all prerequisite molecule steps are closed

--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -266,6 +266,30 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 		mrIssue = existingMR
 		fmt.Printf("%s MR already exists (idempotent)\n", style.Bold.Render("✓"))
 	} else {
+		// wa-skj: verify the branch (and exact commit, when known) is actually
+		// on origin before registering the MR. Without this gate, mq submit
+		// happily creates the MR + nudges refinery while the crew's git push
+		// may still be in flight, may have silently failed, or may never have
+		// run. Refinery's branch existence check is a local-bare-repo lookup,
+		// not a remote ls-remote, so its bare repo must have already fetched
+		// the branch — racing the crew's push. Result before this fix:
+		// refinery rejects ~90s later and mayor cherry-picks manually.
+		// Failing fast here gives the crew an actionable "push first" message
+		// instead of a delayed refinery rejection escalation.
+		if commitSHA != "" {
+			if err := g.VerifyPushedCommit("origin", branch, commitSHA); err != nil {
+				return fmt.Errorf("%w\n\nHint: run 'git push origin %s' first (or 'gt done'), then re-run 'gt mq submit'", err, branch)
+			}
+		} else {
+			exists, err := g.PushRemoteBranchExists("origin", branch)
+			if err != nil {
+				return fmt.Errorf("verify branch on origin: %w\n\nHint: run 'git push origin %s' first, then re-run 'gt mq submit'", err, branch)
+			}
+			if !exists {
+				return fmt.Errorf("branch %q not found on origin\n\nHint: run 'git push origin %s' first, then re-run 'gt mq submit'", branch, branch)
+			}
+		}
+
 		// Create MR bead (ephemeral wisp - will be cleaned up after merge)
 		mrIssue, err = bd.Create(beads.CreateOptions{
 			Title:       title,

--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -250,6 +250,13 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 		description += fmt.Sprintf("\nworker: %s", worker)
 	}
 
+	// Verify before either an idempotent success or a new MR registration.
+	// Refinery's later branch check is local-ref based, so missing/stale pushes
+	// must fail here instead of producing a delayed refinery rejection.
+	if err := verifyMQSubmitPushedBranch(g, branch, commitSHA); err != nil {
+		return err
+	}
+
 	// Check if MR bead already exists for this branch+SHA (idempotency)
 	var mrIssue *beads.Issue
 	var existingMR *beads.Issue
@@ -267,30 +274,6 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 		mrIssue = existingMR
 		fmt.Printf("%s MR already exists (idempotent)\n", style.Bold.Render("✓"))
 	} else {
-		// wa-skj: verify the branch (and exact commit, when known) is actually
-		// on origin before registering the MR. Without this gate, mq submit
-		// happily creates the MR + nudges refinery while the crew's git push
-		// may still be in flight, may have silently failed, or may never have
-		// run. Refinery's branch existence check is a local-bare-repo lookup,
-		// not a remote ls-remote, so its bare repo must have already fetched
-		// the branch — racing the crew's push. Result before this fix:
-		// refinery rejects ~90s later and mayor cherry-picks manually.
-		// Failing fast here gives the crew an actionable "push first" message
-		// instead of a delayed refinery rejection escalation.
-		if commitSHA != "" {
-			if err := g.VerifyPushedCommit("origin", branch, commitSHA); err != nil {
-				return fmt.Errorf("%w\n\nHint: run 'git push origin %s' first (or 'gt done'), then re-run 'gt mq submit'", err, branch)
-			}
-		} else {
-			exists, err := g.PushRemoteBranchExists("origin", branch)
-			if err != nil {
-				return fmt.Errorf("verify branch on origin: %w\n\nHint: run 'git push origin %s' first, then re-run 'gt mq submit'", err, branch)
-			}
-			if !exists {
-				return fmt.Errorf("branch %q not found on origin\n\nHint: run 'git push origin %s' first, then re-run 'gt mq submit'", branch, branch)
-			}
-		}
-
 		// Create MR bead (ephemeral wisp - will be cleaned up after merge)
 		mrIssue, err = bd.Create(beads.CreateOptions{
 			Title:       title,
@@ -383,6 +366,24 @@ func runMqSubmit(cmd *cobra.Command, args []string) error {
 
 func resolveMQSubmitCommitSHA(g *git.Git, branch string) (string, error) {
 	return g.Rev(fmt.Sprintf("refs/heads/%s^{commit}", branch))
+}
+
+func verifyMQSubmitPushedBranch(g *git.Git, branch, commitSHA string) error {
+	if commitSHA != "" {
+		if err := g.VerifyPushedCommit("origin", branch, commitSHA); err != nil {
+			return fmt.Errorf("%w\n\nHint: run 'git push origin %s' first (or 'gt done'), then re-run 'gt mq submit'", err, branch)
+		}
+		return nil
+	}
+
+	exists, err := g.PushRemoteBranchExists("origin", branch)
+	if err != nil {
+		return fmt.Errorf("verify branch on origin: %w\n\nHint: run 'git push origin %s' first (or 'gt done'), then re-run 'gt mq submit'", err, branch)
+	}
+	if !exists {
+		return fmt.Errorf("branch %q not found on origin\n\nHint: run 'git push origin %s' first (or 'gt done'), then re-run 'gt mq submit'", branch, branch)
+	}
+	return nil
 }
 
 // checkMoleculeStepDeps verifies that all prerequisite molecule steps are closed

--- a/internal/cmd/mq_submit_test.go
+++ b/internal/cmd/mq_submit_test.go
@@ -1,11 +1,65 @@
 package cmd
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	gitpkg "github.com/steveyegge/gastown/internal/git"
 )
+
+func TestResolveMQSubmitCommitSHAUsesSubmittedBranch(t *testing.T) {
+	repo := t.TempDir()
+	runGitForMQSubmitTest(t, repo, "init")
+	runGitForMQSubmitTest(t, repo, "config", "user.email", "test@example.com")
+	runGitForMQSubmitTest(t, repo, "config", "user.name", "Test User")
+
+	writeMQSubmitTestFile(t, repo, "file.txt", "main\n")
+	runGitForMQSubmitTest(t, repo, "add", "file.txt")
+	runGitForMQSubmitTest(t, repo, "commit", "-m", "main")
+	runGitForMQSubmitTest(t, repo, "branch", "-M", "main")
+	mainSHA := runGitForMQSubmitTest(t, repo, "rev-parse", "HEAD")
+
+	runGitForMQSubmitTest(t, repo, "checkout", "-b", "feature/pr-target")
+	writeMQSubmitTestFile(t, repo, "file.txt", "feature\n")
+	runGitForMQSubmitTest(t, repo, "commit", "-am", "feature")
+	featureSHA := runGitForMQSubmitTest(t, repo, "rev-parse", "HEAD")
+	runGitForMQSubmitTest(t, repo, "tag", "feature/pr-target", mainSHA)
+
+	runGitForMQSubmitTest(t, repo, "checkout", "main")
+	g := gitpkg.NewGit(repo)
+	got, err := resolveMQSubmitCommitSHA(g, "feature/pr-target")
+	if err != nil {
+		t.Fatalf("resolveMQSubmitCommitSHA: %v", err)
+	}
+	if got != featureSHA {
+		t.Fatalf("resolveMQSubmitCommitSHA() = %s, want submitted branch tip %s", got, featureSHA)
+	}
+	if got == mainSHA {
+		t.Fatalf("resolveMQSubmitCommitSHA() used HEAD %s instead of submitted branch tip", mainSHA)
+	}
+}
+
+func runGitForMQSubmitTest(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %s: %v\n%s", strings.Join(args, " "), err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+func writeMQSubmitTestFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
 
 func TestValidateMoleculePrereqs(t *testing.T) {
 	tests := []struct {

--- a/internal/cmd/mq_submit_test.go
+++ b/internal/cmd/mq_submit_test.go
@@ -43,6 +43,44 @@ func TestResolveMQSubmitCommitSHAUsesSubmittedBranch(t *testing.T) {
 	}
 }
 
+func TestVerifyMQSubmitPushedBranchRequiresRemoteBranch(t *testing.T) {
+	repo := t.TempDir()
+	remote := t.TempDir()
+	runGitForMQSubmitTest(t, remote, "init", "--bare")
+
+	runGitForMQSubmitTest(t, repo, "init")
+	runGitForMQSubmitTest(t, repo, "config", "user.email", "test@example.com")
+	runGitForMQSubmitTest(t, repo, "config", "user.name", "Test User")
+	runGitForMQSubmitTest(t, repo, "remote", "add", "origin", remote)
+
+	writeMQSubmitTestFile(t, repo, "file.txt", "main\n")
+	runGitForMQSubmitTest(t, repo, "add", "file.txt")
+	runGitForMQSubmitTest(t, repo, "commit", "-m", "main")
+	runGitForMQSubmitTest(t, repo, "branch", "-M", "main")
+	runGitForMQSubmitTest(t, repo, "push", "-u", "origin", "main")
+
+	runGitForMQSubmitTest(t, repo, "checkout", "-b", "feature/pr-target")
+	writeMQSubmitTestFile(t, repo, "file.txt", "feature\n")
+	runGitForMQSubmitTest(t, repo, "commit", "-am", "feature")
+	featureSHA := runGitForMQSubmitTest(t, repo, "rev-parse", "HEAD")
+
+	g := gitpkg.NewGit(repo)
+	err := verifyMQSubmitPushedBranch(g, "feature/pr-target", featureSHA)
+	if err == nil {
+		t.Fatal("verifyMQSubmitPushedBranch() = nil, want missing remote branch error")
+	}
+	for _, want := range []string{"git push origin feature/pr-target", "gt done"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Fatalf("verifyMQSubmitPushedBranch() error missing %q: %v", want, err)
+		}
+	}
+
+	runGitForMQSubmitTest(t, repo, "push", "origin", "feature/pr-target")
+	if err := verifyMQSubmitPushedBranch(g, "feature/pr-target", featureSHA); err != nil {
+		t.Fatalf("verifyMQSubmitPushedBranch() after push: %v", err)
+	}
+}
+
 func runGitForMQSubmitTest(t *testing.T, dir string, args ...string) string {
 	t.Helper()
 	cmd := exec.Command("git", args...)


### PR DESCRIPTION
## Symptom

`gt mq submit` registers an MR bead and nudges the refinery without ever verifying the branch is on origin. The push happens (or doesn't) outside `mq submit` — typically in `gt done` or a manual `git push` — so a slow / silently-failed / never-ran push leaves the MR registered with no branch on origin. Refinery's existing `BranchExists` check (`internal/refinery/batch.go`) is a local-bare-repo lookup, not `git ls-remote`, so its bare repo must have already fetched the branch — racing the crew's push. When the race lost, refinery rejected ~90s later and a maintainer manually cherry-picked.

In one rig, this fired 5 times in 24h across multiple crew members (downstream-tracked as bead `wa-skj`):

| MR | crew | symptom |
|---|---|---|
| `wa-wisp-6av` | digo | branch never on origin; bypass-merged manually |
| `wa-wisp-buh` | batista | branch never pushed; closed in 3min |
| `wa-wisp-hux` | thies | branch never pushed; closed in 3min |
| `wa-wisp-wuk` | batista | closed without merging; bypass-merged |
| `wa-wisp-e8j` | thies | branch's `e83b387` not applied; bypass-merged |

## Root cause

In `internal/cmd/mq_submit.go`, the `bd.Create` for the new-MR path runs without a preflight `git ls-remote` (or equivalent) for the branch. There is no `g.Push()` in this command and no verification step before the MR + refinery nudge fire.

## Fix

Before `bd.Create` in the new-MR branch (idempotent re-submits unaffected):

- If `commitSHA` is resolvable: call `g.VerifyPushedCommit("origin", branch, commitSHA)`. The doc-comment on this method already calls out that it catches the dangerous case where `git push` exits 0 but leaves the remote tip stale, so this also closes the silent-push-failure window beyond just "branch missing".
- Else: call `g.PushRemoteBranchExists("origin", branch)` (handles the fork-pushurl workflow correctly when `remote.<name>.pushurl` differs from the fetch URL).

On miss, the crew gets an actionable error at submit time:

```
branch "<X>" not found on origin

Hint: run 'git push origin <X>' first (or 'gt done'), then re-run 'gt mq submit'
```

…instead of a delayed refinery rejection that requires a maintainer to bypass.

## Test

- `go build ./...` — clean
- `go test ./internal/cmd/ -count=1` — passes (`TestValidateMoleculePrereqs` and the rest of the package).

No new test added in this commit because the verify path is a single-call delegation to existing well-tested methods (`VerifyPushedCommit`, `PushRemoteBranchExists`) in `internal/git` that already have round-trip + URL-routing coverage. Happy to add an `mq_submit`-level integration test if reviewer prefers.

## Coordinated with

The symmetric refinery-side check (`VerifyPushedCommit` after `git push origin main` in `internal/refinery/engineer.go`) is already on this codebase. This PR adds the crew-side preflight in `mq submit` to close the remaining race.

🤖 Generated with Gas Town crew workflow

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3922"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->