### PR TITLE
fix(recovery): bead-closed ⇒ SAFE_TO_NUKE despite unpushed checkpoints

### DIFF
--- a/internal/cmd/polecat.go
+++ b/internal/cmd/polecat.go
@@ -1247,6 +1247,10 @@ func applyMQFactsToWorkstateInput(input *polecat.WorkstateInput, status *Recover
 	}
 	input.MQCheckRequired = true
 	input.AssignedBeadTerminal = beadTerminal
+	// beadTerminal here is workTerminal (assigned bead OR hook bead OR active-MR
+	// source terminal). When the work bead is closed, pre-squash checkpoint
+	// commits are not at-risk and must not produce a false NEEDS_RECOVERY.
+	input.WorkBeadClosed = beadTerminal
 	input.HasSubmittableWork = hasSubmittableWorkForRecovery(worktreePath, targetRefs, gitState, gitErr)
 	input.MQNotRequired = isMQNotRequiredSource(bd, status.Issue)
 	if !input.HasSubmittableWork || input.MQNotRequired || input.AssignedBeadTerminal {

--- a/internal/git/git_test.go
+++ b/internal/git/git_test.go
@@ -3170,6 +3170,184 @@ func TestUnpushedCommitsPrefersExactRemoteBranchOverUpstream(t *testing.T) {
 	}
 }
 
