### PR TITLE
fix(dolt): cap managed sql-server heap with GOMEMLIMIT soft ceiling

### DIFF
--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -938,6 +938,11 @@ func (m *DoltServerManager) startLocked() error {
 	cmd.Dir = m.config.DataDir
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
+	// Cap the server's heap with a GOMEMLIMIT soft ceiling so Dolt's unbounded
+	// in-memory working-set growth gets GC'd under pressure instead of climbing
+	// until OOM. The supervisor restarts dolt on crash, so the limit must be set
+	// here too (not only on the `gt dolt start` path).
+	cmd.Env = doltserver.DoltServerEnv(os.Environ())
 
 	// Detach from this process group so it survives daemon restart
 	setSysProcAttr(cmd)

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -1687,6 +1687,47 @@ behavior:
 	return os.WriteFile(configPath, []byte(content), 0600)
 }
 
+// DefaultDoltServerMemLimit is the default soft heap ceiling (GOMEMLIMIT)
+// applied to the managed dolt sql-server. Dolt accumulates an in-memory working
+// set across all databases with no ceiling of its own; without a soft limit the
+// Go runtime lets RSS climb unbounded until the host OOM-kills the server. 8GiB
+// leaves ample headroom over the few-GB on-disk dataset on a 64GB host while
+// capping growth — as the heap approaches the limit the GC runs more
+// aggressively and reclaims instead of growing.
+const DefaultDoltServerMemLimit = "8GiB"
+
+// DoltServerMemLimit returns the GOMEMLIMIT value to apply to the spawned dolt
+// sql-server. It honors the GT_DOLT_GOMEMLIMIT override (e.g. "12GiB") so the
+// limit can be tuned for the host; set the override to "off" or empty to
+// disable the soft limit entirely.
+func DoltServerMemLimit() string {
+	if v, ok := os.LookupEnv("GT_DOLT_GOMEMLIMIT"); ok {
+		if v == "" || strings.EqualFold(v, "off") {
+			return ""
+		}
+		return v
+	}
+	return DefaultDoltServerMemLimit
+}
+
+// DoltServerEnv returns base with a single canonical GOMEMLIMIT entry appended.
+// Any inherited GOMEMLIMIT is stripped first so the Go runtime reads ours (it
+// uses the first match on duplicate keys). When the soft limit is disabled the
+// inherited GOMEMLIMIT is removed and none is added. base is typically
+// os.Environ().
+func DoltServerEnv(base []string) []string {
+	out := make([]string, 0, len(base)+1)
+	for _, e := range base {
+		if !strings.HasPrefix(e, "GOMEMLIMIT=") {
+			out = append(out, e)
+		}
+	}
+	if limit := DoltServerMemLimit(); limit != "" {
+		out = append(out, "GOMEMLIMIT="+limit)
+	}
+	return out
+}
+
 // Start starts the Dolt SQL server.
 func Start(townRoot string) error {
 	config := DefaultConfig(townRoot)
@@ -1902,6 +1943,10 @@ func Start(townRoot string) error {
 	cmd.Dir = config.DataDir
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
+	// Cap the server's heap with a GOMEMLIMIT soft ceiling so Dolt's unbounded
+	// in-memory working-set growth gets GC'd under pressure instead of climbing
+	// until OOM. See DoltServerEnv / DefaultDoltServerMemLimit.
+	cmd.Env = DoltServerEnv(os.Environ())
 
 	// Detach from terminal and put dolt in its own process group so that
 	// signals sent to the parent process group (e.g. SIGHUP when the caller

--- a/internal/doltserver/doltserver_test.go
+++ b/internal/doltserver/doltserver_test.go
@@ -5091,3 +5091,68 @@ func TestHealthMetrics_CommitFreshnessFields(t *testing.T) {
 		t.Errorf("LastCommitAge = %v, want >= 0", metrics.LastCommitAge)
 	}
 }
+
+func TestDoltServerMemLimit(t *testing.T) {
+	tests := []struct {
+		name     string
+		override string // GT_DOLT_GOMEMLIMIT value; "<unset>" means leave unset
+		want     string
+	}{
+		{name: "default", override: "<unset>", want: DefaultDoltServerMemLimit},
+		{name: "custom", override: "12GiB", want: "12GiB"},
+		{name: "off", override: "off", want: ""},
+		{name: "off mixed case", override: "OFF", want: ""},
+		{name: "empty disables", override: "", want: ""},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.override == "<unset>" {
+				os.Unsetenv("GT_DOLT_GOMEMLIMIT")
+			} else {
+				t.Setenv("GT_DOLT_GOMEMLIMIT", tt.override)
+			}
+			if got := DoltServerMemLimit(); got != tt.want {
+				t.Errorf("DoltServerMemLimit() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestDoltServerEnv(t *testing.T) {
+	// Default: a single canonical GOMEMLIMIT is appended.
+	os.Unsetenv("GT_DOLT_GOMEMLIMIT")
+	base := []string{"PATH=/bin", "GOMEMLIMIT=999GiB", "HOME=/home/x"}
+	env := DoltServerEnv(base)
+
+	var memLimits []string
+	hasPath, hasHome := false, false
+	for _, e := range env {
+		if strings.HasPrefix(e, "GOMEMLIMIT=") {
+			memLimits = append(memLimits, e)
+		}
+		if e == "PATH=/bin" {
+			hasPath = true
+		}
+		if e == "HOME=/home/x" {
+			hasHome = true
+		}
+	}
+	if len(memLimits) != 1 {
+		t.Fatalf("expected exactly one GOMEMLIMIT entry, got %v", memLimits)
+	}
+	if memLimits[0] != "GOMEMLIMIT="+DefaultDoltServerMemLimit {
+		t.Errorf("GOMEMLIMIT = %q, want %q (inherited value must be replaced)", memLimits[0], "GOMEMLIMIT="+DefaultDoltServerMemLimit)
+	}
+	if !hasPath || !hasHome {
+		t.Errorf("unrelated env vars must be preserved: PATH=%v HOME=%v", hasPath, hasHome)
+	}
+
+	// Disabled: no GOMEMLIMIT entry at all, even if inherited.
+	t.Setenv("GT_DOLT_GOMEMLIMIT", "off")
+	env = DoltServerEnv(base)
+	for _, e := range env {
+		if strings.HasPrefix(e, "GOMEMLIMIT=") {
+			t.Errorf("expected no GOMEMLIMIT entry when disabled, got %q", e)
+		}
+	}
+}


### PR DESCRIPTION
## Problem

The managed Dolt `sql-server` accumulates an in-memory working set across all rig databases with no memory ceiling of its own (`auto_gc` is off and no `GOMEMLIMIT` is set), so its RSS climbs **unbounded** until the host OOM-kills it. On one town this was observed as ~2.3 GB → 24 GB over ~100 min on a ~3 GB on-disk dataset, OOM-crashing roughly every 6 hours (the daemon supervisor reboots it each time, masking the root cause).

This is distinct from two already-addressed issues:
- the Stats V2 collector leak (mitigated by `dolt_stats_enabled: 0` in the generated config), and
- reaper wisp floods.

A 90-minute monitor with open-wisp count flat while RSS climbed confirmed the growth is the server's own heap, not those subsystems.

## Fix

Set `GOMEMLIMIT=8GiB` (a Go **soft** memory limit) on the spawned `dolt sql-server` process so the runtime GCs more aggressively as the heap approaches the limit, instead of letting RSS grow until OOM. Applied at **both** spawn sites so a crash-restart is covered too, not only a manual start:

- `internal/doltserver/doltserver.go` `Start()` — the `gt dolt start` path
- `internal/daemon/dolt.go` `startLocked()` — the daemon crash-supervisor restart path

Details:
- Default `8GiB` leaves ample headroom over the few-GB dataset on a 64 GB host while capping growth.
- Tunable via `GT_DOLT_GOMEMLIMIT` (e.g. `"12GiB"`); set to `"off"` or empty to disable the soft limit entirely. This mirrors the existing `GT_DOLT_STATS_ENABLED` override philosophy.
- Any inherited `GOMEMLIMIT` is stripped before appending ours, so the Go runtime reads our value (it uses the first match on duplicate env keys) — same defensive pattern the codebase already uses for `DOLT_CLI_PASSWORD`.

## Tests

Added `TestDoltServerMemLimit` and `TestDoltServerEnv` covering the default, the `GT_DOLT_GOMEMLIMIT` override, the disable cases, inherited-value replacement, and preservation of unrelated env vars.

## Verification

Deployed to a live town: the spawned `dolt sql-server` process now carries `GOMEMLIMIT=8GiB` in its environment (confirmed via `ps eww`), and the server starts cleanly with all databases verified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)