### PR TITLE
fix(reaper): auto-close step-wisps of completed molecules

### DIFF
--- a/internal/cmd/reaper.go
+++ b/internal/cmd/reaper.go
@@ -240,15 +240,20 @@ Returns the count of reaped wisps. Use --dry-run to preview.`,
 		if reaperJSON {
 			fmt.Println(reaper.FormatJSON(results))
 		} else {
-			var totalReaped, totalOpen int
+			var totalReaped, totalMolSteps, totalOpen int
 			for _, r := range results {
 				prefix := ""
 				if r.DryRun {
 					prefix = "[DRY RUN] would "
 				}
-				fmt.Printf("%s: %sreaped %d wisps, %d open remain\n",
-					r.Database, prefix, r.Reaped, r.OpenRemain)
+				molSuffix := ""
+				if r.MoleculeStepsClosed > 0 {
+					molSuffix = fmt.Sprintf(" (+%d closed-molecule steps)", r.MoleculeStepsClosed)
+				}
+				fmt.Printf("%s: %sreaped %d wisps%s, %d open remain\n",
+					r.Database, prefix, r.Reaped, molSuffix, r.OpenRemain)
 				totalReaped += r.Reaped
+				totalMolSteps += r.MoleculeStepsClosed
 				totalOpen += r.OpenRemain
 			}
 			if len(results) > 1 {
@@ -256,8 +261,12 @@ Returns the count of reaped wisps. Use --dry-run to preview.`,
 				if reaperDryRun {
 					prefix = "[DRY RUN] "
 				}
-				fmt.Printf("\n%sReap summary (%d databases): reaped %d wisps, %d open remain\n",
-					prefix, len(results), totalReaped, totalOpen)
+				molSuffix := ""
+				if totalMolSteps > 0 {
+					molSuffix = fmt.Sprintf(" (+%d closed-molecule steps)", totalMolSteps)
+				}
+				fmt.Printf("\n%sReap summary (%d databases): reaped %d wisps%s, %d open remain\n",
+					prefix, len(results), totalReaped, molSuffix, totalOpen)
 				if totalOpen > reaper.DefaultAlertThreshold {
 					fmt.Fprintf(os.Stderr, "WARNING: %d open wisps exceed alert threshold (%d)\n",
 						totalOpen, reaper.DefaultAlertThreshold)
@@ -463,7 +472,7 @@ Normally the daemon dispatches a Dog to execute the mol-dog-reaper formula.`,
 			return fmt.Errorf("invalid --stale-age: %w", err)
 		}
 
-		var totalReaped, totalPurged, totalMailPurged, totalClosed, totalOpen int
+		var totalReaped, totalMolSteps, totalPurged, totalMailPurged, totalClosed, totalOpen int
 
 		for i, dbName := range databases {
 			if err := waitBeforeReaperDatabase(i); err != nil {
@@ -507,6 +516,7 @@ Normally the daemon dispatches a Dog to execute the mol-dog-reaper formula.`,
 				fmt.Printf("%s: reap error: %v\n", dbName, err)
 			} else {
 				totalReaped += reapResult.Reaped
+				totalMolSteps += reapResult.MoleculeStepsClosed
 				totalOpen += reapResult.OpenRemain
 			}
 
