### PR TITLE
fix(web): prevent convoy fetch failure storms

### DIFF
--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -99,20 +99,30 @@ type fetchCircuitBreaker struct {
 	failures    int
 	lastAttempt time.Time
 	backoff     time.Duration
+	inFlight    bool
 }
 
 // maxBackoff is the maximum backoff duration for the circuit breaker.
 const maxBackoff = 5 * time.Minute
 
 // allow returns true if enough time has passed since the last failure to permit
-// a new attempt. Always allows the first attempt (zero failures).
+// a new attempt, and reserves that attempt so concurrent callers do not all
+// stampede through when backoff opens.
 func (cb *fetchCircuitBreaker) allow() bool {
 	cb.mu.Lock()
 	defer cb.mu.Unlock()
+	if cb.inFlight {
+		return false
+	}
 	if cb.failures == 0 {
+		cb.inFlight = true
 		return true
 	}
-	return time.Since(cb.lastAttempt) >= cb.backoff
+	if time.Since(cb.lastAttempt) < cb.backoff {
+		return false
+	}
+	cb.inFlight = true
+	return true
 }
 
 // recordFailure increments the failure count and sets exponential backoff.
@@ -122,6 +132,7 @@ func (cb *fetchCircuitBreaker) recordFailure() {
 	defer cb.mu.Unlock()
 	cb.failures++
 	cb.lastAttempt = time.Now()
+	cb.inFlight = false
 	// Exponential backoff: 10s, 20s, 40s, 80s, 160s, capped at maxBackoff
 	cb.backoff = time.Duration(1<<min(cb.failures, 10)) * 5 * time.Second
 	if cb.backoff > maxBackoff {
@@ -135,6 +146,7 @@ func (cb *fetchCircuitBreaker) recordSuccess() {
 	defer cb.mu.Unlock()
 	cb.failures = 0
 	cb.backoff = 0
+	cb.inFlight = false
 }
 
 // LiveConvoyFetcher fetches convoy data from beads.
@@ -239,6 +251,7 @@ func (f *LiveConvoyFetcher) FetchConvoys() ([]ConvoyRow, error) {
 		CreatedAt string `json:"created_at"`
 	}
 	if err := json.Unmarshal(stdout.Bytes(), &convoys); err != nil {
+		f.convoyBreaker.recordFailure()
 		return nil, fmt.Errorf("parsing convoy list: %w", err)
 	}
 

--- a/internal/web/fetcher_test.go
+++ b/internal/web/fetcher_test.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -573,6 +574,112 @@ esac
 			t.Fatalf("expected timeout error, got: %v", err)
 		}
 	})
