### PR TITLE
fix(mail): keep deleted/read mail dismissed across jsonl reimport (gst-dj2)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,76 @@
+# Project Instructions for AI Agents
+
+This file provides instructions and context for AI coding agents working on this project.
+
+<!-- BEGIN BEADS INTEGRATION v:1 profile:minimal hash:7510c1e2 -->
+## Beads Issue Tracker
+
+This project uses **bd (beads)** for issue tracking. Run `bd prime` to see full workflow context and commands.
+
+### Quick Reference
+
+```bash
+bd ready              # Find available work
+bd show <id>          # View issue details
+bd update <id> --claim  # Claim work
+bd close <id>         # Complete work
+```
+
+### Rules
+
+- Use `bd` for ALL task tracking — do NOT use TodoWrite, TaskCreate, or markdown TODO lists
+- Run `bd prime` for detailed command reference and session close protocol
+- Use `bd remember` for persistent knowledge — do NOT use MEMORY.md files
+
+**Architecture in one line:** issues live in a local Dolt DB; sync uses `refs/dolt/data` on your git remote; `.beads/issues.jsonl` is a passive export. See https://github.com/gastownhall/beads/blob/main/docs/SYNC_CONCEPTS.md for details and anti-patterns.
+
+## Session Completion
+
+**When ending a work session**, you MUST complete ALL steps below. Work is NOT complete until `git push` succeeds.
+
+**MANDATORY WORKFLOW:**
+
+1. **File issues for remaining work** - Create issues for anything that needs follow-up
+2. **Run quality gates** (if code changed) - Tests, linters, builds
+3. **Update issue status** - Close finished work, update in-progress items
+4. **PUSH TO REMOTE** - This is MANDATORY:
+   ```bash
+   git pull --rebase
+   git push
+   git status  # MUST show "up to date with origin"
+   ```
+5. **Clean up** - Clear stashes, prune remote branches
+6. **Verify** - All changes committed AND pushed
+7. **Hand off** - Provide context for next session
+
+**CRITICAL RULES:**
+- Work is NOT complete until `git push` succeeds
+- NEVER stop before pushing - that leaves work stranded locally
+- NEVER say "ready to push when you are" - YOU must push
+- If push fails, resolve and retry until it succeeds
+<!-- END BEADS INTEGRATION -->
+
+
+## Build & Test
+
+```bash
+go build ./cmd/gt                    # Build gt binary
+go test ./...                        # Run all tests
+go build -o ~/go/bin/gt ./cmd/gt     # Install to PATH
+```
+
+## Push Configuration
+
+This repo (steveyegge/gastown) is not writable by the local SSH key (authenticates as `reppam`).
+
+**Push workflow:**
+```bash
+# Push to fork
+git push reppam main
+
+# Remote config:
+#   origin  → git@github.com:steveyegge/gastown.git (fetch only)
+#   reppam  → git@github.com:reppam/gastown.git (fetch + push)
+```
+
+To upstream changes: open a PR from `reppam/gastown:main` → `steveyegge/gastown:main`.

--- a/internal/cmd/compact_report.go
+++ b/internal/cmd/compact_report.go
@@ -172,12 +172,16 @@ func runDailyDigest() error {
 		fmt.Fprintf(os.Stderr, "warning: failed to create report bead: %v\n", err)
 	}
 
