### PR TITLE
fix: bug: mol step await-event blocks context-check patrol step — refinery never hands off

### DIFF
--- a/internal/cmd/molecule_await_event.go
+++ b/internal/cmd/molecule_await_event.go
@@ -392,7 +392,7 @@ func waitForEventFiles(ctx context.Context, eventDir string, contextCheckAfter t
 
 	// Set up context-yield timer when requested.
 	// A nil channel is never selected, so when contextCheckAfter is zero
-	// the timer case never fires and existing behaviour is preserved.
+	// the timer case never fires and existing behavior is preserved.
 	var contextYieldC <-chan time.Time
 	if contextCheckAfter > 0 {
 		t := time.NewTimer(contextCheckAfter)

--- a/internal/cmd/molecule_await_event.go
+++ b/internal/cmd/molecule_await_event.go
@@ -18,14 +18,15 @@ import (
 )
 
 var (
-	awaitEventChannel     string
-	awaitEventTimeout     string
-	awaitEventBackoffBase string
-	awaitEventBackoffMult int
-	awaitEventBackoffMax  string
-	awaitEventQuiet       bool
-	awaitEventAgentBead   string
-	awaitEventCleanup     bool
+	awaitEventChannel              string
+	awaitEventTimeout              string
+	awaitEventBackoffBase          string
+	awaitEventBackoffMult          int
+	awaitEventBackoffMax           string
+	awaitEventQuiet                bool
+	awaitEventAgentBead            string
+	awaitEventCleanup              bool
+	awaitEventContextCheckInterval string
 )
 
 // validChannelName is a convenience alias for the canonical regex in channelevents.
@@ -59,8 +60,22 @@ Same as await-signal: base * multiplier^idle_cycles, capped at max.
 Idle cycles and backoff-until timestamp tracked on agent bead labels.
 If killed and restarted, backoff resumes from the stored backoff-until.
 
+CONTEXT-YIELD:
+When --context-check-interval is set, await-event returns early with reason
+"context-yield" after the specified wall-clock interval, even if no event
+arrived and the backoff timeout has not expired. This allows patrol agents
+to assess context usage between waits, preventing unbounded accumulation
+during long idle periods.
+
+Output when yielding:
+  CONTEXT: check
+  EFFORT: full
+
+After context-check, call await-event again with the same parameters if
+context is acceptable, or hand off the session if context is high.
+
 EXIT CODES:
-  0 - Event(s) found or timeout
+  0 - Event(s) found, timeout, or context-yield
   1 - Error
 
 EXAMPLES:
@@ -72,7 +87,12 @@ EXAMPLES:
     --backoff-base 60s --backoff-mult 2 --backoff-max 10m
 
   # Auto-cleanup processed events
-  gt mol step await-event --channel refinery --cleanup`,
+  gt mol step await-event --channel refinery --cleanup
+
+  # Yield every 5m for context check during long idle waits
+  gt mol step await-event --channel refinery --agent-bead VAS-refinery \
+    --backoff-base 60s --backoff-mult 2 --backoff-max 15m --cleanup \
+    --context-check-interval 5m`,
 	RunE: runMoleculeAwaitEvent,
 }
 
@@ -108,6 +128,8 @@ func init() {
 		"Suppress output (for scripting)")
 	moleculeAwaitEventCmd.Flags().BoolVar(&awaitEventCleanup, "cleanup", false,
 		"Delete event files after reading them")
+	moleculeAwaitEventCmd.Flags().StringVar(&awaitEventContextCheckInterval, "context-check-interval", "",
+		"Yield after this wall-clock interval so the caller can assess context (e.g., 5m). Returns reason 'context-yield'.")
 	moleculeAwaitEventCmd.Flags().BoolVar(&moleculeJSON, "json", false,
 		"Output as JSON")
 	_ = moleculeAwaitEventCmd.MarkFlagRequired("channel")
@@ -168,6 +190,15 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("invalid timeout configuration: %w", err)
 	}
 
