### PR TITLE
feat: add zombie polecat auto-cleanup config

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -627,6 +627,13 @@ Supported keys:
   scheduler.max_polecats      Dispatch mode: -1 = direct (default), N > 0 = deferred
   scheduler.batch_size        Beads per heartbeat (default: 1)
   scheduler.spawn_delay       Delay between spawns (default: 0s)
+
+  Zombie cleanup:
+  zombie.auto_cleanup         Auto-nuke clean idle polecats (true/false)
+  zombie.idle_threshold       Idle duration before cleanup (e.g., 2h)
+  zombie.hung_threshold       Inactivity duration before restart (e.g., 30m)
+  zombie.protected            Comma-separated polecat names exempt from auto-nuke
+
   maintenance.window          Maintenance window start time in HH:MM (e.g., "03:00")
   maintenance.interval        How often: "daily", "weekly", "monthly", or duration
   maintenance.threshold       Commit count threshold (default: 1000)
@@ -649,6 +656,8 @@ Examples:
   gt config set default_agent claude
   gt config set dolt.port 3308
   gt config set scheduler.max_polecats 5
+  gt config set zombie.auto_cleanup true
+  gt config set zombie.idle_threshold 2h
   gt config set maintenance.window 03:00
   gt config set maintenance.interval daily
   gt config set lifecycle.reaper.delete_age 336h
@@ -671,6 +680,13 @@ Supported keys:
   scheduler.max_polecats      Dispatch mode (-1 = direct, N > 0 = deferred)
   scheduler.batch_size        Beads per heartbeat
   scheduler.spawn_delay       Delay between spawns
+
+  Zombie cleanup:
+  zombie.auto_cleanup         Auto-nuke clean idle polecats (true/false)
+  zombie.idle_threshold       Idle duration before cleanup (e.g., 2h)
+  zombie.hung_threshold       Inactivity duration before restart (e.g., 30m)
+  zombie.protected            Comma-separated polecat names exempt from auto-nuke
+
   maintenance.window          Maintenance window start time (HH:MM)
   maintenance.interval        How often: daily, weekly, monthly, or duration
   maintenance.threshold       Commit count threshold
@@ -767,6 +783,32 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 		}
 		townSettings.Scheduler.SpawnDelay = value
 
+	case "zombie.auto_cleanup":
+		b, err := parseBool(value)
+		if err != nil {
+			return fmt.Errorf("invalid value for %s: %w (expected true/false)", key, err)
+		}
+		zombieCfg := ensureZombieConfig(townSettings)
+		zombieCfg.AutoCleanup = &b
+
+	case "zombie.idle_threshold":
+		if _, err := time.ParseDuration(value); err != nil {
+			return fmt.Errorf("invalid value for %s: %w (expected Go duration, e.g. 2h, 30m)", key, err)
+		}
+		zombieCfg := ensureZombieConfig(townSettings)
+		zombieCfg.IdleThreshold = value
+
+	case "zombie.hung_threshold":
+		if _, err := time.ParseDuration(value); err != nil {
+			return fmt.Errorf("invalid value for %s: %w (expected Go duration, e.g. 30m, 1h)", key, err)
+		}
+		zombieCfg := ensureZombieConfig(townSettings)
+		zombieCfg.HungThreshold = value
+
+	case "zombie.protected":
+		zombieCfg := ensureZombieConfig(townSettings)
+		zombieCfg.Protected = splitCommaList(value)
+
 	case "maintenance.window", "maintenance.interval", "maintenance.threshold":
 		return setMaintenanceConfig(townRoot, key, value)
 
@@ -794,7 +836,7 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 		if strings.HasPrefix(key, "lifecycle.") {
 			return setLifecycleConfig(townRoot, key, value)
 		}
