### PR TITLE
fix: show patrol scan progress diagnostics

### DIFF
--- a/internal/cmd/patrol_scan.go
+++ b/internal/cmd/patrol_scan.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -41,6 +42,8 @@ Actions taken automatically:
   - Completion routing: MR cleanup wisps created, refinery nudged
 
 Use --notify to send mail when zombies with active work are detected.
+Long-running scan phases emit progress diagnostics to stderr so JSON stdout
+remains machine-readable while operators can see where a slow patrol is stuck.
 
 Examples:
   gt patrol scan                    # Scan current rig
@@ -58,6 +61,8 @@ func init() {
 
 	patrolCmd.AddCommand(patrolScanCmd)
 }
+
+var patrolScanProgressInterval = 10 * time.Second
 
 // PatrolScanOutput is the JSON output format for patrol scan results.
 type PatrolScanOutput struct {
@@ -106,9 +111,9 @@ type PatrolScanStallItem struct {
 
 // PatrolScanCompleteOutput holds completion discovery results.
 type PatrolScanCompleteOutput struct {
-	Checked   int                       `json:"checked"`
-	Found     int                       `json:"found"`
-	Completed []PatrolScanCompleteItem  `json:"completed,omitempty"`
+	Checked   int                      `json:"checked"`
+	Found     int                      `json:"found"`
+	Completed []PatrolScanCompleteItem `json:"completed,omitempty"`
 }
 
 // PatrolScanCompleteItem is a single completion discovery in scan output.
@@ -152,9 +157,16 @@ func runPatrolScan(cmd *cobra.Command, args []string) error {
 	// Note: DetectZombiePolecats takes a router param but does NOT send mail
 	// internally — it only uses the router for workspace context. Notifications
 	// are sent exclusively below via --notify, avoiding double-send.
-	zombieResult := witness.DetectZombiePolecats(bd, workDir, rigName, router)
-	stallResult := witness.DetectStalledPolecats(workDir, rigName)
-	completionResult := witness.DiscoverCompletions(bd, workDir, rigName, router)
+	diagnostics := cmd.ErrOrStderr()
+	zombieResult := runPatrolScanPhase(diagnostics, "zombie detection", func() *witness.DetectZombiePolecatsResult {
+		return witness.DetectZombiePolecats(bd, workDir, rigName, router)
+	})
+	stallResult := runPatrolScanPhase(diagnostics, "stall detection", func() *witness.DetectStalledPolecatsResult {
+		return witness.DetectStalledPolecats(workDir, rigName)
+	})
+	completionResult := runPatrolScanPhase(diagnostics, "completion discovery", func() *witness.DiscoverCompletionsResult {
+		return witness.DiscoverCompletions(bd, workDir, rigName, router)
+	})
 
 	// Build patrol receipts for zombies
 	receipts := witness.BuildPatrolReceipts(rigName, zombieResult)
@@ -175,6 +187,50 @@ func runPatrolScan(cmd *cobra.Command, args []string) error {
 	}
 
 	return outputPatrolScanHuman(rigName, zombieResult, stallResult, completionResult, receipts)
+}
+
+func runPatrolScanPhase[T any](diagnostics io.Writer, name string, fn func() T) T {
+	start := time.Now()
+	if diagnostics != nil {
+		fmt.Fprintf(diagnostics, "gt patrol scan: starting %s\n", name)
+	}
+
+	done := make(chan T, 1)
+	go func() {
+		done <- fn()
+	}()
+
+	if patrolScanProgressInterval <= 0 {
+		result := <-done
+		if diagnostics != nil {
+			fmt.Fprintf(diagnostics, "gt patrol scan: finished %s in %s\n", name, formatPatrolScanElapsed(time.Since(start)))
+		}
+		return result
+	}
+
+	ticker := time.NewTicker(patrolScanProgressInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case result := <-done:
+			if diagnostics != nil {
+				fmt.Fprintf(diagnostics, "gt patrol scan: finished %s in %s\n", name, formatPatrolScanElapsed(time.Since(start)))
+			}
+			return result
+		case <-ticker.C:
+			if diagnostics != nil {
+				fmt.Fprintf(diagnostics, "gt patrol scan: still running %s after %s\n", name, formatPatrolScanElapsed(time.Since(start)))
+			}
+		}
+	}
+}
+
+func formatPatrolScanElapsed(elapsed time.Duration) string {
+	if elapsed < time.Second {
+		return elapsed.Round(time.Millisecond).String()
+	}
+	return elapsed.Round(time.Second).String()
 }
 
 func countActiveWorkZombies(result *witness.DetectZombiePolecatsResult) int {

--- a/internal/cmd/patrol_scan_test.go
+++ b/internal/cmd/patrol_scan_test.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/gastown/internal/witness"
 )
@@ -100,6 +103,61 @@ func TestCountActiveWorkZombies_Empty(t *testing.T) {
 	got := countActiveWorkZombies(result)
 	if got != 0 {
 		t.Errorf("countActiveWorkZombies() = %d, want 0", got)
+	}
+}
+
+func TestRunPatrolScanPhaseEmitsProgressDiagnostics(t *testing.T) {
+	oldInterval := patrolScanProgressInterval
+	patrolScanProgressInterval = 10 * time.Millisecond
+	defer func() { patrolScanProgressInterval = oldInterval }()
+
+	var diagnostics bytes.Buffer
+	got := runPatrolScanPhase(&diagnostics, "slow phase", func() string {
+		time.Sleep(25 * time.Millisecond)
+		return "ok"
+	})
+
+	if got != "ok" {
+		t.Fatalf("runPatrolScanPhase result = %q, want ok", got)
+	}
+
+	output := diagnostics.String()
+	for _, want := range []string{
+		"gt patrol scan: starting slow phase",
+		"gt patrol scan: still running slow phase after",
+		"gt patrol scan: finished slow phase in",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("diagnostics %q missing %q", output, want)
+		}
+	}
+}
+
+func TestRunPatrolScanPhaseZeroIntervalSkipsProgressTicks(t *testing.T) {
+	oldInterval := patrolScanProgressInterval
+	patrolScanProgressInterval = 0
+	defer func() { patrolScanProgressInterval = oldInterval }()
+
+	var diagnostics bytes.Buffer
+	got := runPatrolScanPhase(&diagnostics, "fast phase", func() int {
+		return 42
+	})
+
+	if got != 42 {
+		t.Fatalf("runPatrolScanPhase result = %d, want 42", got)
+	}
+
+	output := diagnostics.String()
+	if strings.Contains(output, "still running") {
+		t.Fatalf("diagnostics should not include progress tick when interval is disabled: %q", output)
+	}
+	for _, want := range []string{
+		"gt patrol scan: starting fast phase",
+		"gt patrol scan: finished fast phase in",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("diagnostics %q missing %q", output, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- emit phase start/finish diagnostics for gt patrol scan on stderr
- report still-running phase diagnostics every 10s so external timeouts are no longer silent
- keep JSON output on stdout machine-readable

## Verification
- /nix/store/rv5np8wj0hmp0nqkbjyr02sk24c77bjk-go-1.25.8/share/go/bin/go test ./internal/cmd -run 'TestRunPatrolScanPhase|TestPatrolScan' -count=1

## Reproduction
Before this change, bounded runs of `timeout 20s gt patrol scan --json --notify` and `timeout 20s gt polecat list ptn_from_scratch` produced no output before exit 124 while Dolt remained healthy. A live scan was observed waiting in the patrol scan process while child cleanup/check commands ran.