### PR TITLE
Add command description to bd timeout errors

### DIFF
--- a/internal/cmd/bd_helpers.go
+++ b/internal/cmd/bd_helpers.go
@@ -198,14 +198,31 @@ func (b *bdCmd) buildContextCommand(ctx context.Context) *exec.Cmd {
 	return cmd
 }
 
-func wrapBdCmdTimeout(ctx context.Context, err error) error {
+func (b *bdCmd) wrapTimeout(err error, deadline time.Duration) error {
 	if err == nil {
 		return nil
 	}
-	if ctx.Err() == context.DeadlineExceeded || strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
-		return fmt.Errorf("bd command timed out after %v: %w", resolveBdCmdTimeout(), err)
+	if strings.Contains(err.Error(), context.DeadlineExceeded.Error()) {
+		return fmt.Errorf("%s timed out after %v: %w", b.argsDesc(), deadline, err)
 	}
 	return err
+}
+
+func (b *bdCmd) argsDesc() string {
+	desc := "bd"
+	if len(b.args) > 0 {
+		desc += " " + b.args[0]
+	}
+	if len(b.args) > 1 {
+		desc += fmt.Sprintf(" ... (%d args)", len(b.args))
+	}
+	if b.beadsDir != "" {
+		desc += fmt.Sprintf(" beads_dir=%s", b.beadsDir)
+	}
+	if b.dir != "" {
+		desc += fmt.Sprintf(" cwd=%s", b.dir)
+	}
+	return desc
 }
 
 // resolvedArgs returns the final args, stripping --allow-stale if bd doesn't support it.
@@ -225,9 +242,10 @@ func (b *bdCmd) resolvedArgs() []string {
 // Run builds and runs the command, returning any error.
 // This is a convenience method equivalent to Build().Run().
 func (b *bdCmd) Run() error {
-	ctx, cancel := context.WithTimeout(context.Background(), resolveBdCmdTimeout())
+	deadline := resolveBdCmdTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
 	defer cancel()
-	return wrapBdCmdTimeout(ctx, b.buildContextCommand(ctx).Run())
+	return b.wrapTimeout(b.buildContextCommand(ctx).Run(), deadline)
 }
 
 // Output builds and runs the command, returning stdout and any error.
@@ -235,17 +253,19 @@ func (b *bdCmd) Run() error {
 // Note: Output() captures stdout but Stderr must still be configured
 // separately if you want to capture stderr instead of it going to os.Stderr.
 func (b *bdCmd) Output() ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), resolveBdCmdTimeout())
+	deadline := resolveBdCmdTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
 	defer cancel()
 	out, err := b.buildContextCommand(ctx).Output()
-	return out, wrapBdCmdTimeout(ctx, err)
+	return out, b.wrapTimeout(err, deadline)
 }
 
 // CombinedOutput builds and runs the command, returning combined stdout+stderr.
 // This overrides the configured Stderr writer to capture both streams.
 // Useful for including command output in error messages.
 func (b *bdCmd) CombinedOutput() ([]byte, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), resolveBdCmdTimeout())
+	deadline := resolveBdCmdTimeout()
+	ctx, cancel := context.WithTimeout(context.Background(), deadline)
 	defer cancel()
 	args := b.resolvedArgs()
 	cmd := exec.CommandContext(ctx, "bd", args...)
@@ -253,5 +273,5 @@ func (b *bdCmd) CombinedOutput() ([]byte, error) {
 	cmd.Dir = b.dir
 	cmd.Env = b.buildEnv()
 	out, err := cmd.CombinedOutput()
-	return out, wrapBdCmdTimeout(ctx, err)
+	return out, b.wrapTimeout(err, deadline)
 }

--- a/internal/cmd/bd_helpers_test.go
+++ b/internal/cmd/bd_helpers_test.go
@@ -187,6 +187,9 @@ timeout /t 5 /nobreak >NUL
 	if !strings.Contains(err.Error(), "timed out") {
 		t.Fatalf("error = %v, want timeout", err)
 	}
+	if !strings.Contains(err.Error(), "bd list") {
+		t.Fatalf("error = %v, want command description bd list in timeout message", err)
+	}
 	if elapsed > 4*time.Second {
 		t.Fatalf("timeout took %v, want under 4s", elapsed)
 	}


### PR DESCRIPTION
## Summary\n- Include bd subcommand name, bead_dir, cwd in timeout error messages\n- Enable faster diagnosis of which bd operation is hanging\n\nTimeout was already present (30s default, GT_BD_TIMEOUT_SEC override). This adds structured context to the error.\n\n## Verification\n- go test ./internal/cmd -run TestBdCmd_RunTimesOut\n- make build