### PR TITLE
fix: bypass prefix routing for agent-bead operations (3 commits)

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -379,7 +379,7 @@ func NewWithBeadsDir(workDir, beadsDir string) *Beads {
 
 // ForAgentBead returns a Beads wrapper suitable for operating on agent beads.
 //
-// Agent beads (labelled gt:agent) live in the TOWN database, but their IDs
+// Agent beads (labeled gt:agent) live in the TOWN database, but their IDs
 // are prefixed with the rig prefix (e.g. "za-zack-polecat-furiosa"). The
 // default prefix routing in routes.jsonl maps "za-" → zack rig database, so
 // any agent-bead operation issued from a rig context (or any context that
@@ -394,7 +394,7 @@ func NewWithBeadsDir(workDir, beadsDir string) *Beads {
 //     ResolveRoutingTarget, forIssueID) do not redirect lookups by prefix.
 //
 // If the town root cannot be determined, returns the original wrapper to
-// preserve current behaviour.
+// preserve current behavior.
 func (b *Beads) ForAgentBead() *Beads {
 	townRoot := b.getTownRoot()
 	if townRoot == "" {

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -341,6 +341,14 @@ type Beads struct {
 	// Populated on first call to getTownRoot() to avoid filesystem walk on every operation.
 	townRoot     string
 	townRootOnce sync.Once
+
+	// noRoute disables prefix-based routing for this Beads instance.
+	// Used for agent-bead operations: agent beads (gt:agent label) live in
+	// the town database regardless of their ID prefix, so prefix routing
+	// (which assumes "za-*" → zack DB) misroutes them. When set, Show()
+	// and forIssueID() skip ResolveRoutingTarget and operate against
+	// beadsDir directly.
+	noRoute bool
 }
 
 // New creates a new Beads wrapper for the given directory.
@@ -367,6 +375,41 @@ func NewIsolatedWithPort(workDir string, serverPort int) *Beads {
 // This is needed when running from a polecat worktree but accessing town-level beads.
 func NewWithBeadsDir(workDir, beadsDir string) *Beads {
 	return &Beads{workDir: workDir, beadsDir: beadsDir}
+}
+
+// ForAgentBead returns a Beads wrapper suitable for operating on agent beads.
+//
+// Agent beads (labelled gt:agent) live in the TOWN database, but their IDs
+// are prefixed with the rig prefix (e.g. "za-zack-polecat-furiosa"). The
+// default prefix routing in routes.jsonl maps "za-" → zack rig database, so
+// any agent-bead operation issued from a rig context (or any context that
+// triggers routing) gets sent to the wrong DB and fails with "issue not
+// found". This silently breaks gt done's hook clearing, agent state
+// transition, completion metadata, etc.
+//
+// ForAgentBead bypasses that:
+//   - Re-roots the wrapper at the town's .beads directory (so bd CLI itself
+//     opens the town/hq Dolt database where agent beads live).
+//   - Sets noRoute=true so the Go-side routing helpers (Show,
+//     ResolveRoutingTarget, forIssueID) do not redirect lookups by prefix.
+//
+// If the town root cannot be determined, returns the original wrapper to
+// preserve current behaviour.
+func (b *Beads) ForAgentBead() *Beads {
+	townRoot := b.getTownRoot()
+	if townRoot == "" {
+		return b
+	}
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	return &Beads{
+		workDir:    townRoot,
+		beadsDir:   townBeadsDir,
+		isolated:   b.isolated,
+		serverPort: b.serverPort,
+		store:      b.store,
+		townRoot:   townRoot,
+		noRoute:    true,
+	}
 }
 
 // getActor returns the BD_ACTOR value for this context.
@@ -424,7 +467,14 @@ func (b *Beads) targetBeadsDirForCreate(opts CreateOptions) string {
 // forIssueID returns a Beads wrapper bound to the correct beads directory for
 // the given issue ID. This is needed for cross-rig write operations that use an
 // ID to determine the owning database.
+//
+// When noRoute is set (see ForAgentBead), routing is skipped: the wrapper is
+// returned unchanged. Used for agent-bead operations whose IDs share the rig
+// prefix but whose data lives in the town DB.
 func (b *Beads) forIssueID(id string) *Beads {
+	if b.noRoute {
+		return b
+	}
 	resolved := ResolveBeadsDirForID(b.getResolvedBeadsDir(), id)
 	if resolved == "" || resolved == b.getResolvedBeadsDir() {
 		return b
@@ -1156,10 +1206,13 @@ func (b *Beads) ReadyWithType(issueType string) ([]*Issue, error) {
 func (b *Beads) Show(id string) (*Issue, error) {
 	// Route cross-rig queries via routes.jsonl so that rig-level bead IDs
 	// (e.g., "gt-abc123") resolve to the correct rig database.
-	targetDir := ResolveRoutingTarget(b.getTownRoot(), id, b.getResolvedBeadsDir())
-	if targetDir != b.getResolvedBeadsDir() {
-		target := NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
-		return target.Show(id)
+	// noRoute (see ForAgentBead) bypasses this for agent-bead lookups.
+	if !b.noRoute {
+		targetDir := ResolveRoutingTarget(b.getTownRoot(), id, b.getResolvedBeadsDir())
+		if targetDir != b.getResolvedBeadsDir() {
+			target := NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
+			return target.Show(id)
+		}
 	}
 
 	if b.store != nil {

--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -378,10 +378,13 @@ func (b *Beads) ResetAgentBeadForReuse(id, reason string) error {
 	// Resolve where this bead lives (handles cross-rig routing).
 	// Without this, cross-rig agent beads (e.g., bd-beads-polecat-obsidian
 	// from gastown) would be looked up in the local rig's database and fail.
-	targetDir := ResolveRoutingTarget(b.getTownRoot(), id, b.getResolvedBeadsDir())
+	// noRoute (see ForAgentBead) skips this for agent beads in the local town.
 	target := b
-	if targetDir != b.getResolvedBeadsDir() {
-		target = NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
+	if !b.noRoute {
+		targetDir := ResolveRoutingTarget(b.getTownRoot(), id, b.getResolvedBeadsDir())
+		if targetDir != b.getResolvedBeadsDir() {
+			target = NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
+		}
 	}
 
 	// Get current issue to preserve immutable fields (title, role_type, rig)
@@ -423,10 +426,14 @@ func (b *Beads) ResetAgentBeadForReuse(id, reason string) error {
 // when the agent bead routes to a different beads dir via routes.jsonl.
 func (b *Beads) UpdateAgentState(id string, state string) (retErr error) {
 	defer func() { telemetry.RecordAgentStateChange(context.Background(), id, state, nil, retErr) }()
-	targetDir := ResolveRoutingTarget(b.getTownRoot(), id, b.getResolvedBeadsDir())
 	target := b
-	if targetDir != b.getResolvedBeadsDir() {
-		target = NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
+	// Skip prefix routing when noRoute is set (agent-bead operations from rig
+	// context — see ForAgentBead).
+	if !b.noRoute {
+		targetDir := ResolveRoutingTarget(b.getTownRoot(), id, b.getResolvedBeadsDir())
+		if targetDir != b.getResolvedBeadsDir() {
+			target = NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
+		}
 	}
 	return target.UpdateAgentDescriptionFields(id, AgentFieldUpdates{AgentState: &state})
 }

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -452,7 +452,8 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 	// skip those stages to avoid repeating work or hitting errors.
 	checkpoints := map[DoneCheckpoint]string{}
 	if agentBeadID != "" {
-		bd := beads.New(cwd)
+		// Agent bead lives in town DB despite rig prefix — bypass routing.
+		bd := beads.New(cwd).ForAgentBead()
 		setDoneIntentLabel(bd, agentBeadID, exitType)
 		checkpoints = readDoneCheckpoints(bd, agentBeadID)
 		if len(checkpoints) > 0 {
@@ -872,7 +873,8 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 		// Write push checkpoint for resume (gt-aufru)
 		if agentBeadID != "" {
-			cpBd := beads.New(cwd)
+			// Agent bead lives in town DB despite rig prefix — bypass routing.
+			cpBd := beads.New(cwd).ForAgentBead()
 			writeDoneCheckpoint(cpBd, agentBeadID, CheckpointPushed, branch)
 		}
 
@@ -1315,7 +1317,8 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 		// Write MR checkpoint for resume (gt-aufru)
 		if mrID != "" && agentBeadID != "" {
-			cpBd := beads.New(cwd)
+			// Agent bead lives in town DB despite rig prefix — bypass routing.
+			cpBd := beads.New(cwd).ForAgentBead()
 			writeDoneCheckpoint(cpBd, agentBeadID, CheckpointMRCreated, mrID)
 		}
 
@@ -1350,7 +1353,8 @@ notifyWitness:
 	// longer processes routine completions from these fields.
 	fmt.Printf("\nNotifying Witness...\n")
 	if agentBeadID != "" {
-		completionBd := beads.New(cwd)
+		// Agent bead lives in town DB despite rig prefix — bypass routing.
+		completionBd := beads.New(cwd).ForAgentBead()
 		meta := &beads.CompletionMetadata{
 			ExitType:       exitType,
 			MRID:           mrID,
@@ -1374,7 +1378,8 @@ notifyWitness:
 
 	// Write witness notification checkpoint for resume (gt-aufru)
 	if agentBeadID != "" {
-		cpBd := beads.New(cwd)
+		// Agent bead lives in town DB despite rig prefix — bypass routing.
+		cpBd := beads.New(cwd).ForAgentBead()
 		writeDoneCheckpoint(cpBd, agentBeadID, CheckpointWitnessNotified, "ok")
 	}
 
@@ -1776,6 +1781,11 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) {
 		beadsPath = filepath.Join(townRoot, ctx.Rig)
 	}
 	bd := beads.New(beadsPath)
+	// agentBd bypasses prefix routing — agent beads (gt:agent label) live in
+	// the town DB regardless of their ID prefix, but the rig-prefix routing
+	// would otherwise misroute them to the rig DB and silently fail with
+	// "issue not found". See beads.ForAgentBead docstring for details.
+	agentBd := bd.ForAgentBead()
 
 	// Find the hooked bead to close. Use issueID directly instead of reading
 	// agent bead's hook_bead slot (hq-l6mm5: direct bead tracking).
@@ -1861,7 +1871,7 @@ doneStateUpdate:
 	// wisp that gets reaped, the witness can't verify it was closed and flags
 	// the polecat as a zombie. Clearing hook_bead prevents this false positive.
 	emptyHook := ""
-	if err := bd.UpdateAgentDescriptionFields(agentBeadID, beads.AgentFieldUpdates{HookBead: &emptyHook}); err != nil {
+	if err := agentBd.UpdateAgentDescriptionFields(agentBeadID, beads.AgentFieldUpdates{HookBead: &emptyHook}); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: couldn't clear hook_bead on %s: %v\n", agentBeadID, err)
 	}
 
@@ -1882,7 +1892,7 @@ doneStateUpdate:
 		doneState = "stuck"
 	}
 	// Use UpdateAgentState to sync both column and description (gt-ulom).
-	if err := bd.UpdateAgentState(agentBeadID, doneState); err != nil {
+	if err := agentBd.UpdateAgentState(agentBeadID, doneState); err != nil {
 		fmt.Fprintf(os.Stderr, "Warning: couldn't set agent %s to %s: %v\n", agentBeadID, doneState, err)
 	}
 
@@ -1891,7 +1901,7 @@ doneStateUpdate:
 	if doneCleanupStatus != "" {
 		cleanupStatus := parseCleanupStatus(doneCleanupStatus)
 		if cleanupStatus != polecat.CleanupUnknown {
-			if err := bd.UpdateAgentCleanupStatus(agentBeadID, string(cleanupStatus)); err != nil {
+			if err := agentBd.UpdateAgentCleanupStatus(agentBeadID, string(cleanupStatus)); err != nil {
 				// Non-fatal: don't return — done-intent labels still need clearing (za-o9e)
 				fmt.Fprintf(os.Stderr, "Warning: couldn't update agent %s cleanup status: %v\n", agentBeadID, err)
 			}
@@ -1901,8 +1911,8 @@ doneStateUpdate:
 	// Clear done-intent label and checkpoints on clean exit — gt done completed
 	// successfully. If we don't reach here (crash/stuck), the Witness uses the
 	// lingering labels to detect the zombie and resume from checkpoints.
-	clearDoneIntentLabel(bd, agentBeadID)
-	clearDoneCheckpoints(bd, agentBeadID)
+	clearDoneIntentLabel(agentBd, agentBeadID)
+	clearDoneCheckpoints(agentBd, agentBeadID)
 }
 
 // findHookedBeadForAgent queries for beads with status=hooked assigned to this agent.

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -1290,9 +1290,12 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				}
 			}
 
-			// Update agent bead with active_mr reference (for traceability)
+			// Update agent bead with active_mr reference (for traceability).
+			// Agent beads live in HQ regardless of rig prefix — bypass routing
+			// via ForAgentBead() to avoid the "issue not found" warning that
+			// leaves active_mr null after every gt done (hq-e73z).
 			if agentBeadID != "" {
-				if err := bd.UpdateAgentActiveMR(agentBeadID, mrID); err != nil {
+				if err := bd.ForAgentBead().UpdateAgentActiveMR(agentBeadID, mrID); err != nil {
 					style.PrintWarning("could not update agent bead with active_mr: %v", err)
 				}
 			}

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -809,10 +809,18 @@ func (d *Daemon) getAgentBeadState(agentBeadID string) (string, error) {
 }
 
 // getAgentBeadInfo fetches and parses an agent bead by ID.
+//
+// Agent beads (gt:agent-labeled, one per polecat/witness/refinery/dog) live
+// in the town/hq Dolt DB but their IDs carry the rig prefix (e.g. za-zack-
+// polecat-furiosa). Without forcing BEADS_DIR to the town's .beads, prefix
+// routing would send the lookup to the rig's DB and return "issue not found"
+// — which the reaper at daemon.go:2796 interprets as a stale polecat and
+// kills mid-work after 3x threshold (hq-3kri). Pin the lookup to the town
+// .beads so the reaper sees the truth.
 func (d *Daemon) getAgentBeadInfo(agentBeadID string) (*AgentBeadInfo, error) {
 	cmd := exec.Command(d.bdPath, "show", agentBeadID, "--json")
 	cmd.Dir = d.config.TownRoot
-	cmd.Env = bdReadOnlyEnv()
+	cmd.Env = append(bdReadOnlyEnv(), "BEADS_DIR="+filepath.Join(d.config.TownRoot, ".beads"))
 	util.SetDetachedProcessGroup(cmd)
 
 	output, err := cmd.Output()

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1774,7 +1774,8 @@ func (m *Manager) ReuseIdlePolecat(name string, opts AddOptions) (*Polecat, erro
 	// The column stays stale (e.g., "idle" from previous gt done) until
 	// StartSession sets it to "working". Without this, the column and
 	// description diverge, causing dashboards to show incorrect state.
-	if err := m.beads.UpdateAgentState(agentID, "spawning"); err != nil {
+	// Agent beads live in town DB — bypass prefix routing.
+	if err := m.beads.ForAgentBead().UpdateAgentState(agentID, "spawning"); err != nil {
 		style.PrintWarning("could not sync agent_state column to spawning: %v", err)
 	}
 
@@ -2101,7 +2102,9 @@ func (m *Manager) Get(name string) (*Polecat, error) {
 // Valid states: "spawning", "working", "done", "stuck", "idle"
 func (m *Manager) SetAgentState(name string, state string) error {
 	agentID := m.agentBeadID(name)
-	return m.beads.UpdateAgentState(agentID, state)
+	// Agent beads live in the town DB — bypass prefix routing that would
+	// otherwise misroute "za-*" / "my-*" agent IDs to a rig DB.
+	return m.beads.ForAgentBead().UpdateAgentState(agentID, state)
 }
 
 // - StateDone: assignee cleared from issue (polecat ready for cleanup)


### PR DESCRIPTION
## Summary
Agent beads (issues with `gt:agent` label — one per polecat, dog, witness, refinery, mayor) live in the town/hq Dolt database, but their IDs carry a rig prefix (e.g. `<rig-prefix>-<rig>-polecat-<name>`). Default prefix routing therefore sends agent-bead lookups into the rig DB and returns "issue not found" — silently dropping cleanup-status, MR-pointer, and idle-state writes.

Symptom in production: `gt done` emits ~6 "issue not found" warnings per call; `agent_state` stays at `working` forever; the witness sees a "busy" polecat that's actually idle (zombie state requiring manual nuke).

This PR adds `Beads.ForAgentBead()` (sets `noRoute=true`) and threads it through the daemon's `getAgentBeadInfo` and `gt done`'s `UpdateAgentActiveMR`.

## Related Issue
Fixes the daemon getAgentBeadInfo lookup and gt done's agent-bead writes. (Tracking IDs in commit messages.)

## Changes
- `internal/beads/beads.go` + `beads_agent.go`: new `ForAgentBead()` helper with `noRoute` flag. `Show` / `forIssueID` / `UpdateAgentState` / `ResetAgentBeadForReuse` skip `ResolveRoutingTarget` when set.
- `internal/daemon/lifecycle.go`: `getAgentBeadInfo` uses `bdReadOnlyEnv()` + `BEADS_DIR=townRoot/.beads` override (subprocess equivalent of `ForAgentBead`).
- `internal/cmd/done.go`: switch all agent-bead writes (cleanup status, MR pointer, idle state, done-intent label, checkpoints) to the `agentBd := bd.ForAgentBead()` handle.
- `internal/polecat/manager.go`: same routing fix for `ResetAgentBeadForReuse`.

## Testing
- [x] `go build ./internal/...` clean
- [ ] Manual: run `gt done` in a polecat — should emit ZERO "issue not found" warnings; `agent_state` transitions `working` → `idle`.

## Checklist
- [x] Code follows project style
- [x] No breaking changes (additive helper + opt-in usage)