### PR TITLE
fix: clean worktree beads identity redirects

### DIFF
--- a/internal/beads/beads_redirect.go
+++ b/internal/beads/beads_redirect.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 )
@@ -108,16 +109,22 @@ func resolveBeadsDirWithDepth(beadsDir string, maxDepth int) string {
 	return resolveBeadsDirWithDepth(resolved, maxDepth-1)
 }
 
-// cleanBeadsRuntimeFiles removes gitignored runtime files from a .beads directory
-// while preserving tracked files (formulas/, README.md, config.yaml, .gitignore).
+// cleanBeadsRuntimeFiles removes redirect-local runtime and identity files from
+// a worktree .beads directory while preserving non-identity docs/config such as
+// formulas/, README.md, and .gitignore. Tracked identity files are hidden from
+// the worktree index before removal so managed worktrees stay clean.
 // This is safe to call even if the directory doesn't exist.
-func cleanBeadsRuntimeFiles(beadsDir string) error {
+func cleanBeadsRuntimeFiles(worktreePath, beadsDir string) error {
 	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
 		return nil // Nothing to clean
 	}
 
-	// Runtime files/patterns that are gitignored and safe to remove
+	// Runtime files/patterns and redirect-local identity files that are unsafe to
+	// keep next to a redirect. metadata.json/config.yaml can cause bd to bind to
+	// the worktree .beads before following the redirect.
 	runtimePatterns := []string{
+		// Redirect-local identity/config
+		"metadata.json", "config.yaml",
 		// Daemon runtime
 		"daemon.lock", "daemon.log", "daemon.pid", "bd.sock",
 		// Sync state
@@ -140,6 +147,12 @@ func cleanBeadsRuntimeFiles(beadsDir string) error {
 			continue
 		}
 		for _, match := range matches {
+			if filepath.Base(match) == "metadata.json" || filepath.Base(match) == "config.yaml" {
+				if err := hideTrackedWorktreePath(worktreePath, match); err != nil && firstErr == nil {
+					firstErr = err
+					continue
+				}
+			}
 			if err := os.RemoveAll(match); err != nil && firstErr == nil {
 				firstErr = err
 			}
@@ -147,6 +160,22 @@ func cleanBeadsRuntimeFiles(beadsDir string) error {
 	}
 
 	return firstErr
+}
+
+func hideTrackedWorktreePath(worktreePath, path string) error {
+	rel, err := filepath.Rel(worktreePath, path)
+	if err != nil || rel == "." || rel == ".." || strings.HasPrefix(rel, ".."+string(filepath.Separator)) {
+		return nil
+	}
+	rel = filepath.ToSlash(rel)
+	if err := exec.Command("git", "-C", worktreePath, "ls-files", "--error-unmatch", "--", rel).Run(); err != nil {
+		return nil
+	}
+	output, err := exec.Command("git", "-C", worktreePath, "update-index", "--skip-worktree", "--", rel).CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("marking %s skip-worktree: %s: %w", rel, strings.TrimSpace(string(output)), err)
+	}
+	return nil
 }
 
 // ComputeRedirectTarget computes the expected redirect target for a worktree.
@@ -349,19 +378,25 @@ func SetupRedirect(townRoot, worktreePath string) error {
 		}
 	}
 
-	// Clean up runtime files in .beads/ but preserve tracked files (formulas/, README.md, etc.)
+	// Clean up runtime/identity files in .beads/ but preserve non-identity tracked
+	// files (formulas/, README.md, etc.).
 	worktreeBeadsDir := filepath.Join(worktreePath, ".beads")
 
-	// Handle edge case: if .beads exists as a file (not directory), remove it.
+	// Handle edge cases: if .beads exists as a file or symlink, remove the path
+	// itself before cleanup. Using Lstat prevents cleanup from traversing a
+	// symlinked .beads and mutating its target.
 	// This can happen with stale state from previous failed operations or
 	// unusual clone state. MkdirAll would fail with "file exists" in this case.
