### PR TITLE
fix(boot): block raw tmux send-keys to prevent staged Deacon-TUI landmines

### DIFF
--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -410,7 +410,12 @@ func outputCommandQuickReference(ctx RoleContext) {
 		fmt.Println("|------------|----------------|----------------|")
 		fmt.Printf("| Run triage | `%s boot triage` | ~~gt deacon heartbeat~~ (that's Deacon's job) |\n", c)
 		fmt.Printf("| Check Deacon health | `%s deacon status` | ~~gt status~~ (town-wide, not Deacon-specific) |\n", c)
-		fmt.Printf("| Nudge the Deacon | `%s nudge deacon \"msg\"` | ~~tmux send-keys~~ (unreliable) |\n", c)
+		fmt.Printf("| Message the Deacon | `%s nudge deacon \"msg\"` | ~~tmux send-keys~~ (BLOCKED — see below) |\n", c)
+		fmt.Println()
+		fmt.Println("**NEVER use raw `tmux send-keys` against the Deacon (or any agent).**")
+		fmt.Println("It can leave text staged but unsubmitted in the Deacon's input box;")
+		fmt.Println("a later submit stops the patrol loop and town monitoring goes dark.")
+		fmt.Printf("Always use `%s nudge deacon \"msg\"` — it submits reliably under a lock.\n", c)
 	}
 
 	fmt.Println()

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -342,8 +342,26 @@ func DefaultOverrides() map[string]*HooksConfig {
 				},
 			},
 		},
+		// Boot watchdog: block raw `tmux send-keys` (hq-fzv).
+		// Boot is an ephemeral, stateless watchdog whose only legitimate way to
+		// reach the Deacon is `gt nudge`, which stages text AND submits it (Enter)
+		// under a serialized lock. A raw `tmux send-keys` from Boot's reasoning can
+		// leave text (e.g. "Stop the patrol loop") staged but UNSUBMITTED in the
+		// Deacon TUI input. Because Boot is fresh each tick with no handoff, the
+		// next tick sees the orphaned draft as an unexplained injection. If that
+		// draft is ever submitted, the Deacon's patrol loop stops and town
+		// monitoring goes dark with no auto-respawn. Force Boot through gt nudge.
 		"boot": {
 			UserPromptSubmit: []HookEntry{{Matcher: ""}},
+			PreToolUse: []HookEntry{
+				{
+					Matcher: "Bash(*tmux send-keys*)",
+					Hooks: []Hook{{
+						Type:    "command",
+						Command: "echo '❌ BLOCKED: Boot must not use raw tmux send-keys. It can leave unsubmitted text staged in the Deacon TUI input, which stops town monitoring if later submitted (hq-fzv).' && echo 'Use: gt nudge deacon \"msg\" — reliable, serialized, always submits.' && exit 2",
+					}},
+				},
+			},
 		},
 		// Deacon roles: patrol-formula-guard (same as witness).
 		// Deacons also run patrols and must use wisps, not persistent molecules.

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -643,6 +643,24 @@ func TestComputeExpectedNoBase(t *testing.T) {
 		}
 	}
 
