### PR TITLE
fix(hooks): block pushing a branch you're not on (HEAD mismatch)

### DIFF
--- a/.githooks/pre-push
+++ b/.githooks/pre-push
@@ -34,6 +34,32 @@ while read local_ref local_sha remote_ref remote_sha; do
 
   branch="${remote_ref#refs/heads/}"
 
+  # HEAD-mismatch guard: refuse pushing a branch you are not standing on.
+  # `git push origin <B>` pushes the local <B> ref regardless of where HEAD is, so
+  # running it from a session/feature branch silently no-ops ("Everything up-to-date")
+  # or pushes a stale ref — the work is stranded on a branch nobody merges. Git's
+  # conflict model can't catch this: it happens before any divergence exists.
+  # Only fires when a local branch ref is being pushed (not HEAD:x, tags, or deletes).
+  # Override for intentional cross-branch pushes: GT_ALLOW_OFFBRANCH_PUSH=1
+  if [[ "${GT_ALLOW_OFFBRANCH_PUSH:-0}" != "1" \
+        && "$local_ref" == refs/heads/* \
+        && "$local_sha" != "0000000000000000000000000000000000000000" ]]; then
+    head_branch=$(git symbolic-ref --short -q HEAD || echo "")
+    pushed_branch="${local_ref#refs/heads/}"
+    if [[ -n "$head_branch" && "$head_branch" != "$pushed_branch" ]]; then
+      echo "BLOCKED: pushing '$pushed_branch' while HEAD is on '$head_branch'."
+      echo ""
+      echo "You are not on the branch you are pushing. This commonly no-ops silently"
+      echo "(\"Everything up-to-date\") or pushes a stale ref, leaving the real work"
+      echo "stranded on a branch nobody merges."
+      echo ""
+      echo "  Check:  git status -sb ; git reflog | head"
+      echo "  Fix:    git switch '$pushed_branch'   (then re-push)"
+      echo "  Intentional cross-branch push? re-run with GT_ALLOW_OFFBRANCH_PUSH=1"
+      exit 1
+    fi
+  fi
+
   case "$branch" in
     "${default_branch}"|beads-sync|polecat/*|integration/*)
       # Allowed branches

--- a/.githooks/pre-push_test.sh
+++ b/.githooks/pre-push_test.sh
@@ -214,6 +214,40 @@ unset GT_INTEGRATION_LAND 2>/dev/null || true
 assert_block "FF integration merge blocked" run_hook "refs/heads/$DEFAULT_BRANCH" "$local_sha" "refs/heads/$DEFAULT_BRANCH" "$remote_sha"
 cleanup
 
+# Test 11: Off-branch push — HEAD on a session branch, pushing the default branch
+# (the classic `git push origin main` from a feature branch). HEAD mismatch — BLOCKED.
+echo "Test 11: Off-branch push (HEAD on session branch, pushing default)"
+setup_repos
+cd "$TMPDIR/local"
+git checkout -b session/x >/dev/null 2>&1
+echo "session work" >> file.txt
+git add file.txt && git commit -m "session work" >/dev/null 2>&1
+default_sha=$(get_sha "$DEFAULT_BRANCH")
+unset GT_ALLOW_OFFBRANCH_PUSH 2>/dev/null || true
+assert_block "Off-branch default push blocked (HEAD mismatch)" run_hook "refs/heads/$DEFAULT_BRANCH" "$default_sha" "refs/heads/$DEFAULT_BRANCH" "$default_sha"
+cleanup
+
+# Test 12: Off-branch push with GT_ALLOW_OFFBRANCH_PUSH=1 — ALLOWED (override).
+echo "Test 12: Off-branch push with GT_ALLOW_OFFBRANCH_PUSH=1"
+setup_repos
+cd "$TMPDIR/local"
+git checkout -b session/y >/dev/null 2>&1
+echo "session work" >> file.txt
+git add file.txt && git commit -m "session work" >/dev/null 2>&1
+default_sha=$(get_sha "$DEFAULT_BRANCH")
+GT_ALLOW_OFFBRANCH_PUSH=1 assert_pass "Off-branch push allowed with override" run_hook "refs/heads/$DEFAULT_BRANCH" "$default_sha" "refs/heads/$DEFAULT_BRANCH" "$default_sha"
+cleanup
+
+# Test 13: Off-branch deletion push (zero local sha) — not a HEAD mismatch, ALLOWED.
+echo "Test 13: Off-branch deletion push (zero local sha)"
+setup_repos
+cd "$TMPDIR/local"
+git checkout -b session/z >/dev/null 2>&1
+default_sha=$(get_sha "$DEFAULT_BRANCH")
+unset GT_ALLOW_OFFBRANCH_PUSH 2>/dev/null || true
+assert_pass "Off-branch deletion not blocked by HEAD guard" run_hook "refs/heads/$DEFAULT_BRANCH" "0000000000000000000000000000000000000000" "refs/heads/$DEFAULT_BRANCH" "$default_sha"
+cleanup
+
 echo ""
 echo "=== Results: $PASS passed, $FAIL failed ==="
 if [[ $FAIL -gt 0 ]]; then


### PR DESCRIPTION
## Summary

The `pre-push` hook guards the **destination** ref (branch allowlist + integration-branch landing) but never checks where local `HEAD` is. So `git push origin <default>` run from a session/feature branch passes — the default branch is on the allowlist — and then silently no-ops (`Everything up-to-date`) or ships a stale ref, stranding the real commit on a branch nobody merges. Git can't flag it: the failure happens *before* any divergence exists, so there's nothing for the conflict model to catch.

This adds a HEAD-mismatch check to the existing hook: when a local branch ref is being pushed and `HEAD` is on a different branch, refuse with a remediation hint.

## Related Issue

N/A (happy to file one if preferred).

## Changes

- `.githooks/pre-push`: refuse a push whose local branch ref differs from current `HEAD`. Fires only for local-branch pushes (`refs/heads/*`); skips deletions (zero local sha), detached `HEAD`, and explicit `HEAD:<branch>` pushes. Deterministic git-state check — no thresholds or behavioural heuristics. Override via `GT_ALLOW_OFFBRANCH_PUSH=1`, mirroring the existing `GT_INTEGRATION_LAND=1` convention.
- `.githooks/pre-push_test.sh`: tests 11–13 (block on mismatch, override allows, deletion skipped).

## Testing

- [x] `.githooks/pre-push_test.sh` — **13/13 pass** (10 existing unchanged + 3 new)
- [x] `bash -n` clean on both files
- [ ] `go test ./...` — not run; change is shell-only, no Go touched

## Checklist

- [x] Code follows project style (env override mirrors `GT_INTEGRATION_LAND`; no Go thresholds/heuristics)
- [x] Documentation updated (hook self-documents via its header comment; `docs/HOOKS.md` covers the settings.json hook system, not `.githooks/`)
- [x] No breaking changes (existing allowlist + integration guardrails untouched; the 10 original tests still pass)

---

Motivated by an external write-up of a multi-agent incident (a verifier agent pushed the default branch from the wrong checkout). Independent implementation against this hook; no external code copied.
