### PR TITLE
fix(reaper): auto-close step-wisps of completed molecules

### DIFF
--- a/.claude/commands/reaper.md
+++ b/.claude/commands/reaper.md
@@ -58,6 +58,7 @@ gt reaper scan --db=<name> --port=3307 \
 
 Inspect the JSON output:
 - `reap_candidates`: wisps eligible for closing
+- `molecule_step_candidates`: step-wisps whose parent molecule is already closed
 - `purge_candidates`: closed wisps eligible for deletion
 - `open_wisps`: total open wisp count
 - `anomalies`: array of detected problems
@@ -67,7 +68,7 @@ If no candidates found across all databases, report "nothing to reap" and stop.
 
 ### Step 4: Reap stale wisps
 
-For each database with reap candidates:
+For each database with reap candidates or molecule step candidates:
 
 ```bash
 gt reaper reap --db=<name> --port=3307 --max-age=24h [--dry-run] --json
@@ -107,6 +108,7 @@ Print a summary in this format:
 
 **Databases scanned**: N
 **Wisps reaped**: N (stale open wisps closed)
+**Molecule steps closed**: N (parent molecule already closed)
 **Wisps purged**: N (old closed wisps deleted)
 **Mail purged**: N (old closed mail deleted)
 **Issues auto-closed**: N (stale issues past 168h)

--- a/internal/cmd/compact.go
+++ b/internal/cmd/compact.go
@@ -283,7 +283,8 @@ func runCompact(cmd *cobra.Command, args []string) error {
 func cleanOrphanedWispDeps(bd *beads.Beads, result *compactResult) {
 	const q = `DELETE FROM wisp_dependencies WHERE ` +
 		`NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.issue_id) ` +
-		`OR NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_id)`
+		`OR (depends_on_wisp_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_wisp_id)) ` +
+		`OR (depends_on_issue_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM issues WHERE id = wisp_dependencies.depends_on_issue_id))`
 	out, err := bd.Run("sql", q)
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("orphaned wisp_deps cleanup: %v", err))

--- a/internal/cmd/reaper.go
+++ b/internal/cmd/reaper.go
@@ -54,6 +54,13 @@ func waitBeforeReaperDatabase(index int) error {
 	return nil
 }
 
+func reaperMoleculeStepSuffix(n int) string {
+	if n == 0 {
+		return ""
+	}
+	return fmt.Sprintf(" (+%d closed-molecule steps)", n)
+}
+
 var reaperCmd = &cobra.Command{
 	Use:     "reaper",
 	GroupID: GroupServices,
@@ -155,10 +162,13 @@ The Dog uses this to understand the state before deciding what to reap.`,
 		if reaperJSON {
 			fmt.Println(reaper.FormatJSON(results))
 		} else {
-			var totalReap, totalPurge, totalMail, totalStale, totalOpen int
+			var totalReap, totalMolSteps, totalPurge, totalMail, totalStale, totalOpen int
 			for _, r := range results {
 				fmt.Printf("Database: %s\n", r.Database)
 				fmt.Printf("  Reap candidates:  %d\n", r.ReapCandidates)
+				if r.MoleculeStepCandidates > 0 {
+					fmt.Printf("  Molecule steps:   %d\n", r.MoleculeStepCandidates)
+				}
 				fmt.Printf("  Purge candidates: %d\n", r.PurgeCandidates)
 				fmt.Printf("  Mail candidates:  %d\n", r.MailCandidates)
 				fmt.Printf("  Stale candidates: %d\n", r.StaleCandidates)
@@ -167,6 +177,7 @@ The Dog uses this to understand the state before deciding what to reap.`,
 					fmt.Printf("  %s %s\n", style.Warning.Render("ANOMALY:"), a.Message)
 				}
 				totalReap += r.ReapCandidates
+				totalMolSteps += r.MoleculeStepCandidates
 				totalPurge += r.PurgeCandidates
 				totalMail += r.MailCandidates
 				totalStale += r.StaleCandidates
@@ -175,6 +186,9 @@ The Dog uses this to understand the state before deciding what to reap.`,
 			if len(results) > 1 {
 				fmt.Printf("\nScan summary (%d databases):\n", len(results))
 				fmt.Printf("  Reap candidates:  %d\n", totalReap)
+				if totalMolSteps > 0 {
+					fmt.Printf("  Molecule steps:   %d\n", totalMolSteps)
+				}
 				fmt.Printf("  Purge candidates: %d\n", totalPurge)
 				fmt.Printf("  Mail candidates:  %d\n", totalMail)
 				fmt.Printf("  Stale candidates: %d\n", totalStale)
@@ -240,15 +254,16 @@ Returns the count of reaped wisps. Use --dry-run to preview.`,
 		if reaperJSON {
 			fmt.Println(reaper.FormatJSON(results))
 		} else {
-			var totalReaped, totalOpen int
+			var totalReaped, totalMolSteps, totalOpen int
 			for _, r := range results {
 				prefix := ""
 				if r.DryRun {
 					prefix = "[DRY RUN] would "
 				}
-				fmt.Printf("%s: %sreaped %d wisps, %d open remain\n",
-					r.Database, prefix, r.Reaped, r.OpenRemain)
+				fmt.Printf("%s: %sreaped %d wisps%s, %d open remain\n",
+					r.Database, prefix, r.Reaped, reaperMoleculeStepSuffix(r.MoleculeStepsClosed), r.OpenRemain)
 				totalReaped += r.Reaped
+				totalMolSteps += r.MoleculeStepsClosed
 				totalOpen += r.OpenRemain
 			}
 			if len(results) > 1 {
@@ -256,8 +271,8 @@ Returns the count of reaped wisps. Use --dry-run to preview.`,
 				if reaperDryRun {
 					prefix = "[DRY RUN] "
 				}
-				fmt.Printf("\n%sReap summary (%d databases): reaped %d wisps, %d open remain\n",
-					prefix, len(results), totalReaped, totalOpen)
+				fmt.Printf("\n%sReap summary (%d databases): reaped %d wisps%s, %d open remain\n",
+					prefix, len(results), totalReaped, reaperMoleculeStepSuffix(totalMolSteps), totalOpen)
 				if totalOpen > reaper.DefaultAlertThreshold {
 					fmt.Fprintf(os.Stderr, "WARNING: %d open wisps exceed alert threshold (%d)\n",
 						totalOpen, reaper.DefaultAlertThreshold)
@@ -463,7 +478,7 @@ Normally the daemon dispatches a Dog to execute the mol-dog-reaper formula.`,
 			return fmt.Errorf("invalid --stale-age: %w", err)
 		}
 
-		var totalReaped, totalPurged, totalMailPurged, totalClosed, totalOpen int
+		var totalReaped, totalMolSteps, totalPurged, totalMailPurged, totalClosed, totalOpen int
 
 		for i, dbName := range databases {
 			if err := waitBeforeReaperDatabase(i); err != nil {
@@ -507,6 +522,7 @@ Normally the daemon dispatches a Dog to execute the mol-dog-reaper formula.`,
 				fmt.Printf("%s: reap error: %v\n", dbName, err)
 			} else {
 				totalReaped += reapResult.Reaped
+				totalMolSteps += reapResult.MoleculeStepsClosed
 				totalOpen += reapResult.OpenRemain
 			}
 
@@ -541,7 +557,7 @@ Normally the daemon dispatches a Dog to execute the mol-dog-reaper formula.`,
 		}
 		fmt.Printf("\n%sReaper cycle complete:\n", prefix)
 		fmt.Printf("  Databases: %d\n", len(databases))
-		fmt.Printf("  Reaped:    %d\n", totalReaped)
+		fmt.Printf("  Reaped:    %d%s\n", totalReaped, reaperMoleculeStepSuffix(totalMolSteps))
 		fmt.Printf("  Purged:    %d wisps, %d mail\n", totalPurged, totalMailPurged)
 		fmt.Printf("  Closed:    %d stale issues\n", totalClosed)
 		fmt.Printf("  Open:      %d wisps remain\n", totalOpen)

--- a/internal/cmd/reaper_test.go
+++ b/internal/cmd/reaper_test.go
@@ -34,3 +34,12 @@ func TestWaitBeforeReaperDatabase(t *testing.T) {
 		t.Fatal("invalid delay should return an error")
 	}
 }
+
+func TestReaperMoleculeStepSuffix(t *testing.T) {
+	if got := reaperMoleculeStepSuffix(0); got != "" {
+		t.Fatalf("zero suffix = %q, want empty", got)
+	}
+	if got := reaperMoleculeStepSuffix(3); got != " (+3 closed-molecule steps)" {
+		t.Fatalf("suffix = %q", got)
+	}
+}

--- a/internal/daemon/wisp_reaper.go
+++ b/internal/daemon/wisp_reaper.go
@@ -159,7 +159,7 @@ func (d *Daemon) reapWispsInline(config *WispReaperConfig, maxAge, deleteAge tim
 
 	port := d.doltServerPort()
 	dryRun := config.DryRun
-	var totalReaped, totalOpen, totalPurged, totalMailPurged, totalAutoClosed int
+	var totalReaped, totalMolSteps, totalOpen, totalPurged, totalMailPurged, totalAutoClosed int
 
 	// Step 2: Reap
 	reapErrors := 0
@@ -186,9 +186,13 @@ func (d *Daemon) reapWispsInline(config *WispReaperConfig, maxAge, deleteAge tim
 			continue
 		}
 		totalReaped += result.Reaped
+		totalMolSteps += result.MoleculeStepsClosed
 		totalOpen += result.OpenRemain
 		if result.Reaped > 0 {
 			d.logger.Printf("wisp_reaper: %s: reaped %d stale wisps, %d open remain", dbName, result.Reaped, result.OpenRemain)
+		}
+		if result.MoleculeStepsClosed > 0 {
+			d.logger.Printf("wisp_reaper: %s: closed %d completed-molecule step wisps", dbName, result.MoleculeStepsClosed)
 		}
 	}
 	if reapErrors > 0 {
@@ -322,8 +326,8 @@ func (d *Daemon) reapWispsInline(config *WispReaperConfig, maxAge, deleteAge tim
 		d.logger.Printf("wisp_reaper: WARNING: %d open wisps exceed threshold %d — investigate wisp lifecycle",
 			totalOpen, wispAlertThreshold)
 	}
-	d.logger.Printf("wisp_reaper: cycle complete — reaped=%d purged=%d mail_purged=%d plugin_closed=%d dispatch_closed=%d auto_closed=%d open=%d databases=%d dryRun=%v",
-		totalReaped, totalPurged, totalMailPurged, totalPluginClosed, totalDispatchClosed, totalAutoClosed, totalOpen, len(databases), dryRun)
+	d.logger.Printf("wisp_reaper: cycle complete — reaped=%d molecule_steps_closed=%d purged=%d mail_purged=%d plugin_closed=%d dispatch_closed=%d auto_closed=%d open=%d databases=%d dryRun=%v",
+		totalReaped, totalMolSteps, totalPurged, totalMailPurged, totalPluginClosed, totalDispatchClosed, totalAutoClosed, totalOpen, len(databases), dryRun)
 	mol.closeStep("report")
 }
 

--- a/internal/doctor/misclassified_wisp_check.go
+++ b/internal/doctor/misclassified_wisp_check.go
@@ -220,6 +220,11 @@ func (c *CheckMisclassifiedWisps) purgeRigBatch(ctx *CheckContext, workDir, rigN
 	if err := execBdSQLWrite(workDir, migrateQuery); err != nil {
 		return fmt.Errorf("migrate to wisps: %w", err)
 	}
+	if bdTableExistsDoctor(workDir, "wisp_dependencies") {
+		if _, err := doltserver.EnsureBdWispDependenciesSchema(workDir); err != nil {
+			return fmt.Errorf("migrate wisp_dependencies schema: %w", err)
+		}
+	}
 
 	// Step 2: Copy auxiliary data to wisp_* tables.
 	auxCopies := []struct {
@@ -240,7 +245,7 @@ func (c *CheckMisclassifiedWisps) purgeRigBatch(ctx *CheckContext, workDir, rigN
 		},
 		{
 			table: "wisp_dependencies",
-			query: fmt.Sprintf("INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_id, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d WHERE d.issue_id IN (%s)", idList),
+			query: fmt.Sprintf("INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, CASE WHEN target_wisp.id IS NULL THEN d.depends_on_issue_id ELSE NULL END, CASE WHEN d.depends_on_wisp_id IS NOT NULL THEN d.depends_on_wisp_id ELSE target_wisp.id END, d.depends_on_external, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d LEFT JOIN wisps target_wisp ON target_wisp.id = d.depends_on_issue_id WHERE d.issue_id IN (%s)", idList),
 		},
 	}
 	for _, aux := range auxCopies {

--- a/internal/doctor/misclassified_wisp_check_test.go
+++ b/internal/doctor/misclassified_wisp_check_test.go
@@ -62,6 +62,26 @@ func TestNoHeuristicClassification(t *testing.T) {
 	}
 }
 
+func TestMisclassifiedWispDependencyCopyUsesTypedTargets(t *testing.T) {
+	data, err := os.ReadFile("misclassified_wisp_check.go")
+	if err != nil {
+		t.Fatalf("read misclassified_wisp_check.go: %v", err)
+	}
+	source := string(data)
+	for _, want := range []string{
+		"doltserver.EnsureBdWispDependenciesSchema",
+		"depends_on_issue_id, depends_on_wisp_id, depends_on_external",
+		"target_wisp.id = d.depends_on_issue_id",
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("misclassified wisp dependency copy missing %q", want)
+		}
+	}
+	if strings.Contains(source, "wisp_dependencies (issue_id, depends_on_id") {
+		t.Fatal("misclassified wisp dependency copy still inserts legacy depends_on_id")
+	}
+}
+
 func TestRunIgnoresJSONLWhenDoltUnavailable(t *testing.T) {
 	townRoot := t.TempDir()
 	beadsDir := filepath.Join(townRoot, "gastown", ".beads")

--- a/internal/doltserver/wisps_migrate.go
+++ b/internal/doltserver/wisps_migrate.go
@@ -3,11 +3,11 @@
 // The wisps table is a dolt_ignored copy of the issues table schema, used for
 // ephemeral operational data (agent beads, patrol wisps, etc.) that should not
 // be version-controlled. This migration:
-//   1. Creates the wisps table and auxiliary tables (wisp_labels, wisp_comments,
-//      wisp_events, wisp_dependencies) if they don't exist
-//   2. Copies existing agent beads (issue_type='agent') from issues to wisps
-//   3. Copies associated labels, comments, events, and dependencies
-//   4. Closes the originals in the issues table
+//  1. Creates the wisps table and auxiliary tables (wisp_labels, wisp_comments,
+//     wisp_events, wisp_dependencies) if they don't exist
+//  2. Copies existing agent beads (issue_type='agent') from issues to wisps
+//  3. Copies associated labels, comments, events, and dependencies
+//  4. Closes the originals in the issues table
 //
 // The migration uses `bd sql` for beads-side operations (copying agent beads between
 // the issues and wisps tables in bd's own database). Additionally, it ensures that
@@ -194,6 +194,15 @@ func ensureWispAuxTables(workDir string) ([]string, error) {
 
 	for _, t := range wispAuxTableDDLs {
 		if bdTableExists(workDir, t.name) {
+			if t.name == "wisp_dependencies" {
+				migrated, err := EnsureBdWispDependenciesSchema(workDir)
+				if err != nil {
+					return created, err
+				}
+				if migrated {
+					created = append(created, t.name)
+				}
+			}
 			continue
 		}
 		if err := bdSQL(workDir, t.ddl); err != nil {
@@ -203,6 +212,30 @@ func ensureWispAuxTables(workDir string) ([]string, error) {
 	}
 
 	return created, nil
+}
+
+// EnsureBdWispDependenciesSchema converges an existing bd-side legacy
+// wisp_dependencies table to the v49 typed-target schema used by Beads.
+func EnsureBdWispDependenciesSchema(workDir string) (bool, error) {
+	if !bdColumnExists(workDir, "wisp_dependencies", "depends_on_id") ||
+		bdColumnExists(workDir, "wisp_dependencies", "depends_on_wisp_id") {
+		return false, nil
+	}
+	stmts := legacyWispDependenciesMigrationStatements()
+	if len(stmts) == 0 {
+		return false, fmt.Errorf("missing wisp_dependencies DDL")
+	}
+	for _, stmt := range stmts {
+		if err := bdSQL(workDir, stmt); err != nil {
+			return false, fmt.Errorf("migrate wisp_dependencies schema: %w", err)
+		}
+	}
+	return true, nil
+}
+
+func bdColumnExists(workDir, tableName, columnName string) bool {
+	err := bdSQL(workDir, fmt.Sprintf("SELECT `%s` FROM `%s` LIMIT 0", columnName, tableName))
+	return err == nil
 }
 
 // copyAgentBeadsToWisps inserts agent beads from issues into wisps, skipping duplicates.
@@ -257,7 +290,7 @@ func copyAuxiliaryData(workDir string, result *MigrateWispsResult) error {
 
 	// Copy dependencies
 	if err := bdSQL(workDir,
-		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_id, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d INNER JOIN wisps w ON d.issue_id = w.id"); err != nil {
+		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, CASE WHEN target_wisp.id IS NULL THEN d.depends_on_issue_id ELSE NULL END, CASE WHEN d.depends_on_wisp_id IS NOT NULL THEN d.depends_on_wisp_id ELSE target_wisp.id END, d.depends_on_external, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d INNER JOIN wisps w ON d.issue_id = w.id LEFT JOIN wisps target_wisp ON target_wisp.id = d.depends_on_issue_id"); err != nil {
 		if !strings.Contains(err.Error(), "nothing") {
 			return fmt.Errorf("copying dependencies: %w", err)
 		}
@@ -317,6 +350,15 @@ func ensureWispsOnGTServer(host string, port int, dbName string) (wispsCreated b
 	// Create auxiliary tables
 	for _, t := range wispAuxTableDDLs {
 		if gtTableExists(ctx, db, dbName, t.name) {
+			if t.name == "wisp_dependencies" {
+				migrated, err := ensureWispDependenciesSchema(ctx, db, dbName)
+				if err != nil {
+					return wispsCreated, auxCreated, err
+				}
+				if migrated {
+					auxCreated = append(auxCreated, t.name)
+				}
+			}
 			continue
 		}
 		if _, err := db.ExecContext(ctx, t.ddl); err != nil {
@@ -337,6 +379,51 @@ func ensureWispsOnGTServer(host string, port int, dbName string) (wispsCreated b
 	return wispsCreated, auxCreated, nil
 }
 
+func ensureWispDependenciesSchema(ctx context.Context, db *sql.DB, dbName string) (bool, error) {
+	if !gtColumnExists(ctx, db, dbName, "wisp_dependencies", "depends_on_id") ||
+		gtColumnExists(ctx, db, dbName, "wisp_dependencies", "depends_on_wisp_id") {
+		return false, nil
+	}
+
+	stmts := legacyWispDependenciesMigrationStatements()
+	if len(stmts) == 0 {
+		return false, fmt.Errorf("missing wisp_dependencies DDL")
+	}
+	for _, stmt := range stmts {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return false, fmt.Errorf("migrate wisp_dependencies schema: %w", err)
+		}
+	}
+	return true, nil
+}
+
+func legacyWispDependenciesMigrationStatements() []string {
+	ddl := ""
+	for _, t := range wispAuxTableDDLs {
+		if t.name == "wisp_dependencies" {
+			ddl = t.ddl
+			break
+		}
+	}
+	if ddl == "" {
+		return nil
+	}
+	return []string{
+		"RENAME TABLE wisp_dependencies TO wisp_dependencies_legacy",
+		ddl,
+		`INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id)
+SELECT wd.issue_id,
+       CASE WHEN target_wisp.id IS NULL AND target_issue.id IS NOT NULL THEN wd.depends_on_id ELSE NULL END,
+       CASE WHEN target_wisp.id IS NOT NULL THEN wd.depends_on_id ELSE NULL END,
+       CASE WHEN target_wisp.id IS NULL AND target_issue.id IS NULL THEN wd.depends_on_id ELSE NULL END,
+       wd.type, wd.created_at, wd.created_by, wd.metadata, wd.thread_id
+FROM wisp_dependencies_legacy wd
+LEFT JOIN wisps target_wisp ON target_wisp.id = wd.depends_on_id
+LEFT JOIN issues target_issue ON target_issue.id = wd.depends_on_id`,
+		"DROP TABLE wisp_dependencies_legacy",
+	}
+}
+
 // gtTableExists checks if a table exists on the gt Dolt server.
 func gtTableExists(ctx context.Context, db *sql.DB, dbName, tableName string) bool {
 	var dummy int
@@ -344,6 +431,14 @@ func gtTableExists(ctx context.Context, db *sql.DB, dbName, tableName string) bo
 	err := db.QueryRowContext(ctx,
 		"SELECT 1 FROM information_schema.tables WHERE table_schema = ? AND table_name = ?",
 		dbName, tableName).Scan(&dummy)
+	return err == nil
+}
+
+func gtColumnExists(ctx context.Context, db *sql.DB, dbName, tableName, columnName string) bool {
+	var dummy int
+	err := db.QueryRowContext(ctx,
+		"SELECT 1 FROM information_schema.columns WHERE table_schema = ? AND table_name = ? AND column_name = ?",
+		dbName, tableName, columnName).Scan(&dummy)
 	return err == nil
 }
 
@@ -458,16 +553,25 @@ var wispAuxTableDDLs = []wispAuxTableDDL{
 	{
 		name: "wisp_dependencies",
 		ddl: `CREATE TABLE wisp_dependencies (
-  issue_id varchar(255) NOT NULL,
-  depends_on_id varchar(255) NOT NULL,
-  type varchar(32) NOT NULL DEFAULT 'blocks',
-  created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  created_by varchar(255) NOT NULL DEFAULT '',
-  metadata json,
-  thread_id varchar(255) DEFAULT '',
-  PRIMARY KEY (issue_id, depends_on_id),
-  KEY idx_wisp_deps_depends_on (depends_on_id)
-)`,
+	  id char(36) NOT NULL DEFAULT (UUID()),
+	  issue_id varchar(255) NOT NULL,
+	  depends_on_issue_id varchar(255),
+	  depends_on_wisp_id varchar(255),
+	  depends_on_external varchar(255),
+	  type varchar(32) NOT NULL DEFAULT 'blocks',
+	  created_at datetime DEFAULT CURRENT_TIMESTAMP,
+	  created_by varchar(255) DEFAULT '',
+	  metadata json DEFAULT (JSON_OBJECT()),
+	  thread_id varchar(255) DEFAULT '',
+	  PRIMARY KEY (id),
+	  UNIQUE KEY uk_wisp_dep_issue_target (issue_id, depends_on_issue_id),
+	  UNIQUE KEY uk_wisp_dep_wisp_target (issue_id, depends_on_wisp_id),
+	  UNIQUE KEY uk_wisp_dep_external_target (issue_id, depends_on_external),
+	  KEY idx_wisp_dep_type_issue (type, depends_on_issue_id),
+	  KEY idx_wisp_dep_type_wisp (type, depends_on_wisp_id),
+	  KEY idx_wisp_dep_type_external (type, depends_on_external),
+	  CHECK ((depends_on_issue_id IS NOT NULL) + (depends_on_wisp_id IS NOT NULL) + (depends_on_external IS NOT NULL) = 1)
+	)`,
 	},
 }
 

