### PR TITLE
fix: feat: witness detects context-frozen polecats and sends /compact via tmux

### DIFF
--- a/internal/config/operational.go
+++ b/internal/config/operational.go
@@ -111,6 +111,7 @@ const (
 	DefaultWitnessMaxBeadRespawns        = 3
 	DefaultWitnessDoneIntentStuckTimeout = 60 * time.Second
 	DefaultWitnessDoneIntentRecentGrace  = 30 * time.Second
+	DefaultWitnessContextFrozenThreshold = 10 * time.Minute
 )
 
 // LoadOperationalConfig loads operational config from a town root.
@@ -731,4 +732,12 @@ func (wt *WitnessThresholds) DoneIntentRecentGraceD() time.Duration {
 		return ParseDurationOrDefault(wt.DoneIntentRecentGrace, DefaultWitnessDoneIntentRecentGrace)
 	}
 	return DefaultWitnessDoneIntentRecentGrace
+}
+
+// ContextFrozenThresholdD returns the configured or default context-frozen threshold.
+func (wt *WitnessThresholds) ContextFrozenThresholdD() time.Duration {
+	if wt != nil {
+		return ParseDurationOrDefault(wt.ContextFrozenThreshold, DefaultWitnessContextFrozenThreshold)
+	}
+	return DefaultWitnessContextFrozenThreshold
 }

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -485,6 +485,12 @@ type WitnessThresholds struct {
 	// DoneIntentRecentGrace is how recently a done-intent must have been created
 	// to be considered still in progress (default "30s").
 	DoneIntentRecentGrace string `json:"done_intent_recent_grace,omitempty"`
+
+	// ContextFrozenThreshold is how long a polecat with a live session, alive
+	// agent, and active hook bead can go without a heartbeat update before the
+	// witness sends /compact to recover a potentially context-frozen session
+	// (default "10m"). Only applies when a heartbeat file exists.
+	ContextFrozenThreshold string `json:"context_frozen_threshold,omitempty"`
 }
 
 // DefaultOperationalConfig returns an OperationalConfig with all defaults.

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1074,6 +1074,10 @@ const (
 	ZombieSessionDeadActive ZombieClassification = "session-dead-active"
 	// ZombieAgentSelfReportedStuck: agent self-reported stuck via heartbeat v2 (gt-3vr5).
 	ZombieAgentSelfReportedStuck ZombieClassification = "agent-self-reported-stuck"
+	// ZombieContextFrozen: session and agent alive, hook bead active, but no
+	// heartbeat update for > ContextFrozenThreshold. The witness sends /compact
+	// to unblock the potentially context-frozen session (gt-4yf).
+	ZombieContextFrozen ZombieClassification = "context-frozen"
 )
 
 // ImpliesActiveWork returns true if this classification indicates the polecat
