### PR TITLE
fix(daemon): parse bd show --children envelope so molecule steps close (#4142)

### DIFF
--- a/internal/daemon/dog_molecule.go
+++ b/internal/daemon/dog_molecule.go
@@ -258,6 +258,23 @@ func parseChildrenJSON(raw string) ([]childInfo, error) {
 		return nil, nil
 	}
 
+	// bd's `show --children --json` envelope: {"<id>": [..children..], "schema_version": N}.
+	// The integer schema_version key breaks the map[string][]childInfo unmarshal above,
+	// so decode leniently and skip non-array keys.
+	var envelope map[string]json.RawMessage
+	if err := json.Unmarshal(data, &envelope); err == nil {
+		for key, rawVal := range envelope {
+			if key == "schema_version" {
+				continue
+			}
+			var children []childInfo
+			if err := json.Unmarshal(rawVal, &children); err == nil {
+				return children, nil
+			}
+		}
+		return nil, nil
+	}
+
 	return nil, fmt.Errorf("unrecognized JSON shape: %.200s", raw)
 }
 

--- a/internal/daemon/dog_molecule_test.go
+++ b/internal/daemon/dog_molecule_test.go
@@ -86,6 +86,15 @@ func TestParseChildrenJSON(t *testing.T) {
 			wantCount: 2,
 		},
 		{
+			// bd `show --children --json` returns the map keyed by parent ID
+			// alongside a top-level integer "schema_version" key. The int value
+			// breaks map[string][]childInfo unmarshalling, so the parser must
+			// skip non-array keys.
+			name:      "envelope with schema_version (bd show --children)",
+			input:     `{"hq-wisp-root":[{"id":"hq-wisp-a","title":"Probe","status":"open"},{"id":"hq-wisp-b","title":"Report","status":"open"}],"schema_version":1}`,
+			wantCount: 2,
+		},
+		{
 			name:      "empty map wrapper",
 			input:     `{"hq-wisp-root":[]}`,
 			wantCount: 0,


### PR DESCRIPTION
## Summary
Dog and polecat molecules never close their step wisps because `parseChildrenJSON` rejects bd's `show <id> --children --json` output. bd returns the children map keyed by parent ID **plus** a top-level integer `schema_version` key; that int breaks the `map[string][]childInfo` unmarshal, so the parser falls through to "unrecognized JSON shape", molecules discover 0 steps, and untyped step wisps leak (the compactor can't reclaim them). This decodes the envelope leniently and skips the `schema_version` key.

## Related Issue
Fixes #4142

## Changes
- `internal/daemon/dog_molecule.go`: `parseChildrenJSON` now also accepts the `{"<id>": [..], "schema_version": N}` envelope (decode to `map[string]json.RawMessage`, skip non-array keys).
- `internal/daemon/dog_molecule_test.go`: added a table case for the envelope shape.

## Testing
- [x] Unit tests pass (`go test ./internal/daemon/ -run TestParseChildrenJSON`)
- [x] Manual testing performed — deployed on a live town; dog molecules now pour with discovered steps (`poured mol-dog-doctor → … (3 steps)`) and no "unrecognized JSON shape" errors; step wisps now close (previously leaked open+untyped).

## Checklist
- [x] Code follows project style
- [x] Documentation updated (if applicable) — N/A
- [x] No breaking changes
