### PR TITLE
fix(doctor): rig-config-sync accepts rig.db == town.db as valid (gt-thv2d)

### DIFF
--- a/internal/doctor/rig_config_sync_check.go
+++ b/internal/doctor/rig_config_sync_check.go
@@ -86,6 +86,10 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 	c.dbCheckErrors = nil
 	var details []string
 
+	// A rig pointing to the town-wide beads DB is a valid configuration after
+	// migration (e.g. deacon migrated to HQ storage). Read town DB name once.
+	townDB := readDoltDatabase(filepath.Join(ctx.TownRoot, ".beads"))
+
 	for rigName, entry := range rigsConfig.Rigs {
 		rigPath := filepath.Join(ctx.TownRoot, rigName)
 		configPath := filepath.Join(rigPath, "config.json")
@@ -189,8 +193,9 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 			expectedDBName := rigName
 
 			if expectedDBName != "" {
-				// Check if database name matches the rig directory name
-				if metadata.DoltDatabase != expectedDBName {
+				// Check if database name matches the rig directory name OR the town
+				// beads DB. rig.db == town.db is valid after HQ storage migration.
+				if metadata.DoltDatabase != expectedDBName && (townDB == "" || metadata.DoltDatabase != townDB) {
 					c.dbNameMismatches = append(c.dbNameMismatches, dbMismatch{
 						rigName:    rigName,
 						prefix:     configPrefix,

--- a/internal/doctor/rig_config_sync_check_test.go
+++ b/internal/doctor/rig_config_sync_check_test.go
@@ -442,6 +442,77 @@ exit 0
 	}
 }
 
+func TestRigConfigSyncCheck_RigPointingToTownDBIsValid(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake dolt stub is shell-specific")
+	}
+
+	tmpDir := t.TempDir()
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	rigsJSON := `{
+		"version": 1,
+		"rigs": {
+			"deacon": {
+				"git_url": "https://github.com/test/test.git",
+				"beads": {"prefix": "dc"}
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(rigsJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create town-level .beads/metadata.json pointing to "hq"
+	townBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	townMeta := `{"backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`
+	if err := os.WriteFile(filepath.Join(townBeadsDir, "metadata.json"), []byte(townMeta), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create deacon rig pointing to "hq" (the town DB) — valid after HQ migration
+	deaconDir := filepath.Join(tmpDir, "deacon")
+	beadsDir := filepath.Join(deaconDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	configJSON := `{"type":"rig","version":1,"name":"deacon","git_url":"https://github.com/test/test.git","beads":{"prefix":"dc"}}`
+	if err := os.WriteFile(filepath.Join(deaconDir, "config.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("prefix: dc\nissue-prefix: dc\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// deacon points to "hq" (town DB), not "deacon" (its own name)
+	deaconMeta := `{"backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(deaconMeta), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Use a fake dolt that reports "hq" as an existing database
+	binDir := t.TempDir()
+	fakeScript := "#!/usr/bin/env bash\necho '{\"databases\":[{\"name\":\"hq\"}]}'\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(binDir, "dolt"), []byte(fakeScript), 0755); err != nil {
+		t.Fatalf("write fake dolt: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("GT_DOLT_HOST", "127.0.0.1")
+
+	ctx := &CheckContext{TownRoot: tmpDir}
+	check := NewRigConfigSyncCheck()
+	result := check.Run(ctx)
+
+	if len(check.dbNameMismatches) != 0 {
+		t.Errorf("expected no dbNameMismatches when rig.db == town.db, got: %v", check.dbNameMismatches)
+	}
+	_ = result
+}
+
 func TestStaleRuntimeFilesCheck_StalePIDFiles(t *testing.T) {
 	// Create temp town root
 	tmpDir := t.TempDir()


### PR DESCRIPTION
Merge request gt-wisp-8o4 for issue gt-thv2d (polecat rictus).

fix(doctor): rig-config-sync accepts rig.db == town.db as valid

Changes: internal/doctor/rig_config_sync_check.go (+9/-2), test file (+71 lines).

Processed by gastown/refinery.