### PR TITLE
fix: make worktree .beads strictly redirect-only (refs #2682, #4033)

### DIFF
--- a/internal/beads/beads_redirect.go
+++ b/internal/beads/beads_redirect.go
@@ -109,8 +109,20 @@ func resolveBeadsDirWithDepth(beadsDir string, maxDepth int) string {
 }
 
 // cleanBeadsRuntimeFiles removes gitignored runtime files from a .beads directory
-// while preserving tracked files (formulas/, README.md, config.yaml, .gitignore).
+// while preserving tracked files (formulas/, README.md, .gitignore).
 // This is safe to call even if the directory doesn't exist.
+//
+// IMPORTANT: This is only ever called by SetupRedirect, which makes a worktree
+// .beads strictly redirect-only. Per the canonical design (docs/design/
+// architecture.md:193), a worktree .beads must contain ONLY a redirect file —
+// it must never carry its own database identity. A git-tracked metadata.json
+// (with dolt_database=<prefix>) or config.yaml left behind in a worktree .beads
+// breaks bd when issue_prefix != db name, because bd reads the worktree's local
+// metadata.json/config.yaml instead of following the redirect (refs #2682,
+// #4033). SetupRedirect refuses to run on the canonical mayor/rig/.beads
+// (ComputeRedirectTarget guards against parts[0]/parts[1] == "mayor"), so
+// removing metadata.json/config.yaml here is scoped to redirect-target
+// worktrees only and never strips the source-of-truth database identity.
 func cleanBeadsRuntimeFiles(beadsDir string) error {
 	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
 		return nil // Nothing to clean
@@ -126,6 +138,11 @@ func cleanBeadsRuntimeFiles(beadsDir string) error {
 		".local_version",
 		// Redirect file (we're about to recreate it)
 		"redirect",
+		// Database identity — a worktree .beads is redirect-only and must NOT
+		// carry its own dolt_database/config, or bd reads it instead of
+		// following the redirect (breaks rigs where issue_prefix != db name).
+		"metadata.json",
+		"config.yaml",
 		// Runtime directories
 		"mq",
 	}

--- a/internal/beads/beads_redirect_test.go
+++ b/internal/beads/beads_redirect_test.go
@@ -1,0 +1,131 @@
+package beads
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestSetupRedirectStripsWorktreeMetadata verifies that SetupRedirect makes a
+// worktree .beads strictly redirect-only: any pre-existing metadata.json or
+// config.yaml (which would carry a stale/wrong dolt_database and break bd when
+// issue_prefix != db name) is removed, leaving only the redirect file.
+//
+// Regression test for #2682 / #4033: a git-tracked worktree
+// refinery/rig/.beads/metadata.json with dolt_database=<prefix> broke bd from
+// the worktree because bd read the local metadata instead of following the
+// redirect. Per docs/design/architecture.md:193, a worktree .beads is
+// redirect-only.
+func TestSetupRedirectStripsWorktreeMetadata(t *testing.T) {
+	t.Run("bogus worktree metadata.json and config.yaml are removed", func(t *testing.T) {
+		townRoot := t.TempDir()
+		rigRoot := filepath.Join(townRoot, "testrig")
+		rigBeads := filepath.Join(rigRoot, ".beads")
+		// refinery/rig is the worktree whose .beads must become redirect-only.
+		worktreePath := filepath.Join(rigRoot, "refinery", "rig")
+		worktreeBeads := filepath.Join(worktreePath, ".beads")
+
+		// Rig has its own database with prefix "lc" (dolt_database "laneassist").
+		if err := os.MkdirAll(rigBeads, 0755); err != nil {
+			t.Fatalf("mkdir rig beads: %v", err)
+		}
+		rigMeta := []byte(`{"dolt_database":"laneassist","issue_prefix":"lc","backend":"dolt"}`)
+		if err := os.WriteFile(filepath.Join(rigBeads, "metadata.json"), rigMeta, 0644); err != nil {
+			t.Fatalf("write rig metadata: %v", err)
+		}
+
+		// The worktree .beads carries a STALE/WRONG metadata.json (dolt_database
+		// does not match the rig prefix) plus a config.yaml — exactly the state
+		// that breaks bd from the worktree.
+		if err := os.MkdirAll(worktreeBeads, 0755); err != nil {
+			t.Fatalf("mkdir worktree beads: %v", err)
+		}
+		bogusMeta := []byte(`{"dolt_database":"lc","issue_prefix":"lc","backend":"dolt"}`)
+		if err := os.WriteFile(filepath.Join(worktreeBeads, "metadata.json"), bogusMeta, 0644); err != nil {
+			t.Fatalf("write worktree metadata: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(worktreeBeads, "config.yaml"), []byte("backend: dolt\n"), 0644); err != nil {
+			t.Fatalf("write worktree config: %v", err)
+		}
+
+		if err := SetupRedirect(townRoot, worktreePath); err != nil {
+			t.Fatalf("SetupRedirect failed: %v", err)
+		}
+
+		// metadata.json and config.yaml must be gone from the worktree .beads.
+		if _, err := os.Stat(filepath.Join(worktreeBeads, "metadata.json")); !os.IsNotExist(err) {
+			t.Errorf("worktree metadata.json should be removed, but stat err = %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(worktreeBeads, "config.yaml")); !os.IsNotExist(err) {
+			t.Errorf("worktree config.yaml should be removed, but stat err = %v", err)
+		}
+
+		// A redirect file must exist and be the only thing pointing the worktree
+		// at the rig-level beads.
+		redirectPath := filepath.Join(worktreeBeads, "redirect")
+		content, err := os.ReadFile(redirectPath)
+		if err != nil {
+			t.Fatalf("read redirect: %v", err)
+		}
+		// refinery/rig -> ../../.beads (rig-level), since rig has its own DB.
+		if want := "../../.beads\n"; string(content) != want {
+			t.Errorf("redirect content = %q, want %q", string(content), want)
+		}
+
+		// The worktree .beads should now contain only the redirect file.
+		entries, err := os.ReadDir(worktreeBeads)
+		if err != nil {
+			t.Fatalf("read worktree beads dir: %v", err)
+		}
+		if len(entries) != 1 || entries[0].Name() != "redirect" {
+			var names []string
+			for _, e := range entries {
+				names = append(names, e.Name())
+			}
+			t.Errorf("worktree .beads should contain only 'redirect', got %v", names)
+		}
+
+		// And the worktree should resolve to the rig-level (correct prefix)
+		// database, not its own stale local one.
+		if resolved := ResolveBeadsDir(worktreePath); resolved != rigBeads {
+			t.Errorf("resolved = %q, want %q (rig-level)", resolved, rigBeads)
+		}
+	})
+
+	t.Run("canonical mayor/rig/.beads is NOT stripped", func(t *testing.T) {
+		// SetupRedirect must refuse the canonical beads location so its
+		// source-of-truth metadata.json/config.yaml is never removed.
+		townRoot := t.TempDir()
+		rigRoot := filepath.Join(townRoot, "testrig")
+		mayorRigBeads := filepath.Join(rigRoot, "mayor", "rig", ".beads")
+		mayorRigPath := filepath.Join(rigRoot, "mayor", "rig")
+
+		if err := os.MkdirAll(mayorRigBeads, 0755); err != nil {
+			t.Fatalf("mkdir mayor/rig beads: %v", err)
+		}
+		canonicalMeta := []byte(`{"dolt_database":"laneassist","issue_prefix":"lc","backend":"dolt"}`)
+		metaPath := filepath.Join(mayorRigBeads, "metadata.json")
+		if err := os.WriteFile(metaPath, canonicalMeta, 0644); err != nil {
+			t.Fatalf("write canonical metadata: %v", err)
+		}
+		configPath := filepath.Join(mayorRigBeads, "config.yaml")
+		if err := os.WriteFile(configPath, []byte("backend: dolt\n"), 0644); err != nil {
+			t.Fatalf("write canonical config: %v", err)
+		}
+
+		// SetupRedirect must refuse — the canonical guard lives in
+		// ComputeRedirectTarget (parts[1] == "mayor").
+		err := SetupRedirect(townRoot, mayorRigPath)
+		if err == nil {
+			t.Fatalf("SetupRedirect should refuse the canonical mayor/rig/.beads")
+		}
+
+		// The canonical metadata.json and config.yaml must be untouched.
+		if _, statErr := os.Stat(metaPath); statErr != nil {
+			t.Errorf("canonical metadata.json must NOT be stripped, stat err = %v", statErr)
+		}
+		if _, statErr := os.Stat(configPath); statErr != nil {
+			t.Errorf("canonical config.yaml must NOT be stripped, stat err = %v", statErr)
+		}
+	})
+}

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -2853,7 +2853,12 @@ func TestSetupRedirect(t *testing.T) {
 		}
 	})
 
-	t.Run("cleans runtime files but preserves config files", func(t *testing.T) {
+	t.Run("strips database identity but preserves tracked docs", func(t *testing.T) {
+		// A worktree .beads is redirect-only (docs/design/architecture.md:193).
+		// SetupRedirect must strip runtime files AND any local database identity
+		// (metadata.json, config.yaml) so the worktree never carries a
+		// stale/wrong dolt_database that breaks bd when issue_prefix != db name
+		// (refs #2682, #4033). Tracked docs like README.md are still preserved.
 		townRoot := t.TempDir()
 		rigRoot := filepath.Join(townRoot, "testrig")
 		rigBeads := filepath.Join(rigRoot, ".beads")
@@ -2863,7 +2868,7 @@ func TestSetupRedirect(t *testing.T) {
 		if err := os.MkdirAll(rigBeads, 0755); err != nil {
 			t.Fatalf("mkdir rig beads: %v", err)
 		}
-		// Simulate worktree with both runtime and tracked files
+		// Simulate worktree with runtime, database-identity, and doc files
 		if err := os.MkdirAll(crewBeads, 0755); err != nil {
 			t.Fatalf("mkdir crew beads: %v", err)
 		}
@@ -2871,14 +2876,14 @@ func TestSetupRedirect(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(crewBeads, "daemon.lock"), []byte("1234"), 0644); err != nil {
 			t.Fatalf("write daemon.lock: %v", err)
 		}
-		// Local beads metadata is per-machine configuration and must survive startup.
+		// Database identity (should now be removed — worktree .beads is redirect-only)
 		if err := os.WriteFile(filepath.Join(crewBeads, "metadata.json"), []byte("{}"), 0644); err != nil {
 			t.Fatalf("write metadata.json: %v", err)
 		}
-		// Config files (should be preserved)
 		if err := os.WriteFile(filepath.Join(crewBeads, "config.yaml"), []byte("prefix: test"), 0644); err != nil {
 			t.Fatalf("write config: %v", err)
 		}
+		// Tracked docs (should be preserved)
 		if err := os.WriteFile(filepath.Join(crewBeads, "README.md"), []byte("# Beads"), 0644); err != nil {
 			t.Fatalf("write README: %v", err)
 		}
@@ -2891,14 +2896,16 @@ func TestSetupRedirect(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(crewBeads, "daemon.lock")); !os.IsNotExist(err) {
 			t.Error("daemon.lock should have been removed")
 		}
-		if _, err := os.Stat(filepath.Join(crewBeads, "metadata.json")); err != nil {
-			t.Errorf("metadata.json should have been preserved: %v", err)
+
+		// Verify database identity was stripped (worktree .beads is redirect-only)
+		if _, err := os.Stat(filepath.Join(crewBeads, "metadata.json")); !os.IsNotExist(err) {
+			t.Errorf("metadata.json should have been removed (redirect-only worktree), stat err = %v", err)
+		}
+		if _, err := os.Stat(filepath.Join(crewBeads, "config.yaml")); !os.IsNotExist(err) {
+			t.Errorf("config.yaml should have been removed (redirect-only worktree), stat err = %v", err)
 		}
 
-		// Verify config files were preserved
-		if _, err := os.Stat(filepath.Join(crewBeads, "config.yaml")); err != nil {
-			t.Errorf("config.yaml should have been preserved: %v", err)
-		}
+		// Verify tracked docs were preserved
 		if _, err := os.Stat(filepath.Join(crewBeads, "README.md")); err != nil {
 			t.Errorf("README.md should have been preserved: %v", err)
 		}


### PR DESCRIPTION
## Summary

Refs #2682, #4033.

On rigs where `issue_prefix != db name`, a git-tracked worktree
`refinery/rig/.beads/metadata.json` carrying `dolt_database=<prefix>` breaks `bd`
from the worktree: `bd` reads the worktree's local `metadata.json`/`config.yaml`
instead of following the redirect. The canonical design
(`docs/design/architecture.md`) is that a worktree `.beads` is **redirect-only**.

**Root cause:** `cleanBeadsRuntimeFiles` (called by `SetupRedirect`) stripped
runtime files but left `metadata.json` and `config.yaml` behind, so a stale or
wrong database identity could persist in a worktree `.beads`.

## Changes

- **`internal/beads/beads_redirect.go`**: add `metadata.json` and `config.yaml`
  to the patterns removed by `cleanBeadsRuntimeFiles`, so a worktree `.beads`
  becomes strictly redirect-only and never carries a stale/wrong `dolt_database`.
  This is scoped to redirect-target worktrees only: `SetupRedirect` calls
  `ComputeRedirectTarget` first, which **refuses the canonical `mayor/rig/.beads`**
  (`parts[0]`/`parts[1] == "mayor"` guard) and returns an error before any cleaning
  happens. I verified that guard ordering before relying on it.
- **`internal/beads/beads_redirect_test.go`** (new): a worktree `.beads` with a
  bogus `metadata.json` (`dolt_database != prefix`) plus `config.yaml` is reduced
  to redirect-only after `SetupRedirect`, resolves to the rig-level DB, and the
  canonical `mayor/rig/.beads` is **NOT** stripped (`SetupRedirect` refuses it).
- **`internal/beads/beads_test.go`**: updated the existing
  "cleans runtime files but preserves config files" subtest to the new
  redirect-only contract — `metadata.json`/`config.yaml` are now stripped from a
  worktree `.beads`; `README.md` and other tracked docs are still preserved.

## Follow-up (not in this PR)

The broad "resolved DB name everywhere" refactor (**#4033**) is the recommended fix
for the root class (#2682 / #4033) and is intentionally **not** attempted here —
this PR is the scoped, lowest-layer fix (worktree redirect is strictly
redirect-only).

## Testing

- `go build -o /tmp/gt ./cmd/gt` — passes.
- `go test ./internal/beads/...` — passes (incl. the new test and the updated
  subtest).
- `go test ./internal/templates/...` — passes.
- `gofmt -l` clean and `go vet ./internal/beads/` clean on changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)