### PR TITLE
fix: converge stuck-agent-dog liveness

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -184,6 +184,9 @@ test: test-makefile
 
 test-makefile:
 	bash scripts/check-install-path_test.sh
+	bash -n plugins/stuck-agent-dog/run.sh
+	bash -n plugins/stuck-agent-dog/run_test.sh
+	bash plugins/stuck-agent-dog/run_test.sh
 
 # Run e2e tests in isolated container (the only supported way to run them)
 test-e2e-container:

--- a/internal/cmd/session.go
+++ b/internal/cmd/session.go
@@ -24,14 +24,16 @@ import (
 
 // Session command flags
 var (
-	sessionIssue      string
-	sessionForce      bool
-	sessionLines      int
-	sessionMessage    string
-	sessionFile       string
-	sessionRigFilter  string
-	sessionListJSON   bool
-	sessionStatusJSON bool
+	sessionIssue               string
+	sessionForce               bool
+	sessionLines               int
+	sessionMessage             string
+	sessionFile                string
+	sessionRigFilter           string
+	sessionListJSON            bool
+	sessionStatusJSON          bool
+	sessionHealthJSON          bool
+	sessionHealthMaxInactivity time.Duration
 )
 
 var sessionCmd = &cobra.Command{
@@ -168,6 +170,25 @@ Examples:
 	RunE: runSessionCheck,
 }
 
+var sessionHealthCmd = &cobra.Command{
+	Use:   "health <tmux-session>",
+	Short: "Check a tmux agent session with central runtime liveness",
+	Long: `Check a tmux agent session using the central runtime-aware liveness path.
+
+This wraps tmux.CheckSessionHealth, which reads GT_PROCESS_NAMES/GT_AGENT from
+the session environment before falling back to built-in agent process names.
+
+The command exits successfully for all valid health states; inspect the status
+field when using --json. Operational failures, argument errors, or invalid flags
+return non-zero.
+
+Examples:
+  gt session health gt-vault --json
+  gt session health gt-vault --json --max-inactivity 30m`,
+	Args: cobra.ExactArgs(1),
+	RunE: runSessionHealth,
+}
+
 func init() {
 	// Start flags
 	sessionStartCmd.Flags().StringVar(&sessionIssue, "issue", "", "Issue ID to work on")
@@ -192,6 +213,10 @@ func init() {
 	// Status flags
 	sessionStatusCmd.Flags().BoolVar(&sessionStatusJSON, "json", false, "Output as JSON")
 
+	// Health flags
+	sessionHealthCmd.Flags().BoolVar(&sessionHealthJSON, "json", false, "Output as JSON")
+	sessionHealthCmd.Flags().DurationVar(&sessionHealthMaxInactivity, "max-inactivity", 0, "Maximum tmux inactivity before reporting agent-hung (0 disables activity check)")
+
 	// Add subcommands
 	sessionCmd.AddCommand(sessionStartCmd)
 	sessionCmd.AddCommand(sessionStopCmd)
@@ -202,8 +227,27 @@ func init() {
 	sessionCmd.AddCommand(sessionRestartCmd)
 	sessionCmd.AddCommand(sessionStatusCmd)
 	sessionCmd.AddCommand(sessionCheckCmd)
+	sessionCmd.AddCommand(sessionHealthCmd)
 
 	rootCmd.AddCommand(sessionCmd)
+}
+
+type sessionHealthReport struct {
+	Session              string `json:"session"`
+	Status               string `json:"status"`
+	Healthy              bool   `json:"healthy"`
+	Zombie               bool   `json:"zombie"`
+	MaxInactivitySeconds int64  `json:"max_inactivity_seconds"`
+}
+
+func newSessionHealthReport(session string, status tmux.ZombieStatus, maxInactivity time.Duration) sessionHealthReport {
+	return sessionHealthReport{
+		Session:              session,
+		Status:               status.String(),
+		Healthy:              status == tmux.SessionHealthy,
+		Zombie:               status.IsZombie(),
+		MaxInactivitySeconds: int64(maxInactivity.Seconds()),
+	}
 }
 
 // parseAddress parses "rig/polecat" format.
@@ -603,6 +647,25 @@ func runSessionStatus(cmd *cobra.Command, args []string) error {
 	}
 
 	fmt.Printf("\nAttach with: %s\n", style.Dim.Render(fmt.Sprintf("gt session at %s/%s", rigName, polecatName)))
+	return nil
+}
+
+func runSessionHealth(cmd *cobra.Command, args []string) error {
+	sessionName := args[0]
+	status := tmux.NewTmux().CheckSessionHealth(sessionName, sessionHealthMaxInactivity)
+	report := newSessionHealthReport(sessionName, status, sessionHealthMaxInactivity)
+
+	if sessionHealthJSON {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		return enc.Encode(report)
+	}
+
+	if report.Healthy {
+		fmt.Printf("%s: %s\n", sessionName, style.Bold.Render(report.Status))
+	} else {
+		fmt.Printf("%s: %s\n", sessionName, style.Dim.Render(report.Status))
+	}
 	return nil
 }
 

--- a/internal/cmd/session_test.go
+++ b/internal/cmd/session_test.go
@@ -2,10 +2,13 @@ package cmd
 
 import (
 	"encoding/json"
+	"io"
+	"os"
 	"testing"
 	"time"
 
 	"github.com/steveyegge/gastown/internal/polecat"
+	"github.com/steveyegge/gastown/internal/tmux"
 )
 
 func TestSessionInfoJSONOutput(t *testing.T) {
@@ -53,6 +56,106 @@ func TestSessionStatusCmdJSONFlagWiring(t *testing.T) {
 	}
 	if f.DefValue != "false" {
 		t.Errorf("--json default = %q, want \"false\"", f.DefValue)
+	}
+}
+
+func TestSessionHealthCmdFlagWiring(t *testing.T) {
+	if sessionCmd.Commands() == nil {
+		t.Fatal("session command has no subcommands")
+	}
+
+	f := sessionHealthCmd.Flags().Lookup("json")
+	if f == nil {
+		t.Fatal("session health command missing --json flag")
+	}
+	if f.DefValue != "false" {
+		t.Errorf("--json default = %q, want \"false\"", f.DefValue)
+	}
+
+	f = sessionHealthCmd.Flags().Lookup("max-inactivity")
+	if f == nil {
+		t.Fatal("session health command missing --max-inactivity flag")
+	}
+	if f.DefValue != "0s" {
+		t.Errorf("--max-inactivity default = %q, want \"0s\"", f.DefValue)
+	}
+}
+
+func TestSessionHealthReportJSONContract(t *testing.T) {
+	report := newSessionHealthReport("gt-vault", tmux.AgentDead, 30*time.Minute)
+	data, err := json.Marshal(report)
+	if err != nil {
+		t.Fatalf("json.Marshal failed: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v", err)
+	}
+	if parsed["session"] != "gt-vault" {
+		t.Errorf("session = %v, want gt-vault", parsed["session"])
+	}
+	if parsed["status"] != "agent-dead" {
+		t.Errorf("status = %v, want agent-dead", parsed["status"])
+	}
+	if parsed["healthy"] != false {
+		t.Errorf("healthy = %v, want false", parsed["healthy"])
+	}
+	if parsed["zombie"] != true {
+		t.Errorf("zombie = %v, want true", parsed["zombie"])
+	}
+	if parsed["max_inactivity_seconds"] != float64(1800) {
+		t.Errorf("max_inactivity_seconds = %v, want 1800", parsed["max_inactivity_seconds"])
+	}
+}
+
+func TestRunSessionHealthJSONSessionDead(t *testing.T) {
+	oldJSON := sessionHealthJSON
+	oldMaxInactivity := sessionHealthMaxInactivity
+	oldStdout := os.Stdout
+	t.Cleanup(func() {
+		sessionHealthJSON = oldJSON
+		sessionHealthMaxInactivity = oldMaxInactivity
+		os.Stdout = oldStdout
+	})
+
+	sessionHealthJSON = true
+	sessionHealthMaxInactivity = 0
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("os.Pipe failed: %v", err)
+	}
+	os.Stdout = w
+
+	err = runSessionHealth(sessionHealthCmd, []string{"gt-session-health-test-nonexistent"})
+	if closeErr := w.Close(); closeErr != nil {
+		t.Fatalf("closing pipe writer: %v", closeErr)
+	}
+	os.Stdout = oldStdout
+	if err != nil {
+		t.Fatalf("runSessionHealth failed: %v", err)
+	}
+
+	data, err := io.ReadAll(r)
+	if err != nil {
+		t.Fatalf("reading stdout pipe: %v", err)
+	}
+
+	var parsed map[string]interface{}
+	if err := json.Unmarshal(data, &parsed); err != nil {
+		t.Fatalf("json.Unmarshal failed: %v\noutput: %s", err, string(data))
+	}
+	if parsed["session"] != "gt-session-health-test-nonexistent" {
+		t.Errorf("session = %v, want gt-session-health-test-nonexistent", parsed["session"])
+	}
+	if parsed["status"] != "session-dead" {
+		t.Errorf("status = %v, want session-dead", parsed["status"])
+	}
+	if parsed["healthy"] != false {
+		t.Errorf("healthy = %v, want false", parsed["healthy"])
+	}
+	if parsed["zombie"] != false {
+		t.Errorf("zombie = %v, want false", parsed["zombie"])
 	}
 }
 

--- a/internal/config/loader_test.go
+++ b/internal/config/loader_test.go
@@ -3794,7 +3794,7 @@ func TestBuildArgsWithPromptWarnsOnDroppedPrompt(t *testing.T) {
 //	      "command": "opencode",
 //	      "args": ["-m", "openai/gpt-5.2-codex"],
 //	      "prompt_mode": "none",
-//	      "process_names": ["opencode", "node"],
+//	      "process_names": ["opencode", "node", "bun"],
 //	      "env": {
 //	        "OPENCODE_PERMISSION": "{\"*\":\"allow\"}"
 //	      }

--- a/internal/plugin/scanner_test.go
+++ b/internal/plugin/scanner_test.go
@@ -435,8 +435,11 @@ func TestParsePluginMD_StuckAgentDogUsesCanonicalHeartbeatPath(t *testing.T) {
 	if !strings.Contains(plugin.Instructions, "could not parse rigs.json") {
 		t.Fatalf("expected fail-safe rigs.json parse handling in instructions, got:\n%s", plugin.Instructions)
 	}
-	if !strings.Contains(plugin.Instructions, ">20m threshold") {
-		t.Fatalf("expected canonical deacon very-stale threshold in instructions, got:\n%s", plugin.Instructions)
+	if !strings.Contains(plugin.Instructions, "GT_STUCK_AGENT_DOG_DEACON_STALE_SECONDS") {
+		t.Fatalf("expected configurable deacon stale threshold in instructions, got:\n%s", plugin.Instructions)
+	}
+	if !strings.Contains(plugin.Instructions, "heartbeat_write_divergence") {
+		t.Fatalf("expected heartbeat write-divergence handling in instructions, got:\n%s", plugin.Instructions)
 	}
 }
 

--- a/plugins/stuck-agent-dog/plugin.md
+++ b/plugins/stuck-agent-dog/plugin.md
@@ -32,7 +32,7 @@ Reference: WAR-ROOM-SERIAL-KILLER.md, commit f3d47a96.
 ## Scope — What You May and May NOT Touch
 
 **IN SCOPE** (these are the ONLY sessions this plugin may inspect or act on):
-- Polecat sessions (`<rig>-polecat-<name>`)
+- Polecat sessions (`<prefix>-<name>`, e.g. `gt-minuteman`)
 - Deacon session (`hq-deacon`)
 
 **OUT OF SCOPE — NEVER touch these, under any circumstances:**
@@ -52,8 +52,9 @@ appear in `CRASHED[]` or `STUCK[]` arrays, it does not exist for your purposes.
 
 ## Step 1: Enumerate agents to check
 
-Gather all polecats and the deacon session. We check both crashed sessions
-(session dead, work on hook) and stuck sessions (session alive but agent hung).
+Gather all polecats and the deacon session. We check crashed sessions
+(`session-dead`, work on hook) and confirmed zombie sessions (`agent-dead`).
+`agent-hung` is observe-only for polecats.
 
 ```bash
 echo "=== Stuck Agent Dog: Checking agent health ==="
@@ -68,7 +69,7 @@ fi
 
 # Read rigs.json for rig names and beads prefixes
 # CRITICAL: We need both the rig name (for filesystem paths like $TOWN_ROOT/$RIG/polecats/)
-# and the beads prefix (for tmux session names like $PREFIX-polecat-$NAME).
+# and the beads prefix (for tmux session names like $PREFIX-$NAME).
 # These can differ — e.g. rig "cfutons" may have prefix "CF".
 if [ ! -f "$RIGS_JSON_PATH" ]; then
   echo "SKIP: rigs.json not found at $RIGS_JSON_PATH"
@@ -99,7 +100,13 @@ fi
 For each rig, enumerate polecats and check their session status.
 A polecat is a concern if:
 - It has hooked work (hook_bead is set)
-- Its tmux session is dead OR the agent process is dead
+- Its central runtime-aware health is `session-dead` OR `agent-dead`
+
+Polecat liveness must use `gt session health`, which wraps the central
+`tmux.CheckSessionHealth` path. That path reads `GT_PROCESS_NAMES`, `GT_AGENT`,
+and `GT_PANE_ID`, so opencode/node/bun detection stays in the shared runtime
+configuration instead of a plugin-local process regex. Treat `agent-hung` as
+observe-only for polecats; quiet OpenCode research can be legitimate live work.
 
 ```bash
 CRASHED=()
@@ -116,54 +123,39 @@ while IFS='|' read -r RIG PREFIX; do
     [ -d "$PCAT_PATH" ] || continue
     PCAT_NAME=$(basename "$PCAT_PATH")
     # Use beads prefix (not rig name) for tmux session name
-    SESSION_NAME="${PREFIX}-polecat-${PCAT_NAME}"
+    SESSION_NAME="${PREFIX}-${PCAT_NAME}"
 
-    # Check if session exists
-    if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
-      # Session dead — check if it has hooked work
-      HOOK_BEAD=$(bd show "$RIG/polecats/$PCAT_NAME" --json 2>/dev/null \
-        | jq -r '.hook_bead // empty' 2>/dev/null)
+    HEALTH_STATUS=$(gt session health "$SESSION_NAME" --json --max-inactivity "${GT_STUCK_AGENT_DOG_MAX_INACTIVITY:-0s}" 2>/dev/null \
+      | jq -r '.status // empty' 2>/dev/null || true)
 
-      if [ -n "$HOOK_BEAD" ]; then
-        # Check agent_state to avoid false alerts for intentional shutdowns
-        AGENT_STATE=$(bd show "$RIG/polecats/$PCAT_NAME" --json 2>/dev/null \
-          | jq -r '.agent_state // empty' 2>/dev/null)
-        if [ "$AGENT_STATE" = "spawning" ]; then
-          echo "  SKIP $SESSION_NAME: agent_state=spawning (sling in progress)"
-          continue
-        fi
-        if [ "$AGENT_STATE" = "done" ] || [ "$AGENT_STATE" = "nuked" ]; then
-          echo "  SKIP $SESSION_NAME: agent_state=$AGENT_STATE (intentional shutdown, not a crash)"
-          continue
-        fi
-        CRASHED+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD")
-        echo "  CRASHED: $SESSION_NAME (hook=$HOOK_BEAD)"
-      fi
-    else
-      # Session alive — check for agent process liveness
-      # Capture last 5 lines of pane output to check for signs of life
-      PANE_OUTPUT=$(tmux capture-pane -t "$SESSION_NAME" -p -S -5 2>/dev/null || echo "")
-
-      # Check if agent process is running in the session
-      PANE_PID=$(tmux list-panes -t "$SESSION_NAME" -F '#{pane_pid}' 2>/dev/null | head -1)
-      if [ -n "$PANE_PID" ]; then
-        # Check if Claude or another agent process is a descendant
-        AGENT_ALIVE=$(pgrep -P "$PANE_PID" -f 'claude|node|anthropic' 2>/dev/null | head -1)
-        if [ -z "$AGENT_ALIVE" ]; then
-          # Agent process dead but session alive — zombie session
-          HOOK_BEAD=$(bd show "$RIG/polecats/$PCAT_NAME" --json 2>/dev/null \
-            | jq -r '.hook_bead // empty' 2>/dev/null)
-          if [ -n "$HOOK_BEAD" ]; then
-            STUCK+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD|agent_dead")
-            echo "  ZOMBIE: $SESSION_NAME (agent dead, session alive, hook=$HOOK_BEAD)"
-          fi
-        else
-          HEALTHY=$((HEALTHY + 1))
-        fi
-      else
+    case "$HEALTH_STATUS" in
+      healthy)
         HEALTHY=$((HEALTHY + 1))
-      fi
-    fi
+        ;;
+      session-dead)
+        # Check hook/status through the target rig workspace before acting.
+        # Only open/hooked/in_progress work is restartable.
+        HOOK_BEAD=$(rig_hook_bead "$RIG" "$PCAT_NAME")
+        if [ -n "$HOOK_BEAD" ] && bead_restartable "$SESSION_NAME" "$RIG" "$HOOK_BEAD"; then
+          CRASHED+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD")
+          echo "  CRASHED: $SESSION_NAME (hook=$HOOK_BEAD)"
+        fi
+        ;;
+      agent-dead)
+        HOOK_BEAD=$(rig_hook_bead "$RIG" "$PCAT_NAME")
+        if [ -n "$HOOK_BEAD" ] && bead_restartable "$SESSION_NAME" "$RIG" "$HOOK_BEAD"; then
+          STUCK+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD|agent_dead")
+          echo "  ZOMBIE: $SESSION_NAME (agent runtime dead, hook=$HOOK_BEAD)"
+        fi
+        ;;
+      agent-hung)
+        HEALTHY=$((HEALTHY + 1))
+        echo "  OBSERVE: $SESSION_NAME runtime alive but inactive; not restarting"
+        ;;
+      *)
+        echo "  SKIP $SESSION_NAME: central liveness probe inconclusive"
+        ;;
+    esac
   done
 done <<< "$RIG_PREFIX_MAP"
 
