### PR TITLE
fix(mail): parse wisp SQL timestamps as UTC

### DIFF
--- a/internal/mail/mailbox.go
+++ b/internal/mail/mailbox.go
@@ -379,9 +379,7 @@ func (m *Mailbox) runWispSQL(beadsDir, query string) ([]wispQueryMessage, error)
 			Assignee:    row.Assignee,
 			Wisp:        true,
 		}
-		if t, err := time.Parse(time.RFC3339, row.CreatedAt); err == nil {
-			bm.CreatedAt = t
-		} else if t, err := time.Parse("2006-01-02 15:04:05 +0000 UTC", row.CreatedAt); err == nil {
+		if t, ok := parseWispTimestamp(row.CreatedAt); ok {
 			bm.CreatedAt = t
 		}
 		if row.LabelsCSV != "" {
@@ -394,6 +392,21 @@ func (m *Mailbox) runWispSQL(beadsDir, query string) ([]wispQueryMessage, error)
 		})
 	}
 	return msgs, nil
+}
+
+func parseWispTimestamp(value string) (time.Time, bool) {
+	for _, layout := range []string{
+		time.RFC3339,
+		"2006-01-02 15:04:05 -0700 MST",
+		// Dolt/MySQL DATETIME values are emitted without a zone; Gas Town runs
+		// managed Dolt servers in UTC, so treat bare timestamps as UTC.
+		"2006-01-02 15:04:05",
+	} {
+		if t, err := time.Parse(layout, strings.TrimSpace(value)); err == nil {
+			return t.UTC(), true
+		}
+	}
+	return time.Time{}, false
 }
 
 func sqlStringList(values []string) string {

--- a/internal/mail/mailbox_test.go
+++ b/internal/mail/mailbox_test.go
@@ -607,6 +607,38 @@ func TestSQLStringListEscapesSQLLiterals(t *testing.T) {
 	}
 }
 
+func TestParseWispTimestamp(t *testing.T) {
+	want := time.Date(2026, 6, 12, 12, 0, 0, 0, time.UTC)
+	tests := []struct {
+		name  string
+		value string
+		want  time.Time
+		ok    bool
+	}{
+		{name: "rfc3339", value: "2026-06-12T12:00:00Z", want: want, ok: true},
+		{name: "rfc3339 offset", value: "2026-06-12T08:00:00-04:00", want: want, ok: true},
+		{name: "go utc", value: "2026-06-12 12:00:00 +0000 UTC", want: want, ok: true},
+		{name: "sql datetime", value: "2026-06-12 12:00:00", want: want, ok: true},
+		{name: "empty"},
+		{name: "malformed", value: "not a timestamp"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, ok := parseWispTimestamp(tt.value)
+			if ok != tt.ok {
+				t.Fatalf("parseWispTimestamp(%q) ok = %v, want %v", tt.value, ok, tt.ok)
+			}
+			if ok && !got.Equal(tt.want) {
+				t.Fatalf("parseWispTimestamp(%q) = %v, want %v", tt.value, got, tt.want)
+			}
+			if ok && got.Location() != time.UTC {
+				t.Fatalf("parseWispTimestamp(%q) location = %v, want UTC", tt.value, got.Location())
+			}
+		})
+	}
+}
+
 func TestMailboxLegacyMultipleOperations(t *testing.T) {
 	tmpDir := t.TempDir()
 	m := NewMailbox(tmpDir)


### PR DESCRIPTION
## Summary

Follow-up from PR sheriff #4063 after replacement PR #4261 merged.

- Consolidates wisp `created_at` parsing behind `parseWispTimestamp`.
- Preserves existing RFC3339 and Go `+0000 UTC` handling.
- Adds bare Dolt/MySQL `DATETIME` parsing as UTC, matching managed Dolt UTC configuration.
- Keeps malformed or empty timestamps non-fatal.
- Adds fixed-time unit coverage for UTC normalization and malformed inputs.

## Sheriff Evidence

Research fanout R01-R15: R01 current cleaned branch sounder than original PR and collapses wisp work; R02 primary assignee errors should remain fatal while CC/wisp paths are best-effort; R03 bd list parsing handles empty/null/No issues/non-JSON/malformed JSON; R04 deterministic dedupe with assignee priority and only equal timestamp tie caveat; R05 targeted tests are internal/mail plus mail cmd tests; R06 performance rationale is sound by replacing serial subprocess wall clock with fanout; R07 no scoped API blocker, store-backed CC mismatch is dormant/future; R08 argv is shell-safe and SQL literals are escaped; R09 no data races found in parallel fetches; R10 cleanup/convergence bias satisfied, with future option to collapse issue queries; R11 original #4063 closed unmerged and superseded by #4261; R12 wisp SQL semantics correct, timestamp gap identified; R13 repo concurrency style matches WaitGroup/simple fanout; R14 `gt mail inbox` hot path uses listFromDir subprocess fallback; R15 hidden-regression pass found no mail-code blocker.

Pre-implementation P01-P05: all approved a private wisp timestamp parser plus focused tests; required UTC treatment for bare Dolt/MySQL DATETIME, preserved existing formats, malformed timestamps non-fatal, no unrelated behavior changes.

Original post-implementation F01-F05: all passed with no mail-code blockers; parser normalizes RFC3339 offsets, Go UTC strings, and bare SQL datetimes to UTC; tests are fixed-time and non-flaky; diff remains scoped.

Post-rebase F06-F10: all passed with no blocking issues. Residual non-blocking risks noted: no live Dolt output integration test for malformed created_at rows; non-UTC Go `time.String` zones are not explicitly tested; local CGO test mode is blocked by missing ICU libs, so validation used `CGO_ENABLED=0`.

## Validation

- `git diff --check upstream/main...HEAD`
- `CGO_ENABLED=0 go test ./internal/mail -count=1`
- `CGO_ENABLED=0 go test ./internal/cmd -run 'Test.*Mail' -count=1 -timeout=120s`
- `CGO_ENABLED=0 go build ./cmd/gt`

Note: normal CGO Go test/build remains blocked in this local environment by missing ICU linker libraries (`-licui18n`, `-licuuc`, `-licudata`); no sudo or system install attempted.
