### PR TITLE
fix: gt polecat prune --remote misses squash/rebase merges (uses IsAncestor instead of patch-equivalence)

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1779,13 +1779,23 @@ func runPolecatPrune(cmd *cobra.Command, args []string) error {
 				continue
 			}
 			branch := strings.TrimPrefix(ref.Name, "refs/heads/")
-			// Use the listed remote tip, not the short branch name, so remote-only
-			// branches can be classified without a local branch.
-			merged, mergeErr := repoGit.IsAncestor(ref.Hash, "origin/"+defaultBranch)
-			if mergeErr != nil {
+			// Use git cherry (patch-id comparison) instead of IsAncestor so that
+			// squash/rebase merges—where the SHA is rewritten—are also detected.
+			// "+" lines are unique commits not yet on upstream; zero means merged.
+			cherryOut, cherryErr := repoGit.Cherry("origin/"+defaultBranch, ref.Hash)
+			if cherryErr != nil {
 				continue
 			}
-			if !merged {
+			// Count "+" lines: patches not yet on upstream. "-" lines are squash/rebase
+			// equivalents; empty output means all commits are reachable ancestors.
+			// Both "-" and empty → unique==0 → branch is merged.
+			unique := 0
+			for _, line := range strings.Split(strings.TrimSpace(cherryOut), "\n") {
+				if strings.HasPrefix(line, "+ ") {
+					unique++
+				}
+			}
+			if unique > 0 {
 				continue
 			}
 

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -1067,6 +1067,124 @@ func TestListPushRemoteRefsWithHashesClassifiesRemoteOnlyMergedBranch(t *testing
 	}
 }
 
+func TestCherry_SquashMergedBranch(t *testing.T) {
+	localDir, _, mainBranch := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+	branch := "polecat/squash-merged"
+
+	runGit(t, localDir, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(localDir, "squash-work.txt"), []byte("work"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	runGit(t, localDir, "add", "squash-work.txt")
+	runGit(t, localDir, "commit", "-m", "squash work")
+	branchSHA, err := g.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev branch: %v", err)
+	}
+	runGit(t, localDir, "push", "origin", branch)
+
+	// Squash-merge into main: different SHA from the branch commit.
+	runGit(t, localDir, "checkout", mainBranch)
+	runGit(t, localDir, "merge", "--squash", branch)
+	runGit(t, localDir, "commit", "-m", "squash merge polecat/squash-merged")
+	runGit(t, localDir, "push", "origin", mainBranch)
+
+	// IsAncestor returns false for squash merges (SHA mismatch) — that's the bug.
+	isAncestor, ancestorErr := g.IsAncestor(branchSHA, "origin/"+mainBranch)
+	if ancestorErr != nil {
+		t.Fatalf("IsAncestor: %v", ancestorErr)
+	}
+	if isAncestor {
+		t.Fatal("test setup broken: IsAncestor returned true for a squash merge (expected false)")
+	}
+
+	// Cherry must report 0 unique commits — the fix for the bug.
+	out, cherryErr := g.Cherry("origin/"+mainBranch, branchSHA)
+	if cherryErr != nil {
+		t.Fatalf("Cherry: %v", cherryErr)
+	}
+	unique := 0
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.HasPrefix(line, "+ ") {
+			unique++
+		}
+	}
+	if unique != 0 {
+		t.Errorf("Cherry unique = %d, want 0 for squash-merged branch", unique)
+	}
+}
+
+func TestCherry_UnmergedBranch(t *testing.T) {
+	localDir, _, mainBranch := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+	branch := "polecat/unmerged"
+
+	runGit(t, localDir, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(localDir, "unmerged.txt"), []byte("work"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	runGit(t, localDir, "add", "unmerged.txt")
+	runGit(t, localDir, "commit", "-m", "unmerged work")
+	branchSHA, err := g.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev branch: %v", err)
+	}
+	runGit(t, localDir, "push", "origin", branch)
+	runGit(t, localDir, "checkout", mainBranch)
+
+	out, cherryErr := g.Cherry("origin/"+mainBranch, branchSHA)
+	if cherryErr != nil {
+		t.Fatalf("Cherry: %v", cherryErr)
+	}
+	unique := 0
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.HasPrefix(line, "+ ") {
+			unique++
+		}
+	}
+	if unique != 1 {
+		t.Errorf("Cherry unique = %d, want 1 for unmerged branch", unique)
+	}
+}
+
+func TestCherry_NormalMergedBranch(t *testing.T) {
+	localDir, _, mainBranch := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+	branch := "polecat/normal-merged"
+
+	runGit(t, localDir, "checkout", "-b", branch)
+	if err := os.WriteFile(filepath.Join(localDir, "normal-work.txt"), []byte("work"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	runGit(t, localDir, "add", "normal-work.txt")
+	runGit(t, localDir, "commit", "-m", "normal work")
+	branchSHA, err := g.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev branch: %v", err)
+	}
+	runGit(t, localDir, "push", "origin", branch)
+
+	// Normal merge: commit becomes reachable from main, cherry outputs nothing.
+	runGit(t, localDir, "checkout", mainBranch)
+	runGit(t, localDir, "merge", "--no-ff", branch)
+	runGit(t, localDir, "push", "origin", mainBranch)
+
+	out, cherryErr := g.Cherry("origin/"+mainBranch, branchSHA)
+	if cherryErr != nil {
+		t.Fatalf("Cherry: %v", cherryErr)
+	}
+	unique := 0
+	for _, line := range strings.Split(strings.TrimSpace(out), "\n") {
+		if strings.HasPrefix(line, "+ ") {
+			unique++
+		}
+	}
+	if unique != 0 {
+		t.Errorf("Cherry unique = %d, want 0 for normal-merged branch", unique)
+	}
+}
+
 func TestPushWithEnv(t *testing.T) {
 	localDir, _, mainBranch := initTestRepoWithRemote(t)
 	g := NewGit(localDir)


### PR DESCRIPTION
## Summary

- `gt polecat prune --remote` used `IsAncestor` to detect merged branches, which returns `false` for squash/rebase merges because the original commits no longer appear on main with the same SHA.
- Replace with `git cherry` (patch-id comparison): commits whose patches are already on upstream show as `-` lines; zero `+` lines means fully merged regardless of merge strategy.
- Add `TestCherry_SquashMergedBranch`, `TestCherry_UnmergedBranch`, and `TestCherry_NormalMergedBranch` to `internal/git` to lock in the behavior across all three merge paths.

## Changes

- `internal/cmd/polecat.go`: swap `IsAncestor` call for `Cherry` with `+`-line counting; add explanatory comment for the empty-output edge case (normal merges produce no output, not `-` lines).
- `internal/git/git_test.go`: three new tests covering squash-merged, unmerged, and normal-merged branches.

## Testing

- [x] `go build ./...` passes
- [x] `go test ./internal/git/... -run TestCherry` — all three tests pass
- [x] `go test ./internal/git/...` — full package passes
- [x] `go vet ./internal/cmd/... ./internal/git/...` passes

Closes #3779