### PR TITLE
fix(hooks): seed Claude autonomous settings

### DIFF
--- a/internal/cmd/hooks_sync.go
+++ b/internal/cmd/hooks_sync.go
@@ -268,8 +268,9 @@ func syncTarget(target hooks.Target, dryRun bool) (syncResult, error) {
 	_, statErr := os.Stat(target.Path)
 	fileExists := statErr == nil
 
-	// Compare hooks sections
-	if fileExists && hooks.HooksEqual(expected, &current.Hooks) {
+	// Compare hooks sections and the Claude startup defaults. Existing settings
+	// from older versions may have current hooks but still miss prompt defaults.
+	if fileExists && hooks.HooksEqual(expected, &current.Hooks) && hooks.HasClaudePromptDefaults(current) {
 		return syncUnchanged, nil
 	}
 

--- a/internal/cmd/hooks_sync_test.go
+++ b/internal/cmd/hooks_sync_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"strings"
@@ -177,6 +178,72 @@ func TestSyncTargetUnchanged(t *testing.T) {
 	}
 }
 
+func TestSyncTargetUpdatesExistingPromptDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	targetPath := filepath.Join(tmpDir, "test", ".claude", "settings.json")
+	if err := os.MkdirAll(filepath.Dir(targetPath), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	expected, err := hooks.ComputeExpected("crew")
+	if err != nil {
+		t.Fatalf("ComputeExpected failed: %v", err)
+	}
+	rawHooks, err := json.Marshal(expected)
+	if err != nil {
+		t.Fatalf("marshal hooks: %v", err)
+	}
+	existing := map[string]json.RawMessage{
+		"customSentinel": json.RawMessage(`true`),
+		"hooks":          rawHooks,
+	}
+	data, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal settings: %v", err)
+	}
+	if err := os.WriteFile(targetPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	target := hooks.Target{
+		Path: targetPath,
+		Key:  "crew",
+		Role: "crew",
+	}
+
+	result, err := syncTarget(target, false)
+	if err != nil {
+		t.Fatalf("syncTarget failed: %v", err)
+	}
+	if result != syncUpdated {
+		t.Fatalf("expected syncUpdated, got %d", result)
+	}
+
+	data, err = os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("settings are not valid JSON: %v", err)
+	}
+	if got, ok := settings["customSentinel"].(bool); !ok || !got {
+		t.Fatalf("customSentinel = %v, want true", settings["customSentinel"])
+	}
+	if got, ok := settings["hasCompletedOnboarding"].(bool); !ok || !got {
+		t.Fatalf("hasCompletedOnboarding = %v, want true", settings["hasCompletedOnboarding"])
+	}
+	permissions, ok := settings["permissions"].(map[string]any)
+	if !ok {
+		t.Fatalf("permissions = %T, want object", settings["permissions"])
+	}
+	if got := permissions["defaultMode"]; got != "bypassPermissions" {
+		t.Fatalf("permissions.defaultMode = %v, want bypassPermissions", got)
+	}
+}
+
 func TestSyncTargetDryRun(t *testing.T) {
 	tmpDir := t.TempDir()
 	t.Setenv("HOME", tmpDir)
@@ -248,6 +315,54 @@ func TestSyncTargetSetsEnabledPlugins(t *testing.T) {
 	}
 	if settings.EnabledPlugins["beads@beads-marketplace"] != false {
 		t.Error("beads@beads-marketplace should be disabled")
+	}
+}
+
+func TestSyncTargetCreatesClaudePromptDefaults(t *testing.T) {
+	tmpDir := t.TempDir()
+	t.Setenv("HOME", tmpDir)
+
+	targetPath := filepath.Join(tmpDir, "test-rig", "crew", ".claude", "settings.json")
+	target := hooks.Target{
+		Path: targetPath,
+		Key:  "crew",
+		Role: "crew",
+	}
+
+	if _, err := syncTarget(target, false); err != nil {
+		t.Fatalf("syncTarget failed: %v", err)
+	}
+
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatalf("read settings: %v", err)
+	}
+	if strings.Contains(string(data), "export PATH=") {
+		t.Fatal("synced settings contain stale export PATH marker")
+	}
+	if strings.Contains(string(data), "{{GT_BIN}}") {
+		t.Fatal("synced settings contain unresolved {{GT_BIN}} placeholder")
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("settings are not valid JSON: %v", err)
+	}
+	if got, ok := settings["skipDangerousModePermissionPrompt"].(bool); !ok || !got {
+		t.Fatalf("skipDangerousModePermissionPrompt = %v, want true", settings["skipDangerousModePermissionPrompt"])
+	}
+	if got, ok := settings["hasCompletedOnboarding"].(bool); !ok || !got {
+		t.Fatalf("hasCompletedOnboarding = %v, want true", settings["hasCompletedOnboarding"])
+	}
+	if got := settings["theme"]; got != "dark" {
+		t.Fatalf("theme = %v, want dark", got)
+	}
+	permissions, ok := settings["permissions"].(map[string]any)
+	if !ok {
+		t.Fatalf("permissions = %T, want object", settings["permissions"])
+	}
+	if got := permissions["defaultMode"]; got != "bypassPermissions" {
+		t.Fatalf("permissions.defaultMode = %v, want bypassPermissions", got)
 	}
 }
 

