### PR TITLE
fix(tmux): guard NewSession against socket-clobber on unresponsive servers (gt-h9z)

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -15,6 +16,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/config"
@@ -242,6 +244,80 @@ func (t *Tmux) run(args ...string) (string, error) {
 	return strings.TrimSpace(stdout.String()), nil
 }
 
+// probeServerHealth guards against the gt-h9z clobber: tmux's internal
+// "is a server already bound to this socket?" probe is tight enough that
+// a momentarily-unresponsive server can be misclassified as absent, and
+// tmux's recovery path unlinks the socket and binds a fresh server at
+// the same path — silently orphaning the existing server and any
+// sessions/clients running inside it.
+//
+// Two-stage check, designed to bail ONLY in the wedge case and not on
+// the common "tmux exited cleanly after its last session was killed,
+// but left the socket file behind" pattern that produces a benign
+// stale socket:
+//
+//  1. Kernel-level Unix-socket dial. ECONNREFUSED (no live listener) →
+//     benign stale; tmux will safely recreate. Successful connect →
+//     listener is alive; proceed to stage 2. Any other dial error
+//     (e.g. ENOTSOCK from a regular file in the way, timeout) → bail.
+//  2. App-level `list-sessions` probe with a tight timeout. Success or
+//     ErrNoServer (kernel said yes but tmux already finished exiting
+//     between stages) → safe. Anything else (wedge, slow response,
+//     protocol error) → bail.
+//
+// Default-socket Tmux (empty socketName) is left untouched: that path
+// is shared with the user's interactive tmux and not part of the gt
+// crew start workflow that produced the captured evidence.
+func (t *Tmux) probeServerHealth() error {
+	if t.socketName == "" {
+		return nil
+	}
+	socketPath := filepath.Join(SocketDir(), t.socketName)
+	if _, err := os.Stat(socketPath); err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("stat tmux socket %s: %w", socketPath, err)
+	}
+	conn, err := net.DialTimeout("unix", socketPath, probeDialTimeout)
+	if err != nil {
+		if errors.Is(err, syscall.ECONNREFUSED) || os.IsNotExist(err) {
+			// No live listener — kernel has no one bound. The socket
+			// file is a benign leftover from a clean tmux exit; tmux
+			// will recreate it.
+			return nil
+		}
+		return fmt.Errorf(
+			"tmux socket %s exists but is not a connectable Unix socket (%v); "+
+				"refusing to start a new session — investigate the file "+
+				"holder (e.g. `ss -lxp src %s` or `lsof %s`) before retrying (see gt-h9z)",
+			socketPath, err, socketPath, socketPath,
+		)
+	}
+	_ = conn.Close()
+	// Kernel-level listener is up. Now confirm tmux itself is responsive.
+	if _, err := t.run("list-sessions", "-F", ""); err != nil {
+		if errors.Is(err, ErrNoServer) {
+			// Listener was up at stage 1 but tmux has since shut down
+			// cleanly — also benign. tmux will recreate.
+			return nil
+		}
+		return fmt.Errorf(
+			"tmux socket %s has a live listener but `list-sessions` failed (%v); "+
+				"refusing to start a new session — tmux's recovery path "+
+				"would unlink and rebind, orphaning the existing server (see gt-h9z)",
+			socketPath, err,
+		)
+	}
+	return nil
+}
+
+// probeDialTimeout bounds the kernel-level Unix-socket probe used by
+// probeServerHealth. Generous enough to ride out brief scheduling
+// hiccups on a loaded host, tight enough that the clobber-guard does
+// not add user-visible latency on the happy path.
+const probeDialTimeout = 200 * time.Millisecond
+
 // wrapError wraps tmux errors with context.
 func (t *Tmux) wrapError(err error, stderr string, args []string) error {
 	stderr = strings.TrimSpace(stderr)
@@ -270,6 +346,9 @@ func (t *Tmux) wrapError(err error, stderr string, args []string) error {
 // NewSession creates a new detached tmux session.
 func (t *Tmux) NewSession(name, workDir string) error {
 	if err := validateSessionName(name); err != nil {
+		return err
+	}
+	if err := t.probeServerHealth(); err != nil {
 		return err
 	}
 	args := []string{"new-session", "-d", "-s", name}
@@ -309,6 +388,9 @@ func (t *Tmux) NewSessionWithCommand(name, workDir, command string) error {
 		}
 	}
 	if err := validateCommandBinary(command); err != nil {
+		return err
+	}
+	if err := t.probeServerHealth(); err != nil {
 		return err
 	}
 
@@ -397,6 +479,9 @@ func (t *Tmux) NewSessionWithCommandAndEnv(name, workDir, command string, env ma
 		}
 	}
 	if err := validateCommandBinary(command); err != nil {
+		return err
+	}
+	if err := t.probeServerHealth(); err != nil {
 		return err
 	}
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -3,8 +3,10 @@ package tmux
 import (
 	"errors"
 	"fmt"
+	"net"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
@@ -1559,6 +1561,143 @@ func TestNewSession_RejectsInvalidName(t *testing.T) {
 	}
 	if !errors.Is(err, ErrInvalidSessionName) {
 		t.Errorf("expected ErrInvalidSessionName, got %v", err)
+	}
+}
+
+// TestProbeServerHealth covers the gt-h9z clobber guard.
+//
+// Probe behavior matrix:
+//
+//	socketName == ""              → nil (default-socket path is untouched).
+//	socket file absent             → nil (tmux will create a fresh server).
+//	stale Unix socket (no listener)→ nil (kernel ECONNREFUSED; benign).
+//	live tmux server               → nil.
+//	non-socket file at socket path → error (refuse to clobber).
+func TestProbeServerHealth(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+
+	t.Run("default_socket_returns_nil", func(t *testing.T) {
+		tm := &Tmux{socketName: ""}
+		if err := tm.probeServerHealth(); err != nil {
+			t.Fatalf("probeServerHealth(default) = %v, want nil", err)
+		}
+	})
+
+	t.Run("absent_socket_returns_nil", func(t *testing.T) {
+		socket := fmt.Sprintf("gt-h9z-absent-%d", time.Now().UnixNano())
+		t.Cleanup(func() { _ = os.Remove(filepath.Join(SocketDir(), socket)) })
+
+		tm := &Tmux{socketName: socket}
+		if err := tm.probeServerHealth(); err != nil {
+			t.Fatalf("probeServerHealth(absent socket) = %v, want nil", err)
+		}
+	})
+
+	// Mirror tmux's "exited cleanly, left socket file behind" state by
+	// binding a real Unix listener and then closing it. The socket file
+	// stays on disk but the kernel returns ECONNREFUSED on connect —
+	// indistinguishable from the post-tmux-exit case, and crucially the
+	// case we MUST allow through (otherwise every test that kills the
+	// last session in a shared tmux server starts failing — that
+	// regressed earlier in this PR before the kernel-level probe was
+	// added).
+	t.Run("stale_unix_socket_returns_nil", func(t *testing.T) {
+		dir := SocketDir()
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", dir, err)
+		}
+		socket := fmt.Sprintf("gt-h9z-stale-unix-%d", time.Now().UnixNano())
+		socketPath := filepath.Join(dir, socket)
+		listener, err := net.Listen("unix", socketPath)
+		if err != nil {
+			t.Fatalf("Listen(%s): %v", socketPath, err)
+		}
+		_ = listener.Close()
+		t.Cleanup(func() { _ = os.Remove(socketPath) })
+
+		tm := &Tmux{socketName: socket}
+		if err := tm.probeServerHealth(); err != nil {
+			t.Fatalf("probeServerHealth(stale unix socket) = %v, want nil", err)
+		}
+	})
+
+	t.Run("non_socket_file_returns_error", func(t *testing.T) {
+		// A regular file at the socket path is not the gt-h9z clobber
+		// scenario per se, but it is unambiguously unsafe: net.Dial
+		// against it returns ENOTSOCK (or similar), not ECONNREFUSED.
+		// Better to bail than to silently let new-session clobber whatever
+		// is there.
+		dir := SocketDir()
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			t.Fatalf("MkdirAll(%s): %v", dir, err)
+		}
+		socket := fmt.Sprintf("gt-h9z-regfile-%d", time.Now().UnixNano())
+		socketPath := filepath.Join(dir, socket)
+		if err := os.WriteFile(socketPath, []byte("not a socket"), 0o600); err != nil {
+			t.Fatalf("WriteFile(%s): %v", socketPath, err)
+		}
+		t.Cleanup(func() { _ = os.Remove(socketPath) })
+
+		tm := &Tmux{socketName: socket}
+		err := tm.probeServerHealth()
+		if err == nil {
+			t.Skip("kernel accepted Dial against a regular file on this platform; cannot exercise the bail path here")
+		}
+		if !strings.Contains(err.Error(), socketPath) {
+			t.Errorf("error %q should mention socket path %q", err, socketPath)
+		}
+		if !strings.Contains(err.Error(), "gt-h9z") {
+			t.Errorf("error %q should cite gt-h9z for traceability", err)
+		}
+	})
+
+	t.Run("live_server_returns_nil", func(t *testing.T) {
+		socket := fmt.Sprintf("gt-h9z-live-%d", time.Now().UnixNano())
+		tm := &Tmux{socketName: socket}
+		sessionName := "gt-h9z-live-session"
+		if err := tm.NewSession(sessionName, ""); err != nil {
+			t.Fatalf("NewSession (live setup): %v", err)
+		}
+		t.Cleanup(func() {
+			_, _ = tm.run("kill-server")
+		})
+
+		if err := tm.probeServerHealth(); err != nil {
+			t.Fatalf("probeServerHealth(live server) = %v, want nil", err)
+		}
+	})
+}
+
+// TestNewSessionAllowsStaleUnixSocket asserts that NewSession proceeds
+// when the only thing at the configured socket path is an unbound Unix
+// socket — the tmux-exited-cleanly state. Regression guard for an
+// earlier draft of the gt-h9z fix that mistakenly bailed in this case
+// and broke every shared-server test in the package.
+func TestNewSessionAllowsStaleUnixSocket(t *testing.T) {
+	if !hasTmux() {
+		t.Skip("tmux not installed")
+	}
+	dir := SocketDir()
+	if err := os.MkdirAll(dir, 0o700); err != nil {
+		t.Fatalf("MkdirAll(%s): %v", dir, err)
+	}
+	socket := fmt.Sprintf("gt-h9z-newsession-stale-unix-%d", time.Now().UnixNano())
+	socketPath := filepath.Join(dir, socket)
+	listener, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatalf("Listen(%s): %v", socketPath, err)
+	}
+	_ = listener.Close()
+	t.Cleanup(func() {
+		_, _ = (&Tmux{socketName: socket}).run("kill-server")
+		_ = os.Remove(socketPath)
+	})
+
+	tm := &Tmux{socketName: socket}
+	if err := tm.NewSession("gt-h9z-newsession", ""); err != nil {
+		t.Fatalf("NewSession against stale Unix socket = %v, want success (tmux must recreate cleanly)", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes gt-h9z. When the configured `-L` socket path is held by a server that tmux's internal liveness probe fails to reach inside its tight timeout, tmux's recovery path unlinks the socket and binds a fresh server at the same path. The original server's listener stays on the kernel fd table — so **two `tmux: server` processes end up simultaneously bound to the same socket path with different inodes**, and any client invoked from a non-tmux shell routes to the new server (which sees none of the old sessions). gt-h9z captured `ss -lx` evidence of this state where a user "lost" their existing pane because the visible server was the post-clobber one.

## Approach

Two-stage health probe in front of every `new-session` call on a named socket:

1. **Kernel-level Unix-socket dial.**
   - `ECONNREFUSED` → file is a benign leftover (tmux exited cleanly, left the inode). tmux will recreate. **Proceed.**
   - Dial succeeds → listener is alive at the kernel layer; advance to stage 2.
   - Other dial error (`ENOTSOCK`, timeout, etc.) → file at the socket path is unsafe. **Bail.**
2. **App-level `list-sessions` probe.**
   - Succeeds → server is responsive. **Proceed.**
   - `ErrNoServer` → server shut down between stages 1 and 2. **Proceed.**
   - Other error → app-layer wedge; this is the gt-h9z window. **Bail.**

Gates all three NewSession entry points (`NewSession`, `NewSessionWithCommand`, `NewSessionWithCommandAndEnv`) so every "create a new tmux session" entry point on a named socket is covered. Default-socket `Tmux` (no `-L`) is left alone — that path is shared with the user's interactive tmux and outside the gt-crew-start workflow that produced the captured evidence.

## Replaces #4041

This PR replaces gastownhall/gastown#4041, which is being closed. #4041's branch carried the same fix in commit 8f9ebab2 but accumulated 76,791 lines of accidentally-committed `.beads/backup/*.jsonl` exports plus 2,398 lines of unrelated polecat-reconcile/config-loader work from a sibling commit on the branch. This PR is the clean cherry-pick — only `internal/tmux/tmux.go` (+85) and `internal/tmux/tmux_test.go` (+139), rebased onto current `gastownhall/gastown:main`.

## Test plan

- [x] `go build ./internal/tmux/...` clean
- [x] `go vet ./internal/tmux/...` clean
- [x] `TestProbeServerHealth` (5 subtests covering default socket / absent socket / stale unix socket / non-socket file / live server) PASS
- [x] `TestNewSessionAllowsStaleUnixSocket` (the previously-broken earlier-draft failure mode — NewSession must succeed against an unbound socket so tmux can recreate the server cleanly) PASS
- [x] All `TestNewSession*` and `TestNewSessionWithCommand*` regression suite PASS
- [x] Pre-existing wall-clock-bound flakes `TestAcceptWorkspaceTrustDialog_NoDialog` and `TestAcceptBypassPermissionsWarning_NoDialog` reproduce on pristine `origin/main` and are unrelated.