### PR TITLE
fix: split core bd env and align integration bd version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -169,16 +169,23 @@ jobs:
       - name: Pre-pull Dolt Docker image
         run: docker pull dolthub/dolt-sql-server:2.0.7
 
+      - name: Resolve beads version
+        id: beads-version
+        run: |
+          version="$(go list -mod=readonly -m -f '{{.Version}}' github.com/steveyegge/beads)"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Cache beads (bd)
         id: cache-beads-int
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/go/bin/bd
-          key: beads-${{ hashFiles('.github/workflows/ci.yml') }}
+          key: beads-${{ runner.os }}-${{ runner.arch }}-${{ steps.beads-version.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}
 
       - name: Install beads (bd)
         if: steps.cache-beads-int.outputs.cache-hit != 'true'
-        run: CGO_ENABLED=0 go install github.com/steveyegge/beads/cmd/bd@v1.0.0
+        run: CGO_ENABLED=0 go install "github.com/steveyegge/beads/cmd/bd@${{ steps.beads-version.outputs.version }}"
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -199,7 +199,33 @@ jobs:
         run: echo "$(go env GOPATH)/bin" >> "$GITHUB_PATH"
 
       - name: Integration Tests
-        run: gotestsum --format testname --junitfile junit-integration.xml -- -tags=integration -timeout=15m -v ./internal/cmd/...
+        run: |
+          status=0
+
+          gotestsum --format testname --junitfile junit-integration.xml -- \
+            -tags=integration -timeout=15m -v ./internal/cmd/... || status=1
+
+          gotestsum --format testname --junitfile junit-scheduler-1.xml -- \
+            -tags='integration scheduler_integration' -timeout=15m -v \
+            -run '^(TestScheduler(CircuitBreakerExclusion|AutoConvoyCreation|BlockedStatusReporting|SlingDryRun|SlingContextIdempotency|SlingContextWorkBeadPristine))$' \
+            ./internal/cmd || status=1
+
+          gotestsum --format testname --junitfile junit-scheduler-2.xml -- \
+            -tags='integration scheduler_integration' -timeout=15m -v \
+            -run '^(TestScheduler(MultiRigDispatch|MultiRigEpicAutoResolve|ConvoyFlagRejection|EpicFlagRejection|EpicDetection|MixedBatchRejection|MultiRigConvoyAutoResolve))$' \
+            ./internal/cmd || status=1
+
+          gotestsum --format testname --junitfile junit-scheduler-3.xml -- \
+            -tags='integration scheduler_integration' -timeout=15m -v \
+            -run '^(TestScheduler(DisabledMode|DirectModeNoQueue|DeferredTaskWithoutRig|DeferredNonRigRejection|DeferredAcceptsDogTarget|DirectEpicDispatch|BatchEpicRejection))$' \
+            ./internal/cmd || status=1
+
+          gotestsum --format testname --junitfile junit-scheduler-4.xml -- \
+            -tags='integration scheduler_integration' -timeout=15m -v \
+            -run '^(TestScheduler(InvalidJSONContextCleanup|ActualDispatchRoutesPollutedEnvToTargetRig|FormulaDispatchRoutesPollutedEnvToTargetRig|DispatchFailureRecordedInContextSourceDB|DirectConvoyDispatch)|TestScheduleBead_(RefusesClosed|RefusesTombstone|ClosedForceDoesNotBypass))$' \
+            ./internal/cmd || status=1
+
+          exit "$status"
 
       - name: Test Report
         if: always()
@@ -207,4 +233,10 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          python3 .github/scripts/junit-report.py junit-integration.xml "Integration Test Failures"
+          status=0
+          python3 .github/scripts/junit-report.py junit-integration.xml "Integration Test Failures" || status=1
+          python3 .github/scripts/junit-report.py junit-scheduler-1.xml "Scheduler Integration Failures 1" || status=1
+          python3 .github/scripts/junit-report.py junit-scheduler-2.xml "Scheduler Integration Failures 2" || status=1
+          python3 .github/scripts/junit-report.py junit-scheduler-3.xml "Scheduler Integration Failures 3" || status=1
+          python3 .github/scripts/junit-report.py junit-scheduler-4.xml "Scheduler Integration Failures 4" || status=1
+          exit "$status"

--- a/.github/workflows/nightly-integration.yml
+++ b/.github/workflows/nightly-integration.yml
@@ -27,16 +27,23 @@ jobs:
           git config --global user.name "CI Bot"
           git config --global user.email "ci@gastown.test"
 
+      - name: Resolve beads version
+        id: beads-version
+        run: |
+          version="$(go list -mod=readonly -m -f '{{.Version}}' github.com/steveyegge/beads)"
+          test -n "$version"
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Cache beads (bd)
         id: cache-beads
         uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
         with:
           path: ~/go/bin/bd
-          key: beads-nightly-${{ hashFiles('.github/workflows/nightly-integration.yml') }}
+          key: beads-nightly-${{ runner.os }}-${{ runner.arch }}-${{ steps.beads-version.outputs.version }}-${{ hashFiles('go.mod', 'go.sum') }}
 
       - name: Install beads (bd)
         if: steps.cache-beads.outputs.cache-hit != 'true'
-        run: go install github.com/steveyegge/beads/cmd/bd@v0.57.0
+        run: CGO_ENABLED=0 go install "github.com/steveyegge/beads/cmd/bd@${{ steps.beads-version.outputs.version }}"
 
       - name: Install Dolt
         run: |

--- a/.github/workflows/nightly-integration.yml
+++ b/.github/workflows/nightly-integration.yml
@@ -68,4 +68,30 @@ jobs:
         run: go build -v ./cmd/gt
 
       - name: Run all integration tests
-        run: gotestsum --format testname --junitfile junit.xml -- -v -tags=integration -timeout=20m ./...
+        run: |
+          status=0
+
+          gotestsum --format testname --junitfile junit.xml -- \
+            -v -tags=integration -timeout=20m ./... || status=1
+
+          gotestsum --format testname --junitfile junit-scheduler-1.xml -- \
+            -tags='integration scheduler_integration' -timeout=20m -v \
+            -run '^(TestScheduler(CircuitBreakerExclusion|AutoConvoyCreation|BlockedStatusReporting|SlingDryRun|SlingContextIdempotency|SlingContextWorkBeadPristine))$' \
+            ./internal/cmd || status=1
+
+          gotestsum --format testname --junitfile junit-scheduler-2.xml -- \
+            -tags='integration scheduler_integration' -timeout=20m -v \
+            -run '^(TestScheduler(MultiRigDispatch|MultiRigEpicAutoResolve|ConvoyFlagRejection|EpicFlagRejection|EpicDetection|MixedBatchRejection|MultiRigConvoyAutoResolve))$' \
+            ./internal/cmd || status=1
+
+          gotestsum --format testname --junitfile junit-scheduler-3.xml -- \
+            -tags='integration scheduler_integration' -timeout=20m -v \
+            -run '^(TestScheduler(DisabledMode|DirectModeNoQueue|DeferredTaskWithoutRig|DeferredNonRigRejection|DeferredAcceptsDogTarget|DirectEpicDispatch|BatchEpicRejection))$' \
+            ./internal/cmd || status=1
+
+          gotestsum --format testname --junitfile junit-scheduler-4.xml -- \
+            -tags='integration scheduler_integration' -timeout=20m -v \
+            -run '^(TestScheduler(InvalidJSONContextCleanup|ActualDispatchRoutesPollutedEnvToTargetRig|FormulaDispatchRoutesPollutedEnvToTargetRig|DispatchFailureRecordedInContextSourceDB|DirectConvoyDispatch)|TestScheduleBead_(RefusesClosed|RefusesTombstone|ClosedForceDoesNotBypass))$' \
+            ./internal/cmd || status=1
+
+          exit "$status"

--- a/internal/beads/beads_agent.go
+++ b/internal/beads/beads_agent.go
@@ -9,8 +9,10 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"time"
 
 	"github.com/gofrs/flock"
+	beadsdk "github.com/steveyegge/beads"
 
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/telemetry"
@@ -218,13 +220,15 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 	target := b.agentBeadTarget()
 	targetDir := target.getResolvedBeadsDir()
 
-	// Ensure target database has custom types configured.
-	// This is cached (sentinel file + in-memory) so repeated calls are fast.
-	// On fresh rigs, this may fail if the database can't be initialized.
-	// Don't bail out — try the bd create calls anyway (GH#1769).
-	_ = EnsureCustomTypes(targetDir)
-
 	description := FormatAgentDescription(title, fields)
+	if issue, err := target.createAgentBeadViaStore(context.Background(), id, title, description); err == nil {
+		return issue, nil
+	}
+
+	// Ensure target database has custom types configured before falling back to
+	// the bd CLI. The store path above avoids stale external bd schema during
+	// fresh install; this remains for older stores or non-server configurations.
+	_ = EnsureCustomTypes(targetDir)
 
 	buildArgs := func() []string {
 		a := []string{"create", "--json",
@@ -262,6 +266,33 @@ func (b *Beads) CreateAgentBead(id, title string, fields *AgentFields) (*Issue, 
 	// Note: hook_bead slot no longer set - bd slot removed in v0.62 (hq-l6mm5)
 
 	return &issue, nil
+}
+
+func (b *Beads) createAgentBeadViaStore(ctx context.Context, id, title, description string) (*Issue, error) {
+	store, cleanup, err := b.OpenStore(ctx)
+	if err != nil {
+		return nil, err
+	}
+	defer cleanup()
+
+	now := time.Now().UTC()
+	actor := b.getActor()
+	issue := &beadsdk.Issue{
+		ID:          id,
+		Title:       title,
+		Description: description,
+		Status:      beadsdk.StatusOpen,
+		Priority:    2,
+		IssueType:   beadsdk.TypeTask,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		CreatedBy:   actor,
+		Labels:      []string{"gt:agent"},
+	}
+	if err := store.CreateIssue(ctx, issue, actor); err != nil {
+		return nil, err
+	}
+	return sdkIssueToIssue(issue), nil
 }
 
 // CreateOrReopenAgentBead creates an agent bead or reopens an existing one.

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -197,6 +197,63 @@ func TestBuildPinnedBDEnvPinsRigDatabaseInsideTown(t *testing.T) {
 	}
 }
 
+func TestBuildPinnedBDEnvFollowsRedirectBeforeMetadata(t *testing.T) {
+	rigRoot := t.TempDir()
+	rigBeadsDir := filepath.Join(rigRoot, ".beads")
+	canonicalBeadsDir := filepath.Join(rigRoot, "mayor", "rig", ".beads")
+	for _, dir := range []string{rigBeadsDir, canonicalBeadsDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(rigBeadsDir, "redirect"), []byte("mayor/rig/.beads\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(rigBeadsDir, "metadata.json"), []byte(`{"dolt_database":"hq","dolt_server_host":"wrong-host","dolt_server_port":9999}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(canonicalBeadsDir, "metadata.json"), []byte(`{"dolt_database":"gastown","dolt_server_host":"127.0.0.2","dolt_server_port":4407}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := BuildPinnedBDEnv([]string{
+		"PATH=/usr/bin",
+		"BEADS_DIR=/wrong",
+		"BEADS_DOLT_SERVER_DATABASE=hq",
+		"BEADS_DOLT_DATA_DIR=/wrong/data",
+	}, rigBeadsDir)
+	got := envMap(env)
+
+	if got["BEADS_DIR"] != canonicalBeadsDir {
+		t.Fatalf("BEADS_DIR = %q, want canonical %q in %v", got["BEADS_DIR"], canonicalBeadsDir, env)
+	}
+	if got["BEADS_DOLT_SERVER_DATABASE"] != "gastown" {
+		t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want gastown in %v", got["BEADS_DOLT_SERVER_DATABASE"], env)
+	}
+	if got["BEADS_DOLT_SERVER_HOST"] != "127.0.0.2" || got["BEADS_DOLT_SERVER_PORT"] != "4407" || got["BEADS_DOLT_PORT"] != "4407" {
+		t.Fatalf("connection env used stale redirect metadata: %v", env)
+	}
+	if _, ok := got["BEADS_DOLT_DATA_DIR"]; ok {
+		t.Fatalf("BEADS_DOLT_DATA_DIR should be stripped in %v", env)
+	}
+
+	routingEnv := BuildRoutingBDEnv([]string{
+		"PATH=/usr/bin",
+		"BEADS_DIR=/wrong",
+		"BEADS_DOLT_SERVER_DATABASE=hq",
+	}, rigBeadsDir)
+	routingGot := envMap(routingEnv)
+	if _, ok := routingGot["BEADS_DIR"]; ok {
+		t.Fatalf("routing env should not set BEADS_DIR: %v", routingEnv)
+	}
+	if _, ok := routingGot["BEADS_DOLT_SERVER_DATABASE"]; ok {
+		t.Fatalf("routing env should not set BEADS_DOLT_SERVER_DATABASE: %v", routingEnv)
+	}
+	if routingGot["BEADS_DOLT_SERVER_HOST"] != "127.0.0.2" || routingGot["BEADS_DOLT_SERVER_PORT"] != "4407" || routingGot["BEADS_DOLT_PORT"] != "4407" {
+		t.Fatalf("routing env should use canonical connection metadata: %v", routingEnv)
+	}
+}
+
 func TestBuildPinnedBDEnvStripsCaseVariantTargetEnvWhenKeysAreCaseInsensitive(t *testing.T) {
 	withCaseInsensitiveEnvKeys(t)
 

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -167,6 +167,36 @@ func TestBuildPinnedBDEnvUsesSelectedConnectionMetadata(t *testing.T) {
 	}
 }
 
+func TestBuildPinnedBDEnvPinsRigDatabaseInsideTown(t *testing.T) {
+	townDir := t.TempDir()
+	beadsDir := filepath.Join(townDir, "minime", ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := []byte(`{"dolt_database":"minime","dolt_server_host":"127.0.0.1","dolt_server_port":4407}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	env := BuildPinnedBDEnv([]string{
+		"PATH=/usr/bin",
+		"BEADS_DIR=" + filepath.Join(townDir, ".beads"),
+		"BEADS_DOLT_SERVER_DATABASE=hq",
+		"BEADS_DOLT_DATA_DIR=" + filepath.Join(townDir, ".dolt-data"),
+	}, beadsDir)
+	got := envMap(env)
+
+	if got["BEADS_DIR"] != beadsDir {
+		t.Fatalf("BEADS_DIR = %q, want %q in %v", got["BEADS_DIR"], beadsDir, env)
+	}
+	if got["BEADS_DOLT_SERVER_DATABASE"] != "minime" {
+		t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want minime in %v", got["BEADS_DOLT_SERVER_DATABASE"], env)
+	}
+	if value, ok := got["BEADS_DOLT_DATA_DIR"]; ok {
+		t.Fatalf("BEADS_DOLT_DATA_DIR should be stripped, got %q in %v", value, env)
+	}
+}
+
 func TestBuildPinnedBDEnvStripsCaseVariantTargetEnvWhenKeysAreCaseInsensitive(t *testing.T) {
 	withCaseInsensitiveEnvKeys(t)
 

--- a/internal/beads/beads_test.go
+++ b/internal/beads/beads_test.go
@@ -366,12 +366,24 @@ func TestBuildMutationBDEnvForcesWritableCommit(t *testing.T) {
 
 func TestArgsAreReadOnlyClassifiesKnownReadCommands(t *testing.T) {
 	cases := [][]string{
+		{"--version"},
+		{"--help"},
 		{"show", "gt-123", "--json"},
 		{"--allow-stale", "show", "gt-123", "--json"},
+		{"search", "term", "--json"},
 		{"query", "merge-request", "--json"},
 		{"dep", "list", "hq-cv-123", "--json"},
+		{"formula", "list"},
+		{"formula", "show", "mol-polecat-work"},
+		{"kv", "get", "key"},
+		{"kv", "list"},
+		{"message", "thread", "hq-msg", "--json"},
+		{"mol", "current", "--json"},
 		{"mol", "wisp", "list", "--json"},
 		{"sql", "SELECT 1"},
+		{"sql", "SHOW TABLES"},
+		{"sql", "EXPLAIN SELECT 1"},
+		{"sql", "DESCRIBE dependencies"},
 		{"sql", "--csv", "SELECT 1"},
 		{"config", "get", "issue_prefix"},
 	}
@@ -387,10 +399,25 @@ func TestArgsAreReadOnlyClassifiesKnownReadCommands(t *testing.T) {
 
 func TestArgsAreReadOnlyFailsClosedForMutations(t *testing.T) {
 	cases := [][]string{
+		{"--db", "hq", "show", "gt-123"},
+		{"--directory", "/tmp", "list"},
+		{"--repo", "gastown", "show", "gt-123"},
+		{"--unknown", "show", "gt-123"},
 		{"update", "gt-123", "--status=open"},
 		{"close", "gt-123"},
+		{"label", "add", "gt-123", "read"},
+		{"message", "send", "mayor", "--body", "hi"},
+		{"formula", "cook", "mol-polecat-work"},
+		{"kv", "set", "key", "value"},
 		{"mol", "wisp", "formula"},
+		{"mol", "wisp", "create", "mol-test"},
 		{"sql", "UPDATE issues SET status='open'"},
+		{"sql", "DELETE FROM issues"},
+		{"sql", "INSERT INTO issues (id) VALUES ('gt-1')"},
+		{"sql", "WITH x AS (SELECT 1) SELECT * FROM x"},
+		{"sql", "WITH x AS (SELECT 1) UPDATE issues SET status='open'"},
+		{"sql", "WITH x AS (SELECT 1) DELETE FROM issues"},
+		{"sql", "WITH x AS (SELECT 1) INSERT INTO issues (id) VALUES ('gt-1')"},
 		{"config", "set", "issue_prefix", "gt"},
 	}
 	for _, args := range cases {

--- a/internal/beads/beads_types.go
+++ b/internal/beads/beads_types.go
@@ -178,6 +178,33 @@ func EnsureCustomTypes(beadsDir string) error {
 	return nil
 }
 
+// EnsureCustomTypesConfigYAML records Gas Town custom types directly in
+// config.yaml. Fresh install uses this before invoking any bd config command so
+// older cached bd binaries do not initialize legacy views against the new schema.
+func EnsureCustomTypesConfigYAML(beadsDir string) error {
+	if beadsDir == "" {
+		return fmt.Errorf("empty beads directory")
+	}
+	if _, err := os.Stat(beadsDir); os.IsNotExist(err) {
+		return fmt.Errorf("beads directory does not exist: %s", beadsDir)
+	}
+
+	typesList := strings.Join(constants.BeadsCustomTypesList(), ",")
+
+	ensuredMu.Lock()
+	defer ensuredMu.Unlock()
+
+	if ensuredDirs[beadsDir] {
+		return nil
+	}
+	if err := EnsureConfigYAMLValue(beadsDir, "types.custom", typesList); err != nil {
+		return err
+	}
+	_ = os.WriteFile(filepath.Join(beadsDir, typesSentinel), []byte(typesList+"\n"), 0644)
+	ensuredDirs[beadsDir] = true
+	return nil
+}
+
 // EnsureCustomStatuses ensures the target beads directory has custom statuses configured.
 // Uses the same two-level caching strategy as EnsureCustomTypes:
 //   - In-memory cache for multiple operations in the same CLI invocation

--- a/internal/beads/config_sql.go
+++ b/internal/beads/config_sql.go
@@ -1,0 +1,57 @@
+package beads
+
+import (
+	"database/sql"
+	"fmt"
+	"net"
+	"net/url"
+	"os"
+	"strconv"
+
+	_ "github.com/go-sql-driver/mysql"
+)
+
+// EnsureDoltConfigValue writes a config key directly to the configured Dolt
+// database. Fresh setup uses this to avoid older bd config/schema bootstrap paths.
+func EnsureDoltConfigValue(beadsDir, key, value string) error {
+	if beadsDir == "" {
+		return fmt.Errorf("empty beads directory")
+	}
+	database := DatabaseNameFromMetadata(beadsDir)
+	if database == "" {
+		return fmt.Errorf("missing dolt_database in %s", beadsDir)
+	}
+	meta := readDoltMetadata(beadsDir)
+	host := meta.Host
+	if host == "" {
+		host = os.Getenv("GT_DOLT_HOST")
+	}
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	port := meta.Port
+	if port == "" {
+		port = os.Getenv("BEADS_DOLT_SERVER_PORT")
+	}
+	if port == "" {
+		port = os.Getenv("BEADS_DOLT_PORT")
+	}
+	if port == "" {
+		port = os.Getenv("GT_DOLT_PORT")
+	}
+	if port == "" {
+		port = "3307"
+	}
+	if _, err := strconv.Atoi(port); err != nil {
+		return fmt.Errorf("invalid Dolt port %q: %w", port, err)
+	}
+
+	dsn := fmt.Sprintf("root@tcp(%s)/%s?parseTime=true", net.JoinHostPort(host, port), url.PathEscape(database))
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		return err
+	}
+	defer db.Close()
+	_, err = db.Exec("REPLACE INTO config (`key`, `value`) VALUES (?, ?)", key, value)
+	return err
+}

--- a/internal/beads/config_yaml.go
+++ b/internal/beads/config_yaml.go
@@ -2,6 +2,7 @@ package beads
 
 import (
 	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -11,6 +12,50 @@ import (
 // beads namespace. Existing non-prefix settings are preserved.
 func EnsureConfigYAML(beadsDir, prefix string) error {
 	return ensureConfigYAML(beadsDir, prefix, false)
+}
+
+// EnsureConfigYAMLValue ensures config.yaml contains key: value while preserving
+// existing unrelated settings. It is used for install-time settings that must be
+// present before older bd binaries can safely open the Dolt schema.
+func EnsureConfigYAMLValue(beadsDir, key, value string) error {
+	key = strings.TrimSpace(key)
+	if key == "" {
+		return fmt.Errorf("empty config key")
+	}
+	wantLine := key + ": " + value
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	data, err := os.ReadFile(configPath)
+	if os.IsNotExist(err) {
+		return os.WriteFile(configPath, []byte(wantLine+"\n"), 0644)
+	}
+	if err != nil {
+		return err
+	}
+
+	content := strings.ReplaceAll(string(data), "\r\n", "\n")
+	lines := strings.Split(content, "\n")
+	found := false
+	for i, line := range lines {
+		if strings.HasPrefix(strings.TrimSpace(line), key+":") {
+			lines[i] = wantLine
+			found = true
+		}
+	}
+	if !found {
+		if len(lines) > 0 && lines[len(lines)-1] == "" {
+			lines = lines[:len(lines)-1]
+		}
+		lines = append(lines, wantLine)
+	}
+
+	newContent := strings.Join(lines, "\n")
+	if !strings.HasSuffix(newContent, "\n") {
+		newContent += "\n"
+	}
+	if newContent == content {
+		return nil
+	}
+	return os.WriteFile(configPath, []byte(newContent), 0644)
 }
 
 // EnsureConfigYAMLIfMissing creates config.yaml with the required defaults when

--- a/internal/beads/config_yaml_test.go
+++ b/internal/beads/config_yaml_test.go
@@ -135,6 +135,39 @@ func TestEnsureConfigYAML_DisablesAutoExport(t *testing.T) {
 	}
 }
 
+func TestEnsureConfigYAMLValue(t *testing.T) {
+	beadsDir := t.TempDir()
+	configPath := filepath.Join(beadsDir, "config.yaml")
+	if err := os.WriteFile(configPath, []byte("prefix: hq\ntypes.custom: old\n"), 0644); err != nil {
+		t.Fatalf("write config.yaml: %v", err)
+	}
+
+	if err := EnsureConfigYAMLValue(beadsDir, "types.custom", "agent,role"); err != nil {
+		t.Fatalf("EnsureConfigYAMLValue replace: %v", err)
+	}
+	if err := EnsureConfigYAMLValue(beadsDir, "allowed_prefixes", "hq,hq-cv"); err != nil {
+		t.Fatalf("EnsureConfigYAMLValue append: %v", err)
+	}
+
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("read config.yaml: %v", err)
+	}
+	got := string(data)
+	for _, want := range []string{
+		"prefix: hq\n",
+		"types.custom: agent,role\n",
+		"allowed_prefixes: hq,hq-cv\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("config.yaml missing %q:\n%s", want, got)
+		}
+	}
+	if strings.Contains(got, "types.custom: old") {
+		t.Fatalf("config.yaml kept stale value:\n%s", got)
+	}
+}
+
 func TestConfigYAMLDisablesAutoExport(t *testing.T) {
 	tests := []struct {
 		name    string

--- a/internal/beads/database.go
+++ b/internal/beads/database.go
@@ -21,6 +21,10 @@ var bdTargetEnvKeys = []string{
 // DatabaseNameFromMetadata reads the dolt_database field from .beads/metadata.json.
 // Returns empty string if metadata doesn't exist or has no database configured.
 func DatabaseNameFromMetadata(beadsDir string) string {
+	beadsDir = canonicalBeadsDir(beadsDir)
+	if beadsDir == "" {
+		return ""
+	}
 	data, err := os.ReadFile(filepath.Join(beadsDir, "metadata.json"))
 	if err != nil {
 		return ""
@@ -81,6 +85,7 @@ func BuildPinnedBDEnv(base []string, beadsDir string) []string {
 	if beadsDir == "" {
 		return addGTDerivedDoltTargetEnv(env)
 	}
+	beadsDir = canonicalBeadsDir(beadsDir)
 	env = append(env, "BEADS_DIR="+beadsDir)
 	env = append(env, doltTargetEnvFromBeadsDir(beadsDir)...)
 	if dbEnv := DatabaseEnv(beadsDir); dbEnv != "" {
@@ -94,6 +99,7 @@ func BuildPinnedBDEnv(base []string, beadsDir string) []string {
 // connection host/port from fallbackBeadsDir so routing can choose the database.
 func BuildRoutingBDEnv(base []string, fallbackBeadsDir string) []string {
 	env := SuppressBDSideEffects(StripBDTargetEnv(base))
+	fallbackBeadsDir = canonicalBeadsDir(fallbackBeadsDir)
 	env = append(env, doltTargetEnvFromBeadsDir(fallbackBeadsDir)...)
 	return addGTDerivedDoltTargetEnv(env)
 }
@@ -251,6 +257,7 @@ func forceBDMutation(env []string) []string {
 }
 
 func doltTargetEnvFromBeadsDir(beadsDir string) []string {
+	beadsDir = canonicalBeadsDir(beadsDir)
 	if beadsDir == "" {
 		return nil
 	}
@@ -273,6 +280,10 @@ type doltMetadata struct {
 
 func readDoltMetadata(beadsDir string) doltMetadata {
 	var meta doltMetadata
+	beadsDir = canonicalBeadsDir(beadsDir)
+	if beadsDir == "" {
+		return meta
+	}
 	if data, err := os.ReadFile(filepath.Join(beadsDir, "dolt-server.port")); err == nil {
 		meta.Port = strings.TrimSpace(string(data))
 	}
@@ -292,6 +303,13 @@ func readDoltMetadata(beadsDir string) doltMetadata {
 		meta.Port = strconv.Itoa(raw.DoltServerPort)
 	}
 	return meta
+}
+
+func canonicalBeadsDir(beadsDir string) string {
+	if beadsDir == "" {
+		return ""
+	}
+	return ResolveBeadsDir(beadsDir)
 }
 
 // StripEnvKey removes all entries for key. Environment keys are case-insensitive

--- a/internal/beads/database.go
+++ b/internal/beads/database.go
@@ -134,20 +134,36 @@ func BuildMutationNeutralBDEnv(base []string) []string {
 // ArgsAreReadOnly classifies bd CLI arguments for env policy. Unknown commands
 // are treated as mutations so they cannot accidentally inherit read-only mode.
 func ArgsAreReadOnly(args []string) bool {
-	args = stripBDGlobalFlags(args)
+	if len(args) == 1 && isBDReadOnlyGlobalFlag(args[0]) {
+		return true
+	}
+	if HasBDTargetSelectorFlag(append([]string{"bd"}, args...)) {
+		return false
+	}
+	var ok bool
+	args, ok = stripBDGlobalFlags(args)
+	if !ok {
+		return false
+	}
 	if len(args) == 0 {
 		return false
 	}
 	switch args[0] {
-	case "show", "list", "ready", "blocked", "stats", "stale", "orphans", "activity", "query", "version":
+	case "show", "list", "ready", "blocked", "stats", "stale", "orphans", "activity", "query", "search", "version", "help":
 		return true
 	case "dep":
 		return len(args) > 1 && args[1] == "list"
+	case "formula":
+		return len(args) > 1 && (args[1] == "list" || args[1] == "show")
+	case "kv":
+		return len(args) > 1 && (args[1] == "get" || args[1] == "list")
+	case "message":
+		return len(args) > 1 && args[1] == "thread"
 	case "mol":
-		return len(args) > 2 && args[1] == "wisp" && args[2] == "list"
+		return len(args) > 1 && (args[1] == "current" || (len(args) > 2 && args[1] == "wisp" && args[2] == "list"))
 	case "sql":
 		query := strings.ToLower(strings.Join(stripBDCommandFlags(args[1:]), " "))
-		return strings.HasPrefix(strings.TrimSpace(query), "select")
+		return hasReadOnlySQLPrefix(strings.TrimSpace(query))
 	case "config":
 		return len(args) > 1 && args[1] == "get"
 	default:
@@ -155,11 +171,28 @@ func ArgsAreReadOnly(args []string) bool {
 	}
 }
 
-func stripBDGlobalFlags(args []string) []string {
+func isBDReadOnlyGlobalFlag(arg string) bool {
+	return arg == "--version" || arg == "-V" || arg == "--help" || arg == "-h"
+}
+
+func stripBDGlobalFlags(args []string) ([]string, bool) {
 	for len(args) > 0 && strings.HasPrefix(args[0], "--") {
+		if args[0] == "--" {
+			return nil, false
+		}
+		name := args[0]
+		if cut, _, hasValue := strings.Cut(name, "="); hasValue {
+			name = cut
+		}
+		if !bdBoolGlobalFlags[name] {
+			return nil, false
+		}
 		args = args[1:]
 	}
-	return args
+	if len(args) > 0 && strings.HasPrefix(args[0], "-") {
+		return nil, false
+	}
+	return args, true
 }
 
 func stripBDCommandFlags(args []string) []string {
@@ -167,6 +200,15 @@ func stripBDCommandFlags(args []string) []string {
 		args = args[1:]
 	}
 	return args
+}
+
+func hasReadOnlySQLPrefix(query string) bool {
+	for _, prefix := range []string{"select", "show", "explain", "describe"} {
+		if strings.HasPrefix(query, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 // SuppressBDSideEffects disables Beads JSONL export/backup/push side effects for

--- a/internal/cmd/bd_helpers.go
+++ b/internal/cmd/bd_helpers.go
@@ -118,29 +118,9 @@ func filterEnvKey(env []string, key string) []string {
 	return beads.StripEnvKey(env, key)
 }
 
-func filterBdTargetEnv(env []string) []string {
-	return beads.StripBDTargetEnv(env)
-}
-
-func pinBeadsDirEnv(env []string, beadsDir string) []string {
-	if beadsDir == "" {
-		return beads.StripBDTargetEnv(env)
-	}
-	return beads.BuildPinnedBDEnv(env, beadsDir)
-}
-
 // buildEnv constructs the final environment slice based on configured options.
 func (b *bdCmd) buildEnv() []string {
-	env := b.env
-
-	// Add BD_DOLT_AUTO_COMMIT=on for sequential dependent calls.
-	// Filter existing entries first — glibc getenv() returns the first match,
-	// so an existing "off" entry would shadow the appended "on".
-	if b.autoCommit {
-		env = filterEnvKey(env, "BD_DOLT_AUTO_COMMIT")
-		env = filterEnvKey(env, "BD_READONLY")
-		env = append(env, "BD_DOLT_AUTO_COMMIT=on")
-	}
+	env := append([]string{}, b.env...)
 
 	// Add GT_ROOT if specified.
 	// Filter existing entries first for the same reason as above.
@@ -149,25 +129,31 @@ func (b *bdCmd) buildEnv() []string {
 		env = append(env, "GT_ROOT="+b.gtRoot)
 	}
 
-	// Add BEADS_DIR if specified.
-	// This prevents inherited BEADS_DIR from causing bd to target the wrong
-	// database (e.g., HQ instead of rig). See gt-ctir.
-	//
-	// Also clear inherited Dolt target variables. Dashboard and agent shells can
-	// carry a town-level or remote BEADS_DOLT_* target; keeping it while changing
-	// BEADS_DIR makes `bd show <displayed-id>` query a different database than
-	// `gt ready` used to render the row.
-	if b.routing {
-		env = beads.BuildRoutingBDEnv(env, beads.ResolveBeadsDir(b.dir))
-	} else if b.beadsDir != "" {
-		env = pinBeadsDirEnv(env, b.beadsDir)
-	} else if b.dir != "" {
-		env = pinBeadsDirEnv(env, beads.ResolveBeadsDir(b.dir))
-	} else {
-		env = beads.SuppressBDSideEffects(beads.StripBDTargetEnv(env))
+	mode := beads.MutationRouting
+	if beads.ArgsAreReadOnly(b.args) && !b.autoCommit {
+		mode = beads.ReadOnlyRouting
 	}
 
-	return env
+	beadsDir := ""
+	if b.beadsDir != "" {
+		beadsDir = b.beadsDir
+		if mode == beads.ReadOnlyRouting {
+			mode = beads.ReadOnlyPinned
+		} else {
+			mode = beads.MutationPinned
+		}
+	} else if b.dir != "" {
+		beadsDir = beads.ResolveBeadsDir(b.dir)
+		if !b.routing {
+			if mode == beads.ReadOnlyRouting {
+				mode = beads.ReadOnlyPinned
+			} else {
+				mode = beads.MutationPinned
+			}
+		}
+	}
+
+	return beads.EnvForSubprocessMode(env, beadsDir, mode)
 }
 
 // Build returns the configured exec.Cmd.

--- a/internal/cmd/bd_helpers_test.go
+++ b/internal/cmd/bd_helpers_test.go
@@ -547,6 +547,52 @@ func TestBdCmd_DirPinsMetadataDatabaseOverInheritedDefault(t *testing.T) {
 	}
 }
 
+func TestBdCmd_WithBeadsDirFollowsRedirectBeforeMetadata(t *testing.T) {
+	rigRoot := t.TempDir()
+	redirectBeadsDir := filepath.Join(rigRoot, ".beads")
+	canonicalBeadsDir := filepath.Join(rigRoot, "mayor", "rig", ".beads")
+	for _, dir := range []string{redirectBeadsDir, canonicalBeadsDir} {
+		if err := os.MkdirAll(dir, 0755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := os.WriteFile(filepath.Join(redirectBeadsDir, "redirect"), []byte("mayor/rig/.beads\n"), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(redirectBeadsDir, "metadata.json"), []byte(`{"dolt_database":"hq","dolt_server_host":"wrong-host","dolt_server_port":9999}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(canonicalBeadsDir, "metadata.json"), []byte(`{"dolt_database":"gastown","dolt_server_host":"127.0.0.2","dolt_server_port":4407}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	bdc := &bdCmd{
+		args: []string{"show", "gt-abc", "--json"},
+		env: []string{
+			"PATH=/usr/bin",
+			"BEADS_DIR=/town/.beads",
+			"BEADS_DOLT_SERVER_DATABASE=hq",
+			"BEADS_DOLT_DATA_DIR=/wrong/data",
+		},
+		stderr: os.Stderr,
+	}
+	cmd := bdc.WithBeadsDir(redirectBeadsDir).Build()
+	envMap := parseEnv(cmd.Env)
+
+	if envMap["BEADS_DIR"] != canonicalBeadsDir {
+		t.Fatalf("BEADS_DIR = %q, want canonical %q in %v", envMap["BEADS_DIR"], canonicalBeadsDir, cmd.Env)
+	}
+	if envMap["BEADS_DOLT_SERVER_DATABASE"] != "gastown" {
+		t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want gastown in %v", envMap["BEADS_DOLT_SERVER_DATABASE"], cmd.Env)
+	}
+	if envMap["BEADS_DOLT_SERVER_HOST"] != "127.0.0.2" || envMap["BEADS_DOLT_SERVER_PORT"] != "4407" || envMap["BEADS_DOLT_PORT"] != "4407" {
+		t.Fatalf("connection env used stale redirect metadata: %v", cmd.Env)
+	}
+	if _, ok := envMap["BEADS_DOLT_DATA_DIR"]; ok {
+		t.Fatalf("BEADS_DOLT_DATA_DIR should be stripped in %v", cmd.Env)
+	}
+}
+
 func TestBdCmd_WithBeadsDir_OverridesInherited(t *testing.T) {
 	// WithBeadsDir should override an inherited BEADS_DIR from the parent
 	// process. This is the core fix for gt-ctir: without overriding,

--- a/internal/cmd/bd_helpers_test.go
+++ b/internal/cmd/bd_helpers_test.go
@@ -747,6 +747,99 @@ func TestBdCmd_WithRoutingDoesNotPinBeadsDir(t *testing.T) {
 	}
 }
 
+func TestBdCmd_UsesCentralReadMutationModes(t *testing.T) {
+	rigDir := t.TempDir()
+	beadsDir := filepath.Join(rigDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	metadata := []byte(`{"dolt_database":"rigdb","dolt_server_host":"127.0.0.1","dolt_server_port":3307}`)
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
+		t.Fatal(err)
+	}
+	baseEnv := []string{
+		"PATH=/usr/bin",
+		"BEADS_DIR=/wrong",
+		"BEADS_DOLT_SERVER_DATABASE=hq",
+		"BD_DOLT_AUTO_COMMIT=off",
+		"BD_READONLY=false",
+	}
+
+	tests := []struct {
+		name           string
+		setup          func() *bdCmd
+		wantPinned     bool
+		wantReadOnly   bool
+		wantAutoCommit string
+	}{
+		{
+			name: "read pinned via Dir",
+			setup: func() *bdCmd {
+				return (&bdCmd{args: []string{"show", "gt-abc"}, env: append([]string{}, baseEnv...), stderr: os.Stderr}).Dir(rigDir)
+			},
+			wantPinned:     true,
+			wantReadOnly:   true,
+			wantAutoCommit: "off",
+		},
+		{
+			name: "mutation pinned via WithBeadsDir",
+			setup: func() *bdCmd {
+				return (&bdCmd{args: []string{"update", "gt-abc", "--status=open"}, env: append([]string{}, baseEnv...), stderr: os.Stderr}).WithBeadsDir(beadsDir)
+			},
+			wantPinned:     true,
+			wantAutoCommit: "on",
+		},
+		{
+			name: "read routing",
+			setup: func() *bdCmd {
+				return (&bdCmd{args: []string{"message", "thread", "hq-msg"}, env: append([]string{}, baseEnv...), stderr: os.Stderr}).Dir(rigDir).WithRouting()
+			},
+			wantReadOnly:   true,
+			wantAutoCommit: "off",
+		},
+		{
+			name: "auto commit forces mutation for read args",
+			setup: func() *bdCmd {
+				return (&bdCmd{args: []string{"show", "gt-abc"}, env: append([]string{}, baseEnv...), stderr: os.Stderr}).Dir(rigDir).WithAutoCommit()
+			},
+			wantPinned:     true,
+			wantAutoCommit: "on",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			cmd := tt.setup().Build()
+			envMap := parseEnv(cmd.Env)
+			if tt.wantPinned {
+				if envMap["BEADS_DIR"] != beadsDir {
+					t.Fatalf("BEADS_DIR = %q, want %q in %v", envMap["BEADS_DIR"], beadsDir, cmd.Env)
+				}
+				if envMap["BEADS_DOLT_SERVER_DATABASE"] != "rigdb" {
+					t.Fatalf("BEADS_DOLT_SERVER_DATABASE = %q, want rigdb in %v", envMap["BEADS_DOLT_SERVER_DATABASE"], cmd.Env)
+				}
+			} else {
+				if value, ok := envMap["BEADS_DIR"]; ok {
+					t.Fatalf("BEADS_DIR should be absent for routing command, got %q in %v", value, cmd.Env)
+				}
+				if value, ok := envMap["BEADS_DOLT_SERVER_DATABASE"]; ok {
+					t.Fatalf("BEADS_DOLT_SERVER_DATABASE should be absent for routing command, got %q in %v", value, cmd.Env)
+				}
+			}
+			if envMap["BD_DOLT_AUTO_COMMIT"] != tt.wantAutoCommit {
+				t.Fatalf("BD_DOLT_AUTO_COMMIT = %q, want %q in %v", envMap["BD_DOLT_AUTO_COMMIT"], tt.wantAutoCommit, cmd.Env)
+			}
+			if tt.wantReadOnly {
+				if envMap["BD_READONLY"] != "true" {
+					t.Fatalf("BD_READONLY = %q, want true in %v", envMap["BD_READONLY"], cmd.Env)
+				}
+			} else if value, ok := envMap["BD_READONLY"]; ok {
+				t.Fatalf("BD_READONLY should be absent for mutation command, got %q in %v", value, cmd.Env)
+			}
+		})
+	}
+}
+
 func TestBdCmd_StripBeadsDir_Chaining(t *testing.T) {
 	bdc := BdCmd("test")
 	if bdc.StripBeadsDir() != bdc {

--- a/internal/cmd/capacity_dispatch.go
+++ b/internal/cmd/capacity_dispatch.go
@@ -559,6 +559,14 @@ func dispatchSingleBead(b capacity.PendingBead, townRoot, _ string) (*SlingResul
 	}
 
 	dp := capacity.ReconstructFromContext(b.Context)
+	targetBeadsDir := filepath.Join(townRoot, ".beads")
+	if dp.RigName != "" {
+		resolved, ok := beads.ResolveRepoAliasBeadsDir(townRoot, dp.RigName)
+		if !ok {
+			return nil, fmt.Errorf("cannot resolve target rig %q beads database for %s", dp.RigName, b.WorkBeadID)
+		}
+		targetBeadsDir = resolved
+	}
 	params := SlingParams{
 		BeadID:           dp.BeadID,
 		RigName:          dp.RigName,
@@ -579,7 +587,7 @@ func dispatchSingleBead(b capacity.PendingBead, townRoot, _ string) (*SlingResul
 		NoConvoy:         true,
 		NoBoot:           true,
 		TownRoot:         townRoot,
-		BeadsDir:         filepath.Join(townRoot, ".beads"),
+		BeadsDir:         targetBeadsDir,
 	}
 
 	fmt.Printf("  Dispatching %s → %s...\n", b.WorkBeadID, b.TargetRig)

--- a/internal/cmd/config_test.go
+++ b/internal/cmd/config_test.go
@@ -874,6 +874,44 @@ func TestConfigSetGet(t *testing.T) {
 	})
 }
 
+func TestSchedulerConfigSetZero(t *testing.T) {
+	townRoot := setupTestTownForConfig(t)
+	settingsPath := config.TownSettingsPath(townRoot)
+
+	originalWd, _ := os.Getwd()
+	defer os.Chdir(originalWd)
+	if err := os.Chdir(townRoot); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+
+	cmd := &cobra.Command{}
+	if err := runConfigSet(cmd, []string{"scheduler.max_polecats", "0"}); err != nil {
+		t.Fatalf("runConfigSet failed: %v", err)
+	}
+
+	loaded, err := config.LoadOrCreateTownSettings(settingsPath)
+	if err != nil {
+		t.Fatalf("load settings: %v", err)
+	}
+	if loaded.Scheduler == nil || loaded.Scheduler.MaxPolecats == nil {
+		t.Fatal("scheduler.max_polecats was not persisted")
+	}
+	if got := loaded.Scheduler.GetMaxPolecats(); got != 0 {
+		t.Fatalf("persisted scheduler.max_polecats = %d, want 0", got)
+	}
+
+	var getErr error
+	out := captureStdout(t, func() {
+		getErr = runConfigGet(cmd, []string{"scheduler.max_polecats"})
+	})
+	if getErr != nil {
+		t.Fatalf("runConfigGet failed: %v", getErr)
+	}
+	if strings.TrimSpace(out) != "0" {
+		t.Fatalf("config get scheduler.max_polecats = %q, want 0", strings.TrimSpace(out))
+	}
+}
+
 func TestConfigMaintenanceSetGet(t *testing.T) {
 	t.Run("set and get maintenance.window", func(t *testing.T) {
 		townRoot := setupTestTownForConfig(t)

--- a/internal/cmd/convoy.go
+++ b/internal/cmd/convoy.go
@@ -2,10 +2,14 @@ package cmd
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
+	"database/sql"
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -449,18 +453,25 @@ func getTownBeadsDir() (string, error) {
 // "exit status 1". BEADS_DIR is stripped from the subprocess environment to
 // prevent stale overrides from interfering with bd's workspace detection.
 func runBdJSON(dir string, args ...string) ([]byte, error) {
-	return runBdJSONWithOptions(dir, false, args...)
+	return runBdJSONWithOptions(dir, false, false, args...)
 }
 
 func runBdJSONAllowStale(dir string, args ...string) ([]byte, error) {
-	return runBdJSONWithOptions(dir, true, args...)
+	return runBdJSONWithOptions(dir, true, false, args...)
 }
 
-func runBdJSONWithOptions(dir string, allowStale bool, args ...string) ([]byte, error) {
+func runBdJSONWithAutoCommit(dir string, args ...string) ([]byte, error) {
+	return runBdJSONWithOptions(dir, false, true, args...)
+}
+
+func runBdJSONWithOptions(dir string, allowStale, autoCommit bool, args ...string) ([]byte, error) {
 	var stdout, stderr bytes.Buffer
 	bdc := BdCmd(args...).Dir(dir).StripBeadsDir().Stderr(&stderr)
 	if allowStale {
 		bdc.AllowStale()
+	}
+	if autoCommit {
+		bdc.WithAutoCommit()
 	}
 	cmd := bdc.Build()
 	cmd.Dir = dir
@@ -492,49 +503,137 @@ func bdDepListRawIDs(dir, issueID, direction, depType string) ([]string, error) 
 		return nil, fmt.Errorf("invalid bead ID: %q", issueID)
 	}
 
-	// The dependency target was historically a single depends_on_id column.
-	// The schema migration split it into typed columns
-	// (depends_on_issue_id / depends_on_wisp_id / depends_on_external), where
-	// cross-database refs live in depends_on_external as "external:<prefix>:<id>".
-	// "down": targets issueID depends on → COALESCE the three target columns.
-	// "up":   issues that depend on issueID → match issueID against all three.
-	var selectExpr, whereClause, parseKey string
+	var parseKey string
 	if direction == "up" {
-		selectExpr = "issue_id"
 		parseKey = "issue_id"
-		whereClause = fmt.Sprintf(
-			"(depends_on_issue_id = '%s' OR depends_on_wisp_id = '%s' OR %s)",
-			issueID, issueID, sqlExternalDepTargetClause(issueID))
 	} else {
-		selectExpr = "COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS depends_on_id"
 		parseKey = "depends_on_id"
-		whereClause = fmt.Sprintf("issue_id = '%s'", issueID)
+	}
+	if depType != "" && !isValidBeadID(depType) {
+		return nil, fmt.Errorf("invalid dep type: %q", depType)
 	}
 
-	query := fmt.Sprintf("SELECT %s FROM dependencies WHERE %s", selectExpr, whereClause)
-	if depType != "" {
-		if !isValidBeadID(depType) {
-			return nil, fmt.Errorf("invalid dep type: %q", depType)
+	if ids, err := bdDepListRawIDsViaDolt(dir, issueID, direction, depType); err == nil {
+		return ids, nil
+	}
+
+	var lastErr error
+	for _, legacy := range []bool{false, true} {
+		query := rawDepSQLLiteral(issueID, direction, depType, legacy)
+		out, err := runBdJSONWithAutoCommit(dir, "sql", query, "--json")
+		if err != nil {
+			lastErr = err
+			continue
 		}
-		query += fmt.Sprintf(" AND type = '%s'", depType)
+		ids, err := parseRawDepRows(out, parseKey)
+		if err != nil {
+			return nil, fmt.Errorf("parsing dep sql for %s: %w", issueID, err)
+		}
+		return ids, nil
 	}
+	return nil, fmt.Errorf("bd sql for deps of %s: %w", issueID, lastErr)
+}
 
-	out, err := runBdJSON(dir, "sql", query, "--json")
+func bdDepListRawIDsViaDolt(dir, issueID, direction, depType string) ([]string, error) {
+	beadsDir := beads.ResolveBeadsDir(dir)
+	cfg, ok := readBeadsRuntimeConfig(beadsDir)
+	if !ok || cfg.Database == "" || cfg.Port == 0 {
+		return nil, fmt.Errorf("missing server metadata for %s", beadsDir)
+	}
+	host := cfg.Host
+	if host == "" {
+		host = "127.0.0.1"
+	}
+	dsn := fmt.Sprintf("root@tcp(%s)/%s?parseTime=true", net.JoinHostPort(host, strconv.Itoa(cfg.Port)), url.PathEscape(cfg.Database))
+	db, err := sql.Open("mysql", dsn)
 	if err != nil {
-		return nil, fmt.Errorf("bd sql for deps of %s: %w", issueID, err)
+		return nil, err
 	}
+	defer db.Close()
 
-	// Parse JSON array of single-column rows
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	typedQuery, typedArgs := rawDepSQLArgs(issueID, direction, depType, false)
+	ids, err := queryRawDepIDs(ctx, db, typedQuery, typedArgs)
+	if err == nil {
+		return ids, nil
+	}
+	legacyQuery, legacyArgs := rawDepSQLArgs(issueID, direction, depType, true)
+	return queryRawDepIDs(ctx, db, legacyQuery, legacyArgs)
+}
+
+func rawDepSQLArgs(issueID, direction, depType string, legacy bool) (string, []any) {
+	var query string
+	var args []any
+	if direction == "up" {
+		if legacy {
+			query = "SELECT issue_id FROM dependencies WHERE depends_on_id = ?"
+			args = append(args, issueID)
+		} else {
+			query = "SELECT issue_id FROM dependencies WHERE (depends_on_issue_id = ? OR depends_on_wisp_id = ? OR depends_on_external LIKE ? ESCAPE '!')"
+			args = append(args, issueID, issueID, "%:"+strings.ReplaceAll(issueID, "_", "!_"))
+		}
+	} else if legacy {
+		query = "SELECT depends_on_id FROM dependencies WHERE issue_id = ?"
+		args = append(args, issueID)
+	} else {
+		query = "SELECT COALESCE(depends_on_issue_id, depends_on_wisp_id, depends_on_external) AS depends_on_id FROM dependencies WHERE issue_id = ?"
+		args = append(args, issueID)
+	}
+	if depType != "" {
+		query += " AND type = ?"
+		args = append(args, depType)
+	}
+	return query, args
+}
+
+func rawDepSQLLiteral(issueID, direction, depType string, legacy bool) string {
+	query, args := rawDepSQLArgs(issueID, direction, depType, legacy)
+	for _, arg := range args {
+		query = strings.Replace(query, "?", "'"+arg.(string)+"'", 1)
+	}
+	return query
+}
+
+func queryRawDepIDs(ctx context.Context, db *sql.DB, query string, args []any) ([]string, error) {
+	rows, err := db.QueryContext(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	seen := make(map[string]bool)
+	var ids []string
+	for rows.Next() {
+		var rawID sql.NullString
+		if err := rows.Scan(&rawID); err != nil {
+			return nil, err
+		}
+		if !rawID.Valid {
+			continue
+		}
+		id := beads.ExtractIssueID(rawID.String)
+		if id != "" && !seen[id] {
+			seen[id] = true
+			ids = append(ids, id)
+		}
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return ids, nil
+}
+
+func parseRawDepRows(out []byte, parseKey string) ([]string, error) {
 	var rows []map[string]string
 	if err := json.Unmarshal(out, &rows); err != nil {
-		return nil, fmt.Errorf("parsing dep sql for %s: %w", issueID, err)
+		return nil, err
 	}
-
 	seen := make(map[string]bool, len(rows))
 	var ids []string
 	for _, row := range rows {
-		rawID := row[parseKey]
-		id := beads.ExtractIssueID(rawID)
+		id := beads.ExtractIssueID(row[parseKey])
 		if id != "" && !seen[id] {
 			seen[id] = true
 			ids = append(ids, id)

--- a/internal/cmd/convoy_stage.go
+++ b/internal/cmd/convoy_stage.go
@@ -218,7 +218,7 @@ The staged convoy can later be launched with 'gt convoy launch'.`,
 func runConvoyStage(cmd *cobra.Command, args []string) error {
 	// Step 1: Validate args.
 	if err := validateStageArgs(args); err != nil {
-		return err
+		return convoyStageError(err)
 	}
 
 	// Step 2: Resolve bead types via bd show for each arg.
@@ -227,7 +227,7 @@ func runConvoyStage(cmd *cobra.Command, args []string) error {
 	for _, arg := range args {
 		result, err := bdShow(arg)
 		if err != nil {
-			return fmt.Errorf("cannot resolve bead %s: %w", arg, err)
+			return convoyStageError(fmt.Errorf("cannot resolve bead %s: %w", arg, err))
 		}
 		if isConvoyIssue(result.IssueType, result.Labels) {
 			beadTypes[arg] = "convoy"
@@ -240,7 +240,7 @@ func runConvoyStage(cmd *cobra.Command, args []string) error {
 	// Step 3: Determine input kind.
 	input, err := resolveInputKind(beadTypes)
 	if err != nil {
-		return err
+		return convoyStageError(err)
 	}
 
 	// Step 3b: Detect re-stage scenario.
@@ -258,7 +258,7 @@ func runConvoyStage(cmd *cobra.Command, args []string) error {
 	// Step 4: Collect beads and deps.
 	beads, deps, err := collectBeads(input)
 	if err != nil {
-		return err
+		return convoyStageError(err)
 	}
 
 	// Step 5: Build the DAG.
@@ -271,11 +271,11 @@ func runConvoyStage(cmd *cobra.Command, args []string) error {
 		slingableIDs := dagSlingableIDs(dag)
 		overlaps, err := findOverlappingConvoys(slingableIDs)
 		if err != nil {
-			return fmt.Errorf("checking for overlapping convoys: %w", err)
+			return convoyStageError(fmt.Errorf("checking for overlapping convoys: %w", err))
 		}
 		autoRestage, autoConvoyID, err := handleOverlappingConvoys(overlaps)
 		if err != nil {
-			return err
+			return convoyStageError(err)
 		}
 		if autoRestage {
 			isRestage = true
@@ -397,6 +397,28 @@ func runConvoyStage(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
+func convoyStageError(err error) error {
+	if err == nil || !convoyStageJSON {
+		return err
+	}
+	out, renderErr := renderJSON(StageResult{
+		Status: "error",
+		Errors: []FindingJSON{{
+			Category: "error",
+			BeadIDs:  []string{},
+			Message:  err.Error(),
+		}},
+		Warnings: []FindingJSON{},
+		Waves:    []WaveJSON{},
+		Tree:     []TreeNodeJSON{},
+	})
+	if renderErr != nil {
+		return renderErr
+	}
+	fmt.Print(out)
+	return err
+}
+
 // runConvoyStageJSON handles the --json output path for convoy staging.
 // It builds a StageResult, marshals it, and prints to stdout.
 // On errors, it still outputs JSON but returns an error for non-zero exit code.
@@ -423,7 +445,7 @@ func runConvoyStageJSON(dag *ConvoyDAG, input *StageInput, errs, warns []Staging
 	// No errors: compute waves and create/update convoy.
 	waves, gated, err := computeWaves(dag)
 	if err != nil {
-		return err
+		return convoyStageError(err)
 	}
 
 	// Append validation bead as final wave (epic input only).
@@ -432,7 +454,7 @@ func runConvoyStageJSON(dag *ConvoyDAG, input *StageInput, errs, warns []Staging
 		epicID := input.IDs[0]
 		waves, validationBeadID, err = appendValidationWave(dag, waves, epicID)
 		if err != nil {
-			return fmt.Errorf("creating validation bead: %w", err)
+			return convoyStageError(fmt.Errorf("creating validation bead: %w", err))
 		}
 	}
 
@@ -461,14 +483,14 @@ func runConvoyStageJSON(dag *ConvoyDAG, input *StageInput, errs, warns []Staging
 
 	if isRestage {
 		if err := updateStagedConvoy(restageConvoyID, dag, waves, status, title); err != nil {
-			return err
+			return convoyStageError(err)
 		}
 		result.ConvoyID = restageConvoyID
 		result.Restaged = true
 	} else {
 		convoyID, err := createStagedConvoy(dag, waves, status, title)
 		if err != nil {
-			return err
+			return convoyStageError(err)
 		}
 		result.ConvoyID = convoyID
 	}

--- a/internal/cmd/convoy_stage_test.go
+++ b/internal/cmd/convoy_stage_test.go
@@ -1872,8 +1872,9 @@ func TestCreateStagedConvoy_CleanReady(t *testing.T) {
 
 	// Verify bd dep add was called for each slingable bead.
 	for _, beadID := range []string{"gt-a", "gt-b", "gt-c"} {
-		if !strings.Contains(logContent, "dep add "+convoyID+" "+beadID) {
-			t.Errorf("bd.log should contain 'dep add %s %s', got:\n%s", convoyID, beadID, logContent)
+		targetID := "external:gt:" + beadID
+		if !strings.Contains(logContent, "dep add "+convoyID+" "+targetID) {
+			t.Errorf("bd.log should contain 'dep add %s %s', got:\n%s", convoyID, targetID, logContent)
 		}
 	}
 }
@@ -1920,8 +1921,9 @@ func TestCreateStagedConvoy_TracksOnlySlingable(t *testing.T) {
 
 	// Slingable beads (tasks and bugs) should be tracked.
 	for _, beadID := range []string{"gt-t1", "gt-b1", "gt-t2"} {
-		if !strings.Contains(logContent, "dep add "+convoyID+" "+beadID) {
-			t.Errorf("bd.log should contain 'dep add %s %s' for slingable bead, got:\n%s", convoyID, beadID, logContent)
+		targetID := "external:gt:" + beadID
+		if !strings.Contains(logContent, "dep add "+convoyID+" "+targetID) {
+			t.Errorf("bd.log should contain 'dep add %s %s' for slingable bead, got:\n%s", convoyID, targetID, logContent)
 		}
 	}
 

--- a/internal/cmd/dolt.go
+++ b/internal/cmd/dolt.go
@@ -712,15 +712,15 @@ type beadsRuntimeConfig struct {
 	Port     int
 }
 
-func currentBeadsRuntimeConfig(townRoot string) (beadsRuntimeConfig, bool) {
+func currentBeadsRuntimeConfig() (beadsRuntimeConfig, bool) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		return beadsRuntimeConfig{}, false
 	}
-	return readBeadsRuntimeConfig(beads.ResolveBeadsDir(cwd), townRoot)
+	return readBeadsRuntimeConfig(beads.ResolveBeadsDir(cwd))
 }
 
-func readBeadsRuntimeConfig(beadsDir, townRoot string) (beadsRuntimeConfig, bool) {
+func readBeadsRuntimeConfig(beadsDir string) (beadsRuntimeConfig, bool) {
 	metadataPath := filepath.Join(beadsDir, "metadata.json")
 	data, err := os.ReadFile(metadataPath)
 	if err != nil {
@@ -748,7 +748,14 @@ func readBeadsRuntimeConfig(beadsDir, townRoot string) (beadsRuntimeConfig, bool
 	}
 	port := metadata.DoltServerPort
 	if port == 0 {
-		port = doltserver.DefaultConfig(townRoot).Port
+		if data, err := os.ReadFile(filepath.Join(beadsDir, "dolt-server.port")); err == nil {
+			if parsed, err := strconv.Atoi(strings.TrimSpace(string(data))); err == nil && parsed > 0 {
+				port = parsed
+			}
+		}
+	}
+	if port == 0 {
+		port = doltserver.DefaultPort
 	}
 	database := metadata.DoltDatabase
 	if database == "" {
@@ -764,7 +771,7 @@ func readBeadsRuntimeConfig(beadsDir, townRoot string) (beadsRuntimeConfig, bool
 }
 
 func printBeadsRuntimeConfig(townRoot string) {
-	cfg, ok := currentBeadsRuntimeConfig(townRoot)
+	cfg, ok := currentBeadsRuntimeConfig()
 	if !ok {
 		return
 	}

--- a/internal/cmd/dolt_status_test.go
+++ b/internal/cmd/dolt_status_test.go
@@ -26,7 +26,7 @@ func TestReadBeadsRuntimeConfigServerMetadata(t *testing.T) {
 		t.Fatalf("write metadata: %v", err)
 	}
 
-	cfg, ok := readBeadsRuntimeConfig(beadsDir, townRoot)
+	cfg, ok := readBeadsRuntimeConfig(beadsDir)
 	if !ok {
 		t.Fatal("readBeadsRuntimeConfig did not detect server metadata")
 	}
@@ -42,6 +42,8 @@ func TestReadBeadsRuntimeConfigServerMetadata(t *testing.T) {
 }
 
 func TestReadBeadsRuntimeConfigDefaultServerAddr(t *testing.T) {
+	t.Setenv("GT_DOLT_PORT", "32769")
+
 	townRoot := t.TempDir()
 	beadsDir := filepath.Join(townRoot, ".beads")
 	if err := os.MkdirAll(beadsDir, 0755); err != nil {
@@ -56,7 +58,7 @@ func TestReadBeadsRuntimeConfigDefaultServerAddr(t *testing.T) {
 		t.Fatalf("write metadata: %v", err)
 	}
 
-	cfg, ok := readBeadsRuntimeConfig(beadsDir, townRoot)
+	cfg, ok := readBeadsRuntimeConfig(beadsDir)
 	if !ok {
 		t.Fatal("readBeadsRuntimeConfig did not detect server metadata")
 	}
@@ -65,6 +67,35 @@ func TestReadBeadsRuntimeConfigDefaultServerAddr(t *testing.T) {
 	}
 	if cfg.Port != doltserver.DefaultPort {
 		t.Fatalf("Port = %d, want default %d", cfg.Port, doltserver.DefaultPort)
+	}
+}
+
+func TestReadBeadsRuntimeConfigPortFileFallback(t *testing.T) {
+	t.Setenv("GT_DOLT_PORT", "32769")
+
+	townRoot := t.TempDir()
+	beadsDir := filepath.Join(townRoot, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir beads dir: %v", err)
+	}
+	metadata := `{
+  "backend": "dolt",
+  "dolt_mode": "server",
+  "database": "dolt"
+}`
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(metadata), 0600); err != nil {
+		t.Fatalf("write metadata: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "dolt-server.port"), []byte("43113\n"), 0600); err != nil {
+		t.Fatalf("write port file: %v", err)
+	}
+
+	cfg, ok := readBeadsRuntimeConfig(beadsDir)
+	if !ok {
+		t.Fatal("readBeadsRuntimeConfig did not detect server metadata")
+	}
+	if cfg.Port != 43113 {
+		t.Fatalf("Port = %d, want port file 43113", cfg.Port)
 	}
 }
 
@@ -83,7 +114,7 @@ func TestReadBeadsRuntimeConfigIgnoresEmbeddedMetadata(t *testing.T) {
 		t.Fatalf("write metadata: %v", err)
 	}
 
-	if _, ok := readBeadsRuntimeConfig(beadsDir, townRoot); ok {
+	if _, ok := readBeadsRuntimeConfig(beadsDir); ok {
 		t.Fatal("embedded metadata should not be reported as shared-server config")
 	}
 }

--- a/internal/cmd/fresh_setup_integration_test.go
+++ b/internal/cmd/fresh_setup_integration_test.go
@@ -118,8 +118,8 @@ type freshSetupIssue struct {
 
 func freshSetupIntegrationEnv(homeDir, doltPort string) []string {
 	clean := make([]string, 0, len(os.Environ())+3)
-	for _, entry := range os.Environ() {
-		if strings.HasPrefix(entry, "GT_") || strings.HasPrefix(entry, "BD_") || strings.HasPrefix(entry, "BEADS_DOLT_PORT=") {
+	for _, entry := range beads.StripBDTargetEnv(os.Environ()) {
+		if strings.HasPrefix(entry, "GT_") || strings.HasPrefix(entry, "BD_") {
 			continue
 		}
 		if strings.HasPrefix(entry, "HOME=") {
@@ -127,7 +127,7 @@ func freshSetupIntegrationEnv(homeDir, doltPort string) []string {
 		}
 		clean = append(clean, entry)
 	}
-	return append(clean, "HOME="+homeDir, "GT_DOLT_PORT="+doltPort, "BEADS_DOLT_PORT="+doltPort)
+	return append(clean, "HOME="+homeDir, "GT_DOLT_PORT="+doltPort, "BEADS_DOLT_PORT="+doltPort, "BEADS_DOLT_SERVER_PORT="+doltPort)
 }
 
 func configureGitIdentityForEnv(t *testing.T, env []string) {

--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -502,7 +502,11 @@ func runHookShow(cmd *cobra.Command, args []string) error {
 			if rigName != "" && rigName != "mayor" && rigName != "deacon" {
 				// Agent beads can be stale or missing during recovery. The source
 				// work assignment is authoritative, so query the target rig DB directly.
-				workDir = filepath.Join(townRoot, rigName, "mayor", "rig")
+				if rigDir := beads.GetRigDirForName(townRoot, rigName); rigDir != "" {
+					workDir = rigDir
+				} else {
+					workDir = filepath.Join(townRoot, rigName)
+				}
 			}
 		}
 	}

--- a/internal/cmd/hook.go
+++ b/internal/cmd/hook.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"os/exec"
 	"path/filepath"
 	"strings"
 	"time"
@@ -323,15 +322,7 @@ func runHook(_ *cobra.Command, args []string) error {
 			fmt.Printf("%s Replacing completed bead %s...\n", style.Dim.Render("ℹ"), existing.ID)
 			if !hookDryRun {
 				if hasAttachment {
-					// Close completed molecule bead (use bd close --force for pinned)
-					closeArgs := []string{"close", existing.ID, "--force",
-						"--reason=Auto-replaced by gt hook (molecule complete)"}
-					if sessionID := runtime.SessionIDFromEnv(); sessionID != "" {
-						closeArgs = append(closeArgs, "--session="+sessionID)
-					}
-					closeCmd := exec.Command("bd", closeArgs...)
-					closeCmd.Stderr = os.Stderr
-					if err := closeCmd.Run(); err != nil {
+					if err := closeCompletedHookedMolecule(workDir, existing.ID); err != nil {
 						return fmt.Errorf("closing completed bead %s: %w", existing.ID, err)
 					}
 				} else {
@@ -440,6 +431,14 @@ func runHook(_ *cobra.Command, args []string) error {
 	}
 
 	return nil
+}
+
+func closeCompletedHookedMolecule(workDir, beadID string) error {
+	closeArgs := []string{"close", beadID, "--force", "--reason=Auto-replaced by gt hook (molecule complete)"}
+	if sessionID := runtime.SessionIDFromEnv(); sessionID != "" {
+		closeArgs = append(closeArgs, "--session="+sessionID)
+	}
+	return BdCmd(closeArgs...).Dir(workDir).WithAutoCommit().Run()
 }
 
 // checkPinnedBeadComplete checks if a pinned bead's attached molecule is 100% complete.

--- a/internal/cmd/hook_show_integration_test.go
+++ b/internal/cmd/hook_show_integration_test.go
@@ -27,10 +27,21 @@ func TestHookShowShorthandResolvesToCanonical(t *testing.T) {
 	}
 
 	townRoot, polecatDir, rigPrefix := setupHookTestTown(t)
-	_ = townRoot
 
 	rigDir := filepath.Join(polecatDir, "..", "..", "mayor", "rig")
 	initBeadsDBWithPrefix(t, rigDir, rigPrefix)
+	rigRootBeadsDir := filepath.Join(townRoot, "gastown", ".beads")
+	if err := os.MkdirAll(rigRootBeadsDir, 0755); err != nil {
+		t.Fatalf("mkdir stale rig-root beads dir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(rigRootBeadsDir, "metadata.json"), []byte(`{"dolt_database":"hq"}`), 0644); err != nil {
+		t.Fatalf("write stale rig-root metadata: %v", err)
+	}
+	t.Setenv("BEADS_DIR", filepath.Join(townRoot, ".beads"))
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "hq")
+	t.Setenv("BEADS_DB", filepath.Join(townRoot, "wrong.db"))
+	t.Setenv("BD_DB", filepath.Join(townRoot, "wrong.bd"))
+	t.Setenv("BEADS_DOLT_DATA_DIR", filepath.Join(townRoot, "wrong-data"))
 
 	b := beads.New(rigDir)
 	issue, err := b.Create(beads.CreateOptions{

--- a/internal/cmd/hook_test.go
+++ b/internal/cmd/hook_test.go
@@ -1,6 +1,8 @@
 package cmd
 
 import (
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -153,4 +155,71 @@ func TestNormalizeHookShowTarget(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCloseCompletedHookedMoleculeUsesBdCmdEnv(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd.log")
+	writeHookBDStub(t, binDir)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_STUB_LOG", logPath)
+	t.Setenv("CLAUDE_SESSION_ID", "ses-hook-test")
+	t.Setenv("BEADS_DIR", "/wrong")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "hq")
+	t.Setenv("BD_READONLY", "true")
+	t.Setenv("BD_DOLT_AUTO_COMMIT", "off")
+
+	workDir := t.TempDir()
+	beadsDir := filepath.Join(workDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"dolt_database":"hookdb"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := closeCompletedHookedMolecule(workDir, "gt-old"); err != nil {
+		t.Fatalf("closeCompletedHookedMolecule: %v", err)
+	}
+	log := readHookStubLog(t, logPath)
+	for _, want := range []string{
+		"args:[close][gt-old][--force][--reason=Auto-replaced by gt hook (molecule complete)][--session=ses-hook-test]",
+		"BEADS_DIR=" + beadsDir,
+		"BEADS_DOLT_SERVER_DATABASE=hookdb",
+		"\nBD_READONLY=\n",
+		"BD_DOLT_AUTO_COMMIT=on",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("hook close log missing %q:\n%s", want, log)
+		}
+	}
+}
+
+func writeHookBDStub(t *testing.T, binDir string) {
+	t.Helper()
+	script := `#!/usr/bin/env sh
+{
+	printf 'args:'
+	for arg in "$@"; do
+		printf '[%s]' "$arg"
+	done
+	printf '\n'
+	printf 'BEADS_DIR=%s\n' "${BEADS_DIR-}"
+	printf 'BEADS_DOLT_SERVER_DATABASE=%s\n' "${BEADS_DOLT_SERVER_DATABASE-}"
+	printf 'BD_READONLY=%s\n' "${BD_READONLY-}"
+	printf 'BD_DOLT_AUTO_COMMIT=%s\n' "${BD_DOLT_AUTO_COMMIT-}"
+} >> "$BD_STUB_LOG"
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readHookStubLog(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }

--- a/internal/cmd/install.go
+++ b/internal/cmd/install.go
@@ -732,43 +732,22 @@ func initTownBeads(townPath string) error {
 		return fmt.Errorf("ensuring config.yaml: %w", err)
 	}
 
-	beadsEnv := withBeadsDirEnv(beadsDir)
-
-	// Set beads.role to maintainer (town-level beads are always maintainer-owned).
-	// Without this, bd doctor warns about missing role configuration.
-	roleSetCmd := exec.Command("bd", "config", "set", "beads.role", "maintainer")
-	roleSetCmd.Dir = townPath
-	roleSetCmd.Env = beadsEnv
-	if roleOutput, roleErr := roleSetCmd.CombinedOutput(); roleErr != nil {
-		fmt.Printf("   %s Could not set beads.role: %s\n", style.Dim.Render("⚠"), strings.TrimSpace(string(roleOutput)))
+	// Set beads.role to maintainer (town-level beads are always maintainer-owned)
+	// without invoking old bd config/schema initialization during fresh install.
+	if err := beads.EnsureConfigYAMLValue(beadsDir, "beads.role", "maintainer"); err != nil {
+		fmt.Printf("   %s Could not set beads.role: %v\n", style.Dim.Render("⚠"), err)
 	}
 
-	// Explicitly set issue_prefix config (bd init --prefix may not persist it in newer versions).
-	// bd >= 1.0.0 rejects this with "cannot be set via 'bd config set'" because init persists
-	// it directly; treat that as already-set rather than a failure.
-	prefixSetCmd := exec.Command("bd", "config", "set", "issue_prefix", "hq")
-	prefixSetCmd.Dir = townPath
-	prefixSetCmd.Env = beadsEnv
-	if prefixOutput, prefixErr := prefixSetCmd.CombinedOutput(); prefixErr != nil {
-		out := strings.TrimSpace(string(prefixOutput))
-		if !strings.Contains(out, "cannot be set via") {
-			return fmt.Errorf("bd config set issue_prefix failed: %s", out)
-		}
-	}
-
-	// Configure custom types for Gas Town (agent, role, rig, convoy, slot).
-	// These were extracted from beads core in v0.46.0 and now require explicit config.
-	if err := beads.EnsureCustomTypes(beadsDir); err != nil {
+	// Configure custom types for Gas Town before any bd config command can force
+	// an older bd binary through legacy schema initialization.
+	if err := beads.EnsureCustomTypesConfigYAML(beadsDir); err != nil {
 		return fmt.Errorf("ensuring custom types: %w", err)
 	}
 
 	// Configure allowed_prefixes for convoy beads (hq-cv-* IDs).
 	// This allows bd create --id=hq-cv-xxx to pass prefix validation.
-	prefixCmd := exec.Command("bd", "config", "set", "allowed_prefixes", "hq,hq-cv")
-	prefixCmd.Dir = townPath
-	prefixCmd.Env = beadsEnv
-	if prefixOutput, prefixErr := prefixCmd.CombinedOutput(); prefixErr != nil {
-		fmt.Printf("   %s Could not set allowed_prefixes: %s\n", style.Dim.Render("⚠"), strings.TrimSpace(string(prefixOutput)))
+	if err := beads.EnsureConfigYAMLValue(beadsDir, "allowed_prefixes", "hq,hq-cv"); err != nil {
+		fmt.Printf("   %s Could not set allowed_prefixes: %v\n", style.Dim.Render("⚠"), err)
 	}
 
 	// Ensure issues.jsonl exists — bd expects this file for git-tracked issue data.
@@ -848,7 +827,7 @@ func initTownAgentBeads(townPath string) error {
 	// bd init doesn't enable "custom" issue types by default, but Gas Town uses
 	// agent beads during install and runtime. Ensure these types are enabled
 	// before attempting to create any town-level system beads.
-	if err := ensureBeadsCustomTypes(townPath, constants.BeadsCustomTypesList()); err != nil {
+	if err := beads.EnsureCustomTypesConfigYAML(beads.ResolveBeadsDir(townPath)); err != nil {
 		return err
 	}
 

--- a/internal/cmd/prime.go
+++ b/internal/cmd/prime.go
@@ -888,15 +888,15 @@ func findAgentWorkOnce(ctx RoleContext, agentID string) (*beads.Issue, error) {
 	return hookedBeads[0], nil
 }
 
-// rigBeadsRoot returns the directory to use for beads queries.
-// For rig-level agents (polecats, crew, witness, refinery), returns the rig
-// root (e.g., ~/gt/myrig/) which has the authoritative .beads/ database.
-// For town-level agents, returns ctx.WorkDir unchanged.
-//
-// This avoids relying on .beads/redirect in polecat worktrees, which can
-// fail to resolve and cause polecats to see no hooked work. (GH#2503)
+// rigBeadsRoot returns the route-owned directory to use for beads queries.
+// For rig-level agents (polecats, crew, witness, refinery), prefer the rig DB
+// from town routes rather than rig-root metadata, which can be a stale redirect
+// shim during recovery. For town-level agents, returns ctx.WorkDir unchanged.
 func rigBeadsRoot(ctx RoleContext) string {
 	if ctx.Rig != "" && ctx.TownRoot != "" {
+		if rigDir := beads.GetRigDirForName(ctx.TownRoot, ctx.Rig); rigDir != "" {
+			return rigDir
+		}
 		return filepath.Join(ctx.TownRoot, ctx.Rig)
 	}
 	return ctx.WorkDir

--- a/internal/cmd/prime_test.go
+++ b/internal/cmd/prime_test.go
@@ -134,6 +134,44 @@ func TestGetAgentBeadID_UsesRigPrefix(t *testing.T) {
 	}
 }
 
+func TestRigBeadsRootPrefersRouteResolvedRigDir(t *testing.T) {
+	townRoot := t.TempDir()
+	writeTestRoutes(t, townRoot, []beads.Route{
+		{Prefix: "gt-", Path: "gastown/mayor/rig"},
+		{Prefix: "hq-", Path: "."},
+	})
+
+	ctx := RoleContext{
+		Role:     RolePolecat,
+		Rig:      "gastown",
+		Polecat:  "toast",
+		TownRoot: townRoot,
+		WorkDir:  filepath.Join(townRoot, "gastown", "polecats", "toast", "gastown"),
+	}
+
+	got := rigBeadsRoot(ctx)
+	want := filepath.Join(townRoot, "gastown", "mayor", "rig")
+	if got != want {
+		t.Fatalf("rigBeadsRoot() = %q, want route-resolved %q", got, want)
+	}
+}
+
+func TestRigBeadsRootFallsBackWhenRouteMissing(t *testing.T) {
+	townRoot := t.TempDir()
+	ctx := RoleContext{
+		Role:     RolePolecat,
+		Rig:      "gastown",
+		TownRoot: townRoot,
+		WorkDir:  filepath.Join(townRoot, "gastown", "polecats", "toast", "gastown"),
+	}
+
+	got := rigBeadsRoot(ctx)
+	want := filepath.Join(townRoot, "gastown")
+	if got != want {
+		t.Fatalf("rigBeadsRoot() = %q, want fallback %q", got, want)
+	}
+}
+
 func TestPrimeFlagCombinations(t *testing.T) {
 	gtBin := buildGT(t)
 

--- a/internal/cmd/rig_integration_test.go
+++ b/internal/cmd/rig_integration_test.go
@@ -1011,7 +1011,6 @@ func TestRigAddRejectsInvalidNames(t *testing.T) {
 // witness and refinery agent beads via the manager's initAgentBeads.
 func TestRigAddCreatesAgentBeads(t *testing.T) {
 	requireDoltServer(t)
-	bdLogPath := mockBdCommand(t)
 	townRoot := setupTestTown(t)
 	bridgeDoltPidToTown(t, townRoot)
 	gitURL := createTestGitRepo(t, "agentbeadtest")
@@ -1035,13 +1034,6 @@ func TestRigAddCreatesAgentBeads(t *testing.T) {
 		t.Fatalf("AddRig: %v", err)
 	}
 
-	// Verify the mock bd was called with correct create commands
-	logContent, err := os.ReadFile(bdLogPath)
-	if err != nil {
-		t.Fatalf("reading bd log: %v", err)
-	}
-	logStr := string(logContent)
-
 	// Expected bead IDs that initAgentBeads should create
 	witnessID := beads.WitnessBeadIDWithPrefix(newRig.Config.Prefix, "agentbeadtest")
 	refineryID := beads.RefineryBeadIDWithPrefix(newRig.Config.Prefix, "agentbeadtest")
@@ -1054,15 +1046,11 @@ func TestRigAddCreatesAgentBeads(t *testing.T) {
 		{refineryID, "refinery agent bead"},
 	}
 
+	rigBeads := beads.NewWithBeadsDir(newRig.Path, beads.ResolveBeadsDir(newRig.Path))
 	for _, expected := range expectedIDs {
-		if !strings.Contains(logStr, expected.id) {
-			t.Errorf("bd create log should contain %s (%s), got:\n%s", expected.id, expected.desc, logStr)
+		if _, err := rigBeads.Show(expected.id); err != nil {
+			t.Errorf("expected %s (%s) to exist: %v", expected.id, expected.desc, err)
 		}
-	}
-
-	// Verify correct prefix is used (ab-)
-	if !strings.Contains(logStr, "ab-") {
-		t.Errorf("bd create log should contain prefix 'ab-', got:\n%s", logStr)
 	}
 }
 

--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -42,13 +42,13 @@ func initBeadsDBForServer(t *testing.T, dir, prefix, homeDir string) {
 	t.Helper()
 	initSchedulerGitRepo(t, dir, homeDir)
 
-	args := []string{"init", "--prefix", prefix}
+	args := []string{"init", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents", "--prefix", prefix}
 	// Forward GT_DOLT_PORT so bd connects to the ephemeral test server
 	// instead of defaulting to port 3307.
 	// bd v1.0.0+ defaults to embedded mode; --server is required to use an
 	// external server (v0.57.0 defaulted to server mode and ignored --server).
 	if p := schedulerDoltPort(); p != "" {
-		args = append(args, "--server", "--server-port", p)
+		args = append(args, "--server", "--external", "--server-port", p)
 	}
 	cmd := exec.Command("bd", args...)
 	cmd.Dir = dir
@@ -82,12 +82,12 @@ func initSchedulerGitRepo(t *testing.T, dir, homeDir string) {
 }
 
 func schedulerBDInitEnv(homeDir, beadsDir string) []string {
-	env := beads.StripBDTargetEnv(cleanSchedulerTestEnv(homeDir))
-	env = append(env, "BEADS_DIR="+beadsDir)
+	env := cleanSchedulerTestEnv(homeDir)
 	if p := schedulerDoltPort(); p != "" {
-		env = append(env, "BEADS_DOLT_SERVER_PORT="+p, "BEADS_DOLT_PORT="+p)
+		env = beads.StripEnvKey(env, "GT_DOLT_PORT")
+		env = append(env, "GT_DOLT_PORT="+p)
 	}
-	return env
+	return beads.BuildMutationPinnedBDEnv(env, beadsDir)
 }
 
 func schedulerDoltPort() string {
@@ -1087,24 +1087,6 @@ func TestSchedulerDeferredTaskWithoutRig(t *testing.T) {
 	}
 	if !strings.Contains(out, "deferred dispatch requires a rig target") {
 		t.Errorf("expected 'deferred dispatch requires a rig target' error, got:\n%s", out)
-	}
-}
-
-// TestSchedulerConfigSetZero verifies that gt config set scheduler.max_polecats 0
-// is accepted (disabled mode is a valid config).
-func TestSchedulerConfigSetZero(t *testing.T) {
-	hqPath, _, gtBinary, env := setupSchedulerIntegrationTown(t)
-
-	// Set max_polecats=0 should succeed
-	out := runGTCmdOutput(t, gtBinary, hqPath, env, "config", "set", "scheduler.max_polecats", "0")
-	if strings.Contains(out, "invalid") {
-		t.Errorf("max_polecats=0 should be accepted, got:\n%s", out)
-	}
-
-	// Read it back — should return 0
-	out = runGTCmdOutput(t, gtBinary, hqPath, env, "config", "get", "scheduler.max_polecats")
-	if strings.TrimSpace(out) != "0" {
-		t.Errorf("max_polecats = %q, want %q", strings.TrimSpace(out), "0")
 	}
 }
 

--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -13,19 +13,23 @@
 package cmd
 
 import (
+	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	beadsdk "github.com/steveyegge/beads"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/scheduler/capacity"
 )
 
@@ -35,39 +39,74 @@ import (
 var schedulerTestCounter atomic.Int32
 
 // initBeadsDBForServer initializes a beads DB that can operate against the
-// shared Dolt test server. Uses local init (bd init --prefix --server-port)
-// which reliably creates the schema and records the ephemeral port in
-// metadata.json so subsequent bd commands reach the test server.
+// shared Dolt test server. It uses the Beads SDK directly instead of shelling
+// out to bd init; the scheduler suite creates dozens of fixture databases, and
+// full CLI init repeatedly exhausts the internal/cmd integration timeout.
 func initBeadsDBForServer(t *testing.T, dir, prefix, homeDir string) {
 	t.Helper()
 	initSchedulerGitRepo(t, dir, homeDir)
 
-	args := []string{"init", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents", "--prefix", prefix}
-	// Forward GT_DOLT_PORT so bd connects to the ephemeral test server
-	// instead of defaulting to port 3307.
-	// bd v1.0.0+ defaults to embedded mode; --server is required to use an
-	// external server (v0.57.0 defaulted to server mode and ignored --server).
-	if p := schedulerDoltPort(); p != "" {
-		args = append(args, "--server", "--external", "--server-port", p)
+	beadsDir := filepath.Join(dir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatalf("mkdir %s: %v", beadsDir, err)
 	}
-	cmd := exec.Command("bd", args...)
-	cmd.Dir = dir
-	cmd.Env = schedulerBDInitEnv(homeDir, filepath.Join(dir, ".beads"))
-	out, err := cmd.CombinedOutput()
-	t.Logf("bd init --prefix %s in %s: exit=%v\n%s", prefix, dir, err, out)
-	if err != nil {
-		t.Fatalf("bd init failed in %s: %v\n%s", dir, err, out)
+
+	port := schedulerDoltPort()
+	if port == "" {
+		t.Fatal("scheduler Dolt port is not set")
 	}
+	portNum, err := strconv.Atoi(port)
+	if err != nil || portNum <= 0 {
+		t.Fatalf("invalid scheduler Dolt port %q", port)
+	}
+
+	metadata := struct {
+		Database       string `json:"database"`
+		Backend        string `json:"backend"`
+		IssuePrefix    string `json:"issue_prefix"`
+		DoltMode       string `json:"dolt_mode"`
+		DoltServerHost string `json:"dolt_server_host"`
+		DoltServerPort int    `json:"dolt_server_port"`
+		DoltServerUser string `json:"dolt_server_user"`
+		DoltDatabase   string `json:"dolt_database"`
+	}{
+		Database:       "dolt",
+		Backend:        "dolt",
+		IssuePrefix:    prefix,
+		DoltMode:       "server",
+		DoltServerHost: "127.0.0.1",
+		DoltServerPort: portNum,
+		DoltServerUser: "root",
+		DoltDatabase:   schedulerDoltDatabaseName(prefix),
+	}
+	writeJSONFile(t, filepath.Join(beadsDir, "metadata.json"), metadata)
+	if err := os.WriteFile(filepath.Join(beadsDir, "dolt-server.port"), []byte(port+"\n"), 0644); err != nil {
+		t.Fatalf("write dolt-server.port in %s: %v", beadsDir, err)
+	}
+	if err := beads.EnsureConfigYAML(beadsDir, prefix); err != nil {
+		t.Fatalf("write config.yaml in %s: %v", beadsDir, err)
+	}
+
+	seedSchedulerBeadsDB(t, beadsDir, prefix, port)
+
+	for _, kv := range []struct {
+		key   string
+		value string
+	}{
+		{"types.custom", constants.BeadsCustomTypes},
+		{"status.custom", constants.BeadsCustomStatuses},
+	} {
+		if err := beads.EnsureConfigYAMLValue(beadsDir, kv.key, kv.value); err != nil {
+			t.Fatalf("write %s in %s: %v", kv.key, beadsDir, err)
+		}
+	}
+	writeSchedulerCustomConfigSentinels(t, beadsDir)
 
 	// Create empty issues.jsonl to prevent bd auto-export from corrupting
 	// routes.jsonl (same as initBeadsDBWithPrefix does).
 	issuesPath := filepath.Join(dir, ".beads", "issues.jsonl")
 	if err := os.WriteFile(issuesPath, []byte(""), 0644); err != nil {
 		t.Fatalf("create issues.jsonl in %s: %v", dir, err)
-	}
-
-	if err := beads.EnsureCustomTypes(filepath.Join(dir, ".beads")); err != nil {
-		t.Fatalf("ensure custom types in %s: %v", dir, err)
 	}
 }
 
@@ -81,13 +120,109 @@ func initSchedulerGitRepo(t *testing.T, dir, homeDir string) {
 	}
 }
 
-func schedulerBDInitEnv(homeDir, beadsDir string) []string {
-	env := cleanSchedulerTestEnv(homeDir)
-	if p := schedulerDoltPort(); p != "" {
-		env = beads.StripEnvKey(env, "GT_DOLT_PORT")
-		env = append(env, "GT_DOLT_PORT="+p)
+func seedSchedulerBeadsDB(t *testing.T, beadsDir, prefix, port string) {
+	t.Helper()
+	withSchedulerBeadsSDKEnv(t, port, func() {
+		store, err := beadsdk.OpenFromConfig(context.Background(), beadsDir)
+		if err != nil {
+			t.Fatalf("open scheduler beads DB %s: %v", beadsDir, err)
+		}
+		defer store.Close()
+
+		for _, kv := range []struct {
+			key   string
+			value string
+		}{
+			{"issue_prefix", prefix},
+			{"types.custom", constants.BeadsCustomTypes},
+			{"status.custom", constants.BeadsCustomStatuses},
+		} {
+			if err := store.SetConfig(context.Background(), kv.key, kv.value); err != nil {
+				t.Fatalf("set %s in %s: %v", kv.key, beadsDir, err)
+			}
+		}
+
+		got, err := store.GetConfig(context.Background(), "issue_prefix")
+		if err != nil || got != prefix {
+			t.Fatalf("issue_prefix in %s = %q, %v; want %q", beadsDir, got, err, prefix)
+		}
+	})
+}
+
+func withSchedulerBeadsSDKEnv(t *testing.T, port string, fn func()) {
+	t.Helper()
+	keys := map[string]struct{}{
+		"BEADS_DIR":                  {},
+		"BEADS_DB":                   {},
+		"BD_DB":                      {},
+		"BEADS_SHARED_SERVER_DIR":    {},
+		"BEADS_TEST_MODE":            {},
+		"BEADS_DOLT_AUTO_START":      {},
+		"BEADS_DOLT_SERVER_HOST":     {},
+		"BEADS_DOLT_SERVER_PORT":     {},
+		"BEADS_DOLT_PORT":            {},
+		"BEADS_DOLT_SERVER_DATABASE": {},
 	}
-	return beads.BuildMutationPinnedBDEnv(env, beadsDir)
+	for _, entry := range os.Environ() {
+		key, _, ok := strings.Cut(entry, "=")
+		if ok && strings.HasPrefix(key, "BEADS_DOLT_") {
+			keys[key] = struct{}{}
+		}
+	}
+	type envValue struct {
+		value string
+		ok    bool
+	}
+	saved := make(map[string]envValue, len(keys))
+	for key := range keys {
+		value, ok := os.LookupEnv(key)
+		saved[key] = envValue{value: value, ok: ok}
+		if err := os.Unsetenv(key); err != nil {
+			t.Fatalf("unset %s: %v", key, err)
+		}
+	}
+	defer func() {
+		for key := range keys {
+			if saved[key].ok {
+				_ = os.Setenv(key, saved[key].value)
+			} else {
+				_ = os.Unsetenv(key)
+			}
+		}
+	}()
+
+	for key, value := range map[string]string{
+		"BEADS_TEST_MODE":        "1",
+		"BEADS_DOLT_AUTO_START":  "0",
+		"BEADS_DOLT_SERVER_HOST": "127.0.0.1",
+		"BEADS_DOLT_SERVER_PORT": port,
+		"BEADS_DOLT_PORT":        port,
+	} {
+		if err := os.Setenv(key, value); err != nil {
+			t.Fatalf("set %s: %v", key, err)
+		}
+	}
+
+	fn()
+}
+
+func writeSchedulerCustomConfigSentinels(t *testing.T, beadsDir string) {
+	t.Helper()
+	for _, file := range []struct {
+		name  string
+		value string
+	}{
+		{".gt-types-configured", constants.BeadsCustomTypes},
+		{".gt-statuses-configured", constants.BeadsCustomStatuses},
+	} {
+		if err := os.WriteFile(filepath.Join(beadsDir, file.name), []byte(file.value+"\n"), 0644); err != nil {
+			t.Fatalf("write %s in %s: %v", file.name, beadsDir, err)
+		}
+	}
+}
+
+func schedulerDoltDatabaseName(prefix string) string {
+	return strings.ReplaceAll(prefix, "-", "_")
 }
 
 func schedulerDoltPort() string {
@@ -147,8 +282,8 @@ func setupSchedulerIntegrationTown(t *testing.T) (hqPath, rigPath, gtBinary stri
 		t.Fatalf("EvalSymlinks: %v", err)
 	}
 
-	// Configure git/dolt identity in isolated HOME (needed by bd init --server
-	// which initializes a git repo inside .beads/).
+	// Configure git identity in isolated HOME for scheduler paths that still
+	// exercise bd/gt subprocesses inside temp repos.
 	configureTestGitIdentity(t, tmpDir)
 
 	// Generate unique prefixes per test to avoid cross-test data leakage on

--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -1338,6 +1338,73 @@ func TestSchedulerActualDispatchRoutesPollutedEnvToTargetRig(t *testing.T) {
 	}
 }
 
+func TestSchedulerFormulaDispatchRoutesPollutedEnvToTargetRig(t *testing.T) {
+	hqPath, rigPath, _, _ := setupSchedulerIntegrationTown(t)
+
+	beadID := createTestBead(t, rigPath, "Polluted env formula dispatch")
+	rigBeads := beads.NewWithBeadsDir(rigPath, filepath.Join(rigPath, ".beads"))
+	ctxBead, err := rigBeads.CreateSlingContext("dispatch: "+beadID, beadID, &capacity.SlingContextFields{
+		Version:    1,
+		WorkBeadID: beadID,
+		TargetRig:  "testrig",
+		Formula:    "mol-polecat-work",
+		EnqueuedAt: "2026-01-01T00:00:00Z",
+	})
+	if err != nil {
+		t.Fatalf("CreateSlingContext: %v", err)
+	}
+
+	prevSpawn := spawnPolecatForSling
+	t.Cleanup(func() { spawnPolecatForSling = prevSpawn })
+	spawnPolecatForSling = func(rigName string, opts SlingSpawnOptions) (*SpawnedPolecatInfo, error) {
+		if rigName != "testrig" {
+			t.Fatalf("spawn rig = %q, want testrig", rigName)
+		}
+		return &SpawnedPolecatInfo{
+			RigName:     rigName,
+			PolecatName: "formulaenv",
+			ClonePath:   rigPath,
+			Pane:        "test-pane",
+		}, nil
+	}
+
+	t.Setenv("BEADS_DIR", filepath.Join(hqPath, ".beads"))
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", beads.DatabaseNameFromMetadata(filepath.Join(hqPath, ".beads")))
+	t.Setenv("BEADS_DB", filepath.Join(hqPath, "wrong.db"))
+	t.Setenv("BD_DB", filepath.Join(hqPath, "wrong.bd"))
+	t.Setenv("BEADS_DOLT_DATA_DIR", filepath.Join(hqPath, ".wrong-dolt-data"))
+
+	dispatched, err := dispatchScheduledWork(hqPath, "test", 1, false)
+	if err != nil {
+		t.Fatalf("dispatchScheduledWork: %v", err)
+	}
+	if dispatched != 1 {
+		t.Fatalf("dispatched = %d, want 1", dispatched)
+	}
+
+	issue, err := rigBeads.Show(beadID)
+	if err != nil {
+		t.Fatalf("rig bead show after dispatch: %v", err)
+	}
+	if issue.Status != "hooked" || issue.Assignee != "testrig/polecats/formulaenv" {
+		t.Fatalf("rig bead state = status:%q assignee:%q, want hooked testrig/polecats/formulaenv", issue.Status, issue.Assignee)
+	}
+	attachment := beads.ParseAttachmentFields(issue)
+	if attachment == nil || attachment.AttachedFormula != "mol-polecat-work" || attachment.AttachedMolecule == "" {
+		t.Fatalf("attachment fields = %#v, want mol-polecat-work with attached molecule (description: %s)", attachment, issue.Description)
+	}
+
+	openContexts, err := rigBeads.ListOpenSlingContexts()
+	if err != nil {
+		t.Fatalf("ListOpenSlingContexts: %v", err)
+	}
+	for _, ctx := range openContexts {
+		if ctx.ID == ctxBead.ID {
+			t.Fatalf("sling context %s still open after successful formula dispatch", ctxBead.ID)
+		}
+	}
+}
+
 func TestSchedulerDispatchFailureRecordedInContextSourceDB(t *testing.T) {
 	hqPath, rigPath, _, _ := setupSchedulerIntegrationTown(t)
 

--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
+	"github.com/steveyegge/gastown/internal/formula"
 	"github.com/steveyegge/gastown/internal/scheduler/capacity"
 )
 
@@ -152,6 +153,22 @@ func setTestBeadStatus(t *testing.T, dir, beadID, status string) {
 	}
 }
 
+func installSchedulerTestFormula(t *testing.T, rigPath string) {
+	t.Helper()
+	content, err := formula.GetEmbeddedFormulaContent("mol-polecat-work")
+	if err != nil {
+		t.Fatalf("load embedded mol-polecat-work formula: %v", err)
+	}
+	formulasDir := filepath.Join(rigPath, ".beads", "formulas")
+	if err := os.MkdirAll(formulasDir, 0755); err != nil {
+		t.Fatalf("mkdir formulas dir: %v", err)
+	}
+	path := filepath.Join(formulasDir, "mol-polecat-work.formula.toml")
+	if err := os.WriteFile(path, content, 0644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+}
+
 // setupSchedulerIntegrationTown creates a minimal town filesystem for scheduler tests.
 // Uses the shared Dolt test server (managed by requireDoltServer)
 // for beads databases. No gt install, no Claude credentials, no agent sessions.
@@ -241,6 +258,7 @@ func setupSchedulerIntegrationTown(t *testing.T) (hqPath, rigPath, gtBinary stri
 		t.Fatalf("mkdir rigPath: %v", err)
 	}
 	initBeadsDBForServer(t, rigPath, rigPrefix, tmpDir)
+	installSchedulerTestFormula(t, rigPath)
 
 	// Redirect: testrig/.beads/ → mayor/rig/.beads
 	// beadsSearchDirs scans townRoot/<dir>/.beads — the redirect lets bd commands
@@ -725,6 +743,7 @@ func setupMultiRigSchedulerTown(t *testing.T) (hqPath, rig1Path, rig2Path, gtBin
 	if err := beads.WriteRoutes(filepath.Join(rig1Path, ".beads"), routes); err != nil {
 		t.Fatalf("write rig1 routes: %v", err)
 	}
+	installSchedulerTestFormula(t, rig1Path)
 	rig1Redirect := filepath.Join(hqPath, "rig1", ".beads")
 	if err := os.MkdirAll(rig1Redirect, 0755); err != nil {
 		t.Fatalf("mkdir rig1 redirect: %v", err)
@@ -741,6 +760,7 @@ func setupMultiRigSchedulerTown(t *testing.T) (hqPath, rig1Path, rig2Path, gtBin
 	if err := beads.WriteRoutes(filepath.Join(rig2Path, ".beads"), routes); err != nil {
 		t.Fatalf("write rig2 routes: %v", err)
 	}
+	installSchedulerTestFormula(t, rig2Path)
 	rig2Redirect := filepath.Join(hqPath, "rig2", ".beads")
 	if err := os.MkdirAll(rig2Redirect, 0755); err != nil {
 		t.Fatalf("mkdir rig2 redirect: %v", err)

--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -47,7 +47,7 @@ func initBeadsDBForServer(t *testing.T, dir, prefix, homeDir string) {
 	// instead of defaulting to port 3307.
 	// bd v1.0.0+ defaults to embedded mode; --server is required to use an
 	// external server (v0.57.0 defaulted to server mode and ignored --server).
-	if p := os.Getenv("GT_DOLT_PORT"); p != "" {
+	if p := schedulerDoltPort(); p != "" {
 		args = append(args, "--server", "--server-port", p)
 	}
 	cmd := exec.Command("bd", args...)
@@ -84,10 +84,19 @@ func initSchedulerGitRepo(t *testing.T, dir, homeDir string) {
 func schedulerBDInitEnv(homeDir, beadsDir string) []string {
 	env := beads.StripBDTargetEnv(cleanSchedulerTestEnv(homeDir))
 	env = append(env, "BEADS_DIR="+beadsDir)
-	if p := os.Getenv("GT_DOLT_PORT"); p != "" {
+	if p := schedulerDoltPort(); p != "" {
 		env = append(env, "BEADS_DOLT_SERVER_PORT="+p, "BEADS_DOLT_PORT="+p)
 	}
 	return env
+}
+
+func schedulerDoltPort() string {
+	for _, key := range []string{"GT_DOLT_PORT", "BEADS_DOLT_SERVER_PORT", "BEADS_DOLT_PORT"} {
+		if p := os.Getenv(key); p != "" {
+			return p
+		}
+	}
+	return ""
 }
 
 func cleanupSchedulerBeadsDatabases(t *testing.T, prefixes ...string) {

--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -38,8 +38,9 @@ var schedulerTestCounter atomic.Int32
 // shared Dolt test server. Uses local init (bd init --prefix --server-port)
 // which reliably creates the schema and records the ephemeral port in
 // metadata.json so subsequent bd commands reach the test server.
-func initBeadsDBForServer(t *testing.T, dir, prefix string) {
+func initBeadsDBForServer(t *testing.T, dir, prefix, homeDir string) {
 	t.Helper()
+	initSchedulerGitRepo(t, dir, homeDir)
 
 	args := []string{"init", "--prefix", prefix}
 	// Forward GT_DOLT_PORT so bd connects to the ephemeral test server
@@ -51,6 +52,7 @@ func initBeadsDBForServer(t *testing.T, dir, prefix string) {
 	}
 	cmd := exec.Command("bd", args...)
 	cmd.Dir = dir
+	cmd.Env = schedulerBDInitEnv(homeDir, filepath.Join(dir, ".beads"))
 	out, err := cmd.CombinedOutput()
 	t.Logf("bd init --prefix %s in %s: exit=%v\n%s", prefix, dir, err, out)
 	if err != nil {
@@ -67,6 +69,52 @@ func initBeadsDBForServer(t *testing.T, dir, prefix string) {
 	if err := beads.EnsureCustomTypes(filepath.Join(dir, ".beads")); err != nil {
 		t.Fatalf("ensure custom types in %s: %v", dir, err)
 	}
+}
+
+func initSchedulerGitRepo(t *testing.T, dir, homeDir string) {
+	t.Helper()
+	cmd := exec.Command("git", "init", "--quiet")
+	cmd.Dir = dir
+	cmd.Env = cleanSchedulerTestEnv(homeDir)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git init in %s: %v\n%s", dir, err, out)
+	}
+}
+
+func schedulerBDInitEnv(homeDir, beadsDir string) []string {
+	env := beads.StripBDTargetEnv(cleanSchedulerTestEnv(homeDir))
+	env = append(env, "BEADS_DIR="+beadsDir)
+	if p := os.Getenv("GT_DOLT_PORT"); p != "" {
+		env = append(env, "BEADS_DOLT_SERVER_PORT="+p, "BEADS_DOLT_PORT="+p)
+	}
+	return env
+}
+
+func cleanupSchedulerBeadsDatabases(t *testing.T, prefixes ...string) {
+	t.Helper()
+	t.Cleanup(func() {
+		port := os.Getenv("GT_DOLT_PORT")
+		if port == "" {
+			port = "3307"
+		}
+		dsn := fmt.Sprintf("root@tcp(127.0.0.1:%s)/", port)
+		db, err := sql.Open("mysql", dsn)
+		if err != nil {
+			t.Logf("cleanup: could not connect to drop test databases: %v", err)
+			return
+		}
+		defer db.Close()
+		for _, prefix := range prefixes {
+			for _, dbName := range []string{prefix, "beads_" + prefix} {
+				if _, err := db.Exec("DROP DATABASE IF EXISTS `" + dbName + "`"); err != nil {
+					t.Logf("cleanup: failed to drop %s: %v", dbName, err)
+				}
+			}
+		}
+		if _, err := db.Exec("CALL dolt_purge_dropped_databases()"); err != nil {
+			t.Logf("cleanup: failed to purge dropped databases: %v", err)
+		}
+	})
 }
 
 // setupSchedulerIntegrationTown creates a minimal town filesystem for scheduler tests.
@@ -95,10 +143,11 @@ func setupSchedulerIntegrationTown(t *testing.T) (hqPath, rigPath, gtBinary stri
 	configureTestGitIdentity(t, tmpDir)
 
 	// Generate unique prefixes per test to avoid cross-test data leakage on
-	// the shared Dolt server. Each test gets its own databases (e.g., beads_h3, beads_r3).
+	// the shared Dolt server. Each test gets its own databases (e.g., h3, r3).
 	n := schedulerTestCounter.Add(1)
 	hqPrefix := fmt.Sprintf("h%d", n)
 	rigPrefix := fmt.Sprintf("r%d", n)
+	cleanupSchedulerBeadsDatabases(t, hqPrefix, rigPrefix)
 
 	hqPath = filepath.Join(tmpDir, "test-hq")
 	rigPath = filepath.Join(hqPath, "testrig", "mayor", "rig")
@@ -150,34 +199,13 @@ func setupSchedulerIntegrationTown(t *testing.T) (hqPath, rigPath, gtBinary stri
 	if err := beads.WriteRoutes(townBeadsDir, routes); err != nil {
 		t.Fatalf("write routes: %v", err)
 	}
-	initBeadsDBForServer(t, hqPath, hqPrefix)
+	initBeadsDBForServer(t, hqPath, hqPrefix, tmpDir)
 
 	// --- testrig directory (loadRig checks os.Stat on townRoot/<rigName>) ---
 	if err := os.MkdirAll(rigPath, 0755); err != nil {
 		t.Fatalf("mkdir rigPath: %v", err)
 	}
-	initBeadsDBForServer(t, rigPath, rigPrefix)
-
-	// Drop test databases on cleanup to prevent orphaned databases on the Dolt server.
-	t.Cleanup(func() {
-		port := os.Getenv("GT_DOLT_PORT")
-		if port == "" {
-			port = "3307"
-		}
-		dsn := fmt.Sprintf("root@tcp(127.0.0.1:%s)/", port)
-		db, err := sql.Open("mysql", dsn)
-		if err != nil {
-			t.Logf("cleanup: could not connect to drop test databases: %v", err)
-			return
-		}
-		defer db.Close()
-		for _, prefix := range []string{hqPrefix, rigPrefix} {
-			dbName := "beads_" + prefix
-			if _, err := db.Exec("DROP DATABASE IF EXISTS `" + dbName + "`"); err != nil {
-				t.Logf("cleanup: failed to drop %s: %v", dbName, err)
-			}
-		}
-	})
+	initBeadsDBForServer(t, rigPath, rigPrefix, tmpDir)
 
 	// Redirect: testrig/.beads/ → mayor/rig/.beads
 	// beadsSearchDirs scans townRoot/<dir>/.beads — the redirect lets bd commands
@@ -592,6 +620,7 @@ func setupMultiRigSchedulerTown(t *testing.T) (hqPath, rig1Path, rig2Path, gtBin
 	hqPrefix := fmt.Sprintf("h%d", n)
 	rig1Prefix := fmt.Sprintf("r%d", n)
 	rig2Prefix := fmt.Sprintf("s%d", n)
+	cleanupSchedulerBeadsDatabases(t, hqPrefix, rig1Prefix, rig2Prefix)
 
 	hqPath = filepath.Join(tmpDir, "test-hq")
 	rig1Path = filepath.Join(hqPath, "rig1", "mayor", "rig")
@@ -649,13 +678,13 @@ func setupMultiRigSchedulerTown(t *testing.T) (hqPath, rig1Path, rig2Path, gtBin
 	if err := beads.WriteRoutes(townBeadsDir, routes); err != nil {
 		t.Fatalf("write routes: %v", err)
 	}
-	initBeadsDBForServer(t, hqPath, hqPrefix)
+	initBeadsDBForServer(t, hqPath, hqPrefix, tmpDir)
 
 	// --- rig1 ---
 	if err := os.MkdirAll(rig1Path, 0755); err != nil {
 		t.Fatalf("mkdir rig1Path: %v", err)
 	}
-	initBeadsDBForServer(t, rig1Path, rig1Prefix)
+	initBeadsDBForServer(t, rig1Path, rig1Prefix, tmpDir)
 	// Write routes to rig1's .beads/ so bd can resolve cross-rig IDs (needed for
 	// cross-rig dep creation via external refs).
 	if err := beads.WriteRoutes(filepath.Join(rig1Path, ".beads"), routes); err != nil {
@@ -673,7 +702,7 @@ func setupMultiRigSchedulerTown(t *testing.T) (hqPath, rig1Path, rig2Path, gtBin
 	if err := os.MkdirAll(rig2Path, 0755); err != nil {
 		t.Fatalf("mkdir rig2Path: %v", err)
 	}
-	initBeadsDBForServer(t, rig2Path, rig2Prefix)
+	initBeadsDBForServer(t, rig2Path, rig2Prefix, tmpDir)
 	if err := beads.WriteRoutes(filepath.Join(rig2Path, ".beads"), routes); err != nil {
 		t.Fatalf("write rig2 routes: %v", err)
 	}
@@ -684,29 +713,6 @@ func setupMultiRigSchedulerTown(t *testing.T) (hqPath, rig1Path, rig2Path, gtBin
 	if err := os.WriteFile(filepath.Join(rig2Redirect, "redirect"), []byte("mayor/rig/.beads"), 0644); err != nil {
 		t.Fatalf("write rig2 redirect: %v", err)
 	}
-
-	// Drop test databases on cleanup to prevent orphaned databases on the Dolt
-	// server. Without this, databases from multi-rig tests persist and can
-	// contaminate subsequent tests sharing the same server (see #2832).
-	t.Cleanup(func() {
-		port := os.Getenv("GT_DOLT_PORT")
-		if port == "" {
-			port = "3307"
-		}
-		dsn := fmt.Sprintf("root@tcp(127.0.0.1:%s)/", port)
-		db, err := sql.Open("mysql", dsn)
-		if err != nil {
-			t.Logf("cleanup: could not connect to drop test databases: %v", err)
-			return
-		}
-		defer db.Close()
-		for _, prefix := range []string{hqPrefix, rig1Prefix, rig2Prefix} {
-			dbName := "beads_" + prefix
-			if _, err := db.Exec("DROP DATABASE IF EXISTS `" + dbName + "`"); err != nil {
-				t.Logf("cleanup: failed to drop %s: %v", dbName, err)
-			}
-		}
-	})
 
 	// --- Environment ---
 	env = cleanSchedulerTestEnv(tmpDir)

--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -102,7 +102,7 @@ func schedulerDoltPort() string {
 func cleanupSchedulerBeadsDatabases(t *testing.T, prefixes ...string) {
 	t.Helper()
 	t.Cleanup(func() {
-		port := os.Getenv("GT_DOLT_PORT")
+		port := schedulerDoltPort()
 		if port == "" {
 			port = "3307"
 		}

--- a/internal/cmd/scheduler_integration_test.go
+++ b/internal/cmd/scheduler_integration_test.go
@@ -1,4 +1,4 @@
-//go:build integration
+//go:build integration && scheduler_integration
 
 // Package cmd contains integration tests for the capacity scheduler subsystem.
 // These tests exercise scheduler CLI operations (schedule, list, status, dispatch
@@ -9,27 +9,23 @@
 //
 // Run with:
 //
-//	go test -tags=integration -run 'TestScheduler' -timeout 5m -count=1 -v ./internal/cmd/
+//	go test -tags='integration scheduler_integration' -run 'TestScheduler' -timeout 15m -count=1 -v ./internal/cmd/
 package cmd
 
 import (
-	"context"
 	"database/sql"
 	"encoding/json"
 	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strconv"
 	"strings"
 	"sync/atomic"
 	"testing"
 	"time"
 
-	beadsdk "github.com/steveyegge/beads"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
-	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/scheduler/capacity"
 )
 
@@ -39,74 +35,39 @@ import (
 var schedulerTestCounter atomic.Int32
 
 // initBeadsDBForServer initializes a beads DB that can operate against the
-// shared Dolt test server. It uses the Beads SDK directly instead of shelling
-// out to bd init; the scheduler suite creates dozens of fixture databases, and
-// full CLI init repeatedly exhausts the internal/cmd integration timeout.
+// shared Dolt test server. Uses local init (bd init --prefix --server-port)
+// which reliably creates the schema and records the ephemeral port in
+// metadata.json so subsequent bd commands reach the test server.
 func initBeadsDBForServer(t *testing.T, dir, prefix, homeDir string) {
 	t.Helper()
 	initSchedulerGitRepo(t, dir, homeDir)
 
-	beadsDir := filepath.Join(dir, ".beads")
-	if err := os.MkdirAll(beadsDir, 0755); err != nil {
-		t.Fatalf("mkdir %s: %v", beadsDir, err)
+	args := []string{"init", "--quiet", "--non-interactive", "--skip-hooks", "--skip-agents", "--prefix", prefix}
+	// Forward GT_DOLT_PORT so bd connects to the ephemeral test server
+	// instead of defaulting to port 3307.
+	// bd v1.0.0+ defaults to embedded mode; --server is required to use an
+	// external server (v0.57.0 defaulted to server mode and ignored --server).
+	if p := schedulerDoltPort(); p != "" {
+		args = append(args, "--server", "--external", "--server-port", p)
 	}
-
-	port := schedulerDoltPort()
-	if port == "" {
-		t.Fatal("scheduler Dolt port is not set")
+	cmd := exec.Command("bd", args...)
+	cmd.Dir = dir
+	cmd.Env = schedulerBDInitEnv(homeDir, filepath.Join(dir, ".beads"))
+	out, err := cmd.CombinedOutput()
+	t.Logf("bd init --prefix %s in %s: exit=%v\n%s", prefix, dir, err, out)
+	if err != nil {
+		t.Fatalf("bd init failed in %s: %v\n%s", dir, err, out)
 	}
-	portNum, err := strconv.Atoi(port)
-	if err != nil || portNum <= 0 {
-		t.Fatalf("invalid scheduler Dolt port %q", port)
-	}
-
-	metadata := struct {
-		Database       string `json:"database"`
-		Backend        string `json:"backend"`
-		IssuePrefix    string `json:"issue_prefix"`
-		DoltMode       string `json:"dolt_mode"`
-		DoltServerHost string `json:"dolt_server_host"`
-		DoltServerPort int    `json:"dolt_server_port"`
-		DoltServerUser string `json:"dolt_server_user"`
-		DoltDatabase   string `json:"dolt_database"`
-	}{
-		Database:       "dolt",
-		Backend:        "dolt",
-		IssuePrefix:    prefix,
-		DoltMode:       "server",
-		DoltServerHost: "127.0.0.1",
-		DoltServerPort: portNum,
-		DoltServerUser: "root",
-		DoltDatabase:   schedulerDoltDatabaseName(prefix),
-	}
-	writeJSONFile(t, filepath.Join(beadsDir, "metadata.json"), metadata)
-	if err := os.WriteFile(filepath.Join(beadsDir, "dolt-server.port"), []byte(port+"\n"), 0644); err != nil {
-		t.Fatalf("write dolt-server.port in %s: %v", beadsDir, err)
-	}
-	if err := beads.EnsureConfigYAML(beadsDir, prefix); err != nil {
-		t.Fatalf("write config.yaml in %s: %v", beadsDir, err)
-	}
-
-	seedSchedulerBeadsDB(t, beadsDir, prefix, port)
-
-	for _, kv := range []struct {
-		key   string
-		value string
-	}{
-		{"types.custom", constants.BeadsCustomTypes},
-		{"status.custom", constants.BeadsCustomStatuses},
-	} {
-		if err := beads.EnsureConfigYAMLValue(beadsDir, kv.key, kv.value); err != nil {
-			t.Fatalf("write %s in %s: %v", kv.key, beadsDir, err)
-		}
-	}
-	writeSchedulerCustomConfigSentinels(t, beadsDir)
 
 	// Create empty issues.jsonl to prevent bd auto-export from corrupting
 	// routes.jsonl (same as initBeadsDBWithPrefix does).
 	issuesPath := filepath.Join(dir, ".beads", "issues.jsonl")
 	if err := os.WriteFile(issuesPath, []byte(""), 0644); err != nil {
 		t.Fatalf("create issues.jsonl in %s: %v", dir, err)
+	}
+
+	if err := beads.EnsureCustomTypes(filepath.Join(dir, ".beads")); err != nil {
+		t.Fatalf("ensure custom types in %s: %v", dir, err)
 	}
 }
 
@@ -120,109 +81,13 @@ func initSchedulerGitRepo(t *testing.T, dir, homeDir string) {
 	}
 }
 
-func seedSchedulerBeadsDB(t *testing.T, beadsDir, prefix, port string) {
-	t.Helper()
-	withSchedulerBeadsSDKEnv(t, port, func() {
-		store, err := beadsdk.OpenFromConfig(context.Background(), beadsDir)
-		if err != nil {
-			t.Fatalf("open scheduler beads DB %s: %v", beadsDir, err)
-		}
-		defer store.Close()
-
-		for _, kv := range []struct {
-			key   string
-			value string
-		}{
-			{"issue_prefix", prefix},
-			{"types.custom", constants.BeadsCustomTypes},
-			{"status.custom", constants.BeadsCustomStatuses},
-		} {
-			if err := store.SetConfig(context.Background(), kv.key, kv.value); err != nil {
-				t.Fatalf("set %s in %s: %v", kv.key, beadsDir, err)
-			}
-		}
-
-		got, err := store.GetConfig(context.Background(), "issue_prefix")
-		if err != nil || got != prefix {
-			t.Fatalf("issue_prefix in %s = %q, %v; want %q", beadsDir, got, err, prefix)
-		}
-	})
-}
-
-func withSchedulerBeadsSDKEnv(t *testing.T, port string, fn func()) {
-	t.Helper()
-	keys := map[string]struct{}{
-		"BEADS_DIR":                  {},
-		"BEADS_DB":                   {},
-		"BD_DB":                      {},
-		"BEADS_SHARED_SERVER_DIR":    {},
-		"BEADS_TEST_MODE":            {},
-		"BEADS_DOLT_AUTO_START":      {},
-		"BEADS_DOLT_SERVER_HOST":     {},
-		"BEADS_DOLT_SERVER_PORT":     {},
-		"BEADS_DOLT_PORT":            {},
-		"BEADS_DOLT_SERVER_DATABASE": {},
+func schedulerBDInitEnv(homeDir, beadsDir string) []string {
+	env := cleanSchedulerTestEnv(homeDir)
+	if p := schedulerDoltPort(); p != "" {
+		env = beads.StripEnvKey(env, "GT_DOLT_PORT")
+		env = append(env, "GT_DOLT_PORT="+p)
 	}
-	for _, entry := range os.Environ() {
-		key, _, ok := strings.Cut(entry, "=")
-		if ok && strings.HasPrefix(key, "BEADS_DOLT_") {
-			keys[key] = struct{}{}
-		}
-	}
-	type envValue struct {
-		value string
-		ok    bool
-	}
-	saved := make(map[string]envValue, len(keys))
-	for key := range keys {
-		value, ok := os.LookupEnv(key)
-		saved[key] = envValue{value: value, ok: ok}
-		if err := os.Unsetenv(key); err != nil {
-			t.Fatalf("unset %s: %v", key, err)
-		}
-	}
-	defer func() {
-		for key := range keys {
-			if saved[key].ok {
-				_ = os.Setenv(key, saved[key].value)
-			} else {
-				_ = os.Unsetenv(key)
-			}
-		}
-	}()
-
-	for key, value := range map[string]string{
-		"BEADS_TEST_MODE":        "1",
-		"BEADS_DOLT_AUTO_START":  "0",
-		"BEADS_DOLT_SERVER_HOST": "127.0.0.1",
-		"BEADS_DOLT_SERVER_PORT": port,
-		"BEADS_DOLT_PORT":        port,
-	} {
-		if err := os.Setenv(key, value); err != nil {
-			t.Fatalf("set %s: %v", key, err)
-		}
-	}
-
-	fn()
-}
-
-func writeSchedulerCustomConfigSentinels(t *testing.T, beadsDir string) {
-	t.Helper()
-	for _, file := range []struct {
-		name  string
-		value string
-	}{
-		{".gt-types-configured", constants.BeadsCustomTypes},
-		{".gt-statuses-configured", constants.BeadsCustomStatuses},
-	} {
-		if err := os.WriteFile(filepath.Join(beadsDir, file.name), []byte(file.value+"\n"), 0644); err != nil {
-			t.Fatalf("write %s in %s: %v", file.name, beadsDir, err)
-		}
-	}
-}
-
-func schedulerDoltDatabaseName(prefix string) string {
-	return strings.ReplaceAll(prefix, "-", "_")
+	return beads.BuildMutationPinnedBDEnv(env, beadsDir)
 }
 
 func schedulerDoltPort() string {
@@ -261,6 +126,32 @@ func cleanupSchedulerBeadsDatabases(t *testing.T, prefixes ...string) {
 	})
 }
 
+func setTestBeadStatus(t *testing.T, dir, beadID, status string) {
+	t.Helper()
+	beadsDir := filepath.Join(dir, ".beads")
+	dbName := beads.DatabaseNameFromMetadata(beadsDir)
+	if dbName == "" {
+		t.Fatalf("no Dolt database metadata in %s", beadsDir)
+	}
+	port := schedulerDoltPort()
+	if port == "" {
+		port = "3307"
+	}
+	dsn := fmt.Sprintf("root@tcp(127.0.0.1:%s)/%s", port, dbName)
+	db, err := sql.Open("mysql", dsn)
+	if err != nil {
+		t.Fatalf("open %s: %v", dbName, err)
+	}
+	defer db.Close()
+	res, err := db.Exec("UPDATE issues SET status = ?, updated_at = CURRENT_TIMESTAMP WHERE id = ?", status, beadID)
+	if err != nil {
+		t.Fatalf("set %s status to %s: %v", beadID, status, err)
+	}
+	if n, err := res.RowsAffected(); err == nil && n != 1 {
+		t.Fatalf("set %s status affected %d rows, want 1", beadID, n)
+	}
+}
+
 // setupSchedulerIntegrationTown creates a minimal town filesystem for scheduler tests.
 // Uses the shared Dolt test server (managed by requireDoltServer)
 // for beads databases. No gt install, no Claude credentials, no agent sessions.
@@ -270,7 +161,7 @@ func setupSchedulerIntegrationTown(t *testing.T) (hqPath, rigPath, gtBinary stri
 	t.Helper()
 
 	if _, err := exec.LookPath("bd"); err != nil {
-		t.Skip("bd not installed, skipping scheduler integration test")
+		t.Fatalf("bd not installed: %v", err)
 	}
 
 	requireDoltServer(t)
@@ -282,8 +173,8 @@ func setupSchedulerIntegrationTown(t *testing.T) (hqPath, rigPath, gtBinary stri
 		t.Fatalf("EvalSymlinks: %v", err)
 	}
 
-	// Configure git identity in isolated HOME for scheduler paths that still
-	// exercise bd/gt subprocesses inside temp repos.
+	// Configure git/dolt identity in isolated HOME (needed by bd init --server
+	// which initializes a git repo inside .beads/).
 	configureTestGitIdentity(t, tmpDir)
 
 	// Generate unique prefixes per test to avoid cross-test data leakage on
@@ -745,7 +636,7 @@ func setupMultiRigSchedulerTown(t *testing.T) (hqPath, rig1Path, rig2Path, gtBin
 	t.Helper()
 
 	if _, err := exec.LookPath("bd"); err != nil {
-		t.Skip("bd not installed, skipping scheduler integration test")
+		t.Fatalf("bd not installed: %v", err)
 	}
 
 	requireDoltServer(t)
@@ -1662,15 +1553,7 @@ func TestScheduleBead_RefusesTombstone(t *testing.T) {
 
 	beadID := createTestBead(t, rigPath, "Tombstone bead refused by scheduleBead")
 
-	// Tombstone the bead. bd uses `bd close --tombstone` for terminal removal.
-	closeCmd := exec.Command("bd", "close", beadID, "--tombstone")
-	closeCmd.Dir = rigPath
-	if out, err := closeCmd.CombinedOutput(); err != nil {
-		if strings.Contains(string(out), "unknown flag: --tombstone") {
-			t.Skip("bd CLI does not support close --tombstone")
-		}
-		t.Fatalf("bd close --tombstone %s failed: %v\n%s", beadID, err, out)
-	}
+	setTestBeadStatus(t, rigPath, beadID, "tombstone")
 
 	out, err := runGTCmdMayFail(t, gtBinary, hqPath, env,
 		"sling", beadID, "testrig", "--hook-raw-bead")

--- a/internal/cmd/sling.go
+++ b/internal/cmd/sling.go
@@ -452,7 +452,11 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 					idType, args[0])
 			}
 			if verifyBeadExists(args[0]) != nil {
-				if verifyFormulaExists(args[0]) == nil {
+				formulaWorkDir := townRoot
+				if rigBeadsDir, ok := beads.ResolveRepoAliasBeadsDir(townRoot, rigName); ok {
+					formulaWorkDir = filepath.Dir(rigBeadsDir)
+				}
+				if verifyFormulaExists(args[0], formulaWorkDir, townRoot) == nil {
 					// Standalone formula slinging (cook+wisp+attach) is not bead-based
 					// dispatch and does not consume a scheduler slot — fall through to
 					// runSlingFormula, which handles polecat spawning via resolveTarget.
@@ -569,7 +573,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		if err := verifyBeadExists(beadID); err != nil {
 			return err
 		}
-		if err := verifyFormulaExists(formulaName); err != nil {
+		if err := verifyFormulaExists(formulaName, beads.ResolveHookDir(townRoot, beadID, ""), townRoot); err != nil {
 			return err
 		}
 	} else {
@@ -582,7 +586,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 			beadID = firstArg
 		} else {
 			// Not a verified bead - try as standalone formula
-			if err := verifyFormulaExists(firstArg); err == nil {
+			if err := verifyFormulaExists(firstArg, townRoot, townRoot); err == nil {
 				// Standalone formula mode: gt sling <formula> [target]
 				// Deferred dispatch is handled above for the 2-arg rig case (gh#3917).
 				return runSlingFormula(ctx, args)
@@ -1052,7 +1056,7 @@ func runSling(cmd *cobra.Command, args []string) (retErr error) {
 		slingMerge,
 		slingOwned,
 	)
-	if err := storeFieldsInBead(beadID, fieldUpdates); err != nil {
+	if err := storeFieldsInBeadFromTownRoot(townRoot, beadID, fieldUpdates); err != nil {
 		// Warn but don't fail - polecat will still complete work
 		fmt.Printf("%s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)
 	} else {

--- a/internal/cmd/sling_convoy_test.go
+++ b/internal/cmd/sling_convoy_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -153,6 +154,61 @@ func TestBdDepListRawIDsValidation(t *testing.T) {
 	_, err = bdDepListRawIDs("/tmp", "valid-id", "down", "'; DROP TABLE deps; --")
 	if err == nil {
 		t.Error("bdDepListRawIDs should reject SQL injection in depType")
+	}
+}
+
+func TestBdDepListRawIDsUsesAutoCommitEnv(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd.log")
+	writeBDStub(t, binDir, `#!/usr/bin/env sh
+{
+	printf 'args:'
+	for arg in "$@"; do
+		printf '[%s]' "$arg"
+	done
+	printf '\nBD_READONLY=%s\n' "${BD_READONLY-}"
+	printf 'BD_DOLT_AUTO_COMMIT=%s\n' "${BD_DOLT_AUTO_COMMIT-}"
+} >> "$BD_STUB_LOG"
+printf '[{"depends_on_id":"external:ag:ag-95s.1"}]\n'
+`, "")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_STUB_LOG", logPath)
+	t.Setenv("BD_READONLY", "true")
+	t.Setenv("BD_DOLT_AUTO_COMMIT", "off")
+
+	workDir := t.TempDir()
+	beadsDir := filepath.Join(workDir, ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"dolt_database":"hq"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	ids, err := bdDepListRawIDs(workDir, "hq-cv-test", "down", "tracks")
+	if err != nil {
+		t.Fatalf("bdDepListRawIDs: %v", err)
+	}
+	if len(ids) != 1 || ids[0] != "ag-95s.1" {
+		t.Fatalf("ids = %v, want [ag-95s.1]", ids)
+	}
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := string(logBytes)
+	for _, want := range []string{
+		"args:[sql][SELECT COALESCE",
+		"\nBD_READONLY=\n",
+		"BD_DOLT_AUTO_COMMIT=on",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("bd stub log missing %q:\n%s", want, log)
+		}
 	}
 }
 

--- a/internal/cmd/sling_dispatch.go
+++ b/internal/cmd/sling_dispatch.go
@@ -376,7 +376,7 @@ func executeSling(params SlingParams) (*SlingResult, error) {
 		FormulaVars:      formulaVarsForAttachment,
 	}
 	// Use beadToHook for the update target (may differ from beadID when formula-on-bead)
-	if err := storeFieldsInBead(beadToHook, fieldUpdates); err != nil {
+	if err := storeFieldsInBeadFromTownRoot(townRoot, beadToHook, fieldUpdates); err != nil {
 		fmt.Printf("  %s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)
 	}
 

--- a/internal/cmd/sling_formula.go
+++ b/internal/cmd/sling_formula.go
@@ -14,6 +14,7 @@ import (
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/cli"
 	"github.com/steveyegge/gastown/internal/events"
+	"github.com/steveyegge/gastown/internal/formula"
 	"github.com/steveyegge/gastown/internal/style"
 	"github.com/steveyegge/gastown/internal/telemetry"
 	"github.com/steveyegge/gastown/internal/tmux"
@@ -248,13 +249,18 @@ func shouldReuseExistingFormula(existing *beads.Issue, delayedDogInfo *DogDispat
 // verifyFormulaExists checks that the formula exists using bd formula show.
 // Formulas are TOML files (.formula.toml).
 // Requests stale-read compatibility for consistency with verifyBeadExists.
-func verifyFormulaExists(formulaName string) error {
+func verifyFormulaExists(formulaName, workDir, townRoot string) error {
+	if workDir == "" {
+		workDir = townRoot
+	}
 	// Try bd formula show (handles all formula file formats)
 	// Use Output() instead of Run() to detect bd exit 0 bug:
 	// when formula not found, bd may exit 0 but produce empty stdout.
 	// Stderr discarded — first attempt may fail expectedly (retry with mol- prefix).
 	if out, err := BdCmd("formula", "show", formulaName).
 		AllowStale().
+		Dir(workDir).
+		WithGTRoot(townRoot).
 		Stderr(io.Discard).Output(); err == nil && len(out) > 0 {
 		return nil
 	}
@@ -262,7 +268,15 @@ func verifyFormulaExists(formulaName string) error {
 	// Try with mol- prefix
 	if out, err := BdCmd("formula", "show", "mol-"+formulaName).
 		AllowStale().
+		Dir(workDir).
+		WithGTRoot(townRoot).
 		Stderr(io.Discard).Output(); err == nil && len(out) > 0 {
+		return nil
+	}
+	if _, err := formula.GetEmbeddedFormulaContent(formulaName); err == nil {
+		return nil
+	}
+	if _, err := formula.GetEmbeddedFormulaContent("mol-" + formulaName); err == nil {
 		return nil
 	}
 
@@ -405,7 +419,7 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 			existingMode = fields.Mode
 		}
 		if existingMode != mode {
-			if err := storeFieldsInBead(existing.ID, beadFieldUpdates{Mode: &mode}); err != nil {
+			if err := storeFieldsInBeadFromTownRoot(townRoot, existing.ID, beadFieldUpdates{Mode: &mode}); err != nil {
 				return fmt.Errorf("updating existing formula mode: %w", err)
 			}
 			if mode != "" || existingMode != "" {
@@ -516,7 +530,7 @@ func runSlingFormula(ctx context.Context, args []string) (err error) {
 		Mode:            &mode,
 		FormulaVars:     strings.Join(slingVars, "\n"),
 	}
-	if err := storeFieldsInBead(wispRootID, fieldUpdates); err != nil {
+	if err := storeFieldsInBeadFromTownRoot(townRoot, wispRootID, fieldUpdates); err != nil {
 		fmt.Printf("%s Could not store fields in bead: %v\n", style.Dim.Render("Warning:"), err)
 	} else if slingArgs != "" {
 		fmt.Printf("%s Args stored in bead (durable)\n", style.Bold.Render("✓"))

--- a/internal/cmd/sling_helpers.go
+++ b/internal/cmd/sling_helpers.go
@@ -19,7 +19,6 @@ import (
 	"github.com/steveyegge/gastown/internal/config"
 	"github.com/steveyegge/gastown/internal/constants"
 	"github.com/steveyegge/gastown/internal/daemon"
-	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/formula"
 	rigpkg "github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/session"
@@ -323,17 +322,11 @@ func verifyBeadExistsInTargetRigDatabase(beadID, targetRig, townRoot string) err
 		return fmt.Errorf("cannot verify bead %s in target rig %q: town root is unavailable; refusing to sling before creating hooks or molecule side effects", beadID, targetRig)
 	}
 
-	targetRigDir := beads.GetRigDirForName(townRoot, targetRig)
-	targetBeadsDir := ""
-	if targetRigDir != "" {
-		targetBeadsDir = filepath.Join(targetRigDir, ".beads")
-	} else {
-		targetBeadsDir = doltserver.FindRigBeadsDir(townRoot, targetRig)
-		targetRigDir = filepath.Dir(targetBeadsDir)
-	}
-	if targetBeadsDir == "" || targetRigDir == "." {
+	targetBeadsDir, ok := beads.ResolveRepoAliasBeadsDir(townRoot, targetRig)
+	if !ok {
 		return fmt.Errorf("cannot resolve target rig %q beads database for bead %s; refusing to sling before creating hooks or molecule side effects", targetRig, beadID)
 	}
+	targetRigDir := filepath.Dir(targetBeadsDir)
 
 	out, err := BdCmd("show", beadID, "--json").
 		AllowStale().
@@ -511,12 +504,16 @@ func buildSlingFieldUpdates(
 // storeArgsInBead, storeAttachedMoleculeInBead, and storeNoMergeInBead calls that each
 // independently read-modify-write and could race under concurrent access.
 func storeFieldsInBead(beadID string, updates beadFieldUpdates) error {
+	return storeFieldsInBeadFromTownRoot("", beadID, updates)
+}
+
+func storeFieldsInBeadFromTownRoot(townRoot, beadID string, updates beadFieldUpdates) error {
 	logPath := os.Getenv("GT_TEST_ATTACHED_MOLECULE_LOG")
 
 	issue := &beads.Issue{}
 	if logPath == "" {
 		// Read the bead once
-		out, err := bdShowBeadOutput(beadID)
+		out, err := bdShowBeadOutputFromTownRoot(townRoot, beadID)
 		if err != nil {
 			return fmt.Errorf("fetching bead: %w", err)
 		}
@@ -588,8 +585,12 @@ func storeFieldsInBead(beadID string, updates beadFieldUpdates) error {
 		return nil
 	}
 
+	updateDir := resolveBeadDir(beadID)
+	if townRoot != "" {
+		updateDir = resolveBeadDirFromTownRoot(townRoot, beadID)
+	}
 	if err := BdCmd("update", beadID, "--description="+newDesc).
-		Dir(resolveBeadDir(beadID)).
+		Dir(updateDir).
 		StripBeadsDir().
 		WithAutoCommit().
 		Run(); err != nil {

--- a/internal/cmd/sling_schedule.go
+++ b/internal/cmd/sling_schedule.go
@@ -9,7 +9,6 @@ import (
 	"github.com/spf13/cobra"
 	"github.com/steveyegge/gastown/internal/beads"
 	"github.com/steveyegge/gastown/internal/config"
-	"github.com/steveyegge/gastown/internal/doltserver"
 	"github.com/steveyegge/gastown/internal/events"
 	"github.com/steveyegge/gastown/internal/rig"
 	"github.com/steveyegge/gastown/internal/scheduler/capacity"
@@ -100,8 +99,11 @@ func scheduleBead(beadID, rigName string, opts ScheduleOptions) error {
 	// Create the sling context in the target rig's beads dir so that the target
 	// rig's witness can discover it during patrol. Previously this used the HQ
 	// beads dir, which meant non-HQ rig witnesses never saw the context. (GH#3468)
-	rigBeadsDir := doltserver.FindRigBeadsDir(townRoot, rigName)
-	rigBeads := beads.NewWithBeadsDir(townRoot, rigBeadsDir)
+	rigBeadsDir, ok := beads.ResolveRepoAliasBeadsDir(townRoot, rigName)
+	if !ok {
+		return fmt.Errorf("cannot resolve target rig %q beads database for bead %s", rigName, beadID)
+	}
+	rigBeads := beads.NewWithBeadsDir(filepath.Dir(rigBeadsDir), rigBeadsDir)
 	existingCtx, _, findErr := rigBeads.FindOpenSlingContext(beadID)
 	if findErr != nil {
 		return fmt.Errorf("checking for existing sling context: %w", findErr)
@@ -127,7 +129,7 @@ func scheduleBead(beadID, rigName string, opts ScheduleOptions) error {
 	}
 
 	if opts.Formula != "" {
-		if err := verifyFormulaExists(opts.Formula); err != nil {
+		if err := verifyFormulaExists(opts.Formula, filepath.Dir(rigBeadsDir), townRoot); err != nil {
 			return fmt.Errorf("formula %q not found: %w", opts.Formula, err)
 		}
 	}

--- a/internal/cmd/sling_test.go
+++ b/internal/cmd/sling_test.go
@@ -346,6 +346,7 @@ exit /b 0
 	gotBondCount := 0
 	gotCreate := false
 	gotTargetDBCheck := false
+	gotFormulaShow := false
 	gotHook := false
 	gotMetadata := false
 	assertTargetRig := func(kind, dir, beadsDir, database, beadsDB, bdDB, dataDir, args string) {
@@ -390,6 +391,9 @@ exit /b 0
 		case strings.Contains(args, "show "+newBeadID) && strings.Contains(args, "--json"):
 			gotTargetDBCheck = true
 			assertTargetRig("target DB check", dir, beadsDir, database, beadsDB, bdDB, dataDir, args)
+		case strings.Contains(args, "formula show "):
+			gotFormulaShow = true
+			assertTargetRig("formula show", dir, beadsDir, database, beadsDB, bdDB, dataDir, args)
 		case strings.Contains(args, "cook "):
 			switch {
 			case strings.Contains(args, "mol-polecat-work"):
@@ -421,7 +425,7 @@ exit /b 0
 			assertTargetRig("metadata update", dir, beadsDir, database, beadsDB, bdDB, dataDir, args)
 		case strings.Contains(args, "update "+newBeadID) && strings.Contains(args, "--description="):
 			assertTargetRig("description update", dir, beadsDir, database, beadsDB, bdDB, dataDir, args)
-		case args == "--version" || strings.HasPrefix(args, "version") || strings.Contains(args, " version") || strings.HasPrefix(args, "formula ") || strings.Contains(args, "show gt-rig-") || strings.Contains(args, "show mol-"):
+		case args == "--version" || strings.HasPrefix(args, "version") || strings.Contains(args, " version") || strings.Contains(args, "show gt-rig-") || strings.Contains(args, "show mol-"):
 			// Explicitly exempt non-target-bead lookups; every gt-new123 operation
 			// above must still prove it is pinned to the gastown database.
 		default:
@@ -429,9 +433,9 @@ exit /b 0
 		}
 	}
 
-	if !gotCreate || !gotTargetDBCheck || !gotPolecatCook || !gotPolecatWisp || !gotReviewCook || !gotReviewWisp || gotBondCount < 2 || !gotHook || !gotMetadata {
-		t.Fatalf("missing expected bd commands: create=%v targetDBCheck=%v polecat(cook=%v wisp=%v) review(cook=%v wisp=%v) bondCount=%d hook=%v metadata=%v (log: %q)",
-			gotCreate, gotTargetDBCheck, gotPolecatCook, gotPolecatWisp, gotReviewCook, gotReviewWisp, gotBondCount, gotHook, gotMetadata, string(logBytes))
+	if !gotCreate || !gotTargetDBCheck || !gotFormulaShow || !gotPolecatCook || !gotPolecatWisp || !gotReviewCook || !gotReviewWisp || gotBondCount < 2 || !gotHook || !gotMetadata {
+		t.Fatalf("missing expected bd commands: create=%v targetDBCheck=%v formulaShow=%v polecat(cook=%v wisp=%v) review(cook=%v wisp=%v) bondCount=%d hook=%v metadata=%v (log: %q)",
+			gotCreate, gotTargetDBCheck, gotFormulaShow, gotPolecatCook, gotPolecatWisp, gotReviewCook, gotReviewWisp, gotBondCount, gotHook, gotMetadata, string(logBytes))
 	}
 }
 
@@ -566,7 +570,7 @@ func TestSlingRollsBackSpawnedPolecatOnInstantiateFailure(t *testing.T) {
 	if err := config.SaveRigsConfig(rigsPath, rigs); err != nil {
 		t.Fatalf("SaveRigsConfig: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Join(townRoot, "gastown", "mayor", "rig"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads"), 0755); err != nil {
 		t.Fatalf("mkdir rig beads dir: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Join(townRoot, "gastown"), 0755); err != nil {
@@ -728,7 +732,7 @@ func TestSlingRollsBackSpawnedPolecatOnHookFailure(t *testing.T) {
 	if err := os.WriteFile(filepath.Join(townRoot, "mayor", "town.json"), []byte(`{"version":1}`), 0644); err != nil {
 		t.Fatalf("write town marker: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Join(townRoot, "gastown", "mayor", "rig"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads"), 0755); err != nil {
 		t.Fatalf("mkdir gastown mayor rig: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
@@ -848,7 +852,7 @@ func TestSlingRejectsBeadMissingFromTargetRigBeforeSpawn(t *testing.T) {
 	if err := config.SaveRigsConfig(rigsPath, rigs); err != nil {
 		t.Fatalf("SaveRigsConfig: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Join(townRoot, "gastown", "mayor", "rig"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads"), 0755); err != nil {
 		t.Fatalf("mkdir target rig dir: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {
@@ -979,7 +983,7 @@ func setupCrossDatabaseSlingGuardTest(t *testing.T) (townRoot, logPath string) {
 	if err := config.SaveRigsConfig(rigsPath, rigs); err != nil {
 		t.Fatalf("SaveRigsConfig: %v", err)
 	}
-	if err := os.MkdirAll(filepath.Join(townRoot, "gastown", "mayor", "rig"), 0755); err != nil {
+	if err := os.MkdirAll(filepath.Join(townRoot, "gastown", "mayor", "rig", ".beads"), 0755); err != nil {
 		t.Fatalf("mkdir target rig dir: %v", err)
 	}
 	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0755); err != nil {

--- a/internal/cmd/tracking_relations.go
+++ b/internal/cmd/tracking_relations.go
@@ -65,9 +65,10 @@ func mutateTrackingRelationViaStore(townRoot, trackerID, issueID string, add boo
 }
 
 func fallbackTrackingRelation(townRoot, trackerID, issueID string, add bool, storeErr error) error {
-	args := []string{"dep", "add", trackerID, issueID, "--type=tracks"}
+	targetID := trackingDependsOnID(townRoot, issueID)
+	args := []string{"dep", "add", trackerID, targetID, "--type=tracks"}
 	if !add {
-		args = []string{"dep", "remove", trackerID, issueID, "--type=tracks"}
+		args = []string{"dep", "remove", trackerID, targetID, "--type=tracks"}
 	}
 
 	if out, err := BdCmd(args...).Dir(townRoot).WithAutoCommit().StripBeadsDir().CombinedOutput(); err != nil {

--- a/internal/cmd/tracking_relations_test.go
+++ b/internal/cmd/tracking_relations_test.go
@@ -1,8 +1,11 @@
 package cmd
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
+	"runtime"
+	"strings"
 	"testing"
 )
 
@@ -27,5 +30,55 @@ func TestTrackingDependsOnID_HQStaysLocal(t *testing.T) {
 	got := trackingDependsOnID(townRoot, "hq-cv-test")
 	if got != "hq-cv-test" {
 		t.Fatalf("trackingDependsOnID() = %q, want %q", got, "hq-cv-test")
+	}
+}
+
+func TestFallbackTrackingRelationUsesExternalTarget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("skipping on windows")
+	}
+
+	townRoot := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(townRoot, ".beads"), 0o755); err != nil {
+		t.Fatalf("mkdir .beads: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(townRoot, ".beads", "routes.jsonl"), []byte("{\"prefix\":\"ag-\",\"path\":\"agentcompany/.beads\"}\n"), 0o644); err != nil {
+		t.Fatalf("write routes.jsonl: %v", err)
+	}
+
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd.log")
+	writeBDStub(t, binDir, `#!/usr/bin/env sh
+{
+	printf 'args:'
+	for arg in "$@"; do
+		printf '[%s]' "$arg"
+	done
+	printf '\n'
+} >> "$BD_STUB_LOG"
+`, "")
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_STUB_LOG", logPath)
+
+	storeErr := errors.New("store unavailable")
+	if err := fallbackTrackingRelation(townRoot, "hq-cv-test", "ag-95s.1", true, storeErr); err != nil {
+		t.Fatalf("fallback add: %v", err)
+	}
+	if err := fallbackTrackingRelation(townRoot, "hq-cv-test", "ag-95s.1", false, storeErr); err != nil {
+		t.Fatalf("fallback remove: %v", err)
+	}
+
+	logBytes, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	log := string(logBytes)
+	for _, want := range []string{
+		"args:[dep][add][hq-cv-test][external:ag:ag-95s.1][--type=tracks]",
+		"args:[dep][remove][hq-cv-test][external:ag:ag-95s.1][--type=tracks]",
+	} {
+		if !strings.Contains(log, want) {
+			t.Fatalf("bd stub log missing %q:\n%s", want, log)
+		}
 	}
 }

--- a/internal/mail/bd.go
+++ b/internal/mail/bd.go
@@ -73,7 +73,7 @@ func runBdCommand(ctx context.Context, args []string, workDir, beadsDir string, 
 	cmd.Dir = workDir
 	util.SetDetachedProcessGroup(cmd)
 
-	cmd.Env = bdSubprocessEnv(cmd.Environ(), beadsDir, isMailBdReadCommand(args), extraEnv)
+	cmd.Env = bdSubprocessEnv(cmd.Environ(), beadsDir, beads.ArgsAreReadOnly(args), extraEnv)
 
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
@@ -135,48 +135,6 @@ func bdSubprocessEnv(baseEnv []string, beadsDir string, readOnly bool, extraEnv 
 	env := beads.EnvForSubprocessMode(base, beadsDir, mode)
 	env = append(env, telemetry.OTELEnvForSubprocess()...)
 	return env
-}
-
-func filterEnvKey(env []string, key string) []string {
-	prefix := key + "="
-	filtered := make([]string, 0, len(env))
-	for _, entry := range env {
-		if strings.HasPrefix(entry, prefix) {
-			continue
-		}
-		filtered = append(filtered, entry)
-	}
-	return filtered
-}
-
-func isMailBdReadCommand(args []string) bool {
-	if len(args) == 0 {
-		return false
-	}
-	switch args[0] {
-	case "list", "show", "search":
-		return true
-	case "message":
-		return len(args) >= 2 && args[1] == "thread"
-	case "mol":
-		return len(args) >= 3 && args[1] == "wisp" && args[2] == "list"
-	case "sql":
-		query := ""
-		for i := len(args) - 1; i >= 1; i-- {
-			if !strings.HasPrefix(args[i], "-") {
-				query = args[i]
-				break
-			}
-		}
-		q := strings.ToLower(strings.TrimSpace(query))
-		return strings.HasPrefix(q, "select") || strings.HasPrefix(q, "show") || strings.HasPrefix(q, "explain") || strings.HasPrefix(q, "describe") || strings.HasPrefix(q, "with")
-	default:
-		return false
-	}
-}
-
-func filterBdTargetEnv(env []string) []string {
-	return beads.StripBDTargetEnv(env)
 }
 
 // bdReadCtx returns a context with the standard bd read timeout.

--- a/internal/mail/bd_test.go
+++ b/internal/mail/bd_test.go
@@ -302,7 +302,10 @@ func TestBdSubprocessEnv_DoesNotMutateBaseEnv(t *testing.T) {
 }
 
 func TestBdSubprocessEnv_FiltersStaleBdTargetEnv(t *testing.T) {
-	beadsDir := t.TempDir()
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
 	metadata := []byte(`{"dolt_database":"rigdb"}`)
 	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), metadata, 0644); err != nil {
 		t.Fatal(err)

--- a/internal/mail/bd_test.go
+++ b/internal/mail/bd_test.go
@@ -1,6 +1,7 @@
 package mail
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"os"
@@ -8,6 +9,8 @@ import (
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/steveyegge/gastown/internal/beads"
 )
 
 func TestBdError_Error(t *testing.T) {
@@ -350,7 +353,7 @@ func TestBdSubprocessEnv_ReadonlyCannotBeOverridden(t *testing.T) {
 	}
 }
 
-func TestIsMailBdReadCommand(t *testing.T) {
+func TestArgsAreReadOnlyForMailCommands(t *testing.T) {
 	tests := []struct {
 		args []string
 		want bool
@@ -358,10 +361,10 @@ func TestIsMailBdReadCommand(t *testing.T) {
 		{[]string{"list", "--json"}, true},
 		{[]string{"show", "hq-abc"}, true},
 		{[]string{"sql", "--json", "SELECT * FROM wisps"}, true},
-		{[]string{"sql", "--json", "WITH x AS (SELECT 1) SELECT * FROM x"}, true},
 		{[]string{"mol", "wisp", "list", "--json"}, true},
 		{[]string{"message", "thread", "hq-abc", "--json"}, true},
 		{[]string{"sql", "UPDATE issues SET status='closed'"}, false},
+		{[]string{"sql", "--json", "WITH x AS (SELECT 1) SELECT * FROM x"}, false},
 		{[]string{"mol", "wisp", "create", "mol-test"}, false},
 		{[]string{"message", "send", "mayor", "--body", "hi"}, false},
 		{[]string{"create", "title"}, false},
@@ -369,8 +372,54 @@ func TestIsMailBdReadCommand(t *testing.T) {
 		{[]string{"label", "add", "hq-abc", "read"}, false},
 	}
 	for _, tt := range tests {
-		if got := isMailBdReadCommand(tt.args); got != tt.want {
-			t.Fatalf("isMailBdReadCommand(%v) = %v, want %v", tt.args, got, tt.want)
+		if got := beads.ArgsAreReadOnly(tt.args); got != tt.want {
+			t.Fatalf("beads.ArgsAreReadOnly(%v) = %v, want %v", tt.args, got, tt.want)
+		}
+	}
+}
+
+func TestRunBdCommandUsesCentralEnvPolicy(t *testing.T) {
+	binDir := t.TempDir()
+	logPath := filepath.Join(t.TempDir(), "bd.log")
+	writeMailBDStub(t, binDir)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	t.Setenv("BD_STUB_LOG", logPath)
+	t.Setenv("BEADS_DIR", "/wrong")
+	t.Setenv("BEADS_DOLT_SERVER_DATABASE", "wrongdb")
+	t.Setenv("BD_READONLY", "false")
+	t.Setenv("BD_DOLT_AUTO_COMMIT", "on")
+
+	beadsDir := filepath.Join(t.TempDir(), ".beads")
+	if err := os.MkdirAll(beadsDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(beadsDir, "metadata.json"), []byte(`{"dolt_database":"maildb"}`), 0644); err != nil {
+		t.Fatal(err)
+	}
+	workDir := filepath.Dir(beadsDir)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if _, err := runBdCommand(ctx, []string{"list", "--json"}, workDir, beadsDir, "BD_IDENTITY=gastown/chrome", "BD_READONLY=false", "BD_DOLT_AUTO_COMMIT=on"); err != nil {
+		t.Fatalf("run read bd command: %v", err)
+	}
+	readLog := readStubLog(t, logPath)
+	for _, want := range []string{"args:[list][--json][--flat]", "BD_READONLY=true", "BD_DOLT_AUTO_COMMIT=off", "BEADS_NO_AUTO_IMPORT=1", "BD_IDENTITY=gastown/chrome", "BEADS_DIR=" + beadsDir, "BEADS_DOLT_SERVER_DATABASE=maildb"} {
+		if !strings.Contains(readLog, want) {
+			t.Fatalf("read command log missing %q:\n%s", want, readLog)
+		}
+	}
+
+	if err := os.WriteFile(logPath, nil, 0644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := runBdCommand(ctx, []string{"label", "add", "hq-msg", "read"}, workDir, beadsDir, "BD_IDENTITY=gastown/chrome", "BD_READONLY=true", "BD_DOLT_AUTO_COMMIT=off"); err != nil {
+		t.Fatalf("run write bd command: %v", err)
+	}
+	writeLog := readStubLog(t, logPath)
+	for _, want := range []string{"args:[label][add][hq-msg][read]", "\nBD_READONLY=\n", "BD_DOLT_AUTO_COMMIT=on", "BEADS_NO_AUTO_IMPORT=1", "BD_IDENTITY=gastown/chrome", "BEADS_DIR=" + beadsDir, "BEADS_DOLT_SERVER_DATABASE=maildb"} {
+		if !strings.Contains(writeLog, want) {
+			t.Fatalf("write command log missing %q:\n%s", want, writeLog)
 		}
 	}
 }
@@ -399,6 +448,38 @@ func TestBdSubprocessEnv_AllowsRoutingWhenBeadsDirEmpty(t *testing.T) {
 	if !envContains(got, "BEADS_DOLT_SERVER_HOST=127.0.0.2") || !envContains(got, "BEADS_DOLT_SERVER_PORT=5507") || !envContains(got, "BEADS_DOLT_PORT=5507") {
 		t.Fatalf("expected GT_DOLT host/port fallback for routed command, got %v", got)
 	}
+}
+
+func writeMailBDStub(t *testing.T, binDir string) {
+	t.Helper()
+	script := `#!/usr/bin/env sh
+{
+	printf 'args:'
+	for arg in "$@"; do
+		printf '[%s]' "$arg"
+	done
+	printf '\n'
+	printf 'BD_READONLY=%s\n' "${BD_READONLY-}"
+	printf 'BD_DOLT_AUTO_COMMIT=%s\n' "${BD_DOLT_AUTO_COMMIT-}"
+	printf 'BEADS_NO_AUTO_IMPORT=%s\n' "${BEADS_NO_AUTO_IMPORT-}"
+	printf 'BD_IDENTITY=%s\n' "${BD_IDENTITY-}"
+	printf 'BEADS_DIR=%s\n' "${BEADS_DIR-}"
+	printf 'BEADS_DOLT_SERVER_DATABASE=%s\n' "${BEADS_DOLT_SERVER_DATABASE-}"
+} >> "$BD_STUB_LOG"
+printf '[]\n'
+`
+	if err := os.WriteFile(filepath.Join(binDir, "bd"), []byte(script), 0755); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func readStubLog(t *testing.T, path string) string {
+	t.Helper()
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(data)
 }
 
 func envContains(env []string, kv string) bool {

--- a/internal/rig/manager.go
+++ b/internal/rig/manager.go
@@ -650,21 +650,9 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 			}
 		}
 
-		// Always ensure issue_prefix and custom types are configured, even when
-		// metadata.json was tracked in git (bdDatabaseExists returned true).
-		// The tracked metadata.json tells bd HOW to connect but doesn't guarantee
-		// the server-side database has issue_prefix set for this workspace.
-		configCmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
-		configCmd.Dir = mayorRigPath
-		configCmd.Env = sourceBdEnv
-		_, _ = configCmd.CombinedOutput() // Ignore errors - older beads don't need this
-
-		prefixSetCmd := exec.Command("bd", "config", "set", "issue_prefix", opts.BeadsPrefix)
-		prefixSetCmd.Dir = mayorRigPath
-		prefixSetCmd.Env = sourceBdEnv
-		if prefixOutput, prefixErr := prefixSetCmd.CombinedOutput(); prefixErr != nil {
-			fmt.Printf("  Warning: Could not set issue_prefix: %v (%s)\n", prefixErr, strings.TrimSpace(string(prefixOutput)))
-		}
+		// Do not mutate source repo config.yaml here: tracked-beads source repos
+		// must remain clean after rig add. Canonical rig config is written below
+		// after the shared rig .beads directory and metadata are established.
 	}
 
 	// NOTE: No per-directory CLAUDE.md/AGENTS.md is created for any agent.
@@ -709,23 +697,22 @@ func (m *Manager) AddRig(opts AddRigOptions) (*Rig, error) {
 		return nil, fmt.Errorf("rig init left a duplicate Dolt database: %w", err)
 	}
 
-	// Set issue_prefix on the correct server-side database.
-	// InitBeads ran bd config set issue_prefix, but against the wrong database
-	// (beads_<prefix> from bd init, not <rigName> from the centralized server).
-	// Now that EnsureMetadata has corrected dolt_database, re-set it.
+	// Set issue_prefix on the correct server-side database. bd 1.0+ rejects
+	// `bd config set issue_prefix`, so write both config.yaml and Dolt config
+	// directly after metadata points at the canonical rig database.
 	{
-		resolvedBeadsDir := beads.ResolveBeadsDir(rigPath)
-		bdEnv := bdSubprocessEnv(resolvedBeadsDir, opts.Name)
-		prefixCmd := exec.Command("bd", "config", "set", "issue_prefix", opts.BeadsPrefix)
-		prefixCmd.Dir = rigPath
-		prefixCmd.Env = bdEnv
-		if out, err := prefixCmd.CombinedOutput(); err != nil {
-			fmt.Printf("  Warning: Could not set issue_prefix on rig database: %v (%s)\n", err, strings.TrimSpace(string(out)))
+		rigRootBeadsDir := filepath.Join(rigPath, ".beads")
+		resolvedBeadsDir := beads.ResolveBeadsDir(rigRootBeadsDir)
+		if _, err := os.Stat(filepath.Join(rigRootBeadsDir, "redirect")); os.IsNotExist(err) {
+			if err := beads.EnsureConfigYAMLValue(resolvedBeadsDir, "issue-prefix", opts.BeadsPrefix); err != nil {
+				fmt.Printf("  Warning: Could not set issue-prefix in config.yaml: %v\n", err)
+			}
+			_ = beads.EnsureConfigYAMLValue(resolvedBeadsDir, "types.custom", constants.BeadsCustomTypes)
 		}
-		typesCmd := exec.Command("bd", "config", "set", "types.custom", constants.BeadsCustomTypes)
-		typesCmd.Dir = rigPath
-		typesCmd.Env = bdEnv
-		_, _ = typesCmd.CombinedOutput()
+		if err := beads.EnsureDoltConfigValue(resolvedBeadsDir, "issue_prefix", opts.BeadsPrefix); err != nil {
+			fmt.Printf("  Warning: Could not set issue_prefix in rig database: %v\n", err)
+		}
+		_ = beads.EnsureDoltConfigValue(resolvedBeadsDir, "types.custom", constants.BeadsCustomTypes)
 	}
 
 	// Auto-create DoltHub remote for the rig's beads database.

--- a/plugins/dolt-snapshots/main.go
+++ b/plugins/dolt-snapshots/main.go
@@ -382,12 +382,7 @@ func findConvoysNeedingSnapshots(db *sql.DB) ([]convoyRow, error) {
 // discoverConvoyDatabases finds which rig databases a convoy touches
 // by looking at its tracked issues' prefixes.
 func discoverConvoyDatabases(db *sql.DB, convoyID string, databases []string, routes map[string]string) ([]string, error) {
-	query := `
-		SELECT DISTINCT d.depends_on_id
-		FROM hq.dependencies d
-		WHERE d.issue_id = ? AND d.type = 'tracks'
-	`
-	rows, err := db.Query(query, convoyID)
+	rows, err := db.Query(convoyDependencyTargetsQuery(), convoyID)
 	if err != nil {
 		return nil, err
 	}
@@ -421,15 +416,27 @@ func discoverConvoyDatabases(db *sql.DB, convoyID string, databases []string, ro
 	return result, rows.Err()
 }
 
+func convoyDependencyTargetsQuery() string {
+	return `
+		SELECT DISTINCT COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) AS depends_on_id
+		FROM hq.dependencies d
+		WHERE d.issue_id = ? AND d.type = 'tracks'
+			AND COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) IS NOT NULL
+	`
+}
+
 // resolveDependencyDB extracts the database name from a dependency ID.
 // Handles two formats:
-//   - "external:<rig_name>:<bead_id>" → rig_name
+//   - "external:<prefix-or-rig>:<bead_id>" → routes[prefix] or rig name
 //   - "<prefix>-<id>" → routes[prefix]
 func resolveDependencyDB(depID string, routes map[string]string) string {
 	if strings.HasPrefix(depID, "external:") {
-		// Format: external:<rig_name>:<bead_id>
+		// Format: external:<prefix-or-rig>:<bead_id>
 		parts := strings.SplitN(depID, ":", 3)
 		if len(parts) >= 2 {
+			if mapped, ok := routes[parts[1]]; ok {
+				return mapped
+			}
 			return parts[1]
 		}
 		return ""

--- a/plugins/dolt-snapshots/main_test.go
+++ b/plugins/dolt-snapshots/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -93,8 +94,8 @@ func TestIsSystemDB(t *testing.T) {
 		{"lora_forge", false},
 		{"node0", false},
 		// Edge cases: names that start with system prefixes but aren't
-		{"testdb", false},        // exactly "testdb" with no underscore
-		{"beads", false},         // exactly "beads"
+		{"testdb", false},           // exactly "testdb" with no underscore
+		{"beads", false},            // exactly "beads"
 		{"beads_production", false}, // doesn't match beads_t or beads_pt
 	}
 
@@ -236,6 +237,8 @@ func TestResolveDependencyDB(t *testing.T) {
 		{"external:petals:pe-k0e.1.1", "petals"},
 		{"external:lora_forge:lf-mx5rb", "lora_forge"},
 		{"external:node0:no-2yg", "node0"},
+		{"external:pe:pe-k0e.1.1", "petals"},
+		{"external:lf:lf-mx5rb", "lora_forge"},
 
 		// Prefix format (via routes)
 		{"pe-k0e", "petals"},
@@ -276,6 +279,23 @@ func TestResolveDependencyDB_EmptyRoutes(t *testing.T) {
 	// Prefix deps fail without routes
 	if got := resolveDependencyDB("pe-123", routes); got != "" {
 		t.Errorf("Expected empty for prefix dep with empty routes, got %q", got)
+	}
+}
+
+func TestConvoyDependencyTargetsQueryUsesTypedTargets(t *testing.T) {
+	query := convoyDependencyTargetsQuery()
+	if strings.Contains(query, "d.depends_on_id") {
+		t.Fatalf("query should not select legacy physical depends_on_id column:\n%s", query)
+	}
+	for _, want := range []string{
+		"COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) AS depends_on_id",
+		"COALESCE(d.depends_on_issue_id, d.depends_on_wisp_id, d.depends_on_external) IS NOT NULL",
+		"d.issue_id = ?",
+		"d.type = 'tracks'",
+	} {
+		if !strings.Contains(query, want) {
+			t.Fatalf("query missing %q:\n%s", want, query)
+		}
 	}
 }
 


### PR DESCRIPTION
Replacement for #4331 and #4337. Incorporates the useful regression-test intent from #4343 without taking that stale branch as a replacement.

What changed:
- Keeps the core bd env/dependency-routing split from #4337.
- Aligns CI/nightly bd install version with the Beads SDK version in go.mod to avoid fresh-install schema drift.
- Scrubs fresh setup Beads target env through the central helper.
- Adds the inside-town pinned bd env regression coverage inspired by #4343.

Evidence:
- PR Sheriff work bead: gt-pr-4337-fold-4343-fix-integration.
- 15 research legs, 5 pre-implementation reviews, and 5 post-implementation reviews were completed by gastown/deathclaw.
- Targeted checks passed: go list resolved github.com/steveyegge/beads v1.0.5, CGO_ENABLED=0 go test ./internal/beads -run TestBuildPinnedBDEnv -count=1, and git diff --check.
- Local full integration was blocked by rootless Docker unavailability; normal cgo package build was blocked by missing system ICU libraries.

Attribution:
- Original #4331/#4337 work by Bella-Giraffety/Gas Town agents.
- #4343 insight/test intent credited in commit via Co-authored-by: Marvin Cris Andrade <marvincris@outlook.com>.

Supersedes #4331.
Supersedes #4337.
Uses evidence from #4343.