### PR TITLE
Fix Ready Across Rigs sling resolution

### DIFF
--- a/internal/cmd/bd_helpers.go
+++ b/internal/cmd/bd_helpers.go
@@ -101,6 +101,32 @@ func filterEnvKey(env []string, key string) []string {
 	return result
 }
 
+func filterBdTargetEnv(env []string) []string {
+	for _, key := range []string{
+		"BEADS_DIR",
+		"BEADS_DB",
+		"BEADS_DOLT_SERVER_DATABASE",
+		"BEADS_DOLT_SERVER_HOST",
+		"BEADS_DOLT_SERVER_PORT",
+		"BEADS_DOLT_PORT",
+	} {
+		env = filterEnvKey(env, key)
+	}
+	return env
+}
+
+func pinBeadsDirEnv(env []string, beadsDir string) []string {
+	env = filterBdTargetEnv(env)
+	if beadsDir == "" {
+		return env
+	}
+	env = append(env, "BEADS_DIR="+beadsDir)
+	if dbEnv := beads.DatabaseEnv(beadsDir); dbEnv != "" {
+		env = append(env, dbEnv)
+	}
+	return env
+}
+
 // buildEnv constructs the final environment slice based on configured options.
 func (b *bdCmd) buildEnv() []string {
 	env := b.env
@@ -123,12 +149,15 @@ func (b *bdCmd) buildEnv() []string {
 	// Add BEADS_DIR if specified.
 	// This prevents inherited BEADS_DIR from causing bd to target the wrong
 	// database (e.g., HQ instead of rig). See gt-ctir.
+	//
+	// Also clear inherited Dolt target variables. Dashboard and agent shells can
+	// carry a town-level or remote BEADS_DOLT_* target; keeping it while changing
+	// BEADS_DIR makes `bd show <displayed-id>` query a different database than
+	// `gt ready` used to render the row.
 	if b.beadsDir != "" {
-		env = filterEnvKey(env, "BEADS_DIR")
-		env = append(env, "BEADS_DIR="+b.beadsDir)
+		env = pinBeadsDirEnv(env, b.beadsDir)
 	} else if b.dir != "" {
-		env = filterEnvKey(env, "BEADS_DIR")
-		env = append(env, "BEADS_DIR="+beads.ResolveBeadsDir(b.dir))
+		env = pinBeadsDirEnv(env, beads.ResolveBeadsDir(b.dir))
 	}
 
 	return env

--- a/internal/cmd/bd_helpers_test.go
+++ b/internal/cmd/bd_helpers_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -472,6 +473,47 @@ func TestBdCmd_WithBeadsDir_OverridesInherited(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("found %d BEADS_DIR entries, want 1 (dedup must remove old)", count)
+	}
+}
+
+func TestBdCmd_WithBeadsDir_OverridesInheritedDoltTarget(t *testing.T) {
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir beads dir: %v", err)
+	}
+	metadata := []byte(`{"backend":"dolt","dolt_database":"rigdb","dolt_server_host":"127.0.0.1","dolt_server_port":3307}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+
+	baseEnv := []string{
+		"PATH=/usr/bin",
+		"BEADS_DIR=/town/.beads",
+		"BEADS_DB=stale",
+		"BEADS_DOLT_SERVER_DATABASE=hq",
+		"BEADS_DOLT_SERVER_HOST=100.107.173.83",
+		"BEADS_DOLT_SERVER_PORT=3307",
+		"BEADS_DOLT_PORT=3307",
+	}
+
+	bdc := &bdCmd{
+		args:   []string{"show", "bds-abc", "--json"},
+		env:    baseEnv,
+		stderr: os.Stderr,
+	}
+	cmd := bdc.WithBeadsDir(beadsDir).Build()
+	envMap := parseEnv(cmd.Env)
+
+	if envMap["BEADS_DIR"] != beadsDir {
+		t.Errorf("BEADS_DIR = %q, want %q", envMap["BEADS_DIR"], beadsDir)
+	}
+	if envMap["BEADS_DOLT_SERVER_DATABASE"] != "rigdb" {
+		t.Errorf("BEADS_DOLT_SERVER_DATABASE = %q, want rigdb", envMap["BEADS_DOLT_SERVER_DATABASE"])
+	}
+	for _, key := range []string{"BEADS_DB", "BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT"} {
+		if value, ok := envMap[key]; ok {
+			t.Errorf("%s should be stripped when BEADS_DIR is pinned, got %q", key, value)
+		}
 	}
 }
 

--- a/internal/cmd/dashboard.go
+++ b/internal/cmd/dashboard.go
@@ -59,6 +59,7 @@ func runDashboard(cmd *cobra.Command, args []string) error {
 	// Check if we're in a workspace - if not, run in setup mode
 	var handler http.Handler
 	var err error
+	webCfg := config.DefaultWebTimeoutsConfig()
 
 	townRoot, wsErr := workspace.FindFromCwdOrError()
 	if wsErr != nil {
@@ -81,9 +82,10 @@ func runDashboard(cmd *cobra.Command, args []string) error {
 		}
 
 		// Load web timeouts config (nil-safe: NewDashboardMux applies defaults)
-		var webCfg *config.WebTimeoutsConfig
 		if ts, loadErr := config.LoadOrCreateTownSettings(config.TownSettingsPath(townRoot)); loadErr == nil {
-			webCfg = ts.WebTimeouts
+			if ts.WebTimeouts != nil {
+				webCfg = ts.WebTimeouts
+			}
 		} else {
 			fmt.Fprintf(cmd.ErrOrStderr(), "warning: loading town settings: %v (using defaults)\n", loadErr)
 		}
@@ -109,6 +111,12 @@ func runDashboard(cmd *cobra.Command, args []string) error {
 	// Open browser if requested
 	if dashboardOpen {
 		go openBrowser(url)
+	}
+
+	maxRunTimeout := config.ParseDurationOrDefault(webCfg.MaxRunTimeout, 120*time.Second)
+	writeTimeout := maxRunTimeout + 15*time.Second
+	if writeTimeout < 60*time.Second {
+		writeTimeout = 60 * time.Second
 	}
 
 	// Start the server with timeouts
@@ -147,7 +155,7 @@ func runDashboard(cmd *cobra.Command, args []string) error {
 		Handler:           handler,
 		ReadHeaderTimeout: 10 * time.Second,
 		ReadTimeout:       30 * time.Second,
-		WriteTimeout:      60 * time.Second,
+		WriteTimeout:      writeTimeout,
 		IdleTimeout:       120 * time.Second,
 	}
 	return server.ListenAndServe()

--- a/internal/cmd/ready.go
+++ b/internal/cmd/ready.go
@@ -3,8 +3,8 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"sort"
 	"strings"
@@ -137,6 +137,10 @@ func runReady(cmd *cobra.Command, args []string) error {
 				// Defense-in-depth: also filter wisps that shouldn't appear in ready work
 				wispIDs := getWispIDs(townBeadsPath)
 				filtered = filterWisps(filtered, wispIDs)
+				// Only show work whose ID routes back to the source that reported it.
+				// Otherwise the dashboard can render a row that `gt sling <same-id>`
+				// cannot resolve because routes.jsonl points that prefix elsewhere.
+				filtered = filterReadyIssuesByRoute(townRoot, "town", filtered)
 				// Filter identity beads (agents, roles, rigs) - not actionable work
 				src.Issues = filterIdentityBeads(filtered)
 			}
@@ -166,6 +170,10 @@ func runReady(cmd *cobra.Command, args []string) error {
 				// Defense-in-depth: also filter wisps that shouldn't appear in ready work
 				wispIDs := getWispIDs(r.BeadsPath())
 				filtered = filterWisps(filtered, wispIDs)
+				// Only show work whose ID routes back to this rig. This keeps the
+				// Ready Across Rigs surface honest: every displayed ID must be
+				// usable by the stock `gt sling <id> <rig>` command.
+				filtered = filterReadyIssuesByRoute(townRoot, r.Name, filtered)
 				// Filter identity beads (agents, roles, rigs) - not actionable work
 				src.Issues = filterIdentityBeads(filtered)
 			}
@@ -383,9 +391,11 @@ func filterFormulaScaffolds(issues []*beads.Issue, formulaNames map[string]bool)
 // This is a defense-in-depth exclusion - bd ready should already filter wisps,
 // but we double-check at the display layer to ensure operational work doesn't leak.
 func getWispIDs(beadsPath string) map[string]bool {
-	cmd := exec.Command("bd", "mol", "wisp", "list", "--json")
-	cmd.Dir = beadsPath
-	output, err := cmd.Output()
+	output, err := BdCmd("mol", "wisp", "list", "--json").
+		Dir(beadsPath).
+		StripBeadsDir().
+		Stderr(io.Discard).
+		Output()
 	if err != nil {
 		return nil // Wisp table may not exist or Dolt unavailable
 	}
@@ -454,6 +464,42 @@ func filterIdentityBeads(issues []*beads.Issue) []*beads.Issue {
 		filtered = append(filtered, issue)
 	}
 	return filtered
+}
+
+// filterReadyIssuesByRoute keeps only issues whose prefix route matches the
+// source that reported them. Ready rows are actionable: the dashboard renders a
+// Sling button for each row, so the displayed ID must resolve through the same
+// routes.jsonl path that produced it.
+func filterReadyIssuesByRoute(townRoot, source string, issues []*beads.Issue) []*beads.Issue {
+	if townRoot == "" {
+		return issues
+	}
+
+	filtered := make([]*beads.Issue, 0, len(issues))
+	for _, issue := range issues {
+		if readyIssueRoutesToSource(townRoot, source, issue.ID) {
+			filtered = append(filtered, issue)
+		}
+	}
+	return filtered
+}
+
+func readyIssueRoutesToSource(townRoot, source, issueID string) bool {
+	prefix := beads.ExtractPrefix(issueID)
+	if prefix == "" {
+		return false
+	}
+
+	routePath := beads.GetRigPathForPrefix(townRoot, prefix)
+	if routePath == "" {
+		return false
+	}
+
+	if source == "town" {
+		return routePath == townRoot
+	}
+
+	return beads.GetRigNameForPrefix(townRoot, prefix) == source
 }
 
 // filterWisps removes wisp issues from the list.

--- a/internal/cmd/ready_test.go
+++ b/internal/cmd/ready_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/beads"
@@ -56,6 +58,14 @@ func TestGetFormulaNames(t *testing.T) {
 	if len(names) != len(expected) {
 		t.Errorf("got %d formula names, want %d", len(names), len(expected))
 	}
+}
+
+func issueIDs(issues []*beads.Issue) []string {
+	ids := make([]string, 0, len(issues))
+	for _, issue := range issues {
+		ids = append(ids, issue.ID)
+	}
+	return ids
 }
 
 func TestGetFormulaNames_NonexistentDir(t *testing.T) {
@@ -176,5 +186,43 @@ func TestFilterFormulaScaffolds_DotInNonScaffold(t *testing.T) {
 	filtered := filterFormulaScaffolds(issues, formulaNames)
 	if len(filtered) != 2 {
 		t.Errorf("got %d issues, want 2 (non-formula dots should not filter)", len(filtered))
+	}
+}
+
+func TestFilterReadyIssuesByRoute(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("creating town beads dir: %v", err)
+	}
+	routes := strings.Join([]string{
+		`{"prefix":"hq-","path":"."}`,
+		`{"prefix":"hq-cv-","path":"."}`,
+		`{"prefix":"bds-","path":"bd_symphony/mayor/rig"}`,
+		`{"prefix":"gt-","path":"gastown/mayor/rig"}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("writing routes: %v", err)
+	}
+
+	issues := []*beads.Issue{
+		{ID: "hq-123", Title: "town work"},
+		{ID: "hq-cv-123", Title: "town convoy"},
+		{ID: "bds-town-stale", Title: "wrongly-created town bds row"},
+		{ID: "unknown-123", Title: "unknown route"},
+	}
+	filtered := filterReadyIssuesByRoute(townRoot, "town", issues)
+	if got, want := issueIDs(filtered), []string{"hq-123", "hq-cv-123"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("town filtered IDs = %v, want %v", got, want)
+	}
+
+	issues = []*beads.Issue{
+		{ID: "bds-123", Title: "bd_symphony work"},
+		{ID: "hq-123", Title: "town work in rig result"},
+		{ID: "gt-123", Title: "other rig work"},
+		{ID: "unknown-123", Title: "unknown route"},
+	}
+	filtered = filterReadyIssuesByRoute(townRoot, "bd_symphony", issues)
+	if got, want := issueIDs(filtered), []string{"bds-123"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("rig filtered IDs = %v, want %v", got, want)
 	}
 }