--- a/internal/doltserver/wisps_schema_guard_test.go
+++ b/internal/doltserver/wisps_schema_guard_test.go
@@ -1,0 +1,51 @@
+package doltserver
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestWispDependenciesDDLUsesTypedTargets(t *testing.T) {
+	ddl := ""
+	for _, table := range wispAuxTableDDLs {
+		if table.name == "wisp_dependencies" {
+			ddl = table.ddl
+			break
+		}
+	}
+	if ddl == "" {
+		t.Fatal("wisp_dependencies DDL not found")
+	}
+	for _, want := range []string{"depends_on_issue_id", "depends_on_wisp_id", "depends_on_external", "uk_wisp_dep_wisp_target"} {
+		if !strings.Contains(ddl, want) {
+			t.Fatalf("wisp_dependencies DDL missing %q:\n%s", want, ddl)
+		}
+	}
+	for _, legacy := range []string{"depends_on_id varchar", "PRIMARY KEY (issue_id, depends_on_id)", "idx_wisp_deps_depends_on"} {
+		if strings.Contains(ddl, legacy) {
+			t.Fatalf("wisp_dependencies DDL still contains legacy %q:\n%s", legacy, ddl)
+		}
+	}
+}
+
+func TestWispDependencyMigrationSQLUsesTypedTargets(t *testing.T) {
+	data, err := os.ReadFile("wisps_migrate.go")
+	if err != nil {
+		t.Fatalf("read wisps_migrate.go: %v", err)
+	}
+	source := string(data)
+	for _, want := range []string{
+		"depends_on_issue_id, depends_on_wisp_id, depends_on_external",
+		"target_wisp.id = d.depends_on_issue_id",
+		"wisp_dependencies_legacy",
+		"target_wisp.id = wd.depends_on_id",
+	} {
+		if !strings.Contains(source, want) {
+			t.Fatalf("wisps migration source missing %q", want)
+		}
+	}
+	if strings.Contains(source, "wisp_dependencies (issue_id, depends_on_id") {
+		t.Fatal("wisps migration source still inserts legacy depends_on_id")
+	}
+}

