### PR TITLE
fix: split core bd env and dependency routing

### DIFF
--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -9,8 +9,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gofrs/flock"
+	beadsdk "github.com/steveyegge/beads"
 
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/telemetry"
@@ -218,13 +220,15 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 	target := b.agentBeadTarget()
 	targetDir := target.getResolvedBeadsDir()
 
-	// Ensure target database has custom types configured.
-	// This is cached (sentinel file + in-memory) so repeated calls are fast.
-	// On fresh rigs, this may fail if the database can't be initialized.
-	// Don't bail out — try the bd create calls anyway (GH#1769).
-	_ = EnsureCustomTypes(targetDir)
-
 	description := FormatAgentDescription(title, fields)
+	if issue, err := target.createAgentBeadViaStore(context.Background(), id, title, description); err == nil {
+		return issue, nil
+	}
+
+	// Ensure target database has custom types configured before falling back to
+	// the bd CLI. The store path above avoids stale external bd schema during
+	// fresh install; this remains for older stores or non-server configurations.
+	_ = EnsureCustomTypes(targetDir)
 
 	buildArgs := func() []string {
 		a := []string{"create", "--json",
@@ -262,6 +266,33 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 	// Note: hook_bead slot no longer set - bd slot removed in v0.62 (hq-l6mm5)
 
 	return &issue, nil
+}
+
+func (b *Beads) createAgentBeadViaStore(ctx context.Context, id, title, description string) (*Issue, error) {
+	store, cleanup, err := b.OpenStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	now := time.Now().UTC()
+	actor := b.getActor()
+	issue := &beadsdk.Issue{
+		ID:          id,
+		Title:       title,
+		Description: description,
+		Status:      beadsdk.StatusOpen,
+		Priority:    2,
+		IssueType:   beadsdk.TypeTask,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		CreatedBy:   actor,
+		Labels:      []string{"gt:agent"},
+	}
+	if err := store.CreateIssue(ctx, issue, actor); err != nil {
+		return nil, err
+	}
+	return sdkIssueToIssue(issue), nil
 }
 
 // CreateOrReopenAgentBead creates an agent bead or reopens an existing one.

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -366,12 +366,24 @@ func TestBuildMutationBDEnvForcesWritableCommit(t *testing.T) {
 
 func TestArgsAreReadOnlyClassifiesKnownReadCommands(t *testing.T) {
 	cases := [][]string{
+		{"--version"},
+		{"--help"},
 		{"show", "gt-123", "--json"},
 		{"--allow-stale", "show", "gt-123", "--json"},
+		{"search", "term", "--json"},
 		{"query", "merge-request", "--json"},
 		{"dep", "list", "hq-cv-123", "--json"},
+		{"formula", "list"},
+		{"formula", "show", "mol-polecat-work"},
+		{"kv", "get", "key"},
+		{"kv", "list"},
+		{"message", "thread", "hq-msg", "--json"},
+		{"mol", "current", "--json"},
 		{"mol", "wisp", "list", "--json"},
 		{"sql", "SELECT 1"},
+		{"sql", "SHOW TABLES"},
+		{"sql", "EXPLAIN SELECT 1"},
+		{"sql", "DESCRIBE dependencies"},
 		{"sql", "--csv", "SELECT 1"},
 		{"config", "get", "issue_prefix"},
 	}
@@ -387,10 +399,25 @@ func TestArgsAreReadOnlyClassifiesKnownReadCommands(t *testing.T) {
 
 func TestArgsAreReadOnlyFailsClosedForMutations(t *testing.T) {
 	cases := [][]string{
+		{"--db", "hq", "show", "gt-123"},
+		{"--directory", "/tmp", "list"},
+		{"--repo", "gastown", "show", "gt-123"},
+		{"--unknown", "show", "gt-123"},
 		{"update", "gt-123", "--status=open"},
 		{"close", "gt-123"},
+		{"label", "add", "gt-123", "read"},
+		{"message", "send", "mayor", "--body", "hi"},
+		{"formula", "cook", "mol-polecat-work"},
+		{"kv", "set", "key", "value"},
 		{"mol", "wisp", "formula"},
+		{"mol", "wisp", "create", "mol-test"},
 		{"sql", "UPDATE issues SET status='open'"},
+		{"sql", "DELETE FROM issues"},
+		{"sql", "INSERT INTO issues (id) VALUES ('gt-1')"},
+		{"sql", "WITH x AS (SELECT 1) SELECT * FROM x"},
+		{"sql", "WITH x AS (SELECT 1) UPDATE issues SET status='open'"},
+		{"sql", "WITH x AS (SELECT 1) DELETE FROM issues"},
+		{"sql", "WITH x AS (SELECT 1) INSERT INTO issues (id) VALUES ('gt-1')"},
 		{"config", "set", "issue_prefix", "gt"},
 	}
 	for _, args := range cases {

--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -178,6 +178,33 @@ func EnsureCustomTypes(beadsDir string) error {
 	return nil
 }
 
+// EnsureCustomTypesConfigYAML records Gas Town custom types directly in
+// config.yaml. Fresh install uses this before invoking any bd config command so
+// older cached bd binaries do not initialize legacy views against the new schema.
+func EnsureCustomTypesConfigYAML(beadsDir string) error {
+	if beadsDir == "" {
+		return fmt.Errorf("empty beads directory")
+	}
+	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
+		return fmt.Errorf("beads directory does not exist: %s", beadsDir)
+	}
+
+	typesList := strings.Join(constants.BeadsCustomTypesList(), ",")
+
+	ensuredMu.Lock()
+	defer ensuredMu.Unlock()
+
+	if ensuredDirs[beadsDir] {
+		return nil
+	}
+	if err := EnsureConfigYAMLValue(beadsDir, "types.custom", typesList); err != nil {
+		return err
+	}
+	_ = os.WriteFile(filepath.Join(beadsDir, typesSentinel), []byte(typesList+"\n"), 0644)
+	ensuredDirs[beadsDir] = true
+	return nil
+}
+
 // EnsureCustomStatuses ensures the target beads directory has custom statuses configured.
 // Uses the same two-level caching strategy as EnsureCustomTypes:
 //   - In-memory cache for multiple operations in the same CLI invocation

--- a/internal/beads/config_sql.go
+++ b/internal/beads/config_sql.go
@@ -1,0 +1,57 @@
+package beads
+
+import (
+	"database/sql"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strconv"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// EnsureDoltConfigValue writes a config key directly to the configured Dolt
+// database. Fresh setup uses this to avoid older bd config/schema bootstrap paths.
+func EnsureDoltConfigValue(beadsDir, key, value string) error {
+	if beadsDir == "" {
+		return fmt.Errorf("empty beads directory")
+	}
+	database := DatabaseNameFromMetadata(beadsDir)
+	if database == "" {
+		return fmt.Errorf("missing dolt_database in %s", beadsDir)
+	}
+	meta := readDoltMetadata(beadsDir)
+	host := meta.Host
+	if host == "" {
+		host = os.Getenv("GT_DOLT_HOST")
+	}
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	port := meta.Port
+	if port == "" {
+		port = os.Getenv("BEADS_DOLT_SERVER_PORT")
+	}
+	if port == "" {
+		port = os.Getenv("BEADS_DOLT_PORT")
+	}
+	if port == "" {
+		port = os.Getenv("GT_DOLT_PORT")
+	}
+	if port == "" {
+		port = "3307"
+	}
+	if _, err := strconv.Atoi(port); err != nil {
+		return fmt.Errorf("invalid Dolt port %q: %w", port, err)
+	}
+
+	dsn := fmt.Sprintf("root@tcp(%s)/%s?parseTime=true", net.JoinHostPort(host, port), url.PathEscape(database))
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	_, err = db.Exec("REPLACE INTO config (`key`, `value`) VALUES (?, ?)", key, value)
+	return err
+}

--- a/internal/beads/config_yaml.go
+++ b/internal/beads/config_yaml.go
@@ -2,6 +2,7 @@ package beads
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,50 @@ import (
 // beads namespace. Existing non-prefix settings are preserved.
 func EnsureConfigYAML(beadsDir, prefix string) error {
 	return ensureConfigYAML(beadsDir, prefix, false)
+}
+
+// EnsureConfigYAMLValue ensures config.yaml contains key: value while preserving
+// existing unrelated settings. It is used for install-time settings that must be
+// present before older bd binaries can safely open the Dolt schema.
+func EnsureConfigYAMLValue(beadsDir, key, value string) error {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return fmt.Errorf("empty config key")
+	}
+	wantLine := key + ": " + value
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	data, err := os.ReadFile(configPath)
+	if os.IsNotExist(err) {
+		return os.WriteFile(configPath, []byte(wantLine+"\n"), 0644)
+	}
+	if err != nil {
+		return err
+	}
+
+	content := strings.ReplaceAll(string(data), "\r\n", "\n")
+	lines := strings.Split(content, "\n")
+	found := false
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), key+":") {
+			lines[i] = wantLine
+			found = true
+		}
+	}
+	if !found {
+		if len(lines) > 0 && lines[len(lines)-1] == "" {
+			lines = lines[:len(lines)-1]
+		}
+		lines = append(lines, wantLine)
+	}
+
+	newContent := strings.Join(lines, "\n")
+	if !strings.HasSuffix(newContent, "\n") {
+		newContent += "\n"
+	}
+	if newContent == content {
+		return nil
+	}
+	return os.WriteFile(configPath, []byte(newContent), 0644)
 }
 
 // EnsureConfigYAMLIfMissing creates config.yaml with the required defaults when

--- a/internal/beads/config_yaml_test.go
+++ b/internal/beads/config_yaml_test.go
@@ -135,6 +135,39 @@ func TestEnsureConfigYAML_DisablesAutoExport(t *testing.T) {
 	}
 }
 
+func TestEnsureConfigYAMLValue(t *testing.T) {
+	beadsDir := t.TempDir()
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("prefix: hq\ntypes.custom: old\n"), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+
+	if err := EnsureConfigYAMLValue(beadsDir, "types.custom", "agent,role"); err != nil {
+		t.Fatalf("EnsureConfigYAMLValue replace: %v", err)
+	}
+	if err := EnsureConfigYAMLValue(beadsDir, "allowed_prefixes", "hq,hq-cv"); err != nil {
+		t.Fatalf("EnsureConfigYAMLValue append: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config.yaml: %v", err)
+	}
+	got := string(data)
+	for _, want := range []string{
+		"prefix: hq\n",
+		"types.custom: agent,role\n",
+		"allowed_prefixes: hq,hq-cv\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("config.yaml missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "types.custom: old") {
+		t.Fatalf("config.yaml kept stale value:\n%s", got)
+	}
+}
+
 func TestConfigYAMLDisablesAutoExport(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/beads/database.go
+++ b/internal/beads/database.go
@@ -134,20 +134,36 @@ func BuildMutationNeutralBDEnv(base []string) []string {
 // ArgsAreReadOnly classifies bd CLI arguments for env policy. Unknown commands
 // are treated as mutations so they cannot accidentally inherit read-only mode.
 func ArgsAreReadOnly(args []string) bool {
-	args = stripBDGlobalFlags(args)
+	if len(args) == 1 && isBDReadOnlyGlobalFlag(args[0]) {
+		return true
+	}
+	if HasBDTargetSelectorFlag(append([]string{"bd"}, args...)) {
+		return false
+	}
+	var ok bool
+	args, ok = stripBDGlobalFlags(args)
+	if !ok {
+		return false
+	}
 	if len(args) == 0 {
 		return false
 	}
 	switch args[0] {
-	case "show", "list", "ready", "blocked", "stats", "stale", "orphans", "activity", "query", "version":
+	case "show", "list", "ready", "blocked", "stats", "stale", "orphans", "activity", "query", "search", "version", "help":
 		return true
 	case "dep":
 		return len(args) > 1 && args[1] == "list"
+	case "formula":
+		return len(args) > 1 && (args[1] == "list" || args[1] == "show")
+	case "kv":
+		return len(args) > 1 && (args[1] == "get" || args[1] == "list")
+	case "message":
+		return len(args) > 1 && args[1] == "thread"
 	case "mol":
-		return len(args) > 2 && args[1] == "wisp" && args[2] == "list"
+		return len(args) > 1 && (args[1] == "current" || (len(args) > 2 && args[1] == "wisp" && args[2] == "list"))
 	case "sql":
 		query := strings.ToLower(strings.Join(stripBDCommandFlags(args[1:]), " "))
-		return strings.HasPrefix(strings.TrimSpace(query), "select")
+		return hasReadOnlySQLPrefix(strings.TrimSpace(query))
 	case "config":
 		return len(args) > 1 && args[1] == "get"
 	default:
@@ -155,11 +171,28 @@ func ArgsAreReadOnly(args []string) bool {
 	}
 }
 
-func stripBDGlobalFlags(args []string) []string {
+func isBDReadOnlyGlobalFlag(arg string) bool {
+	return arg == "--version" || arg == "-V" || arg == "--help" || arg == "-h"
+}
+
+func stripBDGlobalFlags(args []string) ([]string, bool) {
 	for len(args) > 0 && strings.HasPrefix(args[0], "--") {
+		if args[0] == "--" {
+			return nil, false
+		}
+		name := args[0]
+		if cut, _, hasValue := strings.Cut(name, "="); hasValue {
+			name = cut
+		}
+		if !bdBoolGlobalFlags[name] {
+			return nil, false
+		}
 		args = args[1:]
 	}
-	return args
+	if len(args) > 0 && strings.HasPrefix(args[0], "-") {
+		return nil, false
+	}
+	return args, true
 }
 
 func stripBDCommandFlags(args []string) []string {
@@ -167,6 +200,15 @@ func stripBDCommandFlags(args []string) []string {
 		args = args[1:]
 	}
 	return args
+}
+
+func hasReadOnlySQLPrefix(query string) bool {
+	for _, prefix := range []string{"select", "show", "explain", "describe"} {
+		if strings.HasPrefix(query, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // SuppressBDSideEffects disables Beads JSONL export/backup/push side effects for

--- a/internal/cmd/bd_helpers.go
+++ b/internal/cmd/bd_helpers.go
@@ -118,29 +118,9 @@ func filterEnvKey(env []string, key string) []string {
 	return beads.StripEnvKey(env, key)
 }
 
-func filterBdTargetEnv(env []string) []string {
-	return beads.StripBDTargetEnv(env)
-}
-
-func pinBeadsDirEnv(env []string, beadsDir string) []string {
-	if beadsDir == "" {
-		return beads.StripBDTargetEnv(env)
-	}
-	return beads.BuildPinnedBDEnv(env, beadsDir)
-}
-
 // buildEnv constructs the final environment slice based on configured options.
 func (b *bdCmd) buildEnv() []string {
-	env := b.env
-
-	// Add BD_DOLT_AUTO_COMMIT=on for sequential dependent calls.
-	// Filter existing entries first — glibc getenv() returns the first match,
-	// so an existing "off" entry would shadow the appended "on".
-	if b.autoCommit {
-		env = filterEnvKey(env, "BD_DOLT_AUTO_COMMIT")
-		env = filterEnvKey(env, "BD_READONLY")
-		env = append(env, "BD_DOLT_AUTO_COMMIT=on")
-	}
+	env := append([]string{}, b.env...)
 
 	// Add GT_ROOT if specified.
 	// Filter existing entries first for the same reason as above.
@@ -149,25 +129,31 @@ func (b *bdCmd) buildEnv() []string {
 		env = append(env, "GT_ROOT="+b.gtRoot)
 	}
 
-	// Add BEADS_DIR if specified.
-	// This prevents inherited BEADS_DIR from causing bd to target the wrong
-	// database (e.g., HQ instead of rig). See gt-ctir.
-	//
-	// Also clear inherited Dolt target variables. Dashboard and agent shells can
-	// carry a town-level or remote BEADS_DOLT_* target; keeping it while changing
-	// BEADS_DIR makes `bd show <displayed-id>` query a different database than
-	// `gt ready` used to render the row.
-	if b.routing {
-		env = beads.BuildRoutingBDEnv(env, beads.ResolveBeadsDir(b.dir))
-	} else if b.beadsDir != "" {
-		env = pinBeadsDirEnv(env, b.beadsDir)
-	} else if b.dir != "" {
-		env = pinBeadsDirEnv(env, beads.ResolveBeadsDir(b.dir))
-	} else {
-		env = beads.SuppressBDSideEffects(beads.StripBDTargetEnv(env))
+	mode := beads.MutationRouting
+	if beads.ArgsAreReadOnly(b.args) && !b.autoCommit {
+		mode = beads.ReadOnlyRouting
 	}
 
-	return env
+	beadsDir := ""
+	if b.beadsDir != "" {
+		beadsDir = b.beadsDir
+		if mode == beads.ReadOnlyRouting {
+			mode = beads.ReadOnlyPinned
+		} else {
+			mode = beads.MutationPinned
+		}
+	} else if b.dir != "" {
+		beadsDir = beads.ResolveBeadsDir(b.dir)
+		if !b.routing {
+			if mode == beads.ReadOnlyRouting {
+				mode = beads.ReadOnlyPinned
+			} else {
+				mode = beads.MutationPinned
+			}
+		}
+	}
+
+	return beads.EnvForSubprocessMode(env, beadsDir, mode)
 }
 
 // Build returns the configured exec.Cmd.

--- a/internal/cmd/bd_helpers_test.go
+++ b/internal/cmd/bd_helpers_test.go
@@ -747,6 +747,99 @@ func TestBdCmd_WithRoutingDoesNotPinBeadsDir(t *testing.T) {
 	}
 }
 
+func TestBdCmd_UsesCentralReadMutationModes(t *testing.T) {
+	rigDir := t.TempDir()
+	beadsDir := filepath.Join(rigDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := []byte(`{"dolt_database":"rigdb","dolt_server_host":"127.0.0.1","dolt_server_port":3307}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+	baseEnv := []string{
+		"PATH=/usr/bin",
+		"BEADS_DIR=/wrong",
+		"BEADS_DOLT_SERVER_DATABASE=hq",
+		"BD_DOLT_AUTO_COMMIT=off",
+		"BD_READONLY=false",
+	}
+
+	tests := []struct {
+		name           string
+		setup          func() *bdCmd
+		wantPinned     bool
+		wantReadOnly   bool
+		wantAutoCommit string
+	}{
+		{
+			name: "read pinned via Dir",
+			setup: func() *bdCmd {
+				return (&bdCmd{args: []string{"show", "gt-abc"}, env: append([]string{}, baseEnv...), stderr: os.Stderr}).Dir(rigDir)
+			},
+			wantPinned:     true,
+			wantReadOnly:   true,
+			wantAutoCommit: "off",
+		},
+		{
+			name: "mutation pinned via WithBeadsDir",
+			setup: func() *bdCmd {
+				return (&bdCmd{args: []string{"update", "gt-abc", "--status=open"}, env: append([]string{}, baseEnv...), stderr: os.Stderr}).WithBeadsDir(beadsDir)
+			},
+			wantPinned:     true,
+			wantAutoCommit: "on",
+		},
+		{
+			name: "read routing",
+			setup: func() *bdCmd {
+				return (&bdCmd{args: []string{"message", "thread", "hq-msg"}, env: append([]string{}, baseEnv...), stderr: os.Stderr}).Dir(rigDir).WithRouting()
+			},
+			wantReadOnly:   true,
+			wantAutoCommit: "off",
+		},
+		{
+			name: "auto commit forces mutation for read args",
+			setup: func() *bdCmd {
+				return (&bdCmd{args: []string{"show", "gt-abc"}, env: append([]string{}, baseEnv...), stderr: os.Stderr}).Dir(rigDir).WithAutoCommit()
+			},
+			wantPinned:     true,
+			wantAutoCommit: "on",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := tt.setup().Build()
+			envMap := parseEnv(cmd.Env)
+			if tt.wantPinned {
+				if envMap["BEADS_DIR"] != beadsDir {
+					t.Fatalf("BEADS_DIR = %q, want %q in %v", envMap["BEADS_DIR"], beadsDir, cmd.Env)
+				}
+				if envMap["BEADS_DOLT_SERVER_DATABASE"] != "rigdb" {
+					t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want rigdb in %v", envMap["BEADS_DOLT_SERVER_DATABASE"], cmd.Env)
+				}
+			} else {
+				if value, ok := envMap["BEADS_DIR"]; ok {
+					t.Fatalf("BEADS_DIR should be absent for routing command, got %q in %v", value, cmd.Env)
+				}
+				if value, ok := envMap["BEADS_DOLT_SERVER_DATABASE"]; ok {
+					t.Fatalf("BEADS_DOLT_SERVER_DATABASE should be absent for routing command, got %q in %v", value, cmd.Env)
+				}
+			}
+			if envMap["BD_DOLT_AUTO_COMMIT"] != tt.wantAutoCommit {
+				t.Fatalf("BD_DOLT_AUTO_COMMIT = %q, want %q in %v", envMap["BD_DOLT_AUTO_COMMIT"], tt.wantAutoCommit, cmd.Env)
+			}
+			if tt.wantReadOnly {
+				if envMap["BD_READONLY"] != "true" {
+					t.Fatalf("BD_READONLY = %q, want true in %v", envMap["BD_READONLY"], cmd.Env)
+				}
+			} else if value, ok := envMap["BD_READONLY"]; ok {
+				t.Fatalf("BD_READONLY should be absent for mutation command, got %q in %v", value, cmd.Env)
+			}
+		})
+	}
+}
+
 func TestBdCmd_StripBeadsDir_Chaining(t *testing.T) {
 	bdc := BdCmd("test")
 	if bdc.StripBeadsDir() != bdc {

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -2,10 +2,14 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -449,18 +453,25 @@ func getTownBeadsDir() (string, error) {
 // "exit status 1". BEADS_DIR is stripped from the subprocess environment to
 // prevent stale overrides from interfering with bd's workspace detection.
 func runBdJSON(dir string, args ...string) ([]byte, error) {
-	return runBdJSONWithOptions(dir, false, args...)
+	return runBdJSONWithOptions(dir, false, false, args...)
 }
 
 func runBdJSONAllowStale(dir string, args ...string) ([]byte, error) {
-	return runBdJSONWithOptions(dir, true, args...)
+	return runBdJSONWithOptions(dir, true, false, args...)
 }
 
-func runBdJSONWithOptions(dir string, allowStale bool, args ...string) ([]byte, error) {
+func runBdJSONWithAutoCommit(dir string, args ...string) ([]byte, error) {
+	return runBdJSONWithOptions(dir, false, true, args...)
+}
+
+func runBdJSONWithOptions(dir string, allowStale, autoCommit bool, args ...string) ([]byte, error) {
 	var stdout, stderr bytes.Buffer
 	bdc := BdCmd(args...).Dir(dir).StripBeadsDir().Stderr(&stderr)
 	if allowStale {
 		bdc.AllowStale()
+	}
+	if autoCommit {
+		bdc.WithAutoCommit()
 	}
 	cmd := bdc.Build()
 	cmd.Dir = dir
@@ -492,49 +503,137 @@ func bdDepListRawIDs(dir, issueID, direction, depType string) ([]string, error) 
 		return nil, fmt.Errorf("invalid bead ID: %q", issueID)
 	}
 
-	// The dependency target was historically a single depends_on_id column.
-	// The schema migration split it into typed columns
-	// (depends_on_issue_id / depends_on_wisp_id / depends_on_external), where
-	// cross-database refs live in depends_on_external as "external:<prefix>:<id>".
-	// "down": targets issueID depends on → COALESCE the three target columns.
-	// "up":   issues that depend on issueID → match issueID against all three.
-	var selectExpr, whereClause, parseKey string
+	var parseKey string
 	if direction == "up" {
-		selectExpr = "issue_id"
 		parseKey = "issue_id"
-		whereClause = fmt.Sprintf(
-			"(depends_on_issue_id = '%s' OR depends_on_wisp_id = '%s' OR %s)",
-			issueID, issueID, sqlExternalDepTargetClause(issueID))
 	} else {
-		selectExpr = "COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS depends_on_id"
 		parseKey = "depends_on_id"
-		whereClause = fmt.Sprintf("issue_id = '%s'", issueID)
+	}
+	if depType != "" && !isValidBeadID(depType) {
+		return nil, fmt.Errorf("invalid dep type: %q", depType)
 	}
 
-	query := fmt.Sprintf("SELECT %s FROM dependencies WHERE %s", selectExpr, whereClause)
-	if depType != "" {
-		if !isValidBeadID(depType) {
-			return nil, fmt.Errorf("invalid dep type: %q", depType)
+	if ids, err := bdDepListRawIDsViaDolt(dir, issueID, direction, depType); err == nil {
+		return ids, nil
+	}
+
+	var lastErr error
+	for _, legacy := range []bool{false, true} {
+		query := rawDepSQLLiteral(issueID, direction, depType, legacy)
+		out, err := runBdJSONWithAutoCommit(dir, "sql", query, "--json")
+		if err != nil {
+			lastErr = err
+			continue
 		}
-		query += fmt.Sprintf(" AND type = '%s'", depType)
+		ids, err := parseRawDepRows(out, parseKey)
+		if err != nil {
+			return nil, fmt.Errorf("parsing dep sql for %s: %w", issueID, err)
+		}
+		return ids, nil
 	}
+	return nil, fmt.Errorf("bd sql for deps of %s: %w", issueID, lastErr)
+}
 
-	out, err := runBdJSON(dir, "sql", query, "--json")
+func bdDepListRawIDsViaDolt(dir, issueID, direction, depType string) ([]string, error) {
+	beadsDir := beads.ResolveBeadsDir(dir)
+	cfg, ok := readBeadsRuntimeConfig(beadsDir)
+	if !ok || cfg.Database == "" || cfg.Port == 0 {
+		return nil, fmt.Errorf("missing server metadata for %s", beadsDir)
+	}
+	host := cfg.Host
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	dsn := fmt.Sprintf("root@tcp(%s)/%s?parseTime=true", net.JoinHostPort(host, strconv.Itoa(cfg.Port)), url.PathEscape(cfg.Database))
+	db, err := sql.Open("mysql", dsn)
 	if err != nil {
-		return nil, fmt.Errorf("bd sql for deps of %s: %w", issueID, err)
+		return nil, err
 	}
+	defer db.Close()
 
-	// Parse JSON array of single-column rows
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	typedQuery, typedArgs := rawDepSQLArgs(issueID, direction, depType, false)
+	ids, err := queryRawDepIDs(ctx, db, typedQuery, typedArgs)
+	if err == nil {
+		return ids, nil
+	}
+	legacyQuery, legacyArgs := rawDepSQLArgs(issueID, direction, depType, true)
+	return queryRawDepIDs(ctx, db, legacyQuery, legacyArgs)
+}
+
+func rawDepSQLArgs(issueID, direction, depType string, legacy bool) (string, []any) {
+	var query string
+	var args []any
+	if direction == "up" {
+		if legacy {
+			query = "SELECT issue_id FROM dependencies WHERE depends_on_id = ?"
+			args = append(args, issueID)
+		} else {
+			query = "SELECT issue_id FROM dependencies WHERE (depends_on_issue_id = ? OR depends_on_wisp_id = ? OR depends_on_external LIKE ? ESCAPE '!')"
+			args = append(args, issueID, issueID, "%:"+strings.ReplaceAll(issueID, "_", "!_"))
+		}
+	} else if legacy {
+		query = "SELECT depends_on_id FROM dependencies WHERE issue_id = ?"
+		args = append(args, issueID)
+	} else {
+		query = "SELECT COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS depends_on_id FROM dependencies WHERE issue_id = ?"
+		args = append(args, issueID)
+	}
+	if depType != "" {
+		query += " AND type = ?"
+		args = append(args, depType)
+	}
+	return query, args
+}
+
+func rawDepSQLLiteral(issueID, direction, depType string, legacy bool) string {
+	query, args := rawDepSQLArgs(issueID, direction, depType, legacy)
+	for _, arg := range args {
+		query = strings.Replace(query, "?", "'"+arg.(string)+"'", 1)
+	}
+	return query
+}
+
+func queryRawDepIDs(ctx context.Context, db *sql.DB, query string, args []any) ([]string, error) {
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	seen := make(map[string]bool)
+	var ids []string
+	for rows.Next() {
+		var rawID sql.NullString
+		if err := rows.Scan(&rawID); err != nil {
+			return nil, err
+		}
+		if !rawID.Valid {
+			continue
+		}
+		id := beads.ExtractIssueID(rawID.String)
+		if id != "" && !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+func parseRawDepRows(out []byte, parseKey string) ([]string, error) {
 	var rows []map[string]string
 	if err := json.Unmarshal(out, &rows); err != nil {
-		return nil, fmt.Errorf("parsing dep sql for %s: %w", issueID, err)
+		return nil, err
 	}
-
 	seen := make(map[string]bool, len(rows))
 	var ids []string
 	for _, row := range rows {
-		rawID := row[parseKey]
-		id := beads.ExtractIssueID(rawID)
+		id := beads.ExtractIssueID(row[parseKey])
 		if id != "" && !seen[id] {
 			seen[id] = true
 			ids = append(ids, id)

--- a/internal/cmd/convoy_stage.go
+++ b/internal/cmd/convoy_stage.go
@@ -218,7 +218,7 @@ The staged convoy can later be launched with 'gt convoy launch'.`,
 func runConvoyStage(cmd *cobra.Command, args []string) error {
 	// Step 1: Validate args.
 	if err := validateStageArgs(args); err != nil {
-		return err
+		return convoyStageError(err)
 	}
 
 	// Step 2: Resolve bead types via bd show for each arg.
@@ -227,7 +227,7 @@ func runConvoyStage(cmd *cobra.Command, args []string) error {
 	for _, arg := range args {
 		result, err := bdShow(arg)
 		if err != nil {
-			return fmt.Errorf("cannot resolve bead %s: %w", arg, err)
+			return convoyStageError(fmt.Errorf("cannot resolve bead %s: %w", arg, err))
 		}
 		if isConvoyIssue(result.IssueType, result.Labels) {
 			beadTypes[arg] = "convoy"
@@ -240,7 +240,7 @@ func runConvoyStage(cmd *cobra.Command, args []string) error {
 	// Step 3: Determine input kind.
 	input, err := resolveInputKind(beadTypes)
 	if err != nil {
-		return err
+		return convoyStageError(err)
 	}
 
 	// Step 3b: Detect re-stage scenario.
@@ -258,7 +258,7 @@ func runConvoyStage(cmd *cobra.Command, args []string) error {
 	// Step 4: Collect beads and deps.
 	beads, deps, err := collectBeads(input)
 	if err != nil {
-		return err
+		return convoyStageError(err)
 	}
 
 	// Step 5: Build the DAG.
@@ -271,11 +271,11 @@ func runConvoyStage(cmd *cobra.Command, args []string) error {
 		slingableIDs := dagSlingableIDs(dag)
 		overlaps, err := findOverlappingConvoys(slingableIDs)
 		if err != nil {
-			return fmt.Errorf("checking for overlapping convoys: %w", err)
+			return convoyStageError(fmt.Errorf("checking for overlapping convoys: %w", err))
 		}
 		autoRestage, autoConvoyID, err := handleOverlappingConvoys(overlaps)
 		if err != nil {
-			return err
+			return convoyStageError(err)
 		}
 		if autoRestage {
 			isRestage = true
@@ -397,6 +397,28 @@ func runConvoyStage(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func convoyStageError(err error) error {
+	if err == nil || !convoyStageJSON {
+		return err
+	}
+	out, renderErr := renderJSON(StageResult{
+		Status: "error",
+		Errors: []FindingJSON{{
+			Category: "error",
+			BeadIDs:  []string{},
+			Message:  err.Error(),
+		}},
+		Warnings: []FindingJSON{},
+		Waves:    []WaveJSON{},
+		Tree:     []TreeNodeJSON{},
+	})
+	if renderErr != nil {
+		return renderErr
+	}
+	fmt.Print(out)
+	return err
+}
+
 // runConvoyStageJSON handles the --json output path for convoy staging.
 // It builds a StageResult, marshals it, and prints to stdout.
 // On errors, it still outputs JSON but returns an error for non-zero exit code.
@@ -423,7 +445,7 @@ func runConvoyStageJSON(dag *ConvoyDAG, input *StageInput, errs, warns []Staging
 	// No errors: compute waves and create/update convoy.
 	waves, gated, err := computeWaves(dag)
 	if err != nil {
-		return err
+		return convoyStageError(err)
 	}
 
 	// Append validation bead as final wave (epic input only).
@@ -432,7 +454,7 @@ func runConvoyStageJSON(dag *ConvoyDAG, input *StageInput, errs, warns []Staging
 		epicID := input.IDs[0]
 		waves, validationBeadID, err = appendValidationWave(dag, waves, epicID)
 		if err != nil {
-			return fmt.Errorf("creating validation bead: %w", err)
+			return convoyStageError(fmt.Errorf("creating validation bead: %w", err))
 		}
 	}
 
@@ -461,14 +483,14 @@ func runConvoyStageJSON(dag *ConvoyDAG, input *StageInput, errs, warns []Staging
 
 	if isRestage {
 		if err := updateStagedConvoy(restageConvoyID, dag, waves, status, title); err != nil {
-			return err
+			return convoyStageError(err)
 		}
 		result.ConvoyID = restageConvoyID
 		result.Restaged = true
 	} else {
 		convoyID, err := createStagedConvoy(dag, waves, status, title)
 		if err != nil {
-			return err
+			return convoyStageError(err)
 		}
 		result.ConvoyID = convoyID
 	}

--- a/internal/cmd/convoy_stage_test.go
+++ b/internal/cmd/convoy_stage_test.go
@@ -1872,8 +1872,9 @@ func TestCreateStagedConvoy_CleanReady(t *testing.T) {
 
 	// Verify bd dep add was called for each slingable bead.
 	for _, beadID := range []string{"gt-a", "gt-b", "gt-c"} {
-		if !strings.Contains(logContent, "dep add "+convoyID+" "+beadID) {
-			t.Errorf("bd.log should contain 'dep add %s %s', got:\n%s", convoyID, beadID, logContent)
+		targetID := "external:gt:" + beadID
+		if !strings.Contains(logContent, "dep add "+convoyID+" "+targetID) {
+			t.Errorf("bd.log should contain 'dep add %s %s', got:\n%s", convoyID, targetID, logContent)
 		}
 	}
 }
@@ -1920,8 +1921,9 @@ func TestCreateStagedConvoy_TracksOnlySlingable(t *testing.T) {
 
 	// Slingable beads (tasks and bugs) should be tracked.
 	for _, beadID := range []string{"gt-t1", "gt-b1", "gt-t2"} {
-		if !strings.Contains(logContent, "dep add "+convoyID+" "+beadID) {
-			t.Errorf("bd.log should contain 'dep add %s %s' for slingable bead, got:\n%s", convoyID, beadID, logContent)
+		targetID := "external:gt:" + beadID
+		if !strings.Contains(logContent, "dep add "+convoyID+" "+targetID) {
+			t.Errorf("bd.log should contain 'dep add %s %s' for slingable bead, got:\n%s", convoyID, targetID, logContent)
 		}
 	}
 

--- a/internal/cmd/dolt.go
+++ b/internal/cmd/dolt.go
@@ -712,15 +712,15 @@ type beadsRuntimeConfig struct {
 	Port     int
 }
 
-func currentBeadsRuntimeConfig(townRoot string) (beadsRuntimeConfig, bool) {
+func currentBeadsRuntimeConfig() (beadsRuntimeConfig, bool) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return beadsRuntimeConfig{}, false
 	}
-	return readBeadsRuntimeConfig(beads.ResolveBeadsDir(cwd), townRoot)
+	return readBeadsRuntimeConfig(beads.ResolveBeadsDir(cwd))
 }
 
-func readBeadsRuntimeConfig(beadsDir, townRoot string) (beadsRuntimeConfig, bool) {
+func readBeadsRuntimeConfig(beadsDir string) (beadsRuntimeConfig, bool) {
 	metadataPath := filepath.Join(beadsDir, "metadata.json")
 	data, err := os.ReadFile(metadataPath)
 	if err != nil {
@@ -748,7 +748,14 @@ func readBeadsRuntimeConfig(beadsDir, townRoot string) (beadsRuntimeConfig, bool
 	}
 	port := metadata.DoltServerPort
 	if port == 0 {
-		port = doltserver.DefaultConfig(townRoot).Port
+		if data, err := os.ReadFile(filepath.Join(beadsDir, "dolt-server.port")); err == nil {
+			if parsed, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil && parsed > 0 {
+				port = parsed
+			}
+		}
+	}
+	if port == 0 {
+		port = doltserver.DefaultPort
 	}
 	database := metadata.DoltDatabase
 	if database == "" {
@@ -764,7 +771,7 @@ func readBeadsRuntimeConfig(beadsDir, townRoot string) (beadsRuntimeConfig, bool
 }
 
 func printBeadsRuntimeConfig(townRoot string) {
-	cfg, ok := currentBeadsRuntimeConfig(townRoot)
+	cfg, ok := currentBeadsRuntimeConfig()
 	if !ok {
 		return
 	}

--- a/internal/cmd/dolt_status_test.go
+++ b/internal/cmd/dolt_status_test.go
@@ -26,7 +26,7 @@ func TestReadBeadsRuntimeConfigServerMetadata(t *testing.T) {
 		t.Fatalf("write metadata: %v", err)
 	}
 
-	cfg, ok := readBeadsRuntimeConfig(beadsDir, townRoot)
+	cfg, ok := readBeadsRuntimeConfig(beadsDir)
 	if !ok {
 		t.Fatal("readBeadsRuntimeConfig did not detect server metadata")
 	}
@@ -42,6 +42,8 @@ func TestReadBeadsRuntimeConfigServerMetadata(t *testing.T) {
 }
 
 func TestReadBeadsRuntimeConfigDefaultServerAddr(t *testing.T) {
+	t.Setenv("GT_DOLT_PORT", "32769")
+
 	townRoot := t.TempDir()
 	beadsDir := filepath.Join(townRoot, ".beads")
 	if err := os.MkdirAll(beadsDir, 0755); err != nil {
@@ -56,7 +58,7 @@ func TestReadBeadsRuntimeConfigDefaultServerAddr(t *testing.T) {
 		t.Fatalf("write metadata: %v", err)
 	}
 
-	cfg, ok := readBeadsRuntimeConfig(beadsDir, townRoot)
+	cfg, ok := readBeadsRuntimeConfig(beadsDir)
 	if !ok {
 		t.Fatal("readBeadsRuntimeConfig did not detect server metadata")
 	}
@@ -65,6 +67,35 @@ func TestReadBeadsRuntimeConfigDefaultServerAddr(t *testing.T) {
 	}
 	if cfg.Port != doltserver.DefaultPort {
 		t.Fatalf("Port = %d, want default %d", cfg.Port, doltserver.DefaultPort)
+	}
+}
+
+func TestReadBeadsRuntimeConfigPortFileFallback(t *testing.T) {
+	t.Setenv("GT_DOLT_PORT", "32769")
+
+	townRoot := t.TempDir()
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir beads dir: %v", err)
+	}
+	metadata := `{
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "database": "dolt"
+}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(metadata), 0600); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "dolt-server.port"), []byte("43113\n"), 0600); err != nil {
+		t.Fatalf("write port file: %v", err)
+	}
+
+	cfg, ok := readBeadsRuntimeConfig(beadsDir)
+	if !ok {
+		t.Fatal("readBeadsRuntimeConfig did not detect server metadata")
+	}
+	if cfg.Port != 43113 {
+		t.Fatalf("Port = %d, want port file 43113", cfg.Port)
 	}
 }
 
@@ -83,7 +114,7 @@ func TestReadBeadsRuntimeConfigIgnoresEmbeddedMetadata(t *testing.T) {
 		t.Fatalf("write metadata: %v", err)
 	}
 
-	if _, ok := readBeadsRuntimeConfig(beadsDir, townRoot); ok {
+	if _, ok := readBeadsRuntimeConfig(beadsDir); ok {
 		t.Fatal("embedded metadata should not be reported as shared-server config")
 	}
 }

--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -323,15 +322,7 @@ func runHook(_ *cobra.Command, args []string) error {
 			fmt.Printf("%s Replacing completed bead %s...\n", style.Dim.Render("ℹ"), existing.ID)
 			if !hookDryRun {
 				if hasAttachment {
-					// Close completed molecule bead (use bd close --force for pinned)
-					closeArgs := []string{"close", existing.ID, "--force",
-						"--reason=Auto-replaced by gt hook (molecule complete)"}
-					if sessionID := runtime.SessionIDFromEnv(); sessionID != "" {
-						closeArgs = append(closeArgs, "--session="+sessionID)
-					}
-					closeCmd := exec.Command("bd", closeArgs...)
-					closeCmd.Stderr = os.Stderr
-					if err := closeCmd.Run(); err != nil {
+					if err := closeCompletedHookedMolecule(workDir, existing.ID); err != nil {
 						return fmt.Errorf("closing completed bead %s: %w", existing.ID, err)
 					}
 				} else {
@@ -440,6 +431,14 @@ func runHook(_ *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func closeCompletedHookedMolecule(workDir, beadID string) error {
+	closeArgs := []string{"close", beadID, "--force", "--reason=Auto-replaced by gt hook (molecule complete)"}
+	if sessionID := runtime.SessionIDFromEnv(); sessionID != "" {
+		closeArgs = append(closeArgs, "--session="+sessionID)
+	}
+	return BdCmd(closeArgs...).Dir(workDir).WithAutoCommit().Run()
 }
 
 // checkPinnedBeadComplete checks if a pinned bead's attached molecule is 100% complete.

--- a/internal/cmd/hook_test.go
+++ b/internal/cmd/hook_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -153,4 +155,71 @@ func TestNormalizeHookShowTarget(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCloseCompletedHookedMoleculeUsesBdCmdEnv(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd.log")
+	writeHookBDStub(t, binDir)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_STUB_LOG", logPath)
+	t.Setenv("CLAUDE_SESSION_ID", "ses-hook-test")
+	t.Setenv("BEADS_DIR", "/wrong")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "hq")
+	t.Setenv("BD_READONLY", "true")
+	t.Setenv("BD_DOLT_AUTO_COMMIT", "off")
+
+	workDir := t.TempDir()
+	beadsDir := filepath.Join(workDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"dolt_database":"hookdb"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := closeCompletedHookedMolecule(workDir, "gt-old"); err != nil {
+		t.Fatalf("closeCompletedHookedMolecule: %v", err)
+	}
+	log := readHookStubLog(t, logPath)
+	for _, want := range []string{
+		"args:[close][gt-old][--force][--reason=Auto-replaced by gt hook (molecule complete)][--session=ses-hook-test]",
+		"BEADS_DIR=" + beadsDir,
+		"BEADS_DOLT_SERVER_DATABASE=hookdb",
+		"\nBD_READONLY=\n",
+		"BD_DOLT_AUTO_COMMIT=on",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("hook close log missing %q:\n%s", want, log)
+		}
+	}
+}
+
+func writeHookBDStub(t *testing.T, binDir string) {
+	t.Helper()
+	script := `#!/usr/bin/env sh
+{
+	printf 'args:'
+	for arg in "$@"; do
+		printf '[%s]' "$arg"
+	done
+	printf '\n'
+	printf 'BEADS_DIR=%s\n' "${BEADS_DIR-}"
+	printf 'BEADS_DOLT_SERVER_DATABASE=%s\n' "${BEADS_DOLT_SERVER_DATABASE-}"
+	printf 'BD_READONLY=%s\n' "${BD_READONLY-}"
+	printf 'BD_DOLT_AUTO_COMMIT=%s\n' "${BD_DOLT_AUTO_COMMIT-}"
+} >> "$BD_STUB_LOG"
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readHookStubLog(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -732,43 +732,22 @@ func initTownBeads(townPath string) error {
 		return fmt.Errorf("ensuring config.yaml: %w", err)
 	}
 
-	beadsEnv := withBeadsDirEnv(beadsDir)
-
-	// Set beads.role to maintainer (town-level beads are always maintainer-owned).
-	// Without this, bd doctor warns about missing role configuration.
-	roleSetCmd := exec.Command("bd", "config", "set", "beads.role", "maintainer")
-	roleSetCmd.Dir = townPath
-	roleSetCmd.Env = beadsEnv
-	if roleOutput, roleErr := roleSetCmd.CombinedOutput(); roleErr != nil {
-		fmt.Printf("   %s Could not set beads.role: %s\n", style.Dim.Render("⚠"), strings.TrimSpace(string(roleOutput)))
+	// Set beads.role to maintainer (town-level beads are always maintainer-owned)
+	// without invoking old bd config/schema initialization during fresh install.
+	if err := beads.EnsureConfigYAMLValue(beadsDir, "beads.role", "maintainer"); err != nil {
+		fmt.Printf("   %s Could not set beads.role: %v\n", style.Dim.Render("⚠"), err)
 	}
 
-	// Explicitly set issue_prefix config (bd init --prefix may not persist it in newer versions).
-	// bd >= 1.0.0 rejects this with "cannot be set via 'bd config set'" because init persists
-	// it directly; treat that as already-set rather than a failure.
-	prefixSetCmd := exec.Command("bd", "config", "set", "issue_prefix", "hq")
-	prefixSetCmd.Dir = townPath
-	prefixSetCmd.Env = beadsEnv
-	if prefixOutput, prefixErr := prefixSetCmd.CombinedOutput(); prefixErr != nil {
-		out := strings.TrimSpace(string(prefixOutput))
-		if !strings.Contains(out, "cannot be set via") {
-			return fmt.Errorf("bd config set issue_prefix failed: %s", out)
-		}
-	}
-
-	// Configure custom types for Gas Town (agent, role, rig, convoy, slot).
-	// These were extracted from beads core in v0.46.0 and now require explicit config.
-	if err := beads.EnsureCustomTypes(beadsDir); err != nil {
+	// Configure custom types for Gas Town before any bd config command can force
+	// an older bd binary through legacy schema initialization.
+	if err := beads.EnsureCustomTypesConfigYAML(beadsDir); err != nil {
 		return fmt.Errorf("ensuring custom types: %w", err)
 	}
 
 	// Configure allowed_prefixes for convoy beads (hq-cv-* IDs).
 	// This allows bd create --id=hq-cv-xxx to pass prefix validation.
-	prefixCmd := exec.Command("bd", "config", "set", "allowed_prefixes", "hq,hq-cv")
-	prefixCmd.Dir = townPath
-	prefixCmd.Env = beadsEnv
-	if prefixOutput, prefixErr := prefixCmd.CombinedOutput(); prefixErr != nil {
-		fmt.Printf("   %s Could not set allowed_prefixes: %s\n", style.Dim.Render("⚠"), strings.TrimSpace(string(prefixOutput)))
+	if err := beads.EnsureConfigYAMLValue(beadsDir, "allowed_prefixes", "hq,hq-cv"); err != nil {
+		fmt.Printf("   %s Could not set allowed_prefixes: %v\n", style.Dim.Render("⚠"), err)
 	}
 
 	// Ensure issues.jsonl exists — bd expects this file for git-tracked issue data.
@@ -848,7 +827,7 @@ func initTownAgentBeads(townPath string) error {
 	// bd init doesn't enable "custom" issue types by default, but Gas Town uses
 	// agent beads during install and runtime. Ensure these types are enabled
 	// before attempting to create any town-level system beads.
-	if err := ensureBeadsCustomTypes(townPath, constants.BeadsCustomTypesList()); err != nil {
+	if err := beads.EnsureCustomTypesConfigYAML(beads.ResolveBeadsDir(townPath)); err != nil {
 		return err
 	}
 

--- a/internal/cmd/rig_integration_test.go
+++ b/internal/cmd/rig_integration_test.go
@@ -1011,7 +1011,6 @@ func TestRigAddRejectsInvalidNames(t *testing.T) {
 // witness and refinery agent beads via the manager's initAgentBeads.
 func TestRigAddCreatesAgentBeads(t *testing.T) {
 	requireDoltServer(t)
-	bdLogPath := mockBdCommand(t)
 	townRoot := setupTestTown(t)
 	bridgeDoltPidToTown(t, townRoot)
 	gitURL := createTestGitRepo(t, "agentbeadtest")
@@ -1035,13 +1034,6 @@ func TestRigAddCreatesAgentBeads(t *testing.T) {
 		t.Fatalf("AddRig: %v", err)
 	}
 
-	// Verify the mock bd was called with correct create commands
-	logContent, err := os.ReadFile(bdLogPath)
-	if err != nil {
-		t.Fatalf("reading bd log: %v", err)
-	}
-	logStr := string(logContent)
-
 	// Expected bead IDs that initAgentBeads should create
 	witnessID := beads.WitnessBeadIDWithPrefix(newRig.Config.Prefix, "agentbeadtest")
 	refineryID := beads.RefineryBeadIDWithPrefix(newRig.Config.Prefix, "agentbeadtest")
@@ -1054,15 +1046,11 @@ func TestRigAddCreatesAgentBeads(t *testing.T) {
 		{refineryID, "refinery agent bead"},
 	}
 
+	rigBeads := beads.NewWithBeadsDir(newRig.Path, beads.ResolveBeadsDir(newRig.Path))
 	for _, expected := range expectedIDs {
-		if !strings.Contains(logStr, expected.id) {
-			t.Errorf("bd create log should contain %s (%s), got:\n%s", expected.id, expected.desc, logStr)
+		if _, err := rigBeads.Show(expected.id); err != nil {
+			t.Errorf("expected %s (%s) to exist: %v", expected.id, expected.desc, err)
 		}
-	}
-
-	// Verify correct prefix is used (ab-)
-	if !strings.Contains(logStr, "ab-") {
-		t.Errorf("bd create log should contain prefix 'ab-', got:\n%s", logStr)
 	}
 }
 

--- a/internal/cmd/sling_convoy_test.go
+++ b/internal/cmd/sling_convoy_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -153,6 +154,61 @@ func TestBdDepListRawIDsValidation(t *testing.T) {
 	_, err = bdDepListRawIDs("/tmp", "valid-id", "down", "'; DROP TABLE deps; --")
 	if err == nil {
 		t.Error("bdDepListRawIDs should reject SQL injection in depType")
+	}
+}
+
+func TestBdDepListRawIDsUsesAutoCommitEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd.log")
+	writeBDStub(t, binDir, `#!/usr/bin/env sh
+{
+	printf 'args:'
+	for arg in "$@"; do
+		printf '[%s]' "$arg"
+	done
+	printf '\nBD_READONLY=%s\n' "${BD_READONLY-}"
+	printf 'BD_DOLT_AUTO_COMMIT=%s\n' "${BD_DOLT_AUTO_COMMIT-}"
+} >> "$BD_STUB_LOG"
+printf '[{"depends_on_id":"external:ag:ag-95s.1"}]\n'
+`, "")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_STUB_LOG", logPath)
+	t.Setenv("BD_READONLY", "true")
+	t.Setenv("BD_DOLT_AUTO_COMMIT", "off")
+
+	workDir := t.TempDir()
+	beadsDir := filepath.Join(workDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"dolt_database":"hq"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ids, err := bdDepListRawIDs(workDir, "hq-cv-test", "down", "tracks")
+	if err != nil {
+		t.Fatalf("bdDepListRawIDs: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "ag-95s.1" {
+		t.Fatalf("ids = %v, want [ag-95s.1]", ids)
+	}
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := string(logBytes)
+	for _, want := range []string{
+		"args:[sql][SELECT COALESCE",
+		"\nBD_READONLY=\n",
+		"BD_DOLT_AUTO_COMMIT=on",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("bd stub log missing %q:\n%s", want, log)
+		}
 	}
 }
 

--- a/internal/cmd/tracking_relations.go
+++ b/internal/cmd/tracking_relations.go
@@ -65,9 +65,10 @@ func mutateTrackingRelationViaStore(townRoot, trackerID, issueID string, add boo
 }
 
 func fallbackTrackingRelation(townRoot, trackerID, issueID string, add bool, storeErr error) error {
-	args := []string{"dep", "add", trackerID, issueID, "--type=tracks"}
+	targetID := trackingDependsOnID(townRoot, issueID)
+	args := []string{"dep", "add", trackerID, targetID, "--type=tracks"}
 	if !add {
-		args = []string{"dep", "remove", trackerID, issueID, "--type=tracks"}
+		args = []string{"dep", "remove", trackerID, targetID, "--type=tracks"}
 	}
 
 	if out, err := BdCmd(args...).Dir(townRoot).WithAutoCommit().StripBeadsDir().CombinedOutput(); err != nil {

--- a/internal/cmd/tracking_relations_test.go
+++ b/internal/cmd/tracking_relations_test.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -27,5 +30,55 @@ func TestTrackingDependsOnID_HQStaysLocal(t *testing.T) {
 	got := trackingDependsOnID(townRoot, "hq-cv-test")
 	if got != "hq-cv-test" {
 		t.Fatalf("trackingDependsOnID() = %q, want %q", got, "hq-cv-test")
+	}
+}
+
+func TestFallbackTrackingRelationUsesExternalTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte("{\"prefix\":\"ag-\",\"path\":\"agentcompany/.beads\"}\n"), 0o644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd.log")
+	writeBDStub(t, binDir, `#!/usr/bin/env sh
+{
+	printf 'args:'
+	for arg in "$@"; do
+		printf '[%s]' "$arg"
+	done
+	printf '\n'
+} >> "$BD_STUB_LOG"
+`, "")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_STUB_LOG", logPath)
+
+	storeErr := errors.New("store unavailable")
+	if err := fallbackTrackingRelation(townRoot, "hq-cv-test", "ag-95s.1", true, storeErr); err != nil {
+		t.Fatalf("fallback add: %v", err)
+	}
+	if err := fallbackTrackingRelation(townRoot, "hq-cv-test", "ag-95s.1", false, storeErr); err != nil {
+		t.Fatalf("fallback remove: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := string(logBytes)
+	for _, want := range []string{
+		"args:[dep][add][hq-cv-test][external:ag:ag-95s.1][--type=tracks]",
+		"args:[dep][remove][hq-cv-test][external:ag:ag-95s.1][--type=tracks]",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("bd stub log missing %q:\n%s", want, log)
+		}
 	}
 }

--- a/internal/mail/bd.go
+++ b/internal/mail/bd.go
@@ -73,7 +73,7 @@ func runBdCommand(ctx context.Context, args []string, workDir, beadsDir string, 
 	cmd.Dir = workDir
 	util.SetDetachedProcessGroup(cmd)
 
-	cmd.Env = bdSubprocessEnv(cmd.Environ(), beadsDir, isMailBdReadCommand(args), extraEnv)
+	cmd.Env = bdSubprocessEnv(cmd.Environ(), beadsDir, beads.ArgsAreReadOnly(args), extraEnv)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -135,48 +135,6 @@ func bdSubprocessEnv(baseEnv []string, beadsDir string, readOnly bool, extraEnv 
 	env := beads.EnvForSubprocessMode(base, beadsDir, mode)
 	env = append(env, telemetry.OTELEnvForSubprocess()...)
 	return env
-}
-
-func filterEnvKey(env []string, key string) []string {
-	prefix := key + "="
-	filtered := make([]string, 0, len(env))
-	for _, entry := range env {
-		if strings.HasPrefix(entry, prefix) {
-			continue
-		}
-		filtered = append(filtered, entry)
-	}
-	return filtered
-}
-
-func isMailBdReadCommand(args []string) bool {
-	if len(args) == 0 {
-		return false
-	}
-	switch args[0] {
-	case "list", "show", "search":
-		return true
-	case "message":
-		return len(args) >= 2 && args[1] == "thread"
-	case "mol":
-		return len(args) >= 3 && args[1] == "wisp" && args[2] == "list"
-	case "sql":
-		query := ""
-		for i := len(args) - 1; i >= 1; i-- {
-			if !strings.HasPrefix(args[i], "-") {
-				query = args[i]
-				break
-			}
-		}
-		q := strings.ToLower(strings.TrimSpace(query))
-		return strings.HasPrefix(q, "select") || strings.HasPrefix(q, "show") || strings.HasPrefix(q, "explain") || strings.HasPrefix(q, "describe") || strings.HasPrefix(q, "with")
-	default:
-		return false
-	}
-}
-
-func filterBdTargetEnv(env []string) []string {
-	return beads.StripBDTargetEnv(env)
 }
 
 // bdReadCtx returns a context with the standard bd read timeout.

--- a/internal/mail/bd_test.go
+++ b/internal/mail/bd_test.go
@@ -1,6 +1,7 @@
 package mail
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -8,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 func TestBdError_Error(t *testing.T) {
@@ -350,7 +353,7 @@ func TestBdSubprocessEnv_ReadonlyCannotBeOverridden(t *testing.T) {
 	}
 }
 
-func TestIsMailBdReadCommand(t *testing.T) {
+func TestArgsAreReadOnlyForMailCommands(t *testing.T) {
 	tests := []struct {
 		args []string
 		want bool
@@ -358,10 +361,10 @@ func TestIsMailBdReadCommand(t *testing.T) {
 		{[]string{"list", "--json"}, true},
 		{[]string{"show", "hq-abc"}, true},
 		{[]string{"sql", "--json", "SELECT * FROM wisps"}, true},
-		{[]string{"sql", "--json", "WITH x AS (SELECT 1) SELECT * FROM x"}, true},
 		{[]string{"mol", "wisp", "list", "--json"}, true},
 		{[]string{"message", "thread", "hq-abc", "--json"}, true},
 		{[]string{"sql", "UPDATE issues SET status='closed'"}, false},
+		{[]string{"sql", "--json", "WITH x AS (SELECT 1) SELECT * FROM x"}, false},
 		{[]string{"mol", "wisp", "create", "mol-test"}, false},
 		{[]string{"message", "send", "mayor", "--body", "hi"}, false},
 		{[]string{"create", "title"}, false},
@@ -369,8 +372,54 @@ func TestIsMailBdReadCommand(t *testing.T) {
 		{[]string{"label", "add", "hq-abc", "read"}, false},
 	}
 	for _, tt := range tests {
-		if got := isMailBdReadCommand(tt.args); got != tt.want {
-			t.Fatalf("isMailBdReadCommand(%v) = %v, want %v", tt.args, got, tt.want)
+		if got := beads.ArgsAreReadOnly(tt.args); got != tt.want {
+			t.Fatalf("beads.ArgsAreReadOnly(%v) = %v, want %v", tt.args, got, tt.want)
+		}
+	}
+}
+
+func TestRunBdCommandUsesCentralEnvPolicy(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd.log")
+	writeMailBDStub(t, binDir)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_STUB_LOG", logPath)
+	t.Setenv("BEADS_DIR", "/wrong")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "wrongdb")
+	t.Setenv("BD_READONLY", "false")
+	t.Setenv("BD_DOLT_AUTO_COMMIT", "on")
+
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"dolt_database":"maildb"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	workDir := filepath.Dir(beadsDir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := runBdCommand(ctx, []string{"list", "--json"}, workDir, beadsDir, "BD_IDENTITY=gastown/chrome", "BD_READONLY=false", "BD_DOLT_AUTO_COMMIT=on"); err != nil {
+		t.Fatalf("run read bd command: %v", err)
+	}
+	readLog := readStubLog(t, logPath)
+	for _, want := range []string{"args:[list][--json][--flat]", "BD_READONLY=true", "BD_DOLT_AUTO_COMMIT=off", "BEADS_NO_AUTO_IMPORT=1", "BD_IDENTITY=gastown/chrome", "BEADS_DIR=" + beadsDir, "BEADS_DOLT_SERVER_DATABASE=maildb"} {
+		if !strings.Contains(readLog, want) {
+			t.Fatalf("read command log missing %q:\n%s", want, readLog)
+		}
+	}
+
+	if err := os.WriteFile(logPath, nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runBdCommand(ctx, []string{"label", "add", "hq-msg", "read"}, workDir, beadsDir, "BD_IDENTITY=gastown/chrome", "BD_READONLY=true", "BD_DOLT_AUTO_COMMIT=off"); err != nil {
+		t.Fatalf("run write bd command: %v", err)
+	}
+	writeLog := readStubLog(t, logPath)
+	for _, want := range []string{"args:[label][add][hq-msg][read]", "\nBD_READONLY=\n", "BD_DOLT_AUTO_COMMIT=on", "BEADS_NO_AUTO_IMPORT=1", "BD_IDENTITY=gastown/chrome", "BEADS_DIR=" + beadsDir, "BEADS_DOLT_SERVER_DATABASE=maildb"} {
+		if !strings.Contains(writeLog, want) {
+			t.Fatalf("write command log missing %q:\n%s", want, writeLog)
 		}
 	}
 }
@@ -399,6 +448,38 @@ func TestBdSubprocessEnv_AllowsRoutingWhenBeadsDirEmpty(t *testing.T) {
 	if !envContains(got, "BEADS_DOLT_SERVER_HOST=127.0.0.2") || !envContains(got, "BEADS_DOLT_SERVER_PORT=5507") || !envContains(got, "BEADS_DOLT_PORT=5507") {
 		t.Fatalf("expected GT_DOLT host/port fallback for routed command, got %v", got)
 	}
+}
+
+func writeMailBDStub(t *testing.T, binDir string) {
+	t.Helper()
+	script := `#!/usr/bin/env sh
+{
+	printf 'args:'
+	for arg in "$@"; do
+		printf '[%s]' "$arg"
+	done
+	printf '\n'
+	printf 'BD_READONLY=%s\n' "${BD_READONLY-}"
+	printf 'BD_DOLT_AUTO_COMMIT=%s\n' "${BD_DOLT_AUTO_COMMIT-}"
+	printf 'BEADS_NO_AUTO_IMPORT=%s\n' "${BEADS_NO_AUTO_IMPORT-}"
+	printf 'BD_IDENTITY=%s\n' "${BD_IDENTITY-}"
+	printf 'BEADS_DIR=%s\n' "${BEADS_DIR-}"
+	printf 'BEADS_DOLT_SERVER_DATABASE=%s\n' "${BEADS_DOLT_SERVER_DATABASE-}"
+} >> "$BD_STUB_LOG"
+printf '[]\n'
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readStubLog(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }
 
 func envContains(env []string, kv string) bool {

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -650,21 +650,9 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 			}
 		}
 
-		// Always ensure issue_prefix and custom types are configured, even when
-		// metadata.json was tracked in git (bdDatabaseExists returned true).
-		// The tracked metadata.json tells bd HOW to connect but doesn't guarantee
-		// the server-side database has issue_prefix set for this workspace.
-		configCmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
-		configCmd.Dir = mayorRigPath
-		configCmd.Env = sourceBdEnv
-		_, _ = configCmd.CombinedOutput() // Ignore errors - older beads don't need this
-
-		prefixSetCmd := exec.Command("bd", "config", "set", "issue_prefix", opts.BeadsPrefix)
-		prefixSetCmd.Dir = mayorRigPath
-		prefixSetCmd.Env = sourceBdEnv
-		if prefixOutput, prefixErr := prefixSetCmd.CombinedOutput(); prefixErr != nil {
-			fmt.Printf("  Warning: Could not set issue_prefix: %v (%s)\n", prefixErr, strings.TrimSpace(string(prefixOutput)))
-		}
+		// Do not mutate source repo config.yaml here: tracked-beads source repos
+		// must remain clean after rig add. Canonical rig config is written below
+		// after the shared rig .beads directory and metadata are established.
 	}
 
 	// NOTE: No per-directory CLAUDE.md/AGENTS.md is created for any agent.
@@ -709,23 +697,22 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 		return nil, fmt.Errorf("rig init left a duplicate Dolt database: %w", err)
 	}
 
-	// Set issue_prefix on the correct server-side database.
-	// InitBeads ran bd config set issue_prefix, but against the wrong database
-	// (beads_<prefix> from bd init, not <rigName> from the centralized server).
-	// Now that EnsureMetadata has corrected dolt_database, re-set it.
+	// Set issue_prefix on the correct server-side database. bd 1.0+ rejects
+	// `bd config set issue_prefix`, so write both config.yaml and Dolt config
+	// directly after metadata points at the canonical rig database.
 	{
-		resolvedBeadsDir := beads.ResolveBeadsDir(rigPath)
-		bdEnv := bdSubprocessEnv(resolvedBeadsDir, opts.Name)
-		prefixCmd := exec.Command("bd", "config", "set", "issue_prefix", opts.BeadsPrefix)
-		prefixCmd.Dir = rigPath
-		prefixCmd.Env = bdEnv
-		if out, err := prefixCmd.CombinedOutput(); err != nil {
-			fmt.Printf("  Warning: Could not set issue_prefix on rig database: %v (%s)\n", err, strings.TrimSpace(string(out)))
+		rigRootBeadsDir := filepath.Join(rigPath, ".beads")
+		resolvedBeadsDir := beads.ResolveBeadsDir(rigRootBeadsDir)
+		if _, err := os.Stat(filepath.Join(rigRootBeadsDir, "redirect")); os.IsNotExist(err) {
+			if err := beads.EnsureConfigYAMLValue(resolvedBeadsDir, "issue-prefix", opts.BeadsPrefix); err != nil {
+				fmt.Printf("  Warning: Could not set issue-prefix in config.yaml: %v\n", err)
+			}
+			_ = beads.EnsureConfigYAMLValue(resolvedBeadsDir, "types.custom", constants.BeadsCustomTypes)
 		}
-		typesCmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
-		typesCmd.Dir = rigPath
-		typesCmd.Env = bdEnv
-		_, _ = typesCmd.CombinedOutput()
+		if err := beads.EnsureDoltConfigValue(resolvedBeadsDir, "issue_prefix", opts.BeadsPrefix); err != nil {
+			fmt.Printf("  Warning: Could not set issue_prefix in rig database: %v\n", err)
+		}
+		_ = beads.EnsureDoltConfigValue(resolvedBeadsDir, "types.custom", constants.BeadsCustomTypes)
 	}
 
 	// Auto-create DoltHub remote for the rig's beads database.

--- a/plugins/dolt-snapshots/main.go
+++ b/plugins/dolt-snapshots/main.go
@@ -382,12 +382,7 @@ func findConvoysNeedingSnapshots(db *sql.DB) ([]convoyRow, error) {
 // discoverConvoyDatabases finds which rig databases a convoy touches
 // by looking at its tracked issues' prefixes.
 func discoverConvoyDatabases(db *sql.DB, convoyID string, databases []string, routes map[string]string) ([]string, error) {
-	query := `
-		SELECT DISTINCT d.depends_on_id
-		FROM hq.dependencies d
-		WHERE d.issue_id = ? AND d.type = 'tracks'
-	`
-	rows, err := db.Query(query, convoyID)
+	rows, err := db.Query(convoyDependencyTargetsQuery(), convoyID)
 	if err != nil {
 		return nil, err
 	}
@@ -421,15 +416,27 @@ func discoverConvoyDatabases(db *sql.DB, convoyID string, databases []string, ro
 	return result, rows.Err()
 }
 
+func convoyDependencyTargetsQuery() string {
+	return `
+		SELECT DISTINCT COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) AS depends_on_id
+		FROM hq.dependencies d
+		WHERE d.issue_id = ? AND d.type = 'tracks'
+			AND COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) IS NOT NULL
+	`
+}
+
 // resolveDependencyDB extracts the database name from a dependency ID.
 // Handles two formats:
-//   - "external:<rig_name>:<bead_id>" → rig_name
+//   - "external:<prefix-or-rig>:<bead_id>" → routes[prefix] or rig name
 //   - "<prefix>-<id>" → routes[prefix]
 func resolveDependencyDB(depID string, routes map[string]string) string {
 	if strings.HasPrefix(depID, "external:") {
-		// Format: external:<rig_name>:<bead_id>
+		// Format: external:<prefix-or-rig>:<bead_id>
 		parts := strings.SplitN(depID, ":", 3)
 		if len(parts) >= 2 {
+			if mapped, ok := routes[parts[1]]; ok {
+				return mapped
+			}
 			return parts[1]
 		}
 		return ""

--- a/plugins/dolt-snapshots/main_test.go
+++ b/plugins/dolt-snapshots/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -93,8 +94,8 @@ func TestIsSystemDB(t *testing.T) {
 		{"lora_forge", false},
 		{"node0", false},
 		// Edge cases: names that start with system prefixes but aren't
-		{"testdb", false},        // exactly "testdb" with no underscore
-		{"beads", false},         // exactly "beads"
+		{"testdb", false},           // exactly "testdb" with no underscore
+		{"beads", false},            // exactly "beads"
 		{"beads_production", false}, // doesn't match beads_t or beads_pt
 	}
 
@@ -236,6 +237,8 @@ func TestResolveDependencyDB(t *testing.T) {
 		{"external:petals:pe-k0e.1.1", "petals"},
 		{"external:lora_forge:lf-mx5rb", "lora_forge"},
 		{"external:node0:no-2yg", "node0"},
+		{"external:pe:pe-k0e.1.1", "petals"},
+		{"external:lf:lf-mx5rb", "lora_forge"},
 
 		// Prefix format (via routes)
 		{"pe-k0e", "petals"},
@@ -276,6 +279,23 @@ func TestResolveDependencyDB_EmptyRoutes(t *testing.T) {
 	// Prefix deps fail without routes
 	if got := resolveDependencyDB("pe-123", routes); got != "" {
 		t.Errorf("Expected empty for prefix dep with empty routes, got %q", got)
+	}
+}
+
+func TestConvoyDependencyTargetsQueryUsesTypedTargets(t *testing.T) {
+	query := convoyDependencyTargetsQuery()
+	if strings.Contains(query, "d.depends_on_id") {
+		t.Fatalf("query should not select legacy physical depends_on_id column:\n%s", query)
+	}
+	for _, want := range []string{
+		"COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) AS depends_on_id",
+		"COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) IS NOT NULL",
+		"d.issue_id = ?",
+		"d.type = 'tracks'",
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("query missing %q:\n%s", want, query)
+		}
 	}
 }
 


### PR DESCRIPTION
Replacement core PR split from #4331.

Original PR: https://github.com/gastownhall/gastown/pull/4331

Scope:
- Keeps core bd environment and dependency-routing convergence.
- Excludes the scheduler/test-harness follow-up branch so mergeability can be assessed separately.
- Leaves #4331 open until the replacement path is reviewed.

Evidence from split worker:
- 15 research legs, 5 pre-reviews, and 5 post-reviews completed.
- CGO_ENABLED=0 go build -v ./cmd/gt passed.
- CGO_ENABLED=0 go test -short -count=1 ./internal/beads ./internal/cmd ./internal/mail ./internal/testutil passed.
- plugins/dolt-snapshots go test -count=1 ./... passed.
- Default CGO tests blocked locally by missing ICU libs.

Follow-up branch for scheduler/test-harness work:
- Bella-Giraffety:sheriff/pr-4331-scheduler-harness-vault-b4d2aa

PR Sheriff checker on the split evidence passed as defer_human_review, not merge-ready, pending GitHub CI and final label/status review.