### PR TITLE
Resolve convoy tracked issues via rig beads fallback

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -2272,7 +2272,7 @@ func getTrackedIssues(townBeads, convoyID string) ([]trackedIssueInfo, error) {
 	}
 
 	// Fetch fresh issue details via bd show (uses prefix routing for cross-rig).
-	freshDetails := getIssueDetailsBatch(trackedIDs)
+	freshDetails := getIssueDetailsBatch(townBeads, trackedIDs)
 
 	// Build tracked dependency structs from fresh details. When fresh details
 	// are missing (cross-rig DB unreachable, missing, parked, or unroutable
@@ -2485,7 +2485,7 @@ func (d issueDetails) IsBlocked() bool {
 
 // getIssueDetailsBatch fetches details for multiple issues in a single bd show call.
 // Returns a map from issue ID to details. Missing/invalid issues are omitted from the map.
-func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
+func getIssueDetailsBatch(townRoot string, issueIDs []string) map[string]*issueDetails {
 	result := make(map[string]*issueDetails)
 	if len(issueIDs) == 0 {
 		return result
@@ -2497,62 +2497,92 @@ func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
 
 	// Run from town root so bd's prefix routing (routes.jsonl) can dispatch
 	// to the correct rig database for cross-rig bead lookups. (GH#2960)
-	townRoot, _ := workspace.FindFromCwdOrError()
+	if townRoot == "" {
+		townRoot, _ = workspace.FindFromCwdOrError()
+	}
 	bdc := BdCmd(args...).Stderr(io.Discard)
 	if townRoot != "" {
 		bdc.Dir(townRoot).WithRouting()
 	}
 	out, err := bdc.Output()
-	if err != nil {
-		// Batch failed - fall back to individual lookups for robustness
-		// This handles cases where some IDs are invalid/missing
-		for _, id := range issueIDs {
-			if details := getIssueDetails(id); details != nil {
-				result[id] = details
+	if err == nil {
+		var issues []issueDetailsJSON
+		if json.Unmarshal(out, &issues) == nil {
+			for _, issue := range issues {
+				result[issue.ID] = issue.toIssueDetails()
 			}
 		}
-		return result
 	}
 
-	var issues []issueDetailsJSON
-	if err := json.Unmarshal(out, &issues); err != nil {
-		return result
-	}
-
-	for _, issue := range issues {
-		result[issue.ID] = issue.toIssueDetails()
+	// Batch routing can fail or omit cross-rig issues when routes point at a rig
+	// runtime .beads directory that bd cannot discover from cwd alone. Fall back
+	// per ID using Gas Town's route resolver and BEADS_DIR pinning. This keeps a
+	// single bad route from making completed convoys permanently "unknown".
+	for _, id := range issueIDs {
+		if _, ok := result[id]; ok {
+			continue
+		}
+		if details := getIssueDetailsFromTown(townRoot, id); details != nil {
+			result[id] = details
+		}
 	}
 
 	return result
 }
 
-// getIssueDetails fetches issue details by trying to show it via bd.
-// Prefer getIssueDetailsBatch for multiple issues to avoid N+1 subprocess calls.
-func getIssueDetails(issueID string) *issueDetails {
-	// Use bd show with routing - resolve from town root so bd's prefix
-	// routing (routes.jsonl) can dispatch to the correct rig database.
-	// Without Dir + StripBeadsDir, bd inherits CWD/BEADS_DIR which may
-	// point to a rig that doesn't contain the target bead. (GH#2960)
-	townRoot, _ := workspace.FindFromCwdOrError()
-	bdc := BdCmd("show", issueID, "--json").Stderr(io.Discard)
-	if townRoot != "" {
-		bdc.Dir(townRoot).WithRouting()
-	}
-	out, err := bdc.Output()
-	if err != nil {
-		return nil
-	}
-	// Handle bd exit 0 bug: empty stdout means not found
+func parseIssueDetails(out []byte) *issueDetails {
 	if len(out) == 0 {
 		return nil
 	}
-
 	var issues []issueDetailsJSON
 	if err := json.Unmarshal(out, &issues); err != nil || len(issues) == 0 {
 		return nil
 	}
-
 	return issues[0].toIssueDetails()
+}
+
+func getIssueDetailsFromBeadsDir(beadsDir, issueID string) *issueDetails {
+	if beadsDir == "" {
+		return nil
+	}
+	out, err := BdCmd("show", issueID, "--json").WithBeadsDir(beadsDir).Stderr(io.Discard).Output()
+	if err != nil {
+		return nil
+	}
+	return parseIssueDetails(out)
+}
+
+func getIssueDetailsFromTown(townRoot, issueID string) *issueDetails {
+	if townRoot == "" {
+		return nil
+	}
+
+	// First try an explicit route-to-BEADS_DIR lookup. This handles Gas Town's
+	// rig runtime layout (<town>/<rig>/.beads) even when bd's own cwd-based
+	// prefix routing cannot discover that database.
+	townBeads := beads.ResolveBeadsDir(townRoot)
+	if townBeads != "" {
+		resolvedBeads := beads.ResolveBeadsDirForID(townBeads, issueID)
+		if resolvedBeads != "" {
+			if details := getIssueDetailsFromBeadsDir(resolvedBeads, issueID); details != nil {
+				return details
+			}
+		}
+	}
+
+	// Fallback to bd's native routing from the town root.
+	out, err := BdCmd("show", issueID, "--json").Dir(townRoot).WithRouting().Stderr(io.Discard).Output()
+	if err != nil {
+		return nil
+	}
+	return parseIssueDetails(out)
+}
+
+// getIssueDetails fetches issue details by trying to show it via bd.
+// Prefer getIssueDetailsBatch for multiple issues to avoid N+1 subprocess calls.
+func getIssueDetails(issueID string) *issueDetails {
+	townRoot, _ := workspace.FindFromCwdOrError()
+	return getIssueDetailsFromTown(townRoot, issueID)
 }
 
 // workerInfo holds info about a worker assigned to an issue.

--- a/internal/cmd/convoy_empty_test.go
+++ b/internal/cmd/convoy_empty_test.go
@@ -86,6 +86,49 @@ esac
 	return binDir, townRoot, closeLogPath
 }
 
+func TestGetIssueDetailsBatchFallsBackToResolvedBeadsDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell mock uses /bin/sh")
+	}
+
+	binDir := t.TempDir()
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	rigBeads := filepath.Join(townRoot, "hc_lims", ".beads")
+	if err := os.MkdirAll(rigBeads, 0755); err != nil {
+		t.Fatal(err)
+	}
+	routes := `{"prefix":"hc-","path":"hc_lims"}` + "\n"
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	bdPath := filepath.Join(binDir, "bd")
+	script := `#!/bin/sh
+if [ "$BEADS_DIR" = "` + rigBeads + `" ] && [ "$1" = "show" ] && [ "$2" = "hc-done" ]; then
+  echo '[{"id":"hc-done","title":"Done issue","status":"closed","issue_type":"task"}]'
+  exit 0
+fi
+# Simulate native routing failure from town root.
+exit 1
+`
+	if err := os.WriteFile(bdPath, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	details := getIssueDetailsBatch(townRoot, []string{"hc-done"})
+	got := details["hc-done"]
+	if got == nil {
+		t.Fatal("expected fallback to resolved rig .beads to return issue details")
+	}
+	if got.Status != "closed" || got.Title != "Done issue" {
+		t.Fatalf("details = %+v, want closed Done issue", got)
+	}
+}
+
 func TestCheckSingleConvoy_EmptyConvoyDoesNotAutoClose(t *testing.T) {
 	// When getTrackedIssues returns empty (cross-rig resolution failure or truly
 	// no tracked issues), closeConvoyIfComplete must NOT auto-close. A 0/0 result


### PR DESCRIPTION
## Summary\n- Pass town root into convoy tracked-issue detail lookups instead of relying on the caller CWD\n- Fall back from bd native prefix routing to Gas Town route resolution + BEADS_DIR pinning\n- Prevent completed cross-rig tracked issues from staying permanently unknown when routes point at rig runtime .beads directories\n\n## Verification\n- go test ./internal/cmd -run 'TestGetIssueDetailsBatchFallsBackToResolvedBeadsDir|TestCheckSingleConvoy_EmptyConvoyDoesNotAutoClose'\n- make build\n- Manual: built ./gt convoy status hq-cv-xm74i and hq-cv-do73q now reports Progress 1/1 and tracked hc-* issues as closed instead of unknown/cross-rig unreachable\n\nNote: auto-closing the production convoys exposed a separate beads auto-import/stale JSONL issue where bd repeatedly prints auto-importing ... into empty database; that is the next infra task, not part of this convoy routing fix.