### PR TITLE
test: cover Dolt-first wisp checks

### DIFF
--- a/internal/cmd/ready_test.go
+++ b/internal/cmd/ready_test.go
@@ -135,6 +135,35 @@ func TestFilterFormulaScaffolds_EmptyIssues(t *testing.T) {
 	}
 }
 
+func TestGetWispIDsUsesBdMolWispList(t *testing.T) {
+	beadsPath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(beadsPath, "issues.jsonl"), []byte(`{"id":"stale-jsonl-wisp"}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	bdPath := filepath.Join(binDir, "bd")
+	bdScript := `#!/bin/sh
+if [ "$1" = "mol" ] && [ "$2" = "wisp" ] && [ "$3" = "list" ] && [ "$4" = "--json" ]; then
+  printf '{"wisps":[{"id":"dolt-wisp-1"},{"id":"dolt-wisp-2"}],"count":2}\n'
+  exit 0
+fi
+exit 1
+`
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ids := getWispIDs(beadsPath)
+	if !ids["dolt-wisp-1"] || !ids["dolt-wisp-2"] {
+		t.Fatalf("expected IDs from bd mol wisp list, got %#v", ids)
+	}
+	if ids["stale-jsonl-wisp"] {
+		t.Fatalf("getWispIDs read stale issues.jsonl; got %#v", ids)
+	}
+}
+
 func TestFilterFormulaScaffolds_DotInNonScaffold(t *testing.T) {
 	// Issue ID has a dot but prefix is not a formula name
 	formulaNames := map[string]bool{constants.MolDeaconPatrol: true}

--- a/internal/doctor/misclassified_wisp_check_test.go
+++ b/internal/doctor/misclassified_wisp_check_test.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/beads"
@@ -58,6 +59,31 @@ func TestNoHeuristicClassification(t *testing.T) {
 	// shouldBeWisp level — that function no longer exists.
 	if check.misclassified != nil {
 		t.Error("fresh check should have no misclassified items")
+	}
+}
+
+func TestRunIgnoresJSONLWhenDoltUnavailable(t *testing.T) {
+	townRoot := t.TempDir()
+	beadsDir := filepath.Join(townRoot, "gastown", ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	staleJSONL := `{"id":"gt-wisp-stale","title":"Stale wisp","ephemeral":true}` + "\n"
+	if err := os.WriteFile(filepath.Join(beadsDir, "issues.jsonl"), []byte(staleJSONL), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewCheckMisclassifiedWisps()
+	result := check.Run(&CheckContext{TownRoot: townRoot})
+	if result.Status != StatusOK {
+		t.Fatalf("expected StatusOK when only stale JSONL exists, got %v: %s", result.Status, result.Message)
+	}
+	if !strings.Contains(result.Message, "Dolt unavailable") {
+		t.Fatalf("expected Dolt-unavailable skip message, got %q", result.Message)
+	}
+	if len(check.misclassified) != 0 {
+		t.Fatalf("expected no misclassified wisps from stale JSONL, got %d", len(check.misclassified))
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add regression coverage that the misclassified-wisps doctor check does not use stale issues.jsonl when Dolt is unavailable.
- Add regression coverage that gt ready gets wisp IDs from `bd mol wisp list --json` instead of issues.jsonl.

## Test plan
- `go test ./internal/doctor -run TestRunIgnoresJSONLWhenDoltUnavailable -count=1`
- `go test ./internal/cmd -run TestGetWispIDsUsesBdMolWispList -count=1`

Closes #2003