### PR TITLE
fix(daemon): prevent BD_ACTOR=daemon from leaking into polecat sessions (pa-xyr)

### DIFF
--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -340,7 +340,7 @@ func (d *Daemon) identityToSession(identity string) string {
 // Uses role config if available, falls back to hardcoded defaults.
 func (d *Daemon) restartSession(sessionName, identity string) error {
 	// Get role config for this identity
-	config, parsed, err := d.getRoleConfigForIdentity(identity)
+	roleConfig, parsed, err := d.getRoleConfigForIdentity(identity)
 	if err != nil {
 		return fmt.Errorf("parsing identity: %w", err)
 	}
@@ -355,13 +355,13 @@ func (d *Daemon) restartSession(sessionName, identity string) error {
 	}
 
 	// Determine working directory
-	workDir := d.getWorkDir(config, parsed)
+	workDir := d.getWorkDir(roleConfig, parsed)
 	if workDir == "" {
 		return fmt.Errorf("cannot determine working directory for %s", identity)
 	}
 
 	// Determine if pre-sync is needed
-	needsPreSync := d.getNeedsPreSync(config, parsed)
+	needsPreSync := d.getNeedsPreSync(roleConfig, parsed)
 
 	// Pre-sync workspace for agents with git worktrees
 	if needsPreSync {
@@ -373,11 +373,36 @@ func (d *Daemon) restartSession(sessionName, identity string) error {
 	// NewSessionWithCommand (command as initial pane process). This eliminates
 	// the race condition in the old EnsureSessionFresh + SendKeys pattern where
 	// the shell might not be ready to receive keystrokes, producing empty windows.
-	startCmd := d.getStartCommand(config, parsed)
+	startCmd := d.getStartCommand(roleConfig, parsed)
+
+	// Build core identity env vars to pass via -e flags. The startup command
+	// already embeds these via PrependEnv, but -e flags provide defense-in-depth:
+	// they seed the session environment before any shell starts, overriding
+	// global env values (e.g., BD_ACTOR=daemon inherited from the daemon process).
+	// Without this, a polecat session restarted by the daemon could inherit
+	// BD_ACTOR=daemon and have gt done reject it with "you are daemon" (gt-xyr).
+	rigPath := ""
+	if parsed != nil && parsed.RigName != "" {
+		rigPath = filepath.Join(d.config.TownRoot, parsed.RigName)
+	}
+	rc := config.ResolveRoleAgentConfig(parsed.RoleType, d.config.TownRoot, rigPath)
+	var sessionIDEnv string
+	if rc.Session != nil {
+		sessionIDEnv = rc.Session.SessionIDEnv
+	}
+	envVars := config.AgentEnv(config.AgentEnvConfig{
+		Role:         parsed.RoleType,
+		Rig:          parsed.RigName,
+		AgentName:    parsed.AgentName,
+		TownRoot:     d.config.TownRoot,
+		SessionIDEnv: sessionIDEnv,
+	})
+	config.SanitizeAgentEnv(envVars, map[string]string{})
 
 	// Create session with command as initial process (replaces EnsureSessionFresh + SendKeys).
-	// EnsureSessionFreshWithCommand kills zombie sessions and creates a new one atomically.
-	if err := d.tmux.EnsureSessionFreshWithCommand(sessionName, workDir, startCmd); err != nil {
+	// EnsureSessionFreshWithCommandAndEnv kills zombie sessions and creates a new one atomically,
+	// seeding env via -e flags before the shell starts (gt-xyr defense-in-depth).
+	if err := d.tmux.EnsureSessionFreshWithCommandAndEnv(sessionName, workDir, startCmd, envVars); err != nil {
 		if errors.Is(err, tmux.ErrSessionRunning) {
 			d.logger.Printf("Session %s already running with healthy agent, skipping restart", sessionName)
 			return nil
@@ -386,7 +411,7 @@ func (d *Daemon) restartSession(sessionName, identity string) error {
 	}
 
 	// Set environment variables in tmux session table (for debugging/monitoring tools).
-	d.setSessionEnvironment(sessionName, config, parsed)
+	d.setSessionEnvironment(sessionName, roleConfig, parsed)
 
 	// Apply theme (non-fatal: theming failure doesn't affect operation)
 	d.applySessionTheme(sessionName, parsed)

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -312,12 +312,20 @@ func (t *Tmux) NewSessionWithCommand(name, workDir, command string) error {
 		return err
 	}
 
-	// Defense-in-depth: remove CLAUDECODE from the tmux server's global
-	// environment so new sessions don't inherit it. Claude Code sets this
-	// variable on startup and the tmux server inherits it if started from
-	// within a Claude Code session. This causes nested-session detection
-	// failures in all subsequently created sessions.
+	// Defense-in-depth: remove CLAUDECODE and agent-identity vars from the
+	// tmux server's global environment so new sessions don't inherit them.
+	// CLAUDECODE: Claude Code sets this on startup; causes nested-session
+	// detection failures if inherited (GH#1666).
+	// IdentityEnvVars (GT_ROLE, BD_ACTOR, GIT_AUTHOR_NAME, etc.): the daemon
+	// process sets BD_ACTOR=daemon; if the tmux server was started from the
+	// daemon's context the global env inherits that value. Polecat sessions
+	// then inherit BD_ACTOR=daemon and gt done rejects them with "you are daemon"
+	// (gt-xyr). Clearing these here ensures every session gets identity vars
+	// only from its own startup command / -e flags, not from a stale global.
 	_, _ = t.run("set-environment", "-g", "-u", "CLAUDECODE")
+	for _, k := range config.IdentityEnvVars {
+		_, _ = t.run("set-environment", "-g", "-u", k)
+	}
 
 	// Two-step creation: create session with default shell first, configure
 	// remain-on-exit, then replace the shell with the actual command. This


### PR DESCRIPTION
## Summary

- Root cause: when the daemon process first starts the tmux server, the server inherits `BD_ACTOR=daemon` from the daemon's Go process env (`os.Setenv("BD_ACTOR", "daemon")`). All polecat sessions created without `-e` flags inherit this global value.
- When a polecat then runs `gt done`, `done.go` reads `os.Getenv("BD_ACTOR") == "daemon"` and rejects: *"gt done is for polecats only (you are daemon)"*.
- Confirmed: `tmux -L gt-57b1ab show-environment -g | grep BD_ACTOR` → `BD_ACTOR=daemon`.

**Two-layer fix:**

1. **`tmux.go NewSessionWithCommand`**: extend the existing `CLAUDECODE` global-env cleanup to also unset all `IdentityEnvVars` (`GT_ROLE`, `BD_ACTOR`, `GIT_AUTHOR_NAME`, etc.) from the tmux server's global environment. Prevents stale daemon identity from polluting any new session.

2. **`lifecycle.go restartSession`**: switch from `EnsureSessionFreshWithCommand` to `EnsureSessionFreshWithCommandAndEnv`, computing `AgentEnv` for the role and passing it via `-e` flags. This seeds the polecat's correct identity into the session environment before any shell starts — defense-in-depth even if the global cleanup is bypassed. Also renames the local `config` variable to `roleConfig` to avoid shadowing the `config` package import.

## Test plan

- [ ] `go build ./cmd/gt/...` — passes
- [ ] `go test ./internal/tmux/... -run TestNewSessionWithCommand` — all pass
- [ ] `go vet ./internal/tmux/... ./internal/daemon/...` — clean
- [ ] After deploy: confirm `tmux show-environment -g BD_ACTOR` no longer shows `daemon` after daemon starts polecat session

🤖 Generated with [Claude Code](https://claude.ai/claude-code)