### PR TITLE
fix(boot): block raw tmux send-keys

### DIFF
--- a/internal/cmd/hooks_sync.go
+++ b/internal/cmd/hooks_sync.go
@@ -252,63 +252,19 @@ const (
 // syncTarget syncs a single target's .claude/settings.json.
 // Uses MarshalSettings/UnmarshalSettings to preserve unknown fields.
 func syncTarget(target hooks.Target, dryRun bool) (syncResult, error) {
-	// Compute expected hooks for this target
-	expected, err := hooks.ComputeExpected(target.Key)
+	result, err := hooks.SyncManagedClaudeSettings(target, dryRun)
 	if err != nil {
-		return 0, fmt.Errorf("computing expected config: %w", err)
+		return 0, err
 	}
 
-	// Load existing settings (returns zero-value if file doesn't exist)
-	current, err := hooks.LoadSettings(target.Path)
-	if err != nil {
-		return 0, fmt.Errorf("loading current settings: %w", err)
-	}
-
-	// Check if the file exists
-	_, statErr := os.Stat(target.Path)
-	fileExists := statErr == nil
-
-	// Compare hooks sections and the Claude startup defaults. Existing settings
-	// from older versions may have current hooks but still miss prompt defaults.
-	if fileExists && hooks.HooksEqual(expected, &current.Hooks) && hooks.HasClaudePromptDefaults(current) {
-		return syncUnchanged, nil
-	}
-
-	if dryRun {
-		if fileExists {
-			return syncUpdated, nil
-		}
+	switch result {
+	case hooks.SyncCreated:
 		return syncCreated, nil
-	}
-
-	// Update hooks section, preserving all other fields (including unknown ones)
-	current.Hooks = *expected
-
-	// Ensure enabledPlugins map exists with beads disabled (Gas Town standard)
-	if current.EnabledPlugins == nil {
-		current.EnabledPlugins = make(map[string]bool)
-	}
-	current.EnabledPlugins["beads@beads-marketplace"] = false
-
-	// Create .claude directory if needed
-	claudeDir := filepath.Dir(target.Path)
-	if err := os.MkdirAll(claudeDir, 0755); err != nil {
-		return 0, fmt.Errorf("creating .claude directory: %w", err)
-	}
-
-	// Write settings.json using MarshalSettings to preserve unknown fields
-	data, err := hooks.MarshalSettings(current)
-	if err != nil {
-		return 0, fmt.Errorf("marshaling settings: %w", err)
-	}
-	data = append(data, '\n')
-
-	if err := os.WriteFile(target.Path, data, 0644); err != nil {
-		return 0, fmt.Errorf("writing settings: %w", err)
-	}
-
-	if fileExists {
+	case hooks.SyncUpdated:
 		return syncUpdated, nil
+	case hooks.SyncUnchanged:
+		return syncUnchanged, nil
+	default:
+		return 0, fmt.Errorf("unknown sync result: %d", result)
 	}
-	return syncCreated, nil
 }

--- a/internal/cmd/prime_output.go
+++ b/internal/cmd/prime_output.go
@@ -410,7 +410,7 @@ func outputCommandQuickReference(ctx RoleContext) {
 		fmt.Println("|------------|----------------|----------------|")
 		fmt.Printf("| Run triage | `%s boot triage` | ~~gt deacon heartbeat~~ (that's Deacon's job) |\n", c)
 		fmt.Printf("| Check Deacon health | `%s deacon status` | ~~gt status~~ (town-wide, not Deacon-specific) |\n", c)
-		fmt.Printf("| Nudge the Deacon | `%s nudge deacon \"msg\"` | ~~tmux send-keys~~ (unreliable) |\n", c)
+		fmt.Printf("| Nudge the Deacon | `%s nudge deacon \"msg\"` | ~~tmux send-keys~~ (blocked; can stage unsubmitted input) |\n", c)
 	}
 
 	fmt.Println()

--- a/internal/cmd/prime_output_test.go
+++ b/internal/cmd/prime_output_test.go
@@ -180,3 +180,21 @@ func TestOutputRoleDirectives(t *testing.T) {
 		}
 	})
 }
