### PR TITLE
fix: process: gt hooks sync not run during rig/pool init — settings.json silently drifts from gt defaults

### DIFF
--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -273,6 +273,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	// Hooks sync check
 	d.Register(doctor.NewStaleTaskDispatchCheck())
 	d.Register(doctor.NewHooksSyncCheck())
+	d.Register(doctor.NewHooksBaseCheck())
 
 	// Dolt data health checks (binary + server reachability moved to top as prerequisites)
 	d.Register(doctor.NewDoltMetadataCheck())

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -18,6 +18,7 @@ import (
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/util"
+	"github.com/steveyegge/gastown/internal/workspace"
 )
 
 // Polecat command flags
@@ -1825,6 +1826,16 @@ func runPolecatPoolInit(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("\n%s Pool initialized: %d created, %d total (target: %d)\n",
 		style.Bold.Render("✓"), created, created+len(existing), poolSize)
+
+	// Sync hooks so all polecat settings.json files reflect current defaults.
+	// Pool-init may run long after rig-add, when gt defaults have changed.
+	townRoot, twErr := workspace.FindFromCwdOrError()
+	if twErr == nil {
+		ensureHooksBase()
+		if err := syncRigHooks(townRoot, rigName); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to sync hooks after pool-init: %v\n", err)
+		}
+	}
 
 	return nil
 }

--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -637,6 +637,9 @@ func runRigAdd(cmd *cobra.Command, args []string) error {
 	// Auto-assign a namepool theme that doesn't collide with other rigs (gas-21k).
 	autoAssignNamepoolTheme(townRoot, name, mgr)
 
+	// Ensure hooks-base.json exists before syncing (needed for gt hooks diff).
+	ensureHooksBase()
+
 	// Sync hooks for the new rig's targets
 	if err := syncRigHooks(townRoot, name); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to sync hooks for new rig: %v\n", err)
@@ -1357,6 +1360,12 @@ func runRigAdopt(_ *cobra.Command, args []string) error {
 
 	// Auto-assign a namepool theme that doesn't collide with other rigs (gas-21k).
 	autoAssignNamepoolTheme(townRoot, name, mgr)
+
+	// Ensure hooks-base.json exists and sync hooks for the adopted rig.
+	ensureHooksBase()
+	if err := syncRigHooks(townRoot, name); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to sync hooks for adopted rig: %v\n", err)
+	}
 
 	// Print results
 	fmt.Printf("\n%s Rig %s adopted\n", style.Success.Render("✓"), name)
@@ -2396,6 +2405,22 @@ func getRigOperationalState(townRoot, rigName string) (state string, source stri
 
 	// Default: operational
 	return "OPERATIONAL", "default"
+}
+
+// ensureHooksBase creates ~/.gt/hooks-base.json from current defaults if it
+// doesn't exist yet. Without this file, gt hooks diff has no reference point
+// and cannot detect drift when default hooks change after initial setup.
+// Non-fatal: missing base config is caught by gt doctor hooks-base-missing.
+func ensureHooksBase() {
+	if _, err := hooks.LoadBase(); err == nil {
+		return // already exists
+	}
+	base := hooks.DefaultBase()
+	if err := hooks.SaveBase(base); err != nil {
+		fmt.Fprintf(os.Stderr, "  Warning: could not create hooks-base.json: %v\n", err)
+		return
+	}
+	fmt.Printf("  Created hooks-base.json at %s\n", hooks.BasePath())
 }
 
 // syncRigHooks syncs hooks for a specific rig's targets after rig creation.

--- a/internal/doctor/hooks_base_check.go
+++ b/internal/doctor/hooks_base_check.go
@@ -1,0 +1,67 @@
+package doctor
+
+import (
+	"fmt"
+
+	"github.com/steveyegge/gastown/internal/hooks"
+)
+
+// HooksBaseCheck warns when ~/.gt/hooks-base.json is missing.
+// Without this file, gt hooks diff has no reference point and cannot detect
+// drift when gt's default hook configuration changes after initial setup.
+type HooksBaseCheck struct {
+	FixableCheck
+}
+
+// NewHooksBaseCheck creates a new hooks base config check.
+func NewHooksBaseCheck() *HooksBaseCheck {
+	return &HooksBaseCheck{
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "hooks-base-missing",
+				CheckDescription: "Check that ~/.gt/hooks-base.json exists for drift detection",
+				CheckCategory:    CategoryHooks,
+			},
+		},
+	}
+}
+
+// Run checks whether hooks-base.json exists.
+func (c *HooksBaseCheck) Run(ctx *CheckContext) *CheckResult {
+	if _, err := hooks.LoadBase(); err == nil {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: fmt.Sprintf("hooks-base.json present at %s", hooks.BasePath()),
+		}
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusWarning,
+		Message: "hooks-base.json is missing — gt hooks diff cannot detect drift",
+		Details: []string{
+			fmt.Sprintf("Expected at: %s", hooks.BasePath()),
+			"Without this file, hooks sync works but drift detection is unavailable.",
+		},
+		FixHint: "Run 'gt doctor --fix hooks-base-missing' or 'gt hooks base --show' to create it",
+	}
+}
+
+// Fix creates hooks-base.json from current defaults.
+func (c *HooksBaseCheck) Fix(ctx *CheckContext) error {
+	if _, err := hooks.LoadBase(); err == nil {
+		return nil // already exists
+	}
+	base := hooks.DefaultBase()
+	if err := hooks.SaveBase(base); err != nil {
+		return fmt.Errorf("creating hooks-base.json: %w", err)
+	}
+	fmt.Printf("  Created hooks-base.json at %s\n", hooks.BasePath())
+	return nil
+}
+
+// CanFix returns true — we can auto-create the file.
+func (c *HooksBaseCheck) CanFix() bool {
+	return true
+}

