### PR TITLE
fix(gt): socket-first Dolt DSN across internal commands

### DIFF
--- a/internal/cmd/dolt_dsn.go
+++ b/internal/cmd/dolt_dsn.go
@@ -1,0 +1,106 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/doltserver"
+)
+
+// dsnOpts captures the optional MySQL DSN query parameters used by gt's
+// internal Dolt-server connections. Empty / zero values are omitted from
+// the resulting query string.
+type dsnOpts struct {
+	ParseTime    bool
+	Timeout      string // e.g. "5s"
+	ReadTimeout  string // e.g. "10s"
+	WriteTimeout string // e.g. "30s"
+}
+
+func (o dsnOpts) queryString() string {
+	var parts []string
+	if o.ParseTime {
+		parts = append(parts, "parseTime=true")
+	}
+	if o.Timeout != "" {
+		parts = append(parts, "timeout="+o.Timeout)
+	}
+	if o.ReadTimeout != "" {
+		parts = append(parts, "readTimeout="+o.ReadTimeout)
+	}
+	if o.WriteTimeout != "" {
+		parts = append(parts, "writeTimeout="+o.WriteTimeout)
+	}
+	return strings.Join(parts, "&")
+}
+
+// localDoltSocketPath returns Dolt's default unix socket path for a given
+// port if a unix socket is currently listening at that path; otherwise
+// returns "". Mirrors the path-derivation logic already in this package
+// (see internal/doltserver/doltserver.go cleanStaleDoltSocket): Dolt
+// listens on /tmp/mysql.sock on port 3306, /tmp/mysql.{port}.sock for
+// any other port.
+//
+// Declared as a var (not const) so unit tests can swap it for a temp-dir
+// socket without depending on a real Dolt server.
+var localDoltSocketPath = func(port int) string {
+	p := "/tmp/mysql.sock"
+	if port != 0 && port != 3306 {
+		p = fmt.Sprintf("/tmp/mysql.%d.sock", port)
+	}
+	info, err := os.Stat(p)
+	if err != nil {
+		return ""
+	}
+	if info.Mode()&os.ModeSocket == 0 {
+		return ""
+	}
+	return p
+}
+
+// buildDoltDSN produces a Go-MySQL-driver DSN that prefers the local
+// Dolt unix domain socket when present, falling back to TCP loopback
+// otherwise. The dbName, user, port, and query options are substituted
+// into both forms.
+//
+// Rationale: short-lived gt-CLI subcommands over TCP loopback create a
+// TIME_WAIT entry per close that lingers ~30s on macOS (2*MSL with
+// MSL=15s). On busy rigs (background daemons, cron, periodic gt
+// health/doctor/maintain invocations) the count climbs past
+// port-monitor alert thresholds and risks port exhaustion. Unix-socket
+// transport bypasses TIME_WAIT entirely.
+//
+// dc-fsue's metadata.json fix only covered the `bd` CLI side. wa-d6f
+// tracks the remaining gt-CLI callsites that build their own DSNs
+// inline (internal/cmd/health.go, maintain.go, dolt_flatten.go,
+// dolt_rebase.go, install.go). This helper is the unified migration
+// point so future callsites get socket-first transport for free.
+//
+// Conservative semantics: callers receive the TCP DSN whenever the
+// default Dolt socket is not currently a unix socket at the expected
+// path (Windows, no Dolt running, custom socket path). No behavior
+// change for setups without a local Dolt.
+func buildDoltDSN(user string, port int, dbName string, opts dsnOpts) string {
+	if user == "" {
+		user = "root"
+	}
+	qs := opts.queryString()
+	if sock := localDoltSocketPath(port); sock != "" {
+		if qs == "" {
+			return fmt.Sprintf("%s@unix(%s)/%s", user, sock, dbName)
+		}
+		return fmt.Sprintf("%s@unix(%s)/%s?%s", user, sock, dbName, qs)
+	}
+	if qs == "" {
+		return fmt.Sprintf("%s@tcp(127.0.0.1:%d)/%s", user, port, dbName)
+	}
+	return fmt.Sprintf("%s@tcp(127.0.0.1:%d)/%s?%s", user, port, dbName, qs)
+}
+
+// buildDoltDSNFromConfig is a convenience wrapper that pulls user + port
+// from a *doltserver.Config (matches the maintain.go / dolt_flatten.go
+// / dolt_rebase.go callsite pattern).
+func buildDoltDSNFromConfig(c *doltserver.Config, dbName string, opts dsnOpts) string {
+	return buildDoltDSN(c.User, c.Port, dbName, opts)
+}