+
+func TestOutputCommandQuickReferenceBootBlocksRawTmux(t *testing.T) {
+	output := captureStdout(t, func() {
+		outputCommandQuickReference(RoleContext{Role: RoleBoot})
+	})
+
+	for _, want := range []string{
+		"gt nudge deacon",
+		"blocked; can stage unsubmitted input",
+	} {
+		if !strings.Contains(output, want) {
+			t.Fatalf("Boot quick reference missing %q:\n%s", want, output)
+		}
+	}
+	if strings.Contains(output, "tmux send-keys~~ (unreliable)") {
+		t.Fatalf("Boot quick reference still calls raw tmux merely unreliable:\n%s", output)
+	}
+}

--- a/internal/formula/boot_triage_test.go
+++ b/internal/formula/boot_triage_test.go
@@ -1,0 +1,32 @@
+package formula
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestBootTriageFormulaUsesNudgeForWake(t *testing.T) {
+	content, err := formulasFS.ReadFile("formulas/mol-boot-triage.formula.toml")
+	if err != nil {
+		t.Fatalf("reading boot triage formula: %v", err)
+	}
+
+	formula := string(content)
+	for _, want := range []string{
+		`gt nudge --mode=immediate deacon "Boot wake: please check your inbox and pending work"`,
+		"Raw tmux send-keys is blocked for Boot",
+	} {
+		if !strings.Contains(formula, want) {
+			t.Fatalf("boot triage formula missing %q", want)
+		}
+	}
+	for _, forbidden := range []string{
+		"tmux send-keys -t hq-deacon",
+		"sleep 1",
+		"escape + message",
+	} {
+		if strings.Contains(formula, forbidden) {
+			t.Fatalf("boot triage formula still contains forbidden raw tmux wake guidance %q", forbidden)
+		}
+	}
+}

--- a/internal/formula/formulas/mol-boot-triage.formula.toml
+++ b/internal/formula/formulas/mol-boot-triage.formula.toml
@@ -102,7 +102,7 @@ Signs of working:
 **Output**: Record decision as one of:
 - NOTHING: Let Deacon continue
 - NUDGE: Gentle wake signal (gt nudge)