+	// Boot should get DefaultBase + built-in tmux-send-keys guard (hq-fzv).
+	boot, err := ComputeExpected("boot")
+	if err != nil {
+		t.Fatalf("ComputeExpected(boot) failed: %v", err)
+	}
+	if len(boot.SessionStart) != len(defaultBase.SessionStart) {
+		t.Error("expected boot to inherit SessionStart from DefaultBase")
+	}
+	bootSendKeysGuarded := false
+	for _, entry := range boot.PreToolUse {
+		if entry.Matcher == "Bash(*tmux send-keys*)" {
+			bootSendKeysGuarded = true
+		}
+	}
+	if !bootSendKeysGuarded {
+		t.Error("boot missing tmux-send-keys guard matcher: Bash(*tmux send-keys*)")
+	}
+
 	// Refinery should get DefaultBase + built-in patrol-formula-guard (same as witness)
 	refinery, err := ComputeExpected("refinery")
 	if err != nil {


### PR DESCRIPTION
> **DRAFT** — the guard and its config-generation are verified; the behavioral root-cause link (that Boot's raw `tmux send-keys` is what stages the landmine) is **inferred, not proven**. See "Open question for maintainers."

## Summary

Boot (the ephemeral, per-tick Deacon watchdog) can leave text staged but **unsubmitted** in the Deacon's TUI input via a raw `tmux send-keys`. Observed artifact: `"Stop the patrol loop"` recurring in the `hq-deacon` input box. If that staged text is ever submitted (a stray nudge/keystroke), the Deacon's patrol loop stops and town monitoring goes dark with no auto-respawn.

Fix: block `Bash(*tmux send-keys*)` for Boot via a PreToolUse hook and steer it to `gt nudge`, which stages **and** submits (Enter) under a serialized lock.

## Related Issue

No GitHub issue — bug fix with reproduction context. Both the missing guard and the underlying behavior are present on current `main`.

## Changes

- New `"boot"` PreToolUse hook in `DefaultOverrides()` blocking `Bash(*tmux send-keys*)`, mirroring the existing witness/deacon patrol-formula guards.
- Boot prime-context cheatsheet: advisory "(unreliable)" note → explicit prohibition with rationale.
- Test asserting `ComputeExpected("boot")` carries the guard.
- **Mayor intentionally excluded**: the Mayor uses `tmux send-keys C-u` to *clear* a staged landmine — that mitigation must stay available.

## Repro

The *trigger* (what makes Boot emit the keystroke) isn't pinned — the phrase isn't anywhere in the source tree, so it's agent-generated. But the **mechanism** the guard defends against and the **guard itself** are both directly reproducible.

**1. The mechanism — a raw `send-keys` without a submit leaves text staged in the agent's input box (this is what we observed recurring in production):**

```bash
# No Enter — text just sits in the Claude Code input prompt:
tmux send-keys -t <deacon-session> "Stop the patrol loop"
tmux capture-pane -p -t <deacon-session> | grep '❯'
# → "❯ Stop the patrol loop"   (staged, UNSUBMITTED)
```

By contrast `gt nudge deacon "..."` stages **and** submits (Escape → verified Enter) under a per-session lock, so it never leaves a dangling draft. That is why Boot must route through `gt nudge`, never raw `send-keys`. Risk if the staged text is ever submitted: the Deacon's patrol loop stops and town monitoring goes dark with no auto-respawn.

**2. The guard blocks it — `Bash(*tmux send-keys*)` PreToolUse hook returns exit 2 (Claude Code's block signal):**

```bash
$ go test ./internal/hooks/   # asserts ComputeExpected("boot") carries the matcher
ok  github.com/steveyegge/gastown/internal/hooks

# After `gt hooks sync`, the live boot settings.json carries the matcher, and the
# hook command fires on any tmux send-keys attempt:
$ <boot hook command>
❌ BLOCKED: Boot must not use raw tmux send-keys. ...
$ echo $?
2
```

## Design note (ZFC)

Transport-level enforcement, not cognition-in-Go: it does not encode a heuristic about *when* Boot is misbehaving — it makes a footgun tool unreachable and points at the sanctioned primitive (`gt nudge`). It follows the established PreToolUse guard pattern already used for patrol-formula and dangerous-command guards, and deliberately targets the **mechanism** (unsubmitted staging) rather than a proven root cause.

## Open question for maintainers

The exact emitter of the `send-keys` isn't pinned — the phrase isn't anywhere in the source tree, so it's agent-generated. If there's a daemon-side code path that issues it during Deacon-wake / Boot-triage, this hook is defense-in-depth and the real emitter should also be fixed. Pointers welcome.

## Testing
- [x] `go test ./internal/hooks/` passes; `ComputeExpected("boot")` includes `Bash(*tmux send-keys*)`
- [x] Live config-gen: `gt hooks sync` writes the guard into `deacon/dogs/boot/.claude/settings.json`; the hook command returns exit 2 (Claude's block signal) when fired
- [x] `go vet` and `gofmt` clean
- [ ] Live: confirm a real Boot session is blocked from `send-keys` and that the recurrence stops over many ticks (needs extended observation; root cause inferred)

## Checklist
- [x] Code follows project style (gofmt, go vet)
- [x] No breaking changes
- [x] Tests added for new functionality