+	// Parse context-check interval (optional)
+	var contextCheckInterval time.Duration
+	if awaitEventContextCheckInterval != "" {
+		contextCheckInterval, err = time.ParseDuration(awaitEventContextCheckInterval)
+		if err != nil {
+			return fmt.Errorf("invalid context-check-interval: %w", err)
+		}
+	}
+
 	// Resume from backoff-until if interrupted (same pattern as await-signal)
 	timeout := fullTimeout
 	now := time.Now()
@@ -198,7 +229,7 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 	ctx, cancel := context.WithTimeout(context.Background(), timeout)
 	defer cancel()
 
-	result, err := waitForEventFiles(ctx, eventDir)
+	result, err := waitForEventFiles(ctx, eventDir, contextCheckInterval)
 	if err != nil {
 		return fmt.Errorf("event watch failed: %w", err)
 	}
@@ -227,8 +258,10 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 			}
 			result.IdleCycles = 0
 		}
+		// For "context-yield": idle cycles unchanged — we yielded early for context
+		// assessment, not because the full backoff window elapsed.
 
-		// Clear backoff-until — we completed normally
+		// Clear backoff-until — we completed (event, timeout, or context-yield)
 		_ = clearAgentBackoffUntil(awaitEventAgentBead, beadsDir)
 	}
 
@@ -240,7 +273,8 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 	}
 
 	// Set effort level based on idle cycles.
