### PR TITLE
fix: add startup fallback for promptless runtimes in mayor, deacon, boot

### DIFF
--- a/internal/boot/boot.go
+++ b/internal/boot/boot.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/gofrs/flock"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/util"
@@ -179,8 +181,9 @@ func (b *Boot) spawnTmux(agentOverride string) error {
 	}
 
 	// Use unified session lifecycle for config → settings → command → create → env.
-	_, err := session.StartSession(b.tmux, session.SessionConfig{
-		SessionID: session.BootSessionName(),
+	bootSessionID := session.BootSessionName()
+	result, err := session.StartSession(b.tmux, session.SessionConfig{
+		SessionID: bootSessionID,
 		WorkDir:   b.bootDir,
 		Role:      "boot",
 		TownRoot:  b.townRoot,
@@ -192,7 +195,22 @@ func (b *Boot) spawnTmux(agentOverride string) error {
 		Instructions:  "Run `" + cli.Name() + " boot triage` now.",
 		AgentOverride: agentOverride,
 	})
-	return err
+	if err != nil {
+		return err
+	}
+
+	// Startup fallback for promptless runtimes (prompt_mode: none).
+	// BuildCommandWithPrompt drops the prompt text for these runtimes, so boot
+	// never receives its triage instruction via the CLI argument.
+	_ = runtime.RunStartupFallback(b.tmux, bootSessionID, "boot", result.RuntimeConfig)
+	bootPrompt := session.BuildStartupPrompt(session.BeaconConfig{
+		Recipient: "boot",
+		Sender:    "daemon",
+		Topic:     "triage",
+	}, "Run `"+cli.Name()+" boot triage` now.")
+	_ = runtime.DeliverStartupPromptFallback(b.tmux, bootSessionID, bootPrompt, result.RuntimeConfig, constants.ClaudeStartTimeout)
+
+	return nil
 }
 
 // spawnDegraded spawns Boot in degraded mode (no tmux).

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -2442,69 +2442,6 @@ type issueDependency struct {
 	DependencyType string `json:"dependency_type"`
 }
 
-type issueDetailsJSON struct {
-	ID             string            `json:"id"`
-	Title          string            `json:"title"`
-	Status         string            `json:"status"`
-	IssueType      string            `json:"issue_type"`
-	Assignee       string            `json:"assignee"`
-	Labels         []string          `json:"labels"`
-	BlockedBy      []string          `json:"blocked_by"`
-	BlockedByCount int               `json:"blocked_by_count"`
-	Dependencies   []issueDependency `json:"dependencies"`
-}
-
-func (issue issueDetailsJSON) toIssueDetails() *issueDetails {
-	return &issueDetails{
-		ID:             issue.ID,
-		Title:          issue.Title,
-		Status:         issue.Status,
-		IssueType:      issue.IssueType,
-		Assignee:       issue.Assignee,
-		Labels:         issue.Labels,
-		BlockedBy:      issue.BlockedBy,
-		BlockedByCount: issue.BlockedByCount,
-		Dependencies:   issue.Dependencies,
-	}
-}
-
-// getExternalIssueDetails fetches issue details from an external rig database.
-// townBeads: path to town .beads directory
-// rigName: name of the rig (e.g., "claycantrell")
-// issueID: the issue ID to look up
-func getExternalIssueDetails(townBeads, rigName, issueID string) *issueDetails {
-	// Resolve rig directory path: townBeads is the town root
-	rigDir := filepath.Join(townBeads, rigName)
-
-	// Check if rig directory exists
-	if _, err := os.Stat(rigDir); os.IsNotExist(err) {
-		return nil
-	}
-
-	// Query the rig database by running bd show from the rig directory
-	showArgs := beads.MaybePrependAllowStale([]string{"show", issueID, "--json"})
-	showCmd := exec.Command("bd", showArgs...)
-	showCmd.Dir = rigDir // Set working directory to rig directory
-	var stdout bytes.Buffer
-	showCmd.Stdout = &stdout
-
-	if err := showCmd.Run(); err != nil {
-		return nil
-	}
-	if stdout.Len() == 0 {
-		return nil
-	}
-
-	var issues []issueDetailsJSON
-	if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil {
-		return nil
-	}
-	if len(issues) == 0 {
-		return nil
-	}
-
-	return issues[0].toIssueDetails()
-}
 
 // issueDetails holds basic issue info.
 type issueDetails struct {
@@ -2534,82 +2471,64 @@ func (d issueDetails) IsBlocked() bool {
 	return false
 }
 
-// getIssueDetailsBatch fetches details for multiple issues in a single bd show call.
+// issueToDetails converts a beads.Issue to the local issueDetails type.
+func issueToDetails(issue *beads.Issue) *issueDetails {
+	deps := make([]issueDependency, 0, len(issue.Dependencies))
+	for _, d := range issue.Dependencies {
+		deps = append(deps, issueDependency{
+			ID:             d.ID,
+			Status:         d.Status,
+			DependencyType: d.DependencyType,
+		})
+	}
+	return &issueDetails{
+		ID:             issue.ID,
+		Title:          issue.Title,
+		Status:         issue.Status,
+		IssueType:      issue.Type,
+		Assignee:       issue.Assignee,
+		Labels:         issue.Labels,
+		BlockedBy:      issue.BlockedBy,
+		BlockedByCount: issue.BlockedByCount,
+		Dependencies:   deps,
+	}
+}
+
+// getIssueDetailsBatch fetches details for multiple issues.
 // Returns a map from issue ID to details. Missing/invalid issues are omitted from the map.
+// Uses Beads.Show which routes cross-rig lookups via routes.jsonl regardless of cwd.
 func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 	result := make(map[string]*issueDetails)
 	if len(issueIDs) == 0 {
 		return result
 	}
 
-	// Build args: bd show id1 id2 id3 ... --json
-	args := append([]string{"show"}, issueIDs...)
-	args = append(args, "--json")
-
-	// Run from town root so bd's prefix routing (routes.jsonl) can dispatch
-	// to the correct rig database for cross-rig bead lookups. (GH#2960)
+	// Use the Go-side Beads.Show which calls ResolveRoutingTarget internally.
+	// This correctly dispatches cross-rig beads to the right rig database even
+	// when cwd=townRoot and townRoot has a local .beads/ (which caused bd's own
+	// prefix routing to be ignored). See GH#3681.
 	townRoot, _ := workspace.FindFromCwdOrError()
-	showCmd := exec.Command("bd", args...)
-	if townRoot != "" {
-		showCmd.Dir = townRoot
-		showCmd.Env = stripEnvKey(os.Environ(), "BEADS_DIR")
-	}
-	var stdout bytes.Buffer
-	showCmd.Stdout = &stdout
-
-	if err := showCmd.Run(); err != nil {
-		// Batch failed - fall back to individual lookups for robustness
-		// This handles cases where some IDs are invalid/missing
-		for _, id := range issueIDs {
-			if details := getIssueDetails(id); details != nil {
-				result[id] = details
-			}
+	b := beads.New(townRoot)
+	for _, id := range issueIDs {
+		issue, err := b.Show(id)
+		if err != nil || issue == nil {
+			continue
 		}
-		return result
+		result[id] = issueToDetails(issue)
 	}
-
-	var issues []issueDetailsJSON
-	if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil {
-		return result
-	}
-
-	for _, issue := range issues {
-		result[issue.ID] = issue.toIssueDetails()
-	}
-
 	return result
 }
 
-// getIssueDetails fetches issue details by trying to show it via bd.
-// Prefer getIssueDetailsBatch for multiple issues to avoid N+1 subprocess calls.
+// getIssueDetails fetches details for a single issue.
+// Uses Beads.Show which routes cross-rig lookups via routes.jsonl regardless of cwd.
+// Prefer getIssueDetailsBatch when fetching multiple issues.
 func getIssueDetails(issueID string) *issueDetails {
-	// Use bd show with routing - resolve from town root so bd's prefix
-	// routing (routes.jsonl) can dispatch to the correct rig database.
-	// Without Dir + StripBeadsDir, bd inherits CWD/BEADS_DIR which may
-	// point to a rig that doesn't contain the target bead. (GH#2960)
 	townRoot, _ := workspace.FindFromCwdOrError()
-	showCmd := exec.Command("bd", "show", issueID, "--json")
-	if townRoot != "" {
-		showCmd.Dir = townRoot
-		showCmd.Env = stripEnvKey(os.Environ(), "BEADS_DIR")
-	}
-	var stdout bytes.Buffer
-	showCmd.Stdout = &stdout
-
-	if err := showCmd.Run(); err != nil {
+	issue, err := beads.New(townRoot).Show(issueID)
+	if err != nil || issue == nil {
 		return nil
 	}
-	// Handle bd exit 0 bug: empty stdout means not found
-	if stdout.Len() == 0 {
-		return nil
-	}
-
-	var issues []issueDetailsJSON
-	if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil || len(issues) == 0 {
-		return nil
-	}
-
-	return issues[0].toIssueDetails()
+	return issueToDetails(issue)
 }
 
 // workerInfo holds info about a worker assigned to an issue.

--- a/internal/cmd/convoy_external_tracking_test.go
+++ b/internal/cmd/convoy_external_tracking_test.go
@@ -76,13 +76,10 @@ case "$*" in
   "show hq-cv-ext --json")
     echo '[{"id":"hq-cv-ext","title":"External convoy","status":"open","issue_type":"convoy","dependencies":[{"id":"external:ghostty:ghostty-123","title":"Ghost 123","status":"open","type":"task","dependency_type":"tracks"},{"id":"external:ghostty:ghostty-456","title":"Ghost 456","status":"closed","type":"task","dependency_type":"tracks"},{"id":"gt-ignore","title":"Ignore me","status":"open","type":"task","dependency_type":"blocks"}]}]'
     ;;
-  "show ghostty-123 ghostty-456 --json"|"show ghostty-456 ghostty-123 --json")
-    echo '[{"id":"ghostty-123","title":"Ghost 123","status":"open","issue_type":"task"},{"id":"ghostty-456","title":"Ghost 456","status":"closed","issue_type":"task"}]'
-    ;;
-  "show ghostty-123 --json")
+  "--allow-stale show ghostty-123 --json")
     echo '[{"id":"ghostty-123","title":"Ghost 123","status":"open","issue_type":"task"}]'
     ;;
-  "show ghostty-456 --json")
+  "--allow-stale show ghostty-456 --json")
     echo '[{"id":"ghostty-456","title":"Ghost 456","status":"closed","issue_type":"task"}]'
     ;;
   *)
