### PR TITLE
fix: update wisp_dependencies to use typed dependency columns

### DIFF
--- a/internal/cmd/compact.go
+++ b/internal/cmd/compact.go
@@ -283,7 +283,7 @@ func runCompact(cmd *cobra.Command, args []string) error {
 func cleanOrphanedWispDeps(bd *beads.Beads, result *compactResult) {
 	const q = `DELETE FROM wisp_dependencies WHERE ` +
 		`NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.issue_id) ` +
-		`OR NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_id)`
+		`OR (depends_on_wisp_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_wisp_id))`
 	out, err := bd.Run("sql", q)
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("orphaned wisp_deps cleanup: %v", err))

--- a/internal/doltserver/wisps_migrate.go
+++ b/internal/doltserver/wisps_migrate.go
@@ -257,7 +257,7 @@ func copyAuxiliaryData(workDir string, result *MigrateWispsResult) error {
 
 	// Copy dependencies
 	if err := bdSQL(workDir,
-		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_id, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d INNER JOIN wisps w ON d.issue_id = w.id"); err != nil {
+		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_issue_id, d.depends_on_wisp_id, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d INNER JOIN wisps w ON d.issue_id = w.id"); err != nil {
 		if !strings.Contains(err.Error(), "nothing") {
 			return fmt.Errorf("copying dependencies: %w", err)
 		}
@@ -458,14 +458,21 @@ var wispAuxTableDDLs = []wispAuxTableDDL{
 	{
 		name: "wisp_dependencies",
 		ddl: `CREATE TABLE wisp_dependencies (
+  id char(36) NOT NULL DEFAULT (uuid()),
   issue_id varchar(255) NOT NULL,
-  depends_on_id varchar(255) NOT NULL,
+  depends_on_issue_id varchar(255),
+  depends_on_wisp_id varchar(255),
+  depends_on_external varchar(255),
   type varchar(32) NOT NULL DEFAULT 'blocks',
-  created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  created_by varchar(255) NOT NULL DEFAULT '',
-  metadata json,
+  created_at datetime DEFAULT CURRENT_TIMESTAMP,
+  created_by varchar(255) DEFAULT '',
+  metadata json DEFAULT (json_object()),
   thread_id varchar(255) DEFAULT '',
-  PRIMARY KEY (issue_id, depends_on_id),
+  depends_on_id varchar(255) GENERATED ALWAYS AS (COALESCE(depends_on_wisp_id, depends_on_issue_id)) VIRTUAL,
+  PRIMARY KEY (id),
+  KEY idx_wisp_deps_issue (issue_id),
+  KEY idx_wisp_deps_depends_on_issue (depends_on_issue_id),
+  KEY idx_wisp_deps_depends_on_wisp (depends_on_wisp_id),
   KEY idx_wisp_deps_depends_on (depends_on_id)
 )`,
 	},


### PR DESCRIPTION
## Summary

- `compact.go`: orphan cleanup DELETE used the non-existent `depends_on_id` column in `wisp_dependencies`; updated to check `depends_on_wisp_id` (only wisp-side refs need validating against the wisps table — `depends_on_issue_id` targets regular beads)
- `wisps_migrate.go` DDL: `CREATE TABLE wisp_dependencies` still used the old single-column layout; updated to match current schema with typed target columns (`depends_on_issue_id`, `depends_on_wisp_id`, `depends_on_external`), new `id` PK, and `depends_on_id` as a `VIRTUAL GENERATED` compat column
- `wisps_migrate.go` INSERT: `copyAuxiliaryData` referenced old column names; updated to populate the typed columns from `dependencies`

## Background

Beads migrations 0041 + wisps/ignored-0003 split `dependencies.depends_on_id` and `wisp_dependencies.depends_on_id` into three typed columns. Gastown wasn't updated. This caused `gt compact` orphan cleanup to error every compaction cycle with `table "wisp_dependencies" does not have column "depends_on_id"`, and blocked Convoy event polling from initializing the hq beads store.

A mitigation was applied 2026-06-09 (added a `depends_on_id` VIRTUAL column to the live tables), restoring Convoy. This PR is the permanent source fix.

Tracked: hq-esy

## Test plan
- [ ] `gt compact` on an install with new-schema `wisp_dependencies` completes without error
- [ ] Fresh `gt install` creates `wisp_dependencies` with the new schema
- [ ] `gt migrate-wisps` copies dependencies correctly using typed columns

🤖 Generated with [Claude Code](https://claude.com/claude-code)