### PR TITLE
fix: converge routing sling safeguards

### DIFF
--- a/internal/beads/routes.go
+++ b/internal/beads/routes.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/steveyegge/gastown/internal/config"
+	gtlock "github.com/steveyegge/gastown/internal/lock"
 )
 
 // Route represents a prefix-to-path routing rule.
@@ -63,6 +64,106 @@ func LoadRoutes(beadsDir string) ([]Route, error) {
 func AppendRoute(townRoot string, route Route) error {
 	beadsDir := filepath.Join(townRoot, ".beads")
 	return AppendRouteToDir(beadsDir, route)
+}
+
+// AppendRouteIfPrefixAvailable appends or updates a route only when the prefix
+// is unused or already belongs to the same rig. It returns the previous route
+// for rollback, or nil when this call added a new route.
+func AppendRouteIfPrefixAvailable(townRoot string, route Route) (*Route, error) {
+	beadsDir := filepath.Join(townRoot, ".beads")
+	return AppendRouteToDirIfPrefixAvailable(beadsDir, route)
+}
+
+// AppendRouteToDirIfPrefixAvailable is AppendRouteToDir with a same-rig guard.
+func AppendRouteToDirIfPrefixAvailable(beadsDir string, route Route) (*Route, error) {
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		return nil, fmt.Errorf("creating beads directory: %w", err)
+	}
+	unlock, err := gtlock.FlockAcquire(filepath.Join(beadsDir, RoutesFileName+".flock"))
+	if err != nil {
+		return nil, fmt.Errorf("acquiring routes lock: %w", err)
+	}
+	defer unlock()
+
+	routes, err := LoadRoutes(beadsDir)
+	if err != nil {
+		return nil, fmt.Errorf("loading routes: %w", err)
+	}
+
+	newRig := strings.SplitN(route.Path, "/", 2)[0]
+	var previous *Route
+	for _, r := range routes {
+		if r.Prefix != route.Prefix {
+			continue
+		}
+		existingRig := strings.SplitN(r.Path, "/", 2)[0]
+		if existingRig != newRig {
+			return nil, fmt.Errorf("prefix %q is already used by %s (path: %s); use --prefix to specify a different prefix", route.Prefix, existingRig, r.Path)
+		}
+		if previous == nil {
+			prev := r
+			previous = &prev
+		}
+	}
+
+	updated := make([]Route, 0, len(routes)+1)
+	replaced := false
+	for _, r := range routes {
+		if r.Prefix == route.Prefix {
+			if !replaced {
+				updated = append(updated, route)
+				replaced = true
+			}
+			continue
+		}
+		updated = append(updated, r)
+	}
+	if !replaced {
+		updated = append(updated, route)
+	}
+
+	return previous, WriteRoutes(beadsDir, updated)
+}
+
+// RestoreRouteIfCurrent restores or removes a route only if it still matches
+// the route written by this caller. This avoids clobbering another add/repair.
+func RestoreRouteIfCurrent(townRoot string, route Route, previous *Route) error {
+	beadsDir := filepath.Join(townRoot, ".beads")
+	return RestoreRouteInDirIfCurrent(beadsDir, route, previous)
+}
+
+// RestoreRouteInDirIfCurrent restores or removes a route only if it still matches.
+func RestoreRouteInDirIfCurrent(beadsDir string, route Route, previous *Route) error {
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		return fmt.Errorf("creating beads directory: %w", err)
+	}
+	unlock, err := gtlock.FlockAcquire(filepath.Join(beadsDir, RoutesFileName+".flock"))
+	if err != nil {
+		return fmt.Errorf("acquiring routes lock: %w", err)
+	}
+	defer unlock()
+
+	routes, err := LoadRoutes(beadsDir)
+	if err != nil {
+		return fmt.Errorf("loading routes: %w", err)
+	}
+
+	for i, r := range routes {
+		if r.Prefix != route.Prefix {
+			continue
+		}
+		if r.Path != route.Path {
+			return nil
+		}
+		if previous == nil {
+			routes = append(routes[:i], routes[i+1:]...)
+		} else {
+			routes[i] = *previous
+		}
+		return WriteRoutes(beadsDir, routes)
+	}
+
+	return nil
 }
 
 // AppendRouteToDir appends a route to routes.jsonl in the given beads directory.

--- a/internal/beads/routes_test.go
+++ b/internal/beads/routes_test.go
@@ -505,6 +505,93 @@ func TestCheckPrefixAvailable_NoRoutes(t *testing.T) {
 	}
 }
 
