### PR TITLE
Fix beads redirect setup metadata safety

### DIFF
--- a/internal/beads/beads_redirect.go
+++ b/internal/beads/beads_redirect.go
@@ -121,7 +121,7 @@ func cleanBeadsRuntimeFiles(beadsDir string) error {
 		// Daemon runtime
 		"daemon.lock", "daemon.log", "daemon.pid", "bd.sock",
 		// Sync state
-		"last-touched", "metadata.json",
+		"last-touched",
 		// Version tracking
 		".local_version",
 		// Redirect file (we're about to recreate it)
@@ -160,9 +160,24 @@ func cleanBeadsRuntimeFiles(beadsDir string) error {
 // Returns the redirect target path (e.g., "../../.beads" or "../../mayor/rig/.beads"),
 // or an error if the path is invalid or no beads location exists.
 func ComputeRedirectTarget(townRoot, worktreePath string) (string, error) {
+	townRootAbs, err := filepath.Abs(townRoot)
+	if err != nil {
+		return "", fmt.Errorf("resolving town root: %w", err)
+	}
+	worktreeAbs, err := filepath.Abs(worktreePath)
+	if err != nil {
+		return "", fmt.Errorf("resolving worktree path: %w", err)
+	}
+	if worktreeAbs == townRootAbs {
+		return "", fmt.Errorf("cannot create redirect at town root")
+	}
+	if rel, err := filepath.Rel(townRootAbs, worktreeAbs); err != nil || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return "", fmt.Errorf("worktree path %s is outside town root %s", worktreePath, townRoot)
+	}
+
 	// Get rig root from worktree path
 	// worktreePath = <town>/<rig>/crew/<name> or <town>/<rig>/refinery/rig etc.
-	relPath, err := filepath.Rel(townRoot, worktreePath)
+	relPath, err := filepath.Rel(townRootAbs, worktreeAbs)
 	if err != nil {
 		return "", fmt.Errorf("computing relative path: %w", err)
 	}
@@ -180,8 +195,8 @@ func ComputeRedirectTarget(townRoot, worktreePath string) (string, error) {
 	}
 
 	rigName := parts[0]
-	rigRoot := filepath.Join(townRoot, rigName)
-	townBeadsPath := filepath.Join(townRoot, ".beads")
+	rigRoot := filepath.Join(townRootAbs, rigName)
+	townBeadsPath := filepath.Join(townRootAbs, ".beads")
 	rigBeadsPath := filepath.Join(rigRoot, ".beads")
 	mayorBeadsPath := filepath.Join(rigRoot, "mayor", "rig", ".beads")
 

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -2516,7 +2516,7 @@ func TestSetupRedirect(t *testing.T) {
 		}
 	})
 
