### PR TITLE
Clarify Gas Town hq beads routing

### DIFF
--- a/docs/design/dolt-storage.md
+++ b/docs/design/dolt-storage.md
@@ -72,6 +72,22 @@ gt dolt list           # List all databases
 If the server isn't running, `bd` fails fast with a clear message
 pointing to `gt dolt start`.
 
+## Gas Town Scope vs `bd --global`
+
+Gas Town's town-level beads are the `hq` database. Access them by running
+direct `bd` commands from the town root (`~/gt`) or with `bd -C ~/gt ...`.
+Direct `bd` commands from rig worktrees use that rig's `.beads` redirect and
+database, so do not assume an `hq-*` ID will retarget the command.
+
+Do not use `bd --global` for Gas Town town beads. In Beads, `--global`
+means the standalone shared-server database named `beads_global`; it does
+not mean Gas Town's `hq` database, and `BEADS_DOLT_DATABASE=hq` does not
+retarget `--global`.
+
+For Gas Town Dolt health, use `gt dolt status`. `bd dolt status` reports
+the Beads client/runtime view and can say no Beads-managed server is running
+even when the Gas Town Dolt server on port 3307 is healthy.
+
 ## Write Concurrency: All-on-Main
 
 All agents — polecats, crew, witness, refinery, deacon — write directly

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -6,13 +6,14 @@ Technical reference for Gas Town internals. Read the README first.
 
 ## Beads Routing
 
-Gas Town routes beads commands based on issue ID prefix. You don't need to think
-about which database to use - just use the issue ID.
+Gas Town `gt` commands route beads work based on issue ID prefix. For direct
+`bd` commands, run from the owning repository/root so the active `.beads`
+directory matches the database you intend to touch.
 
 ```bash
-bd show gp-xyz    # Routes to greenplace rig's beads
-bd show hq-abc    # Routes to town-level beads
-bd show wyv-123   # Routes to wyvern rig's beads
+bd -C ~/gt/greenplace/mayor/rig show gp-xyz  # Greenplace rig beads
+bd -C ~/gt show hq-abc                       # Town-level beads
+bd -C ~/gt/wyvern/mayor/rig show wyv-123     # Wyvern rig beads
 ```
 
 **How it works**: Routes are defined in `~/gt/.beads/routes.jsonl`. Each rig's
