### PR TITLE
fix(polecat): ban '@' in generated branch names (hq-5w371)

### DIFF
--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -1522,14 +1523,47 @@ notifyWitness:
 		style.PrintWarning("could not log feed event: %v", err)
 	}
 
-	// Update agent bead state (ZFC: self-report completion)
-	updateAgentStateOnDone(cwd, townRoot, exitType, issueID)
+	// Update agent bead state (ZFC: self-report completion).
+	//
+	// Pass push/mr failure flags so updateAgentStateOnDone can refuse to close
+	// the hook bead when the MR was never submitted (glaicier gt-mugh 2nd path).
+	// Without this guard the bead closes with reason "Closed" while the
+	// polecat's branch sits orphaned on origin and no PR exists — bit fury on
+	// gt-qyhr 2026-06-21 and required manual recovery via gh pr create.
+	updateAgentStateOnDone(cwd, townRoot, exitType, issueID, pushFailed, mrFailed)
 
 	// Nudge witness only after hook/cleanup state is updated. Otherwise witness can
 	// evaluate slot availability against stale hook_bead or cleanup_status and emit
 	// false SLOT_BLOCKED/SLOT_OPEN signals.
 	nudgeWitness(rigName, fmt.Sprintf("POLECAT_DONE %s exit=%s", polecatName, exitType))
 	fmt.Printf("%s Witness notified of %s (via nudge)\n", style.Bold.Render("✓"), exitType)
+
+	// Best-effort auto-fire @claude review on the polecat branch's PR.
+	//
+	// Polecat refinery integration PRs don't auto-trigger @claude review under
+	// the current refinery flow — mayor has been manually adding `@claude review`
+	// comments per-PR for #2417/#2422/#2423/etc. This eliminates that toil and
+	// reduces verdict latency.
+	//
+	// If no PR exists yet (refinery hasn't created the integration PR), this
+	// is a no-op. If a PR exists (polecat pushed direct OR refinery already
+	// opened the integration PR), the @claude review comment fires immediately.
+	//
+	// Skips on push/MR failure paths since there's no useful PR to review.
+	if !pushFailed && !mrFailed && branch != "" {
+		if prNum, prErr := g.FindPRNumber(branch); prErr == nil && prNum > 0 {
+			reviewCmd := exec.Command("gh", "pr", "comment", fmt.Sprintf("%d", prNum), "--body", "@claude review")
+			reviewCmd.Dir = cwd
+			reviewCmd.Stdout = io.Discard
+			reviewCmd.Stderr = io.Discard
+			if reviewErr := reviewCmd.Run(); reviewErr != nil {
+				// Non-fatal: @claude review can be fired manually later.
+				_ = reviewErr
+			} else {
+				fmt.Printf("%s @claude review auto-fired on PR #%d\n", style.Bold.Render("✓"), prNum)
+			}
+		}
+	}
 
 	// Persistent polecat model (gt-hdf8): polecats transition to IDLE after completion.
 	// Session stays alive, sandbox preserved, worktree synced to main for reuse.
@@ -1893,7 +1927,7 @@ func clearDoneCheckpoints(bd *beads.Beads, agentBeadID string) {
 // BUG FIX (hq-3xaxy): This function must be resilient to working directory deletion.
 // If the polecat's worktree is deleted before gt done finishes, we use env vars as fallback.
 // All errors are warnings, not failures - gt done must complete even if bead ops fail.
-func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) {
+func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string, pushFailed, mrFailed bool) {
 	// Get role context - try multiple sources for resilience
 	roleInfo, err := GetRoleWithContext(cwd, townRoot)
 	if err != nil {
@@ -2023,8 +2057,33 @@ func updateAgentStateOnDone(cwd, townRoot, exitType, issueID string) {
 			if unchecked := beads.HasUncheckedCriteria(hookedBead); unchecked > 0 {
 				style.PrintWarning("hooked bead %s has %d unchecked acceptance criteria — skipping close", hookedBeadID, unchecked)
 				fmt.Fprintf(os.Stderr, "  The bead will remain open for witness/mayor review.\n")
-			} else if err := bd.Close(hookedBeadID); err != nil {
-				// Non-fatal: warn but continue
+			} else if pushFailed || mrFailed {
+				// MR/push failure gate (glaicier gt-mugh 2nd path).
+				//
+				// Closing the hook bead here without an MR record makes the work
+				// look "done" to mayor/witness while the polecat's branch sits
+				// orphaned on origin with no PR. Refuse to close, leave the bead
+				// open + in_progress so witness flags the polecat for recovery
+				// and the operator can either re-submit via `gh pr create` or
+				// re-sling the bead to another polecat.
+				reasonParts := []string{}
+				if pushFailed {
+					reasonParts = append(reasonParts, "push failed")
+				}
+				if mrFailed {
+					reasonParts = append(reasonParts, "MR submission failed")
+				}
+				style.PrintWarning("hooked bead %s left open (%s) — recovery needed", hookedBeadID, strings.Join(reasonParts, ", "))
+				fmt.Fprintf(os.Stderr, "  The polecat's branch may exist on origin but no MR was submitted.\n")
+				fmt.Fprintf(os.Stderr, "  Recover via 'gh pr create --head <branch> --base <target>' or re-sling.\n")
+				fmt.Fprintf(os.Stderr, "  See glaicier gt-mugh for the recovery pattern.\n")
+			} else if err := bd.ForceCloseWithReason("completed via gt done", hookedBeadID); err != nil {
+				// Non-fatal: warn but continue.
+				// Use ForceCloseWithReason so the close has an audit trail
+				// — bd.Close passes empty reason which defaults to literal "Closed"
+				// indistinguishable from manual close. Glaicier gt-mugh evidence:
+				// gt-qyhr closed with reason="Closed" when MR submission silently
+				// failed — no signal to operator that recovery was needed.
 				fmt.Fprintf(os.Stderr, "Warning: couldn't close hooked bead %s: %v\n", hookedBeadID, err)
 			}
 		}

--- a/internal/cmd/done.go
+++ b/internal/cmd/done.go
@@ -86,6 +86,59 @@ func doneContaminationBaseRef(defaultBranch, explicitTarget string) string {
 	return "origin/" + targetBranch
 }
 
+// resolveDoneTargetBranch returns the actual target branch to use for
+// ahead-count + verify-push checks in `gt done`.
+//
+// Priority (highest first):
+//  1. Explicit --target flag (polecat knows its base branch)
+//  2. formula_vars base_branch on the bead (set by `gt sling --base-branch ...`)
+//  3. Integration branch auto-detect from epic hierarchy
+//  4. Rig default branch (fallback)
+//
+// Mirrors the resolution already used in the MR-creation path (~line 1140) so
+// the no-MR close path (zero-commit, --pre-verified, etc.) also honours
+// integration branches. Without this, a polecat forked off integration/<epic>
+// is incorrectly compared against origin/<default> and either reports
+// spurious ahead-counts or fails VerifyPushedCommit against the wrong tip.
+//
+// Returns defaultBranch on any lookup failure (logged as warning).
+func resolveDoneTargetBranch(bd *beads.Beads, g *git.Git, townRoot, rigName, issueID, doneTarget, defaultBranch string) string {
+	// 1. Explicit --target flag wins
+	if doneTarget != "" {
+		return strings.TrimPrefix(doneTarget, "origin/")
+	}
+
+	if issueID == "" {
+		return defaultBranch
+	}
+
+	// 2. formula_vars base_branch (stored on bead at sling time)
+	if issue, err := bd.Show(issueID); err == nil && issue != nil {
+		if af := beads.ParseAttachmentFields(issue); af != nil {
+			if bb := extractFormulaVar(af.FormulaVars, "base_branch"); bb != "" && bb != defaultBranch {
+				return strings.TrimPrefix(bb, "origin/")
+			}
+		}
+	}
+
+	// 3. Integration branch auto-detect (gated on per-rig refinery integration config)
+	refineryEnabled := true
+	if rigName != "" && townRoot != "" {
+		settingsPath := filepath.Join(townRoot, rigName, "settings", "config.json")
+		if settings, err := config.LoadRigSettings(settingsPath); err == nil && settings.MergeQueue != nil {
+			refineryEnabled = settings.MergeQueue.IsRefineryIntegrationEnabled()
+		}
+	}
+	if refineryEnabled {
+		if autoTarget, err := beads.DetectIntegrationBranch(bd, g, issueID); err == nil && autoTarget != "" {
+			return strings.TrimPrefix(autoTarget, "origin/")
+		}
+	}
+
+	// 4. Fallback
+	return defaultBranch
+}
+
 func shouldSyncIdlePolecatWorktree(exitType, mergeStrategy string, pushFailed, mrFailed, syncSafe bool) bool {
 	if exitType != ExitCompleted || pushFailed || mrFailed || !syncSafe {
 		return false
@@ -529,6 +582,19 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 		defaultBranch = rigCfg.DefaultBranch
 	}
 
+	// Resolve the actual target branch for ahead-count + verify-push checks.
+	// Priority: --target flag > formula_vars base_branch > integration auto-detect > rig default.
+	//
+	// Previously the no-MR close path (lines below) used defaultBranch directly,
+	// silently comparing polecat work against origin/main even when the polecat
+	// was forked off integration/<epic>. For a polecat on an integration branch:
+	//   - aheadCount vs origin/main reads many commits when 0 new work was done
+	//   - VerifyPushedCommit("origin", defaultBranch, ...) checks the wrong remote tip
+	//   - close-reason "target_branch: main" misleads later auditing
+	// The same resolution already ran in the MR-creation path at line ~1130; this
+	// promotes it to also cover the no-MR (zero-commit, --pre-verified, etc) path.
+	targetBranch := resolveDoneTargetBranch(beads.New(cwd), g, townRoot, rigName, issueID, doneTarget, defaultBranch)
+
 	// For COMPLETED, we need an issue ID and branch must not be the default branch
 	var mrID string
 	var pushFailed bool
@@ -565,16 +631,18 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 			return fmt.Errorf("cannot complete: uncommitted changes would be lost\nCommit your changes first, or use --status DEFERRED to exit without completing\nUncommitted: %s", workStatus.String())
 		}
 
-		// Check if branch has commits ahead of origin/default
-		// If not, work may have been pushed directly to main - that's fine, just skip MR
-		originDefault := "origin/" + defaultBranch
+		// Check if branch has commits ahead of origin/target
+		// If not, work may have been pushed directly to target - that's fine, just skip MR.
+		// Uses resolved targetBranch (formula_vars / integration auto-detect) instead of
+		// hard-coded defaultBranch so integration-branch polecats compare correctly.
+		originDefault := "origin/" + targetBranch
 		aheadCount, err := g.CommitsAhead(originDefault, "HEAD")
 		if err != nil {
 			// Fallback to local branch comparison if origin not available
-			aheadCount, err = g.CommitsAhead(defaultBranch, branch)
+			aheadCount, err = g.CommitsAhead(targetBranch, branch)
 			if err != nil {
 				// Can't determine - assume work exists and continue
-				style.PrintWarning("could not check commits ahead of %s: %v", defaultBranch, err)
+				style.PrintWarning("could not check commits ahead of %s: %v", targetBranch, err)
 				aheadCount = 1
 			}
 		}
@@ -614,10 +682,21 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 					branchPushedWithWork = pushErr == nil && pushed && unpushed == 0
 				}
 				if !branchPushedWithWork {
+					// Do NOT suggest --status DEFERRED or ESCALATED here. LLM polecats
+					// read error messages and self-bypass (the comment above on the
+					// uncommitted-changes branch warns about the same pattern).
+					// DEFERRED preserves the bead as open (line ~1865) — using it as
+					// the escape valve for "no commits" silently abandons the work
+					// without an MR or a failure signal to witness.
+					//
+					// The correct response if the polecat genuinely cannot produce
+					// commits is to either: (a) escalate via the witness mail
+					// channel, or (b) fix the underlying tooling. Crashing here
+					// surfaces the problem to the operator instead of training the
+					// LLM to bypass the guard.
 					return fmt.Errorf("cannot complete: no commits on branch ahead of %s\n"+
 						"Polecats must have at least 1 commit to submit.\n"+
-						"If the bug was already fixed upstream: gt done --status DEFERRED\n"+
-						"If you're blocked: gt done --status ESCALATED",
+						"This indicates the polecat could not produce work — investigate the polecat's session for tooling failures or missing scopes before re-dispatching.",
 						originDefault)
 				}
 			}
