### PR TITLE
fix(daemon): retry dog wisp close + harden dolt backup (gt-ye21)

### DIFF
--- a/internal/daemon/dog_molecule.go
+++ b/internal/daemon/dog_molecule.go
@@ -16,7 +16,32 @@ import (
 const (
 	// bdMolTimeout is the timeout for bd molecule operations.
 	bdMolTimeout = 15 * time.Second
+
+	// dogCloseMaxAttempts / dogCloseRetryDelay bound the retry on `bd close` for
+	// dog wisps. A transient Dolt slowdown (the connection-churn window) can make
+	// a single close fail, and without a retry the wisp stays OPEN forever — a
+	// root cause of the dog wisp flood (gt-ye21). Retrying turns a transient
+	// failure back into a clean close instead of a permanent orphan.
+	dogCloseMaxAttempts = 3
+	dogCloseRetryDelay  = 500 * time.Millisecond
 )
+
+// closeWisp runs `bd close <id>` (plus any extra args) with bounded retries so a
+// transient Dolt error does not leave the wisp open. Returns the final error if
+// every attempt fails.
+func (dm *dogMol) closeWisp(id string, extra ...string) error {
+	args := append([]string{"close", id}, extra...)
+	var err error
+	for attempt := 1; attempt <= dogCloseMaxAttempts; attempt++ {
+		if _, err = dm.runBd(args...); err == nil {
+			return nil
+		}
+		if attempt < dogCloseMaxAttempts {
+			time.Sleep(time.Duration(attempt) * dogCloseRetryDelay)
+		}
+	}
+	return err
+}
 
 // dogMol tracks a molecule (wisp) lifecycle for a daemon dog patrol.
 // Graceful degradation: if bd fails, the dog still does its work — molecule
@@ -115,9 +140,8 @@ func (dm *dogMol) close() {
 	// Close any step wisps that were never explicitly closed/failed.
 	dm.closeRemainingSteps()
 
-	_, err := dm.runBd("close", dm.rootID)
-	if err != nil {
-		dm.logger.Printf("dog_molecule: close root %s failed (non-fatal): %v", dm.rootID, err)
+	if err := dm.closeWisp(dm.rootID); err != nil {
+		dm.logger.Printf("dog_molecule: close root %s failed after %d attempts (non-fatal): %v", dm.rootID, dogCloseMaxAttempts, err)
 	}
 }
 
@@ -148,8 +172,8 @@ func (dm *dogMol) closeRemainingSteps() {
 		}
 		// Close any child that is still open/hooked/in_progress.
 		if child.Status == "open" || child.Status == "hooked" || child.Status == "in_progress" {
-			if _, err := dm.runBd("close", child.ID); err != nil {
-				dm.logger.Printf("dog_molecule: closeRemainingSteps: close %s failed: %v", child.ID, err)
+			if err := dm.closeWisp(child.ID); err != nil {
+				dm.logger.Printf("dog_molecule: closeRemainingSteps: close %s failed after %d attempts: %v", child.ID, dogCloseMaxAttempts, err)
 			} else {
 				closed++
 			}

--- a/internal/daemon/dolt_backup.go
+++ b/internal/daemon/dolt_backup.go
@@ -16,7 +16,15 @@ import (
 
 const (
 	defaultDoltBackupInterval = 15 * time.Minute
-	doltBackupTimeout         = 120 * time.Second
+	// doltBackupTimeout is generous so a large commit delta on a big database
+	// (e.g. hq under a wisp flood) does not blow the deadline mid-sync. The old
+	// 120s ceiling produced spurious exit-1 backup failures (gt-ye21).
+	doltBackupTimeout = 5 * time.Minute
+	// doltBackupRetries / doltBackupRetryDelay retry a failed sync after a short
+	// pause, so a transient lock (a concurrent dolt op holding the db) does not
+	// fail the whole backup cycle.
+	doltBackupRetries    = 1
+	doltBackupRetryDelay = 5 * time.Second
 )
 
 // doltBackupInterval returns the configured backup interval, or the default (15m).
@@ -106,23 +114,33 @@ func (d *Daemon) syncDoltBackups() {
 	mol.closeStep("report")
 }
 
-// syncBackup runs `dolt backup sync <backup-name>` for a single database.
+// syncBackup runs `dolt backup sync <backup-name>` for a single database,
+// retrying once on failure so a transient lock or large delta does not fail the
+// cycle (gt-ye21).
 func (d *Daemon) syncBackup(dataDir, db, backupName string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), doltBackupTimeout)
-	defer cancel()
-
 	dbDir := dataDir + "/" + db
-	cmd := exec.CommandContext(ctx, "dolt", "backup", "sync", backupName)
-	cmd.Dir = dbDir
-	util.SetDetachedProcessGroup(cmd)
 
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("%s: %s", err, strings.TrimSpace(string(output)))
+	var lastErr error
+	for attempt := 0; attempt <= doltBackupRetries; attempt++ {
+		if attempt > 0 {
+			time.Sleep(doltBackupRetryDelay)
+			d.logger.Printf("dolt_backup: %s: retry %d/%d after error: %v", db, attempt, doltBackupRetries, lastErr)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), doltBackupTimeout)
+		cmd := exec.CommandContext(ctx, "dolt", "backup", "sync", backupName)
+		cmd.Dir = dbDir
+		util.SetDetachedProcessGroup(cmd)
+
+		output, err := cmd.CombinedOutput()
+		cancel()
+		if err == nil {
+			d.logger.Printf("dolt_backup: %s: synced to %s", db, backupName)
+			return nil
+		}
+		lastErr = fmt.Errorf("%s: %s", err, strings.TrimSpace(string(output)))
 	}
-
-	d.logger.Printf("dolt_backup: %s: synced to %s", db, backupName)
-	return nil
+	return lastErr
 }
 
 // syncOffsiteBackup rsyncs the local backup directory to iCloud Drive.


### PR DESCRIPTION
## Problem
Two recurring town-wide failures trace to the same area:
- **Wisp flood** — the hq beads DB sits at 2-3k+ open wisps (vs the 800 threshold). Root cause: periodic dogs pour a wisp per run and `defer mol.close()`, but `dogMol.close()` logs a failed `bd close` as "non-fatal" and moves on. During a transient Dolt slowdown (exactly when the server is under connection churn) that close fails and the wisp is left **OPEN forever**, so they accumulate.
- **Backup failures** — `dolt-backup FAILED: hq(exit-1)` recurs. The per-db sync has a hard 120s timeout and no retry, so a large commit delta on a big DB (hq under the flood) blows the deadline, and a transient lock fails the whole cycle.

## Fix
- `internal/daemon/dog_molecule.go`: add `closeWisp()` — `bd close` with bounded retries (3 attempts, linear backoff) — and use it for both the root molecule and orphan step wisps in `close()`/`closeRemainingSteps()`. A transient failure now becomes a clean close instead of a permanent orphan.
- `internal/daemon/dolt_backup.go`: raise `doltBackupTimeout` 120s → 5m, and retry a failed `dolt backup sync` once after a short pause.

Both are minimal and defensive; no behavior change on the success path.

## Context
Part of the gt-ye21 connection-leak/wisp-flood investigation. The companion reaper-schema fix (so the reaper can actually drain the backlog) is #4266. A spawn-storm guard for stalled dogs is a planned fast-follow.

## Test
`make build` passes; reaper package tests pass. (The daemon package's unit tests need the ICU cgo headers, which CI provides.)