### PR TITLE
fix: resolve agent bead by role and rig

### DIFF
--- a/internal/cmd/agent_state.go
+++ b/internal/cmd/agent_state.go
@@ -37,18 +37,18 @@ Labels are stored as key:value pairs (e.g., idle:3, backoff:2m).
 
 OPERATIONS:
   Get all labels (default):
-    gt agent state <agent-bead>
+    gt agents state <agent-bead>
 
   Set a label:
-    gt agent state <agent-bead> --set idle=0
-    gt agent state <agent-bead> --set idle=0 --set backoff=30s
+    gt agents state <agent-bead> --set idle=0
+    gt agents state <agent-bead> --set idle=0 --set backoff=30s
 
   Increment a numeric label:
-    gt agent state <agent-bead> --incr idle
+    gt agents state <agent-bead> --incr idle
     (Creates label with value 1 if not present)
 
   Delete a label:
-    gt agent state <agent-bead> --del idle
+    gt agents state <agent-bead> --del idle
 
 COMMON LABELS:
   idle:<n>           - Consecutive idle patrol cycles
@@ -57,16 +57,16 @@ COMMON LABELS:
 
 EXAMPLES:
   # Check current idle count
-  gt agent state gt-gastown-witness
+  gt agents state gt-gastown-witness
 
   # Reset idle counter after finding work
-  gt agent state gt-gastown-witness --set idle=0
+  gt agents state gt-gastown-witness --set idle=0
 
   # Increment idle counter on timeout
-  gt agent state gt-gastown-witness --incr idle
+  gt agents state gt-gastown-witness --incr idle
 
   # Get state as JSON
-  gt agent state gt-gastown-witness --json`,
+  gt agents state gt-gastown-witness --json`,
 	Args: cobra.ExactArgs(1),
 	RunE: runAgentState,
 }

--- a/internal/cmd/agents_resolve.go
+++ b/internal/cmd/agents_resolve.go
@@ -73,7 +73,11 @@ func runAgentsResolve(cmd *cobra.Command, _ []string) error {
 	if err != nil {
 		return fmt.Errorf("getting working directory: %w", err)
 	}
-	currentBeadsDir := beads.ResolveBeadsDir(cwd)
+	workDir, err := findLocalBeadsDir()
+	if err != nil {
+		return err
+	}
+	currentBeadsDir := beads.ResolveBeadsDir(workDir)
 	if currentBeadsDir == "" {
 		return fmt.Errorf("not in a beads workspace")
 	}
@@ -107,6 +111,9 @@ func runAgentsResolve(cmd *cobra.Command, _ []string) error {
 			return NewSilentExit(1)
 		}
 		return fmt.Errorf("%s", message)
+	}
+	if rig != "" && agentBeadSourceIsTown(match.Source) && !agentsResolveJSON {
+		return fmt.Errorf("agent bead %s was found only in %s; patrol await/state commands require a rig-local agent bead", match.ID, match.Source)
 	}
 
 	if agentsResolveJSON {
@@ -166,18 +173,16 @@ func loadAgentBeadsFromDir(beadsDir string, issueSource, wispSource agentBeadSou
 		})
 	}
 
-	wisps, err := db.List(beads.ListOptions{Ephemeral: true, Label: "gt:agent", Status: "all"})
-	if err != nil {
-		return nil, fmt.Errorf("listing agent wisps in %s: %w", beadsDir, err)
-	}
-	for _, wisp := range wisps {
-		candidates = append(candidates, agentBeadCandidate{
-			ID:       wisp.ID,
-			Source:   wispSource,
-			BeadsDir: beadsDir,
-			Status:   wisp.Status,
-			Issue:    wisp,
-		})
+	if wisps, err := db.List(beads.ListOptions{Ephemeral: true, Label: "gt:agent", Status: "all"}); err == nil {
+		for _, wisp := range wisps {
+			candidates = append(candidates, agentBeadCandidate{
+				ID:       wisp.ID,
+				Source:   wispSource,
+				BeadsDir: beadsDir,
+				Status:   wisp.Status,
+				Issue:    wisp,
+			})
+		}
 	}
 
 	return candidates, nil
@@ -270,4 +275,8 @@ func agentBeadSourceRank(source agentBeadSource) int {
 	default:
 		return 99
 	}
+}
+
+func agentBeadSourceIsTown(source agentBeadSource) bool {
+	return source == agentSourceTownWisps || source == agentSourceTownIssues
 }

