### PR TITLE
RCA canonical: design routing repair and migration guard

### DIFF
--- a/docs/design/canonical-routing-repair-and-migration-guard.md
+++ b/docs/design/canonical-routing-repair-and-migration-guard.md
@@ -1,0 +1,139 @@
+# Canonical Routing Repair And Migration Guard
+
+Status: design slice for `gt-rca-canon-routing-repair-design` and canonical source `gt-rca-epic-routing.11`.
+
+## Problem
+
+Gas Town can enter a split-brain state where a prefix-routed read such as `bd show <id>` finds a bead, but operational commands such as `gt sling`, `gt hook`, `gt mq`, or `gt doctor` resolve a different beads database. The common causes are stale redirects, malformed or shadowing `routes.jsonl` files, prefix drift between registry/config/database metadata, and environment variables pinning `bd` to a stale database.
+
+The repair must preserve the current safety property: an explicit target rig must fail closed before hook, molecule, polecat, or merge-queue side effects if the bead is not present in the target rig database.
+
+## Scope
+
+This design defines routing invariants, a workspace repair model, and regression tests. The implementation in this slice is intentionally diagnostic-first: doctor reports malformed route configuration before auto-repair. Runtime routing behavior is not broadened and explicit target-rig guards remain authoritative.
+
+Non-goals:
+
+- Do not make `gt sling <bead> <rig>` fall back to the town or source database when the explicit target rig does not contain the bead.
+- Do not migrate live beads between Dolt databases as a side effect of normal command execution.
+- Do not treat worktree `.beads` directories as source-of-truth databases.
+
+## Current Topology
+
+The town root owns global routing at `.beads/routes.jsonl`. Rig source checkouts live at `<rig>/mayor/rig`. Polecat, crew, and refinery worktrees have `.beads/redirect` files pointing back to the canonical rig beads directory.
+
+For the gastown rig, the canonical tuple is:
+
+| Source | Canonical value |
+| --- | --- |
+| Town route | `gt- -> gastown/mayor/rig` |
+| Rig registry | `mayor/rigs.json` entry `gastown.beads.prefix = gt` |
+| Rig beads | `gastown/mayor/rig/.beads` |
+| Beads config | `prefix: gt`, `issue-prefix: gt`, `routing.mode: explicit` |
+| Dolt metadata | database `gastown` |
+| Worktrees | `.beads/redirect` to canonical rig beads |
+
+HQ prefixes remain town-owned:
+
+| Prefix | Owner | Route |
+| --- | --- | --- |
+| `hq-` | town | `.` |
+| `hq-cv-` | town | `.` |
+
+## Invariants
+
+1. Town-level `.beads/routes.jsonl` is the routing source of truth. Rig-level `.beads/routes.jsonl` files are invalid because they can shadow town routes.
+2. Rig issue prefixes map to a canonical rig beads directory, normally `<rig>/mayor/rig`, not to a redirect-dependent rig root when the canonical directory exists.
+3. `hq-` and `hq-cv-` route to the town root. Non-town prefixes must not route to `.`.
+4. Route paths are relative to the town root, clean, and must not contain traversal or absolute paths.
+5. Prefixes end in `-` and are unique. Longer town prefixes such as `hq-cv-` must remain valid alongside `hq-`.
+6. Worktree `.beads` state is repairable workspace state, not a persistent source of issue truth.
+7. `BEADS_DIR`, `BEADS_DOLT_SERVER_DATABASE`, and related target selectors must be stripped or pinned by command helpers so ambient shell state cannot redirect a command silently.
+8. Agent beads are explicit exceptions: agent identity records can live in town beads even when their IDs include rig-looking prefixes. Normal work beads still follow prefix routes.
+9. Hook state is the work bead state plus `assignee`; legacy `agent.hook_bead` is compatibility data, not authority.
+10. Merge-request beads must live in the target rig database so that the rig refinery can list and process them.
+
+## Safety Model
+
+Explicit target-rig commands keep a two-part guard:
+
+1. Routed lookup proves the bead exists somewhere and can be read.
+2. Direct target-rig lookup proves the bead exists in the requested target rig before any side effects.
+
+If those disagree, the command fails closed. This preserves cross-rig and HQ safety. HQ/town coordination beads may be tracked or referenced, but they must not silently spawn rig polecats or submit rig merge requests unless a command explicitly creates target-rig-owned work artifacts.
+
+## Workspace Repair
+
+Workspace repair is separate from code changes.
+
+Read-only audit first:
+
+```bash
+gt doctor --verbose
+gt dolt status
+gt dolt migrate --dry-run
+gt hooks diff
+```
+
+Repair second:
+
+```bash
+gt doctor --fix --no-start
+gt repair
+```
+
+Repair rules:
+
+- Doctor may add missing `hq-` and `hq-cv-` routes.
+- Doctor may add missing rig routes when the canonical rig beads directory exists.
+- Doctor may rewrite redirect-dependent rig-root routes to canonical `<rig>/mayor/rig` paths when the target has a real `.beads` directory.
+- Doctor must report malformed route definitions and refuse auto-fix until they are repaired manually, because regenerating a partially malformed route file can drop operator intent.
+- Migration between Dolt databases must be explicit, dry-run-capable, and outside normal command execution.
+
+## Migration Guard
+
+The diagnostic guard for `routes.jsonl` reports:
+
+- malformed JSONL lines;
+- empty prefixes or paths;
+- prefixes not ending in `-`;
+- absolute paths;
+- paths that escape the town root;
+- non-clean paths such as `rig/./mayor/rig`;
+- duplicate prefixes;
+- duplicate non-town route paths;
+- non-town prefixes mapping to `.`.
+
+This guard catches drift before `LoadRoutes` can silently skip malformed entries and before `gt doctor --fix` can rewrite a damaged file.
+
+## Command Agreement Tests
+
+The regression suite should prove agreement across commands with representative rig and HQ beads.
+
+| Command | Required assertion |
+| --- | --- |
+| `bd show <rig-id>` | From a polecat worktree with stale `BEADS_*` env, the bead resolves through `routes.jsonl` to canonical rig beads. |
+| `bd show <hq-id>` | HQ prefixes resolve to town beads and do not get pinned to the current rig. |
+| `gt sling <rig-id> <rig>` | Routed read and direct target-rig read agree before spawn/hook/molecule side effects. |
+| `gt sling <hq-id> <rig>` | Fails closed unless the command explicitly creates target-rig-owned work. |
+| `gt hook` / `gt hook show` | Hooked work is discovered by work bead status and assignee in the same database that `bd show` uses for the work bead. |
+| `gt mq list/status/submit` | MR beads are created/listed in the target rig database, with `rig`, `branch`, `target`, and `source_issue` fields present. |
+| `gt doctor` | Route drift, malformed routes, rig-level route files, stale redirects, prefix drift, and database-prefix drift are reported before repair. |
+
+Targeted test packages:
+
+```bash
+go test ./internal/beads -run 'Test(GetPrefixForRig|ResolveBeadsDirForID|ValidateRigPrefix|CreateRoutes)'
+go test ./internal/cmd -run 'Test(Sling|Hook|Done|MakeTestMR|VerifyBranch)'
+go test ./internal/doctor -run 'Test(RoutesCheck|RigRoutesJSONLCheck|PrefixMismatchCheck|DatabasePrefixCheck|BeadsRedirectTargetCheck)'
+go test ./internal/refinery -run 'Test(CheckAndCloseCompletedConvoys_UsesHardenedBDEnvs|Engineer_LoadConfig)'
+```
+
+## Rollout
+
+1. Land diagnostic route-shape validation and documentation.
+2. Run doctor in verbose mode and record current workspace findings as repair work, not source-code changes.
+3. Add command-level agreement tests around polluted env, HQ prefixes, explicit target-rig fail-closed behavior, and MR bead location.
+4. Only after the diagnostic layer is stable, consider consolidating route resolution helpers for write paths.
+
+This task uses fork PR workflow only: push to `Bella-Giraffety/gastown` and open a PR against `gastownhall/gastown` with base `integration/test-beaddolt-hardenning`. Do not submit this work to the internal merge queue.

