### PR TITLE
fix: A few bugs I found with proposed fixes

### DIFF
--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -168,7 +168,7 @@ func DefaultWebTimeoutsConfig() *WebTimeoutsConfig {
 // WorkerStatusConfig configures activity-age thresholds for worker status classification.
 type WorkerStatusConfig struct {
 	// StaleThreshold is the activity age after which a worker is considered "stale".
-	// Default: "5m".
+	// Default: "15m".
 	StaleThreshold string `json:"stale_threshold,omitempty"`
 	// StuckThreshold is the activity age after which a worker is considered "stuck".
 	// Default: "30m".
@@ -184,7 +184,7 @@ type WorkerStatusConfig struct {
 // DefaultWorkerStatusConfig returns a WorkerStatusConfig with sensible defaults.
 func DefaultWorkerStatusConfig() *WorkerStatusConfig {
 	return &WorkerStatusConfig{
-		StaleThreshold:          "5m",
+		StaleThreshold:          "15m",
 		StuckThreshold:          "30m",
 		HeartbeatFreshThreshold: "5m",
 		MayorActiveThreshold:    "5m",

--- a/internal/config/types_test.go
+++ b/internal/config/types_test.go
@@ -89,8 +89,8 @@ func TestDefaultWorkerStatusConfig(t *testing.T) {
 	}
 
 	stale := ParseDurationOrDefault(cfg.StaleThreshold, 0)
-	if stale != 5*time.Minute {
-		t.Errorf("StaleThreshold = %v, want 5m", stale)
+	if stale != 15*time.Minute {
+		t.Errorf("StaleThreshold = %v, want 15m", stale)
 	}
 	stuck := ParseDurationOrDefault(cfg.StuckThreshold, 0)
 	if stuck != 30*time.Minute {

--- a/internal/web/fetcher.go
+++ b/internal/web/fetcher.go
@@ -222,7 +222,7 @@ func NewLiveConvoyFetcher() (*LiveConvoyFetcher, error) {
 		cmdTimeout:              config.ParseDurationOrDefault(webCfg.CmdTimeout, 15*time.Second),
 		ghCmdTimeout:            config.ParseDurationOrDefault(webCfg.GhCmdTimeout, 10*time.Second),
 		tmuxCmdTimeout:          config.ParseDurationOrDefault(webCfg.TmuxCmdTimeout, 2*time.Second),
-		staleThreshold:          config.ParseDurationOrDefault(workerCfg.StaleThreshold, 5*time.Minute),
+		staleThreshold:          config.ParseDurationOrDefault(workerCfg.StaleThreshold, 15*time.Minute),
 		stuckThreshold:          config.ParseDurationOrDefault(workerCfg.StuckThreshold, constants.GUPPViolationTimeout),
 		heartbeatFreshThreshold: config.ParseDurationOrDefault(workerCfg.HeartbeatFreshThreshold, 5*time.Minute),
 		mayorActiveThreshold:    config.ParseDurationOrDefault(workerCfg.MayorActiveThreshold, 5*time.Minute),
@@ -953,8 +953,9 @@ type assignedIssue struct {
 func (f *LiveConvoyFetcher) getAssignedIssuesMap() map[string]assignedIssue {
 	result := make(map[string]assignedIssue)
 
-	// Query all in_progress issues (these are the ones being worked on)
-	stdout, err := f.runBdCmd(f.townRoot, "list", "--status=in_progress", "--json")
+	// Query in_progress and hooked issues — hooked is the initial state when an issue
+	// is assigned to an agent but before it begins active processing.
+	stdout, err := f.runBdCmd(f.townRoot, "list", "--status=in_progress,hooked", "--json")
 	if err != nil {
 		log.Printf("warning: bd list in_progress failed: %v", err)
 		return result

--- a/internal/web/fetcher_test.go
+++ b/internal/web/fetcher_test.go
@@ -347,7 +347,7 @@ func TestParseActivityTimestamp(t *testing.T) {
 // --- calculateWorkerWorkStatus with configurable thresholds ---
 
 func TestCalculateWorkerWorkStatus_DefaultThresholds(t *testing.T) {
-	stale := 5 * time.Minute
+	stale := 15 * time.Minute
 	stuck := 30 * time.Minute
 
 	tests := []struct {
@@ -364,7 +364,7 @@ func TestCalculateWorkerWorkStatus_DefaultThresholds(t *testing.T) {
 		{"very recent is working", 1 * time.Second, "gt-123", "dag", "working"},
 		{"just under stale is working", stale - 1*time.Second, "gt-123", "dag", "working"},
 		{"at stale boundary is stale", stale, "gt-123", "dag", "stale"},
-		{"between stale and stuck is stale", 15 * time.Minute, "gt-123", "dag", "stale"},
+		{"between stale and stuck is stale", 20 * time.Minute, "gt-123", "dag", "stale"},
 		{"just under stuck is stale", stuck - 1*time.Second, "gt-123", "dag", "stale"},
 		{"at stuck boundary is stuck", stuck, "gt-123", "dag", "stuck"},
 		{"well past stuck is stuck", 2 * time.Hour, "gt-123", "dag", "stuck"},


### PR DESCRIPTION
## Summary

- Include `hooked` status alongside `in_progress` in `getAssignedIssuesMap` so newly-assigned polecats appear in the dashboard immediately after being slung, not only after they begin active work
- Raise the default `StaleThreshold` from 5 minutes to 15 minutes to prevent false stale warnings during normal LLM agent operation (reasoning, tool calls, large codebase processing)

## Changes

- `internal/config/types.go` — bump `StaleThreshold` default comment and value: `"5m"` → `"15m"`
- `internal/web/fetcher.go` — add `hooked` to bd list status filter; update staleThreshold fallback to 15m
- `internal/config/types_test.go`, `internal/web/fetcher_test.go` — update tests to reflect new threshold

## Testing

- [x] `go build ./...` passes
- [x] `go test ./internal/config ./internal/web -timeout 2m` passes
- [x] `go vet ./...` passes

Closes #3828