--- a/internal/formula/formulas/mol-dog-reaper.formula.toml
+++ b/internal/formula/formulas/mol-dog-reaper.formula.toml
@@ -83,6 +83,7 @@ gt reaper scan --db=<name> --port={{dolt_port}} \\
 - If `open_wisps` exceeds {{alert_threshold}}, escalate
 
 **4. Decide whether to proceed:**
+- Treat `reap_candidates` plus `molecule_step_candidates` as reap work
 - If no candidates found across all databases, skip remaining steps
 - If anomalies are severe, consider escalating before proceeding
 
@@ -93,9 +94,10 @@ id = "reap"
 title = "Reap stale wisps"
 needs = ["scan"]
 description = """
-Close wisps past max_age whose parent molecule is closed or missing.
+Close wisps past max_age whose parent molecule is closed or missing, plus
+step-wisps whose parent molecule has already completed.
 
-**1. For each database with reap candidates:**
+**1. For each database with reap candidates or molecule_step_candidates:**
 ```bash
 gt reaper reap --db=<name> --port={{dolt_port}} \\
   --max-age={{max_age}} --db-delay={{db_delay}} {{#if dry_run}}--dry-run{{/if}} --json
@@ -112,7 +114,8 @@ gt reaper reap --db=<name> --port={{dolt_port}} \\
 If total open wisps across all databases exceed {{alert_threshold}},
 log a warning and consider escalating.
 
-**Exit criteria:** All stale wisps closed (or dry-run counts reported)."""
+**Exit criteria:** All stale wisps and completed-molecule step wisps closed
+(or dry-run counts reported)."""
 
 [[steps]]
 id = "purge"
@@ -204,6 +207,7 @@ Generate summary and signal completion.
 
 **Databases scanned**: (count)
 **Wisps reaped**: (total closed stale open wisps)
+**Molecule steps closed**: (step-wisps whose parent molecule was already closed)
 **Wisps purged**: (total deleted old closed wisps)
 **Mail purged**: (total deleted old closed mail)
 **Issues auto-closed**: (stale > stale_issue_age, excl. epics/convoys/P0-P1/deps)

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -99,22 +99,24 @@ func DiscoverDatabases(host string, port int) []string {
 
 // ScanResult holds the results of scanning a database for reaper candidates.
 type ScanResult struct {
-	Database        string    `json:"database"`
-	ReapCandidates  int       `json:"reap_candidates"`
-	PurgeCandidates int       `json:"purge_candidates"`
-	MailCandidates  int       `json:"mail_candidates"`
-	StaleCandidates int       `json:"stale_candidates"`
-	OpenWisps       int       `json:"open_wisps"`
-	Anomalies       []Anomaly `json:"anomalies,omitempty"`
+	Database               string    `json:"database"`
+	ReapCandidates         int       `json:"reap_candidates"`
+	MoleculeStepCandidates int       `json:"molecule_step_candidates"`
+	PurgeCandidates        int       `json:"purge_candidates"`
+	MailCandidates         int       `json:"mail_candidates"`
+	StaleCandidates        int       `json:"stale_candidates"`
+	OpenWisps              int       `json:"open_wisps"`
+	Anomalies              []Anomaly `json:"anomalies,omitempty"`
 }
 
 // ReapResult holds the results of a reap operation.
 type ReapResult struct {
-	Database   string    `json:"database"`
-	Reaped     int       `json:"reaped"`
-	OpenRemain int       `json:"open_remain"`
-	DryRun     bool      `json:"dry_run,omitempty"`
-	Anomalies  []Anomaly `json:"anomalies,omitempty"`
+	Database            string    `json:"database"`
+	Reaped              int       `json:"reaped"`
+	MoleculeStepsClosed int       `json:"molecule_steps_closed"`
+	OpenRemain          int       `json:"open_remain"`
+	DryRun              bool      `json:"dry_run,omitempty"`
+	Anomalies           []Anomaly `json:"anomalies,omitempty"`
 }
 
 // PurgeResult holds the results of a purge operation.
@@ -161,6 +163,12 @@ const (
 	DefaultAlertThreshold = 800
 )
 
+type reaperExecutor interface {
+	ExecContext(context.Context, string, ...any) (sql.Result, error)
+	QueryContext(context.Context, string, ...any) (*sql.Rows, error)
+	QueryRowContext(context.Context, string, ...any) *sql.Row
+}
+
 // ValidateDBName returns an error if the database name is unsafe.
 func ValidateDBName(dbName string) error {
 	if !validDBName.MatchString(dbName) {
@@ -203,7 +211,7 @@ func parentExcludeJoin(dbName string) (joinClause, whereCondition string) {
 	joinClause = `LEFT JOIN (
 		SELECT DISTINCT wd.issue_id
 		FROM wisp_dependencies wd
-		LEFT JOIN wisps pw ON pw.id = wd.depends_on_id LEFT JOIN issues pi ON pi.id = wd.depends_on_id
+		LEFT JOIN wisps pw ON pw.id = wd.depends_on_wisp_id LEFT JOIN issues pi ON pi.id = wd.depends_on_issue_id
 		WHERE wd.type = 'parent-child'
 		AND (pw.status IN ('open', 'hooked', 'in_progress') OR pi.status IN ('open', 'in_progress'))
 	) open_parent ON open_parent.issue_id = w.id`
@@ -211,21 +219,117 @@ func parentExcludeJoin(dbName string) (joinClause, whereCondition string) {
 	return
 }
 
+func closedMoleculeStepExists(childAlias string) string {
+	return fmt.Sprintf(`EXISTS (
+		SELECT 1 FROM wisp_dependencies wd
+		INNER JOIN wisps pm ON pm.id = wd.depends_on_wisp_id
+		WHERE wd.issue_id = %s.id
+		  AND wd.type = 'parent-child'
+		  AND pm.issue_type = 'molecule'
+		  AND pm.status = 'closed'
+	)`, childAlias)
+}
+
+func closedMoleculeStepWhere(childAlias string) string {
+	return fmt.Sprintf(
+		"%s.status IN ('open', 'hooked', 'in_progress') AND %s.issue_type != 'agent' AND %s",
+		childAlias, childAlias, closedMoleculeStepExists(childAlias))
+}
+
+func countClosedMoleculeSteps(ctx context.Context, db reaperExecutor) (int, error) {
+	var n int
+	query := fmt.Sprintf("SELECT COUNT(*) FROM wisps w WHERE %s", closedMoleculeStepWhere("w"))
+	err := db.QueryRowContext(ctx, query).Scan(&n)
+	return n, err
+}
+
+func reapClosedMoleculeSteps(ctx context.Context, db reaperExecutor) (int, error) {
+	idQuery := fmt.Sprintf("SELECT w.id FROM wisps w WHERE %s LIMIT %d", closedMoleculeStepWhere("w"), DefaultBatchSize)
+	total := 0
+	for {
+		rows, err := db.QueryContext(ctx, idQuery)
+		if err != nil {
+			return total, fmt.Errorf("select molecule-step batch: %w", err)
+		}
+
+		var ids []string
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				rows.Close()
+				return total, fmt.Errorf("scan molecule-step id: %w", err)
+			}
+			ids = append(ids, id)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return total, fmt.Errorf("iterate molecule-step ids: %w", err)
+		}
+		rows.Close()
+
+		if len(ids) == 0 {
+			break
+		}
+
+		placeholders := make([]string, len(ids))
+		args := make([]interface{}, len(ids))
+		for i, id := range ids {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		updateQuery := fmt.Sprintf(
+			"UPDATE wisps SET status='closed', closed_at=NOW(), close_reason='reaper: parent molecule closed' WHERE id IN (%s)",
+			strings.Join(placeholders, ","))
+		sqlResult, err := db.ExecContext(ctx, updateQuery, args...)
+		if err != nil {
+			return total, fmt.Errorf("close molecule-step batch: %w", err)
+		}
+		affected, _ := sqlResult.RowsAffected()
+		total += int(affected)
+	}
+	return total, nil
+}
+
 // HasReaperSchema checks whether the database has the tables required for reaper
-// operations (wisps and issues). Returns false (no error) when tables are missing
-// — callers use this to skip databases that have incomplete beads schema (e.g.
-// partially initialized databases on the central Dolt server).
+// operations (wisps, issues, and typed wisp dependencies). Returns false (no
+// error) when tables or required columns are missing — callers use this to skip
+// databases that have incomplete beads schema (e.g. partially initialized
+// databases on the central Dolt server).
 func HasReaperSchema(db *sql.DB) (bool, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
 
 	var count int
 	err := db.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM information_schema.tables WHERE table_name IN ('wisps', 'issues') AND table_schema = DATABASE()").Scan(&count)
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_name IN ('wisps', 'issues', 'wisp_dependencies') AND table_schema = DATABASE()").Scan(&count)
 	if err != nil {
 		return false, fmt.Errorf("check reaper schema: %w", err)
 	}
-	return count >= 2, nil
+	if count < 3 {
+		return false, nil
+	}
+	err = db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.columns WHERE table_name = 'wisp_dependencies' AND column_name IN ('depends_on_issue_id', 'depends_on_wisp_id', 'depends_on_external') AND table_schema = DATABASE()").Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("check reaper dependency schema: %w", err)
+	}
+	if count < 3 {
+		return false, nil
+	}
+	err = db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_name = 'dependencies' AND table_schema = DATABASE()").Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("check dependency table: %w", err)
+	}
+	if count == 0 {
+		return true, nil
+	}
+	err = db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.columns WHERE table_name = 'dependencies' AND column_name = 'depends_on_issue_id' AND table_schema = DATABASE()").Scan(&count)
+	if err != nil {
+		return false, fmt.Errorf("check issue dependency schema: %w", err)
+	}
+	return count >= 1, nil
 }
 
 // Scan counts reaper candidates in a database without modifying anything.
@@ -241,12 +345,18 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 	// Must match Reap() eligibility semantics exactly, including the exclusion of
 	// agent beads, otherwise scan can report candidates that reap will never close.
 	// Uses LEFT JOIN anti-pattern instead of correlated EXISTS to avoid O(n*m) cost (gt-jd1z).
+	closedMoleculeStepPredicate := closedMoleculeStepExists("w")
 	reapQuery := fmt.Sprintf(
-		"SELECT COUNT(*) FROM wisps w %s WHERE w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND w.issue_type != 'agent' AND %s",
-		parentJoin, parentWhere)
+		"SELECT COUNT(*) FROM wisps w %s WHERE w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND w.issue_type != 'agent' AND %s AND NOT %s",
+		parentJoin, parentWhere, closedMoleculeStepPredicate)
 	if err := db.QueryRowContext(ctx, reapQuery, now.Add(-maxAge)).Scan(&result.ReapCandidates); err != nil {
 		return nil, fmt.Errorf("count reap candidates: %w", err)
 	}
+	molStepCandidates, err := countClosedMoleculeSteps(ctx, db)
+	if err != nil {
+		return nil, fmt.Errorf("count closed-molecule step candidates: %w", err)
+	}
+	result.MoleculeStepCandidates = molStepCandidates
 
 	// Count purge candidates: closed wisps past purge_age.
 	// No parent check needed — closed wisps past the delete age are unconditionally purgeable.
@@ -280,13 +390,14 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 		AND i.issue_type NOT IN ('epic', 'convoy')
 		AND i.id NOT IN (
 			SELECT DISTINCT d.issue_id FROM dependencies d
-			INNER JOIN issues dep ON d.depends_on_id = dep.id
+			INNER JOIN issues dep ON d.depends_on_issue_id = dep.id
 			WHERE dep.status IN ('open', 'in_progress')
 		)
 		AND i.id NOT IN (
-			SELECT DISTINCT d.depends_on_id FROM dependencies d
+			SELECT DISTINCT d.depends_on_issue_id FROM dependencies d
 			INNER JOIN issues blocker ON d.issue_id = blocker.id
 			WHERE blocker.status IN ('open', 'in_progress')
+			AND d.depends_on_issue_id IS NOT NULL
 		)`
 	if err := db.QueryRowContext(ctx, staleQuery, now.Add(-staleIssueAge)).Scan(&result.StaleCandidates); err != nil {
 		if !isTableNotFound(err) {
@@ -304,7 +415,7 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 	// Anomaly detection: dangling parent references.
 	danglingQuery := `
 		SELECT COUNT(*) FROM wisp_dependencies wd
-		LEFT JOIN wisps pw ON pw.id = wd.depends_on_id LEFT JOIN issues pi ON pi.id = wd.depends_on_id
+		LEFT JOIN wisps pw ON pw.id = wd.depends_on_wisp_id LEFT JOIN issues pi ON pi.id = wd.depends_on_issue_id
 		WHERE wd.type = 'parent-child' AND pw.id IS NULL AND pi.id IS NULL`
 	var danglingCount int
 	if err := db.QueryRowContext(ctx, danglingQuery).Scan(&danglingCount); err == nil && danglingCount > 0 {
@@ -330,7 +441,8 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 	// Exclude agent beads (issue_type='agent') from reaping — they have persistent
 	// identity and should not be closed by the wisp reaper regardless of age.
 	whereClause := fmt.Sprintf(
-		"w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND w.issue_type != 'agent' AND %s", parentWhere)
+		"w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND w.issue_type != 'agent' AND %s AND NOT %s",
+		parentWhere, closedMoleculeStepExists("w"))
 
 	result := &ReapResult{Database: dbName, DryRun: dryRun}
 
@@ -339,6 +451,11 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 		if err := db.QueryRowContext(ctx, countQuery, cutoff).Scan(&result.Reaped); err != nil {
 			return nil, fmt.Errorf("dry-run count: %w", err)
 		}
+		molSteps, err := countClosedMoleculeSteps(ctx, db)
+		if err != nil {
+			return nil, fmt.Errorf("dry-run molecule-step count: %w", err)
+		}
+		result.MoleculeStepsClosed = molSteps
 		openQuery := "SELECT COUNT(*) FROM wisps WHERE status IN ('open', 'hooked', 'in_progress')"
 		if err := db.QueryRowContext(ctx, openQuery).Scan(&result.OpenRemain); err != nil {
 			return nil, fmt.Errorf("count open: %w", err)
@@ -346,12 +463,30 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 		return result, nil
 	}
 
-	if _, err := db.ExecContext(ctx, "SET @@autocommit = 0"); err != nil {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("pin connection: %w", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, "SET @@autocommit = 0"); err != nil {
 		return nil, fmt.Errorf("disable autocommit: %w", err)
 	}
+	sqlCommitted := false
 	defer func() {
-		_, _ = db.ExecContext(context.Background(), "SET @@autocommit = 1")
+		cleanupCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		if !sqlCommitted {
+			_, _ = conn.ExecContext(cleanupCtx, "ROLLBACK")
+		}
+		_, _ = conn.ExecContext(cleanupCtx, "SET @@autocommit = 1")
 	}()
+
+	molStepsClosed, err := reapClosedMoleculeSteps(ctx, conn)
+	if err != nil {
+		return nil, err
+	}
+	result.MoleculeStepsClosed = molStepsClosed
 
 	// Batch UPDATE: select IDs in chunks, update each chunk.
 	// This avoids holding a write lock on the entire table for minutes.
@@ -362,7 +497,7 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 
 	totalReaped := 0
 	for {
-		rows, err := db.QueryContext(ctx, idQuery, cutoff)
+		rows, err := conn.QueryContext(ctx, idQuery, cutoff)
 		if err != nil {
 			return nil, fmt.Errorf("select reap batch: %w", err)
 		}
@@ -375,6 +510,10 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 				return nil, fmt.Errorf("scan wisp id: %w", err)
 			}
 			ids = append(ids, id)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return nil, fmt.Errorf("iterate reap ids: %w", err)
 		}
 		rows.Close()
 
@@ -393,7 +532,7 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 		updateQuery := fmt.Sprintf(
 			"UPDATE wisps SET status='closed', closed_at=NOW() WHERE id IN (%s)",
 			inClause)
-		sqlResult, err := db.ExecContext(ctx, updateQuery, args...)
+		sqlResult, err := conn.ExecContext(ctx, updateQuery, args...)
 		if err != nil {
 			return nil, fmt.Errorf("close stale wisps batch: %w", err)
 		}
@@ -404,16 +543,17 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 
 	result.Reaped = totalReaped
 
-	if totalReaped > 0 {
+	if totalReaped > 0 || molStepsClosed > 0 {
 		// Flush the SQL transaction to the Dolt working set before DOLT_COMMIT.
 		// With autocommit=0, UPDATE changes are in the SQL transaction buffer,
 		// not the Dolt working set. DOLT_COMMIT operates on the working set,
 		// so without this COMMIT it sees "nothing to commit".
-		if _, err := db.ExecContext(ctx, "COMMIT"); err != nil {
+		if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
 			return result, fmt.Errorf("sql commit: %w", err)
 		}
-		commitMsg := fmt.Sprintf("reaper: close %d stale wisps in %s", totalReaped, dbName)
-		if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
+		sqlCommitted = true
+		commitMsg := fmt.Sprintf("reaper: close %d stale + %d molecule-step wisps in %s", totalReaped, molStepsClosed, dbName)
+		if _, err := conn.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
 			// "nothing to commit" is expected when the reaper reverts dirty working
 			// set changes back to match HEAD. The wisps were set to "open" in the
 			// server's in-memory working set without being committed; closing them
@@ -425,7 +565,7 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 	}
 
 	openQuery := "SELECT COUNT(*) FROM wisps WHERE status IN ('open', 'hooked', 'in_progress')"
-	if err := db.QueryRowContext(ctx, openQuery).Scan(&result.OpenRemain); err != nil {
+	if err := conn.QueryRowContext(ctx, openQuery).Scan(&result.OpenRemain); err != nil {
 		return result, fmt.Errorf("count open: %w", err)
 	}
 
@@ -612,13 +752,14 @@ func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (
 		)
 		AND i.id NOT IN (
 			SELECT DISTINCT d.issue_id FROM `+"`%s`"+`.dependencies d
-			INNER JOIN `+"`%s`"+`.issues dep ON d.depends_on_id = dep.id
+			INNER JOIN `+"`%s`"+`.issues dep ON d.depends_on_issue_id = dep.id
 			WHERE dep.status IN ('open', 'in_progress')
 		)
 		AND i.id NOT IN (
-			SELECT DISTINCT d.depends_on_id FROM `+"`%s`"+`.dependencies d
+			SELECT DISTINCT d.depends_on_issue_id FROM `+"`%s`"+`.dependencies d
 			INNER JOIN `+"`%s`"+`.issues blocker ON d.issue_id = blocker.id
 			WHERE blocker.status IN ('open', 'in_progress')
+			AND d.depends_on_issue_id IS NOT NULL
 		)`, dbName, dbName, dbName, dbName, dbName)
 
 	// Two-step SELECT-then-UPDATE to avoid self-referencing subquery in UPDATE,
@@ -755,7 +896,7 @@ func batchDeleteRows(ctx context.Context, db *sql.DB, idQuery string, cutoffArg 
 		}
 
 		// Clean up reverse dependency references to prevent dangling parent refs.
-		delReverse := fmt.Sprintf("DELETE FROM wisp_dependencies WHERE depends_on_id IN %s", inClause)
+		delReverse := fmt.Sprintf("DELETE FROM wisp_dependencies WHERE depends_on_wisp_id IN %s", inClause)
 		if _, err := db.ExecContext(ctx, delReverse, args...); err != nil {
 			// Non-fatal.
 		}

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -1,11 +1,144 @@
 package reaper
 
 import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
 	"fmt"
+	"io"
 	"os"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
+
+var (
+	scriptedDriverOnce sync.Once
+	scriptedStates     sync.Map
+)
+
+type scriptedOp struct {
+	kind     string
+	contains []string
+	wantArgs int
+	columns  []string
+	rows     [][]driver.Value
+	affected int64
+}
+
+type scriptedState struct {
+	mu       sync.Mutex
+	nextConn int
+	ops      []scriptedOp
+	connIDs  []int
+}
+
+type scriptedDriver struct{}
+
+type scriptedConn struct {
+	state *scriptedState
+	id    int
+}
+
+type scriptedRows struct {
+	columns []string
+	rows    [][]driver.Value
+	i       int
+}
+
+type scriptedResult int64
+
+func openScriptedDB(t *testing.T, state *scriptedState) *sql.DB {
+	t.Helper()
+	scriptedDriverOnce.Do(func() { sql.Register("reaper-scripted", scriptedDriver{}) })
+	name := fmt.Sprintf("state-%p", state)
+	scriptedStates.Store(name, state)
+	t.Cleanup(func() { scriptedStates.Delete(name) })
+	db, err := sql.Open("reaper-scripted", name)
+	if err != nil {
+		t.Fatalf("open scripted db: %v", err)
+	}
+	db.SetMaxIdleConns(0)
+	t.Cleanup(func() { _ = db.Close() })
+	return db
+}
+
+func (d scriptedDriver) Open(name string) (driver.Conn, error) {
+	v, ok := scriptedStates.Load(name)
+	if !ok {
+		return nil, fmt.Errorf("unknown scripted state %q", name)
+	}
+	state := v.(*scriptedState)
+	state.mu.Lock()
+	state.nextConn++
+	id := state.nextConn
+	state.mu.Unlock()
+	return &scriptedConn{state: state, id: id}, nil
+}
+
+func (c *scriptedConn) Prepare(string) (driver.Stmt, error) {
+	return nil, fmt.Errorf("prepare not supported")
+}
+func (c *scriptedConn) Close() error              { return nil }
+func (c *scriptedConn) Begin() (driver.Tx, error) { return nil, fmt.Errorf("begin not supported") }
+
+func (c *scriptedConn) ExecContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	op, err := c.state.next("exec", c.id, query, len(args))
+	if err != nil {
+		return nil, err
+	}
+	return scriptedResult(op.affected), nil
+}
+
+func (c *scriptedConn) QueryContext(ctx context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	op, err := c.state.next("query", c.id, query, len(args))
+	if err != nil {
+		return nil, err
+	}
+	cols := op.columns
+	if len(cols) == 0 {
+		cols = []string{"value"}
+	}
+	return &scriptedRows{columns: cols, rows: op.rows}, nil
+}
+
+func (s *scriptedState) next(kind string, connID int, query string, argCount int) (scriptedOp, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.ops) == 0 {
+		return scriptedOp{}, fmt.Errorf("unexpected %s on conn %d: %s", kind, connID, query)
+	}
+	op := s.ops[0]
+	s.ops = s.ops[1:]
+	if op.kind != kind {
+		return scriptedOp{}, fmt.Errorf("got %s, want %s for query %s", kind, op.kind, query)
+	}
+	if op.wantArgs != argCount {
+		return scriptedOp{}, fmt.Errorf("got %d args, want %d for query %s", argCount, op.wantArgs, query)
+	}
+	for _, needle := range op.contains {
+		if !strings.Contains(query, needle) {
+			return scriptedOp{}, fmt.Errorf("query missing %q: %s", needle, query)
+		}
+	}
+	s.connIDs = append(s.connIDs, connID)
+	return op, nil
+}
+
+func (r *scriptedRows) Columns() []string { return r.columns }
+func (r *scriptedRows) Close() error      { return nil }
+func (r *scriptedRows) Next(dest []driver.Value) error {
+	if r.i >= len(r.rows) {
+		return io.EOF
+	}
+	copy(dest, r.rows[r.i])
+	r.i++
+	return nil
+}
+
+func (r scriptedResult) LastInsertId() (int64, error) { return 0, nil }
+func (r scriptedResult) RowsAffected() (int64, error) { return int64(r), nil }
 
 func TestValidateDBName(t *testing.T) {
 	tests := []struct {
@@ -69,6 +202,15 @@ func TestParentExcludeJoin(t *testing.T) {
 	if !contains(joinClause, "parent-child") {
 		t.Error("parentExcludeJoin should filter on parent-child type")
 	}
+	if !contains(joinClause, "depends_on_wisp_id") {
+		t.Error("parentExcludeJoin should join wisp parents through depends_on_wisp_id")
+	}
+	if !contains(joinClause, "depends_on_issue_id") {
+		t.Error("parentExcludeJoin should join issue parents through depends_on_issue_id")
+	}
+	if contains(joinClause, "wd.depends_on_id") {
+		t.Error("parentExcludeJoin must not use legacy depends_on_id")
+	}
 	if !contains(joinClause, "'open', 'hooked', 'in_progress'") {
 		t.Error("parentExcludeJoin should check for open parent statuses")
 	}
@@ -79,6 +221,181 @@ func TestParentExcludeJoin(t *testing.T) {
 	}
 	if !contains(whereCondition, "IS NULL") {
 		t.Error("parentExcludeJoin whereCondition should use IS NULL for anti-join")
+	}
+}
+
+func TestClosedMoleculeStepPredicate(t *testing.T) {
+	where := closedMoleculeStepWhere("w")
+	for _, want := range []string{
+		"w.status IN ('open', 'hooked', 'in_progress')",
+		"w.issue_type != 'agent'",
+		"wisp_dependencies wd",
+		"wd.issue_id = w.id",
+		"wd.depends_on_wisp_id",
+		"wd.type = 'parent-child'",
+		"pm.issue_type = 'molecule'",
+		"pm.status = 'closed'",
+	} {
+		if !strings.Contains(where, want) {
+			t.Fatalf("closed molecule step predicate missing %q:\n%s", want, where)
+		}
+	}
+	if strings.Contains(where, "depends_on_id") {
+		t.Fatalf("closed molecule step predicate must not use legacy depends_on_id:\n%s", where)
+	}
+}
+
+func TestReapStaleQueryExcludesClosedMoleculeSteps(t *testing.T) {
+	parentJoin, parentWhere := parentExcludeJoin("gt")
+	whereClause := fmt.Sprintf(
+		"w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND w.issue_type != 'agent' AND %s AND NOT %s",
+		parentWhere, closedMoleculeStepExists("w"))
+	idQuery := fmt.Sprintf(
+		"SELECT w.id FROM wisps w %s WHERE %s LIMIT %d",
+		parentJoin, whereClause, DefaultBatchSize)
+
+	for _, want := range []string{"AND NOT EXISTS", "depends_on_wisp_id", "pm.status = 'closed'"} {
+		if !strings.Contains(idQuery, want) {
+			t.Fatalf("stale reap query missing %q:\n%s", want, idQuery)
+		}
+	}
+}
+
+func TestHasReaperSchemaRequiresTypedDependencyColumns(t *testing.T) {
+	state := &scriptedState{ops: []scriptedOp{
+		{kind: "query", wantArgs: 0, contains: []string{"information_schema.tables", "wisps", "wisp_dependencies"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(3)}}},
+		{kind: "query", wantArgs: 0, contains: []string{"information_schema.columns", "wisp_dependencies", "depends_on_external"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(3)}}},
+		{kind: "query", wantArgs: 0, contains: []string{"information_schema.tables", "dependencies"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(1)}}},
+		{kind: "query", wantArgs: 0, contains: []string{"information_schema.columns", "dependencies", "depends_on_issue_id"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(1)}}},
+	}}
+	db := openScriptedDB(t, state)
+
+	ok, err := HasReaperSchema(db)
+	if err != nil {
+		t.Fatalf("HasReaperSchema: %v", err)
+	}
+	if !ok {
+		t.Fatal("HasReaperSchema should accept typed dependency schema")
+	}
+
+	legacy := &scriptedState{ops: []scriptedOp{
+		{kind: "query", wantArgs: 0, contains: []string{"information_schema.tables", "wisps", "wisp_dependencies"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(3)}}},
+		{kind: "query", wantArgs: 0, contains: []string{"information_schema.columns", "wisp_dependencies", "depends_on_external"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(2)}}},
+	}}
+	db = openScriptedDB(t, legacy)
+	ok, err = HasReaperSchema(db)
+	if err != nil {
+		t.Fatalf("HasReaperSchema legacy: %v", err)
+	}
+	if ok {
+		t.Fatal("HasReaperSchema should reject incomplete typed dependency schema")
+	}
+}
+
+func TestTypedIssueDependencyQueriesAreNullSafe(t *testing.T) {
+	data, err := os.ReadFile("reaper.go")
+	if err != nil {
+		t.Fatalf("read reaper.go: %v", err)
+	}
+	source := string(data)
+	if got := strings.Count(source, "AND d.depends_on_issue_id IS NOT NULL"); got < 2 {
+		t.Fatalf("typed dependency NOT IN queries must filter NULL targets, found %d guards", got)
+	}
+}
+
+func TestReapDryRunCountsMoleculeStepsSeparately(t *testing.T) {
+	state := &scriptedState{ops: []scriptedOp{
+		{kind: "query", wantArgs: 1, contains: []string{"SELECT COUNT(*) FROM wisps w", "AND NOT EXISTS", "depends_on_wisp_id"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(1)}}},
+		{kind: "query", wantArgs: 0, contains: []string{"SELECT COUNT(*) FROM wisps w", "pm.status = 'closed'", "depends_on_wisp_id"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(2)}}},
+		{kind: "query", wantArgs: 0, contains: []string{"SELECT COUNT(*) FROM wisps WHERE status IN"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(3)}}},
+	}}
+	db := openScriptedDB(t, state)
+
+	result, err := Reap(db, "hq", 24*time.Hour, true)
+	if err != nil {
+		t.Fatalf("dry-run Reap: %v", err)
+	}
+	if result.Reaped != 1 || result.MoleculeStepsClosed != 2 || result.OpenRemain != 3 {
+		t.Fatalf("Reap() = %+v, want reaped=1 molecule_steps_closed=2 open=3", result)
+	}
+}
+
+func TestScanCountsMoleculeStepsSeparately(t *testing.T) {
+	state := &scriptedState{ops: []scriptedOp{
+		{kind: "query", wantArgs: 1, contains: []string{"SELECT COUNT(*) FROM wisps w", "AND NOT EXISTS", "depends_on_wisp_id"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(1)}}},
+		{kind: "query", wantArgs: 0, contains: []string{"SELECT COUNT(*) FROM wisps w", "pm.status = 'closed'", "depends_on_wisp_id"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(2)}}},
+		{kind: "query", wantArgs: 1, contains: []string{"SELECT COUNT(*) FROM wisps w WHERE w.status = 'closed'"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(3)}}},
+		{kind: "query", wantArgs: 1, contains: []string{"SELECT COUNT(*) FROM issues WHERE status = 'closed'"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(4)}}},
+		{kind: "query", wantArgs: 1, contains: []string{"SELECT COUNT(*) FROM issues i", "depends_on_issue_id"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(5)}}},
+		{kind: "query", wantArgs: 0, contains: []string{"SELECT COUNT(*) FROM wisps WHERE status IN"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(6)}}},
+		{kind: "query", wantArgs: 0, contains: []string{"SELECT COUNT(*) FROM wisp_dependencies wd", "depends_on_wisp_id", "depends_on_issue_id"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(0)}}},
+	}}
+	db := openScriptedDB(t, state)
+
+	result, err := Scan(db, "hq", 24*time.Hour, 168*time.Hour, 168*time.Hour, 168*time.Hour)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if result.ReapCandidates != 1 || result.MoleculeStepCandidates != 2 || result.PurgeCandidates != 3 || result.MailCandidates != 4 || result.StaleCandidates != 5 || result.OpenWisps != 6 {
+		t.Fatalf("Scan() = %+v, want disjoint reap/molecule counts and other scripted totals", result)
+	}
+}
+
+func TestReapUsesPinnedConnectionForWrites(t *testing.T) {
+	state := &scriptedState{ops: []scriptedOp{
+		{kind: "exec", wantArgs: 0, contains: []string{"SET @@autocommit = 0"}},
+		{kind: "query", wantArgs: 0, contains: []string{"SELECT w.id FROM wisps w", "pm.status = 'closed'", "depends_on_wisp_id"}, columns: []string{"id"}, rows: [][]driver.Value{{"mol-step-1"}}},
+		{kind: "exec", wantArgs: 1, contains: []string{"UPDATE wisps SET status='closed'", "reaper: parent molecule closed"}, affected: 1},
+		{kind: "query", wantArgs: 0, contains: []string{"SELECT w.id FROM wisps w", "pm.status = 'closed'", "depends_on_wisp_id"}, columns: []string{"id"}},
+		{kind: "query", wantArgs: 1, contains: []string{"SELECT w.id FROM wisps w", "AND NOT EXISTS", "depends_on_wisp_id"}, columns: []string{"id"}, rows: [][]driver.Value{{"stale-1"}}},
+		{kind: "exec", wantArgs: 1, contains: []string{"UPDATE wisps SET status='closed', closed_at=NOW() WHERE id IN (?)"}, affected: 1},
+		{kind: "query", wantArgs: 1, contains: []string{"SELECT w.id FROM wisps w", "AND NOT EXISTS", "depends_on_wisp_id"}, columns: []string{"id"}},
+		{kind: "exec", wantArgs: 0, contains: []string{"COMMIT"}},
+		{kind: "exec", wantArgs: 0, contains: []string{"CALL DOLT_COMMIT", "1 stale + 1 molecule-step"}},
+		{kind: "query", wantArgs: 0, contains: []string{"SELECT COUNT(*) FROM wisps WHERE status IN"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(0)}}},
+		{kind: "exec", wantArgs: 0, contains: []string{"SET @@autocommit = 1"}},
+	}}
+	db := openScriptedDB(t, state)
+
+	result, err := Reap(db, "hq", 24*time.Hour, false)
+	if err != nil {
+		t.Fatalf("Reap: %v", err)
+	}
+	if result.Reaped != 1 || result.MoleculeStepsClosed != 1 || result.OpenRemain != 0 {
+		t.Fatalf("Reap() = %+v, want reaped=1 molecule_steps_closed=1 open=0", result)
+	}
+	state.mu.Lock()
+	defer state.mu.Unlock()
+	if len(state.ops) != 0 {
+		t.Fatalf("%d scripted operations were not consumed", len(state.ops))
+	}
+	for _, id := range state.connIDs {
+		if id != state.connIDs[0] {
+			t.Fatalf("Reap used multiple connections: %v", state.connIDs)
+		}
+	}
+}
+
+func TestReapCommitsMoleculeStepOnlyWrites(t *testing.T) {
+	state := &scriptedState{ops: []scriptedOp{
+		{kind: "exec", wantArgs: 0, contains: []string{"SET @@autocommit = 0"}},
+		{kind: "query", wantArgs: 0, contains: []string{"SELECT w.id FROM wisps w", "pm.status = 'closed'", "depends_on_wisp_id"}, columns: []string{"id"}, rows: [][]driver.Value{{"mol-step-1"}}},
+		{kind: "exec", wantArgs: 1, contains: []string{"UPDATE wisps SET status='closed'", "reaper: parent molecule closed"}, affected: 1},
+		{kind: "query", wantArgs: 0, contains: []string{"SELECT w.id FROM wisps w", "pm.status = 'closed'", "depends_on_wisp_id"}, columns: []string{"id"}},
+		{kind: "query", wantArgs: 1, contains: []string{"SELECT w.id FROM wisps w", "AND NOT EXISTS", "depends_on_wisp_id"}, columns: []string{"id"}},
+		{kind: "exec", wantArgs: 0, contains: []string{"COMMIT"}},
+		{kind: "exec", wantArgs: 0, contains: []string{"CALL DOLT_COMMIT", "0 stale + 1 molecule-step"}},
+		{kind: "query", wantArgs: 0, contains: []string{"SELECT COUNT(*) FROM wisps WHERE status IN"}, columns: []string{"count"}, rows: [][]driver.Value{{int64(0)}}},
+		{kind: "exec", wantArgs: 0, contains: []string{"SET @@autocommit = 1"}},
+	}}
+	db := openScriptedDB(t, state)
+
+	result, err := Reap(db, "hq", 24*time.Hour, false)
+	if err != nil {
+		t.Fatalf("Reap: %v", err)
+	}
+	if result.Reaped != 0 || result.MoleculeStepsClosed != 1 || result.OpenRemain != 0 {
+		t.Fatalf("Reap() = %+v, want reaped=0 molecule_steps_closed=1 open=0", result)
 	}
 }
 


### PR DESCRIPTION
Replacement/fixup for PR #4233, rebuilt from current upstream/main with the original contributor as commit author.

Summary:
- close open/hooked/in_progress step-wisps whose parent molecule is already closed
- converge reaper and wisp migration paths on typed v49 dependency columns
- keep stale max-age reap counts disjoint from completed-molecule step cleanup
- pin non-dry-run Reap writes to one SQL connection and report molecule-step counts

Verification:
- go test ./internal/reaper
- CGO_ENABLED=0 go test ./internal/cmd ./internal/doctor ./internal/doltserver ./internal/daemon -run '^$'
- CGO_ENABLED=0 go test ./internal/cmd -run 'TestReaperMoleculeStepSuffix|TestWaitBeforeReaperDatabase|TestReaperDatabaseNames'
- CGO_ENABLED=0 go test ./internal/doltserver -run 'TestWispDependenciesDDLUsesTypedTargets|TestWispDependencyMigrationSQLUsesTypedTargets'
- CGO_ENABLED=0 go test ./internal/doctor -run TestMisclassifiedWispDependencyCopyUsesTypedTargets
- CGO_ENABLED=0 go test -c -o /tmp/opencode/daemon.test ./internal/daemon
- CGO_ENABLED=0 go build ./cmd/gt ./cmd/gt-proxy-server ./cmd/gt-proxy-client
- git diff --check upstream/main...HEAD
- live read-only hq scan and dry-run reap using rebuilt gt