### PR TITLE
fix: harden GT against Dolt subprocess storms

### DIFF
--- a/.opencode/plugins/gastown.js
+++ b/.opencode/plugins/gastown.js
@@ -2,16 +2,16 @@
 // Injects gt prime context into the system prompt via experimental.chat.system.transform.
 export const GasTown = async ({ $, directory }) => {
   const role = (process.env.GT_ROLE || "").toLowerCase();
-  const autonomousRoles = new Set(["polecat", "witness", "refinery", "deacon"]);
+  const gtBin = "gt";
   let didInit = false;
 
-  // Promise-based context loading ensures the system transform hook can
-  // await the result even if session.created hasn't resolved yet.
   let primePromise = null;
+
+  const shellQuote = (value) => `'${String(value).replace(/'/g, `'\\''`)}'`;
+  const eventSessionID = (event) => event?.properties?.info?.id || event?.sessionID || event?.session?.id || "";
 
   const captureRun = async (cmd) => {
     try {
-      // .text() captures stdout as a string and suppresses terminal echo.
       return await $`/bin/sh -lc ${cmd}`.cwd(directory).text();
     } catch (err) {
       console.error(`[gastown] ${cmd} failed`, err?.message || err);
@@ -19,17 +19,12 @@ export const GasTown = async ({ $, directory }) => {
     }
   };
 
-  const loadPrime = async () => {
-    let context = await captureRun("gt prime");
-    if (autonomousRoles.has(role)) {
-      const mail = await captureRun("gt mail check --inject");
-      if (mail) {
-        context += "\n" + mail;
-      }
+  const loadPrime = async (source = "startup", sessionID = "") => {
+    const env = [`GT_HOOK_SOURCE=${shellQuote(source)}`];
+    if (sessionID) {
+      env.push(`GT_SESSION_ID=${shellQuote(sessionID)}`);
     }
-    // NOTE: session-started nudge to deacon removed — it interrupted
-    // the deacon's await-signal backoff. Deacon wakes on beads activity.
-    return context;
+    return await captureRun(`${env.join(" ")} ${shellQuote(gtBin)} prime --hook`);
   };
 
   return {
@@ -37,30 +32,26 @@ export const GasTown = async ({ $, directory }) => {
       if (event?.type === "session.created") {
         if (didInit) return;
         didInit = true;
-        // Start loading prime context early; system.transform will await it.
-        primePromise = loadPrime();
+        primePromise = loadPrime("startup", eventSessionID(event));
       }
       if (event?.type === "session.compacted") {
-        // Reset so next system.transform gets fresh context.
-        primePromise = loadPrime();
+        primePromise = loadPrime("compact", eventSessionID(event));
       }
       if (event?.type === "session.deleted") {
         const sessionID = event.properties?.info?.id;
         if (sessionID) {
-          await $`gt costs record --session ${sessionID}`.catch(() => {});
+          await captureRun(`${shellQuote(gtBin)} costs record --session ${shellQuote(sessionID)}`);
         }
       }
     },
     "experimental.chat.system.transform": async (input, output) => {
-      // If session.created hasn't fired yet, start loading now.
       if (!primePromise) {
-        primePromise = loadPrime();
+        primePromise = loadPrime("startup");
       }
       const context = await primePromise;
       if (context) {
         output.system.push(context);
       } else {
-        // Reset so next transform retries instead of pushing empty forever.
         primePromise = null;
       }
     },
@@ -69,7 +60,7 @@ export const GasTown = async ({ $, directory }) => {
       output.context.push(`
 ## Gas Town Multi-Agent System
 
-**After Compaction:** Run \`gt prime\` to restore full context.
+**After Compaction:** Run \`gt prime --hook\` to restore full context.
 **Check Hook:** \`gt hook\` - if work present, execute immediately (GUPP).
 **Role:** ${roleDisplay}
 `);

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,7 +140,7 @@ gt mail inbox         # Check for messages
 <!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:ca08a54f -->
 ## Beads Issue Tracker
 
-This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+This project uses **bd (beads)** for issue tracking. Run `gt prime` to see full workflow context and commands.
 
 ### Quick Reference
 
@@ -154,7 +154,7 @@ bd close <id>         # Complete work
 ### Rules
 
 - Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
-- Run `bd prime` for detailed command reference and session close protocol
+- Run `gt prime` for detailed command reference and session close protocol
 - Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
 
 ## Session Completion

