### PR TITLE
fix(reaper): auto-close step-wisps of completed molecules

### DIFF
--- a/internal/cmd/compact.go
+++ b/internal/cmd/compact.go
@@ -283,7 +283,8 @@ func runCompact(cmd *cobra.Command, args []string) error {
 func cleanOrphanedWispDeps(bd *beads.Beads, result *compactResult) {
 	const q = `DELETE FROM wisp_dependencies WHERE ` +
 		`NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.issue_id) ` +
-		`OR NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_id)`
+		`OR (depends_on_wisp_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_wisp_id)) ` +
+		`OR (depends_on_issue_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM issues WHERE id = wisp_dependencies.depends_on_issue_id))`
 	out, err := bd.Run("sql", q)
 	if err != nil {
 		result.Errors = append(result.Errors, fmt.Sprintf("orphaned wisp_deps cleanup: %v", err))

--- a/internal/cmd/compact.go
+++ b/internal/cmd/compact.go
@@ -281,6 +281,10 @@ func runCompact(cmd *cobra.Command, args []string) error {
 // but leaves behind its dependency records (bd delete has no cascade logic for
 // the wisp-level tables). Runs as a post-compact sweep.
 func cleanOrphanedWispDeps(bd *beads.Beads, result *compactResult) {
+	columns, err := bd.Run("sql", "--csv", "SHOW COLUMNS FROM wisp_dependencies")
+	if err != nil || !strings.Contains(string(columns), "\ndepends_on_wisp_id,") || !strings.Contains(string(columns), "\ndepends_on_issue_id,") {
+		return
+	}
 	const q = `DELETE FROM wisp_dependencies WHERE ` +
 		`NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.issue_id) ` +
 		`OR (depends_on_wisp_id IS NOT NULL AND NOT EXISTS (SELECT 1 FROM wisps WHERE id = wisp_dependencies.depends_on_wisp_id)) ` +

--- a/internal/cmd/reaper.go
+++ b/internal/cmd/reaper.go
@@ -155,10 +155,13 @@ The Dog uses this to understand the state before deciding what to reap.`,
 		if reaperJSON {
 			fmt.Println(reaper.FormatJSON(results))
 		} else {
-			var totalReap, totalPurge, totalMail, totalStale, totalOpen int
+			var totalReap, totalMoleculeSteps, totalPurge, totalMail, totalStale, totalOpen int
 			for _, r := range results {
 				fmt.Printf("Database: %s\n", r.Database)
 				fmt.Printf("  Reap candidates:  %d\n", r.ReapCandidates)
+				if r.MoleculeStepCandidates > 0 {
+					fmt.Printf("  Molecule steps:   %d\n", r.MoleculeStepCandidates)
+				}
 				fmt.Printf("  Purge candidates: %d\n", r.PurgeCandidates)
 				fmt.Printf("  Mail candidates:  %d\n", r.MailCandidates)
 				fmt.Printf("  Stale candidates: %d\n", r.StaleCandidates)
@@ -167,6 +170,7 @@ The Dog uses this to understand the state before deciding what to reap.`,
 					fmt.Printf("  %s %s\n", style.Warning.Render("ANOMALY:"), a.Message)
 				}
 				totalReap += r.ReapCandidates
+				totalMoleculeSteps += r.MoleculeStepCandidates
 				totalPurge += r.PurgeCandidates
 				totalMail += r.MailCandidates
 				totalStale += r.StaleCandidates
@@ -175,6 +179,9 @@ The Dog uses this to understand the state before deciding what to reap.`,
 			if len(results) > 1 {
 				fmt.Printf("\nScan summary (%d databases):\n", len(results))
 				fmt.Printf("  Reap candidates:  %d\n", totalReap)
+				if totalMoleculeSteps > 0 {
+					fmt.Printf("  Molecule steps:   %d\n", totalMoleculeSteps)
+				}
 				fmt.Printf("  Purge candidates: %d\n", totalPurge)
 				fmt.Printf("  Mail candidates:  %d\n", totalMail)
 				fmt.Printf("  Stale candidates: %d\n", totalStale)
@@ -240,15 +247,20 @@ Returns the count of reaped wisps. Use --dry-run to preview.`,
 		if reaperJSON {
 			fmt.Println(reaper.FormatJSON(results))
 		} else {
-			var totalReaped, totalOpen int
+			var totalReaped, totalMoleculeSteps, totalOpen int
 			for _, r := range results {
 				prefix := ""
 				if r.DryRun {
 					prefix = "[DRY RUN] would "
 				}
-				fmt.Printf("%s: %sreaped %d wisps, %d open remain\n",
-					r.Database, prefix, r.Reaped, r.OpenRemain)
+				extra := ""
+				if r.MoleculeStepsClosed > 0 {
+					extra = fmt.Sprintf(" (+%d closed-molecule steps)", r.MoleculeStepsClosed)
+				}
+				fmt.Printf("%s: %sreaped %d wisps%s, %d open remain\n",
+					r.Database, prefix, r.Reaped, extra, r.OpenRemain)
 				totalReaped += r.Reaped
+				totalMoleculeSteps += r.MoleculeStepsClosed
 				totalOpen += r.OpenRemain
 			}
 			if len(results) > 1 {
@@ -256,8 +268,12 @@ Returns the count of reaped wisps. Use --dry-run to preview.`,
 				if reaperDryRun {
 					prefix = "[DRY RUN] "
 				}
-				fmt.Printf("\n%sReap summary (%d databases): reaped %d wisps, %d open remain\n",
-					prefix, len(results), totalReaped, totalOpen)
+				extra := ""
+				if totalMoleculeSteps > 0 {
+					extra = fmt.Sprintf(" (+%d closed-molecule steps)", totalMoleculeSteps)
+				}
+				fmt.Printf("\n%sReap summary (%d databases): reaped %d wisps%s, %d open remain\n",
+					prefix, len(results), totalReaped, extra, totalOpen)
 				if totalOpen > reaper.DefaultAlertThreshold {
 					fmt.Fprintf(os.Stderr, "WARNING: %d open wisps exceed alert threshold (%d)\n",
 						totalOpen, reaper.DefaultAlertThreshold)
@@ -463,7 +479,7 @@ Normally the daemon dispatches a Dog to execute the mol-dog-reaper formula.`,
 			return fmt.Errorf("invalid --stale-age: %w", err)
 		}
 
-		var totalReaped, totalPurged, totalMailPurged, totalClosed, totalOpen int
+		var totalReaped, totalMoleculeSteps, totalPurged, totalMailPurged, totalClosed, totalOpen int
 
 		for i, dbName := range databases {
 			if err := waitBeforeReaperDatabase(i); err != nil {
@@ -507,6 +523,7 @@ Normally the daemon dispatches a Dog to execute the mol-dog-reaper formula.`,
 				fmt.Printf("%s: reap error: %v\n", dbName, err)
 			} else {
 				totalReaped += reapResult.Reaped
+				totalMoleculeSteps += reapResult.MoleculeStepsClosed
 				totalOpen += reapResult.OpenRemain
 			}
 
@@ -541,7 +558,11 @@ Normally the daemon dispatches a Dog to execute the mol-dog-reaper formula.`,
 		}
 		fmt.Printf("\n%sReaper cycle complete:\n", prefix)
 		fmt.Printf("  Databases: %d\n", len(databases))
-		fmt.Printf("  Reaped:    %d\n", totalReaped)
+		fmt.Printf("  Reaped:    %d", totalReaped)
+		if totalMoleculeSteps > 0 {
+			fmt.Printf(" (+%d closed-molecule steps)", totalMoleculeSteps)
+		}
+		fmt.Println()
 		fmt.Printf("  Purged:    %d wisps, %d mail\n", totalPurged, totalMailPurged)
 		fmt.Printf("  Closed:    %d stale issues\n", totalClosed)
 		fmt.Printf("  Open:      %d wisps remain\n", totalOpen)

--- a/internal/daemon/wisp_reaper.go
+++ b/internal/daemon/wisp_reaper.go
@@ -159,7 +159,7 @@ func (d *Daemon) reapWispsInline(config *WispReaperConfig, maxAge, deleteAge tim
 
 	port := d.doltServerPort()
 	dryRun := config.DryRun
-	var totalReaped, totalOpen, totalPurged, totalMailPurged, totalAutoClosed int
+	var totalReaped, totalMoleculeSteps, totalOpen, totalPurged, totalMailPurged, totalAutoClosed int
 
 	// Step 2: Reap
 	reapErrors := 0
@@ -186,9 +186,14 @@ func (d *Daemon) reapWispsInline(config *WispReaperConfig, maxAge, deleteAge tim
 			continue
 		}
 		totalReaped += result.Reaped
+		totalMoleculeSteps += result.MoleculeStepsClosed
 		totalOpen += result.OpenRemain
-		if result.Reaped > 0 {
-			d.logger.Printf("wisp_reaper: %s: reaped %d stale wisps, %d open remain", dbName, result.Reaped, result.OpenRemain)
+		if result.Reaped > 0 || result.MoleculeStepsClosed > 0 {
+			reapSummary := fmt.Sprintf("wisp_reaper: %s: reaped %d stale wisps", dbName, result.Reaped)
+			if result.MoleculeStepsClosed > 0 {
+				reapSummary += fmt.Sprintf(", closed %d molecule steps", result.MoleculeStepsClosed)
+			}
+			d.logger.Printf("%s, %d open remain", reapSummary, result.OpenRemain)
 		}
 	}
 	if reapErrors > 0 {
@@ -322,8 +327,13 @@ func (d *Daemon) reapWispsInline(config *WispReaperConfig, maxAge, deleteAge tim
 		d.logger.Printf("wisp_reaper: WARNING: %d open wisps exceed threshold %d — investigate wisp lifecycle",
 			totalOpen, wispAlertThreshold)
 	}
-	d.logger.Printf("wisp_reaper: cycle complete — reaped=%d purged=%d mail_purged=%d plugin_closed=%d dispatch_closed=%d auto_closed=%d open=%d databases=%d dryRun=%v",
-		totalReaped, totalPurged, totalMailPurged, totalPluginClosed, totalDispatchClosed, totalAutoClosed, totalOpen, len(databases), dryRun)
+	summary := fmt.Sprintf("wisp_reaper: cycle complete — reaped=%d", totalReaped)
+	if totalMoleculeSteps > 0 {
+		summary += fmt.Sprintf(" molecule_steps_closed=%d", totalMoleculeSteps)
+	}
+	summary += fmt.Sprintf(" purged=%d mail_purged=%d plugin_closed=%d dispatch_closed=%d auto_closed=%d open=%d databases=%d dryRun=%v",
+		totalPurged, totalMailPurged, totalPluginClosed, totalDispatchClosed, totalAutoClosed, totalOpen, len(databases), dryRun)
+	d.logger.Printf("%s", summary)
 	mol.closeStep("report")
 }
 

--- a/internal/doctor/misclassified_wisp_check.go
+++ b/internal/doctor/misclassified_wisp_check.go
@@ -240,7 +240,7 @@ func (c *CheckMisclassifiedWisps) purgeRigBatch(ctx *CheckContext, workDir, rigN
 		},
 		{
 			table: "wisp_dependencies",
-			query: fmt.Sprintf("INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_id, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d WHERE d.issue_id IN (%s)", idList),
+			query: fmt.Sprintf("INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d WHERE d.issue_id IN (%s)", idList),
 		},
 	}
 	for _, aux := range auxCopies {

--- a/internal/doctor/misclassified_wisp_check.go
+++ b/internal/doctor/misclassified_wisp_check.go
@@ -243,9 +243,12 @@ func (c *CheckMisclassifiedWisps) purgeRigBatch(ctx *CheckContext, workDir, rigN
 			query: fmt.Sprintf("INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d WHERE d.issue_id IN (%s)", idList),
 		},
 	}
+	copyFailed := map[string]bool{}
 	for _, aux := range auxCopies {
 		if bdTableExistsDoctor(workDir, aux.table) {
-			_ = execBdSQLWrite(workDir, aux.query) // Best-effort
+			if err := execBdSQLWrite(workDir, aux.query); err != nil {
+				copyFailed[aux.table] = true
+			}
 		}
 	}
 
@@ -254,7 +257,9 @@ func (c *CheckMisclassifiedWisps) purgeRigBatch(ctx *CheckContext, workDir, rigN
 		fmt.Sprintf("DELETE FROM labels WHERE issue_id IN (%s)", idList),
 		fmt.Sprintf("DELETE FROM comments WHERE issue_id IN (%s)", idList),
 		fmt.Sprintf("DELETE FROM events WHERE issue_id IN (%s)", idList),
-		fmt.Sprintf("DELETE FROM dependencies WHERE issue_id IN (%s)", idList),
+	}
+	if !copyFailed["wisp_dependencies"] {
+		auxDeletes = append(auxDeletes, fmt.Sprintf("DELETE FROM dependencies WHERE issue_id IN (%s)", idList))
 	}
 	for _, q := range auxDeletes {
 		_ = execBdSQLWrite(workDir, q) // Best-effort: table may not exist

--- a/internal/doltserver/wisps_migrate.go
+++ b/internal/doltserver/wisps_migrate.go
@@ -3,11 +3,11 @@
 // The wisps table is a dolt_ignored copy of the issues table schema, used for
 // ephemeral operational data (agent beads, patrol wisps, etc.) that should not
 // be version-controlled. This migration:
-//   1. Creates the wisps table and auxiliary tables (wisp_labels, wisp_comments,
-//      wisp_events, wisp_dependencies) if they don't exist
-//   2. Copies existing agent beads (issue_type='agent') from issues to wisps
-//   3. Copies associated labels, comments, events, and dependencies
-//   4. Closes the originals in the issues table
+//  1. Creates the wisps table and auxiliary tables (wisp_labels, wisp_comments,
+//     wisp_events, wisp_dependencies) if they don't exist
+//  2. Copies existing agent beads (issue_type='agent') from issues to wisps
+//  3. Copies associated labels, comments, events, and dependencies
+//  4. Closes the originals in the issues table
 //
 // The migration uses `bd sql` for beads-side operations (copying agent beads between
 // the issues and wisps tables in bd's own database). Additionally, it ensures that
@@ -68,6 +68,9 @@ func MigrateAgentBeadsToWisps(townRoot, workDir string, dryRun bool) (*MigrateWi
 		return nil, fmt.Errorf("creating auxiliary tables: %w", err)
 	}
 	result.AuxTablesCreated = auxTables
+	if err := ensureWispDependencySchema(workDir); err != nil {
+		return nil, fmt.Errorf("updating wisp dependency schema: %w", err)
+	}
 
 	// Step 3b: Ensure wisps tables also exist on the gt Dolt server.
 	// The reaper connects directly to the gt Dolt server (port 3307), which is
@@ -205,6 +208,58 @@ func ensureWispAuxTables(workDir string) ([]string, error) {
 	return created, nil
 }
 
+func ensureWispDependencySchema(workDir string) error {
+	if !bdTableExists(workDir, "wisp_dependencies") {
+		return nil
+	}
+	columns, err := bdSQLCSV(workDir, "SHOW COLUMNS FROM wisp_dependencies")
+	if err != nil {
+		return err
+	}
+	if hasCSVColumn(columns, "depends_on_issue_id") && hasCSVColumn(columns, "depends_on_wisp_id") && hasCSVColumn(columns, "depends_on_external") {
+		if !hasCSVColumn(columns, "depends_on_id") {
+			return nil
+		}
+	}
+	if !hasCSVColumn(columns, "depends_on_id") {
+		return fmt.Errorf("wisp_dependencies missing split dependency columns")
+	}
+	return rebuildWispDependencyTable(workDir)
+}
+
+func rebuildWispDependencyTable(workDir string) error {
+	if err := bdSQL(workDir, "DROP TABLE IF EXISTS wisp_dependencies_legacy"); err != nil {
+		return err
+	}
+	if err := bdSQL(workDir, "RENAME TABLE wisp_dependencies TO wisp_dependencies_legacy"); err != nil {
+		return err
+	}
+	if err := bdSQL(workDir, wispDependenciesCreateDDL); err != nil {
+		return err
+	}
+	if err := bdSQL(workDir, `INSERT IGNORE INTO wisp_dependencies (issue_id, type, created_at, created_by, metadata, thread_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external)
+SELECT wd.issue_id, wd.type, wd.created_at, wd.created_by, wd.metadata, wd.thread_id,
+       CASE WHEN w.id IS NULL AND i.id IS NOT NULL THEN wd.depends_on_id ELSE NULL END,
+       CASE WHEN w.id IS NOT NULL THEN wd.depends_on_id ELSE NULL END,
+       CASE WHEN w.id IS NULL AND i.id IS NULL THEN wd.depends_on_id ELSE NULL END
+FROM wisp_dependencies_legacy wd
+LEFT JOIN wisps w ON w.id = wd.depends_on_id
+LEFT JOIN issues i ON i.id = wd.depends_on_id`); err != nil {
+		return err
+	}
+	return bdSQL(workDir, "DROP TABLE wisp_dependencies_legacy")
+}
+
+func hasCSVColumn(csvOutput, column string) bool {
+	for _, line := range strings.Split(csvOutput, "\n") {
+		fields := strings.SplitN(line, ",", 2)
+		if len(fields) > 0 && strings.Trim(fields[0], `"`) == column {
+			return true
+		}
+	}
+	return false
+}
+
 // copyAgentBeadsToWisps inserts agent beads from issues into wisps, skipping duplicates.
 func copyAgentBeadsToWisps(workDir string, result *MigrateWispsResult) error {
 	// INSERT IGNORE skips rows where the primary key already exists in wisps.
@@ -257,7 +312,7 @@ func copyAuxiliaryData(workDir string, result *MigrateWispsResult) error {
 
 	// Copy dependencies
 	if err := bdSQL(workDir,
-		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_id, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_id, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d INNER JOIN wisps w ON d.issue_id = w.id"); err != nil {
+		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d INNER JOIN wisps w ON d.issue_id = w.id"); err != nil {
 		if !strings.Contains(err.Error(), "nothing") {
 			return fmt.Errorf("copying dependencies: %w", err)
 		}
@@ -333,6 +388,9 @@ func ensureWispsOnGTServer(host string, port int, dbName string) (wispsCreated b
 			fmt.Printf("  Note: dolt commit after table creation: %v\n", err)
 		}
 	}
+	if err := ensureWispDependencySchemaOnGT(ctx, db, dbName); err != nil {
+		return wispsCreated, auxCreated, err
+	}
 
 	return wispsCreated, auxCreated, nil
 }
@@ -345,6 +403,55 @@ func gtTableExists(ctx context.Context, db *sql.DB, dbName, tableName string) bo
 		"SELECT 1 FROM information_schema.tables WHERE table_schema = ? AND table_name = ?",
 		dbName, tableName).Scan(&dummy)
 	return err == nil
+}
+
+func gtColumnExists(ctx context.Context, db *sql.DB, dbName, tableName, columnName string) bool {
+	var dummy int
+	err := db.QueryRowContext(ctx,
+		"SELECT 1 FROM information_schema.columns WHERE table_schema = ? AND table_name = ? AND column_name = ?",
+		dbName, tableName, columnName).Scan(&dummy)
+	return err == nil
+}
+
+func ensureWispDependencySchemaOnGT(ctx context.Context, db *sql.DB, dbName string) error {
+	if !gtTableExists(ctx, db, dbName, "wisp_dependencies") {
+		return nil
+	}
+	if gtColumnExists(ctx, db, dbName, "wisp_dependencies", "depends_on_issue_id") &&
+		gtColumnExists(ctx, db, dbName, "wisp_dependencies", "depends_on_wisp_id") &&
+		gtColumnExists(ctx, db, dbName, "wisp_dependencies", "depends_on_external") {
+		if !gtColumnExists(ctx, db, dbName, "wisp_dependencies", "depends_on_id") {
+			return nil
+		}
+	}
+	if !gtColumnExists(ctx, db, dbName, "wisp_dependencies", "depends_on_id") {
+		return fmt.Errorf("wisp_dependencies missing split dependency columns")
+	}
+	return rebuildWispDependencyTableOnGT(ctx, db)
+}
+
+func rebuildWispDependencyTableOnGT(ctx context.Context, db *sql.DB) error {
+	if _, err := db.ExecContext(ctx, "DROP TABLE IF EXISTS wisp_dependencies_legacy"); err != nil {
+		return err
+	}
+	if _, err := db.ExecContext(ctx, "RENAME TABLE wisp_dependencies TO wisp_dependencies_legacy"); err != nil {
+		return err
+	}
+	if _, err := db.ExecContext(ctx, wispDependenciesCreateDDL); err != nil {
+		return err
+	}
+	if _, err := db.ExecContext(ctx, `INSERT IGNORE INTO wisp_dependencies (issue_id, type, created_at, created_by, metadata, thread_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external)
+SELECT wd.issue_id, wd.type, wd.created_at, wd.created_by, wd.metadata, wd.thread_id,
+       CASE WHEN w.id IS NULL AND i.id IS NOT NULL THEN wd.depends_on_id ELSE NULL END,
+       CASE WHEN w.id IS NOT NULL THEN wd.depends_on_id ELSE NULL END,
+       CASE WHEN w.id IS NULL AND i.id IS NULL THEN wd.depends_on_id ELSE NULL END
+FROM wisp_dependencies_legacy wd
+LEFT JOIN wisps w ON w.id = wd.depends_on_id
+LEFT JOIN issues i ON i.id = wd.depends_on_id`); err != nil {
+		return err
+	}
+	_, err := db.ExecContext(ctx, "DROP TABLE wisp_dependencies_legacy")
+	return err
 }
 
 // wispsCreateDDL is the CREATE TABLE statement for the wisps table.
@@ -417,6 +524,34 @@ type wispAuxTableDDL struct {
 	ddl  string
 }
 
+const wispDependenciesCreateDDL = `CREATE TABLE wisp_dependencies (
+  id char(36) NOT NULL DEFAULT (uuid()),
+  issue_id varchar(255) NOT NULL,
+  type varchar(32) NOT NULL DEFAULT 'blocks',
+  created_at datetime DEFAULT CURRENT_TIMESTAMP,
+  created_by varchar(255) DEFAULT '',
+  metadata json DEFAULT (json_object()),
+  thread_id varchar(255) DEFAULT '',
+  depends_on_issue_id varchar(255),
+  depends_on_wisp_id varchar(255),
+  depends_on_external varchar(255),
+  PRIMARY KEY (id),
+  KEY idx_wisp_dep_external_target (depends_on_external),
+  KEY idx_wisp_dep_issue_target (depends_on_issue_id),
+  KEY idx_wisp_dep_type (type),
+  KEY idx_wisp_dep_type_external (type, depends_on_external),
+  KEY idx_wisp_dep_type_issue (type, depends_on_issue_id),
+  KEY idx_wisp_dep_type_wisp (type, depends_on_wisp_id),
+  KEY idx_wisp_dep_wisp_target (depends_on_wisp_id),
+  UNIQUE KEY uk_wisp_dep_external_target (issue_id, depends_on_external),
+  UNIQUE KEY uk_wisp_dep_issue_target (issue_id, depends_on_issue_id),
+  UNIQUE KEY uk_wisp_dep_wisp_target (issue_id, depends_on_wisp_id),
+  CONSTRAINT fk_wisp_dep_issue FOREIGN KEY (issue_id) REFERENCES wisps (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT fk_wisp_dep_issue_target FOREIGN KEY (depends_on_issue_id) REFERENCES issues (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT fk_wisp_dep_wisp_target FOREIGN KEY (depends_on_wisp_id) REFERENCES wisps (id) ON DELETE CASCADE ON UPDATE CASCADE,
+  CONSTRAINT ck_wisp_dep_one_target CHECK (((NOT(depends_on_issue_id IS NULL)) + (NOT(depends_on_wisp_id IS NULL)) + (NOT(depends_on_external IS NULL))) = 1)
+)`
+
 // wispAuxTableDDLs are the auxiliary tables needed alongside wisps.
 var wispAuxTableDDLs = []wispAuxTableDDL{
 	{
@@ -457,17 +592,7 @@ var wispAuxTableDDLs = []wispAuxTableDDL{
 	},
 	{
 		name: "wisp_dependencies",
-		ddl: `CREATE TABLE wisp_dependencies (
-  issue_id varchar(255) NOT NULL,
-  depends_on_id varchar(255) NOT NULL,
-  type varchar(32) NOT NULL DEFAULT 'blocks',
-  created_at datetime NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  created_by varchar(255) NOT NULL DEFAULT '',
-  metadata json,
-  thread_id varchar(255) DEFAULT '',
-  PRIMARY KEY (issue_id, depends_on_id),
-  KEY idx_wisp_deps_depends_on (depends_on_id)
-)`,
+		ddl:  wispDependenciesCreateDDL,
 	},
 }
 

--- a/internal/doltserver/wisps_migrate.go
+++ b/internal/doltserver/wisps_migrate.go
@@ -405,11 +405,11 @@ func gtTableExists(ctx context.Context, db *sql.DB, dbName, tableName string) bo
 	return err == nil
 }
 
-func gtColumnExists(ctx context.Context, db *sql.DB, dbName, tableName, columnName string) bool {
+func gtWispDependencyColumnExists(ctx context.Context, db *sql.DB, dbName, columnName string) bool {
 	var dummy int
 	err := db.QueryRowContext(ctx,
 		"SELECT 1 FROM information_schema.columns WHERE table_schema = ? AND table_name = ? AND column_name = ?",
-		dbName, tableName, columnName).Scan(&dummy)
+		dbName, "wisp_dependencies", columnName).Scan(&dummy)
 	return err == nil
 }
 
@@ -417,14 +417,14 @@ func ensureWispDependencySchemaOnGT(ctx context.Context, db *sql.DB, dbName stri
 	if !gtTableExists(ctx, db, dbName, "wisp_dependencies") {
 		return nil
 	}
-	if gtColumnExists(ctx, db, dbName, "wisp_dependencies", "depends_on_issue_id") &&
-		gtColumnExists(ctx, db, dbName, "wisp_dependencies", "depends_on_wisp_id") &&
-		gtColumnExists(ctx, db, dbName, "wisp_dependencies", "depends_on_external") {
-		if !gtColumnExists(ctx, db, dbName, "wisp_dependencies", "depends_on_id") {
+	if gtWispDependencyColumnExists(ctx, db, dbName, "depends_on_issue_id") &&
+		gtWispDependencyColumnExists(ctx, db, dbName, "depends_on_wisp_id") &&
+		gtWispDependencyColumnExists(ctx, db, dbName, "depends_on_external") {
+		if !gtWispDependencyColumnExists(ctx, db, dbName, "depends_on_id") {
 			return nil
 		}
 	}
-	if !gtColumnExists(ctx, db, dbName, "wisp_dependencies", "depends_on_id") {
+	if !gtWispDependencyColumnExists(ctx, db, dbName, "depends_on_id") {
 		return fmt.Errorf("wisp_dependencies missing split dependency columns")
 	}
 	return rebuildWispDependencyTableOnGT(ctx, db)

--- a/internal/formula/formulas/mol-dog-reaper.formula.toml
+++ b/internal/formula/formulas/mol-dog-reaper.formula.toml
@@ -9,7 +9,7 @@ these commands, inspects results, and uses judgment for anomalies.
 
 This is infrastructure cleanup work:
 1. Scan all production databases for candidates
-2. Reap (close) wisps past max_age whose parent is closed/missing
+2. Reap (close) wisps past max_age whose parent is closed/missing, plus step-wisps whose parent molecule is already closed
 3. Purge (delete) closed wisps past purge_age + old closed mail
 4. Auto-close stale issues (>stale_issue_age, not P0/P1, not epics/convoys, no active deps)
 5. Close completed convoys via `gt convoy check` (tracked-bead status, never staleness)
@@ -78,12 +78,13 @@ gt reaper scan --db=<name> --port={{dolt_port}} \\
 
 **3. Inspect results for anomalies:**
 - Check the `anomalies` array in the JSON output
+- Treat an absent `molecule_step_candidates` field as zero
 - Flag any `dangling_parent_ref` anomalies — these indicate wisps with
   parent dependency records pointing to purged/missing parents
 - If `open_wisps` exceeds {{alert_threshold}}, escalate
 
 **4. Decide whether to proceed:**
-- If no candidates found across all databases, skip remaining steps
+- If no candidates found across all databases, including `molecule_step_candidates`, skip remaining steps
 - If anomalies are severe, consider escalating before proceeding
 
 **Exit criteria:** Scan complete, candidates identified, anomalies flagged."""
@@ -93,16 +94,17 @@ id = "reap"
 title = "Reap stale wisps"
 needs = ["scan"]
 description = """
-Close wisps past max_age whose parent molecule is closed or missing.
+Close wisps past max_age whose parent molecule is closed or missing, and close
+step-wisps immediately when their parent molecule is already closed.
 
-**1. For each database with reap candidates:**
+**1. For each database with `reap_candidates` or `molecule_step_candidates`:**
 ```bash
 gt reaper reap --db=<name> --port={{dolt_port}} \\
   --max-age={{max_age}} --db-delay={{db_delay}} {{#if dry_run}}--dry-run{{/if}} --json
 ```
 
 **2. Inspect results:**
-- Compare reaped count to scan candidates. A mismatch (scan > reap) is NORMAL
+- Compare reaped and molecule-step counts to scan candidates. A mismatch (scan > reap) is NORMAL
   and expected — the witness may close wisps for dead polecat sessions between
   scan and reap. Do NOT escalate scan/reap count mismatches.
 - Only escalate if reap returns an actual error (not a zero count).

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -99,22 +99,24 @@ func DiscoverDatabases(host string, port int) []string {
 
 // ScanResult holds the results of scanning a database for reaper candidates.
 type ScanResult struct {
-	Database        string    `json:"database"`
-	ReapCandidates  int       `json:"reap_candidates"`
-	PurgeCandidates int       `json:"purge_candidates"`
-	MailCandidates  int       `json:"mail_candidates"`
-	StaleCandidates int       `json:"stale_candidates"`
-	OpenWisps       int       `json:"open_wisps"`
-	Anomalies       []Anomaly `json:"anomalies,omitempty"`
+	Database               string    `json:"database"`
+	ReapCandidates         int       `json:"reap_candidates"`
+	MoleculeStepCandidates int       `json:"molecule_step_candidates,omitempty"`
+	PurgeCandidates        int       `json:"purge_candidates"`
+	MailCandidates         int       `json:"mail_candidates"`
+	StaleCandidates        int       `json:"stale_candidates"`
+	OpenWisps              int       `json:"open_wisps"`
+	Anomalies              []Anomaly `json:"anomalies,omitempty"`
 }
 
 // ReapResult holds the results of a reap operation.
 type ReapResult struct {
-	Database   string    `json:"database"`
-	Reaped     int       `json:"reaped"`
-	OpenRemain int       `json:"open_remain"`
-	DryRun     bool      `json:"dry_run,omitempty"`
-	Anomalies  []Anomaly `json:"anomalies,omitempty"`
+	Database            string    `json:"database"`
+	Reaped              int       `json:"reaped"`
+	MoleculeStepsClosed int       `json:"molecule_steps_closed,omitempty"`
+	OpenRemain          int       `json:"open_remain"`
+	DryRun              bool      `json:"dry_run,omitempty"`
+	Anomalies           []Anomaly `json:"anomalies,omitempty"`
 }
 
 // PurgeResult holds the results of a purge operation.
@@ -203,12 +205,46 @@ func parentExcludeJoin(dbName string) (joinClause, whereCondition string) {
 	joinClause = `LEFT JOIN (
 		SELECT DISTINCT wd.issue_id
 		FROM wisp_dependencies wd
-		LEFT JOIN wisps pw ON pw.id = wd.depends_on_id LEFT JOIN issues pi ON pi.id = wd.depends_on_id
+		LEFT JOIN wisps pw ON pw.id = wd.depends_on_wisp_id LEFT JOIN issues pi ON pi.id = wd.depends_on_issue_id
 		WHERE wd.type = 'parent-child'
-		AND (pw.status IN ('open', 'hooked', 'in_progress') OR pi.status IN ('open', 'in_progress'))
+		AND (pw.status IN ('open', 'hooked', 'in_progress') OR pi.status IN ('open', 'hooked', 'in_progress') OR wd.depends_on_external IS NOT NULL)
 	) open_parent ON open_parent.issue_id = w.id`
 	whereCondition = "open_parent.issue_id IS NULL"
 	return
+}
+
+const openWispStatusWhere = "w.status IN ('open', 'hooked', 'in_progress')"
+
+// closedMoleculeStepSubquery selects step-wisps whose parent molecule has already closed.
+// wisp_dependencies.issue_id is the child; depends_on_wisp_id is the parent molecule.
+const closedMoleculeStepSubquery = `
+	SELECT DISTINCT wd.issue_id
+	FROM wisp_dependencies wd
+	INNER JOIN wisps pm ON pm.id = wd.depends_on_wisp_id
+	WHERE wd.type = 'parent-child'
+	AND pm.issue_type = 'molecule'
+	AND pm.status = 'closed'
+	AND NOT EXISTS (
+		SELECT 1 FROM wisp_dependencies open_dep
+		LEFT JOIN wisps open_pw ON open_pw.id = open_dep.depends_on_wisp_id
+		LEFT JOIN issues open_pi ON open_pi.id = open_dep.depends_on_issue_id
+		WHERE open_dep.issue_id = wd.issue_id
+		AND open_dep.type = 'parent-child'
+		AND (open_pw.status IN ('open', 'hooked', 'in_progress') OR open_pi.status IN ('open', 'hooked', 'in_progress') OR open_dep.depends_on_external IS NOT NULL)
+	)`
+
+func closedMoleculeStepJoin(alias string) string {
+	return fmt.Sprintf("INNER JOIN (%s) %s ON %s.issue_id = w.id", closedMoleculeStepSubquery, alias, alias)
+}
+
+func closedMoleculeStepExcludeJoin(alias string) string {
+	return fmt.Sprintf("LEFT JOIN (%s) %s ON %s.issue_id = w.id", closedMoleculeStepSubquery, alias, alias)
+}
+
+type sqlRunner interface {
+	QueryContext(context.Context, string, ...interface{}) (*sql.Rows, error)
+	ExecContext(context.Context, string, ...interface{}) (sql.Result, error)
+	QueryRowContext(context.Context, string, ...interface{}) *sql.Row
 }
 
 // HasReaperSchema checks whether the database has the tables required for reaper
@@ -236,14 +272,24 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 	result := &ScanResult{Database: dbName}
 	now := time.Now().UTC()
 	parentJoin, parentWhere := parentExcludeJoin(dbName)
+	moleculeStepJoin := closedMoleculeStepJoin("closed_molecule_step")
+	moleculeStepExcludeJoin := closedMoleculeStepExcludeJoin("closed_molecule_step")
+
+	moleculeStepQuery := fmt.Sprintf(
+		"SELECT COUNT(*) FROM wisps w %s WHERE %s AND w.issue_type != 'agent'",
+		moleculeStepJoin, openWispStatusWhere)
+	if err := db.QueryRowContext(ctx, moleculeStepQuery).Scan(&result.MoleculeStepCandidates); err != nil {
+		return nil, fmt.Errorf("count molecule step candidates: %w", err)
+	}
 
 	// Count reap candidates: open wisps past max_age with eligible parent status.
 	// Must match Reap() eligibility semantics exactly, including the exclusion of
 	// agent beads, otherwise scan can report candidates that reap will never close.
 	// Uses LEFT JOIN anti-pattern instead of correlated EXISTS to avoid O(n*m) cost (gt-jd1z).
+	// Closed-molecule steps are counted separately above and excluded here so counts stay disjoint.
 	reapQuery := fmt.Sprintf(
-		"SELECT COUNT(*) FROM wisps w %s WHERE w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND w.issue_type != 'agent' AND %s",
-		parentJoin, parentWhere)
+		"SELECT COUNT(*) FROM wisps w %s %s WHERE %s AND w.created_at < ? AND w.issue_type != 'agent' AND %s AND closed_molecule_step.issue_id IS NULL",
+		parentJoin, moleculeStepExcludeJoin, openWispStatusWhere, parentWhere)
 	if err := db.QueryRowContext(ctx, reapQuery, now.Add(-maxAge)).Scan(&result.ReapCandidates); err != nil {
 		return nil, fmt.Errorf("count reap candidates: %w", err)
 	}
@@ -280,11 +326,11 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 		AND i.issue_type NOT IN ('epic', 'convoy')
 		AND i.id NOT IN (
 			SELECT DISTINCT d.issue_id FROM dependencies d
-			INNER JOIN issues dep ON d.depends_on_id = dep.id
+			INNER JOIN issues dep ON d.depends_on_issue_id = dep.id
 			WHERE dep.status IN ('open', 'in_progress')
 		)
 		AND i.id NOT IN (
-			SELECT DISTINCT d.depends_on_id FROM dependencies d
+			SELECT DISTINCT d.depends_on_issue_id FROM dependencies d
 			INNER JOIN issues blocker ON d.issue_id = blocker.id
 			WHERE blocker.status IN ('open', 'in_progress')
 		)`
@@ -304,8 +350,8 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 	// Anomaly detection: dangling parent references.
 	danglingQuery := `
 		SELECT COUNT(*) FROM wisp_dependencies wd
-		LEFT JOIN wisps pw ON pw.id = wd.depends_on_id LEFT JOIN issues pi ON pi.id = wd.depends_on_id
-		WHERE wd.type = 'parent-child' AND pw.id IS NULL AND pi.id IS NULL`
+		LEFT JOIN wisps pw ON pw.id = wd.depends_on_wisp_id LEFT JOIN issues pi ON pi.id = wd.depends_on_issue_id
+		WHERE wd.type = 'parent-child' AND wd.depends_on_external IS NULL AND pw.id IS NULL AND pi.id IS NULL`
 	var danglingCount int
 	if err := db.QueryRowContext(ctx, danglingQuery).Scan(&danglingCount); err == nil && danglingCount > 0 {
 		result.Anomalies = append(result.Anomalies, Anomaly{
@@ -327,15 +373,25 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 
 	cutoff := time.Now().UTC().Add(-maxAge)
 	parentJoin, parentWhere := parentExcludeJoin(dbName)
+	moleculeStepJoin := closedMoleculeStepJoin("closed_molecule_step")
+	moleculeStepExcludeJoin := closedMoleculeStepExcludeJoin("closed_molecule_step")
 	// Exclude agent beads (issue_type='agent') from reaping — they have persistent
 	// identity and should not be closed by the wisp reaper regardless of age.
+	// Closed-molecule steps are closed immediately through a separate path, so stale
+	// max-age counts exclude them to keep dry-run and scan counts disjoint.
 	whereClause := fmt.Sprintf(
-		"w.status IN ('open', 'hooked', 'in_progress') AND w.created_at < ? AND w.issue_type != 'agent' AND %s", parentWhere)
+		"%s AND w.created_at < ? AND w.issue_type != 'agent' AND %s AND closed_molecule_step.issue_id IS NULL", openWispStatusWhere, parentWhere)
 
 	result := &ReapResult{Database: dbName, DryRun: dryRun}
 
 	if dryRun {
-		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM wisps w %s WHERE %s", parentJoin, whereClause)
+		moleculeStepCountQuery := fmt.Sprintf(
+			"SELECT COUNT(*) FROM wisps w %s WHERE %s AND w.issue_type != 'agent'",
+			moleculeStepJoin, openWispStatusWhere)
+		if err := db.QueryRowContext(ctx, moleculeStepCountQuery).Scan(&result.MoleculeStepsClosed); err != nil {
+			return nil, fmt.Errorf("dry-run molecule step count: %w", err)
+		}
+		countQuery := fmt.Sprintf("SELECT COUNT(*) FROM wisps w %s %s WHERE %s", parentJoin, moleculeStepExcludeJoin, whereClause)
 		if err := db.QueryRowContext(ctx, countQuery, cutoff).Scan(&result.Reaped); err != nil {
 			return nil, fmt.Errorf("dry-run count: %w", err)
 		}
@@ -346,74 +402,58 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 		return result, nil
 	}
 
-	if _, err := db.ExecContext(ctx, "SET @@autocommit = 0"); err != nil {
+	conn, err := db.Conn(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("pin connection: %w", err)
+	}
+	defer conn.Close()
+
+	if _, err := conn.ExecContext(ctx, "SET @@autocommit = 0"); err != nil {
 		return nil, fmt.Errorf("disable autocommit: %w", err)
 	}
+	sqlCommitted := false
 	defer func() {
-		_, _ = db.ExecContext(context.Background(), "SET @@autocommit = 1")
+		if !sqlCommitted {
+			_, _ = conn.ExecContext(context.Background(), "ROLLBACK")
+		}
+		_, _ = conn.ExecContext(context.Background(), "SET @@autocommit = 1")
 	}()
+
+	moleculeStepIDQuery := fmt.Sprintf(
+		"SELECT w.id FROM wisps w %s WHERE %s AND w.issue_type != 'agent' LIMIT %d",
+		moleculeStepJoin, openWispStatusWhere, DefaultBatchSize)
+	moleculeStepsClosed, err := closeWispsInBatches(ctx, conn, moleculeStepIDQuery, nil, "closed molecule steps")
+	if err != nil {
+		return nil, err
+	}
+	result.MoleculeStepsClosed = moleculeStepsClosed
 
 	// Batch UPDATE: select IDs in chunks, update each chunk.
 	// This avoids holding a write lock on the entire table for minutes.
 	// Uses LEFT JOIN anti-pattern instead of correlated EXISTS to avoid O(n*m) cost (gt-jd1z).
 	idQuery := fmt.Sprintf(
-		"SELECT w.id FROM wisps w %s WHERE %s LIMIT %d",
-		parentJoin, whereClause, DefaultBatchSize)
+		"SELECT w.id FROM wisps w %s %s WHERE %s LIMIT %d",
+		parentJoin, moleculeStepExcludeJoin, whereClause, DefaultBatchSize)
 
-	totalReaped := 0
-	for {
-		rows, err := db.QueryContext(ctx, idQuery, cutoff)
-		if err != nil {
-			return nil, fmt.Errorf("select reap batch: %w", err)
-		}
-
-		var ids []string
-		for rows.Next() {
-			var id string
-			if err := rows.Scan(&id); err != nil {
-				rows.Close()
-				return nil, fmt.Errorf("scan wisp id: %w", err)
-			}
-			ids = append(ids, id)
-		}
-		rows.Close()
-
-		if len(ids) == 0 {
-			break
-		}
-
-		placeholders := make([]string, len(ids))
-		args := make([]interface{}, len(ids))
-		for i, id := range ids {
-			placeholders[i] = "?"
-			args[i] = id
-		}
-		inClause := strings.Join(placeholders, ",")
-
-		updateQuery := fmt.Sprintf(
-			"UPDATE wisps SET status='closed', closed_at=NOW() WHERE id IN (%s)",
-			inClause)
-		sqlResult, err := db.ExecContext(ctx, updateQuery, args...)
-		if err != nil {
-			return nil, fmt.Errorf("close stale wisps batch: %w", err)
-		}
-
-		affected, _ := sqlResult.RowsAffected()
-		totalReaped += int(affected)
+	totalReaped, err := closeWispsInBatches(ctx, conn, idQuery, []interface{}{cutoff}, "stale wisps")
+	if err != nil {
+		return nil, err
 	}
 
 	result.Reaped = totalReaped
+	totalClosed := totalReaped + moleculeStepsClosed
 
-	if totalReaped > 0 {
+	if totalClosed > 0 {
 		// Flush the SQL transaction to the Dolt working set before DOLT_COMMIT.
 		// With autocommit=0, UPDATE changes are in the SQL transaction buffer,
 		// not the Dolt working set. DOLT_COMMIT operates on the working set,
 		// so without this COMMIT it sees "nothing to commit".
-		if _, err := db.ExecContext(ctx, "COMMIT"); err != nil {
+		if _, err := conn.ExecContext(ctx, "COMMIT"); err != nil {
 			return result, fmt.Errorf("sql commit: %w", err)
 		}
-		commitMsg := fmt.Sprintf("reaper: close %d stale wisps in %s", totalReaped, dbName)
-		if _, err := db.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
+		sqlCommitted = true
+		commitMsg := fmt.Sprintf("reaper: close %d wisps in %s", totalClosed, dbName)
+		if _, err := conn.ExecContext(ctx, fmt.Sprintf("CALL DOLT_COMMIT('-Am', '%s')", commitMsg)); err != nil { //nolint:gosec // G201: commitMsg from safe values
 			// "nothing to commit" is expected when the reaper reverts dirty working
 			// set changes back to match HEAD. The wisps were set to "open" in the
 			// server's in-memory working set without being committed; closing them
@@ -425,11 +465,59 @@ func Reap(db *sql.DB, dbName string, maxAge time.Duration, dryRun bool) (*ReapRe
 	}
 
 	openQuery := "SELECT COUNT(*) FROM wisps WHERE status IN ('open', 'hooked', 'in_progress')"
-	if err := db.QueryRowContext(ctx, openQuery).Scan(&result.OpenRemain); err != nil {
+	if err := conn.QueryRowContext(ctx, openQuery).Scan(&result.OpenRemain); err != nil {
 		return result, fmt.Errorf("count open: %w", err)
 	}
 
 	return result, nil
+}
+
+func closeWispsInBatches(ctx context.Context, runner sqlRunner, idQuery string, queryArgs []interface{}, description string) (int, error) {
+	total := 0
+	for {
+		rows, err := runner.QueryContext(ctx, idQuery, queryArgs...)
+		if err != nil {
+			return total, fmt.Errorf("select %s batch: %w", description, err)
+		}
+
+		var ids []string
+		for rows.Next() {
+			var id string
+			if err := rows.Scan(&id); err != nil {
+				rows.Close()
+				return total, fmt.Errorf("scan %s id: %w", description, err)
+			}
+			ids = append(ids, id)
+		}
+		if err := rows.Err(); err != nil {
+			rows.Close()
+			return total, fmt.Errorf("read %s ids: %w", description, err)
+		}
+		rows.Close()
+
+		if len(ids) == 0 {
+			return total, nil
+		}
+
+		placeholders := make([]string, len(ids))
+		args := make([]interface{}, len(ids))
+		for i, id := range ids {
+			placeholders[i] = "?"
+			args[i] = id
+		}
+		inClause := strings.Join(placeholders, ",")
+
+		updateQuery := fmt.Sprintf(
+			"UPDATE wisps SET status='closed', closed_at=NOW() WHERE id IN (%s) AND status IN ('open', 'hooked', 'in_progress') AND issue_type != 'agent'",
+			inClause)
+		sqlResult, err := runner.ExecContext(ctx, updateQuery, args...)
+		if err != nil {
+			return total, fmt.Errorf("close %s batch: %w", description, err)
+		}
+
+		affected, _ := sqlResult.RowsAffected()
+		total += int(affected)
+	}
 }
 
 // Purge deletes old closed wisps and mail from a database.
@@ -612,11 +700,11 @@ func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (
 		)
 		AND i.id NOT IN (
 			SELECT DISTINCT d.issue_id FROM `+"`%s`"+`.dependencies d
-			INNER JOIN `+"`%s`"+`.issues dep ON d.depends_on_id = dep.id
+			INNER JOIN `+"`%s`"+`.issues dep ON d.depends_on_issue_id = dep.id
 			WHERE dep.status IN ('open', 'in_progress')
 		)
 		AND i.id NOT IN (
-			SELECT DISTINCT d.depends_on_id FROM `+"`%s`"+`.dependencies d
+			SELECT DISTINCT d.depends_on_issue_id FROM `+"`%s`"+`.dependencies d
 			INNER JOIN `+"`%s`"+`.issues blocker ON d.issue_id = blocker.id
 			WHERE blocker.status IN ('open', 'in_progress')
 		)`, dbName, dbName, dbName, dbName, dbName)
@@ -755,7 +843,7 @@ func batchDeleteRows(ctx context.Context, db *sql.DB, idQuery string, cutoffArg 
 		}
 
 		// Clean up reverse dependency references to prevent dangling parent refs.
-		delReverse := fmt.Sprintf("DELETE FROM wisp_dependencies WHERE depends_on_id IN %s", inClause)
+		delReverse := fmt.Sprintf("DELETE FROM wisp_dependencies WHERE depends_on_wisp_id IN %s", inClause)
 		if _, err := db.ExecContext(ctx, delReverse, args...); err != nil {
 			// Non-fatal.
 		}

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -257,11 +257,46 @@ func HasReaperSchema(db *sql.DB) (bool, error) {
 
 	var count int
 	err := db.QueryRowContext(ctx,
-		"SELECT COUNT(*) FROM information_schema.tables WHERE table_name IN ('wisps', 'issues') AND table_schema = DATABASE()").Scan(&count)
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_name IN ('wisps', 'issues', 'wisp_dependencies') AND table_schema = DATABASE()").Scan(&count)
 	if err != nil {
 		return false, fmt.Errorf("check reaper schema: %w", err)
 	}
-	return count >= 2, nil
+	if count < 3 {
+		return false, nil
+	}
+
+	hasWispDependencyColumns, err := hasColumns(ctx, db, "wisp_dependencies", "depends_on_issue_id", "depends_on_wisp_id", "depends_on_external")
+	if err != nil || !hasWispDependencyColumns {
+		return hasWispDependencyColumns, err
+	}
+	dependenciesExists, err := tableExists(ctx, db, "dependencies")
+	if err != nil || !dependenciesExists {
+		return !dependenciesExists, err
+	}
+	return hasColumns(ctx, db, "dependencies", "depends_on_issue_id")
+}
+
+func tableExists(ctx context.Context, db *sql.DB, table string) (bool, error) {
+	var count int
+	err := db.QueryRowContext(ctx,
+		"SELECT COUNT(*) FROM information_schema.tables WHERE table_name = ? AND table_schema = DATABASE()", table).Scan(&count)
+	return count > 0, err
+}
+
+func hasColumns(ctx context.Context, db *sql.DB, table string, columns ...string) (bool, error) {
+	if len(columns) == 0 {
+		return true, nil
+	}
+	placeholders := strings.TrimRight(strings.Repeat("?,", len(columns)), ",")
+	args := make([]interface{}, 0, len(columns)+1)
+	args = append(args, table)
+	for _, column := range columns {
+		args = append(args, column)
+	}
+	var count int
+	query := fmt.Sprintf("SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = ? AND column_name IN (%s)", placeholders)
+	err := db.QueryRowContext(ctx, query, args...).Scan(&count)
+	return count == len(columns), err
 }
 
 // Scan counts reaper candidates in a database without modifying anything.
@@ -332,7 +367,8 @@ func Scan(db *sql.DB, dbName string, maxAge, purgeAge, mailDeleteAge, staleIssue
 		AND i.id NOT IN (
 			SELECT DISTINCT d.depends_on_issue_id FROM dependencies d
 			INNER JOIN issues blocker ON d.issue_id = blocker.id
-			WHERE blocker.status IN ('open', 'in_progress')
+			WHERE d.depends_on_issue_id IS NOT NULL
+			AND blocker.status IN ('open', 'in_progress')
 		)`
 	if err := db.QueryRowContext(ctx, staleQuery, now.Add(-staleIssueAge)).Scan(&result.StaleCandidates); err != nil {
 		if !isTableNotFound(err) {
@@ -706,7 +742,8 @@ func AutoClose(db *sql.DB, dbName string, staleAge time.Duration, dryRun bool) (
 		AND i.id NOT IN (
 			SELECT DISTINCT d.depends_on_issue_id FROM `+"`%s`"+`.dependencies d
 			INNER JOIN `+"`%s`"+`.issues blocker ON d.issue_id = blocker.id
-			WHERE blocker.status IN ('open', 'in_progress')
+			WHERE d.depends_on_issue_id IS NOT NULL
+			AND blocker.status IN ('open', 'in_progress')
 		)`, dbName, dbName, dbName, dbName, dbName)
 
 	// Two-step SELECT-then-UPDATE to avoid self-referencing subquery in UPDATE,

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -1,10 +1,19 @@
 package reaper
 
 import (
+	"context"
+	"database/sql"
+	"database/sql/driver"
 	"fmt"
+	"io"
 	"os"
+	"reflect"
+	"sort"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
+	"time"
 )
 
 func TestValidateDBName(t *testing.T) {
@@ -245,4 +254,473 @@ func TestScanExcludesAgentBeads(t *testing.T) {
 	if !strings.Contains(scanBody, "w.issue_type != 'agent'") {
 		t.Fatalf("expected Scan() eligibility to exclude agent beads, scan body was:\n%s", scanBody)
 	}
+}
+
+func TestClosedMoleculeStepReapBehavior(t *testing.T) {
+	now := time.Now().UTC()
+	state := &fakeReaperState{
+		wisps: map[string]*fakeWisp{
+			"mol-closed":               {id: "mol-closed", status: "closed", issueType: "molecule", createdAt: now},
+			"mol-open":                 {id: "mol-open", status: "open", issueType: "molecule", createdAt: now},
+			"closed-epic":              {id: "closed-epic", status: "closed", issueType: "epic", createdAt: now},
+			"step-closed-mol-recent":   {id: "step-closed-mol-recent", status: "open", issueType: "task", createdAt: now.Add(-1 * time.Hour)},
+			"step-closed-mol-old":      {id: "step-closed-mol-old", status: "open", issueType: "task", createdAt: now.Add(-48 * time.Hour)},
+			"step-mixed-parent-old":    {id: "step-mixed-parent-old", status: "open", issueType: "task", createdAt: now.Add(-48 * time.Hour)},
+			"step-external-parent-old": {id: "step-external-parent-old", status: "open", issueType: "task", createdAt: now.Add(-48 * time.Hour)},
+			"step-open-parent-old":     {id: "step-open-parent-old", status: "open", issueType: "task", createdAt: now.Add(-48 * time.Hour)},
+			"step-non-molecule-parent": {id: "step-non-molecule-parent", status: "open", issueType: "task", createdAt: now.Add(-48 * time.Hour)},
+			"agent-step":               {id: "agent-step", status: "open", issueType: "agent", createdAt: now.Add(-48 * time.Hour)},
+			"stale-orphan":             {id: "stale-orphan", status: "open", issueType: "task", createdAt: now.Add(-48 * time.Hour)},
+			"fresh-orphan":             {id: "fresh-orphan", status: "open", issueType: "task", createdAt: now.Add(-1 * time.Hour)},
+		},
+		deps: []fakeDep{
+			{issueID: "step-closed-mol-recent", dependsOnID: "mol-closed", depType: "parent-child"},
+			{issueID: "step-closed-mol-old", dependsOnID: "mol-closed", depType: "parent-child"},
+			{issueID: "step-mixed-parent-old", dependsOnID: "mol-closed", depType: "parent-child"},
+			{issueID: "step-mixed-parent-old", dependsOnID: "mol-open", depType: "parent-child"},
+			{issueID: "step-external-parent-old", dependsOnID: "mol-closed", depType: "parent-child"},
+			{issueID: "step-external-parent-old", dependsOnExternal: "external:other", depType: "parent-child"},
+			{issueID: "step-open-parent-old", dependsOnID: "mol-open", depType: "parent-child"},
+			{issueID: "step-non-molecule-parent", dependsOnID: "closed-epic", depType: "parent-child"},
+			{issueID: "agent-step", dependsOnID: "mol-closed", depType: "parent-child"},
+		},
+		ops: map[int][]string{},
+	}
+	db := openFakeReaperDB(t, state)
+	t.Cleanup(func() { _ = db.Close() })
+
+	maxAge := 24 * time.Hour
+	scan, err := Scan(db, "testdb", maxAge, 7*24*time.Hour, 7*24*time.Hour, 30*24*time.Hour)
+	if err != nil {
+		t.Fatalf("Scan: %v", err)
+	}
+	if scan.MoleculeStepCandidates != 2 {
+		t.Fatalf("Scan MoleculeStepCandidates = %d, want 2", scan.MoleculeStepCandidates)
+	}
+	if scan.ReapCandidates != 2 {
+		t.Fatalf("Scan ReapCandidates = %d, want 2", scan.ReapCandidates)
+	}
+
+	beforeDryRun := state.statuses()
+	dryRun, err := Reap(db, "testdb", maxAge, true)
+	if err != nil {
+		t.Fatalf("dry-run Reap: %v", err)
+	}
+	if dryRun.MoleculeStepsClosed != 2 {
+		t.Fatalf("dry-run MoleculeStepsClosed = %d, want 2", dryRun.MoleculeStepsClosed)
+	}
+	if dryRun.Reaped != 2 {
+		t.Fatalf("dry-run Reaped = %d, want 2", dryRun.Reaped)
+	}
+	if dryRun.OpenRemain != 10 {
+		t.Fatalf("dry-run OpenRemain = %d, want 10", dryRun.OpenRemain)
+	}
+	if afterDryRun := state.statuses(); !reflect.DeepEqual(afterDryRun, beforeDryRun) {
+		t.Fatalf("dry-run mutated statuses: before=%v after=%v", beforeDryRun, afterDryRun)
+	}
+
+	preRealOps := state.opCounts()
+	realRun, err := Reap(db, "testdb", maxAge, false)
+	if err != nil {
+		t.Fatalf("real Reap: %v", err)
+	}
+	if realRun.MoleculeStepsClosed != 2 {
+		t.Fatalf("real MoleculeStepsClosed = %d, want 2", realRun.MoleculeStepsClosed)
+	}
+	if realRun.Reaped != 2 {
+		t.Fatalf("real Reaped = %d, want 2", realRun.Reaped)
+	}
+	if realRun.OpenRemain != 6 {
+		t.Fatalf("real OpenRemain = %d, want 6", realRun.OpenRemain)
+	}
+
+	for _, id := range []string{"step-closed-mol-recent", "step-closed-mol-old", "step-non-molecule-parent", "stale-orphan"} {
+		if got := state.status(id); got != "closed" {
+			t.Fatalf("%s status = %q, want closed", id, got)
+		}
+	}
+	for _, id := range []string{"step-mixed-parent-old", "step-external-parent-old", "step-open-parent-old", "agent-step", "fresh-orphan", "mol-open"} {
+		if got := state.status(id); got != "open" {
+			t.Fatalf("%s status = %q, want open", id, got)
+		}
+	}
+	realOps := state.opsSince(preRealOps)
+	if len(realOps) != 1 {
+		t.Fatalf("real Reap used %d connections, want 1: %#v", len(realOps), realOps)
+	}
+	for connID, ops := range realOps {
+		assertOpsContainInOrder(t, ops,
+			"EXEC SET @@autocommit = 0",
+			"QUERY SELECT w.id FROM wisps w INNER JOIN",
+			"EXEC UPDATE wisps SET status='closed'",
+			"QUERY SELECT w.id FROM wisps w LEFT JOIN",
+			"EXEC UPDATE wisps SET status='closed'",
+			"EXEC COMMIT",
+			"EXEC CALL DOLT_COMMIT",
+			"QUERY SELECT COUNT(*) FROM wisps WHERE status IN",
+			"EXEC SET @@autocommit = 1",
+		)
+		t.Logf("real Reap used pinned connection %d", connID)
+	}
+}
+
+var fakeReaperDriverID uint64
+
+func openFakeReaperDB(t *testing.T, state *fakeReaperState) *sql.DB {
+	t.Helper()
+	driverName := fmt.Sprintf("fake_reaper_%d", atomic.AddUint64(&fakeReaperDriverID, 1))
+	sql.Register(driverName, &fakeReaperDriver{state: state})
+	db, err := sql.Open(driverName, "")
+	if err != nil {
+		t.Fatalf("open fake db: %v", err)
+	}
+	return db
+}
+
+type fakeWisp struct {
+	id        string
+	status    string
+	issueType string
+	createdAt time.Time
+}
+
+type fakeDep struct {
+	issueID           string
+	dependsOnID       string
+	dependsOnExternal string
+	depType           string
+}
+
+type fakeReaperState struct {
+	mu       sync.Mutex
+	wisps    map[string]*fakeWisp
+	deps     []fakeDep
+	nextConn int
+	ops      map[int][]string
+}
+
+func (s *fakeReaperState) status(id string) string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.wisps[id].status
+}
+
+func (s *fakeReaperState) statuses() map[string]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	statuses := make(map[string]string, len(s.wisps))
+	for id, w := range s.wisps {
+		statuses[id] = w.status
+	}
+	return statuses
+}
+
+func (s *fakeReaperState) opCounts() map[int]int {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	counts := make(map[int]int, len(s.ops))
+	for connID, ops := range s.ops {
+		counts[connID] = len(ops)
+	}
+	return counts
+}
+
+func (s *fakeReaperState) opsSince(counts map[int]int) map[int][]string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	opsSince := map[int][]string{}
+	for connID, ops := range s.ops {
+		start := counts[connID]
+		if start < len(ops) {
+			opsSince[connID] = append([]string(nil), ops[start:]...)
+		}
+	}
+	return opsSince
+}
+
+func (s *fakeReaperState) record(connID int, op string) {
+	s.ops[connID] = append(s.ops[connID], normalizeSQL(op))
+}
+
+func (s *fakeReaperState) moleculeStepCandidatesLocked() []string {
+	var ids []string
+	for id := range s.wisps {
+		if s.isMoleculeStepCandidateLocked(id) {
+			ids = append(ids, id)
+		}
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func (s *fakeReaperState) isMoleculeStepCandidateLocked(id string) bool {
+	w := s.wisps[id]
+	if w == nil || !isOpenWispStatus(w.status) || w.issueType == "agent" {
+		return false
+	}
+	for _, dep := range s.deps {
+		if dep.issueID != id || dep.depType != "parent-child" {
+			continue
+		}
+		if dep.dependsOnExternal != "" {
+			return false
+		}
+		if s.hasOpenParentLocked(id) {
+			return false
+		}
+		parent := s.wisps[dep.dependsOnID]
+		if parent != nil && parent.issueType == "molecule" && parent.status == "closed" {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *fakeReaperState) staleCandidatesLocked(cutoff time.Time, excludeMoleculeSteps bool) []string {
+	var ids []string
+	for id, w := range s.wisps {
+		if !isOpenWispStatus(w.status) || w.issueType == "agent" || !w.createdAt.Before(cutoff) {
+			continue
+		}
+		if s.hasOpenParentLocked(id) {
+			continue
+		}
+		if excludeMoleculeSteps && s.isMoleculeStepCandidateLocked(id) {
+			continue
+		}
+		ids = append(ids, id)
+	}
+	sort.Strings(ids)
+	return ids
+}
+
+func (s *fakeReaperState) hasOpenParentLocked(id string) bool {
+	for _, dep := range s.deps {
+		if dep.issueID != id || dep.depType != "parent-child" {
+			continue
+		}
+		if dep.dependsOnExternal != "" {
+			return true
+		}
+		parent := s.wisps[dep.dependsOnID]
+		if parent != nil && isOpenWispStatus(parent.status) {
+			return true
+		}
+	}
+	return false
+}
+
+func (s *fakeReaperState) openCountLocked() int {
+	count := 0
+	for _, w := range s.wisps {
+		if isOpenWispStatus(w.status) {
+			count++
+		}
+	}
+	return count
+}
+
+type fakeReaperDriver struct {
+	state *fakeReaperState
+}
+
+func (d *fakeReaperDriver) Open(string) (driver.Conn, error) {
+	d.state.mu.Lock()
+	defer d.state.mu.Unlock()
+	d.state.nextConn++
+	connID := d.state.nextConn
+	d.state.ops[connID] = nil
+	return &fakeReaperConn{state: d.state, id: connID}, nil
+}
+
+type fakeReaperConn struct {
+	state *fakeReaperState
+	id    int
+}
+
+func (c *fakeReaperConn) Prepare(string) (driver.Stmt, error) {
+	return nil, fmt.Errorf("prepare not implemented")
+}
+
+func (c *fakeReaperConn) Close() error { return nil }
+
+func (c *fakeReaperConn) Begin() (driver.Tx, error) { return fakeReaperTx{}, nil }
+
+func (c *fakeReaperConn) CheckNamedValue(*driver.NamedValue) error { return nil }
+
+func (c *fakeReaperConn) QueryContext(_ context.Context, query string, args []driver.NamedValue) (driver.Rows, error) {
+	normalized := normalizeSQL(query)
+	c.state.mu.Lock()
+	defer c.state.mu.Unlock()
+	c.state.record(c.id, "QUERY "+normalized)
+
+	switch {
+	case strings.Contains(normalized, "SELECT COUNT(*) FROM wisps w") && strings.Contains(normalized, "created_at <"):
+		if err := validateStaleWispQuery(normalized); err != nil {
+			return nil, err
+		}
+		return fakeCountRows(len(c.state.staleCandidatesLocked(namedTime(args), strings.Contains(normalized, "closed_molecule_step.issue_id IS NULL")))), nil
+	case strings.Contains(normalized, "SELECT COUNT(*) FROM wisps w") && strings.Contains(normalized, "pm.issue_type = 'molecule'"):
+		if err := validateMoleculeStepQuery(normalized); err != nil {
+			return nil, err
+		}
+		return fakeCountRows(len(c.state.moleculeStepCandidatesLocked())), nil
+	case strings.Contains(normalized, "SELECT COUNT(*) FROM wisps WHERE status IN"):
+		return fakeCountRows(c.state.openCountLocked()), nil
+	case strings.Contains(normalized, "SELECT COUNT(*) FROM wisps w WHERE w.status = 'closed'"):
+		return fakeCountRows(0), nil
+	case strings.Contains(normalized, "SELECT COUNT(*) FROM issues"):
+		return fakeCountRows(0), nil
+	case strings.Contains(normalized, "SELECT COUNT(*) FROM wisp_dependencies wd"):
+		return fakeCountRows(0), nil
+	case strings.Contains(normalized, "SELECT w.id FROM wisps w") && strings.Contains(normalized, "created_at <"):
+		if err := validateStaleWispQuery(normalized); err != nil {
+			return nil, err
+		}
+		return fakeIDRows(c.state.staleCandidatesLocked(namedTime(args), strings.Contains(normalized, "closed_molecule_step.issue_id IS NULL"))), nil
+	case strings.Contains(normalized, "SELECT w.id FROM wisps w") && strings.Contains(normalized, "pm.issue_type = 'molecule'"):
+		if err := validateMoleculeStepQuery(normalized); err != nil {
+			return nil, err
+		}
+		return fakeIDRows(c.state.moleculeStepCandidatesLocked()), nil
+	default:
+		return nil, fmt.Errorf("unexpected query: %s", normalized)
+	}
+}
+
+func (c *fakeReaperConn) ExecContext(_ context.Context, query string, args []driver.NamedValue) (driver.Result, error) {
+	normalized := normalizeSQL(query)
+	c.state.mu.Lock()
+	defer c.state.mu.Unlock()
+	c.state.record(c.id, "EXEC "+normalized)
+
+	switch {
+	case strings.HasPrefix(normalized, "UPDATE wisps SET status='closed'"):
+		affected := int64(0)
+		for _, arg := range args {
+			id, _ := arg.Value.(string)
+			if w := c.state.wisps[id]; w != nil && isOpenWispStatus(w.status) {
+				w.status = "closed"
+				affected++
+			}
+		}
+		return fakeReaperResult(affected), nil
+	case normalized == "SET @@autocommit = 0" || normalized == "SET @@autocommit = 1" || normalized == "ROLLBACK" || normalized == "COMMIT" || strings.HasPrefix(normalized, "CALL DOLT_COMMIT"):
+		return fakeReaperResult(0), nil
+	default:
+		return nil, fmt.Errorf("unexpected exec: %s", normalized)
+	}
+}
+
+type fakeReaperTx struct{}
+
+func (fakeReaperTx) Commit() error   { return nil }
+func (fakeReaperTx) Rollback() error { return nil }
+
+type fakeReaperResult int64
+
+func (r fakeReaperResult) LastInsertId() (int64, error) { return 0, nil }
+func (r fakeReaperResult) RowsAffected() (int64, error) { return int64(r), nil }
+
+type fakeReaperRows struct {
+	cols []string
+	rows [][]driver.Value
+	next int
+}
+
+func fakeCountRows(count int) *fakeReaperRows {
+	return &fakeReaperRows{cols: []string{"count"}, rows: [][]driver.Value{{int64(count)}}}
+}
+
+func fakeIDRows(ids []string) *fakeReaperRows {
+	rows := make([][]driver.Value, len(ids))
+	for i, id := range ids {
+		rows[i] = []driver.Value{id}
+	}
+	return &fakeReaperRows{cols: []string{"id"}, rows: rows}
+}
+
+func (r *fakeReaperRows) Columns() []string { return r.cols }
+func (r *fakeReaperRows) Close() error      { return nil }
+
+func (r *fakeReaperRows) Next(dest []driver.Value) error {
+	if r.next >= len(r.rows) {
+		return io.EOF
+	}
+	copy(dest, r.rows[r.next])
+	r.next++
+	return nil
+}
+
+func namedTime(args []driver.NamedValue) time.Time {
+	if len(args) == 0 {
+		return time.Time{}
+	}
+	if value, ok := args[0].Value.(time.Time); ok {
+		return value
+	}
+	return time.Time{}
+}
+
+func isOpenWispStatus(status string) bool {
+	return status == "open" || status == "hooked" || status == "in_progress"
+}
+
+func normalizeSQL(query string) string {
+	return strings.Join(strings.Fields(query), " ")
+}
+
+func validateMoleculeStepQuery(query string) error {
+	return requireSQL(query,
+		"wd.issue_id",
+		"pm.id = wd.depends_on_wisp_id",
+		"wd.type = 'parent-child'",
+		"pm.issue_type = 'molecule'",
+		"pm.status = 'closed'",
+		"NOT EXISTS",
+		"open_dep.depends_on_external IS NOT NULL",
+		"w.issue_type != 'agent'",
+		"w.status IN ('open', 'hooked', 'in_progress')",
+	)
+}
+
+func validateStaleWispQuery(query string) error {
+	return requireSQL(query,
+		"wd.issue_id",
+		"pw.id = wd.depends_on_wisp_id",
+		"pi.id = wd.depends_on_issue_id",
+		"pi.status IN ('open', 'hooked', 'in_progress')",
+		"depends_on_external IS NOT NULL",
+		"wd.type = 'parent-child'",
+		"w.issue_type != 'agent'",
+		"w.created_at < ?",
+		"open_parent.issue_id IS NULL",
+		"closed_molecule_step.issue_id IS NULL",
+	)
+}
+
+func requireSQL(query string, required ...string) error {
+	if strings.Contains(query, "depends_on_id") {
+		return fmt.Errorf("query uses legacy depends_on_id column: %s", query)
+	}
+	for _, want := range required {
+		if !strings.Contains(query, want) {
+			return fmt.Errorf("query missing %q: %s", want, query)
+		}
+	}
+	return nil
+}
+
+func assertOpsContainInOrder(t *testing.T, ops []string, want ...string) {
+	t.Helper()
+	next := 0
+	for _, op := range ops {
+		if strings.Contains(op, want[next]) {
+			next++
+			if next == len(want) {
+				return
+			}
+		}
+	}
+	t.Fatalf("ops missing ordered sequence %v in %v", want[next:], ops)
 }


### PR DESCRIPTION
Replacement for contributor PR #4233. Do not accept #4233 as-is: original CI failed and the patch did not cover current split dependency schema, scan visibility, disjoint reap counts, pinned connection behavior, or legacy wisp dependency migration. This branch is a clean upstream/main replacement with Sean Bearden preserved as commit author.

Divergence gates:
- upstream/main...HEAD: 0 2
- origin/main...HEAD: 107 557. This intentionally rejects fork origin/main as a base because fork main is divergent; this PR targets gastownhall/gastown:main.

Research legs:
- R1 original SQL/schema assumptions were incomplete for current dependency storage.
- R2 closed molecule step cleanup must be separate from max-age stale reap counts.
- R3 mutating reap needs one pinned SQL connection for autocommit, COMMIT, DOLT_COMMIT, and final count.
- R4 scan output must expose molecule step candidates so dog patrol does not skip work.
- R5 zero-count text output should stay quiet/backward-compatible.
- R6 dry-run must report molecule steps without mutating.
- R7 only open/hooked/in_progress non-agent child wisps under closed molecule parents are eligible.
- R8 open/hooked/in_progress or external parents must block closure.
- R9 stale reap must exclude closed-molecule-step candidates.
- R10 batch updates should stay parameterized and bounded.
- R11 legacy runtime shims are avoided; persisted legacy wisp dependency tables get migrated.
- R12 original #4233 remains a valid bugfix direction but is not mergeable as-is.
- R13 contributor attribution is preserved in replacement commits.
- R14 live scan/dry-run checks must be part of validation.
- R15 replacement #4267 is not reused because this branch is cleaner and addresses final review blockers.

Pre-implementation reviews:
- P1 PASS scoped selector is valid when using current split dependency columns.
- P2 PASS connection pinning is required for mutation and Dolt commit consistency.
- P3 PASS scan/reap result fields are additive and zero-count text should remain quiet.
- P4 PASS behavioral fake driver coverage is appropriate for selector/disjointness/connection sequencing.
- P5 PASS legacy persisted schema needs a migration path, not a runtime compatibility shim.

Post-implementation reviews:
- V1 PASS clean branch is upstream-based with Sean-authored commits and no WIP commit.
- V2 PASS NOT IN NULL issue fixed with depends_on_issue_id IS NOT NULL guards.
- V3 PASS external/open/multi-parent blockers and status/agent update guards verified.
- V4 PASS reaper/migration/compact/doctor paths converge on split dependency schema with legacy table rebuild.
- V5 PASS publish replacement PR; do not accept original #4233 as-is.

Verification:
- go test ./internal/reaper -count=1
- CGO_ENABLED=0 go test -short ./internal/cmd -run TestReaper|TestCompact|^$ -count=1
- CGO_ENABLED=0 go test ./internal/doctor -count=1
- CGO_ENABLED=0 go test ./internal/doltserver -run ^$ -count=1
- CGO_ENABLED=0 go build -o /tmp/opencode/gt-ghoul-4233 ./cmd/gt
- CGO_ENABLED=0 go test -c -o /tmp/opencode/daemon-ghoul-4233.test ./internal/daemon
- git diff --check upstream/main...HEAD
- CGO_ENABLED=0 go run ./cmd/gt reaper scan --db=hq --json --db-delay=0
- CGO_ENABLED=0 go run ./cmd/gt reaper reap --db=hq --dry-run --json --db-delay=0
- CGO_ENABLED=0 go run ./cmd/gt reaper scan --db=gastown --json --db-delay=0
- CGO_ENABLED=0 go run ./cmd/gt reaper reap --db=gastown --dry-run --json --db-delay=0

Known local environment note: full cgo package tests are blocked here by missing ICU linker libraries. Full internal/doltserver has an unrelated existing stale socket failure noted by reviewers.

Original contributor: Sean Bearden <72461227+seanbearden@users.noreply.github.com>.