### PR TITLE
fix: stale-binary compares against build branch, not feature HEAD (#4034)

### DIFF
--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -291,7 +291,11 @@ func checkStaleBinaryWarning() {
 
 		msg := info.Describe("gt binary")
 		fmt.Fprintf(os.Stderr, "%s %s\n", style.WarningPrefix, msg)
-		fmt.Fprintf(os.Stderr, "    %s Run 'make install' in gastown repo to update\n", style.ArrowPrefix)
+		if info.IsForward && info.OnMainBranch {
+			fmt.Fprintf(os.Stderr, "    %s Run 'make install' in gastown repo to update\n", style.ArrowPrefix)
+		} else {
+			fmt.Fprintf(os.Stderr, "    %s Run 'gt stale' for details; switch to a build branch before rebuilding\n", style.ArrowPrefix)
+		}
 	}
 }
 

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -289,12 +289,7 @@ func checkStaleBinaryWarning() {
 		staleBinaryWarned = true
 		_ = os.Setenv("GT_STALE_WARNED", "1")
 
-		msg := fmt.Sprintf("gt binary is stale (built from %s, %s at %s)",
-			version.ShortCommit(info.BinaryCommit), info.CompareRef, version.ShortCommit(info.RepoCommit))
-		if info.CommitsBehind > 0 {
-			msg = fmt.Sprintf("gt binary is %d commits behind %s (built from %s, %s at %s)",
-				info.CommitsBehind, info.CompareRef, version.ShortCommit(info.BinaryCommit), info.CompareRef, version.ShortCommit(info.RepoCommit))
-		}
+		msg := info.Describe("gt binary")
 		fmt.Fprintf(os.Stderr, "%s %s\n", style.WarningPrefix, msg)
 		fmt.Fprintf(os.Stderr, "    %s Run 'make install' in gastown repo to update\n", style.ArrowPrefix)
 	}

