### PR TITLE
fix(reaper): lower default wisp delete_age 7d->24h (gt-ye21, #4292)

### DIFF
--- a/internal/cmd/config.go
+++ b/internal/cmd/config.go
@@ -638,7 +638,7 @@ Supported keys:
   Lifecycle (Dolt data maintenance):
   lifecycle.reaper.enabled     Enable/disable wisp reaper (true/false)
   lifecycle.reaper.interval    Reaper check interval (default: 30m)
-  lifecycle.reaper.delete_age  Delete closed wisps after this duration (default: 168h / 7d)
+  lifecycle.reaper.delete_age  Delete closed wisps after this duration (default: 24h)
   lifecycle.compactor.enabled  Enable/disable compactor dog (true/false)
   lifecycle.compactor.interval Compactor check interval (default: 24h)
   lifecycle.compactor.threshold Commit count before compaction (default: 500)
@@ -1173,7 +1173,7 @@ func getLifecycleConfig(townRoot, key string) error {
 		if patrolConfig != nil && patrolConfig.Patrols != nil && patrolConfig.Patrols.WispReaper != nil && patrolConfig.Patrols.WispReaper.DeleteAgeStr != "" {
 			value = patrolConfig.Patrols.WispReaper.DeleteAgeStr
 		} else {
-			value = "168h (default, 7 days)"
+			value = "24h (default)"
 		}
 
 	// Compactor

--- a/internal/daemon/lifecycle_defaults.go
+++ b/internal/daemon/lifecycle_defaults.go
@@ -23,7 +23,7 @@ func DefaultLifecycleConfig() *DaemonPatrolConfig {
 				Enabled:      true,
 				IntervalStr:  "30m",
 				MaxAgeStr:    "24h",
-				DeleteAgeStr: "168h", // 7 days
+				DeleteAgeStr: "24h", // closed wisps deleted after 24h; live wisps table is scanned by mail/search, so keep it small (gt-ye21). Dolt AS OF retains history.
 			},
 			CompactorDog: &CompactorDogConfig{
 				Enabled:     true,

--- a/internal/daemon/lifecycle_defaults_test.go
+++ b/internal/daemon/lifecycle_defaults_test.go
@@ -29,8 +29,8 @@ func TestDefaultLifecycleConfig(t *testing.T) {
 	if p.WispReaper.IntervalStr != "30m" {
 		t.Errorf("expected wisp_reaper interval 30m, got %s", p.WispReaper.IntervalStr)
 	}
-	if p.WispReaper.DeleteAgeStr != "168h" {
-		t.Errorf("expected wisp_reaper delete_age 168h, got %s", p.WispReaper.DeleteAgeStr)
+	if p.WispReaper.DeleteAgeStr != "24h" {
+		t.Errorf("expected wisp_reaper delete_age 24h, got %s", p.WispReaper.DeleteAgeStr)
 	}
 
 	if p.CompactorDog == nil || !p.CompactorDog.Enabled {

--- a/internal/daemon/wisp_reaper.go
+++ b/internal/daemon/wisp_reaper.go
@@ -18,7 +18,13 @@ const (
 	// Wisps older than this are reaped (closed). Configurable via formula var max_age.
 	defaultWispMaxAge = 24 * time.Hour
 	// Closed wisps older than this are permanently deleted. Formula var: purge_age.
-	defaultWispDeleteAge = 7 * 24 * time.Hour
+	// Kept short (24h, was 7d): mail/search queries (SearchIssues with no
+	// ephemeral filter) scan the live wisps table, so a large backlog of closed
+	// wisps slows every read and, under churn, thundering-herds Dolt (gt-ye21).
+	// Deleted-wisp history is preserved via Dolt AS OF, so a short live-table
+	// retention is safe. Towns with very high wisp churn can lower further via
+	// `gt config set lifecycle.reaper.delete_age`.
+	defaultWispDeleteAge = 24 * time.Hour
 	// Alert threshold: if open wisp count exceeds this, the Dog should escalate.
 	// Shared with `gt reaper run` warning. See reaper.DefaultAlertThreshold.
 	wispAlertThreshold = reaper.DefaultAlertThreshold


### PR DESCRIPTION
## Problem

`SearchIssues` with no ephemeral filter (what `gt mail inbox` uses) scans the live `wisps` table and merges results. The reaper's `delete_age` default is **7 days**, so on a high-churn town (~200 wisps/hour from convoy steps, dog molecules, plugin receipts, mail, escalations) the live table bloats with tens of thousands of closed wisps. Every mail read then scans that whole table, and under patrol/multi-agent load it thundering-herds the Dolt listener.

This is the wisp-table-size half of #4292 (the other half being per-query connection amplification). It's independent of connection count: #3623 saw `gt mail inbox` take 23-58s at only 10 connections.

## Field data

On our `hq`: wisps reached **33,647 rows (33,565 closed)** under the 7d default. Lowering `lifecycle.reaper.delete_age` to 6h and purging the backlog took the wisp scan from a 33k-row table to ~2.8ms, `gt mail inbox` 698ms -> ~190ms, and stopped the pile-up (we'd captured 339 identical `SELECT ... FROM wisps` queries stacked up, oldest 54 min). Held stable for hours.

## Change

Lower the shipped default `defaultWispDeleteAge` 7d -> 24h, plus the matching `DefaultLifecycleConfig` string and help text. Deleted-wisp history is preserved via Dolt AS OF, so a short live-table retention is safe. High-churn towns can override lower via `gt config set lifecycle.reaper.delete_age`.

Complements #4261 (cut wisp query *count*; this cuts table *size*).

## Tests

`go test ./internal/daemon/` passes (lifecycle defaults test updated to expect 24h).

Draft pending maintainer view on whether this fits the #4292 direction. Refs #4292.