### PR TITLE
fix: harden polecat reuse and session startup

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -415,24 +415,6 @@ func effectivePolecatState(item PolecatListItem) polecat.State {
 	return state
 }
 
-type reuseMRShower interface {
-	Show(issueID string) (*beads.Issue, error)
-}
-
-func activeMRBlocksReuse(bd reuseMRShower, mrID string) bool {
-	if mrID == "" {
-		return false
-	}
-	if bd == nil {
-		return true
-	}
-	mr, err := bd.Show(mrID)
-	if err != nil || mr == nil {
-		return true
-	}
-	return !beads.IssueStatus(mr.Status).IsTerminal()
-}
-
 func polecatReuseStatus(state polecat.State, cleanupStatus, activeMR, branch string, activeMRBlocks bool) string {
 	if state != polecat.StateIdle {
 		return ""
@@ -526,7 +508,7 @@ func runPolecatList(cmd *cobra.Command, args []string) error {
 				CleanupStatus:  cleanupStatus,
 				ActiveMR:       activeMR,
 				Branch:         p.Branch,
-				ReuseStatus:    polecatReuseStatus(state, cleanupStatus, activeMR, p.Branch, activeMRBlocksReuse(bd, activeMR)),
+				ReuseStatus:    polecatReuseStatus(state, cleanupStatus, activeMR, p.Branch, polecat.ActiveMRBlocksReuse(bd, activeMR)),
 				SessionRunning: running,
 			})
 			knownNames[p.Name] = true

--- a/internal/cmd/polecat_list_state_test.go
+++ b/internal/cmd/polecat_list_state_test.go
@@ -154,8 +154,8 @@ func TestActiveMRBlocksReuse(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := activeMRBlocksReuse(tt.bd, tt.mrID); got != tt.want {
-				t.Fatalf("activeMRBlocksReuse() = %v, want %v", got, tt.want)
+			if got := polecat.ActiveMRBlocksReuse(tt.bd, tt.mrID); got != tt.want {
+				t.Fatalf("ActiveMRBlocksReuse() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/internal/cmd/polecat_list_state_test.go
+++ b/internal/cmd/polecat_list_state_test.go
@@ -122,7 +122,7 @@ func TestActiveMRBlocksReuse(t *testing.T) {
 	tests := []struct {
 		name string
 		mrID string
-		bd   reuseMRShower
+		bd   polecat.MRStatusReader
 		want bool
 	}{
 		{name: "empty active MR does not block"},

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2175,6 +2175,8 @@ func (m *Manager) reuseDecisionForPolecat(name string, state State) SlotReuseDec
 		input.HookBead = fields.HookBead
 		input.PushFailed = fields.PushFailed
 		input.MRFailed = fields.MRFailed
+		input.ActiveMR = fields.ActiveMR
+		input.ActiveMRBlocks = ActiveMRBlocksReuse(m.beads, fields.ActiveMR)
 		if fields.CleanupStatus != "" {
 			input.CleanupStatus = CleanupStatus(fields.CleanupStatus)
 		}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2175,7 +2175,6 @@ func (m *Manager) reuseDecisionForPolecat(name string, state State) SlotReuseDec
 		input.HookBead = fields.HookBead
 		input.PushFailed = fields.PushFailed
 		input.MRFailed = fields.MRFailed
-		input.ActiveMR = fields.ActiveMR
 		input.ActiveMRBlocks = ActiveMRBlocksReuse(m.beads, fields.ActiveMR)
 		if fields.CleanupStatus != "" {
 			input.CleanupStatus = CleanupStatus(fields.CleanupStatus)

--- a/internal/polecat/reuse.go
+++ b/internal/polecat/reuse.go
@@ -1,6 +1,10 @@
 package polecat
 
-import "errors"
+import (
+	"errors"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
 
 // ErrPolecatNeedsRecovery marks an idle-looking polecat that must not be reset
 // or advertised as reusable until its preserved work is recovered or submitted.
@@ -12,6 +16,8 @@ type SlotReuseInput struct {
 	State           State
 	HookBead        string
 	CleanupStatus   CleanupStatus
+	ActiveMR        string
+	ActiveMRBlocks  bool
 	PushFailed      bool
 	MRFailed        bool
 	Branch          string
@@ -42,6 +48,9 @@ func DecideSlotReuse(in SlotReuseInput) SlotReuseDecision {
 	if in.MRFailed {
 		return SlotReuseDecision{Reason: "mr-failed"}
 	}
+	if in.ActiveMRBlocks {
+		return SlotReuseDecision{Reason: "active-mr"}
+	}
 	if !in.CleanupStatus.IsSafe() {
 		if in.CleanupStatus == "" {
 			return SlotReuseDecision{Reason: "cleanup-unknown"}
@@ -61,4 +70,22 @@ func DecideSlotReuse(in SlotReuseInput) SlotReuseDecision {
 		return SlotReuseDecision{Reason: "git-unpushed"}
 	}
 	return SlotReuseDecision{Reusable: true, Reason: "reusable"}
+}
+
+type MRStatusReader interface {
+	Show(issueID string) (*beads.Issue, error)
+}
+
+func ActiveMRBlocksReuse(bd MRStatusReader, mrID string) bool {
+	if mrID == "" {
+		return false
+	}
+	if bd == nil {
+		return true
+	}
+	mr, err := bd.Show(mrID)
+	if err != nil || mr == nil {
+		return true
+	}
+	return !beads.IssueStatus(mr.Status).IsTerminal()
 }

--- a/internal/polecat/reuse.go
+++ b/internal/polecat/reuse.go
@@ -16,7 +16,6 @@ type SlotReuseInput struct {
 	State           State
 	HookBead        string
 	CleanupStatus   CleanupStatus
-	ActiveMR        string
 	ActiveMRBlocks  bool
 	PushFailed      bool
 	MRFailed        bool

--- a/internal/polecat/reuse_test.go
+++ b/internal/polecat/reuse_test.go
@@ -14,6 +14,7 @@ func TestDecideSlotReuse(t *testing.T) {
 		{name: "hook", mutate: func(in *SlotReuseInput) { in.HookBead = "gt-work" }, want: "hook-still-set"},
 		{name: "push failed", mutate: func(in *SlotReuseInput) { in.PushFailed = true }, want: "push-failed"},
 		{name: "mr failed", mutate: func(in *SlotReuseInput) { in.MRFailed = true }, want: "mr-failed"},
+		{name: "active MR", mutate: func(in *SlotReuseInput) { in.ActiveMR = "gt-mr"; in.ActiveMRBlocks = true }, want: "active-mr"},
 		{name: "cleanup dirty", mutate: func(in *SlotReuseInput) { in.CleanupStatus = CleanupUnpushed }, want: "cleanup-has_unpushed"},
 		{name: "cleanup unknown", mutate: func(in *SlotReuseInput) { in.CleanupStatus = CleanupUnknown }, want: "cleanup-unknown"},
 		{name: "git dirty", mutate: func(in *SlotReuseInput) { in.GitDirty = true }, want: "git-dirty"},

--- a/internal/polecat/reuse_test.go
+++ b/internal/polecat/reuse_test.go
@@ -14,7 +14,7 @@ func TestDecideSlotReuse(t *testing.T) {
 		{name: "hook", mutate: func(in *SlotReuseInput) { in.HookBead = "gt-work" }, want: "hook-still-set"},
 		{name: "push failed", mutate: func(in *SlotReuseInput) { in.PushFailed = true }, want: "push-failed"},
 		{name: "mr failed", mutate: func(in *SlotReuseInput) { in.MRFailed = true }, want: "mr-failed"},
-		{name: "active MR", mutate: func(in *SlotReuseInput) { in.ActiveMR = "gt-mr"; in.ActiveMRBlocks = true }, want: "active-mr"},
+		{name: "active MR", mutate: func(in *SlotReuseInput) { in.ActiveMRBlocks = true }, want: "active-mr"},
 		{name: "cleanup dirty", mutate: func(in *SlotReuseInput) { in.CleanupStatus = CleanupUnpushed }, want: "cleanup-has_unpushed"},
 		{name: "cleanup unknown", mutate: func(in *SlotReuseInput) { in.CleanupStatus = CleanupUnknown }, want: "cleanup-unknown"},
 		{name: "git dirty", mutate: func(in *SlotReuseInput) { in.GitDirty = true }, want: "git-dirty"},

--- a/internal/tmux/session_creation_test.go
+++ b/internal/tmux/session_creation_test.go
@@ -106,7 +106,7 @@ func TestNewSessionWithCommand_ExecEnvSuccess(t *testing.T) {
 
 	time.Sleep(200 * time.Millisecond)
 	paneCmd, _ := tm.GetPaneCommand(session)
-	if paneCmd != "sleep" {
+	if !isSleepPaneCommand(paneCmd) {
 		t.Errorf("expected pane command 'sleep' (exec replaced shell), got %q", paneCmd)
 	}
 }

--- a/internal/tmux/session_creation_test.go
+++ b/internal/tmux/session_creation_test.go
@@ -1,6 +1,8 @@
 package tmux
 
 import (
+	"errors"
+	"fmt"
 	"strings"
 	"testing"
 	"time"
@@ -50,6 +52,22 @@ func TestNewSessionWithCommand_ExecEnvBadBinary(t *testing.T) {
 	err := tm.NewSessionWithCommand(session, "", cmd)
 	if err == nil {
 		t.Error("NewSessionWithCommand should return error for exec env with missing binary")
+	}
+}
+
+func TestNewSessionWithCommand_SessionDiesDuringStartup(t *testing.T) {
+	tm := newTestTmux(t)
+	session := "gt-test-dies-startup-" + t.Name()
+	_ = tm.KillSession(session)
+	defer func() { _ = tm.KillSession(session) }()
+
+	cmd := fmt.Sprintf("sh -c 'env -u TMUX tmux -u -L %s kill-session -t %s'", tm.socketName, session)
+	err := tm.NewSessionWithCommand(session, "", cmd)
+	if err == nil {
+		t.Fatal("NewSessionWithCommand should return error when session disappears during startup")
+	}
+	if !errors.Is(err, ErrSessionNotFound) {
+		t.Fatalf("NewSessionWithCommand error = %v, want ErrSessionNotFound", err)
 	}
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -454,11 +454,17 @@ func (t *Tmux) NewSessionWithCommandAndEnv(name, workDir, command string, env ma
 // Only returns an error for non-zero exits (command failures), not clean exits (status 0).
 func (t *Tmux) checkSessionAfterCreate(name, command string) error {
 	checkPaneDead := func() (bool, error) {
-		paneDead, _ := t.run("display-message", "-p", "-t", name, "#{pane_dead}")
+		paneDead, err := t.run("display-message", "-p", "-t", name, "#{pane_dead}")
+		if err != nil {
+			return true, fmt.Errorf("checking session %q after create: %w", name, err)
+		}
 		if strings.TrimSpace(paneDead) != "1" {
 			return false, nil
 		}
-		exitStatus, _ := t.run("display-message", "-p", "-t", name, "#{pane_dead_status}")
+		exitStatus, err := t.run("display-message", "-p", "-t", name, "#{pane_dead_status}")
+		if err != nil {
+			return true, fmt.Errorf("checking session %q exit status after create: %w", name, err)
+		}
 		status := strings.TrimSpace(exitStatus)
 		if status != "" && status != "0" {
 			_ = t.KillSession(name)
@@ -484,7 +490,9 @@ func (t *Tmux) checkSessionAfterCreate(name, command string) error {
 	}
 
 	// Pane is alive — restore default (no need to keep dead sessions around)
-	_, _ = t.run("set-option", "-t", name, "remain-on-exit", "off")
+	if _, err := t.run("set-option", "-t", name, "remain-on-exit", "off"); err != nil {
+		return fmt.Errorf("finalizing session %q after create: %w", name, err)
+	}
 	return nil
 }
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -257,7 +257,8 @@ func (t *Tmux) wrapError(err error, stderr string, args []string) error {
 		return ErrSessionExists
 	}
 	if strings.Contains(stderr, "session not found") ||
-		strings.Contains(stderr, "can't find session") {
+		strings.Contains(stderr, "can't find session") ||
+		strings.Contains(stderr, "no such window") {
 		return ErrSessionNotFound
 	}
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -196,6 +196,7 @@ func TestWrapError(t *testing.T) {
 		{"duplicate session: test", ErrSessionExists},
 		{"session not found: test", ErrSessionNotFound},
 		{"can't find session: test", ErrSessionNotFound},
+		{"no such window: test", ErrSessionNotFound},
 	}
 
 	for _, tt := range tests {

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -30,6 +30,10 @@ func newTestTmux(t *testing.T) *Tmux {
 	return NewTmux()
 }
 
+func isSleepPaneCommand(cmd string) bool {
+	return cmd == "sleep" || cmd == "coreutils"
+}
+
 func TestListSessionsNoServer(t *testing.T) {
 	tm := newTestTmux(t)
 	sessions, err := tm.ListSessions()
@@ -597,7 +601,7 @@ func TestGetPaneCommand_MultiPane(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPaneCommand before split: %v", err)
 	}
-	if cmd != "sleep" {
+	if !isSleepPaneCommand(cmd) {
 		t.Fatalf("expected pane 0 command to be 'sleep', got %q", cmd)
 	}
 
@@ -621,7 +625,7 @@ func TestGetPaneCommand_MultiPane(t *testing.T) {
 	if err != nil {
 		t.Fatalf("GetPaneCommand after split: %v", err)
 	}
-	if cmd != "sleep" {
+	if !isSleepPaneCommand(cmd) {
 		t.Errorf("after split, GetPaneCommand should return pane 0 command 'sleep', got %q", cmd)
 	}
 

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -820,12 +820,14 @@ func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) 
 	}
 	prefix := beads.GetPrefixForRig(townRoot, rigName)
 	agentID := beads.PolecatBeadIDWithPrefix(prefix, rigName, polecatName)
-	_, fields, err := beads.New(beads.ResolveBeadsDir(workDir)).ForAgentBead().GetAgentBead(agentID)
+	bd := beads.New(beads.ResolveBeadsDir(workDir))
+	_, fields, err := bd.ForAgentBead().GetAgentBead(agentID)
 	input := polecat.SlotReuseInput{State: polecat.StateIdle, CleanupStatus: polecat.CleanupUnknown, GitCheckFailed: err != nil || fields == nil}
 	if fields != nil {
 		input.HookBead = fields.HookBead
 		input.PushFailed = fields.PushFailed
 		input.MRFailed = fields.MRFailed
+		input.ActiveMRBlocks = polecat.ActiveMRBlocksReuse(bd, fields.ActiveMR)
 		if fields.CleanupStatus != "" {
 			input.CleanupStatus = polecat.CleanupStatus(fields.CleanupStatus)
 		}


### PR DESCRIPTION
## Summary
- Propagate tmux startup health-check failures so sessions that disappear during startup return `ErrSessionNotFound` instead of being treated as started.
- Move active-MR reuse blocking into the shared polecat reuse decision and apply it to manager reuse selection, witness `SLOT_OPEN`, and list display.
- Record RCA evidence on `gt-rca-canon-polecat-stale-idle`, including #4080/#4081 overlap and live hook/agent-bead divergence.

## Validation
- `go test ./internal/polecat -run 'TestDecideSlotReuse' -count=1`
- `go test ./internal/cmd -run 'TestActiveMRBlocksReuse|TestPolecatReuseStatus|TestCleanupStatusBlocker|TestPartialSpawnWithoutDurableHook' -count=1`
- `go test ./internal/witness -count=1`
- `go test ./internal/tmux -run 'TestWrapError|TestNewSessionWithCommand_(SessionDiesDuringStartup|BadBinary|ExecEnvBadBinary|Success)' -count=1`
- `go build ./cmd/gt`

## Notes
Full-package failures observed during validation were filed as `gt-polecat-reuse-session-tests-fail` and `gt-tmux-coreutils-pane-command-tests`.