### PR TITLE
fix: render formula templates correctly

### DIFF
--- a/internal/cmd/formula.go
+++ b/internal/cmd/formula.go
@@ -363,13 +363,8 @@ func dryRunFormula(f *formula.Formula, formulaName, targetRig string) error {
 		// Show output directory if configured
 		var outputDir string
 		if f.Output != nil && f.Output.Directory != "" {
-			dirCtx := map[string]interface{}{
-				"review_id":    reviewID,
-				"formula_name": formulaName,
-			}
-			for k, v := range setVars {
-				dirCtx[k] = v
-			}
+			dirCtx := formulaTemplateContext(formulaName, targetDescription, reviewID,
+				formulaRunPR, prTitle, changedFiles, formulaRunFiles, setVars)
 			outputDir = renderTemplateOrDefault(f.Output.Directory, dirCtx, ".reviews/"+reviewID)
 			fmt.Printf("\n  Output directory: %s\n", outputDir)
 		}
@@ -378,23 +373,13 @@ func dryRunFormula(f *formula.Formula, formulaName, targetRig string) error {
 		for _, leg := range f.Legs {
 			// Show rendered output path for each leg
 			if f.Output != nil && outputDir != "" {
-				legCtx := map[string]interface{}{
-					"formula_name":       formulaName,
-					"target_description": targetDescription,
-					"review_id":          reviewID,
-					"pr_number":          formulaRunPR,
-					"pr_title":           prTitle,
-					"leg": map[string]interface{}{
-						"id":          leg.ID,
-						"title":       leg.Title,
-						"focus":       leg.Focus,
-						"description": leg.Description,
-					},
-					"changed_files": changedFiles,
-					"files":         formulaRunFiles,
-				}
-				for k, v := range setVars {
-					legCtx[k] = v
+				legCtx := formulaTemplateContext(formulaName, targetDescription, reviewID,
+					formulaRunPR, prTitle, changedFiles, formulaRunFiles, setVars)
+				legCtx["leg"] = map[string]interface{}{
+					"id":          leg.ID,
+					"title":       leg.Title,
+					"focus":       leg.Focus,
+					"description": leg.Description,
 				}
 				legPattern := renderTemplateOrDefault(f.Output.LegPattern, legCtx, leg.ID+"-findings.md")
 				outputPath := filepath.Join(outputDir, legPattern)
@@ -527,14 +512,14 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 		prTitle, changedFiles = fetchPRInfo(formulaRunPR)
 	}
 
+	// Parse --set key=value pairs for template rendering.
+	setVars := parseSetVars(formulaRunSet)
+
 	// Create output directory if configured
 	var outputDir string
 	if f.Output != nil && f.Output.Directory != "" {
-		// Build minimal context for directory rendering
-		dirCtx := map[string]interface{}{
-			"review_id":    reviewID,
-			"formula_name": formulaName,
-		}
+		dirCtx := formulaTemplateContext(formulaName, targetDescription, reviewID,
+			formulaRunPR, prTitle, changedFiles, formulaRunFiles, setVars)
 		outputDir = renderTemplateOrDefault(f.Output.Directory, dirCtx, ".reviews/"+reviewID)
 
 		// Create the directory
@@ -546,9 +531,6 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 		}
 	}
 
-	// Parse --set key=value pairs for template rendering
-	setVars := parseSetVars(formulaRunSet)
-
 	// Step 2: Create leg beads and track them
 	legBeads := make(map[string]string) // leg.ID -> bead ID
 	for _, leg := range f.Legs {
@@ -559,25 +541,13 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 		if f.Prompts != nil {
 			if basePrompt, ok := f.Prompts["base"]; ok {
 				// Build template context for this leg
-				legCtx := map[string]interface{}{
-					"formula_name":       formulaName,
-					"target_description": targetDescription,
-					"review_id":          reviewID,
-					"pr_number":          formulaRunPR,
-					"pr_title":           prTitle,
-					"leg": map[string]interface{}{
-						"id":          leg.ID,
-						"title":       leg.Title,
-						"focus":       leg.Focus,
-						"description": leg.Description,
-					},
-					"changed_files": changedFiles,
-					"files":         formulaRunFiles,
-				}
-
-				// Inject --set key=value pairs into template context
-				for k, v := range setVars {
-					legCtx[k] = v
+				legCtx := formulaTemplateContext(formulaName, targetDescription, reviewID,
+					formulaRunPR, prTitle, changedFiles, formulaRunFiles, setVars)
+				legCtx["leg"] = map[string]interface{}{
+					"id":          leg.ID,
+					"title":       leg.Title,
+					"focus":       leg.Focus,
+					"description": leg.Description,
 				}
 
 				// Compute output path for this leg
@@ -585,10 +555,7 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 					legPattern := renderTemplateOrDefault(f.Output.LegPattern, legCtx, leg.ID+"-findings.md")
 					outputPath := filepath.Join(outputDir, legPattern)
 					legCtx["output_path"] = outputPath
-					legCtx["output"] = map[string]interface{}{
-						"directory": outputDir,
-						"synthesis": f.Output.Synthesis,
-					}
+					addOutputTemplateContext(legCtx, outputDir, f.Output.Synthesis)
 				}
 
 				// Render the base prompt with template context
@@ -641,6 +608,17 @@ func executeConvoyFormula(f *formula.Formula, formulaName, targetRig string) err
 		synDesc := f.Synthesis.Description
 		if synDesc == "" {
 			synDesc = "Synthesize findings from all legs into unified output"
+		}
+		synCtx := formulaTemplateContext(formulaName, targetDescription, reviewID,
+			formulaRunPR, prTitle, changedFiles, formulaRunFiles, setVars)
+		if f.Output != nil {
+			addOutputTemplateContext(synCtx, outputDir, f.Output.Synthesis)
+		}
+		if rendered, err := renderTemplate(synDesc, synCtx); err == nil {
+			synDesc = rendered
+		} else {
+			fmt.Printf("%s Failed to render synthesis template: %v\n",
+				style.Dim.Render("Warning:"), err)
 		}
 
 		synArgs := []string{
@@ -1014,6 +992,29 @@ func parseSetVars(setArgs []string) map[string]interface{} {
 		}
 	}
 	return vars
+}
+
+func formulaTemplateContext(formulaName, targetDescription, reviewID string, prNumber int, prTitle string, changedFiles []map[string]interface{}, files []string, setVars map[string]interface{}) map[string]interface{} {
+	ctx := map[string]interface{}{
+		"formula_name":       formulaName,
+		"target_description": targetDescription,
+		"review_id":          reviewID,
+		"pr_number":          prNumber,
+		"pr_title":           prTitle,
+		"changed_files":      changedFiles,
+		"files":              files,
+	}
+	for k, v := range setVars {
+		ctx[k] = v
+	}
+	return ctx
+}
+
+func addOutputTemplateContext(ctx map[string]interface{}, outputDir, synthesisFile string) {
+	ctx["output"] = map[string]interface{}{
+		"directory": outputDir,
+		"synthesis": synthesisFile,
+	}
 }
 
 var formulaVarPlaceholder = regexp.MustCompile(`\{\{\s*([a-zA-Z_][a-zA-Z0-9_]*)\s*\}\}`)

--- a/internal/cmd/formula_test.go
+++ b/internal/cmd/formula_test.go
@@ -319,3 +319,102 @@ func TestAttachmentFormulaVarsPrefersAttachedVars(t *testing.T) {
 		t.Fatalf("attachmentFormulaVars() = %#v, want %#v", got, want)
 	}
 }
+
+func TestApplyFormulaVarsUsesWorkflowBareSyntax(t *testing.T) {
+	t.Parallel()
+
+	got := applyFormulaVars("bd show {{issue}}\nkeep {{.issue}}", map[string]string{"issue": "gt-123"})
+	want := "bd show gt-123\nkeep {{.issue}}"
+	if got != want {
+		t.Fatalf("applyFormulaVars() = %q, want %q", got, want)
+	}
+}
+
+func TestRenderTemplateUsesGoDotSyntax(t *testing.T) {
+	t.Parallel()
+
+	ctx := map[string]interface{}{"issue": "gt-123"}
+	got, err := renderTemplate("bd show {{.issue}}", ctx)
+	if err != nil {
+		t.Fatalf("renderTemplate() dotted syntax error: %v", err)
+	}
+	if got != "bd show gt-123" {
+		t.Fatalf("renderTemplate() = %q, want %q", got, "bd show gt-123")
+	}
+
+	if _, err := renderTemplate("bd show {{issue}}", ctx); err == nil {
+		t.Fatal("renderTemplate() with bare syntax succeeded; want Go template error")
+	}
+}
+
+func TestDesignFormulaOutputUsesReviewID(t *testing.T) {
+	t.Parallel()
+
+	content, err := formula.GetEmbeddedFormulaContent("design")
+	if err != nil {
+		t.Fatalf("GetEmbeddedFormulaContent(design): %v", err)
+	}
+	f, err := formula.Parse(content)
+	if err != nil {
+		t.Fatalf("Parse(design): %v", err)
+	}
+	if f.Output == nil {
+		t.Fatal("design formula missing output config")
+	}
+
+	got, err := renderTemplate(f.Output.Directory, map[string]interface{}{"review_id": "abc123"})
+	if err != nil {
+		t.Fatalf("render output directory: %v", err)
+	}
+	if got != ".designs/abc123" {
+		t.Fatalf("output directory = %q, want %q", got, ".designs/abc123")
+	}
+}
+
+func TestFormulaRunExamplesUseSetVars(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"design", "mol-idea-to-plan"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			content, err := formula.GetEmbeddedFormulaContent(name)
+			if err != nil {
+				t.Fatalf("GetEmbeddedFormulaContent(%s): %v", name, err)
+			}
+			text := string(content)
+			for _, bad := range []string{"--problem=", "--context=", "--plan="} {
+				if strings.Contains(text, bad) {
+					t.Fatalf("%s still contains invalid gt formula run flag %q", name, bad)
+				}
+			}
+		})
+	}
+
+	idea, err := formula.GetEmbeddedFormulaContent("mol-idea-to-plan")
+	if err != nil {
+		t.Fatalf("GetEmbeddedFormulaContent(mol-idea-to-plan): %v", err)
+	}
+	ideaText := string(idea)
+	if strings.Contains(ideaText, "<design-id>") {
+		t.Fatal("mol-idea-to-plan still references stale <design-id> output paths")
+	}
+	for _, want := range []string{
+		"--set problem=\"{{problem}}\"",
+		"--set context=\"See .prd-reviews/{{review_id}}/prd-draft.md. {{context}}\"",
+		"--set context=\"PRD with clarifications: .prd-reviews/{{review_id}}/prd-draft.md. {{context}}\"",
+	} {
+		if !strings.Contains(ideaText, want) {
+			t.Fatalf("mol-idea-to-plan missing %q", want)
+		}
+	}
+
+	design, err := formula.GetEmbeddedFormulaContent("design")
+	if err != nil {
+		t.Fatalf("GetEmbeddedFormulaContent(design): %v", err)
+	}
+	if !strings.Contains(string(design), "gt formula run design --set problem=") {
+		t.Fatal("design usage examples do not mention --set problem=")
+	}
+}

--- a/internal/cmd/formula_test.go
+++ b/internal/cmd/formula_test.go
@@ -371,6 +371,61 @@ func TestDesignFormulaOutputUsesReviewID(t *testing.T) {
 	}
 }
 
