### PR TITLE
fix: correct formula template syntax in 11 task/convoy formulas

### DIFF
--- a/internal/formula/formulas/design.formula.toml
+++ b/internal/formula/formulas/design.formula.toml
@@ -5,8 +5,8 @@
 # are synthesized into a unified design document.
 #
 # Usage:
-#   gt formula run design --problem="Add notification levels to mayor"
-#   gt formula run design --problem="Redesign the merge queue"
+#   gt formula run design --set problem="Add notification levels to mayor"
+#   gt formula run design --set problem="Redesign the merge queue"
 
 description = """
 Structured design exploration via parallel specialized analysts.

--- a/internal/formula/formulas/mol-convoy-cleanup.formula.toml
+++ b/internal/formula/formulas/mol-convoy-cleanup.formula.toml
@@ -47,7 +47,7 @@ Load the convoy bead and verify it's ready for archival.
 **1. Check your assignment:**
 ```bash
 gt hook               # Shows hook_bead = convoy ID
-bd show {{convoy}}          # Full convoy details
+bd show {{.convoy}}          # Full convoy details
 ```
 
 **2. Verify convoy is complete:**
@@ -55,7 +55,7 @@ bd show {{convoy}}          # Full convoy details
 - If convoy is still open, exit - Deacon dispatched too early
 
 ```bash
-bd show {{convoy}}
+bd show {{.convoy}}
 # Check 'tracks' or 'dependencies' field
 # All tracked issues should be closed
 ```
@@ -90,7 +90,7 @@ bd show <tracked-id>
 
 **3. Create summary text:**
 ```markdown
-## Convoy Summary: {{convoy.title}}
+## Convoy Summary: {{.convoy.title}}
 
 **Duration**: X days/hours
 **Issues completed**: N
@@ -120,12 +120,12 @@ Close the convoy to mark it complete. Beads retention handles archival.
 
 **1. Close convoy:**
 ```bash
-bd close {{convoy}} --reason="Convoy complete"
+bd close {{.convoy}} --reason="Convoy complete"
 ```
 
 **2. Verify closure:**
 ```bash
-bd show {{convoy}}
+bd show {{.convoy}}
 # Status should be "closed"
 ```
 
@@ -145,18 +145,18 @@ Notify the Mayor (overseer) of convoy completion.
 
 **1. Send completion mail:**
 ```bash
-gt mail send mayor/ -s "Convoy complete: {{convoy.title}}" -m "$(cat <<EOF
-Convoy {{convoy}} has completed and been closed.
+gt mail send mayor/ -s "Convoy complete: {{.convoy.title}}" -m "$(cat <<EOF
+Convoy {{.convoy}} has completed and been closed.
 
 ## Summary
-{{generated_summary}}
+{{.generated_summary}}
 
 ## Metrics
-- Duration: {{duration}}
-- Issues: {{issue_count}}
-- Contributors: {{contributor_list}}
+- Duration: {{.duration}}
+- Issues: {{.issue_count}}
+- Contributors: {{.contributor_list}}
 
-This convoy has been closed. View details: bd show {{convoy}}
+This convoy has been closed. View details: bd show {{.convoy}}
 EOF
 )"
 ```
@@ -180,9 +180,9 @@ Signal work complete and return to available pool.
 **1. Signal completion to Deacon:**
 ```bash
 gt mail send deacon/ -s "DOG_DONE $(hostname)" -m "Task: convoy-cleanup
-Convoy: {{convoy}}
+Convoy: {{.convoy}}
 Status: COMPLETE
-Duration: {{work_duration}}
+Duration: {{.work_duration}}
 
 Ready for next assignment."
 ```

--- a/internal/formula/formulas/mol-convoy-feed.formula.toml
+++ b/internal/formula/formulas/mol-convoy-feed.formula.toml
@@ -60,7 +60,7 @@ gt hook               # Shows convoy in hook_bead or vars
 
 **2. Load convoy details:**
 ```bash
-gt convoy status {{convoy}} --json
+gt convoy status {{.convoy}} --json
 ```
 
 **3. Identify ready issues:**
@@ -180,21 +180,21 @@ Create summary report of convoy feeding actions.
 
 **1. Generate report:**
 ```markdown
-## Convoy Feed Report: {{convoy}}
+## Convoy Feed Report: {{.convoy}}
 
-**Ready issues found**: {{ready_count}}
-**Polecats available**: {{available_count}}
-**Issues dispatched**: {{dispatch_count}}
+**Ready issues found**: {{.ready_count}}
+**Polecats available**: {{.available_count}}
+**Issues dispatched**: {{.dispatch_count}}
 
 ### Dispatched Work
 {{#each dispatched}}
-- {{issue_id}}: {{title}} → {{rig}}/{{polecat}}
+- {{.issue_id}}: {{.title}} → {{.rig}}/{{.polecat}}
 {{/each}}
 
 ### Skipped (no capacity)
 {{#if skipped}}
 {{#each skipped}}
-- {{issue_id}}: {{title}} (will retry next cycle)
+- {{.issue_id}}: {{.title}} (will retry next cycle)
 {{/each}}
 {{else}}
 (none)
@@ -203,7 +203,7 @@ Create summary report of convoy feeding actions.
 ### Errors
 {{#if errors}}
 {{#each errors}}
-- {{issue_id}}: {{error}}
+- {{.issue_id}}: {{.error}}
 {{/each}}
 {{else}}
 (none)
@@ -212,13 +212,13 @@ Create summary report of convoy feeding actions.
 
 **2. Send to Deacon:**
 ```bash
-gt mail send deacon/ -s "Convoy fed: {{convoy}}" -m "$(cat <<EOF
-Convoy {{convoy}} feeding complete.
+gt mail send deacon/ -s "Convoy fed: {{.convoy}}" -m "$(cat <<EOF
+Convoy {{.convoy}} feeding complete.
 
-Dispatched: {{dispatch_count}}/{{ready_count}} issues
-{{#if errors}}Errors: {{error_count}}{{/if}}
+Dispatched: {{.dispatch_count}}/{{.ready_count}} issues
+{{#if errors}}Errors: {{.error_count}}{{/if}}
 
-{{report_summary}}
+{{.report_summary}}
 EOF
 )"
 ```
@@ -239,9 +239,9 @@ Signal work complete and return to available pool.
 **1. Signal completion to Deacon:**
 ```bash
 gt mail send deacon/ -s "DOG_DONE $(hostname)" -m "Task: convoy-feed
-Convoy: {{convoy}}
-Ready: {{ready_count}}
-Dispatched: {{dispatch_count}}
+Convoy: {{.convoy}}
+Ready: {{.ready_count}}
+Dispatched: {{.dispatch_count}}
 Status: COMPLETE
 
 Ready for next assignment."

--- a/internal/formula/formulas/mol-dep-propagate.formula.toml
+++ b/internal/formula/formulas/mol-dep-propagate.formula.toml
@@ -45,18 +45,18 @@ Load the closed issue and identify cross-rig dependents.
 **1. Check your assignment:**
 ```bash
 gt hook               # Shows hook_bead = resolved issue ID
-bd show {{resolved_issue}}  # Full issue details
+bd show {{.resolved_issue}}  # Full issue details
 ```
 
 **2. Verify issue is closed:**
 ```bash
-bd show {{resolved_issue}}
+bd show {{.resolved_issue}}
 # Status should be 'closed' or similar terminal state
 ```
 
 **3. Find dependents (issues blocked by this one):**
 ```bash
-bd show {{resolved_issue}}
+bd show {{.resolved_issue}}
 # Look at 'blocks' field - these are issues waiting on this one
 ```
 
@@ -98,7 +98,7 @@ Beads should auto-update blocked status when dependencies close.
 This step verifies and fixes if needed:
 ```bash
 # If still showing as blocked by resolved issue (shouldn't happen):
-bd dep remove <dependent-id> {{resolved_issue}}
+bd dep remove <dependent-id> {{.resolved_issue}}
 ```
 
 **Exit criteria:** All cross-rig dependents have updated blocked status."""
