### PR TITLE
fix(tmux): nudge falls back to session name when pane ID is stale (gy-avjr)

### DIFF
--- a/internal/tmux/tmux.go
+++ b/internal/tmux/tmux.go
@@ -1666,12 +1666,26 @@ func (t *Tmux) canonicalPaneTarget(session, pane string) string {
 	out, err := t.run("display-message", "-t", pane, "-p", "#{session_name}:#{window_index}.#{pane_index}")
 	if err == nil {
 		target := strings.TrimSpace(out)
-		if target != "" {
+		// Accept the resolved target ONLY when it is well-formed AND belongs to
+		// the session we intend to nudge. A stale/bogus pane can make
+		// display-message succeed with empty fields (":.") instead of erroring,
+		// and because tmux pane IDs are global and get reused after a server
+		// restart, a stale ID can also resolve into a *different* session — both
+		// would mis-target send-keys.
+		if target != "" && strings.HasPrefix(target, session+":") {
 			return target
 		}
 	}
 
-	return pane
+	// The pane ID could not be resolved to a live pane in this session — it is
+	// stale (e.g. a GT_PANE_ID declared before a tmux server restart, when pane
+	// IDs reset) or otherwise gone. Returning the raw pane ID here is what caused
+	// recurring "send-keys: can't find window: %NNNN" nudge failures (gy-avjr):
+	// the dead ID flows straight into send-keys. Fall back to the stable session
+	// NAME instead — tmux resolves it to the session's active pane, which always
+	// exists if the session does. Worst case (multi-pane session, agent not
+	// focused) we nudge the active pane rather than fail entirely.
+	return session
 }
 
 // NudgeSessionWithOpts is like NudgeSession but accepts delivery options.

--- a/internal/tmux/tmux_test.go
+++ b/internal/tmux/tmux_test.go
@@ -2545,3 +2545,51 @@ func TestValidateCommandBinary(t *testing.T) {
 		})
 	}
 }
+
+// TestCanonicalPaneTarget_StalePaneFallsBackToSession is the gy-avjr regression:
+// when a pane ID cannot be resolved (stale — e.g. a GT_PANE_ID declared before a
+// tmux server restart reset pane IDs), canonicalPaneTarget must fall back to the
+// stable session NAME, NOT return the dead pane ID. Returning the dead ID is what
+// produced recurring "send-keys: can't find window: %NNNN" nudge failures.
+func TestCanonicalPaneTarget_StalePaneFallsBackToSession(t *testing.T) {
+	tm := newTestTmux(t)
+	sessionName := "gt-test-canonical-" + fmt.Sprintf("%d", os.Getpid())
+
+	_ = tm.KillSession(sessionName)
+	if err := tm.NewSession(sessionName, ""); err != nil {
+		t.Fatalf("NewSession: %v", err)
+	}
+	defer func() { _ = tm.KillSession(sessionName) }()
+
+	// Empty pane → session name (existing contract).
+	if got := tm.canonicalPaneTarget(sessionName, ""); got != sessionName {
+		t.Errorf("empty pane: got %q, want session %q", got, sessionName)
+	}
+
+	// Stale/nonexistent pane ID → must fall back to the session name, never the
+	// dead pane ID (the gy-avjr bug).
+	stale := "%999999"
+	if got := tm.canonicalPaneTarget(sessionName, stale); got == stale {
+		t.Errorf("stale pane %q was returned verbatim — would feed send-keys a dead target; want fallback to session %q", stale, sessionName)
+	} else if got != sessionName {
+		t.Errorf("stale pane: got %q, want session fallback %q", got, sessionName)
+	}
+
+	// A live pane ID → resolves to a real session:window.pane target that
+	// send-keys can use (sanity that the success path still works).
+	out, err := tm.run("list-panes", "-t", sessionName, "-F", "#{pane_id}")
+	if err != nil {
+		t.Fatalf("list-panes: %v", err)
+	}
+	livePane := strings.TrimSpace(strings.Split(strings.TrimSpace(out), "\n")[0])
+	if livePane != "" {
+		got := tm.canonicalPaneTarget(sessionName, livePane)
+		if got == "" {
+			t.Errorf("live pane %q resolved to empty target", livePane)
+		}
+		// The resolved target must itself be addressable by tmux.
+		if _, err := tm.run("display-message", "-t", got, "-p", "#{pane_id}"); err != nil {
+			t.Errorf("resolved target %q is not addressable: %v", got, err)
+		}
+	}
+}


### PR DESCRIPTION
## Problem
`gt nudge` recurringly fails with `send-keys: can't find window: %NNNN`, forcing a manual `tmux send-keys` workaround every session (gy-avjr — reproducible across sessions when nudging crew/coach/analyst, especially after a tmux server restart).

## Root cause
`NudgeSessionWithOpts` resolves a delivery target via `canonicalPaneTarget(session, FindAgentPane(session))`. `FindAgentPane` can return a pane ID (from the declared `GT_PANE_ID` or a scan), but `canonicalPaneTarget` **fell back to returning that raw pane ID** whenever it couldn't canonicalize it. A stale pane ID — e.g. a `GT_PANE_ID` declared before a tmux **server restart**, after which pane IDs reset — then flowed straight into `send-keys -t %NNNN` and failed every time. The cached ID is never refreshed, so the failure recurs until manually worked around.

Two failure shapes were possible:
1. `display-message -t <stalePane>` errors → raw stale ID returned → `can't find window`.
2. `display-message` "succeeds" with empty fields (`:.`) for a bogus pane → garbage target returned.

Plus a latent mis-targeting hole: tmux pane IDs are **global** and get reused after a server restart, so a stale ID could resolve into a *different* session and nudge the wrong agent.

## Fix
`canonicalPaneTarget` now returns a pane-based target **only** when `display-message` resolves it to a well-formed `session:window.pane` that **belongs to the expected session**; otherwise it falls back to the stable **session NAME**. tmux resolves the session name to its active pane, which always exists if the session does. Worst case (multi-pane session, agent pane not focused) we nudge the active pane instead of failing entirely.

## Test
Adds `TestCanonicalPaneTarget_StalePaneFallsBackToSession` covering empty-pane, stale-pane (must **not** return the dead ID), and live-pane (resolved target stays addressable) cases. Full `internal/tmux` suite + `go vet` pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)