### PR TITLE
fix: harden wisp dependency schema cleanup

### DIFF
--- a/internal/cmd/compact_test.go
+++ b/internal/cmd/compact_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -22,8 +24,8 @@ func TestGetTTL(t *testing.T) {
 		{"recovery", 7 * 24 * time.Hour},
 		{"escalation", 7 * 24 * time.Hour},
 		{"default", 24 * time.Hour},
-		{"", 24 * time.Hour},          // empty falls back to default
-		{"unknown", 24 * time.Hour},   // unknown falls back to default
+		{"", 24 * time.Hour},        // empty falls back to default
+		{"unknown", 24 * time.Hour}, // unknown falls back to default
 	}
 
 	for _, tc := range tests {
@@ -265,4 +267,38 @@ func TestLoadTTLConfigWithRoleSkipsInvalidPaths(t *testing.T) {
 	if ttls["error"] != defaultTTLs["error"] {
 		t.Errorf("error TTL = %v, want %v", ttls["error"], defaultTTLs["error"])
 	}
+}
+
+func TestCleanOrphanedWispDepsUsesTypedTargets(t *testing.T) {
+	data, err := os.ReadFile("compact.go")
+	if err != nil {
+		t.Fatalf("read compact.go: %v", err)
+	}
+	body := compactSourceBetween(t, string(data), "func cleanOrphanedWispDeps(", "// listWisps")
+	if strings.Contains(body, "depends_on_id") {
+		t.Fatalf("cleanOrphanedWispDeps should not use legacy depends_on_id:\n%s", body)
+	}
+	for _, want := range []string{
+		"depends_on_wisp_id IS NOT NULL AND NOT EXISTS",
+		"wisps WHERE id = wisp_dependencies.depends_on_wisp_id",
+		"depends_on_issue_id IS NOT NULL AND NOT EXISTS",
+		"issues WHERE id = wisp_dependencies.depends_on_issue_id",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("cleanOrphanedWispDeps missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func compactSourceBetween(t *testing.T, source, startMarker, endMarker string) string {
+	t.Helper()
+	start := strings.Index(source, startMarker)
+	if start == -1 {
+		t.Fatalf("could not find %q", startMarker)
+	}
+	end := strings.Index(source[start:], endMarker)
+	if end == -1 {
+		t.Fatalf("could not find %q after %q", endMarker, startMarker)
+	}
+	return source[start : start+end]
 }

--- a/internal/doctor/misclassified_wisp_check.go
+++ b/internal/doctor/misclassified_wisp_check.go
@@ -240,15 +240,32 @@ func (c *CheckMisclassifiedWisps) purgeRigBatch(ctx *CheckContext, workDir, rigN
 		},
 		{
 			table: "wisp_dependencies",
-			query: fmt.Sprintf("INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d WHERE d.issue_id IN (%s)", idList),
+			query: fmt.Sprintf("INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, CASE WHEN target_wisp.id IS NULL THEN d.depends_on_issue_id ELSE NULL END, CASE WHEN target_wisp.id IS NOT NULL THEN d.depends_on_issue_id ELSE d.depends_on_wisp_id END, d.depends_on_external, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d LEFT JOIN wisps target_wisp ON target_wisp.id = d.depends_on_issue_id WHERE d.issue_id IN (%s)", idList),
 		},
 	}
-	copyFailed := map[string]bool{}
+	copyErrors := map[string]error{}
 	for _, aux := range auxCopies {
-		if bdTableExistsDoctor(workDir, aux.table) {
-			if err := execBdSQLWrite(workDir, aux.query); err != nil {
-				copyFailed[aux.table] = true
+		if !bdTableExistsDoctor(workDir, aux.table) {
+			if aux.table == "wisp_dependencies" && bdTableExistsDoctor(workDir, "dependencies") {
+				copyErrors[aux.table] = fmt.Errorf("target table missing")
 			}
+			continue
+		}
+		if err := execBdSQLWrite(workDir, aux.query); err != nil {
+			copyErrors[aux.table] = err
+		}
+	}
+	if err := copyErrors["wisp_dependencies"]; err != nil {
+		return fmt.Errorf("copying wisp_dependencies: %w", err)
+	}
+	if bdTableExistsDoctor(workDir, "wisp_dependencies") {
+		if err := execBdSQLWrite(workDir, fmt.Sprintf("UPDATE wisp_dependencies SET depends_on_wisp_id = depends_on_issue_id, depends_on_issue_id = NULL WHERE depends_on_issue_id IN (%s)", idList)); err != nil {
+			return fmt.Errorf("retargeting incoming wisp_dependencies: %w", err)
+		}
+	}
+	if bdTableExistsDoctor(workDir, "dependencies") {
+		if err := execBdSQLWrite(workDir, fmt.Sprintf("UPDATE dependencies SET depends_on_wisp_id = depends_on_issue_id, depends_on_issue_id = NULL WHERE depends_on_issue_id IN (%s)", idList)); err != nil {
+			return fmt.Errorf("retargeting incoming dependencies: %w", err)
 		}
 	}
 
@@ -257,9 +274,7 @@ func (c *CheckMisclassifiedWisps) purgeRigBatch(ctx *CheckContext, workDir, rigN
 		fmt.Sprintf("DELETE FROM labels WHERE issue_id IN (%s)", idList),
 		fmt.Sprintf("DELETE FROM comments WHERE issue_id IN (%s)", idList),
 		fmt.Sprintf("DELETE FROM events WHERE issue_id IN (%s)", idList),
-	}
-	if !copyFailed["wisp_dependencies"] {
-		auxDeletes = append(auxDeletes, fmt.Sprintf("DELETE FROM dependencies WHERE issue_id IN (%s)", idList))
+		fmt.Sprintf("DELETE FROM dependencies WHERE issue_id IN (%s)", idList),
 	}
 	for _, q := range auxDeletes {
 		_ = execBdSQLWrite(workDir, q) // Best-effort: table may not exist

--- a/internal/doctor/misclassified_wisp_check_test.go
+++ b/internal/doctor/misclassified_wisp_check_test.go
@@ -3,6 +3,7 @@ package doctor
 import (
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -217,4 +218,95 @@ func TestRigDirResolution_Logic(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestMisclassifiedWispDependencyMigrationIsTypedAndFailClosed(t *testing.T) {
+	data, err := os.ReadFile("misclassified_wisp_check.go")
+	if err != nil {
+		t.Fatalf("read misclassified_wisp_check.go: %v", err)
+	}
+	body := doctorSourceBetween(t, string(data), "func (c *CheckMisclassifiedWisps) purgeRigBatch(", "// bdTableExistsDoctor")
+	if strings.Contains(body, "depends_on_id") {
+		t.Fatalf("purgeRigBatch should not copy legacy depends_on_id:\n%s", body)
+	}
+	for _, want := range []string{
+		"depends_on_issue_id, depends_on_wisp_id, depends_on_external",
+		"CASE WHEN target_wisp.id IS NULL THEN d.depends_on_issue_id ELSE NULL END",
+		"CASE WHEN target_wisp.id IS NOT NULL THEN d.depends_on_issue_id ELSE d.depends_on_wisp_id END",
+		"LEFT JOIN wisps target_wisp ON target_wisp.id = d.depends_on_issue_id",
+		"UPDATE wisp_dependencies SET depends_on_wisp_id = depends_on_issue_id, depends_on_issue_id = NULL WHERE depends_on_issue_id IN",
+		"UPDATE dependencies SET depends_on_wisp_id = depends_on_issue_id, depends_on_issue_id = NULL WHERE depends_on_issue_id IN",
+		"return fmt.Errorf(\"copying wisp_dependencies: %w\", err)",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("purgeRigBatch missing %q:\n%s", want, body)
+		}
+	}
+	copyFailure := strings.Index(body, "return fmt.Errorf(\"copying wisp_dependencies: %w\", err)")
+	retargetWisp := strings.Index(body, "UPDATE wisp_dependencies SET depends_on_wisp_id")
+	deleteIssue := strings.Index(body, "DELETE FROM issues WHERE id IN")
+	if copyFailure == -1 || deleteIssue == -1 || copyFailure > deleteIssue {
+		t.Fatalf("purgeRigBatch must abort before deleting source issues when dependency copy fails:\n%s", body)
+	}
+	if retargetWisp == -1 || deleteIssue == -1 || retargetWisp > deleteIssue {
+		t.Fatalf("purgeRigBatch must retarget incoming dependency rows before deleting source issues:\n%s", body)
+	}
+}
+
+func TestMisclassifiedWispDependencyCopyFailureSkipsDeletes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("fake bd stub is shell-specific")
+	}
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd-sql.log")
+	script := `#!/usr/bin/env bash
+query="${@: -1}"
+printf '%s\n' "$query" >> "$BD_SQL_LOG"
+if [[ "$query" == *"SELECT 1 FROM"* ]]; then
+  exit 0
+fi
+if [[ "$query" == *"INSERT IGNORE INTO wisp_dependencies"* ]]; then
+  echo "copy failed"
+  exit 7
+fi
+exit 0
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_SQL_LOG", logPath)
+
+	err := NewCheckMisclassifiedWisps().purgeRigBatch(&CheckContext{TownRoot: t.TempDir()}, t.TempDir(), "gt", "'gt-wisp-a'")
+	if err == nil || !strings.Contains(err.Error(), "copying wisp_dependencies") {
+		t.Fatalf("purgeRigBatch error = %v, want copying wisp_dependencies", err)
+	}
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read query log: %v", err)
+	}
+	log := string(data)
+	for _, forbidden := range []string{
+		"DELETE FROM dependencies",
+		"DELETE FROM issues",
+		"UPDATE wisp_dependencies SET depends_on_wisp_id",
+		"UPDATE dependencies SET depends_on_wisp_id",
+	} {
+		if strings.Contains(log, forbidden) {
+			t.Fatalf("purgeRigBatch ran %q after dependency copy failure:\n%s", forbidden, log)
+		}
+	}
+}
+
+func doctorSourceBetween(t *testing.T, source, startMarker, endMarker string) string {
+	t.Helper()
+	start := strings.Index(source, startMarker)
+	if start == -1 {
+		t.Fatalf("could not find %q", startMarker)
+	}
+	end := strings.Index(source[start:], endMarker)
+	if end == -1 {
+		t.Fatalf("could not find %q after %q", endMarker, startMarker)
+	}
+	return source[start : start+end]
 }

--- a/internal/doltserver/wisps_migrate.go
+++ b/internal/doltserver/wisps_migrate.go
@@ -333,9 +333,21 @@ func copyAuxiliaryData(workDir string, result *MigrateWispsResult) error {
 
 	// Copy dependencies
 	if err := bdSQL(workDir,
-		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d INNER JOIN wisps w ON d.issue_id = w.id"); err != nil {
+		"INSERT IGNORE INTO wisp_dependencies (issue_id, depends_on_issue_id, depends_on_wisp_id, depends_on_external, type, created_at, created_by, metadata, thread_id) SELECT d.issue_id, CASE WHEN target_wisp.id IS NULL THEN d.depends_on_issue_id ELSE NULL END, CASE WHEN target_wisp.id IS NOT NULL THEN d.depends_on_issue_id ELSE d.depends_on_wisp_id END, d.depends_on_external, d.type, d.created_at, d.created_by, d.metadata, d.thread_id FROM dependencies d INNER JOIN wisps w ON d.issue_id = w.id LEFT JOIN wisps target_wisp ON target_wisp.id = d.depends_on_issue_id"); err != nil {
 		if !strings.Contains(err.Error(), "nothing") {
 			return fmt.Errorf("copying dependencies: %w", err)
+		}
+	}
+	if err := bdSQL(workDir,
+		"UPDATE wisp_dependencies wd INNER JOIN wisps target_wisp ON target_wisp.id = wd.depends_on_issue_id SET wd.depends_on_wisp_id = wd.depends_on_issue_id, wd.depends_on_issue_id = NULL"); err != nil {
+		if !strings.Contains(err.Error(), "nothing") {
+			return fmt.Errorf("retargeting wisp dependency targets: %w", err)
+		}
+	}
+	if err := bdSQL(workDir,
+		"UPDATE dependencies d INNER JOIN wisps target_wisp ON target_wisp.id = d.depends_on_issue_id SET d.depends_on_wisp_id = d.depends_on_issue_id, d.depends_on_issue_id = NULL"); err != nil {
+		if !strings.Contains(err.Error(), "nothing") {
+			return fmt.Errorf("retargeting dependency targets: %w", err)
 		}
 	}
 	cnt, _ = bdSQLCount(workDir, "SELECT COUNT(*) as cnt FROM wisp_dependencies")

--- a/internal/doltserver/wisps_migrate_schema_test.go
+++ b/internal/doltserver/wisps_migrate_schema_test.go
@@ -1,0 +1,63 @@
+package doltserver
+
+import (
+	"os"
+	"strings"
+	"testing"
+)
+
+func TestWispDependenciesCreateDDLUsesTypedTargets(t *testing.T) {
+	if strings.Contains(wispDependenciesCreateDDL, "depends_on_id") {
+		t.Fatalf("wisp_dependencies DDL should not create legacy depends_on_id:\n%s", wispDependenciesCreateDDL)
+	}
+	for _, want := range []string{
+		"id char(36)",
+		"depends_on_issue_id varchar(255)",
+		"depends_on_wisp_id varchar(255)",
+		"depends_on_external varchar(255)",
+		"UNIQUE KEY uk_wisp_dep_issue_target",
+		"UNIQUE KEY uk_wisp_dep_wisp_target",
+		"UNIQUE KEY uk_wisp_dep_external_target",
+		"CONSTRAINT ck_wisp_dep_one_target",
+	} {
+		if !strings.Contains(wispDependenciesCreateDDL, want) {
+			t.Fatalf("wisp_dependencies DDL missing %q:\n%s", want, wispDependenciesCreateDDL)
+		}
+	}
+}
+
+func TestCopyAuxiliaryDataUsesTypedDependencyTargets(t *testing.T) {
+	data, err := os.ReadFile("wisps_migrate.go")
+	if err != nil {
+		t.Fatalf("read wisps_migrate.go: %v", err)
+	}
+	body := doltserverSourceBetween(t, string(data), "func copyAuxiliaryData(", "// deriveDBName")
+	if strings.Contains(body, "depends_on_id") {
+		t.Fatalf("copyAuxiliaryData should not copy legacy depends_on_id:\n%s", body)
+	}
+	for _, want := range []string{
+		"depends_on_issue_id, depends_on_wisp_id, depends_on_external",
+		"CASE WHEN target_wisp.id IS NULL THEN d.depends_on_issue_id ELSE NULL END",
+		"CASE WHEN target_wisp.id IS NOT NULL THEN d.depends_on_issue_id ELSE d.depends_on_wisp_id END",
+		"LEFT JOIN wisps target_wisp ON target_wisp.id = d.depends_on_issue_id",
+		"UPDATE wisp_dependencies wd INNER JOIN wisps target_wisp ON target_wisp.id = wd.depends_on_issue_id",
+		"UPDATE dependencies d INNER JOIN wisps target_wisp ON target_wisp.id = d.depends_on_issue_id",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("copyAuxiliaryData missing %q:\n%s", want, body)
+		}
+	}
+}
+
+func doltserverSourceBetween(t *testing.T, source, startMarker, endMarker string) string {
+	t.Helper()
+	start := strings.Index(source, startMarker)
+	if start == -1 {
+		t.Fatalf("could not find %q", startMarker)
+	}
+	end := strings.Index(source[start:], endMarker)
+	if end == -1 {
+		t.Fatalf("could not find %q after %q", endMarker, startMarker)
+	}
+	return source[start : start+end]
+}

--- a/internal/reaper/reaper.go
+++ b/internal/reaper/reaper.go
@@ -273,7 +273,7 @@ func HasReaperSchema(db *sql.DB) (bool, error) {
 	if err != nil || !dependenciesExists {
 		return !dependenciesExists, err
 	}
-	return hasColumns(ctx, db, "dependencies", "depends_on_issue_id")
+	return hasColumns(ctx, db, "dependencies", "depends_on_issue_id", "depends_on_wisp_id", "depends_on_external")
 }
 
 func tableExists(ctx context.Context, db *sql.DB, table string) (bool, error) {

--- a/internal/reaper/reaper_test.go
+++ b/internal/reaper/reaper_test.go
@@ -114,6 +114,16 @@ func TestReaperQueriesUseTypedDependencyColumns(t *testing.T) {
 	scanBody := sourceBetween(t, source, "func Scan(", "func Reap(")
 	autoCloseBody := sourceBetween(t, source, "func AutoClose(", "// batchDeleteRows")
 	batchDeleteBody := sourceBetween(t, source, "func batchDeleteRows(", "// ClosePluginReceiptResult")
+	schemaBody := sourceBetween(t, source, "func HasReaperSchema(", "func tableExists(")
+
+	for _, want := range []string{
+		`hasColumns(ctx, db, "wisp_dependencies", "depends_on_issue_id", "depends_on_wisp_id", "depends_on_external")`,
+		`hasColumns(ctx, db, "dependencies", "depends_on_issue_id", "depends_on_wisp_id", "depends_on_external")`,
+	} {
+		if !strings.Contains(schemaBody, want) {
+			t.Fatalf("HasReaperSchema missing typed schema gate %q", want)
+		}
+	}
 
 	for _, body := range []struct {
 		name string


### PR DESCRIPTION
## Summary

- Hardens wisp/dependency cleanup paths against the current typed dependency schema.
- Stops obsolete `depends_on_id` assumptions in cleanup/reaper paths.
- Adds focused guards for compact cleanup, doctor migration, doltserver wisp migration, and reaper schema checks.

## Context

Addresses repeated production escalations where `bd mol wisp gc --closed --force`, Deacon patrols, and refinery patrols failed with missing `depends_on_id` columns, context-canceled batch deletes, or timeout fallout while Dolt itself stayed responsive.

Related diagnostics recorded in `gt-wisp-gc-dependency-schema`:
- `/tmp/dolt-wisp-gc-context-canceled-1781537350.log`
- `/tmp/dolt-status-wisp-gc-context-canceled-1781537350.log`
- `/tmp/dolt-dotfiles-wisp-gc-timeout-1781538140.log`
- `/tmp/dolt-status-dotfiles-wisp-gc-timeout-1781538140.log`

## Verification

Reported by the implementing polecat:
- `CGO_ENABLED=0 go test ./internal/cmd ./internal/doctor ./internal/doltserver` focused guards passed
- `go test ./internal/reaper -run TestReaperQueriesUseTypedDependencyColumns