### PR TITLE
Dispatch wave one when staging and launching convoys

### DIFF
--- a/internal/cmd/convoy_launch_test.go
+++ b/internal/cmd/convoy_launch_test.go
@@ -171,6 +171,53 @@ func TestConvoyStageLaunchFlag(t *testing.T) {
 	}
 }
 
+// IT-21: stage --launch creates the staged convoy, opens it, and dispatches
+// Wave 1. This protects the gt convoy launch <task...> alias path, which
+// delegates to runConvoyStage with convoyStageLaunch=true.
+func TestConvoyStageLaunchFlagDispatchesWave1(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows — shell stubs")
+	}
+
+	td := newTestDAG(t).
+		Task("gt-t1", "Task One", withRig("gastown")).
+		Task("gt-t2", "Task Two", withRig("gastown")).BlockedBy("gt-t1")
+
+	_, logPath := td.Setup(t)
+
+	var dispatched []string
+	origDispatch := dispatchTaskDirect
+	dispatchTaskDirect = func(townRoot, beadID, rig string) error {
+		dispatched = append(dispatched, beadID)
+		return nil
+	}
+	t.Cleanup(func() {
+		dispatchTaskDirect = origDispatch
+		convoyStageLaunch = false
+		convoyLaunchForce = false
+		convoyStageTitle = ""
+	})
+
+	convoyStageLaunch = true
+	convoyStageTitle = "test staged launch"
+	if err := runConvoyStage(convoyStageCmd, []string{"gt-t1", "gt-t2"}); err != nil {
+		t.Fatalf("runConvoyStage --launch: %v", err)
+	}
+
+	if len(dispatched) != 1 || dispatched[0] != "gt-t1" {
+		t.Fatalf("expected only wave-1 task gt-t1 to dispatch, got %v", dispatched)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd.log: %v", err)
+	}
+	logContent := string(logBytes)
+	if !strings.Contains(logContent, "--status=open") {
+		t.Errorf("bd.log should contain convoy transition to open, got:\n%s", logContent)
+	}
+}
+
 // ---------------------------------------------------------------------------
 // Launch-as-alias tests (gt-csl.6.4)
 // ---------------------------------------------------------------------------
