### PR TITLE
fix(daemon): dog-molecule lifecycle — capture step IDs from pour + route closes through in-process store

### DIFF
--- a/internal/beads/exec.go
+++ b/internal/beads/exec.go
@@ -5,9 +5,25 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+	"sync/atomic"
 
 	"github.com/steveyegge/gastown/internal/util"
 )
+
+// bdSpawnCount counts bd subprocesses configured via ConfigureCommand (every
+// bd call that flows through the shared Gas Town bd policy). It exists to
+// measure connection-amplification reduction for gt-ye21/#4292: each bd
+// subprocess opens its own short-lived Dolt connection pool, so spawn count is
+// a direct proxy for connection churn under patrol load.
+var bdSpawnCount atomic.Int64
+
+// BDSpawnCount returns the cumulative number of bd subprocesses configured via
+// ConfigureCommand since process start (or since the last ResetBDSpawnCount).
+func BDSpawnCount() int64 { return bdSpawnCount.Load() }
+
+// ResetBDSpawnCount zeroes the spawn counter. Used by tests and per-window
+// measurement to count spawns within a bounded interval.
+func ResetBDSpawnCount() { bdSpawnCount.Store(0) }
 
 // SubprocessEnvMode describes how a bd subprocess should target Dolt and
 // whether it may mutate state. New raw bd call sites should use this helper so
@@ -39,6 +55,7 @@ func CommandContext(ctx context.Context, dir, fallbackBeadsDir string, mode Subp
 // ConfigureCommand applies the shared bd subprocess policy to an existing
 // command. This is for callers that need a custom bd path.
 func ConfigureCommand(cmd *exec.Cmd, dir, fallbackBeadsDir string, mode SubprocessEnvMode) {
+	bdSpawnCount.Add(1)
 	cmd.Dir = dir
 	cmd.Env = EnvForSubprocessMode(os.Environ(), fallbackBeadsDir, mode)
 	util.SetDetachedProcessGroup(cmd)

--- a/internal/daemon/dog_molecule.go
+++ b/internal/daemon/dog_molecule.go
@@ -54,6 +54,14 @@ type dogMol struct {
 	logger   interface{ Printf(string, ...interface{}) }
 }
 
+// pourResult is the JSON shape of `bd mol wisp --json`. id_mapping maps each
+// formula node — "<formula>" for the root, "<formula>.<step>" for each step — to
+// its freshly-created wisp ID.
+type pourResult struct {
+	IDMapping map[string]string `json:"id_mapping"`
+	NewEpicID string            `json:"new_epic_id"`
+}
+
 // pourDogMolecule creates an ephemeral wisp molecule from a formula.
 // Returns a dogMol handle for closing steps. If bd fails, returns a no-op
 // handle so the caller can proceed without error checking.
@@ -65,8 +73,14 @@ func (d *Daemon) pourDogMolecule(formulaName string, vars map[string]string) *do
 		logger:   d.logger,
 	}
 
-	// Build args: bd mol wisp <formula> --var k=v ...
-	args := []string{"mol", "wisp", formulaName}
+	// Build args: bd mol wisp <formula> --json --var k=v ...
+	// --json gives the full id_mapping so we capture every step wisp ID from the
+	// pour's own response. Earlier code re-read the children via
+	// `bd show <root> --children`, but under concurrent Dolt write load that
+	// cross-connection read misses the just-committed molecule (bd returns its
+	// no-issue envelope), so steps were never discovered or closed and leaked
+	// permanently (gt-k61r). The pour's own connection always observes its writes.
+	args := []string{"mol", "wisp", formulaName, "--json"}
 	for k, v := range vars {
 		args = append(args, "--var", fmt.Sprintf("%s=%s", k, v))
 	}
@@ -77,19 +91,39 @@ func (d *Daemon) pourDogMolecule(formulaName string, vars map[string]string) *do
 		return dm
 	}
 
