### PR TITLE
docs: align install update guidance

### DIFF
--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -94,19 +94,19 @@ dolt version
 
 Homebrew installs the runtime dependencies declared by the core formula. The
 `gastownhall/gastown` tap is reserved for emergency updates. If you build from
-source instead, install `dolt` first, install `bd` with Go, and ensure
-`$GOPATH/bin` (usually `~/go/bin`) is in your PATH. On macOS, do not install
-`gt` with `go install`: unsigned binaries may be killed by the OS. Clone the
-repository and use `make` instead.
+source instead, install `dolt` first, install `bd` with Go, ensure `$GOPATH/bin`
+(usually `~/go/bin`) is in your PATH, and ensure `~/.local/bin` appears before
+older install locations. On macOS, do not install `gt` with `go install`:
+unsigned binaries may be killed by the OS. Clone the repository and use `make`
+instead.
 
 ```bash
 brew install dolt
 go install github.com/steveyegge/beads/cmd/bd@latest
-export PATH="$PATH:$HOME/go/bin"
+export PATH="$HOME/.local/bin:$PATH:$HOME/go/bin"
 git clone https://github.com/steveyegge/gastown.git
 cd gastown
-make build
-mv gt "$HOME/go/bin/"
+make install
 ```
 
 ### Step 2: Create Your Workspace
@@ -236,13 +236,16 @@ Gas Town is modular. Enable only what you need:
 
 ### `gt: command not found`
 
-Your Go bin directory is not in PATH:
+The Gas Town binary directory is not in PATH. Homebrew usually handles this for
+Homebrew installs. Source installs place `gt` in `~/.local/bin`:
 
 ```bash
 # Add to your shell config (~/.bashrc, ~/.zshrc)
-export PATH="$PATH:$HOME/go/bin"
+export PATH="$HOME/.local/bin:$PATH"
 source ~/.bashrc  # or restart terminal
 ```
+
+If you also installed Beads with Go, keep `$HOME/go/bin` in PATH for `bd`.
 
 ### `bd: command not found`
 
@@ -299,12 +302,35 @@ bd doctor                  # Run beads health check
 
 ## Updating
 
-To update Gas Town and Beads:
+Update Gas Town through the same channel you used to install it. For the
+recommended Homebrew install:
 
 ```bash
-go install github.com/steveyegge/gastown/cmd/gt@latest
-go install github.com/steveyegge/beads/cmd/bd@latest
+brew update
+brew upgrade gastown
 gt doctor --fix            # Fix any post-update issues
+```
+
+If you installed from source, update the checkout and rebuild with `make` rather
+than installing `gt` with `go install` on macOS:
+
+```bash
+git pull --ff-only
+make install
+gt doctor --fix
+```
+
+If you maintain Beads separately from Homebrew, update `bd` from its own source:
+
+```bash
+go install github.com/steveyegge/beads/cmd/bd@latest
+```
+
+After updating, verify that your shell is running the binary you intended:
+
+```bash
+command -v gt
+gt version
 ```
 
 ## Uninstalling


### PR DESCRIPTION
## Summary
- Updates `docs/INSTALLING.md` so update guidance matches the current Homebrew-first install path.
- Replaces stale `gt` update instructions based on `go install` with Homebrew and source-install paths.
- Adds a post-update sanity check for `command -v gt` and `gt version` to help users notice stale-binary shadowing.

## Scope
Partially addresses #3416.

This PR only covers the documented install/update-path drift in `docs/INSTALLING.md`. It does not resolve the broader #3416 items around release-channel drift, active-binary detection in `gt doctor`, `doctor --fix` convergence, or `NULL` assignee state handling.

## Related PR Checks
- #3999: merged install shadow warning work.
- #3904: open broad install/Docker docs PR; this PR may overlap in install-doc wording and should be reviewed with that conflict risk in mind.
- #3418: closed prior install-docs attempt for the same issue area.

## Validation
- `git diff --check origin/main...HEAD`