### PR TITLE
docs: document fork-based rig setup (--push-url / --upstream-url)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -9,6 +9,48 @@ Thanks for your interest in contributing! Gas Town is experimental software, and
 3. Install prerequisites (see README.md)
 4. Build and test: `go build -o gt ./cmd/gt && go test ./...`
 
+## Setting up a rig to contribute to Gas Town
+
+If you run a Gas Town rig against this repo, you don't own the canonical
+repository, so the rig must **fetch from upstream but push to your fork**.
+`gt rig add` has first-class support for this through `--push-url` and
+`--upstream-url`.
+
+1. Fork `gastownhall/gastown` on GitHub (gives you
+   `https://github.com/<you>/gastown`).
+2. Add the rig with fork routing:
+
+   ```bash
+   gt rig add gastown https://github.com/gastownhall/gastown \
+     --push-url     https://github.com/<you>/gastown \
+     --upstream-url https://github.com/gastownhall/gastown
+   ```
+
+What each flag does at the git-remote level:
+
+- The positional `<git-url>` (`https://github.com/gastownhall/gastown`)
+  becomes `origin`'s **fetch** URL — the rig pulls canonical history from
+  upstream.
+- `--push-url` sets `origin`'s **push** URL to your fork, so all pushes land
+  on `https://github.com/<you>/gastown` and never on the canonical repo.
+- `--upstream-url` adds a separate named `upstream` remote pointing at the
+  canonical repo, so rebases against `upstream/main` work without juggling
+  URLs.
+
+> **Current limitation — the refinery is not yet fork-aware.** Until the
+> behavioral half of
+> [gastownhall/gastown#1794](https://github.com/gastownhall/gastown/issues/1794)
+> ships, even a correctly-configured fork rig will have its refinery attempt
+> to **merge polecat branches into the fork's `main`**, diverging it from
+> upstream. If you want strict PR-only behavior, do not start the refinery
+> (park the rig with `gt rig park <rig>`) and use the
+> polecat → branch → manual PR path instead.
+
+If you set up a rig **without** these flags and your fork's `main` has
+already been polluted, see
+[docs/guides/fork-rig-setup.md](docs/guides/fork-rig-setup.md) for
+verification and recovery steps.
+
 ## Development Workflow
 
 We use a direct-to-main workflow for trusted contributors. For external contributors:

--- a/docs/guides/fork-rig-setup.md
+++ b/docs/guides/fork-rig-setup.md
@@ -1,0 +1,126 @@
+# Fork-Based Rig Setup
+
+When you run a rig against a repository you **don't own**, the rig has to
+fetch canonical history from upstream but push all work to your fork.
+`gt rig add` supports this directly through `--push-url` and
+`--upstream-url`. Without them, the default `gt rig add <name> <fork-url>`
+produces a rig whose refinery merges polecat work into your fork's `main`,
+diverging it from upstream.
+
+## When you need fork mode
+
+Use fork mode whenever:
+
+- You have read-only access to the canonical repo (e.g. you're an external
+  contributor), and
+- You push your work to a personal/organisation fork and open PRs from there.
+
+If you own the canonical repo and push directly to it, you do **not** need
+these flags — the plain `gt rig add <name> <git-url>` is correct.
+
+## Setup
+
+```bash
+gt rig add <name> <upstream-url> \
+  --push-url     <your-fork-url> \
+  --upstream-url <upstream-url>
+```
+
+Concretely, for a Gas Town contributor:
+
+```bash
+gt rig add gastown https://github.com/gastownhall/gastown \
+  --push-url     https://github.com/<you>/gastown \
+  --upstream-url https://github.com/gastownhall/gastown
+```
+
+What each flag does:
+
+| Flag | Effect |
+|---|---|
+| positional `<git-url>` | `origin`'s **fetch** URL — where canonical history is pulled from |
+| `--push-url` | `origin`'s **push** URL — where all pushes go (your fork) |
+| `--upstream-url` | Adds a separate named `upstream` remote for rebases against `upstream/main` |
+
+These remotes are configured on **both** the bare canonical clone
+(`<rig>/refinery/rig`) and the mayor's working clone (`<rig>/mayor/rig`).
+
+## Verifying the setup
+
+Check the remotes in the refinery's bare clone and the mayor's clone:
+
+```bash
+cd <town>/<rig>/refinery/rig && git remote -v
+cd <town>/<rig>/mayor/rig    && git remote -v
+```
+
+Expect (substituting your fork and the canonical repo):
+
+```
+origin    https://github.com/gastownhall/gastown (fetch)
+origin    https://github.com/<you>/gastown       (push)
+upstream  https://github.com/gastownhall/gastown (fetch)
+upstream  https://github.com/gastownhall/gastown (push)
+```
+
+The key invariant: **`origin`'s fetch URL is upstream, `origin`'s push URL
+is your fork.** If `origin (push)` points at the canonical repo, the flags
+did not take effect — re-add the rig.
+
+## Current limitation: the refinery is not yet fork-aware
+
+Even a correctly-configured fork rig will, today, have its refinery attempt
+to **merge polecat branches into the fork's `main`** rather than open a PR
+to upstream. The foundation flags (`--push-url` / `--upstream-url`) shipped
+in [gastownhall/gastown#2018](https://github.com/gastownhall/gastown/issues/2018),
+but the behavioral half — refinery raising PRs to upstream instead of
+merging to `origin` — is tracked in
+[gastownhall/gastown#1794](https://github.com/gastownhall/gastown/issues/1794)
+and is not yet implemented.
+
+Until then, for strict PR-only behavior:
+
+- Do **not** start the refinery. Park the rig with `gt rig park <rig>`.
+- Use the polecat → feature branch → manual PR path. Push the branch to
+  your fork and open the PR by hand.
+
+## Recovery: a polluted fork `main`
+
+If you added a rig **without** the fork-routing flags, the refinery may
+have already merged polecat work into your fork's `main`, leaving it with
+mixed `Merge branch ...` and refinery-generated commits diverged from
+upstream.
+
+> **Destructive — consult a maintainer before running.** Resetting `main`
+> rewrites your fork's history. If any of the diverged commits contain work
+> you still need (unmerged PRs, local-only fixes), stop and recover those
+> branches first. `git reflog` is your escape hatch if you reset too far.
+
+1. Inspect the divergence before touching anything:
+
+   ```bash
+   cd <town>/<rig>/mayor/rig
+   git fetch upstream
+   git log --oneline --graph upstream/main...origin/main
+   ```
+
+2. Confirm every commit on `origin/main` that is *not* on `upstream/main`
+   is safe to discard (it's refinery merge noise, not real work). Salvage
+   anything you need onto a separate branch first.
+
+3. Reset `main` to track upstream and force-publish to your fork:
+
+   ```bash
+   git checkout main
+   git reset --hard upstream/main
+   git push --force-with-lease origin main
+   ```
+
+4. Re-add the rig **with** the fork-routing flags (see [Setup](#setup)) so
+   this doesn't recur.
+
+## See also
+
+- [CONTRIBUTING.md](../../CONTRIBUTING.md) — "Setting up a rig to contribute
+  to Gas Town" (Gas Town-specific worked example)
+- [Local Rig Bootstrap](local-rig-bootstrap.md) — local/private repo setup

--- a/internal/cmd/rig.go
+++ b/internal/cmd/rig.go
@@ -75,10 +75,16 @@ Use --adopt to register an existing directory instead of creating new:
   - Auto-detects git URL from origin remote (git-url argument not required)
   - Adds entry to mayor/rigs.json
 
+For a repo you don't own, use fork mode (fetch upstream, push to fork).
+See docs/guides/fork-rig-setup.md for setup, verification, and recovery.
+
 Example:
   gt rig add gastown https://github.com/steveyegge/gastown
   gt rig add my_project git@github.com:user/repo.git --prefix mp
-  gt rig add existing_rig --adopt`,
+  gt rig add existing_rig --adopt
+  gt rig add gastown https://github.com/gastownhall/gastown \
+    --push-url https://github.com/you/gastown \
+    --upstream-url https://github.com/gastownhall/gastown`,
 	Args: cobra.RangeArgs(1, 2),
 	RunE: runRigAdd,
 }
@@ -362,8 +368,8 @@ func init() {
 	rigAddCmd.Flags().StringVar(&rigAddPrefix, "prefix", "", "Beads issue prefix (default: derived from name)")
 	rigAddCmd.Flags().StringVar(&rigAddLocalRepo, "local-repo", "", "Local repo path to share git objects (optional)")
 	rigAddCmd.Flags().StringVar(&rigAddBranch, "branch", "", "Default branch name (default: auto-detected from remote)")
-	rigAddCmd.Flags().StringVar(&rigAddPushURL, "push-url", "", "Push URL for read-only upstreams (push to fork)")
-	rigAddCmd.Flags().StringVar(&rigAddUpstreamURL, "upstream-url", "", "Upstream repository URL (for fork workflows)")
+	rigAddCmd.Flags().StringVar(&rigAddPushURL, "push-url", "", "Push URL for read-only upstreams, i.e. push to fork (see docs/guides/fork-rig-setup.md)")
+	rigAddCmd.Flags().StringVar(&rigAddUpstreamURL, "upstream-url", "", "Upstream repository URL for fork workflows (see docs/guides/fork-rig-setup.md)")
 	rigAddCmd.Flags().BoolVar(&rigAddAdopt, "adopt", false, "Adopt an existing directory instead of creating new")
 	rigAddCmd.Flags().StringVar(&rigAddAdoptURL, "url", "", "Git remote URL for --adopt (default: auto-detected from origin)")
 	rigAddCmd.Flags().BoolVar(&rigAddAdoptForce, "force", false, "With --adopt, register even if git remote cannot be detected")


### PR DESCRIPTION
## Summary

Closes #3994.

Contributors setting up a rig against a repo they don't own had no signposted path to fork mode. The `--push-url` / `--upstream-url` flags exist and work correctly, but were only visible in `--help`. The default `gt rig add <fork-url>` silently produces a rig whose refinery merges polecat work into the fork's `main`, diverging it from upstream — a failure mode that bit a downstream deployment.

This is a **docs-only** change (plus help-text strings); no runtime behavior changes.

- **`CONTRIBUTING.md`** — new "Setting up a rig to contribute to Gas Town" subsection: the canonical fork invocation, per-flag git-remote explanation (origin fetch=upstream / push=fork, named `upstream` remote), and a callout that the refinery is not yet fork-aware (links gastownhall/gastown#1794), recommending `gt rig park` + manual PR for strict PR-only behavior.
- **`docs/guides/fork-rig-setup.md`** — new generic guide: when fork mode is needed, `git remote -v` verification with expected output, the current limitation, and a guarded recovery recipe for a polluted fork `main` (wrapped in a "destructive — consult a maintainer" warning, with a reflog escape hatch).
- **`internal/cmd/rig.go`** — `gt rig add` `Long` text gains a fork-mode pointer + worked example; the `--push-url` / `--upstream-url` flag descriptions cross-link the new doc.

Satisfies all four acceptance criteria in the issue.

### Notes on judgment calls

- Cross-references use full `gastownhall/gastown` URLs so they resolve regardless of which fork the docs are viewed from.
- The example uses the positional `<git-url>` form, not the issue's `--git-url` (which is not a real flag), to match what `--help` actually prints.
- The recovery recipe is deliberately minimal (`reset --hard upstream/main` + `--force-with-lease`) with a strong stop-and-ask warning.

## Test plan

- [x] `go build -o gt ./cmd/gt` succeeds
- [x] `gt rig add --help` renders the new Long text and flag descriptions correctly
- [x] `go test ./internal/cmd/ -run Rig` passes
- [ ] Docs reviewed for accuracy against actual `--push-url` / `--upstream-url` mechanics (verified in `internal/rig/manager.go` and `internal/git/git.go`)

https://claude.ai/code/session_01Urv3oSYh1zF1gDTV9ujURU

---
_Generated by Claude Code