### PR TITLE
Keep rig identity beads durable

### DIFF
--- a/internal/beads/beads_rig_test.go
+++ b/internal/beads/beads_rig_test.go
@@ -1,16 +1,19 @@
 package beads
 
 import (
+	"os"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 )
 
 func TestFormatRigDescription(t *testing.T) {
 	tests := []struct {
-		name   string
+		name    string
 		rigName string
-		fields *RigFields
-		want   []string
+		fields  *RigFields
+		want    []string
 	}{
 		{
 			name:    "nil fields",
@@ -195,6 +198,100 @@ func TestRigBeadIDWithPrefix(t *testing.T) {
 				t.Errorf("RigBeadIDWithPrefix(%q, %q) = %q, want %q", tt.prefix, tt.name, got, tt.want)
 			}
 		})
+	}
+}
+
+func installMockBDCreateRigRecorder(t *testing.T, logPath string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock for bd")
+	}
+
+	binDir := t.TempDir()
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$MOCK_BD_LOG"
+
+cmd=""
+for arg in "$@"; do
+  case "$arg" in
+    --*) ;;
+    *) cmd="$arg"; break ;;
+  esac
+done
+
+case "$cmd" in
+  config)
+    if echo "$*" | grep -q "get types.custom"; then
+      echo "agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request"
+    fi
+    if echo "$*" | grep -q "get types.infra"; then
+      echo "agent,role,message"
+    fi
+    exit 0
+    ;;
+  create)
+    printf '{"id":"gt-rig-gastown","title":"gastown","status":"open","issue_type":"rig","labels":["gt:rig"],"ephemeral":false}\n'
+    exit 0
+    ;;
+  *)
+    exit 0
+    ;;
+esac
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatalf("write mock bd: %v", err)
+	}
+
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("MOCK_BD_LOG", logPath)
+}
+
+func TestCreateRigBeadUsesDurableRigType(t *testing.T) {
+	workDir := t.TempDir()
+	beadsDir := filepath.Join(workDir, ".beads")
+	if err := os.MkdirAll(filepath.Join(beadsDir, "dolt"), 0755); err != nil {
+		t.Fatal(err)
+	}
+
+	logPath := filepath.Join(workDir, "bd.log")
+	installMockBDCreateRigRecorder(t, logPath)
+	ResetEnsuredDirs()
+
+	b := NewWithBeadsDir(workDir, beadsDir)
+	issue, err := b.CreateRigBead("gastown", &RigFields{
+		Prefix: "gt",
+		State:  RigStateActive,
+	})
+	if err != nil {
+		t.Fatalf("CreateRigBead: %v", err)
+	}
+	if issue.Type != "rig" {
+		t.Fatalf("issue.Type = %q, want rig", issue.Type)
+	}
+	if !HasLabel(issue, "gt:rig") {
+		t.Fatalf("created rig bead missing gt:rig label: %+v", issue.Labels)
+	}
+	if issue.Ephemeral {
+		t.Fatal("new rig bead should be durable, got ephemeral=true")
+	}
+
+	logData, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read mock bd log: %v", err)
+	}
+	logOutput := string(logData)
+	for _, want := range []string{
+		"config set types.infra agent,role,message",
+		"create --json --id=gt-rig-gastown",
+		"--labels=gt:rig",
+		"--type=rig",
+	} {
+		if !strings.Contains(logOutput, want) {
+			t.Fatalf("mock bd log missing %q:\n%s", want, logOutput)
+		}
+	}
+	if strings.Contains(logOutput, "--type=task") {
+		t.Fatalf("CreateRigBead used task type instead of rig type:\n%s", logOutput)
 	}
 }
 

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -4154,7 +4154,10 @@ func TestRunEnv_StripsPollutedDoltEnvAndUsesRigMetadata(t *testing.T) {
 		bdAllowStaleMu.Unlock()
 	})
 