@@ -653,20 +732,20 @@ func runDone(cmd *cobra.Command, args []string) (retErr error) {
 				}
 
 				if !skipClose {
-					closeReason := "Completed with no code changes (already fixed or pushed directly to main)"
+					closeReason := fmt.Sprintf("Completed with no code changes (already fixed or pushed directly to %s)", targetBranch)
 					noMRCommitSHA, _ := g.Rev("HEAD")
 					if doneSkipVerify {
-						noteVerifiedPushSkipped(cwd, issueID, defaultBranch, noMRCommitSHA, "--skip-verify on no-MR close")
+						noteVerifiedPushSkipped(cwd, issueID, targetBranch, noMRCommitSHA, "--skip-verify on no-MR close")
 						if noMRCommitSHA != "" {
-							closeReason = fmt.Sprintf("%s\nskip_verify: true\ntarget_branch: %s\ncommit_sha: %s", closeReason, defaultBranch, noMRCommitSHA)
+							closeReason = fmt.Sprintf("%s\nskip_verify: true\ntarget_branch: %s\ncommit_sha: %s", closeReason, targetBranch, noMRCommitSHA)
 						}
 					} else if !isNoMergeTask {
-						if verifyErr := g.VerifyPushedCommit("origin", defaultBranch, noMRCommitSHA); verifyErr != nil {
-							noteVerifiedPushFailure(cwd, issueID, defaultBranch, noMRCommitSHA, verifyErr)
+						if verifyErr := g.VerifyPushedCommit("origin", targetBranch, noMRCommitSHA); verifyErr != nil {
+							noteVerifiedPushFailure(cwd, issueID, targetBranch, noMRCommitSHA, verifyErr)
 							return fmt.Errorf("cannot close no-MR code bead: %w", verifyErr)
 						}
 						if noMRCommitSHA != "" {
-							closeReason = fmt.Sprintf("%s\ntarget_branch: %s\ncommit_sha: %s", closeReason, defaultBranch, noMRCommitSHA)
+							closeReason = fmt.Sprintf("%s\ntarget_branch: %s\ncommit_sha: %s", closeReason, targetBranch, noMRCommitSHA)
 						}
 					}
 					// G15 fix: Force-close bypasses molecule dependency checks.

--- a/internal/cmd/mq.go
+++ b/internal/cmd/mq.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 
@@ -619,6 +620,33 @@ func runMQPostMerge(_ *cobra.Command, args []string) error {
 		_ = err
 	} else {
 		fmt.Printf("  %s Deleted local branch: %s\n", style.Success.Render("✓"), mr.Branch)
+	}
+
+	// Auto-recycle polecat worker after successful merge (glaicier gt-mugh follow-up).
+	//
+	// Without this, polecat directories persist with stale active_mr references
+	// pointing at the just-closed MR bead. `gt polecat list` shows them as
+	// idle-recovery-needed and the 30/rig directory cap fills up over time,
+	// requiring kai's --force named-reuse workaround. Observed 2026-06-21 with
+	// ~13 idle-recovery-needed polecats on m365.
+	//
+	// `gt polecat nuke` has its own safety checks (refuses if cleanup dirty /
+	// unpushed work / open MR on hook). PostMerge just verified merge_commit
+	// on origin AND closed the MR bead, so the safety checks should pass. If
+	// they don't (e.g., uncommitted work was left behind), nuke refuses + the
+	// polecat stays alive for manual recovery — non-fatal here.
+	if mr.Worker != "" && strings.HasPrefix(mr.Worker, "polecats/") {
+		polecatName := strings.TrimPrefix(mr.Worker, "polecats/")
+		target := fmt.Sprintf("%s/%s", rigName, polecatName)
+		nukeCmd := exec.Command("gt", "polecat", "nuke", target)
+		nukeCmd.Stdout = io.Discard
+		nukeCmd.Stderr = io.Discard
+		if err := nukeCmd.Run(); err != nil {
+			fmt.Printf("  %s Polecat auto-recycle skipped for %s (safety check blocked) — %s\n",
+				style.Dim.Render("○"), target, "manual review may be needed")
+		} else {
+			fmt.Printf("  %s Polecat auto-recycled: %s (slot freed)\n", style.Success.Render("✓"), target)
+		}
 	}
 
 	return nil

--- a/internal/cmd/mq.go
+++ b/internal/cmd/mq.go
@@ -1,12 +1,14 @@
 package cmd
 
 import (
+	"encoding/json"
 	"fmt"
 	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/config"
@@ -189,6 +191,35 @@ Examples:
 	RunE: runMQPostMerge,
 }
 
+var mqSweepDryRun bool
+
+var mqSweepCmd = &cobra.Command{
+	Use:   "sweep <rig>",
+	Short: "Detect + clean stale MR wisps for externally-merged PRs (glaicier gt-mugh 4th-layer)",
+	Long: `Scan open MR wisps for orphaned-branch anomalies — branches that no
+longer exist on origin (typically because a PR was merged via 'gh pr merge
+--delete-branch' bypassing the refinery flow). This is the 4th-layer
+gt-mugh gap: external PR merges leave MR wisps stuck open + polecats
+holding slots indefinitely.
+
+For each orphaned MR:
+  1. Query GitHub for the merged PR matching the branch (via gh pr list)
+  2. If a merged PR exists with merge_commit, populate merge_commit on
+     the MR bead (so the gt-mugh post-merge verify gate passes)
+  3. Invoke 'gt mq post-merge' which closes the bead + closes the source
+     issue + deletes the local branch + auto-recycles the polecat slot
+
+If no merged PR can be found for an orphaned branch, that MR is skipped
++ reported for manual investigation (the branch may have been deleted
+without merging).
+
+Examples:
+  gt mq sweep m365             # actually run cleanup
+  gt mq sweep m365 --dry-run   # preview without changes`,
+	Args: cobra.ExactArgs(1),
+	RunE: runMQSweep,
+}
+
 var mqStatusCmd = &cobra.Command{
 	Use:   "status <id>",
 	Short: "Show detailed merge request status",
@@ -336,6 +367,9 @@ func init() {
 	// Post-merge flags
 	mqPostMergeCmd.Flags().BoolVar(&mqPostMergeSkipBranchDelete, "skip-branch-delete", false, "Skip remote branch deletion")
 
+	// Sweep flags
+	mqSweepCmd.Flags().BoolVar(&mqSweepDryRun, "dry-run", false, "Preview what would be cleaned without making changes")
+
 	// Add subcommands
 	mqCmd.AddCommand(mqSubmitCmd)
 	mqCmd.AddCommand(mqRetryCmd)
@@ -343,6 +377,7 @@ func init() {
 	mqCmd.AddCommand(mqRejectCmd)
 	mqCmd.AddCommand(mqStatusCmd)
 	mqCmd.AddCommand(mqPostMergeCmd)
+	mqCmd.AddCommand(mqSweepCmd)
 
 	// Integration branch subcommands
 	mqIntegrationCreateCmd.Flags().StringVar(&mqIntegrationCreateBranch, "branch", "", "Override branch name template (supports {title}, {epic}, {prefix}, {user})")
@@ -649,5 +684,182 @@ func runMQPostMerge(_ *cobra.Command, args []string) error {
 		}
 	}
 
+	return nil
+}
+
+// runMQSweep implements the 4th-layer gt-mugh cleanup: detect MR wisps whose
+// polecat branch was deleted from origin (typical signature of external
+// 'gh pr merge --delete-branch'), populate merge_commit from GitHub state,
+// then invoke 'gt mq post-merge' for full cleanup (which then triggers
+// my auto-recycle nuke on the polecat slot).
+//
+// Without this command, manual `gh pr merge` of polecat PRs leaves MR wisps
+// stuck status=open with empty merge_commit, polecat active_mr stale, slots
+// held indefinitely. Observed on m365 2026-06-21 with 13 stuck polecats
+// before manual recovery.
+func runMQSweep(_ *cobra.Command, args []string) error {
+	rigName := args[0]
+	_, r, _, err := getRefineryManager(rigName)
+	if err != nil {
+		return err
+	}
+
+	eng := refinery.NewEngineer(r)
+	anomalies, err := eng.ListQueueAnomalies(time.Now())
+	if err != nil {
+		return fmt.Errorf("listing queue anomalies: %w", err)
+	}
+
+	// Filter to orphaned-branch anomalies — the external-merge signature.
+	orphans := make([]*refinery.MRAnomaly, 0, len(anomalies))
+	for _, a := range anomalies {
+		if a.Type == "orphaned-branch" {
+			orphans = append(orphans, a)
+		}
+	}
+
+	if len(orphans) == 0 {
+		fmt.Printf("%s No orphaned-branch MRs found in %s (sweep clean)\n", style.Bold.Render("✓"), rigName)
+		return nil
+	}
+
+	mode := "SWEEP"
+	if mqSweepDryRun {
+		mode = "DRY-RUN"
+	}
+	fmt.Printf("%s %s: %d orphaned-branch MR(s) found in %s\n\n", style.Bold.Render("→"), mode, len(orphans), rigName)
+
+	rigGit, gitErr := getRigGit(r.Path)
+	if gitErr != nil {
+		return fmt.Errorf("creating rig git client: %w", gitErr)
+	}
+
+	cleaned := 0
+	skipped := 0
+	for _, anomaly := range orphans {
+		fmt.Printf("  %s\n", style.Bold.Render(anomaly.ID))
+		fmt.Printf("    branch: %s (deleted from origin)\n", anomaly.Branch)
+
+		// Look up the MR bead to see what we already know.
+		mgr, _, _, mgrErr := getRefineryManager(rigName)
+		if mgrErr != nil {
+			fmt.Printf("    %s manager lookup failed: %v\n", style.Dim.Render("○"), mgrErr)
+			skipped++
+			continue
+		}
+		mr, mrErr := mgr.FindMR(anomaly.ID)
+		if mrErr != nil {
+			fmt.Printf("    %s MR lookup failed: %v\n", style.Dim.Render("○"), mrErr)
+			skipped++
+			continue
+		}
+
+		// If merge_commit is already populated, we just need post-merge.
+		if mr.MergeCommit != "" {
+			fmt.Printf("    %s merge_commit already set: %s\n", style.Dim.Render("●"), mr.MergeCommit[:9])
+		} else {
+			// Query GitHub for the merged PR matching this branch.
+			// gh pr list still finds PRs by old head ref even after branch delete.
+			mergeSHA, prNum, ghErr := findMergedPRMergeCommit(rigGit, anomaly.Branch)
+			if ghErr != nil {
+				fmt.Printf("    %s could not find merged PR for branch: %v\n", style.Dim.Render("○"), ghErr)
+				fmt.Printf("    %s manual investigation needed (branch may have been deleted without merge)\n", style.Dim.Render("○"))
+				skipped++
+				continue
+			}
+			fmt.Printf("    %s found merged PR #%d, merge_commit=%s\n", style.Success.Render("✓"), prNum, mergeSHA[:9])
+
+			if mqSweepDryRun {
+				fmt.Printf("    %s would populate merge_commit + run post-merge (skipped: --dry-run)\n", style.Dim.Render("→"))
+				cleaned++
+				continue
+			}
+
+			// Append merge_commit to MR bead description so my post-merge verify gate passes.
+			if updateErr := appendMergeCommitToMRBead(rigName, anomaly.ID, mergeSHA); updateErr != nil {
+				fmt.Printf("    %s could not update MR bead with merge_commit: %v\n", style.Dim.Render("○"), updateErr)
+				skipped++
+				continue
+			}
+			fmt.Printf("    %s merge_commit populated on MR bead\n", style.Success.Render("✓"))
+		}
+
+		if mqSweepDryRun {
+			fmt.Printf("    %s would run 'gt mq post-merge %s %s' (skipped: --dry-run)\n", style.Dim.Render("→"), rigName, anomaly.ID)
+			cleaned++
+			continue
+		}
+
+		// Invoke gt mq post-merge — uses my gt-mugh verify gate + auto-recycle.
+		pmCmd := exec.Command("gt", "mq", "post-merge", rigName, anomaly.ID)
+		pmCmd.Stdout = os.Stdout
+		pmCmd.Stderr = os.Stderr
+		if pmErr := pmCmd.Run(); pmErr != nil {
+			fmt.Printf("    %s post-merge failed: %v\n", style.Dim.Render("○"), pmErr)
+			skipped++
+			continue
+		}
+		cleaned++
+	}
+
+	fmt.Println()
+	if mqSweepDryRun {
+		fmt.Printf("%s DRY-RUN complete: %d would be cleaned, %d would be skipped\n", style.Bold.Render("→"), cleaned, skipped)
+	} else {
+		fmt.Printf("%s Sweep complete: %d cleaned, %d skipped (manual investigation)\n", style.Bold.Render("✓"), cleaned, skipped)
+	}
+	return nil
+}
+
+// findMergedPRMergeCommit queries GitHub via gh CLI for a PR matching the
+// given branch (state=merged), returning the merge_commit SHA + PR number.
+// gh pr list works against deleted branches because the PR record persists
+// with its old headRef.
+func findMergedPRMergeCommit(rigGit *git.Git, branch string) (string, int, error) {
+	cmd := exec.Command("gh", "pr", "list",
+		"--head", branch,
+		"--state", "merged",
+		"--json", "number,mergeCommit",
+		"--limit", "1",
+	)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", 0, fmt.Errorf("gh pr list: %w", err)
+	}
+	out = []byte(strings.TrimSpace(string(out)))
+	if len(out) <= 2 {
+		return "", 0, fmt.Errorf("no merged PR found for branch %s", branch)
+	}
+	type prInfo struct {
+		Number      int    `json:"number"`
+		MergeCommit struct {
+			OID string `json:"oid"`
+		} `json:"mergeCommit"`
+	}
+	var prs []prInfo
+	if err := json.Unmarshal(out, &prs); err != nil {
+		return "", 0, fmt.Errorf("parse gh pr list output: %w", err)
+	}
+	if len(prs) == 0 {
+		return "", 0, fmt.Errorf("empty PR list for branch %s", branch)
+	}
+	if prs[0].MergeCommit.OID == "" {
+		return "", prs[0].Number, fmt.Errorf("PR #%d has no merge_commit (closed without merge?)", prs[0].Number)
+	}
+	return prs[0].MergeCommit.OID, prs[0].Number, nil
+}
+
+// appendMergeCommitToMRBead updates the MR bead's description to append
+// 'merge_commit: <SHA>' so the gt-mugh post-merge verify gate passes.
+// Uses 'bd update --append-notes' which is safer than a full description
+// rewrite (preserves all existing fields).
+func appendMergeCommitToMRBead(rigName, mrID, mergeSHA string) error {
+	cmd := exec.Command("bd", "update", mrID,
+		"--append-notes", fmt.Sprintf("merge_commit: %s\nrecovered_by: gt mq sweep", mergeSHA),
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("bd update %s: %w (output: %s)", mrID, err, string(out))
+	}
 	return nil
 }

--- a/internal/cmd/mq.go
+++ b/internal/cmd/mq.go
@@ -510,6 +510,47 @@ func runMQPostMerge(_ *cobra.Command, args []string) error {
 		return err
 	}
 
+	// Verify the actual merge happened BEFORE closing the bead (glaicier gt-mugh).
+	//
+	// Background: prior to this guard, `gt mq post-merge` blindly closed both the
+	// MR bead and the source issue with "Merged in <mr.ID>" — without ever checking
+	// that the merge_commit on the MR bead corresponds to a real commit on
+	// origin/<target>. The refinery-patrol formula's "STOP HERE - DO NOT PROCEED
+	// UNTIL THE PR IS ACTUALLY MERGED ON GITHUB" gate is natural-language; an LLM
+	// patrol that skips that step (CI not passing, PR queued behind branch
+	// protection, gh pr merge --auto deferred-to-later) still calls `gt mq
+	// post-merge` and the bead closes with a false-positive "Merged in" reason.
+	//
+	// Observed on m365 2026-06-21: gt-pad1.4/.5/.7 closed with "Merged in
+	// gt-wisp-o3x/bfj/vma" but the underlying PRs never produced commits on
+	// origin/main. Ash had to re-ship the same domains via crew worktree.
+	//
+	// Fix: require mr.MergeCommit be present AND verify it on origin/<target>
+	// via existing VerifyPushedCommit helper (same gate polecat-side gt done uses
+	// at internal/cmd/done.go:743-746). Refuse to close if not verified.
+	preMR, err := mgr.FindMR(mrID)
+	if err != nil {
+		return fmt.Errorf("looking up MR: %w", err)
+	}
+	if preMR.MergeCommit == "" {
+		return fmt.Errorf("refusing post-merge close for %s: no merge_commit recorded on MR bead\n"+
+			"  This indicates the merge handshake never completed — the PR may not have actually landed.\n"+
+			"  Fix the underlying merge before re-running post-merge, or record the merge SHA on the MR bead.\n"+
+			"  See glaicier gt-mugh.", mrID)
+	}
+	if rigGit, gitErr := getRigGit(r.Path); gitErr == nil {
+		target := preMR.TargetBranch
+		if target == "" {
+			target = "main"
+		}
+		if verifyErr := rigGit.VerifyPushedCommit("origin", target, preMR.MergeCommit); verifyErr != nil {
+			return fmt.Errorf("refusing post-merge close for %s: merge_commit %s not on origin/%s: %w\n"+
+				"  The MR bead claims a merge that didn't actually land on the remote target.\n"+
+				"  Investigate the merge flow (gh pr view <pr> --json mergeCommit,state) before re-running.\n"+
+				"  See glaicier gt-mugh.", mrID, preMR.MergeCommit, target, verifyErr)
+		}
+	}
+
 	// Run beads-level cleanup (close MR bead + source issue)
 	result, err := mgr.PostMerge(mrID)
 	if err != nil {

--- a/internal/cmd/mq_submit.go
+++ b/internal/cmd/mq_submit.go
@@ -29,25 +29,52 @@ type branchInfo struct {
 // issuePattern matches issue IDs in branch names (e.g., "gt-xyz" or "gt-abc.1")
 var issuePattern = regexp.MustCompile(`([a-z]+-[a-z0-9]+(?:\.[0-9]+)?)`)
 
+// polecatTimestampSuffix matches the base36 UnixMilli timestamp tail that
+// freshBranchName / buildBranchName append after the issue. Millis fit in
+// ~8 base36 chars so we require ≥6 lowercase alphanumerics with no dots
+// (issue IDs use dots for subtasks, base36 timestamps never do). Tighter
+// than `[a-z0-9]+` so that short issue tails like `gt-xyz` are not
+// mistaken for a timestamp when no timestamp was appended.
+var polecatTimestampSuffix = regexp.MustCompile(`^[0-9a-z]{6,}$`)
+
+// stripPolecatTimestampSuffix removes the trailing `@<ts>` or `-<ts>`
+// from the third segment of a polecat branch (`polecat/<worker>/<segment>`).
+// `@` is unambiguous (legacy form). `-` is ambiguous because issue IDs
+// themselves contain `-`, so it's only stripped when the suffix after the
+// rightmost `-` looks like a base36 timestamp. Returns the segment
+// unchanged if neither marker is present (e.g. `polecat/foo/gt-abc`).
+func stripPolecatTimestampSuffix(segment string) string {
+	if atIdx := strings.Index(segment, "@"); atIdx > 0 {
+		return segment[:atIdx]
+	}
+	if dashIdx := strings.LastIndex(segment, "-"); dashIdx > 0 && dashIdx < len(segment)-1 {
+		if polecatTimestampSuffix.MatchString(segment[dashIdx+1:]) {
+			return segment[:dashIdx]
+		}
+	}
+	return segment
+}
+
 // parseBranchName extracts issue ID and worker from a branch name.
 // Supports formats:
-//   - polecat/<worker>/<issue>  → issue=<issue>, worker=<worker>
-//   - polecat/<worker>-<timestamp>  → issue="", worker=<worker> (modern polecat branches)
-//   - <issue>                   → issue=<issue>, worker=""
+//   - polecat/<worker>/<issue>                → issue=<issue>, worker=<worker>  (no timestamp)
+//   - polecat/<worker>/<issue>-<timestamp>    → issue=<issue>, worker=<worker>  (current, hq-5w371+)
+//   - polecat/<worker>/<issue>@<timestamp>    → issue=<issue>, worker=<worker>  (legacy)
+//   - polecat/<worker>-<timestamp>            → issue="", worker=<worker> (modern no-issue form)
+//   - <issue>                                 → issue=<issue>, worker=""
+//
+// The `@` form is the historical default; switched to `-` 2026-06-24
+// (hq-5w371) because `anthropics/claude-code-action` rejects `@` in
+// head refs. The parser accepts both so in-flight branches round-trip.
 func parseBranchName(branch string) branchInfo {
 	info := branchInfo{Branch: branch}
 
-	// Try polecat/<worker>/<issue> or polecat/<worker>/<issue>@<timestamp> format
+	// Try polecat/<worker>/<issue>{-,@}<timestamp> format
 	if strings.HasPrefix(branch, constants.BranchPolecatPrefix) {
 		parts := strings.SplitN(branch, "/", 3)
 		if len(parts) == 3 {
 			info.Worker = parts[1]
-			// Strip @timestamp suffix if present (e.g., "gt-abc@mk123" -> "gt-abc")
-			issue := parts[2]
-			if atIdx := strings.Index(issue, "@"); atIdx > 0 {
-				issue = issue[:atIdx]
-			}
-			info.Issue = issue
+			info.Issue = stripPolecatTimestampSuffix(parts[2])
 			return info
 		}
 		// Modern polecat branch format: polecat/<worker>-<timestamp>

--- a/internal/cmd/patrol_scan.go
+++ b/internal/cmd/patrol_scan.go
@@ -66,12 +66,13 @@ var patrolScanProgressInterval = 10 * time.Second
 
 // PatrolScanOutput is the JSON output format for patrol scan results.
 type PatrolScanOutput struct {
-	Rig         string                    `json:"rig"`
-	Timestamp   string                    `json:"timestamp"`
-	Zombies     *PatrolScanZombieOutput   `json:"zombies"`
-	Stalls      *PatrolScanStallOutput    `json:"stalls,omitempty"`
-	Completions *PatrolScanCompleteOutput `json:"completions,omitempty"`
-	Receipts    []witness.PatrolReceipt   `json:"receipts,omitempty"`
+	Rig         string                              `json:"rig"`
+	Timestamp   string                              `json:"timestamp"`
+	Zombies     *PatrolScanZombieOutput             `json:"zombies"`
+	Stalls      *PatrolScanStallOutput              `json:"stalls,omitempty"`
+	Completions *PatrolScanCompleteOutput           `json:"completions,omitempty"`
+	Receipts    []witness.PatrolReceipt             `json:"receipts,omitempty"`
+	CrewStall   *witness.DetectStalledCrewResult    `json:"crew_stall,omitempty"`
 }
 
 // PatrolScanZombieOutput holds zombie detection results.
@@ -168,6 +169,15 @@ func runPatrolScan(cmd *cobra.Command, args []string) error {
 		return witness.DiscoverCompletions(bd, workDir, rigName, router)
 	})
 
+	// Layer 2 (glaicier gt-e4b3 / gt-wwoh): detect crew sessions stuck at
+	// /clear prompts or rate-limit-loops. Hash-state persisted at
+	// <townRoot>/.gt/crew-hashes/<crew>.json across cycles. Detection-only
+	// for now — auto-action is a follow-up bead once we tune false-positive
+	// thresholds against accumulated signal data.
+	crewStallResult := runPatrolScanPhase(diagnostics, "crew stall detection", func() *witness.DetectStalledCrewResult {
+		return witness.DetectStalledCrew(workDir, rigName)
+	})
+
 	// Build patrol receipts for zombies
 	receipts := witness.BuildPatrolReceipts(rigName, zombieResult)
 
@@ -183,10 +193,10 @@ func runPatrolScan(cmd *cobra.Command, args []string) error {
 	}
 
 	if patrolScanJSON {
-		return outputPatrolScanJSON(rigName, timestamp, zombieResult, stallResult, completionResult, receipts)
+		return outputPatrolScanJSON(rigName, timestamp, zombieResult, stallResult, completionResult, receipts, crewStallResult)
 	}
 
-	return outputPatrolScanHuman(rigName, zombieResult, stallResult, completionResult, receipts)
+	return outputPatrolScanHuman(rigName, zombieResult, stallResult, completionResult, receipts, crewStallResult)
 }
 
 func runPatrolScanPhase[T any](diagnostics io.Writer, name string, fn func() T) T {
@@ -285,11 +295,12 @@ func sendZombieNotification(router *mail.Router, rigName string, result *witness
 	_ = router.Send(mayorMsg)
 }
 
-func outputPatrolScanJSON(rigName, timestamp string, zombieResult *witness.DetectZombiePolecatsResult, stallResult *witness.DetectStalledPolecatsResult, completionResult *witness.DiscoverCompletionsResult, receipts []witness.PatrolReceipt) error {
+func outputPatrolScanJSON(rigName, timestamp string, zombieResult *witness.DetectZombiePolecatsResult, stallResult *witness.DetectStalledPolecatsResult, completionResult *witness.DiscoverCompletionsResult, receipts []witness.PatrolReceipt, crewStallResult *witness.DetectStalledCrewResult) error {
 	output := PatrolScanOutput{
 		Rig:       rigName,
 		Timestamp: timestamp,
 		Receipts:  receipts,
+		CrewStall: crewStallResult,
 	}
 
 	// Zombies
@@ -366,7 +377,7 @@ func outputPatrolScanJSON(rigName, timestamp string, zombieResult *witness.Detec
 	return enc.Encode(output)
 }
 
-func outputPatrolScanHuman(rigName string, zombieResult *witness.DetectZombiePolecatsResult, stallResult *witness.DetectStalledPolecatsResult, completionResult *witness.DiscoverCompletionsResult, _ []witness.PatrolReceipt) error {
+func outputPatrolScanHuman(rigName string, zombieResult *witness.DetectZombiePolecatsResult, stallResult *witness.DetectStalledPolecatsResult, completionResult *witness.DiscoverCompletionsResult, _ []witness.PatrolReceipt, crewStallResult *witness.DetectStalledCrewResult) error {
 	fmt.Printf("%s Patrol scan: %s\n\n", style.Bold.Render("🔍"), rigName)
 
 	// Zombies
@@ -468,11 +479,23 @@ func outputPatrolScanHuman(rigName string, zombieResult *witness.DetectZombiePol
 		completionCount = len(completionResult.Discovered)
 	}
 
-	if zombieCount == 0 && stallCount == 0 && completionCount == 0 {
+	crewStuckCount := 0
+	if crewStallResult != nil {
+		crewStuckCount = len(crewStallResult.Stalled)
+	}
+
+	if zombieCount == 0 && stallCount == 0 && completionCount == 0 && crewStuckCount == 0 {
 		fmt.Printf("%s All clear — no issues detected\n", style.Success.Render("✓"))
 	} else {
-		fmt.Printf("Summary: %d zombie(s) (%d active-work), %d stall(s), %d completion(s)\n",
-			zombieCount, activeCount, stallCount, completionCount)
+		fmt.Printf("Summary: %d zombie(s) (%d active-work), %d stall(s), %d completion(s), %d crew-stuck\n",
+			zombieCount, activeCount, stallCount, completionCount, crewStuckCount)
+	}
+
+	if crewStuckCount > 0 {
+		fmt.Printf("\n%s Crew sessions stuck at prompt (%d):\n", style.Bold.Render("⚠"), crewStuckCount)
+		for _, c := range crewStallResult.Stalled {
+			fmt.Printf("  %s — %d unchanged cycles since %s\n", c.CrewName, c.StuckCycles, c.LastChanged)
+		}
 	}
 
 	return nil

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -1227,20 +1227,38 @@ func tryAcquireSlingBeadLock(townRoot, beadID string) (func(), error) {
 }
 
 // tryAcquireSlingAssigneeLock acquires a per-assignee file lock to serialize concurrent
-// hook writes to the same polecat. The per-bead lock (tryAcquireSlingBeadLock) prevents
-// double-sling of the same bead, but does not prevent concurrent slings from racing on
-// the same assignee's hook_bead field in Dolt. This lock is held only during
-// hookBeadWithRetry. Uses non-blocking try-acquire with retry and timeout to avoid
-// indefinite blocking if a sling gets stuck.
-// See: https://github.com/steveyegge/gastown/issues/3114
+// hook writes to the same polecat AND across different polecats in the same rig.
+// The per-bead lock (tryAcquireSlingBeadLock) prevents double-sling of the same bead;
+// the original #3114 fix added a per-assignee lock to prevent same-polecat hook races.
+// But at parallel-scale (e.g. 6 polecats in one rig slung at 15s spacing — m365 gt-pad1
+// repro 2026-06-21), DIFFERENT polecats in the SAME rig still race on the shared Dolt
+// branch via bd's auto-commit path: bd update --status=hooked runs with auto-commit on
+// against the shared branch HEAD, and concurrent commits can roll each other back
+// silently. The verify read in hookBeadWithRetry sees the row in its own session
+// snapshot and returns success, but the branch-level COMMIT got conflict-rolled-back.
+// Net: sling reports "✓ Work attached to hook" but the row is gone moments later.
+//
+// Fix: serialize the hook write per-RIG (all polecats in a rig share one Dolt branch),
+// not just per-assignee. This adds ~50-200ms per concurrent sling but eliminates the
+// branch-level race window. Same scope as #3114's fix but extended to cross-polecat.
+//
+// See: https://github.com/steveyegge/gastown/issues/3114 (per-assignee fix)
+// See: glaicier/gastown gt-phve (parallel-scale extension)
 func tryAcquireSlingAssigneeLock(townRoot, targetAgent string) (func(), error) {
 	lockDir := filepath.Join(townRoot, ".runtime", "locks", "sling")
 	if err := os.MkdirAll(lockDir, 0755); err != nil {
 		return nil, fmt.Errorf("creating sling lock dir: %w", err)
 	}
 
-	safeAgent := strings.NewReplacer("/", "_", ":", "_").Replace(targetAgent)
-	lockPath := filepath.Join(lockDir, "assignee_"+safeAgent+".flock")
+	// Lock per-rig (first segment of targetAgent, e.g. "m365" from "m365/polecats/chrome").
+	// Different polecats in the same rig race on the shared Dolt branch — serialize all
+	// hook writes for the rig to eliminate the branch-level commit-conflict window.
+	rig := strings.SplitN(targetAgent, "/", 2)[0]
+	if rig == "" {
+		rig = "town"
+	}
+	safeRig := strings.NewReplacer("/", "_", ":", "_").Replace(rig)
+	lockPath := filepath.Join(lockDir, "rig_"+safeRig+".flock")
 
 	// Try non-blocking acquire with retry. hookBeadWithRetry itself has 10 retries
 	// with up to 30s backoff, so we allow generous total wait time for the lock.
@@ -1249,7 +1267,7 @@ func tryAcquireSlingAssigneeLock(townRoot, targetAgent string) (func(), error) {
 	for attempt := 1; attempt <= maxAttempts; attempt++ {
 		release, locked, err := lock.FlockTryAcquire(lockPath)
 		if err != nil {
-			return nil, fmt.Errorf("acquiring assignee sling lock for %s: %w", targetAgent, err)
+			return nil, fmt.Errorf("acquiring rig sling lock for %s (rig=%s): %w", targetAgent, rig, err)
 		}
 		if locked {
 			return release, nil
@@ -1259,7 +1277,7 @@ func tryAcquireSlingAssigneeLock(townRoot, targetAgent string) (func(), error) {
 		}
 	}
 
-	return nil, fmt.Errorf("timed out acquiring assignee sling lock for %s after %ds (another sling may be stuck)", targetAgent, maxAttempts*retryInterval/1000)
+	return nil, fmt.Errorf("timed out acquiring rig sling lock for %s (rig=%s) after %ds (another sling may be stuck)", targetAgent, rig, maxAttempts*retryInterval/1000)
 }
 
 // resolvePRBranch resolves a GitHub PR number to its head branch name via `gh pr view`.

--- a/internal/daemon/daemon.go
+++ b/internal/daemon/daemon.go
@@ -653,6 +653,23 @@ func (d *Daemon) Run() (err error) {
 		d.logger.Printf("Checkpoint dog ticker started (interval %v)", interval)
 	}
 
+	// Start polecat patrol ticker (Layer 1 fix for glaicier gt-e4b3).
+	// Runs `gt patrol scan --rig <X> --notify` for each known rig on a
+	// deterministic timer (default 5m). Without this, polecat zombie/
+	// dead-session detection waits for the witness LLM agent to decide
+	// when to scan — observed gap was 8+ hours. Closes the loop so worst-
+	// case detection latency is bounded by the patrol interval + scan
+	// duration (~6.5 min default).
+	var polecatPatrolTicker *time.Ticker
+	var polecatPatrolChan <-chan time.Time
+	if d.isPatrolActive("polecat_patrol") {
+		interval := polecatPatrolInterval(d.patrolConfig)
+		polecatPatrolTicker = time.NewTicker(interval)
+		polecatPatrolChan = polecatPatrolTicker.C
+		defer polecatPatrolTicker.Stop()
+		d.logger.Printf("Polecat patrol ticker started (interval %v)", interval)
+	}
+
 	// Start scheduled maintenance ticker if configured.
 	// Checks periodically whether we're in the maintenance window and
 	// runs `gt maintain --force` when commit counts exceed threshold.
@@ -777,6 +794,16 @@ func (d *Daemon) Run() (err error) {
 			// worktrees to prevent data loss from session crashes.
 			if !d.isShutdownInProgress() {
 				d.runCheckpointDog()
+			}
+
+		case <-polecatPatrolChan:
+			// Polecat patrol — deterministic cadence for `gt patrol scan`
+			// per rig (Layer 1 fix for glaicier gt-e4b3). Catches dead
+			// polecat sessions with active hooks + auto-restarts them.
+			// The witness LLM agent continues its own slower judgment-
+			// driven patrol; this loop is the deterministic safety net.
+			if !d.isShutdownInProgress() {
+				d.runPolecatPatrol()
 			}
 
 		case <-scheduledMaintenanceChan:

--- a/internal/daemon/polecat_patrol.go
+++ b/internal/daemon/polecat_patrol.go
@@ -1,0 +1,118 @@
+package daemon
+
+import (
+	"context"
+	"os/exec"
+	"time"
+)
+
+// Operational constants for the polecat patrol.
+const (
+	defaultPolecatPatrolInterval = 5 * time.Minute
+	defaultPolecatPatrolTimeout  = 4 * time.Minute
+)
+
+// PolecatPatrolConfig holds configuration for the polecat patrol.
+//
+// This patrol runs `gt patrol scan --rig <X> --notify` for each known rig on
+// a deterministic timer. Without it, polecat zombie/dead-session detection
+// depends on the witness LLM agent's judgment about when to scan — which on
+// m365 was observed to be 8+ hours between scans (glaicier gt-e4b3 evidence).
+//
+// The scan command itself contains the detection + auto-restart logic
+// (internal/witness/handlers.go + internal/cmd/patrol_scan.go). This patrol
+// just gives it deterministic cadence.
+type PolecatPatrolConfig struct {
+	// Enabled controls whether the polecat patrol runs.
+	Enabled bool `json:"enabled"`
+
+	// IntervalStr is how often to run, as a string (e.g., "5m").
+	IntervalStr string `json:"interval,omitempty"`
+
+	// TimeoutStr is the per-rig scan timeout (e.g., "4m").
+	TimeoutStr string `json:"timeout,omitempty"`
+
+	// Rigs lists rig names to patrol. Empty = patrol all known rigs.
+	Rigs []string `json:"rigs,omitempty"`
+}
+
+// polecatPatrolInterval returns the configured or default patrol interval.
+func polecatPatrolInterval(config *DaemonPatrolConfig) time.Duration {
+	if config == nil || config.Patrols == nil || config.Patrols.PolecatPatrol == nil {
+		return defaultPolecatPatrolInterval
+	}
+	if config.Patrols.PolecatPatrol.IntervalStr == "" {
+		return defaultPolecatPatrolInterval
+	}
+	d, err := time.ParseDuration(config.Patrols.PolecatPatrol.IntervalStr)
+	if err != nil || d <= 0 {
+		return defaultPolecatPatrolInterval
+	}
+	return d
+}
+
+// polecatPatrolTimeout returns the configured or default per-rig scan timeout.
+func polecatPatrolTimeout(config *DaemonPatrolConfig) time.Duration {
+	if config == nil || config.Patrols == nil || config.Patrols.PolecatPatrol == nil {
+		return defaultPolecatPatrolTimeout
+	}
+	if config.Patrols.PolecatPatrol.TimeoutStr == "" {
+		return defaultPolecatPatrolTimeout
+	}
+	d, err := time.ParseDuration(config.Patrols.PolecatPatrol.TimeoutStr)
+	if err != nil || d <= 0 {
+		return defaultPolecatPatrolTimeout
+	}
+	return d
+}
+
+// runPolecatPatrol invokes `gt patrol scan --rig <X> --notify` for each
+// configured rig sequentially. Errors are logged but do not stop the loop —
+// one bad rig must not block the others.
+//
+// Each rig invocation runs under a context with timeout so a hung scan
+// can't wedge the daemon's main loop.
+func (d *Daemon) runPolecatPatrol() {
+	rigs := d.polecatPatrolRigs()
+	if len(rigs) == 0 {
+		d.logger.Printf("polecat patrol: no rigs to scan (config empty + no rigs registered)")
+		return
+	}
+
+	timeout := polecatPatrolTimeout(d.patrolConfig)
+
+	for _, rig := range rigs {
+		// New context per rig — one slow scan must not eat into the next rig's budget.
+		ctx, cancel := context.WithTimeout(context.Background(), timeout)
+		cmd := exec.CommandContext(ctx, d.gtPath, "patrol", "scan", "--rig", rig, "--notify")
+		out, err := cmd.CombinedOutput()
+		cancel()
+
+		if err != nil {
+			d.logger.Printf("polecat patrol: rig=%s failed: %v (output: %s)", rig, err, truncate(string(out), 500))
+		} else {
+			d.logger.Printf("polecat patrol: rig=%s ok (%d bytes output)", rig, len(out))
+		}
+	}
+}
+
+// polecatPatrolRigs returns the list of rigs to scan. Priority:
+//   1. Config-supplied list (PolecatPatrolConfig.Rigs) if non-empty
+//   2. All known rigs from the daemon's rig registry
+//   3. Empty list (no-op patrol)
+func (d *Daemon) polecatPatrolRigs() []string {
+	if d.patrolConfig != nil && d.patrolConfig.Patrols != nil &&
+		d.patrolConfig.Patrols.PolecatPatrol != nil &&
+		len(d.patrolConfig.Patrols.PolecatPatrol.Rigs) > 0 {
+		return d.patrolConfig.Patrols.PolecatPatrol.Rigs
+	}
+	return d.getKnownRigs()
+}
+
+// truncate clips a string to maxLen with an ellipsis indicator.
+func truncate(s string, maxLen int) string {
+	if len(s) <= maxLen {
+		return s
+	}
+	return s[:maxLen] + "...[truncated]"
+}

--- a/internal/daemon/types.go
+++ b/internal/daemon/types.go
@@ -131,6 +131,7 @@ type PatrolsConfig struct {
 	MainBranchTest         *MainBranchTestConfig          `json:"main_branch_test,omitempty"`
 	QuotaDog               *QuotaDogConfig                `json:"quota_dog,omitempty"`
 	RestartTracker         *RestartTrackerConfig          `json:"restart_tracker,omitempty"`
+	PolecatPatrol          *PolecatPatrolConfig           `json:"polecat_patrol,omitempty"`
 }
 
 // DoltRemotesConfig holds configuration for the dolt_remotes patrol.
@@ -307,6 +308,16 @@ func IsPatrolEnabled(config *DaemonPatrolConfig, patrol string) bool {
 			return false
 		}
 		return config.Patrols.QuotaDog.Enabled
+	}
+	if patrol == "polecat_patrol" {
+		// Default ENABLED if unconfigured — this is the Layer 1 deterministic
+		// patrol that closes the 8h zombie-detection latency gap. Operators
+		// who want to disable it (e.g., headless CI rigs) must set
+		// patrols.polecat_patrol.enabled = false explicitly.
+		if config == nil || config.Patrols == nil || config.Patrols.PolecatPatrol == nil {
+			return true
+		}
+		return config.Patrols.PolecatPatrol.Enabled
 	}
 
 	if config == nil || config.Patrols == nil {

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -617,8 +617,14 @@ type AddOptions struct {
 // - {timestamp}: unique timestamp
 //
 // If no template is configured or template is empty, uses default format:
-// - polecat/{name}/{issue}@{timestamp} when issue is available
+// - polecat/{name}/{issue}-{timestamp} when issue is available
 // - polecat/{name}-{timestamp} otherwise
+//
+// The historical separator was `@`, but `anthropics/claude-code-action`'s
+// head-ref validator rejects `@` (regex `^[a-zA-Z0-9][a-zA-Z0-9/_.#+,-]*$`)
+// — root cause of hq-1svtk / hq-5w371. Switched to `-` 2026-06-24.
+// Parsers in session_manager.parseFreshBranchName and mq_submit.parseBranchName
+// accept both `@` and `-` so in-flight branches still round-trip.
 func (m *Manager) buildBranchName(name, issue string) string {
 	template := m.rig.GetStringConfig("polecat_branch_template")
 
@@ -626,7 +632,7 @@ func (m *Manager) buildBranchName(name, issue string) string {
 	if template == "" {
 		timestamp := strconv.FormatInt(time.Now().UnixMilli(), 36)
 		if issue != "" {
-			return fmt.Sprintf("polecat/%s/%s@%s", name, issue, timestamp)
+			return fmt.Sprintf("polecat/%s/%s-%s", name, issue, timestamp)
 		}
 		return fmt.Sprintf("polecat/%s-%s", name, timestamp)
 	}

--- a/internal/polecat/manager.go
+++ b/internal/polecat/manager.go
@@ -362,6 +362,68 @@ func (m *Manager) resetAgentBeadForReuse(agentID, reason string) error {
 	return m.agentBeads().ResetAgentBeadForReuse(agentID, reason)
 }
 
+// clearStaleHookedWorkBeads clears any work-bead rows still claiming this
+// polecat as assignee (in either status=hooked or status=in_progress).
+// Called from BOTH the reuse path (ReuseIdlePolecat) and the fresh-spawn
+// path (addWithOptionsLocked) before a new agent bead is created.
+//
+// Why: a polecat whose prior session crashed, was force-nuked, or had its
+// hook bypassed externally can leave its previous work bead claiming this
+// polecat as assignee. Because polecat names are reused from a fixed pool,
+// the same name returning (via reuse OR fresh-allocate-of-released-name)
+// inherits the stale row.
+//
+// Two flavours need clearing:
+//   - status=hooked rows: revert to open (matches the unsling #2384 pattern).
+//     Without this, the next sling's hookBeadWithRetry produces a SECOND
+//     hooked row, and `gt hook show`'s unordered query
+//     (internal/cmd/hook.go:513) returns whichever sorts first.
+//   - status=in_progress rows: clear assignee only (preserves the bead's
+//     progress state — the work itself may have shipped via another path
+//     or be genuinely orphaned). Without this, `gt hook show`'s in-progress
+//     fallback (internal/cmd/hook.go:520-529) returns the stale row when no
+//     hooked row exists, masking the polecat's actual current assignment.
+//
+// Failures are non-fatal (warning only) — the agent-bead reset/create step
+// is the load-bearing operation.
+func (m *Manager) clearStaleHookedWorkBeads(name string) {
+	assignee := m.assigneeID(name)
+	openStatus := "open"
+	emptyAssignee := ""
+
+	// Hooked rows → revert to open, clear assignee (unsling pattern).
+	if staleHooked, err := m.beads.List(beads.ListOptions{
+		Status:   beads.StatusHooked,
+		Assignee: assignee,
+		Priority: -1,
+	}); err == nil && len(staleHooked) > 0 {
+		for _, stale := range staleHooked {
+			if err := m.beads.Update(stale.ID, beads.UpdateOptions{
+				Status:   &openStatus,
+				Assignee: &emptyAssignee,
+			}); err != nil {
+				style.PrintWarning("could not clear stale hooked bead %s for polecat %s: %v", stale.ID, name, err)
+			}
+		}
+	}
+
+	// In-progress rows → clear assignee only (keep status — work may have
+	// shipped via another path; preserve progress info).
+	if staleInProgress, err := m.beads.List(beads.ListOptions{
+		Status:   "in_progress",
+		Assignee: assignee,
+		Priority: -1,
+	}); err == nil && len(staleInProgress) > 0 {
+		for _, stale := range staleInProgress {
+			if err := m.beads.Update(stale.ID, beads.UpdateOptions{
+				Assignee: &emptyAssignee,
+			}); err != nil {
+				style.PrintWarning("could not clear stale in-progress assignee on %s for polecat %s: %v", stale.ID, name, err)
+			}
+		}
+	}
+}
+
 // SetAgentStateWithRetry wraps SetAgentState with retry logic.
 // Returns an error after exhausting retries, but callers may choose to warn
 // rather than fail — e.g., in StartSession where the tmux session is already
@@ -849,6 +911,14 @@ func (m *Manager) addWithOptionsLocked(name string, opts AddOptions, polecatDir 
 		cleanupOnError()
 		return nil, err
 	}
+
+	// Clear stale status=hooked work-bead rows on this polecat name before
+	// binding the new agent bead. Polecat names come from a fixed pool and
+	// can be reused after release — without this, a row from a prior epic
+	// (e.g. status=hooked, assignee=m365/polecats/chrome) survives across
+	// nuke + fresh-allocate-of-released-name and pollutes the next sling's
+	// hook resolution. See clearStaleHookedWorkBeads for full rationale.
+	m.clearStaleHookedWorkBeads(name)
 
 	agentID := m.agentBeadID(name)
 	if err = m.createAgentBeadWithRetry(agentID, &beads.AgentFields{
@@ -1810,6 +1880,10 @@ func (m *Manager) ReuseIdlePolecat(name string, opts AddOptions) (*Polecat, erro
 		_ = polecatGit.CleanForce()
 		return nil, err
 	}
+
+	// Clear stale status=hooked work-bead rows on this polecat before reuse.
+	// See clearStaleHookedWorkBeads doc comment for full rationale.
+	m.clearStaleHookedWorkBeads(name)
 
 	// Reset agent bead for reuse
 	agentID := m.agentBeadID(name)

--- a/internal/polecat/manager_test.go
+++ b/internal/polecat/manager_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
 	"sort"
 	"strconv"
@@ -1010,7 +1011,7 @@ func TestBuildBranchName(t *testing.T) {
 			name:     "default_with_issue",
 			template: "", // Empty template = default behavior
 			issue:    "gt-123",
-			want:     "polecat/alpha/gt-123@", // timestamp suffix varies
+			want:     "polecat/alpha/gt-123-", // hq-5w371: `-` separator (was `@`); timestamp suffix varies
 		},
 		{
 			name:     "default_without_issue",
@@ -1082,6 +1083,61 @@ func TestBuildBranchName(t *testing.T) {
 						t.Errorf("buildBranchName() = %q, want %q", got, tt.want)
 					}
 				}
+			}
+		})
+	}
+}
+
+// claudeCodeActionHeadRefRegex mirrors the head-ref validator inside
+// `anthropics/claude-code-action` (pinned at SHA
+// 2fee15510437d71399d9139ed60433470484a8fb). Any character it rejects in
+// the generated branch name surfaces as "Action failed with error: Invalid
+// branch name: …" on every @claude review request — the regression
+// hq-1svtk / hq-5w371 captured (root cause: the `@` separator). Keep this
+// test green to avoid silently regressing the action's accept-set on
+// future renames.
+var claudeCodeActionHeadRefRegex = regexp.MustCompile(`^[a-zA-Z0-9][a-zA-Z0-9/_.#+,-]*$`)
+
+// TestBuildBranchName_ClaudeActionCompatible asserts that the default
+// branch-name generator produces a ref accepted by claude-code-action.
+// Generates with several plausible issue ID shapes (dashes, dots,
+// subtasks) so future template tweaks that re-introduce `@` (or any
+// other rejected char) fail at unit-test time rather than in production.
+func TestBuildBranchName_ClaudeActionCompatible(t *testing.T) {
+	tmpDir := t.TempDir()
+	gitCmd := exec.Command("git", "init")
+	gitCmd.Dir = tmpDir
+	if err := gitCmd.Run(); err != nil {
+		t.Fatalf("git init: %v", err)
+	}
+
+	r := &rig.Rig{Name: "test-rig", Path: tmpDir}
+	g := git.NewGit(tmpDir)
+	m := NewManager(r, g, nil)
+
+	cases := []struct {
+		name  string
+		pname string
+		issue string
+	}{
+		{name: "simple issue", pname: "mutant", issue: "gt-abc"},
+		{name: "dotted subtask", pname: "raider", issue: "gt-4kp9.5.5.1"},
+		{name: "hq prefix", pname: "pipboy", issue: "hq-571c"},
+		{name: "no issue", pname: "ghoul", issue: ""},
+		{name: "long name", pname: "thunderchief", issue: "gt-jns7.1"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := m.buildBranchName(c.pname, c.issue)
+			if !claudeCodeActionHeadRefRegex.MatchString(got) {
+				t.Errorf("buildBranchName(%q, %q) = %q rejected by claude-code-action regex %q",
+					c.pname, c.issue, got, claudeCodeActionHeadRefRegex)
+			}
+			// Negative pin: `@` must not appear anywhere in the generated
+			// ref (the specific character that caused hq-1svtk).
+			if strings.Contains(got, "@") {
+				t.Errorf("buildBranchName(%q, %q) = %q contains '@'; hq-5w371 banned this character",
+					c.pname, c.issue, got)
 			}
 		})
 	}

--- a/internal/polecat/session_manager.go
+++ b/internal/polecat/session_manager.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"time"
@@ -176,14 +177,21 @@ func (m *SessionManager) clonePath(polecat string) string {
 
 // freshBranchName returns a unique branch name for a new polecat session.
 // Mirrors the naming convention in Manager.buildBranchName:
-//   - polecat/<name>/<issue>@<timestamp> when an issue is known
+//   - polecat/<name>/<issue>-<timestamp> when an issue is known
 //   - polecat/<name>-<timestamp> otherwise
+//
+// The historical separator was `@`, but that character is rejected by
+// `anthropics/claude-code-action`'s head-ref validator
+// (`^[a-zA-Z0-9][a-zA-Z0-9/_.#+,-]*$`, hq-5w371 / blocks hq-1svtk),
+// so the @claude review action 100%-failed on every polecat PR. The
+// separator changed to `-` 2026-06-24; parseFreshBranchName accepts
+// both forms so in-flight `@`-form branches continue to round-trip.
 //
 // parseFreshBranchName is the structural inverse.
 func (m *SessionManager) freshBranchName(polecatName, issue string) string {
 	ts := strconv.FormatInt(time.Now().UnixMilli(), 36)
 	if issue != "" {
-		return fmt.Sprintf("polecat/%s/%s@%s", polecatName, issue, ts)
+		return fmt.Sprintf("polecat/%s/%s-%s", polecatName, issue, ts)
 	}
 	return fmt.Sprintf("polecat/%s-%s", polecatName, ts)
 }
@@ -196,10 +204,25 @@ type freshBranchMeta struct {
 	ok      bool
 }
 
+// polecatTimestampSuffix matches the base36 UnixMilli timestamp tail that
+// freshBranchName / Manager.buildBranchName append after the issue. Millis
+// fit in ~8 base36 chars so we require ≥6 lowercase alphanumerics with no
+// dots (issue IDs use dots for subtasks, base36 timestamps never do).
+// Tighter than `[a-z0-9]+` so short issue tails (e.g. the `xyz` in
+// `gt-xyz`) are not mistaken for a timestamp when none was appended.
+var polecatTimestampSuffix = regexp.MustCompile(`^[0-9a-z]{6,}$`)
+
 // parseFreshBranchName is the structural inverse of freshBranchName. It
 // does not consult git or the filesystem; it recognizes the two formats
 // the formatter emits. Used in place of substring heuristics so that
 // branch-naming changes can be made in a single place.
+//
+// Accepts both the historical `@` separator and the current `-` separator
+// between issue and timestamp (the with-issue form) so in-flight branches
+// created before the hq-5w371 rename still parse. `@` is unambiguous
+// (legacy). For `-`, the rightmost `-` is only treated as the separator
+// when the suffix matches polecatTimestampSuffix — otherwise the segment
+// is taken as an issue with no ts (e.g. `polecat/foo/gt-xyz`).
 func parseFreshBranchName(branch string) freshBranchMeta {
 	const prefix = "polecat/"
 	if !strings.HasPrefix(branch, prefix) {
@@ -207,17 +230,23 @@ func parseFreshBranchName(branch string) freshBranchMeta {
 	}
 	rest := branch[len(prefix):]
 	if slash := strings.Index(rest, "/"); slash >= 0 {
-		// polecat/<name>/<issue>@<ts>
+		// polecat/<name>/<issue>{@|-}<ts>
 		if slash == 0 {
 			return freshBranchMeta{}
 		}
 		name := rest[:slash]
 		tail := rest[slash+1:]
-		at := strings.LastIndex(tail, "@")
-		if at <= 0 || at == len(tail)-1 {
-			return freshBranchMeta{}
+		// Legacy `@` form.
+		if at := strings.LastIndex(tail, "@"); at > 0 && at < len(tail)-1 {
+			return freshBranchMeta{polecat: name, issue: tail[:at], ok: true}
 		}
-		return freshBranchMeta{polecat: name, issue: tail[:at], ok: true}
+		// Current `-` form: rightmost `-` separates issue from ts only when
+		// the suffix looks like a base36 timestamp.
+		if dash := strings.LastIndex(tail, "-"); dash > 0 && dash < len(tail)-1 &&
+			polecatTimestampSuffix.MatchString(tail[dash+1:]) {
+			return freshBranchMeta{polecat: name, issue: tail[:dash], ok: true}
+		}
+		return freshBranchMeta{}
 	}
 	// polecat/<name>-<ts> (no slash in rest)
 	dash := strings.LastIndex(rest, "-")

--- a/internal/witness/crew_patrol.go
+++ b/internal/witness/crew_patrol.go
@@ -1,0 +1,185 @@
+package witness
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/steveyegge/gastown/internal/session"
+	"github.com/steveyegge/gastown/internal/tmux"
+	"github.com/steveyegge/gastown/internal/workspace"
+)
+
+// StalledCrewResult represents a single stalled crew session detection.
+type StalledCrewResult struct {
+	CrewName        string `json:"crew_name"`
+	StuckCycles     int    `json:"stuck_cycles"`     // How many consecutive cycles the pane hash hasn't changed
+	LastChanged     string `json:"last_changed"`     // RFC3339 timestamp of last hash change
+	Action          string `json:"action"`           // "detected" (Layer 2 detection-only; auto-action is a separate bead)
+	PaneSnapshot    string `json:"pane_snapshot"`    // Last ~10 lines for diagnostic context
+	Error           string `json:"error,omitempty"`
+}
+
+// DetectStalledCrewResult holds aggregate results.
+type DetectStalledCrewResult struct {
+	Checked int                 `json:"checked"`
+	Stalled []StalledCrewResult `json:"stalled,omitempty"`
+	Errors  []string            `json:"errors,omitempty"`
+}
+
+// crewHashState is the persisted per-crew hash tracking record.
+type crewHashState struct {
+	Hash             string `json:"hash"`
+	LastChangedAt    string `json:"last_changed_at"`
+	UnchangedCycles  int    `json:"unchanged_cycles"`
+	LastSnapshot     string `json:"last_snapshot,omitempty"`
+}
+
+const (
+	// DefaultCrewStuckThreshold is the number of consecutive unchanged-pane
+	// patrol cycles before emitting a CREW_STUCK signal. At the default
+	// 5m patrol interval this means ~15 min of no pane activity.
+	DefaultCrewStuckThreshold = 3
+
+	// crewPaneCaptureLines is how many recent lines to hash. The volatile
+	// bottom-bar of the Claude Code TUI (token counts, model labels) is
+	// excluded by taking lines from the top of the capture, not the bottom.
+	crewPaneCaptureLines = 40
+)
+
+// DetectStalledCrew checks live crew sessions for the stuck-at-prompt pattern
+// (pane hash unchanged across N patrol cycles AND no nudge consumed). Closes
+// the witness gap captured in glaicier gt-e4b3 / gt-wwoh — dave's session sat
+// at the /clear prompt 30+ min without consuming nudges and required manual
+// mayor intervention.
+//
+// Detection-only — no auto-action. The auto-unblock-via-paste-buffer is a
+// SEPARATE follow-up (gt-e4b3.2 or similar) once we have detection signal
+// data to tune false-positive thresholds against.
+//
+// Hash-state persisted at <townRoot>/.gt/crew-hashes/<crew>.json so unchanged-
+// cycle counts survive daemon restarts.
+func DetectStalledCrew(workDir, rigName string) *DetectStalledCrewResult {
+	result := &DetectStalledCrewResult{}
+
+	townRoot, err := workspace.Find(workDir)
+	if err != nil || townRoot == "" {
+		townRoot = workDir
+	}
+
+	// List crew workers — they live at <townRoot>/<rigName>/crew/
+	crewDir := filepath.Join(townRoot, rigName, "crew")
+	entries, err := os.ReadDir(crewDir)
+	if err != nil {
+		return result // No crew dir or unreadable — no-op
+	}
+
+	hashDir := filepath.Join(townRoot, ".gt", "crew-hashes")
+	if err := os.MkdirAll(hashDir, 0o755); err != nil {
+		result.Errors = append(result.Errors, fmt.Sprintf("create hash dir: %v", err))
+		return result
+	}
+
+	t := tmux.NewTmux()
+	now := time.Now().UTC().Format(time.RFC3339)
+
+	for _, entry := range entries {
+		if !entry.IsDir() || strings.HasPrefix(entry.Name(), ".") {
+			continue
+		}
+
+		crewName := entry.Name()
+		sessionName := session.CrewSessionName(session.PrefixFor(rigName), crewName)
+		result.Checked++
+
+		// Only check live sessions — dead sessions are out of scope for stuck-at-prompt
+		// (they need different recovery: respawn or handoff, both mayor-level decisions).
+		alive, err := t.HasSession(sessionName)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("HasSession(%s): %v", sessionName, err))
+			continue
+		}
+		if !alive {
+			continue
+		}
+
+		// Capture pane content. Take the TOP N lines (skip volatile bottom bar).
+		content, err := t.CapturePane(sessionName, crewPaneCaptureLines)
+		if err != nil {
+			result.Errors = append(result.Errors, fmt.Sprintf("CapturePane(%s): %v", sessionName, err))
+			continue
+		}
+
+		// Hash the captured content. Skip the bottom 5 lines (TUI status bar,
+		// token-count updates, "Update available!" notifications etc — all volatile).
+		lines := strings.Split(content, "\n")
+		stableLineCount := len(lines) - 5
+		if stableLineCount < 5 {
+			continue // Pane too short to hash meaningfully
+		}
+		stableContent := strings.Join(lines[:stableLineCount], "\n")
+		sum := sha256.Sum256([]byte(stableContent))
+		currentHash := hex.EncodeToString(sum[:])
+
+		// Read prior state
+		stateFile := filepath.Join(hashDir, crewName+".json")
+		prior := readCrewHashState(stateFile)
+
+		updated := crewHashState{
+			Hash:            currentHash,
+			LastChangedAt:   prior.LastChangedAt,
+			UnchangedCycles: prior.UnchangedCycles,
+			LastSnapshot:    content,
+		}
+
+		if prior.Hash == "" || prior.Hash != currentHash {
+			// First check OR hash changed — reset counter
+			updated.LastChangedAt = now
+			updated.UnchangedCycles = 0
+		} else {
+			// Hash matches — increment unchanged counter
+			updated.UnchangedCycles = prior.UnchangedCycles + 1
+		}
+
+		_ = writeCrewHashState(stateFile, updated)
+
+		if updated.UnchangedCycles >= DefaultCrewStuckThreshold {
+			snippet := content
+			if len(snippet) > 600 {
+				snippet = "...[truncated]\n" + snippet[len(snippet)-600:]
+			}
+			result.Stalled = append(result.Stalled, StalledCrewResult{
+				CrewName:     crewName,
+				StuckCycles:  updated.UnchangedCycles,
+				LastChanged:  updated.LastChangedAt,
+				Action:       "detected",
+				PaneSnapshot: snippet,
+			})
+		}
+	}
+
+	return result
+}
+
+func readCrewHashState(path string) crewHashState {
+	var s crewHashState
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return s
+	}
+	_ = json.Unmarshal(b, &s)
+	return s
+}
+
+func writeCrewHashState(path string, s crewHashState) error {
+	b, err := json.MarshalIndent(s, "", "  ")
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(path, b, 0o644)
+}


### PR DESCRIPTION
## Summary

Closes `hq-5w371`. Blocks/closes `hq-1svtk` (claude-code-action reliability — 5/20 success rate today, 100% failure since 21:19Z 06-23).

`gt sling` generates polecat branches like `polecat/<name>/<bead>@<ts>`. The `@` character is rejected by `anthropics/claude-code-action@2fee1551…` whose head-ref validator is `^[a-zA-Z0-9][a-zA-Z0-9/_.#+,-]*$`. Every polecat PR therefore 100%-failed its `@claude` review with `Action failed with error: Invalid branch name: …`.

## Change

Separator `@` → `-` in two generators:
- `polecat.Manager.buildBranchName` (internal/polecat/manager.go:629)
- `polecat.SessionManager.freshBranchName` (internal/polecat/session_manager.go:186)

Now emits `polecat/mutant/gt-4kp9.5.5.1-mqr445cc`. Manual rename of this form verified against the action 2026-06-24 06:16Z (both regex and live workflow accept).

## Parser compatibility

In-flight `@`-form branches still round-trip. Both `parseFreshBranchName` (polecat) and `parseBranchName` (cmd/mq_submit) try `@` first (legacy, unambiguous) then fall back to splitting on the rightmost `-` when the suffix matches a base36-timestamp regex (`^[0-9a-z]{6,}$`). The min-length guard prevents short issue tails like the `xyz` in `polecat/Nux/gt-xyz` (an existing test case) from being mistaken for a timestamp. Issue IDs use `.` for subtasks, never base36 digits-only — disambiguation is safe.

## Tests

- `TestBuildBranchName_ClaudeActionCompatible` (new): asserts every generator output matches the action's regex and contains no `@`, run across 5 issue-ID shapes (simple, dotted subtask, hq-prefix, no-issue, long polecat name)
- `TestBuildBranchName` updated: default-with-issue prefix `polecat/alpha/gt-123-`
- `TestParseFreshBranchName_RoundTrip` + `_Rejects`: pass unchanged — all legacy `@` cases still round-trip / still rejected
- All existing polecat-package tests green locally; cmd-package tests blocked by pre-existing `updateAgentStateOnDone` arity drift (unrelated, present on main)

## Not in scope

Per `hq-5w371` acceptance item 4: existing `@`-form polecat PRs not renamed. GitHub auto-closes a PR when its head branch renames (per `github-branch-rename-closes-prs` auto-memory). New branches use `-` going forward.

Other GH-Action-incompatible chars audited (item 3): the existing generators only emit `[a-z0-9-/.]`, all already in the regex's accept-set. No other chars to ban.

## Test plan

- [x] `go test -run TestBuildBranchName ./internal/polecat/` → all subtests pass including the new compatibility assertion
- [x] `go test -run TestParseFreshBranchName ./internal/polecat/` → 3 round-trip cases + 11 reject cases all pass
- [ ] Operator follow-up — after this lands & gastown rebuilds, dispatch one polecat (e.g. resling gt-4kp9.5.5.2) and confirm `@claude` review runs end-to-end on the new `-`-form branch