### PR TITLE
fix(convoy): route cross-rig tracked beads via Beads.Show (GH#3681)

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -2442,69 +2442,6 @@ type issueDependency struct {
 	DependencyType string `json:"dependency_type"`
 }
 
-type issueDetailsJSON struct {
-	ID             string            `json:"id"`
-	Title          string            `json:"title"`
-	Status         string            `json:"status"`
-	IssueType      string            `json:"issue_type"`
-	Assignee       string            `json:"assignee"`
-	Labels         []string          `json:"labels"`
-	BlockedBy      []string          `json:"blocked_by"`
-	BlockedByCount int               `json:"blocked_by_count"`
-	Dependencies   []issueDependency `json:"dependencies"`
-}
-
-func (issue issueDetailsJSON) toIssueDetails() *issueDetails {
-	return &issueDetails{
-		ID:             issue.ID,
-		Title:          issue.Title,
-		Status:         issue.Status,
-		IssueType:      issue.IssueType,
-		Assignee:       issue.Assignee,
-		Labels:         issue.Labels,
-		BlockedBy:      issue.BlockedBy,
-		BlockedByCount: issue.BlockedByCount,
-		Dependencies:   issue.Dependencies,
-	}
-}
-
-// getExternalIssueDetails fetches issue details from an external rig database.
-// townBeads: path to town .beads directory
-// rigName: name of the rig (e.g., "claycantrell")
-// issueID: the issue ID to look up
-func getExternalIssueDetails(townBeads, rigName, issueID string) *issueDetails {
-	// Resolve rig directory path: townBeads is the town root
-	rigDir := filepath.Join(townBeads, rigName)
-
-	// Check if rig directory exists
-	if _, err := os.Stat(rigDir); os.IsNotExist(err) {
-		return nil
-	}
-
-	// Query the rig database by running bd show from the rig directory
-	showArgs := beads.MaybePrependAllowStale([]string{"show", issueID, "--json"})
-	showCmd := exec.Command("bd", showArgs...)
-	showCmd.Dir = rigDir // Set working directory to rig directory
-	var stdout bytes.Buffer
-	showCmd.Stdout = &stdout
-
-	if err := showCmd.Run(); err != nil {
-		return nil
-	}
-	if stdout.Len() == 0 {
-		return nil
-	}
-
-	var issues []issueDetailsJSON
-	if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil {
-		return nil
-	}
-	if len(issues) == 0 {
-		return nil
-	}
-
-	return issues[0].toIssueDetails()
-}
 
 // issueDetails holds basic issue info.
 type issueDetails struct {
@@ -2534,82 +2471,64 @@ func (d issueDetails) IsBlocked() bool {
 	return false
 }
 
-// getIssueDetailsBatch fetches details for multiple issues in a single bd show call.
+// issueToDetails converts a beads.Issue to the local issueDetails type.
+func issueToDetails(issue *beads.Issue) *issueDetails {
+	deps := make([]issueDependency, 0, len(issue.Dependencies))
+	for _, d := range issue.Dependencies {
+		deps = append(deps, issueDependency{
+			ID:             d.ID,
+			Status:         d.Status,
+			DependencyType: d.DependencyType,
+		})
+	}
+	return &issueDetails{
+		ID:             issue.ID,
+		Title:          issue.Title,
+		Status:         issue.Status,
+		IssueType:      issue.Type,
+		Assignee:       issue.Assignee,
+		Labels:         issue.Labels,
+		BlockedBy:      issue.BlockedBy,
+		BlockedByCount: issue.BlockedByCount,
+		Dependencies:   deps,
+	}
+}
+
+// getIssueDetailsBatch fetches details for multiple issues.
 // Returns a map from issue ID to details. Missing/invalid issues are omitted from the map.
+// Uses Beads.Show which routes cross-rig lookups via routes.jsonl regardless of cwd.
 func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 	result := make(map[string]*issueDetails)
 	if len(issueIDs) == 0 {
 		return result
 	}
 
-	// Build args: bd show id1 id2 id3 ... --json
-	args := append([]string{"show"}, issueIDs...)
-	args = append(args, "--json")
-
-	// Run from town root so bd's prefix routing (routes.jsonl) can dispatch
-	// to the correct rig database for cross-rig bead lookups. (GH#2960)
+	// Use the Go-side Beads.Show which calls ResolveRoutingTarget internally.
+	// This correctly dispatches cross-rig beads to the right rig database even
+	// when cwd=townRoot and townRoot has a local .beads/ (which caused bd's own
+	// prefix routing to be ignored). See GH#3681.
 	townRoot, _ := workspace.FindFromCwdOrError()
-	showCmd := exec.Command("bd", args...)
-	if townRoot != "" {
-		showCmd.Dir = townRoot
-		showCmd.Env = stripEnvKey(os.Environ(), "BEADS_DIR")
-	}
-	var stdout bytes.Buffer
-	showCmd.Stdout = &stdout
-
-	if err := showCmd.Run(); err != nil {
-		// Batch failed - fall back to individual lookups for robustness
-		// This handles cases where some IDs are invalid/missing
-		for _, id := range issueIDs {
-			if details := getIssueDetails(id); details != nil {
-				result[id] = details
-			}
+	b := beads.New(townRoot)
+	for _, id := range issueIDs {
+		issue, err := b.Show(id)
+		if err != nil || issue == nil {
+			continue
 		}
-		return result
+		result[id] = issueToDetails(issue)
 	}
-
-	var issues []issueDetailsJSON
-	if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil {
-		return result
-	}
-
-	for _, issue := range issues {
-		result[issue.ID] = issue.toIssueDetails()
-	}
-
 	return result
 }
 
-// getIssueDetails fetches issue details by trying to show it via bd.
-// Prefer getIssueDetailsBatch for multiple issues to avoid N+1 subprocess calls.
+// getIssueDetails fetches details for a single issue.
+// Uses Beads.Show which routes cross-rig lookups via routes.jsonl regardless of cwd.
+// Prefer getIssueDetailsBatch when fetching multiple issues.
 func getIssueDetails(issueID string) *issueDetails {
-	// Use bd show with routing - resolve from town root so bd's prefix
-	// routing (routes.jsonl) can dispatch to the correct rig database.
-	// Without Dir + StripBeadsDir, bd inherits CWD/BEADS_DIR which may
-	// point to a rig that doesn't contain the target bead. (GH#2960)
 	townRoot, _ := workspace.FindFromCwdOrError()
-	showCmd := exec.Command("bd", "show", issueID, "--json")
-	if townRoot != "" {
-		showCmd.Dir = townRoot
-		showCmd.Env = stripEnvKey(os.Environ(), "BEADS_DIR")
-	}
-	var stdout bytes.Buffer
-	showCmd.Stdout = &stdout
-
-	if err := showCmd.Run(); err != nil {
+	issue, err := beads.New(townRoot).Show(issueID)
+	if err != nil || issue == nil {
 		return nil
 	}
-	// Handle bd exit 0 bug: empty stdout means not found
-	if stdout.Len() == 0 {
-		return nil
-	}
-
-	var issues []issueDetailsJSON
-	if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil || len(issues) == 0 {
-		return nil
-	}
-
-	return issues[0].toIssueDetails()
+	return issueToDetails(issue)
 }
 
 // workerInfo holds info about a worker assigned to an issue.

--- a/internal/cmd/convoy_external_tracking_test.go
+++ b/internal/cmd/convoy_external_tracking_test.go
@@ -76,13 +76,10 @@ case "$*" in
   "show hq-cv-ext --json")
     echo '[{"id":"hq-cv-ext","title":"External convoy","status":"open","issue_type":"convoy","dependencies":[{"id":"external:ghostty:ghostty-123","title":"Ghost 123","status":"open","type":"task","dependency_type":"tracks"},{"id":"external:ghostty:ghostty-456","title":"Ghost 456","status":"closed","type":"task","dependency_type":"tracks"},{"id":"gt-ignore","title":"Ignore me","status":"open","type":"task","dependency_type":"blocks"}]}]'
     ;;
-  "show ghostty-123 ghostty-456 --json"|"show ghostty-456 ghostty-123 --json")
-    echo '[{"id":"ghostty-123","title":"Ghost 123","status":"open","issue_type":"task"},{"id":"ghostty-456","title":"Ghost 456","status":"closed","issue_type":"task"}]'
-    ;;
-  "show ghostty-123 --json")
+  "--allow-stale show ghostty-123 --json")
     echo '[{"id":"ghostty-123","title":"Ghost 123","status":"open","issue_type":"task"}]'
     ;;
