### PR TITLE
fix(release): reject unsupported bd versions

### DIFF
--- a/internal/cmd/beads_version.go
+++ b/internal/cmd/beads_version.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -11,24 +12,61 @@ import (
 var (
 	cachedVersionCheckResult error
 	versionCheckOnce         sync.Once
+	checkBeads               = deps.CheckBeads
 )
+
+type beadsVersionError struct {
+	status  deps.BeadsStatus
+	version string
+	err     error
+}
+
+func (e *beadsVersionError) Error() string {
+	return e.err.Error()
+}
+
+func (e *beadsVersionError) Unwrap() error {
+	return e.err
+}
+
+func isUnsupportedNewBeadsVersion(err error) bool {
+	var versionErr *beadsVersionError
+	return errors.As(err, &versionErr) && versionErr.status == deps.BeadsTooNew
+}
 
 // CheckBeadsVersion verifies that the installed beads version meets the minimum requirement.
 // Returns nil if the version is sufficient, or an error with details if not.
 // The check is performed only once per process execution.
 func CheckBeadsVersion() error {
 	versionCheckOnce.Do(func() {
-		status, version := deps.CheckBeads()
+		status, version := checkBeads()
 		switch status {
 		case deps.BeadsOK:
 			cachedVersionCheckResult = nil
 		case deps.BeadsUnknown:
-			cachedVersionCheckResult = fmt.Errorf("beads (bd) version could not be determined\n\nTry reinstalling: go install %s", deps.BeadsInstallPath)
+			cachedVersionCheckResult = &beadsVersionError{
+				status: status,
+				err:    fmt.Errorf("beads (bd) version could not be determined\n\nTry reinstalling: go install %s", deps.BeadsInstallPath),
+			}
 		case deps.BeadsNotFound:
-			cachedVersionCheckResult = fmt.Errorf("beads (bd) not found in PATH\n\nInstall with: go install %s", deps.BeadsInstallPath)
+			cachedVersionCheckResult = &beadsVersionError{
+				status: status,
+				err:    fmt.Errorf("beads (bd) not found in PATH\n\nInstall with: go install %s", deps.BeadsInstallPath),
+			}
 		case deps.BeadsTooOld:
-			cachedVersionCheckResult = fmt.Errorf("beads %s is required, but %s is installed\n\nUpgrade: go install %s",
-				deps.MinBeadsVersion, version, deps.BeadsInstallPath)
+			cachedVersionCheckResult = &beadsVersionError{
+				status:  status,
+				version: version,
+				err: fmt.Errorf("beads %s is required, but %s is installed\n\nUpgrade: go install %s",
+					deps.MinBeadsVersion, version, deps.BeadsInstallPath),
+			}
+		case deps.BeadsTooNew:
+			cachedVersionCheckResult = &beadsVersionError{
+				status:  status,
+				version: version,
+				err: fmt.Errorf("beads %s is installed, but this Gas Town release supports at most %s\n\nDowngrade: go install %s",
+					version, deps.MaxBeadsVersion, deps.BeadsInstallPath),
+			}
 		}
 	})
 	return cachedVersionCheckResult

--- a/internal/cmd/beads_version_test.go
+++ b/internal/cmd/beads_version_test.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/deps"
+)
+
+func resetBeadsVersionCheckForTest(t *testing.T, fn func() (deps.BeadsStatus, string)) {
+	t.Helper()
+
+	origCheckBeads := checkBeads
+	origResult := cachedVersionCheckResult
+	origOnce := versionCheckOnce
+
+	checkBeads = fn
+	cachedVersionCheckResult = nil
+	versionCheckOnce = sync.Once{}
+
+	t.Cleanup(func() {
+		checkBeads = origCheckBeads
+		cachedVersionCheckResult = origResult
+		versionCheckOnce = origOnce
+	})
+}
+
+func TestCheckBeadsVersionRejectsVersionsAboveSupportedMaximum(t *testing.T) {
+	resetBeadsVersionCheckForTest(t, func() (deps.BeadsStatus, string) {
+		return deps.BeadsTooNew, "1.0.5"
+	})
+
+	err := CheckBeadsVersion()
+	if err == nil {
+		t.Fatal("CheckBeadsVersion returned nil for a too-new bd version")
+	}
+	if !isUnsupportedNewBeadsVersion(err) {
+		t.Fatalf("expected unsupported-new marker for error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "supports at most 1.0.4") {
+		t.Fatalf("error %q does not mention supported maximum", err)
+	}
+	if !strings.Contains(err.Error(), deps.BeadsInstallPath) {
+		t.Fatalf("error %q does not include pinned reinstall command", err)
+	}
+}
+
+func TestCheckBeadsVersionDoesNotHardFailOlderVersionErrors(t *testing.T) {
+	resetBeadsVersionCheckForTest(t, func() (deps.BeadsStatus, string) {
+		return deps.BeadsTooOld, "1.0.3"
+	})
+
+	err := CheckBeadsVersion()
+	if err == nil {
+		t.Fatal("CheckBeadsVersion returned nil for a too-old bd version")
+	}
+	if isUnsupportedNewBeadsVersion(err) {
+		t.Fatalf("too-old error should remain warning-only, got unsupported-new marker: %v", err)
+	}
+}
+
+func TestPersistentPreRunFailsForBdAboveSupportedMaximum(t *testing.T) {
+	resetBeadsVersionCheckForTest(t, func() (deps.BeadsStatus, string) {
+		return deps.BeadsTooNew, "1.0.5"
+	})
+
+	for _, use := range []string{"ready", "version", "prime"} {
+		t.Run(use, func(t *testing.T) {
+			err := persistentPreRun(&cobra.Command{Use: use}, nil)
+			if err == nil {
+				t.Fatal("persistentPreRun returned nil for a too-new bd version")
+			}
+			if !isUnsupportedNewBeadsVersion(err) {
+				t.Fatalf("persistentPreRun returned non-fatal beads error marker: %v", err)
+			}
+		})
+	}
+}
+
+func TestPersistentPreRunSkipsBdVersionCheckForHotPathCommands(t *testing.T) {
+	called := false
+	resetBeadsVersionCheckForTest(t, func() (deps.BeadsStatus, string) {
+		called = true
+		return deps.BeadsTooNew, "1.0.5"
+	})
+
+	if err := persistentPreRun(&cobra.Command{Use: "status-line"}, nil); err != nil {
+		t.Fatalf("persistentPreRun(status-line): %v", err)
+	}
+	if called {
+		t.Fatal("status-line should not run bd version checks")
+	}
+}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -79,6 +79,17 @@ var beadsExemptCommands = map[string]bool{
 	"heartbeat":     true, // Heartbeat state update — must be fast and dependency-free
 }
 
+// Commands exempt even from the too-new bd hard guard. These paths are either
+// high-frequency UI hooks or emergency controls that must avoid subprocess work.
+var beadsTooNewExemptCommands = map[string]bool{
+	"status-line": true,
+	"signal":      true,
+	"metrics":     true,
+	"estop":       true,
+	"thaw":        true,
+	"heartbeat":   true,
+}
+
 // Commands exempt from the town root branch warning.
 // These are commands that help fix the problem or are diagnostic.
 var branchCheckExemptCommands = map[string]bool{
@@ -147,15 +158,23 @@ func persistentPreRun(cmd *cobra.Command, args []string) error {
 	// determine liveness without PID signal probing.
 	touchPolecatHeartbeat()
 
-	// Skip beads check for exempt commands
+	var beadsVersionErr error
+	if !isCommandOrAncestorExempt(cmd, beadsTooNewExemptCommands) {
+		beadsVersionErr = CheckBeadsVersion()
+		if isUnsupportedNewBeadsVersion(beadsVersionErr) {
+			return beadsVersionErr
+		}
+	}
+
+	// Skip warning-only beads checks for exempt commands.
 	if beadsExempt || isRoleCommand(cmd) {
 		return nil
 	}
 
-	// Check beads version (non-blocking - warn only)
-	if err := CheckBeadsVersion(); err != nil {
+	// Check beads version (missing/old/unknown is non-blocking - warn only)
+	if beadsVersionErr != nil {
 		fmt.Fprintf(os.Stderr, "\n%s beads (bd) version issue:\n", style.Bold.Render("⚠️  WARNING:"))
-		fmt.Fprintf(os.Stderr, "   %v\n", err)
+		fmt.Fprintf(os.Stderr, "   %v\n", beadsVersionErr)
 		fmt.Fprintf(os.Stderr, "   Run %s for details.\n\n", style.Dim.Render("gt doctor"))
 	}
 	return nil

--- a/internal/deps/beads.go
+++ b/internal/deps/beads.go
@@ -18,9 +18,14 @@ import (
 // Update this when Gas Town requires new beads features.
 const MinBeadsVersion = "1.0.4"
 
+// MaxBeadsVersion is the newest beads version this Gas Town release is known
+// to support. Newer bd releases can change the Dolt schema before Gastown has
+// been updated for it, so fail fast instead of surfacing late SQL errors.
+const MaxBeadsVersion = "1.0.4"
+
 // BeadsInstallPath is the go install path for the bd version compatible with
 // this Gas Town release.
-const BeadsInstallPath = "github.com/steveyegge/beads/cmd/bd@v1.0.4"
+const BeadsInstallPath = "github.com/steveyegge/beads/cmd/bd@v" + MaxBeadsVersion
 
 // BeadsStatus represents the state of the beads installation.
 type BeadsStatus int
@@ -29,6 +34,7 @@ const (
 	BeadsOK       BeadsStatus = iota // bd found, version compatible
 	BeadsNotFound                    // bd not in PATH
 	BeadsTooOld                      // bd found but version too old
+	BeadsTooNew                      // bd found but version is newer than supported
 	BeadsUnknown                     // bd found but couldn't parse version
 )
 
@@ -59,12 +65,18 @@ func CheckBeads() (BeadsStatus, string) {
 		return BeadsUnknown, ""
 	}
 
-	// Compare versions
-	if CompareVersions(version, MinBeadsVersion) < 0 {
-		return BeadsTooOld, version
-	}
+	return CheckBeadsVersionString(version), version
+}
 
-	return BeadsOK, version
+// CheckBeadsVersionString classifies a parsed bd version for compatibility.
+func CheckBeadsVersionString(version string) BeadsStatus {
+	if CompareVersions(version, MinBeadsVersion) < 0 {
+		return BeadsTooOld
+	}
+	if CompareVersions(version, MaxBeadsVersion) > 0 {
+		return BeadsTooNew
+	}
+	return BeadsOK
 }
 
 // EnsureBeads checks for bd and installs it if missing or outdated.
@@ -86,6 +98,10 @@ func EnsureBeads(autoInstall bool) error {
 	case BeadsTooOld:
 		return fmt.Errorf("beads version %s is too old (minimum: %s)\n\nUpgrade with: go install %s",
 			version, MinBeadsVersion, BeadsInstallPath)
+
+	case BeadsTooNew:
+		return fmt.Errorf("beads version %s is newer than this Gas Town release supports (maximum: %s)\n\nDowngrade with: go install %s",
+			version, MaxBeadsVersion, BeadsInstallPath)
 
 	case BeadsUnknown:
 		// Found bd but couldn't determine version - proceed with warning
@@ -116,6 +132,9 @@ func installBeads() error {
 	}
 	if status == BeadsTooOld {
 		return fmt.Errorf("installed beads %s but minimum required is %s", version, MinBeadsVersion)
+	}
+	if status == BeadsTooNew {
+		return fmt.Errorf("installed beads %s but maximum supported is %s", version, MaxBeadsVersion)
 	}
 
 	fmt.Printf("   ✓ Installed beads %s\n", version)

--- a/internal/deps/beads_test.go
+++ b/internal/deps/beads_test.go
@@ -44,6 +44,48 @@ func TestCompareVersions(t *testing.T) {
 	}
 }
 
+func TestCheckBeadsVersionString(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    BeadsStatus
+	}{
+		{
+			name:    "below minimum is too old",
+			version: "1.0.3",
+			want:    BeadsTooOld,
+		},
+		{
+			name:    "minimum is accepted",
+			version: MinBeadsVersion,
+			want:    BeadsOK,
+		},
+		{
+			name:    "maximum is accepted",
+			version: MaxBeadsVersion,
+			want:    BeadsOK,
+		},
+		{
+			name:    "above maximum is too new",
+			version: "1.0.5",
+			want:    BeadsTooNew,
+		},
+		{
+			name:    "future minor is too new",
+			version: "1.1.0",
+			want:    BeadsTooNew,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CheckBeadsVersionString(tt.version); got != tt.want {
+				t.Fatalf("CheckBeadsVersionString(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCheckBeads(t *testing.T) {
 	// This test depends on whether bd is installed in the test environment
 	status, version := CheckBeads()


### PR DESCRIPTION
## Summary
- add an upper compatibility bound for bd at v1.0.4 on the release branch
- hard-fail normal gt startup when bd is newer than the supported schema version
- preserve hot-path/emergency exemptions so status-line, signal, estop, thaw, metrics, and heartbeat avoid bd subprocess work
- add focused tests for version classification, hard-fail behavior, and hot-path exemption

## Validation
- go test ./internal/deps ./internal/cmd -run 'Test(ParseBeadsVersion|CompareVersions|CheckBeadsVersionString|CheckBeadsVersion|PersistentPreRun)' -count=1\n- go test ./internal/cmd -run '^$'\n- git diff --check