+func TestAppendRouteIfPrefixAvailable(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := WriteRoutes(beadsDir, []Route{{Prefix: "gt-", Path: "gastown/mayor/rig"}}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	if _, err := AppendRouteIfPrefixAvailable(tmpDir, Route{Prefix: "gt-", Path: "secondrig/mayor/rig"}); err == nil {
+		t.Fatal("AppendRouteIfPrefixAvailable succeeded for different-rig prefix collision")
+	}
+	routes, err := LoadRoutes(beadsDir)
+	if err != nil {
+		t.Fatalf("load routes: %v", err)
+	}
+	if len(routes) != 1 || routes[0].Path != "gastown/mayor/rig" {
+		t.Fatalf("route changed after rejected collision: %#v", routes)
+	}
+
+	previous, err := AppendRouteIfPrefixAvailable(tmpDir, Route{Prefix: "gt-", Path: "gastown"})
+	if err != nil {
+		t.Fatalf("AppendRouteIfPrefixAvailable same rig: %v", err)
+	}
+	if previous == nil || previous.Path != "gastown/mayor/rig" {
+		t.Fatalf("previous route = %#v, want gastown/mayor/rig", previous)
+	}
+	if err := RestoreRouteIfCurrent(tmpDir, Route{Prefix: "gt-", Path: "gastown"}, previous); err != nil {
+		t.Fatalf("restore previous route: %v", err)
+	}
+	routes, err = LoadRoutes(beadsDir)
+	if err != nil {
+		t.Fatalf("load restored routes: %v", err)
+	}
+	if len(routes) != 1 || routes[0].Path != "gastown/mayor/rig" {
+		t.Fatalf("route was not restored: %#v", routes)
+	}
+
+	previous, err = AppendRouteIfPrefixAvailable(tmpDir, Route{Prefix: "cr-", Path: "crucible"})
+	if err != nil {
+		t.Fatalf("AppendRouteIfPrefixAvailable new route: %v", err)
+	}
+	if previous != nil {
+		t.Fatalf("previous route = %#v, want nil for new route", previous)
+	}
+	if err := RestoreRouteIfCurrent(tmpDir, Route{Prefix: "cr-", Path: "crucible"}, previous); err != nil {
+		t.Fatalf("remove new route rollback: %v", err)
+	}
+	routes, err = LoadRoutes(beadsDir)
+	if err != nil {
+		t.Fatalf("load routes after rollback: %v", err)
+	}
+	if len(routes) != 1 || routes[0].Prefix != "gt-" {
+		t.Fatalf("new route was not removed on rollback: %#v", routes)
+	}
+}
+
+func TestAppendRouteIfPrefixAvailableScansDuplicatePrefixes(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := WriteRoutes(beadsDir, []Route{
+		{Prefix: "gt-", Path: "gastown"},
+		{Prefix: "gt-", Path: "secondrig"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	if _, err := AppendRouteIfPrefixAvailable(tmpDir, Route{Prefix: "gt-", Path: "gastown/mayor/rig"}); err == nil {
+		t.Fatal("AppendRouteIfPrefixAvailable succeeded with duplicate different-rig prefix")
+	}
+
+	if err := WriteRoutes(beadsDir, []Route{
+		{Prefix: "gt-", Path: "gastown"},
+		{Prefix: "gt-", Path: "gastown/mayor/rig"},
+	}); err != nil {
+		t.Fatalf("write same-rig duplicates: %v", err)
+	}
+	if _, err := AppendRouteIfPrefixAvailable(tmpDir, Route{Prefix: "gt-", Path: "gastown/mayor/rig"}); err != nil {
+		t.Fatalf("AppendRouteIfPrefixAvailable same-rig duplicates: %v", err)
+	}
+	routes, err := LoadRoutes(beadsDir)
+	if err != nil {
+		t.Fatalf("load routes: %v", err)
+	}
+	if len(routes) != 1 || routes[0].Prefix != "gt-" || routes[0].Path != "gastown/mayor/rig" {
+		t.Fatalf("same-rig duplicates were not collapsed: %#v", routes)
+	}
+}
+
 func TestAgentBeadIDsWithPrefix(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -118,8 +118,13 @@ func TestExtractIssueID(t *testing.T) {
 	}
 }
 
-func TestSlingFormulaOnBeadRoutesBDCommandsToTargetRig(t *testing.T) {
+func TestSlingNewlyCreatedRigBeadRoutesBDCommandsToTargetRig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: shell stub redacts multiline descriptions")
+	}
+
 	townRoot := t.TempDir()
+	newBeadID := "gt-new123"
 
 	// Minimal workspace marker so workspace.FindFromCwd() succeeds.
 	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
@@ -143,7 +148,8 @@ func TestSlingFormulaOnBeadRoutesBDCommandsToTargetRig(t *testing.T) {
 		t.Fatalf("write routes.jsonl: %v", err)
 	}
 
-	// Stub bd so we can observe the working directory for cook/wisp/bond.
+	// Stub bd so we can observe that a newly-created rig bead's formula,
+	// hook, and metadata writes all resolve to the target rig database.
 	binDir := filepath.Join(townRoot, "bin")
 	if err := os.MkdirAll(binDir, 0755); err != nil {
 		t.Fatalf("mkdir binDir: %v", err)
@@ -151,16 +157,30 @@ func TestSlingFormulaOnBeadRoutesBDCommandsToTargetRig(t *testing.T) {
 	logPath := filepath.Join(townRoot, "bd.log")
 	bdScript := `#!/bin/sh
 set -e
-echo "$(pwd)|${BEADS_DIR:-}|$*" >> "${BD_LOG}"
+log_args=""
+for arg in "$@"; do
+  case "$arg" in
+    --description=*attached_molecule:*gt-wisp-xyz*attached_formula:*mol-polecat-work*) arg="--description=<attached-molecule-and-formula-fields>" ;;
+    --description=*) arg="--description=<redacted>" ;;
+  esac
+  log_args="${log_args}${log_args:+ }${arg}"
+done
+printf '%s|%s|%s\n' "$(pwd)" "${BEADS_DIR:-}" "$log_args" >> "${BD_LOG}"
 cmd="$1"
 shift || true
-if [ "$cmd" = "--allow-stale" ]; then
+while [ "$cmd" = "--db" ] || [ "$cmd" = "--allow-stale" ]; do
+  if [ "$cmd" = "--db" ]; then
+    shift || true
+  fi
   cmd="$1"
   shift || true
-fi
+done
 case "$cmd" in
   show)
     echo '[{"title":"Test issue","status":"open","assignee":"","description":""}]'
+    ;;
+  create)
+    echo '{"id":"gt-new123","title":"New sling smoke","status":"open","assignee":""}'
     ;;
   formula)
     # formula show <name> - must output something for verifyFormulaExists
@@ -181,6 +201,9 @@ case "$cmd" in
         echo '{"root_id":"gt-wisp-xyz"}'
         ;;
     esac
+    ;;
+  update)
+    exit 0
     ;;
 esac
 exit 0
@@ -218,8 +241,6 @@ exit /b 0
 	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
 
 	t.Setenv("BD_LOG", logPath)
-	attachedLogPath := filepath.Join(townRoot, "attached-molecule.log")
-	t.Setenv("GT_TEST_ATTACHED_MOLECULE_LOG", attachedLogPath)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 	t.Setenv(EnvGTRole, "mayor")
 	t.Setenv("GT_POLECAT", "")
@@ -240,23 +261,44 @@ exit /b 0
 	prevVars := slingVars
 	prevDryRun := slingDryRun
 	prevNoConvoy := slingNoConvoy
+	prevResolveTargetAgent := resolveTargetAgentFn
 	t.Cleanup(func() {
 		slingOnTarget = prevOn
 		slingVars = prevVars
 		slingDryRun = prevDryRun
 		slingNoConvoy = prevNoConvoy
+		resolveTargetAgentFn = prevResolveTargetAgent
 	})
 
 	slingDryRun = false
 	slingNoConvoy = true
 	slingVars = nil
-	slingOnTarget = "gt-abc123"
+	slingOnTarget = ""
+	resolveTargetAgentFn = func(target string) (agentID string, pane string, hookRoot string, err error) {
+		if target != "gastown/polecats/toast" {
+			t.Fatalf("resolveTargetAgent target = %q, want gastown/polecats/toast", target)
+		}
+		return "gastown/polecats/toast", "", filepath.Join(townRoot, "gastown", "polecats", "toast", "gastown"), nil
+	}
 
 	// Prevent real tmux nudge from firing during tests (causes agent self-interruption)
 	t.Setenv("GT_TEST_NO_NUDGE", "1")
 	t.Setenv("GT_TEST_SKIP_HOOK_VERIFY", "1") // Stub bd doesn't track state
+	// Poison the ambient beads target: all mutating commands must override this
+	// with the route-resolved target rig database.
+	t.Setenv("BEADS_DIR", filepath.Join(townRoot, ".beads"))
 
-	if err := runSling(nil, []string{"mol-review"}); err != nil {
+	createOut, err := BdCmd("create", "--json", "--title=New sling smoke", "--type=task").
+		Dir(rigDir).
+		Output()
+	if err != nil {
+		t.Fatalf("create new rig bead: %v", err)
+	}
+	if !strings.Contains(string(createOut), newBeadID) {
+		t.Fatalf("created bead output = %q, want %s", createOut, newBeadID)
+	}
+
+	if err := runSling(nil, []string{newBeadID, "gastown/polecats/toast"}); err != nil {
 		t.Fatalf("runSling: %v", err)
 	}
 
@@ -277,6 +319,19 @@ exit /b 0
 	gotCook := false
 	gotWisp := false
 	gotBond := false
+	gotCreate := false
+	gotTargetDBCheck := false
+	gotHook := false
+	gotMetadata := false
+	assertTargetRig := func(kind, dir, beadsDir, args string) {
+		t.Helper()
+		if dir != wantDir {
+			t.Fatalf("bd %s ran in %q, want %q (args: %q)", kind, dir, wantDir, args)
+		}
+		if beadsDir != wantBeadsDir {
+			t.Fatalf("bd %s used BEADS_DIR %q, want %q (args: %q)", kind, beadsDir, wantBeadsDir, args)
+		}
+	}
 
 	for _, line := range logLines {
 		parts := strings.SplitN(line, "|", 3)
@@ -294,30 +349,41 @@ exit /b 0
 		args := parts[2]
 
 		switch {
+		case strings.Contains(args, "create "):
+			gotCreate = true
+			assertTargetRig("create", dir, beadsDir, args)
+		case strings.Contains(args, "--db ") && strings.Contains(args, " show "+newBeadID):
+			gotTargetDBCheck = true
+			if !strings.Contains(args, "--db "+wantBeadsDir) {
+				t.Fatalf("target rig DB check args = %q, want --db %q", args, wantBeadsDir)
+			}
 		case strings.Contains(args, "cook "):
 			gotCook = true
-			// cook doesn't need database context, runs from cwd
+			if !strings.Contains(args, "mol-polecat-work") {
+				t.Fatalf("bd cook args = %q, want mol-polecat-work", args)
+			}
+			assertTargetRig("cook", dir, beadsDir, args)
 		case strings.Contains(args, "mol wisp "):
 			gotWisp = true
-			if dir != wantDir {
-				t.Fatalf("bd mol wisp ran in %q, want %q (args: %q)", dir, wantDir, args)
+			if !strings.Contains(args, "mol-polecat-work") {
+				t.Fatalf("bd mol wisp args = %q, want mol-polecat-work", args)
 			}
-			if beadsDir != wantBeadsDir {
-				t.Fatalf("bd mol wisp used BEADS_DIR %q, want %q (args: %q)", beadsDir, wantBeadsDir, args)
-			}
+			assertTargetRig("mol wisp", dir, beadsDir, args)
 		case strings.Contains(args, "mol bond "):
 			gotBond = true
-			if dir != wantDir {
-				t.Fatalf("bd mol bond ran in %q, want %q (args: %q)", dir, wantDir, args)
-			}
-			if beadsDir != wantBeadsDir {
-				t.Fatalf("bd mol bond used BEADS_DIR %q, want %q (args: %q)", beadsDir, wantBeadsDir, args)
-			}
+			assertTargetRig("mol bond", dir, beadsDir, args)
+		case strings.Contains(args, "update "+newBeadID) && strings.Contains(args, "--status=hooked"):
+			gotHook = true
+			assertTargetRig("hook update", dir, beadsDir, args)
+		case strings.Contains(args, "update "+newBeadID) && strings.Contains(args, "--description=<attached-molecule-and-formula-fields>"):
+			gotMetadata = true
+			assertTargetRig("metadata update", dir, beadsDir, args)
 		}
 	}
 
-	if !gotCook || !gotWisp || !gotBond {
-		t.Fatalf("missing expected bd commands: cook=%v wisp=%v bond=%v (log: %q)", gotCook, gotWisp, gotBond, string(logBytes))
+	if !gotCreate || !gotTargetDBCheck || !gotCook || !gotWisp || !gotBond || !gotHook || !gotMetadata {
+		t.Fatalf("missing expected bd commands: create=%v targetDBCheck=%v cook=%v wisp=%v bond=%v hook=%v metadata=%v (log: %q)",
+			gotCreate, gotTargetDBCheck, gotCook, gotWisp, gotBond, gotHook, gotMetadata, string(logBytes))
 	}
 }
 

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -392,9 +392,11 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 
 	// Track cleanup on failure, but only if this invocation still owns the path.
 	cleanup := func() { removeRigPathIfOwned(rigPath, ownershipStamp) }
+	routeRollback := func() {}
 	success := false
 	defer func() {
 		if !success {
+			routeRollback()
 			cleanup()
 		}
 	}()
@@ -591,6 +593,9 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 			// Only error on mismatch if user explicitly provided --prefix
 			if userProvidedPrefix && strings.TrimSuffix(opts.BeadsPrefix, "-") != strings.TrimSuffix(sourcePrefix, "-") {
 				return nil, fmt.Errorf("prefix mismatch: source repo uses '%s' but --prefix '%s' was provided; use --prefix %s to match existing issues", sourcePrefix, opts.BeadsPrefix, sourcePrefix)
+			}
+			if err := beads.CheckPrefixAvailable(m.townRoot, sourcePrefix+"-", opts.Name); err != nil {
+				return nil, fmt.Errorf("prefix collision (source repo prefix %q): %w", sourcePrefix, err)
 			}
 			// Use detected prefix (overrides derived prefix)
 			opts.BeadsPrefix = sourcePrefix
@@ -866,8 +871,14 @@ Use crew for your own workspace. Polecats are for batch work dispatch.
 			Prefix: opts.BeadsPrefix + "-",
 			Path:   routePath,
 		}
-		if err := beads.AppendRoute(m.townRoot, route); err != nil {
-			fmt.Printf("  Warning: Could not update routes.jsonl: %v\n", err)
+		previousRoute, err := beads.AppendRouteIfPrefixAvailable(m.townRoot, route)
+		if err != nil {
+			return nil, fmt.Errorf("registering rig route: %w", err)
+		}
+		routeRollback = func() {
+			if err := beads.RestoreRouteIfCurrent(m.townRoot, route, previousRoute); err != nil {
+				fmt.Fprintf(os.Stderr, "  Warning: Could not roll back route %s -> %s: %v\n", route.Prefix, route.Path, err)
+			}
 		}
 	}
 

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/git"
@@ -1331,6 +1332,105 @@ func TestDetectBeadsPrefixFromConfig_NoFallbackToJSONL(t *testing.T) {
 	got := detectBeadsPrefixFromConfig(configPath)
 	if got != "" {
 		t.Errorf("detectBeadsPrefixFromConfig() = %q, want empty (should not read issues.jsonl)", got)
+	}
+}
+
+func TestAddRig_TrackedBeadsPrefixCollisionDoesNotRewriteRoute(t *testing.T) {
+	repoDir := t.TempDir()
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("# second rig\n"), 0644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("prefix: gt\nissue-prefix: gt\n"), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	for _, args := range [][]string{
+		{"git", "init", "--initial-branch=main", repoDir},
+		{"git", "-C", repoDir, "config", "user.email", "test@test.com"},
+		{"git", "-C", repoDir, "config", "user.name", "Test User"},
+		{"git", "-C", repoDir, "add", "README.md"},
+		{"git", "-C", repoDir, "add", "-f", ".beads/config.yaml"},
+		{"git", "-C", repoDir, "commit", "-m", "Initial commit with beads config"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	root, rigsConfig := setupTestTown(t)
+	if err := beads.WriteRoutes(filepath.Join(root, ".beads"), []beads.Route{
+		{Prefix: "gt-", Path: "gastown/mayor/rig"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+	manager := NewManager(root, rigsConfig, git.NewGit(root))
+
+	_, err := manager.AddRig(AddRigOptions{
+		Name:          "secondrig",
+		GitURL:        repoDir,
+		SkipDoltCheck: true,
+	})
+	if err == nil {
+		t.Fatal("AddRig succeeded, want tracked source prefix collision")
+	}
+	if got := err.Error(); !strings.Contains(got, "source repo prefix") || !strings.Contains(got, "already used") {
+		t.Fatalf("AddRig error = %q, want source prefix collision", got)
+	}
+
+	routes, err := beads.LoadRoutes(filepath.Join(root, ".beads"))
+	if err != nil {
+		t.Fatalf("load routes: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("routes count = %d, want 1: %#v", len(routes), routes)
+	}
+	if routes[0].Prefix != "gt-" || routes[0].Path != "gastown/mayor/rig" {
+		t.Fatalf("route = %#v, want gt- -> gastown/mayor/rig", routes[0])
+	}
+	if _, err := os.Stat(filepath.Join(root, "secondrig")); !os.IsNotExist(err) {
+		t.Fatalf("secondrig directory still exists after failed add: %v", err)
+	}
+}
+
+func TestAddRig_RollsBackRouteWhenRegistrationFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-based bd shim not reliable on Windows CI")
+	}
+
+	fakeBDForAddRig(t)
+
+	root, rigsConfig := setupTestTown(t)
+	if err := os.WriteFile(filepath.Join(root, "mayor"), []byte("not a directory\n"), 0644); err != nil {
+		t.Fatalf("write mayor blocker: %v", err)
+	}
+	manager := NewManager(root, rigsConfig, git.NewGit(root))
+	repoDir := createTestGitRepoForRig(t, "rollbackrepo")
+
+	_, err := manager.AddRig(AddRigOptions{
+		Name:          "rollbackrig",
+		GitURL:        repoDir,
+		BeadsPrefix:   "rb",
+		SkipDoltCheck: true,
+	})
+	if err == nil {
+		t.Fatal("AddRig succeeded, want rigs.json registration failure")
+	}
+	if got := err.Error(); !strings.Contains(got, "registering rig in rigs.json") {
+		t.Fatalf("AddRig error = %q, want rigs.json registration failure", got)
+	}
+
+	routes, err := beads.LoadRoutes(filepath.Join(root, ".beads"))
+	if err != nil {
+		t.Fatalf("load routes: %v", err)
+	}
+	for _, route := range routes {
+		if route.Prefix == "rb-" {
+			t.Fatalf("route was not rolled back after failed add: %#v", routes)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds same-rig guarded route registration with flock serialization and rollback so tracked source `.beads/config.yaml` prefixes cannot hijack another rig's route.
- Keeps existing source-of-truth routing semantics and direct target-rig sling validation; no repo-specific `do-` or `coder_dotfiles` hardcoding.
- Replaces the narrow formula-on-bead route test with a smoke that creates a rig-prefixed bead and immediately slings it, asserting create, target DB check, formula wisp/bond, hook, and metadata updates all use the route-resolved target rig DB.

## Supersedes
- Supersedes #4085, #4086, and #4088 with one collapsed fork PR.
- Cherry-picked/reimplemented useful pieces from #4086 and #4088.
- Dropped #4085's doctor/design layer from this implementation because it is diagnostic-only and not needed for the failed do-prefix sling class.

## RCA Evidence
- Completed 15 read-only research passes across current target/main, open PR metadata/files/diffs, merged predecessors #3979/#3968/#4020/#3987, and current route/sling/AddRig code.
- Completed pre-implementation reviews for route ownership, AddRig tracked prefix drift, target rig DB guards, bd create routing semantics, and duplicate validation risks.
- Rejected duplicate/fragile paths: no stale `--allow-stale` compatibility changes, no bd create bandaid, no duplicate sling validation layer, no hardcoded repo/prefix handling.

## Validation
- PASS: `make build`
- PASS: `go test ./internal/beads -run 'TestAppendRouteIfPrefixAvailable|TestCheckPrefixAvailable|TestResolveBeadsDirForID|TestGetPrefixForRig' -count=1`
- PASS: `go test ./internal/rig -run 'TestAddRig_TrackedBeadsPrefixCollisionDoesNotRewriteRoute|TestAddRig_RollsBackRouteWhenRegistrationFails|TestAddRig_TrackedBeads|TestAddRig_UpstreamURL|TestAddRig_BranchFlag' -count=1`
- PASS: `go test ./internal/cmd -run '^TestSlingNewlyCreatedRigBeadRoutesBDCommandsToTargetRig$' -count=1 -v`
- NOTE: `go test ./...` was attempted and still fails on existing unrelated suite failures across `internal/cmd`, `internal/doltserver`, `internal/polecat`, `internal/rig`, and `internal/tmux`.

Issue: gt-rca-routing-convergence