### PR TITLE
Fix beads init recovery

### DIFF
--- a/internal/doctor/rig_check.go
+++ b/internal/doctor/rig_check.go
@@ -1083,6 +1083,9 @@ func (c *BeadsRedirectCheck) Fix(ctx *CheckContext) error {
 			configCmd.Env = bdEnv
 			_, _ = configCmd.CombinedOutput() // Ignore errors - older beads don't need this
 		}
+		if err := doltserver.EnsureMetadataForBeadsDir(ctx.TownRoot, rigBeadsDir, ctx.RigName, ctx.RigName); err != nil {
+			return fmt.Errorf("ensuring metadata.json: %w", err)
+		}
 		return nil
 	}
 

--- a/internal/doctor/rig_config_sync_check.go
+++ b/internal/doctor/rig_config_sync_check.go
@@ -25,8 +25,10 @@ type RigConfigSyncCheck struct {
 	prefixMismatches []prefixMismatch // Prefix mismatches between config.json and registry
 	missingRigBeads  []rigBeadInfo    // Rigs missing identity beads
 	missingDoltDB    []string         // Rigs missing Dolt database
+	missingMetadata  []string         // Rigs missing metadata.json
 	missingPrefixCfg []string         // Rigs missing issue-prefix in config.yaml
 	dbNameMismatches []dbMismatch     // Dolt database name doesn't match prefix
+	dbCheckErrors    []string         // Rigs whose Dolt DB status could not be verified
 }
 
 type prefixMismatch struct {
@@ -78,8 +80,10 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 	c.prefixMismatches = nil
 	c.missingRigBeads = nil
 	c.missingDoltDB = nil
+	c.missingMetadata = nil
 	c.missingPrefixCfg = nil
 	c.dbNameMismatches = nil
+	c.dbCheckErrors = nil
 	var details []string
 
 	for rigName, entry := range rigsConfig.Rigs {
@@ -129,15 +133,14 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 				rigName, configPrefix, expectedPrefix))
 		}
 
-		// Check beads configuration at mayor/rig/.beads
-		mayorRigBeads := filepath.Join(rigPath, "mayor", "rig", ".beads")
-		if _, err := os.Stat(mayorRigBeads); os.IsNotExist(err) {
-			details = append(details, fmt.Sprintf("Rig %s is missing mayor/rig/.beads directory", rigName))
+		beadsDir := doltserver.FindRigBeadsDir(ctx.TownRoot, rigName)
+		if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
+			details = append(details, fmt.Sprintf("Rig %s is missing .beads directory", rigName))
 			continue
 		}
 
 		// Check issue-prefix in config.yaml
-		configYamlPath := filepath.Join(mayorRigBeads, "config.yaml")
+		configYamlPath := filepath.Join(beadsDir, "config.yaml")
 		if data, err := os.ReadFile(configYamlPath); err == nil {
 			if !strings.Contains(string(data), "issue-prefix:") && expectedPrefix != "" {
 				c.missingPrefixCfg = append(c.missingPrefixCfg, rigName)
@@ -146,9 +149,17 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 
 		// Check metadata.json for Dolt database
-		metadataPath := filepath.Join(mayorRigBeads, "metadata.json")
+		metadataPath := filepath.Join(beadsDir, "metadata.json")
 		if _, err := os.Stat(metadataPath); os.IsNotExist(err) {
+			c.missingMetadata = append(c.missingMetadata, rigName)
 			details = append(details, fmt.Sprintf("Rig %s is missing .beads/metadata.json", rigName))
+			if exists, err := c.doltDatabaseExists(ctx, rigName); err != nil {
+				c.dbCheckErrors = append(c.dbCheckErrors, rigName)
+				details = append(details, fmt.Sprintf("Rig %s Dolt database status could not be verified: %v", rigName, err))
+			} else if expectedPrefix != "" && !exists {
+				c.missingDoltDB = append(c.missingDoltDB, rigName)
+				details = append(details, fmt.Sprintf("Rig %s Dolt database '%s' not found on server", rigName, rigName))
+			}
 			continue
 		}
 
@@ -191,8 +202,11 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 						rigName, metadata.DoltDatabase, expectedDBName))
 				}
 
