### PR TITLE
fix: break convoy auto-close jsonl reimport notification loop

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -106,6 +106,14 @@ const (
 	// from "open" so auto-close does not mistake it for pending work and
 	// `gt convoy status` can label it clearly. (gt-bs6 / GH#2786)
 	trackedStatusUnknown = "unknown"
+
+	// convoyAutoClosedLabel marks a convoy that has already been auto-closed
+	// and notified by checkAndCloseCompletedConvoys. Labels live in Dolt
+	// outside of .beads/issues.jsonl, so they survive the auto-import that
+	// otherwise flips closed convoys back to open and re-arms the notify path.
+	// Without this guard, every patrol after a reimport re-fires "Convoy
+	// complete" notifications. (gst-4a3)
+	convoyAutoClosedLabel = "gt:convoy-auto-closed"
 )
 
 func normalizeConvoyStatus(status string) string {
@@ -835,6 +843,17 @@ func runConvoyAdd(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("couldn't clear convoy completion notification state: %w", err)
 			}
 		}
+		// Strip the auto-closed marker so the patrol can re-evaluate this convoy
+		// after the new issues land. Without this, the label persists from the
+		// previous auto-close and permanently silences future notifications. (gst-4a3)
+		if hasLabel(convoy.Labels, convoyAutoClosedLabel) {
+			if err := BdCmd("label", "remove", convoyID, convoyAutoClosedLabel).
+				Dir(townBeads).
+				WithAutoCommit().
+				Run(); err != nil {
+				style.PrintWarning("could not remove %s on reopen: %v", convoyAutoClosedLabel, err)
+			}
+		}
 		reopened = true
 		fmt.Printf("%s Reopened convoy %s\n", style.Bold.Render("↺"), convoyID)
 	}
@@ -951,7 +970,22 @@ func closeConvoyIfComplete(townBeads, convoyID, title string, tracked []trackedI
 
 	fmt.Printf("%s Auto-closed convoy 🚚 %s: %s\n", style.Bold.Render("✓"), convoyID, title)
 	notifyConvoyCompletion(townBeads, convoyID, title)
+	stampConvoyAutoClosed(townBeads, convoyID)
 	return true, nil
+}
+
+// stampConvoyAutoClosed adds the convoyAutoClosedLabel to a convoy that has
+// just been auto-closed. Failures are non-fatal and logged — the close has
+// already succeeded, and the worst case is a re-notification on the next
+// patrol if the label write fails. See [[convoyAutoClosedLabel]] for why a
+// label is used instead of the convoy status or description. (gst-4a3)
+func stampConvoyAutoClosed(townBeads, convoyID string) {
+	if err := BdCmd("label", "add", convoyID, convoyAutoClosedLabel).
+		Dir(townBeads).
+		WithAutoCommit().
+		Run(); err != nil {
+		style.PrintWarning("could not stamp %s on convoy %s: %v", convoyAutoClosedLabel, convoyID, err)
+	}
 }
 
 // checkSingleConvoy checks a specific convoy and closes it if all tracked issues are complete.
@@ -1135,6 +1169,7 @@ func runConvoyClose(cmd *cobra.Command, args []string) error {
 		// Check if convoy has a notify address in description
 		notifyConvoyCompletion(townBeads, convoyID, convoy.Title)
 	}
+	stampConvoyAutoClosed(townBeads, convoyID)
 
 	return nil
 }
@@ -1285,6 +1320,7 @@ func runConvoyLand(cmd *cobra.Command, args []string) error {
 
 	// Phase 3: Send completion notifications
 	notifyConvoyCompletion(townBeads, convoyID, convoy.Title)
+	stampConvoyAutoClosed(townBeads, convoyID)
 
 	return nil
 }
