### PR TITLE
fix(mail): converge inbox query fanout

### DIFF
--- a/internal/mail/bd_test.go
+++ b/internal/mail/bd_test.go
@@ -1,11 +1,13 @@
 package mail
 
 import (
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 func TestBdError_Error(t *testing.T) {
@@ -164,6 +166,48 @@ func TestBdError_ImplementsErrorInterface(t *testing.T) {
 	}
 
 	_ = err.Error() // Should compile and not panic
+}
+
+func TestParseBeadsListOutput(t *testing.T) {
+	created := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	valid, err := json.Marshal([]BeadsMessage{{
+		ID:        "msg-1",
+		Title:     "Hello",
+		Status:    "open",
+		Priority:  2,
+		CreatedAt: created,
+		Labels:    []string{"gt:message", "from:mayor/"},
+	}})
+	if err != nil {
+		t.Fatalf("marshal valid message: %v", err)
+	}
+
+	tests := []struct {
+		name    string
+		input   []byte
+		wantLen int
+		wantErr bool
+	}{
+		{name: "empty", input: nil},
+		{name: "plain no issues", input: []byte("No issues found.\n")},
+		{name: "null", input: []byte("null\n")},
+		{name: "empty array", input: []byte("[]\n")},
+		{name: "valid array", input: valid, wantLen: 1},
+		{name: "non json", input: []byte("warning: no rows")},
+		{name: "malformed json", input: []byte("[{bad json]"), wantErr: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseBeadsListOutput(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseBeadsListOutput() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if len(got) != tt.wantLen {
+				t.Fatalf("parseBeadsListOutput() returned %d messages, want %d", len(got), tt.wantLen)
+			}
+		})
+	}
 }
 
 func TestBdError_WithAllFields(t *testing.T) {

--- a/internal/mail/bd_test.go
+++ b/internal/mail/bd_test.go
@@ -208,6 +208,23 @@ func TestParseBeadsListOutput(t *testing.T) {
 			}
 		})
 	}
