### PR TITLE
fix: dispatch queued work after slot-open fallback

### DIFF
--- a/internal/beads/beads_sling_context.go
+++ b/internal/beads/beads_sling_context.go
@@ -92,29 +92,13 @@ func (b *Beads) FindOpenSlingContext(workBeadID string) (*Issue, *capacity.Sling
 
 // ListOpenSlingContexts returns all open sling context beads.
 func (b *Beads) ListOpenSlingContexts() ([]*Issue, error) {
-	out, err := b.run("list",
-		"--label="+capacity.LabelSlingContext,
-		"--status=open",
-		"--json",
-		"--limit=0",
-	)
-	if err != nil {
-		return nil, err
-	}
-
-	// Handle empty output or non-JSON responses.
-	// bd list --json may return plain text like "No issues found." instead
-	// of an empty JSON array when there are no results.
-	if len(out) == 0 || !isJSONBytes(out) {
-		return nil, nil
-	}
-
-	var issues []*Issue
-	if err := json.Unmarshal(out, &issues); err != nil {
-		return nil, fmt.Errorf("parsing sling context list: %w", err)
-	}
-
-	return issues, nil
+	return b.List(ListOptions{
+		Status:    "open",
+		Label:     capacity.LabelSlingContext,
+		Priority:  -1,
+		Limit:     0,
+		Ephemeral: true,
+	})
 }
 
 // CloseSlingContext closes a sling context bead with a reason.

--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -443,6 +443,16 @@ func TestSchedulerBlockedStatusReporting(t *testing.T) {
 	if !foundBlocked {
 		t.Fatalf("unblocked queued bead %s not found in scheduler list", blockedID)
 	}
+	contextCount := 0
+	for _, ctx := range listAllSlingContexts(hqPath) {
+		fields := beads.ParseSlingContextFields(ctx.Description)
+		if fields != nil && fields.WorkBeadID == blockedID {
+			contextCount++
+		}
+	}
+	if contextCount != 1 {
+		t.Fatalf("open sling contexts for %s = %d, want 1", blockedID, contextCount)
+	}
 
 	status = getSchedulerStatus(t, gtBinary, hqPath, env)
 	total = int(status["queued_total"].(float64))

--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -418,6 +418,46 @@ func TestSchedulerBlockedStatusReporting(t *testing.T) {
 	if ready != 1 {
 		t.Errorf("queued_ready = %d, want 1", ready)
 	}
+
+	// Close the blocker and verify the already-queued work becomes ready without
+	// creating a new sling context.
+	closeCmd := exec.Command("bd", "close", blockerID)
+	closeCmd.Dir = rigPath
+	closeCmd.Env = env
+	if out, err := closeCmd.CombinedOutput(); err != nil {
+		t.Fatalf("bd close blocker %s failed: %v\n%s", blockerID, err, out)
+	}
+
+	listed = getSchedulerList(t, gtBinary, hqPath, env)
+	foundBlocked = false
+	for _, item := range listed {
+		id, _ := item["id"].(string)
+		blocked, _ := item["blocked"].(bool)
+		if id == blockedID {
+			foundBlocked = true
+			if blocked {
+				t.Errorf("bead %s should become ready after blocker closes", blockedID)
+			}
+		}
+	}
+	if !foundBlocked {
+		t.Fatalf("unblocked queued bead %s not found in scheduler list", blockedID)
+	}
+
+	status = getSchedulerStatus(t, gtBinary, hqPath, env)
+	total = int(status["queued_total"].(float64))
+	ready = int(status["queued_ready"].(float64))
+	if total != 2 {
+		t.Errorf("queued_total after unblock = %d, want 2", total)
+	}
+	if ready != 2 {
+		t.Errorf("queued_ready after unblock = %d, want 2", ready)
+	}
+
+	out := runGTCmdOutput(t, gtBinary, hqPath, env, "scheduler", "run", "--dry-run")
+	if !strings.Contains(out, blockedID) {
+		t.Errorf("dry-run dispatch should include newly unblocked bead %s\noutput: %s", blockedID, out)
+	}
 }
 
 // TestSchedulerSlingDryRun verifies that gt sling deferred dispatch (max_polecats > 0) --dry-run

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -786,22 +786,34 @@ func defaultRunSchedulerForSlotOpen(townRoot string) (slotOpenSchedulerResult, e
 		return result, nil
 	}
 
-	output, err := runGTForSlotOpen(townRoot, "scheduler", "run", "--batch", strconv.Itoa(before.Capacity.Free))
+	output, err := runGTForSlotOpen(townRoot, "scheduler", "run")
 	result.Ran = true
 	result.Output = output
 	if err != nil {
 		return result, err
 	}
+	result.Dispatched = parseSchedulerRunDispatched(output)
 
 	after, err := readSchedulerStatusForSlotOpen(townRoot)
 	if err != nil {
 		return result, err
 	}
 	result.After = after
-	if before.QueuedReady > after.QueuedReady {
-		result.Dispatched = before.QueuedReady - after.QueuedReady
-	}
 	return result, nil
+}
+
+func parseSchedulerRunDispatched(output string) int {
+	fields := strings.Fields(output)
+	for i, field := range fields {
+		if field != "Dispatched" || i+1 >= len(fields) {
+			continue
+		}
+		n, err := strconv.Atoi(strings.TrimRight(fields[i+1], ","))
+		if err == nil {
+			return n
+		}
+	}
+	return 0
 }
 
 func readSchedulerStatusForSlotOpen(townRoot string) (slotOpenSchedulerStatus, error) {
@@ -906,9 +918,12 @@ func notifyMayorSlotOpen(workDir, rigName, polecatName, exitType string) {
 	if result, err := runSchedulerForSlotOpen(townRoot); err != nil {
 		fmt.Fprintf(os.Stderr, "witness: SLOT_OPEN scheduler trigger failed for %s/%s: %v\n", rigName, polecatName, err)
 	} else if result.Dispatched > 0 {
+		if status, ok := schedulerOpenAfterSlot(result); ok {
+			notifyMayorSchedulerOpen(townRoot, rigName, polecatName, exitType, status)
+		}
 		return
-	} else if schedulerOpenAfterSlot(result) {
-		notifyMayorSchedulerOpen(townRoot, rigName, polecatName, exitType, result)
+	} else if status, ok := schedulerOpenAfterSlot(result); ok {
+		notifyMayorSchedulerOpen(townRoot, rigName, polecatName, exitType, status)
 		return
 	} else if result.Before.Capacity.Max > 0 && (result.Before.Paused || result.Before.Capacity.Free <= 0) {
 		return
@@ -941,18 +956,22 @@ func notifyMayorSlotOpen(workDir, rigName, polecatName, exitType string) {
 	_ = cmd.Run()
 }
 
-func schedulerOpenAfterSlot(result slotOpenSchedulerResult) bool {
-	return !result.Before.Paused && result.Before.Capacity.Max > 0 && result.Before.Capacity.Free > 0 && result.Before.QueuedReady == 0
+func schedulerOpenAfterSlot(result slotOpenSchedulerResult) (slotOpenSchedulerStatus, bool) {
+	status := result.Before
+	if result.Ran {
+		status = result.After
+	}
+	return status, !status.Paused && status.Capacity.Max > 0 && status.Capacity.Free > 0 && status.QueuedReady == 0
 }
 
-func notifyMayorSchedulerOpen(townRoot, rigName, polecatName, exitType string, result slotOpenSchedulerResult) {
+func notifyMayorSchedulerOpen(townRoot, rigName, polecatName, exitType string, status slotOpenSchedulerStatus) {
 	_, _ = channelevents.EmitToTown(townRoot, "mayor", "SCHEDULER_OPEN", []string{
 		"source=witness",
 		"rig=" + rigName,
 		"polecat=" + polecatName,
 		"exit=" + exitType,
-		"capacity_free=" + strconv.Itoa(result.Before.Capacity.Free),
-		"queued_ready=" + strconv.Itoa(result.Before.QueuedReady),
+		"capacity_free=" + strconv.Itoa(status.Capacity.Free),
+		"queued_ready=" + strconv.Itoa(status.QueuedReady),
 	})
 
 	mayorSession := session.MayorSessionName()

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -2,6 +2,7 @@ package witness
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -752,6 +753,91 @@ var slotOpenRecoveryCheck = func(workDir, rigName, polecatName string) (string, 
 	return util.ExecWithOutput(workDir, "gt", "polecat", "check-recovery", rigName+"/"+polecatName, "--json", "--reconcile-cleanup")
 }
 
+type slotOpenSchedulerStatus struct {
+	Paused      bool `json:"paused"`
+	QueuedReady int  `json:"queued_ready"`
+	Capacity    struct {
+		Max  int `json:"max"`
+		Free int `json:"free"`
+	} `json:"capacity"`
+}
+
+type slotOpenSchedulerResult struct {
+	Before     slotOpenSchedulerStatus
+	After      slotOpenSchedulerStatus
+	Ran        bool
+	Dispatched int
+	Output     string
+}
+
+var runSchedulerForSlotOpen = defaultRunSchedulerForSlotOpen
+var slotOpenDecisionForNotify = slotOpenDecision
+
+func defaultRunSchedulerForSlotOpen(townRoot string) (slotOpenSchedulerResult, error) {
+	var result slotOpenSchedulerResult
+
+	before, err := readSchedulerStatusForSlotOpen(townRoot)
+	if err != nil {
+		return result, err
+	}
+	result.Before = before
+
+	if before.Paused || before.Capacity.Max <= 0 || before.Capacity.Free <= 0 || before.QueuedReady == 0 {
+		return result, nil
+	}
+
+	output, err := runGTForSlotOpen(townRoot, "scheduler", "run", "--batch", strconv.Itoa(before.Capacity.Free))
+	result.Ran = true
+	result.Output = output
+	if err != nil {
+		return result, err
+	}
+
+	after, err := readSchedulerStatusForSlotOpen(townRoot)
+	if err != nil {
+		return result, err
+	}
+	result.After = after
+	if before.QueuedReady > after.QueuedReady {
+		result.Dispatched = before.QueuedReady - after.QueuedReady
+	}
+	return result, nil
+}
+
+func readSchedulerStatusForSlotOpen(townRoot string) (slotOpenSchedulerStatus, error) {
+	var status slotOpenSchedulerStatus
+	output, err := runGTForSlotOpen(townRoot, "scheduler", "status", "--json")
+	if err != nil {
+		return status, err
+	}
+	jsonOutput := strings.TrimSpace(output)
+	if idx := strings.Index(jsonOutput, "{"); idx > 0 {
+		jsonOutput = jsonOutput[idx:]
+	}
+	if err := json.Unmarshal([]byte(jsonOutput), &status); err != nil {
+		return status, fmt.Errorf("parse scheduler status: %w", err)
+	}
+	return status, nil
+}
+
+func runGTForSlotOpen(townRoot string, args ...string) (string, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	cmd := exec.CommandContext(ctx, "gt", args...)
+	cmd.Dir = townRoot
+	cmd.Env = append(beads.BuildMutationRoutingBDEnv(os.Environ(), filepath.Join(townRoot, ".beads")), "GT_DAEMON=1")
+	out, err := cmd.CombinedOutput()
+	output := string(out)
+	if ctx.Err() == context.DeadlineExceeded {
+		return output, fmt.Errorf("gt %s timed out after 5m", strings.Join(args, " "))
+	}
+	if err != nil {
+		return output, fmt.Errorf("gt %s failed: %w (output: %s)", strings.Join(args, " "), err, strings.TrimSpace(output))
+	}
+	return output, nil
+}
+
 func shouldNotifyMayorSlotOpen(workDir, rigName, polecatName string) (bool, string) {
 	output, err := slotOpenRecoveryCheck(workDir, rigName, polecatName)
 	if err != nil {
@@ -790,7 +876,7 @@ func notifyMayorSlotOpen(workDir, rigName, polecatName, exitType string) {
 		return
 	}
 	if exitType != string(ExitTypeCompleted) {
-		decision := slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType)
+		decision := slotOpenDecisionForNotify(workDir, townRoot, rigName, polecatName, exitType)
 		if !decision.Reusable {
 			_, _ = channelevents.EmitToTown(townRoot, "mayor", "SLOT_BLOCKED", []string{
 				"source=witness",
@@ -806,7 +892,7 @@ func notifyMayorSlotOpen(workDir, rigName, polecatName, exitType string) {
 		fmt.Fprintf(os.Stderr, "witness: suppressing SLOT_OPEN for %s/%s: %s\n", rigName, polecatName, reason)
 		return
 	}
-	decision := slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType)
+	decision := slotOpenDecisionForNotify(workDir, townRoot, rigName, polecatName, exitType)
 	if !decision.Reusable {
 		_, _ = channelevents.EmitToTown(townRoot, "mayor", "SLOT_BLOCKED", []string{
 			"source=witness",
@@ -815,6 +901,16 @@ func notifyMayorSlotOpen(workDir, rigName, polecatName, exitType string) {
 			"exit=" + exitType,
 			"reason=" + decision.Reason,
 		})
+		return
+	}
+	if result, err := runSchedulerForSlotOpen(townRoot); err != nil {
+		fmt.Fprintf(os.Stderr, "witness: SLOT_OPEN scheduler trigger failed for %s/%s: %v\n", rigName, polecatName, err)
+	} else if result.Dispatched > 0 {
+		return
+	} else if schedulerOpenAfterSlot(result) {
+		notifyMayorSchedulerOpen(townRoot, rigName, polecatName, exitType, result)
+		return
+	} else if result.Before.Capacity.Max > 0 && (result.Before.Paused || result.Before.Capacity.Free <= 0) {
 		return
 	}
 
@@ -841,6 +937,35 @@ func notifyMayorSlotOpen(workDir, rigName, polecatName, exitType string) {
 	subject := fmt.Sprintf("SLOT_OPEN: %s/%s completed (exit=%s)", rigName, polecatName, exitType)
 	body := fmt.Sprintf("Polecat %s/%s finished (exit=%s). Slot available for next bead.", rigName, polecatName, exitType)
 	cmd := exec.Command("gt", "mail", "send", "mayor/", "-s", subject, "-m", body)
+	cmd.Dir = townRoot
+	_ = cmd.Run()
+}
+
+func schedulerOpenAfterSlot(result slotOpenSchedulerResult) bool {
+	return !result.Before.Paused && result.Before.Capacity.Max > 0 && result.Before.Capacity.Free > 0 && result.Before.QueuedReady == 0
+}
+
+func notifyMayorSchedulerOpen(townRoot, rigName, polecatName, exitType string, result slotOpenSchedulerResult) {
+	_, _ = channelevents.EmitToTown(townRoot, "mayor", "SCHEDULER_OPEN", []string{
+		"source=witness",
+		"rig=" + rigName,
+		"polecat=" + polecatName,
+		"exit=" + exitType,
+		"capacity_free=" + strconv.Itoa(result.Before.Capacity.Free),
+		"queued_ready=" + strconv.Itoa(result.Before.QueuedReady),
+	})
+
+	mayorSession := session.MayorSessionName()
+	t := tmux.NewTmux()
+	msg := fmt.Sprintf("SCHEDULER_OPEN: %s/%s completed (exit=%s); scheduler has capacity but no eligible queued beads remain.", rigName, polecatName, exitType)
+	if running, err := t.HasSession(mayorSession); err == nil && running {
+		if err := t.NudgeSession(mayorSession, msg); err == nil {
+			return
+		}
+	}
+
+	subject := fmt.Sprintf("SCHEDULER_OPEN: %s/%s completed (exit=%s)", rigName, polecatName, exitType)
+	cmd := exec.Command("gt", "mail", "send", "mayor/", "-s", subject, "-m", msg)
 	cmd.Dir = townRoot
 	_ = cmd.Run()
 }

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -928,7 +928,7 @@ func notifyMayorSlotOpen(workDir, rigName, polecatName, exitType string) {
 	} else if status, ok := schedulerOpenAfterSlot(result); ok {
 		notifyMayorSchedulerOpen(townRoot, rigName, polecatName, exitType, status)
 		return
-	} else if result.Before.Capacity.Max > 0 && (result.Before.Paused || result.Before.Capacity.Free <= 0) {
+	} else if status := schedulerStatusAfterSlot(result); status.Capacity.Max > 0 && (status.Paused || status.Capacity.Free <= 0) {
 		return
 	}
 
@@ -960,11 +960,16 @@ func notifyMayorSlotOpen(workDir, rigName, polecatName, exitType string) {
 }
 
 func schedulerOpenAfterSlot(result slotOpenSchedulerResult) (slotOpenSchedulerStatus, bool) {
+	status := schedulerStatusAfterSlot(result)
+	return status, !status.Paused && status.Capacity.Max > 0 && status.Capacity.Free > 0 && status.QueuedReady == 0
+}
+
+func schedulerStatusAfterSlot(result slotOpenSchedulerResult) slotOpenSchedulerStatus {
 	status := result.Before
 	if result.Ran {
 		status = result.After
 	}
-	return status, !status.Paused && status.Capacity.Max > 0 && status.Capacity.Free > 0 && status.QueuedReady == 0
+	return status
 }
 
 func notifyMayorSchedulerOpen(townRoot, rigName, polecatName, exitType string, status slotOpenSchedulerStatus) {

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -917,6 +917,9 @@ func notifyMayorSlotOpen(workDir, rigName, polecatName, exitType string) {
 	}
 	if result, err := runSchedulerForSlotOpen(townRoot); err != nil {
 		fmt.Fprintf(os.Stderr, "witness: SLOT_OPEN scheduler trigger failed for %s/%s: %v\n", rigName, polecatName, err)
+		if result.Dispatched > 0 {
+			return
+		}
 	} else if result.Dispatched > 0 {
 		if status, ok := schedulerOpenAfterSlot(result); ok {
 			notifyMayorSchedulerOpen(townRoot, rigName, polecatName, exitType, status)

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -116,6 +116,46 @@ func TestNotifyMayorSlotOpen_SchedulerDispatchSuppressesMayor(t *testing.T) {
 	}
 }
 
+func TestNotifyMayorSlotOpen_DispatchThenEmptyEmitsSchedulerOpen(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	townRoot, workDir := setupSlotOpenTestTown(t)
+
+	prevRecovery := slotOpenRecoveryCheck
+	prevDecision := slotOpenDecisionForNotify
+	prevScheduler := runSchedulerForSlotOpen
+	t.Cleanup(func() {
+		slotOpenRecoveryCheck = prevRecovery
+		slotOpenDecisionForNotify = prevDecision
+		runSchedulerForSlotOpen = prevScheduler
+	})
+
+	slotOpenRecoveryCheck = func(workDir, rigName, polecatName string) (string, error) {
+		return `{"verdict":"SAFE_TO_NUKE"}`, nil
+	}
+	slotOpenDecisionForNotify = func(workDir, townRoot, rigName, polecatName, exitType string) polecat.SlotReuseDecision {
+		return polecat.SlotReuseDecision{Reusable: true}
+	}
+	runSchedulerForSlotOpen = func(gotTownRoot string) (slotOpenSchedulerResult, error) {
+		var result slotOpenSchedulerResult
+		result.Ran = true
+		result.Dispatched = 1
+		result.After.Capacity.Max = 10
+		result.After.Capacity.Free = 1
+		result.After.QueuedReady = 0
+		return result, nil
+	}
+
+	notifyMayorSlotOpen(workDir, "gastown", "guzzle", string(ExitTypeCompleted))
+
+	events := readMayorEvents(t, townRoot)
+	if len(events) != 1 {
+		t.Fatalf("events = %+v, want one SCHEDULER_OPEN event", events)
+	}
+	if events[0].Type != "SCHEDULER_OPEN" {
+		t.Fatalf("event type = %q, want SCHEDULER_OPEN", events[0].Type)
+	}
+}
+
 func TestNotifyMayorSlotOpen_EmitsSchedulerOpenWhenQueueEmpty(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	townRoot, workDir := setupSlotOpenTestTown(t)
@@ -194,6 +234,26 @@ func TestNotifyMayorSlotOpen_QueuedReadyWithoutDispatchFallsBack(t *testing.T) {
 	}
 	if events[0].Type != "SLOT_OPEN" {
 		t.Fatalf("event type = %q, want SLOT_OPEN", events[0].Type)
+	}
+}
+
+func TestParseSchedulerRunDispatched(t *testing.T) {
+	tests := []struct {
+		name   string
+		output string
+		want   int
+	}{
+		{name: "dispatched", output: "\n✓ Dispatched 2, failed 0 (reason: batch)\n", want: 2},
+		{name: "skipped", output: "\n○ Skipped 1 bead(s) — zero capacity\n", want: 0},
+		{name: "cleanup only", output: "", want: 0},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseSchedulerRunDispatched(tt.output); got != tt.want {
+				t.Fatalf("parseSchedulerRunDispatched() = %d, want %d", got, tt.want)
+			}
+		})
 	}
 }
 

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -18,7 +18,13 @@ import (
 	"github.com/steveyegge/gastown/internal/tmux"
 )
 
-func TestNotifyMayorSlotOpen_BlocksNonCompletedExit(t *testing.T) {
+type testMayorEvent struct {
+	Type    string            `json:"type"`
+	Payload map[string]string `json:"payload"`
+}
+
+func setupSlotOpenTestTown(t *testing.T) (string, string) {
+	t.Helper()
 	townRoot := t.TempDir()
 	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
 		t.Fatal(err)
@@ -30,32 +36,164 @@ func TestNotifyMayorSlotOpen_BlocksNonCompletedExit(t *testing.T) {
 	if err := os.MkdirAll(workDir, 0755); err != nil {
 		t.Fatal(err)
 	}
+	return townRoot, workDir
+}
+
+func readMayorEvents(t *testing.T, townRoot string) []testMayorEvent {
+	t.Helper()
+	paths, err := filepath.Glob(filepath.Join(townRoot, "events", "mayor", "*.event"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	events := make([]testMayorEvent, 0, len(paths))
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatal(err)
+		}
+		var event testMayorEvent
+		if err := json.Unmarshal(data, &event); err != nil {
+			t.Fatal(err)
+		}
+		events = append(events, event)
+	}
+	return events
+}
+
+func TestNotifyMayorSlotOpen_BlocksNonCompletedExit(t *testing.T) {
+	townRoot, workDir := setupSlotOpenTestTown(t)
 
 	notifyMayorSlotOpen(workDir, "gastown", "guzzle", string(ExitTypeDeferred))
 
-	events, err := filepath.Glob(filepath.Join(townRoot, "events", "mayor", "*.event"))
-	if err != nil {
-		t.Fatal(err)
-	}
+	events := readMayorEvents(t, townRoot)
 	if len(events) != 1 {
 		t.Fatalf("events = %v, want one SLOT_BLOCKED event", events)
 	}
-	data, err := os.ReadFile(events[0])
-	if err != nil {
-		t.Fatal(err)
-	}
-	var event struct {
-		Type    string            `json:"type"`
-		Payload map[string]string `json:"payload"`
-	}
-	if err := json.Unmarshal(data, &event); err != nil {
-		t.Fatal(err)
-	}
+	event := events[0]
 	if event.Type != "SLOT_BLOCKED" {
 		t.Fatalf("event type = %q, want SLOT_BLOCKED", event.Type)
 	}
 	if event.Payload["reason"] != "exit-deferred" {
 		t.Fatalf("reason = %q, want exit-deferred", event.Payload["reason"])
+	}
+}
+
+func TestNotifyMayorSlotOpen_SchedulerDispatchSuppressesMayor(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	townRoot, workDir := setupSlotOpenTestTown(t)
+
+	prevRecovery := slotOpenRecoveryCheck
+	prevDecision := slotOpenDecisionForNotify
+	prevScheduler := runSchedulerForSlotOpen
+	t.Cleanup(func() {
+		slotOpenRecoveryCheck = prevRecovery
+		slotOpenDecisionForNotify = prevDecision
+		runSchedulerForSlotOpen = prevScheduler
+	})
+
+	slotOpenRecoveryCheck = func(workDir, rigName, polecatName string) (string, error) {
+		return `{"verdict":"SAFE_TO_NUKE"}`, nil
+	}
+	slotOpenDecisionForNotify = func(workDir, townRoot, rigName, polecatName, exitType string) polecat.SlotReuseDecision {
+		return polecat.SlotReuseDecision{Reusable: true}
+	}
+	called := false
+	runSchedulerForSlotOpen = func(gotTownRoot string) (slotOpenSchedulerResult, error) {
+		called = true
+		if gotTownRoot != townRoot {
+			t.Fatalf("townRoot = %q, want %q", gotTownRoot, townRoot)
+		}
+		return slotOpenSchedulerResult{Dispatched: 1}, nil
+	}
+
+	notifyMayorSlotOpen(workDir, "gastown", "guzzle", string(ExitTypeCompleted))
+
+	if !called {
+		t.Fatal("scheduler trigger was not called")
+	}
+	if events := readMayorEvents(t, townRoot); len(events) != 0 {
+		t.Fatalf("events = %+v, want none when scheduler dispatches", events)
+	}
+}
+
+func TestNotifyMayorSlotOpen_EmitsSchedulerOpenWhenQueueEmpty(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	townRoot, workDir := setupSlotOpenTestTown(t)
+
+	prevRecovery := slotOpenRecoveryCheck
+	prevDecision := slotOpenDecisionForNotify
+	prevScheduler := runSchedulerForSlotOpen
+	t.Cleanup(func() {
+		slotOpenRecoveryCheck = prevRecovery
+		slotOpenDecisionForNotify = prevDecision
+		runSchedulerForSlotOpen = prevScheduler
+	})
+
+	slotOpenRecoveryCheck = func(workDir, rigName, polecatName string) (string, error) {
+		return `{"verdict":"SAFE_TO_NUKE"}`, nil
+	}
+	slotOpenDecisionForNotify = func(workDir, townRoot, rigName, polecatName, exitType string) polecat.SlotReuseDecision {
+		return polecat.SlotReuseDecision{Reusable: true}
+	}
+	runSchedulerForSlotOpen = func(gotTownRoot string) (slotOpenSchedulerResult, error) {
+		var result slotOpenSchedulerResult
+		result.Before.Capacity.Max = 10
+		result.Before.Capacity.Free = 2
+		result.Before.QueuedReady = 0
+		return result, nil
+	}
+
+	notifyMayorSlotOpen(workDir, "gastown", "guzzle", string(ExitTypeCompleted))
+
+	events := readMayorEvents(t, townRoot)
+	if len(events) != 1 {
+		t.Fatalf("events = %+v, want one SCHEDULER_OPEN event", events)
+	}
+	if events[0].Type != "SCHEDULER_OPEN" {
+		t.Fatalf("event type = %q, want SCHEDULER_OPEN", events[0].Type)
+	}
+	if events[0].Payload["capacity_free"] != "2" {
+		t.Fatalf("capacity_free = %q, want 2", events[0].Payload["capacity_free"])
+	}
+}
+
+func TestNotifyMayorSlotOpen_QueuedReadyWithoutDispatchFallsBack(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	townRoot, workDir := setupSlotOpenTestTown(t)
+
+	prevRecovery := slotOpenRecoveryCheck
+	prevDecision := slotOpenDecisionForNotify
+	prevScheduler := runSchedulerForSlotOpen
+	t.Cleanup(func() {
+		slotOpenRecoveryCheck = prevRecovery
+		slotOpenDecisionForNotify = prevDecision
+		runSchedulerForSlotOpen = prevScheduler
+	})
+
+	slotOpenRecoveryCheck = func(workDir, rigName, polecatName string) (string, error) {
+		return `{"verdict":"SAFE_TO_NUKE"}`, nil
+	}
+	slotOpenDecisionForNotify = func(workDir, townRoot, rigName, polecatName, exitType string) polecat.SlotReuseDecision {
+		return polecat.SlotReuseDecision{Reusable: true}
+	}
+	runSchedulerForSlotOpen = func(gotTownRoot string) (slotOpenSchedulerResult, error) {
+		var result slotOpenSchedulerResult
+		result.Before.Capacity.Max = 10
+		result.Before.Capacity.Free = 1
+		result.Before.QueuedReady = 1
+		result.After = result.Before
+		result.Ran = true
+		return result, nil
+	}
+
+	notifyMayorSlotOpen(workDir, "gastown", "guzzle", string(ExitTypeCompleted))
+
+	events := readMayorEvents(t, townRoot)
+	if len(events) != 1 {
+		t.Fatalf("events = %+v, want one fallback SLOT_OPEN event", events)
+	}
+	if events[0].Type != "SLOT_OPEN" {
+		t.Fatalf("event type = %q, want SLOT_OPEN", events[0].Type)
 	}
 }
 

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -267,6 +267,44 @@ func TestNotifyMayorSlotOpen_QueuedReadyWithoutDispatchFallsBack(t *testing.T) {
 	}
 }
 
+func TestNotifyMayorSlotOpen_NoDispatchAfterCapacityFillsSuppressesMayor(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	townRoot, workDir := setupSlotOpenTestTown(t)
+
+	prevRecovery := slotOpenRecoveryCheck
+	prevDecision := slotOpenDecisionForNotify
+	prevScheduler := runSchedulerForSlotOpen
+	t.Cleanup(func() {
+		slotOpenRecoveryCheck = prevRecovery
+		slotOpenDecisionForNotify = prevDecision
+		runSchedulerForSlotOpen = prevScheduler
+	})
+
+	slotOpenRecoveryCheck = func(workDir, rigName, polecatName string) (string, error) {
+		return `{"verdict":"SAFE_TO_NUKE"}`, nil
+	}
+	slotOpenDecisionForNotify = func(workDir, townRoot, rigName, polecatName, exitType string) polecat.SlotReuseDecision {
+		return polecat.SlotReuseDecision{Reusable: true}
+	}
+	runSchedulerForSlotOpen = func(gotTownRoot string) (slotOpenSchedulerResult, error) {
+		var result slotOpenSchedulerResult
+		result.Before.Capacity.Max = 10
+		result.Before.Capacity.Free = 1
+		result.Before.QueuedReady = 1
+		result.After.Capacity.Max = 10
+		result.After.Capacity.Free = 0
+		result.After.QueuedReady = 1
+		result.Ran = true
+		return result, nil
+	}
+
+	notifyMayorSlotOpen(workDir, "gastown", "guzzle", string(ExitTypeCompleted))
+
+	if events := readMayorEvents(t, townRoot); len(events) != 0 {
+		t.Fatalf("events = %+v, want none when scheduler no longer has capacity", events)
+	}
+}
+
 func TestParseSchedulerRunDispatched(t *testing.T) {
 	tests := []struct {
 		name   string

--- a/internal/witness/handlers_test.go
+++ b/internal/witness/handlers_test.go
@@ -156,6 +156,36 @@ func TestNotifyMayorSlotOpen_DispatchThenEmptyEmitsSchedulerOpen(t *testing.T) {
 	}
 }
 
+func TestNotifyMayorSlotOpen_DispatchWithStatusErrorSuppressesMayor(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	townRoot, workDir := setupSlotOpenTestTown(t)
+
+	prevRecovery := slotOpenRecoveryCheck
+	prevDecision := slotOpenDecisionForNotify
+	prevScheduler := runSchedulerForSlotOpen
+	t.Cleanup(func() {
+		slotOpenRecoveryCheck = prevRecovery
+		slotOpenDecisionForNotify = prevDecision
+		runSchedulerForSlotOpen = prevScheduler
+	})
+
+	slotOpenRecoveryCheck = func(workDir, rigName, polecatName string) (string, error) {
+		return `{"verdict":"SAFE_TO_NUKE"}`, nil
+	}
+	slotOpenDecisionForNotify = func(workDir, townRoot, rigName, polecatName, exitType string) polecat.SlotReuseDecision {
+		return polecat.SlotReuseDecision{Reusable: true}
+	}
+	runSchedulerForSlotOpen = func(gotTownRoot string) (slotOpenSchedulerResult, error) {
+		return slotOpenSchedulerResult{Dispatched: 1}, errors.New("status read failed")
+	}
+
+	notifyMayorSlotOpen(workDir, "gastown", "guzzle", string(ExitTypeCompleted))
+
+	if events := readMayorEvents(t, townRoot); len(events) != 0 {
+		t.Fatalf("events = %+v, want none after confirmed dispatch", events)
+	}
+}
+
 func TestNotifyMayorSlotOpen_EmitsSchedulerOpenWhenQueueEmpty(t *testing.T) {
 	t.Setenv("PATH", t.TempDir())
 	townRoot, workDir := setupSlotOpenTestTown(t)


### PR DESCRIPTION
## Summary
- converges SLOT_OPEN handling so scheduler runs before Mayor out-of-work notification
- uses current scheduler status when stored sling context fallback is unavailable
- covers fallback dispatch and witness slot-open behavior in tests

## Context
Recovered from gt-wgko after refuge completed and push auth failed. Refinery merged the work to fork main as MR gt-wisp-8xu; this clean PR branch preserves the same commit e613bb04 without relying on fork main.

## Verification
Recorded on gt-wgko:
- CGO_ENABLED=0 go test ./internal/witness ./internal/beads ./internal/scheduler/capacity
- CGO_ENABLED=0 go test ./internal/cmd -run ^
- CGO_ENABLED=0 go test -tags=integration -c ./internal/cmd

Not run by refuge due environment:
- Integration execution blocked by unavailable rootless Docker
- Default CGO tests blocked by missing ICU linker libs

Issue: gt-wgko