--- a/internal/doctor/hooks_base_check_test.go
+++ b/internal/doctor/hooks_base_check_test.go
@@ -1,0 +1,87 @@
+package doctor
+
+import (
+	"os"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/hooks"
+)
+
+func TestHooksBaseCheck_Missing(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	check := NewHooksBaseCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning when hooks-base.json is missing, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestHooksBaseCheck_Present(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Create a base config
+	if err := hooks.SaveBase(hooks.DefaultBase()); err != nil {
+		t.Fatalf("SaveBase: %v", err)
+	}
+
+	check := NewHooksBaseCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when hooks-base.json exists, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestHooksBaseCheck_Fix(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	check := NewHooksBaseCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	// Should warn before fix
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning before fix, got %v", result.Status)
+	}
+
+	// Fix should create the file
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+
+	// Verify file was created
+	if _, err := os.Stat(hooks.BasePath()); err != nil {
+		t.Errorf("hooks-base.json not created after Fix: %v", err)
+	}
+
+	// Should now pass
+	result = check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK after fix, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestHooksBaseCheck_FixIdempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Pre-create the base config
+	if err := hooks.SaveBase(hooks.DefaultBase()); err != nil {
+		t.Fatalf("SaveBase: %v", err)
+	}
+
+	check := NewHooksBaseCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	// Fix on already-present file should be a no-op
+	if err := check.Fix(ctx); err != nil {
+		t.Errorf("Fix on existing base should not error: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

- Run `gt hooks sync` and create `hooks-base.json` automatically during `gt rig add`, `gt rig adopt`, and `gt polecat pool-init` so settings.json files never silently drift from gt defaults
- Add a new `gt doctor` check (`hooks-base-missing`) that warns when `~/.gt/hooks-base.json` is absent and provides an auto-fix
- Introduce `ensureHooksBase()` helper in rig.go that idempotently creates hooks-base.json from current defaults at init time

## Changes

- `internal/cmd/rig.go`: Call `ensureHooksBase()` + `syncRigHooks()` in `runRigAdd` and `runRigAdopt`; add `ensureHooksBase()` helper
- `internal/cmd/polecat.go`: Call `ensureHooksBase()` + `syncRigHooks()` at the end of `runPolecatPoolInit` (guards on workspace resolution)
- `internal/cmd/doctor.go`: Register `NewHooksBaseCheck()` in `runDoctor`
- `internal/doctor/hooks_base_check.go`: New fixable doctor check for missing hooks-base.json
- `internal/doctor/hooks_base_check_test.go`: Tests for missing, present, fix, and fix-idempotent cases

## Testing

- [x] `go build ./...` passes
- [x] `internal/doctor` package tests pass (`go test ./internal/doctor -timeout 2m`)
- [x] `go vet ./...` passes
- [x] New `TestHooksBaseCheck_*` tests cover all cases (missing, present, fix, fix-idempotent)

Closes #3925