+
+	got, err := parseBeadsListOutput(valid)
+	if err != nil {
+		t.Fatalf("parse valid output: %v", err)
+	}
+	if len(got) != 1 {
+		t.Fatalf("parse valid output returned %d messages, want 1", len(got))
+	}
+	if got[0].ID != "msg-1" || got[0].Title != "Hello" || got[0].Status != "open" || got[0].Priority != 2 {
+		t.Fatalf("parse valid output returned unexpected message: %#v", got[0])
+	}
+	if !got[0].CreatedAt.Equal(created) {
+		t.Fatalf("CreatedAt = %v, want %v", got[0].CreatedAt, created)
+	}
+	if len(got[0].Labels) != 2 || got[0].Labels[0] != "gt:message" || got[0].Labels[1] != "from:mayor/" {
+		t.Fatalf("Labels = %#v, want gt:message/from:mayor/", got[0].Labels)
+	}
 }
 
 func TestBdError_WithAllFields(t *testing.T) {

--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -350,7 +350,7 @@ type wispSQLRow struct {
 	CCHit       int    `json:"cc_match"`
 }
 
-// runWispSQL executes a bd sql --json query and converts results to BeadsMessages.
+// runWispSQL executes a bd sql --json query and converts results to wisp query messages.
 func (m *Mailbox) runWispSQL(beadsDir, query string) ([]wispQueryMessage, error) {
 	args := []string{"sql", "--json", query}
 	ctx, cancel := bdReadCtx()
@@ -404,8 +404,9 @@ func sqlStringList(values []string) string {
 	return strings.Join(quoted, ",")
 }
 
-// escapeSQLString escapes single quotes for SQL string literals.
+// escapeSQLString escapes backslashes and single quotes for Dolt/MySQL SQL string literals.
 func escapeSQLString(s string) string {
+	s = strings.ReplaceAll(s, `\`, `\\`)
 	return strings.ReplaceAll(s, "'", "''")
 }
 

--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -218,11 +218,11 @@ func (m *Mailbox) queryIssueMessagesByAssignee(beadsDir string, identities []str
 		stdout, err := runBdCommand(ctx, args, m.workDir, beadsDir)
 		cancel()
 		if err != nil {
-			continue
+			return nil, err
 		}
 		msgs, err := parseBeadsListOutput(stdout)
 		if err != nil {
-			continue
+			return nil, err
 		}
 		messages = append(messages, msgs...)
 	}
@@ -243,11 +243,11 @@ func (m *Mailbox) queryIssueMessagesByCC(beadsDir string, identities []string) (
 		stdout, err := runBdCommand(ctx, args, m.workDir, beadsDir)
 		cancel()
 		if err != nil {
-			return nil, err
+			continue
 		}
 		msgs, err := parseBeadsListOutput(stdout)
 		if err != nil {
-			return nil, err
+			continue
 		}
 		messages = append(messages, msgs...)
 	}

--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -178,7 +178,7 @@ func (m *Mailbox) listFromDir(beadsDir string) ([]*Message, error) {
 	}()
 	go func() {
 		defer wg.Done()
-		cc.messages, cc.err = m.queryIssueMessagesByCC(beadsDir, identities)
+		cc.messages = m.queryIssueMessagesByCC(beadsDir, identities)
 	}()
 	go func() {
 		defer wg.Done()
@@ -194,9 +194,7 @@ func (m *Mailbox) listFromDir(beadsDir string) ([]*Message, error) {
 	seen := make(map[string]bool)
 	messages := make([]*Message, 0, len(assignee.messages)+len(cc.messages)+len(wisps.messages))
 	messages = appendBeadsMessages(messages, seen, assignee.messages, true)
-	if cc.err == nil {
-		messages = appendBeadsMessages(messages, seen, cc.messages, false)
-	}
+	messages = appendBeadsMessages(messages, seen, cc.messages, false)
 	if wisps.err == nil {
 		messages = appendWispMessages(messages, seen, wisps.messages)
 	}
@@ -229,7 +227,7 @@ func (m *Mailbox) queryIssueMessagesByAssignee(beadsDir string, identities []str
 	return messages, nil
 }
 
-func (m *Mailbox) queryIssueMessagesByCC(beadsDir string, identities []string) ([]BeadsMessage, error) {
+func (m *Mailbox) queryIssueMessagesByCC(beadsDir string, identities []string) []BeadsMessage {
 	var messages []BeadsMessage
 	for _, id := range identities {
 		args := []string{"list",
@@ -251,7 +249,7 @@ func (m *Mailbox) queryIssueMessagesByCC(beadsDir string, identities []string) (
 		}
 		messages = append(messages, msgs...)
 	}
-	return messages, nil
+	return messages
 }
 
 func parseBeadsListOutput(stdout []byte) ([]BeadsMessage, error) {

--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -155,11 +155,57 @@ func (m *Mailbox) listFromDir(beadsDir string) ([]*Message, error) {
 		return nil, fmt.Errorf("ensuring custom types: %w", err)
 	}
 
-	// Deduplicate messages across queries (assignee + CC may overlap)
-	seen := make(map[string]bool)
-	messages := make([]*Message, 0)
+	type beadsFetch struct {
+		messages []BeadsMessage
+		err      error
+	}
+	type wispFetch struct {
+		messages []wispQueryMessage
+		err      error
+	}
 
-	// Query 1: assignee match (per identity variant)
+	var assignee beadsFetch
+	var cc beadsFetch
+	var wisps wispFetch
+
+	// The three fetches are independent. Keep identity variants collapsed inside
+	// each fetch so parallelism reduces latency without multiplying wisp SQL work.
+	var wg sync.WaitGroup
+	wg.Add(3)
+	go func() {
+		defer wg.Done()
+		assignee.messages, assignee.err = m.queryIssueMessagesByAssignee(beadsDir, identities)
+	}()
+	go func() {
+		defer wg.Done()
+		cc.messages, cc.err = m.queryIssueMessagesByCC(beadsDir, identities)
+	}()
+	go func() {
+		defer wg.Done()
+		wisps.messages, wisps.err = m.queryWispMessages(beadsDir, identities)
+	}()
+	wg.Wait()
+
+	if assignee.err != nil {
+		return nil, assignee.err
+	}
+
+	// Deduplicate messages across queries (assignee + CC + wisps may overlap).
+	seen := make(map[string]bool)
+	messages := make([]*Message, 0, len(assignee.messages)+len(cc.messages)+len(wisps.messages))
+	messages = appendBeadsMessages(messages, seen, assignee.messages, true)
+	if cc.err == nil {
+		messages = appendBeadsMessages(messages, seen, cc.messages, false)
+	}
+	if wisps.err == nil {
+		messages = appendWispMessages(messages, seen, wisps.messages)
+	}
+
+	return messages, nil
+}
+
+func (m *Mailbox) queryIssueMessagesByAssignee(beadsDir string, identities []string) ([]BeadsMessage, error) {
+	var messages []BeadsMessage
 	for _, id := range identities {
 		args := []string{"list",
 			"--label", "gt:message",
@@ -172,44 +218,23 @@ func (m *Mailbox) listFromDir(beadsDir string) ([]*Message, error) {
 		stdout, err := runBdCommand(ctx, args, m.workDir, beadsDir)
 		cancel()
 		if err != nil {
-			return nil, err
-		}
-
-		// bd v0.58.0 returns plain text (e.g. "No issues found.") for
-		// empty result sets instead of JSON. Skip non-JSON output.
-		if !isJSON(stdout) {
 			continue
 		}
-		var msgs []BeadsMessage
-		trimmed := bytes.TrimSpace(stdout)
-		if len(trimmed) == 0 || string(trimmed) == "null" || (trimmed[0] != '[' && trimmed[0] != '{') {
-			// bd v0.58.0 returns plain text (e.g. "No issues found.") for
-			// empty result sets instead of JSON. Skip non-JSON output.
+		msgs, err := parseBeadsListOutput(stdout)
+		if err != nil {
 			continue
 		}
-		if err := json.Unmarshal(stdout, &msgs); err != nil {
-			return nil, err
-		}
-
-		for i := range msgs {
-			bm := &msgs[i]
-			if seen[bm.ID] {
-				continue
-			}
-			// Assignee match: open or hooked status
-			if bm.Status == "open" || bm.Status == "hooked" {
-				seen[bm.ID] = true
-				messages = append(messages, bm.ToMessage())
-			}
-		}
+		messages = append(messages, msgs...)
 	}
+	return messages, nil
+}
 
-	// Query 2: CC match — fetch messages with cc:<identity> label
+func (m *Mailbox) queryIssueMessagesByCC(beadsDir string, identities []string) ([]BeadsMessage, error) {
+	var messages []BeadsMessage
 	for _, id := range identities {
-		ccLabel := "cc:" + id
 		args := []string{"list",
 			"--label", "gt:message",
-			"--label", ccLabel,
+			"--label", "cc:" + id,
 			"--json",
 			"--limit", "0",
 		}
@@ -218,107 +243,97 @@ func (m *Mailbox) listFromDir(beadsDir string) ([]*Message, error) {
 		stdout, err := runBdCommand(ctx, args, m.workDir, beadsDir)
 		cancel()
 		if err != nil {
-			// CC query failure is non-fatal — assignee messages are primary
-			continue
+			return nil, err
 		}
-
-		if !isJSON(stdout) {
-			continue
+		msgs, err := parseBeadsListOutput(stdout)
+		if err != nil {
+			return nil, err
 		}
-		var msgs []BeadsMessage
-		trimmedCC := bytes.TrimSpace(stdout)
-		if len(trimmedCC) == 0 || string(trimmedCC) == "null" || (trimmedCC[0] != '[' && trimmedCC[0] != '{') {
-			continue
-		}
-		if err := json.Unmarshal(stdout, &msgs); err != nil {
-			continue // Non-fatal for CC
-		}
-
-		for i := range msgs {
-			bm := &msgs[i]
-			if seen[bm.ID] {
-				continue
-			}
-			// CC match: open status only
-			if bm.Status == "open" {
-				seen[bm.ID] = true
-				messages = append(messages, bm.ToMessage())
-			}
-		}
+		messages = append(messages, msgs...)
 	}
-
-	// Query 3: Wisps table — ephemeral messages (protocol/lifecycle) are stored
-	// as wisps by shouldBeWisp(), but bd list only queries the issues table.
-	wispMessages := m.listWispMessages(beadsDir, identities, seen)
-	messages = append(messages, wispMessages...)
-
 	return messages, nil
 }
 
-// listWispMessages queries the wisps table for ephemeral messages matching the identity.
-// Protocol/lifecycle messages are stored as wisps by shouldBeWisp(), but bd list only
-// queries the issues table. Uses bd sql --json for full wisp data.
-func (m *Mailbox) listWispMessages(beadsDir string, identities []string, seen map[string]bool) []*Message {
-	var messages []*Message
-
-	// Query 3a: assignee match via SQL on wisps table
-	for _, id := range identities {
-		wispMsgs := m.queryWispMessagesByAssignee(beadsDir, id)
-		for _, bm := range wispMsgs {
-			if seen[bm.ID] {
-				continue
-			}
-			if bm.Status == "open" || bm.Status == "hooked" {
-				seen[bm.ID] = true
-				messages = append(messages, bm.ToMessage())
-			}
-		}
+func parseBeadsListOutput(stdout []byte) ([]BeadsMessage, error) {
+	trimmed := bytes.TrimSpace(stdout)
+	if len(trimmed) == 0 || bytes.Equal(trimmed, []byte("null")) || bytes.Equal(trimmed, []byte("No issues found.")) {
+		return nil, nil
+	}
+	if !isJSON(trimmed) {
+		return nil, nil
 	}
 
-	// Query 3b: CC match via SQL on wisps table
-	for _, id := range identities {
-		wispMsgs := m.queryWispMessagesByCC(beadsDir, id)
-		for _, bm := range wispMsgs {
-			if seen[bm.ID] {
-				continue
-			}
-			if bm.Status == "open" {
-				seen[bm.ID] = true
-				messages = append(messages, bm.ToMessage())
-			}
+	var msgs []BeadsMessage
+	if err := json.Unmarshal(trimmed, &msgs); err != nil {
+		return nil, err
+	}
+	return msgs, nil
+}
+
+func appendBeadsMessages(messages []*Message, seen map[string]bool, msgs []BeadsMessage, includeHooked bool) []*Message {
+	for i := range msgs {
+		bm := &msgs[i]
+		if seen[bm.ID] {
+			continue
+		}
+		if bm.Status == "open" || (includeHooked && bm.Status == "hooked") {
+			seen[bm.ID] = true
+			messages = append(messages, bm.ToMessage())
 		}
 	}
-
 	return messages
 }
 
-// queryWispMessagesByAssignee queries wisps table for messages assigned to identity.
-func (m *Mailbox) queryWispMessagesByAssignee(beadsDir, identity string) []BeadsMessage {
-	query := fmt.Sprintf(
-		"SELECT w.id, w.title, w.description, w.status, w.priority, w.assignee, w.created_at, w.updated_at, "+
-			"GROUP_CONCAT(al.label) as labels_csv "+
-			"FROM wisps w "+
-			"JOIN wisp_labels l ON w.id = l.issue_id "+
-			"JOIN wisp_labels al ON w.id = al.issue_id "+
-			"WHERE l.label = 'gt:message' AND w.status IN ('open', 'hooked') AND w.assignee = '%s' "+
-			"GROUP BY w.id, w.title, w.description, w.status, w.priority, w.assignee, w.created_at, w.updated_at",
-		escapeSQLString(identity))
-	return m.runWispSQL(beadsDir, query)
+func appendWispMessages(messages []*Message, seen map[string]bool, wisps []wispQueryMessage) []*Message {
+	for i := range wisps {
+		wisp := &wisps[i]
+		bm := &wisp.message
+		if seen[bm.ID] {
+			continue
+		}
+		include := wisp.assigneeMatch && (bm.Status == "open" || bm.Status == "hooked")
+		include = include || (wisp.ccMatch && bm.Status == "open")
+		if include {
+			seen[bm.ID] = true
+			messages = append(messages, bm.ToMessage())
+		}
+	}
+	return messages
 }
 
-// queryWispMessagesByCC queries wisps table for messages where identity is CC'd.
-func (m *Mailbox) queryWispMessagesByCC(beadsDir, identity string) []BeadsMessage {
-	ccLabel := "cc:" + identity
+type wispQueryMessage struct {
+	message       BeadsMessage
+	assigneeMatch bool
+	ccMatch       bool
+}
+
+// queryWispMessages queries ephemeral messages once across all identity variants.
+// Protocol/lifecycle messages are stored as wisps by shouldBeWisp(), but bd list
+// only queries the issues table.
+func (m *Mailbox) queryWispMessages(beadsDir string, identities []string) ([]wispQueryMessage, error) {
+	if len(identities) == 0 {
+		return nil, nil
+	}
+
+	ccLabels := make([]string, 0, len(identities))
+	for _, id := range identities {
+		ccLabels = append(ccLabels, "cc:"+id)
+	}
+	identityList := sqlStringList(identities)
+	ccLabelList := sqlStringList(ccLabels)
+
 	query := fmt.Sprintf(
 		"SELECT w.id, w.title, w.description, w.status, w.priority, w.assignee, w.created_at, w.updated_at, "+
-			"GROUP_CONCAT(al.label) as labels_csv "+
+			"GROUP_CONCAT(DISTINCT al.label) as labels_csv, "+
+			"MAX(CASE WHEN w.assignee IN (%s) THEN 1 ELSE 0 END) as assignee_match, "+
+			"MAX(CASE WHEN cc.label IS NOT NULL THEN 1 ELSE 0 END) as cc_match "+
 			"FROM wisps w "+
-			"JOIN wisp_labels l1 ON w.id = l1.issue_id "+
-			"JOIN wisp_labels l2 ON w.id = l2.issue_id "+
+			"JOIN wisp_labels msg_label ON w.id = msg_label.issue_id AND msg_label.label = 'gt:message' "+
 			"JOIN wisp_labels al ON w.id = al.issue_id "+
-			"WHERE l1.label = 'gt:message' AND l2.label = '%s' AND w.status IN ('open', 'hooked') "+
+			"LEFT JOIN wisp_labels cc ON w.id = cc.issue_id AND cc.label IN (%s) "+
+			"WHERE w.status IN ('open', 'hooked') AND (w.assignee IN (%s) OR cc.label IS NOT NULL) "+
 			"GROUP BY w.id, w.title, w.description, w.status, w.priority, w.assignee, w.created_at, w.updated_at",
-		escapeSQLString(ccLabel))
+		identityList, ccLabelList, identityList)
 	return m.runWispSQL(beadsDir, query)
 }
 
@@ -333,27 +348,29 @@ type wispSQLRow struct {
 	CreatedAt   string `json:"created_at"`
 	UpdatedAt   string `json:"updated_at"`
 	LabelsCSV   string `json:"labels_csv"`
+	AssigneeHit int    `json:"assignee_match"`
+	CCHit       int    `json:"cc_match"`
 }
 
 // runWispSQL executes a bd sql --json query and converts results to BeadsMessages.
-func (m *Mailbox) runWispSQL(beadsDir, query string) []BeadsMessage {
+func (m *Mailbox) runWispSQL(beadsDir, query string) ([]wispQueryMessage, error) {
 	args := []string{"sql", "--json", query}
 	ctx, cancel := bdReadCtx()
 	stdout, err := runBdCommand(ctx, args, m.workDir, beadsDir)
 	cancel()
 	if err != nil {
-		return nil // Wisps table may not exist yet
+		return nil, err // Wisps table may not exist yet.
 	}
 	if !isJSON(stdout) {
-		return nil
+		return nil, nil
 	}
 
 	var rows []wispSQLRow
 	if err := json.Unmarshal(stdout, &rows); err != nil {
-		return nil
+		return nil, err
 	}
 
-	msgs := make([]BeadsMessage, 0, len(rows))
+	msgs := make([]wispQueryMessage, 0, len(rows))
 	for _, row := range rows {
 		bm := BeadsMessage{
 			ID:          row.ID,
@@ -372,9 +389,21 @@ func (m *Mailbox) runWispSQL(beadsDir, query string) []BeadsMessage {
 		if row.LabelsCSV != "" {
 			bm.Labels = strings.Split(row.LabelsCSV, ",")
 		}
-		msgs = append(msgs, bm)
+		msgs = append(msgs, wispQueryMessage{
+			message:       bm,
+			assigneeMatch: row.AssigneeHit != 0,
+			ccMatch:       row.CCHit != 0,
+		})
 	}
-	return msgs
+	return msgs, nil
+}
+
+func sqlStringList(values []string) string {
+	quoted := make([]string, 0, len(values))
+	for _, value := range values {
+		quoted = append(quoted, "'"+escapeSQLString(value)+"'")
+	}
+	return strings.Join(quoted, ",")
 }
 
 // escapeSQLString escapes single quotes for SQL string literals.

--- a/internal/mail/mailbox_test.go
+++ b/internal/mail/mailbox_test.go
@@ -5,10 +5,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"sync"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/constants"
 )
 
 func TestNewMailbox(t *testing.T) {
@@ -436,6 +439,99 @@ func TestNewMailboxWithBeadsDir(t *testing.T) {
 	}
 }
 
+func TestMailboxListFromDirConvergesWispQueryAndFiltersStatuses(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fake bd is POSIX-only")
+	}
+
+	beadsDir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(beadsDir, ".gt-types-configured"), []byte(strings.Join(constants.BeadsCustomTypesList(), ",")+"\n"), 0644); err != nil {
+		t.Fatalf("write types sentinel: %v", err)
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd.log")
+	fakeBD := filepath.Join(binDir, "bd")
+	script := `#!/bin/sh
+printf '%s\n' "$*" >> "$BD_LOG"
+if [ "$1" = "list" ]; then
+  case "$*" in
+    *"--assignee gastown/synth"*)
+      printf '%s\n' '[{"id":"issue-direct-open","title":"Direct open","description":"","status":"open","priority":2,"assignee":"gastown/synth","created_at":"2026-06-12T12:00:05Z","labels":["gt:message","from:mayor/"]},{"id":"issue-direct-hooked","title":"Direct hooked","description":"","status":"hooked","priority":2,"assignee":"gastown/synth","created_at":"2026-06-12T12:00:04Z","labels":["gt:message","from:mayor/"]},{"id":"issue-direct-closed","title":"Direct closed","description":"","status":"closed","priority":2,"assignee":"gastown/synth","created_at":"2026-06-12T12:00:03Z","labels":["gt:message","from:mayor/"]}]'
+      exit 0
+      ;;
+    *"--label cc:gastown/synth"*)
+      printf '%s\n' '[{"id":"issue-cc-open","title":"CC open","description":"","status":"open","priority":2,"assignee":"mayor/","created_at":"2026-06-12T12:00:02Z","labels":["gt:message","cc:gastown/synth","from:mayor/"]},{"id":"issue-cc-hooked","title":"CC hooked","description":"","status":"hooked","priority":2,"assignee":"mayor/","created_at":"2026-06-12T12:00:01Z","labels":["gt:message","cc:gastown/synth","from:mayor/"]}]'
+      exit 0
+      ;;
+  esac
+  printf '%s\n' 'No issues found.'
+  exit 0
+fi
+if [ "$1" = "sql" ]; then
+  printf '%s\n' '[{"id":"wisp-direct-open","title":"Wisp direct open","description":"","status":"open","priority":2,"assignee":"gastown/synth","created_at":"2026-06-12T12:00:00Z","updated_at":"2026-06-12T12:00:00Z","labels_csv":"gt:message,from:mayor/","assignee_match":1,"cc_match":0},{"id":"wisp-direct-hooked","title":"Wisp direct hooked","description":"","status":"hooked","priority":2,"assignee":"gastown/synth","created_at":"2026-06-12T11:59:59Z","updated_at":"2026-06-12T11:59:59Z","labels_csv":"gt:message,from:mayor/","assignee_match":1,"cc_match":0},{"id":"wisp-cc-open","title":"Wisp CC open","description":"","status":"open","priority":2,"assignee":"mayor/","created_at":"2026-06-12T11:59:58Z","updated_at":"2026-06-12T11:59:58Z","labels_csv":"gt:message,cc:gastown/synth,from:mayor/","assignee_match":0,"cc_match":1},{"id":"wisp-cc-hooked","title":"Wisp CC hooked","description":"","status":"hooked","priority":2,"assignee":"mayor/","created_at":"2026-06-12T11:59:57Z","updated_at":"2026-06-12T11:59:57Z","labels_csv":"gt:message,cc:gastown/synth,from:mayor/","assignee_match":0,"cc_match":1},{"id":"issue-direct-open","title":"Duplicate wisp","description":"","status":"open","priority":2,"assignee":"gastown/synth","created_at":"2026-06-12T11:59:56Z","updated_at":"2026-06-12T11:59:56Z","labels_csv":"gt:message,from:mayor/","assignee_match":1,"cc_match":0}]'
+  exit 0
+fi
+printf 'unexpected bd args: %s\n' "$*" >&2
+exit 1
+`
+	if err := os.WriteFile(fakeBD, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_LOG", logPath)
+
+	m := NewMailboxWithBeadsDir("gastown/synth", t.TempDir(), beadsDir)
+	msgs, err := m.listFromDir(beadsDir)
+	if err != nil {
+		t.Fatalf("listFromDir: %v", err)
+	}
+
+	byID := make(map[string]*Message)
+	for _, msg := range msgs {
+		byID[msg.ID] = msg
+	}
+	wantPresent := []string{
+		"issue-direct-open",
+		"issue-direct-hooked",
+		"issue-cc-open",
+		"wisp-direct-open",
+		"wisp-direct-hooked",
+		"wisp-cc-open",
+	}
+	for _, id := range wantPresent {
+		if byID[id] == nil {
+			t.Fatalf("missing message %s in %#v", id, byID)
+		}
+	}
+	wantAbsent := []string{
+		"issue-direct-closed",
+		"issue-cc-hooked",
+		"wisp-cc-hooked",
+	}
+	for _, id := range wantAbsent {
+		if byID[id] != nil {
+			t.Fatalf("unexpected message %s in inbox", id)
+		}
+	}
+	if byID["issue-direct-open"].Wisp {
+		t.Fatal("issue duplicate should keep issue result, not later wisp result")
+	}
+	for _, id := range []string{"wisp-direct-open", "wisp-direct-hooked", "wisp-cc-open"} {
+		if !byID[id].Wisp {
+			t.Fatalf("%s should be marked as wisp", id)
+		}
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	if got := strings.Count(string(logBytes), "sql "); got != 1 {
+		t.Fatalf("bd sql calls = %d, want 1; log:\n%s", got, string(logBytes))
+	}
+}
+
 func TestMailboxLegacyMultipleOperations(t *testing.T) {
 	tmpDir := t.TempDir()
 	m := NewMailbox(tmpDir)
@@ -703,4 +799,3 @@ func TestMailboxLegacyAtomicArchive(t *testing.T) {
 		t.Errorf("Archived message ID = %q, want msg-002", archived[0].ID)
 	}
 }
-

--- a/internal/mail/mailbox_test.go
+++ b/internal/mail/mailbox_test.go
@@ -532,6 +532,81 @@ exit 1
 	}
 }
 
+func TestQueryWispMessagesEscapesIdentitySQLLiterals(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("shell fake bd is POSIX-only")
+	}
+
+	binDir := t.TempDir()
+	sqlLogPath := filepath.Join(t.TempDir(), "bd-sql.log")
+	fakeBD := filepath.Join(binDir, "bd")
+	script := `#!/bin/sh
+if [ "$1" = "sql" ]; then
+  printf '%s\n' "$3" >> "$BD_SQL_LOG"
+  printf '%s\n' '[]'
+  exit 0
+fi
+printf 'unexpected bd args: %s\n' "$*" >&2
+exit 1
+`
+	if err := os.WriteFile(fakeBD, []byte(script), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_SQL_LOG", sqlLogPath)
+
+	m := NewMailboxWithBeadsDir("mayor/", t.TempDir(), t.TempDir())
+	_, err := m.queryWispMessages(t.TempDir(), []string{"mayor/", "mayor", `rig/o\'malley`})
+	if err != nil {
+		t.Fatalf("queryWispMessages: %v", err)
+	}
+
+	sqlLog, err := os.ReadFile(sqlLogPath)
+	if err != nil {
+		t.Fatalf("read SQL log: %v", err)
+	}
+	queries := strings.Split(strings.TrimSpace(string(sqlLog)), "\n")
+	if len(queries) != 1 {
+		t.Fatalf("bd sql calls = %d, want 1; log:\n%s", len(queries), string(sqlLog))
+	}
+	sql := queries[0]
+	for _, want := range []string{
+		`'mayor/'`,
+		`'mayor'`,
+		`'cc:mayor/'`,
+		`'cc:mayor'`,
+		`'rig/o\\''malley'`,
+		`'cc:rig/o\\''malley'`,
+	} {
+		if !strings.Contains(sql, want) {
+			t.Fatalf("generated SQL missing %q:\n%s", want, sql)
+		}
+	}
+}
+
+func TestSQLStringListEscapesSQLLiterals(t *testing.T) {
+	tests := []struct {
+		name   string
+		values []string
+		want   string
+	}{
+		{name: "plain", values: []string{"mayor"}, want: `'mayor'`},
+		{name: "quote", values: []string{"o'brien"}, want: `'o''brien'`},
+		{name: "backslash", values: []string{`rig\agent`}, want: `'rig\\agent'`},
+		{name: "trailing backslash", values: []string{`rig\`}, want: `'rig\\'`},
+		{name: "quote after backslash", values: []string{`rig/o\'malley`}, want: `'rig/o\\''malley'`},
+		{name: "list", values: []string{"mayor/", `rig/o\'malley`}, want: `'mayor/','rig/o\\''malley'`},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := sqlStringList(tt.values); got != tt.want {
+				t.Fatalf("sqlStringList(%#v) = %q, want %q", tt.values, got, tt.want)
+			}
+		})
+	}
+}
+
 func TestMailboxLegacyMultipleOperations(t *testing.T) {
 	tmpDir := t.TempDir()
 	m := NewMailbox(tmpDir)


### PR DESCRIPTION
Supersedes #4063 with a cleanup-first maintainer fix.\n\nWhat changed:\n- Runs inbox assignee issues, CC issues, and wisp fetches as three independent top-level lanes.\n- Collapses wisp inbox lookup to one SQL query across identity variants, preserving assignee vs CC provenance.\n- Preserves existing semantics: assignee open+hooked are included; CC open only; assignee query errors remain fatal; CC/wisp remain best-effort.\n- Adds parser coverage plus behavior coverage for status filtering, wisp handling, dedupe, and single wisp SQL query.\n\nValidation:\n- git diff --check upstream/main...HEAD\n- gofmt -l changed Go files\n- go test ./internal/mail -count=1\n- GT_TEST_NO_NUDGE=1 go test ./internal/cmd -run 'Test.*Mail' -count=1 -timeout=120s\n- go build ./cmd/gt\n- go test -race ./internal/mail -run 'Test(MailboxListFromDirConvergesWispQueryAndFiltersStatuses|ParseBeadsListOutput)' -count=1\n\nPR Sheriff evidence is recorded on bead gt-pr-sheriff-4063. Original #4063 should not merge as-is because it parallelizes per-identity subprocess fanout instead of reducing wisp query work.