### PR TITLE
Add gt hook ack command

### DIFF
--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -38,6 +38,7 @@ you left off.
 
 Examples:
   gt hook                                    # Show what's on my hook
+  gt hook ack                                # Acknowledge current hooked work
   gt hook status                             # Same as above
   gt hook gt-abc                             # Attach issue gt-abc to your hook
   gt hook gt-abc -s "Fix the bug"            # With subject for handoff mail
@@ -91,6 +92,22 @@ Output format (one line):
   gastown/polecats/nux: gt-abc123 'Fix the widget bug' [in_progress]`,
 	Args: cobra.MaximumNArgs(1),
 	RunE: runHookShow,
+}
+
+// hookAckCmd records that the current agent has read and started its hooked work.
+var hookAckCmd = &cobra.Command{
+	Use:   "ack",
+	Short: "Acknowledge current hooked work",
+	Long: `Acknowledge that the current agent has read its hook and is starting work.
+
+The acknowledgment is appended to the hooked bead's notes with a UTC timestamp
+and also emitted as a hook_ack activity event. This gives witnesses a signal
+that work was actually picked up by the agent, distinct from session startup.
+
+Examples:
+  gt hook ack`,
+	Args: cobra.NoArgs,
+	RunE: runHookAck,
 }
 
 // hookAttachCmd attaches a bead to a hook (alias for 'gt hook <bead-id>')
@@ -181,6 +198,7 @@ func init() {
 
 	hookCmd.AddCommand(hookStatusCmd)
 	hookCmd.AddCommand(hookShowCmd)
+	hookCmd.AddCommand(hookAckCmd)
 	hookCmd.AddCommand(hookAttachCmd)
 	hookCmd.AddCommand(hookDetachCmd)
 	hookCmd.AddCommand(hookClearCmd)
@@ -205,6 +223,126 @@ func runHookOrStatus(cmd *cobra.Command, args []string) error {
 // runHookClear handles 'gt hook clear' - delegates to runUnsling
 func runHookClear(cmd *cobra.Command, args []string) error {
 	return runUnslingWith(cmd, args, hookDryRun, hookForce)
+}
+
+func runHookAck(_ *cobra.Command, _ []string) error {
+	agentID, err := currentAgentIDForHookAck()
+	if err != nil {
+		return err
+	}
+
+	hooked, err := currentHookedIssueForAgent(agentID)
+	if err != nil {
+		return err
+	}
+	if hooked == nil {
+		return fmt.Errorf("no hooked work found for %s", agentID)
+	}
+
+	attachment := beads.ParseAttachmentFields(hooked)
+	sessionID := runtime.SessionIDFromEnv()
+	ackTime := time.Now().UTC()
+	note := formatHookAckNote(ackTime, agentID, hooked.ID, sessionID, attachment)
+
+	if err := BdCmd("update", hooked.ID, "--append-notes="+note).
+		Dir(resolveBeadDir(hooked.ID)).
+		StripBeadsDir().
+		WithAutoCommit().
+		Run(); err != nil {
+		return fmt.Errorf("recording hook ack on %s: %w", hooked.ID, err)
+	}
+
+	moleculeID := ""
+	formula := ""
+	if attachment != nil {
+		moleculeID = attachment.AttachedMolecule
+		formula = attachment.AttachedFormula
+	}
+	if err := events.LogFeed(events.TypeHookAck, agentID, events.HookAckPayload(hooked.ID, moleculeID, formula, sessionID)); err != nil {
+		fmt.Fprintf(os.Stderr, "%s Warning: failed to log hook ack event: %v\n", style.Dim.Render("⚠"), err)
+	}
+
+	fmt.Printf("%s Acknowledged hook %s at %s\n", style.Bold.Render("✓"), hooked.ID, ackTime.Format(time.RFC3339))
+	return nil
+}
+
+func currentAgentIDForHookAck() (string, error) {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("getting current directory: %w", err)
+	}
+	townRoot, err := workspace.FindFromCwd()
+	if err != nil {
+		return "", fmt.Errorf("finding workspace: %w", err)
+	}
+	roleCtx := detectRole(cwd, townRoot)
+	if roleCtx.Role == RoleUnknown {
+		roleCtx, _ = GetRoleWithContext(cwd, townRoot)
+	}
+	agentID := buildAgentIdentity(roleCtx)
+	if agentID == "" {
+		return "", fmt.Errorf("cannot determine agent identity (role: %s)", roleCtx.Role)
+	}
+	return agentID, nil
+}
+
+func currentHookedIssueForAgent(agentID string) (*beads.Issue, error) {
+	workDir, err := findLocalBeadsDir()
+	if err != nil {
+		return nil, fmt.Errorf("not in a beads workspace: %w", err)
+	}
+
+	if issue, err := findAssignedIssueInDir(workDir, agentID); err != nil {
+		return nil, err
+	} else if issue != nil {
+		return issue, nil
+	}
+
+	// Mayor-slung hq-* work lives in town beads even when assigned to a rig agent.
+	townRoot, err := workspace.FindFromCwd()
+	if err == nil && townRoot != "" {
+		townDir := filepath.Join(townRoot, ".beads")
+		if townDir != workDir {
+			return findAssignedIssueInDir(townDir, agentID)
+		}
+	}
+
+	return nil, nil
+}
+
+func findAssignedIssueInDir(workDir, agentID string) (*beads.Issue, error) {
+	b := beads.New(workDir)
+	for _, status := range []string{beads.StatusHooked, string(beads.StatusInProgress)} {
+		issues, err := b.List(beads.ListOptions{Status: status, Assignee: agentID, Priority: -1})
+		if err != nil {
+			return nil, fmt.Errorf("listing %s work for %s: %w", status, agentID, err)
+		}
+		if len(issues) > 0 {
+			return issues[0], nil
+		}
+	}
+	return nil, nil
+}
+
+func formatHookAckNote(t time.Time, agentID, beadID, sessionID string, attachment *beads.AttachmentFields) string {
+	parts := []string{
+		"hook_ack:",
+		t.UTC().Format(time.RFC3339),
+		"actor=" + agentID,
+		"bead=" + beadID,
+	}
+	if sessionID != "" {
+		parts = append(parts, "session="+sessionID)
+	}
+	if attachment != nil {
+		if attachment.AttachedMolecule != "" {
+			parts = append(parts, "molecule="+attachment.AttachedMolecule)
+		}
+		if attachment.AttachedFormula != "" {
+			parts = append(parts, "formula="+attachment.AttachedFormula)
+		}
+	}
+	return strings.Join(parts, " ")
 }
 
 func runHook(_ *cobra.Command, args []string) error {

--- a/internal/cmd/hook_test.go
+++ b/internal/cmd/hook_test.go
@@ -3,6 +3,9 @@ package cmd
 import (
 	"strings"
 	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 // TestHookPolecatEnvCheck verifies that the polecat guard in runHook uses
@@ -152,5 +155,19 @@ func TestNormalizeHookShowTarget(t *testing.T) {
 				t.Fatalf("normalizeHookShowTarget(%q) = %q, want %q", tt.target, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestFormatHookAckNote(t *testing.T) {
+	ackTime := time.Date(2026, 5, 13, 18, 45, 0, 0, time.FixedZone("local", -7*60*60))
+	attachment := &beads.AttachmentFields{
+		AttachedMolecule: "hq-wisp-f6fw",
+		AttachedFormula:  "mol-polecat-work",
+	}
+
+	got := formatHookAckNote(ackTime, "gastown/polecats/thunder", "gt-gh-2635", "session-123", attachment)
+	want := "hook_ack: 2026-05-14T01:45:00Z actor=gastown/polecats/thunder bead=gt-gh-2635 session=session-123 molecule=hq-wisp-f6fw formula=mol-polecat-work"
+	if got != want {
+		t.Fatalf("formatHookAckNote() = %q, want %q", got, want)
 	}
 }

--- a/internal/events/events.go
+++ b/internal/events/events.go
@@ -36,6 +36,7 @@ const (
 const (
 	TypeSling   = "sling"
 	TypeHook    = "hook"
+	TypeHookAck = "hook_ack"
 	TypeUnhook  = "unhook"
 	TypeHandoff = "handoff"
 	TypeDone    = "done"
@@ -55,9 +56,9 @@ const (
 	TypeMassDeath    = "mass_death"    // Multiple sessions died in short window
 
 	// Witness patrol events
-	TypePatrolStarted   = "patrol_started"
-	TypePolecatChecked  = "polecat_checked"
-	TypePolecatNudged   = "polecat_nudged"
+	TypePatrolStarted    = "patrol_started"
+	TypePolecatChecked   = "polecat_checked"
+	TypePolecatNudged    = "polecat_nudged"
 	TypeEscalationSent   = "escalation_sent"
 	TypeEscalationAcked  = "escalation_acked"
 	TypeEscalationClosed = "escalation_closed"
@@ -163,6 +164,23 @@ func HookPayload(beadID string) map[string]interface{} {
 	return map[string]interface{}{
 		"bead": beadID,
 	}
+}
+
+// HookAckPayload creates a payload for hook acknowledgment events.
+func HookAckPayload(beadID, moleculeID, formula, sessionID string) map[string]interface{} {
+	p := map[string]interface{}{
+		"bead": beadID,
+	}
+	if moleculeID != "" {
+		p["molecule"] = moleculeID
+	}
+	if formula != "" {
+		p["formula"] = formula
+	}
+	if sessionID != "" {
+		p["session"] = sessionID
+	}
+	return p
 }
 
 // HandoffPayload creates a payload for handoff events.


### PR DESCRIPTION
## Summary
- Add `gt hook ack` as a first-class acknowledgment command for hooked work.
- Record a timestamped `hook_ack` note on the current hooked/in-progress bead.
- Emit a `hook_ack` activity event with bead, molecule, formula, and session metadata.

## Verification
- `go build ./cmd/gt`
- `go test ./internal/cmd -run TestFormatHookAckNote -count=1`
- `go test ./internal/events`
- `go test ./internal/cmd -run 'TestHook|TestNormalizeHookShowTarget' -count=1`

Full `go test ./...` was attempted but did not pass in this sandbox due unrelated/environmental failures: rootless Docker unavailable, Dolt circuit-breaker/timeouts, and tmux command-name expectations (`coreutils` vs `sleep`).

Closes #2635