### PR TITLE
Pin bd subprocesses to resolved beads database

### DIFF
--- a/internal/cmd/bd_helpers.go
+++ b/internal/cmd/bd_helpers.go
@@ -62,7 +62,9 @@ func (b *bdCmd) WithBeadsDir(dir string) *bdCmd {
 	return b
 }
 
-// Dir sets the working directory for the command.
+// Dir sets the working directory for the command. When a directory is provided,
+// bd is also pinned to that directory's resolved .beads database unless
+// WithBeadsDir supplies a more specific database.
 func (b *bdCmd) Dir(dir string) *bdCmd {
 	b.dir = dir
 	return b
@@ -70,8 +72,9 @@ func (b *bdCmd) Dir(dir string) *bdCmd {
 
 // StripBeadsDir removes any inherited BEADS_DIR from the environment.
 // Use this when the command relies on Dir() for routing and an inherited
-// BEADS_DIR would incorrectly override the working-directory-based database
-// discovery. This fixes rig-prefixed bead resolution (GH#2126).
+// BEADS_DIR would incorrectly override the resolved database. If Dir() is set,
+// buildEnv will still add an explicit BEADS_DIR for that directory; this method
+// only strips inherited values from the parent process.
 func (b *bdCmd) StripBeadsDir() *bdCmd {
 	b.env = filterEnvKey(b.env, "BEADS_DIR")
 	return b
@@ -123,6 +126,9 @@ func (b *bdCmd) buildEnv() []string {
 	if b.beadsDir != "" {
 		env = filterEnvKey(env, "BEADS_DIR")
 		env = append(env, "BEADS_DIR="+b.beadsDir)
+	} else if b.dir != "" {
+		env = filterEnvKey(env, "BEADS_DIR")
+		env = append(env, "BEADS_DIR="+beads.ResolveBeadsDir(b.dir))
 	}
 
 	return env

--- a/internal/cmd/bd_helpers_test.go
+++ b/internal/cmd/bd_helpers_test.go
@@ -33,7 +33,9 @@ func TestBdCmd_Build(t *testing.T) {
 			},
 			wantArgs: []string{"bd", "list"},
 			wantDir:  "/some/path",
-			wantEnv:  map[string]string{},
+			wantEnv: map[string]string{
+				"BEADS_DIR": "/some/path/.beads",
+			},
 		},
 		{
 			name: "with auto commit",
@@ -68,6 +70,7 @@ func TestBdCmd_Build(t *testing.T) {
 			wantEnv: map[string]string{
 				"BD_DOLT_AUTO_COMMIT": "on",
 				"GT_ROOT":             "/town/root",
+				"BEADS_DIR":           "/work/dir/.beads",
 			},
 		},
 	}
@@ -412,6 +415,35 @@ func TestBdCmd_WithBeadsDir_SetsEnv(t *testing.T) {
 	}
 }
 
+func TestBdCmd_DirPinsResolvedBeadsDir(t *testing.T) {
+	// Dir should pin bd to that directory's resolved .beads database so ambient
+	// discovery cannot select HQ or an inherited rig database.
+	baseEnv := []string{"PATH=/usr/bin", "BEADS_DIR=/town/.beads", "HOME=/home/user"}
+
+	bdc := &bdCmd{
+		args:   []string{"mol", "wisp", "mol-polecat-work"},
+		env:    baseEnv,
+		stderr: os.Stderr,
+	}
+	bdc.Dir("/town/gastown/mayor/rig")
+	cmd := bdc.Build()
+	envMap := parseEnv(cmd.Env)
+
+	if envMap["BEADS_DIR"] != "/town/gastown/mayor/rig/.beads" {
+		t.Errorf("BEADS_DIR = %q, want %q", envMap["BEADS_DIR"], "/town/gastown/mayor/rig/.beads")
+	}
+
+	count := 0
+	for _, e := range cmd.Env {
+		if strings.HasPrefix(e, "BEADS_DIR=") {
+			count++
+		}
+	}
+	if count != 1 {
+		t.Errorf("found %d BEADS_DIR entries, want 1", count)
+	}
+}
+
 func TestBdCmd_WithBeadsDir_OverridesInherited(t *testing.T) {
 	// WithBeadsDir should override an inherited BEADS_DIR from the parent
 	// process. This is the core fix for gt-ctir: without overriding,
@@ -466,8 +498,8 @@ func TestBdCmd_WithBeadsDir_Chaining(t *testing.T) {
 }
 
 func TestBdCmd_StripBeadsDir_RemovesInherited(t *testing.T) {
-	// StripBeadsDir should remove inherited BEADS_DIR from the environment
-	// so that bd discovers the database from Dir() instead (GH#2126).
+	// StripBeadsDir should remove inherited BEADS_DIR from the environment.
+	// Dir() still pins BEADS_DIR to the resolved target database.
 	bdc := &bdCmd{
 		args:   []string{"show", "myproject-abc", "--json"},
 		env:    []string{"PATH=/usr/bin", "BEADS_DIR=/town/.beads", "HOME=/home/user"},
@@ -476,10 +508,9 @@ func TestBdCmd_StripBeadsDir_RemovesInherited(t *testing.T) {
 	bdc.Dir("/town/myproject/mayor/rig").StripBeadsDir()
 	cmd := bdc.Build()
 
-	for _, e := range cmd.Env {
-		if strings.HasPrefix(e, "BEADS_DIR=") {
-			t.Errorf("StripBeadsDir should remove BEADS_DIR, found: %s", e)
-		}
+	envMap := parseEnv(cmd.Env)
+	if envMap["BEADS_DIR"] != "/town/myproject/mayor/rig/.beads" {
+		t.Errorf("BEADS_DIR = %q, want %q", envMap["BEADS_DIR"], "/town/myproject/mayor/rig/.beads")
 	}
 
 	if cmd.Dir != "/town/myproject/mayor/rig" {
@@ -488,7 +519,8 @@ func TestBdCmd_StripBeadsDir_RemovesInherited(t *testing.T) {
 }
 
 func TestBdCmd_StripBeadsDir_NoOpWhenAbsent(t *testing.T) {
-	// StripBeadsDir should be harmless when BEADS_DIR is not set.
+	// StripBeadsDir should be harmless when BEADS_DIR is not set; Dir() still
+	// pins the target database.
 	bdc := &bdCmd{
 		args:   []string{"show", "hq-abc"},
 		env:    []string{"PATH=/usr/bin", "HOME=/home/user"},
@@ -497,8 +529,9 @@ func TestBdCmd_StripBeadsDir_NoOpWhenAbsent(t *testing.T) {
 	bdc.Dir("/town").StripBeadsDir()
 	cmd := bdc.Build()
 
-	if len(cmd.Env) != 2 {
-		t.Errorf("expected 2 env entries, got %d", len(cmd.Env))
+	envMap := parseEnv(cmd.Env)
+	if envMap["BEADS_DIR"] != "/town/.beads" {
+		t.Errorf("BEADS_DIR = %q, want %q", envMap["BEADS_DIR"], "/town/.beads")
 	}
 }
 

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -150,7 +150,7 @@ func TestSlingFormulaOnBeadRoutesBDCommandsToTargetRig(t *testing.T) {
 	logPath := filepath.Join(townRoot, "bd.log")
 	bdScript := `#!/bin/sh
 set -e
-echo "$(pwd)|$*" >> "${BD_LOG}"
+echo "$(pwd)|${BEADS_DIR:-}|$*" >> "${BD_LOG}"
 cmd="$1"
 shift || true
 case "$cmd" in
@@ -182,7 +182,7 @@ exit 0
 `
 	bdScriptWindows := `@echo off
 setlocal enableextensions
-echo %CD%^|%*>>"%BD_LOG%"
+echo %CD%^|%BEADS_DIR%^|%*>>"%BD_LOG%"
 set "cmd=%1"
 set "sub=%2"
 if "%cmd%"=="show" (
@@ -261,20 +261,28 @@ exit /b 0
 	if resolved, err := filepath.EvalSymlinks(wantDir); err == nil {
 		wantDir = resolved
 	}
+	wantBeadsDir := filepath.Join(rigDir, ".beads")
+	if resolved, err := filepath.EvalSymlinks(wantBeadsDir); err == nil {
+		wantBeadsDir = resolved
+	}
 	gotCook := false
 	gotWisp := false
 	gotBond := false
 
 	for _, line := range logLines {
-		parts := strings.SplitN(line, "|", 2)
-		if len(parts) != 2 {
+		parts := strings.SplitN(line, "|", 3)
+		if len(parts) != 3 {
 			continue
 		}
 		dir := parts[0]
 		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
 			dir = resolved
 		}
-		args := parts[1]
+		beadsDir := parts[1]
+		if resolved, err := filepath.EvalSymlinks(beadsDir); err == nil {
+			beadsDir = resolved
+		}
+		args := parts[2]
 
 		switch {
 		case strings.Contains(args, "cook "):
@@ -285,10 +293,16 @@ exit /b 0
 			if dir != wantDir {
 				t.Fatalf("bd mol wisp ran in %q, want %q (args: %q)", dir, wantDir, args)
 			}
+			if beadsDir != wantBeadsDir {
+				t.Fatalf("bd mol wisp used BEADS_DIR %q, want %q (args: %q)", beadsDir, wantBeadsDir, args)
+			}
 		case strings.Contains(args, "mol bond "):
 			gotBond = true
 			if dir != wantDir {
 				t.Fatalf("bd mol bond ran in %q, want %q (args: %q)", dir, wantDir, args)
+			}
+			if beadsDir != wantBeadsDir {
+				t.Fatalf("bd mol bond used BEADS_DIR %q, want %q (args: %q)", beadsDir, wantBeadsDir, args)
 			}
 		}
 	}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -523,7 +523,7 @@ type AddOptions struct {
 	// worktree instead of creating a fresh polecat/<name>/<bead>@<ts> branch (gh#3602).
 	// When set, the polecat's branch IS this branch — pushes go back to the same ref,
 	// updating the existing PR. Mutually exclusive with BaseBranch (resume implies its
-	// own start point). When empty, normal fresh-branch behaviour is used.
+	// own start point). When empty, normal fresh-branch behavior is used.
 	ResumeBranch string
 }
 


### PR DESCRIPTION
## Summary
- Pin `BdCmd` executions that set `Dir()` to that directory's resolved `.beads` database via `BEADS_DIR`.
- Add regression coverage that sling formula `bd mol wisp` and `bd mol bond` calls run against the target rig database rather than ambient discovery.

## Testing
- `go test ./internal/cmd -run 'TestSlingFormulaOnBeadRoutesBDCommandsToTargetRig|TestBdCmd'`
- `go test ./internal/cmd -run '^$'`

Note: `go test ./internal/cmd` exceeded a 4-minute local timeout without output; leaving full gates to CI.

Fixes #3900