--- a/internal/cmd/show_unix.go
+++ b/internal/cmd/show_unix.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"os/exec"
 	"syscall"
+
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 // execBdShow replaces the current process with 'bd show'.
@@ -19,13 +21,15 @@ func execBdShow(args []string) error {
 		return fmt.Errorf("bd not found in PATH: %w", err)
 	}
 
+	beadsDir := ""
 	if beadID := extractBeadIDFromArgs(args); beadID != "" {
 		if dir := resolveBeadDir(beadID); dir != "" && dir != "." {
 			_ = os.Chdir(dir)
+			beadsDir = beads.ResolveBeadsDir(dir)
 		}
 	}
 
-	env := stripEnvKey(os.Environ(), "BEADS_DIR")
+	env := pinBeadsDirEnv(os.Environ(), beadsDir)
 
 	// Build args: bd show <all-args>
 	// argv[0] must be the program name for exec

--- a/internal/cmd/show_windows.go
+++ b/internal/cmd/show_windows.go
@@ -6,6 +6,8 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 // execBdShow runs 'bd show' with stdio passthrough on Windows.
@@ -18,13 +20,15 @@ func execBdShow(args []string) error {
 		return fmt.Errorf("bd not found in PATH: %w", err)
 	}
 
+	beadsDir := ""
 	if beadID := extractBeadIDFromArgs(args); beadID != "" {
 		if dir := resolveBeadDir(beadID); dir != "" && dir != "." {
 			_ = os.Chdir(dir)
+			beadsDir = beads.ResolveBeadsDir(dir)
 		}
 	}
 
