### PR TITLE
fix: warn when gt install is shadowed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build desktop-build desktop-run install safe-install check-forward-only check-version-tag clean test test-e2e-container check-up-to-date
+.PHONY: build desktop-build desktop-run install safe-install check-forward-only check-version-tag check-install-path clean test test-e2e-container check-up-to-date
 
 BINARY := gt
 BINARY_DESKTOP := gt-desktop
@@ -91,6 +91,14 @@ ifndef SKIP_FORWARD_CHECK
 	fi
 endif
 
+check-install-path:
+	@resolved=$$(command -v $(BINARY) 2>/dev/null || true); \
+	if [ "$$resolved" != "$(INSTALL_DIR)/$(BINARY)" ]; then \
+		echo "Warning: $(BINARY) resolves to $${resolved:-nothing in PATH}, not $(INSTALL_DIR)/$(BINARY)"; \
+		echo "  Add this before other PATH entries in your shell profile:"; \
+		echo '  export PATH="$(INSTALL_DIR):$$PATH"'; \
+	fi
+
 install: check-up-to-date build
 	@mkdir -p $(INSTALL_DIR)
 	@rm -f $(INSTALL_DIR)/$(BINARY)
@@ -103,6 +111,7 @@ install: check-up-to-date build
 		fi; \
 	done
 	@echo "Installed $(BINARY) to $(INSTALL_DIR)/$(BINARY)"
+	@$(MAKE) --no-print-directory check-install-path
 	@# Restart daemon so it picks up the new binary.
 	@# A stale daemon is a recurring source of bugs (wrong session prefixes, etc.)
 	@if $(INSTALL_DIR)/$(BINARY) daemon status >/dev/null 2>&1; then \
@@ -134,6 +143,7 @@ safe-install: check-up-to-date check-forward-only build
 		fi; \
 	done
 	@echo "Installed $(BINARY) to $(INSTALL_DIR)/$(BINARY) (daemon NOT restarted)"
+	@$(MAKE) --no-print-directory check-install-path
 	@echo "Sessions will pick up new binary on next cycle."
 
 # check-version-tag: Verify that if HEAD is tagged vX.Y.Z, the Version constant

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: build desktop-build desktop-run install safe-install check-forward-only check-version-tag check-install-path clean test test-e2e-container check-up-to-date
+.PHONY: build desktop-build desktop-run install safe-install check-forward-only check-version-tag check-install-path clean test test-makefile test-e2e-container check-up-to-date
 
 BINARY := gt
 BINARY_DESKTOP := gt-desktop
@@ -179,8 +179,11 @@ check-version-tag:
 clean:
 	rm -f $(BUILD_DIR)/$(BINARY)
 
-test:
+test: test-makefile
 	go test ./...
+
+test-makefile:
+	bash scripts/check-install-path_test.sh
 
 # Run e2e tests in isolated container (the only supported way to run them)
 test-e2e-container:

--- a/scripts/check-install-path_test.sh
+++ b/scripts/check-install-path_test.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+# Tests for Makefile check-install-path shadow warnings.
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+MAKE_BIN="$(command -v "${MAKE:-make}")"
+SYSTEM_PATH="/usr/bin:/bin"
+TMPDIR=""
+PASS=0
+FAIL=0
+
+cleanup() {
+  if [[ -n "$TMPDIR" && -d "$TMPDIR" ]]; then
+    rm -rf "$TMPDIR"
+  fi
+}
+trap cleanup EXIT
+
+setup_bins() {
+  TMPDIR="$(mktemp -d)"
+  INSTALL_DIR="$TMPDIR/home/.local/bin"
+  BREW_DIR="$TMPDIR/usr/local/bin"
+  OTHER_DIR="$TMPDIR/usr/bin"
+  mkdir -p "$INSTALL_DIR" "$BREW_DIR" "$OTHER_DIR"
+  printf '#!/usr/bin/env sh\nexit 0\n' > "$INSTALL_DIR/gt"
+  printf '#!/usr/bin/env sh\nexit 0\n' > "$BREW_DIR/gt"
+  chmod +x "$INSTALL_DIR/gt" "$BREW_DIR/gt"
+}
+
+run_check() {
+  local path_value="$1"
+  env PATH="$path_value" "$MAKE_BIN" --no-print-directory -C "$REPO_ROOT" \
+    check-install-path INSTALL_DIR="$INSTALL_DIR" 2>&1
+}
+
+assert_empty() {
+  local test_name="$1"
+  local output="$2"
+  if [[ -z "$output" ]]; then
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $test_name"
+    echo "$output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+assert_warns() {
+  local test_name="$1"
+  local output="$2"
+  local expected="$3"
+  if [[ "$output" == *"Warning: gt resolves to $expected, not $INSTALL_DIR/gt"* ]] && \
+     [[ "$output" == *"export PATH=\"$INSTALL_DIR:\$PATH\""* ]]; then
+    echo "  PASS: $test_name"
+    PASS=$((PASS + 1))
+  else
+    echo "  FAIL: $test_name"
+    echo "$output"
+    FAIL=$((FAIL + 1))
+  fi
+}
+
+echo "=== check-install-path tests ==="
+
+setup_bins
+output="$(run_check "$INSTALL_DIR:$BREW_DIR:$OTHER_DIR:$SYSTEM_PATH")"
+assert_empty "no warning when install dir wins PATH" "$output"
+cleanup
+
+setup_bins
+output="$(run_check "$OTHER_DIR:$SYSTEM_PATH")"
+assert_warns "warns when install dir is omitted from PATH" "$output" "nothing in PATH"
+cleanup
+
+setup_bins
+output="$(run_check "$BREW_DIR:$INSTALL_DIR:$OTHER_DIR:$SYSTEM_PATH")"
+assert_warns "warns when earlier Homebrew-style gt shadows install" "$output" "$BREW_DIR/gt"
+cleanup
+
+echo "Results: $PASS passed, $FAIL failed"
+[[ "$FAIL" -eq 0 ]] && exit 0 || exit 1


### PR DESCRIPTION
## Summary
- Warn after `make install` and `make safe-install` when `gt` resolves somewhere other than the installed `~/.local/bin/gt`.
- Add lightweight Makefile coverage for the expected PATH cases: install dir wins, install dir omitted, and an earlier Homebrew-style `gt` shadows it.

## Tests
- `bash scripts/check-install-path_test.sh`
- `make test-makefile`