--- a/internal/cmd/agents_resolve.go
+++ b/internal/cmd/agents_resolve.go
@@ -1,0 +1,273 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/spf13/cobra"
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+var (
+	agentsResolveRole  string
+	agentsResolveRig   string
+	agentsResolveJSON  bool
+	agentsResolveQuiet bool
+)
+
+var agentsResolveCmd = &cobra.Command{
+	Use:   "resolve",
+	Short: "Resolve the active agent bead for a role",
+	Long: `Resolve the active agent bead for a role.
+
+The resolver searches the current rig database and the town database across
+both durable issues and ephemeral wisps. It prefers the current rig's wisp
+record, then rig issue, town wisp, and town issue. Closed beads are ignored.`,
+	RunE: runAgentsResolve,
+}
+
+func init() {
+	agentsResolveCmd.Flags().StringVar(&agentsResolveRole, "role", "", "Agent role to resolve (witness, refinery, crew, polecat, mayor, deacon)")
+	agentsResolveCmd.Flags().StringVar(&agentsResolveRig, "rig", "", "Rig name for rig-scoped roles")
+	agentsResolveCmd.Flags().BoolVar(&agentsResolveJSON, "json", false, "Output match provenance as JSON")
+	agentsResolveCmd.Flags().BoolVar(&agentsResolveQuiet, "quiet", false, "Suppress no-match diagnostics")
+	agentsCmd.AddCommand(agentsResolveCmd)
+}
+
+type agentBeadSource string
+
+const (
+	agentSourceRigWisps   agentBeadSource = "rig-wisps"
+	agentSourceRigIssues  agentBeadSource = "rig-issues"
+	agentSourceTownWisps  agentBeadSource = "town-wisps"
+	agentSourceTownIssues agentBeadSource = "town-issues"
+)
+
+type agentBeadCandidate struct {
+	ID       string
+	Source   agentBeadSource
+	BeadsDir string
+	Status   string
+	Issue    *beads.Issue
+}
+
+type agentsResolveResult struct {
+	ID       string `json:"id"`
+	Source   string `json:"source"`
+	BeadsDir string `json:"beads_dir"`
+	Status   string `json:"status"`
+}
+
+func runAgentsResolve(cmd *cobra.Command, _ []string) error {
+	role := strings.TrimSpace(agentsResolveRole)
+	rig := strings.TrimSpace(agentsResolveRig)
+	if role == "" {
+		return fmt.Errorf("--role is required")
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		return fmt.Errorf("getting working directory: %w", err)
+	}
+	currentBeadsDir := beads.ResolveBeadsDir(cwd)
+	if currentBeadsDir == "" {
+		return fmt.Errorf("not in a beads workspace")
+	}
+
+	candidates, err := findAgentBeadCandidates(cwd, currentBeadsDir)
+	if err != nil {
+		return err
+	}
+
+	var matches []agentBeadCandidate
+	for _, candidate := range candidates {
+		if agentBeadMatches(candidate.Issue, role, rig) {
+			matches = append(matches, candidate)
+		}
+	}
+
+	match, err := pickBestAgentBead(matches)
+	if err != nil {
+		return err
+	}
+	if match == nil {
+		message := fmt.Sprintf("no agent bead found for role %q", role)
+		if rig != "" {
+			message += fmt.Sprintf(" in rig %q", rig)
+		}
+		if agentsResolveJSON {
+			_ = json.NewEncoder(cmd.OutOrStdout()).Encode(map[string]string{"error": message})
+			return NewSilentExit(1)
+		}
+		if agentsResolveQuiet {
+			return NewSilentExit(1)
+		}
+		return fmt.Errorf("%s", message)
+	}
+
+	if agentsResolveJSON {
+		return json.NewEncoder(cmd.OutOrStdout()).Encode(agentsResolveResult{
+			ID:       match.ID,
+			Source:   string(match.Source),
+			BeadsDir: match.BeadsDir,
+			Status:   match.Status,
+		})
+	}
+
+	fmt.Fprintln(cmd.OutOrStdout(), match.ID)
+	return nil
+}
+
+func findAgentBeadCandidates(cwd, currentBeadsDir string) ([]agentBeadCandidate, error) {
+	var candidates []agentBeadCandidate
+
+	rigCandidates, err := loadAgentBeadsFromDir(currentBeadsDir, agentSourceRigIssues, agentSourceRigWisps)
+	if err != nil {
+		return nil, err
+	}
+	candidates = append(candidates, rigCandidates...)
+
+	townRoot := beads.FindTownRoot(cwd)
+	if townRoot == "" {
+		return candidates, nil
+	}
+	townBeadsDir := beads.ResolveBeadsDir(beads.GetTownBeadsPath(townRoot))
+	if townBeadsDir == "" || filepath.Clean(townBeadsDir) == filepath.Clean(currentBeadsDir) {
+		return candidates, nil
+	}
+
+	townCandidates, err := loadAgentBeadsFromDir(townBeadsDir, agentSourceTownIssues, agentSourceTownWisps)
+	if err != nil {
+		return nil, err
+	}
+	candidates = append(candidates, townCandidates...)
+	return candidates, nil
+}
+
+func loadAgentBeadsFromDir(beadsDir string, issueSource, wispSource agentBeadSource) ([]agentBeadCandidate, error) {
+	db := beads.NewWithBeadsDir(filepath.Dir(beadsDir), beadsDir)
+	var candidates []agentBeadCandidate
+
+	issues, err := listAgentIssues(db)
+	if err != nil {
+		return nil, fmt.Errorf("listing agent issues in %s: %w", beadsDir, err)
+	}
+	for _, issue := range issues {
+		candidates = append(candidates, agentBeadCandidate{
+			ID:       issue.ID,
+			Source:   issueSource,
+			BeadsDir: beadsDir,
+			Status:   issue.Status,
+			Issue:    issue,
+		})
+	}
+
+	wisps, err := db.List(beads.ListOptions{Ephemeral: true, Label: "gt:agent", Status: "all"})
+	if err != nil {
+		return nil, fmt.Errorf("listing agent wisps in %s: %w", beadsDir, err)
+	}
+	for _, wisp := range wisps {
+		candidates = append(candidates, agentBeadCandidate{
+			ID:       wisp.ID,
+			Source:   wispSource,
+			BeadsDir: beadsDir,
+			Status:   wisp.Status,
+			Issue:    wisp,
+		})
+	}
+
+	return candidates, nil
+}
+
+func listAgentIssues(db *beads.Beads) ([]*beads.Issue, error) {
+	out, err := db.Run("list", "--label=gt:agent", "--include-infra", "--status=all", "--json", "--flat", "--no-pager", "--limit=0")
+	if err != nil {
+		return nil, err
+	}
+	if len(out) == 0 || !json.Valid(out) {
+		return nil, nil
+	}
+
+	var issues []*beads.Issue
+	if err := json.Unmarshal(out, &issues); err != nil {
+		return nil, fmt.Errorf("parsing bd list output: %w", err)
+	}
+	return issues, nil
+}
+
+func agentBeadMatches(issue *beads.Issue, role, rig string) bool {
+	if issue == nil {
+		return false
+	}
+
+	fields := beads.ParseAgentFields(issue.Description)
+	if fields.RoleType == role {
+		if rig == "" || fields.Rig == rig {
+			return true
+		}
+	}
+
+	idRig, idRole, _, ok := beads.ParseAgentBeadID(issue.ID)
+	if !ok || idRole != role {
+		return false
+	}
+	if rig == "" {
+		return idRig == ""
+	}
+	return idRig == rig
+}
+
+func pickBestAgentBead(candidates []agentBeadCandidate) (*agentBeadCandidate, error) {
+	open := candidates[:0]
+	for _, candidate := range candidates {
+		if strings.EqualFold(candidate.Status, "closed") {
+			continue
+		}
+		open = append(open, candidate)
+	}
+	if len(open) == 0 {
+		return nil, nil
+	}
+
+	sort.Slice(open, func(i, j int) bool {
+		leftRank := agentBeadSourceRank(open[i].Source)
+		rightRank := agentBeadSourceRank(open[j].Source)
+		if leftRank != rightRank {
+			return leftRank < rightRank
+		}
+		return open[i].ID < open[j].ID
+	})
+
+	bestRank := agentBeadSourceRank(open[0].Source)
+	var sameRank []string
+	for _, candidate := range open {
+		if agentBeadSourceRank(candidate.Source) != bestRank {
+			break
+		}
+		sameRank = append(sameRank, candidate.ID)
+	}
+	if len(sameRank) > 1 {
+		return nil, fmt.Errorf("multiple matching agent beads in %s: %s", open[0].Source, strings.Join(sameRank, ", "))
+	}
+
+	return &open[0], nil
+}
+
+func agentBeadSourceRank(source agentBeadSource) int {
+	switch source {
+	case agentSourceRigWisps:
+		return 0
+	case agentSourceRigIssues:
+		return 1
+	case agentSourceTownWisps:
+		return 2
+	case agentSourceTownIssues:
+		return 3
+	default:
+		return 99
+	}
+}

