### PR TITLE
fix: cap dolt sql-server Go runtime memory

### DIFF
--- a/internal/daemon/dolt.go
+++ b/internal/daemon/dolt.go
@@ -937,12 +937,6 @@ func (m *DoltServerManager) startLocked() error {
 		m.logger("Warning: failed to write Dolt config.yaml: %v", err)
 	}
 
-	// Build command arguments
-	args := []string{
-		"sql-server",
-		"--config", configPath,
-	}
-
 	// Open log file
 	logFile, err := os.OpenFile(m.config.LogFile, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0600)
 	if err != nil {
@@ -950,8 +944,7 @@ func (m *DoltServerManager) startLocked() error {
 	}
 
 	// Start dolt sql-server as background process
-	cmd := exec.Command(doltPath, args...)
-	cmd.Dir = m.config.DataDir
+	cmd := doltserver.NewSQLServerCommand(doltPath, m.config.DataDir, configPath)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -140,6 +140,9 @@ const (
 	DefaultUser           = "root" // Default Dolt user (no password for local access)
 	DefaultMaxConnections = 1000   // Dolt default; no reason to limit below (Tim Sehn confirmed 1k is fine)
 
+	defaultDoltSQLServerGoMemLimit = "16GiB"
+	defaultDoltSQLServerGOGC       = "50"
+
 	// DefaultReadTimeoutMs is the server-side timeout for reading a complete request from a client.
 	// Controls how long Dolt waits for a client to send a query on an idle connection.
 	// Prevents CLOSE_WAIT accumulation from abandoned connections: when a client times out
@@ -461,6 +464,31 @@ func buildDoltSQLCmd(ctx context.Context, config *Config, args ...string) *exec.
 	cmd.Env = append(os.Environ(), "DOLT_CLI_PASSWORD="+config.Password)
 
 	return cmd
+}
+
+// NewSQLServerCommand constructs the managed dolt sql-server process command.
+func NewSQLServerCommand(doltPath, dataDir, configPath string) *exec.Cmd {
+	cmd := exec.Command(doltPath, "sql-server", "--config", configPath)
+	cmd.Dir = dataDir
+	cmd.Env = doltSQLServerEnv(cmd.Environ())
+	return cmd
+}
+
+func doltSQLServerEnv(env []string) []string {
+	out := append([]string(nil), env...)
+	out = appendEnvDefault(out, "GOMEMLIMIT", defaultDoltSQLServerGoMemLimit)
+	out = appendEnvDefault(out, "GOGC", defaultDoltSQLServerGOGC)
+	return out
+}
+
+func appendEnvDefault(env []string, key, value string) []string {
+	prefix := key + "="
+	for _, entry := range env {
+		if strings.HasPrefix(entry, prefix) {
+			return env
+		}
+	}
+	return append(env, prefix+value)
 }
 
 // RigDatabaseDir returns the database directory for a specific rig.
@@ -1830,9 +1858,7 @@ func Start(townRoot string) error {
 		logFile.Close()
 		return fmt.Errorf("writing Dolt config: %w", err)
 	}
-	args := []string{"sql-server", "--config", configPath}
-	cmd := exec.Command("dolt", args...)
-	cmd.Dir = config.DataDir
+	cmd := NewSQLServerCommand("dolt", config.DataDir, configPath)
 	cmd.Stdout = logFile
 	cmd.Stderr = logFile
 

--- a/internal/doltserver/doltserver.go
+++ b/internal/doltserver/doltserver.go
@@ -475,20 +475,31 @@ func NewSQLServerCommand(doltPath, dataDir, configPath string) *exec.Cmd {
 }
 
 func doltSQLServerEnv(env []string) []string {
+	return doltSQLServerEnvForGOOS(env, runtime.GOOS)
+}
+
+func doltSQLServerEnvForGOOS(env []string, goos string) []string {
 	out := append([]string(nil), env...)
-	out = appendEnvDefault(out, "GOMEMLIMIT", defaultDoltSQLServerGoMemLimit)
-	out = appendEnvDefault(out, "GOGC", defaultDoltSQLServerGOGC)
+	out = appendEnvDefault(out, "GOMEMLIMIT", defaultDoltSQLServerGoMemLimit, goos)
+	out = appendEnvDefault(out, "GOGC", defaultDoltSQLServerGOGC, goos)
 	return out
 }
 
-func appendEnvDefault(env []string, key, value string) []string {
-	prefix := key + "="
+func appendEnvDefault(env []string, key, value, goos string) []string {
 	for _, entry := range env {
-		if strings.HasPrefix(entry, prefix) {
+		entryKey, _, ok := strings.Cut(entry, "=")
+		if ok && envKeyMatches(entryKey, key, goos) {
 			return env
 		}
 	}
-	return append(env, prefix+value)
+	return append(env, key+"="+value)
+}
+
+func envKeyMatches(entryKey, key, goos string) bool {
+	if goos == "windows" {
+		return strings.EqualFold(entryKey, key)
+	}
+	return entryKey == key
 }
 
 // RigDatabaseDir returns the database directory for a specific rig.

--- a/internal/doltserver/sql_server_command_test.go
+++ b/internal/doltserver/sql_server_command_test.go
@@ -1,0 +1,108 @@
+package doltserver
+
+import (
+	"os"
+	"runtime"
+	"testing"
+)
+
+func TestNewSQLServerCommandAddsRuntimeDefaults(t *testing.T) {
+	unsetEnv(t, "GOMEMLIMIT")
+	unsetEnv(t, "GOGC")
+
+	dataDir := t.TempDir()
+	configPath := dataDir + "/config.yaml"
+	cmd := NewSQLServerCommand("dolt", dataDir, configPath)
+
+	if cmd.Dir != dataDir {
+		t.Fatalf("cmd.Dir = %q, want %q", cmd.Dir, dataDir)
+	}
+	wantArgs := []string{"dolt", "sql-server", "--config", configPath}
+	if len(cmd.Args) != len(wantArgs) {
+		t.Fatalf("cmd.Args = %v, want %v", cmd.Args, wantArgs)
+	}
+	for i, want := range wantArgs {
+		if cmd.Args[i] != want {
+			t.Fatalf("cmd.Args[%d] = %q, want %q", i, cmd.Args[i], want)
+		}
+	}
+
+	if got := envValue(cmd.Env, "GOMEMLIMIT"); got != defaultDoltSQLServerGoMemLimit {
+		t.Fatalf("GOMEMLIMIT = %q, want %q", got, defaultDoltSQLServerGoMemLimit)
+	}
+	if got := envValue(cmd.Env, "GOGC"); got != defaultDoltSQLServerGOGC {
+		t.Fatalf("GOGC = %q, want %q", got, defaultDoltSQLServerGOGC)
+	}
+	if runtime.GOOS != "windows" {
+		if got := envValue(cmd.Env, "PWD"); got != dataDir {
+			t.Fatalf("PWD = %q, want %q", got, dataDir)
+		}
+	}
+}
+
+func TestDoltSQLServerEnvPreservesRuntimeOverrides(t *testing.T) {
+	env := doltSQLServerEnv([]string{"GOMEMLIMIT=24GiB", "GOGC=100"})
+
+	if got := envValue(env, "GOMEMLIMIT"); got != "24GiB" {
+		t.Fatalf("GOMEMLIMIT = %q, want override", got)
+	}
+	if got := envValue(env, "GOGC"); got != "100" {
+		t.Fatalf("GOGC = %q, want override", got)
+	}
+	if got := envKeyCount(env, "GOMEMLIMIT"); got != 1 {
+		t.Fatalf("GOMEMLIMIT count = %d, want 1", got)
+	}
+	if got := envKeyCount(env, "GOGC"); got != 1 {
+		t.Fatalf("GOGC count = %d, want 1", got)
+	}
+}
+
+func TestDoltSQLServerEnvTreatsEmptyAndOffAsOverrides(t *testing.T) {
+	env := doltSQLServerEnv([]string{"GOMEMLIMIT=off", "GOGC="})
+
+	if got := envValue(env, "GOMEMLIMIT"); got != "off" {
+		t.Fatalf("GOMEMLIMIT = %q, want off", got)
+	}
+	if got := envValue(env, "GOGC"); got != "" {
+		t.Fatalf("GOGC = %q, want empty override", got)
+	}
+	if got := envKeyCount(env, "GOGC"); got != 1 {
+		t.Fatalf("GOGC count = %d, want 1", got)
+	}
+}
+
+func unsetEnv(t *testing.T, key string) {
+	t.Helper()
+	old, ok := os.LookupEnv(key)
+	if err := os.Unsetenv(key); err != nil {
+		t.Fatalf("unset %s: %v", key, err)
+	}
+	t.Cleanup(func() {
+		if ok {
+			_ = os.Setenv(key, old)
+		} else {
+			_ = os.Unsetenv(key)
+		}
+	})
+}
+
+func envValue(env []string, key string) string {
+	prefix := key + "="
+	for _, entry := range env {
+		if len(entry) >= len(prefix) && entry[:len(prefix)] == prefix {
+			return entry[len(prefix):]
+		}
+	}
+	return ""
+}
+
+func envKeyCount(env []string, key string) int {
+	prefix := key + "="
+	count := 0
+	for _, entry := range env {
+		if len(entry) >= len(prefix) && entry[:len(prefix)] == prefix {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/doltserver/sql_server_command_test.go
+++ b/internal/doltserver/sql_server_command_test.go
@@ -3,6 +3,7 @@ package doltserver
 import (
 	"os"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -71,6 +72,57 @@ func TestDoltSQLServerEnvTreatsEmptyAndOffAsOverrides(t *testing.T) {
 	}
 }
 
+func TestDoltSQLServerEnvPreservesWindowsCaseInsensitiveRuntimeOverrides(t *testing.T) {
+	tests := []struct {
+		name string
+		env  []string
+		want map[string]string
+	}{
+		{
+			name: "lowercase",
+			env:  []string{"gomemlimit=24GiB", "gogc=100"},
+			want: map[string]string{"GOMEMLIMIT": "24GiB", "GOGC": "100"},
+		},
+		{
+			name: "mixed empty off",
+			env:  []string{"GoMemLimit=off", "GoGc="},
+			want: map[string]string{"GOMEMLIMIT": "off", "GOGC": ""},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			env := doltSQLServerEnvForGOOS(tt.env, "windows")
+			for key, want := range tt.want {
+				got, ok := envValueForGOOS(env, key, "windows")
+				if !ok || got != want {
+					t.Fatalf("%s = %q (found %v), want %q", key, got, ok, want)
+				}
+				if got := envKeyCountForGOOS(env, key, "windows"); got != 1 {
+					t.Fatalf("%s count = %d, want 1", key, got)
+				}
+			}
+		})
+	}
+}
+
+func TestDoltSQLServerEnvKeepsPOSIXRuntimeKeysCaseSensitive(t *testing.T) {
+	env := doltSQLServerEnvForGOOS([]string{"gomemlimit=24GiB", "GoGc=100"}, "linux")
+
+	if got := envValue(env, "GOMEMLIMIT"); got != defaultDoltSQLServerGoMemLimit {
+		t.Fatalf("GOMEMLIMIT = %q, want default", got)
+	}
+	if got := envValue(env, "GOGC"); got != defaultDoltSQLServerGOGC {
+		t.Fatalf("GOGC = %q, want default", got)
+	}
+	if got := envValue(env, "gomemlimit"); got != "24GiB" {
+		t.Fatalf("gomemlimit = %q, want preserved lowercase value", got)
+	}
+	if got := envValue(env, "GoGc"); got != "100" {
+		t.Fatalf("GoGc = %q, want preserved mixed-case value", got)
+	}
+}
+
 func unsetEnv(t *testing.T, key string) {
 	t.Helper()
 	old, ok := os.LookupEnv(key)
@@ -97,10 +149,24 @@ func envValue(env []string, key string) string {
 }
 
 func envKeyCount(env []string, key string) int {
-	prefix := key + "="
+	return envKeyCountForGOOS(env, key, "")
+}
+
+func envValueForGOOS(env []string, key, goos string) (string, bool) {
+	for _, entry := range env {
+		entryKey, value, ok := strings.Cut(entry, "=")
+		if ok && envKeyMatches(entryKey, key, goos) {
+			return value, true
+		}
+	}
+	return "", false
+}
+
+func envKeyCountForGOOS(env []string, key, goos string) int {
 	count := 0
 	for _, entry := range env {
-		if len(entry) >= len(prefix) && entry[:len(prefix)] == prefix {
+		entryKey, _, ok := strings.Cut(entry, "=")
+		if ok && envKeyMatches(entryKey, key, goos) {
 			count++
 		}
 	}


### PR DESCRIPTION
Replacement for https://github.com/gastownhall/gastown/pull/4132.\n\nCarries forward the accepted bug fix on a clean branch based on upstream/main. The change centralizes dolt sql-server command construction so both manual and daemon-managed launches receive default Go runtime caps when operators have not set overrides.\n\nOriginal author attribution is preserved in the commit trailer.\n\nVerification:\n- PASS: CGO_ENABLED=0 go test ./internal/doltserver -run 'TestNewSQLServerCommandAddsRuntimeDefaults|TestDoltSQLServerEnvPreservesRuntimeOverrides|TestDoltSQLServerEnvTreatsEmptyAndOffAsOverrides'\n- PASS: git diff --check origin/main..HEAD\n- PASS: CGO_ENABLED=0 go test ./internal/daemon\n- NOTE: CGO_ENABLED=0 go test ./internal/doltserver ./internal/daemon hit existing unrelated internal/doltserver failure TestCleanStaleSocket_RemovesStaleFile; the new focused doltserver tests pass.\n\nPR Sheriff evidence was produced by gt-pr-sheriff-4132-cleanup; mutant reported implementation, focused verification, post-reviews, and gt-pr-sheriff-check --merge-gate all passed before the original push failed due GitHub HTTPS auth.