### PR TITLE
fix: reconcile stale polecat recovery state

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -349,7 +349,7 @@ func init() {
 
 	// Check-recovery flags
 	polecatCheckRecoveryCmd.Flags().BoolVar(&polecatCheckRecoveryJSON, "json", false, "Output as JSON")
-	polecatCheckRecoveryCmd.Flags().BoolVar(&polecatCheckRecoveryReconcileCleanup, "reconcile-cleanup", false, "Safely rewrite stale cleanup_status=clean when live recovery predicates prove no work is at risk")
+	polecatCheckRecoveryCmd.Flags().BoolVar(&polecatCheckRecoveryReconcileCleanup, "reconcile-cleanup", false, "Safely rewrite stale dirty cleanup_status to clean when live recovery predicates prove no work is at risk")
 
 	// Stale flags
 	polecatStaleCmd.Flags().BoolVar(&polecatStaleJSON, "json", false, "Output as JSON")
@@ -1012,6 +1012,7 @@ type RecoveryStatus struct {
 	ActiveMR             string                `json:"active_mr,omitempty"`
 	Blockers             []string              `json:"blockers,omitempty"`
 	Diagnostics          []string              `json:"diagnostics,omitempty"`
+	RecoveryActions      []string              `json:"recovery_actions,omitempty"`
 	Reconciled           bool                  `json:"reconciled,omitempty"`
 }
 
@@ -1135,7 +1136,7 @@ func runPolecatCheckRecovery(cmd *cobra.Command, args []string) error {
 				loadGitState()
 			}
 			gitSafe := activeMRGitSafeForWorktree(p.ClonePath)
-			if staleCleanupStatusCanBeIgnoredForRecovery(input.CleanupStatus, workTerminal, hookSafe, !activeMRAssessment.Pending, gitSafe) {
+			if polecat.CanIgnoreStaleCleanupStatus(input.CleanupStatus, workTerminal, hookSafe, !activeMRAssessment.Pending, gitSafe) {
 				input.IgnoreCleanupStatus = true
 				status.Diagnostics = append(status.Diagnostics, fmt.Sprintf("ignored_stale_cleanup_status=%s direct_git_state=safe work_ref=terminal", input.CleanupStatus))
 			}
@@ -1195,6 +1196,13 @@ func runPolecatCheckRecovery(cmd *cobra.Command, args []string) error {
 			fmt.Printf("  %s Cleanup refused by these predicate(s):\n", style.Warning.Render("⚠"))
 			for _, blocker := range status.Blockers {
 				fmt.Printf("    - %s\n", blocker)
+			}
+			if len(status.RecoveryActions) > 0 {
+				fmt.Println()
+				fmt.Println("  Recovery action(s):")
+				for _, action := range status.RecoveryActions {
+					fmt.Printf("    - %s\n", action)
+				}
 			}
 		} else {
 			fmt.Printf("  %s Cleanup refused by an unknown recovery predicate.\n", style.Warning.Render("⚠"))
@@ -1263,6 +1271,7 @@ func applyWorkstateDispositionToRecoveryStatus(status *RecoveryStatus, dispositi
 	status.ReuseStatus = disposition.ReuseStatus
 	status.MQStatus = disposition.MQStatus
 	status.Blockers = disposition.Blockers
+	status.RecoveryActions = recoveryActionsForBlockers(disposition.Blockers)
 }
 
 type issueShower interface {
@@ -1297,14 +1306,6 @@ func agentHookBead(agentIssue *beads.Issue, fields *beads.AgentFields) string {
 		return fields.HookBead
 	}
 	return ""
-}
-
-func staleCleanupStatusCanBeIgnoredForRecovery(status polecat.CleanupStatus, workTerminal, hookSafe, activeMRSafe, gitSafe bool) bool {
-	return status == polecat.CleanupUnpushed &&
-		workTerminal &&
-		hookSafe &&
-		activeMRSafe &&
-		gitSafe
 }
 
 func activeMRGitSafeForWorktree(worktreePath string) bool {
@@ -1431,6 +1432,15 @@ func recoveryGitStateBlocker(worktreePath string, gitState *GitState, gitErr err
 		return fmt.Sprintf("git_state=has_stash stash_count=%d", gitState.StashCount)
 	}
 	return fmt.Sprintf("git_state=has_uncommitted uncommitted_files=%d", len(gitState.UncommittedFiles))
+}
+
+func recoveryActionsForBlockers(blockers []string) []string {
+	for _, blocker := range blockers {
+		if strings.HasPrefix(blocker, "git_state=has_stash") {
+			return []string{"preserve branch-owned stash entries to auditable recovery refs before cleanup, then rerun check-recovery"}
+		}
+	}
+	return nil
 }
 
 func activeMRBlocker(bd issueShower, mrID, sourceHint string, requireGitSafe, gitSafe bool) string {

--- a/internal/cmd/polecat_capacity.go
+++ b/internal/cmd/polecat_capacity.go
@@ -251,8 +251,6 @@ func applyAgentFieldsToCapacitySnapshot(snapshot *polecatCapacitySnapshot, rigPa
 	if fields.HookBead != "" || state == "working" || state == "spawning" {
 		if running {
 			snapshot.Working++
-		} else if applyCanonicalCapacitySnapshot(snapshot, rigPath, rigName, polecatName, fields, tmuxClient) {
-			return
 		} else {
 			snapshot.RecoveryBlocked++
 		}

--- a/internal/cmd/polecat_capacity.go
+++ b/internal/cmd/polecat_capacity.go
@@ -248,9 +248,19 @@ func applyAgentFieldsToCapacitySnapshot(snapshot *polecatCapacitySnapshot, rigPa
 	}
 
 	state := strings.TrimSpace(fields.AgentState)
-	if fields.HookBead != "" || state == "working" || state == "spawning" {
+	if state == "working" || state == "spawning" {
 		if running {
 			snapshot.Working++
+		} else {
+			snapshot.RecoveryBlocked++
+		}
+		return
+	}
+	if fields.HookBead != "" {
+		if running {
+			snapshot.Working++
+		} else if applyCanonicalCapacitySnapshot(snapshot, rigPath, rigName, polecatName, fields, tmuxClient) {
+			return
 		} else {
 			snapshot.RecoveryBlocked++
 		}

--- a/internal/cmd/polecat_capacity.go
+++ b/internal/cmd/polecat_capacity.go
@@ -11,7 +11,9 @@ import (
 	"github.com/gofrs/flock"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/git"
 	"github.com/steveyegge/gastown/internal/polecat"
+	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/scheduler/capacity"
 	"github.com/steveyegge/gastown/internal/session"
 	"github.com/steveyegge/gastown/internal/tmux"
@@ -196,7 +198,7 @@ func polecatCapacitySnapshotForTownNoCleanup(townRoot string) (polecatCapacitySn
 				fields = beads.ParseAgentFields(issue.Description)
 				fields.AgentState = beads.ResolveAgentState(issue.Description, issue.AgentState)
 			}
-			applyAgentFieldsToCapacitySnapshot(&snapshot, rigName, name, fields, tmuxClient)
+			applyAgentFieldsToCapacitySnapshot(&snapshot, rigPath, rigName, name, fields, tmuxClient)
 		}
 	}
 
@@ -231,7 +233,7 @@ func listPolecatDirectoryNames(rigPath string) ([]string, error) {
 	return names, nil
 }
 
-func applyAgentFieldsToCapacitySnapshot(snapshot *polecatCapacitySnapshot, rigName, polecatName string, fields *beads.AgentFields, tmuxClient *tmux.Tmux) {
+func applyAgentFieldsToCapacitySnapshot(snapshot *polecatCapacitySnapshot, rigPath, rigName, polecatName string, fields *beads.AgentFields, tmuxClient *tmux.Tmux) {
 	running := false
 	if tmuxClient != nil {
 		running, _ = tmuxClient.HasSession(session.PolecatSessionName(session.PrefixFor(rigName), polecatName))
@@ -249,6 +251,8 @@ func applyAgentFieldsToCapacitySnapshot(snapshot *polecatCapacitySnapshot, rigNa
 	if fields.HookBead != "" || state == "working" || state == "spawning" {
 		if running {
 			snapshot.Working++
+		} else if applyCanonicalCapacitySnapshot(snapshot, rigPath, rigName, polecatName, fields, tmuxClient) {
+			return
 		} else {
 			snapshot.RecoveryBlocked++
 		}
@@ -257,6 +261,11 @@ func applyAgentFieldsToCapacitySnapshot(snapshot *polecatCapacitySnapshot, rigNa
 	if fields.PushFailed || fields.MRFailed {
 		snapshot.RecoveryBlocked++
 		return
+	}
+	if fields.ActiveMR != "" || (fields.CleanupStatus != "" && fields.CleanupStatus != "clean") {
+		if applyCanonicalCapacitySnapshot(snapshot, rigPath, rigName, polecatName, fields, tmuxClient) {
+			return
+		}
 	}
 	if fields.ActiveMR != "" {
 		snapshot.PendingMR++
@@ -267,6 +276,24 @@ func applyAgentFieldsToCapacitySnapshot(snapshot *polecatCapacitySnapshot, rigNa
 		return
 	}
 	snapshot.RecoveryBlocked++
+}
+
+func applyCanonicalCapacitySnapshot(snapshot *polecatCapacitySnapshot, rigPath, rigName, polecatName string, fields *beads.AgentFields, tmuxClient *tmux.Tmux) bool {
+	if snapshot == nil || fields == nil || rigPath == "" {
+		return false
+	}
+	state := polecat.State(strings.TrimSpace(fields.AgentState))
+	if state == "" {
+		state = polecat.StateIdle
+	}
+	issueID := fields.LastSourceIssue
+	if issueID == "" {
+		issueID = fields.HookBead
+	}
+	mgr := polecat.NewManager(&rig.Rig{Name: rigName, Path: rigPath}, git.NewGit(rigPath), tmuxClient)
+	disposition := mgr.WorkstateDispositionForPolecat(polecatName, state, issueID)
+	applyWorkstateDispositionToCapacitySnapshot(snapshot, state, disposition)
+	return true
 }
 
 func applyWorkstateDispositionToCapacitySnapshot(snapshot *polecatCapacitySnapshot, state polecat.State, disposition polecat.WorkstateDisposition) {

--- a/internal/cmd/polecat_capacity_test.go
+++ b/internal/cmd/polecat_capacity_test.go
@@ -311,7 +311,7 @@ func TestApplyAgentFieldsToCapacitySnapshotSeparatesPendingMR(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			snapshot := polecatCapacitySnapshot{}
-			applyAgentFieldsToCapacitySnapshot(&snapshot, "gastown", "synth", tt.fields, nil)
+			applyAgentFieldsToCapacitySnapshot(&snapshot, "", "gastown", "synth", tt.fields, nil)
 			if snapshot.Working != tt.want.Working || snapshot.RecoveryBlocked != tt.want.RecoveryBlocked || snapshot.ReusableIdle != tt.want.ReusableIdle || snapshot.PendingMR != tt.want.PendingMR {
 				t.Fatalf("snapshot = %+v, want %+v", snapshot, tt.want)
 			}

--- a/internal/cmd/polecat_check_recovery_test.go
+++ b/internal/cmd/polecat_check_recovery_test.go
@@ -305,8 +305,26 @@ func TestStaleCleanupStatusCanBeIgnoredForRecovery(t *testing.T) {
 			activeMRSafe: true,
 		},
 		{
-			name:         "non-unpushed cleanup still blocks",
+			name:         "closed source with clean git ignores stale stash cleanup",
 			status:       polecat.CleanupStash,
+			workTerminal: true,
+			hookSafe:     true,
+			activeMRSafe: true,
+			gitSafe:      true,
+			wantCanSkip:  true,
+		},
+		{
+			name:         "closed source with clean git ignores stale uncommitted cleanup",
+			status:       polecat.CleanupUncommitted,
+			workTerminal: true,
+			hookSafe:     true,
+			activeMRSafe: true,
+			gitSafe:      true,
+			wantCanSkip:  true,
+		},
+		{
+			name:         "unknown cleanup still blocks",
+			status:       polecat.CleanupUnknown,
 			workTerminal: true,
 			hookSafe:     true,
 			activeMRSafe: true,
@@ -325,35 +343,39 @@ func TestStaleCleanupStatusCanBeIgnoredForRecovery(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := staleCleanupStatusCanBeIgnoredForRecovery(tt.status, tt.workTerminal, tt.hookSafe, tt.activeMRSafe, tt.gitSafe)
+			got := polecat.CanIgnoreStaleCleanupStatus(tt.status, tt.workTerminal, tt.hookSafe, tt.activeMRSafe, tt.gitSafe)
 			if got != tt.wantCanSkip {
-				t.Fatalf("staleCleanupStatusCanBeIgnoredForRecovery() = %v, want %v", got, tt.wantCanSkip)
+				t.Fatalf("CanIgnoreStaleCleanupStatus() = %v, want %v", got, tt.wantCanSkip)
 			}
 		})
 	}
 }
 
 func TestReconcileCleanupStatusIfSafe(t *testing.T) {
-	status := &RecoveryStatus{
-		CleanupStatus: polecat.CleanupUnpushed,
-		Verdict:       "SAFE_TO_NUKE",
-		Branch:        "polecat/nitro",
-		MQStatus:      "submitted",
-	}
-	updater := &fakeCleanupUpdater{}
-	reconcileCleanupStatusIfSafe(status, updater, "gt-gastown-polecat-nitro", &polecat.Polecat{State: polecat.StateIdle}, &beads.AgentFields{
-		AgentState:    string(beads.AgentStateIdle),
-		CleanupStatus: string(polecat.CleanupUnpushed),
-	})
+	for _, previous := range []polecat.CleanupStatus{polecat.CleanupUnpushed, polecat.CleanupStash, polecat.CleanupUncommitted} {
+		t.Run(string(previous), func(t *testing.T) {
+			status := &RecoveryStatus{
+				CleanupStatus: previous,
+				Verdict:       "SAFE_TO_NUKE",
+				Branch:        "polecat/nitro",
+				MQStatus:      "submitted",
+			}
+			updater := &fakeCleanupUpdater{}
+			reconcileCleanupStatusIfSafe(status, updater, "gt-gastown-polecat-nitro", &polecat.Polecat{State: polecat.StateIdle}, &beads.AgentFields{
+				AgentState:    string(beads.AgentStateIdle),
+				CleanupStatus: string(previous),
+			})
 
-	if updater.calls != 1 {
-		t.Fatalf("UpdateAgentCleanupStatus calls = %d, want 1", updater.calls)
-	}
-	if updater.id != "gt-gastown-polecat-nitro" || updater.status != string(polecat.CleanupClean) {
-		t.Fatalf("update = (%q, %q), want clean update for agent", updater.id, updater.status)
-	}
-	if status.CleanupStatus != polecat.CleanupClean || !status.Reconciled {
-		t.Fatalf("status after reconcile = (%q, reconciled=%v), want clean true", status.CleanupStatus, status.Reconciled)
+			if updater.calls != 1 {
+				t.Fatalf("UpdateAgentCleanupStatus calls = %d, want 1", updater.calls)
+			}
+			if updater.id != "gt-gastown-polecat-nitro" || updater.status != string(polecat.CleanupClean) {
+				t.Fatalf("update = (%q, %q), want clean update for agent", updater.id, updater.status)
+			}
+			if status.CleanupStatus != polecat.CleanupClean || !status.Reconciled {
+				t.Fatalf("status after reconcile = (%q, reconciled=%v), want clean true", status.CleanupStatus, status.Reconciled)
+			}
+		})
 	}
 }
 
@@ -518,6 +540,16 @@ func TestRecoveryGitStateBlocker(t *testing.T) {
 				t.Errorf("recoveryGitStateBlocker() = %q, want %q", got, tt.want)
 			}
 		})
+	}
+}
+
+func TestRecoveryActionsForBlockers(t *testing.T) {
+	actions := recoveryActionsForBlockers([]string{"git_state=has_stash stash_count=1"})
+	if len(actions) != 1 || !strings.Contains(actions[0], "preserve branch-owned stash") {
+		t.Fatalf("actions = %v, want branch stash preservation action", actions)
+	}
+	if actions := recoveryActionsForBlockers([]string{"cleanup_status=has_stash"}); len(actions) != 0 {
+		t.Fatalf("stale cleanup-only blocker actions = %v, want none", actions)
 	}
 }
 

--- a/internal/cmd/polecat_helpers.go
+++ b/internal/cmd/polecat_helpers.go
@@ -172,9 +172,9 @@ func checkPolecatSafety(target polecatTarget) *SafetyCheckResult {
 			if polecatInfo != nil {
 				gitSafe = activeMRGitSafeForWorktree(polecatInfo.ClonePath)
 			}
-			hookSafe, _, _ := hookBeadSafeForCleanup(bd, hookBead)
+			hookSafe, hookTerminal, _ := hookBeadSafeForCleanup(bd, hookBead)
 			activeMRSafe := !activeMRAssessment.Pending
-			if staleCleanupStatusCanBeIgnoredForRecovery(result.CleanupStatus, beadTerminal, hookSafe, activeMRSafe, gitSafe) {
+			if polecat.CanIgnoreStaleCleanupStatus(result.CleanupStatus, beadTerminal || hookTerminal, hookSafe, activeMRSafe, gitSafe) {
 				// OK: stale self-report after terminal source and direct clean git.
 			} else {
 				result.Reasons = append(result.Reasons, cleanupStatusBlocker(result.CleanupStatus))

--- a/internal/cmd/polecat_list_state_test.go
+++ b/internal/cmd/polecat_list_state_test.go
@@ -226,6 +226,19 @@ func TestWorkstateDispositionProjectionAgreement(t *testing.T) {
 			wantCapacity: polecatCapacitySnapshot{RecoveryBlocked: 1},
 		},
 		{
+			name:         "stale stash cleanup ignored is reusable capacity",
+			in:           polecat.WorkstateInput{State: polecat.StateIdle, CleanupStatus: polecat.CleanupStash, IgnoreCleanupStatus: true},
+			wantReusable: true,
+			wantSafe:     true,
+			wantCapacity: polecatCapacitySnapshot{ReusableIdle: 1},
+		},
+		{
+			name:         "live branch stash remains recovery blocked",
+			in:           polecat.WorkstateInput{State: polecat.StateIdle, CleanupStatus: polecat.CleanupClean, StashCount: 1},
+			wantRecovery: true,
+			wantCapacity: polecatCapacitySnapshot{RecoveryBlocked: 1},
+		},
+		{
 			name:         "needs mq submit",
 			in:           polecat.WorkstateInput{State: polecat.StateIdle, CleanupStatus: polecat.CleanupClean, Branch: "polecat/test", MQCheckRequired: true, HasSubmittableWork: true},
 			wantRecovery: true,

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -2186,11 +2186,16 @@ func (m *Manager) workstateInputForPolecat(name string, state State, issue strin
 	activeMR := ""
 	sourceHint := ""
 	_, fields, err := m.agentBeads().GetAgentBead(agentID)
+	hookSafe := true
+	hookTerminal := false
 	if err != nil {
 		input.GitCheckFailed = true
 	}
 	if err == nil && fields != nil {
-		input.HookBead = fields.HookBead
+		hookSafe, hookTerminal = m.hookBeadSafeForWorkstate(fields.HookBead)
+		if !hookSafe {
+			input.HookBead = fields.HookBead
+		}
 		input.PushFailed = fields.PushFailed
 		input.MRFailed = fields.MRFailed
 		input.ActiveMR = fields.ActiveMR
@@ -2237,17 +2242,25 @@ func (m *Manager) workstateInputForPolecat(name string, state State, issue strin
 	if input.CleanupStatus == CleanupUnknown && gitSafe {
 		input.CleanupStatus = CleanupClean
 	}
+	activeMRSafe := true
+	sourceTerminal := sourceHint != "" && m.assignedBeadTerminal(sourceHint)
 	if activeMR != "" {
 		assessment := AssessActiveMR(m.agentBeads(), ActiveMRInput{ActiveMR: activeMR, SourceIssueHint: sourceHint, RequireGitSafe: true, GitSafe: gitSafe})
 		if assessment.Pending {
 			input.ActiveMRBlocker = assessment.Reason
-		} else if input.CleanupStatus == CleanupUnpushed {
-			input.IgnoreCleanupStatus = true
+		}
+		activeMRSafe = !assessment.Pending
+		if assessment.SourceTerminal {
+			sourceTerminal = true
 		}
 	}
 	input.MQCheckRequired = input.Branch != ""
 	input.HasSubmittableWork = hasSubmittableWorkForWorkstate(clonePath)
 	input.AssignedBeadTerminal = m.assignedBeadTerminal(issue)
+	workTerminal := input.AssignedBeadTerminal || sourceTerminal || hookTerminal
+	if CanIgnoreStaleCleanupStatus(input.CleanupStatus, workTerminal, hookSafe, activeMRSafe, gitSafe) {
+		input.IgnoreCleanupStatus = true
+	}
 	input.MQNotRequired = m.mqNotRequiredSource(issue)
 	if input.MQCheckRequired && input.HasSubmittableWork && !input.AssignedBeadTerminal && !input.MQNotRequired {
 		mr, err := m.beads.FindMRForBranchAny(input.Branch)
@@ -2258,6 +2271,20 @@ func (m *Manager) workstateInputForPolecat(name string, state State, issue strin
 		}
 	}
 	return input
+}
+
+func (m *Manager) hookBeadSafeForWorkstate(hookBead string) (safe bool, terminal bool) {
+	if hookBead == "" {
+		return true, false
+	}
+	issue, err := m.beads.Show(hookBead)
+	if err != nil || issue == nil {
+		return false, false
+	}
+	if beads.IssueStatus(issue.Status).IsTerminal() {
+		return true, true
+	}
+	return false, false
 }
 
 func (m *Manager) assignedBeadTerminal(issueID string) bool {

--- a/internal/polecat/reuse_test.go
+++ b/internal/polecat/reuse_test.go
@@ -15,7 +15,7 @@ func TestDecideSlotReuse(t *testing.T) {
 		{name: "push failed", mutate: func(in *SlotReuseInput) { in.PushFailed = true }, want: "push-failed"},
 		{name: "mr failed", mutate: func(in *SlotReuseInput) { in.MRFailed = true }, want: "mr-failed"},
 		{name: "cleanup dirty", mutate: func(in *SlotReuseInput) { in.CleanupStatus = CleanupUnpushed }, want: "cleanup-has_unpushed"},
-		{name: "stale cleanup safe", mutate: func(in *SlotReuseInput) { in.CleanupStatus = CleanupUnpushed; in.IgnoreCleanupStatus = true }, want: "reusable"},
+		{name: "stale cleanup safe", mutate: func(in *SlotReuseInput) { in.CleanupStatus = CleanupStash; in.IgnoreCleanupStatus = true }, want: "reusable"},
 		{name: "cleanup unknown", mutate: func(in *SlotReuseInput) { in.CleanupStatus = CleanupUnknown }, want: "cleanup-unknown"},
 		{name: "git dirty", mutate: func(in *SlotReuseInput) { in.GitDirty = true }, want: "git-dirty"},
 		{name: "stash", mutate: func(in *SlotReuseInput) { in.StashCount = 1 }, want: "git-stash"},

--- a/internal/polecat/workstate.go
+++ b/internal/polecat/workstate.go
@@ -169,6 +169,22 @@ func DecideWorkstate(in WorkstateInput) WorkstateDisposition {
 	return d
 }
 
+// CanIgnoreStaleCleanupStatus returns true when a dirty persisted
+// cleanup_status is older than the direct predicates proving no work is at risk.
+// The status remains unsafe globally; callers must opt into this reconciliation
+// path only after gathering live git, hook, work, and active-MR facts.
+func CanIgnoreStaleCleanupStatus(status CleanupStatus, workTerminal, hookSafe, activeMRSafe, gitSafe bool) bool {
+	if !workTerminal || !hookSafe || !activeMRSafe || !gitSafe {
+		return false
+	}
+	switch status {
+	case CleanupUncommitted, CleanupStash, CleanupUnpushed:
+		return true
+	default:
+		return false
+	}
+}
+
 func itoa(n int) string {
 	if n == 0 {
 		return "0"

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -858,7 +858,10 @@ func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) 
 	hookSafe := true
 	hookTerminal := false
 	if fields != nil {
-		issueID = fields.HookBead
+		issueID = fields.LastSourceIssue
+		if issueID == "" {
+			issueID = fields.HookBead
+		}
 		if fields.HookBead != "" {
 			hookTerminal = witnessIssueTerminal(rigBeads, fields.HookBead)
 			hookSafe = hookTerminal
@@ -895,6 +898,7 @@ func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) 
 	}
 	gitSafe := !input.GitCheckFailed && !input.GitDirty && input.StashCount == 0 && input.UnpushedCommits == 0
 	activeMRSafe := true
+	sourceTerminal := fields != nil && issueID != "" && witnessIssueTerminal(rigBeads, issueID)
 	if fields != nil && fields.ActiveMR != "" {
 		sourceHint := fields.LastSourceIssue
 		if sourceHint == "" {
@@ -905,11 +909,14 @@ func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) 
 			input.ActiveMRBlocker = assessment.Reason
 		}
 		activeMRSafe = !assessment.Pending
+		if assessment.SourceTerminal {
+			sourceTerminal = true
+		}
 	}
 	input.MQCheckRequired = input.Branch != ""
 	input.HasSubmittableWork = witnessHasSubmittableWork(clonePath)
 	input.AssignedBeadTerminal = witnessIssueTerminal(rigBeads, issueID)
-	if polecat.CanIgnoreStaleCleanupStatus(input.CleanupStatus, input.AssignedBeadTerminal || hookTerminal, hookSafe, activeMRSafe, gitSafe) {
+	if polecat.CanIgnoreStaleCleanupStatus(input.CleanupStatus, input.AssignedBeadTerminal || sourceTerminal || hookTerminal, hookSafe, activeMRSafe, gitSafe) {
 		input.IgnoreCleanupStatus = true
 	}
 	input.MQNotRequired = witnessMQNotRequiredSource(rigBeads, issueID)

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -855,9 +855,17 @@ func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) 
 	_, fields, err := rigBeads.ForAgentBead().GetAgentBead(agentID)
 	input := polecat.SlotReuseInput{State: polecat.StateIdle, CleanupStatus: polecat.CleanupUnknown, GitCheckFailed: err != nil || fields == nil}
 	issueID := ""
+	hookSafe := true
+	hookTerminal := false
 	if fields != nil {
 		issueID = fields.HookBead
-		input.HookBead = fields.HookBead
+		if fields.HookBead != "" {
+			hookTerminal = witnessIssueTerminal(rigBeads, fields.HookBead)
+			hookSafe = hookTerminal
+			if !hookSafe {
+				input.HookBead = fields.HookBead
+			}
+		}
 		input.PushFailed = fields.PushFailed
 		input.MRFailed = fields.MRFailed
 		input.ActiveMR = fields.ActiveMR
@@ -885,8 +893,9 @@ func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) 
 	} else {
 		input.GitCheckFailed = true
 	}
+	gitSafe := !input.GitCheckFailed && !input.GitDirty && input.StashCount == 0 && input.UnpushedCommits == 0
+	activeMRSafe := true
 	if fields != nil && fields.ActiveMR != "" {
-		gitSafe := !input.GitCheckFailed && !input.GitDirty && input.StashCount == 0 && input.UnpushedCommits == 0
 		sourceHint := fields.LastSourceIssue
 		if sourceHint == "" {
 			sourceHint = fields.HookBead
@@ -894,13 +903,15 @@ func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) 
 		assessment := polecat.AssessActiveMR(beads.New(beads.ResolveBeadsDir(workDir)), polecat.ActiveMRInput{ActiveMR: fields.ActiveMR, SourceIssueHint: sourceHint, RequireGitSafe: true, GitSafe: gitSafe})
 		if assessment.Pending {
 			input.ActiveMRBlocker = assessment.Reason
-		} else if input.CleanupStatus == polecat.CleanupUnpushed {
-			input.IgnoreCleanupStatus = true
 		}
+		activeMRSafe = !assessment.Pending
 	}
 	input.MQCheckRequired = input.Branch != ""
 	input.HasSubmittableWork = witnessHasSubmittableWork(clonePath)
 	input.AssignedBeadTerminal = witnessIssueTerminal(rigBeads, issueID)
+	if polecat.CanIgnoreStaleCleanupStatus(input.CleanupStatus, input.AssignedBeadTerminal || hookTerminal, hookSafe, activeMRSafe, gitSafe) {
+		input.IgnoreCleanupStatus = true
+	}
 	input.MQNotRequired = witnessMQNotRequiredSource(rigBeads, issueID)
 	if input.MQCheckRequired && input.HasSubmittableWork && !input.AssignedBeadTerminal && !input.MQNotRequired {
 		mr, err := rigBeads.FindMRForBranchAny(input.Branch)


### PR DESCRIPTION
Replacement/fix PR for `gt-ow33`: converge Witness/polecat recovery reconciliation for stale cleanup state.

Summary:
- Reconciles stale hook/capacity state using direct workstate predicates.
- Keeps non-running working/spawning/hooked agents recovery-blocked instead of counting as reusable.
- Distinguishes terminal source work from real recovery risk.
- Preserves non-destructive behavior: no automatic stash deletion in this fix.

Evidence recorded on bead `gt-ow33`. Atom reported completion, but `gt done` push failed due Coder GitHub askpass; Mayor pushed the exact branch to the fork and opened this PR.

Verification from bead:
- Focused CGO_DISABLED cmd recovery/capacity tests pass.
- Focused witness slot gate tests pass.
- Normal Go test blocked locally by missing ICU linker libs.

CI may still show unrelated baseline failures; do not merge without normal Sheriff/Mayor disposition or explicit baseline-red waiver.