### PR TITLE
fix(compact): add progress logging + hard timeout to prevent silent 10min+ hangs

### DIFF
--- a/internal/cmd/compact.go
+++ b/internal/cmd/compact.go
@@ -2,10 +2,14 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"os"
+	"strconv"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"time"
 	"unicode/utf8"
 
@@ -20,7 +24,45 @@ var (
 	compactVerbose bool
 	compactJSON    bool
 	compactRig     string
+	compactTimeout time.Duration
 )
+
+// Compact timeout/progress defaults. Both can be overridden by env or flag.
+// Pre-fix: gt compact could silently hang for 10+ minutes with zero stdout/stderr
+// during deacon patrol while bd subprocesses backed up against a slow Dolt
+// server (aa-c6a). Now we always print progress and impose a hard ceiling.
+const (
+	defaultCompactTimeout       = 5 * time.Minute
+	defaultCompactProgressEvery = 15 * time.Second
+	compactTimeoutEnv           = "GT_COMPACT_TIMEOUT_SEC"
+	compactProgressEnv          = "GT_COMPACT_PROGRESS_SEC"
+)
+
+// resolveCompactTimeout returns the hard timeout for gt compact. Precedence:
+// --timeout flag > GT_COMPACT_TIMEOUT_SEC env > defaultCompactTimeout.
+func resolveCompactTimeout() time.Duration {
+	if compactTimeout > 0 {
+		return compactTimeout
+	}
+	if v := os.Getenv(compactTimeoutEnv); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return defaultCompactTimeout
+}
+
+// resolveCompactProgressInterval returns how often the progress heartbeat fires.
+// Precedence: GT_COMPACT_PROGRESS_SEC env > defaultCompactProgressEvery.
+// A value of 0 disables progress output entirely (useful for tests).
+func resolveCompactProgressInterval() time.Duration {
+	if v := os.Getenv(compactProgressEnv); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n >= 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return defaultCompactProgressEvery
+}
 
 // Default TTLs per wisp type (from design doc WISP-COMPACTION-POLICY.md).
 var defaultTTLs = map[string]time.Duration{
@@ -79,6 +121,8 @@ func init() {
 	compactCmd.Flags().BoolVarP(&compactVerbose, "verbose", "v", false, "Show each wisp decision")
 	compactCmd.Flags().BoolVar(&compactJSON, "json", false, "Output results as JSON")
 	compactCmd.Flags().StringVar(&compactRig, "rig", "", "Compact a specific rig (default: current rig)")
+	compactCmd.Flags().DurationVar(&compactTimeout, "timeout", 0,
+		"Hard timeout for the whole compaction run (default: 5m, env GT_COMPACT_TIMEOUT_SEC)")
 
 	rootCmd.AddCommand(compactCmd)
 }
@@ -173,6 +217,119 @@ type compactIssue struct {
 	WispType     string `json:"wisp_type,omitempty"`
 }
 
+// compactProgress is the shared state the progress heartbeat reads from.
+// runCompact mutates these atomics as it walks the wisp list so the
+// background goroutine can print "step X — i/N" lines without races.
+type compactProgress struct {
+	total       int32
+	processed   int32
+	step        atomic.Value // string: current high-level step
+	currentWisp atomic.Value // string: id of wisp under active processing (or "")
+	start       time.Time
+}
+
+func newCompactProgress() *compactProgress {
+	p := &compactProgress{start: time.Now()}
+	p.step.Store("starting")
+	p.currentWisp.Store("")
+	return p
+}
+
+func (p *compactProgress) setStep(s string) { p.step.Store(s) }
+func (p *compactProgress) setCurrentWisp(id string) {
+	p.currentWisp.Store(id)
+}
+func (p *compactProgress) stepString() string {
+	if v, ok := p.step.Load().(string); ok {
+		return v
+	}
+	return ""
+}
+func (p *compactProgress) currentWispString() string {
+	if v, ok := p.currentWisp.Load().(string); ok {
+		return v
+	}
+	return ""
+}
+
+// formatProgressLine renders a single heartbeat line. Kept pure for testing.
+func (p *compactProgress) formatProgressLine(elapsed time.Duration) string {
+	processed := atomic.LoadInt32(&p.processed)
+	total := atomic.LoadInt32(&p.total)
+	cur := p.currentWispString()
+	curPart := ""
+	if cur != "" {
+		curPart = fmt.Sprintf(" (on %s)", cur)
+	}
+	if total > 0 {
+		return fmt.Sprintf("compact: %s %d/%d%s (elapsed %s)",
+			p.stepString(), processed, total, curPart, elapsed.Round(time.Second))
+	}
+	return fmt.Sprintf("compact: %s%s (elapsed %s)",
+		p.stepString(), curPart, elapsed.Round(time.Second))
+}
+
+// startProgressHeartbeat fires a goroutine that prints a progress line every
+// `interval` until the returned stop func is called. interval==0 disables it.
+// In JSON mode the heartbeat is also suppressed so machine output stays clean.
+// All progress lines go to stderr so they don't corrupt --json on stdout.
+func startProgressHeartbeat(p *compactProgress, interval time.Duration, jsonMode bool) func() {
+	if interval <= 0 || jsonMode {
+		return func() {}
+	}
+	done := make(chan struct{})
+	var wg sync.WaitGroup
+	wg.Add(1)
+	go func() {
+		defer wg.Done()
+		t := time.NewTicker(interval)
+		defer t.Stop()
+		for {
+			select {
+			case <-done:
+				return
+			case now := <-t.C:
+				fmt.Fprintln(os.Stderr, p.formatProgressLine(now.Sub(p.start)))
+			}
+		}
+	}()
+	return func() {
+		close(done)
+		wg.Wait()
+	}
+}
+
+// dumpCompactDiagnostics writes a one-shot diagnostic block to stderr
+// when the hard timeout fires, so silent hangs leave a forensic trail.
+func dumpCompactDiagnostics(p *compactProgress, timeout time.Duration, result *compactResult) {
+	processed := atomic.LoadInt32(&p.processed)
+	total := atomic.LoadInt32(&p.total)
+	remaining := int32(0)
+	if total > processed {
+		remaining = total - processed
+	}
+	fmt.Fprintln(os.Stderr, "")
+	fmt.Fprintf(os.Stderr, "compact: TIMEOUT after %s (env: %s)\n", timeout, compactTimeoutEnv)
+	fmt.Fprintf(os.Stderr, "compact: last step=%q current_wisp=%q processed=%d/%d remaining=%d\n",
+		p.stepString(), p.currentWispString(), processed, total, remaining)
+	if result != nil {
+		fmt.Fprintf(os.Stderr, "compact: partial result promoted=%d deleted=%d skipped=%d errors=%d\n",
+			len(result.Promoted), len(result.Deleted), result.Skipped, len(result.Errors))
+	}
+	fmt.Fprintln(os.Stderr,
+		"compact: most likely cause is a slow/blocked bd subprocess against Dolt; "+
+			"check daemon health (gt doctor), then bump GT_COMPACT_TIMEOUT_SEC if work was legitimately large.")
+}
+
+// errCompactTimeout is returned when the hard ceiling fires.
+type errCompactTimeout struct {
+	timeout time.Duration
+}
+
+func (e *errCompactTimeout) Error() string {
+	return fmt.Sprintf("gt compact: timed out after %s", e.timeout)
+}
+
 func runCompact(cmd *cobra.Command, args []string) error {
 	now := time.Now().UTC()
 
@@ -188,26 +345,98 @@ func runCompact(cmd *cobra.Command, args []string) error {
 		rigName = os.Getenv("GT_RIG")
 	}
 
+	// Hard ceiling on the whole run. Defends against the silent 10+ minute hang
+	// observed during deacon patrol cycle 2026-05-09 16:17 (aa-c6a) where bd
+	// subprocesses stalled and the parent emitted zero stdout/stderr until SIGTERM.
+	timeout := resolveCompactTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), timeout)
+	defer cancel()
+
+	// Periodic progress heartbeat so a stuck run can never be silent again.
+	progress := newCompactProgress()
+	stopHeartbeat := startProgressHeartbeat(progress, resolveCompactProgressInterval(), compactJSON)
+	defer stopHeartbeat()
+
+	progress.setStep("loading TTL config")
+	if !compactJSON && !compactDryRun {
+		fmt.Printf("Compacting wisps (timeout %s)...\n", timeout)
+	}
+
 	// Load TTL config
 	ttls := loadTTLConfig(townRoot, rigName)
 
 	// Query all ephemeral (wisp) issues via bd list
