### PR TITLE
fix(estop): stop `gt estop status` from firing an emergency stop

### DIFF
--- a/internal/cmd/estop.go
+++ b/internal/cmd/estop.go
@@ -46,7 +46,49 @@ Examples:
   gt estop -r "closing laptop"          # Freeze with reason
   gt estop --rig gastown                # Freeze only gastown
   gt estop --rig beads -r "maintenance" # Freeze beads rig`,
+	// NoArgs is critical: without it, a stray positional arg (e.g. the
+	// intuitive-but-wrong `gt estop status`) is silently ignored and the
+	// bare command FIRES an emergency stop. That footgun caused a 14h town
+	// wedge — agents polling estop state via `gt estop status` re-froze the
+	// town on every check. Use `gt estop status` (the subcommand below) or
+	// `gt status` to CHECK; `gt thaw` to clear.
+	Args: cobra.NoArgs,
 	RunE: runEstop,
+}
+
+// estopStatusCmd reports E-stop state WITHOUT firing one. This is the safe,
+// intuitive `gt estop status` that previously fell through to runEstop.
+var estopStatusCmd = &cobra.Command{
+	Use:     "status",
+	Short:   "Show emergency-stop state (read-only; does NOT freeze)",
+	Long:    "Report whether a town-wide or per-rig E-stop is active. Read-only — this never freezes the town. To clear an E-stop, use 'gt thaw'.",
+	Args:    cobra.NoArgs,
+	RunE:    runEstopStatus,
+}
+
+func runEstopStatus(cmd *cobra.Command, args []string) error {
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("not in a Gas Town workspace: %w", err)
+	}
+	if !estop.IsActive(townRoot) {
+		entries, _ := filepath.Glob(filepath.Join(townRoot, "ESTOP.*"))
+		// ESTOP-LOOP-HANDOFF.md and similar are not real per-rig sentinels.
+		realRig := false
+		for _, e := range entries {
+			if estop.ReadRig(townRoot, strings.TrimPrefix(filepath.Base(e), "ESTOP.")) != nil {
+				realRig = true
+				break
+			}
+		}
+		if !realRig {
+			fmt.Println("No E-stop active.")
+			return nil
+		}
+	}
+	addEstopToStatus(townRoot)
+	fmt.Printf("Clear with: %s\n", style.Bold.Render("gt thaw"))
+	return nil
 }
 
 var thawCmd = &cobra.Command{
@@ -68,6 +110,7 @@ func init() {
 	estopCmd.Flags().StringVarP(&estopReason, "reason", "r", "", "Reason for the E-stop")
 	estopCmd.Flags().StringVar(&estopRig, "rig", "", "Freeze only this rig (instead of all)")
 	thawCmd.Flags().StringVar(&thawRig, "rig", "", "Thaw only this rig (instead of all)")
+	estopCmd.AddCommand(estopStatusCmd)
 	rootCmd.AddCommand(estopCmd)
 	rootCmd.AddCommand(thawCmd)
 }

--- a/internal/cmd/estop.go
+++ b/internal/cmd/estop.go
@@ -46,24 +46,17 @@ Examples:
   gt estop -r "closing laptop"          # Freeze with reason
   gt estop --rig gastown                # Freeze only gastown
   gt estop --rig beads -r "maintenance" # Freeze beads rig`,
-	// NoArgs is critical: without it, a stray positional arg (e.g. the
-	// intuitive-but-wrong `gt estop status`) is silently ignored and the
-	// bare command FIRES an emergency stop. That footgun caused a 14h town
-	// wedge — agents polling estop state via `gt estop status` re-froze the
-	// town on every check. Use `gt estop status` (the subcommand below) or
-	// `gt status` to CHECK; `gt thaw` to clear.
+	// Reject stray operands so `gt estop status` cannot fall through to runEstop.
 	Args: cobra.NoArgs,
 	RunE: runEstop,
 }
 
