### PR TITLE
fix(reaper): use v49 dependency columns to stop false dangling-parent flood

### DIFF
--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -203,7 +203,7 @@ func parentExcludeJoin(dbName string) (joinClause, whereCondition string) {
 	joinClause = `LEFT JOIN (
 		SELECT DISTINCT wd.issue_id
 		FROM wisp_dependencies wd
-		LEFT JOIN wisps pw ON pw.id = wd.depends_on_id LEFT JOIN issues pi ON pi.id = wd.depends_on_id
+		LEFT JOIN wisps pw ON pw.id = wd.depends_on_wisp_id LEFT JOIN issues pi ON pi.id = wd.depends_on_issue_id
 		WHERE wd.type = 'parent-child'
 		AND (pw.status IN ('open', 'hooked', 'in_progress') OR pi.status IN ('open', 'in_progress'))
 	) open_parent ON open_parent.issue_id = w.id`
@@ -278,11 +278,11 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 		AND i.issue_type != 'epic'
 		AND i.id NOT IN (
 			SELECT DISTINCT d.issue_id FROM dependencies d
-			INNER JOIN issues dep ON d.depends_on_id = dep.id
+			INNER JOIN issues dep ON d.depends_on_issue_id = dep.id
 			WHERE dep.status IN ('open', 'in_progress')
 		)
 		AND i.id NOT IN (
-			SELECT DISTINCT d.depends_on_id FROM dependencies d
+			SELECT DISTINCT d.depends_on_issue_id FROM dependencies d
 			INNER JOIN issues blocker ON d.issue_id = blocker.id
 			WHERE blocker.status IN ('open', 'in_progress')
 		)`
@@ -302,7 +302,7 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 	// Anomaly detection: dangling parent references.
 	danglingQuery := `
 		SELECT COUNT(*) FROM wisp_dependencies wd
-		LEFT JOIN wisps pw ON pw.id = wd.depends_on_id LEFT JOIN issues pi ON pi.id = wd.depends_on_id
+		LEFT JOIN wisps pw ON pw.id = wd.depends_on_wisp_id LEFT JOIN issues pi ON pi.id = wd.depends_on_issue_id
 		WHERE wd.type = 'parent-child' AND pw.id IS NULL AND pi.id IS NULL`
 	var danglingCount int
 	if err := db.QueryRowContext(ctx, danglingQuery).Scan(&danglingCount); err == nil && danglingCount > 0 {
@@ -604,11 +604,11 @@ func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (
 		)
 		AND i.id NOT IN (
 			SELECT DISTINCT d.issue_id FROM `+"`%s`"+`.dependencies d
-			INNER JOIN `+"`%s`"+`.issues dep ON d.depends_on_id = dep.id
+			INNER JOIN `+"`%s`"+`.issues dep ON d.depends_on_issue_id = dep.id
 			WHERE dep.status IN ('open', 'in_progress')
 		)
 		AND i.id NOT IN (
-			SELECT DISTINCT d.depends_on_id FROM `+"`%s`"+`.dependencies d
+			SELECT DISTINCT d.depends_on_issue_id FROM `+"`%s`"+`.dependencies d
 			INNER JOIN `+"`%s`"+`.issues blocker ON d.issue_id = blocker.id
 			WHERE blocker.status IN ('open', 'in_progress')
 		)`, dbName, dbName, dbName, dbName, dbName)
@@ -747,7 +747,10 @@ func batchDeleteRows(ctx context.Context, db *sql.DB, idQuery string, cutoffArg 
 		}
 
 		// Clean up reverse dependency references to prevent dangling parent refs.
-		delReverse := fmt.Sprintf("DELETE FROM wisp_dependencies WHERE depends_on_id IN %s", inClause)
+		// Post-v49, parent-child links live in depends_on_wisp_id (the legacy
+		// depends_on_id column is empty), so target that column to actually
+		// remove refs pointing to the purged wisps.
+		delReverse := fmt.Sprintf("DELETE FROM wisp_dependencies WHERE depends_on_wisp_id IN %s", inClause)
 		if _, err := db.ExecContext(ctx, delReverse, args...); err != nil {
 			// Non-fatal.
 		}

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -69,6 +69,21 @@ func TestParentExcludeJoin(t *testing.T) {
 	if !contains(joinClause, "parent-child") {
 		t.Error("parentExcludeJoin should filter on parent-child type")
 	}
+
+	// Regression (hq-y5myz): migration v49 moved parent-child links into
+	// depends_on_wisp_id / depends_on_issue_id and left the legacy depends_on_id
+	// column empty. Joining on the empty column flagged every parent-child link as
+	// dangling (~4200 false positives), driving an escalation flood and a failing-
+	// query storm that ballooned Dolt memory. Lock the post-v49 columns in.
+	if !contains(joinClause, "depends_on_wisp_id") {
+		t.Error("parentExcludeJoin should join wisp parents on depends_on_wisp_id (v49 schema)")
+	}
+	if !contains(joinClause, "depends_on_issue_id") {
+		t.Error("parentExcludeJoin should join issue parents on depends_on_issue_id (v49 schema)")
+	}
+	if contains(joinClause, "wd.depends_on_id") {
+		t.Error("parentExcludeJoin must not use the legacy empty depends_on_id column (v49 skew)")
+	}
 	if !contains(joinClause, "'open', 'hooked', 'in_progress'") {
 		t.Error("parentExcludeJoin should check for open parent statuses")
 	}


### PR DESCRIPTION
## Summary

Migration **v49** renamed `dependencies.depends_on_id` → `depends_on_issue_id` and moved parent-child wisp links into `wisp_dependencies.depends_on_wisp_id`, leaving the legacy `depends_on_id` column empty. `internal/reaper/reaper.go` still joined on the old column, so **every reaper scan flagged all parent-child links as dangling** (4369 false positives on `hq`). This drove a multi-day escalation flood and a failing-query storm that ballooned the Dolt server's memory (observed 14.8 GB RSS, swap exhausted on 2026-06-08).

This is **purely a query bug** — the data is intact.

## Changes

Migrated every dependency-column query site in `reaper.go`:
- **dependencies-table joins** (`Scan` stale-issue check + `AutoClose`): `d.depends_on_id` → `d.depends_on_issue_id`
- **dangling-parent detection** + **`parentExcludeJoin`**: parent-wisp join → `wd.depends_on_wisp_id`, parent-issue join → `wd.depends_on_issue_id`
- **`batchDeleteRows`** reverse-ref cleanup `DELETE`: `wisp_dependencies WHERE depends_on_id` → `depends_on_wisp_id` (so purging a parent actually removes the reverse refs)

Added regression assertions to `TestParentExcludeJoin` that lock in the post-v49 columns and forbid the legacy `depends_on_id`.

## Test plan

- [x] `go build ./internal/reaper/` and `go vet ./internal/reaper/` clean
- [x] `go test ./internal/reaper/` passes (incl. new regression assertions)
- [x] Verified against live `hq`: dangling count **4369 → 0** at the SQL level
- [x] Ran the compiled `gt reaper scan --db=hq` — **no `dangling_parent_ref` anomaly** reported (was ~4369)
- [x] Confirmed all 4369 parent-child links resolve via `depends_on_wisp_id` (0 truly missing) — data is intact

🤖 Generated with [Claude Code](https://claude.com/claude-code)