### PR TITLE
feat: migrate gt to fork-built binary, fix rebuild-gt source path (hq-lls)

### DIFF
--- a/docs/design/forked-binary-migration.md
+++ b/docs/design/forked-binary-migration.md
@@ -1,0 +1,135 @@
+# Migration: Run the town on a locally-built forked `gt` binary
+
+**Bead:** hq-lls · **Status:** Complete · **Author:** polecat nux
+
+## Goal
+
+Stop depending on the Homebrew `gt` bottle and instead run the town on a `gt`
+binary built from our own fork (`egroeg121/gastown`), while still pulling
+improvements from upstream (`gastownhall/gastown`).
+
+## Post-migration state
+
+| Thing | Value |
+|---|---|
+| Installed binary | `~/.local/bin/gt` → fork build, shadowing Homebrew |
+| `gt version --verbose` commit | shows fork commit hash (e.g. `51183512`) |
+| `which gt` | `/Users/georgebarnett/.local/bin/gt` |
+| Build source | `~/code/gastown` (standalone fork clone) |
+| `rebuild-gt` plugin source | `~/code/gastown` (via `$GT_GASTOWN_SOURCE_DIR`) |
+| Upstream remote in rig bare repo | ✅ `upstream = https://github.com/gastownhall/gastown.git` |
+| Fallback | `rm ~/.local/bin/gt` reverts to Homebrew bottle instantly |
+
+## Phase 0 — One-time bootstrap (COMPLETED)
+
+Built and installed gt from the fork standalone clone:
+
+```bash
+cd ~/code/gastown
+git fetch origin && git checkout main && git pull --ff-only origin main
+make build
+make install   # installs to ~/.local/bin/gt, restarts daemon, syncs plugins
+```
+
+Verified:
+```bash
+which gt        # → /Users/georgebarnett/.local/bin/gt
+gt version --verbose  # → shows fork commit hash, NOT "Homebrew"
+```
+
+> Do **not** `brew uninstall gastown`. The bottle in place is a known-good
+> fallback — `rm ~/.local/bin/gt` reverts to it instantly.
+
+## Phase 1 — Fix rebuild-gt plugin path (COMPLETED)
+
+The `rebuild-gt` plugin previously assumed source at `~/gt/gastown/mayor/rig`
+(which never existed). Fixed to use `~/code/gastown` as the default build source,
+overridable via `$GT_GASTOWN_SOURCE_DIR`.
+
+Changed in `plugins/rebuild-gt/run.sh`:
+```bash
+# Before (wrong — ~/gt/... never existed):
+RIG_ROOT="${TOWN_ROOT}/gastown/mayor/rig"
+
+# After (correct):
+RIG_ROOT="${GT_GASTOWN_SOURCE_DIR:-${HOME}/code/gastown}"
+```
+
+Also updated `plugin.md` examples to reference `~/code/gastown`.
+
+## Phase 2 — Upstream remote in rig bare repo (COMPLETED)
+
+The rig bare repo (`~/code/footy/gastown/.repo.git`) already had the upstream
+remote added. Verify with:
+
+```bash
+git -C ~/code/footy/gastown/.repo.git remote -v
+# Shows:
+#   origin   https://github.com/egroeg121/gastown.git
+#   upstream https://github.com/gastownhall/gastown.git
+```
+
+If it were missing, add it with:
+```bash
+git -C ~/code/footy/gastown/.repo.git remote add upstream \
+    https://github.com/gastownhall/gastown.git
+```
+
+## Phase 3 — Rebase cadence (MANUAL, weekly or on-demand)
+
+**Strategy:** rebase the fork's `main` onto `upstream/main`. Rebase (not merge)
+keeps fork-specific commits as a clean linear set on top of upstream.
+
+**Where:** the standalone `~/code/gastown` clone — outside the live rig so a
+messy rebase never disturbs running sessions.
+
+```bash
+cd ~/code/gastown
+git checkout main
+git fetch upstream
+git rebase upstream/main          # replay fork commits on top of upstream
+# resolve conflicts if any, then:
+git push origin main --force-with-lease   # update the fork
+```
+
+Then the rig picks it up on next `git pull` / next `rebuild-gt` run.
+
+**Cadence:** weekly, or on-demand when a wanted upstream fix lands.
+
+**NEVER automate the force-push.** A botched rebase that force-pushes the fork
+is high blast radius. If a rebase gets ugly, `git rebase --abort` and escalate.
+
+## Ongoing: rebuild-gt automation
+
+The Deacon dispatches `rebuild-gt` on a 1h cooldown. It runs `gt stale --json`
+and if the binary is behind `main` (and forward-safe + clean + on main), it runs:
+```bash
+cd ~/code/gastown && make build && make safe-install
+```
+
+`safe-install` replaces the binary WITHOUT restarting the daemon, so live
+sessions are undisturbed and pick up the new binary on their next natural cycle.
+
+## Fallback
+
+```bash
+rm ~/.local/bin/gt   # reverts to Homebrew bottle (/opt/homebrew/bin/gt)
+```
+
+## End-to-end flow (steady state)
+
+```
+polecat edits fork worktree
+        │  gt done
+        ▼
+Refinery merges → fork main (egroeg121/gastown)
+        │  Deacon dispatches rebuild-gt (1h cooldown)
+        ▼
+gt stale detects binary behind main → make build && make safe-install
+        │
+        ▼
+~/.local/bin/gt updated (shadows Homebrew bottle) → sessions pick it up on cycle
+
+   ── weekly / on-demand ──
+upstream/main ──rebase──> fork main ──force-with-lease──> origin
+```

