### PR TITLE
fix(daemon): raise Dolt read/write timeout 30s->300s (gt-ye21)

### DIFF
--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -859,8 +859,8 @@ log_level: info
 
 listener:
   port: %d%s
-  read_timeout_millis: 30000
-  write_timeout_millis: 30000
+  read_timeout_millis: 300000
+  write_timeout_millis: 300000
   max_connections: 1000
 
 data_dir: %q


### PR DESCRIPTION
## Problem

`writeDaemonDoltConfig` in `internal/daemon/dolt.go` hardcodes the
daemon-managed `config.yaml` with `read_timeout_millis: 30000` /
`write_timeout_millis: 30000` (30s).

Under `hq` connection churn (gt-ye21), the beads issue-list query
(`SELECT i.id, i.content_hash, i.title, ...` against `hq`) can exceed 30s.
When it does, the server severs the connection mid-query
("use of closed network connection"), which surfaces to `bd`/mail clients
as `i/o timeout`. Repeatedly this drove the pool toward exhaustion and
crashed the server ("server unreachable"), blocking dogs from mail/dispatch.

This also contradicts the codebase's own intent: `doltserver.go` defines
`DefaultReadTimeoutMs = DefaultWriteTimeoutMs = 5 * 60 * 1000` (5min), but
the daemon path wrote 30s regardless.

## Change

Raise both daemon-written timeouts `30000 -> 300000` (5min), matching
`DefaultReadTimeoutMs`. Slow-but-completing queries now finish instead of
being killed.

## Validation

Built locally and ran for hours: Dolt stayed up with **no crashes**, vs
crashing every few minutes before. The acute crash/sever symptom is gone.

## Scope / follow-up

This fixes the **server-severing/crash** symptom only. The underlying
query slowness — a thundering herd of identical `hq` issue-list queries
under connection churn — is the broader **gt-ye21** work (convoy/wisp/session
teardown + reducing concurrent pollers). A separate attempt to raise the
*client-side* timeouts to match was reverted: under a severe herd it made
pileups worse by holding connections ~10x longer (the 30s client timeout
acts as a relief valve).

Draft pending further soak before marking ready.