-	env := stripEnvKey(os.Environ(), "BEADS_DIR")
+	env := pinBeadsDirEnv(os.Environ(), beadsDir)
 
 	cmdArgs := append([]string{"show"}, args...)
 	cmd := exec.Command(bdPath, cmdArgs...)

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -149,7 +149,7 @@ type WebTimeoutsConfig struct {
 	FetchTimeout string `json:"fetch_timeout,omitempty"`
 	// DefaultRunTimeout is the default timeout for /api/run commands. Default: "30s".
 	DefaultRunTimeout string `json:"default_run_timeout,omitempty"`
-	// MaxRunTimeout is the maximum allowed timeout for /api/run commands. Default: "60s".
+	// MaxRunTimeout is the maximum allowed timeout for /api/run commands. Default: "120s".
 	MaxRunTimeout string `json:"max_run_timeout,omitempty"`
 }
 
@@ -161,7 +161,7 @@ func DefaultWebTimeoutsConfig() *WebTimeoutsConfig {
 		TmuxCmdTimeout:    "2s",
 		FetchTimeout:      "8s",
 		DefaultRunTimeout: "30s",
-		MaxRunTimeout:     "60s",
+		MaxRunTimeout:     "120s",
 	}
 }
 

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -66,7 +66,7 @@ func TestDefaultWebTimeoutsConfig(t *testing.T) {
 		{"TmuxCmdTimeout", cfg.TmuxCmdTimeout, 0, 2 * time.Second},
 		{"FetchTimeout", cfg.FetchTimeout, 0, 8 * time.Second},
 		{"DefaultRunTimeout", cfg.DefaultRunTimeout, 0, 30 * time.Second},
-		{"MaxRunTimeout", cfg.MaxRunTimeout, 0, 60 * time.Second},
+		{"MaxRunTimeout", cfg.MaxRunTimeout, 0, 120 * time.Second},
 	}
 
 	for _, tt := range tests {
@@ -141,7 +141,7 @@ func TestWebTimeoutsConfig_JSONRoundTrip(t *testing.T) {
 		TmuxCmdTimeout:    "3s",
 		FetchTimeout:      "12s",
 		DefaultRunTimeout: "45s",
-		MaxRunTimeout:      "90s",
+		MaxRunTimeout:     "90s",
 	}
 
 	data, err := json.Marshal(original)
@@ -603,7 +603,7 @@ func TestParseDurationOrDefault_AllWebTimeoutDefaults(t *testing.T) {
 		{"TmuxCmdTimeout", empty.TmuxCmdTimeout, defaults.TmuxCmdTimeout, 2 * time.Second},
 		{"FetchTimeout", empty.FetchTimeout, defaults.FetchTimeout, 8 * time.Second},
 		{"DefaultRunTimeout", empty.DefaultRunTimeout, defaults.DefaultRunTimeout, 30 * time.Second},
-		{"MaxRunTimeout", empty.MaxRunTimeout, defaults.MaxRunTimeout, 60 * time.Second},
+		{"MaxRunTimeout", empty.MaxRunTimeout, defaults.MaxRunTimeout, 120 * time.Second},
 	}
 
 	for _, p := range pairs {
@@ -621,5 +621,3 @@ func TestParseDurationOrDefault_AllWebTimeoutDefaults(t *testing.T) {
 		})
 	}
 }
