### PR TITLE
fix(refinery): recover hooked patrol workflow at startup

### DIFF
--- a/internal/cmd/hook_workflow.go
+++ b/internal/cmd/hook_workflow.go
@@ -1,0 +1,34 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+// workflowAttachmentForHookedBead returns parsed attachment metadata when present
+// and infers workflow context for root-only molecule wisps that carry the formula
+// name in their title rather than in attached_formula fields.
+func workflowAttachmentForHookedBead(hookedBead *beads.Issue) *beads.AttachmentFields {
+	if hookedBead == nil {
+		return nil
+	}
+
+	if attachment := beads.ParseAttachmentFields(hookedBead); attachment != nil {
+		return attachment
+	}
+
+	if hookedBead.Type != "molecule" {
+		return nil
+	}
+
+	formulaName := strings.TrimSpace(hookedBead.Title)
+	if formulaName == "" || !strings.HasPrefix(formulaName, "mol-") {
+		return nil
+	}
+
+	return &beads.AttachmentFields{
+		AttachedFormula: formulaName,
+	}
+}
+

--- a/internal/cmd/molecule_status.go
+++ b/internal/cmd/molecule_status.go
@@ -497,7 +497,7 @@ func runMoleculeStatus(cmd *cobra.Command, args []string) error {
 		status.PinnedBead = hookBead
 
 		// Check for attached molecule
-		attachment := beads.ParseAttachmentFields(hookBead)
+		attachment := workflowAttachmentForHookedBead(hookBead)
 		if attachment != nil {
 			status.AttachedMolecule = attachment.AttachedMolecule
 			status.AttachedFormula = attachment.AttachedFormula

--- a/internal/cmd/molecule_status_test.go
+++ b/internal/cmd/molecule_status_test.go
@@ -88,3 +88,21 @@ func TestOutputMoleculeStatus_FormulaWispShowsWorkflowContext(t *testing.T) {
 		t.Fatalf("expected workflow next action, got:\n%s", output)
 	}
 }
+
+func TestWorkflowAttachmentForHookedBead_InfersFormulaFromMoleculeTitle(t *testing.T) {
+	attachment := workflowAttachmentForHookedBead(&beads.Issue{
+		ID:    "hq-wisp-7hzt1",
+		Title: "mol-refinery-patrol",
+		Type:  "molecule",
+	})
+
+	if attachment == nil {
+		t.Fatal("expected inferred attachment, got nil")
+	}
+	if attachment.AttachedFormula != "mol-refinery-patrol" {
+		t.Fatalf("AttachedFormula = %q, want %q", attachment.AttachedFormula, "mol-refinery-patrol")
+	}
+	if attachment.AttachedMolecule != "" {
+		t.Fatalf("AttachedMolecule = %q, want empty", attachment.AttachedMolecule)
+	}
+}

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -689,7 +689,7 @@ func checkSlungWork(ctx RoleContext, hookedBead *beads.Issue) bool {
 		return false
 	}
 
-	attachment := beads.ParseAttachmentFields(hookedBead)
+	attachment := workflowAttachmentForHookedBead(hookedBead)
 	hasWorkflow := hasWorkflowAttachment(attachment)
 
 	outputAutonomousDirective(ctx, hookedBead, hasWorkflow)
@@ -924,7 +924,7 @@ func outputAutonomousDirective(ctx RoleContext, hookedBead *beads.Issue, hasMole
 		fmt.Println("3. Work through molecule steps in order - see CURRENT STEP below")
 		fmt.Println("4. Close each step with `bd close <step-id>`, then check `bd mol current` for next step")
 	} else {
-		fmt.Printf("2. Then IMMEDIATELY run: `bd show %s`\n", hookedBead.ID)
+		fmt.Printf("2. Then IMMEDIATELY continue from the hooked bead details for `%s`\n", hookedBead.ID)
 		fmt.Println("3. Begin execution - no waiting for user input")
 	}
 
@@ -1001,6 +1001,15 @@ func outputMoleculeWorkflow(ctx RoleContext, attachment *beads.AttachmentFields)
 
 	// Show inline formula steps from the embedded binary (root-only: no child wisps to query).
 	if attachment.AttachedFormula != "" {
+		if isPatrolFormulaName(attachment.AttachedFormula) {
+			fmt.Println()
+			fmt.Println("Patrol formula detected. Detailed execution guidance is already in the role context above.")
+			fmt.Println("Use the checklist below to track step order, then begin with Step 1 immediately.")
+			showFormulaSteps(attachment.AttachedFormula, "Formula Checklist", ctx.TownRoot, ctx.Rig, attachmentFormulaVars(attachment))
+			fmt.Println()
+			fmt.Printf("%s\n", style.Bold.Render("Work through the patrol checklist in order."))
+			return
+		}
 		showFormulaStepsFull(attachment.AttachedFormula, ctx.TownRoot, ctx.Rig, attachmentFormulaVars(attachment))
 		fmt.Println()
 		fmt.Printf("%s\n", style.Bold.Render("Work through ALL steps above, including submit and cleanup."))
@@ -1014,6 +1023,10 @@ func outputMoleculeWorkflow(ctx RoleContext, attachment *beads.AttachmentFields)
 	fmt.Println()
 	fmt.Printf("%s\n", style.Bold.Render("Follow the molecule steps above, NOT the base bead."))
 	fmt.Println("The base bead is just a container. The molecule steps define your workflow.")
+}
+
+func isPatrolFormulaName(formulaName string) bool {
+	return strings.HasSuffix(strings.TrimSpace(formulaName), "-patrol")
 }
 
 // outputRalphLoopDirective emits inline iterative work instructions for ralph mode.

--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -276,7 +276,6 @@ func outputMoleculeContext(ctx RoleContext) {
 
 	// For Refinery, use special patrol molecule handling (auto-bonds on startup)
 	if ctx.Role == RoleRefinery {
-		outputRefineryPatrolContext(ctx)
 		return
 	}
 
@@ -335,30 +334,6 @@ func outputWitnessPatrolContext(ctx RoleContext) {
 	}
 	outputPatrolContext(cfg)
 	showFormulaSteps(constants.MolWitnessPatrol, "Patrol Steps", ctx.TownRoot, ctx.Rig, extraVars)
-}
-
-// outputRefineryPatrolContext shows patrol molecule status for the Refinery.
-// Refinery AUTO-BONDS its patrol molecule on startup if one isn't already running.
-func outputRefineryPatrolContext(ctx RoleContext) {
-	if stopped, reason := IsRigParkedOrDocked(ctx.TownRoot, ctx.Rig); stopped {
-		fmt.Printf("\n⏸️  Rig %s is %s — skipping patrol wisp generation.\n", ctx.Rig, reason)
-		return
-	}
-	cfg := PatrolConfig{
-		RoleName:      "refinery",
-		PatrolMolName: constants.MolRefineryPatrol,
-		BeadsDir:      ctx.TownRoot,
-		Assignee:      ctx.Rig + "/refinery",
-		HeaderEmoji:   "🔧",
-		HeaderTitle:   "Refinery Patrol Status",
-		ExtraVars:     buildRefineryPatrolVars(ctx),
-		WorkLoopSteps: []string{
-			"Work through each patrol step in sequence (see checklist below)",
-			"At cycle end:\n   - If context LOW:\n     * Report and loop: `" + cli.Name() + " patrol report --summary \"<brief summary of observations>\"`\n     * This closes the current patrol and starts a new cycle\n   - If context HIGH:\n     * Send handoff: `" + cli.Name() + " handoff -s \"Refinery patrol\" -m \"<observations>\"`\n     * Exit cleanly (daemon respawns fresh session)",
-		},
-	}
-	outputPatrolContext(cfg)
-	showFormulaStepsFull(constants.MolRefineryPatrol, ctx.TownRoot, ctx.Rig, cfg.ExtraVars)
 }
 
 // buildWitnessPatrolVars returns --var key=value strings for the witness

--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -915,6 +915,34 @@ func TestCheckSlungWork_StandaloneFormulaUsesWorkflowOutput(t *testing.T) {
 	}
 }
 
