### PR TITLE
fix(refinery): recheck merge eligibility before push

### DIFF
--- a/internal/refinery/batch.go
+++ b/internal/refinery/batch.go
@@ -290,7 +290,9 @@ func (e *Engineer) ProcessBatch(ctx context.Context, batch []*MRInfo, target str
 // processSingleMR handles the degenerate case of a batch with one MR.
 func (e *Engineer) processSingleMR(ctx context.Context, mr *MRInfo, target string) *BatchResult {
 	result := &BatchResult{}
-	processResult := e.doMerge(ctx, mr.Branch, target, mr.SourceIssue)
+	mergeMR := *mr
+	mergeMR.Target = target
+	processResult := e.doMerge(ctx, &mergeMR)
 	if processResult.Success {
 		result.Merged = []*MRInfo{mr}
 		result.MergeCommit = processResult.MergeCommit
@@ -305,8 +307,8 @@ func (e *Engineer) processSingleMR(ctx context.Context, mr *MRInfo, target strin
 		e.HandleMRInfoFailure(mr, processResult)
 		result.Conflicts = []*MRInfo{mr}
 	} else if processResult.NoMerge {
-		// Source issue has no_merge flag — intentionally blocked. Dequeue silently.
-		_, _ = fmt.Fprintf(e.output, "[Batch] MR %s: no_merge flag set, dequeuing\n", mr.ID)
+		// Policy-ineligible work is intentionally blocked. Dequeue silently.
+		_, _ = fmt.Fprintf(e.output, "[Batch] MR %s: not merge-eligible, dequeuing\n", mr.ID)
 		e.HandleMRInfoFailure(mr, processResult)
 	} else if processResult.NeedsApproval {
 		// PR awaiting human approval — leave in queue for retry on next poll.
@@ -384,6 +386,21 @@ func (e *Engineer) fastForwardBatch(ctx context.Context, stacked []*MRInfo, targ
 				}
 			}
 		}()
+	}
+
+	for _, mr := range stacked {
+		if eligibility := e.recheckMRStillMergeable(mr, target); !eligibility.Success {
+			if resetErr := e.git.ResetHard("origin/" + target); resetErr != nil {
+				_, _ = fmt.Fprintf(e.output, "[Batch] Warning: failed to reset %s after pre-push eligibility failure: %v\n", target, resetErr)
+			}
+			if eligibility.NoMerge {
+				_, _ = fmt.Fprintf(e.output, "[Batch] MR %s became ineligible before push: %s\n", mr.ID, eligibility.Error)
+				e.HandleMRInfoFailure(mr, eligibility)
+			} else {
+				result.Error = fmt.Errorf("pre-push eligibility recheck failed for %s: %s", mr.ID, eligibility.Error)
+			}
+			return result
+		}
 	}
 
 	// Push to origin

--- a/internal/refinery/batch.go
+++ b/internal/refinery/batch.go
@@ -213,6 +213,9 @@ func (e *Engineer) ProcessBatch(ctx context.Context, batch []*MRInfo, target str
 	}
 
 	_, _ = fmt.Fprintf(e.output, "[Batch] Processing batch of %d MRs targeting %s\n", len(batch), target)
+	if !e.recheckBatchEligibility(batch, target, result) {
+		return result
+	}
 
 	// Step 1: Build the stack
 	stacked, conflicts, err := e.BuildRebaseStack(ctx, batch, target)
@@ -285,6 +288,21 @@ func (e *Engineer) ProcessBatch(ctx context.Context, batch []*MRInfo, target str
 	}
 
 	return result
+}
+
+func (e *Engineer) recheckBatchEligibility(batch []*MRInfo, target string, result *BatchResult) bool {
+	for _, mr := range batch {
+		if eligibility := e.recheckMRStillMergeable(mr, target); !eligibility.Success {
+			if eligibility.NoMerge {
+				_, _ = fmt.Fprintf(e.output, "[Batch] MR %s is not merge-eligible: %s\n", mr.ID, eligibility.Error)
+				e.HandleMRInfoFailure(mr, eligibility)
+			} else {
+				result.Error = fmt.Errorf("pre-batch eligibility recheck failed for %s: %s", mr.ID, eligibility.Error)
+			}
+			return false
+		}
+	}
+	return true
 }
 
 // processSingleMR handles the degenerate case of a batch with one MR.

