### PR TITLE
fix: wisp_reaper: dispatches mol-dog-reaper to dog group with no idle-dog precheck and no TTL on hooked mols

### DIFF
--- a/internal/daemon/wisp_reaper.go
+++ b/internal/daemon/wisp_reaper.go
@@ -2,7 +2,9 @@ package daemon
 
 import (
 	"fmt"
+	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -26,6 +28,10 @@ const (
 	defaultMailDeleteAge = 7 * 24 * time.Hour
 	// Issues stale longer than this are auto-closed. Formula var: stale_issue_age.
 	defaultStaleIssueAge = 7 * 24 * time.Hour
+	// defaultHookedMolTTL is the short TTL for closing stale hooked dispatch mols
+	// (mol-dog-* wisps in 'hooked' status that no dog consumed). Two reaper cycles
+	// gives a running dog time to pick up the mol; beyond that it is an orphan.
+	defaultHookedMolTTL = 2 * time.Hour
 )
 
 // WispReaperConfig holds configuration for the wisp_reaper patrol.
@@ -111,6 +117,15 @@ func (d *Daemon) reapWisps() {
 		d.logger.Printf("wisp_reaper: DRY RUN — reporting only, no changes will be made")
 	}
 
+	// Guard: skip Dog dispatch if no dog sessions are running. gt sling creates
+	// a hooked bead that sits orphaned forever if no dog consumes it. Running
+	// inline avoids the accumulation of phantom dispatch wisps. GH#3767.
+	if !d.kennelHasRunningDogs() {
+		d.logger.Printf("wisp_reaper: no dog sessions running, running inline")
+		d.reapWispsInline(config, maxAge, deleteAge, mol)
+		return
+	}
+
 	// Try dispatching to a Dog for formula-driven execution.
 	if err := d.dispatchReaperDog(vars); err != nil {
 		d.logger.Printf("wisp_reaper: Dog dispatch failed (%v), running inline fallback", err)
@@ -119,6 +134,33 @@ func (d *Daemon) reapWisps() {
 	}
 
 	d.logger.Printf("wisp_reaper: dispatched to Dog for formula-driven execution")
+}
+
+// kennelHasRunningDogs returns true if at least one dog tmux session is running.
+// Dogs run as tmux sessions named "hq-dog-{name}". The check is a lightweight
+// filesystem + tmux scan that avoids dispatching to a phantom group address
+// when the kennel is empty or all sessions are dead. See: GH#3767.
+func (d *Daemon) kennelHasRunningDogs() bool {
+	kennelPath := filepath.Join(d.config.TownRoot, "deacon", "dogs")
+	entries, err := os.ReadDir(kennelPath)
+	if err != nil || len(entries) == 0 {
+		return false
+	}
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		// Only count valid dogs (those with a .dog.json state file).
+		stateFile := filepath.Join(kennelPath, entry.Name(), ".dog.json")
+		if _, err := os.Stat(stateFile); os.IsNotExist(err) {
+			continue
+		}
+		sessionName := fmt.Sprintf("hq-dog-%s", entry.Name())
+		if running, err := d.tmux.HasSession(sessionName); err == nil && running {
+			return true
+		}
+	}
+	return false
 }
 
 // dispatchReaperDog dispatches the mol-dog-reaper formula to a Dog via gt sling.
@@ -285,6 +327,33 @@ func (d *Daemon) reapWispsInline(config *WispReaperConfig, maxAge, deleteAge tim
 		}
 	}
 
+	// Step 3d: Close stale hooked mols — dispatch wisps that sat in 'hooked'
+	// status beyond defaultHookedMolTTL because no dog was alive to consume them.
+	var totalHookedClosed int
+	for _, dbName := range databases {
+		if err := reaper.ValidateDBName(dbName); err != nil {
+			continue
+		}
+		db, err := reaper.OpenDB("127.0.0.1", port, dbName, 10*time.Second, 10*time.Second)
+		if err != nil {
+			continue
+		}
+		if ok, _ := reaper.HasReaperSchema(db); !ok {
+			db.Close()
+			continue
+		}
+		result, err := reaper.CloseStaleHookedMols(db, dbName, defaultHookedMolTTL, dryRun)
+		db.Close()
+		if err != nil {
+			d.logger.Printf("wisp_reaper: %s: hooked mol close error: %v", dbName, err)
+			continue
+		}
+		totalHookedClosed += result.Closed
+		if result.Closed > 0 {
+			d.logger.Printf("wisp_reaper: %s: closed %d stale hooked mols", dbName, result.Closed)
+		}
+	}
+
 	// Step 4: Auto-close
 	autoCloseErrors := 0
 	for _, dbName := range databases {
@@ -322,8 +391,8 @@ func (d *Daemon) reapWispsInline(config *WispReaperConfig, maxAge, deleteAge tim
 		d.logger.Printf("wisp_reaper: WARNING: %d open wisps exceed threshold %d — investigate wisp lifecycle",
 			totalOpen, wispAlertThreshold)
 	}
-	d.logger.Printf("wisp_reaper: cycle complete — reaped=%d purged=%d mail_purged=%d plugin_closed=%d dispatch_closed=%d auto_closed=%d open=%d databases=%d dryRun=%v",
-		totalReaped, totalPurged, totalMailPurged, totalPluginClosed, totalDispatchClosed, totalAutoClosed, totalOpen, len(databases), dryRun)
+	d.logger.Printf("wisp_reaper: cycle complete — reaped=%d purged=%d mail_purged=%d plugin_closed=%d dispatch_closed=%d hooked_closed=%d auto_closed=%d open=%d databases=%d dryRun=%v",
+		totalReaped, totalPurged, totalMailPurged, totalPluginClosed, totalDispatchClosed, totalHookedClosed, totalAutoClosed, totalOpen, len(databases), dryRun)
 	mol.closeStep("report")
 }
 

