### PR TITLE
fix: filter '(not set)' sentinel from bd config output (gt-kbi)

### DIFF
--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -234,7 +234,7 @@ func EnsureCustomStatuses(beadsDir string) error {
 
 	// Build merged set: existing + required
 	statusSet := make(map[string]bool)
-	if existing := strings.TrimSpace(string(existingOutput)); existing != "" {
+	if existing := ParseConfigOutput(existingOutput); existing != "" {
 		for _, s := range strings.Split(existing, ",") {
 			s = strings.TrimSpace(s)
 			if s != "" {
@@ -478,4 +478,21 @@ func ResetEnsuredDirs() {
 	ensuredMu.Lock()
 	defer ensuredMu.Unlock()
 	ensuredDirs = make(map[string]bool)
+}
+
+// ParseConfigOutput extracts the config value from `bd config get <key>` output,
+// filtering out informational lines (`Note: ...`) and the unset sentinel
+// (`<key> (not set)`). Returns "" when no value line is present.
+//
+// Without this filter, callers that merge the parsed value back into a
+// `bd config set` would pollute the config with strings like
+// "status.custom (not set)", which fail bd's regex validation (gt-kbi).
+func ParseConfigOutput(output []byte) string {
+	for _, line := range strings.Split(string(output), "\n") {
+		line = strings.TrimSpace(line)
+		if line != "" && !strings.HasPrefix(line, "Note:") && !strings.Contains(line, "(not set)") {
+			return line
+		}
+	}
+	return ""
 }

--- a/internal/beads/beads_types_test.go
+++ b/internal/beads/beads_types_test.go
@@ -585,6 +585,102 @@ func TestEnsureCustomStatuses(t *testing.T) {
 			t.Error("statuses cache key should not collide with types cache key")
 		}
 	})
+
+	// Regression for gt-kbi: when `bd config get status.custom` returns the
+	// unset sentinel "status.custom (not set)", EnsureCustomStatuses must NOT
+	// merge that literal string into the value passed to `bd config set` —
+	// bd rejects it via the [a-z][a-z0-9_-]* validator, breaking gt convoy.
+	t.Run("unset sentinel from bd config get is filtered (gt-kbi)", func(t *testing.T) {
+		if runtime.GOOS == "windows" {
+			t.Skip("test uses Unix shell script mock for bd")
+		}
+
+		binDir := t.TempDir()
+		logPath := filepath.Join(binDir, "bd.log")
+		script := `#!/bin/sh
+LOG_FILE='` + logPath + `'
+printf '%s\n' "$*" >> "$LOG_FILE"
+
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+
+case "$cmd" in
+  init)
+    target="${BEADS_DIR:-$(pwd)/.beads}"
+    mkdir -p "$target/dolt"
+    printf 'prefix: gt\nissue-prefix: gt-\n' > "$target/config.yaml"
+    exit 0
+    ;;
+  config)
+    # Simulate the real bd behaviour for an unset key: stdout carries the
+    # "<key> (not set)" sentinel and exit status is 0.
+    if echo "$*" | grep -q "get status.custom"; then
+      echo "status.custom (not set)"
+    fi
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+		if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+			t.Fatalf("write mock bd: %v", err)
+		}
+		t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+		tmpDir := t.TempDir()
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		if err := os.MkdirAll(filepath.Join(beadsDir, "dolt"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		ResetEnsuredDirs()
+
+		if err := EnsureCustomStatuses(beadsDir); err != nil {
+			t.Fatalf("EnsureCustomStatuses: %v", err)
+		}
+
+		logOutput := readMockBDLog(t, logPath)
+		if strings.Contains(logOutput, "(not set)") {
+			t.Fatalf("bd config set received the unset sentinel as a status value:\n%s", logOutput)
+		}
+
+		// Verify the set call carries exactly the canonical statuses list.
+		want := "config set status.custom " + strings.Join(constants.BeadsCustomStatusesList(), ",")
+		if !strings.Contains(logOutput, want) {
+			t.Fatalf("bd config set missing canonical statuses\nwant substring: %q\ngot:\n%s", want, logOutput)
+		}
+	})
+}
+
+func TestParseConfigOutput(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  string
+	}{
+		{"empty", "", ""},
+		{"only whitespace", "  \n  \n", ""},
+		{"plain value", "agent,role,rig\n", "agent,role,rig"},
+		{"value after Note prefix", "Note: background sync off\nagent,role\n", "agent,role"},
+		{"value after multiple Note prefixes", "Note: a\nNote: b\nagent\n", "agent"},
+		{"unset sentinel filtered", "status.custom (not set)\n", ""},
+		{"unset sentinel followed by value", "status.custom (not set)\nstaged_ready\n", "staged_ready"},
+		{"Note prefix is case-sensitive", "note: lower-case\n", "note: lower-case"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := ParseConfigOutput([]byte(tt.input)); got != tt.want {
+				t.Errorf("ParseConfigOutput(%q) = %q, want %q", tt.input, got, tt.want)
+			}
+		})
+	}
 }
 
 func TestEnsureDatabaseInitialized(t *testing.T) {

--- a/internal/doctor/config_check.go
+++ b/internal/doctor/config_check.go
@@ -709,14 +709,9 @@ func (c *CustomTypesCheck) Run(ctx *CheckContext) *CheckResult {
 
 // parseConfigOutput extracts the config value from bd output, filtering out
 // informational messages like "Note: ..." that bd may emit to stdout.
+// Thin wrapper preserved so existing tests/call sites compile unchanged.
 func parseConfigOutput(output []byte) string {
-	for _, line := range strings.Split(string(output), "\n") {
-		line = strings.TrimSpace(line)
-		if line != "" && !strings.HasPrefix(line, "Note:") && !strings.Contains(line, "(not set)") {
-			return line
-		}
-	}
-	return ""
+	return beads.ParseConfigOutput(output)
 }
 
 // Fix registers the missing custom types.


### PR DESCRIPTION
## Summary
- Fixes `gt convoy create` (and any other caller of `EnsureCustomStatuses` / `EnsureCustomTypes`) failing on workspaces where `bd config get status.custom` returns the literal unset sentinel `status.custom (not set)`.
- The beads package's helpers were doing naive `strings.TrimSpace` on bd's stdout, which treated the sentinel string as a valid value. The doctor package already had the correct parser (`internal/doctor/config_check.go:parseConfigOutput` filters `(not set)` and `Note:` lines) — fix unifies the parsing.

Reported by `tongue_sentences2/crew/Teacher` (mail `hq-wisp-ugai`). Tracking bead: `gt-kbi`.

## Test plan
- [ ] Unit test: feed `status.custom (not set)\n` through the filter; expect empty
- [ ] Regression: fresh town with unset `status.custom` → `gt convoy create` succeeds
- [ ] Existing workspaces (status.custom configured) unaffected