### PR TITLE
fix(dolt): disable auto-gc + stuck-agent-dog null-guards

### DIFF
--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -852,8 +852,8 @@ data_dir: %q
 behavior:
   dolt_transaction_commit: false
   auto_gc_behavior:
-    enable: true
-    archive_level: 1
+    enable: false
+    archive_level: 0
 `,
 		cfg.Port,
 		hostLine,

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1446,8 +1446,8 @@ data_dir: "%s"
 behavior:
   dolt_transaction_commit: false
   auto_gc_behavior:
-    enable: true
-    archive_level: 1
+    enable: false
+    archive_level: 0
 `,
 		config.LogLevel,
 		config.Port,

--- a/plugins/stuck-agent-dog/run.sh
+++ b/plugins/stuck-agent-dog/run.sh
@@ -135,7 +135,7 @@ fi
 # --- Take action --------------------------------------------------------------
 
 # Crashed polecats: notify witness to restart
-for ENTRY in "${CRASHED[@]}"; do
+for ENTRY in "${CRASHED[@]:-}"; do
   IFS='|' read -r SESSION RIG PCAT HOOK <<< "$ENTRY"
   log "Requesting restart for $RIG/polecats/$PCAT (hook=$HOOK)"
   gt mail send "$RIG/witness" -s "RESTART_POLECAT: $RIG/$PCAT" --stdin <<BODY
@@ -146,7 +146,7 @@ BODY
 done
 
 # Zombie polecats: kill zombie session, then request restart
-for ENTRY in "${STUCK[@]}"; do
+for ENTRY in "${STUCK[@]:-}"; do
   IFS='|' read -r SESSION RIG PCAT HOOK REASON <<< "$ENTRY"
   log "Killing zombie session $SESSION and requesting restart"
   tmux kill-session -t "$SESSION" 2>/dev/null || true


### PR DESCRIPTION
## Summary

Surgical extraction of the two advertised fixes from #3831, dropped scope per vibe-maintainer split policy.

**Extracted (kept):**

1. **Disable Dolt auto-gc** — `auto_gc_behavior` was causing database lockups during heavy operations. Sets `enable: false`, `archive_level: 0` in both `internal/daemon/dolt.go` and `internal/doltserver/doltserver.go` config generation.

2. **Bash null-guards** in `plugins/stuck-agent-dog/run.sh` — adds `:-` default-value expansion to `${CRASHED[@]}` and `${STUCK[@]}` iterations to prevent "unbound variable" errors when the arrays are empty under `set -u`.

**Dropped from #3831 (out of scope for this hotfix):**

- whole `discord_watcher.go` feature
- comptroller template / `throttle_multipliers` changes
- generated `.beads/` state files
- polecat manager `cleanupOrphanPolecatState` rework
- discord watcher path-resolution refactor

Those changes can be resubmitted individually if they're still wanted. Closing #3831 with credit pointing here.

## Test plan

- [x] `git diff` — 6 lines across 3 files, exactly matches the surgical intent
- [x] `go vet ./internal/daemon/ ./internal/doltserver/` — clean
- [x] `bash -n plugins/stuck-agent-dog/run.sh` — parses
- [ ] CI green

## Attribution

Original work and reasoning by @ztbrown in #3831. Extracted and re-submitted by sheriff (rictus) per Mayor authorization.

Co-authored-by: ztbrown <zacktbrown@gmail.com>
