### PR TITLE
fix: retire polecats after gt done

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -37,8 +37,7 @@ This is a convenience command for polecats that:
 1. Submits the current branch to the merge queue
 2. Auto-detects issue ID from branch name
 3. Notifies the Witness with the exit outcome
-4. Syncs worktree to main and transitions polecat to IDLE
-   (sandbox preserved, session stays alive for reuse)
+4. Retires the assignment sandbox and exits the polecat session
 
 Exit statuses:
   COMPLETED      - Work done, MR submitted (default)
@@ -46,7 +45,7 @@ Exit statuses:
   DEFERRED       - Work paused, issue still open
 
 Examples:
-  gt done                              # Submit branch, notify COMPLETED, transition to IDLE
+  gt done                              # Submit branch, notify COMPLETED, retire sandbox
   gt done --pre-verified               # Submit with pre-verification fast-path
   gt done --target feat/my-branch      # Explicit MR target branch
   gt done --pre-verified --target feat/contract-review  # Pre-verified with explicit target
@@ -114,10 +113,6 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 	if exitType != ExitCompleted && exitType != ExitEscalated && exitType != ExitDeferred {
 		return fmt.Errorf("invalid exit status '%s': must be COMPLETED, ESCALATED, or DEFERRED", doneStatus)
 	}
-
-	// Persistent polecat model (gt-hdf8): sessions stay alive after gt done.
-	// No deferred session kill — the polecat transitions to IDLE with sandbox
-	// preserved. The Witness handles any cleanup if the polecat gets stuck.
 
 	// Find workspace with fallback for deleted worktrees (hq-3xaxy)
 	// If the polecat's worktree was deleted by Witness before gt done finishes,
@@ -230,7 +225,7 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 	if branch == "" {
 		if !cwdAvailable {
 			// We don't have GT_BRANCH and we're using mayor clone - can't determine branch.
-			// Session stays alive (persistent polecat model) — Witness handles recovery.
+			// Fail closed so Witness/deacon recovery can inspect the stranded polecat.
 			return fmt.Errorf("cannot determine branch: GT_BRANCH not set and working directory unavailable")
 		}
 		var err error
@@ -429,9 +424,6 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			WorkDir:  cwd,
 		}
 		agentBeadID = getAgentBeadID(ctx)
-
-		// Persistent polecat model (gt-hdf8): no deferred session kill.
-		// Sessions stay alive after gt done — polecat transitions to IDLE.
 	}
 
 	// If issue ID not set by flag or branch name, query for hooked beads
@@ -1392,7 +1384,7 @@ notifyWitness:
 	}
 
 	// Update agent bead state (ZFC: self-report completion)
-	updateAgentStateOnDone(cwd, townRoot, exitType, issueID)
+	updateAgentStateOnDone(cwd, townRoot, exitType, issueID, pushFailed, mrFailed)
 
 	// Nudge witness only after hook/cleanup state is updated. Otherwise witness can
 	// evaluate slot availability against stale hook_bead or cleanup_status and emit
@@ -1400,61 +1392,13 @@ notifyWitness:
 	nudgeWitness(rigName, fmt.Sprintf("POLECAT_DONE %s exit=%s", polecatName, exitType))
 	fmt.Printf("%s Witness notified of %s (via nudge)\n", style.Bold.Render("✓"), exitType)
 