-	if result.Reason == "event" || result.IdleCycles == 0 {
+	// context-yield forces full effort: context-check must not be abbreviated.
+	if result.Reason == "event" || result.Reason == "context-yield" || result.IdleCycles == 0 {
 		result.EffortLevel = "full"
 	} else {
 		result.EffortLevel = "abbreviated"
@@ -270,6 +304,12 @@ func runMoleculeAwaitEvent(cmd *cobra.Command, args []string) error {
 		case "timeout":
 			fmt.Printf("%s Timeout after %v (idle cycle: %d)\n",
 				style.Dim.Render("⏱"), result.Elapsed.Round(time.Millisecond), result.IdleCycles)
+		case "context-yield":
+			fmt.Printf("%s Context-check interval reached after %v\n",
+				style.Dim.Render("↺"), result.Elapsed.Round(time.Millisecond))
+			fmt.Printf("\n%s Assess context usage before re-entering event wait.\n",
+				style.Bold.Render("CONTEXT: check"))
+			fmt.Printf("If context is OK, call await-event again. If context is high, hand off.\n")
 		}
 
 		// Output effort recommendation for the next patrol cycle.
@@ -322,7 +362,12 @@ func calculateEventTimeout(idleCycles int) (time.Duration, error) {
 
 // waitForEventFiles checks for pending events, then polls until events appear or timeout.
 // Uses a polling loop instead of inotifywait for cross-platform compatibility.
-func waitForEventFiles(ctx context.Context, eventDir string) (*AwaitEventResult, error) {
+//
+// contextCheckAfter, when non-zero, causes an early return with reason "context-yield"
+// after the given wall-clock duration. This allows the caller (a patrol agent) to
+// assess context usage before re-entering the wait, preventing unbounded context
+// accumulation during long idle periods.
+func waitForEventFiles(ctx context.Context, eventDir string, contextCheckAfter time.Duration) (*AwaitEventResult, error) {
 	// Check for already-pending events
 	events, err := readPendingEvents(eventDir)
 	if err != nil {
@@ -343,6 +388,16 @@ func waitForEventFiles(ctx context.Context, eventDir string) (*AwaitEventResult,
 	remaining := time.Until(deadline)
 	if remaining <= 0 {
 		return &AwaitEventResult{Reason: "timeout"}, nil
+	}
+
+	// Set up context-yield timer when requested.
+	// A nil channel is never selected, so when contextCheckAfter is zero
+	// the timer case never fires and existing behaviour is preserved.
+	var contextYieldC <-chan time.Time
+	if contextCheckAfter > 0 {
+		t := time.NewTimer(contextCheckAfter)
+		defer t.Stop()
+		contextYieldC = t.C
 	}
 
 	// Poll with 500ms interval until event appears or timeout.
@@ -366,6 +421,17 @@ func waitForEventFiles(ctx context.Context, eventDir string) (*AwaitEventResult,
 				}, nil
 			}
 			return &AwaitEventResult{Reason: "timeout"}, nil
+		case <-contextYieldC:
+			// Context-check interval elapsed. Do a final event check before
+			// yielding — if an event just arrived, return it instead.
+			events = readPendingEventsBounded(ctx, eventDir, 500*time.Millisecond)
+			if len(events) > 0 {
+				return &AwaitEventResult{
+					Reason: "event",
+					Events: events,
+				}, nil
+			}
+			return &AwaitEventResult{Reason: "context-yield"}, nil
 		case <-ticker.C:
 			// Run readPendingEvents in a goroutine so ctx.Done() can
 			// always interrupt the wait. Without this, a slow/stuck

--- a/internal/cmd/molecule_await_event_test.go
+++ b/internal/cmd/molecule_await_event_test.go
@@ -500,7 +500,7 @@ func TestWaitForEventFilesContextYieldTimeoutWins(t *testing.T) {
 }
 
 func TestWaitForEventFilesNoContextYieldWhenZero(t *testing.T) {
-	// When contextCheckAfter is 0 (not set), behaviour is unchanged:
+	// When contextCheckAfter is 0 (not set), behavior is unchanged:
 	// the wait runs to the full timeout without yielding.
 	dir := t.TempDir()
 

--- a/internal/cmd/molecule_await_event_test.go
+++ b/internal/cmd/molecule_await_event_test.go
@@ -300,7 +300,7 @@ func TestWaitForEventFilesPolling(t *testing.T) {
 	}()
 
 	start := time.Now()
-	result, err := waitForEventFiles(ctx, dir)
+	result, err := waitForEventFiles(ctx, dir, 0)
 	elapsed := time.Since(start)
 
 	if err != nil {
@@ -330,7 +330,7 @@ func TestWaitForEventFilesWithPending(t *testing.T) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
-	result, err := waitForEventFiles(ctx, dir)
+	result, err := waitForEventFiles(ctx, dir, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -349,7 +349,7 @@ func TestWaitForEventFilesTimeout(t *testing.T) {
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(-1*time.Second))
 	defer cancel()
 
-	result, err := waitForEventFiles(ctx, dir)
+	result, err := waitForEventFiles(ctx, dir, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -362,7 +362,7 @@ func TestWaitForEventFilesNoDeadline(t *testing.T) {
 	// With a context that has no deadline, should return timeout immediately.
 	dir := t.TempDir()
 
-	result, err := waitForEventFiles(context.Background(), dir)
+	result, err := waitForEventFiles(context.Background(), dir, 0)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -382,7 +382,7 @@ func TestWaitForEventFilesTimeoutWithPolling(t *testing.T) {
 	defer cancel()
 
 	start := time.Now()
-	result, err := waitForEventFiles(ctx, dir)
+	result, err := waitForEventFiles(ctx, dir, 0)
 	elapsed := time.Since(start)
 
 	if err != nil {
@@ -419,6 +419,127 @@ func TestReadPendingEventsBoundedCtxDone(t *testing.T) {
 	elapsed := time.Since(start)
 	if elapsed > 500*time.Millisecond {
 		t.Errorf("bounded read took %v with cancelled ctx; expected prompt return", elapsed)
+	}
+}
+
+func TestWaitForEventFilesContextYield(t *testing.T) {
+	// Regression test for #3870: --context-check-interval must cause an early
+	// return with reason "context-yield" before the full backoff timeout expires.
+	dir := t.TempDir()
+
+	// Full timeout is much longer than the yield interval.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	yieldAfter := 600 * time.Millisecond
+
+	start := time.Now()
+	result, err := waitForEventFiles(ctx, dir, yieldAfter)
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Reason != "context-yield" {
+		t.Errorf("expected reason 'context-yield', got %q (elapsed: %v)", result.Reason, elapsed)
+	}
+	// Must return close to the yield interval, not the full 10s timeout.
+	if elapsed < yieldAfter-100*time.Millisecond {
+		t.Errorf("returned too early (%v); yield interval was %v", elapsed, yieldAfter)
+	}
+	if elapsed > yieldAfter+2*time.Second {
+		t.Errorf("returned too late (%v); yield interval was %v", elapsed, yieldAfter)
+	}
+}
+
+func TestWaitForEventFilesContextYieldEventWins(t *testing.T) {
+	// When an event arrives before the context-yield interval, the event
+	// result takes priority.
+	dir := t.TempDir()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	yieldAfter := 5 * time.Second // yield interval is long — event arrives first
+
+	go func() {
+		time.Sleep(800 * time.Millisecond)
+		os.WriteFile(filepath.Join(dir, "early.event"), []byte(`{"type":"MERGE_READY"}`), 0644)
+	}()
+
+	result, err := waitForEventFiles(ctx, dir, yieldAfter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Reason != "event" {
+		t.Errorf("expected reason 'event' (event arrived before yield), got %q", result.Reason)
+	}
+	if len(result.Events) != 1 {
+		t.Errorf("expected 1 event, got %d", len(result.Events))
+	}
+}
+
+func TestWaitForEventFilesContextYieldTimeoutWins(t *testing.T) {
+	// When the backoff timeout is shorter than the yield interval, timeout
+	// fires first and the result is "timeout", not "context-yield".
+	dir := t.TempDir()
+
+	// Timeout is shorter than the yield interval.
+	ctx, cancel := context.WithTimeout(context.Background(), 600*time.Millisecond)
+	defer cancel()
+
+	yieldAfter := 5 * time.Second
+
+	result, err := waitForEventFiles(ctx, dir, yieldAfter)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Reason != "timeout" {
+		t.Errorf("expected reason 'timeout' (timeout < yield interval), got %q", result.Reason)
+	}
+}
+
+func TestWaitForEventFilesNoContextYieldWhenZero(t *testing.T) {
+	// When contextCheckAfter is 0 (not set), behaviour is unchanged:
+	// the wait runs to the full timeout without yielding.
+	dir := t.TempDir()
+
+	deadline := 600 * time.Millisecond
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
+	defer cancel()
+
+	start := time.Now()
+	result, err := waitForEventFiles(ctx, dir, 0) // zero = no yield
+	elapsed := time.Since(start)
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Reason != "timeout" {
+		t.Errorf("expected reason 'timeout' with zero yield interval, got %q", result.Reason)
+	}
+	if elapsed > deadline+2*time.Second {
+		t.Errorf("wait took %v; should have returned at ~%v", elapsed, deadline)
+	}
+}
+
+func TestEffortLevelContextYield(t *testing.T) {
+	// context-yield must produce EffortLevel "full" so context-check is
+	// not abbreviated.
+	result := &AwaitEventResult{
+		Reason:     "context-yield",
+		IdleCycles: 5, // high idle count that would normally produce "abbreviated"
+	}
+
+	// Replicate the effort-level logic from runMoleculeAwaitEvent.
+	if result.Reason == "event" || result.Reason == "context-yield" || result.IdleCycles == 0 {
+		result.EffortLevel = "full"
+	} else {
+		result.EffortLevel = "abbreviated"
+	}
+
+	if result.EffortLevel != "full" {
+		t.Errorf("context-yield should produce EffortLevel 'full', got %q", result.EffortLevel)
 	}
 }
 

--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -1145,8 +1145,8 @@ This command:
    - ...capped at 15 minutes max
 4. Tracks `idle:N` label on refinery agent bead for backoff state
 5. Returns `reason: context-yield` after 5m if no event arrived (see below)
-5. `--cleanup` auto-deletes processed event files
-6. Outputs `EFFORT: reduced` or `EFFORT: full` directive for next cycle
+6. `--cleanup` auto-deletes processed event files
+7. Outputs `EFFORT: reduced` or `EFFORT: full` directive for next cycle
 
 **Supported events:**
 - `MERGE_READY` — from witness when polecat branch is pushed and ready to merge

--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -1131,7 +1131,8 @@ Then use await-event to subscribe to the refinery event channel with exponential
 
 ```bash
 gt mol step await-event --channel refinery --agent-bead YOUR_AGENT_BEAD \
-  --backoff-base 30s --backoff-mult 2 --backoff-max 15m --cleanup
+  --backoff-base 30s --backoff-mult 2 --backoff-max 15m --cleanup \
+  --context-check-interval 5m
 ```
 
 This command:
@@ -1143,6 +1144,7 @@ This command:
    - Third timeout: 120s
    - ...capped at 15 minutes max
 4. Tracks `idle:N` label on refinery agent bead for backoff state
+5. Returns `reason: context-yield` after 5m if no event arrived (see below)
 5. `--cleanup` auto-deletes processed event files
 6. Outputs `EFFORT: reduced` or `EFFORT: full` directive for next cycle
 
@@ -1160,6 +1162,27 @@ gt agent state YOUR_AGENT_BEAD --set idle=0
 **On timeout** (no events):
 The idle counter was auto-incremented. Continue to next patrol cycle
 (the longer backoff will apply next time).
+
+**On context-yield** (5-minute interval reached, no events):
+`await-event` output shows `CONTEXT: check`. Assess session health NOW, before
+starting a new patrol cycle. This is the designed yield point — do NOT skip it.
+
+```
+1. Check RSS: ps -o rss= -p $$  (KB; divide by 1024 for MB)
+2. Check session age (see context-check step instructions above)
+3. Use your internal sense of context: are you forgetting earlier conversation?
+```
+
+If context is ACCEPTABLE (< 70% consumed, RSS < 1 GB, session < 8h):
+- Call await-event again with the same parameters to continue waiting
+- Do NOT start a full patrol cycle (avoids unnecessary token burn on idle rig)
+
+If context is HIGH (≥ 70% consumed, or RSS ≥ 1 GB, or session ≥ 8h):
+- Hand off immediately:
+  ```bash
+  gt patrol report --summary "context-yield handoff: <RSS>MB, <age>h"
+  gt handoff -s "Refinery context-yield handoff" -m "Yield after <age>h. Queue: <state>."
+  ```
 
 ## Effort-Based Patrol Routing
 
@@ -1179,14 +1202,15 @@ After await-event returns, check the EFFORT directive in the output:
 Abbreviated patrol should complete in ~10% of the tokens of a full patrol.
 Mark skipped steps as SKIP in the patrol report.
 
-After await-event returns (either by event or timeout):
+After await-event returns (either by event, timeout, or context-yield):
 1. **Re-assess session health** (check RSS, context, age again — conditions change)
-2. Close current patrol and start next cycle:
+2. If reason is `context-yield` and context is acceptable: re-enter await-event (skip steps 3-4)
+3. Close current patrol and start next cycle:
 ```bash
 gt patrol report --summary "<brief summary: branches merged, test results, queue state>"
 ```
 This closes the current patrol wisp and automatically creates a new one.
-3. Continue executing from the first step of the new patrol cycle
+4. Continue executing from the first step of the new patrol cycle
 
 **If you decide to hand off:**
 


### PR DESCRIPTION
## Summary

- Adds `--context-check-interval` flag to `gt mol step await-event`, causing an early return with reason `context-yield` after the specified wall-clock interval when no event has arrived
- Prevents refinery (and any event-waiting agent) from blocking indefinitely without context assessment, fixing the 15-hour runaway session described in the issue
- Updates `mol-refinery-patrol` formula to use `--context-check-interval 5m` and documents the context-yield handling loop

## Changes

- `internal/cmd/molecule_await_event.go`: new `--context-check-interval` flag; `waitForEventFiles` gains an optional `contextCheckAfter time.Duration` parameter; uses nil-channel idiom so zero value preserves existing behaviour; context-yield forces `EFFORT: full` so the context check is never abbreviated
- `internal/cmd/molecule_await_event_test.go`: all existing `waitForEventFiles` call sites updated to pass `0`; 5 new regression tests covering yield fires, event wins, timeout wins, zero-disables-yield, and effort-level
- `internal/formula/formulas/mol-refinery-patrol.formula.toml`: adds `--context-check-interval 5m` to the await-event call; documents the context-yield decision loop (re-enter vs hand off) with RSS/age thresholds

## Testing

- [x] `go build ./...` passes
- [x] All `TestWaitForEvent*` and `TestReadPendingEvents*` tests pass
- [x] `go vet ./...` passes
- [x] Self-review grade: B (no CRITICAL or MAJOR issues)

Closes #3870