### PR TITLE
feat(up): machine-adaptive boot via explicit --role gate (fail-open)

### DIFF
--- a/internal/cmd/up.go
+++ b/internal/cmd/up.go
@@ -8,9 +8,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"runtime"
 	"strconv"
 	"strings"
-	"runtime"
 	"sync"
 	"syscall"
 	"time"
@@ -146,15 +146,20 @@ aren't already running.`,
 }
 
 var (
-	upQuiet   bool
-	upRestore bool
-	upJSON    bool
+	upQuiet      bool
+	upRestore    bool
+	upJSON       bool
+	adaptiveRole string
 )
 
 func init() {
 	upCmd.Flags().BoolVarP(&upQuiet, "quiet", "q", false, "Only show errors (ignored with --json)")
 	upCmd.Flags().BoolVar(&upRestore, "restore", false, "Also restore crew (from settings) and polecats (from hooks)")
 	upCmd.Flags().BoolVar(&upJSON, "json", false, "Output as JSON")
+	upCmd.Flags().StringVar(&adaptiveRole, "role", "",
+		"Explicit host role for machine-adaptive boot tuning: town-host|sandbox|dev. "+
+			"town-host applies the derived scheduler/governor settings; sandbox/dev propose only. "+
+			"Omit (or set GT_TOWN_HOST_ROLE) to leave gt up's behavior unchanged (propose-only).")
 	rootCmd.AddCommand(upCmd)
 }
 
@@ -425,6 +430,18 @@ func runUp(cmd *cobra.Command, args []string) error {
 		}
 		_ = events.LogFeed(events.TypeBoot, "gt", events.BootPayload("town", startedServices))
 	}
