### PR TITLE
Fix convoy stranded blocked dependency decoding

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -2414,7 +2414,7 @@ func bdShowTrackedDeps(dir, convoyID string) ([]string, error) {
 	seen := make(map[string]bool)
 	var ids []string
 	for _, dep := range results[0].Dependencies {
-		if dep.DependencyType != "tracks" {
+		if dep.TypeName() != "tracks" {
 			continue
 		}
 		id := beads.ExtractIssueID(dep.ID)
@@ -2430,6 +2430,14 @@ type issueDependency struct {
 	ID             string `json:"id"`
 	Status         string `json:"status"`
 	DependencyType string `json:"dependency_type"`
+	Type           string `json:"type"`
+}
+
+func (d issueDependency) TypeName() string {
+	if d.DependencyType != "" {
+		return d.DependencyType
+	}
+	return d.Type
 }
 
 type issueDetailsJSON struct {
@@ -2510,7 +2518,7 @@ func (d issueDetails) IsBlocked() bool {
 
 	// bd show can omit blocked_by_count; fall back to live dependency edges.
 	for _, dep := range d.Dependencies {
-		if dep.DependencyType == "blocks" && dep.Status != "closed" && dep.Status != "tombstone" {
+		if isBlockingDepType(dep.TypeName()) && dep.Status != "closed" && dep.Status != "tombstone" {
 			return true
 		}
 	}

--- a/internal/cmd/convoy_empty_test.go
+++ b/internal/cmd/convoy_empty_test.go
@@ -367,3 +367,79 @@ esac
 		t.Errorf("stuck convoy ReadyCount = %d, want 0", s.ReadyCount)
 	}
 }
+
+func TestFindStrandedConvoys_BlocksDependencyTypeField(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping convoy test on Windows")
+	}
+
+	binDir := t.TempDir()
+	townRoot := t.TempDir()
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "routes.jsonl"), []byte(`{"prefix":"gt-","path":"gastown/mayor/rig"}`+"\n"), 0644); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	bdPath := filepath.Join(binDir, "bd")
+	script := `#!/bin/sh
+i=0
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) eval "pos$i=\"$arg\""; i=$((i+1)) ;;
+  esac
+done
+
+case "$pos0" in
+  list)
+    echo '[{"id":"hq-deps1","title":"Dependency convoy"}]'
+    exit 0
+    ;;
+  sql)
+    echo '[{"depends_on_id":"gt-a"},{"depends_on_id":"gt-b"}]'
+    exit 0
+    ;;
+  dep)
+    echo '[{"id":"gt-a","title":"Ready A","status":"open","issue_type":"task","assignee":"","dependency_type":"tracks"},{"id":"gt-b","title":"Blocked B","status":"open","issue_type":"task","assignee":"","dependency_type":"tracks"}]'
+    exit 0
+    ;;
+  show)
+    echo '[{"id":"gt-a","title":"Ready A","status":"open","issue_type":"task","assignee":"","blocked_by":[],"blocked_by_count":0,"dependencies":[]},{"id":"gt-b","title":"Blocked B","status":"open","issue_type":"task","assignee":"","blocked_by":[],"blocked_by_count":0,"dependencies":[{"id":"gt-a","status":"open","type":"blocks"}]}]'
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(bdPath, []byte(script), 0755); err != nil {
+		t.Fatalf("write mock bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	stranded, err := findStrandedConvoys(townRoot)
+	if err != nil {
+		t.Fatalf("findStrandedConvoys() error: %v", err)
+	}
+
+	if len(stranded) != 1 {
+		t.Fatalf("expected 1 stranded convoy, got %d", len(stranded))
+	}
+
+	s := stranded[0]
+	if s.ID != "hq-deps1" {
+		t.Errorf("stranded convoy ID = %q, want %q", s.ID, "hq-deps1")
+	}
+	if s.TrackedCount != 2 {
+		t.Errorf("dependency convoy TrackedCount = %d, want 2", s.TrackedCount)
+	}
+	if s.ReadyCount != 1 {
+		t.Errorf("dependency convoy ReadyCount = %d, want 1", s.ReadyCount)
+	}
+	if len(s.ReadyIssues) != 1 || s.ReadyIssues[0] != "gt-a" {
+		t.Errorf("dependency convoy ReadyIssues = %v, want [gt-a]", s.ReadyIssues)
+	}
+}

--- a/internal/cmd/convoy_stranded_test.go
+++ b/internal/cmd/convoy_stranded_test.go
@@ -104,6 +104,33 @@ func TestIssueDetailsIsBlocked(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "open blocks dependency from type field marks blocked",
+			in: issueDetails{
+				Dependencies: []issueDependency{
+					{Type: "blocks", Status: "open"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "open waits-for dependency marks blocked",
+			in: issueDetails{
+				Dependencies: []issueDependency{
+					{DependencyType: "waits-for", Status: "open"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "closed waits-for dependency does not mark blocked",
+			in: issueDetails{
+				Dependencies: []issueDependency{
+					{DependencyType: "waits-for", Status: "closed"},
+				},
+			},
+			want: false,
+		},
+		{
 			name: "closed blocks dependency does not mark blocked",
 			in: issueDetails{
 				Dependencies: []issueDependency{


### PR DESCRIPTION
## Summary

- Decode both `dependency_type` and `type` dependency JSON fields for convoy stranded readiness checks.
- Reuse the command package's existing blocking dependency predicate when deciding whether fresh `bd show` details are blocked.
- Add a regression where a convoy tracks A and B, B depends on A via `type:"blocks"`, and `gt convoy stranded` reports only A as ready.

## Why

`gt convoy stranded --json` feeds the daemon's convoy manager. If `bd show --json` returns dependency edges with `type` instead of `dependency_type`, a blocked tracked issue can be reported as ready and dispatched before its blocker closes.

## Validation

Passed:

```bash
mise x go@1.25.9 -- gofmt -w internal/cmd/convoy.go internal/cmd/convoy_stranded_test.go internal/cmd/convoy_empty_test.go
mise x go@1.25.9 -- go test ./internal/cmd -run 'TestIssueDetailsIsBlocked|TestFindStrandedConvoys_BlocksDependencyTypeField|TestFindStrandedConvoys_StuckConvoy' -count=1
git diff --check
```

Attempted:

```bash
mise x go@1.25.9 -- go test ./...
```

This did not complete cleanly in my local environment due to pre-existing unrelated `internal/cmd` failures, including ambient push-hook blocks in git-push tests, existing convoy routing test expectations, an install config output mismatch, and a Dolt container/server startup failure. The targeted convoy stranded tests above pass.
