### PR TITLE
fix: handle empty rig repos without masking bad refs

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1198,6 +1198,17 @@ func (g *Git) ListRemoteRefs(remote, prefix string) ([]string, error) {
 	return refs, nil
 }
 
+// RemoteHasRefs reports whether a remote has any refs at all. It deliberately
+// includes tags so callers can distinguish a truly empty repo from a non-empty
+// repo with no branch refs or a broken remote HEAD.
+func (g *Git) RemoteHasRefs(remote string) (bool, error) {
+	out, err := g.run("ls-remote", "--refs", remote)
+	if err != nil {
+		return false, err
+	}
+	return strings.TrimSpace(out) != "", nil
+}
+
 // ListPushRemoteRefs lists remote refs from the push URL when it differs from
 // the fetch URL. With a fork-based workflow (pushurl configured), branches are
 // pushed to the fork but ls-remote reads from the fetch URL (upstream). This

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -427,6 +427,21 @@ func configureRefspec(repoPath string, singleBranch bool) error {
 		return fmt.Errorf("configuring refspec: %s", strings.TrimSpace(stderr.String()))
 	}
 
+	// Empty remotes clone successfully but have no refs to fetch. Let callers
+	// perform their own empty-repository validation instead of returning a
+	// misleading "couldn't find remote ref" error from the fetch below.
+	var refsStderr bytes.Buffer
+	refsCmd := exec.Command("git", "--git-dir", gitDir, "show-ref", "--quiet")
+	util.SetDetachedProcessGroup(refsCmd)
+	refsCmd.Stderr = &refsStderr
+	if err := refsCmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) && exitErr.ExitCode() == 1 {
+			return nil
+		}
+		return fmt.Errorf("checking refs: %s", strings.TrimSpace(refsStderr.String()))
+	}
+
 	if singleBranch {
 		// For shallow single-branch clones, fetch only the HEAD branch to create
 		// the origin/<branch> ref that worktrees need. A full `git fetch origin`

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -569,6 +569,34 @@ func TestCloneBareHasOriginRefs(t *testing.T) {
 	}
 }
 
+func TestCloneBareEmptyRepoSkipsMissingHeadFetch(t *testing.T) {
+	tmp := t.TempDir()
+	remoteDir := filepath.Join(tmp, "remote")
+	if err := os.MkdirAll(remoteDir, 0755); err != nil {
+		t.Fatalf("mkdir remote: %v", err)
+	}
+	cmd := exec.Command("git", "init")
+	cmd.Dir = remoteDir
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	bareDir := filepath.Join(tmp, "bare.git")
+	g := NewGit(tmp)
+	if err := g.CloneBare(remoteDir, bareDir); err != nil {
+		t.Fatalf("CloneBare empty repo: %v", err)
+	}
+
+	bareGit := NewGitWithDir(bareDir, "")
+	empty, err := bareGit.IsEmpty()
+	if err != nil {
+		t.Fatalf("IsEmpty: %v", err)
+	}
+	if !empty {
+		t.Error("expected bare clone of empty repo to be empty")
+	}
+}
+
 func TestIsEmpty_EmptyRepo(t *testing.T) {
 	dir := t.TempDir()
 	cmd := exec.Command("git", "init")

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -446,7 +446,14 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 		return m.git.CloneBareWithBranch(opts.GitURL, bareRepoPath, branch)
 	}
 
+	emptyRepoError := func() error {
+		return fmt.Errorf("repository %s is empty (no commits). Push at least one commit before adding it as a rig", opts.GitURL)
+	}
+
 	if err := cloneBareWith(opts.DefaultBranch); err != nil {
+		if hasRefs, refsErr := m.git.RemoteHasRefs(opts.GitURL); refsErr == nil && !hasRefs {
+			return nil, emptyRepoError()
+		}
 		return nil, wrapCloneError(err, opts.GitURL)
 	}
 	if opts.CloneFilter != "" {
@@ -462,7 +469,14 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 	if empty, err := bareGit.IsEmpty(); err != nil {
 		return nil, fmt.Errorf("checking if repository is empty: %w", err)
 	} else if empty {
-		return nil, fmt.Errorf("repository %s is empty (no commits). Push at least one commit before adding it as a rig", opts.GitURL)
+		hasRefs, refsErr := m.git.RemoteHasRefs(opts.GitURL)
+		if refsErr != nil {
+			return nil, fmt.Errorf("checking if repository is empty: %w", refsErr)
+		}
+		if !hasRefs {
+			return nil, emptyRepoError()
+		}
+		return nil, fmt.Errorf("repository %s has refs, but no default branch could be cloned. Ensure the remote HEAD points to a branch, or pass --branch <branch>", opts.GitURL)
 	}
 
 	// Configure push URL if provided (for read-only upstream repos)

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -326,6 +326,40 @@ func TestAddRig_RejectsInvalidNames(t *testing.T) {
 	}
 }
 
+func TestAddRig_EmptyRepositoryReturnsFriendlyError(t *testing.T) {
+	root, rigsConfig := setupTestTown(t)
+	remoteDir := filepath.Join(t.TempDir(), "empty-remote")
+	if err := os.MkdirAll(remoteDir, 0755); err != nil {
+		t.Fatalf("mkdir remote: %v", err)
+	}
+	cmd := exec.Command("git", "init")
+	cmd.Dir = remoteDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+
+	manager := NewManager(root, rigsConfig, git.NewGit(root))
+	_, err := manager.AddRig(AddRigOptions{
+		Name:          "emptyrepo",
+		GitURL:        remoteDir,
+		BeadsPrefix:   "er",
+		SkipDoltCheck: true,
+	})
+	if err == nil {
+		t.Fatal("AddRig succeeded, want empty repository error")
+	}
+	want := fmt.Sprintf("repository %s is empty (no commits). Push at least one commit before adding it as a rig", remoteDir)
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("AddRig error = %q, want containing %q", err.Error(), want)
+	}
+	if strings.Contains(err.Error(), "couldn't find remote ref") {
+		t.Fatalf("AddRig surfaced low-level fetch error: %q", err.Error())
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "emptyrepo")); !os.IsNotExist(statErr) {
+		t.Fatalf("expected failed rig directory to be removed, stat err = %v", statErr)
+	}
+}
+
 func TestListRigNames(t *testing.T) {
 	root, rigsConfig := setupTestTown(t)
 	rigsConfig.Rigs["rig1"] = config.RigEntry{}

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -360,6 +360,108 @@ func TestAddRig_EmptyRepositoryReturnsFriendlyError(t *testing.T) {
 	}
 }
 
