### PR TITLE
fix(deacon): block patrol cycle batching

### DIFF
--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -284,6 +284,27 @@ func DefaultOverrides() map[string]*HooksConfig {
 		"deacon": {
 			PreToolUse: []HookEntry{
 				{
+					Matcher: "Bash(*for *seq*)",
+					Hooks: []Hook{{
+						Type:    "command",
+						Command: "echo '❌ BLOCKED: Deacon must not batch patrol cycles with for/seq loops.' && echo 'Run one patrol cycle, then use gt patrol report or gt handoff.' && exit 2",
+					}},
+				},
+				{
+					Matcher: "Bash(*while true*)",
+					Hooks: []Hook{{
+						Type:    "command",
+						Command: "echo '❌ BLOCKED: Deacon must not run open-ended patrol loops.' && echo 'Run one patrol cycle, then use gt patrol report or gt handoff.' && exit 2",
+					}},
+				},
+				{
+					Matcher: "Bash(*while :*)",
+					Hooks: []Hook{{
+						Type:    "command",
+						Command: "echo '❌ BLOCKED: Deacon must not run open-ended patrol loops.' && echo 'Run one patrol cycle, then use gt patrol report or gt handoff.' && exit 2",
+					}},
+				},
+				{
 					Matcher: "Bash(*bd mol pour*patrol*)",
 					Hooks: []Hook{{
 						Type:    "command",

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -608,18 +608,21 @@ func TestComputeExpectedNoBase(t *testing.T) {
 		}
 	}
 
-	// Deacon should get DefaultBase + built-in patrol-formula-guard (same as witness)
+	// Deacon should get DefaultBase + built-in patrol-formula-guard plus anti-batch guards.
 	deacon, err := ComputeExpected("deacon")
 	if err != nil {
 		t.Fatalf("ComputeExpected(deacon) failed: %v", err)
 	}
-	if len(deacon.PreToolUse) < 4 {
-		t.Errorf("expected deacon to have at least 4 PreToolUse hooks from DefaultOverrides (patrol-formula-guard), got %d", len(deacon.PreToolUse))
+	if len(deacon.PreToolUse) < 7 {
+		t.Errorf("expected deacon to have at least 7 PreToolUse hooks from DefaultOverrides (anti-batch + patrol-formula-guard), got %d", len(deacon.PreToolUse))
 	}
 	if len(deacon.SessionStart) != len(defaultBase.SessionStart) {
 		t.Error("expected deacon to inherit SessionStart from DefaultBase")
 	}
 	deaconPatrolMatchers := map[string]bool{
+		"Bash(*for *seq*)":                  false,
+		"Bash(*while true*)":                false,
+		"Bash(*while :*)":                   false,
 		"Bash(*bd mol pour*patrol*)":        false,
 		"Bash(*bd mol pour *mol-witness*)":  false,
 		"Bash(*bd mol pour *mol-deacon*)":   false,

--- a/internal/templates/roles/deacon.md.tmpl
+++ b/internal/templates/roles/deacon.md.tmpl
@@ -87,9 +87,10 @@ every health check passing. The ledger is about to become public.
 
 ## Your Role: DEACON (Patrol Executor)
 
-You are the **Deacon** — the patrol executor for Gas Town. You execute the
-`mol-deacon-patrol` molecule as wisps in a loop, monitoring agents and
-handling lifecycle events.
+You are the **Deacon** — the patrol executor for Gas Town. You execute exactly
+one `mol-deacon-patrol` wisp at a time, monitoring agents and handling lifecycle
+events. The daemon and `gt patrol report` handle scheduling the next cycle; do
+not batch patrol cycles inside shell loops.
 
 ## Working Directory
 
@@ -112,8 +113,8 @@ Go Daemon (watches you, auto-starts you if down)
   Mayor    Witnesses --> Polecats
 ```
 
-**Key insight**: You are an AI agent executing a wisp-based patrol loop. Each
-patrol cycle is a single root wisp; formula steps are shown inline at prime time.
+**Key insight**: Each patrol cycle is a single root wisp; formula steps are shown
+inline at prime time. Finish one cycle, then report or hand off.
 
 ## Prefix-Based Routing
 


### PR DESCRIPTION
## Summary
- Fixes #2634 by adding Deacon-only `PreToolUse` guards that block `for ... seq` and open-ended `while` Bash patrol batching.
- Tightens the Deacon role template to describe one patrol wisp at a time, with scheduling delegated to `gt patrol report`/daemon instead of prompting an LLM-managed loop.
- Adds regression coverage that the Deacon hook config includes the anti-batch guards.

## Triage
- Duplicate issue check found only #2634 for this exact Sonnet anti-loop batching report.
- PR check found related patrol-loop fixes (#1470, #2812, and other deacon health PRs), but none add a structural guard against `for i in $(seq ...)` patrol batching.
- Current `main` remains susceptible from code inspection: Deacon prompt/template still described a patrol loop and only existing Deacon hooks block persistent patrol molecules.

## Testing
- `go test ./internal/hooks ./internal/formula`
- `go build ./cmd/gt`