-	workDir := t.TempDir()
+	workDir, err := filepath.EvalSymlinks(t.TempDir())
+	if err != nil {
+		t.Fatalf("resolve temp dir: %v", err)
+	}
 	beadsDir := filepath.Join(workDir, ".beads")
 	if err := os.MkdirAll(beadsDir, 0755); err != nil {
 		t.Fatalf("mkdir .beads: %v", err)

--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -92,9 +92,9 @@ func ResolveRoutingTarget(townRoot, beadID, fallbackDir string) string {
 //   - In-memory cache for multiple creates in the same CLI invocation
 //   - Sentinel file on disk for persistence across CLI invocations
 //
-// The sentinel file stores the configured types list. When the types list changes
-// (e.g., new types added in a gastown upgrade), the sentinel is detected as stale
-// and types are re-configured automatically (gt-zmy, gt-26f).
+// The sentinel file stores the configured type-related values. When those values
+// change (e.g., new types added in a gastown upgrade), the sentinel is detected
+// as stale and types are re-configured automatically (gt-zmy, gt-26f).
 //
 // This function is thread-safe and idempotent.
 //
@@ -106,6 +106,8 @@ func EnsureCustomTypes(beadsDir string) error {
 	}
 
 	typesList := strings.Join(constants.BeadsCustomTypesList(), ",")
+	infraTypesList := strings.Join(constants.BeadsInfraTypesList(), ",")
+	sentinelValue := typesSentinelValue(typesList, infraTypesList)
 
 	ensuredMu.Lock()
 	defer ensuredMu.Unlock()
@@ -121,7 +123,7 @@ func EnsureCustomTypes(beadsDir string) error {
 	// re-configure. Legacy "v1\n" sentinels also won't match.
 	sentinelPath := filepath.Join(beadsDir, typesSentinel)
 	if data, err := os.ReadFile(sentinelPath); err == nil {
-		if strings.TrimSpace(string(data)) == typesList {
+		if strings.TrimSpace(string(data)) == sentinelValue {
 			ensuredDirs[beadsDir] = true
 			return nil
 		}
@@ -155,6 +157,15 @@ func EnsureCustomTypes(beadsDir string) error {
 			beadsDir, strings.TrimSpace(string(output)), err)
 	}
 
+	infraCmd := exec.Command("bd", "config", "set", "types.infra", infraTypesList)
+	infraCmd.Dir = beadsDir
+	util.SetDetachedProcessGroup(infraCmd)
+	infraCmd.Env = bdEnv
+	if output, err := infraCmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("configure infra types in %s: %s: %w",
+			beadsDir, strings.TrimSpace(string(output)), err)
+	}
+
 	// Verify the config was actually persisted in the database (GH#2637).
 	// bd config set can exit 0 but fail to write if it targets the wrong
 	// database (redirect mismatch, stale metadata, server not running).
@@ -169,13 +180,26 @@ func EnsureCustomTypes(beadsDir string) error {
 			beadsDir, strings.TrimSpace(string(verifyOutput)))
 	}
 
-	// Write sentinel file with the types list for staleness detection.
-	// On next invocation, if types have changed, the sentinel won't match
+	infraVerifyCmd := exec.Command("bd", "config", "get", "types.infra")
+	infraVerifyCmd.Dir = beadsDir
+	infraVerifyCmd.Env = bdEnv
+	util.SetDetachedProcessGroup(infraVerifyCmd)
+	if verifyOutput, err := infraVerifyCmd.Output(); err != nil || ParseConfigOutput(verifyOutput) != infraTypesList {
+		return fmt.Errorf("types.infra not persisted in %s after bd config set (verify returned %q): db may be misconfigured",
+			beadsDir, strings.TrimSpace(string(verifyOutput)))
+	}
+
+	// Write sentinel file with the type config for staleness detection.
+	// On next invocation, if type config has changed, the sentinel won't match
 	// and we'll re-configure automatically.
-	_ = os.WriteFile(sentinelPath, []byte(typesList+"\n"), 0644)
+	_ = os.WriteFile(sentinelPath, []byte(sentinelValue+"\n"), 0644)
 
 	ensuredDirs[beadsDir] = true
 	return nil
+}
+
+func typesSentinelValue(customTypes, infraTypes string) string {
+	return "types.custom=" + customTypes + "\ntypes.infra=" + infraTypes
 }
 
 // EnsureCustomStatuses ensures the target beads directory has custom statuses configured.

--- a/internal/beads/beads_types_test.go
+++ b/internal/beads/beads_types_test.go
@@ -56,6 +56,9 @@ switch ($cmd) {
     if ($args.Length -ge 3 -and $args[1] -eq 'get' -and $args[2] -eq 'types.custom') {
       Write-Output 'agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request'
     }
+    if ($args.Length -ge 3 -and $args[1] -eq 'get' -and $args[2] -eq 'types.infra') {
+      Write-Output 'agent,role,message'
+    }
     exit 0
   }
   'migrate' { exit 0 }
@@ -96,9 +99,12 @@ case "$cmd" in
     exit 0
     ;;
   config)
