### PR TITLE
fix(dolt): cap Go runtime memory to prevent CUDA order:4 failures

### DIFF
--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1734,6 +1734,26 @@ func Start(townRoot string) error {
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 
+	// Cap Dolt's Go runtime memory to prevent unbounded RSS growth under
+	// long-running workloads. Without these, dolt has been observed climbing
+	// to 30-55 GiB RSS in WSL2 hosts, which (a) triggers global OOM kills of
+	// dolt itself and (b) starves the WSL2 kernel of contiguous pages needed
+	// by NVIDIA's cuda-EvtHandlr, producing order:4 page allocation failures
+	// in unrelated GPU containers (vLLM, ComfyUI). See dmesg for entries like:
+	//   cuda-EvtHandlr: page allocation failure: order:4, mode:0x40c40...
+	//   VLLM::EngineCor: page allocation failure: order:4, ...
+	// Both vars are only set if the caller hasn't already chosen a value, so
+	// operators can tune via the environment (e.g. GOMEMLIMIT=24GiB) without
+	// editing source.
+	env := os.Environ()
+	if _, set := os.LookupEnv("GOMEMLIMIT"); !set {
+		env = append(env, "GOMEMLIMIT=16GiB")
+	}
+	if _, set := os.LookupEnv("GOGC"); !set {
+		env = append(env, "GOGC=50")
+	}
+	cmd.Env = env
+
 	// Detach from terminal and put dolt in its own process group so that
 	// signals sent to the parent process group (e.g. SIGHUP when the caller
 	// calls syscall.Exec to become tmux) don't reach the dolt server.


### PR DESCRIPTION
## Summary

Default `GOMEMLIMIT=16GiB` and `GOGC=50` on the dolt `sql-server` subprocess so its Go runtime can self-bound. Operators can still override either var in the environment without editing source.

## Why

Without a memory cap, `dolt sql-server` under a sustained agent-fleet workload grows unbounded. On WSL2 hosts this produces two cascading failure modes:

1. **Global OOM kills of dolt itself** (cgroup `user.slice`, `task_memcg=...tmux-spawn-*.scope`, `global_oom`). The agent fleet relying on dolt sees the SQL server vanish and reconnect storms ensue.
2. **`cuda-EvtHandlr` order:4 page allocation failures** in unrelated GPU containers (vLLM, ComfyUI). The WSL2 kernel cannot satisfy NVIDIA event-handler 64 KiB contiguous allocations once the VM is fragmented by a 30-55 GiB dolt process. From dmesg on the affected host:

```
cuda-EvtHandlr: page allocation failure: order:4, mode:0x40c40(GFP_NOFS|__GFP_COMP),
  nodemask=(null),cpuset=docker-<vllm-container-id>.scope,mems_allowed=0
VLLM::EngineCor: page allocation failure: order:4, mode:0x40c40(GFP_NOFS|__GFP_COMP),
  nodemask=(null),cpuset=docker-<vllm-container-id>.scope,mems_allowed=0
Out of memory: Killed process 294270 (dolt) total-vm:40259932kB, anon-rss:36294692kB
Out of memory: Killed process 593428 (dolt) total-vm:35683044kB, anon-rss:32658640kB
```

## Empirical results

On the affected workstation (RTX 5090, 56 GiB WSL2 VM, alleago-town fleet ~116 concurrent connections across 6 databases):

| Configuration       | dolt steady-state RSS | dolt OOM kills / 24h | `cuda-EvtHandlr` order:4 / 24h |
|---------------------|-----------------------|----------------------|---------------------------------|
| No cap (current)    | climbs to 32-55 GiB   | 5-7                  | dozens                          |
| `GOMEMLIMIT=16GiB`  | ~15.6 GiB             | 0                    | 0                               |

## Changes

- `internal/doltserver/doltserver.go`: in `Start()`, between `cmd.Stderr = logFile` and `setProcessGroup(cmd)`, populate `cmd.Env` with the parent environment plus `GOMEMLIMIT=16GiB` and `GOGC=50` if either is unset by the caller.

## Testing

- [x] `go vet ./internal/doltserver/...` clean
- [x] `go test -short -count=1 ./internal/doltserver/...` passes (7.6s, no regressions)
- [x] `make build` succeeds; resulting binary launches `gt dolt restart` and the new dolt process has `GOMEMLIMIT=16GiB` and `GOGC=50` in `/proc/<pid>/environ`
- [x] Manual: deployed binary on the affected host; cuda-EvtHandlr failures stopped after the restart

## Checklist

- [x] Code follows project style (uses stdlib `os.LookupEnv`, no new dependencies)
- [x] Documentation updated (inline comment in `Start()` explains the rationale and the dmesg signature operators should look for)
- [x] No breaking changes — only adds two env vars to the dolt subprocess, both overridable, both no-ops on hosts with plentiful memory

## Operator override

To raise the cap (e.g. on a 128 GiB host):

```bash
GOMEMLIMIT=32GiB gt dolt restart
```

To disable entirely (not recommended on WSL2 with GPU containers):

```bash
GOMEMLIMIT=off gt dolt restart
```
