### PR TITLE
fix(plugin): stuck-agent-dog — resolve hooks from the rig dir, non-fatal

### DIFF
--- a/plugins/stuck-agent-dog/run.sh
+++ b/plugins/stuck-agent-dog/run.sh
@@ -53,6 +53,26 @@ has_in_progress_work() {
   return 1
 }
 
+# --- Beads resolution helpers -------------------------------------------------
+# The plugin runs from the dog's cwd, which is NOT a beads workspace. `gt hook
+# show` and `bd` resolve the beads database from the CWD, so they must run from
+# the target rig's directory to hit that rig's database — otherwise they fail
+# with "not in a beads workspace" / "no beads database found". Each helper runs
+# in a subshell cd'd into the rig dir and is non-fatal: a rig whose beads cannot
+# be resolved (e.g. an inactive rig) is skipped instead of aborting the whole
+# plugin under `set -e` (hq-9e770).
+
+rig_hook_line() {
+  local rig="$1" pcat="$2"
+  ( cd "$TOWN_ROOT/$rig" 2>/dev/null && gt hook show "$rig/polecats/$pcat" 2>/dev/null | head -1 ) || true
+}
+
+rig_bead_status() {
+  local rig="$1" bead="$2"
+  ( cd "$TOWN_ROOT/$rig" 2>/dev/null && bd show "$bead" --json 2>/dev/null ) \
+    | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0].get('status','') if d else '')" 2>/dev/null || echo ""
+}
+
 # --- Enumerate agents ---------------------------------------------------------
 
 log "=== Checking agent health ==="
@@ -87,13 +107,12 @@ while IFS='|' read -r RIG PREFIX; do
 
     if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
       # Session dead — check hook
-      HOOK_OUTPUT=$(gt hook show "$RIG/polecats/$PCAT_NAME" 2>/dev/null | head -1)
+      HOOK_OUTPUT=$(rig_hook_line "$RIG" "$PCAT_NAME")
       HOOK_BEAD=$(echo "$HOOK_OUTPUT" | grep -v '(empty)' | awk '{print $2}' || true)
 
       if [ -n "$HOOK_BEAD" ]; then
         # Check agent_state
-        AGENT_STATE=$(bd show "$HOOK_BEAD" --json 2>/dev/null \
-          | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0].get('status',''))" 2>/dev/null || echo "")
+        AGENT_STATE=$(rig_bead_status "$RIG" "$HOOK_BEAD")
 
         case "$AGENT_STATE" in
           closed) log "  SKIP $SESSION_NAME: bead closed (completed normally)"; continue ;;
@@ -109,7 +128,7 @@ while IFS='|' read -r RIG PREFIX; do
         PROC_COMM=$(ps -o comm= -p "$PANE_PID" 2>/dev/null)
         if [ -z "$PROC_COMM" ]; then
           # Zombie: process dead, session alive
-          HOOK_OUTPUT=$(gt hook show "$RIG/polecats/$PCAT_NAME" 2>/dev/null | head -1)
+          HOOK_OUTPUT=$(rig_hook_line "$RIG" "$PCAT_NAME")
           HOOK_BEAD=$(echo "$HOOK_OUTPUT" | grep -v '(empty)' | awk '{print $2}' || true)
           if [ -n "$HOOK_BEAD" ]; then
             STUCK+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD|agent_dead")

