### PR TITLE
fix: reconnect ralph sling mode to ralph-loop

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -369,6 +369,7 @@ func (b *Beads) ResetAgentBeadForReuse(id, reason string) error {
 	fields.HookBead = ""      // Clear hook_bead
 	fields.ActiveMR = ""      // Clear active_mr
 	fields.CleanupStatus = "" // Clear cleanup_status
+	fields.Mode = ""          // Clear Ralph-mode threshold marker
 	fields.AgentState = string(AgentStateNuked)
 	// Clear completion metadata (gt-x7t9)
 	fields.ExitType = ""

--- a/internal/beads/fields.go
+++ b/internal/beads/fields.go
@@ -13,19 +13,19 @@ import (
 // AttachmentFields holds the attachment info for pinned beads.
 // These fields track which molecule is attached to a handoff/pinned bead.
 type AttachmentFields struct {
-	AttachedMolecule string // Root issue ID of the attached molecule
-	AttachedFormula  string // Formula name (e.g., "mol-polecat-work") for inline step display
-	AttachedAt       string // ISO 8601 timestamp when attached
-	AttachedArgs     string // Natural language args passed via gt sling --args (no-tmux mode)
+	AttachedMolecule string   // Root issue ID of the attached molecule
+	AttachedFormula  string   // Formula name (e.g., "mol-polecat-work") for inline step display
+	AttachedAt       string   // ISO 8601 timestamp when attached
+	AttachedArgs     string   // Natural language args passed via gt sling --args (no-tmux mode)
 	AttachedVars     []string // Formula variables passed via gt sling --var
-	DispatchedBy     string // Agent ID that dispatched this work (for completion notification)
-	NoMerge          bool   // If true, gt done skips merge queue (for upstream PRs/human review)
-	ReviewOnly       bool   // If true, assignee must evaluate and report back — no merge/commit/push
-	Mode             string // Execution mode: "" (normal) or "ralph" (Ralph Wiggum loop)
-	ConvoyID         string // Convoy bead ID tracking this issue (e.g., "hq-cv-abc")
-	MergeStrategy    string // Convoy merge strategy: "direct", "mr", "local", or "" (default = mr)
-	ConvoyOwned      bool   // If true, convoy has gt:owned label (caller-managed lifecycle)
-	FormulaVars      string // Newline-separated key=value pairs for formula template substitution
+	DispatchedBy     string   // Agent ID that dispatched this work (for completion notification)
+	NoMerge          bool     // If true, gt done skips merge queue (for upstream PRs/human review)
+	ReviewOnly       bool     // If true, assignee must evaluate and report back — no merge/commit/push
+	Mode             string   // Execution mode: "" (normal) or "ralph" (Ralph Wiggum loop)
+	ConvoyID         string   // Convoy bead ID tracking this issue (e.g., "hq-cv-abc")
+	MergeStrategy    string   // Convoy merge strategy: "direct", "mr", "local", or "" (default = mr)
+	ConvoyOwned      bool     // If true, convoy has gt:owned label (caller-managed lifecycle)
+	FormulaVars      string   // Newline-separated key=value pairs for formula template substitution
 }
 
 // ParseAttachmentFields extracts attachment fields from an issue's description.
@@ -37,12 +37,21 @@ func ParseAttachmentFields(issue *Issue) *AttachmentFields {
 
 	fields := &AttachmentFields{}
 	hasFields := false
+	var formulaVars []string
+	collectFormulaVarContinuations := false
 
 	for _, line := range strings.Split(issue.Description, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
+			collectFormulaVarContinuations = false
 			continue
 		}
+		if collectFormulaVarContinuations && looksLikeFormulaVarLine(line) {
+			formulaVars = append(formulaVars, line)
+			hasFields = true
+			continue
+		}
+		collectFormulaVarContinuations = false
 
 		// Look for "key: value" pattern
 		colonIdx := strings.Index(line, ":")
@@ -95,9 +104,13 @@ func ParseAttachmentFields(issue *Issue) *AttachmentFields {
 			fields.ConvoyOwned = strings.ToLower(value) == "true"
 			hasFields = true
 		case "formula_vars", "formula-vars", "formulavars":
-			fields.FormulaVars = value
+			formulaVars = append(formulaVars, splitFormulaVars(parseFormulaVars(value))...)
+			collectFormulaVarContinuations = !strings.HasPrefix(strings.TrimSpace(value), "[")
 			hasFields = true
 		}
+	}
+	if len(formulaVars) > 0 {
+		fields.FormulaVars = strings.Join(formulaVars, "\n")
 	}
 
 	if !hasFields {
@@ -152,7 +165,9 @@ func FormatAttachmentFields(fields *AttachmentFields) string {
 		lines = append(lines, "convoy_owned: true")
 	}
 	if fields.FormulaVars != "" {
-		lines = append(lines, "formula_vars: "+fields.FormulaVars)
+		if formatted := formatFormulaVars(fields.FormulaVars); formatted != "" {
+			lines = append(lines, "formula_vars: "+formatted)
+		}
 	}
 
 	return strings.Join(lines, "\n")
@@ -187,7 +202,7 @@ func SetAttachmentFields(issue *Issue, fields *AttachmentFields) string {
 		"nomerge":           true,
 		"review_only":       true,
 		"review-only":       true,
-		"reviewonly":         true,
+		"reviewonly":        true,
 		"mode":              true,
 		"convoy_id":         true,
 		"convoy-id":         true,
@@ -207,13 +222,19 @@ func SetAttachmentFields(issue *Issue, fields *AttachmentFields) string {
 	// Collect non-attachment lines from existing description
 	var otherLines []string
 	if issue != nil && issue.Description != "" {
+		skipFormulaVarContinuations := false
 		for _, line := range strings.Split(issue.Description, "\n") {
 			trimmed := strings.TrimSpace(line)
 			if trimmed == "" {
+				skipFormulaVarContinuations = false
 				// Preserve blank lines in content
 				otherLines = append(otherLines, line)
 				continue
 			}
+			if skipFormulaVarContinuations && looksLikeFormulaVarLine(trimmed) {
+				continue
+			}
+			skipFormulaVarContinuations = false
 
 			// Check if this is an attachment field line
 			colonIdx := strings.Index(trimmed, ":")
@@ -225,6 +246,8 @@ func SetAttachmentFields(issue *Issue, fields *AttachmentFields) string {
 			key := strings.ToLower(strings.TrimSpace(trimmed[:colonIdx]))
 			if !attachmentKeys[key] {
 				otherLines = append(otherLines, line)
+			} else if isFormulaVarsAttachmentKey(key) {
+				skipFormulaVarContinuations = true
 			}
 			// Skip attachment field lines - they'll be replaced
 		}
@@ -505,6 +528,54 @@ func parseAttachedVars(raw string) []string {
 	return []string{raw}
 }
 
+func formatFormulaVars(raw string) string {
+	return formatAttachedVars(splitFormulaVars(raw))
+}
+
+func parseFormulaVars(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	if strings.HasPrefix(raw, "[") {
+		if vars := parseAttachedVars(raw); len(vars) > 0 {
+			return strings.Join(vars, "\n")
+		}
+		return ""
+	}
+	return strings.Join(splitFormulaVars(raw), "\n")
+}
+
+func splitFormulaVars(raw string) []string {
+	if raw == "" {
+		return nil
+	}
+	vars := strings.Split(raw, "\n")
+	out := vars[:0]
+	for _, variable := range vars {
+		variable = strings.TrimSpace(variable)
+		if variable != "" {
+			out = append(out, variable)
+		}
+	}
+	return out
+}
+
+func looksLikeFormulaVarLine(line string) bool {
+	key, _, ok := strings.Cut(strings.TrimSpace(line), "=")
+	key = strings.TrimSpace(key)
+	return ok && key != "" && !strings.ContainsAny(key, " \t:")
+}
+
+func isFormulaVarsAttachmentKey(key string) bool {
+	switch key {
+	case "formula_vars", "formula-vars", "formulavars":
+		return true
+	default:
+		return false
+	}
+}
+
 // SetConvoyFields updates an issue's description with the given convoy fields.
 // Existing convoy field lines are replaced; other content is preserved.
 // Returns the new description string.
@@ -780,50 +851,50 @@ func SetMRFields(issue *Issue, fields *MRFields) string {
 
 	// Known MR field keys (lowercase)
 	mrKeys := map[string]bool{
-		"branch":             true,
-		"target":             true,
-		"source_issue":       true,
-		"source-issue":       true,
-		"sourceissue":        true,
-		"worker":             true,
-		"rig":                true,
-		"commit_sha":         true,
-		"commit-sha":         true,
-		"commitsha":          true,
-		"merge_commit":       true,
-		"merge-commit":       true,
-		"mergecommit":        true,
-		"close_reason":       true,
-		"close-reason":       true,
-		"closereason":        true,
-		"agent_bead":         true,
-		"agent-bead":         true,
-		"agentbead":          true,
-		"retry_count":        true,
-		"retry-count":        true,
-		"retrycount":         true,
-		"last_conflict_sha":  true,
-		"last-conflict-sha":  true,
-		"lastconflictsha":    true,
-		"conflict_task_id":   true,
-		"conflict-task-id":   true,
-		"conflicttaskid":     true,
-		"convoy_id":          true,
-		"convoy-id":          true,
-		"convoyid":           true,
-		"convoy":             true,
-		"convoy_created_at":  true,
-		"convoy-created-at":  true,
-		"convoycreatedat":    true,
-		"pre_verified":       true,
-		"pre-verified":       true,
-		"preverified":        true,
-		"pre_verified_at":    true,
-		"pre-verified-at":    true,
-		"preverifiedat":      true,
-		"pre_verified_base":  true,
-		"pre-verified-base":  true,
-		"preverifiedbase":    true,
+		"branch":            true,
+		"target":            true,
+		"source_issue":      true,
+		"source-issue":      true,
+		"sourceissue":       true,
+		"worker":            true,
+		"rig":               true,
+		"commit_sha":        true,
+		"commit-sha":        true,
+		"commitsha":         true,
+		"merge_commit":      true,
+		"merge-commit":      true,
+		"mergecommit":       true,
+		"close_reason":      true,
+		"close-reason":      true,
+		"closereason":       true,
+		"agent_bead":        true,
+		"agent-bead":        true,
+		"agentbead":         true,
+		"retry_count":       true,
+		"retry-count":       true,
+		"retrycount":        true,
+		"last_conflict_sha": true,
+		"last-conflict-sha": true,
+		"lastconflictsha":   true,
+		"conflict_task_id":  true,
+		"conflict-task-id":  true,
+		"conflicttaskid":    true,
+		"convoy_id":         true,
+		"convoy-id":         true,
+		"convoyid":          true,
+		"convoy":            true,
+		"convoy_created_at": true,
+		"convoy-created-at": true,
+		"convoycreatedat":   true,
+		"pre_verified":      true,
+		"pre-verified":      true,
+		"preverified":       true,
+		"pre_verified_at":   true,
+		"pre-verified-at":   true,
+		"preverifiedat":     true,
+		"pre_verified_base": true,
+		"pre-verified-base": true,
+		"preverifiedbase":   true,
 	}
 
 	// Collect non-MR lines from existing description

--- a/internal/beads/fields.go
+++ b/internal/beads/fields.go
@@ -564,7 +564,15 @@ func splitFormulaVars(raw string) []string {
 func looksLikeFormulaVarLine(line string) bool {
 	key, _, ok := strings.Cut(strings.TrimSpace(line), "=")
 	key = strings.TrimSpace(key)
-	return ok && key != "" && !strings.ContainsAny(key, " \t:")
+	if !ok || key == "" || strings.ContainsAny(key, " \t:") {
+		return false
+	}
+	switch key {
+	case "feature", "issue", "base_branch", "resume_branch", "prior_branch", "previous_branch", "branch", "target", "source_issue", "review_id", "problem", "context", "project", "repo", "rig":
+		return true
+	default:
+		return strings.HasSuffix(key, "_branch") || strings.HasSuffix(key, "_issue")
+	}
 }
 
 func isFormulaVarsAttachmentKey(key string) bool {

--- a/internal/beads/fields.go
+++ b/internal/beads/fields.go
@@ -38,20 +38,12 @@ func ParseAttachmentFields(issue *Issue) *AttachmentFields {
 	fields := &AttachmentFields{}
 	hasFields := false
 	var formulaVars []string
-	collectFormulaVarContinuations := false
 
 	for _, line := range strings.Split(issue.Description, "\n") {
 		line = strings.TrimSpace(line)
 		if line == "" {
-			collectFormulaVarContinuations = false
 			continue
 		}
-		if collectFormulaVarContinuations && looksLikeFormulaVarLine(line) {
-			formulaVars = append(formulaVars, line)
-			hasFields = true
-			continue
-		}
-		collectFormulaVarContinuations = false
 
 		// Look for "key: value" pattern
 		colonIdx := strings.Index(line, ":")
@@ -105,7 +97,6 @@ func ParseAttachmentFields(issue *Issue) *AttachmentFields {
 			hasFields = true
 		case "formula_vars", "formula-vars", "formulavars":
 			formulaVars = append(formulaVars, splitFormulaVars(parseFormulaVars(value))...)
-			collectFormulaVarContinuations = !strings.HasPrefix(strings.TrimSpace(value), "[")
 			hasFields = true
 		}
 	}
@@ -222,19 +213,13 @@ func SetAttachmentFields(issue *Issue, fields *AttachmentFields) string {
 	// Collect non-attachment lines from existing description
 	var otherLines []string
 	if issue != nil && issue.Description != "" {
-		skipFormulaVarContinuations := false
 		for _, line := range strings.Split(issue.Description, "\n") {
 			trimmed := strings.TrimSpace(line)
 			if trimmed == "" {
-				skipFormulaVarContinuations = false
 				// Preserve blank lines in content
 				otherLines = append(otherLines, line)
 				continue
 			}
-			if skipFormulaVarContinuations && looksLikeFormulaVarLine(trimmed) {
-				continue
-			}
-			skipFormulaVarContinuations = false
 
 			// Check if this is an attachment field line
 			colonIdx := strings.Index(trimmed, ":")
@@ -246,8 +231,6 @@ func SetAttachmentFields(issue *Issue, fields *AttachmentFields) string {
 			key := strings.ToLower(strings.TrimSpace(trimmed[:colonIdx]))
 			if !attachmentKeys[key] {
 				otherLines = append(otherLines, line)
-			} else if isFormulaVarsAttachmentKey(key) {
-				skipFormulaVarContinuations = true
 			}
 			// Skip attachment field lines - they'll be replaced
 		}
@@ -559,29 +542,6 @@ func splitFormulaVars(raw string) []string {
 		}
 	}
 	return out
-}
-
-func looksLikeFormulaVarLine(line string) bool {
-	key, _, ok := strings.Cut(strings.TrimSpace(line), "=")
-	key = strings.TrimSpace(key)
-	if !ok || key == "" || strings.ContainsAny(key, " \t:") {
-		return false
-	}
-	switch key {
-	case "feature", "issue", "base_branch", "resume_branch", "prior_branch", "previous_branch", "branch", "target", "source_issue", "review_id", "problem", "context", "project", "repo", "rig":
-		return true
-	default:
-		return strings.HasSuffix(key, "_branch") || strings.HasSuffix(key, "_issue")
-	}
-}
-
-func isFormulaVarsAttachmentKey(key string) bool {
-	switch key {
-	case "formula_vars", "formula-vars", "formulavars":
-		return true
-	default:
-		return false
-	}
 }
 
 // SetConvoyFields updates an issue's description with the given convoy fields.

--- a/internal/beads/fields_test.go
+++ b/internal/beads/fields_test.go
@@ -81,6 +81,61 @@ func TestSetAttachmentFieldsPreservesMode(t *testing.T) {
 	}
 }
 
+func TestAttachmentFormulaVarsRoundTrip(t *testing.T) {
+	fields := &AttachmentFields{
+		AttachedFormula: "mol-polecat-work",
+		FormulaVars:     "feature=Bug to fix\nissue=gt-abc123\nbase_branch=main",
+	}
+
+	formatted := FormatAttachmentFields(fields)
+	if !strings.Contains(formatted, `formula_vars: ["feature=Bug to fix","issue=gt-abc123","base_branch=main"]`) {
+		t.Fatalf("formula_vars should use single-line JSON array, got:\n%s", formatted)
+	}
+	if strings.Contains(formatted, "\nissue=gt-abc123") {
+		t.Fatalf("formula_vars leaked continuation lines:\n%s", formatted)
+	}
+
+	parsed := ParseAttachmentFields(&Issue{Description: formatted})
+	if parsed == nil {
+		t.Fatal("round-trip parse returned nil")
+	}
+	want := "feature=Bug to fix\nissue=gt-abc123\nbase_branch=main"
+	if parsed.FormulaVars != want {
+		t.Fatalf("FormulaVars = %q, want %q", parsed.FormulaVars, want)
+	}
+}
+
+func TestParseAttachmentFieldsLegacyFormulaVarsContinuations(t *testing.T) {
+	desc := "formula_vars: feature=Bug to fix\nissue=gt-abc123\nbase_branch=main\nmode: ralph"
+	fields := ParseAttachmentFields(&Issue{Description: desc})
+	if fields == nil {
+		t.Fatal("ParseAttachmentFields returned nil")
+	}
+	want := "feature=Bug to fix\nissue=gt-abc123\nbase_branch=main"
+	if fields.FormulaVars != want {
+		t.Fatalf("FormulaVars = %q, want %q", fields.FormulaVars, want)
+	}
+	if fields.Mode != "ralph" {
+		t.Fatalf("Mode = %q, want ralph", fields.Mode)
+	}
+}
+
+func TestSetAttachmentFieldsRemovesLegacyFormulaVarsContinuations(t *testing.T) {
+	issue := &Issue{Description: "formula_vars: old=1\nissue=old\nbase_branch=old\n\nBody"}
+	fields := &AttachmentFields{FormulaVars: "feature=New\nissue=gt-new"}
+
+	newDesc := SetAttachmentFields(issue, fields)
+	if strings.Contains(newDesc, "\nissue=old") || strings.Contains(newDesc, "base_branch=old") {
+		t.Fatalf("legacy continuation lines should be removed, got:\n%s", newDesc)
+	}
+	if !strings.Contains(newDesc, `formula_vars: ["feature=New","issue=gt-new"]`) {
+		t.Fatalf("new formula_vars missing, got:\n%s", newDesc)
+	}
+	if !strings.Contains(newDesc, "Body") {
+		t.Fatalf("prose should be preserved, got:\n%s", newDesc)
+	}
+}
+
 // --- AgentFields Mode round-trip ---
 
 func TestAgentFieldsModeRoundTrip(t *testing.T) {

--- a/internal/beads/fields_test.go
+++ b/internal/beads/fields_test.go
@@ -106,7 +106,7 @@ func TestAttachmentFormulaVarsRoundTrip(t *testing.T) {
 }
 
 func TestParseAttachmentFieldsLegacyFormulaVarsContinuations(t *testing.T) {
-	desc := "formula_vars: feature=Bug to fix\nissue=gt-abc123\nbase_branch=main\nmode: ralph"
+	desc := "formula_vars: feature=Bug to fix\nissue=gt-abc123\nbase_branch=main\nexample=value\nmode: ralph"
 	fields := ParseAttachmentFields(&Issue{Description: desc})
 	if fields == nil {
 		t.Fatal("ParseAttachmentFields returned nil")
@@ -115,13 +115,16 @@ func TestParseAttachmentFieldsLegacyFormulaVarsContinuations(t *testing.T) {
 	if fields.FormulaVars != want {
 		t.Fatalf("FormulaVars = %q, want %q", fields.FormulaVars, want)
 	}
+	if strings.Contains(fields.FormulaVars, "example=value") {
+		t.Fatalf("prose-like key=value line should not be parsed as formula var: %q", fields.FormulaVars)
+	}
 	if fields.Mode != "ralph" {
 		t.Fatalf("Mode = %q, want ralph", fields.Mode)
 	}
 }
 
 func TestSetAttachmentFieldsRemovesLegacyFormulaVarsContinuations(t *testing.T) {
-	issue := &Issue{Description: "formula_vars: old=1\nissue=old\nbase_branch=old\n\nBody"}
+	issue := &Issue{Description: "formula_vars: old=1\nissue=old\nbase_branch=old\nexample=value\n\nBody"}
 	fields := &AttachmentFields{FormulaVars: "feature=New\nissue=gt-new"}
 
 	newDesc := SetAttachmentFields(issue, fields)
@@ -130,6 +133,9 @@ func TestSetAttachmentFieldsRemovesLegacyFormulaVarsContinuations(t *testing.T) 
 	}
 	if !strings.Contains(newDesc, `formula_vars: ["feature=New","issue=gt-new"]`) {
 		t.Fatalf("new formula_vars missing, got:\n%s", newDesc)
+	}
+	if !strings.Contains(newDesc, "example=value") {
+		t.Fatalf("adjacent prose-like key=value line should be preserved, got:\n%s", newDesc)
 	}
 	if !strings.Contains(newDesc, "Body") {
 		t.Fatalf("prose should be preserved, got:\n%s", newDesc)

--- a/internal/beads/fields_test.go
+++ b/internal/beads/fields_test.go
@@ -105,37 +105,38 @@ func TestAttachmentFormulaVarsRoundTrip(t *testing.T) {
 	}
 }
 
-func TestParseAttachmentFieldsLegacyFormulaVarsContinuations(t *testing.T) {
+func TestParseAttachmentFieldsDoesNotConsumeAdjacentKeyValueLines(t *testing.T) {
 	desc := "formula_vars: feature=Bug to fix\nissue=gt-abc123\nbase_branch=main\nexample=value\nmode: ralph"
 	fields := ParseAttachmentFields(&Issue{Description: desc})
 	if fields == nil {
 		t.Fatal("ParseAttachmentFields returned nil")
 	}
-	want := "feature=Bug to fix\nissue=gt-abc123\nbase_branch=main"
+	want := "feature=Bug to fix"
 	if fields.FormulaVars != want {
 		t.Fatalf("FormulaVars = %q, want %q", fields.FormulaVars, want)
 	}
-	if strings.Contains(fields.FormulaVars, "example=value") {
-		t.Fatalf("prose-like key=value line should not be parsed as formula var: %q", fields.FormulaVars)
+	for _, adjacent := range []string{"issue=gt-abc123", "base_branch=main", "example=value"} {
+		if strings.Contains(fields.FormulaVars, adjacent) {
+			t.Fatalf("adjacent key=value line should not be parsed as formula var: %q", fields.FormulaVars)
+		}
 	}
 	if fields.Mode != "ralph" {
 		t.Fatalf("Mode = %q, want ralph", fields.Mode)
 	}
 }
 
-func TestSetAttachmentFieldsRemovesLegacyFormulaVarsContinuations(t *testing.T) {
+func TestSetAttachmentFieldsPreservesAdjacentKeyValueLines(t *testing.T) {
 	issue := &Issue{Description: "formula_vars: old=1\nissue=old\nbase_branch=old\nexample=value\n\nBody"}
 	fields := &AttachmentFields{FormulaVars: "feature=New\nissue=gt-new"}
 
 	newDesc := SetAttachmentFields(issue, fields)
-	if strings.Contains(newDesc, "\nissue=old") || strings.Contains(newDesc, "base_branch=old") {
-		t.Fatalf("legacy continuation lines should be removed, got:\n%s", newDesc)
-	}
 	if !strings.Contains(newDesc, `formula_vars: ["feature=New","issue=gt-new"]`) {
 		t.Fatalf("new formula_vars missing, got:\n%s", newDesc)
 	}
-	if !strings.Contains(newDesc, "example=value") {
-		t.Fatalf("adjacent prose-like key=value line should be preserved, got:\n%s", newDesc)
+	for _, adjacent := range []string{"issue=old", "base_branch=old", "example=value"} {
+		if !strings.Contains(newDesc, adjacent) {
+			t.Fatalf("adjacent key=value line %q should be preserved, got:\n%s", adjacent, newDesc)
+		}
 	}
 	if !strings.Contains(newDesc, "Body") {
 		t.Fatalf("prose should be preserved, got:\n%s", newDesc)

--- a/internal/cmd/formula_test.go
+++ b/internal/cmd/formula_test.go
@@ -320,6 +320,22 @@ func TestAttachmentFormulaVarsPrefersAttachedVars(t *testing.T) {
 	}
 }
 
+func TestAttachmentFormulaVarsRoundTripsPersistedVars(t *testing.T) {
+	t.Parallel()
+
+	desc := beads.SetAttachmentFields(&beads.Issue{Description: "Body"}, &beads.AttachmentFields{
+		AttachedFormula: "mol-polecat-work",
+		AttachedVars:    []string{"feature=Attached Feature"},
+		FormulaVars:     "feature=Persisted Feature\nissue=gt-123\nbase_branch=main",
+	})
+	attachment := beads.ParseAttachmentFields(&beads.Issue{Description: desc})
+	got := attachmentFormulaVars(attachment)
+	want := []string{"feature=Attached Feature", "issue=gt-123", "base_branch=main"}
+	if !reflect.DeepEqual(got, want) {
+		t.Fatalf("attachmentFormulaVars() = %#v, want %#v\nDescription:\n%s", got, want, desc)
+	}
+}
+
 func TestApplyFormulaVarsUsesWorkflowBareSyntax(t *testing.T) {
 	t.Parallel()
 

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -222,7 +222,10 @@ func runPrime(cmd *cobra.Command, args []string) (retErr error) {
 	// started with. Only emitted when GT telemetry is active (GT_OTEL_LOGS_URL set).
 	telemetry.RecordPrimeContext(context.Background(), formula, os.Getenv("GT_ROLE"), primeHookMode)
 
-	hasSlungWork := checkSlungWork(ctx, hookedBead)
+	hasSlungWork, err := checkSlungWork(ctx, hookedBead)
+	if err != nil {
+		return err
+	}
 	explain(hasSlungWork, "Autonomous mode: hooked/in-progress work detected")
 
 	outputMoleculeContext(ctx)
@@ -680,9 +683,9 @@ func runMailCheckInject(workDir string) {
 //
 // hookedBead is pre-fetched by the caller (runPrime) via findAgentWork to avoid a
 // redundant lookup and ensure work context is already injected before output runs.
-func checkSlungWork(ctx RoleContext, hookedBead *beads.Issue) bool {
+func checkSlungWork(ctx RoleContext, hookedBead *beads.Issue) (bool, error) {
 	if hookedBead == nil {
-		return false
+		return false, nil
 	}
 
 	attachment := beads.ParseAttachmentFields(hookedBead)
@@ -692,12 +695,14 @@ func checkSlungWork(ctx RoleContext, hookedBead *beads.Issue) bool {
 	outputHookedBeadDetails(hookedBead)
 
 	if hasWorkflow {
-		outputMoleculeWorkflow(ctx, attachment)
+		if err := outputMoleculeWorkflow(ctx, attachment); err != nil {
+			return true, err
+		}
 	} else {
 		outputBeadPreview(hookedBead)
 	}
 
-	return true
+	return true, nil
 }
 
 func hasWorkflowAttachment(attachment *beads.AttachmentFields) bool {
@@ -969,7 +974,7 @@ func outputHookedBeadDetails(hookedBead *beads.Issue) {
 }
 
 // outputMoleculeWorkflow displays attached molecule context with current step.
-func outputMoleculeWorkflow(ctx RoleContext, attachment *beads.AttachmentFields) {
+func outputMoleculeWorkflow(ctx RoleContext, attachment *beads.AttachmentFields) error {
 	fmt.Printf("%s\n\n", style.Bold.Render("## 🧬 ATTACHED FORMULA (WORKFLOW CHECKLIST)"))
 	if attachment.AttachedFormula != "" {
 		fmt.Printf("Formula: %s\n", attachment.AttachedFormula)
@@ -991,8 +996,7 @@ func outputMoleculeWorkflow(ctx RoleContext, attachment *beads.AttachmentFields)
 
 	// Ralph loop mode: output Ralph Wiggum loop command instead of step-by-step execution
 	if attachment.Mode == "ralph" {
-		outputRalphLoopDirective(ctx, attachment)
-		return
+		return outputRalphLoopDirective(ctx, attachment)
 	}
 
 	// Show inline formula steps from the embedded binary (root-only: no child wisps to query).
@@ -1002,7 +1006,7 @@ func outputMoleculeWorkflow(ctx RoleContext, attachment *beads.AttachmentFields)
 		fmt.Printf("%s\n", style.Bold.Render("Work through ALL steps above, including submit and cleanup."))
 		fmt.Println("The base bead is your assignment. The formula steps define your workflow.")
 		fmt.Printf("\n%s\n", style.Bold.Render("REQUIRED: When all steps complete, run `"+cli.Name()+" done` to submit to the merge queue. Do NOT stop after implementation — the formula has submit steps you must follow."))
-		return
+		return nil
 	}
 
 	// Legacy path: no formula name stored, fall back to bd mol current
@@ -1010,42 +1014,100 @@ func outputMoleculeWorkflow(ctx RoleContext, attachment *beads.AttachmentFields)
 	fmt.Println()
 	fmt.Printf("%s\n", style.Bold.Render("Follow the molecule steps above, NOT the base bead."))
 	fmt.Println("The base bead is just a container. The molecule steps define your workflow.")
+	return nil
 }
 
-// outputRalphLoopDirective emits inline iterative work instructions for ralph mode.
-// Ralph mode is designed for long, iterative workflows (e.g., quality improvement
-// loops) that benefit from committing progress incrementally. The agent works
-// through formula steps iteratively, committing after each meaningful change,
-// and calls gt done when all acceptance criteria are met or no further progress
-// can be made.
-func outputRalphLoopDirective(ctx RoleContext, attachment *beads.AttachmentFields) {
-	fmt.Printf("%s\n\n", style.Bold.Render("## RALPH LOOP MODE (ITERATIVE WORKFLOW)"))
-	fmt.Println("This work uses iterative loop mode. Work through the steps below,")
-	fmt.Println("committing after each meaningful change. Loop until acceptance criteria")
-	fmt.Println("are met or no further progress can be made.")
-	fmt.Println()
+const ralphLoopPluginID = "ralph-loop@claude-plugins-official"
 
-	// Show the formula steps inline (same as normal mode) so the agent has
-	// the full checklist. Previously this emitted a /ralph-loop slash command
-	// that didn't exist, causing the polecat to die immediately.
+// outputRalphLoopDirective emits the ralph-loop plugin command for Ralph mode.
+func outputRalphLoopDirective(ctx RoleContext, attachment *beads.AttachmentFields) error {
+	installed, configDir, err := isRalphLoopPluginInstalled()
+	if err != nil {
+		return err
+	}
+	return outputRalphLoopDirectiveWithPluginCheck(ctx, attachment, installed, configDir)
+}
+
+func outputRalphLoopDirectiveWithPluginCheck(ctx RoleContext, attachment *beads.AttachmentFields, pluginInstalled bool, configDir string) error {
+	if !pluginInstalled {
+		return missingRalphLoopPluginError(configDir)
+	}
+
+	prompt, err := renderRalphLoopPrompt(ctx, attachment)
+	if err != nil {
+		return err
+	}
+	fmt.Printf("/ralph-loop %s --completion-promise DONE\n", quoteForRalphLoop(prompt))
+	return nil
+}
+
+func renderRalphLoopPrompt(ctx RoleContext, attachment *beads.AttachmentFields) (string, error) {
+	var sb strings.Builder
 	if attachment.AttachedFormula != "" {
-		showFormulaStepsFull(attachment.AttachedFormula, ctx.TownRoot, ctx.Rig, attachmentFormulaVars(attachment))
-		fmt.Println()
+		rendered, err := renderFormulaStepsFull(attachment.AttachedFormula, ctx.TownRoot, ctx.Rig, attachmentFormulaVars(attachment))
+		if err != nil {
+			return "", err
+		}
+		sb.WriteString(rendered)
 	}
-
 	if attachment.AttachedArgs != "" {
-		fmt.Printf("%s\n", style.Bold.Render("Context:"))
-		fmt.Printf("  %s\n\n", attachment.AttachedArgs)
+		if sb.Len() > 0 {
+			sb.WriteString("\n")
+		}
+		sb.WriteString("Context:\n")
+		sb.WriteString(attachment.AttachedArgs)
+		sb.WriteString("\n")
 	}
+	if sb.Len() == 0 {
+		sb.WriteString("Work through the assigned Ralph-mode workflow.\n")
+	}
+	sb.WriteString("\nWhen all steps are complete and `" + cli.Name() + " done` has run successfully, output exactly: <promise>DONE</promise>")
+	return sb.String(), nil
+}
 
-	fmt.Printf("%s\n", style.Bold.Render("Iterative workflow:"))
-	fmt.Println("1. Work through the formula steps above")
-	fmt.Println("2. Commit after each meaningful change (preserve progress via git)")
-	fmt.Println("3. After completing a pass, evaluate results against acceptance criteria")
-	fmt.Println("4. If criteria not met, loop: identify the worst gap, fix it, commit, re-evaluate")
-	fmt.Println("5. When all criteria are met (or no further progress possible), run `" + cli.Name() + " done`")
-	fmt.Println()
-	fmt.Printf("%s\n", style.Bold.Render("Commit frequently. Each commit preserves your progress."))
+func isRalphLoopPluginInstalled() (bool, string, error) {
+	configDir, err := config.ClaudeConfigDir()
+	if err != nil {
+		return false, "", fmt.Errorf("resolving Claude config dir for ralph-loop plugin: %w", err)
+	}
+	installed, err := ralphLoopPluginInstalledIn(filepath.Join(configDir, "plugins", "installed_plugins.json"))
+	return installed, configDir, err
+}
+
+func missingRalphLoopPluginError(configDir string) error {
+	manifestPath := filepath.Join(configDir, "plugins", "installed_plugins.json")
+	return fmt.Errorf("--ralph requires the %s plugin in Claude Code config %s (checked %s). Install it with: /plugin install %s", ralphLoopPluginID, configDir, manifestPath, ralphLoopPluginID)
+}
+
+func ralphLoopPluginInstalledIn(manifestPath string) (bool, error) {
+	data, err := os.ReadFile(manifestPath)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return false, nil
+		}
+		return false, fmt.Errorf("reading ralph-loop plugin manifest %s: %w", manifestPath, err)
+	}
+	var manifest struct {
+		Plugins map[string]json.RawMessage `json:"plugins"`
+	}
+	if err := json.Unmarshal(data, &manifest); err != nil {
+		return false, fmt.Errorf("parsing ralph-loop plugin manifest %s: %w", manifestPath, err)
+	}
+	_, ok := manifest.Plugins[ralphLoopPluginID]
+	return ok, nil
+}
+
+// quoteForRalphLoop wraps s in double quotes for the slash command and escapes
+// characters that could break the prompt argument or shell-backed plugin setup.
+func quoteForRalphLoop(s string) string {
+	s = strings.ReplaceAll(s, "\r\n", "\n")
+	s = strings.ReplaceAll(s, "\r", "\n")
+	s = strings.ReplaceAll(s, `\`, `\\`)
+	s = strings.ReplaceAll(s, `"`, `\"`)
+	s = strings.ReplaceAll(s, `$`, `\$`)
+	s = strings.ReplaceAll(s, "`", "\\`")
+	s = strings.ReplaceAll(s, "\n", `\n`)
+	return `"` + s + `"`
 }
 
 // outputBeadPreview runs `bd show` and displays a truncated preview of the bead.

--- a/internal/cmd/prime_molecule.go
+++ b/internal/cmd/prime_molecule.go
@@ -152,20 +152,27 @@ func showFormulaSteps(formulaName, label, townRoot, rigName string, extraVars ..
 // townRoot and rigName are used to load formula overlays (operator customizations).
 // extraVars is an optional list of "key=value" overrides substituted into step descriptions.
 func showFormulaStepsFull(formulaName, townRoot, rigName string, extraVars ...[]string) {
+	rendered, err := renderFormulaStepsFull(formulaName, townRoot, rigName, extraVars...)
+	if err != nil {
+		style.PrintWarning("%v", err)
+		return
+	}
+	fmt.Print(rendered)
+}
+
+func renderFormulaStepsFull(formulaName, townRoot, rigName string, extraVars ...[]string) (string, error) {
 	content, err := formula.ResolveFormulaContent(formulaName, townRoot, rigName)
 	if err != nil {
-		style.PrintWarning("could not load formula %s: %v", formulaName, err)
-		return
+		return "", fmt.Errorf("could not load formula %s: %w", formulaName, err)
 	}
 
 	f, err := formula.Parse(content)
 	if err != nil {
-		style.PrintWarning("could not parse formula %s: %v", formulaName, err)
-		return
+		return "", fmt.Errorf("could not parse formula %s: %w", formulaName, err)
 	}
 
 	if len(f.Steps) == 0 {
-		return
+		return "", nil
 	}
 
 	// Apply formula overlays if townRoot is available.
@@ -177,16 +184,18 @@ func showFormulaStepsFull(formulaName, townRoot, rigName string, extraVars ...[]
 	}
 	varMap := buildFormulaVarMap(f, vars)
 
-	fmt.Println()
-	fmt.Printf("**Formula Checklist** (%d steps from %s):\n\n", len(f.Steps), formulaName)
+	var sb strings.Builder
+	sb.WriteString("\n")
+	fmt.Fprintf(&sb, "**Formula Checklist** (%d steps from %s):\n\n", len(f.Steps), formulaName)
 	for i, step := range f.Steps {
 		title := applyFormulaVars(step.Title, varMap)
-		fmt.Printf("### Step %d: %s\n\n", i+1, title)
+		fmt.Fprintf(&sb, "### Step %d: %s\n\n", i+1, title)
 		if step.Description != "" {
-			fmt.Println(applyFormulaVars(step.Description, varMap))
-			fmt.Println()
+			sb.WriteString(applyFormulaVars(step.Description, varMap))
+			sb.WriteString("\n\n")
 		}
 	}
+	return sb.String(), nil
 }
 
 // buildFormulaVarMap builds a map of variable name → value for substitution.
@@ -210,13 +219,32 @@ func attachmentFormulaVars(attachment *beads.AttachmentFields) []string {
 	if attachment == nil {
 		return nil
 	}
-	if len(attachment.AttachedVars) > 0 {
-		return attachment.AttachedVars
+	indexes := make(map[string]int)
+	vars := make([]string, 0, len(attachment.AttachedVars))
+	add := func(variable string) {
+		variable = strings.TrimSpace(variable)
+		if variable == "" {
+			return
+		}
+		idx := strings.IndexByte(variable, '=')
+		if idx <= 0 {
+			return
+		}
+		key := strings.TrimSpace(variable[:idx])
+		if idx, ok := indexes[key]; ok {
+			vars[idx] = variable
+			return
+		}
+		indexes[key] = len(vars)
+		vars = append(vars, variable)
 	}
-	if attachment.FormulaVars == "" {
-		return nil
+	for _, variable := range strings.Split(attachment.FormulaVars, "\n") {
+		add(variable)
 	}
-	return strings.Split(attachment.FormulaVars, "\n")
+	for _, variable := range attachment.AttachedVars {
+		add(variable)
+	}
+	return vars
 }
 
 // applyFormulaVars replaces {{key}} placeholders in text with values from varMap.

--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -919,6 +919,47 @@ func TestCheckSlungWork_StandaloneFormulaUsesWorkflowOutput(t *testing.T) {
 	}
 }
 
+func TestCheckSlungWork_RalphModeUsesLoopDirective(t *testing.T) {
+	configDir := t.TempDir()
+	pluginsDir := filepath.Join(configDir, "plugins")
+	if err := os.MkdirAll(pluginsDir, 0755); err != nil {
+		t.Fatalf("mkdir plugins: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginsDir, "installed_plugins.json"), []byte(`{"plugins":{"ralph-loop@claude-plugins-official":{}}}`), 0644); err != nil {
+		t.Fatalf("write plugin manifest: %v", err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", configDir)
+
+	ctx := RoleContext{Role: RoleCrew}
+	hookedBead := &beads.Issue{
+		ID:    "gt-wisp-ralph",
+		Title: "Ralph workflow",
+		Description: strings.Join([]string{
+			"attached_molecule: gt-wisp-ralph",
+			"attached_args: do the loop",
+			"mode: ralph",
+		}, "\n"),
+	}
+
+	var found bool
+	var gotErr error
+	output := captureStdout(t, func() {
+		found, gotErr = checkSlungWork(ctx, hookedBead)
+	})
+	if gotErr != nil {
+		t.Fatalf("checkSlungWork() error = %v", gotErr)
+	}
+	if !found {
+		t.Fatalf("checkSlungWork() = false, want true")
+	}
+	if !strings.Contains(output, "/ralph-loop ") || !strings.Contains(output, "--completion-promise DONE") {
+		t.Fatalf("expected ralph-loop directive, got:\n%s", output)
+	}
+	if strings.Contains(output, "Formula Checklist") {
+		t.Fatalf("ralph mode should emit plugin directive instead of inline checklist, got:\n%s", output)
+	}
+}
+
 // TestCompactResumeReminder_PolecatGetsGtDone verifies that polecats get a
 // gt done reminder after context compaction. This is the regression test for
 // the polecats-no-gt-done bug: after long work sessions, compaction drops the

--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -897,9 +897,13 @@ func TestCheckSlungWork_StandaloneFormulaUsesWorkflowOutput(t *testing.T) {
 	}
 
 	var found bool
+	var gotErr error
 	output := captureStdout(t, func() {
-		found = checkSlungWork(ctx, hookedBead)
+		found, gotErr = checkSlungWork(ctx, hookedBead)
 	})
+	if gotErr != nil {
+		t.Fatalf("checkSlungWork() error = %v", gotErr)
+	}
 
 	if !found {
 		t.Fatalf("checkSlungWork() = false, want true")
@@ -1028,62 +1032,121 @@ func TestEnsureBeadsRedirect_RepairsExistingRedirectChain(t *testing.T) {
 	}
 }
 
-// TestOutputRalphLoopDirective_NoSlashCommand verifies that ralph mode emits
-// inline iterative work instructions instead of referencing a nonexistent
-// /ralph-loop slash command. This is the regression test for the ralph-loop
-// dies-on-spawn bug: polecats died immediately because Claude tried to run
-// /ralph-loop which didn't exist as a provisioned slash command.
-func TestOutputRalphLoopDirective_NoSlashCommand(t *testing.T) {
-	attachment := &beads.AttachmentFields{
-		Mode:         "ralph",
-		AttachedArgs: "Run story audit, fix worst gap, commit, loop",
-	}
-	output := captureStdout(t, func() {
-		outputRalphLoopDirective(RoleContext{}, attachment)
-	})
-
-	// Must NOT reference /ralph-loop (nonexistent slash command)
-	if strings.Contains(output, "/ralph-loop") {
-		t.Fatalf("ralph directive must NOT reference /ralph-loop (slash command doesn't exist), got:\n%s", output)
-	}
-
-	// Must contain iterative workflow instructions
-	if !strings.Contains(output, "RALPH LOOP MODE") {
-		t.Fatalf("expected 'RALPH LOOP MODE' header, got:\n%s", output)
-	}
-	if !strings.Contains(output, "gt done") {
-		t.Fatalf("expected 'gt done' instruction for completion, got:\n%s", output)
-	}
-	if !strings.Contains(output, "Commit frequently") {
-		t.Fatalf("expected commit guidance, got:\n%s", output)
-	}
-
-	// Must include the context/args
-	if !strings.Contains(output, "story audit") {
-		t.Fatalf("expected attached args in output, got:\n%s", output)
-	}
-}
-
-// TestOutputRalphLoopDirective_WithFormula verifies that ralph mode shows
-// formula steps inline (same as normal mode) when a formula is attached.
-func TestOutputRalphLoopDirective_WithFormula(t *testing.T) {
+func TestOutputRalphLoopDirective_PluginInstalled(t *testing.T) {
 	attachment := &beads.AttachmentFields{
 		Mode:            "ralph",
 		AttachedFormula: "mol-polecat-work",
+		AttachedArgs:    "Run story audit, fix worst gap, commit, loop",
 		FormulaVars:     "base_branch=main",
 	}
+	var gotErr error
 	output := captureStdout(t, func() {
-		outputRalphLoopDirective(RoleContext{}, attachment)
+		gotErr = outputRalphLoopDirectiveWithPluginCheck(RoleContext{}, attachment, true, t.TempDir())
 	})
-
-	// Should NOT reference /ralph-loop
-	if strings.Contains(output, "/ralph-loop") {
-		t.Fatalf("ralph directive must NOT reference /ralph-loop, got:\n%s", output)
+	if gotErr != nil {
+		t.Fatalf("outputRalphLoopDirectiveWithPluginCheck: %v", gotErr)
 	}
 
-	// Should show formula steps (from mol-polecat-work)
+	if !strings.Contains(output, "/ralph-loop ") {
+		t.Fatalf("expected /ralph-loop command, got:\n%s", output)
+	}
+	if !strings.Contains(output, "--completion-promise DONE") {
+		t.Fatalf("expected completion promise flag, got:\n%s", output)
+	}
 	if !strings.Contains(output, "Formula Checklist") {
-		t.Fatalf("expected formula checklist in ralph output, got:\n%s", output)
+		t.Fatalf("expected rendered formula checklist in prompt, got:\n%s", output)
+	}
+	if !strings.Contains(output, "story audit") {
+		t.Fatalf("expected attached args in prompt, got:\n%s", output)
+	}
+	if !strings.Contains(output, `<promise>DONE</promise>`) {
+		t.Fatalf("expected DONE promise instruction in prompt, got:\n%s", output)
+	}
+}
+
+func TestOutputRalphLoopDirective_PluginMissing(t *testing.T) {
+	var gotErr error
+	output := captureStdout(t, func() {
+		gotErr = outputRalphLoopDirectiveWithPluginCheck(RoleContext{}, &beads.AttachmentFields{Mode: "ralph"}, false, "/tmp/claude-test")
+	})
+	if gotErr == nil {
+		t.Fatal("expected missing plugin error")
+	}
+	if !strings.Contains(gotErr.Error(), ralphLoopPluginID) || !strings.Contains(gotErr.Error(), "/plugin install") {
+		t.Fatalf("missing plugin error not actionable: %v", gotErr)
+	}
+	if strings.Contains(output, "/ralph-loop") {
+		t.Fatalf("should not emit /ralph-loop when plugin is missing, got:\n%s", output)
+	}
+}
+
+func TestRalphLoopPluginInstalledIn(t *testing.T) {
+	pluginsDir := filepath.Join(t.TempDir(), "plugins")
+	if err := os.MkdirAll(pluginsDir, 0755); err != nil {
+		t.Fatalf("mkdir plugins: %v", err)
+	}
+	manifestPath := filepath.Join(pluginsDir, "installed_plugins.json")
+	if err := os.WriteFile(manifestPath, []byte(`{"plugins":{"ralph-loop@claude-plugins-official":{},"ralph-loop-evil@claude-plugins-official":{}}}`), 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+
+	installed, err := ralphLoopPluginInstalledIn(manifestPath)
+	if err != nil {
+		t.Fatalf("ralphLoopPluginInstalledIn: %v", err)
+	}
+	if !installed {
+		t.Fatal("expected canonical ralph-loop plugin to be detected")
+	}
+
+	if err := os.WriteFile(manifestPath, []byte(`{"plugins":{"ralph-loop-evil@claude-plugins-official":{}}}`), 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	installed, err = ralphLoopPluginInstalledIn(manifestPath)
+	if err != nil {
+		t.Fatalf("ralphLoopPluginInstalledIn malicious key: %v", err)
+	}
+	if installed {
+		t.Fatal("must not accept prefix-like plugin IDs")
+	}
+}
+
+func TestIsRalphLoopPluginInstalledUsesClaudeConfigDir(t *testing.T) {
+	configDir := t.TempDir()
+	pluginsDir := filepath.Join(configDir, "plugins")
+	if err := os.MkdirAll(pluginsDir, 0755); err != nil {
+		t.Fatalf("mkdir plugins: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(pluginsDir, "installed_plugins.json"), []byte(`{"plugins":{"ralph-loop@claude-plugins-official":{}}}`), 0644); err != nil {
+		t.Fatalf("write manifest: %v", err)
+	}
+	t.Setenv("CLAUDE_CONFIG_DIR", configDir)
+
+	installed, gotConfigDir, err := isRalphLoopPluginInstalled()
+	if err != nil {
+		t.Fatalf("isRalphLoopPluginInstalled: %v", err)
+	}
+	if !installed {
+		t.Fatal("expected plugin installed via CLAUDE_CONFIG_DIR")
+	}
+	if gotConfigDir != configDir {
+		t.Fatalf("configDir = %q, want %q", gotConfigDir, configDir)
+	}
+}
+
+func TestQuoteForRalphLoop(t *testing.T) {
+	quoted := quoteForRalphLoop("line1\r\nline2 \"quoted\" \\ $HOME `cmd`")
+	if !strings.HasPrefix(quoted, `"`) || !strings.HasSuffix(quoted, `"`) {
+		t.Fatalf("expected double-quoted prompt, got %q", quoted)
+	}
+	for _, forbidden := range []string{"\n", "\r"} {
+		if strings.Contains(quoted, forbidden) {
+			t.Fatalf("quoted prompt contains raw line break %q: %q", forbidden, quoted)
+		}
+	}
+	for _, want := range []string{`\n`, `\"`, `\\`, `\$`, "\\`"} {
+		if !strings.Contains(quoted, want) {
+			t.Fatalf("quoted prompt missing escape %q: %q", want, quoted)
+		}
 	}
 }
 

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -932,6 +932,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 
 	// Formula-on-bead mode: instantiate formula and bond to original bead
 	formulaVarsForAttachment := strings.Join(slingVars, "\n")
+	varsForAttachment := append([]string(nil), slingVars...)
 	if formulaName != "" {
 		fmt.Printf("  Instantiating formula %s...\n", formulaName)
 
@@ -939,6 +940,8 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		if parts := strings.SplitN(targetAgent, "/", 2); len(parts) >= 1 && parts[0] != "" {
 			rigCmdVars := loadRigCommandVars(townRoot, parts[0])
 			slingVars = append(rigCmdVars, slingVars...)
+			varsForAttachment = append([]string(nil), slingVars...)
+			formulaVarsForAttachment = strings.Join(slingVars, "\n")
 		}
 
 		result, err := InstantiateFormulaOnBead(ctx, formulaName, beadID, info.Title, hookWorkDir, townRoot, false, slingVars)
@@ -969,6 +972,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		// - Compound resolution: base bead -> attached_molecule -> wisp
 		attachedMoleculeID = result.WispRootID
 		if len(result.FormulaVars) > 0 {
+			varsForAttachment = append([]string(nil), result.FormulaVars...)
 			formulaVarsForAttachment = strings.Join(result.FormulaVars, "\n")
 		}
 
@@ -1037,7 +1041,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	fieldUpdates := buildSlingFieldUpdates(
 		actor,
 		slingArgs,
-		append([]string(nil), slingVars...),
+		varsForAttachment,
 		attachedMoleculeID,
 		formulaName,
 		slingNoMerge,
@@ -1062,9 +1066,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 			fmt.Printf("%s Review-only mode: assignee must evaluate and report back, NOT merge/commit/push\n", style.Bold.Render("⚠"))
 		}
 	}
-	if mode != "" {
-		updateAgentMode(targetAgent, mode, hookWorkDir, townBeadsDir)
-	}
+	updateAgentMode(targetAgent, mode, hookWorkDir, townBeadsDir)
 
 	// Start delayed dog session now that hook is set
 	// This ensures dog sees the hook when gt prime runs on session start

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -1066,7 +1066,9 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 			fmt.Printf("%s Review-only mode: assignee must evaluate and report back, NOT merge/commit/push\n", style.Bold.Render("⚠"))
 		}
 	}
-	updateAgentMode(targetAgent, mode, hookWorkDir, townBeadsDir)
+	if mode != "" {
+		updateAgentMode(targetAgent, mode, hookWorkDir, townBeadsDir)
+	}
 
 	// Start delayed dog session now that hook is set
 	// This ensures dog sees the hook when gt prime runs on session start

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -931,6 +931,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	}
 
 	// Formula-on-bead mode: instantiate formula and bond to original bead
+	formulaVarsForAttachment := strings.Join(slingVars, "\n")
 	if formulaName != "" {
 		fmt.Printf("  Instantiating formula %s...\n", formulaName)
 
@@ -967,6 +968,9 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		// - gt done: close attached_molecule (wisp) first, then close base bead
 		// - Compound resolution: base bead -> attached_molecule -> wisp
 		attachedMoleculeID = result.WispRootID
+		if len(result.FormulaVars) > 0 {
+			formulaVarsForAttachment = strings.Join(result.FormulaVars, "\n")
+		}
 
 		// NOTE: We intentionally keep beadID as the ORIGINAL base bead, not the wisp.
 		// The base bead is hooked so that:
@@ -1026,6 +1030,10 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 	// Store all attachment fields in a single read-modify-write cycle.
 	// This eliminates the race condition where sequential independent updates
 	// (dispatcher, args, no_merge, attached_molecule) could overwrite each other.
+	mode := ""
+	if slingRalph {
+		mode = "ralph"
+	}
 	fieldUpdates := buildSlingFieldUpdates(
 		actor,
 		slingArgs,
@@ -1034,7 +1042,8 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		formulaName,
 		slingNoMerge,
 		slingReviewOnly,
-		strings.Join(slingVars, "\n"),
+		mode,
+		formulaVarsForAttachment,
 		convoyID,
 		slingMerge,
 		slingOwned,
@@ -1052,6 +1061,9 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		if slingReviewOnly {
 			fmt.Printf("%s Review-only mode: assignee must evaluate and report back, NOT merge/commit/push\n", style.Bold.Render("⚠"))
 		}
+	}
+	if mode != "" {
+		updateAgentMode(targetAgent, mode, hookWorkDir, townBeadsDir)
 	}
 
 	// Start delayed dog session now that hook is set

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -292,6 +292,8 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 	beadToHook := params.BeadID
 	attachedMoleculeID := ""
 	var allVars []string
+	varsForAttachment := append([]string(nil), params.Vars...)
+	formulaVarsForAttachment := strings.Join(varsForAttachment, "\n")
 	if params.FormulaName != "" && formulaCooked {
 		// Auto-inject rig command vars as defaults (user --var flags override)
 		rigCmdVars := loadRigCommandVars(townRoot, params.RigName)
@@ -309,6 +311,8 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 			allVars = append(allVars, priorVars...)
 			fmt.Printf("  %s Prior attempt found — context injected for polecat\n", style.Dim.Render("↻"))
 		}
+		varsForAttachment = append([]string(nil), allVars...)
+		formulaVarsForAttachment = strings.Join(allVars, "\n")
 		formulaResult, err := InstantiateFormulaOnBead(context.Background(), params.FormulaName, params.BeadID, info.Title, hookWorkDir, townRoot, true, allVars)
 		if err != nil {
 			if params.FormulaFailFatal {
@@ -324,6 +328,11 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 			fmt.Printf("  %s Formula %s applied\n", style.Bold.Render("✓"), params.FormulaName)
 			beadToHook = formulaResult.BeadToHook
 			attachedMoleculeID = formulaResult.WispRootID
+			if len(formulaResult.FormulaVars) > 0 {
+				allVars = formulaResult.FormulaVars
+				varsForAttachment = append([]string(nil), allVars...)
+				formulaVarsForAttachment = strings.Join(allVars, "\n")
+			}
 		}
 	}
 	result.AttachedMolecule = attachedMoleculeID
@@ -358,24 +367,21 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 	fieldUpdates := beadFieldUpdates{
 		Dispatcher:       actor,
 		Args:             params.Args,
-		Vars:             append([]string(nil), params.Vars...),
+		Vars:             varsForAttachment,
 		AttachedMolecule: attachedMoleculeID,
 		AttachedFormula:  params.FormulaName,
 		NoMerge:          params.NoMerge,
 		ReviewOnly:       params.ReviewOnly,
 		Mode:             &params.Mode,
-		FormulaVars:      strings.Join(allVars, "\n"),
+		FormulaVars:      formulaVarsForAttachment,
 	}
 	// Use beadToHook for the update target (may differ from beadID when formula-on-bead)
 	if err := storeFieldsInBead(beadToHook, fieldUpdates); err != nil {
 		fmt.Printf("  %s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)
 	}
 
-	// Update agent bead mode for stuck-detector Ralph thresholds. Reuse/reset
-	// clears stale mode, so normal dispatches avoid extra agent-bead writes.
-	if params.Mode != "" {
-		updateAgentMode(targetAgent, params.Mode, hookWorkDir, beadsDir)
-	}
+	// Keep agent-bead mode aligned with the hooked work so stale Ralph thresholds clear.
+	updateAgentMode(targetAgent, params.Mode, hookWorkDir, beadsDir)
 
 	// 11. Start polecat session
 	pane, err := spawnInfo.StartSession()

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -380,8 +380,10 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 		fmt.Printf("  %s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)
 	}
 
-	// Keep agent-bead mode aligned with the hooked work so stale Ralph thresholds clear.
-	updateAgentMode(targetAgent, params.Mode, hookWorkDir, beadsDir)
+	// Update agent bead mode for stuck-detector Ralph thresholds. Reuse/reset clears stale mode.
+	if params.Mode != "" {
+		updateAgentMode(targetAgent, params.Mode, hookWorkDir, beadsDir)
+	}
 
 	// 11. Start polecat session
 	pane, err := spawnInfo.StartSession()

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -363,7 +363,7 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 		AttachedFormula:  params.FormulaName,
 		NoMerge:          params.NoMerge,
 		ReviewOnly:       params.ReviewOnly,
-		Mode:             params.Mode,
+		Mode:             &params.Mode,
 		FormulaVars:      strings.Join(allVars, "\n"),
 	}
 	// Use beadToHook for the update target (may differ from beadID when formula-on-bead)
@@ -371,7 +371,8 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 		fmt.Printf("  %s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)
 	}
 
-	// Update agent bead mode (for stuck detector to identify ralphcats)
+	// Update agent bead mode for stuck-detector Ralph thresholds. Reuse/reset
+	// clears stale mode, so normal dispatches avoid extra agent-bead writes.
 	if params.Mode != "" {
 		updateAgentMode(targetAgent, params.Mode, hookWorkDir, beadsDir)
 	}

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -299,9 +299,7 @@ func runSlingFormula(ctx context.Context, args []string) error {
 	} else if slingArgs != "" {
 		fmt.Printf("%s Args stored in bead (durable)\n", style.Bold.Render("✓"))
 	}
-	if mode != "" {
-		updateAgentMode(targetAgent, mode, "", townBeadsDir)
-	}
+	updateAgentMode(targetAgent, mode, "", townBeadsDir)
 
 	// Start delayed dog session now that hook is set
 	// This ensures dog sees the hook when gt prime runs on session start

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -299,7 +299,9 @@ func runSlingFormula(ctx context.Context, args []string) error {
 	} else if slingArgs != "" {
 		fmt.Printf("%s Args stored in bead (durable)\n", style.Bold.Render("✓"))
 	}
-	updateAgentMode(targetAgent, mode, "", townBeadsDir)
+	if mode != "" {
+		updateAgentMode(targetAgent, mode, "", townBeadsDir)
+	}
 
 	// Start delayed dog session now that hook is set
 	// This ensures dog sees the hook when gt prime runs on session start

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -282,17 +282,25 @@ func runSlingFormula(ctx context.Context, args []string) error {
 	// attached_molecule as a self-reference (the wisp's own ID pointing to itself
 	// is meaningless). attached_molecule is only meaningful when a formula-on-bead
 	// creates a wisp that's bonded to a separate base bead.
+	mode := ""
+	if slingRalph {
+		mode = "ralph"
+	}
 	fieldUpdates := beadFieldUpdates{
 		Dispatcher:      actor,
 		Args:            slingArgs,
 		Vars:            append([]string(nil), slingVars...),
 		AttachedFormula: formulaName,
+		Mode:            &mode,
 		FormulaVars:     strings.Join(slingVars, "\n"),
 	}
 	if err := storeFieldsInBead(wispRootID, fieldUpdates); err != nil {
 		fmt.Printf("%s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)
 	} else if slingArgs != "" {
 		fmt.Printf("%s Args stored in bead (durable)\n", style.Bold.Render("✓"))
+	}
+	if mode != "" {
+		updateAgentMode(targetAgent, mode, "", townBeadsDir)
 	}
 
 	// Start delayed dog session now that hook is set

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -197,12 +197,28 @@ func runSlingFormula(ctx context.Context, args []string) error {
 		return fmt.Errorf("serializing formula sling for %s: %w", targetAgent, assigneeLockErr)
 	}
 	defer assigneeUnlock()
+	mode := ""
+	if slingRalph {
+		mode = "ralph"
+	}
 
 	existing, err := findHookedFormulaSingletonFn(formulaWorkDir, targetAgent, formulaName)
 	if err != nil {
 		return fmt.Errorf("checking existing hooked formulas for %s: %w", targetAgent, err)
 	}
 	if existing != nil && !slingForce {
+		existingMode := ""
+		if fields := beads.ParseAttachmentFields(existing); fields != nil {
+			existingMode = fields.Mode
+		}
+		if existingMode != mode {
+			if err := storeFieldsInBead(existing.ID, beadFieldUpdates{Mode: &mode}); err != nil {
+				return fmt.Errorf("updating existing formula mode: %w", err)
+			}
+			if mode != "" || existingMode != "" {
+				updateAgentMode(targetAgent, mode, "", townBeadsDir)
+			}
+		}
 		fmt.Printf("%s Formula %s already hooked to %s via %s, no-op\n",
 			style.Dim.Render("○"), formulaName, targetAgent, existing.ID)
 		return nil
@@ -282,10 +298,6 @@ func runSlingFormula(ctx context.Context, args []string) error {
 	// attached_molecule as a self-reference (the wisp's own ID pointing to itself
 	// is meaningless). attached_molecule is only meaningful when a formula-on-bead
 	// creates a wisp that's bonded to a separate base bead.
-	mode := ""
-	if slingRalph {
-		mode = "ralph"
-	}
 	fieldUpdates := beadFieldUpdates{
 		Dispatcher:      actor,
 		Args:            slingArgs,

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -469,7 +469,7 @@ type beadFieldUpdates struct {
 	AttachedFormula  string   // Formula name (e.g., "mol-polecat-work") for inline step display
 	NoMerge          bool     // Skip merge queue on completion
 	ReviewOnly       bool     // Review-only mode: assignee must not merge/commit/push
-	Mode             string   // Execution mode: "" (normal) or "ralph"
+	Mode             *string  // Execution mode: nil means unchanged, "" clears, "ralph" enables Ralph mode
 	ConvoyID         string   // Convoy bead ID (e.g., "hq-cv-abc")
 	MergeStrategy    string   // Convoy merge strategy: "direct", "mr", "local"
 	ConvoyOwned      bool     // Convoy has gt:owned label (caller-managed lifecycle)
@@ -484,6 +484,7 @@ func buildSlingFieldUpdates(
 	attachedFormula string,
 	noMerge bool,
 	reviewOnly bool,
+	mode string,
 	formulaVars string,
 	convoyID string,
 	mergeStrategy string,
@@ -497,6 +498,7 @@ func buildSlingFieldUpdates(
 		AttachedFormula:  attachedFormula,
 		NoMerge:          noMerge,
 		ReviewOnly:       reviewOnly,
+		Mode:             &mode,
 		ConvoyID:         convoyID,
 		MergeStrategy:    mergeStrategy,
 		ConvoyOwned:      convoyOwned,
@@ -563,8 +565,8 @@ func storeFieldsInBead(beadID string, updates beadFieldUpdates) error {
 	if updates.ReviewOnly {
 		fields.ReviewOnly = true
 	}
-	if updates.Mode != "" {
-		fields.Mode = updates.Mode
+	if updates.Mode != nil {
+		fields.Mode = *updates.Mode
 	}
 	if updates.ConvoyID != "" {
 		fields.ConvoyID = updates.ConvoyID
@@ -904,8 +906,9 @@ func isPolecatTarget(target string) bool {
 
 // FormulaOnBeadResult contains the result of instantiating a formula on a bead.
 type FormulaOnBeadResult struct {
-	WispRootID string // The wisp root ID (compound root after bonding)
-	BeadToHook string // The bead ID to hook (BASE bead, not wisp - lifecycle fix)
+	WispRootID  string   // The wisp root ID (compound root after bonding)
+	BeadToHook  string   // The bead ID to hook (BASE bead, not wisp - lifecycle fix)
+	FormulaVars []string // Vars used to instantiate/render the formula
 }
 
 // InstantiateFormulaOnBead creates a wisp from a formula, bonds it to a bead.
@@ -1022,8 +1025,9 @@ func InstantiateFormulaOnBead(ctx context.Context, formulaName, beadID, title, h
 			return nil, fmt.Errorf("bonding formula to bead: %w (direct formula bond fallback failed: %v)", err, fallbackErr)
 		}
 		return &FormulaOnBeadResult{
-			WispRootID: fallbackRootID,
-			BeadToHook: beadID, // Hook the BASE bead (lifecycle fix: wisp is attached_molecule)
+			WispRootID:  fallbackRootID,
+			BeadToHook:  beadID, // Hook the BASE bead (lifecycle fix: wisp is attached_molecule)
+			FormulaVars: append([]string(nil), formulaVars...),
 		}, nil
 	}
 
@@ -1040,8 +1044,9 @@ func InstantiateFormulaOnBead(ctx context.Context, formulaName, beadID, title, h
 			return nil, fmt.Errorf("bond output not parseable and direct formula bond fallback failed: %v", fallbackErr)
 		}
 		return &FormulaOnBeadResult{
-			WispRootID: fallbackRootID,
-			BeadToHook: beadID, // Hook the BASE bead (lifecycle fix: wisp is attached_molecule)
+			WispRootID:  fallbackRootID,
+			BeadToHook:  beadID, // Hook the BASE bead (lifecycle fix: wisp is attached_molecule)
+			FormulaVars: append([]string(nil), formulaVars...),
 		}, nil
 	}
 	if parsedRootID != "" {
@@ -1049,8 +1054,9 @@ func InstantiateFormulaOnBead(ctx context.Context, formulaName, beadID, title, h
 	}
 
 	return &FormulaOnBeadResult{
-		WispRootID: wispRootID,
-		BeadToHook: beadID, // Hook the BASE bead (lifecycle fix: wisp is attached_molecule)
+		WispRootID:  wispRootID,
+		BeadToHook:  beadID, // Hook the BASE bead (lifecycle fix: wisp is attached_molecule)
+		FormulaVars: append([]string(nil), formulaVars...),
 	}, nil
 }
 

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -2390,6 +2390,25 @@ exit /b 0
 			"This is required for gt hook to recognize the molecule attachment.\n"+
 			"Log output:\n%s\nAttached log:\n%s", string(logBytes), attachedLog)
 	}
+
+	descBytes, err := os.ReadFile(attachedLogPath)
+	if err != nil {
+		t.Fatalf("read attached log: %v", err)
+	}
+	attachment := beads.ParseAttachmentFields(&beads.Issue{Description: string(descBytes)})
+	if attachment == nil {
+		t.Fatalf("parse attached fields returned nil:\n%s", string(descBytes))
+	}
+	vars := map[string]string{}
+	for _, kv := range attachmentFormulaVars(attachment) {
+		key, value, ok := strings.Cut(kv, "=")
+		if ok {
+			vars[key] = value
+		}
+	}
+	if vars["feature"] != "Bug to fix" || vars["issue"] != "gt-abc123" {
+		t.Fatalf("formula vars did not roundtrip through attached bead description: %#v\nDescription:\n%s", vars, string(descBytes))
+	}
 }
 
 // TestSlingNoMergeFlag verifies that gt sling --no-merge stores the no_merge flag

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -1584,15 +1584,18 @@ exit /b 0
 	prevVars := slingVars
 	prevDryRun := slingDryRun
 	prevNoBoot := slingNoBoot
+	prevRalph := slingRalph
 	t.Cleanup(func() {
 		slingVars = prevVars
 		slingDryRun = prevDryRun
 		slingNoBoot = prevNoBoot
+		slingRalph = prevRalph
 	})
 
 	slingVars = []string{"version=1.2.3", "channel=stable"}
 	slingDryRun = false
 	slingNoBoot = true
+	slingRalph = true
 
 	if err := runSlingFormula(context.Background(), []string{"mol-anything"}); err != nil {
 		t.Fatalf("runSlingFormula: %v", err)
@@ -1609,6 +1612,9 @@ exit /b 0
 	}
 	if !strings.Contains(attachment, "version=1.2.3") || !strings.Contains(attachment, "channel=stable") {
 		t.Fatalf("formula vars missing from persisted description:\n%s", attachment)
+	}
+	if !strings.Contains(attachment, "mode: ralph") {
+		t.Fatalf("ralph mode missing from persisted standalone formula description:\n%s", attachment)
 	}
 }
 
@@ -2486,6 +2492,91 @@ exit /b 0
 	}
 }
 
+func TestSlingRalphFlagStoresMode(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir mayor/rig: %v", err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	logPath := filepath.Join(townRoot, "bd.log")
+	bdScript := `#!/bin/sh
+set -e
+echo "ARGS:$*" >> "${BD_LOG}"
+cmd="$1"
+shift || true
+case "$cmd" in
+  show)
+    echo '[{"title":"Test issue","status":"open","assignee":"","description":""}]'
+    ;;
+  update)
+    exit 0
+    ;;
+esac
+exit 0
+`
+	bdScriptWindows := `@echo off
+setlocal enableextensions
+echo ARGS:%*>>"%BD_LOG%"
+set "cmd=%1"
+if not "%cmd%"=="show" goto :notshow
+echo [{"title":"Test issue","status":"open","assignee":"","description":""}]
+exit /b 0
+:notshow
+if "%cmd%"=="update" exit /b 0
+exit /b 0
+`
+	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
+
+	molLogPath := filepath.Join(townRoot, "mol.log")
+	t.Setenv("GT_TEST_ATTACHED_MOLECULE_LOG", molLogPath)
+	t.Setenv("BD_LOG", logPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv(EnvGTRole, "mayor")
+	t.Setenv("GT_CREW", "")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("TMUX_PANE", "")
+	t.Setenv("GT_TEST_NO_NUDGE", "1")
+	t.Setenv("GT_TEST_SKIP_HOOK_VERIFY", "1")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	prevDryRun := slingDryRun
+	prevNoConvoy := slingNoConvoy
+	prevRalph := slingRalph
+	t.Cleanup(func() {
+		slingDryRun = prevDryRun
+		slingNoConvoy = prevNoConvoy
+		slingRalph = prevRalph
+	})
+	slingDryRun = false
+	slingNoConvoy = true
+	slingRalph = true
+
+	if err := runSling(nil, []string{"gt-test123"}); err != nil {
+		t.Fatalf("runSling: %v", err)
+	}
+
+	molBytes, err := os.ReadFile(molLogPath)
+	if err != nil {
+		t.Fatalf("read molecule log: %v", err)
+	}
+	molContent := string(molBytes)
+	if !strings.Contains(molContent, "mode: ralph") {
+		t.Fatalf("--ralph flag not stored in bead description\nDescription:\n%s", molContent)
+	}
+}
+
 // TestSlingSetsDoltAutoCommitOff verifies that gt sling sets BD_DOLT_AUTO_COMMIT=off
 // for all child bd processes. Under concurrent load (batch slinging), auto-commits
 // from individual bd writes cause manifest contention and 'database is read only'
@@ -2766,6 +2857,7 @@ func TestBuildSlingFieldUpdatesIncludesConvoyFields(t *testing.T) {
 		"mol-polecat-work",
 		false,
 		false,
+		"ralph",
 		"feature=test",
 		"hq-cv-test1",
 		"local",
@@ -2780,6 +2872,9 @@ func TestBuildSlingFieldUpdatesIncludesConvoyFields(t *testing.T) {
 	}
 	if !got.ConvoyOwned {
 		t.Fatal("ConvoyOwned = false, want true")
+	}
+	if got.Mode == nil || *got.Mode != "ralph" {
+		t.Fatalf("Mode = %v, want ralph", got.Mode)
 	}
 }
 
@@ -2808,6 +2903,26 @@ func TestStoreFieldsInBeadConvoyFields(t *testing.T) {
 	}
 	if !strings.Contains(text, "convoy_owned: true") {
 		t.Fatalf("missing convoy_owned in description:\n%s", text)
+	}
+}
+
+func TestBeadFieldModeUpdateCanClearStaleRalphMode(t *testing.T) {
+	issue := &beads.Issue{Description: "attached_formula: mol-polecat-work\nmode: ralph"}
+	fields := beads.ParseAttachmentFields(issue)
+	if fields == nil {
+		t.Fatal("expected attachment fields")
+	}
+	mode := ""
+	updates := beadFieldUpdates{Mode: &mode}
+	if updates.Mode != nil {
+		fields.Mode = *updates.Mode
+	}
+	desc := beads.SetAttachmentFields(issue, fields)
+	if strings.Contains(desc, "mode: ralph") || strings.Contains(desc, "mode:") {
+		t.Fatalf("expected stale ralph mode to be cleared, got:\n%s", desc)
+	}
+	if !strings.Contains(desc, "attached_formula: mol-polecat-work") {
+		t.Fatalf("expected unrelated attachment fields preserved, got:\n%s", desc)
 	}
 }
 

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -1708,6 +1708,81 @@ exit /b 0
 	}
 }
 
+func TestRunSlingFormulaUpdatesModeWhenSameFormulaAlreadyHooked(t *testing.T) {
+	townRoot := t.TempDir()
+
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor", "rig"), 0755); err != nil {
+		t.Fatalf("mkdir mayor/rig: %v", err)
+	}
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+
+	binDir := filepath.Join(townRoot, "bin")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatalf("mkdir binDir: %v", err)
+	}
+	bdScript := `#!/bin/sh
+exit 0
+`
+	bdScriptWindows := `@echo off
+exit /b 0
+`
+	_ = writeBDStub(t, binDir, bdScript, bdScriptWindows)
+
+	attachedLogPath := filepath.Join(townRoot, "attached-molecule.log")
+	t.Setenv("GT_TEST_ATTACHED_MOLECULE_LOG", attachedLogPath)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv(EnvGTRole, "mayor")
+	t.Setenv("GT_POLECAT", "")
+	t.Setenv("GT_CREW", "")
+	t.Setenv("TMUX_PANE", "")
+	t.Setenv("GT_TEST_NO_NUDGE", "1")
+	t.Setenv("GT_TEST_SKIP_HOOK_VERIFY", "1")
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(cwd) })
+	if err := os.Chdir(filepath.Join(townRoot, "mayor", "rig")); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	prevDryRun := slingDryRun
+	prevNoBoot := slingNoBoot
+	prevForce := slingForce
+	prevRalph := slingRalph
+	prevFindSingleton := findHookedFormulaSingletonFn
+	t.Cleanup(func() {
+		slingDryRun = prevDryRun
+		slingNoBoot = prevNoBoot
+		slingForce = prevForce
+		slingRalph = prevRalph
+		findHookedFormulaSingletonFn = prevFindSingleton
+	})
+
+	slingDryRun = false
+	slingNoBoot = true
+	slingForce = false
+	slingRalph = false
+	findHookedFormulaSingletonFn = func(workDir, targetAgent, formulaName string) (*beads.Issue, error) {
+		return &beads.Issue{ID: "gt-wisp-existing", Description: "attached_formula: mol-anything\nmode: ralph"}, nil
+	}
+
+	if err := runSlingFormula(context.Background(), []string{"mol-anything"}); err != nil {
+		t.Fatalf("runSlingFormula: %v", err)
+	}
+
+	attachmentBytes, err := os.ReadFile(attachedLogPath)
+	if err != nil {
+		t.Fatalf("read attachment log: %v", err)
+	}
+	if strings.Contains(string(attachmentBytes), "mode: ralph") {
+		t.Fatalf("same-formula normal sling should clear stale ralph mode, got:\n%s", string(attachmentBytes))
+	}
+}
+
 // TestSlingFormulaOnBeadPassesFeatureAndIssueVars verifies that when using
 // gt sling <formula> --on <bead>, both --var feature=<title> and --var issue=<beadID>
 // are passed to the bd mol wisp command.


### PR DESCRIPTION
Replacement PR for PR Sheriff #3932 / gt-pr-sheriff-3932.

Summary:
- Reconnects `gt sling --ralph` to the `/ralph-loop` plugin path instead of inline-only instructions.
- Requires exact ralph-loop plugin detection through the active Claude config and returns actionable errors when missing.
- Persists/clears Ralph mode across direct, deferred/batch, and standalone formula sling paths.
- Preserves formula vars for prime rendering and tightens prompt escaping/metadata reuse edges.

PR Sheriff evidence:
- 15 research legs, 5 pre-implementation reviews, and 5 post-implementation reviews were completed and recorded on `gt-pr-sheriff-3932`.
- Final verdict: clean replacement branch is approved/merge-ready.

Verification reported by Deathclaw:
- CGO_ENABLED=0 targeted `internal/beads` and `internal/cmd` tests
- CGO_ENABLED=0 go build ./...
- CGO_ENABLED=0 go vet ./...
- git diff --check
- Normal `go build ./...` blocked locally by missing ICU linker libs (`-licui18n`, `-licuuc`, `-licudata`), not branch-specific.

Recovery/base hygiene:
- Original recovered branch `polecat/deathclaw/gt-pr-sheriff-3932@58892b` was preserved at 4f0a8f18 but included contaminated fork-main history, so it must not be merged.
- This PR uses clean branch `polecat/deathclaw/gt-pr-sheriff-3932-clean@c83a54` from current upstream/main `925f4766`, containing only the four #3932 commits.

Supersedes original PR #3932 after this replacement merges.