+	progress.setStep("listing wisps")
 	bd := beads.New(workDir)
 	allWisps, err := listWisps(bd)
 	if err != nil {
 		return fmt.Errorf("listing wisps: %w", err)
 	}
 
+	atomic.StoreInt32(&progress.total, int32(len(allWisps)))
 	if !compactJSON && !compactDryRun {
 		fmt.Printf("Compacting %d wisps...\n", len(allWisps))
 	}
 
 	result := &compactResult{}
+	progress.setStep("processing wisps")
 
+	// runCompactLoop is split into a helper so the timeout/diagnostic block
+	// stays readable. ctx.Err() between iterations bounds the bd subprocess
+	// fan-out even when individual bd calls return slowly.
+	if err := runCompactLoop(ctx, bd, allWisps, ttls, now, progress, result); err != nil {
+		if ctx.Err() == context.DeadlineExceeded {
+			dumpCompactDiagnostics(progress, timeout, result)
+			return &errCompactTimeout{timeout: timeout}
+		}
+		return err
+	}
+
+	// Clean up orphaned wisp_dependencies left behind by deleted wisps.
+	// When bd delete removes a wisp, it doesn't cascade-delete dependency
+	// records in wisp_dependencies that reference the deleted wisp. Over many
+	// compaction cycles these accumulate as dangling refs. We sweep them here.
+	if !compactDryRun {
+		progress.setStep("cleaning orphaned wisp_deps")
+		cleanOrphanedWispDeps(bd, result)
+	}
+
+	progress.setStep("done")
+
+	// Output results
+	if compactJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(result)
+	}
+
+	printCompactSummary(result)
+	return nil
+}
+
+// runCompactLoop walks the wisp list and applies the promote/delete/skip
+// policy to each one. It checks ctx between iterations so the hard timeout
+// can short-circuit a slow bd backend without waiting for the next bd call
+// to time out on its own.
+func runCompactLoop(
+	ctx context.Context,
+	bd *beads.Beads,
+	allWisps []*compactIssue,
+	ttls map[string]time.Duration,
+	now time.Time,
+	progress *compactProgress,
+	result *compactResult,
+) error {
 	for _, w := range allWisps {
+		if err := ctx.Err(); err != nil {
+			return err
+		}
+		progress.setCurrentWisp(w.ID)
+
 		age, err := wispAge(w, now)
 		if err != nil {
 			result.Errors = append(result.Errors, fmt.Sprintf("%s: %v", w.ID, err))
+			atomic.AddInt32(&progress.processed, 1)
 			continue
 		}
 
@@ -255,24 +484,10 @@ func runCompact(cmd *cobra.Command, args []string) error {
 				}
 			}
 		}
