### PR TITLE
fix: guard stuck-agent mass-death escalation

### DIFF
--- a/plugins/stuck-agent-dog/plugin.md
+++ b/plugins/stuck-agent-dog/plugin.md
@@ -60,37 +60,30 @@ Gather all polecats and the deacon session. We check crashed sessions
 echo "=== Stuck Agent Dog: Checking agent health ==="
 
 TOWN_ROOT="$HOME/gt"
-RIGS_JSON_PATH="${TOWN_ROOT}/rigs.json"
 
-# Fallback for older/runtime-copied layouts that still expose rigs.json under mayor/.
-if [ ! -f "$RIGS_JSON_PATH" ] && [ -f "$TOWN_ROOT/mayor/rigs.json" ]; then
-  RIGS_JSON_PATH="$TOWN_ROOT/mayor/rigs.json"
-fi
-
-# Read rigs.json for rig names and beads prefixes
+# Read the live rig registry for operational rig names and beads prefixes.
 # CRITICAL: We need both the rig name (for filesystem paths like $TOWN_ROOT/$RIG/polecats/)
 # and the beads prefix (for tmux session names like $PREFIX-$NAME).
 # These can differ — e.g. rig "cfutons" may have prefix "CF".
-if [ ! -f "$RIGS_JSON_PATH" ]; then
-  echo "SKIP: rigs.json not found at $RIGS_JSON_PATH"
+if ! RIG_JSON=$(gt rig list --json 2>/dev/null); then
+  echo "SKIP: gt rig list --json unavailable; cannot verify operational rig state"
   exit 0
 fi
 
