### PR TITLE
fix: pin bd init to rig databases

### DIFF
--- a/internal/doctor/rig_check.go
+++ b/internal/doctor/rig_check.go
@@ -8,11 +8,13 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/git"
 )
 
@@ -1056,9 +1058,17 @@ func (c *BeadsRedirectCheck) Fix(ctx *CheckContext) error {
 		if prefix != "" {
 			initArgs = append(initArgs, "--prefix", prefix)
 		}
+		initArgs = append(initArgs, "--database", ctx.RigName)
 		initArgs = append(initArgs, "--server")
+		doltCfg := doltserver.DefaultConfig(ctx.TownRoot)
+		initArgs = append(initArgs, "--server-port", strconv.Itoa(doltCfg.Port))
+		bdEnv := append(stripEnvPrefixes(os.Environ(), "BEADS_DIR=", "BEADS_DB=", "BEADS_DOLT_SERVER_DATABASE="),
+			"BEADS_DIR="+rigBeadsDir,
+			"BEADS_DOLT_SERVER_DATABASE="+ctx.RigName,
+		)
 		cmd := exec.Command("bd", initArgs...)
 		cmd.Dir = rigPath
+		cmd.Env = bdEnv
 		if output, err := cmd.CombinedOutput(); err != nil {
 			// bd might not be installed — create config.yaml via shared helper.
 			if writeErr := beads.EnsureConfigYAML(rigBeadsDir, prefix); writeErr != nil {
@@ -1070,6 +1080,7 @@ func (c *BeadsRedirectCheck) Fix(ctx *CheckContext) error {
 			// Configure custom types for Gas Town (beads v0.46.0+)
 			configCmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
 			configCmd.Dir = rigPath
+			configCmd.Env = bdEnv
 			_, _ = configCmd.CombinedOutput() // Ignore errors - older beads don't need this
 		}
 		return nil
@@ -1934,8 +1945,8 @@ func (c *BareRepoExistsCheck) Fix(ctx *CheckContext) error {
 // os.RemoveAll erases .repo.git/worktrees/<name>/HEAD; without this the
 // re-registration would silently default to main.
 type bareRepoWorktreeRef struct {
-	relPath  string // rig-relative worktree directory path
-	headRef  string // contents of the worktree's HEAD (e.g. "ref: refs/heads/foo\n"), empty if unreadable
+	relPath string // rig-relative worktree directory path
+	headRef string // contents of the worktree's HEAD (e.g. "ref: refs/heads/foo\n"), empty if unreadable
 }
 
 // collectBareRepoReferences returns refs for every worktree dir whose .git

--- a/internal/doctor/rig_check_test.go
+++ b/internal/doctor/rig_check_test.go
@@ -33,9 +33,12 @@ exit 0
 		}
 	} else {
 		script := `#!/bin/sh
-target="$(pwd)/.beads"
-mkdir -p "$target"
-printf 'prefix: tr\nissue-prefix: tr-\n' > "$target/config.yaml"
+	if [ -n "$BD_ARGS_LOG" ]; then
+	  printf 'args=%s env=%s beads=%s db=%s\n' "$*" "${BEADS_DOLT_SERVER_DATABASE:-<unset>}" "${BEADS_DIR:-<unset>}" "${BEADS_DB:-<unset>}" >> "$BD_ARGS_LOG"
+	fi
+	target="$(pwd)/.beads"
+	mkdir -p "$target"
+	printf 'prefix: tr\nissue-prefix: tr-\n' > "$target/config.yaml"
 exit 0
 `
 		if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
@@ -44,6 +47,64 @@ exit 0
 	}
 
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+}
+
+func TestBeadsRedirectCheck_FixInitBeadsUsesCanonicalDatabase(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("mock bd arg logging is shell-specific")
+	}
+	installMockBdInitOnly(t)
+
+	tmpDir := t.TempDir()
+	rigName := "testrig"
+	rigDir := filepath.Join(tmpDir, rigName)
+	if err := os.MkdirAll(rigDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	rigsJSON := `{
+		"version": 1,
+		"rigs": {
+			"testrig": {
+				"git_url": "https://example.com/test.git",
+				"beads": {"prefix": "tr"}
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(rigsJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	argsLog := filepath.Join(t.TempDir(), "bd-args.log")
+	t.Setenv("BD_ARGS_LOG", argsLog)
+	t.Setenv("BEADS_DIR", filepath.Join(tmpDir, "wrong", ".beads"))
+	t.Setenv("BEADS_DB", filepath.Join(tmpDir, "wrong.db"))
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "wrong_db")
+
+	check := NewBeadsRedirectCheck()
+	ctx := &CheckContext{TownRoot: tmpDir, RigName: rigName}
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+
+	logData, err := os.ReadFile(argsLog)
+	if err != nil {
+		t.Fatalf("reading bd args log: %v", err)
+	}
+	log := string(logData)
+	if !strings.Contains(log, "args=init --prefix tr --database testrig --server --server-port") {
+		t.Fatalf("bd init did not use canonical rig database; log:\n%s", log)
+	}
+	if !strings.Contains(log, "env=testrig") || !strings.Contains(log, "beads="+filepath.Join(rigDir, ".beads")) {
+		t.Fatalf("bd init did not receive canonical env; log:\n%s", log)
+	}
+	if strings.Contains(log, "wrong_db") || strings.Contains(log, "wrong.db") || strings.Contains(log, filepath.Join(tmpDir, "wrong", ".beads")) {
+		t.Fatalf("stale BEADS env leaked into bd subprocess; log:\n%s", log)
+	}
 }
 
 func TestNewBeadsRedirectCheck(t *testing.T) {

--- a/internal/doctor/rig_config_sync_check.go
+++ b/internal/doctor/rig_config_sync_check.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -20,12 +21,12 @@ import (
 // can't find the beads prefix to check docked/parked status.
 type RigConfigSyncCheck struct {
 	FixableCheck
-	missingConfig    []string          // Rig names missing config.json
-	prefixMismatches []prefixMismatch  // Prefix mismatches between config.json and registry
-	missingRigBeads  []rigBeadInfo     // Rigs missing identity beads
-	missingDoltDB    []string          // Rigs missing Dolt database
-	missingPrefixCfg []string          // Rigs missing issue-prefix in config.yaml
-	dbNameMismatches []dbMismatch      // Dolt database name doesn't match prefix
+	missingConfig    []string         // Rig names missing config.json
+	prefixMismatches []prefixMismatch // Prefix mismatches between config.json and registry
+	missingRigBeads  []rigBeadInfo    // Rigs missing identity beads
+	missingDoltDB    []string         // Rigs missing Dolt database
+	missingPrefixCfg []string         // Rigs missing issue-prefix in config.yaml
+	dbNameMismatches []dbMismatch     // Dolt database name doesn't match prefix
 }
 
 type prefixMismatch struct {
@@ -41,10 +42,10 @@ type rigBeadInfo struct {
 }
 
 type dbMismatch struct {
-	rigName     string
-	prefix      string
-	currentDB   string
-	expectedDB  string
+	rigName    string
+	prefix     string
+	currentDB  string
+	expectedDB string
 }
 
 // NewRigConfigSyncCheck creates a new rig config sync check.
@@ -191,8 +192,13 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 				}
 
 				if !c.doltDatabaseExists(ctx, metadata.DoltDatabase) {
-					c.missingDoltDB = append(c.missingDoltDB, rigName)
-					details = append(details, fmt.Sprintf("Rig %s Dolt database '%s' not found on server", rigName, metadata.DoltDatabase))
+					if metadata.DoltDatabase != expectedDBName && c.doltDatabaseExists(ctx, expectedDBName) {
+						// The canonical database exists; the mismatch repair below will
+						// repoint metadata without re-initializing anything destructive.
+					} else {
+						c.missingDoltDB = append(c.missingDoltDB, rigName)
+						details = append(details, fmt.Sprintf("Rig %s Dolt database '%s' not found on server", rigName, metadata.DoltDatabase))
+					}
 				}
 			}
 		}
@@ -335,11 +341,19 @@ func (c *RigConfigSyncCheck) Fix(ctx *CheckContext) error {
 
 		rigPath := filepath.Join(ctx.TownRoot, rigName)
 		mayorRigPath := filepath.Join(rigPath, "mayor", "rig")
+		if c.doltDatabaseExists(ctx, rigName) {
+			continue
+		}
 
-		// Run bd init --prefix <prefix> --force --destroy-token to create the database
+		// Run bd init against the rig-name database, not the prefix-derived default.
+		doltCfg := doltserver.DefaultConfig(ctx.TownRoot)
 		destroyToken := fmt.Sprintf("DESTROY-%s", entry.BeadsConfig.Prefix)
-		cmd := exec.Command("bd", "init", "--prefix", entry.BeadsConfig.Prefix, "--force", "--destroy-token="+destroyToken)
+		cmd := exec.Command("bd", "init", "--prefix", entry.BeadsConfig.Prefix, "--database", rigName, "--server", "--server-port", strconv.Itoa(doltCfg.Port), "--force", "--destroy-token="+destroyToken)
 		cmd.Dir = mayorRigPath
+		cmd.Env = append(stripEnvPrefixes(os.Environ(), "BEADS_DIR=", "BEADS_DB=", "BEADS_DOLT_SERVER_DATABASE="),
+			"BEADS_DIR="+filepath.Join(mayorRigPath, ".beads"),
+			"BEADS_DOLT_SERVER_DATABASE="+rigName,
+		)
 		if output, err := cmd.CombinedOutput(); err != nil {
 			return fmt.Errorf("could not initialize Dolt DB for %s: %w\n%s", rigName, err, string(output))
 		}

--- a/internal/doctor/rig_config_sync_check_test.go
+++ b/internal/doctor/rig_config_sync_check_test.go
@@ -3,6 +3,8 @@ package doctor
 import (
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -159,6 +161,76 @@ func TestRigConfigSyncCheck_AllConfigsPresent(t *testing.T) {
 
 	if result.Status != StatusOK {
 		t.Errorf("expected StatusOK, got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestRigConfigSyncCheck_FixMissingDoltDBUsesCanonicalDatabase(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake bd arg/env logging is shell-specific")
+	}
+
+	tmpDir := t.TempDir()
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	rigsJSON := `{
+		"version": 1,
+		"rigs": {
+			"testrig": {
+				"git_url": "https://github.com/test/test.git",
+				"beads": {"prefix": "tr"}
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(rigsJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	mayorRigDir := filepath.Join(tmpDir, "testrig", "mayor", "rig")
+	if err := os.MkdirAll(mayorRigDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmdLog := filepath.Join(t.TempDir(), "bd-cmds.log")
+	binDir := t.TempDir()
+	script := `#!/usr/bin/env bash
+set -e
+printf 'args=%s env=%s beads=%s db=%s\n' "$*" "${BEADS_DOLT_SERVER_DATABASE:-<unset>}" "${BEADS_DIR:-<unset>}" "${BEADS_DB:-<unset>}" >> "$BD_CMD_LOG"
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_CMD_LOG", cmdLog)
+	t.Setenv("BEADS_DIR", filepath.Join(tmpDir, "wrong", ".beads"))
+	t.Setenv("BEADS_DB", filepath.Join(tmpDir, "wrong.db"))
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "wrong_db")
+
+	ctx := &CheckContext{TownRoot: tmpDir}
+	check := NewRigConfigSyncCheck()
+	check.missingDoltDB = []string{"testrig"}
+
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+
+	logData, err := os.ReadFile(cmdLog)
+	if err != nil {
+		t.Fatalf("reading command log: %v", err)
+	}
+	cmds := string(logData)
+	if !strings.Contains(cmds, "args=init --prefix tr --database testrig --server --server-port") {
+		t.Fatalf("bd init did not use canonical database; log:\n%s", cmds)
+	}
+	if !strings.Contains(cmds, "env=testrig") {
+		t.Fatalf("bd init did not receive canonical database env; log:\n%s", cmds)
+	}
+	if !strings.Contains(cmds, "beads="+filepath.Join(mayorRigDir, ".beads")) {
+		t.Fatalf("bd init did not receive mayor/rig BEADS_DIR; log:\n%s", cmds)
+	}
+	if strings.Contains(cmds, "wrong_db") || strings.Contains(cmds, "wrong.db") || strings.Contains(cmds, filepath.Join(tmpDir, "wrong", ".beads")) {
+		t.Fatalf("stale BEADS env leaked into bd subprocess; log:\n%s", cmds)
 	}
 }
 

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -598,10 +598,14 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 		// When metadata.json exists but the Dolt server database doesn't (fresh clone
 		// to a new workspace), we still need to run bd init to create the server-side
 		// database and set issue_prefix. Always ensure issue_prefix is set afterward.
+		sourceBdEnv := bdSubprocessEnv(sourceBeadsDir, opts.Name)
 		if !bdDatabaseExists(sourceBeadsDir) {
 			initArgs := []string{"init"}
 			if opts.BeadsPrefix != "" {
 				initArgs = append(initArgs, "--prefix", opts.BeadsPrefix)
+			}
+			if opts.Name != "" {
+				initArgs = append(initArgs, "--database", opts.Name)
 			}
 			initArgs = append(initArgs, "--server")
 			// Always pass --server-port so bd connects to gt's central Dolt
@@ -611,6 +615,7 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 			initArgs = append(initArgs, "--server-port", strconv.Itoa(doltCfg.Port))
 			cmd := exec.Command("bd", initArgs...)
 			cmd.Dir = mayorRigPath
+			cmd.Env = sourceBdEnv
 			if output, err := cmd.CombinedOutput(); err != nil {
 				fmt.Printf("  Warning: Could not init bd database: %v (%s)\n", err, strings.TrimSpace(string(output)))
 			}
@@ -627,10 +632,12 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 		// the server-side database has issue_prefix set for this workspace.
 		configCmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
 		configCmd.Dir = mayorRigPath
+		configCmd.Env = sourceBdEnv
 		_, _ = configCmd.CombinedOutput() // Ignore errors - older beads don't need this
 
 		prefixSetCmd := exec.Command("bd", "config", "set", "issue_prefix", opts.BeadsPrefix)
 		prefixSetCmd.Dir = mayorRigPath
+		prefixSetCmd.Env = sourceBdEnv
 		if prefixOutput, prefixErr := prefixSetCmd.CombinedOutput(); prefixErr != nil {
 			fmt.Printf("  Warning: Could not set issue_prefix: %v (%s)\n", prefixErr, strings.TrimSpace(string(prefixOutput)))
 		}
@@ -684,15 +691,16 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 	// Now that EnsureMetadata has corrected dolt_database, re-set it.
 	{
 		resolvedBeadsDir := beads.ResolveBeadsDir(rigPath)
+		bdEnv := bdSubprocessEnv(resolvedBeadsDir, opts.Name)
 		prefixCmd := exec.Command("bd", "config", "set", "issue_prefix", opts.BeadsPrefix)
 		prefixCmd.Dir = rigPath
-		prefixCmd.Env = append(os.Environ(), "BEADS_DIR="+resolvedBeadsDir)
+		prefixCmd.Env = bdEnv
 		if out, err := prefixCmd.CombinedOutput(); err != nil {
 			fmt.Printf("  Warning: Could not set issue_prefix on rig database: %v (%s)\n", err, strings.TrimSpace(string(out)))
 		}
 		typesCmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
 		typesCmd.Dir = rigPath
-		typesCmd.Env = append(os.Environ(), "BEADS_DIR="+resolvedBeadsDir)
+		typesCmd.Env = bdEnv
 		_, _ = typesCmd.CombinedOutput()
 	}
 
@@ -1140,13 +1148,16 @@ func (m *Manager) InitBeads(rigPath, prefix, rigName string) error {
 	// Build environment with explicit BEADS_DIR to prevent bd from
 	// finding a parent directory's .beads/ database
 	env := os.Environ()
-	filteredEnv := make([]string, 0, len(env)+1)
+	filteredEnv := make([]string, 0, len(env)+2)
 	for _, e := range env {
-		if !strings.HasPrefix(e, "BEADS_DIR=") {
+		if !strings.HasPrefix(e, "BEADS_DIR=") && !strings.HasPrefix(e, "BEADS_DB=") && !strings.HasPrefix(e, "BEADS_DOLT_SERVER_DATABASE=") {
 			filteredEnv = append(filteredEnv, e)
 		}
 	}
 	filteredEnv = append(filteredEnv, "BEADS_DIR="+beadsDir)
+	if rigName != "" {
+		filteredEnv = append(filteredEnv, "BEADS_DOLT_SERVER_DATABASE="+rigName)
+	}
 
 	// Ensure BEADS_DOLT_PORT and BEADS_DOLT_SERVER_HOST are set when their GT_
 	// counterparts are present, so that bd subprocesses connect to the correct
@@ -1180,6 +1191,9 @@ func (m *Manager) InitBeads(rigPath, prefix, rigName string) error {
 	initArgs := []string{"init"}
 	if prefix != "" {
 		initArgs = append(initArgs, "--prefix", prefix)
+	}
+	if rigName != "" {
+		initArgs = append(initArgs, "--database", rigName)
 	}
 	initArgs = append(initArgs, "--server")
 	// Always pass --server-port so bd connects to gt's central Dolt server.
@@ -1462,6 +1476,23 @@ var beadsPrefixRegexp = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]{0,19}$`)
 // malicious config files.
 func isValidBeadsPrefix(prefix string) bool {
 	return beadsPrefixRegexp.MatchString(prefix)
+}
+
+func bdSubprocessEnv(beadsDir, database string) []string {
+	env := make([]string, 0, len(os.Environ())+2)
+	for _, e := range os.Environ() {
+		if strings.HasPrefix(e, "BEADS_DIR=") || strings.HasPrefix(e, "BEADS_DB=") || strings.HasPrefix(e, "BEADS_DOLT_SERVER_DATABASE=") {
+			continue
+		}
+		env = append(env, e)
+	}
+	if beadsDir != "" {
+		env = append(env, "BEADS_DIR="+beadsDir)
+	}
+	if database != "" {
+		env = append(env, "BEADS_DOLT_SERVER_DATABASE="+database)
+	}
+	return env
 }
 
 // isStandardBeadHash checks if a string looks like a standard 5-char bead hash.

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -590,6 +590,50 @@ exit 0
 	}
 }
 
+func TestInitBeadsPassesCanonicalDatabase(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake bd arg/env logging is shell-specific")
+	}
+
+	rigPath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(rigPath, "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir mayor/rig: %v", err)
+	}
+
+	cmdLog := filepath.Join(t.TempDir(), "bd-cmds.log")
+	script := `#!/usr/bin/env bash
+set -e
+printf 'args=%s env=%s beads=%s db=%s\n' "$*" "${BEADS_DOLT_SERVER_DATABASE:-<unset>}" "${BEADS_DIR:-<unset>}" "${BEADS_DB:-<unset>}" >> "$BD_CMD_LOG"
+exit 0
+`
+	binDir := writeFakeBD(t, script, "")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_CMD_LOG", cmdLog)
+	t.Setenv("BEADS_DIR", filepath.Join(rigPath, "wrong", ".beads"))
+	t.Setenv("BEADS_DB", filepath.Join(rigPath, "wrong.db"))
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "stale_prefix_db")
+
+	manager := &Manager{}
+	if err := manager.InitBeads(rigPath, "xx", "my_project"); err != nil {
+		t.Fatalf("InitBeads: %v", err)
+	}
+
+	logData, err := os.ReadFile(cmdLog)
+	if err != nil {
+		t.Fatalf("reading command log: %v", err)
+	}
+	cmds := string(logData)
+	if !strings.Contains(cmds, "args=init --prefix xx --database my_project --server") {
+		t.Fatalf("bd init did not use canonical database; log:\n%s", cmds)
+	}
+	if strings.Contains(cmds, "env=stale_prefix_db") || strings.Contains(cmds, "wrong.db") || strings.Contains(cmds, filepath.Join(rigPath, "wrong", ".beads")) {
+		t.Fatalf("stale BEADS env leaked into bd subprocess; log:\n%s", cmds)
+	}
+	if !strings.Contains(cmds, "env=my_project") {
+		t.Fatalf("bd subprocess did not receive canonical database env; log:\n%s", cmds)
+	}
+}
+
 func TestInitAgentBeadsUsesRigBeadsDir(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake bd stub is not compatible with multiline descriptions on Windows")


### PR DESCRIPTION
## Summary
- Pass the canonical rig database name to Gas Town-managed `bd init` calls so prefix-derived defaults cannot create split-brain Dolt databases.
- Scrub stale `BEADS_DIR`, `BEADS_DB`, and `BEADS_DOLT_SERVER_DATABASE` before the touched `bd init`/`bd config` subprocesses.
- Add regression coverage for rig init and doctor repair paths with mismatched prefix vs rig names.

## Triage Notes
- Addresses the Gastown-managed paths for #2682.
- Related/duplicate context checked: #2922 remains broader bd init fragility; merged PRs #1343, #1541, #2668, #3060, #3672, #3829, and #3449 cover adjacent setup/doctor pieces but do not consistently pin these remaining `bd init` call sites to the rig database.
- This does not change arbitrary raw `bd init` behavior or destructive re-init safeguards inside the `bd` CLI; those remain beads-owned follow-up.

## Tests
- `go test ./internal/rig ./internal/doctor`
- `go test ./internal/doltserver -run 'TestEnsureMetadata|TestEnsureAllMetadata_NoOscillation'`