### PR TITLE
fix(refinery): close work bead on real merge success (stop re-dispatch churn)

### DIFF
--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -1205,26 +1205,15 @@ func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
 		}
 	}
 
-	// 1. Close source issue with reference to MR.
-	// Use ForceCloseWithReason to bypass dependency checks — the source issue
-	// may have an attached molecule (wisp) whose open steps would block a
-	// normal close. This matches how gt done handles closures.
-	if mr.SourceIssue != "" {
-		closeReason := fmt.Sprintf("Merged in %s", mr.ID)
-		if result.MergeCommit != "" {
-			closeReason = fmt.Sprintf("%s\ntarget_branch: %s\ncommit_sha: %s", closeReason, mr.Target, result.MergeCommit)
-		}
-		if err := e.beads.ForceCloseWithReason(closeReason, mr.SourceIssue); err != nil {
-			// Check if already closed (by polecat's gt done) — that's fine
-			if issue, showErr := e.beads.Show(mr.SourceIssue); showErr == nil && beads.IssueStatus(issue.Status).IsTerminal() {
-				_, _ = fmt.Fprintf(e.output, "[Engineer] Source issue already closed: %s\n", mr.SourceIssue)
-			} else {
-				_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to close source issue %s: %v\n", mr.SourceIssue, err)
-			}
-		} else {
-			_, _ = fmt.Fprintf(e.output, "[Engineer] Closed source issue: %s\n", mr.SourceIssue)
-		}
-	}
+	// 1. Close the work bead that this MR merged.
+	// This is the fix for the re-dispatch-churn bug: when an MR merges but its
+	// work bead stays open, the scheduler re-dispatches a polecat onto already
+	// merged work, which redoes it and then wedges in NEEDS_RECOVERY.
+	// closeMergedWorkBead resolves the bead (preferring source_issue, falling
+	// back to the worker agent bead's active_mr/last_source_issue), is
+	// idempotent on already-terminal beads, and is only ever reached on a real
+	// merge success (HandleMRInfoFailure never calls it).
+	closeMergedWorkBead(e.beads, e.output, mr, result.MergeCommit)
 
 	// 1.2. Close conflict-resolution tasks that this land has made moot (hq-jnap).
 	// Conflict beads otherwise outlive the successful re-land of their content
