### PR TITLE
fix: block rig add prefix route hijacks

### DIFF
--- a/internal/beads/routes.go
+++ b/internal/beads/routes.go
@@ -65,6 +65,71 @@ func AppendRoute(townRoot string, route Route) error {
 	return AppendRouteToDir(beadsDir, route)
 }
 
+// AppendRouteIfPrefixAvailable appends or updates a route only when the prefix
+// is unused or already belongs to the same rig. It returns the previous route
+// for rollback, or nil when this call added a new route.
+func AppendRouteIfPrefixAvailable(townRoot string, route Route) (*Route, error) {
+	beadsDir := filepath.Join(townRoot, ".beads")
+	return AppendRouteToDirIfPrefixAvailable(beadsDir, route)
+}
+
+// AppendRouteToDirIfPrefixAvailable is AppendRouteToDir with a same-rig guard.
+func AppendRouteToDirIfPrefixAvailable(beadsDir string, route Route) (*Route, error) {
+	routes, err := LoadRoutes(beadsDir)
+	if err != nil {
+		return nil, fmt.Errorf("loading routes: %w", err)
+	}
+
+	newRig := strings.SplitN(route.Path, "/", 2)[0]
+	for i, r := range routes {
+		if r.Prefix != route.Prefix {
+			continue
+		}
+		previous := r
+		existingRig := strings.SplitN(r.Path, "/", 2)[0]
+		if existingRig != newRig {
+			return nil, fmt.Errorf("prefix %q is already used by %s (path: %s); use --prefix to specify a different prefix", route.Prefix, existingRig, r.Path)
+		}
+		routes[i].Path = route.Path
+		return &previous, WriteRoutes(beadsDir, routes)
+	}
+
+	routes = append(routes, route)
+	return nil, WriteRoutes(beadsDir, routes)
+}
+
+// RestoreRouteIfCurrent restores or removes a route only if it still matches
+// the route written by this caller. This avoids clobbering another add/repair.
+func RestoreRouteIfCurrent(townRoot string, route Route, previous *Route) error {
+	beadsDir := filepath.Join(townRoot, ".beads")
+	return RestoreRouteInDirIfCurrent(beadsDir, route, previous)
+}
+
+// RestoreRouteInDirIfCurrent restores or removes a route only if it still matches.
+func RestoreRouteInDirIfCurrent(beadsDir string, route Route, previous *Route) error {
+	routes, err := LoadRoutes(beadsDir)
+	if err != nil {
+		return fmt.Errorf("loading routes: %w", err)
+	}
+
+	for i, r := range routes {
+		if r.Prefix != route.Prefix {
+			continue
+		}
+		if r.Path != route.Path {
+			return nil
+		}
+		if previous == nil {
+			routes = append(routes[:i], routes[i+1:]...)
+		} else {
+			routes[i] = *previous
+		}
+		return WriteRoutes(beadsDir, routes)
+	}
+
+	return nil
+}
+
 // AppendRouteToDir appends a route to routes.jsonl in the given beads directory.
 // If the prefix already exists, it updates the path.
 func AppendRouteToDir(beadsDir string, route Route) error {

--- a/internal/beads/routes.go
+++ b/internal/beads/routes.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/steveyegge/gastown/internal/config"
+	gtlock "github.com/steveyegge/gastown/internal/lock"
 )
 
 // Route represents a prefix-to-path routing rule.
@@ -75,27 +76,53 @@ func AppendRouteIfPrefixAvailable(townRoot string, route Route) (*Route, error) 
 
 // AppendRouteToDirIfPrefixAvailable is AppendRouteToDir with a same-rig guard.
 func AppendRouteToDirIfPrefixAvailable(beadsDir string, route Route) (*Route, error) {
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		return nil, fmt.Errorf("creating beads directory: %w", err)
+	}
+	unlock, err := gtlock.FlockAcquire(filepath.Join(beadsDir, RoutesFileName+".flock"))
+	if err != nil {
+		return nil, fmt.Errorf("acquiring routes lock: %w", err)
+	}
+	defer unlock()
+
 	routes, err := LoadRoutes(beadsDir)
 	if err != nil {
 		return nil, fmt.Errorf("loading routes: %w", err)
 	}
 
 	newRig := strings.SplitN(route.Path, "/", 2)[0]
