### PR TITLE
fix(plugins): close ephemeral run-log beads so they don't leak

### DIFF
--- a/plugins/compactor-dog/run.sh
+++ b/plugins/compactor-dog/run.sh
@@ -201,9 +201,9 @@ log "Skipped (below threshold): ${#SKIPPED[@]}"
 if [[ ${#CANDIDATES[@]} -eq 0 ]]; then
   log "All databases within threshold ($COMMIT_THRESHOLD). No compaction needed."
   SUMMARY="compactor-dog: all ${DB_COUNT} DBs below threshold ($COMMIT_THRESHOLD commits)"
-  bd create "$SUMMARY" -t chore --ephemeral \
+  __rid="$(bd create "$SUMMARY" -t chore --ephemeral \
     -l type:plugin-run,plugin:compactor-dog,result:success \
-    -d "$SUMMARY" --silent 2>/dev/null || true
+    -d "$SUMMARY" --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
   exit 0
 fi
 
@@ -216,9 +216,9 @@ if $CHECK_ONLY; then
     log "  ${entry%%:*} (${entry##*:} commits) — recommends compaction"
   done
   SUMMARY="compactor-dog: ${#CANDIDATES[@]} DBs exceed threshold ($COMMIT_THRESHOLD commits)"
-  bd create "$SUMMARY" -t chore --ephemeral \
+  __rid="$(bd create "$SUMMARY" -t chore --ephemeral \
     -l type:plugin-run,plugin:compactor-dog,result:check-only \
-    -d "$SUMMARY" --silent 2>/dev/null || true
+    -d "$SUMMARY" --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
   exit 0
 fi
 
@@ -478,13 +478,13 @@ if [[ $ERRORS -gt 0 ]]; then
   gt escalate "compactor-dog: $ERRORS databases had compaction errors" -s MEDIUM \
     --reason "Compaction cycle completed with errors. $SUMMARY" 2>/dev/null || true
 
-  bd create "compactor-dog: ERRORS — $SUMMARY" -t chore --ephemeral \
+  __rid="$(bd create "compactor-dog: ERRORS — $SUMMARY" -t chore --ephemeral \
     -l type:plugin-run,plugin:compactor-dog,result:warning \
-    -d "Compaction completed with $ERRORS errors. $SUMMARY" --silent 2>/dev/null || true
+    -d "Compaction completed with $ERRORS errors. $SUMMARY" --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
 else
-  bd create "$SUMMARY" -t chore --ephemeral \
+  __rid="$(bd create "$SUMMARY" -t chore --ephemeral \
     -l type:plugin-run,plugin:compactor-dog,result:success \
-    -d "$SUMMARY" --silent 2>/dev/null || true
+    -d "$SUMMARY" --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
 fi
 
 log "Done."

--- a/plugins/dolt-archive/run.sh
+++ b/plugins/dolt-archive/run.sh
@@ -224,9 +224,9 @@ if [[ "$EXPORT_FAILED" -gt 0 ]] || [[ "$DOLT_PUSH_FAILED" -gt 0 ]]; then
   RESULT="warning"
 fi
 
-bd create "$SUMMARY" -t chore --ephemeral \
+__rid="$(bd create "$SUMMARY" -t chore --ephemeral \
   -l type:plugin-run,plugin:dolt-archive,result:$RESULT \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+  -d "$SUMMARY" --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
 
 if [[ "$EXPORT_FAILED" -gt 0 ]]; then
   gt escalate "dolt-archive: JSONL export failed for $EXPORT_FAILED databases ($EXPORT_ERRORS)" \

--- a/plugins/dolt-backup/run.sh
+++ b/plugins/dolt-backup/run.sh
@@ -185,15 +185,15 @@ log "$SUMMARY"
 
 if [[ "$FAILED" -eq 0 ]]; then
   # Success — record quietly
-  bd create --title "dolt-backup: $SUMMARY" -t chore --ephemeral \
+  __rid="$(bd create --title "dolt-backup: $SUMMARY" -t chore --ephemeral \
     -l type:plugin-run,plugin:dolt-backup,result:success \
-    -d "$SUMMARY" --silent 2>/dev/null || true
+    -d "$SUMMARY" --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
 else
   # Failure — record and escalate
   FAIL_MSG="$SUMMARY. Failed:$FAILED_DBS"
-  bd create --title "dolt-backup: FAILED - $FAIL_MSG" -t chore --ephemeral \
+  __rid="$(bd create --title "dolt-backup: FAILED - $FAIL_MSG" -t chore --ephemeral \
     -l type:plugin-run,plugin:dolt-backup,result:failure \
-    -d "$FAIL_MSG" --silent 2>/dev/null || true
+    -d "$FAIL_MSG" --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
 
   gt escalate "dolt-backup FAILED: $FAIL_MSG" \
     --severity high \

--- a/plugins/dolt-log-rotate/run.sh
+++ b/plugins/dolt-log-rotate/run.sh
@@ -35,9 +35,9 @@ log "Current log size: ${SIZE_MB}MB (threshold: ${MAX_MB}MB)"
 
 if [[ $SIZE_MB -lt $MAX_MB ]]; then
   log "Below threshold. Nothing to do."
-  bd create "dolt-log-rotate: log size ${SIZE_MB}MB, below ${MAX_MB}MB threshold" \
+  __rid="$(bd create "dolt-log-rotate: log size ${SIZE_MB}MB, below ${MAX_MB}MB threshold" \
     -t chore --ephemeral -l type:plugin-run,plugin:dolt-log-rotate,result:success \
-    --silent 2>/dev/null || true
+    --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
   exit 0
 fi
 
@@ -87,6 +87,6 @@ SUMMARY="dolt-log-rotate: rotated ${SIZE_MB}MB -> ${COMPRESSED_MB}MB compressed,
 log ""
 log "=== Done === $SUMMARY"
 
-bd create "$SUMMARY" -t chore --ephemeral \
+__rid="$(bd create "$SUMMARY" -t chore --ephemeral \
   -l type:plugin-run,plugin:dolt-log-rotate,result:success \
-  --silent 2>/dev/null || true
+  --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true

--- a/plugins/git-hygiene/run.sh
+++ b/plugins/git-hygiene/run.sh
@@ -170,6 +170,6 @@ log ""
 log "=== Git Hygiene Summary ==="
 log "$SUMMARY"
 
-bd create "git-hygiene: $SUMMARY" -t chore --ephemeral \
+__rid="$(bd create "git-hygiene: $SUMMARY" -t chore --ephemeral \
   -l type:plugin-run,plugin:git-hygiene,result:success \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+  -d "$SUMMARY" --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true

--- a/plugins/gitignore-reconcile/run.sh
+++ b/plugins/gitignore-reconcile/run.sh
@@ -101,8 +101,8 @@ log "=== Summary ==="
 SUMMARY="gitignore-reconcile: $TOTAL_UNTRACKED file(s) untracked, $TOTAL_BEADS chore bead(s) created"
 log "$SUMMARY"
 
-bd create "$SUMMARY" -t chore --ephemeral \
+__rid="$(bd create "$SUMMARY" -t chore --ephemeral \
   -l "type:plugin-run,plugin:gitignore-reconcile,result:success" \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+  -d "$SUMMARY" --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
 
 log "Done."

--- a/plugins/rebuild-gt/run.sh
+++ b/plugins/rebuild-gt/run.sh
@@ -25,17 +25,17 @@ SAFE=$(echo "$STALE_JSON" | python3 -c "import json,sys; print(json.load(sys.std
 
 if [ "$IS_STALE" != "True" ]; then
   log "Binary is fresh. Nothing to do."
-  bd create "rebuild-gt: binary is fresh" -t chore --ephemeral \
+  __rid="$(bd create "rebuild-gt: binary is fresh" -t chore --ephemeral \
     -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:success \
-    --silent 2>/dev/null || true
+    --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
   exit 0
 fi
 
 if [ "$SAFE" != "True" ]; then
   log "Not safe to rebuild (not on main or would be a downgrade). Skipping."
-  bd create "Plugin: rebuild-gt [skipped]" -t chore --ephemeral \
+  __rid="$(bd create "Plugin: rebuild-gt [skipped]" -t chore --ephemeral \
     -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:skipped \
-    -d "Skipped: not safe to rebuild" --silent 2>/dev/null || true
+    -d "Skipped: not safe to rebuild" --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
   exit 0
 fi
 
@@ -51,18 +51,18 @@ fi
 DIRTY=$(git -C "$RIG_ROOT" status --porcelain 2>/dev/null)
 if [ -n "$DIRTY" ]; then
   log "Repo is dirty, skipping rebuild."
-  bd create "Plugin: rebuild-gt [skipped]" -t chore --ephemeral \
+  __rid="$(bd create "Plugin: rebuild-gt [skipped]" -t chore --ephemeral \
     -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:skipped \
-    -d "Skipped: repo has uncommitted changes" --silent 2>/dev/null || true
+    -d "Skipped: repo has uncommitted changes" --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
   exit 0
 fi
 
 BRANCH=$(git -C "$RIG_ROOT" branch --show-current 2>/dev/null)
 if [ "$BRANCH" != "main" ]; then
   log "Not on main branch (on $BRANCH), skipping rebuild."
-  bd create "Plugin: rebuild-gt [skipped]" -t chore --ephemeral \
+  __rid="$(bd create "Plugin: rebuild-gt [skipped]" -t chore --ephemeral \
     -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:skipped \
-    -d "Skipped: not on main branch (on $BRANCH)" --silent 2>/dev/null || true
+    -d "Skipped: not on main branch (on $BRANCH)" --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
   exit 0
 fi
 
@@ -74,15 +74,15 @@ log "Rebuilding gt from $RIG_ROOT..."
 if (cd "$RIG_ROOT" && make build && make safe-install) 2>&1; then
   NEW_VER=$(gt version 2>/dev/null | head -1 || echo "unknown")
   log "Rebuilt: $OLD_VER -> $NEW_VER"
-  bd create "rebuild-gt: $OLD_VER -> $NEW_VER" -t chore --ephemeral \
+  __rid="$(bd create "rebuild-gt: $OLD_VER -> $NEW_VER" -t chore --ephemeral \
     -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:success \
-    --silent 2>/dev/null || true
+    --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
 else
   ERROR="make build/safe-install failed"
   log "FAILED: $ERROR"
-  bd create "Plugin: rebuild-gt [failure]" -t chore --ephemeral \
+  __rid="$(bd create "Plugin: rebuild-gt [failure]" -t chore --ephemeral \
     -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:failure \
-    -d "Build failed: $ERROR" --silent 2>/dev/null || true
+    -d "Build failed: $ERROR" --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
   gt escalate "Plugin FAILED: rebuild-gt" -s medium 2>/dev/null || true
   exit 1
 fi

--- a/plugins/stuck-agent-dog/run.sh
+++ b/plugins/stuck-agent-dog/run.sh
@@ -248,6 +248,6 @@ SUMMARY="Agent health: ${#CRASHED[@]} crashed, ${#STUCK[@]} stuck, $HEALTHY heal
 log ""
 log "=== $SUMMARY ==="
 
-bd create "stuck-agent-dog: $SUMMARY" -t chore --ephemeral \
+__rid="$(bd create "stuck-agent-dog: $SUMMARY" -t chore --ephemeral \
   -l type:plugin-run,plugin:stuck-agent-dog,result:success \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+  -d "$SUMMARY" --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true

--- a/plugins/submodule-commit/run.sh
+++ b/plugins/submodule-commit/run.sh
@@ -163,8 +163,8 @@ log "=== Summary ==="
 SUMMARY="submodule-commit: $TOTAL_COMMITTED submodule(s) committed, $TOTAL_PUSHED pushed, $TOTAL_PARENT_UPDATED parent pointer(s) updated"
 log "$SUMMARY"
 
-bd create "$SUMMARY" -t chore --ephemeral \
+__rid="$(bd create "$SUMMARY" -t chore --ephemeral \
   -l "type:plugin-run,plugin:submodule-commit,result:success" \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+  -d "$SUMMARY" --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
 
 log "Done."

--- a/plugins/tool-updater/run.sh
+++ b/plugins/tool-updater/run.sh
@@ -31,9 +31,9 @@ done
 
 if [[ ${#OUTDATED[@]} -eq 0 ]]; then
   log "All tools current. Nothing to do."
-  bd create "tool-updater: all tools current (beads=$(bd version 2>/dev/null | awk '{print $3}'), dolt=$(dolt version 2>/dev/null | awk '{print $3}')" \
+  __rid="$(bd create "tool-updater: all tools current (beads=$(bd version 2>/dev/null | awk '{print $3}'), dolt=$(dolt version 2>/dev/null | awk '{print $3}')" \
     -t chore --ephemeral -l type:plugin-run,plugin:tool-updater,result:success \
-    --silent 2>/dev/null || true
+    --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
   exit 0
 fi
 
@@ -64,9 +64,9 @@ log "=== Done === $SUMMARY"
 RESULT="success"
 [[ ${#FAILED[@]} -gt 0 ]] && RESULT="warning"
 
-bd create "$SUMMARY" -t chore --ephemeral \
+__rid="$(bd create "$SUMMARY" -t chore --ephemeral \
   -l type:plugin-run,plugin:tool-updater,result:$RESULT \
-  --silent 2>/dev/null || true
+  --silent 2>/dev/null)" && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
 
 if [[ ${#FAILED[@]} -gt 0 ]]; then
   gt escalate "tool-updater: ${#FAILED[@]} tool(s) failed to upgrade: ${FAILED[*]}" \


### PR DESCRIPTION
## Problem

~10 plugins record each run with `bd create … --ephemeral` (labeled `type:plugin-run`) but leave the bead **open**. A completed run-log is not in-progress work, so these accumulate — `stuck-agent-dog`, `dolt-backup`, `compactor-dog`, `rebuild-gt`, etc. — until the wisp reaper's `max_age` (default **24h**) sweeps them. On a busy town that steady-state backlog blows past the 800-open alert threshold, producing the recurring "hq DB wisp flood" / "open wisps exceed threshold" escalations.

## Fix

`bd create --silent` already prints the new id, so capture it and close it:

```sh
__rid="$(bd create … --ephemeral … --silent 2>/dev/null)" \
  && [ -n "$__rid" ] && bd close "$__rid" --force 2>/dev/null || true
```

- Applied at **21 create sites across 10 plugins** (compactor-dog ×4, rebuild-gt ×6, dolt-backup ×2, dolt-log-rotate ×2, tool-updater ×2, and one each in dolt-archive, git-hygiene, gitignore-reconcile, stuck-agent-dog, submodule-commit).
- `--force` because run-log beads are standalone; the close shouldn't be blocked by anything.
- Non-fatal (`|| true`) preserved, so a failed `bd` never aborts a plugin under `set -e`.

Run-logs are still recorded (as **closed** history), the reaper purges closed ephemeral beads, and `max_age` goes back to being a safety net instead of the cleanup mechanism.

## Verification

Each `run.sh` passes `bash -n`. The create→close pattern verified live (bead ends `closed`). Deployed to a town via `gt plugin sync`; the open-wisp accumulation from plugin run-logs stops.