### PR TITLE
fix(daemon): retry dog wisp close and harden dolt backup

### DIFF
--- a/internal/daemon/dog_molecule.go
+++ b/internal/daemon/dog_molecule.go
@@ -16,7 +16,32 @@ import (
 const (
 	// bdMolTimeout is the timeout for bd molecule operations.
 	bdMolTimeout = 15 * time.Second
+
+	// dogCloseMaxAttempts / dogCloseRetryDelay bound the retry on `bd close` for
+	// dog wisps. A transient Dolt slowdown (the connection-churn window) can make
+	// a single close fail, and without a retry the wisp stays OPEN forever — a
+	// root cause of the dog wisp flood (gt-ye21). Retrying turns a transient
+	// failure back into a clean close instead of a permanent orphan.
+	dogCloseMaxAttempts = 3
+	dogCloseRetryDelay  = 500 * time.Millisecond
 )
+
+// closeWisp runs `bd close <id>` (plus any extra args) with bounded retries so a
+// transient Dolt error does not leave the wisp open. Returns the final error if
+// every attempt fails.
+func (dm *dogMol) closeWisp(id string, extra ...string) error {
+	args := append([]string{"close", id}, extra...)
+	var err error
+	for attempt := 1; attempt <= dogCloseMaxAttempts; attempt++ {
+		if _, err = dm.runBd(args...); err == nil {
+			return nil
+		}
+		if attempt < dogCloseMaxAttempts {
+			time.Sleep(time.Duration(attempt) * dogCloseRetryDelay)
+		}
+	}
+	return err
+}
 
 // dogMol tracks a molecule (wisp) lifecycle for a daemon dog patrol.
 // Graceful degradation: if bd fails, the dog still does its work — molecule
@@ -115,9 +140,8 @@ func (dm *dogMol) close() {
 	// Close any step wisps that were never explicitly closed/failed.
 	dm.closeRemainingSteps()
 
-	_, err := dm.runBd("close", dm.rootID)
-	if err != nil {
-		dm.logger.Printf("dog_molecule: close root %s failed (non-fatal): %v", dm.rootID, err)
+	if err := dm.closeWisp(dm.rootID); err != nil {
+		dm.logger.Printf("dog_molecule: close root %s failed after %d attempts (non-fatal): %v", dm.rootID, dogCloseMaxAttempts, err)
 	}
 }
 
@@ -148,8 +172,8 @@ func (dm *dogMol) closeRemainingSteps() {
 		}
 		// Close any child that is still open/hooked/in_progress.
 		if child.Status == "open" || child.Status == "hooked" || child.Status == "in_progress" {
-			if _, err := dm.runBd("close", child.ID); err != nil {
-				dm.logger.Printf("dog_molecule: closeRemainingSteps: close %s failed: %v", child.ID, err)
+			if err := dm.closeWisp(child.ID); err != nil {
+				dm.logger.Printf("dog_molecule: closeRemainingSteps: close %s failed after %d attempts: %v", child.ID, dogCloseMaxAttempts, err)
 			} else {
 				closed++
 			}

--- a/internal/daemon/dog_molecule.go
+++ b/internal/daemon/dog_molecule.go
@@ -104,9 +104,8 @@ func (dm *dogMol) closeStep(stepSlug string) {
 		return
 	}
 
-	_, err := dm.runBd("close", stepID)
-	if err != nil {
-		dm.logger.Printf("dog_molecule: close step %s (%s) failed (non-fatal): %v", stepSlug, stepID, err)
+	if err := dm.closeWisp(stepID); err != nil {
+		dm.logger.Printf("dog_molecule: close step %s (%s) failed after %d attempts (non-fatal): %v", stepSlug, stepID, dogCloseMaxAttempts, err)
 		return
 	}
 }
@@ -123,9 +122,8 @@ func (dm *dogMol) failStep(stepSlug, reason string) {
 		return
 	}
 
-	_, err := dm.runBd("close", stepID, "--reason", reason)
-	if err != nil {
-		dm.logger.Printf("dog_molecule: fail step %s (%s) failed (non-fatal): %v", stepSlug, stepID, err)
+	if err := dm.closeWisp(stepID, "--reason", reason); err != nil {
+		dm.logger.Printf("dog_molecule: fail step %s (%s) failed after %d attempts (non-fatal): %v", stepSlug, stepID, dogCloseMaxAttempts, err)
 	}
 }
 

--- a/internal/daemon/dolt_backup.go
+++ b/internal/daemon/dolt_backup.go
@@ -16,7 +16,15 @@ import (
 
 const (
 	defaultDoltBackupInterval = 15 * time.Minute
-	doltBackupTimeout         = 120 * time.Second
+	// doltBackupTimeout is generous so a large commit delta on a big database
+	// (e.g. hq under a wisp flood) does not blow the deadline mid-sync. The old
+	// 120s ceiling produced spurious exit-1 backup failures (gt-ye21).
+	doltBackupTimeout = 5 * time.Minute
+	// doltBackupRetries / doltBackupRetryDelay retry a failed sync after a short
+	// pause, so a transient lock (a concurrent dolt op holding the db) does not
+	// fail the whole backup cycle.
+	doltBackupRetries    = 1
+	doltBackupRetryDelay = 5 * time.Second
 )
 
 // doltBackupInterval returns the configured backup interval, or the default (15m).
@@ -106,23 +114,33 @@ func (d *Daemon) syncDoltBackups() {
 	mol.closeStep("report")
 }
 
-// syncBackup runs `dolt backup sync <backup-name>` for a single database.
+// syncBackup runs `dolt backup sync <backup-name>` for a single database,
+// retrying once on failure so a transient lock or large delta does not fail the
+// cycle (gt-ye21).
 func (d *Daemon) syncBackup(dataDir, db, backupName string) error {
-	ctx, cancel := context.WithTimeout(context.Background(), doltBackupTimeout)
-	defer cancel()
-
 	dbDir := dataDir + "/" + db
-	cmd := exec.CommandContext(ctx, "dolt", "backup", "sync", backupName)
-	cmd.Dir = dbDir
-	util.SetDetachedProcessGroup(cmd)
 
-	output, err := cmd.CombinedOutput()
-	if err != nil {
-		return fmt.Errorf("%s: %s", err, strings.TrimSpace(string(output)))
+	var lastErr error
+	for attempt := 0; attempt <= doltBackupRetries; attempt++ {
+		if attempt > 0 {
+			time.Sleep(doltBackupRetryDelay)
+			d.logger.Printf("dolt_backup: %s: retry %d/%d after error: %v", db, attempt, doltBackupRetries, lastErr)
+		}
+
+		ctx, cancel := context.WithTimeout(context.Background(), doltBackupTimeout)
+		cmd := exec.CommandContext(ctx, "dolt", "backup", "sync", backupName)
+		cmd.Dir = dbDir
+		util.SetDetachedProcessGroup(cmd)
+
+		output, err := cmd.CombinedOutput()
+		cancel()
+		if err == nil {
+			d.logger.Printf("dolt_backup: %s: synced to %s", db, backupName)
+			return nil
+		}
+		lastErr = fmt.Errorf("%s: %s", err, strings.TrimSpace(string(output)))
 	}
-
-	d.logger.Printf("dolt_backup: %s: synced to %s", db, backupName)
-	return nil
+	return lastErr
 }
 
 // syncOffsiteBackup rsyncs the local backup directory to iCloud Drive.

--- a/internal/daemon/dolt_backup.go
+++ b/internal/daemon/dolt_backup.go
@@ -118,19 +118,29 @@ func (d *Daemon) syncDoltBackups() {
 // retrying once on failure so a transient lock or large delta does not fail the
 // cycle (gt-ye21).
 func (d *Daemon) syncBackup(dataDir, db, backupName string) error {
-	dbDir := dataDir + "/" + db
+	parentCtx := d.ctx
+	if parentCtx == nil {
+		parentCtx = context.Background()
+	}
+	dbDir := filepath.Join(dataDir, db)
 
 	var lastErr error
 	for attempt := 0; attempt <= doltBackupRetries; attempt++ {
 		if attempt > 0 {
-			time.Sleep(doltBackupRetryDelay)
 			d.logger.Printf("dolt_backup: %s: retry %d/%d after error: %v", db, attempt, doltBackupRetries, lastErr)
+			timer := time.NewTimer(doltBackupRetryDelay)
+			select {
+			case <-timer.C:
+			case <-parentCtx.Done():
+				timer.Stop()
+				return parentCtx.Err()
+			}
 		}
 
-		ctx, cancel := context.WithTimeout(context.Background(), doltBackupTimeout)
+		ctx, cancel := context.WithTimeout(parentCtx, doltBackupTimeout)
 		cmd := exec.CommandContext(ctx, "dolt", "backup", "sync", backupName)
 		cmd.Dir = dbDir
-		util.SetDetachedProcessGroup(cmd)
+		util.SetProcessGroup(cmd)
 
 		output, err := cmd.CombinedOutput()
 		cancel()


### PR DESCRIPTION
Replacement/fixup for #4271.\n\nThis is the PR Sheriff-approved fixup branch from gt-pr-sheriff-4271, preserving the contributor fix and adding the narrow sheriff fixup described in the review comment on #4271.\n\nSummary:\n- Converges dog molecule wisp close paths through closeWisp.\n- Hardens Dolt backup retry cancellation/process cleanup.\n- Avoids merging the stale external PR head directly.\n\nSheriff evidence and validation are recorded on #4271.\n\nSupersedes #4271.