### PR TITLE
Fix bd create --repo rig routing

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -454,23 +454,22 @@ func (b *Beads) getResolvedBeadsDir() string {
 // targetBeadsDirForCreate returns the database a create operation should use.
 // Rig is authoritative for MR/conflict-task creates; otherwise parent-prefixed
 // children should land beside their parent so bd can resolve the relationship.
-func (b *Beads) targetBeadsDirForCreate(opts CreateOptions) string {
+func (b *Beads) targetBeadsDirForCreate(opts CreateOptions) (string, error) {
 	fallback := b.getResolvedBeadsDir()
 	townRoot := b.getTownRoot()
 
-	if opts.Rig != "" && townRoot != "" {
-		if rigDir := GetRigDirForName(townRoot, opts.Rig); rigDir != "" {
-			if targetDir := ResolveBeadsDir(rigDir); targetDir != "" {
-				return targetDir
-			}
+	if opts.Rig != "" {
+		if targetDir, ok := ResolveRepoAliasBeadsDir(townRoot, opts.Rig); ok {
+			return targetDir, nil
 		}
+		return "", fmt.Errorf("unknown repo/rig alias %q", opts.Rig)
 	}
 
 	if opts.Parent != "" {
-		return ResolveRoutingTarget(townRoot, opts.Parent, fallback)
+		return ResolveRoutingTarget(townRoot, opts.Parent, fallback), nil
 	}
 
-	return fallback
+	return fallback, nil
 }
 
 // forIssueID returns a Beads wrapper bound to the correct beads directory for
@@ -1406,7 +1405,10 @@ func (b *Beads) Create(opts CreateOptions) (*Issue, error) {
 		return nil, fmt.Errorf("refusing to create bead: %w (got %q)", ErrFlagTitle, opts.Title)
 	}
 
-	targetDir := b.targetBeadsDirForCreate(opts)
+	targetDir, err := b.targetBeadsDirForCreate(opts)
+	if err != nil {
+		return nil, err
+	}
 	if targetDir != "" && targetDir != b.getResolvedBeadsDir() {
 		bdForCreate := &Beads{
 			workDir:    b.workDir,
@@ -1476,6 +1478,20 @@ func (b *Beads) CreateWithID(id string, opts CreateOptions) (*Issue, error) {
 	// Guard against flag-like titles (gt-e0kx5: --help garbage beads)
 	if IsFlagLikeTitle(opts.Title) {
 		return nil, fmt.Errorf("refusing to create bead: %w (got %q)", ErrFlagTitle, opts.Title)
+	}
+
+	targetDir, err := b.targetBeadsDirForCreate(opts)
+	if err != nil {
+		return nil, err
+	}
+	if targetDir != "" && targetDir != b.getResolvedBeadsDir() {
+		bdForCreate := &Beads{
+			workDir:    b.workDir,
+			beadsDir:   targetDir,
+			serverPort: b.serverPort,
+			isolated:   b.isolated,
+		}
+		return bdForCreate.CreateWithID(id, opts)
 	}
 
 	args := []string{"create", "--json", "--id=" + id}

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -489,8 +489,9 @@ exit 0
 	}
 
 	for _, tc := range []struct {
-		name string
-		opts CreateOptions
+		name   string
+		opts   CreateOptions
+		withID bool
 	}{
 		{
 			name: "explicit rig",
@@ -500,6 +501,16 @@ exit 0
 			name: "parent prefix",
 			opts: CreateOptions{Title: "Child task", Parent: "tr-parent"},
 		},
+		{
+			name:   "deterministic id explicit rig",
+			opts:   CreateOptions{Title: "Fixed merge", Rig: "testrig"},
+			withID: true,
+		},
+		{
+			name:   "deterministic id parent prefix",
+			opts:   CreateOptions{Title: "Fixed child", Parent: "tr-parent"},
+			withID: true,
+		},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			if err := os.Remove(logPath); err != nil && !os.IsNotExist(err) {
@@ -507,7 +518,11 @@ exit 0
 			}
 
 			bd := New(workerDir)
-			if _, err := bd.Create(tc.opts); err != nil {
+			if tc.withID {
+				if _, err := bd.CreateWithID("tr-fixed", tc.opts); err != nil {
+					t.Fatalf("CreateWithID: %v", err)
+				}
+			} else if _, err := bd.Create(tc.opts); err != nil {
 				t.Fatalf("Create: %v", err)
 			}
 
@@ -522,7 +537,37 @@ exit 0
 			if strings.Contains(logOutput, "beads_dir="+rigBeadsDir+"\n") {
 				t.Fatalf("Create used intermediate redirect beads dir %q:\n%s", rigBeadsDir, logOutput)
 			}
+			if tc.withID && !strings.Contains(logOutput, "--id=tr-fixed") {
+				t.Fatalf("CreateWithID did not pass deterministic id:\n%s", logOutput)
+			}
 		})
+	}
+}
+
+func TestCreateWithUnknownRigErrors(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir town .beads: %v", err)
+	}
+	if err := WriteRoutes(townBeadsDir, []Route{{Prefix: "hq-", Path: "."}}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	workerDir := filepath.Join(townRoot, "gastown", "polecats", "rust")
+	if err := os.MkdirAll(workerDir, 0755); err != nil {
+		t.Fatalf("mkdir worker: %v", err)
+	}
+
+	_, err := New(workerDir).Create(CreateOptions{Title: "bad rig", Rig: "missing"})
+	if err == nil || !strings.Contains(err.Error(), `unknown repo/rig alias "missing"`) {
+		t.Fatalf("Create error = %v, want unknown rig alias", err)
 	}
 }
 

--- a/internal/beads/database.go
+++ b/internal/beads/database.go
@@ -110,6 +110,14 @@ func BuildMutationRoutingBDEnv(base []string, fallbackBeadsDir string) []string 
 	return forceBDMutation(BuildRoutingBDEnv(base, fallbackBeadsDir))
 }
 
+// BuildMutationNeutralBDEnv returns env for a mutating bd subprocess whose argv
+// contains an explicit native target such as --repo=<path>. It strips inherited
+// Gas Town target selectors and suppresses side effects without adding BEADS_DIR
+// or town Dolt connection metadata that could change native bd path semantics.
+func BuildMutationNeutralBDEnv(base []string) []string {
+	return forceBDMutation(SuppressBDSideEffects(StripBDTargetEnv(base)))
+}
+
 // ArgsAreReadOnly classifies bd CLI arguments for env policy. Unknown commands
 // are treated as mutations so they cannot accidentally inherit read-only mode.
 func ArgsAreReadOnly(args []string) bool {

--- a/internal/beads/exec.go
+++ b/internal/beads/exec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"strings"
 
 	"github.com/steveyegge/gastown/internal/util"
 )
@@ -63,4 +64,75 @@ func SubprocessModeForArgs(args []string) SubprocessEnvMode {
 		return ReadOnlyRouting
 	}
 	return MutationRouting
+}
+
+var bdBoolGlobalFlags = map[string]bool{
+	"--allow-stale": true,
+	"--help":        true,
+	"--json":        true,
+	"--profile":     true,
+	"--quiet":       true,
+	"--verbose":     true,
+	"--version":     true,
+	"-V":            true,
+	"-h":            true,
+	"-q":            true,
+	"-v":            true,
+}
+
+var bdTargetSelectorFlags = map[string]bool{
+	"--db":        true,
+	"--directory": true,
+	"--global":    true,
+	"--sandbox":   true,
+	"-C":          true,
+}
+
+// BDSubcommandIndex returns the argv index of bd's subcommand after recognized
+// bd global flags. Unknown leading flags fail closed so proxy allowlists cannot
+// be bypassed by treating command flags as globals.
+func BDSubcommandIndex(argv []string) (int, bool) {
+	if len(argv) < 2 || argv[0] != "bd" {
+		return 0, false
+	}
+	for i := 1; i < len(argv); i++ {
+		arg := argv[i]
+		if arg == "--" {
+			return 0, false
+		}
+		if !strings.HasPrefix(arg, "-") {
+			return i, true
+		}
+		if _, _, ok := strings.Cut(arg, "="); ok {
+			return 0, false
+		}
+		if bdBoolGlobalFlags[arg] {
+			continue
+		}
+		return 0, false
+	}
+	return 0, false
+}
+
+// HasBDTargetSelectorFlag reports whether argv contains bd globals that can
+// override the database or working directory selected by Gas Town. The proxy
+// rejects these even after the subcommand because bd accepts globals anywhere.
+func HasBDTargetSelectorFlag(argv []string) bool {
+	if len(argv) == 0 || argv[0] != "bd" {
+		return false
+	}
+	for i := 1; i < len(argv); i++ {
+		arg := argv[i]
+		if arg == "--" {
+			return false
+		}
+		name := arg
+		if cut, _, ok := strings.Cut(arg, "="); ok {
+			name = cut
+		}
+		if bdTargetSelectorFlags[name] {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/beads/routes.go
+++ b/internal/beads/routes.go
@@ -307,6 +307,145 @@ func GetRigDirForName(townRoot, rigName string) string {
 	return ""
 }
 
+// ResolveRepoAliasBeadsDir resolves a Gas Town repo alias to its canonical
+// .beads directory. Bare aliases are route names like "gastown" plus the
+// town aliases "hq" and "town"; path-like repo values are intentionally left
+// unresolved so callers can preserve bd's native --repo path semantics.
+func ResolveRepoAliasBeadsDir(townRoot, repo string) (string, bool) {
+	if townRoot == "" || isRepoPathLike(repo) {
+		return "", false
+	}
+
+	if repo == "hq" || repo == "town" {
+		beadsDir := filepath.Join(townRoot, ".beads")
+		return beadsDir, validRepoAliasBeadsDir(townRoot, beadsDir)
+	}
+
+	rigDir := GetRigDirForName(townRoot, repo)
+	if rigDir == "" || !pathWithin(townRoot, rigDir) {
+		return "", false
+	}
+
+	beadsDir := ResolveBeadsDir(rigDir)
+	if !validRepoAliasBeadsDir(townRoot, beadsDir) {
+		return "", false
+	}
+	return beadsDir, true
+}
+
+// RewriteBDCreateRepoAlias removes a single bd create --repo alias from argv
+// and returns the canonical .beads target for callers to pin via BEADS_DIR.
+// Unresolved, path-like, duplicate, or positional --repo values are preserved so
+// bd keeps its native --repo behavior outside Gas Town aliases.
+func RewriteBDCreateRepoAlias(townRoot string, argv []string) ([]string, string) {
+	cmdIndex, ok := BDSubcommandIndex(argv)
+	if !ok || argv[cmdIndex] != "create" {
+		return argv, ""
+	}
+	if countBDRepoFlags(argv, cmdIndex+1) != 1 {
+		return argv, ""
+	}
+
+	rewritten := make([]string, 0, len(argv))
+	for i := 0; i < len(argv); i++ {
+		arg := argv[i]
+		if arg == "--" {
+			rewritten = append(rewritten, argv[i:]...)
+			break
+		}
+
+		if arg == "--repo" {
+			if i+1 >= len(argv) {
+				rewritten = append(rewritten, arg)
+				continue
+			}
+			value := argv[i+1]
+			if beadsDir, ok := ResolveRepoAliasBeadsDir(townRoot, value); ok {
+				i++
+				return append(rewritten, argv[i+1:]...), beadsDir
+			}
+			rewritten = append(rewritten, arg, value)
+			i++
+			continue
+		}
+
+		if strings.HasPrefix(arg, "--repo=") {
+			value := strings.TrimPrefix(arg, "--repo=")
+			if beadsDir, ok := ResolveRepoAliasBeadsDir(townRoot, value); ok {
+				return append(rewritten, argv[i+1:]...), beadsDir
+			}
+		}
+
+		rewritten = append(rewritten, arg)
+	}
+
+	return rewritten, ""
+}
+
+func countBDRepoFlags(argv []string, start int) int {
+	count := 0
+	for i := start; i < len(argv); i++ {
+		arg := argv[i]
+		if arg == "--" {
+			break
+		}
+		if arg == "--repo" {
+			count++
+			if i+1 < len(argv) {
+				i++
+			}
+			continue
+		}
+		if strings.HasPrefix(arg, "--repo=") {
+			count++
+		}
+	}
+	return count
+}
+
+func isRepoPathLike(value string) bool {
+	if value == "" || filepath.IsAbs(value) {
+		return true
+	}
+	if strings.HasPrefix(value, ".") || strings.HasPrefix(value, "~") {
+		return true
+	}
+	if strings.ContainsAny(value, `/\\`) || strings.Contains(value, "://") {
+		return true
+	}
+	if len(value) >= 2 && value[1] == ':' {
+		return true
+	}
+	return strings.Contains(value, "@") && strings.Contains(value, ":")
+}
+
+func validRepoAliasBeadsDir(townRoot, beadsDir string) bool {
+	if filepath.Base(filepath.Clean(beadsDir)) != ".beads" {
+		return false
+	}
+	info, err := os.Stat(beadsDir)
+	if err != nil || !info.IsDir() {
+		return false
+	}
+	return pathWithin(townRoot, beadsDir)
+}
+
+func pathWithin(root, path string) bool {
+	if resolvedRoot, err := filepath.EvalSymlinks(root); err == nil {
+		root = resolvedRoot
+	}
+	if resolvedPath, err := filepath.EvalSymlinks(path); err == nil {
+		path = resolvedPath
+	}
+	root = filepath.Clean(root)
+	path = filepath.Clean(path)
+	rel, err := filepath.Rel(root, path)
+	if err != nil {
+		return false
+	}
+	return rel == "." || (rel != ".." && !strings.HasPrefix(rel, ".."+string(filepath.Separator)) && !filepath.IsAbs(rel))
+}
+
 // GetRigNameForPrefix returns the rig name that owns a given bead prefix.
 // For example, "gt-" returns "gastown", "bd-" returns "beads".
 // Returns empty string if the prefix is town-level (path=".") or not found in routes.

--- a/internal/beads/routes_test.go
+++ b/internal/beads/routes_test.go
@@ -3,6 +3,7 @@ package beads
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/config"
@@ -423,6 +424,138 @@ func TestGetRigDirForName_TownLevelNotReturned(t *testing.T) {
 	result := GetRigDirForName(tmpDir, "hq")
 	if result != "" {
 		t.Errorf("GetRigDirForName for town-level path = %q, want empty string", result)
+	}
+}
+
+func TestResolveRepoAliasBeadsDir(t *testing.T) {
+	townRoot := t.TempDir()
+	townBeads := filepath.Join(townRoot, ".beads")
+	rigRoot := filepath.Join(townRoot, "gastown")
+	canonicalRig := filepath.Join(rigRoot, "mayor", "rig")
+	canonicalBeads := filepath.Join(canonicalRig, ".beads")
+	decoyBeads := filepath.Join(rigRoot, ".beads")
+	escapeRig := filepath.Join(townRoot, "escape", "mayor", "rig")
+	escapeBeads := filepath.Join(escapeRig, ".beads")
+	escapeTarget := filepath.Join(townRoot, "..", "outside", ".beads")
+
+	for _, dir := range []string{townBeads, canonicalBeads, decoyBeads, escapeBeads, escapeTarget} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townBeads, "routes.jsonl"), []byte(
+		`{"prefix":"hq-","path":"."}`+"\n"+
+			`{"prefix":"gt-","path":"gastown/mayor/rig"}`+"\n"+
+			`{"prefix":"es-","path":"escape/mayor/rig"}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(canonicalBeads, "metadata.json"), []byte(`{"dolt_database":"gastown"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(decoyBeads, "metadata.json"), []byte(`{"dolt_database":"hq"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(escapeBeads, "redirect"), []byte(filepath.Join("..", "..", "..", "..", "outside", ".beads")+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name     string
+		repo     string
+		expected string
+		ok       bool
+	}{
+		{"rig alias uses canonical route", "gastown", canonicalBeads, true},
+		{"hq alias uses town beads", "hq", townBeads, true},
+		{"town alias uses town beads", "town", townBeads, true},
+		{"path-like remains unresolved", "gastown/mayor/rig", "", false},
+		{"unknown bare repo remains unresolved", "unknown", "", false},
+		{"redirect outside town rejected", "escape", "", false},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, ok := ResolveRepoAliasBeadsDir(townRoot, tc.repo)
+			if ok != tc.ok {
+				t.Fatalf("ResolveRepoAliasBeadsDir ok = %v, want %v", ok, tc.ok)
+			}
+			if got != tc.expected {
+				t.Fatalf("ResolveRepoAliasBeadsDir dir = %q, want %q", got, tc.expected)
+			}
+		})
+	}
+}
+
+func TestRewriteBDCreateRepoAlias(t *testing.T) {
+	townRoot := t.TempDir()
+	townBeads := filepath.Join(townRoot, ".beads")
+	canonicalBeads := filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads")
+	decoyBeads := filepath.Join(townRoot, "gastown", ".beads")
+	for _, dir := range []string{townBeads, canonicalBeads, decoyBeads} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townBeads, "routes.jsonl"), []byte(
+		`{"prefix":"hq-","path":"."}`+"\n"+
+			`{"prefix":"gt-","path":"gastown/mayor/rig"}`+"\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	tests := []struct {
+		name    string
+		argv    []string
+		want    []string
+		wantDir string
+	}{
+		{
+			name:    "global flags before create",
+			argv:    []string{"bd", "--allow-stale", "create", "--repo", "gastown", "--title", "x"},
+			want:    []string{"bd", "--allow-stale", "create", "--title", "x"},
+			wantDir: canonicalBeads,
+		},
+		{
+			name:    "equals form",
+			argv:    []string{"bd", "--json", "create", "--repo=gastown"},
+			want:    []string{"bd", "--json", "create"},
+			wantDir: canonicalBeads,
+		},
+		{
+			name:    "unknown bare repo unchanged",
+			argv:    []string{"bd", "create", "--repo", "unknown", "--title", "x"},
+			want:    []string{"bd", "create", "--repo", "unknown", "--title", "x"},
+			wantDir: "",
+		},
+		{
+			name:    "path-like repo unchanged",
+			argv:    []string{"bd", "create", "--repo", "gastown/mayor/rig", "--title", "x"},
+			want:    []string{"bd", "create", "--repo", "gastown/mayor/rig", "--title", "x"},
+			wantDir: "",
+		},
+		{
+			name:    "duplicate repo unchanged",
+			argv:    []string{"bd", "create", "--repo", "gastown", "--repo", "/tmp/other"},
+			want:    []string{"bd", "create", "--repo", "gastown", "--repo", "/tmp/other"},
+			wantDir: "",
+		},
+		{
+			name:    "repo after sentinel unchanged",
+			argv:    []string{"bd", "create", "--", "--repo", "gastown"},
+			want:    []string{"bd", "create", "--", "--repo", "gastown"},
+			wantDir: "",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, gotDir := RewriteBDCreateRepoAlias(townRoot, tc.argv)
+			if gotDir != tc.wantDir {
+				t.Fatalf("beads dir = %q, want %q", gotDir, tc.wantDir)
+			}
+			if strings.Join(got, "\x00") != strings.Join(tc.want, "\x00") {
+				t.Fatalf("argv = %#v, want %#v", got, tc.want)
+			}
+		})
 	}
 }
 

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -2781,13 +2781,10 @@ func (d *Daemon) hasAssignedOpenWork(rigName, assignee string) bool {
 
 	for _, status := range []string{"hooked", "in_progress", "open"} {
 		args := beads.InjectFlatForListJSON([]string{"list", "--assignee=" + assignee, "--status=" + status, "--json"})
-		if rigDir != "" {
-			args = append(args, "--repo="+rigDir)
-		}
 		cmd := exec.Command(d.bdPath, args...) //nolint:gosec // G204: args are constructed internally
 		cmd.Dir = d.config.TownRoot
 		if rigDir != "" {
-			cmd.Env = bdReadOnlyPinnedEnv(filepath.Join(rigDir, ".beads"))
+			cmd.Env = bdReadOnlyPinnedEnv(beads.ResolveBeadsDir(rigDir))
 		} else {
 			cmd.Env = bdReadOnlyRoutingEnv(d.config.TownRoot)
 		}

--- a/internal/daemon/has_assigned_work_test.go
+++ b/internal/daemon/has_assigned_work_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 )
 
-func TestHasAssignedOpenWork_UsesRepoRoutingInsteadOfRigFlag(t *testing.T) {
+func TestHasAssignedOpenWork_UsesPinnedBeadsDirInsteadOfRigOrRepoFlag(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("test uses Unix shell script mocks")
 	}
@@ -27,24 +27,25 @@ func TestHasAssignedOpenWork_UsesRepoRoutingInsteadOfRigFlag(t *testing.T) {
 
 	binDir := t.TempDir()
 	logPath := filepath.Join(binDir, "bd.log")
-	expectedRepo := filepath.Join(townRoot, "gastown", "mayor", "rig")
+	expectedBeadsDir := filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads")
 	script := `#!/bin/sh
 for arg in "$@"; do
-  if [ "$arg" = "--repo=` + expectedRepo + `" ]; then
-    repo_seen=1
-  fi
   case "$arg" in
+    --repo=*)
+      echo "unexpected --repo flag with pinned BEADS_DIR" >&2
+      exit 1
+      ;;
     --rig=*)
       echo "Error: unknown flag: --rig" >&2
       exit 1
       ;;
-  esac
+    esac
 done
-if [ "${repo_seen:-0}" -ne 1 ]; then
-  echo "missing expected --repo flag" >&2
+if [ "$BEADS_DIR" != "` + expectedBeadsDir + `" ]; then
+  echo "unexpected BEADS_DIR: $BEADS_DIR" >&2
   exit 1
 fi
-printf '%s\n' "$*" >> "` + logPath + `"
+printf 'BEADS_DIR=%s args=%s\n' "$BEADS_DIR" "$*" >> "` + logPath + `"
 printf '[{"id":"gt-123"}]\n'
 `
 	bdPath := filepath.Join(binDir, "bd")
@@ -69,7 +70,10 @@ printf '[{"id":"gt-123"}]\n'
 	if strings.Contains(loggedArgs, "--rig=") {
 		t.Fatalf("expected bd call to avoid --rig, got %q", loggedArgs)
 	}
-	if !strings.Contains(loggedArgs, "--repo="+expectedRepo) {
-		t.Fatalf("expected bd call to include resolved --repo flag, got %q", loggedArgs)
+	if strings.Contains(loggedArgs, "--repo=") {
+		t.Fatalf("expected bd call to avoid --repo with pinned BEADS_DIR, got %q", loggedArgs)
+	}
+	if !strings.Contains(loggedArgs, "BEADS_DIR="+expectedBeadsDir) {
+		t.Fatalf("expected bd call to pin BEADS_DIR to %q, got %q", expectedBeadsDir, loggedArgs)
 	}
 }

--- a/internal/proxy/exec.go
+++ b/internal/proxy/exec.go
@@ -8,6 +8,7 @@ import (
 	"os/exec"
 	"strings"
 
+	"github.com/steveyegge/gastown/internal/beads"
 	"golang.org/x/time/rate"
 )
 
@@ -55,11 +56,15 @@ func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 
 	// Validate argv[1] (subcommand) if this command has a subcommand allowlist.
 	if subs, ok := s.allowedSubs[cmd0]; ok {
-		if len(req.Argv) < 2 {
+		sub, ok := allowedSubcommand(cmd0, req.Argv)
+		if !ok {
 			http.Error(w, "subcommand required", http.StatusForbidden)
 			return
 		}
-		sub := req.Argv[1]
+		if cmd0 == "bd" && beads.HasBDTargetSelectorFlag(req.Argv) {
+			http.Error(w, "bd target-selector global flags are not allowed", http.StatusForbidden)
+			return
+		}
 		if !subs[sub] {
 			http.Error(w, fmt.Sprintf("subcommand not allowed: %q %q", cmd0, sub), http.StatusForbidden)
 			return
@@ -68,6 +73,8 @@ func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 
 	// Build argv as a copy of req.Argv to avoid mutating the decoded request.
 	argv := append([]string(nil), req.Argv...)
+	envOverride := []string(nil)
+	argv, envOverride = s.rewriteBDCreateRepo(argv)
 	// Use the resolved absolute binary path to prevent PATH hijacking after startup.
 	if resolved, ok := s.resolvedPaths[cmd0]; ok {
 		argv[0] = resolved
@@ -100,7 +107,7 @@ func (s *Server) handleExec(w http.ResponseWriter, r *http.Request) {
 		execCtx, cancel = context.WithTimeout(execCtx, s.execTimeout)
 		defer cancel()
 	}
-	out, errOut, exitCode := runCommand(execCtx, argv, identity)
+	out, errOut, exitCode := runCommand(execCtx, argv, identity, envOverride)
 
 	// Audit log (do not log full argv — it may contain tokens or secrets).
 	if exitCode == 0 {
@@ -203,7 +210,7 @@ func (s *Server) limiterFor(identity string) *rate.Limiter {
 	return v.(*rate.Limiter)
 }
 
-func runCommand(ctx context.Context, argv []string, identity string) (stdout, stderr string, exitCode int) {
+func runCommand(ctx context.Context, argv []string, identity string, envOverride ...[]string) (stdout, stderr string, exitCode int) {
 	cmd := exec.CommandContext(ctx, argv[0], argv[1:]...)
 	var outBuf, errBuf strings.Builder
 	cmd.Stdout = &outBuf
@@ -212,7 +219,11 @@ func runCommand(ctx context.Context, argv []string, identity string) (stdout, st
 	// leaking into gt/bd calls. Pass identity via env var so commands can
 	// optionally use it without requiring a --identity CLI flag on every command.
 	env := minimalEnv()
+	if len(envOverride) > 0 && envOverride[0] != nil {
+		env = envOverride[0]
+	}
 	if identity != "" {
+		env = stripEnvKey(env, "GT_PROXY_IDENTITY")
 		env = append(env, "GT_PROXY_IDENTITY="+identity)
 	}
 	cmd.Env = env
@@ -225,4 +236,41 @@ func runCommand(ctx context.Context, argv []string, identity string) (stdout, st
 		}
 	}
 	return outBuf.String(), errBuf.String(), exitCode
+}
+
+func (s *Server) rewriteBDCreateRepo(argv []string) ([]string, []string) {
+	rewritten, beadsDir := beads.RewriteBDCreateRepoAlias(s.cfg.TownRoot, argv)
+	if beadsDir != "" {
+		return rewritten, beads.BuildMutationPinnedBDEnv(minimalEnv(), beadsDir)
+	}
+	if cmdIndex, ok := beads.BDSubcommandIndex(argv); ok && argv[cmdIndex] == "create" {
+		return argv, beads.BuildMutationNeutralBDEnv(minimalEnv())
+	}
+	return argv, nil
+}
+
+func allowedSubcommand(cmd0 string, argv []string) (string, bool) {
+	if cmd0 == "bd" {
+		idx, ok := beads.BDSubcommandIndex(argv)
+		if !ok {
+			return "", false
+		}
+		return argv[idx], true
+	}
+	if len(argv) < 2 {
+		return "", false
+	}
+	return argv[1], true
+}
+
+func stripEnvKey(env []string, key string) []string {
+	prefix := key + "="
+	filtered := make([]string, 0, len(env))
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			continue
+		}
+		filtered = append(filtered, entry)
+	}
+	return filtered
 }

--- a/internal/proxy/exec_test.go
+++ b/internal/proxy/exec_test.go
@@ -330,6 +330,165 @@ func TestRunCommand(t *testing.T) {
 	})
 }
 
+func TestHandleExec_BDCreateRepoAliasPinsCanonicalBeadsDir(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fake bd uses POSIX sh")
+	}
+
+	townRoot := t.TempDir()
+	townBeads := filepath.Join(townRoot, ".beads")
+	rigRoot := filepath.Join(townRoot, "gastown")
+	canonicalRig := filepath.Join(rigRoot, "mayor", "rig")
+	canonicalBeads := filepath.Join(canonicalRig, ".beads")
+	decoyBeads := filepath.Join(rigRoot, ".beads")
+	require.NoError(t, os.MkdirAll(canonicalBeads, 0755))
+	require.NoError(t, os.MkdirAll(decoyBeads, 0755))
+	require.NoError(t, os.MkdirAll(townBeads, 0755))
+	require.NoError(t, os.WriteFile(filepath.Join(townBeads, "routes.jsonl"), []byte(
+		`{"prefix":"hq-","path":"."}`+"\n"+
+			`{"prefix":"gt-","path":"gastown/mayor/rig"}`+"\n"), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(townBeads, "metadata.json"), []byte(`{"dolt_database":"hq"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(canonicalBeads, "metadata.json"), []byte(`{"dolt_database":"gastown"}`), 0644))
+	require.NoError(t, os.WriteFile(filepath.Join(decoyBeads, "metadata.json"), []byte(`{"dolt_database":"hq"}`), 0644))
+
+	scriptDir := t.TempDir()
+	scriptPath := filepath.Join(scriptDir, "bd")
+	require.NoError(t, os.WriteFile(scriptPath, []byte("#!/bin/sh\nfor arg in \"$@\"; do printf '[%s]' \"$arg\"; done\nprintf '\\nBEADS_DIR=%s\\nBEADS_DOLT_SERVER_DATABASE=%s\\nBEADS_DOLT_DATA_DIR=%s\\nBD_DOLT_AUTO_COMMIT=%s\\nBD_NO_GIT_OPS=%s\\n' \"${BEADS_DIR:-}\" \"${BEADS_DOLT_SERVER_DATABASE:-}\" \"${BEADS_DOLT_DATA_DIR:-}\" \"${BD_DOLT_AUTO_COMMIT:-}\" \"${BD_NO_GIT_OPS:-}\"\n"), 0755))
+	t.Setenv("PATH", scriptDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "stale")
+	t.Setenv("BEADS_DIR", "/wrong")
+
+	srv, err := New(Config{
+		TownRoot:        townRoot,
+		AllowedCommands: []string{"bd"},
+		AllowedSubcommands: map[string][]string{
+			"bd": {"create"},
+		},
+		Logger: discardLogger(),
+	}, nil)
+	require.NoError(t, err)
+
+	run := func(body string) execResponse {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/v1/exec", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		srv.handleExec(rec, req)
+		require.Equal(t, http.StatusOK, rec.Code)
+		var resp execResponse
+		require.NoError(t, json.NewDecoder(rec.Body).Decode(&resp))
+		require.Equal(t, 0, resp.ExitCode, resp.Stderr)
+		return resp
+	}
+	runStatus := func(body string) (int, string) {
+		t.Helper()
+		req := httptest.NewRequest(http.MethodPost, "/v1/exec", strings.NewReader(body))
+		rec := httptest.NewRecorder()
+		srv.handleExec(rec, req)
+		return rec.Code, rec.Body.String()
+	}
+
+	t.Run("space form rig alias", func(t *testing.T) {
+		resp := run(`{"argv":["bd","create","--repo","gastown","--title","x"]}`)
+		assert.Contains(t, resp.Stdout, "[create][--title][x]")
+		assert.NotContains(t, resp.Stdout, "[--repo]")
+		assert.NotContains(t, resp.Stdout, "[gastown]")
+		assert.Contains(t, resp.Stdout, "BEADS_DIR="+canonicalBeads)
+		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=\n")
+		assert.Contains(t, resp.Stdout, "BD_DOLT_AUTO_COMMIT=on")
+		assert.Contains(t, resp.Stdout, "BD_NO_GIT_OPS=true")
+		assert.NotContains(t, resp.Stdout, "BEADS_DIR="+decoyBeads)
+	})
+
+	t.Run("bd global flag before create", func(t *testing.T) {
+		resp := run(`{"argv":["bd","--allow-stale","create","--repo","gastown","--title","x"]}`)
+		assert.Contains(t, resp.Stdout, "[--allow-stale][create][--title][x]")
+		assert.NotContains(t, resp.Stdout, "[--repo]")
+		assert.Contains(t, resp.Stdout, "BEADS_DIR="+canonicalBeads)
+	})
+
+	t.Run("equals form rig alias", func(t *testing.T) {
+		resp := run(`{"argv":["bd","create","--repo=gastown","--title","x"]}`)
+		assert.Contains(t, resp.Stdout, "[create][--title][x]")
+		assert.NotContains(t, resp.Stdout, "--repo=gastown")
+		assert.NotContains(t, resp.Stdout, "[gastown]")
+		assert.Contains(t, resp.Stdout, "BEADS_DIR="+canonicalBeads)
+		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=\n")
+		assert.Contains(t, resp.Stdout, "BD_DOLT_AUTO_COMMIT=on")
+	})
+
+	t.Run("hq alias", func(t *testing.T) {
+		resp := run(`{"argv":["bd","create","--repo","hq","--title","x"]}`)
+		assert.Contains(t, resp.Stdout, "[create][--title][x]")
+		assert.NotContains(t, resp.Stdout, "[--repo]")
+		assert.NotContains(t, resp.Stdout, "[hq]")
+		assert.Contains(t, resp.Stdout, "BEADS_DIR="+townBeads)
+		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=\n")
+	})
+
+	t.Run("town alias", func(t *testing.T) {
+		resp := run(`{"argv":["bd","create","--repo","town","--title","x"]}`)
+		assert.Contains(t, resp.Stdout, "[create][--title][x]")
+		assert.NotContains(t, resp.Stdout, "[--repo]")
+		assert.NotContains(t, resp.Stdout, "[town]")
+		assert.Contains(t, resp.Stdout, "BEADS_DIR="+townBeads)
+		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=\n")
+	})
+
+	t.Run("path-like repo remains explicit", func(t *testing.T) {
+		resp := run(`{"argv":["bd","create","--repo","gastown/mayor/rig","--title","x"]}`)
+		assert.Contains(t, resp.Stdout, "[create][--repo][gastown/mayor/rig][--title][x]")
+		assert.Contains(t, resp.Stdout, "BEADS_DIR=\n")
+		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=\n")
+		assert.Contains(t, resp.Stdout, "BEADS_DOLT_DATA_DIR=\n")
+		assert.Contains(t, resp.Stdout, "BD_DOLT_AUTO_COMMIT=on")
+		assert.Contains(t, resp.Stdout, "BD_NO_GIT_OPS=true")
+	})
+
+	t.Run("unknown bare repo remains explicit", func(t *testing.T) {
+		resp := run(`{"argv":["bd","create","--repo","unknown","--title","x"]}`)
+		assert.Contains(t, resp.Stdout, "[create][--repo][unknown][--title][x]")
+		assert.Contains(t, resp.Stdout, "BEADS_DIR=\n")
+		assert.Contains(t, resp.Stdout, "BD_DOLT_AUTO_COMMIT=on")
+	})
+
+	t.Run("repo after sentinel remains positional", func(t *testing.T) {
+		resp := run(`{"argv":["bd","create","--","--repo","gastown"]}`)
+		assert.Contains(t, resp.Stdout, "[create][--][--repo][gastown]")
+		assert.Contains(t, resp.Stdout, "BEADS_DIR=\n")
+		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=\n")
+	})
+
+	t.Run("duplicate repo flags remain explicit", func(t *testing.T) {
+		resp := run(`{"argv":["bd","create","--repo","gastown","--repo","/tmp/other","--title","x"]}`)
+		assert.Contains(t, resp.Stdout, "[create][--repo][gastown][--repo][/tmp/other][--title][x]")
+		assert.Contains(t, resp.Stdout, "BEADS_DIR=\n")
+	})
+
+	t.Run("global flag before forbidden bd subcommand returns 403", func(t *testing.T) {
+		code, body := runStatus(`{"argv":["bd","--allow-stale","sql","select 1"]}`)
+		assert.Equal(t, http.StatusForbidden, code)
+		assert.Contains(t, body, "subcommand not allowed")
+	})
+
+	t.Run("unknown leading bd flag returns 403", func(t *testing.T) {
+		code, body := runStatus(`{"argv":["bd","--not-a-global","create","--repo","gastown"]}`)
+		assert.Equal(t, http.StatusForbidden, code)
+		assert.Contains(t, body, "subcommand required")
+	})
+
+	t.Run("target-selector bd global returns 403", func(t *testing.T) {
+		code, body := runStatus(`{"argv":["bd","--db","/tmp/other","create","--repo","gastown"]}`)
+		assert.Equal(t, http.StatusForbidden, code)
+		assert.Contains(t, body, "subcommand required")
+	})
+
+	t.Run("target-selector flag after subcommand returns 403", func(t *testing.T) {
+		code, body := runStatus(`{"argv":["bd","create","--db","/tmp/other","--repo","gastown"]}`)
+		assert.Equal(t, http.StatusForbidden, code)
+		assert.Contains(t, body, "target-selector")
+	})
+}
+
 // TestIsAllowed tests the Server.isAllowed helper.
 func TestIsAllowed(t *testing.T) {
 	srv := newExecTestServer(t, Config{AllowedCommands: []string{"echo", "sh"}})


### PR DESCRIPTION
## Summary
- Consolidate Gas Town repo-alias routing into `internal/beads` instead of proxy-local route/path logic.
- Reuse the shared resolver for internal create routing and proxy-mediated `bd create --repo <alias>`.
- Pin alias creates to canonical route targets like `gastown/mayor/rig/.beads`, avoiding stale intermediate `.beads` capture.
- Fail internal `CreateOptions.Rig` calls on unknown aliases instead of silently falling back to the current database.

## Verification
- `go test -count=1 ./internal/beads`
- `go test -count=1 ./internal/proxy`
- `go test -count=1 ./...` still fails in pre-existing/unrelated packages: `internal/cmd`, `internal/doltserver`, `internal/polecat`, `internal/refinery`, `internal/rig`, `internal/tmux`.

## Workflow Notes
- Completed the required 15 research legs, 5 pre-implementation reviews, and 5 post-implementation reviews.
- Post-review feedback led to moving bd create argv rewriting out of the proxy, adding `--repo town` coverage, and adding unknown-rig error coverage.

## Limitation
- Literal native `/home/coder/.local/bin/bd create --repo gastown` from `/home/coder/gt` still bypasses this Gastown code path. This PR fixes Gas Town internal/proxy create paths; native Beads CLI route-aware `--repo` support needs a Beads-side resolver.

Closes gt-bd-create-repo-routing.