### PR TITLE
fix(test): repair stale #4272 test fixtures

### DIFF
--- a/internal/cmd/convoy_bd_routing_test.go
+++ b/internal/cmd/convoy_bd_routing_test.go
@@ -112,7 +112,7 @@ case "$*" in
 	  "list --json --limit=0 --all --flat")
 	    echo '[]'
 	    ;;
-  "dep list hq-cv-town --direction=down --type=tracks --allow-stale --json")
+  "dep list hq-cv-town --direction=down --type=tracks --json")
     if [ "$PWD" != "%s" ]; then
       echo "expected town root, got $PWD" >&2
       exit 1
@@ -185,7 +185,7 @@ case "$*" in
     fi
     echo '[{"id":"hq-cv-status","title":"Status convoy","status":"open","issue_type":"convoy","created_at":"2026-03-09T00:00:00Z","labels":[],"dependencies":[]}]'
     ;;
-  "dep list hq-cv-status --direction=down --type=tracks --allow-stale --json")
+  "dep list hq-cv-status --direction=down --type=tracks --json")
     if [ "$PWD" != "%s" ]; then
       echo "expected town root, got $PWD" >&2
       exit 1

--- a/internal/cmd/convoy_external_tracking_test.go
+++ b/internal/cmd/convoy_external_tracking_test.go
@@ -70,7 +70,7 @@ case "$*" in
   "--allow-stale version")
     exit 0
     ;;
-  "dep list hq-cv-ext --direction=down --type=tracks --allow-stale --json")
+  "dep list hq-cv-ext --direction=down --type=tracks --json")
     echo '[]'
     ;;
   "show hq-cv-ext --json")

--- a/internal/cmd/convoy_launch_test.go
+++ b/internal/cmd/convoy_launch_test.go
@@ -742,7 +742,7 @@ case "$*" in
     # bdDepListRawIDs down: return tracked bead IDs
     echo '[{"depends_on_id":"external:ghostty:ghostty-1i4.3"},{"depends_on_id":"external:ghostty:ghostty-1i4.4"}]'
     ;;
-  "dep list hq-cv-ext --direction=down --type=tracks --allow-stale --json")
+  "dep list hq-cv-ext --direction=down --type=tracks --json")
     echo '[{"id":"external:ghostty:ghostty-1i4.3"},{"id":"external:ghostty:ghostty-1i4.4"}]'
     ;;
   "dep list hq-cv-ext --json")

--- a/internal/cmd/install_test.go
+++ b/internal/cmd/install_test.go
@@ -93,7 +93,7 @@ func TestEnsureBeadsConfigYAML_CreatesWhenMissing(t *testing.T) {
 	}
 
 	got := string(data)
-	want := "prefix: hq\nissue-prefix: hq\ndolt.idle-timeout: \"0\"\n"
+	want := "prefix: hq\nissue-prefix: hq\ndolt.idle-timeout: \"0\"\nexport.auto: \"false\"\n"
 	if got != want {
 		t.Fatalf("config.yaml = %q, want %q", got, want)
 	}

--- a/internal/cmd/statusline_test.go
+++ b/internal/cmd/statusline_test.go
@@ -15,6 +15,7 @@ func setupCmdTestRegistry(t *testing.T) {
 	registry := session.NewPrefixRegistry()
 	registry.Register("gt", "gastown")
 	registry.Register("do", "coder_dotfiles")
+	registry.Register("mr", "myrig")
 	old := session.DefaultRegistry()
 	session.SetDefaultRegistry(registry)
 	t.Cleanup(func() { session.SetDefaultRegistry(old) })

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -2174,10 +2174,10 @@ esac
 	if strings.Contains(logOutput, "env="+rigBeadsDir) {
 		t.Fatalf("manager agent lifecycle used rig BEADS_DIR; log:\n%s", logOutput)
 	}
-	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=") || !strings.Contains(logOutput, " create") {
+	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=") || !strings.Contains(logOutput, "args=create") {
 		t.Fatalf("manager create did not use town BEADS_DIR; log:\n%s", logOutput)
 	}