@@ -541,7 +551,7 @@ Normally the daemon dispatches a Dog to execute the mol-dog-reaper formula.`,
 		}
 		fmt.Printf("\n%sReaper cycle complete:\n", prefix)
 		fmt.Printf("  Databases: %d\n", len(databases))
-		fmt.Printf("  Reaped:    %d\n", totalReaped)
+		fmt.Printf("  Reaped:    %d (+%d closed-molecule steps)\n", totalReaped, totalMolSteps)
 		fmt.Printf("  Purged:    %d wisps, %d mail\n", totalPurged, totalMailPurged)
 		fmt.Printf("  Closed:    %d stale issues\n", totalClosed)
 		fmt.Printf("  Open:      %d wisps remain\n", totalOpen)

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -110,11 +110,14 @@ type ScanResult struct {
 
 // ReapResult holds the results of a reap operation.
 type ReapResult struct {
-	Database   string    `json:"database"`
-	Reaped     int       `json:"reaped"`
-	OpenRemain int       `json:"open_remain"`
-	DryRun     bool      `json:"dry_run,omitempty"`
-	Anomalies  []Anomaly `json:"anomalies,omitempty"`
+	Database string `json:"database"`
+	Reaped   int    `json:"reaped"`
+	// MoleculeStepsClosed counts open step-wisps closed because their parent
+	// molecule was already closed (hq-9qtwx), independent of the max_age reap.
+	MoleculeStepsClosed int       `json:"molecule_steps_closed,omitempty"`
+	OpenRemain          int       `json:"open_remain"`
+	DryRun              bool      `json:"dry_run,omitempty"`
+	Anomalies           []Anomaly `json:"anomalies,omitempty"`
 }
 
 // PurgeResult holds the results of a purge operation.
@@ -316,6 +319,80 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 	return result, nil
 }
 
+// closedMoleculeStepWhere is the shared WHERE/JOIN body that selects open
+// step-wisps whose parent molecule is already closed.
+//
+// Dog/patrol molecules (issue_type='molecule', e.g. mol-dog-reaper,
+// mol-dog-backup) spawn step-wisps linked via wisp_dependencies
+// (type='parent-child', depends_on_wisp_id = molecule id). When the molecule
+// completes (status='closed') its steps are definitively done, but they were
+// being left open — accumulating thousands of open wisps that the max_age reap
+// only cleared after 24h, so generation outpaced cleanup (hq-9qtwx). These are
+// closed immediately: a closed molecule's steps are moot. Scoped to
+// pm.issue_type='molecule' so it never touches non-molecule parent-child links
+// (e.g. an epic's subtasks). Agent beads are excluded as elsewhere.
+const closedMoleculeStepWhere = `wisps w
+	INNER JOIN wisp_dependencies wd ON wd.issue_id = w.id AND wd.type = 'parent-child'
+	INNER JOIN wisps pm ON pm.id = wd.depends_on_wisp_id
+	WHERE w.status IN ('open', 'hooked', 'in_progress')
+	  AND w.issue_type != 'agent'
+	  AND pm.issue_type = 'molecule'
+	  AND pm.status = 'closed'`
+
+// countClosedMoleculeSteps counts open step-wisps whose parent molecule is closed.
+func countClosedMoleculeSteps(ctx context.Context, db *sql.DB) (int, error) {
+	var n int
+	err := db.QueryRowContext(ctx, "SELECT COUNT(*) FROM "+closedMoleculeStepWhere).Scan(&n)
+	return n, err
+}
+
+// reapClosedMoleculeSteps closes, in batches, open step-wisps whose parent
+// molecule is already closed (see closedMoleculeStepWhere). It assumes the caller
+// has disabled autocommit and does NOT issue COMMIT/DOLT_COMMIT — the caller
+// flushes both as part of its reap commit so all closes land in one Dolt commit.
+func reapClosedMoleculeSteps(ctx context.Context, db *sql.DB) (int, error) {
+	idQuery := fmt.Sprintf("SELECT w.id FROM %s LIMIT %d", closedMoleculeStepWhere, DefaultBatchSize)
+
+	total := 0
+	for {
+		rows, err := db.QueryContext(ctx, idQuery)
+		if err != nil {
+			return total, fmt.Errorf("select molecule-step batch: %w", err)
+		}
+		var ids []string
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				rows.Close()
+				return total, fmt.Errorf("scan molecule-step id: %w", err)
+			}
+			ids = append(ids, id)
+		}
+		rows.Close()
+
+		if len(ids) == 0 {
+			break
+		}
+
+		placeholders := make([]string, len(ids))
+		args := make([]interface{}, len(ids))
+		for i, id := range ids {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		updateQuery := fmt.Sprintf(
+			"UPDATE wisps SET status='closed', closed_at=NOW(), close_reason='reaper: parent molecule closed' WHERE id IN (%s)",
+			strings.Join(placeholders, ","))
+		sqlResult, err := db.ExecContext(ctx, updateQuery, args...)
+		if err != nil {
+			return total, fmt.Errorf("close molecule-step batch: %w", err)
+		}
+		affected, _ := sqlResult.RowsAffected()
+		total += int(affected)
+	}
+	return total, nil
+}
+
 // Reap closes stale wisps in a database whose parent molecule is already closed.
 // UPDATEs are batched to avoid holding a write lock for extended periods on large tables.
 func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapResult, error) {
@@ -337,6 +414,11 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 		if err := db.QueryRowContext(ctx, countQuery, cutoff).Scan(&result.Reaped); err != nil {
 			return nil, fmt.Errorf("dry-run count: %w", err)
 		}
+		molSteps, err := countClosedMoleculeSteps(ctx, db)
+		if err != nil {
+			return nil, fmt.Errorf("dry-run molecule-step count: %w", err)
+		}
+		result.MoleculeStepsClosed = molSteps
 		openQuery := "SELECT COUNT(*) FROM wisps WHERE status IN ('open', 'hooked', 'in_progress')"
 		if err := db.QueryRowContext(ctx, openQuery).Scan(&result.OpenRemain); err != nil {
 			return nil, fmt.Errorf("count open: %w", err)
@@ -350,6 +432,14 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 	defer func() {
 		_, _ = db.ExecContext(context.Background(), "SET @@autocommit = 1")
 	}()
+
+	// Close orphaned step-wisps of already-closed molecules first (hq-9qtwx).
+	// This is independent of max_age: a closed molecule's steps are done.
+	molStepsClosed, err := reapClosedMoleculeSteps(ctx, db)
+	if err != nil {
+		return nil, err
+	}
+	result.MoleculeStepsClosed = molStepsClosed
 
 	// Batch UPDATE: select IDs in chunks, update each chunk.
 	// This avoids holding a write lock on the entire table for minutes.
@@ -402,7 +492,7 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 
 	result.Reaped = totalReaped
 
-	if totalReaped > 0 {
+	if totalReaped > 0 || molStepsClosed > 0 {
 		// Flush the SQL transaction to the Dolt working set before DOLT_COMMIT.
 		// With autocommit=0, UPDATE changes are in the SQL transaction buffer,
 		// not the Dolt working set. DOLT_COMMIT operates on the working set,
@@ -410,7 +500,7 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 		if _, err := db.ExecContext(ctx, "COMMIT"); err != nil {
 			return result, fmt.Errorf("sql commit: %w", err)
 		}
-		commitMsg := fmt.Sprintf("reaper: close %d stale wisps in %s", totalReaped, dbName)
+		commitMsg := fmt.Sprintf("reaper: close %d stale + %d molecule-step wisps in %s", totalReaped, molStepsClosed, dbName)
 		if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
 			// "nothing to commit" is expected when the reaper reverts dirty working
 			// set changes back to match HEAD. The wisps were set to "open" in the

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -191,6 +191,46 @@ func TestIsNothingToCommit(t *testing.T) {
 	}
 }
 
+// TestClosedMoleculeStepQuery verifies the molecule-step auto-close query is
+// correctly scoped so it ONLY closes open step-wisps whose parent is a CLOSED
+// MOLECULE (hq-9qtwx) — never non-molecule parent-child links (e.g. an epic's
+// subtasks) and never agent beads. A regression here could mass-close legitimate
+// open wisps, so the scoping conditions are asserted explicitly.
+func TestClosedMoleculeStepQuery(t *testing.T) {
+	w := closedMoleculeStepWhere
+
+	// Must join steps to their parent via the v49 parent-child column.
+	if !strings.Contains(w, "type = 'parent-child'") {
+		t.Error("closedMoleculeStepWhere should filter parent-child dependencies")
+	}
+	if !strings.Contains(w, "wd.depends_on_wisp_id") {
+		t.Error("closedMoleculeStepWhere should join parent via depends_on_wisp_id (v49 schema)")
+	}
+	// Scope: parent must be a CLOSED molecule.
+	if !strings.Contains(w, "pm.issue_type = 'molecule'") {
+		t.Error("closedMoleculeStepWhere must scope to molecule parents only (safety)")
+	}
+	if !strings.Contains(w, "pm.status = 'closed'") {
+		t.Error("closedMoleculeStepWhere must require the parent molecule be closed")
+	}
+	// Only open steps; never agent beads.
+	if !strings.Contains(w, "w.status IN ('open', 'hooked', 'in_progress')") {
+		t.Error("closedMoleculeStepWhere should only select open step-wisps")
+	}
+	if !strings.Contains(w, "w.issue_type != 'agent'") {
+		t.Error("closedMoleculeStepWhere must exclude agent beads")
+	}
+
+	// The batch id-select query must be parameterless and LIMITed.
+	idQuery := fmt.Sprintf("SELECT w.id FROM %s LIMIT %d", closedMoleculeStepWhere, DefaultBatchSize)
+	if !strings.Contains(idQuery, fmt.Sprintf("LIMIT %d", DefaultBatchSize)) {
+		t.Errorf("molecule-step idQuery should be batched with LIMIT %d", DefaultBatchSize)
+	}
+	if strings.Contains(idQuery, "?") {
+		t.Error("molecule-step idQuery should have no bind params (IDs come from the JOIN)")
+	}
+}
+
 func contains(s, substr string) bool {
 	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsHelper(s, substr))
 }


### PR DESCRIPTION
## Summary

Dog/patrol molecules (`issue_type='molecule'`, e.g. `mol-dog-reaper`, `mol-dog-backup`) spawn step-wisps linked via `wisp_dependencies` (`type='parent-child'`, `depends_on_wisp_id` = molecule id). When the molecule completed (`status='closed'`), its step-wisps were **left open** — so the `hq` open-wisp count climbed unbounded (~2100+ orphaned steps observed). The existing `max_age` reap only cleared them after 24h, so generation outpaced cleanup, tripping the 800-open-wisp alert every cycle and driving escalation spam.

This is the last residual of the hq-y5myz reaper incident (separate from the v49 `depends_on_id` fix in #4211).

## Change

`Reap()` now closes open step-wisps whose parent is an already-closed **molecule** immediately (no `max_age` wait — a closed molecule's steps are definitively done), within the same batched `autocommit=0` → `COMMIT` → `DOLT_COMMIT` envelope as the stale reap (one Dolt commit).

- **Scoped to `pm.issue_type='molecule'`** so it never touches other parent-child links (e.g. an epic's subtasks)
- Agent beads excluded (consistent with the rest of the reaper)
- Reported via `ReapResult.MoleculeStepsClosed`, surfaced in `gt reaper reap`/`run` output

## Test plan

- [x] `go build`/`go vet`/`go test ./internal/reaper/` green (incl. new `TestClosedMoleculeStepQuery` asserting the safety scoping)
- [x] Verified against live `hq` (dry-run): would close **2131** orphaned molecule steps, leaving legitimate open wisps untouched
- [x] Confirmed only 16 open steps have an *open* parent (correctly left alone); 2122+ have a *closed* molecule parent

## Notes

Uses the v49 `depends_on_wisp_id` column (correct for the live schema). Independent of #4211; both touch `reaper.go` on non-overlapping lines.

🤖 Generated with [Claude Code](https://claude.com/claude-code)