--- a/plugins/rebuild-gt/plugin.md
+++ b/plugins/rebuild-gt/plugin.md
@@ -57,7 +57,7 @@ gt plugin record-run --plugin rebuild-gt --result skipped --rig gastown \
 Before building, verify the source repo is clean and on main:
 
 ```bash
-cd ~/gt/gastown/mayor/rig
+cd ~/code/gastown   # or $GT_GASTOWN_SOURCE_DIR if overridden
 git status --porcelain  # Must be clean
 git branch --show-current  # Must be "main"
 ```
@@ -69,7 +69,8 @@ If either check fails, skip the rebuild and record a wisp.
 Rebuild from source (the mayor/rig directory is the canonical source):
 
 ```bash
-cd ~/gt/gastown/mayor/rig && make build && make safe-install
+cd ~/code/gastown && make build && make safe-install
+# or: cd "${GT_GASTOWN_SOURCE_DIR:-~/code/gastown}" && make build && make safe-install
 ```
 
 **IMPORTANT**: Use `make safe-install` (not `make install`) to avoid restarting

--- a/plugins/rebuild-gt/run.sh
+++ b/plugins/rebuild-gt/run.sh
@@ -8,7 +8,9 @@
 set -euo pipefail
 
 TOWN_ROOT="${GT_TOWN_ROOT:-$(gt town root 2>/dev/null)}"
-RIG_ROOT="${TOWN_ROOT}/gastown/mayor/rig"
+# GT_GASTOWN_SOURCE_DIR: override to use a different build source.
+# Default: ~/code/gastown (standalone fork clone with the gastown Go source).
+RIG_ROOT="${GT_GASTOWN_SOURCE_DIR:-${HOME}/code/gastown}"
 
 log() { echo "[rebuild-gt] $*"; }
 


### PR DESCRIPTION
## Summary
- Built and installed `gt` from `~/code/gastown` fork — `~/.local/bin/gt` now shadows Homebrew bottle
- `gt version` shows fork commit hash, not "Homebrew"
- Fixed `rebuild-gt` plugin source path: was `~/gt/gastown/mayor/rig` (nonexistent), now uses `GT_GASTOWN_SOURCE_DIR` env var defaulting to `~/code/gastown`
- Documented upstream rebase cadence in `docs/design/forked-binary-migration.md`

## Test plan
- [ ] `gt version` shows fork commit hash
- [ ] `gt stale --json` shows `binary_commit` matching fork HEAD
- [ ] `rebuild-gt` plugin succeeds end-to-end
- [ ] Deacon: verify town still functions after swap

🤖 Generated with [Claude Code](https://claude.com/claude-code)