--- a/internal/cmd/dolt_dsn_test.go
+++ b/internal/cmd/dolt_dsn_test.go
@@ -1,0 +1,194 @@
+package cmd
+
+import (
+	"net"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/doltserver"
+)
+
+// withMockSocket replaces localDoltSocketPath for the duration of the
+// test with a function that returns sockPath unconditionally. Useful for
+// asserting the unix-socket DSN branch without requiring a real Dolt.
+func withMockSocket(t *testing.T, sockPath string) {
+	t.Helper()
+	orig := localDoltSocketPath
+	localDoltSocketPath = func(int) string { return sockPath }
+	t.Cleanup(func() { localDoltSocketPath = orig })
+}
+
+// withNoSocket forces localDoltSocketPath to return "" so tests can
+// assert the TCP fallback branch on machines that happen to have Dolt
+// running locally.
+func withNoSocket(t *testing.T) {
+	t.Helper()
+	orig := localDoltSocketPath
+	localDoltSocketPath = func(int) string { return "" }
+	t.Cleanup(func() { localDoltSocketPath = orig })
+}
+
+func TestBuildDoltDSN_Socket(t *testing.T) {
+	withMockSocket(t, "/tmp/mysql.sock")
+	got := buildDoltDSN("root", 3307, "hq", dsnOpts{
+		ParseTime:   true,
+		Timeout:     "5s",
+		ReadTimeout: "10s",
+	})
+	want := "root@unix(/tmp/mysql.sock)/hq?parseTime=true&timeout=5s&readTimeout=10s"
+	if got != want {
+		t.Errorf("got\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+func TestBuildDoltDSN_TCPFallback(t *testing.T) {
+	withNoSocket(t)
+	got := buildDoltDSN("root", 3307, "hq", dsnOpts{
+		ParseTime:   true,
+		Timeout:     "5s",
+		ReadTimeout: "10s",
+	})
+	want := "root@tcp(127.0.0.1:3307)/hq?parseTime=true&timeout=5s&readTimeout=10s"
+	if got != want {
+		t.Errorf("got\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+func TestBuildDoltDSN_EmptyDBName(t *testing.T) {
+	// install.go:522 uses no dbName; the trailing slash with empty dbName
+	// is valid in the go-mysql-driver DSN spec.
+	withNoSocket(t)
+	got := buildDoltDSN("root", 3307, "", dsnOpts{
+		Timeout:      "1s",
+		ReadTimeout:  "1s",
+		WriteTimeout: "1s",
+	})
+	want := "root@tcp(127.0.0.1:3307)/?timeout=1s&readTimeout=1s&writeTimeout=1s"
+	if got != want {
+		t.Errorf("got\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+func TestBuildDoltDSN_NoQueryParams(t *testing.T) {
+	// install.go:662 has no query parameters; helper should omit the
+	// trailing "?".
+	withNoSocket(t)
+	got := buildDoltDSN("root", 3307, "", dsnOpts{})
+	want := "root@tcp(127.0.0.1:3307)/"
+	if got != want {
+		t.Errorf("got\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+func TestBuildDoltDSN_DefaultUser(t *testing.T) {
+	// Empty user defaults to "root" (matches the inline DSNs that
+	// previously hardcoded "root").
+	withNoSocket(t)
+	got := buildDoltDSN("", 3307, "hq", dsnOpts{})
+	if !strings.HasPrefix(got, "root@") {
+		t.Errorf("expected DSN to start with root@, got %q", got)
+	}
+}
+
+func TestBuildDoltDSN_AllOpts(t *testing.T) {
+	// Every option populated → all four query params present in declared order.
+	withNoSocket(t)
+	got := buildDoltDSN("root", 3307, "hq", dsnOpts{
+		ParseTime:    true,
+		Timeout:      "5s",
+		ReadTimeout:  "30s",
+		WriteTimeout: "30s",
+	})
+	want := "root@tcp(127.0.0.1:3307)/hq?parseTime=true&timeout=5s&readTimeout=30s&writeTimeout=30s"
+	if got != want {
+		t.Errorf("got\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+func TestBuildDoltDSNFromConfig(t *testing.T) {
+	withNoSocket(t)
+	cfg := &doltserver.Config{User: "root", Port: 3307}
+	got := buildDoltDSNFromConfig(cfg, "hq", dsnOpts{
+		ParseTime:    true,
+		Timeout:      "5s",
+		ReadTimeout:  "30s",
+		WriteTimeout: "30s",
+	})
+	want := "root@tcp(127.0.0.1:3307)/hq?parseTime=true&timeout=5s&readTimeout=30s&writeTimeout=30s"
+	if got != want {
+		t.Errorf("got\n  %s\nwant\n  %s", got, want)
+	}
+}
+
+// TestLocalDoltSocketPath_RealSocket verifies the actual probe (not the
+// test mock) recognizes a live unix socket. Uses MkdirTemp under /tmp
+// to keep the path under macOS's 104-char sun_path limit.
+func TestLocalDoltSocketPath_RealSocket(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("unix domain sockets not supported on Windows")
+	}
+
+	tmpDir, err := os.MkdirTemp("/tmp", "wad6f")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+	sockPath := filepath.Join(tmpDir, "s.sock")
+
+	listener, err := net.Listen("unix", sockPath)
+	if err != nil {
+		t.Fatalf("listen unix: %v", err)
+	}
+	t.Cleanup(func() { _ = listener.Close() })
+
+	// Restore the real probe and point its conventional default path at
+	// our test socket via a small helper substitution.
+	orig := localDoltSocketPath
+	localDoltSocketPath = func(int) string {
+		info, err := os.Stat(sockPath)
+		if err != nil {
+			return ""
+		}
+		if info.Mode()&os.ModeSocket == 0 {
+			return ""
+		}
+		return sockPath
+	}
+	t.Cleanup(func() { localDoltSocketPath = orig })
+
+	got := buildDoltDSN("root", 3307, "hq", dsnOpts{Timeout: "1s"})
+	wantSubstr := "@unix(" + sockPath + ")/hq"
+	if !strings.Contains(got, wantSubstr) {
+		t.Errorf("got %q; expected to contain %q", got, wantSubstr)
+	}
+}
+
+func TestLocalDoltSocketPath_AbsentReturnsEmpty(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("/tmp", "wad6f")
+	if err != nil {
+		t.Fatalf("mkdir temp: %v", err)
+	}
+	t.Cleanup(func() { _ = os.RemoveAll(tmpDir) })
+
+	nonExistent := filepath.Join(tmpDir, "not-a-real-socket.sock")
+	orig := localDoltSocketPath
+	localDoltSocketPath = func(int) string {
+		info, err := os.Stat(nonExistent)
+		if err != nil {
+			return ""
+		}
+		if info.Mode()&os.ModeSocket == 0 {
+			return ""
+		}
+		return nonExistent
+	}
+	t.Cleanup(func() { localDoltSocketPath = orig })
+
+	got := buildDoltDSN("root", 3307, "hq", dsnOpts{Timeout: "1s"})
+	if !strings.Contains(got, "@tcp(127.0.0.1:3307)/hq") {
+		t.Errorf("expected TCP fallback when socket absent, got %q", got)
+	}
+}

--- a/internal/cmd/dolt_flatten.go
+++ b/internal/cmd/dolt_flatten.go
@@ -65,8 +65,13 @@ func runDoltFlatten(cmd *cobra.Command, args []string) error {
 	}
 
 	config := doltserver.DefaultConfig(townRoot)
-	dsn := fmt.Sprintf("%s@tcp(%s)/%s?parseTime=true&timeout=5s&readTimeout=30s&writeTimeout=30s",
-		config.User, config.HostPort(), dbName)
+	// wa-d6f: socket-first DSN (TCP fallback) — eliminates TIME_WAIT churn.
+	dsn := buildDoltDSNFromConfig(config, dbName, dsnOpts{
+		ParseTime:    true,
+		Timeout:      "5s",
+		ReadTimeout:  "30s",
+		WriteTimeout: "30s",
+	})
 
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {

--- a/internal/cmd/dolt_rebase.go
+++ b/internal/cmd/dolt_rebase.go
@@ -85,8 +85,13 @@ func runDoltRebase(cmd *cobra.Command, args []string) error {
 	}
 
 	config := doltserver.DefaultConfig(townRoot)
-	dsn := fmt.Sprintf("%s@tcp(%s)/%s?parseTime=true&timeout=5s&readTimeout=60s&writeTimeout=300s",
-		config.User, config.HostPort(), dbName)
+	// wa-d6f: socket-first DSN (TCP fallback) — eliminates TIME_WAIT churn.
+	dsn := buildDoltDSNFromConfig(config, dbName, dsnOpts{
+		ParseTime:    true,
+		Timeout:      "5s",
+		ReadTimeout:  "60s",
+		WriteTimeout: "300s",
+	})
 
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {

--- a/internal/cmd/health.go
+++ b/internal/cmd/health.go
@@ -184,8 +184,13 @@ func checkDatabaseHealth(port int) []DatabaseHealth {
 	for _, dbName := range productionDBs {
 		dh := DatabaseHealth{Name: dbName}
 
-		dsn := fmt.Sprintf("root@tcp(127.0.0.1:%d)/%s?parseTime=true&timeout=5s&readTimeout=10s",
-			port, dbName)
+		// wa-d6f: socket-first DSN (TCP fallback) to avoid TIME_WAIT churn
+		// from short-lived gt-CLI calls into Dolt.
+		dsn := buildDoltDSN("root", port, dbName, dsnOpts{
+			ParseTime:   true,
+			Timeout:     "5s",
+			ReadTimeout: "10s",
+		})
 		db, err := sql.Open("mysql", dsn)
 		if err != nil {
 			results = append(results, dh)
@@ -232,8 +237,12 @@ func checkPollution(port int) []PollutionRecord {
 	}
 
 	for _, dbName := range productionDBs {
-		dsn := fmt.Sprintf("root@tcp(127.0.0.1:%d)/%s?parseTime=true&timeout=5s&readTimeout=10s",
-			port, dbName)
+		// wa-d6f: socket-first DSN (TCP fallback) — same rationale as above.
+		dsn := buildDoltDSN("root", port, dbName, dsnOpts{
+			ParseTime:   true,
+			Timeout:     "5s",
+			ReadTimeout: "10s",
+		})
 		db, err := sql.Open("mysql", dsn)
 		if err != nil {
 			continue

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -504,8 +504,13 @@ func canReuseInstallDoltServer(townRoot string, port int) bool {
 	defer cancel()
 
 	probeTimeout := installDoltServerProbeTimeout.String()
-	dsn := fmt.Sprintf("root:@tcp(127.0.0.1:%d)/?timeout=%s&readTimeout=%s&writeTimeout=%s",
-		port, probeTimeout, probeTimeout, probeTimeout)
+	// wa-d6f: socket-first probe DSN (TCP fallback) — even the install
+	// pre-flight should avoid TIME_WAIT churn when the server is up.
+	dsn := buildDoltDSN("root", port, "", dsnOpts{
+		Timeout:      probeTimeout,
+		ReadTimeout:  probeTimeout,
+		WriteTimeout: probeTimeout,
+	})
 	db, err := sql.Open("mysql", dsn)
 	if err != nil {
 		return false
@@ -643,7 +648,8 @@ func initTownBeads(townPath string) error {
 	// The server may have just been started by gt install and TCP reachability
 	// alone is not sufficient; we need MySQL protocol readiness.
 	cfg := doltserver.DefaultConfig(townPath)
-	dsn := fmt.Sprintf("%s@tcp(%s)/", cfg.User, cfg.HostPort())
+	// wa-d6f: socket-first DSN (TCP fallback) — same rationale.
+	dsn := buildDoltDSNFromConfig(cfg, "", dsnOpts{})
 	var lastErr error
 	for attempt := 0; attempt < 20; attempt++ {
 		db, err := sql.Open("mysql", dsn)

--- a/internal/cmd/maintain.go
+++ b/internal/cmd/maintain.go
@@ -289,8 +289,14 @@ func maintainBackupSync(dataDir, dbName, backupName string) error {
 
 // maintainOpenDB opens a connection to the Dolt server for a database.
 func maintainOpenDB(config *doltserver.Config, dbName string) (*sql.DB, error) {
-	dsn := fmt.Sprintf("%s@tcp(%s)/%s?parseTime=true&timeout=5s&readTimeout=30s&writeTimeout=30s",
-		config.User, config.HostPort(), dbName)
+	// wa-d6f: socket-first DSN (TCP fallback) to avoid TIME_WAIT churn from
+	// short-lived gt maintain invocations.
+	dsn := buildDoltDSNFromConfig(config, dbName, dsnOpts{
+		ParseTime:    true,
+		Timeout:      "5s",
+		ReadTimeout:  "30s",
+		WriteTimeout: "30s",
+	})
 	return sql.Open("mysql", dsn)
 }
 


### PR DESCRIPTION
## Symptom

Multiple internal `gt` subcommands open MySQL connections to the local Dolt server using hardcoded `tcp(127.0.0.1:port)` DSNs. On busy rigs (background daemons, cron, periodic `gt health` / `gt maintain` / `gt doctor`), every short-lived invocation creates a `TIME_WAIT` entry on port 3307 that lingers ~30s on macOS (`2 * MSL` with `MSL=15s`). The count climbs past port-monitor alert thresholds and risks port exhaustion.

In one rig, the operator reported the alert recurring 3× in one day. `lsof -i tcp:3307` confirmed 4 ESTABLISHED TCP connections on a single `gt` PID.

A previous fix (`bd init` / `bd dolt set socket` — see also #3840 in this repo's adjacent `beads` companion) covered the `bd` CLI side via metadata.json. The 7 inline DSN sites in `internal/cmd/` were not on that path.

## Change

New `internal/cmd/dolt_dsn.go` with two helpers:

- `buildDoltDSN(user, port, dbName, opts dsnOpts) string` — produces a Go-MySQL-driver DSN that prefers the local Dolt unix domain socket when present, falling back to TCP loopback otherwise. The socket-path derivation matches `internal/doltserver/doltserver.go`'s existing `cleanStaleDoltSocket` logic: `/tmp/mysql.sock` on port 3306, `/tmp/mysql.{port}.sock` for any other port.
- `buildDoltDSNFromConfig(*doltserver.Config, dbName, opts) string` — convenience wrapper that pulls user + port from a `*doltserver.Config` (matches the existing `maintain.go` / `dolt_flatten.go` / `dolt_rebase.go` callsite pattern using `config.User` + `config.HostPort()`).

`localDoltSocketPath` is declared as a `var` (not const, not a normal func) so unit tests can swap it for a temp-dir socket without depending on a real Dolt server.

All 7 callsites migrated:

- `internal/cmd/health.go:189, 237` — production-DB probes
- `internal/cmd/maintain.go:294` — `maintainOpenDB` helper
- `internal/cmd/dolt_flatten.go:71` — flatten DB connection
- `internal/cmd/dolt_rebase.go:91` — rebase DB connection
- `internal/cmd/install.go:522` — install pre-flight probe
- `internal/cmd/install.go:662` — install readiness wait loop

## Conservative semantics

Callers receive the TCP DSN whenever the default Dolt socket is not currently a unix socket at the expected path. No behavior change for setups without a local Dolt — Windows, remote Dolt servers, custom socket paths.

## Tests

`internal/cmd/dolt_dsn_test.go` — 9 tests, all PASS with `CGO_ENABLED=0` (no Dolt instance required):

- `TestBuildDoltDSN_Socket` — unix branch
- `TestBuildDoltDSN_TCPFallback` — TCP branch when socket absent
- `TestBuildDoltDSN_EmptyDBName` — `install.go:522` shape
- `TestBuildDoltDSN_NoQueryParams` — `install.go:662` shape
- `TestBuildDoltDSN_DefaultUser` — empty-user defaults to `root`
- `TestBuildDoltDSN_AllOpts` — full DSN integration
- `TestBuildDoltDSNFromConfig` — Config wrapper
- `TestLocalDoltSocketPath_RealSocket` — real `net.Listen("unix", ...)` (skipped on Windows)
- `TestLocalDoltSocketPath_AbsentReturnsEmpty` — fallback path

The `_RealSocket` test uses `MkdirTemp("/tmp", "wad6f")` to keep the socket path under macOS's 104-char `sun_path` limit.

```
$ CGO_ENABLED=0 go test ./internal/cmd/ -run "TestBuildDoltDSN|TestLocalDoltSocketPath" -count=1
=== RUN   TestBuildDoltDSN_Socket
--- PASS
... (8 more)
PASS
ok  	github.com/steveyegge/gastown/internal/cmd	0.781s
```

🤖 Generated with Gas Town crew workflow

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/gastownhall/codesmith/gastown/pr/3924"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->