### PR TITLE
Fix routed convoy tracked issue details

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -2483,7 +2483,9 @@ func (d issueDetails) IsBlocked() bool {
 	return false
 }
 
-// getIssueDetailsBatch fetches details for multiple issues in a single bd show call.
+// getIssueDetailsBatch fetches details for multiple issues via bd show.
+// IDs are grouped by resolved bead directory so each batch query runs against
+// the correct rig database for that prefix.
 // Returns a map from issue ID to details. Missing/invalid issues are omitted from the map.
 func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 	result := make(map[string]*issueDetails)
@@ -2491,36 +2493,42 @@ func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 		return result
 	}
 
-	// Build args: bd show id1 id2 id3 ... --json
-	args := append([]string{"show"}, issueIDs...)
-	args = append(args, "--json")
-
-	// Run from town root so bd's prefix routing (routes.jsonl) can dispatch
-	// to the correct rig database for cross-rig bead lookups. (GH#2960)
-	townRoot, _ := workspace.FindFromCwdOrError()
-	bdc := BdCmd(args...).Stderr(io.Discard)
-	if townRoot != "" {
-		bdc.Dir(townRoot).WithRouting()
+	// Group by routing directory so each bd show batch runs in the owning rig.
+	idsByDir := make(map[string][]string)
+	for _, id := range issueIDs {
+		dir := resolveBeadDir(id)
+		idsByDir[dir] = append(idsByDir[dir], id)
 	}
-	out, err := bdc.Output()
-	if err != nil {
-		// Batch failed - fall back to individual lookups for robustness
-		// This handles cases where some IDs are invalid/missing
-		for _, id := range issueIDs {
-			if details := getIssueDetails(id); details != nil {
-				result[id] = details
-			}
+
+	for dir, ids := range idsByDir {
+		// Build args: bd show id1 id2 ... --json
+		args := append([]string{"show"}, ids...)
+		args = append(args, "--json")
+
+		bdc := BdCmd(args...).Stderr(io.Discard)
+		if dir != "" && dir != "." {
+			bdc.Dir(dir).WithRouting()
 		}
-		return result
-	}
 
-	var issues []issueDetailsJSON
-	if err := json.Unmarshal(out, &issues); err != nil {
-		return result
-	}
+		out, err := bdc.Output()
+		if err != nil {
+			// Batch failed for this route - fall back to individual lookups.
+			for _, id := range ids {
+				if details := getIssueDetails(id); details != nil {
+					result[id] = details
+				}
+			}
+			continue
+		}
 
-	for _, issue := range issues {
-		result[issue.ID] = issue.toIssueDetails()
+		var issues []issueDetailsJSON
+		if err := json.Unmarshal(out, &issues); err != nil {
+			continue
+		}
+
+		for _, issue := range issues {
+			result[issue.ID] = issue.toIssueDetails()
+		}
 	}
 
 	return result
@@ -2529,14 +2537,10 @@ func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 // getIssueDetails fetches issue details by trying to show it via bd.
 // Prefer getIssueDetailsBatch for multiple issues to avoid N+1 subprocess calls.
 func getIssueDetails(issueID string) *issueDetails {
-	// Use bd show with routing - resolve from town root so bd's prefix
-	// routing (routes.jsonl) can dispatch to the correct rig database.
-	// Without Dir + StripBeadsDir, bd inherits CWD/BEADS_DIR which may
-	// point to a rig that doesn't contain the target bead. (GH#2960)
-	townRoot, _ := workspace.FindFromCwdOrError()
 	bdc := BdCmd("show", issueID, "--json").Stderr(io.Discard)
-	if townRoot != "" {
-		bdc.Dir(townRoot).WithRouting()
+	// Route directly to the bead's owning rig database.
+	if dir := resolveBeadDir(issueID); dir != "" && dir != "." {
+		bdc.Dir(dir).WithRouting()
 	}
 	out, err := bdc.Output()
 	if err != nil {

--- a/internal/cmd/convoy_bd_routing_test.go
+++ b/internal/cmd/convoy_bd_routing_test.go
@@ -215,6 +215,92 @@ esac
 	}
 }
 
+func TestGetTrackedIssues_RoutesShowByPrefix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	townRoot, expectedTownWD := makeRoutingTownWorkspace(t)
+	chdirConvoyTest(t, townRoot)
+	t.Setenv("BEADS_DIR", "/wrong/.beads")
+
+	routes := `{"prefix":"hq-","path":"."}
+{"prefix":"ws-","path":"worker/.beads"}
+`
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "worker", ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir worker/.beads: %v", err)
+	}
+
+	expectedWorkerWD := filepath.Join(expectedTownWD, "worker")
+
+	scriptBody := fmt.Sprintf(`
+if [ "$*" = "--allow-stale version" ]; then
+  exit 0
+fi
+
+case "$1" in
+  sql)
+    echo '[{"depends_on_id":"ws-123"},{"depends_on_id":"hq-456"}]'
+    exit 0
+    ;;
+  show)
+    if [ -n "$BEADS_DIR" ]; then
+      echo "BEADS_DIR leaked: $BEADS_DIR" >&2
+      exit 1
+    fi
+    case "$*" in
+      "show ws-123 hq-456 --json"|"show hq-456 ws-123 --json")
+        echo "mixed-prefix batch not supported" >&2
+        exit 1
+        ;;
+      "show ws-123 --json")
+        if [ "$PWD" != "%s" ]; then
+          echo "expected worker dir, got $PWD" >&2
+          exit 1
+        fi
+        echo '[{"id":"ws-123","title":"Worker issue","status":"open","issue_type":"task"}]'
+        exit 0
+        ;;
+      "show hq-456 --json")
+        if [ "$PWD" != "%s" ]; then
+          echo "expected town root, got $PWD" >&2
+          exit 1
+        fi
+        echo '[{"id":"hq-456","title":"Town issue","status":"closed","issue_type":"task"}]'
+        exit 0
+        ;;
+    esac
+    ;;
+esac
+
+echo "unexpected bd args: $*" >&2
+exit 1
+`, expectedWorkerWD, expectedTownWD)
+	writeRoutingBdStub(t, scriptBody)
+
+	tracked, err := getTrackedIssues(filepath.Join(townRoot, ".beads"), "hq-cv-route")
+	if err != nil {
+		t.Fatalf("getTrackedIssues: %v", err)
+	}
+	if len(tracked) != 2 {
+		t.Fatalf("expected 2 tracked issues, got %d: %#v", len(tracked), tracked)
+	}
+
+	statusByID := map[string]string{}
+	for _, item := range tracked {
+		statusByID[item.ID] = item.Status
+	}
+	if statusByID["ws-123"] != "open" {
+		t.Fatalf("ws-123 status = %q, want %q", statusByID["ws-123"], "open")
+	}
+	if statusByID["hq-456"] != "closed" {
+		t.Fatalf("hq-456 status = %q, want %q", statusByID["hq-456"], "closed")
+	}
+}
+
 // TestConvoyCreate_UsesTrackingHelper verifies convoy create delegates tracking
 // to the in-process helper instead of shelling out to `bd dep add`.
 func TestConvoyCreate_UsesTrackingHelper(t *testing.T) {

--- a/internal/cmd/convoy_external_tracking_test.go
+++ b/internal/cmd/convoy_external_tracking_test.go
@@ -169,6 +169,149 @@ esac
 	}
 }
 
+func TestGetIssueDetailsBatchRoutesTrackedIDsByPrefix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	townRoot, _, expectedTownWD := makeExternalTrackingTownWorkspace(t)
+	rigDir := filepath.Join(townRoot, "worker", "mayor", "rig")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir rig beads: %v", err)
+	}
+	routes := `{"prefix":"hq-","path":"."}
+{"prefix":"ws-","path":"worker/mayor/rig"}
+`
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+	chdirExternalTrackingTest(t, townRoot)
+
+	expectedRigWD := rigDir
+	if resolved, err := filepath.EvalSymlinks(rigDir); err == nil && resolved != "" {
+		expectedRigWD = resolved
+	}
+	scriptBody := fmt.Sprintf(`
+case "$PWD|$*" in
+  %q)
+    echo '[{"id":"hq-town","title":"Town task","status":"open","issue_type":"task"}]'
+    ;;
+  %q)
+    echo '[{"id":"ws-rig","title":"Rig task","status":"closed","issue_type":"task"}]'
+    ;;
+  *)
+    echo "unexpected bd cwd/args: $PWD|$*" >&2
+    exit 1
+    ;;
+esac
+`, expectedTownWD+"|show hq-town --json", expectedRigWD+"|show ws-rig --json")
+	writeExternalTrackingBdStub(t, scriptBody)
+
+	got := getIssueDetailsBatch([]string{"hq-town", "ws-rig"})
+	if got["hq-town"] == nil || got["hq-town"].Status != "open" {
+		t.Fatalf("town detail not resolved through town route: %#v", got["hq-town"])
+	}
+	if got["ws-rig"] == nil || got["ws-rig"].Status != "closed" {
+		t.Fatalf("rig detail not resolved through rig route: %#v", got["ws-rig"])
+	}
+}
+
+func TestGetIssueDetailsBatchEmptyInput(t *testing.T) {
+	got := getIssueDetailsBatch(nil)
+	if len(got) != 0 {
+		t.Fatalf("expected empty result, got %#v", got)
+	}
+}
+
+func TestGetIssueDetailsBatchFallsBackThroughRoutedSingleLookup(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	townRoot, _, _ := makeExternalTrackingTownWorkspace(t)
+	rigDir := filepath.Join(townRoot, "worker", "mayor", "rig")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir rig beads: %v", err)
+	}
+	routes := `{"prefix":"ws-","path":"worker/mayor/rig"}
+`
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+	chdirExternalTrackingTest(t, townRoot)
+
+	expectedRigWD := rigDir
+	if resolved, err := filepath.EvalSymlinks(rigDir); err == nil && resolved != "" {
+		expectedRigWD = resolved
+	}
+	scriptBody := fmt.Sprintf(`
+case "$PWD|$*" in
+  %q)
+    echo "batch lookup failed" >&2
+    exit 1
+    ;;
+  %q)
+    echo '[{"id":"ws-one","title":"Recovered via fallback","status":"open","issue_type":"task"}]'
+    ;;
+  %q)
+    echo "missing issue" >&2
+    exit 1
+    ;;
+  *)
+    echo "unexpected bd cwd/args: $PWD|$*" >&2
+    exit 1
+    ;;
+esac
+`, expectedRigWD+"|show ws-one ws-missing --json", expectedRigWD+"|show ws-one --json", expectedRigWD+"|show ws-missing --json")
+	writeExternalTrackingBdStub(t, scriptBody)
+
+	got := getIssueDetailsBatch([]string{"ws-one", "ws-missing"})
+	if got["ws-one"] == nil || got["ws-one"].Status != "open" {
+		t.Fatalf("fallback detail not resolved through rig route: %#v", got["ws-one"])
+	}
+	if got["ws-missing"] != nil {
+		t.Fatalf("missing detail should be omitted, got %#v", got["ws-missing"])
+	}
+}
+
+func TestGetIssueDetailsSkipsUnusableBdOutput(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	townRoot, _, expectedTownWD := makeExternalTrackingTownWorkspace(t)
+	chdirExternalTrackingTest(t, townRoot)
+
+	scriptBody := fmt.Sprintf(`
+case "$PWD|$*" in
+  %q)
+    exit 0
+    ;;
+  %q)
+    echo 'not json'
+    ;;
+  %q)
+    echo 'not json'
+    ;;
+  *)
+    echo "unexpected bd cwd/args: $PWD|$*" >&2
+    exit 1
+    ;;
+esac
+`, expectedTownWD+"|show hq-empty --json", expectedTownWD+"|show hq-invalid --json", expectedTownWD+"|show hq-bad-batch --json")
+	writeExternalTrackingBdStub(t, scriptBody)
+
+	if got := getIssueDetails("hq-empty"); got != nil {
+		t.Fatalf("empty detail output should return nil, got %#v", got)
+	}
+	if got := getIssueDetails("hq-invalid"); got != nil {
+		t.Fatalf("invalid detail output should return nil, got %#v", got)
+	}
+	if got := getIssueDetailsBatch([]string{"hq-bad-batch"}); len(got) != 0 {
+		t.Fatalf("invalid batch output should be omitted, got %#v", got)
+	}
+}
+
 // TestCloseConvoyIfComplete_UnknownBlocksAutoClose verifies (gt-bs6) that an
 // unknown-status tracked bead prevents convoy auto-close. The rig DB being
 // temporarily unreachable must not be mistaken for a completed bead.