@@ -185,30 +177,47 @@ echo "=== Deacon Health ==="
 
 DEACON_SESSION="hq-deacon"
 DEACON_ISSUE=""
+DEACON_DIVERGENCE=""
+DEACON_PROCESS_ALIVE=0
 
 if ! tmux has-session -t "$DEACON_SESSION" 2>/dev/null; then
   echo "  CRASHED: Deacon session is dead"
   DEACON_ISSUE="crashed"
 else
-  # Check deacon heartbeat file
-  HEARTBEAT_FILE="$TOWN_ROOT/deacon/heartbeat.json"
-  if [ -f "$HEARTBEAT_FILE" ]; then
-    HEARTBEAT_TIME=$(jq -r '(.timestamp // empty) | sub("\\.[0-9]+Z$"; "Z") | fromdateiso8601? // empty' "$HEARTBEAT_FILE" 2>/dev/null)
-    if [ -n "$HEARTBEAT_TIME" ]; then
-      NOW=$(date +%s)
-      HEARTBEAT_AGE=$(( NOW - HEARTBEAT_TIME ))
+  DEACON_PID=$(tmux list-panes -t "$DEACON_SESSION" -F '#{pane_pid}' 2>/dev/null | head -1 || true)
+  DEACON_COMM=$(ps -o comm= -p "$DEACON_PID" 2>/dev/null || true)
+  if [ -z "$DEACON_COMM" ]; then
+    echo "  ZOMBIE: Deacon process dead (pid=$DEACON_PID), session alive"
+    DEACON_ISSUE="zombie"
+  else
+    echo "  Process alive: pid=$DEACON_PID comm=$DEACON_COMM"
+    DEACON_PROCESS_ALIVE=1
+  fi
 
