### PR TITLE
fix(tmux): suppress nudge Escape while agent is generating (stop interrupting the Mayor)

### DIFF
--- a/internal/config/agents.go
+++ b/internal/config/agents.go
@@ -160,9 +160,9 @@ type AgentPresetInfo struct {
 
 	// EscapeCancelsRequest indicates that sending an Escape keystroke to this
 	// agent cancels its in-flight generation. NudgeSession normally sends
-	// Escape (step 5) to exit vim INSERT mode — harmless for bash/Claude Code,
-	// but destructive for agents like Gemini CLI where Escape aborts the
-	// active request. When true, NudgeSessionWithOpts skips the Escape
+	// Escape (step 5) to exit vim INSERT mode — harmless for bash, but
+	// destructive for agents where Escape aborts the active request. When true,
+	// NudgeSessionWithOpts skips the Escape
 	// keystroke and the 600ms readline timeout that follows it.
 	EscapeCancelsRequest bool `json:"escape_cancels_request,omitempty"`
 

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1722,6 +1722,19 @@ func (t *Tmux) NudgeSessionWithOpts(session, message string, opts NudgeOpts) err
 	// 2. Sanitize control characters that corrupt delivery
 	sanitized := sanitizeNudgeMessage(message)
 
+	if !opts.SkipEscape {
+		// Auto-skip Escape for Copilot CLI sessions. Escape cancels in-flight
+		// generation in Copilot CLI (like Gemini), leaving the nudge text
+		// stranded in the input field without Enter being processed. (hq-isz)
+		agentType, _ := t.GetEnvironment(session, "GT_AGENT")
+		if agentType == "copilot" {
+			opts.SkipEscape = true
+		}
+	}
+	// Snapshot before typing the nudge so the message text itself cannot look
+	// like the agent's busy indicator.
+	sendEscape := !opts.SkipEscape && t.shouldSendEscape(target)
+
 	// 3. Send text via send-keys -l. Messages > 512 bytes are chunked
 	//    with 10ms inter-chunk delays to avoid argument length limits.
 	if err := t.sendMessageToTarget(target, sanitized); err != nil {
@@ -1732,23 +1745,7 @@ func (t *Tmux) NudgeSessionWithOpts(session, message string, opts NudgeOpts) err
 	// enough time to process all chunks under load. (GH#gt-0b5)
 	time.Sleep(adaptiveTextDelay(len(sanitized)))
 
-	if !opts.SkipEscape {
-		// Auto-skip Escape for Copilot CLI sessions. Escape cancels in-flight
-		// generation in Copilot CLI (like Gemini), leaving the nudge text
-		// stranded in the input field without Enter being processed. (hq-isz)
-		agentType, _ := t.GetEnvironment(session, "GT_AGENT")
-		if agentType == "copilot" {
-			opts.SkipEscape = true
-		}
-	}
-
-	// Only send the vim-mode Escape when the agent is NOT actively generating.
-	// In Claude Code, Escape cancels in-flight generation — the status bar reads
-	// "esc to interrupt" while the agent is working — so sending it mid-turn
-	// would interrupt the agent's current work (e.g. the Mayor). When the agent
-	// is idle, Escape harmlessly exits a vim-mode composer's INSERT mode so the
-	// following Enter submits (GH#307).
-	if !opts.SkipEscape && t.shouldSendEscape(target) {
+	if sendEscape {
 		// 5. Send Escape to exit vim INSERT mode if enabled (harmless in normal mode)
 		// See: https://github.com/anthropics/gastown/issues/307
 		_, _ = t.run("send-keys", "-t", target, "Escape")
@@ -1816,6 +1813,9 @@ func (t *Tmux) NudgePane(pane, message string) error {
 
 	// 2. Sanitize control characters that corrupt delivery
 	sanitized := sanitizeNudgeMessage(message)
+	// Snapshot before typing the nudge so the message text itself cannot look
+	// like the agent's busy indicator.
+	sendEscape := t.shouldSendEscape(pane)
 
 	// 3. Send text via send-keys -l. Messages > 512 bytes are chunked
 	//    with 10ms inter-chunk delays to avoid argument length limits.
@@ -1826,11 +1826,7 @@ func (t *Tmux) NudgePane(pane, message string) error {
 	// 4. Adaptive post-text delay: scales with message length. (GH#gt-0b5)
 	time.Sleep(adaptiveTextDelay(len(sanitized)))
 
-	// Only send the vim-mode Escape when the agent is NOT actively generating —
-	// in Claude Code, Escape cancels in-flight generation ("esc to interrupt"),
-	// so sending it mid-turn would interrupt the agent's current work. When idle
-	// it harmlessly exits a vim-mode composer's INSERT mode. (GH#307)
-	if t.shouldSendEscape(pane) {
+	if sendEscape {
 		// 5. Send Escape to exit vim INSERT mode if enabled (harmless in normal mode)
 		// See: https://github.com/anthropics/gastown/issues/307
 		_, _ = t.run("send-keys", "-t", pane, "Escape")
@@ -2920,10 +2916,12 @@ func shouldSendEscapeForLines(lines []string) bool {
 }
 
 // shouldSendEscape captures the target's pane and reports whether the vim-mode
-// Escape is safe to send right now (see shouldSendEscapeForLines). On capture
-// failure it returns false: when we cannot confirm the agent is idle, skipping
-// the Escape is the safe default — it avoids interrupting an active agent and
-// is harmless for the common (non-vim) case where Enter alone submits.
+// Escape is safe to send right now (see shouldSendEscapeForLines). Callers
+// snapshot before writing nudge text so the message itself cannot masquerade as
+// the busy indicator. On capture failure it returns false: when we cannot
+// confirm the agent is idle, skipping the Escape is the safe default — it avoids
+// interrupting an active agent and is harmless for the common (non-vim) case
+// where Enter alone submits.
 func (t *Tmux) shouldSendEscape(target string) bool {
 	lines, err := t.CapturePaneLines(target, 5)
 	if err != nil {

--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1742,7 +1742,13 @@ func (t *Tmux) NudgeSessionWithOpts(session, message string, opts NudgeOpts) err
 		}
 	}
 
-	if !opts.SkipEscape {
+	// Only send the vim-mode Escape when the agent is NOT actively generating.
+	// In Claude Code, Escape cancels in-flight generation — the status bar reads
+	// "esc to interrupt" while the agent is working — so sending it mid-turn
+	// would interrupt the agent's current work (e.g. the Mayor). When the agent
+	// is idle, Escape harmlessly exits a vim-mode composer's INSERT mode so the
+	// following Enter submits (GH#307).
+	if !opts.SkipEscape && t.shouldSendEscape(target) {
 		// 5. Send Escape to exit vim INSERT mode if enabled (harmless in normal mode)
 		// See: https://github.com/anthropics/gastown/issues/307
 		_, _ = t.run("send-keys", "-t", target, "Escape")
@@ -1820,18 +1826,24 @@ func (t *Tmux) NudgePane(pane, message string) error {
 	// 4. Adaptive post-text delay: scales with message length. (GH#gt-0b5)
 	time.Sleep(adaptiveTextDelay(len(sanitized)))
 
-	// 5. Send Escape to exit vim INSERT mode if enabled (harmless in normal mode)
-	// See: https://github.com/anthropics/gastown/issues/307
-	_, _ = t.run("send-keys", "-t", pane, "Escape")
+	// Only send the vim-mode Escape when the agent is NOT actively generating —
+	// in Claude Code, Escape cancels in-flight generation ("esc to interrupt"),
+	// so sending it mid-turn would interrupt the agent's current work. When idle
+	// it harmlessly exits a vim-mode composer's INSERT mode. (GH#307)
+	if t.shouldSendEscape(pane) {
+		// 5. Send Escape to exit vim INSERT mode if enabled (harmless in normal mode)
+		// See: https://github.com/anthropics/gastown/issues/307
+		_, _ = t.run("send-keys", "-t", pane, "Escape")
 
-	// 6. Wait 600ms — must exceed bash readline's keyseq-timeout (500ms default)
-	time.Sleep(600 * time.Millisecond)
+		// 6. Wait 600ms — must exceed bash readline's keyseq-timeout (500ms default)
+		time.Sleep(600 * time.Millisecond)
 
-	// 6.5. Post-Escape: check if our Escape triggered Rewind mode. (GH#gt-8el)
-	if t.isInRewindMode(pane) {
-		t.dismissRewindMode(pane)
-		_ = t.sendMessageToTarget(pane, sanitized)
-		time.Sleep(adaptiveTextDelay(len(sanitized)))
+		// 6.5. Post-Escape: check if our Escape triggered Rewind mode. (GH#gt-8el)
+		if t.isInRewindMode(pane) {
+			t.dismissRewindMode(pane)
+			_ = t.sendMessageToTarget(pane, sanitized)
+			time.Sleep(adaptiveTextDelay(len(sanitized)))
+		}
 	}
 
 	// 7. Send Enter with verification — polls pane content to confirm Enter
@@ -2881,6 +2893,43 @@ func hasBusyIndicator(line string) bool {
 		return false
 	}
 	return strings.Contains(trimmed, "esc to interrupt")
+}
+
+// shouldSendEscapeForLines reports whether the vim-mode Escape keystroke
+// (nudge delivery step 5) is safe to send, given a snapshot of pane lines.
+//
+// The Escape exists to exit a vim-mode composer's INSERT mode so the following
+// Enter submits the line (GH#307). But in Claude Code — and Codex/Gemini —
+// Escape also cancels in-flight generation; the status bar literally reads
+// "esc to interrupt" while the agent is working. Sending Escape in that state
+// would interrupt the agent's current turn (e.g. the Mayor). Returns false when
+// any line shows the busy indicator so the caller suppresses the Escape.
+//
+// FRAGILITY: this depends on the agent TUI rendering the literal substring
+// "esc to interrupt" while generating (via hasBusyIndicator — the same
+// assumption IsIdle/WaitForIdle already make). If that upstream status text
+// changes, the gate fails open and silently: the Escape is sent again and
+// nudges can resume interrupting the agent. Tracked in gastownhall/gastown#4240.
+func shouldSendEscapeForLines(lines []string) bool {
+	for _, line := range lines {
+		if hasBusyIndicator(line) {
+			return false
+		}
+	}
+	return true
+}
+
+// shouldSendEscape captures the target's pane and reports whether the vim-mode
+// Escape is safe to send right now (see shouldSendEscapeForLines). On capture
+// failure it returns false: when we cannot confirm the agent is idle, skipping
+// the Escape is the safe default — it avoids interrupting an active agent and
+// is harmless for the common (non-vim) case where Enter alone submits.
+func (t *Tmux) shouldSendEscape(target string) bool {
+	lines, err := t.CapturePaneLines(target, 5)
+	if err != nil {
+		return false
+	}
+	return shouldSendEscapeForLines(lines)
 }
 
 func readyPromptPrefixForSession(t *Tmux, session string) string {

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2083,6 +2083,14 @@ func TestShouldSendEscape_LivePane(t *testing.T) {
 	}
 }
 
+func TestShouldSendEscape_CaptureErrorSuppressesEscape(t *testing.T) {
+	tm := newTestTmux(t)
+
+	if tm.shouldSendEscape("missing-session-for-escape-check") {
+		t.Fatal("shouldSendEscape on missing target = true, want false")
+	}
+}
+
 func TestDefaultReadyPromptPrefix(t *testing.T) {
 	t.Parallel()
 	// Verify the constant is set correctly

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -1991,6 +1991,98 @@ func TestHasBusyIndicator(t *testing.T) {
 	}
 }
 
+// TestShouldSendEscapeForLines guards against the regression where a nudge
+// sends the vim-mode Escape keystroke while the agent is actively generating,
+// interrupting its current turn (e.g. the Mayor). When the pane shows the busy
+// indicator ("esc to interrupt"), the Escape must be suppressed.
+func TestShouldSendEscapeForLines(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name  string
+		lines []string
+		want  bool
+	}{
+		{
+			name:  "claude generating - suppress escape",
+			lines: []string{"✻ Cogitating… (12s · ↑ 2.1k tokens · esc to interrupt)"},
+			want:  false,
+		},
+		{
+			name:  "codex working - suppress escape",
+			lines: []string{"• Working (2m 18s • esc to interrupt)"},
+			want:  false,
+		},
+		{
+			name:  "busy indicator among multiple lines - suppress escape",
+			lines: []string{"tool output", "more output", "⏵⏵ bypass permissions on · esc to interrupt"},
+			want:  false,
+		},
+		{
+			name:  "idle ready prompt - allow escape",
+			lines: []string{"❯ "},
+			want:  true,
+		},
+		{
+			name:  "idle with typed nudge text - allow escape",
+			lines: []string{"❯ HEALTH_CHECK: heartbeat stale, respond to confirm"},
+			want:  true,
+		},
+		{
+			name:  "no lines captured - allow escape (not busy)",
+			lines: nil,
+			want:  true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := shouldSendEscapeForLines(tt.lines); got != tt.want {
+				t.Errorf("shouldSendEscapeForLines(%q) = %v, want %v", tt.lines, got, tt.want)
+			}
+		})
+	}
+}
+
+// TestShouldSendEscape_LivePane exercises the busy-state gate end-to-end against
+// a real tmux pane (capture-only, so it avoids the sendEnterVerified timing
+// flakiness of the full nudge integration tests). It confirms the wiring: when
+// the pane shows the "esc to interrupt" busy indicator, shouldSendEscape returns
+// false so a nudge will not interrupt the agent's in-flight work.
+func TestShouldSendEscape_LivePane(t *testing.T) {
+	tm := newTestTmux(t)
+	session := "gt-test-should-escape-" + t.Name()
+
+	_ = tm.KillSession(session)
+	if err := tm.NewSession(session, ""); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tm.KillSession(session) }()
+
+	// Idle shell prompt: no busy indicator → Escape is safe to send.
+	if !tm.shouldSendEscape(session) {
+		out, _ := tm.CapturePane(session, 20)
+		t.Fatalf("shouldSendEscape on idle pane = false, want true; pane:\n%s", out)
+	}
+
+	// Simulate an agent that is actively generating by rendering the busy
+	// indicator into the pane. The typed command line itself contains the
+	// marker, so detection does not depend on the command actually executing.
+	if err := tm.SendKeys(session, "echo esc to interrupt"); err != nil {
+		t.Fatalf("SendKeys: %v", err)
+	}
+
+	// Poll until the gate flips to suppressed (the shell may be slow to render).
+	deadline := time.Now().Add(5 * time.Second)
+	for tm.shouldSendEscape(session) {
+		if time.Now().After(deadline) {
+			out, _ := tm.CapturePane(session, 20)
+			t.Fatalf("shouldSendEscape did not detect busy indicator within timeout; pane:\n%s", out)
+		}
+		time.Sleep(100 * time.Millisecond)
+	}
+}
+
 func TestDefaultReadyPromptPrefix(t *testing.T) {
 	t.Parallel()
 	// Verify the constant is set correctly


### PR DESCRIPTION
## Problem

System nudges are delivered to agents via `tmux send-keys`. The delivery protocol (`NudgeSessionWithOpts` / `NudgePane`) sends a literal **Escape** keystroke (step 5) before Enter — originally to exit a vim-mode composer's INSERT mode so Enter submits (GH#307), commented as *"harmless for bash/Claude Code"*.

It is **not** harmless for Claude Code: Escape cancels in-flight generation. So when a nudge lands while the agent is mid-turn — the **Mayor** being the common victim — the Escape interrupts its current work. This affects every direct `NudgeSession` caller: witness handlers, the daemon health-check heartbeat, the mail router, broadcast, and `gt nudge`.

`EscapeCancelsRequest` already existed to skip the Escape for agents where it cancels generation (Gemini; Copilot auto-skipped), but Claude was wrongly assumed exempt.

## Fix

Gate the Escape on the agent's busy state instead of sending it unconditionally:

- `shouldSendEscape(target)` captures the pane and returns `false` when the busy indicator (`esc to interrupt`) is present — i.e. the agent is generating.
- Step 5 now runs only when `!SkipEscape && shouldSendEscape(...)`.
- Applied to **both** `NudgeSessionWithOpts` and `NudgePane` (the latter previously sent Escape with no gate at all).

This reuses the exact signal `IsIdle` / `WaitForIdle` already trust, so it adds no new external assumption. Behavior is strictly safer:

- **Idle** agent → Escape still sent (vim-mode GH#307 preserved).
- **Generating** agent → Escape suppressed (no interrupt); the typed text + Enter simply queue as the next turn.
- Non-Claude agents that don't render `esc to interrupt` are unaffected (gate returns `true` → unchanged).

### Why not the alternatives
- *Set `EscapeCancelsRequest: true` for Claude* — simplest, but drops the vim-mode INSERT-exit entirely, even when idle.
- *Sniff vim mode from the pane* — fragile and version-dependent; false negatives strand vim users, false positives reintroduce the interrupt. The busy-state signal **is** the actual harm condition and is already battle-tested.

## Design note
On pane-capture error, `shouldSendEscape` returns `false` (suppress). When we can't confirm idle, not interrupting the agent is the safer default, and it's harmless for the common non-vim case where Enter alone submits. Matches `IsIdle`'s return-false-on-error convention.

## Fragility (tracked)
Detection relies on the literal `esc to interrupt` status string. This is **pre-existing** (shared with `IsIdle` / `WaitForIdle`), now load-bearing for nudge correctness. Documented in-code and tracked in #4240.

## Tests
- `TestShouldSendEscapeForLines` — pure decision logic (busy ⇒ suppress; idle/empty ⇒ allow).
- `TestShouldSendEscape_LivePane` — real tmux pane: idle ⇒ allow, `esc to interrupt` rendered ⇒ suppress. Capture-only, so it sidesteps the `sendEnterVerified` flakiness of the full nudge integration tests.

`go build` / `go vet` / `gofmt` clean on `internal/tmux`.

> Note: 3 pre-existing `TestNudgeSession_*` real-tmux integration tests fail in my local sandbox — verified **identical with these changes stashed** (a `sendEnterVerified` environment timing issue, not introduced here).

Relates to #4240
