### PR TITLE
fix(beads): omit BEADS_DOLT_DATA_DIR in server mode so cross-rig bond resolves (#4140)

### DIFF
--- a/internal/beads/database.go
+++ b/internal/beads/database.go
@@ -193,15 +193,23 @@ func doltTargetEnvFromBeadsDir(beadsDir string) []string {
 	}
 	meta := readDoltMetadata(beadsDir)
 	var env []string
-	if townRoot := FindTownRoot(filepath.Dir(beadsDir)); townRoot != "" {
-		env = append(env, "BEADS_DOLT_DATA_DIR="+filepath.Join(townRoot, ".dolt-data"))
-	}
 	if meta.Host != "" {
 		env = append(env, "BEADS_DOLT_SERVER_HOST="+meta.Host)
 	}
 	if meta.Port != "" {
 		env = append(env, "BEADS_DOLT_SERVER_PORT="+meta.Port)
 		env = append(env, "BEADS_DOLT_PORT="+meta.Port)
+	}
+	// In server mode the running server owns the data; the host/port above is the
+	// connection target. Emitting BEADS_DOLT_DATA_DIR (the shared, multi-database
+	// town data dir) makes bd's mol resolution pick a database other than the one
+	// selected by the pinned .beads metadata, so a routed cross-rig bead (e.g. mi-)
+	// fails to resolve in `bd mol bond`. Only point at the data dir for embedded
+	// mode (no server host/port configured).
+	if meta.Host == "" && meta.Port == "" {
+		if townRoot := FindTownRoot(filepath.Dir(beadsDir)); townRoot != "" {
+			env = append(env, "BEADS_DOLT_DATA_DIR="+filepath.Join(townRoot, ".dolt-data"))
+		}
 	}
 	return env
 }

--- a/internal/beads/dolt_target_env_test.go
+++ b/internal/beads/dolt_target_env_test.go
@@ -1,0 +1,81 @@
+package beads
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func doltEnvHasKey(env []string, key string) bool {
+	prefix := key + "="
+	for _, e := range env {
+		if strings.HasPrefix(e, prefix) {
+			return true
+		}
+	}
+	return false
+}
+
+// TestDoltTargetEnvFromBeadsDir_ServerModeOmitsDataDir verifies that in server
+// mode (metadata.json has dolt_server_host/port) the shared, multi-database
+// BEADS_DOLT_DATA_DIR is NOT emitted. Emitting it makes bd's mol resolution
+// select a database other than the one named in the pinned .beads metadata, so
+// a routed cross-rig bead (e.g. mi-) fails to resolve in `bd mol bond`
+// (gastownhall/gastown#4140). The host/port is the connection target in server
+// mode; the data dir is only meaningful for embedded mode.
+func TestDoltTargetEnvFromBeadsDir_ServerModeOmitsDataDir(t *testing.T) {
+	town := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(town, "mayor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(town, "mayor", "town.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	beadsDir := filepath.Join(town, "minerals", ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{"dolt_mode":"server","dolt_server_host":"127.0.0.1","dolt_server_port":3307,"dolt_database":"minerals"}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := doltTargetEnvFromBeadsDir(beadsDir)
+
+	if !doltEnvHasKey(env, "BEADS_DOLT_SERVER_HOST") || !doltEnvHasKey(env, "BEADS_DOLT_SERVER_PORT") {
+		t.Errorf("server-mode env missing host/port: %v", env)
+	}
+	if doltEnvHasKey(env, "BEADS_DOLT_DATA_DIR") {
+		t.Errorf("server-mode env must NOT include BEADS_DOLT_DATA_DIR (causes wrong-db resolution for routed beads): %v", env)
+	}
+}
+
+// TestDoltTargetEnvFromBeadsDir_EmbeddedModeSetsDataDir verifies that embedded
+// mode (no server host/port configured) still points bd at the town data dir.
+func TestDoltTargetEnvFromBeadsDir_EmbeddedModeSetsDataDir(t *testing.T) {
+	town := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(town, "mayor"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(town, "mayor", "town.json"), []byte(`{}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	beadsDir := filepath.Join(town, ".beads")
+	if err := os.MkdirAll(beadsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	meta := `{"dolt_mode":"embedded","dolt_database":"hq"}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(meta), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := doltTargetEnvFromBeadsDir(beadsDir)
+
+	if doltEnvHasKey(env, "BEADS_DOLT_SERVER_HOST") || doltEnvHasKey(env, "BEADS_DOLT_SERVER_PORT") {
+		t.Errorf("embedded-mode env must not include server host/port: %v", env)
+	}
+	if !doltEnvHasKey(env, "BEADS_DOLT_DATA_DIR") {
+		t.Errorf("embedded-mode env should include BEADS_DOLT_DATA_DIR: %v", env)
+	}
+}


### PR DESCRIPTION
## Summary
In a multi-rig Dolt-server workspace, `gt sling <rig-bead> <rig>` spawns the polecat but fails during `mol-polecat-work` instantiation because `bd mol bond` can't resolve a routed cross-rig bead (e.g. `mi-`), and the polecat rolls back. Root cause: `doltTargetEnvFromBeadsDir` emits the shared, multi-database town `BEADS_DOLT_DATA_DIR` even in server mode, so bd's mol resolution selects a database other than the one named in the pinned `.beads` metadata. This scopes the data-dir emission to embedded mode.

## Related Issue
Fixes #4140

## Changes
- `internal/beads/database.go`: in `doltTargetEnvFromBeadsDir`, emit `BEADS_DOLT_DATA_DIR` only when no server host/port is configured (embedded mode). In server mode the running server owns the data and the host/port is the connection target; the shared multi-DB data dir misdirects `bd mol` resolution for routed beads.
- `internal/beads/dolt_target_env_test.go`: unit tests — server mode omits `BEADS_DOLT_DATA_DIR` (regression guard) and embedded mode still sets it.

## Testing
- [x] Unit tests pass (`go test ./internal/beads/`)
- [x] Manual testing performed — validated end-to-end on a town+rig workspace (`hq` + `minerals`, `mi-` routed): `gt sling mi-jjzc minerals` completes (`✓ Formula bonded`, `✓ Work attached to hook (status=hooked)`), the polecat works the bead, `gt done` opens a PR, the refinery merges it; a 5-polecat fleet roll then dispatched cleanly with no recurrence.

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable) — N/A (behavioral fix)
- [x] No breaking changes