+}
+
+func TestFetchConvoysBreakerBacksOffAfterBdFailures(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-based command test")
+	}
+
+	tests := []struct {
+		name   string
+		script string
+	}{
+		{
+			name: "nonzero exit",
+			script: `#!/bin/sh
+printf x >> "$0.count"
+exit 1
+`,
+		},
+		{
+			name: "invalid JSON",
+			script: `#!/bin/sh
+printf x >> "$0.count"
+printf '{invalid'
+exit 0
+`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			bdPath := filepath.Join(t.TempDir(), "bd")
+			if err := os.WriteFile(bdPath, []byte(tt.script), 0o755); err != nil {
+				t.Fatalf("write fake bd: %v", err)
+			}
+
+			f := &LiveConvoyFetcher{townRoot: t.TempDir(), cmdTimeout: 5 * time.Second, bdBin: bdPath}
+			if _, err := f.FetchConvoys(); err == nil {
+				t.Fatal("expected first FetchConvoys call to fail")
+			}
+
+			if _, err := f.FetchConvoys(); err != nil {
+				t.Fatalf("expected immediate retry to be backed off silently, got: %v", err)
+			}
+
+			countBytes, err := os.ReadFile(bdPath + ".count")
+			if err != nil {
+				t.Fatalf("read fake bd call count: %v", err)
+			}
+			if got := len(countBytes); got != 1 {
+				t.Fatalf("fake bd calls = %d, want 1", got)
+			}
+		})
+	}
+}
+
+func TestFetchConvoysBreakerPreventsConcurrentStampede(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-based command test")
+	}
+
+	bdPath := filepath.Join(t.TempDir(), "bd")
+	script := `#!/bin/sh
+printf x >> "$0.count"
+sleep 0.2
+printf '{invalid'
+exit 0
+`
+	if err := os.WriteFile(bdPath, []byte(script), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+
+	f := &LiveConvoyFetcher{townRoot: t.TempDir(), cmdTimeout: 5 * time.Second, bdBin: bdPath}
+	start := make(chan struct{})
+	var wg sync.WaitGroup
+	errCh := make(chan error, 8)
+	for i := 0; i < 8; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			<-start
+			_, err := f.FetchConvoys()
+			errCh <- err
+		}()
+	}
+
+	close(start)
+	wg.Wait()
+	close(errCh)
+
+	errCount := 0
+	for err := range errCh {
+		if err != nil {
+			errCount++
+		}
+	}
+	if errCount != 1 {
+		t.Fatalf("FetchConvoys errors = %d, want 1; backed-off callers should return nil", errCount)
+	}
+
+	countBytes, err := os.ReadFile(bdPath + ".count")
+	if err != nil {
+		t.Fatalf("read fake bd call count: %v", err)
+	}
+	if got := len(countBytes); got != 1 {
+		t.Fatalf("fake bd calls = %d, want 1", got)
+	}
 }
 
 func withMayorFetcherHooks(t *testing.T, sessionEnv func(sessionName, key string) (string, error), runCmdFunc func(time.Duration, string, ...string) (*bytes.Buffer, error)) {

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -808,7 +808,7 @@ func TestE2E_Server_MergeQueueEmpty(t *testing.T) {
 	mock := &MockConvoyFetcher{
 		Convoys:    []ConvoyRow{},
 		MergeQueue: []MergeQueueRow{},
-		Workers:   []WorkerRow{},
+		Workers:    []WorkerRow{},
 	}
 
 	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
@@ -1207,19 +1207,19 @@ func (m *CountingMockFetcher) FetchConvoys() ([]ConvoyRow, error) {
 func (m *CountingMockFetcher) FetchMergeQueue() ([]MergeQueueRow, error) {
 	return m.inner.FetchMergeQueue()
 }
-func (m *CountingMockFetcher) FetchWorkers() ([]WorkerRow, error)       { return m.inner.FetchWorkers() }
-func (m *CountingMockFetcher) FetchMail() ([]MailRow, error)            { return m.inner.FetchMail() }
-func (m *CountingMockFetcher) FetchRigs() ([]RigRow, error)             { return m.inner.FetchRigs() }
-func (m *CountingMockFetcher) FetchDogs() ([]DogRow, error)             { return m.inner.FetchDogs() }
+func (m *CountingMockFetcher) FetchWorkers() ([]WorkerRow, error) { return m.inner.FetchWorkers() }
+func (m *CountingMockFetcher) FetchMail() ([]MailRow, error)      { return m.inner.FetchMail() }
+func (m *CountingMockFetcher) FetchRigs() ([]RigRow, error)       { return m.inner.FetchRigs() }
+func (m *CountingMockFetcher) FetchDogs() ([]DogRow, error)       { return m.inner.FetchDogs() }
 func (m *CountingMockFetcher) FetchEscalations() ([]EscalationRow, error) {
 	return m.inner.FetchEscalations()
 }
-func (m *CountingMockFetcher) FetchHealth() (*HealthRow, error)    { return m.inner.FetchHealth() }
-func (m *CountingMockFetcher) FetchQueues() ([]QueueRow, error)    { return m.inner.FetchQueues() }
+func (m *CountingMockFetcher) FetchHealth() (*HealthRow, error)     { return m.inner.FetchHealth() }
+func (m *CountingMockFetcher) FetchQueues() ([]QueueRow, error)     { return m.inner.FetchQueues() }
 func (m *CountingMockFetcher) FetchSessions() ([]SessionRow, error) { return m.inner.FetchSessions() }
-func (m *CountingMockFetcher) FetchHooks() ([]HookRow, error)      { return m.inner.FetchHooks() }
-func (m *CountingMockFetcher) FetchMayor() (*MayorStatus, error)   { return m.inner.FetchMayor() }
-func (m *CountingMockFetcher) FetchIssues() ([]IssueRow, error)    { return m.inner.FetchIssues() }
+func (m *CountingMockFetcher) FetchHooks() ([]HookRow, error)       { return m.inner.FetchHooks() }
+func (m *CountingMockFetcher) FetchMayor() (*MayorStatus, error)    { return m.inner.FetchMayor() }
+func (m *CountingMockFetcher) FetchIssues() ([]IssueRow, error)     { return m.inner.FetchIssues() }
 func (m *CountingMockFetcher) FetchActivity() ([]ActivityRow, error) {
 	return m.inner.FetchActivity()
 }
@@ -1263,6 +1263,9 @@ func TestFetchCircuitBreaker(t *testing.T) {
 	// Initially allowed
 	if !cb.allow() {
 		t.Fatal("circuit breaker should allow first attempt")
+	}
+	if cb.allow() {
+		t.Fatal("circuit breaker should reserve the in-flight attempt")
 	}
 
 	// Record a failure — should block immediate retry

--- a/internal/web/handler_test.go
+++ b/internal/web/handler_test.go
@@ -1194,6 +1194,43 @@ func TestConvoyHandler_CacheBypassOnExpand(t *testing.T) {
 	}
 }
 
+func TestConvoyHandler_ExpandCachePreventsRepeatedFetchConvoysErrors(t *testing.T) {
+	fetchCount := 0
+	mock := &CountingMockFetcher{
+		inner:      &MockConvoyFetcher{Error: errFetchFailed},
+		fetchCount: &fetchCount,
+	}
+
+	handler, err := NewConvoyHandler(mock, 8*time.Second, "test-token")
+	if err != nil {
+		t.Fatalf("NewConvoyHandler() error = %v", err)
+	}
+	handler.cacheTTL = 5 * time.Second
+
+	req1 := httptest.NewRequest("GET", "/?expand=convoys", nil)
+	w1 := httptest.NewRecorder()
+	handler.ServeHTTP(w1, req1)
+	if w1.Code != http.StatusOK {
+		t.Fatalf("First expand request status = %d, want 200", w1.Code)
+	}
+	if fetchCount != 1 {
+		t.Fatalf("After first expand request, fetchCount = %d, want 1", fetchCount)
+	}
+
+	req2 := httptest.NewRequest("GET", "/?expand=convoys", nil)
+	w2 := httptest.NewRecorder()
+	handler.ServeHTTP(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("Second expand request status = %d, want 200", w2.Code)
+	}
+	if fetchCount != 1 {
+		t.Fatalf("Second expand request should use cached error response; fetchCount = %d, want 1", fetchCount)
+	}
+	if w1.Body.String() != w2.Body.String() {
+		t.Fatal("Cached expand error response should match original response")
+	}
+}
+
 // CountingMockFetcher wraps a ConvoyFetcher and counts FetchConvoys calls.
 type CountingMockFetcher struct {
 	inner      ConvoyFetcher


### PR DESCRIPTION
## Summary
- Serialize `FetchConvoys` circuit-breaker attempts so only one retry can run when backoff opens.
- Treat invalid convoy JSON as a breaker failure, matching bd command failures.
- Add coverage for expanded-view error caching, bd failure backoff, invalid JSON backoff, and concurrent stampede prevention.

## Test plan
- `go test ./internal/web`
- `make build`

Refs #3117