### PR TITLE
fix: supersede PR workflow policy guard

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -1,7 +1,7 @@
 #!/bin/bash
-# Block PRs by preventing pushes to arbitrary feature branches.
-# Gas Town agents push to main (crew) or polecat/* branches (polecats).
-# PRs are for external contributors only.
+# Enforce the active landing policy.
+# Internal MQ/direct workflows may push approved branches; fork-PR workflows may
+# push feature branches but must not push directly to the upstream default branch.
 #
 # Also enforces integration branch landing guardrails: pushes to the default
 # branch that introduce integration branch content are blocked unless
@@ -13,6 +13,7 @@
 # 2. origin/master (if it exists)
 # 3. origin/main (final fallback)
 default_branch=$(git symbolic-ref refs/remotes/origin/HEAD 2>/dev/null | sed 's#refs/remotes/origin/##')
+push_remote="${1:-origin}"
 if [[ -z "$default_branch" ]]; then
   if git rev-parse --verify origin/master &>/dev/null; then
     default_branch=master
@@ -21,8 +22,44 @@ if [[ -z "$default_branch" ]]; then
   fi
 fi
 
+has_fork_pr_remote=0
+origin_url=$(git remote get-url origin 2>/dev/null || true)
+origin_push_url=$(git remote get-url --push origin 2>/dev/null || true)
+fork_url=$(git remote get-url fork 2>/dev/null || true)
+upstream_url=$(git remote get-url upstream 2>/dev/null || true)
+
+if [[ -n "$fork_url" || -n "$upstream_url" ]]; then
+  has_fork_pr_remote=1
+elif [[ -n "$origin_url" && -n "$origin_push_url" && "$origin_url" != "$origin_push_url" ]]; then
+  has_fork_pr_remote=1
+fi
+
+is_fork_push_target=0
+push_remote_url=$(git remote get-url "$push_remote" 2>/dev/null || true)
+case "$push_remote" in
+  fork)
+    is_fork_push_target=1
+    ;;
+  origin)
+    if [[ -n "$origin_url" && -n "$origin_push_url" && "$origin_url" != "$origin_push_url" ]]; then
+      is_fork_push_target=1
+    elif [[ -n "$upstream_url" && -n "$origin_url" && "$origin_url" != "$upstream_url" ]]; then
+      # Traditional contributor setup: origin=fork, upstream=maintainer.
+      is_fork_push_target=1
+    fi
+    ;;
+  upstream)
+    is_fork_push_target=0
+    ;;
+  *)
+    if [[ -n "$push_remote_url" && "$push_remote_url" != "$origin_url" && "$push_remote_url" != "$upstream_url" ]]; then
+      is_fork_push_target=1
+    fi
+    ;;
+esac
+
 # Allowed patterns:
-#   <default_branch>, beads-sync  - Direct work branches
+#   <default_branch>, beads-sync  - Direct work branches (unless fork-PR mode)
 #   polecat/*                     - Polecat working branches (Refinery merges these)
 #   integration/*                 - Integration branches (created by gt mq integration)
 
@@ -35,14 +72,21 @@ while read local_ref local_sha remote_ref remote_sha; do
   branch="${remote_ref#refs/heads/}"
 
   case "$branch" in