-  "show ghostty-456 --json")
+  "--allow-stale show ghostty-456 --json")
     echo '[{"id":"ghostty-456","title":"Ghost 456","status":"closed","issue_type":"task"}]'
     ;;
   *)
@@ -197,5 +194,62 @@ func TestCloseConvoyIfComplete_UnknownBlocksAutoClose(t *testing.T) {
 	}
 	if !strings.Contains(out, "unknown") {
 		t.Fatalf("diagnostic missing 'unknown' label: %q", out)
+	}
+}
+
+// TestGetIssueDetailsBatch_CrossRigRouting is the regression test for GH#3681.
+//
+// When townRoot has a local .beads/, the old exec.Command("bd", ...) ran from
+// townRoot and bd bound to the town's .beads/, ignoring routes.jsonl. The new
+// Beads.Show path calls ResolveRoutingTarget internally, which reads routes.jsonl
+// and dispatches to the correct rig database regardless of cwd.
+func TestGetIssueDetailsBatch_CrossRigRouting(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	townRoot, townBeads, _ := makeExternalTrackingTownWorkspace(t)
+
+	// routes.jsonl routes "gm-" beads to a gemba rig subdirectory.
+	routes := `{"prefix":"gm-","path":"gemba"}` + "\n"
+	if err := os.WriteFile(filepath.Join(townBeads, "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "gemba", ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir gemba/.beads: %v", err)
+	}
+
+	// cwd = townRoot, which also has .beads/ — the problematic layout from GH#3681.
+	chdirExternalTrackingTest(t, townRoot)
+
+	// The stub only responds to the routed form. Old code called
+	// "bd show gm-abc --json" (no --allow-stale) from townRoot, which the
+	// stub does not handle → exits 1 → result is empty. New code routes via
+	// Beads.Show and calls "--allow-stale show gm-abc --json" from the rig dir.
+	scriptBody := `
+case "$*" in
+  "--allow-stale version")
+    exit 0
+    ;;
+  "--allow-stale show gm-abc --json")
+    echo '[{"id":"gm-abc","title":"Gemba task","status":"closed","issue_type":"task"}]'
+    ;;
+  *)
+    echo "unexpected bd args: $*" >&2
+    exit 1
+    ;;
+esac
+`
+	writeExternalTrackingBdStub(t, scriptBody)
+
+	result := getIssueDetailsBatch([]string{"gm-abc"})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d: %#v", len(result), result)
+	}
+	if result["gm-abc"] == nil {
+		t.Fatal("gm-abc missing from result")
+	}
+	if result["gm-abc"].Status != "closed" {
+		t.Fatalf("expected status 'closed', got %q", result["gm-abc"].Status)
 	}
 }