+// TestBranchPreservationGenuineUnmergedStillRecovers guards against a new false
+// NEGATIVE: real local commits whose content is NOT on origin/main must still
+// be reported as unpreserved so work is never silently lost.
+func TestBranchPreservationGenuineUnmergedStillRecovers(t *testing.T) {
+	localDir, _, mainBranch := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+	branch := "polecat/genuine-unmerged"
+
+	if err := g.CreateBranch(branch); err != nil {
+		t.Fatalf("CreateBranch: %v", err)
+	}
+	if err := g.Checkout(branch); err != nil {
+		t.Fatalf("Checkout: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "unmerged.go"),
+		[]byte("package main\n\n// real work not on origin\n"), 0644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := g.Add("unmerged.go"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if err := g.Commit("genuine unmerged work"); err != nil {
+		t.Fatalf("Commit: %v", err)
+	}
+	// Deliberately NOT pushed and NOT merged anywhere.
+
+	status, err := g.BranchPreservationStatus(branch, "origin", []string{mainBranch})
+	if err != nil {
+		t.Fatalf("BranchPreservationStatus: %v", err)
+	}
+	if status.Preserved {
+		t.Fatalf("genuine unmerged work must NOT be Preserved, got %+v", status)
+	}
+	if status.UnpreservedPatchCount < 1 {
+		t.Fatalf("UnpreservedPatchCount = %d, want >= 1 for genuine unmerged content", status.UnpreservedPatchCount)
+	}
+
+	unpushed, err := g.UnpushedCommits()
+	if err != nil {
+		t.Fatalf("UnpushedCommits: %v", err)
+	}
+	if unpushed < 1 {
+		t.Fatalf("UnpushedCommits = %d, want >= 1 — genuine work must still trigger recovery", unpushed)
+	}
+}
+
+// TestBranchPreservationSquashThenAdvancedOriginStillFlags documents WHY the
+// headTreeEqual git heuristic (commit da8452b5) failed live: when origin/main
+// advances PAST the squash commit (later PRs land on top), the polecat's HEAD
+// sits BEHIND an advanced origin/main. The 2-dot `git diff --quiet origin/main
+// HEAD` is then NON-empty (origin/main carries the later commits' content), so
+// headTreeEqual returns false, falls through to `git cherry`, and counts every
+// pre-squash checkpoint as unpushed → a false UnpreservedPatchCount > 0.
+//
+// This test asserts that FALSE positive still happens at the git layer. It is
+// the proof that the reliable fix cannot live in git tree gymnastics — it must
+// use the bead-closed signal at the decision layer (see workstate_test.go:
+// "closed work bead with unpushed checkpoints is safe"). The prior fix's own
+// unit test only exercised the HEAD==ref / origin-not-advanced case, which is
+// why it passed while production failed.
+func TestBranchPreservationSquashThenAdvancedOriginStillFlags(t *testing.T) {
+	localDir, _, mainBranch := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+	branch := "polecat/furiosa-advanced"
+
+	if err := g.CreateBranch(branch); err != nil {
+		t.Fatalf("CreateBranch: %v", err)
+	}
+	if err := g.Checkout(branch); err != nil {
+		t.Fatalf("Checkout: %v", err)
+	}
+	for i := 1; i <= 3; i++ {
+		if err := os.WriteFile(filepath.Join(localDir, "feature.go"),
+			[]byte(fmt.Sprintf("package feature\n\n// step %d\n", i)), 0644); err != nil {
+			t.Fatalf("write step %d: %v", i, err)
+		}
+		if err := g.Add("feature.go"); err != nil {
+			t.Fatalf("Add step %d: %v", i, err)
+		}
+		if err := g.Commit(fmt.Sprintf("checkpoint %d", i)); err != nil {
+			t.Fatalf("Commit step %d: %v", i, err)
+		}
+	}
+	if err := g.Push("origin", branch, false); err != nil {
+		t.Fatalf("Push branch: %v", err)
+	}
+
+	// Squash-merge into main, then ADVANCE main with an unrelated later commit
+	// (a subsequent PR that landed on top). This is the live shape the prior
+	// fix missed.
+	if err := g.Checkout(mainBranch); err != nil {
+		t.Fatalf("Checkout main: %v", err)
+	}
+	runGit(t, localDir, "merge", "--squash", branch)
+	if err := g.Commit("squash: feature (#389)"); err != nil {
+		t.Fatalf("Commit squash: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(localDir, "later.go"),
+		[]byte("package later\n\n// a subsequent PR landed on top\n"), 0644); err != nil {
+		t.Fatalf("write later: %v", err)
+	}
+	if err := g.Add("later.go"); err != nil {
+		t.Fatalf("Add later: %v", err)
+	}
+	if err := g.Commit("later: unrelated follow-up PR"); err != nil {
+		t.Fatalf("Commit later: %v", err)
+	}
+	if err := g.Push("origin", mainBranch, false); err != nil {
+		t.Fatalf("Push main: %v", err)
+	}
+	runGit(t, localDir, "fetch", "origin")
+
+	if err := g.Checkout(branch); err != nil {
+		t.Fatalf("Checkout branch: %v", err)
+	}
+
+	// The git heuristic alone cannot rescue this: HEAD's tree differs from the
+	// advanced origin/main (it lacks later.go), so headTreeEqual is false and
+	// cherry counts the checkpoints. Assert the FALSE positive to lock in the
+	// motivation for the bead-layer fix; if a future git change ever makes this
+	// genuinely 0, that is strictly safer and this test should be revisited.
+	status, err := g.BranchTargetStatus(branch, "origin", []string{mainBranch})
+	if err != nil {
+		t.Fatalf("BranchTargetStatus: %v", err)
+	}
+	if status.Preserved || status.UnpreservedPatchCount == 0 {
+		t.Fatalf("expected the git heuristic to FALSE-flag squash+advanced-origin work "+
+			"(motivating the bead-closed decision-layer fix), got Preserved=%v UnpreservedPatchCount=%d",
+			status.Preserved, status.UnpreservedPatchCount)
+	}
+}
+
+// TestBranchPreservationStaleBranchBehindOriginIgnored verifies that a stale
+// local branch whose content is fully behind origin/main (a huge-deletion diff
+// relative to a stale local main) is treated as content-preserved. These are
+// the ~25 leftover merge/wkb-* branches in the furiosa incident — they must not
+// count as unpushed work at risk. Only when HEAD adds content origin lacks is
+// it flagged.
+func TestBranchPreservationStaleBranchBehindOriginIgnored(t *testing.T) {
+	localDir, _, mainBranch := initTestRepoWithRemote(t)
+	g := NewGit(localDir)
+
+	// Advance origin/main with new content the local stale branch will lack.
+	if err := os.WriteFile(filepath.Join(localDir, "advanced.go"),
+		[]byte("package main\n\n// advanced on main\n"), 0644); err != nil {
+		t.Fatalf("write advanced: %v", err)
+	}
+	if err := g.Add("advanced.go"); err != nil {
+		t.Fatalf("Add advanced: %v", err)
+	}
+	if err := g.Commit("advance main"); err != nil {
+		t.Fatalf("Commit advance: %v", err)
+	}
+	if err := g.Push("origin", mainBranch, false); err != nil {
+		t.Fatalf("Push main: %v", err)
+	}
+	runGit(t, localDir, "fetch", "origin")
+
+	// Create a stale branch pointing at the OLD initial commit (behind origin).
+	// Its tree is a strict subset of origin/main — it adds nothing new.
+	staleBase, err := g.Rev("HEAD~1")
+	if err != nil {
+		t.Fatalf("Rev HEAD~1: %v", err)
+	}
+	runGit(t, localDir, "checkout", "-b", "merge/wkb-stale", strings.TrimSpace(staleBase))
+
+	status, err := g.BranchPreservationStatus("merge/wkb-stale", "origin", []string{mainBranch})
+	if err != nil {
+		t.Fatalf("BranchPreservationStatus: %v", err)
+	}
+	if !status.Preserved {
+		t.Fatalf("stale branch behind origin must be Preserved (adds no content), got %+v", status)
+	}
+	if status.UnpreservedPatchCount != 0 {
+		t.Fatalf("UnpreservedPatchCount = %d, want 0 for stale-behind-origin branch", status.UnpreservedPatchCount)
+	}
+}
+
 // TestBranchPushedToRemote_NoPushURL verifies baseline behavior: when fetch and
 // push URLs are the same, BranchPushedToRemote works normally.
 func TestBranchPushedToRemote_NoPushURL(t *testing.T) {

--- a/internal/polecat/reuse.go
+++ b/internal/polecat/reuse.go
@@ -30,6 +30,9 @@ type SlotReuseInput struct {
 	AssignedBeadTerminal bool
 	MRSubmitted          bool
 	MQLookupFailed       bool
+	// WorkBeadClosed: the work bead (assigned/source/hook) is terminal, so
+	// unpushed pre-squash checkpoint commits are not at-risk work.
+	WorkBeadClosed bool
 }
 
 // SlotReuseDecision explains whether a polecat can be reused and why not.
@@ -63,6 +66,7 @@ func DecideSlotReuse(in SlotReuseInput) SlotReuseDecision {
 		AssignedBeadTerminal: in.AssignedBeadTerminal,
 		MRSubmitted:          in.MRSubmitted,
 		MQLookupFailed:       in.MQLookupFailed,
+		WorkBeadClosed:       in.WorkBeadClosed,
 	})
 	return SlotReuseDecision{Reusable: d.Reusable, Reason: d.Reason}
 }

--- a/internal/polecat/workstate.go
+++ b/internal/polecat/workstate.go
@@ -18,23 +18,31 @@ type WorkstateInput struct {
 	CleanupStatus                  CleanupStatus
 	IgnoreCleanupStatus            bool
 	PartialSpawnWithoutDurableHook bool
-	PushFailed                     bool
-	MRFailed                       bool
-	Branch                         string
-	GitDirty                       bool
-	GitDirtyReason                 string
-	StashCount                     int
-	UnpushedCommits                int
-	GitCheckFailed                 bool
-	GitCheckFailedReason           string
-	ActiveMR                       string
-	ActiveMRBlocker                string
-	MQCheckRequired                bool
-	HasSubmittableWork             bool
-	MQNotRequired                  bool
-	AssignedBeadTerminal           bool
-	MRSubmitted                    bool
-	MQLookupFailed                 bool
+	// WorkBeadClosed is true when the polecat's work bead (assigned issue, hook
+	// bead, or active-MR source issue) is terminal — i.e. the MR merged and the
+	// bead was closed. When the work bead is closed, the polecat's HEAD commits
+	// are pre-squash checkpoints whose content already landed on the target
+	// branch via the squash commit, so a positive UnpushedCommits count is not
+	// at-risk work and must not block cleanup. Live uncommitted/stash/dirty
+	// state (real WIP) is still flagged independently.
+	WorkBeadClosed       bool
+	PushFailed           bool
+	MRFailed             bool
+	Branch               string
+	GitDirty             bool
+	GitDirtyReason       string
+	StashCount           int
+	UnpushedCommits      int
+	GitCheckFailed       bool
+	GitCheckFailedReason string
+	ActiveMR             string
+	ActiveMRBlocker      string
+	MQCheckRequired      bool
+	HasSubmittableWork   bool
+	MQNotRequired        bool
+	AssignedBeadTerminal bool
+	MRSubmitted          bool
+	MQLookupFailed       bool
 }
 
 // WorkstateDisposition is the canonical polecat lifecycle decision. It is pure
@@ -117,7 +125,15 @@ func DecideWorkstate(in WorkstateInput) WorkstateDisposition {
 	if in.StashCount > 0 {
 		block("git-stash", "git_state=has_stash stash_count="+itoa(in.StashCount))
 	}
-	if in.UnpushedCommits > 0 {
+	// Unpushed/ahead commits only signal at-risk work when the work bead is
+	// still open. Once the bead is closed (MR merged), those commits are the
+	// pre-squash checkpoints whose content already landed via the squash commit;
+	// counting them as unpushed is exactly the false NEEDS_RECOVERY that the
+	// 2-dot tree-diff heuristic failed to catch (HEAD sits behind an advanced
+	// origin/main, so the tree diff is non-empty and cherry counts every
+	// checkpoint). Dirty/stash/uncommitted state is handled above and is NOT
+	// suppressed here, so genuine live WIP on a closed-bead worktree still flags.
+	if in.UnpushedCommits > 0 && !in.WorkBeadClosed {
 		block("git-unpushed", "git_state=has_unpushed unpushed_commits="+itoa(in.UnpushedCommits))
 	}
 	activeMRBlocks := in.ActiveMRBlocker != ""

--- a/internal/polecat/workstate_test.go
+++ b/internal/polecat/workstate_test.go
@@ -43,6 +43,38 @@ func TestDecideWorkstateCanonicalFields(t *testing.T) {
 			in:   WorkstateInput{State: StateWorking, CleanupStatus: CleanupClean},
 			want: WorkstateDisposition{Verdict: WorkstateVerdictWorking, Reason: "not-idle", NeedsRecovery: false, CountsTowardCapacity: true},
 		},
+		{
+			// THE LIVE CASE the headTreeEqual git heuristic missed: a polecat
+			// whose work squash-merged so its bead closed, with pre-squash
+			// checkpoint commits still counted as unpushed (HEAD sits behind an
+			// advanced origin/main, so the 2-dot tree diff is non-empty and
+			// `git cherry` reports every checkpoint as unmerged). Clean worktree.
+			// WorkBeadClosed must make this SAFE_TO_NUKE, not NEEDS_RECOVERY.
+			name: "closed work bead with unpushed checkpoints is safe",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/nitro", UnpushedCommits: 36, WorkBeadClosed: true, MQCheckRequired: true, HasSubmittableWork: true, AssignedBeadTerminal: true},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictSafeToNuke, Reason: "reusable", Reusable: true, SafeToNuke: true, MQStatus: "submitted", ReuseStatus: "idle-preserved"},
+		},
+		{
+			// Regression: bead still OPEN with real unpushed content must STILL
+			// flag NEEDS_RECOVERY (no work loss). WorkBeadClosed=false.
+			name: "open bead with unpushed content still needs recovery",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/nitro", UnpushedCommits: 12, WorkBeadClosed: false},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "git-unpushed", NeedsRecovery: true, CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed"},
+		},
+		{
+			// Regression: closed bead but DIRTY worktree (uncommitted live WIP)
+			// must STILL flag. WorkBeadClosed only suppresses unpushed commits,
+			// never uncommitted/stash state.
+			name: "closed bead with dirty worktree still flags",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/nitro", UnpushedCommits: 36, GitDirty: true, GitDirtyReason: "git_state=has_uncommitted uncommitted_files=3", WorkBeadClosed: true},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "git-dirty", NeedsRecovery: true, CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed"},
+		},
+		{
+			// Regression: closed bead but a STASH present must STILL flag.
+			name: "closed bead with stash still flags",
+			in:   WorkstateInput{State: StateIdle, CleanupStatus: CleanupClean, Branch: "polecat/nitro", UnpushedCommits: 36, StashCount: 1, WorkBeadClosed: true},
+			want: WorkstateDisposition{Verdict: WorkstateVerdictNeedsRecovery, Reason: "git-stash", NeedsRecovery: true, CountsTowardCapacity: true, ReuseStatus: "idle-recovery-needed"},
+		},
 	}
 
 	for _, tt := range tests {

--- a/internal/witness/handlers.go
+++ b/internal/witness/handlers.go
@@ -1068,6 +1068,10 @@ func slotOpenDecision(workDir, townRoot, rigName, polecatName, exitType string) 
 	input.MQCheckRequired = input.Branch != ""
 	input.HasSubmittableWork = witnessHasSubmittableWork(clonePath)
 	input.AssignedBeadTerminal = witnessIssueTerminal(rigBeads, issueID)
+	// Work bead closed (assigned OR source OR hook terminal) ⇒ HEAD's unpushed
+	// commits are pre-squash checkpoints whose content already merged; they must
+	// not produce a false NEEDS_RECOVERY. Mirrors check-recovery's workTerminal.
+	input.WorkBeadClosed = input.AssignedBeadTerminal || sourceTerminal || hookTerminal
 	if polecat.CanIgnoreStaleCleanupStatus(input.CleanupStatus, input.AssignedBeadTerminal || sourceTerminal || hookTerminal, hookSafe, activeMRSafe, gitSafe) {
 		input.IgnoreCleanupStatus = true
 	}


### PR DESCRIPTION
## Problem

After a squash-merge where `origin/main` **advances past** the squash commit (later PRs land on top), a polecat's `HEAD` sits behind an advanced `origin/main`. A purely git-tree-based unpushed-commits heuristic then counts every pre-squash checkpoint commit as unpushed → a **false `NEEDS_RECOVERY` on every completion**, even though all of the polecat's content already merged.

We first tried to fix this at the git layer (a `headTreeEqual`-style content-equivalence check). It failed live: when `origin/main` carries later commits' content, the 2-dot `git diff origin/main HEAD` is non-empty, the equivalence check returns false, falls through to `git cherry`, and counts the checkpoints again. The git layer simply cannot distinguish "my squashed content already landed, origin then advanced" from "I have genuinely unmerged commits" using tree comparison alone.

## Fix — at the right layer

The reliable "work is safe" signal is that the polecat's **work bead is CLOSED** (MR merged ⇒ bead closed), not git-tree gymnastics. This PR adds `WorkstateInput.WorkBeadClosed`, wired from the existing `workTerminal = assigned || source || hook-terminal` signal in **both** the `check-recovery` and witness paths.

When the work bead is closed, `DecideWorkstate` suppresses **only** the unpushed-commits blocker — the pre-squash checkpoints whose content already merged. Everything else still blocks: dirty/stash/uncommitted state, `push_failed`, `mr_failed`, and an open active-MR. So **live WIP is never lost** and **open beads still need recovery** — only the specific false positive (closed bead + already-merged checkpoints + clean tree) is resolved.

## Test

- `internal/polecat/workstate_test.go`: closed bead + 36 unpushed + clean ⇒ `SAFE_TO_NUKE` (the live case); regressions — open bead + unpushed ⇒ `NEEDS_RECOVERY`; closed bead + dirty/stash ⇒ still flags.
- `internal/git/git_test.go`: `TestBranchPreservationSquashThenAdvancedOriginStillFlags` documents *why* the git heuristic alone is insufficient (it still false-flags squash + advanced-origin work), motivating the bead-layer signal.

`go build ./...`, `go test ./internal/polecat/` and `go test ./internal/git/` pass against `main`.

## Methodology note

This is a "fix it at the layer that has the reliable signal" change. The git layer can only ever approximate "is this work safe?"; the bead layer *knows* (the MR merged and closed the bead). Rather than pile heuristics onto the git comparison, the fix consults the authoritative state. (One git test that only made sense against the abandoned `headTreeEqual` intermediate was dropped during extraction — the bead-layer behaviour is fully covered by the polecat tests above.)