+func TestSynthesisDescriptionRendersOutputContext(t *testing.T) {
+	t.Parallel()
+
+	for _, name := range []string{"design", "mol-prd-review", "mol-plan-review", "code-review"} {
+		name := name
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			content, err := formula.GetEmbeddedFormulaContent(name)
+			if err != nil {
+				t.Fatalf("GetEmbeddedFormulaContent(%s): %v", name, err)
+			}
+			f, err := formula.Parse(content)
+			if err != nil {
+				t.Fatalf("Parse(%s): %v", name, err)
+			}
+			if f.Synthesis == nil || f.Output == nil {
+				t.Fatalf("%s missing synthesis or output config", name)
+			}
+
+			ctx := formulaTemplateContext(name, "local files", "abc123", 0, "", nil, nil,
+				map[string]interface{}{
+					"context":    "extra context",
+					"plan":       "test plan",
+					"prd_review": "prd-review.md",
+					"problem":    "test problem",
+					"scope":      "test scope",
+				})
+			addOutputTemplateContext(ctx, ".out/abc123", f.Output.Synthesis)
+
+			got, err := renderTemplate(f.Synthesis.Description, ctx)
+			if err != nil {
+				t.Fatalf("render synthesis description: %v", err)
+			}
+			if strings.Contains(got, "{{.") || strings.Contains(got, "<no value>") {
+				t.Fatalf("synthesis description left template placeholders unrendered: %q", got)
+			}
+			if !strings.Contains(got, ".out/abc123") {
+				t.Fatalf("synthesis description missing rendered output directory: %q", got)
+			}
+			if name == "design" {
+				for _, want := range []string{
+					"All dimension analyses from: .out/abc123/",
+					"A synthesized design at: .out/abc123/design-doc.md",
+					"# Design: test problem",
+				} {
+					if !strings.Contains(got, want) {
+						t.Fatalf("synthesis description missing %q", want)
+					}
+				}
+			}
+		})
+	}
+}
+
 func TestFormulaRunExamplesUseSetVars(t *testing.T) {
 	t.Parallel()
 
@@ -400,10 +455,14 @@ func TestFormulaRunExamplesUseSetVars(t *testing.T) {
 	if strings.Contains(ideaText, "<design-id>") {
 		t.Fatal("mol-idea-to-plan still references stale <design-id> output paths")
 	}
+	if strings.Contains(ideaText, ".designs/<review-id>") {
+		t.Fatal("mol-idea-to-plan conflates design output ID with PRD review ID")
+	}
 	for _, want := range []string{
 		"--set problem=\"{{problem}}\"",
 		"--set context=\"See .prd-reviews/{{review_id}}/prd-draft.md. {{context}}\"",
 		"--set context=\"PRD with clarifications: .prd-reviews/{{review_id}}/prd-draft.md. {{context}}\"",
+		".designs/<design-review-id>/design-doc.md",
 	} {
 		if !strings.Contains(ideaText, want) {
 			t.Fatalf("mol-idea-to-plan missing %q", want)

--- a/internal/cmd/synthesis.go
+++ b/internal/cmd/synthesis.go
@@ -502,15 +502,26 @@ func collectLegOutputs(meta *ConvoyMeta, f *formula.Formula) ([]LegOutput, bool,
 }
 
 // expandOutputPath expands template variables in output paths.
-// Supports: {{review_id}}, {{leg.id}}
+// Supports Go template output syntax plus legacy bare placeholders.
 func expandOutputPath(directory, pattern, reviewID, legID string) string {
-	// Expand directory
-	dir := strings.ReplaceAll(directory, "{{review_id}}", reviewID)
-
-	// Expand pattern
-	file := strings.ReplaceAll(pattern, "{{leg.id}}", legID)
-
+	dir := expandOutputTemplate(directory, reviewID, legID)
+	file := expandOutputTemplate(pattern, reviewID, legID)
 	return filepath.Join(dir, file)
+}
+
+func expandOutputTemplate(tmplText, reviewID, legID string) string {
+	ctx := map[string]interface{}{
+		"review_id": reviewID,
+		"leg": map[string]interface{}{
+			"id": legID,
+		},
+	}
+	if rendered, err := renderTemplate(tmplText, ctx); err == nil {
+		return rendered
+	}
+
+	text := strings.ReplaceAll(tmplText, "{{review_id}}", reviewID)
+	return strings.ReplaceAll(text, "{{leg.id}}", legID)
 }
 
 // createSynthesisBead creates a bead for the synthesis step.
@@ -552,7 +563,7 @@ func createSynthesisBead(convoyID string, meta *ConvoyMeta, f *formula.Formula,
 
 	// Add output path if configured
 	if f != nil && f.Output != nil && f.Output.Synthesis != "" {
-		outputPath := strings.ReplaceAll(f.Output.Directory, "{{review_id}}", reviewID)
+		outputPath := expandOutputTemplate(f.Output.Directory, reviewID, "")
 		outputPath = filepath.Join(outputPath, f.Output.Synthesis)
 		desc.WriteString(fmt.Sprintf("\n## Output\n\nWrite synthesis to: %s\n", outputPath))
 	}

--- a/internal/cmd/synthesis.go
+++ b/internal/cmd/synthesis.go
@@ -540,10 +540,25 @@ func createSynthesisBead(convoyID string, meta *ConvoyMeta, f *formula.Formula,
 	desc.WriteString(fmt.Sprintf("review_id: %s\n", reviewID))
 	desc.WriteString("\n")
 
+	var outputDir, outputSynthesis string
+	if f != nil && f.Output != nil {
+		outputDir = expandOutputTemplate(f.Output.Directory, reviewID, "")
+		outputSynthesis = f.Output.Synthesis
+	}
+
 	// Add synthesis instructions from formula
 	if f != nil && f.Synthesis != nil && f.Synthesis.Description != "" {
+		formulaName := meta.Formula
+		if formulaName == "" {
+			formulaName = f.Name
+		}
+		synCtx := formulaTemplateContext(formulaName, meta.Title, reviewID, 0, "", nil, nil, nil)
+		synCtx["problem"] = meta.Title
+		addOutputTemplateContext(synCtx, outputDir, outputSynthesis)
+		synDesc := renderTemplateOrDefault(f.Synthesis.Description, synCtx, f.Synthesis.Description)
+
 		desc.WriteString("## Instructions\n\n")
-		desc.WriteString(f.Synthesis.Description)
+		desc.WriteString(synDesc)
 		desc.WriteString("\n\n")
 	}
 
@@ -563,8 +578,7 @@ func createSynthesisBead(convoyID string, meta *ConvoyMeta, f *formula.Formula,
 
 	// Add output path if configured
 	if f != nil && f.Output != nil && f.Output.Synthesis != "" {
-		outputPath := expandOutputTemplate(f.Output.Directory, reviewID, "")
-		outputPath = filepath.Join(outputPath, f.Output.Synthesis)
+		outputPath := filepath.Join(outputDir, f.Output.Synthesis)
 		desc.WriteString(fmt.Sprintf("\n## Output\n\nWrite synthesis to: %s\n", outputPath))
 	}
 

--- a/internal/cmd/synthesis_test.go
+++ b/internal/cmd/synthesis_test.go
@@ -38,6 +38,14 @@ func TestExpandOutputPath(t *testing.T) {
 			legID:     "performance",
 			want:      "reviews/pr-123/findings/leg-performance-analysis.md",
 		},
+		{
+			name:      "go template expansion",
+			directory: ".designs/{{.review_id}}",
+			pattern:   "{{.leg.id}}.md",
+			reviewID:  "abc123",
+			legID:     "api",
+			want:      ".designs/abc123/api.md",
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/formula/formulas/design.formula.toml
+++ b/internal/formula/formulas/design.formula.toml
@@ -5,8 +5,8 @@
 # are synthesized into a unified design document.
 #
 # Usage:
-#   gt formula run design --problem="Add notification levels to mayor"
-#   gt formula run design --problem="Redesign the merge queue"
+#   gt formula run design --set problem="Add notification levels to mayor"
+#   gt formula run design --set problem="Redesign the merge queue"
 
 description = """
 Structured design exploration via parallel specialized analysts.
@@ -29,7 +29,7 @@ are collected and synthesized into a unified design proposal with options.
 4. Synthesis step combines all analyses into unified design
 
 ## Output
-A .designs/<design-id>/ directory containing:
+A .designs/<review-id>/ directory containing:
 - Individual dimension analyses
 - design-doc.md with unified proposal and decision points
 """
@@ -117,7 +117,7 @@ Be thorough but actionable. Flag decisions needing human input.
 
 # Output configuration
 [output]
-directory = ".designs/{{.design_id}}"
+directory = ".designs/{{.review_id}}"
 leg_pattern = "{{.leg.id}}.md"
 synthesis = "design-doc.md"
 

--- a/internal/formula/formulas/mol-idea-to-plan.formula.toml
+++ b/internal/formula/formulas/mol-idea-to-plan.formula.toml
@@ -122,8 +122,8 @@ Pour the mol-prd-review convoy to run 6 parallel PRD reviewers.
 **1. Pour the convoy:**
 ```bash
 gt formula run mol-prd-review \\
-  --problem="{{problem}}" \\
-  --context="See .prd-reviews/{{review_id}}/prd-draft.md. {{context}}"
+  --set problem="{{problem}}" \\
+  --set context="See .prd-reviews/{{review_id}}/prd-draft.md. {{context}}"
 ```
 
 This spawns 6 polecats in parallel:
@@ -215,8 +215,8 @@ Pour the design convoy to generate an implementation plan from the refined PRD.
 **1. Pour the design convoy:**
 ```bash
 gt formula run design \\
-  --problem="{{problem}}" \\
-  --context="PRD with clarifications: .prd-reviews/{{review_id}}/prd-draft.md. {{context}}"
+  --set problem="{{problem}}" \\
+  --set context="PRD with clarifications: .prd-reviews/{{review_id}}/prd-draft.md. {{context}}"
 ```
 
 This spawns 6 polecats in parallel, each exploring a different dimension:
@@ -236,7 +236,7 @@ ls .designs/   # find the design output directory
 
 **3. Read the design doc:**
 ```bash
-cat .designs/<design-id>/design-doc.md
+cat .designs/<review-id>/design-doc.md
 ```
 
 Pay attention to:
@@ -268,7 +268,7 @@ Polecat A — **requirements-coverage**:
 gt sling --prompt="Review an implementation plan for PRD alignment.
 
 Read the PRD: .prd-reviews/{{review_id}}/prd-draft.md
-Read the plan: .designs/<design-id>/design-doc.md
+Read the plan: .designs/<review-id>/design-doc.md
 
 Walk through every REQUIREMENT in the PRD (Problem Statement, Goals, Acceptance
 Criteria, any explicitly stated requirements). For each, verify the plan has a
@@ -288,7 +288,7 @@ Polecat B — **goals-alignment**:
 gt sling --prompt="Review an implementation plan for PRD alignment.
 
 Read the PRD: .prd-reviews/{{review_id}}/prd-draft.md
-Read the plan: .designs/<design-id>/design-doc.md
+Read the plan: .designs/<review-id>/design-doc.md
 
 Walk through every GOAL in the PRD. For each, trace through the plan and verify
 that executing the plan as written will achieve this goal.
@@ -309,7 +309,7 @@ gt mail inbox  # wait for both polecats to report back
 
 **3. Apply fixes to the plan:**
 Read both reports. For each must-fix and should-fix finding:
-- Edit `.designs/<design-id>/design-doc.md` directly
+- Edit `.designs/<review-id>/design-doc.md` directly
 - Add missing tasks, expand partial coverage, fix misalignments
 - Log all changes in `.plan-reviews/{{review_id}}/prd-align-round-1.md`
 
@@ -329,7 +329,7 @@ Polecat A — **constraints-compliance**:
 gt sling --prompt="Review an implementation plan for PRD alignment (round 2).
 
 Read the PRD: .prd-reviews/{{review_id}}/prd-draft.md
-Read the plan: .designs/<design-id>/design-doc.md
+Read the plan: .designs/<review-id>/design-doc.md
 Read round 1 changes: .plan-reviews/{{review_id}}/prd-align-round-1.md
 
 Check every CONSTRAINT in the PRD (technical, business, timeline, resource).
@@ -350,7 +350,7 @@ Polecat B — **non-goals-enforcement**:
 gt sling --prompt="Review an implementation plan for PRD alignment (round 2).
 
 Read the PRD: .prd-reviews/{{review_id}}/prd-draft.md
-Read the plan: .designs/<design-id>/design-doc.md
+Read the plan: .designs/<review-id>/design-doc.md
 Read round 1 changes: .plan-reviews/{{review_id}}/prd-align-round-1.md
 
 Check the PRD's Non-Goals section. Verify the plan does NOT include work that
@@ -372,7 +372,7 @@ gt mail inbox
 ```
 
 **3. Apply fixes to the plan:**
-Read both reports. Apply must-fix and should-fix changes to `.designs/<design-id>/design-doc.md`.
+Read both reports. Apply must-fix and should-fix changes to `.designs/<review-id>/design-doc.md`.
 Cut scope-creep items. Add constraint-respecting guardrails. Log changes in
 `.plan-reviews/{{review_id}}/prd-align-round-2.md`.
 
@@ -392,7 +392,7 @@ Polecat A — **user-stories-coverage**:
 gt sling --prompt="Review an implementation plan for PRD alignment (round 3).
 
 Read the PRD: .prd-reviews/{{review_id}}/prd-draft.md
-Read the plan: .designs/<design-id>/design-doc.md
+Read the plan: .designs/<review-id>/design-doc.md
 Read prior changes: .plan-reviews/{{review_id}}/prd-align-round-1.md and round-2.md
 
 Walk through every USER STORY and SCENARIO in the PRD. For each, trace the
@@ -413,7 +413,7 @@ Polecat B — **open-questions-resolution**:
 gt sling --prompt="Review an implementation plan for PRD alignment (round 3).
 
 Read the PRD: .prd-reviews/{{review_id}}/prd-draft.md
-Read the plan: .designs/<design-id>/design-doc.md
+Read the plan: .designs/<review-id>/design-doc.md
 Read prior changes: .plan-reviews/{{review_id}}/prd-align-round-1.md and round-2.md
 
 Check every OPEN QUESTION from the PRD (both the original Open Questions section
@@ -437,7 +437,7 @@ gt mail inbox
 ```
 
 **3. Apply fixes to the plan:**
-Read both reports. Apply all fixes to `.designs/<design-id>/design-doc.md`.
+Read both reports. Apply all fixes to `.designs/<review-id>/design-doc.md`.
 Log changes in `.plan-reviews/{{review_id}}/prd-align-round-3.md`.
 
 **4. PRD alignment summary:**
@@ -475,7 +475,7 @@ Polecat A — **completeness**:
 ```bash
 gt sling --prompt="Review an implementation plan for completeness.
 
-Read the plan: .designs/<design-id>/design-doc.md
+Read the plan: .designs/<review-id>/design-doc.md
 Read the PRD alignment logs: .plan-reviews/{{review_id}}/prd-align-round-*.md
 
 Is the plan complete? Check for:
@@ -499,7 +499,7 @@ Polecat B — **sequencing**:
 ```bash
 gt sling --prompt="Review an implementation plan for correct sequencing.
 
-Read the plan: .designs/<design-id>/design-doc.md
+Read the plan: .designs/<review-id>/design-doc.md
 
 Check the ordering and dependencies of all plan phases and tasks:
 - Are tasks in the right order? Would any task fail if executed in sequence?
@@ -523,7 +523,7 @@ gt mail inbox
 
 **3. Apply fixes to the plan:**
 Read both reports. Apply all must-fix and should-fix changes to
-`.designs/<design-id>/design-doc.md`. Log in `.plan-reviews/{{review_id}}/review-round-1.md`.
+`.designs/<review-id>/design-doc.md`. Log in `.plan-reviews/{{review_id}}/review-round-1.md`.
 
 **Exit criteria:** Both reports received. All fixes applied."""
 
@@ -540,7 +540,7 @@ Polecat A — **risk**:
 ```bash
 gt sling --prompt="Review an implementation plan for risk.
 
-Read the plan: .designs/<design-id>/design-doc.md
+Read the plan: .designs/<review-id>/design-doc.md
 Read prior review changes: .plan-reviews/{{review_id}}/review-round-1.md
 
 Identify risks in the plan:
@@ -564,7 +564,7 @@ Polecat B — **scope-creep**:
 ```bash
 gt sling --prompt="Review an implementation plan for scope creep.
 
-Read the plan: .designs/<design-id>/design-doc.md
+Read the plan: .designs/<review-id>/design-doc.md
 Read the PRD: .prd-reviews/{{review_id}}/prd-draft.md
 Read prior review changes: .plan-reviews/{{review_id}}/review-round-1.md
 
@@ -590,7 +590,7 @@ gt mail inbox
 ```
 
 **3. Apply fixes to the plan:**
-Read both reports. Apply fixes to `.designs/<design-id>/design-doc.md`.
+Read both reports. Apply fixes to `.designs/<review-id>/design-doc.md`.
 Add risk mitigations, cut scope-creep items, add spikes for unknowns.
 Log in `.plan-reviews/{{review_id}}/review-round-2.md`.
 
@@ -609,7 +609,7 @@ Polecat A — **testability**:
 ```bash
 gt sling --prompt="Review an implementation plan for testability.
 
-Read the plan: .designs/<design-id>/design-doc.md
+Read the plan: .designs/<review-id>/design-doc.md
 Read prior review changes: .plan-reviews/{{review_id}}/review-round-1.md and round-2.md
 
 For each task/phase in the plan, check:
@@ -632,7 +632,7 @@ Polecat B — **coherence**:
 ```bash
 gt sling --prompt="Review an implementation plan for overall coherence.
 
-Read the plan: .designs/<design-id>/design-doc.md
+Read the plan: .designs/<review-id>/design-doc.md
 Read the PRD: .prd-reviews/{{review_id}}/prd-draft.md
 Read ALL prior review changes: .plan-reviews/{{review_id}}/*.md
 
@@ -658,7 +658,7 @@ gt mail inbox
 ```
 
 **3. Apply fixes to the plan:**
-Read both reports. Apply final fixes to `.designs/<design-id>/design-doc.md`.
+Read both reports. Apply final fixes to `.designs/<review-id>/design-doc.md`.
 Log in `.plan-reviews/{{review_id}}/review-round-3.md`.
 
 **4. Iterative review summary — output in conversation:**
@@ -677,7 +677,7 @@ Log in `.plan-reviews/{{review_id}}/review-round-3.md`.
 - Round 5 (risk + scope-creep): <N> fixes
 - Round 6 (testability + coherence): <N> fixes
 
-**Final plan:** .designs/<design-id>/design-doc.md
+**Final plan:** .designs/<review-id>/design-doc.md
 **Review logs:** .plan-reviews/{{review_id}}/
 
 Proceeding to bead creation...
@@ -694,7 +694,7 @@ Convert the refined implementation plan into beads with dependencies.
 
 **1. Read the final plan:**
 ```bash
-cat .designs/<design-id>/design-doc.md
+cat .designs/<review-id>/design-doc.md
 ```
 
 **2. Identify work items from the Implementation Plan section:**
@@ -734,7 +734,7 @@ Implementation of: {{problem}}
 ## Planning Artifacts
 - PRD: .prd-reviews/<review-id>/prd-draft.md
 - PRD Review: .prd-reviews/<review-id>/prd-review.md
-- Design Doc: .designs/<design-id>/design-doc.md
+- Design Doc: .designs/<review-id>/design-doc.md
 - Review Logs: .plan-reviews/<review-id>/
 "
 ```
@@ -773,7 +773,7 @@ First pass: find gaps between the implementation plan and the beads just created
 
 **1. Read the implementation plan:**
 ```bash
-cat .designs/<design-id>/design-doc.md
+cat .designs/<review-id>/design-doc.md
 ```
 
 **2. List all beads just created:**

--- a/internal/formula/formulas/mol-idea-to-plan.formula.toml
+++ b/internal/formula/formulas/mol-idea-to-plan.formula.toml
@@ -236,7 +236,7 @@ ls .designs/   # find the design output directory
 
 **3. Read the design doc:**
 ```bash
-cat .designs/<review-id>/design-doc.md
+cat .designs/<design-review-id>/design-doc.md
 ```
 
 Pay attention to:
@@ -268,7 +268,7 @@ Polecat A — **requirements-coverage**:
 gt sling --prompt="Review an implementation plan for PRD alignment.
 
 Read the PRD: .prd-reviews/{{review_id}}/prd-draft.md
-Read the plan: .designs/<review-id>/design-doc.md
+Read the plan: .designs/<design-review-id>/design-doc.md
 
 Walk through every REQUIREMENT in the PRD (Problem Statement, Goals, Acceptance
 Criteria, any explicitly stated requirements). For each, verify the plan has a
@@ -288,7 +288,7 @@ Polecat B — **goals-alignment**:
 gt sling --prompt="Review an implementation plan for PRD alignment.
 
 Read the PRD: .prd-reviews/{{review_id}}/prd-draft.md
-Read the plan: .designs/<review-id>/design-doc.md
+Read the plan: .designs/<design-review-id>/design-doc.md
 
 Walk through every GOAL in the PRD. For each, trace through the plan and verify
 that executing the plan as written will achieve this goal.
@@ -309,7 +309,7 @@ gt mail inbox  # wait for both polecats to report back
 
 **3. Apply fixes to the plan:**
 Read both reports. For each must-fix and should-fix finding:
-- Edit `.designs/<review-id>/design-doc.md` directly
+- Edit `.designs/<design-review-id>/design-doc.md` directly
 - Add missing tasks, expand partial coverage, fix misalignments
 - Log all changes in `.plan-reviews/{{review_id}}/prd-align-round-1.md`
 
@@ -329,7 +329,7 @@ Polecat A — **constraints-compliance**:
 gt sling --prompt="Review an implementation plan for PRD alignment (round 2).
 
 Read the PRD: .prd-reviews/{{review_id}}/prd-draft.md
-Read the plan: .designs/<review-id>/design-doc.md
+Read the plan: .designs/<design-review-id>/design-doc.md
 Read round 1 changes: .plan-reviews/{{review_id}}/prd-align-round-1.md
 
 Check every CONSTRAINT in the PRD (technical, business, timeline, resource).
@@ -350,7 +350,7 @@ Polecat B — **non-goals-enforcement**:
 gt sling --prompt="Review an implementation plan for PRD alignment (round 2).
 
 Read the PRD: .prd-reviews/{{review_id}}/prd-draft.md
-Read the plan: .designs/<review-id>/design-doc.md
+Read the plan: .designs/<design-review-id>/design-doc.md
 Read round 1 changes: .plan-reviews/{{review_id}}/prd-align-round-1.md
 
 Check the PRD's Non-Goals section. Verify the plan does NOT include work that
@@ -372,7 +372,7 @@ gt mail inbox
 ```
 
 **3. Apply fixes to the plan:**
-Read both reports. Apply must-fix and should-fix changes to `.designs/<review-id>/design-doc.md`.
+Read both reports. Apply must-fix and should-fix changes to `.designs/<design-review-id>/design-doc.md`.
 Cut scope-creep items. Add constraint-respecting guardrails. Log changes in
 `.plan-reviews/{{review_id}}/prd-align-round-2.md`.
 
@@ -392,7 +392,7 @@ Polecat A — **user-stories-coverage**:
 gt sling --prompt="Review an implementation plan for PRD alignment (round 3).
 
 Read the PRD: .prd-reviews/{{review_id}}/prd-draft.md
-Read the plan: .designs/<review-id>/design-doc.md
+Read the plan: .designs/<design-review-id>/design-doc.md
 Read prior changes: .plan-reviews/{{review_id}}/prd-align-round-1.md and round-2.md
 
 Walk through every USER STORY and SCENARIO in the PRD. For each, trace the
@@ -413,7 +413,7 @@ Polecat B — **open-questions-resolution**:
 gt sling --prompt="Review an implementation plan for PRD alignment (round 3).
 
 Read the PRD: .prd-reviews/{{review_id}}/prd-draft.md
-Read the plan: .designs/<review-id>/design-doc.md
+Read the plan: .designs/<design-review-id>/design-doc.md
 Read prior changes: .plan-reviews/{{review_id}}/prd-align-round-1.md and round-2.md
 
 Check every OPEN QUESTION from the PRD (both the original Open Questions section
@@ -437,7 +437,7 @@ gt mail inbox
 ```
 
 **3. Apply fixes to the plan:**
-Read both reports. Apply all fixes to `.designs/<review-id>/design-doc.md`.
+Read both reports. Apply all fixes to `.designs/<design-review-id>/design-doc.md`.
 Log changes in `.plan-reviews/{{review_id}}/prd-align-round-3.md`.
 
 **4. PRD alignment summary:**
@@ -475,7 +475,7 @@ Polecat A — **completeness**:
 ```bash
 gt sling --prompt="Review an implementation plan for completeness.
 
-Read the plan: .designs/<review-id>/design-doc.md
+Read the plan: .designs/<design-review-id>/design-doc.md
 Read the PRD alignment logs: .plan-reviews/{{review_id}}/prd-align-round-*.md
 
 Is the plan complete? Check for:
@@ -499,7 +499,7 @@ Polecat B — **sequencing**:
 ```bash
 gt sling --prompt="Review an implementation plan for correct sequencing.
 
-Read the plan: .designs/<review-id>/design-doc.md
+Read the plan: .designs/<design-review-id>/design-doc.md
 
 Check the ordering and dependencies of all plan phases and tasks:
 - Are tasks in the right order? Would any task fail if executed in sequence?
@@ -523,7 +523,7 @@ gt mail inbox
 
 **3. Apply fixes to the plan:**
 Read both reports. Apply all must-fix and should-fix changes to
-`.designs/<review-id>/design-doc.md`. Log in `.plan-reviews/{{review_id}}/review-round-1.md`.
+`.designs/<design-review-id>/design-doc.md`. Log in `.plan-reviews/{{review_id}}/review-round-1.md`.
 
 **Exit criteria:** Both reports received. All fixes applied."""
 
@@ -540,7 +540,7 @@ Polecat A — **risk**:
 ```bash
 gt sling --prompt="Review an implementation plan for risk.
 
-Read the plan: .designs/<review-id>/design-doc.md
+Read the plan: .designs/<design-review-id>/design-doc.md
 Read prior review changes: .plan-reviews/{{review_id}}/review-round-1.md
 
 Identify risks in the plan:
@@ -564,7 +564,7 @@ Polecat B — **scope-creep**:
 ```bash
 gt sling --prompt="Review an implementation plan for scope creep.
 
-Read the plan: .designs/<review-id>/design-doc.md
+Read the plan: .designs/<design-review-id>/design-doc.md
 Read the PRD: .prd-reviews/{{review_id}}/prd-draft.md
 Read prior review changes: .plan-reviews/{{review_id}}/review-round-1.md
 
@@ -590,7 +590,7 @@ gt mail inbox
 ```
 
 **3. Apply fixes to the plan:**
-Read both reports. Apply fixes to `.designs/<review-id>/design-doc.md`.
+Read both reports. Apply fixes to `.designs/<design-review-id>/design-doc.md`.
 Add risk mitigations, cut scope-creep items, add spikes for unknowns.
 Log in `.plan-reviews/{{review_id}}/review-round-2.md`.
 
@@ -609,7 +609,7 @@ Polecat A — **testability**:
 ```bash
 gt sling --prompt="Review an implementation plan for testability.
 
-Read the plan: .designs/<review-id>/design-doc.md
+Read the plan: .designs/<design-review-id>/design-doc.md
 Read prior review changes: .plan-reviews/{{review_id}}/review-round-1.md and round-2.md
 
 For each task/phase in the plan, check:
@@ -632,7 +632,7 @@ Polecat B — **coherence**:
 ```bash
 gt sling --prompt="Review an implementation plan for overall coherence.
 
-Read the plan: .designs/<review-id>/design-doc.md
+Read the plan: .designs/<design-review-id>/design-doc.md
 Read the PRD: .prd-reviews/{{review_id}}/prd-draft.md
 Read ALL prior review changes: .plan-reviews/{{review_id}}/*.md
 
@@ -658,7 +658,7 @@ gt mail inbox
 ```
 
 **3. Apply fixes to the plan:**
-Read both reports. Apply final fixes to `.designs/<review-id>/design-doc.md`.
+Read both reports. Apply final fixes to `.designs/<design-review-id>/design-doc.md`.
 Log in `.plan-reviews/{{review_id}}/review-round-3.md`.
 
 **4. Iterative review summary — output in conversation:**
@@ -677,7 +677,7 @@ Log in `.plan-reviews/{{review_id}}/review-round-3.md`.
 - Round 5 (risk + scope-creep): <N> fixes
 - Round 6 (testability + coherence): <N> fixes
 
-**Final plan:** .designs/<review-id>/design-doc.md
+**Final plan:** .designs/<design-review-id>/design-doc.md
 **Review logs:** .plan-reviews/{{review_id}}/
 
 Proceeding to bead creation...
@@ -694,7 +694,7 @@ Convert the refined implementation plan into beads with dependencies.
 
 **1. Read the final plan:**
 ```bash
-cat .designs/<review-id>/design-doc.md
+cat .designs/<design-review-id>/design-doc.md
 ```
 
 **2. Identify work items from the Implementation Plan section:**
@@ -734,7 +734,7 @@ Implementation of: {{problem}}
 ## Planning Artifacts
 - PRD: .prd-reviews/<review-id>/prd-draft.md
 - PRD Review: .prd-reviews/<review-id>/prd-review.md
-- Design Doc: .designs/<review-id>/design-doc.md
+- Design Doc: .designs/<design-review-id>/design-doc.md
 - Review Logs: .plan-reviews/<review-id>/
 "
 ```
@@ -773,7 +773,7 @@ First pass: find gaps between the implementation plan and the beads just created
 
 **1. Read the implementation plan:**
 ```bash
-cat .designs/<review-id>/design-doc.md
+cat .designs/<design-review-id>/design-doc.md
 ```
 
 **2. List all beads just created:**

--- a/internal/templates/roles/crew.md.tmpl
+++ b/internal/templates/roles/crew.md.tmpl
@@ -316,7 +316,7 @@ the work in one session if possible and submit to that rig's Refinery immediatel
 **When the human describes an idea and wants to turn it into a plan, offer this:**
 
 ```bash
-{{ cmd }} formula run mol-idea-to-plan --problem="describe the idea here"
+{{ cmd }} formula run mol-idea-to-plan --set problem="describe the idea here"
 ```
 
 This runs the full pipeline autonomously: structured PRD → 6-leg parallel review →
@@ -330,8 +330,8 @@ human approval gate → beads with dependency graph.
 
 **Standalone phases (if they only want part of the pipeline):**
 ```bash
-{{ cmd }} formula run mol-prd-review --problem="..."          # PRD review only (6 parallel legs)
-{{ cmd }} formula run mol-plan-review --plan="..." --problem="..."  # Plan review only (5 parallel legs)
+{{ cmd }} formula run mol-prd-review --set problem="..."          # PRD review only (6 parallel legs)
+{{ cmd }} formula run mol-plan-review --set plan="..." --set problem="..."  # Plan review only (5 parallel legs)
 ```
 
 ### Communication: Mail


### PR DESCRIPTION
PR Sheriff follow-up for #4042 / gt-pr-sheriff-4042.

This branch is based on upstream/main and avoids the original broad formula-file-only churn by fixing the renderer paths that need Go template context, while keeping formula examples aligned with `gt formula run --set`.

Context:
- Original PR: #4042 by esciara
- Dust completed targeted verification and make build.
- `gt done --target main` could not submit because it auto-rebased onto divergent fork `origin/main`; this PR is the Mayor-managed upstream PR path.

Notes:
- Keep cleanup/convergence bias: prefer the shared renderer/context helpers over expanding one-off template substitutions.
- Broad `go test ./... -short` has unrelated baseline failures per dust escalation; targeted formula/synthesis tests and build passed before submission.

Co-authored/context credit: original issue/PR analysis from esciara in #4042.