-	if info, err := os.Stat(worktreeBeadsDir); err == nil && !info.IsDir() {
+	if info, err := os.Lstat(worktreeBeadsDir); err == nil && (info.Mode()&os.ModeSymlink != 0 || !info.IsDir()) {
+		if err := hideTrackedWorktreePath(worktreePath, worktreeBeadsDir); err != nil {
+			return fmt.Errorf("hiding stale .beads path: %w", err)
+		}
 		if err := os.Remove(worktreeBeadsDir); err != nil {
-			return fmt.Errorf("removing stale .beads file: %w", err)
+			return fmt.Errorf("removing stale .beads path: %w", err)
 		}
 	}
 
-	if err := cleanBeadsRuntimeFiles(worktreeBeadsDir); err != nil {
+	if err := cleanBeadsRuntimeFiles(worktreePath, worktreeBeadsDir); err != nil {
 		return fmt.Errorf("cleaning runtime files: %w", err)
 	}
 

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -3418,7 +3418,7 @@ func TestSetupRedirect(t *testing.T) {
 		}
 	})
 
-	t.Run("cleans runtime files but preserves config files", func(t *testing.T) {
+	t.Run("cleans runtime and identity files but preserves docs", func(t *testing.T) {
 		townRoot := t.TempDir()
 		rigRoot := filepath.Join(townRoot, "testrig")
 		rigBeads := filepath.Join(rigRoot, ".beads")
@@ -3436,11 +3436,10 @@ func TestSetupRedirect(t *testing.T) {
 		if err := os.WriteFile(filepath.Join(crewBeads, "daemon.lock"), []byte("1234"), 0644); err != nil {
 			t.Fatalf("write daemon.lock: %v", err)
 		}
-		// Local beads metadata is per-machine configuration and must survive startup.
+		// Local beads identity files should not survive next to a redirect.
 		if err := os.WriteFile(filepath.Join(crewBeads, "metadata.json"), []byte("{}"), 0644); err != nil {
 			t.Fatalf("write metadata.json: %v", err)
 		}
-		// Config files (should be preserved)
 		if err := os.WriteFile(filepath.Join(crewBeads, "config.yaml"), []byte("prefix: test"), 0644); err != nil {
 			t.Fatalf("write config: %v", err)
 		}
@@ -3456,13 +3455,13 @@ func TestSetupRedirect(t *testing.T) {
 		if _, err := os.Stat(filepath.Join(crewBeads, "daemon.lock")); !os.IsNotExist(err) {
 			t.Error("daemon.lock should have been removed")
 		}
-		if _, err := os.Stat(filepath.Join(crewBeads, "metadata.json")); err != nil {
-			t.Errorf("metadata.json should have been preserved: %v", err)
+		if _, err := os.Stat(filepath.Join(crewBeads, "metadata.json")); !os.IsNotExist(err) {
+			t.Fatalf("metadata.json should have been removed, stat err=%v", err)
 		}
 
-		// Verify config files were preserved
-		if _, err := os.Stat(filepath.Join(crewBeads, "config.yaml")); err != nil {
-			t.Errorf("config.yaml should have been preserved: %v", err)
+		// Verify identity config was removed while docs were preserved.
+		if _, err := os.Stat(filepath.Join(crewBeads, "config.yaml")); !os.IsNotExist(err) {
+			t.Fatalf("config.yaml should have been removed, stat err=%v", err)
 		}
 		if _, err := os.Stat(filepath.Join(crewBeads, "README.md")); err != nil {
 			t.Errorf("README.md should have been preserved: %v", err)
@@ -3475,17 +3474,149 @@ func TestSetupRedirect(t *testing.T) {
 		}
 	})
 
+	t.Run("removes tracked identity files without dirtying worktree", func(t *testing.T) {
+		townRoot := t.TempDir()
+		rigRoot := filepath.Join(townRoot, "testrig")
+		rigBeads := filepath.Join(rigRoot, ".beads")
+		crewPath := filepath.Join(rigRoot, "crew", "max")
+		crewBeads := filepath.Join(crewPath, ".beads")
+
+		if _, err := exec.LookPath("git"); err != nil {
+			t.Skip("git not available")
+		}
+		if err := os.MkdirAll(rigBeads, 0755); err != nil {
+			t.Fatalf("mkdir rig beads: %v", err)
+		}
+		if err := os.MkdirAll(crewBeads, 0755); err != nil {
+			t.Fatalf("mkdir crew beads: %v", err)
+		}
+
+		for _, args := range [][]string{
+			{"init", "--initial-branch=main"},
+			{"config", "user.email", "test@example.com"},
+			{"config", "user.name", "Test User"},
+		} {
+			cmd := exec.Command("git", args...)
+			cmd.Dir = crewPath
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git %v: %v\n%s", args, err, out)
+			}
+		}
+		if err := os.WriteFile(filepath.Join(crewBeads, "metadata.json"), []byte(`{"dolt_database":"stale"}`), 0644); err != nil {
+			t.Fatalf("write metadata: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(crewBeads, "config.yaml"), []byte("prefix: stale\n"), 0644); err != nil {
+			t.Fatalf("write config: %v", err)
+		}
+		for _, args := range [][]string{{"add", ".beads/metadata.json", ".beads/config.yaml"}, {"commit", "-m", "track beads identity"}} {
+			cmd := exec.Command("git", args...)
+			cmd.Dir = crewPath
+			if out, err := cmd.CombinedOutput(); err != nil {
+				t.Fatalf("git %v: %v\n%s", args, err, out)
+			}
+		}
+
+		if err := SetupRedirect(townRoot, crewPath); err != nil {
+			t.Fatalf("SetupRedirect failed: %v", err)
+		}
+		for _, name := range []string{"metadata.json", "config.yaml"} {
+			if _, err := os.Stat(filepath.Join(crewBeads, name)); !os.IsNotExist(err) {
+				t.Fatalf("%s should have been removed, stat err=%v", name, err)
+			}
+		}
+		status := exec.Command("git", "status", "--porcelain", "--", ".beads/metadata.json", ".beads/config.yaml")
+		status.Dir = crewPath
+		out, err := status.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git status: %v\n%s", err, out)
+		}
+		if strings.TrimSpace(string(out)) != "" {
+			t.Fatalf("tracked identity cleanup dirtied worktree:\n%s", out)
+		}
+		flags := exec.Command("git", "ls-files", "-v", "--", ".beads/metadata.json", ".beads/config.yaml")
+		flags.Dir = crewPath
+		out, err = flags.CombinedOutput()
+		if err != nil {
+			t.Fatalf("git ls-files: %v\n%s", err, out)
+		}
+		for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+			if line != "" && !strings.HasPrefix(line, "S ") {
+				t.Fatalf("tracked identity file should be skip-worktree, got %q", line)
+			}
+		}
+	})
+
+	t.Run("replaces symlinked worktree beads without mutating target", func(t *testing.T) {
+		townRoot := t.TempDir()
+		rigRoot := filepath.Join(townRoot, "testrig")
+		rigBeads := filepath.Join(rigRoot, ".beads")
+		crewPath := filepath.Join(rigRoot, "crew", "max")
+		crewBeads := filepath.Join(crewPath, ".beads")
+		metadata := []byte(`{"dolt_database":"canonical"}`)
+		config := []byte("prefix: canonical\n")
+
+		if err := os.MkdirAll(rigBeads, 0755); err != nil {
+			t.Fatalf("mkdir rig beads: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(rigBeads, "metadata.json"), metadata, 0644); err != nil {
+			t.Fatalf("write rig metadata: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(rigBeads, "config.yaml"), config, 0644); err != nil {
+			t.Fatalf("write rig config: %v", err)
+		}
+		if err := os.MkdirAll(crewPath, 0755); err != nil {
+			t.Fatalf("mkdir crew: %v", err)
+		}
+		if err := os.Symlink(rigBeads, crewBeads); err != nil {
+			t.Skipf("symlink unavailable: %v", err)
+		}
+
+		if err := SetupRedirect(townRoot, crewPath); err != nil {
+			t.Fatalf("SetupRedirect failed: %v", err)
+		}
+		info, err := os.Lstat(crewBeads)
+		if err != nil {
+			t.Fatalf("lstat crew beads: %v", err)
+		}
+		if info.Mode()&os.ModeSymlink != 0 {
+			t.Fatal("worktree .beads should have been replaced with a real directory")
+		}
+		gotMetadata, err := os.ReadFile(filepath.Join(rigBeads, "metadata.json"))
+		if err != nil {
+			t.Fatalf("read rig metadata: %v", err)
+		}
+		if string(gotMetadata) != string(metadata) {
+			t.Fatalf("rig metadata changed: got %q want %q", gotMetadata, metadata)
+		}
+		gotConfig, err := os.ReadFile(filepath.Join(rigBeads, "config.yaml"))
+		if err != nil {
+			t.Fatalf("read rig config: %v", err)
+		}
+		if string(gotConfig) != string(config) {
+			t.Fatalf("rig config changed: got %q want %q", gotConfig, config)
+		}
+	})
+
 	t.Run("rejects mayor/rig canonical location", func(t *testing.T) {
 		townRoot := t.TempDir()
 		rigRoot := filepath.Join(townRoot, "testrig")
 		rigBeads := filepath.Join(rigRoot, ".beads")
 		mayorRigPath := filepath.Join(rigRoot, "mayor", "rig")
+		mayorRigBeads := filepath.Join(mayorRigPath, ".beads")
+		metadata := []byte(`{"dolt_database":"canonical"}`)
+		config := []byte("prefix: canonical\n")
 
 		if err := os.MkdirAll(rigBeads, 0755); err != nil {
 			t.Fatalf("mkdir rig beads: %v", err)
 		}
-		if err := os.MkdirAll(mayorRigPath, 0755); err != nil {
+		if err := os.MkdirAll(mayorRigBeads, 0755); err != nil {
 			t.Fatalf("mkdir mayor/rig: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(mayorRigBeads, "metadata.json"), metadata, 0644); err != nil {
+			t.Fatalf("write mayor metadata: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(mayorRigBeads, "config.yaml"), config, 0644); err != nil {
+			t.Fatalf("write mayor config: %v", err)
 		}
 
 		err := SetupRedirect(townRoot, mayorRigPath)
@@ -3494,6 +3625,20 @@ func TestSetupRedirect(t *testing.T) {
 		}
 		if err != nil && !strings.Contains(err.Error(), "canonical") {
 			t.Errorf("error should mention canonical location, got: %v", err)
+		}
+		gotMetadata, readErr := os.ReadFile(filepath.Join(mayorRigBeads, "metadata.json"))
+		if readErr != nil {
+			t.Fatalf("metadata.json should be preserved: %v", readErr)
+		}
+		if string(gotMetadata) != string(metadata) {
+			t.Fatalf("metadata changed: got %q want %q", gotMetadata, metadata)
+		}
+		gotConfig, readErr := os.ReadFile(filepath.Join(mayorRigBeads, "config.yaml"))
+		if readErr != nil {
+			t.Fatalf("config.yaml should be preserved: %v", readErr)
+		}
+		if string(gotConfig) != string(config) {
+			t.Fatalf("config changed: got %q want %q", gotConfig, config)
 		}
 	})
 

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -1294,12 +1294,25 @@ func ensureBeadsRedirect(ctx RoleContext) {
 		if _, statErr := os.Stat(redirectPath); statErr == nil {
 			return
 		}
-	} else if data, readErr := os.ReadFile(redirectPath); readErr == nil && strings.TrimSpace(string(data)) == expected {
+	} else if data, readErr := os.ReadFile(redirectPath); readErr == nil && strings.TrimSpace(string(data)) == expected && !worktreeBeadsNeedsCleanup(ctx.WorkDir) {
 		return
 	}
 
 	// Use shared helper - silently ignore errors during prime
 	_ = beads.SetupRedirect(ctx.TownRoot, ctx.WorkDir)
+}
+
+func worktreeBeadsNeedsCleanup(workDir string) bool {
+	beadsDir := filepath.Join(workDir, ".beads")
+	if info, err := os.Lstat(beadsDir); err == nil && info.Mode()&os.ModeSymlink != 0 {
+		return true
+	}
+	for _, name := range []string{"metadata.json", "config.yaml"} {
+		if _, err := os.Lstat(filepath.Join(beadsDir, name)); err == nil {
+			return true
+		}
+	}
+	return false
 }
 
 // injectWorkContext extracts the current work context (rig, bead, molecule) from the

--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -1073,6 +1073,52 @@ func TestEnsureBeadsRedirect_RepairsExistingRedirectChain(t *testing.T) {
 	}
 }
 
+func TestEnsureBeadsRedirect_CleansIdentityFilesWhenRedirectAlreadyCorrect(t *testing.T) {
+	townRoot := t.TempDir()
+	rigRoot := filepath.Join(townRoot, "testrig")
+	rigBeadsDir := filepath.Join(rigRoot, ".beads")
+	workDir := filepath.Join(rigRoot, "crew", "worker1")
+	workBeadsDir := filepath.Join(workDir, ".beads")
+	redirectPath := filepath.Join(workBeadsDir, "redirect")
+
+	if err := os.MkdirAll(rigBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir rig beads dir: %v", err)
+	}
+	if err := os.MkdirAll(workBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir work beads dir: %v", err)
+	}
+	if err := os.WriteFile(redirectPath, []byte("../../.beads\n"), 0644); err != nil {
+		t.Fatalf("write redirect: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workBeadsDir, "metadata.json"), []byte(`{"dolt_database":"stale"}`), 0644); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(workBeadsDir, "config.yaml"), []byte("prefix: stale\n"), 0644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	ctx := RoleContext{
+		Role:     RoleCrew,
+		WorkDir:  workDir,
+		TownRoot: townRoot,
+	}
+
+	ensureBeadsRedirect(ctx)
+
+	content, err := os.ReadFile(redirectPath)
+	if err != nil {
+		t.Fatalf("read redirect: %v", err)
+	}
+	if got, want := string(content), "../../.beads\n"; got != want {
+		t.Fatalf("redirect content = %q, want %q", got, want)
+	}
+	for _, name := range []string{"metadata.json", "config.yaml"} {
+		if _, err := os.Stat(filepath.Join(workBeadsDir, name)); !os.IsNotExist(err) {
+			t.Fatalf("%s should have been cleaned despite matching redirect, stat err=%v", name, err)
+		}
+	}
+}
+
 func TestOutputRalphLoopDirective_PluginInstalled(t *testing.T) {
 	attachment := &beads.AttachmentFields{
 		Mode:            "ralph",


### PR DESCRIPTION
Replacement for https://github.com/gastownhall/gastown/pull/4130.\n\nCarries forward the accepted bug fix on a clean branch based on upstream/main. The change keeps worktree .beads identity redirects clean and covered by focused tests.\n\nOriginal contributor attribution is preserved in the commit trailers.\n\nVerification:\n- PASS: git diff --check origin/main..HEAD\n- PASS: CGO_ENABLED=0 go test ./internal/beads ./internal/cmd -run 'Test.*Redirect|Test.*Prime|Test.*Beads'\n\nPR Sheriff evidence was produced by gt-pr-sheriff-4130-cleanup; guzzle reported completed work, focused tests, and PR Sheriff checker pass before the original push failed due GitHub HTTPS auth.