-	}
 
-	// Clean up orphaned wisp_dependencies left behind by deleted wisps.
-	// When bd delete removes a wisp, it doesn't cascade-delete dependency
-	// records in wisp_dependencies that reference the deleted wisp. Over many
-	// compaction cycles these accumulate as dangling refs. We sweep them here.
-	if !compactDryRun {
-		cleanOrphanedWispDeps(bd, result)
+		atomic.AddInt32(&progress.processed, 1)
 	}
-
-	// Output results
-	if compactJSON {
-		enc := json.NewEncoder(os.Stdout)
-		enc.SetIndent("", "  ")
-		return enc.Encode(result)
-	}
-
-	printCompactSummary(result)
+	progress.setCurrentWisp("")
 	return nil
 }
 

--- a/internal/cmd/compact_test.go
+++ b/internal/cmd/compact_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -22,8 +24,8 @@ func TestGetTTL(t *testing.T) {
 		{"recovery", 7 * 24 * time.Hour},
 		{"escalation", 7 * 24 * time.Hour},
 		{"default", 24 * time.Hour},
-		{"", 24 * time.Hour},          // empty falls back to default
-		{"unknown", 24 * time.Hour},   // unknown falls back to default
+		{"", 24 * time.Hour},        // empty falls back to default
+		{"unknown", 24 * time.Hour}, // unknown falls back to default
 	}
 
 	for _, tc := range tests {
@@ -264,5 +266,81 @@ func TestLoadTTLConfigWithRoleSkipsInvalidPaths(t *testing.T) {
 	}
 	if ttls["error"] != defaultTTLs["error"] {
 		t.Errorf("error TTL = %v, want %v", ttls["error"], defaultTTLs["error"])
+	}
+}
+
+func TestResolveCompactTimeoutDefault(t *testing.T) {
+	t.Setenv(compactTimeoutEnv, "")
+	compactTimeout = 0
+	if got := resolveCompactTimeout(); got != defaultCompactTimeout {
+		t.Errorf("resolveCompactTimeout() = %v, want %v", got, defaultCompactTimeout)
+	}
+}
+
+func TestResolveCompactTimeoutEnv(t *testing.T) {
+	t.Setenv(compactTimeoutEnv, "12")
+	compactTimeout = 0
+	if got := resolveCompactTimeout(); got != 12*time.Second {
+		t.Errorf("resolveCompactTimeout() = %v, want 12s", got)
+	}
+}
+
+func TestResolveCompactTimeoutFlagWins(t *testing.T) {
+	t.Setenv(compactTimeoutEnv, "12")
+	compactTimeout = 99 * time.Second
+	defer func() { compactTimeout = 0 }()
+	if got := resolveCompactTimeout(); got != 99*time.Second {
+		t.Errorf("resolveCompactTimeout() = %v, want 99s (flag wins)", got)
+	}
+}
+
+func TestResolveCompactProgressIntervalDefault(t *testing.T) {
+	t.Setenv(compactProgressEnv, "")
+	if got := resolveCompactProgressInterval(); got != defaultCompactProgressEvery {
+		t.Errorf("resolveCompactProgressInterval() = %v, want %v",
+			got, defaultCompactProgressEvery)
+	}
+}
+
+func TestResolveCompactProgressIntervalDisabled(t *testing.T) {
+	t.Setenv(compactProgressEnv, "0")
+	if got := resolveCompactProgressInterval(); got != 0 {
+		t.Errorf("resolveCompactProgressInterval() = %v, want 0 (disabled)", got)
+	}
+}
+
+func TestCompactProgressFormatLineWithTotal(t *testing.T) {
+	p := newCompactProgress()
+	atomic.StoreInt32(&p.total, 10)
+	atomic.StoreInt32(&p.processed, 3)
+	p.setStep("processing wisps")
+	p.setCurrentWisp("gt-abc")
+
+	line := p.formatProgressLine(5 * time.Second)
+	for _, want := range []string{"processing wisps", "3/10", "gt-abc", "elapsed 5s"} {
+		if !strings.Contains(line, want) {
+			t.Errorf("formatProgressLine() = %q, want substring %q", line, want)
+		}
+	}
+}
+
+func TestCompactProgressFormatLineNoTotal(t *testing.T) {
+	p := newCompactProgress()
+	p.setStep("listing wisps")
+	line := p.formatProgressLine(2 * time.Second)
+	if !strings.Contains(line, "listing wisps") {
+		t.Errorf("formatProgressLine() = %q, want %q substring", line, "listing wisps")
+	}
+	if strings.Contains(line, "/") {
+		// no total set yet, so we shouldn't print a fraction like 0/0
+		t.Errorf("formatProgressLine() = %q, should not include i/N when total is 0", line)
+	}
+}
+
+func TestErrCompactTimeoutMessage(t *testing.T) {
+	err := &errCompactTimeout{timeout: 5 * time.Minute}
+	got := err.Error()
+	if !strings.Contains(got, "5m") || !strings.Contains(got, "timed out") {
+		t.Errorf("errCompactTimeout.Error() = %q, want 5m + 'timed out' substring", got)
 	}
 }


