### PR TITLE
fix: avoid duplicate inherited slash commands

### DIFF
--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -121,19 +121,29 @@ func pointsToAgentsMD(target string) bool {
 
 // commandsInherited reports whether workDir will receive slash commands via
 // Claude Code's path-hierarchy traversal without explicit provisioning.
-// This is true when workDir is nested inside a git repository that is also
-// a Gas Town workspace root: Claude Code walks up from workDir to the git
-// root and loads .claude/commands/ along the way, so any commands provisioned
-// at the workspace root are automatically visible to the agent.
-// Provisioning a second copy inside workDir would cause each command to appear
-// twice in the agent's command palette.
+// Commands are inherited when workDir is inside a Gas Town workspace root and
+// not separated from it by a nested git repo. Crew and polecat workdirs are
+// nested repos, so they still get their own command provisioning.
 func commandsInherited(workDir string) bool {
-	gitRoot := gitRootOf(workDir)
-	if gitRoot == "" || gitRoot == workDir {
+	townRoot, err := workspace.Find(workDir)
+	if err != nil || townRoot == "" || samePath(townRoot, workDir) {
 		return false
 	}
-	isWS, err := workspace.IsWorkspace(gitRoot)
-	return err == nil && isWS
+
+	gitRoot := gitRootOf(workDir)
+	if gitRoot != "" && !samePath(gitRoot, townRoot) {
+		return false
+	}
+	return true
+}
+
+func samePath(a, b string) bool {
+	absA, errA := filepath.Abs(a)
+	absB, errB := filepath.Abs(b)
+	if errA == nil && errB == nil {
+		return filepath.Clean(absA) == filepath.Clean(absB)
+	}
+	return filepath.Clean(a) == filepath.Clean(b)
 }
 
 // gitRootOf walks up from dir to find the nearest ancestor directory containing

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steveyegge/gastown/internal/hookutil"
 	"github.com/steveyegge/gastown/internal/templates/commands"
 	"github.com/steveyegge/gastown/internal/tmux"
+	"github.com/steveyegge/gastown/internal/workspace"
 )
 
 // EnsureSettingsForRole provisions all agent-specific configuration for a role.
@@ -52,8 +53,11 @@ func EnsureSettingsForRole(settingsDir, workDir, role string, rc *config.Runtime
 	}
 
 	// 2. Slash commands (agent-agnostic, uses shared body with provider-specific frontmatter)
-	// Only provision for known agents to maintain backwards compatibility
-	if commands.IsKnownAgent(provider) {
+	// Only provision for known agents to maintain backwards compatibility.
+	// Skip provisioning when workDir is nested inside a town root: Claude Code's
+	// path-hierarchy traversal already delivers the town root's .claude/commands/
+	// to the agent, so a duplicate copy in workDir causes each command to appear twice.
+	if commands.IsKnownAgent(provider) && !commandsInherited(workDir) {
 		if err := commands.ProvisionFor(workDir, provider); err != nil {
 			return err
 		}
@@ -113,6 +117,37 @@ func ensureGeminiContextFile(workDir string) error {
 
 func pointsToAgentsMD(target string) bool {
 	return filepath.Base(filepath.Clean(target)) == "AGENTS.md"
+}
+
+// commandsInherited reports whether workDir will receive slash commands via
+// Claude Code's path-hierarchy traversal without explicit provisioning.
+// This is true when workDir is nested inside a git repository that is also
+// a Gas Town workspace root: Claude Code walks up from workDir to the git
+// root and loads .claude/commands/ along the way, so any commands provisioned
+// at the workspace root are automatically visible to the agent.
+// Provisioning a second copy inside workDir would cause each command to appear
+// twice in the agent's command palette.
+func commandsInherited(workDir string) bool {
+	gitRoot := gitRootOf(workDir)
+	if gitRoot == "" || gitRoot == workDir {
+		return false
+	}
+	isWS, err := workspace.IsWorkspace(gitRoot)
+	return err == nil && isWS
+}
+
+// gitRootOf walks up from dir to find the nearest ancestor directory containing
+// a .git entry (file or directory). Returns empty string if none found.
+func gitRootOf(dir string) string {
+	for d := dir; ; d = filepath.Dir(d) {
+		if _, err := os.Stat(filepath.Join(d, ".git")); err == nil {
+			return d
+		}
+		parent := filepath.Dir(d)
+		if parent == d {
+			return ""
+		}
+	}
 }
 
 type startupPromptSession interface {

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -861,14 +861,9 @@ func TestRuntimeConfigWithMinDelay_ZeroMin(t *testing.T) {
 	}
 }
 
-// makeTownRoot creates a minimal town root directory structure for testing:
-// a .git marker and mayor/town.json so workspace.IsWorkspace returns true.
 func makeTownRoot(t *testing.T) string {
 	t.Helper()
 	root := t.TempDir()
-	if err := os.MkdirAll(root+"/.git", 0755); err != nil {
-		t.Fatal(err)
-	}
 	if err := os.MkdirAll(root+"/mayor", 0755); err != nil {
 		t.Fatal(err)
 	}
@@ -878,9 +873,18 @@ func makeTownRoot(t *testing.T) string {
 	return root
 }
 
+func makeTownRootWithGit(t *testing.T) string {
+	t.Helper()
+	root := makeTownRoot(t)
+	if err := os.MkdirAll(root+"/.git", 0755); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
 func TestCommandsInherited_WorkDirIsNestedInTownRoot(t *testing.T) {
 	// workDir is a subdirectory of the town root (same git repo) → inherited
-	root := makeTownRoot(t)
+	root := makeTownRootWithGit(t)
 	mayorDir := root + "/mayor"
 
 	if !commandsInherited(mayorDir) {
@@ -890,10 +894,35 @@ func TestCommandsInherited_WorkDirIsNestedInTownRoot(t *testing.T) {
 
 func TestCommandsInherited_WorkDirIsTownRoot(t *testing.T) {
 	// workDir == git root → not inherited (we're provisioning at the root itself)
-	root := makeTownRoot(t)
+	root := makeTownRootWithGit(t)
 
 	if commandsInherited(root) {
 		t.Error("commandsInherited() = true, want false when workDir equals the git root")
+	}
+}
+
+func TestCommandsInherited_WorkDirNestedInTownRootBeforeGitInit(t *testing.T) {
+	// gt install creates mayor/deacon settings before it initializes town .git.
+	// Those role dirs still inherit town-level commands once install provisions them.
+	root := makeTownRoot(t)
+	mayorDir := root + "/mayor"
+
+	if !commandsInherited(mayorDir) {
+		t.Error("commandsInherited() = false, want true for town role dir before .git exists")
+	}
+}
+
+func TestCommandsInherited_NestedGitRepoInsideTownRoot(t *testing.T) {
+	// Crew/polecat workdirs live in nested git repos under the town root. Claude
+	// Code stops at that repo boundary, so they need explicit command provisioning.
+	root := makeTownRootWithGit(t)
+	workDir := root + "/rig/polecats/chrome/repo"
+	if err := os.MkdirAll(workDir+"/.git", 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if commandsInherited(workDir) {
+		t.Error("commandsInherited() = true, want false for nested git repo inside town root")
 	}
 }
 
@@ -927,7 +956,7 @@ func TestEnsureSettingsForRole_SkipsCommandsWhenInheritedFromTownRoot(t *testing
 	// Mayor/deacon run inside the town root git repo. Commands provisioned at the
 	// town root are inherited by Claude Code's path-hierarchy traversal, so
 	// EnsureSettingsForRole must NOT provision a duplicate copy in the role dir.
-	root := makeTownRoot(t)
+	root := makeTownRootWithGit(t)
 	mayorDir := root + "/mayor"
 	if err := os.MkdirAll(mayorDir, 0755); err != nil {
 		t.Fatal(err)

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -860,3 +860,126 @@ func TestRuntimeConfigWithMinDelay_ZeroMin(t *testing.T) {
 		t.Errorf("ReadyDelayMs = %d, want 0", result.Tmux.ReadyDelayMs)
 	}
 }
+
+// makeTownRoot creates a minimal town root directory structure for testing:
+// a .git marker and mayor/town.json so workspace.IsWorkspace returns true.
+func makeTownRoot(t *testing.T) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.MkdirAll(root+"/.git", 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(root+"/mayor", 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(root+"/mayor/town.json", []byte(`{"type":"town"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	return root
+}
+
+func TestCommandsInherited_WorkDirIsNestedInTownRoot(t *testing.T) {
+	// workDir is a subdirectory of the town root (same git repo) → inherited
+	root := makeTownRoot(t)
+	mayorDir := root + "/mayor"
+
+	if !commandsInherited(mayorDir) {
+		t.Error("commandsInherited() = false, want true for workDir nested inside town root")
+	}
+}
+
+func TestCommandsInherited_WorkDirIsTownRoot(t *testing.T) {
+	// workDir == git root → not inherited (we're provisioning at the root itself)
+	root := makeTownRoot(t)
+
+	if commandsInherited(root) {
+		t.Error("commandsInherited() = true, want false when workDir equals the git root")
+	}
+}
+
+func TestCommandsInherited_WorkDirIsOutsideTownRoot(t *testing.T) {
+	// workDir in a standalone git repo that is NOT a Gas Town workspace → not inherited
+	dir := t.TempDir()
+	if err := os.MkdirAll(dir+"/.git", 0755); err != nil {
+		t.Fatal(err)
+	}
+	subDir := dir + "/src"
+	if err := os.MkdirAll(subDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if commandsInherited(subDir) {
+		t.Error("commandsInherited() = true, want false for workDir in non-workspace git repo")
+	}
+}
+
+func TestCommandsInherited_NoGitRoot(t *testing.T) {
+	// workDir has no .git ancestor → not inherited
+	dir := t.TempDir()
+	// Don't create .git
+
+	if commandsInherited(dir) {
+		t.Error("commandsInherited() = true, want false when no .git ancestor found")
+	}
+}
+
+func TestEnsureSettingsForRole_SkipsCommandsWhenInheritedFromTownRoot(t *testing.T) {
+	// Mayor/deacon run inside the town root git repo. Commands provisioned at the
+	// town root are inherited by Claude Code's path-hierarchy traversal, so
+	// EnsureSettingsForRole must NOT provision a duplicate copy in the role dir.
+	root := makeTownRoot(t)
+	mayorDir := root + "/mayor"
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	rc := &config.RuntimeConfig{
+		Hooks: &config.RuntimeHooksConfig{
+			Provider:     "claude",
+			Dir:          ".claude",
+			SettingsFile: "settings.json",
+		},
+	}
+
+	if err := EnsureSettingsForRole(mayorDir, mayorDir, "mayor", rc); err != nil {
+		t.Fatalf("EnsureSettingsForRole() error = %v", err)
+	}
+
+	// Commands must NOT be provisioned inside the role dir
+	for _, cmd := range []string{"done", "handoff", "review"} {
+		path := mayorDir + "/.claude/commands/" + cmd + ".md"
+		if _, err := os.Stat(path); err == nil {
+			t.Errorf("command %s.md was provisioned in mayor dir, want skipped (would duplicate town-root copy)", cmd)
+		}
+	}
+}
+
+func TestEnsureSettingsForRole_ProvisionCommandsOutsideTownRoot(t *testing.T) {
+	// Crew/polecat workDirs are outside the town root git repo.
+	// EnsureSettingsForRole must provision commands normally.
+	workDir := t.TempDir()
+	// workDir has no .git ancestor, so commandsInherited returns false.
+
+	rc := &config.RuntimeConfig{
+		Hooks: &config.RuntimeHooksConfig{
+			Provider:     "claude",
+			Dir:          ".claude",
+			SettingsFile: "settings.json",
+		},
+	}
+
+	if err := EnsureSettingsForRole(workDir, workDir, "crew", rc); err != nil {
+		t.Fatalf("EnsureSettingsForRole() error = %v", err)
+	}
+
+	// At least one command should be provisioned
+	provisioned := 0
+	for _, cmd := range []string{"done", "handoff", "review"} {
+		if _, err := os.Stat(workDir + "/.claude/commands/" + cmd + ".md"); err == nil {
+			provisioned++
+		}
+	}
+	if provisioned == 0 {
+		t.Error("no commands provisioned in workDir outside town root, want at least one")
+	}
+}


### PR DESCRIPTION
## Summary
- Builds on #4014 to skip per-role slash command provisioning when Claude Code already inherits the town-root commands.
- Handles fresh `gt install --git` ordering before the town `.git` exists.
- Preserves explicit command provisioning for nested crew/polecat git repos.

## Testing
- `go test ./internal/runtime`

Supersedes #4014.