+func TestCheckSlungWork_MoleculeHookInfersWorkflowFromTitle(t *testing.T) {
+	ctx := RoleContext{Role: RoleRefinery, Rig: "chatehr"}
+	hookedBead := &beads.Issue{
+		ID:          "hq-wisp-7hzt1",
+		Title:       "mol-refinery-patrol",
+		Type:        "molecule",
+		Description: "Merge queue processor patrol loop.",
+	}
+
+	var found bool
+	output := captureStdout(t, func() {
+		found = checkSlungWork(ctx, hookedBead)
+	})
+
+	if !found {
+		t.Fatalf("checkSlungWork() = false, want true")
+	}
+	if !strings.Contains(output, "ATTACHED FORMULA") {
+		t.Fatalf("expected inferred workflow output, got:\n%s", output)
+	}
+	if strings.Contains(output, "Then IMMEDIATELY run: `bd show") {
+		t.Fatalf("should not instruct cross-rig bd show for molecule patrol wisps, got:\n%s", output)
+	}
+	if !strings.Contains(output, "mol-refinery-patrol") {
+		t.Fatalf("expected inferred formula name in output, got:\n%s", output)
+	}
+}
+
 // TestCompactResumeReminder_PolecatGetsGtDone verifies that polecats get a
 // gt done reminder after context compaction. This is the regression test for
 // the polecats-no-gt-done bug: after long work sessions, compaction drops the

