### PR TITLE
fix: daemon augments PATH at startup so gt/bd subprocess calls work

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -270,6 +270,49 @@ func New(config *Config) (*Daemon, error) {
 	}
 
 	// PATCH-006: Resolve binary paths at startup.
+	//
+	// PATCH-007 (hq-olcb): Augment PATH with common user/local bin
+	// directories before LookPath. The daemon is often launched from a
+	// systemd unit / login shell whose PATH does not include
+	// ~/.local/bin, where pip-installed `bd` and user-installed `gt`
+	// typically live. Without this, both LookPath calls fail at
+	// startup → gtPath / bdPath fall back to literal names → every
+	// subsequent exec.Command(d.gtPath, ...) fails with "executable
+	// file not found in $PATH", which cascaded into stranded convoys
+	// (couldn't query rig beads), failed dog dispatches (wisp_reaper
+	// fell back to inline mode), and likely upstream of hq-we9c
+	// (reaper false-positives, since the polecat-has-work check uses
+	// these binaries). Augmenting the daemon's own PATH propagates to
+	// child processes via bdReadOnlyEnv()'s os.Environ() pass-through.
+	if home := os.Getenv("HOME"); home != "" {
+		extras := []string{
+			filepath.Join(home, ".local/bin"),
+			filepath.Join(home, "bin"),
+			"/usr/local/bin",
+		}
+		current := os.Getenv("PATH")
+		parts := strings.Split(current, string(os.PathListSeparator))
+		seen := make(map[string]struct{}, len(parts)+len(extras))
+		for _, p := range parts {
+			seen[p] = struct{}{}
+		}
+		augmented := parts
+		for _, extra := range extras {
+			if _, ok := seen[extra]; ok {
+				continue
+			}
+			if info, statErr := os.Stat(extra); statErr == nil && info.IsDir() {
+				augmented = append([]string{extra}, augmented...)
+				seen[extra] = struct{}{}
+			}
+		}
+		newPath := strings.Join(augmented, string(os.PathListSeparator))
+		if newPath != current {
+			_ = os.Setenv("PATH", newPath)
+			logger.Printf("PATCH-007: augmented daemon PATH with user bin dirs (was=%q, now=%q)", current, newPath)
+		}
+	}
+
 	gtPath, err := exec.LookPath("gt")
 	if err != nil {
 		gtPath = "gt"

--- a/internal/daemon/wisp_reaper.go
+++ b/internal/daemon/wisp_reaper.go
@@ -129,7 +129,11 @@ func (d *Daemon) dispatchReaperDog(vars map[string]string) error {
 
 	cmd := exec.Command(d.gtPath, args...) //nolint:gosec // G204: d.gtPath resolved at daemon init via LookPath
 	cmd.Dir = d.config.TownRoot
-	cmd.Env = bdReadOnlyEnv()
+	// Inherit os.Environ() (cmd.Env left nil) — gt sling performs WRITES
+	// (creates wisps, dispatches dogs) so it must NOT carry
+	// BD_DOLT_AUTO_COMMIT=off from bdReadOnlyEnv(). PATH augmentation at
+	// daemon startup (PATCH-007) ensures the inherited env still finds
+	// gt/bd via os.Environ()'s PATH.
 	util.SetDetachedProcessGroup(cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("gt sling: %w", err)

--- a/internal/daemon/wisp_reaper.go
+++ b/internal/daemon/wisp_reaper.go
@@ -127,8 +127,9 @@ func (d *Daemon) dispatchReaperDog(vars map[string]string) error {
 		args = append(args, "--var", fmt.Sprintf("%s=%s", k, v))
 	}
 
-	cmd := exec.Command("gt", args...)
+	cmd := exec.Command(d.gtPath, args...) //nolint:gosec // G204: d.gtPath resolved at daemon init via LookPath
 	cmd.Dir = d.config.TownRoot
+	cmd.Env = bdReadOnlyEnv()
 	util.SetDetachedProcessGroup(cmd)
 	if err := cmd.Run(); err != nil {
 		return fmt.Errorf("gt sling: %w", err)


### PR DESCRIPTION
## Summary
The daemon spawns `bd` (read-only bead lookups) and `gt` (sling, mail) as subprocesses. When the daemon is launched from a context whose `PATH` does not include `~/.local/bin` (e.g. a systemd unit, cron, or a plain login shell), `exec.LookPath` at startup fails, `gtPath` / `bdPath` fall back to literal `"gt"` / `"bd"`, and EVERY `exec.Command(d.gtPath, ...)` fails with `executable file not found in $PATH`.

Symptoms (all single root cause):
- `Warning: gt not found in PATH` / `bd not found in PATH` at every daemon startup
- `Convoy: stranded scan failed` — `convoy_manager` couldn't query rig beads
- Stranded convoys accumulate — auto-completion can't reach `bd`
- `wisp_reaper` falls back to inline degraded mode
- Likely upstream of false-positive polecat reaps: if the reaper's "polecat has work?" check spawns `bd`/`gt` and they're missing, the check fails open → reap as if idle.

## Related Issue
Fixes the daemon PATH issue and likely the related polecat-reaper false-positive bug (root cause shared).

## Changes
- `internal/daemon/daemon.go`: at startup, prepend `$HOME/.local/bin`, `$HOME/bin`, and `/usr/local/bin` (where each exists) to the daemon's own `PATH` BEFORE calling `exec.LookPath`. `os.Setenv("PATH", ...)` propagates to spawned children via `bdReadOnlyEnv()`'s `os.Environ()` pass-through, so all existing spawn sites are fixed transparently. Logged as PATCH-007.
- `internal/daemon/wisp_reaper.go`: replace literal `exec.Command("gt", ...)` with `d.gtPath` (defense in depth — if PATH augmentation doesn't catch a future deployment, this site still has a chance via the resolved absolute path). Inherit `os.Environ()` (cmd.Env left nil) — `gt sling` performs WRITES so it must NOT carry `BD_DOLT_AUTO_COMMIT=off` from `bdReadOnlyEnv()`.

## Testing
- [x] `go build ./internal/daemon/...` clean
- [x] After daemon restart with this binary in a real deployment: daemon log free of "gt not found in PATH" warnings; `gt convoy stranded` no longer reports "unknown status (cross-rig unreachable)".

## Checklist
- [x] Code follows project style
- [x] No breaking changes (additive — only EXPANDS PATH if needed dirs exist)