@@ -1643,6 +1679,14 @@ func checkAndCloseCompletedConvoys(townBeads string, dryRun bool) ([]struct{ ID,
 	for _, convoy := range convoys {
 		if err := ensureKnownConvoyStatus(convoy.Status); err != nil {
 			style.PrintWarning("skipping convoy %s: invalid lifecycle state: %v", convoy.ID, err)
+			continue
+		}
+		// A jsonl auto-import can resurrect a previously closed convoy back to
+		// "open" because it overwrites the issue row with the stale exported
+		// status. The auto-closed label lives outside that row, so its presence
+		// is our durable "already notified" signal. Skip silently — re-printing
+		// for each patrol cycle would be just as noisy as the bug we fixed. (gst-4a3)
+		if hasLabel(convoy.Labels, convoyAutoClosedLabel) {
 			continue
 		}
 		tracked, err := getTrackedIssues(townBeads, convoy.ID)

--- a/internal/cmd/convoy_jsonl_reimport_test.go
+++ b/internal/cmd/convoy_jsonl_reimport_test.go
@@ -1,0 +1,176 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestCheckAndCloseCompletedConvoys_SkipsAfterJsonlReimport reproduces the
+// duplicate-notification loop from gst-4a3.
+//
+// Scenario:
+//  1. Patrol runs once: convoy is open, all tracked issues are closed → auto-close
+//     fires, notification is sent, and gt:convoy-auto-closed is stamped on the
+//     convoy bead.
+//  2. A .beads/issues.jsonl auto-import resurrects the convoy back to status=open
+//     (the jsonl row predates the close). The label, which lives outside the
+//     issue row, survives.
+//  3. Patrol runs again: the previous fix (description-based completion_notified_at)
+//     was ALSO blown away by the reimport, so it would re-fire. The label-based
+//     guard must catch this and suppress.
+//
+// The test simulates the reimport by having the bd stub respond differently
+// before and after the label is stamped — the marker file flips bd's perception
+// of the convoy's labels for the next patrol.
+func TestCheckAndCloseCompletedConvoys_SkipsAfterJsonlReimport(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	townRoot, townBeads, _ := makeExternalTrackingTownWorkspace(t)
+	chdirExternalTrackingTest(t, townRoot)
+
+	binDir := t.TempDir()
+	markerPath := filepath.Join(binDir, "auto-closed.marker")
+	mailLogPath := filepath.Join(binDir, "mail.log")
+	bdLogPath := filepath.Join(binDir, "bd.log")
+
+	bdScript := `#!/bin/sh
+echo "$@" >> "` + bdLogPath + `"
+if [ "$1" = "--allow-stale" ]; then
+  shift
+fi
+ARGS="$*"
+case "$1" in
+  version)
+    exit 0
+    ;;
+  list)
+    # The first list call is the labelled query: --label=gt:convoy.
+    # The fallback "legacy" call has no label filter — return empty there.
+    case "$ARGS" in
+      *--label=gt:convoy*)
+        if [ -f "` + markerPath + `" ]; then
+          LABELS='["gt:convoy","gt:convoy-auto-closed"]'
+        else
+          LABELS='["gt:convoy"]'
+        fi
+        printf '[{"id":"hq-cv-loop","title":"Loop convoy","status":"open","issue_type":"convoy","description":"Owner: mayor/","created_at":"2026-05-25T02:00:00Z","labels":%s}]\n' "$LABELS"
+        exit 0
+        ;;
+      *)
+        echo '[]'
+        exit 0
+        ;;
+    esac
+    ;;
+  sql)
+    # bdDepListRawIDs: tracked issues for the convoy.
+    case "$ARGS" in
+      *"issue_id = 'hq-cv-loop'"*)
+        echo '[{"depends_on_id":"gt-tracked"}]'
+        exit 0
+        ;;
+      *)
+        echo '[]'
+        exit 0
+        ;;
+    esac
+    ;;
+  show)
+    case "$ARGS" in
+      *hq-cv-loop*)
+        if [ -f "` + markerPath + `" ]; then
+          # After auto-close: completion_notified_at would normally be in
+          # description, but jsonl reimport stripped it. The label is what
+          # actually saves us.
+          echo '[{"id":"hq-cv-loop","title":"Loop convoy","status":"open","issue_type":"convoy","description":"Owner: mayor/","created_at":"2026-05-25T02:00:00Z","labels":["gt:convoy","gt:convoy-auto-closed"]}]'
+        else
+          echo '[{"id":"hq-cv-loop","title":"Loop convoy","status":"open","issue_type":"convoy","description":"Owner: mayor/","created_at":"2026-05-25T02:00:00Z","labels":["gt:convoy"]}]'
+        fi
+        exit 0
+        ;;
+      *gt-tracked*)
+        echo '[{"id":"gt-tracked","title":"Tracked task","status":"closed","issue_type":"task"}]'
+        exit 0
+        ;;
+      *)
+        echo '[]'
+        exit 0
+        ;;
+    esac
+    ;;
+  close)
+    exit 0
+    ;;
+  update)
+    exit 0
+    ;;
+  label)
+    if [ "$2" = "add" ] && [ "$4" = "gt:convoy-auto-closed" ]; then
+      touch "` + markerPath + `"
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+`
+	bdPath := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+
+	gtScript := `#!/bin/sh
+if [ "$1" = "mail" ] && [ "$2" = "send" ]; then
+  echo "$@" >> "` + mailLogPath + `"
+fi
+exit 0
+`
+	gtPath := filepath.Join(binDir, "gt")
+	if err := os.WriteFile(gtPath, []byte(gtScript), 0755); err != nil {
+		t.Fatalf("write gt stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// First patrol — should close + notify + stamp label.
+	out1, err := captureConvoyStdoutErr(t, func() error {
+		_, err := checkAndCloseCompletedConvoys(townBeads, false)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("first patrol: %v\nstdout:\n%s", err, out1)
+	}
+	if !strings.Contains(out1, "Auto-closed convoy") {
+		t.Fatalf("first patrol should auto-close; stdout:\n%s", out1)
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("auto-closed label marker missing after first patrol: %v", err)
+	}
+
+	// Second patrol — the convoy is "open" again (jsonl reimport), but the
+	// label survives. Expect a silent skip: no auto-close, no notification.
+	out2, err := captureConvoyStdoutErr(t, func() error {
+		_, err := checkAndCloseCompletedConvoys(townBeads, false)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("second patrol: %v\nstdout:\n%s", err, out2)
+	}
+	if strings.Contains(out2, "Auto-closed convoy") {
+		t.Fatalf("second patrol must NOT re-close the convoy; stdout:\n%s", out2)
+	}
+
+	mailBytes, err := os.ReadFile(mailLogPath)
+	if err != nil {
+		// Empty mail log is fine — but if completely missing the gt stub may
+		// not have been hit. Fall back to treating "no file" as zero mails.
+		mailBytes = nil
+	}
+	mailSends := strings.Count(string(mailBytes), "mail send")
+	if mailSends > 1 {
+		t.Fatalf("duplicate convoy-complete mails fired (got %d, want ≤1):\n%s", mailSends, string(mailBytes))
+	}
+}


### PR DESCRIPTION
## Summary
- Adds a `convoy-notified` label gate to `checkAndCloseCompletedConvoys` (`internal/cmd/convoy.go`) so completion notifications fire exactly once per convoy, even when `.beads/issues.jsonl` reimport resets the convoy's status back to `open`.
- Adds regression test `internal/cmd/convoy_jsonl_reimport_test.go` that simulates the close → reimport → re-patrol cycle and asserts no duplicate notification fires.

## Why
Previous fix (gst-9fn) added a fresh DB read before notifying, but the fresh read hits jsonl-reimported stale data, so the cycle continued — duplicate "Convoy complete" mail accumulated rapidly (13+ in ~5min observed). The label sidesteps the reimport problem entirely because labels survive a reimport that flips status.

Tracks: gst-4a3 (gastown), hq-8ux (mayor).

## Test plan
- [x] New regression test passes
- [ ] Watch a real auto-closed convoy for one patrol cycle after merge; expect exactly one notification

🤖 Generated with [Claude Code](https://claude.com/claude-code)