-	// Persistent polecat model (gt-hdf8): polecats transition to IDLE after completion.
-	// Session stays alive, sandbox preserved, worktree synced to main for reuse.
-	// "done means idle" - not "done means dead".
 	isPolecat := false
 	if roleInfo, err := GetRoleWithContext(cwd, townRoot); err == nil && roleInfo.Role == RolePolecat {
 		isPolecat = true
-
-		fmt.Printf("%s Sandbox preserved for reuse (persistent polecat)\n", style.Bold.Render("✓"))
-
-		if pushFailed || mrFailed {
-			fmt.Printf("%s Work needs recovery (push or MR failed) — session preserved\n", style.Bold.Render("⚠"))
+		if err := retirePolecatAfterDone(townRoot, rigName, polecatName, branch, exitType, pushFailed, mrFailed); err != nil {
+			style.PrintWarning("polecat retirement deferred: %v", err)
+			fmt.Printf("  Witness/deacon recovery will handle %s/%s.\n", rigName, polecatName)
 		}
-
-		// Sync worktree to main so the polecat is ready for new assignments.
-		// Phase 3 of persistent-polecat-pool: DONE→IDLE syncs to main and deletes old branch.
-		// Non-fatal: if sync fails, the polecat is still IDLE and the Witness
-		// or next gt sling can handle the branch state.
-		//
-		// GUARD (gt-pvx): Refuse to sync if uncommitted changes remain.
-		// If the auto-commit safety net above failed (git add/commit error),
-		// switching branches would discard the work. Better to leave the worktree
-		// dirty on the feature branch so work can be recovered.
-		syncSafe := true
-		if cwdAvailable {
-			if ws, wsErr := g.CheckUncommittedWork(); wsErr == nil && ws.HasUncommittedChanges && !ws.CleanExcludingRuntime() {
-				syncSafe = false
-				style.PrintWarning("uncommitted changes still present — skipping worktree sync to preserve work")
-				fmt.Printf("  Files: %s\n", ws.String())
-			}
-		}
-		if cwdAvailable && !pushFailed && !mrFailed && syncSafe {
-			// Remember the old branch so we can delete it after switching
-			oldBranch := branch
-
-			fmt.Printf("%s Syncing worktree to %s...\n", style.Bold.Render("→"), defaultBranch)
-			if err := g.Checkout(defaultBranch); err != nil {
-				style.PrintWarning("could not checkout %s: %v (worktree stays on feature branch)", defaultBranch, err)
-			} else if err := g.Pull("origin", defaultBranch); err != nil {
-				style.PrintWarning("could not pull %s: %v (worktree on %s but may be stale)", defaultBranch, defaultBranch, err)
-			} else {
-				fmt.Printf("%s Worktree synced to %s\n", style.Bold.Render("✓"), defaultBranch)
-			}
-
-			// Delete the old polecat branch (non-fatal: cleanup only).
-			// This prevents stale branch accumulation from persistent polecats.
-			if oldBranch != "" && oldBranch != defaultBranch && oldBranch != "master" {
-				if err := g.DeleteBranch(oldBranch, true); err != nil {
-					style.PrintWarning("could not delete old branch %s: %v", oldBranch, err)
-				} else {
-					fmt.Printf("%s Deleted old branch %s\n", style.Bold.Render("✓"), oldBranch)
-				}
-			}
-		}
-
-		fmt.Printf("%s Polecat transitioned to IDLE — ready for new work\n", style.Bold.Render("✓"))
 	}
 
 	fmt.Println()
@@ -1463,25 +1407,63 @@ notifyWitness:
 		fmt.Printf("  Witness will handle cleanup.\n")
 	}
 
-	// Self-terminate AFTER all cleanup is complete (opt-in via config).
-	// When enabled, polecats kill their session after gt done finishes
-	// instead of transitioning to IDLE. This gives fresh context windows
-	// per task, reduces token waste, and eliminates stale state bugs.
+	// Self-terminate AFTER all cleanup is complete.
 	// Must be the LAST thing gt done does — everything above must complete first.
 	if isPolecat {
-		daemonCfg := config.LoadOperationalConfig(townRoot).GetDaemonConfig()
-		if daemonCfg.PolecatSelfTerminate != nil && *daemonCfg.PolecatSelfTerminate {
-			fmt.Printf("%s Self-terminating session (polecat_self_terminate=true)\n", style.Bold.Render("✓"))
-			sessionName := session.PolecatSessionName(session.PrefixFor(rigName), polecatName)
-			go func() {
-				time.Sleep(3 * time.Second)
-				t := tmux.NewTmux()
-				_ = t.KillSessionWithProcesses(sessionName)
-			}()
-		}
+		terminatePolecatSessionAfterDone(rigName, polecatName)
 	}
 
 	return nil