-      if [ "$HEARTBEAT_AGE" -gt 1200 ]; then
-        echo "  STUCK: Deacon heartbeat stale (${HEARTBEAT_AGE}s old, >20m threshold)"
-        DEACON_ISSUE="stuck_heartbeat_${HEARTBEAT_AGE}s"
+  HEARTBEAT_FILE="$TOWN_ROOT/deacon/heartbeat.json"
+  if [ -z "$DEACON_ISSUE" ] && [ -f "$HEARTBEAT_FILE" ]; then
+    HEARTBEAT_TIME=$(heartbeat_epoch "$HEARTBEAT_FILE" || true)
+    NOW=$(date +%s)
+    HEARTBEAT_AGE=$(( NOW - ${HEARTBEAT_TIME:-0} ))
+
+    if [ "$HEARTBEAT_AGE" -gt "${GT_STUCK_AGENT_DOG_DEACON_STALE_SECONDS:-1200}" ]; then
+      ACTIVITY_TIME=$(tmux display-message -t "$DEACON_SESSION" -p '#{window_activity}' 2>/dev/null || true)
+      case "$ACTIVITY_TIME" in
+        ''|*[!0-9]*) ACTIVITY_AGE="" ;;
+        *) ACTIVITY_AGE=$(( NOW - ACTIVITY_TIME )) ;;
+      esac
+      if [ -n "$ACTIVITY_AGE" ] && [ "$ACTIVITY_AGE" -le "${GT_STUCK_AGENT_DOG_ACTIVITY_GRACE_SECONDS:-1200}" ]; then
+        echo "  DIVERGENCE: heartbeat file stale (${HEARTBEAT_AGE}s) but session active ${ACTIVITY_AGE}s ago — write divergence, not stuck"
+        DEACON_DIVERGENCE="heartbeat_write_divergence_${HEARTBEAT_AGE}s_active_${ACTIVITY_AGE}s"
+      elif [ "$DEACON_PROCESS_ALIVE" -eq 1 ] && ! has_in_progress_work; then
+        echo "  SKIP: Deacon heartbeat stale (${HEARTBEAT_AGE}s old) but process is alive and no in_progress work exists"
       else