--- a/internal/doctor/hooks_sync_check.go
+++ b/internal/doctor/hooks_sync_check.go
@@ -79,10 +79,12 @@ func (c *HooksSyncCheck) Run(ctx *CheckContext) *CheckResult {
 		_, statErr := os.Stat(target.Path)
 		fileExists := statErr == nil
 
-		if !fileExists || !hooks.HooksEqual(expected, &current.Hooks) {
+		if !fileExists || !hooks.HooksEqual(expected, &current.Hooks) || !hooks.HasClaudePromptDefaults(current) {
 			c.outOfSync = append(c.outOfSync, target)
 			if !fileExists {
 				details = append(details, fmt.Sprintf("%s: missing", target.DisplayKey()))
+			} else if !hooks.HasClaudePromptDefaults(current) {
+				details = append(details, fmt.Sprintf("%s: missing Claude prompt defaults", target.DisplayKey()))
 			} else {
 				details = append(details, fmt.Sprintf("%s: out of sync", target.DisplayKey()))
 			}

--- a/internal/doctor/hooks_sync_check_test.go
+++ b/internal/doctor/hooks_sync_check_test.go
@@ -1,6 +1,7 @@
 package doctor
 
 import (
+	"encoding/json"
 	"os"
 	"path/filepath"
 	"testing"
@@ -125,6 +126,48 @@ func TestHooksSyncCheck_ClaudeTargetInSync(t *testing.T) {
 		for _, d := range result.Details {
 			t.Logf("  detail: %s", d)
 		}
+	}
+}
+
+func TestHooksSyncCheck_ClaudeTargetMissingPromptDefaults(t *testing.T) {
+	townRoot := scaffoldWorkspace(t, nil)
+	syncAllClaudeTargets(t, townRoot)
+
+	targetPath := filepath.Join(townRoot, "mayor", ".claude", "settings.json")
+	data, err := os.ReadFile(targetPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		t.Fatal(err)
+	}
+	delete(raw, "skipDangerousModePermissionPrompt")
+	delete(raw, "hasCompletedOnboarding")
+	delete(raw, "theme")
+	delete(raw, "permissions")
+	data, err = json.MarshalIndent(raw, "", "  ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(targetPath, data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewHooksSyncCheck()
+	ctx := &CheckContext{TownRoot: townRoot}
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning for missing prompt defaults, got %v: %s", result.Status, result.Message)
+	}
+
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+	check = NewHooksSyncCheck()
+	result = check.Run(ctx)
+	if result.Status != StatusOK {
+		t.Fatalf("expected StatusOK after fix, got %v: %s", result.Status, result.Message)
 	}
 }
 

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -10,7 +10,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"runtime"
 	"strings"
 )
 
@@ -109,6 +108,7 @@ func MarshalSettings(s *SettingsJSON) ([]byte, error) {
 	for k, v := range s.Extra {
 		out[k] = v
 	}
+	addClaudePromptDefaults(out)
 
 	// Write known fields back into the map, or delete if zero-valued
 	if s.EditorMode != "" {
@@ -132,6 +132,70 @@ func MarshalSettings(s *SettingsJSON) ([]byte, error) {
 	out["hooks"] = raw
 
 	return json.MarshalIndent(out, "", "  ")
+}
+
+// HasClaudePromptDefaults reports whether settings already contain the Claude
+// startup defaults Gas Town needs for non-interactive agent sessions.
+func HasClaudePromptDefaults(s *SettingsJSON) bool {
+	if s == nil {
+		return false
+	}
+	if !rawBoolEquals(s.Extra, "skipDangerousModePermissionPrompt", true) {
+		return false
+	}
+	if !rawBoolEquals(s.Extra, "hasCompletedOnboarding", true) {
+		return false
+	}
+	if _, ok := s.Extra["theme"]; !ok {
+		return false
+	}
+	permissions := map[string]json.RawMessage{}
+	if raw, ok := s.Extra["permissions"]; !ok || json.Unmarshal(raw, &permissions) != nil {
+		return false
+	}
+	return rawStringEquals(permissions, "defaultMode", "bypassPermissions")
+}
+
+func addClaudePromptDefaults(out map[string]json.RawMessage) {
+	setRaw(out, "skipDangerousModePermissionPrompt", []byte(`true`))
+	setRaw(out, "hasCompletedOnboarding", []byte(`true`))
+	setRawDefault(out, "theme", []byte(`"dark"`))
+
+	permissions := map[string]json.RawMessage{}
+	if raw, ok := out["permissions"]; ok {
+		_ = json.Unmarshal(raw, &permissions)
+	}
+	permissions["defaultMode"] = json.RawMessage(`"bypassPermissions"`)
+	if raw, err := json.Marshal(permissions); err == nil {
+		out["permissions"] = raw
+	}
+}
+
+func setRaw(out map[string]json.RawMessage, key string, value []byte) {
+	out[key] = json.RawMessage(value)
+}
+
+func setRawDefault(out map[string]json.RawMessage, key string, value []byte) {
+	if _, ok := out[key]; ok {
+		return
+	}
+	out[key] = json.RawMessage(value)
+}
+
+func rawBoolEquals(raw map[string]json.RawMessage, key string, want bool) bool {
+	var got bool
+	if value, ok := raw[key]; !ok || json.Unmarshal(value, &got) != nil {
+		return false
+	}
+	return got == want
+}
+
+func rawStringEquals(raw map[string]json.RawMessage, key, want string) bool {
+	var got string
+	if value, ok := raw[key]; !ok || json.Unmarshal(value, &got) != nil {
+		return false
+	}
+	return got == want
 }
 
 // LoadSettings reads and parses a settings.json file, preserving unknown fields.
@@ -205,8 +269,6 @@ func Merge(base, override *HooksConfig) *HooksConfig {
 // context (which degrades quality), the session is replaced with a fresh one.
 // The successor picks up hooked work via SessionStart hook (gt prime --hook).
 func DefaultOverrides() map[string]*HooksConfig {
-	pathSetup := pathSetupCmd()
-
 	return map[string]*HooksConfig{
 		// Polecats: auto-run gt done on session Stop (gas-lob).
 		// Catches the "idle polecat" problem: polecats that finish work but
@@ -220,7 +282,7 @@ func DefaultOverrides() map[string]*HooksConfig {
 					Hooks: []Hook{
 						{
 							Type:    "command",
-							Command: hookChain(pathSetup, "gt tap polecat-stop-check"),
+							Command: gtCommand("gt tap polecat-stop-check"),
 						},
 					},
 				},
@@ -237,7 +299,7 @@ func DefaultOverrides() map[string]*HooksConfig {
 					Hooks: []Hook{
 						{
 							Type:    "command",
-							Command: hookChain(pathSetup, "gt handoff --cycle --reason compaction"),
+							Command: gtCommand("gt handoff --cycle --reason compaction"),
 						},
 					},
 				},
@@ -860,52 +922,50 @@ func ValidTarget(target string) bool {
 }
 
 // DefaultBase returns a sensible default base configuration.
-// This includes PATH setup and gt prime hooks that all agents need.
+// This includes resolved gt hook commands that all agents need.
 func DefaultBase() *HooksConfig {
-	pathSetup := pathSetupCmd()
-
 	return &HooksConfig{
 		PreToolUse: []HookEntry{
 			{
 				Matcher: "Bash(gh pr create*)",
 				Hooks: []Hook{{
 					Type:    "command",
-					Command: hookChain(pathSetup, "gt tap guard pr-workflow"),
+					Command: gtCommand("gt tap guard pr-workflow"),
 				}},
 			},
 			{
 				Matcher: "Bash(git checkout -b*)",
 				Hooks: []Hook{{
 					Type:    "command",
-					Command: hookChain(pathSetup, "gt tap guard pr-workflow"),
+					Command: gtCommand("gt tap guard pr-workflow"),
 				}},
 			},
 			{
 				Matcher: "Bash(git switch -c*)",
 				Hooks: []Hook{{
 					Type:    "command",
-					Command: hookChain(pathSetup, "gt tap guard pr-workflow"),
+					Command: gtCommand("gt tap guard pr-workflow"),
 				}},
 			},
 			{
 				Matcher: "Bash(rm -rf /*)",
 				Hooks: []Hook{{
 					Type:    "command",
-					Command: hookChain(pathSetup, "gt tap guard dangerous-command"),
+					Command: gtCommand("gt tap guard dangerous-command"),
 				}},
 			},
 			{
 				Matcher: "Bash(git push --force*)",
 				Hooks: []Hook{{
 					Type:    "command",
-					Command: hookChain(pathSetup, "gt tap guard dangerous-command"),
+					Command: gtCommand("gt tap guard dangerous-command"),
 				}},
 			},
 			{
 				Matcher: "Bash(git push -f*)",
 				Hooks: []Hook{{
 					Type:    "command",
-					Command: hookChain(pathSetup, "gt tap guard dangerous-command"),
+					Command: gtCommand("gt tap guard dangerous-command"),
 				}},
 			},
 		},
@@ -915,7 +975,7 @@ func DefaultBase() *HooksConfig {
 				Hooks: []Hook{
 					{
 						Type:    "command",
-						Command: hookChain(pathSetup, "gt prime --hook"),
+						Command: gtCommand("gt prime --hook"),
 					},
 				},
 			},
@@ -926,7 +986,7 @@ func DefaultBase() *HooksConfig {
 				Hooks: []Hook{
 					{
 						Type:    "command",
-						Command: hookChain(pathSetup, "gt prime --hook"),
+						Command: gtCommand("gt prime --hook"),
 					},
 				},
 			},
@@ -937,7 +997,7 @@ func DefaultBase() *HooksConfig {
 				Hooks: []Hook{
 					{
 						Type:    "command",
-						Command: hookChain(pathSetup, "gt mail check --inject"),
+						Command: gtCommand("gt mail check --inject"),
 					},
 				},
 			},
@@ -948,7 +1008,7 @@ func DefaultBase() *HooksConfig {
 				Hooks: []Hook{
 					{
 						Type:    "command",
-						Command: hookChain(pathSetup, "gt costs record &"),
+						Command: gtCommand("gt costs record &"),
 					},
 				},
 			},
@@ -1026,23 +1086,12 @@ func saveConfig(path string, cfg *HooksConfig) error {
 	return nil
 }
 
-// pathSetupCmd returns an OS-appropriate command to add Go and local bin
-// directories to PATH. On Unix this is a bash export; on Windows it
-// prepends to $env:PATH for PowerShell.
-func pathSetupCmd() string {
-	if runtime.GOOS == "windows" {
-		home := os.Getenv("USERPROFILE")
-		return fmt.Sprintf(`$env:PATH="%s\go\bin;%s\.local\bin;$env:PATH"`, home, home)
+func gtCommand(command string) string {
+	if command == "gt" {
+		return resolveGTBinary()
 	}
-	return `export PATH="$HOME/go/bin:$HOME/.local/bin:$PATH"`
-}
-
-// hookChain joins a path setup command with a gt command using an
-// OS-appropriate separator (&& for bash, ; for PowerShell).
-func hookChain(parts ...string) string {
-	sep := " && "
-	if runtime.GOOS == "windows" {
-		sep = "; "
+	if strings.HasPrefix(command, "gt ") {
+		return resolveGTBinary() + command[len("gt"):]
 	}
-	return strings.Join(parts, sep)
+	return command
 }

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -464,7 +464,7 @@ func TestComputeExpected(t *testing.T) {
 
 // TestComputeExpectedBackfillsSessionStart reproduces gt-y22: on-disk base
 // created before SessionStart was added to DefaultBase. SessionStart should
-// be backfilled from DefaultBase so settings.json files contain PATH exports.
+// be backfilled from DefaultBase so settings.json files contain startup hooks.
 func TestComputeExpectedBackfillsSessionStart(t *testing.T) {
 	tmpDir := t.TempDir()
 	setTestHome(t, tmpDir)
@@ -495,17 +495,21 @@ func TestComputeExpectedBackfillsSessionStart(t *testing.T) {
 		if len(expected.SessionStart) == 0 {
 			t.Errorf("%s: expected SessionStart to be backfilled from DefaultBase, got none", target)
 		}
-		// Verify PATH= is present (the actual doctor check)
-		hasPath := false
+		// Verify the generated hook uses a resolved gt command, not the stale
+		// export PATH= marker that causes settings to be treated as out-of-date.
+		hasPrime := false
 		for _, entry := range expected.SessionStart {
 			for _, hook := range entry.Hooks {
-				if strings.Contains(hook.Command, "PATH=") {
-					hasPath = true
+				if strings.Contains(hook.Command, "export PATH=") {
+					t.Errorf("%s: SessionStart contains stale export PATH marker: %q", target, hook.Command)
+				}
+				if strings.Contains(hook.Command, "prime --hook") {
+					hasPrime = true
 				}
 			}
 		}
-		if !hasPath {
-			t.Errorf("%s: expected PATH= in SessionStart hooks", target)
+		if !hasPrime {
+			t.Errorf("%s: expected prime --hook in SessionStart hooks", target)
 		}
 		// On-disk Stop should be preserved (not overwritten by DefaultBase)
 		if len(expected.Stop) == 0 {

--- a/internal/hooks/installer_test.go
+++ b/internal/hooks/installer_test.go
@@ -48,6 +48,109 @@ func TestInstallForRole_RoleAware(t *testing.T) {
 	}
 }
 
+func TestInstallForRole_ClaudeSettingsSuppressStartupPrompts(t *testing.T) {
+	tests := []struct {
+		name string
+		role string
+	}{
+		{"autonomous", "polecat"},
+		{"interactive", "crew"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			if err := InstallForRole("claude", dir, dir, tt.role, ".claude", "settings.json", true); err != nil {
+				t.Fatalf("InstallForRole: %v", err)
+			}
+
+			data, err := os.ReadFile(filepath.Join(dir, ".claude", "settings.json"))
+			if err != nil {
+				t.Fatalf("read settings: %v", err)
+			}
+			if strings.Contains(string(data), "export PATH=") {
+				t.Fatal("claude settings contain stale export PATH marker")
+			}
+			if strings.Contains(string(data), "{{GT_BIN}}") {
+				t.Fatal("claude settings contain unresolved {{GT_BIN}} placeholder")
+			}
+
+			var settings map[string]any
+			if err := json.Unmarshal(data, &settings); err != nil {
+				t.Fatalf("settings are not valid JSON: %v", err)
+			}
+			if got, ok := settings["skipDangerousModePermissionPrompt"].(bool); !ok || !got {
+				t.Fatalf("skipDangerousModePermissionPrompt = %v, want true", settings["skipDangerousModePermissionPrompt"])
+			}
+			if got, ok := settings["hasCompletedOnboarding"].(bool); !ok || !got {
+				t.Fatalf("hasCompletedOnboarding = %v, want true", settings["hasCompletedOnboarding"])
+			}
+			if got := settings["theme"]; got != "dark" {
+				t.Fatalf("theme = %v, want dark", got)
+			}
+			permissions, ok := settings["permissions"].(map[string]any)
+			if !ok {
+				t.Fatalf("permissions = %T, want object", settings["permissions"])
+			}
+			if got := permissions["defaultMode"]; got != "bypassPermissions" {
+				t.Fatalf("permissions.defaultMode = %v, want bypassPermissions", got)
+			}
+		})
+	}
+}
+
+func TestInstallForRole_ClaudeCurrentTemplatePreservesExistingSettings(t *testing.T) {
+	tests := []struct {
+		name string
+		role string
+	}{
+		{"autonomous", "polecat"},
+		{"interactive", "crew"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			settingsPath := filepath.Join(dir, ".claude", "settings.json")
+			if err := InstallForRole("claude", dir, dir, tt.role, ".claude", "settings.json", true); err != nil {
+				t.Fatalf("initial InstallForRole: %v", err)
+			}
+
+			data, err := os.ReadFile(settingsPath)
+			if err != nil {
+				t.Fatalf("read settings: %v", err)
+			}
+			var settings map[string]any
+			if err := json.Unmarshal(data, &settings); err != nil {
+				t.Fatalf("unmarshal settings: %v", err)
+			}
+			settings["customSentinel"] = true
+			updated, err := json.MarshalIndent(settings, "", "  ")
+			if err != nil {
+				t.Fatalf("marshal settings: %v", err)
+			}
+			if err := os.WriteFile(settingsPath, append(updated, '\n'), 0600); err != nil {
+				t.Fatalf("write settings: %v", err)
+			}
+
+			if err := InstallForRole("claude", dir, dir, tt.role, ".claude", "settings.json", true); err != nil {
+				t.Fatalf("second InstallForRole: %v", err)
+			}
+
+			data, err = os.ReadFile(settingsPath)
+			if err != nil {
+				t.Fatalf("read settings after second install: %v", err)
+			}
+			if err := json.Unmarshal(data, &settings); err != nil {
+				t.Fatalf("unmarshal settings after second install: %v", err)
+			}
+			if got, ok := settings["customSentinel"].(bool); !ok || !got {
+				t.Fatalf("customSentinel = %v, want true", settings["customSentinel"])
+			}
+		})
+	}
+}
+
 func TestInstallForRole_RoleAgnostic(t *testing.T) {
 	// OpenCode, Pi, OMP have single templates
 	tests := []struct {

--- a/internal/hooks/templates/claude/settings-autonomous.json
+++ b/internal/hooks/templates/claude/settings-autonomous.json
@@ -1,6 +1,11 @@
 {
   "skipDangerousModePermissionPrompt": true,
+  "hasCompletedOnboarding": true,
+  "theme": "dark",
   "editorMode": "normal",
+  "permissions": {
+    "defaultMode": "bypassPermissions"
+  },
   "enabledPlugins": {
     "beads@beads-marketplace": false
   },
@@ -38,7 +43,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard dangerous-command"
+            "command": "{{GT_BIN}} tap guard dangerous-command"
           }
         ]
       },
@@ -47,7 +52,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard dangerous-command"
+            "command": "{{GT_BIN}} tap guard dangerous-command"
           }
         ]
       },
@@ -56,7 +61,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard dangerous-command"
+            "command": "{{GT_BIN}} tap guard dangerous-command"
           }
         ]
       },
@@ -65,7 +70,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard dangerous-command"
+            "command": "{{GT_BIN}} tap guard dangerous-command"
           }
         ]
       },
@@ -74,7 +79,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard dangerous-command"
+            "command": "{{GT_BIN}} tap guard dangerous-command"
           }
         ]
       },
@@ -83,7 +88,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard dangerous-command"
+            "command": "{{GT_BIN}} tap guard dangerous-command"
           }
         ]
       },