@@ -1083,7 +1087,8 @@ const (
 func (c ZombieClassification) ImpliesActiveWork() bool {
 	switch c {
 	case ZombieStuckInDone, ZombieAgentDeadInSession, ZombieBeadClosedStillRunning,
-		ZombieDoneIntentDead, ZombieSessionDeadActive, ZombieAgentSelfReportedStuck:
+		ZombieDoneIntentDead, ZombieSessionDeadActive, ZombieAgentSelfReportedStuck,
+		ZombieContextFrozen:
 		return true
 	default:
 		return false
@@ -1254,7 +1259,9 @@ func detectZombieLiveSession(bd *BdCli, workDir, townRoot, rigName, polecatName,
 	// Heartbeat v2 check (gt-3vr5): if the agent reports its own state via heartbeat,
 	// trust the agent-reported state instead of inferring from timers.
 	// The witness makes exactly ONE inference: is the heartbeat fresh?
-	if hb := polecat.ReadSessionHeartbeat(townRoot, sessionName); hb != nil && hb.IsV2() {
+	// hb is saved at function scope for context-frozen detection below (gt-4yf).
+	hb := polecat.ReadSessionHeartbeat(townRoot, sessionName)
+	if hb != nil && hb.IsV2() {
 		stale := time.Since(hb.Timestamp) >= polecat.SessionHeartbeatStaleThreshold
 		if !stale {
 			switch hb.EffectiveState() {
@@ -1353,6 +1360,27 @@ func detectZombieLiveSession(bd *BdCli, workDir, townRoot, rigName, polecatName,
 			zombie.Action = fmt.Sprintf("restart-bead-closed-failed: %v", err)
 		}
 		return zombie, true
+	}
+
+	// Context-frozen detection (gt-4yf): session alive, agent alive, hook bead active,
+	// but no heartbeat update for > ContextFrozenThreshold. This indicates the agent's
+	// context window may be full — it can't execute tool calls but its process is alive.
+	// Sending /compact unblocks the session without a restart, preserving in-flight work.
+	// Only fires when a heartbeat file exists; no heartbeat means we can't measure staleness.
+	if hb != nil && snapHook != "" {
+		frozenAge := time.Since(hb.Timestamp)
+		if frozenAge >= witCfg.ContextFrozenThresholdD() {
+			zombie := ZombieResult{
+				PolecatName:    polecatName,
+				AgentState:     snapState,
+				Classification: ZombieContextFrozen,
+				HookBead:       snapHook,
+				WasActive:      true,
+				Action:         fmt.Sprintf("sent-compact (no heartbeat for %v)", frozenAge.Round(time.Second)),
+			}
+			_ = t.NudgeSession(sessionName, "/compact")
+			return zombie, true
+		}
 	}
 
 	return ZombieResult{}, false

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -829,6 +829,58 @@ func TestDetectZombie_BeadClosedVsDoneIntent(t *testing.T) {
 	}
 }
 
+func TestDetectZombie_ContextFrozen(t *testing.T) {
+	t.Parallel()
+	// Verify the logic: live session + alive agent + hooked bead + stale heartbeat
+	// beyond the context-frozen threshold → should trigger /compact (gt-4yf).
+	sessionAlive := true
+	agentAlive := true
+	var doneIntent *DoneIntent
+	hookBead := "gt-some-issue"
+	beadStatus := "hooked"
+
+	// Heartbeat older than the context-frozen threshold (default 10m).
+	heartbeatAge := config.DefaultWitnessContextFrozenThreshold + time.Minute
+	hasHeartbeat := true
+
+	// All conditions met → should detect context-frozen
+	shouldDetect := sessionAlive && agentAlive && doneIntent == nil &&
+		hookBead != "" && beadStatus != "closed" &&
+		hasHeartbeat && heartbeatAge >= config.DefaultWitnessContextFrozenThreshold
+	if !shouldDetect {
+		t.Error("expected context-frozen detection when heartbeat is stale beyond threshold")
+	}
+
+	// Heartbeat younger than the threshold → should NOT detect
+	heartbeatAge = config.DefaultWitnessContextFrozenThreshold - time.Minute
+	shouldSkip := sessionAlive && agentAlive && doneIntent == nil &&
+		hookBead != "" && beadStatus != "closed" &&
+		hasHeartbeat && heartbeatAge >= config.DefaultWitnessContextFrozenThreshold
+	if shouldSkip {
+		t.Error("should not detect context-frozen when heartbeat is recent")
+	}
+
+	// No heartbeat file → should NOT detect (can't measure staleness)
+	heartbeatAge = config.DefaultWitnessContextFrozenThreshold + time.Minute
+	hasHeartbeat = false
+	shouldSkipNoHB := sessionAlive && agentAlive && doneIntent == nil &&
+		hookBead != "" && beadStatus != "closed" &&
+		hasHeartbeat && heartbeatAge >= config.DefaultWitnessContextFrozenThreshold
+	if shouldSkipNoHB {
+		t.Error("should not detect context-frozen when no heartbeat file exists")
+	}
+
+	// No hook bead → should NOT detect (polecat has no active work)
+	hasHeartbeat = true
+	hookBead = ""
+	shouldSkipNoHook := sessionAlive && agentAlive && doneIntent == nil &&
+		hookBead != "" && beadStatus != "closed" &&
+		hasHeartbeat && heartbeatAge >= config.DefaultWitnessContextFrozenThreshold
+	if shouldSkipNoHook {
+		t.Error("should not detect context-frozen when polecat has no hook bead")
+	}
+}
+
 func TestResetAbandonedBead_EmptyHookBead(t *testing.T) {
 	t.Parallel()
 	// resetAbandonedBead should return false for empty hookBead


### PR DESCRIPTION
## Summary

- Adds context-frozen detection to the Witness patrol loop: when a polecat session is alive, the agent is alive, a hook bead is active, but no heartbeat update has been seen for > `ContextFrozenThreshold` (default 10 minutes), the Witness sends `/compact` to unblock the frozen session
- Introduces `ZombieContextFrozen` classification so the Witness audit trail correctly labels compact-triggered recoveries
- Exposes `ContextFrozenThreshold` as a configurable `WitnessThresholds` field (JSON: `context_frozen_threshold`) so operators can tune the window without recompiling

## Changes

- `internal/config/types.go` — adds `ContextFrozenThreshold` field to `WitnessThresholds`
- `internal/config/operational.go` — adds `DefaultWitnessContextFrozenThreshold = 10m` constant and `ContextFrozenThresholdD()` nil-safe accessor
- `internal/witness/handlers.go` — hoists heartbeat read to function scope, adds context-frozen detection block after all other live-session checks, adds `ZombieContextFrozen` to `ImpliesActiveWork()`
- `internal/witness/handlers_test.go` — adds `TestDetectZombie_ContextFrozen` covering all four guard conditions (threshold met, threshold not met, no heartbeat, no hook bead)

## Testing

- [x] `go build ./...` passes
- [x] `go test ./internal/config/... ./internal/witness/...` passes
- [x] `go vet ./...` passes

Closes #3910