### PR TITLE
fix: show patrol scan progress diagnostics

### DIFF
--- a/internal/cmd/patrol_scan.go
+++ b/internal/cmd/patrol_scan.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"os"
 	"strings"
 	"time"
@@ -41,6 +42,8 @@ Actions taken automatically:
   - Completion routing: MR cleanup wisps created, refinery nudged
 
 Use --notify to send mail when zombies with active work are detected.
+Long-running scan phases emit progress diagnostics to stderr so JSON stdout
+remains machine-readable while operators can see where a slow patrol is stuck.
 
 Examples:
   gt patrol scan                    # Scan current rig
@@ -58,6 +61,8 @@ func init() {
 
 	patrolCmd.AddCommand(patrolScanCmd)
 }
+
+var patrolScanProgressInterval = 10 * time.Second
 
 // PatrolScanOutput is the JSON output format for patrol scan results.
 type PatrolScanOutput struct {
@@ -106,9 +111,9 @@ type PatrolScanStallItem struct {
 
 // PatrolScanCompleteOutput holds completion discovery results.
 type PatrolScanCompleteOutput struct {
-	Checked   int                       `json:"checked"`
-	Found     int                       `json:"found"`
-	Completed []PatrolScanCompleteItem  `json:"completed,omitempty"`
+	Checked   int                      `json:"checked"`
+	Found     int                      `json:"found"`
+	Completed []PatrolScanCompleteItem `json:"completed,omitempty"`
 }
 
 // PatrolScanCompleteItem is a single completion discovery in scan output.
@@ -152,9 +157,16 @@ func runPatrolScan(cmd *cobra.Command, args []string) error {
 	// Note: DetectZombiePolecats takes a router param but does NOT send mail
 	// internally — it only uses the router for workspace context. Notifications
 	// are sent exclusively below via --notify, avoiding double-send.
-	zombieResult := witness.DetectZombiePolecats(bd, workDir, rigName, router)
-	stallResult := witness.DetectStalledPolecats(workDir, rigName)
-	completionResult := witness.DiscoverCompletions(bd, workDir, rigName, router)
+	diagnostics := cmd.ErrOrStderr()
+	zombieResult := runPatrolScanPhase(diagnostics, "zombie detection", func() *witness.DetectZombiePolecatsResult {
+		return witness.DetectZombiePolecats(bd, workDir, rigName, router)
+	})
+	stallResult := runPatrolScanPhase(diagnostics, "stall detection", func() *witness.DetectStalledPolecatsResult {
+		return witness.DetectStalledPolecats(workDir, rigName)
+	})
+	completionResult := runPatrolScanPhase(diagnostics, "completion discovery", func() *witness.DiscoverCompletionsResult {
+		return witness.DiscoverCompletions(bd, workDir, rigName, router)
+	})
 
 	// Build patrol receipts for zombies
 	receipts := witness.BuildPatrolReceipts(rigName, zombieResult)
@@ -175,6 +187,50 @@ func runPatrolScan(cmd *cobra.Command, args []string) error {
 	}
 
 	return outputPatrolScanHuman(rigName, zombieResult, stallResult, completionResult, receipts)
+}
+
+func runPatrolScanPhase[T any](diagnostics io.Writer, name string, fn func() T) T {
+	start := time.Now()
+	if diagnostics != nil {
+		fmt.Fprintf(diagnostics, "gt patrol scan: starting %s\n", name)
+	}
+
+	done := make(chan T, 1)
+	go func() {
+		done <- fn()
+	}()
+
+	if patrolScanProgressInterval <= 0 {
+		result := <-done
+		if diagnostics != nil {
+			fmt.Fprintf(diagnostics, "gt patrol scan: finished %s in %s\n", name, formatPatrolScanElapsed(time.Since(start)))
+		}
+		return result
+	}
+
+	ticker := time.NewTicker(patrolScanProgressInterval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case result := <-done:
+			if diagnostics != nil {
+				fmt.Fprintf(diagnostics, "gt patrol scan: finished %s in %s\n", name, formatPatrolScanElapsed(time.Since(start)))
+			}
+			return result
+		case <-ticker.C:
+			if diagnostics != nil {
+				fmt.Fprintf(diagnostics, "gt patrol scan: still running %s after %s\n", name, formatPatrolScanElapsed(time.Since(start)))
+			}
+		}
+	}
+}
+
+func formatPatrolScanElapsed(elapsed time.Duration) string {
+	if elapsed < time.Second {
+		return elapsed.Round(time.Millisecond).String()
+	}
+	return elapsed.Round(time.Second).String()
 }
 
 func countActiveWorkZombies(result *witness.DetectZombiePolecatsResult) int {

--- a/internal/cmd/patrol_scan_test.go
+++ b/internal/cmd/patrol_scan_test.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"bytes"
 	"encoding/json"
+	"strings"
 	"testing"
+	"time"
 
 	"github.com/steveyegge/gastown/internal/witness"
 )
@@ -100,6 +103,61 @@ func TestCountActiveWorkZombies_Empty(t *testing.T) {
 	got := countActiveWorkZombies(result)
 	if got != 0 {
 		t.Errorf("countActiveWorkZombies() = %d, want 0", got)
+	}
+}
+
+func TestRunPatrolScanPhaseEmitsProgressDiagnostics(t *testing.T) {
+	oldInterval := patrolScanProgressInterval
+	patrolScanProgressInterval = 10 * time.Millisecond
+	defer func() { patrolScanProgressInterval = oldInterval }()
+
+	var diagnostics bytes.Buffer
+	got := runPatrolScanPhase(&diagnostics, "slow phase", func() string {
+		time.Sleep(25 * time.Millisecond)
+		return "ok"
+	})
+
+	if got != "ok" {
+		t.Fatalf("runPatrolScanPhase result = %q, want ok", got)
+	}
+
+	output := diagnostics.String()
+	for _, want := range []string{
+		"gt patrol scan: starting slow phase",
+		"gt patrol scan: still running slow phase after",
+		"gt patrol scan: finished slow phase in",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("diagnostics %q missing %q", output, want)
+		}
+	}
+}
+
+func TestRunPatrolScanPhaseZeroIntervalSkipsProgressTicks(t *testing.T) {
+	oldInterval := patrolScanProgressInterval
+	patrolScanProgressInterval = 0
+	defer func() { patrolScanProgressInterval = oldInterval }()
+
+	var diagnostics bytes.Buffer
+	got := runPatrolScanPhase(&diagnostics, "fast phase", func() int {
+		return 42
+	})
+
+	if got != 42 {
+		t.Fatalf("runPatrolScanPhase result = %d, want 42", got)
+	}
+
+	output := diagnostics.String()
+	if strings.Contains(output, "still running") {
+		t.Fatalf("diagnostics should not include progress tick when interval is disabled: %q", output)
+	}
+	for _, want := range []string{
+		"gt patrol scan: starting fast phase",
+		"gt patrol scan: finished fast phase in",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("diagnostics %q missing %q", output, want)
+		}
 	}
 }
 