-    "${default_branch}"|beads-sync|polecat/*|integration/*)
+    "${default_branch}")
+      if [[ "$has_fork_pr_remote" == "1" && "$GT_INTEGRATION_LAND" != "1" && "$GT_ALLOW_DIRECT_MAIN" != "1" ]]; then
+        echo "ERROR: Direct push to $default_branch blocked in fork-PR workflow."
+        echo ""
+        echo "Push a feature branch to your fork and open a PR instead."
+        echo "Use GT_ALLOW_DIRECT_MAIN=1 only for intentional maintainer/release operations."
+        exit 1
+      fi
+      ;;
+    beads-sync|polecat/*|integration/*)
       # Allowed branches
       ;;
     *)
-      # Allow feature branches when contributing to upstream (fork workflow).
-      # If an 'upstream' remote exists, this is a contribution setup where
-      # feature branches are needed for PRs. See: #848
-      if ! git remote get-url upstream &>/dev/null; then
+      # Allow feature branches only when pushing to the configured fork/non-maintainer target.
+      if [[ "$has_fork_pr_remote" != "1" || "$is_fork_push_target" != "1" ]]; then
         echo "ERROR: Invalid branch for Gas Town agents."
         echo ""
         echo "Blocked push to: $branch"
@@ -53,7 +97,7 @@ while read local_ref local_sha remote_ref remote_sha; do
         echo "  integration/* - Integration branches"
         echo "  beads-sync  - Beads synchronization"
         echo ""
-        echo "Do NOT create PRs. Push to main or let Refinery merge polecat work."
+        echo "Feature branches require pushing to a fork/non-maintainer remote. Otherwise use approved direct/MQ branches."
         exit 1
       fi
       ;;

--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -92,7 +92,7 @@ while read local_ref local_sha remote_ref remote_sha; do
         echo "Blocked push to: $branch"
         echo ""
         echo "Allowed branches:"
-        echo "  ${default_branch}        - Crew workers push here directly"
+        echo "  ${default_branch}        - Allowed only when the active workflow permits it"
         echo "  polecat/*   - Polecat working branches"
         echo "  integration/* - Integration branches"
         echo "  beads-sync  - Beads synchronization"

--- a/.githooks/pre-push_test.sh
+++ b/.githooks/pre-push_test.sh
@@ -48,7 +48,7 @@ setup_repos() {
 run_hook() {
   # Simulate pre-push stdin: local_ref local_sha remote_ref remote_sha
   local local_ref=$1 local_sha=$2 remote_ref=$3 remote_sha=$4
-  echo "$local_ref $local_sha $remote_ref $remote_sha" | bash "$HOOK" "origin" 2>&1
+  echo "$local_ref $local_sha $remote_ref $remote_sha" | bash "$HOOK" "${PUSH_REMOTE:-origin}" 2>&1
 }
 
 get_sha() {
@@ -82,15 +82,15 @@ assert_block() {
 echo "=== Pre-push hook test suite ==="
 echo ""
 
-# Test 1: Normal push to default branch (no integration content)
-echo "Test 1: Normal push to default branch (no integration content)"
+# Test 1: Normal push to default branch without fork workflow (no integration content)
+echo "Test 1: Normal push to default branch without fork workflow (no integration content)"
 setup_repos
 cd "$TMPDIR/local"
 remote_sha=$(get_sha HEAD)
 echo "change1" >> file.txt
 git add file.txt && git commit -m "normal change" >/dev/null 2>&1
 local_sha=$(get_sha HEAD)
-assert_pass "Normal push allowed" run_hook "refs/heads/$DEFAULT_BRANCH" "$local_sha" "refs/heads/$DEFAULT_BRANCH" "$remote_sha"
+assert_pass "Normal direct push allowed without fork workflow" run_hook "refs/heads/$DEFAULT_BRANCH" "$local_sha" "refs/heads/$DEFAULT_BRANCH" "$remote_sha"
 cleanup
 
 # Test 2: Push to polecat/* branch
@@ -130,12 +130,53 @@ cleanup
 echo "Test 5: Push to feature/* with upstream remote"
 setup_repos
 cd "$TMPDIR/local"
+git init --bare "$TMPDIR/upstream.git" >/dev/null 2>&1
+git remote set-url origin "$TMPDIR/fork.git" >/dev/null 2>&1
 git remote add upstream "$TMPDIR/remote.git" >/dev/null 2>&1
 git checkout -b feature/thing >/dev/null 2>&1
 echo "feature" >> file.txt
 git add file.txt && git commit -m "feature" >/dev/null 2>&1
 local_sha=$(get_sha HEAD)
 assert_pass "Feature branch allowed (upstream exists)" run_hook "refs/heads/feature/thing" "$local_sha" "refs/heads/feature/thing" "0000000000000000000000000000000000000000"
+cleanup
+
+# Test 5b: Push to feature/* with fork remote (allowed)
+echo "Test 5b: Push to feature/* with fork remote"
+setup_repos
+cd "$TMPDIR/local"
+git init --bare "$TMPDIR/fork.git" >/dev/null 2>&1
+git remote add fork "$TMPDIR/fork.git" >/dev/null 2>&1
+git checkout -b feature/fork-thing >/dev/null 2>&1
+echo "feature" >> file.txt
+git add file.txt && git commit -m "feature" >/dev/null 2>&1
+local_sha=$(get_sha HEAD)
+PUSH_REMOTE=fork assert_pass "Feature branch allowed (push to fork)" run_hook "refs/heads/feature/fork-thing" "$local_sha" "refs/heads/feature/fork-thing" "0000000000000000000000000000000000000000"
+cleanup
+
+# Test 5c: Push to feature/* to origin while fork remote exists (blocked)
+echo "Test 5c: Push to feature/* to origin while fork remote exists"
+setup_repos
+cd "$TMPDIR/local"
+git init --bare "$TMPDIR/fork.git" >/dev/null 2>&1
+git remote add fork "$TMPDIR/fork.git" >/dev/null 2>&1
+git checkout -b feature/origin-thing >/dev/null 2>&1
+echo "feature" >> file.txt
+git add file.txt && git commit -m "feature" >/dev/null 2>&1
+local_sha=$(get_sha HEAD)
+assert_block "Feature branch to origin blocked when fork exists" run_hook "refs/heads/feature/origin-thing" "$local_sha" "refs/heads/feature/origin-thing" "0000000000000000000000000000000000000000"
+cleanup
+
+# Test 5d: Push to default branch with fork remote (blocked)
+echo "Test 5d: Push to default branch with fork remote"
+setup_repos
+cd "$TMPDIR/local"
+git init --bare "$TMPDIR/fork.git" >/dev/null 2>&1
+git remote add fork "$TMPDIR/fork.git" >/dev/null 2>&1
+remote_sha=$(get_sha HEAD)
+echo "change fork main" >> file.txt
+git add file.txt && git commit -m "fork main change" >/dev/null 2>&1
+local_sha=$(get_sha HEAD)
+assert_block "Default branch blocked in fork workflow" run_hook "refs/heads/$DEFAULT_BRANCH" "$local_sha" "refs/heads/$DEFAULT_BRANCH" "$remote_sha"
 cleanup
 
 # Test 6: Push to default branch with integration merge (no env var) — BLOCKED

--- a/.github/workflows/block-internal-prs.yml
+++ b/.github/workflows/block-internal-prs.yml
@@ -2,7 +2,9 @@ name: Block Internal PRs
 
 on:
   pull_request:
-    types: [opened, reopened]
+    # Re-run on edited so retargeting an internal PR to the default branch is
+    # blocked even if the PR originally targeted an integration branch.
+    types: [opened, reopened, edited, synchronize]
 
 permissions: {}
 

--- a/.github/workflows/block-internal-prs.yml
+++ b/.github/workflows/block-internal-prs.yml
@@ -9,8 +9,12 @@ permissions: {}
 jobs:
   block-internal-prs:
     name: Block Internal PRs
-    # Only run if PR is from the same repo (not a fork)
-    if: github.event.pull_request.head.repo.full_name == github.repository && github.actor != 'renovate[bot]'
+    # Only block same-repo PRs to the default branch. Integration branch PRs/MRs
+    # are handled by the Gas Town merge queue and must not get default-branch advice.
+    if: >
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      github.event.pull_request.base.ref == github.event.repository.default_branch &&
+      github.actor != 'renovate[bot]'
     runs-on: ubuntu-latest
     permissions:
       issues: write
@@ -22,21 +26,17 @@ jobs:
           script: |
             const prNumber = context.issue.number;
             const branch = context.payload.pull_request.head.ref;
+            const baseBranch = context.payload.pull_request.base.ref;
 
             const body = [
-              '**Internal PRs are not allowed.**',
+              '**Internal PRs to the default branch are not allowed.**',
               '',
-              'Gas Town agents push directly to main. PRs are for external contributors only.',
+              'Gas Town agents must use the configured merge workflow for internal work.',
               '',
-              'To land your changes:',
-              '```bash',
-              'git checkout main',
-              'git merge ' + branch,
-              'git push origin main',
-              'git push origin --delete ' + branch,
-              '```',
+              'Polecats: run `gt done` so Refinery merges `' + branch + '` to the configured target branch.',
+              'Crew/maintainers: follow the current role workflow instead of opening an internal PR to `' + baseBranch + '`.',
               '',
-              'See CLAUDE.md: "Crew workers push directly to main. No feature branches. NEVER create PRs."'
+              'Integration branch work should flow through the merge queue target, not direct default-branch PRs or pushes.'
             ].join('\n');
 
             await github.rest.issues.createComment({
@@ -53,4 +53,4 @@ jobs:
               state: 'closed'
             });
 
-            core.setFailed('Internal PR blocked. Push directly to main instead.');
+            core.setFailed('Internal PR blocked. Use the configured Gas Town merge workflow.');

--- a/internal/cmd/convoy_test_helpers_test.go
+++ b/internal/cmd/convoy_test_helpers_test.go
@@ -304,7 +304,7 @@ func (d *testDAG) BdStubScript() string {
 	sb.WriteString(fmt.Sprintf("    echo '%s'\n", convoyListJSON))
 	sb.WriteString("    exit 0\n")
 	sb.WriteString("    ;;\n")
-	sb.WriteString("  list\\ --json\\ --limit=0|list\\ --json\\ --limit=0\\ --all|list\\ --json\\ --limit=0\\ --status=*)\n")
+	sb.WriteString("  list\\ --json\\ --limit=0*|list\\ --json\\ --limit=0\\ --all*|list\\ --json\\ --limit=0\\ --status=*)\n")
 	sb.WriteString("    echo '[]'\n")
 	sb.WriteString("    exit 0\n")
 	sb.WriteString("    ;;\n")

--- a/internal/cmd/statusline.go
+++ b/internal/cmd/statusline.go
@@ -103,15 +103,15 @@ func runStatusLine(cmd *cobra.Command, args []string) error {
 
 	// Refinery status line
 	if role == "refinery" || strings.HasSuffix(statusLineSession, "-refinery") {
-		return runRefineryStatusLine(t, rigName)
+		return runRefineryStatusLine(rigName)
 	}
 
 	// Crew/Polecat status line
-	return runWorkerStatusLine(t, statusLineSession, rigName, polecat, crew, issue)
+	return runWorkerStatusLine(statusLineSession, rigName, polecat, crew, issue)
 }
 
 // runWorkerStatusLine outputs status for crew or polecat sessions.
-func runWorkerStatusLine(t *tmux.Tmux, session, rigName, polecat, crew, issue string) error {
+func runWorkerStatusLine(session, rigName, polecat, crew, issue string) error {
 	// Determine agent type and identity
 	var icon string
 	if polecat != "" {
@@ -438,7 +438,7 @@ func runWitnessStatusLine(t *tmux.Tmux, rigName string) error {
 
 // runRefineryStatusLine outputs status for a refinery session.
 // Shows: MQ length, current item, hook or mail preview
-func runRefineryStatusLine(t *tmux.Tmux, rigName string) error {
+func runRefineryStatusLine(rigName string) error {
 	if rigName == "" {
 		// Try to extract from session name: <prefix>-refinery
 		if identity, err := session.ParseSessionName(statusLineSession); err == nil && identity.Role == session.RoleRefinery {

--- a/internal/cmd/statusline.go
+++ b/internal/cmd/statusline.go
@@ -107,11 +107,11 @@ func runStatusLine(cmd *cobra.Command, args []string) error {
 	}
 
 	// Crew/Polecat status line
-	return runWorkerStatusLine(statusLineSession, rigName, polecat, crew, issue)
+	return runWorkerStatusLine(polecat, crew, issue)
 }
 
 // runWorkerStatusLine outputs status for crew or polecat sessions.
-func runWorkerStatusLine(session, rigName, polecat, crew, issue string) error {
+func runWorkerStatusLine(polecat, crew, issue string) error {
 	// Determine agent type and identity
 	var icon string
 	if polecat != "" {

--- a/internal/cmd/statusline_test.go
+++ b/internal/cmd/statusline_test.go
@@ -14,6 +14,7 @@ func setupCmdTestRegistry(t *testing.T) {
 	t.Helper()
 	registry := session.NewPrefixRegistry()
 	registry.Register("gt", "gastown")
+	registry.Register("mr", "myrig")
 	registry.Register("do", "coder_dotfiles")
 	old := session.DefaultRegistry()
 	session.SetDefaultRegistry(registry)

--- a/internal/cmd/tap_guard.go
+++ b/internal/cmd/tap_guard.go
@@ -19,7 +19,7 @@ is violated. They're called before the tool runs, preventing the
 forbidden operation entirely.
 
 Available guards:
-  pr-workflow        - Block PR creation and feature branches
+  pr-workflow        - Enforce configured PR/direct workflow
   bd-init            - Block bd init in wrong directories
   mol-patrol         - Block mol patrol from agent contexts
   dangerous-command  - Block rm -rf, force push, hard reset, git clean
@@ -38,11 +38,12 @@ Example hook configuration:
 
 var tapGuardPRWorkflowCmd = &cobra.Command{
 	Use:   "pr-workflow",
-	Short: "Block PR creation and feature branches",
-	Long: `Block PR workflow operations in Gas Town.
+	Short: "Enforce configured PR/direct workflow",
+	Long: `Enforce PR workflow operations in Gas Town.
 
-Gas Town workers push directly to main. PRs add friction that breaks
-the autonomous execution model (GUPP principle).
+Gas Town supports both internal merge-queue work and fork-PR sweep work.
+This guard blocks ad-hoc PR/branch operations only when no fork/upstream
+workflow is configured.
 
 This guard blocks:
   - gh pr create
@@ -50,14 +51,11 @@ This guard blocks:
   - git switch -c (feature branches)
 
 Exit codes:
-  0 - Operation allowed (not in Gas Town agent context, not maintainer origin)
-  2 - Operation BLOCKED (in agent context OR maintainer origin)
+  0 - Operation allowed (fork/upstream workflow configured, or not an agent)
+  2 - Operation BLOCKED (agent context without configured PR workflow)
 
-The guard blocks in two scenarios:
-  1. Running as a Gas Town agent (crew, polecat, witness, etc.)
-  2. Origin remote is steveyegge/gastown (maintainer should push directly)
-
-Humans running outside Gas Town with a fork origin can still use PRs.`,
+Humans and agents with a fork/upstream remote can use PRs. Direct pushes
+to main are controlled by the git pre-push hook.`,
 	RunE: runTapGuardPRWorkflow,
 }
 
@@ -67,42 +65,56 @@ func init() {
 }
 
 func runTapGuardPRWorkflow(cmd *cobra.Command, args []string) error {
+	if hasForkPRWorkflow() {
+		return nil
+	}
+
 	// Check if we're in a Gas Town agent context
 	if isGasTownAgentContext() {
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "╔══════════════════════════════════════════════════════════════════╗")
-		fmt.Fprintln(os.Stderr, "║  ❌ PR WORKFLOW BLOCKED                                          ║")
+		fmt.Fprintln(os.Stderr, "║  ❌ PR WORKFLOW NOT CONFIGURED                                   ║")
 		fmt.Fprintln(os.Stderr, "╠══════════════════════════════════════════════════════════════════╣")
-		fmt.Fprintln(os.Stderr, "║  Gas Town workers push directly to main. PRs are forbidden.     ║")
+		fmt.Fprintln(os.Stderr, "║  No fork/upstream remote is configured for PR workflow.         ║")
 		fmt.Fprintln(os.Stderr, "║                                                                  ║")
 		fmt.Fprintln(os.Stderr, "║  Instead of:  gh pr create / git checkout -b / git switch -c    ║")
-		fmt.Fprintln(os.Stderr, "║  Do this:     git add . && git commit && git push origin main   ║")
+		fmt.Fprintln(os.Stderr, "║  Do this:     use gt done or configure a fork/upstream remote   ║")
 		fmt.Fprintln(os.Stderr, "║                                                                  ║")
-		fmt.Fprintln(os.Stderr, "║  Why? PRs add friction that breaks autonomous execution.        ║")
-		fmt.Fprintln(os.Stderr, "║  See: ~/gt/docs/PRIMING.md (GUPP principle)                     ║")
+		fmt.Fprintln(os.Stderr, "║  Direct pushes to main are blocked separately by pre-push.      ║")
 		fmt.Fprintln(os.Stderr, "╚══════════════════════════════════════════════════════════════════╝")
 		fmt.Fprintln(os.Stderr, "")
 		return NewSilentExit(2) // Exit 2 = BLOCK in Claude Code hooks
 	}
 
-	// Check if origin is the maintainer's repo (steveyegge/gastown)
-	if isMaintainerOrigin() {
-		fmt.Fprintln(os.Stderr, "")
-		fmt.Fprintln(os.Stderr, "╔══════════════════════════════════════════════════════════════════╗")
-		fmt.Fprintln(os.Stderr, "║  ❌ PR BLOCKED - MAINTAINER ORIGIN                               ║")
-		fmt.Fprintln(os.Stderr, "╠══════════════════════════════════════════════════════════════════╣")
-		fmt.Fprintln(os.Stderr, "║  Your origin is steveyegge/gastown - push directly to main.     ║")
-		fmt.Fprintln(os.Stderr, "║  PRs are for external contributors, not maintainers.            ║")
-		fmt.Fprintln(os.Stderr, "║                                                                  ║")
-		fmt.Fprintln(os.Stderr, "║  Instead of:  gh pr create                                      ║")
-		fmt.Fprintln(os.Stderr, "║  Do this:     git push origin main                              ║")
-		fmt.Fprintln(os.Stderr, "╚══════════════════════════════════════════════════════════════════╝")
-		fmt.Fprintln(os.Stderr, "")
-		return NewSilentExit(2) // Exit 2 = BLOCK in Claude Code hooks
-	}
-
-	// Not in Gas Town context and not maintainer origin - allow PRs
+	// Humans outside Gas Town may use their repository's normal workflow.
 	return nil
+}
+
+func hasForkPRWorkflow() bool {
+	if remoteExists("fork") || remoteExists("upstream") {
+		return true
+	}
+	originURL := remoteURL("origin", false)
+	originPushURL := remoteURL("origin", true)
+	return originURL != "" && originPushURL != "" && originPushURL != originURL
+}
+
+func remoteExists(name string) bool {
+	return remoteURL(name, false) != ""
+}
+
+func remoteURL(name string, push bool) string {
+	args := []string{"remote", "get-url"}
+	if push {
+		args = append(args, "--push")
+	}
+	args = append(args, name)
+	cmd := exec.Command("git", args...)
+	output, err := cmd.Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(output))
 }
 
 // isGasTownAgentContext returns true if we're running as a Gas Town managed agent.
@@ -136,19 +148,4 @@ func isGasTownAgentContext() bool {
 	}
 
 	return false
-}
-
-// isMaintainerOrigin returns true if the origin remote points to the maintainer's repo.
-// This prevents the maintainer from accidentally creating PRs in their own repo.
-func isMaintainerOrigin() bool {
-	cmd := exec.Command("git", "remote", "get-url", "origin")
-	output, err := cmd.Output()
-	if err != nil {
-		return false
-	}
-	url := strings.TrimSpace(string(output))
-	// Match both HTTPS and SSH URL formats:
-	// - https://github.com/steveyegge/gastown.git
-	// - git@github.com:steveyegge/gastown.git
-	return strings.Contains(url, "steveyegge/gastown")
 }

--- a/internal/cmd/tap_guard.go
+++ b/internal/cmd/tap_guard.go
@@ -42,8 +42,9 @@ var tapGuardPRWorkflowCmd = &cobra.Command{
 	Long: `Enforce PR workflow operations in Gas Town.
 
 Gas Town supports both internal merge-queue work and fork-PR sweep work.
-This guard blocks ad-hoc PR/branch operations only when no fork/upstream
-workflow is configured.
+This guard uses fork/upstream remote topology only as a narrow prerequisite
+for allowing PR/branch commands; formula, role, and pre-push policy still
+decide where work may land.
 
 This guard blocks:
   - gh pr create
@@ -51,11 +52,11 @@ This guard blocks:
   - git switch -c (feature branches)
 
 Exit codes:
-  0 - Operation allowed (fork/upstream workflow configured, or not an agent)
-  2 - Operation BLOCKED (agent context without configured PR workflow)
+  0 - Operation allowed (fork/upstream prerequisite present, or not an agent)
+  2 - Operation BLOCKED (agent context without fork/upstream prerequisite)
 
-Humans and agents with a fork/upstream remote can use PRs. Direct pushes
-to main are controlled by the git pre-push hook.`,
+Humans and agents with a fork/upstream remote can run PR commands. Direct
+pushes to the default branch are controlled by the git pre-push hook.`,
 	RunE: runTapGuardPRWorkflow,
 }
 
@@ -65,7 +66,7 @@ func init() {
 }
 
 func runTapGuardPRWorkflow(cmd *cobra.Command, args []string) error {
-	if hasForkPRWorkflow() {
+	if hasForkPRPrerequisite() {
 		return nil
 	}
 
@@ -73,14 +74,14 @@ func runTapGuardPRWorkflow(cmd *cobra.Command, args []string) error {
 	if isGasTownAgentContext() {
 		fmt.Fprintln(os.Stderr, "")
 		fmt.Fprintln(os.Stderr, "╔══════════════════════════════════════════════════════════════════╗")
-		fmt.Fprintln(os.Stderr, "║  ❌ PR WORKFLOW NOT CONFIGURED                                   ║")
+		fmt.Fprintln(os.Stderr, "║  ❌ PR WORKFLOW PREREQUISITE MISSING                             ║")
 		fmt.Fprintln(os.Stderr, "╠══════════════════════════════════════════════════════════════════╣")
 		fmt.Fprintln(os.Stderr, "║  No fork/upstream remote is configured for PR workflow.         ║")
 		fmt.Fprintln(os.Stderr, "║                                                                  ║")
 		fmt.Fprintln(os.Stderr, "║  Instead of:  gh pr create / git checkout -b / git switch -c    ║")
 		fmt.Fprintln(os.Stderr, "║  Do this:     use gt done or configure a fork/upstream remote   ║")
 		fmt.Fprintln(os.Stderr, "║                                                                  ║")
-		fmt.Fprintln(os.Stderr, "║  Direct pushes to main are blocked separately by pre-push.      ║")
+		fmt.Fprintln(os.Stderr, "║  Default-branch pushes are blocked separately by pre-push.      ║")
 		fmt.Fprintln(os.Stderr, "╚══════════════════════════════════════════════════════════════════╝")
 		fmt.Fprintln(os.Stderr, "")
 		return NewSilentExit(2) // Exit 2 = BLOCK in Claude Code hooks
@@ -90,7 +91,7 @@ func runTapGuardPRWorkflow(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func hasForkPRWorkflow() bool {
+func hasForkPRPrerequisite() bool {
 	if remoteExists("fork") || remoteExists("upstream") {
 		return true
 	}

--- a/internal/cmd/tap_guard_test.go
+++ b/internal/cmd/tap_guard_test.go
@@ -1,0 +1,99 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+func TestTapGuardPRWorkflowAllowsAgentWithForkRemote(t *testing.T) {
+	dir := initTapGuardGitRepo(t, "https://github.com/example/upstream.git")
+	runGit(t, dir, "remote", "add", "fork", "https://github.com/example/fork.git")
+	withTapGuardCwd(t, dir)
+	t.Setenv("GT_POLECAT", "toast")
+
+	if err := runTapGuardPRWorkflow(nil, nil); err != nil {
+		t.Fatalf("runTapGuardPRWorkflow() = %v, want allowed", err)
+	}
+}
+
+func TestTapGuardPRWorkflowBlocksAgentWithoutForkRemote(t *testing.T) {
+	dir := initTapGuardGitRepo(t, "https://github.com/example/upstream.git")
+	withTapGuardCwd(t, dir)
+	t.Setenv("GT_POLECAT", "toast")
+
+	if err := runTapGuardPRWorkflow(nil, nil); err == nil {
+		t.Fatal("runTapGuardPRWorkflow() = nil, want block without fork/upstream workflow")
+	}
+}
+
+func TestTapGuardPRWorkflowAllowsHumanWithoutForkRemote(t *testing.T) {
+	dir := initTapGuardGitRepo(t, "https://github.com/example/upstream.git")
+	withTapGuardCwd(t, dir)
+	clearTapGuardAgentEnv(t)
+
+	if err := runTapGuardPRWorkflow(nil, nil); err != nil {
+		t.Fatalf("runTapGuardPRWorkflow() = %v, want allowed outside agent context", err)
+	}
+}
+
+func TestTapGuardPRWorkflowAllowsSplitOriginPushURL(t *testing.T) {
+	dir := initTapGuardGitRepo(t, "https://github.com/example/upstream.git")
+	runGit(t, dir, "remote", "set-url", "--push", "origin", "https://github.com/example/fork.git")
+	withTapGuardCwd(t, dir)
+	t.Setenv("GT_POLECAT", "toast")
+
+	if err := runTapGuardPRWorkflow(nil, nil); err != nil {
+		t.Fatalf("runTapGuardPRWorkflow() = %v, want allowed with split pushurl", err)
+	}
+}
+
+func TestTapGuardPRWorkflowAllowsUpstreamRemote(t *testing.T) {
+	dir := initTapGuardGitRepo(t, "https://github.com/example/fork.git")
+	runGit(t, dir, "remote", "add", "upstream", "https://github.com/example/upstream.git")
+	withTapGuardCwd(t, dir)
+	t.Setenv("GT_POLECAT", "toast")
+
+	if err := runTapGuardPRWorkflow(nil, nil); err != nil {
+		t.Fatalf("runTapGuardPRWorkflow() = %v, want allowed with upstream remote", err)
+	}
+}
+
+func initTapGuardGitRepo(t *testing.T, origin string) string {
+	t.Helper()
+	dir := t.TempDir()
+	runGit(t, dir, "init")
+	runGit(t, dir, "remote", "add", "origin", origin)
+	return dir
+}
+
+func runGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+func withTapGuardCwd(t *testing.T, dir string) {
+	t.Helper()
+	old, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(filepath.Clean(dir)); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() {
+		_ = os.Chdir(old)
+	})
+}
+
+func clearTapGuardAgentEnv(t *testing.T) {
+	t.Helper()
+	for _, env := range []string{"GT_POLECAT", "GT_CREW", "GT_WITNESS", "GT_REFINERY", "GT_MAYOR", "GT_DEACON"} {
+		t.Setenv(env, "")
+	}
+}

--- a/internal/cmd/tap_list.go
+++ b/internal/cmd/tap_list.go
@@ -48,7 +48,7 @@ func runTapList(cmd *cobra.Command, args []string) error {
 		{
 			name:        "pr-workflow",
 			kind:        "guard",
-			description: "Block PR creation and feature branches",
+			description: "Enforce configured PR/direct workflow",
 			event:       "PreToolUse",
 			matchers:    []string{"Bash(gh pr create*)", "Bash(git checkout -b*)", "Bash(git switch -c*)"},
 			implemented: true,

--- a/internal/hooks/templates/omp/gastown-hook.ts
+++ b/internal/hooks/templates/omp/gastown-hook.ts
@@ -7,7 +7,7 @@
 //   session_start       → gt prime --hook (capture context)
 //   before_agent_start  → inject captured context + check mail every prompt
 //   session.compacting  → inject compaction recovery instructions
-//   tool_call           → gt tap guard pr-workflow (on git push/pr create)
+//   tool_call           → gt tap guard pr-workflow (on pr create/branch create)
 //   session_shutdown    → gt costs record
 //
 // Loaded via: omp --hook gastown-hook.ts
@@ -104,14 +104,14 @@ export default function (pi) {
     }
   });
 
-  // PreToolUse — guard dangerous git operations via gt tap.
+  // PreToolUse — guard PR workflow operations via gt tap.
   pi.on("tool_call", async (event, ctx) => {
     if (event.toolName === "bash" && event.input?.command) {
       const cmd = event.input.command;
       if (
-        cmd.includes("git push") ||
         cmd.includes("gh pr create") ||
-        cmd.includes("git checkout -b")
+        cmd.includes("git checkout -b") ||
+        cmd.includes("git switch -c")
       ) {
         try {
           const result = await pi.exec("gt", ["tap", "guard", "pr-workflow"]);

--- a/internal/hooks/templates/pi/gastown-hooks.js
+++ b/internal/hooks/templates/pi/gastown-hooks.js
@@ -5,7 +5,7 @@
 // Events mapped:
 //   session_start       → gt prime --hook (capture context)
 //   before_agent_start  → inject captured context + check mail every prompt
-//   tool_call           → gt tap guard pr-workflow (on git push/pr create)
+//   tool_call           → gt tap guard pr-workflow (on pr create/branch create)
 //   session_shutdown    → gt costs record
 //
 // Enhancement over upstream: mail is checked on every prompt (throttled to
@@ -89,14 +89,14 @@ export default (pi) => {
     }
   });
 
-  // PreToolUse equivalent — guard dangerous git operations
+  // PreToolUse equivalent — guard PR workflow operations
   pi.on("tool_call", async (event, context) => {
     if (event.toolName === "bash" && event.input?.command) {
       const cmd = event.input.command;
       if (
-        cmd.includes("git push") ||
         cmd.includes("gh pr create") ||
-        cmd.includes("git checkout -b")
+        cmd.includes("git checkout -b") ||
+        cmd.includes("git switch -c")
       ) {
         try {
           const result = await pi.exec("gt", ["tap", "guard", "pr-workflow"]);

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -2217,12 +2217,10 @@ func TestAllocateAndAdd_NoDuplicateNames(t *testing.T) {
 	}
 }
 
-// TestReuseIdlePolecat_KillsLiveSession verifies that ReuseIdlePolecat kills
-// an existing live (non-stale) tmux session instead of returning ErrSessionRunning.
-// This is the regression test for the sling-reuse-stale-session bug: idle polecats
-// with a live Claude session at a dead ❯ prompt must have their session killed so
-// StartSession can create a fresh session with a proper gt prime --hook cycle.
-func TestReuseIdlePolecat_KillsLiveSession(t *testing.T) {
+// TestReuseIdlePolecat_PreservesLiveSessionWhenNeedsRecovery verifies that the
+// recovery safety gate runs before destructive session cleanup. A live session
+// means the slot is not proven idle yet, so reuse must fail closed.
+func TestReuseIdlePolecat_PreservesLiveSessionWhenNeedsRecovery(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("tmux not supported on Windows")
 	}
@@ -2274,9 +2272,8 @@ func TestReuseIdlePolecat_KillsLiveSession(t *testing.T) {
 		t.Fatal("precondition: heartbeat should exist")
 	}
 
-	// Call ReuseIdlePolecat — it will kill the session, then fail on worktree
-	// operations (no real git repo). The important thing is it does NOT return
-	// ErrSessionRunning.
+	// Call ReuseIdlePolecat. The recovery-safe reuse gate should fail before any
+	// session kill because a live session is not an idle slot.
 	_, reuseErr := mgr.ReuseIdlePolecat(polecatName, AddOptions{})
 
 	// Verify it did NOT return ErrSessionRunning (the old buggy behavior)
@@ -2286,23 +2283,20 @@ func TestReuseIdlePolecat_KillsLiveSession(t *testing.T) {
 			"sessions must have their session killed, not rejected")
 	}
 
-	// We expect an error from later steps (worktree not found), but not from session handling
 	if reuseErr == nil {
-		t.Fatal("expected error from worktree operations (test has no real git repo)")
+		t.Fatal("expected needs-recovery error")
 	}
-	if !strings.Contains(reuseErr.Error(), "worktree") {
-		t.Logf("ReuseIdlePolecat error (expected worktree-related): %v", reuseErr)
+	if !errors.Is(reuseErr, ErrPolecatNeedsRecovery) || !strings.Contains(reuseErr.Error(), "not-idle") {
+		t.Fatalf("ReuseIdlePolecat error = %v, want needs recovery: not-idle", reuseErr)
 	}
 
-	// Verify the session was killed
+	// Verify the session and heartbeat were preserved for recovery.
 	running, _ = tm.HasSession(sessionName)
-	if running {
-		t.Error("session should have been killed by ReuseIdlePolecat")
+	if !running {
+		t.Error("session should be preserved when reuse needs recovery")
 	}
-
-	// Verify heartbeat was cleaned up
-	if hb := ReadSessionHeartbeat(townRoot, sessionName); hb != nil {
-		t.Error("heartbeat should have been removed after session kill")
+	if hb := ReadSessionHeartbeat(townRoot, sessionName); hb == nil {
+		t.Error("heartbeat should be preserved when reuse needs recovery")
 	}
 }
 
@@ -2392,10 +2386,9 @@ func TestRepairWorktreeWithOptions_KillsLiveSession(t *testing.T) {
 	}
 }
 
-// TestReuseIdlePolecat_KillsStaleSession verifies that ReuseIdlePolecat also
-// handles the stale-session case correctly (regression: the original code path
-// that worked before the fix should still work after).
-func TestReuseIdlePolecat_KillsStaleSession(t *testing.T) {
+// TestReuseIdlePolecat_PreservesStaleSessionWhenNeedsRecovery verifies that even
+// stale sessions are not killed before the reuse decision proves the slot reusable.
+func TestReuseIdlePolecat_PreservesStaleSessionWhenNeedsRecovery(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("tmux not supported on Windows")
 	}
@@ -2447,16 +2440,21 @@ func TestReuseIdlePolecat_KillsStaleSession(t *testing.T) {
 	if errors.Is(reuseErr, ErrSessionRunning) {
 		t.Fatal("ReuseIdlePolecat should not return ErrSessionRunning for stale session")
 	}
-
-	// Session should be killed
-	running, _ := tm.HasSession(sessionName)
-	if running {
-		t.Error("stale session should have been killed")
+	if reuseErr == nil {
+		t.Fatal("expected needs-recovery error")
+	}
+	if !errors.Is(reuseErr, ErrPolecatNeedsRecovery) || !strings.Contains(reuseErr.Error(), "not-idle") {
+		t.Fatalf("ReuseIdlePolecat error = %v, want needs recovery: not-idle", reuseErr)
 	}
 
-	// Heartbeat should be cleaned up
-	if hb := ReadSessionHeartbeat(townRoot, sessionName); hb != nil {
-		t.Error("heartbeat should have been removed after stale session kill")
+	// Session and heartbeat should be preserved for recovery because a stale
+	// session still maps to StateStalled until cleanup/recovery handles it.
+	running, _ := tm.HasSession(sessionName)
+	if !running {
+		t.Error("stale session should be preserved when reuse needs recovery")
+	}
+	if hb := ReadSessionHeartbeat(townRoot, sessionName); hb == nil {
+		t.Error("heartbeat should be preserved when reuse needs recovery")
 	}
 }
 

--- a/internal/templates/polecat-CLAUDE.md
+++ b/internal/templates/polecat-CLAUDE.md
@@ -65,9 +65,9 @@ formula checklist (from `mol-polecat-work`, shown inline at prime time) and sign
 1. Receive work via your hook (formula checklist + issue)
 2. Work through formula steps in order (shown inline at prime time)
 3. Complete and self-clean (`gt done`) — you exit AND nuke yourself
-4. Refinery merges your work from the MQ
+4. The configured landing path (MQ, fork PR, or review-only) carries the work forward
 
-**Self-cleaning model:** `gt done` pushes your branch, submits to MQ, nukes sandbox, exits session.
+**Self-cleaning model:** `gt done` completes the configured workflow, nukes sandbox, exits session.
 
 **Three operating states:**
 - **Working** — actively doing assigned work (normal)
@@ -249,25 +249,26 @@ the project's definition of done. Many projects require a specific test harness
 (not just `go test` or `dotnet test`). If AGENTS.md exists, its "Core rule"
 section defines what "done" means for this project.
 
-The `gt done` command pushes your branch, creates an MR bead in the MQ, nukes
-your sandbox, and exits your session. **You are gone after `gt done`.**
+The `gt done` command completes the workflow configured for this rig: internal
+MQ, fork PR, or review-only/no-merge. **You are gone after `gt done`.**
 
 ### Do NOT Push Directly to Main
 
 **You are a polecat. You NEVER push directly to main.**
 
-Your work goes through the merge queue:
-1. You work on your branch
-2. `gt done` pushes your branch and submits an MR to the merge queue
-3. Refinery merges to main after Witness verification
+Use the active landing mode for the rig:
+1. MQ mode: work on your branch; `gt done` submits an MR bead to Refinery
+2. Fork-PR mode: push only a feature branch to the fork remote and open a PR
+3. Review-only/no-merge mode: leave the branch for the requested reviewer
 
-**Do NOT create GitHub PRs either.** The merge queue handles everything.
+Only create GitHub PRs when the assignment or rig policy explicitly requires
+fork-PR mode. Never use a GitHub PR as a substitute for `gt done` in MQ mode.
 
 ### The Landing Rule
 
-> **Work is NOT landed until it's in the Refinery MQ.**
+> **Work is NOT landed until it is in the configured landing path.**
 
-**Local branch → `gt done` → MR in queue → Refinery merges → LANDED**
+**Local branch → configured MQ/fork-PR/review path → maintainer/Refinery lands**
 
 ---
 

--- a/internal/templates/roles/crew.md.tmpl
+++ b/internal/templates/roles/crew.md.tmpl
@@ -244,30 +244,31 @@ Mail beads can be hooked for ad-hoc instruction handoff:
 If you find mail on your hook (not a molecule), GUPP applies: read the mail
 content, interpret the prose instructions, and execute them.
 
-## Git Workflow: Work Off Main
+## Git Workflow: Match The Landing Mode
 
-**Crew workers push directly to main. No feature branches.**
+Use the active landing mode for the repo or assignment. Do not push directly to
+main when fork-PR or review-only mode is in effect.
 
-### No PRs in Maintainer Repos
+### PR and Direct-Main Policy
 
-If you have direct push access to the repo (you're a maintainer):
-- **NEVER create GitHub PRs** — push directly to main instead
-- Crew workers: push directly to main
-- Polecats: use `{{ cmd }} done` → Refinery merges to main
+- Direct mode: crew may push to the default branch when policy allows
+- Fork-PR mode: push only to a fork/non-maintainer remote and open a PR
+- MQ mode: polecats use `{{ cmd }} done` → Refinery merges to main
 
-PRs are for external contributors submitting to repos they don't own.
-Check `git remote -v` to identify repo ownership.
+Check `git remote -v` before PR work. If no fork/upstream push remote exists,
+do not create a GitHub PR.
 
 ### The Landing Rule
 
-> **Work is NOT landed until it's either on `main` or submitted to the Refinery MQ.**
+> **Work is NOT landed until it is on the configured landing path.**
 
 Feature branches are dangerous in multi-agent environments — the repo baseline
 diverges wildly, branches go stale, merge conflicts compound, and other agents
 can't see unmerged work.
 
-**Valid**: Pushed to main, or submitted to Refinery via `{{ cmd }} done`.
-**Invalid**: Sitting on a local or remote feature branch not in MQ.
+**Valid**: Pushed to main when direct mode allows it, submitted to Refinery via
+`{{ cmd }} done`, or opened as the required fork PR.
+**Invalid**: Sitting on a local or remote feature branch outside the configured workflow.
 
 ### Workflow
 
@@ -275,7 +276,7 @@ can't see unmerged work.
 git pull                    # Start fresh
 # ... do work ...
 git add -A && git commit -m "description"
-git push                    # Direct to main
+git push                    # Only when direct mode allows it
 ```
 
 If push fails (someone else pushed): `git pull --rebase && git push`
@@ -428,27 +429,28 @@ or the human asks.
 
 ## Landing the Plane (Session End Protocol)
 
-When ending a session, complete ALL steps. The plane is NOT landed until `git push`
-succeeds. **YOU must push — NEVER say "ready to push when you are!"**
+When ending a session, complete ALL steps. The plane is NOT landed until the
+configured landing path is reached. **Never say "ready to push when you are!"**
 
 **MANDATORY WORKFLOW:**
 
 1. **File beads** for remaining follow-up work
 2. **Run quality gates** (if code changed): `go test ./...` / `golangci-lint run ./...`
 3. **Update beads** — close finished work
-4. **PUSH TO REMOTE — NON-NEGOTIABLE:**
+4. **Advance the configured landing path — NON-NEGOTIABLE:**
    ```bash
    git pull --rebase
    git add <files> && git commit -m "description"
-   git push                    # DO NOT STOP BEFORE THIS COMPLETES
-   git status                  # MUST show "up to date with origin/main"
+   git push                    # direct mode only, when policy allows
+   # fork-PR mode: push to fork branch and open/update the PR instead
+   git status                  # MUST be clean
    ```
-   If `git push` fails, resolve and retry until it succeeds.
+   If the landing step fails, resolve and retry until it succeeds.
 5. **Clean up**: `git stash clear && git remote prune origin`
 6. **Handoff or close**: `{{ cmd }} handoff` or verify clean `git status`
 7. **Session summary**: What completed, beads filed, quality gate status, push confirmation
 
-**Landing means EVERYTHING is pushed to remote. No exceptions.**
+**Landing means the configured direct, fork-PR, MQ, or review path is reached. No exceptions.**
 
 ## Desire Paths: Improving the Tooling
 

--- a/internal/templates/roles/polecat.md.tmpl
+++ b/internal/templates/roles/polecat.md.tmpl
@@ -113,7 +113,7 @@ becomes part of a permanent ledger of demonstrated capability.
 ## Your Role: POLECAT (Worker: {{ .Polecat }} in {{ .RigName }})
 
 You are polecat **{{ .Polecat }}** — a worker agent in the {{ .RigName }} rig.
-You work on assigned issues and submit completed work to the merge queue.
+You work on assigned issues and complete them through the configured landing mode.
 
 ## Gas Town Architecture
 
@@ -216,7 +216,7 @@ When a command fails but your guess felt reasonable, file a bead with `desire-pa
 See `{{ .TownRoot }}/docs/AGENT-ERGONOMICS.md` for the philosophy.
 
 ### Completion
-- `{{ cmd }} done` — Signal work ready for merge queue (handles beads sync internally)
+- `{{ cmd }} done` — Signal work ready for the configured landing path (handles beads sync internally)
 
 ## Startup Protocol: Propulsion
 
@@ -348,11 +348,11 @@ Use `gt done --cleanup-status clean` when completing with no code changes.
 
 ## PR Workflow (for repos that use pull requests)
 
-**Applies to:** longeye and other repos that require code review via GitHub PRs
+**Applies to:** repos or assignments that explicitly require code review via GitHub PRs
 
 ### New Workflow (PR-based)
 1. Implement → Test
-2. **Create PR** (with branch naming: adam/YY/M/description)
+2. **Create PR** from a fork/non-maintainer push remote (with branch naming: adam/YY/M/description)
 3. **Monitor PR** — Check CI and review status
 4. **Address feedback** — Fix issues if CI fails or reviewers comment
 5. **Verify ready** — Confirm CI green and PR approved
@@ -382,27 +382,28 @@ git log --oneline -3    # Verify your commits are present
 
 Then submit: **`{{ cmd }} done`** ← MANDATORY FINAL STEP
 
-This single command verifies git is clean and submits your branch to the merge
-queue. The Witness handles the rest.
+This single command verifies git is clean and advances the configured landing
+path. The Witness handles the rest.
 
 **Note:** Do NOT manually close the root issue with `bd close`. The Refinery
 closes it after successful merge.
 
-### No PRs in Maintainer Repos
+### Match The Landing Mode
 
-If you have direct push access to the repo (you're a maintainer):
-- **NEVER create GitHub PRs** — push directly to main instead
-- Polecats: use `{{ cmd }} done` → Refinery merges to main
+Polecats never push directly to main. Use the landing mode configured by the rig or assignment:
+- MQ mode: use `{{ cmd }} done` → Refinery merges to main
+- Fork-PR mode: push only to a fork/non-maintainer remote and open a PR
+- Review-only/no-merge mode: leave the branch for the requested reviewer
 
-PRs are for external contributors. Check `git remote -v` to identify repo ownership.
+Check `git remote -v` before PR work. If no fork/upstream push remote exists, do not create a GitHub PR.
 
 ### The Landing Rule
 
-> **Work is NOT landed until it's on `main` OR in the Refinery MQ.**
+> **Work is NOT landed until it's on `main`, in the Refinery MQ, or in the required fork PR.**
 
-Your local branch is NOT landed. Run `{{ cmd }} done` to submit to the merge queue.
+Your local branch is NOT landed. Run `{{ cmd }} done` or follow the explicit fork-PR assignment.
 
-**Local branch → `{{ cmd }} done` → MR in queue → Refinery merges → LANDED**
+**Local branch → configured MQ/fork-PR/review path → maintainer/Refinery lands**
 
 ## If You're Stuck: Escalate and Move On
 

--- a/templates/polecat-CLAUDE.md
+++ b/templates/polecat-CLAUDE.md
@@ -65,9 +65,9 @@ formula checklist (from `mol-polecat-work`, shown inline at prime time) and sign
 1. Receive work via your hook (formula checklist + issue)
 2. Work through formula steps in order (shown inline at prime time)
 3. Complete and self-clean (`gt done`) — you exit AND nuke yourself
-4. Refinery merges your work from the MQ
+4. The configured landing path (MQ, fork PR, or review-only) carries the work forward
 
-**Self-cleaning model:** `gt done` pushes your branch, submits to MQ, nukes sandbox, exits session.
+**Self-cleaning model:** `gt done` completes the configured workflow, nukes sandbox, exits session.
 
 **Three operating states:**
 - **Working** — actively doing assigned work (normal)
@@ -201,25 +201,26 @@ the project's definition of done. Many projects require a specific test harness
 (not just `go test` or `dotnet test`). If AGENTS.md exists, its "Core rule"
 section defines what "done" means for this project.
 
-The `gt done` command pushes your branch, creates an MR bead in the MQ, nukes
-your sandbox, and exits your session. **You are gone after `gt done`.**
+The `gt done` command completes the workflow configured for this rig: internal
+MQ, fork PR, or review-only/no-merge. **You are gone after `gt done`.**
 
 ### Do NOT Push Directly to Main
 
 **You are a polecat. You NEVER push directly to main.**
 
-Your work goes through the merge queue:
-1. You work on your branch
-2. `gt done` pushes your branch and submits an MR to the merge queue
-3. Refinery merges to main after Witness verification
+Use the active landing mode for the rig:
+1. MQ mode: work on your branch; `gt done` submits an MR bead to Refinery
+2. Fork-PR mode: push only a feature branch to the fork remote and open a PR
+3. Review-only/no-merge mode: leave the branch for the requested reviewer
 
-**Do NOT create GitHub PRs either.** The merge queue handles everything.
+Only create GitHub PRs when the assignment or rig policy explicitly requires
+fork-PR mode. Never use a GitHub PR as a substitute for `gt done` in MQ mode.
 
 ### The Landing Rule
 
-> **Work is NOT landed until it's in the Refinery MQ.**
+> **Work is NOT landed until it is in the configured landing path.**
 
-**Local branch → `gt done` → MR in queue → Refinery merges → LANDED**
+**Local branch → configured MQ/fork-PR/review path → maintainer/Refinery lands**
 
 ---
 


### PR DESCRIPTION
## Summary
- Supersedes #4031 with a smaller policy-aware PR focused on fork/direct/MQ guardrails and minimal role wording.
- Makes the tap PR guard use generic fork/upstream remote topology as a PR-command prerequisite rather than hardcoded repository names or a landing-policy source.
- Makes the internal PR blocker only close same-repo PRs to the repository default branch and re-run when PRs are edited/retargeted.
- Ports the omitted #4031 OMP/Pi hook-template changes so plain `git push` is left to pre-push policy while `gh pr create`, `git checkout -b`, and `git switch -c` are guarded.

## RCA Mapping
- Parent bead: `gt-rca-pr-policy-convergence`
- Covers: `gt-rca-pr-fork-policy` and `gt-rca-pr-internal-automation`
- Supersedes: #4031 should remain open until this PR is reviewed/accepted, then #4031 can be closed as superseded.
- Related but not duplicated: #4029 (fork rig docs), #4054 (broader fork-aware runtime/refinery behavior), #4010 (formula PR base targeting).

## Review Size
- Net diff: 16 files, +368/-180.
- Added since the prior #4093 body: OMP/Pi hook-template parity, edited/synchronize coverage for internal-PR blocking, clearer tap-guard wording that treats remote topology as capability/prerequisite, and pre-push help text that defers default-branch pushes to the active workflow.
- Deleted/collapsed from #4031 scope: broad WIP history and hardcoded maintainer-repo policy are not included.

## Validation
- `go test ./internal/cmd -run 'TestTapGuardPRWorkflow|TestTapList'`
- `go test ./internal/hooks`
- `bash .githooks/pre-push_test.sh`
- `go test ./internal/templates`
- `go build -v ./cmd/gt`
- `git diff --check origin/main...HEAD`

## Review Evidence
- Implementation/spec completeness: requested #4093 fixes are present for OMP/Pi push behavior, branch-create guards, block-internal-pr retarget coverage, and policy-source wording.
- PR sheriff/review-size: still a focused superseding PR; no reviewer requests were made.
- Hardcoded-policy scan: changed guard/workflow/template paths do not add repository-name policy hardcoding.
- Stale wording scan: changed paths no longer tell agents to push directly to main as the generic remedy; direct default-branch pushes remain delegated to workflow and pre-push policy.
- Closure path: preserve #4031 until #4093 is accepted, then close #4031 and resolve the mapped RCA beads.