### PR TITLE
fix(stuck-agent-dog): skip restart loops when arrays are empty (gt-05d)

### DIFF
--- a/plugins/stuck-agent-dog/run.sh
+++ b/plugins/stuck-agent-dog/run.sh
@@ -135,7 +135,10 @@ fi
 # --- Take action --------------------------------------------------------------
 
 # Crashed polecats: notify witness to restart
-for ENTRY in "${CRASHED[@]:-}"; do
+# Note: `"${arr[@]:-}"` expands an empty array to a single empty string under
+# `set -u`, which would fire a phantom `RESTART_POLECAT: /` notification. The
+# `${arr[@]+"${arr[@]}"}` form expands to nothing when the array is empty.
+for ENTRY in ${CRASHED[@]+"${CRASHED[@]}"}; do
   IFS='|' read -r SESSION RIG PCAT HOOK <<< "$ENTRY"
   log "Requesting restart for $RIG/polecats/$PCAT (hook=$HOOK)"
   gt mail send "$RIG/witness" -s "RESTART_POLECAT: $RIG/$PCAT" --stdin <<BODY
@@ -146,7 +149,7 @@ BODY
 done
 
 # Zombie polecats: kill zombie session, then request restart
-for ENTRY in "${STUCK[@]:-}"; do
+for ENTRY in ${STUCK[@]+"${STUCK[@]}"}; do
   IFS='|' read -r SESSION RIG PCAT HOOK REASON <<< "$ENTRY"
   log "Killing zombie session $SESSION and requesting restart"
   tmux kill-session -t "$SESSION" 2>/dev/null || true


### PR DESCRIPTION
## Summary
- Guards `${CRASHED[@]:-}` / `${STUCK[@]:-}` loops in `stuck-agent-dog/run.sh` against the bash empty-array-with-default-fallback gotcha (one phantom iteration over the empty string), which caused dogs to emit `RESTART_POLECAT: /` notifications every 5min gate firing.
- Replaces `:-` fallback with `${arr[@]+"${arr[@]}"}` proper empty-array guard.

Fixes gastownhall/gastown bead `gt-05d`. Reported by gastown/witness; escalated by deacon as high-noise (alpha + bravo dogs both affected).

## Test plan
- [ ] Trigger a gate firing with no CRASHED/STUCK candidates — confirm no notification
- [ ] Trigger with one candidate — confirm exactly one RESTART_POLECAT