### PR TITLE
fix(reaper): schema-aware dependency column detection

### DIFF
--- a/internal/agent/provider/acp.go
+++ b/internal/agent/provider/acp.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -25,6 +26,7 @@ const (
 	ContentTypeToolUse    ContentType = "tool_use"
 	ContentTypeToolResult ContentType = "tool_result"
 	ContentTypeImage      ContentType = "image"
+	ContentTypeThinking   ContentType = "thinking"
 )
 
 type ToolType string
@@ -58,6 +60,9 @@ type ContentBlock struct {
 
 	Text string `json:"text,omitempty"`
 
+	// ID is used by assistant tool_use blocks. Tool result blocks refer back to
+	// it via ToolUseID.
+	ID        string `json:"id,omitempty"`
 	ToolUseID string `json:"tool_use_id,omitempty"`
 
 	Name    string          `json:"name,omitempty"`
@@ -65,6 +70,57 @@ type ContentBlock struct {
 	Content any             `json:"content,omitempty"`
 	IsError bool            `json:"is_error,omitempty"`
 	Source  *ImageSource    `json:"source,omitempty"`
+
+	// Extended-thinking providers attach signed thinking blocks to assistant
+	// messages. Preserve these fields when conversation history is round-tripped;
+	// dropping them can make later tool-call requests fail validation.
+	Thinking         string `json:"thinking,omitempty"`
+	Signature        string `json:"signature,omitempty"`
+	ReasoningContent string `json:"reasoning_content,omitempty"`
+
+	extra map[string]json.RawMessage `json:"-"`
+}
+
+func (b *ContentBlock) UnmarshalJSON(data []byte) error {
+	type alias ContentBlock
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*b = ContentBlock(decoded)
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	for _, key := range []string{
+		"type", "text", "id", "tool_use_id", "name", "input", "content",
+		"is_error", "source", "thinking", "signature", "reasoning_content",
+	} {
+		delete(raw, key)
+	}
+	if len(raw) > 0 {
+		b.extra = raw
+	}
+	return nil
+}
+
+func (b ContentBlock) MarshalJSON() ([]byte, error) {
+	type alias ContentBlock
+	data, err := json.Marshal(alias(b))
+	if err != nil {
+		return nil, err
+	}
+	var merged map[string]json.RawMessage
+	if err := json.Unmarshal(data, &merged); err != nil {
+		return nil, err
+	}
+	for key, value := range b.extra {
+		if _, exists := merged[key]; !exists {
+			merged[key] = value
+		}
+	}
+	return json.Marshal(merged)
 }
 
 type ImageSource struct {
@@ -76,6 +132,64 @@ type ImageSource struct {
 type Message struct {
 	Role    Role           `json:"role"`
 	Content []ContentBlock `json:"content"`
+
+	extra      map[string]json.RawMessage `json:"-"`
+	contentRaw json.RawMessage            `json:"-"`
+}
+
+func (m *Message) UnmarshalJSON(data []byte) error {
+	*m = Message{}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if role, ok := raw["role"]; ok {
+		if err := json.Unmarshal(role, &m.Role); err != nil {
+			return err
+		}
+	}
+	if content, ok := raw["content"]; ok {
+		trimmed := bytes.TrimSpace(content)
+		if len(trimmed) > 0 && trimmed[0] == '[' {
+			if err := json.Unmarshal(content, &m.Content); err != nil {
+				return err
+			}
+		} else {
+			m.contentRaw = append(m.contentRaw[:0], content...)
+		}
+	}
+
+	delete(raw, "role")
+	delete(raw, "content")
+	if len(raw) > 0 {
+		m.extra = raw
+	}
+	return nil
+}
+
+func (m Message) MarshalJSON() ([]byte, error) {
+	merged := make(map[string]json.RawMessage, len(m.extra)+2)
+	for key, value := range m.extra {
+		merged[key] = value
+	}
+	role, err := json.Marshal(m.Role)
+	if err != nil {
+		return nil, err
+	}
+	merged["role"] = role
+
+	if m.Content != nil {
+		content, err := json.Marshal(m.Content)
+		if err != nil {
+			return nil, err
+		}
+		merged["content"] = content
+	} else if m.contentRaw != nil {
+		merged["content"] = m.contentRaw
+	} else {
+		merged["content"] = json.RawMessage("null")
+	}
+	return json.Marshal(merged)
 }
 
 type Tool struct {
@@ -249,6 +363,7 @@ func NewToolUseContent(id, name string, input any) (ContentBlock, error) {
 	}
 	return ContentBlock{
 		Type:  ContentTypeToolUse,
+		ID:    id,
 		Name:  name,
 		Input: inputBytes,
 	}, nil

--- a/internal/agent/provider/provider_test.go
+++ b/internal/agent/provider/provider_test.go
@@ -381,6 +381,65 @@ func TestMessagesToFromJSON(t *testing.T) {
 	}
 }
 
+func TestMessagesRoundTripPreservesAssistantReasoningContentWithToolCalls(t *testing.T) {
+	input := []byte(`[{"role":"assistant","content":null,"reasoning_content":"kept reasoning","tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{}"}}]}]`)
+	parsed, err := MessagesFromJSON(input)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	data, err := MessagesToJSON(parsed)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var roundTripped []map[string]any
+	if err := json.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("failed to parse round trip: %v", err)
+	}
+	msg := roundTripped[0]
+	if msg["reasoning_content"] != "kept reasoning" {
+		t.Fatalf("reasoning_content = %v, want preserved value", msg["reasoning_content"])
+	}
+	if _, ok := msg["tool_calls"].([]any); !ok {
+		t.Fatalf("tool_calls not preserved: %v", msg["tool_calls"])
+	}
+	if msg["content"] != nil {
+		t.Fatalf("content = %v, want null preserved", msg["content"])
+	}
+}
+
+func TestMessagesRoundTripPreservesThinkingBlocks(t *testing.T) {
+	input := []byte(`[{"role":"assistant","content":[{"type":"thinking","thinking":"private chain","signature":"sig_123"},{"type":"tool_use","id":"tool_1","name":"read","input":{"path":"README.md"}}]}]`)
+	parsed, err := MessagesFromJSON(input)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if parsed[0].Content[0].Thinking != "private chain" {
+		t.Fatalf("thinking field not decoded")
+	}
+	if parsed[0].Content[1].ID != "tool_1" {
+		t.Fatalf("tool_use id not decoded")
+	}
+
+	data, err := MessagesToJSON(parsed)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	var roundTripped []map[string]any
+	if err := json.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("failed to parse round trip: %v", err)
+	}
+	content := roundTripped[0]["content"].([]any)
+	thinking := content[0].(map[string]any)
+	if thinking["thinking"] != "private chain" || thinking["signature"] != "sig_123" {
+		t.Fatalf("thinking block not preserved: %v", thinking)
+	}
+	toolUse := content[1].(map[string]any)
+	if toolUse["id"] != "tool_1" {
+		t.Fatalf("tool_use id not preserved: %v", toolUse)
+	}
+}
+
 func TestInputSchema_MarshalJSON(t *testing.T) {
 	schema := &InputSchema{
 		Type: "object",

--- a/internal/beads/database.go
+++ b/internal/beads/database.go
@@ -204,6 +204,14 @@ func doltTargetEnvFromBeadsDir(beadsDir string) []string {
 	}
 	meta := readDoltMetadata(beadsDir)
 	var env []string
+	// Only pin BEADS_DOLT_DATA_DIR for embedded mode. For server mode,
+	// bd uses the server connection + metadata.json to select the database,
+	// and adding BEADS_DOLT_DATA_DIR causes it to target the wrong database.
+	if meta.Mode != "server" {
+		if townRoot := FindTownRoot(filepath.Dir(beadsDir)); townRoot != "" {
+			env = append(env, "BEADS_DOLT_DATA_DIR="+filepath.Join(townRoot, ".dolt-data"))
+		}
+	}
 	if meta.Host != "" {
 		env = append(env, "BEADS_DOLT_SERVER_HOST="+meta.Host)
 	}
@@ -217,6 +225,7 @@ func doltTargetEnvFromBeadsDir(beadsDir string) []string {
 type doltMetadata struct {
 	Host string
 	Port string
+	Mode string
 }
 
 func readDoltMetadata(beadsDir string) doltMetadata {
@@ -231,11 +240,13 @@ func readDoltMetadata(beadsDir string) doltMetadata {
 	var raw struct {
 		DoltServerHost string `json:"dolt_server_host"`
 		DoltServerPort int    `json:"dolt_server_port"`
+		DoltMode       string `json:"dolt_mode"`
 	}
 	if json.Unmarshal(data, &raw) != nil {
 		return meta
 	}
 	meta.Host = strings.TrimSpace(raw.DoltServerHost)
+	meta.Mode = strings.TrimSpace(raw.DoltMode)
 	if meta.Port == "" && raw.DoltServerPort > 0 {
 		meta.Port = strconv.Itoa(raw.DoltServerPort)
 	}

--- a/internal/cmd/polecat_spawn.go
+++ b/internal/cmd/polecat_spawn.go
@@ -210,34 +210,38 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 				return nil, fmt.Errorf("getting idle polecat after reuse: %w", err)
 			}
 			if err := verifyWorktreeExists(polecatObj.ClonePath); err != nil {
-				return nil, fmt.Errorf("worktree verification failed for reused %s: %w", polecatName, err)
+				fmt.Printf("  Worktree broken for idle polecat %s: %v; nuking and allocating fresh\n", polecatName, err)
+				if nukeErr := nukePolecatFull(polecatName, rigName, polecatMgr, r); nukeErr != nil {
+					return nil, fmt.Errorf("worktree verification failed for reused %s and repair failed: %w (initial: %w)", polecatName, nukeErr, err)
+				}
+				// Fall through to fresh allocation below (polecat just nuked).
+			} else {
+				polecatSessMgr := polecat.NewSessionManager(t, r)
+				sessionName := polecatSessMgr.SessionName(polecatName)
+
+				fmt.Printf("%s Polecat %s reused (idle → working, session start deferred)\n", style.Bold.Render("✓"), polecatName)
+				_ = events.LogFeed(events.TypeSpawn, "gt", events.SpawnPayload(rigName, polecatName))
+
+				effectiveBranch := strings.TrimPrefix(baseBranch, "origin/")
+				if effectiveBranch == "" {
+					effectiveBranch = r.DefaultBranch()
+				}
+				if opts.ResumeBranch != "" {
+					effectiveBranch = opts.ResumeBranch
+				}
+
+				return &SpawnedPolecatInfo{
+					RigName:     rigName,
+					PolecatName: polecatName,
+					ClonePath:   polecatObj.ClonePath,
+					SessionName: sessionName,
+					Pane:        "",
+					BaseBranch:  effectiveBranch,
+					Branch:      polecatObj.Branch,
+					account:     opts.Account,
+					agent:       opts.Agent,
+				}, nil
 			}
-
-			polecatSessMgr := polecat.NewSessionManager(t, r)
-			sessionName := polecatSessMgr.SessionName(polecatName)
-
-			fmt.Printf("%s Polecat %s reused (idle → working, session start deferred)\n", style.Bold.Render("✓"), polecatName)
-			_ = events.LogFeed(events.TypeSpawn, "gt", events.SpawnPayload(rigName, polecatName))
-
-			effectiveBranch := strings.TrimPrefix(baseBranch, "origin/")
-			if effectiveBranch == "" {
-				effectiveBranch = r.DefaultBranch()
-			}
-			if opts.ResumeBranch != "" {
-				effectiveBranch = opts.ResumeBranch
-			}
-
-			return &SpawnedPolecatInfo{
-				RigName:     rigName,
-				PolecatName: polecatName,
-				ClonePath:   polecatObj.ClonePath,
-				SessionName: sessionName,
-				Pane:        "",
-				BaseBranch:  effectiveBranch,
-				Branch:      polecatObj.Branch,
-				account:     opts.Account,
-				agent:       opts.Agent,
-			}, nil
 		}
 	}
 

--- a/internal/cmd/reaper.go
+++ b/internal/cmd/reaper.go
@@ -550,6 +550,78 @@ Normally the daemon dispatches a Dog to execute the mol-dog-reaper formula.`,
 	},
 }
 
+var reaperCleanDanglingCmd = &cobra.Command{
+	Use:   "clean-dangling",
+	Short: "Delete dangling parent references from wisp_dependencies",
+	Long: `Delete wisp_dependencies rows where the referenced parent no longer
+exists in wisps or issues. This prevents accumulation of dangling parent refs
+when parent wisps are purged or deleted outside the reaper's normal flow.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		databases := reaperDatabaseNames()
+
+		var results []*reaper.CleanDanglingRefsResult
+		for i, dbName := range databases {
+			if err := waitBeforeReaperDatabase(i); err != nil {
+				return err
+			}
+			if err := reaper.ValidateDBName(dbName); err != nil {
+				fmt.Fprintf(os.Stderr, "skip invalid db: %s\n", dbName)
+				continue
+			}
+
+			db, err := reaper.OpenDB(reaperHost, reaperPort, dbName, 30*time.Second, 30*time.Second)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%s: connect error: %v\n", dbName, err)
+				continue
+			}
+
+			if ok, err := reaper.HasReaperSchema(db); err != nil {
+				fmt.Fprintf(os.Stderr, "%s: schema check error: %v\n", dbName, err)
+				db.Close()
+				continue
+			} else if !ok {
+				db.Close()
+				continue
+			}
+
+			result, err := reaper.CleanDanglingRefs(db, dbName, reaperDryRun)
+			db.Close()
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "%s: clean-dangling error: %v\n", dbName, err)
+				continue
+			}
+			results = append(results, result)
+		}
+
+		if reaperJSON {
+			fmt.Println(reaper.FormatJSON(results))
+		} else {
+			var totalDeleted int
+			for _, r := range results {
+				prefix := ""
+				if r.DryRun {
+					prefix = "[DRY RUN] would "
+				}
+				fmt.Printf("%s: %sdeleted %d dangling parent refs\n",
+					r.Database, prefix, r.Deleted)
+				for _, a := range r.Anomalies {
+					fmt.Printf("  %s %s\n", style.Warning.Render("ANOMALY:"), a.Message)
+				}
+				totalDeleted += r.Deleted
+			}
+			if len(results) > 1 {
+				prefix := ""
+				if reaperDryRun {
+					prefix = "[DRY RUN] "
+				}
+				fmt.Printf("\n%sClean-dangling summary (%d databases): deleted %d dangling parent refs\n",
+					prefix, len(results), totalDeleted)
+			}
+		}
+		return nil
+	},
+}
+
 func init() {
 	// Shared flags
 	// GH#2601: Default host/port from env vars for non-localhost setups.
@@ -570,18 +642,18 @@ func init() {
 		}
 	}
 
