### PR TITLE
Make polecat caps configurable and worker reuse robust

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -93,7 +93,7 @@ func shouldSyncIdlePolecatWorktree(exitType, mergeStrategy string, pushFailed, m
 }
 
 func cleanupStatusAfterSuccessfulPush(status string) string {
-	if status == "unpushed" {
+	if status == "unpushed" || status == "has_unpushed" {
 		return "clean"
 	}
 	return status

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -1435,12 +1435,18 @@ notifyWitness:
 			oldBranch := branch
 
 			fmt.Printf("%s Syncing worktree to %s...\n", style.Bold.Render("→"), defaultBranch)
-			if err := g.Checkout(defaultBranch); err != nil {
-				style.PrintWarning("could not checkout %s: %v (worktree stays on feature branch)", defaultBranch, err)
-			} else if err := g.Pull("origin", defaultBranch); err != nil {
-				style.PrintWarning("could not pull %s: %v (worktree on %s but may be stale)", defaultBranch, defaultBranch, err)
+			syncRef := "origin/" + defaultBranch
+			if err := g.Fetch("origin"); err != nil {
+				style.PrintWarning("could not fetch origin before idle sync: %v (using local refs)", err)
+			}
+			if err := g.CheckoutDetach(syncRef); err != nil {
+				if fallbackErr := g.CheckoutDetach(defaultBranch); fallbackErr != nil {
+					style.PrintWarning("could not detach checkout %s: %v; fallback %s also failed: %v (worktree stays on feature branch)", syncRef, err, defaultBranch, fallbackErr)
+				} else {
+					fmt.Printf("%s Worktree synced to %s (detached fallback)\n", style.Bold.Render("✓"), defaultBranch)
+				}
 			} else {
-				fmt.Printf("%s Worktree synced to %s\n", style.Bold.Render("✓"), defaultBranch)
+				fmt.Printf("%s Worktree synced to %s (detached)\n", style.Bold.Render("✓"), syncRef)
 			}
 
 			// Delete the old polecat branch (non-fatal: cleanup only).

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -85,6 +85,13 @@ func doneContaminationBaseRef(defaultBranch, explicitTarget string) string {
 	return "origin/" + targetBranch
 }
 
+func shouldSyncIdlePolecatWorktree(exitType, mergeStrategy string, pushFailed, mrFailed, syncSafe bool) bool {
+	if exitType != ExitCompleted || pushFailed || mrFailed || !syncSafe {
+		return false
+	}
+	return mergeStrategy != "local"
+}
+
 func init() {
 	doneCmd.Flags().StringVar(&doneIssue, "issue", "", "Source issue ID (default: parse from branch name)")
 	doneCmd.Flags().IntVarP(&donePriority, "priority", "p", -1, "Override priority (0-4, default: inherit from issue)")
@@ -1424,13 +1431,26 @@ notifyWitness:
 		// dirty on the feature branch so work can be recovered.
 		syncSafe := true
 		if cwdAvailable {
-			if ws, wsErr := g.CheckUncommittedWork(); wsErr == nil && ws.HasUncommittedChanges && !ws.CleanExcludingRuntime() {
+			if ws, wsErr := g.CheckUncommittedWork(); wsErr != nil {
+				syncSafe = false
+				style.PrintWarning("could not inspect worktree before idle sync: %v — skipping sync to preserve work", wsErr)
+			} else if ws.HasUncommittedChanges && !ws.CleanExcludingRuntime() {
 				syncSafe = false
 				style.PrintWarning("uncommitted changes still present — skipping worktree sync to preserve work")
 				fmt.Printf("  Files: %s\n", ws.String())
 			}
 		}
-		if cwdAvailable && !pushFailed && !mrFailed && syncSafe {
+		if exitType == ExitCompleted && issueID != "" && convoyInfo == nil {
+			convoyInfo = getConvoyInfoFromIssue(issueID, cwd)
+			if convoyInfo == nil {
+				convoyInfo = getConvoyInfoForIssue(issueID)
+			}
+		}
+		mergeStrategy := ""
+		if convoyInfo != nil {
+			mergeStrategy = convoyInfo.MergeStrategy
+		}
+		if cwdAvailable && shouldSyncIdlePolecatWorktree(exitType, mergeStrategy, pushFailed, mrFailed, syncSafe) {
 			// Remember the old branch so we can delete it after switching
 			oldBranch := branch
 

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -92,6 +92,13 @@ func shouldSyncIdlePolecatWorktree(exitType, mergeStrategy string, pushFailed, m
 	return mergeStrategy != "local"
 }
 
+func cleanupStatusAfterSuccessfulPush(status string) string {
+	if status == "unpushed" {
+		return "clean"
+	}
+	return status
+}
+
 func init() {
 	doneCmd.Flags().StringVar(&doneIssue, "issue", "", "Source issue ID (default: parse from branch name)")
 	doneCmd.Flags().IntVarP(&donePriority, "priority", "p", -1, "Override priority (0-4, default: inherit from issue)")
@@ -752,6 +759,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				goto notifyWitness
 			}
 			fmt.Printf("%s Branch pushed directly to %s\n", style.Bold.Render("✓"), defaultBranch)
+			doneCleanupStatus = cleanupStatusAfterSuccessfulPush(doneCleanupStatus)
 
 			// Close the base issue — no MR/refinery will close it
 			if issueID != "" {
@@ -876,9 +884,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 
 		// Fix cleanup_status after successful push (gt-wcr).
 		// Status was detected before push, so "unpushed" is now stale.
-		if doneCleanupStatus == "unpushed" {
-			doneCleanupStatus = "clean"
-		}
+		doneCleanupStatus = cleanupStatusAfterSuccessfulPush(doneCleanupStatus)
 
 		// Write push checkpoint for resume (gt-aufru)
 		if agentBeadID != "" {
@@ -1063,6 +1069,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 					goto notifyWitness
 				}
 				fmt.Printf("%s Branch pushed directly to %s\n", style.Bold.Render("✓"), defaultBranch)
+				doneCleanupStatus = cleanupStatusAfterSuccessfulPush(doneCleanupStatus)
 
 				// Close the issue directly — refinery won't process it.
 				if issueID != "" {

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -512,6 +512,7 @@ func TestCleanupStatusAfterSuccessfulPush(t *testing.T) {
 		want   string
 	}{
 		{"unpushed", "clean"},
+		{"has_unpushed", "clean"},
 		{"clean", "clean"},
 		{"uncommitted", "uncommitted"},
 		{"stash", "stash"},

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -506,6 +506,27 @@ func TestShouldSyncIdlePolecatWorktree(t *testing.T) {
 	}
 }
 
+func TestCleanupStatusAfterSuccessfulPush(t *testing.T) {
+	tests := []struct {
+		status string
+		want   string
+	}{
+		{"unpushed", "clean"},
+		{"clean", "clean"},
+		{"uncommitted", "uncommitted"},
+		{"stash", "stash"},
+		{"unknown", "unknown"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.status, func(t *testing.T) {
+			if got := cleanupStatusAfterSuccessfulPush(tt.status); got != tt.want {
+				t.Errorf("cleanupStatusAfterSuccessfulPush(%q) = %q, want %q", tt.status, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestClearDoneIntentLabel verifies that clearDoneIntentLabel removes
 // only done-intent labels while preserving other labels.
 func TestClearDoneIntentLabel(t *testing.T) {

--- a/internal/cmd/done_test.go
+++ b/internal/cmd/done_test.go
@@ -474,6 +474,38 @@ func TestShouldNudgeRefinery(t *testing.T) {
 	}
 }
 
+func TestShouldSyncIdlePolecatWorktree(t *testing.T) {
+	tests := []struct {
+		name          string
+		exitType      string
+		mergeStrategy string
+		pushFailed    bool
+		mrFailed      bool
+		syncSafe      bool
+		want          bool
+	}{
+		{"completed default strategy syncs", ExitCompleted, "", false, false, true, true},
+		{"completed direct strategy syncs", ExitCompleted, "direct", false, false, true, true},
+		{"completed mr strategy syncs", ExitCompleted, "mr", false, false, true, true},
+		{"local strategy keeps branch", ExitCompleted, "local", false, false, true, false},
+		{"deferred keeps branch", ExitDeferred, "", false, false, true, false},
+		{"escalated keeps branch", ExitEscalated, "", false, false, true, false},
+		{"push failure keeps branch", ExitCompleted, "", true, false, true, false},
+		{"mr failure keeps branch", ExitCompleted, "", false, true, true, false},
+		{"unsafe sync keeps branch", ExitCompleted, "", false, false, false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := shouldSyncIdlePolecatWorktree(tt.exitType, tt.mergeStrategy, tt.pushFailed, tt.mrFailed, tt.syncSafe)
+			if got != tt.want {
+				t.Errorf("shouldSyncIdlePolecatWorktree(%q, %q, %v, %v, %v) = %v, want %v",
+					tt.exitType, tt.mergeStrategy, tt.pushFailed, tt.mrFailed, tt.syncSafe, got, tt.want)
+			}
+		})
+	}
+}
+
 // TestClearDoneIntentLabel verifies that clearDoneIntentLabel removes
 // only done-intent labels while preserving other labels.
 func TestClearDoneIntentLabel(t *testing.T) {

--- a/internal/cmd/polecat_spawn.go
+++ b/internal/cmd/polecat_spawn.go
@@ -235,7 +235,10 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 	// Per-rig directory cap: prevent unbounded worktree accumulation, but only
 	// after trying safe reuse. A reusable preserved polecat should not be blocked
 	// just because the rig is already at the directory cap.
-	const maxPolecatDirsPerRig = 30
+	maxPolecatDirsPerRig := r.GetIntConfig("max_polecats")
+	if maxPolecatDirsPerRig < 30 {
+		maxPolecatDirsPerRig = 30
+	}
 	rigPolecatDir := filepath.Join(townRoot, rigName, "polecats")
 	if entries, err := os.ReadDir(rigPolecatDir); err == nil {
 		dirCount := 0

--- a/internal/cmd/polecat_spawn.go
+++ b/internal/cmd/polecat_spawn.go
@@ -23,6 +23,8 @@ import (
 	"github.com/steveyegge/gastown/internal/workspace"
 )
 
+const minPolecatDirsPerRig = 30
+
 // SpawnedPolecatInfo contains info about a spawned polecat session.
 type SpawnedPolecatInfo struct {
 	RigName     string // Rig name (e.g., "gastown")
@@ -59,6 +61,13 @@ type SlingSpawnOptions struct {
 	BaseBranch    string // Override base branch for polecat worktree (e.g., "develop", "release/v2")
 	ResumeBranch  string // Resume an existing branch (e.g. PR head) instead of creating polecat/<name>/<bead>@<ts>
 	SkipAdmission bool   // Caller already holds a polecat admission reservation
+}
+
+func effectivePolecatDirCap(configured int) int {
+	if configured < minPolecatDirsPerRig {
+		return minPolecatDirsPerRig
+	}
+	return configured
 }
 
 // SpawnPolecatForSling creates a fresh polecat and optionally starts its session.
@@ -235,10 +244,7 @@ func SpawnPolecatForSling(rigName string, opts SlingSpawnOptions) (*SpawnedPolec
 	// Per-rig directory cap: prevent unbounded worktree accumulation, but only
 	// after trying safe reuse. A reusable preserved polecat should not be blocked
 	// just because the rig is already at the directory cap.
-	maxPolecatDirsPerRig := r.GetIntConfig("max_polecats")
-	if maxPolecatDirsPerRig < 30 {
-		maxPolecatDirsPerRig = 30
-	}
+	maxPolecatDirsPerRig := effectivePolecatDirCap(r.GetIntConfig("max_polecats"))
 	rigPolecatDir := filepath.Join(townRoot, rigName, "polecats")
 	if entries, err := os.ReadDir(rigPolecatDir); err == nil {
 		dirCount := 0

--- a/internal/cmd/polecat_spawn_test.go
+++ b/internal/cmd/polecat_spawn_test.go
@@ -1,0 +1,26 @@
+package cmd
+
+import "testing"
+
+func TestEffectivePolecatDirCap(t *testing.T) {
+	tests := []struct {
+		name       string
+		configured int
+		want       int
+	}{
+		{"negative uses floor", -1, minPolecatDirsPerRig},
+		{"zero uses floor", 0, minPolecatDirsPerRig},
+		{"default below floor uses floor", 10, minPolecatDirsPerRig},
+		{"one below floor uses floor", minPolecatDirsPerRig - 1, minPolecatDirsPerRig},
+		{"floor remains floor", minPolecatDirsPerRig, minPolecatDirsPerRig},
+		{"above floor is honored", 45, 45},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := effectivePolecatDirCap(tt.configured); got != tt.want {
+				t.Errorf("effectivePolecatDirCap(%d) = %d, want %d", tt.configured, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -878,6 +878,14 @@ func (g *Git) Checkout(ref string) error {
 	return err
 }
 
+// CheckoutDetach checks out the given ref without attaching to a local branch.
+// This is useful in shared-worktree repos where the branch may already be
+// checked out by another worktree, but this worktree only needs that commit.
+func (g *Git) CheckoutDetach(ref string) error {
+	_, err := g.run("checkout", "--detach", ref)
+	return err
+}
+
 // CheckoutNewBranch creates a new branch from startPoint and checks it out.
 // Equivalent to: git checkout -b <branch> <startPoint>
 func (g *Git) CheckoutNewBranch(branch, startPoint string) error {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -510,6 +510,46 @@ func TestCheckout(t *testing.T) {
 	}
 }
 
+func TestCheckoutDetachAllowsBranchCheckedOutInAnotherWorktree(t *testing.T) {
+	dir := initTestRepo(t)
+	g := NewGit(dir)
+
+	mainBranch, err := g.CurrentBranch()
+	if err != nil {
+		t.Fatalf("CurrentBranch: %v", err)
+	}
+	mainSHA, err := g.Rev(mainBranch)
+	if err != nil {
+		t.Fatalf("Rev %s: %v", mainBranch, err)
+	}
+
+	worktreePath := filepath.Join(t.TempDir(), "worker")
+	runGit(t, dir, "worktree", "add", "-b", "polecat/test-detach", worktreePath, "HEAD")
+	workerGit := NewGit(worktreePath)
+
+	if err := workerGit.Checkout(mainBranch); err == nil {
+		t.Fatalf("Checkout(%s) succeeded, expected branch-in-use failure", mainBranch)
+	}
+	if err := workerGit.CheckoutDetach(mainBranch); err != nil {
+		t.Fatalf("CheckoutDetach(%s): %v", mainBranch, err)
+	}
+
+	branch, err := workerGit.CurrentBranch()
+	if err != nil {
+		t.Fatalf("CurrentBranch after detach: %v", err)
+	}
+	if branch != "HEAD" {
+		t.Fatalf("branch after detach = %q, want HEAD", branch)
+	}
+	headSHA, err := workerGit.Rev("HEAD")
+	if err != nil {
+		t.Fatalf("Rev HEAD after detach: %v", err)
+	}
+	if headSHA != mainSHA {
+		t.Fatalf("detached HEAD = %q, want %q", headSHA, mainSHA)
+	}
+}
+
 func TestCheckoutNewBranch(t *testing.T) {
 	dir := initTestRepo(t)
 	g := NewGit(dir)

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -527,6 +527,16 @@ func TestCheckoutDetachAllowsBranchCheckedOutInAnotherWorktree(t *testing.T) {
 	runGit(t, dir, "worktree", "add", "-b", "polecat/test-detach", worktreePath, "HEAD")
 	workerGit := NewGit(worktreePath)
 
+	if err := os.WriteFile(filepath.Join(dir, "after-worker.txt"), []byte("new main commit\n"), 0644); err != nil {
+		t.Fatalf("write after-worker file: %v", err)
+	}
+	runGit(t, dir, "add", "after-worker.txt")
+	runGit(t, dir, "commit", "-m", "advance main")
+	mainSHA, err = g.Rev(mainBranch)
+	if err != nil {
+		t.Fatalf("Rev advanced %s: %v", mainBranch, err)
+	}
+
 	if err := workerGit.Checkout(mainBranch); err == nil {
 		t.Fatalf("Checkout(%s) succeeded, expected branch-in-use failure", mainBranch)
 	}

--- a/internal/polecat/namepool.go
+++ b/internal/polecat/namepool.go
@@ -8,6 +8,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"sort"
+	"strconv"
 	"strings"
 	"sync"
 
@@ -362,6 +363,10 @@ func (p *NamePool) Reconcile(existingPolecats []string) {
 	for _, name := range existingPolecats {
 		if p.isThemedName(name) {
 			p.InUse[name] = true
+			continue
+		}
+		if seq, err := strconv.Atoi(name); err == nil && seq >= p.OverflowNext {
+			p.OverflowNext = seq + 1
 		}
 	}
 }

--- a/internal/polecat/namepool_test.go
+++ b/internal/polecat/namepool_test.go
@@ -166,9 +166,9 @@ func TestNamePool_SaveLoad(t *testing.T) {
 	pool := NewNamePoolWithConfig(tmpDir, "testrig", "mad-max", nil, 3)
 
 	// Exhaust the pool to trigger overflow, which increments OverflowNext
-	pool.Allocate() // furiosa
-	pool.Allocate() // nux
-	pool.Allocate() // slit
+	pool.Allocate()                    // furiosa
+	pool.Allocate()                    // nux
+	pool.Allocate()                    // slit
 	overflowName, _ := pool.Allocate() // 4 (overflow - just number, not rig-prefixed)
 
 	if overflowName != "4" {
@@ -194,9 +194,9 @@ func TestNamePool_SaveLoad(t *testing.T) {
 
 	// OverflowNext SHOULD persist - it's the one piece of state that can't be derived.
 	// Next overflow should be 5, not 4 (OverflowNext persisted).
-	pool2.Allocate() // furiosa (InUse empty, so starts from beginning)
-	pool2.Allocate() // nux
-	pool2.Allocate() // slit
+	pool2.Allocate()                     // furiosa (InUse empty, so starts from beginning)
+	pool2.Allocate()                     // nux
+	pool2.Allocate()                     // slit
 	overflowName2, _ := pool2.Allocate() // Should be 5
 
 	if overflowName2 != "5" {
@@ -226,6 +226,26 @@ func TestNamePool_Reconcile(t *testing.T) {
 	name, _ := pool.Allocate()
 	if name != "furiosa" {
 		t.Errorf("expected furiosa, got %s", name)
+	}
+}
+
+func TestNamePool_ReconcileAdvancesOverflowPastNumericPolecats(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "namepool-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() { _ = os.RemoveAll(tmpDir) }()
+
+	pool := NewNamePoolWithConfig(tmpDir, "testrig", "mad-max", nil, 3)
+
+	pool.Reconcile([]string{"furiosa", "nux", "slit", "62", "65"})
+
+	name, err := pool.Allocate()
+	if err != nil {
+		t.Fatalf("Allocate error: %v", err)
+	}
+	if name != "66" {
+		t.Fatalf("expected next overflow name 66, got %s", name)
 	}
 }
 
@@ -818,9 +838,9 @@ func TestValidatePoolName(t *testing.T) {
 		{"furiosa", false},
 		{"beta-name", false},
 		{"alpha123", false},
-		{"abc", true},  // too short
-		{"ab", true},   // too short
-		{"", true},     // empty
+		{"abc", true},   // too short
+		{"ab", true},    // too short
+		{"", true},      // empty
 		{"UPPER", true}, // uppercase
 		{"has space", true},
 		{"witness", true},  // reserved


### PR DESCRIPTION
## Summary
- make the polecat directory cap honor rig max_polecats, with a 30-slot floor
- change gt done idle sync to detach to origin/<default> instead of checking out the shared default branch
- advance overflow numeric polecat allocation past existing numeric directories so failed partial slots are not reused
- add regression coverage for detached checkout and numeric overflow reconciliation

## Verification
- go test ./internal/cmd -run 'TestRigConfig|Test.*Polecat'
- go test ./internal/git -run 'TestCheckoutDetachAllowsBranchCheckedOutInAnotherWorktree|TestCheckout'
- go test ./internal/cmd -run 'TestDoneContaminationBaseRef|Test.*Done'
- go test ./internal/polecat -run 'TestNamePool_(Reconcile|ReconcileAdvancesOverflowPastNumericPolecats|Overflow|OverflowNotReusable|SaveLoad)'
- go test ./internal/cmd -run 'TestDoneContaminationBaseRef|Test.*Polecat|TestRigConfig'
- go build -o /tmp/gt-allocator-fix ./cmd/gt