### PR TITLE
fix: route convoy tracked issue details

### DIFF
--- a/internal/beads/beads.go
+++ b/internal/beads/beads.go
@@ -1304,9 +1304,49 @@ func (b *Beads) FindLatestIssueByTitleAndAssignee(title, assignee string) (*Issu
 	return newest, nil
 }
 
-// ShowMultiple fetches multiple issues by ID in a single bd call.
+// ShowMultiple fetches multiple issues by ID, grouped by routed database.
 // Returns a map of ID to Issue. Missing IDs are not included in the map.
+// If one routed group fails, successful groups are returned with the error.
 func (b *Beads) ShowMultiple(ids []string) (map[string]*Issue, error) {
+	if len(ids) == 0 {
+		return make(map[string]*Issue), nil
+	}
+
+	if !b.noRoute {
+		fallbackDir := b.getResolvedBeadsDir()
+		groups := make(map[string][]string)
+		for _, id := range ids {
+			targetDir := ResolveRoutingTarget(b.getTownRoot(), id, fallbackDir)
+			groups[targetDir] = append(groups[targetDir], id)
+		}
+
+		if len(groups) > 1 || groups[fallbackDir] == nil {
+			result := make(map[string]*Issue, len(ids))
+			var firstErr error
+			for targetDir, groupIDs := range groups {
+				target := b
+				if targetDir != fallbackDir {
+					target = NewWithBeadsDir(filepath.Dir(targetDir), targetDir)
+				}
+				issues, err := target.showMultipleLocal(groupIDs)
+				if err != nil {
+					if firstErr == nil {
+						firstErr = err
+					}
+					continue
+				}
+				for id, issue := range issues {
+					result[id] = issue
+				}
+			}
+			return result, firstErr
+		}
+	}
+
+	return b.showMultipleLocal(ids)
+}
+
+func (b *Beads) showMultipleLocal(ids []string) (map[string]*Issue, error) {
 	if len(ids) == 0 {
 		return make(map[string]*Issue), nil
 	}

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -1583,8 +1583,15 @@ func findStrandedConvoys(townBeads string) ([]strandedConvoyInfo, error) {
 // - AND not blocked (cross-rig-aware from issue details)
 // scheduledSet is a pre-computed set of bead IDs with open sling contexts (from areScheduled).
 func isReadyIssue(t trackedIssueInfo, scheduledSet map[string]bool) bool {
+	status := strings.TrimSpace(t.Status)
+
+	// Unresolved issues are not safe to dispatch.
+	if status == "" || status == trackedStatusUnknown {
+		return false
+	}
+
 	// Closed issues are never ready
-	if t.Status == "closed" || t.Status == "tombstone" {
+	if status == "closed" || status == "tombstone" {
 		return false
 	}
 
@@ -1599,7 +1606,7 @@ func isReadyIssue(t trackedIssueInfo, scheduledSet map[string]bool) bool {
 	}
 
 	// Open issues with no assignee are trivially ready
-	if t.Status == "open" && t.Assignee == "" {
+	if status == "open" && t.Assignee == "" {
 		return true
 	}
 
@@ -2265,7 +2272,10 @@ type trackedDependency struct {
 }
 
 func applyFreshIssueDetails(dep *trackedDependency, details *issueDetails) {
-	dep.Status = details.Status
+	dep.Status = strings.TrimSpace(details.Status)
+	if dep.Status == "" {
+		dep.Status = trackedStatusUnknown
+	}
 	dep.Blocked = details.IsBlocked()
 	if dep.Title == "" {
 		dep.Title = details.Title
@@ -2445,64 +2455,6 @@ type issueDependency struct {
 	DependencyType string `json:"dependency_type"`
 }
 
-type issueDetailsJSON struct {
-	ID             string            `json:"id"`
-	Title          string            `json:"title"`
-	Status         string            `json:"status"`
-	IssueType      string            `json:"issue_type"`
-	Assignee       string            `json:"assignee"`
-	Labels         []string          `json:"labels"`
-	BlockedBy      []string          `json:"blocked_by"`
-	BlockedByCount int               `json:"blocked_by_count"`
-	Dependencies   []issueDependency `json:"dependencies"`
-}
-
-func (issue issueDetailsJSON) toIssueDetails() *issueDetails {
-	return &issueDetails{
-		ID:             issue.ID,
-		Title:          issue.Title,
-		Status:         issue.Status,
-		IssueType:      issue.IssueType,
-		Assignee:       issue.Assignee,
-		Labels:         issue.Labels,
-		BlockedBy:      issue.BlockedBy,
-		BlockedByCount: issue.BlockedByCount,
-		Dependencies:   issue.Dependencies,
-	}
-}
-
-// getExternalIssueDetails fetches issue details from an external rig database.
-// townBeads: path to town .beads directory
-// rigName: name of the rig (e.g., "claycantrell")
-// issueID: the issue ID to look up
-func getExternalIssueDetails(townBeads, rigName, issueID string) *issueDetails {
-	// Resolve rig directory path: townBeads is the town root
-	rigDir := filepath.Join(townBeads, rigName)
-
-	// Check if rig directory exists
-	if _, err := os.Stat(rigDir); os.IsNotExist(err) {
-		return nil
-	}
-
-	out, err := BdCmd("show", issueID, "--json").Dir(rigDir).StripBeadsDir().Stderr(io.Discard).Output()
-	if err != nil {
-		return nil
-	}
-	if len(out) == 0 {
-		return nil
-	}
-
-	var issues []issueDetailsJSON
-	if err := json.Unmarshal(out, &issues); err != nil {
-		return nil
-	}
-	if len(issues) == 0 {
-		return nil
-	}
-
-	return issues[0].toIssueDetails()
-}
-
 // issueDetails holds basic issue info.
 type issueDetails struct {
 	ID             string
@@ -2531,76 +2483,93 @@ func (d issueDetails) IsBlocked() bool {
 	return false
 }
 
-// getIssueDetailsBatch fetches details for multiple issues in a single bd show call.
+// getIssueDetailsBatch fetches details through the central routed beads lookup.
 // Returns a map from issue ID to details. Missing/invalid issues are omitted from the map.
 func getIssueDetailsBatch(issueIDs []string) map[string]*issueDetails {
-	result := make(map[string]*issueDetails)
+	result := make(map[string]*issueDetails, len(issueIDs))
 	if len(issueIDs) == 0 {
 		return result
 	}
 
-	// Build args: bd show id1 id2 id3 ... --json
-	args := append([]string{"show"}, issueIDs...)
-	args = append(args, "--json")
-
-	// Run from town root so bd's prefix routing (routes.jsonl) can dispatch
-	// to the correct rig database for cross-rig bead lookups. (GH#2960)
-	townRoot, _ := workspace.FindFromCwdOrError()
-	bdc := BdCmd(args...).Stderr(io.Discard)
-	if townRoot != "" {
-		bdc.Dir(townRoot).WithRouting()
+	client := convoyIssueClient()
+	if client == nil {
+		return result
 	}
-	out, err := bdc.Output()
-	if err != nil {
-		// Batch failed - fall back to individual lookups for robustness
-		// This handles cases where some IDs are invalid/missing
-		for _, id := range issueIDs {
-			if details := getIssueDetails(id); details != nil {
-				result[id] = details
-			}
+
+	issues, err := client.ShowMultiple(issueIDs)
+	for id, issue := range issues {
+		if details := issueToDetails(issue); details != nil {
+			result[id] = details
 		}
+	}
+	if err == nil {
 		return result
 	}
 
-	var issues []issueDetailsJSON
-	if err := json.Unmarshal(out, &issues); err != nil {
-		return result
-	}
-
-	for _, issue := range issues {
-		result[issue.ID] = issue.toIssueDetails()
+	// If a grouped batch fails because one ID is missing or stale, keep the
+	// previous best-effort behavior and recover any IDs that still resolve.
+	for _, id := range issueIDs {
+		if result[id] != nil {
+			continue
+		}
+		if details := getIssueDetailsWithClient(client, id); details != nil {
+			result[id] = details
+		}
 	}
 
 	return result
 }
 
-// getIssueDetails fetches issue details by trying to show it via bd.
-// Prefer getIssueDetailsBatch for multiple issues to avoid N+1 subprocess calls.
+// getIssueDetails fetches issue details through the central routed beads lookup.
 func getIssueDetails(issueID string) *issueDetails {
-	// Use bd show with routing - resolve from town root so bd's prefix
-	// routing (routes.jsonl) can dispatch to the correct rig database.
-	// Without Dir + StripBeadsDir, bd inherits CWD/BEADS_DIR which may
-	// point to a rig that doesn't contain the target bead. (GH#2960)
-	townRoot, _ := workspace.FindFromCwdOrError()
-	bdc := BdCmd("show", issueID, "--json").Stderr(io.Discard)
-	if townRoot != "" {
-		bdc.Dir(townRoot).WithRouting()
+	client := convoyIssueClient()
+	if client == nil {
+		return nil
 	}
-	out, err := bdc.Output()
+	return getIssueDetailsWithClient(client, issueID)
+}
+
+func convoyIssueClient() *beads.Beads {
+	townRoot, err := workspace.FindFromCwdOrError()
 	if err != nil {
 		return nil
 	}
-	// Handle bd exit 0 bug: empty stdout means not found
-	if len(out) == 0 {
+	return beads.New(townRoot)
+}
+
+func getIssueDetailsWithClient(client *beads.Beads, issueID string) *issueDetails {
+	issue, err := client.Show(issueID)
+	if err != nil {
+		return nil
+	}
+	return issueToDetails(issue)
+}
+
+func issueToDetails(issue *beads.Issue) *issueDetails {
+	if issue == nil {
 		return nil
 	}
 
-	var issues []issueDetailsJSON
-	if err := json.Unmarshal(out, &issues); err != nil || len(issues) == 0 {
-		return nil
+	deps := make([]issueDependency, 0, len(issue.Dependencies))
+	for _, dep := range issue.Dependencies {
+		deps = append(deps, issueDependency{
+			ID:             dep.ID,
+			Status:         dep.Status,
+			DependencyType: dep.DependencyType,
+		})
 	}
 
-	return issues[0].toIssueDetails()
+	return &issueDetails{
+		ID:             issue.ID,
+		Title:          issue.Title,
+		Status:         issue.Status,
+		IssueType:      issue.Type,
+		Assignee:       issue.Assignee,
+		Labels:         issue.Labels,
+		BlockedBy:      issue.BlockedBy,
+		BlockedByCount: issue.BlockedByCount,
+		Dependencies:   deps,
+	}
 }
 
 // workerInfo holds info about a worker assigned to an issue.

--- a/internal/cmd/convoy_external_tracking_test.go
+++ b/internal/cmd/convoy_external_tracking_test.go
@@ -57,6 +57,280 @@ func makeExternalTrackingTownWorkspace(t *testing.T) (string, string, string) {
 	return townRoot, townBeads, expectedWD
 }
 
+func TestGetIssueDetailsBatchRoutesTrackedIDsByPrefix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	townRoot, _, expectedTownWD := makeExternalTrackingTownWorkspace(t)
+	rigDir := filepath.Join(townRoot, "worker", "mayor", "rig")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir rig beads: %v", err)
+	}
+	routes := `{"prefix":"hq-","path":"."}
+{"prefix":"ws-","path":"worker/mayor/rig"}
+`
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+	chdirExternalTrackingTest(t, townRoot)
+	t.Setenv("BEADS_DIR", "/wrong/.beads")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "wrong-db")
+
+	expectedRigWD := rigDir
+	if resolved, err := filepath.EvalSymlinks(rigDir); err == nil && resolved != "" {
+		expectedRigWD = resolved
+	}
+	logPath := filepath.Join(t.TempDir(), "bd-calls.log")
+	scriptBody := fmt.Sprintf(`
+printf '%%s|%%s|%%s\n' "$PWD" "$BEADS_DIR" "$*" >> %q
+
+case "$*" in
+	  "--allow-stale version")
+	    echo 'bd 1.0.0'
+	    exit 0
+	    ;;
+	  "show --json hq-town"|"--allow-stale show --json hq-town"|"show hq-town --json"|"--allow-stale show hq-town --json")
+    if [ "$PWD" != "%s" ]; then
+      echo "expected town dir, got $PWD" >&2
+      exit 1
+    fi
+	    if [ "$BEADS_DIR" != "%s/.beads" ]; then
+	      echo "expected town BEADS_DIR, got $BEADS_DIR" >&2
+	      exit 1
+	    fi
+	    if [ "$BEADS_DOLT_SERVER_DATABASE" = "wrong-db" ]; then
+	      echo "stale Dolt database leaked" >&2
+	      exit 1
+	    fi
+	    echo '[{"id":"hq-town","title":"Town task","status":"open","issue_type":"task","assignee":"mayor","labels":["kind/bug"]}]'
+	    ;;
+	  "show --json ws-rig"|"--allow-stale show --json ws-rig"|"show ws-rig --json"|"--allow-stale show ws-rig --json")
+    if [ "$PWD" != "%s" ]; then
+      echo "expected rig dir, got $PWD" >&2
+      exit 1
+    fi
+	    if [ "$BEADS_DIR" != "%s/.beads" ]; then
+	      echo "expected rig BEADS_DIR, got $BEADS_DIR" >&2
+	      exit 1
+	    fi
+	    if [ "$BEADS_DOLT_SERVER_DATABASE" = "wrong-db" ]; then
+	      echo "stale Dolt database leaked" >&2
+	      exit 1
+	    fi
+	    echo '[{"id":"ws-rig","title":"Rig task","status":"closed","issue_type":"task","assignee":"gastown/polecats/chrome","labels":["cleanup"],"dependencies":[{"id":"ws-blocker","status":"open","dependency_type":"blocks"}]}]'
+	    ;;
+	  *"show hq-town ws-rig --json"*|*"show ws-rig hq-town --json"*|*"show --json hq-town ws-rig"*|*"show --json ws-rig hq-town"*)
+    echo "mixed-prefix batch should not be used" >&2
+    exit 1
+    ;;
+  *)
+    echo "unexpected bd args: $*" >&2
+    exit 1
+    ;;
+esac
+`, logPath, expectedTownWD, expectedTownWD, expectedRigWD, expectedRigWD)
+	writeExternalTrackingBdStub(t, scriptBody)
+
+	got := getIssueDetailsBatch([]string{"hq-town", "ws-rig"})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 details, got %d: %#v", len(got), got)
+	}
+	if got["hq-town"] == nil || got["hq-town"].Status != "open" || got["hq-town"].Assignee != "mayor" {
+		t.Fatalf("town detail not resolved through town route: %#v", got["hq-town"])
+	}
+	if got["ws-rig"] == nil || got["ws-rig"].Status != "closed" || got["ws-rig"].IssueType != "task" {
+		t.Fatalf("rig detail not resolved through rig route: %#v", got["ws-rig"])
+	}
+	if !got["ws-rig"].IsBlocked() {
+		t.Fatalf("rig dependencies were not preserved: %#v", got["ws-rig"])
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd call log: %v", err)
+	}
+	log := string(logBytes)
+	if strings.Contains(log, "show hq-town ws-rig --json") ||
+		strings.Contains(log, "show ws-rig hq-town --json") ||
+		strings.Contains(log, "show --json hq-town ws-rig") ||
+		strings.Contains(log, "show --json ws-rig hq-town") {
+		t.Fatalf("mixed-prefix batch call was used:\n%s", log)
+	}
+}
+
+func TestGetIssueDetailsBatchPreservesSuccessfulRouteGroupsOnFallback(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	townRoot, _, _ := makeExternalTrackingTownWorkspace(t)
+	rigDir := filepath.Join(townRoot, "worker", "mayor", "rig")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir rig beads: %v", err)
+	}
+	routes := `{"prefix":"hq-","path":"."}
+{"prefix":"ws-","path":"worker/mayor/rig"}
+`
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+	chdirExternalTrackingTest(t, townRoot)
+
+	logPath := filepath.Join(t.TempDir(), "bd-calls.log")
+	scriptBody := fmt.Sprintf(`
+printf '%%s\n' "$*" >> %q
+
+case "$*" in
+  "--allow-stale version")
+    echo 'bd 1.0.0'
+    exit 0
+    ;;
+  "show --json hq-town"|"--allow-stale show --json hq-town")
+    echo '[{"id":"hq-town","title":"Town task","status":"open","issue_type":"task"}]'
+    ;;
+  "show --json ws-one ws-missing"|"--allow-stale show --json ws-one ws-missing")
+    echo "missing issue in routed batch" >&2
+    exit 1
+    ;;
+  "show ws-one --json"|"--allow-stale show ws-one --json")
+    echo '[{"id":"ws-one","title":"Recovered worker task","status":"open","issue_type":"task"}]'
+    ;;
+  "show ws-missing --json"|"--allow-stale show ws-missing --json")
+    echo "missing issue" >&2
+    exit 1
+    ;;
+  *)
+    echo "unexpected bd args: $*" >&2
+    exit 1
+    ;;
+esac
+`, logPath)
+	writeExternalTrackingBdStub(t, scriptBody)
+
+	got := getIssueDetailsBatch([]string{"hq-town", "ws-one", "ws-missing"})
+	if len(got) != 2 {
+		t.Fatalf("expected 2 recovered details, got %d: %#v", len(got), got)
+	}
+	if got["hq-town"] == nil || got["hq-town"].Status != "open" {
+		t.Fatalf("town detail was not preserved from successful route group: %#v", got["hq-town"])
+	}
+	if got["ws-one"] == nil || got["ws-one"].Title != "Recovered worker task" {
+		t.Fatalf("worker detail was not recovered through single lookup: %#v", got["ws-one"])
+	}
+	if got["ws-missing"] != nil {
+		t.Fatalf("missing issue should be omitted, got %#v", got["ws-missing"])
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read bd call log: %v", err)
+	}
+	log := string(logBytes)
+	if strings.Count(log, "show --json hq-town") != 1 || strings.Contains(log, "show hq-town --json") {
+		t.Fatalf("successful town route group should not be retried:\n%s", log)
+	}
+}
+
+func TestGetTrackedIssues_RoutesShowByPrefix(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows - shell stubs")
+	}
+
+	townRoot, townBeads, expectedTownWD := makeExternalTrackingTownWorkspace(t)
+	rigDir := filepath.Join(townRoot, "worker", "mayor", "rig")
+	if err := os.MkdirAll(filepath.Join(rigDir, ".beads"), 0755); err != nil {
+		t.Fatalf("mkdir rig beads: %v", err)
+	}
+	routes := `{"prefix":"hq-","path":"."}
+{"prefix":"ws-","path":"worker/mayor/rig"}
+`
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte(routes), 0644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+	chdirExternalTrackingTest(t, townRoot)
+	t.Setenv("BEADS_DIR", "/wrong/.beads")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "wrong-db")
+
+	expectedRigWD := rigDir
+	if resolved, err := filepath.EvalSymlinks(rigDir); err == nil && resolved != "" {
+		expectedRigWD = resolved
+	}
+	scriptBody := fmt.Sprintf(`
+case "$*" in
+	  "--allow-stale version")
+	    echo 'bd 1.0.0'
+	    exit 0
+	    ;;
+	  *sql*dependencies*)
+	    if [ "$BEADS_DOLT_SERVER_DATABASE" = "wrong-db" ]; then
+	      echo "stale Dolt database leaked into sql" >&2
+	      exit 1
+	    fi
+	    echo '[{"depends_on_id":"ws-123"},{"depends_on_id":"hq-456"}]'
+	    ;;
+	  "show --json ws-123"|"--allow-stale show --json ws-123"|"show ws-123 --json"|"--allow-stale show ws-123 --json")
+    if [ "$PWD" != "%s" ]; then
+      echo "expected rig dir, got $PWD" >&2
+      exit 1
+    fi
+	    if [ "$BEADS_DIR" != "%s/.beads" ]; then
+	      echo "expected rig BEADS_DIR, got $BEADS_DIR" >&2
+	      exit 1
+	    fi
+	    if [ "$BEADS_DOLT_SERVER_DATABASE" = "wrong-db" ]; then
+	      echo "stale Dolt database leaked" >&2
+	      exit 1
+	    fi
+	    echo '[{"id":"ws-123","title":"Worker issue","status":"open","issue_type":"task"}]'
+	    ;;
+	  "show --json hq-456"|"--allow-stale show --json hq-456"|"show hq-456 --json"|"--allow-stale show hq-456 --json")
+    if [ "$PWD" != "%s" ]; then
+      echo "expected town dir, got $PWD" >&2
+      exit 1
+    fi
+	    if [ "$BEADS_DIR" != "%s/.beads" ]; then
+	      echo "expected town BEADS_DIR, got $BEADS_DIR" >&2
+	      exit 1
+	    fi
+	    if [ "$BEADS_DOLT_SERVER_DATABASE" = "wrong-db" ]; then
+	      echo "stale Dolt database leaked" >&2
+	      exit 1
+	    fi
+	    echo '[{"id":"hq-456","title":"Town issue","status":"closed","issue_type":"task"}]'
+	    ;;
+	  *"show ws-123 hq-456 --json"*|*"show hq-456 ws-123 --json"*|*"show --json ws-123 hq-456"*|*"show --json hq-456 ws-123"*)
+    echo "mixed-prefix batch should not be used" >&2
+    exit 1
+    ;;
+  *)
+    echo "unexpected bd args: $*" >&2
+    exit 1
+    ;;
+esac
+`, expectedRigWD, expectedRigWD, expectedTownWD, expectedTownWD)
+	writeExternalTrackingBdStub(t, scriptBody)
+
+	tracked, err := getTrackedIssues(townBeads, "hq-cv-route")
+	if err != nil {
+		t.Fatalf("getTrackedIssues: %v", err)
+	}
+	if len(tracked) != 2 {
+		t.Fatalf("expected 2 tracked issues, got %d: %#v", len(tracked), tracked)
+	}
+
+	statusByID := map[string]string{}
+	for _, item := range tracked {
+		statusByID[item.ID] = item.Status
+	}
+	if statusByID["ws-123"] != "open" {
+		t.Fatalf("ws-123 status = %q, want %q", statusByID["ws-123"], "open")
+	}
+	if statusByID["hq-456"] != "closed" {
+		t.Fatalf("hq-456 status = %q, want %q", statusByID["hq-456"], "closed")
+	}
+}
+
 func TestGetTrackedIssues_FallsBackToShowTrackedDependencies(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("skipping on windows - shell stubs")

--- a/internal/cmd/convoy_stranded_test.go
+++ b/internal/cmd/convoy_stranded_test.go
@@ -21,6 +21,22 @@ func TestIsReadyIssue_BlockingAndStatus(t *testing.T) {
 			want: false,
 		},
 		{
+			name: "unknown issue never ready",
+			in: trackedIssueInfo{
+				Status:  trackedStatusUnknown,
+				Blocked: false,
+			},
+			want: false,
+		},
+		{
+			name: "blank status never ready",
+			in: trackedIssueInfo{
+				Status:  " ",
+				Blocked: false,
+			},
+			want: false,
+		},
+		{
 			name: "blocked open issue not ready",
 			in: trackedIssueInfo{
 				Status:  "open",
@@ -71,6 +87,17 @@ func TestApplyFreshIssueDetails_SetsBlockedFlag(t *testing.T) {
 
 	if !dep.Blocked {
 		t.Fatalf("applyFreshIssueDetails() should set Blocked=true when details are blocked")
+	}
+}
+
+func TestApplyFreshIssueDetails_BlankStatusBecomesUnknown(t *testing.T) {
+	dep := trackedDependency{ID: "gt-123"}
+	details := &issueDetails{ID: "gt-123", Status: "  "}
+
+	applyFreshIssueDetails(&dep, details)
+
+	if dep.Status != trackedStatusUnknown {
+		t.Fatalf("dep.Status = %q, want %q", dep.Status, trackedStatusUnknown)
 	}
 }
 


### PR DESCRIPTION
Replacement PR for PR Sheriff #4057 / gt-pr-sheriff-4057.

Summary:
- Routes convoy tracked issue detail lookups by issue prefix.
- Preserves successful routed detail groups on fallback.
- Recreates the #4057 fix as one clean commit from current upstream/main.

PR Sheriff evidence:
- PR Sheriff workflow was completed for `gt-pr-sheriff-4057` and the clean replacement path was requested by Mayor.
- Final branch intentionally excludes WIP checkpoint commits and runtime `.beads/config.yaml` drift.

Verification reported by Chrome:
- `CGO_ENABLED=0 go test ./internal/cmd -run 'Test(GetIssueDetailsBatchRoutesTrackedIDsByPrefix|GetIssueDetailsBatchPreservesSuccessfulRouteGroupsOnFallback|GetTrackedIssues_RoutesShowByPrefix|IsReadyIssue_BlockingAndStatus|ApplyFreshIssueDetails)'`\n- `CGO_ENABLED=0 go test ./internal/beads -run 'TestResolveRoutingTarget|TestStoreShowMultiple'`\n\nRecovery/base hygiene:\n- Original local branch `polecat/chrome/gt-pr-sheriff-4057@mqgy8vok` contains WIP checkpoint commits and should not be opened as-is.\n- This PR uses clean branch `polecat/chrome/gt-pr-sheriff-4057-clean@8e8253` at `2e9bc39`, based on upstream/main `925f4766`.\n\nSupersedes original PR #4057 after this replacement merges.