-		return fmt.Errorf("unknown config key: %q\n\nSupported keys:\n  convoy.notify_on_complete\n  cli_theme\n  default_agent\n  dolt.port\n  scheduler.max_polecats\n  scheduler.batch_size\n  scheduler.spawn_delay\n  maintenance.window\n  maintenance.interval\n  maintenance.threshold\n  lifecycle.reaper.*\n  lifecycle.compactor.*\n  lifecycle.doctor.*\n  lifecycle.backup.*", key)
+		return fmt.Errorf("unknown config key: %q\n\nSupported keys:\n  convoy.notify_on_complete\n  cli_theme\n  default_agent\n  dolt.port\n  scheduler.max_polecats\n  scheduler.batch_size\n  scheduler.spawn_delay\n  zombie.auto_cleanup\n  zombie.idle_threshold\n  zombie.hung_threshold\n  zombie.protected\n  maintenance.window\n  maintenance.interval\n  maintenance.threshold\n  lifecycle.reaper.*\n  lifecycle.compactor.*\n  lifecycle.doctor.*\n  lifecycle.backup.*", key)
 	}
 
 	if err := config.SaveTownSettings(settingsPath, townSettings); err != nil {
@@ -861,6 +903,22 @@ func runConfigGet(cmd *cobra.Command, args []string) error {
 		}
 		value = scfg.GetSpawnDelay().String()
 
+	case "zombie.auto_cleanup":
+		zombieCfg := getZombieConfig(townSettings)
+		value = strconv.FormatBool(zombieCfg.AutoCleanupV())
+
+	case "zombie.idle_threshold":
+		zombieCfg := getZombieConfig(townSettings)
+		value = zombieCfg.IdleThresholdD().String()
+
+	case "zombie.hung_threshold":
+		zombieCfg := getZombieConfig(townSettings)
+		value = zombieCfg.HungThresholdD().String()
+
+	case "zombie.protected":
+		zombieCfg := getZombieConfig(townSettings)
+		value = strings.Join(zombieCfg.Protected, ",")
+
 	case "maintenance.window", "maintenance.interval", "maintenance.threshold":
 		return getMaintenanceConfig(townRoot, key)
 
@@ -879,11 +937,40 @@ func runConfigGet(cmd *cobra.Command, args []string) error {
 		if strings.HasPrefix(key, "lifecycle.") {
 			return getLifecycleConfig(townRoot, key)
 		}
-		return fmt.Errorf("unknown config key: %q\n\nSupported keys:\n  convoy.notify_on_complete\n  cli_theme\n  default_agent\n  dolt.port\n  scheduler.max_polecats\n  scheduler.batch_size\n  scheduler.spawn_delay\n  maintenance.window\n  maintenance.interval\n  maintenance.threshold\n  lifecycle.reaper.*\n  lifecycle.compactor.*\n  lifecycle.doctor.*\n  lifecycle.backup.*", key)
+		return fmt.Errorf("unknown config key: %q\n\nSupported keys:\n  convoy.notify_on_complete\n  cli_theme\n  default_agent\n  dolt.port\n  scheduler.max_polecats\n  scheduler.batch_size\n  scheduler.spawn_delay\n  zombie.auto_cleanup\n  zombie.idle_threshold\n  zombie.hung_threshold\n  zombie.protected\n  maintenance.window\n  maintenance.interval\n  maintenance.threshold\n  lifecycle.reaper.*\n  lifecycle.compactor.*\n  lifecycle.doctor.*\n  lifecycle.backup.*", key)
 	}
 
 	fmt.Println(value)
 	return nil
+}
+
+func ensureZombieConfig(townSettings *config.TownSettings) *config.ZombieConfig {
+	if townSettings.Operational == nil {
+		townSettings.Operational = &config.OperationalConfig{}
+	}
+	if townSettings.Operational.Zombie == nil {
+		townSettings.Operational.Zombie = &config.ZombieConfig{}
+	}
+	return townSettings.Operational.Zombie
+}
+
+func getZombieConfig(townSettings *config.TownSettings) *config.ZombieConfig {
+	if townSettings.Operational == nil {
+		return (&config.OperationalConfig{}).GetZombieConfig()
+	}
+	return townSettings.Operational.GetZombieConfig()
+}
+
+func splitCommaList(value string) []string {
+	parts := strings.Split(value, ",")
+	items := make([]string, 0, len(parts))
+	for _, part := range parts {
+		item := strings.TrimSpace(part)
+		if item != "" {
+			items = append(items, item)
+		}
+	}
+	return items
 }
 
 // setMaintenanceConfig sets a maintenance.* key in daemon.json (patrol config).

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -872,6 +872,71 @@ func TestConfigSetGet(t *testing.T) {
 			t.Errorf("error = %v, want 'invalid value'", err)
 		}
 	})
