### PR TITLE
fix(handoff): merge full agent preset env into respawn command

### DIFF
--- a/internal/cmd/handoff.go
+++ b/internal/cmd/handoff.go
@@ -948,16 +948,25 @@ func buildRestartCommandWithOpts(sessionName string, opts buildRestartCommandOpt
 		}
 	}
 
-	// Clear NODE_OPTIONS to prevent debugger flags (e.g., --inspect from VSCode)
-	// from being inherited through tmux into Claude's Node.js runtime.
-	// When the agent's runtime config explicitly sets NODE_OPTIONS (e.g., for
-	// memory tuning via --max-old-space-size in rc.toml [agents.X.env]), export
-	// that value so it survives handoff. Otherwise clear it.
-	// Note: agentEnv is intentionally nil when gtRole is empty (non-role handoffs),
-	// which causes the nil map lookup to return ("", false) — clearing NODE_OPTIONS.
-	if val, hasNodeOpts := agentEnv["NODE_OPTIONS"]; hasNodeOpts {
-		envMap["NODE_OPTIONS"] = val
-	} else {
+	// Merge all agent preset env vars from config.json [agents.X.env] so the
+	// new session inherits the same custom configuration (e.g. ANTHROPIC_BASE_URL,
+	// CLAUDE_CODE_OAUTH_TOKEN, ANTHROPIC_CUSTOM_HEADERS for proxied Claude).
+	// This mirrors the first-spawn path in config/loader.go where preset.Env is
+	// merged into RuntimeConfig.Env. Existing keys (GT_ROLE, BD_ACTOR, etc.) take
+	// precedence over agent-defined keys.
+	for k, v := range agentEnv {
+		if _, exists := envMap[k]; !exists {
+			envMap[k] = v
+		}
+	}
+
+	// Special case: clear NODE_OPTIONS when not explicitly set in the agent
+	// config, to prevent debugger flags (e.g., --inspect from VSCode) from
+	// being inherited through tmux into Claude's Node.js runtime.
+	// Note: agentEnv is intentionally nil when gtRole is empty (non-role
+	// handoffs), which causes the nil map lookup to return ("", false) —
+	// clearing NODE_OPTIONS.
+	if _, hasNodeOpts := agentEnv["NODE_OPTIONS"]; !hasNodeOpts {
 		envMap["NODE_OPTIONS"] = ""
 	}
 

--- a/internal/cmd/handoff_test.go
+++ b/internal/cmd/handoff_test.go
@@ -176,6 +176,86 @@ func TestBuildRestartCommand_UsesRoleAgentsWhenNoAgentOverride(t *testing.T) {
 	}
 }
 
