### PR TITLE
Fix daemon legacy tmux socket cleanup

### DIFF
--- a/internal/cmd/down.go
+++ b/internal/cmd/down.go
@@ -796,130 +796,29 @@ func findOrphanedClaudeProcesses(townRoot string) []int {
 	return orphaned
 }
 
-// legacySocketTmux is the subset of tmux.Tmux used by the legacy socket
-// cleanup functions, extracted to allow test injection.
-type legacySocketTmux interface {
-	ListSessions() ([]string, error)
-	KillSessionWithProcesses(name string) error
-}
-
-// Test hooks — nil in production, set by tests to avoid real tmux calls.
-var (
-	legacyTmuxForTest   func(socket string) legacySocketTmux
-	legacySocketForTest func() string // overrides tmux.GetDefaultSocket()
-)
-
-func getDefaultSocket() string {
-	if legacySocketForTest != nil {
-		return legacySocketForTest()
-	}
-	return tmux.GetDefaultSocket()
-}
-
-func newLegacyTmux(socket string) legacySocketTmux {
-	if legacyTmuxForTest != nil {
-		return legacyTmuxForTest(socket)
-	}
-	return tmux.NewTmuxWithSocket(socket)
-}
-
 // cleanupLegacyDefaultSocket removes Gas Town sessions left on the "default"
 // tmux socket by old binaries. Returns the number of sessions cleaned.
 func cleanupLegacyDefaultSocket() int {
-	currentSocket := getDefaultSocket()
-	if currentSocket == "" || currentSocket == "default" {
-		return 0 // Already on the default socket, nothing to clean up
-	}
-
-	legacyTmux := newLegacyTmux("default")
-	sessions, err := legacyTmux.ListSessions()
-	if err != nil {
-		return 0 // No server on default socket
-	}
-
-	var cleaned int
-	for _, sess := range sessions {
-		if session.IsKnownSession(sess) {
-			if err := legacyTmux.KillSessionWithProcesses(sess); err == nil {
-				cleaned++
-			}
-		}
-	}
-	return cleaned
+	return session.CleanupLegacyDefaultSocket()
 }
 
 // countLegacyDefaultSocketSessions counts Gas Town sessions on the "default"
 // tmux socket (for dry-run output).
 func countLegacyDefaultSocketSessions() int {
-	currentSocket := getDefaultSocket()
-	if currentSocket == "" || currentSocket == "default" {
-		return 0
-	}
-
-	legacyTmux := newLegacyTmux("default")
-	sessions, err := legacyTmux.ListSessions()
-	if err != nil {
-		return 0
-	}
-
-	var count int
-	for _, sess := range sessions {
-		if session.IsKnownSession(sess) {
-			count++
-		}
-	}
-	return count
+	return session.CountLegacyDefaultSocketSessions()
 }
 
 // cleanupLegacyBaseSocket removes Gas Town sessions left on the old basename-only
 // tmux socket (e.g., "gt") by binaries from before path-hashed socket names were
 // introduced (e.g., "gt-a1b2c3"). Returns the number of sessions cleaned.
 func cleanupLegacyBaseSocket(townRoot string) int {
-	currentSocket := getDefaultSocket()
-	legacySocket := session.LegacySocketName(townRoot)
-	if currentSocket == legacySocket {
-		return 0 // Same socket, no migration needed
-	}
-
-	legacyTmux := newLegacyTmux(legacySocket)
-	sessions, err := legacyTmux.ListSessions()
-	if err != nil {
-		return 0 // No server on legacy socket
-	}
-
-	var cleaned int
-	for _, sess := range sessions {
-		if session.IsKnownSession(sess) {
-			if err := legacyTmux.KillSessionWithProcesses(sess); err == nil {
-				cleaned++
-			}
-		}
-	}
-	return cleaned
+	return session.CleanupLegacyBaseSocket(townRoot)
 }
 
 // countLegacyBaseSocketSessions counts Gas Town sessions on the old basename-only
 // tmux socket (for dry-run output).
 func countLegacyBaseSocketSessions(townRoot string) int {
-	currentSocket := getDefaultSocket()
-	legacySocket := session.LegacySocketName(townRoot)
-	if currentSocket == legacySocket {
-		return 0
-	}
-
-	legacyTmux := newLegacyTmux(legacySocket)
-	sessions, err := legacyTmux.ListSessions()
-	if err != nil {
-		return 0
-	}
-
-	var count int
-	for _, sess := range sessions {
-		if session.IsKnownSession(sess) {
-			count++
-		}
-	}
-	return count
+	return session.CountLegacyBaseSocketSessions(townRoot)
 }
 
 // findIdleMonitorProcesses finds bd dolt idle-monitor processes scoped to

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -129,6 +129,10 @@ type Daemon struct {
 	// Only accessed from heartbeat loop goroutine - no sync needed.
 	knownRigsCache      []string
 	knownRigsCacheValid bool
+
+	// legacySocketCleanupOnce ensures upgrade cleanup only runs once per daemon
+	// lifetime, before any patrol agent can be started on the current socket.
+	legacySocketCleanupOnce sync.Once
 }
 
 // sessionDeath records a detected session death for mass death analysis.
