### PR TITLE
fix(prime): don't require .git worktree integrity for no-clone roles (witness/dog/boot)

### DIFF
--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -253,7 +253,11 @@ func ensureRoleWorktreeIntegrity(cwd, townRoot string, role Role) error {
 
 func roleRequiresWorktreeIntegrity(role Role) bool {
 	switch role {
-	case RolePolecat, RoleCrew, RoleWitness, RoleRefinery, RoleDog, RoleBoot:
+	// Only roles backed by a real git worktree (a clone) require .git integrity.
+	// No-clone roles (witness, dog, boot) have no .git of their own — requiring one
+	// makes gt prime abort in those dirs ("worktree integrity violation"), since the
+	// search reaches a town root that may not be a git tree (gt-noclone-integrity).
+	case RolePolecat, RoleCrew, RoleRefinery:
 		return true
 	default:
 		return false

--- a/internal/worktree/integrity.go
+++ b/internal/worktree/integrity.go
@@ -19,8 +19,9 @@ type IntegrityOptions struct {
 	TownRoot string
 
 	// Require reports a missing .git marker as an integrity violation. This is
-	// appropriate for agent worktree roles such as polecats, crew, refinery, and
-	// witness.
+	// appropriate only for cloned agent worktree roles (polecats, crew, refinery).
+	// No-clone roles (witness, dog, boot) legitimately have no .git and must not
+	// set Require, or gt prime aborts in those directories.
 	Require bool
 }
 


### PR DESCRIPTION
## Summary
`gt prime --hook` aborts with `worktree integrity violation: missing .git metadata` in **witness, dog, and boot** directories, blocking witness patrol, deacon boot, and dogs town-wide.

## Root cause
`roleRequiresWorktreeIntegrity` (internal/cmd/prime.go) returns `true` for `RoleWitness`, `RoleDog`, and `RoleBoot`. But these are **no-clone roles** — `gt rig --help` documents `witness/` as "(no clone)", and the boot/dog home dirs have no `.git` of their own. The integrity check then walks up to the town root for a `.git` marker; when the town is not a git tree (e.g. provisioned via `gt init` rather than `gt install --git`), the check fails and `gt prime` aborts. `gt doctor --fix` does not resolve it (the remediation is circular).

## Fix
Require worktree integrity only for genuinely cloned roles (`polecat`, `crew`, `refinery`). No-clone roles (`witness`, `dog`, `boot`) fall through to `Require: false`. Comment in `internal/worktree/integrity.go` updated to match.

## Impact
Restores `gt prime --hook` for witness/boot/dog roles without requiring the town to be a git tree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
