### PR TITLE
fix: honor workflow step target + reconcile convoy tooling (#3798, #4032)

### DIFF
--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -894,6 +894,29 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 	// `target` (gt-3798). A workflow that mixes interactive and non-interactive
 	// steps must still route the non-interactive ones — a single interactive
 	// step does not pin the whole workflow to the orchestrator session.
+	// Pre-flight: warn at pour-time if any ready non-interactive step targets
+	// something the capacity-scheduler's deferred gate will reject — neither a
+	// rig nor a capacity-neutral agent (gt-3798 follow-up, Approach C Part 2).
+	if deferred, _ := shouldDeferDispatch(); deferred {
+		for _, step := range f.Steps {
+			if len(step.Needs) > 0 || step.Interactive {
+				continue
+			}
+			t := workflowStepTarget(step, targetRig)
+			if isUnroutableTarget(t, IsRigName) {
+				fmt.Fprintf(os.Stderr,
+					"\nWARNING: step %q resolves target %q — not a rig or capacity-neutral agent.\n"+
+						"Under the capacity scheduler this step will strand.\n"+
+						"Fix the formula's `target` field.\n\n",
+					step.ID, t)
+				_ = BdCmd("comments", "add", workflowID,
+					fmt.Sprintf("Pour-time WARNING: step %q target %q is not a rig or capacity-neutral agent — will strand under the capacity scheduler (gt-3798).", step.ID, t)).
+					Dir(townBeads).
+					Run()
+			}
+		}
+	}
+
 	fmt.Printf("\n%s Dispatching ready steps...\n\n", style.Bold.Render("→"))
 
 	slingCount := 0

--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -333,11 +333,12 @@ func dryRunFormula(f *formula.Formula, formulaName, targetRig string) error {
 	}
 
 	if f.Type == formula.TypeConvoy && len(f.Legs) > 0 {
-		// Generate review ID for dry-run display
-		reviewID := generateFormulaShortID()
-
 		// Parse --set key=value pairs for template rendering
 		setVars := parseSetVars(formulaRunSet)
+
+		// Generate review ID for dry-run display. Honors --set review_id=X
+		// so dry-run output matches real execution exactly (gt-4032).
+		reviewID := resolveReviewID(setVars)
 
 		// Build target description
 		var targetDescription string
@@ -509,8 +510,12 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 
 	fmt.Printf("%s Created convoy: %s\n", style.Bold.Render("✓"), convoyID)
 
-	// Generate a unique review ID for this convoy run
-	reviewID := generateFormulaShortID()
+	// Parse --set key=value pairs for template rendering
+	setVars := parseSetVars(formulaRunSet)
+
+	// Generate a unique review ID for this convoy run. Honors --set
+	// review_id=X so it matches --dry-run output exactly (gt-4032).
+	reviewID := resolveReviewID(setVars)
 
 	// Build target description
 	var targetDescription string
@@ -530,10 +535,14 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 	// Create output directory if configured
 	var outputDir string
 	if f.Output != nil && f.Output.Directory != "" {
-		// Build minimal context for directory rendering
+		// Build minimal context for directory rendering. Inject --set vars
+		// so the rendered directory matches --dry-run exactly (gt-4032).
 		dirCtx := map[string]interface{}{
 			"review_id":    reviewID,
 			"formula_name": formulaName,
+		}
+		for k, v := range setVars {
+			dirCtx[k] = v
 		}
 		outputDir = renderTemplateOrDefault(f.Output.Directory, dirCtx, ".reviews/"+reviewID)
 
@@ -545,9 +554,6 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 			fmt.Printf("  %s Output directory: %s\n", style.Dim.Render("📁"), outputDir)
 		}
 	}
-
-	// Parse --set key=value pairs for template rendering
-	setVars := parseSetVars(formulaRunSet)
 
 	// Step 2: Create leg beads and track them
 	legBeads := make(map[string]string) // leg.ID -> bead ID
@@ -624,7 +630,7 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 		}
 
 		// Track the leg with the convoy
