### PR TITLE
fix(memories): tolerate non-string values in bd kv list

### DIFF
--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -652,9 +652,22 @@ func bdKvListJSONForPrime(workDir string) (map[string]string, error) {
 		return nil, err
 	}
 
-	var kvs map[string]string
-	if err := json.Unmarshal(stdout.Bytes(), &kvs); err != nil {
+	// bd kv list may include non-string values (e.g. the numeric
+	// schema_version key), so decode into RawMessage first and keep only
+	// the string-valued entries. Memories are always stored as strings.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(stdout.Bytes(), &raw); err != nil {
 		return nil, fmt.Errorf("parsing kv list: %w", err)
+	}
+
+	kvs := make(map[string]string, len(raw))
+	for k, v := range raw {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			// Skip non-string values (e.g. schema_version).
+			continue
+		}
+		kvs[k] = s
 	}
 	return kvs, nil
 }

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -652,24 +652,7 @@ func bdKvListJSONForPrime(workDir string) (map[string]string, error) {
 		return nil, err
 	}
 
-	// bd kv list may include non-string values (e.g. the numeric
-	// schema_version key), so decode into RawMessage first and keep only
-	// the string-valued entries. Memories are always stored as strings.
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(stdout.Bytes(), &raw); err != nil {
-		return nil, fmt.Errorf("parsing kv list: %w", err)
-	}
-
-	kvs := make(map[string]string, len(raw))
-	for k, v := range raw {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			// Skip non-string values (e.g. schema_version).
-			continue
-		}
-		kvs[k] = s
-	}
-	return kvs, nil
+	return parseBdKvListJSON(stdout.Bytes())
 }
 
 // runMailCheckInject runs `gt mail check --inject` and outputs the result.

--- a/internal/cmd/remember.go
+++ b/internal/cmd/remember.go
@@ -223,9 +223,22 @@ func bdKvListJSON() (map[string]string, error) {
 		return nil, err
 	}
 
-	var kvs map[string]string
-	if err := json.Unmarshal(out, &kvs); err != nil {
+	// bd kv list may include non-string values (e.g. the numeric
+	// schema_version key), so decode into RawMessage first and keep only
+	// the string-valued entries. Memories are always stored as strings.
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(out, &raw); err != nil {
 		return nil, fmt.Errorf("parsing kv list: %w", err)
+	}
+
+	kvs := make(map[string]string, len(raw))
+	for k, v := range raw {
+		var s string
+		if err := json.Unmarshal(v, &s); err != nil {
+			// Skip non-string values (e.g. schema_version).
+			continue
+		}
+		kvs[k] = s
 	}
 	return kvs, nil
 }

--- a/internal/cmd/remember.go
+++ b/internal/cmd/remember.go
@@ -215,7 +215,25 @@ func bdKvClear(key string) error {
 	return cmd.Run()
 }
 
-// bdKvListJSON calls bd kv list --json and returns the parsed map.
+// parseBdKvListJSON parses bd kv list --json output, keeping only string values.
+func parseBdKvListJSON(data []byte) (map[string]string, error) {
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return nil, fmt.Errorf("parsing kv list: %w", err)
+	}
+
+	kvs := make(map[string]string, len(raw))
+	for k, v := range raw {
+		var s *string
+		if err := json.Unmarshal(v, &s); err != nil || s == nil {
+			continue
+		}
+		kvs[k] = *s
+	}
+	return kvs, nil
+}
+
+// bdKvListJSON calls bd kv list --json and returns the parsed string values.
 func bdKvListJSON() (map[string]string, error) {
 	cmd := exec.Command("bd", "kv", "list", "--json")
 	out, err := cmd.Output()
@@ -223,22 +241,5 @@ func bdKvListJSON() (map[string]string, error) {
 		return nil, err
 	}
 
-	// bd kv list may include non-string values (e.g. the numeric
-	// schema_version key), so decode into RawMessage first and keep only
-	// the string-valued entries. Memories are always stored as strings.
-	var raw map[string]json.RawMessage
-	if err := json.Unmarshal(out, &raw); err != nil {
-		return nil, fmt.Errorf("parsing kv list: %w", err)
-	}
-
-	kvs := make(map[string]string, len(raw))
-	for k, v := range raw {
-		var s string
-		if err := json.Unmarshal(v, &s); err != nil {
-			// Skip non-string values (e.g. schema_version).
-			continue
-		}
-		kvs[k] = s
-	}
-	return kvs, nil
+	return parseBdKvListJSON(out)
 }

--- a/internal/cmd/remember_test.go
+++ b/internal/cmd/remember_test.go
@@ -190,3 +190,40 @@ func TestMemTypeRank(t *testing.T) {
 		t.Error("unknown type should rank after general")
 	}
 }
+
+func TestParseBdKvListJSON(t *testing.T) {
+	got, err := parseBdKvListJSON([]byte(`{
+		"memory.project.note":"keep me",
+		"memory.project.empty":"",
+		"schema_version":1,
+		"enabled":true,
+		"tags":["one"],
+		"config":{"nested":"value"},
+		"memory.project.null":null
+	}`))
+	if err != nil {
+		t.Fatalf("parseBdKvListJSON() error = %v", err)
+	}
+
+	want := map[string]string{
+		"memory.project.note":  "keep me",
+		"memory.project.empty": "",
+	}
+	if len(got) != len(want) {
+		t.Fatalf("parseBdKvListJSON() returned %d entries, want %d: %#v", len(got), len(want), got)
+	}
+	for k, wantValue := range want {
+		if got[k] != wantValue {
+			t.Errorf("parseBdKvListJSON()[%q] = %q, want %q", k, got[k], wantValue)
+		}
+	}
+	if _, ok := got["memory.project.null"]; ok {
+		t.Error("parseBdKvListJSON() kept null memory value")
+	}
+}
+
+func TestParseBdKvListJSONMalformed(t *testing.T) {
+	if _, err := parseBdKvListJSON([]byte(`{"memory.project.note":`)); err == nil {
+		t.Fatal("parseBdKvListJSON() error = nil, want malformed JSON error")
+	}
+}


### PR DESCRIPTION
## Problem

`gt memories` fails outright and `gt prime`'s memory injection silently drops all memories with:

```
parsing kv list: json: cannot unmarshal number into Go value of type string
```

Both commands shell out to `bd kv list --json` and unmarshal the result into `map[string]string`. Recent `bd` (1.0.5) stores a numeric bookkeeping key in the same kv store:

```json
"schema_version": 1
```

`1` is a JSON number, so unmarshaling into a string-valued map fails. `bd memories` is unaffected because it reads the store natively.

## Fix

`bdKvListJSON()` (`internal/cmd/remember.go`) and `bdKvListJSONForPrime()` (`internal/cmd/prime.go`) now decode into `map[string]json.RawMessage` and keep only string-valued entries, skipping non-strings like `schema_version`. Downstream code already filters to `memory.*` keys, so this is safe and forward-compatible with any future non-string kv entries.

## Testing

Built and verified against a live store: `gt memories` (default), `gt memories --type project`, and `gt memories <search>` all list correctly; the numeric `schema_version` key is silently skipped.

🤖 Generated with [Claude Code](https://claude.com/claude-code)