### PR DESCRIPTION
## Summary

Fix convoy tracked issue detail lookups so routed cross-rig children are resolved from the bead prefix owner directory instead of batching every `bd show` from the town root.

This keeps `gt convoy status` / tracked issue rendering from reporting routable rig-owned work as `unknown` when a convoy tracks work across multiple bead databases.

## Scope

- Groups tracked issue detail lookups by `resolveBeadDir(<id>)` before shelling out to `bd show`.
- Keeps town-root `hq-*` lookups working.
- Adds focused regression coverage for mixed town/rig tracked IDs and direct detail batch routing.

## Why This Is General Gastown Behavior

This is not tied to any specific rig or downstream integration. It fixes the general multi-rig convoy contract: if `routes.jsonl` maps a prefix to a rig, convoy tracking/status should use that route when refreshing tracked child details.

## Validation

- `mise x go@1.25.9 -- go test ./internal/cmd -run 'TestGetTrackedIssues_RoutesShowByPrefix|TestGetIssueDetailsBatchRoutesTrackedIDsByPrefix|TestGetTrackedIssues_UnknownStatusForUnreachableCrossRig|TestGetTrackedIssues_FallsBackToShowTrackedDependencies|TestCloseConvoyIfComplete_UnknownBlocksAutoClose'`
- `mise x go@1.25.9 -- go test ./internal/convoy ./internal/web`
- `mise x go@1.25.9 -- go build -o /tmp/agents/bd-m05ta/gastown/gt ./cmd/gt`
- Local coverage profile now reports `getIssueDetailsBatch` and `getIssueDetails` at 100% for the focused routed-detail tests.
- Codecov: all modified and coverable lines are covered by tests.
- GitHub CI is green on the latest head: Test, Lint, Integration Tests, Windows Smoke Test.

## Local Multi-Rig Smoke

Fresh two-wave routed convoy confidence fixture:

- Convoy: `hq-cv-uttdz`
- Routed children: `bds-e28db0d167e8`, `bds-35d71a1f80a0`
- Patched `gt convoy status hq-cv-uttdz --json` resolved both routed children with titles/statuses instead of `unknown`.
- Launch dispatched wave 1.
- Closing wave 1 triggered daemon feed for wave 2.
- Closing wave 2 auto-closed the convoy at `2/2`.

A first local smoke also completed the same path with convoy `hq-cv-7rg9b`. That run exposed a local runtime hygiene issue where a legacy rig missing its identity bead was treated as non-operational; after the rig identity bead existed, the convoy path completed end-to-end. The code change here remains scoped to routed tracked issue detail resolution.

Agent: codex
Feature-Key: bd-m05ta
