### PR TITLE
Follow up release beads schema handling with split dependency fixes

### DIFF
--- a/internal/beads/dependency_schema.go
+++ b/internal/beads/dependency_schema.go
@@ -1,0 +1,81 @@
+package beads
+
+import "strings"
+
+const DependencyTargetAlias = "depends_on_id"
+
+var splitDependencyTargetColumns = []string{
+	"depends_on_issue_id",
+	"depends_on_wisp_id",
+	"depends_on_external",
+}
+
+// DependencyTargetExpr returns the SQL expression for a dependency target.
+// When splitTarget is true, bd stores targets in type-specific columns and the
+// caller should treat the first non-null value as the legacy depends_on_id.
+func DependencyTargetExpr(tableAlias string, splitTarget bool) string {
+	if !splitTarget {
+		return qualifyDependencyColumn(tableAlias, DependencyTargetAlias)
+	}
+
+	columns := make([]string, 0, len(splitDependencyTargetColumns))
+	for _, column := range splitDependencyTargetColumns {
+		columns = append(columns, qualifyDependencyColumn(tableAlias, column))
+	}
+	return "COALESCE(" + strings.Join(columns, ", ") + ")"
+}
+
+// DependencyTargetSelectExpr returns a SELECT expression whose result column is
+// named depends_on_id for both legacy and split dependency-target schemas.
+func DependencyTargetSelectExpr(tableAlias string, splitTarget bool) string {
+	expr := DependencyTargetExpr(tableAlias, splitTarget)
+	if !splitTarget {
+		return expr
+	}
+	return expr + " AS " + DependencyTargetAlias
+}
+
+// DependencyTargetMatchExpr returns a WHERE predicate for a quoted SQL value.
+// The quotedValue argument must already be a safe SQL string literal.
+func DependencyTargetMatchExpr(tableAlias, quotedValue string, splitTarget bool) string {
+	if !splitTarget {
+		return DependencyTargetExpr(tableAlias, false) + " = " + quotedValue
+	}
+
+	columns := make([]string, 0, len(splitDependencyTargetColumns))
+	for _, column := range splitDependencyTargetColumns {
+		columns = append(columns, qualifyDependencyColumn(tableAlias, column))
+	}
+	return quotedValue + " IN (" + strings.Join(columns, ", ") + ")"
+}
+
+// IsDependencyTargetColumnError reports whether err came from a dependency
+// target-column schema mismatch between legacy and split bd schemas.
+func IsDependencyTargetColumnError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	missingColumn := strings.Contains(msg, "unknown column") ||
+		strings.Contains(msg, "could not be found") ||
+		strings.Contains(msg, "no such column")
+	if !missingColumn {
+		return false
+	}
+	if strings.Contains(msg, DependencyTargetAlias) {
+		return true
+	}
+	for _, column := range splitDependencyTargetColumns {
+		if strings.Contains(msg, column) {
+			return true
+		}
+	}
+	return false
+}
+
+func qualifyDependencyColumn(tableAlias, column string) string {
+	if tableAlias == "" {
+		return column
+	}
+	return tableAlias + "." + column
+}

--- a/internal/beads/dependency_schema.go
+++ b/internal/beads/dependency_schema.go
@@ -1,13 +1,21 @@
 package beads
 
-import "strings"
+import (
+	"fmt"
+	"strings"
+)
 
-const DependencyTargetAlias = "depends_on_id"
+const (
+	DependencyTargetAlias          = "depends_on_id"
+	DependencyTargetIssueColumn    = "depends_on_issue_id"
+	DependencyTargetWispColumn     = "depends_on_wisp_id"
+	DependencyTargetExternalColumn = "depends_on_external"
+)
 
 var splitDependencyTargetColumns = []string{
-	"depends_on_issue_id",
-	"depends_on_wisp_id",
-	"depends_on_external",
+	DependencyTargetIssueColumn,
+	DependencyTargetWispColumn,
+	DependencyTargetExternalColumn,
 }
 
 // DependencyTargetExpr returns the SQL expression for a dependency target.
@@ -49,6 +57,66 @@ func DependencyTargetMatchExpr(tableAlias, quotedValue string, splitTarget bool)
 	return quotedValue + " IN (" + strings.Join(columns, ", ") + ")"
 }
 
+// DependencyTargetSplitColumns returns the typed target columns used by bd's
+// split dependency-target schema, in INSERT order.
+func DependencyTargetSplitColumns() string {
+	return strings.Join(splitDependencyTargetColumns, ", ")
+}
+
+// DependencyTargetSplitValuesExprs returns SELECT expressions matching
+// DependencyTargetSplitColumns. When the source dependency table is legacy, it
+// classifies the legacy target using the same priority as bd migrations.
+func DependencyTargetSplitValuesExprs(tableAlias string, splitSourceTarget bool) string {
+	if splitSourceTarget {
+		columns := make([]string, 0, len(splitDependencyTargetColumns))
+		for _, column := range splitDependencyTargetColumns {
+			columns = append(columns, qualifyDependencyColumn(tableAlias, column))
+		}
+		return strings.Join(columns, ", ")
+	}
+
+	target := qualifyDependencyColumn(tableAlias, DependencyTargetAlias)
+	externalTarget := target + " LIKE 'external:%'"
+	wispTargetExists := dependencyTargetIsWispExpr(target, "")
+	issueTargetExists := fmt.Sprintf("EXISTS (SELECT 1 FROM issues target_issue WHERE target_issue.id = %s)", target)
+
+	return strings.Join([]string{
+		fmt.Sprintf("CASE WHEN NOT (%s) AND NOT (%s) AND %s THEN %s ELSE NULL END", externalTarget, wispTargetExists, issueTargetExists, target),
+		fmt.Sprintf("CASE WHEN NOT (%s) AND %s THEN %s ELSE NULL END", externalTarget, wispTargetExists, target),
+		fmt.Sprintf("CASE WHEN %s OR (NOT (%s) AND NOT (%s)) THEN %s ELSE NULL END", externalTarget, wispTargetExists, issueTargetExists, target),
+	}, ", ")
+}
+
+// DependencyTargetSplitValuesExprsForWispCopy returns SELECT expressions for
+// copying rows into wisp_dependencies with split target columns. migratingIDs is
+// an optional, already-escaped SQL list without surrounding parentheses.
+func DependencyTargetSplitValuesExprsForWispCopy(tableAlias string, splitSourceTarget bool, migratingIDs string) string {
+	if !splitSourceTarget {
+		target := qualifyDependencyColumn(tableAlias, DependencyTargetAlias)
+		externalTarget := target + " LIKE 'external:%'"
+		wispTargetExists := dependencyTargetIsWispExpr(target, migratingIDs)
+		issueTargetExists := fmt.Sprintf("EXISTS (SELECT 1 FROM issues target_issue WHERE target_issue.id = %s)", target)
+
+		return strings.Join([]string{
+			fmt.Sprintf("CASE WHEN NOT (%s) AND NOT (%s) AND %s THEN %s ELSE NULL END", externalTarget, wispTargetExists, issueTargetExists, target),
+			fmt.Sprintf("CASE WHEN NOT (%s) AND %s THEN %s ELSE NULL END", externalTarget, wispTargetExists, target),
+			fmt.Sprintf("CASE WHEN %s OR (NOT (%s) AND NOT (%s)) THEN %s ELSE NULL END", externalTarget, wispTargetExists, issueTargetExists, target),
+		}, ", ")
+	}
+
+	issueTarget := qualifyDependencyColumn(tableAlias, DependencyTargetIssueColumn)
+	wispTarget := qualifyDependencyColumn(tableAlias, DependencyTargetWispColumn)
+	externalTarget := qualifyDependencyColumn(tableAlias, DependencyTargetExternalColumn)
+	issueMovesToWisp := fmt.Sprintf("%s IS NOT NULL AND (%s)", issueTarget, dependencyTargetIsWispExpr(issueTarget, migratingIDs))
+	issueTargetExists := fmt.Sprintf("EXISTS (SELECT 1 FROM issues target_issue WHERE target_issue.id = %s)", issueTarget)
+
+	return strings.Join([]string{
+		fmt.Sprintf("CASE WHEN %s IS NOT NULL AND NOT (%s) AND %s THEN %s ELSE NULL END", issueTarget, issueMovesToWisp, issueTargetExists, issueTarget),
+		fmt.Sprintf("CASE WHEN %s IS NOT NULL THEN %s WHEN %s THEN %s ELSE NULL END", wispTarget, wispTarget, issueMovesToWisp, issueTarget),
+		fmt.Sprintf("CASE WHEN %s IS NOT NULL THEN %s WHEN %s IS NOT NULL AND NOT (%s) AND NOT (%s) THEN %s ELSE NULL END", externalTarget, externalTarget, issueTarget, issueMovesToWisp, issueTargetExists, issueTarget),
+	}, ", ")
+}
+
 // IsDependencyTargetColumnError reports whether err came from a dependency
 // target-column schema mismatch between legacy and split bd schemas.
 func IsDependencyTargetColumnError(err error) bool {
@@ -73,9 +141,27 @@ func IsDependencyTargetColumnError(err error) bool {
 	return false
 }
 
+// IsDependencyTargetGeneratedWriteError reports whether a write attempted to
+// assign the generated legacy target column in bd's split dependency schema.
+func IsDependencyTargetGeneratedWriteError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	return strings.Contains(msg, DependencyTargetAlias) && strings.Contains(msg, "generated")
+}
+
 func qualifyDependencyColumn(tableAlias, column string) string {
 	if tableAlias == "" {
 		return column
 	}
 	return tableAlias + "." + column
+}
+
+func dependencyTargetIsWispExpr(target, migratingIDs string) string {
+	exprs := []string{fmt.Sprintf("EXISTS (SELECT 1 FROM wisps target_wisp WHERE target_wisp.id = %s)", target)}
+	if strings.TrimSpace(migratingIDs) != "" {
+		exprs = append(exprs, fmt.Sprintf("%s IN (%s)", target, migratingIDs))
+	}
+	return strings.Join(exprs, " OR ")
 }