--- a/docs/design/canonical-routing-repair-and-migration-guard.md
+++ b/docs/design/canonical-routing-repair-and-migration-guard.md
@@ -102,7 +102,8 @@ The diagnostic guard for `routes.jsonl` reports:
 - non-clean paths such as `rig/./mayor/rig`;
 - duplicate prefixes;
 - duplicate non-town route paths;
-- non-town prefixes mapping to `.`.
+- non-town prefixes mapping to `.`;
+- town prefixes such as `hq-` or `hq-cv-` mapping away from `.`.
 
 This guard catches drift before `LoadRoutes` can silently skip malformed entries and before `gt doctor --fix` can rewrite a damaged file.
 

--- a/internal/doctor/routes_check.go
+++ b/internal/doctor/routes_check.go
@@ -130,12 +130,16 @@ func (c *RoutesCheck) Run(ctx *CheckContext) *CheckResult {
 			} else if len(routeShapeDetails) > 0 {
 				message += fmt.Sprintf(", %d malformed route definition(s)", len(routeShapeDetails))
 			}
+			fixHint := "Run 'gt doctor --fix' to add missing routes"
+			if len(routeShapeDetails) > 0 {
+				fixHint = "Repair routes.jsonl, then run 'gt doctor --fix' to add missing routes"
+			}
 			return &CheckResult{
 				Name:    c.Name(),
 				Status:  StatusWarning,
 				Message: message,
 				Details: details,
-				FixHint: "Repair routes.jsonl, then run 'gt doctor --fix' to add missing routes",
+				FixHint: fixHint,
 			}
 		}
 		return c.checkRoutesValid(ctx, routes)

