### PR TITLE
fix: bug: gt sling --ralph no longer uses the ralph-loop plugin — flag and plugin are disconnected

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -87,7 +87,6 @@ __pycache__/
 .dolt/
 *.db
 
-<<<<<<< Updated upstream
 # Beads / Dolt files (added by bd init)
 .beads-credential-key
 
@@ -97,8 +96,3 @@ CLAUDE.local.md
 
 # Fork research notes (private — not for public upstream)
 docs/fork-info/
-=======
-# Gas Town (added by gt)
-.runtime/
-CLAUDE.local.md
->>>>>>> Stashed changes

--- a/.gitignore
+++ b/.gitignore
@@ -87,6 +87,7 @@ __pycache__/
 .dolt/
 *.db
 
+<<<<<<< Updated upstream
 # Beads / Dolt files (added by bd init)
 .beads-credential-key
 
@@ -96,3 +97,8 @@ CLAUDE.local.md
 
 # Fork research notes (private — not for public upstream)
 docs/fork-info/
+=======
+# Gas Town (added by gt)
+.runtime/
+CLAUDE.local.md
+>>>>>>> Stashed changes

--- a/internal/cmd/compact.go
+++ b/internal/cmd/compact.go
@@ -129,10 +129,17 @@ func loadTTLConfigWithRole(townRoot, rigName string) map[string]time.Duration {
 // applyRigBeadTTLOverrides reads wisp_ttl_* labels from the rig identity bead
 // and applies them as overrides.
 func applyRigBeadTTLOverrides(ttls map[string]time.Duration, townRoot, rigName string) {
+	prefix := beads.GetPrefixForRig(townRoot, rigName)
+	// Skip bead lookup if prefix has no registered route — avoids routing
+	// warnings on installs where the gastown rig is not registered.
+	if beads.GetRigPathForPrefix(townRoot, prefix+"-") == "" {
+		return
+	}
+
 	beadsDir := beads.ResolveBeadsDir(townRoot)
 	bd := beads.NewWithBeadsDir(townRoot, beadsDir)
 
-	rigBeadID := beads.RigBeadIDWithPrefix("gt", rigName)
+	rigBeadID := beads.RigBeadIDWithPrefix(prefix, rigName)
 	issue, err := bd.Show(rigBeadID)
 	if err != nil {
 		return

--- a/internal/cmd/compact_test.go
+++ b/internal/cmd/compact_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -264,5 +266,39 @@ func TestLoadTTLConfigWithRoleSkipsInvalidPaths(t *testing.T) {
 	}
 	if ttls["error"] != defaultTTLs["error"] {
 		t.Errorf("error TTL = %v, want %v", ttls["error"], defaultTTLs["error"])
+	}
+}
+
+// TestApplyRigBeadTTLOverrides_NoRouteForPrefix verifies that the function
+// returns early without emitting routing warnings when the rig's beads prefix
+// has no entry in routes.jsonl. This is the regression test for the compact
+// fix in https://github.com/gastownhall/gastown/issues/3855.
+func TestApplyRigBeadTTLOverrides_NoRouteForPrefix(t *testing.T) {
+	townRoot := t.TempDir()
+
+	// Write routes.jsonl with entries for other prefixes but NOT "gt-".
+	// This simulates an install where the gastown infrastructure rig is absent.
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	routes := `{"prefix":"hq-","path":"."}` + "\n"
+	if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), []byte(routes), 0o644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	// Populate ttls with defaults; applyRigBeadTTLOverrides must leave them unchanged.
+	ttls := make(map[string]time.Duration)
+	for k, v := range defaultTTLs {
+		ttls[k] = v
+	}
+
+	// Must not panic and must not modify ttls.
+	applyRigBeadTTLOverrides(ttls, townRoot, "myrig")
+
+	for k, want := range defaultTTLs {
+		if ttls[k] != want {
+			t.Errorf("TTLs[%q] = %v, want %v (should be unchanged)", k, ttls[k], want)
+		}
 	}
 }

--- a/internal/cmd/doctor.go
+++ b/internal/cmd/doctor.go
@@ -273,6 +273,7 @@ func runDoctor(cmd *cobra.Command, args []string) error {
 	// Hooks sync check
 	d.Register(doctor.NewStaleTaskDispatchCheck())
 	d.Register(doctor.NewHooksSyncCheck())
+	d.Register(doctor.NewHooksBaseCheck())
 
 	// Dolt data health checks (binary + server reachability moved to top as prerequisites)
 	d.Register(doctor.NewDoltMetadataCheck())

--- a/internal/cmd/handoff_test.go
+++ b/internal/cmd/handoff_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 	"time"
@@ -482,8 +483,23 @@ func TestHandoffPolecatEnvCheck(t *testing.T) {
 			handoffStdin = false
 			handoffAuto = false
 
-			// The polecat path tries to exec "gt done" which will fail in tests.
-			// We capture stdout to detect the "Polecat detected" message, which
+			// Install a no-op gt stub so the polecat path cannot exec the real
+			// "gt done" against the developer's working tree (GH #3878).
+			fakeGTDir := t.TempDir()
+			if runtime.GOOS == "windows" {
+				stub := filepath.Join(fakeGTDir, "gt.cmd")
+				if err := os.WriteFile(stub, []byte("@echo off\r\nexit /b 0\r\n"), 0644); err != nil {
+					t.Fatalf("write gt stub: %v", err)
+				}
+			} else {
+				stub := filepath.Join(fakeGTDir, "gt")
+				if err := os.WriteFile(stub, []byte("#!/bin/sh\nexit 0\n"), 0755); err != nil {
+					t.Fatalf("write gt stub: %v", err)
+				}
+			}
+			t.Setenv("PATH", fakeGTDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+			// Capture stdout to detect the "Polecat detected" message, which
 			// confirms the polecat guard triggered. Non-polecat paths will fail
 			// later (missing tmux, etc.) without printing the polecat message.
 			var blocked bool

--- a/internal/cmd/hooks.go
+++ b/internal/cmd/hooks.go
@@ -4,17 +4,25 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var (
+	hooksCmdVerbose bool
+	hooksCmdJSON    bool
+)
+
 var hooksCmd = &cobra.Command{
 	Use:     "hooks",
 	GroupID: GroupConfig,
-	Short:   "Centralized hook management for Gas Town",
-	Long: `Manage Claude Code hooks across the Gas Town workspace.
+	Short:   "List Claude Code hooks in workspace (or manage hooks via subcommands)",
+	Long: `List all Claude Code hooks across the Gas Town workspace, grouped by type.
 
-Provides centralized hook configuration with a base config and
-per-role/per-rig overrides. Changes are propagated to all workers
-via the sync command.
+Scans .claude/settings.json files in town root, rigs, polecats, crew,
+witness, and refinery. Shows each hook with its owning agent.
 
-Subcommands:
+Flags:
+  --verbose   Show actual hook commands
+  --json      Machine-readable JSON output
+
+Subcommands (for hook management):
   base       Edit the shared base hook config
   override   Edit overrides for a role or rig
   sync       Regenerate all .claude/settings.json files
@@ -31,14 +39,23 @@ Config structure:
 Merge strategy: base → role → rig+role (more specific wins)
 
 Examples:
+  gt hooks                # List all hooks with agent ownership
+  gt hooks --verbose      # Show actual hook commands
+  gt hooks --json         # Machine-readable output
   gt hooks sync           # Regenerate all settings.json files
   gt hooks diff           # Preview what sync would change
   gt hooks base           # Edit the shared base config
   gt hooks override crew  # Edit overrides for all crew workers
   gt hooks list           # Show managed locations and sync status`,
-	RunE: requireSubcommand,
+	RunE: runHooksDefault,
+}
+
+func runHooksDefault(cmd *cobra.Command, args []string) error {
+	return doHooksScan(hooksCmdVerbose, hooksCmdJSON)
 }
 
 func init() {
 	rootCmd.AddCommand(hooksCmd)
+	hooksCmd.Flags().BoolVarP(&hooksCmdVerbose, "verbose", "v", false, "Show hook commands")
+	hooksCmd.Flags().BoolVar(&hooksCmdJSON, "json", false, "Machine-readable JSON output")
 }

--- a/internal/cmd/hooks_scan.go
+++ b/internal/cmd/hooks_scan.go
@@ -61,6 +61,11 @@ type HooksOutput struct {
 }
 
 func runHooksScan(cmd *cobra.Command, args []string) error {
+	return doHooksScan(hooksScanVerbose, hooksScanJSON)
+}
+
+// doHooksScan is the shared implementation for both `gt hooks` and `gt hooks scan`.
+func doHooksScan(verbose, jsonOut bool) error {
 	townRoot, err := workspace.FindFromCwd()
 	if err != nil {
 		return fmt.Errorf("not in a Gas Town workspace: %w", err)
@@ -72,11 +77,11 @@ func runHooksScan(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("discovering hooks: %w", err)
 	}
 
-	if hooksScanJSON {
+	if jsonOut {
 		return outputHooksJSON(townRoot, hookInfos)
 	}
 
-	return outputHooksHuman(townRoot, hookInfos)
+	return outputHooksHuman(townRoot, hookInfos, verbose)
 }
 
 // discoverHooks finds all Claude Code hooks in the workspace using hooks.DiscoverTargets.
@@ -158,7 +163,7 @@ func outputHooksJSON(townRoot string, hookInfos []HookInfo) error {
 	return nil
 }
 
-func outputHooksHuman(townRoot string, hookInfos []HookInfo) error {
+func outputHooksHuman(townRoot string, hookInfos []HookInfo, verbose bool) error {
 	if len(hookInfos) == 0 {
 		fmt.Println(style.Dim.Render("No Claude Code hooks found in workspace"))
 		return nil
@@ -211,7 +216,7 @@ func outputHooksHuman(townRoot string, hookInfos []HookInfo) error {
 
 			fmt.Printf("  %s %-25s%s\n", statusIcon, h.Agent, style.Dim.Render(matcherStr))
 
-			if hooksScanVerbose {
+			if verbose {
 				for _, cmd := range h.Commands {
 					fmt.Printf("    %s %s\n", style.Dim.Render("→"), cmd)
 				}

--- a/internal/cmd/hooks_test.go
+++ b/internal/cmd/hooks_test.go
@@ -325,3 +325,45 @@ func TestResolveSettingsTarget(t *testing.T) {
 		})
 	}
 }
+
+func TestHooksCmdHasVerboseAndJSONFlags(t *testing.T) {
+	verboseFlag := hooksCmd.Flags().Lookup("verbose")
+	if verboseFlag == nil {
+		t.Fatal("hooksCmd missing --verbose flag")
+	}
+	if verboseFlag.Shorthand != "v" {
+		t.Errorf("expected --verbose shorthand -v, got %q", verboseFlag.Shorthand)
+	}
+
+	jsonFlag := hooksCmd.Flags().Lookup("json")
+	if jsonFlag == nil {
+		t.Fatal("hooksCmd missing --json flag")
+	}
+}
+
+func TestOutputHooksHumanVerbose(t *testing.T) {
+	hookInfos := []HookInfo{
+		{
+			Type:     "SessionStart",
+			Location: "/test/.claude/settings.json",
+			Agent:    "gastown/polecats",
+			Matcher:  "",
+			Commands: []string{"gt prime"},
+			Status:   "active",
+		},
+	}
+
+	// Verify the function accepts and uses the verbose parameter without error.
+	if err := outputHooksHuman("/test", hookInfos, false); err != nil {
+		t.Errorf("outputHooksHuman(verbose=false) returned error: %v", err)
+	}
+	if err := outputHooksHuman("/test", hookInfos, true); err != nil {
+		t.Errorf("outputHooksHuman(verbose=true) returned error: %v", err)
+	}
+}
+
+func TestOutputHooksHumanEmpty(t *testing.T) {
+	if err := outputHooksHuman("/test", nil, false); err != nil {
+		t.Errorf("outputHooksHuman(empty) returned error: %v", err)
+	}
+}

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -282,6 +282,18 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		fmt.Printf("   ✓ Preserved existing CLAUDE.md + AGENTS.md (town root identity anchor)\n")
 	}
 
+	// Provision town-level slash commands (.claude/commands/) before role settings.
+	// Must come before EnsureSettingsForRole calls for mayor/deacon so that the
+	// ancestor-check in EnsureSettingsForRole can detect the town root copy and
+	// skip provisioning role-specific duplicates. All agents inherit these via
+	// Claude Code's directory traversal — no per-role copies are needed for
+	// roles (mayor, deacon) whose workDir is inside the town root hierarchy.
+	if err := templates.ProvisionCommands(absPath); err != nil {
+		fmt.Printf("   %s Could not provision slash commands: %v\n", style.Dim.Render("⚠"), err)
+	} else {
+		fmt.Printf("   ✓ Created .claude/commands/ (slash commands for all agents)\n")
+	}
+
 	// Create mayor settings (mayor runs from ~/gt/mayor/)
 	// IMPORTANT: Settings must be in ~/gt/mayor/.claude/, NOT ~/gt/.claude/
 	// Settings at town root would be found by ALL agents via directory traversal,
@@ -415,14 +427,6 @@ func runInstall(cmd *cobra.Command, args []string) error {
 		fmt.Printf("   %s Could not create escalation config: %v\n", style.Dim.Render("⚠"), err)
 	} else {
 		fmt.Printf("   ✓ Created settings/escalation.json\n")
-	}
-
-	// Provision town-level slash commands (.claude/commands/)
-	// All agents inherit these via Claude's directory traversal - no per-workspace copies needed.
-	if err := templates.ProvisionCommands(absPath); err != nil {
-		fmt.Printf("   %s Could not provision slash commands: %v\n", style.Dim.Render("⚠"), err)
-	} else {
-		fmt.Printf("   ✓ Created .claude/commands/ (slash commands for all agents)\n")
 	}
 
 	// Sync hooks to generate .claude/settings.json files for all targets.

--- a/internal/cmd/molecule_await_event.go
+++ b/internal/cmd/molecule_await_event.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"bufio"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -18,14 +19,15 @@ import (
 )
 
 var (
-	awaitEventChannel     string
-	awaitEventTimeout     string
-	awaitEventBackoffBase string
-	awaitEventBackoffMult int
-	awaitEventBackoffMax  string
-	awaitEventQuiet       bool
-	awaitEventAgentBead   string
-	awaitEventCleanup     bool
+	awaitEventChannel      string
+	awaitEventTimeout      string
+	awaitEventBackoffBase  string
+	awaitEventBackoffMult  int
+	awaitEventBackoffMax   string
+	awaitEventQuiet        bool
+	awaitEventAgentBead    string
+	awaitEventCleanup      bool
+	awaitEventContextLimit int
 )
 
 // validChannelName is a convenience alias for the canonical regex in channelevents.
@@ -60,7 +62,7 @@ Idle cycles and backoff-until timestamp tracked on agent bead labels.
 If killed and restarted, backoff resumes from the stored backoff-until.
 
 EXIT CODES:
-  0 - Event(s) found or timeout
+  0 - Event(s) found, timeout, or context-limit
   1 - Error
 
 EXAMPLES:
@@ -72,7 +74,10 @@ EXAMPLES:
     --backoff-base 60s --backoff-mult 2 --backoff-max 10m
 
   # Auto-cleanup processed events
-  gt mol step await-event --channel refinery --cleanup`,
+  gt mol step await-event --channel refinery --cleanup
+
+  # Exit early if context window exceeds 70%
+  gt mol step await-event --channel refinery --context-limit 70`,
 	RunE: runMoleculeAwaitEvent,
 }
 
@@ -110,6 +115,8 @@ func init() {
 		"Delete event files after reading them")
 	moleculeAwaitEventCmd.Flags().BoolVar(&moleculeJSON, "json", false,
 		"Output as JSON")
+	moleculeAwaitEventCmd.Flags().IntVar(&awaitEventContextLimit, "context-limit", 0,
+		"Exit with reason=context-limit when Claude context window usage exceeds this percentage (0 = disabled, e.g. 70 for 70%)")
 	_ = moleculeAwaitEventCmd.MarkFlagRequired("channel")
 
 	moleculeStepCmd.AddCommand(moleculeAwaitEventCmd)
@@ -198,7 +205,19 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	result, err := waitForEventFiles(ctx, eventDir)
+	// Optional: monitor context window usage and exit early when limit is exceeded.
+	// A buffered channel is used so the monitoring goroutine never blocks.
+	var contextLimitCh <-chan struct{}
+	if awaitEventContextLimit > 0 {
+		ch := make(chan struct{}, 1)
+		contextLimitCh = ch
+		cwd, cwdErr := os.Getwd()
+		if cwdErr == nil {
+			go monitorContextLimit(ctx, ch, cwd, awaitEventContextLimit)
+		}
+	}
+
+	result, err := waitForEventFiles(ctx, eventDir, contextLimitCh)
 	if err != nil {
 		return fmt.Errorf("event watch failed: %w", err)
 	}
@@ -220,8 +239,8 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 			} else {
 				result.IdleCycles = newIdle
 			}
-		} else if result.Reason == "event" {
-			// Reset idle on event received
+		} else if result.Reason == "event" || result.Reason == "context-limit" {
+			// Reset idle on event received or context-limit exit
 			if idleCycles > 0 {
 				_ = setAgentIdleCycles(awaitEventAgentBead, beadsDir, 0)
 			}
@@ -239,11 +258,18 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Set effort level based on idle cycles.
-	if result.Reason == "event" || result.IdleCycles == 0 {
+	// Set effort level based on reason and idle cycles.
+	switch result.Reason {
+	case "context-limit":
+		result.EffortLevel = "handoff"
+	case "event":
 		result.EffortLevel = "full"
-	} else {
-		result.EffortLevel = "abbreviated"
+	default: // "timeout"
+		if result.IdleCycles == 0 {
+			result.EffortLevel = "full"
+		} else {
+			result.EffortLevel = "abbreviated"
+		}
 	}
 
 	// Output
@@ -267,16 +293,23 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 					}
 				}
 			}
+		case "context-limit":
+			fmt.Printf("%s Context limit reached (%d%% threshold) after %v\n",
+				style.Bold.Render("⚠"), awaitEventContextLimit, result.Elapsed.Round(time.Millisecond))
 		case "timeout":
 			fmt.Printf("%s Timeout after %v (idle cycle: %d)\n",
 				style.Dim.Render("⏱"), result.Elapsed.Round(time.Millisecond), result.IdleCycles)
 		}
 
 		// Output effort recommendation for the next patrol cycle.
-		if result.EffortLevel == "abbreviated" {
+		switch result.EffortLevel {
+		case "handoff":
+			fmt.Printf("\n%s Context window near limit. Initiate session handoff.\n",
+				style.Bold.Render("EFFORT: handoff"))
+		case "abbreviated":
 			fmt.Printf("\n%s Run ABBREVIATED patrol: quick checks only, skip optional steps.\n",
 				style.Bold.Render("EFFORT: reduced"))
-		} else {
+		default:
 			fmt.Printf("\n%s Run full patrol.\n",
 				style.Bold.Render("EFFORT: full"))
 		}
@@ -322,7 +355,10 @@ func calculateEventTimeout(idleCycles int) (time.Duration, error) {
 
 // waitForEventFiles checks for pending events, then polls until events appear or timeout.
 // Uses a polling loop instead of inotifywait for cross-platform compatibility.
-func waitForEventFiles(ctx context.Context, eventDir string) (*AwaitEventResult, error) {
+//
+// contextLimitCh is optional (may be nil). When a value is sent on it, the function
+// returns immediately with reason="context-limit". A nil channel is never selected.
+func waitForEventFiles(ctx context.Context, eventDir string, contextLimitCh <-chan struct{}) (*AwaitEventResult, error) {
 	// Check for already-pending events
 	events, err := readPendingEvents(eventDir)
 	if err != nil {
@@ -353,6 +389,8 @@ func waitForEventFiles(ctx context.Context, eventDir string) (*AwaitEventResult,
 
 	for {
 		select {
+		case <-contextLimitCh:
+			return &AwaitEventResult{Reason: "context-limit"}, nil
 		case <-ctx.Done():
 			// Final check for events (race condition safety). Bound the
 			// read so a stuck filesystem can't prevent us from returning —
@@ -383,6 +421,8 @@ func waitForEventFiles(ctx context.Context, eventDir string) (*AwaitEventResult,
 				ch <- readRes{events: ev, err: er}
 			}()
 			select {
+			case <-contextLimitCh:
+				return &AwaitEventResult{Reason: "context-limit"}, nil
 			case <-ctx.Done():
 				// Timeout raced with read — abandon the goroutine and
 				// let the outer loop's ctx.Done() case finalize.
@@ -462,4 +502,137 @@ func readPendingEvents(dir string) ([]EventFile, error) {
 	}
 
 	return events, nil
+}
+
+// monitorContextLimit polls the Claude Code JSONL file every 60 seconds and sends
+// on ch when context window usage exceeds the threshold percentage.
+// It exits when ctx is done. The goroutine is started only when --context-limit > 0.
+func monitorContextLimit(ctx context.Context, ch chan<- struct{}, cwd string, limitPct int) {
+	ticker := time.NewTicker(60 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			pct := readContextWindowPct(cwd)
+			if pct >= float64(limitPct) {
+				select {
+				case ch <- struct{}{}:
+				default:
+				}
+				return
+			}
+		}
+	}
+}
+
+// readContextWindowPct returns the current context window usage as a percentage (0–100).
+// It reads the most recent Claude Code JSONL file for the given working directory.
+// Returns 0 when context cannot be determined (best-effort; all errors are silently ignored).
+func readContextWindowPct(cwd string) float64 {
+	projectDir, err := claudeProjectDirForPath(cwd)
+	if err != nil {
+		return 0
+	}
+	jsonlPath, ok := newestJSONLInDir(projectDir)
+	if !ok {
+		return 0
+	}
+	tokens, model := lastInputTokensInJSONL(jsonlPath)
+	if tokens == 0 {
+		return 0
+	}
+	limit := contextWindowForModel(model)
+	return float64(tokens) / float64(limit) * 100
+}
+
+// claudeProjectDirForPath returns the Claude Code project directory for the given path.
+// Formula: $HOME/.claude/projects/<hash> where hash = path with '/' replaced by '-'.
+func claudeProjectDirForPath(dir string) (string, error) {
+	abs, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+	normalized := filepath.ToSlash(abs)
+	// Strip Windows drive letter (e.g. "C:") to match Claude Code's cross-platform hash.
+	if len(normalized) >= 2 && normalized[1] == ':' {
+		normalized = normalized[2:]
+	}
+	hash := strings.ReplaceAll(normalized, "/", "-")
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".claude", "projects", hash), nil
+}
+
+// newestJSONLInDir returns the path of the most recently modified .jsonl file in dir.
+func newestJSONLInDir(dir string) (string, bool) {
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		return "", false
+	}
+	var bestPath string
+	var bestTime time.Time
+	for _, e := range entries {
+		if !strings.HasSuffix(e.Name(), ".jsonl") {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			continue
+		}
+		if bestPath == "" || info.ModTime().After(bestTime) {
+			bestPath = filepath.Join(dir, e.Name())
+			bestTime = info.ModTime()
+		}
+	}
+	return bestPath, bestPath != ""
+}
+
+// lastInputTokensInJSONL reads the last assistant message's input_tokens and model
+// from a Claude Code JSONL conversation file.
+// The most recent assistant entry's input_tokens represents the current context window size.
+func lastInputTokensInJSONL(jsonlPath string) (tokens int, model string) {
+	f, err := os.Open(jsonlPath) //nolint:gosec // G304: path built from OS-reported dir entries
+	if err != nil {
+		return 0, ""
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	buf := make([]byte, 0, 64*1024)
+	scanner.Buffer(buf, 4*1024*1024)
+
+	var lastTokens int
+	var lastModel string
+
+	for scanner.Scan() {
+		var entry struct {
+			Type    string `json:"type"`
+			Message *struct {
+				Usage *struct {
+					InputTokens int `json:"input_tokens"`
+				} `json:"usage"`
+				Model string `json:"model"`
+			} `json:"message"`
+		}
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err != nil {
+			continue
+		}
+		if entry.Type == "assistant" && entry.Message != nil && entry.Message.Usage != nil {
+			lastTokens = entry.Message.Usage.InputTokens
+			if entry.Message.Model != "" {
+				lastModel = entry.Message.Model
+			}
+		}
+	}
+	return lastTokens, lastModel
+}
+
+// contextWindowForModel returns the context window size in tokens for a Claude model.
+// All current Claude models (3.x, 4.x) have a 200k-token context window.
+func contextWindowForModel(_ string) int {
+	return 200_000
 }

--- a/internal/cmd/molecule_await_event_test.go
+++ b/internal/cmd/molecule_await_event_test.go
@@ -9,6 +9,10 @@ import (
 	"time"
 )
 
+// nilContextLimitCh is a nil receive channel — never selected in select statements.
+// Passed to waitForEventFiles when no context-limit monitoring is desired.
+var nilContextLimitCh <-chan struct{}
+
 func TestCalculateEventTimeout(t *testing.T) {
 	tests := []struct {
 		name        string
@@ -300,7 +304,7 @@ func TestWaitForEventFilesPolling(t *testing.T) {
 	}()
 
 	start := time.Now()
-	result, err := waitForEventFiles(ctx, dir)
+	result, err := waitForEventFiles(ctx, dir, nilContextLimitCh)
 	elapsed := time.Since(start)
 
 	if err != nil {
@@ -330,7 +334,7 @@ func TestWaitForEventFilesWithPending(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result, err := waitForEventFiles(ctx, dir)
+	result, err := waitForEventFiles(ctx, dir, nilContextLimitCh)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -349,7 +353,7 @@ func TestWaitForEventFilesTimeout(t *testing.T) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
 	defer cancel()
 
-	result, err := waitForEventFiles(ctx, dir)
+	result, err := waitForEventFiles(ctx, dir, nilContextLimitCh)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -362,7 +366,7 @@ func TestWaitForEventFilesNoDeadline(t *testing.T) {
 	// With a context that has no deadline, should return timeout immediately.
 	dir := t.TempDir()
 
-	result, err := waitForEventFiles(context.Background(), dir)
+	result, err := waitForEventFiles(context.Background(), dir, nilContextLimitCh)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -382,7 +386,7 @@ func TestWaitForEventFilesTimeoutWithPolling(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	result, err := waitForEventFiles(ctx, dir)
+	result, err := waitForEventFiles(ctx, dir, nilContextLimitCh)
 	elapsed := time.Since(start)
 
 	if err != nil {
@@ -448,4 +452,175 @@ func TestEventFileStruct(t *testing.T) {
 	if parsed["type"] != "MQ_SUBMIT" {
 		t.Errorf("type = %v, want MQ_SUBMIT", parsed["type"])
 	}
+}
+
+func TestWaitForEventFilesContextLimitCh(t *testing.T) {
+	// When the context-limit channel fires, waitForEventFiles should return
+	// reason="context-limit" promptly, even with a long timeout and no events.
+	dir := t.TempDir()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Pre-fire the context limit channel so it triggers immediately.
+	ch := make(chan struct{}, 1)
+	ch <- struct{}{}
+
+	start := time.Now()
+	result, err := waitForEventFiles(ctx, dir, ch)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Reason != "context-limit" {
+		t.Errorf("expected reason 'context-limit', got %q", result.Reason)
+	}
+	// Should return almost immediately (well under 1s).
+	if elapsed > 2*time.Second {
+		t.Errorf("took %v; expected near-instant return on pre-fired context limit", elapsed)
+	}
+}
+
+func TestWaitForEventFilesContextLimitDuringPoll(t *testing.T) {
+	// Context limit fires while polling (not pre-fired).
+	dir := t.TempDir()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	ch := make(chan struct{}, 1)
+	// Fire the channel after a short delay — longer than one poll interval (500ms).
+	go func() {
+		time.Sleep(700 * time.Millisecond)
+		ch <- struct{}{}
+	}()
+
+	start := time.Now()
+	result, err := waitForEventFiles(ctx, dir, ch)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Reason != "context-limit" {
+		t.Errorf("expected reason 'context-limit', got %q", result.Reason)
+	}
+	// Should return shortly after 700ms, not at the 10s timeout.
+	if elapsed < 600*time.Millisecond {
+		t.Errorf("returned too quickly (%v); expected ~700ms", elapsed)
+	}
+	if elapsed > 3*time.Second {
+		t.Errorf("took %v; expected ~700ms", elapsed)
+	}
+}
+
+func TestLastInputTokensInJSONL(t *testing.T) {
+	t.Run("reads last assistant entry", func(t *testing.T) {
+		dir := t.TempDir()
+		// Two assistant turns; we want the last one's tokens.
+		content := `{"type":"assistant","message":{"usage":{"input_tokens":50000},"model":"claude-sonnet-4-5"},"timestamp":"2026-05-10T00:00:00Z"}` + "\n" +
+			`{"type":"user","message":{"role":"user","content":[{"type":"tool_result"}]}}` + "\n" +
+			`{"type":"assistant","message":{"usage":{"input_tokens":120000},"model":"claude-sonnet-4-6"},"timestamp":"2026-05-10T00:01:00Z"}` + "\n"
+		path := filepath.Join(dir, "session.jsonl")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		tokens, model := lastInputTokensInJSONL(path)
+		if tokens != 120000 {
+			t.Errorf("tokens = %d, want 120000", tokens)
+		}
+		if model != "claude-sonnet-4-6" {
+			t.Errorf("model = %q, want 'claude-sonnet-4-6'", model)
+		}
+	})
+
+	t.Run("ignores non-assistant entries", func(t *testing.T) {
+		dir := t.TempDir()
+		content := `{"type":"user","message":{"role":"user","content":[]}}` + "\n"
+		path := filepath.Join(dir, "session.jsonl")
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+		tokens, model := lastInputTokensInJSONL(path)
+		if tokens != 0 {
+			t.Errorf("tokens = %d, want 0", tokens)
+		}
+		if model != "" {
+			t.Errorf("model = %q, want empty", model)
+		}
+	})
+
+	t.Run("nonexistent file returns zero", func(t *testing.T) {
+		tokens, model := lastInputTokensInJSONL("/tmp/nonexistent-jsonl-test-file.jsonl")
+		if tokens != 0 {
+			t.Errorf("tokens = %d, want 0", tokens)
+		}
+		if model != "" {
+			t.Errorf("model = %q, want empty", model)
+		}
+	})
+}
+
+func TestContextWindowForModel(t *testing.T) {
+	tests := []struct {
+		model string
+		want  int
+	}{
+		{"claude-sonnet-4-6", 200_000},
+		{"claude-opus-4-7", 200_000},
+		{"claude-haiku-4-5-20251001", 200_000},
+		{"", 200_000},
+	}
+	for _, tt := range tests {
+		got := contextWindowForModel(tt.model)
+		if got != tt.want {
+			t.Errorf("contextWindowForModel(%q) = %d, want %d", tt.model, got, tt.want)
+		}
+	}
+}
+
+func TestReadContextWindowPctMissingDir(t *testing.T) {
+	// readContextWindowPct is best-effort: returns 0 when the project dir doesn't exist.
+	pct := readContextWindowPct("/tmp/nonexistent-cwd-for-context-pct-test-" + t.Name())
+	if pct != 0 {
+		t.Errorf("expected 0 for missing project dir, got %v", pct)
+	}
+}
+
+func TestNewestJSONLInDir(t *testing.T) {
+	t.Run("returns newest file", func(t *testing.T) {
+		dir := t.TempDir()
+		for _, name := range []string{"a.jsonl", "b.jsonl", "c.jsonl"} {
+			if err := os.WriteFile(filepath.Join(dir, name), []byte("{}"), 0644); err != nil {
+				t.Fatal(err)
+			}
+			time.Sleep(5 * time.Millisecond)
+		}
+		path, ok := newestJSONLInDir(dir)
+		if !ok {
+			t.Fatal("expected to find a JSONL file")
+		}
+		if filepath.Base(path) != "c.jsonl" {
+			t.Errorf("expected newest = c.jsonl, got %s", filepath.Base(path))
+		}
+	})
+
+	t.Run("ignores non-jsonl files", func(t *testing.T) {
+		dir := t.TempDir()
+		os.WriteFile(filepath.Join(dir, "session.json"), []byte("{}"), 0644)
+		os.WriteFile(filepath.Join(dir, "notes.txt"), []byte("hi"), 0644)
+		_, ok := newestJSONLInDir(dir)
+		if ok {
+			t.Error("expected no JSONL files, but found one")
+		}
+	})
+
+	t.Run("empty dir returns false", func(t *testing.T) {
+		dir := t.TempDir()
+		_, ok := newestJSONLInDir(dir)
+		if ok {
+			t.Error("expected false for empty dir")
+		}
+	})
 }

--- a/internal/cmd/mq.go
+++ b/internal/cmd/mq.go
@@ -558,11 +558,10 @@ func runMQPostMerge(_ *cobra.Command, args []string) error {
 	// Get git client for the rig
 	rigGit, err := getRigGit(r.Path)
 	if err != nil {
-		return fmt.Errorf("branch delete: %w", err)
+		return fmt.Errorf("remote branch delete: %w", err)
 	}
 
 	if err := deletePostMergeBranch(rigGit, mr.Branch); err != nil {
-		fmt.Printf("  %s %v\n", style.Warning.Render("⚠"), err)
 		return err
 	}
 

--- a/internal/cmd/mq.go
+++ b/internal/cmd/mq.go
@@ -558,27 +558,42 @@ func runMQPostMerge(_ *cobra.Command, args []string) error {
 	// Get git client for the rig
 	rigGit, err := getRigGit(r.Path)
 	if err != nil {
-		fmt.Printf("  %s branch delete: %v\n", style.Warning.Render("⚠"), err)
-		return nil // non-fatal: beads cleanup succeeded
+		return fmt.Errorf("branch delete: %w", err)
 	}
 
-	// Delete remote branch — but skip if there's an open PR on it.
-	// Deleting a branch with an open PR causes GitHub to auto-close the PR
-	// as "closed" (not "merged"), destroying the PR audit trail. (gas-fk4)
-	if rigGit.HasOpenPR(mr.Branch) {
-		fmt.Printf("  %s Skipping remote branch delete for %s: open PR exists (gas-fk4)\n", style.Dim.Render("○"), mr.Branch)
-	} else if err := rigGit.DeleteRemoteBranch("origin", mr.Branch); err != nil {
-		fmt.Printf("  %s remote branch delete: %v\n", style.Warning.Render("⚠"), err)
-	} else {
-		fmt.Printf("  %s Deleted remote branch: %s\n", style.Success.Render("✓"), mr.Branch)
+	if err := deletePostMergeBranch(rigGit, mr.Branch); err != nil {
+		fmt.Printf("  %s %v\n", style.Warning.Render("⚠"), err)
+		return err
 	}
 
-	// Also clean up the local tracking ref if it exists
-	if err := rigGit.DeleteBranch(mr.Branch, true); err != nil {
-		// Not a warning — local branch often doesn't exist
-		_ = err
-	} else {
-		fmt.Printf("  %s Deleted local branch: %s\n", style.Success.Render("✓"), mr.Branch)
+	return nil
+}
+
+// postMergeBranchOps is the subset of git operations needed during post-merge branch cleanup.
+type postMergeBranchOps interface {
+	HasOpenPR(branch string) bool
+	DeleteRemoteBranch(remote, branch string) error
+	DeleteBranch(name string, force bool) error
+}
+
+// deletePostMergeBranch deletes the remote (and optionally local) branch after a merge.
+// Returns an error if remote deletion fails so the refinery can detect and retry.
+// Local tracking ref deletion is best-effort (branch often absent in the rig repo).
+func deletePostMergeBranch(ops postMergeBranchOps, branch string) error {
+	// Skip deletion if an open PR exists — deleting that branch would cause GitHub
+	// to auto-close the PR as "closed" (not "merged"), destroying audit trail. (gas-fk4)
+	if ops.HasOpenPR(branch) {
+		fmt.Printf("  %s Skipping remote branch delete for %s: open PR exists (gas-fk4)\n", style.Dim.Render("○"), branch)
+		return nil
+	}
+
+	if err := ops.DeleteRemoteBranch("origin", branch); err != nil {
+		return fmt.Errorf("remote branch delete: %w", err)
+	}
+	fmt.Printf("  %s Deleted remote branch: %s\n", style.Success.Render("✓"), branch)
+
+	if err := ops.DeleteBranch(branch, true); err == nil {
+		fmt.Printf("  %s Deleted local branch: %s\n", style.Success.Render("✓"), branch)
 	}
 
 	return nil

--- a/internal/cmd/mq_integration_test.go
+++ b/internal/cmd/mq_integration_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -645,6 +646,51 @@ func TestGetRigGit(t *testing.T) {
 			t.Errorf("expected empty WorkDir for bare repo, got %q", g.WorkDir())
 		}
 	})
+}
+
+// TestPostMerge_RigGitError verifies that getRigGit failure in runMQPostMerge
+// propagates as an error rather than being silently swallowed (gh#3868).
+// Before the fix, the function returned nil on getRigGit failure, giving exit
+// code 0 and causing the refinery to skip retry on branch-delete failures.
+func TestPostMerge_RigGitError(t *testing.T) {
+	// Empty temp dir: no .repo.git, no mayor/rig → getRigGit returns error.
+	tmp := t.TempDir()
+
+	_, err := getRigGit(tmp)
+	if err == nil {
+		t.Fatal("expected getRigGit to fail for empty dir, got nil")
+	}
+	if !strings.Contains(err.Error(), "no repo base found") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+// TestPostMerge_DeleteRemoteBranchErrorPropagated verifies that a failing
+// git push --delete returns a non-nil error from DeleteRemoteBranch (gh#3868).
+// Before the fix, runMQPostMerge swallowed this error and returned exit code 0.
+func TestPostMerge_DeleteRemoteBranchErrorPropagated(t *testing.T) {
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	tmp := t.TempDir()
+	bareRepo := filepath.Join(tmp, ".repo.git")
+	if err := os.MkdirAll(bareRepo, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := exec.Command("git", "init", "--bare", bareRepo).Run(); err != nil {
+		t.Skipf("git init --bare: %v", err)
+	}
+
+	rigGit, err := getRigGit(tmp)
+	if err != nil {
+		t.Fatalf("getRigGit: %v", err)
+	}
+
+	// No "origin" remote is configured → git push --delete must fail.
+	err = rigGit.DeleteRemoteBranch("origin", "polecat/test/gt-abc")
+	if err == nil {
+		t.Error("expected error from DeleteRemoteBranch with no remote, got nil")
+	}
 }
 
 func TestGetIntegrationBranchTemplate(t *testing.T) {

--- a/internal/cmd/mq_test.go
+++ b/internal/cmd/mq_test.go
@@ -1,11 +1,88 @@
 package cmd
 
 import (
+	"errors"
 	"testing"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
 )
+
+// mockBranchOps is a test double for postMergeBranchOps.
+type mockBranchOps struct {
+	hasOpenPR            bool
+	deleteRemoteBranchFn func(remote, branch string) error
+	deleteBranchFn       func(name string, force bool) error
+}
+
+func (m *mockBranchOps) HasOpenPR(_ string) bool { return m.hasOpenPR }
+func (m *mockBranchOps) DeleteRemoteBranch(remote, branch string) error {
+	if m.deleteRemoteBranchFn != nil {
+		return m.deleteRemoteBranchFn(remote, branch)
+	}
+	return nil
+}
+func (m *mockBranchOps) DeleteBranch(name string, force bool) error {
+	if m.deleteBranchFn != nil {
+		return m.deleteBranchFn(name, force)
+	}
+	return nil
+}
+
+func TestDeletePostMergeBranch(t *testing.T) {
+	tests := []struct {
+		name       string
+		ops        *mockBranchOps
+		branch     string
+		wantErr    bool
+		wantErrStr string
+	}{
+		{
+			name:   "skips deletion when open PR exists",
+			ops:    &mockBranchOps{hasOpenPR: true},
+			branch: "polecat/nitro/eat-luj@movek49r",
+		},
+		{
+			name: "returns error when remote deletion fails",
+			ops: &mockBranchOps{
+				deleteRemoteBranchFn: func(_, _ string) error {
+					return errors.New("ref not found")
+				},
+			},
+			branch:     "polecat/nitro/eat-luj@movek49r",
+			wantErr:    true,
+			wantErrStr: "remote branch delete",
+		},
+		{
+			name:   "succeeds when both remote and local deletion succeed",
+			ops:    &mockBranchOps{},
+			branch: "polecat/nitro/eat-luj@movek49r",
+		},
+		{
+			name: "succeeds when remote succeeds but local deletion fails (best-effort)",
+			ops: &mockBranchOps{
+				deleteBranchFn: func(_ string, _ bool) error {
+					return errors.New("branch not found locally")
+				},
+			},
+			branch: "polecat/nitro/eat-luj@movek49r",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			err := deletePostMergeBranch(tt.ops, tt.branch)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("deletePostMergeBranch() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr && tt.wantErrStr != "" {
+				if !stringContains(err.Error(), tt.wantErrStr) {
+					t.Errorf("deletePostMergeBranch() error = %q, want containing %q", err.Error(), tt.wantErrStr)
+				}
+			}
+		})
+	}
+}
 
 func TestParseBranchName(t *testing.T) {
 	tests := []struct {

--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -18,6 +18,7 @@ import (
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/util"
+	"github.com/steveyegge/gastown/internal/workspace"
 )
 
 // Polecat command flags
@@ -1825,6 +1826,16 @@ func runPolecatPoolInit(cmd *cobra.Command, args []string) error {
 
 	fmt.Printf("\n%s Pool initialized: %d created, %d total (target: %d)\n",
 		style.Bold.Render("✓"), created, created+len(existing), poolSize)
+
+	// Sync hooks so all polecat settings.json files reflect current defaults.
+	// Pool-init may run long after rig-add, when gt defaults have changed.
+	townRoot, twErr := workspace.FindFromCwdOrError()
+	if twErr == nil {
+		ensureHooksBase()
+		if err := syncRigHooks(townRoot, rigName); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: failed to sync hooks after pool-init: %v\n", err)
+		}
+	}
 
 	return nil
 }

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -946,9 +946,12 @@ func outputMoleculeWorkflow(ctx RoleContext, attachment *beads.AttachmentFields)
 	}
 	fmt.Println()
 
-	// Ralph loop mode: output Ralph Wiggum loop command instead of step-by-step execution
+	// Ralph loop mode: activate the ralph-loop plugin stop-hook loop.
 	if attachment.Mode == "ralph" {
-		outputRalphLoopDirective(ctx, attachment)
+		if err := outputRalphLoopDirective(ctx, attachment); err != nil {
+			fmt.Fprintf(os.Stderr, "error: %v\n", err)
+			os.Exit(1)
+		}
 		return
 	}
 
@@ -969,40 +972,79 @@ func outputMoleculeWorkflow(ctx RoleContext, attachment *beads.AttachmentFields)
 	fmt.Println("The base bead is just a container. The molecule steps define your workflow.")
 }
 
-// outputRalphLoopDirective emits inline iterative work instructions for ralph mode.
-// Ralph mode is designed for long, iterative workflows (e.g., quality improvement
-// loops) that benefit from committing progress incrementally. The agent works
-// through formula steps iteratively, committing after each meaningful change,
-// and calls gt done when all acceptance criteria are met or no further progress
-// can be made.
-func outputRalphLoopDirective(ctx RoleContext, attachment *beads.AttachmentFields) {
-	fmt.Printf("%s\n\n", style.Bold.Render("## RALPH LOOP MODE (ITERATIVE WORKFLOW)"))
-	fmt.Println("This work uses iterative loop mode. Work through the steps below,")
-	fmt.Println("committing after each meaningful change. Loop until acceptance criteria")
-	fmt.Println("are met or no further progress can be made.")
-	fmt.Println()
+// outputRalphLoopDirective emits a /ralph-loop slash command to activate the
+// Ralph Wiggum stop-hook loop for multi-step iterative workflows. The plugin
+// must be installed; if not, an error is returned so the caller can fail clearly.
+func outputRalphLoopDirective(ctx RoleContext, attachment *beads.AttachmentFields) error {
+	return outputRalphLoopDirectiveWithPluginCheck(ctx, attachment, isRalphLoopPluginInstalled())
+}
 
-	// Show the formula steps inline (same as normal mode) so the agent has
-	// the full checklist. Previously this emitted a /ralph-loop slash command
-	// that didn't exist, causing the polecat to die immediately.
+func outputRalphLoopDirectiveWithPluginCheck(ctx RoleContext, attachment *beads.AttachmentFields, pluginInstalled bool) error {
+	if !pluginInstalled {
+		return fmt.Errorf("--ralph requires the ralph-loop plugin, which is not installed.\n" +
+			"Install it with: /plugin install ralph-loop@claude-plugins-official")
+	}
+
+	// Build the loop prompt from formula steps + attached args.
+	var sb strings.Builder
 	if attachment.AttachedFormula != "" {
-		showFormulaStepsFull(attachment.AttachedFormula, ctx.TownRoot, ctx.Rig, strings.Split(attachment.FormulaVars, "\n"))
-		fmt.Println()
+		sb.WriteString(renderFormulaStepsFull(attachment.AttachedFormula, ctx.TownRoot, ctx.Rig, strings.Split(attachment.FormulaVars, "\n")))
 	}
-
 	if attachment.AttachedArgs != "" {
-		fmt.Printf("%s\n", style.Bold.Render("Context:"))
-		fmt.Printf("  %s\n\n", attachment.AttachedArgs)
+		if sb.Len() > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString(attachment.AttachedArgs)
+		sb.WriteString("\n")
 	}
+	if sb.Len() == 0 {
+		sb.WriteString("Work through the assigned formula steps.\n")
+	}
+	sb.WriteString("\nWhen all steps are complete and `" + cli.Name() + " done` has been run successfully, output: <promise>DONE</promise>")
 
-	fmt.Printf("%s\n", style.Bold.Render("Iterative workflow:"))
-	fmt.Println("1. Work through the formula steps above")
-	fmt.Println("2. Commit after each meaningful change (preserve progress via git)")
-	fmt.Println("3. After completing a pass, evaluate results against acceptance criteria")
-	fmt.Println("4. If criteria not met, loop: identify the worst gap, fix it, commit, re-evaluate")
-	fmt.Println("5. When all criteria are met (or no further progress possible), run `" + cli.Name() + " done`")
-	fmt.Println()
-	fmt.Printf("%s\n", style.Bold.Render("Commit frequently. Each commit preserves your progress."))
+	// Emit the /ralph-loop slash command. Claude Code will invoke the plugin's
+	// setup script, which activates the stop-hook loop for this session.
+	fmt.Printf("/ralph-loop %s --completion-promise DONE\n", quoteForRalphLoop(sb.String()))
+	return nil
+}
+
+// isRalphLoopPluginInstalled reports whether the ralph-loop plugin is installed
+// in the user's Claude Code plugin registry (~/.claude/plugins/installed_plugins.json).
+func isRalphLoopPluginInstalled() bool {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	return ralphLoopPluginInstalledIn(home)
+}
+
+// ralphLoopPluginInstalledIn checks the installed_plugins.json under the given home directory.
+// Separated from isRalphLoopPluginInstalled to allow testing with a fake home directory.
+func ralphLoopPluginInstalledIn(home string) bool {
+	data, err := os.ReadFile(filepath.Join(home, ".claude", "plugins", "installed_plugins.json"))
+	if err != nil {
+		return false
+	}
+	var manifest struct {
+		Plugins map[string]json.RawMessage `json:"plugins"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return false
+	}
+	for key := range manifest.Plugins {
+		if strings.HasPrefix(key, "ralph-loop") {
+			return true
+		}
+	}
+	return false
+}
+
+// quoteForRalphLoop wraps s in double quotes, escaping internal double quotes
+// and backslashes so the shell receives s as a single argument.
+func quoteForRalphLoop(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	return `"` + s + `"`
 }
 
 // outputBeadPreview runs `bd show` and displays a truncated preview of the bead.

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -1039,11 +1039,13 @@ func ralphLoopPluginInstalledIn(home string) bool {
 	return false
 }
 
-// quoteForRalphLoop wraps s in double quotes, escaping internal double quotes
-// and backslashes so the shell receives s as a single argument.
+// quoteForRalphLoop wraps s in double quotes, escaping backslashes, double
+// quotes, and newlines so the /ralph-loop slash command receives s as a single
+// argument even when formula step descriptions span multiple lines.
 func quoteForRalphLoop(s string) string {
 	s = strings.ReplaceAll(s, `\`, `\\`)
 	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, "\n", `\n`)
 	return `"` + s + `"`
 }
 

--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -152,20 +152,26 @@ func showFormulaSteps(formulaName, label, townRoot, rigName string, extraVars ..
 // townRoot and rigName are used to load formula overlays (operator customizations).
 // extraVars is an optional list of "key=value" overrides substituted into step descriptions.
 func showFormulaStepsFull(formulaName, townRoot, rigName string, extraVars ...[]string) {
+	fmt.Print(renderFormulaStepsFull(formulaName, townRoot, rigName, extraVars...))
+}
+
+// renderFormulaStepsFull renders formula steps with full descriptions to a string.
+// It applies the same variable substitution and overlay logic as showFormulaStepsFull.
+func renderFormulaStepsFull(formulaName, townRoot, rigName string, extraVars ...[]string) string {
 	content, err := formula.ResolveFormulaContent(formulaName, townRoot, rigName)
 	if err != nil {
 		style.PrintWarning("could not load formula %s: %v", formulaName, err)
-		return
+		return ""
 	}
 
 	f, err := formula.Parse(content)
 	if err != nil {
 		style.PrintWarning("could not parse formula %s: %v", formulaName, err)
-		return
+		return ""
 	}
 
 	if len(f.Steps) == 0 {
-		return
+		return ""
 	}
 
 	// Apply formula overlays if townRoot is available.
@@ -177,16 +183,17 @@ func showFormulaStepsFull(formulaName, townRoot, rigName string, extraVars ...[]
 	}
 	varMap := buildFormulaVarMap(f, vars)
 
-	fmt.Println()
-	fmt.Printf("**Formula Checklist** (%d steps from %s):\n\n", len(f.Steps), formulaName)
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("\n**Formula Checklist** (%d steps from %s):\n\n", len(f.Steps), formulaName))
 	for i, step := range f.Steps {
 		title := applyFormulaVars(step.Title, varMap)
-		fmt.Printf("### Step %d: %s\n\n", i+1, title)
+		sb.WriteString(fmt.Sprintf("### Step %d: %s\n\n", i+1, title))
 		if step.Description != "" {
-			fmt.Println(applyFormulaVars(step.Description, varMap))
-			fmt.Println()
+			sb.WriteString(applyFormulaVars(step.Description, varMap))
+			sb.WriteString("\n\n")
 		}
 	}
+	return sb.String()
 }
 
 // buildFormulaVarMap builds a map of variable name → value for substitution.

--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -1108,6 +1108,23 @@ func TestRalphLoopPluginInstalledIn(t *testing.T) {
 	}
 }
 
+// TestQuoteForRalphLoop verifies that newlines and special characters are escaped.
+func TestQuoteForRalphLoop(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"simple", `"simple"`},
+		{"has\nnewline", `"has\nnewline"`},
+		{`has"quote`, `"has\"quote"`},
+		{`has\backslash`, `"has\\backslash"`},
+		{"multi\nline\nprompt", `"multi\nline\nprompt"`},
+	}
+	for _, c := range cases {
+		got := quoteForRalphLoop(c.in)
+		if got != c.want {
+			t.Errorf("quoteForRalphLoop(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
 func TestIsBeadNotFound(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -980,62 +980,131 @@ func TestEnsureBeadsRedirect_WitnessCreatesRedirect(t *testing.T) {
 	}
 }
 
-// TestOutputRalphLoopDirective_NoSlashCommand verifies that ralph mode emits
-// inline iterative work instructions instead of referencing a nonexistent
-// /ralph-loop slash command. This is the regression test for the ralph-loop
-// dies-on-spawn bug: polecats died immediately because Claude tried to run
-// /ralph-loop which didn't exist as a provisioned slash command.
-func TestOutputRalphLoopDirective_NoSlashCommand(t *testing.T) {
+// TestOutputRalphLoopDirective_PluginNotInstalled verifies that ralph mode
+// returns an error when the ralph-loop plugin is not installed, rather than
+// silently falling back to inline instructions that don't use the stop hook.
+func TestOutputRalphLoopDirective_PluginNotInstalled(t *testing.T) {
 	attachment := &beads.AttachmentFields{
 		Mode:         "ralph",
 		AttachedArgs: "Run story audit, fix worst gap, commit, loop",
 	}
-	output := captureStdout(t, func() {
-		outputRalphLoopDirective(RoleContext{}, attachment)
-	})
+	var output string
+	err := func() error {
+		output = captureStdout(t, func() {})
+		return outputRalphLoopDirectiveWithPluginCheck(RoleContext{}, attachment, false)
+	}()
 
-	// Must NOT reference /ralph-loop (nonexistent slash command)
+	if err == nil {
+		t.Fatal("expected error when ralph-loop plugin is not installed, got nil")
+	}
+	if !strings.Contains(err.Error(), "ralph-loop plugin") {
+		t.Fatalf("error should mention ralph-loop plugin, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), "/plugin install") {
+		t.Fatalf("error should include install instructions, got: %v", err)
+	}
+	// Must NOT emit /ralph-loop when plugin is absent
 	if strings.Contains(output, "/ralph-loop") {
-		t.Fatalf("ralph directive must NOT reference /ralph-loop (slash command doesn't exist), got:\n%s", output)
-	}
-
-	// Must contain iterative workflow instructions
-	if !strings.Contains(output, "RALPH LOOP MODE") {
-		t.Fatalf("expected 'RALPH LOOP MODE' header, got:\n%s", output)
-	}
-	if !strings.Contains(output, "gt done") {
-		t.Fatalf("expected 'gt done' instruction for completion, got:\n%s", output)
-	}
-	if !strings.Contains(output, "Commit frequently") {
-		t.Fatalf("expected commit guidance, got:\n%s", output)
-	}
-
-	// Must include the context/args
-	if !strings.Contains(output, "story audit") {
-		t.Fatalf("expected attached args in output, got:\n%s", output)
+		t.Fatalf("must not emit /ralph-loop when plugin is not installed, got:\n%s", output)
 	}
 }
 
-// TestOutputRalphLoopDirective_WithFormula verifies that ralph mode shows
-// formula steps inline (same as normal mode) when a formula is attached.
+// TestOutputRalphLoopDirective_PluginInstalled verifies that ralph mode emits
+// a /ralph-loop slash command when the plugin is installed.
+func TestOutputRalphLoopDirective_PluginInstalled(t *testing.T) {
+	attachment := &beads.AttachmentFields{
+		Mode:         "ralph",
+		AttachedArgs: "Run story audit, fix worst gap, commit, loop",
+	}
+	var err error
+	output := captureStdout(t, func() {
+		err = outputRalphLoopDirectiveWithPluginCheck(RoleContext{}, attachment, true)
+	})
+
+	if err != nil {
+		t.Fatalf("unexpected error when plugin is installed: %v", err)
+	}
+	// Must emit /ralph-loop to activate the stop-hook loop
+	if !strings.Contains(output, "/ralph-loop") {
+		t.Fatalf("expected /ralph-loop slash command in output, got:\n%s", output)
+	}
+	// Must include completion promise flag
+	if !strings.Contains(output, "--completion-promise") {
+		t.Fatalf("expected --completion-promise in /ralph-loop invocation, got:\n%s", output)
+	}
+	// Must embed the attached args in the prompt
+	if !strings.Contains(output, "story audit") {
+		t.Fatalf("expected attached args embedded in prompt, got:\n%s", output)
+	}
+	// Must include the gt done completion promise text
+	if !strings.Contains(output, "DONE") {
+		t.Fatalf("expected DONE completion promise, got:\n%s", output)
+	}
+}
+
+// TestOutputRalphLoopDirective_WithFormula verifies that ralph mode embeds
+// formula steps in the /ralph-loop prompt when a formula is attached.
 func TestOutputRalphLoopDirective_WithFormula(t *testing.T) {
 	attachment := &beads.AttachmentFields{
 		Mode:            "ralph",
 		AttachedFormula: "mol-polecat-work",
 		FormulaVars:     "base_branch=main",
 	}
+	var err error
 	output := captureStdout(t, func() {
-		outputRalphLoopDirective(RoleContext{}, attachment)
+		err = outputRalphLoopDirectiveWithPluginCheck(RoleContext{}, attachment, true)
 	})
 
-	// Should NOT reference /ralph-loop
-	if strings.Contains(output, "/ralph-loop") {
-		t.Fatalf("ralph directive must NOT reference /ralph-loop, got:\n%s", output)
+	if err != nil {
+		t.Fatalf("unexpected error when plugin is installed: %v", err)
+	}
+	// Must emit /ralph-loop
+	if !strings.Contains(output, "/ralph-loop") {
+		t.Fatalf("expected /ralph-loop slash command in output, got:\n%s", output)
+	}
+	// Formula steps must be embedded in the prompt
+	if !strings.Contains(output, "Formula Checklist") {
+		t.Fatalf("expected formula checklist embedded in ralph-loop prompt, got:\n%s", output)
+	}
+}
+
+// TestRalphLoopPluginInstalledIn verifies detection logic for the ralph-loop plugin.
+func TestRalphLoopPluginInstalledIn(t *testing.T) {
+	dir := t.TempDir()
+	pluginsDir := filepath.Join(dir, ".claude", "plugins")
+	if err := os.MkdirAll(pluginsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	pluginsFile := filepath.Join(pluginsDir, "installed_plugins.json")
+
+	writePluginsJSON := func(content string) {
+		t.Helper()
+		if err := os.WriteFile(pluginsFile, []byte(content), 0o644); err != nil {
+			t.Fatal(err)
+		}
 	}
 
-	// Should show formula steps (from mol-polecat-work)
-	if !strings.Contains(output, "Formula Checklist") {
-		t.Fatalf("expected formula checklist in ralph output, got:\n%s", output)
+	// No file → not installed.
+	if ralphLoopPluginInstalledIn(dir) {
+		t.Error("expected false when installed_plugins.json does not exist")
+	}
+
+	// Empty plugins map → not installed.
+	writePluginsJSON(`{"version":2,"plugins":{}}`)
+	if ralphLoopPluginInstalledIn(dir) {
+		t.Error("expected false when plugins map is empty")
+	}
+
+	// Different plugin → not installed.
+	writePluginsJSON(`{"version":2,"plugins":{"other-plugin@marketplace":{}}}`)
+	if ralphLoopPluginInstalledIn(dir) {
+		t.Error("expected false when only unrelated plugin is present")
+	}
+
+	// ralph-loop installed → true.
+	writePluginsJSON(`{"version":2,"plugins":{"ralph-loop@claude-plugins-official":{}}}`)
+	if !ralphLoopPluginInstalledIn(dir) {
+		t.Error("expected true when ralph-loop@claude-plugins-official is installed")
 	}
 }
 

--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -637,6 +637,9 @@ func runRigAdd(cmd *cobra.Command, args []string) error {
 	// Auto-assign a namepool theme that doesn't collide with other rigs (gas-21k).
 	autoAssignNamepoolTheme(townRoot, name, mgr)
 
+	// Ensure hooks-base.json exists before syncing (needed for gt hooks diff).
+	ensureHooksBase()
+
 	// Sync hooks for the new rig's targets
 	if err := syncRigHooks(townRoot, name); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: failed to sync hooks for new rig: %v\n", err)
@@ -1357,6 +1360,12 @@ func runRigAdopt(_ *cobra.Command, args []string) error {
 
 	// Auto-assign a namepool theme that doesn't collide with other rigs (gas-21k).
 	autoAssignNamepoolTheme(townRoot, name, mgr)
+
+	// Ensure hooks-base.json exists and sync hooks for the adopted rig.
+	ensureHooksBase()
+	if err := syncRigHooks(townRoot, name); err != nil {
+		fmt.Fprintf(os.Stderr, "Warning: failed to sync hooks for adopted rig: %v\n", err)
+	}
 
 	// Print results
 	fmt.Printf("\n%s Rig %s adopted\n", style.Success.Render("✓"), name)
@@ -2396,6 +2405,22 @@ func getRigOperationalState(townRoot, rigName string) (state string, source stri
 
 	// Default: operational
 	return "OPERATIONAL", "default"
+}
+
+// ensureHooksBase creates ~/.gt/hooks-base.json from current defaults if it
+// doesn't exist yet. Without this file, gt hooks diff has no reference point
+// and cannot detect drift when default hooks change after initial setup.
+// Non-fatal: missing base config is caught by gt doctor hooks-base-missing.
+func ensureHooksBase() {
+	if _, err := hooks.LoadBase(); err == nil {
+		return // already exists
+	}
+	base := hooks.DefaultBase()
+	if err := hooks.SaveBase(base); err != nil {
+		fmt.Fprintf(os.Stderr, "  Warning: could not create hooks-base.json: %v\n", err)
+		return
+	}
+	fmt.Printf("  Created hooks-base.json at %s\n", hooks.BasePath())
 }
 
 // syncRigHooks syncs hooks for a specific rig's targets after rig creation.

--- a/internal/cmd/rig_config.go
+++ b/internal/cmd/rig_config.go
@@ -195,6 +195,7 @@ func runRigConfigSet(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("setting %s: %w", key, err)
 		}
 		fmt.Printf("%s Set %s=%s in wisp layer for rig %s\n", style.Success.Render("✓"), key, value, rigName)
+		style.PrintWarning("this value is ephemeral and will not survive a rig reset — use --global to persist")
 	}
 
 	return nil

--- a/internal/cmd/rig_config.go
+++ b/internal/cmd/rig_config.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/wisp"
@@ -45,7 +46,7 @@ Example output:
   status              parked       wisp
   priority_adjustment 10           bead
   auto_restart        true         system
-  max_polecats        4            town`,
+  max_polecats        4            town   [deferred dispatch: ON — set scheduler.max_polecats=-1 to disable]`,
 	Args: cobra.ExactArgs(1),
 	RunE: runRigConfigShow,
 }
@@ -107,6 +108,13 @@ func runRigConfigShow(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Determine deferred dispatch state for the max_polecats annotation.
+	deferredDispatch := false
+	settingsPath := config.TownSettingsPath(townRoot)
+	if settings, loadErr := config.LoadOrCreateTownSettings(settingsPath); loadErr == nil && settings.Scheduler != nil {
+		deferredDispatch = settings.Scheduler.IsDeferred()
+	}
+
 	// Collect all known keys
 	allKeys := getConfigKeys(townRoot, r)
 
@@ -120,6 +128,9 @@ func runRigConfigShow(cmd *cobra.Command, args []string) error {
 			sourceStr := string(result.Source)
 			if result.Source == rig.SourceBlocked {
 				valueStr = "(blocked)"
+			}
+			if key == "max_polecats" {
+				sourceStr += "  " + maxPolecatsAnnotation(deferredDispatch)
 			}
 			fmt.Printf("%-25s %-15s %s\n", key, valueStr, sourceStr)
 		}
@@ -136,11 +147,22 @@ func runRigConfigShow(cmd *cobra.Command, args []string) error {
 			if result.Source == rig.SourceBlocked {
 				valueStr = "(blocked)"
 			}
+			if key == "max_polecats" {
+				valueStr += "  " + maxPolecatsAnnotation(deferredDispatch)
+			}
 			fmt.Printf("%-25s %s\n", key, valueStr)
 		}
 	}
 
 	return nil
+}
+
+// maxPolecatsAnnotation returns the deferred dispatch status annotation for max_polecats.
+func maxPolecatsAnnotation(deferredDispatch bool) string {
+	if deferredDispatch {
+		return "[deferred dispatch: ON — set scheduler.max_polecats=-1 to disable]"
+	}
+	return "[deferred dispatch: OFF]"
 }
 
 func runRigConfigSet(cmd *cobra.Command, args []string) error {

--- a/internal/cmd/rig_config_test.go
+++ b/internal/cmd/rig_config_test.go
@@ -1,0 +1,156 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/wisp"
+)
+
+// setupTestRigForConfig creates a minimal Gas Town workspace for rig config testing.
+// Returns townRoot and rigName.
+func setupTestRigForConfig(t *testing.T) (string, string) {
+	t.Helper()
+
+	townRoot := t.TempDir()
+	rigName := "testrig"
+
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+
+	townConfig := &config.TownConfig{
+		Type:      "town",
+		Version:   config.CurrentTownVersion,
+		Name:      "test-town",
+		CreatedAt: time.Now().Truncate(time.Second),
+	}
+	if err := config.SaveTownConfig(filepath.Join(mayorDir, "town.json"), townConfig); err != nil {
+		t.Fatalf("save town.json: %v", err)
+	}
+
+	rigsConfig := &config.RigsConfig{
+		Version: 1,
+		Rigs: map[string]config.RigEntry{
+			rigName: {
+				GitURL:  "git@github.com:test/testrig.git",
+				AddedAt: time.Now().Truncate(time.Second),
+			},
+		},
+	}
+	if err := config.SaveRigsConfig(filepath.Join(mayorDir, "rigs.json"), rigsConfig); err != nil {
+		t.Fatalf("save rigs.json: %v", err)
+	}
+
+	rigPath := filepath.Join(townRoot, rigName)
+	if err := os.MkdirAll(rigPath, 0755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+
+	rigConfig := config.NewRigConfig(rigName, "git@github.com:test/testrig.git")
+	if err := config.SaveRigConfig(filepath.Join(rigPath, "config.json"), rigConfig); err != nil {
+		t.Fatalf("save rig config: %v", err)
+	}
+
+	oldCwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("get cwd: %v", err)
+	}
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("chdir to town root: %v", err)
+	}
+	t.Cleanup(func() { os.Chdir(oldCwd) })
+
+	return townRoot, rigName
+}
+
+func TestRigConfigSet_WispLayerWarning(t *testing.T) {
+	t.Run("warns about ephemeral when writing to wisp layer", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForConfig(t)
+
+		rigConfigSetGlobal = false
+		rigConfigSetBlock = false
+
+		stderrOut := captureStderr(t, func() {
+			err := runRigConfigSet(rigConfigSetCmd, []string{rigName, "max_polecats", "5"})
+			if err != nil {
+				t.Fatalf("runRigConfigSet: %v", err)
+			}
+		})
+
+		if !strings.Contains(stderrOut, "ephemeral") {
+			t.Errorf("expected ephemeral warning on stderr, got: %q", stderrOut)
+		}
+		if !strings.Contains(stderrOut, "--global") {
+			t.Errorf("expected --global hint on stderr, got: %q", stderrOut)
+		}
+
+		// Verify value was actually stored in wisp layer
+		wispCfg := wisp.NewConfig(townRoot, rigName)
+		val := wispCfg.Get("max_polecats")
+		if val == nil {
+			t.Error("expected max_polecats to be set in wisp layer")
+		}
+	})
+
+	t.Run("warns for string values in wisp layer", func(t *testing.T) {
+		_, rigName := setupTestRigForConfig(t)
+
+		rigConfigSetGlobal = false
+		rigConfigSetBlock = false
+
+		stderrOut := captureStderr(t, func() {
+			err := runRigConfigSet(rigConfigSetCmd, []string{rigName, "default_formula", "mol-custom"})
+			if err != nil {
+				t.Fatalf("runRigConfigSet: %v", err)
+			}
+		})
+
+		if !strings.Contains(stderrOut, "ephemeral") {
+			t.Errorf("expected ephemeral warning on stderr for string value, got: %q", stderrOut)
+		}
+	})
+
+	t.Run("warns for boolean values in wisp layer", func(t *testing.T) {
+		_, rigName := setupTestRigForConfig(t)
+
+		rigConfigSetGlobal = false
+		rigConfigSetBlock = false
+
+		stderrOut := captureStderr(t, func() {
+			err := runRigConfigSet(rigConfigSetCmd, []string{rigName, "auto_restart", "false"})
+			if err != nil {
+				t.Fatalf("runRigConfigSet: %v", err)
+			}
+		})
+
+		if !strings.Contains(stderrOut, "ephemeral") {
+			t.Errorf("expected ephemeral warning on stderr for boolean value, got: %q", stderrOut)
+		}
+	})
+
+	t.Run("no ephemeral warning when using --block flag", func(t *testing.T) {
+		_, rigName := setupTestRigForConfig(t)
+
+		rigConfigSetGlobal = false
+		rigConfigSetBlock = true
+		t.Cleanup(func() { rigConfigSetBlock = false })
+
+		stderrOut := captureStderr(t, func() {
+			err := runRigConfigSet(rigConfigSetCmd, []string{rigName, "auto_restart"})
+			if err != nil {
+				t.Fatalf("runRigConfigSet with --block: %v", err)
+			}
+		})
+
+		// --block also writes to wisp but has different UX semantics; no ephemeral warning expected
+		if strings.Contains(stderrOut, "ephemeral") {
+			t.Errorf("unexpected ephemeral warning for --block operation, got: %q", stderrOut)
+		}
+	})
+}

--- a/internal/cmd/rig_config_test.go
+++ b/internal/cmd/rig_config_test.go
@@ -8,6 +8,7 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/scheduler/capacity"
 	"github.com/steveyegge/gastown/internal/wisp"
 )
 
@@ -67,6 +68,84 @@ func setupTestRigForConfig(t *testing.T) (string, string) {
 	t.Cleanup(func() { os.Chdir(oldCwd) })
 
 	return townRoot, rigName
+}
+
+func TestRigConfigShow_MaxPolecatsAnnotation(t *testing.T) {
+	t.Run("shows deferred dispatch OFF when no scheduler config", func(t *testing.T) {
+		_, rigName := setupTestRigForConfig(t)
+
+		rigConfigShowLayers = false
+		t.Cleanup(func() { rigConfigShowLayers = false })
+
+		out := captureStdout(t, func() {
+			err := runRigConfigShow(rigConfigShowCmd, []string{rigName})
+			if err != nil {
+				t.Fatalf("runRigConfigShow: %v", err)
+			}
+		})
+
+		if !strings.Contains(out, "max_polecats") {
+			t.Fatalf("expected max_polecats in output, got: %q", out)
+		}
+		if !strings.Contains(out, "deferred dispatch: OFF") {
+			t.Errorf("expected 'deferred dispatch: OFF' annotation, got:\n%s", out)
+		}
+	})
+
+	t.Run("shows deferred dispatch ON when scheduler.max_polecats > 0", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForConfig(t)
+
+		maxPol := 5
+		settings := config.NewTownSettings()
+		settings.Scheduler = &capacity.SchedulerConfig{MaxPolecats: &maxPol}
+		settingsPath := config.TownSettingsPath(townRoot)
+		if err := config.SaveTownSettings(settingsPath, settings); err != nil {
+			t.Fatalf("saving town settings: %v", err)
+		}
+
+		rigConfigShowLayers = false
+		t.Cleanup(func() { rigConfigShowLayers = false })
+
+		out := captureStdout(t, func() {
+			err := runRigConfigShow(rigConfigShowCmd, []string{rigName})
+			if err != nil {
+				t.Fatalf("runRigConfigShow: %v", err)
+			}
+		})
+
+		if !strings.Contains(out, "deferred dispatch: ON") {
+			t.Errorf("expected 'deferred dispatch: ON' annotation, got:\n%s", out)
+		}
+		if !strings.Contains(out, "scheduler.max_polecats=-1") {
+			t.Errorf("expected disable hint in annotation, got:\n%s", out)
+		}
+	})
+
+	t.Run("annotation appears in --layers output", func(t *testing.T) {
+		townRoot, rigName := setupTestRigForConfig(t)
+
+		maxPol := 3
+		settings := config.NewTownSettings()
+		settings.Scheduler = &capacity.SchedulerConfig{MaxPolecats: &maxPol}
+		settingsPath := config.TownSettingsPath(townRoot)
+		if err := config.SaveTownSettings(settingsPath, settings); err != nil {
+			t.Fatalf("saving town settings: %v", err)
+		}
+
+		rigConfigShowLayers = true
+		t.Cleanup(func() { rigConfigShowLayers = false })
+
+		out := captureStdout(t, func() {
+			err := runRigConfigShow(rigConfigShowCmd, []string{rigName})
+			if err != nil {
+				t.Fatalf("runRigConfigShow: %v", err)
+			}
+		})
+
+		if !strings.Contains(out, "deferred dispatch: ON") {
+			t.Errorf("expected 'deferred dispatch: ON' in --layers output, got:\n%s", out)
+		}
+	})
 }
 
 func TestRigConfigSet_WispLayerWarning(t *testing.T) {

--- a/internal/cmd/rig_helpers.go
+++ b/internal/cmd/rig_helpers.go
@@ -125,6 +125,14 @@ func IsRigParkedOrDocked(townRoot, rigName string) (bool, string) {
 		beadsPath = rigPath
 	}
 
+	// Skip bead lookup if prefix has no registered route. On installs where the
+	// gastown infrastructure rig is not registered at the expected path, the
+	// "gt-" prefix has no route entry, and Show() would emit a routing warning
+	// once per convoy leg. The wisp check above already covers parked state.
+	if beads.GetRigPathForPrefix(townRoot, prefix+"-") == "" {
+		return false, ""
+	}
+
 	bd := beads.New(beadsPath)
 	rigBeadID := beads.RigBeadIDWithPrefix(prefix, rigName)
 	rigBead, err := bd.Show(rigBeadID)

--- a/internal/cmd/rig_helpers_route_test.go
+++ b/internal/cmd/rig_helpers_route_test.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/config"
+)
+
+// TestIsRigParkedOrDocked_NoRouteForPrefix verifies that IsRigParkedOrDocked
+// returns (false, "") without emitting routing warnings when the rig's beads
+// prefix has no entry in routes.jsonl. This is the regression test for
+// https://github.com/gastownhall/gastown/issues/3855.
+func TestIsRigParkedOrDocked_NoRouteForPrefix(t *testing.T) {
+	townRoot := t.TempDir()
+	rigName := "myproject"
+
+	// Set up rig directory with config.json using the default "gt" prefix.
+	// This simulates a project rig at a non-standard install where the gastown
+	// infrastructure rig (which owns the "gt-" prefix route) is not registered.
+	rigPath := filepath.Join(townRoot, rigName)
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig path: %v", err)
+	}
+	rigCfg := &config.RigConfig{
+		Type:    "rig",
+		Version: config.CurrentRigConfigVersion,
+		Name:    rigName,
+		GitURL:  "git@github.com:example/myproject.git",
+		Beads:   &config.BeadsConfig{Prefix: "gt"},
+	}
+	if err := config.SaveRigConfig(filepath.Join(rigPath, "config.json"), rigCfg); err != nil {
+		t.Fatalf("save rig config: %v", err)
+	}
+
+	// Create .beads directory without any routes.jsonl — gastown infra rig
+	// is not registered at this install (the scenario from issue #3855).
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	blocked, reason := IsRigParkedOrDocked(townRoot, rigName)
+	if blocked {
+		t.Errorf("IsRigParkedOrDocked = (%v, %q), want (false, \"\")", blocked, reason)
+	}
+	if reason != "" {
+		t.Errorf("IsRigParkedOrDocked returned unexpected reason %q, want \"\"", reason)
+	}
+}
+
+// TestIsRigParkedOrDocked_WithRoute_ProceedsToBead verifies that when a route
+// IS registered for the rig's prefix, the bead lookup proceeds normally. The
+// route guard must not prevent the docked/parked check when routing is valid.
+func TestIsRigParkedOrDocked_WithRoute_ProceedsToBead(t *testing.T) {
+	townRoot := t.TempDir()
+	rigName := "myproject"
+
+	rigPath := filepath.Join(townRoot, rigName)
+	if err := os.MkdirAll(rigPath, 0o755); err != nil {
+		t.Fatalf("mkdir rig path: %v", err)
+	}
+	rigCfg := &config.RigConfig{
+		Type:    "rig",
+		Version: config.CurrentRigConfigVersion,
+		Name:    rigName,
+		GitURL:  "git@github.com:example/myproject.git",
+		Beads:   &config.BeadsConfig{Prefix: "gt"},
+	}
+	if err := config.SaveRigConfig(filepath.Join(rigPath, "config.json"), rigCfg); err != nil {
+		t.Fatalf("save rig config: %v", err)
+	}
+
+	// Register a "gt-" route pointing at the rig directory (no real bead DB needed;
+	// bd.Show will fail gracefully and return (false, "")).
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	routes := `{"prefix":"gt-","path":"myproject"}` + "\n"
+	if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), []byte(routes), 0o644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	// With a valid route the code proceeds to bd.Show, which will fail (no Dolt
+	// running in tests) and return (false, "") — same observable result, but the
+	// code path past the route guard is exercised.
+	blocked, reason := IsRigParkedOrDocked(townRoot, rigName)
+	if blocked {
+		t.Errorf("IsRigParkedOrDocked = (%v, %q), want (false, \"\")", blocked, reason)
+	}
+	if reason != "" {
+		t.Errorf("IsRigParkedOrDocked returned unexpected reason %q, want \"\"", reason)
+	}
+}

--- a/internal/cmd/rig_integration_test.go
+++ b/internal/cmd/rig_integration_test.go
@@ -278,6 +278,8 @@ done
 
 case "$cmd" in
   init)
+    # Log init args for verification
+    echo "init $@" >> "$LOG_FILE"
     # Create .beads directory and config.yaml
     mkdir -p .beads
     prefix="gt"
@@ -1451,4 +1453,110 @@ func checkWorktreeClean(t *testing.T, agent agentWorktree, hasTrackedBeads bool)
 	}
 
 	return unexpectedFiles
+}
+
+// createTestGitRepoWithSyncRemote creates a test git repo with .beads/config.yaml
+// committed and containing a sync.remote entry, simulating a repo like gastown
+// that has upstream sync configured. Returns the repo path (usable as a file:// URL).
+func createTestGitRepoWithSyncRemote(t *testing.T, name, prefix, syncRemote string) string {
+	t.Helper()
+
+	repoDir := filepath.Join(t.TempDir(), name)
+	if err := os.MkdirAll(repoDir, 0755); err != nil {
+		t.Fatalf("mkdir repo: %v", err)
+	}
+
+	cmds := [][]string{
+		{"git", "init", "--initial-branch=main"},
+		{"git", "config", "user.email", "test@test.com"},
+		{"git", "config", "user.name", "Test User"},
+	}
+	for _, args := range cmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = repoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	readmePath := filepath.Join(repoDir, "README.md")
+	if err := os.WriteFile(readmePath, []byte("# Test Repo\n"), 0644); err != nil {
+		t.Fatalf("write README: %v", err)
+	}
+
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	configContent := "prefix: " + prefix + "\nsync.remote: \"" + syncRemote + "\"\n"
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte(configContent), 0644); err != nil {
+		t.Fatalf("write .beads/config.yaml: %v", err)
+	}
+
+	commitCmds := [][]string{
+		{"git", "add", "."},
+		{"git", "commit", "-m", "Initial commit with beads config"},
+	}
+	for _, args := range commitCmds {
+		cmd := exec.Command(args[0], args[1:]...)
+		cmd.Dir = repoDir
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("git %v: %v\n%s", args, err, out)
+		}
+	}
+
+	return repoDir
+}
+
+// TestRigAddWithSyncRemotePassesReinitFlags verifies that when a source repo has
+// .beads/config.yaml with sync.remote configured, gt rig add passes --reinit-local
+// --discard-remote --destroy-token to bd init instead of hanging on the interactive
+// remote divergence safety check (GH #3873).
+func TestRigAddWithSyncRemotePassesReinitFlags(t *testing.T) {
+	requireDoltServer(t)
+	bdLogPath := mockBdCommand(t)
+	townRoot := setupTestTown(t)
+	bridgeDoltPidToTown(t, townRoot)
+
+	const prefix = "gt"
+	const syncRemote = "git+https://github.com/steveyegge/gastown.git"
+	gitURL := createTestGitRepoWithSyncRemote(t, "synctest", prefix, syncRemote)
+
+	rigsPath := filepath.Join(townRoot, "mayor", "rigs.json")
+	rigsConfig, err := config.LoadRigsConfig(rigsPath)
+	if err != nil {
+		t.Fatalf("load rigs.json: %v", err)
+	}
+
+	g := git.NewGit(townRoot)
+	mgr := rig.NewManager(townRoot, rigsConfig, g)
+
+	_, err = mgr.AddRig(rig.AddRigOptions{
+		Name:        "synctest",
+		GitURL:      gitURL,
+		BeadsPrefix: prefix,
+	})
+	if err != nil {
+		t.Fatalf("AddRig: %v", err)
+	}
+
+	logContent, err := os.ReadFile(bdLogPath)
+	if err != nil {
+		t.Fatalf("reading bd log: %v", err)
+	}
+	log := string(logContent)
+
+	// bd init should have been called with the reinit flags so it doesn't
+	// block on an interactive remote divergence check with stdin=/dev/null.
+	for _, flag := range []string{"--reinit-local", "--discard-remote", "--destroy-token"} {
+		if !strings.Contains(log, flag) {
+			t.Errorf("bd init should be called with %s when sync.remote is present; log:\n%s", flag, log)
+		}
+	}
+
+	// Verify the destroy token has the correct format: DESTROY-<prefix>
+	expectedToken := "DESTROY-" + prefix
+	if !strings.Contains(log, expectedToken) {
+		t.Errorf("bd init should be called with destroy token %q; log:\n%s", expectedToken, log)
+	}
 }

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -446,7 +446,10 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 			}
 			if verifyBeadExists(args[0]) != nil {
 				if verifyFormulaExists(args[0]) == nil {
-					return fmt.Errorf("standalone formula cannot be scheduled (use --on <bead>)")
+					// Standalone formula slinging (cook+wisp+attach) is not bead-based
+					// dispatch and does not consume a scheduler slot — fall through to
+					// runSlingFormula, which handles polecat spawning via resolveTarget.
+					return runSlingFormula(ctx, args)
 				}
 			}
 			beadID := args[0]
@@ -574,8 +577,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 			// Not a verified bead - try as standalone formula
 			if err := verifyFormulaExists(firstArg); err == nil {
 				// Standalone formula mode: gt sling <formula> [target]
-				// Standalone formula: deferred dispatch is handled above (formula-on-bead),
-				// so no scheduler check needed here.
+				// Deferred dispatch is handled above for the 2-arg rig case (gh#3917).
 				return runSlingFormula(ctx, args)
 			}
 			// Not a formula either - check if it looks like a bead ID (routing issue workaround).

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -2788,3 +2788,125 @@ func TestRunSlingResumeFlagValidation(t *testing.T) {
 		})
 	}
 }
+
+// TestSlingStandaloneFormulaInDeferredMode is a regression test for gh#3917.
+//
+// When scheduler.max_polecats > 0 (deferred dispatch mode), `gt sling <formula> <rig>`
+// was rejected with "standalone formula cannot be scheduled (use --on <bead>)" even
+// though the help text and documented examples explicitly show this usage.
+//
+// Fix: fall through to runSlingFormula instead of erroring. Standalone formula
+// slinging (cook+wisp+attach) is not bead-based capacity-scheduled dispatch.
+func TestSlingStandaloneFormulaInDeferredMode(t *testing.T) {
+	townRoot := t.TempDir()
+
+	// Workspace marker: workspace.FindFromCwdOrError needs mayor/town.json
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorDir, "town.json"), []byte(`{"name":"test","version":2}`), 0644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+
+	// Rig registry: IsRigName("testrig") requires testrig in rigs.json
+	rigsJSON := `{"version":1,"rigs":{"testrig":{"git_url":"file:///dev/null"}}}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(rigsJSON), 0644); err != nil {
+		t.Fatalf("write rigs.json: %v", err)
+	}
+
+	// Town settings: scheduler.max_polecats > 0 activates deferred dispatch
+	settingsDir := filepath.Join(townRoot, "settings")
+	if err := os.MkdirAll(settingsDir, 0755); err != nil {
+		t.Fatalf("mkdir settings: %v", err)
+	}
+	settingsJSON := `{"version":1,"scheduler":{"max_polecats":10,"batch_size":3}}`
+	settingsPath := config.TownSettingsPath(townRoot)
+	if err := os.WriteFile(settingsPath, []byte(settingsJSON), 0644); err != nil {
+		t.Fatalf("write settings: %v", err)
+	}
+
+	// .beads routes
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	routes := `{"prefix":"gt-","path":"testrig/mayor/rig"}` + "\n" + `{"prefix":"hq-","path":"."}` + "\n"
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	// Stub bd: formula show must return output so verifyFormulaExists returns nil
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	bdScript := `#!/bin/sh
+cmd="$1"
+shift || true
+case "$cmd" in
+  formula) echo '{"name":"mol-test-formula"}'; exit 0 ;;
+  show)    echo '[{"title":"Test","status":"open","assignee":"","description":""}]' ;;
+  cook)    exit 0 ;;
+  mol)
+    sub="$1"; shift || true
+    case "$sub" in
+      wisp) echo '{"new_epic_id":"gt-wisp-xyz"}' ;;
+    esac ;;
+esac
+exit 0
+`
+	bdScriptWindows := `@echo off
+set "cmd=%1"
+if "%cmd%"=="formula" ( echo {"name":"mol-test-formula"} & exit /b 0 )
+if "%cmd%"=="show" ( echo [{"title":"Test","status":"open","assignee":"","description":""}] & exit /b 0 )
+if "%cmd%"=="cook" exit /b 0
+if "%cmd%"=="mol" if "%2"=="wisp" ( echo {"new_epic_id":"gt-wisp-xyz"} & exit /b 0 )
+exit /b 0
+`
+	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// chdir into the town so workspace.FindFromCwd() resolves townRoot
+	rigDir := filepath.Join(townRoot, "mayor", "rig")
+	if err := os.MkdirAll(rigDir, 0755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(rigDir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	t.Setenv(EnvGTRole, "mayor")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("GT_CREW", "")
+	t.Setenv("TMUX_PANE", "")
+	t.Setenv("GT_TEST_NO_NUDGE", "1")
+	t.Setenv("GT_TEST_SKIP_HOOK_VERIFY", "1")
+
+	// Save and restore global sling state
+	prevDryRun := slingDryRun
+	prevNoConvoy := slingNoConvoy
+	prevVars := slingVars
+	prevOnTarget := slingOnTarget
+	t.Cleanup(func() {
+		slingDryRun = prevDryRun
+		slingNoConvoy = prevNoConvoy
+		slingVars = prevVars
+		slingOnTarget = prevOnTarget
+	})
+	slingDryRun = true // avoid real polecat spawning
+	slingNoConvoy = true
+	slingVars = nil
+	slingOnTarget = ""
+
+	// Regression: before the fix, this returned "standalone formula cannot be scheduled".
+	err = runSling(nil, []string{"mol-test-formula", "testrig"})
+	if err != nil && strings.Contains(err.Error(), "standalone formula cannot be scheduled") {
+		t.Fatalf("gh#3917 regression: standalone formula rejected in deferred mode: %v", err)
+	}
+	// Any other error (e.g., no polecat to spawn) is acceptable — the guard is what we're testing.
+}

--- a/internal/doctor/claude_settings_check.go
+++ b/internal/doctor/claude_settings_check.go
@@ -521,6 +521,27 @@ func (c *ClaudeSettingsCheck) findSettingsFiles(townRoot string) []staleSettings
 				}
 			}
 		}
+
+		// Check for STALE rig-root settings (<rig>/.claude/settings.json).
+		// Legacy pattern predating the per-role architecture. Superseded by
+		// per-role files (witness/.claude/, polecats/.claude/, etc.).
+		// Skip if tracked in a customer repo — could be intentional.
+		for _, staleFile := range []string{"settings.json", "settings.local.json"} {
+			rigRootSettings := filepath.Join(rigPath, ".claude", staleFile)
+			if fileExists(rigRootSettings) {
+				gs := c.getGitFileStatus(rigRootSettings)
+				if gs != gitStatusTrackedClean && gs != gitStatusTrackedModified {
+					files = append(files, staleSettingsInfo{
+						path:          rigRootSettings,
+						agentType:     "rig-root",
+						rigName:       rigName,
+						wrongLocation: true,
+						gitStatus:     gs,
+						missing:       []string{"legacy rig-root settings (superseded by per-role files)"},
+					})
+				}
+			}
+		}
 	}
 
 	return files
@@ -714,6 +735,13 @@ func (c *ClaudeSettingsCheck) Fix(ctx *CheckContext) error {
 		// settings before the fix does (gt-99u).
 		if sf.wrongLocation {
 			_ = os.Remove(claudeDir) // Best-effort, will fail if not empty
+		}
+
+		// Rig-root settings: just delete. Per-role files are authoritative.
+		// There is no correct "rig-root" settings location to recreate at.
+		if sf.agentType == "rig-root" {
+			fmt.Printf("\n  %s Rig-root settings removed. Per-role settings in %s/{witness,polecats,...}/.claude/ are authoritative.\n", style.Warning.Render("⚠"), sf.rigName)
+			continue
 		}
 
 		// Handle town-root files: redirect to mayor/ instead of recreating at root.

--- a/internal/doctor/claude_settings_check_test.go
+++ b/internal/doctor/claude_settings_check_test.go
@@ -985,6 +985,72 @@ func TestClaudeSettingsCheck_FixPreservesTrackedCleanFiles(t *testing.T) {
 	}
 }
 
+func TestClaudeSettingsCheck_RigRootSettingsFlagged(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+
+	// Create a rig with witness so it's recognised as a rig
+	if err := os.MkdirAll(filepath.Join(tmpDir, rigName, "witness"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create a rig-root settings.json (legacy pattern)
+	rigRootSettings := filepath.Join(tmpDir, rigName, ".claude", "settings.json")
+	createValidSettings(t, rigRootSettings)
+
+	check := NewClaudeSettingsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+	if result.Status == StatusOK {
+		t.Fatal("expected non-OK result when rig-root settings.json exists")
+	}
+
+	foundRigRoot := false
+	for _, sf := range check.staleSettings {
+		if sf.agentType == "rig-root" && sf.path == rigRootSettings {
+			foundRigRoot = true
+			if !sf.wrongLocation {
+				t.Error("expected wrongLocation=true for rig-root settings")
+			}
+		}
+	}
+	if !foundRigRoot {
+		t.Errorf("expected rig-root stale entry for %s", rigRootSettings)
+	}
+}
+
+func TestClaudeSettingsCheck_RigRootSettingsFixDeletes(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+
+	// Create a rig with witness so it's recognised as a rig
+	if err := os.MkdirAll(filepath.Join(tmpDir, rigName, "witness"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create rig-root settings.json
+	rigRootSettings := filepath.Join(tmpDir, rigName, ".claude", "settings.json")
+	createValidSettings(t, rigRootSettings)
+
+	check := NewClaudeSettingsCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	result := check.Run(ctx)
+	if result.Status == StatusOK {
+		t.Fatal("expected non-OK result before fix")
+	}
+
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+
+	// Rig-root settings.json should be deleted
+	if _, err := os.Stat(rigRootSettings); !os.IsNotExist(err) {
+		t.Error("expected rig-root settings.json to be deleted by Fix")
+	}
+}
+
 // NOTE: TestClaudeSettingsCheck_DetectsStaleCLAUDEmdAtTownRoot and
 // TestClaudeSettingsCheck_FixMovesCLAUDEmdToMayor were removed because
 // CLAUDE.md at town root is now intentionally created by gt install.

--- a/internal/doctor/hooks_base_check.go
+++ b/internal/doctor/hooks_base_check.go
@@ -1,0 +1,67 @@
+package doctor
+
+import (
+	"fmt"
+
+	"github.com/steveyegge/gastown/internal/hooks"
+)
+
+// HooksBaseCheck warns when ~/.gt/hooks-base.json is missing.
+// Without this file, gt hooks diff has no reference point and cannot detect
+// drift when gt's default hook configuration changes after initial setup.
+type HooksBaseCheck struct {
+	FixableCheck
+}
+
+// NewHooksBaseCheck creates a new hooks base config check.
+func NewHooksBaseCheck() *HooksBaseCheck {
+	return &HooksBaseCheck{
+		FixableCheck: FixableCheck{
+			BaseCheck: BaseCheck{
+				CheckName:        "hooks-base-missing",
+				CheckDescription: "Check that ~/.gt/hooks-base.json exists for drift detection",
+				CheckCategory:    CategoryHooks,
+			},
+		},
+	}
+}
+
+// Run checks whether hooks-base.json exists.
+func (c *HooksBaseCheck) Run(ctx *CheckContext) *CheckResult {
+	if _, err := hooks.LoadBase(); err == nil {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: fmt.Sprintf("hooks-base.json present at %s", hooks.BasePath()),
+		}
+	}
+
+	return &CheckResult{
+		Name:    c.Name(),
+		Status:  StatusWarning,
+		Message: "hooks-base.json is missing — gt hooks diff cannot detect drift",
+		Details: []string{
+			fmt.Sprintf("Expected at: %s", hooks.BasePath()),
+			"Without this file, hooks sync works but drift detection is unavailable.",
+		},
+		FixHint: "Run 'gt doctor --fix hooks-base-missing' or 'gt hooks base --show' to create it",
+	}
+}
+
+// Fix creates hooks-base.json from current defaults.
+func (c *HooksBaseCheck) Fix(ctx *CheckContext) error {
+	if _, err := hooks.LoadBase(); err == nil {
+		return nil // already exists
+	}
+	base := hooks.DefaultBase()
+	if err := hooks.SaveBase(base); err != nil {
+		return fmt.Errorf("creating hooks-base.json: %w", err)
+	}
+	fmt.Printf("  Created hooks-base.json at %s\n", hooks.BasePath())
+	return nil
+}
+
+// CanFix returns true — we can auto-create the file.
+func (c *HooksBaseCheck) CanFix() bool {
+	return true
+}

--- a/internal/doctor/hooks_base_check_test.go
+++ b/internal/doctor/hooks_base_check_test.go
@@ -1,0 +1,87 @@
+package doctor
+
+import (
+	"os"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/hooks"
+)
+
+func TestHooksBaseCheck_Missing(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	check := NewHooksBaseCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Errorf("expected StatusWarning when hooks-base.json is missing, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestHooksBaseCheck_Present(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Create a base config
+	if err := hooks.SaveBase(hooks.DefaultBase()); err != nil {
+		t.Fatalf("SaveBase: %v", err)
+	}
+
+	check := NewHooksBaseCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+	result := check.Run(ctx)
+
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when hooks-base.json exists, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestHooksBaseCheck_Fix(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	check := NewHooksBaseCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	// Should warn before fix
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning before fix, got %v", result.Status)
+	}
+
+	// Fix should create the file
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix: %v", err)
+	}
+
+	// Verify file was created
+	if _, err := os.Stat(hooks.BasePath()); err != nil {
+		t.Errorf("hooks-base.json not created after Fix: %v", err)
+	}
+
+	// Should now pass
+	result = check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK after fix, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestHooksBaseCheck_FixIdempotent(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	// Pre-create the base config
+	if err := hooks.SaveBase(hooks.DefaultBase()); err != nil {
+		t.Fatalf("SaveBase: %v", err)
+	}
+
+	check := NewHooksBaseCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+
+	// Fix on already-present file should be a no-op
+	if err := check.Fix(ctx); err != nil {
+		t.Errorf("Fix on existing base should not error: %v", err)
+	}
+}

--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -105,9 +105,15 @@ Abbreviated patrol rules:
 
 When `await-event` outputs `EFFORT: full`, run all steps thoroughly (normal mode).
 
+When `await-event` outputs `EFFORT: handoff`, the context window is near its limit.
+Do NOT run patrol steps. Handoff immediately:
+```bash
+gt handoff -s "Refinery patrol - context limit" -m "Context window near limit, cycling for fresh session."
+```
+
 The goal: idle cycles should burn ~10% of the tokens a full patrol uses."""
 formula = "mol-refinery-patrol"
-version = 14
+version = 15
 
 [vars]
 [vars.wisp_type]
@@ -1178,6 +1184,12 @@ After await-event returns, check the EFFORT directive in the output:
 
 Abbreviated patrol should complete in ~10% of the tokens of a full patrol.
 Mark skipped steps as SKIP in the patrol report.
+
+**If `EFFORT: handoff`** — Context window near limit. Do NOT run patrol steps.
+Handoff immediately for a fresh session:
+```bash
+gt handoff -s "Refinery patrol - context limit" -m "Context window near limit, cycling for fresh session."
+```
 
 After await-event returns (either by event or timeout):
 1. **Re-assess session health** (check RSS, context, age again — conditions change)

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -418,6 +418,19 @@ func DiscoverTargets(townRoot string) ([]Target, error) {
 		Role: "deacon",
 	})
 
+	// Boot watchdog — ephemeral Claude agent in deacon/dogs/boot/.
+	// Only added when the directory exists (gitignored and optional).
+	// Adding it here ensures HooksSyncCheck manages the file and Fix() preserves
+	// custom fields (e.g. model) via the LoadSettings → MarshalSettings round-trip.
+	bootDir := filepath.Join(townRoot, "deacon", "dogs", "boot")
+	if info, err := os.Stat(bootDir); err == nil && info.IsDir() {
+		targets = append(targets, Target{
+			Path: filepath.Join(bootDir, ".claude", "settings.json"),
+			Key:  "boot",
+			Role: "boot",
+		})
+	}
+
 	// Scan rigs
 	entries, err := os.ReadDir(townRoot)
 	if err != nil {

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -913,6 +913,54 @@ func TestDiscoverTargets_ReturnsOnlyClaude(t *testing.T) {
 	}
 }
 
+func TestDiscoverTargets_BootIncluded(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	os.MkdirAll(filepath.Join(tmpDir, "mayor"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "deacon", "dogs", "boot"), 0755)
+
+	targets, err := DiscoverTargets(tmpDir)
+	if err != nil {
+		t.Fatalf("DiscoverTargets failed: %v", err)
+	}
+
+	found := false
+	for _, tgt := range targets {
+		if tgt.Key == "boot" {
+			found = true
+			wantPath := filepath.Join(tmpDir, "deacon", "dogs", "boot", ".claude", "settings.json")
+			if tgt.Path != wantPath {
+				t.Errorf("boot target Path = %q, want %q", tgt.Path, wantPath)
+			}
+			if tgt.Role != "boot" {
+				t.Errorf("boot target Role = %q, want %q", tgt.Role, "boot")
+			}
+		}
+	}
+	if !found {
+		t.Error("expected boot target when deacon/dogs/boot/ exists, not found")
+	}
+}
+
+func TestDiscoverTargets_BootAbsent(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	os.MkdirAll(filepath.Join(tmpDir, "mayor"), 0755)
+	os.MkdirAll(filepath.Join(tmpDir, "deacon"), 0755)
+	// No deacon/dogs/boot directory
+
+	targets, err := DiscoverTargets(tmpDir)
+	if err != nil {
+		t.Fatalf("DiscoverTargets failed: %v", err)
+	}
+
+	for _, tgt := range targets {
+		if tgt.Key == "boot" {
+			t.Errorf("expected no boot target when deacon/dogs/boot/ absent, got one: %+v", tgt)
+		}
+	}
+}
+
 func TestDiscoverRoleLocations(t *testing.T) {
 	tmpDir := t.TempDir()
 

--- a/internal/protocol/protocol_test.go
+++ b/internal/protocol/protocol_test.go
@@ -587,7 +587,13 @@ func TestWrapRefineryHandlers_InvalidPayload(t *testing.T) {
 
 func TestDefaultWitnessHandler(t *testing.T) {
 	tmpDir := t.TempDir()
+	// Prevent detectTownRoot from finding the real town via GT_TOWN_ROOT/GT_ROOT.
+	// Without this, NewRouter falls back to the production beads and delivers
+	// synthetic protocol messages to the live mail system during test runs.
+	t.Setenv("GT_TOWN_ROOT", tmpDir)
+	t.Setenv("GT_ROOT", tmpDir)
 	handler := NewWitnessHandler("gastown", tmpDir)
+	handler.Router = mail.NewRouterWithTownRoot(tmpDir, "")
 
 	// Capture output
 	var buf bytes.Buffer

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -319,7 +319,7 @@ func runWithProgressTicker(label string, fn func() error) error {
 		case err := <-done:
 			return err
 		case <-ticker.C:
-			fmt.Printf("  ... %.0fs\n", time.Since(start).Seconds())
+			fmt.Printf("  ... %s (%.0fs)\n", strings.ToLower(label), time.Since(start).Seconds())
 		}
 	}
 }

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -632,6 +632,18 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 			// port, causing "database not found" errors. (GH #2405)
 			doltCfg := doltserver.DefaultConfig(m.townRoot)
 			initArgs = append(initArgs, "--server-port", strconv.Itoa(doltCfg.Port))
+			// If config.yaml has sync.remote, bd init blocks on a remote
+			// divergence safety check (stdin is /dev/null in subprocess).
+			// Pass reinit flags so it proceeds non-interactively. (GH #3873)
+			if detectBeadsSyncRemote(sourceBeadsConfig) != "" {
+				destroyToken := "DESTROY-" + strings.TrimSuffix(opts.BeadsPrefix, "-")
+				initArgs = append(initArgs,
+					"--reinit-local",
+					"--discard-remote",
+					"--destroy-token", destroyToken,
+					"--non-interactive",
+				)
+			}
 			cmd := exec.Command("bd", initArgs...)
 			cmd.Dir = mayorRigPath
 			if output, err := cmd.CombinedOutput(); err != nil {
@@ -1572,6 +1584,31 @@ func detectBeadsPrefixFromConfig(configPath string) string {
 					return strings.TrimSuffix(value, "-")
 				}
 			}
+		}
+	}
+
+	return ""
+}
+
+// detectBeadsSyncRemote reads the sync.remote value from a beads config.yaml file.
+// Returns empty string if the file doesn't exist or doesn't contain sync.remote.
+// Used by AddRig to detect whether bd init will require reinit flags to avoid
+// hanging on a remote divergence safety check (GH #3873).
+func detectBeadsSyncRemote(configPath string) string {
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return ""
+	}
+
+	lines := strings.Split(string(data), "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		if strings.HasPrefix(line, "sync.remote:") {
+			value := strings.TrimSpace(strings.TrimPrefix(line, "sync.remote:"))
+			return strings.Trim(value, `"'`)
 		}
 	}
 

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -304,6 +304,26 @@ func resolveLocalRepo(path, gitURL string) (string, string) {
 	return absPath, ""
 }
 
+// runWithProgressTicker runs fn while printing elapsed-time updates every 5 seconds.
+// Prints "  <label>..." before starting and ticks "  ... Ns" until fn returns.
+func runWithProgressTicker(label string, fn func() error) error {
+	fmt.Printf("  %s...\n", label)
+	start := time.Now()
+	done := make(chan error, 1)
+	go func() { done <- fn() }()
+
+	ticker := time.NewTicker(5 * time.Second)
+	defer ticker.Stop()
+	for {
+		select {
+		case err := <-done:
+			return err
+		case <-ticker.C:
+			fmt.Printf("  ... %.0fs\n", time.Since(start).Seconds())
+		}
+	}
+}
+
 // AddRig creates a new rig as a container with clones for each agent.
 // The rig structure is:
 //
@@ -420,7 +440,6 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 	// Create shared bare repo as source of truth for refinery and polecats.
 	// This allows refinery to see polecat branches without pushing to remote.
 	// Mayor remains a separate clone (doesn't need branch visibility).
-	fmt.Printf("  Cloning repository (this may take a moment)...\n")
 	bareRepoPath := filepath.Join(rigPath, ".repo.git")
 	// cloneBareWith selects the right CloneBare variant based on filter/reference/branch.
 	// When branch is non-empty, git clone --branch is passed so HEAD and the initial
@@ -446,7 +465,9 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 		return m.git.CloneBareWithBranch(opts.GitURL, bareRepoPath, branch)
 	}
 
-	if err := cloneBareWith(opts.DefaultBranch); err != nil {
+	if err := runWithProgressTicker("Cloning repository", func() error {
+		return cloneBareWith(opts.DefaultBranch)
+	}); err != nil {
 		return nil, wrapCloneError(err, opts.GitURL)
 	}
 	if opts.CloneFilter != "" {
@@ -515,25 +536,27 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 	// This also allows mayor to stay on the default branch without conflicting with refinery.
 	// Uses --reference to borrow objects from the bare repo we just created,
 	// avoiding a redundant download from the remote (GH#1059).
-	fmt.Printf("  Creating mayor clone...\n")
 	mayorRigPath := filepath.Join(rigPath, "mayor", "rig")
 	if err := os.MkdirAll(filepath.Dir(mayorRigPath), 0755); err != nil {
 		return nil, fmt.Errorf("creating mayor dir: %w", err)
 	}
-	if opts.CloneFilter != "" {
-		if err := m.git.CloneBranchPartialWithReference(opts.GitURL, mayorRigPath, defaultBranch, opts.CloneFilter, bareRepoPath); err != nil {
-			fmt.Printf("  Warning: could not use bare repo as reference with filter: %v\n", err)
-			_ = os.RemoveAll(mayorRigPath)
-			if err := m.git.CloneBranchPartial(opts.GitURL, mayorRigPath, defaultBranch, opts.CloneFilter); err != nil {
-				return nil, fmt.Errorf("cloning for mayor: %w", err)
+	if err := runWithProgressTicker("Creating mayor clone", func() error {
+		if opts.CloneFilter != "" {
+			if err := m.git.CloneBranchPartialWithReference(opts.GitURL, mayorRigPath, defaultBranch, opts.CloneFilter, bareRepoPath); err != nil {
+				fmt.Printf("  Warning: could not use bare repo as reference with filter: %v\n", err)
+				_ = os.RemoveAll(mayorRigPath)
+				return m.git.CloneBranchPartial(opts.GitURL, mayorRigPath, defaultBranch, opts.CloneFilter)
 			}
+			return nil
 		}
-	} else if err := m.git.CloneBranchWithReference(opts.GitURL, mayorRigPath, defaultBranch, bareRepoPath); err != nil {
-		fmt.Printf("  Warning: could not use bare repo as reference: %v\n", err)
-		_ = os.RemoveAll(mayorRigPath)
-		if err := m.git.CloneBranch(opts.GitURL, mayorRigPath, defaultBranch); err != nil {
-			return nil, fmt.Errorf("cloning for mayor: %w", err)
+		if err := m.git.CloneBranchWithReference(opts.GitURL, mayorRigPath, defaultBranch, bareRepoPath); err != nil {
+			fmt.Printf("  Warning: could not use bare repo as reference: %v\n", err)
+			_ = os.RemoveAll(mayorRigPath)
+			return m.git.CloneBranch(opts.GitURL, mayorRigPath, defaultBranch)
 		}
+		return nil
+	}); err != nil {
+		return nil, fmt.Errorf("cloning for mayor: %w", err)
 	}
 
 	// Set up sparse checkout on mayor clone if requested

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -1138,6 +1138,66 @@ func TestDetectBeadsPrefixFromConfig_NoFallbackToJSONL(t *testing.T) {
 	}
 }
 
+func TestDetectBeadsSyncRemote(t *testing.T) {
+	tests := []struct {
+		name       string
+		configYAML string
+		want       string
+	}{
+		{
+			name:       "detects sync.remote",
+			configYAML: "sync.remote: \"git+https://github.com/steveyegge/gastown.git\"\n",
+			want:       "git+https://github.com/steveyegge/gastown.git",
+		},
+		{
+			name:       "detects unquoted sync.remote",
+			configYAML: "sync.remote: git+https://github.com/user/repo.git\n",
+			want:       "git+https://github.com/user/repo.git",
+		},
+		{
+			name:       "returns empty when no sync.remote",
+			configYAML: "prefix: gt\n",
+			want:       "",
+		},
+		{
+			name:       "returns empty for empty file",
+			configYAML: "",
+			want:       "",
+		},
+		{
+			name:       "ignores comments",
+			configYAML: "# sync.remote: commented-out\nprefix: gt\n",
+			want:       "",
+		},
+		{
+			name:       "detects amid other keys",
+			configYAML: "prefix: gt\nsync.remote: git+ssh://example.com/repo.git\nother: value\n",
+			want:       "git+ssh://example.com/repo.git",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			configPath := filepath.Join(dir, "config.yaml")
+			if err := os.WriteFile(configPath, []byte(tt.configYAML), 0644); err != nil {
+				t.Fatalf("writing config: %v", err)
+			}
+			got := detectBeadsSyncRemote(configPath)
+			if got != tt.want {
+				t.Errorf("detectBeadsSyncRemote() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDetectBeadsSyncRemote_MissingFile(t *testing.T) {
+	got := detectBeadsSyncRemote("/nonexistent/path/config.yaml")
+	if got != "" {
+		t.Errorf("detectBeadsSyncRemote() = %q, want empty for missing file", got)
+	}
+}
+
 func TestIsStandardBeadHash(t *testing.T) {
 	tests := []struct {
 		input string

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -46,8 +46,11 @@ func EnsureSettingsForRole(settingsDir, workDir, role string, rc *config.Runtime
 	}
 
 	// 2. Slash commands (agent-agnostic, uses shared body with provider-specific frontmatter)
-	// Only provision for known agents to maintain backwards compatibility
-	if commands.IsKnownAgent(provider) {
+	// Only provision for known agents to maintain backwards compatibility.
+	// Skip if an ancestor directory already has commands: Claude Code loads commands
+	// from all .claude/ dirs in the path hierarchy, so provisioning into a workDir
+	// that is nested under the town root (e.g. mayor/, deacon/) would cause duplicates.
+	if commands.IsKnownAgent(provider) && !commands.HasCommandsInAncestor(workDir, provider) {
 		if err := commands.ProvisionFor(workDir, provider); err != nil {
 			return err
 		}

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -2,6 +2,7 @@ package runtime
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -301,6 +302,45 @@ func TestEnsureSettingsForRole_ClaudeUsesSettingsDir(t *testing.T) {
 	}
 	if _, err := os.Stat(workDir + "/.claude/settings.json"); err == nil {
 		t.Error("Claude settings should NOT be in workDir when dirs differ")
+	}
+}
+
+func TestEnsureSettingsForRole_SkipsCommandsWhenAncestorHasThem(t *testing.T) {
+	// When workDir is nested under a directory that already has commands provisioned
+	// (e.g. mayor/ inside town root), EnsureSettingsForRole must NOT write a duplicate
+	// copy. Claude Code inherits from all ancestor .claude/commands/ dirs.
+	townRoot := t.TempDir()
+	workDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate town root having commands already (as ProvisionCommands would do).
+	townCommandsDir := filepath.Join(townRoot, ".claude", "commands")
+	if err := os.MkdirAll(townCommandsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townCommandsDir, "done.md"), []byte("---\n---\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rc := &config.RuntimeConfig{
+		Hooks: &config.RuntimeHooksConfig{
+			Provider:     "claude",
+			Dir:          ".claude",
+			SettingsFile: "settings.json",
+		},
+	}
+
+	if err := EnsureSettingsForRole(workDir, workDir, "mayor", rc); err != nil {
+		t.Fatalf("EnsureSettingsForRole() error = %v", err)
+	}
+
+	// Commands must NOT be provisioned into mayor/.claude/commands/ because the
+	// town root's .claude/commands/ is inherited via directory traversal.
+	mayorCommandsDir := filepath.Join(workDir, ".claude", "commands")
+	if _, err := os.Stat(mayorCommandsDir); err == nil {
+		t.Error("EnsureSettingsForRole should not provision commands when ancestor already has them")
 	}
 }
 

--- a/internal/templates/commands/provision.go
+++ b/internal/templates/commands/provision.go
@@ -173,3 +173,26 @@ func Names() []string {
 func IsKnownAgent(agent string) bool {
 	return getAgentConfigDir(strings.ToLower(agent)) != ""
 }
+
+// HasCommandsInAncestor returns true if any ancestor directory of workDir (not
+// including workDir itself) already has commands provisioned for the given agent.
+// This prevents duplicate commands when workDir is nested inside a hierarchy that
+// already serves commands via Claude Code's directory traversal.
+func HasCommandsInAncestor(workDir, agent string) bool {
+	agent = strings.ToLower(agent)
+	configDir := getAgentConfigDir(agent)
+	if configDir == "" {
+		return false
+	}
+
+	dir := filepath.Clean(workDir)
+	parent := filepath.Dir(dir)
+	for parent != dir {
+		if _, err := os.Stat(filepath.Join(parent, configDir, "commands")); err == nil {
+			return true
+		}
+		dir = parent
+		parent = filepath.Dir(dir)
+	}
+	return false
+}

--- a/internal/templates/commands/provision_test.go
+++ b/internal/templates/commands/provision_test.go
@@ -1,6 +1,8 @@
 package commands
 
 import (
+	"os"
+	"path/filepath"
 	"slices"
 	"strings"
 	"testing"
@@ -123,6 +125,62 @@ func TestBuildCommand_Review_Claude(t *testing.T) {
 	}
 	if !strings.Contains(content, "Grade") {
 		t.Error("missing Grade in body")
+	}
+}
+
+func TestHasCommandsInAncestor_NoAncestor(t *testing.T) {
+	workDir := t.TempDir()
+	if HasCommandsInAncestor(workDir, "claude") {
+		t.Error("should return false when no ancestor has commands")
+	}
+}
+
+func TestHasCommandsInAncestor_DirectParent(t *testing.T) {
+	parent := t.TempDir()
+	workDir := filepath.Join(parent, "role")
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Provision commands in parent (simulates town root)
+	if err := ProvisionFor(parent, "claude"); err != nil {
+		t.Fatalf("ProvisionFor: %v", err)
+	}
+	if !HasCommandsInAncestor(workDir, "claude") {
+		t.Error("should return true when direct parent has commands")
+	}
+}
+
+func TestHasCommandsInAncestor_WorkDirItself(t *testing.T) {
+	workDir := t.TempDir()
+	// Provision commands in workDir itself — should NOT count as an ancestor
+	if err := ProvisionFor(workDir, "claude"); err != nil {
+		t.Fatalf("ProvisionFor: %v", err)
+	}
+	if HasCommandsInAncestor(workDir, "claude") {
+		t.Error("should return false when only workDir itself has commands (not an ancestor)")
+	}
+}
+
+func TestHasCommandsInAncestor_GrandparentOnly(t *testing.T) {
+	grandparent := t.TempDir()
+	middle := filepath.Join(grandparent, "mid")
+	workDir := filepath.Join(middle, "role")
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Provision commands in grandparent only
+	if err := ProvisionFor(grandparent, "claude"); err != nil {
+		t.Fatalf("ProvisionFor: %v", err)
+	}
+	if !HasCommandsInAncestor(workDir, "claude") {
+		t.Error("should return true when grandparent has commands")
+	}
+}
+
+func TestHasCommandsInAncestor_UnknownAgent(t *testing.T) {
+	workDir := t.TempDir()
+	if HasCommandsInAncestor(workDir, "unknownagent") {
+		t.Error("should return false for unknown agent")
 	}
 }
 

--- a/scripts/issue-hunter-fetch-upstream.py
+++ b/scripts/issue-hunter-fetch-upstream.py
@@ -1,0 +1,57 @@
+#!/usr/bin/env python3
+"""Fetch open issues from the upstream GitHub repo.
+
+Queries the upstream repo for all open issues that are NOT pull requests and
+writes them to /tmp/ih-issues-raw.json for the subsequent pipeline steps.
+
+Note: ``gh issue list`` uses GitHub's search API with ``type:issue``, which
+excludes pull requests by design.
+
+Output: /tmp/ih-issues-raw.json  (list of open issues, no PRs)
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+UPSTREAM_REPO = "gastownhall/gastown"
+ISSUE_LIMIT = 500
+ISSUE_FIELDS = "number,title,body,labels,author,url"
+
+
+def fetch_issues(repo: str, limit: int) -> list[dict]:
+    result = subprocess.run(
+        [
+            "gh", "issue", "list",
+            "--repo", repo,
+            "--state", "open",
+            "--limit", str(limit),
+            "--json", ISSUE_FIELDS,
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def main() -> None:
+    print(f"Fetching open issues from {UPSTREAM_REPO}...")
+    try:
+        issues = fetch_issues(UPSTREAM_REPO, ISSUE_LIMIT)
+    except subprocess.CalledProcessError as e:
+        print(f"ERROR: gh issue list failed:\n{e.stderr}", file=sys.stderr)
+        sys.exit(1)
+
+    print(f"  Fetched {len(issues)} open issues")
+
+    output_path = Path("/tmp/ih-issues-raw.json")
+    output_path.write_text(json.dumps(issues, indent=2))
+    print(f"Output: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue-hunter-filter-claimed.py
+++ b/scripts/issue-hunter-filter-claimed.py
@@ -1,0 +1,73 @@
+#!/usr/bin/env python3
+"""Filter GitHub issues that are already claimed by an existing branch on origin.
+
+An issue is "claimed" if a branch matching ``origin/issue-hunter/<number>-*``
+already exists on the fork.  This prevents double-slinging on re-runs before
+the previous polecat finishes.
+
+Input:  /tmp/ih-issues-uncovered.json  (from filter-prs step)
+Output: /tmp/ih-issues-available.json  (issues with no existing branch claim)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Repo root is one level above this script's directory.
+REPO_ROOT = Path(__file__).parent.parent
+
+
+def fetch_remote_branches() -> list[str]:
+    """Fetch origin and return all remote branch names."""
+    subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "fetch", "origin", "--prune"],
+        capture_output=True,
+    )
+    result = subprocess.run(
+        ["git", "-C", str(REPO_ROOT), "branch", "-r"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return [line.strip() for line in result.stdout.splitlines() if line.strip()]
+
+
+def extract_claimed_numbers(remote_branches: list[str]) -> set[int]:
+    """Return issue numbers claimed by existing issue-hunter branches."""
+    claimed: set[int] = set()
+    for branch in remote_branches:
+        # Match: origin/issue-hunter/<number>[-...]
+        m = re.match(r"origin/issue-hunter/(\d+)", branch)
+        if m:
+            claimed.add(int(m.group(1)))
+    return claimed
+
+
+def main() -> None:
+    input_path = Path("/tmp/ih-issues-uncovered.json")
+    if not input_path.exists():
+        print("ERROR: /tmp/ih-issues-uncovered.json not found", file=sys.stderr)
+        sys.exit(1)
+
+    print("Fetching remote branches...")
+    remote_branches = fetch_remote_branches()
+    print(f"  Found {len(remote_branches)} remote branches")
+
+    claimed = extract_claimed_numbers(remote_branches)
+    print(f"  Claimed issue numbers: {sorted(claimed) or 'none'}")
+
+    issues = json.loads(input_path.read_text())
+    available = [i for i in issues if i["number"] not in claimed]
+
+    output_path = Path("/tmp/ih-issues-available.json")
+    output_path.write_text(json.dumps(available, indent=2))
+    print(f"\nAvailable (not claimed): {len(available)} of {len(issues)}")
+    print(f"Output: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue-hunter-filter-prs.py
+++ b/scripts/issue-hunter-filter-prs.py
@@ -1,8 +1,9 @@
 #!/usr/bin/env python3
 """Filter GitHub issues that already have an open or recently merged PR.
 
-An issue is "covered" if any PR's title or body contains a closing keyword:
-  closes #N, fixes #N, resolves #N (or variations)
+Two detection methods — an issue is "covered" if either fires:
+  1. closingIssuesReferences: GitHub's own linked-issue tracking (most reliable)
+  2. Keyword regex in PR title/body: closes/fixes/resolves #N (informal references)
 
 Input:  /tmp/ih-issues-raw.json       (from fetch-upstream-issues step)
 Output: /tmp/ih-issues-uncovered.json (issues with no covering PR)
@@ -28,7 +29,7 @@ def fetch_prs(state: str, limit: int) -> list[dict]:
             "--repo", UPSTREAM_REPO,
             "--state", state,
             "--limit", str(limit),
-            "--json", "number,title,body",
+            "--json", "number,title,body,closingIssuesReferences",
         ],
         capture_output=True,
         text=True,
@@ -37,7 +38,7 @@ def fetch_prs(state: str, limit: int) -> list[dict]:
     return json.loads(result.stdout)
 
 
-def extract_referenced(text: str) -> set[int]:
+def extract_keyword_refs(text: str) -> set[int]:
     return set(
         int(m)
         for m in re.findall(
@@ -62,15 +63,20 @@ def main() -> None:
 
     covered: set[int] = set()
     for pr in open_prs + merged_prs:
-        covered |= extract_referenced(pr.get("body") or "")
-        covered |= extract_referenced(pr.get("title") or "")
+        # Method 1: GitHub's own closingIssuesReferences (most reliable)
+        for ref in pr.get("closingIssuesReferences") or []:
+            covered.add(ref["number"])
+        # Method 2: keyword regex fallback (catches informal references)
+        covered |= extract_keyword_refs(pr.get("body") or "")
+        covered |= extract_keyword_refs(pr.get("title") or "")
 
     issues = json.loads(issues_path.read_text())
     uncovered = [i for i in issues if i["number"] not in covered]
 
     output_path = Path("/tmp/ih-issues-uncovered.json")
     output_path.write_text(json.dumps(uncovered, indent=2))
-    print(f"\nUncovered issues: {len(uncovered)} of {len(issues)}")
+    print(f"\nCovered by a PR: {len(covered)} issue(s)")
+    print(f"Uncovered (candidates): {len(uncovered)} of {len(issues)}")
     print(f"Output: {output_path}")
 
 

--- a/scripts/issue-hunter-filter-prs.py
+++ b/scripts/issue-hunter-filter-prs.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Filter GitHub issues that already have an open or recently merged PR.
+
+An issue is "covered" if any PR's title or body contains a closing keyword:
+  closes #N, fixes #N, resolves #N (or variations)
+
+Input:  /tmp/ih-issues-raw.json       (from fetch-upstream-issues step)
+Output: /tmp/ih-issues-uncovered.json (issues with no covering PR)
+"""
+
+from __future__ import annotations
+
+import json
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+UPSTREAM_REPO = "gastownhall/gastown"
+PR_LIMIT_OPEN = 200
+PR_LIMIT_MERGED = 100
+
+
+def fetch_prs(state: str, limit: int) -> list[dict]:
+    result = subprocess.run(
+        [
+            "gh", "pr", "list",
+            "--repo", UPSTREAM_REPO,
+            "--state", state,
+            "--limit", str(limit),
+            "--json", "number,title,body",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+    return json.loads(result.stdout)
+
+
+def extract_referenced(text: str) -> set[int]:
+    return set(
+        int(m)
+        for m in re.findall(
+            r"(?:closes?|fixes?|resolves?)\s+#(\d+)", text or "", re.I
+        )
+    )
+
+
+def main() -> None:
+    issues_path = Path("/tmp/ih-issues-raw.json")
+    if not issues_path.exists():
+        print("ERROR: /tmp/ih-issues-raw.json not found", file=sys.stderr)
+        sys.exit(1)
+
+    print("Fetching open PRs...")
+    open_prs = fetch_prs("open", PR_LIMIT_OPEN)
+    print(f"  Found {len(open_prs)} open PRs")
+
+    print("Fetching recently merged PRs...")
+    merged_prs = fetch_prs("merged", PR_LIMIT_MERGED)
+    print(f"  Found {len(merged_prs)} merged PRs")
+
+    covered: set[int] = set()
+    for pr in open_prs + merged_prs:
+        covered |= extract_referenced(pr.get("body") or "")
+        covered |= extract_referenced(pr.get("title") or "")
+
+    issues = json.loads(issues_path.read_text())
+    uncovered = [i for i in issues if i["number"] not in covered]
+
+    output_path = Path("/tmp/ih-issues-uncovered.json")
+    output_path.write_text(json.dumps(uncovered, indent=2))
+    print(f"\nUncovered issues: {len(uncovered)} of {len(issues)}")
+    print(f"Output: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue-hunter-select.py
+++ b/scripts/issue-hunter-select.py
@@ -1,0 +1,65 @@
+#!/usr/bin/env python3
+"""Select and rank up to max_issues issues by priority.
+
+Selection rules:
+  1. Issues authored by PREFER_AUTHOR come first.
+  2. Within each author group, sort by priority label: p0 > p1 > p2 > p3 > none.
+  3. Take the top IH_MAX_ISSUES (default 5, override via env var).
+
+Input:  /tmp/ih-issues-available.json  (from filter-claimed step)
+Output: /tmp/ih-issues-selected.json   (ranked selection ready for slinging)
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import sys
+from pathlib import Path
+
+PREFER_AUTHOR = "esciara"
+PRIORITY_ORDER = {"priority/p0": 0, "priority/p1": 1, "priority/p2": 2, "priority/p3": 3}
+DEFAULT_MAX = 5
+
+
+def priority_key(issue: dict) -> tuple[int, int, int]:
+    labels = [lbl["name"] for lbl in issue.get("labels", [])]
+    p = min((PRIORITY_ORDER[l] for l in labels if l in PRIORITY_ORDER), default=99)
+    authored = 0 if issue.get("author", {}).get("login") == PREFER_AUTHOR else 1
+    return (authored, p, issue["number"])
+
+
+def main() -> None:
+    input_path = Path("/tmp/ih-issues-available.json")
+    if not input_path.exists():
+        print("ERROR: /tmp/ih-issues-available.json not found", file=sys.stderr)
+        sys.exit(1)
+
+    try:
+        max_issues = int(os.environ.get("IH_MAX_ISSUES", DEFAULT_MAX))
+    except ValueError:
+        print("ERROR: IH_MAX_ISSUES must be an integer", file=sys.stderr)
+        sys.exit(1)
+
+    issues = json.loads(input_path.read_text())
+    ranked = sorted(issues, key=priority_key)
+    selected = ranked[:max_issues]
+
+    output_path = Path("/tmp/ih-issues-selected.json")
+    output_path.write_text(json.dumps(selected, indent=2))
+
+    if not selected:
+        print("No issues available — nothing to sling.")
+    else:
+        print(f"Selected {len(selected)} issue(s) (max={max_issues}):")
+        for issue in selected:
+            labels = [lbl["name"] for lbl in issue.get("labels", [])]
+            print(
+                f"  #{issue['number']} [{', '.join(labels) or 'no labels'}]"
+                f" {issue['title'][:60]}"
+            )
+    print(f"Output: {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/issue-hunter-sling-workers.py
+++ b/scripts/issue-hunter-sling-workers.py
@@ -1,0 +1,75 @@
+#!/usr/bin/env python3
+"""Sling one worker polecat per selected issue.
+
+Reads /tmp/ih-issues-selected.json and calls gt sling mol-issue-hunter-work
+for each issue. Must be run by a role that can sling (e.g., witness, mayor).
+
+Usage:
+    python3 scripts/issue-hunter-sling-workers.py \
+        --rig gastown \
+        --upstream-repo gastownhall/gastown \
+        --fork-repo esciara/gastown
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--rig", default="gastown")
+    parser.add_argument("--upstream-repo", default="gastownhall/gastown")
+    parser.add_argument("--fork-repo", default="esciara/gastown")
+    parser.add_argument(
+        "--input", default="/tmp/ih-issues-selected.json",
+        help="Path to selected issues JSON",
+    )
+    args = parser.parse_args()
+
+    input_path = Path(args.input)
+    if not input_path.exists():
+        print(f"ERROR: {input_path} not found", file=sys.stderr)
+        sys.exit(1)
+
+    issues = json.loads(input_path.read_text())
+    if not issues:
+        print("No issues to sling. Exiting cleanly.")
+        sys.exit(0)
+
+    errors = []
+    for issue in issues:
+        num = issue["number"]
+        title = issue["title"][:50].replace('"', '\\"')
+        print(f"Slinging worker for issue #{num}: {title}")
+        result = subprocess.run(
+            [
+                "gt", "sling", "mol-issue-hunter-work", args.rig,
+                "--var", f"github_issue={num}",
+                "--var", f"upstream_repo={args.upstream_repo}",
+                "--var", f"fork_repo={args.fork_repo}",
+                "--args", f"Contribute a fix for upstream issue #{num}: {title}",
+            ],
+            capture_output=True,
+            text=True,
+        )
+        if result.returncode != 0:
+            msg = f"  ERROR slinging #{num}: {result.stderr.strip()}"
+            print(msg)
+            errors.append(msg)
+        else:
+            print(f"  OK: {result.stdout.strip()}")
+
+    if errors:
+        print(f"\n{len(errors)} error(s) encountered.", file=sys.stderr)
+        sys.exit(1)
+    else:
+        print(f"\nAll {len(issues)} worker(s) slung successfully.")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary

- Reconnects `gt sling --ralph` to the ralph-loop plugin: `outputRalphLoopDirective` now checks `~/.claude/plugins/installed_plugins.json` for the plugin and emits `/ralph-loop "<prompt>" --completion-promise DONE` when found.
- Returns a clear, actionable error (`--ralph requires the ralph-loop plugin … /plugin install ralph-loop@claude-plugins-official`) when the plugin is absent, instead of silently falling back to inline instructions.
- Extracts `renderFormulaStepsFull` (returns string) from `showFormulaStepsFull` so the formula checklist can be embedded in the `/ralph-loop` prompt argument.

## Changes

- `internal/cmd/prime.go` — `outputRalphLoopDirective` now returns `error`; new `outputRalphLoopDirectiveWithPluginCheck` (testable), `isRalphLoopPluginInstalled`, `ralphLoopPluginInstalledIn`, `quoteForRalphLoop` (escapes `\`, `"`, `\n` for single-line argument passing)
- `internal/cmd/prime_molecule.go` — `renderFormulaStepsFull` added; `showFormulaStepsFull` delegates to it
- `internal/cmd/prime_test.go` — old `NoSlashCommand` test replaced by `PluginNotInstalled` / `PluginInstalled` / `WithFormula` / `TestRalphLoopPluginInstalledIn` / `TestQuoteForRalphLoop` tests

## Testing

- [x] `go build ./...` passes
- [x] `go test ./internal/cmd/... -run "TestOutputRalph|TestRalphLoop|TestQuoteForRalph"` — all 5 tests pass
- [x] `go vet ./...` passes

Closes #3918