@@ -1289,6 +1278,100 @@ func (e *Engineer) HandleMRInfoSuccess(mr *MRInfo, result ProcessResult) {
 
 func (e *Engineer) clearAgentActiveMR(agentBeadID string) error {
 	return e.beads.ForAgentBead().UpdateAgentActiveMR(agentBeadID, "")
+}
+
+// workBeadCloser is the minimal slice of *beads.Beads that
+// closeMergedWorkBead needs. Extracting it as an interface lets the
+// merge->bead-closed behaviour be unit-tested with a fake, without a live
+// Dolt server.
+type workBeadCloser interface {
+	Show(id string) (*beads.Issue, error)
+	ForceCloseWithReason(reason string, ids ...string) error
+}
+
+// resolveMergedWorkBead determines which work bead a merged MR closes.
+//
+// Preference order:
+//  1. mr.SourceIssue — the source_issue field stamped on the MR at submit time
+//     (the normal, populated case).
+//  2. The worker agent bead's last_source_issue — the active_mr -> bead mapping.
+//     This is the fallback for MRs whose source_issue field is missing/blank
+//     (the case that produced re-dispatch churn: a real merge with nothing to
+//     close, so the work bead stayed open and got re-slung).
+//
+// Returns "" when no work bead can be resolved (e.g. an MR with no source_issue
+// and no resolvable agent bead) — callers treat that as "nothing to close".
+func resolveMergedWorkBead(bd workBeadCloser, mr *MRInfo) string {
+	if mr == nil {
+		return ""
+	}
+	if mr.SourceIssue != "" {
+		return mr.SourceIssue
+	}
+	if mr.AgentBead == "" {
+		return ""
+	}
+	agent, err := bd.Show(mr.AgentBead)
+	if err != nil || agent == nil {
+		return ""
+	}
+	fields := beads.ParseAgentFields(agent.Description)
+	if fields == nil {
+		return ""
+	}
+	return fields.LastSourceIssue
+}
+
+// closeMergedWorkBead closes the work bead associated with a successfully
+// merged MR. It MUST only be called on a real merge success — never on a
+// reject, conflict, or slot timeout (HandleMRInfoFailure does not call it).
+//
+// Properties:
+//   - Idempotent: if the bead is already terminal (e.g. closed by the polecat's
+//     `gt done`), it is a no-op and never reports an error.
+//   - Force-closes to bypass open-molecule-step dependency checks, matching how
+//     `gt done` closes work beads.
+//   - Resolves the bead via resolveMergedWorkBead (source_issue, then the agent
+//     bead's active_mr -> last_source_issue fallback).
+func closeMergedWorkBead(bd workBeadCloser, out io.Writer, mr *MRInfo, mergeCommit string) {
+	logf := func(format string, args ...interface{}) {
+		if out != nil {
+			_, _ = fmt.Fprintf(out, format, args...)
+		}
+	}
+
+	workBead := resolveMergedWorkBead(bd, mr)
+	if workBead == "" {
+		logf("[Engineer] Note: merged MR %s has no resolvable work bead to close\n", mr.ID)
+		return
+	}
+
+	// Idempotency guard: if the work bead is already terminal, do nothing.
+	// A re-run of post-merge cleanup (or a polecat that already ran `gt done`)
+	// must never error here.
+	if issue, err := bd.Show(workBead); err == nil && issue != nil &&
+		beads.IssueStatus(issue.Status).IsTerminal() {
+		logf("[Engineer] Work bead already closed: %s\n", workBead)
+		return
+	}
+
+	closeReason := fmt.Sprintf("Merged in %s", mr.ID)
+	if mergeCommit != "" {
+		closeReason = fmt.Sprintf("%s\ntarget_branch: %s\ncommit_sha: %s", closeReason, mr.Target, mergeCommit)
+	}
+
+	if err := bd.ForceCloseWithReason(closeReason, workBead); err != nil {
+		// Lost a race with another closer (polecat `gt done`, a concurrent
+		// post-merge) — re-check terminal state before warning.
+		if issue, showErr := bd.Show(workBead); showErr == nil && issue != nil &&
+			beads.IssueStatus(issue.Status).IsTerminal() {
+			logf("[Engineer] Work bead already closed: %s\n", workBead)
+		} else {
+			logf("[Engineer] Warning: failed to close work bead %s: %v\n", workBead, err)
+		}
+		return
+	}
+	logf("[Engineer] Closed work bead: %s\n", workBead)
 }
 
 // HandleMRInfoFailure handles a failed merge from MRInfo.

--- a/internal/refinery/engineer_bead_close_test.go
+++ b/internal/refinery/engineer_bead_close_test.go
@@ -1,0 +1,187 @@
+package refinery
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/steveyegge/gastown/internal/beads"
+)
+
+// fakeWorkBeadCloser is an in-memory stand-in for *beads.Beads, exercising the
+// merge->bead-closed behaviour without a live Dolt server.
+type fakeWorkBeadCloser struct {
+	issues     map[string]*beads.Issue
+	closeCalls []string // work-bead IDs passed to ForceCloseWithReason, in order
+	closeErr   error    // if set, ForceCloseWithReason returns this error
+}
+
+func newFakeCloser() *fakeWorkBeadCloser {
+	return &fakeWorkBeadCloser{issues: map[string]*beads.Issue{}}
+}
+
+func (f *fakeWorkBeadCloser) add(i *beads.Issue) { f.issues[i.ID] = i }
+
+func (f *fakeWorkBeadCloser) Show(id string) (*beads.Issue, error) {
+	i, ok := f.issues[id]
+	if !ok {
+		return nil, fmt.Errorf("issue %s not found", id)
+	}
+	return i, nil
+}
+
+func (f *fakeWorkBeadCloser) ForceCloseWithReason(reason string, ids ...string) error {
+	if f.closeErr != nil {
+		return f.closeErr
+	}
+	for _, id := range ids {
+		f.closeCalls = append(f.closeCalls, id)
+		if i, ok := f.issues[id]; ok {
+			i.Status = string(beads.StatusClosed)
+		}
+	}
+	return nil
+}
+
+// TestCloseMergedWorkBead_SuccessClosesSourceIssue proves that a successful
+// merge closes the source work bead — the core fix for re-dispatch churn.
+func TestCloseMergedWorkBead_SuccessClosesSourceIssue(t *testing.T) {
+	f := newFakeCloser()
+	f.add(&beads.Issue{ID: "gt-work", Status: string(beads.StatusOpen)})
+
+	var out bytes.Buffer
+	mr := &MRInfo{ID: "gt-mr", SourceIssue: "gt-work", Target: "main"}
+
+	closeMergedWorkBead(f, &out, mr, "abc123")
+
+	if got := f.issues["gt-work"].Status; got != string(beads.StatusClosed) {
+		t.Fatalf("work bead status = %q, want closed", got)
+	}
+	if len(f.closeCalls) != 1 || f.closeCalls[0] != "gt-work" {
+		t.Fatalf("close calls = %v, want [gt-work]", f.closeCalls)
+	}
+}
+
+// TestCloseMergedWorkBead_FallsBackToAgentActiveMR proves the active_mr -> bead
+// fallback: when the MR has no source_issue, the work bead is resolved from the
+// worker agent bead's last_source_issue. This is the path that previously left
+// the work bead open (nothing to close) and caused re-dispatch.
+func TestCloseMergedWorkBead_FallsBackToAgentActiveMR(t *testing.T) {
+	f := newFakeCloser()
+	f.add(&beads.Issue{ID: "gt-work", Status: string(beads.StatusOpen)})
+	f.add(&beads.Issue{
+		ID:          "agent-bead",
+		Status:      string(beads.StatusOpen),
+		Description: "active_mr: gt-mr\nlast_source_issue: gt-work\n",
+	})
+
+	var out bytes.Buffer
+	mr := &MRInfo{ID: "gt-mr", SourceIssue: "", AgentBead: "agent-bead", Target: "main"}
+
+	closeMergedWorkBead(f, &out, mr, "abc123")
+
+	if got := f.issues["gt-work"].Status; got != string(beads.StatusClosed) {
+		t.Fatalf("work bead status = %q, want closed (via agent active_mr fallback)", got)
+	}
+}
+
+// TestCloseMergedWorkBead_Idempotent proves that an already-closed work bead is
+// a no-op — no error, no second close call. Covers the polecat-already-ran-
+// gt-done race and re-run of post-merge cleanup.
+func TestCloseMergedWorkBead_Idempotent(t *testing.T) {
+	f := newFakeCloser()
+	f.add(&beads.Issue{ID: "gt-work", Status: string(beads.StatusClosed)})
+
+	var out bytes.Buffer
+	mr := &MRInfo{ID: "gt-mr", SourceIssue: "gt-work", Target: "main"}
+
+	closeMergedWorkBead(f, &out, mr, "abc123")
+
+	if len(f.closeCalls) != 0 {
+		t.Fatalf("expected no close calls for already-terminal bead, got %v", f.closeCalls)
+	}
+}
+
+// TestCloseMergedWorkBead_NoResolvableBead proves that an MR with no
+// source_issue and no agent bead is a safe no-op (nothing to close, no panic).
+func TestCloseMergedWorkBead_NoResolvableBead(t *testing.T) {
+	f := newFakeCloser()
+	var out bytes.Buffer
+	mr := &MRInfo{ID: "gt-mr", Target: "main"}
+
+	closeMergedWorkBead(f, &out, mr, "")
+
+	if len(f.closeCalls) != 0 {
+		t.Fatalf("expected no close calls, got %v", f.closeCalls)
+	}
+}
+
+// TestCloseMergedWorkBead_CloseErrorDoesNotPanic proves that a hard close
+// failure (work bead still open afterward) is reported as a warning, not a
+// panic or a false "closed". The bead correctly stays open so dispatch state is
+// truthful.
+func TestCloseMergedWorkBead_CloseErrorDoesNotPanic(t *testing.T) {
+	f := newFakeCloser()
+	f.add(&beads.Issue{ID: "gt-work", Status: string(beads.StatusOpen)})
+	f.closeErr = fmt.Errorf("dolt unavailable")
+
+	var out bytes.Buffer
+	mr := &MRInfo{ID: "gt-mr", SourceIssue: "gt-work", Target: "main"}
+
+	closeMergedWorkBead(f, &out, mr, "abc123")
+
+	if got := f.issues["gt-work"].Status; got != string(beads.StatusOpen) {
+		t.Fatalf("work bead status = %q, want still open after close error", got)
+	}
+	if !strings.Contains(out.String(), "Warning: failed to close work bead") {
+		t.Fatalf("expected close-failure warning, got: %q", out.String())
+	}
+}
+
+// TestRejectPath_DoesNotCloseWorkBead proves the negative case structurally:
+// the merge-bead close (closeMergedWorkBead) must be reached ONLY from the
+// merge-success handler, never from the reject/conflict handler. A reject must
+// leave the work bead open so the polecat can fix and resubmit.
+//
+// We assert this by inspecting the source of HandleMRInfoFailure and verifying
+// it contains no call to closeMergedWorkBead. This guards against a future edit
+// that wires the close into the failure path (which would close beads on
+// reject).
+func TestRejectPath_DoesNotCloseWorkBead(t *testing.T) {
+	src, err := os.ReadFile("engineer.go")
+	if err != nil {
+		t.Fatalf("read engineer.go: %v", err)
+	}
+
+	// Extract the body of HandleMRInfoFailure.
+	body := string(src)
+	start := strings.Index(body, "func (e *Engineer) HandleMRInfoFailure(")
+	if start == -1 {
+		t.Fatal("could not locate HandleMRInfoFailure in engineer.go")
+	}
+	rest := body[start:]
+	// End at the next top-level func declaration.
+	nextFunc := regexp.MustCompile(`\nfunc `).FindStringIndex(rest[1:])
+	failureBody := rest
+	if nextFunc != nil {
+		failureBody = rest[:nextFunc[0]+1]
+	}
+
+	if strings.Contains(failureBody, "closeMergedWorkBead") {
+		t.Fatal("HandleMRInfoFailure must NOT call closeMergedWorkBead — " +
+			"rejects/conflicts must leave the work bead open")
+	}
+
+	// And confirm the success handler IS the call site, so the test is meaningful.
+	successIdx := strings.Index(body, "func (e *Engineer) HandleMRInfoSuccess(")
+	if successIdx == -1 {
+		t.Fatal("could not locate HandleMRInfoSuccess")
+	}
+	successBody := body[successIdx:start]
+	if !strings.Contains(successBody, "closeMergedWorkBead") {
+		t.Fatal("HandleMRInfoSuccess should call closeMergedWorkBead (fix regressed?)")
+	}
+}