+}
+
+func retirePolecatAfterDone(townRoot, rigName, polecatName, branch, exitType string, pushFailed, mrFailed bool) error {
+	if polecatName == "" {
+		return fmt.Errorf("missing polecat name")
+	}
+	if exitType != ExitCompleted {
+		fmt.Printf("%s Polecat not retired for %s exit; sandbox preserved for recovery/resume\n", style.Dim.Render("○"), exitType)
+		return nil
+	}
+	if pushFailed || mrFailed {
+		fmt.Printf("%s Polecat not retired because submission failed; sandbox preserved for recovery\n", style.Bold.Render("⚠"))
+		return nil
+	}
+
+	cleanupStatus := parseCleanupStatus(doneCleanupStatus)
+	if !cleanupStatus.IsSafe() {
+		return fmt.Errorf("cleanup_status=%s is not safe to retire", cleanupStatus)
+	}
+
+	rigPath := filepath.Join(townRoot, rigName)
+	r := &rig.Rig{Name: rigName, Path: rigPath}
+	mgr := polecat.NewManager(r, git.NewGit(rigPath), tmux.NewTmux())
+
+	fmt.Printf("%s Retiring polecat sandbox %s/%s...\n", style.Bold.Render("→"), rigName, polecatName)
+	if err := mgr.RemoveWithOptions(polecatName, true, true, true); err != nil {
+		return fmt.Errorf("removing worktree: %w", err)
+	}
+	fmt.Printf("%s Polecat sandbox retired; identity reset to nuked\n", style.Bold.Render("✓"))
+
+	defaultBranch := r.DefaultBranch()
+	if branch != "" && branch != defaultBranch && branch != "main" && branch != "master" {
+		deletePolecatBranch(branch, getRepoGitForRig(rigPath), true)
+	}
+	return nil
+}
+
+func terminatePolecatSessionAfterDone(rigName, polecatName string) {
+	if polecatName == "" {
+		return
+	}
+	sessionName := session.PolecatSessionName(session.PrefixFor(rigName), polecatName)
+	t := tmux.NewTmux()
+	running, err := t.HasSession(sessionName)
+	if err != nil || !running {
+		return
+	}
+	fmt.Printf("%s Self-terminating session\n", style.Bold.Render("✓"))
+	time.Sleep(3 * time.Second)
+	_ = t.KillSessionWithProcesses(sessionName)
 }
 
 // pushSubmoduleChanges detects submodules modified between origin/defaultBranch
@@ -1743,7 +1725,7 @@ func clearDoneCheckpoints(bd *beads.Beads, agentBeadID string) {
 // BUG FIX (hq-3xaxy): This function must be resilient to working directory deletion.
 // If the polecat's worktree is deleted before gt done finishes, we use env vars as fallback.
 // All errors are warnings, not failures - gt done must complete even if bead ops fail.
-func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) {
+func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string, pushFailed, mrFailed bool) {
 	// Get role context - try multiple sources for resilience
 	roleInfo, err := GetRoleWithContext(cwd, townRoot)
 	if err != nil {
@@ -1897,14 +1879,11 @@ doneStateUpdate:
 	// Best-effort: failures are non-fatal since the work is already done.
 	purgeClosedEphemeralBeads(bd)
 
-	// Self-managed completion (gt-1qlg, polecat-self-managed-completion.md Phase 2):
-	// Polecat sets agent_state=idle directly, skipping the intermediate "done" state.
-	// The witness is no longer in the critical path for routine completions.
-	// Completion metadata (exit_type, MR ID, branch) remains on the agent bead
-	// for audit purposes and anomaly detection by witness patrol.
-	// Exception: ESCALATED exits use "stuck" — the polecat needs help.
-	doneState := "idle"
-	if exitType == ExitEscalated {
+	// Clean completions are transiently marked done until the retirement path resets
+	// the agent bead to nuked. Failed or paused completions stay non-idle so capacity
+	// accounting treats them as recovery-blocked rather than reusable.
+	doneState := "done"
+	if exitType == ExitEscalated || exitType == ExitDeferred || pushFailed || mrFailed {
 		doneState = "stuck"
 	}
 	// Use UpdateAgentState to sync both column and description (gt-ulom).

--- a/internal/cmd/done_closeDescendants_test.go
+++ b/internal/cmd/done_closeDescendants_test.go
@@ -116,7 +116,7 @@ exit 0
 	}
 
 	// Call updateAgentStateOnDone directly
-	updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitCompleted, "gt-base-123")
+	updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitCompleted, "gt-base-123", false, false)
 
 	// Verify close calls
 	closesBytes, err := os.ReadFile(closesLog)
