### PR TITLE
fix: clean dog formula dispatch lifecycle

### DIFF
--- a/internal/cmd/capacity_dispatch.go
+++ b/internal/cmd/capacity_dispatch.go
@@ -228,7 +228,7 @@ func dispatchScheduledWork(townRoot, actor string, batchOverride int, dryRun boo
 		if planErr != nil {
 			return 0, fmt.Errorf("planning dispatch: %w", planErr)
 		}
-		plan = validateDryRunDispatchPlan(townRoot, cycle, plan)
+		plan = validateDryRunDispatchPlan(townRoot, plan)
 		printDryRunPlan(plan, lastCapacitySnapshot, batchSize)
 		return 0, nil
 	}
@@ -591,7 +591,7 @@ func dispatchSingleBead(b capacity.PendingBead, townRoot, _ string) (*SlingResul
 	return result, nil
 }
 
-func validateDryRunDispatchPlan(townRoot string, cycle *capacity.DispatchCycle, plan capacity.DispatchPlan) capacity.DispatchPlan {
+func validateDryRunDispatchPlan(townRoot string, plan capacity.DispatchPlan) capacity.DispatchPlan {
 	if len(plan.ToDispatch) == 0 {
 		return plan
 	}

--- a/internal/cmd/sling_dog.go
+++ b/internal/cmd/sling_dog.go
@@ -285,12 +285,13 @@ func (d *DogDispatchInfo) StartDelayedSession() (string, error) {
 	return pane, nil
 }
 
-func (d *DogDispatchInfo) clearWorkIfMatches() (bool, error) {
+func (d *DogDispatchInfo) clearWorkIfMatches() error {
 	if d == nil || !d.ownsWork {
-		return false, nil
+		return nil
 	}
 	mgr := dog.NewManager(d.townRoot, d.rigsConfig)
-	return mgr.ClearWorkIfMatches(d.DogName, d.workDesc, d.workStartedAt)
+	_, err := mgr.ClearWorkIfMatches(d.DogName, d.workDesc, d.workStartedAt)
+	return err
 }
 
 // generateDogName creates a unique dog name for pool expansion.

--- a/internal/cmd/sling_dog.go
+++ b/internal/cmd/sling_dog.go
@@ -1,9 +1,11 @@
 package cmd
 
 import (
+	"errors"
 	"fmt"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/dog"
@@ -70,6 +72,8 @@ type DogDispatchInfo struct {
 	sessionDelayed bool
 	townRoot       string
 	workDesc       string
+	workStartedAt  time.Time
+	ownsWork       bool
 	agentOverride  string
 	rigsConfig     *config.RigsConfig
 }
@@ -95,6 +99,7 @@ func DispatchToDog(dogName string, opts DogDispatchOptions) (*DogDispatchInfo, e
 
 	var targetDog *dog.Dog
 	var spawned bool
+	var workStartedAt time.Time
 
 	if dogName != "" {
 		// Specific dog requested
@@ -112,38 +117,96 @@ func DispatchToDog(dogName string, opts DogDispatchOptions) (*DogDispatchInfo, e
 				return nil, fmt.Errorf("dog %s not found (use --create to add)", dogName)
 			}
 		}
+
+		agentID := fmt.Sprintf("deacon/dogs/%s", targetDog.Name)
+		if existing, err := findHookedFormulaSingleton(townRoot, agentID, opts.WorkDesc); err != nil {
+			return nil, fmt.Errorf("checking existing dog formula: %w", err)
+		} else if existing != nil {
+			return &DogDispatchInfo{
+				DogName:        targetDog.Name,
+				AgentID:        agentID,
+				Pane:           "",
+				Spawned:        spawned,
+				sessionDelayed: true,
+				townRoot:       townRoot,
+				workDesc:       opts.WorkDesc,
+				workStartedAt:  targetDog.WorkStartedAt,
+				ownsWork:       false,
+				agentOverride:  opts.AgentOverride,
+				rigsConfig:     rigsConfig,
+			}, nil
+		}
 	} else {
-		// Pool dispatch - find an idle dog
-		targetDog, err = mgr.GetIdleDog()
-		if err != nil {
-			return nil, fmt.Errorf("finding idle dog: %w", err)
+		if existing, existingDogName, err := findHookedFormulaForDogPool(townRoot, opts.WorkDesc); err != nil {
+			return nil, fmt.Errorf("checking existing dog formula: %w", err)
+		} else if existing != nil {
+			targetDog, err = mgr.Get(existingDogName)
+			if err != nil {
+				return nil, fmt.Errorf("loading dog for existing formula %s: %w", existing.ID, err)
+			}
+			agentID := fmt.Sprintf("deacon/dogs/%s", targetDog.Name)
+			return &DogDispatchInfo{
+				DogName:        targetDog.Name,
+				AgentID:        agentID,
+				Pane:           "",
+				Spawned:        false,
+				sessionDelayed: true,
+				townRoot:       townRoot,
+				workDesc:       opts.WorkDesc,
+				workStartedAt:  targetDog.WorkStartedAt,
+				ownsWork:       false,
+				agentOverride:  opts.AgentOverride,
+				rigsConfig:     rigsConfig,
+			}, nil
 		}
 
-		if targetDog == nil {
-			// No idle dogs - auto-create one if pool is under max size.
-			// Pool dispatch means "send to any available dog" - if none exist,
-			// spawning one is the natural behavior (see mol-deacon-patrol:
-			// "Spawn on demand when pool is empty").
-			dogs, listErr := mgr.List()
-			if listErr != nil {
-				return nil, fmt.Errorf("listing dogs: %w", listErr)
-			}
-			if len(dogs) >= maxDogPoolSize {
-				return nil, fmt.Errorf("no idle dogs available (pool at max %d, all busy)", maxDogPoolSize)
-			}
-			newName := generateDogName(mgr)
-			targetDog, err = mgr.Add(newName)
+		// Pool dispatch - find an idle dog
+		for {
+			targetDog, err = mgr.GetIdleDog()
 			if err != nil {
-				return nil, fmt.Errorf("creating dog %s: %w", newName, err)
+				return nil, fmt.Errorf("finding idle dog: %w", err)
 			}
-			fmt.Printf("✓ Auto-created dog %s (no idle dogs, pool %d/%d)\n", newName, len(dogs)+1, maxDogPoolSize)
-			spawned = true
+
+			if targetDog == nil {
+				// No idle dogs - auto-create one if pool is under max size.
+				// Pool dispatch means "send to any available dog" - if none exist,
+				// spawning one is the natural behavior (see mol-deacon-patrol:
+				// "Spawn on demand when pool is empty").
+				dogs, listErr := mgr.List()
+				if listErr != nil {
+					return nil, fmt.Errorf("listing dogs: %w", listErr)
+				}
+				if len(dogs) >= maxDogPoolSize {
+					return nil, fmt.Errorf("no idle dogs available (pool at max %d, all busy)", maxDogPoolSize)
+				}
+				newName := generateDogName(mgr)
+				targetDog, err = mgr.Add(newName)
+				if err != nil {
+					return nil, fmt.Errorf("creating dog %s: %w", newName, err)
+				}
+				fmt.Printf("✓ Auto-created dog %s (no idle dogs, pool %d/%d)\n", newName, len(dogs)+1, maxDogPoolSize)
+				spawned = true
+			}
+
+			assignedState, err := mgr.AssignWorkIfIdle(targetDog.Name, opts.WorkDesc)
+			if errors.Is(err, dog.ErrDogWorking) {
+				spawned = false
+				continue
+			}
+			if err != nil {
+				return nil, fmt.Errorf("assigning idle dog work: %w", err)
+			}
+			workStartedAt = assignedState.WorkStartedAt
+			break
 		}
 	}
 
-	// Mark dog as working with the assigned work
-	if err := mgr.AssignWork(targetDog.Name, opts.WorkDesc); err != nil {
-		return nil, fmt.Errorf("assigning work to dog: %w", err)
+	if dogName != "" {
+		assignedState, err := mgr.AssignWorkIfIdle(targetDog.Name, opts.WorkDesc)
+		if err != nil {
+			return nil, fmt.Errorf("assigning idle dog work: %w", err)
+		}
+		workStartedAt = assignedState.WorkStartedAt
 	}
 
 	// Build agent ID
@@ -160,6 +223,8 @@ func DispatchToDog(dogName string, opts DogDispatchOptions) (*DogDispatchInfo, e
 			sessionDelayed: true,
 			townRoot:       townRoot,
 			workDesc:       opts.WorkDesc,
+			workStartedAt:  workStartedAt,
+			ownsWork:       true,
 			agentOverride:  opts.AgentOverride,
 			rigsConfig:     rigsConfig,
 		}, nil
@@ -181,10 +246,12 @@ func DispatchToDog(dogName string, opts DogDispatchOptions) (*DogDispatchInfo, e
 	}
 
 	return &DogDispatchInfo{
-		DogName: targetDog.Name,
-		AgentID: agentID,
-		Pane:    pane,
-		Spawned: spawned,
+		DogName:       targetDog.Name,
+		AgentID:       agentID,
+		Pane:          pane,
+		Spawned:       spawned,
+		workStartedAt: workStartedAt,
+		ownsWork:      true,
 	}, nil
 }
 
@@ -205,12 +272,25 @@ func (d *DogDispatchInfo) StartDelayedSession() (string, error) {
 	}
 	pane, err := sessMgr.EnsureRunning(d.DogName, opts)
 	if err != nil {
+		if errors.Is(err, dog.ErrSessionRunning) {
+			d.Pane = ""
+			d.sessionDelayed = false
+			return "", nil
+		}
 		return "", fmt.Errorf("starting dog session: %w", err)
 	}
 
 	d.Pane = pane
 	d.sessionDelayed = false
 	return pane, nil
+}
+
+func (d *DogDispatchInfo) clearWorkIfMatches() (bool, error) {
+	if d == nil || !d.ownsWork {
+		return false, nil
+	}
+	mgr := dog.NewManager(d.townRoot, d.rigsConfig)
+	return mgr.ClearWorkIfMatches(d.DogName, d.workDesc, d.workStartedAt)
 }
 
 // generateDogName creates a unique dog name for pool expansion.

--- a/internal/cmd/sling_dog_cleanup_test.go
+++ b/internal/cmd/sling_dog_cleanup_test.go
@@ -49,12 +49,8 @@ func TestDogDispatchInfoClearWorkIfMatchesUsesAssignmentTimestamp(t *testing.T) 
 		ownsWork:      true,
 		rigsConfig:    rigsConfig,
 	}
-	cleared, err := staleDispatch.clearWorkIfMatches()
-	if err != nil {
+	if err := staleDispatch.clearWorkIfMatches(); err != nil {
 		t.Fatalf("clearWorkIfMatches stale dispatch error = %v", err)
-	}
-	if cleared {
-		t.Fatal("stale dispatch cleared dog work with a newer assignment timestamp")
 	}
 
 	mgr := dog.NewManager(townRoot, rigsConfig)
@@ -74,12 +70,8 @@ func TestDogDispatchInfoClearWorkIfMatchesUsesAssignmentTimestamp(t *testing.T) 
 		ownsWork:      true,
 		rigsConfig:    rigsConfig,
 	}
-	cleared, err = matchingDispatch.clearWorkIfMatches()
-	if err != nil {
+	if err := matchingDispatch.clearWorkIfMatches(); err != nil {
 		t.Fatalf("clearWorkIfMatches matching dispatch error = %v", err)
-	}
-	if !cleared {
-		t.Fatal("matching dispatch did not clear dog work")
 	}
 	got, err = mgr.Get("alpha")
 	if err != nil {
@@ -113,12 +105,8 @@ func TestDogDispatchInfoClearWorkIfMatchesSkipsReusedWork(t *testing.T) {
 		ownsWork:      false,
 		rigsConfig:    rigsConfig,
 	}
-	cleared, err := reusedDispatch.clearWorkIfMatches()
-	if err != nil {
+	if err := reusedDispatch.clearWorkIfMatches(); err != nil {
 		t.Fatalf("clearWorkIfMatches reused dispatch error = %v", err)
-	}
-	if cleared {
-		t.Fatal("reused dispatch cleared dog work it did not create")
 	}
 
 	got, err := dog.NewManager(townRoot, rigsConfig).Get("alpha")

--- a/internal/cmd/sling_dog_cleanup_test.go
+++ b/internal/cmd/sling_dog_cleanup_test.go
@@ -1,0 +1,131 @@
+package cmd
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/dog"
+)
+
+func writeDogStateForDispatchTest(t *testing.T, townRoot, name string, state *dog.DogState) {
+	t.Helper()
+	dogPath := filepath.Join(townRoot, "deacon", "dogs", name)
+	if err := os.MkdirAll(dogPath, 0755); err != nil {
+		t.Fatalf("mkdir dog path: %v", err)
+	}
+	data, err := json.MarshalIndent(state, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal dog state: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dogPath, ".dog.json"), data, 0644); err != nil {
+		t.Fatalf("write dog state: %v", err)
+	}
+}
+
+func TestDogDispatchInfoClearWorkIfMatchesUsesAssignmentTimestamp(t *testing.T) {
+	townRoot := t.TempDir()
+	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	now := time.Now().Truncate(time.Second)
+	workStarted := now.Add(-time.Minute)
+	writeDogStateForDispatchTest(t, townRoot, "alpha", &dog.DogState{
+		Name:          "alpha",
+		State:         dog.StateWorking,
+		Work:          "mol-dog-reaper",
+		WorkStartedAt: workStarted,
+		LastActive:    now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	})
+
+	staleDispatch := &DogDispatchInfo{
+		DogName:       "alpha",
+		townRoot:      townRoot,
+		workDesc:      "mol-dog-reaper",
+		workStartedAt: workStarted.Add(time.Second),
+		ownsWork:      true,
+		rigsConfig:    rigsConfig,
+	}
+	cleared, err := staleDispatch.clearWorkIfMatches()
+	if err != nil {
+		t.Fatalf("clearWorkIfMatches stale dispatch error = %v", err)
+	}
+	if cleared {
+		t.Fatal("stale dispatch cleared dog work with a newer assignment timestamp")
+	}
+
+	mgr := dog.NewManager(townRoot, rigsConfig)
+	got, err := mgr.Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.State != dog.StateWorking || got.Work != "mol-dog-reaper" || !got.WorkStartedAt.Equal(workStarted) {
+		t.Fatalf("stale dispatch mutated dog state: state=%q work=%q started=%v", got.State, got.Work, got.WorkStartedAt)
+	}
+
+	matchingDispatch := &DogDispatchInfo{
+		DogName:       "alpha",
+		townRoot:      townRoot,
+		workDesc:      "mol-dog-reaper",
+		workStartedAt: workStarted,
+		ownsWork:      true,
+		rigsConfig:    rigsConfig,
+	}
+	cleared, err = matchingDispatch.clearWorkIfMatches()
+	if err != nil {
+		t.Fatalf("clearWorkIfMatches matching dispatch error = %v", err)
+	}
+	if !cleared {
+		t.Fatal("matching dispatch did not clear dog work")
+	}
+	got, err = mgr.Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() after clear error = %v", err)
+	}
+	if got.State != dog.StateIdle || got.Work != "" || !got.WorkStartedAt.IsZero() {
+		t.Fatalf("matching dispatch did not clear state: state=%q work=%q started=%v", got.State, got.Work, got.WorkStartedAt)
+	}
+}
+
+func TestDogDispatchInfoClearWorkIfMatchesSkipsReusedWork(t *testing.T) {
+	townRoot := t.TempDir()
+	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	now := time.Now().Truncate(time.Second)
+	workStarted := now.Add(-time.Minute)
+	writeDogStateForDispatchTest(t, townRoot, "alpha", &dog.DogState{
+		Name:          "alpha",
+		State:         dog.StateWorking,
+		Work:          "mol-dog-reaper",
+		WorkStartedAt: workStarted,
+		LastActive:    now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	})
+
+	reusedDispatch := &DogDispatchInfo{
+		DogName:       "alpha",
+		townRoot:      townRoot,
+		workDesc:      "mol-dog-reaper",
+		workStartedAt: workStarted,
+		ownsWork:      false,
+		rigsConfig:    rigsConfig,
+	}
+	cleared, err := reusedDispatch.clearWorkIfMatches()
+	if err != nil {
+		t.Fatalf("clearWorkIfMatches reused dispatch error = %v", err)
+	}
+	if cleared {
+		t.Fatal("reused dispatch cleared dog work it did not create")
+	}
+
+	got, err := dog.NewManager(townRoot, rigsConfig).Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if got.State != dog.StateWorking || got.Work != "mol-dog-reaper" || !got.WorkStartedAt.Equal(workStarted) {
+		t.Fatalf("reused dispatch mutated dog state: state=%q work=%q started=%v", got.State, got.Work, got.WorkStartedAt)
+	}
+}

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -75,7 +75,7 @@ func cleanupDelayedDogFormulaFailure(currentErr error, delayedDogInfo *DogDispat
 			cleanupErr = fmt.Errorf("cleaning failed dog formula wisp %s: %w", wispRootID, err)
 		}
 	}
-	if _, err := delayedDogInfo.clearWorkIfMatches(); err != nil {
+	if err := delayedDogInfo.clearWorkIfMatches(); err != nil {
 		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("clearing failed dog assignment: %w", err))
 	}
 	if cleanupErr == nil {
@@ -300,7 +300,7 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 		if delayedDogInfo == nil {
 			return lockErr
 		}
-		if _, clearErr := delayedDogInfo.clearWorkIfMatches(); clearErr != nil {
+		if clearErr := delayedDogInfo.clearWorkIfMatches(); clearErr != nil {
 			return errors.Join(lockErr, fmt.Errorf("clearing failed dog assignment: %w", clearErr))
 		}
 		return lockErr

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -51,6 +52,124 @@ func trimJSONForError(jsonOutput []byte) string {
 	return s
 }
 
+func cleanupFailedDogFormulaWisp(wispRootID, formulaWorkDir string) error {
+	if wispRootID == "" {
+		return nil
+	}
+	bd := beads.New(formulaWorkDir)
+	if _, err := forceCloseDescendants(bd, wispRootID); err != nil {
+		return fmt.Errorf("force-close descendants: %w", err)
+	}
+	if err := bd.ForceCloseWithReason("burned: dog session start failed", wispRootID); err != nil {
+		return fmt.Errorf("force-close formula wisp: %w", err)
+	}
+	return nil
+}
+
+var cleanupFailedDogFormulaWispFn = cleanupFailedDogFormulaWisp
+
+func cleanupDelayedDogFormulaFailure(currentErr error, delayedDogInfo *DogDispatchInfo, wispRootID, formulaWorkDir string) error {
+	var cleanupErr error
+	if wispRootID != "" {
+		if err := cleanupFailedDogFormulaWispFn(wispRootID, formulaWorkDir); err != nil {
+			cleanupErr = fmt.Errorf("cleaning failed dog formula wisp %s: %w", wispRootID, err)
+		}
+	}
+	if _, err := delayedDogInfo.clearWorkIfMatches(); err != nil {
+		cleanupErr = errors.Join(cleanupErr, fmt.Errorf("clearing failed dog assignment: %w", err))
+	}
+	if cleanupErr == nil {
+		return currentErr
+	}
+	if currentErr == nil {
+		return cleanupErr
+	}
+	return errors.Join(currentErr, cleanupErr)
+}
+
+func formulaSlingPrompt(formulaName string) string {
+	if slingArgs != "" {
+		return fmt.Sprintf("Formula %s slung. Args: %s. Run `"+cli.Name()+" hook` to see your hook, then execute using these args.", formulaName, slingArgs)
+	}
+	return fmt.Sprintf("Formula %s slung. Run `"+cli.Name()+" hook` to see your hook, then execute the steps.", formulaName)
+}
+
+func nudgeFormulaDog(delayedDogInfo *DogDispatchInfo, prompt string) {
+	dogSession := fmt.Sprintf("hq-dog-%s", delayedDogInfo.DogName)
+	t := tmux.NewTmux()
+	if err := t.NudgeSession(dogSession, prompt); err != nil {
+		fmt.Printf("%s Could not nudge dog %s: %v (will discover work via gt prime)\n",
+			style.Dim.Render("○"), delayedDogInfo.DogName, err)
+	} else {
+		fmt.Printf("%s Nudged dog %s\n", style.Bold.Render("▶"), delayedDogInfo.DogName)
+	}
+}
+
+// findHookedFormulaSingleton returns the existing hooked bead for an assignee
+// when that bead already carries the same attached_formula metadata.
+func findHookedFormulaSingleton(workDir, targetAgent, formulaName string) (*beads.Issue, error) {
+	if workDir == "" || targetAgent == "" || formulaName == "" {
+		return nil, nil
+	}
+
+	b := beads.New(workDir)
+	hookedBeads, err := b.List(beads.ListOptions{
+		Status:    beads.StatusHooked,
+		Assignee:  targetAgent,
+		Priority:  -1,
+		Ephemeral: true,
+		Limit:     0,
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	for _, bead := range hookedBeads {
+		fields := beads.ParseAttachmentFields(bead)
+		if fields != nil && fields.AttachedFormula == formulaName {
+			return bead, nil
+		}
+	}
+
+	return nil, nil
+}
+
+var findHookedFormulaSingletonFn = findHookedFormulaSingleton
+
+func findHookedFormulaForDogPool(workDir, formulaName string) (*beads.Issue, string, error) {
+	if workDir == "" || formulaName == "" {
+		return nil, "", nil
+	}
+
+	b := beads.New(workDir)
+	hookedBeads, err := b.List(beads.ListOptions{
+		Status:    beads.StatusHooked,
+		Priority:  -1,
+		Ephemeral: true,
+		Limit:     0,
+	})
+	if err != nil {
+		return nil, "", err
+	}
+
+	const dogAssigneePrefix = "deacon/dogs/"
+	for _, bead := range hookedBeads {
+		if !strings.HasPrefix(bead.Assignee, dogAssigneePrefix) {
+			continue
+		}
+		dogName := strings.TrimPrefix(bead.Assignee, dogAssigneePrefix)
+		if dogName == "" || strings.Contains(dogName, "/") {
+			continue
+		}
+		fields := beads.ParseAttachmentFields(bead)
+		if fields != nil && fields.AttachedFormula == formulaName {
+			return bead, dogName, nil
+		}
+	}
+
+	return nil, "", nil
+}
+
 // verifyFormulaExists checks that the formula exists using bd formula show.
 // Formulas are TOML files (.formula.toml).
 // Requests stale-read compatibility for consistency with verifyBeadExists.
@@ -75,38 +194,9 @@ func verifyFormulaExists(formulaName string) error {
 	return fmt.Errorf("formula '%s' not found (check 'bd formula list')", formulaName)
 }
 
-// findHookedFormulaSingleton returns the existing hooked bead for an assignee
-// when that bead already carries the same attached_formula metadata.
-func findHookedFormulaSingleton(workDir, targetAgent, formulaName string) (*beads.Issue, error) {
-	if workDir == "" || targetAgent == "" || formulaName == "" {
-		return nil, nil
-	}
-
-	b := beads.New(workDir)
-	hookedBeads, err := b.List(beads.ListOptions{
-		Status:   beads.StatusHooked,
-		Assignee: targetAgent,
-		Priority: -1,
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	for _, bead := range hookedBeads {
-		fields := beads.ParseAttachmentFields(bead)
-		if fields != nil && fields.AttachedFormula == formulaName {
-			return bead, nil
-		}
-	}
-
-	return nil, nil
-}
-
-var findHookedFormulaSingletonFn = findHookedFormulaSingleton
-
 // runSlingFormula handles standalone formula slinging.
 // Flow: cook → wisp → attach to hook → nudge
-func runSlingFormula(ctx context.Context, args []string) error {
+func runSlingFormula(ctx context.Context, args []string) (err error) {
 	formulaName := args[0]
 
 	// Get town root early - needed for BEADS_DIR when running bd commands
@@ -133,6 +223,15 @@ func runSlingFormula(ctx context.Context, args []string) error {
 				return err
 			}
 			defer admission.Release()
+		}
+	}
+	if !slingDryRun {
+		if dogName, isDog := IsDogTarget(target); isDog && dogName == "" {
+			poolUnlock, poolLockErr := tryAcquireSlingAssigneeLock(townRoot, "deacon/dogs")
+			if poolLockErr != nil {
+				return fmt.Errorf("serializing dog-pool formula sling for %s: %w", formulaName, poolLockErr)
+			}
+			defer poolUnlock()
 		}
 	}
 	resolved, err := resolveTarget(target, ResolveTargetOptions{
@@ -171,6 +270,8 @@ func runSlingFormula(ctx context.Context, args []string) error {
 		formulaWorkDir = townRoot
 	}
 
+	var wispRootID string
+
 	if slingDryRun {
 		existing, err := findHookedFormulaSingletonFn(formulaWorkDir, targetAgent, formulaName)
 		if err != nil {
@@ -190,13 +291,30 @@ func runSlingFormula(ctx context.Context, args []string) error {
 		return nil
 	}
 
+	delayedDogComplete := false
 	// Serialize standalone formula slings per assignee so same-formula retries
 	// and handoffs cannot create duplicate hooked wisps for one target.
 	assigneeUnlock, assigneeLockErr := tryAcquireSlingAssigneeLock(townRoot, targetAgent)
 	if assigneeLockErr != nil {
-		return fmt.Errorf("serializing formula sling for %s: %w", targetAgent, assigneeLockErr)
+		lockErr := fmt.Errorf("serializing formula sling for %s: %w", targetAgent, assigneeLockErr)
+		if delayedDogInfo == nil {
+			return lockErr
+		}
+		if _, clearErr := delayedDogInfo.clearWorkIfMatches(); clearErr != nil {
+			return errors.Join(lockErr, fmt.Errorf("clearing failed dog assignment: %w", clearErr))
+		}
+		return lockErr
 	}
 	defer assigneeUnlock()
+	defer func() {
+		if delayedDogInfo == nil || delayedDogComplete {
+			return
+		}
+		if err == nil && wispRootID == "" {
+			return
+		}
+		err = cleanupDelayedDogFormulaFailure(err, delayedDogInfo, wispRootID, formulaWorkDir)
+	}()
 
 	existing, err := findHookedFormulaSingletonFn(formulaWorkDir, targetAgent, formulaName)
 	if err != nil {
@@ -205,6 +323,15 @@ func runSlingFormula(ctx context.Context, args []string) error {
 	if existing != nil && !slingForce {
 		fmt.Printf("%s Formula %s already hooked to %s via %s, no-op\n",
 			style.Dim.Render("○"), formulaName, targetAgent, existing.ID)
+		if delayedDogInfo != nil {
+			if _, err := delayedDogInfo.StartDelayedSession(); err != nil {
+				return fmt.Errorf("starting delayed dog session for existing formula: %w", err)
+			}
+			delayedDogComplete = true
+			if os.Getenv("GT_TEST_NO_NUDGE") == "" {
+				nudgeFormulaDog(delayedDogInfo, formulaSlingPrompt(formulaName))
+			}
+		}
 		return nil
 	}
 	if admission == nil && strings.Contains(targetAgent, "/polecats/") {
@@ -249,7 +376,7 @@ func runSlingFormula(ctx context.Context, args []string) error {
 	}
 
 	// Parse wisp output to get the root ID
-	wispRootID, err := parseWispIDFromJSON(wispOut)
+	wispRootID, err = parseWispIDFromJSON(wispOut)
 	if err != nil {
 		telemetry.RecordMolWisp(ctx, formulaName, "", "", err)
 		rollbackSpawned("")
@@ -302,6 +429,7 @@ func runSlingFormula(ctx context.Context, args []string) error {
 		if err != nil {
 			return fmt.Errorf("starting delayed dog session: %w", err)
 		}
+		delayedDogComplete = true
 		targetPane = pane
 	}
 
@@ -324,39 +452,29 @@ func runSlingFormula(ctx context.Context, args []string) error {
 		fmt.Printf("%s Self-sling: work hooked, will process on next turn\n", style.Dim.Render("○"))
 		return nil
 	}
-	if targetPane == "" {
-		fmt.Printf("%s No pane to nudge (agent will discover work via gt prime)\n", style.Dim.Render("○"))
-		return nil
-	}
 
 	// Skip nudge during tests to prevent agent self-interruption
 	if os.Getenv("GT_TEST_NO_NUDGE") != "" {
 		return nil
 	}
 
-	var prompt string
-	if slingArgs != "" {
-		prompt = fmt.Sprintf("Formula %s slung. Args: %s. Run `"+cli.Name()+" hook` to see your hook, then execute using these args.", formulaName, slingArgs)
-	} else {
-		prompt = fmt.Sprintf("Formula %s slung. Run `"+cli.Name()+" hook` to see your hook, then execute the steps.", formulaName)
-	}
-	t := tmux.NewTmux()
+	prompt := formulaSlingPrompt(formulaName)
 
 	// Dog sessions need a nudge sent to their session (not to the bare pane ID
 	// from StartDelayedSession, which is ambiguous on platforms where tmux pane
 	// IDs are not globally unique). Use NudgeSession which qualifies the target
 	// with the session name. (gt-etc)
 	if delayedDogInfo != nil {
-		dogSession := fmt.Sprintf("hq-dog-%s", delayedDogInfo.DogName)
-		if err := t.NudgeSession(dogSession, prompt); err != nil {
-			fmt.Printf("%s Could not nudge dog %s: %v (will discover work via gt prime)\n",
-				style.Dim.Render("○"), delayedDogInfo.DogName, err)
-		} else {
-			fmt.Printf("%s Nudged dog %s\n", style.Bold.Render("▶"), delayedDogInfo.DogName)
-		}
+		nudgeFormulaDog(delayedDogInfo, prompt)
 		return nil
 	}
 
+	if targetPane == "" {
+		fmt.Printf("%s No pane to nudge (agent will discover work via gt prime)\n", style.Dim.Render("○"))
+		return nil
+	}
+
+	t := tmux.NewTmux()
 	if err := t.NudgePane(targetPane, prompt); err != nil {
 		// Graceful fallback for no-tmux mode
 		fmt.Printf("%s Could not nudge (no tmux?): %v\n", style.Dim.Render("○"), err)

--- a/internal/cmd/sling_formula_cleanup_test.go
+++ b/internal/cmd/sling_formula_cleanup_test.go
@@ -1,0 +1,150 @@
+package cmd
+
+import (
+	"errors"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/dog"
+)
+
+func runSlingFormulaSourceForTest(t *testing.T) string {
+	t.Helper()
+	data, err := os.ReadFile("sling_formula.go")
+	if err != nil {
+		t.Fatalf("read sling_formula.go: %v", err)
+	}
+	source := string(data)
+	funcStart := strings.Index(source, "func runSlingFormula(")
+	if funcStart == -1 {
+		t.Fatal("runSlingFormula not found")
+	}
+	body := source[funcStart:]
+	nextFunc := strings.Index(body[1:], "\nfunc ")
+	if nextFunc != -1 {
+		body = body[:nextFunc+1]
+	}
+	return body
+}
+
+func TestRunSlingFormulaCleansDelayedDogFailure(t *testing.T) {
+	body := runSlingFormulaSourceForTest(t)
+
+	for _, want := range []string{
+		") (err error)",
+		"defer func()",
+		"cleanupDelayedDogFormulaFailure(err, delayedDogInfo, wispRootID, formulaWorkDir)",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("runSlingFormula missing %q", want)
+		}
+	}
+
+	unlockDeferIdx := strings.Index(body, "defer assigneeUnlock()")
+	cleanupDeferIdx := strings.Index(body, "defer func()")
+	if unlockDeferIdx == -1 || cleanupDeferIdx == -1 || unlockDeferIdx > cleanupDeferIdx {
+		t.Fatal("dog formula cleanup must be deferred after assignee unlock so it runs before unlocking")
+	}
+}
+
+func TestCleanupDelayedDogFormulaFailureClearsWorkAfterWispCleanupError(t *testing.T) {
+	prevCleanup := cleanupFailedDogFormulaWispFn
+	cleanupFailedDogFormulaWispFn = func(string, string) error {
+		return errors.New("close failed")
+	}
+	t.Cleanup(func() { cleanupFailedDogFormulaWispFn = prevCleanup })
+
+	townRoot := t.TempDir()
+	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	startedAt := time.Now().Truncate(time.Second)
+	writeDogStateForDispatchTest(t, townRoot, "alpha", &dog.DogState{
+		Name:          "alpha",
+		State:         dog.StateWorking,
+		Work:          "mol-dog-reaper",
+		WorkStartedAt: startedAt,
+		LastActive:    startedAt,
+		CreatedAt:     startedAt,
+		UpdatedAt:     startedAt,
+	})
+	dispatch := &DogDispatchInfo{
+		DogName:       "alpha",
+		townRoot:      townRoot,
+		workDesc:      "mol-dog-reaper",
+		workStartedAt: startedAt,
+		ownsWork:      true,
+		rigsConfig:    rigsConfig,
+	}
+
+	err := cleanupDelayedDogFormulaFailure(errors.New("start failed"), dispatch, "gt-wisp", townRoot)
+	if err == nil || !strings.Contains(err.Error(), "start failed") || !strings.Contains(err.Error(), "close failed") {
+		t.Fatalf("cleanup error = %v, want joined start and close errors", err)
+	}
+
+	got, err := dog.NewManager(townRoot, rigsConfig).Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() after cleanup: %v", err)
+	}
+	if got.State != dog.StateIdle || got.Work != "" || !got.WorkStartedAt.IsZero() {
+		t.Fatalf("cleanup did not clear dog assignment: state=%q work=%q started=%v", got.State, got.Work, got.WorkStartedAt)
+	}
+}
+
+func TestRunSlingFormulaSerializesWholeDogPool(t *testing.T) {
+	body := runSlingFormulaSourceForTest(t)
+	if !strings.Contains(body, `tryAcquireSlingAssigneeLock(townRoot, "deacon/dogs")`) {
+		t.Fatal("dog-pool formula dispatch must use one pool-wide lock, not a per-formula lock")
+	}
+	if strings.Contains(body, `tryAcquireSlingAssigneeLock(townRoot, "deacon/dogs/"+formulaName)`) {
+		t.Fatal("dog-pool formula dispatch still uses per-formula locking")
+	}
+}
+
+func TestRunSlingFormulaExistingHookedDogStartsDelayedSession(t *testing.T) {
+	body := runSlingFormulaSourceForTest(t)
+
+	existingIdx := strings.Index(body, "existing != nil && !slingForce")
+	if existingIdx == -1 {
+		t.Fatal("existing hooked formula no-op block not found")
+	}
+	existingBlock := body[existingIdx:]
+	stepIdx := strings.Index(existingBlock, "\n\t// Step 1:")
+	if stepIdx == -1 {
+		t.Fatal("could not isolate existing hooked formula block")
+	}
+	existingBlock = existingBlock[:stepIdx]
+	startIdx := strings.Index(existingBlock, "delayedDogInfo.StartDelayedSession()")
+	completeIdx := strings.Index(existingBlock, "delayedDogComplete = true")
+	nudgeIdx := strings.Index(existingBlock, "nudgeFormulaDog(delayedDogInfo, formulaSlingPrompt(formulaName))")
+	returnIdx := strings.LastIndex(existingBlock, "return nil")
+	if startIdx == -1 {
+		t.Fatal("existing hooked formula path must start the delayed dog session")
+	}
+	if completeIdx == -1 || completeIdx < startIdx {
+		t.Fatal("existing hooked formula path must mark delayed dog startup complete")
+	}
+	if nudgeIdx == -1 || nudgeIdx < completeIdx {
+		t.Fatal("existing hooked formula path must nudge the dog before returning")
+	}
+	if returnIdx != -1 && returnIdx < nudgeIdx {
+		t.Fatal("existing hooked formula path returns before starting/nudging dog")
+	}
+}
+
+func TestRunSlingFormulaDogNudgeBeforeEmptyPaneReturn(t *testing.T) {
+	body := runSlingFormulaSourceForTest(t)
+
+	dogNudgeIdx := strings.LastIndex(body, "nudgeFormulaDog(delayedDogInfo, prompt)")
+	emptyPaneIdx := strings.Index(body, "if targetPane == \"\" {")
+	if dogNudgeIdx == -1 {
+		t.Fatal("dog-specific nudge call not found")
+	}
+	if emptyPaneIdx == -1 {
+		t.Fatal("empty-pane return block not found")
+	}
+	if dogNudgeIdx > emptyPaneIdx {
+		t.Fatal("dog-specific nudge must run before generic empty-pane return")
+	}
+}

--- a/internal/cmd/statusline.go
+++ b/internal/cmd/statusline.go
@@ -103,15 +103,15 @@ func runStatusLine(cmd *cobra.Command, args []string) error {
 
 	// Refinery status line
 	if role == "refinery" || strings.HasSuffix(statusLineSession, "-refinery") {
-		return runRefineryStatusLine(t, rigName)
+		return runRefineryStatusLine(rigName)
 	}
 
 	// Crew/Polecat status line
-	return runWorkerStatusLine(t, statusLineSession, rigName, polecat, crew, issue)
+	return runWorkerStatusLine(statusLineSession, rigName, polecat, crew, issue)
 }
 
 // runWorkerStatusLine outputs status for crew or polecat sessions.
-func runWorkerStatusLine(t *tmux.Tmux, session, rigName, polecat, crew, issue string) error {
+func runWorkerStatusLine(session, rigName, polecat, crew, issue string) error {
 	// Determine agent type and identity
 	var icon string
 	if polecat != "" {
@@ -438,7 +438,7 @@ func runWitnessStatusLine(t *tmux.Tmux, rigName string) error {
 
 // runRefineryStatusLine outputs status for a refinery session.
 // Shows: MQ length, current item, hook or mail preview
-func runRefineryStatusLine(t *tmux.Tmux, rigName string) error {
+func runRefineryStatusLine(rigName string) error {
 	if rigName == "" {
 		// Try to extract from session name: <prefix>-refinery
 		if identity, err := session.ParseSessionName(statusLineSession); err == nil && identity.Role == session.RoleRefinery {

--- a/internal/cmd/statusline.go
+++ b/internal/cmd/statusline.go
@@ -107,11 +107,11 @@ func runStatusLine(cmd *cobra.Command, args []string) error {
 	}
 
 	// Crew/Polecat status line
-	return runWorkerStatusLine(statusLineSession, rigName, polecat, crew, issue)
+	return runWorkerStatusLine(polecat, crew, issue)
 }
 
 // runWorkerStatusLine outputs status for crew or polecat sessions.
-func runWorkerStatusLine(session, rigName, polecat, crew, issue string) error {
+func runWorkerStatusLine(polecat, crew, issue string) error {
 	// Determine agent type and identity
 	var icon string
 	if polecat != "" {

--- a/internal/daemon/wisp_reaper_test.go
+++ b/internal/daemon/wisp_reaper_test.go
@@ -1,8 +1,15 @@
 package daemon
 
 import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/constants"
 )
 
 func TestWispReaperInterval(t *testing.T) {
@@ -71,5 +78,43 @@ func TestDefaultReaperIntervalIsOneHour(t *testing.T) {
 	// Verify the default changed from 30m to 1h per issue gt-caf7.
 	if defaultWispReaperInterval != 1*time.Hour {
 		t.Errorf("expected default interval 1h, got %v", defaultWispReaperInterval)
+	}
+}
+
+func TestDispatchReaperDogUsesDogPoolSling(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses Unix shell script mock")
+	}
+
+	townRoot := t.TempDir()
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "gt-args.log")
+	fakeGT := filepath.Join(binDir, "gt")
+	script := fmt.Sprintf("#!/bin/sh\nprintf '%%s\\n' \"$@\" > %q\n", logPath)
+	if err := os.WriteFile(fakeGT, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake gt: %v", err)
+	}
+
+	d := &Daemon{
+		config: &Config{TownRoot: townRoot},
+		gtPath: fakeGT,
+	}
+	if err := d.dispatchReaperDog(map[string]string{"max_age": "1h"}); err != nil {
+		t.Fatalf("dispatchReaperDog() error = %v", err)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read gt args log: %v", err)
+	}
+	args := strings.Split(strings.TrimSpace(string(data)), "\n")
+	wantPrefix := []string{"sling", constants.MolDogReaper, "deacon/dogs"}
+	if len(args) < len(wantPrefix) {
+		t.Fatalf("gt args = %v, want prefix %v", args, wantPrefix)
+	}
+	for i, want := range wantPrefix {
+		if args[i] != want {
+			t.Fatalf("gt arg %d = %q, want %q (all args: %v)", i, args[i], want, args)
+		}
 	}
 }

--- a/internal/dog/manager.go
+++ b/internal/dog/manager.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/gofrs/flock"
 
+	"github.com/steveyegge/gastown/internal/atomicfile"
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/style"
-	"github.com/steveyegge/gastown/internal/atomicfile"
 )
 
 // Common errors
@@ -371,6 +371,42 @@ func (m *Manager) AssignWork(name, work string) error {
 	return m.saveState(name, state)
 }
 
+// AssignWorkIfIdle assigns work only if the dog is still idle, returning the
+// saved state so callers can later perform exact compare-and-clear cleanup.
+func (m *Manager) AssignWorkIfIdle(name, work string) (*DogState, error) {
+	if err := validateDogName(name); err != nil {
+		return nil, err
+	}
+	if !m.exists(name) {
+		return nil, ErrDogNotFound
+	}
+
+	fl, err := m.lockDog(name)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = fl.Unlock() }()
+
+	state, err := m.loadState(name)
+	if err != nil {
+		return nil, fmt.Errorf("loading state: %w", err)
+	}
+	if state.State != StateIdle {
+		return nil, ErrDogWorking
+	}
+
+	state.State = StateWorking
+	state.Work = work
+	state.WorkStartedAt = time.Now()
+	state.LastActive = time.Now()
+	state.UpdatedAt = time.Now()
+
+	if err := m.saveState(name, state); err != nil {
+		return nil, err
+	}
+	return state, nil
+}
+
 // ClearWork clears a dog's work assignment and sets it to idle.
 func (m *Manager) ClearWork(name string) error {
 	if err := validateDogName(name); err != nil {
@@ -399,6 +435,40 @@ func (m *Manager) ClearWork(name string) error {
 	state.UpdatedAt = time.Now()
 
 	return m.saveState(name, state)
+}
+
+// ClearWorkIfMatches clears a dog's work assignment only if it still matches
+// the expected work and assignment timestamp. The compare-and-clear happens
+// under the dog lock so failed dispatch cleanup cannot erase a newer assignment.
+func (m *Manager) ClearWorkIfMatches(name, expectedWork string, expectedStartedAt time.Time) (bool, error) {
+	if err := validateDogName(name); err != nil {
+		return false, err
+	}
+	if !m.exists(name) {
+		return false, ErrDogNotFound
+	}
+
+	fl, err := m.lockDog(name)
+	if err != nil {
+		return false, err
+	}
+	defer func() { _ = fl.Unlock() }()
+
+	state, err := m.loadState(name)
+	if err != nil {
+		return false, fmt.Errorf("loading state: %w", err)
+	}
+	if state.Work != expectedWork || !state.WorkStartedAt.Equal(expectedStartedAt) {
+		return false, nil
+	}
+
+	state.State = StateIdle
+	state.Work = ""
+	state.WorkStartedAt = time.Time{}
+	state.LastActive = time.Now()
+	state.UpdatedAt = time.Now()
+
+	return true, m.saveState(name, state)
 }
 
 // Refresh recreates all worktrees for a dog with fresh branches.

--- a/internal/dog/manager_lifecycle_test.go
+++ b/internal/dog/manager_lifecycle_test.go
@@ -534,6 +534,65 @@ func TestManager_AssignWork_notFound(t *testing.T) {
 	}
 }
 
+func TestManager_AssignWorkIfIdle_success(t *testing.T) {
+	m, _ := testManager(t)
+
+	now := time.Now()
+	state := &DogState{
+		Name:       "alpha",
+		State:      StateIdle,
+		LastActive: now,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	setupDogWithState(t, m, "alpha", state)
+
+	assigned, err := m.AssignWorkIfIdle("alpha", "mol-dog-reaper")
+	if err != nil {
+		t.Fatalf("AssignWorkIfIdle() error = %v", err)
+	}
+	if assigned.State != StateWorking {
+		t.Errorf("State = %q, want %q", assigned.State, StateWorking)
+	}
+	if assigned.Work != "mol-dog-reaper" {
+		t.Errorf("Work = %q, want mol-dog-reaper", assigned.Work)
+	}
+	if assigned.WorkStartedAt.IsZero() {
+		t.Fatal("WorkStartedAt should be set")
+	}
+}
+
+func TestManager_AssignWorkIfIdle_workingDog(t *testing.T) {
+	m, _ := testManager(t)
+
+	now := time.Now()
+	state := &DogState{
+		Name:       "alpha",
+		State:      StateWorking,
+		Work:       "existing-work",
+		LastActive: now,
+		CreatedAt:  now,
+		UpdatedAt:  now,
+	}
+	setupDogWithState(t, m, "alpha", state)
+
+	assigned, err := m.AssignWorkIfIdle("alpha", "mol-dog-reaper")
+	if err != ErrDogWorking {
+		t.Fatalf("AssignWorkIfIdle() error = %v, want ErrDogWorking", err)
+	}
+	if assigned != nil {
+		t.Fatalf("AssignWorkIfIdle() assigned = %#v, want nil", assigned)
+	}
+
+	dog, err := m.Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if dog.Work != "existing-work" {
+		t.Errorf("Work = %q, want existing-work", dog.Work)
+	}
+}
+
 // =============================================================================
 // ClearWork Tests
 // =============================================================================
@@ -577,6 +636,140 @@ func TestManager_ClearWork_notFound(t *testing.T) {
 	err := m.ClearWork("nonexistent")
 	if err != ErrDogNotFound {
 		t.Errorf("ClearWork() error = %v, want ErrDogNotFound", err)
+	}
+}
+
+func TestManager_ClearWorkIfMatches_success(t *testing.T) {
+	m, _ := testManager(t)
+
+	now := time.Now()
+	state := &DogState{
+		Name:          "alpha",
+		State:         StateWorking,
+		Work:          "mol-dog-reaper",
+		WorkStartedAt: now.Add(-time.Minute),
+		LastActive:    now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	setupDogWithState(t, m, "alpha", state)
+
+	cleared, err := m.ClearWorkIfMatches("alpha", "mol-dog-reaper", state.WorkStartedAt)
+	if err != nil {
+		t.Fatalf("ClearWorkIfMatches() error = %v", err)
+	}
+	if !cleared {
+		t.Fatal("ClearWorkIfMatches() cleared = false, want true")
+	}
+
+	dog, err := m.Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if dog.State != StateIdle {
+		t.Errorf("State = %q, want %q", dog.State, StateIdle)
+	}
+	if dog.Work != "" {
+		t.Errorf("Work = %q, want empty", dog.Work)
+	}
+	if !dog.WorkStartedAt.IsZero() {
+		t.Errorf("WorkStartedAt = %v, want zero", dog.WorkStartedAt)
+	}
+}
+
+func TestManager_ClearWorkIfMatches_mismatchNoOp(t *testing.T) {
+	m, _ := testManager(t)
+
+	now := time.Now().Truncate(time.Second)
+	workStarted := now.Add(-time.Minute)
+	state := &DogState{
+		Name:          "alpha",
+		State:         StateWorking,
+		Work:          "other-work",
+		WorkStartedAt: workStarted,
+		LastActive:    now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	setupDogWithState(t, m, "alpha", state)
+
+	cleared, err := m.ClearWorkIfMatches("alpha", "mol-dog-reaper", workStarted)
+	if err != nil {
+		t.Fatalf("ClearWorkIfMatches() error = %v", err)
+	}
+	if cleared {
+		t.Fatal("ClearWorkIfMatches() cleared = true, want false")
+	}
+
+	dog, err := m.Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if dog.State != StateWorking {
+		t.Errorf("State = %q, want %q", dog.State, StateWorking)
+	}
+	if dog.Work != "other-work" {
+		t.Errorf("Work = %q, want other-work", dog.Work)
+	}
+	if !dog.WorkStartedAt.Equal(workStarted) {
+		t.Errorf("WorkStartedAt = %v, want %v", dog.WorkStartedAt, workStarted)
+	}
+	if !dog.LastActive.Equal(now) {
+		t.Errorf("LastActive = %v, want %v", dog.LastActive, now)
+	}
+}
+
+func TestManager_ClearWorkIfMatches_sameWorkDifferentTimestampNoOp(t *testing.T) {
+	m, _ := testManager(t)
+
+	now := time.Now().Truncate(time.Second)
+	workStarted := now.Add(-time.Minute)
+	state := &DogState{
+		Name:          "alpha",
+		State:         StateWorking,
+		Work:          "mol-dog-reaper",
+		WorkStartedAt: workStarted,
+		LastActive:    now,
+		CreatedAt:     now,
+		UpdatedAt:     now,
+	}
+	setupDogWithState(t, m, "alpha", state)
+
+	cleared, err := m.ClearWorkIfMatches("alpha", "mol-dog-reaper", workStarted.Add(time.Second))
+	if err != nil {
+		t.Fatalf("ClearWorkIfMatches() error = %v", err)
+	}
+	if cleared {
+		t.Fatal("ClearWorkIfMatches() cleared = true, want false")
+	}
+
+	dog, err := m.Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() error = %v", err)
+	}
+	if dog.State != StateWorking {
+		t.Errorf("State = %q, want %q", dog.State, StateWorking)
+	}
+	if dog.Work != "mol-dog-reaper" {
+		t.Errorf("Work = %q, want mol-dog-reaper", dog.Work)
+	}
+	if !dog.WorkStartedAt.Equal(workStarted) {
+		t.Errorf("WorkStartedAt = %v, want %v", dog.WorkStartedAt, workStarted)
+	}
+}
+
+func TestManager_ClearWorkIfMatches_notFound(t *testing.T) {
+	m, root := testManager(t)
+
+	cleared, err := m.ClearWorkIfMatches("nonexistent", "mol-dog-reaper", time.Now())
+	if err != ErrDogNotFound {
+		t.Fatalf("ClearWorkIfMatches() error = %v, want ErrDogNotFound", err)
+	}
+	if cleared {
+		t.Fatal("ClearWorkIfMatches() cleared = true, want false")
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "deacon", "dogs", "nonexistent")); !os.IsNotExist(statErr) {
+		t.Fatalf("ClearWorkIfMatches() created dog dir unexpectedly: %v", statErr)
 	}
 }
 

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1339,7 +1339,7 @@ func FindIdleMonitorProcesses(townRoot string) []int {
 func findIdleMonitorProcessesFromPS(output, townRoot, absRoot string, port int) []int {
 	portStr := strconv.Itoa(port)
 	var pids []int
-	for _, line := range strings.Split(string(output), "\n") {
+	for _, line := range strings.Split(output, "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.Contains(line, "idle-monitor") {
 			continue
@@ -2725,7 +2725,11 @@ func EnsureRigIssuePrefix(townRoot, rigName string, serverMode bool) error {
 	if err != nil {
 		return fmt.Errorf("opening beads database: %w", err)
 	}
-	defer store.Close()
+	defer func() {
+		if err := store.Close(); err != nil {
+			fmt.Fprintf(os.Stderr, "Warning: could not close beads store after issue_prefix seed: %v\n", err)
+		}
+	}()
 
 	if err := store.SetConfig(ctx, "issue_prefix", prefix); err != nil {
 		return fmt.Errorf("setting issue_prefix: %w", err)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -457,7 +457,7 @@ func protectedWorktreeTargets(cmd string, args []string, baseDir string) []strin
 	protected := make([]string, 0, len(targets))
 	for _, target := range targets {
 		abs := gitPathAbs(target, baseDir)
-		if _, ok := protectedTownRuntimePath(abs); ok {
+		if protectedTownRuntimePath(abs) {
 			protected = append(protected, abs)
 		}
 	}
@@ -532,16 +532,16 @@ func resolveExistingSymlinkAncestors(path string) string {
 	}
 }
 
-func protectedTownRuntimePath(path string) (string, bool) {
+func protectedTownRuntimePath(path string) bool {
 	abs := filepath.Clean(path)
 	for dir := abs; ; dir = filepath.Dir(dir) {
 		if isTownRoot(dir) {
 			if samePath(abs, dir) {
-				return dir, true
+				return true
 			}
 			rel, err := filepath.Rel(dir, abs)
 			if err != nil {
-				return "", false
+				return false
 			}
 			first := rel
 			if idx := strings.IndexRune(rel, filepath.Separator); idx >= 0 {
@@ -549,14 +549,14 @@ func protectedTownRuntimePath(path string) (string, bool) {
 			}
 			switch first {
 			case "mayor", ".dolt-data", ".runtime", ".beads", "daemon":
-				return dir, true
+				return true
 			default:
-				return "", false
+				return false
 			}
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return "", false
+			return false
 		}
 	}
 }
@@ -608,7 +608,7 @@ type cloneOptions struct {
 // to dest, and applies post-clone configuration (hooks or refspec).
 func (g *Git) cloneInternal(url, dest string, opts cloneOptions) error {
 	dest = gitPathAbs(dest, "")
-	if _, ok := protectedTownRuntimePath(dest); ok {
+	if protectedTownRuntimePath(dest) {
 		return fmt.Errorf("%w: clone destination %s", ErrUnsafeTownRootGitMutation, dest)
 	}
 


### PR DESCRIPTION
Supersedes #4060 and replaces #4243 with a clean upstream/main-based branch. Implements the PR Sheriff root-cause dog formula dispatch fix without the wisp_reaper/daemon TTL bandaid: pool-wide dog dispatch serialization, idle-only dog assignment, existing hooked formula reuse/start, and ownership/timestamp-guarded cleanup. Validation: go test ./internal/dog -count=1; GT_TEST_NO_NUDGE=1 go test ./internal/cmd -run 'Test(RunSlingFormula|DogDispatchInfo|CleanupDelayedDogFormulaFailure)' -count=1 -timeout=60s; go test ./internal/daemon -run 'TestDispatchReaperDogUsesDogPoolSling|TestWispReaper|TestDefaultReaperIntervalIsOneHour' -count=1 -timeout=60s; go build ./cmd/gt.