### PR TITLE
fix: detect submitted polecat ghost sessions

### DIFF
--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1212,11 +1212,6 @@ func DetectZombiePolecats(bd *BdCli, workDir, rigName string, router *mail.Route
 				agentState = snap.AgentState
 			}
 			if beads.AgentState(agentState) == AgentStateIdle {
-				if zombie, found := detectSubmittedStillRunning(bd, workDir, polecatName, sessionName, t, polecat.ReadSessionHeartbeat(townRoot, sessionName), snap, witCfg.HeartbeatStartupGraceD()); found {
-					result.Zombies = append(result.Zombies, zombie)
-					continue
-				}
-
 				cleanupStatus := snap.cleanupStatus()
 				if cleanupStatus != "" && cleanupStatus != "clean" {
 					// ZFC (gt-5rne): Report data, don't escalate. The witness agent
@@ -1440,6 +1435,9 @@ func detectSubmittedStillRunning(bd *BdCli, workDir, polecatName, sessionName st
 
 func isSubmittedStillRunningCandidate(snap *agentBeadSnapshot, hb *polecat.SessionHeartbeat, staleThreshold time.Duration) (time.Duration, bool) {
 	if snap == nil || snap.cleanupStatus() != "clean" || !hasSuccessfulSubmissionEvidence(snap) {
+		return 0, false
+	}
+	if beads.AgentState(snap.AgentState) == AgentStateIdle {
 		return 0, false
 	}
 	age := snap.age()

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1080,6 +1080,10 @@ const (
 	// Detected once the session exceeds the HeartbeatStartupGrace threshold.
 	// Flagged for formula-step review; no auto-action (auth errors don't self-heal). (gt-uk7)
 	ZombieNeverHeartbeated ZombieClassification = "never-heartbeated"
+	// ZombieSubmittedStillRunning: gt done submitted work cleanly, but the polecat
+	// session stayed alive with an open hook and no fresh heartbeat. This catches
+	// the post-submit/pre-exit ghost idle gap from GH#3055.
+	ZombieSubmittedStillRunning ZombieClassification = "submitted-still-running"
 )
 
 // ImpliesActiveWork returns true if this classification indicates the polecat
@@ -1208,6 +1212,11 @@ func DetectZombiePolecats(bd *BdCli, workDir, rigName string, router *mail.Route
 				agentState = snap.AgentState
 			}
 			if beads.AgentState(agentState) == AgentStateIdle {
+				if zombie, found := detectSubmittedStillRunning(bd, workDir, polecatName, sessionName, t, polecat.ReadSessionHeartbeat(townRoot, sessionName), snap, witCfg.HeartbeatStartupGraceD()); found {
+					result.Zombies = append(result.Zombies, zombie)
+					continue
+				}
+
 				cleanupStatus := snap.cleanupStatus()
 				if cleanupStatus != "" && cleanupStatus != "clean" {
 					// ZFC (gt-5rne): Report data, don't escalate. The witness agent
@@ -1363,6 +1372,14 @@ func detectZombieLiveSession(bd *BdCli, workDir, townRoot, rigName, polecatName,
 		return zombie, true
 	}
 
+	// GH#3055: gt done can successfully submit work and leave cleanup_status=clean,
+	// but fail before exiting the polecat session. If successful MR evidence exists
+	// and the hook is either gone or still open, nudge the live session to finish
+	// instead of letting it sit idle forever.
+	if zombie, found := detectSubmittedStillRunning(bd, workDir, polecatName, sessionName, t, hb, snap, witCfg.HeartbeatStartupGraceD()); found {
+		return zombie, true
+	}
+
 	// Live session with assigned work but no heartbeat file: agent stuck at startup
 	// (e.g., auth 401 blocking initialization). Once the session is old enough to
 	// have written a first heartbeat and hasn't, flag for formula-step review.
@@ -1384,6 +1401,84 @@ func detectZombieLiveSession(bd *BdCli, workDir, townRoot, rigName, polecatName,
 	}
 
 	return ZombieResult{}, false
+}
+
+func detectSubmittedStillRunning(bd *BdCli, workDir, polecatName, sessionName string, t *tmux.Tmux, hb *polecat.SessionHeartbeat, snap *agentBeadSnapshot, staleThreshold time.Duration) (ZombieResult, bool) {
+	snapState, snapHook := "", ""
+	if snap != nil {
+		snapState, snapHook = snap.AgentState, snap.HookBead
+	}
+	hookStatus := "none"
+	if snapHook != "" {
+		hookSt, hookOk := getBeadStatus(bd, workDir, snapHook)
+		if !hookOk || !isOpenHookStatus(hookSt) {
+			return ZombieResult{}, false
+		}
+		hookStatus = hookSt
+	}
+	age, shouldNudge := isSubmittedStillRunningCandidate(snap, hb, staleThreshold)
+	if !shouldNudge {
+		return ZombieResult{}, false
+	}
+
+	zombie := ZombieResult{
+		PolecatName:    polecatName,
+		AgentState:     snapState,
+		Classification: ZombieSubmittedStillRunning,
+		HookBead:       snapHook,
+		CleanupStatus:  snap.cleanupStatus(),
+		WasActive:      false,
+		Action:         fmt.Sprintf("nudged-exit-submitted-session (idle=%v, hook_status=%s)", age.Round(time.Second), hookStatus),
+	}
+	msg := fmt.Sprintf("RECOVERY_NEEDED: gt done appears submitted (hook=%s, cleanup_status=clean), but this session is still running with no fresh heartbeat for %v. If work is already submitted, exit now; otherwise run gt done again.", hookStatusForNudge(snapHook), age.Round(time.Second))
+	if err := t.NudgeSession(sessionName, msg); err != nil {
+		zombie.Error = err
+		zombie.Action = fmt.Sprintf("nudge-exit-submitted-session-failed: %v", err)
+	}
+	return zombie, true
+}
+
+func isSubmittedStillRunningCandidate(snap *agentBeadSnapshot, hb *polecat.SessionHeartbeat, staleThreshold time.Duration) (time.Duration, bool) {
+	if snap == nil || snap.cleanupStatus() != "clean" || !hasSuccessfulSubmissionEvidence(snap) {
+		return 0, false
+	}
+	age := snap.age()
+	if hb != nil {
+		age = time.Since(hb.Timestamp)
+	}
+	return age, age >= staleThreshold
+}
+
+func hookStatusForNudge(hookBead string) string {
+	if hookBead == "" {
+		return "none"
+	}
+	return hookBead
+}
+
+func isOpenHookStatus(status string) bool {
+	switch status {
+	case "open", "hooked", "in_progress":
+		return true
+	default:
+		return false
+	}
+}
+
+func hasSuccessfulSubmissionEvidence(snap *agentBeadSnapshot) bool {
+	if snap == nil {
+		return false
+	}
+	if snap.Fields != nil && (snap.Fields.MRFailed || snap.Fields.PushFailed) {
+		return false
+	}
+	if snap.ActiveMR != "" {
+		return true
+	}
+	if snap.Fields == nil {
+		return false
+	}
+	return snap.Fields.ActiveMR != "" || snap.Fields.MRID != ""
 }
 
 // detectZombieDeadSession checks a polecat with a dead tmux session for zombie indicators:
@@ -1792,7 +1887,7 @@ type CompletionDiscovery struct {
 	MRID           string
 	Branch         string
 	MRFailed       bool
-	PushFailed     bool   // True when branch push to origin failed (gas-556)
+	PushFailed     bool // True when branch push to origin failed (gas-556)
 	CompletionTime string
 	Action         string // What was done: "merge-ready-sent", "acknowledged-idle", "phase-complete"
 	WispCreated    string // ID of cleanup wisp if created
@@ -1970,12 +2065,12 @@ func processDiscoveredCompletion(bd *BdCli, workDir, rigName string, payload *Po
 // Used to avoid redundant subprocess invocations during zombie detection, where the same
 // agent bead was previously queried 3-5 times per polecat per patrol cycle. (gt-2gra)
 type agentBeadSnapshot struct {
-	AgentState  string
-	HookBead    string
-	Labels      []string
-	UpdatedAt   string
-	ActiveMR    string
-	Fields      *beads.AgentFields // parsed from description
+	AgentState string
+	HookBead   string
+	Labels     []string
+	UpdatedAt  string
+	ActiveMR   string
+	Fields     *beads.AgentFields // parsed from description
 }
 
 // fetchAgentBeadSnapshot fetches all agent bead data in a single bd show call.
@@ -2158,13 +2253,13 @@ func getBeadStatus(bd *BdCli, workDir, beadID string) (string, bool) {
 
 // resetAbandonedBead resets a dead polecat's hooked bead so it can be re-dispatched.
 // If the bead is in "hooked" or "in_progress" status, it:
-// 0. Checks if the polecat's work is already on main — if so, closes
-//    the bead instead of resetting (prevents re-dispatch of completed work)
-// 1. Records the respawn in the witness spawn-count ledger
-// 2. Resets status to open
-// 3. Clears assignee
-// 4. Sends mail to deacon for re-dispatch (includes respawn count; SPAWN_STORM
-//    prefix and Urgent priority when count exceeds max bead respawns config)
+//  0. Checks if the polecat's work is already on main — if so, closes
+//     the bead instead of resetting (prevents re-dispatch of completed work)
+//  1. Records the respawn in the witness spawn-count ledger
+//  2. Resets status to open
+//  3. Clears assignee
+//  4. Sends mail to deacon for re-dispatch (includes respawn count; SPAWN_STORM
+//     prefix and Urgent priority when count exceeds max bead respawns config)
 //
 // Returns true if the bead was recovered.
 func resetAbandonedBead(bd *BdCli, workDir, rigName, hookBead, polecatName string, router *mail.Router) bool {

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -1902,6 +1902,12 @@ func TestSubmittedStillRunningCandidate(t *testing.T) {
 		t.Error("no-hook submitted sessions must still be treated as submitted still-running")
 	}
 
+	idleSnap := *baseSnap
+	idleSnap.AgentState = string(beads.AgentStateIdle)
+	if _, ok := isSubmittedStillRunningCandidate(&idleSnap, staleHB, config.DefaultWitnessHeartbeatStartupGrace); ok {
+		t.Error("normal idle polecats with submitted MR metadata must not be treated as submitted still-running")
+	}
+
 	freshHB := &polecat.SessionHeartbeat{
 		Timestamp: time.Now(),
 		State:     polecat.HeartbeatWorking,

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -1705,7 +1705,6 @@ func TestClearCompletionMetadata_NoBd(t *testing.T) {
 	}
 }
 
-
 // --- Heartbeat v2 tests (gt-3vr5) ---
 
 func TestHeartbeatV2_ExitingStateSkipsZombieDetection(t *testing.T) {
@@ -1872,6 +1871,100 @@ func TestZombieNeverHeartbeated_Classification(t *testing.T) {
 	if !shouldNotFlag {
 		t.Errorf("expected no flag for session age=%v, threshold=%v",
 			time.Since(newSession).Round(time.Second), config.DefaultWitnessHeartbeatStartupGrace)
+	}
+}
+
+func TestSubmittedStillRunningCandidate(t *testing.T) {
+	t.Parallel()
+
+	baseSnap := &agentBeadSnapshot{
+		AgentState: string(beads.AgentStateDone),
+		HookBead:   "gt-work-123",
+		UpdatedAt:  time.Now().Add(-10 * time.Minute).Format(time.RFC3339),
+		Fields: &beads.AgentFields{
+			CleanupStatus: "clean",
+			MRID:          "gt-mr-123",
+		},
+	}
+	staleHB := &polecat.SessionHeartbeat{
+		Timestamp: time.Now().Add(-10 * time.Minute),
+		State:     polecat.HeartbeatWorking,
+	}
+
+	age, ok := isSubmittedStillRunningCandidate(baseSnap, staleHB, config.DefaultWitnessHeartbeatStartupGrace)
+	if !ok {
+		t.Fatalf("expected submitted still-running candidate, age=%v", age)
+	}
+
+	noHookSnap := *baseSnap
+	noHookSnap.HookBead = ""
+	if _, ok := isSubmittedStillRunningCandidate(&noHookSnap, staleHB, config.DefaultWitnessHeartbeatStartupGrace); !ok {
+		t.Error("no-hook submitted sessions must still be treated as submitted still-running")
+	}
+
+	freshHB := &polecat.SessionHeartbeat{
+		Timestamp: time.Now(),
+		State:     polecat.HeartbeatWorking,
+	}
+	if _, ok := isSubmittedStillRunningCandidate(baseSnap, freshHB, config.DefaultWitnessHeartbeatStartupGrace); ok {
+		t.Error("fresh heartbeat must not be treated as submitted still-running")
+	}
+
+	dirtySnap := *baseSnap
+	dirtyFields := *baseSnap.Fields
+	dirtyFields.CleanupStatus = "has_uncommitted"
+	dirtySnap.Fields = &dirtyFields
+	if _, ok := isSubmittedStillRunningCandidate(&dirtySnap, staleHB, config.DefaultWitnessHeartbeatStartupGrace); ok {
+		t.Error("dirty cleanup status must not be treated as safe submitted still-running")
+	}
+
+	noSubmitSnap := *baseSnap
+	noSubmitSnap.AgentState = string(beads.AgentStateWorking)
+	noSubmitSnap.ActiveMR = ""
+	noSubmitSnap.Fields = &beads.AgentFields{CleanupStatus: "clean"}
+	if _, ok := isSubmittedStillRunningCandidate(&noSubmitSnap, staleHB, config.DefaultWitnessHeartbeatStartupGrace); ok {
+		t.Error("open hooked work without submission evidence must not be treated as submitted still-running")
+	}
+
+	completedOnlySnap := *baseSnap
+	completedOnlySnap.ActiveMR = ""
+	completedOnlySnap.Fields = &beads.AgentFields{
+		CleanupStatus:  "clean",
+		ExitType:       string(ExitTypeCompleted),
+		CompletionTime: time.Now().Format(time.RFC3339),
+	}
+	if _, ok := isSubmittedStillRunningCandidate(&completedOnlySnap, staleHB, config.DefaultWitnessHeartbeatStartupGrace); ok {
+		t.Error("COMPLETED metadata alone must not be treated as successful submission evidence")
+	}
+
+	failedSubmitSnap := *baseSnap
+	failedSubmitSnap.Fields = &beads.AgentFields{
+		CleanupStatus: "clean",
+		MRID:          "gt-mr-123",
+		MRFailed:      true,
+	}
+	if _, ok := isSubmittedStillRunningCandidate(&failedSubmitSnap, staleHB, config.DefaultWitnessHeartbeatStartupGrace); ok {
+		t.Error("failed MR submission must not be treated as successful submission evidence")
+	}
+
+	pushFailedSnap := *baseSnap
+	pushFailedSnap.Fields = &beads.AgentFields{
+		CleanupStatus: "clean",
+		MRID:          "gt-mr-123",
+		PushFailed:    true,
+	}
+	if _, ok := isSubmittedStillRunningCandidate(&pushFailedSnap, staleHB, config.DefaultWitnessHeartbeatStartupGrace); ok {
+		t.Error("failed push must not be treated as successful submission evidence")
+	}
+}
+
+func TestZombieSubmittedStillRunning_Classification(t *testing.T) {
+	t.Parallel()
+	if ZombieSubmittedStillRunning != "submitted-still-running" {
+		t.Errorf("ZombieSubmittedStillRunning = %q, want %q", ZombieSubmittedStillRunning, "submitted-still-running")
+	}
+	if ZombieSubmittedStillRunning.ImpliesActiveWork() {
+		t.Error("ZombieSubmittedStillRunning should be classified as orphan/submitted idle, not active failed work")
 	}
 }
 

--- a/internal/witness/mountain.go
+++ b/internal/witness/mountain.go
@@ -75,6 +75,10 @@ func trackConvoyFailures(bd *BdCli, workDir string, result *DetectZombiePolecats
 }
 
 func zombieImpliesActiveFailure(zombie ZombieResult) bool {
+	switch zombie.Classification {
+	case ZombieBeadClosedStillRunning, ZombieSubmittedStillRunning:
+		return false
+	}
 	if zombie.Classification != "" {
 		return zombie.Classification.ImpliesActiveWork()
 	}

--- a/internal/witness/mountain.go
+++ b/internal/witness/mountain.go
@@ -40,10 +40,11 @@ func trackConvoyFailures(bd *BdCli, workDir string, result *DetectZombiePolecats
 	for i := range result.Zombies {
 		zombie := &result.Zombies[i]
 
-		// Only track failures for zombies that had active work on an issue
-		// and didn't complete it. ZombieBeadClosedStillRunning means the work
-		// WAS completed — don't count that as a failure.
-		if zombie.HookBead == "" || zombie.Classification == ZombieBeadClosedStillRunning {
+		// Only track failures for zombies that had active work on an issue and
+		// didn't complete it. Submitted/orphan cleanup states can still carry a
+		// hook_bead for traceability, but they must not increment mountain failure
+		// counts.
+		if zombie.HookBead == "" || !zombieImpliesActiveFailure(*zombie) {
 			continue
 		}
 
@@ -71,6 +72,13 @@ func trackConvoyFailures(bd *BdCli, workDir string, result *DetectZombiePolecats
 
 		result.ConvoyFailures = append(result.ConvoyFailures, *cfr)
 	}
+}
+
+func zombieImpliesActiveFailure(zombie ZombieResult) bool {
+	if zombie.Classification != "" {
+		return zombie.Classification.ImpliesActiveWork()
+	}
+	return zombie.WasActive
 }
 
 // TrackConvoyFailure checks if an issue belongs to a convoy and tracks the

--- a/internal/witness/mountain_test.go
+++ b/internal/witness/mountain_test.go
@@ -63,10 +63,10 @@ func TestHasLabel(t *testing.T) {
 // execResponses maps "command args" to (output, error) pairs.
 // runResponses maps "command args" to error.
 type mockBdResponses struct {
-	execCalls    []string
-	runCalls     []string
-	execResults  map[string]mockExecResult
-	runResults   map[string]error
+	execCalls   []string
+	runCalls    []string
+	execResults map[string]mockExecResult
+	runResults  map[string]error
 }
 
 type mockExecResult struct {
@@ -336,6 +336,13 @@ func TestTrackConvoyFailures_Integration(t *testing.T) {
 				Classification: ZombieAgentDeadInSession,
 				HookBead:       "",
 			},
+			{
+				// Submitted/orphan cleanup — should NOT be tracked as a failure
+				PolecatName:    "delta",
+				Classification: ZombieSubmittedStillRunning,
+				HookBead:       "gt-task-d",
+				WasActive:      false,
+			},
 		},
 	}
 
@@ -345,7 +352,7 @@ func TestTrackConvoyFailures_Integration(t *testing.T) {
 
 	trackConvoyFailures(mock.toBdCli(), "/tmp", result)
 
-	// Should have queried only gt-task-a (not gt-task-b or empty)
+	// Should have queried only gt-task-a (not gt-task-b, empty, or submitted idle)
 	if len(mock.execCalls) != 1 {
 		t.Errorf("expected 1 exec call, got %d: %v", len(mock.execCalls), mock.execCalls)
 	}


### PR DESCRIPTION
## Summary
- Detect live polecat sessions that successfully submitted work but failed to exit, including no-hook ghost idle cases.
- Require successful MR evidence and clean cleanup status so failed push/MR/no-MQ completions are not treated as submitted.
- Classify submitted-still-running as orphan/submitted idle rather than failed active work.

## Test plan
- go test ./internal/witness
- go test ./internal/cmd -run 'TestPatrolScan|TestBuildWitness|TestRunPatrolNew|TestWitness' -count=1

Fixes #3055