@@ -117,17 +117,17 @@ Send notifications to Witnesses of affected rigs.
 
 **2. For each affected rig, send notification:**
 ```bash
-gt mail send <rig>/witness -s "Dependency resolved: {{resolved_issue}}" -m "$(cat <<EOF
+gt mail send <rig>/witness -s "Dependency resolved: {{.resolved_issue}}" -m "$(cat <<EOF
 External dependency has closed, unblocking work in your rig.
 
 ## Resolved Issue
-- ID: {{resolved_issue}}
-- Title: {{resolved_issue.title}}
-- Rig: {{resolved_issue.prefix}}
+- ID: {{.resolved_issue}}
+- Title: {{.resolved_issue.title}}
+- Rig: {{.resolved_issue.prefix}}
 
 ## Unblocked in Your Rig
 {{range dependent}}
-- {{dependent.id}}: {{dependent.title}} ({{dependent.status}})
+- {{.dependent.id}}: {{.dependent.title}} ({{.dependent.status}})
 {{end}}
 
 These issues may now proceed. Check bd ready for available work.
@@ -185,9 +185,9 @@ Signal work complete and return to available pool.
 **1. Signal completion to Deacon:**
 ```bash
 gt mail send deacon/ -s "DOG_DONE $(hostname)" -m "Task: dep-propagate
