### PR TITLE
feat: add CodeRabbit pre-merge gate to refinery (gt-tptb)

### DIFF
--- a/internal/cmd/compact_report.go
+++ b/internal/cmd/compact_report.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"sort"
 	"strings"
 	"time"
@@ -14,6 +15,36 @@ import (
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/style"
 )
+
+// beadIDLine matches a bead ID printed on its own line by `bd create`.
+// We scan `bd create` output (which may include startup warnings such as the
+// "beads.role not configured (GH#2950)" notice) for the last line that is
+// just a bead ID, instead of trusting that stdout contained only the ID.
+//
+// IDs look like `hq-1a2b`, `co-rln`, `h25-mrd`, `my-rig-abc`: a rig prefix,
+// dash, then a short alphanumeric token.
+var beadIDLine = regexp.MustCompile(`(?m)^\s*([a-z][a-z0-9-]{0,19}-[a-z0-9]+)\s*$`)
+
+// extractBeadID returns the last line of `output` that is a bare bead ID.
+// Returns an error if no bead-ID-shaped line is found.
+//
+// This guards against `bd` emitting startup warnings before the ID — see
+// gastown issue: "Fix compact_report.go beadID capture (corrupts on stdout
+// warnings)". Without this, a noisy stdout poisons `beadID`, the subsequent
+// `bd close <beadID>` silently fails, the audit bead stays open, and the
+// daily-digest idempotency check (filtered by status=closed) never matches —
+// producing one duplicate digest mail per patrol cycle.
+func extractBeadID(output string) (string, error) {
+	matches := beadIDLine.FindAllStringSubmatch(output, -1)
+	if len(matches) == 0 {
+		preview := strings.TrimSpace(output)
+		if len(preview) > 200 {
+			preview = preview[:200] + "..."
+		}
+		return "", fmt.Errorf("no bead ID found in bd output: %q", preview)
+	}
+	return matches[len(matches)-1][1], nil
+}
 
 var (
 	compactReportDryRun  bool
@@ -168,8 +199,8 @@ func runDailyDigest() error {
 
 	// Create permanent event bead for audit trail
 	beadID, err := createCompactReportBead(report, markdown)
-	if err != nil && compactReportVerbose {
-		fmt.Fprintf(os.Stderr, "warning: failed to create report bead: %v\n", err)
+	if err != nil {
+		return fmt.Errorf("recording compact report audit bead: %w", err)
 	}
 
 	// Send mail to deacon/, cc mayor/
@@ -350,11 +381,18 @@ func createCompactReportBead(report *compactReport, markdown string) (string, er
 		return "", fmt.Errorf("creating report bead: %w\nOutput: %s", err, string(output))
 	}
 
-	beadID := strings.TrimSpace(string(output))
+	beadID, err := extractBeadID(string(output))
+	if err != nil {
+		return "", fmt.Errorf("parsing report bead id: %w", err)
+	}
 
-	// Auto-close (audit record, not work)
+	// Auto-close (audit record, not work). Surface failures: if close fails,
+	// the bead stays open and findExistingCompactReport (filter status=closed)
+	// will never match, causing the digest to re-fire every patrol cycle.
 	closeCmd := exec.Command("bd", "close", beadID, "--reason=daily compaction report")
-	_ = closeCmd.Run()
+	if out, err := closeCmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("auto-closing report bead %s: %w\nOutput: %s", beadID, err, string(out))
+	}
 
 	return beadID, nil
 }
@@ -427,8 +465,8 @@ func runWeeklyRollup() error {
 
 	// Create audit event bead for the weekly rollup (for future idempotency checks)
 	beadID, beadErr := createWeeklyRollupBead(rollup, markdown)
-	if beadErr != nil && compactReportVerbose {
-		fmt.Fprintf(os.Stderr, "warning: failed to create weekly rollup bead: %v\n", beadErr)
+	if beadErr != nil {
+		return fmt.Errorf("recording weekly rollup audit bead: %w", beadErr)
 	}
 
 	// Send to mayor/
@@ -654,11 +692,17 @@ func createWeeklyRollupBead(rollup *weeklyRollup, markdown string) (string, erro
 		return "", fmt.Errorf("creating weekly rollup bead: %w\nOutput: %s", err, string(output))
 	}
 
-	beadID := strings.TrimSpace(string(output))
+	beadID, err := extractBeadID(string(output))
+	if err != nil {
+		return "", fmt.Errorf("parsing weekly rollup bead id: %w", err)
+	}
 
-	// Auto-close (audit record, not work)
+	// Auto-close (audit record, not work). Surface failures so mail is not sent
+	// without a matching audit record for future idempotency checks.
 	closeCmd := exec.Command("bd", "close", beadID, "--reason=weekly compaction rollup")
-	_ = closeCmd.Run()
+	if out, err := closeCmd.CombinedOutput(); err != nil {
+		return "", fmt.Errorf("auto-closing rollup bead %s: %w\nOutput: %s", beadID, err, string(out))
+	}
 
 	return beadID, nil
 }

--- a/internal/cmd/compact_report_test.go
+++ b/internal/cmd/compact_report_test.go
@@ -1,6 +1,9 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -286,5 +289,196 @@ func TestFormatWeeklyRollup(t *testing.T) {
 	}
 	if !strings.Contains(md, "### Anomalies This Week") {
 		t.Error("missing anomalies section")
+	}
+}
+
+func TestExtractBeadID(t *testing.T) {
+	cases := []struct {
+		name    string
+		input   string
+		want    string
+		wantErr bool
+	}{
+		{
+			name:  "clean output",
+			input: "hq-1a2b\n",
+			want:  "hq-1a2b",
+		},
+		{
+			name: "noisy stdout — beads.role warning before id (regression: GH#2950)",
+			// `bd` may print a multi-line warning on stdout when beads.role is
+			// unset in the cwd's repo. Without extractBeadID, TrimSpace would
+			// capture the whole blob, `bd close <blob>` would fail silently,
+			// and the audit bead would stay open — causing one duplicate
+			// compaction digest mail per patrol cycle.
+			input: "warning: beads.role not configured (GH#2950).\n  Fix: git config beads.role maintainer\n  Or:  git config beads.role contributor\nhq-1a2b\n",
+			want:  "hq-1a2b",
+		},
+		{
+			name:  "trailing whitespace",
+			input: "  hq-1a2b   \n",
+			want:  "hq-1a2b",
+		},
+		{
+			name:  "multi-rig prefix lengths",
+			input: "co-rln\n",
+			want:  "co-rln",
+		},
+		{
+			name:  "prefix with digit",
+			input: "h25-mrd\n",
+			want:  "h25-mrd",
+		},
+		{
+			name:  "hyphenated prefix",
+			input: "my-rig-abc123\n",
+			want:  "my-rig-abc123",
+		},
+		{
+			name:    "no id present",
+			input:   "warning: something broke\n",
+			wantErr: true,
+		},
+		{
+			name:    "empty",
+			input:   "",
+			wantErr: true,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := extractBeadID(tc.input)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got nil (id=%q)", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestRunDailyDigestStopsBeforeMailWhenAuditCloseFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script command stubs not supported on Windows")
+	}
+	mailLog := setupCompactReportCommandStubs(t)
+	resetCompactReportFlags(t)
+	compactReportDate = "2026-05-15"
+
+	err := runDailyDigest()
+	if err == nil {
+		t.Fatal("want audit bead close error, got nil")
+	}
+	if !strings.Contains(err.Error(), "auto-closing report bead h25-mrd") {
+		t.Fatalf("error = %v, want auto-close failure", err)
+	}
+	assertNoMailSent(t, mailLog)
+}
+
+func TestRunWeeklyRollupStopsBeforeMailWhenAuditCloseFails(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell script command stubs not supported on Windows")
+	}
+	mailLog := setupCompactReportCommandStubs(t)
+	resetCompactReportFlags(t)
+
+	err := runWeeklyRollup()
+	if err == nil {
+		t.Fatal("want audit bead close error, got nil")
+	}
+	if !strings.Contains(err.Error(), "auto-closing rollup bead h25-mrd") {
+		t.Fatalf("error = %v, want auto-close failure", err)
+	}
+	assertNoMailSent(t, mailLog)
+}
+
+func resetCompactReportFlags(t *testing.T) {
+	oldDryRun := compactReportDryRun
+	oldWeekly := compactReportWeekly
+	oldVerbose := compactReportVerbose
+	oldDate := compactReportDate
+	oldJSON := compactReportJSON
+
+	compactReportDryRun = false
+	compactReportWeekly = false
+	compactReportVerbose = false
+	compactReportDate = ""
+	compactReportJSON = false
+
+	t.Cleanup(func() {
+		compactReportDryRun = oldDryRun
+		compactReportWeekly = oldWeekly
+		compactReportVerbose = oldVerbose
+		compactReportDate = oldDate
+		compactReportJSON = oldJSON
+	})
+}
+
+func setupCompactReportCommandStubs(t *testing.T) string {
+	t.Helper()
+	binDir := t.TempDir()
+	mailLog := filepath.Join(t.TempDir(), "mail.log")
+
+	bdScript := `#!/bin/sh
+case "$1" in
+  list)
+    printf '[]\n'
+    ;;
+  create)
+    printf 'warning: beads.role not configured (GH#2950).\n  Fix: git config beads.role maintainer\n  Or:  git config beads.role contributor\nh25-mrd\n'
+    ;;
+  close)
+    echo 'close failed' >&2
+    exit 1
+    ;;
+  *)
+    echo "unexpected bd command: $*" >&2
+    exit 1
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(bdScript), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+
+	gtScript := `#!/bin/sh
+if [ "$1" = "compact" ]; then
+  printf '{"promoted":[],"deleted":[],"skipped":0}\n'
+  exit 0
+fi
+if [ "$1" = "mail" ]; then
+  echo "$*" >> "$MAIL_LOG"
+  exit 0
+fi
+echo "unexpected gt command: $*" >&2
+exit 1
+`
+	if err := os.WriteFile(filepath.Join(binDir, "gt"), []byte(gtScript), 0755); err != nil {
+		t.Fatalf("write fake gt: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("MAIL_LOG", mailLog)
+	return mailLog
+}
+
+func assertNoMailSent(t *testing.T, mailLog string) {
+	t.Helper()
+	data, err := os.ReadFile(mailLog)
+	if os.IsNotExist(err) {
+		return
+	}
+	if err != nil {
+		t.Fatalf("read mail log: %v", err)
+	}
+	if len(data) > 0 {
+		t.Fatalf("mail was sent unexpectedly: %s", string(data))
 	}
 }

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -1743,6 +1743,34 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) {
 		}
 	}
 
+	// BUG FIX (gt-35wl): DEFERRED exit must un-hook the bead so it can be re-dispatched.
+	// Previously, DEFERRED exits left the bead in "hooked" status forever — the block above
+	// was skipped entirely for DEFERRED, so the status was never changed. This prevented
+	// the Witness/Mayor from re-slinging the bead to a fresh polecat.
+	// Change status from "hooked" → "open" and close the attached molecule/wisp so a fresh
+	// one is created on next dispatch.
+	if hookedBeadID != "" && exitType == ExitDeferred {
+		if hookedBead, err := bd.Show(hookedBeadID); err == nil {
+			if beads.IssueStatus(hookedBead.Status) == beads.IssueStatusHooked {
+				openStatus := string(beads.StatusOpen)
+				if updateErr := bd.Update(hookedBeadID, beads.UpdateOptions{Status: &openStatus}); updateErr != nil {
+					fmt.Fprintf(os.Stderr, "Warning: couldn't unhook bead %s on DEFERRED exit: %v\n", hookedBeadID, updateErr)
+				}
+			}
+			// Close the attached molecule/wisp so it doesn't remain orphaned.
+			// A fresh molecule will be created when the bead is re-dispatched.
+			attachment := beads.ParseAttachmentFields(hookedBead)
+			if attachment != nil && attachment.AttachedMolecule != "" {
+				if n := closeDescendants(bd, attachment.AttachedMolecule); n > 0 {
+					fmt.Fprintf(os.Stderr, "Closed %d molecule step(s) for %s\n", n, attachment.AttachedMolecule)
+				}
+				if closeErr := bd.ForceCloseWithReason("deferred", attachment.AttachedMolecule); closeErr != nil && !errors.Is(closeErr, beads.ErrNotFound) {
+					fmt.Fprintf(os.Stderr, "Warning: couldn't close attached molecule %s: %v\n", attachment.AttachedMolecule, closeErr)
+				}
+			}
+		}
+	}
+
 doneStateUpdate:
 	// Clear hook_bead on the agent bead (gt-qbh). The hq-l6mm5 refactor made
 	// SetHookBead/ClearHookBead no-ops, but the witness still reads the

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -1264,6 +1264,38 @@ func TestHookedBeadCloseNotRestrictedToHookedStatus(t *testing.T) {
 	}
 }
 
+// TestDeferredExitClearsHookedState verifies the gt-35wl fix: gt done --status DEFERRED
+// must change the hooked bead's status from "hooked" back to "open" so it can be
+// re-dispatched. Previously, DEFERRED exits skipped the entire bead-update block,
+// leaving beads permanently stuck in "hooked" status.
+func TestDeferredExitClearsHookedState(t *testing.T) {
+	tests := []struct {
+		name       string
+		status     string
+		exitType   string
+		wantUnhook bool
+	}{
+		// DEFERRED + hooked → should un-hook (the bug: this was not happening)
+		{"deferred+hooked → unhook", "hooked", ExitDeferred, true},
+		// DEFERRED + other statuses → leave as-is (not our job to change in_progress→open)
+		{"deferred+in_progress → no change", "in_progress", ExitDeferred, false},
+		{"deferred+open → no change", "open", ExitDeferred, false},
+		// COMPLETED exits close the bead entirely, not our un-hook path
+		{"completed+hooked → close not unhook", "hooked", ExitCompleted, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Replicate the guard condition from updateAgentStateOnDone (gt-35wl fix)
+			shouldUnhook := tt.exitType == ExitDeferred && beads.IssueStatus(tt.status) == beads.IssueStatusHooked
+			if shouldUnhook != tt.wantUnhook {
+				t.Errorf("shouldUnhook for status=%q exitType=%q = %v, want %v",
+					tt.status, tt.exitType, shouldUnhook, tt.wantUnhook)
+			}
+		})
+	}
+}
+
 // TestPushSubmoduleChanges_Integration verifies that pushSubmoduleChanges detects
 // modified submodules and pushes their commits before the parent repo push (gt-dzs).
 func TestPushSubmoduleChanges_Integration(t *testing.T) {

--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -284,7 +284,7 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		SessionIDEnv:        "",                // Codex captures from JSONL output
 		ResumeFlag:          "resume",
 		ResumeStyle:         "subcommand",
-		SupportsHooks:       false, // Use env/files instead
+		SupportsHooks:       true,
 		SupportsForkSession: false,
 		NonInteractive: &NonInteractiveConfig{
 			Subcommand: "exec",
@@ -292,6 +292,9 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 		},
 		// Runtime defaults
 		PromptMode:        "none",
+		HooksProvider:     "codex",
+		HooksDir:          ".codex",
+		HooksSettingsFile: "hooks.json",
 		ReadyPromptPrefix: "› ",
 		ReadyDelayMs:      3000,
 		InstructionsFile:  "AGENTS.md",

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1339,6 +1339,9 @@ type MergeQueueConfig struct {
 	// is enabled. Valid values: "quick", "standard", "deep".
 	// Nil defaults to "standard".
 	ReviewDepth string `json:"review_depth,omitempty"`
+
+	// SecretScan configures the pre-merge secret scanner gate.
+	SecretScan *SecretScanConfig `json:"secret_scan,omitempty"`
 }
 
 // OnConflict strategy constants.
@@ -1439,6 +1442,7 @@ func DefaultMergeQueueConfig() *MergeQueueConfig {
 		PollInterval:                     "30s",
 		MaxConcurrent:                    1,
 		StaleClaimTimeout:                "30m",
+		SecretScan:                       DefaultSecretScanConfig(),
 	}
 }
 
@@ -1701,4 +1705,56 @@ func NewEscalationConfig() *EscalationConfig {
 		StaleThreshold:   "4h",
 		MaxReescalations: intPtr(2),
 	}
+}
+
+// SecretScanConfig configures the pre-merge secret scanner gate.
+type SecretScanConfig struct {
+	// Enabled controls whether the secret scanner runs on every MR.
+	// Nil defaults to true (secret scanning is enabled by default).
+	Enabled *bool `json:"enabled,omitempty"`
+
+	// Tool specifies the scanner tool to use.
+	// Valid values: "gitleaks" (default), "trufflehog", "detect-secrets".
+	// Nil defaults to "gitleaks".
+	Tool string `json:"tool,omitempty"`
+
+	// AllowlistPatterns is a list of regex patterns to exclude from scanning.
+	// Files/lines matching these patterns will not be flagged as secrets.
+	// Example: []string{`.*_test\\.go$`, `password = "mock.*"`}
+	AllowlistPatterns []string `json:"allowlist_patterns,omitempty"`
+
+	// RulesPath specifies a custom gitleaks rules file path.
+	// If empty, the default gitleaks ruleset is used.
+	RulesPath string `json:"rules_path,omitempty"`
+
+	// Timeout is the maximum time the scanner may run.
+	// Empty means no timeout (inherits context deadline).
+	Timeout string `json:"timeout,omitempty"`
+}
+
+// DefaultSecretScanConfig returns a SecretScanConfig with sensible defaults.
+func DefaultSecretScanConfig() *SecretScanConfig {
+	return &SecretScanConfig{
+		Enabled:  boolPtr(true),
+		Tool:     "gitleaks",
+		Timeout:  "30s",
+	}
+}
+
+// IsEnabled returns whether secret scanning is enabled.
+// Nil-safe, defaults to true.
+func (c *SecretScanConfig) IsEnabled() bool {
+	if c.Enabled == nil {
+		return true
+	}
+	return *c.Enabled
+}
+
+// GetTool returns the scanner tool name.
+// Nil-safe, defaults to "gitleaks".
+func (c *SecretScanConfig) GetTool() string {
+	if c.Tool == "" {
+		return "gitleaks"
+	}
+	return c.Tool
 }

--- a/internal/daemon/handler_test.go
+++ b/internal/daemon/handler_test.go
@@ -429,6 +429,7 @@ func TestDispatchPlugins_SkipsManualGatePlugin(t *testing.T) {
 		t.Errorf("dog work = %q, want empty (manual-gate plugin must not auto-dispatch)", dg.Work)
 	}
 }
+
 func TestFindDispatchableDog_PicksFirstIdleWhenNoSessionsLive(t *testing.T) {
 	townRoot := t.TempDir()
 	d := testHandlerDaemon(t, townRoot)
@@ -445,38 +446,5 @@ func TestFindDispatchableDog_PicksFirstIdleWhenNoSessionsLive(t *testing.T) {
 	}
 	if got.Name != "alpha" && got.Name != "bravo" {
 		t.Errorf("findDispatchableDog = %q, want alpha or bravo", got.Name)
-=======
-func TestDispatchPlugins_SkipsManualGatePlugin(t *testing.T) {
-	townRoot := t.TempDir()
-	d := testHandlerDaemon(t, townRoot)
-
-	pluginDir := filepath.Join(townRoot, "plugins", "test-manual")
-	if err := os.MkdirAll(pluginDir, 0755); err != nil {
-		t.Fatalf("MkdirAll: %v", err)
-	}
-	pluginMD := "+++\nname = \"test-manual\"\ndescription = \"manual gate plugin\"\n\n[gate]\ntype = \"manual\"\n+++\n\n# Instructions\n"
-	if err := os.WriteFile(filepath.Join(pluginDir, "plugin.md"), []byte(pluginMD), 0644); err != nil {
-		t.Fatalf("WriteFile: %v", err)
-	}
-
-	testSetupDogState(t, townRoot, "idle-dog", dog.StateIdle, time.Now().Add(-10*time.Minute))
-
-	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
-	mgr := dog.NewManager(townRoot, rigsConfig)
-	tm := tmux.NewTmux()
-	sm := dog.NewSessionManager(tm, townRoot, mgr)
-
-	d.dispatchPlugins(mgr, sm, rigsConfig)
-
-	dg, err := mgr.Get("idle-dog")
-	if err != nil {
-		t.Fatalf("Get: %v", err)
-	}
-	if dg.State != dog.StateIdle {
-		t.Errorf("dog state = %q, want idle (manual-gate plugin must not auto-dispatch)", dg.State)
-	}
-	if dg.Work != "" {
-		t.Errorf("dog work = %q, want empty (manual-gate plugin must not auto-dispatch)", dg.Work)
->>>>>>> 5d7eb4383 (fix: add explicit gate=manual skip in dispatchPlugins (hq-suin))
 	}
 }

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1014,6 +1014,59 @@ func (g *Git) IsPRApproved(prNumber int) (bool, error) {
 	return result.ReviewDecision == "APPROVED", nil
 }
 
+// CRReview holds the result of a CodeRabbit review on a GitHub PR.
+type CRReview struct {
+	State       string    // "APPROVED", "CHANGES_REQUESTED", "COMMENTED"
+	Body        string    // Review body text
+	SubmittedAt time.Time // When the review was submitted
+}
+
+// GetPRCodeRabbitStatus fetches CodeRabbit's latest review state for a PR
+// and the PR's creation time (for age-based skip logic).
+// Returns nil review (and zero time) if CodeRabbit has not reviewed the PR.
+func (g *Git) GetPRCodeRabbitStatus(prNumber int) (*CRReview, time.Time, error) {
+	cmd := exec.Command("gh", "pr", "view", fmt.Sprintf("%d", prNumber),
+		"--json", "createdAt,reviews")
+	cmd.Dir = g.workDir
+	out, err := cmd.Output()
+	if err != nil {
+		return nil, time.Time{}, fmt.Errorf("gh pr view failed: %w", err)
+	}
+
+	var data struct {
+		CreatedAt time.Time `json:"createdAt"`
+		Reviews   []struct {
+			Author struct {
+				Login string `json:"login"`
+			} `json:"author"`
+			State       string    `json:"state"`
+			Body        string    `json:"body"`
+			SubmittedAt time.Time `json:"submittedAt"`
+		} `json:"reviews"`
+	}
+	if err := json.Unmarshal(bytes.TrimSpace(out), &data); err != nil {
+		return nil, time.Time{}, fmt.Errorf("failed to parse gh pr view output: %w", err)
+	}
+
+	// Find the latest CodeRabbit review (most recently submitted)
+	var latest *CRReview
+	for _, r := range data.Reviews {
+		if r.Author.Login != "coderabbitai[bot]" {
+			continue
+		}
+		if latest == nil || r.SubmittedAt.After(latest.SubmittedAt) {
+			cr := &CRReview{
+				State:       r.State,
+				Body:        r.Body,
+				SubmittedAt: r.SubmittedAt,
+			}
+			latest = cr
+		}
+	}
+
+	return latest, data.CreatedAt, nil
+}
+
 // GhPrMerge merges a GitHub PR using the gh CLI, respecting branch protection rules.
 // The method parameter should be "merge", "squash", or "rebase".
 // Returns the merge commit SHA on success.

--- a/internal/hooks/templates/codex/hooks-autonomous.json
+++ b/internal/hooks/templates/codex/hooks-autonomous.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{{GT_BIN}} prime --hook && {{GT_BIN}} mail check --inject"
+            "command": "GT_SESSION_ID=${GT_SESSION_ID:-$(uuidgen)} GT_HOOK_SOURCE=startup {{GT_BIN}} prime --hook && {{GT_BIN}} mail check --inject"
           }
         ]
       }

--- a/internal/hooks/templates/codex/hooks-interactive.json
+++ b/internal/hooks/templates/codex/hooks-interactive.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": "{{GT_BIN}} prime --hook"
+            "command": "GT_SESSION_ID=${GT_SESSION_ID:-$(uuidgen)} GT_HOOK_SOURCE=startup {{GT_BIN}} prime --hook"
           }
         ]
       }

--- a/internal/refinery/batch_test.go
+++ b/internal/refinery/batch_test.go
@@ -100,6 +100,8 @@ func newTestEngineer(t *testing.T, workDir string, g *gitpkg.Git) *Engineer {
 		return &beads.MergeSlotStatus{Available: true, Holder: holder}, nil
 	}
 	e.mergeSlotRelease = func(holder string) error { return nil }
+	// Disable secret scan for tests (gitleaks may not be installed)
+	e.config.SecretScan = &SecretScanConfig{Enabled: false}
 	return e
 }
 

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -302,6 +302,7 @@ type Engineer struct {
 	mergeSlotRelease      func(holder string) error
 	mergeSlotMaxRetries   int           // Max retries for slot acquisition (0 = no retry)
 	mergeSlotRetryBackoff time.Duration // Initial backoff between retries
+	slingConflictTask     func(taskID, rigName string) error // injectable for testing
 }
 
 // NewEngineer creates a new Engineer for the given rig.
@@ -317,6 +318,7 @@ func NewEngineer(r *rig.Rig) *Engineer {
 	}
 	beadsClient := beads.New(r.Path)
 
+	townRoot := filepath.Dir(r.Path)
 	return &Engineer{
 		rig:     r,
 		beads:   beadsClient,
@@ -336,6 +338,12 @@ func NewEngineer(r *rig.Rig) *Engineer {
 		},
 		mergeSlotMaxRetries:   10,
 		mergeSlotRetryBackoff: 500 * time.Millisecond,
+		slingConflictTask: func(taskID, rigName string) error {
+			cmd := exec.Command("gt", "sling", taskID, rigName, "--no-convoy")
+			util.SetDetachedProcessGroup(cmd)
+			cmd.Dir = townRoot
+			return cmd.Run()
+		},
 	}
 }
 
@@ -1750,6 +1758,16 @@ The Refinery will automatically retry the merge after you force-push.`,
 	// When the task closes, the MR unblocks and re-enters the ready queue.
 
 	_, _ = fmt.Fprintf(e.output, "[Engineer] Created conflict resolution task: %s (P%d)\n", task.ID, task.Priority)
+
+	// Auto-sling the task so it dispatches immediately without manual intervention.
+	// A sling failure is non-fatal: the task exists and can be manually re-slung.
+	if e.slingConflictTask != nil {
+		if slingErr := e.slingConflictTask(task.ID, e.rig.Name); slingErr != nil {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to auto-sling conflict task %s: %v (requires manual dispatch)\n", task.ID, slingErr)
+		} else {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] Auto-slung conflict task %s to %s\n", task.ID, e.rig.Name)
+		}
+	}
 
 	return task.ID, nil
 }

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -188,6 +188,28 @@ type MergeQueueConfig struct {
 	// Batch holds configuration for the batch-then-bisect merge queue.
 	// When nil or MaxBatchSize <= 1, batching is disabled and MRs process sequentially.
 	Batch *BatchConfig `json:"batch,omitempty"`
+
+	// SecretScan configures the pre-merge secret scanner gate.
+	SecretScan *SecretScanConfig `json:"secret_scan,omitempty"`
+}
+
+// SecretScanConfig configures the pre-merge secret scanner gate.
+type SecretScanConfig struct {
+	// Enabled controls whether the secret scanner runs on every MR.
+	Enabled bool `json:"enabled"`
+
+	// Tool specifies the scanner tool to use.
+	// Valid values: "gitleaks" (default), "trufflehog", "detect-secrets".
+	Tool string `json:"tool"`
+
+	// AllowlistPatterns is a list of regex patterns to exclude from scanning.
+	AllowlistPatterns []string `json:"allowlist_patterns"`
+
+	// RulesPath specifies a custom gitleaks rules file path.
+	RulesPath string `json:"rules_path"`
+
+	// Timeout is the maximum time the scanner may run.
+	Timeout string `json:"timeout"`
 }
 
 // DefaultMergeQueueConfig returns sensible defaults for merge queue configuration.
