### PR TITLE
bd-hlkrd: guard canonical Beads prefix writes

### DIFF
--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -104,6 +104,9 @@ func EnsureCustomTypes(beadsDir string) error {
 	if beadsDir == "" {
 		return fmt.Errorf("empty beads directory")
 	}
+	if err := GuardNonCanonicalRuntime(beadsDir, "configure Gas Town custom types"); err != nil {
+		return err
+	}
 
 	typesList := strings.Join(constants.BeadsCustomTypesList(), ",")
 
@@ -288,6 +291,10 @@ var prefixRe = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]{0,19}$`)
 // Uses --server mode to match all production bd init callers (gastown uses a
 // centralized Dolt sql-server). JSONL auto-import is handled by bd init itself.
 func ensureDatabaseInitialized(beadsDir string) error {
+	if err := GuardNonCanonicalRuntime(beadsDir, "initialize Gas Town beads database"); err != nil {
+		return err
+	}
+
 	// If this beads dir has a redirect, the database lives elsewhere.
 	// Never create a new database for a redirected location (polecats, crew, refinery).
 	redirectFile := filepath.Join(beadsDir, "redirect")

--- a/internal/beads/canonical_guard.go
+++ b/internal/beads/canonical_guard.go
@@ -1,0 +1,62 @@
+package beads
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// IsCanonicalRuntimeDir reports whether beadsDir is the fleet-wide canonical
+// Beads runtime. Gas Town may read canonical tasks through explicit bridge
+// code, but local town/rig setup must never mutate its issue_prefix.
+func IsCanonicalRuntimeDir(beadsDir string) bool {
+	if strings.TrimSpace(beadsDir) == "" {
+		return false
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return false
+	}
+
+	got := cleanResolvedPath(beadsDir)
+	want := cleanResolvedPath(filepath.Join(home, ".beads-runtime", ".beads"))
+	return got == want
+}
+
+// GuardNonCanonicalRuntime rejects local Gas Town config writes pointed at the
+// canonical Beads runtime.
+func GuardNonCanonicalRuntime(beadsDir, operation string) error {
+	if !IsCanonicalRuntimeDir(beadsDir) {
+		return nil
+	}
+	return fmt.Errorf("refusing %s on canonical Beads runtime %s; use a town/rig .beads directory for Gas Town prefixes", operation, beadsDir)
+}
+
+// EnvWithBeadsDir returns env with inherited Beads routing removed and replaced
+// by the explicit target. This avoids getenv-first duplicate BEADS_DIR bugs.
+func EnvWithBeadsDir(environ []string, beadsDir string) []string {
+	filtered := make([]string, 0, len(environ)+2)
+	for _, entry := range environ {
+		if strings.HasPrefix(entry, "BEADS_DIR=") ||
+			strings.HasPrefix(entry, "BEADS_DB=") ||
+			strings.HasPrefix(entry, "BEADS_DOLT_SERVER_DATABASE=") {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	filtered = append(filtered, "BEADS_DIR="+beadsDir)
+	if dbEnv := DatabaseEnv(beadsDir); dbEnv != "" {
+		filtered = append(filtered, dbEnv)
+	}
+	return filtered
+}
+
+func cleanResolvedPath(path string) string {
+	clean := filepath.Clean(path)
+	if resolved, err := filepath.EvalSymlinks(clean); err == nil {
+		return filepath.Clean(resolved)
+	}
+	return clean
+}

--- a/internal/beads/canonical_guard_test.go
+++ b/internal/beads/canonical_guard_test.go
@@ -1,0 +1,57 @@
+package beads
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestCanonicalRuntimeGuard(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	canonical := filepath.Join(home, ".beads-runtime", ".beads")
+	if err := os.MkdirAll(canonical, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if !IsCanonicalRuntimeDir(canonical) {
+		t.Fatalf("expected %s to be canonical runtime", canonical)
+	}
+	if err := GuardNonCanonicalRuntime(canonical, "test operation"); err == nil {
+		t.Fatal("expected canonical runtime guard to reject mutation")
+	}
+
+	localRig := filepath.Join(home, "gt", "rig", ".beads")
+	if err := os.MkdirAll(localRig, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if IsCanonicalRuntimeDir(localRig) {
+		t.Fatalf("did not expect %s to be canonical runtime", localRig)
+	}
+	if err := GuardNonCanonicalRuntime(localRig, "test operation"); err != nil {
+		t.Fatalf("expected local rig runtime to pass guard: %v", err)
+	}
+}
+
+func TestEnvWithBeadsDirStripsInheritedRouting(t *testing.T) {
+	got := EnvWithBeadsDir([]string{
+		"BEADS_DIR=/bad",
+		"BEADS_DB=/bad/db",
+		"BEADS_DOLT_SERVER_DATABASE=bad",
+		"KEEP=1",
+	}, "/good/.beads")
+
+	seenGood := false
+	for _, entry := range got {
+		switch entry {
+		case "BEADS_DIR=/bad", "BEADS_DB=/bad/db", "BEADS_DOLT_SERVER_DATABASE=bad":
+			t.Fatalf("inherited Beads routing env was not stripped: %v", got)
+		case "BEADS_DIR=/good/.beads":
+			seenGood = true
+		}
+	}
+	if !seenGood {
+		t.Fatalf("explicit BEADS_DIR missing from env: %v", got)
+	}
+}

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -702,6 +702,9 @@ func initTownBeads(townPath string) error {
 	}
 
 	beadsEnv := withBeadsDirEnv(beadsDir)
+	if err := beads.GuardNonCanonicalRuntime(beadsDir, "configure Gas Town HQ issue_prefix"); err != nil {
+		return err
+	}
 
 	// Set beads.role to maintainer (town-level beads are always maintainer-owned).
 	// Without this, bd doctor warns about missing role configuration.

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -599,6 +599,9 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 		// to a new workspace), we still need to run bd init to create the server-side
 		// database and set issue_prefix. Always ensure issue_prefix is set afterward.
 		if !bdDatabaseExists(sourceBeadsDir) {
+			if err := beads.GuardNonCanonicalRuntime(sourceBeadsDir, "initialize tracked rig issue_prefix"); err != nil {
+				return nil, err
+			}
 			initArgs := []string{"init"}
 			if opts.BeadsPrefix != "" {
 				initArgs = append(initArgs, "--prefix", opts.BeadsPrefix)
@@ -611,6 +614,7 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 			initArgs = append(initArgs, "--server-port", strconv.Itoa(doltCfg.Port))
 			cmd := exec.Command("bd", initArgs...)
 			cmd.Dir = mayorRigPath
+			cmd.Env = beads.EnvWithBeadsDir(os.Environ(), sourceBeadsDir)
 			if output, err := cmd.CombinedOutput(); err != nil {
 				fmt.Printf("  Warning: Could not init bd database: %v (%s)\n", err, strings.TrimSpace(string(output)))
 			}
@@ -625,12 +629,18 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 		// metadata.json was tracked in git (bdDatabaseExists returned true).
 		// The tracked metadata.json tells bd HOW to connect but doesn't guarantee
 		// the server-side database has issue_prefix set for this workspace.
+		if err := beads.GuardNonCanonicalRuntime(sourceBeadsDir, "configure tracked rig issue_prefix"); err != nil {
+			return nil, err
+		}
+		beadsEnv := beads.EnvWithBeadsDir(os.Environ(), sourceBeadsDir)
 		configCmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
 		configCmd.Dir = mayorRigPath
+		configCmd.Env = beadsEnv
 		_, _ = configCmd.CombinedOutput() // Ignore errors - older beads don't need this
 
 		prefixSetCmd := exec.Command("bd", "config", "set", "issue_prefix", opts.BeadsPrefix)
 		prefixSetCmd.Dir = mayorRigPath
+		prefixSetCmd.Env = beadsEnv
 		if prefixOutput, prefixErr := prefixSetCmd.CombinedOutput(); prefixErr != nil {
 			fmt.Printf("  Warning: Could not set issue_prefix: %v (%s)\n", prefixErr, strings.TrimSpace(string(prefixOutput)))
 		}
@@ -684,15 +694,19 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 	// Now that EnsureMetadata has corrected dolt_database, re-set it.
 	{
 		resolvedBeadsDir := beads.ResolveBeadsDir(rigPath)
+		if err := beads.GuardNonCanonicalRuntime(resolvedBeadsDir, "configure rig issue_prefix"); err != nil {
+			return nil, err
+		}
+		beadsEnv := beads.EnvWithBeadsDir(os.Environ(), resolvedBeadsDir)
 		prefixCmd := exec.Command("bd", "config", "set", "issue_prefix", opts.BeadsPrefix)
 		prefixCmd.Dir = rigPath
-		prefixCmd.Env = append(os.Environ(), "BEADS_DIR="+resolvedBeadsDir)
+		prefixCmd.Env = beadsEnv
 		if out, err := prefixCmd.CombinedOutput(); err != nil {
 			fmt.Printf("  Warning: Could not set issue_prefix on rig database: %v (%s)\n", err, strings.TrimSpace(string(out)))
 		}
 		typesCmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
 		typesCmd.Dir = rigPath
-		typesCmd.Env = append(os.Environ(), "BEADS_DIR="+resolvedBeadsDir)
+		typesCmd.Env = beadsEnv
 		_, _ = typesCmd.CombinedOutput()
 	}
 
@@ -1117,6 +1131,9 @@ func (m *Manager) InitBeads(rigPath, prefix, rigName string) error {
 
 	beadsDir := filepath.Join(rigPath, ".beads")
 	mayorRigBeads := filepath.Join(rigPath, "mayor", "rig", ".beads")
+	if err := beads.GuardNonCanonicalRuntime(beadsDir, "initialize rig issue_prefix"); err != nil {
+		return err
+	}
 
 	// Check if source repo has tracked .beads/ (cloned into mayor/rig).
 	// If so, create a redirect file instead of a new database.


### PR DESCRIPTION
Agent: codex

Feature-Key: bd-hlkrd

## Summary
- Guard canonical bdx create so new planning issues must use bd-* IDs and canonical prefix config must be consistent.
- Refuse Gastown town/rig prefix setup when it is accidentally pointed at ~/.beads-runtime/.beads.
- Strip inherited Beads routing env before local Gastown rig/town config writes.

## Why
A canonical epyc12 Beads runtime was contaminated with issue_prefix=bds, causing canonical bdx create to mint bds-* IDs that product repo commit hooks correctly reject. Local Gastown execution prefixes must not leak into canonical planning IDs.

## Verification
- go test ./internal/beads ./internal/rig
- Deployed locally on epyc6 and epyc12 as hotfix.
- Canonical bdx create now mints bd-* again after config repair.
- bdx create --id bds-guard-smoke2 fails with canonical_prefix_mismatch on epyc12.