@@ -289,7 +289,7 @@ exit 0
 	}
 
 	// Should not error even though molecule has no children
-	updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitCompleted, "gt-base-123")
+	updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitCompleted, "gt-base-123", false, false)
 
 	// Verify close calls
 	closesBytes, err := os.ReadFile(closesLog)
@@ -422,7 +422,7 @@ exit 0
 		t.Fatalf("chdir: %v", err)
 	}
 
-	updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitCompleted, "gt-base-123")
+	updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitCompleted, "gt-base-123", false, false)
 
 	// Verify close calls
 	closesBytes, err := os.ReadFile(closesLog)
@@ -574,7 +574,7 @@ exit 0
 		t.Fatalf("chdir: %v", err)
 	}
 
-	updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitCompleted, "gt-base-123")
+	updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitCompleted, "gt-base-123", false, false)
 
 	// Verify close calls
 	closesBytes, err := os.ReadFile(closesLog)
@@ -742,7 +742,7 @@ exit 0
 	}
 
 	// Should not error even though there's no attached molecule
-	updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitCompleted, "gt-base-123")
+	updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitCompleted, "gt-base-123", false, false)
 
 	// Verify close calls - should only close the hooked base bead (no molecule)
 	closesBytes, err := os.ReadFile(closesLog)
@@ -866,7 +866,7 @@ exit 0
 	}
 
 	// Should not error even though list fails - continues with closing molecule and base bead
-	updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitCompleted, "gt-base-123")
+	updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitCompleted, "gt-base-123", false, false)
 
 	// Verify close calls - should still close wisp and base even though list failed
 	closesBytes, err := os.ReadFile(closesLog)
@@ -982,7 +982,7 @@ exit 0
 	}
 
 	// Should not error - handles molecule close failure gracefully
-	updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitCompleted, "gt-base-123")
+	updateAgentStateOnDone(filepath.Join(townRoot, "gastown"), townRoot, ExitCompleted, "gt-base-123", false, false)
 
 	// Implementation behavior: when molecule close fails with a generic error
 	// (not beads.ErrNotFound), the function returns early WITHOUT closing the

--- a/internal/cmd/molecule_lifecycle_test.go
+++ b/internal/cmd/molecule_lifecycle_test.go
@@ -1021,9 +1021,9 @@ exit /b 0
 	}
 
 	// Call the unexported function directly (same package)
-	// updateAgentStateOnDone(cwd, townRoot, exitType, issueID)
+	// updateAgentStateOnDone(cwd, townRoot, exitType, issueID, false, false)
 	// Pass issueID directly — hq-l6mm5 removed agent bead hook slot lookup
-	updateAgentStateOnDone(rigPath, townRoot, ExitCompleted, "gt-abc123")
+	updateAgentStateOnDone(rigPath, townRoot, ExitCompleted, "gt-abc123", false, false)
 
 	// Read the close log to see what got closed
 	closesBytes, err := os.ReadFile(closesPath)