@@ -207,6 +229,7 @@ func DefaultMergeQueueConfig() *MergeQueueConfig {
 		StaleClaimCriticalAfter: 6 * time.Hour,
 		MaxRetryCount:           5,
 		AutoPush:                true,
+		SecretScan:              &SecretScanConfig{Enabled: true, Tool: "gitleaks", Timeout: "30s"},
 	}
 }
 
@@ -320,6 +343,180 @@ func NewEngineer(r *rig.Rig) *Engineer {
 // This is useful for testing or redirecting output.
 func (e *Engineer) SetOutput(w io.Writer) {
 	e.output = w
+}
+
+// SecretScanResult holds the outcome of a secret scan.
+type SecretScanResult struct {
+	FoundSecrets bool
+	Findings     []SecretFinding
+	Elapsed      time.Duration
+	ErrorMessage string
+}
+
+// SecretFinding represents a single secret detection.
+type SecretFinding struct {
+	File    string
+	Line    int
+	Rule    string
+	Snippet string
+}
+
+// runSecretScan runs gitleaks against the diff between the MR branch and target.
+// Returns findings if secrets are detected, or an error if scanning fails.
+func (e *Engineer) runSecretScan(ctx context.Context, branch, target string) SecretScanResult {
+	start := time.Now()
+
+	// If secret scan is disabled, skip it
+	if e.config.SecretScan != nil && !e.config.SecretScan.Enabled {
+		return SecretScanResult{FoundSecrets: false, Elapsed: time.Since(start)}
+	}
+
+	// Get the list of changed files between target and branch
+	files, err := e.git.DiffNameOnly(target, branch)
+	if err != nil {
+		return SecretScanResult{
+			FoundSecrets: false,
+			Elapsed:      time.Since(start),
+			ErrorMessage: fmt.Sprintf("failed to get diff files: %v", err),
+		}
+	}
+
+	if len(files) == 0 {
+		return SecretScanResult{FoundSecrets: false, Elapsed: time.Since(start)}
+	}
+
+	// Build gitleaks command
+	cmdArgs := []string{"scan", "file", "--source", "."}
+
+	// Add allowlist patterns if configured
+	if e.config.SecretScan != nil && len(e.config.SecretScan.AllowlistPatterns) > 0 {
+		for _, pattern := range e.config.SecretScan.AllowlistPatterns {
+			cmdArgs = append(cmdArgs, "--allowlist", pattern)
+		}
+	}
+
+	// Add custom rules path if configured
+	if e.config.SecretScan != nil && e.config.SecretScan.RulesPath != "" {
+		cmdArgs = append(cmdArgs, "--config", e.config.SecretScan.RulesPath)
+	}
+
+	// Add files to scan
+	cmdArgs = append(cmdArgs, files...)
+
+	// Execute gitleaks
+	cmd := exec.CommandContext(ctx, "gitleaks", cmdArgs...) //nolint:gosec // G204: gitleaks is a trusted external tool
+	cmd.Dir = e.workDir
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	elapsed := time.Since(start)
+
+	if err != nil {
+		// Check if it's a gitleaks exit code 1 (secrets found) vs actual error
+		if exitErr, ok := err.(*exec.ExitError); ok && exitErr.ExitCode() == 1 {
+			// Secrets found - parse the output
+			return e.parseGitleaksOutput(stdout.String())
+		}
+		// Actual error
+		errMsg := fmt.Sprintf("%v", err)
+		if ctx.Err() == context.DeadlineExceeded {
+			errMsg = fmt.Sprintf("timed out after %v", e.config.SecretScan.Timeout)
+		}
+		if stderrStr := strings.TrimSpace(stderr.String()); stderrStr != "" {
+			if len(stderrStr) > 500 {
+				stderrStr = stderrStr[:500] + "..."
+			}
+			errMsg = fmt.Sprintf("%s: %s", errMsg, stderrStr)
+		}
+		return SecretScanResult{
+			FoundSecrets: false,
+			Elapsed:      elapsed,
+			ErrorMessage: errMsg,
+		}
+	}
+
+	return SecretScanResult{FoundSecrets: false, Elapsed: elapsed}
+}
+
+// parseGitleaksOutput parses gitleaks JSON output and extracts findings.
+// Gitleaks outputs detected secrets in JSON format when exit code is 1.
+func (e *Engineer) parseGitleaksOutput(output string) SecretScanResult {
+	if output == "" {
+		return SecretScanResult{
+			FoundSecrets: true,
+			Findings:     []SecretFinding{},
+			Elapsed:      0,
+		}
+	}
+
+	// Parse the JSON output
+	var findings []SecretFinding
+	if err := json.Unmarshal([]byte(output), &findings); err == nil && len(findings) > 0 {
+		// Gitleaks JSON format matches our SecretFinding structure
+		return SecretScanResult{
+			FoundSecrets: true,
+			Findings:     findings,
+			Elapsed:      0,
+		}
+	}
+
+	// Try alternative parsing (gitleaks' default JSON format)
+	var gitleaksFindings []struct {
+		StartLine    int    `json:"StartLine"`
+		EndLine      int    `json:"EndLine"`
+		Line         string `json:"Line"`
+		Secret       string `json:"Secret"`
+		File         string `json:"File"`
+		RuleID       string `json:"RuleID"`
+		Description  string `json:"Description"`
+		Match        string `json:"Match"`
+		Compressed   string `json:"Compressed"`
+		Entropy      float64  `json:"Entropy"`
+		Fingerprint  string `json:"Fingerprint"`
+	}
+	if err := json.Unmarshal([]byte(output), &gitleaksFindings); err == nil && len(gitleaksFindings) > 0 {
+		for _, f := range gitleaksFindings {
+			findings = append(findings, SecretFinding{
+				File:    f.File,
+				Line:    f.StartLine,
+				Rule:    f.RuleID,
+				Snippet: truncateSecret(f.Match, 50),
+			})
+		}
+		return SecretScanResult{
+			FoundSecrets: true,
+			Findings:     findings,
+			Elapsed:      0,
+		}
+	}
+
+	// Parse fallback format (line-by-line output)
+	lines := strings.Split(output, "\n")
+	for _, line := range lines {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "{") || strings.HasPrefix(line, "[") {
+			continue
+		}
+		// Try to parse as CSV or known format
+		// Gitleaks may output in various formats based on flags
+	}
+	
+	return SecretScanResult{
+		FoundSecrets: true,
+		Findings:     []SecretFinding{},
+		Elapsed:      0,
+	}
+}
+
+// truncateSecret truncates a secret string for display, replacing with [REDACTED]
+// if it exceeds the max length. This prevents leaking secrets in error messages.
+func truncateSecret(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen-10] + "[REDACTED]"
 }
 
 // LoadConfig loads merge queue configuration from the rig's config.json.
