### PR TITLE
Follow-up to #4151: reject unsupported bd versions

### DIFF
--- a/internal/cmd/beads_version.go
+++ b/internal/cmd/beads_version.go
@@ -2,6 +2,7 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"sync"
 
@@ -11,24 +12,61 @@ import (
 var (
 	cachedVersionCheckResult error
 	versionCheckOnce         sync.Once
+	checkBeads               = deps.CheckBeads
 )
+
+type beadsVersionError struct {
+	status  deps.BeadsStatus
+	version string
+	err     error
+}
+
+func (e *beadsVersionError) Error() string {
+	return e.err.Error()
+}
+
+func (e *beadsVersionError) Unwrap() error {
+	return e.err
+}
+
+func isUnsupportedNewBeadsVersion(err error) bool {
+	var versionErr *beadsVersionError
+	return errors.As(err, &versionErr) && versionErr.status == deps.BeadsTooNew
+}
 
 // CheckBeadsVersion verifies that the installed beads version meets the minimum requirement.
 // Returns nil if the version is sufficient, or an error with details if not.
 // The check is performed only once per process execution.
 func CheckBeadsVersion() error {
 	versionCheckOnce.Do(func() {
-		status, version := deps.CheckBeads()
+		status, version := checkBeads()
 		switch status {
 		case deps.BeadsOK:
 			cachedVersionCheckResult = nil
 		case deps.BeadsUnknown:
-			cachedVersionCheckResult = fmt.Errorf("beads (bd) version could not be determined\n\nTry reinstalling: go install %s", deps.BeadsInstallPath)
+			cachedVersionCheckResult = &beadsVersionError{
+				status: status,
+				err:    fmt.Errorf("beads (bd) version could not be determined\n\nTry reinstalling: go install %s", deps.BeadsInstallPath),
+			}
 		case deps.BeadsNotFound:
-			cachedVersionCheckResult = fmt.Errorf("beads (bd) not found in PATH\n\nInstall with: go install %s", deps.BeadsInstallPath)
+			cachedVersionCheckResult = &beadsVersionError{
+				status: status,
+				err:    fmt.Errorf("beads (bd) not found in PATH\n\nInstall with: go install %s", deps.BeadsInstallPath),
+			}
 		case deps.BeadsTooOld:
-			cachedVersionCheckResult = fmt.Errorf("beads %s is required, but %s is installed\n\nUpgrade: go install %s",
-				deps.MinBeadsVersion, version, deps.BeadsInstallPath)
+			cachedVersionCheckResult = &beadsVersionError{
+				status:  status,
+				version: version,
+				err: fmt.Errorf("beads %s is required, but %s is installed\n\nUpgrade: go install %s",
+					deps.MinBeadsVersion, version, deps.BeadsInstallPath),
+			}
+		case deps.BeadsTooNew:
+			cachedVersionCheckResult = &beadsVersionError{
+				status:  status,
+				version: version,
+				err: fmt.Errorf("beads %s is installed, but this Gas Town release supports at most %s\n\nDowngrade: go install %s",
+					version, deps.MaxBeadsVersion, deps.BeadsInstallPath),
+			}
 		}
 	})
 	return cachedVersionCheckResult

--- a/internal/cmd/beads_version.go
+++ b/internal/cmd/beads_version.go
@@ -16,9 +16,8 @@ var (
 )
 
 type beadsVersionError struct {
-	status  deps.BeadsStatus
-	version string
-	err     error
+	status deps.BeadsStatus
+	err    error
 }
 
 func (e *beadsVersionError) Error() string {
@@ -55,15 +54,13 @@ func CheckBeadsVersion() error {
 			}
 		case deps.BeadsTooOld:
 			cachedVersionCheckResult = &beadsVersionError{
-				status:  status,
-				version: version,
+				status: status,
 				err: fmt.Errorf("beads %s is required, but %s is installed\n\nUpgrade: go install %s",
 					deps.MinBeadsVersion, version, deps.BeadsInstallPath),
 			}
 		case deps.BeadsTooNew:
 			cachedVersionCheckResult = &beadsVersionError{
-				status:  status,
-				version: version,
+				status: status,
 				err: fmt.Errorf("beads %s is installed, but this Gas Town release supports at most %s\n\nDowngrade: go install %s",
 					version, deps.MaxBeadsVersion, deps.BeadsInstallPath),
 			}

--- a/internal/cmd/beads_version_test.go
+++ b/internal/cmd/beads_version_test.go
@@ -1,0 +1,95 @@
+package cmd
+
+import (
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/deps"
+)
+
+func resetBeadsVersionCheckForTest(t *testing.T, fn func() (deps.BeadsStatus, string)) {
+	t.Helper()
+
+	origCheckBeads := checkBeads
+	origResult := cachedVersionCheckResult
+	origOnce := versionCheckOnce
+
+	checkBeads = fn
+	cachedVersionCheckResult = nil
+	versionCheckOnce = sync.Once{}
+
+	t.Cleanup(func() {
+		checkBeads = origCheckBeads
+		cachedVersionCheckResult = origResult
+		versionCheckOnce = origOnce
+	})
+}
+
+func TestCheckBeadsVersionRejectsVersionsAboveSupportedMaximum(t *testing.T) {
+	resetBeadsVersionCheckForTest(t, func() (deps.BeadsStatus, string) {
+		return deps.BeadsTooNew, "1.0.5"
+	})
+
+	err := CheckBeadsVersion()
+	if err == nil {
+		t.Fatal("CheckBeadsVersion returned nil for a too-new bd version")
+	}
+	if !isUnsupportedNewBeadsVersion(err) {
+		t.Fatalf("expected unsupported-new marker for error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "supports at most 1.0.4") {
+		t.Fatalf("error %q does not mention supported maximum", err)
+	}
+	if !strings.Contains(err.Error(), deps.BeadsInstallPath) {
+		t.Fatalf("error %q does not include pinned reinstall command", err)
+	}
+}
+
+func TestCheckBeadsVersionDoesNotHardFailOlderVersionErrors(t *testing.T) {
+	resetBeadsVersionCheckForTest(t, func() (deps.BeadsStatus, string) {
+		return deps.BeadsTooOld, "1.0.3"
+	})
+
+	err := CheckBeadsVersion()
+	if err == nil {
+		t.Fatal("CheckBeadsVersion returned nil for a too-old bd version")
+	}
+	if isUnsupportedNewBeadsVersion(err) {
+		t.Fatalf("too-old error should remain warning-only, got unsupported-new marker: %v", err)
+	}
+}
+
+func TestPersistentPreRunFailsForBdAboveSupportedMaximum(t *testing.T) {
+	resetBeadsVersionCheckForTest(t, func() (deps.BeadsStatus, string) {
+		return deps.BeadsTooNew, "1.0.5"
+	})
+
+	for _, use := range []string{"ready", "version", "prime"} {
+		t.Run(use, func(t *testing.T) {
+			err := persistentPreRun(&cobra.Command{Use: use}, nil)
+			if err == nil {
+				t.Fatal("persistentPreRun returned nil for a too-new bd version")
+			}
+			if !isUnsupportedNewBeadsVersion(err) {
+				t.Fatalf("persistentPreRun returned non-fatal beads error marker: %v", err)
+			}
+		})
+	}
+}
+
+func TestPersistentPreRunSkipsBdVersionCheckForHotPathCommands(t *testing.T) {
+	called := false
+	resetBeadsVersionCheckForTest(t, func() (deps.BeadsStatus, string) {
+		called = true
+		return deps.BeadsTooNew, "1.0.5"
+	})
+
+	if err := persistentPreRun(&cobra.Command{Use: "status-line"}, nil); err != nil {
+		t.Fatalf("persistentPreRun(status-line): %v", err)
+	}
+	if called {
+		t.Fatal("status-line should not run bd version checks")
+	}
+}

--- a/internal/cmd/beads_version_test.go
+++ b/internal/cmd/beads_version_test.go
@@ -13,8 +13,6 @@ func resetBeadsVersionCheckForTest(t *testing.T, fn func() (deps.BeadsStatus, st
 	t.Helper()
 
 	origCheckBeads := checkBeads
-	origResult := cachedVersionCheckResult
-	origOnce := versionCheckOnce
 
 	checkBeads = fn
 	cachedVersionCheckResult = nil
@@ -22,8 +20,8 @@ func resetBeadsVersionCheckForTest(t *testing.T, fn func() (deps.BeadsStatus, st
 
 	t.Cleanup(func() {
 		checkBeads = origCheckBeads
-		cachedVersionCheckResult = origResult
-		versionCheckOnce = origOnce
+		cachedVersionCheckResult = nil
+		versionCheckOnce = sync.Once{}
 	})
 }
 
@@ -66,7 +64,7 @@ func TestPersistentPreRunFailsForBdAboveSupportedMaximum(t *testing.T) {
 		return deps.BeadsTooNew, "1.0.5"
 	})
 
-	for _, use := range []string{"ready", "version", "prime"} {
+	for _, use := range []string{"ready"} {
 		t.Run(use, func(t *testing.T) {
 			err := persistentPreRun(&cobra.Command{Use: use}, nil)
 			if err == nil {
@@ -76,6 +74,44 @@ func TestPersistentPreRunFailsForBdAboveSupportedMaximum(t *testing.T) {
 				t.Fatalf("persistentPreRun returned non-fatal beads error marker: %v", err)
 			}
 		})
+	}
+}
+
+func TestPersistentPreRunAllowsBeadsExemptCommandsWithBdAboveSupportedMaximum(t *testing.T) {
+	for _, use := range []string{"version", "prime", "install", "doctor", "health", "config"} {
+		t.Run(use, func(t *testing.T) {
+			called := false
+			resetBeadsVersionCheckForTest(t, func() (deps.BeadsStatus, string) {
+				called = true
+				return deps.BeadsTooNew, "1.0.5"
+			})
+
+			if err := persistentPreRun(&cobra.Command{Use: use}, nil); err != nil {
+				t.Fatalf("persistentPreRun(%s): %v", use, err)
+			}
+			if called {
+				t.Fatalf("%s should not run bd version checks", use)
+			}
+		})
+	}
+}
+
+func TestPersistentPreRunAllowsRoleCommandsWithBdAboveSupportedMaximum(t *testing.T) {
+	called := false
+	resetBeadsVersionCheckForTest(t, func() (deps.BeadsStatus, string) {
+		called = true
+		return deps.BeadsTooNew, "1.0.5"
+	})
+
+	roleCmd := &cobra.Command{Use: "role"}
+	childCmd := &cobra.Command{Use: "inspect"}
+	roleCmd.AddCommand(childCmd)
+
+	if err := persistentPreRun(childCmd, nil); err != nil {
+		t.Fatalf("persistentPreRun(role inspect): %v", err)
+	}
+	if called {
+		t.Fatal("role commands should not run bd version checks")
 	}
 }
 

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -143,11 +143,7 @@ func runInstall(cmd *cobra.Command, args []string) error {
 			"Use --force to override (not recommended).", absPath, existingRoot)
 	}
 
-	// Ensure beads (bd) is available before proceeding
 	if !installNoBeads {
-		if err := deps.EnsureBeads(true); err != nil {
-			return fmt.Errorf("beads dependency check failed: %w", err)
-		}
 		if err := ensureInstallDoltReady(); err != nil {
 			return err
 		}
@@ -193,6 +189,12 @@ func runInstall(cmd *cobra.Command, args []string) error {
 				}
 				return fmt.Errorf("%s", msg)
 			}
+		}
+
+		// Ensure beads (bd) is available after Dolt preflights but before
+		// creating files, so install recovery errors remain specific and retryable.
+		if err := deps.EnsureBeads(true); err != nil {
+			return fmt.Errorf("beads dependency check failed: %w", err)
 		}
 	}
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -79,6 +79,17 @@ var beadsExemptCommands = map[string]bool{
 	"heartbeat":     true, // Heartbeat state update — must be fast and dependency-free
 }
 
+// Commands exempt even from the too-new bd hard guard. These paths are either
+// high-frequency UI hooks or emergency controls that must avoid subprocess work.
+var beadsTooNewExemptCommands = map[string]bool{
+	"status-line": true,
+	"signal":      true,
+	"metrics":     true,
+	"estop":       true,
+	"thaw":        true,
+	"heartbeat":   true,
+}
+
 // Commands exempt from the town root branch warning.
 // These are commands that help fix the problem or are diagnostic.
 var branchCheckExemptCommands = map[string]bool{
@@ -147,15 +158,23 @@ func persistentPreRun(cmd *cobra.Command, args []string) error {
 	// determine liveness without PID signal probing.
 	touchPolecatHeartbeat()
 
-	// Skip beads check for exempt commands
+	var beadsVersionErr error
+	if !isCommandOrAncestorExempt(cmd, beadsTooNewExemptCommands) {
+		beadsVersionErr = CheckBeadsVersion()
+		if isUnsupportedNewBeadsVersion(beadsVersionErr) {
+			return beadsVersionErr
+		}
+	}
+
+	// Skip warning-only beads checks for exempt commands.
 	if beadsExempt || isRoleCommand(cmd) {
 		return nil
 	}
 
-	// Check beads version (non-blocking - warn only)
-	if err := CheckBeadsVersion(); err != nil {
+	// Check beads version (missing/old/unknown is non-blocking - warn only)
+	if beadsVersionErr != nil {
 		fmt.Fprintf(os.Stderr, "\n%s beads (bd) version issue:\n", style.Bold.Render("⚠️  WARNING:"))
-		fmt.Fprintf(os.Stderr, "   %v\n", err)
+		fmt.Fprintf(os.Stderr, "   %v\n", beadsVersionErr)
 		fmt.Fprintf(os.Stderr, "   Run %s for details.\n\n", style.Dim.Render("gt doctor"))
 	}
 	return nil

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -141,6 +141,7 @@ func persistentPreRun(cmd *cobra.Command, args []string) error {
 
 	beadsExempt := isCommandOrAncestorExempt(cmd, beadsExemptCommands)
 	branchExempt := isCommandOrAncestorExempt(cmd, branchCheckExemptCommands)
+	roleCommand := isRoleCommand(cmd)
 
 	// Check for stale binary (warning only, doesn't block)
 	if !beadsExempt {
@@ -159,7 +160,7 @@ func persistentPreRun(cmd *cobra.Command, args []string) error {
 	touchPolecatHeartbeat()
 
 	var beadsVersionErr error
-	if !isCommandOrAncestorExempt(cmd, beadsTooNewExemptCommands) {
+	if !beadsExempt && !roleCommand && !isCommandOrAncestorExempt(cmd, beadsTooNewExemptCommands) {
 		beadsVersionErr = CheckBeadsVersion()
 		if isUnsupportedNewBeadsVersion(beadsVersionErr) {
 			return beadsVersionErr
@@ -167,7 +168,7 @@ func persistentPreRun(cmd *cobra.Command, args []string) error {
 	}
 
 	// Skip warning-only beads checks for exempt commands.
-	if beadsExempt || isRoleCommand(cmd) {
+	if beadsExempt || roleCommand {
 		return nil
 	}
 

--- a/internal/deps/beads.go
+++ b/internal/deps/beads.go
@@ -18,9 +18,14 @@ import (
 // Update this when Gas Town requires new beads features.
 const MinBeadsVersion = "1.0.4"
 
+// MaxBeadsVersion is the newest beads version this Gas Town release is known
+// to support. Newer bd releases can change the Dolt schema before Gastown has
+// been updated for it, so fail fast instead of surfacing late SQL errors.
+const MaxBeadsVersion = "1.0.4"
+
 // BeadsInstallPath is the go install path for the bd version compatible with
 // this Gas Town release.
-const BeadsInstallPath = "github.com/steveyegge/beads/cmd/bd@v1.0.4"
+const BeadsInstallPath = "github.com/steveyegge/beads/cmd/bd@v" + MaxBeadsVersion
 
 // BeadsStatus represents the state of the beads installation.
 type BeadsStatus int
@@ -29,6 +34,7 @@ const (
 	BeadsOK       BeadsStatus = iota // bd found, version compatible
 	BeadsNotFound                    // bd not in PATH
 	BeadsTooOld                      // bd found but version too old
+	BeadsTooNew                      // bd found but version is newer than supported
 	BeadsUnknown                     // bd found but couldn't parse version
 )
 
@@ -59,12 +65,18 @@ func CheckBeads() (BeadsStatus, string) {
 		return BeadsUnknown, ""
 	}
 
-	// Compare versions
-	if CompareVersions(version, MinBeadsVersion) < 0 {
-		return BeadsTooOld, version
-	}
+	return CheckBeadsVersionString(version), version
+}
 
-	return BeadsOK, version
+// CheckBeadsVersionString classifies a parsed bd version for compatibility.
+func CheckBeadsVersionString(version string) BeadsStatus {
+	if CompareVersions(version, MinBeadsVersion) < 0 {
+		return BeadsTooOld
+	}
+	if CompareVersions(version, MaxBeadsVersion) > 0 {
+		return BeadsTooNew
+	}
+	return BeadsOK
 }
 
 // EnsureBeads checks for bd and installs it if missing or outdated.
@@ -86,6 +98,10 @@ func EnsureBeads(autoInstall bool) error {
 	case BeadsTooOld:
 		return fmt.Errorf("beads version %s is too old (minimum: %s)\n\nUpgrade with: go install %s",
 			version, MinBeadsVersion, BeadsInstallPath)
+
+	case BeadsTooNew:
+		return fmt.Errorf("beads version %s is newer than this Gas Town release supports (maximum: %s)\n\nDowngrade with: go install %s",
+			version, MaxBeadsVersion, BeadsInstallPath)
 
 	case BeadsUnknown:
 		// Found bd but couldn't determine version - proceed with warning
@@ -116,6 +132,9 @@ func installBeads() error {
 	}
 	if status == BeadsTooOld {
 		return fmt.Errorf("installed beads %s but minimum required is %s", version, MinBeadsVersion)
+	}
+	if status == BeadsTooNew {
+		return fmt.Errorf("installed beads %s but maximum supported is %s", version, MaxBeadsVersion)
 	}
 
 	fmt.Printf("   ✓ Installed beads %s\n", version)

--- a/internal/deps/beads_test.go
+++ b/internal/deps/beads_test.go
@@ -44,6 +44,48 @@ func TestCompareVersions(t *testing.T) {
 	}
 }
 
+func TestCheckBeadsVersionString(t *testing.T) {
+	tests := []struct {
+		name    string
+		version string
+		want    BeadsStatus
+	}{
+		{
+			name:    "below minimum is too old",
+			version: "1.0.3",
+			want:    BeadsTooOld,
+		},
+		{
+			name:    "minimum is accepted",
+			version: MinBeadsVersion,
+			want:    BeadsOK,
+		},
+		{
+			name:    "maximum is accepted",
+			version: MaxBeadsVersion,
+			want:    BeadsOK,
+		},
+		{
+			name:    "above maximum is too new",
+			version: "1.0.5",
+			want:    BeadsTooNew,
+		},
+		{
+			name:    "future minor is too new",
+			version: "1.1.0",
+			want:    BeadsTooNew,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := CheckBeadsVersionString(tt.version); got != tt.want {
+				t.Fatalf("CheckBeadsVersionString(%q) = %v, want %v", tt.version, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestCheckBeads(t *testing.T) {
 	// This test depends on whether bd is installed in the test environment
 	status, version := CheckBeads()

--- a/internal/doctor/beads_binary_check.go
+++ b/internal/doctor/beads_binary_check.go
@@ -7,7 +7,7 @@ import (
 )
 
 // BeadsBinaryCheck verifies that the beads (bd) binary is installed and meets
-// the minimum version requirement. This is an informational check with no
+// the version requirements. This is an informational check with no
 // auto-fix — the user must install or upgrade bd manually.
 type BeadsBinaryCheck struct {
 	BaseCheck
@@ -18,7 +18,7 @@ func NewBeadsBinaryCheck() *BeadsBinaryCheck {
 	return &BeadsBinaryCheck{
 		BaseCheck: BaseCheck{
 			CheckName:        "beads-binary",
-			CheckDescription: "Check that beads (bd) is installed and meets minimum version",
+			CheckDescription: "Check that beads (bd) is installed and meets version requirements",
 			CheckCategory:    CategoryInfrastructure,
 		},
 	}
@@ -38,8 +38,8 @@ func (c *BeadsBinaryCheck) Run(ctx *CheckContext) *CheckResult {
 
 	case deps.BeadsNotFound:
 		return &CheckResult{
-			Name:   c.Name(),
-			Status: StatusError,
+			Name:    c.Name(),
+			Status:  StatusError,
 			Message: "beads (bd) not found in PATH",
 			Details: []string{
 				"The bd CLI is required for beads operations",
@@ -49,13 +49,24 @@ func (c *BeadsBinaryCheck) Run(ctx *CheckContext) *CheckResult {
 
 	case deps.BeadsTooOld:
 		return &CheckResult{
-			Name:   c.Name(),
-			Status: StatusError,
+			Name:    c.Name(),
+			Status:  StatusError,
 			Message: fmt.Sprintf("bd %s is too old (minimum: %s)", version, deps.MinBeadsVersion),
 			Details: []string{
 				fmt.Sprintf("Installed version %s does not meet the minimum requirement of %s", version, deps.MinBeadsVersion),
 			},
 			FixHint: fmt.Sprintf("Upgrade: go install %s", deps.BeadsInstallPath),
+		}
+
+	case deps.BeadsTooNew:
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusError,
+			Message: fmt.Sprintf("bd %s is too new (maximum supported: %s)", version, deps.MaxBeadsVersion),
+			Details: []string{
+				fmt.Sprintf("Installed version %s is newer than this Gas Town release supports (%s)", version, deps.MaxBeadsVersion),
+			},
+			FixHint: fmt.Sprintf("Downgrade: go install %s", deps.BeadsInstallPath),
 		}
 
 	case deps.BeadsUnknown:

--- a/internal/doctor/beads_binary_check_test.go
+++ b/internal/doctor/beads_binary_check_test.go
@@ -18,7 +18,7 @@ func TestBeadsBinaryCheck_Metadata(t *testing.T) {
 	if check.Name() != "beads-binary" {
 		t.Errorf("Name() = %q, want %q", check.Name(), "beads-binary")
 	}
-	if check.Description() != "Check that beads (bd) is installed and meets minimum version" {
+	if check.Description() != "Check that beads (bd) is installed and meets version requirements" {
 		t.Errorf("Description() = %q", check.Description())
 	}
 	if check.Category() != CategoryInfrastructure {
@@ -47,8 +47,8 @@ func TestBeadsBinaryCheck_BdInstalled(t *testing.T) {
 			t.Errorf("expected version string in message, got %q", result.Message)
 		}
 	case StatusError:
-		if !strings.Contains(result.Message, "too old") {
-			t.Errorf("expected 'too old' in error message, got %q", result.Message)
+		if !strings.Contains(result.Message, "too old") && !strings.Contains(result.Message, "too new") {
+			t.Errorf("expected version error message, got %q", result.Message)
 		}
 	default:
 		t.Errorf("unexpected status %v when bd is installed: %s", result.Status, result.Message)
@@ -140,6 +140,38 @@ func TestBeadsBinaryCheck_BdTooOld(t *testing.T) {
 		}
 		if result.FixHint == "" {
 			t.Error("expected a fix hint with upgrade instructions")
+		}
+	case StatusWarning:
+		// Under heavy CI load the fake bd may time out; tolerate gracefully.
+		t.Logf("fake bd timed out under load (got StatusWarning); skipping assertion")
+	default:
+		t.Errorf("expected StatusError (or StatusWarning under load), got %v: %s", result.Status, result.Message)
+	}
+}
+
+func TestBeadsBinaryCheck_BdTooNew(t *testing.T) {
+	fakeDir := t.TempDir()
+	writeFakeBd(t, fakeDir,
+		"#!/bin/sh\necho 'bd version 999.0.0'\n",
+		"@echo off\r\necho bd version 999.0.0\r\n",
+	)
+
+	t.Setenv("PATH", fakeDir)
+
+	check := NewBeadsBinaryCheck()
+	ctx := &CheckContext{TownRoot: t.TempDir()}
+
+	result := check.Run(ctx)
+	switch result.Status {
+	case StatusError:
+		if !strings.Contains(result.Message, "too new") {
+			t.Errorf("expected 'too new' in message, got %q", result.Message)
+		}
+		if !strings.Contains(result.Message, deps.MaxBeadsVersion) {
+			t.Errorf("expected max version in message, got %q", result.Message)
+		}
+		if !strings.Contains(result.FixHint, "Downgrade") {
+			t.Errorf("expected downgrade fix hint, got %q", result.FixHint)
 		}
 	case StatusWarning:
 		// Under heavy CI load the fake bd may time out; tolerate gracefully.


### PR DESCRIPTION
Follow-up to #4151.

This maintainer follow-up carries forward Julian Knutsen's original fix from #4151, `fix(release): reject unsupported bd versions`, after the original PR was already closed unmerged before finalization. The original change adds a supported `bd` version ceiling so release branches fail clearly when a newer incompatible beads schema is present.

Maintainer-side fixups keep the recovery paths usable while preserving the contributor commit: `gt install --no-beads`, beads-exempt commands, role-command startup paths, and `gt doctor` now handle too-new `bd` versions without trapping users away from repair commands.

Original PR: https://github.com/gastownhall/gastown/pull/4151
Original PR title: fix(release): reject unsupported bd versions
Original PR state at finalization: closed, unmerged
Configured workflow base: release/v1.2.0
Original GitHub base: release/v1.2.0
Base mismatch: none
Final base after refresh: d7ddc667b98c4a4590acb4928d6122df56fe0cb4
Final adopted head: f8f3f24f23e9c526d3cf97e51b33479412608fe0

Local validation before opening this PR:

- `go test ./internal/deps -run 'Test(ParseBeadsVersion|CompareVersions|CheckBeadsVersionString|CheckBeads)' -count=1`
- `go test ./internal/doctor -run TestBeadsBinaryCheck -count=1`
- `go test ./internal/cmd -run 'Test(CheckBeadsVersion|PersistentPreRun|InstallFailsBeforeMutationWhenDoltMissing|InstallNoBeadsAllowsMissingDolt|InstallNoBeadsFlag)' -count=1`
- `go vet ./internal/cmd/ ./internal/deps/ ./internal/doctor/`

Adoption review decision: approved after maintainer fixups. Remaining notes are non-gating: a redundant too-new exemption map and a stale `CheckBeadsVersion` comment can be handled later.