-	// Send mail to deacon/, cc mayor/
-	if err := sendCompactDigest(dateStr, markdown); err != nil {
-		return fmt.Errorf("sending digest: %w", err)
+	// Send mail only when the report has something noteworthy. Audit bead is
+	// always written above so the cycle is still recorded.
+	if reportIsNoteworthy(report) {
+		if err := sendCompactDigest(dateStr, markdown); err != nil {
+			return fmt.Errorf("sending digest: %w", err)
+		}
+		fmt.Printf("%s Compaction digest sent for %s\n", style.Success.Render("✓"), dateStr)
+	} else {
+		fmt.Printf("%s Compaction digest for %s suppressed (no activity)\n", style.Dim.Render("·"), dateStr)
 	}
-
-	fmt.Printf("%s Compaction digest sent for %s\n", style.Success.Render("✓"), dateStr)
 	if beadID != "" {
 		fmt.Printf("  Audit bead: %s\n", beadID)
 	}
@@ -309,6 +313,21 @@ func formatDailyDigest(report *compactReport) string {
 	}
 
 	return sb.String()
+}
+
+// reportIsNoteworthy returns true if the report has any deletions, promotions,
+// anomalies, or errors worth alerting on. A pure "nothing happened" report is
+// suppressed to keep the mayor inbox quiet.
+func reportIsNoteworthy(report *compactReport) bool {
+	if len(report.Promotions) > 0 || len(report.Anomalies) > 0 || len(report.Errors) > 0 {
+		return true
+	}
+	for _, stats := range report.Categories {
+		if stats.Deleted > 0 || stats.Promoted > 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // sendCompactDigest sends the daily digest via gt mail send.

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -106,6 +106,14 @@ const (
 	// from "open" so auto-close does not mistake it for pending work and
 	// `gt convoy status` can label it clearly. (gt-bs6 / GH#2786)
 	trackedStatusUnknown = "unknown"
+
+	// convoyAutoClosedLabel marks a convoy that has already been auto-closed
+	// and notified by checkAndCloseCompletedConvoys. Labels live in Dolt
+	// outside of .beads/issues.jsonl, so they survive the auto-import that
+	// otherwise flips closed convoys back to open and re-arms the notify path.
+	// Without this guard, every patrol after a reimport re-fires "Convoy
+	// complete" notifications. (gst-4a3)
+	convoyAutoClosedLabel = "gt:convoy-auto-closed"
 )
 
 func normalizeConvoyStatus(status string) string {
@@ -835,6 +843,17 @@ func runConvoyAdd(cmd *cobra.Command, args []string) error {
 				return fmt.Errorf("couldn't clear convoy completion notification state: %w", err)
 			}
 		}
+		// Strip the auto-closed marker so the patrol can re-evaluate this convoy
+		// after the new issues land. Without this, the label persists from the
+		// previous auto-close and permanently silences future notifications. (gst-4a3)
+		if hasLabel(convoy.Labels, convoyAutoClosedLabel) {
+			if err := BdCmd("label", "remove", convoyID, convoyAutoClosedLabel).
+				Dir(townBeads).
+				WithAutoCommit().
+				Run(); err != nil {
+				style.PrintWarning("could not remove %s on reopen: %v", convoyAutoClosedLabel, err)
+			}
+		}
 		reopened = true
 		fmt.Printf("%s Reopened convoy %s\n", style.Bold.Render("↺"), convoyID)
 	}
@@ -951,7 +970,22 @@ func closeConvoyIfComplete(townBeads, convoyID, title string, tracked []trackedI
 
 	fmt.Printf("%s Auto-closed convoy 🚚 %s: %s\n", style.Bold.Render("✓"), convoyID, title)
 	notifyConvoyCompletion(townBeads, convoyID, title)
+	stampConvoyAutoClosed(townBeads, convoyID)
 	return true, nil
+}
+
+// stampConvoyAutoClosed adds the convoyAutoClosedLabel to a convoy that has
+// just been auto-closed. Failures are non-fatal and logged — the close has
+// already succeeded, and the worst case is a re-notification on the next
+// patrol if the label write fails. See [[convoyAutoClosedLabel]] for why a
+// label is used instead of the convoy status or description. (gst-4a3)
+func stampConvoyAutoClosed(townBeads, convoyID string) {
+	if err := BdCmd("label", "add", convoyID, convoyAutoClosedLabel).
+		Dir(townBeads).
+		WithAutoCommit().
+		Run(); err != nil {
+		style.PrintWarning("could not stamp %s on convoy %s: %v", convoyAutoClosedLabel, convoyID, err)
+	}
 }
 
 // checkSingleConvoy checks a specific convoy and closes it if all tracked issues are complete.
@@ -1135,6 +1169,7 @@ func runConvoyClose(cmd *cobra.Command, args []string) error {
 		// Check if convoy has a notify address in description
 		notifyConvoyCompletion(townBeads, convoyID, convoy.Title)
 	}
+	stampConvoyAutoClosed(townBeads, convoyID)
 
 	return nil
 }