@@ -152,6 +156,12 @@ const (
 const beadsModulePath = "github.com/steveyegge/beads"
 
 var semverPattern = regexp.MustCompile(`v?(\d+\.\d+\.\d+)`)
+
+var cleanupLegacySocketsForDaemon = func(townRoot string) (int, int) {
+	defaultCleaned := session.CleanupLegacyDefaultSocket()
+	baseCleaned := session.CleanupLegacyBaseSocket(townRoot)
+	return defaultCleaned, baseCleaned
+}
 
 // New creates a new daemon instance.
 func New(config *Config) (*Daemon, error) {
@@ -361,7 +371,7 @@ func New(config *Config) (*Daemon, error) {
 		}
 	}
 
-	return &Daemon{
+	d := &Daemon{
 		config:          config,
 		patrolConfig:    patrolConfig,
 		disabledPatrols: disabledPatrols,
@@ -376,7 +386,20 @@ func New(config *Config) (*Daemon, error) {
 		otelProvider:    otelProvider,
 		metrics:         dm,
 		rigPool:         newRigWorkerPool(0, 0, logger), // defaults: 10 workers, 30s timeout
-	}, nil
+	}
+	return d, nil
+}
+
+func (d *Daemon) cleanupLegacySocketSessions() {
+	d.legacySocketCleanupOnce.Do(func() {
+		defaultCleaned, baseCleaned := cleanupLegacySocketsForDaemon(d.config.TownRoot)
+		if defaultCleaned > 0 {
+			d.logger.Printf("legacy_socket_cleanup: cleaned %d session(s) from default socket", defaultCleaned)
+		}
+		if baseCleaned > 0 {
+			d.logger.Printf("legacy_socket_cleanup: cleaned %d session(s) from basename socket", baseCleaned)
+		}
+	})
 }
 
 // Run starts the daemon main loop.
@@ -467,6 +490,11 @@ func (d *Daemon) Run() (err error) {
 	if err != nil {
 		return err
 	}
+
+	// Clean sessions left behind on legacy tmux sockets after daemon startup has
+	// passed fatal preflight checks but before any patrol agents can be spawned.
+	d.cleanupLegacySocketSessions()
+
 	isRigParked := func(rigName string) bool {
 		ok, _ := d.isRigOperational(rigName)
 		return !ok

--- a/internal/daemon/daemon_test.go
+++ b/internal/daemon/daemon_test.go
@@ -33,6 +33,37 @@ func TestDefaultConfig(t *testing.T) {
 	}
 }
 
+func TestCleanupLegacySocketSessionsRunsOnce(t *testing.T) {
+	oldCleanup := cleanupLegacySocketsForDaemon
+	t.Cleanup(func() { cleanupLegacySocketsForDaemon = oldCleanup })
+
+	var calls int
+	var gotRoot string
+	cleanupLegacySocketsForDaemon = func(townRoot string) (int, int) {
+		calls++
+		gotRoot = townRoot
+		return 1, 2
+	}
+
+	townRoot := t.TempDir()
+	d := &Daemon{
+		config: DefaultConfig(townRoot),
+		logger: log.New(io.Discard, "", 0),
+	}
+	d.cleanupLegacySocketSessions()
+	if calls != 1 {
+		t.Fatalf("cleanup calls after first invocation = %d, want 1", calls)
+	}
+	if gotRoot != townRoot {
+		t.Fatalf("cleanup townRoot = %q, want %q", gotRoot, townRoot)
+	}
+
+	d.cleanupLegacySocketSessions()
+	if calls != 1 {
+		t.Fatalf("cleanup calls after second invocation = %d, want 1", calls)
+	}
+}
+
 func TestStateFile(t *testing.T) {
 	townRoot := "/tmp/test-town"
 	expected := filepath.Join(townRoot, "daemon", "state.json")

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -523,7 +523,7 @@ type AddOptions struct {
 	// worktree instead of creating a fresh polecat/<name>/<bead>@<ts> branch (gh#3602).
 	// When set, the polecat's branch IS this branch — pushes go back to the same ref,
 	// updating the existing PR. Mutually exclusive with BaseBranch (resume implies its
-	// own start point). When empty, normal fresh-branch behaviour is used.
+	// own start point). When empty, normal fresh-branch behavior is used.
 	ResumeBranch string
 }
 

--- a/internal/session/legacy_socket.go
+++ b/internal/session/legacy_socket.go
@@ -1,0 +1,182 @@
+package session
+
+import (
+	"sort"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/tmux"
+)
+
+// legacySocketTmux is the subset of tmux.Tmux used by legacy socket cleanup.
+// It is extracted to allow tests to avoid real tmux calls.
+type legacySocketTmux interface {
+	ListSessions() ([]string, error)
+	KillSessionWithProcesses(name string) error
+}
+
+// Test hooks; nil in production.
+var (
+	legacyTmuxForTest   func(socket string) legacySocketTmux
+	legacySocketForTest func() string
+)
+
+func getDefaultSocket() string {
+	if legacySocketForTest != nil {
+		return legacySocketForTest()
+	}
+	return tmux.GetDefaultSocket()
+}
+
+func newLegacyTmux(socket string) legacySocketTmux {
+	if legacyTmuxForTest != nil {
+		return legacyTmuxForTest(socket)
+	}
+	return tmux.NewTmuxWithSocket(socket)
+}
+
+// CleanupLegacyDefaultSocket removes Gas Town sessions left on the "default"
+// tmux socket by old binaries. Returns the number of sessions cleaned.
+func CleanupLegacyDefaultSocket() int {
+	currentSocket := getDefaultSocket()
+	if currentSocket == "" || currentSocket == "default" {
+		return 0 // Already on the default socket, nothing to clean up.
+	}
+
+	legacyTmux := newLegacyTmux("default")
+	return cleanupLegacySessions(legacyTmux)
+}
+
+// CountLegacyDefaultSocketSessions counts Gas Town sessions on the "default"
+// tmux socket for dry-run output.
+func CountLegacyDefaultSocketSessions() int {
+	currentSocket := getDefaultSocket()
+	if currentSocket == "" || currentSocket == "default" {
+		return 0
+	}
+
+	legacyTmux := newLegacyTmux("default")
+	sessions, err := legacyTmux.ListSessions()
+	if err != nil {
+		return 0
+	}
+
+	var count int
+	for _, sess := range sessions {
+		if isLegacyCleanupSession(sess) {
+			count++
+		}
+	}
+	return count
+}
+
+// CleanupLegacyBaseSocket removes Gas Town sessions left on the old
+// basename-only tmux socket by binaries from before path-hashed socket names
+// were introduced. Returns the number of sessions cleaned.
+func CleanupLegacyBaseSocket(townRoot string) int {
+	currentSocket := getDefaultSocket()
+	legacySocket := LegacySocketName(townRoot)
+	if currentSocket == legacySocket {
+		return 0 // Same socket, no migration needed.
+	}
+
+	legacyTmux := newLegacyTmux(legacySocket)
+	return cleanupLegacySessions(legacyTmux)
+}
+
+// CountLegacyBaseSocketSessions counts Gas Town sessions on the old
+// basename-only tmux socket for dry-run output.
+func CountLegacyBaseSocketSessions(townRoot string) int {
+	currentSocket := getDefaultSocket()
+	legacySocket := LegacySocketName(townRoot)
+	if currentSocket == legacySocket {
+		return 0
+	}
+
+	legacyTmux := newLegacyTmux(legacySocket)
+	sessions, err := legacyTmux.ListSessions()
+	if err != nil {
+		return 0
+	}
+
+	var count int
+	for _, sess := range sessions {
+		if isLegacyCleanupSession(sess) {
+			count++
+		}
+	}
+	return count
+}
+
+func cleanupLegacySessions(legacyTmux legacySocketTmux) int {
+	var cleaned int
+	for range 3 {
+		sessions, err := legacyTmux.ListSessions()
+		if err != nil {
+			return cleaned // No server on legacy socket.
+		}
+		targets := legacyCleanupTargets(sessions)
+		if len(targets) == 0 {
+			return cleaned
+		}
+		for _, sess := range targets {
+			if err := legacyTmux.KillSessionWithProcesses(sess); err == nil {
+				cleaned++
+			}
+		}
+	}
+	return cleaned
+}
+
+func legacyCleanupTargets(sessions []string) []string {
+	targets := make([]string, 0, len(sessions))
+	for _, sess := range sessions {
+		if isLegacyCleanupSession(sess) {
+			targets = append(targets, sess)
+		}
+	}
+	sort.SliceStable(targets, func(i, j int) bool {
+		return legacyCleanupPriority(targets[i]) < legacyCleanupPriority(targets[j])
+	})
+	return targets
+}
+
+func legacyCleanupPriority(sess string) int {
+	switch sess {
+	case DeaconSessionName(), BootSessionName():
+		return 0
+	case MayorSessionName():
+		return 1
+	}
+	if strings.HasPrefix(sess, HQPrefix+"dog-") {
+		return 2
+	}
+	if strings.HasSuffix(sess, "-witness") || strings.HasSuffix(sess, "-refinery") {
+		return 3
+	}
+	if strings.Contains(sess, "-crew-") {
+		return 4
+	}
+	return 5
+}
+
+func isLegacyCleanupSession(sess string) bool {
+	switch sess {
+	case MayorSessionName(), DeaconSessionName(), BootSessionName():
+		return true
+	}
+	if strings.HasPrefix(sess, HQPrefix+"dog-") && strings.TrimPrefix(sess, HQPrefix+"dog-") != "" {
+		return true
+	}
+	if DefaultRegistry().HasPrefix(sess) {
+		return true
+	}
+	for _, p := range LegacyPrefixes {
+		if p == strings.TrimSuffix(HQPrefix, "-") {
+			continue
+		}
+		if strings.HasPrefix(sess, p+"-") {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/session/legacy_socket_test.go
+++ b/internal/session/legacy_socket_test.go
@@ -1,10 +1,8 @@
-package cmd
+package session
 
 import (
 	"fmt"
 	"testing"
-
-	"github.com/steveyegge/gastown/internal/session"
 )
 
 type mockLegacyTmux struct {
@@ -15,7 +13,20 @@ type mockLegacyTmux struct {
 }
 
 func (m *mockLegacyTmux) ListSessions() ([]string, error) {
-	return m.sessions, m.listErr
+	if len(m.killed) == 0 {
+		return m.sessions, m.listErr
+	}
+	killed := make(map[string]bool, len(m.killed))
+	for _, sess := range m.killed {
+		killed[sess] = true
+	}
+	remaining := make([]string, 0, len(m.sessions))
+	for _, sess := range m.sessions {
+		if !killed[sess] {
+			remaining = append(remaining, sess)
+		}
+	}
+	return remaining, m.listErr
 }
 
 func (m *mockLegacyTmux) KillSessionWithProcesses(name string) error {
@@ -26,58 +37,53 @@ func (m *mockLegacyTmux) KillSessionWithProcesses(name string) error {
 	return nil
 }
 
-// setupLegacyHooks wires test hooks and a fresh registry, returning a cleanup func.
 func setupLegacyHooks(t *testing.T, currentSocket string, mock *mockLegacyTmux) {
 	t.Helper()
 
 	origTmuxHook := legacyTmuxForTest
 	origSocketHook := legacySocketForTest
-	origRegistry := session.DefaultRegistry()
+	origRegistry := DefaultRegistry()
 	t.Cleanup(func() {
 		legacyTmuxForTest = origTmuxHook
 		legacySocketForTest = origSocketHook
-		session.SetDefaultRegistry(origRegistry)
+		SetDefaultRegistry(origRegistry)
 	})
 
 	legacySocketForTest = func() string { return currentSocket }
 	legacyTmuxForTest = func(socket string) legacySocketTmux { return mock }
 
-	r := session.NewPrefixRegistry()
+	r := NewPrefixRegistry()
 	r.Register("ga", "gastown")
-	session.SetDefaultRegistry(r)
+	SetDefaultRegistry(r)
 }
 
-// ---------------------------------------------------------------------------
-// cleanupLegacyDefaultSocket
-// ---------------------------------------------------------------------------
-
-func TestCleanupLegacyDefaultSocket_SkipsWhenOnDefaultSocket(t *testing.T) {
+func TestCleanupLegacyDefaultSocketSkipsWhenOnDefaultSocket(t *testing.T) {
 	mock := &mockLegacyTmux{}
 	setupLegacyHooks(t, "", mock)
 
-	got := cleanupLegacyDefaultSocket()
+	got := CleanupLegacyDefaultSocket()
 	if got != 0 {
 		t.Errorf("expected 0, got %d", got)
 	}
 }
 
-func TestCleanupLegacyDefaultSocket_SkipsWhenSocketIsDefault(t *testing.T) {
+func TestCleanupLegacyDefaultSocketSkipsWhenSocketIsDefault(t *testing.T) {
 	mock := &mockLegacyTmux{}
 	setupLegacyHooks(t, "default", mock)
 
-	got := cleanupLegacyDefaultSocket()
+	got := CleanupLegacyDefaultSocket()
 	if got != 0 {
 		t.Errorf("expected 0, got %d", got)
 	}
 }
 
-func TestCleanupLegacyDefaultSocket_CleansGastownSessions(t *testing.T) {
+func TestCleanupLegacyDefaultSocketCleansGastownSessions(t *testing.T) {
 	mock := &mockLegacyTmux{
 		sessions: []string{"ga-witness", "hq-mayor"},
 	}
 	setupLegacyHooks(t, "gt-abc123", mock)
 
-	got := cleanupLegacyDefaultSocket()
+	got := CleanupLegacyDefaultSocket()
 	if got != 2 {
 		t.Errorf("expected 2 cleaned, got %d", got)
 	}
@@ -92,13 +98,13 @@ func TestCleanupLegacyDefaultSocket_CleansGastownSessions(t *testing.T) {
 	}
 }
 
-func TestCleanupLegacyDefaultSocket_IgnoresNonGastownSessions(t *testing.T) {
+func TestCleanupLegacyDefaultSocketIgnoresNonGastownSessions(t *testing.T) {
 	mock := &mockLegacyTmux{
-		sessions: []string{"personal-stuff", "ga-witness"},
+		sessions: []string{"personal-stuff", "hq-notes", "ga-witness"},
 	}
 	setupLegacyHooks(t, "gt-abc123", mock)
 
-	got := cleanupLegacyDefaultSocket()
+	got := CleanupLegacyDefaultSocket()
 	if got != 1 {
 		t.Errorf("expected 1 cleaned, got %d", got)
 	}
@@ -107,66 +113,77 @@ func TestCleanupLegacyDefaultSocket_IgnoresNonGastownSessions(t *testing.T) {
 	}
 }
 
-func TestCleanupLegacyDefaultSocket_NoDefaultServer(t *testing.T) {
+func TestCleanupLegacyDefaultSocketCleansSpecificTownSessions(t *testing.T) {
+	mock := &mockLegacyTmux{
+		sessions: []string{"hq-deacon", "hq-boot", "hq-dog-alpha", "hq-overseer"},
+	}
+	setupLegacyHooks(t, "gt-abc123", mock)
+
+	got := CleanupLegacyDefaultSocket()
+	if got != 3 {
+		t.Errorf("expected 3 cleaned, got %d", got)
+	}
+	if len(mock.killed) != 3 {
+		t.Fatalf("expected 3 killed, got %d: %v", len(mock.killed), mock.killed)
+	}
+	for _, killed := range mock.killed {
+		if killed == "hq-overseer" {
+			t.Fatal("did not expect hq-overseer to be killed")
+		}
+	}
+}
+
+func TestCleanupLegacyDefaultSocketNoDefaultServer(t *testing.T) {
 	mock := &mockLegacyTmux{
 		listErr: fmt.Errorf("no server running"),
 	}
 	setupLegacyHooks(t, "gt-abc123", mock)
 
-	got := cleanupLegacyDefaultSocket()
+	got := CleanupLegacyDefaultSocket()
 	if got != 0 {
 		t.Errorf("expected 0, got %d", got)
 	}
 }
 
-// ---------------------------------------------------------------------------
-// countLegacyDefaultSocketSessions
-// ---------------------------------------------------------------------------
-
-func TestCountLegacyDefaultSocket_SkipsWhenOnDefault(t *testing.T) {
+func TestCountLegacyDefaultSocketSkipsWhenOnDefault(t *testing.T) {
 	mock := &mockLegacyTmux{}
 	setupLegacyHooks(t, "", mock)
 
-	got := countLegacyDefaultSocketSessions()
+	got := CountLegacyDefaultSocketSessions()
 	if got != 0 {
 		t.Errorf("expected 0, got %d", got)
 	}
 }
 
-func TestCountLegacyDefaultSocket_CountsGastownOnly(t *testing.T) {
+func TestCountLegacyDefaultSocketCountsGastownOnly(t *testing.T) {
 	mock := &mockLegacyTmux{
-		sessions: []string{"ga-witness", "personal"},
+		sessions: []string{"ga-witness", "personal", "hq-notes"},
 	}
 	setupLegacyHooks(t, "gt-abc123", mock)
 
-	got := countLegacyDefaultSocketSessions()
+	got := CountLegacyDefaultSocketSessions()
 	if got != 1 {
 		t.Errorf("expected 1, got %d", got)
 	}
 }
 
-// ---------------------------------------------------------------------------
-// cleanupLegacyBaseSocket
-// ---------------------------------------------------------------------------
-
-func TestCleanupLegacyBaseSocket_SkipsWhenSameSocket(t *testing.T) {
+func TestCleanupLegacyBaseSocketSkipsWhenSameSocket(t *testing.T) {
 	mock := &mockLegacyTmux{}
-	// LegacySocketName for "/some/path/gt" returns "gt"
 	setupLegacyHooks(t, "gt", mock)
 
-	got := cleanupLegacyBaseSocket("/some/path/gt")
+	got := CleanupLegacyBaseSocket("/some/path/gt")
 	if got != 0 {
 		t.Errorf("expected 0, got %d", got)
 	}
 }
 
-func TestCleanupLegacyBaseSocket_CleansOldSessions(t *testing.T) {
+func TestCleanupLegacyBaseSocketCleansOldSessions(t *testing.T) {
 	mock := &mockLegacyTmux{
 		sessions: []string{"ga-witness"},
 	}
 	setupLegacyHooks(t, "gt-abc123", mock)
 
-	got := cleanupLegacyBaseSocket("/some/path/gt")
+	got := CleanupLegacyBaseSocket("/some/path/gt")
 	if got != 1 {
 		t.Errorf("expected 1 cleaned, got %d", got)
 	}
@@ -175,27 +192,23 @@ func TestCleanupLegacyBaseSocket_CleansOldSessions(t *testing.T) {
 	}
 }
 
-// ---------------------------------------------------------------------------
-// countLegacyBaseSocketSessions
-// ---------------------------------------------------------------------------
-
-func TestCountLegacyBaseSocket_SkipsWhenSame(t *testing.T) {
+func TestCountLegacyBaseSocketSkipsWhenSame(t *testing.T) {
 	mock := &mockLegacyTmux{}
 	setupLegacyHooks(t, "gt", mock)
 
-	got := countLegacyBaseSocketSessions("/some/path/gt")
+	got := CountLegacyBaseSocketSessions("/some/path/gt")
 	if got != 0 {
 		t.Errorf("expected 0, got %d", got)
 	}
 }
 
-func TestCountLegacyBaseSocket_CountsCorrectly(t *testing.T) {
+func TestCountLegacyBaseSocketCountsCorrectly(t *testing.T) {
 	mock := &mockLegacyTmux{
 		sessions: []string{"ga-witness", "hq-deacon", "random-thing"},
 	}
 	setupLegacyHooks(t, "gt-abc123", mock)
 
-	got := countLegacyBaseSocketSessions("/some/path/gt")
+	got := CountLegacyBaseSocketSessions("/some/path/gt")
 	if got != 2 {
 		t.Errorf("expected 2, got %d", got)
 	}


### PR DESCRIPTION
## Summary
- Move legacy tmux socket cleanup into `internal/session` so daemon startup and `gt down` share the same implementation.
- Run cleanup after daemon startup has acquired the lock and passed fatal preflight, before patrol agents can be spawned on the current socket.
- Tighten cleanup targets for automatic startup cleanup and add repeat passes to catch watchdog respawns.

Fixes #3570

## Tests
- `go test ./internal/session`
- `go test ./internal/cmd -run '^$'`
- `go test -c ./internal/daemon`

## Notes
- `go test ./internal/daemon -run TestCleanupLegacySocketSessionsRunsOnce` cannot run in this environment because `internal/daemon` package `TestMain` panics before selected tests when rootless Docker/testcontainers is unavailable.