--- a/internal/refinery/batch_test.go
+++ b/internal/refinery/batch_test.go
@@ -94,6 +94,7 @@ func newTestEngineer(t *testing.T, workDir string, g *gitpkg.Git) *Engineer {
 	e.git = g
 	e.workDir = workDir
 	e.output = &bytes.Buffer{}
+	e.testAllowSyntheticMRs = true
 	// No-op merge slot functions for tests
 	e.mergeSlotEnsureExists = func() (string, error) { return "test-slot", nil }
 	e.mergeSlotAcquire = func(holder string, addWaiter bool) (*beads.MergeSlotStatus, error) {

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -492,22 +492,22 @@ type ProcessResult struct {
 	TestsFailed    bool
 	SlotTimeout    bool // Merge slot contention timeout (distinct from build/test failure)
 	BranchNotFound bool // Source branch no longer exists (e.g. cleaned up after cherry-pick)
-	NoMerge        bool // Source issue has no_merge flag — intentionally blocked, not a failure
+	NoMerge        bool // MR/source is intentionally not merge-eligible, not a build failure
 	NeedsApproval  bool // PR exists but lacks required approving review (merge_strategy=pr)
 }
 
 // doMerge performs the actual git merge operation.
-func (e *Engineer) doMerge(ctx context.Context, branch, target, sourceIssue string, skipGates ...bool) ProcessResult {
-	// GH#2778: Check no_merge flag on source issue before merging. The polecat
-	// normally skips MR creation when no_merge is set, but if an MR is created
-	// manually (e.g., gh pr create) the refinery would otherwise auto-merge it.
-	if sourceIssue != "" {
-		if si, err := e.beads.Show(sourceIssue); err == nil && si != nil {
-			if af := beads.ParseAttachmentFields(si); af != nil && af.NoMerge {
-				_, _ = fmt.Fprintf(e.output, "[Engineer] Source issue %s has no_merge=true — skipping merge\n", sourceIssue)
-				return ProcessResult{NoMerge: true, Error: "no_merge flag set on source issue"}
-			}
+func (e *Engineer) doMerge(ctx context.Context, mr *MRInfo, skipGates ...bool) ProcessResult {
+	if mr == nil {
+		return ProcessResult{Success: false, Error: "merge request is missing"}
+	}
+	branch, target := mr.Branch, mr.Target
+
+	if eligibility := e.recheckMRStillMergeable(mr, target); !eligibility.Success {
+		if eligibility.NoMerge {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] MR %s is not merge-eligible — skipping merge: %s\n", mr.ID, eligibility.Error)
 		}
+		return eligibility
 	}
 
 	// Step 1: Verify source branch exists locally (shared .repo.git with polecats)
@@ -581,6 +581,9 @@ func (e *Engineer) doMerge(ctx context.Context, branch, target, sourceIssue stri
 			if sc.NewSHA == "" {
 				continue // Submodule removed, nothing to push
 			}
+			if eligibility := e.recheckMRStillMergeable(mr, target); !eligibility.Success {
+				return eligibility
+			}
 			_, _ = fmt.Fprintf(e.output, "[Engineer] Pushing submodule %s (commit %s)...\n", sc.Path, shortSHA(sc.NewSHA))
 			if pushErr := e.git.PushSubmoduleCommit(sc.Path, sc.NewSHA, "origin"); pushErr != nil {
 				return ProcessResult{
@@ -623,7 +626,7 @@ func (e *Engineer) doMerge(ctx context.Context, branch, target, sourceIssue stri
 	// protection/restriction rules and preserves the PR audit trail.
 	// The VCS provider (GitHub, Bitbucket) is selected via vcs_provider config.
 	if e.config.MergeStrategy == "pr" {
-		return e.doMergePR(ctx, branch, target)
+		return e.doMergePR(ctx, mr)
 	}
 
 	// Step 5: Perform the actual merge using squash merge
@@ -633,8 +636,8 @@ func (e *Engineer) doMerge(ctx context.Context, branch, target, sourceIssue stri
 	if err != nil {
 		// Fallback to a descriptive message if we can't get the original
 		originalMsg = fmt.Sprintf("Squash merge %s into %s", branch, target)
-		if sourceIssue != "" {
-			originalMsg = fmt.Sprintf("Squash merge %s into %s (%s)", branch, target, sourceIssue)
+		if mr.SourceIssue != "" {
+			originalMsg = fmt.Sprintf("Squash merge %s into %s (%s)", branch, target, mr.SourceIssue)
 		}
 		_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: could not get original commit message: %v\n", err)
 	}
@@ -716,6 +719,13 @@ func (e *Engineer) doMerge(ctx context.Context, branch, target, sourceIssue stri
 			}()
 		}
 
+		if eligibility := e.recheckMRStillMergeable(mr, target); !eligibility.Success {
+			if resetErr := e.git.ResetHard("origin/" + target); resetErr != nil {
+				_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to reset %s after pre-push eligibility failure: %v\n", target, resetErr)
+			}
+			return eligibility
+		}
+
 		_, _ = fmt.Fprintf(e.output, "[Engineer] Pushing to origin/%s...\n", target)
 		if err := e.git.Push("origin", target, false); err != nil {
 			// Reset the checked-out target branch to undo the local squash commit.
@@ -754,8 +764,12 @@ func (e *Engineer) doMerge(ctx context.Context, branch, target, sourceIssue stri
 // Called from doMerge after quality gates have passed.
 //
 //nolint:unparam // ctx is reserved for future use when git methods accept context
-func (e *Engineer) doMergePR(ctx context.Context, branch, target string) ProcessResult {
+func (e *Engineer) doMergePR(ctx context.Context, mr *MRInfo) ProcessResult {
 	_ = ctx
+	if mr == nil {
+		return ProcessResult{Success: false, Error: "merge request is missing"}
+	}
+	branch, target := mr.Branch, mr.Target
 	provider := e.config.VCSProvider
 	if provider == "" {
 		provider = "github"
@@ -806,6 +820,10 @@ func (e *Engineer) doMergePR(ctx context.Context, branch, target string) Process
 		_, _ = fmt.Fprintf(e.output, "[Engineer] PR #%d has approving review\n", prNumber)
 	}
 
+	if eligibility := e.recheckMRStillMergeable(mr, target); !eligibility.Success {
+		return eligibility
+	}
+
 	// Step PR.3: Merge via VCS provider API using squash merge
 	_, _ = fmt.Fprintf(e.output, "[Engineer] Merging PR #%d via %s API (squash)...\n", prNumber, provider)
 	mergeCommit, err := e.prProvider.MergePR(prNumber, "squash")
@@ -839,6 +857,169 @@ func (e *Engineer) doMergePR(ctx context.Context, branch, target string) Process
 	return ProcessResult{
 		Success:     true,
 		MergeCommit: mergeCommit,
+	}
+}
+
+func mergeIneligibleResult(format string, args ...interface{}) ProcessResult {
+	return ProcessResult{
+		Success: false,
+		NoMerge: true,
+		Error:   fmt.Sprintf(format, args...),
+	}
+}
+
+func (e *Engineer) recheckMRStillMergeable(mr *MRInfo, target string) ProcessResult {
+	if mr == nil {
+		return ProcessResult{Success: false, Error: "merge request is missing"}
+	}
+
+	sourceIssue := strings.TrimSpace(mr.SourceIssue)
+	if sourceIssue == "" {
+		if isSyntheticMergeMechanicsMR(mr) {
+			return ProcessResult{Success: true}
+		}
+		return e.rejectMRBeforeMerge(mr, "MR has missing source_issue")
+	}
+
+	if mrID := strings.TrimSpace(mr.ID); mrID != "" && !isSyntheticMergeMechanicsMR(mr) {
+		mrIssue, err := e.beads.Show(mrID)
+		if err != nil {
+			if errors.Is(err, beads.ErrNotFound) {
+				return mergeIneligibleResult("MR %s no longer exists", mrID)
+			}
+			return ProcessResult{Success: false, Error: fmt.Sprintf("pre-push recheck MR %s: %v", mrID, err)}
+		}
+		if mrIssue == nil {
+			return mergeIneligibleResult("MR %s no longer exists", mrID)
+		}
+		if beads.IssueStatus(strings.TrimSpace(mrIssue.Status)) != beads.StatusOpen {
+			return mergeIneligibleResult("MR %s status is %s", mrID, mrIssue.Status)
+		}
+		if beads.HasLabel(mrIssue, "gt:owned-direct") {
+			return e.rejectMRBeforeMerge(mr, "MR is owned-direct")
+		}
+
+		fields := beads.ParseMRFields(mrIssue)
+		if fields == nil {
+			return e.rejectMRBeforeMerge(mr, "MR has missing merge-request fields")
+		}
+		if closeReason := strings.TrimSpace(fields.CloseReason); closeReason != "" {
+			if strings.EqualFold(closeReason, string(CloseReasonMerged)) {
+				if err := e.closeMRWithReason(mr, string(CloseReasonMerged)); err != nil {
+					return ProcessResult{Success: false, Error: fmt.Sprintf("failed to close already-merged MR %s: %v", mrID, err)}
+				}
+				return mergeIneligibleResult("MR close_reason is %s", closeReason)
+			}
+			return e.rejectMRBeforeMerge(mr, fmt.Sprintf("MR close_reason is %s", closeReason))
+		}
+		if fields.Branch != "" && mr.Branch != "" && fields.Branch != mr.Branch {
+			return e.rejectMRBeforeMerge(mr, fmt.Sprintf("MR branch changed from %s to %s", mr.Branch, fields.Branch))
+		}
+		if strings.TrimSpace(fields.Target) == "" {
+			return e.rejectMRBeforeMerge(mr, "MR has missing target")
+		}
+		if fields.Target != target {
+			return e.rejectMRBeforeMerge(mr, fmt.Sprintf("MR target changed from %s to %s", target, fields.Target))
+		}
+		if fields.Rig != "" && !strings.EqualFold(fields.Rig, e.rig.Name) {
+			return e.rejectMRBeforeMerge(mr, fmt.Sprintf("MR belongs to rig %s", fields.Rig))
+		}
+		if strings.TrimSpace(fields.SourceIssue) == "" {
+			return e.rejectMRBeforeMerge(mr, "MR has missing source_issue")
+		}
+		if fields.SourceIssue != sourceIssue {
+			return e.rejectMRBeforeMerge(mr, fmt.Sprintf("MR source_issue changed from %s to %s", sourceIssue, fields.SourceIssue))
+		}
+		sourceIssue = fields.SourceIssue
+	}
+
+	return e.recheckMRSourceStillMergeable(mr, sourceIssue)
+}
+
+func isSyntheticMergeMechanicsMR(mr *MRInfo) bool {
+	return mr != nil && strings.HasPrefix(strings.TrimSpace(mr.ID), "mr-") && strings.TrimSpace(mr.SourceIssue) == ""
+}
+
+func (e *Engineer) rejectMRBeforeMerge(mr *MRInfo, reason string) ProcessResult {
+	if err := e.closeIneligibleMR(mr, reason); err != nil {
+		mrID := "<missing>"
+		if mr != nil && mr.ID != "" {
+			mrID = mr.ID
+		}
+		return ProcessResult{Success: false, Error: fmt.Sprintf("failed to close ineligible MR %s: %v", mrID, err)}
+	}
+	return mergeIneligibleResult("%s", reason)
+}
+
+func (e *Engineer) recheckMRSourceStillMergeable(mr *MRInfo, sourceIssue string) ProcessResult {
+	issue, err := e.beads.Show(sourceIssue)
+	if err != nil {
+		if errors.Is(err, beads.ErrNotFound) {
+			return e.rejectMRBeforeMerge(mr, fmt.Sprintf("source_issue %s is missing", sourceIssue))
+		}
+		return ProcessResult{Success: false, Error: fmt.Sprintf("pre-push recheck source_issue %s: %v", sourceIssue, err)}
+	}
+	if issue == nil {
+		return e.rejectMRBeforeMerge(mr, fmt.Sprintf("source_issue %s is missing", sourceIssue))
+	}
+	if beads.IssueStatus(issue.Status).IsTerminal() {
+		return e.rejectMRBeforeMerge(mr, fmt.Sprintf("source_issue %s status is %s", sourceIssue, issue.Status))
+	}
+	if reason := refinerySourceIssueConcreteReason(issue); reason != "" {
+		return e.rejectMRBeforeMerge(mr, fmt.Sprintf("source_issue %s is not concrete (%s)", sourceIssue, reason))
+	}
+	if af := beads.ParseAttachmentFields(issue); af != nil {
+		switch {
+		case af.NoMerge:
+			return e.rejectMRBeforeMerge(mr, fmt.Sprintf("source_issue %s has no_merge=true", sourceIssue))
+		case af.ReviewOnly:
+			return e.rejectMRBeforeMerge(mr, fmt.Sprintf("source_issue %s has review_only=true", sourceIssue))
+		case strings.EqualFold(strings.TrimSpace(af.MergeStrategy), "local"):
+			return e.rejectMRBeforeMerge(mr, fmt.Sprintf("source_issue %s has merge_strategy=local", sourceIssue))
+		}
+	}
+	return ProcessResult{Success: true}
+}
+
+func refinerySourceIssueConcreteReason(issue *beads.Issue) string {
+	if issue == nil || strings.TrimSpace(issue.ID) == "" {
+		return "source-missing"
+	}
+	if issue.Ephemeral {
+		return "ephemeral"
+	}
+	if strings.Contains(strings.ToLower(issue.ID), "-wisp-") {
+		return "wisp-id"
+	}
+	if strings.HasPrefix(strings.ToLower(strings.TrimSpace(issue.ID)), "mol-") {
+		return "formula-id"
+	}
+	if refineryInternalIssueType(issue.Type) {
+		return "internal-type:" + strings.ToLower(strings.TrimSpace(issue.Type))
+	}
+	for _, label := range issue.Labels {
+		if refineryInternalIssueLabel(label) {
+			return "internal-label:" + strings.ToLower(strings.TrimSpace(label))
+		}
+	}
+	return ""
+}
+
+func refineryInternalIssueType(issueType string) bool {
+	switch strings.ToLower(strings.TrimSpace(issueType)) {
+	case "wisp", "message", "merge-request", "agent", "queue", "convoy", "formula":
+		return true
+	default:
+		return false
+	}
+}
+
+func refineryInternalIssueLabel(label string) bool {
+	switch strings.ToLower(strings.TrimSpace(label)) {
+	case "gt:wisp", "gt:message", "gt:merge-request", "gt:agent", "gt:queue", "gt:convoy", "gt:formula":
+		return true
+	default:
+		return false
 	}
 }
 
@@ -1161,7 +1342,7 @@ func (e *Engineer) ProcessMRInfo(ctx context.Context, mr *MRInfo) ProcessResult 
 	}
 
 	// Use the shared merge logic
-	return e.doMerge(ctx, mr.Branch, mr.Target, mr.SourceIssue, skipGates)
+	return e.doMerge(ctx, mr, skipGates)
 }
 
 // HandleMRInfoSuccess handles a successful merge from MRInfo.
@@ -1305,10 +1486,18 @@ func (e *Engineer) HandleMRInfoFailure(mr *MRInfo, result ProcessResult) {
 		return
 	}
 
-	// No-merge is intentional — the source issue has no_merge=true. Not a failure.
-	// No polecat or mayor notification needed; the MR is simply dequeued.
+	// Policy ineligibility is intentional — not a build/test failure.
+	// No polecat or mayor notification needed; close any still-open MR so it
+	// cannot retry forever after a no-merge/review-only/rejected decision.
 	if result.NoMerge {
-		_, _ = fmt.Fprintf(e.output, "[Engineer] MR %s: no_merge flag set on source issue, dequeued\n", mr.ID)
+		reason := strings.TrimSpace(result.Error)
+		if reason == "" {
+			reason = "merge request is not merge-eligible"
+		}
+		_, _ = fmt.Fprintf(e.output, "[Engineer] MR %s: %s, dequeued\n", mr.ID, reason)
+		if closeErr := e.closeIneligibleMR(mr, reason); closeErr != nil {
+			_, _ = fmt.Fprintf(e.output, "[Engineer] Warning: failed to close ineligible MR %s: %v\n", mr.ID, closeErr)
+		}
 		return
 	}
 
@@ -1404,6 +1593,50 @@ func (e *Engineer) HandleMRInfoFailure(mr *MRInfo, result ProcessResult) {
 	} else {
 		_, _ = fmt.Fprintln(e.output, "[Engineer] MR remains in queue for retry")
 	}
+}
+
+func (e *Engineer) closeIneligibleMR(mr *MRInfo, reason string) error {
+	return e.closeMRWithReason(mr, "rejected: "+reason)
+}
+
+func (e *Engineer) closeMRWithReason(mr *MRInfo, closeReason string) error {
+	if mr == nil || strings.TrimSpace(mr.ID) == "" {
+		return nil
+	}
+	issue, err := e.beads.Show(mr.ID)
+	if err != nil {
+		if !errors.Is(err, beads.ErrNotFound) {
+			return fmt.Errorf("fetch MR for close: %w", err)
+		}
+		return nil
+	}
+	if issue == nil || beads.IssueStatus(issue.Status) != beads.StatusOpen {
+		return nil
+	}
+
+	fields := beads.ParseMRFields(issue)
+	if fields == nil {
+		fields = &beads.MRFields{}
+	}
+	fields.CloseReason = normalizedMRCloseReason(closeReason)
+	newDesc := beads.SetMRFields(issue, fields)
+	if err := e.beads.Update(mr.ID, beads.UpdateOptions{Description: &newDesc}); err != nil {
+		return fmt.Errorf("record MR close reason: %w", err)
+	}
+
+	if err := e.beads.CloseWithReason(closeReason, mr.ID); err != nil {
+		return fmt.Errorf("close MR: %w", err)
+	}
+	_, _ = fmt.Fprintf(e.output, "[Engineer] Closed MR bead: %s (%s)\n", mr.ID, closeReason)
+	return nil
+}
+
+func normalizedMRCloseReason(closeReason string) string {
+	closeReason = strings.TrimSpace(closeReason)
+	if strings.HasPrefix(strings.ToLower(closeReason), "rejected:") {
+		return string(CloseReasonRejected)
+	}
+	return closeReason
 }
 
 // createConflictResolutionTaskForMR creates a dispatchable task for resolving merge conflicts.

--- a/internal/refinery/engineer.go
+++ b/internal/refinery/engineer.go
@@ -268,6 +268,7 @@ type Engineer struct {
 	mergeSlotRelease      func(holder string) error
 	mergeSlotMaxRetries   int           // Max retries for slot acquisition (0 = no retry)
 	mergeSlotRetryBackoff time.Duration // Initial backoff between retries
+	testAllowSyntheticMRs bool          // Test-only: legacy merge-mechanics tests use synthetic MRs without beads.
 }
 
 // NewEngineer creates a new Engineer for the given rig.
@@ -875,13 +876,13 @@ func (e *Engineer) recheckMRStillMergeable(mr *MRInfo, target string) ProcessRes
 
 	sourceIssue := strings.TrimSpace(mr.SourceIssue)
 	if sourceIssue == "" {
-		if isSyntheticMergeMechanicsMR(mr) {
+		if e.isSyntheticMergeMechanicsMR(mr) {
 			return ProcessResult{Success: true}
 		}
 		return e.rejectMRBeforeMerge(mr, "MR has missing source_issue")
 	}
 
-	if mrID := strings.TrimSpace(mr.ID); mrID != "" && !isSyntheticMergeMechanicsMR(mr) {
+	if mrID := strings.TrimSpace(mr.ID); mrID != "" && !e.isSyntheticMergeMechanicsMR(mr) {
 		mrIssue, err := e.beads.Show(mrID)
 		if err != nil {
 			if errors.Is(err, beads.ErrNotFound) {
@@ -936,8 +937,8 @@ func (e *Engineer) recheckMRStillMergeable(mr *MRInfo, target string) ProcessRes
 	return e.recheckMRSourceStillMergeable(mr, sourceIssue)
 }
 
-func isSyntheticMergeMechanicsMR(mr *MRInfo) bool {
-	return mr != nil && strings.HasPrefix(strings.TrimSpace(mr.ID), "mr-") && strings.TrimSpace(mr.SourceIssue) == ""
+func (e *Engineer) isSyntheticMergeMechanicsMR(mr *MRInfo) bool {
+	return e.testAllowSyntheticMRs && mr != nil && strings.HasPrefix(strings.TrimSpace(mr.ID), "mr-") && strings.TrimSpace(mr.SourceIssue) == ""
 }
 
 func (e *Engineer) rejectMRBeforeMerge(mr *MRInfo, reason string) ProcessResult {
@@ -1007,7 +1008,7 @@ func refinerySourceIssueConcreteReason(issue *beads.Issue) string {
 
 func refineryInternalIssueType(issueType string) bool {
 	switch strings.ToLower(strings.TrimSpace(issueType)) {
-	case "wisp", "message", "merge-request", "agent", "queue", "convoy", "formula":
+	case "wisp", "message", "handoff", "merge-request", "agent", "queue", "convoy", "formula":
 		return true
 	default:
 		return false
@@ -1016,7 +1017,7 @@ func refineryInternalIssueType(issueType string) bool {
 
 func refineryInternalIssueLabel(label string) bool {
 	switch strings.ToLower(strings.TrimSpace(label)) {
-	case "gt:wisp", "gt:message", "gt:merge-request", "gt:agent", "gt:queue", "gt:convoy", "gt:formula":
+	case "gt:wisp", "gt:message", "gt:handoff", "gt:merge-request", "gt:agent", "gt:queue", "gt:convoy", "gt:formula":
 		return true
 	default:
 		return false

--- a/internal/refinery/engineer_pr_merge_test.go
+++ b/internal/refinery/engineer_pr_merge_test.go
@@ -51,9 +51,9 @@ func TestEngineer_LoadConfig_MergeStrategyDefault(t *testing.T) {
 	tmpDir := t.TempDir()
 
 	config := map[string]interface{}{
-		"type":    "rig",
-		"version": 1,
-		"name":    "test-rig",
+		"type":        "rig",
+		"version":     1,
+		"name":        "test-rig",
 		"merge_queue": map[string]interface{}{},
 	}
 
@@ -87,7 +87,7 @@ func TestDoMerge_PRStrategy_RoutesToPRPath(t *testing.T) {
 	// Create a feature branch
 	createFeatureBranch(t, workDir, "feat/test-pr", "test.txt", "hello")
 
-	result := e.doMerge(context.Background(), "feat/test-pr", "main", "gt-test")
+	result := e.doMerge(context.Background(), &MRInfo{ID: "mr-test-pr", Branch: "feat/test-pr", Target: "main"})
 
 	if result.Success {
 		t.Error("expected failure (no GitHub PR exists)")
@@ -107,7 +107,7 @@ func TestDoMerge_DirectStrategy_SkipsPRPath(t *testing.T) {
 
 	createFeatureBranch(t, workDir, "feat/test-direct", "test.txt", "hello")
 
-	result := e.doMerge(context.Background(), "feat/test-direct", "main", "gt-test")
+	result := e.doMerge(context.Background(), &MRInfo{ID: "mr-test-direct", Branch: "feat/test-direct", Target: "main"})
 
 	// Should succeed with direct merge
 	if !result.Success {
@@ -127,7 +127,7 @@ func TestDoMergePR_NoPR_ReturnsError(t *testing.T) {
 
 	createFeatureBranch(t, workDir, "feat/no-pr", "test.txt", "hello")
 
-	result := e.doMergePR(context.Background(), "feat/no-pr", "main")
+	result := e.doMergePR(context.Background(), &MRInfo{ID: "mr-no-pr", Branch: "feat/no-pr", Target: "main"})
 
 	if result.Success {
 		t.Error("expected failure when no PR exists")

--- a/internal/refinery/prepush_recheck_test.go
+++ b/internal/refinery/prepush_recheck_test.go
@@ -1,0 +1,456 @@
+package refinery
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	beadsdk "github.com/steveyegge/beads"
+	"github.com/steveyegge/gastown/internal/beads"
+	gitpkg "github.com/steveyegge/gastown/internal/git"
+)
+
+type prepushStore struct {
+	beadsdk.Storage
+	issues       map[string]*beadsdk.Issue
+	closeReasons map[string]string
+	beforeGet    func(id string)
+}
+
+type prepushPRProvider struct {
+	beforeMerge func()
+	mergeCalled bool
+}
+
+func (p *prepushPRProvider) FindPRNumber(string) (int, error) {
+	return 42, nil
+}
+
+func (p *prepushPRProvider) IsPRApproved(int) (bool, error) {
+	if p.beforeMerge != nil {
+		p.beforeMerge()
+	}
+	return true, nil
+}
+
+func (p *prepushPRProvider) MergePR(int, string) (string, error) {
+	p.mergeCalled = true
+	return "deadbeef", nil
+}
+
+func newPrepushStore(issues ...*beadsdk.Issue) *prepushStore {
+	store := &prepushStore{
+		issues:       make(map[string]*beadsdk.Issue, len(issues)),
+		closeReasons: make(map[string]string),
+	}
+	for _, issue := range issues {
+		store.issues[issue.ID] = issue
+	}
+	return store
+}
+
+func (s *prepushStore) GetIssue(_ context.Context, id string) (*beadsdk.Issue, error) {
+	if s.beforeGet != nil {
+		s.beforeGet(id)
+	}
+	issue, ok := s.issues[id]
+	if !ok {
+		return nil, fmt.Errorf("issue %s not found", id)
+	}
+	return issue, nil
+}
+
+func (s *prepushStore) GetLabels(_ context.Context, id string) ([]string, error) {
+	issue, ok := s.issues[id]
+	if !ok {
+		return nil, fmt.Errorf("issue %s not found", id)
+	}
+	return append([]string(nil), issue.Labels...), nil
+}
+
+func (s *prepushStore) UpdateIssue(_ context.Context, id string, updates map[string]interface{}, _ string) error {
+	issue, ok := s.issues[id]
+	if !ok {
+		return fmt.Errorf("issue %s not found", id)
+	}
+	for key, value := range updates {
+		switch key {
+		case "description":
+			issue.Description, _ = value.(string)
+		case "status":
+			if status, ok := value.(string); ok {
+				issue.Status = beadsdk.Status(status)
+			}
+		}
+	}
+	issue.UpdatedAt = time.Now()
+	return nil
+}
+
+func (s *prepushStore) CloseIssue(_ context.Context, id, reason, _, _ string) error {
+	issue, ok := s.issues[id]
+	if !ok {
+		return fmt.Errorf("issue %s not found", id)
+	}
+	now := time.Now()
+	issue.Status = beadsdk.StatusClosed
+	issue.ClosedAt = &now
+	issue.UpdatedAt = now
+	s.closeReasons[id] = reason
+	return nil
+}
+
+func prepushIssue(id, description string, labels ...string) *beadsdk.Issue {
+	now := time.Now()
+	return &beadsdk.Issue{
+		ID:          id,
+		Title:       id,
+		Description: description,
+		Status:      beadsdk.StatusOpen,
+		IssueType:   beadsdk.IssueType("task"),
+		Priority:    2,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Labels:      labels,
+	}
+}
+
+func prepushMRIssue(id, branch, target, sourceIssue string) *beadsdk.Issue {
+	desc := beads.FormatMRFields(&beads.MRFields{
+		Branch:      branch,
+		Target:      target,
+		SourceIssue: sourceIssue,
+		Worker:      "polecats/test",
+		Rig:         "test-rig",
+	})
+	return prepushIssue(id, desc, "gt:merge-request")
+}
+
+func newPrepushEngineer(t *testing.T, workDir string, store *prepushStore) *Engineer {
+	t.Helper()
+	g := newTestGit(t, workDir)
+	e := newTestEngineer(t, workDir, g)
+	e.beads = beads.NewWithStore(workDir, store)
+	return e
+}
+
+func newTestGit(t *testing.T, workDir string) *gitpkg.Git {
+	t.Helper()
+	return gitpkg.NewGit(workDir)
+}
+
+func assertOriginMainUnchangedAndReset(t *testing.T, workDir, before string) {
+	t.Helper()
+	afterOrigin := run(t, workDir, "git", "rev-parse", "origin/main")
+	if afterOrigin != before {
+		t.Fatalf("origin/main changed: before %s after %s", before, afterOrigin)
+	}
+	remoteLine := run(t, workDir, "git", "ls-remote", "origin", "refs/heads/main")
+	remoteFields := strings.Fields(remoteLine)
+	if len(remoteFields) == 0 || remoteFields[0] != before {
+		t.Fatalf("remote main changed: before %s ls-remote %q", before, remoteLine)
+	}
+	localMain := run(t, workDir, "git", "rev-parse", "main")
+	if localMain != before {
+		t.Fatalf("local main was not reset to origin/main: local %s origin %s", localMain, before)
+	}
+}
+
+func TestRecheckMRStillMergeable_RejectsMissingSourceField(t *testing.T) {
+	workDir, _, cleanup := testGitRepo(t)
+	defer cleanup()
+	store := newPrepushStore(prepushMRIssue("gt-mr", "feature", "main", ""))
+	e := newPrepushEngineer(t, workDir, store)
+
+	result := e.recheckMRStillMergeable(&MRInfo{ID: "gt-mr", Branch: "feature", Target: "main"}, "main")
+	if result.Success || !result.NoMerge {
+		t.Fatalf("missing source_issue should be rejected, got: %+v", result)
+	}
+	if got := store.closeReasons["gt-mr"]; got != "rejected: MR has missing source_issue" {
+		t.Fatalf("MR close reason = %q, want missing source rejection", got)
+	}
+}
+
+func TestRecheckMRStillMergeable_RejectsMissingSourceIssue(t *testing.T) {
+	workDir, _, cleanup := testGitRepo(t)
+	defer cleanup()
+	store := newPrepushStore(prepushMRIssue("gt-mr", "feature", "main", "gt-missing"))
+	e := newPrepushEngineer(t, workDir, store)
+
+	mr := &MRInfo{ID: "gt-mr", Branch: "feature", Target: "main", SourceIssue: "gt-missing"}
+	result := e.recheckMRStillMergeable(mr, "main")
+	if result.Success || !result.NoMerge {
+		t.Fatalf("missing source issue should be rejected, got: %+v", result)
+	}
+	if got := store.closeReasons["gt-mr"]; got != "rejected: source_issue gt-missing is missing" {
+		t.Fatalf("MR close reason = %q, want missing source issue", got)
+	}
+}
+
+func TestRecheckMRStillMergeable_RejectsNonConcreteSource(t *testing.T) {
+	workDir, _, cleanup := testGitRepo(t)
+	defer cleanup()
+	store := newPrepushStore(
+		prepushIssue("gt-src", "", "gt:merge-request"),
+		prepushMRIssue("gt-mr", "feature", "main", "gt-src"),
+	)
+	e := newPrepushEngineer(t, workDir, store)
+
+	mr := &MRInfo{ID: "gt-mr", Branch: "feature", Target: "main", SourceIssue: "gt-src"}
+	result := e.recheckMRStillMergeable(mr, "main")
+	if result.Success || !result.NoMerge {
+		t.Fatalf("non-concrete source should be rejected, got: %+v", result)
+	}
+	if !strings.Contains(store.closeReasons["gt-mr"], "not concrete") {
+		t.Fatalf("MR close reason = %q, want non-concrete rejection", store.closeReasons["gt-mr"])
+	}
+}
+
+func TestRecheckMRStillMergeable_RejectsClosedSource(t *testing.T) {
+	workDir, _, cleanup := testGitRepo(t)
+	defer cleanup()
+	source := prepushIssue("gt-src", "")
+	now := time.Now()
+	source.Status = beadsdk.StatusClosed
+	source.ClosedAt = &now
+	store := newPrepushStore(source, prepushMRIssue("gt-mr", "feature", "main", "gt-src"))
+	e := newPrepushEngineer(t, workDir, store)
+
+	mr := &MRInfo{ID: "gt-mr", Branch: "feature", Target: "main", SourceIssue: "gt-src"}
+	result := e.recheckMRStillMergeable(mr, "main")
+	if result.Success || !result.NoMerge {
+		t.Fatalf("closed source should be rejected, got: %+v", result)
+	}
+	if got := store.closeReasons["gt-mr"]; got != "rejected: source_issue gt-src status is closed" {
+		t.Fatalf("MR close reason = %q, want closed source rejection", got)
+	}
+}
+
+func TestDoMerge_RechecksSourceFlagsBeforeDirectPush(t *testing.T) {
+	tests := []struct {
+		name        string
+		description string
+	}{
+		{name: "no_merge", description: "no_merge: true"},
+		{name: "review_only", description: "review_only: true"},
+		{name: "local_merge", description: "merge_strategy: local"},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			workDir, _, cleanup := testGitRepo(t)
+			defer cleanup()
+			createFeatureBranch(t, workDir, "feature-"+tc.name, tc.name+".txt", tc.name+"\n")
+			store := newPrepushStore(
+				prepushIssue("gt-src", ""),
+				prepushMRIssue("gt-mr", "feature-"+tc.name, "main", "gt-src"),
+			)
+			e := newPrepushEngineer(t, workDir, store)
+			before := run(t, workDir, "git", "rev-parse", "origin/main")
+
+			mutated := false
+			e.mergeSlotAcquire = func(holder string, addWaiter bool) (*beads.MergeSlotStatus, error) {
+				if !mutated {
+					store.issues["gt-src"].Description = tc.description
+					store.issues["gt-src"].UpdatedAt = time.Now()
+					mutated = true
+				}
+				return &beads.MergeSlotStatus{Available: true, Holder: holder}, nil
+			}
+
+			mr := &MRInfo{ID: "gt-mr", Branch: "feature-" + tc.name, Target: "main", SourceIssue: "gt-src"}
+			result := e.doMerge(context.Background(), mr)
+			if result.Success || !result.NoMerge {
+				t.Fatalf("expected clean policy rejection before direct push, got: %+v", result)
+			}
+			if !mutated {
+				t.Fatal("expected merge slot hook to mutate source before push")
+			}
+			assertOriginMainUnchangedAndReset(t, workDir, before)
+		})
+	}
+}
+
+func TestDoMerge_RechecksBeforeSubmodulePush(t *testing.T) {
+	workDir, _, cleanup := testGitRepo(t)
+	defer cleanup()
+
+	subRoot := t.TempDir()
+	subBare := filepath.Join(subRoot, "sub.git")
+	subWork := filepath.Join(subRoot, "sub-work")
+	run(t, subRoot, "git", "init", "--bare", "--initial-branch=main", subBare)
+	run(t, subRoot, "git", "clone", subBare, subWork)
+	run(t, subWork, "git", "config", "user.email", "test@test.com")
+	run(t, subWork, "git", "config", "user.name", "Test")
+	writeFile(t, subWork, "README.md", "submodule v1\n")
+	run(t, subWork, "git", "add", ".")
+	run(t, subWork, "git", "commit", "-m", "submodule initial")
+	run(t, subWork, "git", "push", "-u", "origin", "main")
+
+	run(t, workDir, "git", "-c", "protocol.file.allow=always", "submodule", "add", subBare, "libs/sub")
+	run(t, workDir, "git", "commit", "-m", "add submodule")
+	run(t, workDir, "git", "push", "origin", "main")
+
+	submodulePath := filepath.Join(workDir, "libs", "sub")
+	run(t, submodulePath, "git", "config", "user.email", "test@test.com")
+	run(t, submodulePath, "git", "config", "user.name", "Test")
+	writeFile(t, submodulePath, "v2.txt", "submodule v2\n")
+	run(t, submodulePath, "git", "add", ".")
+	run(t, submodulePath, "git", "commit", "-m", "submodule update")
+	newSubmoduleSHA := run(t, submodulePath, "git", "rev-parse", "HEAD")
+
+	run(t, workDir, "git", "checkout", "-b", "feature-submodule", "main")
+	run(t, workDir, "git", "add", "libs/sub")
+	run(t, workDir, "git", "commit", "-m", "feat: update submodule")
+	run(t, workDir, "git", "checkout", "main")
+
+	store := newPrepushStore(prepushIssue("gt-src", ""), prepushMRIssue("gt-mr", "feature-submodule", "main", "gt-src"))
+	sourceReads := 0
+	store.beforeGet = func(id string) {
+		if id != "gt-src" {
+			return
+		}
+		sourceReads++
+		if sourceReads == 2 {
+			store.issues["gt-src"].Description = "no_merge: true"
+			store.issues["gt-src"].UpdatedAt = time.Now()
+		}
+	}
+	e := newPrepushEngineer(t, workDir, store)
+
+	mr := &MRInfo{ID: "gt-mr", Branch: "feature-submodule", Target: "main", SourceIssue: "gt-src"}
+	result := e.doMerge(context.Background(), mr)
+	if result.Success || !result.NoMerge {
+		t.Fatalf("expected clean policy rejection before submodule push, got: %+v", result)
+	}
+	if sourceReads < 2 {
+		t.Fatalf("expected source re-read before submodule push, got %d reads", sourceReads)
+	}
+	remoteLine := run(t, workDir, "git", "ls-remote", subBare, "refs/heads/main")
+	if strings.Fields(remoteLine)[0] == newSubmoduleSHA {
+		t.Fatal("submodule commit was pushed despite pre-push rejection")
+	}
+}
+
+func TestDoMergePR_RechecksSourceBeforeMergeAPI(t *testing.T) {
+	workDir, _, cleanup := testGitRepo(t)
+	defer cleanup()
+	store := newPrepushStore(prepushIssue("gt-src", ""), prepushMRIssue("gt-mr-pr", "feature-pr", "main", "gt-src"))
+	e := newPrepushEngineer(t, workDir, store)
+	requireReview := true
+	e.config.RequireReview = &requireReview
+	provider := &prepushPRProvider{beforeMerge: func() {
+		store.issues["gt-src"].Description = "no_merge: true"
+		store.issues["gt-src"].UpdatedAt = time.Now()
+	}}
+	e.prProvider = provider
+
+	mr := &MRInfo{ID: "gt-mr-pr", Branch: "feature-pr", Target: "main", SourceIssue: "gt-src"}
+	result := e.doMergePR(context.Background(), mr)
+	if result.Success || !result.NoMerge {
+		t.Fatalf("expected clean policy rejection before PR merge API, got: %+v", result)
+	}
+	if provider.mergeCalled {
+		t.Fatal("MergePR was called after source became no_merge")
+	}
+}
+
+func TestProcessBatch_RechecksBatchBeforePush(t *testing.T) {
+	workDir, _, cleanup := testGitRepo(t)
+	defer cleanup()
+	createFeatureBranch(t, workDir, "feature-a", "a.txt", "a\n")
+	createFeatureBranch(t, workDir, "feature-b", "b.txt", "b\n")
+	store := newPrepushStore(
+		prepushIssue("gt-src-a", ""),
+		prepushIssue("gt-src-b", ""),
+		prepushMRIssue("gt-mr-a", "feature-a", "main", "gt-src-a"),
+		prepushMRIssue("gt-mr-b", "feature-b", "main", "gt-src-b"),
+	)
+	e := newPrepushEngineer(t, workDir, store)
+	before := run(t, workDir, "git", "rev-parse", "origin/main")
+
+	mutated := false
+	e.mergeSlotAcquire = func(holder string, addWaiter bool) (*beads.MergeSlotStatus, error) {
+		if !mutated {
+			store.issues["gt-src-b"].Description = "no_merge: true"
+			store.issues["gt-src-b"].UpdatedAt = time.Now()
+			mutated = true
+		}
+		return &beads.MergeSlotStatus{Available: true, Holder: holder}, nil
+	}
+
+	batch := []*MRInfo{
+		{ID: "gt-mr-a", Branch: "feature-a", Target: "main", SourceIssue: "gt-src-a"},
+		{ID: "gt-mr-b", Branch: "feature-b", Target: "main", SourceIssue: "gt-src-b"},
+	}
+	result := e.ProcessBatch(context.Background(), batch, "main", DefaultBatchConfig())
+	if len(result.Merged) != 0 {
+		t.Fatalf("expected no merged MRs, got %d", len(result.Merged))
+	}
+	if result.Error != nil {
+		t.Fatalf("expected clean policy dequeue, got error: %v", result.Error)
+	}
+	if !mutated {
+		t.Fatal("expected merge slot hook to mutate batch source before push")
+	}
+	assertOriginMainUnchangedAndReset(t, workDir, before)
+	if got := store.issues["gt-mr-b"].Status; got != beadsdk.StatusClosed {
+		t.Fatalf("invalidated MR status = %s, want closed", got)
+	}
+	if got := store.issues["gt-mr-a"].Status; got != beadsdk.StatusOpen {
+		t.Fatalf("unaffected MR status = %s, want open", got)
+	}
+}
+
+func TestProcessBatch_RechecksMRCloseReasonBeforePush(t *testing.T) {
+	workDir, _, cleanup := testGitRepo(t)
+	defer cleanup()
+	createFeatureBranch(t, workDir, "feature-a", "a.txt", "a\n")
+	createFeatureBranch(t, workDir, "feature-b", "b.txt", "b\n")
+	store := newPrepushStore(
+		prepushIssue("gt-src-a", ""),
+		prepushIssue("gt-src-b", ""),
+		prepushMRIssue("gt-mr-a", "feature-a", "main", "gt-src-a"),
+		prepushMRIssue("gt-mr-b", "feature-b", "main", "gt-src-b"),
+	)
+	e := newPrepushEngineer(t, workDir, store)
+	before := run(t, workDir, "git", "rev-parse", "origin/main")
+
+	mutated := false
+	e.mergeSlotAcquire = func(holder string, addWaiter bool) (*beads.MergeSlotStatus, error) {
+		if !mutated {
+			store.issues["gt-mr-b"].Description += "\nclose_reason: rejected"
+			store.issues["gt-mr-b"].UpdatedAt = time.Now()
+			mutated = true
+		}
+		return &beads.MergeSlotStatus{Available: true, Holder: holder}, nil
+	}
+
+	batch := []*MRInfo{
+		{ID: "gt-mr-a", Branch: "feature-a", Target: "main", SourceIssue: "gt-src-a"},
+		{ID: "gt-mr-b", Branch: "feature-b", Target: "main", SourceIssue: "gt-src-b"},
+	}
+	result := e.ProcessBatch(context.Background(), batch, "main", DefaultBatchConfig())
+	if len(result.Merged) != 0 {
+		t.Fatalf("expected no merged MRs, got %d", len(result.Merged))
+	}
+	if result.Error != nil {
+		t.Fatalf("expected clean policy dequeue, got error: %v", result.Error)
+	}
+	if !mutated {
+		t.Fatal("expected merge slot hook to mutate batch MR before push")
+	}
+	assertOriginMainUnchangedAndReset(t, workDir, before)
+	if got := store.issues["gt-mr-b"].Status; got != beadsdk.StatusClosed {
+		t.Fatalf("invalidated MR status = %s, want closed", got)
+	}
+	if got := store.closeReasons["gt-mr-b"]; got != "rejected: MR close_reason is rejected" {
+		t.Fatalf("invalidated MR close reason = %q, want rejected close_reason", got)
+	}
+	if got := store.issues["gt-mr-a"].Status; got != beadsdk.StatusOpen {
+		t.Fatalf("unaffected MR status = %s, want open", got)
+	}
+}

--- a/internal/refinery/prepush_recheck_test.go
+++ b/internal/refinery/prepush_recheck_test.go
@@ -191,21 +191,32 @@ func TestRecheckMRStillMergeable_RejectsMissingSourceIssue(t *testing.T) {
 }
 
 func TestRecheckMRStillMergeable_RejectsNonConcreteSource(t *testing.T) {
-	workDir, _, cleanup := testGitRepo(t)
-	defer cleanup()
-	store := newPrepushStore(
-		prepushIssue("gt-src", "", "gt:merge-request"),
-		prepushMRIssue("gt-mr", "feature", "main", "gt-src"),
-	)
-	e := newPrepushEngineer(t, workDir, store)
-
-	mr := &MRInfo{ID: "gt-mr", Branch: "feature", Target: "main", SourceIssue: "gt-src"}
-	result := e.recheckMRStillMergeable(mr, "main")
-	if result.Success || !result.NoMerge {
-		t.Fatalf("non-concrete source should be rejected, got: %+v", result)
+	tests := []struct {
+		name  string
+		label string
+	}{
+		{name: "merge_request", label: "gt:merge-request"},
+		{name: "handoff", label: "gt:handoff"},
 	}
-	if !strings.Contains(store.closeReasons["gt-mr"], "not concrete") {
-		t.Fatalf("MR close reason = %q, want non-concrete rejection", store.closeReasons["gt-mr"])
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			workDir, _, cleanup := testGitRepo(t)
+			defer cleanup()
+			store := newPrepushStore(
+				prepushIssue("gt-src", "", tc.label),
+				prepushMRIssue("gt-mr", "feature", "main", "gt-src"),
+			)
+			e := newPrepushEngineer(t, workDir, store)
+
+			mr := &MRInfo{ID: "gt-mr", Branch: "feature", Target: "main", SourceIssue: "gt-src"}
+			result := e.recheckMRStillMergeable(mr, "main")
+			if result.Success || !result.NoMerge {
+				t.Fatalf("non-concrete source should be rejected, got: %+v", result)
+			}
+			if !strings.Contains(store.closeReasons["gt-mr"], "not concrete") {
+				t.Fatalf("MR close reason = %q, want non-concrete rejection", store.closeReasons["gt-mr"])
+			}
+		})
 	}
 }
 

--- a/internal/refinery/prepush_recheck_test.go
+++ b/internal/refinery/prepush_recheck_test.go
@@ -416,6 +416,41 @@ func TestProcessBatch_RechecksBatchBeforePush(t *testing.T) {
 	}
 }
 
+func TestProcessBatch_RechecksBatchBeforeGates(t *testing.T) {
+	workDir, _, cleanup := testGitRepo(t)
+	defer cleanup()
+	createFeatureBranch(t, workDir, "feature-a", "a.txt", "a\n")
+	createFeatureBranch(t, workDir, "feature-b", "b.txt", "b\n")
+	store := newPrepushStore(
+		prepushIssue("gt-src-a", ""),
+		prepushIssue("gt-src-b", "no_merge: true"),
+		prepushMRIssue("gt-mr-a", "feature-a", "main", "gt-src-a"),
+		prepushMRIssue("gt-mr-b", "feature-b", "main", "gt-src-b"),
+	)
+	e := newPrepushEngineer(t, workDir, store)
+	e.config.Gates = map[string]*GateConfig{"fail": {Cmd: "false"}}
+	before := run(t, workDir, "git", "rev-parse", "origin/main")
+
+	batch := []*MRInfo{
+		{ID: "gt-mr-a", Branch: "feature-a", Target: "main", SourceIssue: "gt-src-a"},
+		{ID: "gt-mr-b", Branch: "feature-b", Target: "main", SourceIssue: "gt-src-b"},
+	}
+	result := e.ProcessBatch(context.Background(), batch, "main", DefaultBatchConfig())
+	if result.Error != nil {
+		t.Fatalf("expected clean policy dequeue, got error: %v", result.Error)
+	}
+	if len(result.Culprits) != 0 {
+		t.Fatalf("expected no gate culprits for policy-ineligible MR, got %d", len(result.Culprits))
+	}
+	assertOriginMainUnchangedAndReset(t, workDir, before)
+	if got := store.issues["gt-mr-b"].Status; got != beadsdk.StatusClosed {
+		t.Fatalf("invalidated MR status = %s, want closed", got)
+	}
+	if got := store.issues["gt-mr-a"].Status; got != beadsdk.StatusOpen {
+		t.Fatalf("unaffected MR status = %s, want open", got)
+	}
+}
+
 func TestProcessBatch_RechecksMRCloseReasonBeforePush(t *testing.T) {
 	workDir, _, cleanup := testGitRepo(t)
 	defer cleanup()


### PR DESCRIPTION
Prevents the refinery from pushing stale/no-merge/rejected MRs after a ready item changes state between queue selection and push.

Incident context:
- Report-only MR hq-wisp-c5tq was selected while ready and pushed to fork/main before its rejected/no-merge state was observed.
- Fork/main was repaired with revert 5eb0cfb7; upstream main was unaffected.
- This PR is the clean upstream-main port of the refinery guard fix from gt-refinery-prepush-guard-clean-port.

What changed:
- Adds a shared fail-closed pre-push eligibility recheck for direct local pushes, submodule pushes, PR merge API path, and batch fast-forward pushes.
- Re-reads the current MR bead and source issue immediately before push.
- Blocks closed/rejected/close_reason MRs and closed/missing/non-concrete/no_merge/review_only/local source issues.
- Keeps queue/status/report behavior consistent by closing open policy-ineligible MRs with rejected/merged reasons instead of retrying.

Verification:
- CGO_ENABLED=0 go test ./internal/refinery: PASS
- CGO_ENABLED=0 go test ./internal/beads -run 'TestNoMergeField|TestMRFields|TestIssueStatusIsTerminal': PASS\n- Plain go test ./internal/refinery is blocked in this environment by missing ICU linker libs (-licui18n, -licuuc, -licudata).\n- Full CGO_ENABLED=0 go test ./... has unrelated pre-existing failures outside this PR.\n\nEvidence:\n- Bead: gt-refinery-prepush-guard-clean-port\n- Source cleanup bead: gt-refinery-recheck-no-merge-before-push\n- Incident: hq-wwctr / hq-wisp-1bps\n- Required 15 research legs, 5 pre-implementation reviews, and post-implementation reviews completed before publication.\n\nCo-authored-by: mirelurk <thalia.geraghty@fiserv.com>