-	for i, r := range routes {
+	var previous *Route
+	for _, r := range routes {
 		if r.Prefix != route.Prefix {
 			continue
 		}
-		previous := r
 		existingRig := strings.SplitN(r.Path, "/", 2)[0]
 		if existingRig != newRig {
 			return nil, fmt.Errorf("prefix %q is already used by %s (path: %s); use --prefix to specify a different prefix", route.Prefix, existingRig, r.Path)
 		}
-		routes[i].Path = route.Path
-		return &previous, WriteRoutes(beadsDir, routes)
+		if previous == nil {
+			prev := r
+			previous = &prev
+		}
 	}
 
-	routes = append(routes, route)
-	return nil, WriteRoutes(beadsDir, routes)
+	updated := make([]Route, 0, len(routes)+1)
+	replaced := false
+	for _, r := range routes {
+		if r.Prefix == route.Prefix {
+			if !replaced {
+				updated = append(updated, route)
+				replaced = true
+			}
+			continue
+		}
+		updated = append(updated, r)
+	}
+	if !replaced {
+		updated = append(updated, route)
+	}
+
+	return previous, WriteRoutes(beadsDir, updated)
 }
 
 // RestoreRouteIfCurrent restores or removes a route only if it still matches
@@ -107,6 +134,15 @@ func RestoreRouteIfCurrent(townRoot string, route Route, previous *Route) error 
 
 // RestoreRouteInDirIfCurrent restores or removes a route only if it still matches.
 func RestoreRouteInDirIfCurrent(beadsDir string, route Route, previous *Route) error {
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		return fmt.Errorf("creating beads directory: %w", err)
+	}
+	unlock, err := gtlock.FlockAcquire(filepath.Join(beadsDir, RoutesFileName+".flock"))
+	if err != nil {
+		return fmt.Errorf("acquiring routes lock: %w", err)
+	}
+	defer unlock()
+
 	routes, err := LoadRoutes(beadsDir)
 	if err != nil {
 		return fmt.Errorf("loading routes: %w", err)

--- a/internal/beads/routes_test.go
+++ b/internal/beads/routes_test.go
@@ -505,6 +505,61 @@ func TestCheckPrefixAvailable_NoRoutes(t *testing.T) {
 	}
 }
 
