### PR TITLE
Fix cross-database sling target validation

### DIFF
--- a/internal/cmd/sling_batch.go
+++ b/internal/cmd/sling_batch.go
@@ -27,10 +27,15 @@ func runBatchSling(beadIDs []string, rigName string, townBeadsDir string) error 
 			return fmt.Errorf("bead '%s' not found", beadID)
 		}
 	}
+	townRoot := filepath.Dir(townBeadsDir)
+	for _, beadID := range beadIDs {
+		if err := verifyBeadExistsInTargetRigDatabase(beadID, rigName, townRoot); err != nil {
+			return err
+		}
+	}
 
 	// Cross-rig guard: check all beads match the target rig before spawning (gt-myecw)
 	if !slingForce {
-		townRoot := filepath.Dir(townBeadsDir)
 		for _, beadID := range beadIDs {
 			prefix := beads.ExtractPrefix(beadID)
 			beadRig := beads.GetRigNameForPrefix(townRoot, prefix)
@@ -92,7 +97,6 @@ func runBatchSling(beadIDs []string, rigName string, townBeadsDir string) error 
 	}
 
 	// Cook formula once before the loop for efficiency
-	townRoot := filepath.Dir(townBeadsDir)
 	formulaCooked := false
 
 	// Pre-cook formula before the loop (batch optimization: cook once, instantiate many)

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -18,9 +18,9 @@ import (
 // reconstructed into a SlingParams and passed to executeSling().
 type SlingParams struct {
 	// What to sling
-	BeadID      string   // Base bead
-	FormulaName string   // Formula to apply ("mol-polecat-work", user formula, or "")
-	RigName     string   // Target rig (always a rig for queue)
+	BeadID      string // Base bead
+	FormulaName string // Formula to apply ("mol-polecat-work", user formula, or "")
+	RigName     string // Target rig (always a rig for queue)
 
 	// CLI flag passthrough
 	Args         string   // --args
@@ -30,14 +30,14 @@ type SlingParams struct {
 	ResumeBranch string   // --branch / --pr (resume existing PR branch, gh#3602)
 	Account      string   // --account
 	Agent        string   // --agent
-	NoConvoy   bool     // --no-convoy
-	Owned      bool     // --owned
-	NoMerge    bool     // --no-merge
-	Force      bool     // --force
-	HookRawBead bool    // --hook-raw-bead
-	NoBoot     bool     // --no-boot
-	Mode       string   // --ralph: "" (normal) or "ralph"
-	ReviewOnly bool     // --review-only: review and report back only, no merge/commit/push
+	NoConvoy     bool     // --no-convoy
+	Owned        bool     // --owned
+	NoMerge      bool     // --no-merge
+	Force        bool     // --force
+	HookRawBead  bool     // --hook-raw-bead
+	NoBoot       bool     // --no-boot
+	Mode         string   // --ralph: "" (normal) or "ralph"
+	ReviewOnly   bool     // --review-only: review and report back only, no merge/commit/push
 
 	// Execution behavior (set by caller, not serialized to queue)
 	SkipCook         bool   // Batch optimization: formula already cooked
@@ -163,6 +163,13 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 	if isDeferredBead(info) && !explicitForce {
 		result.ErrMsg = "deferred"
 		return result, fmt.Errorf("bead %s is deferred (use --force to override)", params.BeadID)
+	}
+
+	if params.RigName != "" {
+		if err := verifyBeadExistsInTargetRigDatabase(params.BeadID, params.RigName, townRoot); err != nil {
+			result.ErrMsg = err.Error()
+			return result, err
+		}
 	}
 
 	// Send LIFECYCLE:Shutdown to the witness when force-stealing a bead from a

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -309,13 +309,19 @@ func verifyBeadExists(beadID string) error {
 // spawning polecats or creating molecule/hook side effects for beads that only
 // resolve from HQ or another rig database.
 func verifyBeadExistsInTargetRigDatabase(beadID, targetRig, townRoot string) error {
-	if beadID == "" || targetRig == "" || townRoot == "" {
+	if beadID == "" {
 		return nil
+	}
+	if targetRig == "" {
+		return fmt.Errorf("cannot verify bead %s in target rig: target rig is empty; refusing to sling before creating hooks or molecule side effects", beadID)
+	}
+	if townRoot == "" {
+		return fmt.Errorf("cannot verify bead %s in target rig %q: town root is unavailable; refusing to sling before creating hooks or molecule side effects", beadID, targetRig)
 	}
 
 	targetRigDir := beads.GetRigDirForName(townRoot, targetRig)
 	if targetRigDir == "" {
-		return nil
+		return fmt.Errorf("cannot resolve target rig %q beads database for bead %s; refusing to sling before creating hooks or molecule side effects", targetRig, beadID)
 	}
 	targetBeadsDir := filepath.Join(targetRigDir, ".beads")
 

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -304,6 +304,41 @@ func verifyBeadExists(beadID string) error {
 	return nil
 }
 
+// verifyBeadExistsInTargetRigDatabase checks the target rig's beads database
+// directly instead of following prefix routing. This prevents gt sling from
+// spawning polecats or creating molecule/hook side effects for beads that only
+// resolve from HQ or another rig database.
+func verifyBeadExistsInTargetRigDatabase(beadID, targetRig, townRoot string) error {
+	if beadID == "" || targetRig == "" || townRoot == "" {
+		return nil
+	}
+
+	targetRigDir := beads.GetRigDirForName(townRoot, targetRig)
+	if targetRigDir == "" {
+		return nil
+	}
+	targetBeadsDir := filepath.Join(targetRigDir, ".beads")
+
+	out, err := BdCmd("--db", targetBeadsDir, "show", beadID, "--json", "--allow-stale").
+		Dir(targetRigDir).
+		StripBeadsDir().
+		Stderr(io.Discard).
+		Output()
+	if err != nil || len(strings.TrimSpace(string(out))) == 0 {
+		return fmt.Errorf("bead %s is not present in target rig %q beads database; refusing to sling before creating hooks or molecule side effects", beadID, targetRig)
+	}
+
+	var infos []beadInfo
+	if err := json.Unmarshal(out, &infos); err != nil {
+		return fmt.Errorf("checking target rig %q database for bead %s: %w", targetRig, beadID, err)
+	}
+	if len(infos) == 0 {
+		return fmt.Errorf("bead %s is not present in target rig %q beads database; refusing to sling before creating hooks or molecule side effects", beadID, targetRig)
+	}
+
+	return nil
+}
+
 // getBeadInfo returns status and assignee for a bead.
 // Resolves the rig directory from the bead's prefix for correct dolt access.
 func getBeadInfo(beadID string) (*beadInfo, error) {

--- a/internal/cmd/sling_schedule.go
+++ b/internal/cmd/sling_schedule.go
@@ -79,6 +79,9 @@ func scheduleBead(beadID, rigName string, opts ScheduleOptions) error {
 	if _, isRig := IsRigName(rigName); !isRig {
 		return fmt.Errorf("'%s' is not a known rig", rigName)
 	}
+	if err := verifyBeadExistsInTargetRigDatabase(beadID, rigName, townRoot); err != nil {
+		return err
+	}
 
 	if !opts.Force {
 		if err := checkCrossRigGuard(beadID, rigName+"/polecats/_", townRoot); err != nil {

--- a/internal/cmd/sling_target.go
+++ b/internal/cmd/sling_target.go
@@ -297,8 +297,8 @@ func resolveTarget(target string, opts ResolveTargetOptions) (*ResolvedTarget, e
 		}
 		return nil, fmt.Errorf("resolving target: %w", err)
 	}
-	if opts.BeadID != "" && isPolecatTarget(target) {
-		parts := strings.Split(target, "/")
+	if opts.BeadID != "" && isPolecatTarget(agentID) {
+		parts := strings.Split(agentID, "/")
 		if len(parts) >= 3 && parts[1] == "polecats" {
 			rigName := parts[0]
 			if err := verifyBeadExistsInTargetRigDatabase(opts.BeadID, rigName, opts.TownRoot); err != nil {

--- a/internal/cmd/sling_target.go
+++ b/internal/cmd/sling_target.go
@@ -297,6 +297,15 @@ func resolveTarget(target string, opts ResolveTargetOptions) (*ResolvedTarget, e
 		}
 		return nil, fmt.Errorf("resolving target: %w", err)
 	}
+	if opts.BeadID != "" && isPolecatTarget(target) {
+		parts := strings.Split(target, "/")
+		if len(parts) >= 3 && parts[1] == "polecats" {
+			rigName := parts[0]
+			if err := verifyBeadExistsInTargetRigDatabase(opts.BeadID, rigName, opts.TownRoot); err != nil {
+				return nil, err
+			}
+		}
+	}
 	result.Agent = agentID
 	result.Pane = pane
 	result.WorkDir = workDir

--- a/internal/cmd/sling_target.go
+++ b/internal/cmd/sling_target.go
@@ -115,12 +115,12 @@ func resolveSelfTarget() (agentID string, pane string, hookRoot string, err erro
 
 // ResolveTargetOptions controls target resolution behavior.
 type ResolveTargetOptions struct {
-	DryRun   bool
-	Force    bool
-	Create   bool
-	Account  string
-	Agent    string
-	NoBoot   bool
+	DryRun       bool
+	Force        bool
+	Create       bool
+	Account      string
+	Agent        string
+	NoBoot       bool
 	HookBead     string // Bead ID to set atomically during polecat spawn (empty = skip)
 	BeadID       string // For cross-rig guard checks (empty = skip guard)
 	TownRoot     string
@@ -217,6 +217,11 @@ func resolveTarget(target string, opts ResolveTargetOptions) (*ResolvedTarget, e
 				return nil, err
 			}
 		}
+		if opts.BeadID != "" {
+			if err := verifyBeadExistsInTargetRigDatabase(opts.BeadID, rigName, opts.TownRoot); err != nil {
+				return nil, err
+			}
+		}
 		if opts.DryRun {
 			fmt.Printf("Would spawn fresh polecat in rig '%s'\n", rigName)
 			result.Agent = fmt.Sprintf("%s/polecats/<new>", rigName)
@@ -258,6 +263,11 @@ func resolveTarget(target string, opts ResolveTargetOptions) (*ResolvedTarget, e
 				rigName := parts[0]
 				if opts.BeadID != "" && !opts.Force {
 					if err := checkCrossRigGuard(opts.BeadID, rigName+"/polecats/_", opts.TownRoot); err != nil {
+						return nil, err
+					}
+				}
+				if opts.BeadID != "" {
+					if err := verifyBeadExistsInTargetRigDatabase(opts.BeadID, rigName, opts.TownRoot); err != nil {
 						return nil, err
 					}
 				}

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -791,18 +791,22 @@ func TestResolveTargetRejectsLivePolecatMissingTargetRigDatabase(t *testing.T) {
 	prevResolve := resolveTargetAgentFn
 	t.Cleanup(func() { resolveTargetAgentFn = prevResolve })
 	resolveTargetAgentFn = func(target string) (string, string, string, error) {
-		return target, "%1", filepath.Join(townRoot, "gastown", "polecats", "toast"), nil
+		return "gastown/polecats/toast", "%1", filepath.Join(townRoot, "gastown", "polecats", "toast"), nil
 	}
 
-	_, err := resolveTarget("gastown/polecats/toast", ResolveTargetOptions{
-		BeadID:   "gt-r2405",
-		TownRoot: townRoot,
-	})
-	if err == nil {
-		t.Fatal("expected target-rig database validation error")
-	}
-	if !strings.Contains(err.Error(), "not present in target rig") {
-		t.Fatalf("unexpected error: %v", err)
+	for _, target := range []string{"gastown/polecats/toast", "gastown/toast", "gt-gastown-polecat-toast"} {
+		t.Run(target, func(t *testing.T) {
+			_, err := resolveTarget(target, ResolveTargetOptions{
+				BeadID:   "gt-r2405",
+				TownRoot: townRoot,
+			})
+			if err == nil {
+				t.Fatal("expected target-rig database validation error")
+			}
+			if !strings.Contains(err.Error(), "not present in target rig") {
+				t.Fatalf("unexpected error: %v", err)
+			}
+		})
 	}
 }
 

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -599,6 +599,223 @@ exit /b 0
 	}
 }
 
+func setupCrossDatabaseSlingGuardTest(t *testing.T) (townRoot, logPath string) {
+	t.Helper()
+
+	townRoot = t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir mayor/rig: %v", err)
+	}
+	rigsPath := filepath.Join(townRoot, "mayor", "rigs.json")
+	rigs := &config.RigsConfig{
+		Version: 1,
+		Rigs: map[string]config.RigEntry{
+			"gastown": {
+				GitURL:  "git@github.com:test/gastown.git",
+				AddedAt: time.Now().Truncate(time.Second),
+				BeadsConfig: &config.BeadsConfig{
+					Repo:   "local",
+					Prefix: "zz-",
+				},
+			},
+		},
+	}
+	if err := config.SaveRigsConfig(rigsPath, rigs); err != nil {
+		t.Fatalf("SaveRigsConfig: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "gastown", "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir target rig dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	routes := strings.Join([]string{
+		`{"prefix":"gt-","path":"."}`,
+		`{"prefix":"zz-","path":"gastown/mayor/rig"}`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	logPath = filepath.Join(townRoot, "bd.log")
+	bdScript := `#!/bin/sh
+set -e
+echo "$*" >> "${BD_LOG}"
+if [ "$1" = "--db" ]; then
+  exit 1
+fi
+cmd="$1"
+shift || true
+case "$cmd" in
+  show)
+    echo '[{"title":"HQ-owned issue","status":"open","assignee":"","description":""}]'
+    ;;
+  create|update|cook|mol|close|dep)
+    echo "unexpected side effect: $cmd" >&2
+    exit 2
+    ;;
+esac
+exit 0
+`
+	bdScriptWindows := `@echo off
+echo %*>>"%BD_LOG%"
+if "%1"=="--db" exit /b 1
+set "cmd=%1"
+if "%cmd%"=="show" (
+  echo [{"title":"HQ-owned issue","status":"open","assignee":"","description":""}]
+  exit /b 0
+)
+if "%cmd%"=="create" exit /b 2
+if "%cmd%"=="update" exit /b 2
+if "%cmd%"=="cook" exit /b 2
+if "%cmd%"=="mol" exit /b 2
+if "%cmd%"=="close" exit /b 2
+if "%cmd%"=="dep" exit /b 2
+exit /b 0
+`
+	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
+
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv(EnvGTRole, "mayor")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("GT_CREW", "")
+	t.Setenv("TMUX_PANE", "")
+	t.Setenv("GT_TEST_NO_NUDGE", "1")
+	t.Setenv("GT_TEST_SKIP_HOOK_VERIFY", "1")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	return townRoot, logPath
+}
+
+func TestScheduleBeadRejectsMissingTargetRigDatabaseBeforeContext(t *testing.T) {
+	_, logPath := setupCrossDatabaseSlingGuardTest(t)
+
+	err := scheduleBead("gt-r2405", "gastown", ScheduleOptions{})
+	if err == nil {
+		t.Fatal("expected target-rig database validation error")
+	}
+	if !strings.Contains(err.Error(), "not present in target rig") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	logBytes, readErr := os.ReadFile(logPath)
+	if readErr != nil {
+		t.Fatalf("read bd log: %v", readErr)
+	}
+	log := string(logBytes)
+	for _, sideEffect := range []string{"create", "update", "cook", "mol", "close", "dep"} {
+		if strings.Contains(log, sideEffect) {
+			t.Fatalf("bd side effect %q ran before target-rig database validation rejected the bead; log:\n%s", sideEffect, log)
+		}
+	}
+}
+
+func TestBatchSlingRejectsMissingTargetRigDatabaseBeforeSpawn(t *testing.T) {
+	townRoot, _ := setupCrossDatabaseSlingGuardTest(t)
+
+	prevDryRun := slingDryRun
+	prevForce := slingForce
+	prevSpawn := spawnPolecatForSling
+	t.Cleanup(func() {
+		slingDryRun = prevDryRun
+		slingForce = prevForce
+		spawnPolecatForSling = prevSpawn
+	})
+	slingDryRun = false
+	slingForce = false
+
+	spawnCalled := false
+	spawnPolecatForSling = func(rigName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		spawnCalled = true
+		return &SpawnedPolecatInfo{RigName: rigName, PolecatName: "toast", ClonePath: filepath.Join(townRoot, "fake-polecat")}, nil
+	}
+
+	err := runBatchSling([]string{"gt-r2405"}, "gastown", filepath.Join(townRoot, ".beads"))
+	if err == nil {
+		t.Fatal("expected target-rig database validation error")
+	}
+	if !strings.Contains(err.Error(), "not present in target rig") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spawnCalled {
+		t.Fatal("spawnPolecatForSling was called before target-rig database validation rejected the bead")
+	}
+}
+
+func TestExecuteSlingRejectsMissingTargetRigDatabaseBeforeSpawn(t *testing.T) {
+	townRoot, _ := setupCrossDatabaseSlingGuardTest(t)
+
+	prevSpawn := spawnPolecatForSling
+	t.Cleanup(func() { spawnPolecatForSling = prevSpawn })
+
+	spawnCalled := false
+	spawnPolecatForSling = func(rigName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		spawnCalled = true
+		return &SpawnedPolecatInfo{RigName: rigName, PolecatName: "toast", ClonePath: filepath.Join(townRoot, "fake-polecat")}, nil
+	}
+
+	_, err := executeSling(SlingParams{
+		BeadID:   "gt-r2405",
+		RigName:  "gastown",
+		TownRoot: townRoot,
+		BeadsDir: filepath.Join(townRoot, ".beads"),
+	})
+	if err == nil {
+		t.Fatal("expected target-rig database validation error")
+	}
+	if !strings.Contains(err.Error(), "not present in target rig") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spawnCalled {
+		t.Fatal("spawnPolecatForSling was called before target-rig database validation rejected the bead")
+	}
+}
+
+func TestResolveTargetRejectsLivePolecatMissingTargetRigDatabase(t *testing.T) {
+	townRoot, _ := setupCrossDatabaseSlingGuardTest(t)
+
+	prevResolve := resolveTargetAgentFn
+	t.Cleanup(func() { resolveTargetAgentFn = prevResolve })
+	resolveTargetAgentFn = func(target string) (string, string, string, error) {
+		return target, "%1", filepath.Join(townRoot, "gastown", "polecats", "toast"), nil
+	}
+
+	_, err := resolveTarget("gastown/polecats/toast", ResolveTargetOptions{
+		BeadID:   "gt-r2405",
+		TownRoot: townRoot,
+	})
+	if err == nil {
+		t.Fatal("expected target-rig database validation error")
+	}
+	if !strings.Contains(err.Error(), "not present in target rig") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestTargetRigDatabaseLookupFailsClosedWithoutTownRoot(t *testing.T) {
+	err := verifyBeadExistsInTargetRigDatabase("gt-r2405", "gastown", "")
+	if err == nil {
+		t.Fatal("expected fail-closed error without town root")
+	}
+	if !strings.Contains(err.Error(), "town root is unavailable") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestRollbackSlingArtifactsBurnsAttachedMolecules(t *testing.T) {
 	townRoot, _ := filepath.EvalSymlinks(t.TempDir())
 	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -352,6 +352,9 @@ func TestSlingRollsBackSpawnedPolecatOnInstantiateFailure(t *testing.T) {
 	}
 	bdScript := `#!/bin/sh
 set -e
+if [ "$1" = "--db" ]; then
+  shift 2
+fi
 cmd="$1"
 shift || true
 case "$cmd" in
@@ -380,6 +383,10 @@ exit 0
 `
 	bdScriptWindows := `@echo off
 setlocal enableextensions
+if "%1"=="--db" (
+  shift
+  shift
+)
 set "cmd=%1"
 set "sub=%2"
 if "%cmd%"=="show" (
@@ -464,6 +471,131 @@ exit /b 0
 	}
 	if !rollbackCalled {
 		t.Fatalf("expected rollbackSlingArtifacts to be called")
+	}
+}
+
+func TestSlingRejectsBeadMissingFromTargetRigBeforeSpawn(t *testing.T) {
+	townRoot := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir mayor/rig: %v", err)
+	}
+	rigsPath := filepath.Join(townRoot, "mayor", "rigs.json")
+	rigs := &config.RigsConfig{
+		Version: 1,
+		Rigs: map[string]config.RigEntry{
+			"gastown": {
+				GitURL:  "git@github.com:test/gastown.git",
+				AddedAt: time.Now().Truncate(time.Second),
+				BeadsConfig: &config.BeadsConfig{
+					Repo:   "local",
+					Prefix: "zz-",
+				},
+			},
+		},
+	}
+	if err := config.SaveRigsConfig(rigsPath, rigs); err != nil {
+		t.Fatalf("SaveRigsConfig: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "gastown", "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir target rig dir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	routes := strings.Join([]string{
+		`{"prefix":"gt-","path":"."}`,
+		`{"prefix":"zz-","path":"gastown/mayor/rig"}`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	logPath := filepath.Join(townRoot, "bd.log")
+	bdScript := `#!/bin/sh
+set -e
+echo "$*" >> "${BD_LOG}"
+if [ "$1" = "--db" ]; then
+  # The direct target-rig DB lookup must fail: the bead only resolves from HQ.
+  exit 1
+fi
+cmd="$1"
+shift || true
+case "$cmd" in
+  show)
+    echo '[{"title":"HQ-owned issue","status":"open","assignee":"","description":""}]'
+    ;;
+  mol|update|cook)
+    echo "unexpected side effect: $cmd" >&2
+    exit 2
+    ;;
+esac
+exit 0
+`
+	bdScriptWindows := `@echo off
+echo %*>>"%BD_LOG%"
+if "%1"=="--db" exit /b 1
+set "cmd=%1"
+if "%cmd%"=="show" (
+  echo [{"title":"HQ-owned issue","status":"open","assignee":"","description":""}]
+  exit /b 0
+)
+if "%cmd%"=="mol" exit /b 2
+if "%cmd%"=="update" exit /b 2
+if "%cmd%"=="cook" exit /b 2
+exit /b 0
+`
+	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
+
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv(EnvGTRole, "mayor")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("GT_CREW", "")
+	t.Setenv("TMUX_PANE", "")
+	t.Setenv("GT_TEST_NO_NUDGE", "1")
+	t.Setenv("GT_TEST_SKIP_HOOK_VERIFY", "1")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	prevNoConvoy := slingNoConvoy
+	prevNoBoot := slingNoBoot
+	prevSpawn := spawnPolecatForSling
+	t.Cleanup(func() {
+		slingNoConvoy = prevNoConvoy
+		slingNoBoot = prevNoBoot
+		spawnPolecatForSling = prevSpawn
+	})
+	slingNoConvoy = true
+	slingNoBoot = true
+
+	spawnCalled := false
+	spawnPolecatForSling = func(rigName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		spawnCalled = true
+		return &SpawnedPolecatInfo{RigName: rigName, PolecatName: "toast", ClonePath: filepath.Join(townRoot, "fake-polecat")}, nil
+	}
+
+	err = runSling(nil, []string{"gt-r2405", "gastown"})
+	if err == nil {
+		t.Fatal("expected target-rig database validation error")
+	}
+	if !strings.Contains(err.Error(), "not present in target rig") {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if spawnCalled {
+		t.Fatal("spawnPolecatForSling was called before target-rig database validation rejected the bead")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Verify the requested bead exists in the target rig's `.beads` database before spawning a polecat.
- Reuse that fail-fast validation for rig targets and dead-polecat fallback targets to avoid hook/molecule side effects.
- Add coverage proving HQ-routed beads are rejected before spawn/attachment side effects.

## Tests
- `go test ./internal/cmd -run 'TestSlingRejectsBeadMissingFromTargetRigBeforeSpawn|TestSlingRollsBackSpawnedPolecatOnInstantiateFailure'`
- `go test ./...` timed out locally after 10m with no failure output before timeout.
- `go test ./internal/cmd` timed out locally after 5m with no failure output before timeout.

Fixes #3899