### PR TITLE
fix: route cleanup wisps through active rig

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -437,6 +437,19 @@ func (b *Beads) getActor() string {
 func (b *Beads) getTownRoot() string {
 	b.townRootOnce.Do(func() {
 		b.townRoot = FindTownRoot(b.workDir)
+		if b.townRoot != "" {
+			return
+		}
+		for _, envName := range []string{"GT_TOWN_ROOT", "GT_ROOT"} {
+			townRoot := os.Getenv(envName)
+			if townRoot == "" {
+				continue
+			}
+			if _, err := os.Stat(filepath.Join(townRoot, "mayor", "town.json")); err == nil {
+				b.townRoot = townRoot
+				return
+			}
+		}
 	})
 	return b.townRoot
 }

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -552,6 +552,50 @@ exit 0
 	}
 }
 
+func TestCreateRoutesExplicitRigUsingEnvTownRootFromExternalCwd(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatalf("mkdir mayor: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+
+	townBeadsDir := filepath.Join(townRoot, ".beads")
+	rigDir := filepath.Join(townRoot, "accent_unified_au", "mayor", "rig")
+	rigBeadsDir := filepath.Join(rigDir, ".beads")
+	for _, dir := range []string{townBeadsDir, rigBeadsDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := WriteRoutes(townBeadsDir, []Route{
+		{Prefix: "hq-", Path: "."},
+		{Prefix: "au-", Path: "accent_unified_au/mayor/rig"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	externalCwd := filepath.Join(t.TempDir(), "checkout")
+	if err := os.MkdirAll(externalCwd, 0755); err != nil {
+		t.Fatalf("mkdir external cwd: %v", err)
+	}
+	t.Setenv("GT_ROOT", townRoot)
+	t.Setenv("GT_TOWN_ROOT", "")
+
+	got, err := New(externalCwd).targetBeadsDirForCreate(CreateOptions{
+		Title:     "Merge: au-xg5",
+		Rig:       "accent_unified_au",
+		Ephemeral: true,
+	})
+	if err != nil {
+		t.Fatalf("targetBeadsDirForCreate: %v", err)
+	}
+	if got != rigBeadsDir {
+		t.Fatalf("targetBeadsDirForCreate() = %q, want %q", got, rigBeadsDir)
+	}
+}
+
 func TestCreateWithUnknownRigErrors(t *testing.T) {
 	townRoot := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {

--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -64,16 +64,14 @@ func ResolveRoutingTarget(townRoot, beadID, fallbackDir string) string {
 		return fallbackDir
 	}
 
-	// Extract prefix from bead ID (e.g., "gt-gastown-polecat-Toast" -> "gt-")
-	prefix := ExtractPrefix(beadID)
-	if prefix == "" {
+	if ExtractPrefix(beadID) == "" {
 		return fallbackDir
 	}
 
-	// Look up rig path for this prefix
-	rigPath := GetRigPathForPrefix(townRoot, prefix)
+	// Look up rig path using the longest configured route prefix.
+	rigPath := GetRigPathForBeadID(townRoot, beadID)
 	if rigPath == "" {
-		fmt.Fprintf(os.Stderr, "Warning: no route found for prefix %q (bead %s), falling back to %s\n", prefix, beadID, fallbackDir)
+		fmt.Fprintf(os.Stderr, "Warning: no route found for bead %s, falling back to %s\n", beadID, fallbackDir)
 		return fallbackDir
 	}
 

--- a/internal/beads/routes.go
+++ b/internal/beads/routes.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 
 	"github.com/steveyegge/gastown/internal/config"
@@ -285,6 +286,45 @@ func GetRigPathForPrefix(townRoot, prefix string) string {
 	return ""
 }
 
+// GetRouteForBeadID returns the longest configured route whose prefix matches
+// beadID. This supports multi-segment prefixes such as hq-cv- and
+// accent-unified-, while preserving ExtractPrefix for callers that only need a
+// syntactic first-segment prefix.
+func GetRouteForBeadID(townRoot, beadID string) (Route, bool) {
+	beadsDir := filepath.Join(townRoot, ".beads")
+	routes, err := LoadRoutes(beadsDir)
+	if err != nil || routes == nil {
+		return Route{}, false
+	}
+	return longestMatchingRoute(routes, beadID)
+}
+
+func longestMatchingRoute(routes []Route, beadID string) (Route, bool) {
+	sorted := append([]Route(nil), routes...)
+	sort.SliceStable(sorted, func(i, j int) bool {
+		return len(sorted[i].Prefix) > len(sorted[j].Prefix)
+	})
+	for _, r := range sorted {
+		if r.Prefix != "" && strings.HasPrefix(beadID, r.Prefix) {
+			return r, true
+		}
+	}
+	return Route{}, false
+}
+
+// GetRigPathForBeadID returns the rig path for beadID using the longest matching
+// configured route prefix. For town-level beads (path="."), returns townRoot.
+func GetRigPathForBeadID(townRoot, beadID string) string {
+	route, ok := GetRouteForBeadID(townRoot, beadID)
+	if !ok {
+		return ""
+	}
+	if route.Path == "." {
+		return townRoot
+	}
+	return filepath.Join(townRoot, route.Path)
+}
+
 // GetRigDirForName returns the rig directory path for a named rig.
 // The rig directory is the parent of the rig's .beads database and is the
 // directory that contains the rig's .beads database. Returns empty string if the rig is not
@@ -471,14 +511,27 @@ func GetRigNameForPrefix(townRoot, prefix string) string {
 	return ""
 }
 
+// GetRigNameForBeadID returns the rig name that owns beadID by longest matching
+// configured route prefix. Returns empty string for town-level or unknown routes.
+func GetRigNameForBeadID(townRoot, beadID string) string {
+	route, ok := GetRouteForBeadID(townRoot, beadID)
+	if !ok || route.Path == "." {
+		return ""
+	}
+	parts := strings.SplitN(route.Path, "/", 2)
+	if len(parts) == 0 {
+		return ""
+	}
+	return parts[0]
+}
+
 // ResolveBeadsDirForID resolves the correct .beads directory for a given bead ID
 // based on prefix routing. currentBeadsDir is the caller's default beads directory
 // (typically the town-level .beads). If the bead ID's prefix maps to a different
 // rig via routes.jsonl, the resolved rig's beads directory is returned.
 // Returns currentBeadsDir if no routing is needed or prefix can't be resolved.
 func ResolveBeadsDirForID(currentBeadsDir, beadID string) string {
-	prefix := ExtractPrefix(beadID)
-	if prefix == "" {
+	if beadID == "" || ExtractPrefix(beadID) == "" {
 		return currentBeadsDir
 	}
 
@@ -497,20 +550,19 @@ func ResolveBeadsDirForID(currentBeadsDir, beadID string) string {
 		return currentBeadsDir
 	}
 
-	for _, r := range routes {
-		if r.Prefix == prefix {
-			if r.Path == "." {
-				return routesBeadsDir
-			}
-			// Rig-level bead — resolve to rig's beads directory.
-			// Derive town root from the routes directory we actually used.
-			townRoot := filepath.Dir(routesBeadsDir)
-			rigDir := filepath.Join(townRoot, r.Path)
-			return ResolveBeadsDir(rigDir)
-		}
+	r, ok := longestMatchingRoute(routes, beadID)
+	if !ok {
+		return currentBeadsDir
+	}
+	if r.Path == "." {
+		return routesBeadsDir
 	}
 
-	return currentBeadsDir
+	// Rig-level bead — resolve to rig's beads directory.
+	// Derive town root from the routes directory we actually used.
+	townRoot := filepath.Dir(routesBeadsDir)
+	rigDir := filepath.Join(townRoot, r.Path)
+	return ResolveBeadsDir(rigDir)
 }
 
 // ValidateRigPrefix checks that a newly created bead landed in the expected rig's
@@ -523,6 +575,9 @@ func ResolveBeadsDirForID(currentBeadsDir, beadID string) string {
 func ValidateRigPrefix(townRoot, rigName, beadID string) error {
 	expectedPrefix := GetPrefixForRig(townRoot, rigName)           // e.g., "gt"
 	actualPrefix := strings.TrimSuffix(ExtractPrefix(beadID), "-") // e.g., "gt"
+	if route, ok := GetRouteForBeadID(townRoot, beadID); ok {
+		actualPrefix = strings.TrimSuffix(route.Prefix, "-")
+	}
 	if actualPrefix == "" {
 		return nil // Can't determine prefix — not an error
 	}
@@ -539,8 +594,7 @@ func ValidateRigPrefix(townRoot, rigName, beadID string) error {
 // a fallback if prefix resolution fails.
 func ResolveHookDir(townRoot, beadID, hookWorkDir string) string {
 	// Always try prefix resolution first - bd update needs the actual rig dir
-	prefix := ExtractPrefix(beadID)
-	if rigPath := GetRigPathForPrefix(townRoot, prefix); rigPath != "" {
+	if rigPath := GetRigPathForBeadID(townRoot, beadID); rigPath != "" {
 		return rigPath
 	}
 	// Fallback to hookWorkDir if provided

--- a/internal/beads/routes_test.go
+++ b/internal/beads/routes_test.go
@@ -82,6 +82,30 @@ func TestGetPrefixForRig_RigsConfigFallback(t *testing.T) {
 	}
 }
 
+func TestResolveHookDirUsesShortPrefixRoute(t *testing.T) {
+	tmpDir := t.TempDir()
+	townBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir town .beads: %v", err)
+	}
+	if err := WriteRoutes(townBeadsDir, []Route{
+		{Prefix: "hq-", Path: "."},
+		{Prefix: "au-", Path: "accent_unified_au/mayor/rig"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	rigDir := filepath.Join(tmpDir, "accent_unified_au", "mayor", "rig")
+	if err := os.MkdirAll(rigDir, 0755); err != nil {
+		t.Fatalf("mkdir rig dir: %v", err)
+	}
+
+	got := ResolveHookDir(tmpDir, "au-xg5", tmpDir)
+	if got != rigDir {
+		t.Fatalf("ResolveHookDir() = %q, want %q", got, rigDir)
+	}
+}
+
 func TestExtractPrefix(t *testing.T) {
 	tests := []struct {
 		beadID   string

--- a/internal/beads/routes_test.go
+++ b/internal/beads/routes_test.go
@@ -106,6 +106,26 @@ func TestResolveHookDirUsesShortPrefixRoute(t *testing.T) {
 	}
 }
 
+func TestResolveHookDirUsesLongestConfiguredRoutePrefix(t *testing.T) {
+	tmpDir := t.TempDir()
+	townBeadsDir := filepath.Join(tmpDir, ".beads")
+	if err := os.MkdirAll(townBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir town .beads: %v", err)
+	}
+	if err := WriteRoutes(townBeadsDir, []Route{
+		{Prefix: "accent-", Path: "legacy/mayor/rig"},
+		{Prefix: "accent-unified-", Path: "accent_unified_au/mayor/rig"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	want := filepath.Join(tmpDir, "accent_unified_au", "mayor", "rig")
+	got := ResolveHookDir(tmpDir, "accent-unified-bfof", tmpDir)
+	if got != want {
+		t.Fatalf("ResolveHookDir() = %q, want longest-prefix route %q", got, want)
+	}
+}
+
 func TestExtractPrefix(t *testing.T) {
 	tests := []struct {
 		beadID   string
@@ -308,6 +328,33 @@ func TestResolveBeadsDirForID(t *testing.T) {
 					beadsDir, tc.beadID, result, tc.expected)
 			}
 		})
+	}
+}
+
+func TestResolveBeadsDirForIDUsesLongestConfiguredRoutePrefix(t *testing.T) {
+	tmpDir := t.TempDir()
+	beadsDir := filepath.Join(tmpDir, ".beads")
+	legacyBeadsDir := filepath.Join(tmpDir, "legacy", "mayor", "rig", ".beads")
+	activeBeadsDir := filepath.Join(tmpDir, "accent_unified_au", "mayor", "rig", ".beads")
+	for _, dir := range []string{beadsDir, legacyBeadsDir, activeBeadsDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := WriteRoutes(beadsDir, []Route{
+		{Prefix: "accent-", Path: "legacy/mayor/rig"},
+		{Prefix: "accent-unified-", Path: "accent_unified_au/mayor/rig"},
+		{Prefix: "hq-", Path: "."},
+		{Prefix: "hq-cv-", Path: "."},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	if got := ResolveBeadsDirForID(beadsDir, "accent-unified-bfof"); got != activeBeadsDir {
+		t.Fatalf("ResolveBeadsDirForID legacy ID = %q, want %q", got, activeBeadsDir)
+	}
+	if got := ResolveBeadsDirForID(beadsDir, "hq-cv-hhsxy"); got != beadsDir {
+		t.Fatalf("ResolveBeadsDirForID hq-cv ID = %q, want town beads %q", got, beadsDir)
 	}
 }
 

--- a/internal/cmd/ready.go
+++ b/internal/cmd/ready.go
@@ -485,12 +485,7 @@ func filterReadyIssuesByRoute(townRoot, source string, issues []*beads.Issue) []
 }
 
 func readyIssueRoutesToSource(townRoot, source, issueID string) bool {
-	prefix := beads.ExtractPrefix(issueID)
-	if prefix == "" {
-		return false
-	}
-
-	routePath := beads.GetRigPathForPrefix(townRoot, prefix)
+	routePath := beads.GetRigPathForBeadID(townRoot, issueID)
 	if routePath == "" {
 		return false
 	}
@@ -499,7 +494,7 @@ func readyIssueRoutesToSource(townRoot, source, issueID string) bool {
 		return routePath == townRoot
 	}
 
-	return beads.GetRigNameForPrefix(townRoot, prefix) == source
+	return beads.GetRigNameForBeadID(townRoot, issueID) == source
 }
 
 // filterWisps removes wisp issues from the list.

--- a/internal/cmd/ready_test.go
+++ b/internal/cmd/ready_test.go
@@ -197,6 +197,8 @@ func TestFilterReadyIssuesByRoute(t *testing.T) {
 	routes := strings.Join([]string{
 		`{"prefix":"hq-","path":"."}`,
 		`{"prefix":"hq-cv-","path":"."}`,
+		`{"prefix":"accent-","path":"legacy/mayor/rig"}`,
+		`{"prefix":"accent-unified-","path":"accent_unified_au/mayor/rig"}`,
 		`{"prefix":"bds-","path":"bd_symphony/mayor/rig"}`,
 		`{"prefix":"gt-","path":"gastown/mayor/rig"}`,
 	}, "\n") + "\n"
@@ -219,10 +221,17 @@ func TestFilterReadyIssuesByRoute(t *testing.T) {
 		{ID: "bds-123", Title: "bd_symphony work"},
 		{ID: "hq-123", Title: "town work in rig result"},
 		{ID: "gt-123", Title: "other rig work"},
+		{ID: "accent-unified-bfof", Title: "active mirror work"},
+		{ID: "accent-legacy", Title: "legacy work"},
 		{ID: "unknown-123", Title: "unknown route"},
 	}
 	filtered = filterReadyIssuesByRoute(townRoot, "bd_symphony", issues)
 	if got, want := issueIDs(filtered), []string{"bds-123"}; !reflect.DeepEqual(got, want) {
 		t.Fatalf("rig filtered IDs = %v, want %v", got, want)
+	}
+
+	filtered = filterReadyIssuesByRoute(townRoot, "accent_unified_au", issues)
+	if got, want := issueIDs(filtered), []string{"accent-unified-bfof"}; !reflect.DeepEqual(got, want) {
+		t.Fatalf("long-prefix rig filtered IDs = %v, want %v", got, want)
 	}
 }

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -313,7 +313,7 @@ func completionPayloadHasPendingMR(bd *BdCli, workDir, rigName string, payload *
 // handlePolecatDonePendingMR handles a POLECAT_DONE when there's a pending MR.
 // Creates a cleanup wisp, sends MERGE_READY to the Refinery, and nudges it.
 func handlePolecatDonePendingMR(bd *BdCli, workDir, rigName string, payload *PolecatDonePayload, result *HandlerResult) *HandlerResult {
-	wispID, err := createCleanupWisp(bd, workDir, payload.PolecatName, payload.IssueID, payload.Branch)
+	wispID, err := createCleanupWisp(bd, workDir, rigName, payload.PolecatName, payload.IssueID, payload.Branch)
 	if err != nil {
 		result.Error = fmt.Errorf("creating cleanup wisp: %w", err)
 		return result
@@ -549,7 +549,7 @@ func HandleSwarmStart(bd *BdCli, workDir string, msg *mail.Message) *HandlerResu
 }
 
 // createCleanupWisp creates a wisp to track polecat cleanup.
-func createCleanupWisp(bd *BdCli, workDir, polecatName, issueID, branch string) (string, error) {
+func createCleanupWisp(bd *BdCli, workDir, rigName, polecatName, issueID, branch string) (string, error) {
 	title := fmt.Sprintf("cleanup:%s", polecatName)
 	description := fmt.Sprintf("Verify and cleanup polecat %s", polecatName)
 	if issueID != "" {
@@ -560,8 +560,9 @@ func createCleanupWisp(bd *BdCli, workDir, polecatName, issueID, branch string) 
 	}
 
 	labels := strings.Join(CleanupWispLabels(polecatName, "pending"), ",")
+	createWorkDir := rigScopedWorkDir(workDir, rigName)
 
-	output, err := bd.Exec(workDir, "create",
+	output, err := bd.Exec(createWorkDir, "create",
 		"--ephemeral",
 		"--json",
 		"--title", title,
@@ -583,6 +584,17 @@ func createCleanupWisp(bd *BdCli, workDir, polecatName, issueID, branch string) 
 		return "", fmt.Errorf("bd create --json returned empty ID")
 	}
 	return created.ID, nil
+}
+
+func rigScopedWorkDir(workDir, rigName string) string {
+	townRoot, err := workspace.Find(workDir)
+	if err != nil || townRoot == "" || rigName == "" {
+		return workDir
+	}
+	if rigDir := beads.GetRigDirForName(townRoot, rigName); rigDir != "" {
+		return rigDir
+	}
+	return workDir
 }
 
 // createSwarmWisp creates a wisp to track swarm (batch) work.
@@ -1996,7 +2008,7 @@ func handleZombieRestart(bd *BdCli, workDir, rigName, polecatName, hookBead, cle
 			zombie.Action = fmt.Sprintf("cleanup-deferred-acp (cleanup_status=%s, existing-wisp=%s)", cleanupStatus, existingWisp)
 			return
 		}
-		wispID, wispErr := createCleanupWisp(bd, workDir, polecatName, hookBead, "")
+		wispID, wispErr := createCleanupWisp(bd, workDir, rigName, polecatName, hookBead, "")
 		if wispErr != nil {
 			zombie.Error = wispErr
 		}
@@ -2023,7 +2035,7 @@ func handleZombieRestart(bd *BdCli, workDir, rigName, polecatName, hookBead, cle
 		// No existing wisp — create one as the atomic interlock (gt-7vs1).
 		// Previous code checked then created, allowing two concurrent patrols to
 		// both see "no wisp" and create duplicates. Now we create first, then dedup.
-		wispID, wispErr := createCleanupWisp(bd, workDir, polecatName, hookBead, "")
+		wispID, wispErr := createCleanupWisp(bd, workDir, rigName, polecatName, hookBead, "")
 		if wispErr != nil {
 			zombie.Error = fmt.Errorf("cleanup wisp: %w", wispErr)
 			zombie.Action = fmt.Sprintf("restarted-dirty (cleanup_status=%s, wisp-failed)", cleanupStatus)
@@ -2380,7 +2392,7 @@ func processDiscoveredCompletion(bd *BdCli, workDir, rigName string, payload *Po
 	}
 
 	if hasMR {
-		wispID, err := createCleanupWisp(bd, workDir, payload.PolecatName, payload.IssueID, payload.Branch)
+		wispID, err := createCleanupWisp(bd, workDir, rigName, payload.PolecatName, payload.IssueID, payload.Branch)
 		if err != nil {
 			discovery.Error = fmt.Errorf("creating cleanup wisp: %w", err)
 			return

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -512,6 +512,57 @@ func fakeBd() (*BdCli, *mockBdCalls) {
 	)
 }
 
+func TestCreateCleanupWispUsesActiveRigDirectory(t *testing.T) {
+	townRoot := t.TempDir()
+	for _, dir := range []string{
+		filepath.Join(townRoot, "mayor"),
+		filepath.Join(townRoot, ".beads"),
+		filepath.Join(townRoot, "accent_unified", "mayor", "rig"),
+		filepath.Join(townRoot, "accent_unified_au", "mayor", "rig"),
+	} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatalf("mkdir %s: %v", dir, err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"test"}`), 0644); err != nil {
+		t.Fatalf("write town.json: %v", err)
+	}
+	if err := beads.WriteRoutes(filepath.Join(townRoot, ".beads"), []beads.Route{
+		{Prefix: "hq-", Path: "."},
+		{Prefix: "accent_unified-", Path: "accent_unified/mayor/rig"},
+		{Prefix: "au-", Path: "accent_unified_au/mayor/rig"},
+	}); err != nil {
+		t.Fatalf("write routes: %v", err)
+	}
+
+	legacyWorkDir := filepath.Join(townRoot, "accent_unified", "refinery")
+	if err := os.MkdirAll(legacyWorkDir, 0755); err != nil {
+		t.Fatalf("mkdir legacy workdir: %v", err)
+	}
+
+	var createWorkDir string
+	bd := &BdCli{
+		Exec: func(workDir string, args ...string) (string, error) {
+			if len(args) > 0 && args[0] == "create" {
+				createWorkDir = workDir
+				return `{"id":"au-wisp-clean"}`, nil
+			}
+			return `{}`, nil
+		},
+		Run: func(workDir string, args ...string) error { return nil },
+	}
+
+	_, err := createCleanupWisp(bd, legacyWorkDir, "accent_unified_au", "furiosa", "au-xg5", "polecat/furiosa-au-xg5")
+	if err != nil {
+		t.Fatalf("createCleanupWisp: %v", err)
+	}
+
+	want := filepath.Join(townRoot, "accent_unified_au", "mayor", "rig")
+	if createWorkDir != want {
+		t.Fatalf("cleanup wisp create workDir = %q, want active rig dir %q", createWorkDir, want)
+	}
+}
+
 func setupActiveMRGitSafeWorkDir(t *testing.T, rigName, polecatName string) string {
 	t.Helper()
 	townRoot := t.TempDir()


### PR DESCRIPTION
## Summary
- add longest-configured-route matching for Beads IDs so multi-segment prefixes like hq-cv- and accent-unified- route correctly
- route witness cleanup-wisp creation through the active rig's canonical Beads directory
- prevents active accent_unified_au operations from inheriting a shorter/legacy parked rig context when two rigs share one repo

## Stacking note
This branch currently includes the env-town-root routing commit from PR #4246 because both fixes are adjacent. After #4246 lands, this PR can be rebased to contain only commits 0c165c1b and 0beb0dd6.

## Verification
- go test ./internal/beads -run 'TestResolveHookDirUsesLongestConfiguredRoutePrefix|TestResolveBeadsDirForIDUsesLongestConfiguredRoutePrefix|TestResolveHookDirUsesShortPrefixRoute|TestResolveBeadsDirForID|TestValidateRigPrefix'
- go test ./internal/cmd -run TestFilterReadyIssuesByRoute
- go test ./internal/witness -run 'TestCreateCleanupWispUsesActiveRigDirectory|TestHasPendingMRFromSnapshotAssessesMRStatus|TestShouldNotifyMayorSlotOpenRequiresSafeRecovery'
- go test ./internal/beads ./internal/witness
- go test ./internal/cmd -run 'TestFilterReadyIssuesByRoute|TestMRBeadCreationUsesRig|TestDoneUsesResolveBeadsDir|TestDoneBeadsInitBothCodePaths|TestSlingFormulaOnBeadSetsAttachedMolecule|TestSlingRejectsCrossRigMismatch|TestResolveMQSubmitCommitSHAUsesSubmittedBranch|TestVerifyMQSubmitPushedBranchRequiresRemoteBranch'