### PR TITLE
fix(beads): pin metadata database for bd subprocesses

### DIFF
--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -114,8 +114,11 @@ func TestBuildPinnedBDEnvUsesSelectedConnectionMetadata(t *testing.T) {
 	if got["BEADS_DIR"] != beadsDir {
 		t.Fatalf("BEADS_DIR = %q, want %q in %v", got["BEADS_DIR"], beadsDir, env)
 	}
-	if value, ok := got["BEADS_DOLT_SERVER_DATABASE"]; ok {
-		t.Fatalf("BEADS_DOLT_SERVER_DATABASE should be stripped, got %q in %v", value, env)
+	if got["BEADS_DOLT_SERVER_DATABASE"] != "rigdb" {
+		t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want rigdb in %v", got["BEADS_DOLT_SERVER_DATABASE"], env)
+	}
+	if count := countEnvPrefix(env, "BEADS_DOLT_SERVER_DATABASE="); count != 1 {
+		t.Fatalf("BEADS_DOLT_SERVER_DATABASE count = %d, want 1 in %v", count, env)
 	}
 	if got["BEADS_DOLT_SERVER_HOST"] != "127.0.0.1" {
 		t.Fatalf("BEADS_DOLT_SERVER_HOST = %q, want 127.0.0.1 in %v", got["BEADS_DOLT_SERVER_HOST"], env)
@@ -178,8 +181,8 @@ func TestBuildPinnedBDEnvFallsBackToGTDoltPort(t *testing.T) {
 		"GT_DOLT_PORT=5507",
 	}, beadsDir)
 	got := envMap(env)
-	if value, ok := got["BEADS_DOLT_SERVER_DATABASE"]; ok {
-		t.Fatalf("BEADS_DOLT_SERVER_DATABASE should be stripped, got %q in %v", value, env)
+	if got["BEADS_DOLT_SERVER_DATABASE"] != "rigdb" {
+		t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want rigdb in %v", got["BEADS_DOLT_SERVER_DATABASE"], env)
 	}
 	if got["BEADS_DOLT_SERVER_HOST"] != "127.0.0.2" {
 		t.Fatalf("BEADS_DOLT_SERVER_HOST = %q, want GT_DOLT_HOST fallback in %v", got["BEADS_DOLT_SERVER_HOST"], env)
@@ -262,6 +265,9 @@ func TestBuildMutationBDEnvForcesWritableCommit(t *testing.T) {
 
 	if got["BEADS_DIR"] != beadsDir {
 		t.Fatalf("BEADS_DIR = %q, want %q in %v", got["BEADS_DIR"], beadsDir, env)
+	}
+	if got["BEADS_DOLT_SERVER_DATABASE"] != "hq" {
+		t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want hq in %v", got["BEADS_DOLT_SERVER_DATABASE"], env)
 	}
 	if got["BD_DOLT_AUTO_COMMIT"] != "on" {
 		t.Fatalf("BD_DOLT_AUTO_COMMIT = %q, want on in %v", got["BD_DOLT_AUTO_COMMIT"], env)
@@ -3999,6 +4005,7 @@ printf 'unknown\n'
 	}
 	for _, want := range []string{
 		"BEADS_DIR=" + beadsDir,
+		"BEADS_DOLT_SERVER_DATABASE=gastown",
 		"BEADS_DOLT_PORT=3307",
 		"BEADS_DOLT_SERVER_HOST=127.0.0.1",
 	} {

--- a/internal/beads/database.go
+++ b/internal/beads/database.go
@@ -63,9 +63,9 @@ func StripBDTargetEnv(env []string) []string {
 }
 
 // BuildPinnedBDEnv returns env for a bd subprocess pinned to beadsDir. BEADS_DIR
-// is the authoritative database selector; inherited explicit database selectors
-// are stripped because bd 1.0.x can resolve a different/stale view when both are
-// present, making newly-created routed beads invisible to gt hook/sling.
+// and the metadata-backed Dolt database are the authoritative target selectors;
+// inherited selectors are stripped first so stale shell state cannot make bd
+// write to a different database than the selected .beads directory.
 func BuildPinnedBDEnv(base []string, beadsDir string) []string {
 	env := SuppressBDSideEffects(StripBDTargetEnv(base))
 	if beadsDir == "" {
@@ -73,6 +73,9 @@ func BuildPinnedBDEnv(base []string, beadsDir string) []string {
 	}
 	env = append(env, "BEADS_DIR="+beadsDir)
 	env = append(env, doltTargetEnvFromBeadsDir(beadsDir)...)
+	if dbEnv := DatabaseEnv(beadsDir); dbEnv != "" {
+		env = append(env, dbEnv)
+	}
 	return addGTDerivedDoltTargetEnv(env)
 }
 
@@ -201,9 +204,6 @@ func doltTargetEnvFromBeadsDir(beadsDir string) []string {
 	}
 	meta := readDoltMetadata(beadsDir)
 	var env []string
-	if townRoot := FindTownRoot(filepath.Dir(beadsDir)); townRoot != "" {
-		env = append(env, "BEADS_DOLT_DATA_DIR="+filepath.Join(townRoot, ".dolt-data"))
-	}
 	if meta.Host != "" {
 		env = append(env, "BEADS_DOLT_SERVER_HOST="+meta.Host)
 	}

--- a/internal/cmd/bd_helpers_test.go
+++ b/internal/cmd/bd_helpers_test.go
@@ -569,8 +569,8 @@ func TestBdCmd_WithBeadsDir_OverridesInheritedDoltTarget(t *testing.T) {
 	if envMap["BEADS_DIR"] != beadsDir {
 		t.Errorf("BEADS_DIR = %q, want %q", envMap["BEADS_DIR"], beadsDir)
 	}
-	if _, ok := envMap["BEADS_DOLT_SERVER_DATABASE"]; ok {
-		t.Errorf("BEADS_DOLT_SERVER_DATABASE should be absent when BEADS_DIR is pinned, got %q", envMap["BEADS_DOLT_SERVER_DATABASE"])
+	if envMap["BEADS_DOLT_SERVER_DATABASE"] != "rigdb" {
+		t.Errorf("BEADS_DOLT_SERVER_DATABASE = %q, want rigdb", envMap["BEADS_DOLT_SERVER_DATABASE"])
 	}
 	if envMap["BEADS_DOLT_SERVER_HOST"] != "127.0.0.1" {
 		t.Errorf("BEADS_DOLT_SERVER_HOST = %q, want 127.0.0.1", envMap["BEADS_DOLT_SERVER_HOST"])

--- a/internal/daemon/bd_env_test.go
+++ b/internal/daemon/bd_env_test.go
@@ -54,7 +54,7 @@ func TestBdReadOnlyPinnedEnvUsesSelectedBeadsDir(t *testing.T) {
 
 	env := bdReadOnlyPinnedEnv(beadsDir)
 	assertSingleEnvValue(t, env, "BEADS_DIR", beadsDir)
-	assertEnvAbsent(t, env, "BEADS_DOLT_SERVER_DATABASE")
+	assertSingleEnvValue(t, env, "BEADS_DOLT_SERVER_DATABASE", "rigdb")
 	assertSingleEnvValue(t, env, "BEADS_DOLT_SERVER_PORT", "4407")
 	assertSingleEnvValue(t, env, "BEADS_DOLT_PORT", "4407")
 	assertSingleEnvValue(t, env, "BD_DOLT_AUTO_COMMIT", "off")

--- a/internal/mail/bd_test.go
+++ b/internal/mail/bd_test.go
@@ -260,8 +260,8 @@ func TestBdSubprocessEnv_FiltersStaleBdTargetEnv(t *testing.T) {
 	if !envContains(got, "BEADS_DIR="+beadsDir) {
 		t.Fatalf("expected current BEADS_DIR in env, got %v", got)
 	}
-	if _, ok := envLastValue(got, "BEADS_DOLT_SERVER_DATABASE"); ok {
-		t.Fatalf("database selector should be absent when BEADS_DIR is pinned, got %v", got)
+	if value, ok := envLastValue(got, "BEADS_DOLT_SERVER_DATABASE"); !ok || value != "rigdb" {
+		t.Fatalf("database selector = %q present=%v, want rigdb in %v", value, ok, got)
 	}
 	for _, want := range []string{"BD_READONLY=true", "BD_DOLT_AUTO_COMMIT=off", "BD_EXPORT_AUTO=false", "BD_BACKUP_ENABLED=false", "BD_DOLT_AUTO_PUSH=false", "BD_NO_PUSH=true", "BD_EXPORT_GIT_ADD=false", "BD_NO_GIT_OPS=true"} {
 		if !envContains(got, want) {

--- a/internal/proxy/exec_test.go
+++ b/internal/proxy/exec_test.go
@@ -393,7 +393,7 @@ func TestHandleExec_BDCreateRepoAliasPinsCanonicalBeadsDir(t *testing.T) {
 		assert.NotContains(t, resp.Stdout, "[--repo]")
 		assert.NotContains(t, resp.Stdout, "[gastown]")
 		assert.Contains(t, resp.Stdout, "BEADS_DIR="+canonicalBeads)
-		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=\n")
+		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=gastown\n")
 		assert.Contains(t, resp.Stdout, "BD_DOLT_AUTO_COMMIT=on")
 		assert.Contains(t, resp.Stdout, "BD_NO_GIT_OPS=true")
 		assert.NotContains(t, resp.Stdout, "BEADS_DIR="+decoyBeads)
@@ -412,7 +412,7 @@ func TestHandleExec_BDCreateRepoAliasPinsCanonicalBeadsDir(t *testing.T) {
 		assert.NotContains(t, resp.Stdout, "--repo=gastown")
 		assert.NotContains(t, resp.Stdout, "[gastown]")
 		assert.Contains(t, resp.Stdout, "BEADS_DIR="+canonicalBeads)
-		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=\n")
+		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=gastown\n")
 		assert.Contains(t, resp.Stdout, "BD_DOLT_AUTO_COMMIT=on")
 	})
 
@@ -422,7 +422,7 @@ func TestHandleExec_BDCreateRepoAliasPinsCanonicalBeadsDir(t *testing.T) {
 		assert.NotContains(t, resp.Stdout, "[--repo]")
 		assert.NotContains(t, resp.Stdout, "[hq]")
 		assert.Contains(t, resp.Stdout, "BEADS_DIR="+townBeads)
-		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=\n")
+		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=hq\n")
 	})
 
 	t.Run("town alias", func(t *testing.T) {
@@ -431,7 +431,7 @@ func TestHandleExec_BDCreateRepoAliasPinsCanonicalBeadsDir(t *testing.T) {
 		assert.NotContains(t, resp.Stdout, "[--repo]")
 		assert.NotContains(t, resp.Stdout, "[town]")
 		assert.Contains(t, resp.Stdout, "BEADS_DIR="+townBeads)
-		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=\n")
+		assert.Contains(t, resp.Stdout, "BEADS_DOLT_SERVER_DATABASE=hq\n")
 	})
 
 	t.Run("path-like repo remains explicit", func(t *testing.T) {


### PR DESCRIPTION
## Summary
- Pin pinned bd subprocesses to the selected .beads metadata database via BEADS_DOLT_SERVER_DATABASE.
- Keep routing-mode bd subprocesses database-unpinned.
- Update env-policy tests across beads/cmd/daemon/mail/proxy.

## Verification
- git diff --check
- go test ./internal/beads ./internal/cmd ./internal/daemon ./internal/mail ./internal/proxy -run 'Test(BuildPinnedBDEnv|BuildRoutingBDEnv|BuildReadOnlyBDEnv|BuildMutationBDEnv|RunEnv_StripsPollutedDoltEnvAndUsesRigMetadata|BdCmd_WithBeadsDir_OverridesInheritedDoltTarget|BdCmd_WithRoutingDoesNotPinBeadsDir|BdReadOnlyPinnedEnvUsesSelectedBeadsDir|BdReadOnlyRoutingEnvDoesNotPinDatabase|BdSubprocessEnv_FiltersStaleBdTargetEnv|BdSubprocessEnv_AllowsRoutingWhenBeadsDirEmpty|HandleExec_BDCreateRepoAliasPinsCanonicalBeadsDir)' -count=1
- go build ./cmd/gt
- Installed patched gt locally and verified gt hook show gastown/rust reads persisted hook.
- Mayor-side sling smoke: gt sling gt-sling-smoke-1505 gastown; gt scheduler run; hook readback showed gastown/chrome hooked; smoke bead closed and chrome nuked.

## Residual
- bd still emits auto-import warnings during direct mutations/scheduler dispatch; tracked separately in hq-oy83.