-Resolved: {{resolved_issue}}
-Cross-rig dependents: {{dependent_count}}
-Witnesses notified: {{witness_list}}
+Resolved: {{.resolved_issue}}
+Cross-rig dependents: {{.dependent_count}}
+Witnesses notified: {{.witness_list}}
 Status: COMPLETE
 
 Ready for next assignment."

--- a/internal/formula/formulas/mol-digest-generate.formula.toml
+++ b/internal/formula/formulas/mol-digest-generate.formula.toml
@@ -87,26 +87,26 @@ gt rigs
 a) **Issues filed and closed:**
 ```bash
 # From rig beads
-bd list --created-after={{since}} --created-before={{until}}
-bd list --status=closed --updated-after={{since}}
+bd list --created-after={{.since}} --created-before={{.until}}
+bd list --status=closed --updated-after={{.since}}
 ```
 
 b) **Agent activity:**
 ```bash
 gt polecats <rig>           # Polecat activity
-gt feed --since={{since}}   # Activity feed entries
+gt feed --since={{.since}}   # Activity feed entries
 ```
 
 c) **Merges:**
 ```bash
 # Git log for merges to main
-git -C <rig-path> log --merges --since={{since}} --oneline main
+git -C <rig-path> log --merges --since={{.since}} --oneline main
 ```
 
 d) **Incidents:**
 ```bash
 # Issues tagged as incident or high-priority
-bd list --label=incident --created-after={{since}}
+bd list --label=incident --created-after={{.since}}
 ```
 
 **3. Aggregate across rigs:**
@@ -135,7 +135,7 @@ Transform collected data into formatted digest.
 
 **3. Generate digest text:**
 ```markdown
-# Gas Town Daily Digest: {{date}}
+# Gas Town Daily Digest: {{.date}}
 
 ## Summary
 - **Issues filed**: N (tasks: X, bugs: Y, features: Z)
@@ -150,7 +150,7 @@ Transform collected data into formatted digest.
 
 ## Highlights
 ### Completed
-- {{epic or feature}} - completed by {{polecat}}
+- {{epic or feature}} - completed by {{.polecat}}
 
 ### Incidents
 - {{incident summary if any}}
@@ -176,8 +176,8 @@ Deliver digest to the Mayor.
 
 **1. Send via mail:**
 ```bash
-gt mail send mayor/ -s "Gas Town Digest: {{date}}" -m "$(cat <<EOF
-{{formatted_digest}}
+gt mail send mayor/ -s "Gas Town Digest: {{.date}}" -m "$(cat <<EOF
+{{.formatted_digest}}
 EOF
 )"
 ```
@@ -185,9 +185,9 @@ EOF
 **2. Archive as bead:**
 Create a digest bead for permanent record:
 ```bash
-bd create --title="Digest: {{date}}" --type=digest \
-  --description="{{formatted_digest}}" \
-  --label=digest,{{period}}
+bd create --title="Digest: {{.date}}" --type=digest \
+  --description="{{.formatted_digest}}" \
+  --label=digest,{{.period}}
 ```
 
 **3. Sync:**
@@ -207,8 +207,8 @@ Signal work complete and return to available pool.
 **1. Signal completion to Deacon:**
 ```bash
 gt mail send deacon/ -s "DOG_DONE $(hostname)" -m "Task: digest-generate
-Period: {{period}}
-Date range: {{since}} to {{until}}
+Period: {{.period}}
+Date range: {{.since}} to {{.until}}
 Status: COMPLETE
 
 Digest sent to Mayor.

--- a/internal/formula/formulas/mol-dog-backup.formula.toml
+++ b/internal/formula/formulas/mol-dog-backup.formula.toml
@@ -94,18 +94,18 @@ Generate summary and signal completion.
 ```markdown
 ## Backup Dog Report
 
-**Databases synced**: {{synced_count}}/{{total_count}}
-**Offsite sync**: {{offsite_status}}
+**Databases synced**: {{.synced_count}}/{{.total_count}}
+**Offsite sync**: {{.offsite_status}}
 
 ### Per Database
 {{#each db}}
-- {{name}}: {{status}} ({{duration}})
+- {{.name}}: {{.status}} ({{.duration}})
 {{/each}}
 
 ### Failures
 {{#if failures}}
 {{#each failures}}
-- {{name}}: {{error}}
+- {{.name}}: {{.error}}
 {{/each}}
 {{else}}
 None
@@ -115,8 +115,8 @@ None
 **2. Signal completion to Deacon:**
 ```bash
 gt mail send deacon/ -s "DOG_DONE: backup" -m "Task: dolt-backup
