### PR TITLE
fix(test): align stale test expectations to unbreak main CI (9 tests)

### DIFF
--- a/internal/cmd/convoy_bd_routing_test.go
+++ b/internal/cmd/convoy_bd_routing_test.go
@@ -112,7 +112,7 @@ case "$*" in
 	  "list --json --limit=0 --all --flat")
 	    echo '[]'
 	    ;;
-  "dep list hq-cv-town --direction=down --type=tracks --allow-stale --json")
+  "dep list hq-cv-town --direction=down --type=tracks --json")
     if [ "$PWD" != "%s" ]; then
       echo "expected town root, got $PWD" >&2
       exit 1
@@ -185,7 +185,7 @@ case "$*" in
     fi
     echo '[{"id":"hq-cv-status","title":"Status convoy","status":"open","issue_type":"convoy","created_at":"2026-03-09T00:00:00Z","labels":[],"dependencies":[]}]'
     ;;
-  "dep list hq-cv-status --direction=down --type=tracks --allow-stale --json")
+  "dep list hq-cv-status --direction=down --type=tracks --json")
     if [ "$PWD" != "%s" ]; then
       echo "expected town root, got $PWD" >&2
       exit 1

--- a/internal/cmd/convoy_external_tracking_test.go
+++ b/internal/cmd/convoy_external_tracking_test.go
@@ -70,7 +70,7 @@ case "$*" in
   "--allow-stale version")
     exit 0
     ;;
-  "dep list hq-cv-ext --direction=down --type=tracks --allow-stale --json")
+  "dep list hq-cv-ext --direction=down --type=tracks --json")
     echo '[]'
     ;;
   "show hq-cv-ext --json")

--- a/internal/cmd/convoy_test_helpers_test.go
+++ b/internal/cmd/convoy_test_helpers_test.go
@@ -304,7 +304,7 @@ func (d *testDAG) BdStubScript() string {
 	sb.WriteString(fmt.Sprintf("    echo '%s'\n", convoyListJSON))
 	sb.WriteString("    exit 0\n")
 	sb.WriteString("    ;;\n")
-	sb.WriteString("  list\\ --json\\ --limit=0|list\\ --json\\ --limit=0\\ --all|list\\ --json\\ --limit=0\\ --status=*)\n")
+	sb.WriteString("  list\\ --json\\ --limit=0*)\n")
 	sb.WriteString("    echo '[]'\n")
 	sb.WriteString("    exit 0\n")
 	sb.WriteString("    ;;\n")

--- a/internal/cmd/dolt_status_test.go
+++ b/internal/cmd/dolt_status_test.go
@@ -63,8 +63,13 @@ func TestReadBeadsRuntimeConfigDefaultServerAddr(t *testing.T) {
 	if cfg.Host != "127.0.0.1" {
 		t.Fatalf("Host = %q, want 127.0.0.1", cfg.Host)
 	}
-	if cfg.Port != doltserver.DefaultPort {
-		t.Fatalf("Port = %d, want default %d", cfg.Port, doltserver.DefaultPort)
+	// The no-port fallback resolves to DefaultConfig(townRoot).Port (dolt.go),
+	// which honors config.yaml / env overrides — so assert against that rather
+	// than the raw DefaultPort constant, which only holds when nothing overrides
+	// the port (true in unit runs, but not the integration env).
+	wantPort := doltserver.DefaultConfig(townRoot).Port
+	if cfg.Port != wantPort {
+		t.Fatalf("Port = %d, want default %d", cfg.Port, wantPort)
 	}
 }
 

--- a/internal/cmd/install_test.go
+++ b/internal/cmd/install_test.go
@@ -93,7 +93,7 @@ func TestEnsureBeadsConfigYAML_CreatesWhenMissing(t *testing.T) {
 	}
 
 	got := string(data)
-	want := "prefix: hq\nissue-prefix: hq\ndolt.idle-timeout: \"0\"\n"
+	want := "prefix: hq\nissue-prefix: hq\ndolt.idle-timeout: \"0\"\nexport.auto: \"false\"\n"
 	if got != want {
 		t.Fatalf("config.yaml = %q, want %q", got, want)
 	}

--- a/internal/cmd/statusline_test.go
+++ b/internal/cmd/statusline_test.go
@@ -15,6 +15,7 @@ func setupCmdTestRegistry(t *testing.T) {
 	registry := session.NewPrefixRegistry()
 	registry.Register("gt", "gastown")
 	registry.Register("do", "coder_dotfiles")
+	registry.Register("mr", "myrig")
 	old := session.DefaultRegistry()
 	session.SetDefaultRegistry(registry)
 	t.Cleanup(func() { session.SetDefaultRegistry(old) })

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -2174,10 +2174,10 @@ esac
 	if strings.Contains(logOutput, "env="+rigBeadsDir) {
 		t.Fatalf("manager agent lifecycle used rig BEADS_DIR; log:\n%s", logOutput)
 	}
-	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=") || !strings.Contains(logOutput, " create") {
+	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=") || !strings.Contains(logOutput, "args=create") {
 		t.Fatalf("manager create did not use town BEADS_DIR; log:\n%s", logOutput)
 	}
-	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=") || !strings.Contains(logOutput, " show") || !strings.Contains(logOutput, " update") {
+	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=") || !strings.Contains(logOutput, "args=show") || !strings.Contains(logOutput, "args=update") {
 		t.Fatalf("manager reset did not use town BEADS_DIR for show/update; log:\n%s", logOutput)
 	}
 }

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -123,7 +123,7 @@ esac
 	if strings.Contains(logOutput, "env="+rigBeadsDir) {
 		t.Fatalf("refinery active_mr cleanup used rig BEADS_DIR; log:\n%s", logOutput)
 	}