@@ -24,7 +25,11 @@ prefix maps to its beads location (the mayor's clone in that rig).
 | `gp-*` | `~/gt/greenplace/mayor/rig/.beads/` | Greenplace project issues |
 | `wyv-*` | `~/gt/wyvern/mayor/rig/.beads/` | Wyvern project issues |
 
-Debug routing: `BD_DEBUG_ROUTING=1 bd show <id>`
+Debug routing: `BD_DEBUG_ROUTING=1 bd -C <owning-root> show <id>`
+
+`bd --global` is not Gas Town's town database. In Beads it targets a separate
+shared-server database named `beads_global`; run `bd -C ~/gt ...` for
+town-level Gas Town beads.
 
 ## Configuration
 

--- a/internal/cmd/dolt.go
+++ b/internal/cmd/dolt.go
@@ -779,6 +779,17 @@ func printBeadsRuntimeConfig(townRoot string) {
 		parts = append(parts, "from "+cfg.Source)
 	}
 	fmt.Printf("  Beads client: %s\n", strings.Join(parts, ", "))
+	if hint := beadsScopeHint(cfg.Database); hint != "" {
+		fmt.Print(hint)
+	}
+}
+
+func beadsScopeHint(database string) string {
+	if database != "hq" {
+		return ""
+	}
+
+	return "    Gas Town town beads use database hq. Use `bd -C ~/gt <cmd>` for hq-* beads; do not use `bd --global`, which targets Beads' beads_global database.\n"
 }
 
 func netJoinHostPort(host string, port int) string {

--- a/internal/cmd/dolt.go
+++ b/internal/cmd/dolt.go
@@ -779,17 +779,17 @@ func printBeadsRuntimeConfig(townRoot string) {
 		parts = append(parts, "from "+cfg.Source)
 	}
 	fmt.Printf("  Beads client: %s\n", strings.Join(parts, ", "))
-	if hint := beadsScopeHint(cfg.Database); hint != "" {
+	if hint := beadsScopeHint(cfg.Database, townRoot); hint != "" {
 		fmt.Print(hint)
 	}
 }
 
-func beadsScopeHint(database string) string {
+func beadsScopeHint(database, townRoot string) string {
 	if database != "hq" {
 		return ""
 	}
 
-	return "    Gas Town town beads use database hq. Use `bd -C ~/gt <cmd>` for hq-* beads; do not use `bd --global`, which targets Beads' beads_global database.\n"
+	return fmt.Sprintf("    Gas Town town beads use database hq. Use `bd -C %s <cmd>` for hq-* beads; do not use `bd --global`, which targets Beads' beads_global database.\n", townRoot)
 }
 
 func netJoinHostPort(host string, port int) string {

--- a/internal/cmd/dolt_status_test.go
+++ b/internal/cmd/dolt_status_test.go
@@ -89,17 +89,21 @@ func TestReadBeadsRuntimeConfigIgnoresEmbeddedMetadata(t *testing.T) {
 }
 
 func TestBeadsScopeHint_HQWarnsAgainstGlobal(t *testing.T) {
-	hint := beadsScopeHint("hq")
+	townRoot := filepath.Join(string(filepath.Separator), "custom", "town")
+	hint := beadsScopeHint("hq", townRoot)
 
-	for _, want := range []string{"database hq", "bd -C ~/gt", "bd --global", "beads_global"} {
+	for _, want := range []string{"database hq", "bd -C " + townRoot, "bd --global", "beads_global"} {
 		if !strings.Contains(hint, want) {
 			t.Fatalf("beadsScopeHint() missing %q in:\n%s", want, hint)
 		}
 	}
+	if strings.Contains(hint, "~/gt") {
+		t.Fatalf("beadsScopeHint() should not hardcode ~/gt:\n%s", hint)
+	}
 }
 
 func TestBeadsScopeHint_NonHQEmpty(t *testing.T) {
-	if hint := beadsScopeHint("gastown"); hint != "" {
+	if hint := beadsScopeHint("gastown", "/custom/town"); hint != "" {
 		t.Fatalf("beadsScopeHint() = %q, want empty", hint)
 	}
 }

--- a/internal/cmd/dolt_status_test.go
+++ b/internal/cmd/dolt_status_test.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/steveyegge/gastown/internal/doltserver"
@@ -84,5 +85,21 @@ func TestReadBeadsRuntimeConfigIgnoresEmbeddedMetadata(t *testing.T) {
 
 	if _, ok := readBeadsRuntimeConfig(beadsDir, townRoot); ok {
 		t.Fatal("embedded metadata should not be reported as shared-server config")
+	}
+}
+
+func TestBeadsScopeHint_HQWarnsAgainstGlobal(t *testing.T) {
+	hint := beadsScopeHint("hq")
+
+	for _, want := range []string{"database hq", "bd -C ~/gt", "bd --global", "beads_global"} {
+		if !strings.Contains(hint, want) {
+			t.Fatalf("beadsScopeHint() missing %q in:\n%s", want, hint)
+		}
+	}
+}
+
+func TestBeadsScopeHint_NonHQEmpty(t *testing.T) {
+	if hint := beadsScopeHint("gastown"); hint != "" {
+		t.Fatalf("beadsScopeHint() = %q, want empty", hint)
 	}
 }


### PR DESCRIPTION
## Summary
- replace the WIP checkpoint PR history with one clean upstream-based commit
- add an hq-specific `gt dolt status` hint explaining that Gas Town town beads use the `hq` database, not Beads' `beads_global`
- tighten docs so direct `bd` examples use the owning root via `bd -C`, and document `bd --global` and `bd dolt status` caveats

## Root Cause Evidence
- Live Dolt was healthy on 127.0.0.1:3307 with `beads`, `dotfiles`, `gastown`, and `hq`, but raw `bd update gt-dolt-hook-mail-persistence-recovery --notes ...` reproduced `auto-importing ... /home/coder/gt/.beads/issues.jsonl into empty database` and reported success.
- Diagnostics show healthy server status while clients attempted missing databases like `gt` and `mo`, plus repeated `hq` `nothing to commit` and serialization warnings.
- Upstream already contains the substantive gt subprocess hardening in `internal/beads/database.go` and `internal/mail/bd.go`: target env stripping, pinned/routing env builders, read-only/mutation modes, and bd side-effect suppression.
- The remaining upstream-safe fix is operator guidance and status visibility: make the `hq` vs `beads_global` split explicit and remove docs that implied direct `bd` always routes by ID from any worktree.

## Research Legs
1. Confirmed assignment requires PR #4181 repair/resling and research/review workflow.
2. Verified fork `origin/main` was at prior fix `0c5b5d92` while upstream/main is `e7949128`.
3. Inspected PR #4181 metadata: one WIP checkpoint commit, base upstream main.
4. Compared PR diff: four files only.
5. Compared prior fork-only fix against upstream; cherry-pick conflict area is `internal/cmd/dolt.go` and tests.
6. Inspected upstream bd subprocess env hardening in `internal/beads/database.go`.
7. Inspected upstream mail bd subprocess env policy in `internal/mail/bd.go`.
8. Checked live `gt dolt status`: server healthy and serving expected databases.
9. Checked installed `bd` version: 1.0.4.
10. Reproduced raw bd auto-import during research notes update.
11. Captured non-fatal `gt dolt status` after reproduction.
12. Captured non-fatal `gt dolt dump` after reproduction.
13. Reviewed `/tmp/dolt-autoimport-*` diagnostics for missing DB and hq warning patterns.
14. Reviewed related HQ escalations; original hq-wisp IDs are no longer directly showable, active incident trail is under hq-* escalations.
15. Reviewed PR CI failures from previous run; listed failures were pre-existing/unrelated to touched files.

## Pre-Implementation Review
1. Scope review: do not add new routing machinery; upstream already has subprocess hardening.
2. Docs review: current PR text still overpromised direct `bd` routing, so direct examples need `bd -C`/owning-root framing.
3. Code review: status hint should remain pure and only print for database `hq`.
4. Test review: add positive hq hint and negative non-hq coverage only.
5. History review: WIP checkpoint commit must be replaced with a clean commit.

## Post-Implementation Review
1. Final diff remains scoped to docs plus `gt dolt status` hint/tests.
2. Commit history is a single clean commit: `fix: clarify Gas Town beads scope`.
3. The docs now align with observed raw `bd` behavior and avoid claiming universal direct-bd prefix routing.
4. Tests cover hq warning content and non-hq silence.
5. No unrelated files or generated state are in the PR diff.

## Tests
- `go test ./internal/cmd -run 'Test(ReadBeadsRuntimeConfig|BeadsScopeHint)'`
- `go test ./internal/beads ./internal/mail`
- `git diff --check upstream/main...HEAD`

## Known CI Context
- Previous CI failures were in existing lint/test areas unrelated to this four-file PR. New CI is running on clean commit `c67a6c8b`.
