### PR TITLE
fix: gt install provisions shared commands into both town root and role subdirs, causing duplicates in Claude Code

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steveyegge/gastown/internal/hookutil"
 	"github.com/steveyegge/gastown/internal/templates/commands"
 	"github.com/steveyegge/gastown/internal/tmux"
+	"github.com/steveyegge/gastown/internal/workspace"
 )
 
 // EnsureSettingsForRole provisions all agent-specific configuration for a role.
@@ -52,8 +53,11 @@ func EnsureSettingsForRole(settingsDir, workDir, role string, rc *config.Runtime
 	}
 
 	// 2. Slash commands (agent-agnostic, uses shared body with provider-specific frontmatter)
-	// Only provision for known agents to maintain backwards compatibility
-	if commands.IsKnownAgent(provider) {
+	// Only provision for known agents to maintain backwards compatibility.
+	// Skip provisioning when workDir is nested inside a town root: Claude Code's
+	// path-hierarchy traversal already delivers the town root's .claude/commands/
+	// to the agent, so a duplicate copy in workDir causes each command to appear twice.
+	if commands.IsKnownAgent(provider) && !commandsInherited(workDir) {
 		if err := commands.ProvisionFor(workDir, provider); err != nil {
 			return err
 		}
@@ -113,6 +117,37 @@ func ensureGeminiContextFile(workDir string) error {
 
 func pointsToAgentsMD(target string) bool {
 	return filepath.Base(filepath.Clean(target)) == "AGENTS.md"
+}
+
+// commandsInherited reports whether workDir will receive slash commands via
+// Claude Code's path-hierarchy traversal without explicit provisioning.
+// This is true when workDir is nested inside a git repository that is also
+// a Gas Town workspace root: Claude Code walks up from workDir to the git
+// root and loads .claude/commands/ along the way, so any commands provisioned
+// at the workspace root are automatically visible to the agent.
+// Provisioning a second copy inside workDir would cause each command to appear
+// twice in the agent's command palette.
+func commandsInherited(workDir string) bool {
+	gitRoot := gitRootOf(workDir)
+	if gitRoot == "" || gitRoot == workDir {
+		return false
+	}
+	isWS, err := workspace.IsWorkspace(gitRoot)
+	return err == nil && isWS
+}
+
+// gitRootOf walks up from dir to find the nearest ancestor directory containing
+// a .git entry (file or directory). Returns empty string if none found.
+func gitRootOf(dir string) string {
+	for d := dir; ; d = filepath.Dir(d) {
+		if _, err := os.Stat(filepath.Join(d, ".git")); err == nil {
+			return d
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			return ""
+		}
+	}
 }
 
 type startupPromptSession interface {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -860,3 +860,126 @@ func TestRuntimeConfigWithMinDelay_ZeroMin(t *testing.T) {
 		t.Errorf("ReadyDelayMs = %d, want 0", result.Tmux.ReadyDelayMs)
 	}
 }
+
+// makeTownRoot creates a minimal town root directory structure for testing:
+// a .git marker and mayor/town.json so workspace.IsWorkspace returns true.
+func makeTownRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(root+"/.git", 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(root+"/mayor", 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(root+"/mayor/town.json", []byte(`{"type":"town"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func TestCommandsInherited_WorkDirIsNestedInTownRoot(t *testing.T) {
+	// workDir is a subdirectory of the town root (same git repo) → inherited
+	root := makeTownRoot(t)
+	mayorDir := root + "/mayor"
+
+	if !commandsInherited(mayorDir) {
+		t.Error("commandsInherited() = false, want true for workDir nested inside town root")
+	}
+}
+
+func TestCommandsInherited_WorkDirIsTownRoot(t *testing.T) {
+	// workDir == git root → not inherited (we're provisioning at the root itself)
+	root := makeTownRoot(t)
+
+	if commandsInherited(root) {
+		t.Error("commandsInherited() = true, want false when workDir equals the git root")
+	}
+}
+
+func TestCommandsInherited_WorkDirIsOutsideTownRoot(t *testing.T) {
+	// workDir in a standalone git repo that is NOT a Gas Town workspace → not inherited
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir+"/.git", 0755); err != nil {
+		t.Fatal(err)
+	}
+	subDir := dir + "/src"
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if commandsInherited(subDir) {
+		t.Error("commandsInherited() = true, want false for workDir in non-workspace git repo")
+	}
+}
+
+func TestCommandsInherited_NoGitRoot(t *testing.T) {
+	// workDir has no .git ancestor → not inherited
+	dir := t.TempDir()
+	// Don't create .git
+
+	if commandsInherited(dir) {
+		t.Error("commandsInherited() = true, want false when no .git ancestor found")
+	}
+}
+
+func TestEnsureSettingsForRole_SkipsCommandsWhenInheritedFromTownRoot(t *testing.T) {
+	// Mayor/deacon run inside the town root git repo. Commands provisioned at the
+	// town root are inherited by Claude Code's path-hierarchy traversal, so
+	// EnsureSettingsForRole must NOT provision a duplicate copy in the role dir.
+	root := makeTownRoot(t)
+	mayorDir := root + "/mayor"
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	rc := &config.RuntimeConfig{
+		Hooks: &config.RuntimeHooksConfig{
+			Provider:     "claude",
+			Dir:          ".claude",
+			SettingsFile: "settings.json",
+		},
+	}
+
+	if err := EnsureSettingsForRole(mayorDir, mayorDir, "mayor", rc); err != nil {
+		t.Fatalf("EnsureSettingsForRole() error = %v", err)
+	}
+
+	// Commands must NOT be provisioned inside the role dir
+	for _, cmd := range []string{"done", "handoff", "review"} {
+		path := mayorDir + "/.claude/commands/" + cmd + ".md"
+		if _, err := os.Stat(path); err == nil {
+			t.Errorf("command %s.md was provisioned in mayor dir, want skipped (would duplicate town-root copy)", cmd)
+		}
+	}
+}
+
+func TestEnsureSettingsForRole_ProvisionCommandsOutsideTownRoot(t *testing.T) {
+	// Crew/polecat workDirs are outside the town root git repo.
+	// EnsureSettingsForRole must provision commands normally.
+	workDir := t.TempDir()
+	// workDir has no .git ancestor, so commandsInherited returns false.
+
+	rc := &config.RuntimeConfig{
+		Hooks: &config.RuntimeHooksConfig{
+			Provider:     "claude",
+			Dir:          ".claude",
+			SettingsFile: "settings.json",
+		},
+	}
+
+	if err := EnsureSettingsForRole(workDir, workDir, "crew", rc); err != nil {
+		t.Fatalf("EnsureSettingsForRole() error = %v", err)
+	}
+
+	// At least one command should be provisioned
+	provisioned := 0
+	for _, cmd := range []string{"done", "handoff", "review"} {
+		if _, err := os.Stat(workDir + "/.claude/commands/" + cmd + ".md"); err == nil {
+			provisioned++
+		}
+	}
+	if provisioned == 0 {
+		t.Error("no commands provisioned in workDir outside town root, want at least one")
+	}
+}


### PR DESCRIPTION
## Summary

- Adds `commandsInherited(workDir)` check in `EnsureSettingsForRole` to skip provisioning slash commands when `workDir` is nested inside a Gas Town workspace root
- Implements the fix by walking up the directory tree to find the nearest git root, then checking if that root is a Gas Town workspace — if so, Claude Code's path-hierarchy traversal already delivers the town root's `.claude/commands/` to the agent
- Prevents duplicate `done`, `handoff`, and `review` commands appearing in mayor/deacon Claude Code sessions

## Changes

- `internal/runtime/runtime.go`: Added `commandsInherited(workDir)` guard to the commands provisioning call in `EnsureSettingsForRole`; added `commandsInherited` and `gitRootOf` helper functions
- `internal/runtime/runtime_test.go`: Added 6 tests covering the `commandsInherited` logic and the integration behaviour of `EnsureSettingsForRole` for both nested (mayor/deacon) and standalone (crew/polecat) workDirs

## Testing

- [x] `go build ./...` passes
- [x] `go test ./internal/runtime/...` passes (all new tests pass)
- [x] `go vet ./...` passes

Closes #3874