### PR TITLE
fix(plugins): close plugin run receipts

### DIFF
--- a/docs/design/plugin-system.md
+++ b/docs/design/plugin-system.md
@@ -96,25 +96,24 @@ Benefits:
 Each plugin run creates a wisp:
 
 ```bash
-bd create --wisp-type patrol \
-  --labels type:plugin-run,plugin:rebuild-gt,rig:gastown,result:success \
-  --description "Rebuilt gt: abc123 → def456 (5 commits)" \
-  "Plugin: rebuild-gt [success]"
+gt plugin record-run --plugin rebuild-gt --result success --rig gastown \
+  --title "Plugin: rebuild-gt [success]" \
+  --description "Rebuilt gt: abc123 → def456 (5 commits)"
 ```
 
 **Gate evaluation** queries wisps instead of state files:
 
 ```bash
 # Cooldown check: any runs in last hour?
-bd list --wisp-type patrol --label plugin:rebuild-gt --created-after 1h -n 1
+bd list --all --label type:plugin-run --label plugin:rebuild-gt --created-after 1h -n 1
 ```
 
 **Derived state** (no state.json needed):
 
 | Query | Command |
 |-------|---------|
-| Last run time | `bd list --label=plugin:X --limit=1 --json` |
-| Run count | `bd list --label=plugin:X --json \| jq length` |
+| Last run time | `bd list --all --label=plugin:X --limit=1 --json` |
+| Run count | `bd list --all --label=plugin:X --json \| jq length` |
 | Last result | Parse `result:` label from latest wisp |
 | Failure rate | Count `result:failure` vs total |
 

--- a/internal/cmd/plugin.go
+++ b/internal/cmd/plugin.go
@@ -27,6 +27,12 @@ var (
 	pluginSyncSource   string
 	pluginSyncClean    bool
 	pluginSyncDryRun   bool
+	pluginRecordPlugin string
+	pluginRecordResult string
+	pluginRecordTitle  string
+	pluginRecordBody   string
+	pluginRecordRig    string
+	pluginRecordLabels []string
 )
 
 var pluginCmd = &cobra.Command{
@@ -135,6 +141,17 @@ Examples:
 	RunE: runPluginHistory,
 }
 
+var pluginRecordRunCmd = &cobra.Command{
+	Use:   "record-run",
+	Short: "Record a plugin run receipt",
+	Long: `Record a plugin run receipt through the canonical plugin recorder.
+
+The recorder creates an ephemeral type:plugin-run bead, closes it immediately,
+and leaves the receipt available to plugin history/cooldown queries that use
+closed beads. This keeps plugin scripts from leaking open run-log beads.`,
+	RunE: runPluginRecordRun,
+}
+
 func init() {
 	// List subcommand flags
 	pluginListCmd.Flags().BoolVar(&pluginListJSON, "json", false, "Output as JSON")
@@ -150,6 +167,14 @@ func init() {
 	pluginHistoryCmd.Flags().BoolVar(&pluginHistoryJSON, "json", false, "Output as JSON")
 	pluginHistoryCmd.Flags().IntVar(&pluginHistoryLimit, "limit", 10, "Maximum number of runs to show")
 
+	// Record-run subcommand flags
+	pluginRecordRunCmd.Flags().StringVar(&pluginRecordPlugin, "plugin", "", "Plugin name")
+	pluginRecordRunCmd.Flags().StringVar(&pluginRecordResult, "result", "", "Run result label value")
+	pluginRecordRunCmd.Flags().StringVar(&pluginRecordTitle, "title", "", "Receipt title")
+	pluginRecordRunCmd.Flags().StringVar(&pluginRecordBody, "description", "", "Receipt description")
+	pluginRecordRunCmd.Flags().StringVar(&pluginRecordRig, "rig", "", "Rig label value")
+	pluginRecordRunCmd.Flags().StringArrayVarP(&pluginRecordLabels, "label", "l", nil, "Additional label for the receipt")
+
 	// Sync subcommand flags
 	pluginSyncCmd.Flags().StringVar(&pluginSyncSource, "source", "", "Source plugins directory (auto-detected if omitted)")
 	pluginSyncCmd.Flags().BoolVar(&pluginSyncClean, "clean", false, "Remove plugins from target that don't exist in source")
@@ -160,6 +185,7 @@ func init() {
 	pluginCmd.AddCommand(pluginShowCmd)
 	pluginCmd.AddCommand(pluginRunCmd)
 	pluginCmd.AddCommand(pluginHistoryCmd)
+	pluginCmd.AddCommand(pluginRecordRunCmd)
 	pluginCmd.AddCommand(pluginSyncCmd)
 
 	rootCmd.AddCommand(pluginCmd)
@@ -626,5 +652,35 @@ func runPluginHistory(cmd *cobra.Command, args []string) error {
 			style.Dim.Render(run.ID))
 	}
 
+	return nil
+}
+
+func runPluginRecordRun(cmd *cobra.Command, args []string) error {
+	if pluginRecordPlugin == "" {
+		return fmt.Errorf("--plugin is required")
+	}
+	if pluginRecordResult == "" {
+		return fmt.Errorf("--result is required")
+	}
+
+	townRoot, err := workspace.FindFromCwdOrError()
+	if err != nil {
+		return fmt.Errorf("not in a Gas Town workspace: %w", err)
+	}
+
+	recorder := plugin.NewRecorder(townRoot)
+	beadID, err := recorder.RecordRun(plugin.PluginRunRecord{
+		PluginName:  pluginRecordPlugin,
+		RigName:     pluginRecordRig,
+		Result:      plugin.RunResult(pluginRecordResult),
+		Title:       pluginRecordTitle,
+		Body:        pluginRecordBody,
+		ExtraLabels: pluginRecordLabels,
+	})
+	if err != nil {
+		return err
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), beadID)
 	return nil
 }