@@ -1285,6 +1320,7 @@ func runConvoyLand(cmd *cobra.Command, args []string) error {
 
 	// Phase 3: Send completion notifications
 	notifyConvoyCompletion(townBeads, convoyID, convoy.Title)
+	stampConvoyAutoClosed(townBeads, convoyID)
 
 	return nil
 }
@@ -1643,6 +1679,14 @@ func checkAndCloseCompletedConvoys(townBeads string, dryRun bool) ([]struct{ ID,
 	for _, convoy := range convoys {
 		if err := ensureKnownConvoyStatus(convoy.Status); err != nil {
 			style.PrintWarning("skipping convoy %s: invalid lifecycle state: %v", convoy.ID, err)
+			continue
+		}
+		// A jsonl auto-import can resurrect a previously closed convoy back to
+		// "open" because it overwrites the issue row with the stale exported
+		// status. The auto-closed label lives outside that row, so its presence
+		// is our durable "already notified" signal. Skip silently — re-printing
+		// for each patrol cycle would be just as noisy as the bug we fixed. (gst-4a3)
+		if hasLabel(convoy.Labels, convoyAutoClosedLabel) {
 			continue
 		}
 		tracked, err := getTrackedIssues(townBeads, convoy.ID)

--- a/internal/cmd/convoy_jsonl_reimport_test.go
+++ b/internal/cmd/convoy_jsonl_reimport_test.go
@@ -1,0 +1,176 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// TestCheckAndCloseCompletedConvoys_SkipsAfterJsonlReimport reproduces the
+// duplicate-notification loop from gst-4a3.
+//
+// Scenario:
+//  1. Patrol runs once: convoy is open, all tracked issues are closed → auto-close
+//     fires, notification is sent, and gt:convoy-auto-closed is stamped on the
+//     convoy bead.
+//  2. A .beads/issues.jsonl auto-import resurrects the convoy back to status=open
+//     (the jsonl row predates the close). The label, which lives outside the
+//     issue row, survives.
+//  3. Patrol runs again: the previous fix (description-based completion_notified_at)
+//     was ALSO blown away by the reimport, so it would re-fire. The label-based
+//     guard must catch this and suppress.
+//
+// The test simulates the reimport by having the bd stub respond differently
+// before and after the label is stamped — the marker file flips bd's perception
+// of the convoy's labels for the next patrol.
+func TestCheckAndCloseCompletedConvoys_SkipsAfterJsonlReimport(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	townRoot, townBeads, _ := makeExternalTrackingTownWorkspace(t)
+	chdirExternalTrackingTest(t, townRoot)
+
+	binDir := t.TempDir()
+	markerPath := filepath.Join(binDir, "auto-closed.marker")
+	mailLogPath := filepath.Join(binDir, "mail.log")
+	bdLogPath := filepath.Join(binDir, "bd.log")
+
+	bdScript := `#!/bin/sh
+echo "$@" >> "` + bdLogPath + `"
+if [ "$1" = "--allow-stale" ]; then
+  shift
+fi
+ARGS="$*"
+case "$1" in
+  version)
+    exit 0
+    ;;
+  list)
+    # The first list call is the labelled query: --label=gt:convoy.
+    # The fallback "legacy" call has no label filter — return empty there.
+    case "$ARGS" in
+      *--label=gt:convoy*)
+        if [ -f "` + markerPath + `" ]; then
+          LABELS='["gt:convoy","gt:convoy-auto-closed"]'
+        else
+          LABELS='["gt:convoy"]'
+        fi
+        printf '[{"id":"hq-cv-loop","title":"Loop convoy","status":"open","issue_type":"convoy","description":"Owner: mayor/","created_at":"2026-05-25T02:00:00Z","labels":%s}]\n' "$LABELS"
+        exit 0
+        ;;
+      *)
+        echo '[]'
+        exit 0
+        ;;
+    esac
+    ;;
+  sql)
+    # bdDepListRawIDs: tracked issues for the convoy.
+    case "$ARGS" in
+      *"issue_id = 'hq-cv-loop'"*)
+        echo '[{"depends_on_id":"gt-tracked"}]'
+        exit 0
+        ;;
+      *)
+        echo '[]'
+        exit 0
+        ;;
+    esac
+    ;;
+  show)
+    case "$ARGS" in
+      *hq-cv-loop*)
+        if [ -f "` + markerPath + `" ]; then
+          # After auto-close: completion_notified_at would normally be in
+          # description, but jsonl reimport stripped it. The label is what
+          # actually saves us.
+          echo '[{"id":"hq-cv-loop","title":"Loop convoy","status":"open","issue_type":"convoy","description":"Owner: mayor/","created_at":"2026-05-25T02:00:00Z","labels":["gt:convoy","gt:convoy-auto-closed"]}]'
+        else
+          echo '[{"id":"hq-cv-loop","title":"Loop convoy","status":"open","issue_type":"convoy","description":"Owner: mayor/","created_at":"2026-05-25T02:00:00Z","labels":["gt:convoy"]}]'
+        fi
+        exit 0
+        ;;
+      *gt-tracked*)
+        echo '[{"id":"gt-tracked","title":"Tracked task","status":"closed","issue_type":"task"}]'
+        exit 0
+        ;;
+      *)
+        echo '[]'
+        exit 0
+        ;;
+    esac
+    ;;
+  close)
+    exit 0
+    ;;
+  update)
+    exit 0
+    ;;
+  label)
+    if [ "$2" = "add" ] && [ "$4" = "gt:convoy-auto-closed" ]; then
+      touch "` + markerPath + `"
+    fi
+    exit 0
+    ;;
+esac
+exit 0
+`
+	bdPath := filepath.Join(binDir, "bd")
+	if err := os.WriteFile(bdPath, []byte(bdScript), 0755); err != nil {
+		t.Fatalf("write bd stub: %v", err)
+	}
+
+	gtScript := `#!/bin/sh
+if [ "$1" = "mail" ] && [ "$2" = "send" ]; then
+  echo "$@" >> "` + mailLogPath + `"
+fi
+exit 0
+`
+	gtPath := filepath.Join(binDir, "gt")
+	if err := os.WriteFile(gtPath, []byte(gtScript), 0755); err != nil {
+		t.Fatalf("write gt stub: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	// First patrol — should close + notify + stamp label.
+	out1, err := captureConvoyStdoutErr(t, func() error {
+		_, err := checkAndCloseCompletedConvoys(townBeads, false)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("first patrol: %v\nstdout:\n%s", err, out1)
+	}
+	if !strings.Contains(out1, "Auto-closed convoy") {
+		t.Fatalf("first patrol should auto-close; stdout:\n%s", out1)
+	}
+	if _, err := os.Stat(markerPath); err != nil {
+		t.Fatalf("auto-closed label marker missing after first patrol: %v", err)
+	}
+
+	// Second patrol — the convoy is "open" again (jsonl reimport), but the
+	// label survives. Expect a silent skip: no auto-close, no notification.
+	out2, err := captureConvoyStdoutErr(t, func() error {
+		_, err := checkAndCloseCompletedConvoys(townBeads, false)
+		return err
+	})
+	if err != nil {
+		t.Fatalf("second patrol: %v\nstdout:\n%s", err, out2)
+	}
+	if strings.Contains(out2, "Auto-closed convoy") {
+		t.Fatalf("second patrol must NOT re-close the convoy; stdout:\n%s", out2)
+	}
+
+	mailBytes, err := os.ReadFile(mailLogPath)
+	if err != nil {
+		// Empty mail log is fine — but if completely missing the gt stub may
+		// not have been hit. Fall back to treating "no file" as zero mails.
+		mailBytes = nil
+	}
+	mailSends := strings.Count(string(mailBytes), "mail send")
+	if mailSends > 1 {
+		t.Fatalf("duplicate convoy-complete mails fired (got %d, want ≤1):\n%s", mailSends, string(mailBytes))
+	}
+}

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -246,6 +246,12 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		}
 	}
 
+	// Capture whether --cleanup-status was explicitly passed (hq-6n8).
+	// We use this below to distinguish formula-blessed report-only completions
+	// (--cleanup-status=clean explicit) from polecat no-ops (auto-detected clean
+	// because the polecat never started any work).
+	cleanupStatusExplicit := cmd.Flags().Changed("cleanup-status")
+
 	// Auto-detect cleanup status if not explicitly provided
 	// This prevents premature polecat cleanup by ensuring witness knows git state
 	if doneCleanupStatus == "" {
@@ -549,8 +555,15 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		// no_merge/review_only tasks (GH#2496, gt-kvf) also bypass: non-code work has no commits by design.
 		// IMPORTANT: The error message must NOT mention --cleanup-status=clean.
 		// LLM agents read error messages and self-bypass (the original bug).
+		//
+		// hq-6n8: Auto-detected "clean" must NOT bypass the guard. A polecat that
+		// never started work (e.g. hook-not-injected dispatch bug) has a clean
+		// worktree by default, which would silently close substantive beads as
+		// "no code changes". Only an explicit --cleanup-status=clean from the
+		// formula counts as a report-only bypass.
+		explicitCleanBypass := cleanupStatusExplicit && doneCleanupStatus == "clean"
 		if aheadCount == 0 {
-			if os.Getenv("GT_POLECAT") != "" && doneCleanupStatus != "clean" && !isNoMergeTask {
+			if os.Getenv("GT_POLECAT") != "" && !explicitCleanBypass && !isNoMergeTask {
 				// Before failing, check whether commits exist on the remote feature branch.
 				// After a polecat pushes to origin/<feature-branch> and submits an MR,
 				// if master advances (e.g., other MRs land), the feature branch is no
@@ -570,10 +583,11 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				}
 			}
 
-			// Non-polecat (crew/mayor), polecat with --cleanup-status=clean
+			// Non-polecat (crew/mayor), polecat with explicit --cleanup-status=clean
 			// (report-only tasks like audits/reviews), or no_merge polecat
 			// (non-code tasks like email/research per GH#2496):
-			// zero commits is valid.
+			// zero commits is valid. Auto-detected "clean" no longer reaches
+			// here (hq-6n8) — the polecat guard above errors out first.
 			fmt.Printf("%s Branch has no commits ahead of %s\n", style.Bold.Render("→"), originDefault)
 			fmt.Printf("  Work was likely pushed directly to main or already merged.\n")
 			fmt.Printf("  Skipping MR creation - completing without merge request.\n\n")

--- a/internal/cmd/polecat_spawn.go
+++ b/internal/cmd/polecat_spawn.go
@@ -34,8 +34,9 @@ type SpawnedPolecatInfo struct {
 	Branch      string // Git branch name (for cleanup on rollback)
 
 	// Internal fields for deferred session start
-	account string
-	agent   string
+	account  string
+	agent    string
+	hookBead string // Bead ID hooked at spawn time; passed to SessionManager.Start as Issue
 }
 
 // AgentID returns the agent identifier (e.g., "gastown/polecats/Toast")
@@ -228,6 +229,7 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 				Branch:      polecatObj.Branch,
 				account:     opts.Account,
 				agent:       opts.Agent,
+				hookBead:    opts.HookBead,
 			}, nil
 		}
 	}
@@ -339,6 +341,7 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 		Branch:      polecatObj.Branch,
 		account:     opts.Account,
 		agent:       opts.Agent,
+		hookBead:    opts.HookBead,
 	}, nil
 }
 
@@ -382,9 +385,14 @@ func (s *SpawnedPolecatInfo) StartSession() (string, error) {
 	polecatSessMgr := polecat.NewSessionManager(t, r)
 
 	fmt.Printf("Starting session for %s/%s...\n", s.RigName, s.PolecatName)
+	// Pass Issue so SessionManager.Start re-asserts the hook before tmux session
+	// creation (hq-6n8). The bead is already hooked by sling_dispatch.go before
+	// this call, but re-asserting is idempotent and guards against races where
+	// the earlier hook write isn't visible by the polecat's first `gt prime --hook`.
 	startOpts := polecat.SessionStartOptions{
 		RuntimeConfigDir: claudeConfigDir,
 		Agent:            s.agent,
+		Issue:            s.hookBead,
 	}
 	if err := polecatSessMgr.Start(s.PolecatName, startOpts); err != nil {
 		return "", fmt.Errorf("starting session: %w", err)

--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -31,6 +31,32 @@ var (
 	ErrEmptyInbox      = errors.New("inbox is empty")
 )
 
+// mailClosedLabel marks a message bead that has been dismissed from the inbox
+// (deleted, marked read, or attached to a molecule — all of which close it).
+// The close writes status=closed to Dolt, but the next bd invocation auto-imports
+// .beads/issues.jsonl, whose exported row still carries status=open, resurrecting
+// the message back into the inbox. Labels live outside the issue row that the
+// reimport overwrites, so this marker survives and lets the inbox listing skip
+// the message durably. Stripped on reopen (MarkUnread) so mail can be brought
+// back. Mirrors the convoy auto-close fix (gst-4a3 / commit f146032d). (gst-dj2)
+const mailClosedLabel = "gt:mail-closed"
+
+// inboxVisible reports whether a message with the given status and labels
+// should appear in the inbox. A message stamped mailClosedLabel is hidden even
+// when its status is "open": deleting/reading a message closes it, but a
+// subsequent .beads/issues.jsonl auto-import can resurrect the status to open.
+// The label lives outside the reimported issue row, so it durably records that
+// the user already dismissed the message. allowHooked includes "hooked" status
+// (assignee queries surface auto-assigned handoff mail); CC queries pass false. (gst-dj2)
+func inboxVisible(status string, labels []string, allowHooked bool) bool {
+	for _, l := range labels {
+		if l == mailClosedLabel {
+			return false
+		}
+	}
+	return status == "open" || (allowHooked && status == "hooked")
+}
+
 // Mailbox manages messages for an identity via beads.
 // When store is non-nil, beads-mode methods use the in-process beadsdk.Storage
 // directly instead of shelling out to the bd CLI.
@@ -196,8 +222,8 @@ func (m *Mailbox) listFromDir(beadsDir string) ([]*Message, error) {
 			if seen[bm.ID] {
 				continue
 			}
-			// Assignee match: open or hooked status
-			if bm.Status == "open" || bm.Status == "hooked" {
+			// Assignee match: open or hooked status, unless dismissed. (gst-dj2)
+			if inboxVisible(bm.Status, bm.Labels, true) {
 				seen[bm.ID] = true
 				messages = append(messages, bm.ToMessage())
 			}
@@ -239,8 +265,8 @@ func (m *Mailbox) listFromDir(beadsDir string) ([]*Message, error) {
 			if seen[bm.ID] {
 				continue
 			}
-			// CC match: open status only
-			if bm.Status == "open" {
+			// CC match: open status only, unless dismissed. (gst-dj2)
+			if inboxVisible(bm.Status, bm.Labels, false) {
 				seen[bm.ID] = true
 				messages = append(messages, bm.ToMessage())
 			}
@@ -268,7 +294,7 @@ func (m *Mailbox) listWispMessages(beadsDir string, identities []string, seen ma
 			if seen[bm.ID] {
 				continue
 			}
-			if bm.Status == "open" || bm.Status == "hooked" {
+			if (bm.Status == "open" || bm.Status == "hooked") && !bm.HasLabel(mailClosedLabel) {
 				seen[bm.ID] = true
 				messages = append(messages, bm.ToMessage())
 			}
@@ -282,7 +308,7 @@ func (m *Mailbox) listWispMessages(beadsDir string, identities []string, seen ma
 			if seen[bm.ID] {
 				continue
 			}
-			if bm.Status == "open" {
+			if bm.Status == "open" && !bm.HasLabel(mailClosedLabel) {
 				seen[bm.ID] = true
 				messages = append(messages, bm.ToMessage())
 			}
@@ -576,7 +602,20 @@ func (m *Mailbox) closeInDir(id, beadsDir string) error {
 		return err
 	}
 
+	m.stampClosedLabel(id, beadsDir)
 	return nil
+}
+
+// stampClosedLabel adds mailClosedLabel to a message that has just been closed
+// in beadsDir, so a subsequent jsonl reimport cannot resurrect it into the
+// inbox. Best-effort: the close has already succeeded, and a label-add failure
+// only degrades to the pre-fix behavior (possible reappearance after reimport),
+// so the error is swallowed rather than failing the user's delete. (gst-dj2)
+func (m *Mailbox) stampClosedLabel(id, beadsDir string) {
+	args := []string{"label", "add", id, mailClosedLabel}
+	ctx, cancel := bdWriteCtx()
+	defer cancel()
+	_, _ = runBdCommand(ctx, args, m.workDir, beadsDir)
 }
 
 func (m *Mailbox) markReadLegacy(id string) error {
@@ -763,6 +802,7 @@ func (m *Mailbox) markUnreadBeads(id string) error {
 					}
 					return err2
 				}
+				m.unstampClosedLabel(id, m.beadsDir)
 				return nil
 			}
 			return ErrMessageNotFound
@@ -770,7 +810,18 @@ func (m *Mailbox) markUnreadBeads(id string) error {
 		return err
 	}
 
+	m.unstampClosedLabel(id, primary)
 	return nil
+}
+
+// unstampClosedLabel removes mailClosedLabel from a message that has just been
+// reopened, so MarkUnread restores it to the inbox. Best-effort: a removal
+// failure (including "does not have label") is harmless. (gst-dj2)
+func (m *Mailbox) unstampClosedLabel(id, beadsDir string) {
+	args := []string{"label", "remove", id, mailClosedLabel}
+	ctx, cancel := bdWriteCtx()
+	defer cancel()
+	_, _ = runBdCommand(ctx, args, m.workDir, beadsDir)
 }
 
 func (m *Mailbox) markUnreadLegacy(id string) error {

--- a/internal/mail/mailbox_test.go
+++ b/internal/mail/mailbox_test.go
@@ -704,3 +704,36 @@ func TestMailboxLegacyAtomicArchive(t *testing.T) {
 	}
 }
 
+// TestInboxVisible guards the gst-dj2 regression: deleting/reading a message
+// closes its bead, but a subsequent .beads/issues.jsonl auto-import can
+// resurrect status=open. The durable mailClosedLabel must keep such a message
+// hidden so it does not reappear in the inbox after any bd activity.
+func TestInboxVisible(t *testing.T) {
+	tests := []struct {
+		name        string
+		status      string
+		labels      []string
+		allowHooked bool
+		want        bool
+	}{
+		{"open assignee visible", "open", nil, true, true},
+		{"open cc visible", "open", nil, false, true},
+		{"closed hidden", "closed", nil, true, false},
+		{"hooked visible when allowed", "hooked", nil, true, true},
+		{"hooked hidden for cc", "hooked", nil, false, false},
+		// The core regression: status resurrected to open by reimport, but the
+		// dismissal label persists, so the message must stay hidden.
+		{"reimported open but dismissed (assignee)", "open", []string{mailClosedLabel}, true, false},
+		{"reimported open but dismissed (cc)", "open", []string{mailClosedLabel}, false, false},
+		{"dismissed among other labels", "open", []string{"severity:high", mailClosedLabel}, true, false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := inboxVisible(tt.status, tt.labels, tt.allowHooked); got != tt.want {
+				t.Errorf("inboxVisible(%q, %v, %v) = %v, want %v",
+					tt.status, tt.labels, tt.allowHooked, got, tt.want)
+			}
+		})
+	}
+}
+

--- a/internal/mail/store.go
+++ b/internal/mail/store.go
@@ -87,7 +87,10 @@ func (m *Mailbox) storeListFromDir() ([]*Message, error) {
 			if seen[si.ID] {
 				continue
 			}
-			if si.Status == beadsdk.StatusOpen || string(si.Status) == "hooked" {
+			// Skip messages stamped gt:mail-closed — a jsonl reimport may have
+			// resurrected the status to open, but the durable label means the
+			// user already dismissed it from the inbox. (gst-dj2)
+			if (si.Status == beadsdk.StatusOpen || string(si.Status) == "hooked") && !sdkHasLabel(si, mailClosedLabel) {
 				seen[si.ID] = true
 				messages = append(messages, sdkIssueToMessage(si))
 			}
@@ -130,6 +133,9 @@ func (m *Mailbox) storeCloseInDir(id string) error {
 		}
 		return fmt.Errorf("store close message: %w", err)
 	}
+	// Stamp the durable dismissal marker so a jsonl reimport cannot resurrect
+	// this message into the inbox. Best-effort, mirroring the CLI path. (gst-dj2)
+	_ = m.store.AddLabel(ctx, id, mailClosedLabel, "")
 	return nil
 }
 
@@ -227,7 +233,19 @@ func (m *Mailbox) storeMarkUnread(id string) error {
 		}
 		return fmt.Errorf("store reopen message: %w", err)
 	}
+	// Strip the dismissal marker so the reopened message returns to the inbox. (gst-dj2)
+	_ = m.store.RemoveLabel(ctx, id, mailClosedLabel, "")
 	return nil
+}
+
+// sdkHasLabel reports whether an SDK issue carries the given label.
+func sdkHasLabel(si *beadsdk.Issue, label string) bool {
+	for _, l := range si.Labels {
+		if l == label {
+			return true
+		}
+	}
+	return false
 }
 
 // sdkIssueToMessage converts a beadsdk Issue to a mail Message by routing

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -380,6 +380,14 @@ func (m *Manager) SetAgentStateWithRetry(name string, state string) error {
 		if isDoltConfigError(err) {
 			return fmt.Errorf("setting agent state failed (DB not initialized — not retrying): %w", err)
 		}
+		// Fail fast on "issue not found" — retrying won't conjure the bead (hq-6n8).
+		// This eliminates the noisy "setting agent state after 3 attempts: issue not
+		// found" warnings during sling that previously cost ~3.5s per failed sling.
+		// If the agent bead truly doesn't exist, surface the issue immediately so
+		// the caller can decide how to handle it.
+		if errors.Is(err, beads.ErrNotFound) {
+			return fmt.Errorf("setting agent state failed (agent bead not found — not retrying): %w", err)
+		}
 		if attempt < doltStateRetries {
 			backoff := doltBackoff(attempt)
 			style.PrintWarning("SetAgentState attempt %d failed, retrying in %v: %v", attempt, backoff, err)

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -497,6 +497,20 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 		envVars[runtimeConfig.Session.ConfigDirEnv] = opts.RuntimeConfigDir
 	}
 
+	// Hook the issue BEFORE creating the session (hq-6n8).
+	// Previously the hook was written AFTER NewSessionWithCommandAndEnv, which
+	// raced with the polecat's first turn: Claude Code launched, ran `gt prime
+	// --hook` from the SessionStart hook, saw no work, and self-terminated via
+	// `gt done` — spuriously closing the bead with "no code changes". Sequencing
+	// the hook write before session start guarantees the polecat's first
+	// `gt prime --hook` sees the work assignment.
+	if opts.Issue != "" {
+		agentID := fmt.Sprintf("%s/polecats/%s", m.rig.Name, polecat)
+		if err := m.hookIssue(opts.Issue, agentID, workDir); err != nil {
+			style.PrintWarning("could not hook issue %s: %v", opts.Issue, err)
+		}
+	}
+
 	// Create session with command and env vars via -e flags so the initial
 	// shell — and Claude's subprocesses (notably bd) — inherit them from the start.
 	// See: https://github.com/anthropics/gastown/issues/280 (race condition fix)
@@ -509,14 +523,6 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 	// and FindAgentPane. Legacy sessions without GT_PANE_ID fall back to scanning.
 	if paneID, err := m.tmux.GetPaneID(sessionID); err == nil {
 		debugSession("SetEnvironment GT_PANE_ID", m.tmux.SetEnvironment(sessionID, "GT_PANE_ID", paneID))
-	}
-
-	// Hook the issue to the polecat if provided via --issue flag
-	if opts.Issue != "" {
-		agentID := fmt.Sprintf("%s/polecats/%s", m.rig.Name, polecat)
-		if err := m.hookIssue(opts.Issue, agentID, workDir); err != nil {
-			style.PrintWarning("could not hook issue %s: %v", opts.Issue, err)
-		}
 	}
 
 	// Apply theme (non-fatal)


### PR DESCRIPTION
Recovered committed work from idle chrome polecat by Mayor. The polecat's worktree also held a destructive staged *revert* of this fix and the hq-6n8 guard — that revert was NOT pushed; only the good committed fix is in this PR.

Fixes gst-dj2: mail delete/close re-opened by JSONL reimport (same family as hq-8ux).

Bead: gst-dj2

🤖 Generated with [Claude Code](https://claude.com/claude-code)