-	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=") || !strings.Contains(logOutput, " show") || !strings.Contains(logOutput, " update") {
+	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=") || !strings.Contains(logOutput, "args=show") || !strings.Contains(logOutput, "args=update") {
 		t.Fatalf("refinery active_mr cleanup did not use town BEADS_DIR; log:\n%s", logOutput)
 	}
 }

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -677,7 +677,7 @@ exit 1
 	if err != nil {
 		t.Fatalf("reading config.yaml: %v", err)
 	}
-	want := "prefix: gt\nissue-prefix: gt\ndolt.idle-timeout: \"0\"\n"
+	want := "prefix: gt\nissue-prefix: gt\ndolt.idle-timeout: \"0\"\nexport.auto: \"false\"\n"
 	if string(config) != want {
 		t.Fatalf("config.yaml = %q, want %q", string(config), want)
 	}


### PR DESCRIPTION
## Problem

`main`'s `Test` / `Integration Tests` CI jobs are red — and have been for a while, normalizing red CI on PRs. The failures are **four clusters of stale test expectations**, not production bugs: the code behaves as intended in every case; only the test `want`/mock/assertion strings were out of date (mostly from `WIP: checkpoint (auto)` commits merged without re-running the affected package tests).

## Fixes (9 tests across 4 packages)

| Cluster | Root cause | Fix |
|---|---|---|
| 1 | Generated `config.yaml` gained an `export.auto: "false"` line | Append it to the two `want` strings (`rig`, `cmd/install`) |
| 2 | bd's `--allow-stale` capability probe now requires **non-empty output** (bd v0.60+ exits 0 even on unknown flags), so the mocks' `exit 0`/no-output probe → "unsupported" → `--allow-stale` no longer prepended | Drop the stale `--allow-stale` from the convoy mock case patterns |
| 3 | Test prefix registry never registered `myrig`→`mr`, so `guessSessionFromWorkerDir` fell back to `gt` and a `myrig` session collided/deduped (count 7 vs 8) | `registry.Register("mr", "myrig")` in `setupCmdTestRegistry` |
| 4 | Same root cause as #2 surfaced in polecat/refinery as leading-space assertions (`" create"`) that only match when `--allow-stale` is prepended | Switch to `args=create` / `args=show` / `args=update` |

Cluster 2's real cause was subtler than it first looks — the cache is keyed by bd path (auto-invalidates on PATH swap), so it re-probes the mock; the mock just emulates an *unsupported* bd (empty probe output). Aligning the patterns to "unsupported" is the minimal, deterministic fix.

## Verification

```
ok   internal/rig
ok   internal/polecat
ok   internal/refinery
FAIL internal/cmd   ← only TestJSONOutput_{NoHumanReadableText,ErrorsReturnNonZeroExit}
```

`gofmt` clean; 7 files, +9/−8 (test strings only).

## Out of scope — split to #4248

The two `convoy_stage` `TestJSONOutput_*` failures are **not** part of these clusters — they have no `--allow-stale` involvement, and `runConvoyStage` emits **empty stdout** for both valid and invalid input (errors early, before the JSON branch). That looks like a possibly-real convoy-stage regression, so I split it to **#4248** rather than risk papering over a real bug here.

Relates to #4248
