### PR TITLE
fix: gt sling self-targeting injects ack text into caller's prompt and gets interrupted

### DIFF
--- a/internal/cmd/sling_target.go
+++ b/internal/cmd/sling_target.go
@@ -309,5 +309,11 @@ func resolveTarget(target string, opts ResolveTargetOptions) (*ResolvedTarget, e
 	result.Agent = agentID
 	result.Pane = pane
 	result.WorkDir = workDir
+	// Detect self-sling by pane: a named target (e.g. "deacon") that resolves to
+	// the caller's own tmux pane should not inject the ack prompt — the caller is
+	// already running and knows about the hook (GH#3839).
+	if pane != "" && pane == os.Getenv("TMUX_PANE") {
+		result.IsSelfSling = true
+	}
 	return result, nil
 }

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -3281,3 +3281,59 @@ exit /b 0
 	}
 	// Any other error (e.g., no polecat to spawn) is acceptable — the guard is what we're testing.
 }
+
+// TestResolveTargetSelfSlingByPane verifies that a named target resolving to the
+// caller's own tmux pane sets IsSelfSling=true (GH#3839). Without this, gt sling
+// deacon (from the deacon itself) injects the ack prompt into the running agent's
+// pane, wedging it mid-command.
+func TestResolveTargetSelfSlingByPane(t *testing.T) {
+	const callerPane = "%42"
+
+	prev := resolveTargetAgentFn
+	t.Cleanup(func() { resolveTargetAgentFn = prev })
+
+	t.Run("named_target_same_pane_is_self_sling", func(t *testing.T) {
+		resolveTargetAgentFn = func(_ string) (string, string, string, error) {
+			return "deacon/", callerPane, "/home/deacon", nil
+		}
+		t.Setenv("TMUX_PANE", callerPane)
+
+		result, err := resolveTarget("deacon", ResolveTargetOptions{})
+		if err != nil {
+			t.Fatalf("resolveTarget: %v", err)
+		}
+		if !result.IsSelfSling {
+			t.Error("expected IsSelfSling=true when named target pane matches caller pane")
+		}
+	})
+
+	t.Run("named_target_different_pane_is_not_self_sling", func(t *testing.T) {
+		resolveTargetAgentFn = func(_ string) (string, string, string, error) {
+			return "deacon/", "%99", "/home/deacon", nil
+		}
+		t.Setenv("TMUX_PANE", callerPane)
+
+		result, err := resolveTarget("deacon", ResolveTargetOptions{})
+		if err != nil {
+			t.Fatalf("resolveTarget: %v", err)
+		}
+		if result.IsSelfSling {
+			t.Error("expected IsSelfSling=false when named target pane differs from caller pane")
+		}
+	})
+
+	t.Run("empty_pane_is_not_self_sling", func(t *testing.T) {
+		resolveTargetAgentFn = func(_ string) (string, string, string, error) {
+			return "deacon/", "", "/home/deacon", nil
+		}
+		t.Setenv("TMUX_PANE", callerPane)
+
+		result, err := resolveTarget("deacon", ResolveTargetOptions{})
+		if err != nil {
+			t.Fatalf("resolveTarget: %v", err)
+		}
+		if result.IsSelfSling {
+			t.Error("expected IsSelfSling=false when resolved pane is empty (no tmux)")
+		}
+	})
+}


### PR DESCRIPTION
## Summary

- When `gt sling` targets a named agent (e.g. `deacon`) that resolves to the caller's own tmux pane, the ack text was being injected into the caller's running prompt, wedging the agent mid-command.
- Fix detects self-sling by comparing the resolved pane ID against the caller's `TMUX_PANE` env var; if they match, `IsSelfSling` is set and ack injection is skipped.
- The `pane != ""` guard ensures no false positives when running outside tmux.

## Changes

- `internal/cmd/sling_target.go`: Added self-sling detection at the end of `resolveTarget` — sets `result.IsSelfSling = true` when the resolved pane matches `TMUX_PANE`.
- `internal/cmd/sling_test.go`: Added `TestResolveTargetSelfSlingByPane` covering same-pane (self-sling), different-pane (not self-sling), and empty-pane (not self-sling) cases.

## Testing

- [x] `go build ./...` passes
- [x] `TestResolveTargetSelfSlingByPane` (3 subtests) passes
- [x] `go vet ./...` passes

Closes #3839