### PR TITLE
fix: boot role template cwd (deacon/dogs/boot)

### DIFF
--- a/internal/templates/roles/boot.md.tmpl
+++ b/internal/templates/roles/boot.md.tmpl
@@ -45,7 +45,7 @@ Boot restarts on each daemon tick. This is intentional:
 
 ## Working Directory
 
-**IMPORTANT**: Always work from `{{ .TownRoot }}/deacon/` directory.
+**IMPORTANT**: Always work from `{{ .TownRoot }}/deacon/dogs/boot/` directory.
 
 You share context with the Deacon - both operate on the same state.
 


### PR DESCRIPTION
Boot's home is `{TownRoot}/deacon/dogs/boot/` (boot.go bootDir), but boot.md.tmpl directed it to `{TownRoot}/deacon/`, tripping a ROLE/LOCATION MISMATCH warning + cwd auto-reset on every Boot tick (cosmetic but noisy). Aligns the template to the canonical bootDir (same pattern as dog.md.tmpl). Found by Boot triage; templates tests pass.