### PR TITLE
fix: count recovery slots in scheduler capacity

### DIFF
--- a/internal/cmd/capacity_dispatch.go
+++ b/internal/cmd/capacity_dispatch.go
@@ -149,8 +149,11 @@ func dispatchScheduledWork(townRoot, actor string, batchOverride int, dryRun boo
 	polecatNames := make(map[string]string)
 	cycle := &capacity.DispatchCycle{
 		AvailableCapacity: func() (int, error) {
-			active := countWorkingPolecats()
-			cap := maxPolecats - active
+			occupied, err := countCapacityOccupyingPolecats()
+			if err != nil {
+				return 0, nil // Fail closed: do not dispatch when capacity cannot be proven.
+			}
+			cap := maxPolecats - occupied
 			if cap <= 0 {
 				return 0, nil // No free slots — PlanDispatch treats <= 0 as no capacity
 			}
@@ -269,8 +272,8 @@ func dispatchScheduledWork(townRoot, actor string, batchOverride int, dryRun boo
 		fmt.Printf("\n%s Dispatched %d, failed %d (reason: %s)\n",
 			style.Bold.Render("✓"), report.Dispatched, report.Failed, report.Reason)
 	} else if report.Skipped > 0 {
-		fmt.Printf("\n%s Skipped %d bead(s) — zero capacity (working: %d)\n",
-			style.Dim.Render("○"), report.Skipped, countWorkingPolecats())
+		fmt.Printf("\n%s Skipped %d bead(s) — zero capacity (occupied: %d)\n",
+			style.Dim.Render("○"), report.Skipped, countCapacityOccupyingPolecatsForDisplay())
 	}
 
 	return report.Dispatched, nil
@@ -283,7 +286,7 @@ func printDryRunPlan(plan capacity.DispatchPlan, maxPolecats, batchSize int) {
 		return
 	}
 
-	activePolecats := countActivePolecats()
+	activePolecats := countCapacityOccupyingPolecatsForDisplay()
 	capStr := "unlimited"
 	if maxPolecats > 0 {
 		cap := maxPolecats - activePolecats

--- a/internal/cmd/capacity_dispatch_test.go
+++ b/internal/cmd/capacity_dispatch_test.go
@@ -34,13 +34,15 @@ func TestCountCapacityOccupiedSlots(t *testing.T) {
 		{
 			name: "working and failed slots occupy capacity",
 			slots: []polecatCapacitySlot{
+				{HasAgent: true, CleanupStatus: "clean"},
+				{HasAgent: true, ActiveWork: true, AgentState: "idle", CleanupStatus: "clean"},
 				{HasAgent: true, AgentState: "working", CleanupStatus: "clean"},
 				{HasAgent: true, AgentState: "spawning", CleanupStatus: "clean"},
 				{HasAgent: true, AgentState: "idle", CleanupStatus: "clean", HookBead: "gt-work"},
 				{HasAgent: true, AgentState: "idle", CleanupStatus: "clean", PushFailed: true},
 				{HasAgent: true, AgentState: "idle", CleanupStatus: "clean", MRFailed: true},
 			},
-			want: 5,
+			want: 7,
 		},
 	}
 

--- a/internal/cmd/capacity_dispatch_test.go
+++ b/internal/cmd/capacity_dispatch_test.go
@@ -5,6 +5,54 @@ import (
 	"time"
 )
 
+func TestCountCapacityOccupiedSlots(t *testing.T) {
+	tests := []struct {
+		name  string
+		slots []polecatCapacitySlot
+		want  int
+	}{
+		{
+			name: "six idle recovery needed slots occupy capacity",
+			slots: []polecatCapacitySlot{
+				{HasAgent: true, AgentState: "idle", CleanupStatus: "has_unpushed"},
+				{HasAgent: true, AgentState: "idle", CleanupStatus: "has_uncommitted"},
+				{HasAgent: true, AgentState: "idle", CleanupStatus: "has_stash"},
+				{HasAgent: true, AgentState: "idle", CleanupStatus: "unknown"},
+				{HasAgent: true, AgentState: "idle"},
+				{HasAgent: false},
+			},
+			want: 6,
+		},
+		{
+			name: "clean reusable idle slots do not occupy capacity",
+			slots: []polecatCapacitySlot{
+				{HasAgent: true, AgentState: "idle", CleanupStatus: "clean"},
+				{HasAgent: true, AgentState: "nuked", CleanupStatus: "clean"},
+			},
+			want: 0,
+		},
+		{
+			name: "working and failed slots occupy capacity",
+			slots: []polecatCapacitySlot{
+				{HasAgent: true, AgentState: "working", CleanupStatus: "clean"},
+				{HasAgent: true, AgentState: "spawning", CleanupStatus: "clean"},
+				{HasAgent: true, AgentState: "idle", CleanupStatus: "clean", HookBead: "gt-work"},
+				{HasAgent: true, AgentState: "idle", CleanupStatus: "clean", PushFailed: true},
+				{HasAgent: true, AgentState: "idle", CleanupStatus: "clean", MRFailed: true},
+			},
+			want: 5,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := countCapacityOccupiedSlots(tt.slots); got != tt.want {
+				t.Fatalf("countCapacityOccupiedSlots() = %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
 func TestShouldFireCrossRigEscalation_Debounces(t *testing.T) {
 	resetCrossRigEscalationStateForTest()
 	t.Cleanup(resetCrossRigEscalationStateForTest)

--- a/internal/cmd/scheduler.go
+++ b/internal/cmd/scheduler.go
@@ -144,12 +144,12 @@ func runSchedulerStatus(cmd *cobra.Command, args []string) error {
 
 	if schedulerStatusJSON {
 		out := struct {
-			Paused         bool               `json:"paused"`
-			PausedBy       string             `json:"paused_by,omitempty"`
-			ScheduledTotal int                `json:"queued_total"`
-			ScheduledReady int                `json:"queued_ready"`
-			ActivePolecats int                `json:"active_polecats"`
-			LastDispatchAt string             `json:"last_dispatch_at,omitempty"`
+			Paused         bool                `json:"paused"`
+			PausedBy       string              `json:"paused_by,omitempty"`
+			ScheduledTotal int                 `json:"queued_total"`
+			ScheduledReady int                 `json:"queued_ready"`
+			ActivePolecats int                 `json:"active_polecats"`
+			LastDispatchAt string              `json:"last_dispatch_at,omitempty"`
 			Beads          []scheduledBeadInfo `json:"beads"`
 		}{
 			Paused:         state.Paused,

--- a/internal/cmd/scheduler.go
+++ b/internal/cmd/scheduler.go
@@ -544,6 +544,7 @@ func countWorkingPolecats() int {
 
 type polecatCapacitySlot struct {
 	HasAgent      bool
+	ActiveWork    bool
 	AgentState    string
 	HookBead      string
 	CleanupStatus string
@@ -565,9 +566,12 @@ func polecatSlotOccupiesCapacity(slot polecatCapacitySlot) bool {
 	if !slot.HasAgent {
 		return true
 	}
+	if slot.ActiveWork {
+		return true
+	}
 	state := strings.ToLower(strings.TrimSpace(slot.AgentState))
 	switch state {
-	case "", "idle", "nuked":
+	case "idle", "nuked":
 		// Idle/nuked slots are free only when cleanup metadata proves they are reusable.
 	default:
 		return true
@@ -601,6 +605,10 @@ func countCapacityOccupyingPolecats() (int, error) {
 	if err != nil {
 		return 0, err
 	}
+	activeWork, err := activePolecatAssignees(rigDirs)
+	if err != nil {
+		return 0, err
+	}
 
 	var slots []polecatCapacitySlot
 	known := make(map[string]bool)
@@ -615,7 +623,8 @@ func countCapacityOccupyingPolecats() (int, error) {
 				continue
 			}
 			name := entry.Name()
-			known[rigName+"/"+name] = true
+			key := rigName + "/" + name
+			known[key] = true
 			prefix := session.PrefixFor(rigName)
 			agentID := beads.PolecatBeadIDWithPrefix(prefix, rigName, name)
 			issue := agents[agentID]
@@ -627,6 +636,7 @@ func countCapacityOccupyingPolecats() (int, error) {
 			fields.AgentState = beads.ResolveAgentState(issue.Description, issue.AgentState)
 			slots = append(slots, polecatCapacitySlot{
 				HasAgent:      true,
+				ActiveWork:    activeWork[key],
 				AgentState:    fields.AgentState,
 				HookBead:      fields.HookBead,
 				CleanupStatus: fields.CleanupStatus,
@@ -655,6 +665,31 @@ func capacityRigDirs(townRoot string) ([]string, error) {
 		}
 	}
 	return dirs, nil
+}
+
+func activePolecatAssignees(rigDirs []string) (map[string]bool, error) {
+	active := make(map[string]bool)
+	for _, rigDir := range rigDirs {
+		rigName := filepath.Base(rigDir)
+		bd := beads.New(rigDir)
+		for _, status := range []string{"open", "in_progress", beads.StatusHooked} {
+			issues, err := bd.List(beads.ListOptions{Status: status, Priority: -1, Limit: 0})
+			if err != nil {
+				return nil, err
+			}
+			for _, issue := range issues {
+				prefix := rigName + "/polecats/"
+				if !strings.HasPrefix(issue.Assignee, prefix) {
+					continue
+				}
+				name := strings.TrimPrefix(issue.Assignee, prefix)
+				if name != "" {
+					active[rigName+"/"+name] = true
+				}
+			}
+		}
+	}
+	return active, nil
 }
 
 func countOrphanPolecatSessions(known map[string]bool) int {

--- a/internal/cmd/scheduler.go
+++ b/internal/cmd/scheduler.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/polecat"
 	"github.com/steveyegge/gastown/internal/scheduler/capacity"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/style"
@@ -139,7 +140,7 @@ func runSchedulerStatus(cmd *cobra.Command, args []string) error {
 
 	scheduled := listScheduledBeads(townRoot)
 
-	activePolecats := countActivePolecats()
+	activePolecats := countCapacityOccupyingPolecatsForDisplay()
 
 	if schedulerStatusJSON {
 		out := struct {
@@ -537,6 +538,144 @@ func countWorkingPolecats() int {
 			continue // Idle — don't count toward cap
 		}
 		count++
+	}
+	return count
+}
+
+type polecatCapacitySlot struct {
+	HasAgent      bool
+	AgentState    string
+	HookBead      string
+	CleanupStatus string
+	PushFailed    bool
+	MRFailed      bool
+}
+
+func countCapacityOccupiedSlots(slots []polecatCapacitySlot) int {
+	occupied := 0
+	for _, slot := range slots {
+		if polecatSlotOccupiesCapacity(slot) {
+			occupied++
+		}
+	}
+	return occupied
+}
+
+func polecatSlotOccupiesCapacity(slot polecatCapacitySlot) bool {
+	if !slot.HasAgent {
+		return true
+	}
+	state := strings.ToLower(strings.TrimSpace(slot.AgentState))
+	switch state {
+	case "", "idle", "nuked":
+		// Idle/nuked slots are free only when cleanup metadata proves they are reusable.
+	default:
+		return true
+	}
+	if slot.HookBead != "" || slot.PushFailed || slot.MRFailed {
+		return true
+	}
+	return !polecat.CleanupStatus(slot.CleanupStatus).IsSafe()
+}
+
+func countCapacityOccupyingPolecatsForDisplay() int {
+	count, err := countCapacityOccupyingPolecats()
+	if err != nil {
+		return countActivePolecats()
+	}
+	return count
+}
+
+func countCapacityOccupyingPolecats() (int, error) {
+	townRoot, err := workspace.FindFromCwd()
+	if err != nil {
+		return 0, err
+	}
+
+	rigDirs, err := capacityRigDirs(townRoot)
+	if err != nil {
+		return 0, err
+	}
+
+	agents, err := beads.New(townRoot).ForAgentBead().ListAgentBeads()
+	if err != nil {
+		return 0, err
+	}
+
+	var slots []polecatCapacitySlot
+	known := make(map[string]bool)
+	for _, rigDir := range rigDirs {
+		rigName := filepath.Base(rigDir)
+		entries, err := os.ReadDir(filepath.Join(rigDir, "polecats"))
+		if err != nil {
+			return 0, err
+		}
+		for _, entry := range entries {
+			if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+				continue
+			}
+			name := entry.Name()
+			known[rigName+"/"+name] = true
+			prefix := session.PrefixFor(rigName)
+			agentID := beads.PolecatBeadIDWithPrefix(prefix, rigName, name)
+			issue := agents[agentID]
+			if issue == nil {
+				slots = append(slots, polecatCapacitySlot{})
+				continue
+			}
+			fields := beads.ParseAgentFields(issue.Description)
+			fields.AgentState = beads.ResolveAgentState(issue.Description, issue.AgentState)
+			slots = append(slots, polecatCapacitySlot{
+				HasAgent:      true,
+				AgentState:    fields.AgentState,
+				HookBead:      fields.HookBead,
+				CleanupStatus: fields.CleanupStatus,
+				PushFailed:    fields.PushFailed,
+				MRFailed:      fields.MRFailed,
+			})
+		}
+	}
+
+	return countCapacityOccupiedSlots(slots) + countOrphanPolecatSessions(known), nil
+}
+
+func capacityRigDirs(townRoot string) ([]string, error) {
+	entries, err := os.ReadDir(townRoot)
+	if err != nil {
+		return nil, err
+	}
+	var dirs []string
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") || entry.Name() == "mayor" || entry.Name() == "settings" {
+			continue
+		}
+		rigDir := filepath.Join(townRoot, entry.Name())
+		if info, err := os.Stat(filepath.Join(rigDir, "polecats")); err == nil && info.IsDir() {
+			dirs = append(dirs, rigDir)
+		}
+	}
+	return dirs, nil
+}
+
+func countOrphanPolecatSessions(known map[string]bool) int {
+	listCmd := tmux.BuildCommand("list-sessions", "-F", "#{session_name}")
+	out, err := listCmd.Output()
+	if err != nil {
+		return 0
+	}
+
+	count := 0
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		if line == "" {
+			continue
+		}
+		identity, err := session.ParseSessionName(line)
+		if err != nil || identity.Role != session.RolePolecat {
+			continue
+		}
+		if !known[identity.Rig+"/"+identity.Name] {
+			count++
+		}
 	}
 	return count
 }


### PR DESCRIPTION
## Summary
- Counts non-reusable idle/recovery polecat slots as occupied scheduler capacity so unsafe preserved worktrees cannot be refilled past `scheduler.max_polecats`.
- Adds active assigned work into capacity accounting instead of relying only on stale agent `hook_bead` state.
- Adds regression coverage for six recovery-needed idle slots, clean reusable idle slots, and failed/active work states.

## RCA Evidence
- PRs #4080/#4081 are still open and not contained in `integration/test-beaddolt-hardenning`, so no-code closure is not sufficient.
- Live evidence captured in bead notes: `gt hook`, `gt polecat list`, `gt polecat status`, `gt polecat check-recovery`, `bd show gt-gastown-polecat-crater`, `gt scheduler status --json`, `gt config get scheduler.max_polecats`.
- Bead: `gt-rca-canon-polecat-refill-capacity`.

## Validation
- `go test ./internal/cmd -run 'TestCountCapacityOccupiedSlots|TestShouldFireCrossRigEscalation'`
- `go test ./internal/polecat -run TestDecideSlotReuse`
- `go test ./internal/scheduler/capacity`
- `go build ./cmd/gt`