### PR TITLE
Run setup_command during polecat worktree creation

### DIFF
--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1766,6 +1766,12 @@ func (m *Manager) ReuseIdlePolecat(name string, opts AddOptions) (*Polecat, erro
 		return nil, fmt.Errorf("branch mismatch after checkout: expected %s, got %s", branchName, actual)
 	}
 
+	if err := m.runSetupCommand(clonePath); err != nil {
+		_ = polecatGit.ResetHard(startPoint)
+		_ = polecatGit.CleanForce()
+		return nil, err
+	}
+
 	// Reset agent bead for reuse
 	agentID := m.agentBeadID(name)
 	if err := m.beads.ResetAgentBeadForReuse(agentID, "idle polecat reuse"); err != nil {

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2475,6 +2475,7 @@ func (m *Manager) runSetupCommand(worktreePath string) error {
 
 	shell, args := setupShellCommand(setupCmd)
 	cmd := exec.CommandContext(ctx, shell, args...) //nolint:gosec // setup_command is operator-controlled rig configuration.
+	util.SetProcessGroup(cmd)
 	cmd.Dir = worktreePath
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -38,6 +38,7 @@ const (
 	doltMaxRetries  = 10
 	doltBaseBackoff = 500 * time.Millisecond
 	doltBackoffMax  = 30 * time.Second
+	setupCmdTimeout = 30 * time.Minute
 
 	// doltStateRetries is a reduced retry count for SetAgentStateWithRetry.
 	// Agent state is a monitoring concern, not a correctness requirement (see
@@ -831,6 +832,10 @@ func (m *Manager) addWithOptionsLocked(name string, opts AddOptions, polecatDir 
 	if err := rig.RunSetupHooks(m.rig.Path, clonePath); err != nil {
 		style.PrintWarning("could not run setup hooks: %v", err)
 	}
+	if err := m.runSetupCommand(clonePath); err != nil {
+		cleanupOnError()
+		return nil, err
+	}
 
 	agentID := m.agentBeadID(name)
 	if err = m.createAgentBeadWithRetry(agentID, &beads.AgentFields{
@@ -1052,6 +1057,10 @@ func (m *Manager) AddWithOptions(name string, opts AddOptions) (_ *Polecat, retE
 	if err := rig.RunSetupHooks(m.rig.Path, clonePath); err != nil {
 		// Non-fatal - log warning but continue
 		style.PrintWarning("could not run setup hooks: %v", err)
+	}
+	if err := m.runSetupCommand(clonePath); err != nil {
+		cleanupOnError()
+		return nil, err
 	}
 
 	// NOTE: Slash commands (.claude/commands/) are provisioned at town level by gt install.
@@ -1579,6 +1588,12 @@ func (m *Manager) RepairWorktreeWithOptions(name string, force bool, opts AddOpt
 	}
 
 	// NOTE: Slash commands inherited from town level - no per-workspace copies needed.
+	if err := m.runSetupCommand(newClonePath); err != nil {
+		_ = repoGit.WorktreeRemove(newClonePath, true)
+		_ = os.RemoveAll(newClonePath)
+		_ = os.RemoveAll(polecatDir)
+		return nil, err
+	}
 
 	// Create or reopen agent bead for ZFC compliance
 	// HookBead is set atomically at recreation time if provided.
@@ -2419,6 +2434,76 @@ func (m *Manager) setupSharedBeads(clonePath string) error {
 	_ = cmd.Run()
 
 	return nil
+}
+
+func (m *Manager) resolveSetupCommand(worktreePath string) string {
+	if result := m.rig.GetConfigWithSource("setup_command"); result.Source != rig.SourceNone && result.Source != rig.SourceSystem {
+		if result.Source == rig.SourceBlocked {
+			return ""
+		}
+		if setup, ok := result.Value.(string); ok && strings.TrimSpace(setup) != "" {
+			return strings.TrimSpace(setup)
+		}
+	}
+
+	var repoMQ *config.MergeQueueConfig
+	if repoSettings, err := config.LoadRepoSettings(worktreePath); err == nil && repoSettings != nil {
+		repoMQ = repoSettings.MergeQueue
+	}
+
+	var localMQ *config.MergeQueueConfig
+	settingsPath := filepath.Join(m.rig.Path, "settings", "config.json")
+	if localSettings, err := config.LoadRigSettings(settingsPath); err == nil && localSettings != nil {
+		localMQ = localSettings.MergeQueue
+	}
+
+	mq := config.MergeSettingsCommand(repoMQ, localMQ)
+	if mq == nil {
+		return ""
+	}
+	return strings.TrimSpace(mq.SetupCommand)
+}
+
+func (m *Manager) runSetupCommand(worktreePath string) error {
+	setupCmd := m.resolveSetupCommand(worktreePath)
+	if setupCmd == "" {
+		return nil
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), setupCmdTimeout)
+	defer cancel()
+
+	shell, args := setupShellCommand(setupCmd)
+	cmd := exec.CommandContext(ctx, shell, args...) //nolint:gosec // setup_command is operator-controlled rig configuration.
+	cmd.Dir = worktreePath
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	cmd.Env = append(os.Environ(),
+		fmt.Sprintf("GT_WORKTREE_PATH=%s", worktreePath),
+		fmt.Sprintf("GT_RIG_PATH=%s", m.rig.Path),
+	)
+
+	fmt.Println("Running setup_command...")
+	if err := cmd.Run(); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			return fmt.Errorf("setup_command timed out after %s", setupCmdTimeout)
+		}
+		return fmt.Errorf("setup_command failed: %w", err)
+	}
+	fmt.Println("Ran setup_command")
+	return nil
+}
+
+func setupShellCommand(command string) (string, []string) {
+	if os.PathSeparator == '\\' {
+		return "cmd", []string{"/C", command}
+	}
+
+	shell := os.Getenv("SHELL")
+	if shell == "" {
+		shell = "/bin/sh"
+	}
+	return shell, []string{"-c", command}
 }
 
 // CleanupStaleBranches removes orphaned polecat branches that are no longer in use.

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -524,7 +524,7 @@ type AddOptions struct {
 	// worktree instead of creating a fresh polecat/<name>/<bead>@<ts> branch (gh#3602).
 	// When set, the polecat's branch IS this branch — pushes go back to the same ref,
 	// updating the existing PR. Mutually exclusive with BaseBranch (resume implies its
-	// own start point). When empty, normal fresh-branch behaviour is used.
+	// own start point). When empty, normal fresh-branch behavior is used.
 	ResumeBranch string
 }
 

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -1221,6 +1221,54 @@ func TestAddWithOptions_SetupCommandFailureRollsBack(t *testing.T) {
 	}
 }
 
+func TestReuseIdlePolecat_RunsSetupCommand(t *testing.T) {
+	mgr, _ := setupCanonicalBranchManagerTest(t)
+
+	polecat, err := mgr.AddWithOptions("toast", AddOptions{})
+	if err != nil {
+		t.Fatalf("AddWithOptions: %v", err)
+	}
+	writeWispSetupCommand(t, mgr, setupCommandWriteMarker("reuse-setup-marker"))
+
+	reused, err := mgr.ReuseIdlePolecat("toast", AddOptions{HookBead: "gt-next"})
+	if err != nil {
+		t.Fatalf("ReuseIdlePolecat: %v", err)
+	}
+	if reused.ClonePath != polecat.ClonePath {
+		t.Fatalf("reused clone path = %q, want %q", reused.ClonePath, polecat.ClonePath)
+	}
+
+	data, err := os.ReadFile(filepath.Join(reused.ClonePath, "reuse-setup-marker"))
+	if err != nil {
+		t.Fatalf("reuse setup command marker was not created: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "setup" {
+		t.Fatalf("reuse setup marker = %q, want setup", got)
+	}
+}
+
+func TestReuseIdlePolecat_SetupCommandFailureCleansWorktree(t *testing.T) {
+	mgr, _ := setupCanonicalBranchManagerTest(t)
+
+	if _, err := mgr.AddWithOptions("toast", AddOptions{}); err != nil {
+		t.Fatalf("AddWithOptions: %v", err)
+	}
+	writeWispSetupCommand(t, mgr, setupCommandWriteMarkerAndFail("dirty-setup-marker"))
+
+	_, err := mgr.ReuseIdlePolecat("toast", AddOptions{HookBead: "gt-next"})
+	if err == nil {
+		t.Fatal("ReuseIdlePolecat should fail when setup_command fails")
+	}
+	if !strings.Contains(err.Error(), "setup_command failed") {
+		t.Fatalf("error = %q, want setup_command failure", err.Error())
+	}
+
+	dirtyPath := filepath.Join(mgr.clonePath("toast"), "dirty-setup-marker")
+	if _, statErr := os.Stat(dirtyPath); !os.IsNotExist(statErr) {
+		t.Fatalf("dirty setup marker %s still exists after setup_command cleanup", dirtyPath)
+	}
+}
+
 func writeWispSetupCommand(t *testing.T, mgr *Manager, command string) {
 	t.Helper()
 
@@ -1247,6 +1295,13 @@ func setupCommandFail() string {
 		return "exit /b 7"
 	}
 	return "exit 7"
+}
+
+func setupCommandWriteMarkerAndFail(marker string) string {
+	if os.PathSeparator == '\\' {
+		return "echo dirty> " + marker + " & exit /b 7"
+	}
+	return "printf dirty > " + marker + "; exit 7"
 }
 
 func TestReuseIdlePolecat_UsesCanonicalOriginDefaultBranch(t *testing.T) {

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -1185,6 +1185,70 @@ func TestAddWithOptions_UsesCanonicalOriginDefaultBranch(t *testing.T) {
 	}
 }
 
+func TestAllocateAndAdd_RunsWispSetupCommand(t *testing.T) {
+	mgr, _ := setupCanonicalBranchManagerTest(t)
+	writeWispSetupCommand(t, mgr, setupCommandWriteMarker("setup-marker"))
+
+	_, polecat, err := mgr.AllocateAndAdd(AddOptions{})
+	if err != nil {
+		t.Fatalf("AllocateAndAdd: %v", err)
+	}
+
+	data, err := os.ReadFile(filepath.Join(polecat.ClonePath, "setup-marker"))
+	if err != nil {
+		t.Fatalf("setup command marker was not created: %v", err)
+	}
+	if got := strings.TrimSpace(string(data)); got != "setup" {
+		t.Fatalf("setup marker = %q, want setup", got)
+	}
+}
+
+func TestAddWithOptions_SetupCommandFailureRollsBack(t *testing.T) {
+	mgr, _ := setupCanonicalBranchManagerTest(t)
+	writeWispSetupCommand(t, mgr, setupCommandFail())
+
+	_, err := mgr.AddWithOptions("toast", AddOptions{})
+	if err == nil {
+		t.Fatal("AddWithOptions should fail when setup_command fails")
+	}
+	if !strings.Contains(err.Error(), "setup_command failed") {
+		t.Fatalf("error = %q, want setup_command failure", err.Error())
+	}
+
+	polecatDir := filepath.Join(mgr.rig.Path, "polecats", "toast")
+	if _, statErr := os.Stat(polecatDir); !os.IsNotExist(statErr) {
+		t.Fatalf("polecat dir %s still exists after setup_command rollback", polecatDir)
+	}
+}
+
+func writeWispSetupCommand(t *testing.T, mgr *Manager, command string) {
+	t.Helper()
+
+	townRoot := filepath.Dir(mgr.rig.Path)
+	wispDir := filepath.Join(townRoot, ".beads-wisp", "config")
+	if err := os.MkdirAll(wispDir, 0755); err != nil {
+		t.Fatalf("mkdir wisp config: %v", err)
+	}
+	cfg := fmt.Sprintf(`{"rig":"%s","values":{"setup_command":%q},"blocked":[]}`, mgr.rig.Name, command)
+	if err := os.WriteFile(filepath.Join(wispDir, mgr.rig.Name+".json"), []byte(cfg), 0644); err != nil {
+		t.Fatalf("write wisp config: %v", err)
+	}
+}
+
+func setupCommandWriteMarker(marker string) string {
+	if os.PathSeparator == '\\' {
+		return "echo setup> " + marker
+	}
+	return "printf setup > " + marker
+}
+
+func setupCommandFail() string {
+	if os.PathSeparator == '\\' {
+		return "exit /b 7"
+	}
+	return "exit 7"
+}
+
 func TestReuseIdlePolecat_UsesCanonicalOriginDefaultBranch(t *testing.T) {
 	mgr, mayorRig := setupCanonicalBranchManagerTest(t)
 
@@ -2052,8 +2116,8 @@ func TestReuseIdlePolecat_KillsLiveSession(t *testing.T) {
 
 	// Verify it did NOT return ErrSessionRunning (the old buggy behavior)
 	if errors.Is(reuseErr, ErrSessionRunning) {
-		t.Fatalf("ReuseIdlePolecat returned ErrSessionRunning for live session — "+
-			"this is the sling-reuse-stale-session bug: idle polecats with live "+
+		t.Fatalf("ReuseIdlePolecat returned ErrSessionRunning for live session — " +
+			"this is the sling-reuse-stale-session bug: idle polecats with live " +
 			"sessions must have their session killed, not rejected")
 	}
 


### PR DESCRIPTION
## Summary
- Runs configured setup_command deterministically after polecat worktree setup and before agent tracking/session start.
- Resolves setup_command from wisp config first, then repo/local merge-queue settings, matching formula variable sources.
- Fails and rolls back worktree creation when setup_command exits non-zero or times out.

## Verification
- PASS: go test ./internal/polecat -run 'TestAllocateAndAdd_RunsWispSetupCommand|TestAddWithOptions_SetupCommandFailureRollsBack' -v
- BLOCKED: go test ./internal/polecat fails in existing Docker-backed TestAddWithOptions_NoPrimeMDCreatedLocally because rootless Docker is unavailable in this environment.

Fixes #3001