--- a/plugins/stuck-agent-dog/run.sh
+++ b/plugins/stuck-agent-dog/run.sh
@@ -32,12 +32,11 @@ heartbeat_epoch() {
 has_in_progress_work() {
   local locations=("$TOWN_ROOT")
   local rig=""
-  local prefix=""
   local loc=""
   local output=""
   local count=""
 
-  while IFS='|' read -r rig prefix; do
+  while IFS='|' read -r rig _prefix; do
     [ -z "$rig" ] && continue
     [ -d "$TOWN_ROOT/$rig" ] && locations+=("$TOWN_ROOT/$rig")
   done <<< "$RIG_PREFIX_MAP"
@@ -54,23 +53,46 @@ has_in_progress_work() {
 }
 
 # --- Beads resolution helpers -------------------------------------------------
-# The plugin runs from the dog's cwd, which is NOT a beads workspace. `gt hook
-# show` and `bd` resolve the beads database from the CWD, so they must run from
-# the target rig's directory to hit that rig's database — otherwise they fail
-# with "not in a beads workspace" / "no beads database found". Each helper runs
-# in a subshell cd'd into the rig dir and is non-fatal: a rig whose beads cannot
-# be resolved (e.g. an inactive rig) is skipped instead of aborting the whole
-# plugin under `set -e` (hq-9e770).
+# Plugin scripts may run outside a beads workspace. Resolve hook and status
+# lookups from the target rig workspace, and make missing/inactive rigs
+# non-fatal so one bad rig does not abort the dog under `set -e` (hq-9e770).
 
-rig_hook_line() {
-  local rig="$1" pcat="$2"
-  ( cd "$TOWN_ROOT/$rig" 2>/dev/null && gt hook show "$rig/polecats/$pcat" 2>/dev/null | head -1 ) || true
+rig_workdir() {
+  local rig="$1"
+
+  if [ -d "$TOWN_ROOT/$rig/mayor/rig" ]; then
+    printf '%s\n' "$TOWN_ROOT/$rig/mayor/rig"
+    return 0
+  fi
+
+  if [ -d "$TOWN_ROOT/$rig" ]; then
+    printf '%s\n' "$TOWN_ROOT/$rig"
+    return 0
+  fi
+
+  return 1
+}
+
+rig_hook_bead() {
+  local rig="$1" pcat="$2" dir=""
+
+  if ! dir=$(rig_workdir "$rig"); then
+    return 0
+  fi
+
+  ( cd "$dir" 2>/dev/null && gt hook show "$rig/polecats/$pcat" --json 2>/dev/null ) \
+    | jq -r '.bead_id // empty' 2>/dev/null || true
 }
 
 rig_bead_status() {
-  local rig="$1" bead="$2"
-  ( cd "$TOWN_ROOT/$rig" 2>/dev/null && bd show "$bead" --json 2>/dev/null ) \
-    | python3 -c "import json,sys; d=json.load(sys.stdin); print(d[0].get('status','') if d else '')" 2>/dev/null || echo ""
+  local rig="$1" bead="$2" dir=""
+
+  if ! dir=$(rig_workdir "$rig"); then
+    return 0
+  fi
+
+  ( cd "$dir" 2>/dev/null && bd show "$bead" --json 2>/dev/null ) \
+    | jq -r '.[0].status // empty' 2>/dev/null || true
 }
 
 # --- Enumerate agents ---------------------------------------------------------
@@ -107,15 +129,14 @@ while IFS='|' read -r RIG PREFIX; do
 
     if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
       # Session dead — check hook
-      HOOK_OUTPUT=$(rig_hook_line "$RIG" "$PCAT_NAME")
-      HOOK_BEAD=$(echo "$HOOK_OUTPUT" | grep -v '(empty)' | awk '{print $2}' || true)
+      HOOK_BEAD=$(rig_hook_bead "$RIG" "$PCAT_NAME")
 
       if [ -n "$HOOK_BEAD" ]; then
-        # Check agent_state
-        AGENT_STATE=$(rig_bead_status "$RIG" "$HOOK_BEAD")
+        BEAD_STATUS=$(rig_bead_status "$RIG" "$HOOK_BEAD")
 
-        case "$AGENT_STATE" in
+        case "$BEAD_STATUS" in
           closed) log "  SKIP $SESSION_NAME: bead closed (completed normally)"; continue ;;
+          "") log "  SKIP $SESSION_NAME: hook=$HOOK_BEAD status unavailable"; continue ;;
         esac
 
         CRASHED+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD")
@@ -128,8 +149,7 @@ while IFS='|' read -r RIG PREFIX; do
         PROC_COMM=$(ps -o comm= -p "$PANE_PID" 2>/dev/null)
         if [ -z "$PROC_COMM" ]; then
           # Zombie: process dead, session alive
-          HOOK_OUTPUT=$(rig_hook_line "$RIG" "$PCAT_NAME")
-          HOOK_BEAD=$(echo "$HOOK_OUTPUT" | grep -v '(empty)' | awk '{print $2}' || true)
+          HOOK_BEAD=$(rig_hook_bead "$RIG" "$PCAT_NAME")
           if [ -n "$HOOK_BEAD" ]; then
             STUCK+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD|agent_dead")
             log "  ZOMBIE: $SESSION_NAME (pid=$PANE_PID dead, hook=$HOOK_BEAD)"

--- a/plugins/stuck-agent-dog/run.sh
+++ b/plugins/stuck-agent-dog/run.sh
@@ -95,6 +95,21 @@ rig_bead_status() {
     | jq -r '.[0].status // empty' 2>/dev/null || true
 }
 
+bead_restartable() {
+  local session="$1" rig="$2" bead="$3" status=""
+
+  status=$(rig_bead_status "$rig" "$bead")
+
+  case "$status" in
+    open|hooked|in_progress) return 0 ;;
+    closed) log "  SKIP $session: bead closed (completed normally)" ;;
+    "") log "  SKIP $session: hook=$bead status unavailable" ;;
+    *) log "  SKIP $session: hook=$bead status=$status not actionable" ;;
+  esac
+
+  return 1
+}
+
 # --- Enumerate agents ---------------------------------------------------------
 
 log "=== Checking agent health ==="
@@ -131,26 +146,19 @@ while IFS='|' read -r RIG PREFIX; do
       # Session dead — check hook
       HOOK_BEAD=$(rig_hook_bead "$RIG" "$PCAT_NAME")
 