@@ -178,10 +225,8 @@ func TestConvoyStageLaunchFlag(t *testing.T) {
 // IT-19: gt convoy launch <epic-id> delegates to stage+launch (no "not yet
 // implemented" error). Verifies the delegation path is wired up.
 //
-// Note: rigFromBeadID() is a stub returning "", so the staging pipeline will
-// hit no-rig errors and stop before creating a convoy. The test verifies
-// delegation happened (bd show/dep list ran) and the old "not yet implemented"
-// error is gone.
+// The test stubs dispatch so the delegated stage+launch path cannot call the
+// real gt binary while verifying bd show/dep list activity.
 func TestLaunchAsAlias_EpicInput(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows — shell stubs")
@@ -195,10 +240,17 @@ func TestLaunchAsAlias_EpicInput(t *testing.T) {
 
 	_, logPath := td.Setup(t)
 
+	origDispatch := dispatchTaskDirect
+	dispatchTaskDirect = func(townRoot, beadID, rig string) error {
+		return nil
+	}
+
 	// Clean up shared state.
 	defer func() {
+		dispatchTaskDirect = origDispatch
 		convoyStageLaunch = false
 		convoyLaunchForce = false
+		convoyStageTitle = ""
 	}()
 
 	err := runConvoyLaunch(convoyLaunchCmd, []string{"gt-epic-1"})
@@ -236,8 +288,8 @@ func TestLaunchAsAlias_EpicInput(t *testing.T) {
 // IT-20: gt convoy launch <task-id1> <task-id2> delegates to stage+launch for
 // task list input.
 //
-// Note: rigFromBeadID() is a stub returning "", so the staging pipeline will
-// hit no-rig errors. The test verifies delegation happened.
+// The test stubs dispatch so the delegated stage+launch path cannot call the
+// real gt binary while verifying staging delegation happened.
 func TestLaunchAsAlias_TaskListInput(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows — shell stubs")
@@ -250,10 +302,17 @@ func TestLaunchAsAlias_TaskListInput(t *testing.T) {
 
 	_, logPath := td.Setup(t)
 
+	origDispatch := dispatchTaskDirect
+	dispatchTaskDirect = func(townRoot, beadID, rig string) error {
+		return nil
+	}
+
 	// Clean up shared state.
 	defer func() {
+		dispatchTaskDirect = origDispatch
 		convoyStageLaunch = false
 		convoyLaunchForce = false
+		convoyStageTitle = ""
 	}()
 
 	err := runConvoyLaunch(convoyLaunchCmd, []string{"gt-t1", "gt-t2"})

--- a/internal/cmd/convoy_stage.go
+++ b/internal/cmd/convoy_stage.go
@@ -392,7 +392,22 @@ func runConvoyStage(cmd *cobra.Command, args []string) error {
 		if err := transitionConvoyToOpen(convoyID, convoyLaunchForce); err != nil {
 			return err
 		}
-		fmt.Printf("Convoy launched: %s (status: open)\n", convoyID)
+
+		townRoot, err := workspace.FindFromCwdOrError()
+		if err != nil {
+			return fmt.Errorf("resolve town root for dispatch: %w", err)
+		}
+
+		if err := checkBlockedRigsForLaunch(dag, townRoot, convoyLaunchForce); err != nil {
+			return err
+		}
+
+		results, err := dispatchWave1(convoyID, dag, waves, townRoot)
+		if err != nil {
+			return fmt.Errorf("dispatch wave 1: %w", err)
+		}
+
+		fmt.Print(renderLaunchOutput(convoyID, waves, results, dag))
 	}
 
 	return nil

--- a/internal/cmd/convoy_test_helpers_test.go
+++ b/internal/cmd/convoy_test_helpers_test.go
@@ -228,6 +228,12 @@ func (d *testDAG) BdStubScript() string {
 		sb.WriteString("    exit 0\n")
 		sb.WriteString("    ;;\n")
 	}
+	sb.WriteString("  show\\ hq-cv-*\\ --json|show\\ --json\\ hq-cv-*)\n")
+	sb.WriteString("    id=\"\"\n")
+	sb.WriteString("    for arg in \"$@\"; do case \"$arg\" in hq-cv-*) id=\"$arg\";; esac; done\n")
+	sb.WriteString("    echo \"[{\\\"id\\\":\\\"$id\\\",\\\"title\\\":\\\"Generated Convoy\\\",\\\"issue_type\\\":\\\"convoy\\\",\\\"status\\\":\\\"staged_ready\\\",\\\"labels\\\":[\\\"gt:convoy\\\"]}]\"\n")
+	sb.WriteString("    exit 0\n")
+	sb.WriteString("    ;;\n")
 
 	// --- handle: sql "SELECT ..." --json (bdDepListRawIDs) ---
 	// bdDepListRawIDs calls: bd sql "SELECT depends_on_id FROM dependencies WHERE issue_id = '<id>' AND type = 'tracks'" --json
@@ -304,7 +310,7 @@ func (d *testDAG) BdStubScript() string {
 	sb.WriteString(fmt.Sprintf("    echo '%s'\n", convoyListJSON))
 	sb.WriteString("    exit 0\n")
 	sb.WriteString("    ;;\n")
-	sb.WriteString("  list\\ --json\\ --limit=0|list\\ --json\\ --limit=0\\ --all|list\\ --json\\ --limit=0\\ --status=*)\n")
+	sb.WriteString("  list\\ --json\\ --limit=0*|list\\ --json\\ --limit=0\\ --all*|list\\ --json\\ --limit=0\\ --status=*)\n")
 	sb.WriteString("    echo '[]'\n")
 	sb.WriteString("    exit 0\n")
 	sb.WriteString("    ;;\n")


### PR DESCRIPTION
Fixes the stage-launch path used by gt convoy launch task-list input and gt convoy stage --launch. After transitioning the staged convoy to open, it now dispatches wave 1 and renders the same launch output as launching an existing staged convoy. Adds regression coverage and stubs dispatch in alias tests so tests do not invoke the real gt binary.

Verification:
- go test ./internal/cmd -run "TestConvoyStageLaunchFlag|TestLaunchAsAlias|TestDispatchWave1_EndToEnd"