### PR TITLE
fix(release): age-gate npm self-update before publish

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -251,7 +251,7 @@ jobs:
           registry-url: 'https://registry.npmjs.org'
 
       - name: Update npm for provenance support
-        run: npm install -g npm@latest
+        run: npm install -g npm@latest --min-release-age=7
 
       - name: Publish to npm
         run: |


### PR DESCRIPTION
## Summary

Add `--min-release-age=7` to the release workflow's npm self-update step before publishing the npm package.

## Why

The `publish-npm` job updates npm from the public registry immediately before `npm publish --provenance`. Using npm's release-age gate avoids selecting a very fresh npm release in this privileged publish job while preserving the existing workflow behavior.

## Change

```diff
-npm install -g npm@latest
+npm install -g npm@latest --min-release-age=7
```

## Verification

- `git diff --check`
- Verified npm accepts `--min-release-age=7` with a dry-run install through a temporary prefix.
