### PR TITLE
fix(agent): preserve reasoning metadata in messages

### DIFF
--- a/internal/agent/provider/acp.go
+++ b/internal/agent/provider/acp.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"time"
@@ -25,6 +26,7 @@ const (
 	ContentTypeToolUse    ContentType = "tool_use"
 	ContentTypeToolResult ContentType = "tool_result"
 	ContentTypeImage      ContentType = "image"
+	ContentTypeThinking   ContentType = "thinking"
 )
 
 type ToolType string
@@ -58,6 +60,9 @@ type ContentBlock struct {
 
 	Text string `json:"text,omitempty"`
 
+	// ID is used by assistant tool_use blocks. Tool result blocks refer back to
+	// it via ToolUseID.
+	ID        string `json:"id,omitempty"`
 	ToolUseID string `json:"tool_use_id,omitempty"`
 
 	Name    string          `json:"name,omitempty"`
@@ -65,6 +70,57 @@ type ContentBlock struct {
 	Content any             `json:"content,omitempty"`
 	IsError bool            `json:"is_error,omitempty"`
 	Source  *ImageSource    `json:"source,omitempty"`
+
+	// Extended-thinking providers attach signed thinking blocks to assistant
+	// messages. Preserve these fields when conversation history is round-tripped;
+	// dropping them can make later tool-call requests fail validation.
+	Thinking         string `json:"thinking,omitempty"`
+	Signature        string `json:"signature,omitempty"`
+	ReasoningContent string `json:"reasoning_content,omitempty"`
+
+	extra map[string]json.RawMessage `json:"-"`
+}
+
+func (b *ContentBlock) UnmarshalJSON(data []byte) error {
+	type alias ContentBlock
+	var decoded alias
+	if err := json.Unmarshal(data, &decoded); err != nil {
+		return err
+	}
+	*b = ContentBlock(decoded)
+
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	for _, key := range []string{
+		"type", "text", "id", "tool_use_id", "name", "input", "content",
+		"is_error", "source", "thinking", "signature", "reasoning_content",
+	} {
+		delete(raw, key)
+	}
+	if len(raw) > 0 {
+		b.extra = raw
+	}
+	return nil
+}
+
+func (b ContentBlock) MarshalJSON() ([]byte, error) {
+	type alias ContentBlock
+	data, err := json.Marshal(alias(b))
+	if err != nil {
+		return nil, err
+	}
+	var merged map[string]json.RawMessage
+	if err := json.Unmarshal(data, &merged); err != nil {
+		return nil, err
+	}
+	for key, value := range b.extra {
+		if _, exists := merged[key]; !exists {
+			merged[key] = value
+		}
+	}
+	return json.Marshal(merged)
 }
 
 type ImageSource struct {
@@ -76,6 +132,64 @@ type ImageSource struct {
 type Message struct {
 	Role    Role           `json:"role"`
 	Content []ContentBlock `json:"content"`
+
+	extra      map[string]json.RawMessage `json:"-"`
+	contentRaw json.RawMessage            `json:"-"`
+}
+
+func (m *Message) UnmarshalJSON(data []byte) error {
+	*m = Message{}
+	var raw map[string]json.RawMessage
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if role, ok := raw["role"]; ok {
+		if err := json.Unmarshal(role, &m.Role); err != nil {
+			return err
+		}
+	}
+	if content, ok := raw["content"]; ok {
+		trimmed := bytes.TrimSpace(content)
+		if len(trimmed) > 0 && trimmed[0] == '[' {
+			if err := json.Unmarshal(content, &m.Content); err != nil {
+				return err
+			}
+		} else {
+			m.contentRaw = append(m.contentRaw[:0], content...)
+		}
+	}
+
+	delete(raw, "role")
+	delete(raw, "content")
+	if len(raw) > 0 {
+		m.extra = raw
+	}
+	return nil
+}
+
+func (m Message) MarshalJSON() ([]byte, error) {
+	merged := make(map[string]json.RawMessage, len(m.extra)+2)
+	for key, value := range m.extra {
+		merged[key] = value
+	}
+	role, err := json.Marshal(m.Role)
+	if err != nil {
+		return nil, err
+	}
+	merged["role"] = role
+
+	if m.Content != nil {
+		content, err := json.Marshal(m.Content)
+		if err != nil {
+			return nil, err
+		}
+		merged["content"] = content
+	} else if m.contentRaw != nil {
+		merged["content"] = m.contentRaw
+	} else {
+		merged["content"] = json.RawMessage("null")
+	}
+	return json.Marshal(merged)
 }
 
 type Tool struct {
@@ -249,6 +363,7 @@ func NewToolUseContent(id, name string, input any) (ContentBlock, error) {
 	}
 	return ContentBlock{
 		Type:  ContentTypeToolUse,
+		ID:    id,
 		Name:  name,
 		Input: inputBytes,
 	}, nil

--- a/internal/agent/provider/provider_test.go
+++ b/internal/agent/provider/provider_test.go
@@ -381,6 +381,65 @@ func TestMessagesToFromJSON(t *testing.T) {
 	}
 }
 
+func TestMessagesRoundTripPreservesAssistantReasoningContentWithToolCalls(t *testing.T) {
+	input := []byte(`[{"role":"assistant","content":null,"reasoning_content":"kept reasoning","tool_calls":[{"id":"call_1","type":"function","function":{"name":"lookup","arguments":"{}"}}]}]`)
+	parsed, err := MessagesFromJSON(input)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	data, err := MessagesToJSON(parsed)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+
+	var roundTripped []map[string]any
+	if err := json.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("failed to parse round trip: %v", err)
+	}
+	msg := roundTripped[0]
+	if msg["reasoning_content"] != "kept reasoning" {
+		t.Fatalf("reasoning_content = %v, want preserved value", msg["reasoning_content"])
+	}
+	if _, ok := msg["tool_calls"].([]any); !ok {
+		t.Fatalf("tool_calls not preserved: %v", msg["tool_calls"])
+	}
+	if msg["content"] != nil {
+		t.Fatalf("content = %v, want null preserved", msg["content"])
+	}
+}
+
+func TestMessagesRoundTripPreservesThinkingBlocks(t *testing.T) {
+	input := []byte(`[{"role":"assistant","content":[{"type":"thinking","thinking":"private chain","signature":"sig_123"},{"type":"tool_use","id":"tool_1","name":"read","input":{"path":"README.md"}}]}]`)
+	parsed, err := MessagesFromJSON(input)
+	if err != nil {
+		t.Fatalf("failed to unmarshal: %v", err)
+	}
+	if parsed[0].Content[0].Thinking != "private chain" {
+		t.Fatalf("thinking field not decoded")
+	}
+	if parsed[0].Content[1].ID != "tool_1" {
+		t.Fatalf("tool_use id not decoded")
+	}
+
+	data, err := MessagesToJSON(parsed)
+	if err != nil {
+		t.Fatalf("failed to marshal: %v", err)
+	}
+	var roundTripped []map[string]any
+	if err := json.Unmarshal(data, &roundTripped); err != nil {
+		t.Fatalf("failed to parse round trip: %v", err)
+	}
+	content := roundTripped[0]["content"].([]any)
+	thinking := content[0].(map[string]any)
+	if thinking["thinking"] != "private chain" || thinking["signature"] != "sig_123" {
+		t.Fatalf("thinking block not preserved: %v", thinking)
+	}
+	toolUse := content[1].(map[string]any)
+	if toolUse["id"] != "tool_1" {
+		t.Fatalf("tool_use id not preserved: %v", toolUse)
+	}
+}
+
 func TestInputSchema_MarshalJSON(t *testing.T) {
 	schema := &InputSchema{
 		Type: "object",


### PR DESCRIPTION
## Summary\n- Preserve assistant message reasoning_content/tool_calls when message history is round-tripped\n- Preserve thinking/signature content blocks and tool_use IDs\n- Add regression coverage for extended-thinking tool-call histories\n\n## Tests\n- go test ./internal/agent ./internal/agent/provider ./internal/acp\n\nFull go test ./... still has unrelated existing failures in internal/beads, internal/cmd, internal/git, internal/polecat, internal/refinery, internal/rig, and internal/web.