### PR TITLE
harden gt done against spurious refinery nudge on DEFERRED #3885

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -1303,7 +1303,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 notifyWitness:
 	// Nudge refinery — MR bead is already on main (transaction-based shared main).
-	if mrID != "" {
+	if shouldNudgeRefinery(exitType, mrID) {
 		nudgeRefinery(rigName, "MERGE_READY received - check inbox for pending work")
 	}
 
@@ -1500,6 +1500,16 @@ func verifyPushedCommitWithBareFallback(g *git.Git, townRoot, rigName, branch, c
 		return nil
 	}
 	return verifyErr
+}
+
+// shouldNudgeRefinery reports whether a gt done invocation may wake the
+// refinery. Only COMPLETED exits create an MR bead; DEFERRED and ESCALATED
+// exits (polecats finishing operational tasks with no code changes) must
+// never emit MQ_SUBMIT, or the refinery wakes from backoff to find an empty
+// merge queue (gh#3885). The exitType check is defensive: it holds the
+// invariant even if a future code path populates mrID outside COMPLETED.
+func shouldNudgeRefinery(exitType, mrID string) bool {
+	return exitType == ExitCompleted && mrID != ""
 }
 
 // setDoneIntentLabel writes a done-intent:<type>:<unix-ts> label on the agent bead

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -402,6 +402,36 @@ func TestDoneIntentLabelFormat(t *testing.T) {
 	}
 }
 
+// TestShouldNudgeRefinery locks in the gh#3885 invariant: only COMPLETED
+// exits with a created MR bead may wake the refinery. DEFERRED/ESCALATED
+// exits — used by polecats finishing operational tasks with no code changes —
+// must never emit MQ_SUBMIT, even if an mrID is somehow populated. The
+// "stray MR" cases guard against a regression to a bare `mrID != ""` check.
+func TestShouldNudgeRefinery(t *testing.T) {
+	tests := []struct {
+		name     string
+		exitType string
+		mrID     string
+		want     bool
+	}{
+		{"completed with MR nudges", ExitCompleted, "gt-abc123", true},
+		{"completed without MR does not nudge", ExitCompleted, "", false},
+		{"deferred without MR does not nudge", ExitDeferred, "", false},
+		{"deferred with stray MR does not nudge", ExitDeferred, "gt-abc123", false},
+		{"escalated without MR does not nudge", ExitEscalated, "", false},
+		{"escalated with stray MR does not nudge", ExitEscalated, "gt-abc123", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldNudgeRefinery(tt.exitType, tt.mrID); got != tt.want {
+				t.Errorf("shouldNudgeRefinery(%q, %q) = %v, want %v",
+					tt.exitType, tt.mrID, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestClearDoneIntentLabel verifies that clearDoneIntentLabel removes
 // only done-intent labels while preserving other labels.
 func TestClearDoneIntentLabel(t *testing.T) {


### PR DESCRIPTION
## Assessment of #3885

**Could not reproduce** the reported bug on `main` (`2eafac9`). The `gt done --status DEFERRED` path in `internal/cmd/done.go` is *already* correctly guarded:

- `done.go:478` declares `var mrID string` (zero value `""`).
- `done.go:483` — every `mrID` assignment lives inside `if exitType == ExitCompleted { ... }` (lines 1121, 1144, 1202).
- `done.go:1295-1302` — DEFERRED/ESCALATED fall through the `else` branch (status print only).
- `done.go:1306` — `nudgeRefinery` (the only MQ_SUBMIT emitter for the refinery channel, `sling_helpers.go:715`) was already gated by `if mrID != ""`, which is never true on the DEFERRED path.

`git log -p -S 'if mrID != ""'` shows that guard has existed since `done.go` was introduced (~3 weeks before the issue was filed). So this PR is **hardening, not a behaviour fix** — it cannot change what the reporter observed.

## What this PR does

1. Extracts the guard into `shouldNudgeRefinery(exitType, mrID)` and tightens it to `exitType == ExitCompleted && mrID != ""`. Identical behaviour today; makes the invariant explicit and tamper-resistant against a future code path that populates `mrID` outside COMPLETED.
2. Adds `TestShouldNudgeRefinery` with "stray MR" cases that fail if the guard ever regresses to a bare `mrID != ""` check.

Regression proof (temp-regression run) is posted as a PR comment below.

## Still needed — diagnostic data for the real root cause (step 3)

Since the named code path can't emit the ghost events, the reporter's `~6 ghost MQ_SUBMIT events` are coming from elsewhere. The two real emitters are `nudgeRefinery` (`source=sling` in the event payload) and the public `gt mol step emit-event --channel refinery --type MQ_SUBMIT` command. To find the actual source we need from the reporter:

- The raw event files: `cat <town>/gt/events/refinery/*.event` — specifically the `source=` field. `source=sling` ⇒ a real bug we haven't found; anything else ⇒ a stray `emit-event` in a molecule.
- The exact `gt version` of the binary the polecats ran (to rule out a stale binary).
- The formula/molecule definition for the `-wfs-` workflow steps on rig `enocean_async_tui` (branches `polecat/chrome/eat-wfs-dn6ms@...`, `polecat/rust/eat-wfs-phb6e@...`) — checking for an `emit-event --channel refinery` step.

## Test plan

- [x] `go test ./internal/cmd/ -run TestShouldNudgeRefinery` passes
- [x] Temp-regress guard to `return mrID != ""` → test fails on DEFERRED/ESCALATED stray-MR cases
- [x] Restore → passes; `go build ./...` clean
- [x] Existing `TestNudgeRefinery*` / `TestWakeRigAgentsDoesNotNudgeRefinery` still pass

https://claude.ai/code/session_01Y88K2zLuhCHt9CDL2mdfSj

---
_Generated by [Claude Code](https://claude.ai/code/session_01Y88K2zLuhCHt9CDL2mdfSj)_