### PR TITLE
fix(config): set BEADS_NO_AUTO_IMPORT=1 for all agents in AgentEnv

### DIFF
--- a/internal/beads/exec_test.go
+++ b/internal/beads/exec_test.go
@@ -1,0 +1,61 @@
+package beads
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestEnvForSubprocessMode_SuppressesAutoImport guarantees that every bd
+// subprocess mode used by ConfigureCommand sets BEADS_NO_AUTO_IMPORT=1 — and
+// strips any inherited value that would re-enable it. The daemon dog patrols
+// (dog_molecule.runBd) and other migrated raw bd call sites route through this
+// helper, so this is the regression guard for the self-feeding "create N
+// issue(s)" loop where watchdog/compaction dogs auto-imported a stale
+// .beads/issues.jsonl over the live Dolt server.
+func TestEnvForSubprocessMode_SuppressesAutoImport(t *testing.T) {
+	t.Parallel()
+	// Hostile base: explicitly turns auto-import ON, to prove we override it.
+	base := []string{"BEADS_NO_AUTO_IMPORT=0", "PATH=/usr/bin"}
+	for name, mode := range map[string]SubprocessEnvMode{
+		"ReadOnlyRouting": ReadOnlyRouting,
+		"MutationRouting": MutationRouting,
+		"ReadOnlyPinned":  ReadOnlyPinned,
+		"MutationPinned":  MutationPinned,
+	} {
+		env := EnvForSubprocessMode(base, "/town/.beads", mode)
+		assertNoAutoImport(t, name, env)
+	}
+}
+
+// TestSubprocessModeForArgs_SuppressesAutoImport ensures the arg-derived mode
+// (read vs mutation) used by dog_molecule.runBd, prime, and witness yields
+// BEADS_NO_AUTO_IMPORT=1 for both read and write bd commands.
+func TestSubprocessModeForArgs_SuppressesAutoImport(t *testing.T) {
+	t.Parallel()
+	base := []string{"BEADS_NO_AUTO_IMPORT=0"}
+	for _, args := range [][]string{
+		{"list", "--json"},
+		{"show", "hq-1", "--json"},
+		{"close", "hq-1", "--reason=x"},
+		{"update", "hq-1", "--status=open"},
+	} {
+		env := EnvForSubprocessMode(base, "/town/.beads", SubprocessModeForArgs(args))
+		assertNoAutoImport(t, strings.Join(args, " "), env)
+	}
+}
+
+func assertNoAutoImport(t *testing.T, label string, env []string) {
+	t.Helper()
+	found := false
+	for _, kv := range env {
+		switch kv {
+		case "BEADS_NO_AUTO_IMPORT=1":
+			found = true
+		case "BEADS_NO_AUTO_IMPORT=0":
+			t.Fatalf("%s: inherited BEADS_NO_AUTO_IMPORT=0 was not stripped; got %v", label, env)
+		}
+	}
+	if !found {
+		t.Fatalf("%s: env missing BEADS_NO_AUTO_IMPORT=1; got %v", label, env)
+	}
+}

