### PR TITLE
fix(tmux): wake agent's window, not session's active window, on nudge

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1773,8 +1773,14 @@ func (t *Tmux) NudgeSessionWithOpts(session, message string, opts NudgeOpts) err
 		return fmt.Errorf("nudge to session %q: %w", session, err)
 	}
 
-	// 8. Wake the pane to trigger SIGWINCH for detached sessions
-	t.WakePaneIfDetached(session)
+	// 8. Wake the pane to trigger SIGWINCH for detached sessions.
+	// Use the resolved target (session:window.pane) rather than the bare
+	// session name. resize-window on a bare session name resizes the
+	// session's *active* window — in a multi-window session (e.g. one with a
+	// `gt feed -w` window open and focused) that is not the agent's window,
+	// so the agent's pane never receives SIGWINCH and stays idle despite the
+	// delivered nudge. Targeting the resolved pane wakes the correct window.
+	t.WakePaneIfDetached(target)
 	return nil
 }
 

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1789,6 +1789,77 @@ func TestNudgeSession_WithStoredPaneID(t *testing.T) {
 	}
 }
 
+// TestNudgeSession_WakesAgentWindowNotActiveWindow is a regression test for a
+// missed-wake bug in multi-window sessions. NudgeSessionWithOpts used to pass
+// the bare session name to WakePaneIfDetached, which resizes the session's
+// *active* window. When an agent session also has another window open and
+// focused (e.g. a `gt feed -w` window), the agent's pane lives in a now-inactive
+// window, so the SIGWINCH went to the wrong window and the agent never woke.
+//
+// The wake's resize dance ends by setting the targeted window's window-size
+// option to "latest". By pre-setting both windows to "manual" and checking which
+// one flips to "latest" after the nudge, we can assert the agent's window — not
+// the active window — was the one woken.
+func TestNudgeSession_WakesAgentWindowNotActiveWindow(t *testing.T) {
+	tm := newTestTmux(t)
+	sessionName := "gt-test-nudge-multiwin-" + fmt.Sprintf("%d", time.Now().UnixNano()%100000)
+
+	if err := tm.NewSession(sessionName, os.TempDir()); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tm.KillSession(sessionName) }()
+
+	time.Sleep(200 * time.Millisecond)
+
+	// The agent pane is window 0's pane. Record it as the declared identity so
+	// FindAgentPane resolves the nudge target to it.
+	agentPane, err := tm.GetPaneID(sessionName)
+	if err != nil {
+		t.Fatalf("GetPaneID: %v", err)
+	}
+	if err := tm.SetEnvironment(sessionName, "GT_PANE_ID", agentPane); err != nil {
+		t.Fatalf("SetEnvironment GT_PANE_ID: %v", err)
+	}
+
+	// Open a second window, which tmux makes the active window. This puts the
+	// agent's pane in a non-active window — the scenario that exposed the bug.
+	if _, err := tm.run("new-window", "-t", sessionName, "-n", "feed"); err != nil {
+		t.Fatalf("new-window: %v", err)
+	}
+
+	// Pre-set both windows to window-size "manual". The wake resets only the
+	// window it targets back to "latest", giving us a deterministic signal.
+	for _, win := range []string{":0", ":1"} {
+		if _, err := tm.run("set-option", "-w", "-t", sessionName+win, "window-size", "manual"); err != nil {
+			t.Fatalf("set-option window-size manual on %s: %v", sessionName+win, err)
+		}
+	}
+
+	if err := tm.NudgeSession(sessionName, "test message"); err != nil {
+		t.Fatalf("NudgeSession: %v", err)
+	}
+
+	windowSize := func(win string) string {
+		out, err := tm.run("show-options", "-w", "-t", sessionName+win, "window-size")
+		if err != nil {
+			t.Fatalf("show-options window-size on %s: %v", sessionName+win, err)
+		}
+		fields := strings.Fields(strings.TrimSpace(out))
+		if len(fields) < 2 {
+			return ""
+		}
+		return fields[1]
+	}
+
+	// Agent window (0) must have been woken; active window (1) must be untouched.
+	if got := windowSize(":0"); got != "latest" {
+		t.Errorf("agent window (0) window-size = %q, want %q (agent's window was not woken)", got, "latest")
+	}
+	if got := windowSize(":1"); got != "manual" {
+		t.Errorf("active window (1) window-size = %q, want %q (wrong window was woken)", got, "manual")
+	}
+}
+
 // TestAdaptiveTextDelay verifies the delay scaling logic for post-text delivery.
 func TestAdaptiveTextDelay(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
## Problem

`NudgeSessionWithOpts` resolves the correct pane target for *delivering* the nudge keystrokes, but then passes the **bare session name** to `WakePaneIfDetached` for the SIGWINCH wake:

```go
t.WakePaneIfDetached(session)
```

`resize-window` on a bare session name resizes the session's **active** window. In a multi-window session — for example one with a `gt feed -w` window open and focused (`internal/cmd/feed.go` creates and selects a `feed` window in the current session) — the agent's pane lives in a now-inactive window. The wake's SIGWINCH therefore goes to the *wrong* window, and a detached agent never wakes despite the nudge having been delivered to its pane.

## Fix

Pass the already-resolved `target` (`session:window.pane`) to `WakePaneIfDetached`:

```go
t.WakePaneIfDetached(target)
```

In the common single-window case `target` resolves to the same window, so behavior there is unchanged. This is a one-line behavioral change plus an explanatory comment.

## Verification

Confirmed empirically on tmux 3.6a:
- `resize-window -t $session` resizes the session's **active** window
- `resize-window -t $session:0.0` resizes the **pane's own** window

## Test

Adds `TestNudgeSession_WakesAgentWindowNotActiveWindow`, which:
1. Creates a session and records the agent pane via `GT_PANE_ID`
2. Opens a second window (which becomes active), placing the agent pane in a non-active window
3. Pre-sets both windows' `window-size` to `manual`
4. Nudges, then asserts only the agent's window flipped back to `latest` (the wake's final `set-option window-size latest` step), proving the correct window was woken

The test fails against the previous `WakePaneIfDetached(session)` code (agent window stays `manual`, active window becomes `latest`) and passes with the fix. Full `internal/tmux` package suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)