### PR TITLE
fix: update wisp_dependencies queries to use split target columns

### DIFF
--- a/internal/cmd/compact.go
+++ b/internal/cmd/compact.go
@@ -277,13 +277,17 @@ func runCompact(cmd *cobra.Command, args []string) error {
 }
 
 // cleanOrphanedWispDeps removes wisp_dependencies rows where either side no
-// longer exists in the wisps table. This happens when bd delete removes a wisp
-// but leaves behind its dependency records (bd delete has no cascade logic for
-// the wisp-level tables). Runs as a post-compact sweep.
+// longer exists. This happens when bd delete removes a wisp or issue but
+// leaves behind its dependency records. Runs as a post-compact sweep.
+//
+// wisp_dependencies uses three nullable target columns (depends_on_wisp_id,
+// depends_on_issue_id, depends_on_external) rather than the old single
+// depends_on_id column (removed in beads migration 0043).
 func cleanOrphanedWispDeps(bd *beads.Beads, result *compactResult) {
 	const q = `DELETE FROM wisp_dependencies WHERE ` +
 		`NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.issue_id) ` +
-		`OR NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_id)`
+		`OR (depends_on_wisp_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_wisp_id)) ` +
+		`OR (depends_on_issue_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM issues WHERE id = wisp_dependencies.depends_on_issue_id))`
 	out, err := bd.Run("sql", q)
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("orphaned wisp_deps cleanup: %v", err))

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -203,7 +203,8 @@ func parentExcludeJoin(dbName string) (joinClause, whereCondition string) {
 	joinClause = `LEFT JOIN (
 		SELECT DISTINCT wd.issue_id
 		FROM wisp_dependencies wd
-		LEFT JOIN wisps pw ON pw.id = wd.depends_on_id LEFT JOIN issues pi ON pi.id = wd.depends_on_id
+		LEFT JOIN wisps pw ON pw.id = wd.depends_on_wisp_id
+		LEFT JOIN issues pi ON pi.id = wd.depends_on_issue_id
 		WHERE wd.type = 'parent-child'
 		AND (pw.status IN ('open', 'hooked', 'in_progress') OR pi.status IN ('open', 'in_progress'))
 	) open_parent ON open_parent.issue_id = w.id`
@@ -302,8 +303,9 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 	// Anomaly detection: dangling parent references.
 	danglingQuery := `
 		SELECT COUNT(*) FROM wisp_dependencies wd
-		LEFT JOIN wisps pw ON pw.id = wd.depends_on_id LEFT JOIN issues pi ON pi.id = wd.depends_on_id
-		WHERE wd.type = 'parent-child' AND pw.id IS NULL AND pi.id IS NULL`
+		LEFT JOIN wisps pw ON pw.id = wd.depends_on_wisp_id
+		LEFT JOIN issues pi ON pi.id = wd.depends_on_issue_id
+		WHERE wd.type = 'parent-child' AND pw.id IS NULL AND pi.id IS NULL AND wd.depends_on_external IS NULL`
 	var danglingCount int
 	if err := db.QueryRowContext(ctx, danglingQuery).Scan(&danglingCount); err == nil && danglingCount > 0 {
 		result.Anomalies = append(result.Anomalies, Anomaly{
@@ -747,7 +749,9 @@ func batchDeleteRows(ctx context.Context, db *sql.DB, idQuery string, cutoffArg 
 		}
 
 		// Clean up reverse dependency references to prevent dangling parent refs.
-		delReverse := fmt.Sprintf("DELETE FROM wisp_dependencies WHERE depends_on_id IN %s", inClause)
+		// Target wisps are referenced via depends_on_wisp_id (beads migration 0043
+		// removed the old depends_on_id generated column).
+		delReverse := fmt.Sprintf("DELETE FROM wisp_dependencies WHERE depends_on_wisp_id IN %s", inClause)
 		if _, err := db.ExecContext(ctx, delReverse, args...); err != nil {
 			// Non-fatal.
 		}


### PR DESCRIPTION
## Summary

`wisp_dependencies` uses three nullable target columns (`depends_on_wisp_id`, `depends_on_issue_id`, `depends_on_external`) in place of the old `depends_on_id` generated column removed by beads migration 0043. Three query sites in gastown still referenced `depends_on_id`, causing runtime errors:

```
Error 1105 (HY000): table "wisp_dependencies" does not have column "depends_on_id"
```

This surfaces as a silent failure in `gt compact` (compaction report shows the error) and as a hard failure in the reaper scan across any database using the updated beads schema.

**Files changed:**
- `internal/cmd/compact.go` — `cleanOrphanedWispDeps`: orphan check now tests each target column against the correct table (`depends_on_wisp_id` → wisps, `depends_on_issue_id` → issues), with NULL guards. Also adds `depends_on_issue_id` cleanup that the old query missed entirely.
- `internal/reaper/reaper.go` — three sites:
  - `parentExcludeJoin`: parent-child open-status check now joins wisps on `depends_on_wisp_id` and issues on `depends_on_issue_id`
  - `danglingQuery`: dangling parent anomaly detection joins on split columns; external deps excluded from NULL check
  - `delReverse`: reverse-dep cleanup on wisp deletion now targets `depends_on_wisp_id`

Note: queries against the `dependencies` table (not `wisp_dependencies`) are unchanged — that table retains the original `depends_on_id` column at the current beads schema version.

## Test plan

- [ ] `gt compact` no longer emits `orphaned wisp_deps cleanup` error in the compaction report
- [ ] Reaper scan succeeds for databases with the updated beads schema
- [ ] Existing reaper tests pass (`go test ./internal/reaper/...`)
- [ ] Compact tests pass (`go test ./internal/cmd/... -run Compact`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)