### PR TITLE
fix(polecat): submit uncommitted work on session Stop, not just unpushed commits

### DIFF
--- a/internal/cmd/tap_polecat_stop.go
+++ b/internal/cmd/tap_polecat_stop.go
@@ -97,20 +97,23 @@ func runTapPolecatStop(cmd *cobra.Command, args []string) error {
 		return nil // On default branch — nothing to submit
 	}
 
-	// Check for commits ahead of origin/main
-	aheadCmd := exec.Command("git", "-C", cloneDir, "rev-list", "--count", "origin/main..HEAD")
-	aheadOut, err := aheadCmd.Output()
-	if err != nil {
-		return nil // Can't check — exit quietly (don't block session stop)
-	}
-	ahead := strings.TrimSpace(string(aheadOut))
-	if ahead == "0" {
-		return nil // No commits ahead — nothing to submit
+	// Decide whether the polecat has work to submit. This covers BOTH:
+	//   - committed-but-unpushed work (commits ahead of origin/main), and
+	//   - uncommitted work in the working tree (files written but never committed).
+	// The second case is the stranding bug this fix targets: the agent wrote
+	// implementation files, finished its turn (firing Stop), but never ran
+	// `git commit && gt done` — so there are 0 commits ahead and the old check
+	// bailed, leaving the work to rot into NEEDS_RECOVERY. gt done's gt-pvx
+	// auto-commit safety net commits dirty work before submitting, so handing
+	// the uncommitted case to gt done lands the work instead of stranding it.
+	decision := polecatStopPendingWork(cloneDir)
+	if !decision.HasWork {
+		return nil // Nothing to submit — exit quietly
 	}
 
 	// Polecat has pending work! Run gt done as a safety net.
 	fmt.Fprintf(os.Stderr, "\n")
-	fmt.Fprintf(os.Stderr, "⚠️  Polecat %s has %s unpushed commit(s) on branch %s\n", polecatName, ahead, branch)
+	fmt.Fprintf(os.Stderr, "⚠️  Polecat %s has unsubmitted work on branch %s (%s)\n", polecatName, branch, decision.Reason)
 	fmt.Fprintf(os.Stderr, "   Auto-running gt done as safety net...\n")
 	fmt.Fprintf(os.Stderr, "\n")
 
@@ -136,4 +139,57 @@ func runTapPolecatStop(cmd *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+// polecatStopDecision is the pure result of inspecting a polecat worktree for
+// unsubmitted work at session-Stop time.
+type polecatStopDecision struct {
+	HasWork bool
+	Reason  string // human-readable description of what triggered the submit
+}
+
+// polecatStopPendingWork inspects a polecat's git worktree and reports whether
+// it holds work that should be submitted via gt done.
+//
+// It returns HasWork=true when EITHER:
+//   - there are commits ahead of origin/main (committed-but-unpushed work), OR
+//   - the working tree is dirty (uncommitted work — files written but never
+//     committed before the session's turn ended).
+//
+// The uncommitted-work case is the core of the submit-reliability fix: gt done
+// auto-commits dirty work (gt-pvx) before submitting, so routing it through gt
+// done lands the work instead of letting it strand into NEEDS_RECOVERY. This is
+// safe to do on Stop because the Claude Code Stop hook fires only when the agent
+// finishes its turn normally — it does NOT fire on context-limit (PreCompact),
+// crash, or API error — so a Stop is a genuine completion signal, not a snapshot
+// of an in-flight edit. Git errors fail closed (HasWork=false) so a transient
+// git failure never blocks session stop.
+func polecatStopPendingWork(cloneDir string) polecatStopDecision {
+	// Committed-but-unpushed: commits ahead of origin/main.
+	aheadOut, err := exec.Command("git", "-C", cloneDir, "rev-list", "--count", "origin/main..HEAD").Output()
+	if err == nil {
+		ahead := strings.TrimSpace(string(aheadOut))
+		if ahead != "" && ahead != "0" {
+			return polecatStopDecision{
+				HasWork: true,
+				Reason:  ahead + " unpushed commit(s)",
+			}
+		}
+	}
+
+	// Uncommitted work: dirty working tree. `git status --porcelain` prints one
+	// line per changed/untracked path; any output means there is work that gt
+	// done will auto-commit and submit. gt done itself filters out runtime/overlay
+	// artifacts (CLAUDE.local.md, .runtime, etc.) before committing, so a strict
+	// emptiness check here is intentionally conservative: if anything is dirty we
+	// hand off to gt done, which makes the authoritative include/exclude decision.
+	statusOut, err := exec.Command("git", "-C", cloneDir, "status", "--porcelain").Output()
+	if err == nil && strings.TrimSpace(string(statusOut)) != "" {
+		return polecatStopDecision{
+			HasWork: true,
+			Reason:  "uncommitted changes",
+		}
+	}
+
+	return polecatStopDecision{HasWork: false}
 }

--- a/internal/cmd/tap_polecat_stop_test.go
+++ b/internal/cmd/tap_polecat_stop_test.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// gitRun runs a git command in dir and fails the test on error.
+func gitRun(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", append([]string{"-C", dir}, args...)...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v failed: %v\n%s", args, err, out)
+	}
+}
+
+// setupPolecatRepo creates a git repo with an origin remote and a feature branch
+// checked out, mirroring a polecat worktree. Returns the worktree (clone) dir.
+func setupPolecatRepo(t *testing.T) string {
+	t.Helper()
+
+	// Bare "origin" the clone tracks as origin/main.
+	originDir := t.TempDir()
+	gitRun(t, originDir, "init", "--bare", "--initial-branch=main")
+
+	cloneDir := t.TempDir()
+	gitRun(t, cloneDir, "init", "--initial-branch=main")
+	gitRun(t, cloneDir, "config", "user.email", "test@example.com")
+	gitRun(t, cloneDir, "config", "user.name", "Test")
+	gitRun(t, cloneDir, "remote", "add", "origin", originDir)
+
+	// Seed an initial commit and publish main so origin/main exists.
+	psWriteFile(t, cloneDir, "README.md", "seed\n")
+	gitRun(t, cloneDir, "add", "README.md")
+	gitRun(t, cloneDir, "commit", "-m", "seed")
+	gitRun(t, cloneDir, "push", "origin", "main")
+
+	// Move onto a feature branch (what a polecat works on).
+	gitRun(t, cloneDir, "checkout", "-b", "polecat/feature")
+	return cloneDir
+}
+
+func psWriteFile(t *testing.T, dir, name, content string) {
+	t.Helper()
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+}
+
+func TestPolecatStopPendingWork(t *testing.T) {
+	t.Run("clean feature branch — no work", func(t *testing.T) {
+		dir := setupPolecatRepo(t)
+		d := polecatStopPendingWork(dir)
+		if d.HasWork {
+			t.Fatalf("expected no work on clean branch, got reason=%q", d.Reason)
+		}
+	})
+
+	t.Run("uncommitted changes — work detected (the stranding bug)", func(t *testing.T) {
+		dir := setupPolecatRepo(t)
+		// Agent wrote a file but never committed before the turn ended.
+		psWriteFile(t, dir, "impl.go", "package impl\n")
+		d := polecatStopPendingWork(dir)
+		if !d.HasWork {
+			t.Fatal("expected work to be detected for uncommitted changes")
+		}
+		if d.Reason != "uncommitted changes" {
+			t.Fatalf("expected uncommitted-changes reason, got %q", d.Reason)
+		}
+	})
+
+	t.Run("committed but unpushed — work detected", func(t *testing.T) {
+		dir := setupPolecatRepo(t)
+		psWriteFile(t, dir, "impl.go", "package impl\n")
+		gitRun(t, dir, "add", "impl.go")
+		gitRun(t, dir, "commit", "-m", "impl")
+		d := polecatStopPendingWork(dir)
+		if !d.HasWork {
+			t.Fatal("expected work to be detected for committed-but-unpushed branch")
+		}
+		if d.Reason == "" {
+			t.Fatal("expected a non-empty reason for unpushed commits")
+		}
+	})
+
+	t.Run("bogus dir — fails closed, no work", func(t *testing.T) {
+		d := polecatStopPendingWork(filepath.Join(t.TempDir(), "does-not-exist"))
+		if d.HasWork {
+			t.Fatal("expected fail-closed (no work) for a non-repo dir")
+		}
+	})
+}


