### PR TITLE
feat(dolt-backup): retention policy — prune .darc older than N days, keep floor of 3

### DIFF
--- a/plugins/dolt-backup/run.sh
+++ b/plugins/dolt-backup/run.sh
@@ -4,6 +4,8 @@
 # Syncs production databases to filesystem backups via `dolt backup sync`.
 # Skips databases that haven't changed since last backup (hash check).
 # Only escalates when actual backup operations fail — not on ping failures.
+# After each run, prunes old .darc files keeping at least BACKUP_SAFETY_FLOOR
+# most-recent archives and deleting any older than BACKUP_RETENTION_DAYS.
 #
 # Usage: ./run.sh [--databases db1,db2,...] [--dry-run]
 
@@ -30,6 +32,8 @@ if [[ -z "${DOLT_BACKUP_DIR:-}" ]]; then
 fi
 BACKUP_DIR="$DOLT_BACKUP_DIR"
 BACKUP_TIMEOUT=60
+BACKUP_RETENTION_DAYS="${BACKUP_RETENTION_DAYS:-7}"
+BACKUP_SAFETY_FLOOR="${BACKUP_SAFETY_FLOOR:-3}"
 
 # --- Argument parsing ---------------------------------------------------------
 
@@ -52,6 +56,54 @@ done
 
 log() {
   echo "[dolt-backup] $*"
+}
+
+# retention_cleanup <backup_path>
+# Deletes .darc files older than BACKUP_RETENTION_DAYS, always keeping the
+# BACKUP_SAFETY_FLOOR most-recent files. Non-fatal: errors are logged and skipped.
+retention_cleanup() {
+  local backup_path="$1"
+  [[ -d "$backup_path" ]] || return 0
+
+  # Collect all .darc files sorted newest-first (ls -t is portable on macOS+Linux)
+  local -a darcs=()
+  while IFS= read -r f; do
+    darcs+=("$f")
+  done < <(ls -t "$backup_path"/*.darc 2>/dev/null || true)
+
+  local total=${#darcs[@]}
+  [[ $total -eq 0 ]] && return 0
+
+  local deleted=0
+  local freed_kb=0
+  local cutoff=$(( $(date +%s) - BACKUP_RETENTION_DAYS * 86400 ))
+
+  for (( i=0; i<total; i++ )); do
+    local f="${darcs[$i]}"
+    # Safety floor: never delete the BACKUP_SAFETY_FLOOR most-recent archives
+    (( i < BACKUP_SAFETY_FLOOR )) && continue
+
+    # mtime: macOS uses stat -f "%m"; GNU stat uses stat -c "%Y"
+    local mtime
+    mtime=$(stat -f "%m" "$f" 2>/dev/null || stat -c "%Y" "$f" 2>/dev/null || echo 0)
+
+    if (( mtime < cutoff )); then
+      local age_days=$(( ( $(date +%s) - mtime ) / 86400 ))
+      local kb
+      kb=$(du -k "$f" 2>/dev/null | cut -f1 || echo 0)
+      if rm -f "$f" 2>/dev/null; then
+        deleted=$(( deleted + 1 ))
+        freed_kb=$(( freed_kb + kb ))
+        log "    retention: removed $(basename "$f") (${age_days}d old, ${kb}KB)"
+      else
+        log "    retention: could not remove $(basename "$f") — skipping"
+      fi
+    fi
+  done
+
+  if (( deleted > 0 )); then
+    log "  retention: freed ${freed_kb}KB across ${deleted} file(s) (${BACKUP_RETENTION_DAYS}d policy, floor ${BACKUP_SAFETY_FLOOR})"
+  fi
 }
 
 # --- Step 1: Discover databases -----------------------------------------------
@@ -153,12 +205,46 @@ for DB in "${PROD_DBS[@]}"; do
   fi
 done
 
-# --- Step 3: Report results ---------------------------------------------------
+# --- Step 3: Retention — prune old .darc files --------------------------------
+# Read each DB's configured backup URL from repo_state.json. Only file:// remotes
+# are pruned (remote/cloud remotes manage their own retention).
 
-SUMMARY="Backup: $SYNCED synced, $SKIPPED unchanged, $FAILED failed (of ${#PROD_DBS[@]} DBs)"
+RETENTION_CLEANED=0
+for DB in "${PROD_DBS[@]}"; do
+  DB_DIR="$DOLT_DATA_DIR/$DB"
+  REPO_STATE="$DB_DIR/.dolt/repo_state.json"
+  [[ -f "$REPO_STATE" ]] || continue
+
+  # Extract first backup URL (python3 is available on all Gas Town nodes)
+  BACKUP_URL=$(python3 -c "
+import json, sys
+try:
+    d = json.load(open(sys.argv[1]))
+    bk = d.get('backups', {})
+    if bk:
+        print(list(bk.values())[0]['url'])
+except Exception:
+    pass
+" "$REPO_STATE" 2>/dev/null || true)
+
+  if [[ "$BACKUP_URL" == file://* ]]; then
+    BACKUP_PATH="${BACKUP_URL#file://}"
+    if $DRY_RUN; then
+      DARC_COUNT=$(ls "$BACKUP_PATH"/*.darc 2>/dev/null | wc -l | tr -d ' ')
+      log "  $DB: DRY RUN retention — $DARC_COUNT .darc in $BACKUP_PATH"
+    else
+      retention_cleanup "$BACKUP_PATH"
+      RETENTION_CLEANED=$(( RETENTION_CLEANED + 1 ))
+    fi
+  fi
+done
+
+# --- Step 4: Report results ---------------------------------------------------
+
+SUMMARY="Backup: $SYNCED synced, $SKIPPED unchanged, $FAILED failed (of ${#PROD_DBS[@]} DBs); retention checked ${RETENTION_CLEANED} backup dir(s)"
 log "$SUMMARY"
 
-# --- Step 4: Record result and escalate if needed -----------------------------
+# --- Step 5: Record result and escalate if needed -----------------------------
 
 if [[ "$FAILED" -eq 0 ]]; then
   # Success — record quietly


### PR DESCRIPTION
## Summary

Adds a retention policy to `plugins/dolt-backup/run.sh`. After the backup loop,
each DB's configured backup URL is read from `repo_state.json` and
`retention_cleanup()` is called for `file://` remotes (cloud remotes manage
their own retention).

- **Safety floor**: never delete below `BACKUP_SAFETY_FLOOR` (default `3`) most-recent `.darc` archives
- **Age policy**: delete `.darc` older than `BACKUP_RETENTION_DAYS` (default `7`)
- **Scope**: only `file://` remotes; cloud remotes are skipped
- **Non-fatal**: errors are logged but never propagated — sync reporting is never blocked
- **Cross-platform**: macOS `stat -f` and Linux `stat -c` both supported

Both `BACKUP_SAFETY_FLOOR` and `BACKUP_RETENTION_DAYS` are env-overridable.

## History

Originally submitted as #4040 from `crew/batista/dc-2ajt`, but that branch was
contaminated with ~80 unrelated files (data, mail, beads, etc.) and the PR was
closed. This PR is a clean cherry-pick of just the `plugins/dolt-backup/run.sh`
commit (`0dee05c0`) onto a fresh branch from `main`.

## Test plan

- [x] Bash syntax: `bash -n plugins/dolt-backup/run.sh` passes
- [x] Original author dry-run: correctly identifies 8 backup dirs
- [x] Original author functional test: 5 files (3 new + 2 old@10d) → keeps 3, deletes 2
- [ ] CI on this PR

## Pre-existing test failures (not caused by this PR)

`internal/cmd` fails on `go test ./...` with "This binary was built with 'go build' directly. macOS will SIGKILL unsigned binaries. Use 'make build' instead." This failure exists on `upstream/main` (verified by running the test there). This PR only modifies a shell script and cannot affect Go tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)