-
-

--- a/internal/web/api.go
+++ b/internal/web/api.go
@@ -10,11 +10,14 @@ import (
 	"net/http"
 	"os"
 	"os/exec"
+	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
 )
@@ -695,6 +698,16 @@ type OptionsResponse struct {
 // handleOptions returns dynamic options for command arguments.
 // Results are cached for 30 seconds to avoid slow repeated fetches.
 func (h *APIHandler) handleOptions(w http.ResponseWriter, r *http.Request) {
+	optionType := strings.ToLower(strings.TrimSpace(r.URL.Query().Get("type")))
+
+	if optionType == "rigs" {
+		resp := &OptionsResponse{}
+		resp.Rigs = h.loadRigOptions(r.Context())
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(resp)
+		return
+	}
+
 	// Check cache first — serialize under RLock to a buffer so we don't
 	// hold the lock while writing to the ResponseWriter (which can block
 	// on slow clients).
@@ -725,20 +738,9 @@ func (h *APIHandler) handleOptions(w http.ResponseWriter, r *http.Request) {
 	// Fetch rigs
 	go func() {
 		defer wg.Done()
-		if output, err := h.runGtCommand(r.Context(), 3*time.Second, []string{"rig", "list", "--json"}); err == nil {
-			mu.Lock()
-			resp.Rigs = parseRigListJSON(output)
-			mu.Unlock()
-		} else {
-			log.Printf("warning: handleOptions: rig list --json: %v", err)
-			if output, fallbackErr := h.runGtCommand(r.Context(), 3*time.Second, []string{"rig", "list"}); fallbackErr == nil {
-				mu.Lock()
-				resp.Rigs = parseRigListOutput(output)
-				mu.Unlock()
-			} else {
-				log.Printf("warning: handleOptions: rig list fallback: %v", fallbackErr)
-			}
-		}
+		mu.Lock()
+		resp.Rigs = h.loadRigOptions(r.Context())
+		mu.Unlock()
 	}()
 
 	// Fetch polecats
@@ -824,6 +826,75 @@ func (h *APIHandler) handleOptions(w http.ResponseWriter, r *http.Request) {
 	w.Header().Set("Content-Type", "application/json")
 	w.Header().Set("X-Cache", "MISS")
 	_ = json.NewEncoder(w).Encode(resp)
+}
+
+func (h *APIHandler) loadRigOptions(ctx context.Context) []string {
+	if rigs, err := h.loadRigOptionsFromConfig(); err == nil {
+		return rigs
+	}
+
+	if output, err := h.runGtCommand(ctx, 3*time.Second, []string{"rig", "list", "--json"}); err == nil {
+		return parseRigListJSON(output)
+	} else {
+		log.Printf("warning: handleOptions: rig list --json: %v", err)
+	}
+
+	if output, err := h.runGtCommand(ctx, 3*time.Second, []string{"rig", "list"}); err == nil {
+		return parseRigListOutput(output)
+	} else {
+		log.Printf("warning: handleOptions: rig list fallback: %v", err)
+	}
+
+	return nil
+}
+
+func (h *APIHandler) loadRigOptionsFromConfig() ([]string, error) {
+	rigsPath, err := findRigsConfigPath(h.workDir)
+	if err != nil {
+		return nil, err
+	}
+	rigsConfig, err := config.LoadRigsConfig(rigsPath)
+	if err != nil {
+		return nil, err
+	}
+
+	rigs := make([]string, 0, len(rigsConfig.Rigs))
+	for name := range rigsConfig.Rigs {
+		if strings.TrimSpace(name) != "" {
+			rigs = append(rigs, name)
+		}
+	}
+	sort.Strings(rigs)
+	return rigs, nil
+}
+
+func findRigsConfigPath(startDir string) (string, error) {
+	dir := startDir
+	if dir == "" {
+		var err error
+		dir, err = os.Getwd()
+		if err != nil {
+			return "", err
+		}
+	}
+
+	dir, err := filepath.Abs(dir)
+	if err != nil {
+		return "", err
+	}
+
+	for {
+		rigsPath := filepath.Join(dir, "mayor", "rigs.json")
+		if _, err := os.Stat(rigsPath); err == nil {
+			return rigsPath, nil
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			return "", os.ErrNotExist
+		}
+		dir = parent
+	}
 }
 
 // parseRigListOutput extracts rig names from the text output of "gt rig list".

--- a/internal/web/api_test.go
+++ b/internal/web/api_test.go
@@ -1068,6 +1068,147 @@ esac
 	}
 }
 
+func TestHandleOptionsTypeRigsOnlyFetchesRigs(t *testing.T) {
+	binDir := t.TempDir()
+	gtPath := filepath.Join(binDir, "gt")
+
+	gtScript := `#!/usr/bin/env sh
+set -eu
+case "$*" in
+  "rig list --json")
+    printf '[{"name":"bd_symphony","status":"operational"}]\n'
+    ;;
+  *)
+    printf 'unexpected gt args: %s\n' "$*" >&2
+    exit 2
+    ;;
+esac
+`
+
+	if err := os.WriteFile(gtPath, []byte(gtScript), 0o755); err != nil {
+		t.Fatalf("write fake gt: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	h := &APIHandler{
+		gtPath:            gtPath,
+		workDir:           t.TempDir(),
+		defaultRunTimeout: 5 * time.Second,
+		maxRunTimeout:     10 * time.Second,
+		cmdSem:            make(chan struct{}, maxConcurrentCommands),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/options?type=rigs", nil)
+	w := httptest.NewRecorder()
+	h.handleOptions(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("handleOptions returned status %d: %s", w.Code, w.Body.String())
+	}
+	var resp OptionsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v\nbody=%s", err, w.Body.String())
+	}
+	if got, want := resp.Rigs, []string{"bd_symphony"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("Rigs = %v, want %v", got, want)
+	}
+	if len(resp.Convoys) != 0 || len(resp.Hooks) != 0 || len(resp.Agents) != 0 {
+		t.Fatalf("type=rigs response included unrelated options: %+v", resp)
+	}
+}
+
+func TestHandleOptionsTypeRigsUsesConfigWithoutCommands(t *testing.T) {
+	workDir := t.TempDir()
+	mayorDir := filepath.Join(workDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0o755); err != nil {
+		t.Fatalf("create mayor dir: %v", err)
+	}
+	rigsJSON := `{"version":1,"rigs":{"zeta":{"git_url":"x","added_at":"2026-01-01T00:00:00Z"},"bd_symphony":{"git_url":"x","added_at":"2026-01-01T00:00:00Z"}}}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(rigsJSON), 0o644); err != nil {
+		t.Fatalf("write rigs.json: %v", err)
+	}
+
+	binDir := t.TempDir()
+	gtPath := filepath.Join(binDir, "gt")
+	if err := os.WriteFile(gtPath, []byte("#!/usr/bin/env sh\nexit 23\n"), 0o755); err != nil {
+		t.Fatalf("write fake gt: %v", err)
+	}
+
+	h := &APIHandler{
+		gtPath:            gtPath,
+		workDir:           workDir,
+		defaultRunTimeout: 5 * time.Second,
+		maxRunTimeout:     10 * time.Second,
+		cmdSem:            make(chan struct{}, maxConcurrentCommands),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/options?type=rigs", nil)
+	w := httptest.NewRecorder()
+	h.handleOptions(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("handleOptions returned status %d: %s", w.Code, w.Body.String())
+	}
+	var resp OptionsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v\nbody=%s", err, w.Body.String())
+	}
+	want := []string{"bd_symphony", "zeta"}
+	if len(resp.Rigs) != len(want) {
+		t.Fatalf("Rigs = %v, want %v", resp.Rigs, want)
+	}
+	for i := range want {
+		if resp.Rigs[i] != want[i] {
+			t.Fatalf("Rigs[%d] = %q, want %q; full=%v", i, resp.Rigs[i], want[i], resp.Rigs)
+		}
+	}
+}
+
+func TestHandleOptionsTypeRigsFindsConfigFromSubdir(t *testing.T) {
+	townRoot := t.TempDir()
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0o755); err != nil {
+		t.Fatalf("create mayor dir: %v", err)
+	}
+	rigsJSON := `{"version":1,"rigs":{"bd_symphony":{"git_url":"x","added_at":"2026-01-01T00:00:00Z"}}}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(rigsJSON), 0o644); err != nil {
+		t.Fatalf("write rigs.json: %v", err)
+	}
+	subdir := filepath.Join(townRoot, "bd_symphony", "mayor", "rig")
+	if err := os.MkdirAll(subdir, 0o755); err != nil {
+		t.Fatalf("create subdir: %v", err)
+	}
+
+	binDir := t.TempDir()
+	gtPath := filepath.Join(binDir, "gt")
+	if err := os.WriteFile(gtPath, []byte("#!/usr/bin/env sh\nexit 23\n"), 0o755); err != nil {
+		t.Fatalf("write fake gt: %v", err)
+	}
+
+	h := &APIHandler{
+		gtPath:            gtPath,
+		workDir:           subdir,
+		defaultRunTimeout: 5 * time.Second,
+		maxRunTimeout:     10 * time.Second,
+		cmdSem:            make(chan struct{}, maxConcurrentCommands),
+	}
+
+	req := httptest.NewRequest(http.MethodGet, "/api/options?type=rigs", nil)
+	w := httptest.NewRecorder()
+	h.handleOptions(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("handleOptions returned status %d: %s", w.Code, w.Body.String())
+	}
+	var resp OptionsResponse
+	if err := json.Unmarshal(w.Body.Bytes(), &resp); err != nil {
+		t.Fatalf("parse response: %v\nbody=%s", err, w.Body.String())
+	}
+	if got, want := resp.Rigs, []string{"bd_symphony"}; len(got) != len(want) || got[0] != want[0] {
+		t.Fatalf("Rigs = %v, want %v", got, want)
+	}
+}
+
 func TestParseConvoyListJSON(t *testing.T) {
 	tests := []struct {
 		name string

--- a/internal/web/static/dashboard.js
+++ b/internal/web/static/dashboard.js
@@ -1784,7 +1784,7 @@
         fetch('/api/run', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ command: cmd, confirmed: true })
+            body: JSON.stringify({ command: cmd, confirmed: true, timeout: 120 })
         })
         .then(function(r) { return r.json(); })
         .then(function(data) {
@@ -2684,7 +2684,7 @@
         fetch('/api/run', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ command: cmd, confirmed: true })
+            body: JSON.stringify({ command: cmd, confirmed: true, timeout: 120 })
         })
         .then(function(r) { return r.json(); })
         .then(function(data) {

--- a/internal/web/templates_test.go
+++ b/internal/web/templates_test.go
@@ -2,6 +2,7 @@ package web
 
 import (
 	"bytes"
+	"os"
 	"strings"
 	"testing"
 	"time"
@@ -56,6 +57,17 @@ func TestConvoyTemplate_RendersConvoyList(t *testing.T) {
 
 	// The simplified dashboard no longer shows convoy titles in the table,
 	// only the convoy IDs. Titles are shown in expanded view.
+}
+
+func TestDashboardScript_SlingUsesLongRunTimeout(t *testing.T) {
+	js, err := os.ReadFile("static/dashboard.js")
+	if err != nil {
+		t.Fatalf("ReadFile(static/dashboard.js) error = %v", err)
+	}
+
+	if !strings.Contains(string(js), `JSON.stringify({ command: cmd, confirmed: true, timeout: 120 })`) {
+		t.Error("Sling action should request a long /api/run timeout")
+	}
 }
 
 func TestConvoyTemplate_LastActivityColors(t *testing.T) {


### PR DESCRIPTION
## Summary

This fixes the Ready Across Rigs dashboard path so rows shown in the UI are sling-resolvable by the same visible ID.

The change keeps the scope narrow:

- pin routed Beads commands to the selected workspace database when resolving/showing routed work
- filter Ready Across Rigs rows that cannot be resolved through the same visible ID and route
- resolve `type=rigs` dropdown options from the town rig registry without requiring the slower full options fanout
- request a longer `/api/run` timeout for dashboard Sling actions, matching the real launch path

## Why

The dashboard can display ready work across rigs, but the UI should only show actionable rows: if a user sees a row ID in Ready Across Rigs and clicks Sling, that same ID should resolve through Gastown's routing model and dispatch successfully.

Without this, Ready Across Rigs can surface rows whose visible ID and route context disagree, or the Sling dropdown can fail before the user reaches the launch step.

## Validation

Automated checks:

- `go vet ./...`
- `umask 022; go test ./...`

Manual browser smoke test against a local routed-rig fixture:

- installed `gt` from this branch: `gt version v1.1.0-145-g1dd1248c`
- restarted the dashboard from a local town workspace
- confirmed `/api/options?type=rigs` returns the configured rig
- clicked a visible Ready Across Rigs row
- clicked the stock `Sling` action
- selected the target rig from the dropdown
- observed `/api/run` return HTTP 200 with `success: true`
- confirmed the backend moved the same visible row ID to `hooked`
- unslung/reset the fixture afterward

## Notes

This does not add new dashboard concepts; it makes the existing ready-work and Sling surfaces agree on the visible work ID and routing context.

Internal tracking: bd-0xv78
Agent: codex