### PR DESCRIPTION
## Problem

Polecats were observed doing the work (writing implementation files) but the session turn ended before they ran `git commit && gt done` — stranding the work as **uncommitted changes in the worktree** → `NEEDS_RECOVERY` → work lost on reap.

There is already a Stop-hook safety net for this class of bug: the `polecats` role installs a Claude Code `Stop` hook running `gt tap polecat-stop-check`, and `gt done` itself auto-commits a dirty worktree before submitting. The `Stop` hook is the correct, well-gated trigger — per the Claude Code hooks spec, `Stop` fires **only** when the agent finishes its turn normally (never on context-limit, which is `PreCompact`, nor on crash/API error), so a `Stop` is a genuine completion signal, not a snapshot of an in-flight edit.

**The gap:** `polecat-stop-check` only invoked `gt done` when there were commits *ahead* of `origin/main` (`git rev-list --count origin/main..HEAD > 0`). In the exact stranding case the work is **uncommitted**, so the ahead-count is `0`, the hook concluded "nothing to submit", and exited — leaving the uncommitted work to rot.

## Fix

Extend the Stop-check decision to detect uncommitted work too. It now runs `gt done` when **either** there are commits ahead of `origin/main` **or** the working tree is dirty (`git status --porcelain` non-empty). `gt done`'s existing auto-commit safety net then commits and submits the work instead of stranding it. The decision is extracted into a pure `polecatStopPendingWork` helper that **fails closed** (no work) on any git error, so a transient git failure never blocks session stop.

## Test

`internal/cmd/tap_polecat_stop_test.go` (`TestPolecatStopPendingWork`) covers: clean feature branch → no work; uncommitted changes → work detected (the stranding bug); committed-but-unpushed → work detected; and a bogus dir → fails closed. `go build ./...` and the test pass against `main`.

## Methodology note

The fix deliberately reuses the existing, correctly-gated `Stop` trigger and the existing `gt done` auto-commit net rather than adding a new snapshot mechanism — it only widens the *detection* predicate to match the failure mode actually observed. The conservative "any dirt → hand to `gt done`" choice defers the authoritative include/exclude decision (runtime/overlay artifact filtering) to `gt done`, keeping one source of truth for what gets committed.
