### PR TITLE
feat(daemon): per-bead cargo target clean hook (hq-x0v7v)

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/daemon"
+	"github.com/steveyegge/gastown/internal/polecat"
 	"github.com/steveyegge/gastown/internal/scheduler/capacity"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/workspace"
@@ -627,6 +628,9 @@ Supported keys:
   scheduler.max_polecats      Dispatch mode: -1 = direct (default), N > 0 = deferred
   scheduler.batch_size        Beads per heartbeat (default: 1)
   scheduler.spawn_delay       Delay between spawns (default: 0s)
+  polecat.target_clean_policy When to delete <polecat>/target/ on reuse
+                              ("per_bead", "every_n_beads:<N>", "never";
+                              default: per_bead)
   maintenance.window          Maintenance window start time in HH:MM (e.g., "03:00")
   maintenance.interval        How often: "daily", "weekly", "monthly", or duration
   maintenance.threshold       Commit count threshold (default: 1000)
@@ -671,6 +675,8 @@ Supported keys:
   scheduler.max_polecats      Dispatch mode (-1 = direct, N > 0 = deferred)
   scheduler.batch_size        Beads per heartbeat
   scheduler.spawn_delay       Delay between spawns
+  polecat.target_clean_policy When to delete <polecat>/target/ on reuse
+                              (per_bead, every_n_beads:<N>, never)
   maintenance.window          Maintenance window start time (HH:MM)
   maintenance.interval        How often: daily, weekly, monthly, or duration
   maintenance.threshold       Commit count threshold
@@ -767,6 +773,18 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 		}
 		townSettings.Scheduler.SpawnDelay = value
 
+	case "polecat.target_clean_policy":
+		// Validate the policy string parses cleanly. Storage form is the raw input
+		// (normalized via parsed.String() so e.g. "  per_bead  " becomes "per_bead").
+		parsed, err := polecat.ParseTargetCleanPolicy(value)
+		if err != nil {
+			return fmt.Errorf("invalid value for %s: %w", key, err)
+		}
+		if townSettings.Polecat == nil {
+			townSettings.Polecat = &config.PolecatConfig{}
+		}
+		townSettings.Polecat.TargetCleanPolicy = parsed.String()
+
 	case "maintenance.window", "maintenance.interval", "maintenance.threshold":
 		return setMaintenanceConfig(townRoot, key, value)
 