--- a/internal/cmd/agents_resolve_test.go
+++ b/internal/cmd/agents_resolve_test.go
@@ -35,6 +35,15 @@ func TestAgentBeadMatchesDescriptionAndIDFallback(t *testing.T) {
 			want: true,
 		},
 		{
+			name: "collapsed prefix-rig ID fallback matches sparse metadata",
+			issue: &beads.Issue{
+				ID: "cp-refinery",
+			},
+			role: "refinery",
+			rig:  "cp",
+			want: true,
+		},
+		{
 			name: "role mismatch",
 			issue: &beads.Issue{
 				ID:          "gt-gastown-witness",

--- a/internal/cmd/agents_resolve_test.go
+++ b/internal/cmd/agents_resolve_test.go
@@ -1,0 +1,124 @@
+package cmd
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+func TestAgentBeadMatchesDescriptionAndIDFallback(t *testing.T) {
+	tests := []struct {
+		name  string
+		issue *beads.Issue
+		role  string
+		rig   string
+		want  bool
+	}{
+		{
+			name: "description matches legacy random wisp ID",
+			issue: &beads.Issue{
+				ID:          "au-wisp-0ti",
+				Description: "Agent\n\nrole_type: refinery\nrig: alleago_ui",
+			},
+			role: "refinery",
+			rig:  "alleago_ui",
+			want: true,
+		},
+		{
+			name: "canonical ID fallback matches sparse wisp metadata",
+			issue: &beads.Issue{
+				ID: "gt-gastown-witness",
+			},
+			role: "witness",
+			rig:  "gastown",
+			want: true,
+		},
+		{
+			name: "role mismatch",
+			issue: &beads.Issue{
+				ID:          "gt-gastown-witness",
+				Description: "Agent\n\nrole_type: witness\nrig: gastown",
+			},
+			role: "refinery",
+			rig:  "gastown",
+			want: false,
+		},
+		{
+			name: "rig mismatch",
+			issue: &beads.Issue{
+				ID:          "gt-gastown-refinery",
+				Description: "Agent\n\nrole_type: refinery\nrig: gastown",
+			},
+			role: "refinery",
+			rig:  "other",
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := agentBeadMatches(tt.issue, tt.role, tt.rig)
+			if got != tt.want {
+				t.Fatalf("agentBeadMatches() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestPickBestAgentBead(t *testing.T) {
+	candidates := []agentBeadCandidate{
+		candidate("town-issue", agentSourceTownIssues, "open"),
+		candidate("rig-issue", agentSourceRigIssues, "open"),
+		candidate("town-wisp", agentSourceTownWisps, "open"),
+		candidate("rig-wisp", agentSourceRigWisps, "open"),
+	}
+
+	got, err := pickBestAgentBead(candidates)
+	if err != nil {
+		t.Fatalf("pickBestAgentBead returned error: %v", err)
+	}
+	if got == nil || got.ID != "rig-wisp" {
+		t.Fatalf("pickBestAgentBead picked %v, want rig-wisp", got)
+	}
+}
+
+func TestPickBestAgentBeadSkipsClosed(t *testing.T) {
+	candidates := []agentBeadCandidate{
+		candidate("closed-rig-wisp", agentSourceRigWisps, "closed"),
+		candidate("open-rig-issue", agentSourceRigIssues, "open"),
+	}
+
+	got, err := pickBestAgentBead(candidates)
+	if err != nil {
+		t.Fatalf("pickBestAgentBead returned error: %v", err)
+	}
+	if got == nil || got.ID != "open-rig-issue" {
+		t.Fatalf("pickBestAgentBead picked %v, want open-rig-issue", got)
+	}
+}
+
+func TestPickBestAgentBeadRejectsSameRankDuplicates(t *testing.T) {
+	candidates := []agentBeadCandidate{
+		candidate("rig-wisp-a", agentSourceRigWisps, "open"),
+		candidate("rig-wisp-b", agentSourceRigWisps, "open"),
+		candidate("rig-issue", agentSourceRigIssues, "open"),
+	}
+
+	got, err := pickBestAgentBead(candidates)
+	if err == nil {
+		t.Fatalf("pickBestAgentBead picked %v, want duplicate error", got)
+	}
+	if !strings.Contains(err.Error(), "multiple matching agent beads") {
+		t.Fatalf("error = %q, want duplicate diagnostic", err)
+	}
+}
+
+func candidate(id string, source agentBeadSource, status string) agentBeadCandidate {
+	return agentBeadCandidate{
+		ID:     id,
+		Source: source,
+		Status: status,
+		Issue:  &beads.Issue{ID: id, Status: status},
+	}
+}

--- a/internal/cmd/molecule_await_signal.go
+++ b/internal/cmd/molecule_await_signal.go
@@ -67,7 +67,7 @@ EXAMPLES:
     --backoff-base 30s --backoff-mult 2 --backoff-max 15m
 
   # On timeout, the agent bead's idle:N label is auto-incremented
-  # On signal, caller should reset: gt agent state gt-gastown-witness --set idle=0
+  # On signal, caller should reset: gt agents state gt-gastown-witness --set idle=0
 
   # Quiet mode (no output, for scripting)
   gt mol await-signal --timeout 30s --quiet`,
@@ -320,7 +320,9 @@ func runMoleculeAwaitSignal(cmd *cobra.Command, args []string) error {
 
 // calculateEffectiveTimeout determines the timeout based on flags.
 // If backoff parameters are provided, uses exponential backoff formula:
-//   min(base * multiplier^idleCycles, max)
+//
+//	min(base * multiplier^idleCycles, max)
+//
 // Otherwise uses the simple --timeout value.
 func calculateEffectiveTimeout(idleCycles int) (time.Duration, error) {
 	// If backoff base is set, use backoff mode

--- a/internal/formula/formulas/mol-deacon-patrol.formula.toml
+++ b/internal/formula/formulas/mol-deacon-patrol.formula.toml
@@ -1215,7 +1215,7 @@ This command:
 **On signal received** (activity detected):
 Reset the idle counter and start next patrol cycle:
 ```bash
-gt agent state hq-deacon --set idle=0
+gt agents state hq-deacon --set idle=0
 ```
 
 **On timeout** (no activity):

--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -1121,11 +1121,11 @@ End of patrol cycle decision. Use the signals from context-check to decide.
 
 **If you decide to continue patrolling:**
 
-Resolve your agent bead ID for this patrol cycle. You MUST replace `<YOUR_RIG>` below with your actual rig name (e.g., `beads`, `town`) before running:
+Resolve your agent bead ID for this patrol cycle:
 ```bash
-YOUR_AGENT_BEAD=$(gt agents resolve --role refinery --rig <YOUR_RIG>)
+YOUR_AGENT_BEAD=$(gt agents resolve --role refinery --rig {{rig}})
 ```
-This must resolve exactly one bead ID. If it fails, STOP and report the error — verify you substituted `<YOUR_RIG>` correctly. If it reports multiple results, STOP and report the ambiguity — manual disambiguation is required. Use the resolved `YOUR_AGENT_BEAD` in the commands below.
+This must resolve exactly one bead ID. If it fails, STOP and report the error. If it reports multiple results, STOP and report the ambiguity — manual disambiguation is required. Use the resolved `YOUR_AGENT_BEAD` in the commands below.
 
 Then use await-event to subscribe to the refinery event channel with exponential backoff:
 
@@ -1156,7 +1156,7 @@ This command:
 **On event received** (refinery-specific activity):
 Reset the idle counter and start next patrol cycle:
 ```bash
-gt agent state "$YOUR_AGENT_BEAD" --set idle=0
+gt agents state "$YOUR_AGENT_BEAD" --set idle=0
 ```
 
 **On timeout** (no events):

--- a/internal/formula/formulas/mol-refinery-patrol.formula.toml
+++ b/internal/formula/formulas/mol-refinery-patrol.formula.toml
@@ -107,7 +107,7 @@ When `await-event` outputs `EFFORT: full`, run all steps thoroughly (normal mode
 
 The goal: idle cycles should burn ~10% of the tokens a full patrol uses."""
 formula = "mol-refinery-patrol"
-version = 14
+version = 15
 
 [vars]
 [vars.wisp_type]
@@ -1123,14 +1123,14 @@ End of patrol cycle decision. Use the signals from context-check to decide.
 
 Resolve your agent bead ID for this patrol cycle. You MUST replace `<YOUR_RIG>` below with your actual rig name (e.g., `beads`, `town`) before running:
 ```bash
-bd list --label=gt:agent --desc-contains="role_type: refinery" --json | jq -r '.[] | select(.status != "closed") | select(.description | test("(?m)^\\\\s*rig: <YOUR_RIG>\\\\s*$")) | .id'
+YOUR_AGENT_BEAD=$(gt agents resolve --role refinery --rig <YOUR_RIG>)
 ```
-This must return exactly one bead ID. If it returns zero results, STOP and report an error — verify you substituted `<YOUR_RIG>` correctly. If it returns multiple results, STOP and report an error — manual disambiguation is required. Use the single resolved bead ID as YOUR_AGENT_BEAD in the commands below.
+This must resolve exactly one bead ID. If it fails, STOP and report the error — verify you substituted `<YOUR_RIG>` correctly. If it reports multiple results, STOP and report the ambiguity — manual disambiguation is required. Use the resolved `YOUR_AGENT_BEAD` in the commands below.
 
 Then use await-event to subscribe to the refinery event channel with exponential backoff:
 
 ```bash
-gt mol step await-event --channel refinery --agent-bead YOUR_AGENT_BEAD \
+gt mol step await-event --channel refinery --agent-bead "$YOUR_AGENT_BEAD" \
   --backoff-base 30s --backoff-mult 2 --backoff-max 15m --cleanup \
   --context-check-interval 5m
 ```
@@ -1156,7 +1156,7 @@ This command:
 **On event received** (refinery-specific activity):
 Reset the idle counter and start next patrol cycle:
 ```bash
-gt agent state YOUR_AGENT_BEAD --set idle=0
+gt agent state "$YOUR_AGENT_BEAD" --set idle=0
 ```
 
 **On timeout** (no events):

--- a/internal/formula/formulas/mol-witness-patrol.formula.toml
+++ b/internal/formula/formulas/mol-witness-patrol.formula.toml
@@ -99,7 +99,7 @@ This command:
 **On signal received** (activity detected):
 Reset the idle counter and start next patrol cycle:
 ```bash
-gt agent state "$YOUR_AGENT_BEAD" --set idle=0
+gt agents state "$YOUR_AGENT_BEAD" --set idle=0
 ```
 
 **On timeout** (no activity):

--- a/internal/formula/formulas/mol-witness-patrol.formula.toml
+++ b/internal/formula/formulas/mol-witness-patrol.formula.toml
@@ -1,6 +1,6 @@
 description = "Per-rig worker monitor patrol loop.\n\nThe Witness is the Pit Boss for your rig. You watch polecats, nudge them toward\ncompletion, verify clean git state before kills, and escalate stuck workers.\n\n**You do NOT do implementation work.** Your job is oversight, not coding.\n\n## Persistent Polecat Model (gt-4ac)\n\nPolecats persist after work completion — sandbox is preserved for reuse:\n\n```\nPolecat lifecycle: spawning → working → mr_submitted → idle (sandbox preserved)\nMR lifecycle:      created → queued → processed → merged (Refinery handles)\n```\n\nOnce a polecat calls gt done and submits an MR, it transitions to idle state.\nThe MR lifecycle continues independently in the Refinery. The polecat is NOT\nnuked — its sandbox is preserved for reuse by future slings.\n\n**CRITICAL**: Do NOT nuke polecats with pending MRs. The refinery needs the\nremote branch to exist to process the merge. Nuking deletes the remote branch\nand orphans the MR. See gt-6a9d.\n\n**Key principle**: Polecat lifecycle is separate from MR lifecycle. Polecats\ngo idle after work, they are NOT destroyed.\n\n## Restart-First Policy (gt-dsgp)\n\nThe witness NEVER nukes polecats automatically. When a polecat is stuck, hung,\nor has a dead agent process, the witness RESTARTS the session instead of nuking.\nThis preserves the polecat's worktree and branch, preventing work loss.\n\n- Dead agent process → restart session\n- Hung session (no output 30+ min) → restart session\n- Stuck in gt done → restart session\n- Done polecat (bead closed) → leave alone (sandbox preserved)\n- Polecat with pending MR → leave alone (refinery handles)\n\nNuking only happens via explicit `gt polecat nuke` command from a human or Mayor.\n\n## Design Philosophy\n\nThis patrol follows Gas Town principles:\n- **Discovery over tracking**: Observe reality each cycle, with minimal agent-bead state for duration tracking\n- **Beads over mail**: survey-workers discovers completion state from agent bead metadata (gt-w0br); inbox-check POLECAT_DONE is fallback only\n- **Persistent by default**: Clean polecats go idle, sandbox preserved for reuse (gt-4ac)\n- **Cleanup wisps for merge tracking**: Created when MR is pending in refinery\n- **Task tool for parallelism**: Subagents inspect polecats, not molecule arms\n- **Swim lane discipline**: Only close wisps YOU created. Wisp lifecycle for non-witness wisps is the reaper Dog's job. Report orphaned foreign wisps — never close them.\n\n## Patrol Shape (Linear)\n\n```\ninbox-check ─► process-cleanups ─► check-refinery ─► survey-workers\n                                                            │\n         ┌──────────────────────────────────────────────────┘\n         ▼\n  check-timer-gates ─► check-swarm ─► patrol-cleanup ─► context-check ─► loop-or-exit\n```\n\nNo dynamic arms. No fanout gates. No persistent nudge counters.\nState is discovered each cycle from reality (tmux, beads, mail).\n\n## Abbreviated Patrol Mode (Idle Effort Tuning)\n\nWhen `await-signal` outputs `EFFORT: reduced`, run an ABBREVIATED patrol.\nThis happens when idle_cycles >= {{idle_effort_threshold}} (no activity detected).\n\nAbbreviated patrol rules:\n- **inbox-check**: Run `gt mail drain` only. Skip individual message processing unless drain reports new HELP messages.\n- **process-cleanups**: Skip entirely (say \"Abbreviated: skipping cleanups\").\n- **check-refinery**: Quick `gt session status` checks only. Skip queue health analysis and deacon health.\n- **survey-workers**: Run `gt patrol scan --notify` only. Skip orphaned bead detection.\n- **check-timer-gates**: Skip entirely.\n- **check-swarm-completion**: Skip entirely.\n- **patrol-cleanup**: Skip entirely.\n- **context-check**: Quick self-assessment only (one sentence).\n- **loop-or-exit**: Normal (await-signal as usual).\n\nWhen `await-signal` outputs `EFFORT: full`, run all steps thoroughly (normal mode).\n\nThe goal: idle cycles should burn ~10% of the tokens a full patrol uses."
 formula = 'mol-witness-patrol'
-version = 12
+version = 13
 
 [vars]
 [vars.wisp_type]
@@ -67,7 +67,88 @@ needs = ['patrol-cleanup']
 title = 'Check own context limit'
 
 [[steps]]
-description = "End of patrol cycle decision.\n\n**If context LOW** (can continue patrolling):\n\nResolve your agent bead ID for this patrol cycle. Verify your agent bead exists before subscribing:\n```bash\nbd list --label=gt:agent --desc-contains=\"role_type: witness\" --json | jq -r '.[] | select(.status != \"closed\") | select(.description | test(\"(?m)^\\\\s*rig: {{rig}}\\\\s*$\")) | .id'\n```\nThis must return exactly one bead ID. If it returns zero results, STOP and report an error. If it returns multiple results, STOP and report an error — manual disambiguation is required.\n\nThen use await-signal with exponential backoff to wait for activity:\n\n```bash\ngt mol step await-signal --agent-bead {{prefix}}-{{rig}}-witness \\\n  --backoff-base 30s --backoff-mult 2 --backoff-max 5m\n```\n\nThis command:\n1. Subscribes to `bd activity --follow` (beads activity feed)\n2. Returns IMMEDIATELY when any beads activity occurs\n3. If no activity, times out with exponential backoff:\n   - First timeout: 30s\n   - Second timeout: 60s\n   - Third timeout: 120s\n   - ...capped at 5 minutes max\n4. Tracks `idle:N` label on your agent bead for backoff state\n5. Outputs `EFFORT: reduced` or `EFFORT: full` directive for next cycle\n\n**On signal received** (activity detected):\nReset the idle counter and start next patrol cycle:\n```bash\ngt agent state {{prefix}}-{{rig}}-witness --set idle=0\n```\n\n**On timeout** (no activity):\nThe idle counter was auto-incremented. Continue to next patrol cycle\n(the longer backoff will apply next time).\n\n## Effort-Based Patrol Routing\n\nAfter await-signal returns, check the EFFORT directive in the output:\n\n**If `EFFORT: full`** — Run all steps thoroughly (normal patrol).\n\n**If `EFFORT: reduced`** — Run ABBREVIATED patrol:\n- inbox-check: `gt mail drain` only, skip individual messages unless HELP found\n- process-cleanups: SKIP\n- check-refinery: Quick session status checks only\n- survey-workers: `gt patrol scan --notify` only, skip orphan bead detection\n- check-timer-gates: SKIP\n- check-swarm-completion: SKIP\n- patrol-cleanup: SKIP\n- context-check: One-sentence self-assessment\n\nAbbreviated patrol should complete in ~10% of the tokens of a full patrol.\nMark skipped steps as SKIP in the patrol report.\n\nAfter await-signal returns (either by signal or timeout):\n1. Generate a brief summary of this patrol cycle's observations\n2. Close current patrol and start next cycle:\n```bash\ngt patrol report --summary \"<brief summary of patrol observations>\"\n```\nThis closes the current patrol wisp and automatically creates a new one.\n3. Continue executing from the first step of the new patrol cycle\n\n**If context HIGH** (approaching limit):\n1. Write handoff mail with notable observations:\n```bash\ngt handoff -s \"Witness patrol handoff\" -m \"<observations>\"\n```\n2. Exit cleanly - the daemon will respawn a fresh Witness session\n\n**NOTE (gt-058d)**: `gt handoff` enforces a minimum 2-minute cooldown between\nhandoffs. If the previous handoff was less than 2 minutes ago, the command\nwill sleep until the cooldown expires before proceeding. This prevents tight\nrestart loops when the rig is idle and patrols complete quickly.\n\n**IMPORTANT**: You must either report and loop (context LOW) or exit (context HIGH).\nNever leave the session idle without work on your hook."
+description = """
+End of patrol cycle decision.
+
+**If context LOW** (can continue patrolling):
+
+Resolve your agent bead ID for this patrol cycle. Verify your agent bead exists before subscribing:
+```bash
+YOUR_AGENT_BEAD=$(gt agents resolve --role witness --rig {{rig}})
+```
+This must resolve exactly one bead ID. If it fails, STOP and report the error. If it reports multiple results, STOP and report the ambiguity — manual disambiguation is required.
+
+Then use await-signal with exponential backoff to wait for activity:
+
+```bash
+gt mol step await-signal --agent-bead "$YOUR_AGENT_BEAD" \
+  --backoff-base 30s --backoff-mult 2 --backoff-max 5m
+```
+
+This command:
+1. Subscribes to `bd activity --follow` (beads activity feed)
+2. Returns IMMEDIATELY when any beads activity occurs
+3. If no activity, times out with exponential backoff:
+   - First timeout: 30s
+   - Second timeout: 60s
+   - Third timeout: 120s
+   - ...capped at 5 minutes max
+4. Tracks `idle:N` label on your agent bead for backoff state
+5. Outputs `EFFORT: reduced` or `EFFORT: full` directive for next cycle
+
+**On signal received** (activity detected):
+Reset the idle counter and start next patrol cycle:
+```bash
+gt agent state "$YOUR_AGENT_BEAD" --set idle=0
+```
+
+**On timeout** (no activity):
+The idle counter was auto-incremented. Continue to next patrol cycle
+(the longer backoff will apply next time).
+
+## Effort-Based Patrol Routing
+
+After await-signal returns, check the EFFORT directive in the output:
+
+**If `EFFORT: full`** — Run all steps thoroughly (normal patrol).
+
+**If `EFFORT: reduced`** — Run ABBREVIATED patrol:
+- inbox-check: `gt mail drain` only, skip individual messages unless HELP found
+- process-cleanups: SKIP
+- check-refinery: Quick session status checks only
+- survey-workers: `gt patrol scan --notify` only, skip orphan bead detection
+- check-timer-gates: SKIP
+- check-swarm-completion: SKIP
+- patrol-cleanup: SKIP
+- context-check: One-sentence self-assessment
+
+Abbreviated patrol should complete in ~10% of the tokens of a full patrol.
+Mark skipped steps as SKIP in the patrol report.
+
+After await-signal returns (either by signal or timeout):
+1. Generate a brief summary of this patrol cycle's observations
+2. Close current patrol and start next cycle:
+```bash
+gt patrol report --summary "<brief summary of patrol observations>"
+```
+This closes the current patrol wisp and automatically creates a new one.
+3. Continue executing from the first step of the new patrol cycle
+
+**If context HIGH** (approaching limit):
+1. Write handoff mail with notable observations:
+```bash
+gt handoff -s "Witness patrol handoff" -m "<observations>"
+```
+2. Exit cleanly - the daemon will respawn a fresh Witness session
+
+**NOTE (gt-058d)**: `gt handoff` enforces a minimum 2-minute cooldown between
+handoffs. If the previous handoff was less than 2 minutes ago, the command
+will sleep until the cooldown expires before proceeding. This prevents tight
+restart loops when the rig is idle and patrols complete quickly.
+
+**IMPORTANT**: You must either report and loop (context LOW) or exit (context HIGH).
+Never leave the session idle without work on your hook.
+"""
 id = 'loop-or-exit'
 needs = ['context-check']
 title = 'Loop or exit for respawn'

--- a/internal/formula/patrol_backoff_test.go
+++ b/internal/formula/patrol_backoff_test.go
@@ -218,6 +218,10 @@ func TestPatrolFormulasUseDynamicBeadResolution(t *testing.T) {
 		"mol-witness-patrol.formula.toml",
 		"mol-refinery-patrol.formula.toml",
 	}
+	expectedResolver := map[string]string{
+		"mol-witness-patrol.formula.toml":  "YOUR_AGENT_BEAD=$(gt agents resolve --role witness --rig {{rig}})",
+		"mol-refinery-patrol.formula.toml": "YOUR_AGENT_BEAD=$(gt agents resolve --role refinery --rig {{rig}})",
+	}
 
 	for _, name := range patrolFormulas {
 		t.Run(name, func(t *testing.T) {
@@ -246,7 +250,7 @@ func TestPatrolFormulasUseDynamicBeadResolution(t *testing.T) {
 			// Must use dynamic resolution through the agent resolver. The older
 			// bd-list query only sees one table in one DB and misses wisp-backed
 			// or town-stranded agent beads.
-			if !strings.Contains(loopDesc, "YOUR_AGENT_BEAD=$(gt agents resolve") {
+			if !strings.Contains(loopDesc, expectedResolver[name]) {
 				t.Errorf("%s loop step missing dynamic agent bead resolution via gt agents resolve.\n"+
 					"Agent bead IDs must be resolved at runtime, not hardcoded.\n"+
 					"See hq-9xs.",
@@ -255,7 +259,7 @@ func TestPatrolFormulasUseDynamicBeadResolution(t *testing.T) {
 			if !strings.Contains(loopDesc, `--agent-bead "$YOUR_AGENT_BEAD"`) {
 				t.Errorf("%s loop step must pass the resolved agent bead to await", name)
 			}
-			if !strings.Contains(loopDesc, `gt agent state "$YOUR_AGENT_BEAD" --set idle=0`) {
+			if !strings.Contains(loopDesc, `gt agents state "$YOUR_AGENT_BEAD" --set idle=0`) {
 				t.Errorf("%s loop step must reset state on the resolved agent bead", name)
 			}
 			if strings.Contains(loopDesc, "bd list --label=gt:agent") {

--- a/internal/formula/patrol_backoff_test.go
+++ b/internal/formula/patrol_backoff_test.go
@@ -206,8 +206,8 @@ func TestDeaconPatrolDoesNotRunAgeBasedWispGC(t *testing.T) {
 }
 
 // TestPatrolFormulasUseDynamicBeadResolution verifies that patrol formulas
-// resolve their agent bead ID dynamically at runtime via `bd list`, rather
-// than hardcoding a prefix like `gt-<rig>-refinery`.
+// resolve their agent bead ID dynamically at runtime via `gt agents resolve`,
+// rather than hardcoding a prefix like `gt-<rig>-refinery`.
 //
 // Hardcoded IDs break when AgentBeadIDWithPrefix collapses the rig component
 // (prefix == rig), producing e.g. "cp-refinery" instead of "gt-cp-refinery".
@@ -243,12 +243,26 @@ func TestPatrolFormulasUseDynamicBeadResolution(t *testing.T) {
 				t.Fatalf("%s: loop step not found or has empty description", name)
 			}
 
-			// Must use dynamic resolution via bd list
-			if !strings.Contains(loopDesc, "bd list --label=gt:agent") {
-				t.Errorf("%s loop step missing dynamic agent bead resolution (bd list --label=gt:agent).\n"+
+
+			// Must use dynamic resolution through the agent resolver. The older
+			// bd-list query only sees one table in one DB and misses wisp-backed
+			// or town-stranded agent beads.
+			if !strings.Contains(loopDesc, "YOUR_AGENT_BEAD=$(gt agents resolve") {
+				t.Errorf("%s loop step missing dynamic agent bead resolution via gt agents resolve.\n"+
 					"Agent bead IDs must be resolved at runtime, not hardcoded.\n"+
 					"See hq-9xs.",
 					name)
+			}
+			if !strings.Contains(loopDesc, `--agent-bead "$YOUR_AGENT_BEAD"`) &&
+				!strings.Contains(loopDesc, `--agent-bead "$YOUR_AGENT_BEAD"`) &&
+				!strings.Contains(loopDesc, `--agent-bead "$YOUR_AGENT_BEAD"`) {
+				t.Errorf("%s loop step must pass the resolved agent bead to await", name)
+			}
+			if !strings.Contains(loopDesc, `gt agent state "$YOUR_AGENT_BEAD" --set idle=0`) {
+				t.Errorf("%s loop step must reset state on the resolved agent bead", name)
+			}
+			if strings.Contains(loopDesc, "bd list --label=gt:agent") {
+				t.Errorf("%s loop step still uses legacy bd-list agent resolution", name)
 			}
 
 			// Must NOT hardcode gt-<rig> prefix pattern
@@ -257,6 +271,9 @@ func TestPatrolFormulasUseDynamicBeadResolution(t *testing.T) {
 					"This breaks when AgentBeadIDWithPrefix collapses the ID (prefix == rig).\n"+
 					"See hq-9xs.",
 					name)
+			}
+			if strings.Contains(loopDesc, "{{prefix}}-{{rig}}-witness") || strings.Contains(loopDesc, "{{prefix}}-{{rig}}-refinery") {
+				t.Errorf("%s loop step hardcodes prefix/rig agent bead instead of resolved ID", name)
 			}
 		})
 	}

--- a/internal/formula/patrol_backoff_test.go
+++ b/internal/formula/patrol_backoff_test.go
@@ -243,7 +243,6 @@ func TestPatrolFormulasUseDynamicBeadResolution(t *testing.T) {
 				t.Fatalf("%s: loop step not found or has empty description", name)
 			}
 
-
 			// Must use dynamic resolution through the agent resolver. The older
 			// bd-list query only sees one table in one DB and misses wisp-backed
 			// or town-stranded agent beads.
@@ -253,9 +252,7 @@ func TestPatrolFormulasUseDynamicBeadResolution(t *testing.T) {
 					"See hq-9xs.",
 					name)
 			}
-			if !strings.Contains(loopDesc, `--agent-bead "$YOUR_AGENT_BEAD"`) &&
-				!strings.Contains(loopDesc, `--agent-bead "$YOUR_AGENT_BEAD"`) &&
-				!strings.Contains(loopDesc, `--agent-bead "$YOUR_AGENT_BEAD"`) {
+			if !strings.Contains(loopDesc, `--agent-bead "$YOUR_AGENT_BEAD"`) {
 				t.Errorf("%s loop step must pass the resolved agent bead to await", name)
 			}
 			if !strings.Contains(loopDesc, `gt agent state "$YOUR_AGENT_BEAD" --set idle=0`) {


### PR DESCRIPTION
Clean replacement/fixup for PR #4064 via `gt-pr-sheriff-4064-refresh`.

Summary:
- Adds `gt agents resolve` using internal beads issue + ephemeral query paths.
- Updates patrol formulas to resolve and use `YOUR_AGENT_BEAD`.
- Adds focused tests rejecting legacy bd-list/hardcoded agent IDs.

Sheriff evidence recorded on `gt-pr-sheriff-4064-refresh`:
- 15 research legs completed.
- 5 pre-implementation reviews completed.
- 5 post-implementation reviews completed.
- Focused verification passed: `go test ./internal/formula`, `CGO_ENABLED=0 go test ./internal/cmd -run TestAgentBead|TestPickBestAgentBead`, and `CGO_ENABLED=0 go run ./cmd/gt agents resolve --role refinery --rig gastown --json`.
- Full normal test was blocked locally by missing ICU linker libs, unrelated environment dependency.

Original PR #4064 should remain review-failed/superseded after this replacement lands. Do not merge without normal Sheriff/Mayor disposition or explicit baseline-red waiver if CI is unrelated red.