### PR TITLE
fix(compact): use correct column names in orphaned wisp_dependencies sweep

### DIFF
--- a/internal/cmd/compact.go
+++ b/internal/cmd/compact.go
@@ -277,13 +277,19 @@ func runCompact(cmd *cobra.Command, args []string) error {
 }
 
 // cleanOrphanedWispDeps removes wisp_dependencies rows where either side no
-// longer exists in the wisps table. This happens when bd delete removes a wisp
-// but leaves behind its dependency records (bd delete has no cascade logic for
-// the wisp-level tables). Runs as a post-compact sweep.
+// longer exists. This happens when bd delete removes a wisp but leaves behind
+// its dependency records (bd delete has no cascade logic for the wisp-level
+// tables). Runs as a post-compact sweep.
+//
+// The dependency target is split across nullable columns: depends_on_wisp_id
+// (wisp targets), depends_on_issue_id (durable issue targets), and
+// depends_on_external. Each set column is checked against its own table;
+// rows whose only target is depends_on_external are never swept here.
 func cleanOrphanedWispDeps(bd *beads.Beads, result *compactResult) {
 	const q = `DELETE FROM wisp_dependencies WHERE ` +
 		`NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.issue_id) ` +
-		`OR NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_id)`
+		`OR (depends_on_wisp_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_wisp_id)) ` +
+		`OR (depends_on_issue_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM issues WHERE id = wisp_dependencies.depends_on_issue_id))`
 	out, err := bd.Run("sql", q)
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("orphaned wisp_deps cleanup: %v", err))


### PR DESCRIPTION
### Problem

`gt compact`'s post-compact sweep (`cleanOrphanedWispDeps` in
`internal/cmd/compact.go`) deletes orphaned `wisp_dependencies` rows with:

```sql
DELETE FROM wisp_dependencies WHERE
  NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.issue_id)
  OR NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_id)
```

But `wisp_dependencies` has no `depends_on_id` column. The actual schema
(confirmed via `DESCRIBE wisp_dependencies`) splits the target across three
nullable columns: `depends_on_wisp_id`, `depends_on_issue_id`,
`depends_on_external`. Every compaction cycle the DELETE fails with:

```
Error 1105 (HY000): table "wisp_dependencies" does not have column "depends_on_id"
```

so orphaned dependency rows accumulate indefinitely. Observed in a deacon
compaction report on 2026-06-05.

This is the same bug pattern as #4172, which fixed seven references in
`internal/reaper/reaper.go` (reaper purge path) but did not touch the
compaction path.

### Fix

Check each set target column against its own table, mirroring the #4172
column mapping (`depends_on_wisp_id` → `wisps`, `depends_on_issue_id` →
`issues`):

```sql
DELETE FROM wisp_dependencies WHERE
  NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.issue_id)
  OR (depends_on_wisp_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_wisp_id))
  OR (depends_on_issue_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM issues WHERE id = wisp_dependencies.depends_on_issue_id))
```

The `IS NOT NULL` guards matter: rows whose only target is
`depends_on_external` must never be swept by this cleanup.

### Verification

- `go build ./...`, `go vet ./internal/cmd/`, `go test ./internal/cmd/ -run 'Compact|Orphan'` — all pass
- Old predicate reproduced the exact production error against a live Dolt DB (read-only SELECT form)
- New predicate executes cleanly against the same DB (SELECT COUNT form; 251 rows total, 0 currently orphaned post-gc)
- `gt compact --dry-run` with the patched binary: 183 wisps scanned, no errors

### Related

- #4172 — same column bug in the reaper purge path
- Remaining `depends_on_id` references elsewhere in the tree (convoy, dolt-snapshots plugin, wisps_migrate CREATE TABLE template, misclassified_wisp_check) are tracked separately; this PR is scoped to the compaction sweep.
