### PR TITLE
fix: stuck-agent-dog NOTICE-only on deacon heartbeat staleness (#3877)

### DIFF
--- a/internal/templates/roles/deacon.md.tmpl
+++ b/internal/templates/roles/deacon.md.tmpl
@@ -288,6 +288,11 @@ gt mail delete <id>              # ALWAYS delete after handling
 
 **Handoff messages** (`🤝 HANDOFF:`) — read for situational awareness, then delete immediately.
 
+**Notification-only senders have NO reply route.** Mail from the daemon plugin
+and `gt-sling` `LIFECYCLE:Shutdown` is notification-only — handle it and delete
+it, do NOT reply (their inbox shows empty when you check it, and `gt mail send`
+to them errors with "no agent found"). Replying just queues a dead nudge.
+
 ## Lifecycle Request Handling
 
 **Subject format**: `LIFECYCLE: <identity> requesting <action>`
@@ -384,6 +389,21 @@ If you can't fix an issue after 3 attempts:
 1. Log it in state.json
 2. Send mail to human: `{{ cmd }} mail send --human -s "ESCALATION: ..." -m "..."`
 3. Continue monitoring other agents
+
+### Operational Lessons (escalation triage)
+
+- **If `gt mail`/`gt escalate` hang or get SIGKILLed but `bd` still works**, the
+  escalation transport is wedged — route the escalation via
+  `{{ cmd }} nudge hq-mayor` instead. The nudge path stays up when mail is down.
+- **Before restarting Dolt on `signal: killed` from `bd`/`gt`, check `uptime`
+  first.** Load >20 means the OS killed the subprocess — that is NOT a Dolt fault.
+  Wait for load to drop; do NOT restart Dolt (a needless restart destroys live
+  state and evidence).
+- **`stuck-heartbeat` / `wisp-threshold` escalations are recurring noise.** Verify
+  briefly, close them as recurring, and do NOT re-ping the human. (The
+  `stuck-heartbeat` source has been removed from the stuck-agent-dog plugin —
+  heartbeat staleness alone no longer escalates; the daemon owns the
+  idle-guarded nudge/kill.)
 
 ## Handoff (Wisp-Based)
 

--- a/plugins/stuck-agent-dog/plugin.md
+++ b/plugins/stuck-agent-dog/plugin.md
@@ -173,7 +173,9 @@ echo "Health summary: ${#CRASHED[@]} crashed, ${#STUCK[@]} stuck, $HEALTHY healt
 
 ## Step 3: Check deacon health
 
-The deacon session is `hq-deacon`. Check heartbeat staleness.
+The deacon session is `hq-deacon`. A dead session or dead process sets
+`DEACON_ISSUE` and escalates. Heartbeat staleness is logged as a NOTICE only and
+NEVER escalates — the Go daemon owns the idle-guarded nudge/kill for staleness.
 
 ```bash
 echo ""
@@ -186,7 +188,12 @@ if ! tmux has-session -t "$DEACON_SESSION" 2>/dev/null; then
   echo "  CRASHED: Deacon session is dead"
   DEACON_ISSUE="crashed"
 else
-  # Check deacon heartbeat file
+  # Heartbeat staleness alone is NOT "stuck" — log a NOTICE only, never escalate.
+  # The Deacon is event-driven and parks during await-signal idle, so a stale
+  # heartbeat usually just means there was no work. The Go daemon owns the
+  # nudge/kill decision and correctly idle-guards it (skips when no work is in
+  # flight). Duplicating that check here without the guard caused recurring
+  # false HIGH escalations.
   HEARTBEAT_FILE="$TOWN_ROOT/deacon/heartbeat.json"
   if [ -f "$HEARTBEAT_FILE" ]; then
     HEARTBEAT_TIME=$(jq -r '(.timestamp // empty) | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601? // empty' "$HEARTBEAT_FILE" 2>/dev/null)
@@ -194,9 +201,9 @@ else
       NOW=$(date +%s)
       HEARTBEAT_AGE=$(( NOW - HEARTBEAT_TIME ))
 
-      if [ "$HEARTBEAT_AGE" -gt 900 ]; then
-        echo "  STUCK: Deacon heartbeat stale (${HEARTBEAT_AGE}s old, >15m threshold)"
-        DEACON_ISSUE="stuck_heartbeat_${HEARTBEAT_AGE}s"
+      if [ "$HEARTBEAT_AGE" -gt 7200 ]; then
+        # NOTICE only — does NOT set DEACON_ISSUE.
+        echo "  NOTICE: Deacon heartbeat ${HEARTBEAT_AGE}s old (>2h) — likely await-signal idle, not stuck; daemon owns nudge/kill"
       else
         echo "  OK: Deacon heartbeat ${HEARTBEAT_AGE}s old"
       fi
@@ -230,17 +237,25 @@ For STUCK agents (session alive, agent dead):
 - Kill the zombie session, then restart
 - Exception: if pane output shows the agent is in a long-running build/test
 
-For DEACON stuck (stale heartbeat):
-- Capture pane output: `tmux capture-pane -t hq-deacon -p -S -20`
-- If output shows active work (recent timestamps, command output), the heartbeat
-  file may just be stale — nudge instead of kill
-- If output shows no recent activity, restart is warranted
+For DEACON heartbeat staleness:
+- **Heartbeat age alone NEVER escalates.** The Deacon is event-driven and parks
+  during await-signal idle, so a stale heartbeat usually just means there was no
+  work to do — not that the Deacon is stuck or dead.
+- The Go daemon owns the nudge/kill decision on heartbeat staleness, and it
+  idle-guards that decision (it skips the nudge when no work is in flight). This
+  plugin must NOT duplicate that check, or it produces recurring false HIGH
+  escalations. The plugin only logs a NOTICE for visibility.
+- Genuine Deacon death is caught by the session/process checks below, which DO
+  escalate — not by heartbeat age.
 
 **Decision framework:**
-1. If agent is clearly dead (no process, no output) → restart
-2. If agent shows recent activity in pane → nudge first, check again next cycle
-3. If agent has been stuck for >15 minutes with no pane activity → restart
-4. If mass death detected (>3 crashes in same cycle) → escalate, don't restart
+1. If the Deacon tmux session is dead (`crashed`) → escalate.
+2. If the Deacon process is dead but the session is alive (`zombie`) → escalate.
+3. Heartbeat age, no matter how stale → NOTICE only, never escalate. The daemon
+   handles nudge/kill for genuine staleness (idle-guarded).
+4. For polecats: clearly dead (no process) → restart; recent pane activity →
+   nudge first, recheck next cycle.
+5. If mass death detected (>3 crashes in same cycle) → escalate, don't restart.
 
 ## Step 5: Take action
 

--- a/plugins/stuck-agent-dog/run.sh
+++ b/plugins/stuck-agent-dog/run.sh
@@ -107,15 +107,25 @@ else
     log "  Process alive: pid=$DEACON_PID comm=$DEACON_COMM"
   fi
 
+  # Heartbeat staleness alone is NOT "stuck". The Deacon is event-driven and
+  # parks during await-signal idle — a stale heartbeat just means there was no
+  # work to do, not that the Deacon died. Real death is already caught by the
+  # session/process checks above (crashed/zombie). The Go daemon owns the
+  # nudge/kill decision on heartbeat staleness, and it correctly skips when no
+  # work is in flight (see internal/daemon/daemon.go:1600 idle-guard and the
+  # threshold rationale in internal/deacon/heartbeat.go). Escalating here would
+  # duplicate that check WITHOUT the idle-guard, producing recurring false
+  # HIGH escalations. So: log a NOTICE for visibility only, never escalate.
   HEARTBEAT_FILE="$TOWN_ROOT/deacon/heartbeat.json"
   if [ -f "$HEARTBEAT_FILE" ]; then
     HEARTBEAT_TIME=$(stat -f %m "$HEARTBEAT_FILE" 2>/dev/null || stat -c %Y "$HEARTBEAT_FILE" 2>/dev/null)
     NOW=$(date +%s)
     HEARTBEAT_AGE=$(( NOW - HEARTBEAT_TIME ))
 
-    if [ "$HEARTBEAT_AGE" -gt 1200 ]; then
-      log "  STUCK: Deacon heartbeat stale (${HEARTBEAT_AGE}s old, >20m threshold)"
-      DEACON_ISSUE="stuck_heartbeat_${HEARTBEAT_AGE}s"
+    if [ "$HEARTBEAT_AGE" -gt 7200 ]; then
+      # NOTICE only — does NOT set DEACON_ISSUE, so no escalation. The daemon's
+      # idle-guarded nudge/kill handles genuine staleness; this is for visibility.
+      log "  NOTICE: Deacon heartbeat ${HEARTBEAT_AGE}s old (>2h) — likely await-signal idle, not stuck; daemon owns nudge/kill"
     else
       log "  OK: Deacon heartbeat ${HEARTBEAT_AGE}s old"
     fi


### PR DESCRIPTION
## Summary

Closes #3877.

The `stuck-agent-dog` plugin escalated **HIGH** on Deacon heartbeat staleness
alone. But the Deacon is event-driven and parks during await-signal idle, so a
stale heartbeat usually just means there was no work to do — not that the Deacon
is stuck or dead. The Go daemon already owns the nudge/kill decision on heartbeat
staleness and correctly **idle-guards** it (skips when no work is in flight —
`internal/daemon/daemon.go:1600`; threshold rationale in
`internal/deacon/heartbeat.go`). The plugin duplicated the staleness check
*without* that guard, producing recurring false HIGH escalations.

## Changes

- **`plugins/stuck-agent-dog/run.sh`**: the heartbeat-staleness branch now logs a
  `NOTICE` only (threshold `7200`s) and no longer sets `DEACON_ISSUE`, so it never
  escalates. The crashed / zombie session+process branches and the HIGH escalation
  for those are unchanged.
- **`plugins/stuck-agent-dog/plugin.md`**: prose + decision framework updated to
  match — heartbeat age alone never escalates; only a dead tmux session or dead
  process escalate; the daemon owns the idle-guarded nudge/kill.
- **`internal/templates/roles/deacon.md.tmpl`**: added 4 durable ops lessons —
  notification-only senders (daemon, `gt-sling LIFECYCLE:Shutdown`) have no reply
  route; route escalations via `gt nudge hq-mayor` when mail/escalate hang; check
  `uptime` before restarting Dolt on `signal: killed` (load >20 = OS killed the
  subprocess, not a Dolt fault); `stuck-heartbeat`/`wisp-threshold` escalations are
  recurring noise (this PR removes the stuck-heartbeat source itself).

## Testing

- `go build -o /tmp/gt ./cmd/gt` — passes.
- `go test ./internal/daemon/...` (incl. `deacon_idle_guard_test.go`, which already
  covers the Go idle-guard — no Go change here) — passes.
- `go test ./internal/templates/...` — passes.
- `bash -n` syntax check on `run.sh` — passes. There is **no plugin/shell test
  harness** in the repo (no `.bats`, no shellcheck wiring), so no plugin test was
  added per the plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)