--- a/internal/beads/dependency_schema_test.go
+++ b/internal/beads/dependency_schema_test.go
@@ -1,0 +1,68 @@
+package beads
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestDependencyTargetExpr(t *testing.T) {
+	tests := []struct {
+		name        string
+		tableAlias  string
+		splitTarget bool
+		want        string
+	}{
+		{
+			name:        "legacy unqualified",
+			splitTarget: false,
+			want:        "depends_on_id",
+		},
+		{
+			name:        "legacy qualified",
+			tableAlias:  "d",
+			splitTarget: false,
+			want:        "d.depends_on_id",
+		},
+		{
+			name:        "split qualified",
+			tableAlias:  "d",
+			splitTarget: true,
+			want:        "COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := DependencyTargetExpr(tt.tableAlias, tt.splitTarget); got != tt.want {
+				t.Fatalf("DependencyTargetExpr() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDependencyTargetSelectExprAliasesSplitTarget(t *testing.T) {
+	got := DependencyTargetSelectExpr("", true)
+	want := "COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS depends_on_id"
+	if got != want {
+		t.Fatalf("DependencyTargetSelectExpr() = %q, want %q", got, want)
+	}
+}
+
+func TestDependencyTargetMatchExpr(t *testing.T) {
+	got := DependencyTargetMatchExpr("d", "'gt-target'", true)
+	want := "'gt-target' IN (d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)"
+	if got != want {
+		t.Fatalf("DependencyTargetMatchExpr() = %q, want %q", got, want)
+	}
+}
+
+func TestIsDependencyTargetColumnError(t *testing.T) {
+	err := errors.New(`query error: column "depends_on_id" could not be found in any table in scope`)
+	if !IsDependencyTargetColumnError(err) {
+		t.Fatal("expected depends_on_id missing-column error to be detected")
+	}
+
+	if IsDependencyTargetColumnError(errors.New("syntax error near dependencies")) {
+		t.Fatal("unexpected dependency target column match for unrelated error")
+	}
+}

--- a/internal/beads/dependency_schema_test.go
+++ b/internal/beads/dependency_schema_test.go
@@ -2,6 +2,7 @@ package beads
 
 import (
 	"errors"
+	"strings"
 	"testing"
 )
 
@@ -56,6 +57,56 @@ func TestDependencyTargetMatchExpr(t *testing.T) {
 	}
 }
 
+func TestDependencyTargetSplitValuesExprsCopiesTypedSourceColumns(t *testing.T) {
+	got := DependencyTargetSplitValuesExprs("d", true)
+	want := "d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external"
+	if got != want {
+		t.Fatalf("DependencyTargetSplitValuesExprs() = %q, want %q", got, want)
+	}
+}
+
+func TestDependencyTargetSplitValuesExprsClassifiesLegacyTarget(t *testing.T) {
+	got := DependencyTargetSplitValuesExprs("d", false)
+
+	for _, want := range []string{
+		"EXISTS (SELECT 1 FROM wisps target_wisp WHERE target_wisp.id = d.depends_on_id)",
+		"EXISTS (SELECT 1 FROM issues target_issue WHERE target_issue.id = d.depends_on_id)",
+		"d.depends_on_id LIKE 'external:%'",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("DependencyTargetSplitValuesExprs() missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestDependencyTargetSplitValuesExprsForWispCopyReclassifiesMigratingSplitIssueTargets(t *testing.T) {
+	got := DependencyTargetSplitValuesExprsForWispCopy("d", true, "'gt-moving'")
+
+	for _, want := range []string{
+		"d.depends_on_issue_id IN ('gt-moving')",
+		"EXISTS (SELECT 1 FROM wisps target_wisp WHERE target_wisp.id = d.depends_on_issue_id)",
+		"CASE WHEN d.depends_on_wisp_id IS NOT NULL THEN d.depends_on_wisp_id",
+		"WHEN d.depends_on_issue_id IS NOT NULL AND (",
+		"THEN d.depends_on_issue_id ELSE NULL END",
+		"CASE WHEN d.depends_on_external IS NOT NULL THEN d.depends_on_external",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("DependencyTargetSplitValuesExprsForWispCopy() missing %q in %q", want, got)
+		}
+	}
+}
+
+func TestDependencyTargetSplitValuesExprsForWispCopyClassifiesLegacyMigratingTargets(t *testing.T) {
+	got := DependencyTargetSplitValuesExprsForWispCopy("d", false, "'gt-moving'")
+
+	if !strings.Contains(got, "d.depends_on_id IN ('gt-moving')") {
+		t.Fatalf("legacy wisp-copy expression should treat migrating ids as wisp targets: %q", got)
+	}
+	if !strings.Contains(got, "EXISTS (SELECT 1 FROM wisps target_wisp WHERE target_wisp.id = d.depends_on_id)") {
+		t.Fatalf("legacy wisp-copy expression should still classify existing wisps: %q", got)
+	}
+}
+
 func TestIsDependencyTargetColumnError(t *testing.T) {
 	err := errors.New(`query error: column "depends_on_id" could not be found in any table in scope`)
 	if !IsDependencyTargetColumnError(err) {
@@ -64,5 +115,19 @@ func TestIsDependencyTargetColumnError(t *testing.T) {
 
 	if IsDependencyTargetColumnError(errors.New("syntax error near dependencies")) {
 		t.Fatal("unexpected dependency target column match for unrelated error")
+	}
+}
+
+func TestIsDependencyTargetGeneratedWriteError(t *testing.T) {
+	err := errors.New("Error 3105 (HY000): The value specified for generated column 'depends_on_id' in table 'wisp_dependencies' is not allowed.")
+	if !IsDependencyTargetGeneratedWriteError(err) {
+		t.Fatal("expected depends_on_id generated-column write error to be detected")
+	}
+
+	if IsDependencyTargetGeneratedWriteError(errors.New("Error 3105 (HY000): generated column 'other_column' cannot be assigned")) {
+		t.Fatal("unexpected generated-column write match for unrelated column")
+	}
+	if IsDependencyTargetGeneratedWriteError(errors.New("syntax error near depends_on_id")) {
+		t.Fatal("unexpected generated-column write match without generated marker")
 	}
 }

--- a/internal/cmd/compact.go
+++ b/internal/cmd/compact.go
@@ -276,15 +276,16 @@ func runCompact(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-// cleanOrphanedWispDeps removes wisp_dependencies rows where either side no
-// longer exists in the wisps table. This happens when bd delete removes a wisp
-// but leaves behind its dependency records (bd delete has no cascade logic for
-// the wisp-level tables). Runs as a post-compact sweep.
+// cleanOrphanedWispDeps removes wisp_dependencies rows where the source wisp
+// no longer exists, or where the target no longer exists for its stored type.
+// This happens when bd delete removes a wisp but leaves behind its dependency
+// records (bd delete has no cascade logic for the wisp-level tables). Runs as a
+// post-compact sweep.
 func cleanOrphanedWispDeps(bd *beads.Beads, result *compactResult) {
-	const q = `DELETE FROM wisp_dependencies WHERE ` +
-		`NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.issue_id) ` +
-		`OR NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_id)`
-	out, err := bd.Run("sql", q)
+	out, err := bd.Run("sql", orphanedWispDepsCleanupQuery(false))
+	if beads.IsDependencyTargetColumnError(err) {
+		out, err = bd.Run("sql", orphanedWispDepsCleanupQuery(true))
+	}
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("orphaned wisp_deps cleanup: %v", err))
 		return
@@ -295,6 +296,29 @@ func cleanOrphanedWispDeps(bd *beads.Beads, result *compactResult) {
 	if _, scanErr := fmt.Sscanf(strings.TrimSpace(string(out)), "OK, %d rows affected", &n); scanErr == nil {
 		result.OrphanedWispDeps = n
 	}
+}
+
+func orphanedWispDepsCleanupQuery(splitTarget bool) string {
+	sourceMissing := `NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.issue_id)`
+	if splitTarget {
+		issueTarget := "wisp_dependencies." + beads.DependencyTargetIssueColumn
+		wispTarget := "wisp_dependencies." + beads.DependencyTargetWispColumn
+		externalTarget := "wisp_dependencies." + beads.DependencyTargetExternalColumn
+		targetExists := strings.Join([]string{
+			fmt.Sprintf("(%s IS NOT NULL AND EXISTS (SELECT 1 FROM issues WHERE id = %s))", issueTarget, issueTarget),
+			fmt.Sprintf("(%s IS NOT NULL AND EXISTS (SELECT 1 FROM wisps WHERE id = %s))", wispTarget, wispTarget),
+			fmt.Sprintf("(%s IS NOT NULL)", externalTarget),
+		}, " OR ")
+		return `DELETE FROM wisp_dependencies WHERE ` + sourceMissing + ` OR NOT (` + targetExists + `)`
+	}
+
+	targetExpr := beads.DependencyTargetExpr("wisp_dependencies", false)
+	targetExists := strings.Join([]string{
+		fmt.Sprintf("EXISTS (SELECT 1 FROM wisps WHERE id = %s)", targetExpr),
+		fmt.Sprintf("EXISTS (SELECT 1 FROM issues WHERE id = %s)", targetExpr),
+		fmt.Sprintf("(%s IS NOT NULL AND %s LIKE 'external:%%')", targetExpr, targetExpr),
+	}, " OR ")
+	return `DELETE FROM wisp_dependencies WHERE ` + sourceMissing + ` OR NOT (` + targetExists + `)`
 }
 
 // listWisps queries all ephemeral issues from the database.

--- a/internal/cmd/compact_test.go
+++ b/internal/cmd/compact_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,8 +25,8 @@ func TestGetTTL(t *testing.T) {
 		{"recovery", 7 * 24 * time.Hour},
 		{"escalation", 7 * 24 * time.Hour},
 		{"default", 24 * time.Hour},
-		{"", 24 * time.Hour},          // empty falls back to default
-		{"unknown", 24 * time.Hour},   // unknown falls back to default
+		{"", 24 * time.Hour},        // empty falls back to default
+		{"unknown", 24 * time.Hour}, // unknown falls back to default
 	}
 
 	for _, tc := range tests {
@@ -225,6 +228,132 @@ func TestExtractJSONArray(t *testing.T) {
 				t.Errorf("extractJSONArray(%q) = %q, want %q", tc.data, got, tc.want)
 			}
 		})
+	}
+}
+
+func TestOrphanedWispDepsCleanupQueryUsesSplitTarget(t *testing.T) {
+	query := orphanedWispDepsCleanupQuery(true)
+	targetExpr := "COALESCE(wisp_dependencies.depends_on_issue_id, wisp_dependencies.depends_on_wisp_id, wisp_dependencies.depends_on_external)"
+
+	if strings.Contains(query, "wisp_dependencies.depends_on_id") {
+		t.Fatalf("split cleanup query should not use legacy depends_on_id column:\n%s", query)
+	}
+	if strings.Contains(query, targetExpr) {
+		t.Fatalf("split cleanup query should validate typed targets directly, not through %s:\n%s", targetExpr, query)
+	}
+	if !strings.Contains(query, "issues WHERE id = wisp_dependencies.depends_on_issue_id") {
+		t.Fatalf("split cleanup query should preserve live issue targets:\n%s", query)
+	}
+	if !strings.Contains(query, "wisps WHERE id = wisp_dependencies.depends_on_wisp_id") {
+		t.Fatalf("split cleanup query should preserve live wisp targets:\n%s", query)
+	}
+	if !strings.Contains(query, "wisp_dependencies.depends_on_external IS NOT NULL") {
+		t.Fatalf("split cleanup query should preserve external targets:\n%s", query)
+	}
+}
+
+func TestOrphanedWispDepsCleanupQueryPreservesSplitTargetsByType(t *testing.T) {
+	sqlite, err := exec.LookPath("sqlite3")
+	if err != nil {
+		t.Skip("sqlite3 not found")
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "split-wisp-deps-cleanup.db")
+	script := `
+CREATE TABLE issues (
+  id varchar(255) PRIMARY KEY
+);
+CREATE TABLE wisps (
+  id varchar(255) PRIMARY KEY
+);
+CREATE TABLE wisp_dependencies (
+  issue_id varchar(255) NOT NULL,
+  depends_on_issue_id varchar(255),
+  depends_on_wisp_id varchar(255),
+  depends_on_external varchar(255)
+);
+INSERT INTO wisps (id) VALUES ('gt-source'), ('gt-wisp-target');
+INSERT INTO issues (id) VALUES ('gt-issue-target');
+INSERT INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external) VALUES
+  ('gt-source', 'gt-issue-target', NULL, NULL),
+  ('gt-source', NULL, 'gt-wisp-target', NULL),
+  ('gt-source', NULL, NULL, 'external:ticket-1'),
+  ('gt-source', 'gt-missing-issue', NULL, NULL),
+  ('gt-source', NULL, 'gt-missing-wisp', NULL),
+  ('gt-missing-source', NULL, NULL, 'external:orphan-source');
+` + orphanedWispDepsCleanupQuery(true) + `;
+.mode list
+SELECT COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)
+FROM wisp_dependencies
+ORDER BY 1;
+`
+
+	cmd := exec.Command(sqlite, "-batch", dbPath)
+	cmd.Stdin = strings.NewReader(script)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("sqlite fixture failed: %v\n%s", err, output)
+	}
+
+	got := strings.TrimSpace(string(output))
+	want := strings.Join([]string{
+		"external:ticket-1",
+		"gt-issue-target",
+		"gt-wisp-target",
+	}, "\n")
+	if got != want {
+		t.Fatalf("split cleanup survivors:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestOrphanedWispDepsCleanupQueryPreservesLegacyTargetsByType(t *testing.T) {
+	sqlite, err := exec.LookPath("sqlite3")
+	if err != nil {
+		t.Skip("sqlite3 not found")
+	}
+
+	dbPath := filepath.Join(t.TempDir(), "legacy-wisp-deps-cleanup.db")
+	script := `
+CREATE TABLE issues (
+  id varchar(255) PRIMARY KEY
+);
+CREATE TABLE wisps (
+  id varchar(255) PRIMARY KEY
+);
+CREATE TABLE wisp_dependencies (
+  issue_id varchar(255) NOT NULL,
+  depends_on_id varchar(255)
+);
+INSERT INTO wisps (id) VALUES ('gt-source'), ('gt-wisp-target');
+INSERT INTO issues (id) VALUES ('gt-issue-target');
+INSERT INTO wisp_dependencies (issue_id, depends_on_id) VALUES
+  ('gt-source', 'gt-issue-target'),
+  ('gt-source', 'gt-wisp-target'),
+  ('gt-source', 'external:ticket-1'),
+  ('gt-source', 'gt-missing-target'),
+  ('gt-missing-source', 'external:orphan-source');
+` + orphanedWispDepsCleanupQuery(false) + `;
+.mode list
+SELECT depends_on_id
+FROM wisp_dependencies
+ORDER BY depends_on_id;
+`
+
+	cmd := exec.Command(sqlite, "-batch", dbPath)
+	cmd.Stdin = strings.NewReader(script)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("sqlite fixture failed: %v\n%s", err, output)
+	}
+
+	got := strings.TrimSpace(string(output))
+	want := strings.Join([]string{
+		"external:ticket-1",
+		"gt-issue-target",
+		"gt-wisp-target",
+	}, "\n")
+	if got != want {
+		t.Fatalf("legacy cleanup survivors:\n%s\nwant:\n%s", got, want)
 	}
 }
 

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -511,10 +511,7 @@ func bdDepListRawIDs(dir, issueID, direction, depType string) ([]string, error) 
 }
 
 func bdDepListRawIDsWithSchema(dir, issueID, direction, depType string, splitTarget bool) ([]string, error) {
-	targetExpr := "depends_on_id"
-	if splitTarget {
-		targetExpr = "COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)"
-	}
+	targetExpr := beads.DependencyTargetExpr("", splitTarget)
 
 	// Determine query columns based on direction.
 	// "down": issueID depends on targets → SELECT target WHERE issue_id = ?
@@ -525,13 +522,9 @@ func bdDepListRawIDsWithSchema(dir, issueID, direction, depType string, splitTar
 	if direction == "up" {
 		selectExpr = "issue_id"
 		rowKey = "issue_id"
-		if splitTarget {
-			whereExpr = fmt.Sprintf("'%s' IN (depends_on_issue_id, depends_on_wisp_id, depends_on_external)", issueID)
-		} else {
-			whereExpr = fmt.Sprintf("%s = '%s'", targetExpr, issueID)
-		}
+		whereExpr = beads.DependencyTargetMatchExpr("", fmt.Sprintf("'%s'", issueID), splitTarget)
 	} else if splitTarget {
-		selectExpr = targetExpr + " AS depends_on_id"
+		selectExpr = beads.DependencyTargetSelectExpr("", splitTarget)
 	}
 
 	query := fmt.Sprintf("SELECT %s FROM dependencies WHERE %s", selectExpr, whereExpr)
@@ -564,15 +557,7 @@ func bdDepListRawIDsWithSchema(dir, issueID, direction, depType string, splitTar
 }
 
 func isDependencyTargetColumnError(err error) bool {
-	msg := strings.ToLower(err.Error())
-	missingColumn := strings.Contains(msg, "unknown column") ||
-		strings.Contains(msg, "could not be found") ||
-		strings.Contains(msg, "no such column")
-	return missingColumn &&
-		(strings.Contains(msg, "depends_on_id") ||
-			strings.Contains(msg, "depends_on_issue_id") ||
-			strings.Contains(msg, "depends_on_wisp_id") ||
-			strings.Contains(msg, "depends_on_external"))
+	return beads.IsDependencyTargetColumnError(err)
 }
 
 // isValidBeadID checks that a string is safe for SQL interpolation in dep queries.

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -517,7 +517,7 @@ func bdDepListRawIDsWithSchema(dir, issueID, direction, depType string, splitTar
 	// "down": issueID depends on targets → SELECT target WHERE issue_id = ?
 	// "up":   issueID is depended on → SELECT issue_id WHERE target = ?
 	selectExpr := targetExpr
-	rowKey := "depends_on_id"
+	rowKey := beads.DependencyTargetAlias
 	whereExpr := fmt.Sprintf("issue_id = '%s'", issueID)
 	if direction == "up" {
 		selectExpr = "issue_id"

--- a/internal/doctor/misclassified_wisp_check.go
+++ b/internal/doctor/misclassified_wisp_check.go
@@ -240,12 +240,16 @@ func (c *CheckMisclassifiedWisps) purgeRigBatch(ctx *CheckContext, workDir, rigN
 		},
 		{
 			table: "wisp_dependencies",
-			query: fmt.Sprintf("INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_id, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d WHERE d.issue_id IN (%s)", idList),
+			query: buildMisclassifiedWispDependenciesCopyQuery(idList, false),
 		},
 	}
 	for _, aux := range auxCopies {
 		if bdTableExistsDoctor(workDir, aux.table) {
-			_ = execBdSQLWrite(workDir, aux.query) // Best-effort
+			if aux.table == "wisp_dependencies" {
+				_ = copyMisclassifiedWispDependencies(workDir, idList) // Best-effort
+			} else {
+				_ = execBdSQLWrite(workDir, aux.query) // Best-effort
+			}
 		}
 	}
 
@@ -273,6 +277,23 @@ func (c *CheckMisclassifiedWisps) purgeRigBatch(ctx *CheckContext, workDir, rigN
 	}
 
 	return nil
+}
+
+func copyMisclassifiedWispDependencies(workDir, idList string) error {
+	err := execBdSQLWrite(workDir, buildMisclassifiedWispDependenciesCopyQuery(idList, false))
+	if err == nil || !beads.IsDependencyTargetColumnError(err) {
+		return err
+	}
+	return execBdSQLWrite(workDir, buildMisclassifiedWispDependenciesCopyQuery(idList, true))
+}
+
+func buildMisclassifiedWispDependenciesCopyQuery(idList string, splitTarget bool) string {
+	return fmt.Sprintf(
+		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) "+
+			"SELECT d.issue_id, %s, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d WHERE d.issue_id IN (%s)",
+		beads.DependencyTargetExpr("d", splitTarget),
+		idList,
+	)
 }
 
 // bdTableExistsDoctor checks if a table exists by attempting to query it.

--- a/internal/doctor/misclassified_wisp_check.go
+++ b/internal/doctor/misclassified_wisp_check.go
@@ -238,18 +238,15 @@ func (c *CheckMisclassifiedWisps) purgeRigBatch(ctx *CheckContext, workDir, rigN
 			table: "wisp_events",
 			query: fmt.Sprintf("INSERT IGNORE INTO wisp_events (issue_id, event_type, actor, old_value, new_value, comment, created_at) SELECT e.issue_id, e.event_type, e.actor, e.old_value, e.new_value, e.comment, e.created_at FROM events e WHERE e.issue_id IN (%s)", idList),
 		},
-		{
-			table: "wisp_dependencies",
-			query: buildMisclassifiedWispDependenciesCopyQuery(idList, false),
-		},
 	}
 	for _, aux := range auxCopies {
 		if bdTableExistsDoctor(workDir, aux.table) {
-			if aux.table == "wisp_dependencies" {
-				_ = copyMisclassifiedWispDependencies(workDir, idList) // Best-effort
-			} else {
-				_ = execBdSQLWrite(workDir, aux.query) // Best-effort
-			}
+			_ = execBdSQLWrite(workDir, aux.query) // Best-effort
+		}
+	}
+	if bdTableExistsDoctor(workDir, "wisp_dependencies") {
+		if err := copyMisclassifiedWispDependencies(workDir, idList); err != nil {
+			return fmt.Errorf("copy dependencies to wisp_dependencies: %w", err)
 		}
 	}
 
@@ -280,20 +277,59 @@ func (c *CheckMisclassifiedWisps) purgeRigBatch(ctx *CheckContext, workDir, rigN
 }
 
 func copyMisclassifiedWispDependencies(workDir, idList string) error {
-	err := execBdSQLWrite(workDir, buildMisclassifiedWispDependenciesCopyQuery(idList, false))
-	if err == nil || !beads.IsDependencyTargetColumnError(err) {
-		return err
+	splitWispTarget := bdTableHasColumnDoctor(workDir, "wisp_dependencies", beads.DependencyTargetWispColumn)
+	splitSourceTarget := false
+
+	err := execBdSQLWrite(workDir, buildMisclassifiedWispDependenciesCopyQuery(idList, splitSourceTarget, splitWispTarget))
+	if err == nil {
+		return nil
 	}
-	return execBdSQLWrite(workDir, buildMisclassifiedWispDependenciesCopyQuery(idList, true))
+	if beads.IsDependencyTargetColumnError(err) {
+		splitSourceTarget = true
+		err = execBdSQLWrite(workDir, buildMisclassifiedWispDependenciesCopyQuery(idList, splitSourceTarget, splitWispTarget))
+	}
+	if !splitWispTarget && beads.IsDependencyTargetGeneratedWriteError(err) {
+		return execBdSQLWrite(workDir, buildMisclassifiedWispDependenciesCopyQuery(idList, splitSourceTarget, true))
+	}
+	return err
 }
 
-func buildMisclassifiedWispDependenciesCopyQuery(idList string, splitTarget bool) string {
+func buildMisclassifiedWispDependenciesCopyQuery(idList string, splitSourceTarget, splitWispTarget bool) string {
+	if splitWispTarget {
+		return fmt.Sprintf(
+			"INSERT IGNORE INTO wisp_dependencies (issue_id, %s, type, created_at, created_by, metadata, thread_id) "+
+				"SELECT d.issue_id, %s, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d WHERE d.issue_id IN (%s)",
+			beads.DependencyTargetSplitColumns(),
+			beads.DependencyTargetSplitValuesExprsForWispCopy("d", splitSourceTarget, idList),
+			idList,
+		)
+	}
+
 	return fmt.Sprintf(
 		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) "+
 			"SELECT d.issue_id, %s, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d WHERE d.issue_id IN (%s)",
-		beads.DependencyTargetExpr("d", splitTarget),
+		beads.DependencyTargetExpr("d", splitSourceTarget),
 		idList,
 	)
+}
+
+func bdTableHasColumnDoctor(workDir, tableName, columnName string) bool {
+	query := fmt.Sprintf(
+		"SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' AND COLUMN_NAME = '%s'",
+		tableName,
+		columnName,
+	)
+	cmd := exec.Command("bd", "sql", "--csv", query) //nolint:gosec // G204: tableName and columnName are hardcoded by callers
+	cmd.Dir = workDir
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return false
+	}
+	records, err := csv.NewReader(strings.NewReader(string(output))).ReadAll()
+	if err != nil || len(records) < 2 || len(records[1]) < 1 {
+		return false
+	}
+	return strings.TrimSpace(records[1][0]) != "0"
 }
 
 // bdTableExistsDoctor checks if a table exists by attempting to query it.

--- a/internal/doctor/misclassified_wisp_check_test.go
+++ b/internal/doctor/misclassified_wisp_check_test.go
@@ -87,6 +87,28 @@ func TestRunIgnoresJSONLWhenDoltUnavailable(t *testing.T) {
 	}
 }
 
+func TestBuildMisclassifiedWispDependenciesCopyQueryUsesSplitTargetSchema(t *testing.T) {
+	query := buildMisclassifiedWispDependenciesCopyQuery("'gt-wisp-1'", true)
+
+	if !strings.Contains(query, "COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)") {
+		t.Fatalf("split-schema query did not use dependency target COALESCE: %s", query)
+	}
+	if strings.Contains(query, "d.depends_on_id") {
+		t.Fatalf("split-schema query still selects legacy target column: %s", query)
+	}
+	if !strings.Contains(query, "WHERE d.issue_id IN ('gt-wisp-1')") {
+		t.Fatalf("split-schema query lost id filter: %s", query)
+	}
+}
+
+func TestBuildMisclassifiedWispDependenciesCopyQueryUsesLegacyTargetSchema(t *testing.T) {
+	query := buildMisclassifiedWispDependenciesCopyQuery("'gt-wisp-1'", false)
+
+	if !strings.Contains(query, "SELECT d.issue_id, d.depends_on_id, d.type") {
+		t.Fatalf("legacy query did not select depends_on_id: %s", query)
+	}
+}
+
 // TestGetRigPathForPrefix_RoutesResolution verifies that GetRigPathForPrefix
 // correctly resolves rig paths from routes.jsonl. This is critical for the
 // misclassified-wisps check which uses database names (e.g., "sw") to look up

--- a/internal/doctor/misclassified_wisp_check_test.go
+++ b/internal/doctor/misclassified_wisp_check_test.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -88,7 +89,7 @@ func TestRunIgnoresJSONLWhenDoltUnavailable(t *testing.T) {
 }
 
 func TestBuildMisclassifiedWispDependenciesCopyQueryUsesSplitTargetSchema(t *testing.T) {
-	query := buildMisclassifiedWispDependenciesCopyQuery("'gt-wisp-1'", true)
+	query := buildMisclassifiedWispDependenciesCopyQuery("'gt-wisp-1'", true, false)
 
 	if !strings.Contains(query, "COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)") {
 		t.Fatalf("split-schema query did not use dependency target COALESCE: %s", query)
@@ -102,10 +103,139 @@ func TestBuildMisclassifiedWispDependenciesCopyQueryUsesSplitTargetSchema(t *tes
 }
 
 func TestBuildMisclassifiedWispDependenciesCopyQueryUsesLegacyTargetSchema(t *testing.T) {
-	query := buildMisclassifiedWispDependenciesCopyQuery("'gt-wisp-1'", false)
+	query := buildMisclassifiedWispDependenciesCopyQuery("'gt-wisp-1'", false, false)
 
 	if !strings.Contains(query, "SELECT d.issue_id, d.depends_on_id, d.type") {
 		t.Fatalf("legacy query did not select depends_on_id: %s", query)
+	}
+}
+
+func TestBuildMisclassifiedWispDependenciesCopyQueryUsesSplitWispTargetSchema(t *testing.T) {
+	query := buildMisclassifiedWispDependenciesCopyQuery("'gt-wisp-1'", false, true)
+
+	if !strings.Contains(query, "INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type") {
+		t.Fatalf("split wisp-target query did not insert typed target columns: %s", query)
+	}
+	if strings.Contains(query, "INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id") {
+		t.Fatalf("split wisp-target query still inserts generated depends_on_id: %s", query)
+	}
+	if !strings.Contains(query, "WHERE d.issue_id IN ('gt-wisp-1')") {
+		t.Fatalf("split wisp-target query lost id filter: %s", query)
+	}
+}
+
+func TestBuildMisclassifiedWispDependenciesCopyQueryReclassifiesMigratingSplitIssueTargets(t *testing.T) {
+	query := buildMisclassifiedWispDependenciesCopyQuery("'gt-wisp-1','gt-wisp-2'", true, true)
+
+	if !strings.Contains(query, "d.depends_on_issue_id IN ('gt-wisp-1','gt-wisp-2')") {
+		t.Fatalf("split-source query did not treat migrating ids as wisp targets: %s", query)
+	}
+	if !strings.Contains(query, "EXISTS (SELECT 1 FROM wisps target_wisp WHERE target_wisp.id = d.depends_on_issue_id)") {
+		t.Fatalf("split-source query did not treat existing wisps as wisp targets: %s", query)
+	}
+	if strings.Contains(query, "SELECT d.issue_id, d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external") {
+		t.Fatalf("split-source wisp copy should not blindly copy typed target columns: %s", query)
+	}
+}
+
+func TestCopyMisclassifiedWispDependenciesRetriesSplitSourceThenGeneratedTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake bd stub is shell-specific")
+	}
+
+	logPath := installFakeBDForMisclassifiedDependencyCopy(t)
+
+	if err := copyMisclassifiedWispDependencies(t.TempDir(), "'gt-wisp-1','gt-wisp-2'"); err != nil {
+		t.Fatalf("copyMisclassifiedWispDependencies() error = %v", err)
+	}
+
+	lines := readMisclassifiedDependencyCopyLog(t, logPath)
+	if len(lines) != 4 {
+		t.Fatalf("bd queries = %v, want column probe plus 3 copy attempts", lines)
+	}
+	assertMisclassifiedDependencyCopySequence(t, lines)
+}
+
+func installFakeBDForMisclassifiedDependencyCopy(t *testing.T) string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	statePath := filepath.Join(t.TempDir(), "bd-state")
+	logPath := filepath.Join(t.TempDir(), "bd-queries.log")
+	script := `#!/usr/bin/env bash
+set -u
+if [ "${1:-}" != "sql" ]; then
+  exit 1
+fi
+if [ "${2:-}" = "--csv" ]; then
+  printf 'csv:%s\n' "${3:-}" >> "$BD_QUERY_LOG"
+  printf 'cnt\n0\n'
+  exit 0
+fi
+printf 'write:%s\n' "${2:-}" >> "$BD_QUERY_LOG"
+state=0
+if [ -f "$BD_STATE" ]; then
+  state="$(cat "$BD_STATE")"
+fi
+state=$((state + 1))
+printf '%s\n' "$state" > "$BD_STATE"
+case "$state" in
+  1)
+    printf "Error 1054 (42S22): Unknown column 'd.depends_on_id' in 'field list'\n" >&2
+    exit 1
+    ;;
+  2)
+    printf "Error 3105 (HY000): The value specified for generated column 'depends_on_id' in table 'wisp_dependencies' is not allowed.\n" >&2
+    exit 1
+    ;;
+  3)
+    exit 0
+    ;;
+  *)
+    printf 'unexpected bd sql write call %s\n' "$state" >&2
+    exit 1
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_STATE", statePath)
+	t.Setenv("BD_QUERY_LOG", logPath)
+
+	return logPath
+}
+
+func readMisclassifiedDependencyCopyLog(t *testing.T, logPath string) []string {
+	t.Helper()
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	return strings.Split(strings.TrimSpace(string(data)), "\n")
+}
+
+func assertMisclassifiedDependencyCopySequence(t *testing.T, lines []string) {
+	t.Helper()
+
+	if !strings.Contains(lines[0], "INFORMATION_SCHEMA.COLUMNS") || !strings.Contains(lines[0], "wisp_dependencies") {
+		t.Fatalf("first query = %q, want wisp dependency target column probe", lines[0])
+	}
+	if !strings.Contains(lines[1], "INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id") ||
+		!strings.Contains(lines[1], "SELECT d.issue_id, d.depends_on_id") ||
+		!strings.Contains(lines[1], "WHERE d.issue_id IN ('gt-wisp-1','gt-wisp-2')") {
+		t.Fatalf("first copy attempt = %q, want legacy source into legacy target", lines[1])
+	}
+	if !strings.Contains(lines[2], "INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id") ||
+		!strings.Contains(lines[2], "COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)") {
+		t.Fatalf("second copy attempt = %q, want split-source retry into legacy target", lines[2])
+	}
+	if !strings.Contains(lines[3], "INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external") ||
+		!strings.Contains(lines[3], "d.depends_on_issue_id IN ('gt-wisp-1','gt-wisp-2')") ||
+		!strings.Contains(lines[3], "WHERE d.issue_id IN ('gt-wisp-1','gt-wisp-2')") {
+		t.Fatalf("third copy attempt = %q, want generated-target retry into split target columns", lines[3])
 	}
 }
 

--- a/internal/doltserver/wisps_migrate.go
+++ b/internal/doltserver/wisps_migrate.go
@@ -3,11 +3,11 @@
 // The wisps table is a dolt_ignored copy of the issues table schema, used for
 // ephemeral operational data (agent beads, patrol wisps, etc.) that should not
 // be version-controlled. This migration:
-//   1. Creates the wisps table and auxiliary tables (wisp_labels, wisp_comments,
-//      wisp_events, wisp_dependencies) if they don't exist
-//   2. Copies existing agent beads (issue_type='agent') from issues to wisps
-//   3. Copies associated labels, comments, events, and dependencies
-//   4. Closes the originals in the issues table
+//  1. Creates the wisps table and auxiliary tables (wisp_labels, wisp_comments,
+//     wisp_events, wisp_dependencies) if they don't exist
+//  2. Copies existing agent beads (issue_type='agent') from issues to wisps
+//  3. Copies associated labels, comments, events, and dependencies
+//  4. Closes the originals in the issues table
 //
 // The migration uses `bd sql` for beads-side operations (copying agent beads between
 // the issues and wisps tables in bd's own database). Additionally, it ensures that
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 // MigrateWispsResult holds migration statistics.
@@ -256,8 +257,7 @@ func copyAuxiliaryData(workDir string, result *MigrateWispsResult) error {
 	result.EventsCopied = cnt
 
 	// Copy dependencies
-	if err := bdSQL(workDir,
-		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_id, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d INNER JOIN wisps w ON d.issue_id = w.id"); err != nil {
+	if err := copyWispDependencies(workDir); err != nil {
 		if !strings.Contains(err.Error(), "nothing") {
 			return fmt.Errorf("copying dependencies: %w", err)
 		}
@@ -266,6 +266,22 @@ func copyAuxiliaryData(workDir string, result *MigrateWispsResult) error {
 	result.DepsCopied = cnt
 
 	return nil
+}
+
+func copyWispDependencies(workDir string) error {
+	err := bdSQL(workDir, buildWispDependenciesCopyQuery(false))
+	if err == nil || !beads.IsDependencyTargetColumnError(err) {
+		return err
+	}
+	return bdSQL(workDir, buildWispDependenciesCopyQuery(true))
+}
+
+func buildWispDependenciesCopyQuery(splitTarget bool) string {
+	return fmt.Sprintf(
+		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) "+
+			"SELECT d.issue_id, %s, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d INNER JOIN wisps w ON d.issue_id = w.id",
+		beads.DependencyTargetExpr("d", splitTarget),
+	)
 }
 
 // deriveDBName extracts the database name from the workDir relative to townRoot.

--- a/internal/doltserver/wisps_migrate.go
+++ b/internal/doltserver/wisps_migrate.go
@@ -269,19 +269,47 @@ func copyAuxiliaryData(workDir string, result *MigrateWispsResult) error {
 }
 
 func copyWispDependencies(workDir string) error {
-	err := bdSQL(workDir, buildWispDependenciesCopyQuery(false))
-	if err == nil || !beads.IsDependencyTargetColumnError(err) {
-		return err
+	splitWispTarget := bdTableHasColumn(workDir, "wisp_dependencies", beads.DependencyTargetWispColumn)
+	splitSourceTarget := false
+
+	err := bdSQL(workDir, buildWispDependenciesCopyQuery(splitSourceTarget, splitWispTarget))
+	if err == nil {
+		return nil
 	}
-	return bdSQL(workDir, buildWispDependenciesCopyQuery(true))
+	if beads.IsDependencyTargetColumnError(err) {
+		splitSourceTarget = true
+		err = bdSQL(workDir, buildWispDependenciesCopyQuery(splitSourceTarget, splitWispTarget))
+	}
+	if !splitWispTarget && beads.IsDependencyTargetGeneratedWriteError(err) {
+		return bdSQL(workDir, buildWispDependenciesCopyQuery(splitSourceTarget, true))
+	}
+	return err
 }
 
-func buildWispDependenciesCopyQuery(splitTarget bool) string {
+func buildWispDependenciesCopyQuery(splitSourceTarget, splitWispTarget bool) string {
+	if splitWispTarget {
+		return fmt.Sprintf(
+			"INSERT IGNORE INTO wisp_dependencies (issue_id, %s, type, created_at, created_by, metadata, thread_id) "+
+				"SELECT d.issue_id, %s, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d INNER JOIN wisps w ON d.issue_id = w.id",
+			beads.DependencyTargetSplitColumns(),
+			beads.DependencyTargetSplitValuesExprsForWispCopy("d", splitSourceTarget, ""),
+		)
+	}
+
 	return fmt.Sprintf(
 		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) "+
 			"SELECT d.issue_id, %s, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d INNER JOIN wisps w ON d.issue_id = w.id",
-		beads.DependencyTargetExpr("d", splitTarget),
+		beads.DependencyTargetExpr("d", splitSourceTarget),
 	)
+}
+
+func bdTableHasColumn(workDir, tableName, columnName string) bool {
+	cnt, err := bdSQLCount(workDir, fmt.Sprintf(
+		"SELECT COUNT(*) as cnt FROM INFORMATION_SCHEMA.COLUMNS WHERE TABLE_SCHEMA = DATABASE() AND TABLE_NAME = '%s' AND COLUMN_NAME = '%s'",
+		tableName,
+		columnName,
+	))
+	return err == nil && cnt > 0
 }
 
 // deriveDBName extracts the database name from the workDir relative to townRoot.

--- a/internal/doltserver/wisps_migrate_dependency_test.go
+++ b/internal/doltserver/wisps_migrate_dependency_test.go
@@ -1,0 +1,25 @@
+package doltserver
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBuildWispDependenciesCopyQueryUsesSplitTargetSchema(t *testing.T) {
+	query := buildWispDependenciesCopyQuery(true)
+
+	if !strings.Contains(query, "COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)") {
+		t.Fatalf("split-schema query did not use dependency target COALESCE: %s", query)
+	}
+	if strings.Contains(query, "d.depends_on_id") {
+		t.Fatalf("split-schema query still selects legacy target column: %s", query)
+	}
+}
+
+func TestBuildWispDependenciesCopyQueryUsesLegacyTargetSchema(t *testing.T) {
+	query := buildWispDependenciesCopyQuery(false)
+
+	if !strings.Contains(query, "SELECT d.issue_id, d.depends_on_id, d.type") {
+		t.Fatalf("legacy query did not select depends_on_id: %s", query)
+	}
+}

--- a/internal/doltserver/wisps_migrate_dependency_test.go
+++ b/internal/doltserver/wisps_migrate_dependency_test.go
@@ -1,12 +1,16 @@
 package doltserver
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
 
 func TestBuildWispDependenciesCopyQueryUsesSplitTargetSchema(t *testing.T) {
-	query := buildWispDependenciesCopyQuery(true)
+	query := buildWispDependenciesCopyQuery(true, false)
 
 	if !strings.Contains(query, "COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)") {
 		t.Fatalf("split-schema query did not use dependency target COALESCE: %s", query)
@@ -17,9 +21,290 @@ func TestBuildWispDependenciesCopyQueryUsesSplitTargetSchema(t *testing.T) {
 }
 
 func TestBuildWispDependenciesCopyQueryUsesLegacyTargetSchema(t *testing.T) {
-	query := buildWispDependenciesCopyQuery(false)
+	query := buildWispDependenciesCopyQuery(false, false)
 
 	if !strings.Contains(query, "SELECT d.issue_id, d.depends_on_id, d.type") {
 		t.Fatalf("legacy query did not select depends_on_id: %s", query)
+	}
+}
+
+func TestBuildWispDependenciesCopyQueryUsesSplitWispTargetSchema(t *testing.T) {
+	query := buildWispDependenciesCopyQuery(false, true)
+
+	if !strings.Contains(query, "INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type") {
+		t.Fatalf("split wisp-target query did not insert typed target columns: %s", query)
+	}
+	if strings.Contains(query, "INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id") {
+		t.Fatalf("split wisp-target query still inserts generated depends_on_id: %s", query)
+	}
+	if !strings.Contains(query, "EXISTS (SELECT 1 FROM wisps target_wisp WHERE target_wisp.id = d.depends_on_id)") {
+		t.Fatalf("split wisp-target query did not classify legacy targets against wisps: %s", query)
+	}
+}
+
+func TestBuildWispDependenciesCopyQueryReclassifiesSplitIssueTargetsForWisps(t *testing.T) {
+	query := buildWispDependenciesCopyQuery(true, true)
+
+	if !strings.Contains(query, "EXISTS (SELECT 1 FROM wisps target_wisp WHERE target_wisp.id = d.depends_on_issue_id)") {
+		t.Fatalf("split-source query did not reclassify issue targets already present in wisps: %s", query)
+	}
+	if !strings.Contains(query, "WHEN d.depends_on_issue_id IS NOT NULL AND (") {
+		t.Fatalf("split-source query did not route moved issue targets into depends_on_wisp_id: %s", query)
+	}
+	if strings.Contains(query, "SELECT d.issue_id, d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external") {
+		t.Fatalf("split-source wisp copy should not blindly copy typed target columns: %s", query)
+	}
+}
+
+func TestBuildWispDependenciesCopyQueryCopiesIntoSplitGeneratedTarget(t *testing.T) {
+	sqlite, err := exec.LookPath("sqlite3")
+	if err != nil {
+		t.Skip("sqlite3 not found")
+	}
+
+	query := strings.ReplaceAll(buildWispDependenciesCopyQuery(false, true), "INSERT IGNORE", "INSERT OR IGNORE")
+	dbPath := filepath.Join(t.TempDir(), "split-wisp-dependencies.db")
+	script := `
+CREATE TABLE issues (
+  id varchar(255) PRIMARY KEY
+);
+CREATE TABLE wisps (
+  id varchar(255) PRIMARY KEY
+);
+CREATE TABLE dependencies (
+  issue_id varchar(255) NOT NULL,
+  depends_on_id varchar(255) NOT NULL,
+  type varchar(32) NOT NULL DEFAULT 'blocks',
+  created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_by varchar(255) NOT NULL DEFAULT '',
+  metadata text,
+  thread_id varchar(255) DEFAULT ''
+);
+CREATE TABLE wisp_dependencies (
+  issue_id varchar(255) NOT NULL,
+  depends_on_issue_id varchar(255),
+  depends_on_wisp_id varchar(255),
+  depends_on_external varchar(255),
+  depends_on_id varchar(255) GENERATED ALWAYS AS (COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)) STORED,
+  type varchar(32) NOT NULL DEFAULT 'blocks',
+  created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_by varchar(255) NOT NULL DEFAULT '',
+  metadata text,
+  thread_id varchar(255) DEFAULT '',
+  UNIQUE (issue_id, depends_on_id),
+  CHECK ((depends_on_issue_id IS NOT NULL) + (depends_on_wisp_id IS NOT NULL) + (depends_on_external IS NOT NULL) = 1)
+);
+INSERT INTO wisps (id) VALUES ('gt-agent'), ('gt-wisp-target');
+INSERT INTO issues (id) VALUES ('gt-issue-target');
+INSERT INTO dependencies (issue_id, depends_on_id, type, created_by, metadata, thread_id) VALUES
+  ('gt-agent', 'gt-issue-target', 'blocks', '', '{}', ''),
+  ('gt-agent', 'gt-wisp-target', 'blocks', '', '{}', ''),
+  ('gt-agent', 'external:ticket-1', 'blocks', '', '{}', ''),
+  ('gt-agent', 'gt-missing-target', 'blocks', '', '{}', '');
+` + query + `;
+.mode list
+SELECT depends_on_id || '|' ||
+       COALESCE(depends_on_issue_id, '') || '|' ||
+       COALESCE(depends_on_wisp_id, '') || '|' ||
+       COALESCE(depends_on_external, '')
+FROM wisp_dependencies
+ORDER BY depends_on_id;
+`
+
+	cmd := exec.Command(sqlite, "-batch", dbPath)
+	cmd.Stdin = strings.NewReader(script)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("sqlite fixture failed: %v\n%s", err, output)
+	}
+
+	got := strings.TrimSpace(string(output))
+	want := strings.Join([]string{
+		"external:ticket-1|||external:ticket-1",
+		"gt-issue-target|gt-issue-target||",
+		"gt-missing-target|||gt-missing-target",
+		"gt-wisp-target||gt-wisp-target|",
+	}, "\n")
+	if got != want {
+		t.Fatalf("split generated target copy rows:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestBuildWispDependenciesCopyQueryReclassifiesSplitSourceIntoSplitWispTarget(t *testing.T) {
+	sqlite, err := exec.LookPath("sqlite3")
+	if err != nil {
+		t.Skip("sqlite3 not found")
+	}
+
+	query := strings.ReplaceAll(buildWispDependenciesCopyQuery(true, true), "INSERT IGNORE", "INSERT OR IGNORE")
+	dbPath := filepath.Join(t.TempDir(), "split-source-wisp-dependencies.db")
+	script := `
+CREATE TABLE issues (
+  id varchar(255) PRIMARY KEY
+);
+CREATE TABLE wisps (
+  id varchar(255) PRIMARY KEY
+);
+CREATE TABLE dependencies (
+  issue_id varchar(255) NOT NULL,
+  depends_on_issue_id varchar(255),
+  depends_on_wisp_id varchar(255),
+  depends_on_external varchar(255),
+  type varchar(32) NOT NULL DEFAULT 'blocks',
+  created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_by varchar(255) NOT NULL DEFAULT '',
+  metadata text,
+  thread_id varchar(255) DEFAULT '',
+  CHECK ((depends_on_issue_id IS NOT NULL) + (depends_on_wisp_id IS NOT NULL) + (depends_on_external IS NOT NULL) = 1)
+);
+CREATE TABLE wisp_dependencies (
+  issue_id varchar(255) NOT NULL,
+  depends_on_issue_id varchar(255),
+  depends_on_wisp_id varchar(255),
+  depends_on_external varchar(255),
+  depends_on_id varchar(255) GENERATED ALWAYS AS (COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)) STORED,
+  type varchar(32) NOT NULL DEFAULT 'blocks',
+  created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  created_by varchar(255) NOT NULL DEFAULT '',
+  metadata text,
+  thread_id varchar(255) DEFAULT '',
+  UNIQUE (issue_id, depends_on_id),
+  CHECK ((depends_on_issue_id IS NOT NULL) + (depends_on_wisp_id IS NOT NULL) + (depends_on_external IS NOT NULL) = 1)
+);
+INSERT INTO wisps (id) VALUES ('gt-agent'), ('gt-moving-target'), ('gt-wisp-target');
+INSERT INTO issues (id) VALUES ('gt-moving-target'), ('gt-live-issue');
+INSERT INTO dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_by, metadata, thread_id) VALUES
+  ('gt-agent', 'gt-moving-target', NULL, NULL, 'blocks', '', '{}', ''),
+  ('gt-agent', 'gt-live-issue', NULL, NULL, 'blocks', '', '{}', ''),
+  ('gt-agent', NULL, 'gt-wisp-target', NULL, 'blocks', '', '{}', ''),
+  ('gt-agent', NULL, NULL, 'external:ticket-1', 'blocks', '', '{}', ''),
+  ('gt-agent', 'gt-missing-target', NULL, NULL, 'blocks', '', '{}', '');
+` + query + `;
+.mode list
+SELECT depends_on_id || '|' ||
+       COALESCE(depends_on_issue_id, '') || '|' ||
+       COALESCE(depends_on_wisp_id, '') || '|' ||
+       COALESCE(depends_on_external, '')
+FROM wisp_dependencies
+ORDER BY depends_on_id;
+`
+
+	cmd := exec.Command(sqlite, "-batch", dbPath)
+	cmd.Stdin = strings.NewReader(script)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("sqlite fixture failed: %v\n%s", err, output)
+	}
+
+	got := strings.TrimSpace(string(output))
+	want := strings.Join([]string{
+		"external:ticket-1|||external:ticket-1",
+		"gt-live-issue|gt-live-issue||",
+		"gt-missing-target|||gt-missing-target",
+		"gt-moving-target||gt-moving-target|",
+		"gt-wisp-target||gt-wisp-target|",
+	}, "\n")
+	if got != want {
+		t.Fatalf("split-source wisp copy rows:\n%s\nwant:\n%s", got, want)
+	}
+}
+
+func TestCopyWispDependenciesRetriesSplitSourceThenGeneratedTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake bd stub is shell-specific")
+	}
+
+	logPath := installFakeBDForDependencyCopy(t)
+
+	if err := copyWispDependencies(t.TempDir()); err != nil {
+		t.Fatalf("copyWispDependencies() error = %v", err)
+	}
+
+	lines := readDependencyCopyLog(t, logPath)
+	if len(lines) != 4 {
+		t.Fatalf("bd queries = %v, want column probe plus 3 copy attempts", lines)
+	}
+	assertDependencyCopySequence(t, lines, "INNER JOIN wisps w ON d.issue_id = w.id")
+}
+
+func installFakeBDForDependencyCopy(t *testing.T) string {
+	t.Helper()
+
+	binDir := t.TempDir()
+	statePath := filepath.Join(t.TempDir(), "bd-state")
+	logPath := filepath.Join(t.TempDir(), "bd-queries.log")
+	script := `#!/usr/bin/env bash
+set -u
+if [ "${1:-}" != "sql" ]; then
+  exit 1
+fi
+if [ "${2:-}" = "--csv" ]; then
+  printf 'csv:%s\n' "${3:-}" >> "$BD_QUERY_LOG"
+  printf 'cnt\n0\n'
+  exit 0
+fi
+printf 'write:%s\n' "${2:-}" >> "$BD_QUERY_LOG"
+state=0
+if [ -f "$BD_STATE" ]; then
+  state="$(cat "$BD_STATE")"
+fi
+state=$((state + 1))
+printf '%s\n' "$state" > "$BD_STATE"
+case "$state" in
+  1)
+    printf "Error 1054 (42S22): Unknown column 'd.depends_on_id' in 'field list'\n" >&2
+    exit 1
+    ;;
+  2)
+    printf "Error 3105 (HY000): The value specified for generated column 'depends_on_id' in table 'wisp_dependencies' is not allowed.\n" >&2
+    exit 1
+    ;;
+  3)
+    exit 0
+    ;;
+  *)
+    printf 'unexpected bd sql write call %s\n' "$state" >&2
+    exit 1
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_STATE", statePath)
+	t.Setenv("BD_QUERY_LOG", logPath)
+
+	return logPath
+}
+
+func readDependencyCopyLog(t *testing.T, logPath string) []string {
+	t.Helper()
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	return strings.Split(strings.TrimSpace(string(data)), "\n")
+}
+
+func assertDependencyCopySequence(t *testing.T, lines []string, finalWhere string) {
+	t.Helper()
+
+	if !strings.Contains(lines[0], "INFORMATION_SCHEMA.COLUMNS") || !strings.Contains(lines[0], "wisp_dependencies") {
+		t.Fatalf("first query = %q, want wisp dependency target column probe", lines[0])
+	}
+	if !strings.Contains(lines[1], "INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id") ||
+		!strings.Contains(lines[1], "SELECT d.issue_id, d.depends_on_id") {
+		t.Fatalf("first copy attempt = %q, want legacy source into legacy target", lines[1])
+	}
+	if !strings.Contains(lines[2], "INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id") ||
+		!strings.Contains(lines[2], "COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)") {
+		t.Fatalf("second copy attempt = %q, want split-source retry into legacy target", lines[2])
+	}
+	if !strings.Contains(lines[3], "INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external") ||
+		!strings.Contains(lines[3], "d.depends_on_issue_id") ||
+		!strings.Contains(lines[3], finalWhere) {
+		t.Fatalf("third copy attempt = %q, want generated-target retry into split target columns", lines[3])
 	}
 }

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -16,6 +16,8 @@ import (
 	"time"
 
 	_ "github.com/go-sql-driver/mysql"
+
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 // validDBName matches safe database names (alphanumeric, underscore, hyphen).
@@ -46,6 +48,42 @@ func isTableNotFound(err error) bool {
 	}
 	msg := strings.ToLower(err.Error())
 	return strings.Contains(msg, "table not found") || strings.Contains(msg, "doesn't exist")
+}
+
+func scanStaleCandidatesQuery(splitTarget bool) string {
+	targetExpr := beads.DependencyTargetExpr("d", splitTarget)
+	return fmt.Sprintf(`
+		SELECT COUNT(*) FROM issues i
+		WHERE i.status IN ('open', 'in_progress')
+		AND i.updated_at < ?
+		AND i.priority > 1
+		AND i.issue_type != 'epic'
+		AND i.id NOT IN (
+			SELECT DISTINCT d.issue_id FROM dependencies d
+			INNER JOIN issues dep ON %s = dep.id
+			WHERE dep.status IN ('open', 'in_progress')
+		)
+		AND i.id NOT IN (
+			SELECT DISTINCT %s FROM dependencies d
+			INNER JOIN issues blocker ON d.issue_id = blocker.id
+			WHERE blocker.status IN ('open', 'in_progress')
+		)`, targetExpr, targetExpr)
+}
+
+func retryDependencyTargetQuery(query func(splitTarget bool) error) error {
+	err := query(false)
+	if err != nil && beads.IsDependencyTargetColumnError(err) {
+		return query(true)
+	}
+	return err
+}
+
+func queryScanStaleCandidates(ctx context.Context, db *sql.DB, staleCutoff time.Time) (int, error) {
+	var count int
+	err := retryDependencyTargetQuery(func(splitTarget bool) error {
+		return db.QueryRowContext(ctx, scanStaleCandidatesQuery(splitTarget), staleCutoff).Scan(&count)
+	})
+	return count, err
 }
 
 // DiscoverDatabases queries SHOW DATABASES on the Dolt server and returns
