### PR TITLE
Clarify boot no-work behavior

### DIFF
--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -584,7 +584,8 @@ func outputStartupDirective(ctx RoleContext) {
 		fmt.Println("**STARTUP PROTOCOL**: You are Boot. Please:")
 		fmt.Println("1. Run `" + cli.Name() + " prime` (loads full context)")
 		fmt.Println("2. Run `" + cli.Name() + " boot triage` immediately")
-		fmt.Println("3. When triage completes, exit cleanly")
+		fmt.Println("3. If triage finds no work, exit cleanly with no escalation or handoff mail")
+		fmt.Println("4. Only escalate real errors (unreadable state, command failures, database outages)")
 	}
 }
 

--- a/internal/formula/boot_no_work_test.go
+++ b/internal/formula/boot_no_work_test.go
@@ -1,0 +1,25 @@
+package formula
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBootTriageFormulaNoWorkIsSilentNoop(t *testing.T) {
+	content, err := formulasFS.ReadFile("formulas/mol-boot-triage.formula.toml")
+	if err != nil {
+		t.Fatalf("reading boot triage formula: %v", err)
+	}
+
+	text := string(content)
+	for _, want := range []string{
+		"no work available",
+		"NOTHING and exit cleanly without escalation",
+		"Do not call `gt escalate` for \"No work available\"",
+		"exit directly with no mail",
+	} {
+		if !strings.Contains(text, want) {
+			t.Errorf("boot triage formula missing %q", want)
+		}
+	}
+}

--- a/internal/formula/formulas/mol-boot-triage.formula.toml
+++ b/internal/formula/formulas/mol-boot-triage.formula.toml
@@ -14,9 +14,13 @@ Boot lifecycle:
 
 Boot is always fresh - no persistent state between invocations.
 Handoff mail provides continuity for the next Boot instance.
+
+Idle is healthy: "no work available" is a normal no-op outcome. If there is no
+hooked work, no actionable mail, and no Deacon error signal, Boot must choose
+NOTHING and exit cleanly without escalation or handoff mail.
 """
 formula = "mol-boot-triage"
-version = 1
+version = 2
 
 [[steps]]
 id = "observe"
@@ -75,6 +79,7 @@ Analyze observations and decide what action to take.
 
 | Deacon State | Pane Activity | Action |
 |--------------|---------------|--------|
+| Alive | No work, no actionable mail, no errors | NOTHING |
 | Dead session | N/A | START |
 | Alive, active output | N/A | NOTHING |
 | Alive, idle < 5 min | N/A | NOTHING |
@@ -105,6 +110,10 @@ Signs of working:
 - WAKE: Stronger wake (escape + message)
 - INTERRUPT: Force restart needed
 - START: Session is dead, start fresh
+
+**Important**: Do not call `gt escalate` for "No work available". That is the
+expected idle state. Escalate only for real errors such as unreadable hook state,
+triage command failures, database outages, or clear stuck/crash evidence.
 """
 
 [[steps]]
@@ -115,7 +124,8 @@ description = """
 Execute the action decided in the previous step.
 
 **NOTHING**
-No action needed. Log observation and exit.
+No action needed. Log observation locally if useful and exit. Do not send mail,
+nudge, or escalate for idle/no-work observations.
 
 **NUDGE**
 ```bash
@@ -209,7 +219,13 @@ exit 0
 ```
 
 **In normal mode**
-Write brief handoff for next Boot instance:
+If action was NOTHING / no work, exit directly with no mail:
+```bash
+exit 0
+```
+
+Only write a brief handoff for the next Boot instance when you took a non-idle
+action or observed a real anomaly:
 ```bash
 gt mail send boot -s "Boot handoff" -m "Completed triage cycle.
 Action: <action taken>

--- a/internal/templates/roles/boot.md.tmpl
+++ b/internal/templates/roles/boot.md.tmpl
@@ -43,6 +43,13 @@ Boot restarts on each daemon tick. This is intentional:
 - Handoff mail provides continuity without session persistence
 - No keepalive needed
 
+## Idle Is Healthy
+
+"No work available" is a normal idle state, not a failure. If triage finds no
+hooked work, no actionable mail, and no Deacon error, choose **NOTHING** and exit
+cleanly. Do **not** escalate, mail the Mayor, or create handoff noise for an idle
+town.
+
 ## Working Directory
 
 **IMPORTANT**: Always work from `{{ .TownRoot }}/deacon/` directory.
@@ -91,6 +98,7 @@ Don't be too aggressive - false positives are disruptive.
 Execute the decided action:
 
 - **NOTHING**: Log and exit
+- **NO WORK / IDLE**: Same as NOTHING - exit silently, no escalation
 - **NUDGE**: `{{ cmd }} nudge deacon "Boot check-in: you have pending work"`
 - **WAKE**: Escape + `{{ cmd }} nudge deacon "Boot wake: check your inbox"`
 - **INTERRUPT**: Mail the Deacon requesting restart consideration
@@ -103,7 +111,8 @@ Archive stale handoff messages (> 1 hour old) from Deacon's inbox.
 ### Step 5: Exit
 
 In degraded mode: Exit directly.
-In normal mode: Optional brief handoff mail for next Boot instance.
+In normal mode: Exit directly when the action was NOTHING / no work. Only write
+handoff context when you took a non-idle action or found a real anomaly.
 
 ## Degraded Mode (GT_DEGRADED=true)
 
@@ -147,4 +156,5 @@ gt boot triage --degraded
 - Each tick is a fresh observation
 - Be conservative - false positives disrupt legitimate work
 - When in doubt, choose NOTHING over NUDGE
+- Never escalate merely because there is no work available
 - Trust the Deacon unless there's clear evidence of stuck state

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -538,6 +538,39 @@ func TestRoleNames(t *testing.T) {
 	}
 }
 
+func TestRenderRole_BootNoWorkExitsSilently(t *testing.T) {
+	tmpl, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	data := RoleData{
+		Role:          "boot",
+		TownRoot:      "/test/town",
+		TownName:      "town",
+		WorkDir:       "/test/town/deacon/dogs/boot",
+		DefaultBranch: "main",
+		MayorSession:  "gt-town-mayor",
+		DeaconSession: "gt-town-deacon",
+	}
+
+	output, err := tmpl.RenderRole("boot", data)
+	if err != nil {
+		t.Fatalf("RenderRole() error = %v", err)
+	}
+
+	for _, want := range []string{
+		"No work available",
+		"normal idle state, not a failure",
+		"Do **not** escalate",
+		"Never escalate merely because there is no work available",
+	} {
+		if !strings.Contains(output, want) {
+			t.Errorf("boot role template missing %q", want)
+		}
+	}
+}
+
 func TestCreatePolecatCLAUDEmd(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
## Summary
- Clarify Boot role/formula guidance so no-work idle state exits silently instead of escalating.
- Add focused tests that lock the intended no-work wording in the embedded formula and role template.

## Tests
- `go test ./internal/formula -run 'TestBootTriageFormulaNoWorkIsSilentNoop'`
- `go test ./internal/templates -run 'TestRenderRole_BootNoWorkExitsSilently'`

## Review Note
Opened as draft because this is mostly prompt/formula text and adds cleanup surface area. This is a candidate fix for #3148, not approved for merge in this pass.