+
+	// Machine-adaptive boot tuning (hq-lgay). Fully fail-open + additive: this
+	// never changes `services`/`allOK` and never makes gt up fail. With no
+	// explicit role it only proposes (preserving historical behavior); an
+	// explicit --role town-host applies the derived scheduler/governor settings.
+	// In JSON mode we suppress the human-facing notes (discard writer) so JSON
+	// output stays machine-parseable; the script's apply still runs.
+	adaptiveOut := io.Writer(os.Stdout)
+	if upJSON {
+		adaptiveOut = io.Discard
+	}
+	runAdaptiveBoot(townRoot, adaptiveOut, upQuiet || upJSON)
 
 	// Output JSON or text
 	if upJSON {
@@ -1065,4 +1082,3 @@ func recoverOrphanedBeads(townRoot string, rigs []string, prefetchedRigs map[str
 
 	return services
 }
-

--- a/internal/cmd/up_adaptive.go
+++ b/internal/cmd/up_adaptive.go
@@ -1,0 +1,203 @@
+package cmd
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/term"
+)
+
+// Adaptive-boot integration for `gt up` (hq-lgay).
+//
+// `gt up` optionally invokes the machine-adaptive boot script, which detects
+// host facts (CPU/RAM) and derives scheduler.max_polecats + governor thresholds.
+//
+// Design constraints (from hq-lgay):
+//   - Gate on an EXPLICIT role flag/env — NEVER silent auto-detect-and-apply.
+//   - When a role IS provided: run the script in apply mode (mayor-gated inside
+//     the script; --yes added automatically when gt up is headless/non-interactive).
+//   - When NO role is provided: run the script in --print mode (detect + propose,
+//     apply nothing) and tell the operator to re-run with --role to apply. This
+//     preserves the historical `gt up` behavior by default.
+//   - FULLY fail-open + additive: a missing script, a non-town-host, a read-only
+//     devcontainer, or macOS must never make `gt up` fail.
+
+// validAdaptiveRoles are the explicit roles accepted by --role / GT_TOWN_HOST_ROLE.
+// Only "town-host" actually wants the adaptive scheduler/governor tuning applied;
+// "sandbox" and "dev" are accepted as explicit acknowledgements that produce a
+// print-only proposal (never apply) so the operator stays in control on
+// non-production hosts.
+var validAdaptiveRoles = map[string]bool{
+	"town-host": true,
+	"sandbox":   true,
+	"dev":       true,
+}
+
+// adaptiveApplyRoles are the roles for which we actually apply tuning. Only the
+// dedicated town-host applies; other explicit roles get a print-only proposal.
+var adaptiveApplyRoles = map[string]bool{
+	"town-host": true,
+}
+
+// resolveAdaptiveRole returns the explicit role for the adaptive-boot step, the
+// source it came from (for logging), and whether a role was explicitly provided.
+//
+// Precedence: the --role flag wins, then GT_TOWN_HOST_ROLE, then GT_ROLE. We do
+// NOT auto-detect: if nothing is set we return ("", "", false) and the caller
+// runs the script in print-only mode.
+//
+// An unrecognized role value is treated as "no explicit role" (returns false)
+// so a typo can never trigger a silent apply.
+func resolveAdaptiveRole(flagRole, envTownHostRole, envRole string) (role, source string, explicit bool) {
+	candidates := []struct {
+		val, src string
+	}{
+		{strings.TrimSpace(flagRole), "--role flag"},
+		{strings.TrimSpace(envTownHostRole), "GT_TOWN_HOST_ROLE env"},
+		{strings.TrimSpace(envRole), "GT_ROLE env"},
+	}
+	for _, c := range candidates {
+		if c.val == "" {
+			continue
+		}
+		if validAdaptiveRoles[c.val] {
+			return c.val, c.src, true
+		}
+		// A non-empty but unrecognized value: ignore it (fail-safe → print-only).
+		// Keep scanning lower-precedence sources in case one is valid.
+	}
+	return "", "", false
+}
+
+// adaptiveScriptPath resolves the adaptive-boot script location, honoring
+// GOV_TOOLS (falling back to $HOME/gt/.gov-tools). Returns the path and whether
+// it exists on disk.
+func adaptiveScriptPath() (path string, exists bool) {
+	govTools := strings.TrimSpace(os.Getenv("GOV_TOOLS"))
+	if govTools == "" {
+		home, err := os.UserHomeDir()
+		if err != nil || home == "" {
+			// No home dir and no GOV_TOOLS: cannot resolve. Fail-open.
+			return "", false
+		}
+		govTools = filepath.Join(home, "gt", ".gov-tools")
+	}
+	path = filepath.Join(govTools, "tools", "ops", "adaptive-boot.sh")
+	if info, err := os.Stat(path); err == nil && !info.IsDir() {
+		return path, true
+	}
+	return path, false
+}
+
+// adaptiveStdoutIsInteractive reports whether gt up is attached to a TTY. When
+// false (headless/piped/CI), we pass --yes to the apply path so the script does
+// not block on a confirmation prompt that no human can answer.
+func adaptiveStdoutIsInteractive() bool {
+	return term.IsTerminal(int(os.Stdout.Fd())) && term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// adaptiveBootDecision captures the resolved plan for the adaptive-boot step so
+// it can be unit-tested without executing anything.
+type adaptiveBootDecision struct {
+	// run is false only when the script is absent (fail-open skip).
+	run bool
+	// mode is the operating mode: "apply" or "print".
+	mode string
+	// role is the explicit role (empty in print-only/no-role mode).
+	role string
+	// args is the full argument list passed to the script.
+	args []string
+	// note is an operator-facing message (e.g. why we skipped, or how to apply).
+	note string
+}
+
+// decideAdaptiveBoot computes the adaptive-boot plan from inputs. Pure function:
+// no side effects, fully unit-testable.
+//
+//   - scriptExists=false  → run=false, with a note (fail-open skip).
+//   - explicit apply role → mode=apply, --role <role>; --yes if non-interactive.
+//   - explicit non-apply  → mode=print, --role <role> --print (acknowledged host,
+//     but we still never apply outside town-host).
+//   - no explicit role    → mode=print, --print, with a "re-run with --role" note.
+func decideAdaptiveBoot(scriptExists bool, role, roleSource string, explicit, interactive bool) adaptiveBootDecision {
+	if !scriptExists {
+		return adaptiveBootDecision{
+			run:  false,
+			mode: "skip",
+			note: "adaptive-boot script not found; skipping host tuning (gt up unaffected)",
+		}
+	}
+
+	if explicit && adaptiveApplyRoles[role] {
+		args := []string{"--role", role, "--apply"}
+		note := fmt.Sprintf("applying host tuning for role %q (from %s)", role, roleSource)
+		if !interactive {
+			args = append(args, "--yes")
+			note += " [non-interactive: --yes]"
+		}
+		return adaptiveBootDecision{run: true, mode: "apply", role: role, args: args, note: note}
+	}
+
+	if explicit {
+		// Explicit but non-applying role (sandbox/dev): propose only, never apply.
+		return adaptiveBootDecision{
+			run:  true,
+			mode: "print",
+			role: role,
+			args: []string{"--role", role, "--print"},
+			note: fmt.Sprintf("role %q (from %s) is print-only; proposing host tuning without applying", role, roleSource),
+		}
+	}
+
+	// No explicit role: preserve historical gt up behavior — detect + propose,
+	// apply nothing.
+	return adaptiveBootDecision{
+		run:  true,
+		mode: "print",
+		args: []string{"--print"},
+		note: "no --role/GT_TOWN_HOST_ROLE set; proposing host tuning only. Re-run 'gt up --role town-host' to apply.",
+	}
+}
+
+// runAdaptiveBoot performs the adaptive-boot integration step for gt up. It is
+// fully fail-open: any error (missing script, non-zero exit, exec failure) is
+// logged as a warning and never propagated, so gt up always succeeds regardless.
+//
+// out is where operator-facing notes/script output are written (os.Stdout in
+// production; a buffer in tests). quiet suppresses the informational notes.
+func runAdaptiveBoot(townRoot string, out io.Writer, quiet bool) {
+	scriptPath, exists := adaptiveScriptPath()
+
+	role, roleSource, explicit := resolveAdaptiveRole(
+		adaptiveRole,
+		os.Getenv("GT_TOWN_HOST_ROLE"),
+		os.Getenv("GT_ROLE"),
+	)
+
+	decision := decideAdaptiveBoot(exists, role, roleSource, explicit, adaptiveStdoutIsInteractive())
+
+	if !decision.run {
+		if !quiet && decision.note != "" {
+			fmt.Fprintf(out, "  adaptive-boot: %s\n", decision.note)
+		}
+		return
+	}
+
+	if !quiet && decision.note != "" {
+		fmt.Fprintf(out, "  adaptive-boot: %s\n", decision.note)
+	}
+
+	cmd := exec.Command(scriptPath, decision.args...)
+	cmd.Dir = townRoot
+	cmd.Stdout = out
+	cmd.Stderr = out
+	cmd.Stdin = nil
+	if err := cmd.Run(); err != nil {
+		// Fail-open: never break gt up. Surface as a warning only.
+		fmt.Fprintf(os.Stderr, "Warning: adaptive-boot step failed (non-fatal): %v\n", err)
+	}
+}

--- a/internal/cmd/up_adaptive.go
+++ b/internal/cmd/up_adaptive.go
@@ -133,7 +133,10 @@ func decideAdaptiveBoot(scriptExists bool, role, roleSource string, explicit, in
 	}
 
 	if explicit && adaptiveApplyRoles[role] {
-		args := []string{"--role", role, "--apply"}
+		// Apply is the script's DEFAULT mode (mode=apply unless --print/--selftest);
+		// there is no --apply flag. --yes (added below when non-interactive) auto-accepts
+		// the confirm; interactive runs prompt "Apply this proposal? [y/N]".
+		args := []string{"--role", role}
 		note := fmt.Sprintf("applying host tuning for role %q (from %s)", role, roleSource)
 		if !interactive {
 			args = append(args, "--yes")

--- a/internal/cmd/up_adaptive_test.go
+++ b/internal/cmd/up_adaptive_test.go
@@ -108,8 +108,9 @@ func TestDecideAdaptiveBoot(t *testing.T) {
 			t.Fatalf("got run=%v mode=%q, want run=true mode=apply", d.run, d.mode)
 		}
 		joined := strings.Join(d.args, " ")
-		if !strings.Contains(joined, "--role town-host") || !strings.Contains(joined, "--apply") {
-			t.Errorf("args = %v, want --role town-host --apply", d.args)
+		// Apply mode = mode=apply default (no --print). There is no --apply flag.
+		if !strings.Contains(joined, "--role town-host") || strings.Contains(joined, "--print") {
+			t.Errorf("args = %v, want --role town-host in apply mode (no --print)", d.args)
 		}
 		if strings.Contains(joined, "--yes") {
 			t.Errorf("interactive apply should not pass --yes; args = %v", d.args)

--- a/internal/cmd/up_adaptive_test.go
+++ b/internal/cmd/up_adaptive_test.go
@@ -1,0 +1,244 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestResolveAdaptiveRole(t *testing.T) {
+	tests := []struct {
+		name                       string
+		flag, envTownHost, envRole string
+		wantRole, wantSource       string
+		wantExplicit               bool
+	}{
+		{
+			name:         "no role anywhere → not explicit",
+			wantExplicit: false,
+		},
+		{
+			name:         "flag town-host wins",
+			flag:         "town-host",
+			wantRole:     "town-host",
+			wantSource:   "--role flag",
+			wantExplicit: true,
+		},
+		{
+			name:         "flag beats env",
+			flag:         "sandbox",
+			envTownHost:  "town-host",
+			wantRole:     "sandbox",
+			wantSource:   "--role flag",
+			wantExplicit: true,
+		},
+		{
+			name:         "GT_TOWN_HOST_ROLE used when no flag",
+			envTownHost:  "town-host",
+			wantRole:     "town-host",
+			wantSource:   "GT_TOWN_HOST_ROLE env",
+			wantExplicit: true,
+		},
+		{
+			name:         "GT_ROLE lowest precedence",
+			envRole:      "dev",
+			wantRole:     "dev",
+			wantSource:   "GT_ROLE env",
+			wantExplicit: true,
+		},
+		{
+			name:         "unrecognized flag value → not explicit (fail-safe)",
+			flag:         "production",
+			wantExplicit: false,
+		},
+		{
+			name:         "unrecognized flag falls through to valid env",
+			flag:         "bogus",
+			envTownHost:  "town-host",
+			wantRole:     "town-host",
+			wantSource:   "GT_TOWN_HOST_ROLE env",
+			wantExplicit: true,
+		},
+		{
+			name:         "whitespace is trimmed",
+			flag:         "  town-host  ",
+			wantRole:     "town-host",
+			wantSource:   "--role flag",
+			wantExplicit: true,
+		},
+		{
+			name:         "GT_ROLE=polecat (non-adaptive role) ignored",
+			envRole:      "polecat",
+			wantExplicit: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			role, source, explicit := resolveAdaptiveRole(tt.flag, tt.envTownHost, tt.envRole)
+			if explicit != tt.wantExplicit {
+				t.Fatalf("explicit = %v, want %v", explicit, tt.wantExplicit)
+			}
+			if role != tt.wantRole {
+				t.Errorf("role = %q, want %q", role, tt.wantRole)
+			}
+			if source != tt.wantSource {
+				t.Errorf("source = %q, want %q", source, tt.wantSource)
+			}
+		})
+	}
+}
+
+func TestDecideAdaptiveBoot(t *testing.T) {
+	t.Run("missing script → skip, fail-open", func(t *testing.T) {
+		d := decideAdaptiveBoot(false, "town-host", "--role flag", true, true)
+		if d.run {
+			t.Error("run should be false when script is missing")
+		}
+		if d.note == "" {
+			t.Error("expected a skip note")
+		}
+	})
+
+	t.Run("town-host interactive → apply without --yes", func(t *testing.T) {
+		d := decideAdaptiveBoot(true, "town-host", "--role flag", true, true)
+		if !d.run || d.mode != "apply" {
+			t.Fatalf("got run=%v mode=%q, want run=true mode=apply", d.run, d.mode)
+		}
+		joined := strings.Join(d.args, " ")
+		if !strings.Contains(joined, "--role town-host") || !strings.Contains(joined, "--apply") {
+			t.Errorf("args = %v, want --role town-host --apply", d.args)
+		}
+		if strings.Contains(joined, "--yes") {
+			t.Errorf("interactive apply should not pass --yes; args = %v", d.args)
+		}
+	})
+
+	t.Run("town-host non-interactive → apply with --yes", func(t *testing.T) {
+		d := decideAdaptiveBoot(true, "town-host", "GT_TOWN_HOST_ROLE env", true, false)
+		joined := strings.Join(d.args, " ")
+		if d.mode != "apply" {
+			t.Fatalf("mode = %q, want apply", d.mode)
+		}
+		if !strings.Contains(joined, "--yes") {
+			t.Errorf("non-interactive apply must pass --yes; args = %v", d.args)
+		}
+	})
+
+	t.Run("explicit sandbox → print-only, never apply", func(t *testing.T) {
+		d := decideAdaptiveBoot(true, "sandbox", "--role flag", true, false)
+		joined := strings.Join(d.args, " ")
+		if d.mode != "print" {
+			t.Fatalf("mode = %q, want print", d.mode)
+		}
+		if strings.Contains(joined, "--apply") {
+			t.Errorf("sandbox must never apply; args = %v", d.args)
+		}
+		if !strings.Contains(joined, "--print") {
+			t.Errorf("expected --print; args = %v", d.args)
+		}
+	})
+
+	t.Run("no role → print-only, preserves historical behavior", func(t *testing.T) {
+		d := decideAdaptiveBoot(true, "", "", false, false)
+		joined := strings.Join(d.args, " ")
+		if d.mode != "print" {
+			t.Fatalf("mode = %q, want print", d.mode)
+		}
+		if strings.Contains(joined, "--apply") {
+			t.Errorf("no-role path must never apply; args = %v", d.args)
+		}
+		if !strings.Contains(joined, "--print") {
+			t.Errorf("no-role path must use --print; args = %v", d.args)
+		}
+		if !strings.Contains(d.note, "--role") {
+			t.Errorf("no-role note should instruct re-running with --role; got %q", d.note)
+		}
+	})
+}
+
+func TestAdaptiveScriptPath_HonorsGovTools(t *testing.T) {
+	dir := t.TempDir()
+	scriptDir := filepath.Join(dir, "tools", "ops")
+	if err := os.MkdirAll(scriptDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	scriptFile := filepath.Join(scriptDir, "adaptive-boot.sh")
+	if err := os.WriteFile(scriptFile, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GOV_TOOLS", dir)
+
+	path, exists := adaptiveScriptPath()
+	if !exists {
+		t.Fatalf("expected script to exist at %s", path)
+	}
+	if path != scriptFile {
+		t.Errorf("path = %q, want %q", path, scriptFile)
+	}
+}
+
+func TestAdaptiveScriptPath_MissingIsFailOpen(t *testing.T) {
+	t.Setenv("GOV_TOOLS", t.TempDir()) // empty dir, no script
+	path, exists := adaptiveScriptPath()
+	if exists {
+		t.Errorf("expected script to be absent, but path %q reported existing", path)
+	}
+}
+
+// TestRunAdaptiveBoot_MissingScriptIsSilentNoFail verifies the top-level helper
+// never panics or writes apply notes when the script is absent (fail-open).
+func TestRunAdaptiveBoot_MissingScriptIsSilentNoFail(t *testing.T) {
+	t.Setenv("GOV_TOOLS", t.TempDir())
+	t.Setenv("GT_TOWN_HOST_ROLE", "")
+	t.Setenv("GT_ROLE", "")
+	adaptiveRole = ""
+
+	var buf bytes.Buffer
+	runAdaptiveBoot(t.TempDir(), &buf, false)
+
+	if strings.Contains(buf.String(), "applying host tuning") {
+		t.Errorf("should not apply when script missing; got output: %q", buf.String())
+	}
+	if !strings.Contains(buf.String(), "not found") {
+		t.Errorf("expected a 'not found' skip note; got: %q", buf.String())
+	}
+}
+
+// TestRunAdaptiveBoot_RunsScriptAndIsFailOpenOnNonZero verifies the helper
+// executes the resolved script and swallows a non-zero exit (fail-open).
+func TestRunAdaptiveBoot_RunsScriptAndIsFailOpenOnNonZero(t *testing.T) {
+	dir := t.TempDir()
+	scriptDir := filepath.Join(dir, "tools", "ops")
+	if err := os.MkdirAll(scriptDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	// Script records its args then exits non-zero — runAdaptiveBoot must not fail.
+	marker := filepath.Join(dir, "args.txt")
+	script := "#!/bin/sh\necho \"$@\" > " + marker + "\nexit 7\n"
+	scriptFile := filepath.Join(scriptDir, "adaptive-boot.sh")
+	if err := os.WriteFile(scriptFile, []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GOV_TOOLS", dir)
+	t.Setenv("GT_TOWN_HOST_ROLE", "")
+	t.Setenv("GT_ROLE", "")
+	adaptiveRole = "" // no role → print mode
+
+	var buf bytes.Buffer
+	// Must not panic / must return normally despite exit 7.
+	runAdaptiveBoot(t.TempDir(), &buf, false)
+
+	got, err := os.ReadFile(marker)
+	if err != nil {
+		t.Fatalf("script did not run (marker missing): %v", err)
+	}
+	if !strings.Contains(string(got), "--print") {
+		t.Errorf("script should have been invoked with --print; got args: %q", string(got))
+	}
+
+	// Reset shared global to avoid cross-test leakage.
+	adaptiveRole = ""
+}


### PR DESCRIPTION
## Problem

`gt up` boots the same way regardless of host. On a constrained box, the right `scheduler.max_polecats` and governor thresholds differ from a big host, and operators had to tune them by hand after every boot. There was no first-class, **explicit** way to derive those settings from host facts at boot — and any auto-tuning must never silently change behaviour on hosts that don't opt in.

## Fix

Add an explicit **role gate** to `gt up` that (optionally) invokes a machine-adaptive boot step deriving `scheduler.max_polecats` + governor thresholds from detected host facts. The integration is **fully additive and fail-open** — it never changes the `services`/`allOK` accounting and never makes `gt up` fail:

- New `--role town-host|sandbox|dev` flag; also honors `GT_TOWN_HOST_ROLE` and `GT_ROLE` env (precedence: flag > `GT_TOWN_HOST_ROLE` > `GT_ROLE`).
- `town-host` **applies** the derived tuning; `--yes` is added automatically when `gt up` is headless/non-interactive (no TTY).
- `sandbox`/`dev` are explicit acknowledgements that **propose only**.
- **No explicit role** → runs in propose-only mode and tells the operator to re-run with `--role`. This preserves the historical `gt up` behaviour by default.
- A missing script, a non-town-host, a read-only devcontainer, or macOS never makes `gt up` fail.

Pure decision logic (`resolveAdaptiveRole`, `decideAdaptiveBoot`) is split out for unit testing. JSON mode suppresses the human-facing notes.

## Operator-provided script

The adaptive step shells out to `${GOV_TOOLS:-$HOME/gt/.gov-tools}/tools/ops/adaptive-boot.sh`. **That script is operator-provided and is intentionally NOT part of this PR / this repo** — different operators derive host tuning differently. `gt up` resolves the path at runtime and **fail-open skips** (with a note) when the script is absent, so this change is safe to merge with no script present: nothing depends on it to build or boot. The PR upstreams only the `gt up` integration (the `--role` flag + the fail-open invocation helper), giving operators a standard, explicit hook to wire their own host-tuning script into boot.

## Test

`internal/cmd/up_adaptive_test.go` covers role resolution precedence, the decide-to-apply/propose/skip logic, and the script-absent fail-open path. `go build ./...` and `go test ./internal/cmd/` (adaptive tests) pass against `main`.

## Methodology note

The design principle here is **explicit-acknowledgement over silent auto-detect**: host tuning is only ever *applied* when the operator names a `town-host` role, and is otherwise propose-only — so the change can never surprise an existing deployment. Everything is fail-open and additive, so adopting it is zero-risk even before an operator writes their tuning script.