-		if err := addTrackingRelationFn(townBeads, convoyID, legBeadID); err != nil {
+		if err := addTrackingRelationWithRetry(townBeads, convoyID, legBeadID); err != nil {
 			fmt.Printf("%s Failed to track leg %s: %v\n",
 				style.Dim.Render("Warning:"), leg.ID, err)
 		}
@@ -641,6 +647,36 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 		synDesc := f.Synthesis.Description
 		if synDesc == "" {
 			synDesc = "Synthesize findings from all legs into unified output"
+		}
+
+		// Render the synthesis description with the same template context
+		// the legs receive, so {{.output.directory}}/{{.output.synthesis}}
+		// and --set vars resolve to concrete paths instead of being stored
+		// raw for the synthesizer to choke on (gt-4032).
+		synCtx := map[string]interface{}{
+			"formula_name":       formulaName,
+			"target_description": targetDescription,
+			"review_id":          reviewID,
+			"pr_number":          formulaRunPR,
+			"pr_title":           prTitle,
+			"changed_files":      changedFiles,
+			"files":              formulaRunFiles,
+		}
+		for k, v := range setVars {
+			synCtx[k] = v
+		}
+		if f.Output != nil {
+			synCtx["output"] = map[string]interface{}{
+				"directory": outputDir,
+				"synthesis": f.Output.Synthesis,
+			}
+			synCtx["output_path"] = filepath.Join(outputDir, f.Output.Synthesis)
+		}
+		if rendered, err := renderTemplate(synDesc, synCtx); err != nil {
+			fmt.Printf("%s Failed to render synthesis description: %v\n",
+				style.Dim.Render("Warning:"), err)
+		} else {
+			synDesc = rendered
 		}
 
 		synArgs := []string{
@@ -663,7 +699,7 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 				style.Dim.Render("Warning:"), err)
 		} else {
 			// Track synthesis with convoy
-			_ = addTrackingRelationFn(townBeads, convoyID, synthesisBeadID)
+			_ = addTrackingRelationWithRetry(townBeads, convoyID, synthesisBeadID)
 
 			// Add dependencies: synthesis depends on all legs
 			for _, legBeadID := range legBeads {
@@ -826,7 +862,7 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 		}
 
 		// Track the step with the workflow
-		_ = addTrackingRelationFn(townBeads, workflowID, stepBeadID)
+		_ = addTrackingRelationWithRetry(townBeads, workflowID, stepBeadID)
 
 		// Wire dependencies: this step depends on its needs
 		for _, needID := range step.Needs {
@@ -851,19 +887,14 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 		fmt.Printf("  %s %s: %s%s\n", style.Dim.Render("○"), step.ID, stepBeadID, needsStr)
 	}
 
-	// Step 3: Identify and dispatch ready steps (those with no dependencies)
-	// Interactive steps are hooked to the current session; others are slung to polecats.
+	// Step 3: Identify and dispatch ready steps (those with no dependencies).
+	// Each step is routed independently: interactive steps are hooked to the
+	// current session (they need the human's chat channel and must NOT be
+	// routed by `target`); non-interactive steps are slung to their resolved
+	// `target` (gt-3798). A workflow that mixes interactive and non-interactive
+	// steps must still route the non-interactive ones — a single interactive
+	// step does not pin the whole workflow to the orchestrator session.
 	fmt.Printf("\n%s Dispatching ready steps...\n\n", style.Bold.Render("→"))
-
-	// Check if any step in the workflow is interactive — if so, we'll need
-	// to handle the molecule lifecycle in the current session.
-	hasInteractive := false
-	for _, step := range f.Steps {
-		if step.Interactive {
-			hasInteractive = true
-			break
-		}
-	}
 
 	slingCount := 0
 	interactiveCount := 0
@@ -877,7 +908,7 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 			continue
 		}
 
