### PR TITLE
fix(daemon): tolerate bd schema_version envelope in children JSON (hq-r64)

### DIFF
--- a/internal/daemon/dog_molecule.go
+++ b/internal/daemon/dog_molecule.go
@@ -263,7 +263,10 @@ type childInfo struct {
 
 // parseChildrenJSON parses the output of `bd show <id> --children --json`.
 // bd returns a map keyed by parent ID: {"hq-wisp-abc": [{...}, ...]}.
-// For forward compatibility, a bare array is also accepted.
+// As of bd 1.0.3 the map also carries scalar envelope fields such as
+// {"schema_version": 1}, so we decode values lazily and skip any entry that
+// is not a JSON array (regression: hq-r64). For forward compatibility, a bare
+// array is also accepted.
 func parseChildrenJSON(raw string) ([]childInfo, error) {
 	data := []byte(raw)
 
@@ -272,9 +275,17 @@ func parseChildrenJSON(raw string) ([]childInfo, error) {
 		return arr, nil
 	}
 
-	var wrapped map[string][]childInfo
+	var wrapped map[string]json.RawMessage
 	if err := json.Unmarshal(data, &wrapped); err == nil {
-		for _, children := range wrapped {
+		for _, raw := range wrapped {
+			// Skip envelope fields (e.g. "schema_version": 1) that are not arrays.
+			if len(raw) == 0 || raw[0] != '[' {
+				continue
+			}
+			var children []childInfo
+			if err := json.Unmarshal(raw, &children); err != nil {
+				return nil, fmt.Errorf("parse children array: %w", err)
+			}
 			return children, nil
 		}
 		return nil, nil

--- a/internal/daemon/dog_molecule_test.go
+++ b/internal/daemon/dog_molecule_test.go
@@ -91,6 +91,18 @@ func TestParseChildrenJSON(t *testing.T) {
 			wantCount: 0,
 		},
 		{
+			// bd 1.0.3+ adds a schema_version envelope field alongside the
+			// parent-keyed array. Regression: hq-r64.
+			name:      "map wrapper with schema_version envelope, empty children",
+			input:     `{"hq-wisp-root":[],"schema_version":1}`,
+			wantCount: 0,
+		},
+		{
+			name:      "map wrapper with schema_version envelope and children",
+			input:     `{"hq-wisp-root":[{"id":"hq-wisp-a","title":"Probe","status":"open"},{"id":"hq-wisp-b","title":"Report","status":"open"}],"schema_version":1}`,
+			wantCount: 2,
+		},
+		{
 			name:      "empty array",
 			input:     `[]`,
 			wantCount: 0,


### PR DESCRIPTION
## Problem

bd 1.0.3 added a scalar `schema_version` field to `bd show <id> --children --json` output:

```json
{"hq-wisp-abc": [...], "schema_version": 1}
```

`parseChildrenJSON` decoded the whole object into `map[string][]childInfo`, which fails to unmarshal entirely because the scalar `1` is not an array. Every dog molecule then discovered **0 steps** and leaked orphan blocked wisps (~30 per 15 min).

The 2026-06-13 daemon rebuild did **not** fix this — the root cause is the bd JSON envelope change, not binary version drift. This stranded every town running the stock daemon with a steady wisp leak.

## Fix

Decode the map values as `json.RawMessage` and skip any entry that is not a JSON array, so envelope fields (`schema_version`, etc.) are ignored while the parent's child array is still returned. Bare-array output remains accepted for forward compatibility.

Includes a regression test covering the `schema_version` envelope.

## Impact

Restores dog-molecule step discovery; stops the orphan-blocked-wisp leak across all towns once released.

🤖 Generated with [Claude Code](https://claude.com/claude-code)