-Synced: {{synced_count}}/{{total_count}}
-Offsite: {{offsite_status}}
+Synced: {{.synced_count}}/{{.total_count}}
+Offsite: {{.offsite_status}}
 Status: COMPLETE"
 ```
 

--- a/internal/formula/formulas/mol-dog-doctor.formula.toml
+++ b/internal/formula/formulas/mol-dog-doctor.formula.toml
@@ -53,7 +53,7 @@ Use active_branch() — lightweight probe that won't block behind queued queries
 (per Dolt CEO recommendation).
 
 **2. Measure latency:**
-Time the probe query. Warn if > {{latency_threshold}}.
+Time the probe query. Warn if > {{.latency_threshold}}.
 
 **3. Record results:**
 - Server reachable: yes/no
@@ -63,7 +63,7 @@ Time the probe query. Warn if > {{latency_threshold}}.
 **If server unreachable:**
 This is a critical failure. Escalate immediately:
 ```bash
-gt escalate -s CRITICAL "Dolt: server unreachable on port {{port}}"
+gt escalate -s CRITICAL "Dolt: server unreachable on port {{.port}}"
 ```
 
 **Exit criteria:** Server connectivity confirmed (or escalated)."""
@@ -126,16 +126,16 @@ Generate health report and signal completion.
 ```markdown
 ## Doctor Dog Report
 
