### PR TITLE
Fix polecat remove unpushed check for pushed branches

### DIFF
--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -2009,20 +2009,39 @@ func (g *Git) StashPop(ref string) error {
 }
 
 // UnpushedCommits returns the number of commits that are not pushed to the remote.
-// It checks if the current branch has an upstream and counts commits ahead.
-// Returns 0 if there is no upstream configured.
+// It prefers the exact remote branch when one exists, because polecat branches may
+// track origin/main while pushing work to origin/<current-branch>.
+// Returns 0 if there is no upstream or exact remote branch configured.
 func (g *Git) UnpushedCommits() (int, error) {
+	branch, branchErr := g.CurrentBranch()
+	hasBranch := branchErr == nil && branch != "" && branch != "HEAD"
+
 	// Get the upstream branch
 	upstream, err := g.run("rev-parse", "--abbrev-ref", "@{u}")
-	if err != nil {
-		// No upstream configured - this is common for polecat branches
-		// Check if we can compare against origin/main instead
-		// If we can't get any reference, return 0 (benefit of the doubt)
-		return 0, nil
+	if err == nil {
+		if !hasBranch || upstream == "origin/"+branch {
+			return g.countCommitsAhead(upstream)
+		}
+
+		if count, found, remoteErr := g.unpushedFromExactRemoteBranch(branch, "origin"); remoteErr == nil && found {
+			return count, nil
+		}
+		return g.countCommitsAhead(upstream)
 	}
 
-	// Count commits between upstream and HEAD
-	out, err := g.run("rev-list", "--count", upstream+"..HEAD")
+	if hasBranch {
+		if count, found, remoteErr := g.unpushedFromExactRemoteBranch(branch, "origin"); remoteErr == nil && found {
+			return count, nil
+		}
+	}
+
+	// No upstream configured - this is common for polecat branches.
+	// If there is no exact remote branch either, return 0 (benefit of the doubt).
+	return 0, nil
+}
+
+func (g *Git) countCommitsAhead(base string) (int, error) {
+	out, err := g.run("rev-list", "--count", base+"..HEAD")
 	if err != nil {
 		return 0, err
 	}
@@ -2034,6 +2053,16 @@ func (g *Git) UnpushedCommits() (int, error) {
 	}
 
 	return count, nil
+}
+
+func (g *Git) unpushedFromExactRemoteBranch(localBranch, remote string) (int, bool, error) {
+	remoteSHA, err := g.PushRemoteBranchTip(remote, localBranch)
+	if err != nil || remoteSHA == "" {
+		return 0, false, err
+	}
+
+	count, err := g.countCommitsAhead(remoteSHA)
+	return count, true, err
 }
 
 // UncommittedWorkStatus contains information about uncommitted work in a repo.

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -2308,6 +2308,48 @@ func TestBranchPushedToRemote_SplitURL(t *testing.T) {
 	}
 }
 
+func TestUnpushedCommitsPrefersExactRemoteBranchOverUpstream(t *testing.T) {
+	localDir, _, mainBranch := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+	branch := "polecat/already-pushed"
+
+	if err := g.CreateBranch(branch); err != nil {
+		t.Fatalf("CreateBranch: %v", err)
+	}
+	if err := g.Checkout(branch); err != nil {
+		t.Fatalf("Checkout: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "work.go"), []byte("package work\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := g.Add("work.go"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := g.Commit("polecat work"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	if err := g.Push("origin", branch, false); err != nil {
+		t.Fatalf("Push: %v", err)
+	}
+	runGit(t, localDir, "branch", "--set-upstream-to=origin/"+mainBranch, branch)
+
+	unpushed, err := g.UnpushedCommits()
+	if err != nil {
+		t.Fatalf("UnpushedCommits: %v", err)
+	}
+	if unpushed != 0 {
+		t.Fatalf("UnpushedCommits = %d, want 0 for pushed branch tracking origin/%s", unpushed, mainBranch)
+	}
+
+	status, err := g.CheckUncommittedWork()
+	if err != nil {
+		t.Fatalf("CheckUncommittedWork: %v", err)
+	}
+	if !status.Clean() {
+		t.Fatalf("CheckUncommittedWork should be clean, got %s", status)
+	}
+}
+
 // TestBranchPushedToRemote_NoPushURL verifies baseline behavior: when fetch and
 // push URLs are the same, BranchPushedToRemote works normally.
 func TestBranchPushedToRemote_NoPushURL(t *testing.T) {


### PR DESCRIPTION
## Summary
- Prefer the exact pushed polecat branch when computing unpushed commits only when the configured upstream is absent or differs from `origin/<current-branch>`.
- Preserve the low-risk upstream path when the branch already tracks `origin/<current-branch>` so no extra remote probe is introduced there.
- Add regression coverage for a branch that tracks `origin/main` while its work is already pushed to `origin/<branch>`.

## Verification
- go test ./internal/git

## Notes
- Branch history was squashed to a single clean commit for review.
- Earlier full `go test ./...` hit unrelated `internal/acp TestIntegration_FullLoop` session ID timeout and then command timeout.
- Earlier `go test ./internal/polecat` requires rootless Docker/testcontainers in this environment.

Fixes #3183