-		if step.Interactive || hasInteractive {
+		if step.Interactive {
 			// Interactive step: hook to current session instead of slinging to a polecat.
 			// The user will execute this step in their current crew session.
 			_ = BdCmd("update", stepBeadID, "--status=hooked").
@@ -943,6 +974,13 @@ func executeWorkflowFormula(f *formula.Formula, formulaName, targetRig string) e
 const workflowTargetField = "workflow_target"
 
 func workflowStepDescription(step formula.Step, description string) string {
+	// Interactive steps run in the orchestrator's session (they need the human's
+	// chat channel) and must NOT carry a routable workflow_target — otherwise the
+	// auto-dispatch override (applyWorkflowStepTargetOverride) would redirect them
+	// to a role that has no channel to the human (gt-3798).
+	if step.Interactive {
+		return description
+	}
 	target := strings.TrimSpace(step.Target)
 	if target == "" {
 		return description
@@ -951,6 +989,10 @@ func workflowStepDescription(step formula.Step, description string) string {
 }
 
 func workflowStepTarget(step formula.Step, targetRig string) string {
+	// Interactive steps are session-bound and never routed by target (gt-3798).
+	if step.Interactive {
+		return targetRig
+	}
 	target := strings.TrimSpace(step.Target)
 	if target == "" || target == "rig" {
 		return targetRig
@@ -1139,6 +1181,20 @@ func fetchPRInfo(prNumber int) (string, []map[string]interface{}) {
 	}
 
 	return prTitle, changedFiles
+}
+
+// resolveReviewID returns the explicit --set review_id=<id> when provided,
+// otherwise a fresh short ID. Shared by dry-run and real execution so both
+// paths compute identical review IDs and output paths (gt-4032).
+func resolveReviewID(setVars map[string]interface{}) string {
+	if v, ok := setVars["review_id"]; ok {
+		if s, ok := v.(string); ok {
+			if s = strings.TrimSpace(s); s != "" {
+				return s
+			}
+		}
+	}
+	return generateFormulaShortID()
 }
 
 // generateFormulaShortID generates a short random ID (5 lowercase chars)

--- a/internal/cmd/formula_test.go
+++ b/internal/cmd/formula_test.go
@@ -319,3 +319,91 @@ func TestAttachmentFormulaVarsPrefersAttachedVars(t *testing.T) {
 		t.Fatalf("attachmentFormulaVars() = %#v, want %#v", got, want)
 	}
 }
+
+// TestWorkflowStepTargetInteractiveStaysOnRig locks gt-3798: an interactive
+// step is session-bound and must never be routed by `target`, even when the
+// formula declares one. workflowStepTarget must return the rig, not the role.
+func TestWorkflowStepTargetInteractiveStaysOnRig(t *testing.T) {
+	t.Parallel()
+
+	step := formula.Step{Target: "mayor", Interactive: true}
+	if got := workflowStepTarget(step, "gastown"); got != "gastown" {
+		t.Fatalf("workflowStepTarget(interactive, target=mayor) = %q, want %q", got, "gastown")
+	}
+}
+
+// TestWorkflowStepDescriptionInteractiveOmitsTarget locks gt-3798: an
+// interactive step must not carry a routable workflow_target line, otherwise
+// the auto-dispatch override would redirect it away from the human's session.
+func TestWorkflowStepDescriptionInteractiveOmitsTarget(t *testing.T) {
+	t.Parallel()
+
+	description := "Talk to the human\n\nClarify the requirements"
+	got := workflowStepDescription(formula.Step{Target: "mayor", Interactive: true}, description)
+	if got != description {
+		t.Fatalf("workflowStepDescription(interactive) = %q, want raw %q", got, description)
+	}
+	if strings.Contains(got, workflowTargetField) {
+		t.Fatalf("interactive step description must not contain %q: %q", workflowTargetField, got)
+	}
+}
+
+// TestResolveReviewID locks gt-4032-A: --set review_id=X must win so dry-run
+// and real execution compute the same review ID; everything else falls back
+// to a fresh generated short ID.
+func TestResolveReviewID(t *testing.T) {
+	t.Parallel()
+
+	if got := resolveReviewID(map[string]interface{}{"review_id": "fixed-id"}); got != "fixed-id" {
+		t.Fatalf("resolveReviewID(explicit) = %q, want %q", got, "fixed-id")
+	}
+
+	for _, name := range []string{"whitespace", "missing", "non-string"} {
+		t.Run(name, func(t *testing.T) {
+			var setVars map[string]interface{}
+			switch name {
+			case "whitespace":
+				setVars = map[string]interface{}{"review_id": "   "}
+			case "missing":
+				setVars = map[string]interface{}{"problem": "x"}
+			case "non-string":
+				setVars = map[string]interface{}{"review_id": 42}
+			}
+			got := resolveReviewID(setVars)
+			if got == "" || len(got) != 5 {
+				t.Fatalf("resolveReviewID(%s) = %q, want generated 5-char id", name, got)
+			}
+		})
+	}
+}
+
+// TestSynthesisDescriptionRendersOutputVars locks gt-4032-B: the synthesis
+// description is rendered with an .output.* / --set context (mirroring the
+// leg context) so {{.output.directory}}/{{.output.synthesis}} and {{.problem}}
+// resolve to concrete values instead of being stored as raw template text.
+func TestSynthesisDescriptionRendersOutputVars(t *testing.T) {
+	t.Parallel()
+
+	outputDir := ".prd-reviews/fixed-id"
+	synthesisFile := "prd-review.md"
+	synCtx := map[string]interface{}{
+		"formula_name": "mol-prd-review",
+		"review_id":    "fixed-id",
+		"output": map[string]interface{}{
+			"directory": outputDir,
+			"synthesis": synthesisFile,
+		},
+		"output_path": filepath.Join(outputDir, synthesisFile),
+		"problem":     "AI Clause Generator",
+	}
+
+	tmpl := "Input: {{.output.directory}}/\nOutput: {{.output.directory}}/{{.output.synthesis}}\nReview: {{.problem}}"
+	got, err := renderTemplate(tmpl, synCtx)
+	if err != nil {
+		t.Fatalf("renderTemplate() error: %v", err)
+	}
+	want := "Input: .prd-reviews/fixed-id/\nOutput: .prd-reviews/fixed-id/prd-review.md\nReview: AI Clause Generator"
+	if got != want {
+		t.Fatalf("renderTemplate() = %q, want %q", got, want)
+	}
+}

--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -1056,8 +1056,8 @@ func TestSchedulerDeferredNonRigRejection(t *testing.T) {
 	if err == nil {
 		t.Fatalf("gt sling %s %s (non-rig) in deferred mode should fail, but succeeded:\n%s", beadID, otherBead, out)
 	}
-	if !strings.Contains(out, "deferred dispatch requires a rig target") {
-		t.Errorf("expected 'deferred dispatch requires a rig target' error, got:\n%s", out)
+	if !strings.Contains(out, "deferred dispatch requires a rig or capacity-neutral target") {
+		t.Errorf("expected 'deferred dispatch requires a rig or capacity-neutral target' error, got:\n%s", out)
 	}
 
 	// gt sling <bead> . in deferred mode should also be rejected
@@ -1065,8 +1065,8 @@ func TestSchedulerDeferredNonRigRejection(t *testing.T) {
 	if err == nil {
 		t.Fatalf("gt sling %s . in deferred mode should fail, but succeeded:\n%s", beadID, out)
 	}
-	if !strings.Contains(out, "deferred dispatch requires a rig target") {
-		t.Errorf("expected 'deferred dispatch requires a rig target' error for '.', got:\n%s", out)
+	if !strings.Contains(out, "deferred dispatch requires a rig or capacity-neutral target") {
+		t.Errorf("expected 'deferred dispatch requires a rig or capacity-neutral target' error for '.', got:\n%s", out)
 	}
 }
 

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -480,16 +480,23 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 				Ralph:        slingRalph,
 			})
 		}
-		// Dog targets (deacon/dogs, deacon/dogs/<name>, dog:, dog:<name>) fall through
-		// to direct dispatch: dogs are a self-managed pool owned by the Deacon, not rig
-		// polecat slots, and therefore don't participate in the capacity scheduler.
-		// Without this fallthrough, dispatchFeedDog can't feed stranded convoys when a
-		// scheduler is active (bead aa-4yf2).
-		if _, isDog := IsDogTarget(args[1]); !isDog {
-			// Non-rig, non-dog target in deferred mode — reject to prevent bypassing capacity control
-			return fmt.Errorf("deferred dispatch requires a rig target: gt sling %s <rig>\n'%s' is not a known rig", args[0], args[1])
+		// Capacity-neutral targets fall through to direct dispatch even when the
+		// scheduler is active: the cap (scheduler.max_polecats) governs only rig
+		// polecat slots. Dogs (the Deacon's self-managed pool, bead aa-4yf2) and
+		// standing singleton agents (mayor, deacon, rig witness/refinery, named
+		// crew) do not occupy a polecat slot, so the cap does not apply to them.
+		// Without this, the daemon's workflow-step rewrite (rig -> role target,
+		// e.g. workflow_target: mayor) is dead-on-arrival under the scheduler and
+		// silently strands the convoy (gt-3798 deferred-dispatch follow-up).
+		if !isCapacityNeutralTarget(args[1]) {
+			// Non-rig, capacity-consuming target in deferred mode — reject so it
+			// cannot bypass capacity control.
+			return fmt.Errorf("deferred dispatch requires a rig or capacity-neutral target: gt sling %s <rig>\n"+
+				"'%s' is not a rig, dog, or standing agent (mayor, deacon, <rig>/witness, <rig>/refinery, <rig>/crew/<name>)",
+				args[0], args[1])
 		}
-		// else: fall through to direct dispatch path below (resolveTarget handles dogs).
+		// else: fall through to direct dispatch path below (resolveTarget handles
+		// dogs and standing-agent role targets).
 	}
 
 	// Epic/convoy auto-detection (1 arg, no rig): works for both deferred and direct

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -817,6 +817,55 @@ func isPolecatTarget(target string) bool {
 	return len(parts) >= 3 && parts[1] == "polecats"
 }
 
+// isCapacityNeutralTarget reports whether dispatching to target consumes a rig
+// polecat slot governed by scheduler.max_polecats.
+//
+// It returns true for targets that do NOT occupy a polecat slot — dogs (the
+// Deacon's self-managed pool, bead aa-4yf2) and standing singleton agents
+// (mayor, deacon, and the rig-scoped witness/refinery/crew agents). These may
+// dispatch directly even when the capacity scheduler is active, because the
+// cap governs only polecats. A bare rig name (spawns a polecat) and
+// <rig>/polecats/<name> (occupies a polecat slot) are capacity-managed and
+// return false.
+//
+// This exists because the deferred-dispatch gate must classify on the real
+// question — "does this target consume a polecat slot?" — not the proxy
+// question "is the literal arg a rig?". Conflating the two silently stranded
+// workflows whose steps target a standing role (gt-3798 follow-up: the
+// daemon rewrites a rig target to e.g. workflow_target: mayor, which was
+// then dead-on-arrival under the scheduler).
+func isCapacityNeutralTarget(target string) bool {
+	if _, isDog := IsDogTarget(target); isDog {
+		return true
+	}
+	if isPolecatTarget(target) {
+		return false // <rig>/polecats/<name> occupies a polecat slot
+	}
+	t := strings.ToLower(strings.TrimRight(strings.TrimSpace(target), "/"))
+	switch t {
+	case constants.RoleMayor, constants.RoleDeacon:
+		return true // town-level standing singletons
+	}
+	// Rig-scoped standing agents: <rig>/witness, <rig>/refinery, <rig>/crew[/<name>].
+	if parts := strings.Split(t, "/"); len(parts) >= 2 {
+		switch parts[1] {
+		case constants.RoleWitness, constants.RoleRefinery, constants.RoleCrew:
+			return true
+		}
+	}
+	return false
+}
+
+// isUnroutableTarget reports whether target would be rejected by the
+// deferred-dispatch gate when the capacity scheduler is active. It returns
+// true when the target is neither a rig (which spawns a polecat) nor a
+// capacity-neutral agent. isRig is injectable so the pre-flight helper stays
+// unit-testable without a real town on disk.
+func isUnroutableTarget(target string, isRig func(string) (string, bool)) bool {
+	_, ok := isRig(target)
+	return !ok && !isCapacityNeutralTarget(target)
+}
+
 // FormulaOnBeadResult contains the result of instantiating a formula on a bead.
 type FormulaOnBeadResult struct {
 	WispRootID string // The wisp root ID (compound root after bonding)

--- a/internal/cmd/sling_helpers_test.go
+++ b/internal/cmd/sling_helpers_test.go
@@ -236,3 +236,94 @@ func TestIsSlingConfigError(t *testing.T) {
 		})
 	}
 }
+
+// TestIsCapacityNeutralTarget verifies the deferred-dispatch gate's target
+// classification: capacity-neutral targets (dogs + standing singleton agents)
+// bypass the scheduler because they do not occupy a polecat slot; bare rigs
+// and explicit polecat targets are capacity-managed (gt-3798 follow-up).
+func TestIsCapacityNeutralTarget(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name   string
+		target string
+		want   bool
+	}{
+		// Capacity-managed: occupies / spawns a polecat slot -> must go through scheduler.
+		{"bare rig spawns polecat", "agreement_hub", false},
+		{"explicit polecat occupies slot", "agreement_hub/polecats/alpha", false},
+		{"another rig", "gastown", false},
+
+		// Capacity-neutral: dogs (Deacon's self-managed pool, aa-4yf2).
+		{"dog pool", "deacon/dogs", true},
+		{"specific dog", "deacon/dogs/alpha", true},
+		{"dog shorthand pool", "dog:", true},
+		{"dog shorthand named", "dog:bravo", true},
+
+		// Capacity-neutral: town-level standing singletons.
+		{"mayor", "mayor", true},
+		{"mayor case-insensitive", "MAYOR", true},
+		{"mayor trailing slash", "mayor/", true},
+		{"deacon", "deacon", true},
+
+		// Capacity-neutral: rig-scoped standing agents.
+		{"rig witness", "agreement_hub/witness", true},
+		{"rig refinery", "agreement_hub/refinery", true},
+		{"named crew", "agreement_hub/crew/hub_sheriff", true},
+		{"crew without name", "agreement_hub/crew", true},
+
+		// Not capacity-neutral: unrecognized / typo'd targets must still be
+		// rejected by the gate so they cannot silently strand a workflow.
+		{"typo'd role", "mayer", false},
+		{"unknown bare token", "nobody", false},
+		{"empty", "", false},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isCapacityNeutralTarget(tt.target); got != tt.want {
+				t.Errorf("isCapacityNeutralTarget(%q) = %v, want %v", tt.target, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestIsUnroutableTarget locks gt-3798 Approach C Part 2: the pour-time
+// pre-flight must block targets that are neither a rig nor capacity-neutral,
+// and must pass targets that are valid under the deferred-dispatch gate.
+func TestIsUnroutableTarget(t *testing.T) {
+	t.Parallel()
+
+	stubIsRig := func(target string) (string, bool) {
+		if target == "my-rig" {
+			return "my-rig", true
+		}
+		return "", false
+	}
+
+	tests := []struct {
+		target  string
+		blocked bool
+	}{
+		// Valid targets: rig or capacity-neutral
+		{"my-rig", false},
+		{"mayor", false},
+		{"deacon", false},
+		{"agreement_hub/witness", false},
+		{"agreement_hub/crew/hub_sheriff", false},
+		{"deacon/dogs/alpha", false},
+		// Blocked: unknown / typo'd targets
+		{"badtarget", true},
+		{"mayors", true},
+		{"", true},
+	}
+	for _, tt := range tests {
+		tt := tt
+		t.Run(tt.target, func(t *testing.T) {
+			t.Parallel()
+			if got := isUnroutableTarget(tt.target, stubIsRig); got != tt.blocked {
+				t.Fatalf("isUnroutableTarget(%q) = %v, want %v", tt.target, got, tt.blocked)
+			}
+		})
+	}
+}

--- a/internal/cmd/tracking_relations.go
+++ b/internal/cmd/tracking_relations.go
@@ -23,6 +23,47 @@ func addTrackingRelation(townRoot, trackerID, issueID string) error {
 	return nil
 }
 
+// trackingRetryBaseDelay is the base backoff between tracking-relation
+// retries; overridable in tests to keep them fast.
+var trackingRetryBaseDelay = 200 * time.Millisecond
+
+// trackingRetryMaxAttempts bounds addTrackingRelationWithRetry.
+const trackingRetryMaxAttempts = 5
+
+// isBeadNotVisibleErr reports whether err looks like a freshly-created bead
+// that a follow-up read cannot yet see. The tracking write lands moments
+// after `bd create`; on a cold cache the lookup can race the Dolt commit
+// and report the issue as missing even though it exists.
+func isBeadNotVisibleErr(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, "not found") ||
+		strings.Contains(msg, "does not exist") ||
+		strings.Contains(msg, "no such issue")
+}
+
+// addTrackingRelationWithRetry wraps addTrackingRelationFn, retrying with
+// exponential backoff while the target bead is not yet visible (Dolt
+// read-after-write lag). Non-visibility is the only retryable class;
+// every other error fails fast (gt-4032).
+func addTrackingRelationWithRetry(townRoot, trackerID, issueID string) error {
+	var err error
+	for attempt := 0; attempt < trackingRetryMaxAttempts; attempt++ {
+		if err = addTrackingRelationFn(townRoot, trackerID, issueID); err == nil {
+			return nil
+		}
+		if !isBeadNotVisibleErr(err) {
+			return err
+		}
+		if attempt < trackingRetryMaxAttempts-1 && trackingRetryBaseDelay > 0 {
+			time.Sleep(trackingRetryBaseDelay << attempt)
+		}
+	}
+	return err
+}
+
 func removeTrackingRelation(townRoot, trackerID, issueID string) error {
 	if err := mutateTrackingRelationViaStore(townRoot, trackerID, issueID, false); err != nil {
 		return fallbackTrackingRelation(townRoot, trackerID, issueID, false, err)

--- a/internal/cmd/tracking_relations_test.go
+++ b/internal/cmd/tracking_relations_test.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -27,5 +28,101 @@ func TestTrackingDependsOnID_HQStaysLocal(t *testing.T) {
 	got := trackingDependsOnID(townRoot, "hq-cv-test")
 	if got != "hq-cv-test" {
 		t.Fatalf("trackingDependsOnID() = %q, want %q", got, "hq-cv-test")
+	}
+}
+
+func TestIsBeadNotVisibleErr(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"not found", fmt.Errorf("issue ah-leg-abcde not found"), true},
+		{"does not exist", fmt.Errorf("bead does not exist yet"), true},
+		{"no such issue", fmt.Errorf("no such issue: ah-syn-x"), true},
+		{"unrelated", fmt.Errorf("connection refused"), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Parallel()
+			if got := isBeadNotVisibleErr(tt.err); got != tt.want {
+				t.Fatalf("isBeadNotVisibleErr(%v) = %v, want %v", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+// stubTracking swaps addTrackingRelationFn and zeroes the backoff for the
+// duration of a test. Not parallel-safe — these tests mutate package globals.
+func stubTracking(t *testing.T, fn func(townRoot, trackerID, issueID string) error) *int {
+	t.Helper()
+	calls := 0
+	oldFn := addTrackingRelationFn
+	oldDelay := trackingRetryBaseDelay
+	addTrackingRelationFn = func(townRoot, trackerID, issueID string) error {
+		calls++
+		return fn(townRoot, trackerID, issueID)
+	}
+	trackingRetryBaseDelay = 0
+	t.Cleanup(func() {
+		addTrackingRelationFn = oldFn
+		trackingRetryBaseDelay = oldDelay
+	})
+	return &calls
+}
+
+// TestAddTrackingRelationWithRetry_SucceedsAfterNotVisible locks gt-4032-C:
+// a freshly-created leg bead may not be visible to the tracking write yet
+// (Dolt read-after-write lag); the retry must ride out the not-found window.
+func TestAddTrackingRelationWithRetry_SucceedsAfterNotVisible(t *testing.T) {
+	const succeedOnAttempt = 4
+	calls := stubTracking(t, func(_, _, issueID string) error {
+		return fmt.Errorf("issue %s not found", issueID)
+	})
+	// Re-stub with a counter that succeeds once the not-found window passes.
+	addTrackingRelationFn = func(_, _, issueID string) error {
+		*calls++
+		if *calls >= succeedOnAttempt {
+			return nil
+		}
+		return fmt.Errorf("issue %s not found", issueID)
+	}
+
+	if err := addTrackingRelationWithRetry("/town", "ah-cv-x", "ah-leg-abcde"); err != nil {
+		t.Fatalf("addTrackingRelationWithRetry() = %v, want nil after retries", err)
+	}
+	if *calls != succeedOnAttempt {
+		t.Fatalf("attempts = %d, want %d", *calls, succeedOnAttempt)
+	}
+}
+
+// TestAddTrackingRelationWithRetry_GivesUp verifies the retry is bounded:
+// a persistently-invisible bead exhausts attempts and returns the error.
+func TestAddTrackingRelationWithRetry_GivesUp(t *testing.T) {
+	calls := stubTracking(t, func(_, _, issueID string) error {
+		return fmt.Errorf("issue %s not found", issueID)
+	})
+	if err := addTrackingRelationWithRetry("/town", "ah-cv-x", "ah-leg-gone"); err == nil {
+		t.Fatal("addTrackingRelationWithRetry() = nil, want error after exhausting retries")
+	}
+	if *calls != trackingRetryMaxAttempts {
+		t.Fatalf("attempts = %d, want %d", *calls, trackingRetryMaxAttempts)
+	}
+}
+
+// TestAddTrackingRelationWithRetry_FailsFastOnOtherErrors verifies that
+// non-visibility errors are not retried — only the read-after-write race is.
+func TestAddTrackingRelationWithRetry_FailsFastOnOtherErrors(t *testing.T) {
+	calls := stubTracking(t, func(_, _, _ string) error {
+		return fmt.Errorf("connection refused")
+	})
+	if err := addTrackingRelationWithRetry("/town", "ah-cv-x", "ah-leg-y"); err == nil {
+		t.Fatal("addTrackingRelationWithRetry() = nil, want error")
+	}
+	if *calls != 1 {
+		t.Fatalf("attempts = %d, want 1 (no retry on non-visibility error)", *calls)
 	}
 }

--- a/internal/daemon/convoy_manager.go
+++ b/internal/daemon/convoy_manager.go
@@ -112,6 +112,11 @@ type ConvoyManager struct {
 	// been handled. This allows the 1s overlap window above without replaying
 	// the same lifecycle events on every poll.
 	processedLifecycleEvents sync.Map // map[string]bool
+
+	// seenSlingErrors deduplicates persistent sling failures so the daemon
+	// logs and escalates once per stranded issue instead of spamming every
+	// scan cycle. Key: issueID.
+	seenSlingErrors sync.Map // map[string]bool
 }
 
 // NewConvoyManager creates a new convoy manager.
@@ -571,13 +576,36 @@ func (m *ConvoyManager) feedFirstReady(c strandedConvoyInfo) {
 		cmd.Stderr = &stderr
 
 		if err := cmd.Run(); err != nil {
-			m.logger("Convoy %s: sling %s failed: %s", c.ID, issueID, util.FirstLine(stderr.String()))
+			errMsg := util.FirstLine(stderr.String())
+			// Log always; escalate and suppress future repeats on first failure.
+			if _, already := m.seenSlingErrors.LoadOrStore(issueID, true); !already {
+				m.logger("Convoy %s: sling %s failed: %s", c.ID, issueID, errMsg)
+				m.escalateSlingFailure(c.ID, issueID, errMsg)
+			}
 			continue
 		}
+		// Dispatch succeeded — clear any prior failure record so a future
+		// failure (if the issue is re-queued) is reported again.
+		m.seenSlingErrors.Delete(issueID)
 		return // Successfully dispatched one issue
 	}
 
 	m.logger("Convoy %s: no dispatchable issues (all %d skipped)", c.ID, len(c.ReadyIssues))
+}
+
+// escalateSlingFailure fires a one-shot gt escalate for a stranded convoy step.
+// It is called at most once per issueID (the caller deduplicates via seenSlingErrors).
+func (m *ConvoyManager) escalateSlingFailure(convoyID, issueID, errMsg string) {
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+
+	msg := fmt.Sprintf("Convoy %s: step %s cannot be dispatched and will never progress — %s (gt-3798). Investigate with: gt convoy status %s", convoyID, issueID, errMsg, convoyID)
+	cmd := exec.CommandContext(ctx, m.gtPath, "escalate", "-s", "HIGH", msg)
+	cmd.Dir = m.townRoot
+	util.SetDetachedProcessGroup(cmd)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		m.logger("Convoy %s: escalation failed: %v (%s)", convoyID, err, strings.TrimSpace(string(out)))
+	}
 }
 
 // checkConvoyCompletion runs gt convoy check to auto-close a convoy whose


### PR DESCRIPTION
## Summary

Fixes two upstream bugs that together broke `mol-idea-to-plan` and any crew-orchestrated convoy/workflow formula.

### #3798 — workflow dispatcher ignored step `target`

`executeWorkflowFormula` gated **all** ready steps behind a workflow-wide `hasInteractive` flag. Any single interactive step (e.g. `human-clarify`) forced every step onto the orchestrator's session, so non-interactive targeted steps (`prd-review`, `generate-plan` with `target = "mayor"`) were never routed — they ran as the pourer instead.

- Dispatch is now decided **per step**: interactive steps stay session-bound; non-interactive steps sling to their resolved target.
- `workflowStepTarget` returns the rig (never a role) for interactive steps; `workflowStepDescription` omits the `workflow_target:` line for interactive steps so the auto-dispatch override can't hijack them.

**Follow-up (Approach C — this PR's second commit):** end-to-end validation caught that the #3798 fix was incomplete under the capacity scheduler. The deferred-dispatch gate in `sling.go` had a **category error**: it asked "is the literal target a rig?" when the scheduler means "does this target consume a polecat slot?". Dogs were carved out (bead aa-4yf2) because they are a self-managed pool, not polecat slots. Mayor/deacon/rig-scoped standing agents (witness, refinery, crew) are equally not polecat slots but were never given the same exemption — so `gt sling <step> mayor` was dead-on-arrival under any rig with `scheduler.max_polecats` set.

**Three parts (Approach C):**
1. **Gate fix** (`sling.go` + `sling_helpers.go:isCapacityNeutralTarget`): generalises the dog fallthrough to the full capacity-neutral target class — dogs + mayor/deacon + `<rig>/witness`, `<rig>/refinery`, `<rig>/crew[/<name>]`. Bare rigs and `<rig>/polecats/<name>` remain capacity-managed.
2. **Pour-time pre-flight** (`formula.go`): before dispatching, warns on stderr and annotates the workflow bead if any non-interactive step resolves to a target that is neither a rig nor capacity-neutral — catches formula typos at pour rather than as silent daemon.log spam 30 s later.
3. **Loud runtime** (`daemon/convoy_manager.go`): deduplicates repeated sling failures in `feedFirstReady` via `seenSlingErrors` — log + escalate once per stranded issue instead of spamming every 30 s scan cycle.

### #4032 — convoy tooling

- **A. `review_id` divergence**: `--dry-run` honored `--set review_id=X` but real execution auto-slugged a fresh ID. Added `resolveReviewID(setVars)` used by both paths so dry-run == real.
- **B. Unexpanded synthesis template**: synthesis bead stored `f.Synthesis.Description` raw; now rendered with the same context the legs receive (`.output.*`, `--set` vars).
- **C. Leg-tracking race**: leg/synthesis/workflow-step tracking writes raced the bead's Dolt commit, leaving convoys at `0/0`. Added `addTrackingRelationWithRetry` with bounded exponential backoff.

## Test plan

- [x] `go build ./...` — clean
- [x] `go vet ./...` — clean
- [x] `golangci-lint run ./...` (v2.11.4, matching CI) — 0 issues
- [x] New unit tests: per-step interactive routing (#3798), `isCapacityNeutralTarget` + `isUnroutableTarget` (Approach C), `resolveReviewID` (#4032-A), synthesis template render (#4032-B), tracking retry / not-visible classification (#4032-C)
- [x] Existing `formula_test.go` / `tracking_relations_test.go` tests pass
- [x] Pre-existing failures (`TestRunPrimeExternalTools_*`, `TestCheckPendingEscalations_*`) confirmed unrelated (macOS unsigned-binary guard in `root.go:101`)
- [x] End-to-end: re-pour `mol-idea-to-plan` under capacity scheduler and confirm it reaches the `human-clarify` gate with real synthesis report

Closes #3798, Closes #4032.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
