### PR TITLE
fix(reaper): raise DefaultAlertThreshold 800 -> 3000 to stop false-alarm escalation flood

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -156,9 +156,15 @@ const (
 	// DefaultBatchSize is the number of rows per batch DELETE operation.
 	DefaultBatchSize = 100
 	// DefaultAlertThreshold is the open-wisp count above which callers should
-	// surface a warning. Sized above the natural steady-state for the current
-	// dog/deacon emit rate (~23 wisps/h × 24h TTL ≈ 550). See hq-57jr8.
-	DefaultAlertThreshold = 800
+	// surface a warning. This must fire on genuine runaway accumulation, NOT on
+	// normal operation. The open-wisp count is dominated by healthy, recent
+	// wisps (observed steady-state ~1966 open in a busy town); only wisps that
+	// are stale or have orphaned parents AND are past max-age are ever
+	// reap-eligible (typically ~15-25). The previous value of 800 sat below the
+	// healthy open count, so it false-alarmed HIGH every scan despite nothing
+	// being wrong. Raised to 3000 so the alert tracks runaway growth rather than
+	// the normal working set. See hq-57jr8.
+	DefaultAlertThreshold = 3000
 )
 
 // ValidateDBName returns an error if the database name is unsafe.


### PR DESCRIPTION
## Problem: recurring false-alarm "reaper flood"

The reaper (the `mol-dog-reaper` background Dog) escalates **HIGH** whenever a database's open-wisp count exceeds `DefaultAlertThreshold` (`internal/reaper/reaper.go`). The warning is emitted at `internal/cmd/reaper.go:262`:

```
WARNING: %d open wisps exceed alert threshold (%d)
```

The threshold was mis-tuned. The open-wisp count is **dominated by healthy, recent wisps** — a busy town runs a steady-state of **~1966 open wisps** that are perfectly fine. Only wisps that are stale or have orphaned parents **and** are past max-age are ever reap-eligible, which is typically **~15-25**. At `800`, the threshold sat *below* the normal healthy open count, so it false-alarmed HIGH on essentially every scan, producing the recurring escalation flood despite nothing being wrong.

## Change

`internal/reaper/reaper.go`: `DefaultAlertThreshold` `800 -> 3000`, with an expanded comment explaining the healthy-vs-reapable distinction so the value isn't "corrected" back down later.

This is a constant bump only — no change to reap eligibility, scan, or any SQL. The alert now tracks genuine runaway accumulation rather than the normal working set. A configurable env/config field was considered but not adopted: there is no existing config-field pattern for these reaper constants in the file (they are all package-level `const`s consumed directly), so introducing one would be over-engineering for this fix. The constant remains the single source of truth used by both the package and `internal/cmd/reaper.go`.

## Overlay step-override investigation (the a505f51a regression claim)

An operator suspected that commit `a505f51a` ("fix: handle split dependency targets in reaper") may have regressed honoring of formula-overlay **step-overrides** (the `formula-overlays/*.toml` mechanism that lets an operator override/disable reaper steps).

**Conclusion: this is NOT a regression from a505f51a. No code change made here.**

Findings:
- `git show --stat a505f51a` touches 13 files, all concerned with **split dependency target columns** (the `depends_on_id` -> generated/split column migration). The reaper.go and `internal/doctor/misclassified_wisp_check.go` hunks only rewrite SQL builders to call `beads.DependencyTargetExpr(...)` and retry via `retryDependencyTargetQuery`. None of it references overlays.
- `git show --stat a505f51a --name-only` matched **zero** overlay/formula files.
- The reaper package (`internal/reaper/`) and `internal/cmd/reaper.go` contain **no** references to `overlay` or `StepOverride` at all.
- Step-override parsing and application live entirely in `internal/formula/overlay.go` (`StepOverrides`, `ApplyOverlays`), and overlays are applied at `internal/cmd/prime_molecule.go:479` — a path independent of the reaper package and untouched by a505f51a.

Step-override honoring is decoupled from the reaper code a505f51a modified, so that commit cannot have regressed it. If operators are still seeing overlays not applied, the issue is more likely in the overlay-application path (`internal/formula/overlay.go` / `prime_molecule.go`) or in how the Dog is invoked (inline-fallback bypassing the overlaid formula), and warrants a separate investigation — out of scope for this threshold fix.

## Build / test results

Go: `/home/dev/.local/go/bin/go`.

- `CGO_ENABLED=0 go build ./...` — **PASS** (rc=0)
- `CGO_ENABLED=0 go test ./internal/reaper/...` — **PASS** (`ok ... 0.004s`)
- `gofmt -l internal/reaper/reaper.go` — clean
- `CGO_ENABLED=0 go test ./internal/cmd/...` — some failures (`TestFilterAndSortSessions_SortOrder`, `TestJSONOutput_*`, `TestEnsureBeadsConfigYAML_CreatesWhenMissing`, convoy/submodule tests). **Verified these are pre-existing and unrelated**: they fail identically on the pristine base (with my edit stashed) and depend on environment fixtures (rigs.json / `bd` / tmux) not present in this sandbox. This PR's one-line const change does not affect them.

Draft for human review — please do not auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)