-				if !c.doltDatabaseExists(ctx, metadata.DoltDatabase) {
-					if metadata.DoltDatabase != expectedDBName && c.doltDatabaseExists(ctx, expectedDBName) {
+				if exists, err := c.doltDatabaseExists(ctx, metadata.DoltDatabase); err != nil {
+					c.dbCheckErrors = append(c.dbCheckErrors, rigName)
+					details = append(details, fmt.Sprintf("Rig %s Dolt database status could not be verified: %v", rigName, err))
+				} else if !exists {
+					if expectedExists, err := c.doltDatabaseExists(ctx, expectedDBName); err == nil && metadata.DoltDatabase != expectedDBName && expectedExists {
 						// The canonical database exists; the mismatch repair below will
 						// repoint metadata without re-initializing anything destructive.
 					} else {
@@ -206,7 +220,7 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 		// Check if rig identity bead exists
 		if configPrefix != "" {
 			rigBeadID := fmt.Sprintf("%s-rig-%s", configPrefix, rigName)
-			if !c.rigBeadExists(rigBeadID, rigPath) {
+			if !c.rigBeadExists(rigBeadID, rigPath, beadsDir) {
 				c.missingRigBeads = append(c.missingRigBeads, rigBeadInfo{
 					rigName: rigName,
 					prefix:  configPrefix,
@@ -218,7 +232,7 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 	}
 
 	// Check for summary
-	issueCount := len(c.missingConfig) + len(c.prefixMismatches) + len(c.missingRigBeads) + len(c.missingDoltDB) + len(c.missingPrefixCfg) + len(c.dbNameMismatches)
+	issueCount := len(c.missingConfig) + len(c.prefixMismatches) + len(c.missingRigBeads) + len(c.missingDoltDB) + len(c.missingMetadata) + len(c.missingPrefixCfg) + len(c.dbNameMismatches) + len(c.dbCheckErrors)
 	if issueCount == 0 {
 		return &CheckResult{
 			Name:    c.Name(),
@@ -240,11 +254,17 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 	if len(c.missingDoltDB) > 0 {
 		parts = append(parts, fmt.Sprintf("%d missing Dolt DB(s)", len(c.missingDoltDB)))
 	}
+	if len(c.missingMetadata) > 0 {
+		parts = append(parts, fmt.Sprintf("%d missing metadata.json", len(c.missingMetadata)))
+	}
 	if len(c.missingPrefixCfg) > 0 {
 		parts = append(parts, fmt.Sprintf("%d missing issue-prefix", len(c.missingPrefixCfg)))
 	}
 	if len(c.dbNameMismatches) > 0 {
 		parts = append(parts, fmt.Sprintf("%d DB name mismatch(es)", len(c.dbNameMismatches)))
+	}
+	if len(c.dbCheckErrors) > 0 {
+		parts = append(parts, fmt.Sprintf("%d Dolt DB status unknown", len(c.dbCheckErrors)))
 	}
 
 	return &CheckResult{
@@ -307,8 +327,7 @@ func (c *RigConfigSyncCheck) Fix(ctx *CheckContext) error {
 			continue
 		}
 
-		rigPath := filepath.Join(ctx.TownRoot, rigName)
-		configYamlPath := filepath.Join(rigPath, "mayor", "rig", ".beads", "config.yaml")
+		configYamlPath := filepath.Join(doltserver.FindRigBeadsDir(ctx.TownRoot, rigName), "config.yaml")
 
 		// Read existing config
 		data, err := os.ReadFile(configYamlPath)
@@ -332,6 +351,14 @@ func (c *RigConfigSyncCheck) Fix(ctx *CheckContext) error {
 		}
 	}
 
+	// Fix missing metadata.json without requiring the Dolt database to be online.
+	for _, rigName := range c.missingMetadata {
+		beadsDir := doltserver.FindRigBeadsDir(ctx.TownRoot, rigName)
+		if err := doltserver.EnsureMetadataForBeadsDir(ctx.TownRoot, beadsDir, rigName, rigName); err != nil {
+			return fmt.Errorf("could not write metadata.json for %s: %w", rigName, err)
+		}
+	}
+
 	// Fix missing Dolt databases by running bd init
 	for _, rigName := range c.missingDoltDB {
 		entry, ok := rigsConfig.Rigs[rigName]
@@ -340,8 +367,21 @@ func (c *RigConfigSyncCheck) Fix(ctx *CheckContext) error {
 		}
 
 		rigPath := filepath.Join(ctx.TownRoot, rigName)
+		beadsDir := doltserver.FindRigBeadsDir(ctx.TownRoot, rigName)
+		cmdDir := rigPath
 		mayorRigPath := filepath.Join(rigPath, "mayor", "rig")
-		if c.doltDatabaseExists(ctx, rigName) {
+		if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
+			if _, statErr := os.Stat(mayorRigPath); statErr == nil {
+				beadsDir = filepath.Join(mayorRigPath, ".beads")
+			}
+		}
+		if beadsDir == filepath.Join(mayorRigPath, ".beads") {
+			cmdDir = mayorRigPath
+		}
+		if exists, err := c.doltDatabaseExists(ctx, rigName); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: skipping Dolt DB initialization for %s because database status could not be verified: %v\n", rigName, err)
+			continue
+		} else if exists {
 			continue
 		}
 
@@ -349,9 +389,9 @@ func (c *RigConfigSyncCheck) Fix(ctx *CheckContext) error {
 		doltCfg := doltserver.DefaultConfig(ctx.TownRoot)
 		destroyToken := fmt.Sprintf("DESTROY-%s", entry.BeadsConfig.Prefix)
 		cmd := exec.Command("bd", "init", "--prefix", entry.BeadsConfig.Prefix, "--database", rigName, "--server", "--server-port", strconv.Itoa(doltCfg.Port), "--force", "--destroy-token="+destroyToken)
-		cmd.Dir = mayorRigPath
+		cmd.Dir = cmdDir
 		cmd.Env = append(stripEnvPrefixes(os.Environ(), "BEADS_DIR=", "BEADS_DB=", "BEADS_DOLT_SERVER_DATABASE="),
-			"BEADS_DIR="+filepath.Join(mayorRigPath, ".beads"),
+			"BEADS_DIR="+beadsDir,
 			"BEADS_DOLT_SERVER_DATABASE="+rigName,
 		)
 		if output, err := cmd.CombinedOutput(); err != nil {
@@ -362,8 +402,7 @@ func (c *RigConfigSyncCheck) Fix(ctx *CheckContext) error {
 	// Fix database name mismatches - rename database to match rig directory name
 	renamedDBs := false
 	for _, mismatch := range c.dbNameMismatches {
-		rigPath := filepath.Join(ctx.TownRoot, mismatch.rigName)
-		metadataPath := filepath.Join(rigPath, "mayor", "rig", ".beads", "metadata.json")
+		metadataPath := filepath.Join(doltserver.FindRigBeadsDir(ctx.TownRoot, mismatch.rigName), "metadata.json")
 
 		// Read current metadata
 		metadataBytes, err := os.ReadFile(metadataPath)
@@ -437,9 +476,9 @@ func (c *RigConfigSyncCheck) Fix(ctx *CheckContext) error {
 	// Fix missing rig identity beads
 	for _, info := range c.missingRigBeads {
 		rigPath := filepath.Join(ctx.TownRoot, info.rigName)
-		mayorRigPath := filepath.Join(rigPath, "mayor", "rig")
+		beadsDir := doltserver.FindRigBeadsDir(ctx.TownRoot, info.rigName)
 
-		bd := beads.New(mayorRigPath)
+		bd := beads.NewWithBeadsDir(rigPath, beadsDir)
 		fields := &beads.RigFields{
 			Repo:   info.gitURL,
 			Prefix: info.prefix,
@@ -453,36 +492,37 @@ func (c *RigConfigSyncCheck) Fix(ctx *CheckContext) error {
 		// Add status:docked label if the rig should be docked
 		rigBeadID := fmt.Sprintf("%s-rig-%s", info.prefix, info.rigName)
 		cmd := exec.Command("bd", "label", rigBeadID, "--add", "status:docked")
-		cmd.Dir = mayorRigPath
+		cmd.Dir = rigPath
+		cmd.Env = append(stripEnvPrefixes(os.Environ(), "BEADS_DIR="), "BEADS_DIR="+beadsDir)
 		_ = cmd.Run() // Best effort - ignore errors
 	}
 
 	return nil
 }
 
-// doltDatabaseExists checks if a Dolt database exists on the server.
-func (c *RigConfigSyncCheck) doltDatabaseExists(ctx *CheckContext, dbName string) bool {
+// doltDatabaseExists checks if a Dolt database exists. A listing error means
+// status is unknown, not that the database is missing.
+func (c *RigConfigSyncCheck) doltDatabaseExists(ctx *CheckContext, dbName string) (bool, error) {
 	// Use the doltserver package to list databases
 	databases, err := doltserver.ListDatabases(ctx.TownRoot)
 	if err != nil {
-		return false
+		return false, err
 	}
 
 	for _, db := range databases {
 		if db == dbName {
-			return true
+			return true, nil
 		}
 	}
-	return false
+	return false, nil
 }
 
 // rigBeadExists checks if a rig identity bead exists.
-func (c *RigConfigSyncCheck) rigBeadExists(rigBeadID, rigPath string) bool {
-	mayorRigPath := filepath.Join(rigPath, "mayor", "rig")
-
+func (c *RigConfigSyncCheck) rigBeadExists(rigBeadID, rigPath, beadsDir string) bool {
 	// Try to show the bead using bd
 	cmd := exec.Command("bd", "show", rigBeadID, "--json")
-	cmd.Dir = mayorRigPath
+	cmd.Dir = rigPath
+	cmd.Env = append(stripEnvPrefixes(os.Environ(), "BEADS_DIR="), "BEADS_DIR="+beadsDir)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		return false

--- a/internal/doctor/rig_config_sync_check_test.go
+++ b/internal/doctor/rig_config_sync_check_test.go
@@ -164,6 +164,214 @@ func TestRigConfigSyncCheck_AllConfigsPresent(t *testing.T) {
 	}
 }
 
+func TestRigConfigSyncCheck_FixCreatesMissingMetadata(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake bd stub is shell-specific")
+	}
+
+	tmpDir := t.TempDir()
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	rigsJSON := `{
+		"version": 1,
+		"rigs": {
+			"testrig": {
+				"git_url": "https://github.com/test/test.git",
+				"beads": {"prefix": "tr"}
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(rigsJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigDir := filepath.Join(tmpDir, "testrig")
+	beadsDir := filepath.Join(rigDir, "mayor", "rig", ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	configJSON := `{
+		"type": "rig",
+		"version": 1,
+		"name": "testrig",
+		"git_url": "https://github.com/test/test.git",
+		"beads": {"prefix": "tr"}
+	}`
+	if err := os.WriteFile(filepath.Join(rigDir, "config.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("prefix: tr\nissue-prefix: tr\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte("#!/usr/bin/env bash\nexit 0\n"), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ctx := &CheckContext{TownRoot: tmpDir}
+	check := NewRigConfigSyncCheck()
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning, got %v: %s", result.Status, result.Message)
+	}
+	if len(check.missingMetadata) != 1 || check.missingMetadata[0] != "testrig" {
+		t.Fatalf("missingMetadata = %#v, want [testrig]", check.missingMetadata)
+	}
+
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+	metadataBytes, err := os.ReadFile(filepath.Join(beadsDir, "metadata.json"))
+	if err != nil {
+		t.Fatalf("reading metadata.json: %v", err)
+	}
+	metadata := string(metadataBytes)
+	if !strings.Contains(metadata, `"dolt_mode": "server"`) || !strings.Contains(metadata, `"dolt_database": "testrig"`) {
+		t.Fatalf("metadata.json missing server config: %s", metadata)
+	}
+}
+
+func TestRigConfigSyncCheck_FixCreatesMissingRootMetadata(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake bd stub is shell-specific")
+	}
+
+	tmpDir := t.TempDir()
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	rigsJSON := `{
+		"version": 1,
+		"rigs": {
+			"testrig": {
+				"git_url": "https://github.com/test/test.git",
+				"beads": {"prefix": "tr"}
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(rigsJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigDir := filepath.Join(tmpDir, "testrig")
+	beadsDir := filepath.Join(rigDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	configJSON := `{
+		"type": "rig",
+		"version": 1,
+		"name": "testrig",
+		"git_url": "https://github.com/test/test.git",
+		"beads": {"prefix": "tr"}
+	}`
+	if err := os.WriteFile(filepath.Join(rigDir, "config.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("prefix: tr\nissue-prefix: tr\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte("#!/usr/bin/env bash\nexit 0\n"), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ctx := &CheckContext{TownRoot: tmpDir}
+	check := NewRigConfigSyncCheck()
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning, got %v: %s", result.Status, result.Message)
+	}
+	if len(check.missingMetadata) != 1 || check.missingMetadata[0] != "testrig" {
+		t.Fatalf("missingMetadata = %#v, want [testrig]", check.missingMetadata)
+	}
+
+	if err := check.Fix(ctx); err != nil {
+		t.Fatalf("Fix failed: %v", err)
+	}
+	metadataBytes, err := os.ReadFile(filepath.Join(beadsDir, "metadata.json"))
+	if err != nil {
+		t.Fatalf("reading root metadata.json: %v", err)
+	}
+	metadata := string(metadataBytes)
+	if !strings.Contains(metadata, `"dolt_mode": "server"`) || !strings.Contains(metadata, `"dolt_database": "testrig"`) {
+		t.Fatalf("metadata.json missing server config: %s", metadata)
+	}
+}
+
+func TestRigConfigSyncCheck_DoltListErrorDoesNotMeanMissingDB(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake dolt stub is shell-specific")
+	}
+
+	tmpDir := t.TempDir()
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	rigsJSON := `{
+		"version": 1,
+		"rigs": {
+			"testrig": {
+				"git_url": "https://github.com/test/test.git",
+				"beads": {"prefix": "tr"}
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(rigsJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigDir := filepath.Join(tmpDir, "testrig")
+	beadsDir := filepath.Join(rigDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	configJSON := `{
+		"type": "rig",
+		"version": 1,
+		"name": "testrig",
+		"git_url": "https://github.com/test/test.git"
+	}`
+	if err := os.WriteFile(filepath.Join(rigDir, "config.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("prefix: tr\nissue-prefix: tr\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	metadata := `{"backend":"dolt","database":"dolt","dolt_mode":"server","dolt_database":"testrig"}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(metadata), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(binDir, "dolt"), []byte("#!/usr/bin/env bash\necho unreachable >&2\nexit 1\n"), 0755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GT_DOLT_HOST", "192.0.2.1")
+
+	ctx := &CheckContext{TownRoot: tmpDir}
+	check := NewRigConfigSyncCheck()
+	result := check.Run(ctx)
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning, got %v: %s", result.Status, result.Message)
+	}
+	if len(check.missingDoltDB) != 0 {
+		t.Fatalf("missingDoltDB = %#v, want none when DB listing fails", check.missingDoltDB)
+	}
+	if len(check.dbCheckErrors) != 1 || check.dbCheckErrors[0] != "testrig" {
+		t.Fatalf("dbCheckErrors = %#v, want [testrig]", check.dbCheckErrors)
+	}
+}
+
 func TestRigConfigSyncCheck_FixMissingDoltDBUsesCanonicalDatabase(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("fake bd arg/env logging is shell-specific")

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -3134,6 +3134,29 @@ func RepairWorkspace(townRoot string, ws BrokenWorkspace) (string, error) {
 // Callers that know the rig uses a short DB prefix (e.g. "be" for "beads_el")
 // should pass it as doltDatabase so metadata.json gets the right value.
 func EnsureMetadata(townRoot, rigName string, doltDatabase ...string) error {
+	// Use FindOrCreateRigBeadsDir to atomically resolve and create the directory,
+	// avoiding the TOCTOU race where the directory state changes between
+	// FindRigBeadsDir's Stat check and our subsequent file operations.
+	beadsDir, err := FindOrCreateRigBeadsDir(townRoot, rigName)
+	if err != nil {
+		return fmt.Errorf("resolving beads directory for rig %q: %w", rigName, err)
+	}
+
+	return EnsureMetadataForBeadsDir(townRoot, beadsDir, rigName, doltDatabase...)
+}
+
+// EnsureMetadataForBeadsDir writes or updates metadata.json in a known beads
+// directory. It only writes local config and does not require the Dolt server or
+// database to exist, so callers can leave a recoverable rig behind after partial
+// initialization failures.
+func EnsureMetadataForBeadsDir(townRoot, beadsDir, rigName string, doltDatabase ...string) error {
+	if beadsDir == "" {
+		return fmt.Errorf("beads directory is required")
+	}
+	if rigName == "" {
+		return fmt.Errorf("rig name is required")
+	}
+
 	// Determine the Dolt database name to write when the field is absent.
 	// Default: rigName (correct when db-name == rig-dir-name, e.g. "gastown").
 	// Callers from EnsureAllMetadata pass the actual DB prefix ("at", "be") so
@@ -3145,12 +3168,8 @@ func EnsureMetadata(townRoot, rigName string, doltDatabase ...string) error {
 		effectiveDB = doltDatabase[0]
 	}
 
-	// Use FindOrCreateRigBeadsDir to atomically resolve and create the directory,
-	// avoiding the TOCTOU race where the directory state changes between
-	// FindRigBeadsDir's Stat check and our subsequent file operations.
-	beadsDir, err := FindOrCreateRigBeadsDir(townRoot, rigName)
-	if err != nil {
-		return fmt.Errorf("resolving beads directory for rig %q: %w", rigName, err)
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		return fmt.Errorf("creating beads directory: %w", err)
 	}
 
 	metadataPath := filepath.Join(beadsDir, "metadata.json")

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -1254,6 +1254,11 @@ func (m *Manager) InitBeads(rigPath, prefix, rigName string) error {
 	if err := beads.EnsureConfigYAML(beadsDir, prefix); err != nil {
 		return fmt.Errorf("ensuring config.yaml: %w", err)
 	}
+	if rigName != "" {
+		if err := doltserver.EnsureMetadataForBeadsDir(m.townRoot, beadsDir, rigName, rigName); err != nil {
+			return fmt.Errorf("ensuring metadata.json: %w", err)
+		}
+	}
 
 	// Ensure database has repository fingerprint (GH #25).
 	// This is idempotent - safe on both new and legacy (pre-0.17.5) databases.

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -532,7 +532,7 @@ exit 1
 	t.Setenv("BEADS_DIR_LOG", beadsDirLog)
 
 	manager := &Manager{}
-	if err := manager.InitBeads(rigPath, "gt", ""); err != nil {
+	if err := manager.InitBeads(rigPath, "gt", "testrig"); err != nil {
 		t.Fatalf("initBeads: %v", err)
 	}
 
@@ -544,6 +544,22 @@ exit 1
 	want := "prefix: gt\nissue-prefix: gt\ndolt.idle-timeout: \"0\"\n"
 	if string(config) != want {
 		t.Fatalf("config.yaml = %q, want %q", string(config), want)
+	}
+
+	metadataPath := filepath.Join(beadsDir, "metadata.json")
+	metadataBytes, err := os.ReadFile(metadataPath)
+	if err != nil {
+		t.Fatalf("reading metadata.json: %v", err)
+	}
+	var metadata map[string]interface{}
+	if err := json.Unmarshal(metadataBytes, &metadata); err != nil {
+		t.Fatalf("parsing metadata.json: %v", err)
+	}
+	if metadata["dolt_mode"] != "server" {
+		t.Fatalf("dolt_mode = %v, want server", metadata["dolt_mode"])
+	}
+	if metadata["dolt_database"] != "testrig" {
+		t.Fatalf("dolt_database = %v, want testrig", metadata["dolt_database"])
 	}
 	assertBeadsDirLog(t, beadsDirLog, beadsDir)
 }


### PR DESCRIPTION
## Summary
- Write recoverable Beads metadata even when `bd init` cannot complete.
- Make doctor resolve the active rig beads directory, including root `.beads` layouts.
- Treat Dolt database listing failures as unknown status instead of missing DBs, so `doctor --fix` can still repair local metadata without failing on server reachability.

## Verification
- `go test ./internal/rig`
- `go test ./internal/doctor`