@@ -197,5 +194,62 @@ func TestCloseConvoyIfComplete_UnknownBlocksAutoClose(t *testing.T) {
 	}
 	if !strings.Contains(out, "unknown") {
 		t.Fatalf("diagnostic missing 'unknown' label: %q", out)
+	}
+}
+
+// TestGetIssueDetailsBatch_CrossRigRouting is the regression test for GH#3681.
+//
+// When townRoot has a local .beads/, the old exec.Command("bd", ...) ran from
+// townRoot and bd bound to the town's .beads/, ignoring routes.jsonl. The new
+// Beads.Show path calls ResolveRoutingTarget internally, which reads routes.jsonl
+// and dispatches to the correct rig database regardless of cwd.
+func TestGetIssueDetailsBatch_CrossRigRouting(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	townRoot, townBeads, _ := makeExternalTrackingTownWorkspace(t)
+
+	// routes.jsonl routes "gm-" beads to a gemba rig subdirectory.
+	routes := `{"prefix":"gm-","path":"gemba"}` + "\n"
+	if err := os.WriteFile(filepath.Join(townBeads, "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "gemba", ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir gemba/.beads: %v", err)
+	}
+
+	// cwd = townRoot, which also has .beads/ — the problematic layout from GH#3681.
+	chdirExternalTrackingTest(t, townRoot)
+
+	// The stub only responds to the routed form. Old code called
+	// "bd show gm-abc --json" (no --allow-stale) from townRoot, which the
+	// stub does not handle → exits 1 → result is empty. New code routes via
+	// Beads.Show and calls "--allow-stale show gm-abc --json" from the rig dir.
+	scriptBody := `
+case "$*" in
+  "--allow-stale version")
+    exit 0
+    ;;
+  "--allow-stale show gm-abc --json")
+    echo '[{"id":"gm-abc","title":"Gemba task","status":"closed","issue_type":"task"}]'
+    ;;
+  *)
+    echo "unexpected bd args: $*" >&2
+    exit 1
+    ;;
+esac
+`
+	writeExternalTrackingBdStub(t, scriptBody)
+
+	result := getIssueDetailsBatch([]string{"gm-abc"})
+	if len(result) != 1 {
+		t.Fatalf("expected 1 result, got %d: %#v", len(result), result)
+	}
+	if result["gm-abc"] == nil {
+		t.Fatal("gm-abc missing from result")
+	}
+	if result["gm-abc"].Status != "closed" {
+		t.Fatalf("expected status 'closed', got %q", result["gm-abc"].Status)
 	}
 }

