### PR TITLE
Render ready work panel

### DIFF
--- a/internal/web/templates/convoy.html
+++ b/internal/web/templates/convoy.html
@@ -894,6 +894,28 @@
                         </div>
                         {{end}}
                     </div>
+                    <div id="ready-work-list">
+                        <div class="section-header">
+                            <h4>Ready Across Rigs</h4>
+                            <span id="ready-count" class="count">0</span>
+                        </div>
+                        <div id="ready-loading" class="loading-state">Loading ready work...</div>
+                        <table id="ready-table" style="display: none;">
+                            <thead>
+                                <tr>
+                                    <th>Pri</th>
+                                    <th>ID</th>
+                                    <th>Title</th>
+                                    <th>Source</th>
+                                    <th>Actions</th>
+                                </tr>
+                            </thead>
+                            <tbody id="ready-tbody"></tbody>
+                        </table>
+                        <div id="ready-empty" class="empty-state" style="display: none;">
+                            <p>No ready work</p>
+                        </div>
+                    </div>
                     <!-- Issue Detail View (hidden by default) -->
                     <div id="issue-detail" style="display: none;">
                         <div class="detail-header">


### PR DESCRIPTION
## Summary

This wires the existing dashboard ready-work renderer into the template by adding the DOM nodes that `loadReady()` already expects:

- `#ready-loading`
- `#ready-table`
- `#ready-tbody`
- `#ready-empty`
- `#ready-count`

The `/api/ready` endpoint and frontend renderer already exist; without these elements, `loadReady()` returns early and ready work across rigs is not visible in the dashboard.

## Validation

- `mise exec go@1.25.9 -- go test ./internal/web`
- Built a local `gt` binary from this branch and opened the dashboard with `agent-browser`.
- Confirmed the new "Ready Across Rigs" section renders `/api/ready` rows, including rig-sourced rows, with existing Sling buttons.

## Notes

Draft PR for maintainer review. This is intended as a small template-only completion of existing dashboard behavior.

Internal tracking: bd-sfka8.40.9.2
Agent: codex