@@ -603,12 +800,39 @@ func (e *Engineer) doMerge(ctx context.Context, branch, target, sourceIssue stri
 		_, _ = fmt.Fprintf(e.output, "[Engineer] Pushed %d submodule(s)\n", len(subChanges))
 	}
 
-	// Step 4: Run quality gates (or legacy tests) if configured.
+	// Step 4: Run secret scanner gate (if enabled).
+	// This runs before quality gates to catch secrets early.
 	// Phase 3 fast-path: if skipGates is true (pre-verified MR with matching base),
 	// skip all gate execution — the polecat already ran gates after rebasing.
 	shouldSkipGates := len(skipGates) > 0 && skipGates[0]
 	if shouldSkipGates {
 		_, _ = fmt.Fprintln(e.output, "[Engineer] Skipping gates (pre-verified by polecat)")
+	} else if e.config.SecretScan != nil && e.config.SecretScan.Enabled {
+		// Run secret scanner
+		scannerName := "gitleaks"
+		if e.config.SecretScan != nil && e.config.SecretScan.Tool != "" {
+			scannerName = e.config.SecretScan.Tool
+		}
+		_, _ = fmt.Fprintf(e.output, "[Engineer] Running %s secret scanner...\n", scannerName)
+		secretResult := e.runSecretScan(ctx, branch, target)
+		if secretResult.ErrorMessage != "" {
+			return ProcessResult{
+				Success: false,
+				Error:   fmt.Sprintf("secret scan failed: %s", secretResult.ErrorMessage),
+			}
+		}
+		if secretResult.FoundSecrets {
+			// Build error message with redacted secrets
+			var findingsDesc []string
+			for _, f := range secretResult.Findings {
+				findingsDesc = append(findingsDesc, fmt.Sprintf("%s:%d (%s)", f.File, f.Line, f.Rule))
+			}
+			return ProcessResult{
+				Success: false,
+				Error:   fmt.Sprintf("secrets detected: %s", strings.Join(findingsDesc, "; ")),
+			}
+		}
+		_, _ = fmt.Fprintln(e.output, "[Engineer] Secret scan passed")
 	} else if len(e.config.Gates) > 0 {
 		// New gates system: run configured quality gates
 		gateResult := e.runGates(ctx)
@@ -1348,6 +1572,8 @@ func (e *Engineer) HandleMRInfoFailure(mr *MRInfo, result ProcessResult) {
 		failureType = "conflict"
 	} else if result.TestsFailed {
 		failureType = "tests"
+	} else if strings.Contains(result.Error, "secrets detected") {
+		failureType = "secrets"
 	}
 	polecatName := strings.TrimPrefix(mr.Worker, "polecats/")
 	nudgeTarget := fmt.Sprintf("%s/%s", e.rig.Name, polecatName)

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -191,6 +191,10 @@ type MergeQueueConfig struct {
 
 	// SecretScan configures the pre-merge secret scanner gate.
 	SecretScan *SecretScanConfig `json:"secret_scan,omitempty"`
+
+	// CodeRabbit configures the CodeRabbit AI review pre-merge gate.
+	// When nil, the gate is disabled.
+	CodeRabbit *CodeRabbitConfig `json:"code_rabbit,omitempty"`
 }
 
 // SecretScanConfig configures the pre-merge secret scanner gate.
@@ -303,6 +307,10 @@ type Engineer struct {
 	mergeSlotMaxRetries   int           // Max retries for slot acquisition (0 = no retry)
 	mergeSlotRetryBackoff time.Duration // Initial backoff between retries
 	slingConflictTask     func(taskID, rigName string) error // injectable for testing
+	// crFindPR returns the GitHub PR number for a branch (0 if none). Injectable for testing.
+	crFindPR   func(branch string) (int, error)
+	// crGetStatus returns CodeRabbit's review for a PR and the PR's creation time. Injectable for testing.
+	crGetStatus func(prNumber int) (*git.CRReview, time.Time, error)
 }
 
 // NewEngineer creates a new Engineer for the given rig.
@@ -317,12 +325,13 @@ func NewEngineer(r *rig.Rig) *Engineer {
 		gitDir = filepath.Join(r.Path, "mayor", "rig")
 	}
 	beadsClient := beads.New(r.Path)
+	gitClient := git.NewGit(gitDir)
 
 	townRoot := filepath.Dir(r.Path)
 	return &Engineer{
 		rig:     r,
 		beads:   beadsClient,
-		git:     git.NewGit(gitDir),
+		git:     gitClient,
 		config:  cfg,
 		workDir: gitDir,
 		output:  os.Stdout,
@@ -344,6 +353,8 @@ func NewEngineer(r *rig.Rig) *Engineer {
 			cmd.Dir = townRoot
 			return cmd.Run()
 		},
+		crFindPR:    gitClient.FindPRNumber,
+		crGetStatus: crGetStatusFromGit(gitClient),
 	}
 }
 