--- a/internal/cmd/polecat_capacity.go
+++ b/internal/cmd/polecat_capacity.go
@@ -11,7 +11,9 @@ import (
 	"github.com/gofrs/flock"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/polecat"
+	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/scheduler/capacity"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
@@ -33,7 +35,7 @@ type polecatCapacitySnapshot struct {
 }
 
 func (s polecatCapacitySnapshot) occupied() int {
-	return s.Working + s.RecoveryBlocked + s.Reservations
+	return s.Working + s.RecoveryBlocked + s.PendingMR + s.Reservations
 }
 
 type polecatAdmissionReservation struct {
@@ -183,12 +185,18 @@ func polecatCapacitySnapshotForTownNoCleanup(townRoot string) (polecatCapacitySn
 			continue
 		}
 
+		polecatMgr := polecat.NewManager(&rig.Rig{Name: rigName, Path: rigPath}, git.NewGit(rigPath), tmuxClient)
 		agents, err := beads.New(rigPath).ListAgentBeads()
 		if err != nil {
 			return snapshot, fmt.Errorf("listing agent beads for %s capacity: %w", rigName, err)
 		}
 		prefix := beads.GetPrefixForRig(townRoot, rigName)
 		for _, name := range polecatNames {
+			if p, err := polecatMgr.Get(name); err == nil {
+				disposition := polecatMgr.WorkstateDispositionForPolecat(name, p.State, p.Issue)
+				applyWorkstateDispositionToCapacitySnapshot(&snapshot, p.State, disposition)
+				continue
+			}
 			agentID := beads.PolecatBeadIDWithPrefix(prefix, rigName, name)
 			issue := agents[agentID]
 			fields := (*beads.AgentFields)(nil)
@@ -252,6 +260,10 @@ func applyAgentFieldsToCapacitySnapshot(snapshot *polecatCapacitySnapshot, rigNa
 		} else {
 			snapshot.RecoveryBlocked++
 		}
+		return
+	}
+	if state == "done" || state == "stuck" {
+		snapshot.RecoveryBlocked++
 		return
 	}
 	if fields.PushFailed || fields.MRFailed {

--- a/internal/cmd/polecat_capacity_test.go
+++ b/internal/cmd/polecat_capacity_test.go
@@ -306,6 +306,11 @@ func TestApplyAgentFieldsToCapacitySnapshotSeparatesPendingMR(t *testing.T) {
 			fields: &beads.AgentFields{AgentState: string(beads.AgentStateIdle), CleanupStatus: "clean"},
 			want:   polecatCapacitySnapshot{ReusableIdle: 1},
 		},
+		{
+			name:   "leftover done state blocks capacity",
+			fields: &beads.AgentFields{AgentState: "done", CleanupStatus: "clean"},
+			want:   polecatCapacitySnapshot{RecoveryBlocked: 1},
+		},
 	}
 
 	for _, tt := range tests {
@@ -316,6 +321,25 @@ func TestApplyAgentFieldsToCapacitySnapshotSeparatesPendingMR(t *testing.T) {
 				t.Fatalf("snapshot = %+v, want %+v", snapshot, tt.want)
 			}
 		})
+	}
+}
+
+func TestPolecatCapacityOccupiedCountsPendingMRButNotReusableIdle(t *testing.T) {
+	snapshot := polecatCapacitySnapshot{
+		Max:             4,
+		Working:         1,
+		RecoveryBlocked: 1,
+		ReusableIdle:    7,
+		PendingMR:       1,
+		Reservations:    1,
+	}
+	if got := snapshot.occupied(); got != 4 {
+		t.Fatalf("occupied() = %d, want 4", got)
+	}
+
+	snapshot.Free = snapshot.Max - snapshot.occupied()
+	if snapshot.Free != 0 {
+		t.Fatalf("Free = %d, want 0", snapshot.Free)
 	}
 }
 

