### PR TITLE
fix(bd): suppress GH auto-export for molecule-type beads (gt-b48)

### DIFF
--- a/.beads/config.yaml
+++ b/.beads/config.yaml
@@ -42,8 +42,13 @@ external_projects:
 # Custom issue types for Gas Town (fallback when database is unavailable)
 types.custom: "agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request"
 
-prefix: 
-issue-prefix: 
+prefix:
+issue-prefix:
 dolt.idle-timeout: "0"
+
+# Molecules are internal GT scaffolding (patrol instances etc.) and must never
+# reach the GitHub issue tracker. Disabling auto-export prevents silent
+# regressions when the bd binary is upgraded. (gt-b48)
+export.auto: "false"
 
 sync.remote: "git+https://github.com/steveyegge/gastown.git"


### PR DESCRIPTION
## Summary

- Adds `export.auto: "false"` to `.beads/config.yaml` to prevent molecule beads from reaching the GitHub issue tracker
- bd v1.0.3+ defaults `export.auto` to `true`, which would auto-write `issues.jsonl` after every `bd create` — including molecule beads (internal GT scaffolding like patrol instances)
- The CI already rejects `issues.jsonl`, but being explicit prevents silent regressions when the bd binary is upgraded
- Also trims trailing whitespace from `prefix:` and `issue-prefix:` lines

## Changes

- `.beads/config.yaml`: add `export.auto: "false"` with explanatory comment

## Test plan

- [ ] Run `bd create "test molecule" --type molecule` and verify no `issues.jsonl` written
- [ ] Verify `bd create "normal issue"` still works correctly

🤖 Patch authored by gastown/polecats/slit, submitted via fork by mayor