### PR TITLE
fix(convoy): bdDepListRawIDs reads migrated dependency columns (unblocks mountain wave advancement)

### DIFF
--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -486,8 +486,8 @@ func runBdJSONWithOptions(dir string, allowStale bool, args ...string) ([]byte, 
 //
 // Returns deduplicated, unwrapped issue IDs (external:prefix:id → id).
 func bdDepListRawIDs(dir, issueID, direction, depType string) ([]string, error) {
-	// Bead IDs are system-generated alphanumeric strings with hyphens and
-	// dots — validate to prevent injection before interpolating below.
+	// Bead IDs are system-generated alphanumeric strings with hyphens, dots,
+	// and underscores — validate to prevent injection before interpolating below.
 	if !isValidBeadID(issueID) {
 		return nil, fmt.Errorf("invalid bead ID: %q", issueID)
 	}
@@ -503,8 +503,8 @@ func bdDepListRawIDs(dir, issueID, direction, depType string) ([]string, error) 
 		selectExpr = "issue_id"
 		parseKey = "issue_id"
 		whereClause = fmt.Sprintf(
-			"(depends_on_issue_id = '%s' OR depends_on_wisp_id = '%s' OR depends_on_external LIKE '%%:%s')",
-			issueID, issueID, issueID)
+			"(depends_on_issue_id = '%s' OR depends_on_wisp_id = '%s' OR %s)",
+			issueID, issueID, sqlExternalDepTargetClause(issueID))
 	} else {
 		selectExpr = "COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS depends_on_id"
 		parseKey = "depends_on_id"
@@ -541,6 +541,12 @@ func bdDepListRawIDs(dir, issueID, direction, depType string) ([]string, error) 
 		}
 	}
 	return ids, nil