--- a/internal/daemon/wisp_reaper_test.go
+++ b/internal/daemon/wisp_reaper_test.go
@@ -1,6 +1,7 @@
 package daemon
 
 import (
+	"os"
 	"testing"
 	"time"
 )
@@ -71,5 +72,42 @@ func TestDefaultReaperIntervalIsOneHour(t *testing.T) {
 	// Verify the default changed from 30m to 1h per issue gt-caf7.
 	if defaultWispReaperInterval != 1*time.Hour {
 		t.Errorf("expected default interval 1h, got %v", defaultWispReaperInterval)
+	}
+}
+
+func TestDefaultHookedMolTTLIsGreaterThanInterval(t *testing.T) {
+	// TTL must be at least one full reaper cycle so a running dog has time to
+	// pick up the dispatch wisp before it is closed as orphaned. GH#3767.
+	if defaultHookedMolTTL <= defaultWispReaperInterval {
+		t.Errorf("defaultHookedMolTTL (%v) must exceed defaultWispReaperInterval (%v)",
+			defaultHookedMolTTL, defaultWispReaperInterval)
+	}
+}
+
+func TestKennelHasRunningDogsEmptyKennel(t *testing.T) {
+	// An empty or missing kennel dir must return false without panicking.
+	d := &Daemon{
+		config: &Config{TownRoot: t.TempDir()},
+		tmux:   nil, // no tmux needed — kennel dir check is first
+	}
+	if d.kennelHasRunningDogs() {
+		t.Error("expected false for missing kennel dir")
+	}
+}
+
+func TestKennelHasRunningDogsNoValidDogs(t *testing.T) {
+	// A kennel dir with subdirs that have no .dog.json must return false.
+	dir := t.TempDir()
+	kennelPath := dir + "/deacon/dogs/alpha"
+	if err := os.MkdirAll(kennelPath, 0755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// No .dog.json in alpha/ — not a valid dog.
+	d := &Daemon{
+		config: &Config{TownRoot: dir},
+		tmux:   nil,
+	}
+	if d.kennelHasRunningDogs() {
+		t.Error("expected false when no valid dog state files exist")
 	}
 }

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -944,6 +944,87 @@ func ClosePluginDispatches(db *sql.DB, dbName string, maxAge time.Duration, dryR
 	return result, nil
 }
 
+// CloseStaleHookedMols closes wisps that have been in 'hooked' status for
+// longer than maxAge. These are dispatch wisps created by gt sling targeting
+// the dog group (deacon/dogs) that were never consumed because no dog session
+// was running. The title filter "mol-dog-%" scopes cleanup to daemon-dispatch
+// mols without touching user-created hooked beads. The standard Reap() path
+// also reaps hooked wisps but only after 24h; this shorter TTL prevents
+// orphan accumulation between reaper cycles. See: GH#3767.
+func CloseStaleHookedMols(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ClosePluginReceiptResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
+	defer cancel()
+
+	cutoff := time.Now().UTC().Add(-maxAge)
+	result := &ClosePluginReceiptResult{Database: dbName, DryRun: dryRun}
+
+	selectQuery := fmt.Sprintf(
+		"SELECT id FROM `%s`.wisps WHERE status = 'hooked' AND title LIKE 'mol-dog-%%' AND issue_type != 'agent' AND created_at < ?",
+		dbName)
+
+	rows, err := db.QueryContext(ctx, selectQuery, cutoff)
+	if err != nil {
+		if isTableNotFound(err) {
+			return result, nil
+		}
+		return nil, fmt.Errorf("select stale hooked mols: %w", err)
+	}
+	var ids []string
+	for rows.Next() {
+		var id string
+		if err := rows.Scan(&id); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("scan hooked mol id: %w", err)
+		}
+		ids = append(ids, id)
+	}
+	rows.Close()
+
+	result.Closed = len(ids)
+	if len(ids) == 0 || dryRun {
+		return result, nil
+	}
+
+	if _, err := db.ExecContext(ctx, "SET @@autocommit = 0"); err != nil {
+		return nil, fmt.Errorf("disable autocommit: %w", err)
+	}
+	defer func() {
+		_, _ = db.ExecContext(context.Background(), "SET @@autocommit = 1")
+	}()
+
+	placeholders := make([]string, len(ids))
+	args := make([]interface{}, len(ids))
+	for i, id := range ids {
+		placeholders[i] = "?"
+		args[i] = id
+	}
+	updateQuery := fmt.Sprintf(
+		"UPDATE `%s`.wisps SET status = 'closed', closed_at = NOW() WHERE id IN (%s)",
+		dbName, strings.Join(placeholders, ","))
+	if _, err := db.ExecContext(ctx, updateQuery, args...); err != nil {
+		return nil, fmt.Errorf("close stale hooked mols: %w", err)
+	}
+
+	if _, err := db.ExecContext(ctx, "COMMIT"); err != nil {
+		result.Anomalies = append(result.Anomalies, Anomaly{
+			Type:    "sql_commit_failed",
+			Message: fmt.Sprintf("sql commit after hooked mol close failed: %v", err),
+		})
+		return result, nil
+	}
+	commitMsg := fmt.Sprintf("reaper: close %d stale hooked mols in %s", len(ids), dbName)
+	if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
+		if !isNothingToCommit(err) {
+			result.Anomalies = append(result.Anomalies, Anomaly{
+				Type:    "dolt_commit_failed",
+				Message: fmt.Sprintf("dolt commit after hooked mol close failed: %v", err),
+			})
+		}
+	}
+
+	return result, nil
+}
+
 // FormatJSON marshals any value to indented JSON.
 func FormatJSON(v interface{}) string {
 	data, err := json.MarshalIndent(v, "", "  ")

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -246,3 +246,36 @@ func TestScanExcludesAgentBeads(t *testing.T) {
 		t.Fatalf("expected Scan() eligibility to exclude agent beads, scan body was:\n%s", scanBody)
 	}
 }