-        echo "  OK: Deacon heartbeat ${HEARTBEAT_AGE}s old"
+        echo "  STUCK: Deacon heartbeat stale (${HEARTBEAT_AGE}s old, no recent session activity)"
+        DEACON_ISSUE="stuck_heartbeat_${HEARTBEAT_AGE}s"
       fi
     else
-      echo "  WARN: Could not parse heartbeat timestamp from $HEARTBEAT_FILE"
+      echo "  OK: Deacon heartbeat ${HEARTBEAT_AGE}s old"
     fi
-  else
-    echo "  WARN: No heartbeat file found at $HEARTBEAT_FILE"
   fi
 fi
 ```
@@ -232,27 +241,48 @@ For CRASHED agents (session dead, work on hook):
 
 For STUCK agents (session alive, agent dead):
 - Kill the zombie session, then restart
-- Exception: if pane output shows the agent is in a long-running build/test
+- `agent-hung` is not STUCK for polecats; central health keeps that observe-only.
 
 For DEACON stuck (stale heartbeat):
 - Capture pane output: `tmux capture-pane -t hq-deacon -p -S -20`
 - If output shows active work (recent timestamps, command output), the heartbeat
   file may just be stale — nudge instead of kill
-- If output shows no recent activity, restart is warranted
+- If output shows no recent activity, escalation is warranted
 - Use a stable escalation fingerprint (`stuck-agent-dog:deacon:stuck-heartbeat`)
   for stale-heartbeat events; do not include the age seconds in the fingerprint.
 
 **Decision framework:**
-1. If agent is clearly dead (no process, no output) → restart
-2. If agent shows recent activity in pane → nudge first, check again next cycle
-3. If agent has been stuck for >15 minutes with no pane activity → restart
-4. If mass death detected (>3 crashes in same cycle) → escalate, don't restart
+1. If central health is `session-dead` and hook status is actionable → request restart
+2. If central health is `agent-dead` and hook status is actionable → clear zombie, request restart
+3. If central health is `agent-hung` → observe/report only; do not restart polecat research sessions
+4. If mass death detected (threshold default 3) → escalate and skip all per-agent actions
 
-## Step 5: Take action
+## Step 5: Mass death check
+
+If multiple agents crashed in the same cycle, this may indicate a systemic
+issue (Dolt outage, OOM, etc.). Escalate instead of blindly restarting all.
+The executable script checks this before per-agent actions and skips all
+restart/kill loops for that cycle.
+
+```bash
+TOTAL_ISSUES=$(( ${#CRASHED[@]} + ${#STUCK[@]} ))
+MASS_DEATH=0
+if [ "$TOTAL_ISSUES" -ge "${GT_STUCK_AGENT_DOG_MASS_DEATH_THRESHOLD:-3}" ]; then
+  MASS_DEATH=1
+  echo "MASS DEATH: $TOTAL_ISSUES agents down in same cycle — escalating"
+  gt escalate "Mass agent death: $TOTAL_ISSUES agents down" -s CRITICAL
+  echo "Skipping per-agent restart/kill actions during mass-death escalation"
+fi
+```
+
+## Step 6: Take action
 
 For each agent requiring restart:
 
 ```bash
+if [ "$MASS_DEATH" -eq 1 ]; then
+  echo "Skipping per-agent restart/kill actions during mass-death escalation"
+else
 # For crashed polecats — notify witness to handle restart
 for ENTRY in "${CRASHED[@]}"; do
   IFS='|' read -r SESSION RIG PCAT HOOK <<< "$ENTRY"
@@ -294,31 +324,23 @@ Please restart this polecat session.
 BODY
 
 done
+fi
 
 # For deacon issues
 if [ -n "$DEACON_ISSUE" ]; then
   echo "Escalating deacon issue: $DEACON_ISSUE"
+  DEACON_SEVERITY="HIGH"
+  DEACON_FINGERPRINT="stuck-agent-dog:deacon:$DEACON_ISSUE"
+  case "$DEACON_ISSUE" in
+    stuck_heartbeat_*)
+      DEACON_SEVERITY="MEDIUM"
+      DEACON_FINGERPRINT="stuck-agent-dog:deacon:stuck-heartbeat"
+      ;;
+  esac
   gt escalate "Deacon $DEACON_ISSUE detected by stuck-agent-dog" \
-    -s HIGH \
-    --reason "Deacon issue: $DEACON_ISSUE. Context inspection completed."
-fi
-```
-
-## Step 6: Mass death check
-
-If multiple agents crashed in the same cycle, this may indicate a systemic
-issue (Dolt outage, OOM, etc.). Escalate instead of blindly restarting all.
-
-```bash
-TOTAL_ISSUES=$(( ${#CRASHED[@]} + ${#STUCK[@]} ))
-if [ "$TOTAL_ISSUES" -ge 3 ]; then
-  echo "MASS DEATH: $TOTAL_ISSUES agents down in same cycle — escalating"
-  gt escalate "Mass agent death: $TOTAL_ISSUES agents down" \
-    -s CRITICAL \
-    --reason "stuck-agent-dog detected $TOTAL_ISSUES agents down simultaneously.
-Crashed: ${CRASHED[*]}
-Stuck: ${STUCK[*]}
-This may indicate a systemic issue (Dolt, OOM, infra). Investigate before mass restart."
+    -s "$DEACON_SEVERITY" \
+    --source "plugin:stuck-agent-dog" \
+    --fingerprint "$DEACON_FINGERPRINT"
 fi
 ```
 

--- a/plugins/stuck-agent-dog/run.sh
+++ b/plugins/stuck-agent-dog/run.sh
@@ -6,10 +6,36 @@
 
 set -euo pipefail
 
-TOWN_ROOT="${GT_TOWN_ROOT:-$(gt town root 2>/dev/null)}"
-RIGS_JSON_PATH="${TOWN_ROOT}/mayor/rigs.json"
-
 log() { echo "[stuck-agent-dog] $*"; }
+
+TOWN_ROOT="${GT_TOWN_ROOT:-}"
+if [ -z "$TOWN_ROOT" ]; then
+  if ! TOWN_ROOT=$(gt town root 2>/dev/null); then
+    log "SKIP: could not resolve town root"
+    exit 0
+  fi
+fi
+
+RIGS_JSON_PATH="${TOWN_ROOT}/rigs.json"
+if [ ! -f "$RIGS_JSON_PATH" ] && [ -f "$TOWN_ROOT/mayor/rigs.json" ]; then
+  RIGS_JSON_PATH="$TOWN_ROOT/mayor/rigs.json"
+fi
+
+integer_or_default() {
+  local value="$1"
+  local default="$2"
+
+  case "$value" in
+    ''|*[!0-9]*) echo "$default" ;;
+    *) echo "$value" ;;
+  esac
+}
+
+POLECAT_MAX_INACTIVITY="${GT_STUCK_AGENT_DOG_MAX_INACTIVITY:-0s}"
+[ "$POLECAT_MAX_INACTIVITY" = "0" ] && POLECAT_MAX_INACTIVITY="0s"
+DEACON_STALE_SECONDS=$(integer_or_default "${GT_STUCK_AGENT_DOG_DEACON_STALE_SECONDS:-}" 1200)
+ACTIVITY_GRACE_SECONDS=$(integer_or_default "${GT_STUCK_AGENT_DOG_ACTIVITY_GRACE_SECONDS:-}" "$DEACON_STALE_SECONDS")
+MASS_DEATH_THRESHOLD=$(integer_or_default "${GT_STUCK_AGENT_DOG_MASS_DEATH_THRESHOLD:-}" 3)
 
 heartbeat_epoch() {
   local file="$1"
@@ -110,6 +136,17 @@ bead_restartable() {
   return 1
 }
 
+session_health_status() {
+  local session_name="$1"
+  local health_json=""
+  local status=""
+
+  health_json=$(gt session health "$session_name" --json --max-inactivity "$POLECAT_MAX_INACTIVITY" 2>/dev/null) || return 1
+  status=$(printf '%s' "$health_json" | jq -r '.status // empty' 2>/dev/null || true)
+  [ -n "$status" ] || return 1
+  printf '%s\n' "$status"
+}
+
 # --- Enumerate agents ---------------------------------------------------------
 
 log "=== Checking agent health ==="
@@ -120,7 +157,18 @@ if [ ! -f "$RIGS_JSON_PATH" ]; then
 fi
 
 # Build rig_name|prefix mapping
-RIG_PREFIX_MAP=$(jq -r '.rigs | to_entries[] | "\(.key)|\(.value.beads.prefix // .key)"' "$RIGS_JSON_PATH" 2>/dev/null)
+if ! RIG_PREFIX_MAP=$(jq -r '
+  if (.rigs | type) == "object" then
+    .rigs | to_entries[] | "\(.key)|\(.value.beads.prefix // .key)"
+  else
+    empty
+  end
+' "$RIGS_JSON_PATH" 2>/dev/null); then
+  log "SKIP: could not parse rigs.json"
+  exit 0
+fi
+
+RIG_PREFIX_MAP=$(printf '%s\n' "$RIG_PREFIX_MAP" | awk -F'|' 'NF >= 2 && $1 != "" && $2 != ""')
 if [ -z "$RIG_PREFIX_MAP" ]; then
   log "SKIP: no rigs in rigs.json"
   exit 0
@@ -142,33 +190,35 @@ while IFS='|' read -r RIG PREFIX; do
     PCAT_NAME=$(basename "$PCAT_PATH")
     SESSION_NAME="${PREFIX}-${PCAT_NAME}"
 
-    if ! tmux has-session -t "$SESSION_NAME" 2>/dev/null; then
-      # Session dead — check hook
-      HOOK_BEAD=$(rig_hook_bead "$RIG" "$PCAT_NAME")
-
-      if [ -n "$HOOK_BEAD" ] && bead_restartable "$SESSION_NAME" "$RIG" "$HOOK_BEAD"; then
-        CRASHED+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD")
-        log "  CRASHED: $SESSION_NAME (hook=$HOOK_BEAD)"
-      fi
-    else
-      # Session alive — check process
-      PANE_PID=$(tmux list-panes -t "$SESSION_NAME" -F '#{pane_pid}' 2>/dev/null | head -1 || true)
-      if [ -n "$PANE_PID" ]; then
-        PROC_COMM=$(ps -o comm= -p "$PANE_PID" 2>/dev/null || true)
-        if [ -z "$PROC_COMM" ]; then
-          # Zombie: process dead, session alive
-          HOOK_BEAD=$(rig_hook_bead "$RIG" "$PCAT_NAME")
-          if [ -n "$HOOK_BEAD" ] && bead_restartable "$SESSION_NAME" "$RIG" "$HOOK_BEAD"; then
-            STUCK+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD|agent_dead")
-            log "  ZOMBIE: $SESSION_NAME (pid=$PANE_PID dead, hook=$HOOK_BEAD)"
-          fi
-        else
-          HEALTHY=$((HEALTHY + 1))
-        fi
-      else
+    HEALTH_STATUS=$(session_health_status "$SESSION_NAME" || true)
+    case "$HEALTH_STATUS" in
+      healthy)
         HEALTHY=$((HEALTHY + 1))
-      fi
-    fi
+        ;;
+      agent-dead|agent_dead)
+        HOOK_BEAD=$(rig_hook_bead "$RIG" "$PCAT_NAME")
+        if [ -n "$HOOK_BEAD" ] && bead_restartable "$SESSION_NAME" "$RIG" "$HOOK_BEAD"; then
+          STUCK+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD|agent_dead")
+          log "  ZOMBIE: $SESSION_NAME (agent runtime dead, hook=$HOOK_BEAD)"
+        fi
+        ;;
+      agent-hung|agent_hung)
+        # A live runtime with quiet output can be a long research turn. Do not
+        # kill it here; operators can tune the threshold and inspect manually.
+        HEALTHY=$((HEALTHY + 1))
+        log "  OBSERVE: $SESSION_NAME runtime alive but inactive beyond $POLECAT_MAX_INACTIVITY; not restarting"
+        ;;
+      session-dead|session_dead)
+        HOOK_BEAD=$(rig_hook_bead "$RIG" "$PCAT_NAME")
+        if [ -n "$HOOK_BEAD" ] && bead_restartable "$SESSION_NAME" "$RIG" "$HOOK_BEAD"; then
+          CRASHED+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD")
+          log "  CRASHED: $SESSION_NAME (hook=$HOOK_BEAD)"
+        fi
+        ;;
+      *)
+        log "  SKIP $SESSION_NAME: central liveness probe inconclusive"
+        ;;
+    esac
   done
 done <<< "$RIG_PREFIX_MAP"
 
@@ -205,7 +255,7 @@ else
     NOW=$(date +%s)
     HEARTBEAT_AGE=$(( NOW - ${HEARTBEAT_TIME:-0} ))
 
-    if [ "$HEARTBEAT_AGE" -gt 1200 ]; then
+    if [ "$HEARTBEAT_AGE" -gt "$DEACON_STALE_SECONDS" ]; then
       # Cross-check tmux activity before declaring stuck: heartbeat.json is
       # only ONE of three heartbeat stores (hq-qxl9). A live session with
       # recent activity means the file-write path diverged (e.g. a long
@@ -216,13 +266,13 @@ else
         ''|*[!0-9]*) ACTIVITY_AGE="" ;;
         *) ACTIVITY_AGE=$(( NOW - ACTIVITY_TIME )) ;;
       esac
-      if [ -n "$ACTIVITY_AGE" ] && [ "$ACTIVITY_AGE" -le 1200 ]; then
+      if [ -n "$ACTIVITY_AGE" ] && [ "$ACTIVITY_AGE" -le "$ACTIVITY_GRACE_SECONDS" ]; then
         log "  DIVERGENCE: heartbeat file stale (${HEARTBEAT_AGE}s) but session active ${ACTIVITY_AGE}s ago — write divergence, not stuck"
         DEACON_DIVERGENCE="heartbeat_write_divergence_${HEARTBEAT_AGE}s_active_${ACTIVITY_AGE}s"
       elif [ "$DEACON_PROCESS_ALIVE" -eq 1 ] && ! has_in_progress_work; then
         log "  SKIP: Deacon heartbeat stale (${HEARTBEAT_AGE}s old) but process is alive and no in_progress work exists"
       else
-        log "  STUCK: Deacon heartbeat stale (${HEARTBEAT_AGE}s old, >20m threshold), no recent session activity"
+        log "  STUCK: Deacon heartbeat stale (${HEARTBEAT_AGE}s old, >${DEACON_STALE_SECONDS}s threshold), no recent session activity"
         DEACON_ISSUE="stuck_heartbeat_${HEARTBEAT_AGE}s"
       fi
     else
@@ -234,7 +284,9 @@ fi
 # --- Mass death check ---------------------------------------------------------
 
 TOTAL_ISSUES=$(( ${#CRASHED[@]} + ${#STUCK[@]} ))
-if [ "$TOTAL_ISSUES" -ge 3 ]; then
+MASS_DEATH=0
+if [ "$TOTAL_ISSUES" -ge "$MASS_DEATH_THRESHOLD" ]; then
+  MASS_DEATH=1
   log ""
   log "MASS DEATH: $TOTAL_ISSUES agents down — escalating instead of restarting"
   gt escalate "Mass agent death: $TOTAL_ISSUES agents down" \
@@ -243,32 +295,36 @@ fi
 
 # --- Take action --------------------------------------------------------------
 
-# Crashed polecats: notify witness to restart
-# Note: `"${arr[@]:-}"` expands an empty array to a single empty string under
-# `set -u`, which would fire a phantom `RESTART_POLECAT: /` notification. The
-# `${arr[@]+"${arr[@]}"}` form expands to nothing when the array is empty.
-for ENTRY in ${CRASHED[@]+"${CRASHED[@]}"}; do
-  IFS='|' read -r SESSION RIG PCAT HOOK <<< "$ENTRY"
-  log "Requesting restart for $RIG/polecats/$PCAT (hook=$HOOK)"
-  gt mail send "$RIG/witness" -s "RESTART_POLECAT: $RIG/$PCAT" --stdin <<BODY
+if [ "$MASS_DEATH" -eq 1 ]; then
+  log "Skipping per-agent restart/kill actions during mass-death escalation"
+else
+  # Crashed polecats: notify witness to restart
+  # Note: `"${arr[@]:-}"` expands an empty array to a single empty string under
+  # `set -u`, which would fire a phantom `RESTART_POLECAT: /` notification. The
+  # `${arr[@]+"${arr[@]}"}` form expands to nothing when the array is empty.
+  for ENTRY in ${CRASHED[@]+"${CRASHED[@]}"}; do
+    IFS='|' read -r SESSION RIG PCAT HOOK <<< "$ENTRY"
+    log "Requesting restart for $RIG/polecats/$PCAT (hook=$HOOK)"
+    gt mail send "$RIG/witness" -s "RESTART_POLECAT: $RIG/$PCAT" --stdin <<BODY || log "  WARN: restart mail failed for $RIG/$PCAT"
 Polecat $PCAT crash confirmed by stuck-agent-dog plugin.
 hook_bead: $HOOK
 action: restart requested
 BODY
-done
+  done
 
-# Zombie polecats: kill zombie session, then request restart
-for ENTRY in ${STUCK[@]+"${STUCK[@]}"}; do
-  IFS='|' read -r SESSION RIG PCAT HOOK REASON <<< "$ENTRY"
-  log "Killing zombie session $SESSION and requesting restart"
-  tmux kill-session -t "$SESSION" 2>/dev/null || true
-  gt mail send "$RIG/witness" -s "RESTART_POLECAT: $RIG/$PCAT (zombie cleared)" --stdin <<BODY
+  # Zombie polecats: kill zombie session, then request restart
+  for ENTRY in ${STUCK[@]+"${STUCK[@]}"}; do
+    IFS='|' read -r SESSION RIG PCAT HOOK REASON <<< "$ENTRY"
+    log "Killing zombie session $SESSION and requesting restart"
+    tmux kill-session -t "$SESSION" 2>/dev/null || true
+    gt mail send "$RIG/witness" -s "RESTART_POLECAT: $RIG/$PCAT (zombie cleared)" --stdin <<BODY || log "  WARN: restart mail failed for $RIG/$PCAT"
 Polecat $PCAT zombie session cleared by stuck-agent-dog plugin.
 hook_bead: $HOOK
 reason: $REASON
 action: restart requested
 BODY
-done
+  done
+fi
 
 # Deacon issues: escalate
 if [ -n "$DEACON_ISSUE" ]; then

--- a/plugins/stuck-agent-dog/run_test.sh
+++ b/plugins/stuck-agent-dog/run_test.sh
@@ -1,0 +1,351 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+SCRIPT="$ROOT_DIR/plugins/stuck-agent-dog/run.sh"
+ORIGINAL_PATH="$PATH"
+PASS=0
+FAIL=0
+CLEANUP_DIRS=()
+
+cleanup() {
+  for dir in "${CLEANUP_DIRS[@]}"; do
+    rm -rf "$dir"
+  done
+}
+trap cleanup EXIT
+
+record_pass() {
+  PASS=$((PASS + 1))
+  printf 'PASS: %s\n' "$1"
+}
+
+record_fail() {
+  FAIL=$((FAIL + 1))
+  printf 'FAIL: %s\n' "$1"
+}
+
+assert_file_empty() {
+  local file="$1"
+  local label="$2"
+  if [ ! -s "$file" ]; then
+    record_pass "$label"
+  else
+    record_fail "$label"
+    printf '  unexpected contents of %s:\n' "$file"
+    sed 's/^/    /' "$file"
+  fi
+}
+
+assert_file_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if grep -Fq "$needle" "$file"; then
+    record_pass "$label"
+  else
+    record_fail "$label"
+    printf '  expected %q in %s\n' "$needle" "$file"
+    sed 's/^/    /' "$file" 2>/dev/null || true
+  fi
+}
+
+assert_line_count() {
+  local file="$1"
+  local expected="$2"
+  local label="$3"
+  local actual=0
+
+  if [ -f "$file" ]; then
+    actual=$(wc -l < "$file" | tr -d ' ')
+  fi
+  if [ "$actual" = "$expected" ]; then
+    record_pass "$label"
+  else
+    record_fail "$label"
+    printf '  expected %s lines in %s, got %s\n' "$expected" "$file" "$actual"
+    sed 's/^/    /' "$file" 2>/dev/null || true
+  fi
+}
+
+write_fake_commands() {
+  local bin_dir="$1"
+
+  cat > "$bin_dir/gt" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  town)
+    if [ "${2:-}" = "root" ]; then
+      printf '%s\n' "$GT_TOWN_ROOT"
+      exit 0
+    fi
+    ;;
+  hook)
+    if [ "${2:-}" = "show" ]; then
+      target="${3:-}"
+      name="${target##*/}"
+      if [ -f "$TEST_STATE/nohook/$name" ]; then
+        printf '{"bead_id":""}\n'
+      else
+        printf '{"bead_id":"gt-hook-%s"}\n' "$name"
+      fi
+      exit 0
+    fi
+    ;;
+  session)
+    if [ "${2:-}" = "health" ]; then
+      session="${3:-}"
+      shift 3
+      max_inactivity="0s"
+      while [ "$#" -gt 0 ]; do
+        case "$1" in
+          --max-inactivity)
+            max_inactivity="${2:-}"
+            shift 2
+            ;;
+          *)
+            shift
+            ;;
+        esac
+      done
+
+      status="healthy"
+      if [ -f "$TEST_STATE/health/$session" ]; then
+        status=$(tr -d '\n' < "$TEST_STATE/health/$session")
+      fi
+      printf '%s --max-inactivity %s\n' "$session" "$max_inactivity" >> "$TEST_STATE/health_calls.log"
+      healthy=false
+      zombie=false
+      case "$status" in
+        healthy) healthy=true ;;
+        agent-dead|agent-hung) zombie=true ;;
+      esac
+      printf '{"session":"%s","status":"%s","healthy":%s,"zombie":%s,"max_inactivity_seconds":0}\n' "$session" "$status" "$healthy" "$zombie"
+      exit 0
+    fi
+    ;;
+  mail)
+    if [ "${2:-}" = "send" ]; then
+      printf '%s\n' "$*" >> "$TEST_STATE/mail.log"
+      while IFS= read -r _line; do :; done
+      exit 0
+    fi
+    ;;
+  escalate)
+    printf '%s\n' "$*" >> "$TEST_STATE/escalate.log"
+    exit 0
+    ;;
+esac
+
+printf 'unexpected gt call: %s\n' "$*" >&2
+exit 1
+SH
+  chmod +x "$bin_dir/gt"
+
+  cat > "$bin_dir/tmux" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+arg_after_t() {
+  while [ "$#" -gt 0 ]; do
+    if [ "$1" = "-t" ]; then
+      printf '%s\n' "${2:-}"
+      return 0
+    fi
+    shift
+  done
+  return 1
+}
+
+case "${1:-}" in
+  has-session)
+    session=$(arg_after_t "$@" || true)
+    [ -n "$session" ] && [ -f "$TEST_STATE/sessions/$session" ]
+    ;;
+  kill-session)
+    session=$(arg_after_t "$@" || true)
+    printf '%s\n' "$session" >> "$TEST_STATE/kill.log"
+    ;;
+  list-panes)
+    printf '999\n'
+    ;;
+  display-message)
+    date +%s
+    ;;
+  capture-pane)
+    printf 'active opencode research in progress\n'
+    ;;
+  *)
+    printf 'unexpected tmux call: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+SH
+  chmod +x "$bin_dir/tmux"
+
+  cat > "$bin_dir/bd" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+case "${1:-}" in
+  show)
+    bead="${2:-}"
+    status="open"
+    if [ -f "$TEST_STATE/status/$bead" ]; then
+      status=$(tr -d '\n' < "$TEST_STATE/status/$bead")
+    fi
+    printf '[{"status":"%s"}]\n' "$status"
+    ;;
+  list)
+    printf '[]\n'
+    ;;
+  create)
+    printf '%s\n' "$*" >> "$TEST_STATE/bd.log"
+    ;;
+  *)
+    printf 'unexpected bd call: %s\n' "$*" >&2
+    exit 1
+    ;;
+esac
+SH
+  chmod +x "$bin_dir/bd"
+
+  cat > "$bin_dir/ps" <<'SH'
+#!/usr/bin/env bash
+set -euo pipefail
+
+if [ "${1:-}" = "-o" ] && [ "${2:-}" = "comm=" ]; then
+  printf 'bash\n'
+  exit 0
+fi
+
+printf 'unexpected ps call: %s\n' "$*" >&2
+exit 1
+SH
+  chmod +x "$bin_dir/ps"
+}
+
+setup_case() {
+  TEST_TMP=$(mktemp -d)
+  CLEANUP_DIRS+=("$TEST_TMP")
+  export TEST_STATE="$TEST_TMP/state"
+  export GT_TOWN_ROOT="$TEST_TMP/town"
+  local bin_dir="$TEST_TMP/bin"
+
+  mkdir -p "$TEST_STATE/health" "$TEST_STATE/nohook" "$TEST_STATE/sessions" "$TEST_STATE/status" "$bin_dir"
+  mkdir -p "$GT_TOWN_ROOT/gastown/polecats" "$GT_TOWN_ROOT/deacon"
+  printf '{"rigs":{"gastown":{"beads":{"prefix":"gt"}}}}\n' > "$GT_TOWN_ROOT/rigs.json"
+  : > "$TEST_STATE/mail.log"
+  : > "$TEST_STATE/kill.log"
+  : > "$TEST_STATE/escalate.log"
+  : > "$TEST_STATE/health_calls.log"
+  : > "$TEST_STATE/bd.log"
+  touch "$TEST_STATE/sessions/hq-deacon"
+
+  write_fake_commands "$bin_dir"
+  export PATH="$bin_dir:$ORIGINAL_PATH"
+  export GT_STUCK_AGENT_DOG_MAX_INACTIVITY=0s
+  unset GT_STUCK_AGENT_DOG_MASS_DEATH_THRESHOLD
+}
+
+add_polecat() {
+  local name="$1"
+  local status="$2"
+  local session="gt-$name"
+
+  mkdir -p "$GT_TOWN_ROOT/gastown/polecats/$name"
+  touch "$TEST_STATE/sessions/$session"
+  printf '%s\n' "$status" > "$TEST_STATE/health/$session"
+}
+
+run_script() {
+  bash "$SCRIPT" > "$TEST_STATE/output.log" 2>&1
+}
+
+test_healthy_runtime() {
+  local runtime="$1"
+
+  setup_case
+  add_polecat "$runtime" healthy
+  run_script
+
+  assert_file_empty "$TEST_STATE/kill.log" "$runtime healthy: no session kill"
+  assert_file_empty "$TEST_STATE/mail.log" "$runtime healthy: no restart mail"
+  assert_file_empty "$TEST_STATE/escalate.log" "$runtime healthy: no escalation"
+  assert_file_contains "$TEST_STATE/health_calls.log" "gt-$runtime --max-inactivity 0s" "$runtime healthy: used central health"
+}
+
+test_long_research_active_pane() {
+  setup_case
+  export GT_STUCK_AGENT_DOG_MAX_INACTIVITY=30m
+  add_polecat research agent-hung
+  run_script
+
+  assert_file_empty "$TEST_STATE/kill.log" "active research: no session kill"
+  assert_file_empty "$TEST_STATE/mail.log" "active research: no restart mail"
+  assert_file_empty "$TEST_STATE/escalate.log" "active research: no mass-death escalation"
+  assert_file_contains "$TEST_STATE/output.log" "OBSERVE: gt-research runtime alive" "active research: observed live runtime"
+  assert_file_contains "$TEST_STATE/output.log" "0 crashed, 0 stuck, 1 healthy" "active research: counted healthy"
+}
+
+test_dead_agent_restarts_one() {
+  setup_case
+  add_polecat alpha agent-dead
+  run_script
+
+  assert_line_count "$TEST_STATE/kill.log" 1 "dead agent: one session kill"
+  assert_file_contains "$TEST_STATE/kill.log" "gt-alpha" "dead agent: killed target session"
+  assert_line_count "$TEST_STATE/mail.log" 1 "dead agent: one restart mail"
+  assert_file_contains "$TEST_STATE/mail.log" "gastown/witness" "dead agent: mailed rig witness"
+  assert_file_empty "$TEST_STATE/escalate.log" "dead agent: no mass-death escalation"
+}
+
+test_dead_session_restarts_one() {
+  setup_case
+  add_polecat beta session-dead
+  run_script
+
+  assert_file_empty "$TEST_STATE/kill.log" "dead session: no session kill"
+  assert_line_count "$TEST_STATE/mail.log" 1 "dead session: one restart mail"
+  assert_file_contains "$TEST_STATE/mail.log" "RESTART_POLECAT: gastown/beta" "dead session: restart requested"
+  assert_file_empty "$TEST_STATE/escalate.log" "dead session: no mass-death escalation"
+}
+
+test_closed_hook_skips_restart() {
+  setup_case
+  add_polecat alpha agent-dead
+  printf 'closed\n' > "$TEST_STATE/status/gt-hook-alpha"
+  run_script
+
+  assert_file_empty "$TEST_STATE/kill.log" "closed hook: no session kill"
+  assert_file_empty "$TEST_STATE/mail.log" "closed hook: no restart mail"
+  assert_file_contains "$TEST_STATE/output.log" "bead closed" "closed hook: status checked"
+}
+
+test_mass_death_skips_actions() {
+  setup_case
+  add_polecat alpha agent-dead
+  add_polecat beta agent-dead
+  add_polecat gamma agent-dead
+  run_script
+
+  assert_file_empty "$TEST_STATE/kill.log" "mass death: no session kills"
+  assert_file_empty "$TEST_STATE/mail.log" "mass death: no restart mail"
+  assert_line_count "$TEST_STATE/escalate.log" 1 "mass death: one escalation"
+  assert_file_contains "$TEST_STATE/output.log" "Skipping per-agent restart/kill actions" "mass death: action loops skipped"
+}
+
+test_healthy_runtime opencode
+test_healthy_runtime bun
+test_healthy_runtime node
+test_healthy_runtime claude
+test_long_research_active_pane
+test_dead_agent_restarts_one
+test_dead_session_restarts_one
+test_closed_hook_skips_restart
+test_mass_death_skips_actions
+
+printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
+[ "$FAIL" -eq 0 ]

--- a/templates/agents/opencode.json.tmpl
+++ b/templates/agents/opencode.json.tmpl
@@ -15,7 +15,7 @@
     "tmux": {
       "ready_prompt_prefix": "",
       "ready_delay_ms": {{.ReadyDelayMs | default 8000}},
-      "process_names": ["opencode", "node"]
+      "process_names": ["opencode", "node", "bun"]
     }
   },
   "hooks": {


### PR DESCRIPTION
Replacement PR for gt-4016.

Summary:
- Adds a central gt session health JSON command around tmux.CheckSessionHealth.
- Routes stuck-agent-dog polecat liveness through the central health path instead of plugin-local process guessing.
- Treats long-running research/hung panes as observe-only while keeping dead sessions actionable.
- Covers OpenCode/bun runtime detection through the agent process-name template.

PR Sheriff evidence:
- 15 research legs, 5 pre-implementation reviews, and 5 post-implementation reviews were completed by gastown/minuteman and recorded on gt-4016.
- Final verdict: clean replacement is approved/merge-ready.

Verification recorded on gt-4016:
- make test-makefile
- CGO_ENABLED=0 go test ./internal/cmd focused session health tests
- CGO_ENABLED=0 go test ./internal/plugin focused stuck-agent-dog scanner tests
- CGO_ENABLED=0 go test ./internal/config focused OpenCode/process-name tests
- CGO_ENABLED=0 go test ./internal/tmux focused liveness tests
- git diff --check

Recovery note:
- gt done completed but branch push failed due Coder askpass auth. Mayor pushed commit c1707722 manually with gh auth.

Supersedes the stale preserved branch fork/polecat/vault/gt-4016@mqgra3t5; do not open that branch as-is.