@@ -794,7 +812,7 @@ func runConfigSet(cmd *cobra.Command, args []string) error {
 		if strings.HasPrefix(key, "lifecycle.") {
 			return setLifecycleConfig(townRoot, key, value)
 		}
-		return fmt.Errorf("unknown config key: %q\n\nSupported keys:\n  convoy.notify_on_complete\n  cli_theme\n  default_agent\n  dolt.port\n  scheduler.max_polecats\n  scheduler.batch_size\n  scheduler.spawn_delay\n  maintenance.window\n  maintenance.interval\n  maintenance.threshold\n  lifecycle.reaper.*\n  lifecycle.compactor.*\n  lifecycle.doctor.*\n  lifecycle.backup.*", key)
+		return fmt.Errorf("unknown config key: %q\n\nSupported keys:\n  convoy.notify_on_complete\n  cli_theme\n  default_agent\n  dolt.port\n  scheduler.max_polecats\n  scheduler.batch_size\n  scheduler.spawn_delay\n  polecat.target_clean_policy\n  maintenance.window\n  maintenance.interval\n  maintenance.threshold\n  lifecycle.reaper.*\n  lifecycle.compactor.*\n  lifecycle.doctor.*\n  lifecycle.backup.*", key)
 	}
 
 	if err := config.SaveTownSettings(settingsPath, townSettings); err != nil {
@@ -861,6 +879,13 @@ func runConfigGet(cmd *cobra.Command, args []string) error {
 		}
 		value = scfg.GetSpawnDelay().String()
 
+	case "polecat.target_clean_policy":
+		if townSettings.Polecat != nil && townSettings.Polecat.TargetCleanPolicy != "" {
+			value = townSettings.Polecat.TargetCleanPolicy
+		} else {
+			value = polecat.DefaultTargetCleanPolicy().String()
+		}
+
 	case "maintenance.window", "maintenance.interval", "maintenance.threshold":
 		return getMaintenanceConfig(townRoot, key)
 
@@ -879,7 +904,7 @@ func runConfigGet(cmd *cobra.Command, args []string) error {
 		if strings.HasPrefix(key, "lifecycle.") {
 			return getLifecycleConfig(townRoot, key)
 		}
-		return fmt.Errorf("unknown config key: %q\n\nSupported keys:\n  convoy.notify_on_complete\n  cli_theme\n  default_agent\n  dolt.port\n  scheduler.max_polecats\n  scheduler.batch_size\n  scheduler.spawn_delay\n  maintenance.window\n  maintenance.interval\n  maintenance.threshold\n  lifecycle.reaper.*\n  lifecycle.compactor.*\n  lifecycle.doctor.*\n  lifecycle.backup.*", key)
+		return fmt.Errorf("unknown config key: %q\n\nSupported keys:\n  convoy.notify_on_complete\n  cli_theme\n  default_agent\n  dolt.port\n  scheduler.max_polecats\n  scheduler.batch_size\n  scheduler.spawn_delay\n  polecat.target_clean_policy\n  maintenance.window\n  maintenance.interval\n  maintenance.threshold\n  lifecycle.reaper.*\n  lifecycle.compactor.*\n  lifecycle.doctor.*\n  lifecycle.backup.*", key)
 	}
 
 	fmt.Println(value)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -106,6 +106,10 @@ type TownSettings struct {
 	// Scheduler configures the capacity scheduler for polecat dispatch.
 	Scheduler *capacity.SchedulerConfig `json:"scheduler,omitempty"`
 
+	// Polecat configures per-polecat behavior (target/ clean hook, etc.).
+	// Added for hq-x0v7v.
+	Polecat *PolecatConfig `json:"polecat,omitempty"`
+
 	// Operational configures operational thresholds (timeouts, retries, intervals).
 	// These were previously hardcoded as Go constants throughout the codebase.
 	// All values are optional — omitted values use compiled-in defaults.
@@ -503,6 +507,16 @@ type ConvoyConfig struct {
 	// NotifyOnComplete controls whether convoy completion pushes a notification
 	// into the active Mayor session (in addition to mail). Opt-in; default false.
 	NotifyOnComplete bool `json:"notify_on_complete,omitempty"`
+}
+
+// PolecatConfig configures per-polecat behavior. Added for hq-x0v7v
+// (target/ clean hook on reuse).
+type PolecatConfig struct {
+	// TargetCleanPolicy controls when the daemon deletes <polecat>/target/
+	// before reusing an idle polecat for a new bead.
+	// Values: "per_bead" (default), "every_n_beads:<N>", "never".
+	// Parsed by polecat.ParseTargetCleanPolicy.
+	TargetCleanPolicy string `json:"target_clean_policy,omitempty"`
 }
 
 // ParseDurationOrDefault parses a Go duration string, returning fallback on error or empty input.

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1662,6 +1662,23 @@ func (m *Manager) ReuseIdlePolecat(name string, opts AddOptions) (*Polecat, erro
 		return nil, fmt.Errorf("idle polecat worktree not found at %s: %w", clonePath, err)
 	}
 
+	// hq-x0v7v: per-bead target/ clean hook.
+	// Rust polecats accumulate huge target/ dirs (30-50 GB each) when reused
+	// across many beads; the dipgt daemon has hit 100% disk twice from this.
+	// Policy is per-town config (polecat.target_clean_policy). target/ is
+	// gitignored, so the subsequent reset/clean below won't touch it on its own.
+	// Errors are logged as warnings — reuse must not fail because a cleanup did.
+	{
+		policy := m.targetCleanPolicy()
+		polecatDir := m.polecatDir(name)
+		msg, err := RunTargetCleanHook(polecatDir, clonePath, policy)
+		if err != nil {
+			style.PrintWarning("target-clean hook for %s: %v", name, err)
+		} else if msg != "" {
+			fmt.Println(msg)
+		}
+	}
+
 	polecatGit := git.NewGit(clonePath)
 
 	// Fetch latest from origin (non-fatal: may be offline)

--- a/internal/polecat/target_clean.go
+++ b/internal/polecat/target_clean.go
@@ -1,0 +1,262 @@
+// Package polecat — target_clean.go
+//
+// Per-bead `target/` clean hook for reused polecats (hq-x0v7v).
+//
+// Rust polecats accumulate large `target/` directories (30-50 GB each) when a
+// worktree is reused across many beads. The accumulated cruft eventually fills
+// the disk and crashes the daemon. Cargo's own caches don't get reaped because
+// the worktree is technically "always in use".
+//
+// This file implements a configurable hook: when the daemon reuses an idle
+// polecat for a new bead, optionally delete the polecat's `target/` directory
+// before the new work attaches. The cleaner is policy-driven so operators can
+// pick between always, every-N-beads, or never.
+//
+// Policy is parsed from a single config string at `polecat.target_clean_policy`:
+//   - "per_bead"           (default) clean on every reuse
+//   - "every_n_beads:<N>"  clean once every N reuses (N >= 1)
+//   - "never"              skip the hook entirely
+//
+// The counter for `every_n_beads` is persisted alongside the polecat at
+// `<polecatDir>/target_clean_counter`. Cleaner state is intentionally
+// independent of the agent-bead schema so adding/removing the hook never
+// requires a bead migration.
+package polecat
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/config"
+)
+
+// TargetCleanPolicy describes when to clean a polecat's target/ on reuse.
+type TargetCleanPolicy struct {
+	// Mode is one of "per_bead", "every_n_beads", "never".
+	Mode string
+	// EveryN is the N for every_n_beads. Zero/unset for the other modes.
+	EveryN int
+}
+
+// Policy mode constants.
+const (
+	TargetCleanModePerBead     = "per_bead"
+	TargetCleanModeEveryNBeads = "every_n_beads"
+	TargetCleanModeNever       = "never"
+)
+
+// DefaultTargetCleanPolicy returns the default policy (per_bead).
+func DefaultTargetCleanPolicy() TargetCleanPolicy {
+	return TargetCleanPolicy{Mode: TargetCleanModePerBead}
+}
+
+// ParseTargetCleanPolicy parses a config string into a TargetCleanPolicy.
+// Empty input returns the default (per_bead). Whitespace is trimmed.
+func ParseTargetCleanPolicy(raw string) (TargetCleanPolicy, error) {
+	s := strings.TrimSpace(raw)
+	if s == "" {
+		return DefaultTargetCleanPolicy(), nil
+	}
+	switch {
+	case s == TargetCleanModePerBead:
+		return TargetCleanPolicy{Mode: TargetCleanModePerBead}, nil
+	case s == TargetCleanModeNever:
+		return TargetCleanPolicy{Mode: TargetCleanModeNever}, nil
+	case strings.HasPrefix(s, TargetCleanModeEveryNBeads+":"):
+		nStr := strings.TrimPrefix(s, TargetCleanModeEveryNBeads+":")
+		n, err := strconv.Atoi(strings.TrimSpace(nStr))
+		if err != nil {
+			return TargetCleanPolicy{}, fmt.Errorf("invalid target_clean_policy %q: %w", raw, err)
+		}
+		if n < 1 {
+			return TargetCleanPolicy{}, fmt.Errorf("invalid target_clean_policy %q: N must be >= 1", raw)
+		}
+		return TargetCleanPolicy{Mode: TargetCleanModeEveryNBeads, EveryN: n}, nil
+	default:
+		return TargetCleanPolicy{}, fmt.Errorf("invalid target_clean_policy %q (expected per_bead, every_n_beads:N, or never)", raw)
+	}
+}
+
+// String formats the policy back to its config representation.
+func (p TargetCleanPolicy) String() string {
+	switch p.Mode {
+	case TargetCleanModeEveryNBeads:
+		return fmt.Sprintf("%s:%d", TargetCleanModeEveryNBeads, p.EveryN)
+	case TargetCleanModeNever:
+		return TargetCleanModeNever
+	default:
+		return TargetCleanModePerBead
+	}
+}
+
+// targetCleanPolicy resolves the per-town policy from settings.
+// Falls back to the compiled-in default (per_bead) on any load/parse error so
+// the daemon never gets stuck on a malformed config.
+func (m *Manager) targetCleanPolicy() TargetCleanPolicy {
+	townRoot := filepath.Dir(m.rig.Path)
+	settingsPath := config.TownSettingsPath(townRoot)
+	settings, err := config.LoadOrCreateTownSettings(settingsPath)
+	if err != nil || settings == nil || settings.Polecat == nil {
+		return DefaultTargetCleanPolicy()
+	}
+	policy, err := ParseTargetCleanPolicy(settings.Polecat.TargetCleanPolicy)
+	if err != nil {
+		return DefaultTargetCleanPolicy()
+	}
+	return policy
+}
+
+// targetCleanCounterFile is the per-polecat counter path. Keeps every_n_beads
+// state out of the agent-bead schema and reset-safe across daemon restarts.
+func targetCleanCounterFile(polecatDir string) string {
+	return filepath.Join(polecatDir, "target_clean_counter")
+}
+
+// readTargetCleanCounter returns the persisted counter for this polecat.
+// Missing/garbage files return 0 (not an error — first reuse, fresh polecat).
+func readTargetCleanCounter(polecatDir string) int {
+	data, err := os.ReadFile(targetCleanCounterFile(polecatDir))
+	if err != nil {
+		return 0
+	}
+	n, err := strconv.Atoi(strings.TrimSpace(string(data)))
+	if err != nil || n < 0 {
+		return 0
+	}
+	return n
+}
+
+// writeTargetCleanCounter persists the counter. Errors are non-fatal — the
+// worst case is one extra/missed clean.
+func writeTargetCleanCounter(polecatDir string, n int) error {
+	return os.WriteFile(targetCleanCounterFile(polecatDir), []byte(strconv.Itoa(n)), 0o644)
+}
+
+// ShouldCleanTarget decides — given a policy and the post-increment counter
+// value — whether to clean target/ on this reuse.
+//
+// Behavior:
+//   - per_bead: always true
+//   - every_n_beads:N: true when counterAfterIncrement % N == 0
+//   - never: always false
+func ShouldCleanTarget(policy TargetCleanPolicy, counterAfterIncrement int) bool {
+	switch policy.Mode {
+	case TargetCleanModeNever:
+		return false
+	case TargetCleanModeEveryNBeads:
+		if policy.EveryN <= 0 {
+			return false
+		}
+		return counterAfterIncrement%policy.EveryN == 0
+	default:
+		// per_bead and any unknown mode → clean (fail-safe: more cleaning, not less)
+		return true
+	}
+}
+
+// cleanTargetDir deletes <clonePath>/target if it exists.
+//
+// Returns (bytesFreed, didClean, err). bytesFreed is best-effort (du-style sum
+// of regular files inside target/) and may be 0 if walking failed.
+//
+// Safety rails:
+//   - clonePath must be non-empty and absolute (caller should pre-validate it
+//     lives under the polecat root, which this function cannot do alone).
+//   - missing target/ is a no-op, not an error.
+func cleanTargetDir(clonePath string) (int64, bool, error) {
+	if clonePath == "" {
+		return 0, false, fmt.Errorf("clean target: empty clonePath")
+	}
+	if !filepath.IsAbs(clonePath) {
+		return 0, false, fmt.Errorf("clean target: clonePath must be absolute, got %q", clonePath)
+	}
+	targetDir := filepath.Join(clonePath, "target")
+	info, err := os.Stat(targetDir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return 0, false, nil
+		}
+		return 0, false, fmt.Errorf("stat %s: %w", targetDir, err)
+	}
+	if !info.IsDir() {
+		// Refuse to delete a file named "target" — that's not a build artifact dir.
+		return 0, false, fmt.Errorf("%s is not a directory (refusing to clean)", targetDir)
+	}
+
+	bytes := dirSizeBytes(targetDir)
+	if err := os.RemoveAll(targetDir); err != nil {
+		return bytes, false, fmt.Errorf("removing %s: %w", targetDir, err)
+	}
+	return bytes, true, nil
+}
+
+// dirSizeBytes returns the sum of regular file sizes under root. Best-effort:
+// permission errors or symlink loops are silently skipped — this is only used
+// for logging the freed-disk figure.
+func dirSizeBytes(root string) int64 {
+	var total int64
+	_ = filepath.Walk(root, func(_ string, info os.FileInfo, err error) error {
+		if err != nil || info == nil {
+			return nil
+		}
+		if info.Mode().IsRegular() {
+			total += info.Size()
+		}
+		return nil
+	})
+	return total
+}
+
+// formatBytes pretty-prints a byte count for human-readable logs.
+func formatBytes(n int64) string {
+	const unit = 1024
+	if n < unit {
+		return fmt.Sprintf("%d B", n)
+	}
+	div, exp := int64(unit), 0
+	for n2 := n / unit; n2 >= unit; n2 /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %ciB", float64(n)/float64(div), "KMGTPE"[exp])
+}
+
+// RunTargetCleanHook is the polecat-reuse cleaner entry point.
+//
+// Given the polecat's directory (for counter state) and worktree clone path
+// (where target/ lives), the policy decides whether to clean. Counter is
+// always incremented and persisted; the clean only fires when policy permits.
+//
+// Returns a human-readable log line ("" if no action taken) plus any error.
+// Errors from the clean step are returned but should be treated as warnings
+// by the caller — failure to clean must NOT block the reuse path.
+func RunTargetCleanHook(polecatDir, clonePath string, policy TargetCleanPolicy) (string, error) {
+	if policy.Mode == TargetCleanModeNever {
+		return "", nil
+	}
+
+	counter := readTargetCleanCounter(polecatDir) + 1
+	// Persist the bumped counter unconditionally so every_n_beads stays accurate.
+	if err := writeTargetCleanCounter(polecatDir, counter); err != nil {
+		// Counter persistence is best-effort; continue with the clean decision.
+		_ = err
+	}
+
+	if !ShouldCleanTarget(policy, counter) {
+		return "", nil
+	}
+
+	bytes, didClean, err := cleanTargetDir(clonePath)
+	if err != nil {
+		return "", err
+	}
+	if !didClean {
+		// target/ didn't exist — common on first-ever reuse / non-Rust rigs.
+		return "", nil
+	}
+	return fmt.Sprintf("target-clean: removed %s (%s freed, policy=%s, counter=%d)",
+		filepath.Join(clonePath, "target"), formatBytes(bytes), policy.String(), counter), nil
+}