-**Server**: {{server_status}} (latency: {{latency}})
-**Connections**: {{conn_count}}/{{conn_max}} ({{conn_pct}}%)
-**Disk usage**: {{disk_usage}}
-**Orphan databases**: {{orphan_count}}
-**Backup freshness**: {{backup_status}}
+**Server**: {{.server_status}} (latency: {{.latency}})
+**Connections**: {{.conn_count}}/{{.conn_max}} ({{.conn_pct}}%)
+**Disk usage**: {{.disk_usage}}
+**Orphan databases**: {{.orphan_count}}
+**Backup freshness**: {{.backup_status}}
 
 ### Warnings
 {{#if warnings}}
 {{#each warnings}}
-- {{category}}: {{message}}
+- {{.category}}: {{.message}}
 {{/each}}
 {{else}}
 None — server is healthy.
@@ -144,7 +144,7 @@ None — server is healthy.
 ### Orphan Databases
 {{#if orphans}}
 {{#each orphans}}
-- {{name}}
+- {{.name}}
 {{/each}}
 Run `gt dolt cleanup` to remove.
 {{else}}
@@ -161,10 +161,10 @@ gt escalate -s CRITICAL "Dolt: <condition>"
 **3. Signal completion to Deacon:**
 ```bash
 gt mail send deacon/ -s "DOG_DONE: doctor" -m "Task: dolt-doctor
-Server: {{server_status}}
-Latency: {{latency}}
-Connections: {{conn_count}}/{{conn_max}}
-Orphans: {{orphan_count}}
+Server: {{.server_status}}
+Latency: {{.latency}}
+Connections: {{.conn_count}}/{{.conn_max}}
+Orphans: {{.orphan_count}}
 Status: COMPLETE"
 ```
 

--- a/internal/formula/formulas/mol-dog-jsonl.formula.toml
+++ b/internal/formula/formulas/mol-dog-jsonl.formula.toml
@@ -91,7 +91,7 @@ verifyExportCounts(gitRepo, databases, counts, threshold)
 ```
 
 **3. Evaluate results:**
-- If delta > {{spike_threshold}} (default 20%) for ANY database → HALT
+- If delta > {{.spike_threshold}} (default 20%) for ANY database → HALT
 - Log anomalies: sudden jumps = pollution, sudden drops = data loss
 - Escalate to Mayor with spike report
 - Do NOT proceed to commit/push
@@ -133,7 +133,7 @@ git -C <git_repo> push origin main
 ```
 
 **5. Handle push failures:**
-Track consecutive failures. After {{max_push_failures}} consecutive failures,
+Track consecutive failures. After {{.max_push_failures}} consecutive failures,
 escalate to Mayor.
 
 **Exit criteria:** Changes committed and pushed (or no changes to commit)."""
@@ -149,19 +149,19 @@ Generate summary and signal completion.
 ```markdown
 ## JSONL Dog Report
 
-**Databases exported**: {{exported_count}}/{{total_count}}
-**Total records**: {{record_count}}
-**Git push**: {{push_status}}
+**Databases exported**: {{.exported_count}}/{{.total_count}}
+**Total records**: {{.record_count}}
+**Git push**: {{.push_status}}
 
 ### Per Database
 {{#each db}}
-- {{name}}: {{records}} records ({{tables}} tables)
+- {{.name}}: {{.records}} records ({{.tables}} tables)
 {{/each}}
 
 ### Failures
 {{#if failures}}
 {{#each failures}}
-- {{name}}: {{error}}
+- {{.name}}: {{.error}}
 {{/each}}
 {{else}}
 None
@@ -171,9 +171,9 @@ None
 **2. Signal completion to Deacon:**
 ```bash
 gt mail send deacon/ -s "DOG_DONE: jsonl" -m "Task: jsonl-git-backup
-Exported: {{exported_count}}/{{total_count}}
-Records: {{record_count}}
-Push: {{push_status}}
+Exported: {{.exported_count}}/{{.total_count}}
+Records: {{.record_count}}
+Push: {{.push_status}}
 Status: COMPLETE"
 ```
 

--- a/internal/formula/formulas/mol-dog-phantom-db.formula.toml
+++ b/internal/formula/formulas/mol-dog-phantom-db.formula.toml
@@ -90,7 +90,7 @@ Skip this step — nothing to escalate.
 
 **2. If phantoms were found, escalate:**
 ```bash
-gt escalate -s HIGH "Dolt: detected {{phantom_count}} phantom database(s): {{phantom_names}} — requires Dolt server restart to resolve"
+gt escalate -s HIGH "Dolt: detected {{.phantom_count}} phantom database(s): {{.phantom_names}} — requires Dolt server restart to resolve"
 ```
 
 Phantom databases indicate a Dolt bug (DROP DATABASE + catalog re-materialization)
@@ -110,15 +110,15 @@ Generate summary and signal completion.
 ```markdown
 ## Phantom DB Dog Report
 
-**Directories scanned**: {{scan_count}}
-**Phantoms found**: {{phantom_count}}
-**Phantoms quarantined**: {{quarantined_count}}
-**Valid databases**: {{valid_count}}
+**Directories scanned**: {{.scan_count}}
+**Phantoms found**: {{.phantom_count}}
+**Phantoms quarantined**: {{.quarantined_count}}
+**Valid databases**: {{.valid_count}}
 
 ### Phantom Databases
 {{#if phantoms}}
 {{#each phantoms}}
-- {{name}} (quarantined)
+- {{.name}} (quarantined)
 {{/each}}
 {{else}}
 None detected — .dolt-data/ is clean.
@@ -128,9 +128,9 @@ None detected — .dolt-data/ is clean.
 **2. Signal completion to Deacon:**
 ```bash
 gt mail send deacon/ -s "DOG_DONE: phantom-db" -m "Task: phantom-db-scan
-Scanned: {{scan_count}}
-Phantoms: {{phantom_count}}
-Quarantined: {{quarantined_count}}
+Scanned: {{.scan_count}}
+Phantoms: {{.phantom_count}}
+Quarantined: {{.quarantined_count}}
 Status: COMPLETE"
 ```
 

--- a/internal/formula/formulas/mol-dog-reaper.formula.toml
+++ b/internal/formula/formulas/mol-dog-reaper.formula.toml
@@ -62,16 +62,16 @@ Discover databases and count candidates for each operation.
 
 **1. List databases to scan:**
 ```bash
-gt reaper databases --port={{dolt_port}} --json
+gt reaper databases --port={{.dolt_port}} --json
 ```
-Or use configured database list from {{databases}} variable.
+Or use configured database list from {{.databases}} variable.
 
 **2. Scan each database:**
 ```bash
-gt reaper scan --db=<name> --port={{dolt_port}} \\
-  --max-age={{max_age}} --purge-age={{purge_age}} \\
-  --mail-age={{mail_delete_age}} --stale-age={{stale_issue_age}} \\
-  --db-delay={{db_delay}} \\
+gt reaper scan --db=<name> --port={{.dolt_port}} \\
+  --max-age={{.max_age}} --purge-age={{.purge_age}} \\
+  --mail-age={{.mail_delete_age}} --stale-age={{.stale_issue_age}} \\
+  --db-delay={{.db_delay}} \\
   --json
 ```
 
@@ -79,7 +79,7 @@ gt reaper scan --db=<name> --port={{dolt_port}} \\
 - Check the `anomalies` array in the JSON output
 - Flag any `dangling_parent_ref` anomalies — these indicate wisps with
   parent dependency records pointing to purged/missing parents
-- If `open_wisps` exceeds {{alert_threshold}}, escalate
+- If `open_wisps` exceeds {{.alert_threshold}}, escalate
 
 **4. Decide whether to proceed:**
 - If no candidates found across all databases, skip remaining steps
@@ -96,8 +96,8 @@ Close wisps past max_age whose parent molecule is closed or missing.
 
 **1. For each database with reap candidates:**
 ```bash
-gt reaper reap --db=<name> --port={{dolt_port}} \\
-  --max-age={{max_age}} --db-delay={{db_delay}} {{#if dry_run}}--dry-run{{/if}} --json
+gt reaper reap --db=<name> --port={{.dolt_port}} \\
+  --max-age={{.max_age}} --db-delay={{.db_delay}} {{#if dry_run}}--dry-run{{/if}} --json
 ```
 
 **2. Inspect results:**
@@ -108,7 +108,7 @@ gt reaper reap --db=<name> --port={{dolt_port}} \\
 - Check for any anomalies in the response
 
 **3. Alert check:**
-If total open wisps across all databases exceed {{alert_threshold}},
+If total open wisps across all databases exceed {{.alert_threshold}},
 log a warning and consider escalating.
 
 **Exit criteria:** All stale wisps closed (or dry-run counts reported)."""
@@ -122,9 +122,9 @@ Delete closed wisps past purge_age and closed mail past mail_delete_age.
 
 **1. For each database with purge candidates:**
 ```bash
-gt reaper purge --db=<name> --port={{dolt_port}} \\
-  --purge-age={{purge_age}} --mail-age={{mail_delete_age}} \\
-  --db-delay={{db_delay}} \\
+gt reaper purge --db=<name> --port={{.dolt_port}} \\
+  --purge-age={{.purge_age}} --mail-age={{.mail_delete_age}} \\
+  --db-delay={{.db_delay}} \\
   {{#if dry_run}}--dry-run{{/if}} --json
 ```
 
@@ -147,9 +147,9 @@ Close issues that have been open with no status change past stale_issue_age.
 
 **1. For each database with stale candidates:**
 ```bash
-gt reaper auto-close --db=<name> --port={{dolt_port}} \\
-  --stale-age={{stale_issue_age}} \\
-  --db-delay={{db_delay}} \\
+gt reaper auto-close --db=<name> --port={{.dolt_port}} \\
+  --stale-age={{.stale_issue_age}} \\
+  --db-delay={{.db_delay}} \\
   {{#if dry_run}}--dry-run{{/if}} --json
 ```
 

--- a/internal/formula/formulas/mol-dog-stale-db.formula.toml
+++ b/internal/formula/formulas/mol-dog-stale-db.formula.toml
@@ -89,7 +89,7 @@ Remove orphan databases if count is manageable.
 **1. If no orphans found:**
 Skip — nothing to clean.
 
-**2. If orphan count <= {{max_orphans_for_sql}}:**
+**2. If orphan count <= {{.max_orphans_for_sql}}:**
 Clean up via SQL:
 ```sql
 DROP DATABASE IF EXISTS `<orphan_name>`;
@@ -98,11 +98,11 @@ DROP DATABASE IF EXISTS `<orphan_name>`;
 Handle potential read-only mode after DROP (gt-r1cyd):
 If DROP puts server into read-only, attempt recovery before continuing.
 
-**3. If orphan count > {{max_orphans_for_sql}}:**
+**3. If orphan count > {{.max_orphans_for_sql}}:**
 SQL cleanup would take too long (each DROP is ~27s under load).
 Escalate instead of attempting cleanup:
 ```bash
-gt escalate -s HIGH "Dolt: {{orphan_count}} orphan databases detected (too many for SQL cleanup)"
+gt escalate -s HIGH "Dolt: {{.orphan_count}} orphan databases detected (too many for SQL cleanup)"
 ```
 
 Recommend filesystem cleanup:
@@ -130,16 +130,16 @@ Generate summary and signal completion.
 ```markdown
 ## Stale DB Dog Report
 
-**Total databases**: {{total_count}}
-**Production databases**: {{prod_count}}
-**Orphan databases**: {{orphan_count}}
-**Orphans removed**: {{removed_count}}
-**Orphans remaining**: {{remaining_count}}
+**Total databases**: {{.total_count}}
+**Production databases**: {{.prod_count}}
+**Orphan databases**: {{.orphan_count}}
+**Orphans removed**: {{.removed_count}}
+**Orphans remaining**: {{.remaining_count}}
 
 ### Orphan Databases
 {{#if orphans}}
 {{#each orphans}}
-- {{name}} ({{size}})
+- {{.name}} ({{.size}})
 {{/each}}
 {{else}}
 None detected — database list is clean.
@@ -147,27 +147,27 @@ None detected — database list is clean.
 
 ### Action Taken
 {{#if cleaned}}
-Removed {{removed_count}} orphan(s) via SQL DROP DATABASE.
+Removed {{.removed_count}} orphan(s) via SQL DROP DATABASE.
 {{else if escalated}}
-Too many orphans ({{orphan_count}}) for SQL cleanup — escalated.
+Too many orphans ({{.orphan_count}}) for SQL cleanup — escalated.
 {{else}}
 No action needed.
 {{/if}}
 ```
 
 **2. Warn if above threshold:**
-If orphan count >= {{warn_threshold}}, this is early warning:
+If orphan count >= {{.warn_threshold}}, this is early warning:
 ```bash
-gt mail send deacon/ -s "WARN: {{orphan_count}} orphan databases detected" -m "..."
+gt mail send deacon/ -s "WARN: {{.orphan_count}} orphan databases detected" -m "..."
 ```
 
 **3. Signal completion to Deacon:**
 ```bash
 gt mail send deacon/ -s "DOG_DONE: stale-db" -m "Task: stale-db-scan
-Total DBs: {{total_count}}
-Production: {{prod_count}}
-Orphans: {{orphan_count}}
-Removed: {{removed_count}}
+Total DBs: {{.total_count}}
+Production: {{.prod_count}}
+Orphans: {{.orphan_count}}
+Removed: {{.removed_count}}
 Status: COMPLETE"
 ```
 

--- a/internal/formula/formulas/mol-idea-to-plan.formula.toml
+++ b/internal/formula/formulas/mol-idea-to-plan.formula.toml
@@ -122,8 +122,8 @@ Pour the mol-prd-review convoy to run 6 parallel PRD reviewers.
 **1. Pour the convoy:**
 ```bash
 gt formula run mol-prd-review \\
-  --problem="{{problem}}" \\
-  --context="See .prd-reviews/{{review_id}}/prd-draft.md. {{context}}"
+  --set problem="{{problem}}" \\
+  --set context="See .prd-reviews/{{review_id}}/prd-draft.md. {{context}}"
 ```
 
 This spawns 6 polecats in parallel:
@@ -215,8 +215,8 @@ Pour the design convoy to generate an implementation plan from the refined PRD.
 **1. Pour the design convoy:**
 ```bash
 gt formula run design \\
-  --problem="{{problem}}" \\
-  --context="PRD with clarifications: .prd-reviews/{{review_id}}/prd-draft.md. {{context}}"
+  --set problem="{{problem}}" \\
+  --set context="PRD with clarifications: .prd-reviews/{{review_id}}/prd-draft.md. {{context}}"
 ```
 
 This spawns 6 polecats in parallel, each exploring a different dimension:

--- a/internal/formula/formulas/mol-polecat-code-review.formula.toml
+++ b/internal/formula/formulas/mol-polecat-code-review.formula.toml
@@ -63,7 +63,7 @@ gt hook               # Shows your pinned molecule and hook_bead
 
 The hook_bead describes your review scope. Read the tracking issue:
 ```bash
-bd show {{issue}}           # Full issue details
+bd show {{.issue}}           # Full issue details
 ```
 
 **3. Understand the scope:**
@@ -74,16 +74,16 @@ bd show {{issue}}           # Full issue details
 **4. Locate the code:**
 ```bash
 # If scope is a path:
-ls -la {{scope}}
-head -100 {{scope}}         # Quick look at the code
+ls -la {{.scope}}
+head -100 {{.scope}}         # Quick look at the code
 
 # If scope is a directory:
-find {{scope}} -type f -name "*.go" | head -20
+find {{.scope}} -type f -name "*.go" | head -20
 ```
 
 **5. Check for recent changes:**
 ```bash
-git log --oneline -10 -- {{scope}}
+git log --oneline -10 -- {{.scope}}
 ```
 
 **Exit criteria:** You understand what you're reviewing and why."""
@@ -98,10 +98,10 @@ Get a high-level understanding before diving into details.
 **1. Understand the structure:**
 ```bash
 # For a directory:
-tree {{scope}} -L 2
+tree {{.scope}} -L 2
 
 # For a file:
-wc -l {{scope}}             # How big is it?
+wc -l {{.scope}}             # How big is it?
 ```
 
 **2. Identify key components:**
@@ -111,7 +111,7 @@ wc -l {{scope}}             # How big is it?
 
 **3. Read the tests (if any):**
 ```bash
-find {{scope}} -name "*_test.go" | xargs head -50
+find {{.scope}} -name "*_test.go" | xargs head -50
 ```
 Tests often reveal intended behavior.
 
@@ -140,11 +140,11 @@ Systematically review the code for issues.
 | **Maintainability** | Dead code, unclear naming, missing comments on complex logic |
 | **Testing** | Untested paths, missing edge cases, flaky tests |
 
-**Focus on {{focus}} if specified.**
+**Focus on {{.focus}} if specified.**
 
 **1. Read through the code:**
 ```bash
-cat {{scope}}               # For single file
+cat {{.scope}}               # For single file
 # Or read files systematically for a directory
 ```
 
@@ -181,8 +181,8 @@ Group by priority, then by category.
 
 **2. For P0 issues:**
 ```bash
-gt mail send {{rig}}/witness -s "CRITICAL: Security issue found" -m "Scope: {{scope}}
-Issue: {{issue}}
+gt mail send {{.rig}}/witness -s "CRITICAL: Security issue found" -m "Scope: {{.scope}}
+Issue: {{.issue}}
 Finding: <description of critical issue>
 Location: <file:line>"
 ```
@@ -208,7 +208,7 @@ Create beads for each finding.
 ```bash
 bd create --type=bug --priority=1 \
   --title="<clear description of bug>" \
-  --description="Found during code review of {{scope}}.
+  --description="Found during code review of {{.scope}}.
 
 Location: <file:line>
 
@@ -226,7 +226,7 @@ Suggested fix:
 ```bash
 bd create --type=task --priority=2 \
   --title="<clear description>" \
-  --description="Found during code review of {{scope}}.
+  --description="Found during code review of {{.scope}}.
 
 Location: <file:line>
 
@@ -254,10 +254,10 @@ Update the tracking issue with review summary.
 
 **1. Create summary:**
 ```bash
-bd update {{issue}} --notes "Code review complete.
+bd update {{.issue}} --notes "Code review complete.
 
-Scope: {{scope}}
-Focus: {{focus}}
+Scope: {{.scope}}
+Focus: {{.focus}}
 
 Findings:
 - P0 (critical): <count>


### PR DESCRIPTION
## Summary

Fixes two distinct classes of authoring bugs across the formula library (closes #4039).

**Bug A — bare `{{key}}` in task/convoy formula templates (silently unrendered)**

Go's `text/template` engine requires map keys to be accessed as `{{.key}}`; the bare `{{key}}` form tries to call a function named `key`, silently renders to empty string, and produces broken prompts (missing scopes, issue IDs, mail subjects, etc.). Fixed 186 occurrences across 11 files:

- `mol-polecat-code-review.formula.toml`
- `mol-convoy-cleanup.formula.toml`
- `mol-convoy-feed.formula.toml`
- `mol-dep-propagate.formula.toml`
- `mol-digest-generate.formula.toml`
- `mol-dog-backup.formula.toml`
- `mol-dog-doctor.formula.toml`
- `mol-dog-jsonl.formula.toml`
- `mol-dog-phantom-db.formula.toml`
- `mol-dog-reaper.formula.toml`
- `mol-dog-stale-db.formula.toml`

Workflow formulas (where step descriptions are agent prose, not rendered templates) were intentionally left untouched.

**Bug B — non-existent `--problem` / `--context` flags in usage examples**

`gt formula run` only accepts `--set key=value` (introduced in 5559faaf, Apr 12 2026). Two files contained `--problem=` and `--context=` flags that have never existed and cause an "unknown flag" error:

- `design.formula.toml`: comment block lines 8–9
- `mol-idea-to-plan.formula.toml`: workflow step descriptions for `prd-review` and `design-convoy` steps

## Test plan

- [ ] `gt formula run mol-polecat-code-review --set scope="internal/cmd/formula.go" --set issue="hq-abc123" --dry-run` — scope, issue, rig, focus should appear in rendered prompt (not blank)
- [ ] `gt formula run design --set problem="test"` — should not error with "unknown flag"
- [ ] `gt formula run design --problem="test"` — should still error (flag doesn't exist; this verifies the test itself is valid)
- [ ] Verify workflow formula step descriptions are unchanged (bare `{{key}}` forms in `mol-idea-to-plan` steps are intentional agent prose)

🤖 Generated with [Claude Code](https://claude.com/claude-code)