### PR TITLE
Fix dashboard rig options

### DIFF
--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -725,12 +725,19 @@ func (h *APIHandler) handleOptions(w http.ResponseWriter, r *http.Request) {
 	// Fetch rigs
 	go func() {
 		defer wg.Done()
-		if output, err := h.runGtCommand(r.Context(), 3*time.Second, []string{"rig", "list"}); err == nil {
+		if output, err := h.runGtCommand(r.Context(), 3*time.Second, []string{"rig", "list", "--json"}); err == nil {
 			mu.Lock()
-			resp.Rigs = parseRigListOutput(output)
+			resp.Rigs = parseRigListJSON(output)
 			mu.Unlock()
 		} else {
-			log.Printf("warning: handleOptions: rig list: %v", err)
+			log.Printf("warning: handleOptions: rig list --json: %v", err)
+			if output, fallbackErr := h.runGtCommand(r.Context(), 3*time.Second, []string{"rig", "list"}); fallbackErr == nil {
+				mu.Lock()
+				resp.Rigs = parseRigListOutput(output)
+				mu.Unlock()
+			} else {
+				log.Printf("warning: handleOptions: rig list fallback: %v", fallbackErr)
+			}
 		}
 	}()
 
@@ -839,6 +846,24 @@ func parseRigListOutput(output string) []string {
 			if name != "" && !strings.HasPrefix(name, "Rigs") {
 				rigs = append(rigs, name)
 			}
+		}
+	}
+	return rigs
+}
+
+// parseRigListJSON extracts rig names from JSON output of "gt rig list --json".
+func parseRigListJSON(jsonStr string) []string {
+	var rigList []struct {
+		Name string `json:"name"`
+	}
+	if err := json.Unmarshal([]byte(jsonStr), &rigList); err != nil {
+		return nil
+	}
+
+	rigs := make([]string, 0, len(rigList))
+	for _, rig := range rigList {
+		if rig.Name != "" {
+			rigs = append(rigs, rig.Name)
 		}
 	}
 	return rigs

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -6,6 +6,8 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"sync"
 	"testing"
@@ -931,6 +933,139 @@ func TestOptionsCacheConcurrentAccess(t *testing.T) {
 	}
 
 	wg.Wait()
+}
+
+func TestParseRigListJSON(t *testing.T) {
+	tests := []struct {
+		name string
+		json string
+		want []string
+	}{
+		{
+			name: "valid JSON with rigs",
+			json: `[{"name":"alpha","status":"operational"},{"name":"greenplace","status":"operational"}]`,
+			want: []string{"alpha", "greenplace"},
+		},
+		{
+			name: "empty array",
+			json: `[]`,
+			want: []string{},
+		},
+		{
+			name: "invalid JSON",
+			json: `{not valid`,
+			want: nil,
+		},
+		{
+			name: "skips empty names",
+			json: `[{"name":"alpha"},{"name":""},{"name":"greenplace"}]`,
+			want: []string{"alpha", "greenplace"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := parseRigListJSON(tt.json)
+			if tt.want == nil {
+				if got != nil {
+					t.Errorf("parseRigListJSON(%q) = %v, want nil", tt.json, got)
+				}
+				return
+			}
+			if len(got) != len(tt.want) {
+				t.Errorf("parseRigListJSON(%q) = %v, want %v", tt.json, got, tt.want)
+				return
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("parseRigListJSON(%q)[%d] = %q, want %q", tt.json, i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestHandleOptionsUsesRigListJSON(t *testing.T) {
+	binDir := t.TempDir()
+	gtPath := filepath.Join(binDir, "gt")
+	bdPath := filepath.Join(binDir, "bd")
+
+	gtScript := `#!/usr/bin/env sh
+set -eu
+case "$*" in
+  "rig list --json")
+    printf '[{"name":"alpha","status":"operational"},{"name":"greenplace","status":"operational"}]\n'
+    ;;
+  "polecat list --all --json")
+    printf '[]\n'
+    ;;
+  "hooks list")
+    printf '\n'
+    ;;
+  "mail inbox")
+    printf '\n'
+    ;;
+  "crew list --all")
+    printf '\n'
+    ;;
+  "status --json")
+    printf '{"agents":[]}\n'
+    ;;
+  *)
+    printf 'unexpected gt args: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+`
+	bdScript := `#!/usr/bin/env sh
+set -eu
+case "$*" in
+  "list --type=convoy --json")
+    printf '[]\n'
+    ;;
+  *)
+    printf 'unexpected bd args: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+`
+
+	if err := os.WriteFile(gtPath, []byte(gtScript), 0o755); err != nil {
+		t.Fatalf("write fake gt: %v", err)
+	}
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0o755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	h := &APIHandler{
+		gtPath:            gtPath,
+		workDir:           t.TempDir(),
+		defaultRunTimeout: 5 * time.Second,
+		maxRunTimeout:     10 * time.Second,
+		cmdSem:            make(chan struct{}, maxConcurrentCommands),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/options?type=rigs", nil)
+	w := httptest.NewRecorder()
+	h.handleOptions(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("handleOptions returned status %d: %s", w.Code, w.Body.String())
+	}
+	var resp OptionsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v\nbody=%s", err, w.Body.String())
+	}
+	want := []string{"alpha", "greenplace"}
+	if len(resp.Rigs) != len(want) {
+		t.Fatalf("Rigs = %v, want %v", resp.Rigs, want)
+	}
+	for i := range want {
+		if resp.Rigs[i] != want[i] {
+			t.Fatalf("Rigs[%d] = %q, want %q; full=%v", i, resp.Rigs[i], want[i], resp.Rigs)
+		}
+	}
 }
 
 func TestParseConvoyListJSON(t *testing.T) {


### PR DESCRIPTION
## Summary

- Use `gt rig list --json` when populating dashboard rig options.
- Keep the existing text-output parser as a fallback for compatibility.
- Add focused tests for JSON parsing and `/api/options?type=rigs` behavior.

## Why

The dashboard ready-work Sling dropdown fetches `/api/options?type=rigs`. The ready panel can render work from rigs, but the Sling dropdown cannot offer target rigs unless this endpoint returns rig names. The JSON rig list is the stable machine-readable surface for that data.

## Testing

- `go test ./internal/web -run 'TestParseRigListJSON|TestHandleOptionsUsesRigListJSON'`
- `go test ./internal/web`