### PR DESCRIPTION
## Summary

- Replace `exec.Command("bd", "show", ...)` in `getIssueDetailsBatch` and `getIssueDetails` with `beads.New(townRoot).Show(id)`, which calls `ResolveRoutingTarget` internally and dispatches to the correct rig database regardless of cwd.
- Remove dead code: `issueDetailsJSON`, its `toIssueDetails()` method, and the never-called `getExternalIssueDetails` function.
- Add `TestGetIssueDetailsBatch_CrossRigRouting` as a regression test: the stub only responds to the routed call form, so old code (which called `bd show` from townRoot without routing) would return empty and fail.

## Root cause

`getIssueDetailsBatch` shelled out to `bd show <ids> --json` with `Dir=townRoot`. When townRoot has a local `.beads/` (the default gastown layout), `bd` binds to that workspace and ignores `routes.jsonl` for cross-rig dispatch. Cross-rig tracked beads always returned empty, so convoy auto-close treated them as open and convoys never closed.

The fix uses `gt`'s own `Beads.Show()` wrapper, which already handles cross-rig routing correctly via `ResolveRoutingTarget`. This is the approach recommended in the issue as option (a).

## Changes

- `internal/cmd/convoy.go`: Remove `exec.Command` shell-out paths; add `issueToDetails` converter; rewrite `getIssueDetailsBatch` and `getIssueDetails` to use `beads.New(townRoot).Show(id)`.
- `internal/cmd/convoy_external_tracking_test.go`: Update existing stub to match new `--allow-stale show <id>` per-call form; add `TestGetIssueDetailsBatch_CrossRigRouting` regression test.

## Testing

- [x] `go build ./...` passes
- [x] `TestGetIssueDetailsBatch_CrossRigRouting` passes (the regression test)
- [x] `go vet ./...` passes

Closes #3681