--- a/internal/cmd/agent_state.go
+++ b/internal/cmd/agent_state.go
@@ -220,7 +220,11 @@ func modifyAgentState(agentBead, beadsDir string, hasIncr bool) error {
 
 	// Execute bd update
 	cmd := exec.Command("bd", args...)
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
+	// Apply the shared bd side-effect suppression (BEADS_NO_AUTO_IMPORT=1, etc.)
+	// so this watchdog-path write can't auto-import a stale .beads/issues.jsonl
+	// over the live Dolt server — which would revert the label change we just
+	// made and feed the "create N issue(s)" churn loop. Keeps BEADS_DIR pinning.
+	cmd.Env = beads.BuildMutationPinnedBDEnv(os.Environ(), beadsDir)
 
 	var stderr bytes.Buffer
 	cmd.Stderr = &stderr
@@ -273,7 +277,9 @@ func getAllAgentLabels(agentBead, beadsDir string) ([]string, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, "bd", args...) //nolint:gosec // G204: bd is a trusted internal tool
-	cmd.Env = append(os.Environ(), "BEADS_DIR="+beadsDir)
+	// Read-only query, but still suppress bd side effects so the read can't
+	// trigger a stale-JSONL auto-import over the live Dolt server.
+	cmd.Env = beads.BuildReadOnlyPinnedBDEnv(os.Environ(), beadsDir)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/cmd/compact_report.go
+++ b/internal/cmd/compact_report.go
@@ -15,6 +15,18 @@ import (
 	"github.com/steveyegge/gastown/internal/style"
 )
 
+// bdReportCmd builds a bd command for compaction-report bookkeeping with the
+// shared Gas Town side-effect suppression applied (BEADS_NO_AUTO_IMPORT=1, no
+// auto-export/push). Without this, each compactor-dog bd call auto-imports the
+// (often stale) .beads/issues.jsonl over the live Dolt server, producing the
+// self-feeding "create N issue(s)" commit churn. Inherited Dolt/BEADS_DIR
+// targeting is preserved (only side effects are suppressed).
+func bdReportCmd(args ...string) *exec.Cmd {
+	cmd := exec.Command("bd", args...) //nolint:gosec // G204: args constructed internally
+	cmd.Env = beads.SuppressBDSideEffects(os.Environ())
+	return cmd
+}
+
 var (
 	compactReportDryRun  bool
 	compactReportWeekly  bool
@@ -344,7 +356,7 @@ func createCompactReportBead(report *compactReport, markdown string) (string, er
 		"--silent",
 	}
 
-	bdCmd := exec.Command("bd", bdArgs...)
+	bdCmd := bdReportCmd(bdArgs...)
 	output, err := bdCmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("creating report bead: %w\nOutput: %s", err, string(output))
@@ -353,7 +365,7 @@ func createCompactReportBead(report *compactReport, markdown string) (string, er
 	beadID := strings.TrimSpace(string(output))
 
 	// Auto-close (audit record, not work)
-	closeCmd := exec.Command("bd", "close", beadID, "--reason=daily compaction report")
+	closeCmd := bdReportCmd("close", beadID, "--reason=daily compaction report")
 	_ = closeCmd.Run()
 
 	return beadID, nil
@@ -454,7 +466,7 @@ func runWeeklyRollup() error {
 
 // queryCompactionReports queries compaction report event beads in a date range.
 func queryCompactionReports(startDate, endDate string) ([]*compactReport, error) {
-	listCmd := exec.Command("bd", "list",
+	listCmd := bdReportCmd("list",
 		"--type=event",
 		"--json",
 		"--limit=0",
@@ -562,7 +574,7 @@ func formatWeeklyRollup(rollup *weeklyRollup) string {
 func findExistingCompactReport(dateStr string) (string, error) {
 	expectedTitle := fmt.Sprintf("Compaction Report %s", dateStr)
 
-	listCmd := exec.Command("bd", "list",
+	listCmd := bdReportCmd("list",
 		"--type=event",
 		"--status=closed",
 		"--json",
@@ -594,7 +606,7 @@ func findExistingCompactReport(dateStr string) (string, error) {
 func findExistingWeeklyRollup(weekStart, weekEnd string) (string, error) {
 	expectedTitle := fmt.Sprintf("Weekly Compaction Rollup %s to %s", weekStart, weekEnd)
 
-	listCmd := exec.Command("bd", "list",
+	listCmd := bdReportCmd("list",
 		"--type=event",
 		"--json",
 		"--limit=20",
@@ -648,7 +660,7 @@ func createWeeklyRollupBead(rollup *weeklyRollup, markdown string) (string, erro
 		"--silent",
 	}
 
-	bdCmd := exec.Command("bd", bdArgs...)
+	bdCmd := bdReportCmd(bdArgs...)
 	output, err := bdCmd.CombinedOutput()
 	if err != nil {
 		return "", fmt.Errorf("creating weekly rollup bead: %w\nOutput: %s", err, string(output))
@@ -657,7 +669,7 @@ func createWeeklyRollupBead(rollup *weeklyRollup, markdown string) (string, erro
 	beadID := strings.TrimSpace(string(output))
 
 	// Auto-close (audit record, not work)
-	closeCmd := exec.Command("bd", "close", beadID, "--reason=weekly compaction rollup")
+	closeCmd := bdReportCmd("close", beadID, "--reason=weekly compaction rollup")
 	_ = closeCmd.Run()
 
 	return beadID, nil

--- a/internal/config/env.go
+++ b/internal/config/env.go
@@ -191,6 +191,18 @@ func AgentEnv(cfg AgentEnvConfig) map[string]string {
 	// See: https://github.com/steveyegge/beads/issues/2241
 	env["BD_BACKUP_ENABLED"] = "false"
 
+	// Stop bd from auto-importing the (throttled, frequently stale) per-repo
+	// .beads/issues.jsonl over the live Dolt server on every invocation. In Gas
+	// Town, Dolt (:3307) is the authoritative data plane and issues.jsonl is a
+	// passive export — but a stale re-import reverts server-side status changes
+	// and resurrects deleted beads (observed: "hooked" handoff beads that refuse
+	// to clear because each subsequent bd call re-imports the old status). gt
+	// already sets this for the bd subprocesses it spawns via
+	// beads.SuppressBDSideEffects(); setting it here in the single source of
+	// truth for agent env makes every agent's *direct* bd calls follow the same
+	// policy, so interactive/agent-driven writes can't be clobbered either.
+	env["BEADS_NO_AUTO_IMPORT"] = "1"
+
 	// Clear NODE_OPTIONS to prevent debugger flags (e.g., --inspect from VSCode)
 	// from being inherited through tmux into Claude's Node.js runtime.
 	// This is the PRIMARY guard: setting it here (the single source of truth

--- a/internal/config/env_test.go
+++ b/internal/config/env_test.go
@@ -134,6 +134,25 @@ func TestAgentEnv_Dog(t *testing.T) {
 	assertNotSet(t, env, "GT_RIG")
 }
 
+// TestAgentEnv_SuppressesBeadsAutoImport verifies that every agent role gets
+// BEADS_NO_AUTO_IMPORT=1, so a direct bd call can't re-import a stale
+// .beads/issues.jsonl over the live Dolt server (which reverts server-side
+// status changes and resurrects deleted beads). It's an all-roles guarantee.
+func TestAgentEnv_SuppressesBeadsAutoImport(t *testing.T) {
+	t.Parallel()
+	for _, cfg := range []AgentEnvConfig{
+		{Role: "mayor", TownRoot: "/town"},
+		{Role: "deacon", TownRoot: "/town"},
+		{Role: "witness", Rig: "myrig", TownRoot: "/town"},
+		{Role: "refinery", Rig: "myrig", TownRoot: "/town"},
+		{Role: "polecat", Rig: "myrig", AgentName: "Toast", TownRoot: "/town"},
+		{Role: "dog", AgentName: "alpha", TownRoot: "/town"},
+	} {
+		env := AgentEnv(cfg)
+		assertEnv(t, env, "BEADS_NO_AUTO_IMPORT", "1")
+	}
+}
+
 // TestIdentityEnvVars_CoversAgentEnvOutput verifies that IdentityEnvVars contains
 // all identity-bearing keys that AgentEnv can produce. If AgentEnv gains a new
 // identity key, this test fails to remind you to add it to IdentityEnvVars.


### PR DESCRIPTION
## Disclaimer
I'm opening this since I needed to do this in my gastown to fix an issue I was having with zombie tasks. However, I could be using something wrong which leads to this setting being set.  

I was essentially trying to solve Bug 1 from this issue since I ran into it as well: https://github.com/gastownhall/gastown/issues/3955 but am not sure if this is the correct way to go about it.  Curious about opinions on this change and if there are any reasons for `issues.jsonl` to be re-imported?

## Problem

Agents' **direct** `bd` calls auto-import the per-repo `.beads/issues.jsonl` into the working DB on every invocation (`auto-importing N bytes ... into empty database`). The export back to JSONL is throttled, so the file frequently lags the live Dolt server. The stale re-import then **reverts server-side status changes and resurrects deleted beads**.

Observed in production: `hooked` handoff beads that refuse to clear — `bd close`/`gt unsling` flips them to closed on `:3307`, but the next `bd` call re-imports the stale JSONL (still showing `hooked`) and re-hooks them. Independently reproduced for the deacon and a rig refinery; closing a deleted probe bead, then watching a later `bd` call re-insert it, confirmed the mechanism (the resurrected row kept its *old* `updated_at` — the import signature).

## Root cause

`gt` already knows this is harmful — `beads.SuppressBDSideEffects()` sets `BEADS_NO_AUTO_IMPORT=1` (+ export/push off) for the `bd` subprocesses **gt itself** spawns, with the comment that JSONL export/import from high-frequency callers "re-invalidates Beads' import freshness checks and can create a self-feeding Dolt load loop." But this env was **not** applied to agents' own interactive/direct `bd` calls.

## Fix

Set `BEADS_NO_AUTO_IMPORT=1` in `AgentEnv()` — the single source of truth for agent env — right next to the existing `BD_BACKUP_ENABLED=false`, so every role (mayor, deacon, witness, refinery, polecat, crew, dog) inherits the same policy. Dolt (`:3307`) is the authoritative data plane; `issues.jsonl` is a passive export and must not be silently re-imported over it.

## Test

Added `TestAgentEnv_SuppressesBeadsAutoImport` asserting the var is set across all roles. `go test ./internal/config/` passes; `go build ./cmd/gt` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)