### PR TITLE
fix(lint): clear 6 pre-existing golangci-lint violations

### DIFF
--- a/internal/cmd/capacity_dispatch.go
+++ b/internal/cmd/capacity_dispatch.go
@@ -228,7 +228,7 @@ func dispatchScheduledWork(townRoot, actor string, batchOverride int, dryRun boo
 		if planErr != nil {
 			return 0, fmt.Errorf("planning dispatch: %w", planErr)
 		}
-		plan = validateDryRunDispatchPlan(townRoot, cycle, plan)
+		plan = validateDryRunDispatchPlan(townRoot, plan)
 		printDryRunPlan(plan, lastCapacitySnapshot, batchSize)
 		return 0, nil
 	}
@@ -591,7 +591,7 @@ func dispatchSingleBead(b capacity.PendingBead, townRoot, _ string) (*SlingResul
 	return result, nil
 }
 
-func validateDryRunDispatchPlan(townRoot string, cycle *capacity.DispatchCycle, plan capacity.DispatchPlan) capacity.DispatchPlan {
+func validateDryRunDispatchPlan(townRoot string, plan capacity.DispatchPlan) capacity.DispatchPlan {
 	if len(plan.ToDispatch) == 0 {
 		return plan
 	}

--- a/internal/cmd/statusline.go
+++ b/internal/cmd/statusline.go
@@ -103,15 +103,15 @@ func runStatusLine(cmd *cobra.Command, args []string) error {
 
 	// Refinery status line
 	if role == "refinery" || strings.HasSuffix(statusLineSession, "-refinery") {
-		return runRefineryStatusLine(t, rigName)
+		return runRefineryStatusLine(rigName)
 	}
 
 	// Crew/Polecat status line
-	return runWorkerStatusLine(t, statusLineSession, rigName, polecat, crew, issue)
+	return runWorkerStatusLine(polecat, crew, issue)
 }
 
 // runWorkerStatusLine outputs status for crew or polecat sessions.
-func runWorkerStatusLine(t *tmux.Tmux, session, rigName, polecat, crew, issue string) error {
+func runWorkerStatusLine(polecat, crew, issue string) error {
 	// Determine agent type and identity
 	var icon string
 	if polecat != "" {
@@ -438,7 +438,7 @@ func runWitnessStatusLine(t *tmux.Tmux, rigName string) error {
 
 // runRefineryStatusLine outputs status for a refinery session.
 // Shows: MQ length, current item, hook or mail preview
-func runRefineryStatusLine(t *tmux.Tmux, rigName string) error {
+func runRefineryStatusLine(rigName string) error {
 	if rigName == "" {
 		// Try to extract from session name: <prefix>-refinery
 		if identity, err := session.ParseSessionName(statusLineSession); err == nil && identity.Role == session.RoleRefinery {

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1339,7 +1339,7 @@ func FindIdleMonitorProcesses(townRoot string) []int {
 func findIdleMonitorProcessesFromPS(output, townRoot, absRoot string, port int) []int {
 	portStr := strconv.Itoa(port)
 	var pids []int
-	for _, line := range strings.Split(string(output), "\n") {
+	for _, line := range strings.Split(output, "\n") {
 		line = strings.TrimSpace(line)
 		if !strings.Contains(line, "idle-monitor") {
 			continue
@@ -2725,7 +2725,7 @@ func EnsureRigIssuePrefix(townRoot, rigName string, serverMode bool) error {
 	if err != nil {
 		return fmt.Errorf("opening beads database: %w", err)
 	}
-	defer store.Close()
+	defer func() { _ = store.Close() }()
 
 	if err := store.SetConfig(ctx, "issue_prefix", prefix); err != nil {
 		return fmt.Errorf("setting issue_prefix: %w", err)

--- a/internal/git/git.go
+++ b/internal/git/git.go
@@ -457,7 +457,7 @@ func protectedWorktreeTargets(cmd string, args []string, baseDir string) []strin
 	protected := make([]string, 0, len(targets))
 	for _, target := range targets {
 		abs := gitPathAbs(target, baseDir)
-		if _, ok := protectedTownRuntimePath(abs); ok {
+		if protectedTownRuntimePath(abs) {
 			protected = append(protected, abs)
 		}
 	}
@@ -532,16 +532,16 @@ func resolveExistingSymlinkAncestors(path string) string {
 	}
 }
 
-func protectedTownRuntimePath(path string) (string, bool) {
+func protectedTownRuntimePath(path string) bool {
 	abs := filepath.Clean(path)
 	for dir := abs; ; dir = filepath.Dir(dir) {
 		if isTownRoot(dir) {
 			if samePath(abs, dir) {
-				return dir, true
+				return true
 			}
 			rel, err := filepath.Rel(dir, abs)
 			if err != nil {
-				return "", false
+				return false
 			}
 			first := rel
 			if idx := strings.IndexRune(rel, filepath.Separator); idx >= 0 {
@@ -549,14 +549,14 @@ func protectedTownRuntimePath(path string) (string, bool) {
 			}
 			switch first {
 			case "mayor", ".dolt-data", ".runtime", ".beads", "daemon":
-				return dir, true
+				return true
 			default:
-				return "", false
+				return false
 			}
 		}
 		parent := filepath.Dir(dir)
 		if parent == dir {
-			return "", false
+			return false
 		}
 	}
 }
@@ -608,7 +608,7 @@ type cloneOptions struct {
 // to dest, and applies post-clone configuration (hooks or refspec).
 func (g *Git) cloneInternal(url, dest string, opts cloneOptions) error {
 	dest = gitPathAbs(dest, "")
-	if _, ok := protectedTownRuntimePath(dest); ok {
+	if protectedTownRuntimePath(dest) {
 		return fmt.Errorf("%w: clone destination %s", ErrUnsafeTownRootGitMutation, dest)
 	}
 


### PR DESCRIPTION
## Problem

`golangci-lint run` on `main` reports 6 issues that fail the **Lint** CI job. Every PR branched from current main inherits the red check (e.g. #4278, #4271, #4273), even when the PR's own diff is lint-clean.

```
internal/doltserver/doltserver.go:2728  errcheck   store.Close() return unchecked
internal/doltserver/doltserver.go:1342  unconvert  unnecessary string() conversion
internal/cmd/capacity_dispatch.go:594    unparam    validateDryRunDispatchPlan: cycle unused
internal/cmd/statusline.go:114           unparam    runWorkerStatusLine: t unused
internal/cmd/statusline.go:441           unparam    runRefineryStatusLine: t unused
internal/git/git.go:535                  unparam    protectedTownRuntimePath: string result never used
```

## Fix

All mechanical, no behavioral change:

- **doltserver.go** — check the deferred `store.Close()` error (`defer func() { _ = store.Close() }()`); drop a redundant `string(output)` conversion in `findIdleMonitorProcessesFromPS` where `output` is already a `string`.
- **statusline.go** — drop the unused `*tmux.Tmux` parameter from `runWorkerStatusLine` and `runRefineryStatusLine` and their call sites (the `tmux` import is still used by the mayor/deacon/witness status lines).
- **capacity_dispatch.go** — drop the unused `*capacity.DispatchCycle` parameter from `validateDryRunDispatchPlan` and its one caller.
- **git.go** — `protectedTownRuntimePath` returned a `string` that neither caller used; return only the `bool` and update both call sites.

## Verification

`go build` + `go vet` clean across `internal/git`, `internal/cmd`, `internal/doltserver`; affected test packages still compile. (golangci-lint isn't installed locally; CI will confirm the Lint job goes green.)