### PR TITLE
fix(prime): bound external tool injection

### DIFF
--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -22,6 +22,7 @@ import (
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/telemetry"
 	"github.com/steveyegge/gastown/internal/tmux"
+	"github.com/steveyegge/gastown/internal/util"
 	"github.com/steveyegge/gastown/internal/workspace"
 )
 
@@ -31,6 +32,11 @@ var primeState bool
 var primeStateJSON bool
 var primeExplain bool
 var primeStructuredSessionStartOutput bool
+
+// Prime's external injections are best-effort; role context should still
+// return when bd/mail is slow or wedged.
+var primeExternalToolTimeout = 5 * time.Second
+var primeExternalToolWaitDelay = time.Second
 
 // primeHookSource stores the SessionStart source ("startup", "resume", "clear", "compact")
 // when running in hook mode. Used to provide lighter output on compaction/resume.
@@ -517,22 +523,31 @@ func runPrimeExternalTools(cwd string) {
 		return
 	}
 	runBdPrime(cwd)
-	runMemoryInject()
+	runMemoryInject(cwd)
 	runMailCheckInject(cwd)
+}
+
+func runPrimeExternalCommand(workDir, name string, args ...string) (bytes.Buffer, bytes.Buffer, error) {
+	var stdout, stderr bytes.Buffer
+	ctx, cancel := context.WithTimeout(context.Background(), primeExternalToolTimeout)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Dir = workDir
+	cmd.Env = os.Environ()
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	cmd.WaitDelay = primeExternalToolWaitDelay
+	util.SetProcessGroup(cmd)
+
+	return stdout, stderr, cmd.Run()
 }
 
 // runBdPrime runs `bd prime` and outputs the result.
 // This provides beads workflow context to the agent.
 func runBdPrime(workDir string) {
-	cmd := exec.Command("bd", "prime")
-	cmd.Dir = workDir
-	cmd.Env = os.Environ()
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
+	stdout, stderr, err := runPrimeExternalCommand(workDir, "bd", "prime")
+	if err != nil {
 		// Skip if bd prime fails (beads might not be available)
 		// But log stderr if present for debugging
 		if errMsg := strings.TrimSpace(stderr.String()); errMsg != "" {
@@ -559,8 +574,8 @@ var memoryTypeLabels = map[string]string{
 
 // runMemoryInject loads memories from beads kv and outputs them during prime.
 // Memories are grouped by type and ordered by priority (feedback first).
-func runMemoryInject() {
-	kvs, err := bdKvListJSON()
+func runMemoryInject(workDir string) {
+	kvs, err := bdKvListJSONForPrime(workDir)
 	if err != nil {
 		return // Silently skip if kv list fails
 	}
@@ -610,17 +625,24 @@ func runMemoryInject() {
 	}
 }
 
+func bdKvListJSONForPrime(workDir string) (map[string]string, error) {
+	stdout, _, err := runPrimeExternalCommand(workDir, "bd", "kv", "list", "--json")
+	if err != nil {
+		return nil, err
+	}
+
+	var kvs map[string]string
+	if err := json.Unmarshal(stdout.Bytes(), &kvs); err != nil {
+		return nil, fmt.Errorf("parsing kv list: %w", err)
+	}
+	return kvs, nil
+}
+
 // runMailCheckInject runs `gt mail check --inject` and outputs the result.
 // This injects any pending mail into the agent's context.
 func runMailCheckInject(workDir string) {
-	cmd := exec.Command("gt", "mail", "check", "--inject")
-	cmd.Dir = workDir
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
+	stdout, stderr, err := runPrimeExternalCommand(workDir, "gt", "mail", "check", "--inject")
+	if err != nil {
 		// Skip if mail check fails, but log stderr for debugging
 		if errMsg := strings.TrimSpace(stderr.String()); errMsg != "" {
 			fmt.Fprintf(os.Stderr, "gt mail check: %s\n", errMsg)
@@ -1273,15 +1295,8 @@ func setTmuxWorkContext(workRig, workBead, workMol string) {
 // This is called on Mayor startup to surface issues needing human attention.
 func checkPendingEscalations(ctx RoleContext) {
 	// Query for open escalations using bd list with tag filter
-	cmd := exec.Command("bd", "list", "--status=open", "--tag=escalation", "--json")
-	cmd.Dir = ctx.WorkDir
-	cmd.Env = os.Environ()
-
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-
-	if err := cmd.Run(); err != nil {
+	stdout, _, err := runPrimeExternalCommand(ctx.WorkDir, "bd", "list", "--status=open", "--tag=escalation", "--json")
+	if err != nil {
 		// Silently skip - escalation check is best-effort
 		return
 	}

--- a/internal/cmd/prime_external_tools_test.go
+++ b/internal/cmd/prime_external_tools_test.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func setupPrimeExternalToolTest(t *testing.T, bdScript, gtScript string) string {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script subprocess test")
+	}
+	tmpDir := t.TempDir()
+	logPath := filepath.Join(tmpDir, "calls.log")
+
+	oldTimeout := primeExternalToolTimeout
+	oldWaitDelay := primeExternalToolWaitDelay
+	primeExternalToolTimeout = 100 * time.Millisecond
+	primeExternalToolWaitDelay = 10 * time.Millisecond
+	t.Cleanup(func() {
+		primeExternalToolTimeout = oldTimeout
+		primeExternalToolWaitDelay = oldWaitDelay
+	})
+
+	binDir := filepath.Join(tmpDir, "bin")
+	if err := os.Mkdir(binDir, 0700); err != nil {
+		t.Fatalf("create bin dir: %v", err)
+	}
+	writePrimeToolScript(t, filepath.Join(binDir, "bd"), bdScript)
+	writePrimeToolScript(t, filepath.Join(binDir, "gt"), gtScript)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("PRIME_TOOL_CALL_LOG", logPath)
+	t.Setenv("TMUX", "")
+	primeDryRun = false
+
+	return t.TempDir()
+}
+
+func writePrimeToolScript(t *testing.T, path, body string) {
+	t.Helper()
+	tool := filepath.Base(path)
+	script := "#!/bin/sh\n" +
+		"printf '%s\\n' '" + tool + ":'\"$*\" >> \"$PRIME_TOOL_CALL_LOG\"\n" +
+		body + "\n" +
+		"printf '%s\\n' 'unexpected args: '\"$*\" >&2\n" +
+		"exit 99\n"
+	if err := os.WriteFile(path, []byte(script), 0700); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
+func assertElapsedUnder(t *testing.T, elapsed time.Duration, max time.Duration) {
+	t.Helper()
+	if elapsed > max {
+		t.Fatalf("elapsed = %v, want under %v", elapsed, max)
+	}
+}
+
+func assertPrimeToolCalled(t *testing.T, want string) {
+	t.Helper()
+	logPath := os.Getenv("PRIME_TOOL_CALL_LOG")
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read call log: %v", err)
+	}
+	if !strings.Contains(string(data), want) {
+		t.Fatalf("call log missing %q:\n%s", want, string(data))
+	}
+}
+
+func TestRunPrimeExternalTools_BoundsSlowBdPrimeAndContinues(t *testing.T) {
+	workDir := setupPrimeExternalToolTest(t, `
+case "$*" in
+  "prime") sleep 2; exit 0 ;;
+  "kv list --json") printf '%s\n' '{"memory.feedback.test":"remembered"}'; exit 0 ;;
+esac
+`, `
+case "$*" in
+  "mail check --inject") printf '%s\n' 'MAIL OUTPUT'; exit 0 ;;
+esac
+`)
+
+	start := time.Now()
+	output := captureStdout(t, func() { runPrimeExternalTools(workDir) })
+	assertElapsedUnder(t, time.Since(start), time.Second)
+	assertPrimeToolCalled(t, "bd:prime")
+	assertPrimeToolCalled(t, "bd:kv list --json")
+	assertPrimeToolCalled(t, "gt:mail check --inject")
+
+	if !strings.Contains(output, "remembered") {
+		t.Fatalf("memory injection did not continue after bd prime timeout: %q", output)
+	}
+	if !strings.Contains(output, "MAIL OUTPUT") {
+		t.Fatalf("mail injection did not continue after bd prime timeout: %q", output)
+	}
+}
+
+func TestRunPrimeExternalTools_BoundsSlowMailCheck(t *testing.T) {
+	markerDir := t.TempDir()
+	startedPath := filepath.Join(markerDir, "child-started")
+	survivedPath := filepath.Join(markerDir, "child-survived")
+	workDir := setupPrimeExternalToolTest(t, `
+case "$*" in
+  "prime") printf '%s\n' 'BD PRIME OUTPUT'; exit 0 ;;
+  "kv list --json") printf '%s\n' '{"memory.feedback.test":"remembered"}'; exit 0 ;;
+esac
+`, `
+case "$*" in
+  "mail check --inject")
+    (: > "$PRIME_CHILD_STARTED"; sleep 0.5; : > "$PRIME_CHILD_SURVIVED") &
+    while [ ! -f "$PRIME_CHILD_STARTED" ]; do sleep 0.01; done
+    wait
+    exit 0
+    ;;
+esac
+`)
+	t.Setenv("PRIME_CHILD_STARTED", startedPath)
+	t.Setenv("PRIME_CHILD_SURVIVED", survivedPath)
+
+	start := time.Now()
+	output := captureStdout(t, func() { runPrimeExternalTools(workDir) })
+	assertElapsedUnder(t, time.Since(start), time.Second)
+	assertPrimeToolCalled(t, "bd:prime")
+	assertPrimeToolCalled(t, "bd:kv list --json")
+	assertPrimeToolCalled(t, "gt:mail check --inject")
+
+	if !strings.Contains(output, "BD PRIME OUTPUT") {
+		t.Fatalf("bd prime output missing: %q", output)
+	}
+	if !strings.Contains(output, "remembered") {
+		t.Fatalf("memory output missing: %q", output)
+	}
+	if _, err := os.Stat(startedPath); err != nil {
+		t.Fatalf("child did not start before timeout: %v", err)
+	}
+
+	time.Sleep(700 * time.Millisecond)
+	if _, err := os.Stat(survivedPath); err == nil {
+		t.Fatalf("child process survived command timeout and wrote %s", survivedPath)
+	} else if !os.IsNotExist(err) {
+		t.Fatalf("check survived marker: %v", err)
+	}
+}
+
+func TestCheckPendingEscalations_BoundsSlowBdList(t *testing.T) {
+	workDir := setupPrimeExternalToolTest(t, `
+case "$*" in
+  "list --status=open --tag=escalation --json") sleep 2; exit 0 ;;
+esac
+`, `
+`)
+
+	start := time.Now()
+	output := captureStdout(t, func() {
+		checkPendingEscalations(RoleContext{Role: RoleMayor, WorkDir: workDir})
+	})
+	assertElapsedUnder(t, time.Since(start), time.Second)
+	assertPrimeToolCalled(t, "bd:list --status=open --tag=escalation --json")
+
+	if strings.Contains(output, "PENDING ESCALATIONS") {
+		t.Fatalf("timed-out escalation output should not be emitted: %q", output)
+	}
+}


### PR DESCRIPTION
## Summary
- Add a bounded helper for `gt prime`'s best-effort external subprocesses so role context can return when `bd`, mail, or Dolt-backed commands are slow or wedged.
- Apply the bound to `bd prime`, memory injection via `bd kv list --json`, `gt mail check --inject`, and the Mayor pending-escalation listing.
- Add focused tests that prove slow external commands are invoked, timed out, later prime injections still run, and same-process-group children are cleaned up on Unix-like systems.

## Bug
Related to #3928.

Full `gt prime` can render role context and then remain stuck in best-effort external injections. In this workspace, `gt mail check --inject` exceeded 90s and full `gt prime` previously timed out after printing context. That makes session startup look like `gt prime` failed even though the important role context was already available.

This does not claim to fix all of #3928. `gt prime --state` and active-work/session-state lookup latency are separate paths; closed PR #3939 targeted that area. This PR only bounds the later external-tool injection path.

## Why This Change
These subprocesses are supplemental context injection. If they are slow, prime should skip that optional context and keep the agent moving rather than blocking startup indefinitely.

The helper uses `exec.CommandContext`, a 5s per-call timeout, `WaitDelay`, and `util.SetProcessGroup` so timeout cancellation also targets same-process-group descendants on Unix-like systems.

## Related Work
- Related to #3939, which addressed active-work lookup round trips and was closed unmerged.
- Related to #3860, which addresses mail-internal subprocess cleanup.
- Related to #3863, which addresses mail-internal `bd` subprocess environment behavior.

This PR intentionally does not modify `internal/mail`; it only bounds the caller-side `gt prime` subprocesses.

## Validation
- `go test ./internal/cmd -run 'TestRunPrimeExternalTools_|TestCheckPendingEscalations_BoundsSlowBdList' -count=1 -timeout 60s`
- `go test ./internal/cmd -run 'TestParseMemoryKey|TestAutoKey|TestSanitizeKey|TestInjectWorkContext|TestOutputRoleDirectives' -count=1 -timeout 60s`
- `go build -o /tmp/opencode/gt-prime-external-timeouts ./cmd/gt`
- `git diff --cached --check`

Live sanity after build:
- Full `prime` returned instead of hanging indefinitely, but still took about 71s because earlier active-work/state paths remain slow.
- `prime --state` still took about 29s, confirming this PR should not be represented as a complete prime latency fix.
- Standalone `mail check --inject` still took about 65s, confirming mail-internal cleanup remains separate from this PR.

## Review Notes
Five independent inspection passes checked minimality, correctness, test coverage, resource cleanup, and duplicate/scope risk. The resulting patch is intentionally small: one shared helper, four call-site swaps, and focused tests.