### PR TITLE
fix: use split target columns in wisp_dependencies queries

### DIFF
--- a/internal/cmd/compact.go
+++ b/internal/cmd/compact.go
@@ -277,13 +277,16 @@ func runCompact(cmd *cobra.Command, args []string) error {
 }
 
 // cleanOrphanedWispDeps removes wisp_dependencies rows where either side no
-// longer exists in the wisps table. This happens when bd delete removes a wisp
-// but leaves behind its dependency records (bd delete has no cascade logic for
-// the wisp-level tables). Runs as a post-compact sweep.
+// longer exists. This happens when bd delete removes a wisp but leaves behind
+// its dependency records (bd delete has no cascade logic for the wisp-level
+// tables). Runs as a post-compact sweep.
 func cleanOrphanedWispDeps(bd *beads.Beads, result *compactResult) {
+	// wisp_dependencies uses split target columns (depends_on_wisp_id,
+	// depends_on_issue_id, depends_on_external) — no depends_on_id column.
 	const q = `DELETE FROM wisp_dependencies WHERE ` +
 		`NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.issue_id) ` +
-		`OR NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_id)`
+		`OR (depends_on_wisp_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_wisp_id)) ` +
+		`OR (depends_on_issue_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM issues WHERE id = wisp_dependencies.depends_on_issue_id))`
 	out, err := bd.Run("sql", q)
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("orphaned wisp_deps cleanup: %v", err))

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -203,7 +203,7 @@ func parentExcludeJoin(dbName string) (joinClause, whereCondition string) {
 	joinClause = `LEFT JOIN (
 		SELECT DISTINCT wd.issue_id
 		FROM wisp_dependencies wd
-		LEFT JOIN wisps pw ON pw.id = wd.depends_on_id LEFT JOIN issues pi ON pi.id = wd.depends_on_id
+		LEFT JOIN wisps pw ON pw.id = wd.depends_on_wisp_id LEFT JOIN issues pi ON pi.id = wd.depends_on_issue_id
 		WHERE wd.type = 'parent-child'
 		AND (pw.status IN ('open', 'hooked', 'in_progress') OR pi.status IN ('open', 'in_progress'))
 	) open_parent ON open_parent.issue_id = w.id`
@@ -278,13 +278,15 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 		AND i.issue_type != 'epic'
 		AND i.id NOT IN (
 			SELECT DISTINCT d.issue_id FROM dependencies d
-			INNER JOIN issues dep ON d.depends_on_id = dep.id
+			INNER JOIN issues dep ON d.depends_on_issue_id = dep.id
 			WHERE dep.status IN ('open', 'in_progress')
+			AND d.depends_on_issue_id IS NOT NULL
 		)
 		AND i.id NOT IN (
-			SELECT DISTINCT d.depends_on_id FROM dependencies d
+			SELECT DISTINCT d.depends_on_issue_id FROM dependencies d
 			INNER JOIN issues blocker ON d.issue_id = blocker.id
 			WHERE blocker.status IN ('open', 'in_progress')
+			AND d.depends_on_issue_id IS NOT NULL
 		)`
 	if err := db.QueryRowContext(ctx, staleQuery, now.Add(-staleIssueAge)).Scan(&result.StaleCandidates); err != nil {
 		if !isTableNotFound(err) {
@@ -302,8 +304,8 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 	// Anomaly detection: dangling parent references.
 	danglingQuery := `
 		SELECT COUNT(*) FROM wisp_dependencies wd
-		LEFT JOIN wisps pw ON pw.id = wd.depends_on_id LEFT JOIN issues pi ON pi.id = wd.depends_on_id
-		WHERE wd.type = 'parent-child' AND pw.id IS NULL AND pi.id IS NULL`
+		LEFT JOIN wisps pw ON pw.id = wd.depends_on_wisp_id LEFT JOIN issues pi ON pi.id = wd.depends_on_issue_id
+		WHERE wd.type = 'parent-child' AND pw.id IS NULL AND pi.id IS NULL AND wd.depends_on_external IS NULL`
 	var danglingCount int
 	if err := db.QueryRowContext(ctx, danglingQuery).Scan(&danglingCount); err == nil && danglingCount > 0 {
 		result.Anomalies = append(result.Anomalies, Anomaly{
@@ -604,13 +606,15 @@ func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (
 		)
 		AND i.id NOT IN (
 			SELECT DISTINCT d.issue_id FROM `+"`%s`"+`.dependencies d
-			INNER JOIN `+"`%s`"+`.issues dep ON d.depends_on_id = dep.id
+			INNER JOIN `+"`%s`"+`.issues dep ON d.depends_on_issue_id = dep.id
 			WHERE dep.status IN ('open', 'in_progress')
+			AND d.depends_on_issue_id IS NOT NULL
 		)
 		AND i.id NOT IN (
-			SELECT DISTINCT d.depends_on_id FROM `+"`%s`"+`.dependencies d
+			SELECT DISTINCT d.depends_on_issue_id FROM `+"`%s`"+`.dependencies d
 			INNER JOIN `+"`%s`"+`.issues blocker ON d.issue_id = blocker.id
 			WHERE blocker.status IN ('open', 'in_progress')
+			AND d.depends_on_issue_id IS NOT NULL
 		)`, dbName, dbName, dbName, dbName, dbName)
 
 	// Two-step SELECT-then-UPDATE to avoid self-referencing subquery in UPDATE,
@@ -747,8 +751,13 @@ func batchDeleteRows(ctx context.Context, db *sql.DB, idQuery string, cutoffArg 
 		}
 
 		// Clean up reverse dependency references to prevent dangling parent refs.
-		delReverse := fmt.Sprintf("DELETE FROM wisp_dependencies WHERE depends_on_id IN %s", inClause)
-		if _, err := db.ExecContext(ctx, delReverse, args...); err != nil {
+		// Uses split target columns — no depends_on_id column on wisp_dependencies.
+		delReverseWisp := fmt.Sprintf("DELETE FROM wisp_dependencies WHERE depends_on_wisp_id IN %s", inClause)
+		if _, err := db.ExecContext(ctx, delReverseWisp, args...); err != nil {
+			// Non-fatal.
+		}
+		delReverseIssue := fmt.Sprintf("DELETE FROM wisp_dependencies WHERE depends_on_issue_id IN %s", inClause)
+		if _, err := db.ExecContext(ctx, delReverseIssue, args...); err != nil {
 			// Non-fatal.
 		}
 

--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -86,7 +86,10 @@ func (m *Manager) Status() (*tmux.SessionInfo, error) {
 }
 
 // witnessDir returns the working directory for the witness.
-// Prefers witness/rig/, falls back to witness/, then rig root.
+// Prefers witness/rig/, then witness/, creating witness/ if neither exists.
+// Falling back to the rig root is intentionally avoided: rig roots are only
+// 1 level deep from the town root, which causes SetupRedirect to fail with
+// "must be at least 2 levels deep" (beads_redirect.go: ComputeRedirectTarget).
 func (m *Manager) witnessDir() string {
 	witnessRigDir := filepath.Join(m.rig.Path, "witness", "rig")
 	if _, err := os.Stat(witnessRigDir); err == nil {
@@ -98,6 +101,11 @@ func (m *Manager) witnessDir() string {
 		return witnessDir
 	}
 
+	// No dedicated witness directory — create one rather than falling back to
+	// the rig root, which is only 1 level deep and breaks SetupRedirect.
+	if err := os.MkdirAll(witnessDir, 0755); err == nil {
+		return witnessDir
+	}
 	return m.rig.Path
 }
 


### PR DESCRIPTION
## Summary

Two bugs fixed, both caused by the `wisp_dependencies` split-column schema change:

### Bug 1: `depends_on_id` column references (hq-isz)

`wisp_dependencies` uses split target columns (`depends_on_wisp_id`, `depends_on_issue_id`, `depends_on_external`) rather than a single `depends_on_id` column. Databases created with the new schema that didn't go through the old→new migration path in `0047` lack the `depends_on_id` STORED generated column, causing `bd compact` orphan-cleanup and `gt reaper scan` to fail every run.

**`internal/cmd/compact.go`** — `cleanOrphanedWispDeps`:
- Replace single `depends_on_id` check with explicit checks on `depends_on_wisp_id` (vs `wisps`) and `depends_on_issue_id` (vs `issues`)

**`internal/reaper/reaper.go`** — 5 sites:
- `parentExcludeJoin`: join `wisps` on `depends_on_wisp_id`, `issues` on `depends_on_issue_id`
- `danglingQuery`: same split-column joins; exclude `depends_on_external` rows from dangling check
- `Scan` `staleQuery`: use `depends_on_issue_id` for issue-to-issue blocking checks
- `AutoClose` `whereClause`: same fix for the multi-db variant
- `batchDeleteRows` `delReverse`: split into two non-fatal DELETEs (one per target column)

### Bug 2: witness falls back to rig root, breaking SetupRedirect

`witnessDir()` previously fell back to `m.rig.Path` when no `witness/` or `witness/rig/` subdirectory existed. Rig roots are only 1 level deep from the town root, causing `ComputeRedirectTarget` to fail with "must be at least 2 levels deep".

**`internal/witness/manager.go`**: create `witness/` automatically in the fallback path instead.

## Test plan

- [ ] `go build ./internal/cmd/... ./internal/reaper/... ./internal/witness/...` passes (verified)
- [ ] `bd compact` on a fresh-schema db — no `depends_on_id` error
- [ ] `gt reaper scan` on a fresh-schema db — scan completes
- [ ] `gt witness start <rig>` on a rig with no `witness/` dir — starts without depth error
- [ ] Old-schema dbs (with generated `depends_on_id`) still work

🤖 Generated with [Claude Code](https://claude.com/claude-code)