### PR TITLE
fix(deacon): gate patrol heartbeats on lifecycle progress

### DIFF
--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -526,7 +526,7 @@ func startDeaconSession(t *tmux.Tmux, sessionName, agentOverride string) error {
 		Recipient: "deacon",
 		Sender:    "daemon",
 		Topic:     "patrol",
-	}, "I am Deacon. First run `gt deacon heartbeat`. Then check gt hook, and if it is empty run `gt sling mol-deacon-patrol deacon`, then execute the hook it creates.")
+	}, "I am Deacon. First run `gt deacon heartbeat`. Then check gt hook, and if it is empty run `gt patrol new`, then execute the hook it creates.")
 	startupCmd, err := config.BuildStartupCommandFromConfig(config.AgentEnvConfig{
 		Role:             "deacon",
 		TownRoot:         townRoot,
@@ -808,7 +808,6 @@ func runDeaconHeartbeat(cmd *cobra.Command, args []string) error {
 	if err != nil {
 		return fmt.Errorf("not in a Gas Town workspace: %w", err)
 	}
-
 	// Check if Deacon is paused - if so, refuse to update heartbeat
 	paused, state, err := deacon.IsPaused(townRoot)
 	if err != nil {
@@ -820,6 +819,9 @@ func runDeaconHeartbeat(cmd *cobra.Command, args []string) error {
 			fmt.Printf("  Reason: %s\n", state.Reason)
 		}
 		return errors.New("Deacon is paused")
+	}
+	if err := deacon.ConsumeHeartbeatCredit(townRoot); err != nil {
+		return err
 	}
 
 	action := ""

--- a/internal/cmd/patrol_helpers.go
+++ b/internal/cmd/patrol_helpers.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/cli"
+	"github.com/steveyegge/gastown/internal/deacon"
 	"github.com/steveyegge/gastown/internal/style"
 	"golang.org/x/text/cases"
 	"golang.org/x/text/language"
@@ -306,6 +307,15 @@ func autoSpawnPatrol(cfg PatrolConfig) (string, error) {
 	return patrolID, nil
 }
 
+func grantDeaconPatrolHeartbeatCredits(cfg PatrolConfig, patrolID string) {
+	if cfg.RoleName != "deacon" {
+		return
+	}
+	if err := deacon.GrantHeartbeatCredits(cfg.BeadsDir, patrolID, deacon.HeartbeatCreditsPerPatrol); err != nil {
+		style.PrintWarning("could not grant deacon heartbeat credits: %v", err)
+	}
+}
+
 // outputPatrolContext is the main function that handles patrol display logic.
 // It finds or creates a patrol and outputs the status and work loop.
 func outputPatrolContext(cfg PatrolConfig) {
@@ -339,12 +349,14 @@ func outputPatrolContext(cfg PatrolConfig) {
 				return
 			}
 		} else {
+			grantDeaconPatrolHeartbeatCredits(cfg, patrolID)
 			fmt.Printf("✓ Created and hooked patrol wisp: %s\n", patrolID)
 		}
 	} else {
 		// Has active patrol - show status
 		fmt.Println("Status: **Patrol Active**")
 		fmt.Printf("Patrol: %s\n\n", strings.TrimSpace(patrolLine))
+		grantDeaconPatrolHeartbeatCredits(cfg, patrolID)
 	}
 
 	// Show patrol work loop instructions

--- a/internal/cmd/patrol_new.go
+++ b/internal/cmd/patrol_new.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"strings"
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/constants"
@@ -74,6 +75,17 @@ func runPatrolNew(cmd *cobra.Command, args []string) error {
 	default:
 		return fmt.Errorf("unsupported role for patrol: %q (expected deacon, witness, or refinery)", roleName)
 	}
+	if cfg.RoleName == "deacon" {
+		patrolID, patrolLine, hasPatrol, err := findActivePatrol(cfg)
+		if err != nil {
+			return fmt.Errorf("checking active deacon patrol: %w", err)
+		}
+		if hasPatrol {
+			fmt.Printf("active patrol already exists: %s\n", strings.TrimSpace(patrolLine))
+			fmt.Println(patrolID)
+			return nil
+		}
+	}
 
 	// Create and hook the wisp
 	patrolID, err := autoSpawnPatrol(cfg)
@@ -86,6 +98,7 @@ func runPatrolNew(cmd *cobra.Command, args []string) error {
 		}
 		return err
 	}
+	grantDeaconPatrolHeartbeatCredits(cfg, patrolID)
 
 	fmt.Println(patrolID)
 	return nil

--- a/internal/cmd/patrol_report.go
+++ b/internal/cmd/patrol_report.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"fmt"
 	"os"
+	"sort"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -93,8 +94,16 @@ func runPatrolReport(cmd *cobra.Command, args []string) error {
 	// Close the current patrol root with the summary
 	b := beads.New(cfg.BeadsDir)
 
-	// Build step audit checklist
+	// Build step audit checklist. Deacon patrol is integrity-sensitive: missing
+	// or partial audits allowed synthetic cycles to look healthy (GH #2386).
 	stepAudit := buildStepAudit(cfg.PatrolMolName, patrolReportSteps)
+	if cfg.RoleName == "deacon" {
+		var auditErr error
+		stepAudit, auditErr = validateStepAudit(cfg.PatrolMolName, patrolReportSteps, cfg.BeadsDir, "")
+		if auditErr != nil {
+			return auditErr
+		}
+	}
 
 	// Update the description with the patrol summary and step audit
 	desc := fmt.Sprintf("Patrol report: %s\n\n%s", patrolReportSummary, stepAudit)
@@ -132,15 +141,115 @@ func runPatrolReport(cmd *cobra.Command, args []string) error {
 		}
 		return fmt.Errorf("starting next patrol cycle: %w", err)
 	}
+	grantDeaconPatrolHeartbeatCredits(cfg, newPatrolID)
 
 	fmt.Printf("%s Started new patrol: %s\n", style.Success.Render("✓"), newPatrolID)
 	return nil
 }
 
