### PR TITLE
[codex] Reclaim agent-dead dogs in daemon cleanup

### DIFF
--- a/internal/daemon/handler.go
+++ b/internal/daemon/handler.go
@@ -37,6 +37,11 @@ var (
 	maxDogPoolSize = config.DefaultMaxDogPoolSize
 )
 
+// cleanupStuckDogsMaxInactivity is intentionally far beyond any real dog run.
+// cleanupStuckDogs should reclaim only dead agents; live-but-idle agents are
+// handled by detectStaleWorkingDogs after the configured stale-work timeout.
+const cleanupStuckDogsMaxInactivity = 100 * 365 * 24 * time.Hour
+
 // handleDogs manages Dog lifecycle: cleanup stuck dogs, reap idle dogs, then dispatch plugins.
 // This is the main entry point called from heartbeat.
 func (d *Daemon) handleDogs() {
@@ -79,8 +84,8 @@ func (d *Daemon) handleDogsCleanupOnly() {
 	// Skip dispatchPlugins — under pressure
 }
 
-// cleanupStuckDogs finds dogs in state=working whose tmux session is dead and
-// clears their work so they return to idle.
+// cleanupStuckDogs finds dogs in state=working whose tmux session or agent
+// process is dead and clears their work so they return to idle.
 func (d *Daemon) cleanupStuckDogs(mgr *dog.Manager, sm *dog.SessionManager) {
 	dogs, err := mgr.List()
 	if err != nil {
@@ -88,26 +93,25 @@ func (d *Daemon) cleanupStuckDogs(mgr *dog.Manager, sm *dog.SessionManager) {
 		return
 	}
 
+	health := dog.NewHealthChecker(mgr, tmux.NewTmux())
 	for _, dg := range dogs {
 		if dg.State != dog.StateWorking {
 			continue
 		}
 
-		running, err := sm.IsRunning(dg.Name)
-		if err != nil {
-			d.logger.Printf("Handler: error checking session for dog %s: %v", dg.Name, err)
+		result := health.Check(dg, cleanupStuckDogsMaxInactivity, true)
+		if !result.NeedsAttention {
 			continue
 		}
 
-		if running {
+		sessionID := sm.SessionName(dg.Name)
+		if result.AutoCleared {
+			d.logger.Printf("Handler: dog %s (%s) was auto-cleared: %s", dg.Name, sessionID, result.Recommendation)
 			continue
 		}
 
-		// Dog is marked working but session is dead — clean it up.
-		d.logger.Printf("Handler: dog %s is working but session is dead, clearing work", dg.Name)
-		if err := mgr.ClearWork(dg.Name); err != nil {
-			d.logger.Printf("Handler: failed to clear work for dog %s: %v", dg.Name, err)
-		}
+		d.logger.Printf("Handler: dog %s (%s) needs attention but was not auto-cleared: %s",
+			dg.Name, sessionID, result.Recommendation)
 	}
 }
 

--- a/internal/daemon/handler_test.go
+++ b/internal/daemon/handler_test.go
@@ -2,8 +2,10 @@ package daemon
 
 import (
 	"encoding/json"
+	"fmt"
 	"log"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"runtime"
 	"testing"
@@ -445,5 +447,96 @@ func TestFindDispatchableDog_PicksFirstIdleWhenNoSessionsLive(t *testing.T) {
 	}
 	if got.Name != "alpha" && got.Name != "bravo" {
 		t.Errorf("findDispatchableDog = %q, want alpha or bravo", got.Name)
+	}
+}
+
+func TestCleanupStuckDogs_ClearsDeadSessionWorker(t *testing.T) {
+	townRoot := t.TempDir()
+	d := testHandlerDaemon(t, townRoot)
+
+	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	mgr := dog.NewManager(townRoot, rigsConfig)
+	sm := dog.NewSessionManager(tmux.NewTmux(), townRoot, mgr)
+
+	testSetupWorkingDogState(t, townRoot, "alpha", constants.MolDogReaper, time.Now())
+
+	d.cleanupStuckDogs(mgr, sm)
+
+	dg, err := mgr.Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+	if dg.State != dog.StateIdle {
+		t.Errorf("stuck dog state = %q, want idle", dg.State)
+	}
+	if dg.Work != "" {
+		t.Errorf("stuck dog work = %q, want empty", dg.Work)
+	}
+}
+
+func TestCleanupStuckDogs_ClearsAgentDeadWorker(t *testing.T) {
+	if _, err := exec.LookPath("tmux"); err != nil {
+		t.Skip("tmux not installed")
+	}
+
+	oldSocket := tmux.GetDefaultSocket()
+	socketName := fmt.Sprintf("gt-test-dog-cleanup-%d", time.Now().UnixNano())
+	tmux.SetDefaultSocket(socketName)
+	t.Cleanup(func() { tmux.SetDefaultSocket(oldSocket) })
+
+	townRoot := t.TempDir()
+	d := testHandlerDaemon(t, townRoot)
+
+	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	mgr := dog.NewManager(townRoot, rigsConfig)
+	tm := tmux.NewTmux()
+	sm := dog.NewSessionManager(tm, townRoot, mgr)
+
+	testSetupWorkingDogState(t, townRoot, "alpha", constants.MolDogReaper, time.Now())
+
+	sessionName := sm.SessionName("alpha")
+	if err := tm.NewSession(sessionName, ""); err != nil {
+		t.Fatalf("NewSession(%q): %v", sessionName, err)
+	}
+	t.Cleanup(func() { _ = tm.KillSession(sessionName) })
+	time.Sleep(200 * time.Millisecond)
+
+	d.cleanupStuckDogs(mgr, sm)
+
+	dg, err := mgr.Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+	if dg.State != dog.StateIdle {
+		t.Errorf("agent-dead dog state = %q, want idle", dg.State)
+	}
+	if dg.Work != "" {
+		t.Errorf("agent-dead dog work = %q, want empty", dg.Work)
+	}
+	if has, err := tm.HasSession(sessionName); err != nil {
+		t.Fatalf("HasSession(%q): %v", sessionName, err)
+	} else if has {
+		t.Errorf("agent-dead session %q still exists after cleanup", sessionName)
+	}
+}
+
+func TestCleanupStuckDogs_SkipsIdleDogs(t *testing.T) {
+	townRoot := t.TempDir()
+	d := testHandlerDaemon(t, townRoot)
+
+	rigsConfig := &config.RigsConfig{Version: 1, Rigs: map[string]config.RigEntry{}}
+	mgr := dog.NewManager(townRoot, rigsConfig)
+	sm := dog.NewSessionManager(tmux.NewTmux(), townRoot, mgr)
+
+	testSetupDogState(t, townRoot, "alpha", dog.StateIdle, time.Now())
+
+	d.cleanupStuckDogs(mgr, sm)
+
+	dg, err := mgr.Get("alpha")
+	if err != nil {
+		t.Fatalf("Get() error: %v", err)
+	}
+	if dg.State != dog.StateIdle {
+		t.Errorf("idle dog state = %q, want idle", dg.State)
 	}
 }


### PR DESCRIPTION
## Summary

Manual replacement for closed autonomous PR #4309.

- Reuse the existing dog health checker in daemon stuck-dog cleanup.
- Auto-clear working dogs when the tmux session is gone or the agent process inside the session is dead.
- Keep live-but-idle or hung dogs on the existing stale-worker path instead of reclaiming them early.
- Add regression coverage for dead sessions, shell-only agent-dead sessions, and idle dog no-op behavior.

## Why

The autonomous Gas Town self-modification route was stopped by Rodrigo and PR #4309 was closed without merge. This branch reapplies the useful repair manually from `origin/main` under Rodrigo + Codex ownership.

## Validation

With ICU flags from `/opt/homebrew/opt/icu4c@78`:

- `go test ./internal/daemon -run 'TestCleanupStuckDogs|TestFindDispatchableDog' -count=1`
- `go test ./internal/daemon -count=1`
- `go vet ./internal/daemon`
- `go test ./internal/dog -count=1`
- `go build ./...`