### PR TITLE
fix(done): accept ancestor commit when verifying push to shared target branch

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -607,7 +607,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 							closeReason = fmt.Sprintf("%s\nskip_verify: true\ntarget_branch: %s\ncommit_sha: %s", closeReason, defaultBranch, noMRCommitSHA)
 						}
 					} else if !isNoMergeTask {
-						if verifyErr := g.VerifyPushedCommit("origin", defaultBranch, noMRCommitSHA); verifyErr != nil {
+						if verifyErr := g.VerifyCommitOnRemoteBranch("origin", defaultBranch, noMRCommitSHA); verifyErr != nil {
 							noteVerifiedPushFailure(cwd, issueID, defaultBranch, noMRCommitSHA, verifyErr)
 							return fmt.Errorf("cannot close no-MR code bead: %w", verifyErr)
 						}
@@ -734,7 +734,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			directCommitSHA, _ := g.Rev("HEAD")
 			if doneSkipVerify {
 				noteVerifiedPushSkipped(cwd, issueID, defaultBranch, directCommitSHA, "--skip-verify on direct merge")
-			} else if verifyErr := g.VerifyPushedCommit("origin", defaultBranch, directCommitSHA); verifyErr != nil {
+			} else if verifyErr := g.VerifyCommitOnRemoteBranch("origin", defaultBranch, directCommitSHA); verifyErr != nil {
 				pushFailed = true
 				errMsg := verifyErr.Error()
 				doneErrors = append(doneErrors, errMsg)
@@ -1045,7 +1045,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				lateDirectCommitSHA, _ := g.Rev("HEAD")
 				if doneSkipVerify {
 					noteVerifiedPushSkipped(cwd, issueID, defaultBranch, lateDirectCommitSHA, "--skip-verify on late direct merge")
-				} else if verifyErr := g.VerifyPushedCommit("origin", defaultBranch, lateDirectCommitSHA); verifyErr != nil {
+				} else if verifyErr := g.VerifyCommitOnRemoteBranch("origin", defaultBranch, lateDirectCommitSHA); verifyErr != nil {
 					pushFailed = true
 					errMsg := verifyErr.Error()
 					doneErrors = append(doneErrors, errMsg)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1478,10 +1478,52 @@ func (g *Git) PushRemoteBranchTip(remote, branch string) (string, error) {
 	return g.RemoteBranchTip(pushURL, branch)
 }
 
+// VerifyCommitOnRemoteBranch verifies that commit is reachable from the tip of
+// remote/branch on the remote — i.e. it is either the tip or an ancestor of
+// the tip. Use this when verifying that work landed on a shared target branch
+// (e.g. main) where the tip may advance independently between push and verify
+// because other agents push concurrently.
+//
+// For verifying a freshly-pushed feature branch (where the tip must match the
+// commit exactly because no one else writes to it), use VerifyPushedCommit.
+func (g *Git) VerifyCommitOnRemoteBranch(remote, branch, commit string) error {
+	commit = strings.TrimSpace(commit)
+	if commit == "" {
+		return fmt.Errorf("verified_push_failed: empty commit for %s/%s", remote, branch)
+	}
+	tip, err := g.PushRemoteBranchTip(remote, branch)
+	if err != nil {
+		return fmt.Errorf("verified_push_failed: unable to read %s/%s: %w", remote, branch, err)
+	}
+	if tip == "" {
+		return fmt.Errorf("verified_push_failed: branch %s/%s missing after push (expected %s)", remote, branch, shortSHA(commit))
+	}
+	if tip == commit {
+		return nil
+	}
+	// Tip has advanced past our commit. Fetch the branch so we have the new
+	// objects locally, then verify our commit is an ancestor of the new tip.
+	if _, fetchErr := g.run("fetch", remote, branch); fetchErr != nil {
+		return fmt.Errorf("verified_push_failed: fetch %s/%s for ancestry check: %w", remote, branch, fetchErr)
+	}
+	isAncestor, ancErr := g.IsAncestor(commit, remote+"/"+branch)
+	if ancErr != nil {
+		return fmt.Errorf("verified_push_failed: ancestry check on %s/%s: %w", remote, branch, ancErr)
+	}
+	if !isAncestor {
+		return fmt.Errorf("verified_push_failed: commit %s not on %s/%s (remote tip %s)", shortSHA(commit), remote, branch, shortSHA(tip))
+	}
+	return nil
+}
+
 // VerifyPushedCommit verifies that the push target branch tip is exactly commit.
 // gt/refinery callers invoke this immediately after a push, before closing beads
 // or creating downstream merge artifacts. Exact-tip verification catches the
 // dangerous case where git push exits 0 but leaves the remote branch stale.
+//
+// Only safe for branches the caller owns exclusively (e.g. a polecat feature
+// branch). For target branches like main where other agents push concurrently,
+// use VerifyCommitOnRemoteBranch.
 func (g *Git) VerifyPushedCommit(remote, branch, commit string) error {
 	commit = strings.TrimSpace(commit)
 	if commit == "" {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -2385,6 +2385,95 @@ func TestVerifyPushedCommit(t *testing.T) {
 	}
 }
 
+// TestVerifyCommitOnRemoteBranch covers the no-MR / direct-push completion
+// path used by gt done. The shared target branch (e.g. main) may advance
+// between push and verify when other agents push concurrently — verification
+// must accept our commit as either the tip or an ancestor of the tip.
+func TestVerifyCommitOnRemoteBranch(t *testing.T) {
+	localDir, remoteDir, mainBranch := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+
+	// Agent A pushes a commit to main.
+	if err := os.WriteFile(filepath.Join(localDir, "a.txt"), []byte("a\n"), 0644); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+	if err := g.Add("a.txt"); err != nil {
+		t.Fatalf("Add a: %v", err)
+	}
+	if err := g.Commit("agent A commit"); err != nil {
+		t.Fatalf("Commit a: %v", err)
+	}
+	aSHA, err := g.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev a: %v", err)
+	}
+	if err := g.Push("origin", mainBranch, false); err != nil {
+		t.Fatalf("Push a: %v", err)
+	}
+
+	// Agent A's commit is the tip — verification trivially passes.
+	if err := g.VerifyCommitOnRemoteBranch("origin", mainBranch, aSHA); err != nil {
+		t.Fatalf("VerifyCommitOnRemoteBranch on tip: %v", err)
+	}
+
+	// Simulate agent B pushing a commit on top of A directly to the remote,
+	// via a second clone — A does not yet know about it.
+	bDir := filepath.Join(t.TempDir(), "b")
+	for _, args := range [][]string{
+		{"git", "clone", remoteDir, bDir},
+		{"git", "-C", bDir, "config", "user.email", "b@test.com"},
+		{"git", "-C", bDir, "config", "user.name", "Agent B"},
+	} {
+		if err := exec.Command(args[0], args[1:]...).Run(); err != nil {
+			t.Fatalf("%s: %v", args, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(bDir, "b.txt"), []byte("b\n"), 0644); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+	for _, args := range [][]string{
+		{"git", "-C", bDir, "add", "b.txt"},
+		{"git", "-C", bDir, "commit", "-m", "agent B commit"},
+		{"git", "-C", bDir, "push", "origin", mainBranch},
+	} {
+		if err := exec.Command(args[0], args[1:]...).Run(); err != nil {
+			t.Fatalf("%s: %v", args, err)
+		}
+	}
+
+	// Agent A's commit is now behind the tip but still on origin/main.
+	// This is the bug from hq-5ox — must succeed, not fail.
+	if err := g.VerifyCommitOnRemoteBranch("origin", mainBranch, aSHA); err != nil {
+		t.Fatalf("VerifyCommitOnRemoteBranch on ancestor (hq-5ox regression): %v", err)
+	}
+
+	// An unrelated commit that was never pushed must still fail.
+	if err := g.Checkout(mainBranch); err != nil {
+		t.Fatalf("Checkout main: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "unpushed.txt"), []byte("nope\n"), 0644); err != nil {
+		t.Fatalf("write unpushed: %v", err)
+	}
+	if err := g.Add("unpushed.txt"); err != nil {
+		t.Fatalf("Add unpushed: %v", err)
+	}
+	if err := g.Commit("unpushed commit"); err != nil {
+		t.Fatalf("Commit unpushed: %v", err)
+	}
+	unpushedSHA, err := g.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev unpushed: %v", err)
+	}
+	if err := g.VerifyCommitOnRemoteBranch("origin", mainBranch, unpushedSHA); err == nil {
+		t.Fatal("VerifyCommitOnRemoteBranch should fail for commit not on remote branch")
+	}
+
+	// Missing branch should still fail.
+	if err := g.VerifyCommitOnRemoteBranch("origin", "no-such-branch", aSHA); err == nil {
+		t.Fatal("VerifyCommitOnRemoteBranch should fail for missing branch")
+	}
+}
+
 func TestVerifyPushedCommitSplitURL(t *testing.T) {
 	localDir, _, _, _ := initTestRepoWithSplitRemote(t)
 	g := NewGit(localDir)


### PR DESCRIPTION
## Summary

`gt done` falsely reports `verified_push_failed` on no-MR / direct-merge completion when the target branch tip has advanced past the polecat's commit between push and verify (concurrent agent activity). The polecat then can't self-close, idles, and accumulates as a zombie — observed in the wild as 4 polecats warrant-reaped in a single incident.

Fix: accept the commit as the tip **or an ancestor** of the tip, instead of requiring exact tip-equality.

## Related Issue

No GitHub issue — submitted as a bug fix with a reproduction (per CONTRIBUTING "good first contributions"). The bug reproduces on current `main`.

## Changes

- New `git.VerifyCommitOnRemoteBranch`: verifies the commit is reachable from the remote branch tip via `git merge-base --is-ancestor` (with an exact-tip fast path and a fetch before the ancestry check).
- Route the three shared-target-branch verify call sites in `done.go` (no-MR, direct-merge, late-direct-merge) through it.
- Retain exact-tip `VerifyPushedCommit` for feature-branch verification, where the caller owns the branch exclusively and a tip mismatch is a genuine stale/failed push.
- Regression test simulating a concurrent push to `main` from a second clone.

## Repro

Polecat pushes commit `A` to `origin/main` → another polecat pushes `B` → verify checks `tip == A`, sees `B`, and returns `verified_push_failed: commit A not on origin/main (remote tip B)` — even though `git merge-base --is-ancestor A origin/main` is true.

## Design note (ZFC)

Pure-transport correctness fix: it replaces an overly strict equality check on a git primitive with the correct reachability check (`merge-base --is-ancestor`). No heuristics or thresholds — ancestry is deterministic.

## Testing
- [x] `go test ./internal/git/` passes, incl. new `TestVerifyCommitOnRemoteBranch` (tip / ancestor / not-present / missing-branch cases)
- [x] Existing `TestVerifyPushedCommit` and `…SplitURL` still pass (exact-tip semantics preserved for feature branches)
- [x] `go vet ./internal/git/ ./internal/cmd/` and `gofmt` clean
- [ ] `go test ./...`: changed packages pass; the pre-existing env-dependent failures in `internal/tmux` / `internal/polecat` / `internal/cmd` reproduce identically on clean `main` and are not introduced here

## Checklist
- [x] Code follows project style (gofmt, go vet)
- [x] No breaking changes
- [x] Tests added for new functionality
