### PR TITLE
fix(deacon-patrol): stop active wisp GC self-destruct

### DIFF
--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -105,11 +105,16 @@ id = "inbox-check"
 title = "Handle callbacks from agents"
 needs = ["heartbeat"]
 description = """
-First, clean up wisps from previous cycles (closed wisps + abandoned wisps):
+First, clean up CLOSED wisps from previous cycles:
 ```bash
 bd mol wisp gc --closed --force
-bd mol wisp gc --age 1h --force
 ```
+
+> **Warning (hq-3pp):** Do not run unscoped age-based wisp GC from inside
+> this patrol. Active patrol step wisps can be older than 1h before they run;
+> age cleanup can reap this molecule's open steps and make the patrol appear
+> complete early. Use closed-only cleanup here; stale open-wisp cleanup belongs
+> outside active patrol molecules.
 
 Then handle callbacks from agents.
 

--- a/internal/formula/patrol_backoff_test.go
+++ b/internal/formula/patrol_backoff_test.go
@@ -123,11 +123,10 @@ func TestPatrolFormulasHaveReportCycle(t *testing.T) {
 }
 
 // TestPatrolFormulasHaveWispGC verifies that all three patrol formulas
-// include `bd mol wisp gc` in their inbox-check step to clean up stale
-// wisps from abnormal exits in previous cycles.
+// include `bd mol wisp gc` in their inbox-check step for safe cleanup.
 //
-// Without this, patrol agents that die/restart abnormally before reaching
-// the loop-or-exit squash step leave their wisps open indefinitely.
+// Closed-wisp cleanup is safe inside active patrols. Stale open-wisp cleanup
+// belongs to reaper paths that are not running inside the active patrol molecule.
 //
 // Regression test for steveyegge/gastown#1712.
 func TestPatrolFormulasHaveWispGC(t *testing.T) {
@@ -169,6 +168,40 @@ func TestPatrolFormulasHaveWispGC(t *testing.T) {
 					name)
 			}
 		})
+	}
+}
+
+// TestDeaconPatrolDoesNotRunAgeBasedWispGC verifies that the Deacon patrol
+// does not reap open step wisps from its own active patrol molecule.
+//
+// Regression test for hq-3pp.
+func TestDeaconPatrolDoesNotRunAgeBasedWispGC(t *testing.T) {
+	content, err := formulasFS.ReadFile("formulas/mol-deacon-patrol.formula.toml")
+	if err != nil {
+		t.Fatalf("reading deacon patrol formula: %v", err)
+	}
+
+	f, err := Parse(content)
+	if err != nil {
+		t.Fatalf("parsing deacon patrol formula: %v", err)
+	}
+
+	var inboxDesc string
+	for _, step := range f.Steps {
+		if step.ID == "inbox-check" {
+			inboxDesc = step.Description
+			break
+		}
+	}
+	if inboxDesc == "" {
+		t.Fatal("deacon patrol formula: inbox-check step not found or has empty description")
+	}
+
+	if !strings.Contains(inboxDesc, "bd mol wisp gc --closed --force") {
+		t.Fatal("deacon inbox-check must keep closed-wisp cleanup")
+	}
+	if strings.Contains(inboxDesc, "bd mol wisp gc --age") {
+		t.Fatal("deacon inbox-check must not run age-based wisp GC inside the active patrol")
 	}
 }
 


### PR DESCRIPTION
Replacement/fixup for #4264.\n\nThis is the PR Sheriff-approved maintainer fixup from gt-pr-sheriff-4264, cherry-picked cleanly onto current main after #4286/#4287 landed. It preserves contributor authorship and avoids merging stale PR history directly.\n\nSummary:\n- Removes executable age-based wisp GC from active Deacon patrol callbacks.\n- Keeps closed-wisp cleanup.\n- Adds a focused regression test that Deacon patrol does not run age-based wisp GC.\n\nSheriff evidence and validation are recorded on #4264.\n\nSupersedes #4264.