+func TestAppendRouteIfPrefixAvailable(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := WriteRoutes(beadsDir, []Route{{Prefix: "gt-", Path: "gastown/mayor/rig"}}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	if _, err := AppendRouteIfPrefixAvailable(tmpDir, Route{Prefix: "gt-", Path: "secondrig/mayor/rig"}); err == nil {
+		t.Fatal("AppendRouteIfPrefixAvailable succeeded for different-rig prefix collision")
+	}
+	routes, err := LoadRoutes(beadsDir)
+	if err != nil {
+		t.Fatalf("load routes: %v", err)
+	}
+	if len(routes) != 1 || routes[0].Path != "gastown/mayor/rig" {
+		t.Fatalf("route changed after rejected collision: %#v", routes)
+	}
+
+	previous, err := AppendRouteIfPrefixAvailable(tmpDir, Route{Prefix: "gt-", Path: "gastown"})
+	if err != nil {
+		t.Fatalf("AppendRouteIfPrefixAvailable same rig: %v", err)
+	}
+	if previous == nil || previous.Path != "gastown/mayor/rig" {
+		t.Fatalf("previous route = %#v, want gastown/mayor/rig", previous)
+	}
+	if err := RestoreRouteIfCurrent(tmpDir, Route{Prefix: "gt-", Path: "gastown"}, previous); err != nil {
+		t.Fatalf("restore previous route: %v", err)
+	}
+	routes, err = LoadRoutes(beadsDir)
+	if err != nil {
+		t.Fatalf("load restored routes: %v", err)
+	}
+	if len(routes) != 1 || routes[0].Path != "gastown/mayor/rig" {
+		t.Fatalf("route was not restored: %#v", routes)
+	}
+
+	previous, err = AppendRouteIfPrefixAvailable(tmpDir, Route{Prefix: "cr-", Path: "crucible"})
+	if err != nil {
+		t.Fatalf("AppendRouteIfPrefixAvailable new route: %v", err)
+	}
+	if previous != nil {
+		t.Fatalf("previous route = %#v, want nil for new route", previous)
+	}
+	if err := RestoreRouteIfCurrent(tmpDir, Route{Prefix: "cr-", Path: "crucible"}, previous); err != nil {
+		t.Fatalf("remove new route rollback: %v", err)
+	}
+	routes, err = LoadRoutes(beadsDir)
+	if err != nil {
+		t.Fatalf("load routes after rollback: %v", err)
+	}
+	if len(routes) != 1 || routes[0].Prefix != "gt-" {
+		t.Fatalf("new route was not removed on rollback: %#v", routes)
+	}
+}
+
 func TestAgentBeadIDsWithPrefix(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/beads/routes_test.go
+++ b/internal/beads/routes_test.go
@@ -560,6 +560,38 @@ func TestAppendRouteIfPrefixAvailable(t *testing.T) {
 	}
 }
 
+func TestAppendRouteIfPrefixAvailableScansDuplicatePrefixes(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := WriteRoutes(beadsDir, []Route{
+		{Prefix: "gt-", Path: "gastown"},
+		{Prefix: "gt-", Path: "secondrig"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	if _, err := AppendRouteIfPrefixAvailable(tmpDir, Route{Prefix: "gt-", Path: "gastown/mayor/rig"}); err == nil {
+		t.Fatal("AppendRouteIfPrefixAvailable succeeded with duplicate different-rig prefix")
+	}
+
+	if err := WriteRoutes(beadsDir, []Route{
+		{Prefix: "gt-", Path: "gastown"},
+		{Prefix: "gt-", Path: "gastown/mayor/rig"},
+	}); err != nil {
+		t.Fatalf("write same-rig duplicates: %v", err)
+	}
+	if _, err := AppendRouteIfPrefixAvailable(tmpDir, Route{Prefix: "gt-", Path: "gastown/mayor/rig"}); err != nil {
+		t.Fatalf("AppendRouteIfPrefixAvailable same-rig duplicates: %v", err)
+	}
+	routes, err := LoadRoutes(beadsDir)
+	if err != nil {
+		t.Fatalf("load routes: %v", err)
+	}
+	if len(routes) != 1 || routes[0].Prefix != "gt-" || routes[0].Path != "gastown/mayor/rig" {
+		t.Fatalf("same-rig duplicates were not collapsed: %#v", routes)
+	}
+}
+
 func TestAgentBeadIDsWithPrefix(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -867,20 +867,20 @@ Use crew for your own workspace. Polecats are for batch work dispatch.
 		if _, err := os.Stat(mayorRigBeads); err == nil {
 			routePath = opts.Name + "/mayor/rig"
 		}
-			route := beads.Route{
-				Prefix: opts.BeadsPrefix + "-",
-				Path:   routePath,
-			}
-			previousRoute, err := beads.AppendRouteIfPrefixAvailable(m.townRoot, route)
-			if err != nil {
-				return nil, fmt.Errorf("registering rig route: %w", err)
-			}
-			routeRollback = func() {
-				if err := beads.RestoreRouteIfCurrent(m.townRoot, route, previousRoute); err != nil {
-					fmt.Fprintf(os.Stderr, "  Warning: Could not roll back route %s -> %s: %v\n", route.Prefix, route.Path, err)
-				}
+		route := beads.Route{
+			Prefix: opts.BeadsPrefix + "-",
+			Path:   routePath,
+		}
+		previousRoute, err := beads.AppendRouteIfPrefixAvailable(m.townRoot, route)
+		if err != nil {
+			return nil, fmt.Errorf("registering rig route: %w", err)
+		}
+		routeRollback = func() {
+			if err := beads.RestoreRouteIfCurrent(m.townRoot, route, previousRoute); err != nil {
+				fmt.Fprintf(os.Stderr, "  Warning: Could not roll back route %s -> %s: %v\n", route.Prefix, route.Path, err)
 			}
 		}
+	}
 
 	// Create rig-level settings directory (used by gt config for rig overrides)
 	rigSettingsPath := filepath.Join(rigPath, constants.DirSettings)

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -592,6 +592,9 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 			if userProvidedPrefix && strings.TrimSuffix(opts.BeadsPrefix, "-") != strings.TrimSuffix(sourcePrefix, "-") {
 				return nil, fmt.Errorf("prefix mismatch: source repo uses '%s' but --prefix '%s' was provided; use --prefix %s to match existing issues", sourcePrefix, opts.BeadsPrefix, sourcePrefix)
 			}
+			if err := beads.CheckPrefixAvailable(m.townRoot, sourcePrefix+"-", opts.Name); err != nil {
+				return nil, fmt.Errorf("prefix collision (source repo prefix %q): %w", sourcePrefix, err)
+			}
 			// Use detected prefix (overrides derived prefix)
 			opts.BeadsPrefix = sourcePrefix
 			rigConfig.Beads.Prefix = sourcePrefix
@@ -865,6 +868,9 @@ Use crew for your own workspace. Polecats are for batch work dispatch.
 		route := beads.Route{
 			Prefix: opts.BeadsPrefix + "-",
 			Path:   routePath,
+		}
+		if err := beads.CheckPrefixAvailable(m.townRoot, route.Prefix, route.Path); err != nil {
+			return nil, fmt.Errorf("prefix collision before route registration: %w", err)
 		}
 		if err := beads.AppendRoute(m.townRoot, route); err != nil {
 			fmt.Printf("  Warning: Could not update routes.jsonl: %v\n", err)

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -392,9 +392,11 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 
 	// Track cleanup on failure, but only if this invocation still owns the path.
 	cleanup := func() { removeRigPathIfOwned(rigPath, ownershipStamp) }
+	routeRollback := func() {}
 	success := false
 	defer func() {
 		if !success {
+			routeRollback()
 			cleanup()
 		}
 	}()
@@ -865,17 +867,20 @@ Use crew for your own workspace. Polecats are for batch work dispatch.
 		if _, err := os.Stat(mayorRigBeads); err == nil {
 			routePath = opts.Name + "/mayor/rig"
 		}
-		route := beads.Route{
-			Prefix: opts.BeadsPrefix + "-",
-			Path:   routePath,
+			route := beads.Route{
+				Prefix: opts.BeadsPrefix + "-",
+				Path:   routePath,
+			}
+			previousRoute, err := beads.AppendRouteIfPrefixAvailable(m.townRoot, route)
+			if err != nil {
+				return nil, fmt.Errorf("registering rig route: %w", err)
+			}
+			routeRollback = func() {
+				if err := beads.RestoreRouteIfCurrent(m.townRoot, route, previousRoute); err != nil {
+					fmt.Fprintf(os.Stderr, "  Warning: Could not roll back route %s -> %s: %v\n", route.Prefix, route.Path, err)
+				}
+			}
 		}
-		if err := beads.CheckPrefixAvailable(m.townRoot, route.Prefix, route.Path); err != nil {
-			return nil, fmt.Errorf("prefix collision before route registration: %w", err)
-		}
-		if err := beads.AppendRoute(m.townRoot, route); err != nil {
-			fmt.Printf("  Warning: Could not update routes.jsonl: %v\n", err)
-		}
-	}
 
 	// Create rig-level settings directory (used by gt config for rig overrides)
 	rigSettingsPath := filepath.Join(rigPath, constants.DirSettings)

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -2110,6 +2110,44 @@ func TestAddRig_TrackedBeadsPrefixCollisionDoesNotRewriteRoute(t *testing.T) {
 	}
 }
 
+func TestAddRig_RollsBackRouteWhenRegistrationFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-based bd shim not reliable on Windows CI")
+	}
+
+	fakeBDForAddRig(t)
+
+	root, rigsConfig := setupTestTown(t)
+	if err := os.WriteFile(filepath.Join(root, "mayor"), []byte("not a directory\n"), 0644); err != nil {
+		t.Fatalf("write mayor blocker: %v", err)
+	}
+	manager := NewManager(root, rigsConfig, git.NewGit(root))
+	repoDir := createTestGitRepoForRig(t, "rollbackrepo")
+
+	_, err := manager.AddRig(AddRigOptions{
+		Name:          "rollbackrig",
+		GitURL:        repoDir,
+		BeadsPrefix:   "rb",
+		SkipDoltCheck: true,
+	})
+	if err == nil {
+		t.Fatal("AddRig succeeded, want rigs.json registration failure")
+	}
+	if got := err.Error(); !strings.Contains(got, "registering rig in rigs.json") {
+		t.Fatalf("AddRig error = %q, want rigs.json registration failure", got)
+	}
+
+	routes, err := beads.LoadRoutes(filepath.Join(root, ".beads"))
+	if err != nil {
+		t.Fatalf("load routes: %v", err)
+	}
+	for _, route := range routes {
+		if route.Prefix == "rb-" {
+			t.Fatalf("route was not rolled back after failed add: %#v", routes)
+		}
+	}
+}
+
 func TestAddRig_TrackedBeadsWithoutSyncRemote_NoReinitFlags(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("shell-based bd shim not reliable on Windows CI")

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/git"
@@ -2045,6 +2046,67 @@ esac
 	}
 	if !strings.Contains(cmds, "--destroy-token=DESTROY-gt") {
 		t.Errorf("bd init missing --destroy-token=DESTROY-gt; full log:\n%s", cmds)
+	}
+}
+
+func TestAddRig_TrackedBeadsPrefixCollisionDoesNotRewriteRoute(t *testing.T) {
+	repoDir := t.TempDir()
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("# second rig\n"), 0644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("prefix: gt\nissue-prefix: gt\n"), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	for _, args := range [][]string{
+		{"git", "init", "--initial-branch=main", repoDir},
+		{"git", "-C", repoDir, "config", "user.email", "test@test.com"},
+		{"git", "-C", repoDir, "config", "user.name", "Test User"},
+		{"git", "-C", repoDir, "add", "README.md"},
+		{"git", "-C", repoDir, "add", "-f", ".beads/config.yaml"},
+		{"git", "-C", repoDir, "commit", "-m", "Initial commit with beads config"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	root, rigsConfig := setupTestTown(t)
+	if err := beads.WriteRoutes(filepath.Join(root, ".beads"), []beads.Route{
+		{Prefix: "gt-", Path: "gastown/mayor/rig"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+	manager := NewManager(root, rigsConfig, git.NewGit(root))
+
+	_, err := manager.AddRig(AddRigOptions{
+		Name:          "secondrig",
+		GitURL:        repoDir,
+		SkipDoltCheck: true,
+	})
+	if err == nil {
+		t.Fatal("AddRig succeeded, want tracked source prefix collision")
+	}
+	if got := err.Error(); !strings.Contains(got, "source repo prefix") || !strings.Contains(got, "already used") {
+		t.Fatalf("AddRig error = %q, want source prefix collision", got)
+	}
+
+	routes, err := beads.LoadRoutes(filepath.Join(root, ".beads"))
+	if err != nil {
+		t.Fatalf("load routes: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("routes count = %d, want 1: %#v", len(routes), routes)
+	}
+	if routes[0].Prefix != "gt-" || routes[0].Path != "gastown/mayor/rig" {
+		t.Fatalf("route = %#v, want gt- -> gastown/mayor/rig", routes[0])
+	}
+	if _, err := os.Stat(filepath.Join(root, "secondrig")); !os.IsNotExist(err) {
+		t.Fatalf("secondrig directory still exists after failed add: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- Reject tracked source `.beads/config.yaml` prefixes when they collide with another rig before route registration can rewrite `routes.jsonl`.
- Add checked route registration that scans duplicate prefix entries, serializes checked updates with a route flock, and rolls back AddRig route writes on later registration failure.
- Cover second-rig prefix drift, route rollback, checked append, and duplicate-prefix behavior with targeted tests.

## RCA Evidence
- Confirmed current route values: `gt- -> gastown/mayor/rig`, `do- -> coder_dotfiles/mayor/rig`, `hq-`/`hq-cv- -> .`.
- Confirmed drift path: initial derived prefix check passes, tracked source config overrides to `gt`, and old route append semantics can update the existing `gt-` route to a second rig.
- Persisted full 15-pass research and review evidence on bead `gt-rca-canon-routing-rig-add`.

## Testing
- [x] `make build`
- [x] `go test ./internal/beads -run 'TestAppendRouteIfPrefixAvailable|TestAppendRouteIfPrefixAvailableScansDuplicatePrefixes' -count=1`
- [x] `go test ./internal/rig -run 'TestAddRig_TrackedBeadsPrefixCollisionDoesNotRewriteRoute|TestAddRig_RollsBackRouteWhenRegistrationFails|TestAddRig_TrackedBeads|TestAddRig_UpstreamURL|TestAddRig_BranchFlag' -count=1`

## Known Existing Failures
- `go test ./internal/rig -count=1` fails `TestInitBeadsWritesConfigOnFailure` because config output includes `export.auto: "false"`.
- `go test ./internal/beads -count=1` fails `TestRunEnv_StripsPollutedDoltEnvAndUsesRigMetadata` because polluted env selected prefix `hq`, want `gt`.
- Follow-up filed: `gt-existing-package-test-failures`.