@@ -197,18 +235,48 @@ func OpenDB(host string, port int, dbName string, readTimeout, writeTimeout time
 //
 // Usage:
 //
-//	join, where := parentExcludeJoin(dbName)
+//	join, where := parentExcludeJoin(dbName, splitTarget)
 //	query := fmt.Sprintf("SELECT ... FROM wisps w %s WHERE ... AND %s", dbName, join, where)
-func parentExcludeJoin(dbName string) (joinClause, whereCondition string) {
-	joinClause = `LEFT JOIN (
+func parentExcludeJoin(dbName string, splitTarget bool) (joinClause, whereCondition string) {
+	targetExpr := beads.DependencyTargetExpr("wd", splitTarget)
+	joinClause = fmt.Sprintf(`LEFT JOIN (
 		SELECT DISTINCT wd.issue_id
 		FROM wisp_dependencies wd
-		LEFT JOIN wisps pw ON pw.id = wd.depends_on_id LEFT JOIN issues pi ON pi.id = wd.depends_on_id
+		LEFT JOIN wisps pw ON pw.id = %s LEFT JOIN issues pi ON pi.id = %s
 		WHERE wd.type = 'parent-child'
 		AND (pw.status IN ('open', 'hooked', 'in_progress') OR pi.status IN ('open', 'in_progress'))
-	) open_parent ON open_parent.issue_id = w.id`
+	) open_parent ON open_parent.issue_id = w.id`, targetExpr, targetExpr)
 	whereCondition = "open_parent.issue_id IS NULL"
 	return
+}
+
+func reapCandidatesQuery(dbName string, splitTarget bool) string {
+	parentJoin, parentWhere := parentExcludeJoin(dbName, splitTarget)
+	return fmt.Sprintf(
+		"SELECT COUNT(*) FROM wisps w %s WHERE w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND w.issue_type != 'agent' AND %s",
+		parentJoin, parentWhere)
+}
+
+func reapIDsQuery(dbName string, splitTarget bool) string {
+	parentJoin, parentWhere := parentExcludeJoin(dbName, splitTarget)
+	whereClause := fmt.Sprintf(
+		"w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND w.issue_type != 'agent' AND %s", parentWhere)
+	return fmt.Sprintf(
+		"SELECT w.id FROM wisps w %s WHERE %s LIMIT %d",
+		parentJoin, whereClause, DefaultBatchSize)
+}
+
+func danglingParentQuery(splitTarget bool) string {
+	targetExpr := beads.DependencyTargetExpr("wd", splitTarget)
+	return fmt.Sprintf(`
+		SELECT COUNT(*) FROM wisp_dependencies wd
+		LEFT JOIN wisps pw ON pw.id = %s LEFT JOIN issues pi ON pi.id = %s
+		WHERE wd.type = 'parent-child' AND pw.id IS NULL AND pi.id IS NULL`, targetExpr, targetExpr)
+}
+
+func reverseWispDependencyDeleteQuery(inClause string, splitTarget bool) string {
+	targetExpr := beads.DependencyTargetExpr("wisp_dependencies", splitTarget)
+	return fmt.Sprintf("DELETE FROM wisp_dependencies WHERE %s IN %s", targetExpr, inClause)
 }
 
 // HasReaperSchema checks whether the database has the tables required for reaper