-- WAKE: Stronger wake (escape + message)
+- WAKE: Stronger wake (immediate gt nudge)
 - INTERRUPT: Force restart needed
 - START: Session is dead, start fresh
 """
@@ -125,14 +125,8 @@ gt nudge --mode=queue deacon "Boot check-in: you have pending work"
 
 **WAKE**
 ```bash
-# Send escape to break any tool waiting
-tmux send-keys -t hq-deacon Escape
-
-# Brief pause
-sleep 1
-
-# Send wake message
-gt nudge deacon "Boot wake: please check your inbox and pending work"
+# Raw tmux send-keys is blocked for Boot; it can leave unsubmitted input staged.
+gt nudge --mode=immediate deacon "Boot wake: please check your inbox and pending work"
 ```
 
 **INTERRUPT**

--- a/internal/hooks/config.go
+++ b/internal/hooks/config.go
@@ -11,6 +11,8 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+
+	"github.com/steveyegge/gastown/internal/atomicfile"
 )
 
 // HookEntry represents a single hook matcher with its associated hooks.
@@ -218,6 +220,59 @@ func LoadSettings(path string) (*SettingsJSON, error) {
 	return settings, nil
 }
 
+// SyncManagedClaudeSettings merges computed managed hooks into a Claude
+// settings.json file while preserving non-hook settings fields.
+func SyncManagedClaudeSettings(target Target, dryRun bool) (SyncResult, error) {
+	expected, err := ComputeExpected(target.Key)
+	if err != nil {
+		return 0, fmt.Errorf("computing expected config: %w", err)
+	}
+
+	current, err := LoadSettings(target.Path)
+	if err != nil {
+		return 0, fmt.Errorf("loading current settings: %w", err)
+	}
+
+	_, statErr := os.Stat(target.Path)
+	fileExists := statErr == nil
+
+	if fileExists && HooksEqual(expected, &current.Hooks) && HasClaudePromptDefaults(current) {
+		return SyncUnchanged, nil
+	}
+
+	if dryRun {
+		if fileExists {
+			return SyncUpdated, nil
+		}
+		return SyncCreated, nil
+	}
+
+	current.Hooks = *expected
+	if current.EnabledPlugins == nil {
+		current.EnabledPlugins = make(map[string]bool)
+	}
+	current.EnabledPlugins["beads@beads-marketplace"] = false
+
+	if err := os.MkdirAll(filepath.Dir(target.Path), 0755); err != nil {
+		return 0, fmt.Errorf("creating .claude directory: %w", err)
+	}
+
+	data, err := MarshalSettings(current)
+	if err != nil {
+		return 0, fmt.Errorf("marshaling settings: %w", err)
+	}
+	data = append(data, '\n')
+
+	if err := atomicfile.WriteFile(target.Path, data, 0600); err != nil {
+		return 0, fmt.Errorf("writing settings: %w", err)
+	}
+
+	if fileExists {
+		return SyncUpdated, nil
+	}
+	return SyncCreated, nil
+}
+
 // HooksEqual returns true if two HooksConfigs are structurally equal.
 // Compares by serializing to JSON for reliable deep equality.
 func HooksEqual(a, b *HooksConfig) bool {
@@ -344,6 +399,15 @@ func DefaultOverrides() map[string]*HooksConfig {
 		},
 		"boot": {
 			UserPromptSubmit: []HookEntry{{Matcher: ""}},
+			PreToolUse: []HookEntry{
+				{
+					Matcher: "Bash(*tmux*send-keys*)",
+					Hooks: []Hook{{
+						Type:    "command",
+						Command: "echo 'BLOCKED: Boot must not use raw tmux send-keys; it can leave unsubmitted text staged in the Deacon TUI.' && echo 'Use: gt nudge --mode=immediate deacon \"message\" (do not add --force).' && exit 2",
+					}},
+				},
+			},
 		},
 		// Deacon roles: patrol-formula-guard (same as witness).
 		// Deacons also run patrols and must use wisps, not persistent molecules.

--- a/internal/hooks/config_test.go
+++ b/internal/hooks/config_test.go
@@ -722,6 +722,54 @@ func TestComputeExpectedPatrolRolesDisableUserPromptMailCheck(t *testing.T) {
 	}
 }
 
+func TestComputeExpectedBootBlocksRawTmuxSendKeys(t *testing.T) {
+	tmpDir := t.TempDir()
+	setTestHome(t, tmpDir)
+
+	boot, err := ComputeExpected("boot")
+	if err != nil {
+		t.Fatalf("ComputeExpected(boot): %v", err)
+	}
+
+	entry, ok := findPreToolUse(boot, "Bash(*tmux*send-keys*)")
+	if !ok {
+		t.Fatal("boot missing raw tmux send-keys guard")
+	}
+	if len(entry.Hooks) != 1 {
+		t.Fatalf("boot raw tmux guard hooks = %d, want 1", len(entry.Hooks))
+	}
+	command := entry.Hooks[0].Command
+	for _, want := range []string{
+		"BLOCKED: Boot must not use raw tmux send-keys",
+		"gt nudge --mode=immediate deacon",
+		"exit 2",
+	} {
+		if !strings.Contains(command, want) {
+			t.Fatalf("boot raw tmux guard command missing %q: %s", want, command)
+		}
+	}
+	if len(boot.UserPromptSubmit) != 0 {
+		t.Fatalf("boot should still disable UserPromptSubmit mail-check, got %+v", boot.UserPromptSubmit)
+	}
+
+	mayor, err := ComputeExpected("mayor")
+	if err != nil {
+		t.Fatalf("ComputeExpected(mayor): %v", err)
+	}
+	if _, ok := findPreToolUse(mayor, "Bash(*tmux*send-keys*)"); ok {
+		t.Fatal("mayor must not receive Boot's raw tmux send-keys guard")
+	}
+}
+
+func findPreToolUse(cfg *HooksConfig, matcher string) (HookEntry, bool) {
+	for _, entry := range cfg.PreToolUse {
+		if entry.Matcher == matcher {
+			return entry, true
+		}
+	}
+	return HookEntry{}, false
+}
+
 func TestComputeExpectedPolecatsKeepUserPromptMailCheck(t *testing.T) {
 	tmpDir := t.TempDir()
 	setTestHome(t, tmpDir)

--- a/internal/hooks/installer.go
+++ b/internal/hooks/installer.go
@@ -51,6 +51,15 @@ func InstallForRole(provider, settingsDir, workDir, role, hooksDir, hooksFile st
 	}
 
 	targetPath := installTargetPath(settingsDir, workDir, hooksDir, hooksFile, useSettingsDir)
+	if provider == "claude" && role == "boot" && isSettingsFile(hooksFile) {
+		_, err := SyncManagedClaudeSettings(Target{
+			Path:     targetPath,
+			Key:      "boot",
+			Role:     "boot",
+			Provider: "claude",
+		}, false)
+		return err
+	}
 
 	if existing, err := os.ReadFile(targetPath); err == nil {
 		if !needsUpgrade(existing) {

--- a/internal/hooks/installer_test.go
+++ b/internal/hooks/installer_test.go
@@ -151,6 +151,60 @@ func TestInstallForRole_ClaudeCurrentTemplatePreservesExistingSettings(t *testin
 	}
 }
 
+func TestInstallForRole_BootClaudeSettingsUseManagedHooks(t *testing.T) {
+	tests := []struct {
+		name     string
+		existing bool
+	}{
+		{name: "creates managed settings"},
+		{name: "updates existing settings", existing: true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			dir := t.TempDir()
+			setTestHome(t, dir)
+			settingsPath := filepath.Join(dir, ".claude", "settings.json")
+
+			if tt.existing {
+				if err := os.MkdirAll(filepath.Dir(settingsPath), 0755); err != nil {
+					t.Fatalf("creating settings dir: %v", err)
+				}
+				if err := os.WriteFile(settingsPath, []byte(`{"customSentinel":true}`), 0600); err != nil {
+					t.Fatalf("writing existing settings: %v", err)
+				}
+			}
+
+			if err := InstallForRole("claude", dir, dir, "boot", ".claude", "settings.json", true); err != nil {
+				t.Fatalf("InstallForRole: %v", err)
+			}
+
+			settings, err := LoadSettings(settingsPath)
+			if err != nil {
+				t.Fatalf("LoadSettings: %v", err)
+			}
+			entry, ok := findPreToolUse(&settings.Hooks, "Bash(*tmux*send-keys*)")
+			if !ok {
+				t.Fatal("boot install did not write managed raw tmux send-keys guard")
+			}
+			if !strings.Contains(entry.Hooks[0].Command, "gt nudge --mode=immediate deacon") {
+				t.Fatalf("boot guard command does not point to gt nudge: %s", entry.Hooks[0].Command)
+			}
+			if len(settings.Hooks.UserPromptSubmit) != 0 {
+				t.Fatalf("boot managed settings should disable UserPromptSubmit, got %+v", settings.Hooks.UserPromptSubmit)
+			}
+			if !HasClaudePromptDefaults(settings) {
+				t.Fatal("boot managed settings missing Claude prompt defaults")
+			}
+			if tt.existing {
+				if raw, ok := settings.Extra["customSentinel"]; !ok || string(raw) != "true" {
+					t.Fatalf("customSentinel not preserved: %s", raw)
+				}
+			}
+		})
+	}
+}
+
 func TestInstallForRole_RoleAgnostic(t *testing.T) {
 	// OpenCode, Pi, OMP have single templates
 	tests := []struct {

--- a/internal/templates/roles/boot.md.tmpl
+++ b/internal/templates/roles/boot.md.tmpl
@@ -92,9 +92,12 @@ Execute the decided action:
 
 - **NOTHING**: Log and exit
 - **NUDGE**: `{{ cmd }} nudge deacon "Boot check-in: you have pending work"`
-- **WAKE**: Escape + `{{ cmd }} nudge deacon "Boot wake: check your inbox"`
+- **WAKE**: `{{ cmd }} nudge --mode=immediate deacon "Boot wake: check your inbox"`
 - **INTERRUPT**: Mail the Deacon requesting restart consideration
 - **START**: Log detection (daemon handles restart)
+
+Never run raw `tmux send-keys` for Deacon communication; Boot hooks block it
+because it can leave unsubmitted text staged in the Deacon TUI. Use `{{ cmd }} nudge`.
 
 ### Step 4: Clean
 

--- a/internal/templates/templates_test.go
+++ b/internal/templates/templates_test.go
@@ -538,6 +538,38 @@ func TestRoleNames(t *testing.T) {
 	}
 }
 
+func TestRenderRole_BootUsesNudgeNotRawTmux(t *testing.T) {
+	tmpl, err := New()
+	if err != nil {
+		t.Fatalf("New() error = %v", err)
+	}
+
+	output, err := tmpl.RenderRole("boot", RoleData{
+		Role:          "boot",
+		TownRoot:      "/test/town",
+		TownName:      "town",
+		WorkDir:       "/test/town/deacon/dogs/boot",
+		DefaultBranch: "main",
+		MayorSession:  "gt-town-mayor",
+		DeaconSession: "gt-town-deacon",
+	})
+	if err != nil {
+		t.Fatalf("RenderRole() error = %v", err)
+	}
+
+	if !strings.Contains(output, `gt nudge --mode=immediate deacon "Boot wake: check your inbox"`) {
+		t.Fatalf("boot template missing immediate nudge wake guidance:\n%s", output)
+	}
+	if !strings.Contains(output, "Boot hooks block it") {
+		t.Fatalf("boot template missing raw tmux block rationale:\n%s", output)
+	}
+	for _, forbidden := range []string{"Escape +", "tmux send-keys -t"} {
+		if strings.Contains(output, forbidden) {
+			t.Fatalf("boot template contains forbidden raw tmux guidance %q:\n%s", forbidden, output)
+		}
+	}
+}
+
 func TestCreatePolecatCLAUDEmd(t *testing.T) {
 	dir := t.TempDir()
 


### PR DESCRIPTION
Supersedes #4098. The original PR should not merge as-is because it only adds a narrow hook/quick-reference change and leaves the Boot formula/template and first-install managed-settings path uncovered.

Summary:
- Adds a Boot-only Claude `PreToolUse` guard for raw `tmux ... send-keys` and points Boot to `gt nudge --mode=immediate deacon` instead.
- Converges Claude settings sync into `hooks.SyncManagedClaudeSettings` and uses it for Boot startup so existing/missing Boot settings receive managed overrides immediately.
- Replaces Boot triage/template/prime wake guidance with `gt nudge`; no global tmux ban and no `--force` suggestion.
- Adds focused regression tests for hook computation, Boot settings install, Boot formula guidance, Boot role rendering, and Boot quick reference output.

PR Sheriff evidence:
- 15 research legs completed and recorded on bead `gt-pr-sheriff-4098-replacement`; they converged on replacing #4098 with a current-main, Boot-scoped cleanup rather than merging the stale branch.
- Initial 5 pre-implementation reviews found deployment-path and matcher concerns; adjusted 5 pre-implementation reviews all passed after adding managed Boot startup sync and keeping the guard Boot-only.
- 5 clean-branch post-implementation reviews all passed on the upstream-based branch with one focused commit.

Verification:
- `go test ./internal/hooks ./internal/templates ./internal/formula -count=1`
- `CGO_ENABLED=0 go test ./internal/cmd -run 'TestSyncTarget|TestRunHooksSync|TestOutputCommandQuickReferenceBootBlocksRawTmux' -count=1`
- `go vet ./internal/hooks ./internal/templates ./internal/formula`
- `CGO_ENABLED=0 go vet ./internal/cmd ./cmd/gt`
- `CGO_ENABLED=0 make build`

Note: default cgo linking for `internal/cmd` cannot run in this container because ICU libraries are missing (`-licui18n`, `-licuuc`, `-licudata`), so cmd verification used `CGO_ENABLED=0`.

No author action needed on #4098; this maintainer replacement carries the fix forward.