+
+// TestCloseStaleHookedMolsQueryShape verifies that CloseStaleHookedMols targets
+// the wisps table with the correct status/title/agent filters. GH#3767.
+func TestCloseStaleHookedMolsQueryShape(t *testing.T) {
+	sourcePath := "reaper.go"
+	data, err := os.ReadFile(sourcePath)
+	if err != nil {
+		t.Fatalf("read %s: %v", sourcePath, err)
+	}
+	source := string(data)
+
+	funcStart := strings.Index(source, "func CloseStaleHookedMols(")
+	if funcStart == -1 {
+		t.Fatal("CloseStaleHookedMols not found in reaper.go")
+	}
+	// Isolate the function body up to the next top-level func declaration.
+	funcBody := source[funcStart:]
+	nextFunc := strings.Index(funcBody[1:], "\nfunc ")
+	if nextFunc != -1 {
+		funcBody = funcBody[:nextFunc+1]
+	}
+
+	for _, want := range []string{
+		"wisps",          // queries the wisps table, not issues
+		"status = 'hooked'",
+		"mol-dog-",       // title filter scopes to daemon dispatch mols
+		"issue_type != 'agent'",
+	} {
+		if !strings.Contains(funcBody, want) {
+			t.Errorf("CloseStaleHookedMols body missing %q", want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- Add `kennelHasRunningDogs()` guard to skip Dog dispatch when no dog tmux sessions are running, falling back to inline reaper execution
- Add `CloseStaleHookedMols()` in `internal/reaper/reaper.go` to purge dispatch wisps stuck in `hooked` status for >2h (orphaned by past dispatch attempts when no dog was alive)
- Add `defaultHookedMolTTL = 2h` constant (verified > `defaultWispReaperInterval` by test)

## Changes

- `internal/daemon/wisp_reaper.go`: `kennelHasRunningDogs()` scans `<townRoot>/deacon/dogs/` for dirs with a `.dog.json` state file and a live tmux session; runs inline if none found
- `internal/daemon/wisp_reaper.go`: Step 3d in `reapWispsInline` calls `CloseStaleHookedMols` for each database
- `internal/reaper/reaper.go`: `CloseStaleHookedMols` selects wisps with `status=hooked`, `title LIKE mol-dog-%`, older than TTL, and closes them
- `internal/daemon/wisp_reaper_test.go` + `internal/reaper/reaper_test.go`: unit tests for kennel check, TTL invariant, and query shape

## Testing

- [x] `go build ./...` passes
- [x] `go test ./internal/reaper/... -timeout 2m` passes (13 tests)
- [x] `go vet ./internal/reaper/...` passes

Closes #3767