### PR TITLE
fix: rebuild routing convergence for main

### DIFF
--- a/internal/beads/routes.go
+++ b/internal/beads/routes.go
@@ -77,7 +77,7 @@ func LoadRoutes(beadsDir string) ([]Route, error) {
 }
 
 // AppendRoute appends a route to routes.jsonl in the town's beads directory.
-// If the prefix already exists, it updates the path.
+// If the prefix already exists for the same rig, it updates the path.
 func AppendRoute(townRoot string, route Route) error {
 	beadsDir := filepath.Join(townRoot, ".beads")
 	return AppendRouteToDir(beadsDir, route)
@@ -169,13 +169,16 @@ func RestoreRouteInDirIfCurrent(beadsDir string, route Route, previous *Route) e
 }
 
 // AppendRouteToDir appends a route to routes.jsonl in the given beads directory.
-// If the prefix already exists, it updates the path.
+// If the prefix already exists for the same rig, it updates the path.
 func AppendRouteToDir(beadsDir string, route Route) error {
 	return withRoutesLock(beadsDir, func() error {
 		// Load existing routes
 		routes, err := LoadRoutes(beadsDir)
 		if err != nil {
 			return fmt.Errorf("loading routes: %w", err)
+		}
+		if err := checkPrefixAvailableInRoutes(routes, route.Prefix, route.Path); err != nil {
+			return err
 		}
 
 		// Check if prefix already exists

--- a/internal/beads/routes.go
+++ b/internal/beads/routes.go
@@ -23,6 +23,23 @@ type Route struct {
 // RoutesFileName is the name of the routes configuration file.
 const RoutesFileName = "routes.jsonl"
 
+func routesLockPath(beadsDir string) string {
+	return filepath.Join(beadsDir, RoutesFileName+".flock")
+}
+
+func withRoutesLock(beadsDir string, fn func() error) error {
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		return fmt.Errorf("creating beads directory: %w", err)
+	}
+	unlock, err := gtlock.FlockAcquire(routesLockPath(beadsDir))
+	if err != nil {
+		return fmt.Errorf("acquiring routes lock: %w", err)
+	}
+	defer unlock()
+
+	return fn()
+}
+
 // LoadRoutes loads routes from routes.jsonl in the given beads directory.
 // Returns an empty slice if the file doesn't exist.
 func LoadRoutes(beadsDir string) ([]Route, error) {
@@ -76,53 +93,45 @@ func AppendRouteIfPrefixAvailable(townRoot string, route Route) (*Route, error) 
 
 // AppendRouteToDirIfPrefixAvailable is AppendRouteToDir with a same-rig guard.
 func AppendRouteToDirIfPrefixAvailable(beadsDir string, route Route) (*Route, error) {
-	if err := os.MkdirAll(beadsDir, 0755); err != nil {
-		return nil, fmt.Errorf("creating beads directory: %w", err)
-	}
-	unlock, err := gtlock.FlockAcquire(filepath.Join(beadsDir, RoutesFileName+".flock"))
-	if err != nil {
-		return nil, fmt.Errorf("acquiring routes lock: %w", err)
-	}
-	defer unlock()
-
-	routes, err := LoadRoutes(beadsDir)
-	if err != nil {
-		return nil, fmt.Errorf("loading routes: %w", err)
-	}
-
-	newRig := strings.SplitN(route.Path, "/", 2)[0]
 	var previous *Route
-	for _, r := range routes {
-		if r.Prefix != route.Prefix {
-			continue
+	err := withRoutesLock(beadsDir, func() error {
+		routes, err := LoadRoutes(beadsDir)
+		if err != nil {
+			return fmt.Errorf("loading routes: %w", err)
 		}
-		existingRig := strings.SplitN(r.Path, "/", 2)[0]
-		if existingRig != newRig {
-			return nil, fmt.Errorf("prefix %q is already used by %s (path: %s); use --prefix to specify a different prefix", route.Prefix, existingRig, r.Path)
+		if err := checkPrefixAvailableInRoutes(routes, route.Prefix, route.Path); err != nil {
+			return err
 		}
-		if previous == nil {
-			prev := r
-			previous = &prev
-		}
-	}
 
-	updated := make([]Route, 0, len(routes)+1)
-	replaced := false
-	for _, r := range routes {
-		if r.Prefix == route.Prefix {
-			if !replaced {
-				updated = append(updated, route)
-				replaced = true
+		for _, r := range routes {
+			if r.Prefix != route.Prefix {
+				continue
 			}
-			continue
+			if previous == nil {
+				prev := r
+				previous = &prev
+			}
 		}
-		updated = append(updated, r)
-	}
-	if !replaced {
-		updated = append(updated, route)
-	}
 
-	return previous, WriteRoutes(beadsDir, updated)
+		updated := make([]Route, 0, len(routes)+1)
+		replaced := false
+		for _, r := range routes {
+			if r.Prefix == route.Prefix {
+				if !replaced {
+					updated = append(updated, route)
+					replaced = true
+				}
+				continue
+			}
+			updated = append(updated, r)
+		}
+		if !replaced {
+			updated = append(updated, route)
+		}
+
+		return writeRoutesUnlocked(beadsDir, updated)
+	})
+	return previous, err
 }
 
 // RestoreRouteIfCurrent restores or removes a route only if it still matches
@@ -134,89 +143,92 @@ func RestoreRouteIfCurrent(townRoot string, route Route, previous *Route) error 
 
 // RestoreRouteInDirIfCurrent restores or removes a route only if it still matches.
 func RestoreRouteInDirIfCurrent(beadsDir string, route Route, previous *Route) error {
-	if err := os.MkdirAll(beadsDir, 0755); err != nil {
-		return fmt.Errorf("creating beads directory: %w", err)
-	}
-	unlock, err := gtlock.FlockAcquire(filepath.Join(beadsDir, RoutesFileName+".flock"))
-	if err != nil {
-		return fmt.Errorf("acquiring routes lock: %w", err)
-	}
-	defer unlock()
-
-	routes, err := LoadRoutes(beadsDir)
-	if err != nil {
-		return fmt.Errorf("loading routes: %w", err)
-	}
-
-	for i, r := range routes {
-		if r.Prefix != route.Prefix {
-			continue
+	return withRoutesLock(beadsDir, func() error {
+		routes, err := LoadRoutes(beadsDir)
+		if err != nil {
+			return fmt.Errorf("loading routes: %w", err)
 		}
-		if r.Path != route.Path {
-			return nil
-		}
-		if previous == nil {
-			routes = append(routes[:i], routes[i+1:]...)
-		} else {
-			routes[i] = *previous
-		}
-		return WriteRoutes(beadsDir, routes)
-	}
 
-	return nil
+		for i, r := range routes {
+			if r.Prefix != route.Prefix {
+				continue
+			}
+			if r.Path != route.Path {
+				return nil
+			}
+			if previous == nil {
+				routes = append(routes[:i], routes[i+1:]...)
+			} else {
+				routes[i] = *previous
+			}
+			return writeRoutesUnlocked(beadsDir, routes)
+		}
+
+		return nil
+	})
 }
 
 // AppendRouteToDir appends a route to routes.jsonl in the given beads directory.
 // If the prefix already exists, it updates the path.
 func AppendRouteToDir(beadsDir string, route Route) error {
-	// Load existing routes
-	routes, err := LoadRoutes(beadsDir)
-	if err != nil {
-		return fmt.Errorf("loading routes: %w", err)
-	}
-
-	// Check if prefix already exists
-	found := false
-	for i, r := range routes {
-		if r.Prefix == route.Prefix {
-			routes[i].Path = route.Path
-			found = true
-			break
+	return withRoutesLock(beadsDir, func() error {
+		// Load existing routes
+		routes, err := LoadRoutes(beadsDir)
+		if err != nil {
+			return fmt.Errorf("loading routes: %w", err)
 		}
-	}
 
-	if !found {
-		routes = append(routes, route)
-	}
+		// Check if prefix already exists
+		found := false
+		for i, r := range routes {
+			if r.Prefix == route.Prefix {
+				routes[i].Path = route.Path
+				found = true
+				break
+			}
+		}
 
-	// Write back
-	return WriteRoutes(beadsDir, routes)
+		if !found {
+			routes = append(routes, route)
+		}
+
+		// Write back
+		return writeRoutesUnlocked(beadsDir, routes)
+	})
 }
 
 // RemoveRoute removes a route by prefix from routes.jsonl.
 func RemoveRoute(townRoot string, prefix string) error {
 	beadsDir := filepath.Join(townRoot, ".beads")
 
-	// Load existing routes
-	routes, err := LoadRoutes(beadsDir)
-	if err != nil {
-		return fmt.Errorf("loading routes: %w", err)
-	}
-
-	// Filter out the prefix
-	var filtered []Route
-	for _, r := range routes {
-		if r.Prefix != prefix {
-			filtered = append(filtered, r)
+	return withRoutesLock(beadsDir, func() error {
+		// Load existing routes
+		routes, err := LoadRoutes(beadsDir)
+		if err != nil {
+			return fmt.Errorf("loading routes: %w", err)
 		}
-	}
 
-	// Write back
-	return WriteRoutes(beadsDir, filtered)
+		// Filter out the prefix
+		var filtered []Route
+		for _, r := range routes {
+			if r.Prefix != prefix {
+				filtered = append(filtered, r)
+			}
+		}
+
+		// Write back
+		return writeRoutesUnlocked(beadsDir, filtered)
+	})
 }
 
 // WriteRoutes writes routes to routes.jsonl, overwriting existing content.
 func WriteRoutes(beadsDir string, routes []Route) error {
+	return withRoutesLock(beadsDir, func() error {
+		return writeRoutesUnlocked(beadsDir, routes)
+	})
+}
+
+func writeRoutesUnlocked(beadsDir string, routes []Route) error {
 	// Ensure beads directory exists
 	if err := os.MkdirAll(beadsDir, 0755); err != nil {
 		return fmt.Errorf("creating beads directory: %w", err)
@@ -305,20 +317,25 @@ func CheckPrefixAvailable(townRoot string, prefix string, newPath string) error 
 		return fmt.Errorf("loading routes: %w", err)
 	}
 
-	// Extract the rig name (first path component) for comparison,
-	// since the same rig can have different path variants (e.g., "gastown" vs "gastown/mayor/rig").
-	newRig := strings.SplitN(newPath, "/", 2)[0]
+	return checkPrefixAvailableInRoutes(routes, prefix, newPath)
+}
 
+func checkPrefixAvailableInRoutes(routes []Route, prefix string, newPath string) error {
+	newRig := routeRigName(newPath)
 	for _, r := range routes {
 		if r.Prefix == prefix {
-			existingRig := strings.SplitN(r.Path, "/", 2)[0]
+			existingRig := routeRigName(r.Path)
 			if existingRig != newRig {
-				return fmt.Errorf("prefix %q is already used by %s (path: %s); use --prefix to specify a different prefix", prefix, existingRig, r.Path)
+				return fmt.Errorf("prefix %q is already used by %s (path: %s)", prefix, existingRig, r.Path)
 			}
 		}
 	}
 
 	return nil
+}
+
+func routeRigName(path string) string {
+	return strings.SplitN(path, "/", 2)[0]
 }
 
 // FindConflictingPrefixes checks for duplicate prefixes in routes.

--- a/internal/beads/routes.go
+++ b/internal/beads/routes.go
@@ -10,6 +10,7 @@ import (
 	"strings"
 
 	"github.com/steveyegge/gastown/internal/config"
+	gtlock "github.com/steveyegge/gastown/internal/lock"
 )
 
 // Route represents a prefix-to-path routing rule.
@@ -63,6 +64,106 @@ func LoadRoutes(beadsDir string) ([]Route, error) {
 func AppendRoute(townRoot string, route Route) error {
 	beadsDir := filepath.Join(townRoot, ".beads")
 	return AppendRouteToDir(beadsDir, route)
+}
+
+// AppendRouteIfPrefixAvailable appends or updates a route only when the prefix
+// is unused or already belongs to the same rig. It returns the previous route
+// for rollback, or nil when this call added a new route.
+func AppendRouteIfPrefixAvailable(townRoot string, route Route) (*Route, error) {
+	beadsDir := filepath.Join(townRoot, ".beads")
+	return AppendRouteToDirIfPrefixAvailable(beadsDir, route)
+}
+
+// AppendRouteToDirIfPrefixAvailable is AppendRouteToDir with a same-rig guard.
+func AppendRouteToDirIfPrefixAvailable(beadsDir string, route Route) (*Route, error) {
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		return nil, fmt.Errorf("creating beads directory: %w", err)
+	}
+	unlock, err := gtlock.FlockAcquire(filepath.Join(beadsDir, RoutesFileName+".flock"))
+	if err != nil {
+		return nil, fmt.Errorf("acquiring routes lock: %w", err)
+	}
+	defer unlock()
+
+	routes, err := LoadRoutes(beadsDir)
+	if err != nil {
+		return nil, fmt.Errorf("loading routes: %w", err)
+	}
+
+	newRig := strings.SplitN(route.Path, "/", 2)[0]
+	var previous *Route
+	for _, r := range routes {
+		if r.Prefix != route.Prefix {
+			continue
+		}
+		existingRig := strings.SplitN(r.Path, "/", 2)[0]
+		if existingRig != newRig {
+			return nil, fmt.Errorf("prefix %q is already used by %s (path: %s); use --prefix to specify a different prefix", route.Prefix, existingRig, r.Path)
+		}
+		if previous == nil {
+			prev := r
+			previous = &prev
+		}
+	}
+
+	updated := make([]Route, 0, len(routes)+1)
+	replaced := false
+	for _, r := range routes {
+		if r.Prefix == route.Prefix {
+			if !replaced {
+				updated = append(updated, route)
+				replaced = true
+			}
+			continue
+		}
+		updated = append(updated, r)
+	}
+	if !replaced {
+		updated = append(updated, route)
+	}
+
+	return previous, WriteRoutes(beadsDir, updated)
+}
+
+// RestoreRouteIfCurrent restores or removes a route only if it still matches
+// the route written by this caller. This avoids clobbering another add/repair.
+func RestoreRouteIfCurrent(townRoot string, route Route, previous *Route) error {
+	beadsDir := filepath.Join(townRoot, ".beads")
+	return RestoreRouteInDirIfCurrent(beadsDir, route, previous)
+}
+
+// RestoreRouteInDirIfCurrent restores or removes a route only if it still matches.
+func RestoreRouteInDirIfCurrent(beadsDir string, route Route, previous *Route) error {
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		return fmt.Errorf("creating beads directory: %w", err)
+	}
+	unlock, err := gtlock.FlockAcquire(filepath.Join(beadsDir, RoutesFileName+".flock"))
+	if err != nil {
+		return fmt.Errorf("acquiring routes lock: %w", err)
+	}
+	defer unlock()
+
+	routes, err := LoadRoutes(beadsDir)
+	if err != nil {
+		return fmt.Errorf("loading routes: %w", err)
+	}
+
+	for i, r := range routes {
+		if r.Prefix != route.Prefix {
+			continue
+		}
+		if r.Path != route.Path {
+			return nil
+		}
+		if previous == nil {
+			routes = append(routes[:i], routes[i+1:]...)
+		} else {
+			routes[i] = *previous
+		}
+		return WriteRoutes(beadsDir, routes)
+	}
+
+	return nil
 }
 
 // AppendRouteToDir appends a route to routes.jsonl in the given beads directory.

--- a/internal/beads/routes_test.go
+++ b/internal/beads/routes_test.go
@@ -637,6 +637,29 @@ func TestAppendRouteIfPrefixAvailable(t *testing.T) {
 	}
 }
 
+func TestAppendRouteRejectsCrossRigPrefixRewrite(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := WriteRoutes(beadsDir, []Route{{Prefix: "gt-", Path: "gastown/mayor/rig"}}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	if err := AppendRoute(tmpDir, Route{Prefix: "gt-", Path: "secondrig/mayor/rig"}); err == nil {
+		t.Fatal("AppendRoute succeeded for different-rig prefix collision")
+	}
+	if err := AppendRoute(tmpDir, Route{Prefix: "gt-", Path: "gastown"}); err != nil {
+		t.Fatalf("AppendRoute rejected same-rig path variant: %v", err)
+	}
+
+	routes, err := LoadRoutes(beadsDir)
+	if err != nil {
+		t.Fatalf("load routes: %v", err)
+	}
+	if len(routes) != 1 || routes[0].Prefix != "gt-" || routes[0].Path != "gastown" {
+		t.Fatalf("routes = %#v, want gt- -> gastown", routes)
+	}
+}
+
 func TestAppendRouteIfPrefixAvailableScansDuplicatePrefixes(t *testing.T) {
 	tmpDir := t.TempDir()
 	beadsDir := filepath.Join(tmpDir, ".beads")

--- a/internal/beads/routes_test.go
+++ b/internal/beads/routes_test.go
@@ -3,9 +3,12 @@ package beads
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/gastown/internal/config"
+	gtlock "github.com/steveyegge/gastown/internal/lock"
 )
 
 func TestGetPrefixForRig(t *testing.T) {
@@ -502,6 +505,80 @@ func TestCheckPrefixAvailable_NoRoutes(t *testing.T) {
 	err := CheckPrefixAvailable(tmpDir, "gt-", "gastown")
 	if err != nil {
 		t.Errorf("expected no error with no routes file, got: %v", err)
+	}
+}
+
+func TestCheckPrefixAvailableScansDuplicatePrefixes(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := WriteRoutes(beadsDir, []Route{
+		{Prefix: "gt-", Path: "gastown"},
+		{Prefix: "gt-", Path: "secondrig"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	if err := CheckPrefixAvailable(tmpDir, "gt-", "gastown/mayor/rig"); err == nil {
+		t.Fatal("CheckPrefixAvailable succeeded with duplicate different-rig prefix")
+	}
+
+	if err := WriteRoutes(beadsDir, []Route{
+		{Prefix: "gt-", Path: "gastown"},
+		{Prefix: "gt-", Path: "gastown/mayor/rig"},
+	}); err != nil {
+		t.Fatalf("write same-rig routes: %v", err)
+	}
+	if err := CheckPrefixAvailable(tmpDir, "gt-", "gastown/mayor/rig"); err != nil {
+		t.Fatalf("CheckPrefixAvailable rejected same-rig duplicates: %v", err)
+	}
+}
+
+func TestWriteRoutesWaitsForRoutesLock(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("flock is a no-op on Windows")
+	}
+
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	unlock, err := gtlock.FlockAcquire(routesLockPath(beadsDir))
+	if err != nil {
+		t.Fatalf("acquire routes lock: %v", err)
+	}
+
+	done := make(chan error, 1)
+	go func() {
+		done <- WriteRoutes(beadsDir, []Route{{Prefix: "gt-", Path: "gastown"}})
+	}()
+
+	select {
+	case err := <-done:
+		unlock()
+		if err != nil {
+			t.Fatalf("WriteRoutes returned early with error: %v", err)
+		}
+		t.Fatal("WriteRoutes completed while routes lock was held")
+	case <-time.After(100 * time.Millisecond):
+	}
+
+	unlock()
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Fatalf("WriteRoutes after releasing lock: %v", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("WriteRoutes did not complete after releasing routes lock")
+	}
+
+	routes, err := LoadRoutes(beadsDir)
+	if err != nil {
+		t.Fatalf("load routes: %v", err)
+	}
+	if len(routes) != 1 || routes[0].Prefix != "gt-" || routes[0].Path != "gastown" {
+		t.Fatalf("routes = %#v, want gt- -> gastown", routes)
 	}
 }
 

--- a/internal/beads/routes_test.go
+++ b/internal/beads/routes_test.go
@@ -505,6 +505,93 @@ func TestCheckPrefixAvailable_NoRoutes(t *testing.T) {
 	}
 }
 
+func TestAppendRouteIfPrefixAvailable(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := WriteRoutes(beadsDir, []Route{{Prefix: "gt-", Path: "gastown/mayor/rig"}}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	if _, err := AppendRouteIfPrefixAvailable(tmpDir, Route{Prefix: "gt-", Path: "secondrig/mayor/rig"}); err == nil {
+		t.Fatal("AppendRouteIfPrefixAvailable succeeded for different-rig prefix collision")
+	}
+	routes, err := LoadRoutes(beadsDir)
+	if err != nil {
+		t.Fatalf("load routes: %v", err)
+	}
+	if len(routes) != 1 || routes[0].Path != "gastown/mayor/rig" {
+		t.Fatalf("route changed after rejected collision: %#v", routes)
+	}
+
+	previous, err := AppendRouteIfPrefixAvailable(tmpDir, Route{Prefix: "gt-", Path: "gastown"})
+	if err != nil {
+		t.Fatalf("AppendRouteIfPrefixAvailable same rig: %v", err)
+	}
+	if previous == nil || previous.Path != "gastown/mayor/rig" {
+		t.Fatalf("previous route = %#v, want gastown/mayor/rig", previous)
+	}
+	if err := RestoreRouteIfCurrent(tmpDir, Route{Prefix: "gt-", Path: "gastown"}, previous); err != nil {
+		t.Fatalf("restore previous route: %v", err)
+	}
+	routes, err = LoadRoutes(beadsDir)
+	if err != nil {
+		t.Fatalf("load restored routes: %v", err)
+	}
+	if len(routes) != 1 || routes[0].Path != "gastown/mayor/rig" {
+		t.Fatalf("route was not restored: %#v", routes)
+	}
+
+	previous, err = AppendRouteIfPrefixAvailable(tmpDir, Route{Prefix: "cr-", Path: "crucible"})
+	if err != nil {
+		t.Fatalf("AppendRouteIfPrefixAvailable new route: %v", err)
+	}
+	if previous != nil {
+		t.Fatalf("previous route = %#v, want nil for new route", previous)
+	}
+	if err := RestoreRouteIfCurrent(tmpDir, Route{Prefix: "cr-", Path: "crucible"}, previous); err != nil {
+		t.Fatalf("remove new route rollback: %v", err)
+	}
+	routes, err = LoadRoutes(beadsDir)
+	if err != nil {
+		t.Fatalf("load routes after rollback: %v", err)
+	}
+	if len(routes) != 1 || routes[0].Prefix != "gt-" {
+		t.Fatalf("new route was not removed on rollback: %#v", routes)
+	}
+}
+
+func TestAppendRouteIfPrefixAvailableScansDuplicatePrefixes(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	if err := WriteRoutes(beadsDir, []Route{
+		{Prefix: "gt-", Path: "gastown"},
+		{Prefix: "gt-", Path: "secondrig"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	if _, err := AppendRouteIfPrefixAvailable(tmpDir, Route{Prefix: "gt-", Path: "gastown/mayor/rig"}); err == nil {
+		t.Fatal("AppendRouteIfPrefixAvailable succeeded with duplicate different-rig prefix")
+	}
+
+	if err := WriteRoutes(beadsDir, []Route{
+		{Prefix: "gt-", Path: "gastown"},
+		{Prefix: "gt-", Path: "gastown/mayor/rig"},
+	}); err != nil {
+		t.Fatalf("write same-rig duplicates: %v", err)
+	}
+	if _, err := AppendRouteIfPrefixAvailable(tmpDir, Route{Prefix: "gt-", Path: "gastown/mayor/rig"}); err != nil {
+		t.Fatalf("AppendRouteIfPrefixAvailable same-rig duplicates: %v", err)
+	}
+	routes, err := LoadRoutes(beadsDir)
+	if err != nil {
+		t.Fatalf("load routes: %v", err)
+	}
+	if len(routes) != 1 || routes[0].Prefix != "gt-" || routes[0].Path != "gastown/mayor/rig" {
+		t.Fatalf("same-rig duplicates were not collapsed: %#v", routes)
+	}
+}
+
 func TestAgentBeadIDsWithPrefix(t *testing.T) {
 	tests := []struct {
 		name     string

--- a/internal/cmd/beads_routing_integration_test.go
+++ b/internal/cmd/beads_routing_integration_test.go
@@ -484,8 +484,8 @@ func TestBeadsAppendRoute(t *testing.T) {
 		t.Errorf("expected 2 routes, got %d", len(routes))
 	}
 
-	// Update existing route (same prefix, different path)
-	route1Updated := beads.Route{Prefix: "gt-", Path: "newpath/mayor/rig"}
+	// Update existing route (same prefix, same rig path variant)
+	route1Updated := beads.Route{Prefix: "gt-", Path: "gastown"}
 	if err := beads.AppendRoute(tmpDir, route1Updated); err != nil {
 		t.Fatalf("AppendRoute update: %v", err)
 	}
@@ -497,9 +497,14 @@ func TestBeadsAppendRoute(t *testing.T) {
 	}
 
 	for _, r := range routes {
-		if r.Prefix == "gt-" && r.Path != "newpath/mayor/rig" {
+		if r.Prefix == "gt-" && r.Path != "gastown" {
 			t.Errorf("route update failed: got path %q", r.Path)
 		}
+	}
+
+	// Reject same-prefix rewrites to a different rig.
+	if err := beads.AppendRoute(tmpDir, beads.Route{Prefix: "gt-", Path: "newpath/mayor/rig"}); err == nil {
+		t.Fatal("AppendRoute allowed cross-rig prefix rewrite")
 	}
 }
 

--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -469,8 +469,9 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 		}
 	}
 
-	// Step 1: Create convoy bead
-	convoyID := fmt.Sprintf("%s-cv-%s", rigPrefix, generateFormulaShortID())
+	// Step 1: Create convoy bead. Convoys are town-level coordination beads;
+	// only the executable leg/synthesis beads are rig-scoped.
+	convoyID := formulaConvoyID(generateFormulaShortID())
 	convoyTitle := fmt.Sprintf("%s: %s", formulaName, f.Description)
 	if len(convoyTitle) > 80 {
 		convoyTitle = convoyTitle[:77] + "..."
@@ -500,10 +501,7 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 		createArgs = append(createArgs, "--force")
 	}
 
-	createCmd := exec.Command("bd", createArgs...)
-	createCmd.Dir = townBeads
-	createCmd.Stderr = os.Stderr
-	if err := createCmd.Run(); err != nil {
+	if err := BdCmd(createArgs...).WithAutoCommit().Dir(townBeads).Stderr(os.Stderr).Run(); err != nil {
 		return fmt.Errorf("creating convoy bead: %w", err)
 	}
 
@@ -624,7 +622,7 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 		}
 
 		// Track the leg with the convoy
-		if err := addTrackingRelationFn(townBeads, convoyID, legBeadID); err != nil {
+		if err := addTrackingRelationFn(townRoot, convoyID, legBeadID); err != nil {
 			fmt.Printf("%s Failed to track leg %s: %v\n",
 				style.Dim.Render("Warning:"), leg.ID, err)
 		}
@@ -663,7 +661,7 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 				style.Dim.Render("Warning:"), err)
 		} else {
 			// Track synthesis with convoy
-			_ = addTrackingRelationFn(townBeads, convoyID, synthesisBeadID)
+			_ = addTrackingRelationFn(townRoot, convoyID, synthesisBeadID)
 
 			// Add dependencies: synthesis depends on all legs
 			for _, legBeadID := range legBeads {
@@ -704,9 +702,7 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 				style.Dim.Render("Warning:"), leg.ID, err)
 			// Add comment to bead about failure
 			commentArgs := []string{"comments", "add", legBeadID, fmt.Sprintf("Failed to sling: %v", err)}
-			commentCmd := exec.Command("bd", commentArgs...)
-			commentCmd.Dir = townBeads
-			_ = commentCmd.Run()
+			_ = BdCmd(commentArgs...).WithAutoCommit().Dir(rigBeadsDir).Run()
 			continue
 		}
 
@@ -724,6 +720,10 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 	fmt.Printf("\n  Track progress: gt convoy status %s\n", convoyID)
 
 	return nil
+}
+
+func formulaConvoyID(shortID string) string {
+	return fmt.Sprintf("hq-cv-%s", shortID)
 }
 
 // executeWorkflowFormula creates step beads with dependency wiring and dispatches

--- a/internal/cmd/formula_test.go
+++ b/internal/cmd/formula_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"runtime"
 	"slices"
 	"strings"
 	"testing"
@@ -317,5 +318,131 @@ func TestAttachmentFormulaVarsPrefersAttachedVars(t *testing.T) {
 	want := []string{"problem=First\n\nSecond"}
 	if !reflect.DeepEqual(got, want) {
 		t.Fatalf("attachmentFormulaVars() = %#v, want %#v", got, want)
+	}
+}
+
+func TestFormulaConvoyIDUsesTownConvoyPrefix(t *testing.T) {
+	t.Parallel()
+
+	got := formulaConvoyID("abc123")
+	want := "hq-cv-abc123"
+	if got != want {
+		t.Fatalf("formulaConvoyID() = %q, want %q", got, want)
+	}
+}
+
+func TestExecuteConvoyFormulaCreatesTownConvoyAndRigLegs(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell stubs are unix-only")
+	}
+
+	townRoot := t.TempDir()
+	townBeads := filepath.Join(townRoot, ".beads")
+	rigDir := filepath.Join(townRoot, "gastown", "mayor", "rig")
+	rigBeads := filepath.Join(rigDir, ".beads")
+	for _, dir := range []string{filepath.Join(townRoot, "mayor", "rig"), townBeads, rigDir, rigBeads} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	routes := strings.Join([]string{
+		`{"prefix":"gt-","path":"gastown/mayor/rig"}`,
+		`{"prefix":"hq-","path":"."}`,
+		`{"prefix":"hq-cv-","path":"."}`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(townBeads, "routes.jsonl"), []byte(routes), 0o644); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0o755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	logPath := filepath.Join(townRoot, "bd.log")
+	bdScript := `#!/bin/sh
+set -e
+printf '%s|%s|%s\n' "$(pwd)" "${BEADS_DIR:-}" "$*" >> "${BD_LOG}"
+exit 0
+`
+	_ = writeBDStub(t, binDir, bdScript, "")
+	gtPath := filepath.Join(binDir, "gt")
+	gtScript := `#!/bin/sh
+set -e
+printf 'gt|%s|%s\n' "$(pwd)" "$*" >> "${GT_LOG}"
+exit 0
+`
+	if err := os.WriteFile(gtPath, []byte(gtScript), 0o755); err != nil {
+		t.Fatalf("write gt stub: %v", err)
+	}
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("GT_LOG", filepath.Join(townRoot, "gt.log"))
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BEADS_DIR", filepath.Join(townRoot, "wrong", ".beads"))
+
+	oldAddTracking := addTrackingRelationFn
+	oldPR := formulaRunPR
+	oldSet := formulaRunSet
+	oldFiles := formulaRunFiles
+	oldAgent := formulaRunAgent
+	t.Cleanup(func() {
+		addTrackingRelationFn = oldAddTracking
+		formulaRunPR = oldPR
+		formulaRunSet = oldSet
+		formulaRunFiles = oldFiles
+		formulaRunAgent = oldAgent
+	})
+	var trackedTownRoot, trackedConvoyID, trackedIssueID string
+	addTrackingRelationFn = func(townRootArg, convoyID, issueID string) error {
+		trackedTownRoot = townRootArg
+		trackedConvoyID = convoyID
+		trackedIssueID = issueID
+		return nil
+	}
+	formulaRunPR = 0
+	formulaRunSet = nil
+	formulaRunFiles = nil
+	formulaRunAgent = ""
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	f := &formula.Formula{
+		Description: "routing convoy",
+		Legs: []formula.Leg{{
+			ID:          "one",
+			Title:       "Leg one",
+			Description: "Do one thing",
+		}},
+	}
+	if err := executeConvoyFormula(f, "routing-fan", "gastown"); err != nil {
+		t.Fatalf("executeConvoyFormula: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	logText := string(logBytes)
+	if strings.Contains(logText, "--id=gt-cv-") {
+		t.Fatalf("formula convoy created rig-prefixed convoy in town log:\n%s", logText)
+	}
+	if !strings.Contains(logText, townBeads+"|"+townBeads+"|create ") || !strings.Contains(logText, "--id=hq-cv-") {
+		t.Fatalf("formula convoy create did not target town beads with hq-cv id:\n%s", logText)
+	}
+	if !strings.Contains(logText, rigBeads+"|"+rigBeads+"|create ") || !strings.Contains(logText, "--id=gt-leg-") {
+		t.Fatalf("formula leg create did not target rig beads with gt-leg id:\n%s", logText)
+	}
+	if trackedTownRoot != townRoot {
+		t.Fatalf("tracking townRoot = %q, want %q", trackedTownRoot, townRoot)
+	}
+	if !strings.HasPrefix(trackedConvoyID, "hq-cv-") || !strings.HasPrefix(trackedIssueID, "gt-leg-") {
+		t.Fatalf("tracking relation = (%q, %q), want hq-cv to gt-leg", trackedConvoyID, trackedIssueID)
 	}
 }

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -118,201 +118,6 @@ func TestExtractIssueID(t *testing.T) {
 	}
 }
 
-func TestSlingFormulaOnBeadRoutesBDCommandsToTargetRig(t *testing.T) {
-	townRoot := t.TempDir()
-
-	// Minimal workspace marker so workspace.FindFromCwd() succeeds.
-	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
-		t.Fatalf("mkdir mayor/rig: %v", err)
-	}
-
-	// Create a rig path that owns gt-* beads, and a routes.jsonl pointing to it.
-	rigDir := filepath.Join(townRoot, "gastown", "mayor", "rig")
-	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
-		t.Fatalf("mkdir .beads: %v", err)
-	}
-	if err := os.MkdirAll(rigDir, 0755); err != nil {
-		t.Fatalf("mkdir rigDir: %v", err)
-	}
-	routes := strings.Join([]string{
-		`{"prefix":"gt-","path":"gastown/mayor/rig"}`,
-		`{"prefix":"hq-","path":"."}`,
-		"",
-	}, "\n")
-	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
-		t.Fatalf("write routes.jsonl: %v", err)
-	}
-
-	// Stub bd so we can observe the working directory for cook/wisp/bond.
-	binDir := filepath.Join(townRoot, "bin")
-	if err := os.MkdirAll(binDir, 0755); err != nil {
-		t.Fatalf("mkdir binDir: %v", err)
-	}
-	logPath := filepath.Join(townRoot, "bd.log")
-	bdScript := `#!/bin/sh
-set -e
-echo "$(pwd)|${BEADS_DIR:-}|$*" >> "${BD_LOG}"
-cmd="$1"
-shift || true
-case "$cmd" in
-  show)
-    echo '[{"title":"Test issue","status":"open","assignee":"","description":""}]'
-    ;;
-  formula)
-    # formula show <name> - must output something for verifyFormulaExists
-    echo '{"name":"test-formula"}'
-    exit 0
-    ;;
-  cook)
-    exit 0
-    ;;
-  mol)
-    sub="$1"
-    shift || true
-    case "$sub" in
-      wisp)
-        echo '{"new_epic_id":"gt-wisp-xyz"}'
-        ;;
-      bond)
-        echo '{"root_id":"gt-wisp-xyz"}'
-        ;;
-    esac
-    ;;
-esac
-exit 0
-`
-	bdScriptWindows := `@echo off
-setlocal enableextensions
-echo %CD%^|%BEADS_DIR%^|%*>>"%BD_LOG%"
-set "cmd=%1"
-set "sub=%2"
-if "%cmd%"=="show" (
-  echo [{"title":"Test issue","status":"open","assignee":"","description":""}]
-  exit /b 0
-)
-if "%cmd%"=="formula" (
-  echo {"name":"test-formula"}
-  exit /b 0
-)
-if "%cmd%"=="cook" exit /b 0
-if "%cmd%"=="mol" (
-  if "%sub%"=="wisp" (
-    echo {"new_epic_id":"gt-wisp-xyz"}
-    exit /b 0
-  )
-  if "%sub%"=="bond" (
-    echo {"root_id":"gt-wisp-xyz"}
-    exit /b 0
-  )
-)
-exit /b 0
-`
-	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
-
-	t.Setenv("BD_LOG", logPath)
-	attachedLogPath := filepath.Join(townRoot, "attached-molecule.log")
-	t.Setenv("GT_TEST_ATTACHED_MOLECULE_LOG", attachedLogPath)
-	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
-	t.Setenv(EnvGTRole, "mayor")
-	t.Setenv("GT_POLECAT", "")
-	t.Setenv("GT_CREW", "")
-	t.Setenv("TMUX_PANE", "") // Prevent inheriting real tmux pane from test runner
-
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Fatalf("getwd: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(cwd) })
-	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-
-	// Ensure we don't leak global flag state across tests.
-	prevOn := slingOnTarget
-	prevVars := slingVars
-	prevDryRun := slingDryRun
-	prevNoConvoy := slingNoConvoy
-	t.Cleanup(func() {
-		slingOnTarget = prevOn
-		slingVars = prevVars
-		slingDryRun = prevDryRun
-		slingNoConvoy = prevNoConvoy
-	})
-
-	slingDryRun = false
-	slingNoConvoy = true
-	slingVars = nil
-	slingOnTarget = "gt-abc123"
-
-	// Prevent real tmux nudge from firing during tests (causes agent self-interruption)
-	t.Setenv("GT_TEST_NO_NUDGE", "1")
-	t.Setenv("GT_TEST_SKIP_HOOK_VERIFY", "1") // Stub bd doesn't track state
-
-	if err := runSling(nil, []string{"mol-review"}); err != nil {
-		t.Fatalf("runSling: %v", err)
-	}
-
-	logBytes, err := os.ReadFile(logPath)
-	if err != nil {
-		t.Fatalf("read bd log: %v", err)
-	}
-	logLines := strings.Split(strings.TrimSpace(string(logBytes)), "\n")
-
-	wantDir := rigDir
-	if resolved, err := filepath.EvalSymlinks(wantDir); err == nil {
-		wantDir = resolved
-	}
-	wantBeadsDir := filepath.Join(rigDir, ".beads")
-	if resolved, err := filepath.EvalSymlinks(wantBeadsDir); err == nil {
-		wantBeadsDir = resolved
-	}
-	gotCook := false
-	gotWisp := false
-	gotBond := false
-
-	for _, line := range logLines {
-		parts := strings.SplitN(line, "|", 3)
-		if len(parts) != 3 {
-			continue
-		}
-		dir := parts[0]
-		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
-			dir = resolved
-		}
-		beadsDir := parts[1]
-		if resolved, err := filepath.EvalSymlinks(beadsDir); err == nil {
-			beadsDir = resolved
-		}
-		args := parts[2]
-
-		switch {
-		case strings.Contains(args, "cook "):
-			gotCook = true
-			// cook doesn't need database context, runs from cwd
-		case strings.Contains(args, "mol wisp "):
-			gotWisp = true
-			if dir != wantDir {
-				t.Fatalf("bd mol wisp ran in %q, want %q (args: %q)", dir, wantDir, args)
-			}
-			if beadsDir != wantBeadsDir {
-				t.Fatalf("bd mol wisp used BEADS_DIR %q, want %q (args: %q)", beadsDir, wantBeadsDir, args)
-			}
-		case strings.Contains(args, "mol bond "):
-			gotBond = true
-			if dir != wantDir {
-				t.Fatalf("bd mol bond ran in %q, want %q (args: %q)", dir, wantDir, args)
-			}
-			if beadsDir != wantBeadsDir {
-				t.Fatalf("bd mol bond used BEADS_DIR %q, want %q (args: %q)", beadsDir, wantBeadsDir, args)
-			}
-		}
-	}
-
-	if !gotCook || !gotWisp || !gotBond {
-		t.Fatalf("missing expected bd commands: cook=%v wisp=%v bond=%v (log: %q)", gotCook, gotWisp, gotBond, string(logBytes))
-	}
-}
-
 func TestSlingNewlyCreatedRigBeadRoutesBDCommandsToTargetRig(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows: shell stub redacts multiline descriptions")
@@ -493,6 +298,13 @@ exit /b 0
 		t.Fatalf("runSling: %v", err)
 	}
 
+	// Also exercise the explicit formula-on-bead path; this is the older
+	// --on-style route that must use the same target rig database.
+	slingOnTarget = newBeadID
+	if err := runSling(nil, []string{"mol-review"}); err != nil {
+		t.Fatalf("runSling --on: %v", err)
+	}
+
 	logBytes, err := os.ReadFile(logPath)
 	if err != nil {
 		t.Fatalf("read bd log: %v", err)
@@ -507,9 +319,11 @@ exit /b 0
 	if resolved, err := filepath.EvalSymlinks(wantBeadsDir); err == nil {
 		wantBeadsDir = resolved
 	}
-	gotCook := false
-	gotWisp := false
-	gotBond := false
+	gotPolecatCook := false
+	gotPolecatWisp := false
+	gotReviewCook := false
+	gotReviewWisp := false
+	gotBondCount := 0
 	gotCreate := false
 	gotTargetDBCheck := false
 	gotHook := false
@@ -549,19 +363,27 @@ exit /b 0
 				t.Fatalf("target rig DB check args = %q, want --db %q", args, wantBeadsDir)
 			}
 		case strings.Contains(args, "cook "):
-			gotCook = true
-			if !strings.Contains(args, "mol-polecat-work") {
-				t.Fatalf("bd cook args = %q, want mol-polecat-work", args)
+			switch {
+			case strings.Contains(args, "mol-polecat-work"):
+				gotPolecatCook = true
+			case strings.Contains(args, "mol-review"):
+				gotReviewCook = true
+			default:
+				t.Fatalf("bd cook args = %q, want expected formula", args)
 			}
 			assertTargetRig("cook", dir, beadsDir, args)
 		case strings.Contains(args, "mol wisp "):
-			gotWisp = true
-			if !strings.Contains(args, "mol-polecat-work") {
-				t.Fatalf("bd mol wisp args = %q, want mol-polecat-work", args)
+			switch {
+			case strings.Contains(args, "mol-polecat-work"):
+				gotPolecatWisp = true
+			case strings.Contains(args, "mol-review"):
+				gotReviewWisp = true
+			default:
+				t.Fatalf("bd mol wisp args = %q, want expected formula", args)
 			}
 			assertTargetRig("mol wisp", dir, beadsDir, args)
 		case strings.Contains(args, "mol bond "):
-			gotBond = true
+			gotBondCount++
 			assertTargetRig("mol bond", dir, beadsDir, args)
 		case strings.Contains(args, "update "+newBeadID) && strings.Contains(args, "--status=hooked"):
 			gotHook = true
@@ -572,9 +394,9 @@ exit /b 0
 		}
 	}
 
-	if !gotCreate || !gotTargetDBCheck || !gotCook || !gotWisp || !gotBond || !gotHook || !gotMetadata {
-		t.Fatalf("missing expected bd commands: create=%v targetDBCheck=%v cook=%v wisp=%v bond=%v hook=%v metadata=%v (log: %q)",
-			gotCreate, gotTargetDBCheck, gotCook, gotWisp, gotBond, gotHook, gotMetadata, string(logBytes))
+	if !gotCreate || !gotTargetDBCheck || !gotPolecatCook || !gotPolecatWisp || !gotReviewCook || !gotReviewWisp || gotBondCount < 2 || !gotHook || !gotMetadata {
+		t.Fatalf("missing expected bd commands: create=%v targetDBCheck=%v polecat(cook=%v wisp=%v) review(cook=%v wisp=%v) bondCount=%d hook=%v metadata=%v (log: %q)",
+			gotCreate, gotTargetDBCheck, gotPolecatCook, gotPolecatWisp, gotReviewCook, gotReviewWisp, gotBondCount, gotHook, gotMetadata, string(logBytes))
 	}
 }
 

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -313,6 +313,271 @@ exit /b 0
 	}
 }
 
+func TestSlingNewlyCreatedRigBeadRoutesBDCommandsToTargetRig(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows: shell stub redacts multiline descriptions")
+	}
+
+	townRoot := t.TempDir()
+	newBeadID := "gt-new123"
+
+	// Minimal workspace marker so workspace.FindFromCwd() succeeds.
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir mayor/rig: %v", err)
+	}
+
+	// Create a rig path that owns gt-* beads, and a routes.jsonl pointing to it.
+	rigDir := filepath.Join(townRoot, "gastown", "mayor", "rig")
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.MkdirAll(rigDir, 0755); err != nil {
+		t.Fatalf("mkdir rigDir: %v", err)
+	}
+	routes := strings.Join([]string{
+		`{"prefix":"gt-","path":"gastown/mayor/rig"}`,
+		`{"prefix":"hq-","path":"."}`,
+		"",
+	}, "\n")
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	// Stub bd so we can observe that a newly-created rig bead's formula,
+	// hook, and metadata writes all resolve to the target rig database.
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	logPath := filepath.Join(townRoot, "bd.log")
+	bdScript := `#!/bin/sh
+set -e
+log_args=""
+for arg in "$@"; do
+  case "$arg" in
+    --description=*attached_molecule:*gt-wisp-xyz*attached_formula:*mol-polecat-work*) arg="--description=<attached-molecule-and-formula-fields>" ;;
+    --description=*) arg="--description=<redacted>" ;;
+  esac
+  log_args="${log_args}${log_args:+ }${arg}"
+done
+printf '%s|%s|%s\n' "$(pwd)" "${BEADS_DIR:-}" "$log_args" >> "${BD_LOG}"
+cmd="$1"
+shift || true
+while [ "$cmd" = "--db" ] || [ "$cmd" = "--allow-stale" ]; do
+  if [ "$cmd" = "--db" ]; then
+    shift || true
+  fi
+  cmd="$1"
+  shift || true
+done
+case "$cmd" in
+  show)
+    echo '[{"title":"Test issue","status":"open","assignee":"","description":""}]'
+    ;;
+  create)
+    echo '{"id":"gt-new123","title":"New sling smoke","status":"open","assignee":""}'
+    ;;
+  formula)
+    # formula show <name> - must output something for verifyFormulaExists
+    echo '{"name":"test-formula"}'
+    exit 0
+    ;;
+  cook)
+    exit 0
+    ;;
+  mol)
+    sub="$1"
+    shift || true
+    case "$sub" in
+      wisp)
+        echo '{"new_epic_id":"gt-wisp-xyz"}'
+        ;;
+      bond)
+        echo '{"root_id":"gt-wisp-xyz"}'
+        ;;
+    esac
+    ;;
+  update)
+    exit 0
+    ;;
+esac
+exit 0
+`
+	bdScriptWindows := `@echo off
+setlocal enableextensions
+echo %CD%^|%BEADS_DIR%^|%*>>"%BD_LOG%"
+set "cmd=%1"
+set "sub=%2"
+if "%cmd%"=="show" (
+  echo [{"title":"Test issue","status":"open","assignee":"","description":""}]
+  exit /b 0
+)
+if "%cmd%"=="formula" (
+  echo {"name":"test-formula"}
+  exit /b 0
+)
+if "%cmd%"=="cook" exit /b 0
+if "%cmd%"=="mol" (
+  if "%sub%"=="wisp" (
+    echo {"new_epic_id":"gt-wisp-xyz"}
+    exit /b 0
+  )
+  if "%sub%"=="bond" (
+    echo {"root_id":"gt-wisp-xyz"}
+    exit /b 0
+  )
+)
+exit /b 0
+`
+	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
+
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv(EnvGTRole, "mayor")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("GT_CREW", "")
+	t.Setenv("TMUX_PANE", "") // Prevent inheriting real tmux pane from test runner
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	// Ensure we don't leak global flag state across tests.
+	prevOn := slingOnTarget
+	prevVars := slingVars
+	prevDryRun := slingDryRun
+	prevNoConvoy := slingNoConvoy
+	prevResolveTargetAgent := resolveTargetAgentFn
+	t.Cleanup(func() {
+		slingOnTarget = prevOn
+		slingVars = prevVars
+		slingDryRun = prevDryRun
+		slingNoConvoy = prevNoConvoy
+		resolveTargetAgentFn = prevResolveTargetAgent
+	})
+
+	slingDryRun = false
+	slingNoConvoy = true
+	slingVars = nil
+	slingOnTarget = ""
+	resolveTargetAgentFn = func(target string) (agentID string, pane string, hookRoot string, err error) {
+		if target != "gastown/polecats/toast" {
+			t.Fatalf("resolveTargetAgent target = %q, want gastown/polecats/toast", target)
+		}
+		return "gastown/polecats/toast", "", filepath.Join(townRoot, "gastown", "polecats", "toast", "gastown"), nil
+	}
+
+	// Prevent real tmux nudge from firing during tests (causes agent self-interruption)
+	t.Setenv("GT_TEST_NO_NUDGE", "1")
+	t.Setenv("GT_TEST_SKIP_HOOK_VERIFY", "1") // Stub bd doesn't track state
+	// Poison the ambient beads target: all mutating commands must override this
+	// with the route-resolved target rig database.
+	t.Setenv("BEADS_DIR", filepath.Join(townRoot, ".beads"))
+
+	createOut, err := BdCmd("create", "--json", "--title=New sling smoke", "--type=task").
+		Dir(rigDir).
+		Output()
+	if err != nil {
+		t.Fatalf("create new rig bead: %v", err)
+	}
+	if !strings.Contains(string(createOut), newBeadID) {
+		t.Fatalf("created bead output = %q, want %s", createOut, newBeadID)
+	}
+
+	if err := runSling(nil, []string{newBeadID, "gastown/polecats/toast"}); err != nil {
+		t.Fatalf("runSling: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd log: %v", err)
+	}
+	logLines := strings.Split(strings.TrimSpace(string(logBytes)), "\n")
+
+	wantDir := rigDir
+	if resolved, err := filepath.EvalSymlinks(wantDir); err == nil {
+		wantDir = resolved
+	}
+	wantBeadsDir := filepath.Join(rigDir, ".beads")
+	if resolved, err := filepath.EvalSymlinks(wantBeadsDir); err == nil {
+		wantBeadsDir = resolved
+	}
+	gotCook := false
+	gotWisp := false
+	gotBond := false
+	gotCreate := false
+	gotTargetDBCheck := false
+	gotHook := false
+	gotMetadata := false
+	assertTargetRig := func(kind, dir, beadsDir, args string) {
+		t.Helper()
+		if dir != wantDir {
+			t.Fatalf("bd %s ran in %q, want %q (args: %q)", kind, dir, wantDir, args)
+		}
+		if beadsDir != wantBeadsDir {
+			t.Fatalf("bd %s used BEADS_DIR %q, want %q (args: %q)", kind, beadsDir, wantBeadsDir, args)
+		}
+	}
+
+	for _, line := range logLines {
+		parts := strings.SplitN(line, "|", 3)
+		if len(parts) != 3 {
+			continue
+		}
+		dir := parts[0]
+		if resolved, err := filepath.EvalSymlinks(dir); err == nil {
+			dir = resolved
+		}
+		beadsDir := parts[1]
+		if resolved, err := filepath.EvalSymlinks(beadsDir); err == nil {
+			beadsDir = resolved
+		}
+		args := parts[2]
+
+		switch {
+		case strings.Contains(args, "create "):
+			gotCreate = true
+			assertTargetRig("create", dir, beadsDir, args)
+		case strings.Contains(args, "--db ") && strings.Contains(args, " show "+newBeadID):
+			gotTargetDBCheck = true
+			if !strings.Contains(args, "--db "+wantBeadsDir) {
+				t.Fatalf("target rig DB check args = %q, want --db %q", args, wantBeadsDir)
+			}
+		case strings.Contains(args, "cook "):
+			gotCook = true
+			if !strings.Contains(args, "mol-polecat-work") {
+				t.Fatalf("bd cook args = %q, want mol-polecat-work", args)
+			}
+			assertTargetRig("cook", dir, beadsDir, args)
+		case strings.Contains(args, "mol wisp "):
+			gotWisp = true
+			if !strings.Contains(args, "mol-polecat-work") {
+				t.Fatalf("bd mol wisp args = %q, want mol-polecat-work", args)
+			}
+			assertTargetRig("mol wisp", dir, beadsDir, args)
+		case strings.Contains(args, "mol bond "):
+			gotBond = true
+			assertTargetRig("mol bond", dir, beadsDir, args)
+		case strings.Contains(args, "update "+newBeadID) && strings.Contains(args, "--status=hooked"):
+			gotHook = true
+			assertTargetRig("hook update", dir, beadsDir, args)
+		case strings.Contains(args, "update "+newBeadID) && strings.Contains(args, "--description=<attached-molecule-and-formula-fields>"):
+			gotMetadata = true
+			assertTargetRig("metadata update", dir, beadsDir, args)
+		}
+	}
+
+	if !gotCreate || !gotTargetDBCheck || !gotCook || !gotWisp || !gotBond || !gotHook || !gotMetadata {
+		t.Fatalf("missing expected bd commands: create=%v targetDBCheck=%v cook=%v wisp=%v bond=%v hook=%v metadata=%v (log: %q)",
+			gotCreate, gotTargetDBCheck, gotCook, gotWisp, gotBond, gotHook, gotMetadata, string(logBytes))
+	}
+}
+
 func TestSlingRollsBackSpawnedPolecatOnInstantiateFailure(t *testing.T) {
 	townRoot := t.TempDir()
 

--- a/internal/cmd/statusline.go
+++ b/internal/cmd/statusline.go
@@ -103,15 +103,15 @@ func runStatusLine(cmd *cobra.Command, args []string) error {
 
 	// Refinery status line
 	if role == "refinery" || strings.HasSuffix(statusLineSession, "-refinery") {
-		return runRefineryStatusLine(t, rigName)
+		return runRefineryStatusLine(rigName)
 	}
 
 	// Crew/Polecat status line
-	return runWorkerStatusLine(t, statusLineSession, rigName, polecat, crew, issue)
+	return runWorkerStatusLine(polecat, crew, issue)
 }
 
 // runWorkerStatusLine outputs status for crew or polecat sessions.
-func runWorkerStatusLine(t *tmux.Tmux, session, rigName, polecat, crew, issue string) error {
+func runWorkerStatusLine(polecat, crew, issue string) error {
 	// Determine agent type and identity
 	var icon string
 	if polecat != "" {
@@ -438,7 +438,7 @@ func runWitnessStatusLine(t *tmux.Tmux, rigName string) error {
 
 // runRefineryStatusLine outputs status for a refinery session.
 // Shows: MQ length, current item, hook or mail preview
-func runRefineryStatusLine(t *tmux.Tmux, rigName string) error {
+func runRefineryStatusLine(rigName string) error {
 	if rigName == "" {
 		// Try to extract from session name: <prefix>-refinery
 		if identity, err := session.ParseSessionName(statusLineSession); err == nil && identity.Role == session.RoleRefinery {

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -392,9 +392,11 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 
 	// Track cleanup on failure, but only if this invocation still owns the path.
 	cleanup := func() { removeRigPathIfOwned(rigPath, ownershipStamp) }
+	routeRollback := func() {}
 	success := false
 	defer func() {
 		if !success {
+			routeRollback()
 			cleanup()
 		}
 	}()
@@ -591,6 +593,9 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 			// Only error on mismatch if user explicitly provided --prefix
 			if userProvidedPrefix && strings.TrimSuffix(opts.BeadsPrefix, "-") != strings.TrimSuffix(sourcePrefix, "-") {
 				return nil, fmt.Errorf("prefix mismatch: source repo uses '%s' but --prefix '%s' was provided; use --prefix %s to match existing issues", sourcePrefix, opts.BeadsPrefix, sourcePrefix)
+			}
+			if err := beads.CheckPrefixAvailable(m.townRoot, sourcePrefix+"-", opts.Name); err != nil {
+				return nil, fmt.Errorf("prefix collision (source repo prefix %q): %w", sourcePrefix, err)
 			}
 			// Use detected prefix (overrides derived prefix)
 			opts.BeadsPrefix = sourcePrefix
@@ -866,8 +871,14 @@ Use crew for your own workspace. Polecats are for batch work dispatch.
 			Prefix: opts.BeadsPrefix + "-",
 			Path:   routePath,
 		}
-		if err := beads.AppendRoute(m.townRoot, route); err != nil {
-			fmt.Printf("  Warning: Could not update routes.jsonl: %v\n", err)
+		previousRoute, err := beads.AppendRouteIfPrefixAvailable(m.townRoot, route)
+		if err != nil {
+			return nil, fmt.Errorf("registering rig route: %w", err)
+		}
+		routeRollback = func() {
+			if err := beads.RestoreRouteIfCurrent(m.townRoot, route, previousRoute); err != nil {
+				fmt.Fprintf(os.Stderr, "  Warning: Could not roll back route %s -> %s: %v\n", route.Prefix, route.Path, err)
+			}
 		}
 	}
 

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -1380,6 +1380,9 @@ func TestAddRig_TrackedBeadsPrefixCollisionDoesNotRewriteRoute(t *testing.T) {
 	if got := err.Error(); !strings.Contains(got, "source repo prefix") || !strings.Contains(got, "already used") {
 		t.Fatalf("AddRig error = %q, want source prefix collision", got)
 	}
+	if got := err.Error(); strings.Contains(got, "use --prefix") {
+		t.Fatalf("AddRig error = %q, should not suggest --prefix for tracked source prefix collision", got)
+	}
 
 	routes, err := beads.LoadRoutes(filepath.Join(root, ".beads"))
 	if err != nil {

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/git"
@@ -1331,6 +1332,105 @@ func TestDetectBeadsPrefixFromConfig_NoFallbackToJSONL(t *testing.T) {
 	got := detectBeadsPrefixFromConfig(configPath)
 	if got != "" {
 		t.Errorf("detectBeadsPrefixFromConfig() = %q, want empty (should not read issues.jsonl)", got)
+	}
+}
+
+func TestAddRig_TrackedBeadsPrefixCollisionDoesNotRewriteRoute(t *testing.T) {
+	repoDir := t.TempDir()
+	beadsDir := filepath.Join(repoDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(repoDir, "README.md"), []byte("# second rig\n"), 0644); err != nil {
+		t.Fatalf("write README.md: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("prefix: gt\nissue-prefix: gt\n"), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+	for _, args := range [][]string{
+		{"git", "init", "--initial-branch=main", repoDir},
+		{"git", "-C", repoDir, "config", "user.email", "test@test.com"},
+		{"git", "-C", repoDir, "config", "user.name", "Test User"},
+		{"git", "-C", repoDir, "add", "README.md"},
+		{"git", "-C", repoDir, "add", "-f", ".beads/config.yaml"},
+		{"git", "-C", repoDir, "commit", "-m", "Initial commit with beads config"},
+	} {
+		cmd := exec.Command(args[0], args[1:]...)
+		if out, err := cmd.CombinedOutput(); err != nil {
+			t.Fatalf("%v: %v\n%s", args, err, out)
+		}
+	}
+
+	root, rigsConfig := setupTestTown(t)
+	if err := beads.WriteRoutes(filepath.Join(root, ".beads"), []beads.Route{
+		{Prefix: "gt-", Path: "gastown/mayor/rig"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+	manager := NewManager(root, rigsConfig, git.NewGit(root))
+
+	_, err := manager.AddRig(AddRigOptions{
+		Name:          "secondrig",
+		GitURL:        repoDir,
+		SkipDoltCheck: true,
+	})
+	if err == nil {
+		t.Fatal("AddRig succeeded, want tracked source prefix collision")
+	}
+	if got := err.Error(); !strings.Contains(got, "source repo prefix") || !strings.Contains(got, "already used") {
+		t.Fatalf("AddRig error = %q, want source prefix collision", got)
+	}
+
+	routes, err := beads.LoadRoutes(filepath.Join(root, ".beads"))
+	if err != nil {
+		t.Fatalf("load routes: %v", err)
+	}
+	if len(routes) != 1 {
+		t.Fatalf("routes count = %d, want 1: %#v", len(routes), routes)
+	}
+	if routes[0].Prefix != "gt-" || routes[0].Path != "gastown/mayor/rig" {
+		t.Fatalf("route = %#v, want gt- -> gastown/mayor/rig", routes[0])
+	}
+	if _, err := os.Stat(filepath.Join(root, "secondrig")); !os.IsNotExist(err) {
+		t.Fatalf("secondrig directory still exists after failed add: %v", err)
+	}
+}
+
+func TestAddRig_RollsBackRouteWhenRegistrationFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-based bd shim not reliable on Windows CI")
+	}
+
+	fakeBDForAddRig(t)
+
+	root, rigsConfig := setupTestTown(t)
+	if err := os.WriteFile(filepath.Join(root, "mayor"), []byte("not a directory\n"), 0644); err != nil {
+		t.Fatalf("write mayor blocker: %v", err)
+	}
+	manager := NewManager(root, rigsConfig, git.NewGit(root))
+	repoDir := createTestGitRepoForRig(t, "rollbackrepo")
+
+	_, err := manager.AddRig(AddRigOptions{
+		Name:          "rollbackrig",
+		GitURL:        repoDir,
+		BeadsPrefix:   "rb",
+		SkipDoltCheck: true,
+	})
+	if err == nil {
+		t.Fatal("AddRig succeeded, want rigs.json registration failure")
+	}
+	if got := err.Error(); !strings.Contains(got, "registering rig in rigs.json") {
+		t.Fatalf("AddRig error = %q, want rigs.json registration failure", got)
+	}
+
+	routes, err := beads.LoadRoutes(filepath.Join(root, ".beads"))
+	if err != nil {
+		t.Fatalf("load routes: %v", err)
+	}
+	for _, route := range routes {
+		if route.Prefix == "rb-" {
+			t.Fatalf("route was not rolled back after failed add: %#v", routes)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Rebuilds the routing convergence fix as a clean `main`-target fork PR.
- Guards rig route registration so tracked source `.beads/config.yaml` prefixes cannot rewrite another rig's route.
- Adds route rollback for failed rig registration and smoke coverage for newly-created rig bead sling routing to the target rig DB.

## Supersedes
- Clean main-target rebuild of #4092.
- Supersedes and replaces #4092, #4086, and #4088.
- #4085 is intentionally not included; its doctor/design diagnostic route validation should remain a separate follow-up unless maintainers decide to drop that diagnostic slice.

## Validation
- PASS: `make build`
- PASS: `go test ./internal/beads -run 'TestAppendRouteIfPrefixAvailable|TestCheckPrefixAvailable|TestResolveBeadsDirForID|TestGetPrefixForRig|TestValidateRigPrefix' -count=1`
- PASS: `go test ./internal/rig -run 'TestAddRig_TrackedBeadsPrefixCollisionDoesNotRewriteRoute|TestAddRig_RollsBackRouteWhenRegistrationFails|TestAddRig_TrackedBeads|TestAddRig_UpstreamURL|TestAddRig_BranchFlag' -count=1`
- PASS: `go test ./internal/cmd -run '^TestSling(FormulaOnBeadRoutesBDCommandsToTargetRig|NewlyCreatedRigBeadRoutesBDCommandsToTargetRig)$' -count=1 -v`

## Closure Recommendation
- Close #4092, #4086, and #4088 as superseded after this lands.
- Keep #4085 open as follow-up, or close it separately as intentionally deferred/dropped if that is the desired product decision.

Issue: gt-pr-main-routing-rebuild