### PR TITLE
fix(deacon): start nudge-poller so the nudge queue drains

### DIFF
--- a/internal/cmd/deacon.go
+++ b/internal/cmd/deacon.go
@@ -16,6 +16,7 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/deacon"
+	"github.com/steveyegge/gastown/internal/nudge"
 	"github.com/steveyegge/gastown/internal/runtime"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/style"
@@ -580,6 +581,16 @@ func startDeaconSession(t *tmux.Tmux, sessionName, agentOverride string) error {
 	deaconTownRoot, _ := workspace.FindFromCwdOrError()
 	runtimeCfg := config.ResolveRoleAgentConfig("deacon", deaconTownRoot, "")
 	_ = runtime.RunStartupFallback(t, sessionName, "deacon", runtimeCfg)
+
+	// Start nudge-queue poller (gt-dgf, mirroring witness/refinery). Claude's
+	// UserPromptSubmit hook only drains the nudge queue when the agent submits a
+	// prompt, and the Dolt-subprocess-storm hardening disabled the deacon's
+	// per-turn `gt mail check --inject` drain. Without a poller the deacon's
+	// queue never drains and fills up. The poller drains on a 10s interval
+	// without re-introducing the per-turn Dolt subprocess.
+	if _, pollerErr := nudge.StartPoller(townRoot, sessionName); pollerErr != nil {
+		style.PrintWarning("could not start nudge poller for %s: %v", sessionName, pollerErr)
+	}
 
 	return nil
 }


### PR DESCRIPTION
> **DRAFT** — verified against latest `main` (code-level A/B + live poller validation). Opening as draft for maintainer review of the approach.

## Summary

After the Dolt-subprocess-storm hardening disabled the Deacon's per-turn `gt mail check --inject` hook, the Deacon's nudge queue has **no drain mechanism** and fills up (observed 50/50 full; subsequent queue-mode nudges then fail). `witness`/`refinery` compensate with a `nudge.StartPoller`; the Deacon had no such fallback. This adds the same poller to Deacon startup.

## Related Issue

No GitHub issue — bug fix with reproduction. Reproduces on current `main`.

## Root cause

`gt mail check --inject` did double duty — mail check **and** nudge-queue drain (`internal/cmd/mail_check.go` calls `nudge.Drain`). The hardening commit added `UserPromptSubmit: [{matcher:""}]` (explicit-disable) for patrol roles to stop a Dolt subprocess firing on every turn boundary — which also removed their nudge-queue drain.

- `witness`/`refinery`: their managers call `nudge.StartPoller` → queue still drains via the 10s poller ✓
- `deacon`: a Claude Code agent (`HasTurnBoundaryDrain=true`), so the framework starts no poller, and `startDeaconSession` never called `StartPoller` → **no drain at all** ✗

## Changes

- `startDeaconSession` (`internal/cmd/deacon.go`) calls `nudge.StartPoller(townRoot, sessionName)` after session startup, mirroring `internal/witness/manager.go` and `internal/refinery/manager.go`.

## Repro / verification (vs latest main)

```
# nudge.StartPoller present in startDeaconSession?
plain main:   0   (bug — no drain)
this branch:  1   (fixed)

# the asymmetry being corrected — already present on main:
witness:  1
refinery: 1
```

Live: on an affected town whose Deacon queue had filled to 50/50, starting `gt nudge-poller hq-deacon` (the same `nudge.StartPoller` mechanism) drained the queue and kept it empty.

## Design note (ZFC)

Pure transport: it wires up the existing nudge-poller transport for the Deacon, matching the established witness/refinery pattern. No new heuristics or thresholds. It deliberately uses the poller (10s interval) rather than re-enabling the per-turn `gt mail check --inject`, so it does not undo the Dolt-storm hardening.

## Scope note

`boot` also lost its turn-boundary drain, but it is ephemeral (fresh per tick, exits quickly), so a long-lived poller is a poor fit there and its queue does not accumulate the same way. This PR fixes the concrete, observed case (the long-lived Deacon).

## Testing
- [x] `go build ./...`, `go vet ./internal/cmd/`, `gofmt` clean
- [x] A/B vs latest `main`: `nudge.StartPoller` absent in `startDeaconSession` on main, present here; witness/refinery already carry it
- [x] Live: poller drains the Deacon queue and keeps it empty
- [ ] No automated startup test (none exists for the witness/refinery poller calls either — startup wiring)

## Checklist
- [x] Code follows project style (gofmt, go vet)
- [x] No breaking changes
- [x] Mirrors existing, tested-in-production witness/refinery pattern
