### PR TITLE
fix(daemon): reclaim AgentDead dogs in cleanupStuckDogs (hq-54br)

### DIFF
--- a/internal/daemon/handler.go
+++ b/internal/daemon/handler.go
@@ -37,6 +37,13 @@ var (
 	maxDogPoolSize = config.DefaultMaxDogPoolSize
 )
 
+// neverHungInactivity is a deliberately enormous inactivity window passed to
+// CheckSessionHealth from cleanupStuckDogs. It ensures a live-but-slow agent is
+// never classified as AgentHung there — cleanupStuckDogs reclaims only genuinely
+// dead agents (SessionDead/AgentDead), while hung-but-alive dogs remain the job
+// of detectStaleWorkingDogs, which honors the configured grace period.
+const neverHungInactivity = 100 * 365 * 24 * time.Hour
+
 // handleDogs manages Dog lifecycle: cleanup stuck dogs, reap idle dogs, then dispatch plugins.
 // This is the main entry point called from heartbeat.
 func (d *Daemon) handleDogs() {
@@ -79,8 +86,21 @@ func (d *Daemon) handleDogsCleanupOnly() {
 	// Skip dispatchPlugins — under pressure
 }
 
-// cleanupStuckDogs finds dogs in state=working whose tmux session is dead and
-// clears their work so they return to idle.
+// cleanupStuckDogs finds dogs in state=working whose agent is dead and clears
+// their work so they return to idle.
+//
+// A working dog can lose its agent two ways:
+//
+//	SessionDead — the tmux session is gone entirely.
+//	AgentDead   — the tmux session lingers but the agent process inside died.
+//
+// Both leave the dog stuck in state=working with nothing driving it — e.g.
+// mol-dog-reaper finishes (or crashes) without calling `gt dog done`, which is
+// the teardown gap tracked in hq-54br. The previous HasSession-only check
+// caught just SessionDead; an AgentDead husk (live tmux, dead agent) sat
+// zombied until detectStaleWorkingDogs' multi-hour stale timeout, holding a dog
+// out of the pool. Classifying session health here returns those dogs to idle
+// on the next heartbeat regardless of how the agent exited.
 func (d *Daemon) cleanupStuckDogs(mgr *dog.Manager, sm *dog.SessionManager) {
 	dogs, err := mgr.List()
 	if err != nil {
@@ -88,25 +108,34 @@ func (d *Daemon) cleanupStuckDogs(mgr *dog.Manager, sm *dog.SessionManager) {
 		return
 	}
 
+	t := tmux.NewTmux()
 	for _, dg := range dogs {
 		if dg.State != dog.StateWorking {
 			continue
 		}
 
-		running, err := sm.IsRunning(dg.Name)
-		if err != nil {
-			d.logger.Printf("Handler: error checking session for dog %s: %v", dg.Name, err)
-			continue
-		}
+		sessionID := sm.SessionName(dg.Name)
+		switch t.CheckSessionHealth(sessionID, neverHungInactivity) {
+		case tmux.SessionDead:
+			// Dog is marked working but the session is gone — clean it up.
+			d.logger.Printf("Handler: dog %s is working but session is dead, clearing work", dg.Name)
+			if err := mgr.ClearWork(dg.Name); err != nil {
+				d.logger.Printf("Handler: failed to clear work for dog %s: %v", dg.Name, err)
+			}
 
-		if running {
-			continue
-		}
+		case tmux.AgentDead:
+			// Dog is marked working but the agent process died inside a
+			// lingering tmux session — kill the husk, then return it to idle.
+			d.logger.Printf("Handler: dog %s is working but agent is dead, killing session and clearing work", dg.Name)
+			if err := t.KillSession(sessionID); err != nil {
+				d.logger.Printf("Handler: failed to kill dead-agent session for dog %s: %v", dg.Name, err)
+			}
+			if err := mgr.ClearWork(dg.Name); err != nil {
+				d.logger.Printf("Handler: failed to clear work for dog %s: %v", dg.Name, err)
+			}
 
-		// Dog is marked working but session is dead — clean it up.
-		d.logger.Printf("Handler: dog %s is working but session is dead, clearing work", dg.Name)
-		if err := mgr.ClearWork(dg.Name); err != nil {
-			d.logger.Printf("Handler: failed to clear work for dog %s: %v", dg.Name, err)
+			// SessionHealthy / AgentHung: leave alone. A healthy dog is working;
+			// a hung-but-live dog is detectStaleWorkingDogs' responsibility.
 		}
 	}
 }

--- a/internal/daemon/handler_test.go
+++ b/internal/daemon/handler_test.go
@@ -447,3 +447,55 @@ func TestFindDispatchableDog_PicksFirstIdleWhenNoSessionsLive(t *testing.T) {
 		t.Errorf("findDispatchableDog = %q, want alpha or bravo", got.Name)
 	}
 }
+
+// TestCleanupStuckDogs_ClearsDeadSessionWorker is the hq-54br regression: a dog
+// marked state=working with no live session (the mol-dog-reaper failure mode —
+// agent exits without `gt dog done`) must be returned to idle. Test dogs have no
+// real tmux session, so CheckSessionHealth classifies them SessionDead.
+func TestCleanupStuckDogs_ClearsDeadSessionWorker(t *testing.T) {
+	townRoot := t.TempDir()
+	d := testHandlerDaemon(t, townRoot)
+
+	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	mgr := dog.NewManager(townRoot, rigsConfig)
+	sm := dog.NewSessionManager(tmux.NewTmux(), townRoot, mgr)
+
+	// Dog stuck in state=working on the reaper formula, no live session.
+	testSetupWorkingDogState(t, townRoot, "alpha", constants.MolDogReaper, time.Now())
+
+	d.cleanupStuckDogs(mgr, sm)
+
+	dg, err := mgr.Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+	if dg.State != dog.StateIdle {
+		t.Errorf("stuck dog state = %q, want idle", dg.State)
+	}
+	if dg.Work != "" {
+		t.Errorf("stuck dog work = %q, want empty", dg.Work)
+	}
+}
+
+// TestCleanupStuckDogs_SkipsIdleDogs ensures the cleanup never disturbs a dog
+// that is already idle.
+func TestCleanupStuckDogs_SkipsIdleDogs(t *testing.T) {
+	townRoot := t.TempDir()
+	d := testHandlerDaemon(t, townRoot)
+
+	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	mgr := dog.NewManager(townRoot, rigsConfig)
+	sm := dog.NewSessionManager(tmux.NewTmux(), townRoot, mgr)
+
+	testSetupDogState(t, townRoot, "alpha", dog.StateIdle, time.Now())
+
+	d.cleanupStuckDogs(mgr, sm)
+
+	dg, err := mgr.Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+	if dg.State != dog.StateIdle {
+		t.Errorf("idle dog state = %q, want idle (unchanged)", dg.State)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes **hq-54br** (P1): `mol-dog-reaper` leaves its dog stuck in `state=working` after the agent exits without calling `gt dog done`.

The daemon's `cleanupStuckDogs` already returned **SessionDead** dogs (tmux session gone) to idle on each heartbeat — confirmed firing every reaper cycle in `daemon.log`, so the common case already self-heals (no runaway loop). The real remaining gap: it used a crude `HasSession` check that **missed AgentDead** — a lingering tmux session whose agent process died. Those husks sat zombied until `detectStaleWorkingDogs`' multi-hour stale timeout, holding a dog out of the 4-dog pool.

## Change

`cleanupStuckDogs` now classifies session health and reclaims **both** failure modes on the next heartbeat:
- `SessionDead` → clear work → idle (unchanged behavior)
- `AgentDead` → kill the husk session → clear work → idle (new)

Hung-but-live dogs are deliberately left to `detectStaleWorkingDogs` (a huge inactivity window ensures a slow-but-alive agent is never treated as hung here). This makes the supervisor's guaranteed-on-exit idle-return comprehensive across all agent-exit modes — robust even against SIGKILL, which an in-agent defer/trap could never catch.

Scope is intentionally limited to `handler.go` / `handler_test.go` per the bead; the separate "why does the reaper agent exit without `gt dog done` every cycle" session-exit lifecycle question is left for a future bead.

## Test
- `go build` + `go vet`: clean
- New regression tests: `TestCleanupStuckDogs_ClearsDeadSessionWorker`, `TestCleanupStuckDogs_SkipsIdleDogs`
- Full `internal/daemon` package: **pass** (219s)

🤖 Generated with [Claude Code](https://claude.com/claude-code)