-	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=") || !strings.Contains(logOutput, " show") || !strings.Contains(logOutput, " update") {
+	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=") || !strings.Contains(logOutput, "args=show") || !strings.Contains(logOutput, "args=update") {
 		t.Fatalf("manager reset did not use town BEADS_DIR for show/update; log:\n%s", logOutput)
 	}
 }

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -150,7 +150,7 @@ esac
 	if strings.Contains(logOutput, "env="+rigBeadsDir) {
 		t.Fatalf("refinery active_mr cleanup used rig BEADS_DIR; log:\n%s", logOutput)
 	}
-	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=") || !strings.Contains(logOutput, " show") || !strings.Contains(logOutput, " update") {
+	if !strings.Contains(logOutput, "env="+townBeadsDir+" args=") || !strings.Contains(logOutput, "args=show") || !strings.Contains(logOutput, "args=update") {
 		t.Fatalf("refinery active_mr cleanup did not use town BEADS_DIR; log:\n%s", logOutput)
 	}
 }

--- a/internal/rig/manager_test.go
+++ b/internal/rig/manager_test.go
@@ -677,7 +677,7 @@ exit 1
 	if err != nil {
 		t.Fatalf("reading config.yaml: %v", err)
 	}
-	want := "prefix: gt\nissue-prefix: gt\ndolt.idle-timeout: \"0\"\n"
+	want := "prefix: gt\nissue-prefix: gt\ndolt.idle-timeout: \"0\"\nexport.auto: \"false\"\n"
 	if string(config) != want {
 		t.Fatalf("config.yaml = %q, want %q", string(config), want)
 	}


### PR DESCRIPTION
## What
This PR updates stale test fixtures from the main-CI breakage tracked in #4272:
- `config.yaml` expectations now include the intended `export.auto: "false"` line written by `EnsureConfigYAML`.
- convoy `bd` mock expectations now match the current `--allow-stale` capability probe behavior when the probe exits 0 with empty output.
- polecat/refinery BEADS_DIR assertions now match the mock log format (`args=create/show/update`) while still verifying town-beads routing.
- the command test prefix registry now registers `mr -> myrig`, matching production's explicit prefix registry behavior for synthetic rig tests.

## Verified
Contributor verification before sheriff metadata update:
```bash
go test ./internal/cmd/ -run TestEnsureBeadsConfigYAML_CreatesWhenMissing
go test ./internal/rig/  -run TestInitBeadsWritesConfigOnFailure
```

PR Sheriff verification on current `gastownhall/gastown` `upstream/main`:
```bash
CGO_ENABLED=0 go test ./internal/cmd -run '^(TestEnsureBeadsConfigYAML_CreatesWhenMissing|TestRunConvoyList_UsesTownRootAndStripsBeadsDir|TestRunConvoyStatus_UsesTownRootAndStripsBeadsDir|TestGetTrackedIssues_FallsBackToShowTrackedDependencies|TestCollectConvoyBeads_ExternalTrackedIDs|TestFilterAndSortSessions_SortOrder|TestGuessSessionFromWorkerDir)$' -count=1
CGO_ENABLED=0 go test ./internal/rig -run '^TestInitBeadsWritesConfigOnFailure$' -count=1
CGO_ENABLED=0 go test ./internal/polecat -run '^TestManagerAgentLifecycleUsesTownBeadsDir$' -count=1
CGO_ENABLED=0 go test ./internal/refinery -run '^TestEngineerClearAgentActiveMRUsesTownBeadsDir$' -count=1
```

Focused sheriff verification passed. Normal local CGO linking is blocked on this host by missing ICU libraries (`-licui18n`, `-licuuc`, `-licudata`). Broader package sanity still hits known baseline JSON-output failures unrelated to this test-fixture PR.

## Scope
This is a test-only cleanup subset of #4272. It updates fixtures/assertions to match existing intended behavior and does not change production code.