--- a/internal/refinery/manager.go
+++ b/internal/refinery/manager.go
@@ -191,7 +191,7 @@ func (m *Manager) Start(foreground bool, agentOverride string) error {
 		Recipient: session.BeaconRecipient("refinery", "", m.rig.Name),
 		Sender:    "deacon",
 		Topic:     "patrol",
-	}, "Run `gt prime --hook` and begin patrol.")
+	}, "SessionStart already injected `gt prime --hook`. Continue from the hooked patrol context and begin patrol.")
 
 	command, err := config.BuildStartupCommandFromConfig(config.AgentEnvConfig{
 		Role:             "refinery",


### PR DESCRIPTION
## Summary

This fixes a real refinery startup failure in autonomous patrol sessions.

## Problem

Refinery patrol wisps can be hooked as `issue_type: molecule` without explicit
`attached_formula` metadata. In that state, `gt prime --hook` and `gt hook`
misclassify the hooked patrol as plain bead work instead of workflow context.

That broke startup in a few concrete ways:

- `gt prime --hook` told refinery to run `bd show <hq-wisp-id>` instead of
  continuing from patrol workflow context
- refinery sessions got duplicate patrol/formula dumps at startup
- the refinery launcher prompt told Codex to run `gt prime --hook` even though
  SessionStart had already injected it, creating a redundant double-prime path

In practice, this could leave refinery idle or derail it into generic fallback
behavior instead of starting patrol work.

## Fix

- infer workflow context for hooked `molecule` beads whose title is a patrol
  formula name like `mol-refinery-patrol`
- use that inferred workflow in both `gt prime --hook` and `gt hook`
- stop telling hook-driven refinery startup to run cross-rig `bd show ...`
- remove the extra refinery patrol-status/full-formula dump from prime output
- change refinery startup prompt text so it continues from SessionStart-injected
  hook state instead of telling the model to rerun `gt prime --hook`

## Verification

- `CGO_ENABLED=0 go test ./internal/cmd -run 'Test(CheckSlungWork_MoleculeHookInfersWorkflowFromTitle|CheckSlungWork_StandaloneFormulaUsesWorkflowOutput|OutputMoleculeStatus_FormulaWispShowsWorkflowContext|WorkflowAttachmentForHookedBead_InfersFormulaFromMoleculeTitle)'
- `CGO_ENABLED=0 go build ./cmd/gt`

## Notes

I kept this PR focused on the runtime/startup bug itself. It does not include
local-only prompt steering tweaks from operational debugging.