--- a/internal/cmd/patrol_scan_test.go
+++ b/internal/cmd/patrol_scan_test.go
@@ -4,11 +4,25 @@ import (
 	"bytes"
 	"encoding/json"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/witness"
 )
+
+type progressDiagnostics struct {
+	bytes.Buffer
+	sawProgress chan struct{}
+	once        sync.Once
+}
+
+func (d *progressDiagnostics) Write(p []byte) (int, error) {
+	if strings.Contains(string(p), "still running") {
+		d.once.Do(func() { close(d.sawProgress) })
+	}
+	return d.Buffer.Write(p)
+}
 
 func TestPatrolScanOutputJSON(t *testing.T) {
 	output := PatrolScanOutput{
@@ -111,9 +125,18 @@ func TestRunPatrolScanPhaseEmitsProgressDiagnostics(t *testing.T) {
 	patrolScanProgressInterval = 10 * time.Millisecond
 	defer func() { patrolScanProgressInterval = oldInterval }()
 
-	var diagnostics bytes.Buffer
-	got := runPatrolScanPhase(&diagnostics, "slow phase", func() string {
-		time.Sleep(25 * time.Millisecond)
+	diagnostics := &progressDiagnostics{sawProgress: make(chan struct{})}
+	release := make(chan struct{})
+	go func() {
+		select {
+		case <-diagnostics.sawProgress:
+		case <-time.After(time.Second):
+		}
+		close(release)
+	}()
+
+	got := runPatrolScanPhase(diagnostics, "slow phase", func() string {
+		<-release
 		return "ok"
 	})
 
@@ -122,6 +145,11 @@ func TestRunPatrolScanPhaseEmitsProgressDiagnostics(t *testing.T) {
 	}
 
 	output := diagnostics.String()
+	select {
+	case <-diagnostics.sawProgress:
+	default:
+		t.Fatalf("diagnostics %q never emitted progress", output)
+	}
 	for _, want := range []string{
 		"gt patrol scan: starting slow phase",
 		"gt patrol scan: still running slow phase after",


### PR DESCRIPTION
Clean replacement for #4236, which is conflicting and carries stale unrelated fork history. Supersedes #4217/#4236 while preserving original contributor credit for adamziel's patrol scan diagnostics fix.

Scope:
- Based on current `gastownhall/gastown:main`
- Includes only the patrol scan diagnostics payload and deterministic test hardening
- Changed files: `internal/cmd/patrol_scan.go`, `internal/cmd/patrol_scan_test.go`
- Excludes the unrelated 85-commit / 157-file history visible on #4236

PR Sheriff validation:
- 15/15 research legs: no-merge #4236 as-is; branch is contaminated/dirty; intended two-file diagnostics fix is sound and policy-allowed
- 5/5 pre-implementation reviews: approved clean upstream-based replacement branch, no force-push to the existing head
- 5/5 post-implementation reviews: approved final clean branch, two-commit/two-file diff, stderr diagnostics, JSON stdout preserved, deterministic tests

Validation run:
- `git diff --check upstream/main...HEAD` passed
- `go test ./internal/cmd -run 'Test(PatrolScan|RunPatrolScanPhase|CountActiveWorkZombies)' -count=1 -v` passed
- `go test -race ./internal/cmd -run '^TestRunPatrolScanPhase' -count=20 -v` passed
- `make build` passed

Known unrelated gate context:
- `go test ./internal/cmd -count=1` failed in existing unrelated areas outside this two-file diff (`agents`, `convoy`, `install` tests). Focused patrol scan tests and build passed.

Final recommendation:
- Do not merge #4236 as-is.
- Review/merge this clean replacement after required CI/checks are green.