+func validateStepAudit(formulaName string, stepsFlag string, townRoot string, rigName string) (string, error) {
+	if strings.TrimSpace(stepsFlag) == "" {
+		return "", fmt.Errorf("--steps is required for %s patrol reports", formulaName)
+	}
+
+	content, err := formula.ResolveFormulaContent(formulaName, townRoot, rigName)
+	if err != nil {
+		return "", fmt.Errorf("loading formula %s: %w", formulaName, err)
+	}
+
+	f, err := formula.Parse(content)
+	if err != nil {
+		return "", fmt.Errorf("parsing formula %s: %w", formulaName, err)
+	}
+
+	allStepIDs := f.GetAllIDs()
+	if len(allStepIDs) == 0 {
+		return "", fmt.Errorf("formula %s has no steps", formulaName)
+	}
+
+	reported, err := parseStepResultsStrict(stepsFlag)
+	if err != nil {
+		return "", err
+	}
+
+	known := make(map[string]bool, len(allStepIDs))
+	for _, stepID := range allStepIDs {
+		known[stepID] = true
+	}
+
+	var unknown []string
+	for stepID := range reported {
+		if !known[stepID] {
+			unknown = append(unknown, stepID)
+		}
+	}
+	if len(unknown) > 0 {
+		sort.Strings(unknown)
+		return "", fmt.Errorf("--steps contains unknown step IDs: %s", strings.Join(unknown, ", "))
+	}
+
+	var missing []string
+	for _, stepID := range allStepIDs {
+		if _, ok := reported[stepID]; !ok {
+			missing = append(missing, stepID)
+		}
+	}
+	if len(missing) > 0 {
+		return "", fmt.Errorf("--steps missing required step IDs: %s", strings.Join(missing, ", "))
+	}
+	for _, requiredOK := range []string{"heartbeat", "loop-or-exit"} {
+		if reported[requiredOK] != "OK" {
+			return "", fmt.Errorf("--steps must mark %s:OK for deacon patrol reports", requiredOK)
+		}
+	}
+
+	var parts []string
+	okCount := 0
+	for _, stepID := range allStepIDs {
+		status := reported[stepID]
+		if status == "OK" {
+			okCount++
+		}
+		parts = append(parts, stepID+" "+status)
+	}
+
+	return fmt.Sprintf("Steps: %s (%d/%d)", strings.Join(parts, " | "), okCount, len(allStepIDs)), nil
+}
+
+func parseStepResultsStrict(stepsFlag string) (map[string]string, error) {
+	results := make(map[string]string)
+	for _, entry := range strings.Split(stepsFlag, ",") {
+		entry = strings.TrimSpace(entry)
+		if entry == "" {
+			return nil, fmt.Errorf("--steps contains an empty entry")
+		}
+
+		parts := strings.SplitN(entry, ":", 2)
+		if len(parts) != 2 {
+			return nil, fmt.Errorf("--steps entry %q must use step:STATUS format", entry)
+		}
+
+		stepID := strings.TrimSpace(parts[0])
+		status := strings.ToUpper(strings.TrimSpace(parts[1]))
+		if stepID == "" || status == "" {
+			return nil, fmt.Errorf("--steps entry %q must include both step and status", entry)
+		}
+		if _, exists := results[stepID]; exists {
+			return nil, fmt.Errorf("--steps contains duplicate step ID %q", stepID)
+		}
+		if status != "OK" && status != "SKIP" {
+			return nil, fmt.Errorf("--steps entry %q has invalid status %q (want OK or SKIP)", stepID, status)
+		}
+
+		results[stepID] = status
+	}
+	return results, nil
+}
+
 // buildStepAudit builds a step checklist from the formula's steps and the
 // reported step results. Format:
 //