-	t.Run("cleans runtime files but preserves tracked files", func(t *testing.T) {
+	t.Run("cleans runtime files but preserves config files", func(t *testing.T) {
 		townRoot := t.TempDir()
 		rigRoot := filepath.Join(townRoot, "testrig")
 		rigBeads := filepath.Join(rigRoot, ".beads")
@@ -2534,10 +2534,11 @@ func TestSetupRedirect(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(crewBeads, "daemon.lock"), []byte("1234"), 0644); err != nil {
 			t.Fatalf("write daemon.lock: %v", err)
 		}
+		// Local beads metadata is per-machine configuration and must survive startup.
 		if err := os.WriteFile(filepath.Join(crewBeads, "metadata.json"), []byte("{}"), 0644); err != nil {
 			t.Fatalf("write metadata.json: %v", err)
 		}
-		// Tracked files (should be preserved)
+		// Config files (should be preserved)
 		if err := os.WriteFile(filepath.Join(crewBeads, "config.yaml"), []byte("prefix: test"), 0644); err != nil {
 			t.Fatalf("write config: %v", err)
 		}
@@ -2553,11 +2554,11 @@ func TestSetupRedirect(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(crewBeads, "daemon.lock")); !os.IsNotExist(err) {
 			t.Error("daemon.lock should have been removed")
 		}
-		if _, err := os.Stat(filepath.Join(crewBeads, "metadata.json")); !os.IsNotExist(err) {
-			t.Error("metadata.json should have been removed")
+		if _, err := os.Stat(filepath.Join(crewBeads, "metadata.json")); err != nil {
+			t.Errorf("metadata.json should have been preserved: %v", err)
 		}
 
-		// Verify tracked files were preserved
+		// Verify config files were preserved
 		if _, err := os.Stat(filepath.Join(crewBeads, "config.yaml")); err != nil {
 			t.Errorf("config.yaml should have been preserved: %v", err)
 		}
@@ -2605,6 +2606,64 @@ func TestSetupRedirect(t *testing.T) {
 		err := SetupRedirect(townRoot, rigRoot)
 		if err == nil {
 			t.Error("SetupRedirect should reject rig root (too shallow)")
+		}
+	})
+
+	t.Run("rejects town root without mutating beads config", func(t *testing.T) {
+		townRoot := t.TempDir()
+		townBeads := filepath.Join(townRoot, ".beads")
+		metadata := []byte(`{"backend":"dolt","dolt_database":"hq"}`)
+
+		if err := os.MkdirAll(townBeads, 0755); err != nil {
+			t.Fatalf("mkdir town beads: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(townBeads, "metadata.json"), metadata, 0644); err != nil {
+			t.Fatalf("write metadata: %v", err)
+		}
+
+		err := SetupRedirect(townRoot, townRoot)
+		if err == nil {
+			t.Fatal("SetupRedirect should reject town root")
+		}
+		if _, err := os.Stat(filepath.Join(townBeads, "redirect")); !os.IsNotExist(err) {
+			t.Fatalf("town root redirect should not have been created, stat err=%v", err)
+		}
+		got, err := os.ReadFile(filepath.Join(townBeads, "metadata.json"))
+		if err != nil {
+			t.Fatalf("metadata.json should be preserved: %v", err)
+		}
+		if string(got) != string(metadata) {
+			t.Fatalf("metadata changed: got %q want %q", got, metadata)
+		}
+	})
+
+	t.Run("rejects worktree outside town root without mutating beads config", func(t *testing.T) {
+		townRoot := t.TempDir()
+		outsideRoot := t.TempDir()
+		outsideWorktree := filepath.Join(outsideRoot, "crew", "max")
+		outsideBeads := filepath.Join(outsideWorktree, ".beads")
+		metadata := []byte(`{"backend":"dolt","dolt_database":"hq"}`)
+
+		if err := os.MkdirAll(outsideBeads, 0755); err != nil {
+			t.Fatalf("mkdir outside beads: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(outsideBeads, "metadata.json"), metadata, 0644); err != nil {
+			t.Fatalf("write metadata: %v", err)
+		}
+
+		err := SetupRedirect(townRoot, outsideWorktree)
+		if err == nil {
+			t.Fatal("SetupRedirect should reject worktree outside town root")
+		}
+		if _, err := os.Stat(filepath.Join(outsideBeads, "redirect")); !os.IsNotExist(err) {
+			t.Fatalf("outside redirect should not have been created, stat err=%v", err)
+		}
+		got, err := os.ReadFile(filepath.Join(outsideBeads, "metadata.json"))
+		if err != nil {
+			t.Fatalf("metadata.json should be preserved: %v", err)
+		}
+		if string(got) != string(metadata) {
+			t.Fatalf("metadata changed: got %q want %q", got, metadata)
 		}
 	})
 


### PR DESCRIPTION
## Summary
- Preserve `.beads/metadata.json` when repairing worktree redirect directories.
- Reject redirect setup for the town root and for worktree paths outside `GT_ROOT` before any filesystem mutation.
- Add regression coverage for metadata preservation, town-root no-mutation, and outside-root no-mutation.

## Findings
- The reported dev branch `fix/pa-xyr-daemon-bdactor-polecat-done` and commit `0d46c86b` were not fetchable from `origin`, so I compared current `origin/main`.
- Current `main` already rejects town-root/rig-root redirect setup before mutation, but still deleted `metadata.json` whenever `SetupRedirect` cleaned an existing `.beads` directory.
- This PR fixes the current data-plane hazard and locks down the town-root/outside-root safety behavior with tests.

## Verification
- `go test ./internal/beads`
- `go test ./internal/beads -run TestSetupRedirect`

## Notes
- A focused `go test ./internal/cmd -run 'TestRoleShowNoMismatchAtTownRoot|TestPrime'` did not complete within 5 minutes in this worktree.

Fixes #4005