### PR TITLE
fix(beads): pin server database in pinned bd env so mol bond targets the rig DB

### DIFF
--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -114,8 +114,13 @@ func TestBuildPinnedBDEnvUsesSelectedConnectionMetadata(t *testing.T) {
 	if got["BEADS_DIR"] != beadsDir {
 		t.Fatalf("BEADS_DIR = %q, want %q in %v", got["BEADS_DIR"], beadsDir, env)
 	}
-	if value, ok := got["BEADS_DOLT_SERVER_DATABASE"]; ok {
-		t.Fatalf("BEADS_DOLT_SERVER_DATABASE should be stripped, got %q in %v", value, env)
+	// In shared-server mode the database is pinned EXPLICITLY by name from the
+	// selected beadsDir's metadata: the inherited (wrong) "hq" value is stripped
+	// and replaced with the metadata's "rigdb". BEADS_DIR alone does not reliably
+	// select the server database for all bd subcommands (e.g. `bd mol bond`), so
+	// the name must be pinned. See pinnedDoltTargetEnvFromBeadsDir / hq-qzrce.
+	if got["BEADS_DOLT_SERVER_DATABASE"] != "rigdb" {
+		t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want %q (pinned from metadata) in %v", got["BEADS_DOLT_SERVER_DATABASE"], "rigdb", env)
 	}
 	if got["BEADS_DOLT_SERVER_HOST"] != "127.0.0.1" {
 		t.Fatalf("BEADS_DOLT_SERVER_HOST = %q, want 127.0.0.1 in %v", got["BEADS_DOLT_SERVER_HOST"], env)
@@ -130,6 +135,52 @@ func TestBuildPinnedBDEnvUsesSelectedConnectionMetadata(t *testing.T) {
 	}
 	if got["BEADS_DOLT_AUTO_START"] != "0" {
 		t.Fatalf("BEADS_DOLT_AUTO_START should be preserved, got %q in %v", got["BEADS_DOLT_AUTO_START"], env)
+	}
+}
+
+// TestBuildPinnedBDEnvPinsRigDatabaseInsideTown is the regression test for
+// hq-qzrce: a rig beads dir that lives inside a real town (so FindTownRoot
+// resolves) must NOT receive BEADS_DOLT_DATA_DIR pointing at the town data dir.
+// `bd mol bond`/`bd mol wisp` resolve the target database from BEADS_DOLT_DATA_DIR
+// and ignore BEADS_DIR, so re-adding the town data dir made rig-bead (mm-*) bonds
+// land in the town/HQ database ("'<id>' not found"), breaking scheduler dispatch
+// and causing polecats to false-complete. The earlier
+// TestBuildPinnedBDEnvUsesSelectedConnectionMetadata used a temp dir with no town,
+// so FindTownRoot returned "" and this re-addition path was never exercised.
+func TestBuildPinnedBDEnvPinsRigDatabaseInsideTown(t *testing.T) {
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, "mayor"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"name":"gt"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	beadsDir := filepath.Join(townRoot, "minime", ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := []byte(`{"dolt_database":"minime","dolt_server_host":"127.0.0.1","dolt_server_port":3307}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := BuildPinnedBDEnv([]string{
+		"PATH=/usr/bin",
+		"BEADS_DOLT_DATA_DIR=" + filepath.Join(townRoot, ".dolt-data"),
+	}, beadsDir)
+	got := envMap(env)
+
+	if got["BEADS_DIR"] != beadsDir {
+		t.Fatalf("BEADS_DIR = %q, want %q in %v", got["BEADS_DIR"], beadsDir, env)
+	}
+	// The database must be pinned explicitly by name from metadata...
+	if got["BEADS_DOLT_SERVER_DATABASE"] != "minime" {
+		t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want %q (pinned) in %v", got["BEADS_DOLT_SERVER_DATABASE"], "minime", env)
+	}
+	// ...and BEADS_DOLT_DATA_DIR must NOT be present, even though the beads dir is
+	// inside a town: in shared-server mode it overrides BEADS_DIR for `bd mol bond`.
+	if value, ok := got["BEADS_DOLT_DATA_DIR"]; ok {
+		t.Fatalf("BEADS_DOLT_DATA_DIR must be absent in shared-server pinned env, got %q in %v", value, env)
 	}
 }
 

--- a/internal/beads/database.go
+++ b/internal/beads/database.go
@@ -72,8 +72,44 @@ func BuildPinnedBDEnv(base []string, beadsDir string) []string {
 		return addGTDerivedDoltTargetEnv(env)
 	}
 	env = append(env, "BEADS_DIR="+beadsDir)
-	env = append(env, doltTargetEnvFromBeadsDir(beadsDir)...)
+	env = append(env, pinnedDoltTargetEnvFromBeadsDir(beadsDir)...)
 	return addGTDerivedDoltTargetEnv(env)
+}
+
+// pinnedDoltTargetEnvFromBeadsDir returns Dolt connection env for a bd subprocess
+// that must be pinned to the single database belonging to beadsDir.
+//
+// In shared-server mode it selects the database EXPLICITLY by name via
+// BEADS_DOLT_SERVER_DATABASE and deliberately omits BEADS_DOLT_DATA_DIR. This is
+// the key difference from doltTargetEnvFromBeadsDir (used for prefix routing,
+// which must NOT pin a database): some bd subcommands — notably `bd mol bond` /
+// `bd mol wisp` — resolve the target database from BEADS_DOLT_DATA_DIR (the town
+// data dir) and ignore BEADS_DIR. When a rig bead (e.g. mm-*) is bonded with the
+// town data dir present, bd looks in the town/HQ database, reports
+// "'<id>' not found (not an issue ID or formula name)", and the scheduler
+// dispatch fails — so the polecat boots with no work and false-completes
+// (hq-qzrce). Pinning the database by name and dropping DATA_DIR makes the bond
+// land in the correct rig database.
+//
+// In embedded (non-server) mode there is no server database to name, so we fall
+// back to data-dir targeting via doltTargetEnvFromBeadsDir.
+func pinnedDoltTargetEnvFromBeadsDir(beadsDir string) []string {
+	if beadsDir == "" {
+		return nil
+	}
+	meta := readDoltMetadata(beadsDir)
+	if meta.Host == "" || meta.Port == "" {
+		// Embedded / no shared server: keep data-dir targeting.
+		return doltTargetEnvFromBeadsDir(beadsDir)
+	}
+	var env []string
+	if db := DatabaseNameFromMetadata(beadsDir); db != "" {
+		env = append(env, "BEADS_DOLT_SERVER_DATABASE="+db)
+	}
+	env = append(env, "BEADS_DOLT_SERVER_HOST="+meta.Host)
+	env = append(env, "BEADS_DOLT_SERVER_PORT="+meta.Port)
+	env = append(env, "BEADS_DOLT_PORT="+meta.Port)
+	return env
 }
 
 // BuildRoutingBDEnv returns env for a bd subprocess that intentionally relies on


### PR DESCRIPTION
## Problem

On a multi-rig town backed by a **shared Dolt server**, scheduler dispatch of a rig bead (e.g. `mm-*`) fails and the polecat boots with no work, then false-completes. The daemon log shows:

```
Scheduler dispatch: Dispatching mm-xxx → minime...
  "error": "'mm-xxx' not found (not an issue ID or formula name)"
✓ Dispatched 0, failed 1 (reason: batch)
```

The work bead clearly exists (`bd show mm-xxx` finds it), and gt's routing is correct — `beads.ResolveHookDir` resolves the bead to the rig dir (`<town>/minime`) before the bond. The failure is in the **bd subprocess environment**.

## Root cause

`BuildPinnedBDEnv` sets `BEADS_DIR=<rig>/.beads` and, via `doltTargetEnvFromBeadsDir`, also re-adds `BEADS_DOLT_DATA_DIR=<town>/.dolt-data` — but never pins the database **by name**.

Most bd subcommands honor `BEADS_DIR`, but **`bd mol bond` / `bd mol wisp` resolve the target database from `BEADS_DOLT_DATA_DIR`** (the town data dir) and ignore `BEADS_DIR`. So the wisp/bond for a rig bead runs against the town/HQ database, can't find the `mm-` bead, and dispatch fails.

Reproduced directly (shared server, `BEADS_DIR=<rig>/.beads` set):

| env | `bd mol bond mol-polecat-work mm-xxx …` |
|---|---|
| **with** `BEADS_DOLT_DATA_DIR=<town>/.dolt-data` | ❌ `'mm-xxx' not found` |
| **without** it | ✅ bond succeeds |
| with `BEADS_DOLT_SERVER_DATABASE=<rig>` + no `DATA_DIR` | ✅ reliably succeeds |

(Relying on `BEADS_DIR` alone without an explicit `BEADS_DOLT_SERVER_DATABASE` was unreliable in server mode.)

## Fix

Add `pinnedDoltTargetEnvFromBeadsDir`. In shared-server mode it selects the database **explicitly** via `BEADS_DOLT_SERVER_DATABASE` (from the beads dir's `metadata.json`) and **omits** `BEADS_DOLT_DATA_DIR`. Embedded (non-server) mode is unchanged. `BuildRoutingBDEnv` is untouched — routed env must not pin a database.

## Tests

- Updated `TestBuildPinnedBDEnvUsesSelectedConnectionMetadata`: the pinned env now carries the correct DB name (from metadata) instead of stripping `BEADS_DOLT_SERVER_DATABASE` — the inherited *wrong* value is still stripped.
- Added `TestBuildPinnedBDEnvPinsRigDatabaseInsideTown`: exercises a rig beads dir **inside a real town** (so `FindTownRoot` resolves and `BEADS_DOLT_DATA_DIR` would otherwise be re-added). This is the case the previous test missed — it used a town-less temp dir, so `FindTownRoot` returned `""` and the re-addition path was never covered, which is how the bug shipped.

`go test ./internal/beads/` passes (the one unrelated failure, `TestRunEnv_StripsPollutedDoltEnvAndUsesRigMetadata`, fails identically on a clean checkout in this environment due to hardcoded paths).

🤖 Generated with [Claude Code](https://claude.com/claude-code)