### PR TITLE
fix: harden codex agent startup

### DIFF
--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -279,7 +279,7 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 	AgentCodex: {
 		Name:                AgentCodex,
 		Command:             "codex",
-		Args:                []string{"--dangerously-bypass-approvals-and-sandbox"},
+		Args:                []string{"-c", codexUpdateCheckConfig, "--dangerously-bypass-approvals-and-sandbox"},
 		ProcessNames:        []string{"codex"}, // Codex CLI binary
 		SessionIDEnv:        "",                // Codex captures from JSONL output
 		ResumeFlag:          "resume",
@@ -291,7 +291,7 @@ var builtinPresets = map[AgentPreset]*AgentPresetInfo{
 			OutputFlag: "--json",
 		},
 		// Runtime defaults
-		PromptMode:        "none",
+		PromptMode:        "arg",
 		ReadyPromptPrefix: "› ",
 		ReadyDelayMs:      3000,
 		InstructionsFile:  "AGENTS.md",

--- a/internal/config/agents_test.go
+++ b/internal/config/agents_test.go
@@ -1368,6 +1368,16 @@ func TestCodexRuntimeConfigHasPromptDetection(t *testing.T) {
 	if rc.Tmux.ReadyPromptPrefix != "› " {
 		t.Errorf("RuntimeConfigFromPreset(codex).Tmux.ReadyPromptPrefix = %q, want %q", rc.Tmux.ReadyPromptPrefix, "› ")
 	}
+	if rc.PromptMode != "arg" {
+		t.Errorf("RuntimeConfigFromPreset(codex).PromptMode = %q, want arg", rc.PromptMode)
+	}
+	args := strings.Join(rc.Args, " ")
+	if !strings.Contains(args, codexUpdateCheckConfig) {
+		t.Errorf("RuntimeConfigFromPreset(codex).Args = %v, want %q", rc.Args, codexUpdateCheckConfig)
+	}
+	if !strings.Contains(args, "--dangerously-bypass-approvals-and-sandbox") {
+		t.Errorf("RuntimeConfigFromPreset(codex).Args = %v, want bypass flag", rc.Args)
+	}
 }
 
 func TestPiProviderDefaults(t *testing.T) {

--- a/internal/config/loader.go
+++ b/internal/config/loader.go
@@ -1957,6 +1957,7 @@ func fillRuntimeDefaults(rc *RuntimeConfig) *RuntimeConfig {
 	if result.Args == nil && preset != nil {
 		result.Args = append([]string(nil), preset.Args...)
 	}
+	result.Args = ensureCodexAutomationArgs(result.Command, result.Args)
 
 	// Auto-fill Hooks defaults from preset for agents that support hooks.
 	if result.Hooks == nil && preset != nil && preset.HooksProvider != "" {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -3733,6 +3733,25 @@ func TestFillRuntimeDefaultsCodexDoesNotOverrideExplicitUpdateCheck(t *testing.T
 	}
 }
 
+func TestFillRuntimeDefaultsCodexIgnoresUnrelatedUpdateCheckSubstring(t *testing.T) {
+	rc := fillRuntimeDefaults(&RuntimeConfig{
+		Provider: "codex",
+		Command:  "codex",
+		Args:     []string{"--profile=check_for_update_on_startup-note"},
+	})
+
+	found := false
+	for _, arg := range rc.Args {
+		if arg == codexUpdateCheckConfig {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("codex update suppression should be injected despite unrelated substring: %v", rc.Args)
+	}
+}
+
 // TestBuildArgsWithPromptWarnsOnDroppedPrompt verifies the parallel warning in
 // BuildArgsWithPrompt when PromptMode is "none" and a non-empty prompt is provided.
 func TestBuildArgsWithPromptWarnsOnDroppedPrompt(t *testing.T) {

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -3682,6 +3682,57 @@ func TestBuildCommandWithPromptNoWarnOnEmptyPrompt(t *testing.T) {
 	}
 }
 
+func TestCodexBuildCommandWithPromptIncludesBootstrapPrompt(t *testing.T) {
+	rc := RuntimeConfigFromPreset(AgentCodex)
+
+	var cmd string
+	stderr := captureStderr(t, func() {
+		cmd = rc.BuildCommandWithPrompt("bootstrap now")
+	})
+
+	if stderr != "" {
+		t.Errorf("no warning expected for codex prompt delivery, got: %q", stderr)
+	}
+	if !strings.Contains(cmd, "bootstrap now") {
+		t.Errorf("codex startup command should include bootstrap prompt, got: %s", cmd)
+	}
+	if !strings.Contains(cmd, codexUpdateCheckConfig) {
+		t.Errorf("codex startup command should suppress update checks, got: %s", cmd)
+	}
+}
+
+func TestFillRuntimeDefaultsCodexCustomArgsSuppressesUpdateCheck(t *testing.T) {
+	rc := fillRuntimeDefaults(&RuntimeConfig{
+		Provider: "codex",
+		Command:  "codex",
+		Args:     []string{"--profile", "fast"},
+	})
+
+	args := strings.Join(rc.Args, " ")
+	if !strings.Contains(args, codexUpdateCheckConfig) {
+		t.Fatalf("codex custom args missing update suppression: %v", rc.Args)
+	}
+	if strings.Count(args, "check_for_update_on_startup") != 1 {
+		t.Fatalf("codex update suppression duplicated: %v", rc.Args)
+	}
+}
+
+func TestFillRuntimeDefaultsCodexDoesNotOverrideExplicitUpdateCheck(t *testing.T) {
+	rc := fillRuntimeDefaults(&RuntimeConfig{
+		Provider: "codex",
+		Command:  "codex",
+		Args:     []string{"-c", "check_for_update_on_startup=true"},
+	})
+
+	args := strings.Join(rc.Args, " ")
+	if strings.Count(args, "check_for_update_on_startup") != 1 {
+		t.Fatalf("explicit codex update config should not be duplicated: %v", rc.Args)
+	}
+	if !strings.Contains(args, "check_for_update_on_startup=true") {
+		t.Fatalf("explicit codex update config should be preserved: %v", rc.Args)
+	}
+}
+
 // TestBuildArgsWithPromptWarnsOnDroppedPrompt verifies the parallel warning in
 // BuildArgsWithPrompt when PromptMode is "none" and a non-empty prompt is provided.
 func TestBuildArgsWithPromptWarnsOnDroppedPrompt(t *testing.T) {

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -1040,7 +1040,8 @@ func normalizeRuntimeConfig(rc *RuntimeConfig) *RuntimeConfig {
 	return rc
 }
 
-const codexUpdateCheckConfig = "check_for_update_on_startup=false"
+const codexUpdateCheckKey = "check_for_update_on_startup"
+const codexUpdateCheckConfig = codexUpdateCheckKey + "=false"
 
 func ensureCodexAutomationArgs(command string, args []string) []string {
 	if !isCodexRuntime(command) || hasCodexUpdateCheckConfig(args) {
@@ -1058,7 +1059,7 @@ func isCodexRuntime(command string) bool {
 
 func hasCodexUpdateCheckConfig(args []string) bool {
 	for _, arg := range args {
-		if strings.Contains(arg, "check_for_update_on_startup") {
+		if arg == codexUpdateCheckKey || strings.HasPrefix(arg, codexUpdateCheckKey+"=") {
 			return true
 		}
 	}

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -752,7 +752,7 @@ type RuntimeConfig struct {
 
 	// PromptMode controls how prompts are passed to the runtime.
 	// Supported values: "arg" (append prompt arg), "none" (ignore prompt).
-	// Default: "arg" for claude/generic, "none" for codex.
+	// Default: "arg" for built-in interactive runtimes.
 	PromptMode string `json:"prompt_mode,omitempty"`
 
 	// Session config controls environment integration for runtime session IDs.
@@ -972,6 +972,7 @@ func normalizeRuntimeConfig(rc *RuntimeConfig) *RuntimeConfig {
 	if rc.Args == nil {
 		rc.Args = defaultRuntimeArgs(rc.Provider)
 	}
+	rc.Args = ensureCodexAutomationArgs(rc.Command, rc.Args)
 
 	if rc.PromptMode == "" {
 		rc.PromptMode = defaultPromptMode(rc.Provider)
@@ -1037,6 +1038,31 @@ func normalizeRuntimeConfig(rc *RuntimeConfig) *RuntimeConfig {
 	}
 
 	return rc
+}
+
+const codexUpdateCheckConfig = "check_for_update_on_startup=false"
+
+func ensureCodexAutomationArgs(command string, args []string) []string {
+	if !isCodexRuntime(command) || hasCodexUpdateCheckConfig(args) {
+		return args
+	}
+	result := make([]string, 0, len(args)+2)
+	result = append(result, "-c", codexUpdateCheckConfig)
+	result = append(result, args...)
+	return result
+}
+
+func isCodexRuntime(command string) bool {
+	return filepath.Base(command) == string(AgentCodex)
+}
+
+func hasCodexUpdateCheckConfig(args []string) bool {
+	for _, arg := range args {
+		if strings.Contains(arg, "check_for_update_on_startup") {
+			return true
+		}
+	}
+	return false
 }
 
 func defaultRuntimeCommand(provider string) string {

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -532,11 +532,19 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 
 	// Accept startup dialogs (workspace trust + bypass permissions) if they appear
 	debugSession("AcceptStartupDialogs", m.tmux.AcceptStartupDialogs(sessionID))
+	if err := m.tmux.CheckStartupBlocked(sessionID); err != nil {
+		_ = m.tmux.KillSessionWithProcesses(sessionID)
+		return fmt.Errorf("startup blocked: %w", err)
+	}
 
 	// Wait for runtime to be fully ready at the prompt (not just started).
 	// Uses prompt-based polling for agents with ReadyPromptPrefix (e.g., Claude "❯ "),
 	// falling back to ReadyDelayMs sleep for agents without prompt detection.
 	debugSession("WaitForRuntimeReady", m.tmux.WaitForRuntimeReady(sessionID, runtimeConfig, constants.ClaudeStartTimeout))
+	if err := m.tmux.CheckStartupBlocked(sessionID); err != nil {
+		_ = m.tmux.KillSessionWithProcesses(sessionID)
+		return fmt.Errorf("startup blocked: %w", err)
+	}
 
 	// Handle fallback nudges for non-hook agents.
 	// See StartupFallbackInfo in runtime package for the fallback matrix.
@@ -593,6 +601,10 @@ func (m *SessionManager) Start(polecat string, opts SessionStartOptions) error {
 	}
 	if !running {
 		return fmt.Errorf("session %s died during startup (agent command may have failed)", sessionID)
+	}
+	if status := m.tmux.CheckSessionHealth(sessionID, 0); status != tmux.SessionHealthy {
+		_ = m.tmux.KillSessionWithProcesses(sessionID)
+		return fmt.Errorf("session %s unhealthy during startup: %s", sessionID, status)
 	}
 
 	// Validate GT_AGENT is set. Without GT_AGENT, IsAgentAlive falls back to

--- a/internal/session/lifecycle.go
+++ b/internal/session/lifecycle.go
@@ -160,6 +160,13 @@ func StartSession(t *tmux.Tmux, cfg SessionConfig) (_ *StartResult, retErr error
 
 	// 1. Resolve runtime config.
 	runtimeConfig := config.ResolveRoleAgentConfig(cfg.Role, cfg.TownRoot, cfg.RigPath)
+	if cfg.AgentOverride != "" {
+		rc, _, err := config.ResolveAgentConfigWithOverride(cfg.TownRoot, cfg.RigPath, cfg.AgentOverride)
+		if err != nil {
+			return nil, fmt.Errorf("resolving agent config for %s: %w", cfg.AgentOverride, err)
+		}
+		runtimeConfig = rc
+	}
 
 	// 2. Ensure settings/plugins exist for the agent.
 	settingsDir := config.RoleSettingsDir(cfg.Role, cfg.RigPath)
@@ -244,6 +251,10 @@ func StartSession(t *tmux.Tmux, cfg SessionConfig) (_ *StartResult, retErr error
 	// 10. Accept startup dialogs (workspace trust + bypass permissions).
 	if cfg.AcceptBypass {
 		_ = t.AcceptStartupDialogs(cfg.SessionID)
+		if err := t.CheckStartupBlocked(cfg.SessionID); err != nil {
+			_ = t.KillSessionWithProcesses(cfg.SessionID)
+			return nil, fmt.Errorf("startup blocked: %w", err)
+		}
 	}
 
 	// 11. Ready delay: wait for agent to be fully ready at the prompt.
@@ -265,6 +276,14 @@ func StartSession(t *tmux.Tmux, cfg SessionConfig) (_ *StartResult, retErr error
 		}
 		if !running {
 			return nil, fmt.Errorf("session %s died during startup (agent command may have failed)", cfg.SessionID)
+		}
+		if err := t.CheckStartupBlocked(cfg.SessionID); err != nil {
+			_ = t.KillSessionWithProcesses(cfg.SessionID)
+			return nil, fmt.Errorf("startup blocked: %w", err)
+		}
+		if status := t.CheckSessionHealth(cfg.SessionID, 0); status != tmux.SessionHealthy {
+			_ = t.KillSessionWithProcesses(cfg.SessionID)
+			return nil, fmt.Errorf("session %s unhealthy during startup: %s", cfg.SessionID, status)
 		}
 	}
 

--- a/internal/tmux/dialog_acceptance_test.go
+++ b/internal/tmux/dialog_acceptance_test.go
@@ -181,6 +181,7 @@ func TestContainsPromptIndicator(t *testing.T) {
 		want    bool
 	}{
 		{"claude prompt", "Hello! How can I help?\n>", true},
+		{"codex prompt", "Ready\n› ", true},
 		{"bash prompt", "user@host:~$", true},
 		{"zsh prompt", "╰─❯", true},
 		{"root prompt", "root@host:~#", true},
@@ -256,6 +257,39 @@ Skip until next version`,
 			name:        "ready prompt",
 			content:     "› ",
 			wantBlocked: false,
+		},
+		{
+			name: "stale bypass dialog before codex prompt",
+			content: `Bypass Permissions mode
+1. No
+2. Yes, I accept
+› `,
+			wantBlocked: false,
+		},
+		{
+			name: "stale bypass dialog before prompt and status",
+			content: `Bypass Permissions mode
+1. No
+2. Yes, I accept
+›
+session ready`,
+			wantBlocked: false,
+		},
+		{
+			name: "stale trust dialog before shell prompt",
+			content: `Quick safety check
+Do you trust this folder?
+user@host:~$`,
+			wantBlocked: false,
+		},
+		{
+			name: "old shell prompt before current bypass dialog",
+			content: `user@host:~$
+Bypass Permissions mode
+1. No
+2. Yes, I accept`,
+			wantBlocked: true,
+			wantName:    "bypass permissions prompt",
 		},
 	}
 

--- a/internal/tmux/dialog_acceptance_test.go
+++ b/internal/tmux/dialog_acceptance_test.go
@@ -223,6 +223,55 @@ func TestContainsWorkspaceTrustDialog(t *testing.T) {
 	}
 }
 
+func TestContainsBlockingStartupDialog(t *testing.T) {
+	t.Parallel()
+	tests := []struct {
+		name        string
+		content     string
+		wantBlocked bool
+		wantName    string
+	}{
+		{
+			name: "codex update modal",
+			content: `Update available! 0.137.0 -> 0.138.0
+Update now
+Skip
+Skip until next version`,
+			wantBlocked: true,
+			wantName:    "codex update prompt",
+		},
+		{
+			name:        "codex trust modal",
+			content:     "> You are in /tmp/demo\nDo you trust the contents of this directory?",
+			wantBlocked: true,
+			wantName:    "workspace trust prompt",
+		},
+		{
+			name:        "bypass modal",
+			content:     "Bypass Permissions mode\n1. No\n2. Yes, I accept",
+			wantBlocked: true,
+			wantName:    "bypass permissions prompt",
+		},
+		{
+			name:        "ready prompt",
+			content:     "› ",
+			wantBlocked: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotName, gotBlocked := containsBlockingStartupDialog(tt.content)
+			if gotBlocked != tt.wantBlocked {
+				t.Fatalf("blocked = %v, want %v", gotBlocked, tt.wantBlocked)
+			}
+			if gotName != tt.wantName {
+				t.Fatalf("name = %q, want %q", gotName, tt.wantName)
+			}
+		})
+	}
+}
+
 // TestDismissStartupDialogsBlind_SendsKeys verifies that the blind dismiss
 // sends keys without error on a valid session (no screen-scraping).
 func TestDismissStartupDialogsBlind_SendsKeys(t *testing.T) {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1866,14 +1866,23 @@ func (t *Tmux) AcceptStartupDialogs(session string) error {
 // still visible after dialog acceptance. These modals block automated sessions
 // from receiving or acting on the bootstrap prompt.
 func (t *Tmux) CheckStartupBlocked(session string) error {
-	content, err := t.CapturePane(session, 80)
-	if err != nil {
-		return err
+	deadline := time.Now().Add(constants.DialogPollTimeout)
+	var blocker string
+	for {
+		content, err := t.CapturePane(session, 80)
+		if err != nil {
+			return err
+		}
+		current, ok := containsBlockingStartupDialog(content)
+		if !ok {
+			return nil
+		}
+		blocker = current
+		if time.Now().After(deadline) {
+			return fmt.Errorf("interactive startup dialog still visible in %s: %s", session, blocker)
+		}
+		time.Sleep(constants.DialogPollInterval)
 	}
-	if blocker, ok := containsBlockingStartupDialog(content); ok {
-		return fmt.Errorf("interactive startup dialog still visible in %s: %s", session, blocker)
-	}
-	return nil
 }
 
 // AcceptWorkspaceTrustDialog dismisses workspace trust dialogs for supported
@@ -1927,6 +1936,9 @@ func containsWorkspaceTrustDialog(content string) bool {
 }
 
 func containsBlockingStartupDialog(content string) (string, bool) {
+	if promptAppearsAfterStartupBlocker(content) {
+		return "", false
+	}
 	if containsCodexUpdateDialog(content) {
 		return "codex update prompt", true
 	}
@@ -1939,6 +1951,37 @@ func containsBlockingStartupDialog(content string) (string, bool) {
 	return "", false
 }
 
+func promptAppearsAfterStartupBlocker(content string) bool {
+	promptLine := lastPromptIndicatorLine(content)
+	if promptLine < 0 {
+		return false
+	}
+	blockerLine := lastStartupBlockerLine(content)
+	return blockerLine >= 0 && promptLine > blockerLine
+}
+
+func lastStartupBlockerLine(content string) int {
+	markers := []string{
+		"Update available!",
+		"Update now",
+		"Skip until next version",
+		"trust this folder",
+		"Quick safety check",
+		"Do you trust the contents of this directory?",
+		"Bypass Permissions mode",
+	}
+	last := -1
+	for i, line := range strings.Split(content, "\n") {
+		for _, marker := range markers {
+			if strings.Contains(line, marker) {
+				last = i
+				break
+			}
+		}
+	}
+	return last
+}
+
 func containsCodexUpdateDialog(content string) bool {
 	return strings.Contains(content, "Update available!") &&
 		strings.Contains(content, "Update now") &&
@@ -1946,8 +1989,9 @@ func containsCodexUpdateDialog(content string) bool {
 }
 
 // promptSuffixes are strings that indicate a shell or agent prompt is visible.
-// Claude prompt ends with ">", shell prompts end with "$", "%", "#", or "❯".
-var promptSuffixes = []string{">", "$", "%", "#", "❯"}
+// Claude prompt ends with ">", Codex uses "›", and shells often end with
+// "$", "%", "#", or "❯".
+var promptSuffixes = []string{">", "›", "$", "%", "#", "❯"}
 
 // containsPromptIndicator checks if pane content contains a prompt indicator
 // that signals a shell or agent is ready (no dialog blocking it).
@@ -1964,6 +2008,23 @@ func containsPromptIndicator(content string) bool {
 		}
 	}
 	return false
+}
+
+func lastPromptIndicatorLine(content string) int {
+	last := -1
+	for i, line := range strings.Split(content, "\n") {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" {
+			continue
+		}
+		for _, suffix := range promptSuffixes {
+			if strings.HasSuffix(trimmed, suffix) {
+				last = i
+				break
+			}
+		}
+	}
+	return last
 }
 
 // AcceptBypassPermissionsWarning dismisses the Claude Code bypass permissions warning dialog.

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1862,6 +1862,20 @@ func (t *Tmux) AcceptStartupDialogs(session string) error {
 	return nil
 }
 
+// CheckStartupBlocked fails fast when a known interactive startup modal is
+// still visible after dialog acceptance. These modals block automated sessions
+// from receiving or acting on the bootstrap prompt.
+func (t *Tmux) CheckStartupBlocked(session string) error {
+	content, err := t.CapturePane(session, 80)
+	if err != nil {
+		return err
+	}
+	if blocker, ok := containsBlockingStartupDialog(content); ok {
+		return fmt.Errorf("interactive startup dialog still visible in %s: %s", session, blocker)
+	}
+	return nil
+}
+
 // AcceptWorkspaceTrustDialog dismisses workspace trust dialogs for supported
 // agents. Claude shows "Quick safety check"; Codex shows
 // "Do you trust the contents of this directory?". In both cases the safe
@@ -1910,6 +1924,25 @@ func containsWorkspaceTrustDialog(content string) bool {
 	return strings.Contains(content, "trust this folder") ||
 		strings.Contains(content, "Quick safety check") ||
 		strings.Contains(content, "Do you trust the contents of this directory?")
+}
+
+func containsBlockingStartupDialog(content string) (string, bool) {
+	if containsCodexUpdateDialog(content) {
+		return "codex update prompt", true
+	}
+	if containsWorkspaceTrustDialog(content) {
+		return "workspace trust prompt", true
+	}
+	if strings.Contains(content, "Bypass Permissions mode") {
+		return "bypass permissions prompt", true
+	}
+	return "", false
+}
+
+func containsCodexUpdateDialog(content string) bool {
+	return strings.Contains(content, "Update available!") &&
+		strings.Contains(content, "Update now") &&
+		strings.Contains(content, "Skip until next version")
 }
 
 // promptSuffixes are strings that indicate a shell or agent prompt is visible.


### PR DESCRIPTION
Fixes hq-xxef.\n\nChanges:\n- Pass bootstrap prompts to Codex via prompt arg instead of dropping them with prompt_mode none.\n- Suppress Codex startup update checks by default and for custom Codex runtime args.\n- Fail fast and kill sessions if known startup modals remain visible so sling does not leave session-dead zombies.\n\nValidation:\n- go test ./internal/config ./internal/session ./internal/dog ./cmd/gt\n- go test ./internal/tmux -run 'TestContainsBlockingStartupDialog|TestContainsWorkspaceTrustDialog|TestContainsPromptIndicator'\n- go test ./internal/polecat -run '^$'\n- go build ./cmd/gt