### PR TITLE
fix: ignore stale nudge pane IDs from other sessions

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2040,11 +2040,19 @@ func (t *Tmux) FindAgentPane(session string) (string, error) {
 	// ZFC: read declared pane identity set at session startup (gt-qmsx).
 	// This replaces process-tree inference for sessions that record GT_PANE_ID.
 	if declaredPane, err := t.GetEnvironment(session, "GT_PANE_ID"); err == nil && declaredPane != "" {
-		// Verify the pane still exists in tmux (it may have been killed/respawned).
-		if _, verifyErr := t.run("display-message", "-t", declaredPane, "-p", "#{pane_id}"); verifyErr == nil {
+		targetSession := session
+		if sessionOut, sessionErr := t.run("display-message", "-t", session, "-p", "#{session_name}"); sessionErr == nil {
+			if resolved := strings.TrimSpace(sessionOut); resolved != "" {
+				targetSession = resolved
+			}
+		}
+
+		// Verify the pane still exists in the target session. Pane IDs are tmux-global,
+		// so a stale GT_PANE_ID may still resolve in a different restarted session.
+		if paneSession, verifyErr := t.run("display-message", "-t", declaredPane, "-p", "#{session_name}"); verifyErr == nil && strings.TrimSpace(paneSession) == targetSession {
 			return declaredPane, nil
 		}
-		// Declared pane is gone — fall through to scan.
+		// Declared pane is gone or belongs to another session — fall through to scan.
 	}
 
 	// Fallback: scan all panes for legacy sessions without GT_PANE_ID.

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1324,6 +1324,40 @@ func TestFindAgentPane_SinglePane(t *testing.T) {
 	}
 }
 
+func TestFindAgentPane_IgnoresPaneIDFromOtherSession(t *testing.T) {
+	tm := newTestTmux(t)
+	suffix := fmt.Sprintf("%d", time.Now().UnixNano()%10000)
+	targetSession := "gt-test-findagent-target-" + suffix
+	otherSession := "gt-test-findagent-other-" + suffix
+
+	_ = tm.KillSession(targetSession)
+	_ = tm.KillSession(otherSession)
+	if err := tm.NewSession(targetSession, ""); err != nil {
+		t.Fatalf("NewSession target: %v", err)
+	}
+	defer func() { _ = tm.KillSession(targetSession) }()
+	if err := tm.NewSession(otherSession, ""); err != nil {
+		t.Fatalf("NewSession other: %v", err)
+	}
+	defer func() { _ = tm.KillSession(otherSession) }()
+
+	otherPane, err := tm.GetPaneID(otherSession)
+	if err != nil {
+		t.Fatalf("GetPaneID other: %v", err)
+	}
+	if err := tm.SetEnvironment(targetSession, "GT_PANE_ID", otherPane); err != nil {
+		t.Fatalf("SetEnvironment GT_PANE_ID: %v", err)
+	}
+
+	paneID, err := tm.FindAgentPane(targetSession)
+	if err != nil {
+		t.Fatalf("FindAgentPane: %v", err)
+	}
+	if paneID == otherPane {
+		t.Fatalf("FindAgentPane returned pane %q from another session", paneID)
+	}
+}
+
 func TestFindAgentPane_MultiPaneWithNode(t *testing.T) {
 	tm := newTestTmux(t)
 	sessionName := "gt-test-findagent-multi-" + fmt.Sprintf("%d", time.Now().UnixNano()%10000)


### PR DESCRIPTION
## Summary
- Fixes #3563.
- Validates that a stored `GT_PANE_ID` still belongs to the target tmux session before `gt nudge` uses it.
- Falls back to the existing pane scan when the declared pane is stale or belongs to another session.
- Adds a regression test for the cross-session stale pane case.

## Bug
`gt nudge <rig>/crew/<name> ...` can fail after the target agent restarts because the target session may retain an old `GT_PANE_ID`. Since tmux pane IDs are global, validating `%pane` without checking its session can accept a pane from another session and later fail with errors like `can't find window: %164`.

## Why This Fix
This keeps the existing fast path for valid `GT_PANE_ID` values but makes the check session-aware. If the pane does not belong to the requested session, `FindAgentPane` uses the existing fallback scan instead of returning a stale pane.

## Scope / Duplicate Check
- Diff is limited to `internal/tmux/tmux.go` and `internal/tmux/tmux_test.go`.
- Checked open PRs for `GT_PANE_ID`, stale pane, nudge pane, cross-rig crew, and tmux pane overlap; no open duplicate found.
- Related prior work exists in merged/closed PRs, but current `main` still lacks this session-membership validation.

## Review Gate
Five independent review passes were run before submission:
- Reproduction/root-cause review: rework branch scope; use only focused commit.
- Minimality/ZFC review: approved focused commit only.
- Test coverage review: approved with non-blocking end-to-end coverage caveat.
- Duplicate/overlap review: no blocking duplicate found.
- PR readiness review: approved fork PR path with small diff.

## Testing
- `git diff --check origin/main...HEAD`
- `go test ./internal/tmux -run '^TestFindAgentPane_IgnoresPaneIDFromOtherSession$' -count=10 -timeout=2m -v`
- `go test ./internal/tmux -run 'TestFindAgentPane' -count=1 -timeout=3m -v`

## Notes
This PR intentionally does not change nudge delivery policy, add commands, or touch internal MQ behavior. It only tightens the tmux transport pane lookup.