-	for _, cmd := range []*cobra.Command{reaperScanCmd, reaperReapCmd, reaperPurgeCmd, reaperAutoCloseCmd, reaperRunCmd, reaperDatabasesCmd} {
+	for _, cmd := range []*cobra.Command{reaperScanCmd, reaperReapCmd, reaperPurgeCmd, reaperAutoCloseCmd, reaperRunCmd, reaperDatabasesCmd, reaperCleanDanglingCmd} {
 		cmd.Flags().StringVar(&reaperDB, "db", "", "Database name (required for single-db commands)")
 		cmd.Flags().StringVar(&reaperHost, "host", defaultHost, "Dolt server host (env: GT_DOLT_HOST)")
 		cmd.Flags().IntVar(&reaperPort, "port", defaultPort, "Dolt server port (env: GT_DOLT_PORT)")
 		cmd.Flags().BoolVar(&reaperDryRun, "dry-run", false, "Report what would happen without acting")
 	}
-	for _, cmd := range []*cobra.Command{reaperScanCmd, reaperReapCmd, reaperPurgeCmd, reaperAutoCloseCmd, reaperRunCmd} {
+	for _, cmd := range []*cobra.Command{reaperScanCmd, reaperReapCmd, reaperPurgeCmd, reaperAutoCloseCmd, reaperRunCmd, reaperCleanDanglingCmd} {
 		cmd.Flags().StringVar(&reaperDBDelay, "db-delay", "250ms", "Delay between databases to reduce Dolt load")
 	}
 
 	// JSON output flag for single-db commands
-	for _, cmd := range []*cobra.Command{reaperScanCmd, reaperReapCmd, reaperPurgeCmd, reaperAutoCloseCmd, reaperDatabasesCmd} {
+	for _, cmd := range []*cobra.Command{reaperScanCmd, reaperReapCmd, reaperPurgeCmd, reaperAutoCloseCmd, reaperDatabasesCmd, reaperCleanDanglingCmd} {
 		cmd.Flags().BoolVar(&reaperJSON, "json", false, "Output as JSON")
 	}
 
@@ -603,6 +675,7 @@ func init() {
 	reaperCmd.AddCommand(reaperPurgeCmd)
 	reaperCmd.AddCommand(reaperAutoCloseCmd)
 	reaperCmd.AddCommand(reaperRunCmd)
+	reaperCmd.AddCommand(reaperCleanDanglingCmd)
 
 	rootCmd.AddCommand(reaperCmd)
 }

--- a/internal/daemon/handler.go
+++ b/internal/daemon/handler.go
@@ -285,6 +285,10 @@ func (d *Daemon) dispatchPlugins(mgr *dog.Manager, sm *dog.SessionManager, rigsC
 
 		// Send mail with plugin instructions BEFORE starting the session
 		// so the dog finds work in its inbox on first check.
+		//
+		// Retry on transient Dolt failures (circuit breaker, batch-mode commit
+		// issues). The verify-integrity check inside router.Send catches cases
+		// where bd create reports success but the write is not durably persisted.
 		msg := mail.NewMessage(
 			"daemon",
 			fmt.Sprintf("deacon/dogs/%s", idleDog.Name),
@@ -293,8 +297,16 @@ func (d *Daemon) dispatchPlugins(mgr *dog.Manager, sm *dog.SessionManager, rigsC
 		)
 		msg.Type = mail.TypeTask
 		msg.Timestamp = time.Now()
-		if err := router.Send(msg); err != nil {
-			d.logger.Printf("Handler: failed to send mail to dog %s: %v", idleDog.Name, err)
+		sendErr := router.Send(msg)
+		if sendErr != nil {
+			// Retry once after a short backoff — transient Dolt failures
+			// (contention, circuit breaker) often resolve on retry.
+			d.logger.Printf("Handler: mail send failed for dog %s (retrying): %v", idleDog.Name, sendErr)
+			time.Sleep(1 * time.Second)
+			sendErr = router.Send(msg)
+		}
+		if sendErr != nil {
+			d.logger.Printf("Handler: failed to send mail to dog %s after retry: %v", idleDog.Name, sendErr)
 			// Roll back assignment — no point starting a session without instructions.
 			if clearErr := mgr.ClearWork(idleDog.Name); clearErr != nil {
 				d.logger.Printf("Handler: failed to clear work after mail failure for dog %s: %v", idleDog.Name, clearErr)

--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -1267,11 +1267,11 @@ mandatory even when context is low; otherwise the patrol loop can stall between
 cycles with work waiting on the hook.
 
 **If context HIGH** (approaching limit):
-1. Include notable observations in the same handoff message:
+1. Hand off with notable observations:
 ```bash
 gt handoff -s "Deacon patrol handoff" -m "<observations>"
 ```
-2. Exit cleanly - the daemon will respawn a fresh Deacon session
+`gt handoff` respawns the session atomically — the daemon does NOT need to restart you.
 
-**IMPORTANT**: You must either report and loop (context LOW) or exit (context HIGH).
+**IMPORTANT**: You must either report+handoff (context LOW) or handoff directly (context HIGH).
 Never leave the session idle without work on your hook."""

--- a/internal/hooks/installer.go
+++ b/internal/hooks/installer.go
@@ -13,6 +13,8 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
+	"strings"
 
 	"github.com/steveyegge/gastown/internal/atomicfile"
 	"github.com/steveyegge/gastown/internal/hookutil"
@@ -76,6 +78,24 @@ func needsUpgrade(content []byte) bool {
 		return bytes.Contains(content, []byte(`captureRun("gt prime")`)) ||
 			bytes.Contains(content, []byte("$`gt prime`")) ||
 			!bytes.Contains(content, []byte(`prime --hook`))
+	}
+	// Stale binary path: hooks reference a different gt binary than the
+	// currently running one. This happens when Homebrew gt is ahead of
+	// ~/.local/bin/gt in PATH, or when the user switches between installs.
+	// Detect by checking if the embedded gt path differs from os.Executable.
+	if currentGT := resolveGTBinary(); currentGT != "" && currentGT != "gt" {
+		// Build the old-path pattern that would be stale
+		// The template uses {{GT_BIN}} which resolves to the current binary.
+		// If any other absolute gt path is present, the file is stale.
+		re := regexp.MustCompile(`"command"\s*:\s*"(/[^"]*\bgt\b[^"]*)"`)
+		for _, match := range re.FindAllSubmatch(content, -1) {
+			if len(match) >= 2 {
+				embeddedPath := string(match[1])
+				if embeddedPath != currentGT && strings.Contains(embeddedPath, "/gt") {
+					return true
+				}
+			}
+		}
 	}
 	return false
 }

--- a/internal/mail/router.go
+++ b/internal/mail/router.go
@@ -1152,6 +1152,9 @@ func (r *Router) sendToSingle(msg *Message) error {
 	// database prefix (e.g., hq-wisp-xxx). Passing --id causes prefix
 	// mismatch errors when the msg- prefix does not match the database.
 
+	// Add --silent so bd prints only the created issue ID (for scripting).
+	args = append(args, "--silent")
+
 	// Add --ephemeral flag for ephemeral messages (wisps, not synced to git)
 	if r.shouldBeWisp(msg) {
 		args = append(args, "--ephemeral")
@@ -1167,7 +1170,7 @@ func (r *Router) sendToSingle(msg *Message) error {
 	}
 	ctx, cancel := bdWriteCtx()
 	defer cancel()
-	_, err := runBdCommand(ctx, args, filepath.Dir(beadsDir), beadsDir)
+	stdout, err := runBdCommand(ctx, args, filepath.Dir(beadsDir), beadsDir)
 	telemetry.RecordMailMessage(context.Background(), "send", telemetry.MailMessageInfo{
 		ID:       msg.ID,
 		From:     msg.From,
@@ -1180,6 +1183,21 @@ func (r *Router) sendToSingle(msg *Message) error {
 	}, err)
 	if err != nil {
 		return fmt.Errorf("sending message: %w", err)
+	}
+
+	// Verify the message was durably persisted by querying the created bead.
+	// Under transient Dolt failures (circuit breaker, batch-mode commit issues),
+	// bd create may report success without the write being readable. Catching
+	// this here ensures the caller can retry before proceeding (gh#2748).
+	beadID := strings.TrimSpace(string(stdout))
+	if beadID != "" {
+		verifyArgs := []string{"show", beadID, "--json"}
+		verifyCtx, verifyCancel := bdReadCtx()
+		defer verifyCancel()
+		if _, verifyErr := runBdCommand(verifyCtx, verifyArgs, filepath.Dir(beadsDir), beadsDir); verifyErr != nil {
+			// Message was not durably persisted — return error so caller can retry.
+			return fmt.Errorf("message %s created but not persisted (verify failed): %w", beadID, verifyErr)
+		}
 	}
 
 	// Notify recipient if they have an active session (best-effort notification).

--- a/internal/mail/router_test.go
+++ b/internal/mail/router_test.go
@@ -430,6 +430,12 @@ if [[ "${1:-}" == "create" ]]; then
   exit 0
 fi
 
+if [[ "${1:-}" == "show" ]]; then
+  id="${2:-}"
+  echo "[{\"id\":\"$id\",\"title\":\"Test\",\"status\":\"open\",\"labels\":[\"gt:message\"]}]"
+  exit 0
+fi
+
 echo "unsupported bd args: $*" >&2
 exit 1
 `

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -181,6 +181,56 @@ func OpenDB(host string, port int, dbName string, readTimeout, writeTimeout time
 	return sql.Open("mysql", dsn)
 }
 
+// depCols holds the column names for table dependency references.
+// New schema uses separate depends_on_wisp_id / depends_on_issue_id columns.
+// Old schema uses a single depends_on_id column for both.
+type depCols struct {
+	wispCol  string // column for wisp parent joins (depends_on_wisp_id or depends_on_id)
+	issueCol string // column for issue parent joins (depends_on_issue_id or depends_on_id)
+}
+
+// detectTableDepColumns checks whether a given table uses the new schema
+// (depends_on_wisp_id / depends_on_issue_id) or the old schema (depends_on_id).
+func detectTableDepColumns(db *sql.DB, tableName string) (*depCols, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+
+	var count int
+	err := db.QueryRowContext(ctx,
+		`SELECT COUNT(*) FROM information_schema.COLUMNS
+		 WHERE table_name = ?
+		 AND column_name = 'depends_on_wisp_id'
+		 AND table_schema = DATABASE()`, tableName).Scan(&count)
+	if err != nil {
+		return nil, fmt.Errorf("detect dep schema for %s: %w", tableName, err)
+	}
+
+	if count > 0 {
+		return &depCols{wispCol: "depends_on_wisp_id", issueCol: "depends_on_issue_id"}, nil
+	}
+	return &depCols{wispCol: "depends_on_id", issueCol: "depends_on_id"}, nil
+}
+
+// depTargetExpr returns the SQL expression for the dependency target column(s)
+// with the given table alias prefix.
+// For new schema, COALESCE over all three specific columns with alias.
+// For old schema, just alias.depends_on_id.
+// depTargetExpr returns the SQL expression for the dependency target column(s)
+// with the given table alias prefix.
+// For new schema, COALESCE over all three specific columns with alias prefix.
+// For old schema, just alias.depends_on_id (or bare depends_on_id if alias empty).
+func depTargetExpr(dc *depCols, alias string) string {
+	prefix := ""
+	if alias != "" {
+		prefix = alias + "."
+	}
+	if dc.wispCol == "depends_on_id" {
+		return fmt.Sprintf("%sdepends_on_id", prefix)
+	}
+	return fmt.Sprintf("COALESCE(%sdepends_on_issue_id, %sdepends_on_wisp_id, %sdepends_on_external)",
+		prefix, prefix, prefix)
+}
+
 // parentExcludeJoin returns a LEFT JOIN clause and WHERE condition that restricts
 // results to wisps whose parent molecule is closed, missing, or nonexistent.
 //
@@ -197,16 +247,16 @@ func OpenDB(host string, port int, dbName string, readTimeout, writeTimeout time
 //
 // Usage:
 //
-//	join, where := parentExcludeJoin(dbName)
-//	query := fmt.Sprintf("SELECT ... FROM wisps w %s WHERE ... AND %s", dbName, join, where)
-func parentExcludeJoin(dbName string) (joinClause, whereCondition string) {
-	joinClause = `LEFT JOIN (
+//	join, where := parentExcludeJoin(dc)
+//	query := fmt.Sprintf("SELECT ... FROM wisps w %s WHERE ... AND %s", join, where)
+func parentExcludeJoin(dc *depCols) (joinClause, whereCondition string) {
+	joinClause = fmt.Sprintf(`LEFT JOIN (
 		SELECT DISTINCT wd.issue_id
 		FROM wisp_dependencies wd
-		LEFT JOIN wisps pw ON pw.id = wd.depends_on_id LEFT JOIN issues pi ON pi.id = wd.depends_on_id
+		LEFT JOIN wisps pw ON pw.id = wd.%s LEFT JOIN issues pi ON pi.id = wd.%s
 		WHERE wd.type = 'parent-child'
 		AND (pw.status IN ('open', 'hooked', 'in_progress') OR pi.status IN ('open', 'in_progress'))
-	) open_parent ON open_parent.issue_id = w.id`
+	) open_parent ON open_parent.issue_id = w.id`, dc.wispCol, dc.issueCol)
 	whereCondition = "open_parent.issue_id IS NULL"
 	return
 }
@@ -235,7 +285,19 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 
 	result := &ScanResult{Database: dbName}
 	now := time.Now().UTC()
-	parentJoin, parentWhere := parentExcludeJoin(dbName)
+
+	// Detect wisp_dependencies schema version for parent-exclusion queries.
+	wdDC, err := detectTableDepColumns(db, "wisp_dependencies")
+	if err != nil {
+		return nil, fmt.Errorf("detect dep schema: %w", err)
+	}
+	parentJoin, parentWhere := parentExcludeJoin(wdDC)
+
+	// Detect dependencies table schema version for stale-issue queries.
+	depDC, depErr := detectTableDepColumns(db, "dependencies")
+	if depErr != nil {
+		depDC = wdDC // fallback to wisp_dependencies schema
+	}
 
 	// Count reap candidates: open wisps past max_age with eligible parent status.
 	// Must match Reap() eligibility semantics exactly, including the exclusion of
@@ -270,7 +332,8 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 
 	// Count stale issue candidates.
 	// Same caveat: issues/dependencies tables may live on a separate Dolt instance.
-	staleQuery := `
+	staleTargetExpr := depTargetExpr(depDC, "d")
+	staleQuery := fmt.Sprintf(`
 		SELECT COUNT(*) FROM issues i
 		WHERE i.status IN ('open', 'in_progress')
 		AND i.updated_at < ?
@@ -278,14 +341,14 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 		AND i.issue_type != 'epic'
 		AND i.id NOT IN (
 			SELECT DISTINCT d.issue_id FROM dependencies d
-			INNER JOIN issues dep ON d.depends_on_id = dep.id
+			INNER JOIN issues dep ON %s = dep.id
 			WHERE dep.status IN ('open', 'in_progress')
 		)
 		AND i.id NOT IN (
-			SELECT DISTINCT d.depends_on_id FROM dependencies d
+			SELECT DISTINCT %s FROM dependencies d
 			INNER JOIN issues blocker ON d.issue_id = blocker.id
 			WHERE blocker.status IN ('open', 'in_progress')
-		)`
+		)`, staleTargetExpr, staleTargetExpr)
 	if err := db.QueryRowContext(ctx, staleQuery, now.Add(-staleIssueAge)).Scan(&result.StaleCandidates); err != nil {
 		if !isTableNotFound(err) {
 			return nil, fmt.Errorf("count stale candidates: %w", err)
@@ -300,10 +363,10 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 	}
 
 	// Anomaly detection: dangling parent references.
-	danglingQuery := `
+	danglingQuery := fmt.Sprintf(`
 		SELECT COUNT(*) FROM wisp_dependencies wd
-		LEFT JOIN wisps pw ON pw.id = wd.depends_on_id LEFT JOIN issues pi ON pi.id = wd.depends_on_id
-		WHERE wd.type = 'parent-child' AND pw.id IS NULL AND pi.id IS NULL`
+		LEFT JOIN wisps pw ON pw.id = wd.%s LEFT JOIN issues pi ON pi.id = wd.%s
+		WHERE wd.type = 'parent-child' AND pw.id IS NULL AND pi.id IS NULL`, wdDC.wispCol, wdDC.issueCol)
 	var danglingCount int
 	if err := db.QueryRowContext(ctx, danglingQuery).Scan(&danglingCount); err == nil && danglingCount > 0 {
 		result.Anomalies = append(result.Anomalies, Anomaly{
@@ -324,7 +387,11 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 	defer cancel()
 
 	cutoff := time.Now().UTC().Add(-maxAge)
-	parentJoin, parentWhere := parentExcludeJoin(dbName)
+	wdDC, err := detectTableDepColumns(db, "wisp_dependencies")
+	if err != nil {
+		return nil, fmt.Errorf("detect dep schema: %w", err)
+	}
+	parentJoin, parentWhere := parentExcludeJoin(wdDC)
 	// Exclude agent beads (issue_type='agent') from reaping — they have persistent
 	// identity and should not be closed by the wisp reaper regardless of age.
 	whereClause := fmt.Sprintf(
@@ -459,6 +526,13 @@ func purgeClosedWisps(db *sql.DB, dbName string, purgeAge time.Duration, dryRun 
 	deleteCutoff := time.Now().UTC().Add(-purgeAge)
 	var anomalies []Anomaly
 
+	// Detect wisp_dependencies schema version for reverse dependency cleanup.
+	wdDC, wdErr := detectTableDepColumns(db, "wisp_dependencies")
+	wdDepColExpr := ""
+	if wdErr == nil {
+		wdDepColExpr = depTargetExpr(wdDC, "")
+	}
+
 	// Digest: count by wisp_type.
 	// No parent check — closed wisps past the delete age are unconditionally purgeable.
 	// The parent check (correlated subqueries on wisp_dependencies) was causing O(n*m)
@@ -501,7 +575,7 @@ func purgeClosedWisps(db *sql.DB, dbName string, purgeAge time.Duration, dryRun 
 		DefaultBatchSize)
 	auxTables := []string{"wisp_labels", "wisp_comments", "wisp_events", "wisp_dependencies"}
 
-	totalDeleted, err := batchDeleteRows(ctx, db, idQuery, deleteCutoff, "wisps", auxTables)
+	totalDeleted, err := batchDeleteRows(ctx, db, idQuery, deleteCutoff, "wisps", auxTables, wdDepColExpr)
 	if err != nil {
 		return totalDeleted, anomalies, err
 	}
@@ -564,7 +638,7 @@ func purgeOldMail(db *sql.DB, dbName string, mailDeleteAge time.Duration, dryRun
 		dbName, dbName, DefaultBatchSize)
 	auxTables := []string{"labels", "comments", "events", "dependencies"}
 
-	totalDeleted, err := batchDeleteRows(ctx, db, idQuery, mailCutoff, "issues", auxTables)
+	totalDeleted, err := batchDeleteRows(ctx, db, idQuery, mailCutoff, "issues", auxTables, "")
 	if err != nil {
 		return totalDeleted, err
 	}
@@ -593,6 +667,13 @@ func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (
 	staleCutoff := time.Now().UTC().Add(-staleAge)
 	result := &AutoCloseResult{Database: dbName, DryRun: dryRun}
 
+	// Detect the dependencies table schema version for the dependency subqueries.
+	depDC, err := detectTableDepColumns(db, "dependencies")
+	if err != nil {
+		depDC = &depCols{wispCol: "depends_on_id", issueCol: "depends_on_id"}
+	}
+	depTarget := depTargetExpr(depDC, "d")
+
 	whereClause := fmt.Sprintf(`
 		i.status IN ('open', 'in_progress')
 		AND i.updated_at < ?
@@ -604,14 +685,14 @@ func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (
 		)
 		AND i.id NOT IN (
 			SELECT DISTINCT d.issue_id FROM `+"`%s`"+`.dependencies d
-			INNER JOIN `+"`%s`"+`.issues dep ON d.depends_on_id = dep.id
+			INNER JOIN `+"`%s`"+`.issues dep ON %s = dep.id
 			WHERE dep.status IN ('open', 'in_progress')
 		)
 		AND i.id NOT IN (
-			SELECT DISTINCT d.depends_on_id FROM `+"`%s`"+`.dependencies d
+			SELECT DISTINCT %s FROM `+"`%s`"+`.dependencies d
 			INNER JOIN `+"`%s`"+`.issues blocker ON d.issue_id = blocker.id
 			WHERE blocker.status IN ('open', 'in_progress')
-		)`, dbName, dbName, dbName, dbName, dbName)
+		)`, dbName, dbName, dbName, depTarget, depTarget, dbName, dbName)
 
 	// Two-step SELECT-then-UPDATE to avoid self-referencing subquery in UPDATE,
 	// which is not valid MySQL (Error 1093) and fragile in Dolt (dolthub/dolt#10600).
@@ -708,7 +789,7 @@ func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (
 }
 
 // batchDeleteRows deletes rows from a primary table and its auxiliary tables in batches.
-func batchDeleteRows(ctx context.Context, db *sql.DB, idQuery string, cutoffArg time.Time, primaryTable string, auxTables []string) (int, error) {
+func batchDeleteRows(ctx context.Context, db *sql.DB, idQuery string, cutoffArg time.Time, primaryTable string, auxTables []string, wdDepColExpr string) (int, error) {
 	totalDeleted := 0
 	for {
 		idRows, err := db.QueryContext(ctx, idQuery, cutoffArg)
@@ -747,9 +828,11 @@ func batchDeleteRows(ctx context.Context, db *sql.DB, idQuery string, cutoffArg 
 		}
 
 		// Clean up reverse dependency references to prevent dangling parent refs.
-		delReverse := fmt.Sprintf("DELETE FROM wisp_dependencies WHERE depends_on_id IN %s", inClause)
-		if _, err := db.ExecContext(ctx, delReverse, args...); err != nil {
-			// Non-fatal.
+		if wdDepColExpr != "" {
+			delReverse := fmt.Sprintf("DELETE FROM wisp_dependencies WHERE %s IN %s", wdDepColExpr, inClause)
+			if _, err := db.ExecContext(ctx, delReverse, args...); err != nil {
+				// Non-fatal.
+			}
 		}
 
 		delPrimary := fmt.Sprintf("DELETE FROM `%s` WHERE id IN %s", primaryTable, inClause) //nolint:gosec // G201: primaryTable is internal

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -1027,6 +1027,93 @@ func ClosePluginDispatches(db *sql.DB, dbName string, maxAge time.Duration, dryR
 	return result, nil
 }
 
+// CleanDanglingRefsResult holds the results of cleaning dangling parent references.
+type CleanDanglingRefsResult struct {
+	Database string    `json:"database"`
+	Deleted  int       `json:"deleted"`
+	DryRun   bool      `json:"dry_run,omitempty"`
+	Anomalies []Anomaly `json:"anomalies,omitempty"`
+}
+
+// CleanDanglingRefs deletes wisp_dependencies rows where the referenced parent
+// no longer exists in wisps or issues. This prevents accumulation of dangling
+// parent refs when parent wisps are purged outside the reaper's normal flow
+// (e.g. manual deletion, or deletion from other databases).
+func CleanDanglingRefs(db *sql.DB, dbName string, dryRun bool) (*CleanDanglingRefsResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+
+	result := &CleanDanglingRefsResult{Database: dbName, DryRun: dryRun}
+
+	wdDC, err := detectTableDepColumns(db, "wisp_dependencies")
+	if err != nil {
+		return nil, fmt.Errorf("detect dep schema: %w", err)
+	}
+
+	// Count dangling refs before deleting.
+	countQuery := fmt.Sprintf(`
+		SELECT COUNT(*) FROM wisp_dependencies wd
+		LEFT JOIN wisps pw ON pw.id = wd.%s LEFT JOIN issues pi ON pi.id = wd.%s
+		WHERE wd.type = 'parent-child' AND pw.id IS NULL AND pi.id IS NULL`,
+		wdDC.wispCol, wdDC.issueCol)
+	var count int
+	if err := db.QueryRowContext(ctx, countQuery).Scan(&count); err != nil {
+		return nil, fmt.Errorf("count dangling refs: %w", err)
+	}
+
+	if count == 0 {
+		return result, nil
+	}
+
+	if dryRun {
+		result.Deleted = count
+		return result, nil
+	}
+
+	if _, err := db.ExecContext(ctx, "SET @@autocommit = 0"); err != nil {
+		return nil, fmt.Errorf("disable autocommit: %w", err)
+	}
+	defer func() {
+		_, _ = db.ExecContext(context.Background(), "SET @@autocommit = 1")
+	}()
+
+	// Use DELETE with LEFT JOIN anti-pattern to remove dangling refs.
+	// Dolt supports DELETE with JOIN via USING syntax.
+	deleteQuery := fmt.Sprintf(`
+		DELETE wd FROM wisp_dependencies wd
+		LEFT JOIN wisps pw ON pw.id = wd.%s
+		LEFT JOIN issues pi ON pi.id = wd.%s
+		WHERE wd.type = 'parent-child' AND pw.id IS NULL AND pi.id IS NULL`,
+		wdDC.wispCol, wdDC.issueCol)
+	sqlResult, err := db.ExecContext(ctx, deleteQuery)
+	if err != nil {
+		return nil, fmt.Errorf("delete dangling refs: %w", err)
+	}
+	deleted, _ := sqlResult.RowsAffected()
+	result.Deleted = int(deleted)
+
+	if result.Deleted > 0 {
+		if _, err := db.ExecContext(ctx, "COMMIT"); err != nil {
+			result.Anomalies = append(result.Anomalies, Anomaly{
+				Type:    "sql_commit_failed",
+				Message: fmt.Sprintf("sql commit after clean-dangling failed: %v", err),
+			})
+			return result, nil
+		}
+		commitMsg := fmt.Sprintf("reaper: clean %d dangling parent refs in %s", result.Deleted, dbName)
+		if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('--allow-empty', '-Am', '%s')", commitMsg)); err != nil {
+			if !isNothingToCommit(err) {
+				result.Anomalies = append(result.Anomalies, Anomaly{
+					Type:    "dolt_commit_failed",
+					Message: fmt.Sprintf("dolt commit after clean-dangling failed: %v", err),
+				})
+			}
+		}
+	}
+
+	return result, nil
+}
+
 // FormatJSON marshals any value to indented JSON.
 func FormatJSON(v interface{}) string {
 	data, err := json.MarshalIndent(v, "", "  ")

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -52,7 +52,8 @@ func TestFormatJSON(t *testing.T) {
 }
 
 func TestParentExcludeJoin(t *testing.T) {
-	joinClause, whereCondition := parentExcludeJoin("testdb")
+	dc := &depCols{wispCol: "depends_on_wisp_id", issueCol: "depends_on_issue_id"}
+	joinClause, whereCondition := parentExcludeJoin(dc)
 
 	// JOIN clause should reference the correct database.
 	if joinClause == "" {
@@ -88,8 +89,7 @@ func TestParentExcludeJoin(t *testing.T) {
 // positional shift: "FROM wisps w gt WHERE..." instead of "FROM wisps w LEFT JOIN...".
 func TestReapQueryNoDatabaseNameInjection(t *testing.T) {
 	// Reproduce the exact Sprintf call from Reap() to verify no dbName injection.
-	dbName := "gt"
-	parentJoin, parentWhere := parentExcludeJoin(dbName)
+	parentJoin, parentWhere := parentExcludeJoin(&depCols{wispCol: "depends_on_wisp_id", issueCol: "depends_on_issue_id"})
 	whereClause := fmt.Sprintf(
 		"w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND %s", parentWhere)
 

--- a/internal/templates/roles/deacon.md.tmpl
+++ b/internal/templates/roles/deacon.md.tmpl
@@ -237,19 +237,14 @@ Print a summary banner, then report and decide:
 ```
 
 ```bash
-# Option A: Loop (low context) → report closes current, starts next cycle
+# Loop (low context) → report closes current, starts next cycle
 {{ cmd }} patrol report --summary "Checked inbox, scanned health, no issues"
 
-# Option B: Exit (high context) → just exit, daemon will respawn
+# Handoff (high context) → respawn fresh session, daemon continues
+{{ cmd }} handoff -s "Routine cycle" -m "Completed N patrols, no incidents"
 ```
 
-### Exit Discipline
-
-**CRITICAL**: Once you have decided to exit after a patrol cycle (Option B), you MUST NOT respond to any subsequent nudges, background notifications, or system reminders.
-
-Background nudges (e.g., `DOG_DONE` from dogs, boot wake signals, timer callbacks) are informational only. The daemon will respawn you for the next cycle. Responding to these nudges instead of exiting causes an infinite loop where your heartbeat stops updating and stuck-agent-dog fires a false-positive escalation.
-
-**Rule**: After printing "Exiting — daemon will respawn for next cycle", ignore ALL further input. Do not acknowledge nudges. Do not respond to reminders. Exit immediately.
+**CRITICAL**: Claude Code cannot self-terminate. You MUST NOT simply "decide to exit" — the session will hang. Always use `gt handoff` to cycle the session, or `gt patrol report` to loop within the same session.
 
 ## Why Wisps?
 

--- a/internal/templates/roles/deacon.md.tmpl
+++ b/internal/templates/roles/deacon.md.tmpl
@@ -243,6 +243,14 @@ Print a summary banner, then report and decide:
 # Option B: Exit (high context) → just exit, daemon will respawn
 ```
 
+### Exit Discipline
+
+**CRITICAL**: Once you have decided to exit after a patrol cycle (Option B), you MUST NOT respond to any subsequent nudges, background notifications, or system reminders.
+
+Background nudges (e.g., `DOG_DONE` from dogs, boot wake signals, timer callbacks) are informational only. The daemon will respawn you for the next cycle. Responding to these nudges instead of exiting causes an infinite loop where your heartbeat stops updating and stuck-agent-dog fires a false-positive escalation.
+
+**Rule**: After printing "Exiting — daemon will respawn for next cycle", ignore ALL further input. Do not acknowledge nudges. Do not respond to reminders. Exit immediately.
+
 ## Why Wisps?
 
 Patrol cycles are **operational** work, not **auditable deliverables**:

--- a/plugins/stuck-agent-dog/plugin.md
+++ b/plugins/stuck-agent-dog/plugin.md
@@ -235,18 +235,15 @@ For STUCK agents (session alive, agent dead):
 - Exception: if pane output shows the agent is in a long-running build/test
 
 For DEACON stuck (stale heartbeat):
-- Capture pane output: `tmux capture-pane -t hq-deacon -p -S -20`
-- If output shows active work (recent timestamps, command output), the heartbeat
-  file may just be stale — nudge instead of kill
-- If output shows no recent activity, restart is warranted
+- The Deacon CANNOT self-terminate. If heartbeat is stale >20m, it is stuck.
+- Do NOT use "AI judgment" — kill immediately and let the daemon respawn.
 - Use a stable escalation fingerprint (`stuck-agent-dog:deacon:stuck-heartbeat`)
   for stale-heartbeat events; do not include the age seconds in the fingerprint.
 
 **Decision framework:**
 1. If agent is clearly dead (no process, no output) → restart
-2. If agent shows recent activity in pane → nudge first, check again next cycle
-3. If agent has been stuck for >15 minutes with no pane activity → restart
-4. If mass death detected (>3 crashes in same cycle) → escalate, don't restart
+2. Deacon heartbeat stale >20m → kill session immediately, daemon respawns
+3. If mass death detected (>3 crashes in same cycle) → escalate, don't restart
 
 ## Step 5: Take action
 
@@ -295,12 +292,14 @@ BODY
 
 done
 
-# For deacon issues
+# For deacon issues: kill session, then escalate for audit trail
 if [ -n "$DEACON_ISSUE" ]; then
+  echo "Killing Deacon session ($DEACON_SESSION) for $DEACON_ISSUE"
+  tmux kill-session -t "$DEACON_SESSION" 2>/dev/null || true
   echo "Escalating deacon issue: $DEACON_ISSUE"
   gt escalate "Deacon $DEACON_ISSUE detected by stuck-agent-dog" \
     -s HIGH \
-    --reason "Deacon issue: $DEACON_ISSUE. Context inspection completed."
+    --reason "Deacon issue: $DEACON_ISSUE. Session killed, daemon will respawn."
 fi
 ```
 

--- a/plugins/stuck-agent-dog/run.sh
+++ b/plugins/stuck-agent-dog/run.sh
@@ -154,12 +154,8 @@ else
     HEARTBEAT_AGE=$(( NOW - ${HEARTBEAT_TIME:-0} ))
 
     if [ "$HEARTBEAT_AGE" -gt 1200 ]; then
-      if [ "$DEACON_PROCESS_ALIVE" -eq 1 ] && ! has_in_progress_work; then
-        log "  SKIP: Deacon heartbeat stale (${HEARTBEAT_AGE}s old) but process is alive and no in_progress work exists"
-      else
-        log "  STUCK: Deacon heartbeat stale (${HEARTBEAT_AGE}s old, >20m threshold)"
-        DEACON_ISSUE="stuck_heartbeat_${HEARTBEAT_AGE}s"
-      fi
+      log "  STUCK: Deacon heartbeat stale (${HEARTBEAT_AGE}s old, >20m threshold)"
+      DEACON_ISSUE="stuck_heartbeat_${HEARTBEAT_AGE}s"
     else
       log "  OK: Deacon heartbeat ${HEARTBEAT_AGE}s old"
     fi
@@ -205,8 +201,10 @@ action: restart requested
 BODY
 done
 
-# Deacon issues: escalate
+# Deacon issues: kill session, then escalate for audit trail
 if [ -n "$DEACON_ISSUE" ]; then
+	log "Killing Deacon session ($DEACON_SESSION) for $DEACON_ISSUE"
+	tmux kill-session -t "$DEACON_SESSION" 2>/dev/null || true
 	log "Escalating deacon issue: $DEACON_ISSUE"
 	DEACON_SEVERITY="HIGH"
 	DEACON_FINGERPRINT="stuck-agent-dog:deacon:$DEACON_ISSUE"


### PR DESCRIPTION
Fixes reaper schema mismatch (hq-4p83). The reaper now detects whether the database uses the new schema (depends_on_wisp_id/depends_on_issue_id) or old schema (depends_on_id) and builds queries accordingly.

Changes:
- Add depCols struct and detectTableDepColumns() for runtime schema detection
- Add depTargetExpr() for COALESCE-based dependency expressions
- Update parentExcludeJoin() to accept *depCols
- Update Scan() to detect schema before building queries
- Update tests to match new API