### PR TITLE
fix: dolt-backup + gt dog done honor GT_TOWN_ROOT (2 commits)

### DIFF
--- a/internal/cmd/dog.go
+++ b/internal/cmd/dog.go
@@ -299,8 +299,14 @@ func init() {
 }
 
 // getDogManager creates a dog.Manager with the current town root.
+//
+// Use FindFromCwdOrError so we honor GT_TOWN_ROOT/GT_ROOT env vars when
+// invoked from a dog worktree (e.g. ~/gt/deacon/dogs/alpha/<rig>/), where
+// FindFromCwd alone might walk up to a non-town ancestor or stop at a path
+// without mayor/rigs.json — which previously broke `gt dog done` and
+// blocked DOG_DONE delivery (hq-zyvo).
 func getDogManager() (*dog.Manager, error) {
-	townRoot, err := workspace.FindFromCwd()
+	townRoot, err := workspace.FindFromCwdOrError()
 	if err != nil {
 		return nil, fmt.Errorf("finding town root: %w", err)
 	}

--- a/plugins/dolt-backup/run.sh
+++ b/plugins/dolt-backup/run.sh
@@ -11,8 +11,24 @@ set -euo pipefail
 
 # --- Configuration -----------------------------------------------------------
 
-DOLT_DATA_DIR="${DOLT_DATA_DIR:-$HOME/gt/.dolt-data}"
-BACKUP_DIR="${DOLT_BACKUP_DIR:-$HOME/gt/.dolt-backup}"
+# Honor GT_TOWN_ROOT first (set by daemon when invoking plugins). The
+# earlier hardcoded ~/gt fallback caused "No databases found" for towns
+# rooted elsewhere (hq-huub).
+if [[ -z "${DOLT_DATA_DIR:-}" ]]; then
+  if [[ -n "${GT_TOWN_ROOT:-}" && -d "$GT_TOWN_ROOT/.dolt-data" ]]; then
+    DOLT_DATA_DIR="$GT_TOWN_ROOT/.dolt-data"
+  else
+    DOLT_DATA_DIR="$HOME/gt/.dolt-data"
+  fi
+fi
+if [[ -z "${DOLT_BACKUP_DIR:-}" ]]; then
+  if [[ -n "${GT_TOWN_ROOT:-}" ]]; then
+    DOLT_BACKUP_DIR="$GT_TOWN_ROOT/.dolt-backup"
+  else
+    DOLT_BACKUP_DIR="$HOME/gt/.dolt-backup"
+  fi
+fi
+BACKUP_DIR="$DOLT_BACKUP_DIR"
 BACKUP_TIMEOUT=60
 
 # --- Argument parsing ---------------------------------------------------------


### PR DESCRIPTION
## Summary
Two adjacent fixes for code that hard-coded `~/gt/.dolt-data` or assumed the default workspace location, breaking towns rooted elsewhere.

## Related Issue
Fixes the dolt-backup wrong-path bug and the gt dog done env-var lookup bug.

## Changes
- `plugins/dolt-backup/run.sh`: honor `GT_TOWN_ROOT` (set by daemon when invoking plugins) before falling back to `~/gt/.dolt-data`. Same for `DOLT_BACKUP_DIR`.
- `internal/cmd/dog.go`: `gt dog done`'s `getDogManager` now uses `workspace.FindFromCwdOrError` (which honors `GT_TOWN_ROOT` / `GT_ROOT`) instead of the hardcoded default — so a dog's worktree can find `rigs.json` no matter where the town is rooted.

## Testing
- [x] `go build ./internal/cmd/...` clean
- [x] `bash -n plugins/dolt-backup/run.sh` clean
- [ ] Manual: dispatch `dolt-backup` or `stuck-agent-dog` plugin in a non-default-rooted town; verify it operates against the right `.dolt-data` and exits cleanly.

## Checklist
- [x] Code follows project style
- [x] No breaking changes (defaults preserved when env vars unset)