@@ -235,16 +303,14 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 
 	result := &ScanResult{Database: dbName}
 	now := time.Now().UTC()
-	parentJoin, parentWhere := parentExcludeJoin(dbName)
 
 	// Count reap candidates: open wisps past max_age with eligible parent status.
 	// Must match Reap() eligibility semantics exactly, including the exclusion of
 	// agent beads, otherwise scan can report candidates that reap will never close.
 	// Uses LEFT JOIN anti-pattern instead of correlated EXISTS to avoid O(n*m) cost (gt-jd1z).
-	reapQuery := fmt.Sprintf(
-		"SELECT COUNT(*) FROM wisps w %s WHERE w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND w.issue_type != 'agent' AND %s",
-		parentJoin, parentWhere)
-	if err := db.QueryRowContext(ctx, reapQuery, now.Add(-maxAge)).Scan(&result.ReapCandidates); err != nil {
+	if err := retryDependencyTargetQuery(func(splitTarget bool) error {
+		return db.QueryRowContext(ctx, reapCandidatesQuery(dbName, splitTarget), now.Add(-maxAge)).Scan(&result.ReapCandidates)
+	}); err != nil {
 		return nil, fmt.Errorf("count reap candidates: %w", err)
 	}
 
@@ -270,27 +336,14 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 
 	// Count stale issue candidates.
 	// Same caveat: issues/dependencies tables may live on a separate Dolt instance.
-	staleQuery := `
-		SELECT COUNT(*) FROM issues i
-		WHERE i.status IN ('open', 'in_progress')
-		AND i.updated_at < ?
-		AND i.priority > 1
-		AND i.issue_type != 'epic'
-		AND i.id NOT IN (
-			SELECT DISTINCT d.issue_id FROM dependencies d
-			INNER JOIN issues dep ON d.depends_on_id = dep.id
-			WHERE dep.status IN ('open', 'in_progress')
-		)
-		AND i.id NOT IN (
-			SELECT DISTINCT d.depends_on_id FROM dependencies d
-			INNER JOIN issues blocker ON d.issue_id = blocker.id
-			WHERE blocker.status IN ('open', 'in_progress')
-		)`
-	if err := db.QueryRowContext(ctx, staleQuery, now.Add(-staleIssueAge)).Scan(&result.StaleCandidates); err != nil {
+	staleCandidates, err := queryScanStaleCandidates(ctx, db, now.Add(-staleIssueAge))
+	if err != nil {
 		if !isTableNotFound(err) {
 			return nil, fmt.Errorf("count stale candidates: %w", err)
 		}
 		// issues/dependencies table not on this server — skip stale count
+	} else {
+		result.StaleCandidates = staleCandidates
 	}
 
 	// Total open wisps.
@@ -300,12 +353,10 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 	}
 
 	// Anomaly detection: dangling parent references.
-	danglingQuery := `
-		SELECT COUNT(*) FROM wisp_dependencies wd
-		LEFT JOIN wisps pw ON pw.id = wd.depends_on_id LEFT JOIN issues pi ON pi.id = wd.depends_on_id
-		WHERE wd.type = 'parent-child' AND pw.id IS NULL AND pi.id IS NULL`
 	var danglingCount int
-	if err := db.QueryRowContext(ctx, danglingQuery).Scan(&danglingCount); err == nil && danglingCount > 0 {
+	if err := retryDependencyTargetQuery(func(splitTarget bool) error {
+		return db.QueryRowContext(ctx, danglingParentQuery(splitTarget)).Scan(&danglingCount)
+	}); err == nil && danglingCount > 0 {
 		result.Anomalies = append(result.Anomalies, Anomaly{
 			Type:    "dangling_parent_ref",
 			Message: fmt.Sprintf("%d wisp(s) have parent dependency records pointing to purged/missing parents", danglingCount),
@@ -324,17 +375,13 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 	defer cancel()
 
 	cutoff := time.Now().UTC().Add(-maxAge)
-	parentJoin, parentWhere := parentExcludeJoin(dbName)
-	// Exclude agent beads (issue_type='agent') from reaping — they have persistent
-	// identity and should not be closed by the wisp reaper regardless of age.
-	whereClause := fmt.Sprintf(
-		"w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND w.issue_type != 'agent' AND %s", parentWhere)
 
 	result := &ReapResult{Database: dbName, DryRun: dryRun}
 
 	if dryRun {
-		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM wisps w %s WHERE %s", parentJoin, whereClause)
-		if err := db.QueryRowContext(ctx, countQuery, cutoff).Scan(&result.Reaped); err != nil {
+		if err := retryDependencyTargetQuery(func(splitTarget bool) error {
+			return db.QueryRowContext(ctx, reapCandidatesQuery(dbName, splitTarget), cutoff).Scan(&result.Reaped)
+		}); err != nil {
 			return nil, fmt.Errorf("dry-run count: %w", err)
 		}
 		openQuery := "SELECT COUNT(*) FROM wisps WHERE status IN ('open', 'hooked', 'in_progress')"
@@ -354,13 +401,14 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 	// Batch UPDATE: select IDs in chunks, update each chunk.
 	// This avoids holding a write lock on the entire table for minutes.
 	// Uses LEFT JOIN anti-pattern instead of correlated EXISTS to avoid O(n*m) cost (gt-jd1z).
-	idQuery := fmt.Sprintf(
-		"SELECT w.id FROM wisps w %s WHERE %s LIMIT %d",
-		parentJoin, whereClause, DefaultBatchSize)
-
 	totalReaped := 0
 	for {
-		rows, err := db.QueryContext(ctx, idQuery, cutoff)
+		var rows *sql.Rows
+		err := retryDependencyTargetQuery(func(splitTarget bool) error {
+			var queryErr error
+			rows, queryErr = db.QueryContext(ctx, reapIDsQuery(dbName, splitTarget), cutoff)
+			return queryErr
+		})
 		if err != nil {
 			return nil, fmt.Errorf("select reap batch: %w", err)
 		}
@@ -583,17 +631,9 @@ func purgeOldMail(db *sql.DB, dbName string, mailDeleteAge time.Duration, dryRun
 	return totalDeleted, nil
 }
 
-// AutoClose closes issues that have been open with no updates past staleAge.
-// Excludes P0/P1 priority, epics, hooked/pinned issues, standing-order labels,
-// and issues with active dependencies.
-func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (*AutoCloseResult, error) {
-	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
-	defer cancel()
-
-	staleCutoff := time.Now().UTC().Add(-staleAge)
-	result := &AutoCloseResult{Database: dbName, DryRun: dryRun}
-
-	whereClause := fmt.Sprintf(`
+func autoCloseWhereClause(dbName string, splitTarget bool) string {
+	targetExpr := beads.DependencyTargetExpr("d", splitTarget)
+	return fmt.Sprintf(`
 		i.status IN ('open', 'in_progress')
 		AND i.updated_at < ?
 		AND i.priority > 1
@@ -604,19 +644,43 @@ func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (
 		)
 		AND i.id NOT IN (
 			SELECT DISTINCT d.issue_id FROM `+"`%s`"+`.dependencies d
-			INNER JOIN `+"`%s`"+`.issues dep ON d.depends_on_id = dep.id
+			INNER JOIN `+"`%s`"+`.issues dep ON %s = dep.id
 			WHERE dep.status IN ('open', 'in_progress')
 		)
 		AND i.id NOT IN (
-			SELECT DISTINCT d.depends_on_id FROM `+"`%s`"+`.dependencies d
+			SELECT DISTINCT %s FROM `+"`%s`"+`.dependencies d
 			INNER JOIN `+"`%s`"+`.issues blocker ON d.issue_id = blocker.id
 			WHERE blocker.status IN ('open', 'in_progress')
-		)`, dbName, dbName, dbName, dbName, dbName)
+		)`, dbName, dbName, dbName, targetExpr, targetExpr, dbName, dbName)
+}
+
+func autoCloseSelectQuery(dbName string, splitTarget bool) string {
+	return fmt.Sprintf("SELECT i.id, i.title, i.updated_at FROM issues i WHERE %s", autoCloseWhereClause(dbName, splitTarget))
+}
+
+func queryAutoCloseCandidates(ctx context.Context, db *sql.DB, dbName string, staleCutoff time.Time) (*sql.Rows, error) {
+	var rows *sql.Rows
+	err := retryDependencyTargetQuery(func(splitTarget bool) error {
+		var queryErr error
+		rows, queryErr = db.QueryContext(ctx, autoCloseSelectQuery(dbName, splitTarget), staleCutoff)
+		return queryErr
+	})
+	return rows, err
+}
+
+// AutoClose closes issues that have been open with no updates past staleAge.
+// Excludes P0/P1 priority, epics, hooked/pinned issues, standing-order labels,
+// and issues with active dependencies.
+func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (*AutoCloseResult, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), DefaultQueryTimeout)
+	defer cancel()
+
+	staleCutoff := time.Now().UTC().Add(-staleAge)
+	result := &AutoCloseResult{Database: dbName, DryRun: dryRun}
 
 	// Two-step SELECT-then-UPDATE to avoid self-referencing subquery in UPDATE,
 	// which is not valid MySQL (Error 1093) and fragile in Dolt (dolthub/dolt#10600).
-	selectQuery := fmt.Sprintf("SELECT i.id, i.title, i.updated_at FROM issues i WHERE %s", whereClause)
-	rows, err := db.QueryContext(ctx, selectQuery, staleCutoff)
+	rows, err := queryAutoCloseCandidates(ctx, db, dbName, staleCutoff)
 	if err != nil {
 		if isTableNotFound(err) {
 			return result, nil // issues/dependencies not on this server
@@ -747,8 +811,10 @@ func batchDeleteRows(ctx context.Context, db *sql.DB, idQuery string, cutoffArg 
 		}
 
 		// Clean up reverse dependency references to prevent dangling parent refs.
-		delReverse := fmt.Sprintf("DELETE FROM wisp_dependencies WHERE depends_on_id IN %s", inClause)
-		if _, err := db.ExecContext(ctx, delReverse, args...); err != nil {
+		if err := retryDependencyTargetQuery(func(splitTarget bool) error {
+			_, execErr := db.ExecContext(ctx, reverseWispDependencyDeleteQuery(inClause, splitTarget), args...)
+			return execErr
+		}); err != nil {
 			// Non-fatal.
 		}
 

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -2,7 +2,6 @@ package reaper
 
 import (
 	"fmt"
-	"os"
 	"strings"
 	"testing"
 )
@@ -52,7 +51,7 @@ func TestFormatJSON(t *testing.T) {
 }
 
 func TestParentExcludeJoin(t *testing.T) {
-	joinClause, whereCondition := parentExcludeJoin("testdb")
+	joinClause, whereCondition := parentExcludeJoin("testdb", false)
 
 	// JOIN clause should reference the correct database.
 	if joinClause == "" {
@@ -89,7 +88,7 @@ func TestParentExcludeJoin(t *testing.T) {
 func TestReapQueryNoDatabaseNameInjection(t *testing.T) {
 	// Reproduce the exact Sprintf call from Reap() to verify no dbName injection.
 	dbName := "gt"
-	parentJoin, parentWhere := parentExcludeJoin(dbName)
+	parentJoin, parentWhere := parentExcludeJoin(dbName, false)
 	whereClause := fmt.Sprintf(
 		"w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND %s", parentWhere)
 
@@ -108,6 +107,48 @@ func TestReapQueryNoDatabaseNameInjection(t *testing.T) {
 	}
 	if !strings.Contains(idQuery, fmt.Sprintf("LIMIT %d", DefaultBatchSize)) {
 		t.Errorf("Reap idQuery should end with LIMIT %d, got: %s", DefaultBatchSize, idQuery)
+	}
+}
+
+func TestParentExcludeJoinUsesSplitWispDependencyTarget(t *testing.T) {
+	joinClause, _ := parentExcludeJoin("testdb", true)
+	targetExpr := "COALESCE(wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external)"
+
+	if strings.Contains(joinClause, "wd.depends_on_id") {
+		t.Fatalf("split parent join should not use legacy depends_on_id column:\n%s", joinClause)
+	}
+	if !strings.Contains(joinClause, "LEFT JOIN wisps pw ON pw.id = "+targetExpr) {
+		t.Fatalf("split parent join should use %s for wisp parents:\n%s", targetExpr, joinClause)
+	}
+	if !strings.Contains(joinClause, "LEFT JOIN issues pi ON pi.id = "+targetExpr) {
+		t.Fatalf("split parent join should use %s for issue parents:\n%s", targetExpr, joinClause)
+	}
+}
+
+func TestDanglingParentQueryUsesSplitWispDependencyTarget(t *testing.T) {
+	query := danglingParentQuery(true)
+	targetExpr := "COALESCE(wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external)"
+
+	if strings.Contains(query, "wd.depends_on_id") {
+		t.Fatalf("split dangling-parent query should not use legacy depends_on_id column:\n%s", query)
+	}
+	if !strings.Contains(query, "LEFT JOIN wisps pw ON pw.id = "+targetExpr) {
+		t.Fatalf("split dangling-parent query should use %s for wisp parents:\n%s", targetExpr, query)
+	}
+	if !strings.Contains(query, "LEFT JOIN issues pi ON pi.id = "+targetExpr) {
+		t.Fatalf("split dangling-parent query should use %s for issue parents:\n%s", targetExpr, query)
+	}
+}
+
+func TestReverseWispDependencyDeleteQueryUsesSplitTarget(t *testing.T) {
+	query := reverseWispDependencyDeleteQuery("(?,?)", true)
+	targetExpr := "COALESCE(wisp_dependencies.depends_on_issue_id, wisp_dependencies.depends_on_wisp_id, wisp_dependencies.depends_on_external)"
+
+	if strings.Contains(query, "depends_on_id") {
+		t.Fatalf("split reverse dependency cleanup should not use legacy depends_on_id column:\n%s", query)
+	}
+	if !strings.Contains(query, targetExpr+" IN (?,?)") {
+		t.Fatalf("split reverse dependency cleanup should match through %s:\n%s", targetExpr, query)
 	}
 }
 
@@ -230,19 +271,70 @@ func TestReapExcludesAgentBeads(t *testing.T) {
 // predicate as Reap() for stale open wisps. If Scan counts agent beads but Reap
 // excludes them, the operator sees scan>0 and reap=0 for the same cutoff.
 func TestScanExcludesAgentBeads(t *testing.T) {
-	sourcePath := "reaper.go"
-	data, err := os.ReadFile(sourcePath)
+	query := reapCandidatesQuery("gt", false)
+	if !strings.Contains(query, "w.issue_type != 'agent'") {
+		t.Fatalf("expected Scan() eligibility query to exclude agent beads:\n%s", query)
+	}
+}
+
+func TestScanStaleCandidatesQueryUsesSplitDependencyTarget(t *testing.T) {
+	query := scanStaleCandidatesQuery(true)
+	targetExpr := "COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)"
+
+	if strings.Contains(query, "d.depends_on_id") {
+		t.Fatalf("split schema query should not use legacy depends_on_id column:\n%s", query)
+	}
+	if !strings.Contains(query, "INNER JOIN issues dep ON "+targetExpr+" = dep.id") {
+		t.Fatalf("split schema query should join active dependencies through %s:\n%s", targetExpr, query)
+	}
+	if !strings.Contains(query, "SELECT DISTINCT "+targetExpr+" FROM dependencies d") {
+		t.Fatalf("split schema query should exclude issues that are active dependency targets through %s:\n%s", targetExpr, query)
+	}
+}
+
+func TestRetryDependencyTargetQueryFallsBackToSplitTarget(t *testing.T) {
+	var calls []bool
+	err := retryDependencyTargetQuery(func(splitTarget bool) error {
+		calls = append(calls, splitTarget)
+		if !splitTarget {
+			return fmt.Errorf(`query failed: unknown column "d.depends_on_id"`)
+		}
+		return nil
+	})
 	if err != nil {
-		t.Fatalf("read %s: %v", sourcePath, err)
+		t.Fatalf("retryDependencyTargetQuery returned error: %v", err)
 	}
-	source := string(data)
-	scanStart := strings.Index(source, "func Scan(")
-	reapStart := strings.Index(source, "func Reap(")
-	if scanStart == -1 || reapStart == -1 || reapStart <= scanStart {
-		t.Fatalf("could not isolate Scan() body in %s", sourcePath)
+	if len(calls) != 2 || calls[0] || !calls[1] {
+		t.Fatalf("retryDependencyTargetQuery calls = %v, want [false true]", calls)
 	}
-	scanBody := source[scanStart:reapStart]
-	if !strings.Contains(scanBody, "w.issue_type != 'agent'") {
-		t.Fatalf("expected Scan() eligibility to exclude agent beads, scan body was:\n%s", scanBody)
+}
+
+func TestRetryDependencyTargetQueryDoesNotRetryUnrelatedError(t *testing.T) {
+	var calls []bool
+	wantErr := fmt.Errorf("connection refused")
+	err := retryDependencyTargetQuery(func(splitTarget bool) error {
+		calls = append(calls, splitTarget)
+		return wantErr
+	})
+	if err != wantErr {
+		t.Fatalf("retryDependencyTargetQuery error = %v, want %v", err, wantErr)
+	}
+	if len(calls) != 1 || calls[0] {
+		t.Fatalf("retryDependencyTargetQuery calls = %v, want [false]", calls)
+	}
+}
+
+func TestAutoCloseWhereClauseUsesSplitDependencyTarget(t *testing.T) {
+	whereClause := autoCloseWhereClause("hq", true)
+	targetExpr := "COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)"
+
+	if strings.Contains(whereClause, "d.depends_on_id") {
+		t.Fatalf("split schema where clause should not use legacy depends_on_id column:\n%s", whereClause)
+	}
+	if !strings.Contains(whereClause, "INNER JOIN `hq`.issues dep ON "+targetExpr+" = dep.id") {
+		t.Fatalf("split schema where clause should join active dependencies through %s:\n%s", targetExpr, whereClause)
+	}
+	if !strings.Contains(whereClause, "SELECT DISTINCT "+targetExpr+" FROM `hq`.dependencies d") {
+		t.Fatalf("split schema where clause should exclude active dependency targets through %s:\n%s", targetExpr, whereClause)
 	}
 }

--- a/plugins/dolt-snapshots/main.go
+++ b/plugins/dolt-snapshots/main.go
@@ -31,6 +31,17 @@ var (
 	multiDash  = regexp.MustCompile(`-{2,}`)
 )
 
+// Keep dependency-target schema constants and helpers in sync with
+// internal/beads/dependency_schema.go. This plugin is a separate module, so it
+// cannot import gastown's internal package directly.
+const dependencyTargetAlias = "depends_on_id"
+
+var splitDependencyTargetColumns = []string{
+	"depends_on_issue_id",
+	"depends_on_wisp_id",
+	"depends_on_external",
+}
+
 // route represents a single entry from routes.jsonl.
 type route struct {
 	Prefix string `json:"prefix"`
@@ -382,24 +393,19 @@ func findConvoysNeedingSnapshots(db *sql.DB) ([]convoyRow, error) {
 // discoverConvoyDatabases finds which rig databases a convoy touches
 // by looking at its tracked issues' prefixes.
 func discoverConvoyDatabases(db *sql.DB, convoyID string, databases []string, routes map[string]string) ([]string, error) {
-	query := `
-		SELECT DISTINCT d.depends_on_id
-		FROM hq.dependencies d
-		WHERE d.issue_id = ? AND d.type = 'tracks'
-	`
-	rows, err := db.Query(query, convoyID)
+	dependencyIDs, err := discoverConvoyDependencyIDs(db, convoyID, false)
 	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	dbSet := make(map[string]bool)
-	for rows.Next() {
-		var depID string
-		if err := rows.Scan(&depID); err != nil {
+		if !isDependencyTargetColumnError(err) {
 			return nil, err
 		}
+		dependencyIDs, err = discoverConvoyDependencyIDs(db, convoyID, true)
+		if err != nil {
+			return nil, err
+		}
+	}
 
+	dbSet := make(map[string]bool)
+	for _, depID := range dependencyIDs {
 		dbName := resolveDependencyDB(depID, routes)
 		if dbName == "" {
 			continue
@@ -418,7 +424,82 @@ func discoverConvoyDatabases(db *sql.DB, convoyID string, databases []string, ro
 	for d := range dbSet {
 		result = append(result, d)
 	}
-	return result, rows.Err()
+	return result, nil
+}
+
+func discoverConvoyDependencyIDs(db *sql.DB, convoyID string, splitTarget bool) ([]string, error) {
+	query := fmt.Sprintf(`
+		SELECT DISTINCT %s
+		FROM hq.dependencies d
+		WHERE d.issue_id = ? AND d.type = 'tracks'
+	`, dependencyTargetSelectExpr("d", splitTarget))
+	rows, err := db.Query(query, convoyID)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var dependencyIDs []string
+	for rows.Next() {
+		var depID string
+		if err := rows.Scan(&depID); err != nil {
+			return nil, err
+		}
+		dependencyIDs = append(dependencyIDs, depID)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return dependencyIDs, nil
+}
+
+func dependencyTargetSelectExpr(tableAlias string, splitTarget bool) string {
+	expr := dependencyTargetExpr(tableAlias, splitTarget)
+	if !splitTarget {
+		return expr
+	}
+	return expr + " AS " + dependencyTargetAlias
+}
+
+func dependencyTargetExpr(tableAlias string, splitTarget bool) string {
+	if !splitTarget {
+		return qualifyDependencyColumn(tableAlias, dependencyTargetAlias)
+	}
+
+	columns := make([]string, 0, len(splitDependencyTargetColumns))
+	for _, column := range splitDependencyTargetColumns {
+		columns = append(columns, qualifyDependencyColumn(tableAlias, column))
+	}
+	return "COALESCE(" + strings.Join(columns, ", ") + ")"
+}
+
+func qualifyDependencyColumn(tableAlias, column string) string {
+	if tableAlias == "" {
+		return column
+	}
+	return tableAlias + "." + column
+}
+
+func isDependencyTargetColumnError(err error) bool {
+	if err == nil {
+		return false
+	}
+	msg := strings.ToLower(err.Error())
+	missingColumn := strings.Contains(msg, "unknown column") ||
+		strings.Contains(msg, "could not be found") ||
+		strings.Contains(msg, "no such column")
+	if !missingColumn {
+		return false
+	}
+	if strings.Contains(msg, dependencyTargetAlias) {
+		return true
+	}
+	for _, column := range splitDependencyTargetColumns {
+		if strings.Contains(msg, column) {
+			return true
+		}
+	}
+	return false
 }
 
 // resolveDependencyDB extracts the database name from a dependency ID.

--- a/plugins/dolt-snapshots/main_test.go
+++ b/plugins/dolt-snapshots/main_test.go
@@ -1,8 +1,16 @@
 package main
 
 import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
+	"errors"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
+	"strings"
+	"sync"
 	"testing"
 )
 
@@ -93,8 +101,8 @@ func TestIsSystemDB(t *testing.T) {
 		{"lora_forge", false},
 		{"node0", false},
 		// Edge cases: names that start with system prefixes but aren't
-		{"testdb", false},        // exactly "testdb" with no underscore
-		{"beads", false},         // exactly "beads"
+		{"testdb", false},           // exactly "testdb" with no underscore
+		{"beads", false},            // exactly "beads"
 		{"beads_production", false}, // doesn't match beads_t or beads_pt
 	}
 
@@ -279,6 +287,48 @@ func TestResolveDependencyDB_EmptyRoutes(t *testing.T) {
 	}
 }
 
+func TestDiscoverConvoyDatabasesRetriesSplitDependencyTargetSchema(t *testing.T) {
+	script := &dependencyQueryScript{
+		legacyErr: errors.New("Error 1054 (42S22): Unknown column 'd.depends_on_id' in 'field list'"),
+		rows: [][]driver.Value{
+			{"external:petals:pe-123"},
+			{"lf-456"},
+			{"zz-ignored"},
+		},
+	}
+	db := sql.OpenDB(dependencyQueryConnector{script: script})
+	defer db.Close()
+	db.SetMaxOpenConns(1)
+
+	got, err := discoverConvoyDatabases(db, "hq-cv-1", []string{"petals", "lora_forge", "node0"}, map[string]string{
+		"lf": "lora_forge",
+	})
+	if err != nil {
+		t.Fatalf("discoverConvoyDatabases() error = %v", err)
+	}
+
+	want := map[string]bool{"petals": true, "lora_forge": true}
+	if len(got) != len(want) {
+		t.Fatalf("discoverConvoyDatabases() = %v, want entries %v", got, want)
+	}
+	for _, dbName := range got {
+		if !want[dbName] {
+			t.Fatalf("discoverConvoyDatabases() returned unexpected database %q in %v", dbName, got)
+		}
+	}
+
+	queries := script.Queries()
+	if len(queries) != 2 {
+		t.Fatalf("queries = %v, want legacy query and split retry", queries)
+	}
+	if !strings.Contains(queries[0], "d.depends_on_id") {
+		t.Fatalf("legacy query = %q, want d.depends_on_id", queries[0])
+	}
+	if !strings.Contains(queries[1], "COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) AS depends_on_id") {
+		t.Fatalf("split query = %q, want split target COALESCE", queries[1])
+	}
+}
+
 func TestResolveHost(t *testing.T) {
 	// Flag takes precedence
 	if got := resolveHost("192.168.1.1"); got != "192.168.1.1" {
@@ -297,6 +347,93 @@ func TestResolveHost(t *testing.T) {
 	if got := resolveHost(""); got != "127.0.0.1" {
 		t.Errorf("resolveHost default = %q, want 127.0.0.1", got)
 	}
+}
+
+type dependencyQueryConnector struct {
+	script *dependencyQueryScript
+}
+
+func (c dependencyQueryConnector) Connect(context.Context) (driver.Conn, error) {
+	return dependencyQueryConn{script: c.script}, nil
+}
+
+func (c dependencyQueryConnector) Driver() driver.Driver {
+	return dependencyQueryDriver{}
+}
+
+type dependencyQueryDriver struct{}
+
+func (dependencyQueryDriver) Open(string) (driver.Conn, error) {
+	return nil, errors.New("use dependencyQueryConnector")
+}
+
+type dependencyQueryScript struct {
+	mu        sync.Mutex
+	queries   []string
+	legacyErr error
+	rows      [][]driver.Value
+}
+
+func (s *dependencyQueryScript) Queries() []string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return append([]string(nil), s.queries...)
+}
+
+type dependencyQueryConn struct {
+	script *dependencyQueryScript
+}
+
+func (dependencyQueryConn) Prepare(string) (driver.Stmt, error) {
+	return nil, errors.New("prepare is not implemented")
+}
+
+func (dependencyQueryConn) Close() error {
+	return nil
+}
+
+func (dependencyQueryConn) Begin() (driver.Tx, error) {
+	return nil, errors.New("transactions are not implemented")
+}
+
+func (c dependencyQueryConn) QueryContext(_ context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	if len(args) != 1 || args[0].Value != "hq-cv-1" {
+		return nil, fmt.Errorf("unexpected query args: %#v", args)
+	}
+
+	c.script.mu.Lock()
+	defer c.script.mu.Unlock()
+	c.script.queries = append(c.script.queries, query)
+
+	if strings.Contains(query, "d.depends_on_id") {
+		return nil, c.script.legacyErr
+	}
+	if strings.Contains(query, "COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external)") {
+		return &dependencyRows{rows: c.script.rows}, nil
+	}
+	return nil, fmt.Errorf("unexpected query: %s", query)
+}
+
+type dependencyRows struct {
+	rows [][]driver.Value
+	i    int
+}
+
+func (*dependencyRows) Columns() []string {
+	return []string{dependencyTargetAlias}
+}
+
+func (*dependencyRows) Close() error {
+	return nil
+}
+
+func (r *dependencyRows) Next(dest []driver.Value) error {
+	if r.i >= len(r.rows) {
+		return io.EOF
+	}
+	copy(dest, r.rows[r.i])
+	r.i++
+	return nil
 }
 
 func TestResolvePort(t *testing.T) {


### PR DESCRIPTION
Follow-up to #4138, created by the `/adopt-pr` workflow after the original PR was closed before the workflow could safely update it.

Original PR: https://github.com/gastownhall/gastown/pull/4138
Original title: Fix release beads schema and config handling
Original state: CLOSED, unmerged
Configured workflow base: release/v1.2.0
Original GitHub base: release/v1.2.0
Base mismatch: none

PR #4139 already carried the original #4138 release beads schema/config change set into `release/v1.2.0`. This follow-up carries the maintainer-side adoption fixes found during review:

- Adds split/legacy dependency target helpers and coverage.
- Makes wisp migration and doctor dependency copies handle generated `depends_on_id` write failures safely.
- Updates compact, convoy, reaper, doctor, doltserver, and `plugins/dolt-snapshots` dependency handling for split-schema databases.
- Preserves valid issue, wisp, and external dependency targets during cleanup.

Validation before opening this PR:

- `env -u TMPDIR go test ./internal/beads ./internal/cmd ./internal/doltserver ./internal/reaper ./internal/doctor`
- `go test ./...` in `plugins/dolt-snapshots`

Final adopted head: `a505f51aad7716185a3d6708847324d25b495e88`
