### PR TITLE
fix: preserve town beads on reinstall

### DIFF
--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -661,7 +661,7 @@ func writeJSON(path string, data interface{}) error {
 func buildBdInitArgs(townPath string) []string {
 	cfg := doltserver.DefaultConfig(townPath)
 	return []string{"init", "--prefix", "hq", "--server",
-		"--server-port", strconv.Itoa(cfg.Port), "--force"}
+		"--server-port", strconv.Itoa(cfg.Port)}
 }
 
 // initTownBeads initializes town-level beads database using bd init.

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -660,6 +660,7 @@ func writeJSON(path string, data interface{}) error {
 // --server-port derived from the town's Dolt configuration.
 func buildBdInitArgs(townPath string) []string {
 	cfg := doltserver.DefaultConfig(townPath)
+	// gt install --force preserves town state; bd reinit flags would destroy town beads.
 	return []string{"init", "--prefix", "hq", "--server",
 		"--server-port", strconv.Itoa(cfg.Port)}
 }
@@ -692,7 +693,7 @@ func initTownBeads(townPath string) error {
 		return fmt.Errorf("Dolt server is not ready after 10s: %w", lastErr)
 	}
 
-	// Run: bd init --prefix hq --server
+	// Run: bd init --prefix hq --server --server-port <port>
 	// Dolt is the only backend since bd v0.51.0; no --backend flag needed.
 	// Filter inherited BEADS_DIR so bd init targets this town, not a parent .beads.
 	// Always pass --server-port so bd connects to the correct Dolt server.

--- a/internal/cmd/install_test.go
+++ b/internal/cmd/install_test.go
@@ -16,15 +16,15 @@ import (
 	"github.com/steveyegge/gastown/internal/doltserver"
 )
 
-func TestBuildBdInitArgs_AlwaysIncludesServerPort(t *testing.T) {
+func TestBuildBdInitArgs_AlwaysIncludesServerPortWithoutReinit(t *testing.T) {
 	townDir := t.TempDir()
 	t.Setenv("GT_DOLT_PORT", "")
 	t.Setenv("BEADS_DOLT_PORT", "")
 
 	args := buildBdInitArgs(townDir)
 
-	if len(args) != 7 {
-		t.Fatalf("expected 7 args, got %d: %v", len(args), args)
+	if len(args) != 6 {
+		t.Fatalf("expected 6 args, got %d: %v", len(args), args)
 	}
 	if args[4] != "--server-port" {
 		t.Fatalf("expected args[4] = --server-port, got %q", args[4])
@@ -32,8 +32,10 @@ func TestBuildBdInitArgs_AlwaysIncludesServerPort(t *testing.T) {
 	if args[5] != "3307" {
 		t.Fatalf("expected default port 3307, got %q", args[5])
 	}
-	if args[6] != "--force" {
-		t.Fatalf("expected args[6] = --force, got %q", args[6])
+	for _, arg := range args {
+		if arg == "--force" || arg == "--reinit-local" {
+			t.Fatalf("expected no destructive reinit flag, got %v", args)
+		}
 	}
 }
 


### PR DESCRIPTION
Replacement/fixup for #4274.\n\nThis is the PR Sheriff-approved maintainer fixup from gt-pr-sheriff-4274. It preserves the contributor attribution for the real reinstall/town-beads fix and avoids merging the original PR, which added an unrelated root install.go and was marked review-failed.\n\nSummary:\n- Stops passing a destructive bd reinit flag during town install/reinstall.\n- Keeps explicit town prefix/server init behavior.\n- Updates focused tests for the intended install args.\n\nSheriff evidence and validation are recorded on #4274.\n\nSupersedes #4274.