### PR TITLE
fix(daemon): recover launchd Homebrew PATH

### DIFF
--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -153,6 +153,56 @@ const beadsModulePath = "github.com/steveyegge/beads"
 
 var semverPattern = regexp.MustCompile(`v?(\d+\.\d+\.\d+)`)
 
+func daemonPathCandidates(home, exePath string) []string {
+	candidates := make([]string, 0, 5)
+	if exePath != "" {
+		candidates = append(candidates, filepath.Dir(exePath))
+	}
+	if home != "" {
+		candidates = append(candidates,
+			filepath.Join(home, ".local/bin"),
+			filepath.Join(home, "bin"),
+		)
+	}
+	return append(candidates,
+		"/opt/homebrew/bin",
+		"/usr/local/bin",
+	)
+}
+
+func augmentDaemonPath(logger *log.Logger) {
+	exePath := ""
+	if exe, err := os.Executable(); err == nil {
+		exePath = exe
+	}
+	extras := daemonPathCandidates(os.Getenv("HOME"), exePath)
+	if len(extras) == 0 {
+		return
+	}
+
+	current := os.Getenv("PATH")
+	parts := strings.Split(current, string(os.PathListSeparator))
+	seen := make(map[string]struct{}, len(parts)+len(extras))
+	for _, p := range parts {
+		seen[p] = struct{}{}
+	}
+	augmented := parts
+	for _, extra := range extras {
+		if _, ok := seen[extra]; ok {
+			continue
+		}
+		if info, statErr := os.Stat(extra); statErr == nil && info.IsDir() {
+			augmented = append([]string{extra}, augmented...)
+			seen[extra] = struct{}{}
+		}
+	}
+	newPath := strings.Join(augmented, string(os.PathListSeparator))
+	if newPath != current {
+		_ = os.Setenv("PATH", newPath)
+		logger.Printf("PATCH-007: augmented daemon PATH with user/local bin dirs (was=%q, now=%q)", current, newPath)
+	}
+}
+
 // New creates a new daemon instance.
 func New(config *Config) (*Daemon, error) {
 	// Ensure daemon directory exists
@@ -172,6 +222,12 @@ func New(config *Config) (*Daemon, error) {
 
 	logger := log.New(logWriter, "", log.LstdFlags)
 	ctx, cancel := context.WithCancel(context.Background())
+
+	// PATCH-007 (hq-olcb): Augment PATH with common user/local bin
+	// directories before any subprocess lookup. The daemon is often launched
+	// from systemd / login shells / launchd without user-installed tool dirs
+	// such as ~/.local/bin or /opt/homebrew/bin.
+	augmentDaemonPath(logger)
 
 	// Initialize session prefix and agent registries from town root.
 	if err := session.InitRegistry(config.TownRoot); err != nil {
@@ -270,49 +326,6 @@ func New(config *Config) (*Daemon, error) {
 	}
 
 	// PATCH-006: Resolve binary paths at startup.
-	//
-	// PATCH-007 (hq-olcb): Augment PATH with common user/local bin
-	// directories before LookPath. The daemon is often launched from a
-	// systemd unit / login shell whose PATH does not include
-	// ~/.local/bin, where pip-installed `bd` and user-installed `gt`
-	// typically live. Without this, both LookPath calls fail at
-	// startup → gtPath / bdPath fall back to literal names → every
-	// subsequent exec.Command(d.gtPath, ...) fails with "executable
-	// file not found in $PATH", which cascaded into stranded convoys
-	// (couldn't query rig beads), failed dog dispatches (wisp_reaper
-	// fell back to inline mode), and likely upstream of hq-we9c
-	// (reaper false-positives, since the polecat-has-work check uses
-	// these binaries). Augmenting the daemon's own PATH propagates to
-	// child processes via bdReadOnlyEnv()'s os.Environ() pass-through.
-	if home := os.Getenv("HOME"); home != "" {
-		extras := []string{
-			filepath.Join(home, ".local/bin"),
-			filepath.Join(home, "bin"),
-			"/usr/local/bin",
-		}
-		current := os.Getenv("PATH")
-		parts := strings.Split(current, string(os.PathListSeparator))
-		seen := make(map[string]struct{}, len(parts)+len(extras))
-		for _, p := range parts {
-			seen[p] = struct{}{}
-		}
-		augmented := parts
-		for _, extra := range extras {
-			if _, ok := seen[extra]; ok {
-				continue
-			}
-			if info, statErr := os.Stat(extra); statErr == nil && info.IsDir() {
-				augmented = append([]string{extra}, augmented...)
-				seen[extra] = struct{}{}
-			}
-		}
-		newPath := strings.Join(augmented, string(os.PathListSeparator))
-		if newPath != current {
-			_ = os.Setenv("PATH", newPath)
-			logger.Printf("PATCH-007: augmented daemon PATH with user bin dirs (was=%q, now=%q)", current, newPath)
-		}
-	}
-
 	gtPath, err := exec.LookPath("gt")
 	if err != nil {
 		gtPath = "gt"

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -33,6 +33,24 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
+func TestDaemonPathCandidatesIncludesLaunchdToolDirs(t *testing.T) {
+	home := filepath.Join("Users", "alice")
+	exePath := filepath.Join("opt", "homebrew", "bin", "gt")
+
+	got := daemonPathCandidates(home, exePath)
+	for _, want := range []string{
+		filepath.Dir(exePath),
+		filepath.Join(home, ".local/bin"),
+		filepath.Join(home, "bin"),
+		"/opt/homebrew/bin",
+		"/usr/local/bin",
+	} {
+		if !slices.Contains(got, want) {
+			t.Fatalf("daemonPathCandidates(%q, %q) missing %q; got %v", home, exePath, want, got)
+		}
+	}
+}
+
 func TestStateFile(t *testing.T) {
 	townRoot := "/tmp/test-town"
 	expected := filepath.Join(townRoot, "daemon", "state.json")


### PR DESCRIPTION
## Summary
- Fixes #3738 by augmenting the daemon process PATH before any subprocess lookup, including the running binary directory, `/opt/homebrew/bin`, and `/usr/local/bin`.
- Moves PATH repair before early tmux setup so launchd-started daemons can resolve `tmux`, `gt`, and `bd` consistently.
- Adds coverage for the launchd/Homebrew PATH candidates.

## Triage
- Duplicate check: #875 was closed by merged PR #876, but that only inherited the daemon's existing environment and did not add `/opt/homebrew/bin` under launchd.
- PR check: no open or merged PR found specifically for #3738 or launchd `/opt/homebrew/bin` PATH recovery.
- Internal same-repo PR #3953 was auto-closed by policy; this PR is from a fork as required.

## Testing
- `go test -c ./internal/daemon -o /tmp/opencode/daemon.test`
- `go test ./internal/daemon -run TestDaemonPathCandidatesIncludesLaunchdToolDirs -count=1` currently fails before running tests because `internal/daemon.TestMain` panics in testcontainers with `rootless Docker not found` in this environment.