### PR TITLE
fix(formula): fall back to GT_TOWN_ROOT when GT_ROOT unset in formula search

### DIFF
--- a/internal/cmd/synthesis.go
+++ b/internal/cmd/synthesis.go
@@ -652,9 +652,13 @@ func findFormula(name string) (string, error) {
 		searchPaths = append(searchPaths, filepath.Join(home, ".beads", "formulas"))
 	}
 
-	// Add GT_ROOT formulas if set
+	// Add town-root formulas if set. Prefer GT_ROOT, but fall back to
+	// GT_TOWN_ROOT: daemon-launched patrol sessions only set GT_TOWN_ROOT, so
+	// reading GT_ROOT alone leaves formula resolution empty there (hq-2ui).
 	if gtRoot := os.Getenv("GT_ROOT"); gtRoot != "" {
 		searchPaths = append(searchPaths, filepath.Join(gtRoot, ".beads", "formulas"))
+	} else if townRoot := os.Getenv("GT_TOWN_ROOT"); townRoot != "" {
+		searchPaths = append(searchPaths, filepath.Join(townRoot, ".beads", "formulas"))
 	}
 
 	// Try each search path


### PR DESCRIPTION
## Problem

`findFormula()` builds the orchestrator formula search path from `$GT_ROOT` only:

```go
if gtRoot := os.Getenv("GT_ROOT"); gtRoot != "" {
    searchPaths = append(searchPaths, filepath.Join(gtRoot, ".beads", "formulas"))
}
```

Daemon-launched patrol sessions set **`GT_TOWN_ROOT`** but not `GT_ROOT` — the daemon puts only `GT_TOWN_ROOT` in the tmux global environment (see `internal/daemon/daemon.go`: "Only GT_TOWN_ROOT should be global"). In those sessions `gt formula list` returns *"No formulas found"* and patrol formulas silently fail to materialize, so dogs pour 0 steps.

Repro (from an affected town):
```
env | grep ^GT_                      # GT_TOWN_ROOT set, GT_ROOT empty
gt formula list                      # No formulas found
GT_ROOT=$GT_TOWN_ROOT gt formula list  # formulas found
```

## Fix

Mirror the fallback the workspace finder already uses (`internal/workspace/find.go` checks `GT_ROOT` then `GT_TOWN_ROOT`): prefer `GT_ROOT`, fall back to `GT_TOWN_ROOT`, so formula search resolves regardless of which town-root var the spawning context set.

This is the defensive half of the issue. The spawn-side regression (daemon sessions lacking `GT_ROOT`) is already fixed on current `main` — all daemon spawn paths route through `config.AgentEnv` with `TownRoot`, which sets `GT_ROOT`. This change hardens formula resolution so a missing `GT_ROOT` can never silently empty the search path again.

Diagnosed end-to-end by a patrol mayor running an older build (env confirmed: interactive sessions had `GT_ROOT`, daemon patrol sessions did not).

🤖 Generated with [Claude Code](https://claude.com/claude-code)