### PR DESCRIPTION
## Summary

- `gt compact` now imposes a hard 5m timeout (configurable via `--timeout` flag or `GT_COMPACT_TIMEOUT_SEC`) over the whole run, with `ctx.Err()` checks between wisps so a backed-up bd queue short-circuits cleanly.
- A heartbeat goroutine prints a one-line progress update to stderr every 15s (configurable via `GT_COMPACT_PROGRESS_SEC`, `0` disables for tests), showing current step, current wisp id, processed/total, and elapsed time. Stderr keeps `--json` output clean.
- On timeout, a one-shot diagnostic block dumps last step, current wisp, processed/total/remaining, partial result counts, and a remediation hint before returning `errCompactTimeout`.

## Root cause (bug aa-c6a)

During deacon patrol cycle 2026-05-09 16:17, `gt compact` produced zero stdout/stderr for 11+ minutes, alive but unresponsive (PID 488924), and required SIGTERM to recover. The per-bd-subprocess timeout (60s in `internal/beads/beads.go`) bounded individual `bd` calls, but `runCompact` had:

1. No top-level deadline — N wisps × slow Dolt = unbounded wall-clock.
2. No progress output in non-verbose, non-JSON mode — only one "Compacting N wisps..." line before the silent loop.

So a slow Dolt response made the run indistinguishable from a hang.

## Fix shape

- Added `context.WithTimeout` around the whole flow.
- Refactored the wisp processing into `runCompactLoop(ctx, ...)` which checks `ctx.Err()` between iterations.
- Added `compactProgress` (atomics-based) + `startProgressHeartbeat` goroutine.
- Added `dumpCompactDiagnostics` for the timeout path so silent hangs leave a forensic trail.
- New tests for timeout resolution precedence (flag > env > default), progress interval, format line behavior, and the timeout error message.

## Related

`aa-sct` (mail inbox hung ~30s mid-patrol) is being fixed in parallel — same morning, same Dolt server early-shutdown event noted in handoff `aa-4xg`. May share a root cause; this PR is scoped to `gt compact` only and does not conflict with the inbox fix.

## Test plan

- [x] `go build ./...` clean
- [x] `go vet ./internal/cmd/... ./cmd/gt/...` clean
- [x] `gofmt -l` clean on touched files
- [x] `go test ./internal/cmd/...` passes (incl. 8 new tests)
- [ ] Manual: invoke `gt compact` from deacon role and confirm a progress line every 15s
- [ ] Manual: invoke `gt compact --timeout 1s` and confirm the timeout dump + non-zero exit
- [ ] Manual: invoke `gt compact --json` and confirm stdout is still pure JSON (heartbeat suppressed)

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>