### PR TITLE
fix: route agent bead updates to town

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -417,6 +417,24 @@ func (b *Beads) forIssueID(id string) *Beads {
 	}
 }
 
+// forRoutingID returns a Beads wrapper bound to the database that owns id.
+// This uses Gas Town routing rules, including town-owned agent beads whose IDs
+// carry rig prefixes.
+func (b *Beads) forRoutingID(id string) *Beads {
+	resolved := ResolveRoutingTarget(b.getTownRoot(), id, b.getResolvedBeadsDir())
+	if resolved == "" || resolved == b.getResolvedBeadsDir() {
+		return b
+	}
+	return &Beads{
+		workDir:    filepath.Dir(resolved),
+		beadsDir:   resolved,
+		isolated:   b.isolated,
+		serverPort: b.serverPort,
+		store:      b.store,
+		townRoot:   b.townRoot,
+	}
+}
+
 // Init initializes a new beads database in the working directory.
 // This uses the same environment isolation as other commands.
 // If ServerPort is set (via NewIsolatedWithPort), passes --server-port to bd init
@@ -1503,6 +1521,10 @@ func normalizeBugTitle(title string) string {
 func (b *Beads) Update(id string, opts UpdateOptions) error {
 	if b.store != nil {
 		return b.storeUpdate(id, opts)
+	}
+
+	if target := b.forRoutingID(id); target != b {
+		return target.Update(id, opts)
 	}
 
 	args := []string{"update", id}

--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -12,7 +12,6 @@ import (
 
 	"github.com/gofrs/flock"
 
-	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/telemetry"
 )
 
@@ -721,12 +720,32 @@ func isAgentBeadByID(id string) bool {
 	if len(parts) < 2 {
 		return false
 	}
-	// Check parts[1:] to handle both full-form (role at parts[2]) and
-	// collapsed-form (role at parts[1]) agent bead IDs.
-	for _, part := range parts[1:] {
-		switch part {
-		case constants.RoleWitness, constants.RoleRefinery, constants.RoleCrew, constants.RolePolecat, constants.RoleDeacon, constants.RoleMayor:
-			return true
+
+	// Collapsed form when prefix == rig:
+	//   prefix-witness, prefix-refinery
+	//   prefix-crew-name, prefix-polecat-name
+	if isTownLevelRole(parts[1]) || isRigLevelRole(parts[1]) {
+		return len(parts) == 2
+	}
+	if isNamedRole(parts[1]) {
+		return len(parts) == 3 && parts[2] != ""
+	}
+
+	if len(parts) < 3 {
+		return false
+	}
+
+	// Full form:
+	//   prefix-rig-witness, prefix-rig-refinery
+	//   prefix-rig-crew-name, prefix-rig-polecat-name
+	// Rig names may contain hyphens, so scan for the role marker after the
+	// prefix and at least one rig segment.
+	for i := len(parts) - 1; i >= 2; i-- {
+		if isTownLevelRole(parts[i]) || isRigLevelRole(parts[i]) {
+			return i == len(parts)-1
+		}
+		if isNamedRole(parts[i]) {
+			return i < len(parts)-1 && parts[i+1] != ""
 		}
 	}
 	return false

--- a/internal/beads/beads_agent_test.go
+++ b/internal/beads/beads_agent_test.go
@@ -267,6 +267,8 @@ func TestIsAgentBeadByID(t *testing.T) {
 		{name: "full polecat with name", id: "gt-gastown-polecat-Toast", want: true},
 		{name: "full deacon", id: "sh-shippercrm-deacon", want: true},
 		{name: "full mayor", id: "ax-axon-mayor", want: true},
+		{name: "hyphenated rig witness", id: "xx-my-rig-witness", want: true},
+		{name: "hyphenated rig polecat", id: "xx-my-rig-polecat-nux", want: true},
 
 		// Collapsed-form IDs (prefix == rig): prefix-role[-name]
 		// These have only 2 parts for witness/refinery, must still be detected.
@@ -278,6 +280,9 @@ func TestIsAgentBeadByID(t *testing.T) {
 		// Non-agent IDs
 		{name: "regular issue", id: "gt-12345", want: false},
 		{name: "task bead", id: "bcc-fix-button-color", want: false},
+		{name: "issue slug mentions polecat", id: "gt-polecat-nuke-fix", want: false},
+		{name: "issue slug mentions witness", id: "ho-witness-health-check", want: false},
+		{name: "polecat role without name", id: "ho-homelab-polecat", want: false},
 		{name: "single part", id: "witness", want: false},
 		{name: "empty string", id: "", want: false},
 		{name: "patrol molecule", id: "mol-patrol-abc123", want: false},
@@ -460,5 +465,50 @@ func TestCreateAgentBead_ParsesMockCreateOutput(t *testing.T) {
 	}
 	if issue.ID != "pt-imported-polecat-shiny" {
 		t.Fatalf("issue.ID = %q", issue.ID)
+	}
+}
+
+func TestUpdate_RigPrefixedAgentBeadUsesTownRoot(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("path assertions are Unix-oriented")
+	}
+
+	townRoot, _ := filepath.EvalSymlinks(t.TempDir())
+	for _, dir := range []string{
+		filepath.Join(townRoot, "mayor"),
+		filepath.Join(townRoot, ".beads"),
+		filepath.Join(townRoot, "homelab", ".beads"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte("{\"prefix\":\"hq-\",\"path\":\".\"}\n{\"prefix\":\"ho-\",\"path\":\"homelab\"}\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	logPath := filepath.Join(townRoot, "bd.log")
+	installMockBDCreateRecorder(t, logPath)
+
+	rigDir := filepath.Join(townRoot, "homelab")
+	bd := NewWithBeadsDir(rigDir, filepath.Join(rigDir, ".beads"))
+	if err := bd.Update("ho-homelab-polecat-furiosa", UpdateOptions{
+		AddLabels: []string{"done-intent:COMPLETED:1778598000"},
+	}); err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+
+	logOutput := readMockBDLog(t, logPath)
+	if !strings.Contains(logOutput, "pwd="+townRoot) {
+		t.Fatalf("mock bd log missing town root cwd:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "beads_dir="+filepath.Join(townRoot, ".beads")) {
+		t.Fatalf("mock bd log missing town-root BEADS_DIR:\n%s", logOutput)
+	}
+	if !strings.Contains(logOutput, "update ho-homelab-polecat-furiosa --add-label=done-intent:COMPLETED:1778598000") {
+		t.Fatalf("mock bd log missing routed update call:\n%s", logOutput)
 	}
 }

--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -70,6 +70,16 @@ func ResolveRoutingTarget(townRoot, beadID, fallbackDir string) string {
 		return fallbackDir
 	}
 
+	// Agent beads are town-owned identity records even when their IDs carry a
+	// rig prefix (e.g., ho-homelab-polecat-furiosa). Work beads with the same
+	// prefix still route to the rig database below.
+	if isAgentBeadByID(beadID) {
+		if beadsDir := ResolveBeadsDir(townRoot); beadsDir != "" {
+			return beadsDir
+		}
+		return filepath.Join(townRoot, ".beads")
+	}
+
 	// Look up rig path for this prefix
 	rigPath := GetRigPathForPrefix(townRoot, prefix)
 	if rigPath == "" {

--- a/internal/beads/beads_types_test.go
+++ b/internal/beads/beads_types_test.go
@@ -247,8 +247,14 @@ func TestResolveRoutingTarget(t *testing.T) {
 		{
 			name:     "rig-level bead routes to rig",
 			townRoot: tmpDir,
-			beadID:   "gt-gastown-polecat-Toast",
+			beadID:   "gt-work-123",
 			expected: rigBeadsDir,
+		},
+		{
+			name:     "rig-prefixed agent bead routes to town",
+			townRoot: tmpDir,
+			beadID:   "gt-gastown-polecat-Toast",
+			expected: beadsDir,
 		},
 		{
 			name:     "town-level bead routes to town",


### PR DESCRIPTION
## Summary
Fix bead routing so town-owned agent beads are resolved through the town root even when their IDs carry a rig prefix, and make generic bead updates use that routing before invoking `bd update`.

## Related Issue
Fixes hq-pp4 (Gas Town beads issue)

## Changes
- Route agent bead IDs such as `ho-homelab-polecat-furiosa` to the town `.beads` database before applying prefix routes.
- Route `Beads.Update` through the resolved target so label/checkpoint updates from `gt done` use the correct database.
- Tighten agent-bead ID detection to avoid false positives from ordinary issue slugs that mention role names.
- Add regression coverage for rig-prefixed agent beads and hyphenated rig names.

## Testing
- [x] `go test ./internal/beads`
- [x] `go test ./internal/cmd -run 'Test.*Done|Test.*Polecat|TestAgentState|TestUpdateAgent|TestDND|TestNotify'`
- [x] `go test ./internal/polecat`
- [x] `git diff --check`
- [x] `make build`
- [ ] `go test ./...` (fails on existing environment/timing issues: macOS direct-build guard in the full `internal/cmd` suite and `internal/tmux` no-dialog timing over 6s)
- [ ] Manual testing performed

## Checklist
- [x] Code follows project style
- [x] Documentation updated (not applicable)
- [x] No breaking changes