### PR TITLE
fix(doctor): rig-config-sync accepts rig.db == town.db as valid

### DIFF
--- a/internal/doctor/rig_config_sync_check.go
+++ b/internal/doctor/rig_config_sync_check.go
@@ -86,6 +86,10 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 	c.dbCheckErrors = nil
 	var details []string
 
+	// A rig pointing to the town-wide beads DB is a valid configuration after
+	// migration (e.g. deacon migrated to HQ storage). Read town DB name once.
+	townDB := readDoltDatabase(filepath.Join(ctx.TownRoot, ".beads"))
+
 	for rigName, entry := range rigsConfig.Rigs {
 		rigPath := filepath.Join(ctx.TownRoot, rigName)
 		configPath := filepath.Join(rigPath, "config.json")
@@ -189,8 +193,9 @@ func (c *RigConfigSyncCheck) Run(ctx *CheckContext) *CheckResult {
 			expectedDBName := rigName
 
 			if expectedDBName != "" {
-				// Check if database name matches the rig directory name
-				if metadata.DoltDatabase != expectedDBName {
+				// Check if database name matches the rig directory name OR the town
+				// beads DB. rig.db == town.db is valid after HQ storage migration.
+				if metadata.DoltDatabase != expectedDBName && (townDB == "" || metadata.DoltDatabase != townDB) {
 					c.dbNameMismatches = append(c.dbNameMismatches, dbMismatch{
 						rigName:    rigName,
 						prefix:     configPrefix,

--- a/internal/doctor/rig_config_sync_check_test.go
+++ b/internal/doctor/rig_config_sync_check_test.go
@@ -442,6 +442,87 @@ exit 0
 	}
 }
 
+func TestRigConfigSyncCheck_RigPointingToTownDBIsValid(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake dolt stub is shell-specific")
+	}
+
+	tmpDir := t.TempDir()
+	mayorDir := filepath.Join(tmpDir, "mayor")
+	if err := os.MkdirAll(mayorDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	rigsJSON := `{
+		"version": 1,
+		"rigs": {
+			"deacon": {
+				"git_url": "https://github.com/test/test.git",
+				"beads": {"prefix": "dc"}
+			}
+		}
+	}`
+	if err := os.WriteFile(filepath.Join(mayorDir, "rigs.json"), []byte(rigsJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create town-level .beads/metadata.json pointing to "hq"
+	townBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	townMeta := `{"backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`
+	if err := os.WriteFile(filepath.Join(townBeadsDir, "metadata.json"), []byte(townMeta), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create deacon rig pointing to "hq" (the town DB) — valid after HQ migration
+	deaconDir := filepath.Join(tmpDir, "deacon")
+	beadsDir := filepath.Join(deaconDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	configJSON := `{"type":"rig","version":1,"name":"deacon","git_url":"https://github.com/test/test.git","beads":{"prefix":"dc"}}`
+	if err := os.WriteFile(filepath.Join(deaconDir, "config.json"), []byte(configJSON), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "config.yaml"), []byte("prefix: dc\nissue-prefix: dc\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	// deacon points to "hq" (town DB), not "deacon" (its own name)
+	deaconMeta := `{"backend":"dolt","dolt_mode":"server","dolt_database":"hq"}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(deaconMeta), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Create fake "hq" Dolt database on the local filesystem so doltDatabaseExists("hq") returns true.
+	hqDoltDir := filepath.Join(tmpDir, ".dolt-data", "hq", ".dolt", "noms")
+	if err := os.MkdirAll(hqDoltDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(hqDoltDir, "manifest"), []byte(""), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Fake bd that returns the bead ID so rigBeadExists passes.
+	binDir := t.TempDir()
+	fakeBd := "#!/usr/bin/env bash\necho \"$2\"\nexit 0\n"
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(fakeBd), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ctx := &CheckContext{TownRoot: tmpDir}
+	check := NewRigConfigSyncCheck()
+	result := check.Run(ctx)
+
+	if len(check.dbNameMismatches) != 0 {
+		t.Errorf("expected no dbNameMismatches when rig.db == town.db, got: %v", check.dbNameMismatches)
+	}
+	if result.Status != StatusOK {
+		t.Errorf("expected StatusOK when rig.db == town.db, got: %v (details: %v)", result.Status, result.Details)
+	}
+}
+
 func TestStaleRuntimeFilesCheck_StalePIDFiles(t *testing.T) {
 	// Create temp town root
 	tmpDir := t.TempDir()


### PR DESCRIPTION
## Summary

- `rig-config-sync` check was flagging a mismatch when a rig's `dolt_database` field equals the town-wide beads DB name (e.g. `deacon → hq`). This is a legitimate post-migration configuration.
- Relaxed the predicate from `metadata.DoltDatabase != expectedDBName` to `metadata.DoltDatabase != expectedDBName && (townDB == "" || metadata.DoltDatabase != townDB)` — using the existing `readDoltDatabase` helper to read the town DB name once at the top of `Run()`.
- Strengthened `TestRigConfigSyncCheck_RigPointingToTownDBIsValid` to assert `result.Status == StatusOK` (not just absence of `dbNameMismatches`), proving the warning is fully suppressed end-to-end.

## Changes

- `internal/doctor/rig_config_sync_check.go`: read town DB once, relax predicate (~9 lines)
- `internal/doctor/rig_config_sync_check_test.go`: add test with strengthened assertion (~81 lines)

**Total: 2 files, 88 lines added, 2 deleted.**

## Test plan

- [x] `go test ./internal/doctor/...` passes (full suite)
- [x] `TestRigConfigSyncCheck_RigPointingToTownDBIsValid` asserts `result.Status == StatusOK`
- [ ] `gt doctor` against the migrated deacon rig shows 0 warnings (verify post-merge)

## Context

Cherry-pick of the core fix from the abandoned kitchen-sink PR athosmartins/gastown#9 (closed). That PR contained the correct fix but bundled 16,463 unrelated lines of changes.

Bead: gt-dky8e  
Original bead: gt-thv2d

🤖 Generated with [Claude Code](https://claude.com/claude-code)