### PR TITLE
Fix disabled plugin gates

### DIFF
--- a/docs/design/plugin-system.md
+++ b/docs/design/plugin-system.md
@@ -178,6 +178,7 @@ version = 1               # Schema version (for future evolution)
 
 [gate]
 type = "cooldown|cron|condition|event|manual"
+disabled = true|false      # Skip automatic dispatch when true
 # Type-specific fields:
 duration = "1h"           # For cooldown
 schedule = "0 9 * * *"    # For cron

--- a/internal/cmd/plugin.go
+++ b/internal/cmd/plugin.go
@@ -344,6 +344,9 @@ func outputPluginShowText(p *plugin.Plugin) error {
 	fmt.Printf("%s\n", style.Bold.Render("Gate:"))
 	if p.Gate != nil {
 		fmt.Printf("  Type: %s\n", p.Gate.Type)
+		if p.Gate.Disabled {
+			fmt.Printf("  Disabled: true\n")
+		}
 		if p.Gate.Duration != "" {
 			fmt.Printf("  Duration: %s\n", p.Gate.Duration)
 		}
@@ -425,19 +428,24 @@ func runPluginRun(cmd *cobra.Command, args []string) error {
 	// Check gate status for cooldown gates
 	gateOpen := true
 	gateReason := ""
-	if p.Gate != nil && p.Gate.Type == plugin.GateCooldown && !pluginRunForce {
-		recorder := plugin.NewRecorder(townRoot)
-		duration := p.Gate.Duration
-		if duration == "" {
-			duration = "1h" // default
-		}
-		count, err := recorder.CountRunsSince(p.Name, duration)
-		if err != nil {
-			// Log warning but continue
-			fmt.Fprintf(os.Stderr, "Warning: checking gate status: %v\n", err)
-		} else if count > 0 {
+	if p.Gate != nil && !pluginRunForce {
+		if p.Gate.Disabled {
 			gateOpen = false
-			gateReason = fmt.Sprintf("ran %d time(s) within %s cooldown", count, duration)
+			gateReason = "plugin gate is disabled"
+		} else if p.Gate.Type == plugin.GateCooldown {
+			recorder := plugin.NewRecorder(townRoot)
+			duration := p.Gate.Duration
+			if duration == "" {
+				duration = "1h" // default
+			}
+			count, err := recorder.CountRunsSince(p.Name, duration)
+			if err != nil {
+				// Log warning but continue
+				fmt.Fprintf(os.Stderr, "Warning: checking gate status: %v\n", err)
+			} else if count > 0 {
+				gateOpen = false
+				gateReason = fmt.Sprintf("ran %d time(s) within %s cooldown", count, duration)
+			}
 		}
 	}
 

--- a/internal/daemon/handler.go
+++ b/internal/daemon/handler.go
@@ -240,6 +240,11 @@ func (d *Daemon) dispatchPlugins(mgr *dog.Manager, sm *dog.SessionManager, rigsC
 	router := mail.NewRouterWithTownRoot(d.config.TownRoot, d.config.TownRoot)
 
 	for _, p := range plugins {
+		if p.Gate != nil && p.Gate.Disabled {
+			d.logger.Printf("Handler: skipping plugin %s (gate disabled)", p.Name)
+			continue
+		}
+
 		// Never auto-dispatch manual-gate plugins — they require an explicit trigger.
 		if p.Gate != nil && p.Gate.Type == plugin.GateManual {
 			d.logger.Printf("Handler: skipping plugin %s (gate=manual, requires explicit trigger)", p.Name)

--- a/internal/daemon/handler_test.go
+++ b/internal/daemon/handler_test.go
@@ -429,6 +429,41 @@ func TestDispatchPlugins_SkipsManualGatePlugin(t *testing.T) {
 		t.Errorf("dog work = %q, want empty (manual-gate plugin must not auto-dispatch)", dg.Work)
 	}
 }
+
+func TestDispatchPlugins_SkipsDisabledGatePlugin(t *testing.T) {
+	townRoot := t.TempDir()
+	d := testHandlerDaemon(t, townRoot)
+
+	pluginDir := filepath.Join(townRoot, "plugins", "test-disabled")
+	if err := os.MkdirAll(pluginDir, 0755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	pluginMD := "+++\nname = \"test-disabled\"\ndescription = \"disabled plugin\"\n\n[gate]\ntype = \"cooldown\"\nduration = \"1h\"\ndisabled = true\n+++\n\n# Instructions\n"
+	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.md"), []byte(pluginMD), 0644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+
+	testSetupDogState(t, townRoot, "idle-dog", dog.StateIdle, time.Now().Add(-10*time.Minute))
+
+	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	mgr := dog.NewManager(townRoot, rigsConfig)
+	tm := tmux.NewTmux()
+	sm := dog.NewSessionManager(tm, townRoot, mgr)
+
+	d.dispatchPlugins(mgr, sm, rigsConfig)
+
+	dg, err := mgr.Get("idle-dog")
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if dg.State != dog.StateIdle {
+		t.Errorf("dog state = %q, want idle (disabled plugin must not auto-dispatch)", dg.State)
+	}
+	if dg.Work != "" {
+		t.Errorf("dog work = %q, want empty (disabled plugin must not auto-dispatch)", dg.Work)
+	}
+}
+
 func TestFindDispatchableDog_PicksFirstIdleWhenNoSessionsLive(t *testing.T) {
 	townRoot := t.TempDir()
 	d := testHandlerDaemon(t, townRoot)

--- a/internal/plugin/scanner_test.go
+++ b/internal/plugin/scanner_test.go
@@ -198,6 +198,33 @@ type = "cooldown"
 	}
 }
 
+func TestParsePluginMD_DisabledGate(t *testing.T) {
+	content := []byte(`+++
+name = "disabled-plugin"
+description = "Disabled plugin"
+version = 1
+
+[gate]
+type = "cooldown"
+duration = "20h"
+disabled = true
++++
+
+# Disabled Plugin
+`)
+
+	plugin, err := parsePluginMD(content, "/test/path", LocationTown, "")
+	if err != nil {
+		t.Fatalf("parsePluginMD failed: %v", err)
+	}
+	if plugin.Gate == nil {
+		t.Fatal("expected gate to be non-nil")
+	}
+	if !plugin.Gate.Disabled {
+		t.Error("expected gate disabled to be true")
+	}
+}
+
 func TestParsePluginMD_UnknownGateType(t *testing.T) {
 	content := []byte(`+++
 name = "unknown-gate"

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -78,6 +78,9 @@ type Gate struct {
 
 	// On is for event gates (e.g., "startup").
 	On string `json:"on,omitempty" toml:"on,omitempty"`
+
+	// Disabled prevents automatic gate evaluation and dispatch.
+	Disabled bool `json:"disabled,omitempty" toml:"disabled,omitempty"`
 }
 
 // GateType is the type of gate that controls plugin execution.


### PR DESCRIPTION
## Summary
- Parse and surface `[gate].disabled` on plugins.
- Skip disabled-gate plugins in daemon auto-dispatch and `gt plugin run` unless forced.

## Tests
- `go test ./internal/plugin -run 'TestParsePluginMD_DisabledGate'`
- `go test ./internal/daemon -run 'TestDispatchPlugins_SkipsDisabledGatePlugin'` blocked in this environment by missing rootless Docker/TestMain testcontainers setup.

## Review Note
Opened as draft because the sweep is minimizing new code before cleanup. This is a candidate fix for #3178, not approved for merge in this pass.