--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ Federated work coordination network linking Gas Towns through DoltHub. Rigs post
 
 - **Go 1.25+** - [go.dev/dl](https://go.dev/dl/)
 - **Git 2.25+** - for worktree support
-- **Dolt 1.82.4+** - `brew install dolt` on macOS, or see [github.com/dolthub/dolt](https://github.com/dolthub/dolt)
+- **Dolt 1.84.0+** - `brew install dolt` on macOS, or see [github.com/dolthub/dolt](https://github.com/dolthub/dolt)
 - **beads (bd) 0.55.4+** - installed by `brew install gastown`, or see [github.com/steveyegge/beads](https://github.com/steveyegge/beads)
 - **sqlite3** - for convoy database queries (usually pre-installed on macOS/Linux)
 - **tmux 3.0+** - recommended for full experience

--- a/docs/INSTALLING.md
+++ b/docs/INSTALLING.md
@@ -10,7 +10,7 @@ Complete setup guide for Gas Town multi-agent orchestrator.
 |------|---------|-------|---------|
 | **Go** | 1.25.8+ | `go version` | See [golang.org](https://go.dev/doc/install) |
 | **Git** | 2.20+ | `git --version` | See below |
-| **Dolt** | >= 1.82.4 | `dolt version` | macOS: `brew install dolt`; other platforms: see [dolthub/dolt](https://github.com/dolthub/dolt?tab=readme-ov-file#installation) |
+| **Dolt** | >= 1.84.0 | `dolt version` | macOS: `brew install dolt`; other platforms: see [dolthub/dolt](https://github.com/dolthub/dolt?tab=readme-ov-file#installation) |
 | **Beads** | >= 0.55.4 | `bd version` | Installed by `brew install gastown`, or from source with `go install github.com/steveyegge/beads/cmd/bd@latest` |
 
 ### Optional (for Full Stack Mode)
@@ -74,7 +74,7 @@ sudo dnf install -y tmux
 # Check all prerequisites
 go version        # Should show go1.25.8 or higher
 git --version     # Should show 2.20 or higher
-dolt version      # Should show 1.82.4 or higher
+dolt version      # Should show 1.84.0 or higher
 tmux -V           # (Optional) Should show 3.0 or higher
 ```
 

--- a/docs/WASTELAND.md
+++ b/docs/WASTELAND.md
@@ -37,7 +37,7 @@ You need a running Gas Town installation and a DoltHub account.
 | Requirement | Check | Setup |
 |-------------|-------|-------|
 | **Gas Town** | `gt version` | See [INSTALLING.md](INSTALLING.md) |
-| **Dolt** | `dolt version` (>= 1.82.4) | See [dolthub/dolt](https://github.com/dolthub/dolt?tab=readme-ov-file#installation) |
+| **Dolt** | `dolt version` (>= 1.84.0) | See [dolthub/dolt](https://github.com/dolthub/dolt?tab=readme-ov-file#installation) |
 | **DoltHub account** | — | [Sign up](https://www.dolthub.com/signin) |
 | **DoltHub API token** | — | [Generate token](https://www.dolthub.com/settings/tokens) |
 

--- a/docs/guides/mvgt-integration.md
+++ b/docs/guides/mvgt-integration.md
@@ -2,7 +2,7 @@
 
 > **Minimum Viable Gas Town** — How to participate in the Wasteland federation using only Dolt and the commons schema, without running Gas Town.
 
-**Commons schema version:** 1.1 | **Dolt version tested:** 1.83.1 | **Last updated:** March 2026
+**Commons schema version:** 1.1 | **Dolt version tested:** 1.84.0 | **Last updated:** March 2026
 
 ---
 
@@ -18,7 +18,7 @@ This guide was planned using Jeffrey Emanuel's agent flywheel — a comprehensiv
 
 ## Prerequisites
 
-**Dolt CLI (>= v1.83.1)**
+**Dolt CLI (>= v1.84.0)**
 
 Dolt is a SQL database with Git-like version control. Install it for your platform:
 
@@ -34,7 +34,7 @@ Dolt is a SQL database with Git-like version control. Install it for your platfo
   ```bash
   dolt version
   ```
-  Confirm the output shows `1.83.1` or higher.
+  Confirm the output shows `1.84.0` or higher.
 
 **DoltHub Account**
 
@@ -59,7 +59,7 @@ This is the ten-step path from zero to your first claimed item on the Wasteland 
 
 **1. Install Dolt**
 
-Pick the one-liner for your platform and run it. Linux: `sudo bash -c 'curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash'`. macOS: `brew install dolt`. Confirm with `dolt version` — you need v1.83.1 or higher.
+Pick the one-liner for your platform and run it. Linux: `sudo bash -c 'curl -L https://github.com/dolthub/dolt/releases/latest/download/install.sh | bash'`. macOS: `brew install dolt`. Confirm with `dolt version` — you need v1.84.0 or higher.
 
 **2. Create a DoltHub account and authenticate**
 
@@ -469,7 +469,7 @@ dolt version
 dolt version 1.x.x
 ```
 
-Any version `1.83.1` or later supports all features used by the commons. If the command is not found, ensure `dolt` is on your `PATH`.
+Any version `1.84.0` or later supports all features used by the commons. If the command is not found, ensure `dolt` is on your `PATH`.
 
 ### Step 2: Authenticate with DoltHub
 
@@ -927,7 +927,7 @@ The system also includes Agent Mail, an MCP-based messaging system for inter-age
 
 On March 4, 2026, the flywheel completed the full MVGT flow without Gas Town installed. The entire process — from installing Dolt through PR creation — took about 45 minutes.
 
-After installing Dolt v1.83.1 and authenticating with DoltHub as `jorisdevreede`, the flywheel forked `steveyegge/wl-commons`, cloned the fork to `/tmp/wl-commons-test`, and registered a rig:
+After installing Dolt v1.84.0 and authenticating with DoltHub as `jorisdevreede`, the flywheel forked `steveyegge/wl-commons`, cloned the fork to `/tmp/wl-commons-test`, and registered a rig:
 
 ```sql
 INSERT INTO rigs (handle, display_name, dolthub_org, trust_level, rig_type, registered_at, last_seen)

--- a/internal/beads/bd_subprocess_policy_test.go
+++ b/internal/beads/bd_subprocess_policy_test.go
@@ -1,0 +1,113 @@
+package beads
+
+import (
+	"go/ast"
+	"go/parser"
+	"go/token"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestNoAdHocBdSubprocessesInHardenedPackages(t *testing.T) {
+	_, thisFile, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	repoRoot := filepath.Clean(filepath.Join(filepath.Dir(thisFile), "..", ".."))
+	packages := []string{
+		"internal/deacon",
+		"internal/plugin",
+		"internal/refinery",
+		"internal/witness",
+	}
+
+	var violations []string
+	for _, pkg := range packages {
+		dir := filepath.Join(repoRoot, pkg)
+		entries, err := os.ReadDir(dir)
+		if err != nil {
+			t.Fatalf("read %s: %v", dir, err)
+		}
+		for _, entry := range entries {
+			name := entry.Name()
+			if entry.IsDir() || !strings.HasSuffix(name, ".go") || strings.HasSuffix(name, "_test.go") {
+				continue
+			}
+			path := filepath.Join(dir, name)
+			violations = append(violations, adHocBDSubprocesses(t, repoRoot, path)...)
+		}
+	}
+
+	if len(violations) > 0 {
+		t.Fatalf("do not spawn bd directly in hardened packages; use internal/beads.Command so env targeting, read-only mode, and side-effect suppression stay centralized:\n%s", strings.Join(violations, "\n"))
+	}
+}
+
+func adHocBDSubprocesses(t *testing.T, repoRoot, path string) []string {
+	t.Helper()
+	fset := token.NewFileSet()
+	file, err := parser.ParseFile(fset, path, nil, 0)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+
+	var out []string
+	ast.Inspect(file, func(n ast.Node) bool {
+		call, ok := n.(*ast.CallExpr)
+		if !ok || !isExecCommandCall(call) {
+			return true
+		}
+		argIndex := 0
+		if selectorName(call) == "CommandContext" {
+			argIndex = 1
+		}
+		if len(call.Args) <= argIndex || !isBDCommandArg(call.Args[argIndex]) {
+			return true
+		}
+		pos := fset.Position(call.Pos())
+		rel, err := filepath.Rel(repoRoot, pos.Filename)
+		if err != nil {
+			rel = pos.Filename
+		}
+		out = append(out, rel+":"+strconv.Itoa(pos.Line))
+		return true
+	})
+	return out
+}
+
+func isExecCommandCall(call *ast.CallExpr) bool {
+	sel, ok := call.Fun.(*ast.SelectorExpr)
+	if !ok || (sel.Sel.Name != "Command" && sel.Sel.Name != "CommandContext") {
+		return false
+	}
+	x, ok := sel.X.(*ast.Ident)
+	return ok && x.Name == "exec"
+}
+
+func selectorName(call *ast.CallExpr) string {
+	if sel, ok := call.Fun.(*ast.SelectorExpr); ok {
+		return sel.Sel.Name
+	}
+	return ""
+}
+
+func isBDCommandArg(expr ast.Expr) bool {
+	switch v := expr.(type) {
+	case *ast.BasicLit:
+		if v.Kind != token.STRING {
+			return false
+		}
+		value, err := strconv.Unquote(v.Value)
+		return err == nil && value == "bd"
+	case *ast.Ident:
+		return strings.EqualFold(v.Name, "bdPath")
+	case *ast.SelectorExpr:
+		return strings.EqualFold(v.Sel.Name, "bdPath")
+	default:
+		return false
+	}
+}

--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -725,11 +725,9 @@ func (b *Beads) buildRunEnv() []string {
 			env = append(env, fmt.Sprintf("GT_DOLT_PORT=%d", b.serverPort))
 			env = append(env, fmt.Sprintf("BEADS_DOLT_PORT=%d", b.serverPort))
 		}
-		return env
+		return SuppressBDSideEffects(env)
 	}
-	env := stripEnvPrefixes(os.Environ(), "BEADS_DIR=")
-	env = overrideDoltEnvFromBeadsDir(env, b.getResolvedBeadsDir())
-	return translateDoltPort(env)
+	return BuildPinnedBDEnv(os.Environ(), b.getResolvedBeadsDir())
 }
 
 // buildRoutingEnv builds the environment for runWithRouting() calls.
@@ -742,11 +740,9 @@ func (b *Beads) buildRoutingEnv() []string {
 			env = append(env, fmt.Sprintf("GT_DOLT_PORT=%d", b.serverPort))
 			env = append(env, fmt.Sprintf("BEADS_DOLT_PORT=%d", b.serverPort))
 		}
-		return env
+		return SuppressBDSideEffects(env)
 	}
-	env := stripEnvPrefixes(os.Environ(), "BEADS_DIR=")
-	env = overrideDoltEnvFromBeadsDir(env, b.getResolvedBeadsDir())
-	return translateDoltPort(env)
+	return BuildRoutingBDEnv(os.Environ(), b.getResolvedBeadsDir())
 }
 
 // filterBeadsEnv removes beads-related environment variables from the given

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -87,6 +87,240 @@ func TestCreateOptionsRig(t *testing.T) {
 	}
 }
 
+func TestBuildPinnedBDEnvUsesSelectedMetadata(t *testing.T) {
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := []byte(`{"dolt_database":"rigdb","dolt_server_host":"127.0.0.1","dolt_server_port":4407}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := BuildPinnedBDEnv([]string{
+		"PATH=/usr/bin",
+		"BEADS_DIR=/wrong",
+		"BEADS_DB=/wrong.db",
+		"BD_DB=/wrong.bd",
+		"BEADS_DOLT_SERVER_DATABASE=hq",
+		"BEADS_DOLT_SERVER_HOST=wrong-host",
+		"BEADS_DOLT_SERVER_PORT=9999",
+		"BEADS_DOLT_PORT=9999",
+		"BEADS_DOLT_DATA_DIR=/wrong/data",
+		"BEADS_DOLT_AUTO_START=0",
+	}, beadsDir)
+	got := envMap(env)
+
+	if got["BEADS_DIR"] != beadsDir {
+		t.Fatalf("BEADS_DIR = %q, want %q in %v", got["BEADS_DIR"], beadsDir, env)
+	}
+	if got["BEADS_DOLT_SERVER_DATABASE"] != "rigdb" {
+		t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want rigdb in %v", got["BEADS_DOLT_SERVER_DATABASE"], env)
+	}
+	if got["BEADS_DOLT_SERVER_HOST"] != "127.0.0.1" {
+		t.Fatalf("BEADS_DOLT_SERVER_HOST = %q, want 127.0.0.1 in %v", got["BEADS_DOLT_SERVER_HOST"], env)
+	}
+	if got["BEADS_DOLT_SERVER_PORT"] != "4407" || got["BEADS_DOLT_PORT"] != "4407" {
+		t.Fatalf("ports = server:%q legacy:%q, want 4407 in %v", got["BEADS_DOLT_SERVER_PORT"], got["BEADS_DOLT_PORT"], env)
+	}
+	for _, key := range []string{"BEADS_DB", "BD_DB", "BEADS_DOLT_DATA_DIR"} {
+		if value, ok := got[key]; ok {
+			t.Fatalf("%s should be stripped, got %q in %v", key, value, env)
+		}
+	}
+	if got["BEADS_DOLT_AUTO_START"] != "0" {
+		t.Fatalf("BEADS_DOLT_AUTO_START should be preserved, got %q in %v", got["BEADS_DOLT_AUTO_START"], env)
+	}
+}
+
+func TestBuildRoutingBDEnvStripsDatabaseButKeepsSelectedConnection(t *testing.T) {
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := []byte(`{"dolt_database":"rigdb","dolt_server_host":"127.0.0.1","dolt_server_port":4407}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := BuildRoutingBDEnv([]string{
+		"PATH=/usr/bin",
+		"BEADS_DIR=/wrong",
+		"BEADS_DOLT_SERVER_DATABASE=hq",
+		"BEADS_DOLT_SERVER_HOST=wrong-host",
+		"BEADS_DOLT_SERVER_PORT=9999",
+		"BEADS_DOLT_PORT=9999",
+	}, beadsDir)
+	got := envMap(env)
+	for _, key := range []string{"BEADS_DIR", "BEADS_DOLT_SERVER_DATABASE"} {
+		if value, ok := got[key]; ok {
+			t.Fatalf("%s should be absent for routed env, got %q in %v", key, value, env)
+		}
+	}
+	if got["BEADS_DOLT_SERVER_HOST"] != "127.0.0.1" || got["BEADS_DOLT_SERVER_PORT"] != "4407" || got["BEADS_DOLT_PORT"] != "4407" {
+		t.Fatalf("routing env did not use selected connection, got %v", env)
+	}
+}
+
+func TestBuildPinnedBDEnvFallsBackToGTDoltPort(t *testing.T) {
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := []byte(`{"dolt_database":"rigdb"}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := BuildPinnedBDEnv([]string{
+		"PATH=/usr/bin",
+		"GT_DOLT_HOST=127.0.0.2",
+		"GT_DOLT_PORT=5507",
+	}, beadsDir)
+	got := envMap(env)
+	if got["BEADS_DOLT_SERVER_DATABASE"] != "rigdb" {
+		t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want rigdb in %v", got["BEADS_DOLT_SERVER_DATABASE"], env)
+	}
+	if got["BEADS_DOLT_SERVER_HOST"] != "127.0.0.2" {
+		t.Fatalf("BEADS_DOLT_SERVER_HOST = %q, want GT_DOLT_HOST fallback in %v", got["BEADS_DOLT_SERVER_HOST"], env)
+	}
+	if got["BEADS_DOLT_SERVER_PORT"] != "5507" || got["BEADS_DOLT_PORT"] != "5507" {
+		t.Fatalf("ports = server:%q legacy:%q, want 5507 in %v", got["BEADS_DOLT_SERVER_PORT"], got["BEADS_DOLT_PORT"], env)
+	}
+}
+
+func TestSuppressBDSideEffectsOverridesInherited(t *testing.T) {
+	env := SuppressBDSideEffects([]string{
+		"PATH=/usr/bin",
+		"BD_EXPORT_AUTO=true",
+		"BD_BACKUP_ENABLED=true",
+		"BD_DOLT_AUTO_PUSH=true",
+		"BD_NO_PUSH=false",
+		"BD_EXPORT_GIT_ADD=true",
+		"BD_NO_GIT_OPS=false",
+	})
+	got := envMap(env)
+	for key, want := range map[string]string{
+		"BEADS_NO_AUTO_IMPORT": "1",
+		"BD_EXPORT_AUTO":       "false",
+		"BD_BACKUP_ENABLED":    "false",
+		"BD_DOLT_AUTO_PUSH":    "false",
+		"BD_NO_PUSH":           "true",
+		"BD_EXPORT_GIT_ADD":    "false",
+		"BD_NO_GIT_OPS":        "true",
+	} {
+		if got[key] != want {
+			t.Fatalf("%s = %q, want %q in %v", key, got[key], want, env)
+		}
+	}
+}
+
+func TestBuildReadOnlyBDEnvForcesReadOnly(t *testing.T) {
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"dolt_database":"hq","dolt_server_host":"127.0.0.1","dolt_server_port":3307}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := BuildReadOnlyRoutingBDEnv([]string{
+		"PATH=/usr/bin",
+		"BD_DOLT_AUTO_COMMIT=on",
+		"BD_READONLY=false",
+		"BEADS_DOLT_SERVER_DATABASE=wrong",
+	}, beadsDir)
+	got := envMap(env)
+
+	if got["BD_DOLT_AUTO_COMMIT"] != "off" {
+		t.Fatalf("BD_DOLT_AUTO_COMMIT = %q, want off in %v", got["BD_DOLT_AUTO_COMMIT"], env)
+	}
+	if got["BD_READONLY"] != "true" {
+		t.Fatalf("BD_READONLY = %q, want true in %v", got["BD_READONLY"], env)
+	}
+	if _, ok := got["BEADS_DOLT_SERVER_DATABASE"]; ok {
+		t.Fatalf("routing read-only env should not pin database: %v", env)
+	}
+}
+
+func TestBuildMutationBDEnvForcesWritableCommit(t *testing.T) {
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"dolt_database":"hq","dolt_server_host":"127.0.0.1","dolt_server_port":3307}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := BuildMutationPinnedBDEnv([]string{
+		"PATH=/usr/bin",
+		"BD_DOLT_AUTO_COMMIT=off",
+		"BD_READONLY=true",
+		"BEADS_DIR=/wrong",
+	}, beadsDir)
+	got := envMap(env)
+
+	if got["BEADS_DIR"] != beadsDir {
+		t.Fatalf("BEADS_DIR = %q, want %q in %v", got["BEADS_DIR"], beadsDir, env)
+	}
+	if got["BD_DOLT_AUTO_COMMIT"] != "on" {
+		t.Fatalf("BD_DOLT_AUTO_COMMIT = %q, want on in %v", got["BD_DOLT_AUTO_COMMIT"], env)
+	}
+	if _, ok := got["BD_READONLY"]; ok {
+		t.Fatalf("BD_READONLY should be absent for mutation env, got %q in %v", got["BD_READONLY"], env)
+	}
+}
+
+func TestArgsAreReadOnlyClassifiesKnownReadCommands(t *testing.T) {
+	cases := [][]string{
+		{"show", "gt-123", "--json"},
+		{"--allow-stale", "show", "gt-123", "--json"},
+		{"query", "merge-request", "--json"},
+		{"dep", "list", "hq-cv-123", "--json"},
+		{"mol", "wisp", "list", "--json"},
+		{"sql", "SELECT 1"},
+		{"sql", "--csv", "SELECT 1"},
+		{"config", "get", "issue_prefix"},
+	}
+	for _, args := range cases {
+		if !ArgsAreReadOnly(args) {
+			t.Fatalf("ArgsAreReadOnly(%v) = false, want true", args)
+		}
+		if got := SubprocessModeForArgs(args); got != ReadOnlyRouting {
+			t.Fatalf("SubprocessModeForArgs(%v) = %v, want ReadOnlyRouting", args, got)
+		}
+	}
+}
+
+func TestArgsAreReadOnlyFailsClosedForMutations(t *testing.T) {
+	cases := [][]string{
+		{"update", "gt-123", "--status=open"},
+		{"close", "gt-123"},
+		{"mol", "wisp", "formula"},
+		{"sql", "UPDATE issues SET status='open'"},
+		{"config", "set", "issue_prefix", "gt"},
+	}
+	for _, args := range cases {
+		if ArgsAreReadOnly(args) {
+			t.Fatalf("ArgsAreReadOnly(%v) = true, want false", args)
+		}
+		if got := SubprocessModeForArgs(args); got != MutationRouting {
+			t.Fatalf("SubprocessModeForArgs(%v) = %v, want MutationRouting", args, got)
+		}
+	}
+}
+
+func envMap(env []string) map[string]string {
+	out := make(map[string]string)
+	for _, entry := range env {
+		parts := strings.SplitN(entry, "=", 2)
+		if len(parts) == 2 {
+			out[parts[0]] = parts[1]
+		}
+	}
+	return out
+}
+
 // TestCreateRoutesSameDatabaseViaBEADSDIR verifies that when opts.Rig resolves
 // to a .beads dir that exists, Create routes via BEADS_DIR (not --repo). (hq-1uf2)
 //

--- a/internal/beads/database.go
+++ b/internal/beads/database.go
@@ -4,7 +4,25 @@ import (
 	"encoding/json"
 	"os"
 	"path/filepath"
+	"strconv"
+	"strings"
 )
+
+var bdTargetEnvKeys = []string{
+	"BEADS_DIR",
+	"BEADS_DB",
+	"BD_DB",
+	"BEADS_DOLT_DATA_DIR",
+	"BEADS_DOLT_HOST",
+	"BEADS_DOLT_PORT",
+	"BEADS_DOLT_SERVER_DATABASE",
+	"BEADS_DOLT_SERVER_HOST",
+	"BEADS_DOLT_SERVER_PORT",
+	"BEADS_DOLT_SERVER_SOCKET",
+	"BEADS_DOLT_SERVER_MODE",
+	"BEADS_DOLT_SHARED_SERVER",
+	"BEADS_SHARED_SERVER_DIR",
+}
 
 // DatabaseNameFromMetadata reads the dolt_database field from .beads/metadata.json.
 // Returns empty string if metadata doesn't exist or has no database configured.
@@ -30,4 +48,228 @@ func DatabaseEnv(beadsDir string) string {
 		return ""
 	}
 	return "BEADS_DOLT_SERVER_DATABASE=" + db
+}
+
+// StripBDTargetEnv removes inherited environment variables that can make a bd
+// subprocess select a database/server other than the .beads directory chosen by
+// Gas Town. It intentionally preserves BEADS_DOLT_AUTO_START so callers can keep
+// the shared-server guardrail enabled.
+func StripBDTargetEnv(env []string) []string {
+	filtered := env
+	for _, key := range bdTargetEnvKeys {
+		filtered = stripEnvKey(filtered, key)
+	}
+	return filtered
+}
+
+// BuildPinnedBDEnv returns env for a bd subprocess pinned to beadsDir. The
+// selected .beads metadata is authoritative over inherited BEADS_DOLT_* values.
+func BuildPinnedBDEnv(base []string, beadsDir string) []string {
+	env := SuppressBDSideEffects(StripBDTargetEnv(base))
+	if beadsDir == "" {
+		return addGTDerivedDoltTargetEnv(env)
+	}
+	env = append(env, "BEADS_DIR="+beadsDir)
+	env = append(env, doltTargetEnvFromBeadsDir(beadsDir, true)...)
+	return addGTDerivedDoltTargetEnv(env)
+}
+
+// BuildRoutingBDEnv returns env for a bd subprocess that intentionally relies on
+// bd prefix routing. It strips stale target/database selectors, then re-adds only
+// connection host/port from fallbackBeadsDir so routing can choose the database.
+func BuildRoutingBDEnv(base []string, fallbackBeadsDir string) []string {
+	env := SuppressBDSideEffects(StripBDTargetEnv(base))
+	env = append(env, doltTargetEnvFromBeadsDir(fallbackBeadsDir, false)...)
+	return addGTDerivedDoltTargetEnv(env)
+}
+
+// BuildReadOnlyPinnedBDEnv returns env for a read-only bd subprocess pinned to
+// beadsDir. It strips any inherited write/read mode before forcing read-only.
+func BuildReadOnlyPinnedBDEnv(base []string, beadsDir string) []string {
+	return forceBDReadOnly(BuildPinnedBDEnv(base, beadsDir))
+}
+
+// BuildReadOnlyRoutingBDEnv returns env for a read-only bd subprocess that uses
+// bd prefix routing instead of pinning BEADS_DIR.
+func BuildReadOnlyRoutingBDEnv(base []string, fallbackBeadsDir string) []string {
+	return forceBDReadOnly(BuildRoutingBDEnv(base, fallbackBeadsDir))
+}
+
+// BuildMutationPinnedBDEnv returns env for a mutating bd subprocess pinned to
+// beadsDir. It removes inherited read-only/auto-commit mode and forces commit-on
+// so writes do not get stranded in a daemon or status-line subprocess context.
+func BuildMutationPinnedBDEnv(base []string, beadsDir string) []string {
+	return forceBDMutation(BuildPinnedBDEnv(base, beadsDir))
+}
+
+// BuildMutationRoutingBDEnv returns env for a mutating bd subprocess that uses
+// bd prefix routing instead of pinning BEADS_DIR.
+func BuildMutationRoutingBDEnv(base []string, fallbackBeadsDir string) []string {
+	return forceBDMutation(BuildRoutingBDEnv(base, fallbackBeadsDir))
+}
+
+// ArgsAreReadOnly classifies bd CLI arguments for env policy. Unknown commands
+// are treated as mutations so they cannot accidentally inherit read-only mode.
+func ArgsAreReadOnly(args []string) bool {
+	args = stripBDGlobalFlags(args)
+	if len(args) == 0 {
+		return false
+	}
+	switch args[0] {
+	case "show", "list", "ready", "blocked", "stats", "stale", "orphans", "activity", "query", "version":
+		return true
+	case "dep":
+		return len(args) > 1 && args[1] == "list"
+	case "mol":
+		return len(args) > 2 && args[1] == "wisp" && args[2] == "list"
+	case "sql":
+		query := strings.ToLower(strings.Join(stripBDCommandFlags(args[1:]), " "))
+		return strings.HasPrefix(strings.TrimSpace(query), "select")
+	case "config":
+		return len(args) > 1 && args[1] == "get"
+	default:
+		return false
+	}
+}
+
+func stripBDGlobalFlags(args []string) []string {
+	for len(args) > 0 && strings.HasPrefix(args[0], "--") {
+		args = args[1:]
+	}
+	return args
+}
+
+func stripBDCommandFlags(args []string) []string {
+	for len(args) > 0 && strings.HasPrefix(args[0], "--") {
+		args = args[1:]
+	}
+	return args
+}
+
+// SuppressBDSideEffects disables Beads JSONL export/backup/push side effects for
+// Gas Town-managed subprocesses. The authoritative data plane is Dolt; exporting
+// JSONL from high-frequency gt callers re-invalidates Beads' import freshness
+// checks and can create a self-feeding Dolt load loop.
+func SuppressBDSideEffects(env []string) []string {
+	for _, key := range []string{
+		"BEADS_NO_AUTO_IMPORT",
+		"BD_EXPORT_AUTO",
+		"BD_BACKUP_ENABLED",
+		"BD_DOLT_AUTO_PUSH",
+		"BD_NO_PUSH",
+		"BD_EXPORT_GIT_ADD",
+		"BD_NO_GIT_OPS",
+	} {
+		env = stripEnvKey(env, key)
+	}
+	return append(env,
+		"BEADS_NO_AUTO_IMPORT=1",
+		"BD_EXPORT_AUTO=false",
+		"BD_BACKUP_ENABLED=false",
+		"BD_DOLT_AUTO_PUSH=false",
+		"BD_NO_PUSH=true",
+		"BD_EXPORT_GIT_ADD=false",
+		"BD_NO_GIT_OPS=true",
+	)
+}
+
+func forceBDReadOnly(env []string) []string {
+	env = stripEnvKey(env, "BD_DOLT_AUTO_COMMIT")
+	env = stripEnvKey(env, "BD_READONLY")
+	return append(env, "BD_DOLT_AUTO_COMMIT=off", "BD_READONLY=true")
+}
+
+func forceBDMutation(env []string) []string {
+	env = stripEnvKey(env, "BD_DOLT_AUTO_COMMIT")
+	env = stripEnvKey(env, "BD_READONLY")
+	return append(env, "BD_DOLT_AUTO_COMMIT=on")
+}
+
+func doltTargetEnvFromBeadsDir(beadsDir string, includeDatabase bool) []string {
+	if beadsDir == "" {
+		return nil
+	}
+	meta := readDoltMetadata(beadsDir)
+	var env []string
+	if includeDatabase && meta.Database != "" {
+		env = append(env, "BEADS_DOLT_SERVER_DATABASE="+meta.Database)
+	}
+	if meta.Host != "" {
+		env = append(env, "BEADS_DOLT_SERVER_HOST="+meta.Host)
+	}
+	if meta.Port != "" {
+		env = append(env, "BEADS_DOLT_SERVER_PORT="+meta.Port)
+		env = append(env, "BEADS_DOLT_PORT="+meta.Port)
+	}
+	return env
+}
+
+type doltMetadata struct {
+	Database string
+	Host     string
+	Port     string
+}
+
+func readDoltMetadata(beadsDir string) doltMetadata {
+	var meta doltMetadata
+	if data, err := os.ReadFile(filepath.Join(beadsDir, "dolt-server.port")); err == nil {
+		meta.Port = strings.TrimSpace(string(data))
+	}
+	data, err := os.ReadFile(filepath.Join(beadsDir, "metadata.json"))
+	if err != nil {
+		return meta
+	}
+	var raw struct {
+		DoltDatabase   string `json:"dolt_database"`
+		DoltServerHost string `json:"dolt_server_host"`
+		DoltServerPort int    `json:"dolt_server_port"`
+	}
+	if json.Unmarshal(data, &raw) != nil {
+		return meta
+	}
+	meta.Database = strings.TrimSpace(raw.DoltDatabase)
+	meta.Host = strings.TrimSpace(raw.DoltServerHost)
+	if meta.Port == "" && raw.DoltServerPort > 0 {
+		meta.Port = strconv.Itoa(raw.DoltServerPort)
+	}
+	return meta
+}
+
+func stripEnvKey(env []string, key string) []string {
+	prefix := key + "="
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
+}
+
+func addGTDerivedDoltTargetEnv(env []string) []string {
+	gtHost := envValue(env, "GT_DOLT_HOST")
+	gtPort := envValue(env, "GT_DOLT_PORT")
+	if gtHost != "" && envValue(env, "BEADS_DOLT_SERVER_HOST") == "" {
+		env = append(env, "BEADS_DOLT_SERVER_HOST="+gtHost)
+	}
+	if gtPort != "" {
+		if envValue(env, "BEADS_DOLT_SERVER_PORT") == "" {
+			env = append(env, "BEADS_DOLT_SERVER_PORT="+gtPort)
+		}
+		if envValue(env, "BEADS_DOLT_PORT") == "" {
+			env = append(env, "BEADS_DOLT_PORT="+gtPort)
+		}
+	}
+	return env
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return strings.TrimPrefix(entry, prefix)
+		}
+	}
+	return ""
 }

--- a/internal/beads/exec.go
+++ b/internal/beads/exec.go
@@ -1,0 +1,66 @@
+package beads
+
+import (
+	"context"
+	"os"
+	"os/exec"
+
+	"github.com/steveyegge/gastown/internal/util"
+)
+
+// SubprocessEnvMode describes how a bd subprocess should target Dolt and
+// whether it may mutate state. New raw bd call sites should use this helper so
+// target selection and side-effect suppression stay centralized.
+type SubprocessEnvMode int
+
+const (
+	ReadOnlyRouting SubprocessEnvMode = iota
+	MutationRouting
+	ReadOnlyPinned
+	MutationPinned
+)
+
+// Command builds a bd command with the shared Gas Town bd environment policy.
+func Command(dir, fallbackBeadsDir string, mode SubprocessEnvMode, args ...string) *exec.Cmd {
+	cmd := exec.Command("bd", args...) //nolint:gosec // G204: args are constructed internally
+	ConfigureCommand(cmd, dir, fallbackBeadsDir, mode)
+	return cmd
+}
+
+// CommandContext builds a context-bound bd command with the shared Gas Town bd
+// environment policy.
+func CommandContext(ctx context.Context, dir, fallbackBeadsDir string, mode SubprocessEnvMode, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: args are constructed internally
+	ConfigureCommand(cmd, dir, fallbackBeadsDir, mode)
+	return cmd
+}
+
+// ConfigureCommand applies the shared bd subprocess policy to an existing
+// command. This is for callers that need a custom bd path.
+func ConfigureCommand(cmd *exec.Cmd, dir, fallbackBeadsDir string, mode SubprocessEnvMode) {
+	cmd.Dir = dir
+	cmd.Env = EnvForSubprocessMode(os.Environ(), fallbackBeadsDir, mode)
+	util.SetDetachedProcessGroup(cmd)
+}
+
+func EnvForSubprocessMode(base []string, fallbackBeadsDir string, mode SubprocessEnvMode) []string {
+	switch mode {
+	case ReadOnlyRouting:
+		return BuildReadOnlyRoutingBDEnv(base, fallbackBeadsDir)
+	case MutationRouting:
+		return BuildMutationRoutingBDEnv(base, fallbackBeadsDir)
+	case ReadOnlyPinned:
+		return BuildReadOnlyPinnedBDEnv(base, fallbackBeadsDir)
+	case MutationPinned:
+		return BuildMutationPinnedBDEnv(base, fallbackBeadsDir)
+	default:
+		return BuildMutationRoutingBDEnv(base, fallbackBeadsDir)
+	}
+}
+
+func SubprocessModeForArgs(args []string) SubprocessEnvMode {
+	if ArgsAreReadOnly(args) {
+		return ReadOnlyRouting
+	}
+	return MutationRouting
+}

--- a/internal/cmd/bd_helpers.go
+++ b/internal/cmd/bd_helpers.go
@@ -1,12 +1,18 @@
 package cmd
 
 import (
+	"context"
+	"fmt"
 	"io"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
+	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/constants"
+	"github.com/steveyegge/gastown/internal/util"
 )
 
 // bdCmd is a builder for constructing bd exec.Command calls.
@@ -20,6 +26,7 @@ type bdCmd struct {
 	autoCommit bool
 	gtRoot     string
 	beadsDir   string
+	routing    bool
 }
 
 // BdCmd creates a new bd command builder with the given arguments.
@@ -80,6 +87,14 @@ func (b *bdCmd) StripBeadsDir() *bdCmd {
 	return b
 }
 
+// WithRouting strips inherited bd target selectors and does not pin BEADS_DIR,
+// allowing bd prefix routing to choose the target database. Dir still sets cwd.
+func (b *bdCmd) WithRouting() *bdCmd {
+	b.routing = true
+	b.env = filterEnvKey(b.env, "BEADS_DIR")
+	return b
+}
+
 // Stderr sets the stderr writer for the command.
 // Defaults to os.Stderr if not set.
 func (b *bdCmd) Stderr(w io.Writer) *bdCmd {
@@ -102,29 +117,14 @@ func filterEnvKey(env []string, key string) []string {
 }
 
 func filterBdTargetEnv(env []string) []string {
-	for _, key := range []string{
-		"BEADS_DIR",
-		"BEADS_DB",
-		"BEADS_DOLT_SERVER_DATABASE",
-		"BEADS_DOLT_SERVER_HOST",
-		"BEADS_DOLT_SERVER_PORT",
-		"BEADS_DOLT_PORT",
-	} {
-		env = filterEnvKey(env, key)
-	}
-	return env
+	return beads.StripBDTargetEnv(env)
 }
 
 func pinBeadsDirEnv(env []string, beadsDir string) []string {
-	env = filterBdTargetEnv(env)
 	if beadsDir == "" {
-		return env
+		return beads.StripBDTargetEnv(env)
 	}
-	env = append(env, "BEADS_DIR="+beadsDir)
-	if dbEnv := beads.DatabaseEnv(beadsDir); dbEnv != "" {
-		env = append(env, dbEnv)
-	}
-	return env
+	return beads.BuildPinnedBDEnv(env, beadsDir)
 }
 
 // buildEnv constructs the final environment slice based on configured options.
@@ -136,6 +136,7 @@ func (b *bdCmd) buildEnv() []string {
 	// so an existing "off" entry would shadow the appended "on".
 	if b.autoCommit {
 		env = filterEnvKey(env, "BD_DOLT_AUTO_COMMIT")
+		env = filterEnvKey(env, "BD_READONLY")
 		env = append(env, "BD_DOLT_AUTO_COMMIT=on")
 	}
 
@@ -154,10 +155,14 @@ func (b *bdCmd) buildEnv() []string {
 	// carry a town-level or remote BEADS_DOLT_* target; keeping it while changing
 	// BEADS_DIR makes `bd show <displayed-id>` query a different database than
 	// `gt ready` used to render the row.
-	if b.beadsDir != "" {
+	if b.routing {
+		env = beads.BuildRoutingBDEnv(env, beads.ResolveBeadsDir(b.dir))
+	} else if b.beadsDir != "" {
 		env = pinBeadsDirEnv(env, b.beadsDir)
 	} else if b.dir != "" {
 		env = pinBeadsDirEnv(env, beads.ResolveBeadsDir(b.dir))
+	} else {
+		env = beads.SuppressBDSideEffects(beads.StripBDTargetEnv(env))
 	}
 
 	return env
@@ -172,6 +177,35 @@ func (b *bdCmd) Build() *exec.Cmd {
 	cmd.Env = b.buildEnv()
 	cmd.Stderr = b.stderr
 	return cmd
+}
+
+func resolveBdCmdTimeout() time.Duration {
+	if v := os.Getenv("GT_BD_TIMEOUT_SEC"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return time.Duration(n) * time.Second
+		}
+	}
+	return constants.BdCommandTimeout
+}
+
+func (b *bdCmd) buildContextCommand(ctx context.Context) *exec.Cmd {
+	args := b.resolvedArgs()
+	cmd := exec.CommandContext(ctx, "bd", args...)
+	util.SetProcessGroup(cmd)
+	cmd.Dir = b.dir
+	cmd.Env = b.buildEnv()
+	cmd.Stderr = b.stderr
+	return cmd
+}
+
+func wrapBdCmdTimeout(ctx context.Context, err error) error {
+	if err == nil {
+		return nil
+	}
+	if ctx.Err() == context.DeadlineExceeded || strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+		return fmt.Errorf("bd command timed out after %v: %w", resolveBdCmdTimeout(), err)
+	}
+	return err
 }
 
 // resolvedArgs returns the final args, stripping --allow-stale if bd doesn't support it.
@@ -191,7 +225,9 @@ func (b *bdCmd) resolvedArgs() []string {
 // Run builds and runs the command, returning any error.
 // This is a convenience method equivalent to Build().Run().
 func (b *bdCmd) Run() error {
-	return b.Build().Run()
+	ctx, cancel := context.WithTimeout(context.Background(), resolveBdCmdTimeout())
+	defer cancel()
+	return wrapBdCmdTimeout(ctx, b.buildContextCommand(ctx).Run())
 }
 
 // Output builds and runs the command, returning stdout and any error.
@@ -199,16 +235,23 @@ func (b *bdCmd) Run() error {
 // Note: Output() captures stdout but Stderr must still be configured
 // separately if you want to capture stderr instead of it going to os.Stderr.
 func (b *bdCmd) Output() ([]byte, error) {
-	return b.Build().Output()
+	ctx, cancel := context.WithTimeout(context.Background(), resolveBdCmdTimeout())
+	defer cancel()
+	out, err := b.buildContextCommand(ctx).Output()
+	return out, wrapBdCmdTimeout(ctx, err)
 }
 
 // CombinedOutput builds and runs the command, returning combined stdout+stderr.
 // This overrides the configured Stderr writer to capture both streams.
 // Useful for including command output in error messages.
 func (b *bdCmd) CombinedOutput() ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), resolveBdCmdTimeout())
+	defer cancel()
 	args := b.resolvedArgs()
-	cmd := exec.Command("bd", args...)
+	cmd := exec.CommandContext(ctx, "bd", args...)
+	util.SetProcessGroup(cmd)
 	cmd.Dir = b.dir
 	cmd.Env = b.buildEnv()
-	return cmd.CombinedOutput()
+	out, err := cmd.CombinedOutput()
+	return out, wrapBdCmdTimeout(ctx, err)
 }

--- a/internal/cmd/bd_helpers_test.go
+++ b/internal/cmd/bd_helpers_test.go
@@ -168,6 +168,54 @@ func TestBdCmd_Run(t *testing.T) {
 	}
 }
 
+func TestBdCmd_RunTimesOut(t *testing.T) {
+	binDir := t.TempDir()
+	writeBDStub(t, binDir, `#!/usr/bin/env sh
+sleep 5
+`, `@echo off
+timeout /t 5 /nobreak >NUL
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GT_BD_TIMEOUT_SEC", "1")
+
+	start := time.Now()
+	err := BdCmd("list").Run()
+	elapsed := time.Since(start)
+	if err == nil {
+		t.Fatal("expected timeout error")
+	}
+	if !strings.Contains(err.Error(), "timed out") {
+		t.Fatalf("error = %v, want timeout", err)
+	}
+	if elapsed > 4*time.Second {
+		t.Fatalf("timeout took %v, want under 4s", elapsed)
+	}
+}
+
+func TestBdCmd_CombinedOutputDoesNotPreSetStderr(t *testing.T) {
+	binDir := t.TempDir()
+	writeBDStub(t, binDir, `#!/usr/bin/env sh
+printf 'stdout:%s\n' "$*"
+printf 'stderr:%s\n' "$*" >&2
+`, `@echo off
+echo stdout:%*
+echo stderr:%* 1>&2
+`)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	out, err := BdCmd("show", "id").CombinedOutput()
+	if err != nil {
+		t.Fatalf("CombinedOutput: %v", err)
+	}
+	text := string(out)
+	if !strings.Contains(text, "stdout:show id") {
+		t.Fatalf("missing stdout in combined output: %q", text)
+	}
+	if !strings.Contains(text, "stderr:show id") {
+		t.Fatalf("missing stderr in combined output: %q", text)
+	}
+}
+
 func TestBdCmd_Chaining(t *testing.T) {
 	// Test that all builder methods return the receiver for chaining
 	bdc := BdCmd("test")
@@ -210,7 +258,7 @@ func TestBdCmd_WithAutoCommit_OverridesParentOff(t *testing.T) {
 	// before appending BD_DOLT_AUTO_COMMIT=on. This is critical because
 	// glibc getenv() returns the first match in the env array, so a duplicate
 	// "off" entry would shadow the appended "on".
-	baseEnv := []string{"PATH=/usr/bin", "BD_DOLT_AUTO_COMMIT=off", "HOME=/home/user"}
+	baseEnv := []string{"PATH=/usr/bin", "BD_DOLT_AUTO_COMMIT=off", "BD_READONLY=true", "HOME=/home/user"}
 
 	bdc := &bdCmd{
 		args:   []string{"show", "id"},
@@ -235,6 +283,9 @@ func TestBdCmd_WithAutoCommit_OverridesParentOff(t *testing.T) {
 	}
 	if count != 1 {
 		t.Errorf("found %d BD_DOLT_AUTO_COMMIT entries, want exactly 1 (dedup must remove old entry)", count)
+	}
+	if _, ok := envMap["BD_READONLY"]; ok {
+		t.Errorf("BD_READONLY should be stripped for WithAutoCommit mutation env, got %q", envMap["BD_READONLY"])
 	}
 }
 
@@ -494,6 +545,8 @@ func TestBdCmd_WithBeadsDir_OverridesInheritedDoltTarget(t *testing.T) {
 		"BEADS_DOLT_SERVER_HOST=100.107.173.83",
 		"BEADS_DOLT_SERVER_PORT=3307",
 		"BEADS_DOLT_PORT=3307",
+		"BEADS_DOLT_DATA_DIR=/wrong/data",
+		"BD_DB=/wrong.db",
 	}
 
 	bdc := &bdCmd{
@@ -510,7 +563,16 @@ func TestBdCmd_WithBeadsDir_OverridesInheritedDoltTarget(t *testing.T) {
 	if envMap["BEADS_DOLT_SERVER_DATABASE"] != "rigdb" {
 		t.Errorf("BEADS_DOLT_SERVER_DATABASE = %q, want rigdb", envMap["BEADS_DOLT_SERVER_DATABASE"])
 	}
-	for _, key := range []string{"BEADS_DB", "BEADS_DOLT_SERVER_HOST", "BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT"} {
+	if envMap["BEADS_DOLT_SERVER_HOST"] != "127.0.0.1" {
+		t.Errorf("BEADS_DOLT_SERVER_HOST = %q, want 127.0.0.1", envMap["BEADS_DOLT_SERVER_HOST"])
+	}
+	if envMap["BEADS_DOLT_SERVER_PORT"] != "3307" {
+		t.Errorf("BEADS_DOLT_SERVER_PORT = %q, want 3307", envMap["BEADS_DOLT_SERVER_PORT"])
+	}
+	if envMap["BEADS_DOLT_PORT"] != "3307" {
+		t.Errorf("BEADS_DOLT_PORT = %q, want 3307", envMap["BEADS_DOLT_PORT"])
+	}
+	for _, key := range []string{"BEADS_DB", "BD_DB", "BEADS_DOLT_DATA_DIR"} {
 		if value, ok := envMap[key]; ok {
 			t.Errorf("%s should be stripped when BEADS_DIR is pinned, got %q", key, value)
 		}
@@ -528,6 +590,30 @@ func TestBdCmd_EmptyBeadsDir_Skipped(t *testing.T) {
 		if strings.HasPrefix(e, "BEADS_DIR=") {
 			t.Errorf("BEADS_DIR should not be added when empty, found: %s", e)
 		}
+	}
+}
+
+func TestBdCmd_DefaultStripsTargetEnvAndSuppressesSideEffects(t *testing.T) {
+	bdc := &bdCmd{
+		args: []string{"version"},
+		env: []string{
+			"PATH=/usr/bin",
+			"BEADS_DIR=/wrong",
+			"BEADS_DOLT_SERVER_DATABASE=hq",
+			"BEADS_DOLT_SERVER_HOST=wrong-host",
+			"BD_EXPORT_AUTO=true",
+		},
+		stderr: os.Stderr,
+	}
+	cmd := bdc.Build()
+	envMap := parseEnv(cmd.Env)
+	for _, key := range []string{"BEADS_DIR", "BEADS_DOLT_SERVER_DATABASE", "BEADS_DOLT_SERVER_HOST"} {
+		if value, ok := envMap[key]; ok {
+			t.Fatalf("%s should be stripped for unpinned BdCmd, got %q in %v", key, value, cmd.Env)
+		}
+	}
+	if envMap["BD_EXPORT_AUTO"] != "false" {
+		t.Fatalf("BD_EXPORT_AUTO = %q, want false in %v", envMap["BD_EXPORT_AUTO"], cmd.Env)
 	}
 }
 
@@ -574,6 +660,39 @@ func TestBdCmd_StripBeadsDir_NoOpWhenAbsent(t *testing.T) {
 	envMap := parseEnv(cmd.Env)
 	if envMap["BEADS_DIR"] != "/town/.beads" {
 		t.Errorf("BEADS_DIR = %q, want %q", envMap["BEADS_DIR"], "/town/.beads")
+	}
+}
+
+func TestBdCmd_WithRoutingDoesNotPinBeadsDir(t *testing.T) {
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := []byte(`{"dolt_database":"rigdb","dolt_server_host":"127.0.0.1","dolt_server_port":3307}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+	workDir := filepath.Dir(beadsDir)
+	bdc := &bdCmd{
+		args: []string{"show", "gt-abc", "--json"},
+		env: []string{
+			"PATH=/usr/bin",
+			"BEADS_DIR=/wrong",
+			"BEADS_DOLT_SERVER_DATABASE=hq",
+			"BEADS_DOLT_SERVER_HOST=wrong-host",
+		},
+		stderr: os.Stderr,
+	}
+	cmd := bdc.Dir(workDir).WithRouting().Build()
+	envMap := parseEnv(cmd.Env)
+	if _, ok := envMap["BEADS_DIR"]; ok {
+		t.Fatalf("BEADS_DIR should be absent for routing command, got %v", cmd.Env)
+	}
+	if _, ok := envMap["BEADS_DOLT_SERVER_DATABASE"]; ok {
+		t.Fatalf("BEADS_DOLT_SERVER_DATABASE should be absent for routing command, got %v", cmd.Env)
+	}
+	if envMap["BEADS_DOLT_SERVER_HOST"] != "127.0.0.1" {
+		t.Fatalf("BEADS_DOLT_SERVER_HOST = %q, want 127.0.0.1 in %v", envMap["BEADS_DOLT_SERVER_HOST"], cmd.Env)
 	}
 }
 

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -449,24 +449,10 @@ func getTownBeadsDir() (string, error) {
 // "exit status 1". BEADS_DIR is stripped from the subprocess environment to
 // prevent stale overrides from interfering with bd's workspace detection.
 func runBdJSON(dir string, args ...string) ([]byte, error) {
-	// Strip --allow-stale if bd doesn't support it (version mismatch).
-	if !beads.BdSupportsAllowStale() {
-		filtered := make([]string, 0, len(args))
-		for _, a := range args {
-			if a != "--allow-stale" {
-				filtered = append(filtered, a)
-			}
-		}
-		args = filtered
-	}
-	cmd := exec.Command("bd", args...)
-	cmd.Dir = dir
-	// Strip BEADS_DIR so bd discovers the correct database from cmd.Dir
-	// rather than using an inherited (possibly wrong) override.
-	cmd.Env = stripEnvKey(os.Environ(), "BEADS_DIR")
 	var stdout, stderr bytes.Buffer
+	cmd := BdCmd(args...).Dir(dir).StripBeadsDir().Stderr(&stderr).Build()
+	cmd.Dir = dir
 	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
 
 	if err := cmd.Run(); err != nil {
 		if errMsg := strings.TrimSpace(stderr.String()); errMsg != "" {
@@ -936,10 +922,7 @@ func closeConvoyIfComplete(townBeads, convoyID, title string, tracked []trackedI
 
 	reason := "All tracked issues completed"
 	closeArgs := []string{"close", convoyID, "-r", reason}
-	closeCmd := exec.Command("bd", closeArgs...)
-	closeCmd.Dir = townBeads
-
-	if err := closeCmd.Run(); err != nil {
+	if err := BdCmd(closeArgs...).Dir(townBeads).WithAutoCommit().Run(); err != nil {
 		return false, fmt.Errorf("closing convoy: %w", err)
 	}
 
@@ -950,14 +933,8 @@ func closeConvoyIfComplete(townBeads, convoyID, title string, tracked []trackedI
 
 // checkSingleConvoy checks a specific convoy and closes it if all tracked issues are complete.
 func checkSingleConvoy(townBeads, convoyID string, dryRun bool) error {
-	// Get convoy details
-	showArgs := []string{"show", convoyID, "--json"}
-	showCmd := exec.Command("bd", showArgs...)
-	showCmd.Dir = townBeads
-	var stdout bytes.Buffer
-	showCmd.Stdout = &stdout
-
-	if err := showCmd.Run(); err != nil {
+	stdout, err := runBdJSON(townBeads, "show", convoyID, "--json")
+	if err != nil {
 		return fmt.Errorf("convoy '%s' not found", convoyID)
 	}
 
@@ -969,7 +946,7 @@ func checkSingleConvoy(townBeads, convoyID string, dryRun bool) error {
 		Description string   `json:"description"`
 		Labels      []string `json:"labels"`
 	}
-	if err := json.Unmarshal(stdout.Bytes(), &convoys); err != nil {
+	if err := json.Unmarshal(stdout, &convoys); err != nil {
 		return fmt.Errorf("parsing convoy data: %w", err)
 	}
 
@@ -1011,14 +988,8 @@ func runConvoyClose(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Get convoy details
-	showArgs := []string{"show", convoyID, "--json"}
-	showCmd := exec.Command("bd", showArgs...)
-	showCmd.Dir = townBeads
-	var stdout bytes.Buffer
-	showCmd.Stdout = &stdout
-
-	if err := showCmd.Run(); err != nil {
+	stdout, err := runBdJSON(townBeads, "show", convoyID, "--json")
+	if err != nil {
 		return fmt.Errorf("convoy '%s' not found", convoyID)
 	}
 
@@ -1030,7 +1001,7 @@ func runConvoyClose(cmd *cobra.Command, args []string) error {
 		Description string   `json:"description"`
 		Labels      []string `json:"labels"`
 	}
-	if err := json.Unmarshal(stdout.Bytes(), &convoys); err != nil {
+	if err := json.Unmarshal(stdout, &convoys); err != nil {
 		return fmt.Errorf("parsing convoy data: %w", err)
 	}
 
@@ -1101,10 +1072,7 @@ func runConvoyClose(cmd *cobra.Command, args []string) error {
 
 	// Close the convoy
 	closeArgs := []string{"close", convoyID, "-r", reason}
-	closeCmd := exec.Command("bd", closeArgs...)
-	closeCmd.Dir = townBeads
-
-	if err := closeCmd.Run(); err != nil {
+	if err := BdCmd(closeArgs...).Dir(townBeads).WithAutoCommit().Run(); err != nil {
 		return fmt.Errorf("closing convoy: %w", err)
 	}
 
@@ -1170,14 +1138,8 @@ func runConvoyLand(cmd *cobra.Command, args []string) error {
 		return err
 	}
 
-	// Get convoy details
-	showArgs := []string{"show", convoyID, "--json"}
-	showCmd := exec.Command("bd", showArgs...)
-	showCmd.Dir = townBeads
-	var stdout bytes.Buffer
-	showCmd.Stdout = &stdout
-
-	if err := showCmd.Run(); err != nil {
+	stdout, err := runBdJSON(townBeads, "show", convoyID, "--json")
+	if err != nil {
 		return fmt.Errorf("convoy '%s' not found", convoyID)
 	}
 
@@ -1189,7 +1151,7 @@ func runConvoyLand(cmd *cobra.Command, args []string) error {
 		Description string   `json:"description"`
 		Labels      []string `json:"labels,omitempty"`
 	}
-	if err := json.Unmarshal(stdout.Bytes(), &convoys); err != nil {
+	if err := json.Unmarshal(stdout, &convoys); err != nil {
 		return fmt.Errorf("parsing convoy data: %w", err)
 	}
 
@@ -1283,10 +1245,7 @@ func runConvoyLand(cmd *cobra.Command, args []string) error {
 	// Phase 2: Close the convoy
 	reason := "Landed by owner"
 	closeArgs := []string{"close", convoyID, "-r", reason}
-	closeCmd := exec.Command("bd", closeArgs...)
-	closeCmd.Dir = townBeads
-
-	if err := closeCmd.Run(); err != nil {
+	if err := BdCmd(closeArgs...).Dir(townBeads).WithAutoCommit().Run(); err != nil {
 		return fmt.Errorf("closing convoy: %w", err)
 	}
 
@@ -1683,14 +1642,8 @@ func checkAndCloseCompletedConvoys(townBeads string, dryRun bool) ([]struct{ ID,
 
 // notifyConvoyCompletion sends notifications to owner, any notify addresses, and mayor/.
 func notifyConvoyCompletion(townBeads, convoyID, title string) {
-	// Get convoy description + creation time for notification enrichment.
-	showArgs := []string{"show", convoyID, "--json"}
-	showCmd := exec.Command("bd", showArgs...)
-	showCmd.Dir = townBeads
-	var stdout bytes.Buffer
-	showCmd.Stdout = &stdout
-
-	if err := showCmd.Run(); err != nil {
+	stdout, err := runBdJSON(townBeads, "show", convoyID, "--json")
+	if err != nil {
 		return
 	}
 
@@ -1698,7 +1651,7 @@ func notifyConvoyCompletion(townBeads, convoyID, title string) {
 		Description string `json:"description"`
 		CreatedAt   string `json:"created_at"`
 	}
-	if err := json.Unmarshal(stdout.Bytes(), &convoys); err != nil || len(convoys) == 0 {
+	if err := json.Unmarshal(stdout, &convoys); err != nil || len(convoys) == 0 {
 		return
 	}
 
@@ -2153,6 +2106,7 @@ func listConvoyIssues(townBeads, status string, all bool, extraLabels ...string)
 		args = append(args, "--all")
 	}
 
+	args = beads.InjectFlatForListJSON(args)
 	convoys, err := readConvoyIssues(townBeads, args...)
 	if err != nil {
 		return nil, err
@@ -2168,6 +2122,7 @@ func listConvoyIssues(townBeads, status string, all bool, extraLabels ...string)
 	} else if all {
 		legacyArgs = append(legacyArgs, "--all")
 	}
+	legacyArgs = beads.InjectFlatForListJSON(legacyArgs)
 	legacy, err := readConvoyIssues(townBeads, legacyArgs...)
 	if err != nil {
 		return nil, err
@@ -2481,22 +2436,16 @@ func getExternalIssueDetails(townBeads, rigName, issueID string) *issueDetails {
 		return nil
 	}
 
-	// Query the rig database by running bd show from the rig directory
-	showArgs := beads.MaybePrependAllowStale([]string{"show", issueID, "--json"})
-	showCmd := exec.Command("bd", showArgs...)
-	showCmd.Dir = rigDir // Set working directory to rig directory
-	var stdout bytes.Buffer
-	showCmd.Stdout = &stdout
-
-	if err := showCmd.Run(); err != nil {
+	out, err := BdCmd("show", issueID, "--json").Dir(rigDir).StripBeadsDir().Stderr(io.Discard).Output()
+	if err != nil {
 		return nil
 	}
-	if stdout.Len() == 0 {
+	if len(out) == 0 {
 		return nil
 	}
 
 	var issues []issueDetailsJSON
-	if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil {
+	if err := json.Unmarshal(out, &issues); err != nil {
 		return nil
 	}
 	if len(issues) == 0 {
@@ -2549,15 +2498,12 @@ func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 	// Run from town root so bd's prefix routing (routes.jsonl) can dispatch
 	// to the correct rig database for cross-rig bead lookups. (GH#2960)
 	townRoot, _ := workspace.FindFromCwdOrError()
-	showCmd := exec.Command("bd", args...)
+	bdc := BdCmd(args...).Stderr(io.Discard)
 	if townRoot != "" {
-		showCmd.Dir = townRoot
-		showCmd.Env = stripEnvKey(os.Environ(), "BEADS_DIR")
+		bdc.Dir(townRoot).WithRouting()
 	}
-	var stdout bytes.Buffer
-	showCmd.Stdout = &stdout
-
-	if err := showCmd.Run(); err != nil {
+	out, err := bdc.Output()
+	if err != nil {
 		// Batch failed - fall back to individual lookups for robustness
 		// This handles cases where some IDs are invalid/missing
 		for _, id := range issueIDs {
@@ -2569,7 +2515,7 @@ func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 	}
 
 	var issues []issueDetailsJSON
-	if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil {
+	if err := json.Unmarshal(out, &issues); err != nil {
 		return result
 	}
 
@@ -2588,24 +2534,21 @@ func getIssueDetails(issueID string) *issueDetails {
 	// Without Dir + StripBeadsDir, bd inherits CWD/BEADS_DIR which may
 	// point to a rig that doesn't contain the target bead. (GH#2960)
 	townRoot, _ := workspace.FindFromCwdOrError()
-	showCmd := exec.Command("bd", "show", issueID, "--json")
+	bdc := BdCmd("show", issueID, "--json").Stderr(io.Discard)
 	if townRoot != "" {
-		showCmd.Dir = townRoot
-		showCmd.Env = stripEnvKey(os.Environ(), "BEADS_DIR")
+		bdc.Dir(townRoot).WithRouting()
 	}
-	var stdout bytes.Buffer
-	showCmd.Stdout = &stdout
-
-	if err := showCmd.Run(); err != nil {
+	out, err := bdc.Output()
+	if err != nil {
 		return nil
 	}
 	// Handle bd exit 0 bug: empty stdout means not found
-	if stdout.Len() == 0 {
+	if len(out) == 0 {
 		return nil
 	}
 
 	var issues []issueDetailsJSON
-	if err := json.Unmarshal(stdout.Bytes(), &issues); err != nil || len(issues) == 0 {
+	if err := json.Unmarshal(out, &issues); err != nil || len(issues) == 0 {
 		return nil
 	}
 
@@ -2670,20 +2613,21 @@ func getWorkersForIssues(issueIDs []string) map[string]*workerInfo {
 
 	for _, dir := range beadsDirs {
 		wg.Add(1)
-		go func(beadsDir string) {
+		go func(workDir string) {
 			defer wg.Done()
 
-			cmd := exec.Command("bd", "list", "--label=gt:agent", "--status=open", "--json", "--limit=0")
-			cmd.Dir = beadsDir
-			var stdout bytes.Buffer
-			cmd.Stdout = &stdout
-			if err := cmd.Run(); err != nil {
+			out, err := BdCmd("list", "--label=gt:agent", "--status=open", "--json", "--limit=0", "--flat").
+				Dir(workDir).
+				StripBeadsDir().
+				Stderr(io.Discard).
+				Output()
+			if err != nil {
 				resultChan <- rigResult{}
 				return
 			}
 
 			var rr rigResult
-			if err := json.Unmarshal(stdout.Bytes(), &rr.agents); err != nil {
+			if err := json.Unmarshal(out, &rr.agents); err != nil {
 				resultChan <- rigResult{}
 				return
 			}

--- a/internal/cmd/convoy_bd_routing_test.go
+++ b/internal/cmd/convoy_bd_routing_test.go
@@ -96,20 +96,20 @@ if [ "$*" = "--allow-stale version" ]; then
   exit 0
 fi
 
-if [ -n "$BEADS_DIR" ]; then
-  echo "BEADS_DIR leaked: $BEADS_DIR" >&2
+if [ "$BEADS_DIR" != "%s/.beads" ]; then
+  echo "expected hardened BEADS_DIR, got $BEADS_DIR" >&2
   exit 1
 fi
 
 case "$*" in
-	  "list --label=gt:convoy --json --limit=0 --all")
+	  "list --label=gt:convoy --json --limit=0 --all --flat")
 	    if [ "$PWD" != "%s" ]; then
 	      echo "expected town root, got $PWD" >&2
 	      exit 1
 	    fi
 	    echo '[{"id":"hq-cv-town","title":"Town convoy","status":"open","created_at":"2026-03-09T00:00:00Z","labels":["gt:convoy"]}]'
 	    ;;
-	  "list --json --limit=0 --all")
+	  "list --json --limit=0 --all --flat")
 	    echo '[]'
 	    ;;
   "dep list hq-cv-town --direction=down --type=tracks --allow-stale --json")
@@ -131,7 +131,7 @@ case "$*" in
     exit 1
     ;;
 esac
-`, expectedWD, expectedWD, expectedWD)
+`, expectedWD, expectedWD, expectedWD, expectedWD)
 	writeRoutingBdStub(t, scriptBody)
 
 	oldJSON, oldAll, oldStatus, oldTree := convoyListJSON, convoyListAll, convoyListStatus, convoyListTree
@@ -172,8 +172,8 @@ if [ "$*" = "--allow-stale version" ]; then
   exit 0
 fi
 
-if [ -n "$BEADS_DIR" ]; then
-  echo "BEADS_DIR leaked: $BEADS_DIR" >&2
+if [ "$BEADS_DIR" != "%s/.beads" ]; then
+  echo "expected hardened BEADS_DIR, got $BEADS_DIR" >&2
   exit 1
 fi
 
@@ -197,7 +197,7 @@ case "$*" in
     exit 1
     ;;
 esac
-`, expectedWD, expectedWD)
+`, expectedWD, expectedWD, expectedWD)
 	writeRoutingBdStub(t, scriptBody)
 
 	oldJSON := convoyStatusJSON

--- a/internal/cmd/convoy_staged_scan_test.go
+++ b/internal/cmd/convoy_staged_scan_test.go
@@ -186,7 +186,7 @@ exit 0
 		t.Fatalf("bd was never called with a 'list' subcommand; log: %q", string(logData))
 	}
 
-	requiredFlags := []string{"list", "--label=gt:convoy", "--status=open", "--json", "--limit=0"}
+	requiredFlags := []string{"list", "--label=gt:convoy", "--status=open", "--json", "--limit=0", "--flat"}
 	for _, flag := range requiredFlags {
 		if !strings.Contains(listLine, flag) {
 			t.Errorf("bd list command missing %q; got: %q", flag, listLine)

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -1082,26 +1082,28 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// Determine target branch for the MR.
 		// Priority: explicit --target flag > formula_vars base_branch > integration branch auto-detect > rig default.
 		target := defaultBranch
+		explicitTarget := false
 
 		// 1. Explicit --target flag (highest priority — polecat knows its base branch).
 		// This is the most reliable path: the formula passes {{base_branch}} directly,
 		// avoiding any dependency on bd.Show() or Dolt availability.
-		if doneTarget != "" && doneTarget != defaultBranch {
+		if doneTarget != "" {
 			target = doneTarget
+			explicitTarget = true
 			fmt.Printf("  Target branch: %s (from --target flag)\n", target)
 		}
 
 		// 2. Check for --base-branch override in formula vars (stored on bead at sling time).
 		// Fallback for polecats dispatched before --target flag existed, or when
 		// the formula doesn't pass --target explicitly.
-		if target == defaultBranch && sourceIssueForNoMerge != nil {
+		if !explicitTarget && target == defaultBranch && sourceIssueForNoMerge != nil {
 			if af := beads.ParseAttachmentFields(sourceIssueForNoMerge); af != nil {
 				if bb := extractFormulaVar(af.FormulaVars, "base_branch"); bb != "" && bb != defaultBranch {
 					target = bb
 					fmt.Printf("  Target branch override: %s (from formula_vars)\n", target)
 				}
 			}
-		} else if target == defaultBranch && sourceIssueForNoMerge == nil && issueID != "" {
+		} else if !explicitTarget && target == defaultBranch && sourceIssueForNoMerge == nil && issueID != "" {
 			// sourceIssueForNoMerge is nil — bd.Show(issueID) failed earlier.
 			// This is the silent failure path that caused 150+ procedure beads to
 			// target main instead of feat/contract-review-procedure.
@@ -1110,7 +1112,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 		// 3. Auto-detect integration branch from epic hierarchy (if enabled).
 		// Only overrides if no explicit target was set above.
-		if target == defaultBranch {
+		if !explicitTarget && target == defaultBranch {
 			refineryEnabled := true
 			settingsPath := filepath.Join(townRoot, rigName, "settings", "config.json")
 			if settings, err := config.LoadRigSettings(settingsPath); err == nil && settings.MergeQueue != nil {
@@ -1372,13 +1374,6 @@ notifyWitness:
 		}
 	}
 
-	// Nudge witness via tmux (observability, not critical path).
-	// Self-managed completion (gt-1qlg): witness no longer processes routine completions.
-	// The nudge is kept for observability — witness logs the event but doesn't
-	// need to act on it. Nudges are free (no Dolt commit).
-	nudgeWitness(rigName, fmt.Sprintf("POLECAT_DONE %s exit=%s", polecatName, exitType))
-	fmt.Printf("%s Witness notified of %s (via nudge)\n", style.Bold.Render("✓"), exitType)
-
 	// Write witness notification checkpoint for resume (gt-aufru)
 	if agentBeadID != "" {
 		// Agent bead lives in town DB despite rig prefix — bypass routing.
@@ -1396,6 +1391,12 @@ notifyWitness:
 
 	// Update agent bead state (ZFC: self-report completion)
 	updateAgentStateOnDone(cwd, townRoot, exitType, issueID)
+
+	// Nudge witness only after hook/cleanup state is updated. Otherwise witness can
+	// evaluate slot availability against stale hook_bead or cleanup_status and emit
+	// false SLOT_BLOCKED/SLOT_OPEN signals.
+	nudgeWitness(rigName, fmt.Sprintf("POLECAT_DONE %s exit=%s", polecatName, exitType))
+	fmt.Printf("%s Witness notified of %s (via nudge)\n", style.Bold.Render("✓"), exitType)
 
 	// Persistent polecat model (gt-hdf8): polecats transition to IDLE after completion.
 	// Session stays alive, sandbox preserved, worktree synced to main for reuse.
@@ -1427,7 +1428,7 @@ notifyWitness:
 				fmt.Printf("  Files: %s\n", ws.String())
 			}
 		}
-		if cwdAvailable && !pushFailed && syncSafe {
+		if cwdAvailable && !pushFailed && !mrFailed && syncSafe {
 			// Remember the old branch so we can delete it after switching
 			oldBranch := branch
 

--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -499,16 +499,11 @@ func runHookShow(cmd *cobra.Command, args []string) error {
 	if len(args) > 0 && !isTownLevelRole(target) {
 		townRoot, townErr := workspace.FindFromCwd()
 		if townErr == nil && townRoot != "" {
-			agentBeadID := agentIDToBeadID(target, townRoot)
-			if agentBeadID != "" {
-				rigName := strings.Split(target, "/")[0]
-				var fallbackPath string
-				if rigName == "mayor" || rigName == "deacon" {
-					fallbackPath = townRoot
-				} else {
-					fallbackPath = filepath.Join(townRoot, rigName, "mayor", "rig")
-				}
-				workDir = beads.ResolveHookDir(townRoot, agentBeadID, fallbackPath)
+			rigName := strings.Split(target, "/")[0]
+			if rigName != "" && rigName != "mayor" && rigName != "deacon" {
+				// Agent beads can be stale or missing during recovery. The source
+				// work assignment is authoritative, so query the target rig DB directly.
+				workDir = filepath.Join(townRoot, rigName, "mayor", "rig")
 			}
 		}
 	}
@@ -522,6 +517,17 @@ func runHookShow(cmd *cobra.Command, args []string) error {
 	})
 	if err != nil {
 		return fmt.Errorf("listing hooked beads: %w", err)
+	}
+	if len(hookedBeads) == 0 {
+		inProgressBeads, err := b.List(beads.ListOptions{
+			Status:   "in_progress",
+			Assignee: target,
+			Priority: -1,
+		})
+		if err != nil {
+			return fmt.Errorf("listing in-progress beads: %w", err)
+		}
+		hookedBeads = inProgressBeads
 	}
 
 	// If nothing found in local beads, also check town beads for hooked convoys.
@@ -541,6 +547,15 @@ func runHookShow(cmd *cobra.Command, args []string) error {
 				})
 				if err == nil && len(townHooked) > 0 {
 					hookedBeads = townHooked
+				} else if err == nil {
+					townInProgress, err := townBeads.List(beads.ListOptions{
+						Status:   "in_progress",
+						Assignee: target,
+						Priority: -1,
+					})
+					if err == nil && len(townInProgress) > 0 {
+						hookedBeads = townInProgress
+					}
 				}
 			}
 

--- a/internal/cmd/hook_show_integration_test.go
+++ b/internal/cmd/hook_show_integration_test.go
@@ -96,4 +96,14 @@ func TestHookShowShorthandResolvesToCanonical(t *testing.T) {
 		t.Fatalf("shorthand target did not normalize: got agent=%q, want %q",
 			shorthand.Agent, "gastown/polecats/toast")
 	}
+
+	inProgress := "in_progress"
+	if err := b.Update(issue.ID, beads.UpdateOptions{Status: &inProgress}); err != nil {
+		t.Fatalf("mark issue in progress: %v", err)
+	}
+	active := runShow("gastown/toast")
+	if active.BeadID != issue.ID || active.Status != "in_progress" {
+		t.Fatalf("in-progress target mismatch: got bead=%q status=%q, want bead=%q status=in_progress",
+			active.BeadID, active.Status, issue.ID)
+	}
 }

--- a/internal/cmd/polecat_spawn.go
+++ b/internal/cmd/polecat_spawn.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -130,24 +131,6 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 		witness.RecordBeadRespawn(townRoot, opts.HookBead)
 	}
 
-	// Per-rig directory cap: prevent unbounded worktree accumulation even when
-	// polecats die quickly (tmux session count stays low).
-	const maxPolecatDirsPerRig = 30
-	rigPolecatDir := filepath.Join(townRoot, rigName, "polecats")
-	if entries, err := os.ReadDir(rigPolecatDir); err == nil {
-		dirCount := 0
-		for _, e := range entries {
-			if e.IsDir() && !strings.HasPrefix(e.Name(), ".") {
-				dirCount++
-			}
-		}
-		if dirCount >= maxPolecatDirsPerRig {
-			return nil, fmt.Errorf("rig %s has %d polecat directories (max %d). "+
-				"Nuke idle polecats first: gt polecat nuke %s/<name> --force",
-				rigName, dirCount, maxPolecatDirsPerRig, rigName)
-		}
-	}
-
 	// Persistent polecat model (gt-4ac): try to reuse an idle polecat first.
 	// Idle polecats have completed their work but kept their sandbox (worktree).
 	// Reusing avoids the overhead of creating a new worktree.
@@ -186,7 +169,8 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 
 		// Reuse the idle polecat with branch-only operations (no worktree add/remove).
 		// Phase 3 of persistent-polecat-pool: eliminates ~5s worktree creation overhead.
-		// Falls back to full worktree repair if branch-only reuse fails.
+		// If reuse is unsafe or fails, allocate a new polecat instead of repairing
+		// this worktree destructively.
 		addOpts := polecat.AddOptions{
 			HookBead:     opts.HookBead,
 			BaseBranch:   baseBranch,
@@ -194,12 +178,10 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 		}
 		reuseOK := false
 		if _, err := polecatMgr.ReuseIdlePolecat(polecatName, addOpts); err != nil {
-			// Branch-only reuse failed — try full worktree repair as fallback
-			fmt.Printf("  Branch-only reuse failed for idle polecat %s: %v, trying full repair...\n", polecatName, err)
-			if _, err := polecatMgr.RepairWorktreeWithOptions(polecatName, true, addOpts); err != nil {
-				fmt.Printf("  Full repair also failed for %s: %v, allocating new...\n", polecatName, err)
+			if errors.Is(err, polecat.ErrPolecatNeedsRecovery) {
+				fmt.Printf("  Idle polecat %s needs recovery before reuse: %v; allocating new...\n", polecatName, err)
 			} else {
-				reuseOK = true
+				fmt.Printf("  Branch-only reuse failed for idle polecat %s: %v; allocating new...\n", polecatName, err)
 			}
 		} else {
 			reuseOK = true
@@ -239,6 +221,25 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 				account:     opts.Account,
 				agent:       opts.Agent,
 			}, nil
+		}
+	}
+
+	// Per-rig directory cap: prevent unbounded worktree accumulation, but only
+	// after trying safe reuse. A reusable preserved polecat should not be blocked
+	// just because the rig is already at the directory cap.
+	const maxPolecatDirsPerRig = 30
+	rigPolecatDir := filepath.Join(townRoot, rigName, "polecats")
+	if entries, err := os.ReadDir(rigPolecatDir); err == nil {
+		dirCount := 0
+		for _, e := range entries {
+			if e.IsDir() && !strings.HasPrefix(e.Name(), ".") {
+				dirCount++
+			}
+		}
+		if dirCount >= maxPolecatDirsPerRig {
+			return nil, fmt.Errorf("rig %s has %d polecat directories (max %d). "+
+				"Resolve recovery-needed polecats before allocating more slots: gt polecat list %s",
+				rigName, dirCount, maxPolecatDirsPerRig, rigName)
 		}
 	}
 

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -106,7 +106,7 @@ func init() {
 	primeCmd.Flags().BoolVar(&primeHookMode, "hook", false,
 		"Hook mode: read session ID from stdin JSON (for LLM runtime hooks)")
 	primeCmd.Flags().BoolVar(&primeDryRun, "dry-run", false,
-		"Show what would be injected without side effects (no marker removal, no bd prime, no mail)")
+		"Show what would be injected without side effects (no marker removal, no mail)")
 	primeCmd.Flags().BoolVar(&primeState, "state", false,
 		"Show detected session state only (normal/post-handoff/crash/autonomous)")
 	primeCmd.Flags().BoolVar(&primeStateJSON, "json", false,
@@ -227,7 +227,7 @@ func runPrime(cmd *cobra.Command, args []string) (retErr error) {
 
 	outputMoleculeContext(ctx)
 	outputCheckpointContext(ctx)
-	runPrimeExternalTools(cwd)
+	runPrimeExternalTools(ctx, cwd)
 
 	if ctx.Role == RoleMayor {
 		checkPendingEscalations(ctx)
@@ -536,18 +536,29 @@ func outputRoleContext(ctx RoleContext) (string, error) {
 	return formula, nil
 }
 
-// runPrimeExternalTools runs bd prime, memory injection, and gt mail check --inject.
+// runPrimeExternalTools runs lightweight memory and mail injection.
 // Skipped in dry-run mode with explain output.
-func runPrimeExternalTools(cwd string) {
+func runPrimeExternalTools(ctx RoleContext, cwd string) {
 	if primeDryRun {
-		explain(true, "bd prime: skipped in dry-run mode")
 		explain(true, "memory injection: skipped in dry-run mode")
 		explain(true, "gt mail check --inject: skipped in dry-run mode")
 		return
 	}
-	runBdPrime(cwd)
 	runMemoryInject(cwd)
+	if shouldSkipStartupMailInject(string(ctx.Role)) {
+		explain(true, fmt.Sprintf("gt mail check --inject: skipped for patrol role %s", ctx.Role))
+		return
+	}
 	runMailCheckInject(cwd)
+}
+
+func shouldSkipStartupMailInject(role string) bool {
+	switch strings.ToLower(role) {
+	case string(RoleWitness), string(RoleRefinery), string(RoleDeacon), string(RoleBoot):
+		return true
+	default:
+		return false
+	}
 }
 
 func runPrimeExternalCommand(workDir, name string, args ...string) (bytes.Buffer, bytes.Buffer, error) {
@@ -555,35 +566,22 @@ func runPrimeExternalCommand(workDir, name string, args ...string) (bytes.Buffer
 	ctx, cancel := context.WithTimeout(context.Background(), primeExternalToolTimeout)
 	defer cancel()
 
+	if name == "bd" {
+		args = beads.InjectFlatForListJSON(args)
+	}
 	cmd := exec.CommandContext(ctx, name, args...)
-	cmd.Dir = workDir
-	cmd.Env = os.Environ()
+	if name == "bd" {
+		beads.ConfigureCommand(cmd, workDir, beads.ResolveBeadsDir(workDir), beads.SubprocessModeForArgs(args))
+	} else {
+		cmd.Dir = workDir
+		cmd.Env = os.Environ()
+		util.SetProcessGroup(cmd)
+	}
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	cmd.WaitDelay = primeExternalToolWaitDelay
-	util.SetProcessGroup(cmd)
 
 	return stdout, stderr, cmd.Run()
-}
-
-// runBdPrime runs `bd prime` and outputs the result.
-// This provides beads workflow context to the agent.
-func runBdPrime(workDir string) {
-	stdout, stderr, err := runPrimeExternalCommand(workDir, "bd", "prime")
-	if err != nil {
-		// Skip if bd prime fails (beads might not be available)
-		// But log stderr if present for debugging
-		if errMsg := strings.TrimSpace(stderr.String()); errMsg != "" {
-			fmt.Fprintf(os.Stderr, "bd prime: %s\n", errMsg)
-		}
-		return
-	}
-
-	output := strings.TrimSpace(stdout.String())
-	if output != "" {
-		fmt.Println()
-		fmt.Println(output)
-	}
 }
 
 // memoryTypeLabels maps type keys to human-readable section headers for prime injection.
@@ -810,6 +808,7 @@ func findAgentWorkOnce(ctx RoleContext, agentID string) (*beads.Issue, error) {
 	// (see sling_helpers.go), so HookBead is typically empty. Kept for backward
 	// compatibility with agent beads that still have hook_bead set.
 	agentBeadID := buildAgentBeadID(agentID, ctx.Role, ctx.TownRoot)
+	var staleHookErr error
 	if agentBeadID != "" {
 		agentBeadDir := beads.ResolveHookDir(ctx.TownRoot, agentBeadID, ctx.WorkDir)
 		ab := beads.New(agentBeadDir)
@@ -827,7 +826,7 @@ func findAgentWorkOnce(ctx RoleContext, agentID string) (*beads.Issue, error) {
 			// fast — never pontificate, the witness will clear the hook on
 			// its next sweep and the dispatcher will (or won't) re-issue.
 			if hookBead == nil || isBeadNotFound(showErr) {
-				return nil, fmt.Errorf("%w: agent=%s hook_bead=%s cwd=%s: %v",
+				staleHookErr = fmt.Errorf("%w: agent=%s hook_bead=%s cwd=%s: %v",
 					ErrHookUnresolvable, agentID, agentBead.HookBead, ctx.WorkDir, showErr)
 			}
 		}
@@ -880,6 +879,9 @@ func findAgentWorkOnce(ctx RoleContext, agentID string) (*beads.Issue, error) {
 	}
 
 	if len(hookedBeads) == 0 {
+		if staleHookErr != nil {
+			return nil, staleHookErr
+		}
 		return nil, nil
 	}
 	return hookedBeads[0], nil
@@ -1053,20 +1055,13 @@ func outputRalphLoopDirective(ctx RoleContext, attachment *beads.AttachmentField
 // outputBeadPreview runs `bd show` and displays a truncated preview of the bead.
 func outputBeadPreview(hookedBead *beads.Issue) {
 	fmt.Println("**Bead details:**")
-	cmd := exec.Command("bd", "show", hookedBead.ID)
-	cmd.Env = os.Environ()
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		if errMsg := strings.TrimSpace(stderr.String()); errMsg != "" {
-			fmt.Fprintf(os.Stderr, "  bd show %s: %s\n", hookedBead.ID, errMsg)
-		} else {
-			fmt.Fprintf(os.Stderr, "  bd show %s: %v\n", hookedBead.ID, err)
-		}
-	} else {
-		lines := strings.Split(stdout.String(), "\n")
-		maxLines := 15
+	fmt.Printf("  %s: %s\n", hookedBead.ID, hookedBead.Title)
+	if hookedBead.Status != "" {
+		fmt.Printf("  status: %s\n", hookedBead.Status)
+	}
+	if hookedBead.Description != "" {
+		lines := strings.Split(hookedBead.Description, "\n")
+		maxLines := 12
 		if len(lines) > maxLines {
 			lines = lines[:maxLines]
 			lines = append(lines, "...")
@@ -1253,7 +1248,7 @@ func ensureBeadsRedirect(ctx RoleContext) {
 // hooked bead and persists it in two places so all subsequent subprocesses carry it:
 //
 //  1. Current process env (GT_WORK_RIG/BEAD/MOL via os.Setenv) — inherited by bd, mail,
-//     and any other subprocess spawned from this gt prime invocation (e.g. bd prime).
+//     and any other subprocess spawned from this gt prime invocation.
 //
 //  2. Tmux session env (via tmux set-environment) — inherited by future processes
 //     spawned in the session after a handoff or compaction (e.g. new Claude Code instance).

--- a/internal/cmd/prime_external_tools_test.go
+++ b/internal/cmd/prime_external_tools_test.go
@@ -72,10 +72,9 @@ func assertPrimeToolCalled(t *testing.T, want string) {
 	}
 }
 
-func TestRunPrimeExternalTools_BoundsSlowBdPrimeAndContinues(t *testing.T) {
+func TestRunPrimeExternalTools_RunsMemoryAndMail(t *testing.T) {
 	workDir := setupPrimeExternalToolTest(t, `
 case "$*" in
-  "prime") sleep 2; exit 0 ;;
   "kv list --json") printf '%s\n' '{"memory.feedback.test":"remembered"}'; exit 0 ;;
 esac
 `, `
@@ -85,17 +84,16 @@ esac
 `)
 
 	start := time.Now()
-	output := captureStdout(t, func() { runPrimeExternalTools(workDir) })
+	output := captureStdout(t, func() { runPrimeExternalTools(RoleContext{Role: RolePolecat}, workDir) })
 	assertElapsedUnder(t, time.Since(start), time.Second)
-	assertPrimeToolCalled(t, "bd:prime")
 	assertPrimeToolCalled(t, "bd:kv list --json")
 	assertPrimeToolCalled(t, "gt:mail check --inject")
 
 	if !strings.Contains(output, "remembered") {
-		t.Fatalf("memory injection did not continue after bd prime timeout: %q", output)
+		t.Fatalf("memory injection missing: %q", output)
 	}
 	if !strings.Contains(output, "MAIL OUTPUT") {
-		t.Fatalf("mail injection did not continue after bd prime timeout: %q", output)
+		t.Fatalf("mail injection missing: %q", output)
 	}
 }
 
@@ -105,7 +103,6 @@ func TestRunPrimeExternalTools_BoundsSlowMailCheck(t *testing.T) {
 	survivedPath := filepath.Join(markerDir, "child-survived")
 	workDir := setupPrimeExternalToolTest(t, `
 case "$*" in
-  "prime") printf '%s\n' 'BD PRIME OUTPUT'; exit 0 ;;
   "kv list --json") printf '%s\n' '{"memory.feedback.test":"remembered"}'; exit 0 ;;
 esac
 `, `
@@ -122,15 +119,11 @@ esac
 	t.Setenv("PRIME_CHILD_SURVIVED", survivedPath)
 
 	start := time.Now()
-	output := captureStdout(t, func() { runPrimeExternalTools(workDir) })
+	output := captureStdout(t, func() { runPrimeExternalTools(RoleContext{Role: RolePolecat}, workDir) })
 	assertElapsedUnder(t, time.Since(start), time.Second)
-	assertPrimeToolCalled(t, "bd:prime")
 	assertPrimeToolCalled(t, "bd:kv list --json")
 	assertPrimeToolCalled(t, "gt:mail check --inject")
 
-	if !strings.Contains(output, "BD PRIME OUTPUT") {
-		t.Fatalf("bd prime output missing: %q", output)
-	}
 	if !strings.Contains(output, "remembered") {
 		t.Fatalf("memory output missing: %q", output)
 	}
@@ -146,10 +139,39 @@ esac
 	}
 }
 
+func TestRunPrimeExternalTools_SkipsMailCheckForPatrolRoles(t *testing.T) {
+	for _, role := range []string{string(RoleWitness), string(RoleRefinery), string(RoleDeacon), string(RoleBoot)} {
+		t.Run(role, func(t *testing.T) {
+			workDir := setupPrimeExternalToolTest(t, `
+case "$*" in
+  "kv list --json") printf '%s\n' '{}'; exit 0 ;;
+esac
+`, `
+case "$*" in
+  "mail check --inject") printf '%s\n' 'MAIL OUTPUT'; exit 0 ;;
+esac
+`)
+
+			output := captureStdout(t, func() { runPrimeExternalTools(RoleContext{Role: Role(role)}, workDir) })
+			assertPrimeToolCalled(t, "bd:kv list --json")
+			logData, err := os.ReadFile(os.Getenv("PRIME_TOOL_CALL_LOG"))
+			if err != nil {
+				t.Fatalf("read call log: %v", err)
+			}
+			if strings.Contains(string(logData), "gt:mail check --inject") {
+				t.Fatalf("patrol role %s should not run startup mail check:\n%s", role, string(logData))
+			}
+			if strings.Contains(output, "MAIL OUTPUT") {
+				t.Fatalf("patrol role %s injected mail output: %q", role, output)
+			}
+		})
+	}
+}
+
 func TestCheckPendingEscalations_BoundsSlowBdList(t *testing.T) {
 	workDir := setupPrimeExternalToolTest(t, `
 case "$*" in
-  "list --status=open --tag=escalation --json") sleep 2; exit 0 ;;
+	  "list --status=open --tag=escalation --json --flat") sleep 2; exit 0 ;;
 esac
 `, `
 `)
@@ -159,7 +181,7 @@ esac
 		checkPendingEscalations(RoleContext{Role: RoleMayor, WorkDir: workDir})
 	})
 	assertElapsedUnder(t, time.Since(start), time.Second)
-	assertPrimeToolCalled(t, "bd:list --status=open --tag=escalation --json")
+	assertPrimeToolCalled(t, "bd:list --status=open --tag=escalation --json --flat")
 
 	if strings.Contains(output, "PENDING ESCALATIONS") {
 		t.Fatalf("timed-out escalation output should not be emitted: %q", output)

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -23,10 +23,10 @@ import (
 )
 
 var rootCmd = &cobra.Command{
-	Use:     "gt", // Updated in init() based on GT_COMMAND
-	Short:   "Gas Town - Multi-agent workspace manager",
-	Version: Version,
-	Long:    "", // Updated in init() based on GT_COMMAND
+	Use:               "gt", // Updated in init() based on GT_COMMAND
+	Short:             "Gas Town - Multi-agent workspace manager",
+	Version:           Version,
+	Long:              "", // Updated in init() based on GT_COMMAND
 	PersistentPreRunE: persistentPreRun,
 }
 
@@ -43,52 +43,56 @@ across distributed teams of AI agents working on shared codebases.`, cmdName)
 // Commands that don't require beads to be installed/checked.
 // These commands should work even when bd is missing or outdated.
 var beadsExemptCommands = map[string]bool{
-	"version":    true,
-	"help":       true,
-	"completion": true,
-	"crew":       true,
-	"polecat":    true,
-	"witness":    true,
-	"refinery":   true,
-	"status":     true,
-	"mail":       true,
-	"hook":       true,
-	"prime":      true,
-	"nudge":      true,
-	"seance":     true,
-	"doctor":     true,
-	"dolt":       true,
-	"handoff":    true,
-	"costs":      true,
-	"feed":       true,
-	"rig":        true,
-	"config":     true,
-	"install":    true,
-	"tap":        true,
-	"dnd":        true,
-	"estop":      true, // E-stop must work when Dolt is down
-	"thaw":       true, // Thaw must work when Dolt is down
+	"version":       true,
+	"help":          true,
+	"completion":    true,
+	"crew":          true,
+	"polecat":       true,
+	"witness":       true,
+	"refinery":      true,
+	"status":        true,
+	"status-line":   true,
+	"mail":          true,
+	"hook":          true,
+	"prime":         true,
+	"nudge":         true,
+	"seance":        true,
+	"doctor":        true,
+	"dolt":          true,
+	"handoff":       true,
+	"costs":         true,
+	"feed":          true,
+	"rig":           true,
+	"scheduler":     true,
+	"config":        true,
+	"install":       true,
+	"tap":           true,
+	"dnd":           true,
+	"estop":         true, // E-stop must work when Dolt is down
+	"thaw":          true, // Thaw must work when Dolt is down
 	"signal":        true, // Hook signal handlers must be fast, handle beads internally
 	"metrics":       true, // Metrics reads local JSONL, no beads needed
 	"krc":           true, // KRC doesn't require beads
-	"run-migration":       true, // Migration orchestrator handles its own beads checks
-	"health":              true, // Health check doesn't require beads
-	"upgrade":             true, // Post-install migration orchestrator
-	"heartbeat":           true, // Heartbeat state update — must be fast and dependency-free
+	"run-migration": true, // Migration orchestrator handles its own beads checks
+	"health":        true, // Health check doesn't require beads
+	"upgrade":       true, // Post-install migration orchestrator
+	"heartbeat":     true, // Heartbeat state update — must be fast and dependency-free
 }
 
 // Commands exempt from the town root branch warning.
 // These are commands that help fix the problem or are diagnostic.
 var branchCheckExemptCommands = map[string]bool{
-	"version":    true,
-	"help":       true,
-	"completion": true,
-	"doctor":     true, // Used to fix the problem
-	"estop":      true, // Emergency stop must always work
-	"thaw":       true, // Thaw must always work
-	"install":    true, // Initial setup
-	"git-init":   true, // Git setup
-	"upgrade":    true, // Post-install migration
+	"version":     true,
+	"help":        true,
+	"completion":  true,
+	"doctor":      true, // Used to fix the problem
+	"status-line": true, // tmux hot path; never run git freshness checks here
+	"estop":       true, // Emergency stop must always work
+	"thaw":        true, // Thaw must always work
+	"install":     true, // Initial setup
+	"git-init":    true, // Git setup
+	"upgrade":     true, // Post-install migration
+	"scheduler":   true, // Daemon hot path; scheduler handles beads internally
 }
 
 // persistentPreRun runs before every command.
@@ -124,16 +128,16 @@ func persistentPreRun(cmd *cobra.Command, args []string) error {
 		}
 	}
 
-	// Get the root command name being run
-	cmdName := cmd.Name()
+	beadsExempt := isCommandOrAncestorExempt(cmd, beadsExemptCommands)
+	branchExempt := isCommandOrAncestorExempt(cmd, branchCheckExemptCommands)
 
 	// Check for stale binary (warning only, doesn't block)
-	if !beadsExemptCommands[cmdName] {
+	if !beadsExempt {
 		checkStaleBinaryWarning()
 	}
 
 	// Check town root branch (warning only, non-blocking)
-	if !branchCheckExemptCommands[cmdName] {
+	if !branchExempt {
 		warnIfTownRootOffMain()
 	}
 
@@ -144,7 +148,7 @@ func persistentPreRun(cmd *cobra.Command, args []string) error {
 	touchPolecatHeartbeat()
 
 	// Skip beads check for exempt commands
-	if beadsExemptCommands[cmdName] || isRoleCommand(cmd) {
+	if beadsExempt || isRoleCommand(cmd) {
 		return nil
 	}
 
@@ -155,6 +159,15 @@ func persistentPreRun(cmd *cobra.Command, args []string) error {
 		fmt.Fprintf(os.Stderr, "   Run %s for details.\n\n", style.Dim.Render("gt doctor"))
 	}
 	return nil
+}
+
+func isCommandOrAncestorExempt(cmd *cobra.Command, exemptions map[string]bool) bool {
+	for c := cmd; c != nil; c = c.Parent() {
+		if exemptions[c.Name()] {
+			return true
+		}
+	}
+	return false
 }
 
 // isRoleCommand returns true when the invoked command belongs to the `gt role` tree.

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -728,6 +728,17 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	delayedDogInfo := resolved.DelayedDogInfo
 	newPolecatInfo := resolved.NewPolecatInfo
 	isSelfSling := resolved.IsSelfSling
+	rollbackSpawnedPolecat := func(reason string) {
+		if newPolecatInfo == nil {
+			return
+		}
+		fmt.Printf("%s %s, rolling back spawned polecat %s...\n", style.Warning.Render("⚠"), reason, newPolecatInfo.PolecatName)
+		rollbackSlingArtifactsFn(newPolecatInfo, beadID, hookWorkDir, "")
+		// Under --force, rollback's unhook can clear a pinned bead's original state.
+		if force && originalStatus == "pinned" {
+			restorePinnedBead(townRoot, beadID, originalAssignee)
+		}
+	}
 
 	// Inject base_branch var for formula instantiation (non-main only; formula default handles main)
 	if newPolecatInfo != nil && newPolecatInfo.BaseBranch != "" && newPolecatInfo.BaseBranch != "main" {
@@ -745,6 +756,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	// Skip for self-sling (user knows what they're doing) and --force overrides.
 	if strings.Contains(targetAgent, "/polecats/") && !force && !isSelfSling {
 		if err := checkCrossRigGuard(beadID, targetAgent, townRoot); err != nil {
+			rollbackSpawnedPolecat("Cross-rig guard failed")
 			return err
 		}
 	}
@@ -957,11 +969,13 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	// same assignee's row in Dolt, causing silent rollbacks (issue #3114).
 	assigneeUnlock, assigneeLockErr := tryAcquireSlingAssigneeLock(townRoot, targetAgent)
 	if assigneeLockErr != nil {
+		rollbackSpawnedPolecat("Could not serialize hook write")
 		return fmt.Errorf("serializing hook write for %s: %w", targetAgent, assigneeLockErr)
 	}
 	defer assigneeUnlock()
 	hookDir := beads.ResolveHookDir(townRoot, beadID, hookWorkDir)
-	if err := hookBeadWithRetry(beadID, targetAgent, hookDir); err != nil {
+	if err := hookBeadWithRetryFn(beadID, targetAgent, hookDir); err != nil {
+		rollbackSpawnedPolecat("Hook write failed")
 		return err
 	}
 

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -337,7 +337,7 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 	}
 	defer assigneeUnlock()
 	hookDir := beads.ResolveHookDir(townRoot, beadToHook, hookWorkDir)
-	if err := hookBeadWithRetry(beadToHook, targetAgent, hookDir); err != nil {
+	if err := hookBeadWithRetryFn(beadToHook, targetAgent, hookDir); err != nil {
 		// Clean up orphaned polecat to avoid leaving spawned-but-unhookable polecats
 		cleanupSpawnedPolecat(spawnInfo, params.RigName, convoyID)
 		result.ErrMsg = "hook failed"

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -1145,6 +1145,7 @@ func hookBeadWithRetry(beadID, targetAgent, hookDir string) error {
 	for attempt := 1; attempt <= maxRetries; attempt++ {
 		err := BdCmd("update", beadID, "--status=hooked", "--assignee="+targetAgent).
 			Dir(hookDir).
+			WithAutoCommit().
 			Run()
 		if err != nil {
 			lastErr = err
@@ -1194,6 +1195,8 @@ func hookBeadWithRetry(beadID, targetAgent, hookDir string) error {
 
 	return nil
 }
+
+var hookBeadWithRetryFn = hookBeadWithRetry
 
 // slingBackoff calculates exponential backoff with ±25% jitter for a given attempt (1-indexed).
 // Formula: base * 2^(attempt-1) * (1 ± 25% random), capped at max.

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -482,6 +483,112 @@ exit /b 0
 	err = runSling(nil, []string{"gt-abc123", "gastown"})
 	if err == nil {
 		t.Fatalf("expected error from runSling")
+	}
+	if !rollbackCalled {
+		t.Fatalf("expected rollbackSlingArtifacts to be called")
+	}
+}
+
+func TestSlingRollsBackSpawnedPolecatOnHookFailure(t *testing.T) {
+	townRoot := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir mayor/rig: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"version":1}`), 0644); err != nil {
+		t.Fatalf("write town marker: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, "gastown", "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir gastown mayor rig: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(`{"prefix":"gt-","path":"gastown/mayor/rig"}`+"\n"), 0644); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+	rigs := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{
+		"gastown": {GitURL: "git@github.com:test/gastown.git", AddedAt: time.Now().Truncate(time.Second), BeadsConfig: &config.BeadsConfig{Repo: "local", Prefix: "gt-"}},
+	}}
+	if err := config.SaveRigsConfig(filepath.Join(townRoot, "mayor", "rigs.json"), rigs); err != nil {
+		t.Fatalf("SaveRigsConfig: %v", err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	bdScript := `#!/bin/sh
+for arg in "$@"; do
+  case "$arg" in
+    show) echo '[{"title":"Test issue","status":"open","assignee":"","description":""}]'; exit 0 ;;
+    update) exit 0 ;;
+  esac
+done
+exit 0
+`
+	bdScriptWindows := `@echo off
+for %%a in (%*) do (
+  if "%%a"=="show" (echo [{"title":"Test issue","status":"open","assignee":"","description":""}]& exit /b 0)
+  if "%%a"=="update" exit /b 0
+)
+exit /b 0
+`
+	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv(EnvGTRole, "mayor")
+	t.Setenv("GT_TEST_NO_NUDGE", "1")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	prevNoConvoy := slingNoConvoy
+	prevNoBoot := slingNoBoot
+	prevHookRaw := slingHookRawBead
+	prevSpawn := spawnPolecatForSling
+	prevResolveTargetAgent := resolveTargetAgentFn
+	prevRollback := rollbackSlingArtifactsFn
+	prevHook := hookBeadWithRetryFn
+	t.Cleanup(func() {
+		slingNoConvoy = prevNoConvoy
+		slingNoBoot = prevNoBoot
+		slingHookRawBead = prevHookRaw
+		spawnPolecatForSling = prevSpawn
+		resolveTargetAgentFn = prevResolveTargetAgent
+		rollbackSlingArtifactsFn = prevRollback
+		hookBeadWithRetryFn = prevHook
+	})
+	slingNoConvoy = true
+	slingNoBoot = true
+	slingHookRawBead = true
+
+	spawnPolecatForSling = func(rigName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		return &SpawnedPolecatInfo{RigName: rigName, PolecatName: "Toast", ClonePath: filepath.Join(townRoot, "fake-polecat")}, nil
+	}
+	resolveTargetAgentFn = func(target string) (agentID string, pane string, hookRoot string, err error) {
+		return "", "", "", errors.New("simulated dead target")
+	}
+	hookBeadWithRetryFn = func(beadID, targetAgent, hookDir string) error {
+		return errors.New("simulated hook failure")
+	}
+
+	rollbackCalled := false
+	rollbackSlingArtifactsFn = func(spawnInfo *SpawnedPolecatInfo, beadID, hookWorkDir, convoyID string) {
+		rollbackCalled = true
+		if spawnInfo == nil || spawnInfo.PolecatName != "Toast" {
+			t.Fatalf("unexpected spawnInfo in rollback: %+v", spawnInfo)
+		}
+	}
+
+	err = runSling(nil, []string{"gt-abc123", "gastown/polecats/toast"})
+	if err == nil {
+		t.Fatalf("expected hook failure from runSling")
 	}
 	if !rollbackCalled {
 		t.Fatalf("expected rollbackSlingArtifacts to be called")
@@ -2203,6 +2310,41 @@ exit /b 0
 		if !strings.Contains(line, "ENV:BD_DOLT_AUTO_COMMIT=off|") {
 			t.Errorf("bd command missing BD_DOLT_AUTO_COMMIT=off: %s", line)
 		}
+	}
+}
+
+func TestHookBeadWithRetryForcesAutoCommit(t *testing.T) {
+	townRoot := t.TempDir()
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd.log")
+
+	bdScript := `#!/usr/bin/env sh
+printf 'ENV:BD_DOLT_AUTO_COMMIT=%s|%s\n' "$BD_DOLT_AUTO_COMMIT" "$*" >> "$BD_LOG"
+exit 0
+`
+	bdScriptWindows := `@echo off
+setlocal enableextensions
+echo ENV:BD_DOLT_AUTO_COMMIT=%BD_DOLT_AUTO_COMMIT%^|%*>>"%BD_LOG%"
+exit /b 0
+`
+	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
+
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_DOLT_AUTO_COMMIT", "off")
+	t.Setenv("GT_TEST_SKIP_HOOK_VERIFY", "1")
+
+	if err := hookBeadWithRetry("gt-test123", "gastown/polecats/toast", townRoot); err != nil {
+		t.Fatalf("hookBeadWithRetry: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	logText := string(logBytes)
+	if !strings.Contains(logText, "ENV:BD_DOLT_AUTO_COMMIT=on|") {
+		t.Fatalf("hook update did not force auto-commit; log:\n%s", logText)
 	}
 }
 

--- a/internal/cmd/statusline.go
+++ b/internal/cmd/statusline.go
@@ -8,10 +8,8 @@ import (
 	"strings"
 
 	"github.com/spf13/cobra"
-	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/estop"
-	"github.com/steveyegge/gastown/internal/mail"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/workspace"
@@ -115,49 +113,17 @@ func runStatusLine(cmd *cobra.Command, args []string) error {
 // runWorkerStatusLine outputs status for crew or polecat sessions.
 func runWorkerStatusLine(t *tmux.Tmux, session, rigName, polecat, crew, issue string) error {
 	// Determine agent type and identity
-	var icon, identity string
+	var icon string
 	if polecat != "" {
 		icon = AgentTypeIcons[AgentPolecat]
-		identity = fmt.Sprintf("%s/%s", rigName, polecat)
 	} else if crew != "" {
 		icon = AgentTypeIcons[AgentCrew]
-		identity = fmt.Sprintf("%s/crew/%s", rigName, crew)
-	}
-
-	// Get pane's working directory to find workspace
-	var townRoot string
-	if session != "" {
-		paneDir, err := t.GetPaneWorkDir(session)
-		if err == nil && paneDir != "" {
-			townRoot, _ = workspace.Find(paneDir)
-		}
 	}
 
 	// Build status parts
 	var parts []string
-
-	// Priority 1: Check for hooked work (use rig beads)
-	hookedWork := ""
-	if identity != "" && rigName != "" && townRoot != "" {
-		rigBeadsDir := filepath.Join(townRoot, rigName, "mayor", "rig")
-		hookedWork = getHookedWork(identity, 40, rigBeadsDir)
-	}
-
-	// Priority 2: Fall back to GT_ISSUE env var or in_progress beads
 	currentWork := issue
-	if currentWork == "" && hookedWork == "" && session != "" {
-		currentWork = getCurrentWork(t, session, identity, 40)
-	}
-
-	// Show hooked work (takes precedence)
-	if hookedWork != "" {
-		if icon != "" {
-			parts = append(parts, fmt.Sprintf("%s 🪝 %s", icon, hookedWork))
-		} else {
-			parts = append(parts, fmt.Sprintf("🪝 %s", hookedWork))
-		}
-	} else if currentWork != "" {
-		// Fall back to current work (in_progress)
+	if currentWork != "" {
 		if icon != "" {
 			parts = append(parts, fmt.Sprintf("%s %s", icon, currentWork))
 		} else {
@@ -165,18 +131,6 @@ func runWorkerStatusLine(t *tmux.Tmux, session, rigName, polecat, crew, issue st
 		}
 	} else if icon != "" {
 		parts = append(parts, icon)
-	}
-
-	// Mail preview - only show if hook is empty
-	if hookedWork == "" && identity != "" && townRoot != "" {
-		unread, subject := getMailPreviewWithRoot(identity, 45, townRoot)
-		if unread > 0 {
-			if subject != "" {
-				parts = append(parts, fmt.Sprintf("\U0001F4EC %s", subject))
-			} else {
-				parts = append(parts, fmt.Sprintf("\U0001F4EC %d", unread))
-			}
-		}
 	}
 
 	// Output
@@ -275,14 +229,10 @@ func runMayorStatusLine(t *tmux.Tmux) error {
 		}
 	}
 
-	// Get operational state for each rig
-	for rigName, status := range rigStatuses {
-		opState, _ := getRigOperationalState(townRoot, rigName)
-		if opState == "PARKED" || opState == "DOCKED" {
-			status.opState = opState
-		} else {
-			status.opState = "OPERATIONAL"
-		}
+	// Status-line is a tmux hot path. Do not query beads for dock/park state here;
+	// `gt rig list/status` remains the authoritative live status view.
+	for _, status := range rigStatuses {
+		status.opState = "OPERATIONAL"
 	}
 
 	// Build status
@@ -391,25 +341,6 @@ func runMayorStatusLine(t *tmux.Tmux) error {
 		parts = append(parts, strings.Join(rigParts, " "))
 	}
 
-	// Priority 1: Check for hooked work (town beads for mayor)
-	hookedWork := ""
-	if townRoot != "" {
-		hookedWork = getHookedWork("mayor", 40, townRoot)
-	}
-	if hookedWork != "" {
-		parts = append(parts, fmt.Sprintf("🪝 %s", hookedWork))
-	} else if townRoot != "" {
-		// Priority 2: Fall back to mail preview
-		unread, subject := getMailPreviewWithRoot("mayor/", 45, townRoot)
-		if unread > 0 {
-			if subject != "" {
-				parts = append(parts, fmt.Sprintf("\U0001F4EC %s", subject))
-			} else {
-				parts = append(parts, fmt.Sprintf("\U0001F4EC %d", unread))
-			}
-		}
-	}
-
 	fmt.Print(strings.Join(parts, " | ") + " |")
 	return nil
 }
@@ -423,7 +354,7 @@ func runDeaconStatusLine(t *tmux.Tmux) error {
 		return nil // Silent fail
 	}
 
-	// Get town root from deacon pane's working directory
+	// Get town root from deacon pane's working directory. Config files only; no beads.
 	var townRoot string
 	deaconSession := getDeaconSessionName()
 	paneDir, err := t.GetPaneWorkDir(deaconSession)
@@ -460,25 +391,6 @@ func runDeaconStatusLine(t *tmux.Tmux) error {
 	var parts []string
 	parts = append(parts, fmt.Sprintf("%d rigs", rigCount))
 
-	// Priority 1: Check for hooked work (town beads for deacon)
-	hookedWork := ""
-	if townRoot != "" {
-		hookedWork = getHookedWork("deacon", 35, townRoot)
-	}
-	if hookedWork != "" {
-		parts = append(parts, fmt.Sprintf("🪝 %s", hookedWork))
-	} else if townRoot != "" {
-		// Priority 2: Fall back to mail preview
-		unread, subject := getMailPreviewWithRoot("deacon/", 40, townRoot)
-		if unread > 0 {
-			if subject != "" {
-				parts = append(parts, fmt.Sprintf("\U0001F4EC %s", subject))
-			} else {
-				parts = append(parts, fmt.Sprintf("\U0001F4EC %d", unread))
-			}
-		}
-	}
-
 	fmt.Print(strings.Join(parts, " | ") + " |")
 	return nil
 }
@@ -492,14 +404,6 @@ func runWitnessStatusLine(t *tmux.Tmux, rigName string) error {
 		if identity, err := session.ParseSessionName(statusLineSession); err == nil && identity.Role == session.RoleWitness {
 			rigName = identity.Rig
 		}
-	}
-
-	// Get town root from witness pane's working directory
-	var townRoot string
-	sessionName := session.WitnessSessionName(session.PrefixFor(rigName))
-	paneDir, err := t.GetPaneWorkDir(sessionName)
-	if err == nil && paneDir != "" {
-		townRoot, _ = workspace.Find(paneDir)
 	}
 
 	// Count crew in this rig (crew are persistent, worth tracking)
@@ -519,32 +423,13 @@ func runWitnessStatusLine(t *tmux.Tmux, rigName string) error {
 		}
 	}
 
-	identity := fmt.Sprintf("%s/witness", rigName)
-
 	// Build status
 	var parts []string
 	if crewCount > 0 {
 		parts = append(parts, fmt.Sprintf("%d crew", crewCount))
 	}
-
-	// Priority 1: Check for hooked work (rig beads for witness)
-	hookedWork := ""
-	if townRoot != "" && rigName != "" {
-		rigBeadsDir := filepath.Join(townRoot, rigName, "mayor", "rig")
-		hookedWork = getHookedWork(identity, 30, rigBeadsDir)
-	}
-	if hookedWork != "" {
-		parts = append(parts, fmt.Sprintf("🪝 %s", hookedWork))
-	} else if townRoot != "" {
-		// Priority 2: Fall back to mail preview
-		unread, subject := getMailPreviewWithRoot(identity, 35, townRoot)
-		if unread > 0 {
-			if subject != "" {
-				parts = append(parts, fmt.Sprintf("\U0001F4EC %s", subject))
-			} else {
-				parts = append(parts, fmt.Sprintf("\U0001F4EC %d", unread))
-			}
-		}
+	if len(parts) == 0 {
+		parts = append(parts, "patrol")
 	}
 
 	fmt.Print(strings.Join(parts, " | ") + " |")
@@ -566,78 +451,7 @@ func runRefineryStatusLine(t *tmux.Tmux, rigName string) error {
 		return nil
 	}
 
-	// Get town root from refinery pane's working directory
-	var townRoot string
-	sessionName := session.RefinerySessionName(session.PrefixFor(rigName))
-	paneDir, err := t.GetPaneWorkDir(sessionName)
-	if err == nil && paneDir != "" {
-		townRoot, _ = workspace.Find(paneDir)
-	}
-
-	// Get refinery manager using shared helper
-	mgr, _, _, err := getRefineryManager(rigName)
-	if err != nil {
-		// Fallback to simple status if we can't access refinery
-		fmt.Printf("%s MQ: ? |", AgentTypeIcons[AgentRefinery])
-		return nil
-	}
-
-	// Get queue
-	queue, err := mgr.Queue()
-	if err != nil {
-		// Fallback to simple status if we can't read queue
-		fmt.Printf("%s MQ: ? |", AgentTypeIcons[AgentRefinery])
-		return nil
-	}
-
-	// Count pending items and find current item
-	pending := 0
-	var currentItem string
-	for _, item := range queue {
-		if item.Position == 0 && item.MR != nil {
-			// Currently processing - show issue ID
-			currentItem = item.MR.IssueID
-		} else {
-			pending++
-		}
-	}
-
-	identity := fmt.Sprintf("%s/refinery", rigName)
-
-	// Build status
-	var parts []string
-	if currentItem != "" {
-		parts = append(parts, fmt.Sprintf("merging %s", currentItem))
-		if pending > 0 {
-			parts = append(parts, fmt.Sprintf("+%d queued", pending))
-		}
-	} else if pending > 0 {
-		parts = append(parts, fmt.Sprintf("%d queued", pending))
-	} else {
-		parts = append(parts, "idle")
-	}
-
-	// Priority 1: Check for hooked work (rig beads for refinery)
-	hookedWork := ""
-	if townRoot != "" && rigName != "" {
-		rigBeadsDir := filepath.Join(townRoot, rigName, "mayor", "rig")
-		hookedWork = getHookedWork(identity, 25, rigBeadsDir)
-	}
-	if hookedWork != "" {
-		parts = append(parts, fmt.Sprintf("🪝 %s", hookedWork))
-	} else if townRoot != "" {
-		// Priority 2: Fall back to mail preview
-		unread, subject := getMailPreviewWithRoot(identity, 30, townRoot)
-		if unread > 0 {
-			if subject != "" {
-				parts = append(parts, fmt.Sprintf("\U0001F4EC %s", subject))
-			} else {
-				parts = append(parts, fmt.Sprintf("\U0001F4EC %d", unread))
-			}
-		}
-	}
-
-	fmt.Print(strings.Join(parts, " | ") + " |")
+	fmt.Print("idle |")
 	return nil
 }
 
@@ -660,95 +474,4 @@ func isSessionWorking(t *tmux.Tmux, session string) bool {
 	}
 
 	return false
-}
-
-// getMailPreviewWithRoot returns unread count and a truncated subject of the first unread message,
-// using an explicit town root.
-func getMailPreviewWithRoot(identity string, maxLen int, townRoot string) (int, string) {
-	// Use NewMailboxFromAddress to normalize identity (e.g., gastown/crew/gus -> gastown/gus)
-	mailbox := mail.NewMailboxFromAddress(identity, townRoot)
-
-	// Get unread messages
-	messages, err := mailbox.ListUnread()
-	if err != nil || len(messages) == 0 {
-		return 0, ""
-	}
-
-	// Get first message subject, truncated
-	subject := messages[0].Subject
-	if len(subject) > maxLen {
-		subject = subject[:maxLen-1] + "…"
-	}
-
-	return len(messages), subject
-}
-
-// getHookedWork returns a truncated title of the hooked bead for an agent.
-// Returns empty string if nothing is hooked.
-// beadsDir should be the directory containing .beads (for rig-level) or
-// empty to use the town root (for town-level roles).
-func getHookedWork(identity string, maxLen int, beadsDir string) string {
-	// If no beadsDir specified, use town root
-	if beadsDir == "" {
-		var err error
-		beadsDir, err = findMailWorkDir()
-		if err != nil {
-			return ""
-		}
-	}
-
-	b := beads.New(beadsDir)
-
-	// Query for hooked beads assigned to this agent
-	hookedBeads, err := b.List(beads.ListOptions{
-		Status:   beads.StatusHooked,
-		Assignee: identity,
-		Priority: -1,
-	})
-	if err != nil || len(hookedBeads) == 0 {
-		return ""
-	}
-
-	// Return first hooked bead's ID and title, truncated
-	bead := hookedBeads[0]
-	display := fmt.Sprintf("%s: %s", bead.ID, bead.Title)
-	if len(display) > maxLen {
-		display = display[:maxLen-1] + "…"
-	}
-	return display
-}
-
-// getCurrentWork returns a truncated title of the first in_progress issue assigned to identity.
-// Uses the pane's working directory to find the beads.
-func getCurrentWork(t *tmux.Tmux, session string, identity string, maxLen int) string {
-	// Get the pane's working directory
-	workDir, err := t.GetPaneWorkDir(session)
-	if err != nil || workDir == "" {
-		return ""
-	}
-
-	// Check if there's a .beads directory
-	beadsDir := filepath.Join(workDir, ".beads")
-	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
-		return ""
-	}
-
-	// Query beads for in_progress issues assigned to this agent
-	b := beads.New(workDir)
-	issues, err := b.List(beads.ListOptions{
-		Status:   "in_progress",
-		Assignee: identity,
-		Priority: -1,
-	})
-	if err != nil || len(issues) == 0 {
-		return ""
-	}
-
-	// Return first issue's ID and title, truncated
-	issue := issues[0]
-	display := fmt.Sprintf("%s: %s", issue.ID, issue.Title)
-	if len(display) > maxLen {
-		display = display[:maxLen-1] + "…"
-	}
-	return display
 }

--- a/internal/cmd/statusline_test.go
+++ b/internal/cmd/statusline_test.go
@@ -1,6 +1,10 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/session"
@@ -8,87 +12,58 @@ import (
 
 func setupCmdTestRegistry(t *testing.T) {
 	t.Helper()
-	reg := session.NewPrefixRegistry()
-	reg.Register("gt", "gastown")
-	reg.Register("mr", "myrig")
+	registry := session.NewPrefixRegistry()
+	registry.Register("gt", "gastown")
+	registry.Register("do", "coder_dotfiles")
 	old := session.DefaultRegistry()
-	session.SetDefaultRegistry(reg)
+	session.SetDefaultRegistry(registry)
 	t.Cleanup(func() { session.SetDefaultRegistry(old) })
 }
 
-func TestCategorizeSessionRig(t *testing.T) {
-	setupCmdTestRegistry(t)
-	tests := []struct {
-		session string
-		wantRig string
-	}{
-		// Standard polecat sessions (prefix-based)
-		{"gt-slit", "gastown"},
-		{"gt-Toast", "gastown"},
-		{"mr-worker", "myrig"},
-
-		// Crew sessions
-		{"gt-crew-max", "gastown"},
-		{"mr-crew-user", "myrig"},
-
-		// Witness sessions
-		{"gt-witness", "gastown"},
-		{"mr-witness", "myrig"},
-
-		// Refinery sessions
-		{"gt-refinery", "gastown"},
-		{"mr-refinery", "myrig"},
-
-		// Town-level agents (no rig, use hq- prefix)
-		{"hq-mayor", ""},
-		{"hq-deacon", ""},
+func TestStatusLineAvoidsBeadsHotPath(t *testing.T) {
+	if !beadsExemptCommands["status-line"] {
+		t.Fatal("status-line must be exempt from bd version checks")
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.session, func(t *testing.T) {
-			agent := categorizeSession(tt.session)
-			gotRig := ""
-			if agent != nil {
-				gotRig = agent.Rig
-			}
-			if gotRig != tt.wantRig {
-				t.Errorf("categorizeSession(%q).Rig = %q, want %q", tt.session, gotRig, tt.wantRig)
-			}
-		})
+	if !branchCheckExemptCommands["status-line"] {
+		t.Fatal("status-line must be exempt from git branch/stale checks")
+	}
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	data, err := os.ReadFile(filepath.Join(filepath.Dir(file), "statusline.go"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	source := string(data)
+	for _, forbidden := range []string{
+		`internal/beads`,
+		`internal/mail`,
+		`beads.New`,
+		`mail.New`,
+		`getHookedWork`,
+		`getMailPreview`,
+		`ListUnread`,
+		`getRefineryManager`,
+		`.Queue()`,
+	} {
+		if strings.Contains(source, forbidden) {
+			t.Fatalf("status-line hot path must not contain %q", forbidden)
+		}
 	}
 }
 
-func TestCategorizeSessionType(t *testing.T) {
-	setupCmdTestRegistry(t)
-	tests := []struct {
-		session  string
-		wantType AgentType
-	}{
-		// Polecat sessions
-		{"gt-slit", AgentPolecat},
-		{"gt-Toast", AgentPolecat},
-		{"mr-worker", AgentPolecat},
-
-		// Non-polecat sessions
-		{"gt-witness", AgentWitness},
-		{"gt-refinery", AgentRefinery},
-		{"gt-crew-max", AgentCrew},
-		{"mr-crew-user", AgentCrew},
-
-		// Town-level agents (hq- prefix)
-		{"hq-mayor", AgentMayor},
-		{"hq-deacon", AgentDeacon},
+func TestSchedulerRunAvoidsRootBeadsChecks(t *testing.T) {
+	if !beadsExemptCommands["scheduler"] {
+		t.Fatal("scheduler must be exempt from root bd version checks")
 	}
-
-	for _, tt := range tests {
-		t.Run(tt.session, func(t *testing.T) {
-			agent := categorizeSession(tt.session)
-			if agent == nil {
-				t.Fatalf("categorizeSession(%q) returned nil", tt.session)
-			}
-			if agent.Type != tt.wantType {
-				t.Errorf("categorizeSession(%q).Type = %v, want %v", tt.session, agent.Type, tt.wantType)
-			}
-		})
+	if !branchCheckExemptCommands["scheduler"] {
+		t.Fatal("scheduler must be exempt from root git branch checks")
+	}
+	if !isCommandOrAncestorExempt(schedulerRunCmd, beadsExemptCommands) {
+		t.Fatal("scheduler run must inherit bd exemption from scheduler parent")
+	}
+	if !isCommandOrAncestorExempt(schedulerRunCmd, branchCheckExemptCommands) {
+		t.Fatal("scheduler run must inherit branch-check exemption from scheduler parent")
 	}
 }

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1271,6 +1271,8 @@ func resolveAgentConfigWithOverrideInternal(townRoot, rigPath, agentOverride str
 			return nil, "", fmt.Errorf("agent '%s' not found", agentName)
 		}
 
+		rc.ResolvedAgent = agentName
+
 		// Append extra arguments from the override
 		if len(extraArgs) > 0 {
 			rc.Args = append(rc.Args, extraArgs...)

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -5680,3 +5680,62 @@ func TestBuildStartupCommandWithAgentOverride_NoDoubleSettingsOnNonOverridePath(
 		t.Errorf("default Claude agent on polecat role should still get --settings, got: %q", cmd)
 	}
 }
+
+func TestResolveAgentConfigWithOverrideSetsResolvedAgent(t *testing.T) {
+	t.Parallel()
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "testrig")
+
+	if err := SaveTownSettings(TownSettingsPath(townRoot), NewTownSettings()); err != nil {
+		t.Fatalf("SaveTownSettings: %v", err)
+	}
+	if err := SaveRigSettings(RigSettingsPath(rigPath), NewRigSettings()); err != nil {
+		t.Fatalf("SaveRigSettings: %v", err)
+	}
+
+	for _, agentName := range []string{"opencode", "gemini", "codex", "claude", "copilot"} {
+		rc, resolvedAgent, err := ResolveAgentConfigWithOverride(townRoot, rigPath, agentName)
+		if err != nil {
+			t.Fatalf("ResolveAgentConfigWithOverride(%q): %v", agentName, err)
+		}
+		if resolvedAgent != agentName {
+			t.Errorf("resolved agent for %q: got %q, want %q", agentName, resolvedAgent, agentName)
+		}
+		if rc.ResolvedAgent != agentName {
+			t.Errorf("RuntimeConfig.ResolvedAgent for %q: got %q, want %q", agentName, rc.ResolvedAgent, agentName)
+		}
+	}
+}
+
+func TestBuildStartupCommandWithAgentOverrideSetsGTAgentForOpenCode(t *testing.T) {
+	t.Parallel()
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "testrig")
+
+	if err := SaveTownSettings(TownSettingsPath(townRoot), NewTownSettings()); err != nil {
+		t.Fatalf("SaveTownSettings: %v", err)
+	}
+	if err := SaveRigSettings(RigSettingsPath(rigPath), NewRigSettings()); err != nil {
+		t.Fatalf("SaveRigSettings: %v", err)
+	}
+
+	cmd, err := BuildStartupCommandWithAgentOverride(
+		map[string]string{"GT_ROLE": constants.RolePolecat},
+		rigPath,
+		"[GAS TOWN] test polecat beacon",
+		"opencode",
+	)
+	if err != nil {
+		t.Fatalf("BuildStartupCommandWithAgentOverride: %v", err)
+	}
+
+	if !strings.Contains(cmd, "GT_AGENT=opencode") {
+		t.Errorf("expected GT_AGENT=opencode in command, got: %q", cmd)
+	}
+	if !strings.Contains(cmd, "GT_PROCESS_NAMES=opencode") {
+		t.Errorf("expected GT_PROCESS_NAMES=opencode in command, got: %q", cmd)
+	}
+	if strings.Contains(cmd, "--settings") {
+		t.Errorf("opencode should not get Claude --settings, got: %q", cmd)
+	}
+}

--- a/internal/daemon/bd_env.go
+++ b/internal/daemon/bd_env.go
@@ -2,7 +2,9 @@ package daemon
 
 import (
 	"os"
-	"strings"
+	"path/filepath"
+
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 // bdReadOnlyEnv returns an environment slice for read-only bd/gt subprocess
@@ -17,12 +19,25 @@ import (
 // the authoritative "off" value, because glibc getenv() returns the first
 // matching entry — a stale "on" earlier in the slice would otherwise win.
 func bdReadOnlyEnv() []string {
-	base := os.Environ()
-	filtered := make([]string, 0, len(base)+1)
-	for _, e := range base {
-		if !strings.HasPrefix(e, "BD_DOLT_AUTO_COMMIT=") {
-			filtered = append(filtered, e)
-		}
+	return beads.BuildReadOnlyRoutingBDEnv(os.Environ(), "")
+}
+
+func bdReadOnlyRoutingEnv(townRoot string) []string {
+	fallback := ""
+	if townRoot != "" {
+		fallback = filepath.Join(townRoot, ".beads")
 	}
-	return append(filtered, "BD_DOLT_AUTO_COMMIT=off")
+	return beads.BuildReadOnlyRoutingBDEnv(os.Environ(), fallback)
+}
+
+func bdMutationRoutingEnv(townRoot string) []string {
+	fallback := ""
+	if townRoot != "" {
+		fallback = filepath.Join(townRoot, ".beads")
+	}
+	return beads.BuildMutationRoutingBDEnv(os.Environ(), fallback)
+}
+
+func bdReadOnlyPinnedEnv(beadsDir string) []string {
+	return beads.BuildReadOnlyPinnedBDEnv(os.Environ(), beadsDir)
 }

--- a/internal/daemon/bd_env_test.go
+++ b/internal/daemon/bd_env_test.go
@@ -1,6 +1,8 @@
 package daemon
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -30,21 +32,77 @@ func TestBdReadOnlyEnv(t *testing.T) {
 
 			env := bdReadOnlyEnv()
 
-			var count int
-			var value string
-			for _, e := range env {
-				if strings.HasPrefix(e, "BD_DOLT_AUTO_COMMIT=") {
-					count++
-					value = strings.TrimPrefix(e, "BD_DOLT_AUTO_COMMIT=")
-				}
-			}
-
-			if count != 1 {
-				t.Errorf("found %d BD_DOLT_AUTO_COMMIT entries, want exactly 1", count)
-			}
-			if value != "off" {
-				t.Errorf("BD_DOLT_AUTO_COMMIT = %q, want %q", value, "off")
-			}
+			assertSingleEnvValue(t, env, "BD_DOLT_AUTO_COMMIT", "off")
+			assertSingleEnvValue(t, env, "BD_READONLY", "true")
 		})
+	}
+}
+
+func TestBdReadOnlyPinnedEnvUsesSelectedBeadsDir(t *testing.T) {
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := []byte(`{"dolt_database":"rigdb","dolt_server_host":"127.0.0.1","dolt_server_port":4407}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BEADS_DIR", "/wrong")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "hq")
+	t.Setenv("BEADS_DOLT_SERVER_PORT", "9999")
+	t.Setenv("BD_DOLT_AUTO_COMMIT", "on")
+
+	env := bdReadOnlyPinnedEnv(beadsDir)
+	assertSingleEnvValue(t, env, "BEADS_DIR", beadsDir)
+	assertSingleEnvValue(t, env, "BEADS_DOLT_SERVER_DATABASE", "rigdb")
+	assertSingleEnvValue(t, env, "BEADS_DOLT_SERVER_PORT", "4407")
+	assertSingleEnvValue(t, env, "BEADS_DOLT_PORT", "4407")
+	assertSingleEnvValue(t, env, "BD_DOLT_AUTO_COMMIT", "off")
+	assertSingleEnvValue(t, env, "BD_READONLY", "true")
+	assertSingleEnvValue(t, env, "BD_EXPORT_AUTO", "false")
+}
+
+func TestBdReadOnlyRoutingEnvDoesNotPinDatabase(t *testing.T) {
+	townRoot := t.TempDir()
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := []byte(`{"dolt_database":"hq","dolt_server_host":"127.0.0.1","dolt_server_port":4407}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("BEADS_DIR", "/wrong")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "wrong")
+
+	env := bdReadOnlyRoutingEnv(townRoot)
+	assertEnvAbsent(t, env, "BEADS_DIR")
+	assertEnvAbsent(t, env, "BEADS_DOLT_SERVER_DATABASE")
+	assertSingleEnvValue(t, env, "BEADS_DOLT_SERVER_PORT", "4407")
+	assertSingleEnvValue(t, env, "BD_DOLT_AUTO_COMMIT", "off")
+	assertSingleEnvValue(t, env, "BD_READONLY", "true")
+}
+
+func assertSingleEnvValue(t *testing.T, env []string, key, want string) {
+	t.Helper()
+	var count int
+	var value string
+	for _, e := range env {
+		if strings.HasPrefix(e, key+"=") {
+			count++
+			value = strings.TrimPrefix(e, key+"=")
+		}
+	}
+	if count != 1 || value != want {
+		t.Fatalf("%s count/value = %d/%q, want 1/%q in %v", key, count, value, want, env)
+	}
+}
+
+func assertEnvAbsent(t *testing.T, env []string, key string) {
+	t.Helper()
+	for _, e := range env {
+		if strings.HasPrefix(e, key+"=") {
+			t.Fatalf("%s should be absent, got %q in %v", key, e, env)
+		}
 	}
 }

--- a/internal/daemon/convoy_manager.go
+++ b/internal/daemon/convoy_manager.go
@@ -510,7 +510,7 @@ func (m *ConvoyManager) scan() {
 func (m *ConvoyManager) findStranded() ([]strandedConvoyInfo, error) {
 	cmd := exec.CommandContext(m.ctx, m.gtPath, "convoy", "stranded", "--json")
 	cmd.Dir = m.townRoot
-	cmd.Env = bdReadOnlyEnv()
+	cmd.Env = bdReadOnlyRoutingEnv(m.townRoot)
 	util.SetProcessGroup(cmd)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -566,6 +566,7 @@ func (m *ConvoyManager) feedFirstReady(c strandedConvoyInfo) {
 		}
 		cmd := exec.CommandContext(m.ctx, m.gtPath, slingArgs...)
 		cmd.Dir = m.townRoot
+		cmd.Env = bdMutationRoutingEnv(m.townRoot)
 		util.SetProcessGroup(cmd)
 		var stderr bytes.Buffer
 		cmd.Stderr = &stderr
@@ -586,6 +587,7 @@ func (m *ConvoyManager) feedFirstReady(c strandedConvoyInfo) {
 func (m *ConvoyManager) checkConvoyCompletion(convoyID string) {
 	cmd := exec.CommandContext(m.ctx, m.gtPath, "convoy", "check", convoyID)
 	cmd.Dir = m.townRoot
+	cmd.Env = bdMutationRoutingEnv(m.townRoot)
 	util.SetProcessGroup(cmd)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -601,6 +603,7 @@ func (m *ConvoyManager) closeEmptyConvoy(convoyID string) {
 
 	cmd := exec.CommandContext(m.ctx, m.gtPath, "convoy", "check", convoyID)
 	cmd.Dir = m.townRoot
+	cmd.Env = bdMutationRoutingEnv(m.townRoot)
 	util.SetProcessGroup(cmd)
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2753,7 +2753,7 @@ func (d *Daemon) isBeadClosed(beadID string) bool {
 	cmd := exec.Command(d.bdPath, "show", beadID, "--json") //nolint:gosec // G204: args are constructed internally
 	setSysProcAttr(cmd)
 	cmd.Dir = d.config.TownRoot
-	cmd.Env = bdReadOnlyEnv()
+	cmd.Env = bdReadOnlyRoutingEnv(d.config.TownRoot)
 
 	output, err := cmd.Output()
 	if err != nil {
@@ -2780,13 +2780,17 @@ func (d *Daemon) hasAssignedOpenWork(rigName, assignee string) bool {
 	rigDir := beads.GetRigDirForName(d.config.TownRoot, rigName)
 
 	for _, status := range []string{"hooked", "in_progress", "open"} {
-		args := []string{"list", "--assignee=" + assignee, "--status=" + status, "--json"}
+		args := beads.InjectFlatForListJSON([]string{"list", "--assignee=" + assignee, "--status=" + status, "--json"})
 		if rigDir != "" {
 			args = append(args, "--repo="+rigDir)
 		}
 		cmd := exec.Command(d.bdPath, args...) //nolint:gosec // G204: args are constructed internally
 		cmd.Dir = d.config.TownRoot
-		cmd.Env = bdReadOnlyEnv()
+		if rigDir != "" {
+			cmd.Env = bdReadOnlyPinnedEnv(filepath.Join(rigDir, ".beads"))
+		} else {
+			cmd.Env = bdReadOnlyRoutingEnv(d.config.TownRoot)
+		}
 		output, err := cmd.Output()
 		if err != nil {
 			continue
@@ -2903,7 +2907,7 @@ func (d *Daemon) reapIdlePolecat(rigName, polecatName string, timeout time.Durat
 			// Use 3x threshold (not 2x) to avoid killing polecats during transient
 			// infrastructure degradation when the agent process is alive but not
 			// detectable (e.g. long thinking sessions, slow process inspection).
-			if staleDuration >= timeout*3 || !d.tmux.IsAgentRunning(sessionName) && staleDuration >= timeout*2 {
+			if staleDuration >= timeout*3 || !d.tmux.IsAgentAlive(sessionName) && staleDuration >= timeout*2 {
 				d.killIdlePolecat(rigName, polecatName, sessionName, staleDuration, timeout, "working-bead-lookup-failed")
 			}
 			return
@@ -2931,7 +2935,7 @@ func (d *Daemon) reapIdlePolecat(rigName, polecatName string, timeout time.Durat
 		// No hooked work + stale heartbeat — but check if the agent process
 		// is still actively running before reaping. A failed gt sling rollback
 		// can clear the hook while the agent is still working (GH#3342).
-		if d.tmux.IsAgentRunning(sessionName) {
+		if d.tmux.IsAgentAlive(sessionName) {
 			return
 		}
 		d.killIdlePolecat(rigName, polecatName, sessionName, staleDuration, timeout, "working-no-hook")
@@ -3037,7 +3041,7 @@ func (d *Daemon) dispatchQueuedWork() {
 	cmd := exec.CommandContext(ctx, "gt", "scheduler", "run")
 	setSysProcAttr(cmd)
 	cmd.Dir = d.config.TownRoot
-	cmd.Env = append(os.Environ(), "GT_DAEMON=1", "BD_DOLT_AUTO_COMMIT=off")
+	cmd.Env = append(beads.BuildMutationRoutingBDEnv(os.Environ(), filepath.Join(d.config.TownRoot, ".beads")), "GT_DAEMON=1")
 	out, err := cmd.CombinedOutput()
 	if ctx.Err() == context.DeadlineExceeded {
 		d.logger.Printf("Scheduler dispatch timed out after 5m")

--- a/internal/daemon/dog_molecule.go
+++ b/internal/daemon/dog_molecule.go
@@ -6,10 +6,11 @@ import (
 	"encoding/json"
 	"fmt"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 
-	"github.com/steveyegge/gastown/internal/util"
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 const (
@@ -21,7 +22,7 @@ const (
 // Graceful degradation: if bd fails, the dog still does its work — molecule
 // tracking is observability, not control flow.
 type dogMol struct {
-	rootID   string // Root wisp ID (e.g., "gt-wisp-abc123"), empty if pour failed.
+	rootID   string            // Root wisp ID (e.g., "gt-wisp-abc123"), empty if pour failed.
 	stepIDs  map[string]string // step slug -> wisp issue ID
 	bdPath   string
 	townRoot string
@@ -280,8 +281,7 @@ func (dm *dogMol) runBd(args ...string) (string, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, bdPath, args...)
-	cmd.Dir = dm.townRoot
-	util.SetDetachedProcessGroup(cmd)
+	beads.ConfigureCommand(cmd, dm.townRoot, filepath.Join(dm.townRoot, ".beads"), beads.SubprocessModeForArgs(args))
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -345,5 +345,3 @@ func stripANSI(s string) string {
 	}
 	return result.String()
 }
-
-

--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -836,6 +836,22 @@ func writeDaemonDoltConfig(cfg *DoltServerConfig, configPath string) error {
 	if cfg.Host != "" {
 		hostLine = fmt.Sprintf("\n  host: %s", cfg.Host)
 	}
+	eventSchedulerLine := "  event_scheduler: \"OFF\"\n"
+	if scheduler, ok := os.LookupEnv("GT_DOLT_EVENT_SCHEDULER"); ok {
+		if strings.EqualFold(scheduler, "omit") {
+			eventSchedulerLine = ""
+		} else if strings.TrimSpace(scheduler) != "" {
+			eventSchedulerLine = fmt.Sprintf("  event_scheduler: %q\n", strings.ToUpper(strings.TrimSpace(scheduler)))
+		}
+	}
+	systemVariablesBlock := "\nsystem_variables:\n  dolt_stats_enabled: 0\n"
+	if stats, ok := os.LookupEnv("GT_DOLT_STATS_ENABLED"); ok {
+		if strings.EqualFold(stats, "omit") {
+			systemVariablesBlock = ""
+		} else if strings.TrimSpace(stats) != "" {
+			systemVariablesBlock = fmt.Sprintf("\nsystem_variables:\n  dolt_stats_enabled: %s\n", strings.TrimSpace(stats))
+		}
+	}
 	content := fmt.Sprintf(`# Dolt SQL server configuration — managed by Gas Town daemon
 # Do not edit manually; overwritten on each daemon-managed server start.
 
@@ -851,13 +867,15 @@ data_dir: %q
 
 behavior:
   dolt_transaction_commit: false
-  auto_gc_behavior:
+%s  auto_gc_behavior:
     enable: false
     archive_level: 0
-`,
+%s`,
 		cfg.Port,
 		hostLine,
 		cfg.DataDir,
+		eventSchedulerLine,
+		systemVariablesBlock,
 	)
 	return os.WriteFile(configPath, []byte(content), 0600)
 }

--- a/internal/daemon/lifecycle.go
+++ b/internal/daemon/lifecycle.go
@@ -42,7 +42,7 @@ func (d *Daemon) ProcessLifecycleRequests() {
 	// Get mail for deacon identity (using gt mail, not bd mail)
 	cmd := exec.Command(d.gtPath, "mail", "inbox", "--identity", "deacon/", "--json")
 	cmd.Dir = d.config.TownRoot
-	cmd.Env = bdReadOnlyEnv()
+	cmd.Env = bdReadOnlyPinnedEnv(filepath.Join(d.config.TownRoot, ".beads"))
 	util.SetDetachedProcessGroup(cmd)
 
 	output, err := cmd.Output()
@@ -820,7 +820,7 @@ func (d *Daemon) getAgentBeadState(agentBeadID string) (string, error) {
 func (d *Daemon) getAgentBeadInfo(agentBeadID string) (*AgentBeadInfo, error) {
 	cmd := exec.Command(d.bdPath, "show", agentBeadID, "--json")
 	cmd.Dir = d.config.TownRoot
-	cmd.Env = append(bdReadOnlyEnv(), "BEADS_DIR="+filepath.Join(d.config.TownRoot, ".beads"))
+	cmd.Env = bdReadOnlyPinnedEnv(filepath.Join(d.config.TownRoot, ".beads"))
 	util.SetDetachedProcessGroup(cmd)
 
 	output, err := cmd.Output()
@@ -881,7 +881,7 @@ func (d *Daemon) getAgentBeadInfo(agentBeadID string) (*AgentBeadInfo, error) {
 func (d *Daemon) getAgentHookBead(agentBeadID string) string {
 	cmd := exec.Command(d.bdPath, "show", agentBeadID, "--json")
 	cmd.Dir = d.config.TownRoot
-	cmd.Env = bdReadOnlyEnv()
+	cmd.Env = bdReadOnlyPinnedEnv(filepath.Join(d.config.TownRoot, ".beads"))
 	util.SetDetachedProcessGroup(cmd)
 
 	output, err := cmd.Output()
@@ -973,7 +973,7 @@ func (d *Daemon) listAgentBeadsJSON(dest interface{}) error {
 	// Query issues table (backward compat during migration)
 	cmd := exec.Command(d.bdPath, "list", "--label=gt:agent", "--json", "--flat") //nolint:gosec // G204: bd is a trusted internal tool
 	cmd.Dir = d.config.TownRoot
-	cmd.Env = bdReadOnlyEnv()
+	cmd.Env = bdReadOnlyPinnedEnv(filepath.Join(d.config.TownRoot, ".beads"))
 	util.SetDetachedProcessGroup(cmd)
 
 	issuesOutput, issuesErr := cmd.Output()
@@ -981,7 +981,7 @@ func (d *Daemon) listAgentBeadsJSON(dest interface{}) error {
 	// Query wisps table (primary source after agent bead migration)
 	wispCmd := exec.Command(d.bdPath, "mol", "wisp", "list", "--json") //nolint:gosec // G204: bd is a trusted internal tool
 	wispCmd.Dir = d.config.TownRoot
-	wispCmd.Env = bdReadOnlyEnv()
+	wispCmd.Env = bdReadOnlyPinnedEnv(filepath.Join(d.config.TownRoot, ".beads"))
 	util.SetDetachedProcessGroup(wispCmd)
 
 	wispOutput, _ := wispCmd.Output() // Best-effort: wisps table may not exist

--- a/internal/deacon/bd_env.go
+++ b/internal/deacon/bd_env.go
@@ -1,0 +1,23 @@
+package deacon
+
+import (
+	"os"
+	"path/filepath"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func deaconReadOnlyRoutingEnv(townRoot string) []string {
+	return beads.BuildReadOnlyRoutingBDEnv(os.Environ(), townBeadsDir(townRoot))
+}
+
+func deaconMutationRoutingEnv(townRoot string) []string {
+	return beads.BuildMutationRoutingBDEnv(os.Environ(), townBeadsDir(townRoot))
+}
+
+func townBeadsDir(townRoot string) string {
+	if townRoot == "" {
+		return ""
+	}
+	return filepath.Join(townRoot, ".beads")
+}

--- a/internal/deacon/feed_stranded.go
+++ b/internal/deacon/feed_stranded.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/util"
 )
@@ -183,6 +184,7 @@ func (s *ConvoyFeedState) RecordFeed() {
 func FindStrandedConvoys(townRoot string) ([]StrandedConvoy, error) {
 	cmd := exec.Command("gt", "convoy", "stranded", "--json")
 	cmd.Dir = townRoot
+	cmd.Env = deaconReadOnlyRoutingEnv(townRoot)
 	util.SetDetachedProcessGroup(cmd)
 
 	output, err := cmd.Output()
@@ -337,6 +339,7 @@ func FeedStranded(townRoot string, maxPerCycle int, cooldown time.Duration) *Fee
 func closeEmptyConvoy(townRoot, convoyID string) error {
 	cmd := exec.Command("gt", "convoy", "check", convoyID)
 	cmd.Dir = townRoot
+	cmd.Env = deaconMutationRoutingEnv(townRoot)
 	util.SetDetachedProcessGroup(cmd)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -348,6 +351,7 @@ func dispatchFeedDog(townRoot, convoyID string) error {
 	cmd := exec.Command("gt", "sling", constants.MolConvoyFeed, "deacon/dogs",
 		"--var", fmt.Sprintf("convoy=%s", convoyID))
 	cmd.Dir = townRoot
+	cmd.Env = deaconMutationRoutingEnv(townRoot)
 	util.SetDetachedProcessGroup(cmd)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -382,9 +386,7 @@ func PruneFeedStrandedState(townRoot string) (int, error) {
 
 // getConvoyStatus returns the current status of a convoy bead.
 func getConvoyStatus(townRoot, convoyID string) string {
-	cmd := exec.Command("bd", "show", convoyID, "--json")
-	cmd.Dir = townRoot
-	util.SetDetachedProcessGroup(cmd)
+	cmd := beads.Command(townRoot, townBeadsDir(townRoot), beads.ReadOnlyRouting, "show", convoyID, "--json")
 
 	output, err := cmd.Output()
 	if err != nil {

--- a/internal/deacon/redispatch.go
+++ b/internal/deacon/redispatch.go
@@ -95,12 +95,12 @@ const ModelEscalationConfigPath = ".gastown/model-escalation.json"
 
 // RedispatchResult describes the outcome of a re-dispatch attempt.
 type RedispatchResult struct {
-	BeadID     string `json:"bead_id"`
-	Action     string `json:"action"` // "redispatched", "cooldown", "escalated", "error"
-	TargetRig  string `json:"target_rig,omitempty"`
-	Attempts   int    `json:"attempts"`
-	Message    string `json:"message,omitempty"`
-	Error      error  `json:"error,omitempty"`
+	BeadID    string `json:"bead_id"`
+	Action    string `json:"action"` // "redispatched", "cooldown", "escalated", "error"
+	TargetRig string `json:"target_rig,omitempty"`
+	Attempts  int    `json:"attempts"`
+	Message   string `json:"message,omitempty"`
+	Error     error  `json:"error,omitempty"`
 }
 
 // RedispatchStateFile returns the path to the re-dispatch state file.
@@ -376,9 +376,7 @@ func resolveRigFromBead(townRoot, beadID string) string {
 
 // getBeadStatusForRedispatch returns the current status of a bead.
 func getBeadStatusForRedispatch(townRoot, beadID string) string {
-	cmd := exec.Command("bd", "show", beadID, "--json")
-	cmd.Dir = townRoot
-	util.SetDetachedProcessGroup(cmd)
+	cmd := beads.Command(townRoot, townBeadsDir(townRoot), beads.ReadOnlyRouting, "show", beadID, "--json")
 
 	output, err := cmd.Output()
 	if err != nil {
@@ -453,6 +451,7 @@ func slingBead(townRoot, beadID, rig, agent string) error {
 	}
 	cmd := exec.Command("gt", args...)
 	cmd.Dir = townRoot
+	cmd.Env = deaconMutationRoutingEnv(townRoot)
 	util.SetDetachedProcessGroup(cmd)
 	cmd.Stdout = os.Stdout
 	cmd.Stderr = os.Stderr
@@ -484,6 +483,7 @@ Please investigate and either:
 
 	cmd := exec.Command("gt", "mail", "send", "mayor/", "-s", subject, "-m", body)
 	cmd.Dir = townRoot
+	cmd.Env = deaconMutationRoutingEnv(townRoot)
 	util.SetDetachedProcessGroup(cmd)
 	return cmd.Run()
 }

--- a/internal/deacon/stale_hooks.go
+++ b/internal/deacon/stale_hooks.go
@@ -6,15 +6,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
 
+	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
-	"github.com/steveyegge/gastown/internal/util"
 )
 
 // StaleHookConfig holds configurable parameters for stale hook detection.
@@ -44,19 +43,19 @@ type HookedBead struct {
 
 // StaleHookResult represents the result of processing a stale hooked bead.
 type StaleHookResult struct {
-	BeadID      string `json:"bead_id"`
-	Title       string `json:"title"`
-	Assignee    string `json:"assignee"`
-	Age         string `json:"age"`
-	AgentAlive  bool   `json:"agent_alive"`
-	Unhooked    bool   `json:"unhooked"`
-	Error       string `json:"error,omitempty"`
+	BeadID     string `json:"bead_id"`
+	Title      string `json:"title"`
+	Assignee   string `json:"assignee"`
+	Age        string `json:"age"`
+	AgentAlive bool   `json:"agent_alive"`
+	Unhooked   bool   `json:"unhooked"`
+	Error      string `json:"error,omitempty"`
 	// PartialWork indicates uncommitted changes or unpushed commits were found
 	// in the agent's worktree before unhooking.
-	PartialWork    bool   `json:"partial_work,omitempty"`
-	WorktreeDirty  bool   `json:"worktree_dirty,omitempty"`
-	UnpushedCount  int    `json:"unpushed_count,omitempty"`
-	WorktreeError  string `json:"worktree_error,omitempty"`
+	PartialWork   bool   `json:"partial_work,omitempty"`
+	WorktreeDirty bool   `json:"worktree_dirty,omitempty"`
+	UnpushedCount int    `json:"unpushed_count,omitempty"`
+	WorktreeError string `json:"worktree_error,omitempty"`
 }
 
 // StaleHookScanResult contains the full results of a stale hook scan.
@@ -156,9 +155,7 @@ func ScanStaleHooks(townRoot string, cfg *StaleHookConfig) (*StaleHookScanResult
 
 // listHookedBeads returns all beads with status=hooked.
 func listHookedBeads(townRoot string) ([]*HookedBead, error) {
-	cmd := exec.Command("bd", "list", "--status=hooked", "--json", "--flat", "--limit=0")
-	cmd.Dir = townRoot
-	util.SetDetachedProcessGroup(cmd)
+	cmd := beads.Command(townRoot, townBeadsDir(townRoot), beads.ReadOnlyRouting, "list", "--status=hooked", "--json", "--flat", "--limit=0")
 
 	output, err := cmd.Output()
 	if err != nil {
@@ -252,8 +249,6 @@ func assigneeToWorktreePath(townRoot, assignee string) string {
 
 // unhookBead sets a bead's status back to 'open'.
 func unhookBead(townRoot, beadID string) error {
-	cmd := exec.Command("bd", "update", beadID, "--status=open")
-	cmd.Dir = townRoot
-	util.SetDetachedProcessGroup(cmd)
+	cmd := beads.Command(townRoot, townBeadsDir(townRoot), beads.MutationRouting, "update", beadID, "--status=open")
 	return cmd.Run()
 }

--- a/internal/deps/dolt.go
+++ b/internal/deps/dolt.go
@@ -13,7 +13,7 @@ import (
 
 // MinDoltVersion is the minimum compatible dolt version for this Gas Town release.
 // Update this when Gas Town requires new dolt features.
-const MinDoltVersion = "1.82.4"
+const MinDoltVersion = "1.84.0"
 
 // DoltInstallURL is the installation page for dolt.
 const DoltInstallURL = "https://github.com/dolthub/dolt#installation"

--- a/internal/deps/dolt_test.go
+++ b/internal/deps/dolt_test.go
@@ -9,6 +9,9 @@ func TestParseDoltVersion(t *testing.T) {
 	}{
 		{"dolt version 1.82.4", "1.82.4"},
 		{"dolt version 1.82.4\n", "1.82.4"},
+		{"dolt version 1.84.0", "1.84.0"},
+		{"dolt version 2.0.3", "2.0.3"},
+		{"dolt version 1.84.0\nWarning: you are on an old version of Dolt. The newest version is 2.0.3.", "1.84.0"},
 		{"dolt version 1.0.0", "1.0.0"},
 		{"dolt version 10.20.30", "10.20.30"},
 		{"some other output", ""},
@@ -35,4 +38,16 @@ func TestCheckDolt(t *testing.T) {
 	}
 
 	t.Logf("CheckDolt: status=%d, version=%s", status, version)
+}
+
+func TestMinDoltVersionBoundary(t *testing.T) {
+	if CompareVersions("1.83.9", MinDoltVersion) >= 0 {
+		t.Fatalf("1.83.9 should be below MinDoltVersion %s", MinDoltVersion)
+	}
+	if CompareVersions("1.84.0", MinDoltVersion) != 0 {
+		t.Fatalf("1.84.0 should equal MinDoltVersion %s", MinDoltVersion)
+	}
+	if CompareVersions("2.0.3", MinDoltVersion) <= 0 {
+		t.Fatalf("2.0.3 should be above MinDoltVersion %s", MinDoltVersion)
+	}
 }

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -276,6 +276,16 @@ type Config struct {
 	// Default is "warning" to suppress connection open/close noise. Override with
 	// GT_DOLT_LOGLEVEL=info (or debug) for diagnostics.
 	LogLevel string
+
+	// EventScheduler controls Dolt's MySQL event scheduler in managed config.
+	// Default is OFF for Gas Town: background SQL events are not part of normal
+	// beads operation and add hidden work during outage recovery.
+	EventScheduler string
+
+	// DoltStatsEnabled controls the dolt_stats_enabled system variable in managed
+	// config. Default is "0" to avoid background stats workers during high-churn
+	// agent workloads. Set to "omit" to leave the variable out of config.yaml.
+	DoltStatsEnabled string
 }
 
 // DefaultConfig returns the default Dolt server configuration.
@@ -296,18 +306,20 @@ type Config struct {
 func DefaultConfig(townRoot string) *Config {
 	daemonDir := filepath.Join(townRoot, "daemon")
 	config := &Config{
-		TownRoot:       townRoot,
-		Port:           DefaultPort,
-		User:           DefaultUser,
-		DataDir:        filepath.Join(townRoot, ".dolt-data"),
-		LogFile:        filepath.Join(daemonDir, "dolt.log"),
-		PidFile:        filepath.Join(daemonDir, "dolt.pid"),
-		MaxConnections: DefaultMaxConnections,
-		ReadTimeoutMs:  DefaultReadTimeoutMs,
-		WriteTimeoutMs: DefaultWriteTimeoutMs,
-		WaitTimeoutSec: DefaultWaitTimeoutSec,
-		TimeZone:       DefaultTimeZone,
-		LogLevel:       "warning",
+		TownRoot:         townRoot,
+		Port:             DefaultPort,
+		User:             DefaultUser,
+		DataDir:          filepath.Join(townRoot, ".dolt-data"),
+		LogFile:          filepath.Join(daemonDir, "dolt.log"),
+		PidFile:          filepath.Join(daemonDir, "dolt.pid"),
+		MaxConnections:   DefaultMaxConnections,
+		ReadTimeoutMs:    DefaultReadTimeoutMs,
+		WriteTimeoutMs:   DefaultWriteTimeoutMs,
+		WaitTimeoutSec:   DefaultWaitTimeoutSec,
+		TimeZone:         DefaultTimeZone,
+		LogLevel:         "warning",
+		EventScheduler:   "OFF",
+		DoltStatsEnabled: "0",
 	}
 
 	// Optional override for the idle-session timeout. Negative values disable
@@ -332,14 +344,29 @@ func DefaultConfig(townRoot string) *Config {
 		config.Host = h
 	}
 
-	// Port precedence: config.yaml > env var > default
+	// Port precedence: config.yaml > env var > daemon.json > default
 	// config.yaml takes precedence to prevent stale env var pollution
-	if port := readPortFromConfigYAML(townRoot); port > 0 {
+	portFromConfig := false
+	if os.Getenv("GT_DOLT_IGNORE_CONFIG") == "1" {
+		// Emergency recovery hatch: ignore a bad managed config and use env/daemon
+		// fallbacks below. Does not delete or modify the config file.
+	} else if port := readPortFromConfigYAML(townRoot); port > 0 {
 		config.Port = port
-	} else if p := os.Getenv("GT_DOLT_PORT"); p != "" {
-		if port, err := strconv.Atoi(p); err == nil {
-			config.Port = port
+		portFromConfig = true
+	}
+	if !portFromConfig {
+		p := os.Getenv("GT_DOLT_PORT")
+		if p != "" {
+			if port, err := strconv.Atoi(p); err == nil {
+				config.Port = port
+			}
 		}
+	}
+	if scheduler, ok := os.LookupEnv("GT_DOLT_EVENT_SCHEDULER"); ok {
+		config.EventScheduler = scheduler
+	}
+	if stats, ok := os.LookupEnv("GT_DOLT_STATS_ENABLED"); ok {
+		config.DoltStatsEnabled = stats
 	}
 
 	if u := os.Getenv("GT_DOLT_USER"); u != "" {
@@ -367,7 +394,7 @@ func DefaultConfig(townRoot string) *Config {
 	// when the town uses a custom port (e.g. GT_DOLT_PORT=3308).
 	// We cannot import the daemon package here (circular: daemon→doltserver),
 	// so we parse the minimal JSON structure directly.
-	if os.Getenv("GT_DOLT_PORT") == "" && townRoot != "" {
+	if !portFromConfig && os.Getenv("GT_DOLT_PORT") == "" && townRoot != "" {
 		daemonJSONPath := filepath.Join(townRoot, "mayor", "daemon.json")
 		if data, err := os.ReadFile(daemonJSONPath); err == nil {
 			var daemonEnv struct {
@@ -1430,11 +1457,24 @@ func writeServerConfig(config *Config, configPath string) error {
 	if config.MaxConnections > 0 {
 		maxConnLine = fmt.Sprintf("\n  max_connections: %d", config.MaxConnections)
 	}
+	eventSchedulerLine := "  event_scheduler: \"OFF\"\n"
+	if strings.EqualFold(config.EventScheduler, "omit") {
+		eventSchedulerLine = ""
+	} else if strings.TrimSpace(config.EventScheduler) != "" {
+		eventSchedulerLine = fmt.Sprintf("  event_scheduler: %q\n", strings.ToUpper(strings.TrimSpace(config.EventScheduler)))
+	}
+	systemVariablesBlock := "\nsystem_variables:\n  dolt_stats_enabled: 0\n"
+	if strings.EqualFold(config.DoltStatsEnabled, "omit") {
+		systemVariablesBlock = ""
+	} else if strings.TrimSpace(config.DoltStatsEnabled) != "" {
+		systemVariablesBlock = fmt.Sprintf("\nsystem_variables:\n  dolt_stats_enabled: %s\n", strings.TrimSpace(config.DoltStatsEnabled))
+	}
 
 	content := fmt.Sprintf(`# Dolt SQL server configuration — managed by Gas Town (gt dolt start)
 # Do not edit manually; changes are overwritten on each server start.
 # To customize, set Gas Town environment variables:
 #   GT_DOLT_PORT, GT_DOLT_HOST, GT_DOLT_USER, GT_DOLT_PASSWORD, GT_DOLT_LOGLEVEL
+#   GT_DOLT_EVENT_SCHEDULER (OFF, ON, omit), GT_DOLT_STATS_ENABLED (0, 1, omit)
 
 log_level: %s
 
@@ -1445,10 +1485,10 @@ data_dir: "%s"
 
 behavior:
   dolt_transaction_commit: false
-  auto_gc_behavior:
+%s  auto_gc_behavior:
     enable: false
     archive_level: 0
-`,
+%s`,
 		config.LogLevel,
 		config.Port,
 		hostLine,
@@ -1456,6 +1496,8 @@ behavior:
 		readTimeoutLine,
 		writeTimeoutLine,
 		filepath.ToSlash(config.DataDir),
+		eventSchedulerLine,
+		systemVariablesBlock,
 	)
 
 	return os.WriteFile(configPath, []byte(content), 0600)

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -13,6 +13,8 @@ import (
 	"sync"
 	"testing"
 	"time"
+
+	"gopkg.in/yaml.v3"
 )
 
 // =============================================================================
@@ -3638,6 +3640,86 @@ func TestDefaultConfig_InvalidPortIgnored(t *testing.T) {
 	}
 }
 
+func TestDefaultConfig_ConfigYAMLBeatsDaemonJSON(t *testing.T) {
+	townRoot := t.TempDir()
+	dataDir := filepath.Join(townRoot, ".dolt-data")
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "config.yaml"), []byte("listener:\n  port: 4407\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorDir, "daemon.json"), []byte(`{"env":{"GT_DOLT_PORT":"5507"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	config := DefaultConfig(townRoot)
+	if config.Port != 4407 {
+		t.Errorf("Port = %d, want config.yaml port 4407", config.Port)
+	}
+}
+
+func TestDefaultConfig_DaemonJSONFallbackWithoutConfigOrEnv(t *testing.T) {
+	townRoot := t.TempDir()
+	t.Setenv("GT_DOLT_PORT", "")
+	mayorDir := filepath.Join(townRoot, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(mayorDir, "daemon.json"), []byte(`{"env":{"GT_DOLT_PORT":"5507"}}`), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	config := DefaultConfig(townRoot)
+	if config.Port != 5507 {
+		t.Errorf("Port = %d, want daemon.json port 5507", config.Port)
+	}
+}
+
+func TestDefaultConfig_IgnoreConfigUsesEnvPort(t *testing.T) {
+	townRoot := t.TempDir()
+	dataDir := filepath.Join(townRoot, ".dolt-data")
+	if err := os.MkdirAll(dataDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dataDir, "config.yaml"), []byte("listener:\n  port: 4407\n"), 0600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GT_DOLT_IGNORE_CONFIG", "1")
+	t.Setenv("GT_DOLT_PORT", "5507")
+
+	config := DefaultConfig(townRoot)
+	if config.Port != 5507 {
+		t.Errorf("Port = %d, want env port 5507 when config ignored", config.Port)
+	}
+}
+
+func TestDefaultConfig_ManagedDefaultsAndEnvOverrides(t *testing.T) {
+	townRoot := t.TempDir()
+
+	config := DefaultConfig(townRoot)
+	if config.EventScheduler != "OFF" {
+		t.Errorf("EventScheduler = %q, want OFF", config.EventScheduler)
+	}
+	if config.DoltStatsEnabled != "0" {
+		t.Errorf("DoltStatsEnabled = %q, want 0", config.DoltStatsEnabled)
+	}
+
+	t.Setenv("GT_DOLT_STATS_ENABLED", "omit")
+	t.Setenv("GT_DOLT_EVENT_SCHEDULER", "omit")
+	config = DefaultConfig(townRoot)
+	if config.DoltStatsEnabled != "omit" {
+		t.Errorf("DoltStatsEnabled = %q, want omit", config.DoltStatsEnabled)
+	}
+	if config.EventScheduler != "omit" {
+		t.Errorf("EventScheduler = %q, want omit", config.EventScheduler)
+	}
+}
+
 func TestBuildDoltSQLCmd_Local(t *testing.T) {
 	config := &Config{
 		Host:    "",
@@ -4081,11 +4163,72 @@ func TestWriteServerConfig_Defaults(t *testing.T) {
 		"data_dir: \"" + dir + "\"",
 		"log_level: warning",
 		"auto_gc_behavior:",
+		"event_scheduler: \"OFF\"",
+		"system_variables:",
+		"dolt_stats_enabled: 0",
 	}
 	for _, want := range checks {
 		if !strings.Contains(content, want) {
 			t.Errorf("config missing %q\nfull content:\n%s", want, content)
 		}
+	}
+
+	var parsed struct {
+		LogLevel string `yaml:"log_level"`
+		Listener struct {
+			Port               int `yaml:"port"`
+			MaxConnections     int `yaml:"max_connections"`
+			ReadTimeoutMillis  int `yaml:"read_timeout_millis"`
+			WriteTimeoutMillis int `yaml:"write_timeout_millis"`
+		} `yaml:"listener"`
+		DataDir  string `yaml:"data_dir"`
+		Behavior struct {
+			DoltTransactionCommit bool    `yaml:"dolt_transaction_commit"`
+			EventScheduler        *string `yaml:"event_scheduler"`
+			AutoGCBehavior        struct {
+				Enable       bool `yaml:"enable"`
+				ArchiveLevel int  `yaml:"archive_level"`
+			} `yaml:"auto_gc_behavior"`
+		} `yaml:"behavior"`
+		SystemVariables struct {
+			DoltStatsEnabled *int `yaml:"dolt_stats_enabled"`
+		} `yaml:"system_variables"`
+	}
+	if err := yaml.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("generated config is invalid YAML: %v\n%s", err, content)
+	}
+	if parsed.LogLevel != "warning" {
+		t.Errorf("log_level = %q, want warning", parsed.LogLevel)
+	}
+	if parsed.Listener.Port != 3307 {
+		t.Errorf("listener.port = %d, want 3307", parsed.Listener.Port)
+	}
+	if parsed.Listener.MaxConnections != 1000 {
+		t.Errorf("listener.max_connections = %d, want 1000", parsed.Listener.MaxConnections)
+	}
+	if parsed.Listener.ReadTimeoutMillis != DefaultReadTimeoutMs {
+		t.Errorf("listener.read_timeout_millis = %d, want %d", parsed.Listener.ReadTimeoutMillis, DefaultReadTimeoutMs)
+	}
+	if parsed.Listener.WriteTimeoutMillis != DefaultWriteTimeoutMs {
+		t.Errorf("listener.write_timeout_millis = %d, want %d", parsed.Listener.WriteTimeoutMillis, DefaultWriteTimeoutMs)
+	}
+	if parsed.DataDir != dir {
+		t.Errorf("data_dir = %q, want %q", parsed.DataDir, dir)
+	}
+	if parsed.Behavior.DoltTransactionCommit {
+		t.Error("behavior.dolt_transaction_commit = true, want false")
+	}
+	if parsed.Behavior.EventScheduler == nil || *parsed.Behavior.EventScheduler != "OFF" {
+		t.Fatalf("behavior.event_scheduler = %v, want OFF", parsed.Behavior.EventScheduler)
+	}
+	if parsed.Behavior.AutoGCBehavior.Enable {
+		t.Error("behavior.auto_gc_behavior.enable = true, want false")
+	}
+	if parsed.Behavior.AutoGCBehavior.ArchiveLevel != 0 {
+		t.Errorf("behavior.auto_gc_behavior.archive_level = %d, want 0", parsed.Behavior.AutoGCBehavior.ArchiveLevel)
+	}
+	if parsed.SystemVariables.DoltStatsEnabled == nil || *parsed.SystemVariables.DoltStatsEnabled != 0 {
+		t.Fatalf("system_variables.dolt_stats_enabled = %v, want 0", parsed.SystemVariables.DoltStatsEnabled)
 	}
 }
 
@@ -4148,6 +4291,33 @@ func TestWriteServerConfig_ZeroTimeoutsOmitted(t *testing.T) {
 	}
 	if strings.Contains(content, "write_timeout_millis") {
 		t.Error("zero WriteTimeoutMs should not write write_timeout_millis")
+	}
+}
+
+func TestWriteServerConfig_StatsAndSchedulerCanBeOmitted(t *testing.T) {
+	dir := t.TempDir()
+	configPath := filepath.Join(dir, "config.yaml")
+
+	config := &Config{
+		Port:             3307,
+		DataDir:          dir,
+		DoltStatsEnabled: "omit",
+		EventScheduler:   "omit",
+	}
+	if err := writeServerConfig(config, configPath); err != nil {
+		t.Fatal(err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	content := string(data)
+	if strings.Contains(content, "dolt_stats_enabled") {
+		t.Fatalf("dolt_stats_enabled should be omitted:\n%s", content)
+	}
+	if strings.Contains(content, "event_scheduler") {
+		t.Fatalf("event_scheduler should be omitted:\n%s", content)
 	}
 }
 

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -310,6 +310,7 @@ func DefaultOverrides() map[string]*HooksConfig {
 		// Without this, witnesses could accidentally create permanent patrol molecules
 		// that survive session restarts and accumulate unbounded.
 		"witness": {
+			UserPromptSubmit: []HookEntry{{Matcher: ""}},
 			PreToolUse: []HookEntry{
 				{
 					Matcher: "Bash(*bd mol pour*patrol*)",
@@ -341,9 +342,13 @@ func DefaultOverrides() map[string]*HooksConfig {
 				},
 			},
 		},
+		"boot": {
+			UserPromptSubmit: []HookEntry{{Matcher: ""}},
+		},
 		// Deacon roles: patrol-formula-guard (same as witness).
 		// Deacons also run patrols and must use wisps, not persistent molecules.
 		"deacon": {
+			UserPromptSubmit: []HookEntry{{Matcher: ""}},
 			PreToolUse: []HookEntry{
 				{
 					Matcher: "Bash(*for *seq*)",
@@ -399,6 +404,7 @@ func DefaultOverrides() map[string]*HooksConfig {
 		// Refinery roles: patrol-formula-guard (same as witness).
 		// Refineries also run patrols and must use wisps, not persistent molecules.
 		"refinery": {
+			UserPromptSubmit: []HookEntry{{Matcher: ""}},
 			PreToolUse: []HookEntry{
 				{
 					Matcher: "Bash(*bd mol pour*patrol*)",

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -700,8 +700,38 @@ func TestComputeExpectedWitnessRigSpecific(t *testing.T) {
 	if len(skyWitness.SessionStart) == 0 {
 		t.Error("sky/witness should inherit SessionStart from DefaultBase")
 	}
-	if len(skyWitness.UserPromptSubmit) == 0 {
-		t.Error("sky/witness should inherit UserPromptSubmit (mail-check) from DefaultBase")
+	if len(skyWitness.UserPromptSubmit) != 0 {
+		t.Error("sky/witness should disable UserPromptSubmit mail-check from DefaultBase")
+	}
+}
+
+func TestComputeExpectedPatrolRolesDisableUserPromptMailCheck(t *testing.T) {
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+
+	for _, target := range []string{"witness", "refinery", "deacon", "boot", "sky/witness", "sky/refinery"} {
+		t.Run(target, func(t *testing.T) {
+			cfg, err := ComputeExpected(target)
+			if err != nil {
+				t.Fatalf("ComputeExpected(%s): %v", target, err)
+			}
+			if len(cfg.UserPromptSubmit) != 0 {
+				t.Fatalf("%s should disable UserPromptSubmit mail-check, got %+v", target, cfg.UserPromptSubmit)
+			}
+		})
+	}
+}
+
+func TestComputeExpectedPolecatsKeepUserPromptMailCheck(t *testing.T) {
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+
+	cfg, err := ComputeExpected("polecats")
+	if err != nil {
+		t.Fatalf("ComputeExpected(polecats): %v", err)
+	}
+	if len(cfg.UserPromptSubmit) == 0 {
+		t.Fatal("polecats should retain UserPromptSubmit mail-check")
 	}
 }
 

--- a/internal/hooks/installer.go
+++ b/internal/hooks/installer.go
@@ -69,7 +69,15 @@ func needsUpgrade(content []byte) bool {
 	// Stale pattern: export PATH=... && gt — replaced by {{GT_BIN}} in current templates.
 	// The PATH export breaks Gemini CLI's hook runner which expands $PATH into
 	// an enormous string. Also catches files missing GT_HOOK_SOURCE env vars.
-	return bytes.Contains(content, []byte(`export PATH=`))
+	if bytes.Contains(content, []byte(`export PATH=`)) {
+		return true
+	}
+	if bytes.Contains(content, []byte(`Gas Town OpenCode plugin`)) {
+		return bytes.Contains(content, []byte(`captureRun("gt prime")`)) ||
+			bytes.Contains(content, []byte("$`gt prime`")) ||
+			!bytes.Contains(content, []byte(`prime --hook`))
+	}
+	return false
 }
 
 // SyncResult describes what SyncForRole did.

--- a/internal/hooks/installer_test.go
+++ b/internal/hooks/installer_test.go
@@ -236,10 +236,60 @@ func TestInstallForRole_UpgradesStaleExportPath(t *testing.T) {
 	if strings.Contains(string(got), "export PATH=") {
 		t.Error("stale export PATH pattern was not upgraded")
 	}
-	// Should now match the current template
-	template, _ := templateFS.ReadFile("templates/opencode/gastown.js")
+	// Should now match the current template after placeholder substitution.
+	template, _ := resolveAndSubstitute("opencode", "gastown.js", "crew")
 	if string(got) != string(template) {
 		t.Error("upgraded file does not match current template")
+	}
+}
+
+func TestInstallForRole_UpgradesStaleOpenCodePrimeHook(t *testing.T) {
+	dir := t.TempDir()
+	hooksPath := filepath.Join(dir, ".opencode/plugins", "gastown.js")
+	os.MkdirAll(filepath.Dir(hooksPath), 0755)
+
+	os.WriteFile(hooksPath, []byte(`// Gas Town OpenCode plugin: hooks SessionStart/Compaction via events.
+export const GasTown = async ({ $ }) => {
+  await $`+"`"+`gt prime`+"`"+`
+}`), 0644)
+
+	if err := InstallForRole("opencode", dir, dir, "crew", ".opencode/plugins", "gastown.js", false); err != nil {
+		t.Fatalf("InstallForRole: %v", err)
+	}
+
+	got, err := os.ReadFile(hooksPath)
+	if err != nil {
+		t.Fatalf("read upgraded hook: %v", err)
+	}
+	if strings.Contains(string(got), "captureRun(\"gt prime\")") || strings.Contains(string(got), "$`gt prime`") {
+		t.Fatal("stale bare gt prime was not upgraded")
+	}
+	if !strings.Contains(string(got), "prime --hook") {
+		t.Fatal("upgraded OpenCode hook does not run prime --hook")
+	}
+}
+
+func TestOpenCodeTemplateUsesHookModeAndCompoundRoles(t *testing.T) {
+	content, err := resolveAndSubstitute("opencode", "gastown.js", "polecat")
+	if err != nil {
+		t.Fatalf("resolveAndSubstitute: %v", err)
+	}
+	s := string(content)
+	for _, want := range []string{
+		"prime --hook",
+		"GT_HOOK_SOURCE=",
+		"GT_SESSION_ID=",
+		`parts[1] === "polecats"`,
+	} {
+		if !strings.Contains(s, want) {
+			t.Fatalf("OpenCode template missing %q", want)
+		}
+	}
+	if strings.Contains(s, "{{GT_BIN}}") {
+		t.Fatal("OpenCode template contains unresolved {{GT_BIN}}")
+	}
+	if strings.Contains(s, "mail check --inject") {
+		t.Fatal("OpenCode template should not duplicate startup mail injection")
 	}
 }
 
@@ -262,8 +312,8 @@ func TestSyncForRole_UpdatesStaleContent(t *testing.T) {
 		t.Error("stale file was not updated")
 	}
 
-	// Should match the template
-	template, _ := templateFS.ReadFile("templates/opencode/gastown.js")
+	// Should match the template after placeholder substitution.
+	template, _ := resolveAndSubstitute("opencode", "gastown.js", "crew")
 	if string(got) != string(template) {
 		t.Error("updated file does not match current template")
 	}
@@ -274,8 +324,8 @@ func TestSyncForRole_SkipsMatchingContent(t *testing.T) {
 	hooksPath := filepath.Join(dir, ".opencode/plugins", "gastown.js")
 	os.MkdirAll(filepath.Dir(hooksPath), 0755)
 
-	// Write the actual template content — should report unchanged
-	template, _ := templateFS.ReadFile("templates/opencode/gastown.js")
+	// Write the actual installed template content — should report unchanged.
+	template, _ := resolveAndSubstitute("opencode", "gastown.js", "crew")
 	os.WriteFile(hooksPath, template, 0644)
 
 	result, err := SyncForRole("opencode", dir, dir, "crew", ".opencode/plugins", "gastown.js", false)

--- a/internal/hooks/templates/claude/settings-autonomous.json
+++ b/internal/hooks/templates/claude/settings-autonomous.json
@@ -108,7 +108,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{{GT_BIN}} prime --hook && {{GT_BIN}} mail check --inject"
+            "command": "{{GT_BIN}} prime --hook"
           }
         ]
       }
@@ -130,7 +130,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{{GT_BIN}} mail check --inject"
+            "command": "case \"${GT_ROLE:-}\" in *witness*|*refinery*|deacon*|*boot*) exit 0 ;; *) {{GT_BIN}} mail check --inject ;; esac"
           }
         ]
       }

--- a/internal/hooks/templates/codex/hooks-autonomous.json
+++ b/internal/hooks/templates/codex/hooks-autonomous.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{{GT_BIN}} prime --hook && {{GT_BIN}} mail check --inject"
+            "command": "{{GT_BIN}} prime --hook"
           }
         ]
       }

--- a/internal/hooks/templates/copilot/gastown-autonomous.json
+++ b/internal/hooks/templates/copilot/gastown-autonomous.json
@@ -4,14 +4,14 @@
     "sessionStart": [
       {
         "type": "command",
-        "bash": "{{GT_BIN}} prime --hook && {{GT_BIN}} mail check --inject",
+        "bash": "{{GT_BIN}} prime --hook",
         "timeoutSec": 30
       }
     ],
     "userPromptSubmitted": [
       {
         "type": "command",
-        "bash": "{{GT_BIN}} mail check --inject",
+        "bash": "case \"${GT_ROLE:-}\" in *witness*|*refinery*|deacon*|*boot*) exit 0 ;; *) {{GT_BIN}} mail check --inject ;; esac",
         "timeoutSec": 10
       }
     ],

--- a/internal/hooks/templates/cursor/hooks-autonomous.json
+++ b/internal/hooks/templates/cursor/hooks-autonomous.json
@@ -17,7 +17,7 @@
     ],
     "sessionStart": [
       {
-        "command": "{{GT_BIN}} prime --hook && {{GT_BIN}} mail check --inject"
+        "command": "{{GT_BIN}} prime --hook"
       }
     ],
     "preCompact": [
@@ -27,7 +27,7 @@
     ],
     "beforeSubmitPrompt": [
       {
-        "command": "{{GT_BIN}} mail check --inject"
+        "command": "case \"${GT_ROLE:-}\" in *witness*|*refinery*|deacon*|*boot*) exit 0 ;; *) {{GT_BIN}} mail check --inject ;; esac"
       }
     ],
     "stop": [

--- a/internal/hooks/templates/gemini/settings-autonomous.json
+++ b/internal/hooks/templates/gemini/settings-autonomous.json
@@ -35,7 +35,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "GT_SESSION_ID=${GT_SESSION_ID:-$(uuidgen)} GT_HOOK_SOURCE=startup {{GT_BIN}} prime --hook && {{GT_BIN}} mail check --inject"
+            "command": "GT_SESSION_ID=${GT_SESSION_ID:-$(uuidgen)} GT_HOOK_SOURCE=startup {{GT_BIN}} prime --hook"
           }
         ]
       }
@@ -57,7 +57,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{{GT_BIN}} mail check --inject"
+            "command": "case \"${GT_ROLE:-}\" in *witness*|*refinery*|deacon*|*boot*) exit 0 ;; *) {{GT_BIN}} mail check --inject ;; esac"
           }
         ]
       }

--- a/internal/hooks/templates/omp/gastown-hook.ts
+++ b/internal/hooks/templates/omp/gastown-hook.ts
@@ -14,7 +14,8 @@
 
 export default function (pi) {
   const role = (process.env.GT_ROLE || "").toLowerCase();
-  const autonomousRoles = new Set(["polecat", "witness", "refinery", "deacon"]);
+  const shouldCheckMail = () =>
+    !role.includes("witness") && !role.includes("refinery") && !role.startsWith("deacon") && !role.includes("boot");
   let primeContext = null;
   let contextInjected = false;
   let lastMailCheck = 0;
@@ -33,31 +34,14 @@ export default function (pi) {
       console.error("[gastown] gt prime failed:", e.message);
     }
 
-    // Check mail at session start for autonomous roles.
-    if (autonomousRoles.has(role)) {
-      try {
-        const mailResult = await pi.exec("gt", ["mail", "check", "--inject"]);
-        if (mailResult.code === 0 && mailResult.stdout?.trim()) {
-          if (primeContext) {
-            primeContext += "\n\n" + mailResult.stdout.trim();
-          } else {
-            primeContext = mailResult.stdout.trim();
-          }
-          console.error("[gastown] mail context appended");
-        }
-        lastMailCheck = Date.now();
-      } catch (e) {
-        console.error("[gastown] gt mail check failed:", e.message);
-      }
-    }
   });
 
   // BeforeAgentStart — inject prime context + check mail every prompt.
   pi.on("before_agent_start", async (event, ctx) => {
     let mailContext = null;
 
-    // Check mail on every prompt (throttled to once per 30s) for autonomous roles.
-    if (autonomousRoles.has(role)) {
+    // Check mail on every prompt (throttled to once per 30s) for non-patrol roles.
+    if (shouldCheckMail()) {
       const now = Date.now();
       if (now - lastMailCheck >= 30000) {
         lastMailCheck = now;

--- a/internal/hooks/templates/opencode/gastown.js
+++ b/internal/hooks/templates/opencode/gastown.js
@@ -3,6 +3,7 @@
 export const GasTown = async ({ $, directory }) => {
   const role = (process.env.GT_ROLE || "").toLowerCase();
   const autonomousRoles = new Set(["polecat", "witness", "refinery", "deacon"]);
+  const gtBin = "{{GT_BIN}}";
   let didInit = false;
 
   // Promise-based context loading ensures the system transform hook can
@@ -76,6 +77,19 @@ export const GasTown = async ({ $, directory }) => {
     console.error(lines.join("\n"));
   };
 
+  const simpleRole = (value) => {
+    if (!value) return "";
+    const parts = value.split("/").filter(Boolean);
+    if (parts.length >= 2 && parts[1] === "polecats") return "polecat";
+    if (parts.length >= 2 && parts[1] === "crew") return "crew";
+    if (parts.length >= 2) return parts[1];
+    return parts[0];
+  };
+
+  const shellQuote = (value) => `'${String(value).replace(/'/g, `'\\''`)}'`;
+
+  const eventSessionID = (event) => event?.properties?.info?.id || event?.sessionID || event?.session?.id || "";
+
   const captureRun = async (cmd) => {
     try {
       // .text() captures stdout as a string and suppresses terminal echo.
@@ -86,14 +100,12 @@ export const GasTown = async ({ $, directory }) => {
     }
   };
 
-  const loadPrime = async () => {
-    let context = await captureRun("gt prime");
-    if (autonomousRoles.has(role)) {
-      const mail = await captureRun("gt mail check --inject");
-      if (mail) {
-        context += "\n" + mail;
-      }
+  const loadPrime = async (source = "startup", sessionID = "") => {
+    const env = [`GT_HOOK_SOURCE=${shellQuote(source)}`];
+    if (sessionID) {
+      env.push(`GT_SESSION_ID=${shellQuote(sessionID)}`);
     }
+    let context = await captureRun(`${env.join(" ")} ${shellQuote(gtBin)} prime --hook`);
     // NOTE: session-started nudge to deacon removed — it interrupted
     // the deacon's await-signal backoff. Deacon wakes on beads activity.
     return context;
@@ -105,23 +117,23 @@ export const GasTown = async ({ $, directory }) => {
         if (didInit) return;
         didInit = true;
         // Start loading prime context early; system.transform will await it.
-        primePromise = loadPrime();
+        primePromise = loadPrime("startup", eventSessionID(event));
       }
       if (event?.type === "session.compacted") {
         // Reset so next system.transform gets fresh context.
-        primePromise = loadPrime();
+        primePromise = loadPrime("compact", eventSessionID(event));
       }
       if (event?.type === "session.deleted") {
         const sessionID = event.properties?.info?.id;
         if (sessionID) {
-          await $`gt costs record --session ${sessionID}`.catch(() => {});
+          await captureRun(`${shellQuote(gtBin)} costs record --session ${shellQuote(sessionID)}`);
         }
       }
     },
     "experimental.chat.system.transform": async (input, output) => {
       // If session.created hasn't fired yet, start loading now.
       if (!primePromise) {
-        primePromise = loadPrime();
+        primePromise = loadPrime("startup");
       }
       const context = await primePromise;
       if (context) {
@@ -136,7 +148,7 @@ export const GasTown = async ({ $, directory }) => {
       output.context.push(`
 ## Gas Town Multi-Agent System
 
-**After Compaction:** Run \`gt prime\` to restore full context.
+**After Compaction:** Run \`gt prime --hook\` to restore full context.
 **Check Hook:** \`gt hook\` - if work present, execute immediately (GUPP).
 **Role:** ${roleDisplay}
 `);

--- a/internal/hooks/templates/pi/gastown-hooks.js
+++ b/internal/hooks/templates/pi/gastown-hooks.js
@@ -14,9 +14,13 @@
 // Loaded via: pi -e gastown-hooks.js
 
 export default (pi) => {
+  const role = (process.env.GT_ROLE || "").toLowerCase();
   let primeContext = null;
   let contextInjected = false;
   let lastMailCheck = 0;
+
+  const shouldCheckMail = () =>
+    !role.includes("witness") && !role.includes("refinery") && !role.startsWith("deacon") && !role.includes("boot");
 
   // SessionStart — run gt prime and capture context for injection
   pi.on("session_start", async (event, context) => {
@@ -32,22 +36,6 @@ export default (pi) => {
       console.error("[gastown] gt prime failed:", e.message);
     }
 
-    // Check mail at session start
-    try {
-      const mailResult = await pi.exec("gt", ["mail", "check", "--inject"]);
-      if (mailResult.code === 0 && mailResult.stdout.trim()) {
-        // Append mail context to prime context
-        if (primeContext) {
-          primeContext += "\n\n" + mailResult.stdout.trim();
-        } else {
-          primeContext = mailResult.stdout.trim();
-        }
-        console.error("[gastown] mail context appended");
-      }
-      lastMailCheck = Date.now();
-    } catch (e) {
-      console.error("[gastown] gt mail check failed:", e.message);
-    }
   });
 
   // BeforeAgentStart — inject prime context + check mail every prompt
@@ -56,7 +44,7 @@ export default (pi) => {
 
     // Check mail on every prompt (throttled to once per 30s)
     const now = Date.now();
-    if (now - lastMailCheck >= 30000) {
+    if (shouldCheckMail() && now - lastMailCheck >= 30000) {
       lastMailCheck = now;
       try {
         const mailResult = await pi.exec("gt", ["mail", "check", "--inject"]);

--- a/internal/mail/bd.go
+++ b/internal/mail/bd.go
@@ -73,7 +73,7 @@ func runBdCommand(ctx context.Context, args []string, workDir, beadsDir string, 
 	cmd.Dir = workDir
 	util.SetDetachedProcessGroup(cmd)
 
-	cmd.Env = bdSubprocessEnv(cmd.Environ(), beadsDir, extraEnv)
+	cmd.Env = bdSubprocessEnv(cmd.Environ(), beadsDir, isMailBdReadCommand(args), extraEnv)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -119,31 +119,64 @@ func firstArg(args []string) string {
 	return ""
 }
 
-func bdSubprocessEnv(baseEnv []string, beadsDir string, extraEnv []string) []string {
-	env := filterBdTargetEnv(baseEnv)
+func bdSubprocessEnv(baseEnv []string, beadsDir string, readOnly bool, extraEnv []string) []string {
+	base := append(append([]string{}, baseEnv...), extraEnv...)
+	mode := beads.MutationRouting
+	if readOnly {
+		mode = beads.ReadOnlyRouting
+	}
 	if beadsDir != "" {
-		env = append(env, "BEADS_DIR="+beadsDir)
-		if dbEnv := beads.DatabaseEnv(beadsDir); dbEnv != "" {
-			env = append(env, dbEnv)
+		if readOnly {
+			mode = beads.ReadOnlyPinned
+		} else {
+			mode = beads.MutationPinned
 		}
 	}
-	env = append(env, "BEADS_NO_AUTO_IMPORT=1")
-	env = append(env, extraEnv...)
+	env := beads.EnvForSubprocessMode(base, beadsDir, mode)
 	env = append(env, telemetry.OTELEnvForSubprocess()...)
 	return env
 }
 
-func filterBdTargetEnv(env []string) []string {
+func filterEnvKey(env []string, key string) []string {
+	prefix := key + "="
 	filtered := make([]string, 0, len(env))
 	for _, entry := range env {
-		if strings.HasPrefix(entry, "BEADS_DIR=") ||
-			strings.HasPrefix(entry, "BEADS_DB=") ||
-			strings.HasPrefix(entry, "BEADS_DOLT_SERVER_DATABASE=") {
+		if strings.HasPrefix(entry, prefix) {
 			continue
 		}
 		filtered = append(filtered, entry)
 	}
 	return filtered
+}
+
+func isMailBdReadCommand(args []string) bool {
+	if len(args) == 0 {
+		return false
+	}
+	switch args[0] {
+	case "list", "show", "search":
+		return true
+	case "message":
+		return len(args) >= 2 && args[1] == "thread"
+	case "mol":
+		return len(args) >= 3 && args[1] == "wisp" && args[2] == "list"
+	case "sql":
+		query := ""
+		for i := len(args) - 1; i >= 1; i-- {
+			if !strings.HasPrefix(args[i], "-") {
+				query = args[i]
+				break
+			}
+		}
+		q := strings.ToLower(strings.TrimSpace(query))
+		return strings.HasPrefix(q, "select") || strings.HasPrefix(q, "show") || strings.HasPrefix(q, "explain") || strings.HasPrefix(q, "describe") || strings.HasPrefix(q, "with")
+	default:
+		return false
+	}
+}
+
+func filterBdTargetEnv(env []string) []string {
+	return beads.StripBDTargetEnv(env)
 }
 
 // bdReadCtx returns a context with the standard bd read timeout.

--- a/internal/mail/bd_test.go
+++ b/internal/mail/bd_test.go
@@ -196,7 +196,7 @@ func TestBdError_WithAllFields(t *testing.T) {
 }
 
 func TestBdSubprocessEnv_SuppressesAutoImport(t *testing.T) {
-	got := bdSubprocessEnv([]string{"PATH=/usr/bin"}, "/tmp/.beads", nil)
+	got := bdSubprocessEnv([]string{"PATH=/usr/bin"}, "/tmp/.beads", true, nil)
 
 	if !envContains(got, "BEADS_NO_AUTO_IMPORT=1") {
 		t.Fatalf("expected BEADS_NO_AUTO_IMPORT=1 in env, got %v", got)
@@ -209,15 +209,15 @@ func TestBdSubprocessEnv_SuppressesAutoImport(t *testing.T) {
 	}
 }
 
-func TestBdSubprocessEnv_ExtraEnvAppendedAfterCanonical(t *testing.T) {
-	got := bdSubprocessEnv(nil, "/tmp/.beads", []string{"BEADS_NO_AUTO_IMPORT=0"})
+func TestBdSubprocessEnv_ExtraEnvCannotOverrideCanonicalPolicy(t *testing.T) {
+	got := bdSubprocessEnv(nil, "/tmp/.beads", true, []string{"BEADS_NO_AUTO_IMPORT=0"})
 
 	value, ok := envLastValue(got, "BEADS_NO_AUTO_IMPORT")
 	if !ok {
 		t.Fatalf("expected BEADS_NO_AUTO_IMPORT in env, got %v", got)
 	}
-	if value != "0" {
-		t.Fatalf("expected extra env override to win, got BEADS_NO_AUTO_IMPORT=%s in %v", value, got)
+	if value != "1" {
+		t.Fatalf("expected canonical env to win, got BEADS_NO_AUTO_IMPORT=%s in %v", value, got)
 	}
 }
 
@@ -227,7 +227,7 @@ func TestBdSubprocessEnv_DoesNotMutateBaseEnv(t *testing.T) {
 	backing := base[:cap(base)]
 	backing[1] = "SENTINEL=keep"
 
-	_ = bdSubprocessEnv(base, "/tmp/.beads", nil)
+	_ = bdSubprocessEnv(base, "/tmp/.beads", true, nil)
 
 	if len(base) != 1 {
 		t.Fatalf("baseEnv length changed to %d", len(base))
@@ -249,9 +249,12 @@ func TestBdSubprocessEnv_FiltersStaleBdTargetEnv(t *testing.T) {
 		"BEADS_DIR=/wrong",
 		"BEADS_DB=/wrong.db",
 		"BEADS_DOLT_SERVER_DATABASE=wrong",
-	}, beadsDir, nil)
+		"BEADS_DOLT_SERVER_HOST=wrong-host",
+		"BEADS_DOLT_SERVER_PORT=9999",
+		"BEADS_DOLT_PORT=9999",
+	}, beadsDir, true, nil)
 
-	if envContains(got, "BEADS_DIR=/wrong") || envContains(got, "BEADS_DB=/wrong.db") || envContains(got, "BEADS_DOLT_SERVER_DATABASE=wrong") {
+	if envContains(got, "BEADS_DIR=/wrong") || envContains(got, "BEADS_DB=/wrong.db") || envContains(got, "BEADS_DOLT_SERVER_DATABASE=wrong") || envContains(got, "BEADS_DOLT_SERVER_HOST=wrong-host") || envContains(got, "BEADS_DOLT_SERVER_PORT=9999") || envContains(got, "BEADS_DOLT_PORT=9999") {
 		t.Fatalf("stale bd target env was not filtered: %v", got)
 	}
 	if !envContains(got, "BEADS_DIR="+beadsDir) {
@@ -260,15 +263,69 @@ func TestBdSubprocessEnv_FiltersStaleBdTargetEnv(t *testing.T) {
 	if !envContains(got, "BEADS_DOLT_SERVER_DATABASE=rigdb") {
 		t.Fatalf("expected metadata database env in env, got %v", got)
 	}
+	for _, want := range []string{"BD_READONLY=true", "BD_DOLT_AUTO_COMMIT=off", "BD_EXPORT_AUTO=false", "BD_BACKUP_ENABLED=false", "BD_DOLT_AUTO_PUSH=false", "BD_NO_PUSH=true", "BD_EXPORT_GIT_ADD=false", "BD_NO_GIT_OPS=true"} {
+		if !envContains(got, want) {
+			t.Fatalf("expected %s in env, got %v", want, got)
+		}
+	}
+}
+
+func TestBdSubprocessEnv_WriteCommandsAreNotReadonly(t *testing.T) {
+	got := bdSubprocessEnv([]string{"PATH=/usr/bin", "BD_READONLY=true"}, "/tmp/.beads", false, []string{"BD_READONLY=true"})
+	if value, ok := envLastValue(got, "BD_READONLY"); ok {
+		t.Fatalf("write command env should not inherit or set BD_READONLY, got %q in %v", value, got)
+	}
+	for _, want := range []string{"BD_DOLT_AUTO_COMMIT=on", "BD_EXPORT_AUTO=false", "BD_BACKUP_ENABLED=false", "BD_DOLT_AUTO_PUSH=false", "BD_NO_PUSH=true", "BD_EXPORT_GIT_ADD=false", "BD_NO_GIT_OPS=true"} {
+		if !envContains(got, want) {
+			t.Fatalf("expected %s in env, got %v", want, got)
+		}
+	}
+}
+
+func TestBdSubprocessEnv_ReadonlyCannotBeOverridden(t *testing.T) {
+	got := bdSubprocessEnv([]string{"PATH=/usr/bin", "BD_READONLY=false"}, "/tmp/.beads", true, []string{"BD_READONLY=false"})
+	if value, ok := envLastValue(got, "BD_READONLY"); !ok || value != "true" {
+		t.Fatalf("read command env should force BD_READONLY=true, got %q present=%v in %v", value, ok, got)
+	}
+}
+
+func TestIsMailBdReadCommand(t *testing.T) {
+	tests := []struct {
+		args []string
+		want bool
+	}{
+		{[]string{"list", "--json"}, true},
+		{[]string{"show", "hq-abc"}, true},
+		{[]string{"sql", "--json", "SELECT * FROM wisps"}, true},
+		{[]string{"sql", "--json", "WITH x AS (SELECT 1) SELECT * FROM x"}, true},
+		{[]string{"mol", "wisp", "list", "--json"}, true},
+		{[]string{"message", "thread", "hq-abc", "--json"}, true},
+		{[]string{"sql", "UPDATE issues SET status='closed'"}, false},
+		{[]string{"mol", "wisp", "create", "mol-test"}, false},
+		{[]string{"message", "send", "mayor", "--body", "hi"}, false},
+		{[]string{"create", "title"}, false},
+		{[]string{"close", "hq-abc"}, false},
+		{[]string{"label", "add", "hq-abc", "read"}, false},
+	}
+	for _, tt := range tests {
+		if got := isMailBdReadCommand(tt.args); got != tt.want {
+			t.Fatalf("isMailBdReadCommand(%v) = %v, want %v", tt.args, got, tt.want)
+		}
+	}
 }
 
 func TestBdSubprocessEnv_AllowsRoutingWhenBeadsDirEmpty(t *testing.T) {
 	got := bdSubprocessEnv([]string{
 		"PATH=/usr/bin",
+		"GT_DOLT_HOST=127.0.0.2",
+		"GT_DOLT_PORT=5507",
 		"BEADS_DIR=/wrong",
 		"BEADS_DB=/wrong.db",
 		"BEADS_DOLT_SERVER_DATABASE=wrong",
-	}, "", nil)
+		"BEADS_DOLT_SERVER_HOST=wrong-host",
+		"BEADS_DOLT_SERVER_PORT=9999",
+		"BEADS_DOLT_PORT=9999",
+	}, "", true, nil)
 
 	for _, key := range []string{"BEADS_DIR", "BEADS_DB", "BEADS_DOLT_SERVER_DATABASE"} {
 		if value, ok := envLastValue(got, key); ok {
@@ -277,6 +334,9 @@ func TestBdSubprocessEnv_AllowsRoutingWhenBeadsDirEmpty(t *testing.T) {
 	}
 	if !envContains(got, "BEADS_NO_AUTO_IMPORT=1") {
 		t.Fatalf("expected BEADS_NO_AUTO_IMPORT=1 in env, got %v", got)
+	}
+	if !envContains(got, "BEADS_DOLT_SERVER_HOST=127.0.0.2") || !envContains(got, "BEADS_DOLT_SERVER_PORT=5507") || !envContains(got, "BEADS_DOLT_PORT=5507") {
+		t.Fatalf("expected GT_DOLT host/port fallback for routed command, got %v", got)
 	}
 }
 

--- a/internal/plugin/recording.go
+++ b/internal/plugin/recording.go
@@ -5,8 +5,6 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"os"
-	"os/exec"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/beads"
@@ -80,11 +78,8 @@ func (r *Recorder) RecordRun(record PluginRunRecord) (string, error) {
 
 	ctx, cancel := context.WithTimeout(context.Background(), constants.BdCommandTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
-	cmd.Dir = r.townRoot
-	// Set BEADS_DIR explicitly to prevent inherited env vars from causing
-	// prefix mismatches when redirects are in play.
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beads.ResolveBeadsDir(r.townRoot))
+	townBeads := beads.ResolveBeadsDir(r.townRoot)
+	cmd := beads.CommandContext(ctx, r.townRoot, townBeads, beads.MutationPinned, args...)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -106,9 +101,7 @@ func (r *Recorder) RecordRun(record PluginRunRecord) (string, error) {
 	// (which use --all to include closed beads) but should not stay open.
 	closeCtx, closeCancel := context.WithTimeout(context.Background(), constants.BdCommandTimeout)
 	defer closeCancel()
-	closeCmd := exec.CommandContext(closeCtx, "bd", "close", result.ID, "--reason", "plugin run recorded") //nolint:gosec // G204: bd is a trusted internal tool
-	closeCmd.Dir = r.townRoot
-	closeCmd.Env = append(os.Environ(), "BEADS_DIR="+beads.ResolveBeadsDir(r.townRoot))
+	closeCmd := beads.CommandContext(closeCtx, r.townRoot, townBeads, beads.MutationPinned, "close", result.ID, "--reason", "plugin run recorded")
 	_ = closeCmd.Run() // Best-effort — reaper will catch it if this fails
 
 	return result.ID, nil
@@ -157,14 +150,11 @@ func (r *Recorder) queryRuns(pluginName string, limit int, since string) ([]*Plu
 		cutoff := time.Now().Add(-d).UTC().Format(time.RFC3339)
 		args = append(args, "--created-after="+cutoff)
 	}
+	args = beads.InjectFlatForListJSON(args)
 
 	ctx, cancel := context.WithTimeout(context.Background(), constants.BdCommandTimeout)
 	defer cancel()
-	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
-	cmd.Dir = r.townRoot
-	// Set BEADS_DIR explicitly to prevent inherited env vars from causing
-	// prefix mismatches when redirects are in play.
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beads.ResolveBeadsDir(r.townRoot))
+	cmd := beads.CommandContext(ctx, r.townRoot, beads.ResolveBeadsDir(r.townRoot), beads.ReadOnlyPinned, args...)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -1666,6 +1666,13 @@ func (m *Manager) ReuseIdlePolecat(name string, opts AddOptions) (*Polecat, erro
 	if !m.exists(name) {
 		return nil, ErrPolecatNotFound
 	}
+	current, err := m.loadFromBeads(name)
+	if err != nil {
+		return nil, err
+	}
+	if decision := m.reuseDecisionForPolecat(name, current.State); !decision.Reusable {
+		return nil, fmt.Errorf("%w: %s", ErrPolecatNeedsRecovery, decision.Reason)
+	}
 
 	// Kill any existing session unconditionally before reuse.
 	// The polecat was found idle (no hooked work), so even a "live" session is
@@ -2145,11 +2152,60 @@ func (m *Manager) FindIdlePolecat() (*Polecat, error) {
 		return nil, err
 	}
 	for _, p := range polecats {
-		if p.State == StateIdle {
+		if p.State == StateIdle && m.reuseDecisionForPolecat(p.Name, p.State).Reusable {
 			return p, nil
 		}
 	}
 	return nil, nil
+}
+
+func (m *Manager) reuseDecisionForPolecat(name string, state State) SlotReuseDecision {
+	input := SlotReuseInput{State: state, CleanupStatus: CleanupUnknown}
+	agentID := m.agentBeadID(name)
+	_, fields, err := m.agentBeads().GetAgentBead(agentID)
+	if err != nil {
+		input.GitCheckFailed = true
+	}
+	if err == nil && fields != nil {
+		input.HookBead = fields.HookBead
+		input.PushFailed = fields.PushFailed
+		input.MRFailed = fields.MRFailed
+		if fields.CleanupStatus != "" {
+			input.CleanupStatus = CleanupStatus(fields.CleanupStatus)
+		}
+	}
+
+	clonePath := m.clonePath(name)
+	g := git.NewGit(clonePath)
+	branch, branchErr := g.CurrentBranch()
+	if branchErr != nil {
+		input.GitCheckFailed = true
+	} else {
+		input.Branch = branch
+	}
+	if status, err := g.CheckUncommittedWork(); err == nil {
+		input.GitDirty = !status.CleanExcludingRuntime()
+		input.StashCount = status.StashCount
+		input.UnpushedCommits = status.UnpushedCommits
+	} else {
+		input.GitCheckFailed = true
+	}
+	if branch != "" {
+		if pushed, unpushed, err := g.BranchPushedToRemote(branch, "origin"); err == nil {
+			if !pushed && unpushed > input.UnpushedCommits {
+				input.UnpushedCommits = unpushed
+			}
+		} else {
+			input.GitCheckFailed = true
+		}
+	}
+	// Legacy/test polecats can lack agent cleanup metadata. If git proves there is
+	// no local work at risk, treat the missing cleanup_status as clean; otherwise
+	// DecideSlotReuse will continue to fail closed on CleanupUnknown.
+	if input.CleanupStatus == CleanupUnknown && !input.GitCheckFailed && !input.GitDirty && input.StashCount == 0 && input.UnpushedCommits == 0 {
+		input.CleanupStatus = CleanupClean
+	}
+	return DecideSlotReuse(input)
 }
 
 // Get returns a specific polecat by name.

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -91,8 +91,19 @@ case "$cmd" in
     exit 0
     ;;
   show)
-    echo '{"error":"not found"}' >&2
-    exit 1
+    id=""
+    seen_show=0
+    for arg in "$@"; do
+      if [ "$seen_show" = 0 ]; then
+        [ "$arg" = "show" ] && seen_show=1
+        continue
+      fi
+      case "$arg" in --*) continue ;; esac
+      id="$arg"
+      break
+    done
+    printf '[{"id":"%s","title":"agent","issue_type":"agent","description":"agent\\n\\nrole_type: polecat\\nagent_state: idle\\nhook_bead: null\\ncleanup_status: clean"}]\n' "$id"
+    exit 0
     ;;
   *)
     exit 0
@@ -1228,6 +1239,7 @@ func TestReuseIdlePolecat_RunsSetupCommand(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
+	_ = git.NewGit(polecat.ClonePath).CleanForce()
 	writeWispSetupCommand(t, mgr, setupCommandWriteMarker("reuse-setup-marker"))
 
 	reused, err := mgr.ReuseIdlePolecat("toast", AddOptions{HookBead: "gt-next"})
@@ -1250,12 +1262,14 @@ func TestReuseIdlePolecat_RunsSetupCommand(t *testing.T) {
 func TestReuseIdlePolecat_SetupCommandFailureCleansWorktree(t *testing.T) {
 	mgr, _ := setupCanonicalBranchManagerTest(t)
 
-	if _, err := mgr.AddWithOptions("toast", AddOptions{}); err != nil {
+	polecat, err := mgr.AddWithOptions("toast", AddOptions{})
+	if err != nil {
 		t.Fatalf("AddWithOptions: %v", err)
 	}
+	_ = git.NewGit(polecat.ClonePath).CleanForce()
 	writeWispSetupCommand(t, mgr, setupCommandWriteMarkerAndFail("dirty-setup-marker"))
 
-	_, err := mgr.ReuseIdlePolecat("toast", AddOptions{HookBead: "gt-next"})
+	_, err = mgr.ReuseIdlePolecat("toast", AddOptions{HookBead: "gt-next"})
 	if err == nil {
 		t.Fatal("ReuseIdlePolecat should fail when setup_command fails")
 	}
@@ -1320,26 +1334,20 @@ func TestReuseIdlePolecat_UsesCanonicalOriginDefaultBranch(t *testing.T) {
 
 	staleSHA := createStalePolecatCommit(t, polecat.ClonePath, "HEAD", "polecat/toast-stale")
 
-	reused, err := mgr.ReuseIdlePolecat("toast", AddOptions{HookBead: "gt-next"})
+	_, err = mgr.ReuseIdlePolecat("toast", AddOptions{HookBead: "gt-next"})
+	if !errors.Is(err, ErrPolecatNeedsRecovery) {
+		t.Fatalf("ReuseIdlePolecat error = %v, want ErrPolecatNeedsRecovery", err)
+	}
+	worktreeGit := git.NewGit(polecat.ClonePath)
+	currentSHA, err := worktreeGit.Rev("HEAD")
 	if err != nil {
-		t.Fatalf("ReuseIdlePolecat: %v", err)
+		t.Fatalf("resolve current HEAD: %v", err)
 	}
-
-	worktreeGit := git.NewGit(reused.ClonePath)
-	staleAncestor, err := worktreeGit.IsAncestor(staleSHA, reused.Branch)
-	if err != nil {
-		t.Fatalf("check stale ancestry: %v", err)
+	if currentSHA != staleSHA {
+		t.Fatalf("reuse should preserve stale local commit %s, got HEAD %s", staleSHA, currentSHA)
 	}
-	if staleAncestor {
-		t.Fatalf("reused polecat branch %q unexpectedly includes stale local commit %s", reused.Branch, staleSHA)
-	}
-
-	baseAncestor, err := worktreeGit.IsAncestor(baseSHA, reused.Branch)
-	if err != nil {
-		t.Fatalf("check canonical ancestry: %v", err)
-	}
-	if !baseAncestor {
-		t.Fatalf("reused polecat branch %q should descend from origin/main commit %s", reused.Branch, baseSHA)
+	if baseSHA == "" {
+		t.Fatal("base SHA unexpectedly empty")
 	}
 }
 

--- a/internal/polecat/reuse.go
+++ b/internal/polecat/reuse.go
@@ -1,0 +1,64 @@
+package polecat
+
+import "errors"
+
+// ErrPolecatNeedsRecovery marks an idle-looking polecat that must not be reset
+// or advertised as reusable until its preserved work is recovered or submitted.
+var ErrPolecatNeedsRecovery = errors.New("polecat needs recovery before reuse")
+
+// SlotReuseInput is the shared input for deciding whether a polecat slot can be
+// advertised as open and destructively reused for new work.
+type SlotReuseInput struct {
+	State           State
+	HookBead        string
+	CleanupStatus   CleanupStatus
+	PushFailed      bool
+	MRFailed        bool
+	Branch          string
+	GitDirty        bool
+	StashCount      int
+	UnpushedCommits int
+	GitCheckFailed  bool
+}
+
+// SlotReuseDecision explains whether a polecat can be reused and why not.
+type SlotReuseDecision struct {
+	Reusable bool
+	Reason   string
+}
+
+// DecideSlotReuse is the single source of truth for reuse safety. It fails
+// closed: unknown cleanup/git state means the slot needs recovery, not reuse.
+func DecideSlotReuse(in SlotReuseInput) SlotReuseDecision {
+	if in.State != StateIdle {
+		return SlotReuseDecision{Reason: "not-idle"}
+	}
+	if in.HookBead != "" {
+		return SlotReuseDecision{Reason: "hook-still-set"}
+	}
+	if in.PushFailed {
+		return SlotReuseDecision{Reason: "push-failed"}
+	}
+	if in.MRFailed {
+		return SlotReuseDecision{Reason: "mr-failed"}
+	}
+	if !in.CleanupStatus.IsSafe() {
+		if in.CleanupStatus == "" {
+			return SlotReuseDecision{Reason: "cleanup-unknown"}
+		}
+		return SlotReuseDecision{Reason: "cleanup-" + string(in.CleanupStatus)}
+	}
+	if in.GitCheckFailed {
+		return SlotReuseDecision{Reason: "git-check-failed"}
+	}
+	if in.GitDirty {
+		return SlotReuseDecision{Reason: "git-dirty"}
+	}
+	if in.StashCount > 0 {
+		return SlotReuseDecision{Reason: "git-stash"}
+	}
+	if in.UnpushedCommits > 0 {
+		return SlotReuseDecision{Reason: "git-unpushed"}
+	}
+	return SlotReuseDecision{Reusable: true, Reason: "reusable"}
+}

--- a/internal/polecat/reuse_test.go
+++ b/internal/polecat/reuse_test.go
@@ -1,0 +1,39 @@
+package polecat
+
+import "testing"
+
+func TestDecideSlotReuse(t *testing.T) {
+	base := SlotReuseInput{State: StateIdle, CleanupStatus: CleanupClean}
+	tests := []struct {
+		name   string
+		mutate func(*SlotReuseInput)
+		want   string
+	}{
+		{name: "clean idle", want: "reusable"},
+		{name: "working", mutate: func(in *SlotReuseInput) { in.State = StateWorking }, want: "not-idle"},
+		{name: "hook", mutate: func(in *SlotReuseInput) { in.HookBead = "gt-work" }, want: "hook-still-set"},
+		{name: "push failed", mutate: func(in *SlotReuseInput) { in.PushFailed = true }, want: "push-failed"},
+		{name: "mr failed", mutate: func(in *SlotReuseInput) { in.MRFailed = true }, want: "mr-failed"},
+		{name: "cleanup dirty", mutate: func(in *SlotReuseInput) { in.CleanupStatus = CleanupUnpushed }, want: "cleanup-has_unpushed"},
+		{name: "cleanup unknown", mutate: func(in *SlotReuseInput) { in.CleanupStatus = CleanupUnknown }, want: "cleanup-unknown"},
+		{name: "git dirty", mutate: func(in *SlotReuseInput) { in.GitDirty = true }, want: "git-dirty"},
+		{name: "stash", mutate: func(in *SlotReuseInput) { in.StashCount = 1 }, want: "git-stash"},
+		{name: "unpushed", mutate: func(in *SlotReuseInput) { in.UnpushedCommits = 1 }, want: "git-unpushed"},
+		{name: "git failed", mutate: func(in *SlotReuseInput) { in.GitCheckFailed = true }, want: "git-check-failed"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			in := base
+			if tt.mutate != nil {
+				tt.mutate(&in)
+			}
+			got := DecideSlotReuse(in)
+			if got.Reason != tt.want {
+				t.Fatalf("Reason = %q, want %q", got.Reason, tt.want)
+			}
+			if got.Reusable != (tt.want == "reusable") {
+				t.Fatalf("Reusable = %v for reason %q", got.Reusable, got.Reason)
+			}
+		})
+	}
+}

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -26,17 +26,6 @@ import (
 	"github.com/steveyegge/gastown/internal/util"
 )
 
-func stripEnvKey(env []string, key string) []string {
-	prefix := key + "="
-	filtered := env[:0]
-	for _, entry := range env {
-		if !strings.HasPrefix(entry, prefix) {
-			filtered = append(filtered, entry)
-		}
-	}
-	return filtered
-}
-
 // shortSHA returns at most 8 characters of a SHA for display.
 func shortSHA(sha string) string {
 	if len(sha) > 8 {
@@ -1965,14 +1954,14 @@ func refineryHasLabel(labels []string, target string) bool {
 // checkAndCloseCompletedConvoys finds and closes convoys where all tracked issues
 // are complete. Returns the list of convoys that were closed.
 func (e *Engineer) checkAndCloseCompletedConvoys(townRoot, townBeads string) []convoyInfo {
-	bdEnv := stripEnvKey(os.Environ(), "BEADS_DIR")
+	townReadEnv := beads.BuildReadOnlyPinnedBDEnv(os.Environ(), townBeads)
+	townMutationEnv := beads.BuildMutationPinnedBDEnv(os.Environ(), townBeads)
+	routingReadEnv := beads.BuildReadOnlyRoutingBDEnv(os.Environ(), townBeads)
 
 	// List all open issues and filter locally so legacy type=convoy beads remain visible.
-	listArgs := beads.MaybePrependAllowStaleWithEnv(bdEnv, []string{"list", "--status=open", "--json", "--limit=0"})
-	listCmd := exec.Command("bd", listArgs...)
-	util.SetDetachedProcessGroup(listCmd)
-	listCmd.Dir = townBeads
-	listCmd.Env = bdEnv
+	listArgs := beads.InjectFlatForListJSON([]string{"list", "--status=open", "--json", "--limit=0"})
+	listArgs = beads.MaybePrependAllowStaleWithEnv(townReadEnv, listArgs)
+	listCmd := beads.Command(townBeads, townBeads, beads.ReadOnlyPinned, listArgs...)
 	var stdout bytes.Buffer
 	listCmd.Stdout = &stdout
 
@@ -2001,11 +1990,8 @@ func (e *Engineer) checkAndCloseCompletedConvoys(townRoot, townBeads string) []c
 			continue
 		}
 		// Get tracked issues for this convoy via bd dep list
-		depArgs := beads.MaybePrependAllowStaleWithEnv(bdEnv, []string{"dep", "list", convoy.ID, "--direction=down", "--type=tracks", "--json"})
-		depCmd := exec.Command("bd", depArgs...)
-		util.SetDetachedProcessGroup(depCmd)
-		depCmd.Dir = townRoot
-		depCmd.Env = bdEnv
+		depArgs := beads.MaybePrependAllowStaleWithEnv(townReadEnv, []string{"dep", "list", convoy.ID, "--direction=down", "--type=tracks", "--json"})
+		depCmd := beads.Command(townRoot, townBeads, beads.ReadOnlyPinned, depArgs...)
 		var depOut bytes.Buffer
 		depCmd.Stdout = &depOut
 
@@ -2034,11 +2020,8 @@ func (e *Engineer) checkAndCloseCompletedConvoys(townRoot, townBeads string) []c
 			}
 
 			// Get fresh status from home rig via bd show with routing
-			showArgs := beads.MaybePrependAllowStaleWithEnv(bdEnv, []string{"show", depID, "--json"})
-			showCmd := exec.Command("bd", showArgs...)
-			util.SetDetachedProcessGroup(showCmd)
-			showCmd.Dir = townRoot
-			showCmd.Env = bdEnv
+			showArgs := beads.MaybePrependAllowStaleWithEnv(routingReadEnv, []string{"show", depID, "--json"})
+			showCmd := beads.Command(townRoot, townBeads, beads.ReadOnlyRouting, showArgs...)
 			var showOut bytes.Buffer
 			showCmd.Stdout = &showOut
 
@@ -2072,11 +2055,8 @@ func (e *Engineer) checkAndCloseCompletedConvoys(townRoot, townBeads string) []c
 			reason = "Empty convoy — auto-closed as definitionally complete"
 		}
 
-		closeArgs := beads.MaybePrependAllowStaleWithEnv(bdEnv, []string{"close", convoy.ID, "-r", reason})
-		closeCmd := exec.Command("bd", closeArgs...)
-		util.SetDetachedProcessGroup(closeCmd)
-		closeCmd.Dir = townBeads
-		closeCmd.Env = bdEnv
+		closeArgs := beads.MaybePrependAllowStaleWithEnv(townMutationEnv, []string{"close", convoy.ID, "-r", reason})
+		closeCmd := beads.Command(townBeads, townBeads, beads.MutationPinned, closeArgs...)
 
 		if err := closeCmd.Run(); err != nil {
 			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to close convoy %s: %v\n", convoy.ID, err)

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -848,7 +848,7 @@ func TestPostMergeConvoyCheck_NoTownBeads(t *testing.T) {
 	}
 }
 
-func TestCheckAndCloseCompletedConvoys_StripsBeadsDir(t *testing.T) {
+func TestCheckAndCloseCompletedConvoys_UsesHardenedBDEnvs(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows - shell stubs")
 	}
@@ -867,36 +867,58 @@ func TestCheckAndCloseCompletedConvoys_StripsBeadsDir(t *testing.T) {
 	binDir := t.TempDir()
 	bdPath := filepath.Join(binDir, "bd")
 	script := `#!/bin/sh
+assert_town_read_env() {
+  if [ "$BEADS_DIR" != "$TOWN_BEADS" ]; then
+    echo "BEADS_DIR = $BEADS_DIR, want $TOWN_BEADS" >&2
+    exit 1
+  fi
+  if [ "$BD_READONLY" != "true" ] || [ "$BD_DOLT_AUTO_COMMIT" != "off" ]; then
+    echo "read env not read-only: BD_READONLY=$BD_READONLY BD_DOLT_AUTO_COMMIT=$BD_DOLT_AUTO_COMMIT" >&2
+    exit 1
+  fi
+  if [ -n "$BEADS_DOLT_SERVER_DATABASE" ] || [ -n "$BEADS_DB" ] || [ -n "$BD_DB" ] || [ -n "$BEADS_DOLT_DATA_DIR" ]; then
+    echo "stale target env leaked" >&2
+    exit 1
+  fi
+}
+assert_town_write_env() {
+  if [ "$BEADS_DIR" != "$TOWN_BEADS" ]; then
+    echo "BEADS_DIR = $BEADS_DIR, want $TOWN_BEADS" >&2
+    exit 1
+  fi
+  if [ -n "$BD_READONLY" ] || [ "$BD_DOLT_AUTO_COMMIT" != "on" ]; then
+    echo "write env not mutable: BD_READONLY=$BD_READONLY BD_DOLT_AUTO_COMMIT=$BD_DOLT_AUTO_COMMIT" >&2
+    exit 1
+  fi
+}
+assert_routing_read_env() {
+  if [ -n "$BEADS_DIR" ] || [ -n "$BEADS_DOLT_SERVER_DATABASE" ]; then
+    echo "routing env pinned target: BEADS_DIR=$BEADS_DIR DB=$BEADS_DOLT_SERVER_DATABASE" >&2
+    exit 1
+  fi
+  if [ "$BD_READONLY" != "true" ] || [ "$BD_DOLT_AUTO_COMMIT" != "off" ]; then
+    echo "routing read env not read-only: BD_READONLY=$BD_READONLY BD_DOLT_AUTO_COMMIT=$BD_DOLT_AUTO_COMMIT" >&2
+    exit 1
+  fi
+}
 case "$*" in
   "--allow-stale version")
     exit 0
     ;;
-	  "--allow-stale list --status=open --json --limit=0"|"list --status=open --json --limit=0")
-    if [ -n "$BEADS_DIR" ]; then
-      echo "BEADS_DIR leaked: $BEADS_DIR" >&2
-      exit 1
-    fi
+	  "--allow-stale list --status=open --json --limit=0 --flat"|"list --status=open --json --limit=0 --flat")
+	assert_town_read_env
 	    echo '[{"id":"hq-cv-l9","title":"Cross-rig convoy","status":"open","description":"","issue_type":"convoy"}]'
     ;;
   "--allow-stale dep list hq-cv-l9 --direction=down --type=tracks --json"|"dep list hq-cv-l9 --direction=down --type=tracks --json")
-    if [ -n "$BEADS_DIR" ]; then
-      echo "BEADS_DIR leaked: $BEADS_DIR" >&2
-      exit 1
-    fi
+    assert_town_read_env
     echo '[{"id":"external:l9:l9-123","status":"closed"}]'
     ;;
   "--allow-stale show l9-123 --json"|"show l9-123 --json")
-    if [ -n "$BEADS_DIR" ]; then
-      echo "BEADS_DIR leaked: $BEADS_DIR" >&2
-      exit 1
-    fi
+    assert_routing_read_env
     echo '[{"status":"closed"}]'
     ;;
   "--allow-stale close hq-cv-l9 -r All tracked issues completed"|"close hq-cv-l9 -r All tracked issues completed")
-    if [ -n "$BEADS_DIR" ]; then
-      echo "BEADS_DIR leaked: $BEADS_DIR" >&2
-      exit 1
-    fi
+    assert_town_write_env
     exit 0
     ;;
   *)
@@ -909,7 +931,14 @@ esac
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("TOWN_BEADS", townBeads)
 	t.Setenv("BEADS_DIR", "/wrong/.beads")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "wrong")
+	t.Setenv("BEADS_DB", "/wrong.db")
+	t.Setenv("BD_DB", "/wrong.bd")
+	t.Setenv("BEADS_DOLT_DATA_DIR", "/wrong/data")
+	t.Setenv("BD_READONLY", "true")
+	t.Setenv("BD_DOLT_AUTO_COMMIT", "off")
 
 	e := NewEngineer(&rig.Rig{
 		Name: "l9",

--- a/internal/runtime/runtime.go
+++ b/internal/runtime/runtime.go
@@ -11,7 +11,6 @@ import (
 	"github.com/steveyegge/gastown/internal/cli"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/hooks"
-	"github.com/steveyegge/gastown/internal/hookutil"
 	"github.com/steveyegge/gastown/internal/templates/commands"
 	"github.com/steveyegge/gastown/internal/tmux"
 	"github.com/steveyegge/gastown/internal/workspace"
@@ -197,9 +196,6 @@ func StartupFallbackCommands(role string, rc *config.RuntimeConfig) []string {
 
 	role = strings.ToLower(role)
 	command := "gt prime"
-	if isAutonomousRole(role) {
-		command += " && gt mail check --inject"
-	}
 	// NOTE: session-started nudge to deacon removed — it interrupted
 	// the deacon's await-signal backoff (exponential sleep). The deacon
 	// already wakes on beads activity via bd activity --follow.
@@ -216,13 +212,6 @@ func RunStartupFallback(t *tmux.Tmux, sessionID, role string, rc *config.Runtime
 		}
 	}
 	return nil
-}
-
-// isAutonomousRole returns true if the given role should automatically
-// inject mail check on startup. Delegates to hookutil.IsAutonomousRole
-// for the single source of truth on role classification.
-func isAutonomousRole(role string) bool {
-	return hookutil.IsAutonomousRole(role)
 }
 
 // DefaultPrimeWaitMs is the default wait time in milliseconds for non-hook agents

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -157,23 +157,39 @@ func TestStartupFallbackCommands_AutonomousRole(t *testing.T) {
 		},
 	}
 
-	autonomousRoles := []string{"polecat", "witness", "refinery", "deacon"}
+	autonomousRoles := []string{"polecat"}
 	for _, role := range autonomousRoles {
 		t.Run(role, func(t *testing.T) {
 			commands := StartupFallbackCommands(role, rc)
 			if commands == nil || len(commands) == 0 {
 				t.Error("StartupFallbackCommands() should return commands for autonomous role")
 			}
-			// Should contain mail check
-			found := false
 			for _, cmd := range commands {
-				if contains(cmd, "mail check --inject") {
-					found = true
-					break
+				if cmd != "gt prime" {
+					t.Fatalf("Commands for %s = %q, want gt prime", role, cmd)
 				}
 			}
-			if !found {
-				t.Errorf("Commands for %s should contain mail check --inject", role)
+		})
+	}
+}
+
+func TestStartupFallbackCommands_PatrolRolesSkipMailInject(t *testing.T) {
+	rc := &config.RuntimeConfig{
+		Hooks: &config.RuntimeHooksConfig{
+			Provider: "none",
+		},
+	}
+
+	for _, role := range []string{"witness", "refinery", "deacon", "boot", "deacon/boot"} {
+		t.Run(role, func(t *testing.T) {
+			commands := StartupFallbackCommands(role, rc)
+			if commands == nil || len(commands) == 0 {
+				t.Fatal("StartupFallbackCommands() should return commands for patrol role")
+			}
+			for _, cmd := range commands {
+				if contains(cmd, "mail check --inject") {
+					t.Fatalf("patrol role %s should not contain startup mail check: %q", role, cmd)
+				}
 			}
 		})
 	}

--- a/internal/templates/polecat-CLAUDE.md
+++ b/internal/templates/polecat-CLAUDE.md
@@ -149,7 +149,7 @@ gt dolt status                     # Check server health + latency
 ## Startup Protocol
 
 1. Announce: "Polecat {{name}}, checking in."
-2. Run: `gt prime && bd prime`
+2. Run: `gt prime`
 3. Check hook: `gt hook`
 4. If formula attached, steps are shown inline by `gt prime`
 5. Work through the checklist, then `gt done`

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -3218,8 +3218,8 @@ func (t *Tmux) SetDynamicStatus(session string) error {
 	if _, err := t.run("set-option", "-t", session, "status-right-length", "80"); err != nil {
 		return err
 	}
-	// Set faster refresh for more responsive status
-	if _, err := t.run("set-option", "-t", session, "status-interval", "5"); err != nil {
+	// Keep refresh modest: status-line may inspect hooks/mail, which are Dolt-backed.
+	if _, err := t.run("set-option", "-t", session, "status-interval", "60"); err != nil {
 		return err
 	}
 	_, err := t.run("set-option", "-t", session, "status-right", right)

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1,6 +1,7 @@
 package witness
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"os"
@@ -70,13 +71,45 @@ func DefaultBdCli() *BdCli {
 		Exec: func(workDir string, args ...string) (string, error) {
 			// bd v0.59+ requires --flat for list --json to produce JSON
 			args = beads.InjectFlatForListJSON(args)
-			return util.ExecWithOutput(workDir, "bd", args...)
+			return defaultBDExecWithOutput(workDir, args...)
 		},
 		Run: func(workDir string, args ...string) error {
 			args = beads.InjectFlatForListJSON(args)
-			return util.ExecRun(workDir, "bd", args...)
+			return defaultBDRun(workDir, args...)
 		},
 	}
+}
+
+func defaultBDExecWithOutput(workDir string, args ...string) (string, error) {
+	cmd := beads.Command(workDir, beads.ResolveBeadsDir(workDir), beads.SubprocessModeForArgs(args), args...)
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	if err := cmd.Run(); err != nil {
+		errMsg := strings.TrimSpace(stderr.String())
+		if errMsg != "" {
+			return "", fmt.Errorf("%s", errMsg)
+		}
+		return "", err
+	}
+	return strings.TrimSpace(stdout.String()), nil
+}
+
+func defaultBDRun(workDir string, args ...string) error {
+	cmd := beads.Command(workDir, beads.ResolveBeadsDir(workDir), beads.SubprocessModeForArgs(args), args...)
+
+	var stderr bytes.Buffer
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		errMsg := strings.TrimSpace(stderr.String())
+		if errMsg != "" {
+			return fmt.Errorf("%s", errMsg)
+		}
+		return err
+	}
+	return nil
 }
 
 // initRegistryFromTownRoot initializes registries from a known town root,
@@ -707,6 +740,17 @@ func notifyMayorSlotOpen(workDir, rigName, polecatName, exitType string) {
 	if townRoot == "" {
 		return
 	}
+	decision := slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType)
+	if !decision.Reusable {
+		_, _ = channelevents.EmitToTown(townRoot, "mayor", "SLOT_BLOCKED", []string{
+			"source=witness",
+			"rig=" + rigName,
+			"polecat=" + polecatName,
+			"exit=" + exitType,
+			"reason=" + decision.Reason,
+		})
+		return
+	}
 
 	// Emit SLOT_OPEN channel event so Mayor's await-event unblocks instantly.
 	_, _ = channelevents.EmitToTown(townRoot, "mayor", "SLOT_OPEN", []string{
@@ -733,6 +777,46 @@ func notifyMayorSlotOpen(workDir, rigName, polecatName, exitType string) {
 	cmd := exec.Command("gt", "mail", "send", "mayor/", "-s", subject, "-m", body)
 	cmd.Dir = townRoot
 	_ = cmd.Run()
+}
+
+func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) polecat.SlotReuseDecision {
+	if exitType != string(ExitTypeCompleted) {
+		return polecat.SlotReuseDecision{Reason: "exit-" + strings.ToLower(exitType)}
+	}
+	prefix := beads.GetPrefixForRig(townRoot, rigName)
+	agentID := beads.PolecatBeadIDWithPrefix(prefix, rigName, polecatName)
+	_, fields, err := beads.New(beads.ResolveBeadsDir(workDir)).ForAgentBead().GetAgentBead(agentID)
+	input := polecat.SlotReuseInput{State: polecat.StateIdle, CleanupStatus: polecat.CleanupUnknown, GitCheckFailed: err != nil || fields == nil}
+	if fields != nil {
+		input.HookBead = fields.HookBead
+		input.PushFailed = fields.PushFailed
+		input.MRFailed = fields.MRFailed
+		if fields.CleanupStatus != "" {
+			input.CleanupStatus = polecat.CleanupStatus(fields.CleanupStatus)
+		}
+	}
+	clonePath := filepath.Join(townRoot, rigName, "polecats", polecatName, rigName)
+	g := git.NewGit(clonePath)
+	if branch, err := g.CurrentBranch(); err == nil {
+		input.Branch = branch
+		if status, err := g.CheckUncommittedWork(); err == nil {
+			input.GitDirty = !status.CleanExcludingRuntime()
+			input.StashCount = status.StashCount
+			input.UnpushedCommits = status.UnpushedCommits
+		} else {
+			input.GitCheckFailed = true
+		}
+		if pushed, unpushed, err := g.BranchPushedToRemote(branch, "origin"); err == nil {
+			if !pushed && unpushed > input.UnpushedCommits {
+				input.UnpushedCommits = unpushed
+			}
+		} else {
+			input.GitCheckFailed = true
+		}
+	} else {
+		input.GitCheckFailed = true
+	}
+	return polecat.DecideSlotReuse(input)
 }
 
 // RecoveryPayload contains data for RECOVERY_NEEDED escalation.
@@ -2170,8 +2254,9 @@ func clearCompletionMetadata(bd *BdCli, workDir, agentBeadID string) error {
 	// Clear completion metadata fields
 	fields.ExitType = ""
 	fields.MRID = ""
-	fields.Branch = ""
-	fields.MRFailed = false
+	if !fields.MRFailed && !fields.PushFailed {
+		fields.Branch = ""
+	}
 	fields.CompletionTime = ""
 
 	newDesc := beads.FormatAgentDescription(issues[0].Title, fields)

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -16,6 +16,47 @@ import (
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
+func TestNotifyMayorSlotOpen_BlocksNonCompletedExit(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	workDir := filepath.Join(townRoot, "gastown", "witness")
+	if err := os.MkdirAll(workDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	notifyMayorSlotOpen(workDir, "gastown", "guzzle", string(ExitTypeDeferred))
+
+	events, err := filepath.Glob(filepath.Join(townRoot, "events", "mayor", "*.event"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %v, want one SLOT_BLOCKED event", events)
+	}
+	data, err := os.ReadFile(events[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	var event struct {
+		Type    string            `json:"type"`
+		Payload map[string]string `json:"payload"`
+	}
+	if err := json.Unmarshal(data, &event); err != nil {
+		t.Fatal(err)
+	}
+	if event.Type != "SLOT_BLOCKED" {
+		t.Fatalf("event type = %q, want SLOT_BLOCKED", event.Type)
+	}
+	if event.Payload["reason"] != "exit-deferred" {
+		t.Fatalf("reason = %q, want exit-deferred", event.Payload["reason"])
+	}
+}
+
 func TestHandlePolecatDoneFromBead_NilFields(t *testing.T) {
 	t.Parallel()
 	result := HandlePolecatDoneFromBead(DefaultBdCli(), "/tmp", "testrig", "nux", nil, nil)

--- a/templates/polecat-CLAUDE.md
+++ b/templates/polecat-CLAUDE.md
@@ -101,7 +101,7 @@ gt done                  # Submit and self-clean
 ## Startup Protocol
 
 1. Announce: "Polecat {{name}}, checking in."
-2. Run: `gt prime && bd prime`
+2. Run: `gt prime`
 3. Check hook: `gt hook`
 4. If formula attached, steps are shown inline by `gt prime`
 5. Work through the checklist, then `gt done`


### PR DESCRIPTION
## Review Context

This is a review-only PR for code review and inline comments on an already-landed direct push to `main`.

- Landed commit: 221f839f4dc169200f726b923e97915de3c2bf65
- Tracking issue: #4070
- Primary incident: #4028

## Important

Do not merge this PR into `main`. The commit is already present on `main`; the base branch is a frozen branch at the parent commit (`445fd8fd`) so GitHub can show the landed diff for review.

## Summary

- Hardened GT hot paths against Dolt subprocess storms and repeated bd invocations.
- Added subprocess policy and server-mode/routing coverage around `bd` helper usage.
- Reduced amplification paths across daemon, Deacon, witness, refinery, mail, hooks, polecat reuse, and statusline behavior.

## Related

- #4070
- #4028
- #4026
- #3955
- #3396
- #3589
- gastownhall/beads#3948
- gastownhall/beads#3691