### PR TITLE
fix: identify convoys by label

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -702,14 +702,12 @@ func runConvoyCreate(cmd *cobra.Command, args []string) error {
 
 	createArgs := []string{
 		"create",
-		"--type=convoy",
+		"--type=task",
 		"--id=" + convoyID,
 		"--title=" + name,
 		"--description=" + description,
+		"--labels=" + convoyLabels(convoyOwned),
 		"--json",
-	}
-	if convoyOwned {
-		createArgs = append(createArgs, "--labels=gt:owned")
 	}
 	if beads.NeedsForceForID(convoyID) {
 		createArgs = append(createArgs, "--force")
@@ -793,10 +791,11 @@ func runConvoyAdd(cmd *cobra.Command, args []string) error {
 	}
 
 	var convoys []struct {
-		ID     string `json:"id"`
-		Title  string `json:"title"`
-		Status string `json:"status"`
-		Type   string `json:"issue_type"`
+		ID     string   `json:"id"`
+		Title  string   `json:"title"`
+		Status string   `json:"status"`
+		Type   string   `json:"issue_type"`
+		Labels []string `json:"labels"`
 	}
 	if err := json.Unmarshal(showOut, &convoys); err != nil {
 		return fmt.Errorf("parsing convoy data: %w", err)
@@ -809,7 +808,7 @@ func runConvoyAdd(cmd *cobra.Command, args []string) error {
 	convoy := convoys[0]
 
 	// Verify it's actually a convoy type
-	if convoy.Type != "convoy" {
+	if !isConvoyIssue(convoy.Type, convoy.Labels) {
 		return fmt.Errorf("'%s' is not a convoy (type: %s)", convoyID, convoy.Type)
 	}
 	if err := ensureKnownConvoyStatus(convoy.Status); err != nil {
@@ -963,11 +962,12 @@ func checkSingleConvoy(townBeads, convoyID string, dryRun bool) error {
 	}
 
 	var convoys []struct {
-		ID          string `json:"id"`
-		Title       string `json:"title"`
-		Status      string `json:"status"`
-		Type        string `json:"issue_type"`
-		Description string `json:"description"`
+		ID          string   `json:"id"`
+		Title       string   `json:"title"`
+		Status      string   `json:"status"`
+		Type        string   `json:"issue_type"`
+		Description string   `json:"description"`
+		Labels      []string `json:"labels"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &convoys); err != nil {
 		return fmt.Errorf("parsing convoy data: %w", err)
@@ -980,7 +980,7 @@ func checkSingleConvoy(townBeads, convoyID string, dryRun bool) error {
 	convoy := convoys[0]
 
 	// Verify it's actually a convoy type
-	if convoy.Type != "convoy" {
+	if !isConvoyIssue(convoy.Type, convoy.Labels) {
 		return fmt.Errorf("'%s' is not a convoy (type: %s)", convoyID, convoy.Type)
 	}
 	if err := ensureKnownConvoyStatus(convoy.Status); err != nil {
@@ -1023,11 +1023,12 @@ func runConvoyClose(cmd *cobra.Command, args []string) error {
 	}
 
 	var convoys []struct {
-		ID          string `json:"id"`
-		Title       string `json:"title"`
-		Status      string `json:"status"`
-		Type        string `json:"issue_type"`
-		Description string `json:"description"`
+		ID          string   `json:"id"`
+		Title       string   `json:"title"`
+		Status      string   `json:"status"`
+		Type        string   `json:"issue_type"`
+		Description string   `json:"description"`
+		Labels      []string `json:"labels"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &convoys); err != nil {
 		return fmt.Errorf("parsing convoy data: %w", err)
@@ -1040,7 +1041,7 @@ func runConvoyClose(cmd *cobra.Command, args []string) error {
 	convoy := convoys[0]
 
 	// Verify it's actually a convoy type
-	if convoy.Type != "convoy" {
+	if !isConvoyIssue(convoy.Type, convoy.Labels) {
 		return fmt.Errorf("'%s' is not a convoy (type: %s)", convoyID, convoy.Type)
 	}
 	if err := ensureKnownConvoyStatus(convoy.Status); err != nil {
@@ -1199,7 +1200,7 @@ func runConvoyLand(cmd *cobra.Command, args []string) error {
 	convoy := convoys[0]
 
 	// Verify it's a convoy type
-	if convoy.Type != "convoy" {
+	if !isConvoyIssue(convoy.Type, convoy.Labels) {
 		return fmt.Errorf("'%s' is not a convoy (type: %s)", convoyID, convoy.Type)
 	}
 
@@ -1492,20 +1493,9 @@ func runConvoyStranded(cmd *cobra.Command, args []string) error {
 func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
 	stranded := []strandedConvoyInfo{} // Initialize as empty slice for proper JSON encoding
 
-	// List all open convoys
-	out, err := runBdJSON(townBeads, "list", "--type=convoy", "--status=open", "--json")
+	convoys, err := listConvoyIssues(townBeads, "open", false)
 	if err != nil {
 		return nil, fmt.Errorf("listing convoys: %w", err)
-	}
-
-	var convoys []struct {
-		ID          string `json:"id"`
-		Title       string `json:"title"`
-		CreatedAt   string `json:"created_at"`
-		Description string `json:"description"`
-	}
-	if err := json.Unmarshal(out, &convoys); err != nil {
-		return nil, fmt.Errorf("parsing convoy list: %w", err)
 	}
 
 	// Check each convoy for stranded state
@@ -1662,19 +1652,9 @@ func isSlingableBead(townRoot, beadID string) bool {
 func checkAndCloseCompletedConvoys(townBeads string, dryRun bool) ([]struct{ ID, Title string }, error) {
 	var closed []struct{ ID, Title string }
 
-	// List all open convoys
-	out, err := runBdJSON(townBeads, "list", "--type=convoy", "--status=open", "--json")
+	convoys, err := listConvoyIssues(townBeads, "open", false)
 	if err != nil {
 		return nil, fmt.Errorf("listing convoys: %w", err)
-	}
-
-	var convoys []struct {
-		ID     string `json:"id"`
-		Title  string `json:"title"`
-		Status string `json:"status"`
-	}
-	if err := json.Unmarshal(out, &convoys); err != nil {
-		return nil, fmt.Errorf("parsing convoy list: %w", err)
 	}
 
 	// Check each convoy
@@ -1965,20 +1945,9 @@ func runConvoyStatus(cmd *cobra.Command, args []string) error {
 }
 
 func showAllConvoyStatus(townBeads string) error {
-	// List all convoy-type issues
-	out, err := runBdJSON(townBeads, "list", "--type=convoy", "--status=open", "--json")
+	convoys, err := listConvoyIssues(townBeads, "open", false)
 	if err != nil {
 		return fmt.Errorf("listing convoys: %w", err)
-	}
-
-	var convoys []struct {
-		ID     string   `json:"id"`
-		Title  string   `json:"title"`
-		Status string   `json:"status"`
-		Labels []string `json:"labels"`
-	}
-	if err := json.Unmarshal(out, &convoys); err != nil {
-		return fmt.Errorf("parsing convoy list: %w", err)
 	}
 
 	if len(convoys) == 0 {
@@ -2012,29 +1981,9 @@ func runConvoyList(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// List convoy-type issues.
-	listArgs := []string{"list", "--type=convoy", "--json"}
-	if convoyListStatus != "" {
-		listArgs = append(listArgs, "--status="+convoyListStatus)
-	} else if convoyListAll {
-		listArgs = append(listArgs, "--all")
-	}
-	// bd no longer requires --flat for JSON output.
-
-	out, err := runBdJSON(townBeads, listArgs...)
+	convoys, err := listConvoyIssues(townBeads, convoyListStatus, convoyListAll)
 	if err != nil {
 		return fmt.Errorf("listing convoys: %w", err)
-	}
-
-	var convoys []struct {
-		ID        string   `json:"id"`
-		Title     string   `json:"title"`
-		Status    string   `json:"status"`
-		CreatedAt string   `json:"created_at"`
-		Labels    []string `json:"labels"`
-	}
-	if err := json.Unmarshal(out, &convoys); err != nil {
-		return fmt.Errorf("parsing convoy list: %w", err)
 	}
 
 	if convoyListJSON {
@@ -2105,13 +2054,7 @@ func runConvoyList(cmd *cobra.Command, args []string) error {
 }
 
 // printConvoyTree displays convoys with their child issues in a tree format.
-func printConvoyTree(townBeads string, convoys []struct {
-	ID        string   `json:"id"`
-	Title     string   `json:"title"`
-	Status    string   `json:"status"`
-	CreatedAt string   `json:"created_at"`
-	Labels    []string `json:"labels"`
-}) error {
+func printConvoyTree(townBeads string, convoys []convoyListIssue) error {
 	for _, c := range convoys {
 		// Get tracked issues for this convoy
 		tracked, err := getTrackedIssues(townBeads, c.ID)
@@ -2176,6 +2119,88 @@ func hasLabel(labels []string, target string) bool { //nolint:unparam // target 
 		}
 	}
 	return false
+}
+
+type convoyListIssue struct {
+	ID          string   `json:"id"`
+	Title       string   `json:"title"`
+	Status      string   `json:"status"`
+	CreatedAt   string   `json:"created_at"`
+	Description string   `json:"description"`
+	IssueType   string   `json:"issue_type"`
+	Labels      []string `json:"labels"`
+}
+
+func isConvoyIssue(issueType string, labels []string) bool {
+	return issueType == "convoy" || hasLabel(labels, "gt:convoy")
+}
+
+func convoyLabels(owned bool) string {
+	if owned {
+		return "gt:convoy,gt:owned"
+	}
+	return "gt:convoy"
+}
+
+func listConvoyIssues(townBeads, status string, all bool, extraLabels ...string) ([]convoyListIssue, error) {
+	args := []string{"list", "--label=gt:convoy", "--json", "--limit=0"}
+	for _, label := range extraLabels {
+		args = append(args, "--label="+label)
+	}
+	if status != "" {
+		args = append(args, "--status="+status)
+	} else if all {
+		args = append(args, "--all")
+	}
+
+	convoys, err := readConvoyIssues(townBeads, args...)
+	if err != nil {
+		return nil, err
+	}
+	seen := make(map[string]bool, len(convoys))
+	for _, convoy := range convoys {
+		seen[convoy.ID] = true
+	}
+
+	legacyArgs := []string{"list", "--json", "--limit=0"}
+	if status != "" {
+		legacyArgs = append(legacyArgs, "--status="+status)
+	} else if all {
+		legacyArgs = append(legacyArgs, "--all")
+	}
+	legacy, err := readConvoyIssues(townBeads, legacyArgs...)
+	if err != nil {
+		return nil, err
+	}
+	for _, issue := range legacy {
+		if seen[issue.ID] || issue.IssueType != "convoy" || !hasAllLabels(issue.Labels, extraLabels) {
+			continue
+		}
+		convoys = append(convoys, issue)
+		seen[issue.ID] = true
+	}
+	return convoys, nil
+}
+
+func readConvoyIssues(townBeads string, args ...string) ([]convoyListIssue, error) {
+	out, err := runBdJSON(townBeads, args...)
+	if err != nil {
+		return nil, err
+	}
+	var issues []convoyListIssue
+	if err := json.Unmarshal(out, &issues); err != nil {
+		return nil, err
+	}
+	return issues, nil
+}
+
+func hasAllLabels(labels, required []string) bool {
+	for _, label := range required {
+		if !hasLabel(labels, label) {
+			return false
+		}
+	}
+	return true
 }
 
 // convoyMergeFromFields extracts the merge strategy from a convoy description
@@ -2762,17 +2787,9 @@ func runConvoyTUI() error {
 // resolveConvoyNumber converts a numeric shortcut (1, 2, 3...) to a convoy ID.
 // Numbers correspond to the order shown in 'gt convoy list'.
 func resolveConvoyNumber(townBeads string, n int) (string, error) {
-	// Get convoy list (same query as runConvoyList)
-	out, err := runBdJSON(townBeads, "list", "--type=convoy", "--json")
+	convoys, err := listConvoyIssues(townBeads, "", false)
 	if err != nil {
 		return "", fmt.Errorf("listing convoys: %w", err)
-	}
-
-	var convoys []struct {
-		ID string `json:"id"`
-	}
-	if err := json.Unmarshal(out, &convoys); err != nil {
-		return "", fmt.Errorf("parsing convoy list: %w", err)
 	}
 
 	if n < 1 || n > len(convoys) {

--- a/internal/cmd/convoy_bd_routing_test.go
+++ b/internal/cmd/convoy_bd_routing_test.go
@@ -102,13 +102,16 @@ if [ -n "$BEADS_DIR" ]; then
 fi
 
 case "$*" in
-  "list --type=convoy --json --all")
-    if [ "$PWD" != "%s" ]; then
-      echo "expected town root, got $PWD" >&2
-      exit 1
-    fi
-    echo '[{"id":"hq-cv-town","title":"Town convoy","status":"open","created_at":"2026-03-09T00:00:00Z"}]'
-    ;;
+	  "list --label=gt:convoy --json --limit=0 --all")
+	    if [ "$PWD" != "%s" ]; then
+	      echo "expected town root, got $PWD" >&2
+	      exit 1
+	    fi
+	    echo '[{"id":"hq-cv-town","title":"Town convoy","status":"open","created_at":"2026-03-09T00:00:00Z","labels":["gt:convoy"]}]'
+	    ;;
+	  "list --json --limit=0 --all")
+	    echo '[]'
+	    ;;
   "dep list hq-cv-town --direction=down --type=tracks --allow-stale --json")
     if [ "$PWD" != "%s" ]; then
       echo "expected town root, got $PWD" >&2

--- a/internal/cmd/convoy_launch.go
+++ b/internal/cmd/convoy_launch.go
@@ -284,7 +284,7 @@ func runConvoyLaunch(cmd *cobra.Command, args []string) error {
 	// and dispatch Wave 1.
 	if len(args) == 1 {
 		result := beadTypes[args[0]]
-		if result.IssueType == "convoy" && isStagedStatus(normalizeConvoyStatus(result.Status)) {
+		if isConvoyIssue(result.IssueType, result.Labels) && isStagedStatus(normalizeConvoyStatus(result.Status)) {
 			convoyID := args[0]
 
 			if err := transitionConvoyToOpen(convoyID, convoyLaunchForce); err != nil {

--- a/internal/cmd/convoy_stage.go
+++ b/internal/cmd/convoy_stage.go
@@ -230,7 +230,11 @@ func runConvoyStage(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return fmt.Errorf("cannot resolve bead %s: %w", arg, err)
 		}
-		beadTypes[arg] = result.IssueType
+		if isConvoyIssue(result.IssueType, result.Labels) {
+			beadTypes[arg] = "convoy"
+		} else {
+			beadTypes[arg] = result.IssueType
+		}
 		beadResults[arg] = result
 	}
 
@@ -528,18 +532,9 @@ func findOverlappingConvoys(slingableIDs []string) ([]overlappingConvoy, error) 
 		return nil, err
 	}
 
-	// List all convoys (--all includes every status).
-	out, err := runBdJSON(townBeads, "list", "--type=convoy", "--all", "--json")
+	convoys, err := listConvoyIssues(townBeads, "", true)
 	if err != nil {
 		return nil, fmt.Errorf("listing convoys: %w", err)
-	}
-
-	var convoys []struct {
-		ID     string `json:"id"`
-		Status string `json:"status"`
-	}
-	if err := json.Unmarshal(out, &convoys); err != nil {
-		return nil, fmt.Errorf("parsing convoy list: %w", err)
 	}
 
 	// Build set of slingable IDs for fast lookup.
@@ -713,10 +708,11 @@ func createStagedConvoy(dag *ConvoyDAG, waves []Wave, status string, title strin
 	// Create the convoy via bd create in town beads, then set status via bd update.
 	createArgs := []string{
 		"create",
-		"--type=convoy",
+		"--type=task",
 		"--id=" + convoyID,
 		"--title=" + title,
 		"--description=" + description,
+		"--labels=gt:convoy",
 	}
 	if beads.NeedsForceForID(convoyID) {
 		createArgs = append(createArgs, "--force")
@@ -1415,10 +1411,11 @@ func buildGatedJSON(gated []GatedTask, dag *ConvoyDAG) []GatedTaskJSON {
 
 // bdShowResult matches the JSON output of `bd show <id> --json`.
 type bdShowResult struct {
-	ID        string `json:"id"`
-	Title     string `json:"title"`
-	Status    string `json:"status"`
-	IssueType string `json:"issue_type"`
+	ID        string   `json:"id"`
+	Title     string   `json:"title"`
+	Status    string   `json:"status"`
+	IssueType string   `json:"issue_type"`
+	Labels    []string `json:"labels"`
 }
 
 // bdDepResult matches the JSON output of `bd dep list <id> --json`.

--- a/internal/cmd/convoy_stage_test.go
+++ b/internal/cmd/convoy_stage_test.go
@@ -1975,7 +1975,7 @@ func TestCreateStagedConvoy_DescriptionFormat(t *testing.T) {
 	lines := strings.Split(logContent, "\n")
 	var createLine string
 	for _, line := range lines {
-		if strings.Contains(line, "create") && strings.Contains(line, "--type=convoy") {
+		if strings.Contains(line, "create") && strings.Contains(line, "--type=task") && strings.Contains(line, "--labels=gt:convoy") {
 			createLine = line
 			break
 		}
@@ -2148,9 +2148,9 @@ func TestRestageConvoy_DetectionLogic(t *testing.T) {
 		t.Fatalf("bdShow: %v", err)
 	}
 
-	// Verify it's a convoy.
-	if result.IssueType != "convoy" {
-		t.Fatalf("expected convoy type, got %q", result.IssueType)
+	// Verify it's recognized as a convoy.
+	if !isConvoyIssue(result.IssueType, result.Labels) {
+		t.Fatalf("expected convoy bead, got type %q labels %v", result.IssueType, result.Labels)
 	}
 
 	// Verify status is "staged_ready".

--- a/internal/cmd/convoy_staged_scan_test.go
+++ b/internal/cmd/convoy_staged_scan_test.go
@@ -131,7 +131,7 @@ exit 0
 }
 
 // TestStrandedScanQueryShape verifies the exact arguments passed to bd
-// by findStrandedConvoys, ensuring the --type=convoy and --status=open
+// by findStrandedConvoys, ensuring the gt:convoy label and --status=open
 // flags are both present. This guards against flag drift in refactors.
 func TestStrandedScanQueryShape(t *testing.T) {
 	if runtime.GOOS == "windows" {
@@ -186,7 +186,7 @@ exit 0
 		t.Fatalf("bd was never called with a 'list' subcommand; log: %q", string(logData))
 	}
 
-	requiredFlags := []string{"list", "--type=convoy", "--status=open", "--json"}
+	requiredFlags := []string{"list", "--label=gt:convoy", "--status=open", "--json", "--limit=0"}
 	for _, flag := range requiredFlags {
 		if !strings.Contains(listLine, flag) {
 			t.Errorf("bd list command missing %q; got: %q", flag, listLine)

--- a/internal/cmd/convoy_test_helpers_test.go
+++ b/internal/cmd/convoy_test_helpers_test.go
@@ -298,10 +298,14 @@ func (d *testDAG) BdStubScript() string {
 	sb.WriteString("    exit 0\n")
 	sb.WriteString("    ;;\n")
 
-	// --- handle: list --type=convoy --all --json (overlapping convoy detection) ---
+	// --- handle: convoy list queries (overlapping convoy detection) ---
 	convoyListJSON := d.convoyListJSON()
-	sb.WriteString("  list\\ *--type=convoy*)\n")
+	sb.WriteString("  list\\ *--label=gt:convoy*)\n")
 	sb.WriteString(fmt.Sprintf("    echo '%s'\n", convoyListJSON))
+	sb.WriteString("    exit 0\n")
+	sb.WriteString("    ;;\n")
+	sb.WriteString("  list\\ --json\\ --limit=0|list\\ --json\\ --limit=0\\ --all|list\\ --json\\ --limit=0\\ --status=*)\n")
+	sb.WriteString("    echo '[]'\n")
 	sb.WriteString("    exit 0\n")
 	sb.WriteString("    ;;\n")
 
@@ -605,8 +609,8 @@ func (d *testDAG) trackersSQLJSONFor(beadID string) string {
 	return string(raw)
 }
 
-// convoyListJSON returns the JSON array for `bd list --type=convoy --all --json`.
-// Returns all convoy-type beads with their ID and status.
+// convoyListJSON returns the JSON array for convoy list queries.
+// Returns all convoy beads with their ID and status.
 func (d *testDAG) convoyListJSON() string {
 	type convoyEntry struct {
 		ID     string `json:"id"`

--- a/internal/cmd/convoy_watch.go
+++ b/internal/cmd/convoy_watch.go
@@ -15,9 +15,9 @@ import (
 
 // convoy watch flags
 var (
-	convoyWatchNudge  bool
-	convoyWatchAddr   string
-	convoyWatchJSON   bool
+	convoyWatchNudge bool
+	convoyWatchAddr  string
+	convoyWatchJSON  bool
 )
 
 func init() {
@@ -251,11 +251,12 @@ func getConvoyForWatch(townBeads, convoyID string) (*convoyForWatch, error) {
 	}
 
 	var convoys []struct {
-		ID          string `json:"id"`
-		Title       string `json:"title"`
-		Status      string `json:"status"`
-		Type        string `json:"issue_type"`
-		Description string `json:"description"`
+		ID          string   `json:"id"`
+		Title       string   `json:"title"`
+		Status      string   `json:"status"`
+		Type        string   `json:"issue_type"`
+		Description string   `json:"description"`
+		Labels      []string `json:"labels"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &convoys); err != nil {
 		return nil, fmt.Errorf("parsing convoy data: %w", err)
@@ -266,7 +267,7 @@ func getConvoyForWatch(townBeads, convoyID string) (*convoyForWatch, error) {
 	}
 
 	c := convoys[0]
-	if c.Type != "convoy" {
+	if !isConvoyIssue(c.Type, c.Labels) {
 		return nil, fmt.Errorf("'%s' is not a convoy (type: %s)", convoyID, c.Type)
 	}
 

--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -483,10 +483,11 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 
 	createArgs := []string{
 		"create",
-		"--type=convoy",
+		"--type=task",
 		"--id=" + convoyID,
 		"--title=" + convoyTitle,
 		"--description=" + description,
+		"--labels=gt:convoy",
 	}
 	if beads.NeedsForceForID(convoyID) {
 		createArgs = append(createArgs, "--force")
@@ -775,10 +776,11 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 
 	createArgs := []string{
 		"create",
-		"--type=convoy", // reuse convoy type for workflow tracking
+		"--type=task",
 		"--id=" + workflowID,
 		"--title=" + workflowTitle,
 		"--description=" + description,
+		"--labels=gt:convoy,gt:workflow",
 	}
 	if beads.NeedsForceForID(workflowID) {
 		createArgs = append(createArgs, "--force")

--- a/internal/cmd/mountain.go
+++ b/internal/cmd/mountain.go
@@ -19,10 +19,10 @@ var mountainForce bool
 var mountainJSON bool
 
 var mountainCmd = &cobra.Command{
-	Use:   "mountain <epic-id>",
-	GroupID: GroupWork,
+	Use:         "mountain <epic-id>",
+	GroupID:     GroupWork,
 	Annotations: map[string]string{AnnotationPolecatSafe: "true"},
-	Short: "Activate Mountain-Eater: stage, label, and launch an epic",
+	Short:       "Activate Mountain-Eater: stage, label, and launch an epic",
 	Long: `Activate the Mountain-Eater on an epic for autonomous grinding.
 
 A mountain is a convoy with the 'mountain' label. This command:
@@ -563,14 +563,18 @@ func showMountainDetail(townBeads, inputID string) error {
 
 // findMountainConvoys lists all open convoys with the mountain label.
 func findMountainConvoys(townBeads string) ([]mountainConvoyInfo, error) {
-	out, err := runBdJSON(townBeads, "list", "--type=convoy", "--status=open", "--label=mountain", "--json")
+	issues, err := listConvoyIssues(townBeads, "open", false, "mountain")
 	if err != nil {
 		return nil, fmt.Errorf("listing mountain convoys: %w", err)
 	}
 
-	var convoys []mountainConvoyInfo
-	if err := json.Unmarshal(out, &convoys); err != nil {
-		return nil, fmt.Errorf("parsing mountain convoy list: %w", err)
+	convoys := make([]mountainConvoyInfo, 0, len(issues))
+	for _, issue := range issues {
+		convoys = append(convoys, mountainConvoyInfo{
+			ID:     issue.ID,
+			Title:  issue.Title,
+			Labels: issue.Labels,
+		})
 	}
 
 	return convoys, nil
@@ -585,7 +589,7 @@ func resolveMountainID(townBeads, inputID string) (string, error) {
 		return "", fmt.Errorf("cannot resolve %s: %w", inputID, err)
 	}
 
-	if result.IssueType == "convoy" {
+	if isConvoyIssue(result.IssueType, result.Labels) {
 		return inputID, nil
 	}
 

--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -317,8 +317,9 @@ func TestSchedulerAutoConvoyCreation(t *testing.T) {
 		t.Fatalf("bd show convoy %s failed: %v\noutput: %s", fields.Convoy, err, out)
 	}
 	var convoys []struct {
-		ID        string `json:"id"`
-		IssueType string `json:"issue_type"`
+		ID        string   `json:"id"`
+		IssueType string   `json:"issue_type"`
+		Labels    []string `json:"labels"`
 	}
 	if err := json.Unmarshal(out, &convoys); err != nil {
 		t.Fatalf("parse convoy show: %v\nraw output: %s", err, out)
@@ -326,8 +327,8 @@ func TestSchedulerAutoConvoyCreation(t *testing.T) {
 	if len(convoys) == 0 {
 		t.Fatalf("convoy %s not found via bd show", fields.Convoy)
 	}
-	if convoys[0].IssueType != "convoy" {
-		t.Errorf("convoy issue_type = %q, want %q", convoys[0].IssueType, "convoy")
+	if convoys[0].IssueType != "task" || !hasLabel(convoys[0].Labels, "gt:convoy") {
+		t.Errorf("convoy identity = type %q labels %v, want task with gt:convoy", convoys[0].IssueType, convoys[0].Labels)
 	}
 
 	// Verify: convoy has a "tracks" dependency pointing to the rig bead.
@@ -444,7 +445,7 @@ func TestSchedulerSlingDryRun(t *testing.T) {
 	}
 
 	// Verify: no convoy created (HQ beads DB should have no convoy issues)
-	listArgs := beads.MaybePrependAllowStale([]string{"list", "--type=convoy", "--json"})
+	listArgs := beads.MaybePrependAllowStale([]string{"list", "--label=gt:convoy", "--json"})
 	cmd := exec.Command("bd", listArgs...)
 	cmd.Dir = hqPath
 	out, err := cmd.Output()

--- a/internal/cmd/sling_batch_test.go
+++ b/internal/cmd/sling_batch_test.go
@@ -179,10 +179,8 @@ exit 0
 	}
 	logContent := string(logBytes)
 
-	// The first line starting with CMD: is the create command (NUL-delimited args).
-	// Check for --labels=gt:owned anywhere in the logged content for the create call.
-	if !strings.Contains(logContent, "--labels=gt:owned") {
-		t.Errorf("create command missing --labels=gt:owned in log:\n%q", logContent)
+	if !strings.Contains(logContent, "--labels=gt:convoy,gt:owned") {
+		t.Errorf("create command missing convoy/owned labels in log:\n%q", logContent)
 	}
 }
 
@@ -959,8 +957,8 @@ exit 0
 	if err != nil {
 		t.Fatalf("read log: %v", err)
 	}
-	if !strings.Contains(string(logBytes), "--labels=gt:owned") {
-		t.Errorf("create should include --labels=gt:owned:\n%q", string(logBytes))
+	if !strings.Contains(string(logBytes), "--labels=gt:convoy,gt:owned") {
+		t.Errorf("create should include convoy/owned labels:\n%q", string(logBytes))
 	}
 }
 

--- a/internal/cmd/sling_convoy.go
+++ b/internal/cmd/sling_convoy.go
@@ -48,7 +48,7 @@ func isTrackedByConvoy(beadID string) string {
 			if err != nil {
 				continue
 			}
-			if result.IssueType == "convoy" && result.Status == "open" {
+			if isConvoyIssue(result.IssueType, result.Labels) && result.Status == "open" {
 				return trackerID
 			}
 		}
@@ -67,20 +67,8 @@ func isTrackedByConvoy(beadID string) string {
 func findConvoyByDescription(townRoot, beadID string) string {
 	townBeads := filepath.Join(townRoot, ".beads")
 
-	// Query all open convoys from HQ
-	listCmd := exec.Command("bd", "list", "--type=convoy", "--status=open", "--json")
-	listCmd.Dir = townBeads
-
-	out, err := listCmd.Output()
+	convoys, err := listConvoyIssues(townBeads, "open", false)
 	if err != nil {
-		return ""
-	}
-
-	var convoys []struct {
-		ID          string `json:"id"`
-		Description string `json:"description"`
-	}
-	if err := json.Unmarshal(out, &convoys); err != nil {
 		return ""
 	}
 
@@ -326,13 +314,11 @@ func createBatchConvoy(beadIDs []string, rigName string, owned bool, mergeStrate
 
 	createArgs := []string{
 		"create",
-		"--type=convoy",
+		"--type=task",
 		"--id=" + convoyID,
 		"--title=" + convoyTitle,
 		"--description=" + description,
-	}
-	if owned {
-		createArgs = append(createArgs, "--labels=gt:owned")
+		"--labels=" + convoyLabels(owned),
 	}
 	if beads.NeedsForceForID(convoyID) {
 		createArgs = append(createArgs, "--force")
@@ -391,13 +377,11 @@ func createAutoConvoy(beadID, beadTitle string, owned bool, mergeStrategy, baseB
 
 	createArgs := []string{
 		"create",
-		"--type=convoy",
+		"--type=task",
 		"--id=" + convoyID,
 		"--title=" + convoyTitle,
 		"--description=" + description,
-	}
-	if owned {
-		createArgs = append(createArgs, "--labels=gt:owned")
+		"--labels=" + convoyLabels(owned),
 	}
 	if beads.NeedsForceForID(convoyID) {
 		createArgs = append(createArgs, "--force")

--- a/internal/cmd/synthesis.go
+++ b/internal/cmd/synthesis.go
@@ -387,17 +387,18 @@ func getConvoyMeta(convoyID string) (*ConvoyMeta, error) {
 	}
 
 	var convoys []struct {
-		ID          string `json:"id"`
-		Title       string `json:"title"`
-		Status      string `json:"status"`
-		Description string `json:"description"`
-		Type        string `json:"issue_type"`
+		ID          string   `json:"id"`
+		Title       string   `json:"title"`
+		Status      string   `json:"status"`
+		Description string   `json:"description"`
+		Type        string   `json:"issue_type"`
+		Labels      []string `json:"labels"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &convoys); err != nil {
 		return nil, fmt.Errorf("parsing convoy data: %w", err)
 	}
 
-	if len(convoys) == 0 || convoys[0].Type != "convoy" {
+	if len(convoys) == 0 || !isConvoyIssue(convoys[0].Type, convoys[0].Labels) {
 		return nil, fmt.Errorf("'%s' is not a convoy", convoyID)
 	}
 

--- a/internal/daemon/jsonl_git_backup.go
+++ b/internal/daemon/jsonl_git_backup.go
@@ -55,6 +55,7 @@ const scrubWhereClause = ` WHERE (ephemeral IS NULL OR ephemeral != 1)` +
 	` AND issue_type NOT IN ('message', 'event', 'agent', 'convoy', 'molecule', 'role', 'merge-request', 'rig')` +
 	` AND id NOT LIKE '%-wisp-%'` +
 	` AND id NOT LIKE '%-cv-%'` +
+	` AND id NOT LIKE '%-wf-%'` +
 	` AND id NOT LIKE 'test%'` +
 	` AND id NOT LIKE 'beads\_t%'` +
 	` AND id NOT LIKE 'beads\_pt%'` +

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -251,7 +251,6 @@ type MRAnomaly struct {
 	Detail   string        `json:"detail"`
 }
 
-
 // errMergeSlotTimeout is returned by acquireMainPushSlot when retries are
 // exhausted due to slot contention. Infrastructure errors (beads down,
 // permission errors) return a different error so callers can distinguish
@@ -270,7 +269,7 @@ type Engineer struct {
 	beads                 *beads.Beads
 	git                   *git.Git
 	config                *MergeQueueConfig
-	prProvider            PRProvider   // VCS-specific PR operations (nil when MergeStrategy != "pr")
+	prProvider            PRProvider // VCS-specific PR operations (nil when MergeStrategy != "pr")
 	workDir               string
 	output                io.Writer    // Output destination for user-facing messages
 	router                *mail.Router // Mail router for sending protocol messages
@@ -350,21 +349,21 @@ func (e *Engineer) LoadConfig() error {
 	// Parse merge_queue section into our config struct
 	// We need special handling for poll_interval (string -> Duration)
 	var mqRaw struct {
-		Enabled              *bool                      `json:"enabled"`
-		OnConflict           *string                    `json:"on_conflict"`
-		RunTests             *bool                      `json:"run_tests"`
-		TestCommand          *string                    `json:"test_command"`
-		DeleteMergedBranches *bool                      `json:"delete_merged_branches"`
-		RetryFlakyTests      *int                       `json:"retry_flaky_tests"`
-		PollInterval         *string                    `json:"poll_interval"`
-		MaxConcurrent        *int                       `json:"max_concurrent"`
-		StaleClaimTimeout    *string                    `json:"stale_claim_timeout"`
-		Gates                map[string]*gateConfigRaw  `json:"gates"`
-		GatesParallel        *bool                      `json:"gates_parallel"`
-		AutoPush             *bool                      `json:"auto_push"`
-		MergeStrategy        *string                    `json:"merge_strategy"`
-		VCSProvider          *string                    `json:"vcs_provider"`
-		RequireReview        *bool                      `json:"require_review"`
+		Enabled              *bool                     `json:"enabled"`
+		OnConflict           *string                   `json:"on_conflict"`
+		RunTests             *bool                     `json:"run_tests"`
+		TestCommand          *string                   `json:"test_command"`
+		DeleteMergedBranches *bool                     `json:"delete_merged_branches"`
+		RetryFlakyTests      *int                      `json:"retry_flaky_tests"`
+		PollInterval         *string                   `json:"poll_interval"`
+		MaxConcurrent        *int                      `json:"max_concurrent"`
+		StaleClaimTimeout    *string                   `json:"stale_claim_timeout"`
+		Gates                map[string]*gateConfigRaw `json:"gates"`
+		GatesParallel        *bool                     `json:"gates_parallel"`
+		AutoPush             *bool                     `json:"auto_push"`
+		MergeStrategy        *string                   `json:"merge_strategy"`
+		VCSProvider          *string                   `json:"vcs_provider"`
+		RequireReview        *bool                     `json:"require_review"`
 	}
 
 	if err := json.Unmarshal(rawConfig.MergeQueue, &mqRaw); err != nil {
@@ -852,7 +851,6 @@ func (e *Engineer) doMergePR(ctx context.Context, branch, target string) Process
 		MergeCommit: mergeCommit,
 	}
 }
-
 
 func (e *Engineer) acquireMainPushSlot(ctx context.Context) (string, error) {
 	slotID, err := e.mergeSlotEnsureExists()
@@ -1951,13 +1949,22 @@ type convoyInfo struct {
 	Description string
 }
 
+func refineryHasLabel(labels []string, target string) bool {
+	for _, label := range labels {
+		if label == target {
+			return true
+		}
+	}
+	return false
+}
+
 // checkAndCloseCompletedConvoys finds and closes convoys where all tracked issues
 // are complete. Returns the list of convoys that were closed.
 func (e *Engineer) checkAndCloseCompletedConvoys(townRoot, townBeads string) []convoyInfo {
 	bdEnv := stripEnvKey(os.Environ(), "BEADS_DIR")
 
-	// List all open convoys
-	listArgs := beads.MaybePrependAllowStaleWithEnv(bdEnv, []string{"list", "--type=convoy", "--status=open", "--json"})
+	// List all open issues and filter locally so legacy type=convoy beads remain visible.
+	listArgs := beads.MaybePrependAllowStaleWithEnv(bdEnv, []string{"list", "--status=open", "--json", "--limit=0"})
 	listCmd := exec.Command("bd", listArgs...)
 	util.SetDetachedProcessGroup(listCmd)
 	listCmd.Dir = townBeads
@@ -1971,10 +1978,12 @@ func (e *Engineer) checkAndCloseCompletedConvoys(townRoot, townBeads string) []c
 	}
 
 	var convoys []struct {
-		ID          string `json:"id"`
-		Title       string `json:"title"`
-		Status      string `json:"status"`
-		Description string `json:"description"`
+		ID          string   `json:"id"`
+		Title       string   `json:"title"`
+		Status      string   `json:"status"`
+		Description string   `json:"description"`
+		IssueType   string   `json:"issue_type"`
+		Labels      []string `json:"labels"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &convoys); err != nil {
 		_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to parse convoy list: %v\n", err)
@@ -1984,6 +1993,9 @@ func (e *Engineer) checkAndCloseCompletedConvoys(townRoot, townBeads string) []c
 	var closed []convoyInfo
 
 	for _, convoy := range convoys {
+		if convoy.IssueType != "convoy" && !refineryHasLabel(convoy.Labels, "gt:convoy") {
+			continue
+		}
 		// Get tracked issues for this convoy via bd dep list
 		depArgs := beads.MaybePrependAllowStaleWithEnv(bdEnv, []string{"dep", "list", convoy.ID, "--direction=down", "--type=tracks", "--json"})
 		depCmd := exec.Command("bd", depArgs...)

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -490,9 +490,9 @@ func TestRunGatesForPhase_FiltersCorrectly(t *testing.T) {
 	e.workDir = t.TempDir()
 	e.output = io.Discard
 	e.config.Gates = map[string]*GateConfig{
-		"pre-lint":    {Cmd: "true", Phase: GatePhasePreMerge},
-		"pre-test":    {Cmd: "true", Phase: GatePhasePreMerge},
-		"post-build":  {Cmd: "true", Phase: GatePhasePostSquash},
+		"pre-lint":   {Cmd: "true", Phase: GatePhasePreMerge},
+		"pre-test":   {Cmd: "true", Phase: GatePhasePreMerge},
+		"post-build": {Cmd: "true", Phase: GatePhasePostSquash},
 	}
 
 	// Pre-merge phase should only run pre-lint and pre-test
@@ -783,12 +783,12 @@ case "$*" in
   "--allow-stale version")
     exit 0
     ;;
-  "--allow-stale list --type=convoy --status=open --json"|"list --type=convoy --status=open --json")
+	  "--allow-stale list --status=open --json --limit=0"|"list --status=open --json --limit=0")
     if [ -n "$BEADS_DIR" ]; then
       echo "BEADS_DIR leaked: $BEADS_DIR" >&2
       exit 1
     fi
-    echo '[{"id":"hq-cv-l9","title":"Cross-rig convoy","status":"open","description":""}]'
+	    echo '[{"id":"hq-cv-l9","title":"Cross-rig convoy","status":"open","description":"","issue_type":"convoy"}]'
     ;;
   "--allow-stale dep list hq-cv-l9 --direction=down --type=tracks --json"|"dep list hq-cv-l9 --direction=down --type=tracks --json")
     if [ -n "$BEADS_DIR" ]; then

--- a/internal/tui/convoy/model.go
+++ b/internal/tui/convoy/model.go
@@ -91,8 +91,8 @@ func loadConvoys(townBeads string) ([]ConvoyItem, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), constants.BdSubprocessTimeout)
 	defer cancel()
 
-	// Get list of open convoys
-	listArgs := []string{"list", "--type=convoy", "--json"}
+	// Get list of open issues and filter locally so legacy type=convoy beads remain visible.
+	listArgs := []string{"list", "--json", "--limit=0"}
 	listCmd := exec.CommandContext(ctx, "bd", listArgs...)
 	util.SetDetachedProcessGroup(listCmd)
 	listCmd.Dir = townBeads
@@ -104,9 +104,11 @@ func loadConvoys(townBeads string) ([]ConvoyItem, error) {
 	}
 
 	var rawConvoys []struct {
-		ID     string `json:"id"`
-		Title  string `json:"title"`
-		Status string `json:"status"`
+		ID        string   `json:"id"`
+		Title     string   `json:"title"`
+		Status    string   `json:"status"`
+		IssueType string   `json:"issue_type"`
+		Labels    []string `json:"labels"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &rawConvoys); err != nil {
 		return nil, fmt.Errorf("parsing convoy list: %w", err)
@@ -114,6 +116,9 @@ func loadConvoys(townBeads string) ([]ConvoyItem, error) {
 
 	convoys := make([]ConvoyItem, 0, len(rawConvoys))
 	for _, rc := range rawConvoys {
+		if rc.IssueType != "convoy" && !tuiConvoyHasLabel(rc.Labels, "gt:convoy") {
+			continue
+		}
 		issues, completed, total := loadTrackedIssues(townBeads, rc.ID)
 		convoys = append(convoys, ConvoyItem{
 			ID:       rc.ID,
@@ -128,6 +133,14 @@ func loadConvoys(townBeads string) ([]ConvoyItem, error) {
 	return convoys, nil
 }
 
+func tuiConvoyHasLabel(labels []string, target string) bool {
+	for _, label := range labels {
+		if label == target {
+			return true
+		}
+	}
+	return false
+}
 
 // loadTrackedIssues loads issues tracked by a convoy.
 func loadTrackedIssues(townBeads, convoyID string) ([]IssueItem, int, int) {

--- a/internal/tui/feed/convoy.go
+++ b/internal/tui/feed/convoy.go
@@ -103,7 +103,7 @@ func FetchConvoys(townRoot string) (*ConvoyState, error) {
 
 // listConvoys returns convoys with the given status
 func listConvoys(beadsDir, status string) ([]convoyListItem, error) {
-	listArgs := []string{"list", "--type=convoy", "--status=" + status, "--json"}
+	listArgs := []string{"list", "--status=" + status, "--json", "--limit=0"}
 
 	ctx, cancel := context.WithTimeout(context.Background(), constants.BdSubprocessTimeout)
 	defer cancel()
@@ -118,20 +118,37 @@ func listConvoys(beadsDir, status string) ([]convoyListItem, error) {
 		return nil, err
 	}
 
-	var items []convoyListItem
-	if err := json.Unmarshal(stdout.Bytes(), &items); err != nil {
+	var rawItems []convoyListItem
+	if err := json.Unmarshal(stdout.Bytes(), &rawItems); err != nil {
 		return nil, err
 	}
 
+	items := make([]convoyListItem, 0, len(rawItems))
+	for _, item := range rawItems {
+		if item.IssueType == "convoy" || feedConvoyHasLabel(item.Labels, "gt:convoy") {
+			items = append(items, item)
+		}
+	}
 	return items, nil
 }
 
 type convoyListItem struct {
-	ID        string `json:"id"`
-	Title     string `json:"title"`
-	Status    string `json:"status"`
-	CreatedAt string `json:"created_at"`
-	ClosedAt  string `json:"closed_at,omitempty"`
+	ID        string   `json:"id"`
+	Title     string   `json:"title"`
+	Status    string   `json:"status"`
+	CreatedAt string   `json:"created_at"`
+	ClosedAt  string   `json:"closed_at,omitempty"`
+	IssueType string   `json:"issue_type"`
+	Labels    []string `json:"labels"`
+}
+
+func feedConvoyHasLabel(labels []string, target string) bool {
+	for _, label := range labels {
+		if label == target {
+			return true
+		}
+	}
+	return false
 }
 
 // enrichConvoy adds tracked issue counts to a convoy
@@ -334,7 +351,7 @@ var (
 			Foreground(colorDim)
 
 	MQStatusMerging = lipgloss.NewStyle().
-				Foreground(colorPrimary)
+			Foreground(colorPrimary)
 
 	MQStatusMerged = lipgloss.NewStyle().
 			Foreground(colorSuccess).

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -749,7 +749,7 @@ func (h *APIHandler) handleOptions(w http.ResponseWriter, r *http.Request) {
 	// Fetch convoys
 	go func() {
 		defer wg.Done()
-		if output, err := h.runBdCommand(r.Context(), 3*time.Second, []string{"list", "--type=convoy", "--json"}); err == nil {
+		if output, err := h.runBdCommand(r.Context(), 3*time.Second, []string{"list", "--json", "--limit=0"}); err == nil {
 			mu.Lock()
 			resp.Convoys = parseConvoyListJSON(output)
 			mu.Unlock()
@@ -844,10 +844,12 @@ func parseRigListOutput(output string) []string {
 	return rigs
 }
 
-// parseConvoyListJSON extracts convoy IDs from JSON output of "bd list --type=convoy --json".
+// parseConvoyListJSON extracts convoy IDs from JSON output of "bd list --json".
 func parseConvoyListJSON(jsonStr string) []string {
 	var convoys []struct {
-		ID string `json:"id"`
+		ID        string   `json:"id"`
+		IssueType string   `json:"issue_type"`
+		Labels    []string `json:"labels"`
 	}
 	if err := json.Unmarshal([]byte(jsonStr), &convoys); err != nil {
 		log.Printf("warning: parseConvoyListJSON: %v", err)
@@ -855,11 +857,20 @@ func parseConvoyListJSON(jsonStr string) []string {
 	}
 	ids := make([]string, 0, len(convoys))
 	for _, c := range convoys {
-		if c.ID != "" {
+		if c.ID != "" && (c.IssueType == "convoy" || webAPIHasLabel(c.Labels, "gt:convoy")) {
 			ids = append(ids, c.ID)
 		}
 	}
 	return ids
+}
+
+func webAPIHasLabel(labels []string, target string) bool {
+	for _, label := range labels {
+		if label == target {
+			return true
+		}
+	}
+	return false
 }
 
 // parseHooksListOutput extracts bead names from hooks list output.

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -941,7 +941,7 @@ func TestParseConvoyListJSON(t *testing.T) {
 	}{
 		{
 			name: "valid JSON with convoys",
-			json: `[{"id":"hq-cv-abc","title":"Deploy widgets"},{"id":"hq-cv-def","title":"Fix bugs"}]`,
+			json: `[{"id":"hq-cv-abc","title":"Deploy widgets","issue_type":"convoy"},{"id":"hq-cv-def","title":"Fix bugs","issue_type":"task","labels":["gt:convoy"]}]`,
 			want: []string{"hq-cv-abc", "hq-cv-def"},
 		},
 		{
@@ -961,7 +961,7 @@ func TestParseConvoyListJSON(t *testing.T) {
 		},
 		{
 			name: "skips empty IDs",
-			json: `[{"id":"hq-cv-abc"},{"id":""},{"id":"hq-cv-def"}]`,
+			json: `[{"id":"hq-cv-abc","issue_type":"convoy"},{"id":"","issue_type":"convoy"},{"id":"hq-cv-def","labels":["gt:convoy"]}]`,
 			want: []string{"hq-cv-abc", "hq-cv-def"},
 		},
 	}

--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -168,7 +168,7 @@ type LiveConvoyFetcher struct {
 	tmuxSocket string
 
 	// Circuit breaker for FetchConvoys — prevents process storms when
-	// bd list --type=convoy fails persistently (e.g., schema mismatch).
+	// bd list by convoy label fails persistently (e.g., schema mismatch).
 	convoyBreaker fetchCircuitBreaker
 }
 
@@ -225,18 +225,20 @@ func (f *LiveConvoyFetcher) FetchConvoys() ([]ConvoyRow, error) {
 		return nil, nil // Backed off — return empty result silently
 	}
 
-	// List all open convoy issues
-	stdout, err := f.runBdCmd(f.townRoot, "list", "--type=convoy", "--status=open", "--json")
+	// List all open issues and filter locally so legacy type=convoy beads remain visible.
+	stdout, err := f.runBdCmd(f.townRoot, "list", "--status=open", "--json", "--limit=0")
 	if err != nil {
 		f.convoyBreaker.recordFailure()
 		return nil, fmt.Errorf("listing convoys: %w", err)
 	}
 
 	var convoys []struct {
-		ID        string `json:"id"`
-		Title     string `json:"title"`
-		Status    string `json:"status"`
-		CreatedAt string `json:"created_at"`
+		ID        string   `json:"id"`
+		Title     string   `json:"title"`
+		Status    string   `json:"status"`
+		CreatedAt string   `json:"created_at"`
+		IssueType string   `json:"issue_type"`
+		Labels    []string `json:"labels"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &convoys); err != nil {
 		return nil, fmt.Errorf("parsing convoy list: %w", err)
@@ -245,6 +247,9 @@ func (f *LiveConvoyFetcher) FetchConvoys() ([]ConvoyRow, error) {
 	// Build convoy rows with activity data
 	rows := make([]ConvoyRow, 0, len(convoys))
 	for _, c := range convoys {
+		if c.IssueType != "convoy" && !webConvoyHasLabel(c.Labels, "gt:convoy") {
+			continue
+		}
 		row := ConvoyRow{
 			ID:     c.ID,
 			Title:  c.Title,
@@ -346,6 +351,15 @@ func (f *LiveConvoyFetcher) FetchConvoys() ([]ConvoyRow, error) {
 
 	f.convoyBreaker.recordSuccess()
 	return rows, nil
+}
+
+func webConvoyHasLabel(labels []string, target string) bool {
+	for _, label := range labels {
+		if label == target {
+			return true
+		}
+	}
+	return false
 }
 
 // trackedIssueInfo holds info about an issue being tracked by a convoy.

--- a/plugins/dolt-snapshots/main.go
+++ b/plugins/dolt-snapshots/main.go
@@ -344,7 +344,10 @@ func findConvoysNeedingSnapshots(db *sql.DB) ([]convoyRow, error) {
 			CASE WHEN EXISTS (SELECT 1 FROM hq.dolt_tags t WHERE t.tag_name LIKE CONCAT('staged/%-', i.id))
 				 THEN 1 ELSE 0 END AS has_staged_tag
 		FROM hq.issues i
-		WHERE i.issue_type = 'convoy'
+		WHERE (i.issue_type = 'convoy' OR EXISTS (
+				SELECT 1 FROM hq.labels l
+				WHERE l.issue_id = i.id AND l.label = 'gt:convoy'
+			))
 			AND (
 				i.status IN ('staged_ready', 'staged_warnings', 'launched', 'open')
 				OR (i.status = 'closed' AND i.updated_at >= NOW() - INTERVAL 24 HOUR)
@@ -536,7 +539,10 @@ func escalateStale(db *sql.DB, databases []string, dryRun bool) {
 			WHERE b.name LIKE 'convoy/%%'
 				AND EXISTS (
 					SELECT 1 FROM hq.issues i
-					WHERE i.issue_type = 'convoy'
+					WHERE (i.issue_type = 'convoy' OR EXISTS (
+							SELECT 1 FROM hq.labels l
+							WHERE l.issue_id = i.id AND l.label = 'gt:convoy'
+						))
 						AND b.name LIKE CONCAT('%%-', i.id)
 						AND i.status IN ('closed', 'landed')
 						AND i.updated_at < DATE_SUB(NOW(), INTERVAL 7 DAY)


### PR DESCRIPTION
## Summary
- Finish the custom-type migration for convoy tracking by creating convoy/workflow roots as built-in `task` beads labeled `gt:convoy`.
- Replace production `bd --type=convoy` calls with label-based or locally filtered queries so bd 1.x works without custom convoy type registration.
- Keep legacy `issue_type=convoy` beads visible in CLI, web/TUI, refinery, and snapshot paths while new beads use `task + gt:convoy`.

## Triage Notes
- The original `agent` failure in #3539 was already fixed by merged PR #3547.
- The secondary convoy report on #3539 is still reproducible on current `main`: `bd list --type=convoy --json` fails with `invalid issue type \"convoy\"` when `types.custom` is unset.
- Checked related PRs: #3935 is agent routing, #3896 touches formula sling args, and neither fixes convoy type validation.
- This does not migrate existing beads; it preserves compatibility by recognizing both legacy `issue_type=convoy` and new `gt:convoy` labels.

## Tests
- `go test ./internal/cmd -run 'TestRunConvoyList|TestStrandedScanQueryShape|TestCreateBatchConvoy|TestCreateAutoConvoy|TestConvoyStage|TestConvoyLaunch|TestMountain'`
- `go test ./internal/web ./internal/tui/convoy ./internal/tui/feed`
- `go test ./internal/refinery -run TestCheckAndCloseCompletedConvoys_StripsBeadsDir`
- `(cd plugins/dolt-snapshots && go test .)`

## Notes
- Full `go test ./internal/cmd` timed out locally.
- Full `go test ./internal/refinery` reaches Docker-backed tests and fails here because rootless Docker is unavailable.