--- a/internal/cmd/fanout.go
+++ b/internal/cmd/fanout.go
@@ -99,6 +99,11 @@ func runFanout(_ *cobra.Command, _ []string) error {
 	// Resolve the rig's beads directory, pinning all writes to it.
 	// This prevents ambient database discovery when running from arbitrary cwd.
 	rigDir := filepath.Join(townRoot, fanoutRig)
+	// Guard against path traversal: --rig "../other" would escape townRoot.
+	cleanTown := filepath.Clean(townRoot)
+	if !strings.HasPrefix(filepath.Clean(rigDir), cleanTown+string(os.PathSeparator)) {
+		return fmt.Errorf("rig %q escapes town root %s", fanoutRig, townRoot)
+	}
 	if info, err := os.Stat(rigDir); err != nil || !info.IsDir() {
 		return fmt.Errorf("rig %q not found at %s", fanoutRig, rigDir)
 	}
@@ -201,6 +206,8 @@ func runFanout(_ *cobra.Command, _ []string) error {
 		created = append(created, beadID)
 
 		// Persist to state file before sleeping so partial runs are recoverable.
+		// Also update done map to skip duplicate titles later in the same run.
+		done[title] = beadID
 		entry := fanoutStateEntry{
 			Title:     title,
 			BeadID:    beadID,

--- a/internal/cmd/fanout.go
+++ b/internal/cmd/fanout.go
@@ -165,7 +165,8 @@ func runFanout(_ *cobra.Command, _ []string) error {
 		err   string
 	}
 	var created []string
-	var failures []fanoutFailure
+	var failures []fanoutFailure   // bead creation failures (retryable via state file)
+	var depWarnings []fanoutFailure // dep-link failures (bead created; fix manually)
 	skipped := 0
 
 	for i, title := range titles {
@@ -184,12 +185,15 @@ func runFanout(_ *cobra.Command, _ []string) error {
 			continue
 		}
 
-		// Link to parent if specified.
+		// Link to parent if specified. Dep failure is a warning — the bead exists
+		// and is persisted, so retrying won't help. User must fix the link manually.
 		if fanoutParent != "" {
 			if depErr := fanoutAddParentDep(fanoutParent, beadID, rigBeadsDir); depErr != nil {
-				// Dep failure is reported but doesn't block; the bead still exists.
 				fmt.Printf("         %s dep link failed: %v\n", style.Warning.Render("⚠"), depErr)
-				failures = append(failures, fanoutFailure{title: title, err: fmt.Sprintf("created as %s but dep link failed: %v", beadID, depErr)})
+				depWarnings = append(depWarnings, fanoutFailure{
+					title: title,
+					err:   fmt.Sprintf("%s created but dep link failed: %v", beadID, depErr),
+				})
 			}
 		}
 
@@ -219,6 +223,13 @@ func runFanout(_ *cobra.Command, _ []string) error {
 
 	if len(created) > 0 {
 		fmt.Printf("  Created: %s\n", strings.Join(created, " "))
+	}
+	if len(depWarnings) > 0 {
+		fmt.Printf("\n%s Dep-link warnings — beads created but parent links missing (fix with 'bd dep add'):\n",
+			style.Warning.Render("⚠"))
+		for _, w := range depWarnings {
+			fmt.Printf("  ⚠ %q: %s\n", w.title, w.err)
+		}
 	}
 	if len(failures) > 0 {
 		fmt.Printf("\n%s Partial failures — retry with the same --state-file to skip successful beads:\n",

--- a/internal/cmd/fanout.go
+++ b/internal/cmd/fanout.go
@@ -1,0 +1,325 @@
+package cmd
+
+import (
+	"bufio"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/style"
+	"github.com/steveyegge/gastown/internal/workspace"
+)
+
+var fanoutCmd = &cobra.Command{
+	Use:     "fanout --rig <rig> [--parent <bead-id>]",
+	GroupID: GroupWork,
+	Short:   "Throttled bulk bead creation pinned to a target rig",
+	Long: `Create many beads in a target rig's database without ambient database discovery.
+
+Reads bead titles from stdin (one per line). Blank lines and lines starting
+with '#' are skipped. Each title becomes a new bead created serially in the
+specified rig's database with a configurable delay between writes.
+
+This command is designed for mayor orchestration workflows that need to convert
+large GitHub issue triage sets into rig-owned tracking beads without triggering
+Dolt instability from parallel writes or ambient database discovery.
+
+Key properties:
+  - All writes are pinned to --rig's database (no ambient discovery)
+  - Serial writes with configurable rate limiting (--rate)
+  - Idempotent: re-running with the same --state-file skips already-created beads
+  - Partial failures are reported with enough detail to retry safely
+
+Examples:
+  # Create tasks for a rig epic (reads titles from stdin)
+  echo -e "Fix auth bug\nAdd login rate limit\nAudit token storage" \
+    | gt fanout --rig gastown --parent gt-epic123
+
+  # Create from a file with throttling
+  cat issue-titles.txt | gt fanout --rig gastown --rate 1s
+
+  # Dry run to preview without creating
+  cat titles.txt | gt fanout --rig gastown --parent gt-epic123 --dry-run
+
+  # Resume after interruption using existing state file
+  cat titles.txt | gt fanout --rig gastown --parent gt-epic123 \
+    --state-file /tmp/fanout-epic123.jsonl
+
+Input format (stdin):
+  Fix the auth token refresh bug
+  Add rate limiting to the login endpoint
+  # This comment line is skipped
+  Audit session token storage for compliance`,
+	RunE: runFanout,
+}
+
+var (
+	fanoutRig       string
+	fanoutParent    string
+	fanoutType      string
+	fanoutPriority  string
+	fanoutLabels    []string
+	fanoutRate      time.Duration
+	fanoutStateFile string
+	fanoutDryRun    bool
+)
+
+func init() {
+	fanoutCmd.Flags().StringVar(&fanoutRig, "rig", "", "Target rig (required); pins all writes to this rig's database")
+	fanoutCmd.Flags().StringVar(&fanoutParent, "parent", "", "Parent epic bead ID; each created bead is linked as a child")
+	fanoutCmd.Flags().StringVarP(&fanoutType, "type", "t", "task", "Bead type for created beads")
+	fanoutCmd.Flags().StringVarP(&fanoutPriority, "priority", "p", "2", "Priority 0-4 for created beads")
+	fanoutCmd.Flags().StringArrayVarP(&fanoutLabels, "label", "l", nil, "Label to add to each bead (repeatable)")
+	fanoutCmd.Flags().DurationVar(&fanoutRate, "rate", 500*time.Millisecond, "Delay between writes to throttle Dolt load (0 to disable)")
+	fanoutCmd.Flags().StringVar(&fanoutStateFile, "state-file", "", "JSONL file tracking progress; created automatically if not specified")
+	fanoutCmd.Flags().BoolVarP(&fanoutDryRun, "dry-run", "n", false, "Preview what would be created without writing")
+
+	_ = fanoutCmd.MarkFlagRequired("rig")
+	rootCmd.AddCommand(fanoutCmd)
+}
+
+// fanoutStateEntry records one successfully created bead for idempotent re-runs.
+type fanoutStateEntry struct {
+	Title     string `json:"title"`
+	BeadID    string `json:"bead_id"`
+	CreatedAt string `json:"created_at"`
+}
+
+func runFanout(_ *cobra.Command, _ []string) error {
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("finding town root: %w", err)
+	}
+
+	// Resolve the rig's beads directory, pinning all writes to it.
+	// This prevents ambient database discovery when running from arbitrary cwd.
+	rigDir := filepath.Join(townRoot, fanoutRig)
+	if info, err := os.Stat(rigDir); err != nil || !info.IsDir() {
+		return fmt.Errorf("rig %q not found at %s", fanoutRig, rigDir)
+	}
+	rigBeadsDir := beads.ResolveBeadsDir(rigDir)
+
+	// Read titles from stdin.
+	titles, err := readFanoutTitles()
+	if err != nil {
+		return err
+	}
+	if len(titles) == 0 {
+		return fmt.Errorf("no titles provided on stdin (one per line)")
+	}
+
+	// Load existing state for idempotency.
+	stateFile := fanoutStateFile
+	if stateFile == "" {
+		key := fanoutRig
+		if fanoutParent != "" {
+			key = fanoutParent
+		}
+		stateFile = filepath.Join(os.TempDir(), fmt.Sprintf("gt-fanout-%s.jsonl", sanitizeFilename(key)))
+	}
+	done, err := loadFanoutState(stateFile)
+	if err != nil {
+		return fmt.Errorf("loading state file %s: %w", stateFile, err)
+	}
+
+	if fanoutDryRun {
+		fmt.Printf("%s Dry run — would create %d beads in rig %q\n", style.Bold.Render("🔍"), len(titles), fanoutRig)
+		if fanoutParent != "" {
+			fmt.Printf("  Parent: %s\n", fanoutParent)
+		}
+		fmt.Printf("  Rate: %s between writes\n", fanoutRate)
+		fmt.Printf("  State file: %s\n", stateFile)
+		fmt.Printf("\n")
+		for i, title := range titles {
+			if beadID, ok := done[title]; ok {
+				fmt.Printf("  [%d/%d] SKIP (already created as %s): %s\n", i+1, len(titles), beadID, title)
+			} else {
+				fmt.Printf("  [%d/%d] CREATE: %s\n", i+1, len(titles), title)
+			}
+		}
+		return nil
+	}
+
+	// State file writer (append-only for resume safety).
+	sf, err := os.OpenFile(stateFile, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0644)
+	if err != nil {
+		return fmt.Errorf("opening state file %s: %w", stateFile, err)
+	}
+	defer sf.Close()
+
+	fmt.Printf("%s Creating %d beads in rig %q\n", style.Bold.Render("📋"), len(titles), fanoutRig)
+	if fanoutParent != "" {
+		fmt.Printf("  Parent: %s\n", fanoutParent)
+	}
+	fmt.Printf("  Rate: %s between writes\n", fanoutRate)
+	fmt.Printf("  State: %s\n", stateFile)
+	fmt.Printf("\n")
+
+	type fanoutFailure struct {
+		title string
+		err   string
+	}
+	var created []string
+	var failures []fanoutFailure
+	skipped := 0
+
+	for i, title := range titles {
+		if beadID, ok := done[title]; ok {
+			fmt.Printf("  [%d/%d] %s %s → %s\n", i+1, len(titles), style.Dim.Render("SKIP"), title, beadID)
+			skipped++
+			continue
+		}
+
+		fmt.Printf("  [%d/%d] Creating: %s\n", i+1, len(titles), title)
+
+		beadID, createErr := fanoutCreateBead(title, rigBeadsDir)
+		if createErr != nil {
+			fmt.Printf("         %s %v\n", style.Error.Render("✗"), createErr)
+			failures = append(failures, fanoutFailure{title: title, err: createErr.Error()})
+			continue
+		}
+
+		// Link to parent if specified.
+		if fanoutParent != "" {
+			if depErr := fanoutAddParentDep(fanoutParent, beadID, rigBeadsDir); depErr != nil {
+				// Dep failure is reported but doesn't block; the bead still exists.
+				fmt.Printf("         %s dep link failed: %v\n", style.Warning.Render("⚠"), depErr)
+				failures = append(failures, fanoutFailure{title: title, err: fmt.Sprintf("created as %s but dep link failed: %v", beadID, depErr)})
+			}
+		}
+
+		fmt.Printf("         %s %s\n", style.Success.Render("✓"), beadID)
+		created = append(created, beadID)
+
+		// Persist to state file before sleeping so partial runs are recoverable.
+		entry := fanoutStateEntry{
+			Title:     title,
+			BeadID:    beadID,
+			CreatedAt: time.Now().UTC().Format(time.RFC3339),
+		}
+		if data, err := json.Marshal(entry); err == nil {
+			_, _ = fmt.Fprintf(sf, "%s\n", data)
+			_ = sf.Sync()
+		}
+
+		// Throttle: delay before next write to avoid Dolt lock contention.
+		if fanoutRate > 0 && i < len(titles)-1 {
+			time.Sleep(fanoutRate)
+		}
+	}
+
+	// Summary.
+	fmt.Printf("\n%s Fanout complete: %d created, %d skipped, %d failed\n",
+		style.Bold.Render("📊"), len(created), skipped, len(failures))
+
+	if len(created) > 0 {
+		fmt.Printf("  Created: %s\n", strings.Join(created, " "))
+	}
+	if len(failures) > 0 {
+		fmt.Printf("\n%s Partial failures — retry with the same --state-file to skip successful beads:\n",
+			style.Warning.Render("⚠"))
+		for _, f := range failures {
+			fmt.Printf("  ✗ %q: %s\n", f.title, f.err)
+		}
+		return fmt.Errorf("%d bead(s) failed to create", len(failures))
+	}
+
+	return nil
+}
+
+// readFanoutTitles reads bead titles from stdin, one per line.
+// Blank lines and comment lines (starting with '#') are skipped.
+func readFanoutTitles() ([]string, error) {
+	var titles []string
+	scanner := bufio.NewScanner(os.Stdin)
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		titles = append(titles, line)
+	}
+	return titles, scanner.Err()
+}
+
+// loadFanoutState reads an existing state file and returns a map of title → bead ID.
+// Returns an empty map if the file does not exist (fresh run).
+func loadFanoutState(path string) (map[string]string, error) {
+	done := make(map[string]string)
+	f, err := os.Open(path) //nolint:gosec // G304: user-controlled path, intentional
+	if os.IsNotExist(err) {
+		return done, nil
+	}
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	scanner := bufio.NewScanner(f)
+	for scanner.Scan() {
+		var entry fanoutStateEntry
+		if err := json.Unmarshal(scanner.Bytes(), &entry); err == nil && entry.Title != "" {
+			done[entry.Title] = entry.BeadID
+		}
+	}
+	return done, scanner.Err()
+}
+
+// fanoutCreateBead creates a single bead in the pinned rig database.
+// Returns the new bead ID on success.
+func fanoutCreateBead(title, rigBeadsDir string) (string, error) {
+	if beads.IsFlagLikeTitle(title) {
+		return "", fmt.Errorf("title %q looks like a CLI flag; skip or quote it", title)
+	}
+
+	args := []string{
+		"create",
+		"--title=" + title,
+		"--type=" + fanoutType,
+		"--priority=" + fanoutPriority,
+		"--silent",
+	}
+	for _, label := range fanoutLabels {
+		args = append(args, "--label="+label)
+	}
+
+	out, err := BdCmd(args...).
+		WithBeadsDir(rigBeadsDir).
+		WithAutoCommit().
+		Output()
+	if err != nil {
+		return "", fmt.Errorf("bd create: %w", err)
+	}
+
+	beadID := strings.TrimSpace(string(out))
+	if beadID == "" {
+		return "", fmt.Errorf("bd create returned empty ID for %q", title)
+	}
+	return beadID, nil
+}
+
+// fanoutAddParentDep links a child bead to its parent epic via a parent-child dep.
+func fanoutAddParentDep(parentID, childID, rigBeadsDir string) error {
+	return BdCmd("dep", "add", parentID, childID, "--type=parent-child").
+		WithBeadsDir(rigBeadsDir).
+		WithAutoCommit().
+		Run()
+}
+
+// sanitizeFilename makes a string safe for use in a filename.
+func sanitizeFilename(s string) string {
+	var b strings.Builder
+	for _, r := range s {
+		if (r >= 'a' && r <= 'z') || (r >= 'A' && r <= 'Z') || (r >= '0' && r <= '9') || r == '-' || r == '_' {
+			b.WriteRune(r)
+		} else {
+			b.WriteRune('-')
+		}
+	}
+	return b.String()
+}

--- a/internal/cmd/fanout_test.go
+++ b/internal/cmd/fanout_test.go
@@ -1,0 +1,490 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestReadFanoutTitles(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  []string
+	}{
+		{
+			name:  "simple titles",
+			input: "Fix auth bug\nAdd rate limit\nAudit storage\n",
+			want:  []string{"Fix auth bug", "Add rate limit", "Audit storage"},
+		},
+		{
+			name:  "skip blank lines",
+			input: "Title A\n\nTitle B\n\n",
+			want:  []string{"Title A", "Title B"},
+		},
+		{
+			name:  "skip comment lines",
+			input: "# This is a comment\nTitle A\n# Another comment\nTitle B\n",
+			want:  []string{"Title A", "Title B"},
+		},
+		{
+			name:  "trim whitespace",
+			input: "  Title A  \n  Title B  \n",
+			want:  []string{"Title A", "Title B"},
+		},
+		{
+			name:  "empty input",
+			input: "",
+			want:  nil,
+		},
+		{
+			name:  "only comments and blanks",
+			input: "# comment\n\n# another\n",
+			want:  nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Redirect stdin for the test.
+			r, w, err := os.Pipe()
+			if err != nil {
+				t.Fatal(err)
+			}
+			origStdin := os.Stdin
+			os.Stdin = r
+			t.Cleanup(func() { os.Stdin = origStdin })
+
+			_, _ = w.WriteString(tt.input)
+			w.Close()
+
+			got, err := readFanoutTitles()
+			if err != nil {
+				t.Fatalf("readFanoutTitles() error: %v", err)
+			}
+			if len(got) != len(tt.want) {
+				t.Fatalf("readFanoutTitles() = %v (len %d), want %v (len %d)", got, len(got), tt.want, len(tt.want))
+			}
+			for i := range got {
+				if got[i] != tt.want[i] {
+					t.Errorf("readFanoutTitles()[%d] = %q, want %q", i, got[i], tt.want[i])
+				}
+			}
+		})
+	}
+}
+
+func TestLoadFanoutState(t *testing.T) {
+	t.Run("nonexistent file returns empty map", func(t *testing.T) {
+		done, err := loadFanoutState(filepath.Join(t.TempDir(), "no-such-file.jsonl"))
+		if err != nil {
+			t.Fatalf("loadFanoutState() error: %v", err)
+		}
+		if len(done) != 0 {
+			t.Errorf("expected empty map, got %v", done)
+		}
+	})
+
+	t.Run("reads existing entries", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "state.jsonl")
+
+		entries := []fanoutStateEntry{
+			{Title: "Fix auth bug", BeadID: "gt-aaa", CreatedAt: time.Now().UTC().Format(time.RFC3339)},
+			{Title: "Add rate limit", BeadID: "gt-bbb", CreatedAt: time.Now().UTC().Format(time.RFC3339)},
+		}
+		f, err := os.Create(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		for _, e := range entries {
+			b, _ := json.Marshal(e)
+			_, _ = f.WriteString(string(b) + "\n")
+		}
+		f.Close()
+
+		done, err := loadFanoutState(path)
+		if err != nil {
+			t.Fatalf("loadFanoutState() error: %v", err)
+		}
+		if len(done) != 2 {
+			t.Fatalf("expected 2 entries, got %d", len(done))
+		}
+		if done["Fix auth bug"] != "gt-aaa" {
+			t.Errorf("expected gt-aaa, got %q", done["Fix auth bug"])
+		}
+		if done["Add rate limit"] != "gt-bbb" {
+			t.Errorf("expected gt-bbb, got %q", done["Add rate limit"])
+		}
+	})
+
+	t.Run("skips malformed lines", func(t *testing.T) {
+		dir := t.TempDir()
+		path := filepath.Join(dir, "state.jsonl")
+
+		content := `{"title":"Good","bead_id":"gt-aaa","created_at":"2026-01-01T00:00:00Z"}
+not-valid-json
+{"title":"Also Good","bead_id":"gt-bbb","created_at":"2026-01-01T00:00:00Z"}
+`
+		if err := os.WriteFile(path, []byte(content), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		done, err := loadFanoutState(path)
+		if err != nil {
+			t.Fatalf("loadFanoutState() error: %v", err)
+		}
+		if len(done) != 2 {
+			t.Fatalf("expected 2 valid entries, got %d", len(done))
+		}
+	})
+}
+
+func TestSanitizeFilename(t *testing.T) {
+	tests := []struct {
+		in   string
+		want string
+	}{
+		{"gastown", "gastown"},
+		{"gt-epic123", "gt-epic123"},
+		{"some/rig:name", "some-rig-name"},
+		{"spaces here", "spaces-here"},
+		{"gt.abc", "gt-abc"},
+	}
+	for _, tt := range tests {
+		got := sanitizeFilename(tt.in)
+		if got != tt.want {
+			t.Errorf("sanitizeFilename(%q) = %q, want %q", tt.in, got, tt.want)
+		}
+	}
+}
+
+func TestRunFanout_DryRun(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows — shell stubs")
+	}
+
+	townRoot := t.TempDir()
+
+	// Minimal workspace structure.
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	// Rig directory.
+	if err := os.MkdirAll(filepath.Join(townRoot, "gastown", ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir rig: %v", err)
+	}
+
+	// Change cwd to town root so workspace.FindFromCwdOrError() works.
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	// Redirect stdin.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = origStdin })
+	_, _ = w.WriteString("Fix auth bug\nAdd rate limit\n")
+	w.Close()
+
+	// Set flags.
+	fanoutRig = "gastown"
+	fanoutParent = ""
+	fanoutType = "task"
+	fanoutPriority = "2"
+	fanoutLabels = nil
+	fanoutRate = 0
+	fanoutStateFile = filepath.Join(t.TempDir(), "state.jsonl")
+	fanoutDryRun = true
+	t.Cleanup(func() { fanoutDryRun = false })
+
+	if err := runFanout(fanoutCmd, nil); err != nil {
+		t.Errorf("runFanout(dry-run) error: %v", err)
+	}
+}
+
+func TestRunFanout_SkipsAlreadyCreated(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows — shell stubs")
+	}
+
+	townRoot := t.TempDir()
+	binDir := filepath.Join(townRoot, "bin")
+
+	// Workspace structure.
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "gastown", ".beads"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Count bd create calls.
+	logPath := filepath.Join(townRoot, "bd.log")
+	bdScript := `#!/bin/sh
+echo "CMD:$*" >> "` + logPath + `"
+cmd="$1"
+if [ "$cmd" = "--allow-stale" ]; then shift || true; cmd="$1"; fi
+shift || true
+case "$cmd" in
+  create) echo "gt-new001" ;;
+  dep) exit 0 ;;
+esac
+exit 0
+`
+	bdPath := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
+		t.Fatal(err)
+	}
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+":"+origPath)
+
+	// Pre-populate state file: "Fix auth bug" already created.
+	stateFile := filepath.Join(t.TempDir(), "state.jsonl")
+	existing := fanoutStateEntry{Title: "Fix auth bug", BeadID: "gt-old001", CreatedAt: "2026-01-01T00:00:00Z"}
+	b, _ := json.Marshal(existing)
+	if err := os.WriteFile(stateFile, append(b, '\n'), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// stdin: two titles, one already in state.
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = origStdin })
+	_, _ = w.WriteString("Fix auth bug\nAdd rate limit\n")
+	w.Close()
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	fanoutRig = "gastown"
+	fanoutParent = ""
+	fanoutType = "task"
+	fanoutPriority = "2"
+	fanoutLabels = nil
+	fanoutRate = 0
+	fanoutStateFile = stateFile
+	fanoutDryRun = false
+
+	if err := runFanout(fanoutCmd, nil); err != nil {
+		t.Errorf("runFanout() error: %v", err)
+	}
+
+	// Only one bd create call expected (the already-created title was skipped).
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading bd.log: %v", err)
+	}
+	log := string(logData)
+	createCalls := strings.Count(log, "create")
+	if createCalls != 1 {
+		t.Errorf("expected 1 bd create call (skipped 1), got %d\nlog:\n%s", createCalls, log)
+	}
+}
+
+func TestRunFanout_LinksToParent(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows — shell stubs")
+	}
+
+	townRoot := t.TempDir()
+	binDir := filepath.Join(townRoot, "bin")
+
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "gastown", ".beads"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	logPath := filepath.Join(townRoot, "bd.log")
+	bdScript := `#!/bin/sh
+echo "CMD:$*" >> "` + logPath + `"
+cmd="$1"
+if [ "$cmd" = "--allow-stale" ]; then shift || true; cmd="$1"; fi
+shift || true
+case "$cmd" in
+  create) echo "gt-child001" ;;
+  dep) exit 0 ;;
+esac
+exit 0
+`
+	bdPath := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
+		t.Fatal(err)
+	}
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+":"+origPath)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = origStdin })
+	_, _ = w.WriteString("Task one\n")
+	w.Close()
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	fanoutRig = "gastown"
+	fanoutParent = "gt-epic001"
+	fanoutType = "task"
+	fanoutPriority = "2"
+	fanoutLabels = nil
+	fanoutRate = 0
+	fanoutStateFile = filepath.Join(t.TempDir(), "state.jsonl")
+	fanoutDryRun = false
+	t.Cleanup(func() { fanoutParent = "" })
+
+	if err := runFanout(fanoutCmd, nil); err != nil {
+		t.Errorf("runFanout() error: %v", err)
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading bd.log: %v", err)
+	}
+	log := string(logData)
+
+	if !strings.Contains(log, "dep") {
+		t.Errorf("expected dep add call in log, got:\n%s", log)
+	}
+	if !strings.Contains(log, "gt-epic001") {
+		t.Errorf("expected parent ID gt-epic001 in dep call, got:\n%s", log)
+	}
+	if !strings.Contains(log, "parent-child") {
+		t.Errorf("expected --type=parent-child in dep call, got:\n%s", log)
+	}
+}
+
+func TestRunFanout_PartialFailureReported(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows — shell stubs")
+	}
+
+	townRoot := t.TempDir()
+	binDir := filepath.Join(townRoot, "bin")
+
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "gastown", ".beads"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	// Stub: fail on "Bad title", succeed otherwise.
+	logPath := filepath.Join(townRoot, "bd.log")
+	bdScript := `#!/bin/sh
+echo "CMD:$*" >> "` + logPath + `"
+cmd="$1"
+if [ "$cmd" = "--allow-stale" ]; then shift || true; cmd="$1"; fi
+shift || true
+case "$cmd" in
+  create)
+    # fail if title contains "Bad"
+    if echo "$*" | grep -q "Bad"; then
+      echo "error: rejected" >&2
+      exit 1
+    fi
+    echo "gt-good001"
+    ;;
+  dep) exit 0 ;;
+esac
+exit 0
+`
+	bdPath := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
+		t.Fatal(err)
+	}
+	origPath := os.Getenv("PATH")
+	t.Setenv("PATH", binDir+":"+origPath)
+
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatal(err)
+	}
+	origStdin := os.Stdin
+	os.Stdin = r
+	t.Cleanup(func() { os.Stdin = origStdin })
+	_, _ = w.WriteString("Good title\nBad title\n")
+	w.Close()
+
+	orig, _ := os.Getwd()
+	t.Cleanup(func() { _ = os.Chdir(orig) })
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatal(err)
+	}
+
+	fanoutRig = "gastown"
+	fanoutParent = ""
+	fanoutType = "task"
+	fanoutPriority = "2"
+	fanoutLabels = nil
+	fanoutRate = 0
+	fanoutStateFile = filepath.Join(t.TempDir(), "state.jsonl")
+	fanoutDryRun = false
+
+	err = runFanout(fanoutCmd, nil)
+	if err == nil {
+		t.Error("runFanout() expected error for partial failures, got nil")
+	}
+	if !strings.Contains(err.Error(), "1 bead(s) failed") {
+		t.Errorf("unexpected error: %v", err)
+	}
+
+	// Verify good bead was persisted to state file.
+	done, loadErr := loadFanoutState(fanoutStateFile)
+	if loadErr != nil {
+		t.Fatalf("loadFanoutState() error: %v", loadErr)
+	}
+	if done["Good title"] != "gt-good001" {
+		t.Errorf("state file: expected gt-good001 for 'Good title', got %q", done["Good title"])
+	}
+	if _, ok := done["Bad title"]; ok {
+		t.Error("state file: 'Bad title' should not be persisted after failure")
+	}
+}