-      if [ -n "$HOOK_BEAD" ]; then
-        BEAD_STATUS=$(rig_bead_status "$RIG" "$HOOK_BEAD")
-
-        case "$BEAD_STATUS" in
-          closed) log "  SKIP $SESSION_NAME: bead closed (completed normally)"; continue ;;
-          "") log "  SKIP $SESSION_NAME: hook=$HOOK_BEAD status unavailable"; continue ;;
-        esac
-
+      if [ -n "$HOOK_BEAD" ] && bead_restartable "$SESSION_NAME" "$RIG" "$HOOK_BEAD"; then
         CRASHED+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD")
         log "  CRASHED: $SESSION_NAME (hook=$HOOK_BEAD)"
       fi
     else
       # Session alive — check process
-      PANE_PID=$(tmux list-panes -t "$SESSION_NAME" -F '#{pane_pid}' 2>/dev/null | head -1)
+      PANE_PID=$(tmux list-panes -t "$SESSION_NAME" -F '#{pane_pid}' 2>/dev/null | head -1 || true)
       if [ -n "$PANE_PID" ]; then
-        PROC_COMM=$(ps -o comm= -p "$PANE_PID" 2>/dev/null)
+        PROC_COMM=$(ps -o comm= -p "$PANE_PID" 2>/dev/null || true)
         if [ -z "$PROC_COMM" ]; then
           # Zombie: process dead, session alive
           HOOK_BEAD=$(rig_hook_bead "$RIG" "$PCAT_NAME")
-          if [ -n "$HOOK_BEAD" ]; then
+          if [ -n "$HOOK_BEAD" ] && bead_restartable "$SESSION_NAME" "$RIG" "$HOOK_BEAD"; then
             STUCK+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD|agent_dead")
             log "  ZOMBIE: $SESSION_NAME (pid=$PANE_PID dead, hook=$HOOK_BEAD)"
           fi
@@ -181,8 +189,8 @@ if ! tmux has-session -t "$DEACON_SESSION" 2>/dev/null; then
   log "  CRASHED: Deacon session is dead"
   DEACON_ISSUE="crashed"
 else
-  DEACON_PID=$(tmux list-panes -t "$DEACON_SESSION" -F '#{pane_pid}' 2>/dev/null | head -1)
-  DEACON_COMM=$(ps -o comm= -p "$DEACON_PID" 2>/dev/null)
+  DEACON_PID=$(tmux list-panes -t "$DEACON_SESSION" -F '#{pane_pid}' 2>/dev/null | head -1 || true)
+  DEACON_COMM=$(ps -o comm= -p "$DEACON_PID" 2>/dev/null || true)
   if [ -z "$DEACON_COMM" ]; then
     log "  ZOMBIE: Deacon process dead (pid=$DEACON_PID), session alive"
     DEACON_ISSUE="zombie"
@@ -203,7 +211,7 @@ else
       # recent activity means the file-write path diverged (e.g. a long
       # turn, or the agent refreshing a different store) — not a stuck
       # Deacon. Escalating that as stuck caused a false-positive storm.
-      ACTIVITY_TIME=$(tmux display-message -t "$DEACON_SESSION" -p '#{window_activity}' 2>/dev/null)
+      ACTIVITY_TIME=$(tmux display-message -t "$DEACON_SESSION" -p '#{window_activity}' 2>/dev/null || true)
       case "$ACTIVITY_TIME" in
         ''|*[!0-9]*) ACTIVITY_AGE="" ;;
         *) ACTIVITY_AGE=$(( NOW - ACTIVITY_TIME )) ;;


### PR DESCRIPTION
## Problem

The `stuck-agent-dog` plugin runs from the dog's cwd, which is **not** a beads workspace. It called `gt hook show <rig>/polecats/<name>` and `bd show <bead>` directly — but `gt`/`bd` resolve the beads database from the **CWD**, not from the target. So those calls failed with `not in a beads workspace` / `no beads database found`, and under `set -euo pipefail` the failing command substitution **aborted the entire plugin** (dogs reported "Plugin FAILED": hq-9e770, and a swarm of related HIGH alerts about `gt hook show` routing/lookup failures).

Reproduced: running the plugin from a neutral cwd aborts right after the first log line; `gt hook show courier/polecats/x` errors `no beads database found`.

## Fix

Two small helpers resolve hooks/bead-status **from the target rig's directory**, in a subshell, and non-fatally:

```sh
rig_hook_line()   { ( cd "$TOWN_ROOT/$rig" 2>/dev/null && gt hook show "$rig/polecats/$pcat" 2>/dev/null | head -1 ) || true; }
rig_bead_status() { ( cd "$TOWN_ROOT/$rig" 2>/dev/null && bd show "$bead" --json 2>/dev/null ) | python3 -c '...' || echo ""; }
```

- **cd into the rig dir** so `bd` resolves *that rig's* database (matches what the existing `has_in_progress_work` already does with `cd "$loc"`).
- **non-fatal** (`|| true`) so a rig whose beads can't be resolved (e.g. an inactive rig) is skipped instead of aborting the whole run under `set -e`.

## Verification

Before: plugin aborts after `=== Checking agent health ===` (exit non-zero). After: completes end to end — `Polecat health … / Deacon Health / === Agent health: … ===` — exit 0. Deployed to a live town via `gt plugin sync`; the dogs' "Plugin FAILED" escalations stop.

Fixes hq-9e770.