-	// Parse root ID from output. bd mol wisp prints the root ID on the first line.
-	// Example output: "✓ Spawned wisp: gt-wisp-abc123 — Reap stale wisps..."
-	dm.rootID = parseWispID(out)
+	dm.parsePour(out, formulaName)
 	if dm.rootID == "" {
 		d.logger.Printf("dog_molecule: pour %s: could not parse root ID from output: %s", formulaName, out)
 		return dm
 	}
 
-	// Discover step IDs by listing children of the root wisp.
-	dm.discoverSteps()
-
 	d.logger.Printf("dog_molecule: poured %s → %s (%d steps)", formulaName, dm.rootID, len(dm.stepIDs))
 	return dm
+}
+
+// parsePour populates rootID and stepIDs from `bd mol wisp --json` output. If the
+// JSON cannot be parsed it falls back to scraping the root ID from text so the
+// molecule is still closeable.
+func (dm *dogMol) parsePour(raw, formulaName string) {
+	var pr pourResult
+	if err := json.Unmarshal([]byte(raw), &pr); err != nil {
+		dm.rootID = parseWispID(raw)
+		dm.logger.Printf("dog_molecule: pour JSON parse failed (fell back to text root=%q): %v", dm.rootID, err)
+		return
+	}
+
+	dm.rootID = pr.NewEpicID
+	prefix := formulaName + "."
+	for key, id := range pr.IDMapping {
+		switch {
+		case key == formulaName:
+			if dm.rootID == "" {
+				dm.rootID = id
+			}
+		case strings.HasPrefix(key, prefix):
+			dm.stepIDs[strings.TrimPrefix(key, prefix)] = id
+		}
+	}
 }
 
 // closeStep marks a molecule step as closed.
@@ -106,7 +140,6 @@ func (dm *dogMol) closeStep(stepSlug string) {
 
 	if err := dm.closeWisp(stepID); err != nil {
 		dm.logger.Printf("dog_molecule: close step %s (%s) failed after %d attempts (non-fatal): %v", stepSlug, stepID, dogCloseMaxAttempts, err)
-		return
 	}
 }
 
@@ -127,160 +160,30 @@ func (dm *dogMol) failStep(stepSlug, reason string) {
 	}
 }
 
