### PR TITLE
fix(config): warn when prompt_mode: "none" drops a non-empty startup prompt

### DIFF
--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -1,7 +1,9 @@
 package config
 
 import (
+	"bytes"
 	"encoding/json"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -3604,6 +3606,97 @@ func TestBuildCommandWithPromptRespectsPromptModeNone(t *testing.T) {
 	}
 	if !strings.HasPrefix(cmd, "opencode") {
 		t.Errorf("Command should start with opencode, got: %s", cmd)
+	}
+}
+
+// captureStderr redirects os.Stderr for the duration of fn and returns what was written.
+func captureStderr(t *testing.T, fn func()) string {
+	t.Helper()
+	old := os.Stderr
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("create pipe: %v", err)
+	}
+	os.Stderr = w
+	fn()
+	_ = w.Close()
+	os.Stderr = old
+	var buf bytes.Buffer
+	if _, err := io.Copy(&buf, r); err != nil {
+		t.Fatalf("read stderr: %v", err)
+	}
+	_ = r.Close()
+	return buf.String()
+}
+
+// TestBuildCommandWithPromptWarnsOnDroppedPrompt verifies that when PromptMode
+// is "none" and a non-empty prompt is provided, a warning is emitted to stderr.
+// This makes the misconfiguration self-diagnosing (issue #3803).
+func TestBuildCommandWithPromptWarnsOnDroppedPrompt(t *testing.T) {
+	rc := &RuntimeConfig{
+		Command:    "claude",
+		Args:       []string{"--dangerously-skip-permissions"},
+		PromptMode: "none",
+	}
+
+	var cmd string
+	stderr := captureStderr(t, func() {
+		cmd = rc.BuildCommandWithPrompt("[GAS TOWN] deacon <- daemon • patrol")
+	})
+
+	if strings.Contains(cmd, "GAS TOWN") {
+		t.Errorf("prompt_mode=none should prevent prompt from appearing in command, got: %s", cmd)
+	}
+	if !strings.Contains(stderr, "warning:") {
+		t.Errorf("expected a warning on stderr when prompt is dropped, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, "prompt_mode") {
+		t.Errorf("warning should mention prompt_mode, got: %q", stderr)
+	}
+	if !strings.Contains(stderr, `"claude"`) {
+		t.Errorf("warning should include the agent command name, got: %q", stderr)
+	}
+}
+
+// TestBuildCommandWithPromptNoWarnOnEmptyPrompt verifies that no warning is
+// emitted when the prompt is empty (that is the normal PromptMode:"none" use case).
+func TestBuildCommandWithPromptNoWarnOnEmptyPrompt(t *testing.T) {
+	rc := &RuntimeConfig{
+		Command:    "codex",
+		Args:       []string{},
+		PromptMode: "none",
+	}
+
+	stderr := captureStderr(t, func() {
+		_ = rc.BuildCommandWithPrompt("")
+	})
+
+	if stderr != "" {
+		t.Errorf("no warning expected when prompt is empty, got: %q", stderr)
+	}
+}
+
+// TestBuildArgsWithPromptWarnsOnDroppedPrompt verifies the parallel warning in
+// BuildArgsWithPrompt when PromptMode is "none" and a non-empty prompt is provided.
+func TestBuildArgsWithPromptWarnsOnDroppedPrompt(t *testing.T) {
+	rc := &RuntimeConfig{
+		Command:    "claude",
+		Args:       []string{"--dangerously-skip-permissions"},
+		PromptMode: "none",
+	}
+
+	var args []string
+	stderr := captureStderr(t, func() {
+		args = rc.BuildArgsWithPrompt("[GAS TOWN] deacon <- daemon • patrol")
+	})
+
+	for _, arg := range args {
+		if strings.Contains(arg, "GAS TOWN") {
+			t.Errorf("prompt_mode=none should prevent prompt appearing in args, got: %v", args)
+		}
+	}
+	if !strings.Contains(stderr, "warning:") {
+		t.Errorf("expected a warning on stderr when prompt is dropped, got: %q", stderr)
 	}
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -874,6 +874,14 @@ func (rc *RuntimeConfig) BuildCommandWithPrompt(prompt string) string {
 	}
 
 	if p == "" || resolved.PromptMode == "none" {
+		if p != "" {
+			// A non-empty prompt was silently dropped because prompt_mode is "none".
+			// This commonly happens when a user copies a codex agent entry (which ships
+			// with prompt_mode: "none") to create a claude override, inadvertently
+			// suppressing the daemon's startup beacon injection and causing a crash-loop
+			// that looks like a deacon failure. Warn so misconfiguration is self-diagnosing.
+			fmt.Fprintf(os.Stderr, "warning: agent %q has prompt_mode: \"none\" — startup prompt dropped (agent may not bootstrap correctly)\n", resolved.Command)
+		}
 		return base
 	}
 
@@ -919,6 +927,8 @@ func (rc *RuntimeConfig) BuildArgsWithPrompt(prompt string) []string {
 		default:
 			args = append(args, p)
 		}
+	} else if p != "" {
+		fmt.Fprintf(os.Stderr, "warning: agent %q has prompt_mode: \"none\" — startup prompt dropped (agent may not bootstrap correctly)\n", resolved.Command)
 	}
 
 	return args


### PR DESCRIPTION
Closes #3803

## Summary

When `BuildCommandWithPrompt` or `BuildArgsWithPrompt` is called with a non-empty prompt but the resolved `PromptMode` is `"none"`, the prompt was silently discarded with no log, no warning, no metric.

This made the bug nearly impossible to diagnose: the agent process stayed alive, the daemon logged "started successfully", and only 6 minutes later the stuck-agent-dog killed the session with what looked like a crash-loop.

Now both functions emit a warning to stderr naming the agent command, so the misconfiguration is immediately visible in the daemon log.

The most common trigger: copying the codex agent entry (which ships with `prompt_mode: "none"`) to create a claude override in `agents.json`. Codex has its own startup mechanics and doesn't need the positional-arg beacon; claude does. The silent drop broke beacon injection without any indication.

## Changes

- `internal/config/types.go`: emit warning when `prompt_mode: "none"` silently drops a non-empty startup prompt
- `internal/config/loader_test.go`: add tests covering the warning path

🤖 Merged by [Gas Town Refinery](https://github.com/gastownhall/gastown) — esciara/gastown fork