### PR TITLE
fix: suppress satisfaction survey and away-recap for autonomous agents

### DIFF
--- a/internal/hooks/templates/claude/settings-autonomous.json
+++ b/internal/hooks/templates/claude/settings-autonomous.json
@@ -3,6 +3,8 @@
   "hasCompletedOnboarding": true,
   "theme": "dark",
   "editorMode": "normal",
+  "feedbackSurveyRate": 0,
+  "awaySummaryEnabled": false,
   "permissions": {
     "defaultMode": "bypassPermissions"
   },


### PR DESCRIPTION
## Summary

Disable two Claude Code UI elements that block stdin in autonomous agent panes:

- `feedbackSurveyRate: 0` — suppresses the *How is Claude doing this session?* modal
- `awaySummaryEnabled: false` — suppresses the `※ recap` that appears after the session has been idle for ~5 minutes

Both are added to `internal/hooks/templates/claude/settings-autonomous.json` so they apply to every autonomous role: deacon, witness, refinery, polecat, boot.

## Why

Either of those UI elements, once shown, captures stdin in the pane. For interactive roles (mayor, crew) a human dismisses them. For autonomous roles there is no human:

- The agent's heartbeat stops updating.
- Mail injected via `UserPromptSubmit` is never drained.
- Downstream watchdogs (e.g. `stuck-agent-dog`) escalate noise that an operator has to manually clear.

Reproduced on a deacon session: after ~4h idle the recap and survey stacked up, heartbeat went stale, and the `stuck-agent-dog` plugin fired ~50 escalations against the mayor inbox over the course of a day. Manually dismissing the modal + nudging the agent restored normal patrol, but the same trap can spring on any autonomous role.

## Test plan

- [x] Apply template change; rebuild gt (`make install`); restart deacon (`gt deacon restart`)
- [x] Confirm rendered `~/gt/deacon/.claude/settings.json` contains both new keys
- [x] Confirm deacon's heartbeat resumes incrementing (cycle advanced from 4594 → 4599 within minutes of restart)
- [x] Confirm no recap/survey appears in the deacon pane after the restart
- [ ] Reviewer to confirm: same template path is used by witness/refinery/polecat/boot via `IsAutonomousRole`

## Notes

Both keys are documented in the upstream Claude Code settings schema. `awaySummaryEnabled` is marked `@internal` in the schema but its behavior (disabling the away-summary/recap) is the stable one we rely on here.