+
+	t.Run("set and get zombie config", func(t *testing.T) {
+		townRoot := setupTestTownForConfig(t)
+		settingsPath := config.TownSettingsPath(townRoot)
+
+		originalWd, _ := os.Getwd()
+		defer os.Chdir(originalWd)
+		if err := os.Chdir(townRoot); err != nil {
+			t.Fatalf("chdir: %v", err)
+		}
+
+		cmd := &cobra.Command{}
+		for _, args := range [][]string{
+			{"zombie.auto_cleanup", "true"},
+			{"zombie.idle_threshold", "2h"},
+			{"zombie.hung_threshold", "45m"},
+			{"zombie.protected", "nitro, quartz"},
+		} {
+			if err := runConfigSet(cmd, args); err != nil {
+				t.Fatalf("runConfigSet(%v) failed: %v", args, err)
+			}
+		}
+
+		loaded, err := config.LoadOrCreateTownSettings(settingsPath)
+		if err != nil {
+			t.Fatalf("load settings: %v", err)
+		}
+		if loaded.Operational == nil || loaded.Operational.Zombie == nil {
+			t.Fatal("Zombie config is nil after set")
+		}
+		zombie := loaded.Operational.Zombie
+		if zombie.AutoCleanup == nil || !*zombie.AutoCleanup {
+			t.Error("AutoCleanup should be true")
+		}
+		if zombie.IdleThreshold != "2h" {
+			t.Errorf("IdleThreshold = %q, want 2h", zombie.IdleThreshold)
+		}
+		if zombie.HungThreshold != "45m" {
+			t.Errorf("HungThreshold = %q, want 45m", zombie.HungThreshold)
+		}
+		if got := strings.Join(zombie.Protected, ","); got != "nitro,quartz" {
+			t.Errorf("Protected = %q, want nitro,quartz", got)
+		}
+
+		for _, key := range []string{"zombie.auto_cleanup", "zombie.idle_threshold", "zombie.hung_threshold", "zombie.protected"} {
+			if err := runConfigGet(cmd, []string{key}); err != nil {
+				t.Fatalf("runConfigGet(%s) failed: %v", key, err)
+			}
+		}
+	})
+
+	t.Run("zombie duration rejects invalid value", func(t *testing.T) {
+		townRoot := setupTestTownForConfig(t)
+
+		originalWd, _ := os.Getwd()
+		defer os.Chdir(originalWd)
+		if err := os.Chdir(townRoot); err != nil {
+			t.Fatalf("chdir: %v", err)
+		}
+
+		cmd := &cobra.Command{}
+		if err := runConfigSet(cmd, []string{"zombie.idle_threshold", "later"}); err == nil {
+			t.Fatal("expected error for invalid zombie.idle_threshold")
+		}
+	})
 }
 
 func TestConfigMaintenanceSetGet(t *testing.T) {

--- a/internal/cmd/patrol_scan.go
+++ b/internal/cmd/patrol_scan.go
@@ -106,9 +106,9 @@ type PatrolScanStallItem struct {
 
 // PatrolScanCompleteOutput holds completion discovery results.
 type PatrolScanCompleteOutput struct {
-	Checked   int                       `json:"checked"`
-	Found     int                       `json:"found"`
-	Completed []PatrolScanCompleteItem  `json:"completed,omitempty"`
+	Checked   int                      `json:"checked"`
+	Found     int                      `json:"found"`
+	Completed []PatrolScanCompleteItem `json:"completed,omitempty"`
 }
 
 // PatrolScanCompleteItem is a single completion discovery in scan output.
@@ -149,9 +149,8 @@ func runPatrolScan(cmd *cobra.Command, args []string) error {
 	timestamp := time.Now().UTC().Format(time.RFC3339)
 
 	// Run all three detection passes.
-	// Note: DetectZombiePolecats takes a router param but does NOT send mail
-	// internally — it only uses the router for workspace context. Notifications
-	// are sent exclusively below via --notify, avoiding double-send.
+	// DetectZombiePolecats sends best-effort mail only for completed auto-cleanups;
+	// active-work zombie detection notifications are sent below.
 	zombieResult := witness.DetectZombiePolecats(bd, workDir, rigName, router)
 	stallResult := witness.DetectStalledPolecats(workDir, rigName)
 	completionResult := witness.DiscoverCompletions(bd, workDir, rigName, router)

--- a/internal/config/operational.go
+++ b/internal/config/operational.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"path/filepath"
+	"strings"
 	"time"
 )
 
@@ -35,19 +36,19 @@ const (
 
 // Daemon defaults.
 const (
-	DefaultMassDeathWindow                 = 30 * time.Second
-	DefaultMassDeathThreshold              = 3
-	DefaultDogIdleSessionTimeout           = 1 * time.Hour
-	DefaultPolecatIdleSessionTimeout       = 15 * time.Minute
-	DefaultDogIdleRemoveTimeout            = 4 * time.Hour
-	DefaultStaleWorkingTimeout             = 2 * time.Hour
-	DefaultMaxDogPoolSize                  = 4
-	DefaultMaxLifecycleMessageAge          = 6 * time.Hour
-	DefaultSyncFailureEscalationThreshold  = 3
-	DefaultDoctorMolCooldown               = 5 * time.Minute
-	DefaultRecoveryHeartbeatInterval       = 3 * time.Minute
-	DefaultBootSpawnCooldown               = 2 * time.Minute
-	DefaultDeaconGracePeriod               = 5 * time.Minute
+	DefaultMassDeathWindow                = 30 * time.Second
+	DefaultMassDeathThreshold             = 3
+	DefaultDogIdleSessionTimeout          = 1 * time.Hour
+	DefaultPolecatIdleSessionTimeout      = 15 * time.Minute
+	DefaultDogIdleRemoveTimeout           = 4 * time.Hour
+	DefaultStaleWorkingTimeout            = 2 * time.Hour
+	DefaultMaxDogPoolSize                 = 4
+	DefaultMaxLifecycleMessageAge         = 6 * time.Hour
+	DefaultSyncFailureEscalationThreshold = 3
+	DefaultDoctorMolCooldown              = 5 * time.Minute
+	DefaultRecoveryHeartbeatInterval      = 3 * time.Minute
+	DefaultBootSpawnCooldown              = 2 * time.Minute
+	DefaultDeaconGracePeriod              = 5 * time.Minute
 
 	// Pressure check defaults — fully opt-in. All zero = disabled.
 	// Configure in settings/config.json under operational.daemon to enable.
@@ -59,21 +60,21 @@ const (
 
 // Deacon defaults.
 const (
-	DefaultDeaconPingTimeout               = 30 * time.Second
-	DefaultDeaconConsecutiveFailures       = 3
-	DefaultDeaconCooldown                  = 5 * time.Minute
-	DefaultDeaconHeartbeatStaleThreshold   = 5 * time.Minute
-	DefaultDeaconHeartbeatVeryStale        = 20 * time.Minute
-	DefaultMaxRedispatches                 = 3
-	DefaultRedispatchCooldown              = 5 * time.Minute
-	DefaultMaxFeedsPerCycle                = 3
-	DefaultFeedCooldown                    = 10 * time.Minute
+	DefaultDeaconPingTimeout             = 30 * time.Second
+	DefaultDeaconConsecutiveFailures     = 3
+	DefaultDeaconCooldown                = 5 * time.Minute
+	DefaultDeaconHeartbeatStaleThreshold = 5 * time.Minute
+	DefaultDeaconHeartbeatVeryStale      = 20 * time.Minute
+	DefaultMaxRedispatches               = 3
+	DefaultRedispatchCooldown            = 5 * time.Minute
+	DefaultMaxFeedsPerCycle              = 3
+	DefaultFeedCooldown                  = 10 * time.Minute
 )
 
 // Polecat defaults.
 const (
-	DefaultPolecatHeartbeatStale = 3 * time.Minute
-	DefaultPolecatDoltMaxRetries = 10
+	DefaultPolecatHeartbeatStale  = 3 * time.Minute
+	DefaultPolecatDoltMaxRetries  = 10
 	DefaultPolecatDoltBaseBackoff = 500 * time.Millisecond
 	DefaultPolecatDoltBackoffMax  = 30 * time.Second
 	DefaultPolecatPendingMaxAge   = 5 * time.Minute
@@ -109,9 +110,16 @@ const (
 	DefaultWitnessStartupStallThreshold  = 90 * time.Second
 	DefaultWitnessStartupActivityGrace   = 60 * time.Second
 	DefaultWitnessMaxBeadRespawns        = 3
-	DefaultWitnessDoneIntentStuckTimeout    = 60 * time.Second
-	DefaultWitnessDoneIntentRecentGrace     = 30 * time.Second
-	DefaultWitnessHeartbeatStartupGrace     = 5 * time.Minute
+	DefaultWitnessDoneIntentStuckTimeout = 60 * time.Second
+	DefaultWitnessDoneIntentRecentGrace  = 30 * time.Second
+	DefaultWitnessHeartbeatStartupGrace  = 5 * time.Minute
+)
+
+// Zombie cleanup defaults.
+const (
+	DefaultZombieAutoCleanup   = false
+	DefaultZombieIdleThreshold = 2 * time.Hour
+	DefaultZombieHungThreshold = DefaultHungSessionThreshold
 )
 
 // LoadOperationalConfig loads operational config from a town root.
@@ -692,6 +700,51 @@ func (c *OperationalConfig) GetWitnessConfig() *WitnessThresholds {
 		return c.Witness
 	}
 	return &WitnessThresholds{}
+}
+
+// GetZombieConfig returns the zombie cleanup config, never nil.
+func (c *OperationalConfig) GetZombieConfig() *ZombieConfig {
+	if c != nil && c.Zombie != nil {
+		return c.Zombie
+	}
+	return &ZombieConfig{}
+}
+
+// AutoCleanupV returns whether idle zombie auto-cleanup is enabled.
+func (z *ZombieConfig) AutoCleanupV() bool {
+	if z != nil && z.AutoCleanup != nil {
+		return *z.AutoCleanup
+	}
+	return DefaultZombieAutoCleanup
+}
+
+// IdleThresholdD returns the configured or default idle cleanup threshold.
+func (z *ZombieConfig) IdleThresholdD() time.Duration {
+	if z != nil {
+		return ParseDurationOrDefault(z.IdleThreshold, DefaultZombieIdleThreshold)
+	}
+	return DefaultZombieIdleThreshold
+}
+
+// HungThresholdD returns the configured or default hung session threshold.
+func (z *ZombieConfig) HungThresholdD() time.Duration {
+	if z != nil {
+		return ParseDurationOrDefault(z.HungThreshold, DefaultZombieHungThreshold)
+	}
+	return DefaultZombieHungThreshold
+}
+
+// IsProtected reports whether name is exempt from automatic zombie cleanup.
+func (z *ZombieConfig) IsProtected(name string) bool {
+	if z == nil || name == "" {
+		return false
+	}
+	for _, protected := range z.Protected {
+		if strings.EqualFold(strings.TrimSpace(protected), name) {
+			return true
+		}
+	}
+	return false
 }
 
 // StartupStallThresholdD returns the configured or default startup stall threshold.

--- a/internal/config/operational_test.go
+++ b/internal/config/operational_test.go
@@ -204,6 +204,47 @@ func TestDoltThresholds_Defaults(t *testing.T) {
 	}
 }
 
+func TestZombieConfig_DefaultsAndOverrides(t *testing.T) {
+	t.Parallel()
+
+	op := &OperationalConfig{}
+	zombie := op.GetZombieConfig()
+
+	if got := zombie.AutoCleanupV(); got != DefaultZombieAutoCleanup {
+		t.Errorf("AutoCleanup: got %v, want %v", got, DefaultZombieAutoCleanup)
+	}
+	if got := zombie.IdleThresholdD(); got != DefaultZombieIdleThreshold {
+		t.Errorf("IdleThreshold: got %v, want %v", got, DefaultZombieIdleThreshold)
+	}
+	if got := zombie.HungThresholdD(); got != DefaultZombieHungThreshold {
+		t.Errorf("HungThreshold: got %v, want %v", got, DefaultZombieHungThreshold)
+	}
+
+	autoCleanup := true
+	op.Zombie = &ZombieConfig{
+		AutoCleanup:   &autoCleanup,
+		IdleThreshold: "3h",
+		HungThreshold: "45m",
+		Protected:     []string{"nitro", " Quartz "},
+	}
+	zombie = op.GetZombieConfig()
+	if !zombie.AutoCleanupV() {
+		t.Error("AutoCleanup should be true")
+	}
+	if got := zombie.IdleThresholdD(); got != 3*time.Hour {
+		t.Errorf("IdleThreshold: got %v, want 3h", got)
+	}
+	if got := zombie.HungThresholdD(); got != 45*time.Minute {
+		t.Errorf("HungThreshold: got %v, want 45m", got)
+	}
+	if !zombie.IsProtected("quartz") {
+		t.Error("IsProtected should match case-insensitively with surrounding whitespace")
+	}
+	if zombie.IsProtected("chrome") {
+		t.Error("IsProtected should be false for unlisted polecat")
+	}
+}
+
 func TestLoadOperationalConfig_NonexistentDir(t *testing.T) {
 	t.Parallel()
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -239,6 +239,24 @@ type OperationalConfig struct {
 
 	// Witness configures witness patrol thresholds.
 	Witness *WitnessThresholds `json:"witness,omitempty"`
+
+	// Zombie configures automatic zombie polecat cleanup.
+	Zombie *ZombieConfig `json:"zombie,omitempty"`
+}
+
+// ZombieConfig configures automatic cleanup for idle or hung polecats.
+type ZombieConfig struct {
+	// AutoCleanup controls whether clean idle polecats are nuked after IdleThreshold.
+	AutoCleanup *bool `json:"auto_cleanup,omitempty"`
+
+	// IdleThreshold is how long a clean idle polecat can remain before cleanup.
+	IdleThreshold string `json:"idle_threshold,omitempty"`
+
+	// HungThreshold is how long a non-idle live session can be inactive before restart.
+	HungThreshold string `json:"hung_threshold,omitempty"`
+
+	// Protected lists polecat names that must never be auto-nuked.
+	Protected []string `json:"protected,omitempty"`
 }
 
 // SessionThresholds configures session management timeouts.

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -523,7 +523,7 @@ type AddOptions struct {
 	// worktree instead of creating a fresh polecat/<name>/<bead>@<ts> branch (gh#3602).
 	// When set, the polecat's branch IS this branch — pushes go back to the same ref,
 	// updating the existing PR. Mutually exclusive with BaseBranch (resume implies its
-	// own start point). When empty, normal fresh-branch behaviour is used.
+	// own start point). When empty, normal fresh-branch behavior is used.
 	ResumeBranch string
 }
 

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1070,6 +1070,10 @@ const (
 	ZombieDoneIntentDead ZombieClassification = "done-intent-dead"
 	// ZombieIdleDirtySandbox: idle polecat with uncommitted changes.
 	ZombieIdleDirtySandbox ZombieClassification = "idle-dirty-sandbox"
+	// ZombieIdleCleanSandbox: idle polecat with clean sandbox auto-cleaned after threshold.
+	ZombieIdleCleanSandbox ZombieClassification = "idle-clean-sandbox"
+	// ZombieHungSession: tmux session and agent are live, but inactive past threshold.
+	ZombieHungSession ZombieClassification = "hung-session"
 	// ZombieSessionDeadActive: session dead but agent state indicates active work.
 	ZombieSessionDeadActive ZombieClassification = "session-dead-active"
 	// ZombieAgentSelfReportedStuck: agent self-reported stuck via heartbeat v2 (gt-3vr5).
@@ -1090,7 +1094,7 @@ func (c ZombieClassification) ImpliesActiveWork() bool {
 	switch c {
 	case ZombieStuckInDone, ZombieAgentDeadInSession, ZombieBeadClosedStillRunning,
 		ZombieDoneIntentDead, ZombieSessionDeadActive, ZombieAgentSelfReportedStuck,
-		ZombieNeverHeartbeated:
+		ZombieNeverHeartbeated, ZombieHungSession:
 		return true
 	default:
 		return false
@@ -1136,9 +1140,11 @@ type DetectZombiePolecatsResult struct {
 // Dedup: Checks for existing cleanup wisps before escalating, preventing
 // infinite escalation loops on subsequent patrol cycles.
 //
-// gt-dsgp: Restart-first policy. For each zombie found, we RESTART the session
-// instead of nuking. This preserves the polecat's worktree and branch, preventing
-// work loss. Nuking only happens via explicit `gt polecat nuke` command.
+// gt-dsgp: Restart-first policy. For each active-work zombie found, we RESTART
+// the session instead of nuking. This preserves the polecat's worktree and
+// branch, preventing work loss. Clean idle polecats can only be auto-nuked when
+// zombie.auto_cleanup is enabled and their idle age exceeds the configured
+// threshold.
 //
 // For each zombie found:
 //   - If polecat has a pending MR: skip (not a zombie, waiting for refinery)
@@ -1156,8 +1162,10 @@ func DetectZombiePolecats(bd *BdCli, workDir, rigName string, router *mail.Route
 	}
 	initRegistryFromTownRoot(townRoot)
 
-	// Load witness thresholds from config (fallback to compiled-in defaults).
-	witCfg := config.LoadOperationalConfig(townRoot).GetWitnessConfig()
+	// Load witness and zombie thresholds from config (fallback to compiled-in defaults).
+	opCfg := config.LoadOperationalConfig(townRoot)
+	witCfg := opCfg.GetWitnessConfig()
+	zombieCfg := opCfg.GetZombieConfig()
 
 	polecatsDir := filepath.Join(townRoot, rigName, "polecats")
 	entries, err := os.ReadDir(polecatsDir)
@@ -1200,33 +1208,22 @@ func DetectZombiePolecats(bd *BdCli, workDir, rigName string, router *mail.Route
 
 		if sessionAlive {
 			// gt-s8bq: Idle Polecat Heresy fix. Idle polecats are HEALTHY — they
-			// have no hook_bead, agent_state="idle", and their sandbox is preserved
-			// for reuse. Skip them entirely during patrol. Only report if the
-			// sandbox is dirty (uncommitted changes in idle state).
+			// have no hook_bead and agent_state="idle". Preserve them by default;
+			// auto-clean only when explicitly enabled and safely past threshold.
+			// Always report dirty idle sandboxes for witness review.
 			agentState := ""
 			if snap != nil {
 				agentState = snap.AgentState
 			}
 			if beads.AgentState(agentState) == AgentStateIdle {
-				cleanupStatus := snap.cleanupStatus()
-				if cleanupStatus != "" && cleanupStatus != "clean" {
-					// ZFC (gt-5rne): Report data, don't escalate. The witness agent
-					// decides whether dirty idle state warrants escalation.
-					zombie := ZombieResult{
-						PolecatName:    polecatName,
-						AgentState:     agentState,
-						Classification: ZombieIdleDirtySandbox,
-						CleanupStatus:  cleanupStatus,
-						WasActive:      false,
-						Action:         "detected-dirty-idle-polecat",
-					}
+				if zombie, found := handleIdlePolecatCleanup(bd, workDir, rigName, polecatName, agentState, snap, zombieCfg, router); found {
 					result.Zombies = append(result.Zombies, zombie)
 				}
-				// Clean idle polecat — healthy, skip entirely.
+				// Clean idle polecat below threshold, disabled, or protected — healthy, skip entirely.
 				continue
 			}
 
-			if zombie, found := detectZombieLiveSession(bd, workDir, townRoot, rigName, polecatName, sessionName, t, doneIntent, witCfg, snap); found {
+			if zombie, found := detectZombieLiveSession(bd, workDir, townRoot, rigName, polecatName, sessionName, t, doneIntent, witCfg, zombieCfg, snap); found {
 				result.Zombies = append(result.Zombies, zombie)
 			}
 			continue // Either handled or not a zombie
@@ -1245,12 +1242,78 @@ func DetectZombiePolecats(bd *BdCli, workDir, rigName string, router *mail.Route
 	return result
 }
 
+func handleIdlePolecatCleanup(bd *BdCli, workDir, rigName, polecatName, agentState string, snap *agentBeadSnapshot, zombieCfg *config.ZombieConfig, router *mail.Router) (ZombieResult, bool) {
+	cleanupStatus := snap.cleanupStatus()
+	if cleanupStatus != "" && cleanupStatus != "clean" {
+		// ZFC (gt-5rne): Report data, don't escalate. The witness agent
+		// decides whether dirty idle state warrants escalation.
+		return ZombieResult{
+			PolecatName:    polecatName,
+			AgentState:     agentState,
+			Classification: ZombieIdleDirtySandbox,
+			CleanupStatus:  cleanupStatus,
+			WasActive:      false,
+			Action:         "detected-dirty-idle-polecat",
+		}, true
+	}
+
+	if !shouldAutoCleanupIdlePolecat(polecatName, snap, zombieCfg) {
+		return ZombieResult{}, false
+	}
+
+	idleAge := snap.age()
+	idleThreshold := zombieCfg.IdleThresholdD()
+	if idleThreshold <= 0 || idleAge < idleThreshold {
+		return ZombieResult{}, false
+	}
+
+	zombie := ZombieResult{
+		PolecatName:    polecatName,
+		AgentState:     agentState,
+		Classification: ZombieIdleCleanSandbox,
+		CleanupStatus:  "clean",
+		WasActive:      false,
+		Action:         fmt.Sprintf("auto-nuked (idle-age=%v, threshold=%v)", idleAge.Round(time.Second), idleThreshold),
+	}
+	if err := NukePolecat(bd, workDir, rigName, polecatName); err != nil {
+		zombie.Error = err
+		zombie.Action = fmt.Sprintf("auto-nuke-failed (idle-age=%v, threshold=%v): %v", idleAge.Round(time.Second), idleThreshold, err)
+		return zombie, true
+	}
+	sendZombieCleanupNotification(router, rigName, zombie)
+	return zombie, true
+}
+
+func shouldAutoCleanupIdlePolecat(polecatName string, snap *agentBeadSnapshot, zombieCfg *config.ZombieConfig) bool {
+	if !zombieCfg.AutoCleanupV() || snap == nil || snap.HookBead != "" || zombieCfg.IsProtected(polecatName) {
+		return false
+	}
+	idleThreshold := zombieCfg.IdleThresholdD()
+	return idleThreshold > 0 && snap.age() >= idleThreshold
+}
+
+func sendZombieCleanupNotification(router *mail.Router, rigName string, zombie ZombieResult) {
+	if router == nil || zombie.Action == "" || !strings.HasPrefix(zombie.Action, "auto-nuked") {
+		return
+	}
+
+	from := fmt.Sprintf("%s/witness", rigName)
+	msg := &mail.Message{
+		From:    from,
+		To:      from,
+		Subject: fmt.Sprintf("ZOMBIE_CLEANED: %s/%s", rigName, zombie.PolecatName),
+		Body: fmt.Sprintf("Auto-cleaned idle zombie polecat: %s/%s\nClassification: %s\nCleanup status: %s\nAction: %s",
+			rigName, zombie.PolecatName, zombie.Classification, zombie.CleanupStatus, zombie.Action),
+	}
+	_ = router.Send(msg)
+}
+
 // detectZombieLiveSession checks a polecat with a live tmux session for zombie indicators:
 // stuck done-intent, dead agent process, or closed bead while still running.
 //
 // gt-dsgp: Uses restart-first policy. Instead of nuking polecats, restarts their
 // sessions to preserve worktrees and branches.
-func detectZombieLiveSession(bd *BdCli, workDir, townRoot, rigName, polecatName, sessionName string, t *tmux.Tmux, doneIntent *DoneIntent, witCfg *config.WitnessThresholds, snap *agentBeadSnapshot) (ZombieResult, bool) {
+func detectZombieLiveSession(bd *BdCli, workDir, townRoot, rigName, polecatName, sessionName string, t *tmux.Tmux, doneIntent *DoneIntent, witCfg *config.WitnessThresholds, zombieCfg *config.ZombieConfig, snap *agentBeadSnapshot) (ZombieResult, bool) {
 	// gt-2gra: Agent state and hook bead are read from the pre-fetched snapshot
 	// instead of calling getAgentBeadState multiple times per code path.
 	snapState, snapHook := "", ""
@@ -1337,6 +1400,32 @@ func detectZombieLiveSession(bd *BdCli, workDir, townRoot, rigName, polecatName,
 			zombie.Action = fmt.Sprintf("restart-agent-dead-session-failed: %v", err)
 		}
 		return zombie, true
+	}
+
+	// Agent and session are alive but inactive beyond threshold — likely hung.
+	if hungThreshold := zombieCfg.HungThresholdD(); hungThreshold > 0 {
+		if lastActivity, err := t.GetSessionActivity(sessionName); err == nil && !lastActivity.IsZero() {
+			inactiveFor := time.Since(lastActivity)
+			if inactiveFor > hungThreshold {
+				zombie := ZombieResult{
+					PolecatName:    polecatName,
+					AgentState:     snapState,
+					Classification: ZombieHungSession,
+					HookBead:       snapHook,
+					WasActive:      snapHook != "" || beads.AgentState(snapState).IsActive(),
+					Action:         fmt.Sprintf("restarted-hung-session (inactive=%v, threshold=%v)", inactiveFor.Round(time.Second), hungThreshold),
+				}
+				// TOCTOU guard (gt-0pst): Re-check session liveness before restarting.
+				if alive, _ := t.HasSession(sessionName); !alive {
+					return ZombieResult{}, false
+				}
+				if err := RestartPolecatSession(workDir, rigName, polecatName); err != nil {
+					zombie.Error = err
+					zombie.Action = fmt.Sprintf("restart-hung-session-failed: %v", err)
+				}
+				return zombie, true
+			}
+		}
 	}
 
 	// Agent alive but hooked bead closed — occupying slot without work (gt-h1l6i).
@@ -1792,7 +1881,7 @@ type CompletionDiscovery struct {
 	MRID           string
 	Branch         string
 	MRFailed       bool
-	PushFailed     bool   // True when branch push to origin failed (gas-556)
+	PushFailed     bool // True when branch push to origin failed (gas-556)
 	CompletionTime string
 	Action         string // What was done: "merge-ready-sent", "acknowledged-idle", "phase-complete"
 	WispCreated    string // ID of cleanup wisp if created
@@ -1970,12 +2059,12 @@ func processDiscoveredCompletion(bd *BdCli, workDir, rigName string, payload *Po
 // Used to avoid redundant subprocess invocations during zombie detection, where the same
 // agent bead was previously queried 3-5 times per polecat per patrol cycle. (gt-2gra)
 type agentBeadSnapshot struct {
-	AgentState  string
-	HookBead    string
-	Labels      []string
-	UpdatedAt   string
-	ActiveMR    string
-	Fields      *beads.AgentFields // parsed from description
+	AgentState string
+	HookBead   string
+	Labels     []string
+	UpdatedAt  string
+	ActiveMR   string
+	Fields     *beads.AgentFields // parsed from description
 }
 
 // fetchAgentBeadSnapshot fetches all agent bead data in a single bd show call.
@@ -2158,13 +2247,13 @@ func getBeadStatus(bd *BdCli, workDir, beadID string) (string, bool) {
 
 // resetAbandonedBead resets a dead polecat's hooked bead so it can be re-dispatched.
 // If the bead is in "hooked" or "in_progress" status, it:
-// 0. Checks if the polecat's work is already on main — if so, closes
-//    the bead instead of resetting (prevents re-dispatch of completed work)
-// 1. Records the respawn in the witness spawn-count ledger
-// 2. Resets status to open
-// 3. Clears assignee
-// 4. Sends mail to deacon for re-dispatch (includes respawn count; SPAWN_STORM
-//    prefix and Urgent priority when count exceeds max bead respawns config)
+//  0. Checks if the polecat's work is already on main — if so, closes
+//     the bead instead of resetting (prevents re-dispatch of completed work)
+//  1. Records the respawn in the witness spawn-count ledger
+//  2. Resets status to open
+//  3. Clears assignee
+//  4. Sends mail to deacon for re-dispatch (includes respawn count; SPAWN_STORM
+//     prefix and Urgent priority when count exceeds max bead respawns config)
 //
 // Returns true if the bead was recovered.
 func resetAbandonedBead(bd *BdCli, workDir, rigName, hookBead, polecatName string, router *mail.Router) bool {

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -700,6 +700,41 @@ func TestDetectZombie_AgentDeadInLiveSession(t *testing.T) {
 	}
 }
 
+func TestShouldAutoCleanupIdlePolecat(t *testing.T) {
+	t.Parallel()
+
+	autoCleanup := true
+	cfg := &config.ZombieConfig{
+		AutoCleanup:   &autoCleanup,
+		IdleThreshold: "2h",
+		Protected:     []string{"protected"},
+	}
+	oldIdleSnap := &agentBeadSnapshot{UpdatedAt: time.Now().Add(-3 * time.Hour).Format(time.RFC3339)}
+
+	if !shouldAutoCleanupIdlePolecat("nitro", oldIdleSnap, cfg) {
+		t.Error("expected clean idle polecat past threshold to be eligible for auto-cleanup")
+	}
+
+	if shouldAutoCleanupIdlePolecat("protected", oldIdleSnap, cfg) {
+		t.Error("protected polecat should not be eligible for auto-cleanup")
+	}
+
+	withHook := &agentBeadSnapshot{HookBead: "gt-work", UpdatedAt: time.Now().Add(-3 * time.Hour).Format(time.RFC3339)}
+	if shouldAutoCleanupIdlePolecat("nitro", withHook, cfg) {
+		t.Error("polecat with hooked work should not be eligible for idle auto-cleanup")
+	}
+
+	recentSnap := &agentBeadSnapshot{UpdatedAt: time.Now().Add(-30 * time.Minute).Format(time.RFC3339)}
+	if shouldAutoCleanupIdlePolecat("nitro", recentSnap, cfg) {
+		t.Error("recently idle polecat should not be eligible before threshold")
+	}
+
+	autoCleanup = false
+	if shouldAutoCleanupIdlePolecat("nitro", oldIdleSnap, cfg) {
+		t.Error("disabled auto-cleanup should prevent eligibility")
+	}
+}
+
 func TestGetAgentBeadLabels_NoBdAvailable(t *testing.T) {
 	t.Parallel()
 	// When bd is not available, should return nil without panicking
@@ -1704,7 +1739,6 @@ func TestClearCompletionMetadata_NoBd(t *testing.T) {
 		t.Error("expected error when bd unavailable")
 	}
 }
-
 
 // --- Heartbeat v2 tests (gt-3vr5) ---
 


### PR DESCRIPTION
## Summary
- Add `operational.zombie` settings surfaced through `gt config set/get zombie.*`.
- Auto-clean clean idle polecats only when explicitly enabled, past threshold, unhooked, and not protected.
- Restart live hung sessions using configurable `zombie.hung_threshold` and send `ZOMBIE_CLEANED` mail after successful idle auto-cleanup.

## Test Plan
- `go test ./internal/cmd -run TestConfigSetGet -count=1`
- `go test ./internal/config -run TestZombieConfig_DefaultsAndOverrides -count=1`
- `go test ./internal/witness -run TestShouldAutoCleanupIdlePolecat -count=1`
- `go test ./internal/polecat -run '^$' -count=1`
- `go build ./...`
- `go vet ./internal/cmd ./internal/config ./internal/witness ./internal/polecat`

## Notes
- Replaces closed internal PR #3947 with a fork PR so the internal-PR blocker does not apply.
- The prior integration failures in #3947 were unrelated test-environment failures around Dolt port reuse / unsupported `bd close --tombstone`.

Closes #1085