--- a/internal/cmd/prime_external_tools_test.go
+++ b/internal/cmd/prime_external_tools_test.go
@@ -19,7 +19,11 @@ func setupPrimeExternalToolTest(t *testing.T, bdScript, gtScript string) string 
 
 	oldTimeout := primeExternalToolTimeout
 	oldWaitDelay := primeExternalToolWaitDelay
-	primeExternalToolTimeout = 100 * time.Millisecond
+	// 500ms gives macOS shell scripts enough time to start and write their log
+	// entry before SIGKILL arrives (shell startup can take >100ms on macOS due
+	// to codesigning validation). The slow-bd/slow-mail scripts sleep 2s, so
+	// the 500ms bound still exercises the timeout path.
+	primeExternalToolTimeout = 500 * time.Millisecond
 	primeExternalToolWaitDelay = 10 * time.Millisecond
 	t.Cleanup(func() {
 		primeExternalToolTimeout = oldTimeout
@@ -86,7 +90,7 @@ esac
 
 	start := time.Now()
 	output := captureStdout(t, func() { runPrimeExternalTools(workDir) })
-	assertElapsedUnder(t, time.Since(start), time.Second)
+	assertElapsedUnder(t, time.Since(start), 2*time.Second)
 	assertPrimeToolCalled(t, "bd:prime")
 	assertPrimeToolCalled(t, "bd:kv list --json")
 	assertPrimeToolCalled(t, "gt:mail check --inject")
@@ -123,7 +127,7 @@ esac
 
 	start := time.Now()
 	output := captureStdout(t, func() { runPrimeExternalTools(workDir) })
-	assertElapsedUnder(t, time.Since(start), time.Second)
+	assertElapsedUnder(t, time.Since(start), 2*time.Second)
 	assertPrimeToolCalled(t, "bd:prime")
 	assertPrimeToolCalled(t, "bd:kv list --json")
 	assertPrimeToolCalled(t, "gt:mail check --inject")
@@ -158,7 +162,7 @@ esac
 	output := captureStdout(t, func() {
 		checkPendingEscalations(RoleContext{Role: RoleMayor, WorkDir: workDir})
 	})
-	assertElapsedUnder(t, time.Since(start), time.Second)
+	assertElapsedUnder(t, time.Since(start), 2*time.Second)
 	assertPrimeToolCalled(t, "bd:list --status=open --tag=escalation --json")
 
 	if strings.Contains(output, "PENDING ESCALATIONS") {

--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -62,12 +62,20 @@ func outputPrimeContext(ctx RoleContext) (string, error) {
 	// Get town name for session names
 	townName, _ := workspace.GetTownName(ctx.TownRoot)
 
-	// Get default branch from rig config (default to "main" if not set)
+	// Get default branch and fork info from rig config.
 	defaultBranch := "main"
+	var isForkRig bool
+	var upstreamURL string
 	if ctx.Rig != "" && ctx.TownRoot != "" {
 		rigPath := filepath.Join(ctx.TownRoot, ctx.Rig)
-		if rigCfg, err := rig.LoadRigConfig(rigPath); err == nil && rigCfg.DefaultBranch != "" {
-			defaultBranch = rigCfg.DefaultBranch
+		if rigCfg, err := rig.LoadRigConfig(rigPath); err == nil {
+			if rigCfg.DefaultBranch != "" {
+				defaultBranch = rigCfg.DefaultBranch
+			}
+			if rigCfg.UpstreamURL != "" {
+				isForkRig = true
+				upstreamURL = rigCfg.UpstreamURL
+			}
 		}
 	}
 
@@ -82,6 +90,8 @@ func outputPrimeContext(ctx RoleContext) (string, error) {
 		DogName:       ctx.Polecat, // ctx.Polecat holds the dog name for RoleDog
 		MayorSession:  session.MayorSessionName(),
 		DeaconSession: session.DeaconSessionName(),
+		IsForkRig:     isForkRig,
+		UpstreamURL:   upstreamURL,
 	}
 
 	// Render and output

--- a/internal/cmd/refinery.go
+++ b/internal/cmd/refinery.go
@@ -23,6 +23,7 @@ var (
 	refineryStatusJSON    bool
 	refineryQueueJSON     bool
 	refineryAgentOverride string
+	refineryForce         bool
 )
 
 var refineryCmd = &cobra.Command{
@@ -226,10 +227,75 @@ Examples:
 
 var refineryBlockedJSON bool
 
+var refineryDisableCmd = &cobra.Command{
+	Use:   "disable [rig]",
+	Short: "Persistently disable the refinery for a rig",
+	Long: `Persistently disable the refinery for a rig (witness stays up).
+
+Sets refinery_disabled=true in the rig's config.json. The refinery will
+not start even after daemon restarts or 'gt up'. Use 'gt refinery enable'
+to re-enable.
+
+This is the correct persistent state for fork rigs where the refinery
+should never run (the witness continues to manage polecat lifecycle).
+
+If rig is not specified, infers it from the current directory.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runRefineryDisable,
+}
+
+var refineryEnableCmd = &cobra.Command{
+	Use:   "enable [rig]",
+	Short: "Re-enable the refinery for a rig",
+	Long: `Re-enable the refinery for a rig after 'gt refinery disable'.
+
+Clears the refinery_disabled flag in the rig's config.json.
+Does not automatically start the refinery — use 'gt refinery start' after.
+
+If rig is not specified, infers it from the current directory.`,
+	Args: cobra.MaximumNArgs(1),
+	RunE: runRefineryEnable,
+}
+
+func runRefineryDisable(cmd *cobra.Command, args []string) error {
+	rigName := ""
+	if len(args) > 0 {
+		rigName = args[0]
+	}
+	_, r, rigName, err := getRefineryManager(rigName)
+	if err != nil {
+		return err
+	}
+	if err := rig.SetRefineryDisabled(r.Path, true); err != nil {
+		return fmt.Errorf("disabling refinery: %w", err)
+	}
+	fmt.Printf("%s Refinery disabled for %s\n", style.Bold.Render("✓"), rigName)
+	fmt.Printf("  %s\n", style.Dim.Render("Witness continues running. Use 'gt refinery enable "+rigName+"' to re-enable."))
+	return nil
+}
+
+func runRefineryEnable(cmd *cobra.Command, args []string) error {
+	rigName := ""
+	if len(args) > 0 {
+		rigName = args[0]
+	}
+	_, r, rigName, err := getRefineryManager(rigName)
+	if err != nil {
+		return err
+	}
+	if err := rig.SetRefineryDisabled(r.Path, false); err != nil {
+		return fmt.Errorf("enabling refinery: %w", err)
+	}
+	fmt.Printf("%s Refinery enabled for %s\n", style.Bold.Render("✓"), rigName)
+	fmt.Printf("  %s\n", style.Dim.Render("Use 'gt refinery start "+rigName+"' to start."))
+	return nil
+}
+
 func init() {
 	// Start flags
 	refineryStartCmd.Flags().BoolVar(&refineryForeground, "foreground", false, "Run in foreground (default: background)")
 	refineryStartCmd.Flags().StringVar(&refineryAgentOverride, "agent", "", "Agent alias to run the Refinery with (overrides town default)")
+	refineryStartCmd.Flags().BoolVar(&refineryForce, "force", false, "Start refinery even on a fork rig (overrides upstream_url guard)")
 
 	// Attach flags
 	refineryAttachCmd.Flags().StringVar(&refineryAgentOverride, "agent", "", "Agent alias to run the Refinery with (overrides town default)")
@@ -265,6 +331,8 @@ func init() {
 	refineryCmd.AddCommand(refineryUnclaimedCmd)
 	refineryCmd.AddCommand(refineryReadyCmd)
 	refineryCmd.AddCommand(refineryBlockedCmd)
+	refineryCmd.AddCommand(refineryDisableCmd)
+	refineryCmd.AddCommand(refineryEnableCmd)
 
 	rootCmd.AddCommand(refineryCmd)
 }
@@ -299,7 +367,7 @@ func runRefineryStart(cmd *cobra.Command, args []string) error {
 		rigName = args[0]
 	}
 
-	mgr, _, rigName, err := getRefineryManager(rigName)
+	mgr, r, rigName, err := getRefineryManager(rigName)
 	if err != nil {
 		return err
 	}
@@ -308,11 +376,40 @@ func runRefineryStart(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Refuse to start the refinery on a fork rig unless --force is given.
+	// The refinery merges branches to the rig's main, which corrupts fork/upstream
+	// fast-forward sync for rigs where upstream_url != git_url.
+	if !refineryForce {
+		if rigCfg, err := rig.LoadRigConfig(r.Path); err == nil && rigCfg.UpstreamURL != "" {
+			fmt.Println()
+			fmt.Printf("  %s Refinery blocked for fork rig %q\n", style.Bold.Render("⛔"), rigName)
+			fmt.Println()
+			fmt.Printf("  This rig is a fork (upstream_url = %s).\n", rigCfg.UpstreamURL)
+			fmt.Println("  Running the refinery merges branches to fork main, which breaks")
+			fmt.Println("  fork↔upstream fast-forward sync and pollutes the fork's history.")
+			fmt.Println()
+			fmt.Println("  Correct workflow for a fork rig:")
+			fmt.Println("    1. Work on a feature branch")
+			fmt.Println("    2. Push to your fork")
+			fmt.Println("    3. Open a PR to the upstream repo")
+			fmt.Println()
+			fmt.Printf("  To permanently disable the refinery for this rig: gt refinery disable %s\n", rigName)
+			fmt.Printf("  To start anyway (advanced / non-standard):        gt refinery start %s --force\n", rigName)
+			fmt.Println()
+			return fmt.Errorf("refinery blocked for fork rig %q (use --force to override)", rigName)
+		}
+	}
+
 	fmt.Printf("Starting refinery for %s...\n", rigName)
 
 	if err := mgr.Start(refineryForeground, refineryAgentOverride); err != nil {
 		if err == refinery.ErrAlreadyRunning {
 			fmt.Printf("%s Refinery is already running\n", style.Dim.Render("⚠"))
+			return nil
+		}
+		if err == refinery.ErrDisabled {
+			fmt.Printf("%s Refinery is disabled for %s (use 'gt refinery enable %s' to re-enable)\n",
+				style.Dim.Render("⚠"), rigName, rigName)
 			return nil
 		}
 		return fmt.Errorf("starting refinery: %w", err)
@@ -549,6 +646,11 @@ func runRefineryRestart(cmd *cobra.Command, args []string) error {
 
 	// Start fresh
 	if err := mgr.Start(false, refineryAgentOverride); err != nil {
+		if err == refinery.ErrDisabled {
+			fmt.Printf("%s Refinery is disabled for %s (use 'gt refinery enable %s' to re-enable)\n",
+				style.Dim.Render("⚠"), rigName, rigName)
+			return nil
+		}
 		return fmt.Errorf("starting refinery: %w", err)
 	}
 

--- a/internal/cmd/root_test.go
+++ b/internal/cmd/root_test.go
@@ -185,6 +185,13 @@ func TestPersistentPreRunLoadsAgentRegistry(t *testing.T) {
 	}
 	t.Cleanup(func() { _ = os.Chdir(origDir) })
 
+	// persistentPreRun calls os.Exit(1) when BuiltProperly=="" on macOS (the
+	// binary signing guard). In tests the binary is built without ldflags, so
+	// BuiltProperly is empty. Set it to "1" to bypass the guard.
+	oldBuiltProperly := BuiltProperly
+	BuiltProperly = "1"
+	t.Cleanup(func() { BuiltProperly = oldBuiltProperly })
+
 	// Run persistentPreRun (the function under test).
 	cmd := &cobra.Command{Use: "version"}
 	if err := persistentPreRun(cmd, nil); err != nil {
@@ -235,6 +242,13 @@ func TestPersistentPreRunMalformedAgentRegistry(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Cleanup(func() { _ = os.Chdir(origDir) })
+
+	// persistentPreRun calls os.Exit(1) when BuiltProperly=="" on macOS (the
+	// binary signing guard). In tests the binary is built without ldflags, so
+	// BuiltProperly is empty. Set it to "1" to bypass the guard.
+	oldBuiltProperly2 := BuiltProperly
+	BuiltProperly = "1"
+	t.Cleanup(func() { BuiltProperly = oldBuiltProperly2 })
 
 	// persistentPreRun should succeed despite malformed agents.json.
 	cmd := &cobra.Command{Use: "version"}

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -807,15 +807,18 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	// If not, create one for dashboard visibility (unless --no-convoy is set)
 	var convoyID string
 	if !slingNoConvoy && formulaName == "" {
-		existingConvoy := isTrackedByConvoy(beadID)
-		if existingConvoy == "" {
-			if slingDryRun {
-				fmt.Printf("Would create convoy 'Work: %s'\n", info.Title)
-				fmt.Printf("Would add tracking relation to %s\n", beadID)
-				if slingMerge != "" {
-					fmt.Printf("Would set convoy merge strategy: %s\n", slingMerge)
-				}
-			} else {
+		if slingDryRun {
+			// Skip the Dolt convoy query in dry-run: isTrackedByConvoy runs bd
+			// subprocesses that can hang under load, causing --dry-run itself to
+			// time out (GH#3903). Just show what would happen.
+			fmt.Printf("Would create convoy 'Work: %s'\n", info.Title)
+			fmt.Printf("Would add tracking relation to %s\n", beadID)
+			if slingMerge != "" {
+				fmt.Printf("Would set convoy merge strategy: %s\n", slingMerge)
+			}
+		} else {
+			existingConvoy := isTrackedByConvoy(beadID)
+			if existingConvoy == "" {
 				var err error
 				convoyID, err = createAutoConvoy(beadID, info.Title, slingOwned, slingMerge, slingBaseBranch)
 				if err != nil {
@@ -831,9 +834,9 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 						fmt.Printf("  Merge:    %s\n", slingMerge)
 					}
 				}
+			} else {
+				fmt.Printf("%s Already tracked by convoy %s\n", style.Dim.Render("○"), existingConvoy)
 			}
-		} else {
-			fmt.Printf("%s Already tracked by convoy %s\n", style.Dim.Render("○"), existingConvoy)
 		}
 	}
 

--- a/internal/cmd/sling_batch_test.go
+++ b/internal/cmd/sling_batch_test.go
@@ -907,7 +907,14 @@ exit 0
 		t.Errorf("create should include 'Work: Fix the widget' in args:\n%s", logContent)
 	}
 
-	if helperTownRoot != townRoot {
+	// workspace.FindFromCwd resolves symlinks, so helperTownRoot may be the
+	// canonical /private/var/... path while townRoot is the unresolved /var/...
+	// path from t.TempDir(). Resolve before comparing to avoid macOS mismatch.
+	wantTownRoot := townRoot
+	if resolved, err := filepath.EvalSymlinks(townRoot); err == nil {
+		wantTownRoot = resolved
+	}
+	if helperTownRoot != wantTownRoot {
 		t.Errorf("tracking helper townRoot = %q, want %q", helperTownRoot, townRoot)
 	}
 	if helperConvoyID != convoyID {

--- a/internal/cmd/sling_target.go
+++ b/internal/cmd/sling_target.go
@@ -309,5 +309,11 @@ func resolveTarget(target string, opts ResolveTargetOptions) (*ResolvedTarget, e
 	result.Agent = agentID
 	result.Pane = pane
 	result.WorkDir = workDir
+	// Detect self-sling by pane: a named target (e.g. "deacon") that resolves to
+	// the caller's own tmux pane should not inject the ack prompt — the caller is
+	// already running and knows about the hook (GH#3839).
+	if pane != "" && pane == os.Getenv("TMUX_PANE") {
+		result.IsSelfSling = true
+	}
 	return result, nil
 }

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -3281,3 +3281,59 @@ exit /b 0
 	}
 	// Any other error (e.g., no polecat to spawn) is acceptable — the guard is what we're testing.
 }
+
+// TestResolveTargetSelfSlingByPane verifies that a named target resolving to the
+// caller's own tmux pane sets IsSelfSling=true (GH#3839). Without this, gt sling
+// deacon (from the deacon itself) injects the ack prompt into the running agent's
+// pane, wedging it mid-command.
+func TestResolveTargetSelfSlingByPane(t *testing.T) {
+	const callerPane = "%42"
+
+	prev := resolveTargetAgentFn
+	t.Cleanup(func() { resolveTargetAgentFn = prev })
+
+	t.Run("named_target_same_pane_is_self_sling", func(t *testing.T) {
+		resolveTargetAgentFn = func(_ string) (string, string, string, error) {
+			return "deacon/", callerPane, "/home/deacon", nil
+		}
+		t.Setenv("TMUX_PANE", callerPane)
+
+		result, err := resolveTarget("deacon", ResolveTargetOptions{})
+		if err != nil {
+			t.Fatalf("resolveTarget: %v", err)
+		}
+		if !result.IsSelfSling {
+			t.Error("expected IsSelfSling=true when named target pane matches caller pane")
+		}
+	})
+
+	t.Run("named_target_different_pane_is_not_self_sling", func(t *testing.T) {
+		resolveTargetAgentFn = func(_ string) (string, string, string, error) {
+			return "deacon/", "%99", "/home/deacon", nil
+		}
+		t.Setenv("TMUX_PANE", callerPane)
+
+		result, err := resolveTarget("deacon", ResolveTargetOptions{})
+		if err != nil {
+			t.Fatalf("resolveTarget: %v", err)
+		}
+		if result.IsSelfSling {
+			t.Error("expected IsSelfSling=false when named target pane differs from caller pane")
+		}
+	})
+
+	t.Run("empty_pane_is_not_self_sling", func(t *testing.T) {
+		resolveTargetAgentFn = func(_ string) (string, string, string, error) {
+			return "deacon/", "", "/home/deacon", nil
+		}
+		t.Setenv("TMUX_PANE", callerPane)
+
+		result, err := resolveTarget("deacon", ResolveTargetOptions{})
+		if err != nil {
+			t.Fatalf("resolveTarget: %v", err)
+		}
+		if result.IsSelfSling {
+			t.Error("expected IsSelfSling=false when resolved pane is empty (no tmux)")
+		}
+	})
+}

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -3337,3 +3337,91 @@ func TestResolveTargetSelfSlingByPane(t *testing.T) {
 		}
 	})
 }
+
+// TestSlingDryRunSkipsConvoyLookup verifies that --dry-run does not invoke
+// isTrackedByConvoy (which runs bd sql and can hang under Dolt load).
+// Regression test for GH#3903.
+func TestSlingDryRunSkipsConvoyLookup(t *testing.T) {
+	townRoot, _ := filepath.EvalSymlinks(t.TempDir())
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir mayor/rig: %v", err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	logPath := filepath.Join(townRoot, "bd.log")
+
+	// bd stub: log all commands; return minimal valid responses.
+	// "sql" must NOT appear in the log after --dry-run (isTrackedByConvoy uses it).
+	bdScript := `#!/bin/sh
+set -e
+echo "$*" >> "${BD_LOG}"
+cmd="$1"
+shift || true
+case "$cmd" in
+  show)
+    echo '[{"title":"Test issue","status":"open","assignee":"","description":""}]'
+    ;;
+  sql)
+    echo '[]'
+    ;;
+esac
+exit 0
+`
+	bdScriptWindows := `@echo off
+echo %*>>"%BD_LOG%"
+set "cmd=%1"
+if "%cmd%"=="show" (
+  echo [{"title":"Test issue","status":"open","assignee":"","description":""}]
+  exit /b 0
+)
+if "%cmd%"=="sql" ( echo [] & exit /b 0 )
+exit /b 0
+`
+	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
+
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv(EnvGTRole, "mayor")
+	t.Setenv("GT_CREW", "")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("TMUX_PANE", "")
+	t.Setenv("GT_TEST_NO_NUDGE", "1")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	prevDryRun := slingDryRun
+	prevNoConvoy := slingNoConvoy
+	t.Cleanup(func() {
+		slingDryRun = prevDryRun
+		slingNoConvoy = prevNoConvoy
+	})
+	slingDryRun = true
+	slingNoConvoy = false // convoy check enabled — the important part
+
+	// Self-sling (no target) with convoy check enabled. Before the fix,
+	// this would call isTrackedByConvoy → bd sql, which can hang under load.
+	_ = runSling(nil, []string{"gt-test123"})
+
+	// Verify bd sql was never invoked.
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil && !os.IsNotExist(err) {
+		t.Fatalf("read bd log: %v", err)
+	}
+	for _, line := range strings.Split(string(logBytes), "\n") {
+		line = strings.TrimSpace(line)
+		if strings.HasPrefix(line, "sql ") || line == "sql" {
+			t.Errorf("--dry-run called bd sql (isTrackedByConvoy ran): "+
+				"GH#3903 regression — Dolt queries must be skipped in dry-run\nlog:\n%s", string(logBytes))
+		}
+	}
+}

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -261,10 +261,11 @@ exit /b 0
 	if resolved, err := filepath.EvalSymlinks(wantDir); err == nil {
 		wantDir = resolved
 	}
-	wantBeadsDir := filepath.Join(rigDir, ".beads")
-	if resolved, err := filepath.EvalSymlinks(wantBeadsDir); err == nil {
-		wantBeadsDir = resolved
-	}
+	// Build wantBeadsDir from the already-resolved wantDir, not from rigDir.
+	// EvalSymlinks fails on non-existent paths (the .beads dir isn't created in
+	// this test), so we'd fall back to the unresolved /var/... path while the
+	// actual subprocess path resolves to /private/var/... — a mismatch on macOS.
+	wantBeadsDir := filepath.Join(wantDir, ".beads")
 	gotCook := false
 	gotWisp := false
 	gotBond := false

--- a/internal/cmd/start.go
+++ b/internal/cmd/start.go
@@ -413,6 +413,9 @@ func startRefineryForRig(r *rig.Rig) string {
 		if errors.Is(err, refinery.ErrAlreadyRunning) {
 			return fmt.Sprintf("  %s %s refinery already running\n", style.Dim.Render("○"), r.Name)
 		}
+		if errors.Is(err, refinery.ErrDisabled) {
+			return fmt.Sprintf("  %s %s refinery disabled\n", style.Dim.Render("○"), r.Name)
+		}
 		return fmt.Sprintf("  %s %s refinery failed: %v\n", style.Dim.Render("○"), r.Name, err)
 	}
 	return fmt.Sprintf("  %s %s refinery started\n", style.Bold.Render("✓"), r.Name)

--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -758,6 +758,9 @@ func upStartRefinery(rigName string, r *rig.Rig) agentStartResult {
 		if err == refinery.ErrAlreadyRunning {
 			return agentStartResult{name: name, ok: true, detail: mgr.SessionName()}
 		}
+		if err == refinery.ErrDisabled {
+			return agentStartResult{name: name, ok: true, detail: "skipped (refinery disabled)"}
+		}
 		return agentStartResult{name: name, ok: false, detail: err.Error()}
 	}
 	return agentStartResult{name: name, ok: true, detail: mgr.SessionName()}

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -1836,6 +1836,10 @@ func (d *Daemon) ensureRefineryRunning(rigName string) {
 			d.logger.Printf("Refinery for %s already running, skipping spawn", rigName)
 			return
 		}
+		if err == refinery.ErrDisabled {
+			d.logger.Printf("Refinery for %s is disabled (refinery_disabled=true), skipping spawn", rigName)
+			return
+		}
 		d.logger.Printf("Error starting refinery for %s: %v", rigName, err)
 		return
 	}

--- a/internal/deacon/manager.go
+++ b/internal/deacon/manager.go
@@ -179,6 +179,15 @@ func (m *Manager) Start(agentOverride string) error {
 	// Accept startup dialogs (workspace trust + bypass permissions) if they appear.
 	_ = t.AcceptStartupDialogs(sessionID)
 
+	// Startup fallback for promptless runtimes (prompt_mode: none).
+	// BuildStartupCommandFromConfig drops the prompt text for non-prompt runtimes,
+	// so the deacon never receives its work instructions via the CLI argument.
+	// We must deliver them via tmux nudge to ensure the deacon starts patrol.
+	if realTmux, ok := t.(*tmux.Tmux); ok {
+		_ = runtime.RunStartupFallback(realTmux, sessionID, "deacon", runtimeConfig)
+		_ = runtime.DeliverStartupPromptFallback(realTmux, sessionID, initialPrompt, runtimeConfig, constants.ClaudeStartTimeout)
+	}
+
 	time.Sleep(constants.ShutdownNotifyDelay)
 
 	return nil

--- a/internal/mayor/manager.go
+++ b/internal/mayor/manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/steveyegge/gastown/internal/acp"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/templates"
 	"github.com/steveyegge/gastown/internal/tmux"
@@ -159,7 +160,7 @@ func (m *Manager) StartTMUX(agentOverride string) error {
 
 	// Use unified session lifecycle for config → settings → command → create → env → theme → wait.
 	theme := tmux.ResolveSessionTheme(m.townRoot, "", "mayor", "")
-	_, err = session.StartSession(t, session.SessionConfig{
+	result, err := session.StartSession(t, session.SessionConfig{
 		SessionID:        sessionID,
 		WorkDir:          mayorDir,
 		Role:             "mayor",
@@ -181,6 +182,17 @@ func (m *Manager) StartTMUX(agentOverride string) error {
 	if err != nil {
 		return err
 	}
+
+	// Startup fallback for promptless runtimes (prompt_mode: none).
+	// BuildCommandWithPrompt drops the prompt text for these runtimes, so the
+	// mayor never receives its work instructions via the CLI argument.
+	_ = runtime.RunStartupFallback(t, sessionID, "mayor", result.RuntimeConfig)
+	initialPrompt := session.FormatStartupBeacon(session.BeaconConfig{
+		Recipient: "mayor",
+		Sender:    "human",
+		Topic:     "cold-start",
+	})
+	_ = runtime.DeliverStartupPromptFallback(t, sessionID, initialPrompt, result.RuntimeConfig, constants.ClaudeStartTimeout)
 
 	time.Sleep(session.ShutdownDelay())
 

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -32,6 +32,7 @@ var (
 	ErrNotRunning     = errors.New("refinery not running")
 	ErrAlreadyRunning = errors.New("refinery already running")
 	ErrNoQueue        = errors.New("no items in queue")
+	ErrDisabled       = errors.New("refinery disabled for this rig")
 )
 
 // Manager handles refinery lifecycle and queue operations.
@@ -117,6 +118,11 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 	if foreground {
 		// Foreground mode is deprecated - the Refinery agent handles merge processing
 		return fmt.Errorf("foreground mode is deprecated; use background mode (remove --foreground flag)")
+	}
+
+	// Check persistent refinery-disabled flag before doing anything.
+	if rigCfg, err := rig.LoadRigConfig(m.rig.Path); err == nil && rigCfg.RefineryDisabled {
+		return ErrDisabled
 	}
 
 	// Check if session already exists

--- a/internal/refinery/manager_test.go
+++ b/internal/refinery/manager_test.go
@@ -89,19 +89,21 @@ func TestManager_Start_ReturnsErrDisabledWhenRefineryDisabled(t *testing.T) {
 }
 
 func TestManager_Start_NotDisabledWhenFlagFalse(t *testing.T) {
-	_, rigPath := setupTestManager(t)
+	mgr, rigPath := setupTestManager(t)
 	// Write a config.json with refinery_disabled=false (should not return ErrDisabled)
 	cfgJSON := `{"type":"rig","version":1,"name":"testrig","git_url":"https://github.com/example/repo","refinery_disabled":false}`
 	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), []byte(cfgJSON), 0644); err != nil {
 		t.Fatalf("write config.json: %v", err)
 	}
-	r := &rig.Rig{Name: "testrig", Path: rigPath}
-	mgr := NewManager(r)
 	err := mgr.Start(false, "")
 	// Should not return ErrDisabled (may return other errors for missing tmux/repo)
 	if err == ErrDisabled {
 		t.Error("Start() with refinery_disabled=false returned ErrDisabled unexpectedly")
 	}
+	// If a session was started, stop it to avoid leaking into other tests.
+	t.Cleanup(func() {
+		_ = mgr.Stop()
+	})
 }
 
 func TestManager_Status_NotRunning(t *testing.T) {

--- a/internal/refinery/manager_test.go
+++ b/internal/refinery/manager_test.go
@@ -73,39 +73,6 @@ func TestManager_IsRunning_NoSession(t *testing.T) {
 	}
 }
 
-func TestManager_Start_ReturnsErrDisabledWhenRefineryDisabled(t *testing.T) {
-	_, rigPath := setupTestManager(t)
-	// Write a config.json with refinery_disabled=true
-	cfgJSON := `{"type":"rig","version":1,"name":"testrig","git_url":"https://github.com/example/repo","refinery_disabled":true}`
-	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), []byte(cfgJSON), 0644); err != nil {
-		t.Fatalf("write config.json: %v", err)
-	}
-	r := &rig.Rig{Name: "testrig", Path: rigPath}
-	mgr := NewManager(r)
-	err := mgr.Start(false, "")
-	if err != ErrDisabled {
-		t.Errorf("Start() with refinery_disabled=true: got %v, want ErrDisabled", err)
-	}
-}
-
-func TestManager_Start_NotDisabledWhenFlagFalse(t *testing.T) {
-	mgr, rigPath := setupTestManager(t)
-	// Write a config.json with refinery_disabled=false (should not return ErrDisabled)
-	cfgJSON := `{"type":"rig","version":1,"name":"testrig","git_url":"https://github.com/example/repo","refinery_disabled":false}`
-	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), []byte(cfgJSON), 0644); err != nil {
-		t.Fatalf("write config.json: %v", err)
-	}
-	err := mgr.Start(false, "")
-	// Should not return ErrDisabled (may return other errors for missing tmux/repo)
-	if err == ErrDisabled {
-		t.Error("Start() with refinery_disabled=false returned ErrDisabled unexpectedly")
-	}
-	// If a session was started, stop it to avoid leaking into other tests.
-	t.Cleanup(func() {
-		_ = mgr.Stop()
-	})
-}
-
 func TestManager_Status_NotRunning(t *testing.T) {
 	mgr, _ := setupTestManager(t)
 
@@ -333,5 +300,33 @@ func TestManager_PostMerge_NotFound(t *testing.T) {
 	_, err := mgr.PostMerge("nonexistent-mr-id")
 	if err == nil {
 		t.Error("PostMerge() expected error for nonexistent MR")
+	}
+}
+
+func TestManager_Start_ReturnsErrDisabledWhenRefineryDisabled(t *testing.T) {
+	_, rigPath := setupTestManager(t)
+	cfgJSON := `{"type":"rig","version":1,"name":"testrig","git_url":"https://github.com/example/repo","refinery_disabled":true}`
+	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), []byte(cfgJSON), 0644); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+	r := &rig.Rig{Name: "testrig", Path: rigPath}
+	mgr := NewManager(r)
+	err := mgr.Start(false, "")
+	if err != ErrDisabled {
+		t.Errorf("Start() with refinery_disabled=true: got %v, want ErrDisabled", err)
+	}
+}
+
+func TestManager_Start_NotDisabledWhenFlagFalse(t *testing.T) {
+	mgr, rigPath := setupTestManager(t)
+	cfgJSON := `{"type":"rig","version":1,"name":"testrig","git_url":"https://github.com/example/repo","refinery_disabled":false}`
+	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), []byte(cfgJSON), 0644); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+	err := mgr.Start(false, "")
+	// Eagerly stop the session before returning so it doesn't leak into other packages.
+	_ = mgr.Stop()
+	if err == ErrDisabled {
+		t.Error("Start() with refinery_disabled=false returned ErrDisabled unexpectedly")
 	}
 }

--- a/internal/refinery/manager_test.go
+++ b/internal/refinery/manager_test.go
@@ -73,6 +73,37 @@ func TestManager_IsRunning_NoSession(t *testing.T) {
 	}
 }
 
+func TestManager_Start_ReturnsErrDisabledWhenRefineryDisabled(t *testing.T) {
+	_, rigPath := setupTestManager(t)
+	// Write a config.json with refinery_disabled=true
+	cfgJSON := `{"type":"rig","version":1,"name":"testrig","git_url":"https://github.com/example/repo","refinery_disabled":true}`
+	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), []byte(cfgJSON), 0644); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+	r := &rig.Rig{Name: "testrig", Path: rigPath}
+	mgr := NewManager(r)
+	err := mgr.Start(false, "")
+	if err != ErrDisabled {
+		t.Errorf("Start() with refinery_disabled=true: got %v, want ErrDisabled", err)
+	}
+}
+
+func TestManager_Start_NotDisabledWhenFlagFalse(t *testing.T) {
+	_, rigPath := setupTestManager(t)
+	// Write a config.json with refinery_disabled=false (should not return ErrDisabled)
+	cfgJSON := `{"type":"rig","version":1,"name":"testrig","git_url":"https://github.com/example/repo","refinery_disabled":false}`
+	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), []byte(cfgJSON), 0644); err != nil {
+		t.Fatalf("write config.json: %v", err)
+	}
+	r := &rig.Rig{Name: "testrig", Path: rigPath}
+	mgr := NewManager(r)
+	err := mgr.Start(false, "")
+	// Should not return ErrDisabled (may return other errors for missing tmux/repo)
+	if err == ErrDisabled {
+		t.Error("Start() with refinery_disabled=false returned ErrDisabled unexpectedly")
+	}
+}
+
 func TestManager_Status_NotRunning(t *testing.T) {
 	mgr, _ := setupTestManager(t)
 

--- a/internal/rig/config_test.go
+++ b/internal/rig/config_test.go
@@ -274,3 +274,41 @@ func TestGetConfig_BeadLabel(t *testing.T) {
 		t.Logf("source is %s (expected SourceBead or SourceSystem)", result.Source)
 	}
 }
+
+func TestSetRefineryDisabled_RoundTrip(t *testing.T) {
+	tmpDir := t.TempDir()
+	rigPath := filepath.Join(tmpDir, "testrig")
+	if err := os.MkdirAll(rigPath, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Write minimal config.json
+	cfg := &RigConfig{Type: "rig", Version: 1, Name: "testrig", GitURL: "https://github.com/example/repo"}
+	data, _ := json.MarshalIndent(cfg, "", "  ")
+	if err := os.WriteFile(filepath.Join(rigPath, "config.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Disable
+	if err := SetRefineryDisabled(rigPath, true); err != nil {
+		t.Fatalf("SetRefineryDisabled(true): %v", err)
+	}
+	got, err := LoadRigConfig(rigPath)
+	if err != nil {
+		t.Fatalf("LoadRigConfig after disable: %v", err)
+	}
+	if !got.RefineryDisabled {
+		t.Error("RefineryDisabled should be true after SetRefineryDisabled(true)")
+	}
+
+	// Re-enable
+	if err := SetRefineryDisabled(rigPath, false); err != nil {
+		t.Fatalf("SetRefineryDisabled(false): %v", err)
+	}
+	got, err = LoadRigConfig(rigPath)
+	if err != nil {
+		t.Fatalf("LoadRigConfig after enable: %v", err)
+	}
+	if got.RefineryDisabled {
+		t.Error("RefineryDisabled should be false after SetRefineryDisabled(false)")
+	}
+}

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -106,6 +106,11 @@ type RigConfig struct {
 	CreatedAt     time.Time    `json:"created_at"`               // when rig was created
 	Beads         *BeadsConfig `json:"beads,omitempty"`
 
+	// RefineryDisabled persistently disables the refinery for this rig.
+	// When true, gt refinery start is a no-op (returns ErrRefineryDisabled).
+	// The witness remains operational. Use gt refinery enable to clear.
+	RefineryDisabled bool `json:"refinery_disabled,omitempty"`
+
 	// Persistent polecat pool configuration.
 	// PolecatPoolSize is the number of persistent polecats to create with pool init.
 	// PolecatNames optionally specifies fixed names (overrides theme-based naming).
@@ -1064,6 +1069,22 @@ func LoadRigConfig(rigPath string) (*RigConfig, error) {
 	}
 	warnDeprecatedRigConfigKeys(data, configPath)
 	return &cfg, nil
+}
+
+// SetRefineryDisabled sets the refinery_disabled flag in a rig's config.json.
+// When disabled is true, gt refinery start returns ErrRefineryDisabled for that rig.
+func SetRefineryDisabled(rigPath string, disabled bool) error {
+	cfg, err := LoadRigConfig(rigPath)
+	if err != nil {
+		return fmt.Errorf("loading rig config: %w", err)
+	}
+	cfg.RefineryDisabled = disabled
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return err
+	}
+	configPath := filepath.Join(rigPath, "config.json")
+	return os.WriteFile(configPath, data, 0644)
 }
 
 // warnDeprecatedRigConfigKeys detects merge_queue keys in rig root config.json

--- a/internal/templates/roles/crew.md.tmpl
+++ b/internal/templates/roles/crew.md.tmpl
@@ -244,8 +244,37 @@ Mail beads can be hooked for ad-hoc instruction handoff:
 If you find mail on your hook (not a molecule), GUPP applies: read the mail
 content, interpret the prose instructions, and execute them.
 
-## Git Workflow: Work Off Main
+## Git Workflow{{ if .IsForkRig }}: Fork Rig — Branch → PR to Upstream{{ else }}: Work Off Main{{ end }}
 
+{{ if .IsForkRig -}}
+> ⚠️ **This is a fork rig.** Upstream: `{{ .UpstreamURL }}`
+>
+> **DO NOT push directly to fork main.** That pollutes fork↔upstream fast-forward sync.
+> The refinery is disabled for this rig by design.
+
+**Correct workflow for crew in a fork rig:**
+
+1. Create a feature branch from upstream/{{ .DefaultBranch }}:
+   ```bash
+   git fetch upstream
+   git checkout -b feat/description upstream/{{ .DefaultBranch }}
+   ```
+2. Do your work, commit atomically
+3. Push the branch to your fork:
+   ```bash
+   git push origin feat/description
+   ```
+4. Open a PR to the upstream repo:
+   ```bash
+   gh pr create --repo {{ .UpstreamURL }} --title "..." --body "..."
+   ```
+5. Monitor CI and review; address feedback on the same branch
+6. When the PR is approved and CI passes: `{{ cmd }} done`
+
+**No PRs from fork main.** Always create a dedicated feature branch — PRs from
+main accumulate ALL commits pushed to your fork and can't be targeted to one change.
+
+{{ else -}}
 **Crew workers push directly to main. No feature branches.**
 
 ### No PRs in Maintainer Repos
@@ -279,6 +308,7 @@ git push                    # Direct to main
 ```
 
 If push fails (someone else pushed): `git pull --rebase && git push`
+{{ end -}}
 
 ### Fix-Merging Community PRs
 

--- a/internal/templates/roles/polecat.md.tmpl
+++ b/internal/templates/roles/polecat.md.tmpl
@@ -9,6 +9,32 @@
 The instant your work is done, you run `{{ cmd }} done`. **There is no approval step.
 There is no confirmation.**
 
+{{ if .IsForkRig -}}
+> ⚠️ **This is a fork rig.** Upstream: `{{ .UpstreamURL }}`
+>
+> The refinery is disabled. Your workflow is: **branch → push to fork → PR to upstream**.
+
+**Fork rig workflow:**
+
+1. Work on a feature branch (already created when you were slunged)
+2. Commit your changes
+3. Push the branch to the fork origin:
+   ```bash
+   git push origin <your-branch>
+   ```
+4. Open a PR to the upstream repo:
+   ```bash
+   gh pr create --repo {{ .UpstreamURL }} --title "..." --body "..."
+   ```
+5. Monitor CI and review; address feedback on the same branch
+6. When the PR is approved and CI passes: `{{ cmd }} done`
+
+**DO NOT:**
+- Push directly to fork main (`git push origin {{ .DefaultBranch }}` — WRONG)
+- Start or restart the refinery (it is disabled for this rig)
+- Merge your own PR (the upstream maintainer does that)
+
+{{ else -}}
 **Two workflow types:**
 
 **1. Merge Queue Workflow (gastown, beads repos):**
@@ -26,6 +52,7 @@ There is no confirmation.**
 - Push directly to main (`git push origin main` — WRONG)
 - Merge their own PRs (maintainer or Refinery does this)
 - Wait around after running `{{ cmd }} done`
+{{ end -}}
 
 **If you have finished your implementation work, your ONLY next action is:**
 ```bash

--- a/internal/templates/templates.go
+++ b/internal/templates/templates.go
@@ -69,6 +69,8 @@ type RoleData struct {
 	IssuePrefix    string   // beads issue prefix
 	MayorSession   string   // e.g., "gt-ai-mayor" - dynamic mayor session name
 	DeaconSession  string   // e.g., "gt-ai-deacon" - dynamic deacon session name
+	IsForkRig      bool     // true when upstream_url != "" (rig is a fork of an upstream)
+	UpstreamURL    string   // upstream repo URL when IsForkRig is true
 }
 
 // SpawnData contains information for spawn assignment messages.


### PR DESCRIPTION
## Summary

Fixes #3735: sessions started via `deacon.Manager`, `mayor.Manager.StartTMUX`, and `boot.spawnTmux` were idle at the prompt when using a promptless runtime (`prompt_mode: none`, e.g. Codex), because `BuildCommandWithPrompt` drops the startup prompt for these runtimes and none of these three paths called the runtime fallback layer.

- `witness` and `refinery` already call `runtime.RunStartupFallback` + `runtime.DeliverStartupPromptFallback` after session startup — this PR applies the same pattern to the three missing paths
- For `deacon.Manager`, the tmux interface is narrowed (`tmuxOps`), so a type assertion to `*tmux.Tmux` is used (matching the existing pattern for `session.TrackSessionPID`)
- For `mayor.Manager.StartTMUX` and `boot.spawnTmux`, the `StartResult.RuntimeConfig` returned by `session.StartSession` is used (the field is documented as being for exactly this purpose)

## Test plan

- [x] `go build ./internal/deacon/... ./internal/mayor/... ./internal/boot/...` — clean
- [x] `go test ./internal/deacon/... ./internal/mayor/... ./internal/boot/...` — all pass
- [x] `go vet ./internal/deacon/... ./internal/mayor/... ./internal/boot/...` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)