-//	Steps: heartbeat OK | inbox-check OK | orphan-cleanup SKIP | ... (14/25)
+//	Steps: heartbeat OK | inbox-check OK | orphan-cleanup SKIP | ... (14/26)
 //
 // If stepsFlag is empty, returns a line indicating the audit was not reported.
 func buildStepAudit(formulaName string, stepsFlag string) string {

--- a/internal/cmd/patrol_test.go
+++ b/internal/cmd/patrol_test.go
@@ -1,8 +1,12 @@
 package cmd
 
 import (
+	"os"
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/gastown/internal/deacon"
+	"github.com/steveyegge/gastown/internal/formula"
 )
 
 func TestExtractPatrolRole(t *testing.T) {
@@ -234,5 +238,124 @@ func TestBuildStepAudit(t *testing.T) {
 				t.Errorf("buildStepAudit() = %q, want to contain %q", got, tt.wantContain)
 			}
 		})
+	}
+}
+
+func deaconAllOKSteps(t *testing.T) string {
+	t.Helper()
+	content, err := formula.GetEmbeddedFormulaContent("mol-deacon-patrol")
+	if err != nil {
+		t.Fatalf("load deacon formula: %v", err)
+	}
+	f, err := formula.Parse(content)
+	if err != nil {
+		t.Fatalf("parse deacon formula: %v", err)
+	}
+	ids := f.GetAllIDs()
+	parts := make([]string, 0, len(ids))
+	for _, id := range ids {
+		parts = append(parts, id+":OK")
+	}
+	return strings.Join(parts, ",")
+}
+
+func TestValidateStepAudit(t *testing.T) {
+	allOK := deaconAllOKSteps(t)
+	allSkip := strings.ReplaceAll(allOK, ":OK", ":SKIP")
+
+	tests := []struct {
+		name      string
+		stepsFlag string
+		wantErr   string
+	}{
+		{
+			name:      "all steps accepted",
+			stepsFlag: allOK,
+		},
+		{
+			name:      "missing steps rejected",
+			stepsFlag: "heartbeat:OK",
+			wantErr:   "missing required step IDs",
+		},
+		{
+			name:      "empty steps rejected",
+			stepsFlag: "",
+			wantErr:   "--steps is required",
+		},
+		{
+			name:      "unknown step rejected",
+			stepsFlag: allOK + ",made-up:OK",
+			wantErr:   "unknown step IDs",
+		},
+		{
+			name:      "invalid status rejected",
+			stepsFlag: strings.Replace(allOK, "heartbeat:OK", "heartbeat:DONE", 1),
+			wantErr:   "invalid status",
+		},
+		{
+			name:      "duplicate step rejected",
+			stepsFlag: allOK + ",heartbeat:OK",
+			wantErr:   "duplicate step ID",
+		},
+		{
+			name:      "all skip rejected",
+			stepsFlag: allSkip,
+			wantErr:   "heartbeat:OK",
+		},
+		{
+			name:      "malformed entry rejected",
+			stepsFlag: strings.Replace(allOK, "heartbeat:OK", "heartbeat", 1),
+			wantErr:   "step:STATUS",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			audit, err := validateStepAudit("mol-deacon-patrol", tt.stepsFlag, "", "")
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("validateStepAudit() error = %v", err)
+				}
+				if !strings.HasSuffix(audit, "(26/26)") {
+					t.Fatalf("audit suffix = %q, want (26/26)", audit)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("validateStepAudit() succeeded, want error containing %q", tt.wantErr)
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Fatalf("validateStepAudit() error = %q, want containing %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestDeaconHeartbeatCreditsMatchFormula(t *testing.T) {
+	content, err := formula.GetEmbeddedFormulaContent("mol-deacon-patrol")
+	if err != nil {
+		t.Fatalf("load deacon formula: %v", err)
+	}
+	heartbeats := strings.Count(string(content), "gt deacon heartbeat")
+	if heartbeats != deacon.HeartbeatCreditsPerPatrol {
+		t.Fatalf("formula heartbeat calls = %d, HeartbeatCreditsPerPatrol = %d", heartbeats, deacon.HeartbeatCreditsPerPatrol)
+	}
+}
+
+func TestDeaconTemplatePatrolIntegrityGuidance(t *testing.T) {
+	content, err := os.ReadFile("../templates/roles/deacon.md.tmpl")
+	if err != nil {
+		t.Fatalf("read deacon template: %v", err)
+	}
+	template := string(content)
+	for _, stale := range []string{"patrol_count", "25 steps", "/25"} {
+		if strings.Contains(template, stale) {
+			t.Fatalf("deacon template still contains stale patrol guidance %q", stale)
+		}
+	}
+	for _, required := range []string{"26 steps", "--steps"} {
+		if !strings.Contains(template, required) {
+			t.Fatalf("deacon template missing required patrol guidance %q", required)
+		}
 	}
 }

--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -225,6 +225,7 @@ func extractFormulaVar(formulaVars, key string) string {
 	}
 	return ""
 }
+
 // truncateDescription truncates a multi-line description to a single line summary.
 func truncateDescription(desc string, maxLen int) string {
 	// Take just the first line
@@ -271,7 +272,6 @@ func outputMoleculeContext(ctx RoleContext) {
 	// No child-based tracking needed.
 }
 
-
 // outputDeaconPatrolContext shows patrol molecule status for the Deacon.
 // Deacon uses wisps (Wisp:true issues in main .beads/) for patrol cycles.
 // Deacon is a town-level role, so it uses town root beads (not rig beads).
@@ -284,15 +284,15 @@ func outputDeaconPatrolContext(ctx RoleContext) {
 	}
 
 	cfg := PatrolConfig{
-		RoleName:        "deacon",
-		PatrolMolName:   constants.MolDeaconPatrol,
-		BeadsDir:        ctx.TownRoot, // Town-level role uses town root beads
-		Assignee:        "deacon",
-		HeaderEmoji:     "🔄",
-		HeaderTitle:     "Patrol Status (Wisp-based)",
+		RoleName:      "deacon",
+		PatrolMolName: constants.MolDeaconPatrol,
+		BeadsDir:      ctx.TownRoot, // Town-level role uses town root beads
+		Assignee:      "deacon",
+		HeaderEmoji:   "🔄",
+		HeaderTitle:   "Patrol Status (Wisp-based)",
 		WorkLoopSteps: []string{
 			"Work through each patrol step in sequence (see checklist below)",
-			"At cycle end:\n   - If context LOW:\n     * Report and loop: `" + cli.Name() + " patrol report --summary \"<brief summary of observations>\"`\n     * This closes the current patrol and starts a new cycle\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Deacon patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",
+			"At cycle end:\n   - If context LOW:\n     * Report and loop: `" + cli.Name() + " patrol report --summary \"<brief summary of observations>\" --steps \"<all 26 step_id:OK|SKIP pairs>\"`\n     * This closes the current patrol and starts a new cycle\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Deacon patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",
 		},
 	}
 	outputPatrolContext(cfg)
@@ -308,13 +308,13 @@ func outputWitnessPatrolContext(ctx RoleContext) {
 	}
 	extraVars := buildWitnessPatrolVars(ctx)
 	cfg := PatrolConfig{
-		RoleName:        "witness",
-		PatrolMolName:   constants.MolWitnessPatrol,
-		BeadsDir:        ctx.TownRoot,
-		Assignee:        ctx.Rig + "/witness",
-		HeaderEmoji:     constants.EmojiWitness,
-		HeaderTitle:     "Witness Patrol Status",
-		ExtraVars:       extraVars,
+		RoleName:      "witness",
+		PatrolMolName: constants.MolWitnessPatrol,
+		BeadsDir:      ctx.TownRoot,
+		Assignee:      ctx.Rig + "/witness",
+		HeaderEmoji:   constants.EmojiWitness,
+		HeaderTitle:   "Witness Patrol Status",
+		ExtraVars:     extraVars,
 		WorkLoopSteps: []string{
 			"Work through each patrol step in sequence (see checklist below)",
 			"At cycle end:\n   - If context LOW:\n     * Report and loop: `" + cli.Name() + " patrol report --summary \"<brief summary of observations>\"`\n     * This closes the current patrol and starts a new cycle\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Witness patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",
@@ -332,13 +332,13 @@ func outputRefineryPatrolContext(ctx RoleContext) {
 		return
 	}
 	cfg := PatrolConfig{
-		RoleName:        "refinery",
-		PatrolMolName:   constants.MolRefineryPatrol,
-		BeadsDir:        ctx.TownRoot,
-		Assignee:        ctx.Rig + "/refinery",
-		HeaderEmoji:     "🔧",
-		HeaderTitle:     "Refinery Patrol Status",
-		ExtraVars:       buildRefineryPatrolVars(ctx),
+		RoleName:      "refinery",
+		PatrolMolName: constants.MolRefineryPatrol,
+		BeadsDir:      ctx.TownRoot,
+		Assignee:      ctx.Rig + "/refinery",
+		HeaderEmoji:   "🔧",
+		HeaderTitle:   "Refinery Patrol Status",
+		ExtraVars:     buildRefineryPatrolVars(ctx),
 		WorkLoopSteps: []string{
 			"Work through each patrol step in sequence (see checklist below)",
 			"At cycle end:\n   - If context LOW:\n     * Report and loop: `" + cli.Name() + " patrol report --summary \"<brief summary of observations>\"`\n     * This closes the current patrol and starts a new cycle\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Refinery patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",

--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -1,9 +1,9 @@
 package cmd
 
 import (
-	"github.com/steveyegge/gastown/internal/cli"
 	"encoding/json"
 	"fmt"
+	"github.com/steveyegge/gastown/internal/cli"
 	"io"
 	"os"
 	"path/filepath"
@@ -560,7 +560,7 @@ func outputStartupDirective(ctx RoleContext) {
 		fmt.Println("4. Check mail: `" + cli.Name() + " mail inbox` - look for 🤝 HANDOFF messages")
 		fmt.Println("5. Check for attached patrol: `" + cli.Name() + " hook`")
 		fmt.Println("   - If mol attached → **RUN IT** (resume from current step)")
-		fmt.Println("   - If no mol → create patrol: `bd mol wisp mol-deacon-patrol`")
+		fmt.Println("   - If no mol → create patrol: `" + cli.Name() + " patrol new`")
 	case RoleDog:
 		fmt.Println()
 		fmt.Println("---")

--- a/internal/deacon/heartbeat.go
+++ b/internal/deacon/heartbeat.go
@@ -5,9 +5,12 @@ package deacon
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/lock"
 )
 
 // Heartbeat age thresholds — these are compiled-in defaults.
@@ -22,7 +25,21 @@ const (
 	// Must be greater than patrol backoff-max (15m) to avoid false positives
 	// during legitimate await-signal sleep.
 	HeartbeatVeryStaleThreshold = 20 * time.Minute
+
+	// HeartbeatCreditsPerPatrol matches the three heartbeat calls in
+	// mol-deacon-patrol: cycle start, mid-cycle, and pre-await checkpoint.
+	HeartbeatCreditsPerPatrol = 3
 )
+
+// HeartbeatCreditState gates deacon heartbeat writes on patrol lifecycle
+// progress. It prevents background loops from inflating heartbeat/cycle counts
+// without creating or reporting patrol wisps.
+type HeartbeatCreditState struct {
+	Credits          int       `json:"credits"`
+	PatrolID         string    `json:"patrol_id,omitempty"`
+	BootstrapGranted bool      `json:"bootstrap_granted"`
+	UpdatedAt        time.Time `json:"updated_at"`
+}
 
 // Heartbeat represents the Deacon's heartbeat file contents.
 // Written by the Deacon on each wake cycle.
@@ -47,6 +64,125 @@ type Heartbeat struct {
 // HeartbeatFile returns the path to the Deacon heartbeat file.
 func HeartbeatFile(townRoot string) string {
 	return filepath.Join(townRoot, "deacon", "heartbeat.json")
+}
+
+// HeartbeatCreditFile returns the path to the persisted heartbeat credit state.
+func HeartbeatCreditFile(townRoot string) string {
+	return filepath.Join(townRoot, "deacon", "heartbeat_credits.json")
+}
+
+func readHeartbeatCredits(townRoot string) (*HeartbeatCreditState, bool, error) {
+	data, err := os.ReadFile(HeartbeatCreditFile(townRoot)) //nolint:gosec // G304: path is constructed from trusted townRoot
+	if os.IsNotExist(err) {
+		return &HeartbeatCreditState{}, false, nil
+	}
+	if err != nil {
+		return nil, false, err
+	}
+
+	var state HeartbeatCreditState
+	if err := json.Unmarshal(data, &state); err != nil {
+		return nil, true, err
+	}
+	return &state, true, nil
+}
+
+func writeHeartbeatCredits(townRoot string, state *HeartbeatCreditState) error {
+	path := HeartbeatCreditFile(townRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+	state.UpdatedAt = time.Now().UTC()
+
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		return err
+	}
+
+	tmp, err := os.CreateTemp(filepath.Dir(path), ".heartbeat_credits-*")
+	if err != nil {
+		return err
+	}
+	tmpPath := tmp.Name()
+	defer os.Remove(tmpPath) //nolint:errcheck // best-effort cleanup after rename/failure
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Chmod(0600); err != nil {
+		_ = tmp.Close()
+		return err
+	}
+	if err := tmp.Close(); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpPath, path)
+}
+
+func withHeartbeatCreditsLock(townRoot string, fn func(*HeartbeatCreditState, bool) error) error {
+	path := HeartbeatCreditFile(townRoot)
+	if err := os.MkdirAll(filepath.Dir(path), 0755); err != nil {
+		return err
+	}
+
+	unlock, err := lock.FlockAcquire(path + ".flock")
+	if err != nil {
+		return err
+	}
+	defer unlock()
+
+	state, exists, err := readHeartbeatCredits(townRoot)
+	if err != nil {
+		return err
+	}
+	if err := fn(state, exists); err != nil {
+		return err
+	}
+	return writeHeartbeatCredits(townRoot, state)
+}
+
+// GrantHeartbeatCredits records verified patrol lifecycle progress. Credits are
+// capped at one patrol cycle so repeated lifecycle calls cannot accumulate an
+// unbounded heartbeat budget.
+func GrantHeartbeatCredits(townRoot string, patrolID string, credits int) error {
+	if patrolID == "" {
+		return fmt.Errorf("patrol ID is required to grant deacon heartbeat credits")
+	}
+	if credits <= 0 {
+		return nil
+	}
+	return withHeartbeatCreditsLock(townRoot, func(state *HeartbeatCreditState, _ bool) error {
+		if state.PatrolID == patrolID {
+			return nil
+		}
+		state.PatrolID = patrolID
+		state.BootstrapGranted = true
+		state.Credits = credits
+		if state.Credits > HeartbeatCreditsPerPatrol {
+			state.Credits = HeartbeatCreditsPerPatrol
+		}
+		return nil
+	})
+}
+
+// ConsumeHeartbeatCredit spends one heartbeat credit. A missing state file gets
+// exactly one persisted bootstrap credit for startup before the first patrol
+// wisp is created; restarts do not recreate it after it has been consumed.
+func ConsumeHeartbeatCredit(townRoot string) error {
+	return withHeartbeatCreditsLock(townRoot, func(state *HeartbeatCreditState, exists bool) error {
+		if !exists && !state.BootstrapGranted {
+			state.BootstrapGranted = true
+			state.Credits = 1
+		}
+
+		if state.Credits <= 0 {
+			return fmt.Errorf("deacon heartbeat refused: no patrol heartbeat credits remain; run gt patrol new or complete the current patrol with gt patrol report")
+		}
+		state.Credits--
+		return nil
+	})
 }
 
 // WriteHeartbeat writes a new heartbeat to disk.

--- a/internal/deacon/heartbeat_test.go
+++ b/internal/deacon/heartbeat_test.go
@@ -299,6 +299,93 @@ func TestTouchWithAction(t *testing.T) {
 	}
 }
 
+func TestConsumeHeartbeatCreditBootstrapOnce(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "deacon-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	if err := ConsumeHeartbeatCredit(tmpDir); err != nil {
+		t.Fatalf("first bootstrap consume failed: %v", err)
+	}
+	state, exists, err := readHeartbeatCredits(tmpDir)
+	if err != nil {
+		t.Fatalf("read credits: %v", err)
+	}
+	if !exists {
+		t.Fatal("expected credit state to be persisted")
+	}
+	if !state.BootstrapGranted {
+		t.Fatal("expected bootstrap to be marked granted")
+	}
+	if state.Credits != 0 {
+		t.Fatalf("credits after bootstrap consume = %d, want 0", state.Credits)
+	}
+
+	if err := ConsumeHeartbeatCredit(tmpDir); err == nil {
+		t.Fatal("second consume without patrol credit succeeded, want failure")
+	}
+}
+
+func TestGrantHeartbeatCreditsCapsAtOnePatrol(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "deacon-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	if err := GrantHeartbeatCredits(tmpDir, "hq-wisp-one", HeartbeatCreditsPerPatrol); err != nil {
+		t.Fatalf("grant credits: %v", err)
+	}
+	if err := GrantHeartbeatCredits(tmpDir, "hq-wisp-two", HeartbeatCreditsPerPatrol); err != nil {
+		t.Fatalf("second grant credits: %v", err)
+	}
+
+	state, _, err := readHeartbeatCredits(tmpDir)
+	if err != nil {
+		t.Fatalf("read credits: %v", err)
+	}
+	if state.Credits != HeartbeatCreditsPerPatrol {
+		t.Fatalf("credits = %d, want cap %d", state.Credits, HeartbeatCreditsPerPatrol)
+	}
+
+	for i := 0; i < HeartbeatCreditsPerPatrol; i++ {
+		if err := ConsumeHeartbeatCredit(tmpDir); err != nil {
+			t.Fatalf("consume credit %d: %v", i+1, err)
+		}
+	}
+	if err := ConsumeHeartbeatCredit(tmpDir); err == nil {
+		t.Fatal("consume after granted credits were exhausted succeeded, want failure")
+	}
+}
+
+func TestGrantHeartbeatCreditsSamePatrolDoesNotTopUp(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "deacon-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	if err := GrantHeartbeatCredits(tmpDir, "hq-wisp-one", HeartbeatCreditsPerPatrol); err != nil {
+		t.Fatalf("grant credits: %v", err)
+	}
+	if err := ConsumeHeartbeatCredit(tmpDir); err != nil {
+		t.Fatalf("consume credit: %v", err)
+	}
+	if err := GrantHeartbeatCredits(tmpDir, "hq-wisp-one", HeartbeatCreditsPerPatrol); err != nil {
+		t.Fatalf("repeat grant same patrol: %v", err)
+	}
+
+	state, _, err := readHeartbeatCredits(tmpDir)
+	if err != nil {
+		t.Fatalf("read credits: %v", err)
+	}
+	if state.Credits != HeartbeatCreditsPerPatrol-1 {
+		t.Fatalf("credits = %d, want %d after repeated same-patrol grant", state.Credits, HeartbeatCreditsPerPatrol-1)
+	}
+}
+
 func TestWriteHeartbeat_CreatesDirectory(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "deacon-test-*")
 	if err != nil {

--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -110,7 +110,7 @@ func (m *Manager) Start(agentOverride string) error {
 		Recipient: "deacon",
 		Sender:    "daemon",
 		Topic:     "patrol",
-	}, "I am Deacon. Start patrol: run gt deacon heartbeat, then check gt hook. If no hook, run gt sling mol-deacon-patrol deacon, then execute the hook it creates.")
+	}, "I am Deacon. Start patrol: run gt deacon heartbeat, then check gt hook. If no hook, run gt patrol new, then execute the hook it creates.")
 	startupCmd, err := config.BuildStartupCommandFromConfig(config.AgentEnvConfig{
 		Role:        "deacon",
 		TownRoot:    m.townRoot,

--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -1239,7 +1239,7 @@ After await-signal returns (either by signal or timeout):
 3. Close current patrol and start next cycle:
 ```bash
 gt patrol report --summary "<brief summary>" \
-  --steps "heartbeat:OK,inbox-check:OK,orphan-process-cleanup:SKIP,..."
+  --steps "<all 26 step_id:OK|SKIP pairs>"
 ```
 The --steps flag is REQUIRED. List ALL 26 steps with their actual status.
 Steps you executed get OK, steps you skipped get SKIP.

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -523,7 +523,7 @@ type AddOptions struct {
 	// worktree instead of creating a fresh polecat/<name>/<bead>@<ts> branch (gh#3602).
 	// When set, the polecat's branch IS this branch — pushes go back to the same ref,
 	// updating the existing PR. Mutually exclusive with BaseBranch (resume implies its
-	// own start point). When empty, normal fresh-branch behaviour is used.
+	// own start point). When empty, normal fresh-branch behavior is used.
 	ResumeBranch string
 }
 

--- a/internal/templates/roles/deacon.md.tmpl
+++ b/internal/templates/roles/deacon.md.tmpl
@@ -37,10 +37,10 @@ you keep alive becomes part of a permanent ledger of demonstrated capability.
 
 ### Formula Compliance IS Your CV Entry
 
-Your patrol formula has 25 steps. Each step exists because it solves a real
+Your patrol formula has 26 steps. Each step exists because it solves a real
 problem that has caused outages, data loss, or wasted hours. **Skipping steps
 is visible in the ledger.** A patrol report that says "Quiet. All healthy."
-after executing 6 of 25 steps is not evidence of operational excellence — it's
+after executing 6 of 26 steps is not evidence of operational excellence — it's
 evidence of shortcutting.
 
 **The anti-pattern**: Running heartbeat → inbox → rig status → dog status →
@@ -56,7 +56,7 @@ is DISABLED) can be noted and skipped. Every other step runs.
 **Your patrol report** must include a step audit showing which steps executed:
 ```
 Steps: heartbeat OK | inbox OK | orphan-cleanup OK | test-pollution OK |
-gate-eval OK | dispatch-gated SKIP(none) | convoy-check OK | ... (22/25)
+gate-eval OK | dispatch-gated SKIP(none) | convoy-check OK | ... (22/26)
 ```
 
 This is not busywork — it's the difference between a patrol cycle that proves
@@ -237,7 +237,8 @@ Print a summary banner, then report and decide:
 
 ```bash
 # Option A: Loop (low context) → report closes current, starts next cycle
-{{ cmd }} patrol report --summary "Checked inbox, scanned health, no issues"
+{{ cmd }} patrol report --summary "Checked inbox, scanned health, no issues" \
+  --steps "<all 26 step_id:OK|SKIP pairs>"
 
 # Option B: Exit (high context) → just exit, daemon will respawn
 ```
@@ -347,21 +348,17 @@ no escalation, no action.
 | File | Purpose |
 |------|---------|
 | `{{ .TownRoot }}/deacon/heartbeat.json` | Freshness signal for daemon |
-| `{{ .TownRoot }}/deacon/state.json` | Patrol tracking and scan results |
+| `{{ .TownRoot }}/deacon/heartbeat_credits.json` | Patrol lifecycle credits for heartbeat updates |
+| `{{ .TownRoot }}/deacon/state.json` | Scan results and extraordinary-action notes |
 
-**state.json format:**
-```json
-{
-  "patrol_count": 0,
-  "last_patrol": "2025-12-23T13:30:00Z",
-  "extraordinary_action": false
-}
-```
+Heartbeat updates are gated by patrol lifecycle progress. `gt patrol new` and
+successful `gt patrol report` calls refresh the bounded heartbeat budget for one
+patrol cycle. Do not use free-form counters as proof of patrol completion.
 
 ## Context Management
 
-**Heuristic**: Hand off after **20 patrol loops** without major incident, OR
-**immediately** after any extraordinary action.
+**Heuristic**: Hand off when context is high, OR **immediately** after any
+extraordinary action.
 
 **Extraordinary actions** (trigger immediate handoff):
 - Processing a LIFECYCLE request
@@ -370,10 +367,9 @@ no escalation, no action.
 - Any action that consumes significant context
 
 **At loop-or-exit step:**
-1. Read `state.json` for `patrol_count` and `extraordinary_action`
-2. If `extraordinary_action == true` → hand off immediately
-3. If `patrol_count >= 20` → hand off
-4. Otherwise → increment `patrol_count`, save state, run `{{ cmd }} patrol report`
+1. Check context and whether any extraordinary action occurred this cycle.
+2. If context is high or an extraordinary action needs handoff → hand off immediately.
+3. Otherwise, run `{{ cmd }} patrol report` with a complete `--steps` audit for all 26 formula steps.
 
 **Handoff command:** `{{ cmd }} handoff -s "Routine cycle" -m "Completed N patrols, no incidents"`
 


### PR DESCRIPTION
## Summary

- Adds a persisted `deacon/heartbeat_credits.json` gate so `gt deacon heartbeat` can only update liveness while bounded patrol lifecycle credits remain.
- Grants credits from `gt patrol new`, active patrol discovery, and successful `gt patrol report`, tied to a specific patrol wisp ID so repeated calls do not top up the same patrol.
- Requires Deacon patrol reports to provide a complete, strictly validated 26-step `--steps` audit, and removes stale `patrol_count` / 25-step startup guidance.

## Reproduction Evidence

On current `main`, #2386 remains reproducible by code inspection:

- `gt patrol report` accepts missing or partial `--steps` and records `Steps: NOT REPORTED` or partial audits instead of failing.
- `gt deacon heartbeat` updates heartbeat/cycle state directly without patrol progress validation.
- Deacon startup/template guidance still includes stale `patrol_count` loop instructions and 25-step references while `mol-deacon-patrol` has 26 steps.

That matches the reported background-task bypass: a Deacon can run lightweight heartbeat/counter loops without completing patrol lifecycle work.

## Fix Rationale

This is a transport invariant, not agent cognition: Go does not decide whether Deacon's observations are good. It only ensures heartbeat side effects and patrol reports are bounded by concrete patrol lifecycle artifacts and complete step-audit coverage.

The first startup heartbeat still receives exactly one persisted bootstrap credit. After that, credits are refreshed only by patrol lifecycle progression and capped at the formula's three heartbeat calls.

## Tests

- `go test ./internal/cmd -run 'Test(ParseStepResults|BuildStepAudit|ValidateStepAudit|DeaconHeartbeatCreditsMatchFormula|DeaconTemplatePatrolIntegrityGuidance)$'`
- `go test ./internal/deacon`
- `go test ./internal/formula -run 'DeaconPatrol|Patrol'`

Note: a broader `go test ./internal/cmd -run 'Heartbeat|Patrol|StepAudit|DeaconTemplate'` hit an unrelated environment requirement in `TestFindActivePatrolHooked` because rootless Docker/testcontainers is unavailable here.

## Duplicate Checks

No relevant open or closed PRs found for:

- `2386`
- `gt patrol report --steps`
- `patrol_count deacon`
- `deacon heartbeat patrol`
- `heartbeat credit`
- `patrol progress`
- `synthetic cycles`
- `run_in_background`

Refs #2386