+}
+
+func sqlExternalDepTargetClause(issueID string) string {
+	// Use an escape character that is not valid in bead IDs so underscores stay literal.
+	escapedID := strings.ReplaceAll(issueID, "_", "!_")
+	return fmt.Sprintf("depends_on_external LIKE '%%:%s' ESCAPE '!'", escapedID)
 }
 
 // isValidBeadID checks that a string is safe for SQL interpolation in dep queries.

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -486,25 +486,32 @@ func runBdJSONWithOptions(dir string, allowStale bool, args ...string) ([]byte, 
 //
 // Returns deduplicated, unwrapped issue IDs (external:prefix:id → id).
 func bdDepListRawIDs(dir, issueID, direction, depType string) ([]string, error) {
-	// Determine query columns based on direction.
-	// "down": issueID depends on targets → SELECT depends_on_id WHERE issue_id = ?
-	// "up":   issueID is depended on → SELECT issue_id WHERE depends_on_id = ?
-	var selectCol, whereCol string
-	if direction == "up" {
-		selectCol = "issue_id"
-		whereCol = "depends_on_id"
-	} else {
-		selectCol = "depends_on_id"
-		whereCol = "issue_id"
-	}
-
-	// Build SQL query. Bead IDs are system-generated alphanumeric strings
-	// with hyphens and dots — validate to prevent injection.
+	// Bead IDs are system-generated alphanumeric strings with hyphens and
+	// dots — validate to prevent injection before interpolating below.
 	if !isValidBeadID(issueID) {
 		return nil, fmt.Errorf("invalid bead ID: %q", issueID)
 	}
 
-	query := fmt.Sprintf("SELECT %s FROM dependencies WHERE %s = '%s'", selectCol, whereCol, issueID)
+	// The dependency target was historically a single depends_on_id column.
+	// The schema migration split it into typed columns
+	// (depends_on_issue_id / depends_on_wisp_id / depends_on_external), where
+	// cross-database refs live in depends_on_external as "external:<prefix>:<id>".
+	// "down": targets issueID depends on → COALESCE the three target columns.
+	// "up":   issues that depend on issueID → match issueID against all three.
+	var selectExpr, whereClause, parseKey string
+	if direction == "up" {
+		selectExpr = "issue_id"
+		parseKey = "issue_id"
+		whereClause = fmt.Sprintf(
+			"(depends_on_issue_id = '%s' OR depends_on_wisp_id = '%s' OR depends_on_external LIKE '%%:%s')",
+			issueID, issueID, issueID)
+	} else {
+		selectExpr = "COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS depends_on_id"
+		parseKey = "depends_on_id"
+		whereClause = fmt.Sprintf("issue_id = '%s'", issueID)
+	}
+
+	query := fmt.Sprintf("SELECT %s FROM dependencies WHERE %s", selectExpr, whereClause)
 	if depType != "" {
 		if !isValidBeadID(depType) {
 			return nil, fmt.Errorf("invalid dep type: %q", depType)
@@ -526,7 +533,7 @@ func bdDepListRawIDs(dir, issueID, direction, depType string) ([]string, error) 
 	seen := make(map[string]bool, len(rows))
 	var ids []string
 	for _, row := range rows {
-		rawID := row[selectCol]
+		rawID := row[parseKey]
 		id := beads.ExtractIssueID(rawID)
 		if id != "" && !seen[id] {
 			seen[id] = true

--- a/internal/cmd/convoy_test_helpers_test.go
+++ b/internal/cmd/convoy_test_helpers_test.go
@@ -230,8 +230,8 @@ func (d *testDAG) BdStubScript() string {
 	}
 
 	// --- handle: sql "SELECT ..." --json (bdDepListRawIDs) ---
-	// bdDepListRawIDs calls: bd sql "SELECT depends_on_id FROM dependencies WHERE issue_id = '<id>' AND type = 'tracks'" --json
-	// or: bd sql "SELECT issue_id FROM dependencies WHERE depends_on_id = '<id>' AND type = 'tracks'" --json
+	// bdDepListRawIDs calls: bd sql "SELECT COALESCE(...) AS depends_on_id FROM dependencies WHERE issue_id = '<id>' AND type = 'tracks'" --json
+	// or: bd sql "SELECT issue_id FROM dependencies WHERE <typed target columns match id> AND type = 'tracks'" --json
 	sb.WriteString("  sql\\ *)\n")
 	sb.WriteString("    # Handle SQL queries for dependency lookups\n")
 	// For "down" direction (convoy → tracked beads): match on issue_id = '<convoyID>'
@@ -246,12 +246,12 @@ func (d *testDAG) BdStubScript() string {
 			sb.WriteString("    esac\n")
 		}
 	}
-	// For "up" direction (bead → tracking convoys): match on depends_on_id = '<beadID>'
+	// For "up" direction (bead → tracking convoys): match typed target columns.
 	for id := range d.beads {
 		trackersJSON := d.trackersSQLJSONFor(id)
 		if trackersJSON != "[]" {
 			sb.WriteString(`    case "$ALL_ARGS" in` + "\n")
-			sb.WriteString(fmt.Sprintf("      *\"depends_on_id = '%s'\"*)\n", id))
+			sb.WriteString(fmt.Sprintf("      *\"depends_on_issue_id = '%s'\"*)\n", id))
 			sb.WriteString(fmt.Sprintf("        echo '%s'\n", trackersJSON))
 			sb.WriteString("        exit 0\n")
 			sb.WriteString("        ;;\n")

--- a/internal/cmd/sling_batch_test.go
+++ b/internal/cmd/sling_batch_test.go
@@ -465,9 +465,9 @@ shift || true
 
 case "$cmd" in
   sql)
-    # bdDepListRawIDs up: SELECT issue_id FROM dependencies WHERE depends_on_id = '<beadID>' AND type = 'tracks'
+    # bdDepListRawIDs up: match beadID against typed dependency target columns.
     case "$*" in
-      *"depends_on_id = 'gt-bbb'"*)
+      *"depends_on_issue_id = 'gt-bbb'"*)
         echo '[{"issue_id":"hq-cv-existing"}]'
         ;;
       *)

--- a/internal/cmd/sling_convoy_test.go
+++ b/internal/cmd/sling_convoy_test.go
@@ -155,3 +155,11 @@ func TestBdDepListRawIDsValidation(t *testing.T) {
 		t.Error("bdDepListRawIDs should reject SQL injection in depType")
 	}
 }
+
+func TestSQLExternalDepTargetClauseEscapesUnderscore(t *testing.T) {
+	got := sqlExternalDepTargetClause("gt-a_b")
+	want := "depends_on_external LIKE '%:gt-a!_b' ESCAPE '!'"
+	if got != want {
+		t.Fatalf("sqlExternalDepTargetClause() = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Problem

`bdDepListRawIDs` (internal/cmd/convoy.go) queries a single `depends_on_id` column, but the beads schema migration split the dependency target into typed columns: `depends_on_issue_id` / `depends_on_wisp_id` / `depends_on_external` (the last holding cross-database refs as `external:<prefix>:<id>`).

Against a migrated database, every convoy dep lookup fails:

```
bd sql for deps of <id>: Error 1105 (HY000): column "depends_on_id" could not be found in any table in scope
```

This breaks `gt convoy status`, `gt mountain status`, and — critically — the ConvoyManager's wave advancement, so **a mountain stalls after Wave 1**. (Reproduced live: a 10-bead mountain dispatched Wave 1 then could not advance.) Same schema-skew class as #4228 (reaper) and #4230 (beads bump).

## Fix

Handle both query directions against the split columns:
- **down** (targets issueID depends on): `SELECT COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS depends_on_id`
- **up** (issues that depend on issueID): match issueID against all three, incl. `depends_on_external LIKE '%:<id>'` for cross-DB refs

`beads.ExtractIssueID` already unwraps `external:<prefix>:<id>`. Input is still validated by `isValidBeadID` before interpolation.

## Verification

- `go build ./cmd/gt` OK (ICU flags)
- `internal/cmd` test failures are **pre-existing on main** (the same set — TestCreateAutoConvoy_BasicSuccess, TestGetTrackedIssues_FallsBackToShowTrackedDependencies, etc. — fails on unmodified origin/main)
- Live: this is the carry build now driving a real cross-DB mountain (hq convoy tracking bizsearch beads via depends_on_external)

## Follow-up (not in this PR)

Sibling `depends_on_id` sites in other subsystems remain and should get a focused, carefully-tested change (they mutate data): `compact.go` `cleanOrphanedWispDeps` (DELETE) and `doctor/misclassified_wisp_check.go` (INSERT backfill).