### PR TITLE
fix(beads): omit shared BEADS_DOLT_DATA_DIR in server mode (#4140)

### DIFF
--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -162,6 +162,86 @@ func TestBuildRoutingBDEnvStripsDatabaseButKeepsSelectedConnection(t *testing.T)
 	}
 }
 
+// TestBuildPinnedBDEnv_ServerModeOmitsSharedDataDir is a regression test for
+// gastownhall/gastown#4140. When the pinned beads dir's metadata.json names a
+// server host/port (server mode), BuildPinnedBDEnv must NOT emit
+// BEADS_DOLT_DATA_DIR — the shared multi-database town data dir would override
+// the pinned database selection and make `bd mol bond` resolve routed
+// cross-rig beads against the wrong database.
+//
+// The previous tests above use a beadsDir under t.TempDir() with no
+// mayor/town.json above it, so FindTownRoot returned "" and the bug was
+// invisible. This test creates the town root explicitly so the regression
+// path is exercised.
+func TestBuildPinnedBDEnv_ServerModeOmitsSharedDataDir(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	rigBeadsDir := filepath.Join(townRoot, "minerals", ".beads")
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := []byte(`{"dolt_database":"minerals","dolt_server_host":"127.0.0.1","dolt_server_port":3307}`)
+	if err := os.WriteFile(filepath.Join(rigBeadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := BuildPinnedBDEnv([]string{"PATH=/usr/bin"}, rigBeadsDir)
+	got := envMap(env)
+
+	if value, ok := got["BEADS_DOLT_DATA_DIR"]; ok {
+		t.Fatalf("BEADS_DOLT_DATA_DIR should be omitted in server mode (would clobber the pinned database for routed cross-rig beads), got %q in %v", value, env)
+	}
+	if got["BEADS_DOLT_SERVER_HOST"] != "127.0.0.1" {
+		t.Fatalf("BEADS_DOLT_SERVER_HOST = %q, want 127.0.0.1 in %v", got["BEADS_DOLT_SERVER_HOST"], env)
+	}
+	if got["BEADS_DOLT_SERVER_PORT"] != "3307" || got["BEADS_DOLT_PORT"] != "3307" {
+		t.Fatalf("ports = server:%q legacy:%q, want 3307 in %v", got["BEADS_DOLT_SERVER_PORT"], got["BEADS_DOLT_PORT"], env)
+	}
+}
+
+// TestBuildPinnedBDEnv_EmbeddedModeKeepsSharedDataDir verifies the
+// complement of the regression case: when metadata.json has no server
+// host/port (embedded mode), BEADS_DOLT_DATA_DIR IS still emitted so bd can
+// locate the on-disk data.
+func TestBuildPinnedBDEnv_EmbeddedModeKeepsSharedDataDir(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Embedded mode: metadata names a database but no server connection.
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"dolt_database":"hq"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := BuildPinnedBDEnv([]string{"PATH=/usr/bin"}, beadsDir)
+	got := envMap(env)
+
+	wantDataDir := filepath.Join(townRoot, ".dolt-data")
+	if got["BEADS_DOLT_DATA_DIR"] != wantDataDir {
+		t.Fatalf("BEADS_DOLT_DATA_DIR = %q, want %q in %v", got["BEADS_DOLT_DATA_DIR"], wantDataDir, env)
+	}
+	if _, ok := got["BEADS_DOLT_SERVER_HOST"]; ok {
+		t.Fatalf("BEADS_DOLT_SERVER_HOST should be unset in embedded mode, env=%v", env)
+	}
+	if _, ok := got["BEADS_DOLT_SERVER_PORT"]; ok {
+		t.Fatalf("BEADS_DOLT_SERVER_PORT should be unset in embedded mode, env=%v", env)
+	}
+}
+
 func TestBuildPinnedBDEnvFallsBackToGTDoltPort(t *testing.T) {
 	beadsDir := filepath.Join(t.TempDir(), ".beads")
 	if err := os.MkdirAll(beadsDir, 0755); err != nil {

--- a/internal/beads/database.go
+++ b/internal/beads/database.go
@@ -193,15 +193,25 @@ func doltTargetEnvFromBeadsDir(beadsDir string) []string {
 	}
 	meta := readDoltMetadata(beadsDir)
 	var env []string
-	if townRoot := FindTownRoot(filepath.Dir(beadsDir)); townRoot != "" {
-		env = append(env, "BEADS_DOLT_DATA_DIR="+filepath.Join(townRoot, ".dolt-data"))
-	}
 	if meta.Host != "" {
 		env = append(env, "BEADS_DOLT_SERVER_HOST="+meta.Host)
 	}
 	if meta.Port != "" {
 		env = append(env, "BEADS_DOLT_SERVER_PORT="+meta.Port)
 		env = append(env, "BEADS_DOLT_PORT="+meta.Port)
+	}
+	// BEADS_DOLT_DATA_DIR is the SHARED multi-database town data dir. In server
+	// mode (host/port configured), the running Dolt server already owns the
+	// data and the connection is reached via host/port; the pinned beadsDir's
+	// metadata.json selects the database. Emitting the shared data dir there
+	// makes `bd mol bond` resolve routed cross-rig beads against the wrong
+	// database (closes gastownhall/gastown#4140). Only emit it in embedded
+	// mode, where there's no connection target and bd needs to locate the
+	// data on disk.
+	if meta.Host == "" && meta.Port == "" {
+		if townRoot := FindTownRoot(filepath.Dir(beadsDir)); townRoot != "" {
+			env = append(env, "BEADS_DOLT_DATA_DIR="+filepath.Join(townRoot, ".dolt-data"))
+		}
 	}
 	return env
 }


### PR DESCRIPTION
## Summary

Closes #4140. \`doltTargetEnvFromBeadsDir\` previously emitted the **shared** multi-database town data dir (\`<townRoot>/.dolt-data\`) on every call, even when the pinned \`.beads/metadata.json\` named a server connection. In server mode the running Dolt server already owns the data and the connection target is host/port; the shared data dir overrode the pinned database selector, so \`bd mol bond\` resolved routed cross-rig beads against the wrong database:

\`\`\`
bd: '<bead>' not found (not an issue ID or formula name)
\`\`\`

This broke polecat dispatch in any multi-rig town whose work bead's prefix routes to a non-town DB. Single-rig / town-prefix setups escaped because the bead lives in the DB the bond runs against — which is why this went unnoticed.

Companion to #4043, which added \`BEADS_DOLT_DATA_DIR\` to \`bdTargetEnvKeys\` so \`StripBDTargetEnv\` removes the inherited value. \`BuildPinnedBDEnv\` then immediately re-added it via \`doltTargetEnvFromBeadsDir\`; this fix scopes the re-add to **embedded mode only** (\`host == "" && port == ""\`).

## Diagnosis credit

The issue author (#4140) did the full bisection, traced the exact emit site, named the fix, and validated end-to-end (full \`gt sling mi-jjzc minerals\` → \`✓ Formula bonded\` → polecat picks up its hook). This PR applies their proposed fix and adds regression coverage.

## Test plan

- [x] \`go vet ./internal/beads/...\` clean
- [x] \`go test ./internal/beads/...\` — full package PASS (existing + new)
- [x] **TestBuildPinnedBDEnv_ServerModeOmitsSharedDataDir** — under a real town root (\`mayor/town.json\` present) with metadata.json naming server host+port, asserts \`BEADS_DOLT_DATA_DIR\` is absent. Verified the test FAILS on \`main\` without the fix (caught the bug).
- [x] **TestBuildPinnedBDEnv_EmbeddedModeKeepsSharedDataDir** — complement: under a real town root with NO server metadata, asserts the shared data dir IS still emitted so bd can locate on-disk data.
- [x] Pre-existing \`TestBuildPinnedBDEnvUsesSelectedConnectionMetadata\` — still passes (its temp dir has no \`mayor/town.json\` above it, so \`FindTownRoot\` returned \`""\` and the bug path wasn't exercised there).
- [x] Companion env builders (\`TestBuildRoutingBDEnvStripsDatabaseButKeepsSelectedConnection\`, \`TestBuildReadOnlyBDEnv*\`) — still pass.