### PR TITLE
fix(dolt-snapshots): use split dependency columns in convoy DB discovery

### DIFF
--- a/plugins/dolt-snapshots/main.go
+++ b/plugins/dolt-snapshots/main.go
@@ -383,7 +383,7 @@ func findConvoysNeedingSnapshots(db *sql.DB) ([]convoyRow, error) {
 // by looking at its tracked issues' prefixes.
 func discoverConvoyDatabases(db *sql.DB, convoyID string, databases []string, routes map[string]string) ([]string, error) {
 	query := `
-		SELECT DISTINCT d.depends_on_id
+		SELECT DISTINCT COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) AS depends_on_id
 		FROM hq.dependencies d
 		WHERE d.issue_id = ? AND d.type = 'tracks'
 	`


### PR DESCRIPTION
## Problem

The beads schema split the single `dependencies.depends_on_id` column into
three typed target columns (`depends_on_issue_id`, `depends_on_wisp_id`,
`depends_on_external`). Most of the codebase already resolves a dependency
target via `COALESCE` of the three, but the `dolt-snapshots` plugin's
convoy-database discovery query still selected the removed `depends_on_id`
column directly:

```sql
SELECT DISTINCT d.depends_on_id
FROM hq.dependencies d
WHERE d.issue_id = ? AND d.type = 'tracks'
```

Against the current schema this fails with `Error 1105: column "depends_on_id"
could not be found`, so `discoverConvoyDatabases` errors out.

## Fix

Select `COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external)
AS depends_on_id` — the same expression the rest of the code uses to resolve a
dependency target. The result is aliased back to `depends_on_id`, so the
scanning caller is unchanged.

One-line change. `go build`, `go vet`, and `go test` all pass for the
`plugins/dolt-snapshots` module.