### PR TITLE
fix(refinery): read merge_queue config from canonical settings/config.json

### DIFF
--- a/internal/cmd/rig_settings.go
+++ b/internal/cmd/rig_settings.go
@@ -14,6 +14,8 @@ import (
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/refinery"
+	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/style"
 )
 
@@ -35,6 +37,8 @@ Use dot notation to access nested keys (e.g., role_agents.witness).`,
 	RunE: requireSubcommand,
 }
 
+var rigSettingsShowEffective bool
+
 var rigSettingsShowCmd = &cobra.Command{
 	Use:     "show <rig>",
 	Aliases: []string{"get"},
@@ -43,8 +47,18 @@ var rigSettingsShowCmd = &cobra.Command{
 
 Shows the complete settings/config.json file as formatted JSON.
 
-Example:
-  gt rig settings show gastown`,
+With --effective, shows the merge_queue configuration exactly as the refinery
+will resolve it via LoadConfig (canonical settings/config.json, falling back to
+the legacy rig-root config.json), including defaults for unset fields. Use this
+to confirm that 'gt rig settings set merge_queue.*' values actually reach the
+refinery.
+
+Note: the legacy file <rig>/.gastown/settings.json is deprecated and read by
+nothing; it is ignored.
+
+Examples:
+  gt rig settings show gastown
+  gt rig settings show gastown --effective`,
 	Args: cobra.ExactArgs(1),
 	RunE: runRigSettingsShow,
 }
@@ -93,6 +107,9 @@ func init() {
 	rigSettingsCmd.AddCommand(rigSettingsShowCmd)
 	rigSettingsCmd.AddCommand(rigSettingsSetCmd)
 	rigSettingsCmd.AddCommand(rigSettingsUnsetCmd)
+
+	rigSettingsShowCmd.Flags().BoolVar(&rigSettingsShowEffective, "effective", false,
+		"Show the merge_queue config the refinery will load (resolved + defaults)")
 }
 
 func runRigSettingsShow(cmd *cobra.Command, args []string) error {
@@ -101,6 +118,10 @@ func runRigSettingsShow(cmd *cobra.Command, args []string) error {
 	_, r, err := getRig(rigName)
 	if err != nil {
 		return err
+	}
+
+	if rigSettingsShowEffective {
+		return runRigSettingsShowEffective(r)
 	}
 
 	settingsPath := filepath.Join(r.Path, "settings", "config.json")
@@ -120,6 +141,31 @@ func runRigSettingsShow(cmd *cobra.Command, args []string) error {
 		return fmt.Errorf("formatting settings: %w", err)
 	}
 
+	fmt.Println(string(data))
+	return nil
+}
+
+// runRigSettingsShowEffective prints the merge_queue configuration exactly as
+// the refinery resolves it via Engineer.LoadConfig (canonical
+// settings/config.json with legacy rig-root config.json fallback), with defaults
+// applied for unset fields. This lets operators confirm that values written by
+// 'gt rig settings set merge_queue.*' actually reach the refinery.
+func runRigSettingsShowEffective(r *rig.Rig) error {
+	cfg, srcPath, err := refinery.EffectiveConfig(r)
+	if err != nil {
+		return fmt.Errorf("resolving effective merge_queue config: %w", err)
+	}
+
+	if srcPath == "" {
+		fmt.Println("# source: (none — compiled-in defaults)")
+	} else {
+		fmt.Printf("# source: %s\n", srcPath)
+	}
+
+	data, err := json.MarshalIndent(cfg, "", "  ")
+	if err != nil {
+		return fmt.Errorf("formatting effective config: %w", err)
+	}
 	fmt.Println(string(data))
 	return nil
 }

--- a/internal/cmd/rig_settings_test.go
+++ b/internal/cmd/rig_settings_test.go
@@ -9,6 +9,8 @@ import (
 	"time"
 
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/refinery"
+	"github.com/steveyegge/gastown/internal/rig"
 )
 
 // setupTestRigForSettings creates a test rig for settings testing.
@@ -27,9 +29,9 @@ func setupTestRigForSettings(t *testing.T) (string, string) {
 	// Create town.json (primary marker for workspace detection)
 	townConfig := &config.TownConfig{
 		Type:      "town",
-		Version:    config.CurrentTownVersion,
-		Name:       "test-town",
-		CreatedAt:  time.Now().Truncate(time.Second),
+		Version:   config.CurrentTownVersion,
+		Name:      "test-town",
+		CreatedAt: time.Now().Truncate(time.Second),
 	}
 	townConfigPath := filepath.Join(mayorDir, "town.json")
 	if err := config.SaveTownConfig(townConfigPath, townConfig); err != nil {
@@ -814,5 +816,116 @@ func TestParseValue(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestRigSettingsWriterReaderAgree is the regression test for hq-am01: it proves
+// that values written by `gt rig settings set merge_queue.*` (writer →
+// settings/config.json) are the values the refinery resolves via LoadConfig
+// (reader). Before the fix the reader read the rig-root config.json and silently
+// fell back to DefaultMergeQueueConfig (on_conflict=assign_back, max_concurrent=1).
+func TestRigSettingsWriterReaderAgree(t *testing.T) {
+	townRoot, rigName := setupTestRigForSettings(t)
+	rigPath := filepath.Join(townRoot, rigName)
+
+	// Writer path: drive the real `gt rig settings set` handlers.
+	if err := runRigSettingsSet(rigSettingsSetCmd, []string{rigName, "merge_queue.max_concurrent", "3"}); err != nil {
+		t.Fatalf("set merge_queue.max_concurrent: %v", err)
+	}
+	if err := runRigSettingsSet(rigSettingsSetCmd, []string{rigName, "merge_queue.on_conflict", "auto_rebase"}); err != nil {
+		t.Fatalf("set merge_queue.on_conflict: %v", err)
+	}
+
+	// Sanity: the writer wrote settings/config.json (canonical path).
+	settingsPath := filepath.Join(rigPath, "settings", "config.json")
+	if _, err := os.Stat(settingsPath); err != nil {
+		t.Fatalf("expected writer to create %s: %v", settingsPath, err)
+	}
+
+	// Reader path: exactly what the refinery's LoadConfig resolves.
+	r := &rig.Rig{Name: rigName, Path: rigPath}
+	cfg, srcPath, err := refinery.EffectiveConfig(r)
+	if err != nil {
+		t.Fatalf("EffectiveConfig: %v", err)
+	}
+
+	if srcPath != settingsPath {
+		t.Errorf("effective config source = %q, want canonical %q", srcPath, settingsPath)
+	}
+	if cfg.MaxConcurrent != 3 {
+		t.Errorf("MaxConcurrent = %d, want 3 (writer value, not default 1)", cfg.MaxConcurrent)
+	}
+	if cfg.OnConflict != "auto_rebase" {
+		t.Errorf("OnConflict = %q, want %q (writer value, not default assign_back)", cfg.OnConflict, "auto_rebase")
+	}
+}
+
+// TestRigSettingsShowEffective verifies `gt rig settings show --effective` runs
+// against the canonical file and surfaces resolved values (with defaults applied
+// for unset fields).
+func TestRigSettingsShowEffective(t *testing.T) {
+	townRoot, rigName := setupTestRigForSettings(t)
+	rigPath := filepath.Join(townRoot, rigName)
+
+	if err := runRigSettingsSet(rigSettingsSetCmd, []string{rigName, "merge_queue.max_concurrent", "4"}); err != nil {
+		t.Fatalf("set merge_queue.max_concurrent: %v", err)
+	}
+
+	// Drive the --effective path; must not error and must read the set value.
+	prev := rigSettingsShowEffective
+	rigSettingsShowEffective = true
+	t.Cleanup(func() { rigSettingsShowEffective = prev })
+
+	if err := runRigSettingsShow(rigSettingsShowCmd, []string{rigName}); err != nil {
+		t.Fatalf("runRigSettingsShow --effective: %v", err)
+	}
+
+	// Confirm the underlying resolver returns the set value plus defaults.
+	r := &rig.Rig{Name: rigName, Path: rigPath}
+	cfg, _, err := refinery.EffectiveConfig(r)
+	if err != nil {
+		t.Fatalf("EffectiveConfig: %v", err)
+	}
+	if cfg.MaxConcurrent != 4 {
+		t.Errorf("MaxConcurrent = %d, want 4", cfg.MaxConcurrent)
+	}
+	// Default preserved for an unset field.
+	if cfg.PollInterval != 30*time.Second {
+		t.Errorf("PollInterval = %v, want default 30s", cfg.PollInterval)
+	}
+}
+
+// TestRigSettingsEffectiveLegacyFallback verifies that a rig with only a legacy
+// rig-root config.json merge_queue (no settings/config.json) still resolves via
+// the fallback, so the mayor's earlier hand-patched stopgaps keep working until
+// removed.
+func TestRigSettingsEffectiveLegacyFallback(t *testing.T) {
+	tmpDir := t.TempDir()
+	legacy := map[string]interface{}{
+		"type":    "rig",
+		"version": 1,
+		"merge_queue": map[string]interface{}{
+			"max_concurrent": 7,
+			"on_conflict":    "auto_rebase",
+		},
+	}
+	data, _ := json.MarshalIndent(legacy, "", "  ")
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), data, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &rig.Rig{Name: "legacy-rig", Path: tmpDir}
+	cfg, srcPath, err := refinery.EffectiveConfig(r)
+	if err != nil {
+		t.Fatalf("EffectiveConfig: %v", err)
+	}
+	if srcPath != filepath.Join(tmpDir, "config.json") {
+		t.Errorf("source = %q, want legacy rig-root config.json", srcPath)
+	}
+	if cfg.MaxConcurrent != 7 {
+		t.Errorf("MaxConcurrent = %d, want 7 (legacy fallback)", cfg.MaxConcurrent)
+	}
+	if cfg.OnConflict != "auto_rebase" {
+		t.Errorf("OnConflict = %q, want auto_rebase (legacy fallback)", cfg.OnConflict)
 	}
 }

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -311,13 +311,68 @@ func (e *Engineer) SetOutput(w io.Writer) {
 	e.output = w
 }
 
-// LoadConfig loads merge queue configuration from the rig's config.json.
+// resolveConfigPath returns the path the refinery loads its merge_queue
+// configuration from. The canonical source of truth is settings/config.json —
+// the same file written by `gt rig settings set` and read by the rest of the
+// config-loader subsystem. For backward compatibility with rigs that still have
+// an operator-edited rig-root config.json (e.g. earlier hand-patched stopgaps),
+// fall back to <rig>/config.json when settings/config.json does not exist.
+//
+// Returning ("", nil) means no config file exists at all (use defaults).
+func (e *Engineer) resolveConfigPath() (string, error) {
+	settingsPath := filepath.Join(e.rig.Path, "settings", "config.json")
+	if _, err := os.Stat(settingsPath); err == nil {
+		return settingsPath, nil
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("stat settings config: %w", err)
+	}
+
+	// Legacy fallback: rig-root config.json.
+	legacyPath := filepath.Join(e.rig.Path, "config.json")
+	if _, err := os.Stat(legacyPath); err == nil {
+		return legacyPath, nil
+	} else if !os.IsNotExist(err) {
+		return "", fmt.Errorf("stat legacy config: %w", err)
+	}
+
+	return "", nil
+}
+
+// LoadConfig loads merge queue configuration from the rig's settings/config.json
+// (canonical), falling back to the legacy rig-root config.json. This is the same
+// file that `gt rig settings set merge_queue.*` writes, so operator settings now
+// take effect in the refinery.
+//
+// EffectiveConfig loads and returns the merge_queue configuration exactly as the
+// refinery's LoadConfig would resolve it for the given rig, along with the file
+// path it was sourced from (empty when no config file exists and pure defaults
+// apply). This powers `gt rig settings show --effective` so operators can see
+// what the refinery will actually use. It performs no network or beads access.
+func EffectiveConfig(r *rig.Rig) (*MergeQueueConfig, string, error) {
+	e := &Engineer{rig: r, config: DefaultMergeQueueConfig()}
+	path, err := e.resolveConfigPath()
+	if err != nil {
+		return nil, "", err
+	}
+	if err := e.LoadConfig(); err != nil {
+		return nil, path, err
+	}
+	return e.config, path, nil
+}
+
 func (e *Engineer) LoadConfig() error {
-	configPath := filepath.Join(e.rig.Path, "config.json")
+	configPath, err := e.resolveConfigPath()
+	if err != nil {
+		return err
+	}
+	if configPath == "" {
+		// No config file anywhere: use defaults.
+		return nil
+	}
 	data, err := os.ReadFile(configPath)
 	if err != nil {
 		if os.IsNotExist(err) {
-			// Use defaults if no config file
+			// Use defaults if no config file (race: removed after stat).
 			return nil
 		}
 		return fmt.Errorf("reading config: %w", err)
@@ -443,7 +498,9 @@ func (e *Engineer) LoadConfig() error {
 	}
 
 	// Initialize the PR provider when merge_strategy=pr.
-	if e.config.MergeStrategy == "pr" {
+	// Skipped when e.git is nil (read-only config inspection via
+	// EffectiveConfig), since provider construction needs a git remote.
+	if e.config.MergeStrategy == "pr" && e.git != nil {
 		if err := e.initPRProvider(); err != nil {
 			return fmt.Errorf("initializing PR provider: %w", err)
 		}

--- a/internal/refinery/engineer_test.go
+++ b/internal/refinery/engineer_test.go
@@ -247,6 +247,59 @@ func TestEngineer_LoadConfig_WithMergeQueue(t *testing.T) {
 	}
 }
 
+// TestEngineer_LoadConfig_PrefersSettingsConfig verifies the hq-am01 fix: when
+// both settings/config.json (canonical) and the legacy rig-root config.json
+// exist, LoadConfig reads the canonical settings file. This is what makes
+// `gt rig settings set merge_queue.*` actually take effect in the refinery.
+func TestEngineer_LoadConfig_PrefersSettingsConfig(t *testing.T) {
+	tmpDir, err := os.MkdirTemp("", "engineer-test-*")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	// Legacy rig-root config.json with stale/default-ish values.
+	legacy := map[string]interface{}{
+		"merge_queue": map[string]interface{}{
+			"max_concurrent": 1,
+			"on_conflict":    "assign_back",
+		},
+	}
+	legacyData, _ := json.MarshalIndent(legacy, "", "  ")
+	if err := os.WriteFile(filepath.Join(tmpDir, "config.json"), legacyData, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	// Canonical settings/config.json with the operator's intended values.
+	settingsDir := filepath.Join(tmpDir, "settings")
+	if err := os.MkdirAll(settingsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	settings := map[string]interface{}{
+		"merge_queue": map[string]interface{}{
+			"max_concurrent": 3,
+			"on_conflict":    "auto_rebase",
+		},
+	}
+	settingsData, _ := json.MarshalIndent(settings, "", "  ")
+	if err := os.WriteFile(filepath.Join(settingsDir, "config.json"), settingsData, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	r := &rig.Rig{Name: "test-rig", Path: tmpDir}
+	e := NewEngineer(r)
+	if err := e.LoadConfig(); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if e.config.MaxConcurrent != 3 {
+		t.Errorf("MaxConcurrent = %d, want 3 (canonical settings, not legacy 1)", e.config.MaxConcurrent)
+	}
+	if e.config.OnConflict != "auto_rebase" {
+		t.Errorf("OnConflict = %q, want auto_rebase (canonical settings, not legacy)", e.config.OnConflict)
+	}
+}
+
 func TestEngineer_LoadConfig_AutoPushDisabled(t *testing.T) {
 	tmpDir, err := os.MkdirTemp("", "engineer-test-*")
 	if err != nil {


### PR DESCRIPTION
## Problem

`gt rig settings set merge_queue.*` was a **silent no-op** for the refinery. The writer wrote `<rig>/settings/config.json`, while the refinery's `Engineer.LoadConfig` read `<rig>/config.json`. So operator-set merge-queue settings never took effect and the refinery silently ran `DefaultMergeQueueConfig` (`on_conflict=assign_back`, `max_concurrent=1`) regardless of what the operator configured.

## Fix

Make `settings/config.json` the **single source of truth**. `LoadConfig` now resolves the path via a new `resolveConfigPath()`, preferring the canonical `settings/config.json` (where the writer and the rest of the config-loader subsystem already operate) and falling back to the legacy rig-root `config.json` for backward compatibility with hand-patched stopgaps.

Added observability: `gt rig settings show --effective` prints the merge-queue config **exactly as the refinery's `LoadConfig` resolves it** (resolved values + defaults, plus the source file), powered by a new read-only `refinery.EffectiveConfig` helper. `initPRProvider` is skipped when `git` is nil so the helper stays read-only and panic-free.

## Test

`internal/refinery/engineer_test.go` + `internal/cmd/rig_settings_test.go` cover: writer + reader agreement (set `max_concurrent=3` + `on_conflict=auto_rebase` → `LoadConfig` returns those, not defaults), `--effective` output, legacy fallback, and canonical-over-legacy precedence. `go build ./...`, `go test ./internal/refinery/` and the merge-queue/rig-settings tests in `./internal/cmd/` pass against `main`.

(Note: `TestJSONOutput_NoHumanReadableText` and `TestJSONOutput_ErrorsReturnNonZeroExit` fail on a clean `main` checkout too — they are pre-existing and unrelated to this change.)

## Methodology note

The root cause was a **writer/reader path divergence** — two subsystems silently disagreeing on where config lives. The fix converges them on one canonical path and then makes the convergence *observable* (`--effective` shows the resolved values and the source file), so the next operator never has to guess whether their setting took effect. Determinism plus a verifiable read-back.
