### PR TITLE
fix: route beads operations via env town root

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -437,6 +437,19 @@ func (b *Beads) getActor() string {
 func (b *Beads) getTownRoot() string {
 	b.townRootOnce.Do(func() {
 		b.townRoot = FindTownRoot(b.workDir)
+		if b.townRoot != "" {
+			return
+		}
+		for _, envName := range []string{"GT_TOWN_ROOT", "GT_ROOT"} {
+			townRoot := os.Getenv(envName)
+			if townRoot == "" {
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(townRoot, "mayor", "town.json")); err == nil {
+				b.townRoot = townRoot
+				return
+			}
+		}
 	})
 	return b.townRoot
 }

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -552,6 +552,50 @@ exit 0
 	}
 }
 
+func TestCreateRoutesExplicitRigUsingEnvTownRootFromExternalCwd(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	rigDir := filepath.Join(townRoot, "accent_unified_au", "mayor", "rig")
+	rigBeadsDir := filepath.Join(rigDir, ".beads")
+	for _, dir := range []string{townBeadsDir, rigBeadsDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := WriteRoutes(townBeadsDir, []Route{
+		{Prefix: "hq-", Path: "."},
+		{Prefix: "au-", Path: "accent_unified_au/mayor/rig"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	externalCwd := filepath.Join(t.TempDir(), "checkout")
+	if err := os.MkdirAll(externalCwd, 0755); err != nil {
+		t.Fatalf("mkdir external cwd: %v", err)
+	}
+	t.Setenv("GT_ROOT", townRoot)
+	t.Setenv("GT_TOWN_ROOT", "")
+
+	got, err := New(externalCwd).targetBeadsDirForCreate(CreateOptions{
+		Title:     "Merge: au-xg5",
+		Rig:       "accent_unified_au",
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("targetBeadsDirForCreate: %v", err)
+	}
+	if got != rigBeadsDir {
+		t.Fatalf("targetBeadsDirForCreate() = %q, want %q", got, rigBeadsDir)
+	}
+}
+
 func TestCreateWithUnknownRigErrors(t *testing.T) {
 	townRoot := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {

--- a/internal/beads/routes_test.go
+++ b/internal/beads/routes_test.go
@@ -82,6 +82,30 @@ func TestGetPrefixForRig_RigsConfigFallback(t *testing.T) {
 	}
 }
 
+func TestResolveHookDirUsesShortPrefixRoute(t *testing.T) {
+	tmpDir := t.TempDir()
+	townBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir town .beads: %v", err)
+	}
+	if err := WriteRoutes(townBeadsDir, []Route{
+		{Prefix: "hq-", Path: "."},
+		{Prefix: "au-", Path: "accent_unified_au/mayor/rig"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	rigDir := filepath.Join(tmpDir, "accent_unified_au", "mayor", "rig")
+	if err := os.MkdirAll(rigDir, 0755); err != nil {
+		t.Fatalf("mkdir rig dir: %v", err)
+	}
+
+	got := ResolveHookDir(tmpDir, "au-xg5", tmpDir)
+	if got != rigDir {
+		t.Fatalf("ResolveHookDir() = %q, want %q", got, rigDir)
+	}
+}
+
 func TestExtractPrefix(t *testing.T) {
 	tests := []struct {
 		beadID   string


### PR DESCRIPTION
## Summary
- make Beads town-root detection fall back to GT_TOWN_ROOT/GT_ROOT when cwd is outside the town
- add regression coverage for accent_unified_au MR routing from an external cwd
- add short-prefix hook routing coverage for au-* formula bonding

## Verification
- go test ./internal/beads -run 'TestCreateRoutesExplicitRigUsingEnvTownRootFromExternalCwd|TestResolveHookDirUsesShortPrefixRoute|TestCreateRoutesToResolvedRigBeadsDir|TestGetPrefixForRig'
- go test ./internal/cmd -run 'TestMRBeadCreationUsesRig|TestDoneUsesResolveBeadsDir|TestDoneBeadsInitBothCodePaths|TestSlingFormulaOnBeadSetsAttachedMolecule|TestSlingRejectsCrossRigMismatch|TestResolveMQSubmitCommitSHAUsesSubmittedBranch|TestVerifyMQSubmitPushedBranchRequiresRemoteBranch'
- go test ./internal/beads
- go test ./internal/beads ./internal/cmd ./internal/mq (fails in unrelated existing internal/cmd tests: agents, convoy, install)