### PR TITLE
fix(cmd): allow underscores in isBeadID prefix (#4090)

### DIFF
--- a/internal/cmd/cat.go
+++ b/internal/cmd/cat.go
@@ -61,17 +61,21 @@ func runCat(cmd *cobra.Command, args []string) error {
 }
 
 // isBeadID checks if a string looks like a bead ID.
-// Bead IDs have the format <prefix>-<id> where prefix is lowercase letters
-// (e.g. gt-abc123, bd-xyz, hq-cv-foo, wisp-bar, mol-baz).
+// Bead IDs have the format <prefix>-<id> where the prefix is lowercase letters
+// or underscores (rig names may contain underscores, and the rig name is used as
+// the bead prefix — e.g. gt-abc123, hq-cv-foo, japanese_reader-id3a).
 func isBeadID(s string) bool {
 	// Must contain a dash and start with lowercase letters
 	dashIdx := strings.Index(s, "-")
 	if dashIdx <= 0 || dashIdx >= len(s)-1 {
 		return false
 	}
-	// Prefix must be all lowercase letters
+	// Prefix must be lowercase letters or underscores. Rig names may contain
+	// underscores (hyphens are disallowed in rig names, so underscores are the
+	// natural separator), and the rig name becomes the bead prefix. This mirrors
+	// the characters already permitted by isValidBeadID in convoy.go. See #4090.
 	for _, c := range s[:dashIdx] {
-		if c < 'a' || c > 'z' {
+		if !((c >= 'a' && c <= 'z') || c == '_') {
 			return false
 		}
 	}

--- a/internal/cmd/cat_test.go
+++ b/internal/cmd/cat_test.go
@@ -18,6 +18,9 @@ func TestIsBeadID(t *testing.T) {
 		{"wy-def", true},
 		// Multi-segment prefixes
 		{"hq-cv-foo", true},
+		// Underscored prefixes - rig names may contain underscores (#4090)
+		{"japanese_reader-id3a", true},
+		{"mcp_fit-92f", true},
 		// Invalid inputs
 		{"", false},
 		{"-abc", false},


### PR DESCRIPTION
## Summary

`isBeadID` rejected bead IDs whose prefix contains an underscore, so `gt cat` / `gt hook` / `gt sling` refused to dispatch beads for any rig whose name contains `_` — even though `bd show` resolves them. Since `gt rig add` disallows hyphens, underscores are the natural separator in rig names, and the rig name becomes the bead prefix, so this hits common names (e.g. `japanese_reader`, `mcp_fit`).

The prefix check only allowed `[a-z]`; this widens it to also allow `_`, mirroring the characters already permitted by `isValidBeadID` in `convoy.go`. Uppercase- and digit-prefix inputs stay invalid (no change to existing expectations).

## Related Issue

Fixes #4090

Note: this is the **underscore-rejection** half of the "fresh rig can't dispatch" problem. The other compounding pieces are #2682 (gt derives an abbreviation route prefix while bd writes beads as the full DB-name prefix) and #4140 (formula-bond DB targeting — PRs #4141 / #4174). This change is independent of those and useful on its own.

## Changes

- `internal/cmd/cat.go`: allow `_` in the `isBeadID` prefix character set; updated the doc comment.
- `internal/cmd/cat_test.go`: extended `TestIsBeadID` with underscored-prefix cases (`japanese_reader-id3a`, `mcp_fit-92f`).

## Testing

- [x] Unit tests pass (`go test ./internal/cmd/ -run TestIsBeadID`) — new underscore cases pass; `ABC-123` / `123-abc` still rejected.
- [x] Original rejection reproduced on `gt 1.2.1` (`gt show mcp_fit-92f` → "no issue found", `gt sling` → "not a valid bead or formula").
- [ ] Not yet run with a rebuilt binary against a live town end-to-end — full underscored-rig dispatch is also gated by #2682 and #4140, so an e2e dispatch test isn't possible until those land.

## Checklist

- [x] Code follows project style
- [x] Documentation updated (doc comment on `isBeadID`)
- [x] No breaking changes (uppercase/digit prefixes remain invalid; existing test expectations unchanged)