--- a/internal/cmd/root.go
+++ b/internal/cmd/root.go
@@ -289,11 +289,11 @@ func checkStaleBinaryWarning() {
 		staleBinaryWarned = true
 		_ = os.Setenv("GT_STALE_WARNED", "1")
 
-		msg := fmt.Sprintf("gt binary is stale (built from %s, repo at %s)",
-			version.ShortCommit(info.BinaryCommit), version.ShortCommit(info.RepoCommit))
+		msg := fmt.Sprintf("gt binary is stale (built from %s, %s at %s)",
+			version.ShortCommit(info.BinaryCommit), info.CompareRef, version.ShortCommit(info.RepoCommit))
 		if info.CommitsBehind > 0 {
-			msg = fmt.Sprintf("gt binary is %d commits behind (built from %s, repo at %s)",
-				info.CommitsBehind, version.ShortCommit(info.BinaryCommit), version.ShortCommit(info.RepoCommit))
+			msg = fmt.Sprintf("gt binary is %d commits behind %s (built from %s, %s at %s)",
+				info.CommitsBehind, info.CompareRef, version.ShortCommit(info.BinaryCommit), info.CompareRef, version.ShortCommit(info.RepoCommit))
 		}
 		fmt.Fprintf(os.Stderr, "%s %s\n", style.WarningPrefix, msg)
 		fmt.Fprintf(os.Stderr, "    %s Run 'make install' in gastown repo to update\n", style.ArrowPrefix)

--- a/internal/cmd/stale.go
+++ b/internal/cmd/stale.go
@@ -48,7 +48,10 @@ type StaleOutput struct {
 	SafeToRebuild bool   `json:"safe_to_rebuild"`
 	BinaryCommit  string `json:"binary_commit"`
 	RepoCommit    string `json:"repo_commit"`
+	CompareRef    string `json:"compare_ref,omitempty"`
 	CommitsBehind int    `json:"commits_behind,omitempty"`
+	Skipped       bool   `json:"skipped,omitempty"`
+	SkipReason    string `json:"skip_reason,omitempty"`
 	Error         string `json:"error,omitempty"`
 }
 
@@ -97,7 +100,10 @@ func runStale(cmd *cobra.Command, args []string) error {
 		SafeToRebuild: safeToRebuild,
 		BinaryCommit:  info.BinaryCommit,
 		RepoCommit:    info.RepoCommit,
+		CompareRef:    info.CompareRef,
 		CommitsBehind: info.CommitsBehind,
+		Skipped:       info.Skipped,
+		SkipReason:    info.SkipReason,
 	}
 
 	if staleJSON {
@@ -114,18 +120,24 @@ func outputStaleJSON(output StaleOutput) error {
 }
 
 func outputStaleText(output StaleOutput) error {
+	if output.Skipped {
+		fmt.Printf("%s Binary staleness check skipped\n", style.Dim.Render("•"))
+		fmt.Printf("  %s\n", output.SkipReason)
+		fmt.Printf("  Binary: %s\n", version.ShortCommit(output.BinaryCommit))
+		return nil
+	}
 	if output.Stale {
 		fmt.Printf("%s Binary is stale\n", style.Warning.Render("⚠"))
-		fmt.Printf("  Binary: %s\n", version.ShortCommit(output.BinaryCommit))
-		fmt.Printf("  Repo:   %s\n", version.ShortCommit(output.RepoCommit))
+		fmt.Printf("  Binary:   %s\n", version.ShortCommit(output.BinaryCommit))
+		fmt.Printf("  Build ref (%s): %s\n", output.CompareRef, version.ShortCommit(output.RepoCommit))
 		if output.CommitsBehind > 0 {
-			fmt.Printf("  %s\n", style.Dim.Render(fmt.Sprintf("(%d commits behind)", output.CommitsBehind)))
+			fmt.Printf("  %s\n", style.Dim.Render(fmt.Sprintf("(%d commits behind %s)", output.CommitsBehind, output.CompareRef)))
 		}
 		if !output.Forward {
-			fmt.Printf("  %s repo HEAD is NOT a descendant of binary commit (diverged or older)\n", style.Error.Render("✗"))
+			fmt.Printf("  %s %s is NOT a descendant of binary commit (diverged or older)\n", style.Error.Render("✗"), output.CompareRef)
 		}
 		if !output.OnMainBranch {
-			fmt.Printf("  %s repo is not on main branch\n", style.Warning.Render("⚠"))
+			fmt.Printf("  %s source worktree is not on a build branch (compared against %s)\n", style.Warning.Render("⚠"), output.CompareRef)
 		}
 		if output.SafeToRebuild {
 			fmt.Printf("\n  Safe to rebuild: run 'make build && make install'\n")
@@ -136,6 +148,9 @@ func outputStaleText(output StaleOutput) error {
 	} else {
 		fmt.Printf("%s Binary is fresh\n", style.Success.Render("✓"))
 		fmt.Printf("  Commit: %s\n", version.ShortCommit(output.BinaryCommit))
+		if output.CompareRef != "" {
+			fmt.Printf("  %s\n", style.Dim.Render(fmt.Sprintf("(compared against %s)", output.CompareRef)))
+		}
 	}
 	return nil
 }

--- a/internal/cmd/stale.go
+++ b/internal/cmd/stale.go
@@ -17,26 +17,26 @@ var staleCmd = &cobra.Command{
 	Use:     "stale",
 	GroupID: GroupDiag,
 	Short:   "Check if the gt binary is stale",
-	Long: `Check if the gt binary was built from an older commit than the current repo HEAD.
+	Long: `Check if the gt binary was built from an older commit than a build ref.
 
 This command compares the commit hash embedded in the binary at build time
-with the current HEAD of the gastown repository.
+with the resolved build branch of the gastown repository (main/master/carry/*).
 
 Examples:
   gt stale              # Human-readable output
   gt stale --json       # Machine-readable JSON output
-  gt stale --quiet      # Exit code only (0=stale, 1=fresh)
+  gt stale --quiet      # Exit code only (0=stale, 1=fresh, 2=undetermined)
 
 Exit codes:
-  0 - Binary is stale (needs rebuild)
+  0 - Binary is stale
   1 - Binary is fresh (up to date)
-  2 - Error (could not determine staleness)`,
+  2 - Error or skipped (could not determine staleness)`,
 	RunE: runStale,
 }
 
 func init() {
 	staleCmd.Flags().BoolVar(&staleJSON, "json", false, "Output as JSON")
-	staleCmd.Flags().BoolVarP(&staleQuiet, "quiet", "q", false, "Exit code only (0=stale, 1=fresh)")
+	staleCmd.Flags().BoolVarP(&staleQuiet, "quiet", "q", false, "Exit code only (0=stale, 1=fresh, 2=undetermined)")
 	rootCmd.AddCommand(staleCmd)
 }
 
@@ -84,14 +84,11 @@ func runStale(cmd *cobra.Command, args []string) error {
 
 	// Quiet mode: just exit with appropriate code
 	if staleQuiet {
-		if info.IsStale {
-			return NewSilentExit(0)
-		}
-		return NewSilentExit(1)
+		return NewSilentExit(staleQuietExitCode(info))
 	}
 
 	// Build output
-	// SafeToRebuild requires: stale + forward-only + on main branch
+	// SafeToRebuild requires: stale + forward-only + on a build branch.
 	safeToRebuild := info.IsStale && info.IsForward && info.OnMainBranch
 	output := StaleOutput{
 		Stale:         info.IsStale,
@@ -111,6 +108,16 @@ func runStale(cmd *cobra.Command, args []string) error {
 	}
 
 	return outputStaleText(output)
+}
+
+func staleQuietExitCode(info *version.StaleBinaryInfo) int {
+	if info.Skipped {
+		return 2
+	}
+	if info.IsStale {
+		return 0
+	}
+	return 1
 }
 
 func outputStaleJSON(output StaleOutput) error {
@@ -142,7 +149,7 @@ func outputStaleText(output StaleOutput) error {
 		if output.SafeToRebuild {
 			fmt.Printf("\n  Safe to rebuild: run 'make build && make install'\n")
 		} else {
-			fmt.Printf("\n  %s NOT safe for automated rebuild (forward=%v, main=%v)\n",
+			fmt.Printf("\n  %s NOT safe for automated rebuild (forward=%v, build_branch=%v)\n",
 				style.Error.Render("✗"), output.Forward, output.OnMainBranch)
 		}
 	} else {

--- a/internal/cmd/stale_test.go
+++ b/internal/cmd/stale_test.go
@@ -3,6 +3,8 @@ package cmd
 import (
 	"strings"
 	"testing"
+
+	"github.com/steveyegge/gastown/internal/version"
 )
 
 // TestOutputStaleText exercises the pure text renderer for `gt stale`,
@@ -53,7 +55,7 @@ func TestOutputStaleText(t *testing.T) {
 				"(3 commits behind main)",
 				"main is NOT a descendant of binary commit",
 				"source worktree is not on a build branch (compared against main)",
-				"NOT safe for automated rebuild (forward=false, main=false)",
+				"NOT safe for automated rebuild (forward=false, build_branch=false)",
 			},
 			notWant: []string{"Safe to rebuild: run"},
 		},
@@ -121,6 +123,25 @@ func TestOutputStaleText(t *testing.T) {
 				if strings.Contains(out, nw) {
 					t.Errorf("output unexpectedly contains %q\n--- got ---\n%s", nw, out)
 				}
+			}
+		})
+	}
+}
+
+func TestStaleQuietExitCode(t *testing.T) {
+	tests := []struct {
+		name string
+		info *version.StaleBinaryInfo
+		want int
+	}{
+		{name: "skipped is undetermined", info: &version.StaleBinaryInfo{Skipped: true}, want: 2},
+		{name: "stale", info: &version.StaleBinaryInfo{IsStale: true}, want: 0},
+		{name: "fresh", info: &version.StaleBinaryInfo{}, want: 1},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := staleQuietExitCode(tt.info); got != tt.want {
+				t.Errorf("staleQuietExitCode() = %d, want %d", got, tt.want)
 			}
 		})
 	}

--- a/internal/cmd/stale_test.go
+++ b/internal/cmd/stale_test.go
@@ -1,0 +1,127 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestOutputStaleText exercises the pure text renderer for `gt stale`,
+// covering the Skipped / Stale / Fresh branches added for GH#4034.
+// It asserts on the unstyled literal substrings (style.Render only wraps
+// the leading glyph, not the message text) so it is colour-agnostic.
+//
+// Note: outputStaleText is a plain function; this test never executes the
+// cobra command tree, so the macOS unsigned-binary guard in
+// persistentPreRun is not tripped. Run targeted (`-run TestOutputStaleText`)
+// to avoid sibling tests that do execute commands.
+func TestOutputStaleText(t *testing.T) {
+	tests := []struct {
+		name    string
+		output  StaleOutput
+		want    []string // substrings that must be present
+		notWant []string // substrings that must be absent
+	}{
+		{
+			name: "skipped names the reason and binary",
+			output: StaleOutput{
+				Skipped:      true,
+				SkipReason:   "source worktree not on a build branch",
+				BinaryCommit: "abc1234567890",
+			},
+			want: []string{
+				"Binary staleness check skipped",
+				"source worktree not on a build branch",
+				"abc123456789",
+			},
+			notWant: []string{"Binary is stale", "Binary is fresh"},
+		},
+		{
+			name: "stale, behind, diverged, off build branch, unsafe",
+			output: StaleOutput{
+				Stale:         true,
+				Forward:       false,
+				OnMainBranch:  false,
+				SafeToRebuild: false,
+				BinaryCommit:  "abc1234567890",
+				RepoCommit:    "def4567890123",
+				CompareRef:    "main",
+				CommitsBehind: 3,
+			},
+			want: []string{
+				"Binary is stale",
+				"Build ref (main): def456789012",
+				"(3 commits behind main)",
+				"main is NOT a descendant of binary commit",
+				"source worktree is not on a build branch (compared against main)",
+				"NOT safe for automated rebuild (forward=false, main=false)",
+			},
+			notWant: []string{"Safe to rebuild: run"},
+		},
+		{
+			name: "stale, forward, on build branch, safe to rebuild",
+			output: StaleOutput{
+				Stale:         true,
+				Forward:       true,
+				OnMainBranch:  true,
+				SafeToRebuild: true,
+				BinaryCommit:  "abc1234567890",
+				RepoCommit:    "def4567890123",
+				CompareRef:    "carry/ops",
+			},
+			want: []string{
+				"Binary is stale",
+				"Build ref (carry/ops): def456789012",
+				"Safe to rebuild: run 'make build && make install'",
+			},
+			notWant: []string{
+				"commits behind",
+				"NOT a descendant",
+				"not on a build branch",
+				"NOT safe for automated rebuild",
+			},
+		},
+		{
+			name: "fresh with compare ref",
+			output: StaleOutput{
+				Stale:        false,
+				BinaryCommit: "abc1234567890",
+				CompareRef:   "origin/main",
+			},
+			want: []string{
+				"Binary is fresh",
+				"Commit: abc123456789",
+				"(compared against origin/main)",
+			},
+			notWant: []string{"Binary is stale", "skipped"},
+		},
+		{
+			name: "fresh without compare ref omits the comparison line",
+			output: StaleOutput{
+				Stale:        false,
+				BinaryCommit: "abc1234567890",
+			},
+			want:    []string{"Binary is fresh", "Commit: abc123456789"},
+			notWant: []string{"compared against"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var err error
+			out := captureStdout(t, func() { err = outputStaleText(tt.output) })
+			if err != nil {
+				t.Fatalf("outputStaleText returned error: %v", err)
+			}
+			for _, w := range tt.want {
+				if !strings.Contains(out, w) {
+					t.Errorf("output missing %q\n--- got ---\n%s", w, out)
+				}
+			}
+			for _, nw := range tt.notWant {
+				if strings.Contains(out, nw) {
+					t.Errorf("output unexpectedly contains %q\n--- got ---\n%s", nw, out)
+				}
+			}
+		})
+	}
+}

--- a/internal/doctor/stale_binary_check.go
+++ b/internal/doctor/stale_binary_check.go
@@ -66,7 +66,7 @@ func staleResult(name string, info *version.StaleBinaryInfo) *CheckResult {
 			Name:    name,
 			Status:  StatusWarning,
 			Message: info.Describe("Binary"),
-			FixHint: "Run 'gt install' to rebuild and install",
+			FixHint: staleFixHint(info),
 		}
 	}
 
@@ -75,6 +75,13 @@ func staleResult(name string, info *version.StaleBinaryInfo) *CheckResult {
 		Status:  StatusOK,
 		Message: fmt.Sprintf("Binary is up to date (%s)", version.ShortCommit(info.BinaryCommit)),
 	}
+}
+
+func staleFixHint(info *version.StaleBinaryInfo) string {
+	if info.IsForward && info.OnMainBranch {
+		return "Run 'gt install' to rebuild and install"
+	}
+	return "Run 'gt stale' for details; switch to a build branch before rebuilding"
 }
 
 // Fix rebuilds and installs gt.

--- a/internal/doctor/stale_binary_check.go
+++ b/internal/doctor/stale_binary_check.go
@@ -36,10 +36,16 @@ func (c *StaleBinaryCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
-	info := version.CheckStaleBinary(repoRoot)
+	return staleResult(c.Name(), version.CheckStaleBinary(repoRoot))
+}
+
+// staleResult maps a completed staleness check to a doctor CheckResult.
+// It is pure (no git/env access) so it can be unit-tested directly; Run only
+// handles repo resolution before delegating here.
+func staleResult(name string, info *version.StaleBinaryInfo) *CheckResult {
 	if info.Error != nil {
 		return &CheckResult{
-			Name:    c.Name(),
+			Name:    name,
 			Status:  StatusOK,
 			Message: "Cannot determine binary version (dev build?)",
 			Details: []string{info.Error.Error()},
@@ -48,7 +54,7 @@ func (c *StaleBinaryCheck) Run(ctx *CheckContext) *CheckResult {
 
 	if info.Skipped {
 		return &CheckResult{
-			Name:    c.Name(),
+			Name:    name,
 			Status:  StatusOK,
 			Message: "Binary staleness check skipped",
 			Details: []string{info.SkipReason},
@@ -56,23 +62,16 @@ func (c *StaleBinaryCheck) Run(ctx *CheckContext) *CheckResult {
 	}
 
 	if info.IsStale {
-		msg := fmt.Sprintf("Binary is stale (built from %s, %s at %s)",
-			version.ShortCommit(info.BinaryCommit), info.CompareRef, version.ShortCommit(info.RepoCommit))
-		if info.CommitsBehind > 0 {
-			msg = fmt.Sprintf("Binary is %d commits behind %s (built from %s, %s at %s)",
-				info.CommitsBehind, info.CompareRef, version.ShortCommit(info.BinaryCommit), info.CompareRef, version.ShortCommit(info.RepoCommit))
-		}
-
 		return &CheckResult{
-			Name:    c.Name(),
+			Name:    name,
 			Status:  StatusWarning,
-			Message: msg,
+			Message: info.Describe("Binary"),
 			FixHint: "Run 'gt install' to rebuild and install",
 		}
 	}
 
 	return &CheckResult{
-		Name:    c.Name(),
+		Name:    name,
 		Status:  StatusOK,
 		Message: fmt.Sprintf("Binary is up to date (%s)", version.ShortCommit(info.BinaryCommit)),
 	}

--- a/internal/doctor/stale_binary_check.go
+++ b/internal/doctor/stale_binary_check.go
@@ -46,12 +46,21 @@ func (c *StaleBinaryCheck) Run(ctx *CheckContext) *CheckResult {
 		}
 	}
 
+	if info.Skipped {
+		return &CheckResult{
+			Name:    c.Name(),
+			Status:  StatusOK,
+			Message: "Binary staleness check skipped",
+			Details: []string{info.SkipReason},
+		}
+	}
+
 	if info.IsStale {
-		msg := fmt.Sprintf("Binary is stale (built from %s, repo at %s)",
-			version.ShortCommit(info.BinaryCommit), version.ShortCommit(info.RepoCommit))
+		msg := fmt.Sprintf("Binary is stale (built from %s, %s at %s)",
+			version.ShortCommit(info.BinaryCommit), info.CompareRef, version.ShortCommit(info.RepoCommit))
 		if info.CommitsBehind > 0 {
-			msg = fmt.Sprintf("Binary is %d commits behind (built from %s, repo at %s)",
-				info.CommitsBehind, version.ShortCommit(info.BinaryCommit), version.ShortCommit(info.RepoCommit))
+			msg = fmt.Sprintf("Binary is %d commits behind %s (built from %s, %s at %s)",
+				info.CommitsBehind, info.CompareRef, version.ShortCommit(info.BinaryCommit), info.CompareRef, version.ShortCommit(info.RepoCommit))
 		}
 
 		return &CheckResult{

--- a/internal/doctor/stale_binary_check_test.go
+++ b/internal/doctor/stale_binary_check_test.go
@@ -1,0 +1,92 @@
+package doctor
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/version"
+)
+
+// TestStaleResult covers the pure info -> CheckResult mapping. Run() itself is
+// not unit-tested because it depends on version.GetRepoRoot() (env/git driven);
+// the testable logic lives in staleResult.
+func TestStaleResult(t *testing.T) {
+	const name = "stale-binary"
+
+	tests := []struct {
+		name        string
+		info        *version.StaleBinaryInfo
+		wantStatus  CheckStatus
+		wantMessage string
+		wantDetail  string // substring expected in Details[0]; "" => no details required
+		wantFixHint bool
+	}{
+		{
+			name:        "error -> OK dev-build message",
+			info:        &version.StaleBinaryInfo{Error: errors.New("cannot determine binary commit")},
+			wantStatus:  StatusOK,
+			wantMessage: "Cannot determine binary version (dev build?)",
+			wantDetail:  "cannot determine binary commit",
+		},
+		{
+			name:        "skipped -> OK with skip reason",
+			info:        &version.StaleBinaryInfo{Skipped: true, SkipReason: "no build-branch ref found"},
+			wantStatus:  StatusOK,
+			wantMessage: "Binary staleness check skipped",
+			wantDetail:  "no build-branch ref found",
+		},
+		{
+			name: "stale with count -> Warning + fix hint",
+			info: &version.StaleBinaryInfo{
+				IsStale: true, CommitsBehind: 2, CompareRef: "main",
+				BinaryCommit: "abc1234567890", RepoCommit: "def4567890123",
+			},
+			wantStatus:  StatusWarning,
+			wantMessage: "Binary is 2 commits behind main (built from abc123456789, main at def456789012)",
+			wantFixHint: true,
+		},
+		{
+			name: "stale without count -> Warning, stale wording",
+			info: &version.StaleBinaryInfo{
+				IsStale: true, CompareRef: "origin/main",
+				BinaryCommit: "abc1234567890", RepoCommit: "def4567890123",
+			},
+			wantStatus:  StatusWarning,
+			wantMessage: "Binary is stale (built from abc123456789, origin/main at def456789012)",
+			wantFixHint: true,
+		},
+		{
+			name:        "fresh -> OK up to date",
+			info:        &version.StaleBinaryInfo{BinaryCommit: "abc1234567890"},
+			wantStatus:  StatusOK,
+			wantMessage: "Binary is up to date (abc123456789)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := staleResult(name, tt.info)
+			if got.Name != name {
+				t.Errorf("Name = %q, want %q", got.Name, name)
+			}
+			if got.Status != tt.wantStatus {
+				t.Errorf("Status = %v, want %v", got.Status, tt.wantStatus)
+			}
+			if got.Message != tt.wantMessage {
+				t.Errorf("Message = %q, want %q", got.Message, tt.wantMessage)
+			}
+			if tt.wantDetail != "" {
+				if len(got.Details) == 0 || !strings.Contains(got.Details[0], tt.wantDetail) {
+					t.Errorf("Details = %v, want one containing %q", got.Details, tt.wantDetail)
+				}
+			}
+			if tt.wantFixHint && got.FixHint == "" {
+				t.Error("expected a FixHint for a stale binary, got none")
+			}
+			if !tt.wantFixHint && got.FixHint != "" {
+				t.Errorf("unexpected FixHint %q", got.FixHint)
+			}
+		})
+	}
+}

--- a/internal/doctor/stale_binary_check_test.go
+++ b/internal/doctor/stale_binary_check_test.go
@@ -20,7 +20,7 @@ func TestStaleResult(t *testing.T) {
 		wantStatus  CheckStatus
 		wantMessage string
 		wantDetail  string // substring expected in Details[0]; "" => no details required
-		wantFixHint bool
+		wantFixHint string
 	}{
 		{
 			name:        "error -> OK dev-build message",
@@ -39,22 +39,23 @@ func TestStaleResult(t *testing.T) {
 		{
 			name: "stale with count -> Warning + fix hint",
 			info: &version.StaleBinaryInfo{
-				IsStale: true, CommitsBehind: 2, CompareRef: "main",
+				IsStale: true, IsForward: true, OnMainBranch: true,
+				CommitsBehind: 2, CompareRef: "main",
 				BinaryCommit: "abc1234567890", RepoCommit: "def4567890123",
 			},
 			wantStatus:  StatusWarning,
 			wantMessage: "Binary is 2 commits behind main (built from abc123456789, main at def456789012)",
-			wantFixHint: true,
+			wantFixHint: "gt install",
 		},
 		{
-			name: "stale without count -> Warning, stale wording",
+			name: "stale off build branch -> Warning, qualified fix hint",
 			info: &version.StaleBinaryInfo{
 				IsStale: true, CompareRef: "origin/main",
 				BinaryCommit: "abc1234567890", RepoCommit: "def4567890123",
 			},
 			wantStatus:  StatusWarning,
 			wantMessage: "Binary is stale (built from abc123456789, origin/main at def456789012)",
-			wantFixHint: true,
+			wantFixHint: "switch to a build branch",
 		},
 		{
 			name:        "fresh -> OK up to date",
@@ -81,10 +82,10 @@ func TestStaleResult(t *testing.T) {
 					t.Errorf("Details = %v, want one containing %q", got.Details, tt.wantDetail)
 				}
 			}
-			if tt.wantFixHint && got.FixHint == "" {
-				t.Error("expected a FixHint for a stale binary, got none")
+			if tt.wantFixHint != "" && !strings.Contains(got.FixHint, tt.wantFixHint) {
+				t.Errorf("FixHint = %q, want substring %q", got.FixHint, tt.wantFixHint)
 			}
-			if !tt.wantFixHint && got.FixHint != "" {
+			if tt.wantFixHint == "" && got.FixHint != "" {
 				t.Errorf("unexpected FixHint %q", got.FixHint)
 			}
 		})

--- a/internal/version/stale.go
+++ b/internal/version/stale.go
@@ -27,9 +27,15 @@ type StaleBinaryInfo struct {
 	RepoCommit    string // Commit of the ref the binary was compared against (CompareRef)
 	CompareRef    string // The ref staleness was computed against (e.g. "main", "origin/main")
 	CommitsBehind int    // Number of commits binary is behind (0 if unknown)
-	Skipped       bool   // True if no build-branch ref could be resolved to compare against
+	Skipped       bool   // True if staleness could not be determined safely
 	SkipReason    string // Human-readable reason the check was skipped
 	Error         error  // Any error encountered during check
+}
+
+type buildBranchRef struct {
+	ref     string
+	display string
+	commit  string
 }
 
 // resolveCommitHash gets the commit hash from build info or the Commit variable.
@@ -90,10 +96,10 @@ func commitsMatch(a, b string) bool {
 	return strings.HasPrefix(a, b[:minLen]) || strings.HasPrefix(b, a[:minLen])
 }
 
-// CheckStaleBinary compares the binary's embedded commit with the repo HEAD.
-// It returns staleness info including whether the binary needs rebuilding.
-// This check is designed to be fast and non-blocking - errors are captured
-// but don't interrupt normal operation.
+// CheckStaleBinary compares the binary's embedded commit with a build-branch
+// ref. It returns staleness info including whether the binary needs rebuilding.
+// This check is designed to be fast and non-blocking - errors are captured but
+// don't interrupt normal operation.
 func CheckStaleBinary(repoDir string) *StaleBinaryInfo {
 	info := &StaleBinaryInfo{}
 
@@ -101,6 +107,16 @@ func CheckStaleBinary(repoDir string) *StaleBinaryInfo {
 	info.BinaryCommit = resolveCommitHash()
 	if info.BinaryCommit == "" {
 		info.Error = fmt.Errorf("cannot determine binary commit (dev build?)")
+		return info
+	}
+	if !isGitRepo(repoDir) {
+		info.Error = fmt.Errorf("source repo %q is not a git worktree", repoDir)
+		return info
+	}
+	binaryCommit, err := resolveGitCommit(repoDir, info.BinaryCommit)
+	if err != nil {
+		info.Skipped = true
+		info.SkipReason = "binary commit not found in source repo; cannot compare staleness"
 		return info
 	}
 
@@ -123,52 +139,35 @@ func CheckStaleBinary(repoDir string) *StaleBinaryInfo {
 	// feature work and produces a false "N commits behind" warning advising a
 	// rebuild from the feature branch (GH#4034). Staleness is only meaningful
 	// relative to a *build branch*.
-	var compareRef string
+	var compareCommit string
 	if info.OnMainBranch {
 		// Already on a build branch — its HEAD is the build branch.
-		compareRef = "HEAD"
 		info.CompareRef = branch
+		compareCommit, err = resolveGitCommit(repoDir, "HEAD")
+		if err != nil {
+			info.Error = fmt.Errorf("cannot resolve build branch HEAD: %w", err)
+			return info
+		}
 	} else {
 		// Resolve a real build-branch ref instead of the feature HEAD.
-		ref, ok := resolveBuildBranchRef(repoDir, info.BinaryCommit)
+		ref, ok := resolveBuildBranchRef(repoDir, binaryCommit)
 		if !ok {
 			info.Skipped = true
 			info.SkipReason = "source worktree not on a build branch and no build-branch ref found to compare against"
 			return info
 		}
-		compareRef = ref
-		info.CompareRef = ref
+		info.CompareRef = ref.display
+		compareCommit = ref.commit
 	}
-
-	// Resolve the compare ref to a commit hash.
-	revCmd := exec.Command("git", "rev-parse", compareRef)
-	revCmd.Dir = repoDir
-	util.SetDetachedProcessGroup(revCmd)
-	output, err := revCmd.Output()
-	if err != nil {
-		info.Error = fmt.Errorf("cannot resolve compare ref %q: %w", compareRef, err)
-		return info
-	}
-	info.RepoCommit = strings.TrimSpace(string(output))
+	info.RepoCommit = compareCommit
 
 	// Compare commits using prefix matching (handles short vs full hash)
 	// Use the shorter of the two commit lengths for comparison
 	if !commitsMatch(info.BinaryCommit, info.RepoCommit) {
-		// Verify the binary commit exists in the found repo. GetRepoRoot may
-		// find a different clone (e.g., mayor/rig) than the one the binary was
-		// built from (e.g., crew/woodhouse). If the binary commit isn't in the
-		// repo's object store, we can't determine staleness — skip.
-		verifyCmd := exec.Command("git", "cat-file", "-t", info.BinaryCommit)
-		verifyCmd.Dir = repoDir
-		if err := verifyCmd.Run(); err != nil {
-			// Binary commit not in this repo — different clones, can't compare
-			return info
-		}
-
 		// Check if all commits between binary and the build ref only touch
 		// .beads/ files (e.g., bd backup commits). These don't affect the
 		// binary and should not trigger a stale warning. (GH#2596)
-		if onlyBeadsChanges(repoDir, info.BinaryCommit, compareRef) {
+		if onlyBeadsChanges(repoDir, binaryCommit, compareCommit) {
 			// Build ref advanced but only via beads-only commits — not stale
 			return info
 		}
@@ -179,13 +178,10 @@ func CheckStaleBinary(repoDir string) *StaleBinaryInfo {
 		// the build ref). This prevents rebuilding to an older or diverged
 		// commit, which caused a crash loop when a worktree's HEAD was behind
 		// the binary's commit.
-		ancestorCmd := exec.Command("git", "merge-base", "--is-ancestor", info.BinaryCommit, compareRef)
-		ancestorCmd.Dir = repoDir
-		util.SetDetachedProcessGroup(ancestorCmd)
-		info.IsForward = ancestorCmd.Run() == nil
+		info.IsForward = isAncestor(repoDir, binaryCommit, compareCommit)
 
 		// Try to count commits between binary and the build ref
-		countCmd := exec.Command("git", "rev-list", "--count", info.BinaryCommit+".."+compareRef)
+		countCmd := exec.Command("git", "rev-list", "--count", binaryCommit+".."+compareCommit)
 		countCmd.Dir = repoDir
 		util.SetDetachedProcessGroup(countCmd)
 		if countOutput, err := countCmd.Output(); err == nil {
@@ -203,39 +199,73 @@ func CheckStaleBinary(repoDir string) *StaleBinaryInfo {
 // state for $GT_ROOT/gastown/mayor/rig). Without this, staleness would be
 // computed against unmerged feature work (GH#4034).
 //
-// Candidates are tried in build-branch precedence order; the first that both
-// (a) resolves to a commit and (b) has binaryCommit as an ancestor is returned.
-// Requiring binaryCommit to be an ancestor ensures we compare against the branch
-// the binary was actually built from — e.g. it routes a fork build to its
-// carry/* operational branch rather than a stale local main.
-func resolveBuildBranchRef(repoDir, binaryCommit string) (string, bool) {
-	candidates := []string{"main", "master"}
-
-	// Fork operational branch: include a local carry/* branch, but only if
-	// exactly one exists (ambiguous otherwise — don't guess).
-	if c, ok := singleCarryBranch(repoDir); ok {
-		candidates = append(candidates, c)
+// Candidate refs are fully qualified to avoid branch/tag shadowing. Among refs
+// that contain the binary commit, choose the freshest descendant; only use the
+// candidate order below to break truly diverged ties.
+func resolveBuildBranchRef(repoDir, binaryCommit string) (buildBranchRef, bool) {
+	var usable []buildBranchRef
+	for _, candidate := range buildBranchCandidates(repoDir) {
+		commit, err := resolveGitCommit(repoDir, candidate.ref)
+		if err != nil || !isAncestor(repoDir, binaryCommit, commit) {
+			continue
+		}
+		candidate.commit = commit
+		usable = append(usable, candidate)
+	}
+	if len(usable) == 0 {
+		return buildBranchRef{}, false
 	}
 
-	candidates = append(candidates,
-		"origin/main", "origin/master",
-		"upstream/main", "upstream/master",
-	)
-
-	for _, ref := range candidates {
-		if refExists(repoDir, ref) && isAncestor(repoDir, binaryCommit, ref) {
-			return ref, true
+	frontier := make([]buildBranchRef, 0, len(usable))
+	for i, candidate := range usable {
+		older := false
+		for j, other := range usable {
+			if i == j || candidate.commit == other.commit {
+				continue
+			}
+			if isAncestor(repoDir, candidate.commit, other.commit) {
+				older = true
+				break
+			}
+		}
+		if !older {
+			frontier = append(frontier, candidate)
 		}
 	}
-	return "", false
+	return frontier[0], true
 }
 
-// refExists reports whether ref resolves to a commit in repoDir.
-func refExists(repoDir, ref string) bool {
-	cmd := exec.Command("git", "rev-parse", "--verify", "--quiet", ref+"^{commit}")
+func buildBranchCandidates(repoDir string) []buildBranchRef {
+	candidates := make([]buildBranchRef, 0, 10)
+	for _, pattern := range []string{
+		"refs/heads/carry/",
+		"refs/remotes/upstream/carry/",
+		"refs/remotes/origin/carry/",
+	} {
+		if ref, ok := singleBranchRef(repoDir, pattern); ok {
+			candidates = append(candidates, ref)
+		}
+	}
+	candidates = append(candidates,
+		buildBranchRef{ref: "refs/remotes/upstream/main", display: "upstream/main"},
+		buildBranchRef{ref: "refs/remotes/upstream/master", display: "upstream/master"},
+		buildBranchRef{ref: "refs/remotes/origin/main", display: "origin/main"},
+		buildBranchRef{ref: "refs/remotes/origin/master", display: "origin/master"},
+		buildBranchRef{ref: "refs/heads/main", display: "main"},
+		buildBranchRef{ref: "refs/heads/master", display: "master"},
+	)
+	return candidates
+}
+
+func resolveGitCommit(repoDir, rev string) (string, error) {
+	cmd := exec.Command("git", "rev-parse", "--verify", "--quiet", "--end-of-options", rev+"^{commit}")
 	cmd.Dir = repoDir
 	util.SetDetachedProcessGroup(cmd)
-	return cmd.Run() == nil
+	output, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(output)), nil
 }
 
 // isAncestor reports whether ancestor is an ancestor of ref (a commit is its
@@ -247,21 +277,23 @@ func isAncestor(repoDir, ancestor, ref string) bool {
 	return cmd.Run() == nil
 }
 
-// singleCarryBranch returns the sole local carry/* branch, if exactly one
-// exists. Multiple carry/* branches are ambiguous and yield ("", false).
-func singleCarryBranch(repoDir string) (string, bool) {
-	cmd := exec.Command("git", "for-each-ref", "--format=%(refname:short)", "refs/heads/carry/")
+// singleBranchRef returns the sole matching branch/ref, if exactly one exists.
+// Multiple matches are ambiguous and yield false.
+func singleBranchRef(repoDir, pattern string) (buildBranchRef, bool) {
+	cmd := exec.Command("git", "for-each-ref", "--format=%(refname)", pattern)
 	cmd.Dir = repoDir
 	util.SetDetachedProcessGroup(cmd)
 	out, err := cmd.Output()
 	if err != nil {
-		return "", false
+		return buildBranchRef{}, false
 	}
-	branches := strings.Fields(strings.TrimSpace(string(out)))
-	if len(branches) == 1 {
-		return branches[0], true
+	refs := strings.Fields(strings.TrimSpace(string(out)))
+	if len(refs) != 1 {
+		return buildBranchRef{}, false
 	}
-	return "", false
+	display := strings.TrimPrefix(refs[0], "refs/heads/")
+	display = strings.TrimPrefix(display, "refs/remotes/")
+	return buildBranchRef{ref: refs[0], display: display}, true
 }
 
 // GetRepoRoot returns the git repository root for the gt source code.
@@ -315,10 +347,11 @@ func GetRepoRoot() (string, error) {
 
 // isGitRepo checks if a directory is a git repository.
 func isGitRepo(dir string) bool {
-	cmd := exec.Command("git", "rev-parse", "--git-dir")
+	cmd := exec.Command("git", "rev-parse", "--is-inside-work-tree")
 	cmd.Dir = dir
 	util.SetDetachedProcessGroup(cmd)
-	return cmd.Run() == nil
+	output, err := cmd.Output()
+	return err == nil && strings.TrimSpace(string(output)) == "true"
 }
 
 // hasGtSource checks if a directory contains the gt source code.

--- a/internal/version/stale.go
+++ b/internal/version/stale.go
@@ -49,6 +49,25 @@ func resolveCommitHash() string {
 	return ""
 }
 
+// Describe returns a one-line, human-readable staleness summary for a stale
+// binary, using subject as the leading noun so callers can vary it
+// ("Binary" for gt doctor, "gt binary" for the startup warning):
+//
+//	"Binary is 3 commits behind main (built from abc123…, main at def456…)"
+//	"gt binary is stale (built from abc123…, origin/main at def456…)"
+//
+// It is only meaningful when i.IsStale; callers gate on that. A zero
+// CommitsBehind (count unknown) falls back to the "is stale" wording.
+func (i *StaleBinaryInfo) Describe(subject string) string {
+	if i.CommitsBehind > 0 {
+		return fmt.Sprintf("%s is %d commits behind %s (built from %s, %s at %s)",
+			subject, i.CommitsBehind, i.CompareRef,
+			ShortCommit(i.BinaryCommit), i.CompareRef, ShortCommit(i.RepoCommit))
+	}
+	return fmt.Sprintf("%s is stale (built from %s, %s at %s)",
+		subject, ShortCommit(i.BinaryCommit), i.CompareRef, ShortCommit(i.RepoCommit))
+}
+
 // ShortCommit returns first 12 characters of a hash.
 func ShortCommit(hash string) string {
 	if len(hash) > 12 {

--- a/internal/version/stale.go
+++ b/internal/version/stale.go
@@ -20,12 +20,15 @@ var (
 
 // StaleBinaryInfo contains information about binary staleness.
 type StaleBinaryInfo struct {
-	IsStale       bool   // True if binary commit doesn't match repo HEAD
-	IsForward     bool   // True if repo HEAD is a descendant of binary commit (safe to rebuild)
-	OnMainBranch  bool   // True if the repo is on the main branch
+	IsStale       bool   // True if binary commit is behind the build-branch ref
+	IsForward     bool   // True if the compare commit is a descendant of binary commit (safe to rebuild)
+	OnMainBranch  bool   // True if the resolved source worktree is on a build branch
 	BinaryCommit  string // Commit hash the binary was built from
-	RepoCommit    string // Current repo HEAD commit
+	RepoCommit    string // Commit of the ref the binary was compared against (CompareRef)
+	CompareRef    string // The ref staleness was computed against (e.g. "main", "origin/main")
 	CommitsBehind int    // Number of commits binary is behind (0 if unknown)
+	Skipped       bool   // True if no build-branch ref could be resolved to compare against
+	SkipReason    string // Human-readable reason the check was skipped
 	Error         error  // Any error encountered during check
 }
 
@@ -82,26 +85,52 @@ func CheckStaleBinary(repoDir string) *StaleBinaryInfo {
 		return info
 	}
 
-	// Get repo HEAD
-	cmd := exec.Command("git", "rev-parse", "HEAD")
-	cmd.Dir = repoDir
-	util.SetDetachedProcessGroup(cmd)
-	output, err := cmd.Output()
-	if err != nil {
-		info.Error = fmt.Errorf("cannot get repo HEAD: %w", err)
-		return info
-	}
-	info.RepoCommit = strings.TrimSpace(string(output))
-
-	// Check which branch the repo is on.
+	// Check which branch the resolved source worktree is on.
 	// Accept main/master (upstream) and carry/* (fork operational branches).
+	var branch string
 	branchCmd := exec.Command("git", "symbolic-ref", "--short", "HEAD")
 	branchCmd.Dir = repoDir
 	util.SetDetachedProcessGroup(branchCmd)
 	if branchOutput, err := branchCmd.Output(); err == nil {
-		branch := strings.TrimSpace(string(branchOutput))
-		info.OnMainBranch = isBuildBranch(branch)
+		branch = strings.TrimSpace(string(branchOutput))
 	}
+	info.OnMainBranch = isBuildBranch(branch)
+
+	// Decide which ref to compare the binary against.
+	//
+	// GetRepoRoot resolves to $GT_ROOT/gastown/mayor/rig, a worktree that
+	// normally sits on a feature branch (that's where the Mayor does git work).
+	// Diffing the binary against that worktree's HEAD compares it to unmerged
+	// feature work and produces a false "N commits behind" warning advising a
+	// rebuild from the feature branch (GH#4034). Staleness is only meaningful
+	// relative to a *build branch*.
+	var compareRef string
+	if info.OnMainBranch {
+		// Already on a build branch — its HEAD is the build branch.
+		compareRef = "HEAD"
+		info.CompareRef = branch
+	} else {
+		// Resolve a real build-branch ref instead of the feature HEAD.
+		ref, ok := resolveBuildBranchRef(repoDir, info.BinaryCommit)
+		if !ok {
+			info.Skipped = true
+			info.SkipReason = "source worktree not on a build branch and no build-branch ref found to compare against"
+			return info
+		}
+		compareRef = ref
+		info.CompareRef = ref
+	}
+
+	// Resolve the compare ref to a commit hash.
+	revCmd := exec.Command("git", "rev-parse", compareRef)
+	revCmd.Dir = repoDir
+	util.SetDetachedProcessGroup(revCmd)
+	output, err := revCmd.Output()
+	if err != nil {
+		info.Error = fmt.Errorf("cannot resolve compare ref %q: %w", compareRef, err)
+		return info
+	}
+	info.RepoCommit = strings.TrimSpace(string(output))
 
 	// Compare commits using prefix matching (handles short vs full hash)
 	// Use the shorter of the two commit lengths for comparison
@@ -117,26 +146,27 @@ func CheckStaleBinary(repoDir string) *StaleBinaryInfo {
 			return info
 		}
 
-		// Check if all commits between binary and HEAD only touch .beads/ files
-		// (e.g., bd backup commits). These don't affect the binary and should not
-		// trigger a stale warning. (GH#2596)
-		if onlyBeadsChanges(repoDir, info.BinaryCommit) {
-			// HEAD advanced but only via beads-only commits — not stale
+		// Check if all commits between binary and the build ref only touch
+		// .beads/ files (e.g., bd backup commits). These don't affect the
+		// binary and should not trigger a stale warning. (GH#2596)
+		if onlyBeadsChanges(repoDir, info.BinaryCommit, compareRef) {
+			// Build ref advanced but only via beads-only commits — not stale
 			return info
 		}
 
 		info.IsStale = true
 
-		// Check if this is a forward-only update (binary commit is ancestor of HEAD).
-		// This prevents rebuilding to an older or diverged commit, which caused
-		// a crash loop when a crew worktree's HEAD was behind the binary's commit.
-		ancestorCmd := exec.Command("git", "merge-base", "--is-ancestor", info.BinaryCommit, "HEAD")
+		// Check if this is a forward-only update (binary commit is ancestor of
+		// the build ref). This prevents rebuilding to an older or diverged
+		// commit, which caused a crash loop when a worktree's HEAD was behind
+		// the binary's commit.
+		ancestorCmd := exec.Command("git", "merge-base", "--is-ancestor", info.BinaryCommit, compareRef)
 		ancestorCmd.Dir = repoDir
 		util.SetDetachedProcessGroup(ancestorCmd)
 		info.IsForward = ancestorCmd.Run() == nil
 
-		// Try to count commits between binary and HEAD
-		countCmd := exec.Command("git", "rev-list", "--count", info.BinaryCommit+"..HEAD")
+		// Try to count commits between binary and the build ref
+		countCmd := exec.Command("git", "rev-list", "--count", info.BinaryCommit+".."+compareRef)
 		countCmd.Dir = repoDir
 		util.SetDetachedProcessGroup(countCmd)
 		if countOutput, err := countCmd.Output(); err == nil {
@@ -147,6 +177,72 @@ func CheckStaleBinary(repoDir string) *StaleBinaryInfo {
 	}
 
 	return info
+}
+
+// resolveBuildBranchRef finds a build-branch ref to compare the binary against
+// when the resolved source worktree is parked on a non-build branch (the normal
+// state for $GT_ROOT/gastown/mayor/rig). Without this, staleness would be
+// computed against unmerged feature work (GH#4034).
+//
+// Candidates are tried in build-branch precedence order; the first that both
+// (a) resolves to a commit and (b) has binaryCommit as an ancestor is returned.
+// Requiring binaryCommit to be an ancestor ensures we compare against the branch
+// the binary was actually built from — e.g. it routes a fork build to its
+// carry/* operational branch rather than a stale local main.
+func resolveBuildBranchRef(repoDir, binaryCommit string) (string, bool) {
+	candidates := []string{"main", "master"}
+
+	// Fork operational branch: include a local carry/* branch, but only if
+	// exactly one exists (ambiguous otherwise — don't guess).
+	if c, ok := singleCarryBranch(repoDir); ok {
+		candidates = append(candidates, c)
+	}
+
+	candidates = append(candidates,
+		"origin/main", "origin/master",
+		"upstream/main", "upstream/master",
+	)
+
+	for _, ref := range candidates {
+		if refExists(repoDir, ref) && isAncestor(repoDir, binaryCommit, ref) {
+			return ref, true
+		}
+	}
+	return "", false
+}
+
+// refExists reports whether ref resolves to a commit in repoDir.
+func refExists(repoDir, ref string) bool {
+	cmd := exec.Command("git", "rev-parse", "--verify", "--quiet", ref+"^{commit}")
+	cmd.Dir = repoDir
+	util.SetDetachedProcessGroup(cmd)
+	return cmd.Run() == nil
+}
+
+// isAncestor reports whether ancestor is an ancestor of ref (a commit is its
+// own ancestor) in repoDir.
+func isAncestor(repoDir, ancestor, ref string) bool {
+	cmd := exec.Command("git", "merge-base", "--is-ancestor", ancestor, ref)
+	cmd.Dir = repoDir
+	util.SetDetachedProcessGroup(cmd)
+	return cmd.Run() == nil
+}
+
+// singleCarryBranch returns the sole local carry/* branch, if exactly one
+// exists. Multiple carry/* branches are ambiguous and yield ("", false).
+func singleCarryBranch(repoDir string) (string, bool) {
+	cmd := exec.Command("git", "for-each-ref", "--format=%(refname:short)", "refs/heads/carry/")
+	cmd.Dir = repoDir
+	util.SetDetachedProcessGroup(cmd)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", false
+	}
+	branches := strings.Fields(strings.TrimSpace(string(out)))
+	if len(branches) == 1 {
+		return branches[0], true
+	}
+	return "", false
 }
 
 // GetRepoRoot returns the git repository root for the gt source code.
@@ -213,14 +309,15 @@ func hasGtSource(dir string) bool {
 	return err == nil
 }
 
-// onlyBeadsChanges checks whether all commits between binaryCommit and HEAD
-// exclusively modify files under .beads/. Returns true if the diff contains
-// no changes outside .beads/, meaning the binary is functionally up-to-date.
-// Used to suppress false-positive stale warnings from bd backup commits. (GH#2596)
-func onlyBeadsChanges(repoDir, binaryCommit string) bool {
-	// Get files changed between binary commit and HEAD, excluding .beads/
-	// If this produces no output, all changes are within .beads/
-	cmd := exec.Command("git", "diff", "--name-only", binaryCommit+"..HEAD", "--", ".", ":!.beads")
+// onlyBeadsChanges checks whether all commits between binaryCommit and
+// compareRef exclusively modify files under .beads/. Returns true if the diff
+// contains no changes outside .beads/, meaning the binary is functionally
+// up-to-date. Used to suppress false-positive stale warnings from bd backup
+// commits. (GH#2596)
+func onlyBeadsChanges(repoDir, binaryCommit, compareRef string) bool {
+	// Get files changed between binary commit and the build ref, excluding
+	// .beads/. If this produces no output, all changes are within .beads/
+	cmd := exec.Command("git", "diff", "--name-only", binaryCommit+".."+compareRef, "--", ".", ":!.beads")
 	cmd.Dir = repoDir
 	util.SetDetachedProcessGroup(cmd)
 	output, err := cmd.Output()

--- a/internal/version/stale_test.go
+++ b/internal/version/stale_test.go
@@ -39,9 +39,10 @@ func gitCommit(t *testing.T, dir, file, content string) string {
 
 func newGitRepo(t *testing.T) string {
 	t.Helper()
-	if testing.Short() {
-		t.Skip("skipping git-backed test in -short mode")
-	}
+	// These tests create tiny temp-dir repos and shell out to git a handful
+	// of times — fast and deterministic, so they run even under -short. CI
+	// runs `-short`; skipping here left stale.go's staleness logic at 0%
+	// patch coverage (GH#4034 follow-up). Only skip if git is unavailable.
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}

--- a/internal/version/stale_test.go
+++ b/internal/version/stale_test.go
@@ -344,3 +344,42 @@ func TestResolveBuildBranchRef(t *testing.T) {
 		}
 	})
 }
+
+func TestStaleBinaryInfo_Describe(t *testing.T) {
+	const (
+		bin  = "abc1234567890def"
+		repo = "fed0987654321cba"
+	)
+	tests := []struct {
+		name    string
+		info    StaleBinaryInfo
+		subject string
+		want    string
+	}{
+		{
+			name:    "commits behind known",
+			info:    StaleBinaryInfo{BinaryCommit: bin, RepoCommit: repo, CompareRef: "main", CommitsBehind: 3},
+			subject: "Binary",
+			want:    "Binary is 3 commits behind main (built from abc123456789, main at fed098765432)",
+		},
+		{
+			name:    "count unknown falls back to stale wording",
+			info:    StaleBinaryInfo{BinaryCommit: bin, RepoCommit: repo, CompareRef: "origin/main", CommitsBehind: 0},
+			subject: "gt binary",
+			want:    "gt binary is stale (built from abc123456789, origin/main at fed098765432)",
+		},
+		{
+			name:    "short hashes are not truncated",
+			info:    StaleBinaryInfo{BinaryCommit: "abc123", RepoCommit: "def456", CompareRef: "carry/ops", CommitsBehind: 1},
+			subject: "Binary",
+			want:    "Binary is 1 commits behind carry/ops (built from abc123, carry/ops at def456)",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.info.Describe(tt.subject); got != tt.want {
+				t.Errorf("Describe(%q) = %q, want %q", tt.subject, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/version/stale_test.go
+++ b/internal/version/stale_test.go
@@ -1,8 +1,63 @@
 package version
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
 	"testing"
 )
+
+// --- git-backed test helpers ---
+
+func gitRun(t *testing.T, dir string, args ...string) string {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	cmd.Env = append(os.Environ(),
+		"GIT_AUTHOR_NAME=t", "GIT_AUTHOR_EMAIL=t@t",
+		"GIT_COMMITTER_NAME=t", "GIT_COMMITTER_EMAIL=t@t",
+		"GIT_CONFIG_GLOBAL=/dev/null", "GIT_CONFIG_SYSTEM=/dev/null",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("git %v: %v\n%s", args, err, out)
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// gitCommit writes file and creates a commit, returning its full hash.
+func gitCommit(t *testing.T, dir, file, content string) string {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, file), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	gitRun(t, dir, "add", "-A")
+	gitRun(t, dir, "commit", "-q", "--no-gpg-sign", "-m", "c-"+file)
+	return gitRun(t, dir, "rev-parse", "HEAD")
+}
+
+func newGitRepo(t *testing.T) string {
+	t.Helper()
+	if testing.Short() {
+		t.Skip("skipping git-backed test in -short mode")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+	dir := t.TempDir()
+	gitRun(t, dir, "init", "-q")
+	gitRun(t, dir, "config", "commit.gpgsign", "false")
+	return dir
+}
+
+// setBinaryCommit overrides the build-time commit for the duration of the test.
+func setBinaryCommit(t *testing.T, c string) {
+	t.Helper()
+	orig := Commit
+	t.Cleanup(func() { Commit = orig })
+	Commit = c
+}
 
 func TestShortCommit(t *testing.T) {
 	tests := []struct {
@@ -104,4 +159,187 @@ func TestCheckStaleBinary_NoCommit(t *testing.T) {
 	if info.BinaryCommit == "" && info.Error == nil {
 		t.Error("expected error when binary commit is empty")
 	}
+}
+
+// TestCheckStaleBinary_FeatureBranchBinaryAtMainTip is the GH#4034 regression:
+// the resolved worktree is on a feature branch but the binary is at the main
+// tip. Before the fix this falsely reported "N commits behind"; now it must be
+// reported as not stale (compared against main, not the feature HEAD).
+func TestCheckStaleBinary_FeatureBranchBinaryAtMainTip(t *testing.T) {
+	dir := newGitRepo(t)
+	gitCommit(t, dir, "a.go", "1")
+	mainTip := gitCommit(t, dir, "b.go", "2")
+	gitRun(t, dir, "branch", "-M", "main")
+	gitRun(t, dir, "checkout", "-q", "-b", "feat/x")
+	gitCommit(t, dir, "c.go", "unmerged feature work")
+	setBinaryCommit(t, mainTip)
+
+	info := CheckStaleBinary(dir)
+	if info.Error != nil {
+		t.Fatalf("unexpected error: %v", info.Error)
+	}
+	if info.Skipped {
+		t.Fatalf("expected not skipped (main resolvable), got skip: %s", info.SkipReason)
+	}
+	if info.IsStale {
+		t.Errorf("binary is at main tip on a feature branch — must NOT be stale (GH#4034)")
+	}
+	if info.OnMainBranch {
+		t.Errorf("OnMainBranch should be false on feat/x")
+	}
+	if info.CompareRef != "main" {
+		t.Errorf("CompareRef = %q, want \"main\"", info.CompareRef)
+	}
+	if info.RepoCommit != mainTip {
+		t.Errorf("RepoCommit = %q, want main tip %q", info.RepoCommit, mainTip)
+	}
+}
+
+// TestCheckStaleBinary_FeatureBranchBinaryBehindMain: on a feature branch with
+// a binary genuinely behind main — must still be reported stale, counted
+// against main (not the feature HEAD).
+func TestCheckStaleBinary_FeatureBranchBinaryBehindMain(t *testing.T) {
+	dir := newGitRepo(t)
+	old := gitCommit(t, dir, "a.go", "1")
+	gitCommit(t, dir, "b.go", "2")
+	mainTip := gitCommit(t, dir, "c.go", "3")
+	gitRun(t, dir, "branch", "-M", "main")
+	gitRun(t, dir, "checkout", "-q", "-b", "feat/x")
+	gitCommit(t, dir, "d.go", "feature work")
+	setBinaryCommit(t, old)
+
+	info := CheckStaleBinary(dir)
+	if info.Error != nil {
+		t.Fatalf("unexpected error: %v", info.Error)
+	}
+	if !info.IsStale {
+		t.Fatalf("binary behind main must be stale")
+	}
+	if info.CompareRef != "main" {
+		t.Errorf("CompareRef = %q, want \"main\"", info.CompareRef)
+	}
+	if info.RepoCommit != mainTip {
+		t.Errorf("RepoCommit = %q, want main tip %q", info.RepoCommit, mainTip)
+	}
+	if info.CommitsBehind != 2 {
+		t.Errorf("CommitsBehind = %d, want 2 (counted against main)", info.CommitsBehind)
+	}
+	if !info.IsForward {
+		t.Errorf("IsForward should be true (binary is ancestor of main)")
+	}
+	if info.OnMainBranch {
+		t.Errorf("OnMainBranch should be false on feat/x")
+	}
+}
+
+// TestCheckStaleBinary_OnMainBehind: on a build branch, behind HEAD — the
+// pre-existing behavior must be unchanged (compare against HEAD/the branch).
+func TestCheckStaleBinary_OnMainBehind(t *testing.T) {
+	dir := newGitRepo(t)
+	old := gitCommit(t, dir, "a.go", "1")
+	tip := gitCommit(t, dir, "b.go", "2")
+	gitRun(t, dir, "branch", "-M", "main")
+	setBinaryCommit(t, old)
+
+	info := CheckStaleBinary(dir)
+	if info.Error != nil {
+		t.Fatalf("unexpected error: %v", info.Error)
+	}
+	if !info.OnMainBranch {
+		t.Fatalf("OnMainBranch should be true on main")
+	}
+	if !info.IsStale {
+		t.Fatalf("binary behind main HEAD must be stale")
+	}
+	if info.CompareRef != "main" {
+		t.Errorf("CompareRef = %q, want \"main\"", info.CompareRef)
+	}
+	if info.RepoCommit != tip {
+		t.Errorf("RepoCommit = %q, want %q", info.RepoCommit, tip)
+	}
+	if info.CommitsBehind != 1 {
+		t.Errorf("CommitsBehind = %d, want 1", info.CommitsBehind)
+	}
+}
+
+// TestCheckStaleBinary_NoBuildBranchSkips: feature branch, no main/master/
+// carry/remote — the check must skip rather than diff against feature HEAD.
+func TestCheckStaleBinary_NoBuildBranchSkips(t *testing.T) {
+	dir := newGitRepo(t)
+	c1 := gitCommit(t, dir, "a.go", "1")
+	gitRun(t, dir, "branch", "-M", "feature/only")
+	setBinaryCommit(t, c1)
+
+	info := CheckStaleBinary(dir)
+	if info.Error != nil {
+		t.Fatalf("unexpected error: %v", info.Error)
+	}
+	if !info.Skipped {
+		t.Fatalf("expected Skipped when no build-branch ref exists")
+	}
+	if info.SkipReason == "" {
+		t.Errorf("SkipReason should be set when skipped")
+	}
+	if info.IsStale {
+		t.Errorf("IsStale must be false when skipped")
+	}
+	if info.OnMainBranch {
+		t.Errorf("OnMainBranch must be false on feature/only")
+	}
+}
+
+func TestResolveBuildBranchRef(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping git-backed test in -short mode")
+	}
+	if _, err := exec.LookPath("git"); err != nil {
+		t.Skip("git not available")
+	}
+
+	t.Run("prefers local main", func(t *testing.T) {
+		dir := newGitRepo(t)
+		c1 := gitCommit(t, dir, "a.go", "1")
+		gitRun(t, dir, "branch", "-M", "main")
+		gitRun(t, dir, "branch", "carry/operational")
+		gitRun(t, dir, "checkout", "-q", "-b", "feat/x")
+		ref, ok := resolveBuildBranchRef(dir, c1)
+		if !ok || ref != "main" {
+			t.Errorf("got (%q,%v), want (\"main\",true)", ref, ok)
+		}
+	})
+
+	t.Run("routes to carry when binary not on main", func(t *testing.T) {
+		dir := newGitRepo(t)
+		gitCommit(t, dir, "a.go", "1")
+		gitRun(t, dir, "branch", "-M", "main")
+		gitRun(t, dir, "checkout", "-q", "-b", "carry/operational")
+		carryOnly := gitCommit(t, dir, "b.go", "fork work")
+		gitRun(t, dir, "checkout", "-q", "-b", "feat/x")
+		ref, ok := resolveBuildBranchRef(dir, carryOnly)
+		if !ok || ref != "carry/operational" {
+			t.Errorf("got (%q,%v), want (\"carry/operational\",true)", ref, ok)
+		}
+	})
+
+	t.Run("ambiguous carry is skipped", func(t *testing.T) {
+		dir := newGitRepo(t)
+		c1 := gitCommit(t, dir, "a.go", "1")
+		gitRun(t, dir, "branch", "-M", "feature/only")
+		gitRun(t, dir, "branch", "carry/a")
+		gitRun(t, dir, "branch", "carry/b")
+		if ref, ok := resolveBuildBranchRef(dir, c1); ok {
+			t.Errorf("got (%q,%v), want (\"\",false) for ambiguous carry/*", ref, ok)
+		}
+	})
+
+	t.Run("falls back to origin/main", func(t *testing.T) {
+		dir := newGitRepo(t)
+		c1 := gitCommit(t, dir, "a.go", "1")
+		gitRun(t, dir, "branch", "-M", "feature/only")
+		gitRun(t, dir, "update-ref", "refs/remotes/origin/main", c1)
+		ref, ok := resolveBuildBranchRef(dir, c1)
+		if !ok || ref != "origin/main" {
+			t.Errorf("got (%q,%v), want (\"origin/main\",true)", ref, ok)
+		}
+	})
 }

--- a/internal/version/stale_test.go
+++ b/internal/version/stale_test.go
@@ -289,23 +289,41 @@ func TestCheckStaleBinary_NoBuildBranchSkips(t *testing.T) {
 	}
 }
 
-func TestResolveBuildBranchRef(t *testing.T) {
-	if testing.Short() {
-		t.Skip("skipping git-backed test in -short mode")
+func TestCheckStaleBinary_BinaryCommitMissingSkips(t *testing.T) {
+	dir := newGitRepo(t)
+	gitCommit(t, dir, "a.go", "1")
+	gitRun(t, dir, "branch", "-M", "main")
+	setBinaryCommit(t, "ffffffffffffffffffffffffffffffffffffffff")
+
+	info := CheckStaleBinary(dir)
+	if info.Error != nil {
+		t.Fatalf("unexpected error: %v", info.Error)
 	}
+	if !info.Skipped {
+		t.Fatalf("expected missing binary commit to skip")
+	}
+	if !strings.Contains(info.SkipReason, "binary commit not found") {
+		t.Errorf("SkipReason = %q, want binary commit not found", info.SkipReason)
+	}
+	if info.IsStale {
+		t.Errorf("IsStale must be false when binary commit is missing")
+	}
+}
+
+func TestResolveBuildBranchRef(t *testing.T) {
 	if _, err := exec.LookPath("git"); err != nil {
 		t.Skip("git not available")
 	}
 
-	t.Run("prefers local main", func(t *testing.T) {
+	t.Run("prefers carry when same commit is on carry and main", func(t *testing.T) {
 		dir := newGitRepo(t)
 		c1 := gitCommit(t, dir, "a.go", "1")
 		gitRun(t, dir, "branch", "-M", "main")
 		gitRun(t, dir, "branch", "carry/operational")
 		gitRun(t, dir, "checkout", "-q", "-b", "feat/x")
 		ref, ok := resolveBuildBranchRef(dir, c1)
-		if !ok || ref != "main" {
-			t.Errorf("got (%q,%v), want (\"main\",true)", ref, ok)
+		if !ok || ref.display != "carry/operational" || ref.ref != "refs/heads/carry/operational" || ref.commit != c1 {
+			t.Errorf("got (%+v,%v), want carry/operational at %s", ref, ok, c1)
 		}
 	})
 
@@ -317,8 +335,8 @@ func TestResolveBuildBranchRef(t *testing.T) {
 		carryOnly := gitCommit(t, dir, "b.go", "fork work")
 		gitRun(t, dir, "checkout", "-q", "-b", "feat/x")
 		ref, ok := resolveBuildBranchRef(dir, carryOnly)
-		if !ok || ref != "carry/operational" {
-			t.Errorf("got (%q,%v), want (\"carry/operational\",true)", ref, ok)
+		if !ok || ref.display != "carry/operational" || ref.commit != carryOnly {
+			t.Errorf("got (%+v,%v), want carry/operational at %s", ref, ok, carryOnly)
 		}
 	})
 
@@ -329,7 +347,7 @@ func TestResolveBuildBranchRef(t *testing.T) {
 		gitRun(t, dir, "branch", "carry/a")
 		gitRun(t, dir, "branch", "carry/b")
 		if ref, ok := resolveBuildBranchRef(dir, c1); ok {
-			t.Errorf("got (%q,%v), want (\"\",false) for ambiguous carry/*", ref, ok)
+			t.Errorf("got (%+v,%v), want no ref for ambiguous carry/*", ref, ok)
 		}
 	})
 
@@ -339,8 +357,69 @@ func TestResolveBuildBranchRef(t *testing.T) {
 		gitRun(t, dir, "branch", "-M", "feature/only")
 		gitRun(t, dir, "update-ref", "refs/remotes/origin/main", c1)
 		ref, ok := resolveBuildBranchRef(dir, c1)
-		if !ok || ref != "origin/main" {
-			t.Errorf("got (%q,%v), want (\"origin/main\",true)", ref, ok)
+		if !ok || ref.display != "origin/main" || ref.ref != "refs/remotes/origin/main" || ref.commit != c1 {
+			t.Errorf("got (%+v,%v), want origin/main at %s", ref, ok, c1)
+		}
+	})
+
+	t.Run("fresher remote beats stale local main", func(t *testing.T) {
+		dir := newGitRepo(t)
+		old := gitCommit(t, dir, "a.go", "1")
+		fresh := gitCommit(t, dir, "b.go", "2")
+		gitRun(t, dir, "branch", "-M", "main")
+		gitRun(t, dir, "update-ref", "refs/remotes/origin/main", fresh)
+		gitRun(t, dir, "reset", "--hard", old)
+		gitRun(t, dir, "checkout", "-q", "-b", "feat/x")
+
+		ref, ok := resolveBuildBranchRef(dir, old)
+		if !ok || ref.display != "origin/main" || ref.commit != fresh {
+			t.Errorf("got (%+v,%v), want fresher origin/main at %s", ref, ok, fresh)
+		}
+	})
+
+	t.Run("prefers upstream over divergent origin", func(t *testing.T) {
+		dir := newGitRepo(t)
+		base := gitCommit(t, dir, "a.go", "1")
+		gitRun(t, dir, "branch", "-M", "main")
+		gitRun(t, dir, "checkout", "-q", "-b", "origin-line")
+		originTip := gitCommit(t, dir, "origin.go", "origin")
+		gitRun(t, dir, "update-ref", "refs/remotes/origin/main", originTip)
+		gitRun(t, dir, "checkout", "-q", "main")
+		gitRun(t, dir, "checkout", "-q", "-b", "upstream-line")
+		upstreamTip := gitCommit(t, dir, "upstream.go", "upstream")
+		gitRun(t, dir, "update-ref", "refs/remotes/upstream/main", upstreamTip)
+		gitRun(t, dir, "checkout", "-q", "main")
+		gitRun(t, dir, "checkout", "-q", "-b", "feat/x")
+
+		ref, ok := resolveBuildBranchRef(dir, base)
+		if !ok || ref.display != "upstream/main" || ref.commit != upstreamTip {
+			t.Errorf("got (%+v,%v), want upstream/main at %s", ref, ok, upstreamTip)
+		}
+	})
+
+	t.Run("uses remote carry when local carry absent", func(t *testing.T) {
+		dir := newGitRepo(t)
+		c1 := gitCommit(t, dir, "a.go", "1")
+		gitRun(t, dir, "branch", "-M", "feature/only")
+		gitRun(t, dir, "update-ref", "refs/remotes/origin/carry/operational", c1)
+
+		ref, ok := resolveBuildBranchRef(dir, c1)
+		if !ok || ref.display != "origin/carry/operational" || ref.ref != "refs/remotes/origin/carry/operational" || ref.commit != c1 {
+			t.Errorf("got (%+v,%v), want origin/carry/operational at %s", ref, ok, c1)
+		}
+	})
+
+	t.Run("fully qualified remote ref resists local branch shadow", func(t *testing.T) {
+		dir := newGitRepo(t)
+		old := gitCommit(t, dir, "a.go", "1")
+		gitRun(t, dir, "branch", "-M", "feature/only")
+		fresh := gitCommit(t, dir, "b.go", "2")
+		gitRun(t, dir, "update-ref", "refs/heads/origin/main", old)
+		gitRun(t, dir, "update-ref", "refs/remotes/origin/main", fresh)
+
+		ref, ok := resolveBuildBranchRef(dir, old)
+		if !ok || ref.display != "origin/main" || ref.ref != "refs/remotes/origin/main" || ref.commit != fresh {
+			t.Errorf("got (%+v,%v), want remote origin/main at %s", ref, ok, fresh)
 		}
 	})
 }


### PR DESCRIPTION
Supersedes #4036.

This preserves @esciara's original four commits from #4036 and adds the sheriff-required fixup. The original PR still points at `890e912ff0d3fa3680c5834f850198e1e48f05e4`, so it must not merge as-is because it lacks the fixup recorded by the PR Sheriff workflow.

Reconciliation evidence:
- Prior bead `gt-pr-sheriff-4036` recorded 15 research legs, 5 pre-implementation reviews, 5 post-implementation reviews, and targeted validation for the fixup.
- This reconciliation reran 15 independent research legs, 5 independent pre-implementation reviews, and 5 independent post-implementation reviews.
- Branch is based on current `upstream/main` (`ccd16c18606ad87e9e62abdf048c337a7323282b`).
- Diff is limited to the seven stale-binary product/test files.
- Local/preserved fork branches with fork-main drift or `.opencode` autosave contamination were not used directly.

Verification run on this branch:
- `go build ./...`
- `go vet ./...`
- `go test -short -count=1 ./internal/version`
- `go test -short -count=1 ./internal/cmd -run 'TestOutputStaleText|TestStaleQuietExitCode'`
- `go test -short -count=1 ./internal/doctor -run TestStaleResult`

Fixes #4034.