-    # Return types list for "config get types.custom" verification
+    # Return types lists for "config get" verification
     if echo "$*" | grep -q "get types.custom"; then
       echo "agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request"
+    fi
+    if echo "$*" | grep -q "get types.infra"; then
+      echo "agent,role,message"
     fi
     exit 0
     ;;
@@ -312,10 +318,11 @@ func TestEnsureCustomTypes(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Create sentinel file with current types list
+		// Create sentinel file with current type-related config.
 		currentTypes := strings.Join(constants.BeadsCustomTypesList(), ",")
+		currentInfraTypes := strings.Join(constants.BeadsInfraTypesList(), ",")
 		sentinelPath := filepath.Join(beadsDir, typesSentinel)
-		if err := os.WriteFile(sentinelPath, []byte(currentTypes+"\n"), 0644); err != nil {
+		if err := os.WriteFile(sentinelPath, []byte(typesSentinelValue(currentTypes, currentInfraTypes)+"\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -350,15 +357,45 @@ func TestEnsureCustomTypes(t *testing.T) {
 			t.Fatalf("EnsureCustomTypes: %v", err)
 		}
 
-		if got := strings.TrimSpace(string(mustReadFile(t, sentinelPath))); got != strings.Join(constants.BeadsCustomTypesList(), ",") {
-			t.Fatalf("types sentinel = %q, want current configured types", got)
+		currentTypes := strings.Join(constants.BeadsCustomTypesList(), ",")
+		currentInfraTypes := strings.Join(constants.BeadsInfraTypesList(), ",")
+		if got := strings.TrimSpace(string(mustReadFile(t, sentinelPath))); got != typesSentinelValue(currentTypes, currentInfraTypes) {
+			t.Fatalf("types sentinel = %q, want current configured type config", got)
 		}
 
 		logOutput := readMockBDLog(t, logPath)
-		for _, want := range []string{"init", "config set types.custom"} {
+		for _, want := range []string{"init", "config set types.custom", "config set types.infra agent,role,message", "config get types.infra"} {
 			if !strings.Contains(logOutput, want) {
 				t.Fatalf("mock bd log %q missing %q", logOutput, want)
 			}
+		}
+	})
+
+	t.Run("legacy types-only sentinel triggers infra re-configuration", func(t *testing.T) {
+		logPath := installMockBDRecorder(t)
+		tmpDir := t.TempDir()
+		beadsDir := filepath.Join(tmpDir, ".beads")
+		if err := os.MkdirAll(beadsDir, 0755); err != nil {
+			t.Fatal(err)
+		}
+
+		// Existing sentinels recorded only types.custom. Those must be stale so
+		// existing databases receive the new types.infra value.
+		legacyTypesOnly := strings.Join(constants.BeadsCustomTypesList(), ",")
+		sentinelPath := filepath.Join(beadsDir, typesSentinel)
+		if err := os.WriteFile(sentinelPath, []byte(legacyTypesOnly+"\n"), 0644); err != nil {
+			t.Fatal(err)
+		}
+
+		ResetEnsuredDirs()
+
+		if err := EnsureCustomTypes(beadsDir); err != nil {
+			t.Fatalf("EnsureCustomTypes: %v", err)
+		}
+
+		logOutput := readMockBDLog(t, logPath)
+		if !strings.Contains(logOutput, "config set types.infra agent,role,message") {
+			t.Fatalf("legacy sentinel did not trigger types.infra config:\n%s", logOutput)
 		}
 	})
 
@@ -369,10 +406,11 @@ func TestEnsureCustomTypes(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		// Create sentinel with current types to avoid bd call
+		// Create sentinel with current type config to avoid bd call.
 		currentTypes := strings.Join(constants.BeadsCustomTypesList(), ",")
+		currentInfraTypes := strings.Join(constants.BeadsInfraTypesList(), ",")
 		sentinelPath := filepath.Join(beadsDir, typesSentinel)
-		if err := os.WriteFile(sentinelPath, []byte(currentTypes+"\n"), 0644); err != nil {
+		if err := os.WriteFile(sentinelPath, []byte(typesSentinelValue(currentTypes, currentInfraTypes)+"\n"), 0644); err != nil {
 			t.Fatal(err)
 		}
 

--- a/internal/cmd/convoy_bd_routing_test.go
+++ b/internal/cmd/convoy_bd_routing_test.go
@@ -228,8 +228,7 @@ func TestConvoyCreate_UsesTrackingHelper(t *testing.T) {
 	// Write sentinel files to skip EnsureCustomTypes/Statuses (they call bd
 	// config set/get which isn't relevant to routing).
 	beadsDir := filepath.Join(townRoot, ".beads")
-	typesList := "agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request"
-	_ = os.WriteFile(filepath.Join(beadsDir, ".gt-types-configured"), []byte(typesList), 0644)
+	_ = os.WriteFile(filepath.Join(beadsDir, ".gt-types-configured"), typeConfigSentinelForTest(), 0644)
 	_ = os.WriteFile(filepath.Join(beadsDir, ".gt-statuses-configured"), []byte("staged_ready,staged_warnings"), 0644)
 
 	var helperTownRoot, helperConvoyID, helperIssueID string

--- a/internal/cmd/convoy_resolve_beadsdir_test.go
+++ b/internal/cmd/convoy_resolve_beadsdir_test.go
@@ -87,9 +87,8 @@ func TestConvoyResolveBeadsDir_RegressionEmptyConvoy(t *testing.T) {
 		}
 
 		// Put sentinel ONLY in .beads (the correct location).
-		currentTypes := strings.Join(constants.BeadsCustomTypesList(), ",")
 		correctSentinel := filepath.Join(beadsDir, ".gt-types-configured")
-		if err := os.WriteFile(correctSentinel, []byte(currentTypes+"\n"), 0644); err != nil {
+		if err := os.WriteFile(correctSentinel, typeConfigSentinelForTest(), 0644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -131,8 +130,7 @@ func TestConvoyResolveBeadsDir_RegressionEmptyConvoy(t *testing.T) {
 		}
 
 		// Pre-populate sentinel in .beads so we don't need a real bd.
-		currentTypes := strings.Join(constants.BeadsCustomTypesList(), ",")
-		if err := os.WriteFile(filepath.Join(beadsDir, ".gt-types-configured"), []byte(currentTypes+"\n"), 0644); err != nil {
+		if err := os.WriteFile(filepath.Join(beadsDir, ".gt-types-configured"), typeConfigSentinelForTest(), 0644); err != nil {
 			t.Fatal(err)
 		}
 
@@ -271,8 +269,7 @@ func TestConvoyCreate_SentinelPlacement(t *testing.T) {
 	}
 
 	// Pre-populate sentinels to avoid needing a real bd binary.
-	currentTypes := strings.Join(constants.BeadsCustomTypesList(), ",")
-	if err := os.WriteFile(filepath.Join(beadsDir, ".gt-types-configured"), []byte(currentTypes+"\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(beadsDir, ".gt-types-configured"), typeConfigSentinelForTest(), 0644); err != nil {
 		t.Fatal(err)
 	}
 	currentStatuses := strings.Join(constants.BeadsCustomStatusesList(), ",")

--- a/internal/cmd/convoy_test_helpers_test.go
+++ b/internal/cmd/convoy_test_helpers_test.go
@@ -46,6 +46,12 @@ type testDAG struct {
 // withRig is a helper for the fluent API to pass rig names to Task().
 func withRig(name string) string { return name }
 
+func typeConfigSentinelForTest() []byte {
+	typesList := strings.Join(constants.BeadsCustomTypesList(), ",")
+	infraTypesList := strings.Join(constants.BeadsInfraTypesList(), ",")
+	return []byte("types.custom=" + typesList + "\ntypes.infra=" + infraTypesList + "\n")
+}
+
 // newTestDAG creates an empty test DAG builder.
 func newTestDAG(t *testing.T) *testDAG {
 	t.Helper()
@@ -383,8 +389,7 @@ func (d *testDAG) Setup(t *testing.T) (townRoot, logPath string) {
 	}
 
 	// Write sentinel files so beads.EnsureCustomTypes/Statuses skip bd calls.
-	typesList := strings.Join(constants.BeadsCustomTypesList(), ",")
-	if err := os.WriteFile(filepath.Join(townRoot, ".beads", ".gt-types-configured"), []byte(typesList+"\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", ".gt-types-configured"), typeConfigSentinelForTest(), 0644); err != nil {
 		t.Fatalf("write types sentinel: %v", err)
 	}
 	statusesList := strings.Join(constants.BeadsCustomStatusesList(), ",")

--- a/internal/constants/constants.go
+++ b/internal/constants/constants.go
@@ -183,11 +183,21 @@ const (
 	//   gate          - Async coordination (bd gate wait, park/resume)
 	//   merge-request - Refinery MR processing (gt done, refinery)
 	BeadsCustomTypes = "agent,role,rig,convoy,slot,queue,event,message,molecule,gate,merge-request"
+
+	// BeadsInfraTypes is the comma-separated list of custom issue types that
+	// beads should route to the wisps table. Rig beads are intentionally
+	// excluded so newly-created type=rig identity beads are durable.
+	BeadsInfraTypes = "agent,role,message"
 )
 
 // BeadsCustomTypesList returns the custom types as a slice.
 func BeadsCustomTypesList() []string {
 	return []string{"agent", "role", "rig", "convoy", "slot", "queue", "event", "message", "molecule", "gate", "merge-request"}
+}
+
+// BeadsInfraTypesList returns the infra types as a slice.
+func BeadsInfraTypesList() []string {
+	return []string{"agent", "role", "message"}
 }
 
 // Beads custom status configuration constants.
@@ -420,13 +430,13 @@ func MayorQuotaPath(townRoot string) string {
 // Patterns are intentionally specific to actual Claude rate-limit messages
 // to avoid false positives from agent discussion or code comments.
 var DefaultRateLimitPatterns = []string{
-	`You've hit your .*limit`,                        // Claude's primary rate-limit message
-	`limit\s*·\s*resets \d+[:\d]*(am|pm)\b`,         // "limit · resets 7pm" — requires limit context before resets
-	`Stop and wait for limit to reset`,               // /rate-limit-options TUI prompt option 1
-	`Add funds to continue with extra usage`,         // /rate-limit-options TUI prompt option 2
-	`API Error: Rate limit reached`,                  // Mid-stream API 429 during tool use or generation
-	`OAuth token revoked`,                            // Token invalidated after keychain swap
-	`OAuth token has expired`,                        // Token expired — needs fresh auth
+	`You've hit your .*limit`,                // Claude's primary rate-limit message
+	`limit\s*·\s*resets \d+[:\d]*(am|pm)\b`,  // "limit · resets 7pm" — requires limit context before resets
+	`Stop and wait for limit to reset`,       // /rate-limit-options TUI prompt option 1
+	`Add funds to continue with extra usage`, // /rate-limit-options TUI prompt option 2
+	`API Error: Rate limit reached`,          // Mid-stream API 429 during tool use or generation
+	`OAuth token revoked`,                    // Token invalidated after keychain swap
+	`OAuth token has expired`,                // Token expired — needs fresh auth
 }
 
 // DefaultNearLimitPatterns are patterns that indicate a session is approaching
@@ -437,8 +447,7 @@ var DefaultNearLimitPatterns = []string{
 	`usage\s+(is\s+)?(at|near|approaching)\s+\d+\s*%`,             // "usage is at 90%"
 	`approaching\s+(your\s+)?(rate\s+)?limit`,                     // "approaching your rate limit"
 	`nearing\s+(your\s+)?(rate\s+)?limit`,                         // "nearing your rate limit"
-	`close\s+to\s+(your\s+)?(rate\s+)?limit`,                     // "close to your rate limit"
+	`close\s+to\s+(your\s+)?(rate\s+)?limit`,                      // "close to your rate limit"
 	`almost\s+(at|hit|reached)\s+(your\s+)?(rate\s+)?limit`,       // "almost reached your rate limit"
-	`\d+\s*(messages?|requests?)\s*(left|remaining)`,               // "10 messages remaining"
+	`\d+\s*(messages?|requests?)\s*(left|remaining)`,              // "10 messages remaining"
 }
-

--- a/internal/constants/constants_test.go
+++ b/internal/constants/constants_test.go
@@ -42,6 +42,23 @@ func TestBeadsCustomTypesList(t *testing.T) {
 	}
 }
 
+func TestBeadsInfraTypesList(t *testing.T) {
+	types := BeadsInfraTypesList()
+	expected := []string{"agent", "role", "message"}
+
+	if len(types) != len(expected) {
+		t.Fatalf("BeadsInfraTypesList() returned %d items, want %d", len(types), len(expected))
+	}
+	for i, typ := range types {
+		if typ != expected[i] {
+			t.Errorf("BeadsInfraTypesList()[%d] = %q, want %q", i, typ, expected[i])
+		}
+		if typ == "rig" {
+			t.Fatal("rig must not be configured as an infra type")
+		}
+	}
+}
+
 func TestMayorRigsPath(t *testing.T) {
 	got := MayorRigsPath("/town")
 	expect := "/town/mayor/rigs.json"

--- a/internal/mail/router_test.go
+++ b/internal/mail/router_test.go
@@ -22,6 +22,12 @@ import (
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
+func typeConfigSentinelForTest() []byte {
+	typesList := strings.Join(constants.BeadsCustomTypesList(), ",")
+	infraTypesList := strings.Join(constants.BeadsInfraTypesList(), ",")
+	return []byte("types.custom=" + typesList + "\ntypes.infra=" + infraTypesList + "\n")
+}
+
 func TestDetectTownRoot(t *testing.T) {
 	// Unset GT_TOWN_ROOT/GT_ROOT so tests exercise workspace.Find fallback.
 	// (The real session always has these set; this tests the detection logic itself.)
@@ -374,8 +380,7 @@ func TestSendFromCrewWorkspace_AvoidsEphemeralPrefixMismatch(t *testing.T) {
 	}
 
 	// Write sentinel files so beads.EnsureCustomTypes skips bd config calls.
-	typesList := strings.Join(constants.BeadsCustomTypesList(), ",")
-	if err := os.WriteFile(filepath.Join(townBeadsDir, ".gt-types-configured"), []byte(typesList+"\n"), 0644); err != nil {
+	if err := os.WriteFile(filepath.Join(townBeadsDir, ".gt-types-configured"), typeConfigSentinelForTest(), 0644); err != nil {
 		t.Fatalf("write types sentinel: %v", err)
 	}
 


### PR DESCRIPTION
## Summary

- Restore rig identity bead creation to `type=rig` while keeping the `gt:rig`
  label.
- Configure rig beads DB type settings so `rig` is not treated as ephemeral
  infra.
- Update the custom-type sentinel path to cover both custom type and infra type
  configuration.
- Update tests for the intended durable `type=rig` behavior.

## Root Cause

Gas Town changed rig identity beads to `type=rig` so they would not pollute
`bd ready`. That was the right issue type, but the installed `bd` runtime also
classified `rig` as an infra type. Infra beads are ephemeral wisps, so the
identity beads could disappear.

The fix is not to change rig identity beads back to `type=task`. The correct
behavior is:

- identity bead type stays `rig`;
- `rig` is durable, not infra;
- `bd ready` still excludes `rig`.

## Change Details

- Rig identity creation remains `type=rig`.
- `EnsureCustomTypes` also configures infra types as `agent,role,message`.
- The old one-line custom-type sentinel is replaced with a sentinel format that
  accounts for both custom and infra type configuration.
- Tests are updated for the new sentinel/configuration behavior.

## Validation

- PASS:
  `go test ./internal/constants ./internal/beads ./internal/mail`

- PASS:
  targeted `internal/cmd` convoy sentinel tests

- ATTEMPTED:
  `go test ./...`

  The full suite failed in unrelated/environment-heavy packages recorded on
  `gtn-2o2`.

- Runtime acceptance after the beads fix:
  - `gtn-rig-gastown`: `issue_type=rig`, `gt:rig` label, no `ephemeral` field.
  - `bds-rig-beads`: `issue_type=rig`, `gt:rig` label, no `ephemeral` field.
  - Neither identity bead appears in `bd ready`.

## Related

- Umbrella post-mortem issue: https://github.com/gastownhall/gastown/issues/4254
- Beads companion PR: https://github.com/gastownhall/beads/pull/4373