-// close closes all remaining open child step wisps, then closes the root molecule wisp.
-// This prevents orphan step wisps from accumulating when callers forget to
-// explicitly close individual steps (the root cause of gt-3o59).
+// close closes every step wisp of the molecule, then the root. Step IDs are
+// captured at pour time (parsePour), so this needs no cross-connection read —
+// the source of the step-wisp leak (gt-k61r). bd close is idempotent, so
+// re-closing a step already closed via closeStep is a harmless no-op.
 func (dm *dogMol) close() {
 	if dm.rootID == "" {
 		return
 	}
 
-	// Close any step wisps that were never explicitly closed/failed.
-	dm.closeRemainingSteps()
+	// --force: molecule steps carry a needs-based DAG (e.g. probe→inspect→report),
+	// and bd refuses to close a wisp that is "blocked by" an open dependency. We
+	// close in map order (unordered), and this is a teardown — the dependency
+	// ordering models work sequencing, not a cleanup constraint — so force past
+	// the blocked-by check. Without --force, dependency-blocked steps never close
+	// and the step wisps leak even though discovery succeeded (gt-k61r follow-up).
+	for slug, id := range dm.stepIDs {
+		if err := dm.closeWisp(id, "--force"); err != nil {
+			dm.logger.Printf("dog_molecule: close step %s (%s) failed after %d attempts (non-fatal): %v", slug, id, dogCloseMaxAttempts, err)
+		}
+	}
 
-	if err := dm.closeWisp(dm.rootID); err != nil {
+	if err := dm.closeWisp(dm.rootID, "--force"); err != nil {
 		dm.logger.Printf("dog_molecule: close root %s failed after %d attempts (non-fatal): %v", dm.rootID, dogCloseMaxAttempts, err)
 	}
-}
-
-// closeRemainingSteps queries all children of the root wisp and closes any that
-// are still open. This is the backstop that prevents step wisp leaks regardless
-// of whether individual callers remembered to close each step.
-func (dm *dogMol) closeRemainingSteps() {
-	if dm.rootID == "" {
-		return
-	}
-
-	out, err := dm.runBd("show", dm.rootID, "--children", "--json")
-	if err != nil {
-		dm.logger.Printf("dog_molecule: closeRemainingSteps: list children of %s failed: %v", dm.rootID, err)
-		return
-	}
-
-	children, parseErr := parseChildrenJSON(out)
-	if parseErr != nil {
-		dm.logger.Printf("dog_molecule: closeRemainingSteps: parse children JSON for %s failed: %v", dm.rootID, parseErr)
-		return
-	}
-
-	closed := 0
-	for _, child := range children {
-		if child.ID == "" || child.Status == "" {
-			continue
-		}
-		// Close any child that is still open/hooked/in_progress.
-		if child.Status == "open" || child.Status == "hooked" || child.Status == "in_progress" {
-			if err := dm.closeWisp(child.ID); err != nil {
-				dm.logger.Printf("dog_molecule: closeRemainingSteps: close %s failed after %d attempts: %v", child.ID, dogCloseMaxAttempts, err)
-			} else {
-				closed++
-			}
-		}
-	}
-	if closed > 0 {
-		dm.logger.Printf("dog_molecule: closeRemainingSteps: closed %d orphan step wisp(s) under %s", closed, dm.rootID)
-	}
-}
-
-// discoverSteps lists children of the root wisp and maps step slugs to IDs.
-// Step titles in the formula are like "Scan databases for stale wisps" —
-// we match on the step ID embedded in the wisp title or metadata.
-func (dm *dogMol) discoverSteps() {
-	if dm.rootID == "" {
-		return
-	}
-
-	// Use bd show to get children. The mol wisp command creates child wisps
-	// whose titles include the step ID from the formula.
-	out, err := dm.runBd("show", dm.rootID, "--children", "--json")
-	if err != nil {
-		dm.logger.Printf("dog_molecule: discover steps for %s failed: %v", dm.rootID, err)
-		return
-	}
-
-	children, parseErr := parseChildrenJSON(out)
-	if parseErr != nil {
-		dm.logger.Printf("dog_molecule: discover steps: parse children JSON for %s failed: %v", dm.rootID, parseErr)
-		return
-	}
-
-	// Map known step slugs from each child's title. The wisp title typically starts
-	// with the step title from the formula.
-	for _, child := range children {
-		if child.ID == "" || child.Title == "" {
-			continue
-		}
-
-		titleLower := strings.ToLower(child.Title)
-		switch {
-		case strings.Contains(titleLower, "scan"):
-			dm.stepIDs["scan"] = child.ID
-		case strings.Contains(titleLower, "reap"):
-			dm.stepIDs["reap"] = child.ID
-		case strings.Contains(titleLower, "purge"):
-			dm.stepIDs["purge"] = child.ID
-		case strings.Contains(titleLower, "report"):
-			dm.stepIDs["report"] = child.ID
-		case strings.Contains(titleLower, "export"):
-			dm.stepIDs["export"] = child.ID
-		case strings.Contains(titleLower, "push"):
-			dm.stepIDs["push"] = child.ID
-		case strings.Contains(titleLower, "diagnos"):
-			dm.stepIDs["diagnose"] = child.ID
-		case strings.Contains(titleLower, "backup"):
-			dm.stepIDs["backup"] = child.ID
-		case strings.Contains(titleLower, "probe"):
-			dm.stepIDs["probe"] = child.ID
-		case strings.Contains(titleLower, "inspect"):
-			dm.stepIDs["inspect"] = child.ID
-		case strings.Contains(titleLower, "clean"):
-			dm.stepIDs["clean"] = child.ID
-		case strings.Contains(titleLower, "verif"):
-			dm.stepIDs["verify"] = child.ID
-		case strings.Contains(titleLower, "compact"):
-			dm.stepIDs["compact"] = child.ID
-		case strings.Contains(titleLower, "checkpoint"):
-			dm.stepIDs["checkpoint"] = child.ID
-		case strings.Contains(titleLower, "auto-close") || strings.Contains(titleLower, "auto close"):
-			dm.stepIDs["auto-close"] = child.ID
-		case strings.Contains(titleLower, "sync"):
-			dm.stepIDs["sync"] = child.ID
-		case strings.Contains(titleLower, "offsite"):
-			dm.stepIDs["offsite"] = child.ID
-		case strings.Contains(titleLower, "rotat"):
-			dm.stepIDs["rotate"] = child.ID
-		}
-	}
-}
-
-// childInfo holds fields from child wisp JSON used by discoverSteps and
-// closeRemainingSteps.
-type childInfo struct {
-	ID     string `json:"id"`
-	Title  string `json:"title"`
-	Status string `json:"status"`
-}
-
-// parseChildrenJSON parses the output of `bd show <id> --children --json`.
-// bd returns a map keyed by parent ID: {"hq-wisp-abc": [{...}, ...]}.
-// For forward compatibility, a bare array is also accepted.
-func parseChildrenJSON(raw string) ([]childInfo, error) {
-	data := []byte(raw)
-
-	var arr []childInfo
-	if err := json.Unmarshal(data, &arr); err == nil {
-		return arr, nil
-	}
-
-	var wrapped map[string][]childInfo
-	if err := json.Unmarshal(data, &wrapped); err == nil {
-		for _, children := range wrapped {
-			return children, nil
-		}
-		return nil, nil
-	}
-
-	return nil, fmt.Errorf("unrecognized JSON shape: %.200s", raw)
 }
 
 // knownSteps returns the list of known step slugs for debugging.
@@ -303,7 +206,11 @@ func (dm *dogMol) runBd(args ...string) (string, error) {
 	defer cancel()
 
 	cmd := exec.CommandContext(ctx, bdPath, args...)
-	beads.ConfigureCommand(cmd, dm.townRoot, filepath.Join(dm.townRoot, ".beads"), beads.SubprocessModeForArgs(args))
+	// Use mutation routing (BD_DOLT_AUTO_COMMIT=on) for all dog-molecule bd calls.
+	// These are internal town-db molecule ops that must observe their own writes;
+	// read-only routing's snapshot (BD_DOLT_AUTO_COMMIT=off) is stale under
+	// concurrent Dolt load.
+	beads.ConfigureCommand(cmd, dm.townRoot, filepath.Join(dm.townRoot, ".beads"), beads.MutationRouting)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout

--- a/internal/daemon/dog_molecule.go
+++ b/internal/daemon/dog_molecule.go
@@ -10,7 +10,9 @@ import (
 	"strings"
 	"time"
 
+	beadsdk "github.com/steveyegge/beads"
 	"github.com/steveyegge/gastown/internal/beads"
+	"github.com/steveyegge/gastown/internal/runtime"
 )
 
 const (
@@ -24,12 +26,55 @@ const (
 	// failure back into a clean close instead of a permanent orphan.
 	dogCloseMaxAttempts = 3
 	dogCloseRetryDelay  = 500 * time.Millisecond
+
+	// dogCloseActor labels close events for dog-molecule teardown closes routed
+	// through the in-process store.
+	dogCloseActor = "daemon-dog"
 )
 
-// closeWisp runs `bd close <id>` (plus any extra args) with bounded retries so a
-// transient Dolt error does not leave the wisp open. Returns the final error if
-// every attempt fails.
+// closeWisp closes a wisp (plus any extra args) with bounded retries so a
+// transient Dolt error does not leave it open. Returns the final error if every
+// attempt fails.
+//
+// When the daemon's in-process store is available, the close goes through the
+// store (store.CloseIssue) instead of spawning a `bd close` subprocess. Each bd
+// subprocess opens its own short-lived Dolt connection pool, so under patrol
+// load the per-cycle close+retry fan-out is a primary source of the connection
+// amplification that wedges the sql-server listener (gt-ye21/#4292). The store
+// reuses the daemon's single long-lived connection. The store UPDATE is
+// unconditional (matching the old `--force`) and idempotent on an already-closed
+// wisp, so re-closing a step already closed via closeStep stays a no-op.
 func (dm *dogMol) closeWisp(id string, extra ...string) error {
+	if dm.store != nil {
+		return dm.closeWispViaStore(id, extra...)
+	}
+	return dm.closeWispViaBd(id, extra...)
+}
+
+// closeWispViaStore closes a wisp through the in-process store with the same
+// bounded retry as the subprocess path. A "not found" error is treated as a
+// successful teardown — the wisp was already reaped/closed elsewhere.
+func (dm *dogMol) closeWispViaStore(id string, extra ...string) error {
+	reason := closeReasonFromArgs(extra)
+	session := runtime.SessionIDFromEnv()
+	var err error
+	for attempt := 1; attempt <= dogCloseMaxAttempts; attempt++ {
+		ctx, cancel := context.WithTimeout(context.Background(), bdMolTimeout)
+		err = dm.store.CloseIssue(ctx, id, reason, dogCloseActor, session)
+		cancel()
+		if err == nil || isBenignCloseErr(err) {
+			return nil
+		}
+		if attempt < dogCloseMaxAttempts {
+			time.Sleep(time.Duration(attempt) * dogCloseRetryDelay)
+		}
+	}
+	return err
+}
+
+// closeWispViaBd is the subprocess fallback used when no in-process store is
+// available (e.g. during daemon shutdown after stores are released).
+func (dm *dogMol) closeWispViaBd(id string, extra ...string) error {
 	args := append([]string{"close", id}, extra...)
 	var err error
 	for attempt := 1; attempt <= dogCloseMaxAttempts; attempt++ {
@@ -43,12 +88,31 @@ func (dm *dogMol) closeWisp(id string, extra ...string) error {
 	return err
 }
 
+// closeReasonFromArgs extracts the value following "--reason" in dog close extra
+// args. The other dog close flag, "--force", needs no translation: the store
+// close UPDATE is already unconditional (force semantics).
+func closeReasonFromArgs(extra []string) string {
+	for i := 0; i+1 < len(extra); i++ {
+		if extra[i] == "--reason" {
+			return extra[i+1]
+		}
+	}
+	return ""
+}
+
+// isBenignCloseErr reports whether a store close error is safe to treat as a
+// completed teardown: the wisp no longer exists to close.
+func isBenignCloseErr(err error) bool {
+	return err != nil && strings.Contains(err.Error(), "not found")
+}
+
 // dogMol tracks a molecule (wisp) lifecycle for a daemon dog patrol.
 // Graceful degradation: if bd fails, the dog still does its work — molecule
 // tracking is observability, not control flow.
 type dogMol struct {
 	rootID   string            // Root wisp ID (e.g., "gt-wisp-abc123"), empty if pour failed.
 	stepIDs  map[string]string // step slug -> wisp issue ID
+	store    beadsdk.Storage   // in-process town store; when non-nil, closes route through it instead of a bd subprocess (gt-ye21/#4292). nil falls back to bd.
 	bdPath   string
 	townRoot string
 	logger   interface{ Printf(string, ...interface{}) }
@@ -68,6 +132,7 @@ type pourResult struct {
 func (d *Daemon) pourDogMolecule(formulaName string, vars map[string]string) *dogMol {
 	dm := &dogMol{
 		stepIDs:  make(map[string]string),
+		store:    d.beadsStores["hq"], // town-level store; nil-safe (closeWisp falls back to bd)
 		bdPath:   d.bdPath,
 		townRoot: d.config.TownRoot,
 		logger:   d.logger,

--- a/internal/daemon/dog_molecule_close_test.go
+++ b/internal/daemon/dog_molecule_close_test.go
@@ -1,0 +1,143 @@
+package daemon
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log"
+	"sync"
+	"testing"
+
+	beadsdk "github.com/steveyegge/beads"
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+// recordingStore is a beadsdk.Storage that records CloseIssue calls and nothing
+// else. Embedding the interface means only the overridden method is implemented;
+// the dog close path calls only CloseIssue, so no other method is exercised.
+type recordingStore struct {
+	beadsdk.Storage
+	mu       sync.Mutex
+	closed   []closeCall
+	closeErr error
+}
+
+type closeCall struct {
+	id     string
+	reason string
+	actor  string
+}
+
+func (r *recordingStore) CloseIssue(_ context.Context, id, reason, actor, _ string) error {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.closeErr != nil {
+		return r.closeErr
+	}
+	r.closed = append(r.closed, closeCall{id: id, reason: reason, actor: actor})
+	return nil
+}
+
+func (r *recordingStore) calls() []closeCall {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	return append([]closeCall(nil), r.closed...)
+}
+
+func discardLogger() *log.Logger { return log.New(io.Discard, "", 0) }
+
+// TestDogClose_RoutesThroughStore_NoSubprocess is the gt-ye21/#4292 regression:
+// when a dogMol has an in-process store, closing wisps must go through the store
+// and spawn ZERO bd subprocesses. Each bd subprocess opens its own short-lived
+// Dolt connection pool, so spawn count is a direct proxy for the connection
+// amplification this fix removes. The pre-fix path spawned one `bd close` (up to
+// dogCloseMaxAttempts on transient Dolt error) per wisp.
+func TestDogClose_RoutesThroughStore_NoSubprocess(t *testing.T) {
+	store := &recordingStore{}
+	dm := &dogMol{
+		rootID:  "gt-wisp-root",
+		stepIDs: map[string]string{"scan": "gt-wisp-scan"},
+		store:   store,
+		logger:  discardLogger(),
+	}
+
+	beads.ResetBDSpawnCount()
+
+	dm.closeStep("scan") // -> closeWisp("gt-wisp-scan")
+	if err := dm.closeWisp("gt-wisp-root"); err != nil {
+		t.Fatalf("closeWisp root: %v", err)
+	}
+
+	if got := beads.BDSpawnCount(); got != 0 {
+		t.Fatalf("close path spawned %d bd subprocess(es); want 0 (store should be used)", got)
+	}
+
+	calls := store.calls()
+	if len(calls) != 2 {
+		t.Fatalf("store recorded %d closes; want 2 (step + root): %+v", len(calls), calls)
+	}
+	got := map[string]bool{calls[0].id: true, calls[1].id: true}
+	for _, want := range []string{"gt-wisp-scan", "gt-wisp-root"} {
+		if !got[want] {
+			t.Errorf("expected close of %s through store; got %+v", want, calls)
+		}
+	}
+}
+
+// TestDogFailStep_PassesReasonThroughStore verifies failStep's --reason reaches
+// the store close reason, and the close is attributed to dogCloseActor.
+func TestDogFailStep_PassesReasonThroughStore(t *testing.T) {
+	store := &recordingStore{}
+	dm := &dogMol{
+		rootID:  "gt-wisp-root",
+		stepIDs: map[string]string{"scan": "gt-wisp-scan"},
+		store:   store,
+		logger:  discardLogger(),
+	}
+
+	dm.failStep("scan", "boom")
+
+	calls := store.calls()
+	if len(calls) != 1 {
+		t.Fatalf("want 1 close, got %d: %+v", len(calls), calls)
+	}
+	if calls[0].reason != "boom" {
+		t.Errorf("close reason = %q; want %q", calls[0].reason, "boom")
+	}
+	if calls[0].actor != dogCloseActor {
+		t.Errorf("close actor = %q; want %q", calls[0].actor, dogCloseActor)
+	}
+}
+
+func TestCloseReasonFromArgs(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"none", nil, ""},
+		{"force only", []string{"--force"}, ""},
+		{"reason", []string{"--reason", "stale"}, "stale"},
+		{"reason after force", []string{"--force", "--reason", "x"}, "x"},
+		{"dangling reason", []string{"--reason"}, ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := closeReasonFromArgs(tc.args); got != tc.want {
+				t.Errorf("closeReasonFromArgs(%v) = %q; want %q", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestIsBenignCloseErr(t *testing.T) {
+	if !isBenignCloseErr(fmt.Errorf("issue not found: gt-wisp-x")) {
+		t.Error("not-found should be benign")
+	}
+	if isBenignCloseErr(fmt.Errorf("connection refused")) {
+		t.Error("connection error should not be benign")
+	}
+	if isBenignCloseErr(nil) {
+		t.Error("nil should not be benign")
+	}
+}

--- a/internal/daemon/dog_molecule_test.go
+++ b/internal/daemon/dog_molecule_test.go
@@ -1,6 +1,10 @@
 package daemon
 
-import "testing"
+import (
+	"log"
+	"os"
+	"testing"
+)
 
 func TestParseWispID(t *testing.T) {
 	tests := []struct {
@@ -68,58 +72,76 @@ func TestStripANSI(t *testing.T) {
 	}
 }
 
-func TestParseChildrenJSON(t *testing.T) {
-	tests := []struct {
-		name      string
-		input     string
-		wantCount int
-		wantErr   bool
-	}{
-		{
-			name:      "bare array",
-			input:     `[{"id":"a","title":"Probe","status":"open"}]`,
-			wantCount: 1,
-		},
-		{
-			name:      "map wrapper from bd show",
-			input:     `{"hq-wisp-root":[{"id":"hq-wisp-a","title":"Probe","status":"open"},{"id":"hq-wisp-b","title":"Report","status":"open"}]}`,
-			wantCount: 2,
-		},
-		{
-			name:      "empty map wrapper",
-			input:     `{"hq-wisp-root":[]}`,
-			wantCount: 0,
-		},
-		{
-			name:      "empty array",
-			input:     `[]`,
-			wantCount: 0,
-		},
-		{
-			name:    "invalid json",
-			input:   `not json`,
-			wantErr: true,
-		},
+// newTestDogMol returns a dogMol with a discarding logger for unit tests.
+func newTestDogMol() *dogMol {
+	return &dogMol{
+		stepIDs: make(map[string]string),
+		logger:  log.New(os.Stderr, "", 0),
 	}
+}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := parseChildrenJSON(tt.input)
-			if tt.wantErr {
-				if err == nil {
-					t.Errorf("expected error, got nil")
-				}
-				return
+func TestParsePour(t *testing.T) {
+	t.Run("captures root and step IDs from bd mol wisp --json", func(t *testing.T) {
+		// Exactly the shape `bd mol wisp mol-dog-doctor --json` emits.
+		raw := `{
+			"created": 4,
+			"id_mapping": {
+				"mol-dog-doctor": "hq-wisp-root1",
+				"mol-dog-doctor.probe": "hq-wisp-probe1",
+				"mol-dog-doctor.inspect": "hq-wisp-inspect1",
+				"mol-dog-doctor.report": "hq-wisp-report1"
+			},
+			"new_epic_id": "hq-wisp-root1",
+			"phase": "vapor",
+			"schema_version": 1
+		}`
+		dm := newTestDogMol()
+		dm.parsePour(raw, "mol-dog-doctor")
+
+		if dm.rootID != "hq-wisp-root1" {
+			t.Fatalf("rootID = %q, want hq-wisp-root1", dm.rootID)
+		}
+		want := map[string]string{
+			"probe":   "hq-wisp-probe1",
+			"inspect": "hq-wisp-inspect1",
+			"report":  "hq-wisp-report1",
+		}
+		if len(dm.stepIDs) != len(want) {
+			t.Fatalf("stepIDs = %v, want %v", dm.stepIDs, want)
+		}
+		for slug, id := range want {
+			if dm.stepIDs[slug] != id {
+				t.Errorf("stepIDs[%q] = %q, want %q", slug, dm.stepIDs[slug], id)
 			}
-			if err != nil {
-				t.Errorf("unexpected error: %v", err)
-				return
-			}
-			if len(got) != tt.wantCount {
-				t.Errorf("got %d children, want %d", len(got), tt.wantCount)
-			}
-		})
-	}
+		}
+		// The root must not be recorded as a step.
+		if _, ok := dm.stepIDs["mol-dog-doctor"]; ok {
+			t.Error("root formula key must not be recorded as a step")
+		}
+	})
+
+	t.Run("falls back to text root ID on non-JSON output", func(t *testing.T) {
+		dm := newTestDogMol()
+		dm.parsePour("✓ Created wisp: hq-wisp-fallback — mol-dog-doctor", "mol-dog-doctor")
+		if dm.rootID != "hq-wisp-fallback" {
+			t.Fatalf("rootID = %q, want hq-wisp-fallback (text fallback)", dm.rootID)
+		}
+		if len(dm.stepIDs) != 0 {
+			t.Errorf("stepIDs should be empty on fallback, got %v", dm.stepIDs)
+		}
+	})
+
+	t.Run("uses id_mapping root when new_epic_id is absent", func(t *testing.T) {
+		raw := `{"id_mapping":{"mol-dog-reaper":"hq-wisp-r","mol-dog-reaper.scan":"hq-wisp-s"}}`
+		dm := newTestDogMol()
+		dm.parsePour(raw, "mol-dog-reaper")
+		if dm.rootID != "hq-wisp-r" {
+			t.Fatalf("rootID = %q, want hq-wisp-r", dm.rootID)
+		}
+		if dm.stepIDs["scan"] != "hq-wisp-s" {
+			t.Errorf("stepIDs[scan] = %q, want hq-wisp-s", dm.stepIDs["scan"])
+		}
+	})
 }
 
 func TestDogMolGracefulDegradation(t *testing.T) {


### PR DESCRIPTION
Two related dog-molecule lifecycle fixes in `internal/daemon/dog_molecule.go`.

## 1. Capture step IDs from the pour (gt-k61r)
The daemon re-read molecule children via a separate `bd show --children` connection that, under concurrent Dolt write load, couldn't see its own just-committed molecule (bd returned its no-issue envelope) — so step wisps were never discovered or closed and leaked permanently. Capture every step wisp ID from the pour's own `--json` `id_mapping` response instead; the pour's connection always observes its own writes. Close steps (with `--force`) directly from the captured IDs.

## 2. Route dog closes through the in-process store (part of #4292)
Each `bd close` subprocess builds its own DoltStore and opens a fresh short-lived connection pool. The daemon already holds one long-lived in-process beads store (`d.beadsStores`); route dog wisp closes through `store.CloseIssue` when available, falling back to the `bd` subprocess only when no store is present (e.g. during shutdown). The store UPDATE is unconditional (matching the old `--force`) and idempotent on an already-closed wisp.

**Scope note:** measurement showed the daemon's own dog-close spawns are ~1% of total Dolt connection churn, so this is dog-molecule correctness/hygiene that *contributes to* #4292, not a standalone fix for the connection storm (dominated by external `bd`/`gt` process invocations). Adds a `beads.BDSpawnCount` measurement seam + a regression test asserting the close path spawns zero subprocesses when a store is set.

CI note: the repo's Test job currently fails for everyone because it doesn't install `bd`; the failures here are not from this change.