### PR TITLE
Fix added-rig witness startup bootstrap

### DIFF
--- a/internal/witness/manager.go
+++ b/internal/witness/manager.go
@@ -86,19 +86,25 @@ func (m *Manager) Status() (*tmux.SessionInfo, error) {
 }
 
 // witnessDir returns the working directory for the witness.
-// Prefers witness/rig/, falls back to witness/, then rig root.
+// Prefers witness/rig/ for existing legacy clones, otherwise uses witness/.
 func (m *Manager) witnessDir() string {
 	witnessRigDir := filepath.Join(m.rig.Path, "witness", "rig")
 	if _, err := os.Stat(witnessRigDir); err == nil {
 		return witnessRigDir
 	}
 
-	witnessDir := filepath.Join(m.rig.Path, "witness")
-	if _, err := os.Stat(witnessDir); err == nil {
-		return witnessDir
-	}
+	return filepath.Join(m.rig.Path, "witness")
+}
 
-	return m.rig.Path
+func (m *Manager) prepareWitnessDir(townRoot string) (string, error) {
+	witnessDir := m.witnessDir()
+	if err := os.MkdirAll(witnessDir, 0755); err != nil {
+		return "", fmt.Errorf("creating witness dir: %w", err)
+	}
+	if err := beads.SetupRedirect(townRoot, witnessDir); err != nil {
+		return "", fmt.Errorf("ensuring witness beads redirect: %w", err)
+	}
+	return witnessDir, nil
 }
 
 // Start starts the witness.
@@ -155,10 +161,10 @@ func (m *Manager) Start(foreground bool, agentOverride string, envOverrides []st
 	// package config) to prevent concurrent rig starts from corrupting the
 	// global agent registry.
 	// Working directory
-	witnessDir := m.witnessDir()
 	townRoot := m.townRoot()
-	if err := beads.SetupRedirect(townRoot, witnessDir); err != nil {
-		return fmt.Errorf("ensuring witness beads redirect: %w", err)
+	witnessDir, err := m.prepareWitnessDir(townRoot)
+	if err != nil {
+		return err
 	}
 
 	// Resolve CLAUDE_CONFIG_DIR from accounts.json so witness sessions

--- a/internal/witness/manager_test.go
+++ b/internal/witness/manager_test.go
@@ -1,6 +1,8 @@
 package witness
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -16,6 +18,47 @@ func TestManagerStartForegroundDeprecated(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "foreground mode is deprecated") {
 		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPrepareWitnessDirCreatesMissingAddedRigWitnessDir(t *testing.T) {
+	t.Parallel()
+
+	townRoot := t.TempDir()
+	rigPath := filepath.Join(townRoot, "gastown")
+	rigBeadsDir := filepath.Join(rigPath, ".beads")
+	mayorBeadsDir := filepath.Join(rigPath, "mayor", "rig", ".beads")
+
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir rig beads: %v", err)
+	}
+	if err := os.MkdirAll(mayorBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir mayor beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigBeadsDir, "redirect"), []byte("mayor/rig/.beads\n"), 0644); err != nil {
+		t.Fatalf("write rig beads redirect: %v", err)
+	}
+
+	mgr := NewManager(&rig.Rig{Name: "gastown", Path: rigPath})
+	witnessDir, err := mgr.prepareWitnessDir(townRoot)
+	if err != nil {
+		t.Fatalf("prepareWitnessDir: %v", err)
+	}
+
+	wantWitnessDir := filepath.Join(rigPath, "witness")
+	if witnessDir != wantWitnessDir {
+		t.Fatalf("witnessDir = %q, want %q", witnessDir, wantWitnessDir)
+	}
+	if info, err := os.Stat(witnessDir); err != nil || !info.IsDir() {
+		t.Fatalf("witness dir was not created: info=%v err=%v", info, err)
+	}
+
+	redirectData, err := os.ReadFile(filepath.Join(witnessDir, ".beads", "redirect"))
+	if err != nil {
+		t.Fatalf("read witness redirect: %v", err)
+	}
+	if got, want := string(redirectData), "../mayor/rig/.beads\n"; got != want {
+		t.Fatalf("redirect = %q, want %q", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Create the witness work directory before setting up its beads redirect.
- Stop falling back to the rig root when the witness directory does not exist.
- Add regression coverage for added rigs whose witness directory has not been
  created yet.

## Root Cause

For an added rig, `gt witness start gastown` failed with:

```text
starting witness: ensuring witness beads redirect: invalid worktree path: must be at least 2 levels deep from town root
```

`witnessDir()` fell back to the rig root when `gastown/witness` did not exist.
`beads.SetupRedirect()` then correctly rejected that path because a rig root is
not an agent worktree.

## Change Details

- `internal/witness/manager.go`
  - `witnessDir()` no longer falls back to the rig root.
  - Missing witness dirs resolve to `<rig>/witness`.
  - Startup preparation creates `<rig>/witness` before calling
    `beads.SetupRedirect()`.

- `internal/witness/manager_test.go`
  - Adds regression coverage for an added rig with a missing witness directory
    and a rig `.beads/redirect` pointing at `mayor/rig/.beads`.

## Validation

- PASS:
  `go test ./internal/witness`

- Runtime validation after restart:
  - `gt witness start gastown`: exit 0, witness already running.
  - `gt witness status gastown`: `State: running`, session `gtn-witness`.
  - `gastown/witness/.beads/redirect`: `../mayor/rig/.beads`.
  - `gt doctor --verbose`: `93 passed, 0 warnings, 0 failed` after regenerating
    hook settings for the newly-created witness directory.

## Related

- Umbrella post-mortem issue: https://github.com/gastownhall/gastown/issues/4254
- Local tracking bead: `gtn-3pm`