--- a/internal/config/types.go
+++ b/internal/config/types.go
@@ -321,12 +321,9 @@ type DaemonThresholds struct {
 	// unlike dogs, they should not persist when idle.
 	PolecatIdleSessionTimeout string `json:"polecat_idle_session_timeout,omitempty"`
 
-	// PolecatSelfTerminate controls whether polecats kill their own session after
-	// gt done completes (default false). When true, polecats terminate 3 seconds
-	// after work submission instead of transitioning to IDLE. This gives fresh
-	// context windows per task, reduces token waste, and eliminates stale state
-	// issues at scale. Worktree reuse is preserved — ReuseIdlePolecat creates
-	// a fresh branch on the existing worktree.
+	// PolecatSelfTerminate is retained for compatibility with existing settings.
+	// Successful gt done now retires the local polecat sandbox and terminates the
+	// session unconditionally.
 	PolecatSelfTerminate *bool `json:"polecat_self_terminate,omitempty"`
 
 	// StaleWorkingTimeout is how long a dog in state=working with no activity

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -948,9 +948,9 @@ func (d *Daemon) heartbeat(state *State) {
 	// This validates tmux sessions are still alive for polecats with work-on-hook
 	d.checkPolecatSessionHealth()
 
-	// 12b. Reap idle polecat sessions to prevent API slot burn.
-	// Polecats transition to IDLE after gt done but sessions stay alive.
-	// Kill sessions that have been idle longer than the configured threshold.
+	// 12b. Reap legacy idle polecat sessions to prevent API slot burn.
+	// Successful gt done now self-terminates, but this remains a safety net for
+	// older sessions and interrupted lifecycle paths.
 	d.reapIdlePolecats()
 
 	// 13. Clean up orphaned claude subagent processes (memory leak prevention)
@@ -2821,10 +2821,9 @@ Restart deferred to stuck-agent-dog plugin for context-aware recovery.`,
 	}
 }
 
-// reapIdlePolecats kills polecat tmux sessions that have been idle too long.
-// The persistent polecat model (gt-4ac) keeps sessions alive after gt done for reuse,
-// but idle sessions consume API slots (Claude Code process stays alive at 0% CPU).
-// This reaper checks heartbeat state and kills sessions idle longer than the threshold.
+// reapIdlePolecats kills legacy polecat tmux sessions that have been idle too long.
+// Successful gt done now self-terminates, but idle sessions from older or interrupted
+// flows can still consume API slots.
 func (d *Daemon) reapIdlePolecats() {
 	opCfg := d.loadOperationalConfig().GetDaemonConfig()
 	idleTimeout := opCfg.PolecatIdleSessionTimeoutD()

--- a/internal/polecat/namepool.go
+++ b/internal/polecat/namepool.go
@@ -17,9 +17,9 @@ import (
 
 const (
 	// DefaultPoolSize is the number of name slots in the pool.
-	// Names are allocated when a polecat is first created. In the persistent
-	// polecat model (gt-4ac), polecats cycle IDLE → WORKING → DONE → IDLE,
-	// keeping their name, identity, and sandbox across assignments.
+	// Names are allocated when a polecat is first created. Clean completion now
+	// retires the local sandbox; legacy/preallocated idle sandboxes can still be
+	// reused when recovery policy proves they are safe.
 	DefaultPoolSize = 50
 
 	// DefaultTheme is the default theme for new rigs.
@@ -82,9 +82,8 @@ var BuiltinThemes = map[string][]string{
 }
 
 // NamePool manages a bounded pool of reusable polecat names.
-// Names are allocated once per polecat and persist across assignments in the
-// persistent polecat model (gt-4ac). A name slot is only freed when a polecat
-// is explicitly nuked.
+// Names are allocated once per polecat. A name slot is freed when the polecat
+// sandbox is removed or otherwise released back to the pool.
 //
 // Names are drawn from a themed pool (mad-max by default).
 // When the pool is exhausted, overflow names use N format (just numbers).

--- a/internal/polecat/types.go
+++ b/internal/polecat/types.go
@@ -5,8 +5,9 @@ import "time"
 
 // State represents the current lifecycle state of a polecat.
 //
-// Polecats are PERSISTENT: they survive work completion and can be reused.
-// The four operating states are:
+// Polecat sandboxes are normally retired after clean work completion. Idle is
+// reserved for legacy/preallocated clean sandboxes that can still be reused.
+// The operating states are:
 //
 //   - Working: Session active, doing assigned work (normal operation)
 //   - Idle: Work completed, session killed, sandbox preserved for reuse
@@ -14,13 +15,13 @@ import "time"
 //   - Stalled: Session stopped unexpectedly, was never nudged back to life
 //   - Zombie: Session called 'gt done' but cleanup failed - tried to die but couldn't
 //
-// The distinction matters: idle polecats completed their work successfully and
-// are ready for new assignments. Stalled polecats failed mid-work. Zombies
+// The distinction matters: idle polecats have no active work and are safe for
+// reassignment. Stalled polecats failed mid-work. Zombies
 // tried to exit but couldn't complete cleanup.
 //
-// Note: These are LIFECYCLE states. The polecat IDENTITY (CV chain, mailbox, work
-// history) and SANDBOX (worktree) persist across sessions. An idle polecat keeps
-// its worktree so it can be quickly reassigned without creating a new one.
+// Note: These are LIFECYCLE states. The polecat identity and sandbox are not a
+// completion contract; clean gt done retires the local sandbox instead of moving
+// it to idle.
 //
 // "Stalled", "zombie", and related conditions are detected at query time by
 // cross-checking tmux session liveness against beads state. The Witness also
@@ -32,10 +33,9 @@ const (
 	// This is the initial and primary state after sling.
 	StateWorking State = "working"
 
-	// StateIdle means the polecat completed its work and the session was killed,
-	// but the sandbox (worktree) is preserved for reuse. An idle polecat has no
-	// hook_bead and no active session. It can be reassigned via gt sling without
-	// creating a new worktree.
+	// StateIdle means the polecat has no hook_bead and no active session, and its
+	// sandbox is clean enough to reuse. Clean gt done should retire the sandbox
+	// instead of leaving a new idle polecat behind.
 	StateIdle State = "idle"
 
 	// StateDone means the polecat has completed its assigned work and called

--- a/internal/templates/commands/bodies/done.md
+++ b/internal/templates/commands/bodies/done.md
@@ -39,5 +39,6 @@ bd close <issue-id> --reason="no-changes: <brief explanation>"
 gt done
 ```
 
-This command pushes your branch, submits an MR to the merge queue, and transitions
-you to IDLE. The Refinery handles the actual merge. You are done after this.
+This command pushes your branch, submits an MR to the merge queue, and retires
+your local polecat sandbox. The Refinery handles the actual merge. You are done
+after this.


### PR DESCRIPTION
## Summary
- retire successful polecat sandboxes after gt done instead of syncing them back to idle
- mark clean completions as transient done and failed/deferred completions as stuck for recovery
- align scheduler capacity with canonical polecat workstate and count pending MR slots as occupied
- update lifecycle wording that still claimed gt done transitions to IDLE

## Tests
- PATH=/nix/store/zkkhcz8rd5q5y3gv27yq1ikdcrdhgir2-go-1.25.11/bin:/home/claude/.npm-global/bin:/home/claude/.npm-global/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/home/claude/.codex/tmp/arg0/codex-arg0BC9zvO:/home/claude/.local/bin:/home/claude/.npm-global/bin:/home/claude/.npm-global/bin:/home/claude/.npm-global/bin:/home/claude/.codex/tmp/arg0/codex-arg0Ddz3hy:/home/claude/.local/bin:/home/claude/.npm-global/bin:/home/claude/.npm-global/bin:/home/claude/bin:/home/claude/.local/bin:/home/claude/.npm-global/bin:/home/claude/.npm-global/bin:/home/claude/.cargo/bin:/run/wrappers/bin:/home/claude/.nix-profile/bin:/nix/profile/bin:/home/claude/.local/state/nix/profile/bin:/etc/profiles/per-user/claude/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin go test ./internal/cmd ./internal/polecat ./internal/config ./internal/daemon -run '^$'
- PATH=/nix/store/zkkhcz8rd5q5y3gv27yq1ikdcrdhgir2-go-1.25.11/bin:/home/claude/.npm-global/bin:/home/claude/.npm-global/lib/node_modules/@openai/codex/node_modules/@openai/codex-linux-x64/vendor/x86_64-unknown-linux-musl/codex-path:/home/claude/.codex/tmp/arg0/codex-arg0BC9zvO:/home/claude/.local/bin:/home/claude/.npm-global/bin:/home/claude/.npm-global/bin:/home/claude/.npm-global/bin:/home/claude/.codex/tmp/arg0/codex-arg0Ddz3hy:/home/claude/.local/bin:/home/claude/.npm-global/bin:/home/claude/.npm-global/bin:/home/claude/bin:/home/claude/.local/bin:/home/claude/.npm-global/bin:/home/claude/.npm-global/bin:/home/claude/.cargo/bin:/run/wrappers/bin:/home/claude/.nix-profile/bin:/nix/profile/bin:/home/claude/.local/state/nix/profile/bin:/etc/profiles/per-user/claude/bin:/nix/var/nix/profiles/default/bin:/run/current-system/sw/bin go test ./internal/cmd -run 'TestApplyAgentFieldsToCapacitySnapshotSeparatesPendingMR|TestPolecatCapacityOccupiedCountsPendingMRButNotReusableIdle|TestWorkstateDispositionProjectionAgreement|TestDoneCloseDescendants|TestDoneClosesAttachedMolecule'

## Notes
- Full touched-package test run was attempted; internal/daemon passed, but existing unrelated failures remain in internal/cmd and internal/polecat (agent session sorting, convoy bd args, install config YAML, manager BEADS_DIR expectation).