### PR DESCRIPTION
## Problem

When a polecat's MR/PR merges, its **work bead can stay OPEN**. The scheduler then re-dispatches a polecat onto already-merged work — the polecat redoes the work and wedges in `NEEDS_RECOVERY`. We observed this live as recurring re-dispatch churn.

The deterministic merge-success handler `HandleMRInfoSuccess` only closed the source issue inside `if mr.SourceIssue != ""`. When the merged MR carried no resolvable `source_issue`, the merge succeeded but **nothing closed the work bead** — it stayed open and got re-slung. There was no fallback to the worker agent bead's `active_mr → work-bead` mapping, which is exactly the link that survives when `source_issue` is absent.

## Fix

Extract the close into `closeMergedWorkBead(bd, out, mr, mergeCommit)`, called from `HandleMRInfoSuccess` on **real merge success only** (`HandleMRInfoFailure` never calls it, so rejects/conflicts still leave the work bead open for re-submit). The helper:

- Resolves the work bead via `source_issue` first, then falls back to the worker agent bead's `last_source_issue` (the `active_mr → bead` mapping).
- Is **idempotent**: an already-terminal bead is a no-op, never an error (covers the polecat-already-ran-`gt done` race and post-merge re-runs).
- Force-closes to bypass open-molecule-step dependency checks, matching how `gt done` closes work beads.

A small `workBeadCloser` interface is extracted so the merge → bead-closed behaviour is unit-testable with a fake (no live Dolt server required).

## Test

`internal/refinery/engineer_bead_close_test.go` covers: close via `source_issue`; fallback via the agent bead's `last_source_issue` when `source_issue` is blank (the churn case); idempotency on an already-terminal bead; and that a failure path (`HandleMRInfoFailure`) never closes the bead. `go build ./...` and `go test ./internal/refinery/` pass against `main`.

## Methodology note

This came out of treating a recurring operational symptom (re-dispatch churn / `NEEDS_RECOVERY` after merge) as a determinism gap: the merge-success path should leave exactly one well-defined post-state (work bead terminal), not depend on a field that is sometimes empty. The fallback closes that gap deterministically rather than relying on the polecat having already self-closed.