--- a/internal/doctor/routes_check.go
+++ b/internal/doctor/routes_check.go
@@ -1,6 +1,8 @@
 package doctor
 
 import (
+	"bufio"
+	"encoding/json"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -79,6 +81,9 @@ func (c *RoutesCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
+	// Validate the raw file before LoadRoutes drops malformed/empty entries.
+	routeShapeDetails := validateRouteFileShape(routesPath)
+
 	// Load existing routes
 	routes, err := beads.LoadRoutes(beadsDir)
 	if err != nil {
@@ -97,7 +102,7 @@ func (c *RoutesCheck) Run(ctx *CheckContext) *CheckResult {
 		routeByPath[r.Path] = r.Prefix
 	}
 
-	var details []string
+	details := append([]string{}, routeShapeDetails...)
 	var missingTownRoute bool
 	var missingConvoyRoute bool
 
@@ -118,13 +123,19 @@ func (c *RoutesCheck) Run(ctx *CheckContext) *CheckResult {
 	rigsConfig, err := config.LoadRigsConfig(rigsPath)
 	if err != nil {
 		// No rigs config - check for missing town/convoy routes and validate existing routes
-		if missingTownRoute || missingConvoyRoute {
+		if missingTownRoute || missingConvoyRoute || len(routeShapeDetails) > 0 {
+			message := "Required town routes are missing"
+			if len(routeShapeDetails) > 0 && !missingTownRoute && !missingConvoyRoute {
+				message = fmt.Sprintf("%d malformed route definition(s)", len(routeShapeDetails))
+			} else if len(routeShapeDetails) > 0 {
+				message += fmt.Sprintf(", %d malformed route definition(s)", len(routeShapeDetails))
+			}
 			return &CheckResult{
 				Name:    c.Name(),
 				Status:  StatusWarning,
-				Message: "Required town routes are missing",
+				Message: message,
 				Details: details,
-				FixHint: "Run 'gt doctor --fix' to add missing routes",
+				FixHint: "Repair routes.jsonl, then run 'gt doctor --fix' to add missing routes",
 			}
 		}
 		return c.checkRoutesValid(ctx, routes)
@@ -209,10 +220,13 @@ func (c *RoutesCheck) Run(ctx *CheckContext) *CheckResult {
 	}
 
 	// Determine result
-	if missingTownRoute || missingConvoyRoute || len(missingRigs) > 0 || len(invalidRoutes) > 0 || len(suboptimalRoutes) > 0 {
+	if len(routeShapeDetails) > 0 || missingTownRoute || missingConvoyRoute || len(missingRigs) > 0 || len(invalidRoutes) > 0 || len(suboptimalRoutes) > 0 {
 		status := StatusWarning
 		var messageParts []string
 
+		if len(routeShapeDetails) > 0 {
+			messageParts = append(messageParts, fmt.Sprintf("%d malformed route definition(s)", len(routeShapeDetails)))
+		}
 		if missingTownRoute {
 			messageParts = append(messageParts, "town root route missing")
 		}
@@ -243,6 +257,91 @@ func (c *RoutesCheck) Run(ctx *CheckContext) *CheckResult {
 		Status:  StatusOK,
 		Message: fmt.Sprintf("Routes configured correctly (%d routes)", len(routes)),
 	}
+}
+
+// validateRouteFileShape reports route definitions that LoadRoutes would silently
+// skip or normalize poorly. It is diagnostic-only: runtime routing semantics stay
+// unchanged and repair remains explicit.
+func validateRouteFileShape(routesPath string) []string {
+	file, err := os.Open(routesPath)
+	if err != nil {
+		return nil
+	}
+	defer file.Close()
+
+	var details []string
+	prefixLines := make(map[string]int)
+	pathPrefixes := make(map[string]string)
+
+	scanner := bufio.NewScanner(file)
+	lineNum := 0
+	for scanner.Scan() {
+		lineNum++
+		line := strings.TrimSpace(scanner.Text())
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+
+		var route beads.Route
+		if err := json.Unmarshal([]byte(line), &route); err != nil {
+			details = append(details, fmt.Sprintf("Route line %d is malformed JSON: %v", lineNum, err))
+			continue
+		}
+
+		if route.Prefix == "" {
+			details = append(details, fmt.Sprintf("Route line %d has empty prefix", lineNum))
+		} else {
+			if !strings.HasSuffix(route.Prefix, "-") {
+				details = append(details, fmt.Sprintf("Route line %d prefix %q must end in '-'", lineNum, route.Prefix))
+			}
+			if route.Prefix == "-" {
+				details = append(details, fmt.Sprintf("Route line %d prefix %q is not a valid routing prefix", lineNum, route.Prefix))
+			}
+			if firstLine, exists := prefixLines[route.Prefix]; exists {
+				details = append(details, fmt.Sprintf("Route line %d duplicates prefix %q first defined on line %d", lineNum, route.Prefix, firstLine))
+			} else {
+				prefixLines[route.Prefix] = lineNum
+			}
+		}
+
+		if route.Path == "" {
+			details = append(details, fmt.Sprintf("Route line %d has empty path", lineNum))
+			continue
+		}
+
+		if route.Path == "." {
+			if route.Prefix != "hq-" && route.Prefix != "hq-cv-" {
+				details = append(details, fmt.Sprintf("Route line %d maps non-town prefix %q to town root", lineNum, route.Prefix))
+			}
+			continue
+		}
+
+		if filepath.IsAbs(route.Path) {
+			details = append(details, fmt.Sprintf("Route line %d path %q must be relative to town root", lineNum, route.Path))
+			continue
+		}
+
+		cleanPath := filepath.Clean(route.Path)
+		cleanSlash := filepath.ToSlash(cleanPath)
+		if cleanSlash == ".." || strings.HasPrefix(cleanSlash, "../") {
+			details = append(details, fmt.Sprintf("Route line %d path %q escapes town root", lineNum, route.Path))
+			continue
+		}
+		if cleanPath != route.Path {
+			details = append(details, fmt.Sprintf("Route line %d path %q is not clean; use %q", lineNum, route.Path, cleanPath))
+		}
+
+		if existingPrefix, exists := pathPrefixes[cleanPath]; exists && existingPrefix != route.Prefix {
+			details = append(details, fmt.Sprintf("Route line %d path %q is also used by prefix %q", lineNum, route.Path, existingPrefix))
+		} else {
+			pathPrefixes[cleanPath] = route.Prefix
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		details = append(details, fmt.Sprintf("Failed reading routes.jsonl: %v", err))
+	}
+
+	return details
 }
 
 // checkRoutesValid checks that existing routes point to valid locations.
@@ -303,10 +402,15 @@ func isRedirectDependent(townRoot, routePath string) bool {
 // Fix attempts to add missing routing entries and rewrite suboptimal ones.
 func (c *RoutesCheck) Fix(ctx *CheckContext) error {
 	beadsDir := filepath.Join(ctx.TownRoot, ".beads")
+	routesPath := filepath.Join(beadsDir, beads.RoutesFileName)
 
 	// Ensure .beads directory exists
 	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
 		return fmt.Errorf(".beads directory does not exist; run 'bd init' first")
+	}
+
+	if details := validateRouteFileShape(routesPath); len(details) > 0 {
+		return fmt.Errorf("routes.jsonl has malformed route definitions; repair manually before auto-fix: %s", strings.Join(details, "; "))
 	}
 
 	// Load existing routes

--- a/internal/doctor/routes_check.go
+++ b/internal/doctor/routes_check.go
@@ -155,9 +155,11 @@ func (c *RoutesCheck) Run(ctx *CheckContext) *CheckResult {
 			prefix = rigEntry.BeadsConfig.Prefix + "-"
 		}
 
-		// Check if there's already a route for this rig (by path)
-		if _, hasRoute := routeByPath[expectedPath]; hasRoute {
-			// Rig already has a route with the correct path
+		// Check if there's already a route for this rig with the expected prefix
+		// and path. A town prefix pointing at a rig path must not mask a missing
+		// rig route.
+		if existingPrefix, hasRoute := routeByPath[expectedPath]; hasRoute && existingPrefix == prefix {
+			// Rig already has a route with the correct prefix and path.
 			continue
 		}
 
@@ -243,12 +245,17 @@ func (c *RoutesCheck) Run(ctx *CheckContext) *CheckResult {
 			messageParts = append(messageParts, fmt.Sprintf("%d route(s) using redirect instead of canonical path", len(suboptimalRoutes)))
 		}
 
+		fixHint := "Run 'gt doctor --fix' to fix routing issues"
+		if len(routeShapeDetails) > 0 {
+			fixHint = "Repair routes.jsonl, then run 'gt doctor --fix' to fix routing issues"
+		}
+
 		return &CheckResult{
 			Name:    c.Name(),
 			Status:  status,
 			Message: strings.Join(messageParts, ", "),
 			Details: details,
-			FixHint: "Run 'gt doctor --fix' to fix routing issues",
+			FixHint: fixHint,
 		}
 	}
 
@@ -314,6 +321,9 @@ func validateRouteFileShape(routesPath string) []string {
 				details = append(details, fmt.Sprintf("Route line %d maps non-town prefix %q to town root", lineNum, route.Prefix))
 			}
 			continue
+		}
+		if route.Prefix == "hq-" || route.Prefix == "hq-cv-" {
+			details = append(details, fmt.Sprintf("Route line %d maps town prefix %q away from town root", lineNum, route.Prefix))
 		}
 
 		if filepath.IsAbs(route.Path) {

--- a/internal/doctor/routes_check_test.go
+++ b/internal/doctor/routes_check_test.go
@@ -605,7 +605,6 @@ func TestRoutesCheck_SuboptimalRoutes(t *testing.T) {
 	})
 }
 
-
 func TestRoutesCheck_CorruptedRoutesJsonl(t *testing.T) {
 	t.Run("corrupted routes.jsonl results in empty routes", func(t *testing.T) {
 		tmpDir := t.TempDir()

--- a/internal/doctor/routes_check_test.go
+++ b/internal/doctor/routes_check_test.go
@@ -42,6 +42,9 @@ func TestRoutesCheck_MissingTownRoute(t *testing.T) {
 		if result.Message != "Required town routes are missing" {
 			t.Errorf("expected 'Required town routes are missing', got %s", result.Message)
 		}
+		if strings.Contains(result.FixHint, "Repair routes.jsonl") {
+			t.Errorf("expected auto-fix hint for well-formed routes, got %q", result.FixHint)
+		}
 	})
 
 	t.Run("passes when town root route exists", func(t *testing.T) {

--- a/internal/doctor/routes_check_test.go
+++ b/internal/doctor/routes_check_test.go
@@ -753,6 +753,11 @@ func TestRoutesCheck_RouteShapeValidation(t *testing.T) {
 			route:   `{"prefix":"gt-","path":"."}` + "\n",
 			details: []string{"non-town prefix", "town root"},
 		},
+		{
+			name:    "town prefix away from town root",
+			route:   `{"prefix":"hq-","path":"gastown/mayor/rig"}` + "\n",
+			details: []string{"town prefix", "away from town root"},
+		},
 	}
 
 	for _, tt := range tests {
@@ -769,7 +774,60 @@ func TestRoutesCheck_RouteShapeValidation(t *testing.T) {
 					t.Fatalf("expected detail containing %q, got %v", want, result.Details)
 				}
 			}
+			if err := check.Fix(ctx); err == nil || !strings.Contains(err.Error(), "repair manually") {
+				t.Fatalf("expected Fix to require manual repair, got %v", err)
+			}
 		})
+	}
+}
+
+func TestRoutesCheck_TownPrefixDoesNotMaskRigRoute(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, "gastown", "mayor", "rig", ".beads"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(tmpDir, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	rigsContent := `{
+		"version": 1,
+		"rigs": {
+			"gastown": {
+				"git_url": "https://github.com/example/gastown",
+				"beads": { "prefix": "gt" }
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(tmpDir, "mayor", "rigs.json"), []byte(rigsContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	routesContent := `{"prefix":"hq-","path":"gastown/mayor/rig"}
+{"prefix":"hq-cv-","path":"."}
+`
+	if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), []byte(routesContent), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	check := NewRoutesCheck()
+	ctx := &CheckContext{TownRoot: tmpDir}
+	result := check.Run(ctx)
+
+	if result.Status != StatusWarning {
+		t.Fatalf("expected StatusWarning, got %v: %s", result.Status, result.Message)
+	}
+	for _, want := range []string{"town prefix", "away from town root", "Rig 'gastown'"} {
+		if !detailsContain(result.Details, want) {
+			t.Fatalf("expected detail containing %q, got %v", want, result.Details)
+		}
+	}
+	if !strings.Contains(result.FixHint, "Repair routes.jsonl") {
+		t.Fatalf("expected manual repair fix hint, got %q", result.FixHint)
 	}
 }
 

--- a/internal/doctor/routes_check_test.go
+++ b/internal/doctor/routes_check_test.go
@@ -631,17 +631,18 @@ func TestRoutesCheck_CorruptedRoutesJsonl(t *testing.T) {
 		ctx := &CheckContext{TownRoot: tmpDir}
 		result := check.Run(ctx)
 
-		// Corrupted/malformed lines are skipped, resulting in empty routes
-		// This triggers the "Required town routes are missing" warning
 		if result.Status != StatusWarning {
 			t.Errorf("expected StatusWarning, got %v: %s", result.Status, result.Message)
 		}
-		if result.Message != "Required town routes are missing" {
-			t.Errorf("expected 'Required town routes are missing', got %s", result.Message)
+		if !strings.Contains(result.Message, "malformed route definition") {
+			t.Errorf("expected malformed route warning, got %s", result.Message)
+		}
+		if !detailsContain(result.Details, "malformed JSON") {
+			t.Errorf("expected malformed JSON detail, got %v", result.Details)
 		}
 	})
 
-	t.Run("fix regenerates corrupted routes.jsonl with town route", func(t *testing.T) {
+	t.Run("fix refuses corrupted routes.jsonl", func(t *testing.T) {
 		tmpDir := t.TempDir()
 
 		// Create .beads directory with corrupted routes.jsonl
@@ -664,28 +665,120 @@ func TestRoutesCheck_CorruptedRoutesJsonl(t *testing.T) {
 		check := NewRoutesCheck()
 		ctx := &CheckContext{TownRoot: tmpDir}
 
-		// Run fix
-		if err := check.Fix(ctx); err != nil {
-			t.Fatalf("Fix failed: %v", err)
-		}
-
-		// Verify routes.jsonl now contains both hq- and hq-cv- routes
-		content, err := os.ReadFile(routesPath)
-		if err != nil {
-			t.Fatalf("Failed to read routes.jsonl: %v", err)
-		}
-
-		contentStr := string(content)
-		if contentStr != `{"prefix":"hq-","path":"."}
-{"prefix":"hq-cv-","path":"."}
-` {
-			t.Errorf("unexpected routes.jsonl content after fix: %s", contentStr)
-		}
-
-		// Verify the check now passes
-		result := check.Run(ctx)
-		if result.Status != StatusOK {
-			t.Errorf("expected StatusOK after fix, got %v: %s", result.Status, result.Message)
+		if err := check.Fix(ctx); err == nil || !strings.Contains(err.Error(), "repair manually") {
+			t.Fatalf("expected manual repair error, got %v", err)
 		}
 	})
+}
+
+func TestRoutesCheck_RouteShapeValidation(t *testing.T) {
+	setup := func(t *testing.T, routesContent string) string {
+		t.Helper()
+		tmpDir := t.TempDir()
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		if err := os.MkdirAll(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(tmpDir, "mayor"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.MkdirAll(filepath.Join(tmpDir, "gastown", "mayor", "rig", ".beads"), 0755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), []byte(routesContent), 0644); err != nil {
+			t.Fatal(err)
+		}
+		return tmpDir
+	}
+
+	baseRoutes := `{"prefix":"hq-","path":"."}
+{"prefix":"hq-cv-","path":"."}
+`
+
+	tests := []struct {
+		name    string
+		route   string
+		details []string
+	}{
+		{
+			name:    "malformed JSON",
+			route:   "not valid json\n",
+			details: []string{"malformed JSON"},
+		},
+		{
+			name:    "empty prefix",
+			route:   `{"prefix":"","path":"gastown/mayor/rig"}` + "\n",
+			details: []string{"empty prefix"},
+		},
+		{
+			name:    "empty path",
+			route:   `{"prefix":"gt-","path":""}` + "\n",
+			details: []string{"empty path"},
+		},
+		{
+			name:    "prefix missing hyphen",
+			route:   `{"prefix":"gt","path":"gastown/mayor/rig"}` + "\n",
+			details: []string{"must end in '-"},
+		},
+		{
+			name:    "absolute path",
+			route:   `{"prefix":"gt-","path":"/outside"}` + "\n",
+			details: []string{"must be relative"},
+		},
+		{
+			name:    "path traversal",
+			route:   `{"prefix":"gt-","path":"../outside"}` + "\n",
+			details: []string{"escapes town root"},
+		},
+		{
+			name:    "non-clean path",
+			route:   `{"prefix":"gt-","path":"gastown/./mayor/rig"}` + "\n",
+			details: []string{"is not clean"},
+		},
+		{
+			name: "duplicate non-town path",
+			route: `{"prefix":"gt-","path":"gastown/mayor/rig"}
+{"prefix":"ga-","path":"gastown/mayor/rig"}
+`,
+			details: []string{"also used by prefix"},
+		},
+		{
+			name: "duplicate prefix",
+			route: `{"prefix":"gt-","path":"gastown/mayor/rig"}
+{"prefix":"gt-","path":"gastown/mayor/rig"}
+`,
+			details: []string{"duplicates prefix"},
+		},
+		{
+			name:    "non-town prefix to town root",
+			route:   `{"prefix":"gt-","path":"."}` + "\n",
+			details: []string{"non-town prefix", "town root"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			check := NewRoutesCheck()
+			ctx := &CheckContext{TownRoot: setup(t, baseRoutes+tt.route)}
+			result := check.Run(ctx)
+
+			if result.Status != StatusWarning {
+				t.Fatalf("expected StatusWarning, got %v: %s", result.Status, result.Message)
+			}
+			for _, want := range tt.details {
+				if !detailsContain(result.Details, want) {
+					t.Fatalf("expected detail containing %q, got %v", want, result.Details)
+				}
+			}
+		})
+	}
+}
+
+func detailsContain(details []string, substr string) bool {
+	for _, detail := range details {
+		if strings.Contains(detail, substr) {
+			return true
+		}
+	}
+	return false
 }


### PR DESCRIPTION
## Summary
- Defines canonical routing/prefix invariants, workspace repair separation, command agreement tests, and fork-PR rollout guidance.
- Adds diagnostic-only `routes.jsonl` shape validation in doctor before `LoadRoutes` can silently skip malformed entries.
- Refuses doctor auto-fix on malformed routes and guards HQ prefixes from being routed away from town root or masking missing rig routes.

## Validation
- `go test ./internal/doctor`
- `go test ./internal/beads -run 'Test(GetPrefixForRig|ResolveBeadsDirForID|ValidateRigPrefix|CreateRoutes|Build.*BDEnv|ArgsAreReadOnly)'`
- `go test ./internal/cmd -run 'Test(NormalizeHookShowTarget|OutputMoleculeStatus|DoneUsesResolveBeadsDir|MRBeadCreationUsesRig|MakeTestMR|VerifyBranch)'`

## RCA Evidence
- Completed 15 independent read-only research passes.
- Completed 5 pre-implementation reviews.
- Completed 5 post-implementation reviews and fixed the HQ route ownership finding before submission.
- Broader sling-targeted `internal/cmd` run exposed existing sling stub/rollback failures outside the changed doctor/doc paths.