### PR TITLE
fix(deacon-patrol): stop wisp gc self-destructing the active patrol molecule (hq-3pp)

### DIFF
--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -105,11 +105,16 @@ id = "inbox-check"
 title = "Handle callbacks from agents"
 needs = ["heartbeat"]
 description = """
-First, clean up wisps from previous cycles (closed wisps + abandoned wisps):
+First, clean up CLOSED wisps from previous cycles:
 ```bash
 bd mol wisp gc --closed --force
-bd mol wisp gc --age 1h --force
 ```
+
+> ⚠️ hq-3pp: do NOT add an unscoped age-based gc (`bd mol wisp gc --age ...`) here.
+> It reaps step wisps by their per-step updated_at and deletes THIS patrol molecule's
+> own not-yet-run steps, silently auto-closing the patrol at ~2-3/26. `--closed` is
+> safe (closed wisps only, cannot touch open steps). Abandoned-wisp reaping for dead
+> sessions belongs in a separate dog task that runs OUTSIDE any patrol molecule.
 
 Then handle callbacks from agents.
 


### PR DESCRIPTION
## Problem (hq-3pp)

The `mol-deacon-patrol` "Handle callbacks" step ran `bd mol wisp gc --age 1h --force`. That age-based gc reaps step wisps by their per-step `updated_at` and deletes the **active patrol molecule's own not-yet-run steps**, silently auto-closing the cycle at ~2–3/26. It recurred on **every** patrol cycle (6×/day), skipping ~24 health-check steps while the ledger showed "molecule complete."

## Fix

Drop the unscoped `--age` gc from this step; keep `bd mol wisp gc --closed --force` only, which cannot touch open/in-progress steps. Add an inline warning so it isn't re-added.

Abandoned-wisp reaping for dead sessions is already handled by `mol-dog-reaper` (`--age 2h`, run **outside** any active molecule), so no cleanup coverage is lost.

## Verification

Slung a fresh patrol on the fixed formula: the callbacks-step gc ran and the molecule stayed **26/26 intact** (previously auto-closed at 2–3/26). Full cycle completed cleanly.

## Scope / follow-up

This is an **interim mitigation** at the formula level. The real fix is bd-side: `gc` should skip wisps belonging to any open/in-progress molecule by parent membership (independent of `--age`/type) — `--exclude-type` was empirically ruled out since patrol steps and orphans are both `type=task`. That membership fix also protects `mol-dog-reaper`'s own `--age` gc. Tracked on hq-3pp (still open).

🤖 Generated with [Claude Code](https://claude.com/claude-code)