### PR TITLE
ci: install bd in the Test job so bd-dependent unit tests pass

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -88,6 +88,20 @@ jobs:
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
+      - name: Cache beads (bd)
+        id: cache-beads-test
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
+        with:
+          path: ~/go/bin/bd
+          key: beads-${{ hashFiles('.github/workflows/ci.yml') }}
+
+      - name: Install beads (bd)
+        if: steps.cache-beads-test.outputs.cache-hit != 'true'
+        run: CGO_ENABLED=0 go install github.com/steveyegge/beads/cmd/bd@v1.0.0
+
+      - name: Add bd to PATH
+        run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
+
       - name: Build
         run: go build -v ./cmd/gt
 


### PR DESCRIPTION
## Problem

The **Test** job in `ci.yml` builds `gt` and runs the full `-short` suite, but several unit tests exec the `bd` binary — `agent_beads_check_test.go`, and the `internal/cmd` `TestJSONOutput_*` tests (which run `gt` commands that shell out to `bd`). The Test job **never installs bd**, so those tests fail with `exec: "bd": executable file not found in $PATH`, cascading to `unexpected end of JSON input` on the JSON-output assertions.

This red-fails the **Test** check on **every** PR in the repo (confirmed identical failures on unrelated PRs #4278, #4311, #4314 — including a 2-line config change), not just changed code.

## Fix

Install `bd` in the Test job, mirroring what the **Integration** job already does: cache `~/go/bin/bd`, `go install github.com/steveyegge/beads/cmd/bd@v1.0.0`, and add `$(go env GOPATH)/bin` to `$GITHUB_PATH`.

No product code changes. Once merged, the Test check should pass on PRs again.