+func TestBuildRestartCommand_MergesAgentPresetEnv(t *testing.T) {
+	// Regression test: ensure agent preset Env block (config.json [agents.X.env])
+	// is fully merged into the respawn command, not just NODE_OPTIONS.
+	// Without this, custom env vars like ANTHROPIC_BASE_URL configured for
+	// proxied Claude were silently dropped on handoff/respawn.
+	setupHandoffTestRegistry(t)
+
+	origCwd, _ := os.Getwd()
+	origGTAgent := os.Getenv("GT_AGENT")
+	origTownRoot := os.Getenv("GT_TOWN_ROOT")
+	origRoot := os.Getenv("GT_ROOT")
+
+	townRoot := t.TempDir()
+
+	t.Cleanup(func() {
+		_ = os.Chdir(origCwd)
+		_ = os.Setenv("GT_AGENT", origGTAgent)
+		_ = os.Setenv("GT_TOWN_ROOT", origTownRoot)
+		_ = os.Setenv("GT_ROOT", origRoot)
+	})
+	rigPath := filepath.Join(townRoot, "gastown")
+	witnessDir := filepath.Join(rigPath, "witness")
+
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"gastown"}`), 0644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+	if err := os.MkdirAll(witnessDir, 0755); err != nil {
+		t.Fatalf("mkdir witness dir: %v", err)
+	}
+
+	townSettings := config.NewTownSettings()
+	townSettings.DefaultAgent = "claude-proxy"
+	townSettings.Agents = map[string]*config.RuntimeConfig{
+		"claude-proxy": {
+			Command: "claude",
+			Args:    []string{"--dangerously-skip-permissions"},
+			Env: map[string]string{
+				"ANTHROPIC_BASE_URL":       "http://localhost:8080",
+				"CLAUDE_CODE_OAUTH_TOKEN":  "placeholder",
+				"ANTHROPIC_CUSTOM_HEADERS": "Authorization: Bearer prx_test",
+			},
+		},
+	}
+	if err := config.SaveTownSettings(config.TownSettingsPath(townRoot), townSettings); err != nil {
+		t.Fatalf("SaveTownSettings: %v", err)
+	}
+	if err := config.SaveRigSettings(config.RigSettingsPath(rigPath), config.NewRigSettings()); err != nil {
+		t.Fatalf("SaveRigSettings: %v", err)
+	}
+
+	_ = os.Setenv("GT_AGENT", "claude-proxy")
+	_ = os.Setenv("GT_TOWN_ROOT", "")
+	_ = os.Setenv("GT_ROOT", "")
+	if err := os.Chdir(witnessDir); err != nil {
+		t.Fatalf("chdir witness dir: %v", err)
+	}
+
+	cmd, err := buildRestartCommand("gt-witness")
+	if err != nil {
+		t.Fatalf("buildRestartCommand: %v", err)
+	}
+
+	wantEnv := map[string]string{
+		"ANTHROPIC_BASE_URL":       "http://localhost:8080",
+		"CLAUDE_CODE_OAUTH_TOKEN":  "placeholder",
+		"ANTHROPIC_CUSTOM_HEADERS": "Authorization: Bearer prx_test",
+	}
+	for k, v := range wantEnv {
+		if !strings.Contains(cmd, k+"=") {
+			t.Errorf("agent preset env %q not exported in restart command\ncmd: %s", k, cmd)
+		}
+		if !strings.Contains(cmd, v) {
+			t.Errorf("agent preset env value for %q (%q) missing in restart command\ncmd: %s", k, v, cmd)
+		}
+	}
+}
+
 func TestBuildRestartCommandWithOpts_ContinuePrompt(t *testing.T) {
 	setupHandoffTestRegistry(t)
 


### PR DESCRIPTION
## Summary

Fixes the bug where custom agent preset env vars (`agents.<name>.env` in `~/gt/settings/config.json`) are dropped on handoff/respawn. Detailed reproduction in linked issue.

Fixes #3926

## Root cause

`buildRestartCommandWithOpts` resolves the agent's `runtimeConfig.Env` into `agentEnv`, but only consumes `agentEnv["NODE_OPTIONS"]`. All other keys (e.g. `ANTHROPIC_BASE_URL`, `CLAUDE_CODE_OAUTH_TOKEN`, `ANTHROPIC_CUSTOM_HEADERS`) are silently discarded, so the respawn command's `PrependEnv` emits no exports for them. The fresh shell launched by `tmux respawn-pane` inherits nothing, and the post-handoff Claude reverts to default config.

This is asymmetric with the first-spawn path (`internal/config/loader.go:2023-2032`) which merges the **entire** `preset.Env` map.

## Fix

Replace the single-key NODE_OPTIONS lookup with a full merge over `agentEnv`. Existing keys in `envMap` (`GT_ROLE`, `BD_ACTOR`, etc.) take precedence to preserve current semantics. NODE_OPTIONS keeps its explicit fallback to `""` when the agent config does not define it (preserves the original anti-debugger-leak behavior).

```go
for k, v := range agentEnv {
    if _, exists := envMap[k]; !exists {
        envMap[k] = v
    }
}
if _, hasNodeOpts := agentEnv["NODE_OPTIONS"]; !hasNodeOpts {
    envMap["NODE_OPTIONS"] = ""
}
```

Diff is +99/-10 across two files (the test is most of the addition).

## Test

Adds `TestBuildRestartCommand_MergesAgentPresetEnv` as a regression test:
- Creates a town with a custom `claude-proxy` agent containing three env keys
- Calls `buildRestartCommand("gt-witness")`
- Asserts all three keys + values appear in the resulting respawn command

```
$ go test ./internal/cmd/ -run TestBuildRestartCommand -v
=== RUN   TestBuildRestartCommand_UsesRoleAgentsWhenNoAgentOverride
--- PASS: TestBuildRestartCommand_UsesRoleAgentsWhenNoAgentOverride (0.00s)
=== RUN   TestBuildRestartCommand_MergesAgentPresetEnv
--- PASS: TestBuildRestartCommand_MergesAgentPresetEnv (0.00s)
=== RUN   TestBuildRestartCommandWithOpts_ContinuePrompt
--- PASS: TestBuildRestartCommandWithOpts_ContinuePrompt (0.00s)
PASS
ok  	github.com/steveyegge/gastown/internal/cmd	0.145s
```

## Test plan

- [x] Unit test passes (`go test ./internal/cmd/ -run TestBuildRestartCommand`)
- [x] Existing handoff tests still pass (`go test ./internal/cmd/ -run Handoff`)
- [ ] (manual, by reviewer) reproduce per issue, verify post-handoff env now matches first-spawn env
