### PR TITLE
fix: protect remote polecat prune deletes

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -2217,7 +2217,7 @@ func runPolecatPrune(cmd *cobra.Command, args []string) error {
 			if polecatPruneDryRun {
 				fmt.Printf("  Would delete remote: %s\n", style.Dim.Render(branch))
 			} else {
-				if delErr := repoGit.DeleteRemoteBranch("origin", branch); delErr != nil {
+				if delErr := repoGit.DeleteRemoteBranchIfAt("origin", branch, ref.Hash); delErr != nil {
 					fmt.Printf("  %s remote %s: %v\n", style.Warning.Render("⚠"), branch, delErr)
 				} else {
 					fmt.Printf("  %s deleted remote %s\n", style.Success.Render("✓"), branch)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -1408,6 +1408,13 @@ func (g *Git) DeleteRemoteBranch(remote, branch string) error {
 	return err
 }
 
+// DeleteRemoteBranchIfAt deletes a remote branch only if it still points at expectedHash.
+func (g *Git) DeleteRemoteBranchIfAt(remote, branch, expectedHash string) error {
+	ref := "refs/heads/" + branch
+	_, err := g.runWithTimeout(pushTimeout, "push", "--force-with-lease="+ref+":"+expectedHash, remote, ":"+ref)
+	return err
+}
+
 // HasOpenPR checks whether the given branch has an open pull request on GitHub.
 // Uses the gh CLI to query for open PRs with the branch as head ref.
 // Returns false on any error (fail-open: branch deletion proceeds if gh is unavailable).

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -2851,6 +2851,76 @@ func TestListPushRemoteRefsWithHashesUsesPushURLHash(t *testing.T) {
 	}
 }
 
+func TestDeleteRemoteBranchIfAtRejectsChangedBranch(t *testing.T) {
+	localDir, _, mainBranch := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+
+	branch := "polecat/lease-test"
+	if err := g.CreateBranch(branch); err != nil {
+		t.Fatalf("CreateBranch: %v", err)
+	}
+	if err := g.Checkout(branch); err != nil {
+		t.Fatalf("Checkout: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "lease.txt"), []byte("old"), 0644); err != nil {
+		t.Fatalf("write old: %v", err)
+	}
+	if err := g.Add("lease.txt"); err != nil {
+		t.Fatalf("Add old: %v", err)
+	}
+	if err := g.Commit("lease old"); err != nil {
+		t.Fatalf("Commit old: %v", err)
+	}
+	oldHash, err := g.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev old: %v", err)
+	}
+	if err := g.Push("origin", branch, false); err != nil {
+		t.Fatalf("Push old: %v", err)
+	}
+
+	if err := os.WriteFile(filepath.Join(localDir, "lease.txt"), []byte("new"), 0644); err != nil {
+		t.Fatalf("write new: %v", err)
+	}
+	if err := g.Add("lease.txt"); err != nil {
+		t.Fatalf("Add new: %v", err)
+	}
+	if err := g.Commit("lease new"); err != nil {
+		t.Fatalf("Commit new: %v", err)
+	}
+	newHash, err := g.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev new: %v", err)
+	}
+	if err := g.Push("origin", branch, false); err != nil {
+		t.Fatalf("Push new: %v", err)
+	}
+
+	if err := g.DeleteRemoteBranchIfAt("origin", branch, oldHash); err == nil {
+		t.Fatal("DeleteRemoteBranchIfAt should reject a branch that advanced")
+	}
+	exists, err := g.RemoteBranchExists("origin", branch)
+	if err != nil {
+		t.Fatalf("RemoteBranchExists after rejected delete: %v", err)
+	}
+	if !exists {
+		t.Fatal("branch should still exist after rejected delete")
+	}
+	if err := g.DeleteRemoteBranchIfAt("origin", branch, newHash); err != nil {
+		t.Fatalf("DeleteRemoteBranchIfAt current hash: %v", err)
+	}
+	exists, err = g.RemoteBranchExists("origin", branch)
+	if err != nil {
+		t.Fatalf("RemoteBranchExists after delete: %v", err)
+	}
+	if exists {
+		t.Fatal("branch should be deleted when expected hash matches")
+	}
+	if err := g.Checkout(mainBranch); err != nil {
+		t.Fatalf("Checkout main: %v", err)
+	}
+}
+
 // TestPushRemoteBranchExists_NoPushURL verifies that PushRemoteBranchExists
 // falls back to RemoteBranchExists when no custom push URL is configured.
 func TestPushRemoteBranchExists_NoPushURL(t *testing.T) {


### PR DESCRIPTION
Supersedes #3847 and replaces closed PR #4208 with a clean branch based on current upstream/main.

This keeps the already-upstreamed hash-preserving remote prune classifier behavior and adds the remaining safety guard from the sheriff review: remote prune now deletes a branch only if it still points at the advertised hash used for classification.

Original author credit preserved in the commit trailer: Co-Authored-By: Brandon Smyth <bsmyth77@gmail.com>.

Sheriff summary:
- R1-R15: root cause was remote prune classifying remote-only refs by short branch name; the narrow fix is to use ls-remote hashes from the push target and avoid broader active-polecat filtering or cleanup layers.
- P1-P5: pre-implementation reviewers approved the narrow hash-preserving classifier approach with focused regression coverage and no scope expansion.
- F1-F5: final post-review found no blockers; two reviewers noted the pre-existing summary counter can count failed remote deletes, but per-branch warnings remain clear and preserving existing counter behavior matches the prior scope decision.

Validation:
- PASS: go test -count=1 ./internal/git -run 'Test(ListPushRemoteRefsWithHashes(ClassifiesRemoteOnlyMergedBranch|UsesPushURLHash)|DeleteRemoteBranchIfAtRejectsChangedBranch)$'
- PASS: go test -count=1 ./internal/cmd -run 'TestPolecat|TestPrune'
- PASS: make build
- PASS: git diff --check upstream/main...HEAD
- FAIL unrelated/pre-existing: go test -count=1 ./internal/git ./internal/cmd failed in internal/cmd tests including TestFilterAndSortSessions_SortOrder, TestGuessSessionFromWorkerDir/different_rig, convoy tracking/JSON tests, and TestEnsureBeadsConfigYAML_CreatesWhenMissing. internal/git passed in that broader run.
