### PR TITLE
fix: collapse status mail lookup

### DIFF
--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -120,15 +120,15 @@ type DNDInfo struct {
 
 // AgentRuntime represents the runtime state of an agent.
 type AgentRuntime struct {
-	Name         string `json:"name"`                    // Display name (e.g., "mayor", "witness")
-	Address      string `json:"address"`                 // Full address (e.g., "greenplace/witness")
-	Session      string `json:"session"`                 // tmux session name
-	Role         string `json:"role"`                    // Role type
-	Running      bool   `json:"running"`                 // Is tmux session running?
-	ACP          bool   `json:"acp"`                     // Is ACP session active?
-	HasWork      bool   `json:"has_work"`                // Has pinned work?
-	WorkTitle    string `json:"work_title,omitempty"`    // Title of pinned work
-	HookBead     string `json:"hook_bead,omitempty"`     // Pinned bead ID from agent bead
+	Name              string `json:"name"`                         // Display name (e.g., "mayor", "witness")
+	Address           string `json:"address"`                      // Full address (e.g., "greenplace/witness")
+	Session           string `json:"session"`                      // tmux session name
+	Role              string `json:"role"`                         // Role type
+	Running           bool   `json:"running"`                      // Is tmux session running?
+	ACP               bool   `json:"acp"`                          // Is ACP session active?
+	HasWork           bool   `json:"has_work"`                     // Has pinned work?
+	WorkTitle         string `json:"work_title,omitempty"`         // Title of pinned work
+	HookBead          string `json:"hook_bead,omitempty"`          // Pinned bead ID from agent bead
 	State             string `json:"state,omitempty"`              // Agent state from agent bead
 	NotificationLevel string `json:"notification_level,omitempty"` // Notification level (verbose, normal, muted)
 	UnreadMail        int    `json:"unread_mail"`                  // Number of unread messages
@@ -1685,11 +1685,19 @@ func populateMailInfo(agent *AgentRuntime, router *mail.Router) {
 	if err != nil {
 		return
 	}
-	_, unread, _ := mailbox.Count()
-	agent.UnreadMail = unread
-	if unread > 0 {
-		if messages, err := mailbox.ListUnread(); err == nil && len(messages) > 0 {
-			agent.FirstSubject = messages[0].Subject
+	messages, err := mailbox.List()
+	if err != nil {
+		return
+	}
+	firstSubjectSet := false
+	for _, msg := range messages {
+		if msg.Read {
+			continue
+		}
+		agent.UnreadMail++
+		if !firstSubjectSet {
+			agent.FirstSubject = msg.Subject
+			firstSubjectSet = true
 		}
 	}
 }

--- a/internal/cmd/status.go
+++ b/internal/cmd/status.go
@@ -120,15 +120,15 @@ type DNDInfo struct {
 
 // AgentRuntime represents the runtime state of an agent.
 type AgentRuntime struct {
-	Name              string `json:"name"`                         // Display name (e.g., "mayor", "witness")
-	Address           string `json:"address"`                      // Full address (e.g., "greenplace/witness")
-	Session           string `json:"session"`                      // tmux session name
-	Role              string `json:"role"`                         // Role type
-	Running           bool   `json:"running"`                      // Is tmux session running?
-	ACP               bool   `json:"acp"`                          // Is ACP session active?
-	HasWork           bool   `json:"has_work"`                     // Has pinned work?
-	WorkTitle         string `json:"work_title,omitempty"`         // Title of pinned work
-	HookBead          string `json:"hook_bead,omitempty"`          // Pinned bead ID from agent bead
+	Name         string `json:"name"`                    // Display name (e.g., "mayor", "witness")
+	Address      string `json:"address"`                 // Full address (e.g., "greenplace/witness")
+	Session      string `json:"session"`                 // tmux session name
+	Role         string `json:"role"`                    // Role type
+	Running      bool   `json:"running"`                 // Is tmux session running?
+	ACP          bool   `json:"acp"`                     // Is ACP session active?
+	HasWork      bool   `json:"has_work"`                // Has pinned work?
+	WorkTitle    string `json:"work_title,omitempty"`    // Title of pinned work
+	HookBead     string `json:"hook_bead,omitempty"`     // Pinned bead ID from agent bead
 	State             string `json:"state,omitempty"`              // Agent state from agent bead
 	NotificationLevel string `json:"notification_level,omitempty"` // Notification level (verbose, normal, muted)
 	UnreadMail        int    `json:"unread_mail"`                  // Number of unread messages


### PR DESCRIPTION
## Summary
- Rebuilds the useful one-file status mail enrichment collapse from #4084 on a fresh `main`-based fork branch.
- Replaces `Count()` plus `ListUnread()` in `populateMailInfo` with a single `List()` pass, preserving empty first-subject values.
- Keeps #4084 untouched because it targets `integration/test-beaddolt-hardenning`; recommend closing #4084 and `gt-rca-dolt-status-latency` after this lands.

## Verification
- Confirmed absent on `origin/main`: `git grep -n -E "mailbox.Count|ListUnread|mailbox.List" origin/main -- internal/cmd/status.go`
- Confirmed absent from installed `gt` source commit `a80591ab`
- `go build -o /tmp/opencode/gt-main-status ./cmd/gt`
- `go test ./internal/cmd -run 'TestTryStatusDetailLockContention|TestRunStatusWatch|TestOutputStatusText|TestBuildStatusIndicator'`
- `go test ./internal/mail -run 'TestMailbox.*Unread|TestMailboxLegacyListUnread|TestMailboxMarkReadOnlyExcludesFromUnread'`
- `/review-implementation --branch origin/main...HEAD` returned Grade A/no findings

Refs: #4084, gt-pr-main-status-4084-rebuild