### PR TITLE
fix(formulas): drop redundant required=true on vars that also set a default

### DIFF
--- a/internal/formula/formulas/mol-digest-generate.formula.toml
+++ b/internal/formula/formulas/mol-digest-generate.formula.toml
@@ -223,7 +223,6 @@ Dog returns to available state in the pool.
 [vars]
 [vars.period]
 description = "The digest period type (daily, weekly, custom)"
-required = true
 default = "daily"
 
 [vars.date]

--- a/internal/formula/formulas/mol-orphan-scan.formula.toml
+++ b/internal/formula/formulas/mol-orphan-scan.formula.toml
@@ -322,7 +322,6 @@ Dog returns to available state in the pool.
 [vars]
 [vars.scope]
 description = "Scan scope: 'town' or specific rig name"
-required = true
 default = "town"
 
 [vars.action]

--- a/internal/formula/formulas/mol-shutdown-dance.formula.toml
+++ b/internal/formula/formulas/mol-shutdown-dance.formula.toml
@@ -515,5 +515,4 @@ required = true
 
 [vars.requester]
 description = "Who filed the warrant (deacon, witness, mayor)"
-required = true
 default = "deacon"


### PR DESCRIPTION
## Summary
Three formulas declare a `[vars.*]` entry with **both** `required = true` and a `default`, which the formula validator rejects:
```
formula validation failed:
  - vars.<x>: cannot have both required:true and default
```
This makes `bd cook` — and therefore `gt sling` — fail for these formulas on a clean, matched install (reproduced on bd v1.0.0, the version `go.mod` pins, and on 1.0.5).

## Affected formulas & provenance
| Formula | Var (default) | Introduced | Broken for |
|---|---|---|---|
| `mol-digest-generate` | `period` (`"daily"`) | `1e76bfd7c` 2026-01-05 | ~5 months |
| `mol-shutdown-dance` | `requester` (`"deacon"`) | `b649635f4` 2026-01-07 | ~5 months |
| `mol-orphan-scan` | `scope` (`"town"`) | `6ed4deaf1` 2026-02-20 | ~3.5 months |

## Root cause
A var with a `default` is never "missing" — the default supplies a value when the var isn't passed — so `required = true` can never fire. The two are contradictory, and the validator enforces them as mutually exclusive. The `required` flag is redundant and renders the formula uncookable.

## Why it went unnoticed
All three are rarely-cooked admin/infra formulas (digest generation, shutdown, orphan recovery). The ~44 core work formulas (polecat-work, feature, bug, …) are unaffected, so normal operation never trips it. It only surfaces when one of these is slung.

## Fix
Remove the redundant `required = true` from each var. Behavior is unchanged — the defaults (`daily` / `deacon` / `town`) still apply.

## Verification
All three cook cleanly after the change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