--- a/internal/polecat/target_clean_test.go
+++ b/internal/polecat/target_clean_test.go
@@ -1,0 +1,322 @@
+package polecat
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestParseTargetCleanPolicy(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		want    TargetCleanPolicy
+		wantErr bool
+	}{
+		{"empty defaults to per_bead", "", TargetCleanPolicy{Mode: TargetCleanModePerBead}, false},
+		{"per_bead", "per_bead", TargetCleanPolicy{Mode: TargetCleanModePerBead}, false},
+		{"never", "never", TargetCleanPolicy{Mode: TargetCleanModeNever}, false},
+		{"every_n_beads:5", "every_n_beads:5", TargetCleanPolicy{Mode: TargetCleanModeEveryNBeads, EveryN: 5}, false},
+		{"every_n_beads:1", "every_n_beads:1", TargetCleanPolicy{Mode: TargetCleanModeEveryNBeads, EveryN: 1}, false},
+		{"whitespace tolerated", "  per_bead  ", TargetCleanPolicy{Mode: TargetCleanModePerBead}, false},
+		{"whitespace in N tolerated", "every_n_beads: 3", TargetCleanPolicy{Mode: TargetCleanModeEveryNBeads, EveryN: 3}, false},
+		{"unknown mode rejected", "yolo", TargetCleanPolicy{}, true},
+		{"N=0 rejected", "every_n_beads:0", TargetCleanPolicy{}, true},
+		{"negative N rejected", "every_n_beads:-3", TargetCleanPolicy{}, true},
+		{"non-numeric N rejected", "every_n_beads:abc", TargetCleanPolicy{}, true},
+		{"missing colon rejected", "every_n_beads", TargetCleanPolicy{}, true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := ParseTargetCleanPolicy(tc.input)
+			if (err != nil) != tc.wantErr {
+				t.Fatalf("ParseTargetCleanPolicy(%q) err=%v wantErr=%v", tc.input, err, tc.wantErr)
+			}
+			if err == nil && got != tc.want {
+				t.Errorf("ParseTargetCleanPolicy(%q) = %+v, want %+v", tc.input, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestTargetCleanPolicyString(t *testing.T) {
+	tests := []struct {
+		policy TargetCleanPolicy
+		want   string
+	}{
+		{TargetCleanPolicy{Mode: TargetCleanModePerBead}, "per_bead"},
+		{TargetCleanPolicy{Mode: TargetCleanModeNever}, "never"},
+		{TargetCleanPolicy{Mode: TargetCleanModeEveryNBeads, EveryN: 7}, "every_n_beads:7"},
+		{TargetCleanPolicy{}, "per_bead"}, // unknown falls back to per_bead
+	}
+	for _, tc := range tests {
+		if got := tc.policy.String(); got != tc.want {
+			t.Errorf("policy %+v String() = %q, want %q", tc.policy, got, tc.want)
+		}
+	}
+}
+
+func TestShouldCleanTarget(t *testing.T) {
+	perBead := TargetCleanPolicy{Mode: TargetCleanModePerBead}
+	never := TargetCleanPolicy{Mode: TargetCleanModeNever}
+	every3 := TargetCleanPolicy{Mode: TargetCleanModeEveryNBeads, EveryN: 3}
+
+	// per_bead: always clean
+	for i := 1; i <= 5; i++ {
+		if !ShouldCleanTarget(perBead, i) {
+			t.Errorf("per_bead at counter=%d: want clean=true", i)
+		}
+	}
+	// never: never clean
+	for i := 1; i <= 5; i++ {
+		if ShouldCleanTarget(never, i) {
+			t.Errorf("never at counter=%d: want clean=false", i)
+		}
+	}
+	// every_n_beads:3 — clean at counter=3, 6, 9
+	wantClean := map[int]bool{1: false, 2: false, 3: true, 4: false, 5: false, 6: true, 7: false, 8: false, 9: true}
+	for c, want := range wantClean {
+		if got := ShouldCleanTarget(every3, c); got != want {
+			t.Errorf("every_n_beads:3 at counter=%d: got %v, want %v", c, got, want)
+		}
+	}
+
+	// Guard: every_n_beads with EveryN<=0 must not panic and must not clean.
+	bad := TargetCleanPolicy{Mode: TargetCleanModeEveryNBeads, EveryN: 0}
+	if ShouldCleanTarget(bad, 5) {
+		t.Errorf("every_n_beads:0 should never clean (defensive)")
+	}
+}
+
+func TestCounterPersistence(t *testing.T) {
+	dir := t.TempDir()
+	// Missing file → 0
+	if got := readTargetCleanCounter(dir); got != 0 {
+		t.Errorf("missing counter file: got %d, want 0", got)
+	}
+	// Write + read round-trip
+	if err := writeTargetCleanCounter(dir, 7); err != nil {
+		t.Fatalf("write counter: %v", err)
+	}
+	if got := readTargetCleanCounter(dir); got != 7 {
+		t.Errorf("after write 7: got %d", got)
+	}
+	// Garbage file → 0 (don't error)
+	if err := os.WriteFile(targetCleanCounterFile(dir), []byte("not a number"), 0o644); err != nil {
+		t.Fatalf("write garbage: %v", err)
+	}
+	if got := readTargetCleanCounter(dir); got != 0 {
+		t.Errorf("garbage counter file: got %d, want 0", got)
+	}
+	// Negative file → 0
+	if err := os.WriteFile(targetCleanCounterFile(dir), []byte("-5"), 0o644); err != nil {
+		t.Fatalf("write negative: %v", err)
+	}
+	if got := readTargetCleanCounter(dir); got != 0 {
+		t.Errorf("negative counter file: got %d, want 0", got)
+	}
+}
+
+func TestCleanTargetDir(t *testing.T) {
+	clonePath := t.TempDir()
+	targetDir := filepath.Join(clonePath, "target")
+	debugDir := filepath.Join(targetDir, "debug")
+	if err := os.MkdirAll(debugDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	payload := []byte(strings.Repeat("X", 4096))
+	if err := os.WriteFile(filepath.Join(debugDir, "artifact.o"), payload, 0o644); err != nil {
+		t.Fatalf("writefile: %v", err)
+	}
+
+	bytes, didClean, err := cleanTargetDir(clonePath)
+	if err != nil {
+		t.Fatalf("cleanTargetDir: %v", err)
+	}
+	if !didClean {
+		t.Errorf("didClean: want true")
+	}
+	if bytes < int64(len(payload)) {
+		t.Errorf("bytes freed = %d, expected >= %d", bytes, len(payload))
+	}
+	if _, err := os.Stat(targetDir); !os.IsNotExist(err) {
+		t.Errorf("target dir still exists after clean: %v", err)
+	}
+
+	// Re-running on a missing target/ must be a no-op, not an error.
+	bytes2, didClean2, err := cleanTargetDir(clonePath)
+	if err != nil {
+		t.Fatalf("second cleanTargetDir on missing target/: %v", err)
+	}
+	if didClean2 || bytes2 != 0 {
+		t.Errorf("expected no-op on missing target/, got didClean=%v bytes=%d", didClean2, bytes2)
+	}
+}
+
+func TestCleanTargetDirSafety(t *testing.T) {
+	// Empty path rejected.
+	if _, _, err := cleanTargetDir(""); err == nil {
+		t.Error("empty clonePath should error")
+	}
+	// Relative path rejected (defense-in-depth — caller should pass absolute).
+	if _, _, err := cleanTargetDir("relative/path"); err == nil {
+		t.Error("relative clonePath should error")
+	}
+	// "target" being a regular file (not a dir) is refused.
+	clonePath := t.TempDir()
+	if err := os.WriteFile(filepath.Join(clonePath, "target"), []byte("oops"), 0o644); err != nil {
+		t.Fatalf("writefile: %v", err)
+	}
+	_, didClean, err := cleanTargetDir(clonePath)
+	if err == nil {
+		t.Error("file named target/ (not a dir) should error")
+	}
+	if didClean {
+		t.Error("file named target/ should not be deleted")
+	}
+	if _, err := os.Stat(filepath.Join(clonePath, "target")); err != nil {
+		t.Errorf("file target should still exist: %v", err)
+	}
+}
+
+func TestRunTargetCleanHook_PerBead(t *testing.T) {
+	polecatDir := t.TempDir()
+	clonePath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(clonePath, "target", "debug"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(clonePath, "target", "debug", "x.o"), []byte("data"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := RunTargetCleanHook(polecatDir, clonePath, TargetCleanPolicy{Mode: TargetCleanModePerBead})
+	if err != nil {
+		t.Fatalf("RunTargetCleanHook: %v", err)
+	}
+	if msg == "" {
+		t.Errorf("per_bead with existing target/: expected log message, got empty")
+	}
+	if _, err := os.Stat(filepath.Join(clonePath, "target")); !os.IsNotExist(err) {
+		t.Errorf("target/ should be gone")
+	}
+	if readTargetCleanCounter(polecatDir) != 1 {
+		t.Errorf("counter should be 1, got %d", readTargetCleanCounter(polecatDir))
+	}
+}
+
+func TestRunTargetCleanHook_Never(t *testing.T) {
+	polecatDir := t.TempDir()
+	clonePath := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(clonePath, "target"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	msg, err := RunTargetCleanHook(polecatDir, clonePath, TargetCleanPolicy{Mode: TargetCleanModeNever})
+	if err != nil {
+		t.Fatalf("RunTargetCleanHook: %v", err)
+	}
+	if msg != "" {
+		t.Errorf("never: expected no log message, got %q", msg)
+	}
+	if _, err := os.Stat(filepath.Join(clonePath, "target")); err != nil {
+		t.Errorf("never: target/ should still exist: %v", err)
+	}
+	// never mode should NOT touch the counter
+	if got := readTargetCleanCounter(polecatDir); got != 0 {
+		t.Errorf("never: counter should stay 0, got %d", got)
+	}
+}
+
+func TestRunTargetCleanHook_EveryNBeads(t *testing.T) {
+	polecatDir := t.TempDir()
+	clonePath := t.TempDir()
+	policy := TargetCleanPolicy{Mode: TargetCleanModeEveryNBeads, EveryN: 3}
+
+	// Helper: re-stage target/ before each reuse (real worktree gets rebuilt).
+	restage := func() {
+		if err := os.MkdirAll(filepath.Join(clonePath, "target"), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Beads 1, 2: counter increments but no clean.
+	for i := 1; i <= 2; i++ {
+		restage()
+		msg, err := RunTargetCleanHook(polecatDir, clonePath, policy)
+		if err != nil {
+			t.Fatalf("reuse %d: %v", i, err)
+		}
+		if msg != "" {
+			t.Errorf("reuse %d (every_n:3): expected no clean, got %q", i, msg)
+		}
+		if _, err := os.Stat(filepath.Join(clonePath, "target")); err != nil {
+			t.Errorf("reuse %d: target/ should still exist", i)
+		}
+		if got := readTargetCleanCounter(polecatDir); got != i {
+			t.Errorf("reuse %d: counter = %d, want %d", i, got, i)
+		}
+	}
+	// Bead 3: clean fires.
+	restage()
+	msg, err := RunTargetCleanHook(polecatDir, clonePath, policy)
+	if err != nil {
+		t.Fatalf("reuse 3: %v", err)
+	}
+	if msg == "" {
+		t.Errorf("reuse 3 (every_n:3): expected clean log, got empty")
+	}
+	if _, err := os.Stat(filepath.Join(clonePath, "target")); !os.IsNotExist(err) {
+		t.Errorf("reuse 3: target/ should be gone")
+	}
+	if got := readTargetCleanCounter(polecatDir); got != 3 {
+		t.Errorf("reuse 3: counter = %d, want 3", got)
+	}
+	// Bead 4: increments to 4, no clean.
+	restage()
+	msg, err = RunTargetCleanHook(polecatDir, clonePath, policy)
+	if err != nil {
+		t.Fatalf("reuse 4: %v", err)
+	}
+	if msg != "" {
+		t.Errorf("reuse 4: expected no clean, got %q", msg)
+	}
+	if got := readTargetCleanCounter(polecatDir); got != 4 {
+		t.Errorf("reuse 4: counter = %d, want 4", got)
+	}
+}
+
+func TestRunTargetCleanHook_MissingTargetIsNoop(t *testing.T) {
+	polecatDir := t.TempDir()
+	clonePath := t.TempDir()
+	// No target/ directory at all (first-ever reuse / non-Rust rig).
+	msg, err := RunTargetCleanHook(polecatDir, clonePath, TargetCleanPolicy{Mode: TargetCleanModePerBead})
+	if err != nil {
+		t.Fatalf("RunTargetCleanHook with no target/: %v", err)
+	}
+	if msg != "" {
+		t.Errorf("missing target/: expected no log message, got %q", msg)
+	}
+	// Counter still increments — that's by design (policy says "clean every reuse").
+	if got := readTargetCleanCounter(polecatDir); got != 1 {
+		t.Errorf("counter should be 1 even when target/ was missing, got %d", got)
+	}
+}
+
+func TestFormatBytes(t *testing.T) {
+	tests := []struct {
+		n    int64
+		want string
+	}{
+		{0, "0 B"},
+		{1023, "1023 B"},
+		{1024, "1.0 KiB"},
+		{1024 * 1024, "1.0 MiB"},
+		{30 * 1024 * 1024 * 1024, "30.0 GiB"},
+	}
+	for _, tc := range tests {
+		if got := formatBytes(tc.n); got != tc.want {
+			t.Errorf("formatBytes(%d) = %q, want %q", tc.n, got, tc.want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a daemon hook that runs `os.RemoveAll(<polecat>/target)` when a polecat is reused for a new bead, so each bead starts from a clean cargo target dir. Fixes the recurring 100%-disk-fill on dipgt where concurrent polecat target dirs accumulated to 30-50 GB each (saw 100% twice in 24h before the temporary `scheduler.max_polecats=2` throttle).

Per Overseer directive 2026-05-14 hq-wisp-ly7iz: \"polecats should clean target periodically, even when busy. causes a lot of rebuilds but I think also stuff from old code accumulates.\"

## Design

- New config knob: `polecat.target_clean_policy = per_bead | every_n_beads:<N> | never` (default `per_bead`).
- Hook fires inside `ReuseIdlePolecat` (the canonical reuse path) right after the worktree-exists check, before any git ops. `target/` is gitignored, so subsequent reset/clean doesn't touch it.
- Uses `os.RemoveAll(<clonePath>/target)` rather than `cargo clean` — no `.cargo` lock contention, no toolchain dep, faster.
- `every_n_beads:N` counter persists at `<polecatDir>/target_clean_counter` — outside the agent-bead schema so the hook can be added/removed without bead migrations.
- Errors are logged as warnings, never block reuse.

## Files (5, +642/-2)

- `internal/polecat/target_clean.go` (new) — policy parser, per-polecat counter persistence, `cleanTargetDir`, `RunTargetCleanHook`, `Manager.targetCleanPolicy` helper.
- `internal/polecat/target_clean_test.go` (new) — unit tests covering parse (incl. malformed inputs), every-N cycling, never-mode no-counter-touch, missing-target no-op, safety rails (empty path, relative path, file-named-\`target\`).
- `internal/polecat/manager.go` — inserts the hook into `ReuseIdlePolecat`.
- `internal/config/types.go` — new `PolecatConfig` struct + `TownSettings.Polecat` field.
- `internal/cmd/config.go` — `gt config get/set polecat.target_clean_policy` + help text.

## Tests

- `go test ./internal/polecat/...` — PASS (67.7s)
- `go test ./internal/config/...` — PASS (0.5s)
- `go test ./internal/daemon/... -short` — PASS (203s)
- `go vet ./internal/polecat/... ./internal/cmd/... ./internal/config/...` — clean

## Acceptance

- Polecat dispatch path logs `cleaned target/ for <polecat> (N MB freed)` on reuse.
- `gt config set polecat.target_clean_policy never` bypasses the clean step.
- After landing, dipgt mayor will bump `scheduler.max_polecats` 2→3 (currently throttled as the manual workaround).

Refs: hq-x0v7v.