### PR TITLE
refactor(tmux): centralize agent busy-indicator detection (closes #4240)

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -2977,12 +2977,35 @@ func matchesPromptPrefix(line, readyPromptPrefix string) bool {
 	return strings.HasPrefix(trimmed, normalizedPrefix) || (prefix != "" && trimmed == prefix)
 }
 
+// busyIndicators is the single source of truth for the substrings an agent TUI
+// renders in its status bar while actively generating. Detection of "is the
+// agent working?" scrapes the pane for any of these (see hasBusyIndicator), and
+// that signal underpins IsIdle, WaitForIdle, and the nudge Escape-suppression in
+// shouldSendEscape. Claude Code, Codex, and Gemini all surface "esc to
+// interrupt"; if an agent uses different wording, add it here — that is the only
+// place that needs to change.
+//
+// FRAGILITY (gastownhall/gastown#4240): this couples to upstream TUI status
+// text. Scraping the status bar cannot detect a silent upstream rename on its
+// own — a truly structural readiness signal would, but none is available across
+// all agents today. Centralizing the markers here keeps any required update to a
+// single reviewable line, and TestBusyIndicators pins the known marker so a
+// change is intentional rather than accidental. The idle side is already
+// centralized via the agent presets' ReadyPromptPrefix; this is its busy-side
+// counterpart.
+var busyIndicators = []string{"esc to interrupt"}
+
 func hasBusyIndicator(line string) bool {
 	trimmed := strings.TrimSpace(line)
 	if trimmed == "" {
 		return false
 	}
-	return strings.Contains(trimmed, "esc to interrupt")
+	for _, marker := range busyIndicators {
+		if strings.Contains(trimmed, marker) {
+			return true
+		}
+	}
+	return false
 }
 
 // shouldSendEscapeForLines reports whether the vim-mode Escape keystroke

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2091,6 +2091,38 @@ func TestShouldSendEscape_CaptureErrorSuppressesEscape(t *testing.T) {
 	}
 }
 
+// TestBusyIndicators pins the centralized busy-indicator source of truth so a
+// change to the upstream-coupled status string is intentional and reviewed
+// rather than accidental (gastownhall/gastown#4240).
+func TestBusyIndicators(t *testing.T) {
+	t.Parallel()
+
+	if len(busyIndicators) == 0 {
+		t.Fatal("busyIndicators must not be empty — busy/idle detection would silently break")
+	}
+
+	// "esc to interrupt" is the marker Claude Code / Codex / Gemini render while
+	// generating. If this assertion fails, the change must be deliberate.
+	found := false
+	for _, m := range busyIndicators {
+		if m == "esc to interrupt" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Errorf("busyIndicators = %q, want it to contain the known \"esc to interrupt\" marker", busyIndicators)
+	}
+
+	// Every marker must be matched by hasBusyIndicator (guards against an empty
+	// or whitespace-only entry slipping in).
+	for _, m := range busyIndicators {
+		if !hasBusyIndicator("⏵⏵ status · " + m) {
+			t.Errorf("hasBusyIndicator did not match a registered busy indicator %q", m)
+		}
+	}
+}
+
 func TestDefaultReadyPromptPrefix(t *testing.T) {
 	t.Parallel()
 	// Verify the constant is set correctly


### PR DESCRIPTION
## Problem

The busy-state detection that powers `IsIdle`, `WaitForIdle`, and the nudge Escape-suppression (#4242) scraped the agent TUI status bar for a **hardcoded `"esc to interrupt"` literal** buried inside `hasBusyIndicator`. That made a correctness-relevant signal an undocumented, single-point coupling to upstream agent UI text — if the wording changes, detection fails **open and silently**. (Filed as #4240.)

## Change

- Hoist the marker into a single documented source of truth: `var busyIndicators = []string{"esc to interrupt"}`.
- `hasBusyIndicator` now matches **any** registered marker, so supporting a new agent's wording (or absorbing an upstream rename) is a one-line edit in one place.
- `TestBusyIndicators` pins the known marker — a change to the upstream-coupled string now has to be deliberate and reviewed, not accidental.

The **idle** side was already centralized via the agent presets' `ReadyPromptPrefix`; this gives the **busy** side the same treatment.

## Scope (deliberately proportionate)

This is the low-risk, high-value slice of #4240. Two larger options from the issue are **intentionally deferred**, and called out so the residual risk is explicit rather than hidden:

- **Per-agent config** (a `BusyIndicator` preset field mirroring `ReadyPromptPrefix`): YAGNI today — Claude Code, Codex, and Gemini all render the same marker. The centralized list already supports adding variants; graduating to per-agent is a clean follow-up if an agent ever diverges.
- **Runtime canary** (detect a live upstream rename): would need to drive a known-generating agent and is inherently flaky. TUI-scraping can't fully eliminate silent-failure risk without a structural readiness signal, which no agent exposes uniformly today.

## Tests
- `TestHasBusyIndicator` (existing) — still green against the centralized list.
- `TestBusyIndicators` (new) — guards the source of truth.
- `go build` / `go vet` / `gofmt` clean.

Independent of #4242 — both touch the `hasBusyIndicator` neighborhood but not the same lines; either can merge first.

Closes #4240