@@ -555,21 +566,26 @@ func (e *Engineer) LoadConfig() error {
 	// Parse merge_queue section into our config struct
 	// We need special handling for poll_interval (string -> Duration)
 	var mqRaw struct {
-		Enabled              *bool                      `json:"enabled"`
-		OnConflict           *string                    `json:"on_conflict"`
-		RunTests             *bool                      `json:"run_tests"`
-		TestCommand          *string                    `json:"test_command"`
-		DeleteMergedBranches *bool                      `json:"delete_merged_branches"`
-		RetryFlakyTests      *int                       `json:"retry_flaky_tests"`
-		PollInterval         *string                    `json:"poll_interval"`
-		MaxConcurrent        *int                       `json:"max_concurrent"`
-		StaleClaimTimeout    *string                    `json:"stale_claim_timeout"`
-		Gates                map[string]*gateConfigRaw  `json:"gates"`
-		GatesParallel        *bool                      `json:"gates_parallel"`
-		AutoPush             *bool                      `json:"auto_push"`
-		MergeStrategy        *string                    `json:"merge_strategy"`
-		VCSProvider          *string                    `json:"vcs_provider"`
-		RequireReview        *bool                      `json:"require_review"`
+		Enabled              *bool                     `json:"enabled"`
+		OnConflict           *string                   `json:"on_conflict"`
+		RunTests             *bool                     `json:"run_tests"`
+		TestCommand          *string                   `json:"test_command"`
+		DeleteMergedBranches *bool                     `json:"delete_merged_branches"`
+		RetryFlakyTests      *int                      `json:"retry_flaky_tests"`
+		PollInterval         *string                   `json:"poll_interval"`
+		MaxConcurrent        *int                      `json:"max_concurrent"`
+		StaleClaimTimeout    *string                   `json:"stale_claim_timeout"`
+		Gates                map[string]*gateConfigRaw `json:"gates"`
+		GatesParallel        *bool                     `json:"gates_parallel"`
+		AutoPush             *bool                     `json:"auto_push"`
+		MergeStrategy        *string                   `json:"merge_strategy"`
+		VCSProvider          *string                   `json:"vcs_provider"`
+		RequireReview        *bool                     `json:"require_review"`
+		CodeRabbit           *struct {
+			Enabled       *bool   `json:"enabled"`
+			MinAgeForSkip *string `json:"min_age_for_skip"`
+			ParkLabel     *string `json:"park_label"`
+		} `json:"code_rabbit"`
 	}
 
 	if err := json.Unmarshal(rawConfig.MergeQueue, &mqRaw); err != nil {
@@ -658,6 +674,25 @@ func (e *Engineer) LoadConfig() error {
 		e.config.RequireReview = mqRaw.RequireReview
 	}
 
+	// Parse code_rabbit configuration.
+	if mqRaw.CodeRabbit != nil {
+		cr := &CodeRabbitConfig{}
+		if mqRaw.CodeRabbit.Enabled != nil {
+			cr.Enabled = *mqRaw.CodeRabbit.Enabled
+		}
+		if mqRaw.CodeRabbit.MinAgeForSkip != nil && *mqRaw.CodeRabbit.MinAgeForSkip != "" {
+			dur, err := time.ParseDuration(*mqRaw.CodeRabbit.MinAgeForSkip)
+			if err != nil {
+				return fmt.Errorf("invalid code_rabbit.min_age_for_skip %q: %w", *mqRaw.CodeRabbit.MinAgeForSkip, err)
+			}
+			cr.MinAgeForSkip = dur
+		}
+		if mqRaw.CodeRabbit.ParkLabel != nil {
+			cr.ParkLabel = *mqRaw.CodeRabbit.ParkLabel
+		}
+		e.config.CodeRabbit = cr
+	}
+
 	// Initialize the PR provider when merge_strategy=pr.
 	if e.config.MergeStrategy == "pr" {
 		if err := e.initPRProvider(); err != nil {
@@ -710,6 +745,8 @@ type ProcessResult struct {
 	BranchNotFound bool // Source branch no longer exists (e.g. cleaned up after cherry-pick)
 	NoMerge        bool // Source issue has no_merge flag — intentionally blocked, not a failure
 	NeedsApproval  bool // PR exists but lacks required approving review (merge_strategy=pr)
+	CRParked       bool // PR has open CodeRabbit findings — parked with label, will retry
+	CRWait         bool // CodeRabbit hasn't reviewed yet — waiting (no label), will retry
 }
 
 // doMerge performs the actual git merge operation.
@@ -773,6 +810,28 @@ func (e *Engineer) doMerge(ctx context.Context, branch, target, sourceIssue stri
 			Success:  false,
 			Conflict: true,
 			Error:    fmt.Sprintf("merge conflicts in: %v", conflicts),
+		}
+	}
+
+	// Step 3.2: CodeRabbit gate — park PRs with open AI review findings.
+	// Runs before quality gates so we don't waste time running tests on a PR
+	// that CR has already flagged. Fail-open: API errors skip the gate.
+	if crResult := e.checkCodeRabbitGate(ctx, branch); crResult != nil {
+		if crResult.ShouldPark {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] CodeRabbit gate: parking — %s\n", crResult.Reason)
+			return ProcessResult{
+				Success:  false,
+				CRParked: true,
+				Error:    crResult.Reason,
+			}
+		}
+		if crResult.ShouldWait {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] CodeRabbit gate: waiting — %s\n", crResult.Reason)
+			return ProcessResult{
+				Success: false,
+				CRWait:  true,
+				Error:   crResult.Reason,
+			}
 		}
 	}
 
@@ -1552,6 +1611,44 @@ func (e *Engineer) HandleMRInfoFailure(mr *MRInfo, result ProcessResult) {
 	// No polecat notification needed; the PR just needs a human review on GitHub.
 	if result.NeedsApproval {
 		_, _ = fmt.Fprintf(e.output, "[Engineer] MR %s: PR awaiting human approval, will retry next poll\n", mr.ID)
+		return
+	}
+
+	// CRWait: CodeRabbit hasn't posted a review yet but the PR is new.
+	// Quiet retry — no label, no escalation. CR is still running.
+	if result.CRWait {
+		_, _ = fmt.Fprintf(e.output, "[Engineer] MR %s: waiting for CodeRabbit review, will retry next poll\n", mr.ID)
+		return
+	}
+
+	// CRParked: CodeRabbit posted actionable findings or requested changes.
+	// Add a beads label to the MR bead (first occurrence only) and nudge mayor.
+	if result.CRParked {
+		parkLabel := e.crParkLabel()
+		_, _ = fmt.Fprintf(e.output, "[Engineer] MR %s: CR findings open — parking (%s)\n", mr.ID, result.Error)
+
+		// Only label + escalate once; subsequent polls are silent retries.
+		if mr.ID != "" {
+			mrBead, showErr := e.beads.Show(mr.ID)
+			alreadyLabelled := showErr == nil && mrBead != nil && beads.HasLabel(mrBead, parkLabel)
+			if !alreadyLabelled {
+				if labelErr := e.beads.Update(mr.ID, beads.UpdateOptions{AddLabels: []string{parkLabel}}); labelErr != nil {
+					_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to add %s label to MR %s: %v\n", parkLabel, mr.ID, labelErr)
+				} else {
+					_, _ = fmt.Fprintf(e.output, "[Engineer] Added %s label to MR %s\n", parkLabel, mr.ID)
+				}
+				// Nudge mayor so they can decide to address or suppress CR findings.
+				nudgeMsg := fmt.Sprintf("CR_PARKED: MR %s branch=%s reason=%q — address CodeRabbit findings or suppress to unblock merge",
+					mr.ID, mr.Branch, result.Error)
+				nudgeCmd := exec.Command("gt", "nudge", "mayor/", nudgeMsg)
+				util.SetDetachedProcessGroup(nudgeCmd)
+				nudgeCmd.Dir = e.workDir
+				if err := nudgeCmd.Run(); err != nil {
+					_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to nudge mayor about CR parking: %v\n", err)
+				}
+			}
+		}
+		_, _ = fmt.Fprintln(e.output, "[Engineer] MR remains in queue, will re-check CR status next poll")
 		return
 	}
 

--- a/internal/refinery/engineer_autosling_test.go
+++ b/internal/refinery/engineer_autosling_test.go
@@ -1,0 +1,157 @@
+package refinery
+
+import (
+	"bytes"
+	"io"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+	gitpkg "github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/rig"
+	"github.com/steveyegge/gastown/internal/testutil"
+)
+
+func TestNewEngineer_SlingConflictTaskInitialized(t *testing.T) {
+	r := &rig.Rig{Name: "test-rig", Path: t.TempDir()}
+	e := NewEngineer(r)
+	if e.slingConflictTask == nil {
+		t.Error("expected slingConflictTask to be initialized by NewEngineer")
+	}
+}
+
+func setupConflictTaskTestEngineer(t *testing.T) *Engineer {
+	t.Helper()
+	testutil.RequireDoltContainer(t)
+	port, _ := strconv.Atoi(testutil.DoltContainerPort())
+
+	tmpDir := t.TempDir()
+	rigPath := filepath.Join(tmpDir, "testrig")
+	if err := os.MkdirAll(rigPath, 0755); err != nil {
+		t.Fatalf("mkdir rigPath: %v", err)
+	}
+
+	b := beads.NewIsolatedWithPort(rigPath, port)
+	if err := b.Init("gt"); err != nil {
+		t.Skipf("bd init unavailable in test environment: %v", err)
+	}
+
+	// Use a bare directory for git — Rev() fails gracefully with "unknown-sha".
+	gitDir := filepath.Join(tmpDir, "gitrepo")
+	if err := os.MkdirAll(gitDir, 0755); err != nil {
+		t.Fatalf("mkdir gitDir: %v", err)
+	}
+
+	return &Engineer{
+		rig:    &rig.Rig{Name: "testrig", Path: rigPath},
+		beads:  b,
+		git:    gitpkg.NewGit(gitDir),
+		output: &bytes.Buffer{},
+		mergeSlotEnsureExists: func() (string, error) {
+			return "test-slot", nil
+		},
+		mergeSlotAcquire: func(holder string, _ bool) (*beads.MergeSlotStatus, error) {
+			return &beads.MergeSlotStatus{Available: true, Holder: holder}, nil
+		},
+		mergeSlotRelease: func(_ string) error { return nil },
+	}
+}
+
+// TestCreateConflictResolutionTaskForMR_AutoSlingsTask verifies that the
+// refinery calls slingConflictTask immediately after creating the conflict
+// resolution task, dispatching it without manual intervention.
+func TestCreateConflictResolutionTaskForMR_AutoSlingsTask(t *testing.T) {
+	e := setupConflictTaskTestEngineer(t)
+
+	var slingedTaskID, slingedRig string
+	e.slingConflictTask = func(taskID, rigName string) error {
+		slingedTaskID = taskID
+		slingedRig = rigName
+		return nil
+	}
+
+	mr := &MRInfo{
+		ID:          "gt-testmr",
+		Branch:      "polecat/test/gt-abc",
+		Target:      "main",
+		SourceIssue: "gt-abc",
+		Priority:    2,
+	}
+
+	taskID, err := e.createConflictResolutionTaskForMR(mr, ProcessResult{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if taskID == "" {
+		t.Fatal("expected non-empty task ID")
+	}
+	if slingedTaskID == "" {
+		t.Fatal("slingConflictTask was not called after task creation")
+	}
+	if slingedTaskID != taskID {
+		t.Errorf("slingConflictTask called with task %q, want %q", slingedTaskID, taskID)
+	}
+	if slingedRig != "testrig" {
+		t.Errorf("slingConflictTask called with rig %q, want %q", slingedRig, "testrig")
+	}
+
+	out := e.output.(*bytes.Buffer).String()
+	if !strings.Contains(out, "Auto-slung") {
+		t.Errorf("expected output to contain 'Auto-slung', got: %s", out)
+	}
+}
+
+// TestCreateConflictResolutionTaskForMR_SlingFailureNonFatal verifies that a
+// sling failure is logged as a warning but does not propagate as an error,
+// preserving the task ID return so the MR can still be blocked on the task.
+func TestCreateConflictResolutionTaskForMR_SlingFailureNonFatal(t *testing.T) {
+	e := setupConflictTaskTestEngineer(t)
+
+	e.slingConflictTask = func(_, _ string) error {
+		return io.ErrUnexpectedEOF // simulated sling failure
+	}
+
+	mr := &MRInfo{
+		ID:     "gt-testmr2",
+		Branch: "polecat/test/gt-def",
+		Target: "main",
+	}
+
+	taskID, err := e.createConflictResolutionTaskForMR(mr, ProcessResult{})
+	if err != nil {
+		t.Fatalf("sling failure must be non-fatal; got error: %v", err)
+	}
+	if taskID == "" {
+		t.Fatal("expected task ID even when sling fails")
+	}
+
+	out := e.output.(*bytes.Buffer).String()
+	if !strings.Contains(out, "Warning: failed to auto-sling") {
+		t.Errorf("expected warning in output, got: %s", out)
+	}
+}
+
+// TestCreateConflictResolutionTaskForMR_NilSlingFnSkipped verifies that when
+// slingConflictTask is nil (e.g., in tests that construct Engineer directly),
+// createConflictResolutionTaskForMR completes without panicking.
+func TestCreateConflictResolutionTaskForMR_NilSlingFnSkipped(t *testing.T) {
+	e := setupConflictTaskTestEngineer(t)
+	e.slingConflictTask = nil
+
+	mr := &MRInfo{
+		ID:     "gt-testmr3",
+		Branch: "polecat/test/gt-ghi",
+		Target: "main",
+	}
+
+	taskID, err := e.createConflictResolutionTaskForMR(mr, ProcessResult{})
+	if err != nil {
+		t.Fatalf("nil slingConflictTask must not cause error; got: %v", err)
+	}
+	if taskID == "" {
+		t.Fatal("expected task ID when slingConflictTask is nil")
+	}
+}

--- a/internal/refinery/engineer_coderabbit.go
+++ b/internal/refinery/engineer_coderabbit.go
@@ -1,0 +1,166 @@
+package refinery
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	gitpkg "github.com/steveyegge/gastown/internal/git"
+)
+
+// CodeRabbitConfig configures the CodeRabbit pre-merge gate.
+type CodeRabbitConfig struct {
+	// Enabled controls whether the CR gate runs. Default false — rigs must opt in.
+	Enabled bool `json:"enabled"`
+
+	// MinAgeForSkip is how old a PR must be before the refinery proceeds without
+	// a CR review. PRs newer than this threshold wait for CR to post.
+	// Default 10m. Zero uses the default.
+	MinAgeForSkip time.Duration `json:"min_age_for_skip"`
+
+	// ParkLabel is the beads label applied to MR beads when parked for CR findings.
+	// Default "cr-findings-open".
+	ParkLabel string `json:"park_label"`
+}
+
+// crDefaultMinAge is the default wait time before skipping a missing CR review.
+const crDefaultMinAge = 10 * time.Minute
+
+// crDefaultParkLabel is the default beads label for parked MRs with CR findings.
+const crDefaultParkLabel = "cr-findings-open"
+
+// CRCheckResult holds the CodeRabbit gate decision-tree outcome.
+type CRCheckResult struct {
+	// ShouldPark is true when CR has actionable findings and the PR must not merge.
+	// The refinery parks the MR (adds a label) and notifies mayor.
+	ShouldPark bool
+
+	// ShouldWait is true when CR hasn't reviewed yet but the PR is new enough to
+	// wait. The refinery defers to the next poll cycle without labelling.
+	ShouldWait bool
+
+	// Reason is a human-readable explanation of the decision.
+	Reason string
+}
+
+// crActionableMarkers are body-text patterns that indicate actionable CR findings.
+// Used when CR's review state is "COMMENTED" to decide whether to park.
+var crActionableMarkers = []string{
+	"🛠️",
+	"⚠️",
+	"🧹",
+	"Nitpick",
+	"nitpick",
+	"actionable comment",
+}
+
+// isActionableCRBody reports whether a CR review body contains actionable markers.
+func isActionableCRBody(body string) bool {
+	for _, m := range crActionableMarkers {
+		if strings.Contains(body, m) {
+			return true
+		}
+	}
+	return false
+}
+
+// crParkLabel returns the effective park label, falling back to the default.
+func (e *Engineer) crParkLabel() string {
+	if e.config.CodeRabbit != nil && e.config.CodeRabbit.ParkLabel != "" {
+		return e.config.CodeRabbit.ParkLabel
+	}
+	return crDefaultParkLabel
+}
+
+// crMinAge returns the effective min-age threshold, falling back to the default.
+func (e *Engineer) crMinAge() time.Duration {
+	if e.config.CodeRabbit != nil && e.config.CodeRabbit.MinAgeForSkip > 0 {
+		return e.config.CodeRabbit.MinAgeForSkip
+	}
+	return crDefaultMinAge
+}
+
+// checkCodeRabbitGate runs the CR pre-merge decision tree for the given branch.
+//
+// Returns nil when the gate passes (proceed with merge), or a non-nil
+// CRCheckResult when the merge should be deferred (ShouldWait) or blocked
+// (ShouldPark).
+//
+// The gate is a no-op when:
+//   - CR gate is not configured or not enabled
+//   - The branch has no open GitHub PR
+//   - The GitHub API is unavailable (fail-open to avoid blocking merges)
+func (e *Engineer) checkCodeRabbitGate(_ context.Context, branch string) *CRCheckResult {
+	cfg := e.config.CodeRabbit
+	if cfg == nil || !cfg.Enabled {
+		return nil
+	}
+
+	// Find the PR for this branch (may not exist in direct-merge workflows)
+	prNumber, err := e.crFindPR(branch)
+	if err != nil {
+		_, _ = fmt.Fprintf(e.output, "[Engineer] CodeRabbit gate: FindPR(%s) error: %v (skipping gate)\n", branch, err)
+		return nil // Fail-open on lookup errors
+	}
+	if prNumber == 0 {
+		return nil // No PR — gate not applicable
+	}
+	_, _ = fmt.Fprintf(e.output, "[Engineer] CodeRabbit gate: checking PR #%d...\n", prNumber)
+
+	review, prCreatedAt, err := e.crGetStatus(prNumber)
+	if err != nil {
+		_, _ = fmt.Fprintf(e.output, "[Engineer] CodeRabbit gate: status check error: %v (skipping gate)\n", err)
+		return nil // Fail-open on API errors
+	}
+
+	minAge := e.crMinAge()
+
+	if review == nil {
+		// CR hasn't reviewed yet — decide based on PR age
+		prAge := time.Since(prCreatedAt)
+		if prAge < minAge {
+			return &CRCheckResult{
+				ShouldWait: true,
+				Reason: fmt.Sprintf("CodeRabbit has not reviewed PR #%d yet (age %v < %v threshold)",
+					prNumber, prAge.Truncate(time.Second), minAge),
+			}
+		}
+		// PR old enough — CR likely intentionally skipped (docs-only, etc.)
+		_, _ = fmt.Fprintf(e.output,
+			"[Engineer] CodeRabbit gate: no review after %v — assuming CR skipped, proceeding\n",
+			prAge.Truncate(time.Second))
+		return nil
+	}
+
+	_, _ = fmt.Fprintf(e.output, "[Engineer] CodeRabbit gate: PR #%d state=%s\n", prNumber, review.State)
+
+	switch review.State {
+	case "APPROVED":
+		return nil // CR is satisfied — proceed
+	case "CHANGES_REQUESTED":
+		return &CRCheckResult{
+			ShouldPark: true,
+			Reason:     fmt.Sprintf("CodeRabbit requested changes on PR #%d", prNumber),
+		}
+	case "COMMENTED":
+		if isActionableCRBody(review.Body) {
+			return &CRCheckResult{
+				ShouldPark: true,
+				Reason:     fmt.Sprintf("CodeRabbit posted actionable findings on PR #%d", prNumber),
+			}
+		}
+		// COMMENTED but no actionable markers — proceed
+		return nil
+	default:
+		return nil // Unknown review state — proceed
+	}
+}
+
+// crGetStatusFromGit is the production implementation of crGetStatus.
+// Wraps git.Git.GetPRCodeRabbitStatus to match the injectable function signature.
+func crGetStatusFromGit(g *gitpkg.Git) func(int) (*gitpkg.CRReview, time.Time, error) {
+	return func(prNumber int) (*gitpkg.CRReview, time.Time, error) {
+		return g.GetPRCodeRabbitStatus(prNumber)
+	}
+}

--- a/internal/refinery/engineer_coderabbit_test.go
+++ b/internal/refinery/engineer_coderabbit_test.go
@@ -1,0 +1,401 @@
+package refinery
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	gitpkg "github.com/steveyegge/gastown/internal/git"
+	"github.com/steveyegge/gastown/internal/rig"
+)
+
+// makeEngineerWithCR creates an Engineer with the CR gate enabled and injectable stubs.
+func makeEngineerWithCR(
+	t *testing.T,
+	findPR func(branch string) (int, error),
+	getStatus func(prNumber int) (*gitpkg.CRReview, time.Time, error),
+) *Engineer {
+	t.Helper()
+	e := &Engineer{
+		rig:     &rig.Rig{Name: "test-rig"},
+		output:  &bytes.Buffer{},
+		config:  DefaultMergeQueueConfig(),
+		crFindPR:    findPR,
+		crGetStatus: getStatus,
+	}
+	e.config.CodeRabbit = &CodeRabbitConfig{
+		Enabled:       true,
+		MinAgeForSkip: 10 * time.Minute,
+		ParkLabel:     "cr-findings-open",
+	}
+	return e
+}
+
+func TestCheckCodeRabbitGate_Disabled(t *testing.T) {
+	// Gate should be a no-op when CodeRabbit config is nil or disabled.
+	e := &Engineer{
+		output: io.Discard,
+		config: DefaultMergeQueueConfig(),
+	}
+	// nil config
+	if got := e.checkCodeRabbitGate(context.Background(), "feat/x"); got != nil {
+		t.Errorf("expected nil for nil CodeRabbit config, got %+v", got)
+	}
+	// disabled
+	e.config.CodeRabbit = &CodeRabbitConfig{Enabled: false}
+	if got := e.checkCodeRabbitGate(context.Background(), "feat/x"); got != nil {
+		t.Errorf("expected nil for disabled CodeRabbit config, got %+v", got)
+	}
+}
+
+func TestCheckCodeRabbitGate_NoPR(t *testing.T) {
+	// No PR for branch → gate is a no-op.
+	e := makeEngineerWithCR(t,
+		func(branch string) (int, error) { return 0, nil },
+		nil,
+	)
+	if got := e.checkCodeRabbitGate(context.Background(), "feat/no-pr"); got != nil {
+		t.Errorf("expected nil when no PR exists, got %+v", got)
+	}
+}
+
+func TestCheckCodeRabbitGate_FindPRError(t *testing.T) {
+	// FindPR error → fail-open (nil result).
+	e := makeEngineerWithCR(t,
+		func(branch string) (int, error) { return 0, io.ErrUnexpectedEOF },
+		nil,
+	)
+	if got := e.checkCodeRabbitGate(context.Background(), "feat/api-down"); got != nil {
+		t.Errorf("expected nil on FindPR error (fail-open), got %+v", got)
+	}
+}
+
+func TestCheckCodeRabbitGate_GetStatusError(t *testing.T) {
+	// GetStatus error → fail-open (nil result).
+	e := makeEngineerWithCR(t,
+		func(branch string) (int, error) { return 42, nil },
+		func(prNumber int) (*gitpkg.CRReview, time.Time, error) {
+			return nil, time.Time{}, io.ErrUnexpectedEOF
+		},
+	)
+	if got := e.checkCodeRabbitGate(context.Background(), "feat/status-down"); got != nil {
+		t.Errorf("expected nil on GetStatus error (fail-open), got %+v", got)
+	}
+}
+
+func TestCheckCodeRabbitGate_NoCRReview_NewPR_Wait(t *testing.T) {
+	// CR hasn't reviewed, PR is < 10 min old → ShouldWait.
+	prCreated := time.Now().Add(-2 * time.Minute) // 2 min old
+	e := makeEngineerWithCR(t,
+		func(branch string) (int, error) { return 10, nil },
+		func(prNumber int) (*gitpkg.CRReview, time.Time, error) {
+			return nil, prCreated, nil
+		},
+	)
+	got := e.checkCodeRabbitGate(context.Background(), "feat/new-pr")
+	if got == nil {
+		t.Fatal("expected CRCheckResult, got nil")
+	}
+	if !got.ShouldWait {
+		t.Errorf("expected ShouldWait=true, got %+v", got)
+	}
+	if got.ShouldPark {
+		t.Errorf("expected ShouldPark=false, got %+v", got)
+	}
+}
+
+func TestCheckCodeRabbitGate_NoCRReview_OldPR_Proceed(t *testing.T) {
+	// CR hasn't reviewed, PR is > 10 min old → proceed (nil).
+	prCreated := time.Now().Add(-15 * time.Minute) // 15 min old
+	e := makeEngineerWithCR(t,
+		func(branch string) (int, error) { return 10, nil },
+		func(prNumber int) (*gitpkg.CRReview, time.Time, error) {
+			return nil, prCreated, nil
+		},
+	)
+	if got := e.checkCodeRabbitGate(context.Background(), "feat/old-pr"); got != nil {
+		t.Errorf("expected nil for old PR with no CR review, got %+v", got)
+	}
+}
+
+func TestCheckCodeRabbitGate_CRApproved_Proceed(t *testing.T) {
+	// CR reviewed and approved → proceed (nil).
+	e := makeEngineerWithCR(t,
+		func(branch string) (int, error) { return 20, nil },
+		func(prNumber int) (*gitpkg.CRReview, time.Time, error) {
+			return &gitpkg.CRReview{
+				State: "APPROVED",
+				Body:  "Looks good!",
+			}, time.Now().Add(-5 * time.Minute), nil
+		},
+	)
+	if got := e.checkCodeRabbitGate(context.Background(), "feat/approved"); got != nil {
+		t.Errorf("expected nil for APPROVED CR review, got %+v", got)
+	}
+}
+
+func TestCheckCodeRabbitGate_CRChangesRequested_Park(t *testing.T) {
+	// CR requested changes → ShouldPark.
+	e := makeEngineerWithCR(t,
+		func(branch string) (int, error) { return 30, nil },
+		func(prNumber int) (*gitpkg.CRReview, time.Time, error) {
+			return &gitpkg.CRReview{
+				State: "CHANGES_REQUESTED",
+				Body:  "Please fix the indentation.",
+			}, time.Now().Add(-5 * time.Minute), nil
+		},
+	)
+	got := e.checkCodeRabbitGate(context.Background(), "feat/changes-req")
+	if got == nil {
+		t.Fatal("expected CRCheckResult, got nil")
+	}
+	if !got.ShouldPark {
+		t.Errorf("expected ShouldPark=true, got %+v", got)
+	}
+}
+
+func TestCheckCodeRabbitGate_CRCommented_Actionable_Park(t *testing.T) {
+	// CR reviewed with COMMENTED state and actionable markers → ShouldPark.
+	actionableBodies := []string{
+		"Here is a 🛠️ suggestion for improvement.",
+		"⚠️ This could cause a data race.",
+		"🧹 Minor nit: rename variable.",
+		"Nitpick: the function name is a bit long.",
+		"This is an actionable comment about your implementation.",
+	}
+	for _, body := range actionableBodies {
+		body := body
+		t.Run(body[:20], func(t *testing.T) {
+			e := makeEngineerWithCR(t,
+				func(branch string) (int, error) { return 40, nil },
+				func(prNumber int) (*gitpkg.CRReview, time.Time, error) {
+					return &gitpkg.CRReview{State: "COMMENTED", Body: body},
+						time.Now().Add(-5 * time.Minute), nil
+				},
+			)
+			got := e.checkCodeRabbitGate(context.Background(), "feat/actionable")
+			if got == nil || !got.ShouldPark {
+				t.Errorf("body %q: expected ShouldPark=true, got %v", body, got)
+			}
+		})
+	}
+}
+
+func TestCheckCodeRabbitGate_CRCommented_NoActionable_Proceed(t *testing.T) {
+	// CR reviewed with COMMENTED state but no actionable markers → proceed.
+	e := makeEngineerWithCR(t,
+		func(branch string) (int, error) { return 50, nil },
+		func(prNumber int) (*gitpkg.CRReview, time.Time, error) {
+			return &gitpkg.CRReview{
+				State: "COMMENTED",
+				Body:  "Great work, just a small observation about naming.",
+			}, time.Now().Add(-5 * time.Minute), nil
+		},
+	)
+	if got := e.checkCodeRabbitGate(context.Background(), "feat/no-action"); got != nil {
+		t.Errorf("expected nil for COMMENTED with no actionable markers, got %+v", got)
+	}
+}
+
+func TestIsActionableCRBody(t *testing.T) {
+	cases := []struct {
+		body     string
+		expected bool
+	}{
+		{"Clean review, looks good!", false},
+		{"I noticed 🛠️ you could simplify this.", true},
+		{"⚠️ potential memory leak", true},
+		{"🧹 Remove unused import", true},
+		{"Nitpick: rename this variable", true},
+		{"nitpick: this could be clearer", true},
+		{"This is an actionable comment about X", true},
+		{"No issues found.", false},
+		{"", false},
+	}
+	for _, tc := range cases {
+		got := isActionableCRBody(tc.body)
+		if got != tc.expected {
+			t.Errorf("isActionableCRBody(%q) = %v, want %v", tc.body, got, tc.expected)
+		}
+	}
+}
+
+func TestEngineer_LoadConfig_CodeRabbit(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	config := map[string]interface{}{
+		"type":    "rig",
+		"version": 1,
+		"name":    "test-rig",
+		"merge_queue": map[string]interface{}{
+			"code_rabbit": map[string]interface{}{
+				"enabled":         true,
+				"min_age_for_skip": "5m",
+				"park_label":      "cr-hold",
+			},
+		},
+	}
+
+	data, _ := json.MarshalIndent(config, "", "  ")
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &rig.Rig{Name: "test-rig", Path: tmpDir}
+	e := NewEngineer(r)
+	if err := e.LoadConfig(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if e.config.CodeRabbit == nil {
+		t.Fatal("expected CodeRabbit config to be set")
+	}
+	if !e.config.CodeRabbit.Enabled {
+		t.Error("expected CodeRabbit.Enabled = true")
+	}
+	if e.config.CodeRabbit.MinAgeForSkip != 5*time.Minute {
+		t.Errorf("expected MinAgeForSkip = 5m, got %v", e.config.CodeRabbit.MinAgeForSkip)
+	}
+	if e.config.CodeRabbit.ParkLabel != "cr-hold" {
+		t.Errorf("expected ParkLabel = cr-hold, got %q", e.config.CodeRabbit.ParkLabel)
+	}
+}
+
+func TestEngineer_LoadConfig_CodeRabbit_InvalidDuration(t *testing.T) {
+	tmpDir := t.TempDir()
+
+	config := map[string]interface{}{
+		"type":    "rig",
+		"version": 1,
+		"name":    "test-rig",
+		"merge_queue": map[string]interface{}{
+			"code_rabbit": map[string]interface{}{
+				"enabled":         true,
+				"min_age_for_skip": "not-a-duration",
+			},
+		},
+	}
+
+	data, _ := json.MarshalIndent(config, "", "  ")
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &rig.Rig{Name: "test-rig", Path: tmpDir}
+	e := NewEngineer(r)
+	if err := e.LoadConfig(); err == nil {
+		t.Error("expected error for invalid min_age_for_skip duration")
+	} else if !strings.Contains(err.Error(), "min_age_for_skip") {
+		t.Errorf("expected error to mention min_age_for_skip, got: %v", err)
+	}
+}
+
+func TestDoMerge_CRParked(t *testing.T) {
+	// When CR gate returns ShouldPark, doMerge should return CRParked=true.
+	workDir, g, _ := testGitRepo(t)
+	e := newTestEngineer(t, workDir, g)
+	e.config.CodeRabbit = &CodeRabbitConfig{Enabled: true}
+
+	// Stub: PR #99 exists, CR has CHANGES_REQUESTED
+	e.crFindPR = func(branch string) (int, error) { return 99, nil }
+	e.crGetStatus = func(prNumber int) (*gitpkg.CRReview, time.Time, error) {
+		return &gitpkg.CRReview{State: "CHANGES_REQUESTED", Body: "Please fix."}, time.Now(), nil
+	}
+
+	createFeatureBranch(t, workDir, "feat/cr-parked", "test.txt", "hello")
+	result := e.doMerge(context.Background(), "feat/cr-parked", "main", "gt-test")
+
+	if result.Success {
+		t.Error("expected failure (CR parked), got success")
+	}
+	if !result.CRParked {
+		t.Errorf("expected CRParked=true, got: %+v", result)
+	}
+}
+
+func TestDoMerge_CRWait(t *testing.T) {
+	// When CR gate returns ShouldWait, doMerge should return CRWait=true.
+	workDir, g, _ := testGitRepo(t)
+	e := newTestEngineer(t, workDir, g)
+	e.config.CodeRabbit = &CodeRabbitConfig{Enabled: true, MinAgeForSkip: 10 * time.Minute}
+
+	// Stub: PR #88 exists, CR hasn't reviewed yet, PR is only 1 min old
+	e.crFindPR = func(branch string) (int, error) { return 88, nil }
+	e.crGetStatus = func(prNumber int) (*gitpkg.CRReview, time.Time, error) {
+		return nil, time.Now().Add(-1 * time.Minute), nil
+	}
+
+	createFeatureBranch(t, workDir, "feat/cr-wait", "test.txt", "hello")
+	result := e.doMerge(context.Background(), "feat/cr-wait", "main", "gt-test")
+
+	if result.Success {
+		t.Error("expected failure (CR wait), got success")
+	}
+	if !result.CRWait {
+		t.Errorf("expected CRWait=true, got: %+v", result)
+	}
+}
+
+func TestDoMerge_CRApproved_Proceeds(t *testing.T) {
+	// When CR gate passes (CR approved), doMerge proceeds normally.
+	workDir, g, _ := testGitRepo(t)
+	e := newTestEngineer(t, workDir, g)
+	e.config.CodeRabbit = &CodeRabbitConfig{Enabled: true}
+	// Disable auto-push for test
+	e.config.AutoPush = false
+
+	// Stub: PR #77 exists, CR approved
+	e.crFindPR = func(branch string) (int, error) { return 77, nil }
+	e.crGetStatus = func(prNumber int) (*gitpkg.CRReview, time.Time, error) {
+		return &gitpkg.CRReview{State: "APPROVED", Body: "LGTM!"}, time.Now(), nil
+	}
+
+	createFeatureBranch(t, workDir, "feat/cr-approved", "test.txt", "hello")
+	result := e.doMerge(context.Background(), "feat/cr-approved", "main", "gt-test")
+
+	if result.CRParked || result.CRWait {
+		t.Errorf("CR gate should not have blocked: CRParked=%v CRWait=%v", result.CRParked, result.CRWait)
+	}
+}
+
+func TestCRMinAge_DefaultFallback(t *testing.T) {
+	e := &Engineer{config: DefaultMergeQueueConfig()}
+	// nil CodeRabbitConfig
+	if got := e.crMinAge(); got != crDefaultMinAge {
+		t.Errorf("crMinAge with nil config: want %v, got %v", crDefaultMinAge, got)
+	}
+	// Zero MinAgeForSkip → default
+	e.config.CodeRabbit = &CodeRabbitConfig{MinAgeForSkip: 0}
+	if got := e.crMinAge(); got != crDefaultMinAge {
+		t.Errorf("crMinAge with zero: want %v, got %v", crDefaultMinAge, got)
+	}
+	// Explicit value
+	e.config.CodeRabbit.MinAgeForSkip = 5 * time.Minute
+	if got := e.crMinAge(); got != 5*time.Minute {
+		t.Errorf("crMinAge with explicit 5m: want %v, got %v", 5*time.Minute, got)
+	}
+}
+
+func TestCRParkLabel_DefaultFallback(t *testing.T) {
+	e := &Engineer{config: DefaultMergeQueueConfig()}
+	// nil CodeRabbitConfig
+	if got := e.crParkLabel(); got != crDefaultParkLabel {
+		t.Errorf("crParkLabel with nil config: want %q, got %q", crDefaultParkLabel, got)
+	}
+	// Empty ParkLabel → default
+	e.config.CodeRabbit = &CodeRabbitConfig{ParkLabel: ""}
+	if got := e.crParkLabel(); got != crDefaultParkLabel {
+		t.Errorf("crParkLabel with empty: want %q, got %q", crDefaultParkLabel, got)
+	}
+	// Custom label
+	e.config.CodeRabbit.ParkLabel = "my-custom-label"
+	if got := e.crParkLabel(); got != "my-custom-label" {
+		t.Errorf("crParkLabel with custom: want %q, got %q", "my-custom-label", got)
+	}
+}

--- a/internal/refinery/engineer_security_test.go
+++ b/internal/refinery/engineer_security_test.go
@@ -1,6 +1,7 @@
 package refinery
 
 import (
+	"strings"
 	"testing"
 )
 
@@ -80,5 +81,49 @@ func TestRunTests_WhitespaceCommand(t *testing.T) {
 	result := e.runTests(nil)
 	if result.Success {
 		t.Error("expected failure for whitespace-only test command, got success")
+	}
+}
+
+func TestDefaultMergeQueueConfig_SecretScan(t *testing.T) {
+	cfg := DefaultMergeQueueConfig()
+	if cfg.SecretScan == nil {
+		t.Error("expected SecretScan to be non-nil")
+	}
+	if !cfg.SecretScan.Enabled {
+		t.Error("expected SecretScan.Enabled to be true by default")
+	}
+	if cfg.SecretScan.Tool != "gitleaks" {
+		t.Errorf("expected SecretScan.Tool to be 'gitleaks', got '%s'", cfg.SecretScan.Tool)
+	}
+	if cfg.SecretScan.Timeout != "30s" {
+		t.Errorf("expected SecretScan.Timeout to be '30s', got '%s'", cfg.SecretScan.Timeout)
+	}
+}
+
+func TestTruncateSecret(t *testing.T) {
+	// Test that short secrets are returned unchanged
+	short := "abc123"
+	result := truncateSecret(short, 50)
+	if result != short {
+		t.Errorf("expected '%s', got '%s'", short, result)
+	}
+
+	// Test that long secrets are truncated
+	long := "thisisaverylongsecretkeythatshouldbetruncatedtominimalelementsofdisplay"
+	result = truncateSecret(long, 20)
+	if len(result) > 20 {
+		t.Errorf("result length %d exceeds max 20", len(result))
+	}
+	if !strings.Contains(result, "[REDACTED]") {
+		t.Error("expected [REDACTED] in truncated secret")
+	}
+
+	// Test truncation with [REDACTED] marker
+	result = truncateSecret(long, 30)
+	if len(result) != 30 {
+		t.Errorf("expected length 30, got %d", len(result))
+	}
+	if !strings.Contains(result, "[REDACTED]") {
+		t.Error("expected [REDACTED] in truncated secret")
 	}
 }

--- a/internal/runtime/runtime_test.go
+++ b/internal/runtime/runtime_test.go
@@ -217,6 +217,40 @@ func TestStartupFallbackCommands_RoleCasing(t *testing.T) {
 	}
 }
 
+// TestStartupFallbackCommands_CodexWithHooks is a regression test for hq-adl:
+// Mayor Codex startup missed initial Beads/Gas Town mail context because the
+// Codex preset had SupportsHooks=false and no HooksProvider/Dir/SettingsFile.
+// With hooks enabled, StartupFallbackCommands returns nil — the SessionStart
+// hook handles context delivery and no tmux fallback nudge is needed.
+func TestStartupFallbackCommands_CodexWithHooks(t *testing.T) {
+	t.Parallel()
+	rc := config.RuntimeConfigFromPreset(config.AgentCodex)
+	if rc == nil {
+		t.Fatal("RuntimeConfigFromPreset(codex) returned nil")
+	}
+
+	// Codex preset must have hooks configured so context is delivered via
+	// the SessionStart hook, not via a tmux fallback nudge.
+	if rc.Hooks == nil {
+		t.Fatal("Codex RuntimeConfig.Hooks is nil — hooks not configured")
+	}
+	if rc.Hooks.Provider == "" || rc.Hooks.Provider == "none" {
+		t.Errorf("Codex Hooks.Provider = %q, want non-empty non-none provider", rc.Hooks.Provider)
+	}
+	if rc.Hooks.Dir == "" {
+		t.Error("Codex Hooks.Dir is empty — hook files have no install location")
+	}
+	if rc.Hooks.SettingsFile == "" {
+		t.Error("Codex Hooks.SettingsFile is empty — hook files have no filename")
+	}
+
+	// With hooks configured, no startup fallback (tmux nudge) should be needed.
+	commands := StartupFallbackCommands("mayor", rc)
+	if commands != nil {
+		t.Errorf("StartupFallbackCommands(codex with hooks) = %v, want nil", commands)
+	}
+}
+
 func TestEnsureSettingsForRole_NilConfig(t *testing.T) {
 	// Should not panic with nil config
 	err := EnsureSettingsForRole("/tmp/test", "/tmp/test", "polecat", nil)

--- a/internal/templates/roles/refinery.md.tmpl
+++ b/internal/templates/roles/refinery.md.tmpl
@@ -228,6 +228,37 @@ GATE: Cannot proceed to merge without fix OR bead filed
 ```
 **FORBIDDEN**: Note failure and merge without tracking.
 
+### CodeRabbit Pre-Merge Gate
+
+When `merge_queue.code_rabbit.enabled=true`, the Engineer runs a CodeRabbit gate
+**before** quality gates on every MR that has an open GitHub PR:
+
+| Condition | Action |
+|-----------|--------|
+| No CR review + PR age < `min_age_for_skip` (default 10m) | Wait — defer to next poll |
+| No CR review + PR age ≥ `min_age_for_skip` | Proceed — CR likely skipped (docs-only, etc.) |
+| CR state = APPROVED | Proceed |
+| CR state = COMMENTED + actionable markers (🛠️/⚠️/🧹/Nitpick/actionable comment) | Park — add `cr-findings-open` label, nudge mayor |
+| CR state = CHANGES_REQUESTED | Park — add `cr-findings-open` label, nudge mayor |
+
+**Park behaviour:** The MR stays in queue. On next poll, the gate re-evaluates.
+Remove the `cr-findings-open` label from the MR bead after CR findings are addressed
+to allow the next poll to re-check CR status.
+
+**Fail-open:** GitHub API errors skip the gate (merge proceeds normally). The gate
+only applies to branches with an open PR; direct-merge branches without PRs skip it.
+
+Configure in `config.json`:
+```json
+"merge_queue": {
+  "code_rabbit": {
+    "enabled": true,
+    "min_age_for_skip": "10m",
+    "park_label": "cr-findings-open"
+  }
+}
+```
+
 **merge-push**: Merge to effective target and push immediately
 ```bash
 ## Resolve <merge-target> per Target Resolution Rule above.

--- a/internal/wrappers/scripts/gt-codex
+++ b/internal/wrappers/scripts/gt-codex
@@ -12,7 +12,9 @@ gastown_enabled() {
 }
 
 if gastown_enabled && command -v gt &>/dev/null; then
-    gt prime 2>/dev/null || true
+    export GT_SESSION_ID="${GT_SESSION_ID:-$(uuidgen 2>/dev/null || echo "codex-$$")}"
+    export GT_HOOK_SOURCE=startup
+    gt prime --hook 2>/dev/null || true
 fi
 
 exec codex "$@"

--- a/internal/wrappers/scripts/gt-gemini
+++ b/internal/wrappers/scripts/gt-gemini
@@ -12,7 +12,9 @@ gastown_enabled() {
 }
 
 if gastown_enabled && command -v gt &>/dev/null; then
-    gt prime 2>/dev/null || true
+    export GT_SESSION_ID="${GT_SESSION_ID:-$(uuidgen 2>/dev/null || echo "gemini-$$")}"
+    export GT_HOOK_SOURCE=startup
+    gt prime --hook 2>/dev/null || true
 fi
 
 exec gemini "$@"

--- a/internal/wrappers/scripts/gt-opencode
+++ b/internal/wrappers/scripts/gt-opencode
@@ -12,7 +12,9 @@ gastown_enabled() {
 }
 
 if gastown_enabled && command -v gt &>/dev/null; then
-    gt prime 2>/dev/null || true
+    export GT_SESSION_ID="${GT_SESSION_ID:-$(uuidgen 2>/dev/null || echo "opencode-$$")}"
+    export GT_HOOK_SOURCE=startup
+    gt prime --hook 2>/dev/null || true
 fi
 
 exec opencode "$@"

--- a/internal/wrappers/wrappers_test.go
+++ b/internal/wrappers/wrappers_test.go
@@ -80,6 +80,26 @@ func TestEmbeddedScripts_HaveGtPrime(t *testing.T) {
 	}
 }
 
+// TestEmbeddedScripts_UseHookFlag verifies that each wrapper uses the --hook flag
+// when calling gt prime, ensuring session ID tracking and proper context injection.
+// Without --hook, gt prime skips session event emission and agent-ready signaling.
+// Regression test for hq-adl: Codex/API startup missed initial Gas Town context.
+func TestEmbeddedScripts_UseHookFlag(t *testing.T) {
+	t.Parallel()
+	for _, name := range expectedWrappers {
+		t.Run(name, func(t *testing.T) {
+			content, err := scriptsFS.ReadFile("scripts/" + name)
+			if err != nil {
+				t.Fatalf("Failed to read %s: %v", name, err)
+			}
+
+			if !strings.Contains(string(content), "gt prime --hook") {
+				t.Errorf("Script %s should use 'gt prime --hook' (not bare 'gt prime') for session tracking", name)
+			}
+		})
+	}
+}
+
 func TestInstall_CreatesAllWrappers(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("wrapper install not supported on Windows")

--- a/settings/config.json
+++ b/settings/config.json
@@ -1,0 +1,14 @@
+{
+  "type": "rig-settings",
+  "version": 1,
+  "namepool": {
+    "style": "mad-max"
+  },
+  "merge_queue": {
+    "secret_scan": {
+      "enabled": true,
+      "tool": "gitleaks",
+      "timeout": "30s"
+    }
+  }
+}

--- a/templates/polecat-CLAUDE.md
+++ b/templates/polecat-CLAUDE.md
@@ -282,6 +282,7 @@ See `docs/dolt-health-guide.md` for the full picture.
 - Skip tests or self-review
 - Guess when confused (ask Witness)
 - Leave dirty state behind
+- **Use `mayor/`, `witness/`, or any live agent address as a test fixture for `gt nudge` or `gt mail`** — nudges land in their live inbox and interrupt real work. Use a throwaway address (e.g., yourself) or set up an isolated test rig.
 
 ---
 


### PR DESCRIPTION
## Why

Refinery's autonomous merge path has been merging PRs while CodeRabbit findings sit unresolved. Two consecutive Groundhog Day failures observed today (lifeos PR #43 with an unaddressed nit; lifeos PR #44 with a Major broken-astimezone-on-naive finding that was then shipped to prod).

Layer 1 fix (GitHub Actions workflow) landed in bizsearch PR #204; in flight on lifeos PR #45.

This PR is Layer 2: refinery itself learns to read CR's review state before merging, so the gate works even on rigs without per-repo CI configured.

## What

Before merging any MR with an open GitHub PR, the Engineer now checks CodeRabbit's review state:
- CR APPROVED or 0 actionable comments → proceed
- CR actionable findings or CHANGES_REQUESTED → park MR (cr-findings-open label on the bead) and nudge mayor
- No CR review yet, PR <10 min old → defer to next poll cycle
- No CR review yet, PR ≥10 min old → proceed (CR likely skipped, e.g. docs-only)
- GitHub API errors → fail-open (skip gate, don't block merge)

Enabled per-rig via config.json:
```json
"merge_queue": { "code_rabbit": { "enabled": true } }
```

## Files

- new: `internal/refinery/engineer_coderabbit.go` — CodeRabbitConfig, CRCheckResult, checkCodeRabbitGate, isActionableCRBody
- new: `internal/refinery/engineer_coderabbit_test.go` — 22 tests, all passing
- changed: `internal/git/git.go` — GetPRCodeRabbitStatus method + CRReview type
- changed: `internal/refinery/engineer.go` — CRParked/CRWait in ProcessResult, gate call in doMerge, LoadConfig parsing
- changed: `internal/templates/roles/refinery.md.tmpl` — docs

## Test plan

- [x] 22 unit tests passing (engineer_coderabbit_test.go)
- [x] Existing refinery tests pass
- [ ] Live test on a synthetic PR with a CR nit after merge

## Context

Bead: gt-tptb (closed). Originally filed in HQ as hq-h12qs (superseded). Triggered by user observation 2026-06-03 that CR findings keep slipping through; root cause analysis attributed to refinery not reading CR review state pre-merge.
