### PR TITLE
fix(test): reap leaked dolt sql-server processes

### DIFF
--- a/internal/cmd/convoy_test_helpers_test.go
+++ b/internal/cmd/convoy_test_helpers_test.go
@@ -424,6 +424,39 @@ func (d *testDAG) Setup(t *testing.T) (townRoot, logPath string) {
 	// Inject bin/ into PATH.
 	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
 
+	// Prevent the embedded beads SDK from auto-spawning a real `dolt
+	// sql-server` if any test code path slips past our stubs and hits
+	// b.OpenStore / mutateTrackingRelationViaStore. Without this, a
+	// previously-passing test like TestLaunchAsAlias_EpicInput could
+	// silently fork a dolt process whose cwd is inside this test's
+	// t.TempDir(); when the temp dir was removed at test exit the dolt
+	// kept running (cwd "(deleted)"), reparented to systemd. That was
+	// the bug behind aa-7f9r — 77+ orphaned dolt sql-servers piled up
+	// on a developer host over ~11 days.
+	t.Setenv("BEADS_DOLT_AUTO_START", "0")
+
+	// Stub the tracking-relation helpers so calls from runConvoyStage /
+	// createStagedConvoy don't reach mutateTrackingRelationViaStore (which
+	// would open a beads-SDK store and, if no server were running, fork a
+	// fresh dolt sql-server in the test temp dir). The stub records each
+	// call into bd.log using the same "CMD:dep add ..." line shape that
+	// the bd shell stub uses, so existing assertions that grep bd.log for
+	// `dep add <convoy> <bead>` continue to pass.
+	oldAddTracking := addTrackingRelationFn
+	oldRemoveTracking := removeTrackingRelationFn
+	addTrackingRelationFn = func(townRoot, trackerID, issueID string) error {
+		appendBdLog(logPath, fmt.Sprintf("dep add %s %s --type=tracks", trackerID, issueID))
+		return nil
+	}
+	removeTrackingRelationFn = func(townRoot, trackerID, issueID string) error {
+		appendBdLog(logPath, fmt.Sprintf("dep remove %s %s --type=tracks", trackerID, issueID))
+		return nil
+	}
+	t.Cleanup(func() {
+		addTrackingRelationFn = oldAddTracking
+		removeTrackingRelationFn = oldRemoveTracking
+	})
+
 	// Change cwd to town root with cleanup.
 	cwd, err := os.Getwd()
 	if err != nil {
@@ -440,6 +473,20 @@ func (d *testDAG) Setup(t *testing.T) (townRoot, logPath string) {
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
+
+// appendBdLog mimics the bd shell stub's `echo "CMD:$*" >> "$LOGPATH"` line
+// for in-process stubs that bypass the shell stub (e.g. the tracking-
+// relation stubs in Setup). Keeping the line shape consistent means tests
+// can assert on the same bd.log regardless of whether a particular bd
+// invocation went through the shell stub or an in-process Go stub.
+func appendBdLog(logPath, cmd string) {
+	f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		return
+	}
+	defer f.Close()
+	fmt.Fprintf(f, "CMD:%s\n", cmd)
+}
 
 // prefixOf extracts the prefix from a bead ID (e.g. "gt-abc" → "gt-").
 func prefixOf(id string) string {

--- a/internal/cmd/fresh_setup_integration_test.go
+++ b/internal/cmd/fresh_setup_integration_test.go
@@ -16,6 +16,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/testutil"
 )
 
 var freshSetupIntegrationCounter atomic.Int32
@@ -41,6 +42,11 @@ func TestFreshInstallRigPolecatHookIntegration(t *testing.T) {
 	configureGitIdentityForEnv(t, env)
 
 	gtBinary := buildGT(t)
+	// Register dolt-reap cleanup BEFORE the install runs, so the dolt
+	// sql-server gets killed even if a later assertion in this test
+	// fatals (aa-7f9r). The `gt dolt stop` cleanup below is best-effort
+	// graceful shutdown; testutil.ReapDoltOnCleanup is the hard backstop.
+	testutil.ReapDoltOnCleanup(t, hqPath)
 	runFreshSetupCmd(t, "", env, gtBinary, "install", hqPath, "--name", "test-town", "--git", "--dolt-port", doltPortString)
 	t.Cleanup(func() {
 		cmd := exec.Command(gtBinary, "dolt", "stop")

--- a/internal/cmd/install_integration_test.go
+++ b/internal/cmd/install_integration_test.go
@@ -11,6 +11,7 @@ import (
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/testutil"
 )
 
 // TestInstallCreatesCorrectStructure validates that a fresh gt install
@@ -28,6 +29,11 @@ func TestInstallCreatesCorrectStructure(t *testing.T) {
 
 	// Kill any stale dolt from a previous test to avoid port 3307 conflict.
 	_ = exec.Command("pkill", "-f", "dolt sql-server").Run()
+	// Register a per-town dolt-reap BEFORE running gt install, so the dolt
+	// sql-server spawned by install gets killed even if a later assertion
+	// fatals (aa-7f9r). The broad pkill below is a defensive backstop;
+	// testutil.ReapDoltOnCleanup is the targeted, reliable path.
+	testutil.ReapDoltOnCleanup(t, hqPath)
 	t.Cleanup(func() { _ = exec.Command("pkill", "-f", "dolt sql-server").Run() })
 
 	// Run gt install
@@ -94,6 +100,11 @@ func TestInstallBeadsHasCorrectPrefix(t *testing.T) {
 
 	// Kill any stale dolt from a previous test to avoid port 3307 conflict.
 	_ = exec.Command("pkill", "-f", "dolt sql-server").Run()
+	// Register a per-town dolt-reap BEFORE running gt install, so the dolt
+	// sql-server spawned by install gets killed even if a later assertion
+	// fatals (aa-7f9r). The broad pkill below is a defensive backstop;
+	// testutil.ReapDoltOnCleanup is the targeted, reliable path.
+	testutil.ReapDoltOnCleanup(t, hqPath)
 	t.Cleanup(func() { _ = exec.Command("pkill", "-f", "dolt sql-server").Run() })
 
 	// Run gt install (includes beads init by default)
@@ -358,6 +369,11 @@ func TestInstallFormulasProvisioned(t *testing.T) {
 
 	// Kill any stale dolt from a previous test to avoid port 3307 conflict.
 	_ = exec.Command("pkill", "-f", "dolt sql-server").Run()
+	// Register a per-town dolt-reap BEFORE running gt install, so the dolt
+	// sql-server spawned by install gets killed even if a later assertion
+	// fatals (aa-7f9r). The broad pkill below is a defensive backstop;
+	// testutil.ReapDoltOnCleanup is the targeted, reliable path.
+	testutil.ReapDoltOnCleanup(t, hqPath)
 	t.Cleanup(func() { _ = exec.Command("pkill", "-f", "dolt sql-server").Run() })
 
 	// Run gt install (includes beads and formula provisioning)
@@ -556,6 +572,11 @@ func TestInstallDoctorClean(t *testing.T) {
 
 	// Kill any stale dolt from previous test BEFORE install to avoid port 3307 conflict.
 	_ = exec.Command("pkill", "-f", "dolt sql-server").Run()
+	// Register a per-town dolt-reap BEFORE running gt install, so the dolt
+	// sql-server spawned by install gets killed even if a later assertion
+	// fatals (aa-7f9r). `gt dolt stop` below is best-effort graceful
+	// shutdown; testutil.ReapDoltOnCleanup is the hard backstop.
+	testutil.ReapDoltOnCleanup(t, hqPath)
 
 	// Set up git identity in the test's temp HOME so EnsureDoltIdentity can copy it.
 	configureGitIdentity(t, env)
@@ -690,6 +711,11 @@ func TestInstallWithDaemon(t *testing.T) {
 
 	// Kill any stale dolt from previous test BEFORE install to avoid port 3307 conflict.
 	_ = exec.Command("pkill", "-f", "dolt sql-server").Run()
+	// Register a per-town dolt-reap BEFORE running gt install, so the dolt
+	// sql-server spawned by install gets killed even if a later assertion
+	// fatals (aa-7f9r). `gt dolt stop` below is best-effort graceful
+	// shutdown; testutil.ReapDoltOnCleanup is the hard backstop.
+	testutil.ReapDoltOnCleanup(t, hqPath)
 
 	// Set up git identity in the test's temp HOME so EnsureDoltIdentity can copy it.
 	configureGitIdentity(t, env)

--- a/internal/testutil/dolt_cleanup.go
+++ b/internal/testutil/dolt_cleanup.go
@@ -1,0 +1,201 @@
+// Package testutil — Dolt process cleanup helpers for tests that spawn
+// real `dolt sql-server` processes via `gt install` (or similar) and need
+// to reap them reliably at the end of the test.
+//
+// Why this exists (aa-7f9r): `gt install` forks `dolt sql-server` as a
+// long-lived background process — it survives the `gt install` exit by
+// design (the server is meant to stick around so subsequent `bd`/`gt`
+// commands can talk to it). When the test that spawned it doesn't reach
+// its cleanup path (panic, t.Fatal, build cancel, signal, etc.), the
+// dolt process gets reparented to init/systemd and lingers indefinitely.
+// On one developer host this leaked 77+ orphaned dolt sql-server processes
+// over ~11 days, each holding open .dolt LOCK fds on /tmp dirs that the
+// test framework had already removed.
+//
+// ReapDoltOnCleanup() registers a t.Cleanup hook that:
+//
+//  1. Reads the PID from <townRoot>/daemon/dolt.pid (written by Start()).
+//  2. Falls back to <townRoot>/.dolt-data/.dolt/sql-server.info — Dolt's
+//     own runtime metadata file — which exists even before the gt
+//     daemon/dolt.pid is written (covers crash-during-startup cases).
+//  3. Sends SIGTERM to that specific PID, waits up to 2s for it to exit,
+//     then escalates to SIGKILL. Process-name verification before kill
+//     keeps us from murdering some unrelated PID that happens to be
+//     reused.
+//  4. As a belt-and-braces fallback, also scans for any `dolt sql-server`
+//     whose --config path lives inside the test's townRoot, and reaps
+//     those too. This catches the case where the PID file was never
+//     written (e.g., Start() died mid-startup).
+//
+// The cleanup is registered immediately when this helper is called, so it
+// fires even if a later assertion in the same test fatals — that is the
+// key property the previous `defer gt dolt stop` / `pkill -f` patterns
+// lacked.
+
+package testutil
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+)
+
+// ReapDoltOnCleanup registers a t.Cleanup that reaps any dolt sql-server
+// process associated with townRoot. Safe to call before `gt install`
+// actually runs — the cleanup is a best-effort no-op when there's nothing
+// to reap.
+//
+// Call this immediately after constructing townRoot, BEFORE invoking
+// `gt install` (or anything else that may spawn dolt). That way, even if
+// the install command itself panics, the cleanup still fires.
+func ReapDoltOnCleanup(t *testing.T, townRoot string) {
+	t.Helper()
+	t.Cleanup(func() { reapDolt(t, townRoot) })
+}
+
+// reapDolt is the cleanup body. Exposed as a free function so it can be
+// tested directly and called from non-t.Cleanup contexts if needed.
+func reapDolt(t *testing.T, townRoot string) {
+	t.Helper()
+
+	pids := collectDoltPIDs(townRoot)
+	if len(pids) == 0 {
+		return
+	}
+
+	// First pass: SIGTERM (graceful).
+	for pid := range pids {
+		if !looksLikeDoltSQLServer(pid) {
+			delete(pids, pid)
+			continue
+		}
+		if err := signalProcess(pid, "TERM"); err != nil {
+			// Best-effort; the process may have already exited between
+			// our discovery and the signal.
+			t.Logf("dolt reap: SIGTERM to PID %d failed: %v", pid, err)
+		}
+	}
+
+	// Wait for graceful shutdown, polling.
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		anyAlive := false
+		for pid := range pids {
+			if processIsAlive(pid) {
+				anyAlive = true
+				break
+			}
+		}
+		if !anyAlive {
+			return
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+
+	// Escalate: SIGKILL the stragglers.
+	for pid := range pids {
+		if !processIsAlive(pid) {
+			continue
+		}
+		if err := signalProcess(pid, "KILL"); err != nil {
+			t.Logf("dolt reap: SIGKILL to PID %d failed: %v", pid, err)
+		}
+	}
+}
+
+// collectDoltPIDs returns the set of candidate dolt sql-server PIDs
+// associated with townRoot. Deduplicated across the three discovery
+// strategies (PID file, sql-server.info, /proc scan).
+func collectDoltPIDs(townRoot string) map[int]struct{} {
+	pids := make(map[int]struct{})
+
+	// Strategy 1: <townRoot>/daemon/dolt.pid (written by doltserver.Start).
+	if pid, ok := readPIDFile(filepath.Join(townRoot, "daemon", "dolt.pid")); ok {
+		pids[pid] = struct{}{}
+	}
+
+	// Strategy 2: <townRoot>/.dolt-data/.dolt/sql-server.info (Dolt's own
+	// metadata; format is "PID:PORT[:SECRET]"). Present even if gt's PID
+	// file was never written.
+	if pid, ok := readDoltSQLServerInfoPID(filepath.Join(townRoot, ".dolt-data", ".dolt", "sql-server.info")); ok {
+		pids[pid] = struct{}{}
+	}
+
+	// Strategy 3 (Linux only): scan /proc for `dolt sql-server` processes
+	// whose --config path lives inside townRoot. This is the catch-all
+	// for processes that escaped both PID file mechanisms (e.g., the
+	// pidfile write failed, or Dolt itself wrote a different
+	// sql-server.info location).
+	for _, pid := range scanProcForDoltInTown(townRoot) {
+		pids[pid] = struct{}{}
+	}
+
+	return pids
+}
+
+// readPIDFile reads a file containing a single integer PID. Returns
+// (0, false) if the file is missing, empty, or unparseable.
+func readPIDFile(path string) (int, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	pidStr := strings.TrimSpace(string(data))
+	if pidStr == "" {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(pidStr)
+	if err != nil || pid <= 1 {
+		return 0, false
+	}
+	return pid, true
+}
+
+// readDoltSQLServerInfoPID parses Dolt's sql-server.info file
+// (format: "PID:PORT" or "PID:PORT:SECRET") and returns the PID.
+func readDoltSQLServerInfoPID(path string) (int, bool) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return 0, false
+	}
+	parts := strings.SplitN(strings.TrimSpace(string(data)), ":", 3)
+	if len(parts) < 2 {
+		return 0, false
+	}
+	pid, err := strconv.Atoi(parts[0])
+	if err != nil || pid <= 1 {
+		return 0, false
+	}
+	return pid, true
+}
+
+// signalProcess sends a named signal to a PID using `kill`. Going through
+// the `kill` binary (rather than syscall.Kill) keeps this file portable
+// across GOOS values without a separate _windows variant — Windows
+// integration tests skip on dolt-server scenarios anyway, and the helper
+// is a no-op there because no PIDs would have been discovered.
+func signalProcess(pid int, sig string) error {
+	cmd := exec.Command("kill", "-"+sig, strconv.Itoa(pid))
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("kill -%s %d: %v (%s)", sig, pid, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// processIsAlive reports whether a PID currently refers to a running
+// process. Uses `kill -0` (no signal sent, just permission check) which
+// is portable across POSIX systems.
+func processIsAlive(pid int) bool {
+	// FindProcess always succeeds on Unix, so we use the kill -0 idiom
+	// instead. Errors mean either ESRCH (no such pid) or EPERM (process
+	// exists but we can't signal it). Treat EPERM as "alive" — better to
+	// over-report than skip a kill.
+	cmd := exec.Command("kill", "-0", strconv.Itoa(pid))
+	return cmd.Run() == nil
+}

--- a/internal/testutil/dolt_cleanup_linux.go
+++ b/internal/testutil/dolt_cleanup_linux.go
@@ -1,0 +1,116 @@
+//go:build linux
+
+package testutil
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+)
+
+// scanProcForDoltInTown walks /proc looking for `dolt sql-server`
+// processes whose --config argument lives inside townRoot. Linux-only
+// because /proc/<pid>/cmdline is the simplest portable way to inspect
+// process arguments without spawning `ps`.
+//
+// Returns an empty slice on any error or on platforms without /proc.
+func scanProcForDoltInTown(townRoot string) []int {
+	absRoot, err := filepath.Abs(townRoot)
+	if err != nil {
+		return nil
+	}
+	// Trailing separator guards against substring false-positives
+	// (e.g. /tmp/townA vs /tmp/townA-other).
+	rootWithSep := absRoot + string(filepath.Separator)
+
+	entries, err := os.ReadDir("/proc")
+	if err != nil {
+		return nil
+	}
+
+	var pids []int
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		pid, err := strconv.Atoi(entry.Name())
+		if err != nil {
+			continue
+		}
+		cmdline, err := os.ReadFile(filepath.Join("/proc", entry.Name(), "cmdline"))
+		if err != nil {
+			continue
+		}
+		// /proc/<pid>/cmdline uses NUL separators between argv entries.
+		args := bytes.Split(cmdline, []byte{0})
+		if len(args) < 2 {
+			continue
+		}
+		// argv[0] is "dolt" (or absolute path ending in /dolt) and
+		// argv[1] is "sql-server". Anything else is not our target.
+		exe := string(args[0])
+		if !(exe == "dolt" || strings.HasSuffix(exe, "/dolt")) {
+			continue
+		}
+		if string(args[1]) != "sql-server" {
+			continue
+		}
+		// Look for an argument that points into townRoot. Both
+		// "--config /path" (two args) and "--config=/path" (one arg)
+		// are accepted; same for --data-dir.
+		match := false
+		for i, raw := range args {
+			a := string(raw)
+			if a == "" {
+				continue
+			}
+			// Standalone "--config /path" or "--data-dir /path"
+			if (a == "--config" || a == "--data-dir") && i+1 < len(args) {
+				next := string(args[i+1])
+				if next == absRoot || strings.HasPrefix(next, rootWithSep) {
+					match = true
+					break
+				}
+			}
+			// Inlined "--config=/path" or "--data-dir=/path"
+			for _, prefix := range []string{"--config=", "--data-dir="} {
+				if strings.HasPrefix(a, prefix) {
+					val := a[len(prefix):]
+					if val == absRoot || strings.HasPrefix(val, rootWithSep) {
+						match = true
+					}
+				}
+			}
+			if match {
+				break
+			}
+		}
+		if match {
+			pids = append(pids, pid)
+		}
+	}
+	return pids
+}
+
+// looksLikeDoltSQLServer verifies that pid is actually a `dolt sql-server`
+// process. This guards against killing some unrelated PID that has been
+// reused since the PID file was written.
+func looksLikeDoltSQLServer(pid int) bool {
+	cmdline, err := os.ReadFile(filepath.Join("/proc", strconv.Itoa(pid), "cmdline"))
+	if err != nil {
+		// If we can't read /proc/<pid>/cmdline the process is probably
+		// gone (or we lack permission). Either way it's safe to skip.
+		return false
+	}
+	args := bytes.Split(cmdline, []byte{0})
+	if len(args) < 2 {
+		return false
+	}
+	exe := string(args[0])
+	if !(exe == "dolt" || strings.HasSuffix(exe, "/dolt")) {
+		return false
+	}
+	return string(args[1]) == "sql-server"
+}

--- a/internal/testutil/dolt_cleanup_other.go
+++ b/internal/testutil/dolt_cleanup_other.go
@@ -1,0 +1,42 @@
+//go:build !linux
+
+package testutil
+
+import (
+	"os/exec"
+	"strconv"
+	"strings"
+)
+
+// scanProcForDoltInTown is a no-op on non-Linux platforms. The PID-file
+// and sql-server.info strategies still work; we just lose the catch-all
+// /proc scan. macOS tests that reach the leak path are rare in practice
+// because most integration tests run in Docker/CI on Linux.
+func scanProcForDoltInTown(townRoot string) []int {
+	return nil
+}
+
+// looksLikeDoltSQLServer verifies a PID via `ps -o command=`. Works on
+// macOS and BSD; on Windows it falls back to "true" (Windows tests skip
+// the spawn-dolt scenarios via build tags).
+func looksLikeDoltSQLServer(pid int) bool {
+	out, err := exec.Command("ps", "-p", strconv.Itoa(pid), "-o", "command=").Output()
+	if err != nil {
+		return false
+	}
+	cmdline := strings.TrimSpace(string(out))
+	if cmdline == "" {
+		return false
+	}
+	// Must start with "dolt" (possibly an absolute path) and contain
+	// "sql-server" as the next token.
+	fields := strings.Fields(cmdline)
+	if len(fields) < 2 {
+		return false
+	}
+	exe := fields[0]
+	if !(exe == "dolt" || strings.HasSuffix(exe, "/dolt")) {
+		return false
+	}
+	return fields[1] == "sql-server"
+}

--- a/internal/testutil/dolt_cleanup_test.go
+++ b/internal/testutil/dolt_cleanup_test.go
@@ -1,0 +1,146 @@
+package testutil
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"testing"
+	"time"
+)
+
+// TestReapDoltOnCleanup_NoFiles verifies that the cleanup helper is a no-op
+// when neither the PID file nor sql-server.info exists, and when /proc has
+// no matching dolt process. This is the common "nothing to do" path.
+func TestReapDoltOnCleanup_NoFiles(t *testing.T) {
+	townRoot := t.TempDir()
+	// reapDolt should not panic and should not log anything alarming.
+	reapDolt(t, townRoot)
+}
+
+// TestReapDoltOnCleanup_PIDFileMissingProcess covers a stale PID file
+// pointing at a PID that no longer exists. Should not kill anything and
+// must not panic.
+func TestReapDoltOnCleanup_PIDFileMissingProcess(t *testing.T) {
+	townRoot := t.TempDir()
+	daemonDir := filepath.Join(townRoot, "daemon")
+	if err := os.MkdirAll(daemonDir, 0o755); err != nil {
+		t.Fatalf("mkdir daemon: %v", err)
+	}
+	// Pick a PID that's almost certainly not in use. 999999 is well above
+	// the typical pid_max on Linux defaults; even when it's not, the
+	// process-name check (looksLikeDoltSQLServer) will filter it out.
+	pidFile := filepath.Join(daemonDir, "dolt.pid")
+	if err := os.WriteFile(pidFile, []byte("999999\n"), 0o644); err != nil {
+		t.Fatalf("write pid file: %v", err)
+	}
+	reapDolt(t, townRoot)
+}
+
+// TestReapDoltOnCleanup_ReapsRealChild spawns a long-running sleep process
+// as a stand-in for dolt sql-server, writes its PID into the conventional
+// dolt.pid path, and verifies the reaper's signal+wait plumbing kills it.
+//
+// We bypass the process-name guard by calling signalProcess directly:
+// looksLikeDoltSQLServer would (correctly) reject a sleep process, so this
+// test asserts the SIGTERM→wait→SIGKILL plumbing, not the discovery
+// filter (which is tested by TestLooksLikeDoltSQLServer_RejectsNonDolt).
+//
+// Skipped in sandboxed environments where the test process can't send
+// signals to its own children (some CI sandboxes block this) — detected
+// by spawning a quick sleep and confirming SIGKILL actually kills it.
+func TestReapDoltOnCleanup_ReapsRealChild(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("sleep + kill semantics differ on Windows")
+	}
+	if !canKillChildren(t) {
+		t.Skip("environment blocks signals to child processes (likely a sandbox); test cannot run here")
+	}
+
+	townRoot := t.TempDir()
+	daemonDir := filepath.Join(townRoot, "daemon")
+	if err := os.MkdirAll(daemonDir, 0o755); err != nil {
+		t.Fatalf("mkdir daemon: %v", err)
+	}
+
+	cmd := exec.Command("sleep", "30")
+	if err := cmd.Start(); err != nil {
+		t.Fatalf("start sleep: %v", err)
+	}
+	t.Cleanup(func() {
+		// Belt-and-braces: if the test fails before our reap runs,
+		// still kill the sleep so we don't leak.
+		_ = cmd.Process.Kill()
+		_, _ = cmd.Process.Wait()
+	})
+
+	pid := cmd.Process.Pid
+	pidFile := filepath.Join(daemonDir, "dolt.pid")
+	if err := os.WriteFile(pidFile, []byte(strconv.Itoa(pid)+"\n"), 0o644); err != nil {
+		t.Fatalf("write pid file: %v", err)
+	}
+
+	// Sanity check.
+	if !processIsAlive(pid) {
+		t.Fatalf("sleep child (PID %d) died before reap", pid)
+	}
+
+	// Bypass the process-name guard: send SIGTERM directly. We're
+	// asserting the signal/wait plumbing works, not the discovery
+	// filter (which is tested below).
+	if err := signalProcess(pid, "TERM"); err != nil {
+		t.Fatalf("signalProcess SIGTERM: %v", err)
+	}
+	deadline := time.Now().Add(3 * time.Second)
+	for time.Now().Before(deadline) {
+		if !processIsAlive(pid) {
+			break
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	if processIsAlive(pid) {
+		// Escalate, as the reaper would.
+		_ = signalProcess(pid, "KILL")
+		time.Sleep(200 * time.Millisecond)
+	}
+	if processIsAlive(pid) {
+		t.Fatalf("sleep child (PID %d) survived SIGTERM and SIGKILL", pid)
+	}
+	_, _ = cmd.Process.Wait() // Reap the zombie.
+}
+
+// canKillChildren probes whether this process can actually deliver signals
+// to its own children. Some CI sandboxes silently swallow kill(2) calls
+// targeting child processes, which would otherwise make the reaper test
+// appear broken when the bug is really in the test harness.
+func canKillChildren(t *testing.T) bool {
+	t.Helper()
+	probe := exec.Command("sleep", "5")
+	if err := probe.Start(); err != nil {
+		return false
+	}
+	defer func() { _, _ = probe.Process.Wait() }()
+	pid := probe.Process.Pid
+	if err := signalProcess(pid, "KILL"); err != nil {
+		return false
+	}
+	deadline := time.Now().Add(500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if !processIsAlive(pid) {
+			return true
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	// Probe survived SIGKILL — sandbox is blocking child signals.
+	return false
+}
+
+// TestLooksLikeDoltSQLServer_RejectsNonDolt confirms the process-name
+// filter doesn't false-positive on arbitrary processes. We use our own
+// test process — definitely not "dolt sql-server".
+func TestLooksLikeDoltSQLServer_RejectsNonDolt(t *testing.T) {
+	if looksLikeDoltSQLServer(os.Getpid()) {
+		t.Fatalf("looksLikeDoltSQLServer falsely matched the test process")
+	}
+}


### PR DESCRIPTION
## Summary
Fixes a bug where gt test runs leaked `dolt sql-server` child processes that ended up reparented to `systemd` and lived forever. On one developer host, 77+ orphaned dolt sql-servers accumulated over ~11 days, each holding open `.dolt` LOCK fds on `/tmp` dirs the test framework had already removed (`cwd` showed as `(deleted)`).

Two distinct leak sources, both fixed:

### 1. Unit tests using `newTestDAG` (the larger leak)
Tests like `TestLaunchAsAlias_EpicInput`, `TestLaunchAsAlias_TaskListInput`, and `TestCreateStagedConvoy_CleanReady` flowed through `createStagedConvoy` -> `addTrackingRelationFn` -> `mutateTrackingRelationViaStore` -> `beadsdk.OpenFromConfig`, and the beads Go SDK auto-spawned a `dolt sql-server` inside the test's `t.TempDir()`. The `bd` shell stub intercepted only the bd-subprocess path; the Go SDK path slipped through.

Fixed by:
- Stubbing `addTrackingRelationFn` / `removeTrackingRelationFn` inside `testDAG.Setup()` so the SDK path is never reached.
- Setting `BEADS_DOLT_AUTO_START=0` via `t.Setenv` as a belt-and-braces guard against any other store-open paths.
- Mirroring the bd stub's `CMD:...` log line shape so existing assertions on `bd.log` continue to pass.

**Verified**: running the three named tests now spawns **zero** new dolt sql-servers (was: one per test invocation). All 130+ tests in `internal/cmd` still pass.

### 2. e2e integration tests that genuinely need a real dolt
`TestInstallCreatesCorrectStructure`, `TestInstallBeadsHasCorrectPrefix`, `TestInstallFormulasProvisioned`, `TestInstallDoctorClean`, `TestInstallWithDaemon`, and `TestFreshInstallRigPolecatHookIntegration` spawn a real `dolt sql-server` via `gt install` and rely on either `gt dolt stop` or `pkill -f "dolt sql-server"` at `t.Cleanup` time. Both cleanups are fragile.

Added `testutil.ReapDoltOnCleanup(t, townRoot)`:
- Reads `<townRoot>/daemon/dolt.pid` (Dolt's own `.dolt/sql-server.info` as fallback).
- Sends SIGTERM -> waits 2s -> escalates to SIGKILL.
- On Linux also scans `/proc` for `dolt sql-server` processes whose `--config`/`--data-dir` args live inside `townRoot`, catching cases where the PID file write itself failed.
- Process-name verified (won't reap unrelated PIDs that happen to be reused).
- Registered **before** `gt install` runs, so cleanup fires even if a later assertion fatals.

The two fixes are layered: the unit-test stub **prevents** the leak from happening (best), and the reaper is the hard backstop for tests that genuinely need a real dolt sql-server.

## Test plan
- [x] `go build ./...` clean
- [x] `go vet ./...` clean (also with `-tags=e2e` and `-tags=integration`)
- [x] `go test ./internal/cmd/...` passes (all 130+ tests, ~46s)
- [x] `go test ./internal/testutil/...` passes (new helper tests included)
- [x] Confirmed `TestLaunchAsAlias_EpicInput` (and siblings) now spawn 0 new dolt sql-servers per run (was: 1 per run)
- [x] Cross-platform: helper uses build tags (`_linux.go`, `_other.go`) for `/proc` scan vs `ps` fallback
- [x] Pre-existing tmux test failures (`TestNudgeSession_WithRetry`, `TestNudgeSession_WithStoredPaneID`) confirmed unrelated to this change (failed on `gastownhall/main` before the diff)

Closes aa-7f9r.