+func TestAddRig_EmptyRepositoryWithBranchReturnsFriendlyError(t *testing.T) {
+	root, rigsConfig := setupTestTown(t)
+	remoteDir := filepath.Join(t.TempDir(), "empty-remote")
+	if err := os.MkdirAll(remoteDir, 0755); err != nil {
+		t.Fatalf("mkdir remote: %v", err)
+	}
+	cmd := exec.Command("git", "init")
+	cmd.Dir = remoteDir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init: %v\n%s", err, out)
+	}
+
+	manager := NewManager(root, rigsConfig, git.NewGit(root))
+	_, err := manager.AddRig(AddRigOptions{
+		Name:          "emptybranchrepo",
+		GitURL:        remoteDir,
+		BeadsPrefix:   "ebr",
+		DefaultBranch: "main",
+		SkipDoltCheck: true,
+	})
+	if err == nil {
+		t.Fatal("AddRig succeeded, want empty repository error")
+	}
+	want := fmt.Sprintf("repository %s is empty (no commits). Push at least one commit before adding it as a rig", remoteDir)
+	if !strings.Contains(err.Error(), want) {
+		t.Fatalf("AddRig error = %q, want containing %q", err.Error(), want)
+	}
+	if strings.Contains(err.Error(), "Remote branch main not found") {
+		t.Fatalf("AddRig surfaced low-level clone error: %q", err.Error())
+	}
+}
+
+func TestAddRig_NonEmptyRepositoryWithBadHeadIsNotReportedAsEmpty(t *testing.T) {
+	root, rigsConfig := setupTestTown(t)
+	tmp := t.TempDir()
+	remoteDir := filepath.Join(tmp, "remote.git")
+	workDir := filepath.Join(tmp, "work")
+	for _, args := range [][]string{
+		{"git", "init", "--bare", "--initial-branch=main", remoteDir},
+		{"git", "clone", remoteDir, workDir},
+		{"git", "-C", workDir, "config", "user.email", "test@test.com"},
+		{"git", "-C", workDir, "config", "user.name", "Test User"},
+		{"git", "-C", workDir, "commit", "--allow-empty", "-m", "init"},
+		{"git", "-C", workDir, "push", "origin", "HEAD:refs/heads/main"},
+		{"git", "--git-dir", remoteDir, "symbolic-ref", "HEAD", "refs/heads/missing"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	manager := NewManager(root, rigsConfig, git.NewGit(root))
+	_, err := manager.AddRig(AddRigOptions{
+		Name:          "badheadrepo",
+		GitURL:        remoteDir,
+		BeadsPrefix:   "bhr",
+		SkipDoltCheck: true,
+	})
+	if err == nil {
+		t.Fatal("AddRig succeeded, want bad remote HEAD error")
+	}
+	if strings.Contains(err.Error(), "is empty") {
+		t.Fatalf("AddRig reported non-empty bad-HEAD repo as empty: %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "has refs, but no default branch could be cloned") {
+		t.Fatalf("AddRig error = %q, want bad remote HEAD diagnostic", err.Error())
+	}
+}
+
+func TestAddRig_TagOnlyRepositoryIsNotReportedAsEmpty(t *testing.T) {
+	root, rigsConfig := setupTestTown(t)
+	repoDir := filepath.Join(t.TempDir(), "tag-only")
+	for _, args := range [][]string{
+		{"git", "init", "--initial-branch=main", repoDir},
+		{"git", "-C", repoDir, "config", "user.email", "test@test.com"},
+		{"git", "-C", repoDir, "config", "user.name", "Test User"},
+		{"git", "-C", repoDir, "commit", "--allow-empty", "-m", "init"},
+		{"git", "-C", repoDir, "tag", "v1"},
+		{"git", "-C", repoDir, "update-ref", "-d", "refs/heads/main"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	manager := NewManager(root, rigsConfig, git.NewGit(root))
+	_, err := manager.AddRig(AddRigOptions{
+		Name:          "tagonlyrepo",
+		GitURL:        repoDir,
+		BeadsPrefix:   "tor",
+		SkipDoltCheck: true,
+	})
+	if err == nil {
+		t.Fatal("AddRig succeeded, want no branch error")
+	}
+	if strings.Contains(err.Error(), "is empty") {
+		t.Fatalf("AddRig reported tag-only repo as empty: %q", err.Error())
+	}
+}
+
 func TestListRigNames(t *testing.T) {
 	root, rigsConfig := setupTestTown(t)
 	rigsConfig.Rigs["rig1"] = config.RigEntry{}


### PR DESCRIPTION
## Summary

- Preserve the friendly empty-repository error when `gt rig add --branch` targets a repo with no refs.
- Distinguish truly empty repos from non-empty remotes with broken HEADs or tag-only refs.
- Add regression coverage for empty explicit-branch, bad-HEAD, and tag-only remotes.

## Test plan

- `go test ./internal/git ./internal/rig`

Fixes #3054.