-// estopStatusCmd reports E-stop state WITHOUT firing one. This is the safe,
-// intuitive `gt estop status` that previously fell through to runEstop.
 var estopStatusCmd = &cobra.Command{
-	Use:     "status",
-	Short:   "Show emergency-stop state (read-only; does NOT freeze)",
-	Long:    "Report whether a town-wide or per-rig E-stop is active. Read-only — this never freezes the town. To clear an E-stop, use 'gt thaw'.",
-	Args:    cobra.NoArgs,
-	RunE:    runEstopStatus,
+	Use:   "status",
+	Short: "Show emergency-stop state without freezing agents",
+	Long:  "Report whether a town-wide or per-rig E-stop is active. This is read-only and never freezes agents. To clear an E-stop, use 'gt thaw'.",
+	Args:  cobra.NoArgs,
+	RunE:  runEstopStatus,
 }
 
 func runEstopStatus(cmd *cobra.Command, args []string) error {
@@ -73,15 +66,15 @@ func runEstopStatus(cmd *cobra.Command, args []string) error {
 	}
 	if !estop.IsActive(townRoot) {
 		entries, _ := filepath.Glob(filepath.Join(townRoot, "ESTOP.*"))
-		// ESTOP-LOOP-HANDOFF.md and similar are not real per-rig sentinels.
-		realRig := false
-		for _, e := range entries {
-			if estop.ReadRig(townRoot, strings.TrimPrefix(filepath.Base(e), "ESTOP.")) != nil {
-				realRig = true
+		hasRigEstop := false
+		for _, entry := range entries {
+			rigName := strings.TrimPrefix(filepath.Base(entry), "ESTOP.")
+			if estop.ReadRig(townRoot, rigName) != nil {
+				hasRigEstop = true
 				break
 			}
 		}
-		if !realRig {
+		if !hasRigEstop {
 			fmt.Println("No E-stop active.")
 			return nil
 		}

--- a/internal/cmd/estop_test.go
+++ b/internal/cmd/estop_test.go
@@ -1,0 +1,87 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/estop"
+)
+
+func setupEstopCommandTestTown(t *testing.T) string {
+	t.Helper()
+
+	townRoot := t.TempDir()
+	if err := os.Mkdir(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatalf("create mayor marker: %v", err)
+	}
+
+	oldWd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("chdir test town: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := os.Chdir(oldWd); err != nil {
+			t.Errorf("restore cwd: %v", err)
+		}
+	})
+
+	return townRoot
+}
+
+func TestEstopCmdRejectsUnexpectedArgs(t *testing.T) {
+	if estopCmd.Args == nil {
+		t.Fatal("estopCmd.Args is nil")
+	}
+	if err := estopCmd.Args(estopCmd, []string{"junk"}); err == nil {
+		t.Fatal("estopCmd should reject unexpected positional args")
+	}
+	if err := estopCmd.Args(estopCmd, nil); err != nil {
+		t.Fatalf("estopCmd should accept no positional args: %v", err)
+	}
+}
+
+func TestRunEstopStatusDoesNotCreateSentinel(t *testing.T) {
+	townRoot := setupEstopCommandTestTown(t)
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = runEstopStatus(estopStatusCmd, nil)
+	})
+	if runErr != nil {
+		t.Fatalf("runEstopStatus: %v", runErr)
+	}
+	if !strings.Contains(out, "No E-stop active.") {
+		t.Fatalf("status output = %q, want no-active message", out)
+	}
+	if _, err := os.Stat(estop.FilePath(townRoot)); !os.IsNotExist(err) {
+		t.Fatalf("status should not create town-wide ESTOP sentinel, stat err = %v", err)
+	}
+}
+
+func TestRunEstopStatusReportsPerRigEstop(t *testing.T) {
+	townRoot := setupEstopCommandTestTown(t)
+	if err := estop.ActivateRig(townRoot, "gastown", estop.TriggerManual, "maintenance"); err != nil {
+		t.Fatalf("ActivateRig: %v", err)
+	}
+
+	var runErr error
+	out := captureStdout(t, func() {
+		runErr = runEstopStatus(estopStatusCmd, nil)
+	})
+	if runErr != nil {
+		t.Fatalf("runEstopStatus: %v", runErr)
+	}
+	for _, want := range []string{"E-STOP: gastown", "maintenance", "Clear with:"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("status output = %q, want %q", out, want)
+		}
+	}
+	if _, err := os.Stat(estop.FilePath(townRoot)); !os.IsNotExist(err) {
+		t.Fatalf("status should not create town-wide ESTOP sentinel, stat err = %v", err)
+	}
+}


### PR DESCRIPTION
`gt estop` has no `status` subcommand, so `gt estop status` silently ignores the positional arg and runs the bare command — **firing a real emergency stop** (writes the ESTOP sentinel, SIGTSTPs the town). Operators/agents/scripts running the intuitive `gt estop status` to *check* state therefore trigger a town-wide freeze; polling it re-freezes after every `gt thaw`, producing a self-sustaining freeze loop.

Fix:
- `Args: cobra.NoArgs` on `estopCmd` so a stray positional arg errors instead of silently firing.
- A real read-only `gt estop status` subcommand that reports town-wide + per-rig E-stop state and never freezes.

No change to who can fire an estop or to freeze/thaw behavior — pure footgun removal. Verified: `gt estop status` now reports without creating the sentinel; `gt estop <junk>` errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)