### PR TITLE
fix: collapse status mail enrichment

### DIFF
--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -1703,13 +1703,15 @@ func populateMailInfo(agent *AgentRuntime, router *mail.Router) {
 	if err != nil {
 		return
 	}
+	firstSubjectSet := false
 	for _, msg := range messages {
 		if msg.Read {
 			continue
 		}
 		agent.UnreadMail++
-		if agent.FirstSubject == "" {
+		if !firstSubjectSet {
 			agent.FirstSubject = msg.Subject
+			firstSubjectSet = true
 		}
 	}
 }

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -1699,11 +1699,17 @@ func populateMailInfo(agent *AgentRuntime, router *mail.Router) {
 	if err != nil {
 		return
 	}
-	_, unread, _ := mailbox.Count()
-	agent.UnreadMail = unread
-	if unread > 0 {
-		if messages, err := mailbox.ListUnread(); err == nil && len(messages) > 0 {
-			agent.FirstSubject = messages[0].Subject
+	messages, err := mailbox.List()
+	if err != nil {
+		return
+	}
+	for _, msg := range messages {
+		if msg.Read {
+			continue
+		}
+		agent.UnreadMail++
+		if agent.FirstSubject == "" {
+			agent.FirstSubject = msg.Subject
 		}
 	}
 }


### PR DESCRIPTION
## Summary
- Reproduced residual `gt status --json` latency while Dolt health stayed green (`gt dolt status` query latency `0s`).
- Collapsed status mail enrichment from `Count()` plus `ListUnread()` into a single mailbox `List()` pass per agent.
- Persisted RCA evidence, raw-bd bypass findings, and validation notes to `gt-rca-canon-dolt-status-latency`.

## Test plan
- `go build -o /tmp/opencode/gt-rca ./cmd/gt`
- `go test ./internal/cmd -run 'TestTryStatusDetailLockContention|TestRunStatusWatch|TestOutputStatusText|TestBuildStatusIndicator'`
- `go test ./internal/mail -run 'TestMailbox.*Unread|TestMailboxLegacyListUnread|TestMailboxMarkReadOnlyExcludesFromUnread'`

## Notes
- Broad `go test ./internal/cmd ./internal/mail` exceeded 180s without output, so targeted tests were run instead.
- Full status timing is noisy under concurrent agent load; observed baseline full status around 8.79s with healthy Dolt, built binary after change around 7.72s.