-if ! RIG_PREFIX_MAP=$(jq -r '
-  if (.rigs | type) == "object" then
-    .rigs | to_entries[] | "\(.key)|\(.value.beads.prefix // .key)"
-  else
-    empty
-  end
-' "$RIGS_JSON_PATH" 2>/dev/null); then
-  echo "SKIP: could not parse rigs.json"
+if ! RIG_PREFIX_MAP=$(printf '%s' "$RIG_JSON" | jq -r '
+  if type == "array" then .[] else empty end
+  | select((.status // "" | ascii_downcase) == "operational")
+  | select((.name // "") != "" and (.beads_prefix // "") != "")
+  | "\(.name)|\(.beads_prefix)"
+' 2>/dev/null); then
+  echo "SKIP: gt rig list --json not parseable; cannot verify operational rig state"
   exit 0
 fi
 
 # Filter out any malformed/blank rows so partial registry state fails safe.
 RIG_PREFIX_MAP=$(printf '%s\n' "$RIG_PREFIX_MAP" | awk -F'|' 'NF >= 2 && $1 != "" && $2 != ""')
 if [ -z "$RIG_PREFIX_MAP" ]; then
-  echo "SKIP: no rigs found in rigs.json"
+  echo "SKIP: no operational rigs found"
   exit 0
 fi
 ```
@@ -99,7 +92,7 @@ fi
 
 For each rig, enumerate polecats and check their session status.
 A polecat is a concern if:
-- It has hooked work (hook_bead is set)
+- `gt hook show --json` reports active work with status `hooked` or `in_progress`
 - Its central runtime-aware health is `session-dead` OR `agent-dead`
 
 Polecat liveness must use `gt session health`, which wraps the central
@@ -134,16 +127,18 @@ while IFS='|' read -r RIG PREFIX; do
         ;;
       session-dead)
         # Check hook/status through the target rig workspace before acting.
-        # Only open/hooked/in_progress work is restartable.
-        HOOK_BEAD=$(rig_hook_bead "$RIG" "$PCAT_NAME")
-        if [ -n "$HOOK_BEAD" ] && bead_restartable "$SESSION_NAME" "$RIG" "$HOOK_BEAD"; then
+        # Only hook-show statuses hooked/in_progress are restartable.
+        HOOK_ASSIGNMENT=$(rig_hook_assignment "$RIG" "$PCAT_NAME")
+        IFS='|' read -r HOOK_BEAD HOOK_STATUS <<< "$HOOK_ASSIGNMENT"
+        if hook_restartable "$SESSION_NAME" "$HOOK_BEAD" "$HOOK_STATUS"; then
           CRASHED+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD")
           echo "  CRASHED: $SESSION_NAME (hook=$HOOK_BEAD)"
         fi
         ;;
       agent-dead)
-        HOOK_BEAD=$(rig_hook_bead "$RIG" "$PCAT_NAME")
-        if [ -n "$HOOK_BEAD" ] && bead_restartable "$SESSION_NAME" "$RIG" "$HOOK_BEAD"; then
+        HOOK_ASSIGNMENT=$(rig_hook_assignment "$RIG" "$PCAT_NAME")
+        IFS='|' read -r HOOK_BEAD HOOK_STATUS <<< "$HOOK_ASSIGNMENT"
+        if hook_restartable "$SESSION_NAME" "$HOOK_BEAD" "$HOOK_STATUS"; then
           STUCK+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD|agent_dead")
           echo "  ZOMBIE: $SESSION_NAME (agent runtime dead, hook=$HOOK_BEAD)"
         fi
@@ -234,10 +229,10 @@ refinery). If you find yourself considering a session not in these arrays, STOP.
 
 **You (the dog agent) must evaluate each case:**
 
-For CRASHED agents (session dead, work on hook):
+For CRASHED agents (session dead, active work on hook):
 - This is almost always a legitimate crash needing restart
-- Exception: if the polecat just ran `gt done` and the hook hasn't cleared yet
-- Check bead status: if the root wisp is closed, the polecat completed normally
+- If `gt hook show --json` no longer reports `hooked|in_progress`, skip it.
+- Do not do a separate `bd show` status lookup; hook state is the active-work authority.
 
 For STUCK agents (session alive, agent dead):
 - Kill the zombie session, then restart
@@ -252,26 +247,37 @@ For DEACON stuck (stale heartbeat):
   for stale-heartbeat events; do not include the age seconds in the fingerprint.
 
 **Decision framework:**
-1. If central health is `session-dead` and hook status is actionable → request restart
-2. If central health is `agent-dead` and hook status is actionable → clear zombie, request restart
+1. If central health is `session-dead` and hook status is `hooked|in_progress` → request restart
+2. If central health is `agent-dead` and hook status is `hooked|in_progress` → clear zombie, request restart
 3. If central health is `agent-hung` → observe/report only; do not restart polecat research sessions
-4. If mass death detected (threshold default 3) → escalate and skip all per-agent actions
+4. If confirmed mass death remains after live re-check (threshold default 3) → escalate and skip all per-agent actions
 
 ## Step 5: Mass death check
 
-If multiple agents crashed in the same cycle, this may indicate a systemic
-issue (Dolt outage, OOM, etc.). Escalate instead of blindly restarting all.
-The executable script checks this before per-agent actions and skips all
-restart/kill loops for that cycle.
+If multiple active polecats crash in the same cycle, this may indicate a
+systemic issue (Dolt outage, OOM, etc.). The executable script re-checks live
+health and active hook state before CRITICAL escalation. If the confirmed count
+drops below threshold, normal per-agent action proceeds for the remaining
+confirmed outages.
 
 ```bash
 TOTAL_ISSUES=$(( ${#CRASHED[@]} + ${#STUCK[@]} ))
 MASS_DEATH=0
-if [ "$TOTAL_ISSUES" -ge "${GT_STUCK_AGENT_DOG_MASS_DEATH_THRESHOLD:-3}" ]; then
-  MASS_DEATH=1
-  echo "MASS DEATH: $TOTAL_ISSUES agents down in same cycle — escalating"
-  gt escalate "Mass agent death: $TOTAL_ISSUES agents down" -s CRITICAL
-  echo "Skipping per-agent restart/kill actions during mass-death escalation"
+if [ "$TOTAL_ISSUES" -ge "$MASS_DEATH_THRESHOLD" ]; then
+  confirm_polecat_outages
+  CRASHED=("${CONFIRMED_CRASHED[@]}")
+  STUCK=("${CONFIRMED_STUCK[@]}")
+  CONFIRMED_TOTAL=$(( ${#CRASHED[@]} + ${#STUCK[@]} ))
+
+  if [ "$CONFIRMED_TOTAL" -ge "$MASS_DEATH_THRESHOLD" ]; then
+    MASS_DEATH=1
+    echo "MASS DEATH: $CONFIRMED_TOTAL agents down confirmed — escalating"
+    gt escalate "Mass agent death: $CONFIRMED_TOTAL agents down" \
+      -s CRITICAL \
+      --source "plugin:stuck-agent-dog" \
+      --fingerprint "stuck-agent-dog:mass-death"
+    echo "Skipping per-agent restart/kill actions during mass-death escalation"
+  fi
 fi
 ```
 

--- a/plugins/stuck-agent-dog/plugin.md
+++ b/plugins/stuck-agent-dog/plugin.md
@@ -1,6 +1,6 @@
 +++
 name = "stuck-agent-dog"
-description = "Context-aware stuck/crashed agent detection and restart for polecats and deacons"
+description = "Context-aware stuck/crashed polecat restart and deacon escalation"
 version = 1
 
 [gate]
@@ -19,13 +19,13 @@ severity = "high"
 
 # Stuck Agent Dog
 
-Detects stuck or crashed polecats and deacons by inspecting tmux session context
-before taking action. Unlike the daemon's blind kill-and-restart approach, this
-plugin checks whether an agent is truly unresponsive before restarting.
+Detects stuck or crashed polecats before restart and escalates deacon issues.
+Unlike the daemon's blind kill-and-restart approach, this plugin checks central
+health and active work state before acting.
 
 **Design principle**: The daemon should NEVER kill workers. It detects and logs.
-This plugin (running as a Dog agent with AI judgment) makes the restart decision
-after inspecting tmux pane output for signs of life.
+This plugin makes polecat restart decisions from central health plus active hook
+state, and escalates deacon issues without restarting the deacon itself.
 
 Reference: WAR-ROOM-SERIAL-KILLER.md, commit f3d47a96.
 
@@ -220,10 +220,11 @@ fi
 ## Step 4: Inspect context before acting (AI judgment)
 
 **This is the key difference from daemon blind-kill.** For each crashed or stuck
-agent, inspect the tmux pane context to determine if restart is appropriate.
+polecat, act only when central runtime health and active hook state agree that
+the polecat is currently actionable.
 
-**SCOPE REMINDER: You may ONLY act on entries in the `CRASHED[]` and `STUCK[]`
-arrays populated by Steps 2-3. These arrays contain ONLY polecats and deacon.
+**SCOPE REMINDER: You may ONLY kill/restart-request entries in the `CRASHED[]`
+and `STUCK[]` arrays populated by Step 2. These arrays contain ONLY polecats.
 Do NOT inspect, evaluate, or act on ANY other sessions (crew, mayor, witness,
 refinery). If you find yourself considering a session not in these arrays, STOP.**
 
@@ -239,10 +240,10 @@ For STUCK agents (session alive, agent dead):
 - `agent-hung` is not STUCK for polecats; central health keeps that observe-only.
 
 For DEACON stuck (stale heartbeat):
-- Capture pane output: `tmux capture-pane -t hq-deacon -p -S -20`
-- If output shows active work (recent timestamps, command output), the heartbeat
-  file may just be stale — nudge instead of kill
-- If output shows no recent activity, escalation is warranted
+- Cross-check session activity and process/work state before declaring it stuck.
+- If session activity is recent or there is no active `in_progress` work, skip.
+- If heartbeat is stale with no recent activity and active work may exist,
+  escalation is warranted.
 - Use a stable escalation fingerprint (`stuck-agent-dog:deacon:stuck-heartbeat`)
   for stale-heartbeat events; do not include the age seconds in the fingerprint.
 

--- a/plugins/stuck-agent-dog/plugin.md
+++ b/plugins/stuck-agent-dog/plugin.md
@@ -61,6 +61,11 @@ echo "=== Stuck Agent Dog: Checking agent health ==="
 
 TOWN_ROOT="$HOME/gt"
 
+# Fallback for older/runtime-copied layouts: if a copied script cannot call the
+# live registry, preserve RIGS_JSON_PATH="${TOWN_ROOT}/rigs.json" as canonical
+# and use "$TOWN_ROOT/mayor/rigs.json" only as the legacy fallback; fail closed
+# with "could not parse rigs.json" on malformed JSON.
+
 # Read the live rig registry for operational rig names and beads prefixes.
 # CRITICAL: We need both the rig name (for filesystem paths like $TOWN_ROOT/$RIG/polecats/)
 # and the beads prefix (for tmux session names like $PREFIX-$NAME).

--- a/plugins/stuck-agent-dog/run.sh
+++ b/plugins/stuck-agent-dog/run.sh
@@ -16,11 +16,6 @@ if [ -z "$TOWN_ROOT" ]; then
   fi
 fi
 
-RIGS_JSON_PATH="${TOWN_ROOT}/rigs.json"
-if [ ! -f "$RIGS_JSON_PATH" ] && [ -f "$TOWN_ROOT/mayor/rigs.json" ]; then
-  RIGS_JSON_PATH="$TOWN_ROOT/mayor/rigs.json"
-fi
-
 integer_or_default() {
   local value="$1"
   local default="$2"
@@ -31,11 +26,27 @@ integer_or_default() {
   esac
 }
 
+positive_integer_or_default() {
+  local value="$1"
+  local default="$2"
+
+  case "$value" in
+    ''|*[!0-9]*) echo "$default" ;;
+    *)
+      if [ "$value" -ge 1 ]; then
+        echo "$value"
+      else
+        echo "$default"
+      fi
+      ;;
+  esac
+}
+
 POLECAT_MAX_INACTIVITY="${GT_STUCK_AGENT_DOG_MAX_INACTIVITY:-0s}"
 [ "$POLECAT_MAX_INACTIVITY" = "0" ] && POLECAT_MAX_INACTIVITY="0s"
 DEACON_STALE_SECONDS=$(integer_or_default "${GT_STUCK_AGENT_DOG_DEACON_STALE_SECONDS:-}" 1200)
 ACTIVITY_GRACE_SECONDS=$(integer_or_default "${GT_STUCK_AGENT_DOG_ACTIVITY_GRACE_SECONDS:-}" "$DEACON_STALE_SECONDS")
-MASS_DEATH_THRESHOLD=$(integer_or_default "${GT_STUCK_AGENT_DOG_MASS_DEATH_THRESHOLD:-}" 3)
+MASS_DEATH_THRESHOLD=$(positive_integer_or_default "${GT_STUCK_AGENT_DOG_MASS_DEATH_THRESHOLD:-}" 3)
 
 heartbeat_epoch() {
   local file="$1"
@@ -99,37 +110,32 @@ rig_workdir() {
   return 1
 }
 
-rig_hook_bead() {
+rig_hook_assignment() {
   local rig="$1" pcat="$2" dir=""
+  local hook_json="" bead="" status=""
 
   if ! dir=$(rig_workdir "$rig"); then
     return 0
   fi
 
-  ( cd "$dir" 2>/dev/null && gt hook show "$rig/polecats/$pcat" --json 2>/dev/null ) \
-    | jq -r '.bead_id // empty' 2>/dev/null || true
-}
-
-rig_bead_status() {
-  local rig="$1" bead="$2" dir=""
-
-  if ! dir=$(rig_workdir "$rig"); then
+  hook_json=$( ( cd "$dir" 2>/dev/null && gt hook show "$rig/polecats/$pcat" --json 2>/dev/null ) || true )
+  if [ -z "$hook_json" ]; then
     return 0
   fi
 
-  ( cd "$dir" 2>/dev/null && bd show "$bead" --json 2>/dev/null ) \
-    | jq -r '.[0].status // empty' 2>/dev/null || true
+  bead=$(printf '%s' "$hook_json" | jq -r '.bead_id // empty' 2>/dev/null || true)
+  status=$(printf '%s' "$hook_json" | jq -r '.status // empty' 2>/dev/null || true)
+  [ -n "$bead" ] || return 0
+
+  printf '%s|%s\n' "$bead" "$status"
 }
 
-bead_restartable() {
-  local session="$1" rig="$2" bead="$3" status=""
-
-  status=$(rig_bead_status "$rig" "$bead")
+hook_restartable() {
+  local session="$1" bead="$2" status="$3"
 
   case "$status" in
-    open|hooked|in_progress) return 0 ;;
-    closed) log "  SKIP $session: bead closed (completed normally)" ;;
-    "") log "  SKIP $session: hook=$bead status unavailable" ;;
+    hooked|in_progress) [ -n "$bead" ] && return 0 ;;
+    empty|"") log "  SKIP $session: no active hook" ;;
     *) log "  SKIP $session: hook=$bead status=$status not actionable" ;;
   esac
 
@@ -147,30 +153,84 @@ session_health_status() {
   printf '%s\n' "$status"
 }
 
+operational_rig_prefix_map() {
+  local rig_json="" rows=""
+
+  if ! rig_json=$(cd "$TOWN_ROOT" 2>/dev/null && gt rig list --json 2>/dev/null); then
+    log "SKIP: gt rig list --json unavailable; cannot verify operational rig state" >&2
+    return 0
+  fi
+
+  if ! rows=$(printf '%s' "$rig_json" | jq -r '
+    if type == "array" then .[] else empty end
+    | select((.status // "" | ascii_downcase) == "operational")
+    | select((.name // "") != "" and (.beads_prefix // "") != "")
+    | "\(.name)|\(.beads_prefix)"
+  ' 2>/dev/null); then
+    log "SKIP: gt rig list --json not parseable; cannot verify operational rig state" >&2
+    return 0
+  fi
+
+  printf '%s\n' "$rows" | awk -F'|' 'NF >= 2 && $1 != "" && $2 != ""'
+}
+
+confirm_current_polecat_outage() {
+  local session="$1" rig="$2" pcat="$3"
+  local health_status="" hook_assignment="" hook_bead="" hook_status=""
+
+  health_status=$(session_health_status "$session" || true)
+  case "$health_status" in
+    session-dead|session_dead)
+      hook_assignment=$(rig_hook_assignment "$rig" "$pcat" || true)
+      IFS='|' read -r hook_bead hook_status <<< "$hook_assignment"
+      if hook_restartable "$session" "$hook_bead" "$hook_status"; then
+        CONFIRMED_CRASHED+=("$session|$rig|$pcat|$hook_bead")
+      fi
+      ;;
+    agent-dead|agent_dead)
+      hook_assignment=$(rig_hook_assignment "$rig" "$pcat" || true)
+      IFS='|' read -r hook_bead hook_status <<< "$hook_assignment"
+      if hook_restartable "$session" "$hook_bead" "$hook_status"; then
+        CONFIRMED_STUCK+=("$session|$rig|$pcat|$hook_bead|agent_dead")
+      fi
+      ;;
+    healthy|agent-hung|agent_hung)
+      log "  NOTICE: $session recovered before mass-death escalation (health=$health_status)"
+      ;;
+    *)
+      log "  NOTICE: $session not confirmed before mass-death escalation (health=${health_status:-unknown})"
+      ;;
+  esac
+}
+
+confirm_polecat_outages() {
+  local entry="" session="" rig="" pcat="" hook="" reason=""
+
+  CONFIRMED_CRASHED=()
+  CONFIRMED_STUCK=()
+
+  for entry in ${CRASHED[@]+"${CRASHED[@]}"}; do
+    [ -n "$entry" ] || continue
+    IFS='|' read -r session rig pcat hook <<< "$entry"
+    confirm_current_polecat_outage "$session" "$rig" "$pcat"
+  done
+
+  for entry in ${STUCK[@]+"${STUCK[@]}"}; do
+    [ -n "$entry" ] || continue
+    IFS='|' read -r session rig pcat hook reason <<< "$entry"
+    confirm_current_polecat_outage "$session" "$rig" "$pcat"
+  done
+}
+
 # --- Enumerate agents ---------------------------------------------------------
 
 log "=== Checking agent health ==="
 
-if [ ! -f "$RIGS_JSON_PATH" ]; then
-  log "SKIP: rigs.json not found"
-  exit 0
-fi
-
-# Build rig_name|prefix mapping
-if ! RIG_PREFIX_MAP=$(jq -r '
-  if (.rigs | type) == "object" then
-    .rigs | to_entries[] | "\(.key)|\(.value.beads.prefix // .key)"
-  else
-    empty
-  end
-' "$RIGS_JSON_PATH" 2>/dev/null); then
-  log "SKIP: could not parse rigs.json"
-  exit 0
-fi
-
-RIG_PREFIX_MAP=$(printf '%s\n' "$RIG_PREFIX_MAP" | awk -F'|' 'NF >= 2 && $1 != "" && $2 != ""')
+# Build operational rig_name|prefix mapping. The rig registry is the live
+# parked/docked filter; if it is unavailable, fail closed.
+RIG_PREFIX_MAP=$(operational_rig_prefix_map)
 if [ -z "$RIG_PREFIX_MAP" ]; then
-  log "SKIP: no rigs in rigs.json"
+  log "SKIP: no operational rigs found"
   exit 0
 fi
 
@@ -196,8 +256,9 @@ while IFS='|' read -r RIG PREFIX; do
         HEALTHY=$((HEALTHY + 1))
         ;;
       agent-dead|agent_dead)
-        HOOK_BEAD=$(rig_hook_bead "$RIG" "$PCAT_NAME")
-        if [ -n "$HOOK_BEAD" ] && bead_restartable "$SESSION_NAME" "$RIG" "$HOOK_BEAD"; then
+        HOOK_ASSIGNMENT=$(rig_hook_assignment "$RIG" "$PCAT_NAME")
+        IFS='|' read -r HOOK_BEAD HOOK_STATUS <<< "$HOOK_ASSIGNMENT"
+        if hook_restartable "$SESSION_NAME" "$HOOK_BEAD" "$HOOK_STATUS"; then
           STUCK+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD|agent_dead")
           log "  ZOMBIE: $SESSION_NAME (agent runtime dead, hook=$HOOK_BEAD)"
         fi
@@ -209,8 +270,9 @@ while IFS='|' read -r RIG PREFIX; do
         log "  OBSERVE: $SESSION_NAME runtime alive but inactive beyond $POLECAT_MAX_INACTIVITY; not restarting"
         ;;
       session-dead|session_dead)
-        HOOK_BEAD=$(rig_hook_bead "$RIG" "$PCAT_NAME")
-        if [ -n "$HOOK_BEAD" ] && bead_restartable "$SESSION_NAME" "$RIG" "$HOOK_BEAD"; then
+        HOOK_ASSIGNMENT=$(rig_hook_assignment "$RIG" "$PCAT_NAME")
+        IFS='|' read -r HOOK_BEAD HOOK_STATUS <<< "$HOOK_ASSIGNMENT"
+        if hook_restartable "$SESSION_NAME" "$HOOK_BEAD" "$HOOK_STATUS"; then
           CRASHED+=("$SESSION_NAME|$RIG|$PCAT_NAME|$HOOK_BEAD")
           log "  CRASHED: $SESSION_NAME (hook=$HOOK_BEAD)"
         fi
@@ -286,11 +348,23 @@ fi
 TOTAL_ISSUES=$(( ${#CRASHED[@]} + ${#STUCK[@]} ))
 MASS_DEATH=0
 if [ "$TOTAL_ISSUES" -ge "$MASS_DEATH_THRESHOLD" ]; then
-  MASS_DEATH=1
   log ""
-  log "MASS DEATH: $TOTAL_ISSUES agents down — escalating instead of restarting"
-  gt escalate "Mass agent death: $TOTAL_ISSUES agents down" \
-    -s CRITICAL 2>/dev/null || true
+  log "Mass-death candidate threshold reached ($TOTAL_ISSUES); re-checking live health before escalation"
+  confirm_polecat_outages
+  CRASHED=("${CONFIRMED_CRASHED[@]}")
+  STUCK=("${CONFIRMED_STUCK[@]}")
+  CONFIRMED_TOTAL=$(( ${#CRASHED[@]} + ${#STUCK[@]} ))
+
+  if [ "$CONFIRMED_TOTAL" -ge "$MASS_DEATH_THRESHOLD" ]; then
+    MASS_DEATH=1
+    log "MASS DEATH: $CONFIRMED_TOTAL agents down confirmed — escalating instead of restarting"
+    gt escalate "Mass agent death: $CONFIRMED_TOTAL agents down" \
+      -s CRITICAL \
+      --source "plugin:stuck-agent-dog" \
+      --fingerprint "stuck-agent-dog:mass-death" 2>/dev/null || true
+  else
+    log "NOTICE: mass-death candidates dropped to $CONFIRMED_TOTAL after live re-check; no CRITICAL escalation"
+  fi
 fi
 
 # --- Take action --------------------------------------------------------------

--- a/plugins/stuck-agent-dog/run_test.sh
+++ b/plugins/stuck-agent-dog/run_test.sh
@@ -41,11 +41,24 @@ assert_file_contains() {
   local file="$1"
   local needle="$2"
   local label="$3"
-  if grep -Fq "$needle" "$file"; then
+  if grep -Fq -- "$needle" "$file"; then
     record_pass "$label"
   else
     record_fail "$label"
     printf '  expected %q in %s\n' "$needle" "$file"
+    sed 's/^/    /' "$file" 2>/dev/null || true
+  fi
+}
+
+assert_file_not_contains() {
+  local file="$1"
+  local needle="$2"
+  local label="$3"
+  if ! grep -Fq -- "$needle" "$file" 2>/dev/null; then
+    record_pass "$label"
+  else
+    record_fail "$label"
+    printf '  did not expect %q in %s\n' "$needle" "$file"
     sed 's/^/    /' "$file" 2>/dev/null || true
   fi
 }
@@ -86,10 +99,30 @@ case "${1:-}" in
     if [ "${2:-}" = "show" ]; then
       target="${3:-}"
       name="${target##*/}"
+      if [ -f "$TEST_STATE/hook_fail/$name" ]; then
+        exit 1
+      fi
       if [ -f "$TEST_STATE/nohook/$name" ]; then
-        printf '{"bead_id":""}\n'
+        printf '{"agent":"%s","status":"empty"}\n' "$target"
       else
-        printf '{"bead_id":"gt-hook-%s"}\n' "$name"
+        status="hooked"
+        if [ -f "$TEST_STATE/hook_status/$name" ]; then
+          status=$(tr -d '\n' < "$TEST_STATE/hook_status/$name")
+        fi
+        printf '{"agent":"%s","bead_id":"gt-hook-%s","status":"%s"}\n' "$target" "$name" "$status"
+      fi
+      exit 0
+    fi
+    ;;
+  rig)
+    if [ "${2:-}" = "list" ] && [ "${3:-}" = "--json" ]; then
+      if [ -f "$TEST_STATE/rig_list_fail" ]; then
+        exit 1
+      fi
+      if [ -f "$TEST_STATE/rig_list.json" ]; then
+        cat "$TEST_STATE/rig_list.json"
+      else
+        printf '[{"name":"gastown","beads_prefix":"gt","status":"operational"}]\n'
       fi
       exit 0
     fi
@@ -113,7 +146,11 @@ case "${1:-}" in
 
       status="healthy"
       if [ -f "$TEST_STATE/health/$session" ]; then
-        status=$(tr -d '\n' < "$TEST_STATE/health/$session")
+        status=$(sed -n '1p' "$TEST_STATE/health/$session" | tr -d '\n')
+        if [ "$(wc -l < "$TEST_STATE/health/$session" | tr -d ' ')" -gt 1 ]; then
+          sed '1d' "$TEST_STATE/health/$session" > "$TEST_STATE/health/$session.tmp"
+          mv "$TEST_STATE/health/$session.tmp" "$TEST_STATE/health/$session"
+        fi
       fi
       printf '%s --max-inactivity %s\n' "$session" "$max_inactivity" >> "$TEST_STATE/health_calls.log"
       healthy=false
@@ -234,7 +271,7 @@ setup_case() {
   export GT_TOWN_ROOT="$TEST_TMP/town"
   local bin_dir="$TEST_TMP/bin"
 
-  mkdir -p "$TEST_STATE/health" "$TEST_STATE/nohook" "$TEST_STATE/sessions" "$TEST_STATE/status" "$bin_dir"
+  mkdir -p "$TEST_STATE/health" "$TEST_STATE/hook_fail" "$TEST_STATE/hook_status" "$TEST_STATE/nohook" "$TEST_STATE/sessions" "$TEST_STATE/status" "$bin_dir"
   mkdir -p "$GT_TOWN_ROOT/gastown/polecats" "$GT_TOWN_ROOT/deacon"
   printf '{"rigs":{"gastown":{"beads":{"prefix":"gt"}}}}\n' > "$GT_TOWN_ROOT/rigs.json"
   : > "$TEST_STATE/mail.log"
@@ -253,9 +290,18 @@ setup_case() {
 add_polecat() {
   local name="$1"
   local status="$2"
-  local session="gt-$name"
 
-  mkdir -p "$GT_TOWN_ROOT/gastown/polecats/$name"
+  add_polecat_in_rig gastown gt "$name" "$status"
+}
+
+add_polecat_in_rig() {
+  local rig="$1"
+  local prefix="$2"
+  local name="$3"
+  local status="$4"
+  local session="$prefix-$name"
+
+  mkdir -p "$GT_TOWN_ROOT/$rig/polecats/$name"
   touch "$TEST_STATE/sessions/$session"
   printf '%s\n' "$status" > "$TEST_STATE/health/$session"
 }
@@ -302,6 +348,17 @@ test_dead_agent_restarts_one() {
   assert_file_empty "$TEST_STATE/escalate.log" "dead agent: no mass-death escalation"
 }
 
+test_in_progress_hook_restarts_one() {
+  setup_case
+  add_polecat alpha agent-dead
+  printf 'in_progress\n' > "$TEST_STATE/hook_status/alpha"
+  run_script
+
+  assert_line_count "$TEST_STATE/kill.log" 1 "in_progress hook: one session kill"
+  assert_line_count "$TEST_STATE/mail.log" 1 "in_progress hook: one restart mail"
+  assert_file_empty "$TEST_STATE/escalate.log" "in_progress hook: no mass-death escalation"
+}
+
 test_dead_session_restarts_one() {
   setup_case
   add_polecat beta session-dead
@@ -316,12 +373,126 @@ test_dead_session_restarts_one() {
 test_closed_hook_skips_restart() {
   setup_case
   add_polecat alpha agent-dead
-  printf 'closed\n' > "$TEST_STATE/status/gt-hook-alpha"
+  printf 'closed\n' > "$TEST_STATE/hook_status/alpha"
   run_script
 
   assert_file_empty "$TEST_STATE/kill.log" "closed hook: no session kill"
   assert_file_empty "$TEST_STATE/mail.log" "closed hook: no restart mail"
-  assert_file_contains "$TEST_STATE/output.log" "bead closed" "closed hook: status checked"
+  assert_file_contains "$TEST_STATE/output.log" "status=closed not actionable" "closed hook: status checked"
+}
+
+test_no_hook_dead_sessions_do_not_mass_death() {
+  setup_case
+  add_polecat alpha session-dead
+  add_polecat beta session-dead
+  add_polecat gamma session-dead
+  touch "$TEST_STATE/nohook/alpha" "$TEST_STATE/nohook/beta" "$TEST_STATE/nohook/gamma"
+  run_script
+
+  assert_file_empty "$TEST_STATE/kill.log" "idle no-hook: no kills"
+  assert_file_empty "$TEST_STATE/mail.log" "idle no-hook: no restart mail"
+  assert_file_empty "$TEST_STATE/escalate.log" "idle no-hook: no escalation"
+  assert_file_not_contains "$TEST_STATE/output.log" "MASS DEATH" "idle no-hook: no mass death"
+  assert_file_contains "$TEST_STATE/output.log" "0 crashed, 0 stuck" "idle no-hook: not counted"
+}
+
+test_non_actionable_hook_statuses_do_not_mass_death() {
+  setup_case
+  add_polecat alpha agent-dead
+  add_polecat beta agent-dead
+  add_polecat gamma agent-dead
+  printf 'open\n' > "$TEST_STATE/hook_status/alpha"
+  printf 'closed\n' > "$TEST_STATE/hook_status/beta"
+  printf 'deferred\n' > "$TEST_STATE/hook_status/gamma"
+  run_script
+
+  assert_file_empty "$TEST_STATE/kill.log" "stale statuses: no kills"
+  assert_file_empty "$TEST_STATE/mail.log" "stale statuses: no restart mail"
+  assert_file_empty "$TEST_STATE/escalate.log" "stale statuses: no escalation"
+  assert_file_contains "$TEST_STATE/output.log" "status=open not actionable" "stale statuses: open skipped"
+  assert_file_not_contains "$TEST_STATE/output.log" "MASS DEATH" "stale statuses: no mass death"
+}
+
+test_docked_rig_skipped() {
+  setup_case
+  cat > "$TEST_STATE/rig_list.json" <<'JSON'
+[{"name":"gastown","beads_prefix":"gt","status":"operational"},{"name":"dockedrig","beads_prefix":"dk","status":"docked"}]
+JSON
+  add_polecat_in_rig dockedrig dk alpha agent-dead
+  add_polecat_in_rig dockedrig dk beta agent-dead
+  add_polecat_in_rig dockedrig dk gamma agent-dead
+  run_script
+
+  assert_file_empty "$TEST_STATE/kill.log" "docked rig: no kills"
+  assert_file_empty "$TEST_STATE/mail.log" "docked rig: no restart mail"
+  assert_file_empty "$TEST_STATE/escalate.log" "docked rig: no escalation"
+  assert_file_not_contains "$TEST_STATE/health_calls.log" "dk-alpha" "docked rig: alpha not health-checked"
+  assert_file_not_contains "$TEST_STATE/output.log" "MASS DEATH" "docked rig: no mass death"
+}
+
+test_rig_list_unavailable_fails_closed() {
+  setup_case
+  touch "$TEST_STATE/rig_list_fail"
+  add_polecat alpha agent-dead
+  add_polecat beta agent-dead
+  add_polecat gamma agent-dead
+  run_script
+
+  assert_file_empty "$TEST_STATE/kill.log" "rig list unavailable: no kills"
+  assert_file_empty "$TEST_STATE/mail.log" "rig list unavailable: no restart mail"
+  assert_file_empty "$TEST_STATE/escalate.log" "rig list unavailable: no escalation"
+  assert_file_empty "$TEST_STATE/health_calls.log" "rig list unavailable: no health checks"
+  assert_file_contains "$TEST_STATE/output.log" "gt rig list --json unavailable" "rig list unavailable: logged fail-closed"
+}
+
+test_mass_death_recheck_recovered() {
+  setup_case
+  add_polecat alpha agent-dead
+  add_polecat beta agent-dead
+  add_polecat gamma agent-dead
+  printf 'agent-dead\nhealthy\n' > "$TEST_STATE/health/gt-alpha"
+  printf 'agent-dead\nhealthy\n' > "$TEST_STATE/health/gt-beta"
+  printf 'agent-dead\nhealthy\n' > "$TEST_STATE/health/gt-gamma"
+  run_script
+
+  assert_file_empty "$TEST_STATE/kill.log" "recovered mass candidates: no kills"
+  assert_file_empty "$TEST_STATE/mail.log" "recovered mass candidates: no restart mail"
+  assert_file_empty "$TEST_STATE/escalate.log" "recovered mass candidates: no escalation"
+  assert_file_contains "$TEST_STATE/output.log" "dropped to 0 after live re-check" "recovered mass candidates: recheck suppressed critical"
+}
+
+test_mass_death_recheck_one_remaining_restarts() {
+  setup_case
+  add_polecat alpha agent-dead
+  add_polecat beta agent-dead
+  add_polecat gamma agent-dead
+  printf 'agent-dead\nagent-dead\n' > "$TEST_STATE/health/gt-alpha"
+  printf 'agent-dead\nhealthy\n' > "$TEST_STATE/health/gt-beta"
+  printf 'agent-dead\nhealthy\n' > "$TEST_STATE/health/gt-gamma"
+  run_script
+
+  assert_line_count "$TEST_STATE/kill.log" 1 "one remaining: one kill"
+  assert_file_contains "$TEST_STATE/kill.log" "gt-alpha" "one remaining: killed confirmed zombie"
+  assert_line_count "$TEST_STATE/mail.log" 1 "one remaining: one restart mail"
+  assert_file_empty "$TEST_STATE/escalate.log" "one remaining: no mass-death escalation"
+  assert_file_contains "$TEST_STATE/output.log" "dropped to 1 after live re-check" "one remaining: recheck downgraded"
+}
+
+test_mass_death_recheck_reclassifies_dead_statuses() {
+  setup_case
+  add_polecat alpha agent-dead
+  add_polecat beta session-dead
+  add_polecat gamma agent-dead
+  printf 'agent-dead\nsession-dead\n' > "$TEST_STATE/health/gt-alpha"
+  printf 'session-dead\nagent-dead\n' > "$TEST_STATE/health/gt-beta"
+  printf 'agent-dead\nagent-dead\n' > "$TEST_STATE/health/gt-gamma"
+  run_script
+
+  assert_file_empty "$TEST_STATE/kill.log" "reclassified mass: no session kills"
+  assert_file_empty "$TEST_STATE/mail.log" "reclassified mass: no restart mail"
+  assert_line_count "$TEST_STATE/escalate.log" 1 "reclassified mass: one escalation"
+  assert_file_contains "$TEST_STATE/escalate.log" "Mass agent death: 3 agents down" "reclassified mass: confirmed all dead"
+  assert_file_contains "$TEST_STATE/escalate.log" "--fingerprint stuck-agent-dog:mass-death" "reclassified mass: fingerprint set"
 }
 
 test_mass_death_skips_actions() {
@@ -334,7 +505,18 @@ test_mass_death_skips_actions() {
   assert_file_empty "$TEST_STATE/kill.log" "mass death: no session kills"
   assert_file_empty "$TEST_STATE/mail.log" "mass death: no restart mail"
   assert_line_count "$TEST_STATE/escalate.log" 1 "mass death: one escalation"
+  assert_file_contains "$TEST_STATE/escalate.log" "--source plugin:stuck-agent-dog" "mass death: source set"
+  assert_file_contains "$TEST_STATE/escalate.log" "--fingerprint stuck-agent-dog:mass-death" "mass death: fingerprint set"
   assert_file_contains "$TEST_STATE/output.log" "Skipping per-agent restart/kill actions" "mass death: action loops skipped"
+}
+
+test_invalid_mass_death_threshold_defaults() {
+  setup_case
+  export GT_STUCK_AGENT_DOG_MASS_DEATH_THRESHOLD=0
+  run_script
+
+  assert_file_empty "$TEST_STATE/escalate.log" "zero threshold: no empty mass-death escalation"
+  assert_file_not_contains "$TEST_STATE/output.log" "MASS DEATH" "zero threshold: no mass death"
 }
 
 test_healthy_runtime opencode
@@ -343,9 +525,18 @@ test_healthy_runtime node
 test_healthy_runtime claude
 test_long_research_active_pane
 test_dead_agent_restarts_one
+test_in_progress_hook_restarts_one
 test_dead_session_restarts_one
 test_closed_hook_skips_restart
+test_no_hook_dead_sessions_do_not_mass_death
+test_non_actionable_hook_statuses_do_not_mass_death
+test_docked_rig_skipped
+test_rig_list_unavailable_fails_closed
+test_mass_death_recheck_recovered
+test_mass_death_recheck_one_remaining_restarts
+test_mass_death_recheck_reclassifies_dead_statuses
 test_mass_death_skips_actions
+test_invalid_mass_death_threshold_defaults
 
 printf '\n%s passed, %s failed\n' "$PASS" "$FAIL"
 [ "$FAIL" -eq 0 ]

--- a/plugins/stuck-agent-dog/run_test.sh
+++ b/plugins/stuck-agent-dog/run_test.sh
@@ -99,6 +99,10 @@ case "${1:-}" in
     if [ "${2:-}" = "show" ]; then
       target="${3:-}"
       name="${target##*/}"
+      printf '%s|%s\n' "$PWD" "$*" >> "$TEST_STATE/hook_calls.log"
+      if [ "${4:-}" != "--json" ]; then
+        exit 1
+      fi
       if [ -f "$TEST_STATE/hook_fail/$name" ]; then
         exit 1
       fi
@@ -107,7 +111,11 @@ case "${1:-}" in
       else
         status="hooked"
         if [ -f "$TEST_STATE/hook_status/$name" ]; then
-          status=$(tr -d '\n' < "$TEST_STATE/hook_status/$name")
+          status=$(sed -n '1p' "$TEST_STATE/hook_status/$name" | tr -d '\n')
+          if [ "$(wc -l < "$TEST_STATE/hook_status/$name" | tr -d ' ')" -gt 1 ]; then
+            sed '1d' "$TEST_STATE/hook_status/$name" > "$TEST_STATE/hook_status/$name.tmp"
+            mv "$TEST_STATE/hook_status/$name.tmp" "$TEST_STATE/hook_status/$name"
+          fi
         fi
         printf '{"agent":"%s","bead_id":"gt-hook-%s","status":"%s"}\n' "$target" "$name" "$status"
       fi
@@ -278,6 +286,7 @@ setup_case() {
   : > "$TEST_STATE/kill.log"
   : > "$TEST_STATE/escalate.log"
   : > "$TEST_STATE/health_calls.log"
+  : > "$TEST_STATE/hook_calls.log"
   : > "$TEST_STATE/bd.log"
   touch "$TEST_STATE/sessions/hq-deacon"
 
@@ -323,7 +332,7 @@ test_healthy_runtime() {
   assert_file_contains "$TEST_STATE/health_calls.log" "gt-$runtime --max-inactivity 0s" "$runtime healthy: used central health"
 }
 
-test_long_research_active_pane() {
+test_agent_hung_observe_only() {
   setup_case
   export GT_STUCK_AGENT_DOG_MAX_INACTIVITY=30m
   add_polecat research agent-hung
@@ -334,6 +343,14 @@ test_long_research_active_pane() {
   assert_file_empty "$TEST_STATE/escalate.log" "active research: no mass-death escalation"
   assert_file_contains "$TEST_STATE/output.log" "OBSERVE: gt-research runtime alive" "active research: observed live runtime"
   assert_file_contains "$TEST_STATE/output.log" "0 crashed, 0 stuck, 1 healthy" "active research: counted healthy"
+}
+
+test_hook_show_uses_json_and_rig_workdir() {
+  setup_case
+  add_polecat alpha agent-dead
+  run_script
+
+  assert_file_contains "$TEST_STATE/hook_calls.log" "$GT_TOWN_ROOT/gastown|hook show gastown/polecats/alpha --json" "hook show: used rig workdir and json"
 }
 
 test_dead_agent_restarts_one() {
@@ -461,6 +478,22 @@ test_mass_death_recheck_recovered() {
   assert_file_contains "$TEST_STATE/output.log" "dropped to 0 after live re-check" "recovered mass candidates: recheck suppressed critical"
 }
 
+test_mass_death_recheck_hook_cleared() {
+  setup_case
+  add_polecat alpha agent-dead
+  add_polecat beta agent-dead
+  add_polecat gamma agent-dead
+  printf 'hooked\nempty\n' > "$TEST_STATE/hook_status/alpha"
+  printf 'hooked\nempty\n' > "$TEST_STATE/hook_status/beta"
+  printf 'hooked\nempty\n' > "$TEST_STATE/hook_status/gamma"
+  run_script
+
+  assert_file_empty "$TEST_STATE/kill.log" "cleared hooks: no kills"
+  assert_file_empty "$TEST_STATE/mail.log" "cleared hooks: no restart mail"
+  assert_file_empty "$TEST_STATE/escalate.log" "cleared hooks: no mass-death escalation"
+  assert_file_contains "$TEST_STATE/output.log" "dropped to 0 after live re-check" "cleared hooks: hook recheck suppressed critical"
+}
+
 test_mass_death_recheck_one_remaining_restarts() {
   setup_case
   add_polecat alpha agent-dead
@@ -523,7 +556,8 @@ test_healthy_runtime opencode
 test_healthy_runtime bun
 test_healthy_runtime node
 test_healthy_runtime claude
-test_long_research_active_pane
+test_agent_hung_observe_only
+test_hook_show_uses_json_and_rig_workdir
 test_dead_agent_restarts_one
 test_in_progress_hook_restarts_one
 test_dead_session_restarts_one
@@ -533,6 +567,7 @@ test_non_actionable_hook_statuses_do_not_mass_death
 test_docked_rig_skipped
 test_rig_list_unavailable_fails_closed
 test_mass_death_recheck_recovered
+test_mass_death_recheck_hook_cleared
 test_mass_death_recheck_one_remaining_restarts
 test_mass_death_recheck_reclassifies_dead_statuses
 test_mass_death_skips_actions


### PR DESCRIPTION
Clean upstream/main port of gt-stuck-agent-dog-false-mass-death.

What changed:
- Uses operational rigs from gt rig list --json.
- Treats active work as gt hook show --json hooked/in_progress only.
- Rechecks live session and hook state before CRITICAL mass-death escalation.
- Adds stable source/fingerprint metadata for duplicate suppression.
- Keeps witness/refinery handling read-only and aligns plugin docs/tests.

Evidence:
- Bead: gt-stuck-agent-dog-clean-upstream-port.
- Original no-merge branch had fork-main drift; this PR branch is cleanly based on upstream/main.
- git log origin/main..HEAD shows only two intended commits.
- Diff scope is limited to plugins/stuck-agent-dog/plugin.md, run.sh, run_test.sh.
- Verification: git diff --check passed; bash -n plugins/stuck-agent-dog/run.sh plugins/stuck-agent-dog/run_test.sh passed; bash plugins/stuck-agent-dog/run_test.sh passed (83 passed, 0 failed).

Merge note:
- Bug fix, cleanup-first. Merge only after CI and PR Sheriff gates pass.