### PR TITLE
fix(release): clear reaper lint failures

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -235,9 +235,9 @@ func OpenDB(host string, port int, dbName string, readTimeout, writeTimeout time
 //
 // Usage:
 //
-//	join, where := parentExcludeJoin(dbName, splitTarget)
-//	query := fmt.Sprintf("SELECT ... FROM wisps w %s WHERE ... AND %s", dbName, join, where)
-func parentExcludeJoin(dbName string, splitTarget bool) (joinClause, whereCondition string) {
+//	join, where := parentExcludeJoin(splitTarget)
+//	query := fmt.Sprintf("SELECT ... FROM wisps w %s WHERE ... AND %s", join, where)
+func parentExcludeJoin(splitTarget bool) (joinClause, whereCondition string) {
 	targetExpr := beads.DependencyTargetExpr("wd", splitTarget)
 	joinClause = fmt.Sprintf(`LEFT JOIN (
 		SELECT DISTINCT wd.issue_id
@@ -250,15 +250,15 @@ func parentExcludeJoin(dbName string, splitTarget bool) (joinClause, whereCondit
 	return
 }
 
-func reapCandidatesQuery(dbName string, splitTarget bool) string {
-	parentJoin, parentWhere := parentExcludeJoin(dbName, splitTarget)
+func reapCandidatesQuery(splitTarget bool) string {
+	parentJoin, parentWhere := parentExcludeJoin(splitTarget)
 	return fmt.Sprintf(
 		"SELECT COUNT(*) FROM wisps w %s WHERE w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND w.issue_type != 'agent' AND %s",
 		parentJoin, parentWhere)
 }
 
-func reapIDsQuery(dbName string, splitTarget bool) string {
-	parentJoin, parentWhere := parentExcludeJoin(dbName, splitTarget)
+func reapIDsQuery(splitTarget bool) string {
+	parentJoin, parentWhere := parentExcludeJoin(splitTarget)
 	whereClause := fmt.Sprintf(
 		"w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND w.issue_type != 'agent' AND %s", parentWhere)
 	return fmt.Sprintf(
@@ -309,7 +309,7 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 	// agent beads, otherwise scan can report candidates that reap will never close.
 	// Uses LEFT JOIN anti-pattern instead of correlated EXISTS to avoid O(n*m) cost (gt-jd1z).
 	if err := retryDependencyTargetQuery(func(splitTarget bool) error {
-		return db.QueryRowContext(ctx, reapCandidatesQuery(dbName, splitTarget), now.Add(-maxAge)).Scan(&result.ReapCandidates)
+		return db.QueryRowContext(ctx, reapCandidatesQuery(splitTarget), now.Add(-maxAge)).Scan(&result.ReapCandidates)
 	}); err != nil {
 		return nil, fmt.Errorf("count reap candidates: %w", err)
 	}
@@ -380,7 +380,7 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 
 	if dryRun {
 		if err := retryDependencyTargetQuery(func(splitTarget bool) error {
-			return db.QueryRowContext(ctx, reapCandidatesQuery(dbName, splitTarget), cutoff).Scan(&result.Reaped)
+			return db.QueryRowContext(ctx, reapCandidatesQuery(splitTarget), cutoff).Scan(&result.Reaped)
 		}); err != nil {
 			return nil, fmt.Errorf("dry-run count: %w", err)
 		}
@@ -406,7 +406,7 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 		var rows *sql.Rows
 		err := retryDependencyTargetQuery(func(splitTarget bool) error {
 			var queryErr error
-			rows, queryErr = db.QueryContext(ctx, reapIDsQuery(dbName, splitTarget), cutoff)
+			rows, queryErr = db.QueryContext(ctx, reapIDsQuery(splitTarget), cutoff)
 			return queryErr
 		})
 		if err != nil {

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -51,7 +51,7 @@ func TestFormatJSON(t *testing.T) {
 }
 
 func TestParentExcludeJoin(t *testing.T) {
-	joinClause, whereCondition := parentExcludeJoin("testdb", false)
+	joinClause, whereCondition := parentExcludeJoin(false)
 
 	// JOIN clause should reference the correct database.
 	if joinClause == "" {
@@ -59,7 +59,7 @@ func TestParentExcludeJoin(t *testing.T) {
 	}
 	// parentExcludeJoin no longer qualifies table names with the database — the
 	// reaper connects to a specific database via the DSN, so unqualified names
-	// are correct. The dbName parameter is retained for API compatibility.
+	// are correct.
 
 	// JOIN should select wisps with open parents from wisp_dependencies.
 	if !contains(joinClause, "wisp_dependencies") {
@@ -87,8 +87,7 @@ func TestParentExcludeJoin(t *testing.T) {
 // positional shift: "FROM wisps w gt WHERE..." instead of "FROM wisps w LEFT JOIN...".
 func TestReapQueryNoDatabaseNameInjection(t *testing.T) {
 	// Reproduce the exact Sprintf call from Reap() to verify no dbName injection.
-	dbName := "gt"
-	parentJoin, parentWhere := parentExcludeJoin(dbName, false)
+	parentJoin, parentWhere := parentExcludeJoin(false)
 	whereClause := fmt.Sprintf(
 		"w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND %s", parentWhere)
 
@@ -111,7 +110,7 @@ func TestReapQueryNoDatabaseNameInjection(t *testing.T) {
 }
 
 func TestParentExcludeJoinUsesSplitWispDependencyTarget(t *testing.T) {
-	joinClause, _ := parentExcludeJoin("testdb", true)
+	joinClause, _ := parentExcludeJoin(true)
 	targetExpr := "COALESCE(wd.depends_on_issue_id, wd.depends_on_wisp_id, wd.depends_on_external)"
 
 	if strings.Contains(joinClause, "wd.depends_on_id") {
@@ -271,7 +270,7 @@ func TestReapExcludesAgentBeads(t *testing.T) {
 // predicate as Reap() for stale open wisps. If Scan counts agent beads but Reap
 // excludes them, the operator sees scan>0 and reap=0 for the same cutoff.
 func TestScanExcludesAgentBeads(t *testing.T) {
-	query := reapCandidatesQuery("gt", false)
+	query := reapCandidatesQuery(false)
 	if !strings.Contains(query, "w.issue_type != 'agent'") {
 		t.Fatalf("expected Scan() eligibility query to exclude agent beads:\n%s", query)
 	}


### PR DESCRIPTION
## Summary
- remove unused reaper query helper dbName parameters
- update reaper query tests to call the simplified private helpers

## Validation
- go test ./internal/reaper
- golangci-lint run

This unblocks the local RC lint gate for release/v1.2.0.