### PR TITLE
fix: fail closed on corrupt hook worktrees

### DIFF
--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -209,6 +209,9 @@ func runHookClear(cmd *cobra.Command, args []string) error {
 
 func runHook(_ *cobra.Command, args []string) error {
 	beadID := args[0]
+	if err := ensureCurrentHookWorktreeIntegrity(); err != nil {
+		return err
+	}
 
 	// Reject non-bead-shaped first args before passing to bd show, which would
 	// emit a confusing "bead 'set' not found" error. cobra has already failed to
@@ -468,6 +471,10 @@ func checkPinnedBeadComplete(b *beads.Beads, issue *beads.Issue) (isComplete boo
 
 // runHookShow displays another agent's hook in compact one-line format.
 func runHookShow(cmd *cobra.Command, args []string) error {
+	if err := ensureCurrentHookWorktreeIntegrity(); err != nil {
+		return err
+	}
+
 	var target string
 	if len(args) > 0 {
 		target = normalizeHookShowTarget(args[0])
@@ -573,6 +580,19 @@ func runHookShow(cmd *cobra.Command, args []string) error {
 	bead := hookedBeads[0]
 	fmt.Printf("%s: %s '%s' [%s]\n", target, bead.ID, bead.Title, bead.Status)
 	return nil
+}
+
+func ensureCurrentHookWorktreeIntegrity() error {
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting current directory: %w", err)
+	}
+	townRoot, err := workspace.FindFromCwd()
+	if err != nil || townRoot == "" {
+		return nil
+	}
+	roleCtx := detectRole(cwd, townRoot)
+	return ensureRoleWorktreeIntegrity(cwd, townRoot, roleCtx.Role)
 }
 
 // normalizeHookShowTarget resolves target aliases/shorthand to canonical agent IDs.

--- a/internal/cmd/hook_slot_integration_test.go
+++ b/internal/cmd/hook_slot_integration_test.go
@@ -59,8 +59,8 @@ func setupHookTestTown(t *testing.T) (townRoot, polecatDir, rigPrefix string) {
 
 	// Create routes.jsonl
 	routes := []beads.Route{
-		{Prefix: "hq-", Path: "."},                             // Town-level beads
-		{Prefix: rigPrefix + "-", Path: "gastown/mayor/rig"},   // Gastown rig
+		{Prefix: "hq-", Path: "."},                           // Town-level beads
+		{Prefix: rigPrefix + "-", Path: "gastown/mayor/rig"}, // Gastown rig
 	}
 	if err := beads.WriteRoutes(townBeadsDir, routes); err != nil {
 		t.Fatalf("write routes: %v", err)
@@ -85,6 +85,13 @@ func setupHookTestTown(t *testing.T) (townRoot, polecatDir, rigPrefix string) {
 	polecatDir = filepath.Join(townRoot, "gastown", "polecats", "toast")
 	if err := os.MkdirAll(polecatDir, 0755); err != nil {
 		t.Fatalf("mkdir polecats: %v", err)
+	}
+	gitDir := filepath.Join(polecatDir, ".git")
+	if err := os.MkdirAll(gitDir, 0755); err != nil {
+		t.Fatalf("mkdir polecat .git: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(gitDir, "HEAD"), []byte("ref: refs/heads/main\n"), 0644); err != nil {
+		t.Fatalf("write polecat .git HEAD: %v", err)
 	}
 
 	// Create redirect file for polecat -> mayor/rig/.beads

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -353,6 +353,9 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 			return fmt.Errorf("cannot determine agent identity (role: %s)", roleCtx.Role)
 		}
 	}
+	if err := ensureRoleWorktreeIntegrity(cwd, townRoot, roleCtx.Role); err != nil {
+		return err
+	}
 
 	// Find beads directory.
 	// First try CWD-based discovery, then resolve to the correct rig database
@@ -466,7 +469,8 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 	var hookBead *beads.Issue
 	isPolecat := roleCtx.Role == RolePolecat ||
 		(os.Getenv("GT_ROLE") != "" && func() bool {
-			r, _, _ := parseRoleString(os.Getenv("GT_ROLE")); return r == RolePolecat
+			r, _, _ := parseRoleString(os.Getenv("GT_ROLE"))
+			return r == RolePolecat
 		}())
 
 	hookBead = lookupHookedWork()

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -333,10 +333,13 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 	// Determine target agent
 	var target string
 	var roleCtx RoleContext
+	validationRole := RoleUnknown
 
 	if len(args) > 0 {
 		// Explicit target provided
 		target = args[0]
+		callerCtx := detectRole(cwd, townRoot)
+		validationRole = callerCtx.Role
 	} else {
 		// Use cwd-based detection for status display
 		// This ensures we show the hook for the agent whose directory we're in,
@@ -352,8 +355,9 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 		if target == "" {
 			return fmt.Errorf("cannot determine agent identity (role: %s)", roleCtx.Role)
 		}
+		validationRole = roleCtx.Role
 	}
-	if err := ensureRoleWorktreeIntegrity(cwd, townRoot, roleCtx.Role); err != nil {
+	if err := ensureRoleWorktreeIntegrity(cwd, townRoot, validationRole); err != nil {
 		return err
 	}
 

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -24,6 +24,7 @@ import (
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/util"
 	"github.com/steveyegge/gastown/internal/workspace"
+	worktreeintegrity "github.com/steveyegge/gastown/internal/worktree"
 )
 
 var primeHookMode bool
@@ -133,6 +134,14 @@ func runPrime(cmd *cobra.Command, args []string) (retErr error) {
 		return nil // Silent exit - not in workspace and not enabled
 	}
 
+	roleInfo, err := GetRoleWithContext(cwd, townRoot)
+	if err != nil {
+		return fmt.Errorf("detecting role: %w", err)
+	}
+	if err := ensureRoleWorktreeIntegrity(cwd, townRoot, roleInfo.Role); err != nil {
+		return err
+	}
+
 	if primeHookMode {
 		handlePrimeHookMode(townRoot, cwd)
 	}
@@ -142,11 +151,6 @@ func runPrime(cmd *cobra.Command, args []string) (retErr error) {
 		checkHandoffMarkerDryRun(cwd)
 	} else {
 		checkHandoffMarker(cwd)
-	}
-
-	roleInfo, err := GetRoleWithContext(cwd, townRoot)
-	if err != nil {
-		return fmt.Errorf("detecting role: %w", err)
 	}
 
 	warnRoleMismatch(roleInfo, cwd)
@@ -235,6 +239,25 @@ func runPrime(cmd *cobra.Command, args []string) (retErr error) {
 	}
 
 	return nil
+}
+
+func ensureRoleWorktreeIntegrity(cwd, townRoot string, role Role) error {
+	if err := worktreeintegrity.Validate(cwd, worktreeintegrity.IntegrityOptions{
+		TownRoot: townRoot,
+		Require:  roleRequiresWorktreeIntegrity(role),
+	}); err != nil {
+		return fmt.Errorf("%w\nRemediation: stop using this worktree and run `gt doctor --fix`", err)
+	}
+	return nil
+}
+
+func roleRequiresWorktreeIntegrity(role Role) bool {
+	switch role {
+	case RolePolecat, RoleCrew, RoleWitness, RoleRefinery, RoleDog, RoleBoot:
+		return true
+	default:
+		return false
+	}
 }
 
 // runPrimeCompactResume runs a lighter prime after compaction or resume.

--- a/internal/cmd/worktree_integrity_test.go
+++ b/internal/cmd/worktree_integrity_test.go
@@ -1,0 +1,51 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	worktreeintegrity "github.com/steveyegge/gastown/internal/worktree"
+)
+
+func TestEnsureRoleWorktreeIntegrityRequiresPolecatMetadata(t *testing.T) {
+	townRoot := t.TempDir()
+	cwd := filepath.Join(townRoot, "gastown", "polecats", "deathclaw", "gastown")
+	if err := os.MkdirAll(cwd, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ensureRoleWorktreeIntegrity(cwd, townRoot, RolePolecat)
+	if !errors.Is(err, worktreeintegrity.ErrIntegrityViolation) {
+		t.Fatalf("ensureRoleWorktreeIntegrity() error = %v, want ErrIntegrityViolation", err)
+	}
+	if !strings.Contains(err.Error(), "gt doctor --fix") {
+		t.Fatalf("ensureRoleWorktreeIntegrity() error = %v, want remediation", err)
+	}
+}
+
+func TestEnsureRoleWorktreeIntegrityAllowsNeutralDirectoryWithoutMetadata(t *testing.T) {
+	townRoot := t.TempDir()
+
+	if err := ensureRoleWorktreeIntegrity(townRoot, townRoot, RoleUnknown); err != nil {
+		t.Fatalf("ensureRoleWorktreeIntegrity() error = %v, want nil", err)
+	}
+}
+
+func TestEnsureRoleWorktreeIntegrityRejectsMalformedOptionalMetadata(t *testing.T) {
+	townRoot := t.TempDir()
+	cwd := filepath.Join(townRoot, "scratch")
+	if err := os.MkdirAll(cwd, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(cwd, ".git"), []byte("corrupted\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := ensureRoleWorktreeIntegrity(cwd, townRoot, RoleUnknown)
+	if !errors.Is(err, worktreeintegrity.ErrIntegrityViolation) {
+		t.Fatalf("ensureRoleWorktreeIntegrity() error = %v, want ErrIntegrityViolation", err)
+	}
+}

--- a/internal/cmd/worktree_integrity_test.go
+++ b/internal/cmd/worktree_integrity_test.go
@@ -49,3 +49,31 @@ func TestEnsureRoleWorktreeIntegrityRejectsMalformedOptionalMetadata(t *testing.
 		t.Fatalf("ensureRoleWorktreeIntegrity() error = %v, want ErrIntegrityViolation", err)
 	}
 }
+
+func TestRunMoleculeStatusExplicitTargetValidatesCallerWorktree(t *testing.T) {
+	t.Setenv(EnvGTRole, "")
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	cwd := filepath.Join(townRoot, "gastown", "polecats", "deathclaw")
+	if err := os.MkdirAll(cwd, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldWD, err := os.Getwd()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chdir(cwd); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(oldWD)
+	})
+
+	err = runMoleculeStatus(nil, []string{"gastown/polecats/toast"})
+	if !errors.Is(err, worktreeintegrity.ErrIntegrityViolation) {
+		t.Fatalf("runMoleculeStatus() error = %v, want ErrIntegrityViolation", err)
+	}
+}

--- a/internal/worktree/integrity.go
+++ b/internal/worktree/integrity.go
@@ -1,0 +1,122 @@
+package worktree
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+)
+
+// ErrIntegrityViolation classifies corrupted worktree metadata. Command paths
+// that depend on hook/worktree state should fail closed when this is returned.
+var ErrIntegrityViolation = errors.New("worktree integrity violation")
+
+// IntegrityOptions controls worktree validation.
+type IntegrityOptions struct {
+	// TownRoot bounds the upward search for .git metadata. Empty means search to
+	// the filesystem root.
+	TownRoot string
+
+	// Require reports a missing .git marker as an integrity violation. This is
+	// appropriate for agent worktree roles such as polecats, crew, refinery, and
+	// witness.
+	Require bool
+}
+
+// Validate checks the nearest worktree metadata for path. It accepts regular
+// clones (.git directory) and validates linked worktree .git files by ensuring
+// they are well formed and point at usable git metadata.
+func Validate(path string, opts IntegrityOptions) error {
+	if path == "" {
+		cwd, err := os.Getwd()
+		if err != nil {
+			return fmt.Errorf("%w: get cwd: %v", ErrIntegrityViolation, err)
+		}
+		path = cwd
+	}
+
+	marker, found, err := findGitMarker(path, opts.TownRoot)
+	if err != nil {
+		return err
+	}
+	if !found {
+		if opts.Require {
+			return fmt.Errorf("%w: missing .git metadata under %s", ErrIntegrityViolation, path)
+		}
+		return nil
+	}
+
+	info, err := os.Stat(marker)
+	if err != nil {
+		return fmt.Errorf("%w: cannot stat %s: %v", ErrIntegrityViolation, marker, err)
+	}
+	if info.IsDir() {
+		return nil
+	}
+
+	content, err := os.ReadFile(marker)
+	if err != nil {
+		return fmt.Errorf("%w: cannot read %s: %v", ErrIntegrityViolation, marker, err)
+	}
+
+	line := strings.TrimSpace(string(content))
+	if !strings.HasPrefix(line, "gitdir: ") {
+		return fmt.Errorf("%w: malformed .git file at %s", ErrIntegrityViolation, marker)
+	}
+
+	target := strings.TrimSpace(strings.TrimPrefix(line, "gitdir: "))
+	if target == "" {
+		return fmt.Errorf("%w: empty gitdir target in %s", ErrIntegrityViolation, marker)
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Clean(filepath.Join(filepath.Dir(marker), target))
+	}
+
+	if info, err := os.Stat(target); err != nil {
+		return fmt.Errorf("%w: gitdir target missing for %s: %s", ErrIntegrityViolation, marker, target)
+	} else if !info.IsDir() {
+		return fmt.Errorf("%w: gitdir target is not a directory for %s: %s", ErrIntegrityViolation, marker, target)
+	}
+
+	if _, err := os.Stat(filepath.Join(target, "HEAD")); err != nil {
+		return fmt.Errorf("%w: gitdir metadata incomplete for %s: missing HEAD in %s", ErrIntegrityViolation, marker, target)
+	}
+
+	return nil
+}
+
+func findGitMarker(path, townRoot string) (string, bool, error) {
+	path, err := filepath.Abs(path)
+	if err != nil {
+		return "", false, fmt.Errorf("%w: resolve path %s: %v", ErrIntegrityViolation, path, err)
+	}
+
+	var stop string
+	if townRoot != "" {
+		stop, err = filepath.Abs(townRoot)
+		if err != nil {
+			return "", false, fmt.Errorf("%w: resolve town root %s: %v", ErrIntegrityViolation, townRoot, err)
+		}
+	}
+
+	for {
+		marker := filepath.Join(path, ".git")
+		if _, err := os.Lstat(marker); err == nil {
+			return marker, true, nil
+		} else if !os.IsNotExist(err) {
+			return "", false, fmt.Errorf("%w: cannot inspect %s: %v", ErrIntegrityViolation, marker, err)
+		}
+
+		if stop != "" && path == stop {
+			break
+		}
+		parent := filepath.Dir(path)
+		if parent == path {
+			break
+		}
+		path = parent
+	}
+
+	return "", false, nil
+}

--- a/internal/worktree/integrity.go
+++ b/internal/worktree/integrity.go
@@ -52,7 +52,7 @@ func Validate(path string, opts IntegrityOptions) error {
 		return fmt.Errorf("%w: cannot stat %s: %v", ErrIntegrityViolation, marker, err)
 	}
 	if info.IsDir() {
-		return nil
+		return validateGitDir(marker, marker)
 	}
 
 	content, err := os.ReadFile(marker)
@@ -79,10 +79,17 @@ func Validate(path string, opts IntegrityOptions) error {
 		return fmt.Errorf("%w: gitdir target is not a directory for %s: %s", ErrIntegrityViolation, marker, target)
 	}
 
-	if _, err := os.Stat(filepath.Join(target, "HEAD")); err != nil {
-		return fmt.Errorf("%w: gitdir metadata incomplete for %s: missing HEAD in %s", ErrIntegrityViolation, marker, target)
+	if err := validateGitDir(target, marker); err != nil {
+		return err
 	}
 
+	return nil
+}
+
+func validateGitDir(gitdir, marker string) error {
+	if _, err := os.Stat(filepath.Join(gitdir, "HEAD")); err != nil {
+		return fmt.Errorf("%w: gitdir metadata incomplete for %s: missing HEAD in %s", ErrIntegrityViolation, marker, gitdir)
+	}
 	return nil
 }
 

--- a/internal/worktree/integrity_test.go
+++ b/internal/worktree/integrity_test.go
@@ -1,0 +1,113 @@
+package worktree
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestValidateAcceptsGitDirectory(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Validate(root, IntegrityOptions{Require: true}); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestValidateAcceptsLinkedWorktreeGitfile(t *testing.T) {
+	root := t.TempDir()
+	gitdir := filepath.Join(root, "repo.git", "worktrees", "alpha")
+	writeLinkedWorktree(t, root, gitdir, true)
+
+	if err := Validate(filepath.Join(root, "nested"), IntegrityOptions{Require: true}); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestValidateRejectsMissingRequiredMetadata(t *testing.T) {
+	root := t.TempDir()
+
+	err := Validate(root, IntegrityOptions{Require: true})
+	if !errors.Is(err, ErrIntegrityViolation) {
+		t.Fatalf("Validate() error = %v, want ErrIntegrityViolation", err)
+	}
+}
+
+func TestValidateAllowsMissingOptionalMetadata(t *testing.T) {
+	root := t.TempDir()
+
+	if err := Validate(root, IntegrityOptions{}); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestValidateRejectsMalformedGitfile(t *testing.T) {
+	root := t.TempDir()
+	if err := os.WriteFile(filepath.Join(root, ".git"), []byte("not a gitdir\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Validate(root, IntegrityOptions{Require: true})
+	if !errors.Is(err, ErrIntegrityViolation) {
+		t.Fatalf("Validate() error = %v, want ErrIntegrityViolation", err)
+	}
+}
+
+func TestValidateRejectsMissingGitdirTarget(t *testing.T) {
+	root := t.TempDir()
+	missing := filepath.Join(root, "repo.git", "worktrees", "alpha")
+	if err := os.WriteFile(filepath.Join(root, ".git"), []byte("gitdir: "+missing+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Validate(root, IntegrityOptions{Require: true})
+	if !errors.Is(err, ErrIntegrityViolation) {
+		t.Fatalf("Validate() error = %v, want ErrIntegrityViolation", err)
+	}
+}
+
+func TestValidateRejectsPartialGitdirMetadata(t *testing.T) {
+	root := t.TempDir()
+	gitdir := filepath.Join(root, "repo.git", "worktrees", "alpha")
+	writeLinkedWorktree(t, root, gitdir, false)
+
+	err := Validate(root, IntegrityOptions{Require: true})
+	if !errors.Is(err, ErrIntegrityViolation) {
+		t.Fatalf("Validate() error = %v, want ErrIntegrityViolation", err)
+	}
+}
+
+func TestValidateHonorsTownRootBoundary(t *testing.T) {
+	townRoot := t.TempDir()
+	outside := t.TempDir()
+	if err := os.Mkdir(filepath.Join(outside, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Validate(townRoot, IntegrityOptions{TownRoot: townRoot, Require: true})
+	if !errors.Is(err, ErrIntegrityViolation) {
+		t.Fatalf("Validate() error = %v, want ErrIntegrityViolation", err)
+	}
+}
+
+func writeLinkedWorktree(t *testing.T, root, gitdir string, withHead bool) {
+	t.Helper()
+	if err := os.MkdirAll(filepath.Join(root, "nested"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(gitdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if withHead {
+		if err := os.WriteFile(filepath.Join(gitdir, "HEAD"), []byte("ref: refs/heads/main\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(root, ".git"), []byte("gitdir: "+gitdir+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/internal/worktree/integrity_test.go
+++ b/internal/worktree/integrity_test.go
@@ -9,12 +9,28 @@ import (
 
 func TestValidateAcceptsGitDirectory(t *testing.T) {
 	root := t.TempDir()
-	if err := os.Mkdir(filepath.Join(root, ".git"), 0755); err != nil {
+	gitdir := filepath.Join(root, ".git")
+	if err := os.Mkdir(gitdir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(gitdir, "HEAD"), []byte("ref: refs/heads/main\n"), 0644); err != nil {
 		t.Fatal(err)
 	}
 
 	if err := Validate(root, IntegrityOptions{Require: true}); err != nil {
 		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestValidateRejectsPartialGitDirectory(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, ".git"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	err := Validate(root, IntegrityOptions{Require: true})
+	if !errors.Is(err, ErrIntegrityViolation) {
+		t.Fatalf("Validate() error = %v, want ErrIntegrityViolation", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Add typed worktree integrity validation for missing, malformed, and partial `.git` metadata.
- Fail closed before hook/worktree-dependent `gt prime`, `gt hook`, and molecule status paths continue.
- Cover regular clone and linked worktree corruption with targeted tests.

Fixes #2026

## Validation
- `go test ./internal/worktree ./internal/cmd -run 'TestValidate|TestEnsureRoleWorktreeIntegrity'`
- `go test ./internal/worktree`

## Notes
- Attempted `go test ./internal/worktree ./internal/cmd`; `internal/worktree` passed, `internal/cmd` reached unrelated testcontainers coverage and failed because rootless Docker is unavailable for `TestFindActivePatrolHooked`.