### PR TITLE
fix(prime): collapse active work lookups

### DIFF
--- a/internal/beads/store.go
+++ b/internal/beads/store.go
@@ -156,8 +156,17 @@ func issueFilterFromListOpts(opts ListOptions) beadsdk.IssueFilter {
 	}
 
 	if opts.Status != "" && opts.Status != "all" {
-		status := beadsdk.Status(opts.Status)
-		f.Status = &status
+		if strings.Contains(opts.Status, ",") {
+			for _, part := range strings.Split(opts.Status, ",") {
+				part = strings.TrimSpace(part)
+				if part != "" {
+					f.Statuses = append(f.Statuses, beadsdk.Status(part))
+				}
+			}
+		} else {
+			status := beadsdk.Status(opts.Status)
+			f.Status = &status
+		}
 	}
 
 	// Prefer Label; fall back to deprecated Type

--- a/internal/beads/store_test.go
+++ b/internal/beads/store_test.go
@@ -14,22 +14,22 @@ import (
 // Embeds beadsdk.Storage to satisfy unimplemented methods (they panic if called).
 type mockStorage struct {
 	beadsdk.Storage // embedded for unimplemented methods
-	issues     map[string]*beadsdk.Issue
-	labels     map[string][]string // issueID -> labels
-	deps       map[string][]string // issueID -> depends-on IDs
-	nextID     int
-	prefix     string
-	closed     map[string]bool
-	closeErr   error
-	createErr  error
-	updateErr  error
-	searchErr  error
-	getErr     error
-	addLabelErr    error
-	removeLabelErr error
-	addDepErr      error
-	removeDepErr   error
-	getLabelsErr   error
+	issues          map[string]*beadsdk.Issue
+	labels          map[string][]string // issueID -> labels
+	deps            map[string][]string // issueID -> depends-on IDs
+	nextID          int
+	prefix          string
+	closed          map[string]bool
+	closeErr        error
+	createErr       error
+	updateErr       error
+	searchErr       error
+	getErr          error
+	addLabelErr     error
+	removeLabelErr  error
+	addDepErr       error
+	removeDepErr    error
+	getLabelsErr    error
 }
 
 func newMockStorage() *mockStorage {
@@ -135,6 +135,18 @@ func (m *mockStorage) SearchIssues(_ context.Context, query string, filter beads
 		if filter.Status != nil && issue.Status != *filter.Status {
 			continue
 		}
+		if len(filter.Statuses) > 0 {
+			matchedStatus := false
+			for _, status := range filter.Statuses {
+				if issue.Status == status {
+					matchedStatus = true
+					break
+				}
+			}
+			if !matchedStatus {
+				continue
+			}
+		}
 		if filter.Assignee != nil && issue.Assignee != *filter.Assignee {
 			continue
 		}
@@ -214,7 +226,6 @@ func (m *mockStorage) RemoveDependency(_ context.Context, issueID, dependsOnID, 
 	return nil
 }
 
-
 func (m *mockStorage) AddLabel(_ context.Context, issueID, label, _ string) error {
 	if m.addLabelErr != nil {
 		return m.addLabelErr
@@ -290,6 +301,33 @@ func TestStoreList(t *testing.T) {
 	}
 	if len(issues) != 2 {
 		t.Fatalf("expected 2 issues, got %d", len(issues))
+	}
+}
+
+func TestStoreListCommaSeparatedStatuses(t *testing.T) {
+	store := newMockStorage()
+	b := newTestBeads(store)
+
+	store.issues["test-hooked"] = &beadsdk.Issue{ID: "test-hooked", Title: "hooked", Status: beadsdk.Status("hooked"), Assignee: "mayor/"}
+	store.issues["test-in-progress"] = &beadsdk.Issue{ID: "test-in-progress", Title: "ip", Status: beadsdk.Status("in_progress"), Assignee: "mayor/"}
+	store.issues["test-open"] = &beadsdk.Issue{ID: "test-open", Title: "open", Status: beadsdk.StatusOpen, Assignee: "mayor/"}
+	store.issues["test-other"] = &beadsdk.Issue{ID: "test-other", Title: "other", Status: beadsdk.Status("hooked"), Assignee: "deacon/"}
+
+	issues, err := b.List(ListOptions{Status: "hooked,in_progress", Assignee: "mayor/", Priority: -1})
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(issues) != 2 {
+		t.Fatalf("List returned %d issues, want 2: %#v", len(issues), issues)
+	}
+	got := map[string]bool{}
+	for _, issue := range issues {
+		got[issue.ID] = true
+	}
+	for _, want := range []string{"test-hooked", "test-in-progress"} {
+		if !got[want] {
+			t.Fatalf("missing %s from results %#v", want, got)
+		}
 	}
 }
 

--- a/internal/cmd/active_work_lookup.go
+++ b/internal/cmd/active_work_lookup.go
@@ -1,0 +1,165 @@
+package cmd
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+const (
+	activeWorkStatusFilter = "hooked,in_progress"
+	statusInProgress       = "in_progress"
+)
+
+// findActiveAssignedWork returns the first hooked or in-progress issue for an
+// agent with hooked work taking precedence. It intentionally performs one bd
+// list call; gt prime and gt hook are startup hot paths.
+func findActiveAssignedWork(b *beads.Beads, agentID string) (*beads.Issue, error) {
+	if agentID == "" {
+		return nil, nil
+	}
+
+	issues, err := b.List(beads.ListOptions{
+		Status:   activeWorkStatusFilter,
+		Assignee: agentID,
+		Priority: -1,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	return firstActiveAssignedWork(issues), nil
+}
+
+func findActiveAssignedWorkForAssignees(b *beads.Beads, assignees []string) (*beads.Issue, error) {
+	for _, assignee := range assignees {
+		issue, err := findActiveAssignedWork(b, assignee)
+		if err != nil {
+			return nil, err
+		}
+		if issue != nil {
+			return issue, nil
+		}
+	}
+	return nil, nil
+}
+
+func activeWorkAssignee(ctx RoleContext, fallback string) string {
+	assignees := activeWorkAssignees(ctx, fallback)
+	if len(assignees) == 0 {
+		return ""
+	}
+	return assignees[0]
+}
+
+func activeWorkAssignees(ctx RoleContext, fallback string) []string {
+	if assignee := buildAgentIdentity(ctx); assignee != "" {
+		return activeWorkTargetAliases(assignee)
+	}
+	return activeWorkTargetAliases(fallback)
+}
+
+func canonicalActiveWorkTarget(target string) string {
+	switch strings.TrimRight(target, "/") {
+	case "mayor":
+		return "mayor/"
+	case "deacon":
+		return "deacon/"
+	case "boot", "deacon-boot":
+		return "deacon/boot"
+	default:
+		return target
+	}
+}
+
+func activeWorkTargetAliases(target string) []string {
+	canonical := canonicalActiveWorkTarget(target)
+	aliases := []string{canonical}
+	switch canonical {
+	case "mayor/":
+		aliases = append(aliases, "mayor")
+	case "deacon/":
+		aliases = append(aliases, "deacon")
+	case "deacon/boot":
+		aliases = append(aliases, "boot", "deacon-boot")
+	}
+	return uniqueStrings(aliases)
+}
+
+func uniqueStrings(values []string) []string {
+	seen := make(map[string]bool, len(values))
+	unique := make([]string, 0, len(values))
+	for _, value := range values {
+		if value == "" || seen[value] {
+			continue
+		}
+		seen[value] = true
+		unique = append(unique, value)
+	}
+	return unique
+}
+
+func firstActiveAssignedWork(issues []*beads.Issue) *beads.Issue {
+	var firstInProgress *beads.Issue
+	for _, issue := range issues {
+		if issue == nil {
+			continue
+		}
+		switch issue.Status {
+		case beads.StatusHooked:
+			return issue
+		case statusInProgress:
+			if firstInProgress == nil {
+				firstInProgress = issue
+			}
+		}
+	}
+	return firstInProgress
+}
+
+func isActiveWorkStatus(status string) bool {
+	return status == beads.StatusHooked || status == statusInProgress
+}
+
+func shouldCheckLegacyHookBead(ctx RoleContext) bool {
+	switch ctx.Role {
+	case RolePolecat, RoleCrew, RoleWitness, RoleRefinery:
+		return true
+	default:
+		return false
+	}
+}
+
+func shouldCheckLegacyHookBeadBeforeActive(ctx RoleContext) bool {
+	return ctx.Role == RolePolecat || ctx.Role == RoleCrew
+}
+
+// lookupLegacyAgentHookBead follows the deprecated agent-bead hook_bead slot.
+// Normal hook state is issue status + assignee; this is retained only for older
+// worker hooks and unresolvable-hook diagnostics.
+func lookupLegacyAgentHookBead(ctx RoleContext, agentID string) (*beads.Issue, error) {
+	agentBeadID := buildAgentBeadID(agentID, ctx.Role, ctx.TownRoot)
+	if agentBeadID == "" {
+		return nil, nil
+	}
+
+	agentBeadDir := beads.ResolveHookDir(ctx.TownRoot, agentBeadID, ctx.WorkDir)
+	agentB := beads.New(agentBeadDir)
+	agentBead, err := agentB.Show(agentBeadID)
+	if err != nil || agentBead == nil || agentBead.HookBead == "" {
+		return nil, nil
+	}
+
+	hookBeadDir := beads.ResolveHookDir(ctx.TownRoot, agentBead.HookBead, ctx.WorkDir)
+	hookB := beads.New(hookBeadDir)
+	hookBead, showErr := hookB.Show(agentBead.HookBead)
+	if showErr == nil && hookBead != nil && isActiveWorkStatus(hookBead.Status) {
+		return hookBead, nil
+	}
+	if hookBead == nil || isBeadNotFound(showErr) {
+		return nil, fmt.Errorf("%w: agent=%s hook_bead=%s cwd=%s: %v",
+			ErrHookUnresolvable, agentID, agentBead.HookBead, ctx.WorkDir, showErr)
+	}
+	return nil, nil
+}

--- a/internal/cmd/active_work_lookup_test.go
+++ b/internal/cmd/active_work_lookup_test.go
@@ -1,0 +1,330 @@
+package cmd
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func TestFirstActiveAssignedWork(t *testing.T) {
+	tests := []struct {
+		name   string
+		issues []*beads.Issue
+		wantID string
+	}{
+		{
+			name: "nil list",
+		},
+		{
+			name: "ignores inactive statuses",
+			issues: []*beads.Issue{
+				{ID: "gt-open", Status: "open"},
+				{ID: "gt-closed", Status: "closed"},
+			},
+		},
+		{
+			name: "returns in progress when no hooked work exists",
+			issues: []*beads.Issue{
+				{ID: "gt-ip", Status: statusInProgress},
+			},
+			wantID: "gt-ip",
+		},
+		{
+			name: "prefers hooked over earlier in progress",
+			issues: []*beads.Issue{
+				{ID: "gt-ip", Status: statusInProgress},
+				{ID: "gt-hook", Status: beads.StatusHooked},
+			},
+			wantID: "gt-hook",
+		},
+		{
+			name: "preserves first hooked work",
+			issues: []*beads.Issue{
+				{ID: "gt-hook-1", Status: beads.StatusHooked},
+				{ID: "gt-hook-2", Status: beads.StatusHooked},
+			},
+			wantID: "gt-hook-1",
+		},
+		{
+			name: "skips nil entries",
+			issues: []*beads.Issue{
+				nil,
+				{ID: "gt-ip", Status: statusInProgress},
+			},
+			wantID: "gt-ip",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := firstActiveAssignedWork(tt.issues)
+			if tt.wantID == "" {
+				if got != nil {
+					t.Fatalf("expected nil, got %s", got.ID)
+				}
+				return
+			}
+			if got == nil {
+				t.Fatalf("expected %s, got nil", tt.wantID)
+			}
+			if got.ID != tt.wantID {
+				t.Fatalf("expected %s, got %s", tt.wantID, got.ID)
+			}
+		})
+	}
+}
+
+func TestActiveWorkAssigneeUsesCanonicalHookAddress(t *testing.T) {
+	tests := []struct {
+		name     string
+		ctx      RoleContext
+		fallback string
+		want     string
+	}{
+		{
+			name:     "mayor uses trailing slash",
+			ctx:      RoleContext{Role: RoleMayor},
+			fallback: "mayor",
+			want:     "mayor/",
+		},
+		{
+			name:     "deacon uses trailing slash",
+			ctx:      RoleContext{Role: RoleDeacon},
+			fallback: "deacon",
+			want:     "deacon/",
+		},
+		{
+			name:     "boot uses deacon boot address",
+			ctx:      RoleContext{Role: RoleBoot},
+			fallback: "boot",
+			want:     "deacon/boot",
+		},
+		{
+			name:     "unknown falls back",
+			ctx:      RoleContext{Role: RoleUnknown},
+			fallback: "custom",
+			want:     "custom",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := activeWorkAssignee(tt.ctx, tt.fallback); got != tt.want {
+				t.Fatalf("activeWorkAssignee() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCanonicalActiveWorkTarget(t *testing.T) {
+	tests := []struct {
+		target string
+		want   string
+	}{
+		{target: "mayor", want: "mayor/"},
+		{target: "mayor/", want: "mayor/"},
+		{target: "deacon", want: "deacon/"},
+		{target: "deacon/", want: "deacon/"},
+		{target: "boot", want: "deacon/boot"},
+		{target: "deacon-boot", want: "deacon/boot"},
+		{target: "gastown/witness", want: "gastown/witness"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.target, func(t *testing.T) {
+			if got := canonicalActiveWorkTarget(tt.target); got != tt.want {
+				t.Fatalf("canonicalActiveWorkTarget(%q) = %q, want %q", tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestActiveWorkTargetAliasesIncludeLegacyTownAssignees(t *testing.T) {
+	tests := []struct {
+		target string
+		want   []string
+	}{
+		{target: "mayor", want: []string{"mayor/", "mayor"}},
+		{target: "mayor/", want: []string{"mayor/", "mayor"}},
+		{target: "deacon", want: []string{"deacon/", "deacon"}},
+		{target: "deacon/", want: []string{"deacon/", "deacon"}},
+		{target: "boot", want: []string{"deacon/boot", "boot", "deacon-boot"}},
+		{target: "gastown/witness", want: []string{"gastown/witness"}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.target, func(t *testing.T) {
+			got := activeWorkTargetAliases(tt.target)
+			if len(got) != len(tt.want) {
+				t.Fatalf("aliases = %#v, want %#v", got, tt.want)
+			}
+			for i := range tt.want {
+				if got[i] != tt.want[i] {
+					t.Fatalf("aliases = %#v, want %#v", got, tt.want)
+				}
+			}
+		})
+	}
+}
+
+func TestFindAgentWorkOnceUsesCanonicalTownAssignee(t *testing.T) {
+	workDir := t.TempDir()
+	if err := os.Mkdir(filepath.Join(workDir, ".beads"), 0700); err != nil {
+		t.Fatalf("create .beads: %v", err)
+	}
+
+	binDir := filepath.Join(workDir, "bin")
+	if err := os.Mkdir(binDir, 0700); err != nil {
+		t.Fatalf("create bin dir: %v", err)
+	}
+	logPath := filepath.Join(workDir, "bd-args.log")
+	bdPath := filepath.Join(binDir, "bd")
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %q
+case "$*" in
+  *"--allow-stale version"*) echo "bd test"; exit 0 ;;
+  *"--status=hooked,in_progress"*"--assignee=mayor/"*)
+    printf '%%s\n' '[{"id":"hq-work","title":"Hooked work","status":"hooked","priority":2,"issue_type":"task","assignee":"mayor/"}]'
+    exit 0
+    ;;
+esac
+printf '%%s\n' '[]'
+`, logPath)
+	if err := os.WriteFile(bdPath, []byte(script), 0700); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+
+	beads.ResetBdAllowStaleCacheForTest()
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GT_BD_TIMEOUT_SEC", "5")
+
+	issue, err := findAgentWorkOnce(RoleContext{Role: RoleMayor, WorkDir: workDir, TownRoot: workDir}, "mayor")
+	if err != nil {
+		t.Fatalf("findAgentWorkOnce: %v", err)
+	}
+	if issue == nil || issue.ID != "hq-work" {
+		t.Fatalf("findAgentWorkOnce issue = %#v, want hq-work", issue)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd args log: %v", err)
+	}
+	logText := string(logData)
+	if !strings.Contains(logText, "--assignee=mayor/") {
+		t.Fatalf("bd args did not use canonical mayor/ assignee:\n%s", logText)
+	}
+}
+
+func TestDetectSessionStateUsesTownRootForMayorHome(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(townRoot, ".beads"), 0700); err != nil {
+		t.Fatalf("create town .beads: %v", err)
+	}
+	mayorHome := filepath.Join(townRoot, "mayor")
+	if err := os.Mkdir(mayorHome, 0700); err != nil {
+		t.Fatalf("create mayor home: %v", err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.Mkdir(binDir, 0700); err != nil {
+		t.Fatalf("create bin dir: %v", err)
+	}
+	logPath := filepath.Join(townRoot, "bd-args.log")
+	bdPath := filepath.Join(binDir, "bd")
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %q
+case "$*" in
+  *"--allow-stale version"*) echo "bd test"; exit 0 ;;
+  *"show hq-mayor"*) echo "unexpected legacy agent lookup" >&2; exit 2 ;;
+  *"--status=hooked --assignee=mayor/"*) echo "unexpected serial hooked lookup" >&2; exit 3 ;;
+  *"--status=in_progress --assignee=mayor/"*) echo "unexpected serial in_progress lookup" >&2; exit 4 ;;
+  *"--status=hooked,in_progress"*"--assignee=mayor/"*)
+    printf '%%s\n' '[{"id":"hq-work","title":"Hooked work","status":"hooked","priority":2,"issue_type":"task","assignee":"mayor/"}]'
+    exit 0
+    ;;
+esac
+printf '%%s\n' '[]'
+`, logPath)
+	if err := os.WriteFile(bdPath, []byte(script), 0700); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+
+	beads.ResetBdAllowStaleCacheForTest()
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GT_BD_TIMEOUT_SEC", "5")
+
+	state := detectSessionState(RoleContext{Role: RoleMayor, WorkDir: mayorHome, TownRoot: townRoot})
+	if state.State != "autonomous" {
+		t.Fatalf("state.State = %q, want autonomous", state.State)
+	}
+	if state.HookedBead != "hq-work" {
+		t.Fatalf("state.HookedBead = %q, want hq-work", state.HookedBead)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd args log: %v", err)
+	}
+	logText := string(logData)
+	if !strings.Contains(logText, "--assignee=mayor/") {
+		t.Fatalf("bd args did not use canonical mayor/ assignee:\n%s", logText)
+	}
+	if strings.Contains(logText, "show hq-mayor") {
+		t.Fatalf("detectSessionState used legacy agent-bead lookup:\n%s", logText)
+	}
+}
+
+func TestDetectSessionStateFallsBackToLegacyBareTownAssignee(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(townRoot, ".beads"), 0700); err != nil {
+		t.Fatalf("create town .beads: %v", err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.Mkdir(binDir, 0700); err != nil {
+		t.Fatalf("create bin dir: %v", err)
+	}
+	logPath := filepath.Join(townRoot, "bd-args.log")
+	bdPath := filepath.Join(binDir, "bd")
+	script := fmt.Sprintf(`#!/bin/sh
+printf '%%s\n' "$*" >> %q
+case "$*" in
+  *"--allow-stale version"*) echo "bd test"; exit 0 ;;
+  *"--status=hooked,in_progress"*"--assignee=deacon/"*) printf '%%s\n' '[]'; exit 0 ;;
+  *"--status=hooked,in_progress"*"--assignee=deacon"*)
+    printf '%%s\n' '[{"id":"hq-legacy","title":"Legacy work","status":"hooked","priority":2,"issue_type":"task","assignee":"deacon"}]'
+    exit 0
+    ;;
+esac
+printf '%%s\n' '[]'
+`, logPath)
+	if err := os.WriteFile(bdPath, []byte(script), 0700); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+
+	beads.ResetBdAllowStaleCacheForTest()
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GT_BD_TIMEOUT_SEC", "5")
+
+	state := detectSessionState(RoleContext{Role: RoleDeacon, WorkDir: townRoot, TownRoot: townRoot})
+	if state.State != "autonomous" {
+		t.Fatalf("state.State = %q, want autonomous", state.State)
+	}
+	if state.HookedBead != "hq-legacy" {
+		t.Fatalf("state.HookedBead = %q, want hq-legacy", state.HookedBead)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd args log: %v", err)
+	}
+	logText := string(logData)
+	if !strings.Contains(logText, "--assignee=deacon/") || !strings.Contains(logText, "--assignee=deacon") {
+		t.Fatalf("bd args did not query canonical and legacy deacon assignees:\n%s", logText)
+	}
+}

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -336,7 +336,7 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 
 	if len(args) > 0 {
 		// Explicit target provided
-		target = args[0]
+		target = canonicalActiveWorkTarget(args[0])
 	} else {
 		// Use cwd-based detection for status display
 		// This ensures we show the hook for the agent whose directory we're in,
@@ -405,57 +405,33 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 			}
 		}
 
-		// Query for hooked beads using the authoritative source: bead status + assignee.
-		// First try status=hooked (work that's been slung but not yet claimed)
-		hookedBeads, err := b.List(beads.ListOptions{
-			Status:   beads.StatusHooked,
-			Assignee: target,
-			Priority: -1,
-		})
+		// Query for active work using the authoritative source: bead status + assignee.
+		assignees := activeWorkTargetAliases(target)
+		hookBead, err := findActiveAssignedWorkForAssignees(b, assignees)
 		if err != nil {
 			return nil
 		}
 
-		// If no hooked beads found, also check in_progress beads assigned to this agent.
-		// This handles the case where work was claimed (status changed to in_progress)
-		// but the session was interrupted before completion. The hook should persist.
-		if len(hookedBeads) == 0 {
-			inProgressBeads, _ := b.List(beads.ListOptions{
-				Status:   "in_progress",
-				Assignee: target,
-				Priority: -1,
-			})
-			hookedBeads = inProgressBeads
-		}
-
 		// For town-level roles (mayor, deacon), scan all rigs if nothing found locally
-		if len(hookedBeads) == 0 && isTownLevelRole(target) {
-			hookedBeads = scanAllRigsForHookedBeads(townRoot, target)
+		if hookBead == nil && isTownLevelRole(target) {
+			if hookedBeads := scanAllRigsForHookedBeads(townRoot, target); len(hookedBeads) > 0 {
+				hookBead = hookedBeads[0]
+			}
 		}
 
 		// For rig-level agents (polecats, crew), also search town-level beads.
 		// When the Mayor slings an hq-* bead to a polecat, the bead lives in
 		// townRoot/.beads, not the rig's .beads database.
 		// See: https://github.com/steveyegge/gastown/issues/1438
-		if len(hookedBeads) == 0 && !isTownLevelRole(target) && townRoot != "" {
+		if hookBead == nil && len(assignees) > 0 && !isTownLevelRole(assignees[0]) && townRoot != "" {
 			townB := beads.New(filepath.Join(townRoot, ".beads"))
-			if townHooked, err := townB.List(beads.ListOptions{
-				Status:   beads.StatusHooked,
-				Assignee: target,
-				Priority: -1,
-			}); err == nil && len(townHooked) > 0 {
-				hookedBeads = townHooked
-			} else if townInProgress, err := townB.List(beads.ListOptions{
-				Status:   "in_progress",
-				Assignee: target,
-				Priority: -1,
-			}); err == nil && len(townInProgress) > 0 {
-				hookedBeads = townInProgress
+			if townHookBead, err := findActiveAssignedWorkForAssignees(townB, assignees); err == nil && townHookBead != nil {
+				hookBead = townHookBead
 			}
 		}
 
-		if len(hookedBeads) > 0 {
-			return hookedBeads[0]
+		if hookBead != nil {
+			return hookBead
 		}
 		return nil
 	}
@@ -466,7 +442,8 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 	var hookBead *beads.Issue
 	isPolecat := roleCtx.Role == RolePolecat ||
 		(os.Getenv("GT_ROLE") != "" && func() bool {
-			r, _, _ := parseRoleString(os.Getenv("GT_ROLE")); return r == RolePolecat
+			r, _, _ := parseRoleString(os.Getenv("GT_ROLE"))
+			return r == RolePolecat
 		}())
 
 	hookBead = lookupHookedWork()
@@ -1214,32 +1191,13 @@ func scanAllRigsForHookedBeads(townRoot, target string) []*beads.Issue {
 		}
 
 		b := beads.New(rigBeadsDir)
-		// First check for hooked beads
-		hookedBeads, err := b.List(beads.ListOptions{
-			Status:   beads.StatusHooked,
-			Assignee: target,
-			Priority: -1,
-		})
+		hookBead, err := findActiveAssignedWorkForAssignees(b, activeWorkTargetAliases(target))
 		if err != nil {
 			continue
 		}
 
-		if len(hookedBeads) > 0 {
-			return hookedBeads
-		}
-
-		// Also check for in_progress beads (work that was claimed but session interrupted)
-		inProgressBeads, err := b.List(beads.ListOptions{
-			Status:   "in_progress",
-			Assignee: target,
-			Priority: -1,
-		})
-		if err != nil {
-			continue
-		}
-
-		if len(inProgressBeads) > 0 {
-			return inProgressBeads
+		if hookBead != nil {
+			return []*beads.Issue{hookBead}
 		}
 	}
 

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -553,7 +553,7 @@ var memoryTypeLabels = map[string]string{
 	"feedback":  "Behavioral Rules (from user feedback)",
 	"user":      "User Context",
 	"project":   "Project Context",
-	"reference":  "Reference Links",
+	"reference": "Reference Links",
 	"general":   "General",
 }
 
@@ -666,8 +666,8 @@ func hasWorkflowAttachment(attachment *beads.AttachmentFields) bool {
 }
 
 // findAgentWork looks up hooked or in-progress beads assigned to this agent.
-// Primary: reads hook_bead from the agent bead (same strategy as detectSessionState/gt hook).
-// Fallback: queries by assignee for agents without an agent bead.
+// Primary: queries active work by assignee. Worker roles still check the legacy
+// hook_bead slot first to preserve cross-rig unresolvable-hook diagnostics.
 // For polecats and crew, retries up to 3 times with 2-second delays to handle
 // the timing race where hook state hasn't propagated by the time gt prime runs.
 // See: https://github.com/steveyegge/gastown/issues/1438
@@ -760,84 +760,51 @@ func findAgentWorkOnce(ctx RoleContext, agentID string) (*beads.Issue, error) {
 	// polecats to miss hooked work and exit immediately. The rig root directory
 	// always has the authoritative .beads/ database. (GH#2503)
 	b := beads.New(rigBeadsRoot(ctx))
+	assignees := activeWorkAssignees(ctx, agentID)
 
-	// Agent bead's hook_bead field. NOTE: updateAgentHookBead was made a no-op
-	// (see sling_helpers.go), so HookBead is typically empty. Kept for backward
-	// compatibility with agent beads that still have hook_bead set.
-	agentBeadID := buildAgentBeadID(agentID, ctx.Role, ctx.TownRoot)
-	if agentBeadID != "" {
-		agentBeadDir := beads.ResolveHookDir(ctx.TownRoot, agentBeadID, ctx.WorkDir)
-		ab := beads.New(agentBeadDir)
-		if agentBead, err := ab.Show(agentBeadID); err == nil && agentBead != nil && agentBead.HookBead != "" {
-			hookBeadDir := beads.ResolveHookDir(ctx.TownRoot, agentBead.HookBead, ctx.WorkDir)
-			hb := beads.New(hookBeadDir)
-			hookBead, showErr := hb.Show(agentBead.HookBead)
-			if showErr == nil && hookBead != nil &&
-				(hookBead.Status == beads.StatusHooked || hookBead.Status == "in_progress") {
-				return hookBead, nil
-			}
-			// The agent bead names a hook bead but `bd show` cannot find it.
-			// This is the cross-rig dispatch failure mode (gt-el4): an `hq-`
-			// bead was handed to a polecat whose DB only resolves `gt-`. Fail
-			// fast — never pontificate, the witness will clear the hook on
-			// its next sweep and the dispatcher will (or won't) re-issue.
-			if hookBead == nil || isBeadNotFound(showErr) {
-				return nil, fmt.Errorf("%w: agent=%s hook_bead=%s cwd=%s: %v",
-					ErrHookUnresolvable, agentID, agentBead.HookBead, ctx.WorkDir, showErr)
-			}
-		}
-	}
-
-	// Fallback: query by assignee
-	hookedBeads, err := b.List(beads.ListOptions{
-		Status:   beads.StatusHooked,
-		Assignee: agentID,
-		Priority: -1,
-	})
-	if err != nil {
-		return nil, fmt.Errorf("querying hooked beads: %w", err)
-	}
-
-	// Fall back to in_progress beads (session interrupted before completion)
-	if len(hookedBeads) == 0 {
-		inProgressBeads, err := b.List(beads.ListOptions{
-			Status:   "in_progress",
-			Assignee: agentID,
-			Priority: -1,
-		})
+	if shouldCheckLegacyHookBeadBeforeActive(ctx) {
+		legacyHookBead, err := lookupLegacyAgentHookBead(ctx, agentID)
 		if err != nil {
-			return nil, fmt.Errorf("querying in-progress beads: %w", err)
+			return nil, err
 		}
-		if len(inProgressBeads) > 0 {
-			hookedBeads = inProgressBeads
+		if legacyHookBead != nil {
+			return legacyHookBead, nil
 		}
+	}
+
+	// Primary: query active work by assignee in one hot-path lookup. The
+	// legacy agent-bead hook_bead slot is no longer maintained for normal
+	// dispatch, so avoid paying that lookup on every mayor/deacon prime.
+	hookedBead, err := findActiveAssignedWorkForAssignees(b, assignees)
+	if err != nil {
+		return nil, fmt.Errorf("querying active work: %w", err)
 	}
 
 	// Town-level fallback: rig-level agents (polecats, crew) may have hooked
 	// HQ beads (hq-* prefix) stored in townRoot/.beads, not the rig's database.
 	// Matches the fallback in molecule_status.go and unsling.go. (gt-dtq7)
-	if len(hookedBeads) == 0 && !isTownLevelRole(agentID) && ctx.TownRoot != "" {
+	if hookedBead == nil && len(assignees) > 0 && !isTownLevelRole(assignees[0]) && ctx.TownRoot != "" {
 		townB := beads.New(filepath.Join(ctx.TownRoot, ".beads"))
-		if townHooked, err := townB.List(beads.ListOptions{
-			Status:   beads.StatusHooked,
-			Assignee: agentID,
-			Priority: -1,
-		}); err == nil && len(townHooked) > 0 {
-			hookedBeads = townHooked
-		} else if townIP, err := townB.List(beads.ListOptions{
-			Status:   "in_progress",
-			Assignee: agentID,
-			Priority: -1,
-		}); err == nil && len(townIP) > 0 {
-			hookedBeads = townIP
+		if townHookBead, err := findActiveAssignedWorkForAssignees(townB, assignees); err == nil && townHookBead != nil {
+			hookedBead = townHookBead
 		}
 		// Town-level fallback errors are non-fatal — rig-level query succeeded
 	}
 
-	if len(hookedBeads) == 0 {
+	// Legacy worker fallback: older hooks may still be stored only in the agent
+	// bead's hook_bead field. Keep this off the mayor hot path.
+	if hookedBead == nil && shouldCheckLegacyHookBead(ctx) && !shouldCheckLegacyHookBeadBeforeActive(ctx) {
+		legacyHookBead, err := lookupLegacyAgentHookBead(ctx, agentID)
+		if err != nil {
+			return nil, err
+		}
+		hookedBead = legacyHookBead
+	}
+
+	if hookedBead == nil {
 		return nil, nil
 	}
-	return hookedBeads[0], nil
+	return hookedBead, nil
 }
 
 // rigBeadsRoot returns the directory to use for beads queries.

--- a/internal/cmd/prime_session.go
+++ b/internal/cmd/prime_session.go
@@ -305,8 +305,8 @@ func detectSessionState(ctx RoleContext) SessionState {
 	}
 
 	// Check for hooked work (autonomous state).
-	// Primary: read hook_bead from the agent bead's DB column (same strategy as gt hook).
-	// Fallback: query hooked/in_progress beads by assignee.
+	// Primary: query hooked/in_progress beads by assignee.
+	// Fallback: read legacy hook_bead from worker/rig agent beads.
 	agentID := getAgentIdentity(ctx)
 	if agentID != "" {
 		// Use rig beads directory, not polecat worktree. Polecats don't have their
@@ -318,68 +318,34 @@ func detectSessionState(ctx RoleContext) SessionState {
 				beadsDir = rigDir
 			}
 		}
-		b := beads.New(beadsDir)
-		// Primary: agent bead's hook_bead field (authoritative, set by bd slot set during sling)
-		agentBeadID := buildAgentBeadID(agentID, ctx.Role, ctx.TownRoot)
-		if agentBeadID != "" {
-			agentBeadDir := beads.ResolveHookDir(ctx.TownRoot, agentBeadID, ctx.WorkDir)
-			ab := beads.New(agentBeadDir)
-			if agentBead, err := ab.Show(agentBeadID); err == nil && agentBead != nil && agentBead.HookBead != "" {
-				// Resolve and verify the target bead exists with active status
-				// (mirrors molecule_status.go and signal_stop.go patterns)
-				hookBeadDir := beads.ResolveHookDir(ctx.TownRoot, agentBead.HookBead, ctx.WorkDir)
-				hb := beads.New(hookBeadDir)
-				if hookBead, err := hb.Show(agentBead.HookBead); err == nil && hookBead != nil &&
-					(hookBead.Status == beads.StatusHooked || hookBead.Status == "in_progress") {
-					state.State = "autonomous"
-					state.HookedBead = agentBead.HookBead
-					return state
-				}
+		assignees := activeWorkAssignees(ctx, agentID)
+		if _, err := os.Stat(filepath.Join(beadsDir, ".beads")); err != nil && ctx.TownRoot != "" {
+			if _, townErr := os.Stat(filepath.Join(ctx.TownRoot, ".beads")); townErr == nil {
+				beadsDir = ctx.TownRoot
 			}
 		}
-
-		// Fallback: query by assignee
-		hookedBeads, err := b.List(beads.ListOptions{
-			Status:   beads.StatusHooked,
-			Assignee: agentID,
-			Priority: -1,
-		})
-		if err == nil && len(hookedBeads) > 0 {
-			state.State = "autonomous"
-			state.HookedBead = hookedBeads[0].ID
-			return state
-		}
-		// Also check in_progress beads
-		inProgressBeads, err := b.List(beads.ListOptions{
-			Status:   "in_progress",
-			Assignee: agentID,
-			Priority: -1,
-		})
-		if err == nil && len(inProgressBeads) > 0 {
-			state.State = "autonomous"
-			state.HookedBead = inProgressBeads[0].ID
-			return state
+		if _, err := os.Stat(filepath.Join(beadsDir, ".beads")); err == nil {
+			b := beads.New(beadsDir)
+			if hookBead, err := findActiveAssignedWorkForAssignees(b, assignees); err == nil && hookBead != nil {
+				state.State = "autonomous"
+				state.HookedBead = hookBead.ID
+				return state
+			}
 		}
 		// Town-level fallback: rig-level agents may have hooked HQ beads
 		// stored in townRoot/.beads. Matches prime.go and molecule_status.go. (gt-dtq7)
-		if !isTownLevelRole(agentID) && ctx.TownRoot != "" {
+		if len(assignees) > 0 && !isTownLevelRole(assignees[0]) && ctx.TownRoot != "" {
 			townB := beads.New(filepath.Join(ctx.TownRoot, ".beads"))
-			if townHooked, err := townB.List(beads.ListOptions{
-				Status:   beads.StatusHooked,
-				Assignee: agentID,
-				Priority: -1,
-			}); err == nil && len(townHooked) > 0 {
+			if townHookBead, err := findActiveAssignedWorkForAssignees(townB, assignees); err == nil && townHookBead != nil {
 				state.State = "autonomous"
-				state.HookedBead = townHooked[0].ID
+				state.HookedBead = townHookBead.ID
 				return state
 			}
-			if townIP, err := townB.List(beads.ListOptions{
-				Status:   "in_progress",
-				Assignee: agentID,
-				Priority: -1,
-			}); err == nil && len(townIP) > 0 {
+		}
+		if shouldCheckLegacyHookBead(ctx) {
+			if hookBead, err := lookupLegacyAgentHookBead(ctx, agentID); err == nil && hookBead != nil {
 				state.State = "autonomous"
-				state.HookedBead = townIP[0].ID
+				state.HookedBead = hookBead.ID
 				return state
 			}
 		}


### PR DESCRIPTION
## Summary
- Replace serialized `hooked` then `in_progress` startup scans with one combined active-work lookup that preserves `hooked` precedence.
- Keep worker legacy `hook_bead` fallback for unresolvable-hook diagnostics, while avoiding that stale lookup on the mayor/deacon hot path.
- Teach the in-process beads store path to honor comma-separated status filters so the shared lookup behaves consistently with `bd list`.

## Bug
Addresses #3928.

`gt prime --state` was doing multiple serialized HQ/beads reads on startup. In the reproduced mayor workspace, installed `gt prime --state` took about 32s, with each underlying bd read costing several seconds. Full `gt prime`, `gt hook`, and mail reads were also contributing to repeated Dolt pressure/outages during investigation.

## Why this change
The active-work check only needs to know whether an agent has `hooked` or `in_progress` work. Querying those statuses separately doubles the bd/Dolt round trips on the startup hot path. This PR consolidates that into one active-work helper, while keeping compatibility with existing assigned work:

- Canonical town assignees are queried first (`mayor/`, `deacon/`, `deacon/boot`).
- Legacy bare assignees are also queried (`mayor`, `deacon`, `boot`, `deacon-boot`) so existing hooked work is not missed after upgrade.
- Polecat/crew legacy `hook_bead` lookup remains before active-work lookup to preserve cross-rig `ErrHookUnresolvable` behavior.
- Witness/refinery legacy `hook_bead` lookup remains as a fallback.

## Validation
- `go test -vet=off ./internal/cmd -run 'TestFirstActiveAssignedWork|TestActiveWorkAssigneeUsesCanonicalHookAddress|TestCanonicalActiveWorkTarget|TestActiveWorkTargetAliasesIncludeLegacyTownAssignees|TestFindAgentWorkOnceUsesCanonicalTownAssignee|TestDetectSessionStateUsesTownRootForMayorHome|TestDetectSessionStateFallsBackToLegacyBareTownAssignee|TestDetectSessionState|TestOutputState' -count=1 -timeout 60s`
- `go test -vet=off ./internal/beads -run 'TestStoreListCommaSeparatedStatuses|TestStoreList' -count=1 -timeout 30s`
- `go build -o /tmp/opencode/gt-prime-fix ./cmd/gt`
- `git diff --check`

Timing from the same mayor workspace:
- Before: installed `gt prime --state` around 32s.
- After: branch `gt prime --state` around 10-13s.
- Remaining floor: direct active bd query still around 5-9s, so this mitigates the serialized hot-path cost but does not claim to fix all bd/Dolt latency.

Not run: full `go test ./...`. The local Dolt server repeatedly flapped during this investigation; the PR is limited to focused unit coverage and a local build.

## Review
Five read-only review passes checked correctness, performance scope, tests, maintainer fit, and regression risk. Findings about town-role canonical assignees, role-home `prime --state`, and store-backed comma status filters were addressed before opening this PR.