--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -473,10 +473,10 @@ Record the quality review result. This is fail-open: if the command fails,
 log the error and continue — never block the merge.
 
 ```bash
-bd create "quality-review: Score <score>, <recommendation>" -t chore --ephemeral \\
-  -l type:plugin-run,plugin:quality-review-result,worker:<polecat-name>,rig:<rig-name>,score:<score>,recommendation:<approve|request_changes>,result:success \\
-  -d "Score: <score>, <recommendation>. Issues: <count> (<summary>)" \\
-  --silent 2>/dev/null || true
+gt plugin record-run --plugin quality-review-result --result success --rig <rig-name> \\
+  --label worker:<polecat-name> --label score:<score> --label recommendation:<approve|request_changes> \\
+  --title "quality-review: Score <score>, <recommendation>" \\
+  --description "Score: <score>, <recommendation>. Issues: <count> (<summary>)" >/dev/null 2>&1 || true
 ```
 
 **Step 6: Handle breach scores (measurement-only)**

--- a/internal/plugin/recording.go
+++ b/internal/plugin/recording.go
@@ -22,10 +22,12 @@ const (
 
 // PluginRunRecord represents data for creating a plugin run bead.
 type PluginRunRecord struct {
-	PluginName string
-	RigName    string
-	Result     RunResult
-	Body       string
+	PluginName  string
+	RigName     string
+	Result      RunResult
+	Title       string
+	Body        string
+	ExtraLabels []string
 }
 
 // PluginRunBead represents a recorded plugin run from the ledger.
@@ -50,7 +52,10 @@ func NewRecorder(townRoot string) *Recorder {
 // RecordRun creates an ephemeral bead for a plugin run.
 // This is pure data writing - the caller decides what result to record.
 func (r *Recorder) RecordRun(record PluginRunRecord) (string, error) {
-	title := fmt.Sprintf("Plugin run: %s", record.PluginName)
+	title := record.Title
+	if title == "" {
+		title = fmt.Sprintf("Plugin run: %s", record.PluginName)
+	}
 
 	// Build labels
 	labels := []string{
@@ -61,12 +66,14 @@ func (r *Recorder) RecordRun(record PluginRunRecord) (string, error) {
 	if record.RigName != "" {
 		labels = append(labels, fmt.Sprintf("rig:%s", record.RigName))
 	}
+	labels = append(labels, record.ExtraLabels...)
 
 	// Build bd create command
 	args := []string{
 		"create",
 		"--ephemeral",
 		"--json",
+		"-t", "chore",
 		"--title=" + title,
 	}
 	for _, label := range labels {

--- a/internal/plugin/recording_test.go
+++ b/internal/plugin/recording_test.go
@@ -1,6 +1,9 @@
 package plugin
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 )
@@ -21,6 +24,61 @@ func TestPluginRunRecord(t *testing.T) {
 	}
 	if record.Result != ResultSuccess {
 		t.Errorf("expected result 'success', got %q", record.Result)
+	}
+}
+
+func TestRecordRunCreatesAndClosesReceipt(t *testing.T) {
+	townRoot := t.TempDir()
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd-args.log")
+	bdPath := filepath.Join(binDir, "bd")
+	fakeBD := "#!/usr/bin/env bash\n" +
+		"printf '%s\\n' \"$*\" >> \"$BD_ARGS_LOG\"\n" +
+		"case \"$1\" in\n" +
+		"  create) printf '{\\\"id\\\":\\\"gt-test-run\\\"}\\n' ;;\n" +
+		"  close) exit 0 ;;\n" +
+		"  *) exit 2 ;;\n" +
+		"esac\n"
+	if err := os.WriteFile(bdPath, []byte(fakeBD), 0755); err != nil {
+		t.Fatalf("write fake bd: %v", err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_ARGS_LOG", logPath)
+
+	recorder := NewRecorder(townRoot)
+	id, err := recorder.RecordRun(PluginRunRecord{
+		PluginName:  "tool-updater",
+		RigName:     "gastown",
+		Result:      RunResult("warning"),
+		Title:       "tool-updater: failed=brew",
+		Body:        "brew failed",
+		ExtraLabels: []string{"source:test"},
+	})
+	if err != nil {
+		t.Fatalf("RecordRun failed: %v", err)
+	}
+	if id != "gt-test-run" {
+		t.Fatalf("RecordRun id = %q, want gt-test-run", id)
+	}
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("read fake bd log: %v", err)
+	}
+	log := string(data)
+	for _, want := range []string{
+		"create --ephemeral --json -t chore --title=tool-updater: failed=brew",
+		"-l type:plugin-run",
+		"-l plugin:tool-updater",
+		"-l result:warning",
+		"-l rig:gastown",
+		"-l source:test",
+		"--description=brew failed",
+		"close gt-test-run --reason plugin run recorded",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("fake bd log missing %q in:\n%s", want, log)
+		}
 	}
 }
 

--- a/internal/plugin/scanner_test.go
+++ b/internal/plugin/scanner_test.go
@@ -687,6 +687,12 @@ func TestFormatMailBody_WithRunScript(t *testing.T) {
 	if !strings.Contains(body, "Do NOT interpret the plugin.md instructions") {
 		t.Error("expected mail body to warn against interpreting markdown")
 	}
+	if !strings.Contains(body, "gt plugin record-run --plugin test-plugin --result <outcome>") {
+		t.Error("expected mail body to use canonical plugin run recorder")
+	}
+	if strings.Contains(body, "bd create --ephemeral") {
+		t.Error("expected mail body to avoid raw ephemeral receipt creation")
+	}
 	// Must NOT contain "## Instructions" section
 	if strings.Contains(body, "## Instructions") {
 		t.Error("expected mail body to NOT contain markdown instructions section")
@@ -865,5 +871,11 @@ func TestFormatMailBody_WithoutRunScript(t *testing.T) {
 	// Must NOT contain run.sh dispatch
 	if strings.Contains(body, "bash run.sh") {
 		t.Error("expected mail body to NOT contain run.sh command")
+	}
+	if !strings.Contains(body, "gt plugin record-run --plugin test-plugin --result <outcome>") {
+		t.Error("expected mail body to use canonical plugin run recorder")
+	}
+	if strings.Contains(body, "bd create --ephemeral") {
+		t.Error("expected mail body to avoid raw ephemeral receipt creation")
 	}
 }

--- a/internal/plugin/types.go
+++ b/internal/plugin/types.go
@@ -220,9 +220,9 @@ func (p *Plugin) FormatMailBody() string {
 				"Run this command EXACTLY. Do NOT interpret the plugin.md instructions.\n"+
 				"Do NOT write your own implementation. Just run the script and report the output.\n\n"+
 				"After completion:\n"+
-				"1. The script should record a plugin-run receipt. If it did not, create one with `bd create --ephemeral` using labels `type:plugin-run`, `plugin:%s`, and `result:<outcome>`.\n"+
+				"1. The script should record a plugin-run receipt. If it did not, run `gt plugin record-run --plugin %s --result <outcome> --title \"Plugin run: %s\"`.\n"+
 				"2. Run `gt dog done` — this clears your work and auto-terminates the session. Run this even if recording fails.\n",
-			p.Name, p.Description, p.Path, p.Name)
+			p.Name, p.Description, p.Path, p.Name, p.Name)
 	}
 
 	var sb strings.Builder
@@ -241,7 +241,7 @@ func (p *Plugin) FormatMailBody() string {
 	sb.WriteString(p.Instructions)
 	sb.WriteString("\n\n---\n\n")
 	sb.WriteString("After completion:\n")
-	sb.WriteString("1. Follow the plugin's recording instructions above. If none are provided, create a receipt with `bd create --ephemeral` using labels `type:plugin-run`, `plugin:" + p.Name + "`, and `result:<outcome>`.\n")
+	sb.WriteString("1. Follow the plugin's recording instructions above. If none are provided, run `gt plugin record-run --plugin " + p.Name + " --result <outcome> --title \"Plugin run: " + p.Name + "\"`.\n")
 	sb.WriteString("2. Run `gt dog done` — this clears your work and auto-terminates the session. Run this even if recording fails.\n")
 
 	return sb.String()

--- a/plugins/compactor-dog/plugin.md
+++ b/plugins/compactor-dog/plugin.md
@@ -239,23 +239,22 @@ echo "=== $SUMMARY ==="
 
 On success (no escalation needed):
 ```bash
-bd create "compactor-dog: $SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:compactor-dog,result:success \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record-run --plugin compactor-dog --result success \
+  --title "compactor-dog: $SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true
 ```
 
 On escalation:
 ```bash
-bd create "compactor-dog: ESCALATED - $SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:compactor-dog,result:warning \
-  -d "Escalated to Mayor for compaction. $SUMMARY" --silent 2>/dev/null || true
+gt plugin record-run --plugin compactor-dog --result warning \
+  --title "compactor-dog: ESCALATED - $SUMMARY" \
+  --description "Escalated to Mayor for compaction. $SUMMARY" >/dev/null 2>&1 || true
 ```
 
 On failure:
 ```bash
-bd create "compactor-dog: FAILED" -t chore --ephemeral \
-  -l type:plugin-run,plugin:compactor-dog,result:failure \
-  -d "Compactor check failed: $ERROR" --silent 2>/dev/null || true
+gt plugin record-run --plugin compactor-dog --result failure \
+  --title "compactor-dog: FAILED" \
+  --description "Compactor check failed: $ERROR" >/dev/null 2>&1 || true
 
 gt escalate "Plugin FAILED: compactor-dog" \
   --severity medium \

--- a/plugins/compactor-dog/run.sh
+++ b/plugins/compactor-dog/run.sh
@@ -201,9 +201,8 @@ log "Skipped (below threshold): ${#SKIPPED[@]}"
 if [[ ${#CANDIDATES[@]} -eq 0 ]]; then
   log "All databases within threshold ($COMMIT_THRESHOLD). No compaction needed."
   SUMMARY="compactor-dog: all ${DB_COUNT} DBs below threshold ($COMMIT_THRESHOLD commits)"
-  bd create "$SUMMARY" -t chore --ephemeral \
-    -l type:plugin-run,plugin:compactor-dog,result:success \
-    -d "$SUMMARY" --silent 2>/dev/null || true
+  gt plugin record-run --plugin compactor-dog --result success \
+    --title "$SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true
   exit 0
 fi
 
@@ -216,9 +215,8 @@ if $CHECK_ONLY; then
     log "  ${entry%%:*} (${entry##*:} commits) — recommends compaction"
   done
   SUMMARY="compactor-dog: ${#CANDIDATES[@]} DBs exceed threshold ($COMMIT_THRESHOLD commits)"
-  bd create "$SUMMARY" -t chore --ephemeral \
-    -l type:plugin-run,plugin:compactor-dog,result:check-only \
-    -d "$SUMMARY" --silent 2>/dev/null || true
+  gt plugin record-run --plugin compactor-dog --result check-only \
+    --title "$SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true
   exit 0
 fi
 
@@ -478,13 +476,12 @@ if [[ $ERRORS -gt 0 ]]; then
   gt escalate "compactor-dog: $ERRORS databases had compaction errors" -s MEDIUM \
     --reason "Compaction cycle completed with errors. $SUMMARY" 2>/dev/null || true
 
-  bd create "compactor-dog: ERRORS — $SUMMARY" -t chore --ephemeral \
-    -l type:plugin-run,plugin:compactor-dog,result:warning \
-    -d "Compaction completed with $ERRORS errors. $SUMMARY" --silent 2>/dev/null || true
+  gt plugin record-run --plugin compactor-dog --result warning \
+    --title "compactor-dog: ERRORS — $SUMMARY" \
+    --description "Compaction completed with $ERRORS errors. $SUMMARY" >/dev/null 2>&1 || true
 else
-  bd create "$SUMMARY" -t chore --ephemeral \
-    -l type:plugin-run,plugin:compactor-dog,result:success \
-    -d "$SUMMARY" --silent 2>/dev/null || true
+  gt plugin record-run --plugin compactor-dog --result success \
+    --title "$SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true
 fi
 
 log "Done."

--- a/plugins/dolt-archive/plugin.md
+++ b/plugins/dolt-archive/plugin.md
@@ -260,9 +260,8 @@ if [ "$EXPORT_FAILED" -gt 0 ] || [ "$DOLT_PUSH_FAILED" -gt 0 ] || [ "$VERIFY_FAI
   RESULT="warning"
 fi
 
-bd create "$SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:dolt-archive,result:$RESULT \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record-run --plugin dolt-archive --result "$RESULT" \
+  --title "$SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true
 
 if [ "$EXPORT_FAILED" -gt 0 ]; then
   gt escalate "JSONL export failed for $EXPORT_FAILED databases" \

--- a/plugins/dolt-archive/run.sh
+++ b/plugins/dolt-archive/run.sh
@@ -224,9 +224,8 @@ if [[ "$EXPORT_FAILED" -gt 0 ]] || [[ "$DOLT_PUSH_FAILED" -gt 0 ]]; then
   RESULT="warning"
 fi
 
-bd create "$SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:dolt-archive,result:$RESULT \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record-run --plugin dolt-archive --result "$RESULT" \
+  --title "$SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true
 
 if [[ "$EXPORT_FAILED" -gt 0 ]]; then
   gt escalate "dolt-archive: JSONL export failed for $EXPORT_FAILED databases ($EXPORT_ERRORS)" \

--- a/plugins/dolt-backup/run.sh
+++ b/plugins/dolt-backup/run.sh
@@ -185,15 +185,13 @@ log "$SUMMARY"
 
 if [[ "$FAILED" -eq 0 ]]; then
   # Success — record quietly
-  bd create --title "dolt-backup: $SUMMARY" -t chore --ephemeral \
-    -l type:plugin-run,plugin:dolt-backup,result:success \
-    -d "$SUMMARY" --silent 2>/dev/null || true
+  gt plugin record-run --plugin dolt-backup --result success \
+    --title "dolt-backup: $SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true
 else
   # Failure — record and escalate
   FAIL_MSG="$SUMMARY. Failed:$FAILED_DBS"
-  bd create --title "dolt-backup: FAILED - $FAIL_MSG" -t chore --ephemeral \
-    -l type:plugin-run,plugin:dolt-backup,result:failure \
-    -d "$FAIL_MSG" --silent 2>/dev/null || true
+  gt plugin record-run --plugin dolt-backup --result failure \
+    --title "dolt-backup: FAILED - $FAIL_MSG" --description "$FAIL_MSG" >/dev/null 2>&1 || true
 
   gt escalate "dolt-backup FAILED: $FAIL_MSG" \
     --severity high \

--- a/plugins/dolt-log-rotate/run.sh
+++ b/plugins/dolt-log-rotate/run.sh
@@ -35,9 +35,8 @@ log "Current log size: ${SIZE_MB}MB (threshold: ${MAX_MB}MB)"
 
 if [[ $SIZE_MB -lt $MAX_MB ]]; then
   log "Below threshold. Nothing to do."
-  bd create "dolt-log-rotate: log size ${SIZE_MB}MB, below ${MAX_MB}MB threshold" \
-    -t chore --ephemeral -l type:plugin-run,plugin:dolt-log-rotate,result:success \
-    --silent 2>/dev/null || true
+  gt plugin record-run --plugin dolt-log-rotate --result success \
+    --title "dolt-log-rotate: log size ${SIZE_MB}MB, below ${MAX_MB}MB threshold" >/dev/null 2>&1 || true
   exit 0
 fi
 
@@ -87,6 +86,5 @@ SUMMARY="dolt-log-rotate: rotated ${SIZE_MB}MB -> ${COMPRESSED_MB}MB compressed,
 log ""
 log "=== Done === $SUMMARY"
 
-bd create "$SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:dolt-log-rotate,result:success \
-  --silent 2>/dev/null || true
+gt plugin record-run --plugin dolt-log-rotate --result success \
+  --title "$SUMMARY" >/dev/null 2>&1 || true

--- a/plugins/dolt-snapshots/plugin.md
+++ b/plugins/dolt-snapshots/plugin.md
@@ -135,7 +135,7 @@ if [ $SNAPSHOT_EXIT -ne 0 ]; then
   RESULT="failure"
 fi
 
-bd create "dolt-snapshots: $RESULT" -t chore --ephemeral \
-  -l type:plugin-run,plugin:dolt-snapshots,result:$RESULT \
-  -d "dolt-snapshots plugin completed with exit code $SNAPSHOT_EXIT. Watcher started." --silent 2>/dev/null || true
+gt plugin record-run --plugin dolt-snapshots --result "$RESULT" \
+  --title "dolt-snapshots: $RESULT" \
+  --description "dolt-snapshots plugin completed with exit code $SNAPSHOT_EXIT. Watcher started." >/dev/null 2>&1 || true
 ```

--- a/plugins/git-hygiene/plugin.md
+++ b/plugins/git-hygiene/plugin.md
@@ -207,16 +207,15 @@ echo "$SUMMARY"
 
 On success:
 ```bash
-bd create "git-hygiene: $SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:git-hygiene,result:success \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record-run --plugin git-hygiene --result success \
+  --title "git-hygiene: $SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true
 ```
 
 On failure:
 ```bash
-bd create "git-hygiene: FAILED" -t chore --ephemeral \
-  -l type:plugin-run,plugin:git-hygiene,result:failure \
-  -d "Git hygiene failed: $ERROR" --silent 2>/dev/null || true
+gt plugin record-run --plugin git-hygiene --result failure \
+  --title "git-hygiene: FAILED" \
+  --description "Git hygiene failed: $ERROR" >/dev/null 2>&1 || true
 
 gt escalate "Plugin FAILED: git-hygiene" \
   --severity low \

--- a/plugins/git-hygiene/run.sh
+++ b/plugins/git-hygiene/run.sh
@@ -170,6 +170,5 @@ log ""
 log "=== Git Hygiene Summary ==="
 log "$SUMMARY"
 
-bd create "git-hygiene: $SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:git-hygiene,result:success \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record-run --plugin git-hygiene --result success \
+  --title "git-hygiene: $SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true

--- a/plugins/github-sheriff/plugin.md
+++ b/plugins/github-sheriff/plugin.md
@@ -152,16 +152,15 @@ echo "$SUMMARY"
 
 On success:
 ```bash
-bd create "github-sheriff: $SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:github-sheriff,result:success \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record-run --plugin github-sheriff --result success \
+  --title "github-sheriff: $SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true
 ```
 
 On failure:
 ```bash
-bd create "github-sheriff: FAILED" -t chore --ephemeral \
-  -l type:plugin-run,plugin:github-sheriff,result:failure \
-  -d "GitHub sheriff failed: $ERROR" --silent 2>/dev/null || true
+gt plugin record-run --plugin github-sheriff --result failure \
+  --title "github-sheriff: FAILED" \
+  --description "GitHub sheriff failed: $ERROR" >/dev/null 2>&1 || true
 
 gt escalate "Plugin FAILED: github-sheriff" \
   --severity low \

--- a/plugins/gitignore-reconcile/plugin.md
+++ b/plugins/gitignore-reconcile/plugin.md
@@ -132,7 +132,6 @@ echo "$SUMMARY"
 RESULT="success"
 [ -n "$ERRORS" ] && RESULT="warning"
 
-bd create "$SUMMARY" -t chore --ephemeral \
-  -l "type:plugin-run,plugin:gitignore-reconcile,result:$RESULT" \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record-run --plugin gitignore-reconcile --result "$RESULT" \
+  --title "$SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true
 ```

--- a/plugins/gitignore-reconcile/run.sh
+++ b/plugins/gitignore-reconcile/run.sh
@@ -101,8 +101,7 @@ log "=== Summary ==="
 SUMMARY="gitignore-reconcile: $TOTAL_UNTRACKED file(s) untracked, $TOTAL_BEADS chore bead(s) created"
 log "$SUMMARY"
 
-bd create "$SUMMARY" -t chore --ephemeral \
-  -l "type:plugin-run,plugin:gitignore-reconcile,result:success" \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record-run --plugin gitignore-reconcile --result success \
+  --title "$SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true
 
 log "Done."

--- a/plugins/quality-review/plugin.md
+++ b/plugins/quality-review/plugin.md
@@ -34,10 +34,9 @@ bd list --json --all -l type:plugin-run,plugin:quality-review-result --created-a
 If no results are found, record a run wisp and stop:
 
 ```bash
-bd create "quality-review: No results in last 24h" -t chore --ephemeral \
-  -l type:plugin-run,plugin:quality-review,result:success \
-  -d "No quality-review results in last 24h. Nothing to analyze." \
-  --silent 2>/dev/null || true
+gt plugin record-run --plugin quality-review --result success \
+  --title "quality-review: No results in last 24h" \
+  --description "No quality-review results in last 24h. Nothing to analyze." >/dev/null 2>&1 || true
 ```
 
 ## Step 2: Compute per-worker trends
@@ -91,19 +90,17 @@ gt escalate "Quality BREACH: <worker> (avg: <avg>)" \
 Record a summary wisp for this plugin run:
 
 ```bash
-bd create "quality-review: Analyzed <N> workers over <M> reviews" -t chore --ephemeral \
-  -l type:plugin-run,plugin:quality-review,result:success \
-  -d "Analyzed <N> workers over <M> reviews. <B> breaches, <W> warnings." \
-  --silent 2>/dev/null || true
+gt plugin record-run --plugin quality-review --result success \
+  --title "quality-review: Analyzed <N> workers over <M> reviews" \
+  --description "Analyzed <N> workers over <M> reviews. <B> breaches, <W> warnings." >/dev/null 2>&1 || true
 ```
 
 If any step fails unexpectedly, record a failure wisp and escalate:
 
 ```bash
-bd create "quality-review: FAILED" -t chore --ephemeral \
-  -l type:plugin-run,plugin:quality-review,result:failure \
-  -d "<error description>" \
-  --silent 2>/dev/null || true
+gt plugin record-run --plugin quality-review --result failure \
+  --title "quality-review: FAILED" \
+  --description "<error description>" >/dev/null 2>&1 || true
 
 gt escalate "Plugin FAILED: quality-review" \
   --severity medium \
@@ -118,10 +115,10 @@ This plugin does NOT record scores itself. The Refinery records result wisps dur
 merges via the `quality-review` formula step. Each merge produces a wisp like:
 
 ```bash
-bd create "quality-review: Score 0.85, approve" -t chore --ephemeral \
-  -l type:plugin-run,plugin:quality-review-result,worker:<polecat-name>,rig:<rig-name>,score:0.85,recommendation:approve,result:success \
-  -d "Score: 0.85, approve. Issues: 1 minor (style)" \
-  --silent 2>/dev/null || true
+gt plugin record-run --plugin quality-review-result --result success --rig <rig-name> \
+  --label worker:<polecat-name> --label score:0.85 --label recommendation:approve \
+  --title "quality-review: Score 0.85, approve" \
+  --description "Score: 0.85, approve. Issues: 1 minor (style)" >/dev/null 2>&1 || true
 ```
 
 This creates the data that Step 1 queries.

--- a/plugins/rebuild-gt/plugin.md
+++ b/plugins/rebuild-gt/plugin.md
@@ -47,10 +47,9 @@ Parse the JSON output and check these fields:
 
 If `safe_to_rebuild` is false, record a skip wisp:
 ```bash
-bd create --wisp-type patrol \
-  --labels type:plugin-run,plugin:rebuild-gt,rig:gastown,result:skipped \
-  --description "Skipped: not safe to rebuild (forward=$FORWARD, main=$ON_MAIN)" \
-  "Plugin: rebuild-gt [skipped]"
+gt plugin record-run --plugin rebuild-gt --result skipped --rig gastown \
+  --title "Plugin: rebuild-gt [skipped]" \
+  --description "Skipped: not safe to rebuild (forward=$FORWARD, main=$ON_MAIN)" >/dev/null 2>&1 || true
 ```
 
 ## Pre-flight Checks
@@ -81,18 +80,16 @@ NOT restart the daemon — sessions will pick up the new binary on their next cy
 
 On success:
 ```bash
-bd create --wisp-type patrol \
-  --labels type:plugin-run,plugin:rebuild-gt,rig:gastown,result:success \
-  --description "Rebuilt gt: $OLD → $NEW ($N commits)" \
-  "Plugin: rebuild-gt [success]"
+gt plugin record-run --plugin rebuild-gt --result success --rig gastown \
+  --title "Plugin: rebuild-gt [success]" \
+  --description "Rebuilt gt: $OLD → $NEW ($N commits)" >/dev/null 2>&1 || true
 ```
 
 On failure:
 ```bash
-bd create --wisp-type patrol \
-  --labels type:plugin-run,plugin:rebuild-gt,rig:gastown,result:failure \
-  --description "Build failed: $ERROR" \
-  "Plugin: rebuild-gt [failure]"
+gt plugin record-run --plugin rebuild-gt --result failure --rig gastown \
+  --title "Plugin: rebuild-gt [failure]" \
+  --description "Build failed: $ERROR" >/dev/null 2>&1 || true
 
 gt escalate --severity=medium \
   --subject="Plugin FAILED: rebuild-gt" \

--- a/plugins/rebuild-gt/run.sh
+++ b/plugins/rebuild-gt/run.sh
@@ -25,17 +25,16 @@ SAFE=$(echo "$STALE_JSON" | python3 -c "import json,sys; print(json.load(sys.std
 
 if [ "$IS_STALE" != "True" ]; then
   log "Binary is fresh. Nothing to do."
-  bd create "rebuild-gt: binary is fresh" -t chore --ephemeral \
-    -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:success \
-    --silent 2>/dev/null || true
+  gt plugin record-run --plugin rebuild-gt --result success --rig gastown \
+    --title "rebuild-gt: binary is fresh" >/dev/null 2>&1 || true
   exit 0
 fi
 
 if [ "$SAFE" != "True" ]; then
   log "Not safe to rebuild (not on main or would be a downgrade). Skipping."
-  bd create "Plugin: rebuild-gt [skipped]" -t chore --ephemeral \
-    -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:skipped \
-    -d "Skipped: not safe to rebuild" --silent 2>/dev/null || true
+  gt plugin record-run --plugin rebuild-gt --result skipped --rig gastown \
+    --title "Plugin: rebuild-gt [skipped]" \
+    --description "Skipped: not safe to rebuild" >/dev/null 2>&1 || true
   exit 0
 fi
 
@@ -51,18 +50,18 @@ fi
 DIRTY=$(git -C "$RIG_ROOT" status --porcelain 2>/dev/null)
 if [ -n "$DIRTY" ]; then
   log "Repo is dirty, skipping rebuild."
-  bd create "Plugin: rebuild-gt [skipped]" -t chore --ephemeral \
-    -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:skipped \
-    -d "Skipped: repo has uncommitted changes" --silent 2>/dev/null || true
+  gt plugin record-run --plugin rebuild-gt --result skipped --rig gastown \
+    --title "Plugin: rebuild-gt [skipped]" \
+    --description "Skipped: repo has uncommitted changes" >/dev/null 2>&1 || true
   exit 0
 fi
 
 BRANCH=$(git -C "$RIG_ROOT" branch --show-current 2>/dev/null)
 if [ "$BRANCH" != "main" ]; then
   log "Not on main branch (on $BRANCH), skipping rebuild."
-  bd create "Plugin: rebuild-gt [skipped]" -t chore --ephemeral \
-    -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:skipped \
-    -d "Skipped: not on main branch (on $BRANCH)" --silent 2>/dev/null || true
+  gt plugin record-run --plugin rebuild-gt --result skipped --rig gastown \
+    --title "Plugin: rebuild-gt [skipped]" \
+    --description "Skipped: not on main branch (on $BRANCH)" >/dev/null 2>&1 || true
   exit 0
 fi
 
@@ -74,15 +73,14 @@ log "Rebuilding gt from $RIG_ROOT..."
 if (cd "$RIG_ROOT" && make build && make safe-install) 2>&1; then
   NEW_VER=$(gt version 2>/dev/null | head -1 || echo "unknown")
   log "Rebuilt: $OLD_VER -> $NEW_VER"
-  bd create "rebuild-gt: $OLD_VER -> $NEW_VER" -t chore --ephemeral \
-    -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:success \
-    --silent 2>/dev/null || true
+  gt plugin record-run --plugin rebuild-gt --result success --rig gastown \
+    --title "rebuild-gt: $OLD_VER -> $NEW_VER" >/dev/null 2>&1 || true
 else
   ERROR="make build/safe-install failed"
   log "FAILED: $ERROR"
-  bd create "Plugin: rebuild-gt [failure]" -t chore --ephemeral \
-    -l type:plugin-run,plugin:rebuild-gt,rig:gastown,result:failure \
-    -d "Build failed: $ERROR" --silent 2>/dev/null || true
+  gt plugin record-run --plugin rebuild-gt --result failure --rig gastown \
+    --title "Plugin: rebuild-gt [failure]" \
+    --description "Build failed: $ERROR" >/dev/null 2>&1 || true
   gt escalate "Plugin FAILED: rebuild-gt" -s medium 2>/dev/null || true
   exit 1
 fi

--- a/plugins/stuck-agent-dog/plugin.md
+++ b/plugins/stuck-agent-dog/plugin.md
@@ -356,16 +356,15 @@ echo "=== $SUMMARY ==="
 
 On success (no issues or issues handled):
 ```bash
-bd create "stuck-agent-dog: $SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:stuck-agent-dog,result:success \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record-run --plugin stuck-agent-dog --result success \
+  --title "stuck-agent-dog: $SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true
 ```
 
 On failure:
 ```bash
-bd create "stuck-agent-dog: FAILED" -t chore --ephemeral \
-  -l type:plugin-run,plugin:stuck-agent-dog,result:failure \
-  -d "Agent health check failed: $ERROR" --silent 2>/dev/null || true
+gt plugin record-run --plugin stuck-agent-dog --result failure \
+  --title "stuck-agent-dog: FAILED" \
+  --description "Agent health check failed: $ERROR" >/dev/null 2>&1 || true
 
 gt escalate "Plugin FAILED: stuck-agent-dog" \
   --severity high \

--- a/plugins/stuck-agent-dog/run.sh
+++ b/plugins/stuck-agent-dog/run.sh
@@ -351,6 +351,5 @@ SUMMARY="Agent health: ${#CRASHED[@]} crashed, ${#STUCK[@]} stuck, $HEALTHY heal
 log ""
 log "=== $SUMMARY ==="
 
-bd create "stuck-agent-dog: $SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:stuck-agent-dog,result:success \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record-run --plugin stuck-agent-dog --result success \
+  --title "stuck-agent-dog: $SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true

--- a/plugins/submodule-commit/plugin.md
+++ b/plugins/submodule-commit/plugin.md
@@ -181,7 +181,6 @@ echo "$SUMMARY"
 RESULT="success"
 [ -n "$ERRORS" ] && RESULT="warning"
 
-bd create "$SUMMARY" -t chore --ephemeral \
-  -l "type:plugin-run,plugin:submodule-commit,result:$RESULT" \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record-run --plugin submodule-commit --result "$RESULT" \
+  --title "$SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true
 ```

--- a/plugins/submodule-commit/run.sh
+++ b/plugins/submodule-commit/run.sh
@@ -163,8 +163,7 @@ log "=== Summary ==="
 SUMMARY="submodule-commit: $TOTAL_COMMITTED submodule(s) committed, $TOTAL_PUSHED pushed, $TOTAL_PARENT_UPDATED parent pointer(s) updated"
 log "$SUMMARY"
 
-bd create "$SUMMARY" -t chore --ephemeral \
-  -l "type:plugin-run,plugin:submodule-commit,result:success" \
-  -d "$SUMMARY" --silent 2>/dev/null || true
+gt plugin record-run --plugin submodule-commit --result success \
+  --title "$SUMMARY" --description "$SUMMARY" >/dev/null 2>&1 || true
 
 log "Done."

--- a/plugins/tool-updater/run.sh
+++ b/plugins/tool-updater/run.sh
@@ -31,9 +31,8 @@ done
 
 if [[ ${#OUTDATED[@]} -eq 0 ]]; then
   log "All tools current. Nothing to do."
-  bd create "tool-updater: all tools current (beads=$(bd version 2>/dev/null | awk '{print $3}'), dolt=$(dolt version 2>/dev/null | awk '{print $3}')" \
-    -t chore --ephemeral -l type:plugin-run,plugin:tool-updater,result:success \
-    --silent 2>/dev/null || true
+  gt plugin record-run --plugin tool-updater --result success \
+    --title "tool-updater: all tools current (beads=$(bd version 2>/dev/null | awk '{print $3}'), dolt=$(dolt version 2>/dev/null | awk '{print $3}')" >/dev/null 2>&1 || true
   exit 0
 fi
 
@@ -64,9 +63,8 @@ log "=== Done === $SUMMARY"
 RESULT="success"
 [[ ${#FAILED[@]} -gt 0 ]] && RESULT="warning"
 
-bd create "$SUMMARY" -t chore --ephemeral \
-  -l type:plugin-run,plugin:tool-updater,result:$RESULT \
-  --silent 2>/dev/null || true
+gt plugin record-run --plugin tool-updater --result "$RESULT" \
+  --title "$SUMMARY" >/dev/null 2>&1 || true
 
 if [[ ${#FAILED[@]} -gt 0 ]]; then
   gt escalate "tool-updater: ${#FAILED[@]} tool(s) failed to upgrade: ${FAILED[*]}" \


### PR DESCRIPTION
Replacement for #4289.

This is the PR Sheriff cleanup-first branch for closing plugin run-log receipts through the authoritative `gt plugin record-run` / `plugin.Recorder` path instead of repeating raw open `bd create --ephemeral` producers.

Sheriff evidence was recorded on `gt-pr-sheriff-4289` and #4289. I rebuilt the reviewed railroad replacement onto current `origin/main` and squashed the WIP-named implementation commits into one clean contributor-attributed commit.

Verification on the clean current-main branch:
- `git diff --check origin/main...HEAD`
- `bash -n` for all modified plugin `run.sh` files
- `CGO_ENABLED=0 go test ./internal/plugin`
- `CGO_ENABLED=0 make build`

Original PR: #4289. Close #4289 as superseded after this lands.