@@ -92,7 +97,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "export PATH=\"$HOME/go/bin:$HOME/.local/bin:$PATH\" && gt tap guard dangerous-command"
+            "command": "{{GT_BIN}} tap guard dangerous-command"
           }
         ]
       }

--- a/internal/hooks/templates/claude/settings-interactive.json
+++ b/internal/hooks/templates/claude/settings-interactive.json
@@ -1,6 +1,11 @@
 {
   "skipDangerousModePermissionPrompt": true,
+  "hasCompletedOnboarding": true,
+  "theme": "dark",
   "editorMode": "normal",
+  "permissions": {
+    "defaultMode": "bypassPermissions"
+  },
   "enabledPlugins": {
     "beads@beads-marketplace": false
   },


### PR DESCRIPTION
## Summary
- Seed Claude settings generated by both template installs and `gt hooks sync`/`gt install` with prompt-suppression defaults: `skipDangerousModePermissionPrompt`, `hasCompletedOnboarding`, `theme`, and `permissions.defaultMode=bypassPermissions`.
- Replace remaining Claude autonomous `export PATH=... && gt` hook commands with resolved `gt` binary commands so freshly generated settings do not trigger `needsUpgrade()` on every startup.
- Teach hooks-sync/doctor to repair existing settings whose hooks are current but whose Claude prompt defaults are missing.

## Reproduction Before
On current `main`, `internal/hooks/installer.go` marks any settings file containing `export PATH=` as stale. `internal/hooks/templates/claude/settings-autonomous.json` still contained `export PATH=... && gt tap guard dangerous-command`, so generated polecat settings could be treated as stale by their own template on every startup. The Claude templates and `syncTarget`-generated settings also lacked `hasCompletedOnboarding` and `permissions.defaultMode=bypassPermissions`, leaving fresh Mayor/polecat sessions vulnerable to Claude permission/onboarding prompts.

## Fix Rationale
The smallest fix is to make Gas Town-managed Claude settings self-consistent at generation time. Template installs, `gt install`/`gt hooks sync`, and `gt doctor --fix hooks-sync` now converge on settings that include the required Claude prompt defaults and do not include the stale `export PATH=` marker.

## Duplicate Checks
- No open PR found for #3000, `hasCompletedOnboarding`, `bypassPermissions`, `needsUpgrade`, or the remaining `export PATH` Claude settings issue.
- Related merged PR #3315 replaced most hook-template `export PATH` usage but current `main` still had the Claude autonomous dangerous-command hooks and missing prompt defaults.
- Related closed PRs #3425 and #3644 handled account-switch/session startup wizard symptoms, not this fresh settings generation path.

## Tests
- `go test ./internal/hooks/...`
- `go test ./internal/cmd -run 'TestSyncTarget|TestComputeExpected|TestInstallHook|TestParseHooks|TestDiscoverHooks'`
- `go test ./internal/doctor -run 'TestHooksSyncCheck'`
- `go build ./cmd/gt`
- Attempted `go test ./...`; it did not complete within 10m and reproduced an unrelated existing `internal/acp` `TestIntegration_FullLoop` failure (agent stdin nil/session ID timeout). Rerun: `go test ./internal/acp -run TestIntegration_FullLoop -count=1` fails the same way.

Fixes #3000